### PR TITLE
refactor: Schema-driven FlowStepCard — eliminate hardcoded step type branching

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -1,29 +1,24 @@
 /**
  * Flow Step Card Component.
  *
- * Display individual flow step with handler configuration.
+ * Schema-driven display for individual flow steps. All step types render
+ * through the same path — no hardcoded step type branching.
  */
 
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useCallback, useRef, useMemo } from '@wordpress/element';
-import {
-	Button,
-	Card,
-	CardBody,
-	TextareaControl,
-	TextControl,
-	Notice,
-} from '@wordpress/components';
+import { useState, useMemo, useCallback } from '@wordpress/element';
+import { Card, CardBody, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
 import FlowStepHandler from './FlowStepHandler';
-import { useUpdateQueueItem, useAddToQueue } from '../../queries/queue';
+import QueueablePromptField from './QueueablePromptField';
+import InlineStepConfig from './InlineStepConfig';
 import { updateFlowStepConfig } from '../../utils/api';
-import { AUTO_SAVE_DELAY } from '../../utils/constants';
 import { useStepTypes } from '../../queries/config';
 
 /**
@@ -50,389 +45,68 @@ export default function FlowStepCard( {
 	onConfigure,
 	onQueueClick,
 } ) {
-	// Global config: Use stepTypes hook directly (TanStack Query handles caching)
 	const { data: stepTypes = {} } = useStepTypes();
 	const stepTypeInfo = stepTypes[ pipelineStep.step_type ] || {};
 	const showSettingsDisplay = stepTypeInfo.show_settings_display !== false;
+
 	const isAiStep = pipelineStep.step_type === 'ai';
-	const isAgentPing = pipelineStep.step_type === 'agent_ping';
 	const aiConfig = isAiStep
 		? pipelineConfig[ pipelineStep.pipeline_step_id ]
 		: null;
 
 	const promptQueue = flowStepConfig.prompt_queue || [];
 	const queueEnabled = !! flowStepConfig.queue_enabled;
-	const queueCount = promptQueue.length;
-	const queueHasItems = queueCount > 0;
-	const firstQueuePrompt = queueHasItems ? promptQueue[ 0 ].prompt : '';
-	const shouldUseQueue = queueEnabled || queueHasItems;
+	const queueHasItems = promptQueue.length > 0;
+	const shouldShowQueue = queueEnabled || queueHasItems;
 
-	const [ localUserMessage, setLocalUserMessage ] = useState(
-		firstQueuePrompt || flowStepConfig.user_message || ''
-	);
-	const [ localAgentPingPrompt, setLocalAgentPingPrompt ] = useState(
-		firstQueuePrompt || flowStepConfig?.handler_config?.prompt || ''
-	);
-	const [ localWebhookUrl, setLocalWebhookUrl ] = useState(
-		flowStepConfig?.handler_config?.webhook_url || ''
-	);
-	const [ localAuthHeaderName, setLocalAuthHeaderName ] = useState(
-		flowStepConfig?.handler_config?.auth_header_name || ''
-	);
-	const [ localAuthToken, setLocalAuthToken ] = useState(
-		flowStepConfig?.handler_config?.auth_token || ''
-	);
-	const [ localReplyTo, setLocalReplyTo ] = useState(
-		flowStepConfig?.handler_config?.reply_to || ''
-	);
-	const [ isSaving, setIsSaving ] = useState( false );
 	const [ error, setError ] = useState( null );
-	const saveTimeout = useRef( null );
 
-	// Ref to track current Agent Ping config values for debounced saves
-	const agentPingConfigRef = useRef( {
-		webhook_url: localWebhookUrl,
-		prompt: localAgentPingPrompt,
-		auth_header_name: localAuthHeaderName,
-		auth_token: localAuthToken,
-		reply_to: localReplyTo,
-	} );
-
-	// Keep ref in sync with state
-	useEffect( () => {
-		agentPingConfigRef.current = {
-			webhook_url: localWebhookUrl,
-			prompt: localAgentPingPrompt,
-			auth_header_name: localAuthHeaderName,
-			auth_token: localAuthToken,
-			reply_to: localReplyTo,
-		};
-	}, [
-		localWebhookUrl,
-		localAgentPingPrompt,
-		localAuthHeaderName,
-		localAuthToken,
-		localReplyTo,
-	] );
-
-	// State setters map for unified handler
-	const agentPingSetters = useMemo(
-		() => ( {
-			webhook_url: setLocalWebhookUrl,
-			prompt: setLocalAgentPingPrompt,
-			auth_header_name: setLocalAuthHeaderName,
-			auth_token: setLocalAuthToken,
-			reply_to: setLocalReplyTo,
-		} ),
-		[]
-	);
-	const updateQueueItemMutation = useUpdateQueueItem();
-	const addToQueueMutation = useAddToQueue();
-
-	/**
-	 * Sync local user message with queue/config changes
-	 */
-	useEffect( () => {
-		// Priority: queue[0] > user_message
-		const newValue = firstQueuePrompt || flowStepConfig.user_message || '';
-		setLocalUserMessage( newValue );
-	}, [ firstQueuePrompt, flowStepConfig.user_message ] );
-
-	useEffect( () => {
-		const newValue =
-			firstQueuePrompt || flowStepConfig?.handler_config?.prompt || '';
-		setLocalAgentPingPrompt( newValue );
-	}, [ firstQueuePrompt, flowStepConfig?.handler_config?.prompt ] );
-
-	useEffect( () => {
-		setLocalWebhookUrl( flowStepConfig?.handler_config?.webhook_url || '' );
-	}, [ flowStepConfig?.handler_config?.webhook_url ] );
-
-	useEffect( () => {
-		setLocalAuthHeaderName(
-			flowStepConfig?.handler_config?.auth_header_name || ''
-		);
-	}, [ flowStepConfig?.handler_config?.auth_header_name ] );
-
-	useEffect( () => {
-		setLocalAuthToken( flowStepConfig?.handler_config?.auth_token || '' );
-	}, [ flowStepConfig?.handler_config?.auth_token ] );
-
-	useEffect( () => {
-		setLocalReplyTo( flowStepConfig?.handler_config?.reply_to || '' );
-	}, [ flowStepConfig?.handler_config?.reply_to ] );
-
-	/**
-	 * Save user message to queue (add if empty, update index 0 if exists)
-	 */
-	const saveToQueue = useCallback(
-		async ( message ) => {
-			if ( ! isAiStep && ! isAgentPing ) {
-				return;
-			}
-
-			if ( ! shouldUseQueue ) {
-				return;
-			}
-
-			// Skip if message is empty (don't add empty items)
-			if ( ! message.trim() ) {
-				return;
-			}
-
-			// Compare to current queue value
-			const currentMessage = firstQueuePrompt || '';
-			if ( message === currentMessage ) {
-				return;
-			}
-
-			setIsSaving( true );
-			setError( null );
-
-			try {
-				let response;
-
-				if ( queueHasItems ) {
-					// Update existing queue[0]
-					response = await updateQueueItemMutation.mutateAsync( {
-						flowId,
-						flowStepId,
-						index: 0,
-						prompt: message,
-					} );
-				} else {
-					// Add new item when queue is empty
-					response = await addToQueueMutation.mutateAsync( {
-						flowId,
-						flowStepId,
-						prompt: message,
-					} );
-				}
-
-				if ( ! response?.success ) {
-					setError(
-						response?.message ||
-							__( 'Failed to save prompt', 'data-machine' )
-					);
-					setLocalUserMessage( currentMessage );
-				}
-			} catch ( err ) {
-				// eslint-disable-next-line no-console
-				console.error( 'Queue save error:', err );
-				setError(
-					err.message || __( 'An error occurred', 'data-machine' )
-				);
-				setLocalUserMessage( currentMessage );
-			} finally {
-				setIsSaving( false );
-			}
-		},
-		[
-			flowId,
-			flowStepId,
-			firstQueuePrompt,
-			queueHasItems,
-			isAiStep,
-			isAgentPing,
-			shouldUseQueue,
-			updateQueueItemMutation,
-			addToQueueMutation,
-		]
-	);
-
-	const saveStepConfig = useCallback(
-		async ( config, onErrorRevert ) => {
-			setIsSaving( true );
-			setError( null );
-
-			try {
-				const response = await updateFlowStepConfig(
-					flowStepId,
-					config
-				);
-				if ( ! response?.success ) {
-					setError(
-						response?.message ||
-							__( 'Failed to save settings', 'data-machine' )
-					);
-					if ( onErrorRevert ) {
-						onErrorRevert();
-					}
-				}
-			} catch ( err ) {
-				// eslint-disable-next-line no-console
-				console.error( 'Flow step save error:', err );
-				setError(
-					err.message || __( 'An error occurred', 'data-machine' )
-				);
-				if ( onErrorRevert ) {
-					onErrorRevert();
-				}
-			} finally {
-				setIsSaving( false );
-			}
-		},
-		[ flowStepId ]
-	);
-
-	/**
-	 * Unified handler for Agent Ping config fields.
-	 * Uses ref to get current values, avoiding stale closure issues.
-	 *
-	 * @param {string} field - Config field name (webhook_url, prompt, auth_header_name, auth_token, reply_to)
-	 * @param {string} value - New value for the field
-	 */
-	const handleAgentPingConfigChange = useCallback(
-		( field, value ) => {
-			// Update local state
-			const setter = agentPingSetters[ field ];
-			if ( setter ) {
-				setter( value );
-			}
-
-			// Clear existing timeout
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
-			}
-
-			saveTimeout.current = setTimeout( () => {
-				// Special case: prompt field with queue enabled
-				if ( field === 'prompt' && shouldUseQueue ) {
-					saveToQueue( value );
-					return;
-				}
-
-				// Build config with current ref values, overriding the changed field
-				const currentConfig = agentPingConfigRef.current;
-				saveStepConfig(
-					{
-						handler_config: {
-							...currentConfig,
-							[ field ]: value,
-						},
-					},
-					() => setter && setter( currentConfig[ field ] )
-				);
-			}, AUTO_SAVE_DELAY );
-		},
-		[ agentPingSetters, shouldUseQueue, saveToQueue, saveStepConfig ]
-	);
-
-	// Convenience handlers that call the unified handler
-	const handleAgentPingPromptChange = useCallback(
-		( value ) => handleAgentPingConfigChange( 'prompt', value ),
-		[ handleAgentPingConfigChange ]
-	);
-	const handleWebhookUrlChange = useCallback(
-		( value ) => handleAgentPingConfigChange( 'webhook_url', value ),
-		[ handleAgentPingConfigChange ]
-	);
-	const handleAuthHeaderNameChange = useCallback(
-		( value ) => handleAgentPingConfigChange( 'auth_header_name', value ),
-		[ handleAgentPingConfigChange ]
-	);
-	const handleAuthTokenChange = useCallback(
-		( value ) => handleAgentPingConfigChange( 'auth_token', value ),
-		[ handleAgentPingConfigChange ]
-	);
-	const handleReplyToChange = useCallback(
-		( value ) => handleAgentPingConfigChange( 'reply_to', value ),
-		[ handleAgentPingConfigChange ]
-	);
-
-	/**
-	 * Handle user message change with debouncing
-	 */
-	const handleUserMessageChange = useCallback(
-		( value ) => {
-			setLocalUserMessage( value );
-
-			// Clear existing timeout
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
-			}
-
-			saveTimeout.current = setTimeout( () => {
-				if ( shouldUseQueue ) {
-					saveToQueue( value );
-					return;
-				}
-
-				saveStepConfig( { user_message: value }, () =>
-					setLocalUserMessage( localUserMessage )
-				);
-			}, AUTO_SAVE_DELAY );
-		},
-		[ shouldUseQueue, saveToQueue, saveStepConfig, localUserMessage ]
-	);
-
-	const getPromptValue = () => {
-		// Queue has items → show queue[0]
-		if ( queueHasItems ) {
-			return firstQueuePrompt;
-		}
-		// Queue empty → fall back to stored prompt (regardless of queueEnabled)
+	// Determine the current prompt value based on step type.
+	const currentPrompt = useMemo( () => {
 		if ( isAiStep ) {
-			return localUserMessage;
+			return flowStepConfig.user_message || '';
 		}
-		return localAgentPingPrompt;
-	};
+		return flowStepConfig?.handler_config?.prompt || '';
+	}, [ isAiStep, flowStepConfig.user_message, flowStepConfig?.handler_config?.prompt ] );
 
