### PR TITLE
fix: preserve handler_config for non-handler step types during normalization

### DIFF
--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -58,12 +58,15 @@ trait FlowStepHelpers {
 		if ( ! empty( $slug ) ) {
 			$step_config['handler_slugs']  = array( $slug );
 			$step_config['handler_configs'] = array( $slug => $config );
+			unset( $step_config['handler_slug'], $step_config['handler_config'] );
 		} else {
 			$step_config['handler_slugs']  = array();
 			$step_config['handler_configs'] = array();
+			unset( $step_config['handler_slug'] );
+			// Preserve handler_config for non-handler step types (Agent Ping, Webhook Gate)
+			// that store settings directly in handler_config without a handler_slug.
 		}
 
-		unset( $step_config['handler_slug'], $step_config['handler_config'] );
 		return $step_config;
 	}
 


### PR DESCRIPTION
## Problem

After the source-of-truth refactor (#259), non-handler step types (Agent Ping, Webhook Gate) show blank settings in the pipeline builder UI despite having been configured.

## Cause

`normalizeHandlerFields()` was unsetting `handler_config` for ALL steps, including those without a `handler_slug`. Non-handler steps store settings directly in `handler_config` (webhook URLs, auth tokens, reply channels, etc.) without a corresponding `handler_slug`, so the normalization was nuking their config.

## Fix

Only unset `handler_config` when a `handler_slug` is present (meaning the config has been properly migrated into `handler_configs`). When no slug exists, `handler_config` is preserved as a plain settings bag for non-handler step types.

**No data was lost** — normalization only happens in memory on read, and the DB data was never overwritten with blank values (steps weren't saved after loading).

Closes regression from #259.