### PR TITLE
fix(ui): filter ghost steps without step_type from pipeline display

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineSteps.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineSteps.jsx
@@ -43,11 +43,13 @@ export default function PipelineSteps( {
 			return [];
 		}
 
-		return Object.values( pipelineConfig ).sort( ( a, b ) => {
-			const orderA = a.execution_order || 0;
-			const orderB = b.execution_order || 0;
-			return orderA - orderB;
-		} );
+		return Object.values( pipelineConfig )
+			.filter( ( step ) => step.step_type )
+			.sort( ( a, b ) => {
+				const orderA = a.execution_order || 0;
+				const orderB = b.execution_order || 0;
+				return orderA - orderB;
+			} );
 	}, [ pipelineConfig ] );
 
 	/**


### PR DESCRIPTION
## Problem
Pipeline 12 has a legacy `system_prompt` key in the config with no `step_type`, causing an empty "ghost" card to render in the pipeline steps UI.

The root cause is that `Object.values(pipelineConfig)` returns ALL keys in the config object, including non-step entries like `system_prompt`.

## Solution
In the `sortedSteps` useMemo, filter to only include entries that have a valid `step_type` before sorting:

```javascript
.filter( ( step ) => step.step_type )
```

This ensures only actual pipeline steps are rendered, and legacy/metadata keys are ignored.