### PR TITLE
feat: Agent admin page — memory file browser and editor

### DIFF
--- a/inc/Core/Admin/Pages/Agent/AgentFilters.php
+++ b/inc/Core/Admin/Pages/Agent/AgentFilters.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Agent Admin Page Component Filter Registration
+ *
+ * @package DataMachine
+ * @subpackage Core\Admin\Pages\Agent
+ * @since 0.28.0
+ */
+
+namespace DataMachine\Core\Admin\Pages\Agent;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register all Agent Admin Page component filters
+ *
+ * @since 0.28.0
+ */
+function datamachine_register_agent_admin_page_filters() {
+
+	add_filter(
+		'datamachine_admin_pages',
+		function ( $pages ) {
+			$pages['agent'] = array(
+				'page_title' => __( 'Agent', 'data-machine' ),
+				'menu_title' => __( 'Agent', 'data-machine' ),
+				'capability' => 'manage_options',
+				'position'   => 20,
+				'templates'  => __DIR__ . '/templates/',
+				'assets'     => array(
+					'css' => array(
+						'wp-components'          => array(
+							'file'  => null,
+							'deps'  => array(),
+							'media' => 'all',
+						),
+						'datamachine-agent-page' => array(
+							'file'  => 'inc/Core/Admin/Pages/Agent/assets/css/agent-page.css',
+							'deps'  => array(),
+							'media' => 'all',
+						),
+					),
+					'js'  => array(
+						'datamachine-agent-react' => array(
+							'file'      => 'inc/Core/Admin/assets/build/agent-react.js',
+							'deps'      => array( 'wp-element', 'wp-components', 'wp-i18n', 'wp-api-fetch', 'wp-dom-ready' ),
+							'in_footer' => true,
+							'localize'  => array(
+								'object' => 'dataMachineAgentConfig',
+								'data'   => array(
+									'restNamespace' => 'datamachine/v1',
+									'restNonce'     => wp_create_nonce( 'wp_rest' ),
+								),
+							),
+						),
+					),
+				),
+			);
+			return $pages;
+		}
+	);
+}
+
+add_action( 'init', __NAMESPACE__ . '\\datamachine_register_agent_admin_page_filters' );

