### PR TITLE
feat(cli): auto-resolve queueable step when --step omitted

### DIFF
--- a/inc/Cli/Commands/FlowsCommand.php
+++ b/inc/Cli/Commands/FlowsCommand.php
@@ -92,7 +92,7 @@ class FlowsCommand extends BaseCommand {
 	 * ---
 	 *
 	 * [--step=<flow_step_id>]
-	 * : Flow step ID for queue subcommands (queue add/list/remove/clear/update/move).
+	 * : Flow step ID for queue subcommands. Optional if flow has exactly one queueable step (auto-resolved).
 	 *
 	 * [--dry-run]
 	 * : Validate without creating (create subcommand).
@@ -157,26 +157,29 @@ class FlowsCommand extends BaseCommand {
 	 *     # Dry-run validation
 	 *     wp datamachine flows create --pipeline_id=3 --name="Test" --dry-run
 	 *
-	 *     # Add a prompt to the queue (requires --step)
+	 *     # Add a prompt to the queue (--step auto-resolved if flow has one queueable step)
+	 *     wp datamachine flows queue add 42 "Generate a blog post about AI"
+	 *
+	 *     # Add with explicit step (required if multiple queueable steps)
 	 *     wp datamachine flows queue add 42 --step=flow-42-step-abc123 "Generate a blog post about AI"
 	 *
-	 *     # List queued prompts for a step
-	 *     wp datamachine flows queue list 42 --step=flow-42-step-abc123
+	 *     # List queued prompts (--step optional)
+	 *     wp datamachine flows queue list 42
 	 *
 	 *     # List queued prompts as JSON
-	 *     wp datamachine flows queue list 42 --step=flow-42-step-abc123 --format=json
+	 *     wp datamachine flows queue list 42 --format=json
 	 *
 	 *     # Remove a prompt from queue by index
-	 *     wp datamachine flows queue remove 42 --step=flow-42-step-abc123 0
+	 *     wp datamachine flows queue remove 42 0
 	 *
 	 *     # Clear all prompts from queue
-	 *     wp datamachine flows queue clear 42 --step=flow-42-step-abc123
+	 *     wp datamachine flows queue clear 42
 	 *
 	 *     # Update a prompt at index 0
-	 *     wp datamachine flows queue update 42 --step=flow-42-step-abc123 0 "Updated prompt text"
+	 *     wp datamachine flows queue update 42 0 "Updated prompt text"
 	 *
 	 *     # Move a prompt from index 2 to index 0 (front of queue)
-	 *     wp datamachine flows queue move 42 --step=flow-42-step-abc123 2 0
+	 *     wp datamachine flows queue move 42 2 0
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
 		$flow_id     = null;


### PR DESCRIPTION
## Summary
Fixes #82 - Simplify queue CLI for single-step flows

## Before
```bash
wp datamachine flows queue add 29 --step=12_e5eda239-5bd7-4ae6-89f1-e21909115c98_29 "My prompt"
```

## After
```bash
wp datamachine flows queue add 29 "My prompt"
```

## How It Works
Added `resolveQueueableStep()` helper that:
1. Queries flow_config from database
2. Finds all steps with `queue_enabled=true`
3. If exactly 1 → returns that step_id
4. If 0 → returns error: "Flow X has no queueable steps"
5. If multiple → returns error listing step IDs

## Methods Updated
- queueAdd
- queueList
- queueClear
- queueRemove
- queueUpdate
- queueMove

## Testing
Tested locally on Flow 29 (single queueable AI step):
```
$ wp datamachine flows queue list 29
Total: 28 prompt(s) in queue. (queue_enabled: yes)

$ wp datamachine flows queue add 29 "Test prompt"
Success: Prompt added to queue. Queue now has 29 item(s).
```

## Backward Compatibility
`--step` flag still works when provided, enabling explicit step selection for flows with multiple queueable steps.