### PR TITLE
refactor(agent-ping): extract webhook logic to SendPingAbility

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -156,6 +156,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/StepTypeAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/LocalSearchAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/SystemAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/AgentPingAbilities.php';
 	new \DataMachine\Abilities\AuthAbilities();
 	new \DataMachine\Abilities\FileAbilities();
 	new \DataMachine\Abilities\FlowAbilities();
@@ -171,6 +172,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\StepTypeAbilities();
 	new \DataMachine\Abilities\LocalSearchAbilities();
 	new \DataMachine\Abilities\SystemAbilities();
+	new \DataMachine\Abilities\AgentPingAbilities();
 }
 
 

--- a/inc/Abilities/AgentPing/SendPingAbility.php
+++ b/inc/Abilities/AgentPing/SendPingAbility.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Send Ping Ability
+ *
+ * Sends pipeline context to webhook endpoints (Discord, Slack, custom).
+ * Supports Discord-specific formatting when URL contains discord.com.
+ *
+ * @package DataMachine\Abilities\AgentPing
+ * @since 0.18.0
+ */
+
+namespace DataMachine\Abilities\AgentPing;
+
+defined( 'ABSPATH' ) || exit;
+
+class SendPingAbility {
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		$this->registerAbility();
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/send-ping',
+				array(
+					'label'               => __( 'Send Ping', 'data-machine' ),
+					'description'         => __( 'Send pipeline context to a webhook endpoint (Discord, Slack, custom).', 'data-machine' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'webhook_url' ),
+						'properties' => array(
+							'webhook_url'  => array(
+								'type'        => 'string',
+								'description' => __( 'URL to POST data to (Discord, Slack, custom endpoint)', 'data-machine' ),
+							),
+							'prompt'       => array(
+								'type'        => 'string',
+								'description' => __( 'Optional instructions for the receiving agent', 'data-machine' ),
+							),
+							'data_packets' => array(
+								'type'        => 'array',
+								'description' => __( 'Pipeline data packets to include in payload', 'data-machine' ),
+							),
+							'flow_id'      => array(
+								'type'        => array( 'integer', 'string' ),
+								'description' => __( 'Flow ID for context', 'data-machine' ),
+							),
+							'pipeline_id'  => array(
+								'type'        => array( 'integer', 'string' ),
+								'description' => __( 'Pipeline ID for context', 'data-machine' ),
+							),
+							'job_id'       => array(
+								'type'        => 'integer',
+								'description' => __( 'Job ID for context', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'     => array( 'type' => 'boolean' ),
+							'status_code' => array( 'type' => 'integer' ),
+							'message'     => array( 'type' => 'string' ),
+							'error'       => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Check permission for ability execution.
+	 *
+	 * @return bool True if user has permission.
+	 */
+	public function checkPermission(): bool {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return true;
+		}
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Execute send ping ability.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result with success status.
+	 */
+	public function execute( array $input ): array {
+		$webhook_url  = trim( $input['webhook_url'] ?? '' );
+		$prompt       = $input['prompt'] ?? '';
+		$data_packets = $input['data_packets'] ?? array();
+		$flow_id      = $input['flow_id'] ?? null;
+		$pipeline_id  = $input['pipeline_id'] ?? null;
+		$job_id       = $input['job_id'] ?? null;
+
+		if ( empty( $webhook_url ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'webhook_url is required',
+			);
+		}
+
+		$payload = $this->buildPayload( $webhook_url, $prompt, $data_packets, $flow_id, $pipeline_id, $job_id );
+
+		$response = wp_remote_post(
+			$webhook_url,
+			array(
+				'headers' => array( 'Content-Type' => 'application/json' ),
+				'body'    => wp_json_encode( $payload ),
+				'timeout' => 30,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Agent Ping request failed',
+				array(
+					'url'   => $this->sanitizeUrlForLog( $webhook_url ),
+					'error' => $response->get_error_message(),
+				)
+			);
+
+			return array(
+				'success' => false,
+				'error'   => $response->get_error_message(),
+			);
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+
+		if ( $status_code >= 200 && $status_code < 300 ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Agent Ping sent successfully',
+				array(
+					'url'         => $this->sanitizeUrlForLog( $webhook_url ),
+					'status_code' => $status_code,
+				)
+			);
+
+			return array(
+				'success'     => true,
+				'status_code' => $status_code,
+				'message'     => 'Webhook notification sent successfully',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'warning',
+			'Agent Ping received non-success response',
+			array(
+				'url'           => $this->sanitizeUrlForLog( $webhook_url ),
+				'status_code'   => $status_code,
+				'response_body' => wp_remote_retrieve_body( $response ),
+			)
+		);
+
+		return array(
+			'success'     => false,
+			'status_code' => $status_code,
+			'error'       => 'Webhook returned non-success status code: ' . $status_code,
+		);
+	}
+
+	/**
+	 * Build payload for webhook request.
+	 *
+	 * @param string     $url Webhook URL.
+	 * @param string     $prompt Optional instructions.
+	 * @param array      $data_packets Pipeline data packets.
+	 * @param mixed      $flow_id Flow ID.
+	 * @param mixed      $pipeline_id Pipeline ID.
+	 * @param int|null   $job_id Job ID.
+	 * @return array Payload for POST request.
+	 */
+	private function buildPayload( string $url, string $prompt, array $data_packets, $flow_id, $pipeline_id, ?int $job_id ): array {
+		if ( $this->isDiscordWebhook( $url ) ) {
+			return $this->buildDiscordPayload( $prompt, $data_packets );
+		}
+
+		return array(
+			'prompt'    => $prompt,
+			'context'   => array(
+				'data_packets' => $data_packets,
+				'flow_id'      => $flow_id,
+				'pipeline_id'  => $pipeline_id,
+				'job_id'       => $job_id,
+			),
+			'timestamp' => gmdate( 'c' ),
+		);
+	}
+
+	/**
+	 * Build Discord-formatted payload.
+	 *
+	 * @param string $prompt Optional instructions.
+	 * @param array  $data_packets Pipeline data packets.
+	 * @return array Discord webhook payload.
+	 */
+	private function buildDiscordPayload( string $prompt, array $data_packets ): array {
+		$first_packet = $data_packets[0] ?? array();
+		$title        = $first_packet['content']['title'] ?? 'New content';
+		$url          = $first_packet['metadata']['url'] ?? $first_packet['metadata']['permalink'] ?? '';
+
+		$content = "🤖 **{$title}**";
+		if ( ! empty( $url ) ) {
+			$content .= "\n{$url}";
+		}
+		if ( ! empty( $prompt ) ) {
+			$content .= "\n\n{$prompt}";
+		}
+
+		return array( 'content' => $content );
+	}
+
+	/**
+	 * Check if URL is a Discord webhook.
+	 *
+	 * @param string $url Webhook URL.
+	 * @return bool
+	 */
+	private function isDiscordWebhook( string $url ): bool {
+		return str_contains( $url, 'discord.com/api/webhooks/' )
+			|| str_contains( $url, 'discordapp.com/api/webhooks/' );
+	}
+
+	/**
+	 * Sanitize URL for logging (mask tokens).
+	 *
+	 * @param string $url Full URL.
+	 * @return string URL with token masked.
+	 */
+	private function sanitizeUrlForLog( string $url ): string {
+		return preg_replace(
+			'#(discord(?:app)?\.com/api/webhooks/\d+/)[^/\s]+#',
+			'$1[MASKED]',
+			$url
+		);
+	}
+}

--- a/inc/Abilities/AgentPingAbilities.php
+++ b/inc/Abilities/AgentPingAbilities.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Agent Ping Abilities
+ *
+ * Facade that loads and registers all Agent Ping ability classes.
+ *
+ * @package DataMachine\Abilities
+ * @since 0.18.0
+ */
+
+namespace DataMachine\Abilities;
+
+use DataMachine\Abilities\AgentPing\SendPingAbility;
+
+defined( 'ABSPATH' ) || exit;
+
+class AgentPingAbilities {
+
+	private static bool $registered = false;
+
+	private SendPingAbility $send_ping;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
+			return;
+		}
+
+		$this->send_ping = new SendPingAbility();
+
+		self::$registered = true;
+	}
+
+	/**
+	 * Permission callback for abilities.
+	 *
+	 * @return bool True if user has permission.
+	 */
+	public function checkPermission(): bool {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return true;
+		}
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Execute send-ping ability (backward compatibility).
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result with success status.
+	 */
+	public function executeSendPing( array $input ): array {
+		if ( ! isset( $this->send_ping ) ) {
+			$this->send_ping = new SendPingAbility();
+		}
+		return $this->send_ping->execute( $input );
+	}
+}

--- a/inc/Core/Steps/AgentPing/AgentPingStep.php
+++ b/inc/Core/Steps/AgentPing/AgentPingStep.php
@@ -87,138 +87,35 @@ class AgentPingStep extends Step {
 		$prompt       = $handler_config['prompt'] ?? '';
 		$data_packets = $this->dataPackets;
 
-		$payload = $this->buildPayload( $webhook_url, $prompt, $data_packets );
-
-		$response = wp_remote_post(
-			$webhook_url,
+		// Execute the send-ping ability
+		$result = wp_execute_ability(
+			'datamachine/send-ping',
 			array(
-				'headers' => array( 'Content-Type' => 'application/json' ),
-				'body'    => wp_json_encode( $payload ),
-				'timeout' => 30,
+				'webhook_url'  => $webhook_url,
+				'prompt'       => $prompt,
+				'data_packets' => $data_packets,
+				'flow_id'      => $this->engine->get( 'flow_id' ),
+				'pipeline_id'  => $this->engine->get( 'pipeline_id' ),
+				'job_id'       => $this->job_id,
 			)
 		);
 
-		$success = false;
-		if ( is_wp_error( $response ) ) {
-			$this->log(
-				'error',
-				'Agent Ping request failed',
-				array(
-					'url'   => $this->sanitizeUrlForLog( $webhook_url ),
-					'error' => $response->get_error_message(),
-				)
-			);
-		} else {
-			$status_code = wp_remote_retrieve_response_code( $response );
-			if ( $status_code >= 200 && $status_code < 300 ) {
-				$success = true;
-				$this->log(
-					'info',
-					'Agent Ping sent successfully',
-					array(
-						'url'         => $this->sanitizeUrlForLog( $webhook_url ),
-						'status_code' => $status_code,
-					)
-				);
-			} else {
-				$this->log(
-					'warning',
-					'Agent Ping received non-success response',
-					array(
-						'url'           => $this->sanitizeUrlForLog( $webhook_url ),
-						'status_code'   => $status_code,
-						'response_body' => wp_remote_retrieve_body( $response ),
-					)
-				);
-			}
-		}
+		$success = $result['success'] ?? false;
 
 		$result_packet = new DataPacket(
 			array(
 				'title' => 'Agent Ping Result',
-				'body'  => $success ? 'Webhook notification sent successfully' : 'Webhook notification failed',
+				'body'  => $success ? 'Webhook notification sent successfully' : ( $result['error'] ?? 'Webhook notification failed' ),
 			),
 			array(
 				'source_type'  => 'agent_ping',
 				'flow_step_id' => $this->flow_step_id,
 				'success'      => $success,
+				'status_code'  => $result['status_code'] ?? null,
 			),
 			'agent_ping_result'
 		);
 
-		return $result_packet->addTo( $this->dataPackets );
-	}
-
-	/**
-	 * Build payload for webhook request.
-	 *
-	 * @param string $url Webhook URL
-	 * @param string $prompt Optional instructions
-	 * @param array  $data_packets Pipeline data packets
-	 * @return array Payload for POST request
-	 */
-	private function buildPayload( string $url, string $prompt, array $data_packets ): array {
-		if ( $this->isDiscordWebhook( $url ) ) {
-			return $this->buildDiscordPayload( $prompt, $data_packets );
-		}
-
-		return array(
-			'prompt'    => $prompt,
-			'context'   => array(
-				'data_packets' => $data_packets,
-				'flow_id'      => $this->engine->get( 'flow_id' ),
-				'pipeline_id'  => $this->engine->get( 'pipeline_id' ),
-				'job_id'       => $this->job_id,
-			),
-			'timestamp' => gmdate( 'c' ),
-		);
-	}
-
-	/**
-	 * Build Discord-formatted payload.
-	 *
-	 * @param string $prompt Optional instructions
-	 * @param array  $data_packets Pipeline data packets
-	 * @return array Discord webhook payload
-	 */
-	private function buildDiscordPayload( string $prompt, array $data_packets ): array {
-		$first_packet = $data_packets[0] ?? array();
-		$title        = $first_packet['content']['title'] ?? 'New content';
-		$url          = $first_packet['metadata']['url'] ?? $first_packet['metadata']['permalink'] ?? '';
-
-		$content = "🤖 **{$title}**";
-		if ( ! empty( $url ) ) {
-			$content .= "\n{$url}";
-		}
-		if ( ! empty( $prompt ) ) {
-			$content .= "\n\n{$prompt}";
-		}
-
-		return array( 'content' => $content );
-	}
-
-	/**
-	 * Check if URL is a Discord webhook.
-	 *
-	 * @param string $url Webhook URL
-	 * @return bool
-	 */
-	private function isDiscordWebhook( string $url ): bool {
-		return str_contains( $url, 'discord.com/api/webhooks/' )
-			|| str_contains( $url, 'discordapp.com/api/webhooks/' );
-	}
-
-	/**
-	 * Sanitize URL for logging (mask tokens).
-	 *
-	 * @param string $url Full URL
-	 * @return string URL with token masked
-	 */
-	private function sanitizeUrlForLog( string $url ): string {
-		return preg_replace(
-			'#(discord(?:app)?\.com/api/webhooks/\d+/)[^/\s]+#',
-			'$1[MASKED]',
-			$url
-		);
+			return $result_packet->addTo( $this->dataPackets );
 	}
 }


### PR DESCRIPTION
## Summary

Refactors the Agent Ping step to follow the abilities-first architecture pattern established in CLAUDE.md. The webhook logic is now extracted into a dedicated ability class.

## Changes

### New Files
- `inc/Abilities/AgentPing/SendPingAbility.php` - Handles webhook POST with Discord formatting
- `inc/Abilities/AgentPingAbilities.php` - Facade that registers the ability

### Modified Files
- `inc/Core/Steps/AgentPing/AgentPingStep.php` - Now calls `wp_execute_ability('datamachine/send-ping', ...)`
- `inc/Core/Steps/AgentPing/AgentPingSettings.php` - Updated @since version
- `data-machine.php` - Loads and instantiates AgentPingAbilities

## Architecture

Following the pattern from CLAUDE.md:
- Step classes remain thin orchestrators
- Business logic lives in ability classes
- Abilities are registered via `wp_register_ability()`
- Step calls ability via `wp_execute_ability()`

## Key Fixes from Previous PR

- Config now reads from `handler_config` (flow step level) not `pipeline_step_config`
- Uses `$this->dataPackets` instead of `$this->engine->getDataPackets()`
- Sets `hasPipelineConfig: false` and `config_type: 'handler'`

## Testing

- [ ] Verify ability registration: `wp ability list | grep send-ping`
- [ ] Test webhook delivery with Discord URL
- [ ] Test webhook delivery with generic URL
- [ ] Verify error handling when webhook fails