### PR TITLE
fix(LocalSearch): handle WP_Error from ability execution

### DIFF
--- a/inc/Engine/AI/Tools/Global/LocalSearch.php
+++ b/inc/Engine/AI/Tools/Global/LocalSearch.php
@@ -39,6 +39,15 @@ class LocalSearch extends BaseTool {
 			)
 		);
 
+		// Handle WP_Error from ability execution (e.g., permission denied).
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'   => false,
+				'error'     => $result->get_error_message(),
+				'tool_name' => 'local_search',
+			);
+		}
+
 		if ( isset( $result['error'] ) ) {
 			return array(
 				'success'   => false,


### PR DESCRIPTION
## Problem

The `local_search` tool was crashing with:
```
Cannot use object of type WP_Error as array
```

This happened when `$ability->execute()` returned a WP_Error instead of an array (e.g., permission denied during Action Scheduler cron execution).

**Affected jobs:** 855, 856, 857 on saraichinwag.com — all failed overnight.

## Solution

Added `is_wp_error()` check before accessing the result as an array:

```php
if ( is_wp_error( $result ) ) {
    return array(
        'success'   => false,
        'error'     => $result->get_error_message(),
        'tool_name' => 'local_search',
    );
}
```

## Testing

- Verified the fix handles WP_Error gracefully
- Returns proper error structure instead of crashing