### PR TITLE
fix: tool enablement falls back to global when step has empty array

### DIFF
--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -279,7 +279,10 @@ class ToolManager {
 
 		// Pipeline context: check step-specific selections
 		if ( $context_id ) {
-			return $this->is_step_tool_enabled( $context_id, $tool_id );
+			$step_tools = $this->get_step_enabled_tools( $context_id );
+			if ( ! empty( $step_tools ) ) {
+				return in_array( $tool_id, $step_tools, true );
+			}
 		}
 
 		// Chat context (no context_id): check global enablement + configuration


### PR DESCRIPTION
## Problem
When a pipeline step has `enabled_tools = []` (empty array), all tools are disabled instead of falling back to global defaults.

This broke local_search and other tools during content generation - the AI couldn't search the site for existing posts or related content.

## Root Cause
In `ToolManager::is_tool_available()`, when `context_id` (pipeline step) is set, it immediately returns the result of `is_step_tool_enabled()`. 

If the step has an empty `enabled_tools` array, `in_array($tool_id, [])` always returns false, disabling ALL tools with no fallback.

## Fix
Only use step-specific tools when the step has a non-empty `enabled_tools` array. Otherwise, fall through to the global enablement check:

```php
if ( $context_id ) {
    $step_tools = $this->get_step_enabled_tools( $context_id );
    if ( ! empty( $step_tools ) ) {
        return in_array( $tool_id, $step_tools, true );
    }
}
// Falls through to global check below
```

## Behavior Change
| Scenario | Before | After |
|----------|--------|-------|
| Step has `['local_search', 'web_fetch']` | Uses step tools ✓ | Uses step tools ✓ |
| Step has `[]` (empty) | All tools disabled ✗ | Falls back to global ✓ |
| Step has no enabled_tools key | All tools disabled ✗ | Falls back to global ✓ |

## Testing
Created a flow with empty `enabled_tools` in flow_config - verified tools now available via global settings.