### PR TITLE
feat: Agent memory foundation — SOUL.md in files repository

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -47,6 +47,9 @@ if ( ! class_exists( 'ActionScheduler' ) ) {
 
 function datamachine_run_datamachine_plugin() {
 
+	// Run agent memory migration on upgrade (version check).
+	\DataMachine\Core\FilesRepository\AgentMemoryMigration::maybe_run();
+
 	// Set Action Scheduler timeout to 10 minutes (600 seconds) for large tasks
 	add_filter(
 		'action_scheduler_timeout_period',
@@ -293,6 +296,9 @@ function datamachine_activate_plugin() {
 	if ( ! file_exists( $log_dir ) ) {
 		wp_mkdir_p( $log_dir );
 	}
+
+	// Run agent memory migration (SOUL.md to files repository).
+	\DataMachine\Core\FilesRepository\AgentMemoryMigration::maybe_run();
 
 	// Re-schedule any flows with non-manual scheduling
 	datamachine_activate_scheduled_flows();

--- a/inc/Core/FilesRepository/AgentMemoryMigration.php
+++ b/inc/Core/FilesRepository/AgentMemoryMigration.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Agent Memory Migration
+ *
+ * Migrates agent soul from wp_options (PluginSettings) to SOUL.md
+ * in the files repository agent directory. Runs on plugin activation
+ * and version-based upgrade check.
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since 0.13.0
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+use DataMachine\Core\PluginSettings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class AgentMemoryMigration {
+
+	/**
+	 * Option key for tracking migration version.
+	 */
+	private const MIGRATION_VERSION_KEY = 'datamachine_agent_memory_version';
+
+	/**
+	 * Current migration version.
+	 */
+	private const CURRENT_VERSION = '1.0';
+
+	/**
+	 * Section definitions matching the old AgentSoulDirective structure.
+	 */
+	private const SECTIONS = array(
+		'identity' => 'Identity',
+		'voice'    => 'Voice & Tone',
+		'rules'    => 'Rules',
+		'context'  => 'Context',
+	);
+
+	/**
+	 * Default SOUL.md template for fresh installs.
+	 */
+	private const DEFAULT_TEMPLATE = <<<'MD'
+# Agent Soul
+
+## Identity
+You are an AI content assistant.
+
+## Voice & Tone
+Write in a clear, helpful tone.
+
+## Rules
+- Follow the site's content guidelines
+- Ask for clarification when instructions are ambiguous
+
+## Context
+<!-- Add background about your site, audience, brand, or domain expertise here -->
+MD;
+
+	/**
+	 * Run migration if needed.
+	 *
+	 * @return void
+	 */
+	public static function maybe_run(): void {
+		$stored_version = get_option( self::MIGRATION_VERSION_KEY, '' );
+
+		if ( self::CURRENT_VERSION === $stored_version ) {
+			return;
+		}
+
+		self::migrate();
+		update_option( self::MIGRATION_VERSION_KEY, self::CURRENT_VERSION );
+	}
+
+	/**
+	 * Execute the migration.
+	 *
+	 * @return void
+	 */
+	private static function migrate(): void {
+		$directory_manager = new DirectoryManager();
+		$agent_dir         = $directory_manager->get_agent_directory();
+		$soul_path         = "{$agent_dir}/SOUL.md";
+
+		// Already migrated — skip.
+		if ( file_exists( $soul_path ) ) {
+			return;
+		}
+
+		// Ensure agent directory exists with index.php protection.
+		if ( ! $directory_manager->ensure_directory_exists( $agent_dir ) ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'AgentMemoryMigration: Failed to create agent directory.',
+				array( 'path' => $agent_dir )
+			);
+			return;
+		}
+
+		self::write_index_protection( $agent_dir );
+
+		$content = self::build_soul_content();
+
+		$fs = FilesystemHelper::get();
+		if ( ! $fs ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'AgentMemoryMigration: Filesystem not available.'
+			);
+			return;
+		}
+
+		$written = $fs->put_contents( $soul_path, $content, FS_CHMOD_FILE );
+
+		if ( ! $written ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'AgentMemoryMigration: Failed to write SOUL.md.',
+				array( 'path' => $soul_path )
+			);
+			return;
+		}
+
+		// Clean up old settings keys.
+		self::cleanup_old_settings();
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'AgentMemoryMigration: Successfully migrated agent soul to SOUL.md.',
+			array( 'path' => $soul_path )
+		);
+	}
+
+	/**
+	 * Build SOUL.md content from existing settings or defaults.
+	 *
+	 * @return string Markdown content.
+	 */
+	private static function build_soul_content(): string {
+		$soul = PluginSettings::get( 'agent_soul', array() );
+
+		// Try structured soul sections.
+		if ( is_array( $soul ) && ! empty( $soul ) ) {
+			$parts      = array();
+			$has_content = false;
+
+			foreach ( self::SECTIONS as $key => $header ) {
+				$value = trim( $soul[ $key ] ?? '' );
+				if ( '' !== $value ) {
+					$has_content = true;
+					$parts[]     = "## {$header}\n{$value}";
+				}
+			}
+
+			if ( $has_content ) {
+				return "# Agent Soul\n\n" . implode( "\n\n", $parts ) . "\n";
+			}
+		}
+
+		// Fallback: legacy global_system_prompt.
+		$legacy = PluginSettings::get( 'global_system_prompt', '' );
+		if ( ! empty( trim( $legacy ) ) ) {
+			return trim( $legacy ) . "\n";
+		}
+
+		// Fresh install: default template.
+		return self::DEFAULT_TEMPLATE . "\n";
+	}
+
+	/**
+	 * Remove old settings keys after successful migration.
+	 *
+	 * @return void
+	 */
+	private static function cleanup_old_settings(): void {
+		$settings = PluginSettings::all();
+		$changed  = false;
+
+		if ( isset( $settings['agent_soul'] ) ) {
+			unset( $settings['agent_soul'] );
+			$changed = true;
+		}
+
+		if ( isset( $settings['global_system_prompt'] ) ) {
+			unset( $settings['global_system_prompt'] );
+			$changed = true;
+		}
+
+		if ( $changed ) {
+			update_option( 'datamachine_settings', $settings );
+			PluginSettings::clearCache();
+		}
+	}
+
+	/**
+	 * Write index.php protection file to a directory.
+	 *
+	 * @param string $directory Directory path.
+	 * @return void
+	 */
+	private static function write_index_protection( string $directory ): void {
+		$index_path = trailingslashit( $directory ) . 'index.php';
+
+		if ( file_exists( $index_path ) ) {
+			return;
+		}
+
+		$fs = FilesystemHelper::get();
+		if ( $fs ) {
+			$fs->put_contents( $index_path, "<?php\n// Silence is golden.\n", FS_CHMOD_FILE );
+		}
+	}
+}

