### PR TITLE
fix(cli): add missing --step parameter declaration for queue commands

### DIFF
--- a/inc/Cli/Commands/FlowsCommand.php
+++ b/inc/Cli/Commands/FlowsCommand.php
@@ -91,6 +91,9 @@ class FlowsCommand extends BaseCommand {
 	 * default: manual
 	 * ---
 	 *
+	 * [--step=<flow_step_id>]
+	 * : Flow step ID for queue subcommands (queue add/list/remove/clear/update/move).
+	 *
 	 * [--dry-run]
 	 * : Validate without creating (create subcommand).
 	 *


### PR DESCRIPTION
The `--step` parameter was used in queue subcommands but never declared in the WP-CLI docblock, causing 'unknown parameter' errors.

This was introduced in the queue management feature (PR #62).