### PR TITLE
Fix misleading fail-job example in database-schema docs

### DIFF
--- a/docs/core-system/database-schema.md
+++ b/docs/core-system/database-schema.md
@@ -221,14 +221,14 @@ $job_id = $db_jobs->create_job([
 ]);
 ```
 
-**Update Status**:
+**Fail Job**:
 ```php
 // Abilities API
 $ability = wp_get_ability( 'datamachine/fail-job' );
-$ability->execute( [ 'job_id' => $job_id, 'reason' => 'Success message' ] );
+$ability->execute( [ 'job_id' => $job_id, 'reason' => 'Processing failed: timeout exceeded' ] );
 
 // Action Hook (for extensibility)
-do_action('datamachine_update_job_status', $job_id, 'completed', 'Success message');
+do_action('datamachine_update_job_status', $job_id, 'failed', 'Processing failed: timeout exceeded');
 ```
 
 ### Processed Items


### PR DESCRIPTION
The example used `datamachine/fail-job` ability with 'Success message' under an 'Update Status' heading — implying it was a generic status updater. Fixed to accurately show fail-job usage with a failure reason under a 'Fail Job' heading.

Caught by Command during #261 review.

Ref: #255