### PR TITLE
feat: InternalLinkingTask — System Agent task for semantic internal cross-linking (#228)

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -132,6 +132,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/AgentPingAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/TaxonomyAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/InternalLinkingAbilities.php';
 	// Defer ability instantiation to init so translations are loaded.
 	add_action( 'init', function () {
 		new \DataMachine\Abilities\AuthAbilities();
@@ -156,6 +157,7 @@ function datamachine_run_datamachine_plugin() {
 		new \DataMachine\Abilities\Analytics\GoogleSearchConsoleAbilities();
 		new \DataMachine\Abilities\AgentPingAbilities();
 		new \DataMachine\Abilities\TaxonomyAbilities();
+		new \DataMachine\Abilities\InternalLinkingAbilities();
 	} );
 }
 

--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -1,0 +1,364 @@
+<?php
+/**
+ * Internal Linking Abilities
+ *
+ * Ability endpoints for AI-powered internal link insertion and diagnostics.
+ * Delegates async execution to the System Agent infrastructure.
+ *
+ * @package DataMachine\Abilities
+ * @since 0.24.0
+ */
+
+namespace DataMachine\Abilities;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\System\SystemAgent;
+
+defined( 'ABSPATH' ) || exit;
+
+class InternalLinkingAbilities {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/internal-linking',
+				array(
+					'label'               => 'Internal Linking',
+					'description'         => 'Queue system agent insertion of semantic internal links into posts',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'post_ids'       => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'integer' ),
+								'description' => 'Post IDs to process',
+							),
+							'category'       => array(
+								'type'        => 'string',
+								'description' => 'Category slug to process all posts from',
+							),
+							'links_per_post' => array(
+								'type'        => 'integer',
+								'description' => 'Maximum internal links to insert per post',
+								'default'     => 3,
+							),
+							'dry_run'        => array(
+								'type'        => 'boolean',
+								'description' => 'Preview which posts would be queued without processing',
+								'default'     => false,
+							),
+							'force'          => array(
+								'type'        => 'boolean',
+								'description' => 'Force re-processing even if already linked',
+								'default'     => false,
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'      => array( 'type' => 'boolean' ),
+							'queued_count' => array( 'type' => 'integer' ),
+							'post_ids'     => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'integer' ),
+							),
+							'message'      => array( 'type' => 'string' ),
+							'error'        => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'queueInternalLinking' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/diagnose-internal-links',
+				array(
+					'label'               => 'Diagnose Internal Links',
+					'description'         => 'Report internal link coverage across published posts',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'            => array( 'type' => 'boolean' ),
+							'total_posts'        => array( 'type' => 'integer' ),
+							'posts_with_links'   => array( 'type' => 'integer' ),
+							'posts_without_links' => array( 'type' => 'integer' ),
+							'avg_links_per_post' => array( 'type' => 'number' ),
+							'by_category'        => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'object' ),
+							),
+						),
+					),
+					'execute_callback'    => array( self::class, 'diagnoseInternalLinks' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Queue internal linking for posts.
+	 *
+	 * @param array $input Ability input.
+	 * @return array Ability response.
+	 */
+	public static function queueInternalLinking( array $input ): array {
+		$post_ids       = array_map( 'absint', $input['post_ids'] ?? array() );
+		$category       = sanitize_text_field( $input['category'] ?? '' );
+		$links_per_post = absint( $input['links_per_post'] ?? 3 );
+		$dry_run        = ! empty( $input['dry_run'] );
+		$force          = ! empty( $input['force'] );
+
+		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$provider        = $system_defaults['provider'];
+		$model           = $system_defaults['model'];
+
+		if ( empty( $provider ) || empty( $model ) ) {
+			return array(
+				'success'      => false,
+				'queued_count' => 0,
+				'post_ids'     => array(),
+				'message'      => 'No default AI provider/model configured.',
+				'error'        => 'Configure default_provider and default_model in Data Machine settings.',
+			);
+		}
+
+		// Resolve category to post IDs.
+		if ( ! empty( $category ) ) {
+			$term = get_term_by( 'slug', $category, 'category' );
+			if ( ! $term ) {
+				return array(
+					'success'      => false,
+					'queued_count' => 0,
+					'post_ids'     => array(),
+					'message'      => "Category '{$category}' not found.",
+					'error'        => 'Invalid category slug',
+				);
+			}
+
+			$cat_posts = get_posts( array(
+				'post_type'      => 'post',
+				'post_status'    => 'publish',
+				'category'       => $term->term_id,
+				'fields'         => 'ids',
+				'numberposts'    => -1,
+			) );
+
+			$post_ids = array_merge( $post_ids, $cat_posts );
+		}
+
+		$post_ids = array_values( array_unique( array_filter( $post_ids ) ) );
+
+		if ( empty( $post_ids ) ) {
+			return array(
+				'success'      => false,
+				'queued_count' => 0,
+				'post_ids'     => array(),
+				'message'      => 'No post IDs provided or resolved.',
+				'error'        => 'Missing required parameter: post_ids or category',
+			);
+		}
+
+		if ( $dry_run ) {
+			return array(
+				'success'      => true,
+				'queued_count' => count( $post_ids ),
+				'post_ids'     => $post_ids,
+				'message'      => sprintf( 'Dry run: %d post(s) would be queued for internal linking.', count( $post_ids ) ),
+			);
+		}
+
+		$systemAgent = SystemAgent::getInstance();
+		$queued      = array();
+
+		foreach ( $post_ids as $pid ) {
+			$post = get_post( $pid );
+			if ( ! $post || 'publish' !== $post->post_status ) {
+				continue;
+			}
+
+			$jobId = $systemAgent->scheduleTask(
+				'internal_linking',
+				array(
+					'post_id'        => $pid,
+					'links_per_post' => $links_per_post,
+					'force'          => $force,
+					'source'         => 'ability',
+				)
+			);
+
+			if ( $jobId ) {
+				$queued[] = $pid;
+			}
+		}
+
+		return array(
+			'success'      => true,
+			'queued_count' => count( $queued ),
+			'post_ids'     => $queued,
+			'message'      => ! empty( $queued )
+				? sprintf( 'Internal linking queued for %d post(s) via System Agent.', count( $queued ) )
+				: 'No posts queued (already processed or ineligible).',
+		);
+	}
+
+	/**
+	 * Diagnose internal link coverage across published posts.
+	 *
+	 * @param array $input Ability input (unused).
+	 * @return array Ability response.
+	 */
+	public static function diagnoseInternalLinks( array $input = array() ): array {
+		global $wpdb;
+
+		$total_posts = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = %s",
+				'post',
+				'publish'
+			)
+		);
+
+		$posts_with_links = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT p.ID)
+				 FROM {$wpdb->posts} p
+				 INNER JOIN {$wpdb->postmeta} m
+					ON p.ID = m.post_id AND m.meta_key = %s
+				 WHERE p.post_type = %s
+				 AND p.post_status = %s
+				 AND m.meta_value != ''
+				 AND m.meta_value IS NOT NULL",
+				'_dm_internal_links',
+				'post',
+				'publish'
+			)
+		);
+
+		$posts_without_links = $total_posts - $posts_with_links;
+
+		// Calculate average links per post from tracked meta.
+		$all_meta = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT m.meta_value
+				 FROM {$wpdb->posts} p
+				 INNER JOIN {$wpdb->postmeta} m
+					ON p.ID = m.post_id AND m.meta_key = %s
+				 WHERE p.post_type = %s
+				 AND p.post_status = %s
+				 AND m.meta_value != ''",
+				'_dm_internal_links',
+				'post',
+				'publish'
+			)
+		);
+
+		$total_links = 0;
+		foreach ( $all_meta as $meta_value ) {
+			$data = maybe_unserialize( $meta_value );
+			if ( is_array( $data ) && isset( $data['links'] ) && is_array( $data['links'] ) ) {
+				$total_links += count( $data['links'] );
+			}
+		}
+
+		$avg_links = $posts_with_links > 0 ? round( $total_links / $posts_with_links, 2 ) : 0;
+
+		// Breakdown by category.
+		$categories  = get_terms( array(
+			'taxonomy'   => 'category',
+			'hide_empty' => true,
+		) );
+		$by_category = array();
+
+		if ( is_array( $categories ) ) {
+			foreach ( $categories as $cat ) {
+				$cat_total = (int) $wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT COUNT(DISTINCT p.ID)
+						 FROM {$wpdb->posts} p
+						 INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
+						 INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+						 WHERE p.post_type = %s
+						 AND p.post_status = %s
+						 AND tt.taxonomy = %s
+						 AND tt.term_id = %d",
+						'post',
+						'publish',
+						'category',
+						$cat->term_id
+					)
+				);
+
+				$cat_with = (int) $wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT COUNT(DISTINCT p.ID)
+						 FROM {$wpdb->posts} p
+						 INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
+						 INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+						 INNER JOIN {$wpdb->postmeta} m ON p.ID = m.post_id AND m.meta_key = %s
+						 WHERE p.post_type = %s
+						 AND p.post_status = %s
+						 AND tt.taxonomy = %s
+						 AND tt.term_id = %d
+						 AND m.meta_value != ''
+						 AND m.meta_value IS NOT NULL",
+						'_dm_internal_links',
+						'post',
+						'publish',
+						'category',
+						$cat->term_id
+					)
+				);
+
+				$by_category[] = array(
+					'category'      => $cat->name,
+					'slug'          => $cat->slug,
+					'total_posts'   => $cat_total,
+					'with_links'    => $cat_with,
+					'without_links' => $cat_total - $cat_with,
+				);
+			}
+		}
+
+		return array(
+			'success'             => true,
+			'total_posts'         => $total_posts,
+			'posts_with_links'    => $posts_with_links,
+			'posts_without_links' => $posts_without_links,
+			'avg_links_per_post'  => $avg_links,
+			'by_category'         => $by_category,
+		);
+	}
+}

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -32,3 +32,5 @@ WP_CLI::add_command( 'datamachine job', Commands\JobsCommand::class );
 WP_CLI::add_command( 'datamachine pipeline', Commands\PipelinesCommand::class );
 WP_CLI::add_command( 'datamachine post', Commands\PostsCommand::class );
 WP_CLI::add_command( 'datamachine log', Commands\LogsCommand::class );
