### PR TITLE
refactor: consolidate tool resolution into ToolManager

### DIFF
--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -35,7 +35,7 @@ class ToolExecutor {
 
 			if ( $prev_handler_slug ) {
 				$prev_tools         = apply_filters( 'chubes_ai_tools', array(), $prev_handler_slug, $prev_handler_config, $engine_data );
-				$prev_tools         = self::resolveTools( $prev_tools );
+				$prev_tools         = $tool_manager->resolveAllTools( $prev_tools );
 				$allowed_prev_tools = self::getAllowedTools( $prev_tools, $prev_handler_slug, $current_pipeline_step_id, $tool_manager );
 				$available_tools    = array_merge( $available_tools, $allowed_prev_tools );
 			}
@@ -47,7 +47,7 @@ class ToolExecutor {
 
 			if ( $next_handler_slug ) {
 				$next_tools         = apply_filters( 'chubes_ai_tools', array(), $next_handler_slug, $next_handler_config, $engine_data );
-				$next_tools         = self::resolveTools( $next_tools );
+				$next_tools         = $tool_manager->resolveAllTools( $next_tools );
 				$allowed_next_tools = self::getAllowedTools( $next_tools, $next_handler_slug, $current_pipeline_step_id, $tool_manager );
 				$available_tools    = array_merge( $available_tools, $allowed_next_tools );
 			}
@@ -59,28 +59,6 @@ class ToolExecutor {
 		$available_tools      = array_merge( $available_tools, $allowed_global_tools );
 
 		return array_unique( $available_tools, SORT_REGULAR );
-	}
-
-	/**
-	 * Resolve tool definitions from callables to arrays.
-	 *
-	 * Tool definitions may be registered as callables for lazy evaluation
-	 * (e.g., to defer translations until after init). This method invokes
-	 * callables and returns the resolved array definitions.
-	 *
-	 * @param array $tools Raw tools array (may contain callables)
-	 * @return array Resolved tools array with all definitions as arrays
-	 */
-	private static function resolveTools( array $tools ): array {
-		$resolved = array();
-		foreach ( $tools as $tool_id => $definition ) {
-			if ( is_callable( $definition ) ) {
-				$resolved[ $tool_id ] = $definition();
-			} else {
-				$resolved[ $tool_id ] = is_array( $definition ) ? $definition : array();
-			}
-		}
-		return $resolved;
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -135,7 +135,7 @@ class ToolManager {
 	 * @param array $tools Raw tools array (may contain callables)
 	 * @return array Resolved tools array
 	 */
-	private function resolveAllTools( array $tools ): array {
+	public function resolveAllTools( array $tools ): array {
 		$resolved = array();
 		foreach ( $tools as $tool_id => $definition ) {
 			$resolved[ $tool_id ] = $this->resolveToolDefinition( $tool_id, $definition );

--- a/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
+++ b/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Tests\Unit\AI\Tools;
 
 use DataMachine\Engine\AI\Tools\ToolExecutor;
+use DataMachine\Engine\AI\Tools\ToolManager;
 use WP_UnitTestCase;
 use ReflectionClass;
 
@@ -238,7 +239,8 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 			),
 		);
 
-		$resolved = $this->invokeResolveMethod( $tools );
+		$tool_manager = new ToolManager();
+		$resolved     = $tool_manager->resolveAllTools( $tools );
 
 		$this->assertTrue( $callable_invoked, 'Callable should be invoked' );
 		$this->assertIsArray( $resolved['callable_tool'] );
@@ -252,7 +254,8 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 			'invalid_tool' => 'not an array or callable',
 		);
 
-		$resolved = $this->invokeResolveMethod( $tools );
+		$tool_manager = new ToolManager();
+		$resolved     = $tool_manager->resolveAllTools( $tools );
 
 		$this->assertIsArray( $resolved['invalid_tool'] );
 		$this->assertEmpty( $resolved['invalid_tool'] );
@@ -266,13 +269,6 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 		return $method->invoke( null, $tool_parameters, $tool_def );
 	}
 
-	private function invokeResolveMethod( array $tools ): array {
-		$reflection = new ReflectionClass( ToolExecutor::class );
-		$method     = $reflection->getMethod( 'resolveTools' );
-		$method->setAccessible( true );
-
-		return $method->invoke( null, $tools );
-	}
 }
 
 class TestToolHandler {


### PR DESCRIPTION
Consolidates duplicate tool resolution logic by removing `ToolExecutor::resolveTools()` and using `ToolManager::resolveAllTools()` as the single canonical resolver.

**Changes:**
- Made `ToolManager::resolveAllTools()` public (was private)
- Updated `ToolExecutor::getAvailableTools()` to use `$tool_manager->resolveAllTools()` instead of `self::resolveTools()`
- Removed duplicate `ToolExecutor::resolveTools()` method
- Updated tests to call `ToolManager::resolveAllTools()` directly

Fixes #201