### PR TITLE
refactor: extract BaseRepository for shared database CRUD patterns

### DIFF
--- a/inc/Core/Database/BaseRepository.php
+++ b/inc/Core/Database/BaseRepository.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Base Repository for shared database CRUD patterns.
+ *
+ * Provides common constructor logic (wpdb + table name), helper methods
+ * for simple lookups, deletes, counts, and standardized error logging.
+ *
+ * @package DataMachine\Core\Database
+ * @since   0.19.0
+ */
+
+namespace DataMachine\Core\Database;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Abstract base class for database repository classes.
+ *
+ * Child classes must define a TABLE_NAME constant with the unprefixed table name.
+ */
+abstract class BaseRepository {
+
+	/**
+	 * WordPress database instance.
+	 *
+	 * @var \wpdb
+	 */
+	protected $wpdb;
+
+	/**
+	 * Full prefixed table name.
+	 *
+	 * @var string
+	 */
+	protected $table_name;
+
+	/**
+	 * Initialize wpdb and build the prefixed table name from the child's TABLE_NAME constant.
+	 */
+	public function __construct() {
+		global $wpdb;
+		$this->wpdb       = $wpdb;
+		$this->table_name = $wpdb->prefix . static::TABLE_NAME;
+	}
+
+	/**
+	 * Get the full prefixed table name.
+	 *
+	 * @return string
+	 */
+	public function get_table_name(): string {
+		return $this->table_name;
+	}
+
+	/**
+	 * Find a single row by primary key column.
+	 *
+	 * @param string     $id_column Column name.
+	 * @param int|string $id        Value to match.
+	 * @return array|null Row as associative array or null.
+	 */
+	protected function find_by_id( string $id_column, $id ): ?array {
+		$format = is_int( $id ) ? '%d' : '%s';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT * FROM {$this->table_name} WHERE {$id_column} = {$format}",
+				$id
+			),
+			ARRAY_A
+		);
+
+		return $row ?: null;
+	}
+
+	/**
+	 * Delete a single row by primary key column.
+	 *
+	 * @param string     $id_column Column name.
+	 * @param int|string $id        Value to match.
+	 * @return bool True on success, false on failure.
+	 */
+	protected function delete_by_id( string $id_column, $id ): bool {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $this->wpdb->delete(
+			$this->table_name,
+			array( $id_column => $id ),
+			array( is_int( $id ) ? '%d' : '%s' )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Count rows with an optional WHERE clause.
+	 *
+	 * @param string $where        SQL WHERE clause (without "WHERE" keyword). Default '1=1'.
+	 * @param array  $prepare_args Values for wpdb::prepare placeholders.
+	 * @return int Row count.
+	 */
+	protected function count_rows( string $where = '1=1', array $prepare_args = array() ): int {
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$sql = "SELECT COUNT(*) FROM {$this->table_name} WHERE {$where}";
+
+		if ( ! empty( $prepare_args ) ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$sql = $this->wpdb->prepare( $sql, ...$prepare_args );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		return (int) $this->wpdb->get_var( $sql );
+	}
+
+	/**
+	 * Log a database error if one occurred on the last query.
+	 *
+	 * @param string $context Description of the operation that failed.
+	 * @param array  $extra   Additional context to include in the log entry.
+	 * @return void
+	 */
+	protected function log_db_error( string $context, array $extra = array() ): void {
+		if ( ! empty( $this->wpdb->last_error ) ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				"DB error: {$context}",
+				array_merge(
+					array(
+						'db_error' => $this->wpdb->last_error,
+						'table'    => $this->table_name,
+					),
+					$extra
+				)
+			);
+		}
+	}
+}

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Core\Database\Chat;
 
 use DataMachine\Core\Admin\DateFormatter;
+use DataMachine\Core\Database\BaseRepository;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -20,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Chat Database Manager
  */
-class Chat {
+class Chat extends BaseRepository {
 
 	/**
 	 * Table name (without prefix)

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -2,6 +2,8 @@
 
 namespace DataMachine\Core\Database\Flows;
 
+use DataMachine\Core\Database\BaseRepository;
+
 /**
  * Flows Database Class
  *
@@ -9,17 +11,9 @@ namespace DataMachine\Core\Database\Flows;
  * and scheduling. Flow-level scheduling only - no pipeline-level scheduling.
  * Admin-only implementation.
  */
-class Flows {
+class Flows extends BaseRepository {
 
-	private $table_name;
-
-	private $wpdb;
-
-	public function __construct() {
-		global $wpdb;
-		$this->wpdb       = $wpdb;
-		$this->table_name = $this->wpdb->prefix . 'datamachine_flows';
-	}
+	const TABLE_NAME = 'datamachine_flows';
 
 	public static function create_table(): void {
 		global $wpdb;

--- a/inc/Core/Database/Jobs/JobsOperations.php
+++ b/inc/Core/Database/Jobs/JobsOperations.php
@@ -5,21 +5,15 @@
 
 namespace DataMachine\Core\Database\Jobs;
 
+use DataMachine\Core\Database\BaseRepository;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-class JobsOperations {
+class JobsOperations extends BaseRepository {
 
-	private $table_name;
-
-	private $wpdb;
-
-	public function __construct() {
-		global $wpdb;
-		$this->wpdb       = $wpdb;
-		$this->table_name = $wpdb->prefix . 'datamachine_jobs';
-	}
+	const TABLE_NAME = 'datamachine_jobs';
 
 	/**
 	 * Create a new job record.

--- a/inc/Core/Database/Jobs/JobsStatus.php
+++ b/inc/Core/Database/Jobs/JobsStatus.php
@@ -14,34 +14,16 @@
 
 namespace DataMachine\Core\Database\Jobs;
 
+use DataMachine\Core\Database\BaseRepository;
 use DataMachine\Core\JobStatus;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-class JobsStatus {
+class JobsStatus extends BaseRepository {
 
-	/**
-	 * The name of the jobs database table.
-	 *
-	 * @var string
-	 */
-	private $table_name;
-
-	/**
-	 * @var \wpdb WordPress database instance
-	 */
-	private $wpdb;
-
-	/**
-	 * Initialize the status component.
-	 */
-	public function __construct() {
-		global $wpdb;
-		$this->wpdb       = $wpdb;
-		$this->table_name = $this->wpdb->prefix . 'datamachine_jobs';
-	}
+	const TABLE_NAME = 'datamachine_jobs';
 
 	/**
 	 * Update the status for a job.

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -9,21 +9,13 @@
 
 namespace DataMachine\Core\Database\Pipelines;
 
+use DataMachine\Core\Database\BaseRepository;
+
 defined( 'ABSPATH' ) || exit;
 
-class Pipelines {
+class Pipelines extends BaseRepository {
 
-	/** @var string Database table name */
-	private $table_name;
-
-	/** @var \wpdb WordPress database instance */
-	private $wpdb;
-
-	public function __construct() {
-		global $wpdb;
-		$this->wpdb       = $wpdb;
-		$this->table_name = $wpdb->prefix . 'datamachine_pipelines';
-	}
+	const TABLE_NAME = 'datamachine_pipelines';
 
 	/**
 	 * Create a new pipeline in the database.

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -12,21 +12,15 @@
 
 namespace DataMachine\Core\Database\ProcessedItems;
 
+use DataMachine\Core\Database\BaseRepository;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-class ProcessedItems {
+class ProcessedItems extends BaseRepository {
 
-	private $table_name;
-	private $wpdb;
-
-
-	public function __construct() {
-		global $wpdb;
-		$this->wpdb       = $wpdb;
-		$this->table_name = $this->wpdb->prefix . 'datamachine_processed_items';
-	}
+	const TABLE_NAME = 'datamachine_processed_items';
 
 
 	/**


### PR DESCRIPTION
## Summary

Extracts a shared `BaseRepository` abstract class that consolidates the duplicated constructor pattern (`global $wpdb` + table name setup) found across all 6 database repository classes.

### Changes

- **New**: `inc/Core/Database/BaseRepository.php` — abstract base with:
  - Shared constructor: `$wpdb` assignment + prefixed table name from child `TABLE_NAME` constant
  - `get_table_name()` — public accessor
  - `find_by_id()` — single-row lookup by primary key
  - `delete_by_id()` — single-row delete by primary key
  - `count_rows()` — count with optional WHERE clause
  - `log_db_error()` — standardized error logging via `datamachine_log` action

- **Updated 6 classes** to extend `BaseRepository`:
  - `Chat`, `Flows`, `Pipelines`, `JobsOperations`, `JobsStatus`, `ProcessedItems`
  - Each adds `const TABLE_NAME` and removes duplicate constructor logic
  - `Jobs.php` (facade) left unchanged — it delegates, doesn't do DB ops

### What's NOT changed
- No method bodies refactored to use base helpers yet (incremental approach)
- Complex/custom queries untouched
- Static methods (e.g. `create_table()`) remain static

This is foundational work — future PRs can migrate individual methods to use the base class helpers.

Fixes #209