### PR TITLE
test: add coverage for System Agent and image generation tool

### DIFF
--- a/tests/Unit/AI/System/SystemAgentServiceProviderTest.php
+++ b/tests/Unit/AI/System/SystemAgentServiceProviderTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Tests for the SystemAgentServiceProvider registration.
+ *
+ * @package DataMachine\Tests\Unit\AI\System
+ */
+
+namespace DataMachine\Tests\Unit\AI\System;
+
+use DataMachine\Engine\AI\System\SystemAgentServiceProvider;
+use DataMachine\Engine\AI\System\Tasks\ImageGenerationTask;
+use WP_UnitTestCase;
+
+class SystemAgentServiceProviderTest extends WP_UnitTestCase {
+
+	private SystemAgentServiceProvider $provider;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->provider = new SystemAgentServiceProvider();
+	}
+
+	public function test_get_built_in_tasks_registers_image_generation(): void {
+		$tasks = $this->provider->getBuiltInTasks( [] );
+		$this->assertArrayHasKey( 'image_generation', $tasks );
+		$this->assertSame( ImageGenerationTask::class, $tasks['image_generation'] );
+	}
+
+	public function test_get_built_in_tasks_preserves_existing_tasks(): void {
+		$existing = [ 'custom_task' => 'CustomTaskClass' ];
+		$tasks = $this->provider->getBuiltInTasks( $existing );
+		$this->assertArrayHasKey( 'custom_task', $tasks );
+		$this->assertArrayHasKey( 'image_generation', $tasks );
+	}
+
+	public function test_handle_task_action_is_registered(): void {
+		$this->assertIsInt(
+			has_action( 'datamachine_system_agent_handle_task', [ $this->provider, 'handleScheduledTask' ] )
+		);
+	}
+
+	public function test_set_featured_image_action_is_registered(): void {
+		$this->assertIsInt(
+			has_action( 'datamachine_system_agent_set_featured_image', [ $this->provider, 'handleDeferredFeaturedImage' ] )
+		);
+	}
+}

--- a/tests/Unit/AI/System/SystemAgentTest.php
+++ b/tests/Unit/AI/System/SystemAgentTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Tests for the SystemAgent singleton and task scheduling.
+ *
+ * @package DataMachine\Tests\Unit\AI\System
+ */
+
+namespace DataMachine\Tests\Unit\AI\System;
+
+use DataMachine\Engine\AI\System\SystemAgent;
+use WP_UnitTestCase;
+
+class SystemAgentTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		// Reset singleton for clean tests via reflection.
+		$ref = new \ReflectionClass( SystemAgent::class );
+		$prop = $ref->getProperty( 'instance' );
+		$prop->setAccessible( true );
+		$prop->setValue( null, null );
+	}
+
+	public function tear_down(): void {
+		// Reset singleton after tests.
+		$ref = new \ReflectionClass( SystemAgent::class );
+		$prop = $ref->getProperty( 'instance' );
+		$prop->setAccessible( true );
+		$prop->setValue( null, null );
+
+		parent::tear_down();
+	}
+
+	public function test_get_instance_returns_singleton(): void {
+		$a = SystemAgent::getInstance();
+		$b = SystemAgent::getInstance();
+		$this->assertSame( $a, $b );
+	}
+
+	public function test_get_task_handlers_returns_registered_handlers(): void {
+		$agent = SystemAgent::getInstance();
+		$handlers = $agent->getTaskHandlers();
+		$this->assertIsArray( $handlers );
+	}
+
+	public function test_schedule_task_returns_false_for_unknown_task_type(): void {
+		$agent = SystemAgent::getInstance();
+		$result = $agent->scheduleTask( 'nonexistent_task_type', [] );
+		$this->assertFalse( $result );
+	}
+
+	public function test_handle_task_handles_missing_job_gracefully(): void {
+		$agent = SystemAgent::getInstance();
+		// Job ID 999999 should not exist — should not throw.
+		$agent->handleTask( 999999 );
+		// If we get here without exception, the test passes.
+		$this->assertTrue( true );
+	}
+
+	public function test_handle_task_handles_missing_task_type(): void {
+		// Create a job without task_type in engine_data.
+		$jobs_db = new \DataMachine\Core\Database\Jobs\Jobs();
+		$job_id = $jobs_db->create_job( [
+			'pipeline_id' => 'direct',
+			'flow_id'     => 'direct',
+			'source'      => 'system',
+			'label'       => 'Test Job',
+		] );
+
+		if ( ! $job_id ) {
+			$this->markTestSkipped( 'Could not create test job.' );
+		}
+
+		// Store engine_data without task_type.
+		$jobs_db->store_engine_data( (int) $job_id, [ 'foo' => 'bar' ] );
+
+		$agent = SystemAgent::getInstance();
+		$agent->handleTask( (int) $job_id );
+
+		// Job should be marked as failed.
+		$job = $jobs_db->get_job( (int) $job_id );
+		$this->assertStringContainsString( 'failed', strtolower( $job['status'] ?? '' ) );
+	}
+}

