### PR TITLE
fix(agent-ping): use engine->all() not getAll()

### DIFF
--- a/inc/Core/Steps/AgentPing/AgentPingStep.php
+++ b/inc/Core/Steps/AgentPing/AgentPingStep.php
@@ -130,7 +130,7 @@ class AgentPingStep extends Step {
 				'prompt'       => $prompt,
 				'from_queue'   => $from_queue,
 				'data_packets' => $data_packets,
-				'engine_data'  => $this->engine->getAll(),
+				'engine_data'  => $this->engine->all(),
 				'flow_id'      => $this->engine->get( 'flow_id' ),
 				'pipeline_id'  => $this->engine->get( 'pipeline_id' ),
 				'job_id'       => $this->job_id,


### PR DESCRIPTION
EngineData class uses `all()` method, not `getAll()`.

This fix was pushed to PR #53 after it was merged. Creating separate PR to get this into main.

**The bug:** `Call to undefined method DataMachine\Core\EngineData::getAll()`

**The fix:** Use `->all()` like all other steps do (AIStep, WordPress handlers, etc.)