### PR TITLE
Fix: show 'Direct Execution' for direct jobs instead of 'Unknown'

### DIFF
--- a/inc/Abilities/Job/JobHelpers.php
+++ b/inc/Abilities/Job/JobHelpers.php
@@ -55,14 +55,19 @@ trait JobHelpers {
 			$job['completed_at_display'] = DateFormatter::format_for_display( $job['completed_at'] );
 		}
 
-		// Compute display_label for UI
+		// Handle direct execution jobs (system agent, chat, API).
+		if ( ( $job['pipeline_id'] ?? '' ) === 'direct' ) {
+			$job['pipeline_name'] = $job['pipeline_name'] ?? __( 'Direct', 'data-machine' );
+			$job['flow_name']     = $job['flow_name'] ?? __( 'Direct Execution', 'data-machine' );
+		}
+
+		// Compute display_label for UI.
 		if ( ! empty( $job['label'] ) ) {
 			$job['display_label'] = $job['label'];
 		} elseif ( ! empty( $job['pipeline_name'] ) && ! empty( $job['flow_name'] ) ) {
 			$job['display_label'] = $job['pipeline_name'] . ' → ' . $job['flow_name'];
 		} else {
-			$source               = $job['source'] ?? 'unknown';
-			$job['display_label'] = ucfirst( $source ) . ' Execution';
+			$job['display_label'] = __( 'Unknown Execution', 'data-machine' );
 		}
 
 		return $job;

--- a/inc/Core/Admin/Pages/Jobs/assets/react/components/JobsTable.jsx
+++ b/inc/Core/Admin/Pages/Jobs/assets/react/components/JobsTable.jsx
@@ -93,11 +93,8 @@ const JobsTable = ( { jobs, isLoading, isError, error } ) => {
 								<strong>{ job.job_id }</strong>
 							</td>
 							<td>
-								{ job.pipeline_name ||
-									__( 'Unknown Pipeline', 'data-machine' ) }
-								{ ' → ' }
-								{ job.flow_name ||
-									__( 'Unknown Flow', 'data-machine' ) }
+								{ job.display_label ||
+									`${ job.pipeline_name || __( 'Unknown Pipeline', 'data-machine' ) } → ${ job.flow_name || __( 'Unknown Flow', 'data-machine' ) }` }
 							</td>
 							<td>
 								<span


### PR DESCRIPTION
## Problem

Jobs created via direct execution (system agent, chat API) have `pipeline_id='direct'` and `flow_id='direct'`. The SQL JOIN in `get_jobs_for_list_table()` produces NULL for `pipeline_name`/`flow_name` because no pipeline/flow records exist with ID 'direct'.

The Jobs admin page shows these as **'Unknown Pipeline → Unknown Flow'**.

## Fix

**Backend** (`JobHelpers.php`):
- Detect `pipeline_id === 'direct'` in `addDisplayFields()`
- Populate `pipeline_name` = 'Direct' and `flow_name` = 'Direct Execution' as defaults
- Remove reference to non-existent `source` column in fallback

**Frontend** (`JobsTable.jsx`):
- Prefer `display_label` (computed by backend) over raw `pipeline_name`/`flow_name`
- Falls back to raw fields for backward compatibility

## Testing

Jobs with `pipeline_id='direct'` now show as **'Direct → Direct Execution'** instead of 'Unknown Pipeline → Unknown Flow'. Regular pipeline jobs are unaffected.