-	/**
-	 * Cleanup timeout on unmount
-	 */
-	useEffect( () => {
-		return () => {
-			if ( saveTimeout.current ) {
-				clearTimeout( saveTimeout.current );
-			}
-		};
+	// Determine if this step type shows a prompt field.
+	// AI steps always get it. Other steps get it if they have a prompt in handler_config
+	// or if queue is enabled/has items.
+	const hasPromptConfig = flowStepConfig?.handler_config?.prompt !== undefined;
+	const showPromptField = isAiStep || shouldShowQueue || hasPromptConfig;
+
+	// Fields to exclude from inline config (handled by QueueablePromptField).
+	const excludeFields = useMemo( () => {
+		const excluded = [ 'prompt' ]; // Always exclude prompt — handled by QueueablePromptField.
+		return excluded;
 	}, [] );
 
 	/**
-	 * Build the label with queue indicator
+	 * Save prompt for non-queue mode.
 	 */
-	const getFieldLabel = () => {
-		if ( queueHasItems ) {
-			return (
-				<span className="datamachine-user-message-label">
-					{ __( 'User Message', 'data-machine' ) }
-					<span className="datamachine-queue-indicator">
-						{ ' ' }
-						<span className="datamachine-queue-badge">
-							{ __( 'Next in queue', 'data-machine' ) }
-						</span>
-					</span>
-				</span>
-			);
-		}
-		return __( 'User Message', 'data-machine' );
-	};
+	const handlePromptSave = useCallback(
+		async ( value ) => {
+			try {
+				const config = isAiStep
+					? { user_message: value }
+					: { handler_config: { ...( flowStepConfig?.handler_config || {} ), prompt: value } };
 
-	/**
-	 * Build help text
-	 */
-	const getHelpText = () => {
-		if ( isSaving ) {
-			return __( 'Saving…', 'data-machine' );
-		}
-		if ( shouldUseQueue ) {
-			if ( queueHasItems ) {
-				return __(
-					'Editing updates the first item in the prompt queue.',
-					'data-machine'
-				);
+				const response = await updateFlowStepConfig( flowStepId, config );
+				if ( ! response?.success ) {
+					setError( response?.message || __( 'Failed to save', 'data-machine' ) );
+				}
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Prompt save error:', err );
+				setError( err.message || __( 'An error occurred', 'data-machine' ) );
 			}
-			return __(
-				'Queue enabled. Type a prompt to add it to the queue. Use Manage Queue for multiple prompts.',
-				'data-machine'
-			);
-		}
-		return __(
-			'Type a prompt to save it directly. Enable the queue to pop prompts in order.',
-			'data-machine'
-		);
-	};
+		},
+		[ flowStepId, isAiStep, flowStepConfig?.handler_config ]
+	);
+
+	// Resolve handler info for settings display.
+	const usesHandler = stepTypeInfo.uses_handler !== '' && stepTypeInfo.uses_handler !== false;
+	const effectiveHandlerSlug = usesHandler ? flowStepConfig.handler_slug : pipelineStep.step_type;
 
 	return (
 		<Card
@@ -457,7 +131,7 @@ export default function FlowStepCard( {
 						</strong>
 					</div>
 
-					{ /* AI Configuration Display */ }
+					{ /* AI Provider/Model Display */ }
 					{ isAiStep && aiConfig && (
 						<div className="datamachine-ai-config-display">
 							<div className="datamachine-ai-provider-info">
@@ -471,186 +145,52 @@ export default function FlowStepCard( {
 								</strong>{ ' ' }
 								{ aiConfig.model || 'Not configured' }
 							</div>
-
-							{ /* Prompt Field - shows/edits queue[0] */ }
-							<TextareaControl
-								label={ getFieldLabel() }
-								value={ getPromptValue() }
-								onChange={ handleUserMessageChange }
-								placeholder={ __(
-									'Enter user message for AI processing…',
-									'data-machine'
-								) }
-								rows={ 4 }
-								help={ getHelpText() }
-								className={
-									queueHasItems
-										? 'datamachine-queue-linked'
-										: ''
-								}
-							/>
-
-							{ /* Queue Management Button */ }
-							<div className="datamachine-queue-actions">
-								<Button
-									variant="secondary"
-									size="small"
-									onClick={ onQueueClick }
-								>
-									{ __( 'Manage Queue', 'data-machine' ) }{ ' ' }
-									<span
-										className={ `datamachine-queue-count ${
-											queueCount > 0
-												? 'datamachine-queue-count--active'
-												: ''
-										}` }
-									>
-										({ queueCount })
-									</span>
-								</Button>
-							</div>
 						</div>
 					) }
 
-					{ /* Agent Ping Configuration */ }
-					{ isAgentPing && (
-						<div className="datamachine-agent-ping-config">
-							<TextControl
-								label={ __( 'Webhook URL', 'data-machine' ) }
-								value={ localWebhookUrl }
-								onChange={ handleWebhookUrlChange }
-								placeholder={ __(
-									'Enter webhook URL…',
-									'data-machine'
-								) }
-								help={ __(
-									'URL to POST data to (Discord, Slack, custom endpoint).',
-									'data-machine'
-								) }
-								className="datamachine-agent-ping-webhook"
-							/>
-
-							<TextControl
-								label={ __(
-									'Auth Header Name',
-									'data-machine'
-								) }
-								value={ localAuthHeaderName }
-								onChange={ handleAuthHeaderNameChange }
-								help={ __(
-									'e.g. X-Agent-Token',
-									'data-machine'
-								) }
-							/>
-
-							<TextControl
-								label={ __( 'Auth Token', 'data-machine' ) }
-								value={ localAuthToken }
-								onChange={ handleAuthTokenChange }
-							/>
-
-							<TextControl
-								label={ __(
-									'Reply To Channel',
-									'data-machine'
-								) }
-								value={ localReplyTo }
-								onChange={ handleReplyToChange }
-								placeholder={ __(
-									'e.g., Discord channel ID',
-									'data-machine'
-								) }
-								help={ __(
-									'Optional channel ID for response routing.',
-									'data-machine'
-								) }
-							/>
-
-							<TextareaControl
-								label={ getFieldLabel() }
-								value={ getPromptValue() }
-								onChange={ handleAgentPingPromptChange }
-								placeholder={ __(
-									'Enter instructions for the agent…',
-									'data-machine'
-								) }
-								rows={ 4 }
-								help={ getHelpText() }
-								className={
-									queueHasItems
-										? 'datamachine-queue-linked'
-										: ''
-								}
-							/>
-
-							<div className="datamachine-queue-actions">
-								<Button
-									variant="secondary"
-									size="small"
-									onClick={ onQueueClick }
-								>
-									{ __( 'Manage Queue', 'data-machine' ) }{ ' ' }
-									<span
-										className={ `datamachine-queue-count ${
-											queueCount > 0
-												? 'datamachine-queue-count--active'
-												: ''
-										}` }
-									>
-										({ queueCount })
-									</span>
-								</Button>
-							</div>
-						</div>
+					{ /* Inline Config Fields (schema-driven from handler details API) */ }
+					{ showSettingsDisplay && effectiveHandlerSlug && (
+						<InlineStepConfig
+							flowStepId={ flowStepId }
+							handlerConfig={ flowStepConfig?.handler_config || {} }
+							handlerSlug={ effectiveHandlerSlug }
+							excludeFields={ excludeFields }
+							onError={ setError }
+						/>
 					) }
 
-					{ /* Handler Configuration */ }
-					{ showSettingsDisplay &&
-						( () => {
-							const handlerStepTypeInfo =
-								stepTypes[ pipelineStep.step_type ] || {};
-							// Falsy check: PHP false becomes "" in JSON, but undefined means still loading
-							const usesHandler =
-								handlerStepTypeInfo.uses_handler !== '' &&
-								handlerStepTypeInfo.uses_handler !== false;
-
-							// For steps that don't use handlers, use the step_type as the effective handler slug
-							const effectiveHandlerSlug = usesHandler
-								? flowStepConfig.handler_slug
-								: pipelineStep.step_type;
-
-							// Handler-based step with no handler configured - show configure button
-							if (
-								usesHandler &&
-								! flowStepConfig.handler_slug
-							) {
-								return (
-									<FlowStepHandler
-										handlerSlug={ null }
-										settingsDisplay={ [] }
-										onConfigure={ () =>
-											onConfigure &&
-											onConfigure( flowStepId )
-										}
-									/>
-								);
+					{ /* Prompt Field with Queue Integration */ }
+					{ showPromptField && (
+						<QueueablePromptField
+							flowId={ flowId }
+							flowStepId={ flowStepId }
+							prompt={ currentPrompt }
+							promptQueue={ promptQueue }
+							queueEnabled={ queueEnabled }
+							placeholder={
+								isAiStep
+									? __( 'Enter user message for AI processing…', 'data-machine' )
+									: __( 'Enter instructions…', 'data-machine' )
 							}
+							label={ __( 'User Message', 'data-machine' ) }
+							onSave={ handlePromptSave }
+							onQueueClick={ onQueueClick }
+							onError={ setError }
+						/>
+					) }
 
-							// Show settings display
-							return (
-								<FlowStepHandler
-									handlerSlug={ effectiveHandlerSlug }
-									settingsDisplay={
-										flowStepConfig.settings_display || []
-									}
-									onConfigure={ () =>
-										onConfigure && onConfigure( flowStepId )
-									}
-									showConfigureButton={ usesHandler }
-									showBadge={ usesHandler }
-								/>
-							);
-						} )() }
+					{ /* Handler Configuration (handler-based steps only) */ }
+					{ usesHandler && (
+						<FlowStepHandler
+							handlerSlug={ flowStepConfig.handler_slug || null }
+							settingsDisplay={ flowStepConfig.settings_display || [] }
+							onConfigure={ () =>
+								onConfigure && onConfigure( flowStepId )
+							}
+							showConfigureButton
+							showBadge
+						/>
+					) }
 				</div>
 			</CardBody>
 		</Card>

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/InlineStepConfig.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/InlineStepConfig.jsx
@@ -1,0 +1,141 @@
+/**
+ * Inline Step Config Component.
+ *
+ * Schema-driven inline editor for flow step handler_config fields.
+ * Fetches field definitions from the handler details API and renders
+ * editable fields using HandlerSettingField.
+ *
+ * Replaces hardcoded per-step-type field rendering in FlowStepCard.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useCallback, useRef, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import HandlerSettingField from '../modals/handler-settings/HandlerSettingField';
+import { useHandlerDetails } from '../../queries/handlers';
+import { updateFlowStepConfig } from '../../utils/api';
+import { AUTO_SAVE_DELAY } from '../../utils/constants';
+
+/**
+ * InlineStepConfig Component.
+ *
+ * @param {Object}   props               - Component props.
+ * @param {string}   props.flowStepId    - Flow step ID.
+ * @param {Object}   props.handlerConfig - Current handler_config values.
+ * @param {string}   props.handlerSlug   - Handler or step type slug.
+ * @param {string[]} props.excludeFields - Field keys to exclude (e.g., 'prompt').
+ * @param {Function} props.onError       - Error callback.
+ * @return {JSX.Element|null} Inline config fields.
+ */
+export default function InlineStepConfig( {
+	flowStepId,
+	handlerConfig = {},
+	handlerSlug,
+	excludeFields = [],
+	onError,
+} ) {
+	// Fetch full field schema from handler details API.
+	const { data: handlerDetails } = useHandlerDetails( handlerSlug );
+	const fieldSchema = handlerDetails?.settings || {};
+
+	// Filter out excluded fields and fields with type 'info'.
+	const fieldEntries = Object.entries( fieldSchema ).filter(
+		( [ key, config ] ) =>
+			! excludeFields.includes( key ) && config.type !== 'info'
+	);
+
+	// Local state for field values.
+	const [ localValues, setLocalValues ] = useState( {} );
+	const saveTimeout = useRef( null );
+	const localValuesRef = useRef( localValues );
+
+	// Initialize local values from handler config.
+	useEffect( () => {
+		if ( fieldEntries.length === 0 ) {
+			return;
+		}
+		const initial = {};
+		fieldEntries.forEach( ( [ key, config ] ) => {
+			initial[ key ] =
+				handlerConfig[ key ] ?? config.current_value ?? config.default ?? '';
+		} );
+		setLocalValues( initial );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ handlerSlug, JSON.stringify( handlerConfig ) ] );
+
+	// Keep ref in sync.
+	useEffect( () => {
+		localValuesRef.current = localValues;
+	}, [ localValues ] );
+
+	// Cleanup on unmount.
+	useEffect( () => {
+		return () => {
+			if ( saveTimeout.current ) {
+				clearTimeout( saveTimeout.current );
+			}
+		};
+	}, [] );
+
+	/**
+	 * Handle field change with debounced save.
+	 */
+	const handleFieldChange = useCallback(
+		( fieldKey, value ) => {
+			setLocalValues( ( prev ) => ( { ...prev, [ fieldKey ]: value } ) );
+
+			if ( saveTimeout.current ) {
+				clearTimeout( saveTimeout.current );
+			}
+
+			saveTimeout.current = setTimeout( async () => {
+				try {
+					const currentValues = {
+						...localValuesRef.current,
+						[ fieldKey ]: value,
+					};
+					const response = await updateFlowStepConfig( flowStepId, {
+						handler_config: currentValues,
+					} );
+					if ( ! response?.success && onError ) {
+						onError(
+							response?.message || 'Failed to save settings'
+						);
+					}
+				} catch ( err ) {
+					// eslint-disable-next-line no-console
+					console.error( 'Inline config save error:', err );
+					if ( onError ) {
+						onError( err.message || 'An error occurred' );
+					}
+				}
+			}, AUTO_SAVE_DELAY );
+		},
+		[ flowStepId, onError ]
+	);
+
+	// Don't render until we have the field schema.
+	if ( fieldEntries.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div className="datamachine-inline-step-config">
+			{ fieldEntries.map( ( [ key, config ] ) => (
+				<HandlerSettingField
+					key={ key }
+					fieldKey={ key }
+					fieldConfig={ config }
+					value={ localValues[ key ] ?? '' }
+					onChange={ handleFieldChange }
+					handlerSlug={ handlerSlug }
+				/>
+			) ) }
+		</div>
+	);
+}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/QueueablePromptField.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/QueueablePromptField.jsx
@@ -1,0 +1,249 @@
+/**
+ * Queueable Prompt Field Component.
+ *
+ * Shared prompt field with queue integration for any step type
+ * that supports prompt queues (AI steps, Agent Ping, etc.).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
+import { Button, TextareaControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useUpdateQueueItem, useAddToQueue } from '../../queries/queue';
+import { AUTO_SAVE_DELAY } from '../../utils/constants';
+
+/**
+ * QueueablePromptField Component.
+ *
+ * @param {Object}   props                - Component props.
+ * @param {number}   props.flowId         - Flow ID.
+ * @param {string}   props.flowStepId     - Flow step ID.
+ * @param {string}   props.prompt         - Current prompt value (from handler_config or user_message).
+ * @param {Array}    props.promptQueue    - Prompt queue array.
+ * @param {boolean}  props.queueEnabled   - Whether queue is enabled.
+ * @param {string}   props.placeholder    - Placeholder text.
+ * @param {string}   props.label          - Field label override.
+ * @param {Function} props.onSave         - Save callback for non-queue saves (receives prompt string).
+ * @param {Function} props.onQueueClick   - Queue management button handler.
+ * @param {Function} props.onError        - Error callback.
+ * @return {JSX.Element} Prompt field with queue integration.
+ */
+export default function QueueablePromptField( {
+	flowId,
+	flowStepId,
+	prompt = '',
+	promptQueue = [],
+	queueEnabled = false,
+	placeholder,
+	label,
+	onSave,
+	onQueueClick,
+	onError,
+} ) {
+	const queueCount = promptQueue.length;
+	const queueHasItems = queueCount > 0;
+	const firstQueuePrompt = queueHasItems ? promptQueue[ 0 ].prompt : '';
+	const shouldUseQueue = queueEnabled || queueHasItems;
+
+	const [ localValue, setLocalValue ] = useState(
+		firstQueuePrompt || prompt || ''
+	);
+	const [ isSaving, setIsSaving ] = useState( false );
+	const saveTimeout = useRef( null );
+
+	const updateQueueItemMutation = useUpdateQueueItem();
+	const addToQueueMutation = useAddToQueue();
+
+	// Sync with external changes.
+	useEffect( () => {
+		setLocalValue( firstQueuePrompt || prompt || '' );
+	}, [ firstQueuePrompt, prompt ] );
+
+	// Cleanup timeout on unmount.
+	useEffect( () => {
+		return () => {
+			if ( saveTimeout.current ) {
+				clearTimeout( saveTimeout.current );
+			}
+		};
+	}, [] );
+
+	/**
+	 * Save to queue (add or update index 0).
+	 */
+	const saveToQueue = useCallback(
+		async ( message ) => {
+			if ( ! shouldUseQueue || ! message.trim() ) {
+				return;
+			}
+
+			const currentMessage = firstQueuePrompt || '';
+			if ( message === currentMessage ) {
+				return;
+			}
+
+			setIsSaving( true );
+
+			try {
+				let response;
+
+				if ( queueHasItems ) {
+					response = await updateQueueItemMutation.mutateAsync( {
+						flowId,
+						flowStepId,
+						index: 0,
+						prompt: message,
+					} );
+				} else {
+					response = await addToQueueMutation.mutateAsync( {
+						flowId,
+						flowStepId,
+						prompt: message,
+					} );
+				}
+
+				if ( ! response?.success ) {
+					const errorMsg =
+						response?.message ||
+						__( 'Failed to save prompt', 'data-machine' );
+					if ( onError ) {
+						onError( errorMsg );
+					}
+					setLocalValue( currentMessage );
+				}
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Queue save error:', err );
+				if ( onError ) {
+					onError(
+						err.message ||
+							__( 'An error occurred', 'data-machine' )
+					);
+				}
+				setLocalValue( currentMessage );
+			} finally {
+				setIsSaving( false );
+			}
+		},
+		[
+			flowId,
+			flowStepId,
+			firstQueuePrompt,
+			queueHasItems,
+			shouldUseQueue,
+			updateQueueItemMutation,
+			addToQueueMutation,
+			onError,
+		]
+	);
+
+	/**
+	 * Handle value change with debounced save.
+	 */
+	const handleChange = useCallback(
+		( value ) => {
+			setLocalValue( value );
+
+			if ( saveTimeout.current ) {
+				clearTimeout( saveTimeout.current );
+			}
+
+			saveTimeout.current = setTimeout( () => {
+				if ( shouldUseQueue ) {
+					saveToQueue( value );
+				} else if ( onSave ) {
+					onSave( value );
+				}
+			}, AUTO_SAVE_DELAY );
+		},
+		[ shouldUseQueue, saveToQueue, onSave ]
+	);
+
+	/**
+	 * Build the label with queue indicator.
+	 */
+	const getFieldLabel = () => {
+		const baseLabel = label || __( 'User Message', 'data-machine' );
+		if ( queueHasItems ) {
+			return (
+				<span className="datamachine-user-message-label">
+					{ baseLabel }
+					<span className="datamachine-queue-indicator">
+						{ ' ' }
+						<span className="datamachine-queue-badge">
+							{ __( 'Next in queue', 'data-machine' ) }
+						</span>
+					</span>
+				</span>
+			);
+		}
+		return baseLabel;
+	};
+
+	/**
+	 * Build help text.
+	 */
+	const getHelpText = () => {
+		if ( isSaving ) {
+			return __( 'Saving…', 'data-machine' );
+		}
+		if ( shouldUseQueue ) {
+			if ( queueHasItems ) {
+				return __(
+					'Editing updates the first item in the prompt queue.',
+					'data-machine'
+				);
+			}
+			return __(
+				'Queue enabled. Type a prompt to add it to the queue. Use Manage Queue for multiple prompts.',
+				'data-machine'
+			);
+		}
+		return __(
+			'Type a prompt to save it directly. Enable the queue to pop prompts in order.',
+			'data-machine'
+		);
+	};
+
+	return (
+		<div className="datamachine-queueable-prompt">
+			<TextareaControl
+				label={ getFieldLabel() }
+				value={ localValue }
+				onChange={ handleChange }
+				placeholder={
+					placeholder ||
+					__( 'Enter prompt…', 'data-machine' )
+				}
+				rows={ 4 }
+				help={ getHelpText() }
+				className={ queueHasItems ? 'datamachine-queue-linked' : '' }
+			/>
+
+			<div className="datamachine-queue-actions">
+				<Button
+					variant="secondary"
+					size="small"
+					onClick={ onQueueClick }
+				>
+					{ __( 'Manage Queue', 'data-machine' ) }{ ' ' }
+					<span
+						className={ `datamachine-queue-count ${
+							queueCount > 0
+								? 'datamachine-queue-count--active'
+								: ''
+						}` }
+					>
+						({ queueCount })
+					</span>
+				</Button>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Refactors `FlowStepCard.jsx` from 658 to 198 lines by replacing hardcoded `isAgentPing` rendering with schema-driven components. All step types now render through the same path — no step-type-specific branching.

## Problem

`FlowStepCard.jsx` had hardcoded `isAiStep` and `isAgentPing` checks with completely separate 100+ line JSX blocks. Agent Ping's 5 config fields (webhook_url, auth_header_name, auth_token, reply_to, prompt) were individual `TextControl` components instead of using the schema-driven `HandlerSettingField` renderer. Prompt/queue logic was copy-pasted between both blocks.

This meant any new step type (webhook_gate, future types) required hardcoded frontend changes.

## Solution

### New: `QueueablePromptField` component
Shared prompt field with queue integration. Any step type with prompt/queue support gets the same UI automatically:
- Save to queue / update queue[0]
- Queue indicator badge
- Debounced auto-save
- "Manage Queue" button

### New: `InlineStepConfig` component
Schema-driven inline editor for `handler_config` fields:
- Fetches field definitions from `/handlers/{slug}` API (handler details)
- Renders each field via existing `HandlerSettingField` (text, textarea, select, checkbox, url_list, etc.)
- Debounced auto-save per field
- Works for both traditional handlers AND step types

### Modified: `Handlers.php` API
Falls back to step type settings when a handler slug isn't in the handlers list. Step types like `agent_ping` and `webhook_gate` register settings via `datamachine_handler_settings` filter but aren't traditional handlers — now the API resolves their field schema too.

### Modified: `FlowStepCard.jsx` (658 → 198 lines)
- **Removed**: All `isAgentPing` checks, 5 hardcoded TextControl fields, 6 useState hooks, 6 useEffect syncs, duplicated prompt/queue logic
- **Kept**: `isAiStep` check for AI provider/model display (pipeline-level config, architecturally different from flow-level handler_config)
- All step types render through: header → InlineStepConfig (schema-driven fields) → QueueablePromptField (if applicable) → FlowStepHandler (if handler-based)

## Result

Adding a new step type with configuration fields requires:
1. Register a `SettingsHandler` subclass with `get_fields()` (backend)
2. That's it. Zero frontend changes.

Agent Ping, Webhook Gate, and any future step types all render their fields from the same schema-driven path.

Closes #183