+WP_CLI::add_command( 'datamachine links', Commands\LinksCommand::class );
+WP_CLI::add_command( 'datamachine link', Commands\LinksCommand::class );

--- a/inc/Cli/Commands/LinksCommand.php
+++ b/inc/Cli/Commands/LinksCommand.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * WP-CLI Links Command
+ *
+ * Provides CLI access to internal linking diagnostics and cross-linking.
+ * Wraps InternalLinkingAbilities API primitives.
+ *
+ * @package DataMachine\Cli\Commands
+ * @since 0.24.0
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Abilities\InternalLinkingAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class LinksCommand extends BaseCommand {
+
+	/**
+	 * Queue internal cross-linking for posts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--post_id=<id>]
+	 * : Specific post ID to cross-link.
+	 *
+	 * [--category=<slug>]
+	 * : Process all published posts in a category.
+	 *
+	 * [--all]
+	 * : Process all published posts.
+	 *
+	 * [--links-per-post=<number>]
+	 * : Maximum internal links per post.
+	 * ---
+	 * default: 3
+	 * ---
+	 *
+	 * [--force]
+	 * : Force re-processing even if already linked.
+	 *
+	 * [--dry-run]
+	 * : Preview which posts would be queued without processing.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * [--fields=<fields>]
+	 * : Limit output to specific fields (comma-separated).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Cross-link a specific post
+	 *     wp datamachine links crosslink --post_id=123
+	 *
+	 *     # Cross-link all posts in a category
+	 *     wp datamachine links crosslink --category=nature
+	 *
+	 *     # Cross-link all posts with 5 links each
+	 *     wp datamachine links crosslink --all --links-per-post=5
+	 *
+	 *     # Dry run
+	 *     wp datamachine links crosslink --all --dry-run
+	 *
+	 *     # Force re-processing, JSON output
+	 *     wp datamachine links crosslink --post_id=123 --force --format=json
+	 *
+	 * @subcommand crosslink
+	 */
+	public function crosslink( array $args, array $assoc_args ): void {
+		$post_id        = isset( $assoc_args['post_id'] ) ? absint( $assoc_args['post_id'] ) : 0;
+		$category       = sanitize_text_field( $assoc_args['category'] ?? '' );
+		$all            = isset( $assoc_args['all'] );
+		$links_per_post = absint( $assoc_args['links-per-post'] ?? 3 );
+		$force          = isset( $assoc_args['force'] );
+		$dry_run        = isset( $assoc_args['dry-run'] );
+		$format         = $assoc_args['format'] ?? 'table';
+
+		$post_ids = array();
+
+		if ( $post_id > 0 ) {
+			$post_ids[] = $post_id;
+		}
+
+		if ( $all ) {
+			$all_posts = get_posts( array(
+				'post_type'      => 'post',
+				'post_status'    => 'publish',
+				'fields'         => 'ids',
+				'numberposts'    => -1,
+			) );
+			$post_ids = array_merge( $post_ids, $all_posts );
+		}
+
+		if ( 0 === $post_id && empty( $category ) && ! $all ) {
+			WP_CLI::error( 'Required: --post_id=<id>, --category=<slug>, or --all' );
+			return;
+		}
+
+		$result = InternalLinkingAbilities::queueInternalLinking( array(
+			'post_ids'       => $post_ids,
+			'category'       => $category,
+			'links_per_post' => $links_per_post,
+			'dry_run'        => $dry_run,
+			'force'          => $force,
+		) );
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to queue internal linking.' );
+			return;
+		}
+
+		$queued_count = (int) ( $result['queued_count'] ?? 0 );
+		$queued_ids   = $result['post_ids'] ?? array();
+		$queued_ids   = is_array( $queued_ids ) ? array_values( array_map( 'intval', $queued_ids ) ) : array();
+
+		if ( 'json' === $format ) {
+			WP_CLI::line(
+				\wp_json_encode(
+					array(
+						'queued_count' => $queued_count,
+						'post_ids'     => $queued_ids,
+						'message'      => $result['message'] ?? '',
+					),
+					JSON_PRETTY_PRINT
+				)
+			);
+			return;
+		}
+
+		if ( 'table' === $format && ! empty( $result['message'] ) ) {
+			WP_CLI::success( $result['message'] );
+		}
+
+		$items = array(
+			array(
+				'queued_count' => $queued_count,
+				'post_ids'     => empty( $queued_ids ) ? '' : implode( ', ', $queued_ids ),
+			),
+		);
+
+		$this->format_items( $items, array( 'queued_count', 'post_ids' ), $assoc_args );
+	}
+
+	/**
+	 * Diagnose internal link coverage across published posts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * [--fields=<fields>]
+	 * : Limit output to specific fields (comma-separated).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Diagnose internal link coverage
+	 *     wp datamachine links diagnose
+	 *
+	 *     # JSON output
+	 *     wp datamachine links diagnose --format=json
+	 *
+	 * @subcommand diagnose
+	 */
+	public function diagnose( array $args, array $assoc_args ): void {
+		$format = $assoc_args['format'] ?? 'table';
+
+		$result = InternalLinkingAbilities::diagnoseInternalLinks();
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to diagnose internal links.' );
+			return;
+		}
+
+		$total_posts         = (int) ( $result['total_posts'] ?? 0 );
+		$posts_with_links    = (int) ( $result['posts_with_links'] ?? 0 );
+		$posts_without_links = (int) ( $result['posts_without_links'] ?? 0 );
+		$avg_links_per_post  = (float) ( $result['avg_links_per_post'] ?? 0 );
+		$by_category         = $result['by_category'] ?? array();
+
+		if ( 'json' === $format ) {
+			WP_CLI::line(
+				\wp_json_encode(
+					array(
+						'total_posts'         => $total_posts,
+						'posts_with_links'    => $posts_with_links,
+						'posts_without_links' => $posts_without_links,
+						'avg_links_per_post'  => $avg_links_per_post,
+						'by_category'         => $by_category,
+					),
+					JSON_PRETTY_PRINT
+				)
+			);
+			return;
+		}
+
+		// Summary row + category breakdown.
+		$items   = array();
+		$items[] = array(
+			'category'      => 'ALL',
+			'total_posts'   => $total_posts,
+			'with_links'    => $posts_with_links,
+			'without_links' => $posts_without_links,
+			'avg_links'     => $avg_links_per_post,
+		);
+
+		foreach ( $by_category as $row ) {
+			$items[] = array(
+				'category'      => $row['category'] ?? 'unknown',
+				'total_posts'   => (int) ( $row['total_posts'] ?? 0 ),
+				'with_links'    => (int) ( $row['with_links'] ?? 0 ),
+				'without_links' => (int) ( $row['without_links'] ?? 0 ),
+				'avg_links'     => '',
+			);
+		}
+
+		$this->format_items( $items, array( 'category', 'total_posts', 'with_links', 'without_links', 'avg_links' ), $assoc_args );
+	}
+}

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit;
 use DataMachine\Engine\AI\System\Tasks\AltTextTask;
 use DataMachine\Engine\AI\System\Tasks\GitHubIssueTask;
 use DataMachine\Engine\AI\System\Tasks\ImageGenerationTask;
