### PR TITLE
feat: Pinterest board selection — cached boards, AI decides, category mapping

### DIFF
--- a/inc/Core/Steps/Publish/Handlers/Pinterest/PinterestSettings.php
+++ b/inc/Core/Steps/Publish/Handlers/Pinterest/PinterestSettings.php
@@ -32,10 +32,27 @@ class PinterestSettings extends PublishHandlerSettings {
 		return array_merge(
 			parent::get_common_fields(),
 			array(
-				'board_id' => array(
+				'board_id'             => array(
 					'type'        => 'text',
 					'label'       => __( 'Default Board ID', 'data-machine' ),
 					'description' => __( 'Pinterest board ID to pin to. Find in board URL.', 'data-machine' ),
+					'default'     => '',
+				),
+				'board_selection_mode' => array(
+					'type'        => 'select',
+					'label'       => __( 'Board Selection Mode', 'data-machine' ),
+					'description' => __( 'How to choose which Pinterest board to pin to.', 'data-machine' ),
+					'default'     => 'pre_selected',
+					'options'     => array(
+						'pre_selected'     => __( 'Pre-selected (use default board)', 'data-machine' ),
+						'ai_decides'       => __( 'AI Decides (agent picks from available boards)', 'data-machine' ),
+						'category_mapping' => __( 'Category Mapping (route by WordPress category)', 'data-machine' ),
+					),
+				),
+				'board_mapping'        => array(
+					'type'        => 'textarea',
+					'label'       => __( 'Category → Board Mapping', 'data-machine' ),
+					'description' => __( 'One mapping per line: category_slug=board_id (e.g., spirituality=123456789). Used when mode is Category Mapping.', 'data-machine' ),
 					'default'     => '',
 				),
 			)


### PR DESCRIPTION
## Summary
Add three board selection modes to Pinterest publish handler, matching the TaxonomyHandler pattern.

### Board Selection Modes
1. **Pre-selected** — Use default board_id from handler config (existing behavior, unchanged)
2. **AI Decides** — Cached board names injected into tool parameter description so AI can pick the best board
3. **Category Mapping** — Deterministic routing based on WordPress post category → board_id mapping

### Board Caching
- Fetch all boards via Pinterest API v5 with pagination (bookmark pattern)
- Cache in `datamachine_pinterest_boards` option with sync timestamp
- `sync_boards()` method for manual/scheduled refresh

### Board Resolution Order
1. AI parameter `board_id` (from tool call)
2. Category mapping lookup (post categories → board_id mapping)
3. Default `board_id` from handler config

### Files Changed
- `Pinterest.php` — Board fetching, caching, resolution logic
- `PinterestSettings.php` — New settings fields (selection mode, category mapping)

Closes #231