--- a/inc/Core/Admin/Pages/Agent/assets/css/agent-page.css
+++ b/inc/Core/Admin/Pages/Agent/assets/css/agent-page.css
@@ -1,0 +1,299 @@
+/**
+ * Agent Admin Page Styles
+ *
+ * Two-panel layout: file list sidebar + markdown editor.
+ */
+
+/* App Container */
+.datamachine-agent-app {
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 20px 0;
+}
+
+/* Header */
+.datamachine-agent-header {
+	margin-bottom: 20px;
+	padding-bottom: 15px;
+	border-bottom: 1px solid #ddd;
+}
+
+.datamachine-agent-title {
+	margin: 0;
+	font-size: 23px;
+	font-weight: 400;
+	line-height: 1.3;
+}
+
+/* Two-Panel Layout */
+.datamachine-agent-layout {
+	display: flex;
+	gap: 0;
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+	min-height: 600px;
+}
+
+/* File List Sidebar */
+.datamachine-agent-file-list {
+	width: 260px;
+	min-width: 260px;
+	border-right: 1px solid #c3c4c7;
+	display: flex;
+	flex-direction: column;
+}
+
+.datamachine-agent-file-list-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 12px 15px;
+	border-bottom: 1px solid #e0e0e0;
+	background: #f6f7f7;
+}
+
+.datamachine-agent-file-list-header h3 {
+	margin: 0;
+	font-size: 13px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: #1e1e1e;
+}
+
+.datamachine-agent-file-list-loading,
+.datamachine-agent-file-list-error,
+.datamachine-agent-file-list-empty {
+	padding: 20px 15px;
+	text-align: center;
+	color: #757575;
+	font-size: 13px;
+}
+
+.datamachine-agent-file-list-error {
+	color: #d63638;
+}
+
+/* File Items */
+.datamachine-agent-file-items {
+	flex: 1;
+	overflow-y: auto;
+}
+
+.datamachine-agent-file-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 10px 15px;
+	cursor: pointer;
+	border-bottom: 1px solid #f0f0f0;
+	transition: background-color 0.1s;
+}
+
+.datamachine-agent-file-item:hover {
+	background: #f6f7f7;
+}
+
+.datamachine-agent-file-item.is-selected {
+	background: #e7f0ff;
+	border-left: 3px solid #3858e9;
+	padding-left: 12px;
+}
+
+.datamachine-agent-file-item.is-soul .datamachine-agent-file-item-name {
+	font-weight: 600;
+}
+
+.datamachine-agent-file-item-info {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+	flex: 1;
+}
+
+.datamachine-agent-file-item-name {
+	font-size: 13px;
+	color: #1e1e1e;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.datamachine-agent-file-soul-badge {
+	margin-right: 4px;
+}
+
+.datamachine-agent-file-item-meta {
+	font-size: 11px;
+	color: #757575;
+}
+
+.datamachine-agent-file-item-delete {
+	background: none;
+	border: none;
+	cursor: pointer;
+	padding: 2px 4px;
+	font-size: 12px;
+	opacity: 0;
+	transition: opacity 0.15s;
+	flex-shrink: 0;
+}
+
+.datamachine-agent-file-item:hover .datamachine-agent-file-item-delete {
+	opacity: 0.6;
+}
+
+.datamachine-agent-file-item-delete:hover {
+	opacity: 1 !important;
+}
+
+/* Add New File */
+.datamachine-agent-file-add {
+	padding: 10px 15px;
+	border-bottom: 1px solid #e0e0e0;
+	background: #fafafa;
+}
+
+.datamachine-agent-file-add input {
+	width: 100%;
+	padding: 6px 8px;
+	font-size: 13px;
+	border: 1px solid #c3c4c7;
+	border-radius: 3px;
+	margin-bottom: 8px;
+}
+
+.datamachine-agent-file-add-actions {
+	display: flex;
+	gap: 6px;
+}
+
+.datamachine-agent-file-add-error {
+	color: #d63638;
+	font-size: 12px;
+	margin-top: 6px;
+}
+
+/* Delete Confirmation */
+.datamachine-agent-delete-confirm {
+	padding: 12px 15px;
+	background: #fcf0f1;
+	border-top: 1px solid #d63638;
+}
+
+.datamachine-agent-delete-confirm-inner p {
+	margin: 0 0 10px;
+	font-size: 13px;
+	color: #1e1e1e;
+}
+
+.datamachine-agent-delete-confirm-actions {
+	display: flex;
+	gap: 6px;
+}
+
+/* Editor Panel */
+.datamachine-agent-editor-panel {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.datamachine-agent-editor {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+}
+
+.datamachine-agent-editor-header {
+	padding: 12px 20px;
+	border-bottom: 1px solid #e0e0e0;
+	background: #f6f7f7;
+}
+
+.datamachine-agent-editor-header h3 {
+	margin: 0;
+	font-size: 14px;
+	font-weight: 500;
+	color: #1e1e1e;
+	font-family: 'SF Mono', Monaco, Menlo, 'Ubuntu Mono', Consolas, monospace;
+}
+
+.datamachine-agent-editor-textarea {
+	flex: 1;
+	width: 100%;
+	min-height: 500px;
+	padding: 15px 20px;
+	font-family: 'SF Mono', Monaco, Menlo, 'Ubuntu Mono', Consolas, monospace;
+	font-size: 13px;
+	line-height: 1.6;
+	border: none;
+	outline: none;
+	resize: none;
+	tab-size: 4;
+	box-sizing: border-box;
+}
+
+.datamachine-agent-editor-textarea:focus {
+	box-shadow: none;
+	outline: none;
+}
+
+.datamachine-agent-editor .datamachine-settings-submit {
+	padding: 12px 20px;
+	border-top: 1px solid #e0e0e0;
+	background: #f6f7f7;
+}
+
+.datamachine-agent-editor-loading,
+.datamachine-agent-editor-error {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	padding: 40px;
+	color: #757575;
+	font-size: 14px;
+}
+
+.datamachine-agent-editor-error {
+	color: #d63638;
+}
+
+/* Empty State */
+.datamachine-agent-empty-state {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: 1;
+	padding: 40px;
+}
+
+.datamachine-agent-empty-state p {
+	color: #757575;
+	font-size: 14px;
+	text-align: center;
+}
+
+/* Responsive */
+@media screen and (max-width: 782px) {
+	.datamachine-agent-layout {
+		flex-direction: column;
+		min-height: auto;
+	}
+
+	.datamachine-agent-file-list {
+		width: 100%;
+		min-width: 100%;
+		border-right: none;
+		border-bottom: 1px solid #c3c4c7;
+		max-height: 300px;
+	}
+
+	.datamachine-agent-editor-textarea {
+		min-height: 300px;
+	}
+}

--- a/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
@@ -1,0 +1,48 @@
+/**
+ * AgentApp Component
+ *
+ * Root container for the Agent admin page.
+ * Two-panel layout: file list sidebar + editor.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import AgentFileList from './components/AgentFileList';
+import AgentFileEditor from './components/AgentFileEditor';
+import AgentEmptyState from './components/AgentEmptyState';
+import { useAgentFiles } from './queries/agentFiles';
+
+const AgentApp = () => {
+	const [ selectedFile, setSelectedFile ] = useState( null );
+	const { data: files } = useAgentFiles();
+	const hasFiles = files && files.length > 0;
+
+	return (
+		<div className="datamachine-agent-app">
+			<div className="datamachine-agent-header">
+				<h1 className="datamachine-agent-title">Agent</h1>
+			</div>
+			<div className="datamachine-agent-layout">
+				<AgentFileList
+					selectedFile={ selectedFile }
+					onSelectFile={ setSelectedFile }
+				/>
+				<div className="datamachine-agent-editor-panel">
+					{ selectedFile ? (
+						<AgentFileEditor filename={ selectedFile } />
+					) : (
+						<AgentEmptyState hasFiles={ hasFiles } />
+					) }
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default AgentApp;

--- a/inc/Core/Admin/Pages/Agent/assets/react/api/agentFiles.js
+++ b/inc/Core/Admin/Pages/Agent/assets/react/api/agentFiles.js
@@ -1,0 +1,45 @@
+/**
+ * Agent Files API
+ *
+ * REST client functions for agent memory file operations.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+const getConfig = () => {
+	const config = window.dataMachineAgentConfig || {};
+	return { restNamespace: config.restNamespace || 'datamachine/v1' };
+};
+
+export const listAgentFiles = async () => {
+	const config = getConfig();
+	return apiFetch( { path: `/${ config.restNamespace }/files/agent` } );
+};
+
+export const getAgentFile = async ( filename ) => {
+	const config = getConfig();
+	return apiFetch( {
+		path: `/${ config.restNamespace }/files/agent/${ filename }`,
+	} );
+};
+
+export const putAgentFile = async ( filename, content ) => {
+	const config = getConfig();
+	return apiFetch( {
+		path: `/${ config.restNamespace }/files/agent/${ filename }`,
+		method: 'PUT',
+		body: content,
+		headers: { 'Content-Type': 'text/plain' },
+	} );
+};
+
+export const deleteAgentFile = async ( filename ) => {
+	const config = getConfig();
+	return apiFetch( {
+		path: `/${ config.restNamespace }/files/agent/${ filename }`,
+		method: 'DELETE',
+	} );
+};

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentEmptyState.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentEmptyState.jsx
@@ -1,0 +1,19 @@
+/**
+ * AgentEmptyState Component
+ *
+ * Displayed when no file is selected or when no files exist.
+ */
+
+const AgentEmptyState = ( { hasFiles } ) => {
+	return (
+		<div className="datamachine-agent-empty-state">
+			<p>
+				{ hasFiles
+					? 'Select a file to edit, or create a new one.'
+					: "No memory files yet. Click 'Add New' to create your first file." }
+			</p>
+		</div>
+	);
+};
+
+export default AgentEmptyState;

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileEditor.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileEditor.jsx
@@ -1,0 +1,94 @@
+/**
+ * AgentFileEditor Component
+ *
+ * Markdown editor panel for agent memory files with save bar.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import SettingsSaveBar, {
+	useSaveStatus,
+} from '@shared/components/SettingsSaveBar';
+import { useAgentFile, useSaveAgentFile } from '../queries/agentFiles';
+
+const AgentFileEditor = ( { filename } ) => {
+	const { data: file, isLoading, error } = useAgentFile( filename );
+	const saveMutation = useSaveAgentFile();
+	const [ content, setContent ] = useState( '' );
+
+	// Sync content when file data loads or filename changes.
+	useEffect( () => {
+		if ( file?.content !== undefined ) {
+			setContent( file.content );
+		}
+	}, [ file ] );
+
+	const { saveStatus, hasChanges, markChanged, handleSave, setHasChanges } =
+		useSaveStatus( {
+			onSave: async () => {
+				await saveMutation.mutateAsync( { filename, content } );
+			},
+		} );
+
+	const handleContentChange = useCallback(
+		( e ) => {
+			setContent( e.target.value );
+			markChanged();
+		},
+		[ markChanged ]
+	);
+
+	// Reset dirty state when switching files.
+	useEffect( () => {
+		setHasChanges( false );
+	}, [ filename, setHasChanges ] );
+
+	if ( isLoading ) {
+		return (
+			<div className="datamachine-agent-editor">
+				<div className="datamachine-agent-editor-loading">
+					<Spinner />
+					<span>Loading file...</span>
+				</div>
+			</div>
+		);
+	}
+
+	if ( error ) {
+		return (
+			<div className="datamachine-agent-editor">
+				<div className="datamachine-agent-editor-error">
+					Failed to load file: { error.message || 'Unknown error' }
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="datamachine-agent-editor">
+			<div className="datamachine-agent-editor-header">
+				<h3>{ filename }</h3>
+			</div>
+			<textarea
+				className="datamachine-agent-editor-textarea code"
+				value={ content }
+				onChange={ handleContentChange }
+				spellCheck={ false }
+			/>
+			<SettingsSaveBar
+				hasChanges={ hasChanges }
+				saveStatus={ saveStatus }
+				onSave={ handleSave }
+			/>
+		</div>
+	);
+};
+
+export default AgentFileEditor;

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
@@ -1,0 +1,355 @@
+/**
+ * AgentFileList Component
+ *
+ * Sidebar listing agent memory files with add/delete controls.
+ * SOUL.md is pinned to top and cannot be deleted from the UI.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useCallback } from '@wordpress/element';
+import { Button, Spinner } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { useAgentFiles, useSaveAgentFile, useDeleteAgentFile } from '../queries/agentFiles';
+
+const SOUL_FILE = 'SOUL.md';
+
+/**
+ * Format bytes to human-readable size.
+ *
+ * @param {number} bytes File size in bytes.
+ * @return {string} Formatted size string.
+ */
+const formatSize = ( bytes ) => {
+	if ( bytes < 1024 ) {
+		return `${ bytes } B`;
+	}
+	const kb = bytes / 1024;
+	if ( kb < 1024 ) {
+		return `${ kb.toFixed( 1 ) } KB`;
+	}
+	return `${ ( kb / 1024 ).toFixed( 1 ) } MB`;
+};
+
+/**
+ * Format ISO date to human-readable relative/short date.
+ *
+ * @param {string} dateStr ISO date string.
+ * @return {string} Formatted date.
+ */
+const formatDate = ( dateStr ) => {
+	if ( ! dateStr ) {
+		return '';
+	}
+	const date = new Date( dateStr );
+	const now = new Date();
+	const diffMs = now - date;
+	const diffMins = Math.floor( diffMs / 60000 );
+
+	if ( diffMins < 1 ) {
+		return 'just now';
+	}
+	if ( diffMins < 60 ) {
+		return `${ diffMins }m ago`;
+	}
+	const diffHours = Math.floor( diffMins / 60 );
+	if ( diffHours < 24 ) {
+		return `${ diffHours }h ago`;
+	}
+	const diffDays = Math.floor( diffHours / 24 );
+	if ( diffDays < 7 ) {
+		return `${ diffDays }d ago`;
+	}
+	return date.toLocaleDateString();
+};
+
+/**
+ * Validate a filename for creation.
+ *
+ * @param {string} name Raw filename input.
+ * @return {string|null} Error message or null if valid.
+ */
+const validateFilename = ( name ) => {
+	if ( ! name || ! name.trim() ) {
+		return 'Filename is required.';
+	}
+	if ( /[/\\:*?"<>|]/.test( name ) ) {
+		return 'Filename contains invalid characters.';
+	}
+	if ( name.includes( '..' ) ) {
+		return 'Invalid filename.';
+	}
+	return null;
+};
+
+const AgentFileList = ( { selectedFile, onSelectFile } ) => {
+	const { data: files, isLoading, error } = useAgentFiles();
+	const saveMutation = useSaveAgentFile();
+	const deleteMutation = useDeleteAgentFile();
+
+	const [ isAdding, setIsAdding ] = useState( false );
+	const [ newFilename, setNewFilename ] = useState( '' );
+	const [ addError, setAddError ] = useState( null );
+	const [ deleteConfirm, setDeleteConfirm ] = useState( null );
+
+	const handleAddNew = useCallback( () => {
+		setIsAdding( true );
+		setNewFilename( '' );
+		setAddError( null );
+	}, [] );
+
+	const handleCancelAdd = useCallback( () => {
+		setIsAdding( false );
+		setNewFilename( '' );
+		setAddError( null );
+	}, [] );
+
+	const handleCreateFile = useCallback( async () => {
+		let name = newFilename.trim();
+		const validationError = validateFilename( name );
+		if ( validationError ) {
+			setAddError( validationError );
+			return;
+		}
+		if ( ! name.endsWith( '.md' ) ) {
+			name += '.md';
+		}
+
+		// Check for duplicates.
+		if ( files?.some( ( f ) => f.filename === name ) ) {
+			setAddError( 'A file with this name already exists.' );
+			return;
+		}
+
+		try {
+			await saveMutation.mutateAsync( { filename: name, content: '' } );
+			setIsAdding( false );
+			setNewFilename( '' );
+			setAddError( null );
+			onSelectFile( name );
+		} catch {
+			setAddError( 'Failed to create file.' );
+		}
+	}, [ newFilename, files, saveMutation, onSelectFile ] );
+
+	const handleKeyDown = useCallback(
+		( e ) => {
+			if ( e.key === 'Enter' ) {
+				handleCreateFile();
+			} else if ( e.key === 'Escape' ) {
+				handleCancelAdd();
+			}
+		},
+		[ handleCreateFile, handleCancelAdd ]
+	);
+
+	const handleDelete = useCallback(
+		async ( filename ) => {
+			try {
+				await deleteMutation.mutateAsync( filename );
+				setDeleteConfirm( null );
+				if ( selectedFile === filename ) {
+					onSelectFile( null );
+				}
+			} catch {
+				// Mutation error handled by TanStack Query.
+			}
+		},
+		[ deleteMutation, selectedFile, onSelectFile ]
+	);
+
+	// Sort files: SOUL.md first, then alphabetical.
+	const sortedFiles = files
+		? [ ...files ].sort( ( a, b ) => {
+				if ( a.filename === SOUL_FILE ) {
+					return -1;
+				}
+				if ( b.filename === SOUL_FILE ) {
+					return 1;
+				}
+				return a.filename.localeCompare( b.filename );
+		  } )
+		: [];
+
+	if ( isLoading ) {
+		return (
+			<div className="datamachine-agent-file-list">
+				<div className="datamachine-agent-file-list-header">
+					<h3>Memory Files</h3>
+				</div>
+				<div className="datamachine-agent-file-list-loading">
+					<Spinner />
+				</div>
+			</div>
+		);
+	}
+
+	if ( error ) {
+		return (
+			<div className="datamachine-agent-file-list">
+				<div className="datamachine-agent-file-list-header">
+					<h3>Memory Files</h3>
+				</div>
+				<div className="datamachine-agent-file-list-error">
+					Failed to load files.
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="datamachine-agent-file-list">
+			<div className="datamachine-agent-file-list-header">
+				<h3>Memory Files</h3>
+				<Button
+					variant="secondary"
+					size="small"
+					onClick={ handleAddNew }
+					disabled={ isAdding }
+				>
+					Add New
+				</Button>
+			</div>
+
+			{ isAdding && (
+				<div className="datamachine-agent-file-add">
+					<input
+						type="text"
+						placeholder="filename.md"
+						value={ newFilename }
+						onChange={ ( e ) => {
+							setNewFilename( e.target.value );
+							setAddError( null );
+						} }
+						onKeyDown={ handleKeyDown }
+						autoFocus
+					/>
+					<div className="datamachine-agent-file-add-actions">
+						<Button
+							variant="primary"
+							size="small"
+							onClick={ handleCreateFile }
+							disabled={ saveMutation.isPending }
+						>
+							{ saveMutation.isPending
+								? 'Creating...'
+								: 'Create' }
+						</Button>
+						<Button
+							variant="tertiary"
+							size="small"
+							onClick={ handleCancelAdd }
+						>
+							Cancel
+						</Button>
+					</div>
+					{ addError && (
+						<div className="datamachine-agent-file-add-error">
+							{ addError }
+						</div>
+					) }
+				</div>
+			) }
+
+			<div className="datamachine-agent-file-items">
+				{ sortedFiles.map( ( file ) => {
+					const isSoul = file.filename === SOUL_FILE;
+					const isSelected = selectedFile === file.filename;
+
+					return (
+						<div
+							key={ file.filename }
+							className={ `datamachine-agent-file-item${
+								isSelected ? ' is-selected' : ''
+							}${ isSoul ? ' is-soul' : '' }` }
+							onClick={ () => onSelectFile( file.filename ) }
+							role="button"
+							tabIndex={ 0 }
+							onKeyDown={ ( e ) => {
+								if ( e.key === 'Enter' || e.key === ' ' ) {
+									onSelectFile( file.filename );
+								}
+							} }
+						>
+							<div className="datamachine-agent-file-item-info">
+								<span className="datamachine-agent-file-item-name">
+									{ isSoul && (
+										<span
+											className="datamachine-agent-file-soul-badge"
+											title="Agent identity"
+										>
+											🧠
+										</span>
+									) }
+									{ file.filename }
+								</span>
+								<span className="datamachine-agent-file-item-meta">
+									{ formatSize( file.size ) }
+									{ file.modified &&
+										` · ${ formatDate(
+											file.modified
+										) }` }
+								</span>
+							</div>
+							{ ! isSoul && (
+								<button
+									className="datamachine-agent-file-item-delete"
+									title={ `Delete ${ file.filename }` }
+									onClick={ ( e ) => {
+										e.stopPropagation();
+										setDeleteConfirm( file.filename );
+									} }
+								>
+									🗑
+								</button>
+							) }
+						</div>
+					);
+				} ) }
+
+				{ sortedFiles.length === 0 && ! isAdding && (
+					<div className="datamachine-agent-file-list-empty">
+						No files yet.
+					</div>
+				) }
+			</div>
+
+			{ deleteConfirm && (
+				<div className="datamachine-agent-delete-confirm">
+					<div className="datamachine-agent-delete-confirm-inner">
+						<p>
+							Delete <strong>{ deleteConfirm }</strong>? This
+							cannot be undone.
+						</p>
+						<div className="datamachine-agent-delete-confirm-actions">
+							<Button
+								variant="primary"
+								isDestructive
+								size="small"
+								onClick={ () => handleDelete( deleteConfirm ) }
+								disabled={ deleteMutation.isPending }
+							>
+								{ deleteMutation.isPending
+									? 'Deleting...'
+									: 'Delete' }
+							</Button>
+							<Button
+								variant="tertiary"
+								size="small"
+								onClick={ () => setDeleteConfirm( null ) }
+							>
+								Cancel
+							</Button>
+						</div>
+					</div>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default AgentFileList;

--- a/inc/Core/Admin/Pages/Agent/assets/react/index.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/index.jsx
@@ -1,0 +1,46 @@
+/**
+ * Data Machine Agent React Entry Point
+ *
+ * Initializes React application for agent admin interface.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { render } from '@wordpress/element';
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * External dependencies
+ */
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@shared/lib/queryClient';
+
+/**
+ * Internal dependencies
+ */
+import AgentApp from './AgentApp';
+
+/**
+ * Initialize React app when DOM is ready
+ */
+domReady( () => {
+	const rootElement = document.getElementById( 'datamachine-agent-root' );
+
+	if ( ! rootElement ) {
+		console.error( 'Data Machine Agent: React root element not found' );
+		return;
+	}
+
+	if ( ! window.dataMachineAgentConfig ) {
+		console.error( 'Data Machine Agent: Configuration not found' );
+		return;
+	}
+
+	render(
+		<QueryClientProvider client={ queryClient }>
+			<AgentApp />
+		</QueryClientProvider>,
+		rootElement
+	);
+} );

--- a/inc/Core/Admin/Pages/Agent/assets/react/queries/agentFiles.js
+++ b/inc/Core/Admin/Pages/Agent/assets/react/queries/agentFiles.js
@@ -1,0 +1,57 @@
+/**
+ * Agent Files TanStack Query Hooks
+ *
+ * Query and mutation hooks for agent memory file operations.
+ */
+
+/**
+ * External dependencies
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+/**
+ * Internal dependencies
+ */
+import * as api from '../api/agentFiles';
+
+const KEYS = {
+	list: [ 'agent-files' ],
+	detail: ( filename ) => [ 'agent-files', filename ],
+};
+
+export const useAgentFiles = () =>
+	useQuery( {
+		queryKey: KEYS.list,
+		queryFn: api.listAgentFiles,
+	} );
+
+export const useAgentFile = ( filename ) =>
+	useQuery( {
+		queryKey: KEYS.detail( filename ),
+		queryFn: () => api.getAgentFile( filename ),
+		enabled: !! filename,
+	} );
+
+export const useSaveAgentFile = () => {
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( { filename, content } ) =>
+			api.putAgentFile( filename, content ),
+		onSuccess: ( _data, { filename } ) => {
+			queryClient.invalidateQueries( { queryKey: KEYS.list } );
+			queryClient.invalidateQueries( {
+				queryKey: KEYS.detail( filename ),
+			} );
+		},
+	} );
+};
+
+export const useDeleteAgentFile = () => {
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( filename ) => api.deleteAgentFile( filename ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: KEYS.list } );
+		},
+	} );
+};

--- a/inc/Core/Admin/Pages/Agent/templates/page/agent-page.php
+++ b/inc/Core/Admin/Pages/Agent/templates/page/agent-page.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Agent Admin Page Template
+ *
+ * Minimal template for React mount point.
+ *
+ * @package DataMachine\Core\Admin\Pages\Agent
+ * @since 0.28.0
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+?>
+
+<div class="wrap">
+	<div id="datamachine-agent-root"></div>
+</div>

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -41,6 +41,7 @@ require_once __DIR__ . '/Core/Admin/Settings/SettingsFilters.php';
 require_once __DIR__ . '/Core/Admin/Modal/ModalFilters.php';
 require_once __DIR__ . '/Core/Admin/AdminRootFilters.php';
 require_once __DIR__ . '/Core/Admin/Pages/Pipelines/PipelinesFilters.php';
+require_once __DIR__ . '/Core/Admin/Pages/Agent/AgentFilters.php';
 require_once __DIR__ . '/Core/Admin/Pages/Logs/LogsFilters.php';
 require_once __DIR__ . '/Core/Admin/Pages/Jobs/JobsFilters.php';
 require_once __DIR__ . '/Api/Providers.php';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
 			'./inc/Core/Admin/Pages/Pipelines/assets/react/index.jsx',
 		'logs-react': './inc/Core/Admin/Pages/Logs/assets/react/index.jsx',
 		'settings-react': './inc/Core/Admin/Settings/assets/react/index.jsx',
+		'agent-react': './inc/Core/Admin/Pages/Agent/assets/react/index.jsx',
 		'jobs-react': './inc/Core/Admin/Pages/Jobs/assets/react/index.jsx',
 	},
 	output: {


### PR DESCRIPTION
## Phase 2: Agent Admin Page — File Browser & Editor

Closes #279

### What this does
Adds a new top-level **Agent** admin page under the Data Machine menu with a React-powered two-panel UI:

- **Left panel:** File list sidebar showing all agent memory files from `agent/` directory
- **Right panel:** Monospace markdown editor with save bar (dirty tracking, status indicators)

### Features
- List, create, edit, and delete agent memory files via the Phase 1 REST API
- SOUL.md pinned to top with 🧠 badge — **not deletable from UI** (defines agent identity)
- Add New flow with inline filename input, auto-appends `.md`, validates input
- Delete confirmation dialog for non-SOUL files
- TanStack Query for data fetching with automatic cache invalidation
- Responsive layout (stacks vertically on mobile)
- Follows existing page patterns exactly (LogsFilters, webpack entry, shared components)

### Files added
- `AgentFilters.php` — page registration (position 20, before Logs)
- `agent-page.php` — React mount template
- `agent-page.css` — two-panel layout styles
- React components: `AgentApp`, `AgentFileList`, `AgentFileEditor`, `AgentEmptyState`
- API layer + TanStack Query hooks

### Files modified
- `webpack.config.js` — added `agent-react` entry point
- `inc/bootstrap.php` — added AgentFilters require

### What this does NOT do (Phase 3)
- Does not migrate settings from the Settings page
- Does not modify existing settings UI