### PR TITLE
fix: treat empty prompt queue as skipped, not failure

### DIFF
--- a/inc/Core/Steps/AgentPing/AgentPingStep.php
+++ b/inc/Core/Steps/AgentPing/AgentPingStep.php
@@ -135,6 +135,23 @@ class AgentPingStep extends Step {
 			$queue_result = $this->popFromQueueIfEmpty( '', true );
 			$prompt       = $queue_result['value'];
 			$from_queue   = $queue_result['from_queue'];
+
+			// Queue is enabled but empty — skip cleanly instead of failing.
+			if ( empty( $prompt ) && empty( $configured_prompt ) ) {
+				do_action(
+					'datamachine_log',
+					'info',
+					'Agent ping step skipped — queue enabled but empty, no configured prompt',
+					array(
+						'job_id'       => $this->job_id,
+						'flow_step_id' => $this->flow_step_id,
+					)
+				);
+
+				$this->engine->set( 'job_status', \DataMachine\Core\JobStatus::COMPLETED_NO_ITEMS );
+
+				return $this->dataPackets;
+			}
 		} else {
 			$prompt = $queued_prompt;
 		}


### PR DESCRIPTION
## Problem

When a flow's prompt queue is enabled but temporarily empty (e.g. all prompts consumed, new ones not yet added), the job proceeds into the AI conversation with no user message. This produces empty data packets, which the Engine treats as `empty_data_packet_returned` — a **failure**.

Example: Job 1049 on Flow 29 (Content Generation) failed at 2026-02-16 01:55 UTC because the queue was empty at trigger time. This inflates failure counts and triggers unnecessary prompt re-queue via FailJobHandler.

## Fix

In both `AIStep::executeStep()` and `AgentPingStep::executeStep()`:
- After popping from queue, check if we got nothing AND there's no configured fallback message
- If so, set `job_status` to `COMPLETED_NO_ITEMS` and return early
- The Engine's existing status override path completes the job cleanly

`COMPLETED_NO_ITEMS` is already a success status that:
- Resets consecutive failure counters (`SUCCESS_STATUSES`)
- Doesn't trigger prompt re-queue (no `queued_prompt_backup` stored)
- Shows as a clean completion in job history

## Files Changed
- `inc/Core/Steps/AI/AIStep.php` — early return on empty queue
- `inc/Core/Steps/AgentPing/AgentPingStep.php` — same pattern

## Testing
- Empty queue + no configured message → `completed_no_items` (was: `failed - empty_data_packet_returned`)
- Empty queue + configured fallback message → uses fallback as before (unchanged)
- Queue with items → pops and processes as before (unchanged)
- Queue disabled → no behavior change