### PR TITLE
feat: expose agent memory as global AI tool

### DIFF
--- a/inc/Engine/AI/Tools/Global/AgentMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentMemory.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Agent Memory AI Tool - Persistent memory management for AI agents
+ *
+ * Delegates to AgentMemoryAbilities for section-level read/write operations
+ * on the agent's MEMORY.md file. Provides persistent knowledge storage
+ * across sessions for all agent types.
+ *
+ * @package DataMachine\Engine\AI\Tools\Global
+ * @since   0.30.0
+ */
+
+namespace DataMachine\Engine\AI\Tools\Global;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+class AgentMemory extends BaseTool {
+
+	public function __construct() {
+		$this->registerGlobalTool( 'agent_memory', array( $this, 'getToolDefinition' ) );
+	}
+
+	/**
+	 * Handle tool call by routing to the appropriate ability.
+	 *
+	 * @param array $parameters Tool parameters from AI.
+	 * @param array $tool_def   Tool definition context.
+	 * @return array Response array.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$action = $parameters['action'] ?? '';
+
+		return match ( $action ) {
+			'get'           => $this->handleGet( $parameters ),
+			'update'        => $this->handleUpdate( $parameters ),
+			'list_sections' => $this->handleListSections(),
+			default         => $this->buildErrorResponse(
+				'Invalid action "' . $action . '". Use "get", "update", or "list_sections".',
+				'agent_memory'
+			),
+		};
+	}
+
+	/**
+	 * Read full memory or a specific section.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array Response.
+	 */
+	private function handleGet( array $parameters ): array {
+		$ability = wp_get_ability( 'datamachine/get-agent-memory' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'Agent Memory ability not registered. Ensure WordPress 6.9+ and AgentMemoryAbilities is loaded.',
+				'agent_memory'
+			);
+		}
+
+		$result = $ability->execute(
+			array(
+				'section' => $parameters['section'] ?? '',
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'agent_memory' );
+		}
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return $this->buildErrorResponse(
+				$this->getAbilityError( $result, 'Failed to read agent memory.' ),
+				'agent_memory'
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'agent_memory',
+		);
+	}
+
+	/**
+	 * Write to a section — set (replace) or append.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array Response.
+	 */
+	private function handleUpdate( array $parameters ): array {
+		$section = $parameters['section'] ?? '';
+		$content = $parameters['content'] ?? '';
+		$mode    = $parameters['mode'] ?? 'set';
+
+		if ( '' === $section ) {
+			return $this->buildErrorResponse(
+				'Parameter "section" is required for update action.',
+				'agent_memory'
+			);
+		}
+
+		if ( '' === $content ) {
+			return $this->buildErrorResponse(
+				'Parameter "content" is required for update action.',
+				'agent_memory'
+			);
+		}
+
+		$ability = wp_get_ability( 'datamachine/update-agent-memory' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'Agent Memory ability not registered. Ensure WordPress 6.9+ and AgentMemoryAbilities is loaded.',
+				'agent_memory'
+			);
+		}
+
+		$result = $ability->execute(
+			array(
+				'section' => $section,
+				'content' => $content,
+				'mode'    => $mode,
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'agent_memory' );
+		}
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return $this->buildErrorResponse(
+				$this->getAbilityError( $result, 'Failed to update agent memory.' ),
+				'agent_memory'
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'agent_memory',
+		);
+	}
+
+	/**
+	 * List all section headers.
+	 *
+	 * @return array Response.
+	 */
+	private function handleListSections(): array {
+		$ability = wp_get_ability( 'datamachine/list-agent-memory-sections' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'Agent Memory ability not registered. Ensure WordPress 6.9+ and AgentMemoryAbilities is loaded.',
+				'agent_memory'
+			);
+		}
+
+		$result = $ability->execute( array() );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'agent_memory' );
+		}
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return $this->buildErrorResponse(
+				$this->getAbilityError( $result, 'Failed to list memory sections.' ),
+				'agent_memory'
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'agent_memory',
+		);
+	}
+
+	/**
+	 * Tool definition for AI agent discovery.
+	 *
+	 * @return array Tool schema.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'           => __CLASS__,
+			'method'          => 'handle_tool_call',
+			'description'     => 'Manage persistent agent memory that survives across sessions. Memory is stored as markdown sections (## headers) in MEMORY.md. Use "list_sections" to see what exists, "get" to read content, and "update" to write. Use "append" mode to add new information without losing existing content. Use "set" mode to replace a section entirely.',
+			'requires_config' => false,
+			'parameters'      => array(
+				'action'  => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Action to perform: "get" (read memory), "update" (write to section), or "list_sections" (show all section headers).',
+				),
+				'section' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Section name without "##" prefix. Required for "update". Optional for "get" (omit to read full memory).',
+				),
+				'content' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Content to write. Required for "update" action.',
+				),
+				'mode'    => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Write mode for "update": "set" replaces section content (default), "append" adds to end of section.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Always configured — no external dependencies.
+	 *
+	 * @return bool
+	 */
+	public static function is_configured(): bool {
+		return true;
+	}
+
+	/**
+	 * Configuration check filter handler.
+	 *
+	 * @param bool   $configured Current configuration state.
+	 * @param string $tool_id    Tool identifier.
+	 * @return bool
+	 */
+	public function check_configuration( $configured, $tool_id ) {
+		if ( 'agent_memory' !== $tool_id ) {
+			return $configured;
+		}
+
+		return self::is_configured();
+	}
+}

--- a/inc/Engine/AI/Tools/ToolServiceProvider.php
+++ b/inc/Engine/AI/Tools/ToolServiceProvider.php
@@ -15,6 +15,7 @@ namespace DataMachine\Engine\AI\Tools;
 defined( 'ABSPATH' ) || exit;
 
 // Global tools.
+use DataMachine\Engine\AI\Tools\Global\AgentMemory;
 use DataMachine\Engine\AI\Tools\Global\AmazonAffiliateLink;
 use DataMachine\Engine\AI\Tools\Global\BingWebmaster;
 use DataMachine\Engine\AI\Tools\Global\GoogleSearch;
@@ -79,6 +80,7 @@ class ToolServiceProvider {
 	 * These tools are available to all agent types (pipeline, system, chat).
 	 */
 	private static function registerGlobalTools(): void {
+		new AgentMemory();
 		new AmazonAffiliateLink();
 		new BingWebmaster();
 		new GoogleSearch();


### PR DESCRIPTION
## Summary

- Adds `AgentMemory` global AI tool that wraps the three existing `AgentMemoryAbilities` (`get`, `update`, `list_sections`)
- Registers the tool in `ToolServiceProvider` so it's available to **all agent types** (pipeline, chat, system)
- Completes the access pattern: **Ability → AI Tool + CLI + REST** — agents can now manage persistent memory through the same abstraction regardless of their execution context

## What it does

Single tool called `agent_memory` with an `action` parameter:

| Action | Description | Required Params |
|--------|-------------|-----------------|
| `get` | Read full memory or a specific section | `section` (optional) |
| `update` | Set or append to a section | `section`, `content`, `mode` |
| `list_sections` | List all `##` section headers | none |

## Testing

Verified on live site via `wp eval`:
- ✅ `list_sections` returns all 9 memory sections
- ✅ `get` (full) returns 4143 bytes
- ✅ `get` (section) returns correct section content
- ✅ `update` (append) adds content and persists
- ✅ Invalid action returns proper error response
- ✅ Lint clean — zero new errors or warnings