### PR TITLE
refactor: Space out directive priorities for extensibility

### DIFF
--- a/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Pipeline Memory Files Directive - Priority 25
+ * Pipeline Memory Files Directive - Priority 40
  *
  * Injects agent memory files referenced by pipeline configuration into AI context.
  * Memory files are stored in the shared agent/ directory and selected per-pipeline.
@@ -8,11 +8,12 @@
  * Priority Order in Directive System:
  * 1. Priority 10 - Plugin Core Directive (agent identity)
  * 2. Priority 20 - Agent SOUL.md (identity)
- * 3. Priority 22 - Agent MEMORY.md (knowledge)
- * 4. Priority 25 - Pipeline Memory Files (THIS CLASS - per-pipeline selectable)
- * 5. Priority 30 - Pipeline System Prompt (pipeline instructions)
- * 6. Priority 40 - Tool Definitions (available tools and workflow)
- * 7. Priority 50 - Site Context (WordPress metadata)
+ * 3. Priority 30 - Agent MEMORY.md (knowledge)
+ * 4. Priority 40 - Pipeline Memory Files (THIS CLASS - per-pipeline selectable)
+ * 5. Priority 50 - Pipeline System Prompt (pipeline instructions)
+ * 6. Priority 60 - Pipeline Context Files
+ * 7. Priority 70 - Tool Definitions (available tools and workflow)
+ * 8. Priority 80 - Site Context (WordPress metadata)
  *
  * @package DataMachine\Core\Steps\AI\Directives
  */
@@ -103,13 +104,13 @@ class PipelineMemoryFilesDirective implements \DataMachine\Engine\AI\Directives\
 	}
 }
 
-// Register at Priority 25 — between MEMORY.md (22) and pipeline system prompt (30).
+// Register at Priority 40 — between MEMORY.md (30) and pipeline system prompt (50).
 add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
 		$directives[] = array(
 			'class'       => PipelineMemoryFilesDirective::class,
-			'priority'    => 25,
+			'priority'    => 40,
 			'agent_types' => array( 'pipeline' ),
 		);
 		return $directives;

--- a/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Pipeline System Prompt Directive - Priority 30
+ * Pipeline System Prompt Directive - Priority 50
  *
  * Injects user-configured task instructions and dynamic workflow visualization
  * as the third directive in the 5-tier AI directive system. Provides both workflow
@@ -9,10 +9,13 @@
  *
  * Priority Order in 5-Tier System:
  * 1. Priority 10 - Plugin Core Directive
- * 2. Priority 20 - Global System Prompt
- * 3. Priority 30 - Pipeline System Prompt (THIS CLASS)
- * 4. Priority 40 - Tool Definitions and Workflow Context
- * 5. Priority 50 - WordPress Site Context
+ * 2. Priority 20 - Agent SOUL.md (identity)
+ * 3. Priority 30 - Agent MEMORY.md (knowledge)
+ * 4. Priority 40 - Pipeline Memory Files (per-pipeline selectable)
+ * 5. Priority 50 - Pipeline System Prompt (THIS CLASS)
+ * 6. Priority 60 - Pipeline Context Files
+ * 7. Priority 70 - Tool Definitions and Workflow Context
+ * 8. Priority 80 - WordPress Site Context
  */
 
 namespace DataMachine\Core\Steps\AI\Directives;
@@ -152,13 +155,13 @@ class PipelineSystemPromptDirective implements \DataMachine\Engine\AI\Directives
 	}
 }
 
-// Register with universal agent directive system (Priority 30 = third in 5-tier directive system)
+// Register with universal agent directive system (Priority 50 = pipeline system prompt)
 add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
 		$directives[] = array(
 			'class'       => PipelineSystemPromptDirective::class,
-			'priority'    => 30,
+			'priority'    => 50,
 			'agent_types' => array( 'pipeline' ),
 		);
 		return $directives;

