### PR TITLE
feat: expose GitHub issue tool to chat agent

### DIFF
--- a/inc/Engine/AI/Tools/GitHubIssueTool.php
+++ b/inc/Engine/AI/Tools/GitHubIssueTool.php
@@ -99,7 +99,7 @@ class GitHubIssueTool extends BaseTool {
 			'class'       => __CLASS__,
 			'method'      => 'handle_tool_call',
 			'description' => 'Create a GitHub issue in a repository. Requires a GitHub PAT configured in settings. Use for bug reports, feature requests, and task tracking.',
-			'agent_types' => array( 'system' ),
+			'agent_types' => array( 'system', 'chat' ),
 			'parameters'  => array(
 				'title'  => array(
 					'type'        => 'string',


### PR DESCRIPTION
One-line follow-up to #189. Expands `agent_types` from `['system']` to `['system', 'chat']` so the chat agent can also file GitHub issues. Execution remains async via the system agent task.