### PR TITLE
simplify: use global tool enablement only, ignore step context

### DIFF
--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -277,20 +277,16 @@ class ToolManager {
 			return false; // Tool doesn't exist
 		}
 
-		// Pipeline context: check step-specific selections
-		if ( $context_id ) {
-			return $this->is_step_tool_enabled( $context_id, $tool_id );
-		}
+// Simplified: always use global enablement, ignore step-level config
+// Step-level tool enablement removed for architectural simplification
+if ( ! $this->is_globally_enabled( $tool_id ) ) {
+    return false; // Globally disabled
+}
 
-		// Chat context (no context_id): check global enablement + configuration
-		if ( ! $this->is_globally_enabled( $tool_id ) ) {
-			return false; // Globally disabled
-		}
+$requires_config = $this->requires_configuration( $tool_id );
+$configured      = $this->is_tool_configured( $tool_id );
 
-		$requires_config = $this->requires_configuration( $tool_id );
-		$configured      = $this->is_tool_configured( $tool_id );
-
-		return ! $requires_config || $configured;
+return ! $requires_config || $configured;
 	}
 
 	// ============================================


### PR DESCRIPTION
## Summary
Simplifies tool enablement architecture by removing pipeline/step-level tool configuration.

**Before:** Tools could be enabled/disabled per pipeline step, creating a confusing hierarchy that repeatedly broke.

**After:** Global settings = single source of truth. All AI steps use globally enabled tools.

## The Change
```php
// Before: checked step-specific config when context_id was set
if ( $context_id ) {
    return $this->is_step_tool_enabled( $context_id, $tool_id );
}

// After: always use global enablement
if ( ! $this->is_globally_enabled( $tool_id ) ) {
    return false;
}
```

## Why
- Pipeline-level tool enablement was never effectively used
- The hierarchy (global → pipeline → flow) created bugs repeatedly
- Empty `enabled_tools` arrays disabled all tools instead of falling back
- AI agents follow instructions anyway — tool availability is less important than prompt guidance

## Backwards Compatibility
- APIs still accept `enabled_tools` parameter (ignored gracefully)
- Existing pipeline configs with `enabled_tools` are ignored
- UI changes (removing tool selector) can follow in a separate PR

## Testing
- Verified tools now use global settings regardless of pipeline context
- AI steps get all globally-enabled tools