### PR TITLE
fix(flow-steps): use step_type as fallback handler_slug for non-handler steps

### DIFF
--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -270,10 +270,15 @@ trait FlowStepHelpers {
 			);
 		}
 
-		$effective_slug = ! empty( $handler_slug ) ? $handler_slug : ( $flow_config[ $flow_step_id ]['handler_slug'] ?? null );
+		// Priority: explicit handler_slug > existing handler_slug > step_type (for non-handler steps like agent_ping).
+		$effective_slug = ! empty( $handler_slug )
+			? $handler_slug
+			: ( ! empty( $flow_config[ $flow_step_id ]['handler_slug'] )
+				? $flow_config[ $flow_step_id ]['handler_slug']
+				: ( $flow_config[ $flow_step_id ]['step_type'] ?? null ) );
 
 		if ( empty( $effective_slug ) ) {
-			do_action( 'datamachine_log', 'error', 'No handler slug available for flow step update', array( 'flow_step_id' => $flow_step_id ) );
+			do_action( 'datamachine_log', 'error', 'No handler slug or step_type available for flow step update', array( 'flow_step_id' => $flow_step_id ) );
 			return false;
 		}
 

--- a/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
+++ b/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
@@ -118,12 +118,17 @@ class UpdateFlowStepAbility {
 		$updated_fields = array();
 
 		if ( $has_handler_update ) {
-			$effective_slug = ! empty( $handler_slug ) ? $handler_slug : ( $existing_step['handler_slug'] ?? '' );
+			// Priority: explicit handler_slug > existing handler_slug > step_type (for non-handler steps like agent_ping).
+			$effective_slug = ! empty( $handler_slug )
+				? $handler_slug
+				: ( ! empty( $existing_step['handler_slug'] )
+					? $existing_step['handler_slug']
+					: ( $existing_step['step_type'] ?? '' ) );
 
 			if ( empty( $effective_slug ) ) {
 				return array(
 					'success' => false,
-					'error'   => 'handler_slug is required when configuring a step without an existing handler',
+					'error'   => 'Unable to determine handler: no handler_slug provided, stored, or step_type available',
 				);
 			}
 


### PR DESCRIPTION
## Summary
When updating `handler_config` for steps with `usesHandler: false` but `config_type: 'handler'` (like `agent_ping`), the system now correctly falls back to the `step_type` as the effective `handler_slug`.

## Problem
When saving Agent Ping configuration through the React UI (FlowStepCard.jsx), only `handler_config` is sent - no `handler_slug`. If the flow step doesn't already have a `handler_slug` stored, the update fails with:

```
handler_slug is required when configuring a step without an existing handler
```

This happens because:
1. Agent Ping registers with `usesHandler: false` 
2. So flow steps don't always have `handler_slug` stored
3. The React UI correctly doesn't send one
4. But the PHP validation required it

## Solution
Use `step_type` as the fallback when no explicit or stored `handler_slug` exists:

**Priority chain:** explicit handler_slug > stored handler_slug > step_type

## Files Changed
- `inc/Abilities/FlowStep/UpdateFlowStepAbility.php` - Updated slug resolution logic
- `inc/Abilities/FlowStep/FlowStepHelpers.php` - Updated `updateHandler()` for consistency

## Testing
Verified on saraichinwag.com:
1. Found flows with Agent Ping steps missing `handler_slug`
2. Applied fix
3. Successfully updated handler_config without providing handler_slug
4. Confirmed handler_slug is now properly set to `agent_ping`