### PR TITLE
fix: Defer admin page filter registration to init hook

### DIFF
--- a/inc/Core/Admin/Pages/Jobs/JobsFilters.php
+++ b/inc/Core/Admin/Pages/Jobs/JobsFilters.php
@@ -80,4 +80,4 @@ function datamachine_register_jobs_admin_page_filters() {
 }
 
 // Auto-register when file loads - achieving complete self-containment
-datamachine_register_jobs_admin_page_filters();
+add_action( 'init', __NAMESPACE__ . '\\datamachine_register_jobs_admin_page_filters' );

--- a/inc/Core/Admin/Pages/Logs/LogsFilters.php
+++ b/inc/Core/Admin/Pages/Logs/LogsFilters.php
@@ -74,4 +74,4 @@ function datamachine_register_logs_admin_page_filters() {
 }
 
 // Auto-register when file loads - achieving complete self-containment
-datamachine_register_logs_admin_page_filters();
+add_action( 'init', __NAMESPACE__ . '\\datamachine_register_logs_admin_page_filters' );

--- a/inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php
+++ b/inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php
@@ -157,4 +157,4 @@ function datamachine_get_chubes_ai_tools_for_react() {
 }
 
 // Auto-register when file loads - achieving complete self-containment
-datamachine_register_pipelines_admin_page_filters();
+add_action( 'init', __NAMESPACE__ . '\\datamachine_register_pipelines_admin_page_filters' );

--- a/inc/Core/Admin/Settings/SettingsFilters.php
+++ b/inc/Core/Admin/Settings/SettingsFilters.php
@@ -167,4 +167,4 @@ function datamachine_sanitize_settings( $input ) {
 	return $sanitized;
 }
 
-datamachine_register_settings_admin_page_filters();
+add_action( 'init', 'datamachine_register_settings_admin_page_filters' );


### PR DESCRIPTION
Admin page filter files were auto-registering at file inclusion time with `__('...', 'data-machine')` calls, triggering the WP 6.7+ `_load_textdomain_just_in_time` notice.

Wraps the auto-registration in `add_action('init', ...)` for:
- `LogsFilters.php`
- `JobsFilters.php`
- `PipelinesFilters.php`
- `SettingsFilters.php`

**Note:** This is a partial fix for #141. The notice still appears — there's at least one more source I haven't identified yet (possibly WP core's plugin header translation). The deferred files are correct regardless.

Ref #141