### PR TITLE
feat: Bing Webmaster Tools analytics connector (issue #131)

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -59,6 +59,7 @@ require_once __DIR__ . '/inc/Engine/AI/Tools/Global/LocalSearch.php';
 require_once __DIR__ . '/inc/Engine/AI/Tools/Global/WebFetch.php';
 require_once __DIR__ . '/inc/Engine/AI/Tools/Global/WordPressPostReader.php';
 require_once __DIR__ . '/inc/Engine/AI/Tools/Global/ImageGeneration.php';
+require_once __DIR__ . '/inc/Engine/AI/Tools/Global/BingWebmaster.php';
 require_once __DIR__ . '/inc/Engine/AI/Tools/Global/QueueValidator.php';
 require_once __DIR__ . '/inc/Engine/AI/System/Tasks/SystemTask.php';
 require_once __DIR__ . '/inc/Engine/AI/System/Tasks/ImageGenerationTask.php';
@@ -166,6 +167,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/SystemAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/AltTextAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/ImageGenerationAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/Analytics/BingWebmasterAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/AgentPingAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/TaxonomyAbilities.php';
 	// Defer ability instantiation to init so translations are loaded.
@@ -188,6 +190,7 @@ function datamachine_run_datamachine_plugin() {
 		new \DataMachine\Engine\AI\System\SystemAgentServiceProvider();
 		new \DataMachine\Abilities\Media\AltTextAbilities();
 		new \DataMachine\Abilities\Media\ImageGenerationAbilities();
+		new \DataMachine\Abilities\Analytics\BingWebmasterAbilities();
 		new \DataMachine\Abilities\AgentPingAbilities();
 		new \DataMachine\Abilities\TaxonomyAbilities();
 	} );

