### PR TITLE
fix: remove showSettingsDisplay gate from InlineStepConfig (#239)

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -47,7 +47,6 @@ export default function FlowStepCard( {
 } ) {
 	const { data: stepTypes = {} } = useStepTypes();
 	const stepTypeInfo = stepTypes[ pipelineStep.step_type ] || {};
-	const showSettingsDisplay = stepTypeInfo.show_settings_display !== false;
 
 	const isAiStep = pipelineStep.step_type === 'ai';
 	const aiConfig = isAiStep
@@ -148,8 +147,12 @@ export default function FlowStepCard( {
 						</div>
 					) }
 
-					{ /* Inline Config Fields (schema-driven from handler details API) */ }
-					{ showSettingsDisplay && effectiveHandlerSlug && (
+					{ /* Inline Config Fields (schema-driven from handler details API).
+					   Renders for any step type with registered fields — the component
+					   self-determines whether to render based on API response (returns
+					   null when no fields exist). Not gated by show_settings_display,
+					   which controls the PHP-side read-only summary, not the React editor. */ }
+					{ effectiveHandlerSlug && (
 						<InlineStepConfig
 							flowStepId={ flowStepId }
 							handlerConfig={ flowStepConfig?.handler_config || {} }


### PR DESCRIPTION
## Problem

PR #184 gated `InlineStepConfig` rendering on `show_settings_display`, which is a PHP-side flag controlling the read-only settings summary in flow config responses. This prevented step types like Agent Ping (`showSettingsDisplay: false`) from rendering their editable inline fields — webhook URL, auth header, auth token, and reply-to channel all disappeared from the pipeline builder.

## Fix

Remove the `showSettingsDisplay` guard. `InlineStepConfig` already self-determines whether to render based on the handler details API response (returns `null` when `fieldEntries.length === 0`), and the `/handlers/{slug}` endpoint already serves field schemas for step types via `SettingsDisplayService::getFieldState()` fallback.

Also removed the now-unused `showSettingsDisplay` variable (no dead variables per coding standards).

## What This Restores

- Agent Ping inline fields: webhook URL(s), auth header name, auth token, reply-to channel
- Any future non-handler step type with registered fields will render correctly without needing `showSettingsDisplay: true`

## What Stays the Same

- Handler-based steps (fetch/publish/update) — unaffected, they resolve via `flowStepConfig.handler_slug`
- `FlowStepHandler` (badge + configure button) — still only renders for `usesHandler` steps
- AI step — unaffected, `uses_handler: false` so `effectiveHandlerSlug = 'ai'`, and if no fields are registered for `ai` slug, `InlineStepConfig` returns null

Fixes #239