--- a/inc/Core/FilesRepository/DirectoryManager.php
+++ b/inc/Core/FilesRepository/DirectoryManager.php
@@ -85,6 +85,17 @@ class DirectoryManager {
 	}
 
 	/**
+	 * Get agent directory path
+	 *
+	 * @return string Full path to agent directory
+	 */
+	public function get_agent_directory(): string {
+		$upload_dir = wp_upload_dir();
+		$base       = trailingslashit( $upload_dir['basedir'] ) . self::REPOSITORY_DIR;
+		return "{$base}/agent";
+	}
+
+	/**
 	 * Ensure directory exists
 	 *
 	 * @param string $directory Directory path


### PR DESCRIPTION
## Summary

Moves the Agent Soul from `wp_options` database storage to a `SOUL.md` markdown file in the Files repository. Backend-only — no UI changes.

Closes #279

## Changes

### 1. DirectoryManager — Agent directory
- Added `get_agent_directory()` method returning `{uploads}/datamachine-files/agent`

### 2. AgentSoulDirective — Read from file
- Now reads `SOUL.md` from the agent directory instead of `PluginSettings::get('agent_soul')`
- Returns empty if file doesn't exist (migration handles creation)

### 3. AgentMemoryMigration (new)
- Migrates existing structured soul (identity/voice/rules/context) to markdown
- Falls back to legacy `global_system_prompt` if no structured soul
- Writes default template for fresh installs
- Creates `agent/` directory with `index.php` protection
- Cleans up old settings keys after successful migration
- Runs on plugin activation and `plugins_loaded` (version-gated)

### 4. FileAbilities — Agent scope
- All file abilities (list/get/delete/upload) now accept `scope="agent"` parameter
- New private methods: `listAgentFiles()`, `getAgentFile()`, `deleteAgentFile()`, `uploadToAgent()`
- SOUL.md deletion logs a warning but is allowed

### 5. REST API — Agent files endpoints
- `GET /datamachine/v1/files/agent` — list files
- `GET /datamachine/v1/files/agent/{filename}` — get file content
- `PUT /datamachine/v1/files/agent/{filename}` — write/update (raw markdown body)
- `DELETE /datamachine/v1/files/agent/{filename}` — delete file

## Patterns followed
- WordPress Filesystem API via `FilesystemHelper::get()`
- `sanitize_file_name()` for all filenames
- `DirectoryManager::ensure_directory_exists()` for directory creation
- `index.php` protection in new directories
- Existing `datamachine_log` action for logging