### PR TITLE
Fix prompt display when queue enabled but empty

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -3,7 +3,7 @@
  * Plugin Name:     Data Machine
  * Plugin URI:      https://wordpress.org/plugins/data-machine/
  * Description:     AI-powered WordPress plugin for automated content workflows with visual pipeline builder and multi-provider AI integration.
- * Version:           0.21.2
+ * Version:           0.21.1
  * Requires at least: 6.9
  * Requires PHP:     8.2
  * Author:          Chris Huber, extrachill

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,11 +3,10 @@
 All notable changes to Data Machine will be documented in this file. Also viewable at: 
 
 
-## [0.21.2] - 2026-02-09
+## Unreleased
 
 - CLI: Added --set-prompt option to flows update command for updating handler step prompts via WP-CLI
 - CLI: flows get now shows prompt preview column (truncated to 50 chars)
-- Fix prompt display when queue enabled but empty - shows stored prompt instead of blank field
 
 ## [0.21.1] - 2026-02-05
 


### PR DESCRIPTION
## Problem
When `queue_enabled` is `true` but `prompt_queue` is empty, the UI shows a blank prompt field instead of the stored `handler_config.prompt`.

This was causing Flow 44's alt text maintenance prompt to appear blank in the UI even though the data was correctly stored in the database.

## Root Cause
`getPromptValue()` in FlowStepCard.jsx returned empty string when `shouldUseQueue` was true but queue had no items:
```javascript
if ( shouldUseQueue ) {
    return queueHasItems ? firstQueuePrompt : '';  // Bug: returns '' when queue empty
}
```

## Fix
Changed logic to fall back to stored prompt when queue is empty:
```javascript
if ( queueHasItems ) {
    return firstQueuePrompt;
}
// Falls through to return stored prompt
```

## Testing
- Verified Flow 44 data exists correctly in database via `datamachine/get-flows` ability
- Built and deployed to production
- Prompt now displays correctly when queue is enabled but empty

## Version
v0.21.2 (patch bump)