### PR TITLE
feat: Multi-handler steps — config & validation layer (#233)

### DIFF
--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -168,6 +168,18 @@ class ImportExport {
 					$flow_step    = $flow_config[ $flow_step_id ] ?? array();
 
 					if ( ! empty( $flow_step['handler_slug'] ) ) {
+						$settings = array(
+							'handler_config' => $flow_step['handler_config'] ?? array(),
+						);
+
+						// Include multi-handler fields if present.
+						if ( ! empty( $flow_step['handler_slugs'] ) ) {
+							$settings['handler_slugs'] = $flow_step['handler_slugs'];
+						}
+						if ( ! empty( $flow_step['handler_configs'] ) ) {
+							$settings['handler_configs'] = $flow_step['handler_configs'];
+						}
+
 						$csv_rows[] = array(
 							$pipeline_id,
 							$pipeline['pipeline_name'],
@@ -177,7 +189,7 @@ class ImportExport {
 							$flow['flow_id'],
 							$flow['flow_name'],
 							$flow_step['handler_slug'],
-							wp_json_encode( $flow_step['handler_config'] ?? array() ),
+							wp_json_encode( $settings ),
 						);
 					}
 				}


### PR DESCRIPTION
## Multi-handler steps — config & validation layer

Builds on PR #247 (core backend) which added `getHandlerSlugs()` and `getHandlerConfigs()` to Step.php. This PR adds the **API-level support** for configuring multi-handler steps.

### Changes

- **FlowStepHelpers**: New `addHandler()` and `removeHandler()` methods for managing multiple handlers on a single step, with backward-compatible `handler_slug` preservation
- **UpdateFlowStepAbility**: New `add_handler`, `add_handler_config`, and `remove_handler` schema fields with full validation and execution support
- **PipelineSystemPromptDirective**: Workflow visualization now shows all handlers (e.g. `REDDIT+TWITTER FETCH`) when a step has multiple handlers
- **ImportExport**: Export now preserves `handler_slugs` and `handler_configs` fields

Closes #233