### PR TITLE
feat: Pipeline memory file references — agent memory files in pipeline context

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/MemoryFilesModal.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/MemoryFilesModal.jsx
@@ -1,0 +1,37 @@
+/**
+ * Memory Files Modal Component
+ *
+ * Modal for selecting agent memory files for pipeline AI context.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import PipelineMemoryFiles from '../pipelines/PipelineMemoryFiles';
+
+/**
+ * Memory Files Modal Component
+ *
+ * @param {Object}   props            - Component props
+ * @param {Function} props.onClose    - Close handler
+ * @param {number}   props.pipelineId - Pipeline ID
+ * @return {React.ReactElement} Memory files modal
+ */
+export default function MemoryFilesModal( { onClose, pipelineId } ) {
+	return (
+		<Modal
+			title={ __( 'Pipeline Memory Files', 'data-machine' ) }
+			onRequestClose={ onClose }
+			className="datamachine-memory-files-modal"
+		>
+			<div className="datamachine-modal-content">
+				<PipelineMemoryFiles pipelineId={ pipelineId } />
+			</div>
+		</Modal>
+	);
+}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/index.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/index.js
@@ -13,3 +13,4 @@ export { default as HandlerSettingsModal } from './HandlerSettingsModal';
 export { default as ImportExportModal } from './ImportExportModal';
 export { default as OAuthAuthenticationModal } from './OAuthAuthenticationModal';
 export { default as ContextFilesModal } from './ContextFilesModal';
+export { default as MemoryFilesModal } from './MemoryFilesModal';

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineCard.jsx
@@ -127,6 +127,15 @@ export default function PipelineCard( {
 		} );
 	}, [ pipeline.pipeline_id, openModal ] );
 
