### PR TITLE
Fix ImageGenerationTask undefined $params in handleSuccess()

### DIFF
--- a/inc/Engine/AI/System/Tasks/ImageGenerationTask.php
+++ b/inc/Engine/AI/System/Tasks/ImageGenerationTask.php
@@ -99,7 +99,7 @@ class ImageGenerationTask extends SystemTask {
 
 		switch ( $status ) {
 			case 'succeeded':
-				$this->handleSuccess( $jobId, $status_data, $model, $prompt, $aspect_ratio );
+				$this->handleSuccess( $jobId, $status_data, $model, $prompt, $aspect_ratio, $params );
 				break;
 
 			case 'failed':
@@ -129,8 +129,9 @@ class ImageGenerationTask extends SystemTask {
 	 * @param string $model       Model used for generation.
 	 * @param string $prompt      Original prompt.
 	 * @param string $aspectRatio Original aspect ratio.
+	 * @param array  $params      Task params (contains context.pipeline_job_id).
 	 */
-	private function handleSuccess( int $jobId, array $statusData, string $model, string $prompt, string $aspectRatio ): void {
+	protected function handleSuccess( int $jobId, array $statusData, string $model, string $prompt, string $aspectRatio, array $params ): void {
 		$output = $statusData['output'] ?? null;
 
 		// Handle different output formats (string URL or array)
@@ -213,7 +214,7 @@ class ImageGenerationTask extends SystemTask {
 	 * @param int   $attachmentId WordPress attachment ID.
 	 * @param array $params       Task params (contains context.pipeline_job_id).
 	 */
-	private function trySetFeaturedImage( int $jobId, int $attachmentId, array $params ): void {
+	protected function trySetFeaturedImage( int $jobId, int $attachmentId, array $params ): void {
 		$context         = $params['context'] ?? [];
 		$pipeline_job_id = $context['pipeline_job_id'] ?? 0;
 
@@ -326,7 +327,7 @@ class ImageGenerationTask extends SystemTask {
 	 * @param string $model     Model used for generation.
 	 * @return array|\WP_Error Array with attachment_id and attachment_url on success, WP_Error on failure.
 	 */
-	private function sideloadImage( string $image_url, string $prompt, string $model ): array|\WP_Error {
+	protected function sideloadImage( string $image_url, string $prompt, string $model ): array|\WP_Error {
 		// Ensure required WordPress functions are available
 		if ( ! function_exists( 'download_url' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/tests/Unit/AI/System/Tasks/ImageGenerationTaskTest.php
+++ b/tests/Unit/AI/System/Tasks/ImageGenerationTaskTest.php
@@ -10,6 +10,29 @@ namespace DataMachine\Tests\Unit\AI\System\Tasks;
 use DataMachine\Engine\AI\System\Tasks\ImageGenerationTask;
 use WP_UnitTestCase;
 
+class TestableImageGenerationTask extends ImageGenerationTask {
+	public array $set_featured_image_calls = [];
+
+	public function callHandleSuccess( int $job_id, array $status_data, string $model, string $prompt, string $aspect_ratio, array $params ): void {
+		$this->handleSuccess( $job_id, $status_data, $model, $prompt, $aspect_ratio, $params );
+	}
+
+	protected function sideloadImage( string $image_url, string $prompt, string $model ): array|\WP_Error {
+		return [
+			'attachment_id'  => 123,
+			'attachment_url' => 'https://example.com/image.jpg',
+		];
+	}
+
+	protected function trySetFeaturedImage( int $jobId, int $attachmentId, array $params ): void {
+		$this->set_featured_image_calls[] = [
+			'job_id'         => $jobId,
+			'attachment_id'  => $attachmentId,
+			'params'         => $params,
+		];
+	}
+}
+
 class ImageGenerationTaskTest extends WP_UnitTestCase {
 
 	private ImageGenerationTask $task;
@@ -66,5 +89,41 @@ class ImageGenerationTaskTest extends WP_UnitTestCase {
 
 		$job = $jobs_db->get_job( (int) $job_id );
 		$this->assertStringContainsString( 'failed', strtolower( $job['status'] ?? '' ) );
+	}
+
+	public function test_handle_success_passes_params_to_try_set_featured_image(): void {
+		$jobs_db = new \DataMachine\Core\Database\Jobs\Jobs();
+		$job_id  = $jobs_db->create_job( [
+			'pipeline_id' => 'direct',
+			'flow_id'     => 'direct',
+			'source'      => 'system',
+			'label'       => 'Test Image Gen Success',
+		] );
+
+		if ( ! $job_id ) {
+			$this->markTestSkipped( 'Could not create test job.' );
+		}
+
+		$task = new TestableImageGenerationTask();
+
+		$params = [
+			'context' => [
+				'pipeline_job_id' => 999,
+			],
+		];
+
+		$task->callHandleSuccess(
+			(int) $job_id,
+			[ 'output' => 'https://example.com/remote-image.jpg' ],
+			'test-model',
+			'test prompt',
+			'3:4',
+			$params
+		);
+
+		$this->assertCount( 1, $task->set_featured_image_calls );
+		$this->assertSame( (int) $job_id, $task->set_featured_image_calls[0]['job_id'] );
+		$this->assertSame( 123, $task->set_featured_image_calls[0]['attachment_id'] );
+		$this->assertSame( $params, $task->set_featured_image_calls[0]['params'] );
 	}
 }


### PR DESCRIPTION
Fixes #153.

`ImageGenerationTask::handleSuccess()` was passing an undefined `$params` variable into `trySetFeaturedImage()`, which can fatal/TypeError on the success path.

### What changed
- Pass the actual task params (from `get_task_params()`) through to `trySetFeaturedImage()`.
- Add a regression unit test to ensure `handleSuccess()` calls `trySetFeaturedImage()` with the expected params.