### PR TITLE
refactor: reduce bootstrap require_once sprawl with inc/bootstrap.php

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -36,55 +36,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once __DIR__ . '/inc/Cli/Bootstrap.php';
 }
 
-// Load function files that define global functions used by the plugin
-require_once __DIR__ . '/inc/Engine/Filters/SchedulerIntervals.php';
-require_once __DIR__ . '/inc/Engine/Filters/DataMachineFilters.php';
-require_once __DIR__ . '/inc/Engine/Filters/Handlers.php';
-require_once __DIR__ . '/inc/Engine/Filters/Admin.php';
-require_once __DIR__ . '/inc/Engine/Logger.php';
-require_once __DIR__ . '/inc/Engine/Filters/OAuth.php';
-require_once __DIR__ . '/inc/Engine/Actions/DataMachineActions.php';
-require_once __DIR__ . '/inc/Engine/Filters/EngineData.php';
-require_once __DIR__ . '/inc/Engine/AI/ConversationManager.php';
-require_once __DIR__ . '/inc/Core/Admin/Modal/ModalFilters.php';
-require_once __DIR__ . '/inc/Core/Admin/AdminRootFilters.php';
-require_once __DIR__ . '/inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php';
-require_once __DIR__ . '/inc/Core/Admin/Settings/SettingsFilters.php';
-require_once __DIR__ . '/inc/Core/Admin/Pages/Logs/LogsFilters.php';
-require_once __DIR__ . '/inc/Core/Admin/Pages/Jobs/JobsFilters.php';
-require_once __DIR__ . '/inc/Core/WordPress/PostTrackingTrait.php';
-require_once __DIR__ . '/inc/Core/Steps/StepTypeRegistrationTrait.php';
-require_once __DIR__ . '/inc/Engine/AI/Tools/Global/GoogleSearch.php';
-require_once __DIR__ . '/inc/Engine/AI/Tools/Global/LocalSearch.php';
-require_once __DIR__ . '/inc/Engine/AI/Tools/Global/WebFetch.php';
-require_once __DIR__ . '/inc/Engine/AI/Tools/Global/WordPressPostReader.php';
-require_once __DIR__ . '/inc/Engine/AI/Tools/Global/ImageGeneration.php';
-require_once __DIR__ . '/inc/Engine/AI/Tools/Global/BingWebmaster.php';
-require_once __DIR__ . '/inc/Engine/AI/Tools/Global/GoogleSearchConsole.php';
-require_once __DIR__ . '/inc/Engine/AI/Tools/Global/QueueValidator.php';
-require_once __DIR__ . '/inc/Engine/AI/Tools/GitHubIssueTool.php';
-require_once __DIR__ . '/inc/Engine/AI/System/Tasks/SystemTask.php';
-require_once __DIR__ . '/inc/Engine/AI/System/Tasks/ImageGenerationTask.php';
-require_once __DIR__ . '/inc/Engine/AI/System/Tasks/GitHubIssueTask.php';
-require_once __DIR__ . '/inc/Engine/AI/System/SystemAgent.php';
-require_once __DIR__ . '/inc/Engine/AI/System/SystemAgentServiceProvider.php';
-require_once __DIR__ . '/inc/Engine/AI/Directives/AgentSoulDirective.php';
-require_once __DIR__ . '/inc/Engine/AI/Directives/SiteContext.php';
-require_once __DIR__ . '/inc/Engine/AI/Directives/SiteContextDirective.php';
-require_once __DIR__ . '/inc/Engine/AI/RequestBuilder.php';
-require_once __DIR__ . '/inc/Api/Chat/ChatFilters.php';
-require_once __DIR__ . '/inc/Api/Chat/ChatAgentDirective.php';
-require_once __DIR__ . '/inc/Core/Steps/AI/Directives/PipelineCoreDirective.php';
-require_once __DIR__ . '/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php';
-require_once __DIR__ . '/inc/Core/Steps/AI/Directives/PipelineContextDirective.php';
-require_once __DIR__ . '/inc/Core/FilesRepository/FileCleanup.php';
-require_once __DIR__ . '/inc/Core/ActionScheduler/ClaimsCleanup.php';
-require_once __DIR__ . '/inc/Core/ActionScheduler/QueueTuning.php';
-require_once __DIR__ . '/inc/Api/StepTypes.php';
-require_once __DIR__ . '/inc/Api/Handlers.php';
-require_once __DIR__ . '/inc/Api/Providers.php';
-require_once __DIR__ . '/inc/Api/Tools.php';
-require_once __DIR__ . '/inc/Api/Chat/Chat.php';
+// Procedural includes and side-effect registrations (see inc/bootstrap.php).
+// Namespaced classes without file-level side effects rely on Composer PSR-4.
+require_once __DIR__ . '/inc/bootstrap.php';
 
 if ( ! class_exists( 'ActionScheduler' ) ) {
 	require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Plugin bootstrap — procedural includes and side-effect registrations.
+ *
+ * Namespaced classes without file-level side effects are autoloaded by
+ * Composer (see composer.json PSR-4 config). Only files that define
+ * global functions or register hooks/filters at load time are listed here.
+ *
+ * @package DataMachine
+ * @since   0.26.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/*
+|--------------------------------------------------------------------------
+| Procedural function files (no namespace, no class)
+|--------------------------------------------------------------------------
+| These define global functions and cannot be autoloaded by Composer.
+*/
+
+require_once __DIR__ . '/Engine/Filters/SchedulerIntervals.php';
+require_once __DIR__ . '/Engine/Filters/DataMachineFilters.php';
+require_once __DIR__ . '/Engine/Filters/Handlers.php';
+require_once __DIR__ . '/Engine/Filters/Admin.php';
+require_once __DIR__ . '/Engine/Logger.php';
+require_once __DIR__ . '/Engine/Filters/OAuth.php';
+require_once __DIR__ . '/Engine/Actions/DataMachineActions.php';
+require_once __DIR__ . '/Engine/Filters/EngineData.php';
+require_once __DIR__ . '/Core/Admin/Settings/SettingsFilters.php';
+
+/*
+|--------------------------------------------------------------------------
+| Namespaced files with file-level side effects
+|--------------------------------------------------------------------------
+| These contain namespaced functions or classes but register hooks/filters
+| at the file level (outside any class method). They must be explicitly
+| loaded so those registrations fire at include time.
+*/
+
+require_once __DIR__ . '/Core/Admin/Modal/ModalFilters.php';
+require_once __DIR__ . '/Core/Admin/AdminRootFilters.php';
+require_once __DIR__ . '/Core/Admin/Pages/Pipelines/PipelinesFilters.php';
+require_once __DIR__ . '/Core/Admin/Pages/Logs/LogsFilters.php';
+require_once __DIR__ . '/Core/Admin/Pages/Jobs/JobsFilters.php';
+require_once __DIR__ . '/Api/Chat/ChatFilters.php';
+require_once __DIR__ . '/Engine/AI/Directives/AgentSoulDirective.php';
+require_once __DIR__ . '/Engine/AI/Directives/SiteContext.php';
+require_once __DIR__ . '/Api/Chat/ChatAgentDirective.php';
+require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineCoreDirective.php';
+require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php';
+require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineContextDirective.php';
+require_once __DIR__ . '/Core/FilesRepository/FileCleanup.php';
+require_once __DIR__ . '/Core/ActionScheduler/ClaimsCleanup.php';
+require_once __DIR__ . '/Core/ActionScheduler/QueueTuning.php';


### PR DESCRIPTION
Fixes #202

## Summary

Replaces ~45 individual `require_once` statements in `data-machine.php` (lines 40-88) with a single `require_once __DIR__ . '/inc/bootstrap.php'`.

## What changed

- **Created `inc/bootstrap.php`** — contains only the requires that can't be autoloaded:
  - 9 procedural function files (no namespace, no class — Composer can't autoload these)
  - 15 namespaced files with file-level side effects (hooks/filters registered at include time)
- **Removed 24 require_once lines** for pure namespaced classes/traits that Composer PSR-4 already handles
- **Kept in `data-machine.php`**: `vendor/autoload.php` (before bootstrap), WP-CLI conditional require, ActionScheduler conditional require

## What was NOT changed

- No file contents modified — only loading mechanism changed
- All files with file-level `add_action`/`add_filter` calls are still explicitly required
- Composer autoload config unchanged