### PR TITLE
fix: Add set() method to EngineData class

### DIFF
--- a/inc/Core/EngineData.php
+++ b/inc/Core/EngineData.php
@@ -121,6 +121,21 @@ class EngineData {
 	}
 
 	/**
+	 * Set a value in the engine data and persist it.
+	 *
+	 * @param string $key   Data key.
+	 * @param mixed  $value Value to set.
+	 * @return void
+	 */
+	public function set( string $key, $value ): void {
+		$this->data[ $key ] = $value;
+
+		if ( $this->job_id ) {
+			self::merge( (int) $this->job_id, array( $key => $value ) );
+		}
+	}
+
+	/**
 	 * Get a value from the engine data.
 	 *
 	 * @param string $key Data key.


### PR DESCRIPTION
## Problem
`AIStep.php` line 122 and `AgentPingStep.php` line 151 both call `$this->engine->set('job_status', ...)` but `EngineData` only had `get()`, static `merge()`, `persist()`, and `retrieve()` methods.

This caused `Call to undefined method DataMachine\Core\EngineData::set()` errors that broke:
- **Content Generation** (Flow 29, Job 1485)
- **Recipe Generation** (Flow 45, Job 1480)

## Fix
Adds a `set()` instance method that updates the in-memory data array and persists via the existing `merge()` mechanism.

## Already deployed
Fix was applied directly to production earlier today to unblock pipelines. This PR brings the repo in sync.

Closes #317 (if you want me to file a bug issue too)