### PR TITLE
feat: CLI commands for managing publish step handlers

### DIFF
--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -499,15 +499,17 @@ class PipelineStepAbilities {
 			);
 		}
 
-		$system_prompt  = $input['system_prompt'] ?? null;
-		$provider       = $input['provider'] ?? null;
-		$model          = $input['model'] ?? null;
-		$disabled_tools = $input['disabled_tools'] ?? null;
+		$system_prompt   = $input['system_prompt'] ?? null;
+		$provider        = $input['provider'] ?? null;
+		$model           = $input['model'] ?? null;
+		$disabled_tools  = $input['disabled_tools'] ?? null;
+		$handler_slugs   = $input['handler_slugs'] ?? null;
+		$handler_configs = $input['handler_configs'] ?? null;
 
-		if ( null === $system_prompt && null === $provider && null === $model && null === $disabled_tools ) {
+		if ( null === $system_prompt && null === $provider && null === $model && null === $disabled_tools && null === $handler_slugs && null === $handler_configs ) {
 			return array(
 				'success' => false,
-				'error'   => 'At least one of system_prompt, provider, model, or disabled_tools is required',
+				'error'   => 'At least one of system_prompt, provider, model, disabled_tools, handler_slugs, or handler_configs is required',
 			);
 		}
 
@@ -568,6 +570,18 @@ class PipelineStepAbilities {
 
 			$step_config_data['disabled_tools'] = $tools_manager->save_step_tool_selections( $pipeline_step_id, $sanitized_tool_ids );
 			$updated_fields[]                   = 'disabled_tools';
+		}
+
+		if ( null !== $handler_slugs && is_array( $handler_slugs ) ) {
+			$step_config_data['handler_slugs'] = array_map( 'sanitize_text_field', $handler_slugs );
+			$updated_fields[]                  = 'handler_slugs';
+		}
+
+		if ( null !== $handler_configs && is_array( $handler_configs ) ) {
+			// Merge with existing handler_configs, don't replace.
+			$existing_handler_configs          = $existing_config['handler_configs'] ?? array();
+			$step_config_data['handler_configs'] = array_merge( $existing_handler_configs, $handler_configs );
+			$updated_fields[]                  = 'handler_configs';
 		}
 
 		$pipeline_config[ $pipeline_step_id ] = array_merge( $existing_config, $step_config_data );


### PR DESCRIPTION
## Summary
Add handler management CLI commands + extend abilities layer.

### Problem
Adding/removing handlers on pipeline publish steps requires `wp eval` with direct DB access, bypassing the abilities layer entirely.

### Solution

**Extended: `PipelineStepAbilities.executeUpdatePipelineStep()`**
- Now accepts `handler_slugs` (array) and `handler_configs` (associative array)
- Merges handler_configs with existing (additive, not destructive)

**New CLI subcommands on `wp datamachine pipelines`:**
- `add-handler <pipeline_id> --handler=<slug> [--step=<step_id>] [--config=<json>]`
- `remove-handler <pipeline_id> --handler=<slug> [--step=<step_id>]`
- `list-handlers <pipeline_id> [--step=<step_id>]`

Auto-resolves publish step when pipeline has exactly one (same pattern as `resolveAiStep`).

### Examples
```bash
# List handlers
wp datamachine pipelines list-handlers 12

# Add Pinterest to content pipeline
wp datamachine pipelines add-handler 12 --handler=pinterest_publish \
  --config='{"board_selection_mode":"ai_decides"}'

# Remove a handler
wp datamachine pipelines remove-handler 12 --handler=pinterest_publish
```

Closes #302