--- a/inc/Abilities/Analytics/BingWebmasterAbilities.php
+++ b/inc/Abilities/Analytics/BingWebmasterAbilities.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Bing Webmaster Tools Abilities
+ *
+ * Primitive ability for Bing Webmaster API analytics.
+ * All Bing Webmaster data — tools, CLI, REST, chat — flows through this ability.
+ *
+ * @package DataMachine\Abilities\Analytics
+ * @since 0.23.0
+ */
+
+namespace DataMachine\Abilities\Analytics;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+
+defined( 'ABSPATH' ) || exit;
+
+class BingWebmasterAbilities {
+
+	/**
+	 * Option key for storing Bing Webmaster configuration.
+	 *
+	 * @var string
+	 */
+	const CONFIG_OPTION = 'datamachine_bing_webmaster_config';
+
+	/**
+	 * API endpoint mapping for supported actions.
+	 *
+	 * @var array
+	 */
+	const ACTION_ENDPOINTS = [
+		'query_stats'   => 'GetQueryStats',
+		'traffic_stats' => 'GetRankAndTrafficStats',
+		'page_stats'    => 'GetPageStats',
+		'crawl_stats'   => 'GetCrawlStats',
+	];
+
+	/**
+	 * Default result limit.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_LIMIT = 20;
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/bing-webmaster',
+				[
+					'label'               => 'Bing Webmaster Tools',
+					'description'         => 'Fetch search analytics data from Bing Webmaster Tools API',
+					'category'            => 'datamachine',
+					'input_schema'        => [
+						'type'       => 'object',
+						'required'   => [ 'action' ],
+						'properties' => [
+							'action'   => [
+								'type'        => 'string',
+								'description' => 'Analytics action: query_stats, traffic_stats, page_stats, crawl_stats.',
+							],
+							'site_url' => [
+								'type'        => 'string',
+								'description' => 'Site URL to query (defaults to configured site URL).',
+							],
+							'limit'    => [
+								'type'        => 'integer',
+								'description' => 'Maximum number of results to return (default: 20).',
+							],
+						],
+					],
+					'output_schema'       => [
+						'type'       => 'object',
+						'properties' => [
+							'success'       => [ 'type' => 'boolean' ],
+							'action'        => [ 'type' => 'string' ],
+							'results_count' => [ 'type' => 'integer' ],
+							'results'       => [ 'type' => 'array' ],
+							'error'         => [ 'type' => 'string' ],
+						],
+					],
+					'execute_callback'    => [ self::class, 'fetchStats' ],
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => [ 'show_in_rest' => false ],
+				]
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Fetch stats from Bing Webmaster Tools API.
+	 *
+	 * @param array $input Ability input.
+	 * @return array Ability response.
+	 */
+	public static function fetchStats( array $input ): array {
+		$action = sanitize_text_field( $input['action'] ?? '' );
+
+		if ( empty( $action ) || ! isset( self::ACTION_ENDPOINTS[ $action ] ) ) {
+			return [
+				'success' => false,
+				'error'   => 'Invalid action. Must be one of: ' . implode( ', ', array_keys( self::ACTION_ENDPOINTS ) ),
+			];
+		}
+
+		$config = self::get_config();
+
+		if ( empty( $config['api_key'] ) ) {
+			return [
+				'success' => false,
+				'error'   => 'Bing Webmaster Tools not configured. Add an API key in Settings.',
+			];
+		}
+
+		$site_url = ! empty( $input['site_url'] ) ? sanitize_text_field( $input['site_url'] ) : ( $config['site_url'] ?? get_site_url() );
+		$limit    = ! empty( $input['limit'] ) ? (int) $input['limit'] : self::DEFAULT_LIMIT;
+		$endpoint = self::ACTION_ENDPOINTS[ $action ];
+
+		$request_url = add_query_arg(
+			[
+				'apikey'  => $config['api_key'],
+				'siteUrl' => $site_url,
+			],
+			'https://ssl.bing.com/webmaster/api.svc/json/' . $endpoint
+		);
+
+		$result = HttpClient::get(
+			$request_url,
+			[
+				'timeout' => 15,
+				'headers' => [
+					'Accept' => 'application/json',
+				],
+				'context' => 'Bing Webmaster Tools Ability',
+			]
+		);
+
+		if ( ! $result['success'] ) {
+			return [
+				'success' => false,
+				'error'   => 'Failed to connect to Bing Webmaster API: ' . ( $result['error'] ?? 'Unknown error' ),
+			];
+		}
+
+		$data = json_decode( $result['data'], true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return [
+				'success' => false,
+				'error'   => 'Failed to parse Bing Webmaster API response.',
+			];
+		}
+
+		$results = $data['d'] ?? [];
+
+		if ( is_array( $results ) && count( $results ) > $limit ) {
+			$results = array_slice( $results, 0, $limit );
+		}
+
+		return [
+			'success'       => true,
+			'action'        => $action,
+			'results_count' => is_array( $results ) ? count( $results ) : 0,
+			'results'       => $results,
+		];
+	}
+
+	/**
+	 * Check if Bing Webmaster Tools is configured.
+	 *
+	 * @return bool
+	 */
+	public static function is_configured(): bool {
+		$config = self::get_config();
+		return ! empty( $config['api_key'] );
+	}
+
+	/**
+	 * Get stored configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_config(): array {
+		return get_site_option( self::CONFIG_OPTION, [] );
+	}
+}

--- a/inc/Engine/AI/Tools/Global/BingWebmaster.php
+++ b/inc/Engine/AI/Tools/Global/BingWebmaster.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Bing Webmaster Tools — AI agent wrapper for the bing-webmaster ability.
+ *
+ * Provides the AI-callable tool interface and settings page configuration.
+ * Delegates actual data fetching to the datamachine/bing-webmaster ability.
+ *
+ * @package DataMachine\Engine\AI\Tools\Global
+ */
+
+namespace DataMachine\Engine\AI\Tools\Global;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Abilities\Analytics\BingWebmasterAbilities;
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+class BingWebmaster extends BaseTool {
+
+	public function __construct() {
+		$this->registerConfigurationHandlers( 'bing_webmaster' );
+		$this->registerGlobalTool( 'bing_webmaster', [ $this, 'getToolDefinition' ] );
+	}
+
+	/**
+	 * Execute Bing Webmaster query by delegating to the ability.
+	 *
+	 * @param array $parameters Contains 'action' and optional 'site_url', 'limit'.
+	 * @param array $tool_def   Tool definition (unused).
+	 * @return array Result from the ability.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = [] ): array {
+		$ability = wp_get_ability( 'datamachine/bing-webmaster' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'Bing Webmaster ability not registered. Ensure WordPress 6.9+ and BingWebmasterAbilities is loaded.',
+				'bing_webmaster'
+			);
+		}
+
+		$result = $ability->execute( $parameters );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse(
+				$result->get_error_message(),
+				'bing_webmaster'
+			);
+		}
+
+		if ( ! empty( $result['error'] ) ) {
+			return $this->buildErrorResponse(
+				$result['error'],
+				'bing_webmaster'
+			);
+		}
+
+		$result['tool_name'] = 'bing_webmaster';
+		return $result;
+	}
+
+	/**
+	 * Get tool definition for AI agents.
+	 *
+	 * @return array Tool definition array.
+	 */
+	public function getToolDefinition(): array {
+		return [
+			'class'           => __CLASS__,
+			'method'          => 'handle_tool_call',
+			'description'     => 'Fetch search analytics data from Bing Webmaster Tools. Returns query performance stats, traffic rankings, page-level stats, or crawl information for the configured site. Use to analyze search visibility, top queries, and crawl health on Bing.',
+			'requires_config' => true,
+			'parameters'      => [
+				'action'   => [
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Analytics action to perform: query_stats (search query performance), traffic_stats (rank and traffic data), page_stats (per-page metrics), crawl_stats (crawl information).',
+				],
+				'site_url' => [
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Site URL to query. Defaults to the configured site URL.',
+				],
+				'limit'    => [
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Maximum number of results to return (default: 20).',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Check if Bing Webmaster Tools is configured.
+	 *
+	 * @return bool
+	 */
+	public static function is_configured(): bool {
+		return BingWebmasterAbilities::is_configured();
+	}
+
+	/**
+	 * Get stored configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_config(): array {
+		return BingWebmasterAbilities::get_config();
+	}
+
+	/**
+	 * Check if this tool is configured.
+	 *
+	 * @param bool   $configured Current status.
+	 * @param string $tool_id    Tool identifier.
+	 * @return bool
+	 */
+	public function check_configuration( $configured, $tool_id ) {
+		if ( 'bing_webmaster' !== $tool_id ) {
+			return $configured;
+		}
+
+		return self::is_configured();
+	}
+
+	/**
+	 * Get current configuration.
+	 *
+	 * @param array  $config  Current config.
+	 * @param string $tool_id Tool identifier.
+	 * @return array
+	 */
+	public function get_configuration( $config, $tool_id ) {
+		if ( 'bing_webmaster' !== $tool_id ) {
+			return $config;
+		}
+
+		return self::get_config();
+	}
+
+	/**
+	 * Save configuration from settings page.
+	 *
+	 * @param string $tool_id     Tool identifier.
+	 * @param array  $config_data Configuration data.
+	 */
+	public function save_configuration( $tool_id, $config_data ) {
+		if ( 'bing_webmaster' !== $tool_id ) {
+			return;
+		}
+
+		$api_key  = sanitize_text_field( $config_data['api_key'] ?? '' );
+		$site_url = esc_url_raw( $config_data['site_url'] ?? '' );
+
+		if ( empty( $api_key ) ) {
+			wp_send_json_error( [ 'message' => __( 'Bing Webmaster API key is required', 'data-machine' ) ] );
+			return;
+		}
+
+		$config = [
+			'api_key'  => $api_key,
+			'site_url' => $site_url,
+		];
+
+		if ( update_site_option( BingWebmasterAbilities::CONFIG_OPTION, $config ) ) {
+			wp_send_json_success(
+				[
+					'message'    => __( 'Bing Webmaster Tools configuration saved successfully', 'data-machine' ),
+					'configured' => true,
+				]
+			);
+		} else {
+			wp_send_json_error( [ 'message' => __( 'Failed to save configuration', 'data-machine' ) ] );
+		}
+	}
+
+	/**
+	 * Get configuration field definitions for the settings page.
+	 *
+	 * @param array  $fields  Current fields.
+	 * @param string $tool_id Tool identifier.
+	 * @return array
+	 */
+	public function get_config_fields( $fields = [], $tool_id = '' ) {
+		if ( ! empty( $tool_id ) && 'bing_webmaster' !== $tool_id ) {
+			return $fields;
+		}
+
+		return [
+			'api_key'  => [
+				'type'        => 'password',
+				'label'       => __( 'Bing Webmaster API Key', 'data-machine' ),
+				'placeholder' => __( 'Enter your Bing Webmaster API key', 'data-machine' ),
+				'required'    => true,
+				'description' => __( 'Get your API key from Bing Webmaster Tools → Settings → API Access', 'data-machine' ),
+			],
+			'site_url' => [
+				'type'        => 'text',
+				'label'       => __( 'Site URL', 'data-machine' ),
+				'placeholder' => 'https://yoursite.com',
+				'required'    => false,
+				'description' => __( 'The site URL registered in Bing Webmaster Tools. Defaults to your WordPress site URL.', 'data-machine' ),
+			],
+		];
+	}
+}
+
+// Self-register the tool.
+new BingWebmaster();


### PR DESCRIPTION
## Bing Webmaster Tools Connector

Adds a new ability + global tool for fetching search analytics from Bing Webmaster Tools API.

### New Files
- **`inc/Abilities/Analytics/BingWebmasterAbilities.php`** — Ability primitive (`datamachine/bing-webmaster`) that makes GET requests to the Bing Webmaster API
- **`inc/Engine/AI/Tools/Global/BingWebmaster.php`** — Global tool wrapper with settings page config handlers

### Supported Actions
- `query_stats` — Search query performance (GetQueryStats)
- `traffic_stats` — Rank and traffic data (GetRankAndTrafficStats)
- `page_stats` — Per-page metrics (GetPageStats)
- `crawl_stats` — Crawl information (GetCrawlStats)

### Configuration
- **API Key** (required) — Bing Webmaster Tools API key
- **Site URL** (optional) — Defaults to WordPress site URL

### Pattern
Follows the same ability + tool pattern as ImageGeneration. Uses `DataMachine\Core\HttpClient` for requests.

Closes #131