### PR TITLE
feat: PinterestAbilities class + CLI subcommand for board management

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -133,6 +133,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/Media/ImageGenerationAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Analytics/BingWebmasterAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/Pinterest/PinterestAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/AgentPingAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/TaxonomyAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/InternalLinkingAbilities.php';
@@ -162,6 +163,7 @@ function datamachine_run_datamachine_plugin() {
 		new \DataMachine\Abilities\Media\ImageGenerationAbilities();
 		new \DataMachine\Abilities\Analytics\BingWebmasterAbilities();
 		new \DataMachine\Abilities\Analytics\GoogleSearchConsoleAbilities();
+		new \DataMachine\Abilities\Pinterest\PinterestAbilities();
 		new \DataMachine\Abilities\AgentPingAbilities();
 		new \DataMachine\Abilities\TaxonomyAbilities();
 		new \DataMachine\Abilities\InternalLinkingAbilities();

--- a/inc/Abilities/Pinterest/PinterestAbilities.php
+++ b/inc/Abilities/Pinterest/PinterestAbilities.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Pinterest Abilities
+ *
+ * Primitive ability for Pinterest board management.
+ * All Pinterest board operations — sync, cache, resolution — flow through this ability.
+ *
+ * @package DataMachine\Abilities\Pinterest
+ * @since 0.28.0
+ */
+
+namespace DataMachine\Abilities\Pinterest;
+
+use DataMachine\Abilities\AuthAbilities;
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+
+defined( 'ABSPATH' ) || exit;
+
+class PinterestAbilities {
+
+	/**
+	 * Option key for storing cached Pinterest boards.
+	 *
+	 * @var string
+	 */
+	const BOARDS_OPTION = 'datamachine_pinterest_boards';
+
+	/**
+	 * Option key for storing last sync timestamp.
+	 *
+	 * @var string
+	 */
+	const BOARDS_SYNCED_OPTION = 'datamachine_pinterest_boards_synced';
+
+	/**
+	 * Whether the ability has been registered.
+	 *
+	 * @var bool
+	 */
+	private static bool $registered = false;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	/**
+	 * Register the Pinterest boards ability.
+	 *
+	 * @return void
+	 */
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/pinterest-boards',
+				[
+					'label'               => 'Pinterest Boards',
+					'description'         => 'Sync, list, and manage Pinterest boards',
+					'category'            => 'datamachine',
+					'input_schema'        => [
+						'type'       => 'object',
+						'required'   => [ 'action' ],
+						'properties' => [
+							'action' => [
+								'type'        => 'string',
+								'description' => 'Action: sync_boards, list_boards, status',
+							],
+						],
+					],
+					'output_schema'       => [
+						'type'       => 'object',
+						'properties' => [
+							'success'       => [ 'type' => 'boolean' ],
+							'boards'        => [ 'type' => 'array' ],
+							'count'         => [ 'type' => 'integer' ],
+							'board_count'   => [ 'type' => 'integer' ],
+							'last_synced'   => [ 'type' => 'string' ],
+							'authenticated' => [ 'type' => 'boolean' ],
+							'error'         => [ 'type' => 'string' ],
+						],
+					],
+					'execute_callback'    => [ self::class, 'execute' ],
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => [ 'show_in_rest' => false ],
+				]
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Execute ability action.
+	 *
+	 * @param array $input Ability input with 'action' key.
+	 * @return array Ability response.
+	 */
+	public static function execute( array $input ): array {
+		$action = sanitize_text_field( $input['action'] ?? '' );
+
+		switch ( $action ) {
+			case 'sync_boards':
+				return self::sync_boards();
+
+			case 'list_boards':
+				return [ 'success' => true, 'boards' => self::get_cached_boards() ];
+
+			case 'status':
+				$status                  = self::get_sync_status();
+				$status['success']       = true;
+				$status['authenticated'] = self::is_configured();
+				return $status;
+
+			default:
+				return [ 'success' => false, 'error' => 'Invalid action. Must be: sync_boards, list_boards, status' ];
+		}
+	}
+
+	/**
+	 * Sync boards from Pinterest API v5.
+	 *
+	 * @return array Result with success, count, and boards.
+	 */
+	public static function sync_boards(): array {
+		$auth     = new AuthAbilities();
+		$provider = $auth->getProvider( 'pinterest' );
+
+		if ( ! $provider || ! $provider->is_authenticated() ) {
+			return [ 'success' => false, 'error' => 'Pinterest not authenticated' ];
+		}
+
+		$config = $provider->get_config();
+		$token  = $config['access_token'] ?? '';
+
+		$all_boards = [];
+		$bookmark   = null;
+
+		for ( $i = 0; $i < 10; $i++ ) {
+			$url = 'https://api.pinterest.com/v5/boards?page_size=100';
+			if ( $bookmark ) {
+				$url .= '&bookmark=' . urlencode( $bookmark );
+			}
+
+			$result = HttpClient::get( $url, [
+				'headers' => [ 'Authorization' => 'Bearer ' . $token ],
+				'timeout' => 15,
+				'context' => 'Pinterest Board Sync',
+			] );
+
+			if ( ! $result['success'] ) {
+				break;
+			}
+
+			$data = json_decode( $result['data'], true );
+
+			foreach ( $data['items'] ?? [] as $board ) {
+				$all_boards[] = [
+					'id'          => $board['id'],
+					'name'        => $board['name'] ?? '',
+					'description' => $board['description'] ?? '',
+				];
+			}
+
+			$bookmark = $data['bookmark'] ?? null;
+			if ( ! $bookmark ) {
+				break;
+			}
+		}
+
+		update_option( self::BOARDS_OPTION, $all_boards );
+		update_option( self::BOARDS_SYNCED_OPTION, time() );
+
+		return [ 'success' => true, 'count' => count( $all_boards ), 'boards' => $all_boards ];
+	}
+
+	/**
+	 * Get cached Pinterest boards.
+	 *
+	 * @return array Array of cached boards.
+	 */
+	public static function get_cached_boards(): array {
+		return get_option( self::BOARDS_OPTION, [] );
+	}
+
+	/**
+	 * Get sync status information.
+	 *
+	 * @return array Board count and last synced timestamp.
+	 */
+	public static function get_sync_status(): array {
+		$boards = self::get_cached_boards();
+		$synced = get_option( self::BOARDS_SYNCED_OPTION, 0 );
+
+		return [
+			'board_count'          => count( $boards ),
+			'last_synced'          => $synced ? gmdate( 'Y-m-d H:i:s', $synced ) : 'never',
+			'last_synced_timestamp' => $synced,
+		];
+	}
+
+	/**
+	 * Resolve board ID based on handler config and post categories.
+	 *
+	 * @param int   $post_id        WordPress post ID.
+	 * @param array $handler_config Handler configuration.
+	 * @return string|null Board ID or null.
+	 */
+	public static function resolve_board_id( int $post_id, array $handler_config ): ?string {
+		$mode = $handler_config['board_selection_mode'] ?? 'pre_selected';
+
+		if ( 'category_mapping' === $mode && $post_id > 0 ) {
+			$lines   = explode( "\n", $handler_config['board_mapping'] ?? '' );
+			$mapping = [];
+
+			foreach ( $lines as $line ) {
+				$line = trim( $line );
+				if ( empty( $line ) || strpos( $line, '=' ) === false ) {
+					continue;
+				}
+				[ $slug, $bid ] = array_map( 'trim', explode( '=', $line, 2 ) );
+				$mapping[ $slug ] = $bid;
+			}
+
+			if ( ! empty( $mapping ) ) {
+				$terms = get_the_terms( $post_id, 'category' );
+				if ( is_array( $terms ) ) {
+					foreach ( $terms as $term ) {
+						if ( isset( $mapping[ $term->slug ] ) ) {
+							return $mapping[ $term->slug ];
+						}
+					}
+				}
+			}
+		}
+
+		// Default fallback.
+		$default = $handler_config['board_id'] ?? '';
+		return ! empty( $default ) ? $default : null;
+	}
+
+	/**
+	 * Check if Pinterest is authenticated and configured.
+	 *
+	 * @return bool
+	 */
+	public static function is_configured(): bool {
+		$auth     = new AuthAbilities();
+		$provider = $auth->getProvider( 'pinterest' );
+		return $provider && $provider->is_authenticated();
+	}
+}

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -36,3 +36,4 @@ WP_CLI::add_command( 'datamachine links', Commands\LinksCommand::class );
 WP_CLI::add_command( 'datamachine link', Commands\LinksCommand::class );
 WP_CLI::add_command( 'datamachine blocks', Commands\BlocksCommand::class );
 WP_CLI::add_command( 'datamachine block', Commands\BlocksCommand::class );
+WP_CLI::add_command( 'datamachine pinterest', Commands\PinterestCommand::class );

--- a/inc/Cli/Commands/PinterestCommand.php
+++ b/inc/Cli/Commands/PinterestCommand.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * WP-CLI Pinterest Command
+ *
+ * Provides CLI access to Pinterest board management.
+ *
+ * @package DataMachine\Cli\Commands
+ * @since 0.28.0
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Abilities\Pinterest\PinterestAbilities;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manage Pinterest integration for Data Machine.
+ *
+ * ## EXAMPLES
+ *
+ *     wp datamachine pinterest sync-boards
+ *     wp datamachine pinterest list-boards
+ *     wp datamachine pinterest status
+ */
+class PinterestCommand extends BaseCommand {
+
+	/**
+	 * Sync Pinterest boards from API.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine pinterest sync-boards
+	 *
+	 * @subcommand sync-boards
+	 */
+	public function sync_boards( $args, $assoc_args ) {
+		WP_CLI::log( 'Syncing Pinterest boards...' );
+		$result = PinterestAbilities::sync_boards();
+
+		if ( $result['success'] ) {
+			WP_CLI::success( "Synced {$result['count']} boards." );
+			$this->format_items( $result['boards'], [ 'id', 'name', 'description' ], $assoc_args );
+		} else {
+			WP_CLI::error( $result['error'] );
+		}
+	}
+
+	/**
+	 * List cached Pinterest boards.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine pinterest list-boards
+	 *     wp datamachine pinterest list-boards --format=json
+	 *
+	 * @subcommand list-boards
+	 */
+	public function list_boards( $args, $assoc_args ) {
+		$boards = PinterestAbilities::get_cached_boards();
+
+		if ( empty( $boards ) ) {
+			WP_CLI::warning( 'No cached boards. Run: wp datamachine pinterest sync-boards' );
+			return;
+		}
+
+		$this->format_items( $boards, [ 'id', 'name', 'description' ], $assoc_args );
+	}
+
+	/**
+	 * Show Pinterest integration status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine pinterest status
+	 */
+	public function status( $args, $assoc_args ) {
+		$authenticated = PinterestAbilities::is_configured();
+		$sync_status   = PinterestAbilities::get_sync_status();
+
+		WP_CLI::log( 'Pinterest Integration Status' );
+		WP_CLI::log( '---' );
+		WP_CLI::log( 'Authenticated: ' . ( $authenticated ? 'Yes ✓' : 'No ✗' ) );
+		WP_CLI::log( 'Cached boards: ' . $sync_status['board_count'] );
+		WP_CLI::log( 'Last synced: ' . $sync_status['last_synced'] );
+	}
+}

--- a/inc/Core/Steps/Publish/Handlers/Pinterest/Pinterest.php
+++ b/inc/Core/Steps/Publish/Handlers/Pinterest/Pinterest.php
@@ -15,6 +15,7 @@
 namespace DataMachine\Core\Steps\Publish\Handlers\Pinterest;
 
 use DataMachine\Abilities\AuthAbilities;
+use DataMachine\Abilities\Pinterest\PinterestAbilities;
 use DataMachine\Core\EngineData;
 use DataMachine\Core\Steps\Publish\Handlers\PublishHandler;
 use DataMachine\Core\Steps\HandlerRegistrationTrait;
@@ -56,7 +57,7 @@ class Pinterest extends PublishHandler {
 					// Inject cached board names when AI decides mode is active.
 					$mode = $handler_config['board_selection_mode'] ?? 'pre_selected';
 					if ( 'ai_decides' === $mode ) {
-						$cached_boards = get_option( 'datamachine_pinterest_boards', array() );
+						$cached_boards = PinterestAbilities::get_cached_boards();
 						if ( ! empty( $cached_boards ) ) {
 							$board_list = implode( ', ', array_map( function ( $b ) {
 								return $b['name'] . ' (' . $b['id'] . ')';
@@ -279,128 +280,22 @@ class Pinterest extends PublishHandler {
 			return $parameters['board_id'];
 		}
 
-		// 2. Mode-based resolution.
-		$mode = $handler_config['board_selection_mode'] ?? 'pre_selected';
-
-		if ( 'category_mapping' === $mode && $engine ) {
-			$post_id = null;
+		// 2. Delegate to abilities for mode-based resolution.
+		$post_id = 0;
+		if ( $engine ) {
 			$source_url = $engine->getSourceUrl();
 			if ( ! empty( $source_url ) ) {
 				$post_id = url_to_postid( $source_url );
 			}
-
-			if ( $post_id > 0 ) {
-				$lines   = explode( "\n", $handler_config['board_mapping'] ?? '' );
-				$mapping = array();
-				foreach ( $lines as $line ) {
-					$line = trim( $line );
-					if ( empty( $line ) || strpos( $line, '=' ) === false ) {
-						continue;
-					}
-					[ $slug, $bid ] = array_map( 'trim', explode( '=', $line, 2 ) );
-					$mapping[ $slug ] = $bid;
-				}
-
-				if ( ! empty( $mapping ) ) {
-					$terms = get_the_terms( $post_id, 'category' );
-					if ( is_array( $terms ) ) {
-						foreach ( $terms as $term ) {
-							if ( isset( $mapping[ $term->slug ] ) ) {
-								$this->log(
-									'info',
-									'Pinterest: Board ID from category mapping',
-									array(
-										'category' => $term->slug,
-										'board_id' => $mapping[ $term->slug ],
-									)
-								);
-								return $mapping[ $term->slug ];
-							}
-						}
-					}
-				}
-			}
 		}
 
-		// 3. Default fallback.
-		$default = $handler_config['board_id'] ?? '';
-		return ! empty( $default ) ? $default : null;
-	}
-
-	/**
-	 * Fetch all boards from Pinterest API v5 with pagination.
-	 *
-	 * @since 0.3.0
-	 *
-	 * @return array Array of boards with id, name, and description.
-	 */
-	public function fetch_boards(): array {
-		$auth = $this->get_auth();
-		if ( ! $auth ) {
-			$this->log( 'error', 'Pinterest: Cannot fetch boards — auth not available' );
-			return array();
+		$board_id = PinterestAbilities::resolve_board_id( $post_id, $handler_config );
+		if ( $board_id ) {
+			$this->log( 'info', 'Pinterest: Board ID from abilities resolution', array( 'board_id' => $board_id ) );
+			return $board_id;
 		}
 
-		$config = $auth->get_config();
-		$token  = $config['access_token'] ?? '';
-
-		if ( empty( $token ) ) {
-			$this->log( 'error', 'Pinterest: Cannot fetch boards — access token empty' );
-			return array();
-		}
-
-		$all_boards = array();
-		$bookmark   = null;
-
-		for ( $i = 0; $i < 10; $i++ ) {
-			$url = 'https://api.pinterest.com/v5/boards?page_size=100';
-			if ( $bookmark ) {
-				$url .= '&bookmark=' . urlencode( $bookmark );
-			}
-
-			$result = $this->httpGet( $url, array(
-				'headers' => array( 'Authorization' => 'Bearer ' . $token ),
-				'context' => 'Pinterest Board Sync',
-			) );
-
-			if ( ! $result['success'] ) {
-				$this->log( 'error', 'Pinterest: Board fetch failed', array( 'error' => $result['error'] ?? 'Unknown' ) );
-				break;
-			}
-
-			$data = json_decode( $result['data'], true );
-			foreach ( $data['items'] ?? array() as $board ) {
-				$all_boards[] = array(
-					'id'          => $board['id'],
-					'name'        => $board['name'] ?? '',
-					'description' => $board['description'] ?? '',
-				);
-			}
-
-			$bookmark = $data['bookmark'] ?? null;
-			if ( ! $bookmark ) {
-				break;
-			}
-		}
-
-		$this->log( 'info', 'Pinterest: Fetched boards', array( 'count' => count( $all_boards ) ) );
-
-		return $all_boards;
-	}
-
-	/**
-	 * Fetch and cache all Pinterest boards.
-	 *
-	 * @since 0.3.0
-	 *
-	 * @return array Array of cached boards.
-	 */
-	public function sync_boards(): array {
-		$boards = $this->fetch_boards();
-		update_option( 'datamachine_pinterest_boards', $boards );
-		update_option( 'datamachine_pinterest_boards_synced', time() );
-		$this->log( 'info', 'Pinterest: Boards synced', array( 'count' => count( $boards ) ) );
-		return $boards;
+		return null;
 	}
 
 	/**
@@ -411,7 +306,7 @@ class Pinterest extends PublishHandler {
 	 * @return array Array of cached boards.
 	 */
 	public function get_cached_boards(): array {
-		return get_option( 'datamachine_pinterest_boards', array() );
+		return PinterestAbilities::get_cached_boards();
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Extract Pinterest board logic from handler into proper abilities layer + CLI access.

### Problem
PR #298 added board selection but put all logic (API calls, caching, resolution) directly on the handler class. This bypasses the abilities architecture — every other integration (Bing, GSC, image gen) uses abilities as the universal primitive.

### Solution

**New: `PinterestAbilities`** (`inc/Abilities/Pinterest/PinterestAbilities.php`)
- `sync_boards()` — fetch from Pinterest API v5 + cache in WP options
- `get_cached_boards()` — read cached boards
- `get_sync_status()` — board count + last sync timestamp
- `resolve_board_id()` — category mapping resolution logic
- `is_configured()` — auth check
- Registered as `datamachine/pinterest-boards` ability

**New: `PinterestCommand`** (`inc/Cli/Commands/PinterestCommand.php`)
- `wp datamachine pinterest sync-boards` — trigger board sync
- `wp datamachine pinterest list-boards` — show cached boards
- `wp datamachine pinterest status` — auth + sync status

**Modified: `Pinterest.php`**
Handler delegates to PinterestAbilities instead of owning API/cache logic.

**Modified: `Bootstrap.php`** + **`data-machine.php`**
Register CLI command and abilities class.

### Architecture
Follows the same pattern as BingWebmasterAbilities/GoogleSearchConsoleAbilities:
- Abilities = primitive operations (API calls, caching, resolution)
- CLI = wraps abilities for terminal access
- Handler = thin wrapper that delegates to abilities

Closes #300