### PR TITLE
fix(ui): hide Configure button for steps without handlers

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepHandler.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepHandler.jsx
@@ -17,6 +17,7 @@ export default function FlowStepHandler( {
 	handlerSlug,
 	settingsDisplay,
 	onConfigure,
+	showConfigureButton = true,
 } ) {
 	const { data: handlers = {} } = useHandlers();
 	const { data: stepTypes = {} } = useStepTypes();
@@ -78,9 +79,11 @@ export default function FlowStepHandler( {
 				</div>
 			) }
 
-			<Button variant="secondary" size="small" onClick={ onConfigure }>
-				{ __( 'Configure', 'data-machine' ) }
-			</Button>
+			{ showConfigureButton && (
+				<Button variant="secondary" size="small" onClick={ onConfigure }>
+					{ __( 'Configure', 'data-machine' ) }
+				</Button>
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
## Problem
AI steps show a Configure button even though they don't use handlers (configured at pipeline level).

## Root Cause
The check `uses_handler !== false` passes for empty string because PHP `false` becomes `""` in JSON serialization.

## Fix
- Use `Boolean(uses_handler)` for proper falsy check
- Skip FlowStepHandler entirely for non-handler steps (ai, agent_ping)

## Testing
- AI steps should show no Configure button
- Publish/Fetch steps should still show Configure button
- agent_ping steps should show no Configure button