### PR TITLE
Add Data Machine agent skill in OpenClaw format

### DIFF
--- a/skills/data-machine/SKILL.md
+++ b/skills/data-machine/SKILL.md
@@ -78,25 +78,25 @@ Configure via `scheduling_config` in the flow:
 ### List Flows
 
 ```bash
-wp --allow-root datamachine flows list
+wp datamachine flows list
 ```
 
 ### Get Flow Details
 
 ```bash
-wp --allow-root datamachine flows get <flow_id>
+wp datamachine flows get <flow_id>
 ```
 
 ### Run a Flow Manually
 
 ```bash
-wp --allow-root datamachine flows run <flow_id>
+wp datamachine flows run <flow_id>
 ```
 
 ### Check Job Status
 
 ```bash
-wp --allow-root datamachine jobs list --limit=10
+wp datamachine jobs list --limit=10
 ```
 
 ---
@@ -111,13 +111,13 @@ This enables **varied task instructions** per execution — not the same prompt 
 
 ```bash
 # Add to queue
-wp --allow-root datamachine flows queue add <flow_id> "Task instruction here"
+wp datamachine flows queue add <flow_id> "Task instruction here"
 
 # List queue contents
-wp --allow-root datamachine flows queue list <flow_id>
+wp datamachine flows queue list <flow_id>
 
 # Clear queue
-wp --allow-root datamachine flows queue clear <flow_id>
+wp datamachine flows queue clear <flow_id>
 ```
 
 ### Chaining Pattern
@@ -240,6 +240,8 @@ local_search(query="topic name", title_only=true)
 
 ## CLI Reference
 
+**Note:** If running WP-CLI as root, add `--allow-root` to commands.
+
 ```bash
 # Settings
 wp datamachine settings list
@@ -274,17 +276,17 @@ tail -f wp-content/uploads/datamachine-logs/datamachine-pipeline.log
 ### Failed Jobs
 
 ```bash
-wp --allow-root datamachine jobs list --status=failed
+wp datamachine jobs list --status=failed
 ```
 
 ### Scheduled Actions
 
 ```bash
 # List pending actions
-wp --allow-root action-scheduler run --hooks=datamachine --force
+wp action-scheduler run --hooks=datamachine --force
 
 # Check cron
-wp --allow-root cron event list
+wp cron event list
 ```
 
 ---


### PR DESCRIPTION
## Summary

Adds `skills/data-machine/SKILL.md` — a usage-focused skill that teaches AI agents how to use Data Machine for autonomous operation.

## What's Included

- **Proper OpenClaw frontmatter** (name, description, compatibility)
- **Core philosophy** — reminder system + task manager + workflow executor
- **Flow and queue management** patterns
- **Agent Ping configuration** guide
- **Self-scheduling and chaining** patterns
- **Taxonomy handling** (AI Decides mode)
- **CLI reference** and debugging tips

## Why

Data Machine currently has `AGENTS.md` which guides contributors working ON the codebase. This skill teaches AI agents how to USE Data Machine — the user-facing documentation in a format that agent frameworks (OpenClaw, etc.) can consume directly.

## Location

`skills/data-machine/SKILL.md` follows the standard skill format:
- Frontmatter with name, description, compatibility
- Structured sections for different use cases
- CLI examples and debugging guidance

This positions Data Machine skills to be bundled with wp-openclaw for ready-to-go agent setups.