--- a/inc/Engine/AI/Directives/AgentMemoryDirective.php
+++ b/inc/Engine/AI/Directives/AgentMemoryDirective.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Agent Memory Directive - Priority 22
+ * Agent Memory Directive - Priority 30
  *
  * Injects the agent memory from MEMORY.md in the files repository as context
  * for every AI call. Defines WHAT the agent knows — accumulated state, lessons,
@@ -9,11 +9,12 @@
  * Priority Order in Directive System:
  * 1. Priority 10 - Plugin Core Directive
  * 2. Priority 20 - Agent SOUL.md (identity)
- * 3. Priority 22 - Agent MEMORY.md (THIS CLASS - knowledge)
- * 4. Priority 25 - Pipeline Memory Files (per-pipeline selectable)
- * 5. Priority 30 - Pipeline System Prompt
- * 6. Priority 40 - Tool Definitions and Workflow Context
- * 7. Priority 50 - WordPress Site Context
+ * 3. Priority 30 - Agent MEMORY.md (THIS CLASS - knowledge)
+ * 4. Priority 40 - Pipeline Memory Files (per-pipeline selectable)
+ * 5. Priority 50 - Pipeline System Prompt
+ * 6. Priority 60 - Pipeline Context Files
+ * 7. Priority 70 - Tool Definitions and Workflow Context
+ * 8. Priority 80 - WordPress Site Context
  */
 
 namespace DataMachine\Engine\AI\Directives;
@@ -49,13 +50,13 @@ class AgentMemoryDirective implements DirectiveInterface {
 	}
 }
 
-// Self-register (Priority 22 = agent memory/knowledge for all AI agents).
+// Self-register (Priority 30 = agent memory/knowledge for all AI agents).
 add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
 		$directives[] = array(
 			'class'       => AgentMemoryDirective::class,
-			'priority'    => 22,
+			'priority'    => 30,
 			'agent_types' => array( 'all' ),
 		);
 		return $directives;

--- a/inc/Engine/AI/Directives/AgentSoulDirective.php
+++ b/inc/Engine/AI/Directives/AgentSoulDirective.php
@@ -11,11 +11,12 @@
  * Priority Order in Directive System:
  * 1. Priority 10 - Plugin Core Directive
  * 2. Priority 20 - Agent Soul (THIS CLASS)
- * 3. Priority 22 - Agent Memory (MEMORY.md - knowledge)
- * 4. Priority 25 - Pipeline Memory Files (per-pipeline selectable)
- * 5. Priority 30 - Pipeline System Prompt
- * 6. Priority 40 - Tool Definitions and Workflow Context
- * 7. Priority 50 - WordPress Site Context
+ * 3. Priority 30 - Agent Memory (MEMORY.md - knowledge)
+ * 4. Priority 40 - Pipeline Memory Files (per-pipeline selectable)
+ * 5. Priority 50 - Pipeline System Prompt
+ * 6. Priority 60 - Pipeline Context Files
+ * 7. Priority 70 - Tool Definitions and Workflow Context
+ * 8. Priority 80 - WordPress Site Context
  */
 
 namespace DataMachine\Engine\AI\Directives;

--- a/inc/Engine/AI/Directives/SiteContextDirective.php
+++ b/inc/Engine/AI/Directives/SiteContextDirective.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Site Context Directive - Priority 50 (Lowest Priority)
+ * Site Context Directive - Priority 80 (Lowest Priority)
  *
  * Injects WordPress site context information as the final directive in the
  * 5-tier AI directive system. Provides comprehensive site metadata including
@@ -8,10 +8,13 @@
  *
  * Priority Order in 5-Tier System:
  * 1. Priority 10 - Plugin Core Directive
- * 2. Priority 20 - Global System Prompt
- * 3. Priority 30 - Pipeline System Prompt
- * 4. Priority 40 - Tool Definitions and Workflow Context
- * 5. Priority 50 - WordPress Site Context (THIS CLASS)
+ * 2. Priority 20 - Agent SOUL.md (identity)
+ * 3. Priority 30 - Agent MEMORY.md (knowledge)
+ * 4. Priority 40 - Pipeline Memory Files (per-pipeline selectable)
+ * 5. Priority 50 - Pipeline System Prompt
+ * 6. Priority 60 - Pipeline Context Files
+ * 7. Priority 70 - Tool Definitions and Workflow Context
+ * 8. Priority 80 - WordPress Site Context (THIS CLASS)
  */
 
 namespace DataMachine\Engine\AI\Directives;
