### PR TITLE
fix: register missing API endpoints for data-driven UI

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -105,6 +105,10 @@ function datamachine_run_datamachine_plugin() {
 	\DataMachine\Api\Auth::register();
 	\DataMachine\Api\Chat\Chat::register();
 	\DataMachine\Api\System\System::register();
+	\DataMachine\Api\Handlers::register();
+	\DataMachine\Api\StepTypes::register();
+	\DataMachine\Api\Tools::register();
+	\DataMachine\Api\Providers::register();
 
 	// Load abilities
 	require_once __DIR__ . '/inc/Abilities/AuthAbilities.php';

--- a/inc/Api/Handlers.php
+++ b/inc/Api/Handlers.php
@@ -29,6 +29,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Handlers {
 
 	/**
+	 * Register the API endpoint.
+	 */
+	public static function register() {
+		add_action( 'rest_api_init', array( self::class, 'register_routes' ) );
+	}
+
+	/**
 	 * Register REST API routes
 	 *
 	 * @since 0.1.2
@@ -250,6 +257,3 @@ class Handlers {
 		);
 	}
 }
-
-// Register routes on WordPress REST API initialization
-add_action( 'rest_api_init', array( Handlers::class, 'register_routes' ) );

--- a/inc/Api/Providers.php
+++ b/inc/Api/Providers.php
@@ -26,6 +26,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Providers {
 
 	/**
+	 * Register the API endpoint.
+	 */
+	public static function register() {
+		add_action( 'rest_api_init', array( self::class, 'register_routes' ) );
+	}
+
+	/**
 	 * Register REST API routes
 	 *
 	 * @since 0.1.2
@@ -97,6 +104,3 @@ class Providers {
 		}
 	}
 }
-
-// Register routes on WordPress REST API initialization
-add_action( 'rest_api_init', array( Providers::class, 'register_routes' ) );

--- a/inc/Api/StepTypes.php
+++ b/inc/Api/StepTypes.php
@@ -27,6 +27,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class StepTypes {
 
 	/**
+	 * Register the API endpoint.
+	 */
+	public static function register() {
+		add_action( 'rest_api_init', array( self::class, 'register_routes' ) );
+	}
+
+	/**
 	 * Register REST API routes
 	 *
 	 * @since 0.1.2
@@ -142,6 +149,3 @@ class StepTypes {
 		);
 	}
 }
-
-// Register routes on WordPress REST API initialization
-add_action( 'rest_api_init', array( StepTypes::class, 'register_routes' ) );

--- a/inc/Api/Tools.php
+++ b/inc/Api/Tools.php
@@ -25,6 +25,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Tools {
 
 	/**
+	 * Register the API endpoint.
+	 */
+	public static function register() {
+		add_action( 'rest_api_init', array( self::class, 'register_routes' ) );
+	}
+
+	/**
 	 * Register REST API routes
 	 *
 	 * @since 0.1.2
@@ -63,6 +70,3 @@ class Tools {
 		);
 	}
 }
-
-// Register routes on WordPress REST API initialization
-add_action( 'rest_api_init', array( Tools::class, 'register_routes' ) );

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -104,7 +104,9 @@ export default function FlowStepCard( {
 	);
 
 	// Resolve handler info for settings display.
-	const usesHandler = stepTypeInfo.uses_handler !== '' && stepTypeInfo.uses_handler !== false;
+	// Strict positive check — defaults to false while step types are loading
+	// so non-handler step types (AI, Agent Ping, Webhook Gate) never flash handler UI.
+	const usesHandler = stepTypeInfo.uses_handler === true;
 	const effectiveHandlerSlug = usesHandler ? flowStepConfig.handler_slug : pipelineStep.step_type;
 
 	return (


### PR DESCRIPTION
## Problem

Four API classes existed in `inc/Api/` but were never registered in `data-machine.php`:
- `Api\Handlers` — `/handlers`, `/handlers/{slug}`
- `Api\StepTypes` — `/step-types`
- `Api\Tools` — `/tools`
- `Api\Providers` — `/providers`

All four had `register_routes()` methods and loose `add_action()` calls at file bottom, but PSR-4 autoloading only loads classes on first reference. Nothing referenced these classes, so the files never loaded and the endpoints never registered.

**This is the root cause of all pipeline builder rendering issues:**
- `useStepTypes()` returned `{}` → all step type metadata missing (`uses_handler`, labels)
- `useTools()` returned `{}` → tools display showed 'NONE' for all AI steps
- `useHandlerDetails()` 404'd → `InlineStepConfig` couldn't fetch field schemas for Agent Ping / Webhook Gate
- `useHandlers()` 404'd → handler list unavailable
- The old hardcoded branching (`isAgentPing`, `isAiStep`) in FlowStepCard worked precisely because the API wasn't loading — the frontend couldn't be data-driven so it relied on hardcoded checks. PR #184 removed the hardcoded checks and replaced them with API-driven logic that calls these non-existent endpoints.

## Fix

1. Added `register()` method to all four API classes (matching existing pattern)
2. Removed loose `add_action()` calls from file bottoms
3. Added all four `::register()` calls to `data-machine.php`
4. Fixed `usesHandler` check in FlowStepCard from `!== false` to `=== true` (strict positive, safe during loading)

## Tested on saraichinwag.com

All six endpoints verified returning correct data:
- `/step-types` — 6 step types, correct `uses_handler` values
- `/handlers/agent_ping` — 5 fields (webhook_url, prompt, auth_header_name, auth_token, reply_to)
- `/handlers/webhook_gate` — 2 fields (timeout_hours, description)
- `/tools` — 9 tools with `globally_enabled` status
- `/handlers` — 17 handlers listed
- `/providers` — providers with models

## Files Changed

- `data-machine.php` — added 4 register() calls
- `inc/Api/Handlers.php` — added register(), removed loose add_action
- `inc/Api/StepTypes.php` — added register(), removed loose add_action
- `inc/Api/Tools.php` — added register(), removed loose add_action
- `inc/Api/Providers.php` — added register(), removed loose add_action
- `FlowStepCard.jsx` — usesHandler === true strict check

Fixes #239