### PR TITLE
feat(queue): re-queue prompt on job failure

### DIFF
--- a/inc/Core/Steps/QueueableTrait.php
+++ b/inc/Core/Steps/QueueableTrait.php
@@ -74,17 +74,20 @@ trait QueueableTrait {
 				)
 			);
 
-            // Store backup of the popped prompt in engine data for retry on failure
-            if (property_exists($this, 'job_id') && !empty($this->job_id)) {
-                \datamachine_merge_engine_data($this->job_id, array(
-                    'queued_prompt_backup' => array(
-                        'prompt'      => $queued_item['prompt'],
-                        'flow_id'     => (int) $flow_id,
-                        'flow_step_id'=> $this->flow_step_id,
-                        'added_at'    => $queued_item['added_at'] ?? null,
-                    )
-                ));
-            }
+			// Store backup of the popped prompt in engine data for retry on failure.
+			if ( property_exists( $this, 'job_id' ) && ! empty( $this->job_id ) ) {
+				\datamachine_merge_engine_data(
+					$this->job_id,
+					array(
+						'queued_prompt_backup' => array(
+							'prompt'       => $queued_item['prompt'],
+							'flow_id'      => (int) $flow_id,
+							'flow_step_id' => $this->flow_step_id,
+							'added_at'     => $queued_item['added_at'] ?? null,
+						),
+					)
+				);
+			}
 
 			return array(
 				'value'      => $queued_item['prompt'],

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -127,33 +127,52 @@ function datamachine_register_core_actions() {
 			$status          = \DataMachine\Core\JobStatus::failed( $specific_reason );
 			$success         = $db_jobs->complete_job( $job_id, $status->toString() );
 
-            // Re-queue logic: If a queued prompt was popped but the job failed, add it back to the end of the queue
-            $engine_data = \datamachine_get_engine_data($job_id);
-            if (isset($engine_data['queued_prompt_backup']) && is_array($engine_data['queued_prompt_backup'])) {
-                $backup = $engine_data['queued_prompt_backup'];
-                if (!empty($backup['prompt']) && !empty($backup['flow_id']) && !empty($backup['flow_step_id'])) {
-                    $queue_ability = new \DataMachine\Abilities\Flow\QueueAbility();
-                    $result = $queue_ability->executeQueueAdd([
-                        'flow_id' => (int)$backup['flow_id'],
-                        'flow_step_id' => (string)$backup['flow_step_id'],
-                        'prompt' => $backup['prompt'],
-                    ]);
-                    unset($engine_data['queued_prompt_backup']);
-                    \datamachine_set_engine_data($job_id, $engine_data);
-                    do_action(
-                        'datamachine_log',
-                        'info',
-                        'Prompt re-queued to back due to job failure',
-                        [
-                            'job_id'   => $job_id,
-                            'flow_id'  => (int)$backup['flow_id'],
-                            'flow_step_id' => (string)$backup['flow_step_id'],
-                            'prompt'   => $backup['prompt'],
-                            'queue_result' => $result,
-                        ]
-                    );
-                }
-            }
+			// Re-queue logic: If a queued prompt was popped but the job failed, add it back to the end of the queue.
+			$engine_data = \datamachine_get_engine_data( $job_id );
+			if ( isset( $engine_data['queued_prompt_backup'] ) && is_array( $engine_data['queued_prompt_backup'] ) ) {
+				$backup = $engine_data['queued_prompt_backup'];
+				if ( ! empty( $backup['prompt'] ) && ! empty( $backup['flow_id'] ) && ! empty( $backup['flow_step_id'] ) ) {
+					$queue_ability = new \DataMachine\Abilities\Flow\QueueAbility();
+					$result        = $queue_ability->executeQueueAdd(
+						array(
+							'flow_id'      => (int) $backup['flow_id'],
+							'flow_step_id' => (string) $backup['flow_step_id'],
+							'prompt'       => $backup['prompt'],
+						)
+					);
+
+					if ( ! empty( $result['success'] ) ) {
+						// Only clear backup after successful re-queue.
+						unset( $engine_data['queued_prompt_backup'] );
+						\datamachine_set_engine_data( $job_id, $engine_data );
+						do_action(
+							'datamachine_log',
+							'info',
+							'Prompt re-queued to back due to job failure',
+							array(
+								'job_id'       => $job_id,
+								'flow_id'      => (int) $backup['flow_id'],
+								'flow_step_id' => (string) $backup['flow_step_id'],
+								'prompt'       => $backup['prompt'],
+							)
+						);
+					} else {
+						// Re-queue failed - keep backup so operator can recover manually.
+						do_action(
+							'datamachine_log',
+							'error',
+							'Failed to re-queue prompt after job failure - backup retained in engine_data',
+							array(
+								'job_id'       => $job_id,
+								'flow_id'      => (int) $backup['flow_id'],
+								'flow_step_id' => (string) $backup['flow_step_id'],
+								'prompt'       => $backup['prompt'],
+								'queue_error'  => $result['error'] ?? 'unknown',
+							)
+						);
+					}
+				}
+			}
 
 			if ( ! $success ) {
 				do_action(


### PR DESCRIPTION
## Problem

When a job uses queue pop (QueueableTrait) and fails, the prompt was previously lost forever. Users could lose work in the event of transient failures.

## Solution

Belt-and-suspenders approach — if a job fails after popping from queue, re-add the prompt to the back of the queue.

### Changes

**QueueableTrait.php:**
- After popping a prompt, stores it in engine_data as `queued_prompt_backup`

**DataMachineActions.php:**
- On job failure, checks for `queued_prompt_backup` in engine_data
- If found, re-adds prompt to the BACK of the queue via QueueAbility
- Clears backup from engine_data to prevent duplicate re-queues
- Logs the re-queue action

## Behavior

- Prompt added to BACK of queue (not front)
- No retry counter needed — simple re-queue
- Only re-queues if job actually used a queued prompt
- Backup is cleaned up after re-queue to prevent duplicates

## Testing

- Verified syntax: `php -l` passes on both files
- Live install updated and ready for testing