### PR TITLE
fix: InlineStepConfig renders only for non-handler step types

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -149,12 +149,11 @@ export default function FlowStepCard( {
 						</div>
 					) }
 
-					{ /* Inline Config Fields (schema-driven from handler details API).
-					   Renders for any step type with registered fields — the component
-					   self-determines whether to render based on API response (returns
-					   null when no fields exist). Not gated by show_settings_display,
-					   which controls the PHP-side read-only summary, not the React editor. */ }
-					{ effectiveHandlerSlug && (
+					{ /* Inline Config Fields — flow step settings for non-handler step types only.
+					   Handler-based steps show their settings in the configuration modal,
+					   not inline on the card. Non-handler step types (Agent Ping, Webhook Gate)
+					   render their fields here via the handler details API fallback. */ }
+					{ ! usesHandler && effectiveHandlerSlug && (
 						<InlineStepConfig
 							flowStepId={ flowStepId }
 							handlerConfig={ flowStepConfig?.handler_config || {} }


### PR DESCRIPTION
## Problem

`InlineStepConfig` was rendering editable fields for ALL step types, including handler-based steps (fetch/publish/update). Handler settings belong in the configuration modal, not inline on the flow step card.

## The Distinction

- **Flow step settings** (Agent Ping, Webhook Gate) → editable fields **inline on the flow step card**
- **Handler settings** (fetch/publish/update) → read-only summary on the card, editable fields **in the configuration modal only**

## Fix

Gate `InlineStepConfig` with `! usesHandler` so it only renders for non-handler step types:

```jsx
{ ! usesHandler && effectiveHandlerSlug && (
    <InlineStepConfig ... />
) }
```

Handler-based steps continue to use `FlowStepHandler` for their read-only summary display + Configure button → modal.

## Verified on saraichinwag.com

- Source file on server confirms the fix
- Build is current (built after source change)
- Endpoints all responding correctly from #242

## Files Changed

- `FlowStepCard.jsx` — added `! usesHandler &&` gate to `InlineStepConfig`