--- a/tests/Unit/AI/System/Tasks/ImageGenerationTaskTest.php
+++ b/tests/Unit/AI/System/Tasks/ImageGenerationTaskTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Tests for the ImageGenerationTask system task.
+ *
+ * @package DataMachine\Tests\Unit\AI\System\Tasks
+ */
+
+namespace DataMachine\Tests\Unit\AI\System\Tasks;
+
+use DataMachine\Engine\AI\System\Tasks\ImageGenerationTask;
+use WP_UnitTestCase;
+
+class ImageGenerationTaskTest extends WP_UnitTestCase {
+
+	private ImageGenerationTask $task;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->task = new ImageGenerationTask();
+	}
+
+	public function tear_down(): void {
+		delete_site_option( 'datamachine_image_generation_config' );
+		parent::tear_down();
+	}
+
+	public function test_get_task_type_returns_image_generation(): void {
+		$this->assertSame( 'image_generation', $this->task->getTaskType() );
+	}
+
+	public function test_execute_fails_when_prediction_id_missing(): void {
+		$jobs_db = new \DataMachine\Core\Database\Jobs\Jobs();
+		$job_id = $jobs_db->create_job( [
+			'pipeline_id' => 'direct',
+			'flow_id'     => 'direct',
+			'source'      => 'system',
+			'label'       => 'Test Image Gen',
+		] );
+
+		if ( ! $job_id ) {
+			$this->markTestSkipped( 'Could not create test job.' );
+		}
+
+		$this->task->execute( (int) $job_id, [] );
+
+		$job = $jobs_db->get_job( (int) $job_id );
+		$this->assertStringContainsString( 'failed', strtolower( $job['status'] ?? '' ) );
+	}
+
+	public function test_execute_fails_when_api_key_not_configured(): void {
+		delete_site_option( 'datamachine_image_generation_config' );
+
+		$jobs_db = new \DataMachine\Core\Database\Jobs\Jobs();
+		$job_id = $jobs_db->create_job( [
+			'pipeline_id' => 'direct',
+			'flow_id'     => 'direct',
+			'source'      => 'system',
+			'label'       => 'Test Image Gen',
+		] );
+
+		if ( ! $job_id ) {
+			$this->markTestSkipped( 'Could not create test job.' );
+		}
+
+		$this->task->execute( (int) $job_id, [ 'prediction_id' => 'test-pred-123' ] );
+
+		$job = $jobs_db->get_job( (int) $job_id );
+		$this->assertStringContainsString( 'failed', strtolower( $job['status'] ?? '' ) );
+	}
+}

