### PR TITLE
fix: add tool_id guard to GoogleSearch get_config_fields filter

### DIFF
--- a/inc/Engine/AI/Tools/Global/GoogleSearch.php
+++ b/inc/Engine/AI/Tools/Global/GoogleSearch.php
@@ -223,7 +223,11 @@ class GoogleSearch extends BaseTool {
 		}
 	}
 
-	public function get_config_fields(): array {
+	public function get_config_fields( $fields = array(), $tool_id = '' ) {
+		if ( ! empty( $tool_id ) && 'google_search' !== $tool_id ) {
+			return $fields;
+		}
+
 		return array(
 			'api_key'          => array(
 				'type'        => 'text',


### PR DESCRIPTION
## Problem

`get_config_fields()` is registered as a filter callback via `registerConfigurationHandlers()` with 2 args (`$fields`, `$tool_id`), but GoogleSearch's implementation ignored both parameters and returned its fields unconditionally.

This works when GoogleSearch is the only configurable tool, but adding a second configurable tool would cause config fields to clobber each other since the last registered callback wins.

## Fix

Add `$tool_id` guard to `get_config_fields()`, matching the pattern already used by `check_configuration()`, `get_configuration()`, and `save_configuration()` in the same class.

## Impact

No behavioral change for existing single-tool setup. Enables correct multi-tool config field resolution going forward.