### PR TITLE
fix: resolve race condition in InlineStepConfig field initialization

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/InlineStepConfig.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/InlineStepConfig.jsx
@@ -55,6 +55,8 @@ export default function InlineStepConfig( {
 	const localValuesRef = useRef( localValues );
 
 	// Initialize local values from handler config.
+	// Depends on fieldEntries.length so values are set once the handler details schema loads
+	// (fixes race condition where handlerConfig arrives before the schema query resolves).
 	useEffect( () => {
 		if ( fieldEntries.length === 0 ) {
 			return;
@@ -66,7 +68,7 @@ export default function InlineStepConfig( {
 		} );
 		setLocalValues( initial );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ handlerSlug, JSON.stringify( handlerConfig ) ] );
+	}, [ handlerSlug, fieldEntries.length, JSON.stringify( handlerConfig ) ] );
 
 	// Keep ref in sync.
 	useEffect( () => {


### PR DESCRIPTION
## Problem

Non-handler step config fields (Agent Ping webhook URLs, auth tokens, reply channels, etc.) appear **blank on initial page load** but populate correctly when switching tabs.

## Root Cause

Race condition in `InlineStepConfig`: the handler details schema loads asynchronously *after* the flow data. The `useEffect` that initializes `localValues` from `handlerConfig`:

1. Runs on mount → `fieldEntries` is empty (schema not loaded) → **returns early**
2. Schema arrives → `fieldEntries` populates → but **useEffect doesn't re-run** because its deps (`handlerSlug`, `handlerConfig`) haven't changed
3. Fields render with empty `localValues`

When switching tabs, handler details are cached (30-min staleTime), so both arrive simultaneously → fields work.

## Fix

Add `fieldEntries.length` to the `useEffect` dependency array so it re-runs when the handler details query resolves.

One-line change: `[handlerSlug, JSON.stringify(handlerConfig)]` → `[handlerSlug, fieldEntries.length, JSON.stringify(handlerConfig)]`