### PR TITLE
Fix WP-CLI settings set fatal when ability returns WP_Error

### DIFF
--- a/tests/Unit/Cli/SettingsCommandTest.php
+++ b/tests/Unit/Cli/SettingsCommandTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Settings Command Tests
+ *
+ * @package DataMachine\Tests\Unit\Cli
+ */
+
+namespace DataMachine\Tests\Unit\Cli;
+
+use DataMachine\Abilities\SettingsAbilities;
+use DataMachine\Cli\Commands\SettingsCommand;
+use WP_UnitTestCase;
+
+class SettingsCommandTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		new SettingsAbilities();
+	}
+
+	public function test_set_handles_wp_error_without_fatal(): void {
+		ob_start();
+
+		$command = new SettingsCommand();
+		$command->set( [ 'max_turns', 'not-an-integer' ], [] );
+
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Error:', $output );
+	}
+
+	public function test_set_parses_enabled_tools_comma_list(): void {
+		ob_start();
+
+		$command = new SettingsCommand();
+		$command->set( [ 'enabled_tools', 'example-tool-a,example-tool-b' ], [] );
+
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Success:', $output );
+
+		$settings = get_option( 'datamachine_settings', [] );
+		$this->assertArrayHasKey( 'enabled_tools', $settings );
+		$this->assertSame(
+			[ 'example-tool-a' => true, 'example-tool-b' => true ],
+			$settings['enabled_tools']
+		);
+	}
+}


### PR DESCRIPTION
Fixes #152.

### What changed
- Guard against `WP_Error` results from the Abilities API in `wp datamachine settings set` (prevents fatal when a schema validation error occurs).
- Improve CLI value parsing:
  - JSON decode for array/object settings.
  - Comma-separated convenience format for `enabled_tools`.
- Add unit test covering WP_Error handling + enabled_tools parsing.

### Repro
Before:
- Run: wp datamachine settings set enabled_tools foo
- Result: fatal error `Cannot use object of type WP_Error as array`

After:
- Command returns a WP-CLI error message (no fatal).