### PR TITLE
fix: Register GitHub issue tool as global (was invisible to chat agent)

### DIFF
--- a/inc/Engine/AI/Tools/GitHubIssueTool.php
+++ b/inc/Engine/AI/Tools/GitHubIssueTool.php
@@ -26,7 +26,7 @@ class GitHubIssueTool extends BaseTool {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->registerTool( 'system', 'create_github_issue', array( $this, 'getToolDefinition' ) );
+		$this->registerGlobalTool( 'create_github_issue', array( $this, 'getToolDefinition' ) );
 	}
 
 	/**
@@ -99,7 +99,6 @@ class GitHubIssueTool extends BaseTool {
 			'class'       => __CLASS__,
 			'method'      => 'handle_tool_call',
 			'description' => 'Create a GitHub issue in a repository. Requires a GitHub PAT configured in settings. Use for bug reports, feature requests, and task tracking.',
-			'agent_types' => array( 'system', 'chat' ),
 			'parameters'  => array(
 				'title'  => array(
 					'type'        => 'string',


### PR DESCRIPTION
## Bug

PR #195 changed `agent_types` in the tool definition to `['system', 'chat']`, but that's just metadata. The actual tool routing is determined by which filter hook it's registered on:

- `registerTool('system', ...)` → `datamachine_system_tools` filter
- `getAvailableToolsForChat()` only pulls from `datamachine_global_tools` + `datamachine_chat_tools`

**Result: the chat agent never actually received `create_github_issue`.**

## Fix

Switch from `registerTool('system', ...)` to `registerGlobalTool()`. This matches the `image_generation` pattern — global tool available to all agent types, with async execution delegated to the system agent via Action Scheduler.

One file, two lines changed.