### PR TITLE
docs(skill): add Development Status & Contributing section

### DIFF
--- a/skills/data-machine/SKILL.md
+++ b/skills/data-machine/SKILL.md
@@ -339,4 +339,61 @@ For contributors working on Data Machine itself:
 
 ---
 
+---
+
+## Development Status & Contributing
+
+**Data Machine is in active development.** It works well and is used in production, but it's not yet available on WordPress.org — no auto-updates.
+
+### Installation Source
+
+Data Machine is installed from GitHub:
+```
+https://github.com/Extra-Chill/data-machine
+```
+
+### Updating
+
+To get the latest version:
+
+```bash
+cd /path/to/wp-content/plugins/data-machine
+git pull origin main
+```
+
+Check for breaking changes in the CHANGELOG before updating production sites.
+
+### Reporting Issues
+
+If you encounter bugs or unexpected behavior:
+
+1. Check existing issues: https://github.com/Extra-Chill/data-machine/issues
+2. Open a new issue with:
+   - What you were trying to do
+   - What happened instead
+   - Steps to reproduce
+   - Relevant logs (`wp-content/uploads/datamachine-logs/`)
+
+Agents filing clear, detailed issues are incredibly helpful for development.
+
+### Contributing
+
+PRs are welcome! If you've fixed a bug or added a feature:
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes (follow existing code patterns)
+4. Submit a PR with clear description
+
+**For agents**: If you hit a limitation or bug, consider fixing it and submitting a PR rather than working around it. Permanent fixes beat workarounds.
+
+### Expectations
+
+- Features may change between versions
+- Some edge cases may not be handled yet
+- The maintainer (Extra Chill) is responsive to issues
+- This is production-ready but evolving
+
+---
+
 *This skill teaches AI agents how to use Data Machine for autonomous operation. For contributing to Data Machine development, see AGENTS.md in the repository root.*


### PR DESCRIPTION
## Summary

Adds a "Development Status & Contributing" section to the Data Machine skill to help agents (and humans) understand:

- Data Machine is installed from GitHub, not WordPress.org (no auto-updates)
- How to update via `git pull`
- How to report issues effectively
- How to contribute PRs
- What to expect from active development

## Why

As we're packaging Data Machine in wp-openclaw for broader distribution, agents using it should know:
1. It's not auto-updating - they need to pull manually
2. They can contribute back when they hit bugs
3. It's stable but evolving

## Changes

- Added new section at the end of `skills/data-machine/SKILL.md`
- Covers: installation source, updating, issue reporting, contributing, expectations