### PR TITLE
feat: System Agent sets featured image after pipeline publish

### DIFF
--- a/inc/Engine/AI/System/Tasks/ImageGenerationTask.php
+++ b/inc/Engine/AI/System/Tasks/ImageGenerationTask.php
@@ -177,6 +177,11 @@ class ImageGenerationTask extends SystemTask {
 			$image_file_path = get_attached_file( $attachment_id );
 		}
 
+		// If we have an attachment and a pipeline job context, try to set featured image
+		if ( $attachment_id ) {
+			$this->trySetFeaturedImage( $jobId, $attachment_id, $params );
+		}
+
 		// Complete job with success data
 		$result = [
 			'success'      => true,
@@ -195,6 +200,119 @@ class ImageGenerationTask extends SystemTask {
 		];
 
 		$this->completeJob( $jobId, $result );
+	}
+
+	/**
+	 * Try to set the generated image as the featured image on the published post.
+	 *
+	 * Reads the pipeline's engine data to find the post_id written by the
+	 * publish step. If the post hasn't been published yet (race condition),
+	 * schedules a deferred attempt via Action Scheduler.
+	 *
+	 * @param int   $jobId        System Agent job ID.
+	 * @param int   $attachmentId WordPress attachment ID.
+	 * @param array $params       Task params (contains context.pipeline_job_id).
+	 */
+	private function trySetFeaturedImage( int $jobId, int $attachmentId, array $params ): void {
+		$context         = $params['context'] ?? [];
+		$pipeline_job_id = $context['pipeline_job_id'] ?? 0;
+
+		if ( empty( $pipeline_job_id ) ) {
+			// No pipeline context — this was a chat or standalone request
+			return;
+		}
+
+		// Read the pipeline job's engine data to find the published post_id
+		$pipeline_engine_data = datamachine_get_engine_data( (int) $pipeline_job_id );
+		$post_id              = $pipeline_engine_data['post_id'] ?? 0;
+
+		if ( empty( $post_id ) ) {
+			// Post hasn't been published yet — schedule a deferred attempt
+			$this->scheduleFeaturedImageRetry( $attachmentId, $pipeline_job_id );
+			return;
+		}
+
+		// Check if post already has a featured image
+		if ( has_post_thumbnail( $post_id ) ) {
+			do_action(
+				'datamachine_log',
+				'debug',
+				"System Agent: Post #{$post_id} already has a featured image, skipping",
+				[
+					'job_id'        => $jobId,
+					'post_id'       => $post_id,
+					'attachment_id' => $attachmentId,
+					'agent_type'    => 'system',
+				]
+			);
+			return;
+		}
+
+		// Set the featured image
+		$result = set_post_thumbnail( $post_id, $attachmentId );
+
+		if ( $result ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				"System Agent: Featured image set on post #{$post_id} (attachment #{$attachmentId})",
+				[
+					'job_id'        => $jobId,
+					'post_id'       => $post_id,
+					'attachment_id' => $attachmentId,
+					'agent_type'    => 'system',
+				]
+			);
+		} else {
+			do_action(
+				'datamachine_log',
+				'warning',
+				"System Agent: Failed to set featured image on post #{$post_id}",
+				[
+					'job_id'        => $jobId,
+					'post_id'       => $post_id,
+					'attachment_id' => $attachmentId,
+					'agent_type'    => 'system',
+				]
+			);
+		}
+	}
+
+	/**
+	 * Schedule a deferred attempt to set the featured image.
+	 *
+	 * Used when the System Agent finishes image generation before the
+	 * pipeline's publish step has written the post_id to engine data.
+	 *
+	 * @param int $attachmentId     WordPress attachment ID.
+	 * @param int $pipelineJobId    Pipeline job ID to check for post_id.
+	 */
+	private function scheduleFeaturedImageRetry( int $attachmentId, int $pipelineJobId ): void {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			return;
+		}
+
+		as_schedule_single_action(
+			time() + 15,
+			'datamachine_system_agent_set_featured_image',
+			[
+				'attachment_id'   => $attachmentId,
+				'pipeline_job_id' => $pipelineJobId,
+				'attempt'         => 1,
+			],
+			'data-machine'
+		);
+
+		do_action(
+			'datamachine_log',
+			'debug',
+			"System Agent: Scheduled deferred featured image set (attachment #{$attachmentId}, pipeline job #{$pipelineJobId})",
+			[
+				'attachment_id'   => $attachmentId,
+				'pipeline_job_id' => $pipelineJobId,
+				'agent_type'      => 'system',
+			]
+		);
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/ImageGeneration.php
+++ b/inc/Engine/AI/Tools/Global/ImageGeneration.php
@@ -127,7 +127,14 @@ class ImageGeneration extends BaseTool {
 			);
 		}
 
