### PR TITLE
fix: use Replicate models endpoint for image generation (fixes #159)

### DIFF
--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -179,7 +179,7 @@ class ImageGenerationAbilities {
 
 		// Start Replicate prediction.
 		$result = HttpClient::post(
-			'https://api.replicate.com/v1/predictions',
+			"https://api.replicate.com/v1/models/{$model}/predictions",
 			[
 				'timeout' => 30,
 				'headers' => [
@@ -187,7 +187,6 @@ class ImageGenerationAbilities {
 					'Content-Type'  => 'application/json',
 				],
 				'body'    => wp_json_encode( [
-					'model' => $model,
 					'input' => $input_params,
 				] ),
 				'context' => 'Image Generation Ability',


### PR DESCRIPTION
## Problem

`generateImage()` POSTs to `https://api.replicate.com/v1/predictions` with a `model` field in the body. Replicate returns 422 because that endpoint requires a `version` hash, not a model identifier.

## Fix

- Changed endpoint to `https://api.replicate.com/v1/models/{model}/predictions` (the models endpoint resolves the latest version automatically)
- Removed `model` from the request body since it's now in the URL

Fixes #159