--- a/tests/Unit/AI/Tools/GoogleSearchConfigTest.php
+++ b/tests/Unit/AI/Tools/GoogleSearchConfigTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Tests for GoogleSearch configuration guard logic.
+ *
+ * @package DataMachine\Tests\Unit\AI\Tools
+ */
+
+namespace DataMachine\Tests\Unit\AI\Tools;
+
+use DataMachine\Engine\AI\Tools\Global\GoogleSearch;
+use WP_UnitTestCase;
+
+class GoogleSearchConfigTest extends WP_UnitTestCase {
+
+	private GoogleSearch $tool;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->tool = new GoogleSearch();
+	}
+
+	public function tear_down(): void {
+		delete_site_option( 'datamachine_search_config' );
+		parent::tear_down();
+	}
+
+	public function test_get_config_fields_returns_fields_for_google_search(): void {
+		$fields = $this->tool->get_config_fields( [], 'google_search' );
+		$this->assertArrayHasKey( 'api_key', $fields );
+		$this->assertArrayHasKey( 'search_engine_id', $fields );
+	}
+
+	public function test_get_config_fields_returns_fields_when_tool_id_empty(): void {
+		$fields = $this->tool->get_config_fields( [], '' );
+		$this->assertArrayHasKey( 'api_key', $fields );
+		$this->assertArrayHasKey( 'search_engine_id', $fields );
+	}
+
+	public function test_get_config_fields_passthrough_for_different_tool_id(): void {
+		$existing = [ 'foo' => 'bar' ];
+		$result = $this->tool->get_config_fields( $existing, 'image_generation' );
+		$this->assertSame( $existing, $result );
+	}
+
+	public function test_check_configuration_passthrough_for_wrong_tool_id(): void {
+		$this->assertFalse( $this->tool->check_configuration( false, 'image_generation' ) );
+		$this->assertTrue( $this->tool->check_configuration( true, 'image_generation' ) );
+	}
+
+	public function test_check_configuration_returns_status_for_google_search(): void {
+		delete_site_option( 'datamachine_search_config' );
+		$this->assertFalse( $this->tool->check_configuration( true, 'google_search' ) );
+
+		update_site_option( 'datamachine_search_config', [
+			'google_search' => [
+				'api_key'          => 'test-key',
+				'search_engine_id' => 'test-cx',
+			],
+		] );
+		$this->assertTrue( $this->tool->check_configuration( false, 'google_search' ) );
+	}
+}

