### PR TITLE
fix(ui): sync tools display with global settings source of truth

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/ConfigureStepModal.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/ConfigureStepModal.jsx
@@ -110,14 +110,29 @@ export default function ConfigureStepModal( {
 			return;
 		}
 
-		// Pre-populate with all globally enabled tools for new AI steps
-		if ( ! currentConfig?.enabled_tools && tools ) {
-			const availableTools = Object.entries( tools )
+		/*
+		 * Tools selection logic:
+		 * - Global settings = source of truth for NEW steps (defaults)
+		 * - Steps can DISABLE globally-enabled tools (override)
+		 * - Steps CANNOT enable globally-disabled tools
+		 *
+		 * Detection:
+		 * - enabled_tools is Array → explicitly configured (use as-is, even if empty)
+		 * - enabled_tools is undefined → never configured → pre-fill with global defaults
+		 */
+		const isExplicitlyConfigured = Array.isArray(
+			currentConfig?.enabled_tools
+		);
+
+		if ( isExplicitlyConfigured ) {
+			// Use explicitly configured tools (even if empty array)
+			setSelectedTools( currentConfig.enabled_tools );
+		} else if ( tools ) {
+			// Never configured - pre-fill with globally enabled tools
+			const globalDefaults = Object.entries( tools )
 				.filter( ( [ , tool ] ) => tool.globally_enabled )
 				.map( ( [ id ] ) => id );
-			setSelectedTools( availableTools );
-		} else if ( currentConfig?.enabled_tools ) {
-			setSelectedTools( currentConfig.enabled_tools );
+			setSelectedTools( globalDefaults );
 		}
 	}, [ configKey, tools, isLoadingTools ] );
 

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineSteps.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineSteps.jsx
@@ -43,11 +43,13 @@ export default function PipelineSteps( {
 			return [];
 		}
 
-		return Object.values( pipelineConfig ).sort( ( a, b ) => {
-			const orderA = a.execution_order || 0;
-			const orderB = b.execution_order || 0;
-			return orderA - orderB;
-		} );
+		return Object.values( pipelineConfig )
+			.filter( ( step ) => step.step_type )
+			.sort( ( a, b ) => {
+				const orderA = a.execution_order || 0;
+				const orderB = b.execution_order || 0;
+				return orderA - orderB;
+			} );
 	}, [ pipelineConfig ] );
 
 	/**


### PR DESCRIPTION
## Problem
When a pipeline step has no explicit `enabled_tools` configured:
- The modal pre-fills with globally enabled tools (correct behavior)
- The card shows "No tools enabled" (inconsistent)

## Solution
Apply the same fallback logic to PipelineStepCard - when `aiConfig.enabled_tools` is empty, display the globally enabled tools from `toolsData` (filtered by `globally_enabled: true`).

This ensures the card's tools display matches what the modal would show, maintaining consistency with the global settings as the source of truth.