### PR TITLE
fix: Multi-handler settings display and handler filtering (#233)

### DIFF
--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -236,8 +236,10 @@ class ConfigureFlowStepsAbility {
 				}
 
 				if ( ! empty( $handler_slug ) ) {
-					$config_handler_slug = $step_config['handler_slug'] ?? null;
-					if ( $config_handler_slug !== $handler_slug ) {
+					$config_handler_slug  = $step_config['handler_slug'] ?? null;
+					$config_handler_slugs = $step_config['handler_slugs'] ?? array();
+					// Match on singular field OR presence in handler_slugs array.
+					if ( $config_handler_slug !== $handler_slug && ! in_array( $handler_slug, $config_handler_slugs, true ) ) {
 						continue;
 					}
 				}
@@ -712,8 +714,10 @@ class ConfigureFlowStepsAbility {
 					}
 				}
 
-				$config_handler_slug = $step_config['handler_slug'] ?? null;
-				if ( $config_handler_slug === $handler_slug ) {
+				$config_handler_slug  = $step_config['handler_slug'] ?? null;
+				$config_handler_slugs = $step_config['handler_slugs'] ?? array();
+				// Match on singular field OR presence in handler_slugs array.
+				if ( $config_handler_slug === $handler_slug || in_array( $handler_slug, $config_handler_slugs, true ) ) {
 					$matching_flows[] = array(
 						'flow'         => $flow,
 						'flow_step_id' => $flow_step_id,

--- a/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
+++ b/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
@@ -199,8 +199,10 @@ class ValidateFlowStepsConfigAbility {
 				}
 
 				if ( ! empty( $handler_slug ) ) {
-					$config_handler_slug = $step_config['handler_slug'] ?? null;
-					if ( $config_handler_slug !== $handler_slug ) {
+					$config_handler_slug  = $step_config['handler_slug'] ?? null;
+					$config_handler_slugs = $step_config['handler_slugs'] ?? array();
+					// Match on singular field OR presence in handler_slugs array.
+					if ( $config_handler_slug !== $handler_slug && ! in_array( $handler_slug, $config_handler_slugs, true ) ) {
 						continue;
 					}
 				}

--- a/inc/Api/Flows/FlowSteps.php
+++ b/inc/Api/Flows/FlowSteps.php
@@ -374,8 +374,9 @@ class FlowSteps {
 				$step_config['execution_order'] = $existing_step['execution_order'];
 			}
 
-			$service                  = new \DataMachine\Core\Steps\Settings\SettingsDisplayService();
-			$handler_settings_display = $service->getDisplaySettings( $flow_step_id, $step_type );
+			$service                   = new \DataMachine\Core\Steps\Settings\SettingsDisplayService();
+			$handler_settings_display  = $service->getDisplaySettings( $flow_step_id, $step_type );
+			$handler_settings_displays = $service->getDisplaySettingsForHandlers( $flow_step_id, $step_type );
 
 			$message = sprintf(
 				/* translators: %s: handler label */
@@ -393,7 +394,8 @@ class FlowSteps {
 						'flow_id'                  => $flow_id,
 						'pipeline_step_id'         => $pipeline_step_id,
 						'step_config'              => $step_config,
-						'handler_settings_display' => $handler_settings_display,
+						'handler_settings_display'  => $handler_settings_display,
+						'handler_settings_displays' => $handler_settings_displays,
 					),
 					'message' => $message,
 				)

--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -28,6 +28,8 @@ class FlowFormatter {
 
 		$handler_abilities = new HandlerAbilities();
 
+		$settings_display_service = new \DataMachine\Core\Steps\Settings\SettingsDisplayService();
+
 		foreach ( $flow_config as $flow_step_id => &$step_data ) {
 			$step_type    = $step_data['step_type'] ?? '';
 			$handler_slug = $step_data['handler_slug'] ?? '';
@@ -44,6 +46,12 @@ class FlowFormatter {
 			$step_data['settings_display'] = apply_filters(
 				'datamachine_get_handler_settings_display',
 				array(),
+				$flow_step_id,
+				$step_type
+			);
+
+			// Multi-handler: per-handler settings displays keyed by slug.
+			$step_data['handler_settings_displays'] = $settings_display_service->getDisplaySettingsForHandlers(
 				$flow_step_id,
 				$step_type
 			);

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -190,6 +190,7 @@ export default function FlowStepCard( {
 							handlerSlug={ flowStepConfig.handler_slug || null }
 							handlerSlugs={ flowStepConfig.handler_slugs || null }
 							settingsDisplay={ flowStepConfig.settings_display || [] }
+							handlerSettingsDisplays={ flowStepConfig.handler_settings_displays || null }
 							onConfigure={ ( slug ) =>
 								onConfigure && onConfigure( flowStepId, slug )
 							}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/HandlerSelectionModal.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/HandlerSelectionModal.jsx
@@ -31,17 +31,20 @@ export default function HandlerSelectionModal( {
 	stepType,
 	onSelectHandler,
 	handlers,
+	existingHandlerSlugs = [],
 } ) {
 	const [ error, setError ] = useState( null );
 	// Presentational: Receive handlers data as props
 
 	/**
-	 * Filter handlers by step type
+	 * Filter handlers by step type, excluding already-configured handlers.
 	 */
 	const { handlers: rawHandlers, getModel } = useHandlerContext() || {};
 
 	const filteredHandlers = Object.entries( rawHandlers || handlers ).filter(
-		( [ , handler ] ) => handler.type === stepType
+		( [ slug, handler ] ) =>
+			handler.type === stepType &&
+			! existingHandlerSlugs.includes( slug )
 	);
 
 	/**

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalSwitch.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalSwitch.jsx
@@ -54,6 +54,7 @@ export default function ModalSwitch( { activeModal, baseProps } ) {
 				<HandlerSelectionModal
 					{ ...baseProps }
 					handlers={ baseProps.handlers }
+					existingHandlerSlugs={ baseProps.addMode ? ( baseProps.handlerSlugs || [] ) : [] }
 				/>
 			);
 

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
@@ -305,6 +305,8 @@ export const useUpdateFlowHandler = () => {
 			const stepConfig = response.data.step_config;
 			const handlerSettingsDisplay =
 				response.data.handler_settings_display;
+			const handlerSettingsDisplays =
+				response.data.handler_settings_displays;
 
 			if ( ! flowId || ! flowStepId || ! stepConfig ) {
 				return;
@@ -319,6 +321,8 @@ export const useUpdateFlowHandler = () => {
 					...stepConfig,
 					settings_display:
 						handlerSettingsDisplay || existingStep.settings_display,
+					handler_settings_displays:
+						handlerSettingsDisplays || existingStep.handler_settings_displays,
 				} ),
 			} );
 		},


### PR DESCRIPTION
## Summary

Cleanup PR for multi-handler steps (#233). Closes gaps left after PRs #247-#249 were merged.

### Changes

**PHP Backend:**
- `SettingsDisplayService`: New `getDisplaySettingsForHandlers()` method that iterates `handler_configs` and returns a per-handler settings display map keyed by slug. Extracted shared logic into private `getDisplayForHandler()`.
- `FlowFormatter`: Includes `handler_settings_displays` in API response alongside existing `settings_display`.
- `FlowSteps`: Handler save endpoint returns `handler_settings_displays` for cache updates.
- `ConfigureFlowStepsAbility`: Handler slug filter now matches against `handler_slugs` array in addition to singular `handler_slug`, so bulk operations find multi-handler steps.
- `ValidateFlowStepsConfigAbility`: Same multi-handler matching for dry-run validation.

**Frontend (React):**
- `FlowStepHandler`: Multi-handler mode renders a handler stack — each handler gets its own badge + settings row.
- `FlowStepCard`: Passes `handler_settings_displays` prop.
- `HandlerSelectionModal`: Filters already-configured handlers in add mode (no duplicates).
- `ModalSwitch`: Passes `existingHandlerSlugs` when `addMode` is true.
- `flows.js` queries: Cache update stores `handler_settings_displays`.

### Approach
Data-driven — reads `handler_configs` / `handler_slugs` from DB. No hardcoded handler assumptions. Falls back gracefully to singular fields when multi-handler data isn't populated (backward compatible).