### PR TITLE
Extract shared TabPanel styles across all admin pages

### DIFF
--- a/inc/Core/Admin/Pages/Agent/AgentFilters.php
+++ b/inc/Core/Admin/Pages/Agent/AgentFilters.php
@@ -36,6 +36,11 @@ function datamachine_register_agent_admin_page_filters() {
 							'deps'  => array(),
 							'media' => 'all',
 						),
+						'datamachine-tabs'       => array(
+							'file'  => 'inc/Core/Admin/shared/styles/tabs.css',
+							'deps'  => array(),
+							'media' => 'all',
+						),
 						'datamachine-agent-page' => array(
 							'file'  => 'inc/Core/Admin/Pages/Agent/assets/css/agent-page.css',
 							'deps'  => array(),

--- a/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
@@ -36,7 +36,7 @@ const AgentApp = () => {
 				<h1 className="datamachine-agent-title">Agent</h1>
 			</div>
 			<TabPanel
-				className="datamachine-agent-tabs"
+				className="datamachine-tabs"
 				tabs={ TABS }
 			>
 				{ ( tab ) => {

--- a/inc/Core/Admin/Pages/Logs/LogsFilters.php
+++ b/inc/Core/Admin/Pages/Logs/LogsFilters.php
@@ -46,6 +46,11 @@ function datamachine_register_logs_admin_page_filters() {
 							'deps'  => array(),
 							'media' => 'all',
 						),
+						'datamachine-tabs'      => array(
+							'file'  => 'inc/Core/Admin/shared/styles/tabs.css',
+							'deps'  => array(),
+							'media' => 'all',
+						),
 						'datamachine-logs-page' => array(
 							'file'  => 'inc/Core/Admin/Pages/Logs/assets/css/logs-page.css',
 							'deps'  => array(),

--- a/inc/Core/Admin/Pages/Logs/assets/css/logs-page.css
+++ b/inc/Core/Admin/Pages/Logs/assets/css/logs-page.css
@@ -33,45 +33,6 @@
 	gap: 10px;
 }
 
-/* Tabs */
-.datamachine-logs-tabs {
-	background: #fff;
-	border: 1px solid #c3c4c7;
-	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
-}
-
-.datamachine-logs-tabs .components-tab-panel__tabs {
-	background: #f6f7f7;
-	border-bottom: 1px solid #c3c4c7;
-	margin: 0;
-	padding: 0;
-}
-
-.datamachine-logs-tabs .components-tab-panel__tabs-item {
-	padding: 12px 20px;
-	font-size: 14px;
-	font-weight: 500;
-	color: #1e1e1e;
-	border: none;
-	background: transparent;
-	cursor: pointer;
-	position: relative;
-}
-
-.datamachine-logs-tabs .components-tab-panel__tabs-item:hover {
-	background: #fff;
-}
-
-.datamachine-logs-tabs .components-tab-panel__tabs-item.is-active {
-	background: #fff;
-	box-shadow: inset 0 -3px 0 0 #3858e9;
-}
-
-.datamachine-logs-tabs .components-tab-panel__tabs-item:focus {
-	box-shadow: inset 0 0 0 1.5px #3858e9;
-	outline: none;
-}
-
 /* Tab Content */
 .datamachine-logs-tab-content {
 	padding: 20px;

--- a/inc/Core/Admin/Pages/Logs/assets/react/components/LogsTabs.jsx
+++ b/inc/Core/Admin/Pages/Logs/assets/react/components/LogsTabs.jsx
@@ -43,7 +43,7 @@ const LogsTabs = () => {
 	} ) );
 
 	return (
-		<TabPanel className="datamachine-logs-tabs" tabs={ tabs }>
+		<TabPanel className="datamachine-tabs" tabs={ tabs }>
 			{ ( tab ) => (
 				<div className="datamachine-logs-tab-content">
 					<LogsControls

--- a/inc/Core/Admin/Settings/SettingsFilters.php
+++ b/inc/Core/Admin/Settings/SettingsFilters.php
@@ -25,6 +25,16 @@ function datamachine_register_settings_admin_page_filters() {
 				'templates'  => DATAMACHINE_PATH . 'inc/Core/Admin/Settings/templates/',
 				'assets'     => array(
 					'css' => array(
+						'wp-components'             => array(
+							'file'  => null,
+							'deps'  => array(),
+							'media' => 'all',
+						),
+						'datamachine-tabs'          => array(
+							'file'  => 'inc/Core/Admin/shared/styles/tabs.css',
+							'deps'  => array(),
+							'media' => 'all',
+						),
 						'datamachine-settings-page' => array(
 							'file'  => 'inc/Core/Admin/Settings/assets/css/settings-page.css',
 							'deps'  => array(),

--- a/inc/Core/Admin/Settings/assets/css/settings-page.css
+++ b/inc/Core/Admin/Settings/assets/css/settings-page.css
@@ -133,22 +133,6 @@
     max-width: 1200px;
 }
 
-/* Tab navigation wrapper */
-.datamachine-nav-tab-wrapper {
-    margin: 20px 0 0 0;
-    border-bottom: 1px solid #ccd0d4;
-}
-
-/* Tab content containers */
-.datamachine-tab-content {
-    display: none;
-    padding-top: 20px;
-}
-
-.datamachine-tab-content.active {
-    display: block;
-}
-
 /* Form styling */
 .datamachine-settings-form {
     background: #fff;
@@ -166,51 +150,10 @@
     border-top: 1px solid #ddd;
 }
 
-/* Section headers within tabs */
-.datamachine-tab-content h3 {
-    margin-top: 0;
-    margin-bottom: 10px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid #eee;
-    font-size: 16px;
-    color: #23282d;
-}
-
-/* Enhanced form table styling for tabs */
-.datamachine-tab-content .form-table {
-    margin-top: 0;
-}
-
-.datamachine-tab-content .form-table th {
-    padding-left: 0;
-    width: 200px;
-    vertical-align: top;
-}
-
-.datamachine-tab-content .form-table td {
-    padding-left: 20px;
-}
-
 /* Responsive design for smaller screens */
 @media screen and (max-width: 782px) {
-    .datamachine-nav-tab-wrapper .nav-tab {
-        margin-bottom: 5px;
-        margin-right: 5px;
-    }
-    
     .datamachine-settings-form {
         padding: 15px;
-    }
-    
-    .datamachine-tab-content .form-table th,
-    .datamachine-tab-content .form-table td {
-        width: auto;
-        padding: 10px 0;
-        display: block;
-    }
-    
-    .datamachine-tab-content .form-table td {
-        padding-left: 0;
     }
 }
 
@@ -253,34 +196,6 @@
 
 .datamachine-settings-app {
     margin-top: 20px;
-}
-
-.datamachine-settings-app .nav-tab-wrapper {
-    margin-bottom: 0;
-}
-
-.datamachine-settings-app .nav-tab {
-    cursor: pointer;
-    border: none;
-    background: transparent;
-}
-
-.datamachine-settings-app .nav-tab:hover {
-    background-color: #f0f0f1;
-}
-
-.datamachine-settings-app .nav-tab-active {
-    background: #fff;
-    border-bottom: 1px solid #fff;
-    margin-bottom: -1px;
-}
-
-.datamachine-settings-content {
-    background: #fff;
-    border: 1px solid #ccd0d4;
-    border-top: none;
-    padding: 20px;
-    min-height: 400px;
 }
 
 /* ========================================================================
@@ -472,7 +387,6 @@
 }
 
 .datamachine-general-tab-loading,
-.datamachine-agent-tab-loading,
 .datamachine-api-keys-tab-loading {
     display: flex;
     align-items: center;
@@ -497,34 +411,6 @@
 .datamachine-error-indicator {
     color: #d63638;
     font-size: 13px;
-}
-
-/* ========================================================================
-   AGENT TAB
-   ======================================================================== */
-
-.datamachine-agent-tab .datamachine-tool-config-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 16px;
-}
-
-.datamachine-agent-tab .datamachine-tool-config-item h4 {
-    margin: 0 0 4px 0;
-    font-size: 14px;
-}
-
-.datamachine-agent-tab .datamachine-tool-config-item .description {
-    margin: 0 0 8px 0;
-    font-size: 12px;
-    color: #646970;
-}
-
-.datamachine-agent-tab .datamachine-tool-controls {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 10px;
 }
 
 .datamachine-config-status {

--- a/inc/Core/Admin/Settings/assets/react/SettingsApp.jsx
+++ b/inc/Core/Admin/Settings/assets/react/SettingsApp.jsx
@@ -40,7 +40,7 @@ const SettingsApp = () => {
 	return (
 		<div className="datamachine-settings-app">
 			<TabPanel
-				className="datamachine-settings-tabs"
+				className="datamachine-tabs"
 				tabs={ TABS }
 				initialTabName={ getInitialTab() }
 				onSelect={ handleSelect }

--- a/inc/Core/Admin/shared/styles/tabs.css
+++ b/inc/Core/Admin/shared/styles/tabs.css
@@ -1,0 +1,48 @@
+/**
+ * Shared TabPanel styles
+ *
+ * Common styling for @wordpress/components TabPanel across all admin pages.
+ * Apply the class `datamachine-tabs` to each <TabPanel>.
+ */
+
+.datamachine-tabs {
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+}
+
+.datamachine-tabs .components-tab-panel__tabs {
+	background: #f6f7f7;
+	border-bottom: 1px solid #c3c4c7;
+	margin: 0;
+	padding: 0;
+}
+
+.datamachine-tabs .components-tab-panel__tabs-item {
+	padding: 12px 20px;
+	font-size: 14px;
+	font-weight: 500;
+	color: #1e1e1e;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	position: relative;
+}
+
+.datamachine-tabs .components-tab-panel__tabs-item:hover {
+	background: #fff;
+}
+
+.datamachine-tabs .components-tab-panel__tabs-item.is-active {
+	background: #fff;
+	box-shadow: inset 0 -3px 0 0 #3858e9;
+}
+
+.datamachine-tabs .components-tab-panel__tabs-item:focus {
+	box-shadow: inset 0 0 0 1.5px #3858e9;
+	outline: none;
+}
+
+.datamachine-tabs .components-tab-panel__tab-content {
+	padding: 20px;
+}


### PR DESCRIPTION
## Visual consistency for tabbed admin pages

All three tabbed pages (Agent, Logs, Settings) were using different tab styling:
- **Logs** — custom CSS targeting `.datamachine-logs-tabs`
- **Settings** — dead `.nav-tab-wrapper` styles (from before TabPanel migration)
- **Agent** — no tab styles at all

### Changes

**New:** `inc/Core/Admin/shared/styles/tabs.css`
- Shared `.datamachine-tabs` class with consistent look (white panel, grey tab bar, blue active indicator)
- Registered in all three page filters

**Cleaned up:**
- Removed duplicate tab CSS from `logs-page.css` (~39 lines)
- Removed dead `.nav-tab`, `.datamachine-tab-content`, and `.datamachine-agent-tab` styles from `settings-page.css` (~114 lines)
- Added missing `wp-components` CSS dependency to Settings page

**Updated:** All three `TabPanel` components use `className="datamachine-tabs"`

Net: -85 lines of duplicate/dead CSS, one shared source of truth.