### PR TITLE
fix: stop manual flows from continuing to schedule

### DIFF
--- a/inc/Api/Flows/FlowScheduling.php
+++ b/inc/Api/Flows/FlowScheduling.php
@@ -44,7 +44,7 @@ class FlowScheduling {
 		// Handle manual scheduling (unschedule)
 		if ( 'manual' === $interval || null === $interval ) {
 			if ( function_exists( 'as_unschedule_all_actions' ) ) {
-				as_unschedule_all_actions( 'datamachine_run_flow_now', array(), 'data-machine' );
+				as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
 			}
 
 			$db_flows->update_flow_scheduling( $flow_id, array( 'interval' => 'manual' ) );
@@ -110,7 +110,7 @@ class FlowScheduling {
 
 		// Clear any existing schedule first
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( 'datamachine_run_flow_now', array(), 'data-machine' );
+			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
 		}
 
 		as_schedule_recurring_action(

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -574,7 +574,7 @@ function datamachine_register_execution_engine() {
 
 			// 1. Always unschedule existing to prevent duplicates
 			if ( function_exists( 'as_unschedule_all_actions' ) ) {
-				as_unschedule_all_actions( 'datamachine_run_flow_now', array(), 'data-machine' );
+				as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
 			}
 
 			// 2. Handle 'manual' case


### PR DESCRIPTION
When a flow schedule is set to manual, Data Machine should fully unschedule any Action Scheduler actions for that flow.\n\nRoot cause: code used as_unschedule_action(), which only removes a single pending instance and can leave the recurring schedule chain alive.\n\nChanges:\n- Use as_unschedule_all_actions() when clearing schedules (manual/null interval) and before re-scheduling.\n\nFiles:\n- inc/Api/Flows/FlowScheduling.php\n- inc/Engine/Actions/Engine.php\n\nManual QA:\n1) Set a flow to a recurring interval, confirm datamachine_run_flow_now actions exist for that flow.\n2) Switch the flow scheduling interval to 'manual'.\n3) Verify there are no pending/recurring actions for hook datamachine_run_flow_now with args [flow_id] in group 'data-machine'.\n4) Wait past the prior interval window and confirm it does not run again.\n