--- a/tests/Unit/AI/Tools/ImageGenerationTest.php
+++ b/tests/Unit/AI/Tools/ImageGenerationTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests for the ImageGeneration global tool.
+ *
+ * @package DataMachine\Tests\Unit\AI\Tools
+ */
+
+namespace DataMachine\Tests\Unit\AI\Tools;
+
+use DataMachine\Engine\AI\Tools\Global\ImageGeneration;
+use WP_UnitTestCase;
+
+class ImageGenerationTest extends WP_UnitTestCase {
+
+	private ImageGeneration $tool;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->tool = new ImageGeneration();
+	}
+
+	public function tear_down(): void {
+		delete_site_option( 'datamachine_image_generation_config' );
+		parent::tear_down();
+	}
+
+	public function test_is_configured_returns_false_when_no_config(): void {
+		delete_site_option( 'datamachine_image_generation_config' );
+		$this->assertFalse( ImageGeneration::is_configured() );
+	}
+
+	public function test_is_configured_returns_true_when_api_key_set(): void {
+		update_site_option( 'datamachine_image_generation_config', [ 'api_key' => 'test-key' ] );
+		$this->assertTrue( ImageGeneration::is_configured() );
+	}
+
+	public function test_get_config_returns_empty_array_by_default(): void {
+		delete_site_option( 'datamachine_image_generation_config' );
+		$this->assertSame( [], ImageGeneration::get_config() );
+	}
+
+	public function test_get_config_returns_stored_config(): void {
+		$config = [ 'api_key' => 'test-key', 'default_model' => 'flux' ];
+		update_site_option( 'datamachine_image_generation_config', $config );
+		$this->assertSame( $config, ImageGeneration::get_config() );
+	}
+
+	public function test_check_configuration_passthrough_for_wrong_tool_id(): void {
+		$this->assertFalse( $this->tool->check_configuration( false, 'google_search' ) );
+		$this->assertTrue( $this->tool->check_configuration( true, 'google_search' ) );
+	}
+
+	public function test_check_configuration_returns_status_for_image_generation(): void {
+		delete_site_option( 'datamachine_image_generation_config' );
+		$this->assertFalse( $this->tool->check_configuration( true, 'image_generation' ) );
+
+		update_site_option( 'datamachine_image_generation_config', [ 'api_key' => 'test-key' ] );
+		$this->assertTrue( $this->tool->check_configuration( false, 'image_generation' ) );
+	}
+
+	public function test_get_configuration_passthrough_for_wrong_tool_id(): void {
+		$existing = [ 'some' => 'config' ];
+		$this->assertSame( $existing, $this->tool->get_configuration( $existing, 'google_search' ) );
+	}
+
+	public function test_get_configuration_returns_config_for_image_generation(): void {
+		$config = [ 'api_key' => 'test-key' ];
+		update_site_option( 'datamachine_image_generation_config', $config );
+		$this->assertSame( $config, $this->tool->get_configuration( [], 'image_generation' ) );
+	}
+
+	public function test_get_config_fields_returns_fields_for_image_generation(): void {
+		$fields = $this->tool->get_config_fields( [], 'image_generation' );
+		$this->assertArrayHasKey( 'api_key', $fields );
+		$this->assertArrayHasKey( 'default_model', $fields );
+		$this->assertArrayHasKey( 'default_aspect_ratio', $fields );
+	}
+
+	public function test_get_config_fields_passthrough_for_wrong_tool_id(): void {
+		$existing = [ 'foo' => 'bar' ];
+		$this->assertSame( $existing, $this->tool->get_config_fields( $existing, 'google_search' ) );
+	}
+
+	public function test_get_config_fields_returns_fields_when_tool_id_empty(): void {
+		$fields = $this->tool->get_config_fields( [], '' );
+		$this->assertArrayHasKey( 'api_key', $fields );
+	}
+
+	public function test_get_tool_definition_has_required_keys(): void {
+		$def = $this->tool->getToolDefinition();
+		$this->assertArrayHasKey( 'class', $def );
+		$this->assertArrayHasKey( 'method', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertArrayHasKey( 'requires_config', $def );
+		$this->assertArrayHasKey( 'parameters', $def );
+		$this->assertTrue( $def['requires_config'] );
+		$this->assertSame( 'handle_tool_call', $def['method'] );
+	}
+
+	public function test_handle_tool_call_error_when_prompt_empty(): void {
+		$result = $this->tool->handle_tool_call( [] );
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'prompt', $result['error'] );
+		$this->assertSame( 'image_generation', $result['tool_name'] );
+	}
+
+	public function test_handle_tool_call_error_when_not_configured(): void {
+		delete_site_option( 'datamachine_image_generation_config' );
+		$result = $this->tool->handle_tool_call( [ 'prompt' => 'A sunset' ] );
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'not configured', $result['error'] );
+	}
+
+	public function test_tool_registers_as_global_tool(): void {
+		$tools = apply_filters( 'datamachine_global_tools', [] );
+		$this->assertArrayHasKey( 'image_generation', $tools );
+	}
+
+	public function test_config_option_key(): void {
+		$this->assertSame( 'datamachine_image_generation_config', ImageGeneration::CONFIG_OPTION );
+	}
+}


### PR DESCRIPTION
Adds PHPUnit test coverage for:

- **ImageGenerationTest** - Tool configuration, config fields, tool definition, error handling (empty prompt, missing API key), global tool registration
- **GoogleSearchConfigTest** - Config field guard logic (correct tool_id, empty tool_id backward compat, passthrough for wrong tool_id)
- **SystemAgentTest** - Singleton pattern, task handler registration, unknown task type rejection, missing job handling, missing task_type handling
- **ImageGenerationTaskTest** - Task type identifier, failure on missing prediction_id, failure on missing API key
- **SystemAgentServiceProviderTest** - Built-in task registration, Action Scheduler hook registration

All tests use `WP_UnitTestCase` pattern with `set_up()`/`tear_down()` and proper option cleanup.