### PR TITLE
refactor: eliminate local state mirroring, use TanStack Query as single source of truth

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -172,6 +172,8 @@ export default function FlowStepCard( {
 							handlerSlug={ effectiveHandlerSlug }
 							excludeFields={ excludeFields }
 							onError={ setError }
+							pipelineId={ pipelineId }
+							flowId={ flowId }
 						/>
 					) }
 

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/config.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/config.js
@@ -12,7 +12,7 @@ import { useQuery } from '@tanstack/react-query';
 /**
  * Internal dependencies
  */
-import { getStepTypes, getTools } from '../utils/api';
+import { getStepTypes, getTools, getSchedulingIntervals } from '../utils/api';
 
 export const useStepTypes = () =>
 	useQuery( {
@@ -31,6 +31,16 @@ export const useGlobalSettings = () =>
 			return window.datamachineConfig?.globalSettings || {};
 		},
 		staleTime: 10 * 60 * 1000, // 10 minutes
+	} );
+
+export const useSchedulingIntervals = () =>
+	useQuery( {
+		queryKey: [ 'config', 'scheduling-intervals' ],
+		queryFn: async () => {
+			const result = await getSchedulingIntervals();
+			return result.success ? result.data : [];
+		},
+		staleTime: Infinity, // Scheduling intervals don't change
 	} );
 
 export const useTools = () =>

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
@@ -23,6 +23,7 @@ import {
 	removeFlowHandler,
 	updateUserMessage,
 	updateFlowSchedule,
+	updateFlowStepConfig,
 } from '../utils/api';
 import { isSameId, normalizeId } from '../utils/ids';
 
@@ -421,6 +422,33 @@ export const useRemoveFlowHandler = () => {
 		mutationFn: ( { flowStepId, handlerSlug } ) =>
 			removeFlowHandler( flowStepId, handlerSlug ),
 		onSuccess: ( response, variables ) => {
+			if ( variables.pipelineId ) {
+				const cachedPipelineId = normalizeId( variables.pipelineId );
+				queryClient.invalidateQueries( {
+					queryKey: [ 'flows', cachedPipelineId ],
+				} );
+			}
+			if ( variables.flowId ) {
+				const cachedFlowId = normalizeId( variables.flowId );
+				queryClient.invalidateQueries( {
+					queryKey: [ 'flows', 'single', cachedFlowId ],
+				} );
+			}
+		},
+	} );
+};
+
+export const useUpdateFlowStepConfig = () => {
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( { flowStepId, config } ) =>
+			updateFlowStepConfig( flowStepId, config ),
+		onSuccess: ( response, variables ) => {
+			if ( ! response?.success ) {
+				return;
+			}
+
+			// Invalidate flow queries to pick up updated config.
 			if ( variables.pipelineId ) {
 				const cachedPipelineId = normalizeId( variables.pipelineId );
 				queryClient.invalidateQueries( {


### PR DESCRIPTION
## Summary

Eliminates local state mirroring patterns that bypass TanStack Query's cache, addressing the root cause of race conditions like #262 (blank fields on initial load).

Closes #263

## Changes

### PipelineContextFiles.jsx
- **Removed** all manual state (`files`, `loading`, `error`, `uploading`, `deleting`) and the `loadFiles` fetch-in-useEffect pattern
- **Now uses** `useContextFiles(pipelineId)`, `useUploadContextFile()`, and `useDeleteContextFile()` — TanStack hooks that already existed but were unused
- TanStack Query handles caching, loading states, and automatic refetch after mutations

### InlineStepConfig.jsx
- **Replaced** `useEffect`-based initialization of `localValues` with `useMemo` to derive initial values from `handlerConfig` prop + field schema
- **Replaced** raw `updateFlowStepConfig()` API call with new `useUpdateFlowStepConfig` mutation that properly invalidates flow query cache on success
- Local state for controlled inputs is preserved (needed for typing without per-keystroke cache updates)

### FlowScheduleModal.jsx
- **Replaced** manual `intervals` fetch-in-useEffect + `useAsyncOperation` with new `useSchedulingIntervals()` TanStack query hook
- Intervals are cached with `staleTime: Infinity` since they don't change at runtime

### New hooks
- **`useUpdateFlowStepConfig`** in `queries/flows.js` — mutation for flow step config updates with cache invalidation
- **`useSchedulingIntervals`** in `queries/config.js` — query for scheduling interval options

### FlowStepCard.jsx
- Passes `pipelineId` and `flowId` to `InlineStepConfig` for proper cache invalidation

## Not changed (lower priority)
- **PromptField.jsx** — pattern is mostly correct (local state for controlled input + useEffect sync from prop is fine)
- **QueueablePromptField.jsx** — already uses TanStack mutations for queue saves

## Testing
- Pure internal refactor — no visual or behavioral changes
- All imports/exports verified consistent