### PR TITLE
fix: initialize queue before WP_Ability check for CLI compatibility

### DIFF
--- a/inc/Abilities/FlowAbilities.php
+++ b/inc/Abilities/FlowAbilities.php
@@ -32,6 +32,9 @@ class FlowAbilities {
 	private QueueAbility $queue;
 
 	public function __construct() {
+		// Always initialize queue - CLI commands need it regardless of WP_Ability
+		$this->queue = new QueueAbility();
+
 		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
 			return;
 		}
@@ -43,7 +46,6 @@ class FlowAbilities {
 		$this->update_flow    = new UpdateFlowAbility();
 		$this->delete_flow    = new DeleteFlowAbility();
 		$this->duplicate_flow = new DuplicateFlowAbility();
-		$this->queue          = new QueueAbility();
 
 		self::$registered = true;
 	}


### PR DESCRIPTION
## Problem

After merging #27, CLI commands fail with:
```
Fatal error: Typed property DataMachine\Abilities\FlowAbilities::$queue must not be accessed before initialization
```

## Cause

When `WP_Ability` class doesn't exist (common in CLI context), the constructor early-returns before initializing `$this->queue`. The typed property declaration requires initialization before access.

## Fix

Initialize `$this->queue` before the early return check, since CLI commands need it regardless of whether the Abilities API is loaded.

## Lesson Learned

Updated my coding standards: defensive fallback patterns that *seem* unnecessary might actually be handling edge cases. In this case, the checks we removed were compensating for this initialization gap.

Refs: #26