+	/**
+	 * Handle memory files modal open
+	 */
+	const handleOpenMemoryFiles = useCallback( () => {
+		openModal( MODAL_TYPES.MEMORY_FILES, {
+			pipelineId: pipeline.pipeline_id,
+		} );
+	}, [ pipeline.pipeline_id, openModal ] );
+
 	return (
 		<Card className="datamachine-pipeline-card" size="large">
 			<CardBody>
@@ -136,6 +145,7 @@ export default function PipelineCard( {
 					onNameChange={ handleNameChange }
 					onDelete={ handleDelete }
 					onOpenContextFiles={ handleOpenContextFiles }
+					onOpenMemoryFiles={ handleOpenMemoryFiles }
 				/>
 
 				<CardDivider />

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineHeader.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineHeader.jsx
@@ -26,6 +26,7 @@ import { AUTO_SAVE_DELAY } from '../../utils/constants';
  * @param {Function} props.onNameChange       - Called after successful save
  * @param {Function} props.onDelete           - Called after successful deletion
  * @param {Function} props.onOpenContextFiles - Called when context files button clicked
+ * @param {Function} props.onOpenMemoryFiles  - Called when memory files button clicked
  * @return {React.ReactElement} Pipeline header
  */
 export default function PipelineHeader( {
@@ -34,6 +35,7 @@ export default function PipelineHeader( {
 	onNameChange,
 	onDelete,
 	onOpenContextFiles,
+	onOpenMemoryFiles,
 } ) {
 	const [ localName, setLocalName ] = useState( pipelineName );
 	const saveTimeout = useRef( null );
@@ -137,6 +139,12 @@ export default function PipelineHeader( {
 	return (
 		<div className="datamachine-pipeline-header">
 			<div className="datamachine-header--absolute-top-right datamachine-header--flex-start">
+				<Button
+					variant="secondary"
+					onClick={ onOpenMemoryFiles }
+					icon="database"
+					label={ __( 'Memory Files', 'data-machine' ) }
+				/>
 				<Button
 					variant="secondary"
 					onClick={ onOpenContextFiles }

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineMemoryFiles.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineMemoryFiles.jsx
@@ -1,0 +1,186 @@
+/**
+ * Pipeline Memory Files Component
+ *
+ * Allows selecting agent memory files to include in pipeline AI context.
+ * SOUL.md is excluded (always injected separately at Priority 20).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { CheckboxControl, Button, Notice, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import {
+	useAgentFiles,
+	usePipelineMemoryFiles,
+	useUpdatePipelineMemoryFiles,
+} from '../../queries/pipelines';
+
+/**
+ * Files to exclude from the memory files picker (always injected separately).
+ */
+const EXCLUDED_FILES = [ 'SOUL.md' ];
+
+/**
+ * Pipeline Memory Files Component
+ *
+ * @param {Object} props            - Component props
+ * @param {number} props.pipelineId - Pipeline ID
+ * @return {React.ReactElement} Memory files selector
+ */
+export default function PipelineMemoryFiles( { pipelineId } ) {
+	const { data: agentFiles = [], isLoading: loadingAgent } =
+		useAgentFiles();
+	const { data: selectedFiles = [], isLoading: loadingSelected } =
+		usePipelineMemoryFiles( pipelineId );
+	const updateMutation = useUpdatePipelineMemoryFiles( pipelineId );
+
+	const [ localSelected, setLocalSelected ] = useState( [] );
+	const [ success, setSuccess ] = useState( null );
+
+	// Sync local state when server data loads.
+	useEffect( () => {
+		setLocalSelected( selectedFiles );
+	}, [ selectedFiles ] );
+
+	const loading = loadingAgent || loadingSelected;
+
+	// Filter out SOUL.md and non-text files.
+	const availableFiles = agentFiles
+		.map( ( f ) => ( typeof f === 'string' ? f : f.name || f.filename ) )
+		.filter( ( name ) => name && ! EXCLUDED_FILES.includes( name ) );
+
+	const handleToggle = ( filename, checked ) => {
+		setLocalSelected( ( prev ) =>
+			checked
+				? [ ...prev, filename ]
+				: prev.filter( ( f ) => f !== filename )
+		);
+	};
+
+	const handleSave = async () => {
+		setSuccess( null );
+		try {
+			await updateMutation.mutateAsync( localSelected );
+			setSuccess(
+				__( 'Memory files updated successfully!', 'data-machine' )
+			);
+		} catch ( err ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Memory files save error:', err );
+		}
+	};
+
+	const isDirty =
+		JSON.stringify( [ ...localSelected ].sort() ) !==
+		JSON.stringify( [ ...selectedFiles ].sort() );
+
+	return (
+		<div className="datamachine-pipeline-memory-files">
+			<h3
+				style={ {
+					margin: '0 0 8px 0',
+					fontSize: '16px',
+					fontWeight: '600',
+				} }
+			>
+				{ __( 'Agent Memory Files', 'data-machine' ) }
+			</h3>
+			<p
+				style={ {
+					margin: '0 0 16px 0',
+					color: '#757575',
+					fontSize: '13px',
+				} }
+			>
+				{ __(
+					'Select agent memory files to include as AI context for this pipeline.',
+					'data-machine'
+				) }
+			</p>
+
+			{ success && (
+				<Notice
+					status="success"
+					isDismissible
+					onRemove={ () => setSuccess( null ) }
+				>
+					<p>{ success }</p>
+				</Notice>
+			) }
+
+			{ updateMutation.isError && (
+				<Notice status="error" isDismissible={ false }>
+					<p>
+						{ __(
+							'Failed to save memory files.',
+							'data-machine'
+						) }
+					</p>
+				</Notice>
+			) }
+
+			{ loading ? (
+				<div
+					style={ {
+						textAlign: 'center',
+						padding: '20px',
+						color: '#757575',
+					} }
+				>
+					<Spinner />
+				</div>
+			) : availableFiles.length === 0 ? (
+				<p
+					style={ {
+						color: '#757575',
+						fontStyle: 'italic',
+						padding: '12px 0',
+					} }
+				>
+					{ __(
+						'No agent memory files available. Upload files to the agent directory first.',
+						'data-machine'
+					) }
+				</p>
+			) : (
+				<>
+					<div
+						style={ {
+							display: 'flex',
+							flexDirection: 'column',
+							gap: '8px',
+							marginBottom: '16px',
+						} }
+					>
+						{ availableFiles.map( ( filename ) => (
+							<CheckboxControl
+								key={ filename }
+								label={ filename }
+								checked={ localSelected.includes( filename ) }
+								onChange={ ( checked ) =>
+									handleToggle( filename, checked )
+								}
+							/>
+						) ) }
+					</div>
+
+					<Button
+						variant="primary"
+						onClick={ handleSave }
+						disabled={ ! isDirty || updateMutation.isPending }
+						isBusy={ updateMutation.isPending }
+					>
+						{ updateMutation.isPending
+							? __( 'Saving…', 'data-machine' )
+							: __( 'Save Memory Files', 'data-machine' ) }
+					</Button>
+				</>
+			) }
+		</div>
+	);
+}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalSwitch.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalSwitch.jsx
@@ -21,6 +21,7 @@ import {
 	HandlerSettingsModal,
 	OAuthAuthenticationModal,
 	ContextFilesModal,
+	MemoryFilesModal,
 } from '../modals';
 
 export default function ModalSwitch( { activeModal, baseProps } ) {
@@ -73,6 +74,9 @@ export default function ModalSwitch( { activeModal, baseProps } ) {
 
 		case MODAL_TYPES.CONTEXT_FILES:
 			return <ContextFilesModal { ...baseProps } />;
+
+		case MODAL_TYPES.MEMORY_FILES:
+			return <MemoryFilesModal { ...baseProps } />;
 
 		default:
 			console.warn( `Unknown modal type: ${ activeModal }` );

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
@@ -23,6 +23,9 @@ import {
 	fetchContextFiles,
 	uploadContextFile,
 	deleteContextFile,
+	fetchPipelineMemoryFiles,
+	updatePipelineMemoryFiles,
+	fetchAgentFiles,
 } from '../utils/api';
 import { isSameId } from '../utils/ids';
 
@@ -260,6 +263,38 @@ export const useDeleteContextFile = () => {
 		mutationFn: deleteContextFile,
 		onSuccess: () => {
 			queryClient.invalidateQueries( { queryKey: [ 'context-files' ] } );
+		},
+	} );
+};
+
+export const useAgentFiles = () =>
+	useQuery( {
+		queryKey: [ 'agent-files' ],
+		queryFn: async () => {
+			const response = await fetchAgentFiles();
+			return response.success ? response.data : [];
+		},
+	} );
+
+export const usePipelineMemoryFiles = ( pipelineId ) =>
+	useQuery( {
+		queryKey: [ 'pipeline-memory-files', pipelineId ],
+		queryFn: async () => {
+			const response = await fetchPipelineMemoryFiles( pipelineId );
+			return response.success ? response.data : [];
+		},
+		enabled: !! pipelineId,
+	} );
+
+export const useUpdatePipelineMemoryFiles = ( pipelineId ) => {
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( filenames ) =>
+			updatePipelineMemoryFiles( pipelineId, filenames ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( {
+				queryKey: [ 'pipeline-memory-files', pipelineId ],
+			} );
 		},
 	} );
 };

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -425,6 +425,42 @@ export const deleteContextFile = async ( filename ) => {
 };
 
 /**
+ * Memory Files Operations
+ */
+
+/**
+ * Fetch memory files for a pipeline
+ *
+ * @param {number} pipelineId - Pipeline ID
+ * @return {Promise<Object>} Array of memory filenames
+ */
+export const fetchPipelineMemoryFiles = async ( pipelineId ) => {
+	return await client.get( `/pipelines/${ pipelineId }/memory-files` );
+};
+
+/**
+ * Update memory files for a pipeline
+ *
+ * @param {number}        pipelineId  - Pipeline ID
+ * @param {Array<string>} memoryFiles - Array of filenames
+ * @return {Promise<Object>} Update confirmation
+ */
+export const updatePipelineMemoryFiles = async ( pipelineId, memoryFiles ) => {
+	return await client.put( `/pipelines/${ pipelineId }/memory-files`, {
+		memory_files: memoryFiles,
+	} );
+};
+
+/**
+ * Fetch available agent files
+ *
+ * @return {Promise<Object>} Array of agent files
+ */
+export const fetchAgentFiles = async () => {
+	return await client.get( '/files/agent' );
+};
+
+/**
  * Fetch complete handler details
  *
  * @param {string} handlerSlug - Handler slug (e.g., 'twitter', 'wordpress_publish')

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/constants.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/constants.js
@@ -18,6 +18,7 @@ export const MODAL_TYPES = {
 	OAUTH: 'oauth',
 	CONFIRM_DELETE: 'confirm-delete',
 	CONTEXT_FILES: 'context-files',
+	MEMORY_FILES: 'memory-files',
 };
 
 /**

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -370,6 +370,43 @@ class Pipelines extends BaseRepository {
 	}
 
 	/**
+	 * Get pipeline memory files from pipeline config.
+	 *
+	 * @param int $pipeline_id Pipeline ID.
+	 * @return array Array of memory filenames.
+	 */
+	public function get_pipeline_memory_files( int $pipeline_id ): array {
+		$pipeline_config = $this->get_pipeline_config( $pipeline_id );
+		return $pipeline_config['memory_files'] ?? array();
+	}
+
+	/**
+	 * Update pipeline memory files in pipeline config.
+	 *
+	 * @param int   $pipeline_id  Pipeline ID.
+	 * @param array $memory_files Array of memory filenames.
+	 * @return bool True on success, false on failure.
+	 */
+	public function update_pipeline_memory_files( int $pipeline_id, array $memory_files ): bool {
+		if ( empty( $pipeline_id ) ) {
+			return false;
+		}
+
+		$pipeline_config                 = $this->get_pipeline_config( $pipeline_id );
+		$pipeline_config['memory_files'] = $memory_files;
+
+		$result = $this->wpdb->update(
+			$this->table_name,
+			array( 'pipeline_config' => wp_json_encode( $pipeline_config ) ),
+			array( 'pipeline_id' => $pipeline_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		return false !== $result;
+	}
+
+	/**
 	 * Create pipelines database table.
 	 */
 	/**

--- a/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Pipeline Memory Files Directive - Priority 25
+ *
+ * Injects agent memory files referenced by pipeline configuration into AI context.
+ * Memory files are stored in the shared agent/ directory and selected per-pipeline.
+ *
+ * Priority Order in Directive System:
+ * 1. Priority 10 - Plugin Core Directive (agent identity)
+ * 2. Priority 20 - Agent SOUL.md (global AI behavior)
+ * 3. Priority 25 - Pipeline Memory Files (THIS CLASS - agent memory references)
+ * 4. Priority 30 - Pipeline System Prompt (pipeline instructions)
+ * 5. Priority 35 - Pipeline Context Files (uploaded reference materials)
+ * 6. Priority 40 - Tool Definitions (available tools and workflow)
+ * 7. Priority 50 - Site Context (WordPress metadata)
+ *
+ * @package DataMachine\Core\Steps\AI\Directives
+ */
+
+namespace DataMachine\Core\Steps\AI\Directives;
+
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\FilesRepository\DirectoryManager;
+
+defined( 'ABSPATH' ) || exit;
+
+class PipelineMemoryFilesDirective implements \DataMachine\Engine\AI\Directives\DirectiveInterface {
+
+	/**
+	 * Get directive outputs for pipeline memory files.
+	 *
+	 * @param string      $provider_name AI provider name.
+	 * @param array       $tools         Available tools.
+	 * @param string|null $step_id       Pipeline step ID.
+	 * @param array       $payload       Additional payload data.
+	 * @return array Directive outputs.
+	 */
+	public static function get_outputs( string $provider_name, array $tools, ?string $step_id = null, array $payload = array() ): array {
+		if ( empty( $step_id ) ) {
+			return array();
+		}
+
+		$db_pipelines = new Pipelines();
+		$step_config  = $db_pipelines->get_pipeline_step_config( $step_id );
+		$pipeline_id  = $step_config['pipeline_id'] ?? null;
+
+		if ( empty( $pipeline_id ) ) {
+			return array();
+		}
+
+		$memory_files = $db_pipelines->get_pipeline_memory_files( (int) $pipeline_id );
+
+		if ( empty( $memory_files ) ) {
+			return array();
+		}
+
+		$directory_manager = new DirectoryManager();
+		$agent_dir         = $directory_manager->get_agent_directory();
+		$outputs           = array();
+
+		foreach ( $memory_files as $filename ) {
+			$safe_filename = sanitize_file_name( $filename );
+			$filepath      = "{$agent_dir}/{$safe_filename}";
+
+			if ( ! file_exists( $filepath ) ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					'Pipeline Memory Files: File not found',
+					array(
+						'filename'    => $safe_filename,
+						'pipeline_id' => $pipeline_id,
+					)
+				);
+				continue;
+			}
+
+			$content = file_get_contents( $filepath );
+			if ( empty( trim( $content ) ) ) {
+				continue;
+			}
+
+			$outputs[] = array(
+				'type'    => 'system_text',
+				'content' => "## Memory File: {$safe_filename}\n{$content}",
+			);
+		}
+
+		if ( ! empty( $outputs ) ) {
+			do_action(
+				'datamachine_log',
+				'debug',
+				'Pipeline Memory Files: Injected memory files',
+				array(
+					'pipeline_id' => $pipeline_id,
+					'file_count'  => count( $outputs ),
+					'files'       => $memory_files,
+				)
+			);
+		}
+
+		return $outputs;
+	}
+}
+
+// Register at Priority 25 — between SOUL.md (20) and pipeline system prompt (30).
+add_filter(
+	'datamachine_directives',
+	function ( $directives ) {
+		$directives[] = array(
+			'class'       => PipelineMemoryFilesDirective::class,
+			'priority'    => 25,
+			'agent_types' => array( 'pipeline' ),
+		);
+		return $directives;
+	}
+);

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -55,6 +55,7 @@ require_once __DIR__ . '/Api/Chat/ChatAgentDirective.php';
 require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineCoreDirective.php';
 require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php';
 require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineContextDirective.php';
+require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php';
 require_once __DIR__ . '/Core/FilesRepository/FileCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/ClaimsCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/QueueTuning.php';


### PR DESCRIPTION
## Phase 4: Pipeline Memory File References (#280)

Adds the ability to reference agent memory files from pipeline configuration, injecting them into AI context at Priority 25 (between SOUL.md and pipeline system prompt).

### Changes

**Backend:**
- `Pipelines.php` — Added `get_pipeline_memory_files()` and `update_pipeline_memory_files()` methods storing a `memory_files` array in `pipeline_config`
- `PipelineMemoryFilesDirective.php` (new) — Priority 25 directive that reads agent memory files and injects them as `system_text` blocks
- Registered directive in `bootstrap.php`

**REST API:**
- `GET /datamachine/v1/pipelines/{id}/memory-files` — Returns array of selected filenames
- `PUT /datamachine/v1/pipelines/{id}/memory-files` — Saves array of filenames to pipeline config

**Frontend:**
- `PipelineMemoryFiles.jsx` (new) — Checklist component fetching agent files via `GET /files/agent`, excludes SOUL.md
- `MemoryFilesModal.jsx` (new) — Modal wrapper
- Added Memory Files button (database icon) to pipeline header alongside Context Files
- Query hooks and API functions for memory files CRUD

### Priority Order
```
10: Core plugin instructions
20: SOUL.md (AgentSoulDirective)
25: Pipeline memory files (NEW)
30: Pipeline system prompt
35: Pipeline context files (unchanged)
40: Tool definitions
50: Site context
```

### Notes
- Existing PipelineContextDirective (Priority 35) is untouched — both coexist
- SOUL.md excluded from the picker (always injected at Priority 20)
- Webpack build verified