### PR TITLE
feat: add duplicate detection to queue-add ability

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Data Machine will be documented in this file. Also viewable at: 
 
 
+## Unreleased
+
+- Queue validation: queue-add ability now checks for duplicate prompts in queue and similar existing posts before adding
+
 ## [0.21.4] - 2026-02-08
 
 - Fix: pin webpack to 5.104.1 for security; remove legacy CircleCI config


### PR DESCRIPTION
## Summary
Adds duplicate detection to the `datamachine/queue-add` ability to prevent wasted AI cycles on content that already exists.

## Changes
- Check for exact duplicates already in queue (case-insensitive)
- Check for similar existing posts by extracting core topic from prompt
- Return error with existing post info if duplicate found

## Why
Job failures were occurring because:
1. Prompts were added to queue without checking for existing content
2. AI would find duplicates via `local_search` at runtime
3. gpt-5-mini would stop without calling `skip_item()`, causing empty data packets
4. Failed jobs get re-queued → infinite failure loop

This moves duplicate detection **upstream** where it belongs, rather than relying on runtime AI behavior.

## Example
```php
// Before: silently adds duplicate
queue-add("The Spiritual Meaning of Red Roses")

// After: returns error
{
  "success": false,
  "error": "Duplicate: Similar post already exists: 'The Spiritual Meaning of Red Roses' (ID 4667)",
  "existing_post": {"id": 4667, "title": "The Spiritual Meaning of Red Roses"}
}
```