### PR TITLE
refactor: Move modal callbacks from PipelinesApp into ModalManager

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalManager.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalManager.jsx
@@ -1,30 +1,109 @@
 /**
  * ModalManager Component
  *
- * Centralized modal rendering logic for the pipelines page.
- * Eliminates repetitive conditional rendering in PipelinesApp.
+ * Centralized modal rendering and callback logic for the pipelines page.
+ * Owns all modal-to-modal navigation callbacks, eliminating prop drilling
+ * through PipelinesApp.
  */
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { useQueryClient } from '@tanstack/react-query';
+
 /**
  * Internal dependencies
  */
 import { useUIStore } from '../../stores/uiStore';
+import { useHandlers, useHandlerDetails } from '../../queries/handlers';
+import { useUpdateFlowHandler } from '../../queries/flows';
 import { MODAL_TYPES } from '../../utils/constants';
 import ModalSwitch from './ModalSwitch';
 import { HandlerProvider } from '../../context/HandlerProvider';
 
-export default function ModalManager( {
-	pipelines,
-	handlers,
-	handlerDetails,
-	pipelineConfig,
-	flows,
-	onModalSuccess,
-	onHandlerSelected,
-	onChangeHandler,
-	onOAuthConnect,
-	onBackToSettings,
-} ) {
-	const { activeModal, modalData, closeModal } = useUIStore();
+export default function ModalManager() {
+	const { activeModal, modalData, openModal, closeModal } = useUIStore();
+	const { data: handlers = {} } = useHandlers();
+	const updateHandlerMutation = useUpdateFlowHandler();
+
+	// Fetch handler details when settings modal is open and not already seeded.
+	const handlerSlug =
+		activeModal === MODAL_TYPES.HANDLER_SETTINGS &&
+		! modalData?.handlerDetails
+			? modalData?.handlerSlug
+			: null;
+	const { data: handlerDetails } = useHandlerDetails( handlerSlug );
+
+	/**
+	 * Close the active modal.
+	 */
+	const handleSuccess = useCallback( () => {
+		closeModal();
+	}, [ closeModal ] );
+
+	/**
+	 * Handler selected in HandlerSelectionModal — persist to flow step,
+	 * then transition to HandlerSettingsModal.
+	 */
+	const handleHandlerSelected = useCallback(
+		async ( selectedHandlerSlug ) => {
+			const result = await updateHandlerMutation.mutateAsync( {
+				flowStepId: modalData.flowStepId,
+				handlerSlug: selectedHandlerSlug,
+				settings: {},
+				pipelineId: modalData.pipelineId,
+				stepType: modalData.stepType,
+			} );
+
+			if ( ! result || ! result.success ) {
+				const message =
+					result?.message ||
+					'Failed to assign handler to this flow step.';
+				throw new Error( message );
+			}
+
+			openModal( MODAL_TYPES.HANDLER_SETTINGS, {
+				...modalData,
+				handlerSlug: selectedHandlerSlug,
+				currentSettings:
+					result?.data?.step_config?.handler_config || {},
+			} );
+		},
+		[ openModal, modalData, updateHandlerMutation ]
+	);
+
+	/**
+	 * Navigate from HandlerSettingsModal → HandlerSelectionModal.
+	 */
+	const handleChangeHandler = useCallback( () => {
+		openModal( MODAL_TYPES.HANDLER_SELECTION, modalData );
+	}, [ openModal, modalData ] );
+
+	/**
+	 * Navigate from HandlerSettingsModal → OAuthModal.
+	 */
+	const handleOAuthConnect = useCallback(
+		( oauthHandlerSlug, handlerInfo ) => {
+			openModal( MODAL_TYPES.OAUTH, {
+				...modalData,
+				handlerSlug: oauthHandlerSlug,
+				handlerInfo,
+			} );
+		},
+		[ openModal, modalData ]
+	);
+
+	/**
+	 * Navigate from OAuthModal → HandlerSettingsModal.
+	 */
+	const handleBackToSettings = useCallback( () => {
+		openModal( MODAL_TYPES.HANDLER_SETTINGS, modalData );
+	}, [ openModal, modalData ] );
 
 	if ( ! activeModal ) {
 		return null;
@@ -33,13 +112,13 @@ export default function ModalManager( {
 	const baseProps = {
 		onClose: closeModal,
 		...modalData,
-		onSuccess: onModalSuccess,
+		onSuccess: handleSuccess,
 		handlers,
-		handlerDetails: modalData.handlerDetails ?? handlerDetails,
-		onChangeHandler,
-		onOAuthConnect,
-		onBackToSettings,
-		onSelectHandler: onHandlerSelected,
+		handlerDetails: modalData?.handlerDetails ?? handlerDetails,
+		onChangeHandler: handleChangeHandler,
+		onOAuthConnect: handleOAuthConnect,
+		onBackToSettings: handleBackToSettings,
+		onSelectHandler: handleHandlerSelected,
 	};
 
 	return (


### PR DESCRIPTION
## Summary

Eliminates modal callback prop drilling by moving all modal navigation logic into ModalManager, which already has access to the Zustand store.

### Before

PipelinesApp defined 5 callbacks, passed them through ModalManager (11 props), which spread them into ModalSwitch, which passed them to individual modals:

```
PipelinesApp (defines callbacks)
  → ModalManager (passes through)
    → ModalSwitch (spreads into baseProps)
      → HandlerSettingsModal / HandlerSelectionModal / OAuthModal
```

### After

ModalManager owns its callbacks and fetches its own data:

```
PipelinesApp
  → <ModalManager />  (zero props)

ModalManager (defines callbacks, fetches handlers/details)
  → ModalSwitch
    → individual modals
```

### Changes

**PipelinesApp (342 → 259 lines, -83):**
- Removed: `handleModalSuccess`, `handleHandlerSelected`, `handleChangeHandler`, `handleOAuthConnect`, `handleBackToSettings`
- Removed imports: `useHandlers`, `useHandlerDetails`, `useUpdateFlowHandler`
- Removed from store destructuring: `closeModal`, `activeModal`, `modalData`
- ModalManager rendered as `<ModalManager />` with zero props

**ModalManager (57 → 133 lines):**
- Absorbed all 5 callbacks from PipelinesApp
- Fetches `useHandlers()` and `useHandlerDetails()` directly
- Uses `useUpdateFlowHandler()` for handler selection persistence
- Fully self-contained modal orchestration

### Testing
- `npx wp-scripts build` compiles successfully
- All modal flows preserved: handler selection → settings, settings → change handler, settings → OAuth → back to settings