### PR TITLE
feat: Webhook Gate step type — pause pipeline until external webhook fires

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -233,6 +233,7 @@ function datamachine_load_step_types() {
 	new \DataMachine\Core\Steps\Update\UpdateStep();
 	new \DataMachine\Core\Steps\AI\AIStep();
 	new \DataMachine\Core\Steps\AgentPing\AgentPingStep();
+	new \DataMachine\Core\Steps\WebhookGate\WebhookGateStep();
 }
 
 /**

--- a/inc/Core/JobStatus.php
+++ b/inc/Core/JobStatus.php
@@ -21,6 +21,7 @@ class JobStatus {
 	// Base status constants
 	public const PENDING            = 'pending';
 	public const PROCESSING         = 'processing';
+	public const WAITING            = 'waiting';
 	public const COMPLETED          = 'completed';
 	public const FAILED             = 'failed';
 	public const COMPLETED_NO_ITEMS = 'completed_no_items';
@@ -180,6 +181,28 @@ class JobStatus {
 	}
 
 	/**
+	 * Check if this is a waiting status (pipeline parked at webhook gate).
+	 */
+	public function isWaiting(): bool {
+		return $this->baseStatus === self::WAITING;
+	}
+
+	/**
+	 * Check if a status string represents waiting.
+	 */
+	public static function isStatusWaiting( string $status ): bool {
+		$base = self::parseBaseStatus( $status );
+		return $base === self::WAITING;
+	}
+
+	/**
+	 * Create a waiting status.
+	 */
+	public static function waiting(): self {
+		return new self( self::WAITING );
+	}
+
+	/**
 	 * Check if this is an agent_skipped status.
 	 */
 	public function isAgentSkipped(): bool {
@@ -253,6 +276,10 @@ class JobStatus {
 
 		if ( str_starts_with( $status, self::PROCESSING ) ) {
 			return self::PROCESSING;
+		}
+
+		if ( str_starts_with( $status, self::WAITING ) ) {
+			return self::WAITING;
 		}
 
 		if ( str_starts_with( $status, self::PENDING ) ) {

--- a/inc/Core/Steps/WebhookGate/WebhookGateSettings.php
+++ b/inc/Core/Steps/WebhookGate/WebhookGateSettings.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Webhook Gate Settings - Configuration fields for webhook gate steps.
+ *
+ * @package DataMachine\Core\Steps\WebhookGate
+ * @since 0.25.0
+ */
+
+namespace DataMachine\Core\Steps\WebhookGate;
+
+use DataMachine\Core\Steps\Settings\SettingsHandler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class WebhookGateSettings extends SettingsHandler {
+
+	/**
+	 * Get configuration fields for the webhook gate step.
+	 *
+	 * @return array
+	 */
+	public static function get_fields(): array {
+		return [
+			'timeout_hours' => [
+				'type'        => 'number',
+				'label'       => 'Timeout (hours)',
+				'description' => 'How long to wait for the webhook before failing the job. 0 = no timeout (defaults to 7-day token expiry).',
+				'default'     => 0,
+				'min'         => 0,
+				'max'         => 8760,
+			],
+			'description' => [
+				'type'        => 'text',
+				'label'       => 'Description',
+				'description' => 'Human-readable description of what this gate is waiting for.',
+				'default'     => '',
+			],
+		];
+	}
+}

--- a/inc/Core/Steps/WebhookGate/WebhookGateStep.php
+++ b/inc/Core/Steps/WebhookGate/WebhookGateStep.php
@@ -1,0 +1,386 @@
+<?php
+/**
+ * Webhook Gate Step - Pause pipeline until external webhook fires.
+ *
+ * Parks the pipeline in a "waiting" state and generates a unique webhook URL.
+ * When the webhook receives a POST, the pipeline resumes from the next step
+ * with the webhook payload injected as data packets.
+ *
+ * This is a handler-free step type. No handler_config or handler_slug needed.
+ *
+ * @package DataMachine\Core\Steps\WebhookGate
+ * @since 0.25.0
+ */
+
+namespace DataMachine\Core\Steps\WebhookGate;
+
+use DataMachine\Core\DataPacket;
+use DataMachine\Core\JobStatus;
+use DataMachine\Core\Steps\Step;
+use DataMachine\Core\Steps\StepTypeRegistrationTrait;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class WebhookGateStep extends Step {
+
+	use StepTypeRegistrationTrait;
+
+	/**
+	 * Initialize Webhook Gate step.
+	 */
+	public function __construct() {
+		parent::__construct( 'webhook_gate' );
+
+		self::registerStepType(
+			slug: 'webhook_gate',
+			label: 'Webhook Gate',
+			description: 'Pause pipeline and wait for an external webhook before continuing',
+			class: self::class,
+			position: 70,
+			usesHandler: false,
+			hasPipelineConfig: false,
+			consumeAllPackets: false,
+			stepSettings: [
+				'config_type' => 'inline',
+				'modal_type'  => 'configure-step',
+				'button_text' => 'Configure',
+				'label'       => 'Webhook Gate Configuration',
+			],
+			showSettingsDisplay: false
+		);
+
+		self::registerStepSettings();
+		self::registerWebhookEndpoint();
+		self::registerTimeoutHandler();
+	}
+
+	/**
+	 * Register Webhook Gate settings class for UI display.
+	 */
+	private static function registerStepSettings(): void {
+		static $registered = false;
+		if ( $registered ) {
+			return;
+		}
+		$registered = true;
+
+		add_filter(
+			'datamachine_handler_settings',
+			function ( $all_settings, $handler_slug = null ) {
+				if ( null === $handler_slug || 'webhook_gate' === $handler_slug ) {
+					$all_settings['webhook_gate'] = new WebhookGateSettings();
+				}
+				return $all_settings;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Register the webhook gate timeout handler.
+	 */
+	private static function registerTimeoutHandler(): void {
+		static $timeout_registered = false;
+		if ( $timeout_registered ) {
+			return;
+		}
+		$timeout_registered = true;
+
+		add_action(
+			'datamachine_webhook_gate_timeout',
+			function ( $job_id, $token ) {
+				$job_id = (int) $job_id;
+
+				// Only fail the job if it's still waiting.
+				$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
+				$job     = $db_jobs->get_job( $job_id );
+
+				if ( ! $job || 'waiting' !== ( $job['status'] ?? '' ) ) {
+					return; // Job already resumed or failed.
+				}
+
+				// Clean up the transient.
+				delete_transient( 'dm_webhook_gate_' . $token );
+
+				// Fail the job.
+				do_action(
+					'datamachine_fail_job',
+					$job_id,
+					'webhook_gate_timeout',
+					[
+						'flow_step_id'  => '',
+						'error_message' => 'Webhook gate timed out waiting for inbound webhook.',
+					]
+				);
+
+				do_action(
+					'datamachine_log',
+					'warning',
+					"Webhook Gate: Timed out for job #{$job_id}",
+					[ 'job_id' => $job_id, 'token' => $token ]
+				);
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Register the inbound webhook REST endpoint.
+	 */
+	private static function registerWebhookEndpoint(): void {
+		static $endpoint_registered = false;
+		if ( $endpoint_registered ) {
+			return;
+		}
+		$endpoint_registered = true;
+
+		add_action( 'rest_api_init', function () {
+			register_rest_route(
+				'datamachine/v1',
+				'/webhook/(?P<token>[a-f0-9]{64})',
+				[
+					'methods'             => 'POST',
+					'callback'            => [ __CLASS__, 'handleInboundWebhook' ],
+					'permission_callback' => '__return_true', // Auth is via the token itself
+					'args'                => [
+						'token' => [
+							'required'          => true,
+							'type'              => 'string',
+							'validate_callback' => function ( $value ) {
+								return (bool) preg_match( '/^[a-f0-9]{64}$/', $value );
+							},
+						],
+					],
+				]
+			);
+		} );
+	}
+
+	/**
+	 * Validate Webhook Gate step configuration.
+	 *
+	 * @return bool
+	 */
+	protected function validateStepConfiguration(): bool {
+		// No required configuration — timeout is optional.
+		return true;
+	}
+
+	/**
+	 * Execute Webhook Gate step logic.
+	 *
+	 * Generates a unique token, stores resume context in engine_data,
+	 * sets job status to "waiting", and returns a success packet.
+	 *
+	 * The engine's status override mechanism will see "waiting" and
+	 * park the job without scheduling the next step.
+	 *
+	 * @return array
+	 */
+	protected function executeStep(): array {
+		$token          = bin2hex( random_bytes( 32 ) ); // 64-char hex token
+		$handler_config = $this->getHandlerConfig();
+		$timeout_hours  = (int) ( $handler_config['timeout_hours'] ?? 0 );
+
+		// Determine the next step ID for resumption.
+		$navigator      = new \DataMachine\Engine\StepNavigator();
+		$payload        = [
+			'job_id'       => $this->job_id,
+			'flow_step_id' => $this->flow_step_id,
+			'data'         => $this->dataPackets,
+			'engine'       => $this->engine,
+		];
+		$next_step_id   = $navigator->get_next_flow_step_id( $this->flow_step_id, $payload );
+
+		// Store webhook gate context in engine_data.
+		datamachine_merge_engine_data(
+			$this->job_id,
+			[
+				'webhook_gate' => [
+					'token'            => $token,
+					'flow_step_id'     => $this->flow_step_id,
+					'next_flow_step_id' => $next_step_id,
+					'created_at'       => gmdate( 'Y-m-d\TH:i:s\Z' ),
+					'timeout_hours'    => $timeout_hours,
+					'status'           => 'waiting',
+				],
+			]
+		);
+
+		// Store the token → job_id mapping in a transient for fast lookup.
+		// Expires based on timeout or defaults to 7 days.
+		$expiry = $timeout_hours > 0 ? $timeout_hours * HOUR_IN_SECONDS : 7 * DAY_IN_SECONDS;
+		set_transient( 'dm_webhook_gate_' . $token, $this->job_id, $expiry );
+
+		// Schedule timeout action if configured.
+		if ( $timeout_hours > 0 && function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action(
+				time() + ( $timeout_hours * HOUR_IN_SECONDS ),
+				'datamachine_webhook_gate_timeout',
+				[ 'job_id' => $this->job_id, 'token' => $token ],
+				'data-machine'
+			);
+		}
+
+		// Set the job status to "waiting" — the engine will see this override
+		// and park the job without scheduling the next step.
+		datamachine_merge_engine_data(
+			$this->job_id,
+			[ 'job_status' => JobStatus::WAITING ]
+		);
+
+		// Update the actual job status in the database.
+		$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
+		$db_jobs->update_job_status( $this->job_id, JobStatus::WAITING );
+
+		$webhook_url = rest_url( "datamachine/v1/webhook/{$token}" );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			"Webhook Gate: Pipeline parked, waiting for webhook",
+			[
+				'job_id'       => $this->job_id,
+				'flow_step_id' => $this->flow_step_id,
+				'webhook_url'  => $webhook_url,
+				'timeout_hours' => $timeout_hours,
+			]
+		);
+
+		$result_packet = new DataPacket(
+			[
+				'title'       => 'Webhook Gate Active',
+				'body'        => "Pipeline paused. Waiting for webhook at: {$webhook_url}",
+				'webhook_url' => $webhook_url,
+				'token'       => $token,
+			],
+			[
+				'source_type'  => 'webhook_gate',
+				'flow_step_id' => $this->flow_step_id,
+				'success'      => true,
+				'waiting'      => true,
+			],
+			'webhook_gate_waiting'
+		);
+
+		return $result_packet->addTo( $this->dataPackets );
+	}
+
+	/**
+	 * Handle an inbound webhook POST that resumes a waiting pipeline.
+	 *
+	 * @param \WP_REST_Request $request REST request object.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public static function handleInboundWebhook( \WP_REST_Request $request ) {
+		$token  = $request->get_param( 'token' );
+		$job_id = get_transient( 'dm_webhook_gate_' . $token );
+
+		if ( ! $job_id ) {
+			return new \WP_Error(
+				'invalid_token',
+				'Webhook token not found or expired.',
+				[ 'status' => 404 ]
+			);
+		}
+
+		$job_id = (int) $job_id;
+
+		// Verify job is actually in waiting status.
+		$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
+		$job     = $db_jobs->get_job( $job_id );
+
+		if ( ! $job || 'waiting' !== ( $job['status'] ?? '' ) ) {
+			return new \WP_Error(
+				'job_not_waiting',
+				'Job is not in waiting status.',
+				[ 'status' => 409 ]
+			);
+		}
+
+		// Get the webhook gate context from engine_data.
+		$engine_data = datamachine_get_engine_data( $job_id );
+		$gate_data   = $engine_data['webhook_gate'] ?? [];
+
+		if ( empty( $gate_data['next_flow_step_id'] ) ) {
+			return new \WP_Error(
+				'no_next_step',
+				'No next step configured for this webhook gate.',
+				[ 'status' => 500 ]
+			);
+		}
+
+		$next_step_id = $gate_data['next_flow_step_id'];
+
+		// Build webhook payload as data packets.
+		$webhook_body = $request->get_json_params();
+		if ( empty( $webhook_body ) ) {
+			$webhook_body = $request->get_body_params();
+		}
+		if ( empty( $webhook_body ) ) {
+			$webhook_body = [];
+		}
+
+		$webhook_packet = new DataPacket(
+			[
+				'title' => 'Webhook Payload',
+				'body'  => $webhook_body,
+			],
+			[
+				'source_type'  => 'webhook_gate_inbound',
+				'flow_step_id' => $gate_data['flow_step_id'] ?? '',
+				'received_at'  => gmdate( 'Y-m-d\TH:i:s\Z' ),
+				'remote_ip'    => $request->get_header( 'x-forwarded-for' ) ?? $_SERVER['REMOTE_ADDR'] ?? '',
+			],
+			'webhook_payload'
+		);
+
+		$data_packets = $webhook_packet->addTo( [] );
+
+		// Update engine_data: clear webhook_gate status, remove job_status override.
+		datamachine_merge_engine_data(
+			$job_id,
+			[
+				'webhook_gate' => array_merge( $gate_data, [
+					'status'      => 'received',
+					'received_at' => gmdate( 'Y-m-d\TH:i:s\Z' ),
+				] ),
+				'job_status'   => null, // Clear the status override so engine proceeds normally.
+			]
+		);
+
+		// Update job status back to processing.
+		$db_jobs->update_job_status( $job_id, JobStatus::PROCESSING );
+
+		// Clean up the transient.
+		delete_transient( 'dm_webhook_gate_' . $token );
+
+		// Resume the pipeline by scheduling the next step.
+		do_action( 'datamachine_schedule_next_step', $job_id, $next_step_id, $data_packets );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			"Webhook Gate: Pipeline resumed via inbound webhook",
+			[
+				'job_id'        => $job_id,
+				'next_step_id'  => $next_step_id,
+				'payload_keys'  => array_keys( $webhook_body ),
+			]
+		);
+
+		return new \WP_REST_Response(
+			[
+				'success'       => true,
+				'job_id'        => $job_id,
+				'next_step_id'  => $next_step_id,
+				'message'       => 'Pipeline resumed.',
+			],
+			200
+		);
+	}
+}

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -354,7 +354,22 @@ function datamachine_register_execution_engine() {
 					)
 				);
 
-				if ( $status_override ) {
+				if ( $status_override && JobStatus::isStatusWaiting( $status_override ) ) {
+					// Waiting status: pipeline is parked at a webhook gate.
+					// Job status was already set by the step. Do not schedule next step.
+					// Do not clean up data packets (needed when pipeline resumes).
+					do_action(
+						'datamachine_log',
+						'info',
+						'Pipeline parked in waiting state (webhook gate)',
+						[
+							'job_id'       => $job_id,
+							'pipeline_id'  => $flow_step_config['pipeline_id'] ?? null,
+							'flow_id'      => $flow_id,
+							'flow_step_id' => $flow_step_id,
+						]
+					);
+				} elseif ( $status_override ) {
 					$complete_result = $db_jobs->complete_job( $job_id, $status_override );
 
 					do_action(

--- a/tests/Unit/Core/JobStatusWaitingTest.php
+++ b/tests/Unit/Core/JobStatusWaitingTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Tests for JobStatus WAITING state.
+ *
+ * @package DataMachine\Tests\Unit\Core
+ */
+
+namespace DataMachine\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+use DataMachine\Core\JobStatus;
+
+class JobStatusWaitingTest extends TestCase {
+
+	/**
+	 * Test WAITING constant exists.
+	 */
+	public function test_waiting_constant(): void {
+		$this->assertSame( 'waiting', JobStatus::WAITING );
+	}
+
+	/**
+	 * Test waiting is NOT a final status.
+	 */
+	public function test_waiting_is_not_final(): void {
+		$this->assertFalse( JobStatus::isStatusFinal( 'waiting' ) );
+		$this->assertNotContains( JobStatus::WAITING, JobStatus::FINAL_STATUSES );
+	}
+
+	/**
+	 * Test waiting is NOT a success status.
+	 */
+	public function test_waiting_is_not_success(): void {
+		$this->assertFalse( JobStatus::isStatusSuccess( 'waiting' ) );
+	}
+
+	/**
+	 * Test waiting is NOT a failure status.
+	 */
+	public function test_waiting_is_not_failure(): void {
+		$this->assertFalse( JobStatus::isStatusFailure( 'waiting' ) );
+	}
+
+	/**
+	 * Test isStatusWaiting static helper.
+	 */
+	public function test_is_status_waiting(): void {
+		$this->assertTrue( JobStatus::isStatusWaiting( 'waiting' ) );
+		$this->assertFalse( JobStatus::isStatusWaiting( 'pending' ) );
+		$this->assertFalse( JobStatus::isStatusWaiting( 'completed' ) );
+	}
+
+	/**
+	 * Test waiting factory method.
+	 */
+	public function test_waiting_factory(): void {
+		$status = JobStatus::waiting();
+		$this->assertTrue( $status->isWaiting() );
+		$this->assertFalse( $status->isFinal() );
+		$this->assertFalse( $status->isSuccess() );
+		$this->assertFalse( $status->isFailure() );
+		$this->assertSame( 'waiting', $status->toString() );
+	}
+
+	/**
+	 * Test parseBaseStatus handles waiting.
+	 */
+	public function test_parse_base_status_waiting(): void {
+		$status = JobStatus::fromString( 'waiting' );
+		$this->assertSame( 'waiting', $status->getBaseStatus() );
+		$this->assertNull( $status->getReason() );
+	}
+
+	/**
+	 * Test parseBaseStatus handles waiting with reason.
+	 */
+	public function test_parse_waiting_with_reason(): void {
+		$status = JobStatus::fromString( 'waiting - webhook gate' );
+		$this->assertSame( 'waiting', $status->getBaseStatus() );
+		$this->assertSame( 'webhook gate', $status->getReason() );
+		$this->assertTrue( $status->isWaiting() );
+	}
+}

--- a/tests/Unit/Core/Steps/WebhookGate/WebhookGateStepTest.php
+++ b/tests/Unit/Core/Steps/WebhookGate/WebhookGateStepTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Tests for WebhookGateStep.
+ *
+ * @package DataMachine\Tests\Unit\Core\Steps\WebhookGate
+ */
+
+namespace DataMachine\Tests\Unit\Core\Steps\WebhookGate;
+
+use PHPUnit\Framework\TestCase;
+use DataMachine\Core\Steps\WebhookGate\WebhookGateStep;
+use DataMachine\Core\Steps\WebhookGate\WebhookGateSettings;
+use DataMachine\Core\JobStatus;
+use ReflectionMethod;
+
+class WebhookGateStepTest extends TestCase {
+
+	/**
+	 * Test that WebhookGateStep class exists and extends Step.
+	 */
+	public function test_class_exists(): void {
+		$this->assertTrue( class_exists( WebhookGateStep::class ) );
+	}
+
+	/**
+	 * Test that WebhookGateStep extends the base Step class.
+	 */
+	public function test_extends_step(): void {
+		$reflection = new \ReflectionClass( WebhookGateStep::class );
+		$this->assertTrue( $reflection->isSubclassOf( \DataMachine\Core\Steps\Step::class ) );
+	}
+
+	/**
+	 * Test that WebhookGateStep uses StepTypeRegistrationTrait.
+	 */
+	public function test_uses_registration_trait(): void {
+		$traits = class_uses( WebhookGateStep::class );
+		$this->assertArrayHasKey(
+			\DataMachine\Core\Steps\StepTypeRegistrationTrait::class,
+			$traits
+		);
+	}
+
+	/**
+	 * Test that validateStepConfiguration exists and returns bool.
+	 */
+	public function test_has_validate_step_configuration(): void {
+		$method = new ReflectionMethod( WebhookGateStep::class, 'validateStepConfiguration' );
+		$this->assertTrue( $method->isProtected() );
+		$return_type = $method->getReturnType();
+		$this->assertNotNull( $return_type );
+		$this->assertSame( 'bool', $return_type->getName() );
+	}
+
+	/**
+	 * Test that executeStep exists and returns array.
+	 */
+	public function test_has_execute_step(): void {
+		$method = new ReflectionMethod( WebhookGateStep::class, 'executeStep' );
+		$this->assertTrue( $method->isProtected() );
+		$return_type = $method->getReturnType();
+		$this->assertNotNull( $return_type );
+		$this->assertSame( 'array', $return_type->getName() );
+	}
+
+	/**
+	 * Test that handleInboundWebhook is a public static method.
+	 */
+	public function test_has_handle_inbound_webhook(): void {
+		$method = new ReflectionMethod( WebhookGateStep::class, 'handleInboundWebhook' );
+		$this->assertTrue( $method->isPublic() );
+		$this->assertTrue( $method->isStatic() );
+	}
+
+	/**
+	 * Test WebhookGateSettings fields.
+	 */
+	public function test_settings_fields(): void {
+		$fields = WebhookGateSettings::get_fields();
+
+		$this->assertIsArray( $fields );
+		$this->assertArrayHasKey( 'timeout_hours', $fields );
+		$this->assertArrayHasKey( 'description', $fields );
+		$this->assertSame( 'number', $fields['timeout_hours']['type'] );
+		$this->assertSame( 0, $fields['timeout_hours']['default'] );
+		$this->assertSame( 'text', $fields['description']['type'] );
+	}
+
+	/**
+	 * Test WebhookGateSettings extends SettingsHandler.
+	 */
+	public function test_settings_extends_settings_handler(): void {
+		$reflection = new \ReflectionClass( WebhookGateSettings::class );
+		$this->assertTrue( $reflection->isSubclassOf( \DataMachine\Core\Steps\Settings\SettingsHandler::class ) );
+	}
+}


### PR DESCRIPTION
## Summary

New step type: **Webhook Gate** — a handler-free pipeline step that parks execution and waits for an external HTTP POST before resuming. Enables cross-pipeline orchestration, human-in-the-loop approvals, and external service integration.

## How it works

```
Pipeline: AI Step → Publish Step → Webhook Gate (⏸️ parked) → Agent Ping Step
                                         ↑
                          External POST /datamachine/v1/webhook/{token}
                                         ↓
                                    Pipeline resumes →  Agent Ping Step
```

1. Pipeline reaches `webhook_gate` step
2. Step generates a cryptographically random 64-char hex token
3. Stores resume context (next step ID, token, timestamp) in engine_data
4. Sets job status to `waiting` — engine parks the job
5. Returns webhook URL in data packet for downstream use

**When webhook fires:**
1. `POST /datamachine/v1/webhook/{token}` with any JSON body
2. Endpoint validates token (transient lookup), verifies job is waiting
3. Wraps webhook payload as a data packet (`webhook_payload` type)
4. Updates job status to `processing`, resumes pipeline via `datamachine_schedule_next_step`

## What's new

### Files added
- `inc/Core/Steps/WebhookGate/WebhookGateStep.php` — Step class + REST endpoint + timeout handler
- `inc/Core/Steps/WebhookGate/WebhookGateSettings.php` — Config fields (timeout_hours, description)
- `tests/Unit/Core/Steps/WebhookGate/WebhookGateStepTest.php` — 7 tests
- `tests/Unit/Core/JobStatusWaitingTest.php` — 8 tests

### Files modified
- `inc/Core/JobStatus.php` — Added `WAITING` constant, helpers, factory method. Not a final status.
- `inc/Engine/Actions/Engine.php` — Handle `waiting` status override: parks job without completing or scheduling next step. Preserves data packets for resume.
- `data-machine.php` — Register WebhookGateStep in bootstrap

## Design decisions

- **Handler-free**: Like AI step, no handler_config or handler_slug. Self-contained.
- **Dumb gate**: Accepts any JSON POST, normalizes to data packet. No payload validation at the gate — composable with AI steps downstream.
- **Token-in-URL auth**: `/datamachine/v1/webhook/{64-char-hex}` — simple, shareable, cryptographically random.
- **Transient-based lookup**: Token → job_id stored as WordPress transient with configurable expiry.
- **Timeout via Action Scheduler**: Optional. Fails the job if webhook doesn't fire within configured hours.
- **`waiting` is NOT a final status**: Job stays active. Not in `FINAL_STATUSES`, not success, not failure. Can be resumed or timed out.

## Use cases

- **Cross-pipeline orchestration**: Pipeline A → agent ping to Pipeline B → webhook gate waits → Pipeline B fires webhook back → Pipeline A resumes
- **Human-in-the-loop**: Pipeline writes article → webhook gate → human reviews and approves via POST → pipeline publishes
- **External services**: Generate content → webhook gate → wait for Stripe payment confirmation → deliver
- **Self-iterating loops**: Pipeline completes → fires agent ping to itself → webhook gate catches it → next iteration

## Configuration

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| timeout_hours | number | 0 | Hours to wait before failing. 0 = no timeout (7-day token expiry) |
| description | text | empty | Human-readable label for what the gate waits for |

Addresses #73