### PR TITLE
fix: Rename dm_ prefix to datamachine_

### DIFF
--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -261,7 +261,7 @@ class InternalLinkingAbilities {
 				 AND p.post_status = %s
 				 AND m.meta_value != ''
 				 AND m.meta_value IS NOT NULL",
-				'_dm_internal_links',
+				'_datamachine_internal_links',
 				'post',
 				'publish'
 			)
@@ -279,7 +279,7 @@ class InternalLinkingAbilities {
 				 WHERE p.post_type = %s
 				 AND p.post_status = %s
 				 AND m.meta_value != ''",
-				'_dm_internal_links',
+				'_datamachine_internal_links',
 				'post',
 				'publish'
 			)
@@ -334,7 +334,7 @@ class InternalLinkingAbilities {
 						 AND tt.term_id = %d
 						 AND m.meta_value != ''
 						 AND m.meta_value IS NOT NULL",
-						'_dm_internal_links',
+						'_datamachine_internal_links',
 						'post',
 						'publish',
 						'category',

--- a/inc/Core/Steps/WebhookGate/WebhookGateStep.php
+++ b/inc/Core/Steps/WebhookGate/WebhookGateStep.php
@@ -103,7 +103,7 @@ class WebhookGateStep extends Step {
 				}
 
 				// Clean up the transient.
-				delete_transient( 'dm_webhook_gate_' . $token );
+				delete_transient( 'datamachine_webhook_gate_' . $token );
 
 				// Fail the job.
 				do_action(
@@ -217,7 +217,7 @@ class WebhookGateStep extends Step {
 		// Store the token → job_id mapping in a transient for fast lookup.
 		// Expires based on timeout or defaults to 7 days.
 		$expiry = $timeout_hours > 0 ? $timeout_hours * HOUR_IN_SECONDS : 7 * DAY_IN_SECONDS;
-		set_transient( 'dm_webhook_gate_' . $token, $this->job_id, $expiry );
+		set_transient( 'datamachine_webhook_gate_' . $token, $this->job_id, $expiry );
 
 		// Schedule timeout action if configured.
 		if ( $timeout_hours > 0 && function_exists( 'as_schedule_single_action' ) ) {
@@ -284,7 +284,7 @@ class WebhookGateStep extends Step {
 	 */
 	public static function handleInboundWebhook( \WP_REST_Request $request ) {
 		$token  = $request->get_param( 'token' );
-		$job_id = get_transient( 'dm_webhook_gate_' . $token );
+		$job_id = get_transient( 'datamachine_webhook_gate_' . $token );
 
 		if ( ! $job_id ) {
 			return new \WP_Error(
@@ -363,7 +363,7 @@ class WebhookGateStep extends Step {
 		$db_jobs->update_job_status( $job_id, JobStatus::PROCESSING );
 
 		// Clean up the transient.
-		delete_transient( 'dm_webhook_gate_' . $token );
+		delete_transient( 'datamachine_webhook_gate_' . $token );
 
 		// Resume the pipeline by scheduling the next step.
 		do_action( 'datamachine_schedule_next_step', $job_id, $next_step_id, $data_packets );

--- a/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
+++ b/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
@@ -46,7 +46,7 @@ class InternalLinkingTask extends SystemTask {
 
 		// Check if already processed.
 		if ( ! $force ) {
-			$existing_links = get_post_meta( $post_id, '_dm_internal_links', true );
+			$existing_links = get_post_meta( $post_id, '_datamachine_internal_links', true );
 			if ( ! empty( $existing_links ) ) {
 				$this->completeJob( $jobId, array(
 					'skipped' => true,
@@ -201,7 +201,7 @@ class InternalLinkingTask extends SystemTask {
 			'links'        => $inserted_links,
 			'job_id'       => $jobId,
 		);
-		update_post_meta( $post_id, '_dm_internal_links', $link_tracking );
+		update_post_meta( $post_id, '_datamachine_internal_links', $link_tracking );
 
 		$this->completeJob( $jobId, array(
 			'post_id'        => $post_id,


### PR DESCRIPTION
Renames all short `dm_` prefixes to full `datamachine_` for consistency.

**Changes:**
- `_dm_internal_links` → `_datamachine_internal_links` (post meta)
- `dm_webhook_gate_` → `datamachine_webhook_gate_` (transients)

**Files:** InternalLinkingTask.php, InternalLinkingAbilities.php, WebhookGateStep.php

Existing post meta (9 rows) already migrated on production via SQL.