### PR TITLE
fix: defer ability instantiation to init to resolve textdomain notice

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -168,26 +168,29 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/Media/ImageGenerationAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/AgentPingAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/TaxonomyAbilities.php';
-	new \DataMachine\Abilities\AuthAbilities();
-	new \DataMachine\Abilities\FileAbilities();
-	new \DataMachine\Abilities\FlowAbilities();
-	new \DataMachine\Abilities\FlowStepAbilities();
-	new \DataMachine\Abilities\JobAbilities();
-	new \DataMachine\Abilities\LogAbilities();
-	new \DataMachine\Abilities\PostQueryAbilities();
-	new \DataMachine\Abilities\PipelineAbilities();
-	new \DataMachine\Abilities\PipelineStepAbilities();
-	new \DataMachine\Abilities\ProcessedItemsAbilities();
-	new \DataMachine\Abilities\SettingsAbilities();
-	new \DataMachine\Abilities\HandlerAbilities();
-	new \DataMachine\Abilities\StepTypeAbilities();
-	new \DataMachine\Abilities\LocalSearchAbilities();
-	new \DataMachine\Abilities\SystemAbilities();
-	new \DataMachine\Engine\AI\System\SystemAgentServiceProvider();
-	new \DataMachine\Abilities\Media\AltTextAbilities();
-	new \DataMachine\Abilities\Media\ImageGenerationAbilities();
-	new \DataMachine\Abilities\AgentPingAbilities();
-	new \DataMachine\Abilities\TaxonomyAbilities();
+	// Defer ability instantiation to init so translations are loaded.
+	add_action( 'init', function () {
+		new \DataMachine\Abilities\AuthAbilities();
+		new \DataMachine\Abilities\FileAbilities();
+		new \DataMachine\Abilities\FlowAbilities();
+		new \DataMachine\Abilities\FlowStepAbilities();
+		new \DataMachine\Abilities\JobAbilities();
+		new \DataMachine\Abilities\LogAbilities();
+		new \DataMachine\Abilities\PostQueryAbilities();
+		new \DataMachine\Abilities\PipelineAbilities();
+		new \DataMachine\Abilities\PipelineStepAbilities();
+		new \DataMachine\Abilities\ProcessedItemsAbilities();
+		new \DataMachine\Abilities\SettingsAbilities();
+		new \DataMachine\Abilities\HandlerAbilities();
+		new \DataMachine\Abilities\StepTypeAbilities();
+		new \DataMachine\Abilities\LocalSearchAbilities();
+		new \DataMachine\Abilities\SystemAbilities();
+		new \DataMachine\Engine\AI\System\SystemAgentServiceProvider();
+		new \DataMachine\Abilities\Media\AltTextAbilities();
+		new \DataMachine\Abilities\Media\ImageGenerationAbilities();
+		new \DataMachine\Abilities\AgentPingAbilities();
+		new \DataMachine\Abilities\TaxonomyAbilities();
+	} );
 }
 
 


### PR DESCRIPTION
Wraps all Abilities and ServiceProvider instantiation in an `add_action('init')` callback so that `__()` calls in ability registration happen after translations are loaded.

Fixes the `_load_textdomain_just_in_time` notice that appears on every WP-CLI call (and likely admin pages) on WP 6.7+.

The `require_once` lines (class file loading) remain at `plugins_loaded` — only the `new` instantiation calls are deferred to `init`.

Closes #141