### PR TITLE
refactor: Scope queue cache invalidation to specific pipeline

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowCard.jsx
@@ -282,9 +282,10 @@ function FlowCardContent( props ) {
 				flowId: currentFlowData.flow_id,
 				flowStepId,
 				flowName: currentFlowData.flow_name,
+				pipelineId: currentFlowData.pipeline_id,
 			} );
 		},
-		[ currentFlowData.flow_id, currentFlowData.flow_name, openModal ]
+		[ currentFlowData.flow_id, currentFlowData.flow_name, currentFlowData.pipeline_id, openModal ]
 	);
 
 	/**

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -164,6 +164,7 @@ export default function FlowStepCard( {
 						<QueueablePromptField
 							flowId={ flowId }
 							flowStepId={ flowStepId }
+							pipelineId={ pipelineId }
 							prompt={ currentPrompt }
 							promptQueue={ promptQueue }
 							queueEnabled={ queueEnabled }

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/QueueablePromptField.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/QueueablePromptField.jsx
@@ -37,6 +37,7 @@ import { AUTO_SAVE_DELAY } from '../../utils/constants';
 export default function QueueablePromptField( {
 	flowId,
 	flowStepId,
+	pipelineId,
 	prompt = '',
 	promptQueue = [],
 	queueEnabled = false,
@@ -97,6 +98,7 @@ export default function QueueablePromptField( {
 					response = await updateQueueItemMutation.mutateAsync( {
 						flowId,
 						flowStepId,
+						pipelineId,
 						index: 0,
 						prompt: message,
 					} );
@@ -104,6 +106,7 @@ export default function QueueablePromptField( {
 					response = await addToQueueMutation.mutateAsync( {
 						flowId,
 						flowStepId,
+						pipelineId,
 						prompt: message,
 					} );
 				}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/FlowQueueModal.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/FlowQueueModal.jsx
@@ -43,6 +43,7 @@ export default function FlowQueueModal( {
 	flowId,
 	flowStepId,
 	flowName,
+	pipelineId,
 } ) {
 	const [ newPrompt, setNewPrompt ] = useState( '' );
 	const [ confirmClear, setConfirmClear ] = useState( false );
@@ -74,10 +75,11 @@ export default function FlowQueueModal( {
 			updateSettingsMutation.mutate( {
 				flowId,
 				flowStepId,
+				pipelineId,
 				queueEnabled: enabled,
 			} );
 		},
-		[ flowId, flowStepId, updateSettingsMutation ]
+		[ flowId, flowStepId, pipelineId, updateSettingsMutation ]
 	);
 
 	/**
@@ -90,7 +92,7 @@ export default function FlowQueueModal( {
 		}
 
 		addMutation.mutate(
-			{ flowId, flowStepId, prompts: trimmed },
+			{ flowId, flowStepId, pipelineId, prompts: trimmed },
 			{
 				onSuccess: () => {
 					setNewPrompt( '' );
@@ -104,9 +106,9 @@ export default function FlowQueueModal( {
 	 */
 	const handleRemove = useCallback(
 		( index ) => {
-			removeMutation.mutate( { flowId, flowStepId, index } );
+			removeMutation.mutate( { flowId, flowStepId, pipelineId, index } );
 		},
-		[ flowId, flowStepId, removeMutation ]
+		[ flowId, flowStepId, pipelineId, removeMutation ]
 	);
 
 	/**
@@ -119,7 +121,7 @@ export default function FlowQueueModal( {
 		}
 
 		clearMutation.mutate(
-			{ flowId, flowStepId },
+			{ flowId, flowStepId, pipelineId },
 			{
 				onSuccess: () => {
 					setConfirmClear( false );


### PR DESCRIPTION
## Summary

Queue mutations previously invalidated ALL flows across ALL pipelines. Now they scope invalidation to the specific pipeline being modified.

### Problem

Every queue operation (add, remove, clear, update, toggle) called:
```js
queryClient.invalidateQueries({ queryKey: ['flows'] });
```
This triggered refetches for every pipeline's flow list — unnecessary network requests and UI flicker when you're only working in one pipeline.

### Solution

1. **New `invalidateFlows()` helper** in queue.js — scopes to `['flows', pipelineId]` when available, falls back to broad invalidation for backward compat
2. **Thread `pipelineId` through mutation calls:**
   - `FlowCard` → `FlowQueueModal` (via modal data props)
   - `FlowStepCard` → `QueueablePromptField` (via prop)
3. **All 5 queue mutations** now use scoped invalidation

### Files changed

- `queries/queue.js` — `invalidateFlows()` helper, scoped all 5 mutations
- `FlowCard.jsx` — pass `pipelineId` when opening queue modal
- `FlowQueueModal.jsx` — accept and thread `pipelineId` to all mutations
- `FlowStepCard.jsx` — pass `pipelineId` to QueueablePromptField
- `QueueablePromptField.jsx` — accept and thread `pipelineId` to mutations

### Testing

- `npx wp-scripts build` compiles successfully
- Graceful fallback: if `pipelineId` is missing, falls back to broad invalidation (no breaking change)