### PR TITLE
Use TabPanel component for Agent and Settings pages

### DIFF
--- a/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
@@ -2,13 +2,14 @@
  * AgentApp Component
  *
  * Root container for the Agent admin page.
- * Two-panel layout: file list sidebar + editor.
+ * Tabbed layout: Memory (file browser + editor) and Configuration.
  */
 
 /**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
+import { TabPanel } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -18,6 +19,11 @@ import AgentFileEditor from './components/AgentFileEditor';
 import AgentEmptyState from './components/AgentEmptyState';
 import AgentSettings from './components/AgentSettings';
 import { useAgentFiles } from './queries/agentFiles';
+
+const TABS = [
+	{ name: 'memory', title: 'Memory' },
+	{ name: 'configuration', title: 'Configuration' },
+];
 
 const AgentApp = () => {
 	const [ selectedFile, setSelectedFile ] = useState( null );
@@ -29,20 +35,36 @@ const AgentApp = () => {
 			<div className="datamachine-agent-header">
 				<h1 className="datamachine-agent-title">Agent</h1>
 			</div>
-			<div className="datamachine-agent-layout">
-				<AgentFileList
-					selectedFile={ selectedFile }
-					onSelectFile={ setSelectedFile }
-				/>
-				<div className="datamachine-agent-editor-panel">
-					{ selectedFile ? (
-						<AgentFileEditor filename={ selectedFile } />
-					) : (
-						<AgentEmptyState hasFiles={ hasFiles } />
-					) }
-				</div>
-			</div>
-			<AgentSettings />
+			<TabPanel
+				className="datamachine-agent-tabs"
+				tabs={ TABS }
+			>
+				{ ( tab ) => {
+					if ( tab.name === 'memory' ) {
+						return (
+							<div className="datamachine-agent-layout">
+								<AgentFileList
+									selectedFile={ selectedFile }
+									onSelectFile={ setSelectedFile }
+								/>
+								<div className="datamachine-agent-editor-panel">
+									{ selectedFile ? (
+										<AgentFileEditor
+											filename={ selectedFile }
+										/>
+									) : (
+										<AgentEmptyState
+											hasFiles={ hasFiles }
+										/>
+									) }
+								</div>
+							</div>
+						);
+					}
+
+					return <AgentSettings />;
+				} }
+			</TabPanel>
 		</div>
 	);
 };

--- a/inc/Core/Admin/Settings/assets/react/SettingsApp.jsx
+++ b/inc/Core/Admin/Settings/assets/react/SettingsApp.jsx
@@ -7,7 +7,9 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
+import { TabPanel } from '@wordpress/components';
+
 /**
  * Internal dependencies
  */
@@ -15,61 +17,47 @@ import GeneralTab from './components/tabs/GeneralTab';
 import ApiKeysTab from './components/tabs/ApiKeysTab';
 import HandlerDefaultsTab from './components/tabs/HandlerDefaultsTab';
 
-const TABS = [
-	{ id: 'general', label: 'General' },
-	{ id: 'api-keys', label: 'API Keys' },
-	{ id: 'handler-defaults', label: 'Handler Defaults' },
-];
-
 const STORAGE_KEY = 'datamachine_settings_active_tab';
 
+const TABS = [
+	{ name: 'general', title: 'General' },
+	{ name: 'api-keys', title: 'API Keys' },
+	{ name: 'handler-defaults', title: 'Handler Defaults' },
+];
+
+const getInitialTab = () => {
+	const stored = localStorage.getItem( STORAGE_KEY );
+	return stored && TABS.some( ( t ) => t.name === stored )
+		? stored
+		: 'general';
+};
+
 const SettingsApp = () => {
-	const [ activeTab, setActiveTab ] = useState( () => {
-		// Restore from localStorage or default to first tab
-		const stored = localStorage.getItem( STORAGE_KEY );
-		return stored && TABS.some( ( t ) => t.id === stored )
-			? stored
-			: 'general';
-	} );
-
-	// Persist active tab to localStorage
-	useEffect( () => {
-		localStorage.setItem( STORAGE_KEY, activeTab );
-	}, [ activeTab ] );
-
-	const renderTabContent = () => {
-		switch ( activeTab ) {
-			case 'general':
-				return <GeneralTab />;
-			case 'api-keys':
-				return <ApiKeysTab />;
-			case 'handler-defaults':
-				return <HandlerDefaultsTab />;
-			default:
-				return <GeneralTab />;
-		}
-	};
+	const handleSelect = useCallback( ( tabName ) => {
+		localStorage.setItem( STORAGE_KEY, tabName );
+	}, [] );
 
 	return (
 		<div className="datamachine-settings-app">
-			<h2 className="nav-tab-wrapper datamachine-nav-tab-wrapper">
-				{ TABS.map( ( tab ) => (
-					<button
-						key={ tab.id }
-						type="button"
-						className={ `nav-tab ${
-							activeTab === tab.id ? 'nav-tab-active' : ''
-						}` }
-						onClick={ () => setActiveTab( tab.id ) }
-					>
-						{ tab.label }
-					</button>
-				) ) }
-			</h2>
-
-			<div className="datamachine-settings-content">
-				{ renderTabContent() }
-			</div>
+			<TabPanel
+				className="datamachine-settings-tabs"
+				tabs={ TABS }
+				initialTabName={ getInitialTab() }
+				onSelect={ handleSelect }
+			>
+				{ ( tab ) => {
+					switch ( tab.name ) {
+						case 'general':
+							return <GeneralTab />;
+						case 'api-keys':
+							return <ApiKeysTab />;
+						case 'handler-defaults':
+							return <HandlerDefaultsTab />;
+						default:
+							return <GeneralTab />;
+					}
+				} }
+			</TabPanel>
 		</div>
 	);
 };


### PR DESCRIPTION
## Consistent tab UI across all admin pages

Migrates Agent and Settings pages to use `@wordpress/components` `TabPanel` — matching the pattern Logs already uses.

### Agent page
- Adds **Memory** and **Configuration** tabs
- Memory: file browser + markdown editor (existing UI, now in a tab)
- Configuration: tools, provider/model, site context, max turns, webhook

### Settings page
- Replaces manual `nav-tab-wrapper` markup with `TabPanel`
- Retains `localStorage` tab persistence via `onSelect`

### Result
All three tabbed pages (Logs, Settings, Agent) now use the same WP component. No functional changes — purely UI consistency.