### PR TITLE
fix(ui): remove queue button from flow footer

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowCard.jsx
@@ -274,19 +274,6 @@ function FlowCardContent( props ) {
 	);
 
 	/**
-	 * Handle queue button click
-	 */
-	const handleQueue = useCallback( () => {
-		openModal( MODAL_TYPES.FLOW_QUEUE, {
-			flowId: currentFlowData.flow_id,
-			flowName: currentFlowData.flow_name,
-		} );
-	}, [ currentFlowData.flow_id, currentFlowData.flow_name, openModal ] );
-
-	// Compute queue count from flow config
-	const queueCount = currentFlowData.flow_config?.prompt_queue?.length || 0;
-
-	/**
 	 * Handle step configuration
 	 */
 	const handleStepConfigured = useCallback(
@@ -374,8 +361,6 @@ function FlowCardContent( props ) {
 						is_running: currentFlowData.is_running,
 						next_run_display: currentFlowData.next_run_display,
 					} }
-					queueCount={ queueCount }
-					onQueueClick={ handleQueue }
 				/>
 			</CardBody>
 		</Card>

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowFooter.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowFooter.jsx
@@ -62,15 +62,11 @@ const formatStatus = ( status ) => {
  * @param {string}   props.scheduling.last_run_status  - Job status from last run
  * @param {boolean}  props.scheduling.is_running       - Whether a job is currently running
  * @param {string}   props.scheduling.next_run_display - Pre-formatted next run display
- * @param {number}   props.queueCount                  - Number of prompts in queue
- * @param {Function} props.onQueueClick                - Handler for queue button click
  * @return {React.ReactElement} Flow footer
  */
 export default function FlowFooter( {
 	flowId,
 	scheduling,
-	queueCount = 0,
-	onQueueClick,
 } ) {
 	const {
 		interval,
@@ -125,26 +121,6 @@ export default function FlowFooter( {
 				</div>
 			) }
 
-			{ onQueueClick && (
-				<div className="datamachine-flow-meta-item datamachine-flow-meta-item--queue">
-					<Button
-						variant="link"
-						onClick={ onQueueClick }
-						className="datamachine-queue-badge"
-					>
-						{ __( 'Queue', 'data-machine' ) }{ ' ' }
-						<span
-							className={ `datamachine-queue-count ${
-								queueCount > 0
-									? 'datamachine-queue-count--active'
-									: ''
-							}` }
-						>
-							({ queueCount })
-						</span>
-					</Button>
-				</div>
-			) }
 		</div>
 	);
 }


### PR DESCRIPTION
Queue management was moved to the flow step card in PR #49.

This removes the now-redundant queue button from the flow footer.

## Changes
- Remove `queueCount` and `onQueueClick` props from FlowFooter
- Remove queue button JSX from FlowFooter  
- Remove `handleQueue` callback and `queueCount` from FlowCard

## Related
- PR #49 added the queue button to FlowStepCard