### PR TITLE
feat: per-agent default provider/model configuration

### DIFF
--- a/inc/Abilities/Media/AltTextAbilities.php
+++ b/inc/Abilities/Media/AltTextAbilities.php
@@ -144,8 +144,9 @@ class AltTextAbilities {
 		$post_id       = absint( $input['post_id'] ?? 0 );
 		$force         = ! empty( $input['force'] );
 
-		$provider = PluginSettings::get( 'default_provider', '' );
-		$model    = PluginSettings::get( 'default_model', '' );
+		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$provider        = $system_defaults['provider'];
+		$model           = $system_defaults['model'];
 
 		if ( empty( $provider ) || empty( $model ) ) {
 			return array(
@@ -327,8 +328,9 @@ class AltTextAbilities {
 			return;
 		}
 
-		$provider = PluginSettings::get( 'default_provider', '' );
-		$model    = PluginSettings::get( 'default_model', '' );
+		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$provider        = $system_defaults['provider'];
+		$model           = $system_defaults['model'];
 
 		if ( empty( $provider ) || empty( $model ) ) {
 			return;

--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -281,8 +281,9 @@ class ImageGenerationAbilities {
 	 * @return string|null Refined prompt on success, null on failure.
 	 */
 	public static function refine_prompt( string $raw_prompt, string $post_context = '', array $config = [] ): ?string {
-		$provider = PluginSettings::get( 'default_provider', '' );
-		$model    = PluginSettings::get( 'default_model', '' );
+		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$provider        = $system_defaults['provider'];
+		$model           = $system_defaults['model'];
 
 		if ( empty( $provider ) || empty( $model ) ) {
 			do_action(
@@ -382,10 +383,9 @@ class ImageGenerationAbilities {
 		}
 
 		// Must have a DM AI provider configured.
-		$provider = PluginSettings::get( 'default_provider', '' );
-		$model    = PluginSettings::get( 'default_model', '' );
+		$system_defaults = PluginSettings::getAgentModel( 'system' );
 
-		return ! empty( $provider ) && ! empty( $model );
+		return ! empty( $system_defaults['provider'] ) && ! empty( $system_defaults['model'] );
 	}
 
 	/**

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -405,8 +405,9 @@ class PipelineStepAbilities {
 		);
 
 		if ( 'ai' === $step_type ) {
-			$new_step['provider'] = PluginSettings::get( 'default_provider', '' );
-			$new_step['model']    = PluginSettings::get( 'default_model', '' );
+			$pipeline_defaults    = PluginSettings::getAgentModel( 'pipeline' );
+			$new_step['provider'] = $pipeline_defaults['provider'];
+			$new_step['model']    = $pipeline_defaults['model'];
 		}
 
 		$pipeline_config = array();

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -113,6 +113,10 @@ class SettingsAbilities {
 						'site_context_enabled'        => array( 'type' => 'boolean' ),
 						'default_provider'            => array( 'type' => 'string' ),
 						'default_model'               => array( 'type' => 'string' ),
+						'agent_models'                => array(
+							'type'        => 'object',
+							'description' => 'Per-agent-type provider/model overrides keyed by agent type id',
+						),
 						'max_turns'                   => array( 'type' => 'integer' ),
 						'disabled_tools'              => array( 'type' => 'object' ),
 						'ai_provider_keys'            => array( 'type' => 'object' ),
@@ -362,6 +366,7 @@ class SettingsAbilities {
 				'site_context_enabled'        => $settings['site_context_enabled'] ?? false,
 				'default_provider'            => $settings['default_provider'] ?? '',
 				'default_model'               => $settings['default_model'] ?? '',
+				'agent_models'                => $settings['agent_models'] ?? array(),
 				'max_turns'                   => $settings['max_turns'] ?? 12,
 				'disabled_tools'              => $settings['disabled_tools'] ?? array(),
 				'ai_provider_keys'            => $masked_keys,
@@ -440,6 +445,20 @@ class SettingsAbilities {
 
 		if ( isset( $input['default_model'] ) ) {
 			$all_settings['default_model'] = sanitize_text_field( $input['default_model'] );
+		}
+
+		if ( isset( $input['agent_models'] ) && is_array( $input['agent_models'] ) ) {
+			$valid_agent_ids = array_column( PluginSettings::getAgentTypes(), 'id' );
+			$agent_models    = array();
+			foreach ( $input['agent_models'] as $agent_type => $config ) {
+				if ( in_array( $agent_type, $valid_agent_ids, true ) && is_array( $config ) ) {
+					$agent_models[ $agent_type ] = array(
+						'provider' => sanitize_text_field( $config['provider'] ?? '' ),
+						'model'    => sanitize_text_field( $config['model'] ?? '' ),
+					);
+				}
+			}
+			$all_settings['agent_models'] = $agent_models;
 		}
 
 		if ( isset( $input['max_turns'] ) ) {

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -446,8 +446,9 @@ class SystemAbilities {
 	}
 
 	private static function generateAITitle( string $first_user_message, ?string $first_assistant_response ): ?string {
-		$provider = PluginSettings::get('default_provider', '');
-		$model    = PluginSettings::get('default_model', '');
+		$chat_defaults = PluginSettings::getAgentModel( 'chat' );
+		$provider      = $chat_defaults['provider'];
+		$model         = $chat_defaults['model'];
 
 		if ( empty($provider) || empty($model) ) {
 			do_action(

--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -288,8 +288,9 @@ class Chat {
 		$prompt  = sanitize_textarea_field( wp_unslash( $request->get_param( 'prompt' ) ?? '' ) );
 		$context = $request->get_param( 'context' ) ?? array();
 
-		$provider = PluginSettings::get( 'default_provider', '' );
-		$model    = PluginSettings::get( 'default_model', '' );
+		$agent_config = PluginSettings::getAgentModel( 'chat' );
+		$provider     = $agent_config['provider'];
+		$model        = $agent_config['model'];
 
 		if ( empty( $provider ) || empty( $model ) ) {
 			return new WP_Error(
@@ -548,11 +549,14 @@ class Chat {
 		$provider = $request->get_param( 'provider' );
 		$model    = $request->get_param( 'model' );
 
-		if ( empty( $provider ) ) {
-			$provider = PluginSettings::get( 'default_provider', '' );
-		}
-		if ( empty( $model ) ) {
-			$model = PluginSettings::get( 'default_model', '' );
+		if ( empty( $provider ) || empty( $model ) ) {
+			$agent_config = PluginSettings::getAgentModel( 'chat' );
+			if ( empty( $provider ) ) {
+				$provider = $agent_config['provider'];
+			}
+			if ( empty( $model ) ) {
+				$model = $agent_config['model'];
+			}
 		}
 
 		$provider = sanitize_text_field( $provider );
@@ -805,8 +809,9 @@ class Chat {
 		}
 
 		$messages             = $session['messages'] ?? array();
-		$provider             = $session['provider'] ?? PluginSettings::get( 'default_provider', '' );
-		$model                = $session['model'] ?? PluginSettings::get( 'default_model', '' );
+		$chat_defaults        = PluginSettings::getAgentModel( 'chat' );
+		$provider             = $session['provider'] ?? $chat_defaults['provider'];
+		$model                = $session['model'] ?? $chat_defaults['model'];
 		$message_count_before = count( $messages );
 		$selected_pipeline_id = $metadata['selected_pipeline_id'] ?? null;
 

--- a/inc/Api/Providers.php
+++ b/inc/Api/Providers.php
@@ -86,12 +86,17 @@ class Providers {
 				'model'    => PluginSettings::get( 'default_model', '' ),
 			);
 
+			$agent_types  = PluginSettings::getAgentTypes();
+			$agent_models = PluginSettings::get( 'agent_models', array() );
+
 			return rest_ensure_response(
 				array(
 					'success' => true,
 					'data'    => array(
-						'providers' => $providers,
-						'defaults'  => $defaults,
+						'providers'    => $providers,
+						'defaults'     => $defaults,
+						'agent_types'  => $agent_types,
+						'agent_models' => $agent_models,
 					),
 				)
 			);

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -49,6 +49,59 @@ class PluginSettings {
 	 *
 	 * @return void
 	 */
+	/**
+	 * Get provider and model for a specific agent type.
+	 *
+	 * Resolution order:
+	 * 1. Agent-specific override from agent_models setting
+	 * 2. Global default_provider / default_model
+	 * 3. Empty strings
+	 *
+	 * @param string $agent_type Agent type: 'chat', 'pipeline', 'system'.
+	 * @return array{ provider: string, model: string }
+	 */
+	public static function getAgentModel( string $agent_type ): array {
+		$agent_models = self::get( 'agent_models', array() );
+		$agent_config = $agent_models[ $agent_type ] ?? array();
+		$provider     = ! empty( $agent_config['provider'] ) ? $agent_config['provider'] : self::get( 'default_provider', '' );
+		$model        = ! empty( $agent_config['model'] ) ? $agent_config['model'] : self::get( 'default_model', '' );
+
+		return array(
+			'provider' => $provider,
+			'model'    => $model,
+		);
+	}
+
+	/**
+	 * Get the list of known agent types.
+	 *
+	 * @return array Array of agent type definitions with id, label, and description.
+	 */
+	public static function getAgentTypes(): array {
+		return array(
+			array(
+				'id'          => 'chat',
+				'label'       => __( 'Chat Agent', 'data-machine' ),
+				'description' => __( 'Interactive chat conversations. Benefits from capable models for complex reasoning.', 'data-machine' ),
+			),
+			array(
+				'id'          => 'pipeline',
+				'label'       => __( 'Pipeline Agent', 'data-machine' ),
+				'description' => __( 'Structured workflow execution. Operates within defined steps — efficient models work well.', 'data-machine' ),
+			),
+			array(
+				'id'          => 'system',
+				'label'       => __( 'System Agent', 'data-machine' ),
+				'description' => __( 'Background tasks like alt text generation and issue creation.', 'data-machine' ),
+			),
+		);
+	}
+
+	/**
+	 * Clear the settings cache.
+	 *
+	 * @return void
+	 */
 	public static function clearCache(): void {
 		self::$cache = null;
 	}

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -70,7 +70,8 @@ class AIStep extends Step {
 		$pipeline_step_id = $this->flow_step_config['pipeline_step_id'];
 
 		$pipeline_step_config = $this->engine->getPipelineStepConfig( $pipeline_step_id );
-		$provider_name        = $pipeline_step_config['provider'] ?? PluginSettings::get( 'default_provider', '' );
+		$pipeline_defaults    = PluginSettings::getAgentModel( 'pipeline' );
+		$provider_name        = $pipeline_step_config['provider'] ?? $pipeline_defaults['provider'];
 		if ( empty( $provider_name ) ) {
 			do_action(
 				'datamachine_fail_job',
@@ -175,7 +176,8 @@ class AIStep extends Step {
 		$engine_data     = $this->engine->all();
 		$available_tools = ToolExecutor::getAvailableTools( $previous_step_config, $next_step_config, $pipeline_step_id, $engine_data );
 
-		$provider_name = $pipeline_step_config['provider'] ?? $settings['default_provider'] ?? '';
+		$pipeline_agent_defaults = PluginSettings::getAgentModel( 'pipeline' );
+		$provider_name           = $pipeline_step_config['provider'] ?? $pipeline_agent_defaults['provider'];
 
 		// Execute conversation loop
 		$loop        = new AIConversationLoop();
@@ -183,7 +185,7 @@ class AIStep extends Step {
 			$messages,
 			$available_tools,
 			$provider_name,
-			$pipeline_step_config['model'] ?? $settings['default_model'] ?? '',
+			$pipeline_step_config['model'] ?? $pipeline_agent_defaults['model'],
 			AgentType::PIPELINE,
 			$payload,
 			$max_turns

--- a/inc/Engine/AI/System/Tasks/AltTextTask.php
+++ b/inc/Engine/AI/System/Tasks/AltTextTask.php
@@ -55,8 +55,9 @@ class AltTextTask extends SystemTask {
 			return;
 		}
 
-		$provider = PluginSettings::get( 'default_provider', '' );
-		$model    = PluginSettings::get( 'default_model', '' );
+		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$provider        = $system_defaults['provider'];
+		$model           = $system_defaults['model'];
 
 		if ( empty( $provider ) || empty( $model ) ) {
 			$this->failJob( $jobId, 'No default AI provider/model configured' );


### PR DESCRIPTION
## Problem

All agent types (chat, pipeline, system) share a single global default provider/model. This forces a tradeoff between cost and capability.

## Solution

Per-agent-type model overrides. Each agent can have its own default provider/model, falling back to the global default when not set.

### Resolution order (per agent)
1. Agent-specific override (if set)
2. Global default provider/model (existing)
3. Empty (fail gracefully)

### Backend
- `PluginSettings::getAgentModel($agent_type)` — single resolution helper
- `PluginSettings::getAgentTypes()` — returns agent type definitions for the UI (data-driven)
- SettingsAbilities: full schema, get, and update support
- Providers API: exposes `agent_types` and `agent_models` so React has zero hardcoded assumptions
- All 11 resolution points across Chat, Pipeline, and System agents updated

### React (fully data-driven)
- Per-agent ProviderModelSelector sections rendered from `agent_types` returned by the API
- Agent type IDs, labels, descriptions — all from the server, nothing hardcoded
- Global default relabeled as 'fallback'

### CLI
```
wp datamachine settings set agent_models '{"chat":{"provider":"anthropic","model":"claude-sonnet-4-20250514"}}'
```

### Files changed (11)
- `PluginSettings.php` — new helper methods
- `Providers.php` — expose agent_types/agent_models in API
- `SettingsAbilities.php` — schema + persistence
- `Chat.php` (3 resolution points)
- `AIStep.php` (2 resolution points)
- `PipelineStepAbilities.php`, `SystemAbilities.php`, `AltTextTask.php`, `AltTextAbilities.php`, `ImageGenerationAbilities.php`
- `AgentTab.jsx` — per-agent UI

Zero breaking changes. Unset overrides fall back to the existing global default.

Fixes #245