### PR TITLE
refactor: Granular paragraph-level internal linking (#278)

### DIFF
--- a/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
+++ b/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
@@ -4,7 +4,7 @@
  *
  * Semantically weaves internal links into post content by finding related
  * posts via shared taxonomy terms and using AI to insert anchor tags
- * naturally into existing sentences.
+ * naturally into individual paragraphs via block-level editing.
  *
  * @package DataMachine\Engine\AI\System\Tasks
  * @since 0.24.0
@@ -14,6 +14,8 @@ namespace DataMachine\Engine\AI\System\Tasks;
 
 defined( 'ABSPATH' ) || exit;
 
+use DataMachine\Abilities\Content\GetPostBlocksAbility;
+use DataMachine\Abilities\Content\ReplacePostBlocksAbility;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\RequestBuilder;
 
@@ -46,44 +48,62 @@ class InternalLinkingTask extends SystemTask {
 		if ( ! $force ) {
 			$existing_links = get_post_meta( $post_id, '_dm_internal_links', true );
 			if ( ! empty( $existing_links ) ) {
-				$this->completeJob( $jobId, [
+				$this->completeJob( $jobId, array(
 					'skipped' => true,
 					'post_id' => $post_id,
 					'reason'  => 'Already processed (use force to re-run)',
-				] );
+				) );
 				return;
 			}
 		}
 
 		// Get post taxonomies.
-		$categories = wp_get_post_categories( $post_id, [ 'fields' => 'ids' ] );
-		$tags       = wp_get_post_tags( $post_id, [ 'fields' => 'ids' ] );
+		$categories = wp_get_post_categories( $post_id, array( 'fields' => 'ids' ) );
+		$tags       = wp_get_post_tags( $post_id, array( 'fields' => 'ids' ) );
 
 		if ( empty( $categories ) && empty( $tags ) ) {
-			$this->completeJob( $jobId, [
+			$this->completeJob( $jobId, array(
 				'skipped' => true,
 				'post_id' => $post_id,
 				'reason'  => 'Post has no categories or tags',
-			] );
+			) );
 			return;
 		}
+
+		// Parse post into paragraph blocks.
+		$blocks_result = GetPostBlocksAbility::execute( array(
+			'post_id'     => $post_id,
+			'block_types' => array( 'core/paragraph' ),
+		) );
+
+		if ( empty( $blocks_result['success'] ) || empty( $blocks_result['blocks'] ) ) {
+			$this->completeJob( $jobId, array(
+				'skipped' => true,
+				'post_id' => $post_id,
+				'reason'  => 'No paragraph blocks found in post',
+			) );
+			return;
+		}
+
+		$paragraph_blocks = $blocks_result['blocks'];
 
 		// Find related posts scored by taxonomy overlap.
 		$related = $this->findRelatedPosts( $post_id, $categories, $tags, $links_per_post );
 
-		// Filter out posts already linked in content.
-		$related = $this->filterAlreadyLinked( $related, $post->post_content );
+		// Filter out posts already linked in any paragraph block.
+		$all_block_html = implode( "\n", array_column( $paragraph_blocks, 'inner_html' ) );
+		$related        = $this->filterAlreadyLinked( $related, $all_block_html );
 
 		if ( empty( $related ) ) {
-			$this->completeJob( $jobId, [
+			$this->completeJob( $jobId, array(
 				'skipped' => true,
 				'post_id' => $post_id,
 				'reason'  => 'No unlinked related posts found',
-			] );
+			) );
 			return;
 		}
 
-		// Build AI request.
+		// Build AI request config.
 		$system_defaults = PluginSettings::getAgentModel( 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
@@ -93,75 +113,102 @@ class InternalLinkingTask extends SystemTask {
 			return;
 		}
 
-		$prompt   = $this->buildPrompt( $post->post_content, $related );
-		$messages = [
-			[
-				'role'    => 'user',
-				'content' => $prompt,
-			],
-		];
+		// For each related post, find a candidate paragraph and send to AI.
+		$replacements   = array();
+		$inserted_links = array();
 
-		$response = RequestBuilder::build(
-			$messages,
-			$provider,
-			$model,
-			[],
-			'system',
-			[ 'post_id' => $post_id ]
-		);
+		foreach ( $related as $related_post ) {
+			$candidate = $this->findCandidateParagraph( $paragraph_blocks, $related_post, $replacements );
 
-		if ( empty( $response['success'] ) ) {
-			$this->failJob( $jobId, 'AI request failed: ' . ( $response['error'] ?? 'Unknown error' ) );
-			return;
+			if ( null === $candidate ) {
+				continue;
+			}
+
+			$prompt   = $this->buildBlockPrompt( $candidate['inner_html'], $related_post );
+			$response = RequestBuilder::build(
+				array(
+					array(
+						'role'    => 'user',
+						'content' => $prompt,
+					),
+				),
+				$provider,
+				$model,
+				array(),
+				'system',
+				array( 'post_id' => $post_id )
+			);
+
+			if ( empty( $response['success'] ) ) {
+				continue;
+			}
+
+			$new_html = trim( $response['data']['content'] ?? '' );
+
+			if ( empty( $new_html ) || $new_html === $candidate['inner_html'] ) {
+				continue;
+			}
+
+			// Validate a link was actually inserted.
+			if ( ! $this->detectInsertedLink( $new_html, $related_post['url'] ) ) {
+				continue;
+			}
+
+			$replacements[] = array(
+				'block_index' => $candidate['index'],
+				'new_content' => $new_html,
+			);
+
+			$inserted_links[] = array(
+				'url'     => $related_post['url'],
+				'post_id' => $related_post['id'],
+				'title'   => $related_post['title'],
+			);
+
+			// Update inner_html in our working copy so subsequent candidates see the change.
+			foreach ( $paragraph_blocks as &$block ) {
+				if ( $block['index'] === $candidate['index'] ) {
+					$block['inner_html'] = $new_html;
+					break;
+				}
+			}
+			unset( $block );
 		}
-
-		$new_content = $response['data']['content'] ?? '';
-
-		if ( empty( $new_content ) ) {
-			$this->failJob( $jobId, 'AI returned empty content' );
-			return;
-		}
-
-		// Validate that at least one new link was inserted.
-		$inserted_links = $this->detectInsertedLinks( $new_content, $related );
 
 		if ( empty( $inserted_links ) ) {
-			$this->completeJob( $jobId, [
+			$this->completeJob( $jobId, array(
 				'skipped' => true,
 				'post_id' => $post_id,
 				'reason'  => 'AI found no natural insertion points',
-			] );
+			) );
 			return;
 		}
 
-		// Update post content.
-		$update_result = wp_update_post(
-			[
-				'ID'           => $post_id,
-				'post_content' => $new_content,
-			],
-			true
-		);
+		// Apply all block replacements at once.
+		$replace_result = ReplacePostBlocksAbility::execute( array(
+			'post_id'      => $post_id,
+			'replacements' => $replacements,
+		) );
 
-		if ( is_wp_error( $update_result ) ) {
-			$this->failJob( $jobId, 'Failed to update post: ' . $update_result->get_error_message() );
+		if ( empty( $replace_result['success'] ) ) {
+			$this->failJob( $jobId, 'Failed to save block replacements: ' . ( $replace_result['error'] ?? 'Unknown error' ) );
 			return;
 		}
 
 		// Track which links were added.
-		$link_tracking = [
+		$link_tracking = array(
 			'processed_at' => current_time( 'mysql' ),
 			'links'        => $inserted_links,
 			'job_id'       => $jobId,
-		];
+		);
 		update_post_meta( $post_id, '_dm_internal_links', $link_tracking );
 
-		$this->completeJob( $jobId, [
+		$this->completeJob( $jobId, array(
 			'post_id'        => $post_id,
 			'links_inserted' => count( $inserted_links ),
 			'links'          => $inserted_links,
 			'completed_at'   => current_time( 'mysql' ),
-		] );
+		) );
 	}
 
 	/**
@@ -174,6 +221,98 @@ class InternalLinkingTask extends SystemTask {
 	}
 
 	/**
+	 * Find the best candidate paragraph block for a related post link.
+	 *
+	 * Scores paragraphs by title word matches, tag overlap, and keyword
+	 * relevance. Skips blocks already targeted by a pending replacement.
+	 *
+	 * @param array $blocks       Paragraph blocks from GetPostBlocksAbility.
+	 * @param array $related_post Related post data with id, url, title, tags.
+	 * @param array $replacements Already-queued replacements (to avoid same block).
+	 * @return array|null Best candidate block or null if none found.
+	 */
+	private function findCandidateParagraph( array $blocks, array $related_post, array $replacements ): ?array {
+		$used_indices = array_column( $replacements, 'block_index' );
+
+		// Get title words (3+ chars) for matching.
+		$title_words = array_filter(
+			preg_split( '/\s+/', strtolower( $related_post['title'] ) ),
+			fn( $word ) => strlen( $word ) >= 3
+		);
+
+		// Get related post's tag names for matching.
+		$related_tags = wp_get_post_tags( $related_post['id'], array( 'fields' => 'names' ) );
+		$related_tags = array_map( 'strtolower', $related_tags );
+
+		$best_block = null;
+		$best_score = 0;
+
+		foreach ( $blocks as $block ) {
+			if ( in_array( $block['index'], $used_indices, true ) ) {
+				continue;
+			}
+
+			// Skip blocks that already contain a link to this URL.
+			if ( false !== stripos( $block['inner_html'], $related_post['url'] ) ) {
+				continue;
+			}
+
+			$html_lower = strtolower( $block['inner_html'] );
+			$score      = 0;
+
+			// Score by title word matches.
+			foreach ( $title_words as $word ) {
+				if ( false !== strpos( $html_lower, $word ) ) {
+					$score += 2;
+				}
+			}
+
+			// Score by tag name matches.
+			foreach ( $related_tags as $tag ) {
+				if ( false !== strpos( $html_lower, $tag ) ) {
+					$score += 3;
+				}
+			}
+
+			if ( $score > $best_score ) {
+				$best_score = $score;
+				$best_block = $block;
+			}
+		}
+
+		return $best_block;
+	}
+
+	/**
+	 * Build AI prompt for a single paragraph + link insertion.
+	 *
+	 * @param string $paragraph_html The paragraph innerHTML.
+	 * @param array  $related_post   Related post data with url and title.
+	 * @return string Prompt text.
+	 */
+	private function buildBlockPrompt( string $paragraph_html, array $related_post ): string {
+		return 'Here is a paragraph from a blog post. Weave in a link to the URL below by wrapping '
+			. 'a relevant existing phrase in an anchor tag. Do NOT add new text or change meaning. '
+			. 'Return ONLY the updated paragraph HTML. If no natural insertion point exists, '
+			. "return the paragraph unchanged.\n\n"
+			. 'URL: ' . $related_post['url'] . "\n"
+			. 'Title: ' . $related_post['title'] . "\n\n"
+			. "Paragraph:\n" . $paragraph_html;
+	}
+
+	/**
+	 * Check if a specific URL was inserted as an anchor tag in the content.
+	 *
+	 * @param string $html The HTML content to check.
+	 * @param string $url  The URL to look for.
+	 * @return bool True if the URL is found in an anchor href.
+	 */
+	private function detectInsertedLink( string $html, string $url ): bool {
+		$escaped_url = preg_quote( $url, '/' );
+		return (bool) preg_match( '/<a\s[^>]*href=["\']' . $escaped_url . '["\'][^>]*>/', $html );
+	}
+
+	/**
 	 * Find related posts by shared taxonomy terms, scored by overlap.
 	 *
 	 * @param int   $post_id    Current post ID to exclude.
@@ -183,45 +322,45 @@ class InternalLinkingTask extends SystemTask {
 	 * @return array Array of related post data [{id, url, title, excerpt, score}].
 	 */
 	private function findRelatedPosts( int $post_id, array $categories, array $tags, int $limit ): array {
-		$tax_query = [ 'relation' => 'OR' ];
+		$tax_query = array( 'relation' => 'OR' );
 
 		if ( ! empty( $categories ) ) {
-			$tax_query[] = [
+			$tax_query[] = array(
 				'taxonomy' => 'category',
 				'field'    => 'term_id',
 				'terms'    => $categories,
-			];
+			);
 		}
 
 		if ( ! empty( $tags ) ) {
-			$tax_query[] = [
+			$tax_query[] = array(
 				'taxonomy' => 'post_tag',
 				'field'    => 'term_id',
 				'terms'    => $tags,
-			];
+			);
 		}
 
-		$query = new \WP_Query( [
+		$query = new \WP_Query( array(
 			'post_type'      => 'post',
 			'post_status'    => 'publish',
-			'post__not_in'   => [ $post_id ],
+			'post__not_in'   => array( $post_id ),
 			'posts_per_page' => 50,
 			'tax_query'      => $tax_query,
 			'fields'         => 'ids',
 			'no_found_rows'  => true,
-		] );
+		) );
 
 		if ( empty( $query->posts ) ) {
-			return [];
+			return array();
 		}
 
 		// Score each candidate by taxonomy overlap.
-		$scored = [];
+		$scored = array();
 
 		foreach ( $query->posts as $candidate_id ) {
 			$score          = 0;
-			$candidate_cats = wp_get_post_categories( $candidate_id, [ 'fields' => 'ids' ] );
-			$candidate_tags = wp_get_post_tags( $candidate_id, [ 'fields' => 'ids' ] );
+			$candidate_cats = wp_get_post_categories( $candidate_id, array( 'fields' => 'ids' ) );
+			$candidate_tags = wp_get_post_tags( $candidate_id, array( 'fields' => 'ids' ) );
 
 			$shared_cats = array_intersect( $categories, $candidate_cats );
 			$shared_tags = array_intersect( $tags, $candidate_tags );
@@ -239,17 +378,17 @@ class InternalLinkingTask extends SystemTask {
 
 		// Pick top N.
 		$top_ids = array_slice( array_keys( $scored ), 0, $limit, true );
-		$related = [];
+		$related = array();
 
 		foreach ( $top_ids as $rel_id ) {
 			$rel_post  = get_post( $rel_id );
-			$related[] = [
+			$related[] = array(
 				'id'      => $rel_id,
 				'url'     => get_permalink( $rel_id ),
 				'title'   => get_the_title( $rel_id ),
 				'excerpt' => wp_trim_words( $rel_post->post_content, 30, '...' ),
 				'score'   => $scored[ $rel_id ],
-			];
+			);
 		}
 
 		return $related;
@@ -259,7 +398,7 @@ class InternalLinkingTask extends SystemTask {
 	 * Filter out posts that are already linked in the content.
 	 *
 	 * @param array  $related      Related posts array.
-	 * @param string $post_content Current post content.
+	 * @param string $post_content Content to check for existing links.
 	 * @return array Filtered related posts.
 	 */
 	private function filterAlreadyLinked( array $related, string $post_content ): array {
@@ -267,59 +406,5 @@ class InternalLinkingTask extends SystemTask {
 			$url = preg_quote( $item['url'], '/' );
 			return ! preg_match( '/' . $url . '/', $post_content );
 		} ) );
-	}
-
-	/**
-	 * Build the AI prompt for internal link insertion.
-	 *
-	 * @param string $post_content Full post content.
-	 * @param array  $related      Related posts data.
-	 * @return string Prompt text.
-	 */
-	private function buildPrompt( string $post_content, array $related ): string {
-		$related_list = '';
-		foreach ( $related as $item ) {
-			$related_list .= sprintf(
-				"- URL: %s\n  Title: %s\n  Excerpt: %s\n\n",
-				$item['url'],
-				$item['title'],
-				$item['excerpt']
-			);
-		}
-
-		return "Here is a blog post in Gutenberg block format. Below are related posts on this site. "
-			. "Weave internal links to these related posts SEMANTICALLY into existing sentences — "
-			. "find natural mentions of the topic and wrap the relevant phrase in an anchor tag. "
-			. "Do NOT add a Related Posts section. Do NOT change tone, meaning, or Gutenberg block structure. "
-			. "Return the FULL updated content with all blocks intact. "
-			. "If no natural insertion point exists for a link, skip that link — do not force it.\n\n"
-			. "=== POST CONTENT ===\n\n"
-			. $post_content . "\n\n"
-			. "=== RELATED POSTS TO LINK ===\n\n"
-			. $related_list;
-	}
-
-	/**
-	 * Detect which related post URLs were inserted into the new content.
-	 *
-	 * @param string $new_content Updated content from AI.
-	 * @param array  $related     Related posts that were candidates.
-	 * @return array URLs that were found in the new content.
-	 */
-	private function detectInsertedLinks( string $new_content, array $related ): array {
-		$inserted = [];
-
-		foreach ( $related as $item ) {
-			$url = preg_quote( $item['url'], '/' );
-			if ( preg_match( '/<a\s[^>]*href=["\']' . $url . '["\'][^>]*>/', $new_content ) ) {
-				$inserted[] = [
-					'url'     => $item['url'],
-					'post_id' => $item['id'],
-					'title'   => $item['title'],
-				];
-			}
-		}
-
-		return $inserted;
 	}
 }


### PR DESCRIPTION
## Summary

Refactors `InternalLinkingTask` to use block-level content abilities (`GetPostBlocksAbility` and `ReplacePostBlocksAbility`) instead of sending the entire post content to AI.

Closes #278

## What changed

**Before:** Sent full `post_content` to AI → AI returned entire content with links → saved via `wp_update_post()`

**After:**
1. `GetPostBlocksAbility::execute()` parses post into indexed `core/paragraph` blocks
2. For each related post, `findCandidateParagraph()` scores blocks by title word matches and tag name overlap to find the best insertion point
3. Each candidate paragraph + link is sent as a separate AI call with a simple prompt: "wrap a relevant phrase in an anchor tag"
4. `ReplacePostBlocksAbility::execute()` applies all block replacements in a single save

## What stayed the same

- `findRelatedPosts()` — taxonomy-based scoring, untouched
- `filterAlreadyLinked()` — same logic, now checks concatenated block HTML
- `detectInsertedLink()` — validates AI actually inserted an anchor tag
- `_dm_internal_links` meta tracking
- Job completion/failure patterns
- System agent model config

## Benefits

- **Smaller AI context** — one paragraph instead of entire post
- **Isolated failures** — one failed link doesn't affect others
- **No content corruption** — only touched paragraphs change, block structure preserved
- **Simpler prompts** — AI does one thing: wrap a phrase in an anchor tag