### PR TITLE
fix: default agent type fallback to system instead of pipeline

### DIFF
--- a/inc/Engine/Logger.php
+++ b/inc/Engine/Logger.php
@@ -102,8 +102,8 @@ function datamachine_resolve_agent_type( array $context = array() ): string {
 		return $execution_context;
 	}
 
-	// Priority 3: Default to pipeline
-	return AgentType::PIPELINE;
+	// Priority 3: Default to system
+	return AgentType::SYSTEM;
 }
 
 /**


### PR DESCRIPTION
Closes #14

One-line change: default fallback in `datamachine_resolve_agent_type()` from `AgentType::PIPELINE` to `AgentType::SYSTEM`.

Logs without an explicit `AgentContext` (testing tools, system utilities, ephemeral workflows) now route to system log instead of pipeline log. Pipeline and chat contexts both set their context explicitly, so they're unaffected.