### PR TITLE
fix(agent-ping): include engine_data in webhook payload

### DIFF
--- a/inc/Core/Steps/AgentPing/AgentPingStep.php
+++ b/inc/Core/Steps/AgentPing/AgentPingStep.php
@@ -122,6 +122,7 @@ class AgentPingStep extends Step {
 				'webhook_url'  => $webhook_url,
 				'prompt'       => $prompt,
 				'data_packets' => $data_packets,
+				'engine_data'  => $this->engine->getAll(),
 				'flow_id'      => $this->engine->get( 'flow_id' ),
 				'pipeline_id'  => $this->engine->get( 'pipeline_id' ),
 				'job_id'       => $this->job_id,


### PR DESCRIPTION
Fixes #44

## Summary
Include `engine_data` in the Agent Ping webhook payload, giving webhook consumers access to post_id, published_url, and other engine state.

## Changes

### AgentPingStep.php
- Added `engine_data => $this->engine->getAll()` to the ability call

### SendPingAbility.php
- Added `engine_data` to the input schema
- Extract and pass `engine_data` through to `buildPayload()`
- Include `engine_data` in the standard webhook payload context
- Updated `buildDiscordPayload()` signature to accept engine_data for future use

## Payload Structure
Non-Discord webhooks now receive:
```json
{
  "prompt": "...",
  "context": {
    "data_packets": [...],
    "engine_data": {
      "post_id": 123,
      "published_url": "https://...",
      ...
    },
    "flow_id": ...,
    "pipeline_id": ...,
    "job_id": ...
  },
  "timestamp": "..."
}
```