### PR TITLE
refactor: introduce ToolServiceProvider for centralized tool registration

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -86,8 +86,8 @@ function datamachine_run_datamachine_plugin() {
 	// Initialize FetchHandler to register skip_item tool for all fetch-type handlers
 	\DataMachine\Core\Steps\Fetch\Handlers\FetchHandler::init();
 
-	// Load chat tools - must happen AFTER step types and handlers are registered
-	datamachine_load_chat_tools();
+	// Register all tools - must happen AFTER step types and handlers are registered.
+	\DataMachine\Engine\AI\Tools\ToolServiceProvider::register();
 
 	\DataMachine\Api\Execute::register();
 	\DataMachine\Api\Pipelines\Pipelines::register();
@@ -220,43 +220,6 @@ function datamachine_load_handlers() {
 
 	// Update Handlers
 	new \DataMachine\Core\Steps\Update\Handlers\WordPress\WordPress();
-}
-
-/**
- * Load chat tools - must be called AFTER step types and handlers are registered.
- * These tools build their descriptions from registered step types and handlers.
- */
-function datamachine_load_chat_tools() {
-	new \DataMachine\Api\Chat\Tools\ApiQuery();
-	new \DataMachine\Api\Chat\Tools\CreatePipeline();
-	new \DataMachine\Api\Chat\Tools\AddPipelineStep();
-	new \DataMachine\Api\Chat\Tools\CreateFlow();
-	new \DataMachine\Api\Chat\Tools\ConfigureFlowSteps();
-	new \DataMachine\Api\Chat\Tools\RunFlow();
-	new \DataMachine\Api\Chat\Tools\UpdateFlow();
-	new \DataMachine\Api\Chat\Tools\ConfigurePipelineStep();
-	new \DataMachine\Api\Chat\Tools\ExecuteWorkflowTool();
-	new \DataMachine\Api\Chat\Tools\CopyFlow();
-	new \DataMachine\Api\Chat\Tools\AuthenticateHandler();
-	new \DataMachine\Api\Chat\Tools\ReadLogs();
-	new \DataMachine\Api\Chat\Tools\ManageLogs();
-	new \DataMachine\Api\Chat\Tools\CreateTaxonomyTerm();
-	new \DataMachine\Api\Chat\Tools\SearchTaxonomyTerms();
-	new \DataMachine\Api\Chat\Tools\UpdateTaxonomyTerm();
-	new \DataMachine\Api\Chat\Tools\MergeTaxonomyTerms();
-	new \DataMachine\Api\Chat\Tools\AssignTaxonomyTerm();
-	new \DataMachine\Api\Chat\Tools\GetHandlerDefaults();
-	new \DataMachine\Api\Chat\Tools\SetHandlerDefaults();
-	new \DataMachine\Api\Chat\Tools\DeleteFile();
-	new \DataMachine\Api\Chat\Tools\DeleteFlow();
-	new \DataMachine\Api\Chat\Tools\DeletePipeline();
-	new \DataMachine\Api\Chat\Tools\DeletePipelineStep();
-	new \DataMachine\Api\Chat\Tools\ReorderPipelineSteps();
-	new \DataMachine\Api\Chat\Tools\ListFlows();
-	new \DataMachine\Api\Chat\Tools\ManageQueue();
-	new \DataMachine\Api\Chat\Tools\ManageJobs();
-	new \DataMachine\Api\Chat\Tools\SendPing();
-	new \DataMachine\Api\Chat\Tools\SystemHealthCheck();
 }
 
 /**

--- a/inc/Engine/AI/Tools/Global/AmazonAffiliateLink.php
+++ b/inc/Engine/AI/Tools/Global/AmazonAffiliateLink.php
@@ -443,5 +443,3 @@ class AmazonAffiliateLink extends BaseTool {
 	}
 }
 
-// Self-register the tool.
-new AmazonAffiliateLink();

--- a/inc/Engine/AI/Tools/Global/BingWebmaster.php
+++ b/inc/Engine/AI/Tools/Global/BingWebmaster.php
@@ -205,5 +205,3 @@ class BingWebmaster extends BaseTool {
 	}
 }
 
-// Self-register the tool.
-new BingWebmaster();

--- a/inc/Engine/AI/Tools/Global/GoogleSearch.php
+++ b/inc/Engine/AI/Tools/Global/GoogleSearch.php
@@ -247,5 +247,3 @@ class GoogleSearch extends BaseTool {
 	}
 }
 
-// Self-register the tool
-new GoogleSearch();

--- a/inc/Engine/AI/Tools/Global/GoogleSearchConsole.php
+++ b/inc/Engine/AI/Tools/Global/GoogleSearchConsole.php
@@ -241,5 +241,3 @@ class GoogleSearchConsole extends BaseTool {
 	}
 }
 
-// Self-register the tool.
-new GoogleSearchConsole();

--- a/inc/Engine/AI/Tools/Global/ImageGeneration.php
+++ b/inc/Engine/AI/Tools/Global/ImageGeneration.php
@@ -253,5 +253,3 @@ class ImageGeneration extends BaseTool {
 	}
 }
 
-// Self-register the tool.
-new ImageGeneration();

--- a/inc/Engine/AI/Tools/Global/LocalSearch.php
+++ b/inc/Engine/AI/Tools/Global/LocalSearch.php
@@ -114,4 +114,3 @@ class LocalSearch extends BaseTool {
 	}
 }
 
-new LocalSearch();

--- a/inc/Engine/AI/Tools/Global/QueueValidator.php
+++ b/inc/Engine/AI/Tools/Global/QueueValidator.php
@@ -404,5 +404,3 @@ class QueueValidator extends BaseTool {
 	}
 }
 
-// Self-register the tool.
-new QueueValidator();

--- a/inc/Engine/AI/Tools/Global/WebFetch.php
+++ b/inc/Engine/AI/Tools/Global/WebFetch.php
@@ -163,5 +163,3 @@ class WebFetch extends BaseTool {
 	}
 }
 
-// Self-register the tool
-new WebFetch();

--- a/inc/Engine/AI/Tools/Global/WordPressPostReader.php
+++ b/inc/Engine/AI/Tools/Global/WordPressPostReader.php
@@ -148,5 +148,3 @@ class WordPressPostReader extends BaseTool {
 	}
 }
 
-// Self-register the tool
-new WordPressPostReader();

--- a/inc/Engine/AI/Tools/ToolServiceProvider.php
+++ b/inc/Engine/AI/Tools/ToolServiceProvider.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tool Service Provider.
+ *
+ * Centralizes registration of all global and chat tools.
+ * Global tools are registered first, then chat tools (which depend
+ * on step types and handlers already being registered).
+ *
+ * @package DataMachine\Engine\AI\Tools
+ * @since   0.27.0
+ */
+
+namespace DataMachine\Engine\AI\Tools;
+
+defined( 'ABSPATH' ) || exit;
+
+// Global tools.
+use DataMachine\Engine\AI\Tools\Global\AmazonAffiliateLink;
+use DataMachine\Engine\AI\Tools\Global\BingWebmaster;
+use DataMachine\Engine\AI\Tools\Global\GoogleSearch;
+use DataMachine\Engine\AI\Tools\Global\GoogleSearchConsole;
+use DataMachine\Engine\AI\Tools\Global\ImageGeneration;
+use DataMachine\Engine\AI\Tools\Global\LocalSearch;
+use DataMachine\Engine\AI\Tools\Global\QueueValidator;
+use DataMachine\Engine\AI\Tools\Global\WebFetch;
+use DataMachine\Engine\AI\Tools\Global\WordPressPostReader;
+
+// Chat tools.
+use DataMachine\Api\Chat\Tools\AddPipelineStep;
+use DataMachine\Api\Chat\Tools\ApiQuery;
+use DataMachine\Api\Chat\Tools\AssignTaxonomyTerm;
+use DataMachine\Api\Chat\Tools\AuthenticateHandler;
+use DataMachine\Api\Chat\Tools\ConfigureFlowSteps;
+use DataMachine\Api\Chat\Tools\ConfigurePipelineStep;
+use DataMachine\Api\Chat\Tools\CopyFlow;
+use DataMachine\Api\Chat\Tools\CreateFlow;
+use DataMachine\Api\Chat\Tools\CreatePipeline;
+use DataMachine\Api\Chat\Tools\CreateTaxonomyTerm;
+use DataMachine\Api\Chat\Tools\DeleteFile;
+use DataMachine\Api\Chat\Tools\DeleteFlow;
+use DataMachine\Api\Chat\Tools\DeletePipeline;
+use DataMachine\Api\Chat\Tools\DeletePipelineStep;
+use DataMachine\Api\Chat\Tools\ExecuteWorkflowTool;
+use DataMachine\Api\Chat\Tools\GetHandlerDefaults;
+use DataMachine\Api\Chat\Tools\ListFlows;
+use DataMachine\Api\Chat\Tools\ManageJobs;
+use DataMachine\Api\Chat\Tools\ManageLogs;
+use DataMachine\Api\Chat\Tools\ManageQueue;
+use DataMachine\Api\Chat\Tools\MergeTaxonomyTerms;
+use DataMachine\Api\Chat\Tools\ReadLogs;
+use DataMachine\Api\Chat\Tools\ReorderPipelineSteps;
+use DataMachine\Api\Chat\Tools\RunFlow;
+use DataMachine\Api\Chat\Tools\SearchTaxonomyTerms;
+use DataMachine\Api\Chat\Tools\SendPing;
+use DataMachine\Api\Chat\Tools\SetHandlerDefaults;
+use DataMachine\Api\Chat\Tools\SystemHealthCheck;
+use DataMachine\Api\Chat\Tools\UpdateFlow;
+use DataMachine\Api\Chat\Tools\UpdateTaxonomyTerm;
+
+/**
+ * Registers all global and chat tools.
+ */
+class ToolServiceProvider {
+
+	/**
+	 * Register all tools.
+	 *
+	 * Global tools are registered first because chat tools may depend
+	 * on handlers and step types that global tools provide.
+	 */
+	public static function register(): void {
+		self::registerGlobalTools();
+		self::registerChatTools();
+	}
+
+	/**
+	 * Register global tools.
+	 *
+	 * These tools are available to all agent types (pipeline, system, chat).
+	 */
+	private static function registerGlobalTools(): void {
+		new AmazonAffiliateLink();
+		new BingWebmaster();
+		new GoogleSearch();
+		new GoogleSearchConsole();
+		new ImageGeneration();
+		new LocalSearch();
+		new QueueValidator();
+		new WebFetch();
+		new WordPressPostReader();
+	}
+
+	/**
+	 * Register chat tools.
+	 *
+	 * These tools are only available to the chat agent and depend on
+	 * step types and handlers being already registered.
+	 */
+	private static function registerChatTools(): void {
+		new ApiQuery();
+		new CreatePipeline();
+		new AddPipelineStep();
+		new CreateFlow();
+		new ConfigureFlowSteps();
+		new RunFlow();
+		new UpdateFlow();
+		new ConfigurePipelineStep();
+		new ExecuteWorkflowTool();
+		new CopyFlow();
+		new AuthenticateHandler();
+		new ReadLogs();
+		new ManageLogs();
+		new CreateTaxonomyTerm();
+		new SearchTaxonomyTerms();
+		new UpdateTaxonomyTerm();
+		new MergeTaxonomyTerms();
+		new AssignTaxonomyTerm();
+		new GetHandlerDefaults();
+		new SetHandlerDefaults();
+		new DeleteFile();
+		new DeleteFlow();
+		new DeletePipeline();
+		new DeletePipelineStep();
+		new ReorderPipelineSteps();
+		new ListFlows();
+		new ManageQueue();
+		new ManageJobs();
+		new SendPing();
+		new SystemHealthCheck();
+	}
+}


### PR DESCRIPTION
Fixes #203

## Changes

- Created `ToolServiceProvider` (`inc/Engine/AI/Tools/ToolServiceProvider.php`) with a static `register()` method that centralizes instantiation of all 9 global tools and 30 chat tools
- Removed self-instantiation (`new ClassName();`) from the bottom of all 9 `Global/*.php` tool files
- Removed `datamachine_load_chat_tools()` function from `data-machine.php`
- Replaced the call site with `ToolServiceProvider::register()`, preserving the existing call order (after step types and handlers are registered)
- All classes remain autoloaded via Composer PSR-4; no changes to `inc/bootstrap.php` needed

## Registration Order (preserved)
1. `ToolManager::init()`
2. Step types loaded
3. Handlers loaded
4. **`ToolServiceProvider::register()`** → global tools first, then chat tools