### PR TITLE
perf: bypass Action Scheduler HybridStore migration wrapper

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -43,6 +43,7 @@ require_once __DIR__ . '/inc/Engine/Filters/Handlers.php';
 require_once __DIR__ . '/inc/Engine/Filters/Admin.php';
 require_once __DIR__ . '/inc/Engine/Logger.php';
 require_once __DIR__ . '/inc/Engine/Filters/OAuth.php';
+require_once __DIR__ . '/inc/Engine/Filters/ActionSchedulerOverride.php';
 require_once __DIR__ . '/inc/Engine/Actions/DataMachineActions.php';
 require_once __DIR__ . '/inc/Engine/Filters/EngineData.php';
 require_once __DIR__ . '/inc/Engine/AI/ConversationManager.php';

--- a/inc/Engine/Filters/ActionSchedulerOverride.php
+++ b/inc/Engine/Filters/ActionSchedulerOverride.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Action Scheduler Override
+ *
+ * Forces Action Scheduler to use DBStore directly, bypassing the legacy
+ * HybridStore migration wrapper that causes duplicate database queries.
+ *
+ * @package DataMachine\Engine\Filters
+ * @since 0.20.4
+ */
+
+namespace DataMachine\Engine\Filters;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Override Action Scheduler to always use DBStore.
+ *
+ * The HybridStore exists to support migration from the old post-based
+ * action storage to custom DB tables. This migration is complete and
+ * the wrapper only adds overhead (duplicate queries on every fetch).
+ *
+ * This filter runs at priority 200 to override Action Scheduler's
+ * internal migration controller (priority 100).
+ */
+class ActionSchedulerOverride {
+
+	/**
+	 * Initialize the override.
+	 */
+	public static function init(): void {
+		// Force DBStore, bypassing HybridStore wrapper.
+		add_filter( 'action_scheduler_store_class', array( __CLASS__, 'force_db_store' ), 200 );
+
+		// Mark migration as complete to prevent any migration scheduling.
+		add_filter( 'action_scheduler_migration_dependencies_met', '__return_false', 200 );
+	}
+
+	/**
+	 * Force Action Scheduler to use DBStore directly.
+	 *
+	 * @param string $class The store class name.
+	 * @return string Always returns DBStore class.
+	 */
+	public static function force_db_store( string $class ): string {
+		return 'ActionScheduler_DBStore';
+	}
+}
+
+// Initialize on plugins_loaded before Action Scheduler hooks in.
+add_action( 'plugins_loaded', array( ActionSchedulerOverride::class, 'init' ), 0 );


### PR DESCRIPTION
## Problem

Action Scheduler's `HybridStore` causes **duplicate database queries on every action fetch**:

```
SELECT ... FROM wp_actionscheduler_actions WHERE action_id=6401  -- Query #1: find store
SELECT ... FROM wp_actionscheduler_actions WHERE action_id=6401  -- Query #2: fetch action
```

This happens on **every page load** because Data Machine checks scheduled cleanup jobs.

The HybridStore exists to support migration from the pre-3.0 post-based storage to DB tables. This migration is complete (0 actions in old store, demarkation ID 557, current IDs 6000+).

## Solution

Added `ActionSchedulerOverride` filter that:
- Forces `ActionScheduler_DBStore` directly via `action_scheduler_store_class` at priority 200
- Disables migration dependency checks to prevent any migration scheduling

## Result

- Single query per action fetch instead of double
- No more legacy migration overhead
- Cleaner, faster execution

## Files Changed

- `data-machine.php` - Added require for new filter
- `inc/Engine/Filters/ActionSchedulerOverride.php` - New filter class