### PR TITLE
feat: Multi-handler steps — core backend (#233)

### DIFF
--- a/inc/Core/Steps/Publish/PublishStep.php
+++ b/inc/Core/Steps/Publish/PublishStep.php
@@ -7,8 +7,8 @@ use DataMachine\Core\Steps\Step;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
 use DataMachine\Engine\AI\Tools\ToolResultFinder;
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+if (! defined('ABSPATH') ) {
+    exit;
 }
 
 /**
@@ -16,98 +16,161 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @package DataMachine
  */
-class PublishStep extends Step {
+class PublishStep extends Step
+{
 
-	use StepTypeRegistrationTrait;
+    use StepTypeRegistrationTrait;
 
-	/**
-	 * Initialize publish step.
-	 */
-	public function __construct() {
-		parent::__construct( 'publish' );
+    /**
+     * Initialize publish step.
+     */
+    public function __construct()
+    {
+        parent::__construct('publish');
 
-		self::registerStepType(
-			slug: 'publish',
-			label: 'Publish',
-			description: 'Publish content to external platforms',
-			class: self::class,
-			position: 30,
-			usesHandler: true,
-			hasPipelineConfig: false
-		);
-	}
+        self::registerStepType(
+            slug: 'publish',
+            label: 'Publish',
+            description: 'Publish content to external platforms',
+            class: self::class,
+            position: 30,
+            usesHandler: true,
+            hasPipelineConfig: false
+        );
+    }
 
-	/**
-	 * Execute publish step logic.
-	 *
-	 * @return array
-	 */
-	protected function executeStep(): array {
-		$handler = $this->getHandlerSlug();
+    /**
+     * Validate that at least one handler is configured.
+     * Supports both singular handler_slug and plural handler_slugs.
+     *
+     * @return bool True if configuration is valid, false otherwise
+     */
+    protected function validateStepConfiguration(): bool
+    {
+        $handlers = $this->getHandlerSlugs();
+        if (empty($handlers) ) {
+            $this->logConfigurationError(
+                'Step requires at least one handler configuration',
+                array( 'available_flow_step_config' => array_keys($this->flow_step_config) )
+            );
+            return false;
+        }
+        return true;
+    }
 
-		$tool_result_entry = ToolResultFinder::findHandlerResult( $this->dataPackets, $handler, $this->flow_step_id );
-		if ( $tool_result_entry ) {
-			$this->log(
-				'info',
-				'AI successfully used handler tool',
-				array(
-					'handler'     => $handler,
-					'tool_result' => $tool_result_entry['metadata']['tool_name'] ?? 'unknown',
-				)
-			);
+    /**
+     * Execute publish step logic.
+     * Supports both single and multi-handler configurations.
+     *
+     * @return array
+     */
+    protected function executeStep(): array
+    {
+        $handler_slugs = $this->getHandlerSlugs();
 
-			return $this->create_publish_entry_from_tool_result( $tool_result_entry, $this->dataPackets, $handler, $this->flow_step_id );
-		}
+        if (empty($handler_slugs) ) {
+            $this->log('error', 'No handlers configured for publish step');
+            return array();
+        }
 
-		return array();
-	}
+        // Single handler: preserve existing behavior exactly
+        if (count($handler_slugs) === 1 ) {
+            $handler           = $handler_slugs[0];
+            $tool_result_entry = ToolResultFinder::findHandlerResult($this->dataPackets, $handler, $this->flow_step_id);
+            if ($tool_result_entry ) {
+                $this->log(
+                    'info',
+                    'AI successfully used handler tool',
+                    array(
+                    'handler'     => $handler,
+                    'tool_result' => $tool_result_entry['metadata']['tool_name'] ?? 'unknown',
+                    )
+                );
+                return $this->create_publish_entry_from_tool_result($tool_result_entry, $this->dataPackets, $handler, $this->flow_step_id);
+            }
+            return array();
+        }
 
-	/**
-	 * Create publish data packet from AI tool execution result.
-	 *
-	 * @param array  $tool_result_entry Tool execution result entry
-	 * @param array  $dataPackets Current data packet array
-	 * @param string $handler Handler name
-	 * @param string $flow_step_id Flow step identifier
-	 * @return array Publish data packet
-	 */
-	private function create_publish_entry_from_tool_result( array $tool_result_entry, array $dataPackets, string $handler, string $flow_step_id ): array {
-		$tool_result_data = $tool_result_entry['metadata']['tool_result'] ?? array();
-		$entry_type       = $tool_result_entry['type'] ?? '';
+        // Multi-handler: find and process all matching results
+        $all_results = ToolResultFinder::findAllHandlerResults($this->dataPackets, $handler_slugs, $this->flow_step_id);
 
-		if ( empty( $tool_result_data ) ) {
-			$this->log(
-				'warning',
-				'Tool result entry found but tool_result_data is empty',
-				array(
-					'handler'       => $handler,
-					'entry_type'    => $entry_type,
-					'metadata_keys' => array_keys( $tool_result_entry['metadata'] ?? array() ),
-				)
-			);
-		}
+        if (empty($all_results) ) {
+            return array();
+        }
 
-		$executed_via = ( 'ai_handler_complete' === $entry_type ) ? 'ai_conversation_tool' : 'ai_tool_call';
-		$title_suffix = ( 'ai_handler_complete' === $entry_type ) ? '(via AI Conversation)' : '(via AI Tool)';
+        $updatedPackets = $this->dataPackets;
+        foreach ( $all_results as $tool_result_entry ) {
+            $handler = $tool_result_entry['metadata']['handler_tool'] ?? 'unknown';
+            $this->log(
+                'info',
+                'AI successfully used handler tool',
+                array(
+                'handler'     => $handler,
+                'tool_result' => $tool_result_entry['metadata']['tool_name'] ?? 'unknown',
+                )
+            );
+            $updatedPackets = $this->create_publish_entry_from_tool_result($tool_result_entry, $updatedPackets, $handler, $this->flow_step_id);
+        }
 
-		$packet = new DataPacket(
-			array(
-				'title' => 'Publish Complete ' . $title_suffix,
-				'body'  => wp_json_encode( $tool_result_data, JSON_PRETTY_PRINT ),
-			),
-			array(
-				'handler_used'        => $handler,
-				'publish_success'     => true,
-				'executed_via'        => $executed_via,
-				'flow_step_id'        => $flow_step_id,
-				'source_type'         => $tool_result_entry['metadata']['source_type'] ?? 'unknown',
-				'tool_execution_data' => $tool_result_data,
-				'original_entry_type' => $entry_type,
-				'result'              => $tool_result_data,
-			),
-			'publish'
-		);
+        $this->log(
+            'info',
+            'Multi-handler publish complete',
+            array(
+            'handlers_configured' => count($handler_slugs),
+            'handlers_executed'   => count($all_results),
+            )
+        );
 
-		return $packet->addTo( $dataPackets );
-	}
+        return $updatedPackets;
+    }
+
+    /**
+     * Create publish data packet from AI tool execution result.
+     *
+     * @param  array  $tool_result_entry Tool execution result entry
+     * @param  array  $dataPackets       Current data packet array
+     * @param  string $handler           Handler name
+     * @param  string $flow_step_id      Flow step identifier
+     * @return array Publish data packet
+     */
+    private function create_publish_entry_from_tool_result( array $tool_result_entry, array $dataPackets, string $handler, string $flow_step_id ): array
+    {
+        $tool_result_data = $tool_result_entry['metadata']['tool_result'] ?? array();
+        $entry_type       = $tool_result_entry['type'] ?? '';
+
+        if (empty($tool_result_data) ) {
+            $this->log(
+                'warning',
+                'Tool result entry found but tool_result_data is empty',
+                array(
+                'handler'       => $handler,
+                'entry_type'    => $entry_type,
+                'metadata_keys' => array_keys($tool_result_entry['metadata'] ?? array()),
+                )
+            );
+        }
+
+        $executed_via = ( 'ai_handler_complete' === $entry_type ) ? 'ai_conversation_tool' : 'ai_tool_call';
+        $title_suffix = ( 'ai_handler_complete' === $entry_type ) ? '(via AI Conversation)' : '(via AI Tool)';
+
+        $packet = new DataPacket(
+            array(
+            'title' => 'Publish Complete ' . $title_suffix,
+            'body'  => wp_json_encode($tool_result_data, JSON_PRETTY_PRINT),
+            ),
+            array(
+            'handler_used'        => $handler,
+            'publish_success'     => true,
+            'executed_via'        => $executed_via,
+            'flow_step_id'        => $flow_step_id,
+            'source_type'         => $tool_result_entry['metadata']['source_type'] ?? 'unknown',
+            'tool_execution_data' => $tool_result_data,
+            'original_entry_type' => $entry_type,
+            'result'              => $tool_result_data,
+            ),
+            'publish'
+        );
+
+        return $packet->addTo($dataPackets);
+    }
 }

--- a/inc/Core/Steps/Step.php
+++ b/inc/Core/Steps/Step.php
@@ -6,259 +6,304 @@
  * and exception handling across all step implementations.
  *
  * @package DataMachine\Core\Steps
- * @since 0.2.1
+ * @since   0.2.1
  */
 
 namespace DataMachine\Core\Steps;
 
 use DataMachine\Core\EngineData;
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+if (! defined('ABSPATH') ) {
+    exit;
 }
 
-abstract class Step {
+abstract class Step
+{
 
-	/**
-	 * Step type identifier.
-	 *
-	 * @var string
-	 */
-	protected string $step_type;
+    /**
+     * Step type identifier.
+     *
+     * @var string
+     */
+    protected string $step_type;
 
-	/**
-	 * Job ID from payload.
-	 *
-	 * @var int
-	 */
-	protected int $job_id;
+    /**
+     * Job ID from payload.
+     *
+     * @var int
+     */
+    protected int $job_id;
 
-	/**
-	 * Flow step ID from payload.
-	 *
-	 * @var string
-	 */
-	protected string $flow_step_id;
+    /**
+     * Flow step ID from payload.
+     *
+     * @var string
+     */
+    protected string $flow_step_id;
 
-	/**
-	 * Data packets array from payload.
-	 *
-	 * @var array
-	 */
-	protected array $dataPackets;
+    /**
+     * Data packets array from payload.
+     *
+     * @var array
+     */
+    protected array $dataPackets;
 
-	/**
-	 * Flow step configuration from payload.
-	 *
-	 * @var array
-	 */
-	protected array $flow_step_config;
+    /**
+     * Flow step configuration from payload.
+     *
+     * @var array
+     */
+    protected array $flow_step_config;
 
-	/**
-	 * Engine data loaded from centralized storage.
-	 *
-	 * @var array
-	 */
-	protected array $engine_data = array();
+    /**
+     * Engine data loaded from centralized storage.
+     *
+     * @var array
+     */
+    protected array $engine_data = array();
 
-	/**
-	 * Engine snapshot helper.
-	 */
-	protected EngineData $engine;
+    /**
+     * Engine snapshot helper.
+     */
+    protected EngineData $engine;
 
-	/**
-	 * Initialize step with type identifier.
-	 *
-	 * @param string $step_type Step type identifier (fetch, ai, publish, update)
-	 */
-	public function __construct( string $step_type ) {
-		$this->step_type = $step_type;
-	}
+    /**
+     * Initialize step with type identifier.
+     *
+     * @param string $step_type Step type identifier (fetch, ai, publish, update)
+     */
+    public function __construct( string $step_type )
+    {
+        $this->step_type = $step_type;
+    }
 
-	/**
-	 * Execute step with unified payload handling.
-	 *
-	 * @param array $payload Unified step payload (job_id, flow_step_id, data, flow_step_config)
-	 * @return array Updated data packet array
-	 */
-	public function execute( array $payload ): array {
-		try {
-			// Destructure payload to properties
-			$this->destructurePayload( $payload );
+    /**
+     * Execute step with unified payload handling.
+     *
+     * @param  array $payload Unified step payload (job_id, flow_step_id, data, flow_step_config)
+     * @return array Updated data packet array
+     */
+    public function execute( array $payload ): array
+    {
+        try {
+            // Destructure payload to properties
+            $this->destructurePayload($payload);
 
-			// Validate common configuration
-			if ( ! $this->validateCommonConfiguration() ) {
-				return $this->dataPackets;
-			}
+            // Validate common configuration
+            if (! $this->validateCommonConfiguration() ) {
+                return $this->dataPackets;
+            }
 
-			// Validate step-specific configuration
-			if ( ! $this->validateStepConfiguration() ) {
-				return $this->dataPackets;
-			}
+            // Validate step-specific configuration
+            if (! $this->validateStepConfiguration() ) {
+                return $this->dataPackets;
+            }
 
-			// Execute step-specific logic
-			return $this->executeStep();
-		} catch ( \Exception $e ) {
-			return $this->handleException( $e );
-		}
-	}
+            // Execute step-specific logic
+            return $this->executeStep();
+        } catch ( \Exception $e ) {
+            return $this->handleException($e);
+        }
+    }
 
-	/**
-	 * Execute step-specific logic.
-	 * Called after payload destructuring and common validation.
-	 *
-	 * @return array Updated data packet array
-	 */
-	abstract protected function executeStep(): array;
+    /**
+     * Execute step-specific logic.
+     * Called after payload destructuring and common validation.
+     *
+     * @return array Updated data packet array
+     */
+    abstract protected function executeStep(): array;
 
-	/**
-	 * Validate step-specific configuration requirements.
-	 * Default implementation checks for handler_slug. Override for custom validation.
-	 *
-	 * @return bool True if configuration is valid, false otherwise
-	 */
-	protected function validateStepConfiguration(): bool {
-		$handler = $this->getHandlerSlug();
+    /**
+     * Validate step-specific configuration requirements.
+     * Default implementation checks for handler_slug. Override for custom validation.
+     *
+     * @return bool True if configuration is valid, false otherwise
+     */
+    protected function validateStepConfiguration(): bool
+    {
+        $handler = $this->getHandlerSlug();
 
-		if ( empty( $handler ) ) {
-			$this->logConfigurationError(
-				'Step requires handler configuration',
-				array(
-					'available_flow_step_config' => array_keys( $this->flow_step_config ),
-				)
-			);
-			return false;
-		}
+        if (empty($handler) ) {
+            $this->logConfigurationError(
+                'Step requires handler configuration',
+                array(
+                'available_flow_step_config' => array_keys($this->flow_step_config),
+                )
+            );
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	/**
-	 * Extract and store payload fields to class properties.
-	 *
-	 * @param array $payload Unified step payload
-	 * @return void
-	 */
-	protected function destructurePayload( array $payload ): void {
-		if ( ! isset( $payload['job_id'] ) || empty( $payload['job_id'] ) ) {
-			throw new \InvalidArgumentException( 'Job ID is required in step payload' );
-		}
-		if ( ! isset( $payload['flow_step_id'] ) || empty( $payload['flow_step_id'] ) ) {
-			throw new \InvalidArgumentException( 'Flow step ID is required in step payload' );
-		}
+    /**
+     * Extract and store payload fields to class properties.
+     *
+     * @param  array $payload Unified step payload
+     * @return void
+     */
+    protected function destructurePayload( array $payload ): void
+    {
+        if (! isset($payload['job_id']) || empty($payload['job_id']) ) {
+            throw new \InvalidArgumentException('Job ID is required in step payload');
+        }
+        if (! isset($payload['flow_step_id']) || empty($payload['flow_step_id']) ) {
+            throw new \InvalidArgumentException('Flow step ID is required in step payload');
+        }
 
-		$this->job_id       = $payload['job_id'];
-		$this->flow_step_id = $payload['flow_step_id'];
-		$this->dataPackets  = is_array( $payload['data'] ?? null ) ? $payload['data'] : array();
-		$engine             = $payload['engine'] ?? null;
-		if ( ! $engine instanceof EngineData ) {
-			$engine = new EngineData( datamachine_get_engine_data( $this->job_id ), $this->job_id );
-		}
+        $this->job_id       = $payload['job_id'];
+        $this->flow_step_id = $payload['flow_step_id'];
+        $this->dataPackets  = is_array($payload['data'] ?? null) ? $payload['data'] : array();
+        $engine             = $payload['engine'] ?? null;
+        if (! $engine instanceof EngineData ) {
+            $engine = new EngineData(datamachine_get_engine_data($this->job_id), $this->job_id);
+        }
 
-		$this->engine           = $engine;
-		$this->engine_data      = $engine->all();
-		$this->flow_step_config = $engine->getFlowStepConfig( $this->flow_step_id );
+        $this->engine           = $engine;
+        $this->engine_data      = $engine->all();
+        $this->flow_step_config = $engine->getFlowStepConfig($this->flow_step_id);
 
-		if ( empty( $this->flow_step_config ) ) {
-			throw new \RuntimeException( 'Flow step configuration missing from engine snapshot' );
-		}
-	}
+        if (empty($this->flow_step_config) ) {
+            throw new \RuntimeException('Flow step configuration missing from engine snapshot');
+        }
+    }
 
-	/**
-	 * Centralized logging with consistent context.
-	 *
-	 * Automatically includes job_id, pipeline_id, and flow_id from engine context
-	 * to ensure all step logs can be filtered and queried effectively.
-	 *
-	 * @param string $level Log level (debug, info, warning, error)
-	 * @param string $message Log message
-	 * @param array  $context Additional context data
-	 * @return void
-	 */
-	protected function log( string $level, string $message, array $context = array() ): void {
-		$job_context = $this->engine->getJobContext();
+    /**
+     * Centralized logging with consistent context.
+     *
+     * Automatically includes job_id, pipeline_id, and flow_id from engine context
+     * to ensure all step logs can be filtered and queried effectively.
+     *
+     * @param  string $level   Log level (debug, info, warning, error)
+     * @param  string $message Log message
+     * @param  array  $context Additional context data
+     * @return void
+     */
+    protected function log( string $level, string $message, array $context = array() ): void
+    {
+        $job_context = $this->engine->getJobContext();
 
-		$full_context = array_merge(
-			array(
-				'flow_step_id' => $this->flow_step_id,
-				'step_type'    => $this->step_type,
-				'job_id'       => $job_context['job_id'] ?? $this->job_id,
-				'pipeline_id'  => $job_context['pipeline_id'] ?? null,
-				'flow_id'      => $job_context['flow_id'] ?? null,
-			),
-			$context
-		);
+        $full_context = array_merge(
+            array(
+            'flow_step_id' => $this->flow_step_id,
+            'step_type'    => $this->step_type,
+            'job_id'       => $job_context['job_id'] ?? $this->job_id,
+            'pipeline_id'  => $job_context['pipeline_id'] ?? null,
+            'flow_id'      => $job_context['flow_id'] ?? null,
+            ),
+            $context
+        );
 
-		// Remove null values to keep logs clean
-		$full_context = array_filter( $full_context, fn( $v ) => null !== $v );
+        // Remove null values to keep logs clean
+        $full_context = array_filter($full_context, fn( $v ) => null !== $v);
 
-		do_action( 'datamachine_log', $level, $message, $full_context );
-	}
-
-
-
-	/**
-	 * Log configuration errors with consistent formatting.
-	 *
-	 * @param string $message Error message
-	 * @param array  $additional_context Additional context beyond flow_step_id
-	 * @return void
-	 */
-	protected function logConfigurationError( string $message, array $additional_context = array() ): void {
-		$this->log( 'error', $this->step_type . ': ' . $message, $additional_context );
-	}
+        do_action('datamachine_log', $level, $message, $full_context);
+    }
 
 
 
-	/**
-	 * Get handler slug from flow step configuration.
-	 *
-	 * @return string|null Handler slug or null if not set
-	 */
-	protected function getHandlerSlug(): ?string {
-		return $this->flow_step_config['handler_slug'] ?? null;
-	}
+    /**
+     * Log configuration errors with consistent formatting.
+     *
+     * @param  string $message            Error message
+     * @param  array  $additional_context Additional context beyond flow_step_id
+     * @return void
+     */
+    protected function logConfigurationError( string $message, array $additional_context = array() ): void
+    {
+        $this->log('error', $this->step_type . ': ' . $message, $additional_context);
+    }
 
-	/**
-	 * Get handler configuration from flow step configuration.
-	 *
-	 * @return array Handler configuration array
-	 */
-	protected function getHandlerConfig(): array {
-		return $this->flow_step_config['handler_config'] ?? array();
-	}
 
-	/**
-	 * Handle exceptions with consistent logging and data packet return.
-	 *
-	 * @param \Exception $e Exception instance
-	 * @param string     $context Context where exception occurred
-	 * @return array Data packet array (unchanged on exception)
-	 */
-	protected function handleException( \Exception $e, string $context = 'execution' ): array {
-		$this->log(
-			'error',
-			$this->step_type . ': Exception during ' . $context,
-			array(
-				'exception' => $e->getMessage(),
-				'trace'     => $e->getTraceAsString(),
-			)
-		);
 
-		return $this->dataPackets;
-	}
+    /**
+     * Get handler slug from flow step configuration.
+     *
+     * @return string|null Handler slug or null if not set
+     */
+    protected function getHandlerSlug(): ?string
+    {
+        return $this->flow_step_config['handler_slug'] ?? null;
+    }
 
-	/**
-	 * Validate common configuration requirements shared by all steps.
-	 *
-	 * @return bool True if common validation passes, false otherwise
-	 */
-	protected function validateCommonConfiguration(): bool {
-		if ( empty( $this->flow_step_config ) ) {
-			$this->logConfigurationError( 'No step configuration provided' );
-			return false;
-		}
+    /**
+     * Get handler configuration from flow step configuration.
+     *
+     * @return array Handler configuration array
+     */
+    protected function getHandlerConfig(): array
+    {
+        return $this->flow_step_config['handler_config'] ?? array();
+    }
 
-		return true;
-	}
+    /**
+     * Get handler slugs (supports both singular and plural config).
+     *
+     * @return array Handler slug array
+     */
+    protected function getHandlerSlugs(): array
+    {
+        // Check handler_slugs (new array format) first
+        if (! empty($this->flow_step_config['handler_slugs']) && is_array($this->flow_step_config['handler_slugs']) ) {
+            return $this->flow_step_config['handler_slugs'];
+        }
+        // Fall back to singular handler_slug
+        $slug = $this->getHandlerSlug();
+        return $slug ? array( $slug ) : array();
+    }
+
+    /**
+     * Get handler configs keyed by handler slug.
+     * Supports new per-handler format and falls back to single handler_config.
+     *
+     * @return array<string, array> Handler configs keyed by slug
+     */
+    protected function getHandlerConfigs(): array
+    {
+        // New format: handler_configs keyed by slug
+        if (! empty($this->flow_step_config['handler_configs']) && is_array($this->flow_step_config['handler_configs']) ) {
+            return $this->flow_step_config['handler_configs'];
+        }
+        // Fall back: single handler_config paired with handler_slug
+        $slug   = $this->getHandlerSlug();
+        $config = $this->getHandlerConfig();
+        return $slug ? array( $slug => $config ) : array();
+    }
+
+    /**
+     * Handle exceptions with consistent logging and data packet return.
+     *
+     * @param  \Exception $e       Exception instance
+     * @param  string     $context Context where exception occurred
+     * @return array Data packet array (unchanged on exception)
+     */
+    protected function handleException( \Exception $e, string $context = 'execution' ): array
+    {
+        $this->log(
+            'error',
+            $this->step_type . ': Exception during ' . $context,
+            array(
+            'exception' => $e->getMessage(),
+            'trace'     => $e->getTraceAsString(),
+            )
+        );
+
+        return $this->dataPackets;
+    }
+
+    /**
+     * Validate common configuration requirements shared by all steps.
+     *
+     * @return bool True if common validation passes, false otherwise
+     */
+    protected function validateCommonConfiguration(): bool
+    {
+        if (empty($this->flow_step_config) ) {
+            $this->logConfigurationError('No step configuration provided');
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -6,189 +6,190 @@
  * Handles tool discovery, validation, execution, and parameter building.
  *
  * @package DataMachine\Engine\AI\Tools
- * @since 0.2.0
+ * @since   0.2.0
  */
 
 namespace DataMachine\Engine\AI\Tools;
 
-defined( 'ABSPATH' ) || exit;
+defined('ABSPATH') || exit;
 
-class ToolExecutor {
+class ToolExecutor
+{
 
-	/**
-	 * Get available tools for AI agent execution.
-	 * Used by both chat and pipeline agents.
-	 *
-	 * @param array|null  $previous_step_config Previous step configuration (pipeline only)
-	 * @param array|null  $next_step_config Next step configuration (pipeline only)
-	 * @param string|null $current_pipeline_step_id Current pipeline step ID (pipeline only)
-	 * @param array       $engine_data Engine data snapshot for dynamic tool generation
-	 * @return array Available tools array
-	 */
-	public static function getAvailableTools( ?array $previous_step_config = null, ?array $next_step_config = null, ?string $current_pipeline_step_id = null, array $engine_data = array() ): array {
-		$available_tools = array();
-		$tool_manager    = new ToolManager();
+    /**
+     * Get available tools for AI agent execution.
+     * Used by both chat and pipeline agents.
+     *
+     * @param  array|null  $previous_step_config     Previous step configuration (pipeline only)
+     * @param  array|null  $next_step_config         Next step configuration (pipeline only)
+     * @param  string|null $current_pipeline_step_id Current pipeline step ID (pipeline only)
+     * @param  array       $engine_data              Engine data snapshot for dynamic tool generation
+     * @return array Available tools array
+     */
+    public static function getAvailableTools( ?array $previous_step_config = null, ?array $next_step_config = null, ?string $current_pipeline_step_id = null, array $engine_data = array() ): array
+    {
+        $available_tools = array();
+        $tool_manager    = new ToolManager();
 
-		if ( $previous_step_config ) {
-			$prev_handler_slug   = $previous_step_config['handler_slug'] ?? null;
-			$prev_handler_config = $previous_step_config['handler_config'] ?? array();
+        // Load tools from adjacent steps (supports both singular and plural handler config)
+        foreach ( array( $previous_step_config, $next_step_config ) as $step_config ) {
+            if (! $step_config ) {
+                continue;
+            }
 
-			if ( $prev_handler_slug ) {
-				$prev_tools         = apply_filters( 'chubes_ai_tools', array(), $prev_handler_slug, $prev_handler_config, $engine_data );
-				$prev_tools         = $tool_manager->resolveAllTools( $prev_tools );
-				$allowed_prev_tools = self::getAllowedTools( $prev_tools, $prev_handler_slug, $current_pipeline_step_id, $tool_manager );
-				$available_tools    = array_merge( $available_tools, $allowed_prev_tools );
-			}
-		}
+            // Resolve handler slugs (supports both singular and plural)
+            $handler_slugs      = $step_config['handler_slugs']
+            ?? ( isset($step_config['handler_slug']) ? array( $step_config['handler_slug'] ) : array() );
+            $handler_configs_map = $step_config['handler_configs'] ?? array();
 
-		if ( $next_step_config ) {
-			$next_handler_slug   = $next_step_config['handler_slug'] ?? null;
-			$next_handler_config = $next_step_config['handler_config'] ?? array();
+            foreach ( $handler_slugs as $slug ) {
+                $handler_config  = $handler_configs_map[ $slug ] ?? ( $step_config['handler_config'] ?? array() );
+                $tools           = apply_filters('chubes_ai_tools', array(), $slug, $handler_config, $engine_data);
+                $tools           = $tool_manager->resolveAllTools($tools);
+                $allowed         = self::getAllowedTools($tools, $slug, $current_pipeline_step_id, $tool_manager);
+                $available_tools = array_merge($available_tools, $allowed);
+            }
+        }
 
-			if ( $next_handler_slug ) {
-				$next_tools         = apply_filters( 'chubes_ai_tools', array(), $next_handler_slug, $next_handler_config, $engine_data );
-				$next_tools         = $tool_manager->resolveAllTools( $next_tools );
-				$allowed_next_tools = self::getAllowedTools( $next_tools, $next_handler_slug, $current_pipeline_step_id, $tool_manager );
-				$available_tools    = array_merge( $available_tools, $allowed_next_tools );
-			}
-		}
+        // Load global tools (available to all AI agents) - use ToolManager which resolves callables
+        $global_tools         = $tool_manager->get_global_tools();
+        $allowed_global_tools = self::getAllowedTools($global_tools, null, $current_pipeline_step_id, $tool_manager);
+        $available_tools      = array_merge($available_tools, $allowed_global_tools);
 
-		// Load global tools (available to all AI agents) - use ToolManager which resolves callables
-		$global_tools         = $tool_manager->get_global_tools();
-		$allowed_global_tools = self::getAllowedTools( $global_tools, null, $current_pipeline_step_id, $tool_manager );
-		$available_tools      = array_merge( $available_tools, $allowed_global_tools );
+        return array_unique($available_tools, SORT_REGULAR);
+    }
 
-		return array_unique( $available_tools, SORT_REGULAR );
-	}
+    /**
+     * Get allowed tools based on enablement and configuration.
+     *
+     * @param  array       $all_tools        All available tools (must be resolved, not callables)
+     * @param  string|null $handler_slug     Handler slug for filtering
+     * @param  string|null $pipeline_step_id Pipeline step ID (pipeline only, null for chat)
+     * @param  ToolManager $tool_manager     Tool manager instance for availability checks
+     * @return array Filtered allowed tools
+     */
+    private static function getAllowedTools( array $all_tools, ?string $handler_slug, ?string $pipeline_step_id, ToolManager $tool_manager ): array
+    {
+        $allowed_tools = array();
 
-	/**
-	 * Get allowed tools based on enablement and configuration.
-	 *
-	 * @param array       $all_tools All available tools (must be resolved, not callables)
-	 * @param string|null $handler_slug Handler slug for filtering
-	 * @param string|null $pipeline_step_id Pipeline step ID (pipeline only, null for chat)
-	 * @param ToolManager $tool_manager Tool manager instance for availability checks
-	 * @return array Filtered allowed tools
-	 */
-	private static function getAllowedTools( array $all_tools, ?string $handler_slug, ?string $pipeline_step_id, ToolManager $tool_manager ): array {
-		$allowed_tools = array();
+        foreach ( $all_tools as $tool_name => $tool_config ) {
+            // Skip if not a valid array definition
+            if (! is_array($tool_config) ) {
+                continue;
+            }
 
-		foreach ( $all_tools as $tool_name => $tool_config ) {
-			// Skip if not a valid array definition
-			if ( ! is_array( $tool_config ) ) {
-				continue;
-			}
+            if (isset($tool_config['handler']) ) {
+                if ($tool_config['handler'] === $handler_slug ) {
+                    $allowed_tools[ $tool_name ] = $tool_config;
+                }
+                continue;
+            }
 
-			if ( isset( $tool_config['handler'] ) ) {
-				if ( $tool_config['handler'] === $handler_slug ) {
-					$allowed_tools[ $tool_name ] = $tool_config;
-				}
-				continue;
-			}
+            // Direct ToolManager call replaces filter
+            if ($tool_manager->is_tool_available($tool_name, $pipeline_step_id) ) {
+                $allowed_tools[ $tool_name ] = $tool_config;
+            }
+        }
 
-			// Direct ToolManager call replaces filter
-			if ( $tool_manager->is_tool_available( $tool_name, $pipeline_step_id ) ) {
-				$allowed_tools[ $tool_name ] = $tool_config;
-			}
-		}
+        return $allowed_tools;
+    }
 
-		return $allowed_tools;
-	}
+    /**
+     * Execute tool with parameter merging and comprehensive error handling.
+     * Builds complete parameters by combining AI parameters with step payload.
+     *
+     * @param  string $tool_name       Tool name to execute
+     * @param  array  $tool_parameters Parameters from AI
+     * @param  array  $available_tools Available tools array
+     * @param  array  $payload         Step payload (job_id, flow_step_id, data, flow_step_config)
+     * @return array Tool execution result
+     */
+    public static function executeTool( string $tool_name, array $tool_parameters, array $available_tools, array $payload ): array
+    {
+        $tool_def = $available_tools[ $tool_name ] ?? null;
+        if (! $tool_def ) {
+            return array(
+            'success'   => false,
+            'error'     => "Tool '{$tool_name}' not found",
+            'tool_name' => $tool_name,
+            );
+        }
 
-	/**
-	 * Execute tool with parameter merging and comprehensive error handling.
-	 * Builds complete parameters by combining AI parameters with step payload.
-	 *
-	 * @param string $tool_name Tool name to execute
-	 * @param array  $tool_parameters Parameters from AI
-	 * @param array  $available_tools Available tools array
-	 * @param array  $payload Step payload (job_id, flow_step_id, data, flow_step_config)
-	 * @return array Tool execution result
-	 */
-	public static function executeTool( string $tool_name, array $tool_parameters, array $available_tools, array $payload ): array {
-		$tool_def = $available_tools[ $tool_name ] ?? null;
-		if ( ! $tool_def ) {
-			return array(
-				'success'   => false,
-				'error'     => "Tool '{$tool_name}' not found",
-				'tool_name' => $tool_name,
-			);
-		}
+        $validation = self::validateRequiredParameters($tool_parameters, $tool_def);
+        if (! $validation['valid'] ) {
+            return array(
+            'success'   => false,
+            'error'     => sprintf(
+                '%s requires the following parameters: %s. Please provide these parameters and try again.',
+                ucwords(str_replace('_', ' ', $tool_name)),
+                implode(', ', $validation['missing'])
+            ),
+            'tool_name' => $tool_name,
+            );
+        }
 
-		$validation = self::validateRequiredParameters( $tool_parameters, $tool_def );
-		if ( ! $validation['valid'] ) {
-			return array(
-				'success'   => false,
-				'error'     => sprintf(
-					'%s requires the following parameters: %s. Please provide these parameters and try again.',
-					ucwords( str_replace( '_', ' ', $tool_name ) ),
-					implode( ', ', $validation['missing'] )
-				),
-				'tool_name' => $tool_name,
-			);
-		}
+        $complete_parameters = ToolParameters::buildParameters(
+            $tool_parameters,
+            $payload,
+            $tool_def
+        );
 
-		$complete_parameters = ToolParameters::buildParameters(
-			$tool_parameters,
-			$payload,
-			$tool_def
-		);
+        // Ensure tool definition has required 'class' key
+        if (! isset($tool_def['class']) || empty($tool_def['class']) ) {
+            return array(
+            'success'   => false,
+            'error'     => "Tool '{$tool_name}' is missing required 'class' definition. This may indicate the tool was not properly resolved from a callable.",
+            'tool_name' => $tool_name,
+            );
+        }
 
-		// Ensure tool definition has required 'class' key
-		if ( ! isset( $tool_def['class'] ) || empty( $tool_def['class'] ) ) {
-			return array(
-				'success'   => false,
-				'error'     => "Tool '{$tool_name}' is missing required 'class' definition. This may indicate the tool was not properly resolved from a callable.",
-				'tool_name' => $tool_name,
-			);
-		}
+        $class_name = $tool_def['class'];
+        if (! class_exists($class_name) ) {
+            return array(
+            'success'   => false,
+            'error'     => "Tool class '{$class_name}' not found",
+            'tool_name' => $tool_name,
+            );
+        }
 
-		$class_name = $tool_def['class'];
-		if ( ! class_exists( $class_name ) ) {
-			return array(
-				'success'   => false,
-				'error'     => "Tool class '{$class_name}' not found",
-				'tool_name' => $tool_name,
-			);
-		}
+        $tool_handler = new $class_name();
+        $tool_result  = $tool_handler->handle_tool_call($complete_parameters, $tool_def);
 
-		$tool_handler = new $class_name();
-		$tool_result  = $tool_handler->handle_tool_call( $complete_parameters, $tool_def );
+        return $tool_result;
+    }
 
-		return $tool_result;
-	}
+    /**
+     * Validate that all required parameters are present.
+     *
+     * @param  array $tool_parameters Parameters from AI
+     * @param  array $tool_def        Tool definition with parameter specs
+     * @return array Validation result with 'valid', 'required', and 'missing' keys
+     */
+    private static function validateRequiredParameters( array $tool_parameters, array $tool_def ): array
+    {
+        $required = array();
+        $missing  = array();
 
-	/**
-	 * Validate that all required parameters are present.
-	 *
-	 * @param array $tool_parameters Parameters from AI
-	 * @param array $tool_def Tool definition with parameter specs
-	 * @return array Validation result with 'valid', 'required', and 'missing' keys
-	 */
-	private static function validateRequiredParameters( array $tool_parameters, array $tool_def ): array {
-		$required = array();
-		$missing  = array();
+        $param_defs = $tool_def['parameters'] ?? array();
 
-		$param_defs = $tool_def['parameters'] ?? array();
+        foreach ( $param_defs as $param_name => $param_config ) {
+            if (! is_array($param_config) ) {
+                continue;
+            }
 
-		foreach ( $param_defs as $param_name => $param_config ) {
-			if ( ! is_array( $param_config ) ) {
-				continue;
-			}
+            if (! empty($param_config['required']) ) {
+                $required[] = $param_name;
 
-			if ( ! empty( $param_config['required'] ) ) {
-				$required[] = $param_name;
+                if (! isset($tool_parameters[ $param_name ]) || '' === $tool_parameters[ $param_name ] ) {
+                    $missing[] = $param_name;
+                }
+            }
+        }
 
-				if ( ! isset( $tool_parameters[ $param_name ] ) || '' === $tool_parameters[ $param_name ] ) {
-					$missing[] = $param_name;
-				}
-			}
-		}
-
-		return array(
-			'valid'    => empty( $missing ),
-			'required' => $required,
-			'missing'  => $missing,
-		);
-	}
+        return array(
+        'valid'    => empty($missing),
+        'required' => $required,
+        'missing'  => $missing,
+        );
+    }
 }

--- a/inc/Engine/AI/Tools/ToolResultFinder.php
+++ b/inc/Engine/AI/Tools/ToolResultFinder.php
@@ -2,8 +2,8 @@
 
 namespace DataMachine\Engine\AI\Tools;
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+if (! defined('ABSPATH') ) {
+    exit;
 }
 
 /**
@@ -13,56 +13,98 @@ if ( ! defined( 'ABSPATH' ) ) {
  * for all step types that participate in AI tool calling.
  *
  * @package DataMachine\Engine\AI\Tools
- * @since 0.2.1
+ * @since   0.2.1
  */
-class ToolResultFinder {
+class ToolResultFinder
+{
 
-	/**
-	 * Find AI tool execution result by exact handler match.
-	 *
-	 * Searches data packet for tool_result or ai_handler_complete entries
-	 * matching the specified handler slug. Logs error when no match found.
-	 *
-	 * @param array  $dataPackets Data packet array from pipeline execution
-	 * @param string $handler Handler slug to match
-	 * @param string $flow_step_id Flow step ID for error logging context
-	 * @return array|null Tool result entry or null if no match found
-	 */
-	public static function findHandlerResult( array $dataPackets, string $handler, string $flow_step_id ): ?array {
-		foreach ( $dataPackets as $entry ) {
-			$entry_type = $entry['type'] ?? '';
+    /**
+     * Find AI tool execution result by exact handler match.
+     *
+     * Searches data packet for tool_result or ai_handler_complete entries
+     * matching the specified handler slug. Logs error when no match found.
+     *
+     * @param  array  $dataPackets  Data packet array from pipeline execution
+     * @param  string $handler      Handler slug to match
+     * @param  string $flow_step_id Flow step ID for error logging context
+     * @return array|null Tool result entry or null if no match found
+     */
+    public static function findHandlerResult( array $dataPackets, string $handler, string $flow_step_id ): ?array
+    {
+        foreach ( $dataPackets as $entry ) {
+            $entry_type = $entry['type'] ?? '';
 
-			// Only match successful handler completions.
-			// 'ai_handler_complete' entries are already filtered for success during creation.
-			// 'tool_result' entries must be checked for tool_success to avoid treating
-			// failed tool calls as successful publish completions.
-			if ( 'ai_handler_complete' === $entry_type ) {
-				$handler_tool = $entry['metadata']['handler_tool'] ?? '';
-				if ( $handler_tool === $handler ) {
-					return $entry;
-				}
-			}
+            // Only match successful handler completions.
+            // 'ai_handler_complete' entries are already filtered for success during creation.
+            // 'tool_result' entries must be checked for tool_success to avoid treating
+            // failed tool calls as successful publish completions.
+            if ('ai_handler_complete' === $entry_type ) {
+                $handler_tool = $entry['metadata']['handler_tool'] ?? '';
+                if ($handler_tool === $handler ) {
+                    return $entry;
+                }
+            }
 
-			if ( 'tool_result' === $entry_type ) {
-				$handler_tool = $entry['metadata']['handler_tool'] ?? '';
-				$tool_success = $entry['metadata']['tool_success'] ?? false;
-				if ( $handler_tool === $handler && $tool_success ) {
-					return $entry;
-				}
-			}
-		}
+            if ('tool_result' === $entry_type ) {
+                $handler_tool = $entry['metadata']['handler_tool'] ?? '';
+                $tool_success = $entry['metadata']['tool_success'] ?? false;
+                if ($handler_tool === $handler && $tool_success ) {
+                    return $entry;
+                }
+            }
+        }
 
-		// Log error when not found
-		do_action(
-			'datamachine_log',
-			'error',
-			'AI did not execute handler tool',
-			array(
-				'handler'      => $handler,
-				'flow_step_id' => $flow_step_id,
-			)
-		);
+        // Log error when not found
+        do_action(
+            'datamachine_log',
+            'error',
+            'AI did not execute handler tool',
+            array(
+            'handler'      => $handler,
+            'flow_step_id' => $flow_step_id,
+            )
+        );
 
-		return null;
-	}
+        return null;
+    }
+
+    /**
+     * Find ALL handler results matching any of the given handler slugs.
+     *
+     * @param  array  $dataPackets   Data packets from pipeline
+     * @param  array  $handler_slugs Handler slugs to match
+     * @param  string $flow_step_id  Flow step ID for logging
+     * @return array Array of matching tool result entries
+     */
+    public static function findAllHandlerResults( array $dataPackets, array $handler_slugs, string $flow_step_id ): array
+    {
+        $results = array();
+
+        foreach ( $handler_slugs as $slug ) {
+            foreach ( $dataPackets as $entry ) {
+                $entry_type   = $entry['type'] ?? '';
+                $handler_tool = $entry['metadata']['handler_tool'] ?? '';
+
+                if ('ai_handler_complete' === $entry_type && $handler_tool === $slug ) {
+                    $results[] = $entry;
+                } elseif ('tool_result' === $entry_type && $handler_tool === $slug && ( $entry['metadata']['tool_success'] ?? false ) ) {
+                    $results[] = $entry;
+                }
+            }
+        }
+
+        if (empty($results) ) {
+            do_action(
+                'datamachine_log',
+                'error',
+                'AI did not execute any handler tools',
+                array(
+                'handlers'     => $handler_slugs,
+                'flow_step_id' => $flow_step_id,
+                )
+            );
+        }
+
+        return $results;
+    }
 }


### PR DESCRIPTION
## Multi-handler steps — Core Backend

Closes #233 (PR 1 of series)

### What this PR does
Allows a single pipeline step to have multiple handlers (e.g., a Publish step with WordPress + Pinterest + Twitter). The preceding AI step sees all handler tools in one conversation.

### Changes

#### `inc/Core/Steps/Step.php`
- Added `getHandlerSlugs()`: returns handler slugs from `handler_slugs` (array) or falls back to singular `handler_slug`
- Added `getHandlerConfigs()`: returns per-handler configs from `handler_configs` or falls back to `handler_config`

#### `inc/Engine/AI/Tools/ToolExecutor.php`
- `getAvailableTools()` now loops over multiple handler slugs for both prev/next step configs
- Each handler slug gets its own `chubes_ai_tools` filter call with its own config

#### `inc/Engine/AI/Tools/ToolResultFinder.php`
- Added `findAllHandlerResults()` — finds all matching tool results across multiple handler slugs
- Existing `findHandlerResult()` unchanged for backward compat

#### `inc/Core/Steps/Publish/PublishStep.php`
- Single handler: preserves existing behavior exactly (uses `findHandlerResult`)
- Multi-handler: iterates all results via `findAllHandlerResults`, creates publish entries for each
- `validateStepConfiguration()` overridden to accept multi-handler configs

### Backward Compatibility
Fully backward-compatible. Existing `handler_slug` (string) + `handler_config` (object) configs continue to work unchanged. New plural format (`handler_slugs` array + `handler_configs` map) is additive.