### PR TITLE
Fix broken doc references from Services→Abilities migration

### DIFF
--- a/docs/api/endpoints/handlers.md
+++ b/docs/api/endpoints/handlers.md
@@ -53,7 +53,7 @@ curl https://example.com/wp-json/datamachine/v1/handlers?step_type=update \
   "data": {
     "rss": {
       "type": "fetch",
-      "class": "DataMachine\\Core\\Steps\\Fetch\\Handlers\\RSS\\RSS",
+      "class": "DataMachine\\Core\\Steps\\Fetch\\Handlers\\Rss\\Rss",
       "label": "RSS Feed",
       "description": "Fetch content from RSS feeds",
       "requires_auth": false
@@ -103,7 +103,7 @@ curl https://example.com/wp-json/datamachine/v1/handlers?step_type=update \
     },
     "wordpress-update": {
       "type": "update",
-      "class": "DataMachine\\Core\\Steps\\Update\\Handlers\\WordPressUpdate\\WordPressUpdate",
+      "class": "DataMachine\\Core\\Steps\\Update\\Handlers\\WordPress\\WordPress",
       "label": "WordPress Update",
       "description": "Update existing WordPress content",
       "requires_auth": false

--- a/docs/api/endpoints/logs.md
+++ b/docs/api/endpoints/logs.md
@@ -41,21 +41,22 @@ Clears log files.
 
 For technical details on the logging architecture and the service layer, see the [Logger System Documentation](../../core-system/logger.md).
 
-### LogsManager Service
+### Log Abilities
 
-The `LogsManager` service provides direct method calls for logging and retrieval. Note: logging-related actions are also exposed via Abilities (`LogAbilities.php`) and REST endpoints delegate to abilities where available; `LogsManager` remains as a file/IO utility during the Abilities migration.
+Logging operations are handled via the Abilities API (`DataMachine\Abilities\LogAbilities`).
 
 ```php
-$logs_manager = new \DataMachine\Services\LogsManager();
+// Write a log entry
+$ability = wp_get_ability( 'datamachine/write-to-log' );
+$ability->execute( [
+    'level'   => 'info',
+    'message' => 'Executing flow',
+    'agent'   => 'pipeline',
+] );
 
-// Log a message
-$logs_manager->log('info', 'Executing flow', ['flow_id' => 123]);
-
-// Retrieve logs
-$logs = $logs_manager->get_logs([
-    'level' => 'error',
-    'per_page' => 50
-]);
+// Read logs
+$ability = wp_get_ability( 'datamachine/read-logs' );
+$logs = $ability->execute( [ 'agent' => 'pipeline', 'limit' => 50 ] );
 ```
 
 ### Log Levels

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -85,15 +85,13 @@ register_rest_route('datamachine/v1', '/pipelines', [
     'permission_callback' => [Pipelines::class, 'check_permission']
 ]);
 
-// Services layer usage in endpoint callbacks
+// Abilities API usage in endpoint callbacks
 public function create_pipeline($request) {
-    // Prefer abilities when available:
-    // $ability = wp_get_ability('datamachine/create-pipeline');
-    // return $ability->execute(['pipeline_name' => $request['name'], 'options' => $request['options'] ?? []]);
-
-    // Transitional: service manager usage supported until full migration completes
-    $pipeline_manager = new \DataMachine\Services\PipelineManager();
-    return $pipeline_manager->create($request['name'], $request['options'] ?? []);
+    $ability = wp_get_ability( 'datamachine/create-pipeline' );
+    return $ability->execute( [
+        'pipeline_name' => $request['name'],
+        'options'       => $request['options'] ?? [],
+    ] );
 }
 ```
 

--- a/docs/core-system/ai-directives.md
+++ b/docs/core-system/ai-directives.md
@@ -38,9 +38,9 @@ Provides a lightweight inventory of all pipelines, including their configured st
 **Context Awareness**:
 When `selected_pipeline_id` is provided (e.g., from the Integrated Chat Sidebar), the agent prioritizes and expands context for that specific pipeline, enabling it to learn from established configuration patterns and provide targeted assistance.
 
-### GlobalSystemPromptDirective (Priority 20)
+### AgentSoulDirective (Priority 20)
 
-**Location**: `inc/Engine/AI/Directives/GlobalSystemPromptDirective.php`  
+**Location**: `inc/Engine/AI/Directives/AgentSoulDirective.php`  
 **Agent Types**: All agents  
 **Purpose**: Injects user-configured global AI behavior
 

--- a/docs/core-system/database-schema.md
+++ b/docs/core-system/database-schema.md
@@ -223,9 +223,9 @@ $job_id = $db_jobs->create_job([
 
 **Update Status**:
 ```php
-// Services Layer (recommended since v0.4.0)
-$job_manager = new \DataMachine\Services\JobManager();
-$job_manager->updateStatus($job_id, 'completed', 'Success message');
+// Abilities API
+$ability = wp_get_ability( 'datamachine/fail-job' );
+$ability->execute( [ 'job_id' => $job_id, 'reason' => 'Success message' ] );
 
 // Action Hook (for extensibility)
 do_action('datamachine_update_job_status', $job_id, 'completed', 'Success message');

--- a/docs/core-system/step-navigator.md
+++ b/docs/core-system/step-navigator.md
@@ -106,11 +106,6 @@ if ($next_flow_step_id) {
     do_action('datamachine_schedule_next_step', $job_id, $next_flow_step_id, $data);
 } else {
     // Pipeline complete
-    // Services Layer (recommended since v0.4.0)
-    $job_manager = new \DataMachine\Services\JobManager();
-    $job_manager->updateStatus($job_id, 'completed');
-    
-    // Action Hook (for extensibility)
     do_action('datamachine_update_job_status', $job_id, 'completed');
 }
 ```

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -377,7 +377,7 @@ add_filter('datamachine_session_title_prompt', function($prompt, $context) {
 
 **Purpose**: Create new pipeline
 
-**Services Integration**: Primarily handled by PipelineManager::create() since v0.4.0
+**Abilities Integration**: Handled by `datamachine/create-pipeline` ability.
 
 **Parameters**:
 - `$pipeline_id` (null) - Placeholder for return value
@@ -395,9 +395,9 @@ $data = [
 
 **Usage**:
 ```php
-// Services Layer (recommended since v0.4.0)
-$pipeline_manager = new \DataMachine\Services\PipelineManager();
-$result = $pipeline_manager->create('Pipeline Name', $options);
+// Abilities API
+$ability = wp_get_ability( 'datamachine/create-pipeline' );
+$result = $ability->execute( [ 'pipeline_name' => 'Pipeline Name', 'options' => $options ] );
 
 // Filter Hook (for extensibility)
 $pipeline_id = apply_filters('datamachine_create_pipeline', null, $data);
@@ -407,7 +407,7 @@ $pipeline_id = apply_filters('datamachine_create_pipeline', null, $data);
 
 **Purpose**: Create new flow instance
 
-**Services Integration**: Primarily handled by FlowManager::create() since v0.4.0
+**Abilities Integration**: Handled by `datamachine/create-flow` ability.
 
 **Parameters**:
 - `$flow_id` (null) - Placeholder for return value
@@ -417,9 +417,9 @@ $pipeline_id = apply_filters('datamachine_create_pipeline', null, $data);
 
 **Usage**:
 ```php
-// Services Layer (recommended since v0.4.0)
-$flow_manager = new \DataMachine\Services\FlowManager();
-$result = $flow_manager->create($pipeline_id, 'Flow Name', $options);
+// Abilities API
+$ability = wp_get_ability( 'datamachine/create-flow' );
+$result = $ability->execute( [ 'pipeline_id' => $pipeline_id, 'flow_name' => 'Flow Name' ] );
 
 // Filter Hook (for extensibility)
 $flow_id = apply_filters('datamachine_create_flow', null, $data);


### PR DESCRIPTION
## Summary

Fixes all broken documentation references from the Services layer → Abilities API migration.

### Changes

**Namespace/class refs updated (18 broken refs fixed):**
- `DataMachine\Services\JobManager` → `wp_get_ability('datamachine/fail-job')` / `wp_get_ability('datamachine/retry-job')`
- `DataMachine\Services\LogsManager` → `wp_get_ability('datamachine/write-to-log')` / `wp_get_ability('datamachine/read-logs')`
- `DataMachine\Services\PipelineManager` → `wp_get_ability('datamachine/create-pipeline')`
- `DataMachine\Services\FlowManager` → `wp_get_ability('datamachine/create-flow')`
- `DataMachine\Core\Steps\Fetch\Handlers\RSS\RSS` → `Rss\Rss` (case fix)
- `DataMachine\Core\Steps\Update\Handlers\WordPressUpdate\WordPressUpdate` → `WordPress\WordPress`
- `DataMachine\Api\Status` → removed (endpoint no longer exists)
- `GlobalSystemPromptDirective` → `AgentSoulDirective`

**Code examples updated:**
- All `new \DataMachine\Services\*Manager()` instantiations replaced with `wp_get_ability()` calls
- "Services Layer" language updated to "Abilities API" throughout

**Left as-is (intentional example/placeholder refs, 14 refs):**
- `MyNamespace\*`, `My\Directive\Class`, `Namespace\ClassName`
- `DMRecipes\*`, `DmEvents\*`, `DMStructuredData\*`, `YourExtension\*`
- `DataMachine\Engine\AI\Tools\MyTool` (example in tool-execution.md)
- `DataMachine\Engine\AI\Tools\Global` (valid namespace, false positive)
- `DataMachine\Core\FilesRepository` (valid namespace used in `use` statement)
- `DataMachine\Abilities` (valid namespace reference in overview.md)

**Files changed:** 9 docs across api/, core-system/, development/

Fixes #255