### PR TITLE
fix(agent-ping): use flow-level handler_config instead of pipeline config

### DIFF
--- a/inc/Core/Steps/AgentPing/AgentPingSettings.php
+++ b/inc/Core/Steps/AgentPing/AgentPingSettings.php
@@ -6,7 +6,7 @@
  * Used by the admin UI to render configuration forms.
  *
  * @package DataMachine\Core\Steps\AgentPing
- * @since 0.14.0
+ * @since 0.18.0
  */
 
 namespace DataMachine\Core\Steps\AgentPing;


### PR DESCRIPTION
## Summary

This PR fixes the Agent Ping step to use flow-level `handler_config` instead of pipeline-level configuration, allowing more flexible per-flow webhook configuration.

## Changes

- Use `$this->getHandlerConfig()` instead of `$this->engine->getPipelineStepConfig()`
- Fix data packets access: use `$this->dataPackets` instead of `$this->engine->getDataPackets()`
- Set `hasPipelineConfig: false` and `config_type: 'handler'`
- Update version to @since 0.18.0

## Why

The original implementation read configuration from the pipeline step level (`pipeline_step_config`), which meant all flows using the same pipeline step would share the same webhook URL.

With this change, each **flow step** can have its own `handler_config` with a unique `webhook_url` and `prompt`, enabling scenarios like:
- Flow A sends to Discord channel #alerts
- Flow B sends to a custom webhook endpoint
- Flow C sends to Slack

## Configuration Fields

```php
'webhook_url' => 'https://discord.com/api/webhooks/...'  // Required
'prompt'      => 'Instructions for the receiving agent'   // Optional
```

## Testing

- [ ] Create a flow with Agent Ping step
- [ ] Configure webhook_url in the flow step's handler_config
- [ ] Run pipeline and verify webhook receives correct payload
- [ ] Test Discord-specific formatting when URL contains 'discord.com'