+use DataMachine\Engine\AI\System\Tasks\InternalLinkingTask;
 
 class SystemAgentServiceProvider {
 
@@ -51,6 +52,7 @@ class SystemAgentServiceProvider {
 		$tasks['image_generation']    = ImageGenerationTask::class;
 		$tasks['alt_text_generation'] = AltTextTask::class;
 		$tasks['github_create_issue'] = GitHubIssueTask::class;
+		$tasks['internal_linking']    = InternalLinkingTask::class;
 
 		return $tasks;
 	}

--- a/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
+++ b/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
@@ -1,0 +1,325 @@
+<?php
+/**
+ * Internal Linking Task for System Agent.
+ *
+ * Semantically weaves internal links into post content by finding related
+ * posts via shared taxonomy terms and using AI to insert anchor tags
+ * naturally into existing sentences.
+ *
+ * @package DataMachine\Engine\AI\System\Tasks
+ * @since 0.24.0
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\RequestBuilder;
+
+class InternalLinkingTask extends SystemTask {
+
+	/**
+	 * Execute internal linking for a specific post.
+	 *
+	 * @param int   $jobId  Job ID from DM Jobs table.
+	 * @param array $params Task parameters from engine_data.
+	 */
+	public function execute( int $jobId, array $params ): void {
+		$post_id        = absint( $params['post_id'] ?? 0 );
+		$links_per_post = absint( $params['links_per_post'] ?? 3 );
+		$force          = ! empty( $params['force'] );
+
+		if ( $post_id <= 0 ) {
+			$this->failJob( $jobId, 'Missing or invalid post_id' );
+			return;
+		}
+
+		$post = get_post( $post_id );
+
+		if ( ! $post || 'publish' !== $post->post_status ) {
+			$this->failJob( $jobId, "Post #{$post_id} does not exist or is not published" );
+			return;
+		}
+
+		// Check if already processed.
+		if ( ! $force ) {
+			$existing_links = get_post_meta( $post_id, '_dm_internal_links', true );
+			if ( ! empty( $existing_links ) ) {
+				$this->completeJob( $jobId, [
+					'skipped' => true,
+					'post_id' => $post_id,
+					'reason'  => 'Already processed (use force to re-run)',
+				] );
+				return;
+			}
+		}
+
+		// Get post taxonomies.
+		$categories = wp_get_post_categories( $post_id, [ 'fields' => 'ids' ] );
+		$tags       = wp_get_post_tags( $post_id, [ 'fields' => 'ids' ] );
+
+		if ( empty( $categories ) && empty( $tags ) ) {
+			$this->completeJob( $jobId, [
+				'skipped' => true,
+				'post_id' => $post_id,
+				'reason'  => 'Post has no categories or tags',
+			] );
+			return;
+		}
+
+		// Find related posts scored by taxonomy overlap.
+		$related = $this->findRelatedPosts( $post_id, $categories, $tags, $links_per_post );
+
+		// Filter out posts already linked in content.
+		$related = $this->filterAlreadyLinked( $related, $post->post_content );
+
+		if ( empty( $related ) ) {
+			$this->completeJob( $jobId, [
+				'skipped' => true,
+				'post_id' => $post_id,
+				'reason'  => 'No unlinked related posts found',
+			] );
+			return;
+		}
+
+		// Build AI request.
+		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$provider        = $system_defaults['provider'];
+		$model           = $system_defaults['model'];
+
+		if ( empty( $provider ) || empty( $model ) ) {
+			$this->failJob( $jobId, 'No default AI provider/model configured' );
+			return;
+		}
+
+		$prompt   = $this->buildPrompt( $post->post_content, $related );
+		$messages = [
+			[
+				'role'    => 'user',
+				'content' => $prompt,
+			],
+		];
+
+		$response = RequestBuilder::build(
+			$messages,
+			$provider,
+			$model,
+			[],
+			'system',
+			[ 'post_id' => $post_id ]
+		);
+
+		if ( empty( $response['success'] ) ) {
+			$this->failJob( $jobId, 'AI request failed: ' . ( $response['error'] ?? 'Unknown error' ) );
+			return;
+		}
+
+		$new_content = $response['data']['content'] ?? '';
+
+		if ( empty( $new_content ) ) {
+			$this->failJob( $jobId, 'AI returned empty content' );
+			return;
+		}
+
+		// Validate that at least one new link was inserted.
+		$inserted_links = $this->detectInsertedLinks( $new_content, $related );
+
+		if ( empty( $inserted_links ) ) {
+			$this->completeJob( $jobId, [
+				'skipped' => true,
+				'post_id' => $post_id,
+				'reason'  => 'AI found no natural insertion points',
+			] );
+			return;
+		}
+
+		// Update post content.
+		$update_result = wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => $new_content,
+			],
+			true
+		);
+
+		if ( is_wp_error( $update_result ) ) {
+			$this->failJob( $jobId, 'Failed to update post: ' . $update_result->get_error_message() );
+			return;
+		}
+
+		// Track which links were added.
+		$link_tracking = [
+			'processed_at' => current_time( 'mysql' ),
+			'links'        => $inserted_links,
+			'job_id'       => $jobId,
+		];
+		update_post_meta( $post_id, '_dm_internal_links', $link_tracking );
+
+		$this->completeJob( $jobId, [
+			'post_id'        => $post_id,
+			'links_inserted' => count( $inserted_links ),
+			'links'          => $inserted_links,
+			'completed_at'   => current_time( 'mysql' ),
+		] );
+	}
+
+	/**
+	 * Get the task type identifier.
+	 *
+	 * @return string
+	 */
+	public function getTaskType(): string {
+		return 'internal_linking';
+	}
+
+	/**
+	 * Find related posts by shared taxonomy terms, scored by overlap.
+	 *
+	 * @param int   $post_id    Current post ID to exclude.
+	 * @param array $categories Category term IDs.
+	 * @param array $tags       Tag term IDs.
+	 * @param int   $limit      Maximum related posts to return.
+	 * @return array Array of related post data [{id, url, title, excerpt, score}].
+	 */
+	private function findRelatedPosts( int $post_id, array $categories, array $tags, int $limit ): array {
+		$tax_query = [ 'relation' => 'OR' ];
+
+		if ( ! empty( $categories ) ) {
+			$tax_query[] = [
+				'taxonomy' => 'category',
+				'field'    => 'term_id',
+				'terms'    => $categories,
+			];
+		}
+
+		if ( ! empty( $tags ) ) {
+			$tax_query[] = [
+				'taxonomy' => 'post_tag',
+				'field'    => 'term_id',
+				'terms'    => $tags,
+			];
+		}
+
+		$query = new \WP_Query( [
+			'post_type'      => 'post',
+			'post_status'    => 'publish',
+			'post__not_in'   => [ $post_id ],
+			'posts_per_page' => 50,
+			'tax_query'      => $tax_query,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+		] );
+
+		if ( empty( $query->posts ) ) {
+			return [];
+		}
+
+		// Score each candidate by taxonomy overlap.
+		$scored = [];
+
+		foreach ( $query->posts as $candidate_id ) {
+			$score          = 0;
+			$candidate_cats = wp_get_post_categories( $candidate_id, [ 'fields' => 'ids' ] );
+			$candidate_tags = wp_get_post_tags( $candidate_id, [ 'fields' => 'ids' ] );
+
+			$shared_cats = array_intersect( $categories, $candidate_cats );
+			$shared_tags = array_intersect( $tags, $candidate_tags );
+
+			$score += count( $shared_cats ) * 1;
+			$score += count( $shared_tags ) * 2;
+
+			if ( $score > 0 ) {
+				$scored[ $candidate_id ] = $score;
+			}
+		}
+
+		// Sort by score descending.
+		arsort( $scored );
+
+		// Pick top N.
+		$top_ids = array_slice( array_keys( $scored ), 0, $limit, true );
+		$related = [];
+
+		foreach ( $top_ids as $rel_id ) {
+			$rel_post  = get_post( $rel_id );
+			$related[] = [
+				'id'      => $rel_id,
+				'url'     => get_permalink( $rel_id ),
+				'title'   => get_the_title( $rel_id ),
+				'excerpt' => wp_trim_words( $rel_post->post_content, 30, '...' ),
+				'score'   => $scored[ $rel_id ],
+			];
+		}
+
+		return $related;
+	}
+
+	/**
+	 * Filter out posts that are already linked in the content.
+	 *
+	 * @param array  $related      Related posts array.
+	 * @param string $post_content Current post content.
+	 * @return array Filtered related posts.
+	 */
+	private function filterAlreadyLinked( array $related, string $post_content ): array {
+		return array_values( array_filter( $related, function ( $item ) use ( $post_content ) {
+			$url = preg_quote( $item['url'], '/' );
+			return ! preg_match( '/' . $url . '/', $post_content );
+		} ) );
+	}
+
+	/**
+	 * Build the AI prompt for internal link insertion.
+	 *
+	 * @param string $post_content Full post content.
+	 * @param array  $related      Related posts data.
+	 * @return string Prompt text.
+	 */
+	private function buildPrompt( string $post_content, array $related ): string {
+		$related_list = '';
+		foreach ( $related as $item ) {
+			$related_list .= sprintf(
+				"- URL: %s\n  Title: %s\n  Excerpt: %s\n\n",
+				$item['url'],
+				$item['title'],
+				$item['excerpt']
+			);
+		}
+
+		return "Here is a blog post in Gutenberg block format. Below are related posts on this site. "
+			. "Weave internal links to these related posts SEMANTICALLY into existing sentences — "
+			. "find natural mentions of the topic and wrap the relevant phrase in an anchor tag. "
+			. "Do NOT add a Related Posts section. Do NOT change tone, meaning, or Gutenberg block structure. "
+			. "Return the FULL updated content with all blocks intact. "
+			. "If no natural insertion point exists for a link, skip that link — do not force it.\n\n"
+			. "=== POST CONTENT ===\n\n"
+			. $post_content . "\n\n"
+			. "=== RELATED POSTS TO LINK ===\n\n"
+			. $related_list;
+	}
+
+	/**
+	 * Detect which related post URLs were inserted into the new content.
+	 *
+	 * @param string $new_content Updated content from AI.
+	 * @param array  $related     Related posts that were candidates.
+	 * @return array URLs that were found in the new content.
+	 */
+	private function detectInsertedLinks( string $new_content, array $related ): array {
+		$inserted = [];
+
+		foreach ( $related as $item ) {
+			$url = preg_quote( $item['url'], '/' );
+			if ( preg_match( '/<a\s[^>]*href=["\']' . $url . '["\'][^>]*>/', $new_content ) ) {
+				$inserted[] = [
+					'url'     => $item['url'],
+					'post_id' => $item['id'],
+					'title'   => $item['title'],
+				];
+			}
+		}
+
+		return $inserted;
+	}
+}


