### PR TITLE
docs: align top-level ai-directives.md with 7-tier system

### DIFF
--- a/docs/ai-directives.md
+++ b/docs/ai-directives.md
@@ -15,18 +15,28 @@ The directive system is built on a modular architecture using the following core
 
 Directives are layered by priority (lowest number = highest priority) to create a cohesive context:
 
-1. **Plugin Core Directive** (Priority 10): Defines the agent's identity as the Data Machine Assistant and sets core operational principles.
-2. **Global System Prompt** (Priority 20): Provides high-level system instructions and safety guidelines.
-3. **Pipeline System Prompt** (Priority 30): Instructions specific to pipeline operations and step execution.
-4. **Pipeline Context** (Priority 35): Injects metadata about the current pipeline (ID, name, description, steps).
-5. **Site Context** (Priority 50): Provides information about the WordPress site (name, URL, active plugins, theme).
+1. **Priority 10** - Plugin Core Directive (agent identity)
+2. **Priority 15** - Chat Agent Directive (chat-specific identity)
+3. **Priority 20** - Agent Soul Directive (SOUL.md from agent memory)
+4. **Priority 25** - Pipeline Memory Files (per-pipeline selected agent memory files)
+5. **Priority 30** - Pipeline System Prompt (pipeline instructions)
+6. **Priority 35** - Pipeline Context Files (uploaded reference materials)
+7. **Priority 40** - Tool Definitions (available tools and workflow)
+8. **Priority 45** - Chat Pipelines Inventory (pipeline discovery)
+9. **Priority 50** - Site Context (WordPress metadata)
 
 ## Specialized Directives
 
-### Chat Agent Directive
+### ChatAgentDirective (Priority 15)
 Specialized directive for the conversational chat interface. It instructs the agent on discovery and configuration patterns, emphasizing querying existing workflows before creating new ones.
 
-### Chat Pipelines Directive
+### AgentSoulDirective (Priority 20)
+Reads `SOUL.md` from the agent memory directory (`{uploads}/datamachine-files/agent/SOUL.md`) and injects it as a system message. This defines the agent's personality, tone, and behavioral guidelines globally across all agent types. Migrated from the old `global_system_prompt` database setting in v0.13.0.
+
+### PipelineMemoryFilesDirective (Priority 25)
+Injects agent memory files selected for a specific pipeline. Files are stored in the shared agent directory and selected per-pipeline via the admin UI. SOUL.md is excluded (always injected separately at Priority 20). This enables pipelines to access strategy documents, reference material, or other persistent context.
+
+### ChatPipelinesDirective (Priority 45)
 Provides the conversational agent with an inventory of available pipelines. When a pipeline is selected in the UI, `selected_pipeline_id` is used to prioritize and expand context for that specific pipeline, including its flow summaries and handler configurations.
 
 ## Registration
@@ -36,9 +46,9 @@ Directives are registered via WordPress filters:
 ```php
 add_filter('datamachine_directives', function($directives) {
     $directives[] = [
-        'id'       => 'my-custom-directive',
-        'priority' => 40,
-        'class'    => MyCustomDirective::class,
+        'class'       => MyCustomDirective::class,
+        'priority'    => 25,
+        'agent_types' => ['pipeline'],
     ];
     return $directives;
 });
@@ -49,3 +59,4 @@ add_filter('datamachine_directives', function($directives) {
 - Directives should be read-only and never mutate the AI request structure directly.
 - Use `DirectiveOutputValidator` to ensure responses from the AI follow the correct `system_text` or `system_json` formats.
 - Context injection should be minimal and focused on what the agent needs for the current task.
+- See `docs/core-system/ai-directives.md` for detailed implementation reference including agent-specific behavior, caching strategy, and extensibility hooks.


### PR DESCRIPTION
Homeboy docs audit flagged `docs/ai-directives.md` as stale — still referenced the old 5-tier system and `global_system_prompt`.

**Changes:**
- Priority 20 updated from 'Global System Prompt' to 'Agent Soul Directive (SOUL.md)'
- Priority 25 added for Pipeline Memory Files
- AgentSoulDirective and PipelineMemoryFilesDirective sections added
- Registration example updated to current array format (`class`, `priority`, `agent_types`)
- Cross-references `docs/core-system/ai-directives.md` for implementation details

Note: `docs/core-system/ai-directives.md` was already updated in a prior PR — this aligns the top-level summary doc.