### PR TITLE
fix(abilities): add Action Scheduler context to permission checks

### DIFF
--- a/inc/Abilities/AgentPing/SendPingAbility.php
+++ b/inc/Abilities/AgentPing/SendPingAbility.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Abilities\AgentPing;
 
+use DataMachine\Abilities\PermissionHelper;
+
 defined( 'ABSPATH' ) || exit;
 
 class SendPingAbility {
@@ -103,13 +105,12 @@ class SendPingAbility {
 	/**
 	 * Check permission for ability execution.
 	 *
+	 * @since 0.20.4 Uses PermissionHelper for Action Scheduler compatibility.
+	 *
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/AgentPingAbilities.php
+++ b/inc/Abilities/AgentPingAbilities.php
@@ -9,6 +9,7 @@
  */
 
 namespace DataMachine\Abilities;
+use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Abilities\AgentPing\SendPingAbility;
 
@@ -36,10 +37,7 @@ class AgentPingAbilities {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/AuthAbilities.php
+++ b/inc/Abilities/AuthAbilities.php
@@ -10,6 +10,7 @@
  */
 
 namespace DataMachine\Abilities;
+use DataMachine\Abilities\PermissionHelper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -293,10 +294,7 @@ class AuthAbilities {
 	}
 
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	public function executeGetAuthStatus( array $input ): array {

--- a/inc/Abilities/FileAbilities.php
+++ b/inc/Abilities/FileAbilities.php
@@ -10,6 +10,8 @@
 
 namespace DataMachine\Abilities;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\FilesRepository\FileCleanup;
@@ -283,10 +285,7 @@ class FileAbilities {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -10,6 +10,7 @@
  */
 
 namespace DataMachine\Abilities\Flow;
+use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Abilities\FlowStepAbilities;
 use DataMachine\Abilities\HandlerAbilities;
@@ -38,10 +39,7 @@ trait FlowHelpers {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/FlowAbilities.php
+++ b/inc/Abilities/FlowAbilities.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Abilities;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Abilities\Flow\GetFlowsAbility;
 use DataMachine\Abilities\Flow\CreateFlowAbility;
 use DataMachine\Abilities\Flow\UpdateFlowAbility;
@@ -77,10 +79,7 @@ class FlowAbilities {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Abilities\FlowStep;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Abilities\HandlerAbilities;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
@@ -35,10 +37,7 @@ trait FlowStepHelpers {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/FlowStepAbilities.php
+++ b/inc/Abilities/FlowStepAbilities.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Abilities;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Abilities\FlowStep\GetFlowStepsAbility;
 use DataMachine\Abilities\FlowStep\UpdateFlowStepAbility;
 use DataMachine\Abilities\FlowStep\ConfigureFlowStepsAbility;
@@ -46,10 +48,7 @@ class FlowStepAbilities {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/HandlerAbilities.php
+++ b/inc/Abilities/HandlerAbilities.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Abilities;
 
+use DataMachine\Abilities\PermissionHelper;
+
 defined( 'ABSPATH' ) || exit;
 
 class HandlerAbilities {
@@ -269,10 +271,7 @@ class HandlerAbilities {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/Job/JobHelpers.php
+++ b/inc/Abilities/Job/JobHelpers.php
@@ -10,6 +10,7 @@
  */
 
 namespace DataMachine\Abilities\Job;
+use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Core\Admin\DateFormatter;
 use DataMachine\Core\Database\Flows\Flows;
@@ -36,10 +37,7 @@ trait JobHelpers {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/JobAbilities.php
+++ b/inc/Abilities/JobAbilities.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Abilities;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Abilities\Job\GetJobsAbility;
 use DataMachine\Abilities\Job\DeleteJobsAbility;
 use DataMachine\Abilities\Job\ExecuteWorkflowAbility;
@@ -55,10 +57,7 @@ class JobAbilities {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/LocalSearchAbilities.php
+++ b/inc/Abilities/LocalSearchAbilities.php
@@ -10,6 +10,7 @@
  */
 
 namespace DataMachine\Abilities;
+use DataMachine\Abilities\PermissionHelper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -73,12 +74,7 @@ class LocalSearchAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'executeLocalSearch' ),
-					'permission_callback' => function () {
-						if ( defined( 'WP_CLI' ) && WP_CLI ) {
-							return true;
-						}
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/LogAbilities.php
+++ b/inc/Abilities/LogAbilities.php
@@ -9,6 +9,7 @@
  */
 
 namespace DataMachine\Abilities;
+use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Engine\Logger;
 use DataMachine\Engine\AI\AgentType;
@@ -67,12 +68,7 @@ class LogAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'write' ),
-					'permission_callback' => function () {
-						if ( defined( 'WP_CLI' ) && WP_CLI ) {
-							return true;
-						}
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -106,12 +102,7 @@ class LogAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'clear' ),
-					'permission_callback' => function () {
-						if ( defined( 'WP_CLI' ) && WP_CLI ) {
-							return true;
-						}
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -168,12 +159,7 @@ class LogAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'readLogs' ),
-					'permission_callback' => function () {
-						if ( defined( 'WP_CLI' ) && WP_CLI ) {
-							return true;
-						}
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -205,12 +191,7 @@ class LogAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'getMetadata' ),
-					'permission_callback' => function () {
-						if ( defined( 'WP_CLI' ) && WP_CLI ) {
-							return true;
-						}
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -248,12 +229,7 @@ class LogAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'setLevel' ),
-					'permission_callback' => function () {
-						if ( defined( 'WP_CLI' ) && WP_CLI ) {
-							return true;
-						}
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -285,12 +261,7 @@ class LogAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'getLevel' ),
-					'permission_callback' => function () {
-						if ( defined( 'WP_CLI' ) && WP_CLI ) {
-							return true;
-						}
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/Media/AltTextAbilities.php
+++ b/inc/Abilities/Media/AltTextAbilities.php
@@ -10,6 +10,7 @@
  */
 
 namespace DataMachine\Abilities\Media;
+use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\RequestBuilder;
@@ -76,12 +77,7 @@ class AltTextAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'generateAltText' ),
-					'permission_callback' => function () {
-						if ( defined( 'WP_CLI' ) && WP_CLI ) {
-							return true;
-						}
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => false ),
 				)
 			);
@@ -109,12 +105,7 @@ class AltTextAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'diagnoseAltText' ),
-					'permission_callback' => function () {
-						if ( defined( 'WP_CLI' ) && WP_CLI ) {
-							return true;
-						}
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Permission helper for Data Machine abilities.
+ *
+ * @package DataMachine\Abilities
+ * @since 0.20.4
+ */
+
+namespace DataMachine\Abilities;
+
+/**
+ * Helper class for ability permission checks.
+ *
+ * Centralizes permission logic to handle:
+ * - WP-CLI commands
+ * - Action Scheduler background processing
+ * - Standard user capability checks
+ */
+class PermissionHelper {
+
+	/**
+	 * Check if current context has admin-level permissions.
+	 *
+	 * Allows execution in:
+	 * - WP-CLI context (command line)
+	 * - Action Scheduler background processing (scheduled jobs)
+	 * - Standard requests with logged-in admin user
+	 *
+	 * @since 0.20.4
+	 *
+	 * @return bool True if permission granted.
+	 */
+	public static function can_manage(): bool {
+		// WP-CLI always allowed.
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return true;
+		}
+
+		// Action Scheduler background processing context.
+		// This is needed because async requests may not have user cookies.
+		if ( doing_action( 'action_scheduler_run_queue' ) ) {
+			return true;
+		}
+
+		// Standard capability check for logged-in users.
+		return current_user_can( 'manage_options' );
+	}
+}

--- a/inc/Abilities/Pipeline/PipelineHelpers.php
+++ b/inc/Abilities/Pipeline/PipelineHelpers.php
@@ -10,6 +10,7 @@
  */
 
 namespace DataMachine\Abilities\Pipeline;
+use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Abilities\HandlerAbilities;
 use DataMachine\Abilities\StepTypeAbilities;
@@ -35,10 +36,7 @@ trait PipelineHelpers {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/PipelineAbilities.php
+++ b/inc/Abilities/PipelineAbilities.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Abilities;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Abilities\Pipeline\GetPipelinesAbility;
 use DataMachine\Abilities\Pipeline\CreatePipelineAbility;
 use DataMachine\Abilities\Pipeline\UpdatePipelineAbility;
@@ -52,10 +54,7 @@ class PipelineAbilities {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -10,6 +10,8 @@
 
 namespace DataMachine\Abilities;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
@@ -278,10 +280,7 @@ class PipelineStepAbilities {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/PostQueryAbilities.php
+++ b/inc/Abilities/PostQueryAbilities.php
@@ -10,6 +10,7 @@
  */
 
 namespace DataMachine\Abilities;
+use DataMachine\Abilities\PermissionHelper;
 
 use const DataMachine\Core\WordPress\DATAMACHINE_POST_HANDLER_META_KEY;
 use const DataMachine\Core\WordPress\DATAMACHINE_POST_FLOW_ID_META_KEY;
@@ -105,12 +106,7 @@ class PostQueryAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'executeQueryPosts' ),
-					'permission_callback' => function () {
-						if ( defined( 'WP_CLI' ) && WP_CLI ) {
-							return true;
-						}
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/ProcessedItemsAbilities.php
+++ b/inc/Abilities/ProcessedItemsAbilities.php
@@ -12,6 +12,8 @@
 
 namespace DataMachine\Abilities;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 
 defined( 'ABSPATH' ) || exit;
@@ -176,10 +178,7 @@ class ProcessedItemsAbilities {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -9,6 +9,7 @@
  */
 
 namespace DataMachine\Abilities;
+use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Core\PluginSettings;
 
@@ -289,10 +290,7 @@ class SettingsAbilities {
 	}
 
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	public function executeGetSettings( array $input ): array {

--- a/inc/Abilities/StepTypeAbilities.php
+++ b/inc/Abilities/StepTypeAbilities.php
@@ -10,6 +10,7 @@
  */
 
 namespace DataMachine\Abilities;
+use DataMachine\Abilities\PermissionHelper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -128,10 +129,7 @@ class StepTypeAbilities {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -10,6 +10,7 @@
  */
 
 namespace DataMachine\Abilities;
+use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Engine\AI\RequestBuilder;
 use DataMachine\Engine\AI\AgentType;
@@ -85,12 +86,7 @@ class SystemAbilities {
 					),
 				),
 				'execute_callback'    => array( self::class, 'generateSessionTitle' ),
-				'permission_callback' => function () {
-					if ( defined('WP_CLI') && WP_CLI ) {
-						return true;
-					}
-					return current_user_can('manage_options');
-				},
+				'permission_callback' => fn() => PermissionHelper::can_manage(),
 				'meta'                => array( 'show_in_rest' => false ),
 			)
 		);
@@ -130,12 +126,7 @@ class SystemAbilities {
 					),
 				),
 				'execute_callback'    => array( $this, 'executeHealthCheck' ),
-				'permission_callback' => function () {
-					if ( defined('WP_CLI') && WP_CLI ) {
-						return true;
-					}
-					return current_user_can('manage_options');
-				},
+				'permission_callback' => fn() => PermissionHelper::can_manage(),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
 		);

--- a/inc/Abilities/Taxonomy/CreateTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/CreateTaxonomyTermAbility.php
@@ -10,6 +10,8 @@
 
 namespace DataMachine\Abilities\Taxonomy;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Core\WordPress\TaxonomyHandler;
 
 defined( 'ABSPATH' ) || exit;
@@ -217,9 +219,6 @@ class CreateTaxonomyTermAbility {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 }

--- a/inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php
@@ -10,6 +10,8 @@
 
 namespace DataMachine\Abilities\Taxonomy;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Core\WordPress\TaxonomyHandler;
 
 defined( 'ABSPATH' ) || exit;
@@ -198,9 +200,6 @@ class DeleteTaxonomyTermAbility {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 }

--- a/inc/Abilities/Taxonomy/GetTaxonomyTermsAbility.php
+++ b/inc/Abilities/Taxonomy/GetTaxonomyTermsAbility.php
@@ -10,6 +10,8 @@
 
 namespace DataMachine\Abilities\Taxonomy;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Core\WordPress\TaxonomyHandler;
 
 defined( 'ABSPATH' ) || exit;
@@ -198,9 +200,6 @@ class GetTaxonomyTermsAbility {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 }

--- a/inc/Abilities/Taxonomy/ResolveTermAbility.php
+++ b/inc/Abilities/Taxonomy/ResolveTermAbility.php
@@ -10,6 +10,8 @@
 
 namespace DataMachine\Abilities\Taxonomy;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Core\WordPress\TaxonomyHandler;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -196,10 +198,7 @@ class ResolveTermAbility {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php
@@ -10,6 +10,8 @@
 
 namespace DataMachine\Abilities\Taxonomy;
 
+use DataMachine\Abilities\PermissionHelper;
+
 use DataMachine\Core\WordPress\TaxonomyHandler;
 
 defined( 'ABSPATH' ) || exit;
@@ -267,9 +269,6 @@ class UpdateTaxonomyTermAbility {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 }

--- a/inc/Abilities/TaxonomyAbilities.php
+++ b/inc/Abilities/TaxonomyAbilities.php
@@ -10,6 +10,7 @@
  */
 
 namespace DataMachine\Abilities;
+use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Abilities\Taxonomy\GetTaxonomyTermsAbility;
 use DataMachine\Abilities\Taxonomy\CreateTaxonomyTermAbility;
@@ -49,10 +50,7 @@ class TaxonomyAbilities {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return true;
-		}
-		return current_user_can( 'manage_options' );
+		return PermissionHelper::can_manage();
 	}
 
 	/**


### PR DESCRIPTION
## Problem

Action Scheduler's async requests forward `$_COOKIE` from the dispatch context. When no admin is logged in during dispatch (e.g., from cron or another async request), `current_user_can('manage_options')` returns false, causing ability permission checks to fail intermittently.

**Evidence:**
- Jobs 861-863 failed at 18:26:25 with 'does not have necessary permission'
- Same flows succeeded at other times when admin cookies were present
- All via 'Async Request' method - the difference was cookie context

## Solution

Added `PermissionHelper::can_manage()` that checks for:
1. WP-CLI context (`defined('WP_CLI') && WP_CLI`)
2. Action Scheduler background processing (`doing_action('action_scheduler_run_queue')`)
3. Standard user capability (`current_user_can('manage_options')`)

Updated all 28 ability files to use this centralized helper.

## Changes

- New: `inc/Abilities/PermissionHelper.php` - centralized permission logic
- Modified: All ability classes to use `PermissionHelper::can_manage()` instead of inline checks

## Testing

- Verified PHP syntax on all modified files
- Logic maintains same behavior for WP-CLI and admin users
- Adds explicit allow for Action Scheduler context