### PR DESCRIPTION
## Summary
Adds `InternalLinkingTask` to the System Agent — AI-powered semantic internal cross-linking of posts. Follows the exact same architecture as `AltTextTask`.

Closes #228

## What It Does
1. Finds related posts by shared taxonomy overlap (categories=1pt, tags=2pts)
2. Filters out already-linked posts
3. Sends post content + related post data to AI
4. AI weaves links semantically into existing sentences (no "Related Posts" section)
5. Validates links were actually inserted
6. Updates post content and tracks via `_dm_internal_links` post meta

## Files Added
- `inc/Engine/AI/System/Tasks/InternalLinkingTask.php` — The task (extends SystemTask)
- `inc/Abilities/InternalLinkingAbilities.php` — Two abilities: `datamachine/internal-linking` + `datamachine/diagnose-internal-links`
- `inc/Cli/Commands/LinksCommand.php` — `wp datamachine links crosslink` + `diagnose`

## Files Modified
- `SystemAgentServiceProvider.php` — registered task
- `data-machine.php` — registered abilities
- `Cli/Bootstrap.php` — registered CLI command

## Usage

### Ability
```php
wp_get_ability('datamachine/internal-linking')->execute([
    'post_ids' => [1234, 5678],
    'links_per_post' => 3,
]);

// Or by category
wp_get_ability('datamachine/internal-linking')->execute([
    'category' => 'birds',
]);
```

### CLI
```bash
wp datamachine links crosslink --post_id=1234
wp datamachine links crosslink --category=birds --dry-run
wp datamachine links crosslink --all --links-per-post=3
wp datamachine links diagnose
```

## Architecture
Same pattern as AltTextTask:
- One post per job → Action Scheduler handles batching
- `RequestBuilder::build()` with system agent model
- Idempotent via `_dm_internal_links` post meta tracking
- `force` flag to re-process