### PR TITLE
fix: Include site_url and wp_path in Agent Ping payload

### DIFF
--- a/inc/Abilities/AgentPing/SendPingAbility.php
+++ b/inc/Abilities/AgentPing/SendPingAbility.php
@@ -343,6 +343,8 @@ class SendPingAbility {
 				'pipeline_id'  => $pipeline_id,
 				'job_id'       => $job_id,
 				'from_queue'   => $from_queue,
+				'site_url'     => site_url(),
+				'wp_path'      => ABSPATH,
 			),
 			'timestamp' => gmdate( 'c' ),
 		);


### PR DESCRIPTION
Two-liner. Adds `site_url` and `wp_path` (ABSPATH) to the Agent Ping context payload so receiving agents know where WordPress lives without hardcoding `--path`.

Before: agents needed `--path=/var/www/site.com` in every WP-CLI command in flow prompts.
After: agents can read `context.wp_path` from the ping payload.

Only affects non-Discord webhook payloads (Discord payloads are plaintext, no context object).

Fixes #139