@@ -69,7 +72,7 @@ if ( $datamachine_site_context_directive ) {
 		function ( $directives ) use ( $datamachine_site_context_directive ) {
 			$directives[] = array(
 				'class'       => $datamachine_site_context_directive,
-				'priority'    => 50,
+				'priority'    => 80,
 				'agent_types' => array( 'all' ),
 			);
 			return $directives;

--- a/skills/data-machine/SKILL.md
+++ b/skills/data-machine/SKILL.md
@@ -73,14 +73,14 @@ System prompts are injected in priority order into every AI call:
 |----------|-----------|-------|
 | 10 | Plugin Core | Hardcoded agent identity |
 | 20 | Agent SOUL.md | Global AI personality (identity, voice, rules) |
-| 22 | Agent MEMORY.md | Accumulated knowledge (state, lessons, context) |
-| 25 | Pipeline Memory Files | Per-pipeline selected memory files |
-| 30 | Pipeline System Prompt | Per-pipeline AI step instructions |
-| 35 | Pipeline Context Files | Uploaded reference materials |
-| 40 | Tool Definitions | Available tools and workflow context |
-| 50 | Site Context | WordPress metadata |
+| 30 | Agent MEMORY.md | Accumulated knowledge (state, lessons, context) |
+| 40 | Pipeline Memory Files | Per-pipeline selected memory files |
+| 50 | Pipeline System Prompt | Per-pipeline AI step instructions |
+| 60 | Pipeline Context Files | Uploaded reference materials (reserved) |
+| 70 | Tool Definitions | Available tools and workflow context (reserved) |
+| 80 | Site Context | WordPress metadata |
 
-**Key:** SOUL.md (Priority 20) and MEMORY.md (Priority 22) are always injected into every AI call. SOUL.md defines *who* the agent is. MEMORY.md defines *what* the agent knows. Other memory files are selectable per-pipeline via the admin UI.
+**Key:** SOUL.md (Priority 20) and MEMORY.md (Priority 30) are always injected into every AI call. SOUL.md defines *who* the agent is. MEMORY.md defines *what* the agent knows. Other memory files are selectable per-pipeline via the admin UI. Priorities are spaced by 10 to allow future additions (e.g., 15, 25, 35) without rebasing.
 
 ### Scheduling Options
 
@@ -103,8 +103,8 @@ Data Machine has file-based agent memory in `{wp-content}/uploads/datamachine-fi
 
 1. Files live in the agent directory (managed via Admin UI or REST API)
 2. **SOUL.md** is always injected at Priority 20 — defines agent identity, voice, and rules
-3. **MEMORY.md** is always injected at Priority 22 — accumulated state, lessons learned, and domain context
-4. Other files can be selected per-pipeline as memory file references (Priority 25)
+3. **MEMORY.md** is always injected at Priority 30 — accumulated state, lessons learned, and domain context
+4. Other files can be selected per-pipeline as memory file references (Priority 40)
 5. Selected files are injected as system context — the AI sees them every execution
 
 ### REST API


### PR DESCRIPTION
## What
Reorders directive priorities from tight spacing (10/20/22/25/30/40/50) to wider spacing (10/20/30/40/50/60/70/80).

## Why
Makes room for a new Pipeline Context Files directive at priority 60 without priority collisions. The old 22/25 spacing left no room to insert anything between tiers.

## Impact
No behavioral change — same execution order, just wider gaps between priorities.

## New priority map
| Priority | Directive |
|----------|-----------|
| 10 | Plugin Core |
| 20 | Agent SOUL.md |
| 30 | Agent MEMORY.md |
| 40 | Pipeline Memory Files |
| 50 | Pipeline System Prompt |
| 60 | Pipeline Context Files (new slot) |
| 70 | Tool Definitions |
| 80 | Site Context |