### PR TITLE
feat: Image generation insert mode for placing images in post content

### DIFF
--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -101,6 +101,14 @@ class ImageGenerationAbilities {
 								'description' => 'Post ID to set the generated image as featured image (for standalone/direct calls).',
 							],
 
+							'mode'            => [
+								'type'        => 'string',
+								'description' => 'Post-sideload behavior: featured (set as featured image, default) or insert (insert image block into post content).',
+							],
+							'position'        => [
+								'type'        => 'string',
+								'description' => 'Where to insert image in content (insert mode only): after_intro (default), before_heading, end, or index:N.',
+							],
 							'post_context'    => [
 								'type'        => 'string',
 								'description' => 'Optional post content/excerpt for context-aware prompt refinement.',
@@ -221,6 +229,12 @@ class ImageGenerationAbilities {
 		}
 		if ( ! empty( $input['post_id'] ) ) {
 			$context['post_id'] = (int) $input['post_id'];
+		}
+		if ( ! empty( $input['mode'] ) ) {
+			$context['mode'] = sanitize_text_field( $input['mode'] );
+		}
+		if ( ! empty( $input['position'] ) ) {
+			$context['position'] = sanitize_text_field( $input['position'] );
 		}
 
 		$systemAgent = SystemAgent::getInstance();


### PR DESCRIPTION
Closes #235

Adds mode parameter to image generation: featured (default, existing) and insert (new).

Insert mode places a wp:image block into post_content at a configurable position:
- after_intro (default) — after first paragraph
- before_heading — before first H2/H3
- end — append to bottom
- index:N — explicit block index

Builds on #234 (standalone post_id support).