### PR TITLE
fix: normalize interval shorthands in scheduling validation

### DIFF
--- a/inc/Api/Flows/FlowScheduling.php
+++ b/inc/Api/Flows/FlowScheduling.php
@@ -17,6 +17,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FlowScheduling {
 
 	/**
+	 * Interval shorthand aliases.
+	 *
+	 * Maps common shorthand formats (from UI/database) to canonical interval names.
+	 * Ensures backwards compatibility with existing data.
+	 *
+	 * @var array<string, string>
+	 */
+	private static $interval_aliases = array(
+		'2hours' => 'every_2_hours',
+		'3days'  => 'every_3_days',
+		'4hours' => 'every_4_hours',
+		'6hours' => 'qtrdaily',
+		'5min'   => 'every_5_minutes',
+		'5mins'  => 'every_5_minutes',
+	);
+
+	/**
+	 * Normalize interval name, converting shorthands to canonical names.
+	 *
+	 * @param string $interval Raw interval value
+	 * @return string Normalized interval name
+	 */
+	private static function normalize_interval( string $interval ): string {
+		return self::$interval_aliases[ $interval ] ?? $interval;
+	}
+
+	/**
 	 * Handle scheduling configuration updates for a flow.
 	 *
 	 * scheduling_config now only contains scheduling data (interval, timestamps).
@@ -40,6 +67,11 @@ class FlowScheduling {
 		}
 
 		$interval = $scheduling_config['interval'] ?? null;
+
+		// Normalize shorthand intervals to canonical names
+		if ( $interval && 'manual' !== $interval && 'one_time' !== $interval ) {
+			$interval = self::normalize_interval( $interval );
+		}
 
 		// Handle manual scheduling (unschedule)
 		if ( 'manual' === $interval || null === $interval ) {


### PR DESCRIPTION
## Problem

When using the `datamachine/update-flow` ability with an interval like `3days`, validation fails:

```
Error: Invalid interval: 3days
```

However, the database already has flows with `3days` intervals that work fine (Flow 30 runs every 3 days).

## Root Cause

- Database/UI stores shorthand formats: `2hours`, `3days`
- API validation expects canonical names: `every_2_hours`, `every_3_days`
- No normalization layer between them

## Solution

Added `normalize_interval()` to `FlowScheduling` class that converts common shorthands to canonical names before validation:

- `2hours` → `every_2_hours`
- `3days` → `every_3_days`
- `4hours` → `every_4_hours`
- `6hours` → `qtrdaily`
- `5min`/`5mins` → `every_5_minutes`

Now abilities accept both formats for backwards compatibility.