### PR TITLE
feat: Enforce duplicate validation on queue-add ability

### DIFF
--- a/inc/Abilities/Flow/QueueAbility.php
+++ b/inc/Abilities/Flow/QueueAbility.php
@@ -441,27 +441,21 @@ class QueueAbility {
 		$skip_validation = ! empty( $input['skip_validation'] );
 		if ( ! $skip_validation ) {
 			$validator = new QueueValidator();
-
-			// Check against published posts.
-			$post_match = $validator->handle_tool_call( array(
-				'topic'         => $prompt,
-				'flow_id'       => $flow_id,
-				'flow_step_id'  => $flow_step_id,
+			$result    = $validator->validate( array(
+				'topic'        => $prompt,
+				'flow_id'      => $flow_id,
+				'flow_step_id' => $flow_step_id,
 			) );
 
-			if ( ! empty( $post_match['verdict'] ) && 'duplicate' === $post_match['verdict'] ) {
+			if ( 'duplicate' === $result['verdict'] ) {
 				return array(
-					'success'  => false,
-					'error'    => 'duplicate_rejected',
-					'reason'   => $post_match['reason'] ?? 'Duplicate detected',
-					'match'    => $post_match['match'] ?? array(),
-					'source'   => $post_match['source'] ?? 'unknown',
-					'flow_id'  => $flow_id,
-					'message'  => sprintf(
-						'Rejected: "%s" is a duplicate. %s',
-						$prompt,
-						$post_match['reason'] ?? ''
-					),
+					'success' => false,
+					'error'   => 'duplicate_rejected',
+					'reason'  => $result['reason'],
+					'match'   => $result['match'] ?? array(),
+					'source'  => $result['source'] ?? 'unknown',
+					'flow_id' => $flow_id,
+					'message' => sprintf( 'Rejected: "%s" is a duplicate. %s', $prompt, $result['reason'] ),
 				);
 			}
 		}


### PR DESCRIPTION
## Problem
QueueValidator exists as a global AI tool but validation is opt-in — the AI model has to voluntarily call it. The `queue-add` ability and CLI blindly accept any prompt.

This caused:
- Quiz queue duplicates from failed job retries
- Content ideation occasionally skipping validation

## Solution
Wire `QueueValidator::handle_tool_call()` directly into `executeQueueAdd()`. Every queue-add now validates against published posts AND existing queue items before accepting.

### Behavior:
- **Default**: Validates prompt against published posts + queue items using Jaccard similarity (0.65 threshold)
- **On duplicate**: Returns `success=false`, `error='duplicate_rejected'` with match details
- **Skip**: Pass `skip_validation=true` for intentional re-adds

### No new dependencies:
Reuses existing `QueueValidator` class — same tokenization, same Jaccard logic, same threshold. Just called from the ability layer instead of hoping the AI calls it.

## Impact
- All callers validated: abilities API, WP-CLI, REST API
- QueueValidator global tool remains available for pre-checking
- Zero behavior change for prompts that aren't duplicates

Closes #316