### PR TITLE
docs: consolidate into AGENTS.md, audit SKILL.md, remove duplicates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,51 @@
 
 Data Machine — WordPress plugin for automating content workflows with AI. Visual pipeline builder, chat agent, REST API, and extensibility via handlers and tools.
 
-Version: 0.13.6
+This file provides a concise, present-tense technical reference for contributors and automated agents. For user-focused docs see `docs/`. For the agent skill (how to *use* Data Machine), see `skills/data-machine/SKILL.md`.
 
-This file provides a concise, present-tense technical reference for contributors and automated agents. For user-focused docs see datamachine/docs/.
+## Build system
+
+- **Homeboy** is used for all build operations (versioning, packaging, deployment)
+- Homeboy provides full WordPress test environment for running tests (no local WordPress setup required)
+- Build command: `homeboy build data-machine` — runs tests, lints code, builds frontend, creates production ZIP
+- Test command: `homeboy test data-machine` — runs PHPUnit tests using homeboy's WordPress environment
+- Lint command: `homeboy lint data-machine` — runs PHP CodeSniffer with WordPress coding standards
+- Auto-fix: `homeboy lint data-machine --fix` — runs PHPCBF to auto-fix formatting issues
+
+## Testing
+
+- PHPUnit tests located in `tests/Unit/` directory
+- Tests use `WP_UnitTestCase` with homeboy's WordPress test environment
+- Ability registration tests in `tests/Unit/Abilities/`
+- Run tests: `homeboy test data-machine`
+- Run build: `homeboy build data-machine` (tests + lint + frontend + ZIP)
+
+## Abilities API
+
+- WordPress 6.9 Abilities API provides standardized capability discovery and execution for all Data Machine operations
+- Abilities are organized across classes in `inc/Abilities/`:
+  - `Pipeline/` — Pipeline CRUD, import/export, duplication
+  - `PipelineStepAbilities` — Pipeline step management
+  - `Flow/` — Flow CRUD, duplication, queue management
+  - `FlowStep/` — Flow step configuration and validation
+  - `Job/` — Workflow execution, job management, health monitoring, problem flow detection, recovery
+  - `FileAbilities` — File management and uploads
+  - `ProcessedItemsAbilities` — Deduplication tracking
+  - `SettingsAbilities` — Plugin and handler settings (includes `agent_models` for per-agent model configuration)
+  - `AuthAbilities` — OAuth authentication management
+  - `LogAbilities` — Logging operations (write, clear, read, metadata, level management)
+  - `HandlerAbilities` — Handler discovery and configuration
+  - `StepTypeAbilities` — Step type discovery and validation
+  - `PostQueryAbilities` — Querying Data Machine-created posts
+  - `LocalSearchAbilities` — WordPress site search
+  - `Media/` — Image generation (with insert mode support), alt text
+  - `Taxonomy/` — Taxonomy term CRUD and resolution
+  - `Analytics/` — Google Search Console, Bing Webmaster
+  - `SystemAbilities` — System-level operations
+  - `AgentPing/` — Agent ping dispatch
+- Category registration: `datamachine` category registered via `wp_register_ability_category()` on `wp_abilities_api_categories_init` hook
+- Ability execution: Each ability implements `execute_callback` with `permission_callback` (checks `manage_options` or WP_CLI)
+- REST API endpoints, CLI commands, and Chat tools delegate to abilities for business logic
 
 Build system
 
@@ -123,6 +165,7 @@ Design principles
 
 Where to find more
 
-- User docs: data-machine/docs/
-- Code: data-machine/inc/
-- Admin UI source: data-machine/inc/Core/Admin/Pages/
+- Agent skill: `skills/data-machine/SKILL.md`
+- User docs: `docs/`
+- Code: `inc/`
+- Admin UI source: `inc/Core/Admin/Pages/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # CLAUDE.md
 
-See [AGENTS.md](AGENTS.md) for all project documentation.
+See **AGENTS.md** for contributor and agent guidance.
 
-This file exists for backwards compatibility with tools that look for CLAUDE.md.
+This file exists for compatibility with tools that look for `CLAUDE.md` by convention.


### PR DESCRIPTION
## Summary

Consolidates contributor/agent guidance into AGENTS.md as the single source of truth. Audits SKILL.md against current codebase. Removes redundant docs.

### Changes

**CLAUDE.md → thin pointer**
- Gutted to a 3-line pointer to AGENTS.md
- Kept as a file so existing tools that reference CLAUDE.md don't break

**AGENTS.md (now single source of truth)**
- Merged build system, testing, and abilities API sections from CLAUDE.md
- Removed hardcoded version (was 0.13.6)
- Removed hardcoded ability count (was 58, actual is 84+)
- Added missing ability classes: Media, Taxonomy, Analytics, System, AgentPing
- Added agent_models and image insert mode references
- Fixed code location paths

**skills/data-machine/SKILL.md — missing features added**
- webhook_gate step type (v0.25.0) — table entry + dedicated section
- Multi-handler publish steps (handler_slugs/handler_configs)
- Pinterest added to publish handler list
- Per-agent model configuration (agent_models, PluginSettings::getAgentModel())
- Image insert modes (featured vs insert, position options)
- Queue update, move, and remove subcommands in CLI reference

**Deleted**
- docs/SKILL.md — redundant duplicate of skills/data-machine/SKILL.md

### Verification
All documented features verified against source files.