### PR TITLE
refactor: Move alt text generation into System Agent

### DIFF
--- a/inc/Abilities/Media/AltTextAbilities.php
+++ b/inc/Abilities/Media/AltTextAbilities.php
@@ -2,18 +2,18 @@
 /**
  * Alt Text Abilities
  *
- * System agent abilities for generating image alt text and diagnostics.
- * Includes Action Scheduler handling and auto-queue on attachment upload.
+ * Ability endpoints for AI-powered alt text generation and diagnostics.
+ * Delegates async execution to the System Agent infrastructure.
  *
  * @package DataMachine\Abilities\Media
  * @since 0.13.8
  */
 
 namespace DataMachine\Abilities\Media;
-use DataMachine\Abilities\PermissionHelper;
 
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\PluginSettings;
-use DataMachine\Engine\AI\RequestBuilder;
+use DataMachine\Engine\AI\System\SystemAgent;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -118,12 +118,14 @@ class AltTextAbilities {
 		}
 	}
 
+	/**
+	 * Register hooks for auto-queue on attachment upload.
+	 */
 	private function registerHooks(): void {
 		if ( self::$hooks_registered ) {
 			return;
 		}
 
-		add_action( 'datamachine_generate_image_alt_text', array( $this, 'handleGenerateImageAltText' ), 10, 3 );
 		add_action( 'add_attachment', array( $this, 'queueAttachmentAltText' ), 10, 1 );
 
 		self::$hooks_registered = true;
@@ -131,6 +133,8 @@ class AltTextAbilities {
 
 	/**
 	 * Generate alt text for a specific attachment or post.
+	 *
+	 * Resolves eligible attachment IDs and delegates each to the System Agent.
 	 *
 	 * @param array $input Ability input.
 	 * @return array Ability response.
@@ -140,7 +144,6 @@ class AltTextAbilities {
 		$post_id       = absint( $input['post_id'] ?? 0 );
 		$force         = ! empty( $input['force'] );
 
-		// Gate on provider/model being configured.
 		$provider = PluginSettings::get( 'default_provider', '' );
 		$model    = PluginSettings::get( 'default_model', '' );
 
@@ -204,18 +207,28 @@ class AltTextAbilities {
 			);
 		}
 
-		$queued = array();
+		$systemAgent = SystemAgent::getInstance();
+		$queued      = array();
+
 		foreach ( $attachment_ids as $id ) {
-			if ( ! self::isImageAttachment( $id ) ) {
+			if ( ! wp_attachment_is_image( $id ) ) {
 				continue;
 			}
 
-			if ( ! $force && ! self::isAltTextMissing( $id ) ) {
+			if ( ! $force && self::isAltTextMissing( $id ) === false ) {
 				continue;
 			}
 
-			$scheduled = self::scheduleAltTextGeneration( $id, $force, 'ability' );
-			if ( $scheduled ) {
+			$jobId = $systemAgent->scheduleTask(
+				'alt_text_generation',
+				array(
+					'attachment_id' => $id,
+					'force'         => $force,
+					'source'        => 'ability',
+				)
+			);
+
+			if ( $jobId ) {
 				$queued[] = $id;
 			}
 		}
@@ -225,7 +238,7 @@ class AltTextAbilities {
 			'queued_count'   => count( $queued ),
 			'attachment_ids' => $queued,
 			'message'        => ! empty( $queued )
-				? sprintf( 'Alt text generation queued for %d attachment(s).', count( $queued ) )
+				? sprintf( 'Alt text generation queued for %d attachment(s) via System Agent.', count( $queued ) )
 				: 'No attachments queued (alt text already present or no eligible images).',
 		);
 	}
@@ -233,6 +246,7 @@ class AltTextAbilities {
 	/**
 	 * Diagnose alt text coverage across image attachments.
 	 *
+	 * @param array $input Ability input (unused).
 	 * @return array Ability response.
 	 */
 	public static function diagnoseAltText( array $input = array() ): array {
@@ -296,252 +310,23 @@ class AltTextAbilities {
 	}
 
 	/**
-	 * Action Scheduler handler for alt text generation.
-	 *
-	 * @param int  $attachment_id Attachment ID.
-	 * @param bool $force Force generation even if alt text exists.
-	 * @param int  $job_id Optional DM Job ID for tracking.
-	 * @return void
-	 */
-	public function handleGenerateImageAltText( int $attachment_id, bool $force = false, int $job_id = 0 ): void {
-		$attachment_id = absint( $attachment_id );
-		if ( $attachment_id <= 0 ) {
-			return;
-		}
-
-		if ( ! self::isImageAttachment( $attachment_id ) ) {
-			return;
-		}
-
-		if ( ! $force && ! self::isAltTextMissing( $attachment_id ) ) {
-			return;
-		}
-
-		// Instantiate Jobs DB once for all job tracking in this method.
-		$jobs_db = ( $job_id > 0 ) ? new \DataMachine\Core\Database\Jobs\Jobs() : null;
-
-		$file_path = get_attached_file( $attachment_id );
-		if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
-			do_action(
-				'datamachine_log',
-				'error',
-				'Alt text generation skipped - image file missing',
-				array(
-					'attachment_id' => $attachment_id,
-					'agent_type'    => 'system',
-				)
-			);
-			if ( $jobs_db ) {
-				$jobs_db->complete_job( $job_id, (string) \DataMachine\Core\JobStatus::failed( 'image file missing' ) );
-			}
-			return;
-		}
-
-		$provider = PluginSettings::get( 'default_provider', '' );
-		$model    = PluginSettings::get( 'default_model', '' );
-
-		if ( empty( $provider ) || empty( $model ) ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Alt text AI generation skipped - no default provider/model configured',
-				array(
-					'attachment_id' => $attachment_id,
-					'agent_type'    => 'system',
-				)
-			);
-			if ( $jobs_db ) {
-				$jobs_db->complete_job( $job_id, (string) \DataMachine\Core\JobStatus::failed( 'no AI provider configured' ) );
-			}
-			return;
-		}
-
-		$file_info = wp_check_filetype( $file_path );
-		$mime_type = $file_info['type'] ?? '';
-
-		$context_lines = array();
-		$title         = get_the_title( $attachment_id );
-		$caption       = wp_get_attachment_caption( $attachment_id );
-		$description   = get_post_field( 'post_content', $attachment_id );
-		$parent_id     = (int) get_post_field( 'post_parent', $attachment_id );
-
-		if ( ! empty( $title ) ) {
-			$context_lines[] = 'Attachment title: ' . wp_strip_all_tags( $title );
-		}
-		if ( ! empty( $caption ) ) {
-			$context_lines[] = 'Caption: ' . wp_strip_all_tags( $caption );
-		}
-		if ( ! empty( $description ) ) {
-			$context_lines[] = 'Description: ' . wp_strip_all_tags( $description );
-		}
-		if ( $parent_id > 0 ) {
-			$parent_title = get_the_title( $parent_id );
-			if ( ! empty( $parent_title ) ) {
-				$context_lines[] = 'Parent post title: ' . wp_strip_all_tags( $parent_title );
-			}
-		}
-
-		$prompt = "Write alt text for the provided image using these guidelines:\n"
-			. "- Write 1-2 sentences describing the image\n"
-			. "- Don't start with 'Image of' or 'Photo of'\n"
-			. "- Capitalize first word, end with period\n"
-			. "- Describe what's visually present, focus on purpose\n"
-			. "- For complex images (charts/diagrams), provide brief summary only\n\n"
-			. 'Return ONLY the alt text, nothing else.';
-
-		if ( ! empty( $context_lines ) ) {
-			$prompt .= "\n\nContext:\n" . implode( "\n", $context_lines );
-		}
-
-		$messages = array(
-			array(
-				'role'    => 'user',
-				'content' => array(
-					array(
-						'type'      => 'file',
-						'file_path' => $file_path,
-						'mime_type' => $mime_type,
-					),
-				),
-			),
-			array(
-				'role'    => 'user',
-				'content' => $prompt,
-			),
-		);
-
-		$response = RequestBuilder::build(
-			$messages,
-			$provider,
-			$model,
-			array(),
-			'system',
-			array(
-				'attachment_id' => $attachment_id,
-			)
-		);
-
-		if ( empty( $response['success'] ) ) {
-			do_action(
-				'datamachine_log',
-				'error',
-				'Alt text AI generation failed',
-				array(
-					'attachment_id' => $attachment_id,
-					'error'         => $response['error'] ?? 'Unknown error',
-					'agent_type'    => 'system',
-				)
-			);
-			if ( $jobs_db ) {
-				$jobs_db->complete_job( $job_id, (string) \DataMachine\Core\JobStatus::failed( $response['error'] ?? 'Unknown error' ) );
-			}
-			return;
-		}
-
-		$content = $response['data']['content'] ?? '';
-		$alt_text = self::normalizeAltText( $content );
-
-		if ( empty( $alt_text ) ) {
-			do_action(
-				'datamachine_log',
-				'error',
-				'Alt text AI generation returned empty content',
-				array(
-					'attachment_id' => $attachment_id,
-					'agent_type'    => 'system',
-				)
-			);
-			if ( $jobs_db ) {
-				$jobs_db->complete_job( $job_id, (string) \DataMachine\Core\JobStatus::failed( 'empty AI response' ) );
-			}
-			return;
-		}
-
-		// update_post_meta returns false when value unchanged (e.g., force regenerated same text).
-		// Check if current value matches to distinguish "unchanged" from "failed".
-		$current_alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
-		$updated     = update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
-
-		if ( $updated ) {
-			do_action(
-				'datamachine_log',
-				'info',
-				'Alt text generated and saved',
-				array(
-					'attachment_id' => $attachment_id,
-					'alt_text'      => $alt_text,
-					'agent_type'    => 'system',
-					'success'       => true,
-				)
-			);
-			// Update DM Job status
-			if ( $jobs_db ) {
-				$jobs_db->store_engine_data( $job_id, [
-					'alt_text'      => $alt_text,
-					'attachment_id' => $attachment_id,
-					'completed_at'  => current_time( 'mysql' ),
-				] );
-				$jobs_db->complete_job( $job_id, \DataMachine\Core\JobStatus::COMPLETED );
-			}
-		} elseif ( $current_alt === $alt_text ) {
-			// Value unchanged - not an error, just already correct.
-			do_action(
-				'datamachine_log',
-				'info',
-				'Alt text generated (unchanged from existing)',
-				array(
-					'attachment_id' => $attachment_id,
-					'alt_text'      => $alt_text,
-					'agent_type'    => 'system',
-					'success'       => true,
-				)
-			);
-			// Update DM Job status
-			if ( $jobs_db ) {
-				$jobs_db->store_engine_data( $job_id, [
-					'alt_text'      => $alt_text,
-					'attachment_id' => $attachment_id,
-					'completed_at'  => current_time( 'mysql' ),
-				] );
-				$jobs_db->complete_job( $job_id, \DataMachine\Core\JobStatus::COMPLETED );
-			}
-		} else {
-			do_action(
-				'datamachine_log',
-				'error',
-				'Alt text generated but failed to save',
-				array(
-					'attachment_id' => $attachment_id,
-					'alt_text'      => $alt_text,
-					'agent_type'    => 'system',
-					'success'       => false,
-				)
-			);
-			if ( $jobs_db ) {
-				$jobs_db->complete_job( $job_id, (string) \DataMachine\Core\JobStatus::failed( 'failed to save' ) );
-			}
-		}
-	}
-
-	/**
 	 * Auto-queue alt text generation when attachments are added.
 	 *
 	 * @param int $attachment_id Attachment ID.
-	 * @return void
 	 */
 	public function queueAttachmentAltText( int $attachment_id ): void {
 		$attachment_id = absint( $attachment_id );
+
 		if ( $attachment_id <= 0 ) {
 			return;
 		}
 
-		// Check if auto-generation is enabled (defaults to true, like chat_ai_titles_enabled).
 		$auto_generate_enabled = PluginSettings::get( 'alt_text_auto_generate_enabled', true );
+
 		if ( ! $auto_generate_enabled ) {
 			return;
 		}
 
-		// Skip scheduling if no provider/model configured - avoid queuing actions that will no-op.
 		$provider = PluginSettings::get( 'default_provider', '' );
 		$model    = PluginSettings::get( 'default_model', '' );
 
@@ -549,7 +334,7 @@ class AltTextAbilities {
 			return;
 		}
 
-		if ( ! self::isImageAttachment( $attachment_id ) ) {
+		if ( ! wp_attachment_is_image( $attachment_id ) ) {
 			return;
 		}
 
@@ -557,89 +342,15 @@ class AltTextAbilities {
 			return;
 		}
 
-		self::scheduleAltTextGeneration( $attachment_id, false, 'add_attachment' );
-	}
-
-	/**
-	 * Schedule Action Scheduler job for alt text generation.
-	 *
-	 * @param int    $attachment_id Attachment ID.
-	 * @param bool   $force Force regeneration.
-	 * @param string $source Source label for logs.
-	 * @return bool True if scheduled.
-	 */
-	private static function scheduleAltTextGeneration( int $attachment_id, bool $force, string $source ): bool {
-		if ( ! function_exists( 'as_schedule_single_action' ) ) {
-			return false;
-		}
-
-		$args = array(
-			'attachment_id' => $attachment_id,
-			'force'         => $force,
-		);
-
-		if ( ! $force && function_exists( 'as_has_scheduled_action' ) ) {
-			$has_scheduled = as_has_scheduled_action( 'datamachine_generate_image_alt_text', $args, 'data-machine' );
-			if ( $has_scheduled ) {
-				return false;
-			}
-		}
-
-		// Create a DM Job for tracking
-		$jobs_db = new \DataMachine\Core\Database\Jobs\Jobs();
-		$job_id = $jobs_db->create_job( [
-			'pipeline_id' => 'direct',
-			'flow_id'     => 'direct',
-			'source'      => 'system',
-			'label'       => 'Alt Text Generation',
-		] );
-
-		if ( $job_id ) {
-			// Store context in engine_data
-			$jobs_db->store_engine_data( (int) $job_id, [
-				'system_task_type' => 'alt_text_generation',
-				'attachment_id'    => $attachment_id,
-				'source'           => $source,
-				'force'            => $force,
-			] );
-			$jobs_db->start_job( (int) $job_id, 'processing' );
-		}
-
-		// Include job_id in AS action args so handler can update status
-		$args['job_id'] = $job_id ?: 0;
-
-		$action_id = as_schedule_single_action(
-			time(),
-			'datamachine_generate_image_alt_text',
-			$args,
-			'data-machine'
-		);
-
-		do_action(
-			'datamachine_log',
-			'debug',
-			'Alt text generation scheduled',
+		$systemAgent = SystemAgent::getInstance();
+		$systemAgent->scheduleTask(
+			'alt_text_generation',
 			array(
 				'attachment_id' => $attachment_id,
-				'action_id'     => $action_id,
-				'job_id'        => $job_id ?: 0,
-				'source'        => $source,
-				'agent_type'    => 'system',
-				'success'       => ( false !== $action_id ),
+				'force'         => false,
+				'source'        => 'add_attachment',
 			)
 		);
-
-		return false !== $action_id;
-	}
-
-	/**
-	 * Check if attachment is an image.
-	 *
-	 * @param int $attachment_id Attachment ID.
-	 * @return bool
-	 */
-	private static function isImageAttachment( int $attachment_id ): bool {
-		return (bool) wp_attachment_is_image( $attachment_id );
 	}
 
 	/**
@@ -651,33 +362,7 @@ class AltTextAbilities {
 	private static function isAltTextMissing( int $attachment_id ): bool {
 		$alt_text = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
 		$alt_text = is_string( $alt_text ) ? trim( $alt_text ) : '';
+
 		return '' === $alt_text;
-	}
-
-	/**
-	 * Normalize AI response to a clean alt text string.
-	 *
-	 * @param string $raw Alt text from AI.
-	 * @return string Normalized alt text.
-	 */
-	private static function normalizeAltText( string $raw ): string {
-		$alt_text = trim( $raw );
-		$alt_text = trim( $alt_text, " \t\n\r\0\x0B\"'" );
-		$alt_text = sanitize_text_field( $alt_text );
-
-		if ( '' === $alt_text ) {
-			return '';
-		}
-
-		$first_char = mb_substr( $alt_text, 0, 1 );
-		$rest       = mb_substr( $alt_text, 1 );
-		$first_char = preg_match( '/[a-z]/', $first_char ) ? strtoupper( $first_char ) : $first_char;
-		$alt_text   = $first_char . $rest;
-
-		if ( ! preg_match( '/\.$/', $alt_text ) ) {
-			$alt_text .= '.';
-		}
-
-		return $alt_text;
 	}
 }

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -13,6 +13,7 @@ namespace DataMachine\Engine\AI\System;
 
 defined( 'ABSPATH' ) || exit;
 
+use DataMachine\Engine\AI\System\Tasks\AltTextTask;
 use DataMachine\Engine\AI\System\Tasks\ImageGenerationTask;
 
 class SystemAgentServiceProvider {
@@ -46,7 +47,8 @@ class SystemAgentServiceProvider {
 	 * @return array Task handlers including built-in ones.
 	 */
 	public function getBuiltInTasks( array $tasks ): array {
-		$tasks['image_generation'] = ImageGenerationTask::class;
+		$tasks['image_generation']    = ImageGenerationTask::class;
+		$tasks['alt_text_generation'] = AltTextTask::class;
 
 		return $tasks;
 	}

--- a/inc/Engine/AI/System/Tasks/AltTextTask.php
+++ b/inc/Engine/AI/System/Tasks/AltTextTask.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Alt Text Generation Task for System Agent.
+ *
+ * Generates AI-powered alt text for image attachments. Loads the image file,
+ * builds a contextual prompt, sends to the configured AI provider, normalizes
+ * the response, and saves it as the attachment's alt text meta.
+ *
+ * @package DataMachine\Engine\AI\System\Tasks
+ * @since 0.23.0
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\RequestBuilder;
+
+class AltTextTask extends SystemTask {
+
+	/**
+	 * Execute alt text generation for a specific attachment.
+	 *
+	 * @param int   $jobId  Job ID from DM Jobs table.
+	 * @param array $params Task parameters from engine_data.
+	 */
+	public function execute( int $jobId, array $params ): void {
+		$attachment_id = absint( $params['attachment_id'] ?? 0 );
+		$force         = ! empty( $params['force'] );
+
+		if ( $attachment_id <= 0 ) {
+			$this->failJob( $jobId, 'Missing or invalid attachment_id' );
+			return;
+		}
+
+		if ( ! wp_attachment_is_image( $attachment_id ) ) {
+			$this->failJob( $jobId, "Attachment #{$attachment_id} is not an image" );
+			return;
+		}
+
+		if ( ! $force && ! $this->isAltTextMissing( $attachment_id ) ) {
+			$this->completeJob( $jobId, [
+				'skipped'       => true,
+				'attachment_id' => $attachment_id,
+				'reason'        => 'Alt text already exists',
+			] );
+			return;
+		}
+
+		$file_path = get_attached_file( $attachment_id );
+
+		if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+			$this->failJob( $jobId, "Image file missing for attachment #{$attachment_id}" );
+			return;
+		}
+
+		$provider = PluginSettings::get( 'default_provider', '' );
+		$model    = PluginSettings::get( 'default_model', '' );
+
+		if ( empty( $provider ) || empty( $model ) ) {
+			$this->failJob( $jobId, 'No default AI provider/model configured' );
+			return;
+		}
+
+		$file_info = wp_check_filetype( $file_path );
+		$mime_type = $file_info['type'] ?? '';
+
+		$prompt   = $this->buildPrompt( $attachment_id );
+		$messages = [
+			[
+				'role'    => 'user',
+				'content' => [
+					[
+						'type'      => 'file',
+						'file_path' => $file_path,
+						'mime_type' => $mime_type,
+					],
+				],
+			],
+			[
+				'role'    => 'user',
+				'content' => $prompt,
+			],
+		];
+
+		$response = RequestBuilder::build(
+			$messages,
+			$provider,
+			$model,
+			[],
+			'system',
+			[ 'attachment_id' => $attachment_id ]
+		);
+
+		if ( empty( $response['success'] ) ) {
+			$this->failJob( $jobId, 'AI request failed: ' . ( $response['error'] ?? 'Unknown error' ) );
+			return;
+		}
+
+		$content  = $response['data']['content'] ?? '';
+		$alt_text = $this->normalizeAltText( $content );
+
+		if ( empty( $alt_text ) ) {
+			$this->failJob( $jobId, 'AI returned empty alt text' );
+			return;
+		}
+
+		// Save the alt text.
+		$current_alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+		$updated     = update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
+
+		if ( ! $updated && $current_alt !== $alt_text ) {
+			$this->failJob( $jobId, 'Failed to save alt text to post meta' );
+			return;
+		}
+
+		$this->completeJob( $jobId, [
+			'alt_text'      => $alt_text,
+			'attachment_id' => $attachment_id,
+			'completed_at'  => current_time( 'mysql' ),
+		] );
+	}
+
+	/**
+	 * Get the task type identifier.
+	 *
+	 * @return string
+	 */
+	public function getTaskType(): string {
+		return 'alt_text_generation';
+	}
+
+	/**
+	 * Build the AI prompt with contextual information.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @return string Prompt text.
+	 */
+	private function buildPrompt( int $attachment_id ): string {
+		$context_lines = [];
+
+		$title       = get_the_title( $attachment_id );
+		$caption     = wp_get_attachment_caption( $attachment_id );
+		$description = get_post_field( 'post_content', $attachment_id );
+		$parent_id   = (int) get_post_field( 'post_parent', $attachment_id );
+
+		if ( ! empty( $title ) ) {
+			$context_lines[] = 'Attachment title: ' . wp_strip_all_tags( $title );
+		}
+		if ( ! empty( $caption ) ) {
+			$context_lines[] = 'Caption: ' . wp_strip_all_tags( $caption );
+		}
+		if ( ! empty( $description ) ) {
+			$context_lines[] = 'Description: ' . wp_strip_all_tags( $description );
+		}
+		if ( $parent_id > 0 ) {
+			$parent_title = get_the_title( $parent_id );
+			if ( ! empty( $parent_title ) ) {
+				$context_lines[] = 'Parent post title: ' . wp_strip_all_tags( $parent_title );
+			}
+		}
+
+		$prompt = "Write alt text for the provided image using these guidelines:\n"
+			. "- Write 1-2 sentences describing the image\n"
+			. "- Don't start with 'Image of' or 'Photo of'\n"
+			. "- Capitalize first word, end with period\n"
+			. "- Describe what's visually present, focus on purpose\n"
+			. "- For complex images (charts/diagrams), provide brief summary only\n\n"
+			. 'Return ONLY the alt text, nothing else.';
+
+		if ( ! empty( $context_lines ) ) {
+			$prompt .= "\n\nContext:\n" . implode( "\n", $context_lines );
+		}
+
+		return $prompt;
+	}
+
+	/**
+	 * Check if attachment alt text is missing.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @return bool
+	 */
+	private function isAltTextMissing( int $attachment_id ): bool {
+		$alt_text = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+		$alt_text = is_string( $alt_text ) ? trim( $alt_text ) : '';
+
+		return '' === $alt_text;
+	}
+
+	/**
+	 * Normalize AI response to a clean alt text string.
+	 *
+	 * @param string $raw Raw AI response.
+	 * @return string Normalized alt text.
+	 */
+	private function normalizeAltText( string $raw ): string {
+		$alt_text = trim( $raw );
+		$alt_text = trim( $alt_text, " \t\n\r\0\x0B\"'" );
+		$alt_text = sanitize_text_field( $alt_text );
+
+		if ( '' === $alt_text ) {
+			return '';
+		}
+
+		// Capitalize first character.
+		$first_char = mb_substr( $alt_text, 0, 1 );
+		$rest       = mb_substr( $alt_text, 1 );
+		if ( preg_match( '/[a-z]/', $first_char ) ) {
+			$first_char = strtoupper( $first_char );
+		}
+		$alt_text = $first_char . $rest;
+
+		// Ensure trailing period.
+		if ( ! preg_match( '/\.$/', $alt_text ) ) {
+			$alt_text .= '.';
+		}
+
+		return $alt_text;
+	}
+}


### PR DESCRIPTION
## Summary

Centralizes alt text generation as an `AltTextTask` in the System Agent infrastructure, alongside `ImageGenerationTask`. Eliminates the parallel scheduling/job-tracking code that `AltTextAbilities` was doing independently.

## What moved → `AltTextTask.php`

- AI request building (file loading, context gathering, prompt construction)
- Response normalization (capitalization, trailing period, sanitization)
- Alt text saving to `_wp_attachment_image_alt` post meta
- Job completion/failure handling via `SystemTask` base class

## What stayed in `AltTextAbilities.php`

- Ability endpoints (`datamachine/generate-alt-text`, `datamachine/diagnose-alt-text`) — same signatures, same behavior
- `add_attachment` auto-queue hook — now delegates to `SystemAgent::scheduleTask()`
- `isAltTextMissing()` helper (needed for pre-scheduling checks)
- WP-CLI command completely unchanged (calls same ability methods)

## What was removed

- `scheduleAltTextGeneration()` — redundant with `SystemAgent::scheduleTask()`
- `handleGenerateImageAltText()` — logic moved to `AltTextTask::execute()`
- `datamachine_generate_image_alt_text` AS hook — replaced by shared `datamachine_system_agent_handle_task`
- `normalizeAltText()`, `isImageAttachment()` — moved to AltTextTask as private methods

## Stats

- Net: **-91 lines** of duplicated scheduling/job infrastructure
- `AltTextAbilities.php`: 19,486 → ~9,600 bytes (cut in half)
- System Agent now has 2 registered task handlers: `image_generation`, `alt_text_generation`

## Verified

- `wp eval` confirms both task handlers registered in SystemAgent
- WP-CLI `wp datamachine alt-text diagnose` still works
- Ability API surface unchanged

## Files changed

- `inc/Engine/AI/System/Tasks/AltTextTask.php` — new task (222 lines)
- `inc/Engine/AI/System/SystemAgentServiceProvider.php` — registers AltTextTask
- `inc/Abilities/Media/AltTextAbilities.php` — slimmed down, delegates to SystemAgent