### PR TITLE
fix(flows): correct timezone for next_run display

### DIFF
--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -107,6 +107,6 @@ class FlowFormatter {
 
 		$next_timestamp = as_next_scheduled_action( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
 
-		return $next_timestamp ? wp_date( 'Y-m-d H:i:s', $next_timestamp ) : null;
+		return $next_timestamp ? wp_date( 'Y-m-d H:i:s', $next_timestamp, new \DateTimeZone( 'UTC' ) ) : null;
 	}
 }


### PR DESCRIPTION
## Summary
Fixes #85 - Flow list shows stale next_run dates

## Problem
`get_next_run_time()` was using `wp_date()` without a timezone parameter, which returns local time. But `DateFormatter::format_for_display()` expects UTC input and converts to local.

This caused double timezone conversion:
1. Action Scheduler timestamp (UTC) → `wp_date()` → local time string (e.g., 07:30 EST)
2. `format_for_display()` interprets as UTC → converts again → wrong time (02:30 EST)

## Fix
Explicitly specify UTC timezone in `wp_date()`:
```php
wp_date( 'Y-m-d H:i:s', $next_timestamp, new \DateTimeZone( 'UTC' ) )
```

## Testing
Before: Flow 29 showed "February 3, 2026 2:30 am" (wrong)
After: Should show correct time matching Action Scheduler

## Checklist
- [x] Traced root cause
- [x] Minimal fix (1 line change)
- [x] Consistent with DateFormatter expectations