### PR TITLE
refactor: make handler_configs/handler_slugs single source of truth (#233)

### DIFF
--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -236,16 +236,13 @@ class ConfigureFlowStepsAbility {
 				}
 
 				if ( ! empty( $handler_slug ) ) {
-					$config_handler_slug  = $step_config['handler_slug'] ?? null;
-					$config_handler_slugs = $step_config['handler_slugs'] ?? array();
-					// Match on singular field OR presence in handler_slugs array.
-					if ( $config_handler_slug !== $handler_slug && ! in_array( $handler_slug, $config_handler_slugs, true ) ) {
+					if ( ! in_array( $handler_slug, $step_config['handler_slugs'] ?? array(), true ) ) {
 						continue;
 					}
 				}
 
-				$existing_handler_slug   = $step_config['handler_slug'] ?? null;
-				$existing_handler_config = $step_config['handler_config'] ?? array();
+				$existing_handler_slug   = self::getPrimaryHandlerSlug( $step_config );
+				$existing_handler_config = self::getPrimaryHandlerConfig( $step_config );
 
 				$effective_handler_slug = $target_handler_slug ?? $existing_handler_slug;
 
@@ -550,7 +547,7 @@ class ConfigureFlowStepsAbility {
 				$handler_config = $config['handler_config'] ?? array();
 				$user_message   = $config['user_message'] ?? null;
 
-				$effective_slug = $handler_slug ?? ( $flow_config[ $flow_step_id ]['handler_slug'] ?? null );
+				$effective_slug = $handler_slug ?? self::getPrimaryHandlerSlug( $flow_config[ $flow_step_id ] );
 
 				if ( ! empty( $handler_config ) && ! empty( $effective_slug ) ) {
 					$validation_result = $this->validateHandlerConfig( $effective_slug, $handler_config );
@@ -714,10 +711,7 @@ class ConfigureFlowStepsAbility {
 					}
 				}
 
-				$config_handler_slug  = $step_config['handler_slug'] ?? null;
-				$config_handler_slugs = $step_config['handler_slugs'] ?? array();
-				// Match on singular field OR presence in handler_slugs array.
-				if ( $config_handler_slug === $handler_slug || in_array( $handler_slug, $config_handler_slugs, true ) ) {
+				if ( in_array( $handler_slug, $step_config['handler_slugs'] ?? array(), true ) ) {
 					$matching_flows[] = array(
 						'flow'         => $flow,
 						'flow_step_id' => $flow_step_id,
@@ -768,8 +762,8 @@ class ConfigureFlowStepsAbility {
 			$flow_id      = (int) $flow['flow_id'];
 			$flow_name    = $flow['flow_name'] ?? __( 'Unnamed Flow', 'data-machine' );
 
-			$existing_handler_slug   = $step_config['handler_slug'] ?? null;
-			$existing_handler_config = $step_config['handler_config'] ?? array();
+			$existing_handler_slug   = self::getPrimaryHandlerSlug( $step_config );
+			$existing_handler_config = self::getPrimaryHandlerConfig( $step_config );
 
 			$effective_handler_slug = $target_handler_slug ?? $existing_handler_slug;
 			$is_switching           = ! empty( $target_handler_slug ) && $target_handler_slug !== $existing_handler_slug;

--- a/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
+++ b/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
@@ -135,8 +135,8 @@ class UpdateFlowStepAbility {
 			// Priority: explicit handler_slug > existing handler_slug > step_type (for non-handler steps like agent_ping).
 			$effective_slug = ! empty( $handler_slug )
 				? $handler_slug
-				: ( ! empty( $existing_step['handler_slug'] )
-					? $existing_step['handler_slug']
+				: ( ! empty( self::getPrimaryHandlerSlug( $existing_step ) )
+					? self::getPrimaryHandlerSlug( $existing_step )
 					: ( $existing_step['step_type'] ?? '' ) );
 
 			if ( empty( $effective_slug ) ) {

--- a/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
+++ b/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
@@ -199,17 +199,14 @@ class ValidateFlowStepsConfigAbility {
 				}
 
 				if ( ! empty( $handler_slug ) ) {
-					$config_handler_slug  = $step_config['handler_slug'] ?? null;
-					$config_handler_slugs = $step_config['handler_slugs'] ?? array();
-					// Match on singular field OR presence in handler_slugs array.
-					if ( $config_handler_slug !== $handler_slug && ! in_array( $handler_slug, $config_handler_slugs, true ) ) {
+					if ( ! in_array( $handler_slug, $step_config['handler_slugs'] ?? array(), true ) ) {
 						continue;
 					}
 				}
 
 				++$total_matching_steps;
 
-				$existing_handler_slug  = $step_config['handler_slug'] ?? null;
+				$existing_handler_slug  = self::getPrimaryHandlerSlug( $step_config );
 				$effective_handler_slug = $target_handler_slug ?? $existing_handler_slug;
 
 				if ( empty( $effective_handler_slug ) ) {

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -480,13 +480,16 @@ class ExecuteWorkflowAbility {
 			$pipeline_step_id = "ephemeral_pipeline_{$index}";
 
 			// Flow config (instance-specific)
+			$handler_slug   = $step['handler_slug'] ?? '';
+			$handler_config = $step['handler_config'] ?? array();
+
 			$flow_config[ $step_id ] = array(
 				'flow_step_id'     => $step_id,
 				'pipeline_step_id' => $pipeline_step_id,
 				'step_type'        => $step['type'],
 				'execution_order'  => $index,
-				'handler_slug'     => $step['handler_slug'] ?? '',
-				'handler_config'   => $step['handler_config'] ?? array(),
+				'handler_slugs'    => ! empty( $handler_slug ) ? array( $handler_slug ) : array(),
+				'handler_configs'  => ! empty( $handler_slug ) ? array( $handler_slug => $handler_config ) : array(),
 				'user_message'     => $step['user_message'] ?? '',
 				'disabled_tools'   => $step['disabled_tools'] ?? array(),
 				'pipeline_id'      => 'direct',

--- a/inc/Api/Chat/ChatPipelinesDirective.php
+++ b/inc/Api/Chat/ChatPipelinesDirective.php
@@ -103,9 +103,11 @@ class ChatPipelinesDirective implements \DataMachine\Engine\AI\Directives\Direct
 			$handlers    = array();
 
 			foreach ( $flow_config as $step_config ) {
-				$handler_slug = $step_config['handler_slug'] ?? null;
-				if ( $handler_slug && ! in_array( $handler_slug, $handlers, true ) ) {
-					$handlers[] = $handler_slug;
+				// Data is normalized at the DB layer — handler_slugs is canonical.
+				foreach ( $step_config['handler_slugs'] ?? array() as $slug ) {
+					if ( ! in_array( $slug, $handlers, true ) ) {
+						$handlers[] = $slug;
+					}
 				}
 			}
 

--- a/inc/Api/Chat/Tools/CreatePipeline.php
+++ b/inc/Api/Chat/Tools/CreatePipeline.php
@@ -318,11 +318,14 @@ class CreatePipeline extends BaseTool {
 				$step = array( 'step_type' => $step );
 			}
 
+			$handler_slug   = $step['handler_slug'] ?? null;
+			$handler_config = $step['handler_config'] ?? array();
+
 			$normalized_step = array(
 				'step_type'       => $step['step_type'],
 				'execution_order' => $step['execution_order'] ?? $index,
-				'handler_slug'    => $step['handler_slug'] ?? null,
-				'handler_config'  => $step['handler_config'] ?? array(),
+				'handler_slugs'   => ! empty( $handler_slug ) ? array( $handler_slug ) : array(),
+				'handler_configs' => ! empty( $handler_slug ) ? array( $handler_slug => $handler_config ) : array(),
 			);
 
 			if ( isset( $step['provider'] ) ) {

--- a/inc/Cli/Commands/FlowsCommand.php
+++ b/inc/Cli/Commands/FlowsCommand.php
@@ -615,9 +615,8 @@ class FlowsCommand extends BaseCommand {
 		$handlers    = array();
 
 		foreach ( $flow_config as $step_data ) {
-			if ( ! empty( $step_data['handler_slug'] ) ) {
-				$handlers[] = $step_data['handler_slug'];
-			}
+			// Data is normalized at the DB layer — handler_slugs is canonical.
+			$handlers = array_merge( $handlers, $step_data['handler_slugs'] ?? array() );
 		}
 
 		return implode( ', ', array_unique( $handlers ) );
@@ -633,8 +632,10 @@ class FlowsCommand extends BaseCommand {
 		$flow_config = $flow['flow_config'] ?? array();
 
 		foreach ( $flow_config as $step_data ) {
-			if ( ! empty( $step_data['handler_config']['prompt'] ) ) {
-				$prompt = $step_data['handler_config']['prompt'];
+			$primary_slug   = $step_data['handler_slugs'][0] ?? '';
+			$primary_config = ! empty( $primary_slug ) ? ( $step_data['handler_configs'][ $primary_slug ] ?? array() ) : array();
+			if ( ! empty( $primary_config['prompt'] ) ) {
+				$prompt = $primary_config['prompt'];
 				return mb_strlen( $prompt ) > 50
 					? mb_substr( $prompt, 0, 47 ) . '...'
 					: $prompt;
@@ -743,7 +744,7 @@ class FlowsCommand extends BaseCommand {
 
 		$handler_steps = array();
 		foreach ( $flow_config as $step_id => $step_data ) {
-			if ( ! empty( $step_data['handler_slug'] ) ) {
+			if ( ! empty( $step_data['handler_slugs'] ) ) {
 				$handler_steps[] = $step_id;
 			}
 		}

--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -11,6 +11,7 @@
 namespace DataMachine\Core\Admin;
 
 use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Abilities\FlowStep\FlowStepHelpers;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -31,6 +32,11 @@ class FlowFormatter {
 		$settings_display_service = new \DataMachine\Core\Steps\Settings\SettingsDisplayService();
 
 		foreach ( $flow_config as $flow_step_id => &$step_data ) {
+			// Derive singular fields for backward compatibility in API response.
+			// Data is normalized at the DB layer — handler_slugs/handler_configs are canonical.
+			$step_data['handler_slug']   = FlowStepHelpers::getPrimaryHandlerSlug( $step_data );
+			$step_data['handler_config'] = FlowStepHelpers::getPrimaryHandlerConfig( $step_data );
+
 			$step_type    = $step_data['step_type'] ?? '';
 			$handler_slug = $step_data['handler_slug'] ?? '';
 

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalManager.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalManager.jsx
@@ -102,11 +102,15 @@ export default function ModalManager() {
 					throw new Error( message );
 				}
 
+				// Derive current settings from plural fields, fall back to singular.
+				const stepConfig = result?.data?.step_config || {};
+				const handlerConfigs = stepConfig.handler_configs || {};
+				const currentSettings = handlerConfigs[selectedHandlerSlug] || stepConfig.handler_config || {};
+
 				openModal( MODAL_TYPES.HANDLER_SETTINGS, {
 					...modalData,
 					handlerSlug: selectedHandlerSlug,
-					currentSettings:
-						result?.data?.step_config?.handler_config || {},
+					currentSettings,
 				} );
 			}
 		},

--- a/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
@@ -108,7 +108,6 @@ class PipelineSystemPromptDirective implements \DataMachine\Engine\AI\Directives
 				$sorted_steps[ $execution_order ] = array(
 					'pipeline_step_id' => $step_pipeline_step_id,
 					'step_type'        => $step_config['step_type'] ?? '',
-					'handler_slug'     => $step_config['handler_slug'] ?? '',
 					'handler_slugs'    => $step_config['handler_slugs'] ?? array(),
 				);
 			}
@@ -121,7 +120,6 @@ class PipelineSystemPromptDirective implements \DataMachine\Engine\AI\Directives
 
 		foreach ( $sorted_steps as $step_data ) {
 			$step_type             = $step_data['step_type'];
-			$handler_slug          = $step_data['handler_slug'];
 			$handler_slugs         = $step_data['handler_slugs'];
 			$step_pipeline_step_id = $step_data['pipeline_step_id'];
 
@@ -137,8 +135,10 @@ class PipelineSystemPromptDirective implements \DataMachine\Engine\AI\Directives
 					$labels[]     = strtoupper( $handler_info['label'] ?? $slug );
 				}
 				$workflow_parts[] = implode( '+', $labels ) . ' ' . strtoupper( $step_type );
-			} elseif ( $handler_slug ) {
-				$handler_info     = $handler_abilities->getHandler( $handler_slug, $step_type );
+			} elseif ( ! empty( $handler_slugs ) ) {
+				// Single handler step: show primary handler label.
+				$primary_slug     = $handler_slugs[0];
+				$handler_info     = $handler_abilities->getHandler( $primary_slug, $step_type );
 				$label            = strtoupper( $handler_info['label'] ?? 'UNKNOWN' );
 				$workflow_parts[] = $label . ' ' . strtoupper( $step_type );
 			} else {

--- a/inc/Core/Steps/Settings/SettingsDisplayService.php
+++ b/inc/Core/Steps/Settings/SettingsDisplayService.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Core\Steps\Settings;
 
 use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Abilities\FlowStep\FlowStepHelpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -47,8 +48,9 @@ class SettingsDisplayService {
 			return array();
 		}
 
-		$handler_slug     = $flow_step_config['handler_slug'] ?? '';
-		$current_settings = $flow_step_config['handler_config'] ?? array();
+		// Data is normalized at the DB layer.
+		$handler_slug     = FlowStepHelpers::getPrimaryHandlerSlug( $flow_step_config );
+		$current_settings = FlowStepHelpers::getPrimaryHandlerConfig( $flow_step_config );
 
 		// For step types with usesHandler: false, fall back to step_type as settings key
 		// This allows steps like agent_ping to display their config without a traditional handler
@@ -81,13 +83,14 @@ class SettingsDisplayService {
 			return array();
 		}
 
+		// Data is normalized at the DB layer.
 		$handler_configs = $flow_step_config['handler_configs'] ?? array();
 		$handler_slugs   = $flow_step_config['handler_slugs'] ?? array();
 
-		// Fallback: build from singular fields when multi-handler data isn't populated.
+		// Fallback: build from primary handler when configs are empty.
 		if ( empty( $handler_configs ) ) {
-			$handler_slug     = $flow_step_config['handler_slug'] ?? '';
-			$current_settings = $flow_step_config['handler_config'] ?? array();
+			$handler_slug     = FlowStepHelpers::getPrimaryHandlerSlug( $flow_step_config );
+			$current_settings = FlowStepHelpers::getPrimaryHandlerConfig( $flow_step_config );
 
 			if ( empty( $handler_slug ) && ! empty( $step_type ) ) {
 				$handler_slug = $step_type;

--- a/inc/Core/Steps/Step.php
+++ b/inc/Core/Steps/Step.php
@@ -224,7 +224,7 @@ abstract class Step
      */
     protected function getHandlerSlug(): ?string
     {
-        return $this->flow_step_config['handler_slug'] ?? null;
+        return $this->flow_step_config['handler_slugs'][0] ?? null;
     }
 
     /**
@@ -234,7 +234,8 @@ abstract class Step
      */
     protected function getHandlerConfig(): array
     {
-        return $this->flow_step_config['handler_config'] ?? array();
+        $slug = $this->getHandlerSlug();
+        return ! empty( $slug ) ? ( $this->flow_step_config['handler_configs'][ $slug ] ?? array() ) : array();
     }
 
     /**
@@ -244,31 +245,17 @@ abstract class Step
      */
     protected function getHandlerSlugs(): array
     {
-        // Check handler_slugs (new array format) first
-        if (! empty($this->flow_step_config['handler_slugs']) && is_array($this->flow_step_config['handler_slugs']) ) {
-            return $this->flow_step_config['handler_slugs'];
-        }
-        // Fall back to singular handler_slug
-        $slug = $this->getHandlerSlug();
-        return $slug ? array( $slug ) : array();
+        return $this->flow_step_config['handler_slugs'] ?? array();
     }
 
     /**
      * Get handler configs keyed by handler slug.
-     * Supports new per-handler format and falls back to single handler_config.
      *
      * @return array<string, array> Handler configs keyed by slug
      */
     protected function getHandlerConfigs(): array
     {
-        // New format: handler_configs keyed by slug
-        if (! empty($this->flow_step_config['handler_configs']) && is_array($this->flow_step_config['handler_configs']) ) {
-            return $this->flow_step_config['handler_configs'];
-        }
-        // Fall back: single handler_config paired with handler_slug
-        $slug   = $this->getHandlerSlug();
-        $config = $this->getHandlerConfig();
-        return $slug ? array( $slug => $config ) : array();
+        return $this->flow_step_config['handler_configs'] ?? array();
     }
 
     /**

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -37,13 +37,12 @@ class ToolExecutor
                 continue;
             }
 
-            // Resolve handler slugs (supports both singular and plural)
-            $handler_slugs      = $step_config['handler_slugs']
-            ?? ( isset($step_config['handler_slug']) ? array( $step_config['handler_slug'] ) : array() );
+            // Data is normalized at the DB layer — handler_slugs/handler_configs are canonical.
+            $handler_slugs       = $step_config['handler_slugs'] ?? array();
             $handler_configs_map = $step_config['handler_configs'] ?? array();
 
             foreach ( $handler_slugs as $slug ) {
-                $handler_config  = $handler_configs_map[ $slug ] ?? ( $step_config['handler_config'] ?? array() );
+                $handler_config  = $handler_configs_map[ $slug ] ?? array();
                 $tools           = apply_filters('chubes_ai_tools', array(), $slug, $handler_config, $engine_data);
                 $tools           = $tool_manager->resolveAllTools($tools);
                 $allowed         = self::getAllowedTools($tools, $slug, $current_pipeline_step_id, $tool_manager);

--- a/tests/Unit/Abilities/FlowAbilitiesTest.php
+++ b/tests/Unit/Abilities/FlowAbilitiesTest.php
@@ -163,12 +163,14 @@ class FlowAbilitiesTest extends WP_UnitTestCase {
 			'flow_config' => [
 				'step1' => [
 					'step_type'        => 'fetch',
-					'handler_slug'     => 'rss',
+					'handler_slugs'    => [ 'rss' ],
+					'handler_configs'  => [ 'rss' => [] ],
 					'pipeline_step_id' => 'step1',
 				],
 				'step2' => [
 					'step_type'        => 'publish',
-					'handler_slug'     => 'wordpress_publish',
+					'handler_slugs'    => [ 'wordpress_publish' ],
+					'handler_configs'  => [ 'wordpress_publish' => [] ],
 					'pipeline_step_id' => 'step2',
 				],
 			],


### PR DESCRIPTION
## Summary

Eliminates duplication between singular (`handler_slug`/`handler_config`) and plural (`handler_slugs`/`handler_configs`) fields. Plural fields are now the **only source of truth** for flow step handler configuration.

### The Problem

PRs #247-249 added `handler_slugs` and `handler_configs` for multi-handler support but kept writing to the singular fields too. This created two sources of truth, and `updateHandler()` only wrote to singular — so editing a handler on a multi-handler step left `handler_configs` stale.

### The Fix

**New utilities in FlowStepHelpers:**
- `normalizeHandlerFields()` — converts legacy singular fields to plural format on read. Called whenever step config is loaded from DB.
- `getPrimaryHandlerSlug()` / `getPrimaryHandlerConfig()` — convenience getters that read from plural fields with legacy fallback.

**All writes go to plural only:**
- `updateHandler()` — writes to `handler_configs[$slug]` and `handler_slugs`, never `handler_slug`/`handler_config`
- `addHandler()` — normalizes first, writes plural only
- `removeHandler()` — normalizes first, writes plural only

**Backward compatibility maintained:**
- API responses (FlowFormatter) derive `handler_slug` and `handler_config` from plural fields for consumers that read singular
- Ability input schemas still accept singular for ergonomics (AI agents send singular when configuring one handler)
- Legacy DB data (only has singular fields) auto-migrated on read via normalization

### Files Changed (16)

**Core write path:** FlowStepHelpers, UpdateFlowStepAbility
**Abilities:** ConfigureFlowStepsAbility, ValidateFlowStepsConfigAbility, FlowHelpers, ExecuteWorkflowAbility
**API:** FlowSteps REST, FlowFormatter, CreatePipeline chat tool
**Engine:** Step.php runtime, PipelineSystemPromptDirective, ImportExport
**Display:** SettingsDisplayService
**Frontend:** FlowStepCard.jsx, ModalManager.jsx
**Tests:** FlowAbilitiesTest fixtures