-		// NEW: Hand off to System Agent instead of polling
+		// Hand off to System Agent instead of polling.
+		// Pass pipeline job_id in context so the System Agent can read
+		// engine data (e.g. post_id) and set featured image after publish.
+		$context = [];
+		if ( ! empty( $parameters['job_id'] ) ) {
+			$context['pipeline_job_id'] = (int) $parameters['job_id'];
+		}
+
 		return $this->buildPendingResponse(
 			'image_generation',
 			[
@@ -136,7 +143,7 @@ class ImageGeneration extends BaseTool {
 				'prompt'        => $prompt,
 				'aspect_ratio'  => $aspect_ratio,
 			],
-			[], // context - pipeline/chat routing handled upstream
+			$context,
 			'image_generation'
 		);
 	}


### PR DESCRIPTION
## What

Completes the image generation pipeline integration. The System Agent now sets the featured image on the published post automatically — no new pipeline step needed.

Relates to #95, #77

## The Problem

The pipeline is non-blocking: AI step → Publish step runs immediately. Image generation is async (System Agent polls Replicate in the background). The publish step runs before the image is ready, so posts publish without featured images.

## The Solution: Sub-Agent Pattern

The System Agent acts as a sub-agent that works alongside the pipeline:

```
Pipeline:     AI step → Publish step → Done (post live, no image yet)
System Agent: Generate image → Sideload → Set featured image on post
```

No pipeline pausing. Post goes live fast. Image follows when ready.

## How It Works

### 1. Pipeline job_id flows through context

`ImageGeneration::handle_tool_call()` reads `job_id` from the tool parameters (injected by `ToolParameters::buildParameters()` from the pipeline payload) and passes it as `pipeline_job_id` in the `buildPendingResponse()` context.

### 2. System Agent reads pipeline engine data

When `ImageGenerationTask::handleSuccess()` fires after sideloading the image, it reads the pipeline job's engine data via `datamachine_get_engine_data($pipeline_job_id)` to find the `post_id` written by the publish step.

### 3. Race condition handling

Two scenarios:

**Normal (publish completes first):**
- System Agent finds `post_id` in engine data → `set_post_thumbnail()` → done

**Fast generation (System Agent completes first):**
- No `post_id` yet → schedules `datamachine_system_agent_set_featured_image` action
- Retries every 15 seconds, max 12 attempts (3 minutes)
- Next retry finds `post_id` → sets featured image

### 4. Safety checks

- Skips if no pipeline context (chat/standalone requests)
- Won't overwrite existing featured images (`has_post_thumbnail()` check)
- Max retry limit prevents infinite loops

## Files Changed

### `ImageGeneration.php`
- Passes `pipeline_job_id` from tool parameters into `buildPendingResponse()` context

### `ImageGenerationTask.php`
- `handleSuccess()` calls new `trySetFeaturedImage()` after sideloading
- `trySetFeaturedImage()` reads pipeline engine data for `post_id`
- `scheduleFeaturedImageRetry()` handles the race condition via AS

### `SystemAgentServiceProvider.php`
- Registers `datamachine_system_agent_set_featured_image` AS action
- `handleDeferredFeaturedImage()` retry handler with attempt tracking

Also cherry-picks the `image_file_path` fix from the previous branch.

## End-to-End Pipeline Flow

```
1. Fetch step → fetches content source
2. AI step → generates content + calls image_generation tool
   → Tool starts Replicate prediction, returns "pending (Job #X)"
   → Pipeline job_id passed in context
3. Publish step → publishes post (no featured image yet)
   → Writes post_id to engine data
4. System Agent (parallel) → polls Replicate → image ready
   → Sideloads to media library
   → Reads pipeline engine data → finds post_id
   → set_post_thumbnail() → featured image attached
5. Agent Ping step → posts to social media (image already on post)
```