### PR TITLE
Add comprehensive SKILL.md for AI agent usage

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,563 @@
+---
+name: data-machine
+description: "Self-scheduling execution layer for autonomous task orchestration. Use for queuing tasks, chaining pipeline executions, scheduling recurring work, and 24/7 autonomous operation via Agent Ping webhooks."
+compatibility: "WordPress 6.9+ with Data Machine plugin. WP-CLI required for queue management."
+---
+
+# Data Machine Skill
+
+**A self-scheduling execution layer for AI agents.** Not just content automation — it's how agents schedule themselves to achieve goals autonomously.
+
+## When to Use This Skill
+
+Use this skill when:
+- Setting up automated workflows (content generation, publishing, notifications)
+- Creating self-scheduling patterns (reminders, recurring tasks)
+- Building multi-phase projects with queued task progression
+- Configuring Agent Ping webhooks to trigger external agents
+- Managing content blocks, internal links, alt text, or Pinterest integration
+- Debugging failed jobs or recovering stuck pipelines
+
+---
+
+## Core Philosophy
+
+Data Machine is designed with AI agents as primary users. It functions as a **reminder system + task manager + workflow executor** all in one.
+
+### Three Key Concepts
+
+1. **Flows operate on schedules** — Configure "ping me at X time to do Y"
+2. **Step-level prompt queues** — Each ping can be a different task instruction
+3. **Multiple purpose-specific flows** — Separate flows for separate concerns
+
+### Mental Model
+
+| Role | How It Works |
+|------|--------------|
+| **Reminder System** | Flows run on schedules (daily, hourly, cron) and ping the agent |
+| **Task Manager** | Queues hold task backlog; each run pops the next task |
+| **Workflow Executor** | Pipeline steps execute work (AI generation, publishing, API calls) |
+
+---
+
+## Architecture Overview
+
+### Execution Model
+
+```
+Pipeline (template) → Flow (instance) → Job (execution)
+```
+
+- **Pipeline**: Reusable workflow template with ordered steps
+- **Flow**: Instance of a pipeline with specific configuration and schedule
+- **Job**: Single execution of a flow
+
+### Step Types
+
+| Type | Purpose | Has Queue | Has Handlers |
+|------|---------|-----------|-------------|
+| `fetch` | Import data from external sources | No | Yes |
+| `ai` | Process with AI (multi-turn, tools) | **Yes** | No |
+| `publish` | Output to platforms | No | Yes |
+| `update` | Modify existing content | No | Yes |
+| `agent_ping` | Webhook to external agents | **Yes** | No |
+| `webhook_gate` | Pause pipeline until external webhook fires | No | No |
+
+### Fetch Handlers
+
+| Handler | Source |
+|---------|--------|
+| `rss` | RSS/Atom feeds |
+| `google_sheets` | Google Sheets |
+| `files` | Local/remote files |
+| `reddit` | Reddit posts/comments |
+| `wordpress` | WordPress posts (local) |
+| `wordpress_api` | WordPress REST API (remote) |
+| `wordpress_media` | WordPress media library |
+
+### Publish Handlers
+
+| Handler | Destination |
+|---------|------------|
+| `wordpress_publish` | WordPress posts |
+| `pinterest_publish` | Pinterest pins |
+| `twitter` | Twitter/X posts |
+| `bluesky` | Bluesky posts |
+| `facebook` | Facebook posts |
+| `threads` | Threads posts |
+| `google_sheets` | Google Sheets |
+
+### Update Handlers
+
+| Handler | Target |
+|---------|--------|
+| `wordpress` | WordPress post content |
+
+### Webhook Gate
+
+A handler-free step type that pauses the pipeline and generates a unique webhook URL. When the webhook receives a POST, the pipeline resumes with the webhook payload injected as data packets. Configurable timeout (default: 7-day token expiry).
+
+### Scheduling Options
+
+Configure via `--scheduling` flag on flow create/update:
+
+| Interval | Behavior |
+|----------|----------|
+| `manual` | Only runs when triggered via UI or CLI |
+| `daily` | Runs once per day |
+| `hourly` | Runs once per hour |
+| Cron expression | e.g., `0 9 * * 1` for Mondays at 9am |
+
+---
+
+## CLI Reference
+
+**Note:** All commands accept `--allow-root` when running as root. Singular and plural aliases work interchangeably (`flow`/`flows`, `job`/`jobs`, `pipeline`/`pipelines`, `post`/`posts`, `block`/`blocks`, `link`/`links`, `log`/`logs`).
+
+### Pipelines
+
+```bash
+# List all pipelines
+wp datamachine pipelines [--per_page=<n>] [--offset=<n>] [--format=table|json|csv|yaml|ids|count] [--fields=<fields>]
+
+# Get a specific pipeline
+wp datamachine pipelines get <pipeline_id>
+# or: wp datamachine pipelines <pipeline_id>
+
+# Create a pipeline
+wp datamachine pipelines create --name="My Pipeline" [--steps='[{"step_type":"fetch"},{"step_type":"ai"}]'] [--dry-run]
+
+# Update a pipeline
+wp datamachine pipelines update <pipeline_id> [--name=<name>] [--config=<json>]
+
+# Update system prompt on AI step
+wp datamachine pipelines update <id> --set-system-prompt="Write a blog post..."
+# Target specific step if multiple AI steps:
+wp datamachine pipelines update <id> --step=<pipeline_step_id> --set-system-prompt="..."
+
+# Delete a pipeline
+wp datamachine pipelines delete <pipeline_id> [--force]
+```
+
+### Flows
+
+```bash
+# List flows (all, or for a pipeline)
+wp datamachine flows [<pipeline_id>] [--handler=<slug>] [--per_page=<n>] [--offset=<n>] [--format=table|json|csv|yaml|ids|count]
+
+# Get a specific flow
+wp datamachine flows get <flow_id>
+# or: wp datamachine flows --id=<flow_id>
+
+# Create a flow
+wp datamachine flows create --pipeline_id=<id> --name="My Flow" [--scheduling=manual|hourly|daily] [--step_configs=<json>] [--dry-run]
+
+# Update a flow
+wp datamachine flows update <flow_id> [--name=<name>] [--scheduling=<interval>]
+
+# Update prompt on handler step
+wp datamachine flows update <flow_id> --set-prompt="New prompt" [--step=<flow_step_id>]
+
+# Run a flow
+wp datamachine flows run <flow_id> [--count=<1-10>] [--timestamp=<unix>]
+
+# Delete a flow
+wp datamachine flows delete <flow_id> [--yes]
+```
+
+### Queues
+
+Both AI and Agent Ping steps support queues via `QueueableTrait`. If the configured prompt is empty and `queue_enabled` is true, the step pops from its queue.
+
+```bash
+# Add to queue (--step auto-resolved if flow has one queueable step)
+wp datamachine flows queue add <flow_id> "Task instruction here" [--step=<flow_step_id>]
+
+# List queue contents
+wp datamachine flows queue list <flow_id> [--format=table|json]
+
+# Remove by index
+wp datamachine flows queue remove <flow_id> <index>
+
+# Update prompt at index
+wp datamachine flows queue update <flow_id> <index> "Updated prompt text"
+
+# Move prompt from one position to another
+wp datamachine flows queue move <flow_id> <from_index> <to_index>
+
+# Clear entire queue
+wp datamachine flows queue clear <flow_id>
+```
+
+### Jobs
+
+```bash
+# List jobs
+wp datamachine jobs list [--status=pending|processing|completed|failed|agent_skipped|completed_no_items] [--flow=<flow_id>] [--source=pipeline|system] [--limit=<n>] [--format=table|json|csv|yaml|ids|count]
+
+# Show job details (includes engine_data in JSON format)
+wp datamachine jobs show <job_id> [--format=table|json|yaml]
+
+# Status summary
+wp datamachine jobs summary [--format=table|json|csv]
+
+# Manually fail a processing job
+wp datamachine jobs fail <job_id> [--reason=<reason>]
+
+# Retry a failed/stuck job (requeues prompt if backup exists)
+wp datamachine jobs retry <job_id> [--force]
+
+# Recover stuck jobs (processing but with status override in engine_data)
+wp datamachine jobs recover-stuck [--dry-run] [--flow=<flow_id>] [--timeout=<hours>]
+```
+
+### Settings
+
+```bash
+wp datamachine settings list
+wp datamachine settings get <key>
+wp datamachine settings set <key> <value>
+```
+
+### Logs
+
+```bash
+# Read log entries
+wp datamachine logs read <agent_type>  # agent_type: pipeline, system, chat
+
+# Log file metadata
+wp datamachine logs info <agent_type>
+
+# Get or set log level
+wp datamachine logs level <agent_type> [<level>]
+
+# Clear logs
+wp datamachine logs clear <agent_type|all> [--yes]
+```
+
+### Posts (Query by Data Machine metadata)
+
+```bash
+# Query posts created by a specific flow
+wp datamachine posts by-flow <flow_id> [--post_type=<type>] [--post_status=<status>] [--per_page=<n>] [--format=table|json|csv|yaml|ids|count]
+
+# Query posts by handler slug
+wp datamachine posts by-handler <handler_slug> [--post_type=<type>] [--per_page=<n>]
+
+# Query posts by pipeline
+wp datamachine posts by-pipeline <pipeline_id> [--post_type=<type>] [--per_page=<n>]
+```
+
+### Blocks (Gutenberg block editing)
+
+```bash
+# List blocks in a post
+wp datamachine blocks list <post_id> [--type=<block_type>] [--search=<text>] [--format=table|json|csv]
+
+# Find/replace within a specific block
+wp datamachine blocks edit <post_id> <block_index> --find=<text> --replace=<text> [--dry-run]
+
+# Replace entire block content
+wp datamachine blocks replace <post_id> <block_index> --content="<p>New HTML</p>"
+```
+
+### Internal Links
+
+```bash
+# Diagnose internal link coverage across published posts
+wp datamachine links diagnose [--format=table|json|csv]
+
+# Queue cross-linking for posts
+wp datamachine links crosslink [--post_id=<id>] [--category=<slug>] [--all] [--links-per-post=<n>] [--force] [--dry-run]
+```
+
+### Alt Text
+
+```bash
+# Diagnose alt text coverage
+wp datamachine alt-text diagnose [--format=table|json|csv]
+
+# Queue alt text generation
+wp datamachine alt-text generate [--attachment_id=<id>] [--post_id=<id>] [--force]
+```
+
+### Pinterest
+
+```bash
+# Check Pinterest integration status
+wp datamachine pinterest status
+
+# List cached boards
+wp datamachine pinterest list-boards [--format=table|json|csv]
+
+# Sync boards from API
+wp datamachine pinterest sync-boards
+```
+
+---
+
+## Prompt Queues
+
+This enables **varied task instructions** per execution — not the same prompt every time.
+
+### Chaining Pattern
+
+When an agent receives a ping, it should:
+1. Execute the immediate task
+2. Queue the next logical task (if continuation needed)
+3. Let the cycle continue
+
+```
+Ping: "Phase 1: Design the architecture"
+  → Agent designs, writes DESIGN.md
+  → Agent queues: "Phase 2: Implement schema per DESIGN.md"
+
+Ping: "Phase 2: Implement schema per DESIGN.md"
+  → Agent implements
+  → Agent queues: "Phase 3: Build API endpoints"
+```
+
+The queue becomes the agent's **persistent project memory** — multi-phase work is tracked in the queue, not held in context.
+
+---
+
+## Purpose-Specific Flows
+
+**Critical pattern**: Don't try to do everything in one flow. Create separate flows for separate concerns:
+
+```
+Flow: Content Generation (queue-driven)
+  → AI Step (pops topic from queue) → Publish → Agent Ping
+
+Flow: Content Ideation (daily)
+  → Agent Ping: "Review analytics, add topics to content queue"
+
+Flow: Weekly Review (cron: Monday 9am)
+  → Agent Ping: "Analyze last week's performance"
+
+Flow: Coding Tasks (manual, queue-driven)
+  → Agent Ping (pops from queue): specific coding task instructions
+```
+
+Each flow has its own:
+- **Schedule**: When it runs
+- **Queue**: Task backlog specific to that workflow
+- **Purpose**: Single responsibility, clear scope
+
+---
+
+## Agent Ping Configuration
+
+Agent Ping steps send webhooks to external agent frameworks (OpenClaw, LangChain, custom handlers).
+
+### Handler Configuration
+
+- `webhook_url`: Where to send the ping
+- `prompt`: Static prompt, or leave empty to use queue
+- `queue_enabled`: Whether to pop from queue when prompt is empty
+
+### Webhook Payload
+
+The ping includes:
+- Flow and job context
+- The prompt (from config or queue)
+- Any data from previous steps
+
+**Note**: Data Machine is agent-agnostic. It sends webhooks — whatever listens on the URL handles the prompt.
+
+---
+
+## Chat API (Abilities System)
+
+Data Machine exposes a comprehensive Chat API at `/wp-json/datamachine/v1/chat/` with 30+ tool-based abilities. This powers the admin UI chat interface but can also be used programmatically.
+
+Key ability groups:
+- **Flow management**: Create, list, update, delete, duplicate, run flows
+- **Pipeline management**: Create, list, update, delete, duplicate pipelines
+- **Queue management**: Add, list, clear queue items
+- **Job management**: List, show, fail, retry, recover-stuck, summary, delete jobs
+- **Content**: Get/edit/replace post blocks
+- **Taxonomy**: Get, create, update, delete, merge, resolve terms
+- **Logs**: Read, manage log entries
+- **System**: Health check, problem flows detection
+- **Pinterest**: Board management, pin operations
+- **Analytics**: Bing Webmaster, Google Search Console queries
+- **Settings**: Read/update plugin settings
+
+The REST API also has dedicated endpoints for flows, flow steps, flow queues, pipelines, pipeline steps, jobs, settings, logs, and more under `/wp-json/datamachine/v1/`.
+
+---
+
+## Taxonomy Handling (Publishing)
+
+When publishing WordPress content, taxonomies can be handled three ways:
+
+| Selection | Behavior |
+|-----------|----------|
+| `skip` | Don't assign this taxonomy |
+| `ai_decides` | AI provides values via tool parameters |
+| `<term_id\|name\|slug>` | Pre-select specific term |
+
+### AI Decides Mode
+
+When `ai_decides` is set:
+1. TaxonomyHandler generates a tool parameter for that taxonomy
+2. AI provides term names in its tool call
+3. Handler assigns terms (creating if needed)
+
+- Hierarchical taxonomies (category): expects single string
+- Non-hierarchical (tags): expects array of strings
+
+**Best Practice**: AI taxonomy selection works for simple cases. For complex categorization, use `skip` and assign programmatically after publish.
+
+---
+
+## Key AI Tools
+
+### skip_item
+
+Allows AI to skip items that shouldn't be processed:
+
+```
+Before generating content:
+1. Search for similar existing posts
+2. If duplicate found, use skip_item("duplicate of [existing URL]")
+```
+
+The tool marks the item as processed and sets job status to `agent_skipped`.
+
+### local_search
+
+Search site content for duplicate detection:
+
+```bash
+# Search by title
+local_search(query="topic name", title_only=true)
+```
+
+**Tip**: Search for core topic, not exact title. "pelicans dangerous" catches "Are Australian Pelicans Dangerous?"
+
+---
+
+## Debugging
+
+### Check Logs
+
+```bash
+# Via CLI
+wp datamachine logs read pipeline
+wp datamachine logs read system
+wp datamachine logs read chat
+
+# Via file
+tail -f wp-content/uploads/datamachine-logs/datamachine-pipeline.log
+```
+
+### Failed Jobs
+
+```bash
+# List failures
+wp datamachine jobs list --status=failed
+
+# Get details on a specific failure
+wp datamachine jobs show <job_id> --format=json
+
+# Status overview
+wp datamachine jobs summary
+```
+
+### Stuck Jobs
+
+```bash
+# Preview what would be recovered
+wp datamachine jobs recover-stuck --dry-run
+
+# Recover (marks stuck jobs as failed, requeues prompts if backup exists)
+wp datamachine jobs recover-stuck
+
+# Retry a specific job
+wp datamachine jobs retry <job_id>
+```
+
+### Scheduled Actions
+
+```bash
+# List pending actions
+wp action-scheduler run --hooks=datamachine --force
+
+# Check cron
+wp cron event list
+```
+
+---
+
+## Common Patterns
+
+### Self-Improving Content Pipeline
+
+```
+1. Fetch topics (RSS, manual queue, or AI ideation)
+2. AI generates content with local_search to avoid duplicates
+3. Publish to WordPress
+4. Agent Ping to notify agent for image addition / promotion
+```
+
+### Autonomous Maintenance
+
+```
+Daily Flow:
+  → Agent Ping: "Check for failed jobs, investigate issues"
+
+Weekly Flow:
+  → Agent Ping: "Review analytics, identify optimization opportunities"
+```
+
+### Multi-Phase Project Execution
+
+```
+Queue tasks in sequence:
+  "Phase 1: Research and planning"
+  "Phase 2: Implementation"
+  "Phase 3: Testing"
+  "Phase 4: Documentation"
+
+Flow runs daily, pops next phase, agent executes and queues follow-up if needed.
+```
+
+### Content Quality Maintenance
+
+```bash
+# Find posts with poor internal linking
+wp datamachine links diagnose --format=json
+
+# Queue cross-linking for a category
+wp datamachine links crosslink --category=nature --links-per-post=5
+
+# Find posts with missing alt text
+wp datamachine alt-text diagnose
+
+# Generate alt text for a post's images
+wp datamachine alt-text generate --post_id=123
+
+# Review what a flow has produced
+wp datamachine posts by-flow 29 --per_page=50
+```
+
+---
+
+## Code Locations
+
+For contributors working on Data Machine itself:
+
+- Steps: `inc/Core/Steps/` (AI, AgentPing, Fetch, Publish, Update, WebhookGate)
+- Abilities: `inc/Abilities/`
+- CLI: `inc/Cli/Commands/`
+- REST API: `inc/Api/`
+- Chat Tools: `inc/Api/Chat/Tools/`
+- Taxonomy Handler: `inc/Core/WordPress/TaxonomyHandler.php`
+- Queueable Trait: `inc/Core/Steps/QueueableTrait.php`
+- React UI: `inc/Core/Admin/Pages/Pipelines/assets/react/`
+
+---
+
+*This skill teaches AI agents how to use Data Machine for autonomous operation. For contributing to Data Machine development, see AGENTS.md in the repository root.*


### PR DESCRIPTION
## What

Adds a complete `SKILL.md` to the repo root — the agent skill file that teaches AI agents how to use Data Machine via CLI, REST API, and queues.

## Why

The existing skill (installed locally via clawhub) had drifted significantly from the actual system. This audit found:

- **6 missing CLI command groups** (logs, links, posts, blocks, alt-text, pinterest)
- **Wrong subcommand names** (`jobs get` → actually `jobs show`)
- **Missing queue operations** (remove, update, move)
- **Missing step type** (webhook_gate)
- **Wrong handler lists** (listed Discord publish which doesn't exist, missed Bluesky/Facebook/Threads/Google Sheets)
- **No mention of Chat API** (30+ tool-based abilities)
- **No pipeline CRUD** docs
- **Missing job management** (fail, retry, recover-stuck, summary)

## What's covered

- All 6 step types with handler tables
- Complete CLI reference for every command and subcommand
- Queue management patterns
- Job debugging workflows
- Chat API / Abilities overview
- Common autonomous operation patterns
- Code locations for contributors

Audited against v0.29.0 codebase.