### PR TITLE
fix: Align agent_soul sanitization between SettingsFilters and Abilities

### DIFF
--- a/inc/Core/Admin/Settings/SettingsFilters.php
+++ b/inc/Core/Admin/Settings/SettingsFilters.php
@@ -118,7 +118,7 @@ function datamachine_sanitize_settings( $input ) {
 		foreach ( $soul_keys as $soul_key ) {
 			$sanitized['agent_soul'][ $soul_key ] = '';
 			if ( isset( $input['agent_soul'][ $soul_key ] ) ) {
-				$sanitized['agent_soul'][ $soul_key ] = wp_unslash( $input['agent_soul'][ $soul_key ] );
+				$sanitized['agent_soul'][ $soul_key ] = wp_kses_post( wp_unslash( $input['agent_soul'][ $soul_key ] ) );
 			}
 		}
 	}
@@ -126,7 +126,7 @@ function datamachine_sanitize_settings( $input ) {
 	// Legacy global system prompt (backward compat — read by AgentSoulDirective as fallback).
 	$sanitized['global_system_prompt'] = '';
 	if ( isset( $input['global_system_prompt'] ) ) {
-		$sanitized['global_system_prompt'] = wp_unslash( $input['global_system_prompt'] );
+		$sanitized['global_system_prompt'] = wp_kses_post( wp_unslash( $input['global_system_prompt'] ) );
 	}
 
 	// Site context toggle


### PR DESCRIPTION
## Problem

SettingsFilters used `wp_unslash()` only for agent_soul and global_system_prompt, while SettingsAbilities used `wp_kses_post()`. This meant admin form saves had no HTML sanitization — only slash removal.

## Fix

Both paths now use `wp_kses_post(wp_unslash())` — unslash first (WordPress adds magic quotes to POST data), then sanitize HTML.

One file, two lines changed.

Closes #180