### PR TITLE
fix: prevent false publish completion when handler tool fails

### DIFF
--- a/inc/Engine/AI/Tools/ToolResultFinder.php
+++ b/inc/Engine/AI/Tools/ToolResultFinder.php
@@ -32,9 +32,21 @@ class ToolResultFinder {
 		foreach ( $dataPackets as $entry ) {
 			$entry_type = $entry['type'] ?? '';
 
-			if ( in_array( $entry_type, array( 'tool_result', 'ai_handler_complete' ), true ) ) {
+			// Only match successful handler completions.
+			// 'ai_handler_complete' entries are already filtered for success during creation.
+			// 'tool_result' entries must be checked for tool_success to avoid treating
+			// failed tool calls as successful publish completions.
+			if ( 'ai_handler_complete' === $entry_type ) {
 				$handler_tool = $entry['metadata']['handler_tool'] ?? '';
 				if ( $handler_tool === $handler ) {
+					return $entry;
+				}
+			}
+
+			if ( 'tool_result' === $entry_type ) {
+				$handler_tool = $entry['metadata']['handler_tool'] ?? '';
+				$tool_success = $entry['metadata']['tool_success'] ?? false;
+				if ( $handler_tool === $handler && $tool_success ) {
 					return $entry;
 				}
 			}


### PR DESCRIPTION
## Problem

When the AI calls a handler tool (e.g. `wordpress_recipe_publish`) and every call fails (`success: false`), the flow still completes as if publishing succeeded.

### Root Cause

`ToolResultFinder::findHandlerResult()` matches `tool_result` data packet entries by handler slug but does **not** check `tool_success`. The `PublishStep` finds the failed result, creates a 'Publish Complete' packet with `publish_success: true`, and the engine sees non-empty packets → marks the job completed.

### Evidence (job 982, flow 45)

- AI called `wordpress_recipe_publish` 5 times (turns 2-6), all returned `success: false`
- PublishStep logged 'AI successfully used handler tool' for the failed call
- Flow completed with no post created

### Fix

`ToolResultFinder::findHandlerResult()` now:
- Matches `ai_handler_complete` entries as before (already filtered for success during creation)
- Only matches `tool_result` entries when `tool_success === true`

This ensures failed handler tool calls are not treated as successful completions.