### PR TITLE
feat: Multi-handler steps — frontend UI (#233)

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/css/pipelines-modal.css
+++ b/inc/Core/Admin/Pages/Pipelines/assets/css/pipelines-modal.css
@@ -965,6 +965,14 @@
     margin-top: 12px;
 }
 
+.datamachine-handler-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
 .datamachine-handler-badge {
     display: inline-block;
     padding: 4px 12px;
@@ -973,7 +981,32 @@
     border-radius: var(--datamachine-border-radius);
     font-size: 11px;
     font-weight: 500;
-    margin-bottom: 8px;
+    cursor: pointer;
+}
+
+.datamachine-handler-badge:hover {
+    opacity: 0.8;
+}
+
+.datamachine-handler-add-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+    border: 1px dashed #757575;
+    background: transparent;
+    color: #757575;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    padding: 0;
+}
+
+.datamachine-handler-add-badge:hover {
+    border-color: #007cba;
+    color: #007cba;
 }
 
 .datamachine-handler-settings-entry {

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -188,9 +188,13 @@ export default function FlowStepCard( {
 					{ usesHandler && (
 						<FlowStepHandler
 							handlerSlug={ flowStepConfig.handler_slug || null }
+							handlerSlugs={ flowStepConfig.handler_slugs || null }
 							settingsDisplay={ flowStepConfig.settings_display || [] }
-							onConfigure={ () =>
-								onConfigure && onConfigure( flowStepId )
+							onConfigure={ ( slug ) =>
+								onConfigure && onConfigure( flowStepId, slug )
+							}
+							onAddHandler={ () =>
+								onConfigure && onConfigure( flowStepId, null, true )
 							}
 							showConfigureButton
 							showBadge

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/HandlerSettingsModal.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/HandlerSettingsModal.jsx
@@ -39,18 +39,22 @@ import useHandlerModel from '../../hooks/useHandlerModel';
  * @param {Function} props.onOAuthConnect  - OAuth connect callback
  * @param {Object}   props.handlers        - Global handlers metadata from PipelineContext
  * @param {Object}   props.handlerDetails  - Detailed configuration for the selected handler
+ * @param {Array}    props.handlerSlugs    - All handler slugs on this step (multi-handler)
+ * @param {Function} props.onRemoveHandler - Remove handler callback (multi-handler)
  * @return {React.ReactElement|null} Handler settings modal
  */
 export default function HandlerSettingsModal( {
 	onClose,
 	flowStepId,
 	handlerSlug,
+	handlerSlugs,
 	stepType,
 	pipelineId,
 	flowId,
 	currentSettings,
 	onSuccess,
 	onChangeHandler,
+	onRemoveHandler,
 	onOAuthConnect,
 	handlers,
 	handlerDetails,
@@ -231,6 +235,16 @@ export default function HandlerSettingsModal( {
 						>
 							{ __( 'Change Handler', 'data-machine' ) }
 						</Button>
+						{ handlerSlugs?.length > 1 && onRemoveHandler && (
+							<Button
+								variant="secondary"
+								size="small"
+								isDestructive
+								onClick={ () => onRemoveHandler( handlerSlug ) }
+							>
+								{ __( 'Remove Handler', 'data-machine' ) }
+							</Button>
+						) }
 					</div>
 
 					{ handlerInfo.requires_auth && (

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
@@ -19,6 +19,8 @@ import {
 	duplicateFlow,
 	runFlow,
 	updateFlowHandler,
+	addFlowHandler,
+	removeFlowHandler,
 	updateUserMessage,
 	updateFlowSchedule,
 } from '../utils/api';
@@ -381,6 +383,51 @@ export const useUpdateUserMessage = () => {
 						queryClient.setQueryData( queryKey, data );
 					}
 				);
+			}
+		},
+	} );
+};
+
+export const useAddFlowHandler = () => {
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( { flowStepId, handlerSlug, settings = {} } ) =>
+			addFlowHandler( flowStepId, handlerSlug, settings ),
+		onSuccess: ( response, variables ) => {
+			// Invalidate flows to pick up updated handler_slugs / handler_configs.
+			if ( variables.pipelineId ) {
+				const cachedPipelineId = normalizeId( variables.pipelineId );
+				queryClient.invalidateQueries( {
+					queryKey: [ 'flows', cachedPipelineId ],
+				} );
+			}
+			if ( variables.flowId ) {
+				const cachedFlowId = normalizeId( variables.flowId );
+				queryClient.invalidateQueries( {
+					queryKey: [ 'flows', 'single', cachedFlowId ],
+				} );
+			}
+		},
+	} );
+};
+
+export const useRemoveFlowHandler = () => {
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( { flowStepId, handlerSlug } ) =>
+			removeFlowHandler( flowStepId, handlerSlug ),
+		onSuccess: ( response, variables ) => {
+			if ( variables.pipelineId ) {
+				const cachedPipelineId = normalizeId( variables.pipelineId );
+				queryClient.invalidateQueries( {
+					queryKey: [ 'flows', cachedPipelineId ],
+				} );
+			}
+			if ( variables.flowId ) {
+				const cachedFlowId = normalizeId( variables.flowId );
+				queryClient.invalidateQueries( {
+					queryKey: [ 'flows', 'single', cachedFlowId ],
+				} );
 			}
 		},
 	} );

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -279,6 +279,50 @@ export const updateFlowStepConfig = async ( flowStepId, config ) => {
 };
 
 /**
+ * Add a handler to a flow step (multi-handler mode).
+ *
+ * Uses the wp-abilities API to invoke the datamachine/update-flow-step ability.
+ *
+ * @param {string} flowStepId  - Flow step ID
+ * @param {string} handlerSlug - Handler slug to add
+ * @param {Object} settings    - Initial handler settings
+ * @return {Promise<Object>} Ability execution result
+ */
+export const addFlowHandler = async ( flowStepId, handlerSlug, settings = {} ) => {
+	const { default: apiFetch } = await import( '@wordpress/api-fetch' );
+	return await apiFetch( {
+		path: '/wp-abilities/v1/execute/datamachine/update-flow-step',
+		method: 'POST',
+		data: {
+			flow_step_id: flowStepId,
+			add_handler: handlerSlug,
+			add_handler_config: settings,
+		},
+	} );
+};
+
+/**
+ * Remove a handler from a flow step (multi-handler mode).
+ *
+ * Uses the wp-abilities API to invoke the datamachine/update-flow-step ability.
+ *
+ * @param {string} flowStepId  - Flow step ID
+ * @param {string} handlerSlug - Handler slug to remove
+ * @return {Promise<Object>} Ability execution result
+ */
+export const removeFlowHandler = async ( flowStepId, handlerSlug ) => {
+	const { default: apiFetch } = await import( '@wordpress/api-fetch' );
+	return await apiFetch( {
+		path: '/wp-abilities/v1/execute/datamachine/update-flow-step',
+		method: 'POST',
+		data: {
+			flow_step_id: flowStepId,
+			remove_handler: handlerSlug,
+		},
+	} );
+};
+
+/**
  * Update user message for AI step in flow
  *
  * @param {string} flowStepId - Flow step ID


### PR DESCRIPTION
## Multi-handler Steps — Frontend UI

Closes #233 (PR 3 of 3)

### Summary
Adds UI support for managing multiple handlers on a single flow step. Users can now:
- See all assigned handlers as clickable badges on each step card
- Click a badge to configure that specific handler's settings
- Click the **+** button to add another handler to the step
- Remove individual handlers from multi-handler steps via the settings modal

### Changes
- **FlowStepHandler.jsx** — Renders multiple handler badges with click-to-configure; shows add-handler (+) button
- **FlowStepCard.jsx** — Passes `handler_slugs` array and `onAddHandler` callback
- **FlowCard.jsx** — `handleStepConfigured` accepts `specificHandler` and `addMode` to route to correct modal
- **ModalManager.jsx** — Routes `addMode` through `addFlowHandler` ability API; adds `removeHandler` callback
- **HandlerSettingsModal.jsx** — Shows "Remove Handler" button when step has multiple handlers
- **utils/api.js** — `addFlowHandler()` and `removeFlowHandler()` using wp-abilities API
- **queries/flows.js** — `useAddFlowHandler` and `useRemoveFlowHandler` mutation hooks
- **CSS** — Multi-handler badge layout and add-handler button styles

### Dependencies
Builds on:
- #247 — Multi-handler backend support (`handler_slugs`, `handler_configs`)
- #248 — `add_handler` / `remove_handler` in UpdateFlowStepAbility