### PR TITLE
Add timeout-based recovery for stuck processing jobs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Data Machine will be documented in this file. Also viewable at: 
 
 
+## Unreleased
+
+### Added
+- Add timeout-based recovery for stuck processing jobs without status override
+
 ## [0.22.1] - 2026-02-12
 
 - Remove scheduling interval aliases — only canonical names from SchedulerIntervals.php are accepted. Non-canonical values now return WP_Error instead of being silently normalized.


### PR DESCRIPTION
## Summary

Extends `RecoverStuckJobsAbility` to handle a second failure mode: jobs stuck in `processing` state where the PHP process died mid-execution (no `job_status` written to engine_data).

## Changes

### `RecoverStuckJobsAbility.php`
- Added `timeout_hours` input parameter (default: 2, minimum: 1)
- After existing job_status-based recovery, runs a second pass for timed-out jobs
- Timed-out jobs are marked as `failed` with `completed_at` set
- If `queued_prompt_backup` exists in engine_data, the prompt is re-queued to the flow's prompt_queue
- Added `timed_out` and `requeued` counts to output

### `JobsCommand.php`  
- Added `--timeout=<hours>` option to `recover-stuck` CLI command
- Added display for `would_timeout` and `timed_out` status jobs

## Testing

```bash
# Preview what would be recovered (dry run)
wp datamachine jobs recover-stuck --dry-run

# Recover with default 2-hour timeout
wp datamachine jobs recover-stuck

# Custom timeout
wp datamachine jobs recover-stuck --timeout=4
```

## Context

Job 907 was stuck in `processing` for 37+ hours. The existing recovery only handles jobs where the engine wrote a `job_status` override. This PR adds coverage for the case where the process died before any status was written.

Closes #117