### PR TITLE
perf: only check scheduled cleanup jobs in admin context

### DIFF
--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -639,11 +639,15 @@ add_action(
 );
 
 /**
- * Schedule chat session cleanup after Action Scheduler is initialized
+ * Schedule chat session cleanup after Action Scheduler is initialized.
+ * Only check in admin context to avoid database queries on every frontend request.
  */
 add_action(
 	'action_scheduler_init',
 	function () {
+		if ( ! is_admin() ) {
+			return;
+		}
 		// Daily cleanup of old sessions
 		if ( ! as_next_scheduled_action( 'datamachine_cleanup_chat_sessions', array(), 'datamachine-chat' ) ) {
 			as_schedule_recurring_action(

--- a/inc/Core/FilesRepository/FileCleanup.php
+++ b/inc/Core/FilesRepository/FileCleanup.php
@@ -237,11 +237,15 @@ add_action(
 );
 
 /**
- * Schedule cleanup after Action Scheduler is fully initialized
+ * Schedule cleanup after Action Scheduler is fully initialized.
+ * Only check in admin context to avoid database queries on every frontend request.
  */
 add_action(
 	'action_scheduler_init',
 	function () {
+		if ( ! is_admin() ) {
+			return;
+		}
 		if ( ! as_next_scheduled_action( 'datamachine_cleanup_old_files', array(), 'datamachine-files' ) ) {
 			as_schedule_recurring_action(
 				time() + WEEK_IN_SECONDS,


### PR DESCRIPTION
## Problem

`action_scheduler_init` fires on **every request**. Two places were checking `as_next_scheduled_action()` on this hook:

- `FileCleanup.php` - checks if file cleanup job is scheduled
- `Chat.php` - checks if chat session cleanup job is scheduled

This caused unnecessary database queries on every frontend page load.

## Fix

Wrapped both checks in `is_admin()` - jobs only need to be verified/scheduled from admin context.

## Result

- Frontend requests: no scheduler queries
- Admin requests: still verify jobs are scheduled
- Zero risk: if somehow the job gets unscheduled, first admin page load will reschedule it