### PR TITLE
fix(ui): open queue modal from step card button

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowCard.jsx
@@ -274,6 +274,16 @@ function FlowCardContent( props ) {
 	);
 
 	/**
+	 * Handle queue button click - opens queue management modal
+	 */
+	const handleQueue = useCallback( () => {
+		openModal( MODAL_TYPES.FLOW_QUEUE, {
+			flowId: currentFlowData.flow_id,
+			flowName: currentFlowData.flow_name,
+		} );
+	}, [ currentFlowData.flow_id, currentFlowData.flow_name, openModal ] );
+
+	/**
 	 * Handle step configuration
 	 */
 	const handleStepConfigured = useCallback(
@@ -346,6 +356,7 @@ function FlowCardContent( props ) {
 					flowConfig={ currentFlowData.flow_config || {} }
 					pipelineConfig={ pipelineConfig }
 					onStepConfigured={ handleStepConfigured }
+					onQueueClick={ handleQueue }
 				/>
 
 				<CardDivider />

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowSteps.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowSteps.jsx
@@ -25,6 +25,7 @@ import { isSameId } from '../../utils/ids';
  * @param {Object}   props.flowConfig       - Flow configuration (keyed by flow_step_id).
  * @param {Object}   props.pipelineConfig   - Pipeline configuration (keyed by pipeline_step_id).
  * @param {Function} props.onStepConfigured - Configure step handler.
+ * @param {Function} props.onQueueClick     - Queue button click handler (opens modal).
  * @return {JSX.Element} Flow steps container.
  */
 export default function FlowSteps( {
@@ -33,6 +34,7 @@ export default function FlowSteps( {
 	flowConfig,
 	pipelineConfig,
 	onStepConfigured,
+	onQueueClick,
 } ) {
 	// Extract prompt_queue from flow config (it's at the flow level, not step level)
 	const promptQueue = flowConfig?.prompt_queue || [];
@@ -124,6 +126,7 @@ export default function FlowSteps( {
 						pipelineConfig={ pipelineConfig }
 						promptQueue={ promptQueue }
 						onConfigure={ onStepConfigured }
+						onQueueClick={ onQueueClick }
 					/>
 				</div>
 			);


### PR DESCRIPTION
## Summary
Replace inline queue editing in FlowStepCard with a 'Manage Queue' button that opens the existing FlowQueueModal for full queue management.

## Problem
The previous implementation showed an 'Add to Queue' button only when the queue was empty, and hid it when items existed. This prevented users from managing the queue from the UI once items were added.

## Solution
- Add `handleQueue` to FlowCard that opens the FLOW_QUEUE modal
- Pass `onQueueClick` through FlowSteps to FlowStepCard  
- Show 'Manage Queue (N)' button on AI steps that always opens the modal
- Remove complex inline editing logic (200+ lines simpler)

The existing FlowQueueModal already provides proper CRUD:
- View all queued items
- Add new prompts
- Remove individual items
- Clear all

## Testing
1. Navigate to Pipelines → expand a flow with AI step
2. Click 'Manage Queue (N)' button on the AI step
3. Modal should open with full queue management