### PR TITLE
refactor: Unify tool filtering to disabled_tools opt-out pattern

### DIFF
--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -114,7 +114,7 @@ class SettingsAbilities {
 						'default_provider'            => array( 'type' => 'string' ),
 						'default_model'               => array( 'type' => 'string' ),
 						'max_turns'                   => array( 'type' => 'integer' ),
-						'enabled_tools'               => array( 'type' => 'object' ),
+						'disabled_tools'              => array( 'type' => 'object' ),
 						'ai_provider_keys'            => array( 'type' => 'object' ),
 						'queue_tuning'                => array(
 							'type'        => 'object',
@@ -323,7 +323,7 @@ class SettingsAbilities {
 				'description'            => $tool_config['description'] ?? '',
 				'is_configured'          => $tool_manager->is_tool_configured( $tool_name ),
 				'requires_configuration' => $tool_manager->requires_configuration( $tool_name ),
-				'is_enabled'             => isset( $settings['enabled_tools'][ $tool_name ] ),
+				'is_enabled'             => ! isset( $settings['disabled_tools'][ $tool_name ] ),
 			);
 		}
 
@@ -363,7 +363,7 @@ class SettingsAbilities {
 				'default_provider'            => $settings['default_provider'] ?? '',
 				'default_model'               => $settings['default_model'] ?? '',
 				'max_turns'                   => $settings['max_turns'] ?? 12,
-				'enabled_tools'               => $settings['enabled_tools'] ?? array(),
+				'disabled_tools'              => $settings['disabled_tools'] ?? array(),
 				'ai_provider_keys'            => $masked_keys,
 				'queue_tuning'                => $settings['queue_tuning'] ?? array(
 					'concurrent_batches' => 3,
@@ -447,11 +447,11 @@ class SettingsAbilities {
 			$all_settings['max_turns'] = max( 1, min( 50, $turns ) );
 		}
 
-		if ( isset( $input['enabled_tools'] ) ) {
-			$all_settings['enabled_tools'] = array();
-			foreach ( $input['enabled_tools'] as $tool_id => $enabled ) {
-				if ( $enabled ) {
-					$all_settings['enabled_tools'][ sanitize_key( $tool_id ) ] = true;
+		if ( isset( $input['disabled_tools'] ) ) {
+			$all_settings['disabled_tools'] = array();
+			foreach ( $input['disabled_tools'] as $tool_id => $disabled ) {
+				if ( $disabled ) {
+					$all_settings['disabled_tools'][ sanitize_key( $tool_id ) ] = true;
 				}
 			}
 		}

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -498,7 +498,7 @@ class PipelinesCommand extends BaseCommand {
 					'system_prompt' => 'system_prompt',
 					'provider'      => 'provider',
 					'model'         => 'model',
-					'enabled_tools' => 'enabled_tools',
+					'disabled_tools' => 'disabled_tools',
 				);
 
 				$has_update = false;

--- a/inc/Cli/Commands/SettingsCommand.php
+++ b/inc/Cli/Commands/SettingsCommand.php
@@ -131,8 +131,8 @@ class SettingsCommand extends BaseCommand {
 				}
 			}
 
-			// Convenience format for enabled_tools: comma-separated list of tool IDs.
-			if ( 'enabled_tools' === $key && is_string( $value ) && '' !== trim( $value ) && ! str_contains( $value, '{' ) ) {
+			// Convenience format for disabled_tools: comma-separated list of tool IDs.
+			if ( 'disabled_tools' === $key && is_string( $value ) && '' !== trim( $value ) && ! str_contains( $value, '{' ) ) {
 				$tool_ids = array_filter( array_map( 'trim', explode( ',', $value ) ) );
 				if ( ! empty( $tool_ids ) ) {
 					$value = array_fill_keys( $tool_ids, true );

--- a/inc/Core/Admin/Settings/assets/react/components/tabs/AgentTab.jsx
+++ b/inc/Core/Admin/Settings/assets/react/components/tabs/AgentTab.jsx
@@ -31,7 +31,7 @@ import SettingsSaveBar, {
 import ProviderModelSelector from '@shared/components/ai/ProviderModelSelector';
 
 const DEFAULTS = {
-	enabled_tools: {},
+	disabled_tools: {},
 	global_system_prompt: '',
 	default_provider: '',
 	default_model: '',
@@ -103,7 +103,7 @@ const AgentTab = () => {
 	useEffect( () => {
 		if ( data?.settings ) {
 			form.reset( {
-				enabled_tools: data.settings.enabled_tools || {},
+				disabled_tools: data.settings.disabled_tools || {},
 				global_system_prompt:
 					data.settings.global_system_prompt || '',
 				default_provider: data.settings.default_provider || '',
@@ -128,13 +128,13 @@ const AgentTab = () => {
 	};
 
 	const handleToolToggle = ( toolName, enabled ) => {
-		const newTools = { ...form.data.enabled_tools };
+		const newTools = { ...form.data.disabled_tools };
 		if ( enabled ) {
-			newTools[ toolName ] = true;
-		} else {
 			delete newTools[ toolName ];
+		} else {
+			newTools[ toolName ] = true;
 		}
-		form.updateField( 'enabled_tools', newTools );
+		form.updateField( 'disabled_tools', newTools );
 		save.markChanged();
 	};
 
@@ -186,9 +186,9 @@ const AgentTab = () => {
 											const isConfigured =
 												toolConfig.is_configured;
 											const isEnabled =
-												form.data.enabled_tools?.[
+												! ( form.data.disabled_tools?.[
 													toolName
-												] ?? false;
+												] ?? false );
 											const toolLabel =
 												toolConfig.label ||
 												toolName.replace( /_/g, ' ' );

--- a/inc/Engine/Filters/Admin.php
+++ b/inc/Engine/Filters/Admin.php
@@ -170,11 +170,11 @@ function datamachine_get_enabled_global_tools() {
 		}
 	);
 
-	if ( empty( $settings['enabled_tools'] ) ) {
+	if ( empty( $settings['disabled_tools'] ) ) {
 		return $global_tools;
 	}
 
-	return array_intersect_key( $global_tools, array_filter( $settings['enabled_tools'] ) );
+	return array_diff_key( $global_tools, array_filter( $settings['disabled_tools'] ) );
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces global `enabled_tools` (opt-in allowlist) with `disabled_tools` (opt-out blocklist). Now both global and step-level filtering use the **same mental model**: everything configured is on by default, disable what you don't want.

**Closes #162**

## Before
- **Global**: `enabled_tools` — map of `{tool_id: true}` for tools that are ON
- **Step**: `disabled_tools` — array of tool IDs that are OFF
- Two competing concepts = confusing

## After
- **Global**: `disabled_tools` — map of `{tool_id: true}` for tools that are OFF
- **Step**: `disabled_tools` — array of tool IDs that are OFF
- One concept everywhere = simple

## Changes (8 files)

| File | Change |
|------|--------|
| `ToolManager.php` | Flipped `is_globally_enabled()` logic, renamed helper, removed `get_opt_out_defaults()` |
| `AgentTab.jsx` | Flipped toggle handler and `isEnabled` derivation |
| `agent-tab.php` | PHP template uses `disabled_tools`, hidden+checkbox pattern |
| `SettingsAbilities.php` | Schema, response, save handler all use `disabled_tools` |
| `SettingsFilters.php` | Sanitizes `disabled_tools`, removed auto-enable fallback |
| `Admin.php` | `array_intersect_key` → `array_diff_key` (all EXCEPT disabled) |
| `SettingsCommand.php` | CLI convenience format for `disabled_tools` |
| `PipelinesCommand.php` | Field map key update |

## Migration
No migration script needed. Empty `disabled_tools` (the default for existing installs) = all configured tools enabled. This matches the previous behavior where all configured tools were auto-added to `enabled_tools`. Old `enabled_tools` data is harmless dead weight — nothing reads it anymore.

## Net result
`-74 lines, +49 lines` — simpler code, simpler concept.