### PR TITLE
fix: remove hardcoded agent_type=system from operational logs

### DIFF
--- a/inc/Abilities/AuthAbilities.php
+++ b/inc/Abilities/AuthAbilities.php
@@ -99,7 +99,6 @@ class AuthAbilities {
 				'debug',
 				'Resolved auth provider key differs from handler slug',
 				array(
-					'agent_type'        => 'system',
 					'handler_slug'      => $handler_slug,
 					'auth_provider_key' => $auth_provider_key,
 				)

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -47,7 +47,6 @@ class Flows {
 			'debug',
 			'Flows table creation completed',
 			array(
-				'agent_type' => 'system',
 				'table_name' => $table_name,
 				'result'     => $result,
 			)

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -122,7 +122,6 @@ class Jobs {
 			'debug',
 			'Created jobs database table with pipeline+flow architecture',
 			array(
-				'agent_type' => 'system',
 				'table_name' => $table_name,
 				'action'     => 'create_table',
 			)
@@ -169,7 +168,6 @@ class Jobs {
 				'info',
 				'Migrated jobs.status column to varchar(255)',
 				array(
-					'agent_type'    => 'system',
 					'table_name'    => $table_name,
 					'previous_size' => $columns['status']->CHARACTER_MAXIMUM_LENGTH,
 				)
@@ -185,7 +183,6 @@ class Jobs {
 				'info',
 				'Migrated jobs.pipeline_id column to varchar(20) for direct execution support',
 				array(
-					'agent_type' => 'system',
 					'table_name' => $table_name,
 				)
 			);
@@ -200,7 +197,6 @@ class Jobs {
 				'info',
 				'Migrated jobs.flow_id column to varchar(20) for direct execution support',
 				array(
-					'agent_type' => 'system',
 					'table_name' => $table_name,
 				)
 			);

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -265,7 +265,6 @@ class ProcessedItems {
 			'debug',
 			'Created processed items database table',
 			array(
-				'agent_type' => 'system',
 				'table_name' => $this->table_name,
 				'action'     => 'create_table',
 			)

--- a/inc/Core/OAuth/OAuth1Handler.php
+++ b/inc/Core/OAuth/OAuth1Handler.php
@@ -55,7 +55,6 @@ class OAuth1Handler {
 					'error',
 					'OAuth1: Failed to get request token',
 					array(
-						'agent_type' => 'system',
 						'provider'   => $provider_key,
 						'http_code'  => $connection->getLastHttpCode(),
 						'response'   => $connection->getLastBody(),
@@ -81,7 +80,6 @@ class OAuth1Handler {
 				'debug',
 				'OAuth1: Request token obtained',
 				array(
-					'agent_type'  => 'system',
 					'provider'    => $provider_key,
 					'oauth_token' => substr( $request_token['oauth_token'], 0, 10 ) . '...',
 				)
@@ -94,7 +92,6 @@ class OAuth1Handler {
 				'error',
 				'OAuth1: Exception getting request token',
 				array(
-					'agent_type' => 'system',
 					'provider'   => $provider_key,
 					'error'      => $e->getMessage(),
 				)
@@ -131,7 +128,6 @@ class OAuth1Handler {
 			'debug',
 			'OAuth1: Built authorization URL',
 			array(
-				'agent_type'  => 'system',
 				'provider'    => $provider_key,
 				'oauth_token' => substr( $oauth_token, 0, 10 ) . '...',
 			)
@@ -168,7 +164,6 @@ class OAuth1Handler {
 				'error',
 				'OAuth1: Callback nonce verification failed',
 				array(
-					'agent_type' => 'system',
 					'provider'   => $provider_key,
 				)
 			);
@@ -190,7 +185,6 @@ class OAuth1Handler {
 				'warning',
 				'OAuth1: User denied access',
 				array(
-					'agent_type'   => 'system',
 					'provider'     => $provider_key,
 					'denied_token' => substr( $denied, 0, 10 ) . '...',
 				)
@@ -207,7 +201,6 @@ class OAuth1Handler {
 				'error',
 				'OAuth1: Missing callback parameters',
 				array(
-					'agent_type'   => 'system',
 					'provider'     => $provider_key,
 					'has_token'    => ! empty( $oauth_token ),
 					'has_verifier' => ! empty( $oauth_verifier ),
@@ -227,7 +220,6 @@ class OAuth1Handler {
 				'error',
 				'OAuth1: Token secret missing or expired',
 				array(
-					'agent_type'  => 'system',
 					'provider'    => $provider_key,
 					'oauth_token' => substr( $oauth_token, 0, 10 ) . '...',
 				)
@@ -257,7 +249,6 @@ class OAuth1Handler {
 					'error',
 					'OAuth1: Failed to get access token',
 					array(
-						'agent_type' => 'system',
 						'provider'   => $provider_key,
 						'http_code'  => $connection->getLastHttpCode(),
 						'response'   => $connection->getLastBody(),
@@ -281,7 +272,6 @@ class OAuth1Handler {
 					'error',
 					'OAuth1: No storage callback provided',
 					array(
-						'agent_type' => 'system',
 						'provider'   => $provider_key,
 					)
 				);
@@ -293,7 +283,6 @@ class OAuth1Handler {
 					'error',
 					'OAuth1: Failed to store account data',
 					array(
-						'agent_type' => 'system',
 						'provider'   => $provider_key,
 					)
 				);
@@ -307,7 +296,6 @@ class OAuth1Handler {
 				'info',
 				'OAuth1: Authentication successful',
 				array(
-					'agent_type' => 'system',
 					'provider'   => $provider_key,
 					'user_id'    => $account_data['user_id'] ?? 'unknown',
 				)
@@ -322,7 +310,6 @@ class OAuth1Handler {
 				'error',
 				'OAuth1: Exception during callback',
 				array(
-					'agent_type' => 'system',
 					'provider'   => $provider_key,
 					'error'      => $e->getMessage(),
 				)

--- a/inc/Core/OAuth/OAuth2Handler.php
+++ b/inc/Core/OAuth/OAuth2Handler.php
@@ -35,7 +35,6 @@ class OAuth2Handler {
 			'debug',
 			'OAuth2: Created state nonce',
 			array(
-				'agent_type'   => 'system',
 				'provider'     => $provider_key,
 				'state_length' => strlen( $state ),
 			)
@@ -64,7 +63,6 @@ class OAuth2Handler {
 			$is_valid ? 'debug' : 'error',
 			'OAuth2: State verification',
 			array(
-				'agent_type' => 'system',
 				'provider'   => $provider_key,
 				'valid'      => $is_valid,
 			)
@@ -88,7 +86,6 @@ class OAuth2Handler {
 			'debug',
 			'OAuth2: Built authorization URL',
 			array(
-				'agent_type'  => 'system',
 				'auth_url'    => $auth_url,
 				'param_count' => count( $params ),
 			)
@@ -137,7 +134,6 @@ class OAuth2Handler {
 				'error',
 				'OAuth2: Provider returned error',
 				array(
-					'agent_type' => 'system',
 					'provider'   => $provider_key,
 					'error'      => $error,
 				)
@@ -154,7 +150,6 @@ class OAuth2Handler {
 				'error',
 				'OAuth2: State verification failed',
 				array(
-					'agent_type' => 'system',
 					'provider'   => $provider_key,
 				)
 			);
@@ -172,7 +167,6 @@ class OAuth2Handler {
 				'error',
 				'OAuth2: Token exchange failed',
 				array(
-					'agent_type' => 'system',
 					'provider'   => $provider_key,
 					'error'      => $token_data->get_error_message(),
 				)
@@ -192,7 +186,6 @@ class OAuth2Handler {
 					'error',
 					'OAuth2: Token transformation failed',
 					array(
-						'agent_type' => 'system',
 						'provider'   => $provider_key,
 						'error'      => $token_data->get_error_message(),
 					)
@@ -212,7 +205,6 @@ class OAuth2Handler {
 				'error',
 				'OAuth2: Failed to retrieve account details',
 				array(
-					'agent_type' => 'system',
 					'provider'   => $provider_key,
 					'error'      => $account_data->get_error_message(),
 				)
@@ -232,7 +224,6 @@ class OAuth2Handler {
 				'error',
 				'OAuth2: No storage callback provided',
 				array(
-					'agent_type' => 'system',
 					'provider'   => $provider_key,
 				)
 			);
@@ -244,7 +235,6 @@ class OAuth2Handler {
 				'error',
 				'OAuth2: Failed to store account data',
 				array(
-					'agent_type' => 'system',
 					'provider'   => $provider_key,
 				)
 			);
@@ -258,7 +248,6 @@ class OAuth2Handler {
 			'info',
 			'OAuth2: Authentication successful',
 			array(
-				'agent_type' => 'system',
 				'provider'   => $provider_key,
 				'account_id' => $account_data['id'] ?? 'unknown',
 			)

--- a/inc/Core/OAuth/Providers/GoogleSheetsAuth.php
+++ b/inc/Core/OAuth/Providers/GoogleSheetsAuth.php
@@ -78,11 +78,11 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	 * @return string|\WP_Error Access token or error
 	 */
 	public function get_service() {
-		do_action( 'datamachine_log', 'debug', 'Attempting to get authenticated Google Sheets access token.', array( 'agent_type' => 'system' ) );
+		do_action( 'datamachine_log', 'debug', 'Attempting to get authenticated Google Sheets access token.', array() );
 
 		$credentials = $this->get_account();
 		if ( empty( $credentials ) || empty( $credentials['access_token'] ) || empty( $credentials['refresh_token'] ) ) {
-			do_action( 'datamachine_log', 'error', 'Missing Google Sheets credentials in options.', array( 'agent_type' => 'system' ) );
+			do_action( 'datamachine_log', 'error', 'Missing Google Sheets credentials in options.', array() );
 			return new \WP_Error( 'googlesheets_missing_credentials', __( 'Google Sheets credentials not found. Please authenticate.', 'data-machine' ) );
 		}
 
@@ -92,7 +92,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 		// Check if access token needs refreshing (Google-specific logic)
 		$expires_at = $credentials['expires_at'] ?? 0;
 		if ( time() >= $expires_at - 300 ) { // Refresh 5 minutes before expiry
-			do_action( 'datamachine_log', 'debug', 'Google Sheets access token expired, attempting refresh.', array( 'agent_type' => 'system' ) );
+			do_action( 'datamachine_log', 'debug', 'Google Sheets access token expired, attempting refresh.', array() );
 
 			$refreshed_token = $this->refresh_access_token( $refresh_token );
 			if ( is_wp_error( $refreshed_token ) ) {
@@ -102,7 +102,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 			return $refreshed_token;
 		}
 
-		do_action( 'datamachine_log', 'debug', 'Successfully retrieved valid Google Sheets access token.', array( 'agent_type' => 'system' ) );
+		do_action( 'datamachine_log', 'debug', 'Successfully retrieved valid Google Sheets access token.', array() );
 		return $access_token;
 	}
 
@@ -118,7 +118,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 		$client_secret = $config['client_secret'] ?? '';
 
 		if ( empty( $client_id ) || empty( $client_secret ) ) {
-			do_action( 'datamachine_log', 'error', 'Missing Google OAuth client credentials.', array( 'agent_type' => 'system' ) );
+			do_action( 'datamachine_log', 'error', 'Missing Google OAuth client credentials.', array() );
 			return new \WP_Error( 'googlesheets_missing_oauth_config', __( 'Google OAuth configuration is incomplete.', 'data-machine' ) );
 		}
 
@@ -141,7 +141,6 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 				'error',
 				'Google token refresh request failed.',
 				array(
-					'agent_type' => 'system',
 					'error'      => $result['error'],
 				)
 			);
@@ -157,7 +156,6 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 				'error',
 				'Google token refresh failed.',
 				array(
-					'agent_type'    => 'system',
 					'response_code' => $response_code,
 					'response_body' => $response_body,
 				)
@@ -167,14 +165,14 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 
 		$token_data = json_decode( $response_body, true );
 		if ( empty( $token_data['access_token'] ) ) {
-			do_action( 'datamachine_log', 'error', 'Invalid token refresh response from Google.', array( 'agent_type' => 'system' ) );
+			do_action( 'datamachine_log', 'error', 'Invalid token refresh response from Google.', array() );
 			return new \WP_Error( 'googlesheets_invalid_refresh_response', __( 'Invalid response from Google during token refresh.', 'data-machine' ) );
 		}
 
 		// Update stored credentials
 		$this->update_credentials( $token_data['access_token'], $refresh_token, $token_data['expires_in'] ?? 3600 );
 
-		do_action( 'datamachine_log', 'debug', 'Successfully refreshed Google Sheets access token.', array( 'agent_type' => 'system' ) );
+		do_action( 'datamachine_log', 'debug', 'Successfully refreshed Google Sheets access token.', array() );
 		return $token_data['access_token'];
 	}
 
@@ -211,7 +209,6 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 				'error',
 				'Google Sheets OAuth Error: Client ID not configured.',
 				array(
-					'agent_type' => 'system',
 					'handler'    => 'googlesheets',
 					'operation'  => 'get_authorization_url',
 				)
@@ -249,7 +246,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 		$client_secret = $config['client_secret'] ?? '';
 
 		if ( empty( $client_id ) || empty( $client_secret ) ) {
-			do_action( 'datamachine_log', 'error', 'Google Sheets OAuth Error: Missing configuration', array( 'agent_type' => 'system' ) );
+			do_action( 'datamachine_log', 'error', 'Google Sheets OAuth Error: Missing configuration', array() );
 			wp_safe_redirect(
 				add_query_arg(
 					array(

--- a/inc/Core/Steps/Fetch/Handlers/GoogleSheets/GoogleSheetsFetch.php
+++ b/inc/Core/Steps/Fetch/Handlers/GoogleSheets/GoogleSheetsFetch.php
@@ -57,7 +57,6 @@ class GoogleSheetsFetch extends FetchHandler {
 					'error',
 					'Google Sheets Handler: Authentication service not available',
 					array(
-						'agent_type'          => 'system',
 						'handler'             => 'googlesheets',
 						'missing_service'     => 'googlesheets',
 						'available_providers' => array_keys( $auth_abilities->getAllProviders() ),

--- a/inc/Core/Steps/Fetch/Handlers/Reddit/Reddit.php
+++ b/inc/Core/Steps/Fetch/Handlers/Reddit/Reddit.php
@@ -53,7 +53,6 @@ class Reddit extends FetchHandler {
 					'error',
 					'Reddit Handler: Authentication service not available',
 					array(
-						'agent_type'          => 'system',
 						'handler'             => 'reddit',
 						'missing_service'     => 'reddit',
 						'available_providers' => array_keys( $auth_abilities->getAllProviders() ),

--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -348,7 +348,6 @@ add_action(
 			'error',
 			'AI Library Error: ' . $error_data['component'] . ' - ' . $error_data['message'],
 			array(
-				'agent_type' => 'system',
 				'component'  => $error_data['component'],
 				'message'    => $error_data['message'],
 				'context'    => $error_data['context'],

--- a/inc/Engine/AI/Directives/DirectiveOutputValidator.php
+++ b/inc/Engine/AI/Directives/DirectiveOutputValidator.php
@@ -25,20 +25,20 @@ class DirectiveOutputValidator {
 
 		foreach ( $outputs as $output ) {
 			if ( ! is_array( $output ) ) {
-				do_action( 'datamachine_log', 'warning', 'Directive output skipped (not an array)', array( 'agent_type' => 'system' ) + $context );
+				do_action( 'datamachine_log', 'warning', 'Directive output skipped (not an array)', $context );
 				continue;
 			}
 
 			$type = $output['type'] ?? null;
 			if ( ! is_string( $type ) || '' === $type ) {
-				do_action( 'datamachine_log', 'warning', 'Directive output skipped (missing type)', array( 'agent_type' => 'system' ) + $context );
+				do_action( 'datamachine_log', 'warning', 'Directive output skipped (missing type)', $context );
 				continue;
 			}
 
 			if ( 'system_text' === $type ) {
 				$content = $output['content'] ?? null;
 				if ( ! is_string( $content ) ) {
-					do_action( 'datamachine_log', 'warning', 'Directive output skipped (system_text missing content)', array( 'agent_type' => 'system' ) + $context );
+					do_action( 'datamachine_log', 'warning', 'Directive output skipped (system_text missing content)', $context );
 					continue;
 				}
 
@@ -60,12 +60,12 @@ class DirectiveOutputValidator {
 				$data  = $output['data'] ?? null;
 
 				if ( ! is_string( $label ) || trim( $label ) === '' ) {
-					do_action( 'datamachine_log', 'warning', 'Directive output skipped (system_json missing label)', array( 'agent_type' => 'system' ) + $context );
+					do_action( 'datamachine_log', 'warning', 'Directive output skipped (system_json missing label)', $context );
 					continue;
 				}
 
 				if ( ! is_array( $data ) ) {
-					do_action( 'datamachine_log', 'warning', 'Directive output skipped (system_json missing data)', array( 'agent_type' => 'system' ) + $context );
+					do_action( 'datamachine_log', 'warning', 'Directive output skipped (system_json missing data)', $context );
 					continue;
 				}
 
@@ -83,7 +83,7 @@ class DirectiveOutputValidator {
 				$mime_type = $output['mime_type'] ?? null;
 
 				if ( ! is_string( $file_path ) || trim( $file_path ) === '' || ! is_string( $mime_type ) || trim( $mime_type ) === '' ) {
-					do_action( 'datamachine_log', 'warning', 'Directive output skipped (system_file missing file_path or mime_type)', array( 'agent_type' => 'system' ) + $context );
+					do_action( 'datamachine_log', 'warning', 'Directive output skipped (system_file missing file_path or mime_type)', $context );
 					continue;
 				}
 
@@ -101,7 +101,6 @@ class DirectiveOutputValidator {
 				'warning',
 				'Directive output skipped (unknown type)',
 				array_merge(
-					array( 'agent_type' => 'system' ),
 					$context,
 					array(
 						'type' => $type,

--- a/inc/Engine/AI/Tools/ToolResultFinder.php
+++ b/inc/Engine/AI/Tools/ToolResultFinder.php
@@ -46,7 +46,6 @@ class ToolResultFinder {
 			'error',
 			'AI did not execute handler tool',
 			array(
-				'agent_type'   => 'system',
 				'handler'      => $handler,
 				'flow_step_id' => $flow_step_id,
 			)

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -541,7 +541,6 @@ function datamachine_register_execution_engine() {
 					'debug',
 					'Next step scheduled via Action Scheduler',
 					array(
-						'agent_type'   => 'system',
 						'job_id'       => $job_id,
 						'flow_step_id' => $flow_step_id,
 						'action_id'    => $action_id,
@@ -586,7 +585,6 @@ function datamachine_register_execution_engine() {
 					'info',
 					'Flow schedule cleared (set to manual)',
 					array(
-						'agent_type' => 'system',
 						'flow_id'    => $flow_id,
 					)
 				);
@@ -617,7 +615,6 @@ function datamachine_register_execution_engine() {
 						'info',
 						'Flow scheduled for one-time execution',
 						array(
-							'agent_type'     => 'system',
 							'flow_id'        => $flow_id,
 							'timestamp'      => $interval_or_timestamp,
 							'scheduled_time' => wp_date( 'c', $interval_or_timestamp ),
@@ -636,7 +633,6 @@ function datamachine_register_execution_engine() {
 						'error',
 						'Invalid schedule interval',
 						array(
-							'agent_type'          => 'system',
 							'flow_id'             => $flow_id,
 							'interval'            => $interval_or_timestamp,
 							'available_intervals' => array_keys( $intervals ),
@@ -667,7 +663,6 @@ function datamachine_register_execution_engine() {
 						'info',
 						'Flow scheduled for recurring execution',
 						array(
-							'agent_type'       => 'system',
 							'flow_id'          => $flow_id,
 							'interval'         => $interval_or_timestamp,
 							'interval_seconds' => $interval_seconds,


### PR DESCRIPTION
## Problem

Operational log calls (scheduling, OAuth, DB operations, AI library errors, directive validation) hardcode `'agent_type' => 'system'` in their context arrays. This forces these logs into `datamachine-system.log` even when they execute during pipeline or chat agent sessions.

The `datamachine_resolve_agent_type()` function in Logger.php already handles agent type resolution correctly:
1. Checks for explicit `agent_type` in context
2. Falls back to `AgentContext::get()`
3. Defaults to `pipeline`

The hardcoded overrides bypass this resolution.

## Fix

Removed `'agent_type' => 'system'` from operational log context arrays so they inherit the correct agent type from AgentContext.

**Kept** `'agent_type' => 'system'` only where the system agent is genuinely running its own work:
- `SystemAbilities.php` (title generation, alt text)
- `AltTextAbilities.php` (alt text generation is system agent work)
- `LogAbilities.php` line 314 (log cleared notification)

## Files Changed (13)

| File | Removals | Context |
|------|----------|---------|
| Engine.php | 5 lines | Scheduling operations |
| ConversationManager.php | 1 line | AI library error handler |
| ToolResultFinder.php | 1 line | Tool result lookup |
| DirectiveOutputValidator.php | 7 lines | Validation warnings |
| OAuth2Handler.php | 11 lines | OAuth2 operations |
| OAuth1Handler.php | 13 lines | OAuth1 operations |
| GoogleSheetsAuth.php | 19 lines | Google Sheets auth |
| Flows.php | 1 line | Flow DB operations |
| Jobs.php | 4 lines | Job DB operations |
| ProcessedItems.php | 1 line | Processed items DB |
| GoogleSheetsFetch.php | 1 line | Google Sheets fetch handler |
| Reddit.php | 1 line | Reddit fetch handler |
| AuthAbilities.php | 1 line | Auth ability execution |

## Testing

After this change, scheduling and step execution logs should appear in `datamachine-pipeline.log` (or `datamachine-chat.log`) instead of `datamachine-system.log` when running during pipeline/chat execution.