### PR TITLE
CLI: Add prompt support to flows command

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Data Machine will be documented in this file. Also viewable at: 
 
 
+## Unreleased
+
+- CLI: Added --set-prompt option to flows update command for updating handler step prompts via WP-CLI
+- CLI: flows get now shows prompt preview column (truncated to 50 chars)
+
 ## [0.21.1] - 2026-02-05
 
 ### Added


### PR DESCRIPTION
## Summary

Adds the ability to read and update flow step prompts via WP-CLI.

## Problem

The CLI `flows get` command didn't show prompts, and `flows update` couldn't update them. This made it impossible for agents to audit or modify flow prompts programmatically.

The prompt data IS stored (in `flow_config → step → handler_config.prompt`), but the CLI didn't expose it.

## Solution

**`flows get` changes:**
- Added `prompt` column to default output fields
- Shows truncated preview (first 47 chars + `...` if longer)
- Checks both `handler_config.prompt` and `pipeline_config.prompt`

**`flows update` changes:**
- Added `--set-prompt=<text>` option (named `set-prompt` to avoid conflict with WP-CLI's built-in `--prompt` global option)
- Added `--step=<flow_step_id>` option for targeting specific steps
- Auto-resolves handler step when flow has exactly one
- Uses existing `UpdateFlowStepAbility` to merge `handler_config.prompt`

## Usage

```bash
# View prompts
wp datamachine flows get 44

# Update prompt (auto-resolves step)
wp datamachine flows update 44 --set-prompt="New prompt text"

# Update specific step in multi-step flow
wp datamachine flows update 44 --step=flow-42-step-abc123 --set-prompt="Step-specific prompt"
```

## Testing

Tested on production site:
- `flows get 44 --format=json` shows prompt preview ✅
- `flows update 44 --set-prompt="test"` updates the prompt ✅
- Auto-resolution works for single-handler flows ✅
- Error messages guide users when multiple handler steps exist ✅