### PR TITLE
fix(ui): hide step settings display when disabled

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -46,6 +46,8 @@ export default function FlowStepCard( {
 	// Global config: Use stepTypes hook directly (TanStack Query handles caching)
 	const { data: stepTypes = {} } = useStepTypes();
 	const stepTypeInfo = stepTypes[ pipelineStep.step_type ] || {};
+	const showSettingsDisplay =
+		stepTypeInfo.show_settings_display !== false;
 	const isAiStep = pipelineStep.step_type === 'ai';
 	const isAgentPing = pipelineStep.step_type === 'agent_ping';
 	const aiConfig = isAiStep
@@ -490,49 +492,47 @@ export default function FlowStepCard( {
 				) }
 
 				{ /* Handler Configuration */ }
-					{ ( () => {
-						const handlerStepTypeInfo =
-							stepTypes[ pipelineStep.step_type ] || {};
-						// Falsy check: PHP false becomes "" in JSON, but undefined means still loading
-						const usesHandler =
-							handlerStepTypeInfo.uses_handler !== '' &&
-							handlerStepTypeInfo.uses_handler !== false;
+				{ showSettingsDisplay && ( () => {
+					const handlerStepTypeInfo =
+						stepTypes[ pipelineStep.step_type ] || {};
+					// Falsy check: PHP false becomes "" in JSON, but undefined means still loading
+					const usesHandler =
+						handlerStepTypeInfo.uses_handler !== '' &&
+						handlerStepTypeInfo.uses_handler !== false;
 
-						// For steps that don't use handlers (e.g., agent_ping),
-						// use the step_type as the effective handler slug for settings display
-						const effectiveHandlerSlug = usesHandler
-							? flowStepConfig.handler_slug
-							: pipelineStep.step_type;
+					// For steps that don't use handlers, use the step_type as the effective handler slug
+					const effectiveHandlerSlug = usesHandler
+						? flowStepConfig.handler_slug
+						: pipelineStep.step_type;
 
-						// Handler-based step with no handler configured - show configure button
-						if ( usesHandler && ! flowStepConfig.handler_slug ) {
-							return (
-								<FlowStepHandler
-									handlerSlug={ null }
-									settingsDisplay={ [] }
-									onConfigure={ () =>
-										onConfigure && onConfigure( flowStepId )
-									}
-								/>
-							);
-						}
-
-						// Show settings display (works for both handler steps and non-handler steps like agent_ping)
-						// Non-handler steps don't need Configure button or badge (configured at pipeline level)
+					// Handler-based step with no handler configured - show configure button
+					if ( usesHandler && ! flowStepConfig.handler_slug ) {
 						return (
 							<FlowStepHandler
-								handlerSlug={ effectiveHandlerSlug }
-								settingsDisplay={
-									flowStepConfig.settings_display || []
-								}
+								handlerSlug={ null }
+								settingsDisplay={ [] }
 								onConfigure={ () =>
 									onConfigure && onConfigure( flowStepId )
 								}
-								showConfigureButton={ usesHandler }
-								showBadge={ usesHandler }
 							/>
 						);
-					} )() }
+					}
+
+					// Show settings display
+					return (
+						<FlowStepHandler
+							handlerSlug={ effectiveHandlerSlug }
+							settingsDisplay={
+								flowStepConfig.settings_display || []
+							}
+							onConfigure={ () =>
+								onConfigure && onConfigure( flowStepId )
+							}
+							showConfigureButton={ usesHandler }
+							showBadge={ usesHandler }
+						/>
+					);
+				} )() }
 				</div>
 			</CardBody>
 		</Card>

--- a/inc/Core/Steps/AgentPing/AgentPingStep.php
+++ b/inc/Core/Steps/AgentPing/AgentPingStep.php
@@ -48,7 +48,8 @@ class AgentPingStep extends Step {
 				'modal_type'  => 'configure-step',
 				'button_text' => 'Configure',
 				'label'       => 'Agent Ping Configuration',
-			)
+			),
+			showSettingsDisplay: false
 		);
 
 		self::registerStepSettings();

--- a/inc/Core/Steps/Settings/SettingsDisplayService.php
+++ b/inc/Core/Steps/Settings/SettingsDisplayService.php
@@ -33,6 +33,10 @@ class SettingsDisplayService {
 	 * @return array Formatted settings display array
 	 */
 	public function getDisplaySettings( string $flow_step_id, string $step_type ): array {
+		if ( ! $this->shouldShowSettingsDisplay( $step_type ) ) {
+			return array();
+		}
+
 		// Get flow step configuration
 		$db_flows         = new \DataMachine\Core\Database\Flows\Flows();
 		$flow_step_config = $db_flows->get_flow_step_config( $flow_step_id );
@@ -65,6 +69,20 @@ class SettingsDisplayService {
 		$fields = $handler_settings::get_fields();
 
 		return $this->buildDisplayArray( $fields, $current_settings );
+	}
+
+	/**
+	 * Determine if settings display should render for a step type.
+	 *
+	 * @param string $step_type Step type slug.
+	 * @return bool
+	 */
+	private function shouldShowSettingsDisplay( string $step_type ): bool {
+		$step_types = apply_filters( 'datamachine_step_types', array() );
+		if ( empty( $step_type ) || empty( $step_types[ $step_type ] ) ) {
+			return true;
+		}
+		return $step_types[ $step_type ]['show_settings_display'] ?? true;
 	}
 
 	/**

--- a/inc/Core/Steps/StepTypeRegistrationTrait.php
+++ b/inc/Core/Steps/StepTypeRegistrationTrait.php
@@ -52,7 +52,8 @@ trait StepTypeRegistrationTrait {
 		bool $usesHandler = true,
 		bool $hasPipelineConfig = false,
 		bool $consumeAllPackets = false,
-		?array $stepSettings = null
+		?array $stepSettings = null,
+		bool $showSettingsDisplay = true
 	): void {
 		// Prevent duplicate registration when step class is instantiated multiple times
 		if ( isset( self::$registered_step_types[ $slug ] ) ) {
@@ -70,7 +71,8 @@ trait StepTypeRegistrationTrait {
 				$position,
 				$usesHandler,
 				$hasPipelineConfig,
-				$consumeAllPackets
+				$consumeAllPackets,
+				$showSettingsDisplay
 			) {
 				$steps[ $slug ] = array(
 					'label'               => $label,
@@ -79,7 +81,8 @@ trait StepTypeRegistrationTrait {
 					'position'            => $position,
 					'uses_handler'        => $usesHandler,
 					'has_pipeline_config' => $hasPipelineConfig,
-					'consume_all_packets' => $consumeAllPackets,
+					'consume_all_packets'   => $consumeAllPackets,
+					'show_settings_display' => $showSettingsDisplay,
 				);
 				return $steps;
 			}


### PR DESCRIPTION
## Summary
- add step type metadata to control settings display rendering
- disable settings display for Agent Ping via step registration
- respect the flag in SettingsDisplayService and FlowStepCard