### PR TITLE
Fix agent page response shape + harden SOUL.md deletion

### DIFF
--- a/inc/Abilities/FileAbilities.php
+++ b/inc/Abilities/FileAbilities.php
@@ -1128,11 +1128,9 @@ class FileAbilities {
 		}
 
 		if ( 'SOUL.md' === $filename ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Agent SOUL.md is being deleted via abilities API.',
-				array( 'filename' => $filename )
+			return array(
+				'success' => false,
+				'error'   => 'SOUL.md cannot be deleted. It is a core agent file. Clear its contents instead.',
 			);
 		}
 

--- a/inc/Core/Admin/Pages/Agent/assets/react/queries/agentFiles.js
+++ b/inc/Core/Admin/Pages/Agent/assets/react/queries/agentFiles.js
@@ -23,6 +23,7 @@ export const useAgentFiles = () =>
 	useQuery( {
 		queryKey: KEYS.list,
 		queryFn: api.listAgentFiles,
+		select: ( response ) => response?.data ?? response ?? [],
 	} );
 
 export const useAgentFile = ( filename ) =>
@@ -30,6 +31,7 @@ export const useAgentFile = ( filename ) =>
 		queryKey: KEYS.detail( filename ),
 		queryFn: () => api.getAgentFile( filename ),
 		enabled: !! filename,
+		select: ( response ) => response?.data ?? response ?? {},
 	} );
 
 export const useSaveAgentFile = () => {


### PR DESCRIPTION
## Phase 5 Cleanup — Agentic Memory System

Two fixes from the rapid build:

### Response shape fix (Agent page)
The `useAgentFiles` and `useAgentFile` query hooks on the Agent page return raw API responses (`{ success: true, data: [...] }`) but consumers treat them as unwrapped data. Added `select` transforms to unwrap — matching the pattern already used in the Pipeline page's queries.

### SOUL.md deletion hardening
`FileAbilities::delete_agent_file()` previously only logged a warning when SOUL.md deletion was attempted but didn't actually block it. Now returns an error response, making the protection real (UI already blocks it, this closes the API/abilities gap).

### Not included (future)
- `file_get_contents()` caching in directives — filesystem reads are fast for small markdown files, premature optimization for now

Refs: #279, #280