### PR TITLE
refactor: consolidate EngineData persistence into Core\EngineData class

### DIFF
--- a/inc/Engine/Filters/EngineData.php
+++ b/inc/Engine/Filters/EngineData.php
@@ -2,6 +2,9 @@
 /**
  * Engine data snapshot helpers.
  *
+ * Thin wrappers around \DataMachine\Core\EngineData static methods.
+ * Kept for backward compatibility.
+ *
  * @package DataMachine\Engine
  */
 
@@ -10,54 +13,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Retrieve engine data snapshot for a job.
+ *
+ * @param int $job_id Job ID.
+ * @return array Engine data array.
+ */
+function datamachine_get_engine_data( int $job_id ): array {
+	return \DataMachine\Core\EngineData::retrieve( $job_id );
+}
+
+/**
  * Persist a complete engine data snapshot for a job.
+ *
+ * @param int   $job_id   Job ID.
+ * @param array $snapshot Engine data snapshot.
+ * @return bool True on success.
  */
 function datamachine_set_engine_data( int $job_id, array $snapshot ): bool {
-	if ( $job_id <= 0 ) {
-		return false;
-	}
-
-	$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
-	$success = $db_jobs->store_engine_data( $job_id, $snapshot );
-
-	if ( $success ) {
-		wp_cache_set( $job_id, $snapshot, 'datamachine_engine_data' );
-	}
-
-	return $success;
+	return \DataMachine\Core\EngineData::persist( $job_id, $snapshot );
 }
 
 /**
  * Merge new data into the stored engine snapshot.
+ *
+ * @param int   $job_id Job ID.
+ * @param array $data   Data to merge.
+ * @return bool True on success.
  */
 function datamachine_merge_engine_data( int $job_id, array $data ): bool {
-	if ( $job_id <= 0 ) {
-		return false;
-	}
-
-	$current = datamachine_get_engine_data( $job_id );
-	$merged  = array_replace_recursive( $current, $data );
-
-	return datamachine_set_engine_data( $job_id, $merged );
-}
-
-/**
- * Retrieve engine data snapshot for a job.
- */
-function datamachine_get_engine_data( int $job_id ): array {
-	if ( $job_id <= 0 ) {
-		return array();
-	}
-
-	$cached = wp_cache_get( $job_id, 'datamachine_engine_data' );
-	if ( false !== $cached ) {
-		return is_array( $cached ) ? $cached : array();
-	}
-
-	$db_jobs     = new \DataMachine\Core\Database\Jobs\Jobs();
-	$engine_data = $db_jobs->retrieve_engine_data( $job_id );
-
-	wp_cache_set( $job_id, $engine_data, 'datamachine_engine_data' );
-
-	return $engine_data;
+	return \DataMachine\Core\EngineData::merge( $job_id, $data );
 }


### PR DESCRIPTION
Fixes #208

Moves the 3 procedural persistence functions from `inc/Engine/Filters/EngineData.php` into static methods on the `\DataMachine\Core\EngineData` class:

- `EngineData::retrieve()` — replaces `datamachine_get_engine_data()`
- `EngineData::persist()` — replaces `datamachine_set_engine_data()`
- `EngineData::merge()` — replaces `datamachine_merge_engine_data()`

Adds `EngineData::forJob()` factory method for convenient instantiation.

The procedural functions remain as thin wrappers for backward compatibility — no callers need updating.