### PR TITLE
fix: filter invalid pipeline_config entries, handle missing enabled_tools

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineStepCard.jsx
@@ -50,6 +50,12 @@ export default function PipelineStepCard( {
 		step.step_type === 'ai'
 			? pipelineConfig[ step.pipeline_step_id ]
 			: null;
+	const enabledTools =
+		aiConfig?.enabled_tools?.length > 0
+			? aiConfig.enabled_tools
+			: Object.entries( toolsData || {} )
+					.filter( ( [ , tool ] ) => tool.globally_enabled )
+					.map( ( [ name ] ) => name );
 
 	const [ localPrompt, setLocalPrompt ] = useState(
 		aiConfig?.system_prompt || ''
@@ -193,8 +199,8 @@ export default function PipelineStepCard( {
 						</div>
 						<div className="datamachine-step-card-tools-label">
 							<strong>{ __( 'Tools:', 'data-machine' ) }</strong>{ ' ' }
-							{ aiConfig.enabled_tools?.length > 0
-								? aiConfig.enabled_tools
+							{ enabledTools.length > 0
+								? enabledTools
 										.map(
 											( toolId ) =>
 												toolsData[ toolId ]?.label ||

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineSteps.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineSteps.jsx
@@ -44,7 +44,7 @@ export default function PipelineSteps( {
 		}
 
 		return Object.values( pipelineConfig )
-			.filter( ( step ) => step.step_type )
+			.filter( ( step ) => step && step.step_type )
 			.sort( ( a, b ) => {
 				const orderA = a.execution_order || 0;
 				const orderB = b.execution_order || 0;


### PR DESCRIPTION
## Summary
Fixes two critical UI bugs in the Data Machine React admin:

### Bug 1: Ghost Pipeline Step
**Root cause**: Pipeline 12's `pipeline_config` had a `system_prompt` key at root level lacking `step_type`. `Object.values(pipelineConfig)` included it, rendering an empty card.

**Fix**: Added `.filter(step => step && step.step_type)` before mapping to cards in `PipelineSteps.jsx`.

### Bug 2: "No tools enabled" Regression  
**Root cause**: AI step config had no `enabled_tools` field saved. Modal computed defaults from globally enabled tools, but card showed empty.

**Fix**: In `PipelineStepCard.jsx`, compute `enabledTools` fallback from `toolsData` using same logic as `ConfigureStepModal`.

## Changes
- `PipelineSteps.jsx`: Filter entries without valid `step_type`
- `PipelineStepCard.jsx`: Compute enabled tools fallback from globally enabled tools

## Testing
- Build passes (`npm run build`)
- Ghost step should no longer appear
- AI step cards should show correct tool list even when not explicitly saved