### PR TITLE
feat: agent workspace for managed repo operations

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -134,6 +134,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/AgentPingAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/TaxonomyAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/AgentMemoryAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/WorkspaceAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/InternalLinkingAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Content/BlockSanitizer.php';
 	require_once __DIR__ . '/inc/Abilities/Content/GetPostBlocksAbility.php';
@@ -173,6 +174,7 @@ function datamachine_run_datamachine_plugin() {
 		new \DataMachine\Abilities\AgentPingAbilities();
 		new \DataMachine\Abilities\TaxonomyAbilities();
 		new \DataMachine\Abilities\AgentMemoryAbilities();
+		new \DataMachine\Abilities\WorkspaceAbilities();
 		new \DataMachine\Abilities\InternalLinkingAbilities();
 		new \DataMachine\Abilities\Content\GetPostBlocksAbility();
 		new \DataMachine\Abilities\Content\EditPostBlocksAbility();

--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Workspace Abilities
+ *
+ * WordPress 6.9 Abilities API primitives for agent workspace operations.
+ * Provides read-only discovery of the workspace path and repo listing.
+ *
+ * Note: Clone and remove operations are intentionally CLI-only for now.
+ * See issue #338 for future exploration of coding capabilities.
+ *
+ * @package DataMachine\Abilities
+ * @since 0.31.0
+ */
+
+namespace DataMachine\Abilities;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\FilesRepository\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+class WorkspaceAbilities {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/workspace-path',
+				array(
+					'label'               => 'Get Workspace Path',
+					'description'         => 'Get the agent workspace directory path',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'path'    => array( 'type' => 'string' ),
+							'exists'  => array( 'type' => 'boolean' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'getPath' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/workspace-list',
+				array(
+					'label'               => 'List Workspace Repos',
+					'description'         => 'List repositories in the agent workspace',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'path'    => array( 'type' => 'string' ),
+							'repos'   => array(
+								'type'  => 'array',
+								'items' => array(
+									'type'       => 'object',
+									'properties' => array(
+										'name'   => array( 'type' => 'string' ),
+										'path'   => array( 'type' => 'string' ),
+										'git'    => array( 'type' => 'boolean' ),
+										'remote' => array( 'type' => 'string' ),
+										'branch' => array( 'type' => 'string' ),
+									),
+								),
+							),
+						),
+					),
+					'execute_callback'    => array( self::class, 'listRepos' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Get workspace path.
+	 *
+	 * @param array $input Input parameters (unused).
+	 * @return array Result.
+	 */
+	public static function getPath( array $input ): array {
+		$workspace = new Workspace();
+
+		return array(
+			'success' => true,
+			'path'    => $workspace->get_path(),
+			'exists'  => is_dir( $workspace->get_path() ),
+		);
+	}
+
+	/**
+	 * List workspace repos.
+	 *
+	 * @param array $input Input parameters (unused).
+	 * @return array Result.
+	 */
+	public static function listRepos( array $input ): array {
+		$workspace = new Workspace();
+		return $workspace->list_repos();
+	}
+}

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -25,6 +25,7 @@ WP_CLI::add_command( 'datamachine pipelines', Commands\PipelinesCommand::class )
 WP_CLI::add_command( 'datamachine posts', Commands\PostsCommand::class );
 WP_CLI::add_command( 'datamachine logs', Commands\LogsCommand::class );
 WP_CLI::add_command( 'datamachine agent', Commands\AgentCommand::class );
+WP_CLI::add_command( 'datamachine workspace', Commands\WorkspaceCommand::class );
 
 // Aliases for AI agent compatibility (singular/plural variants).
 WP_CLI::add_command( 'datamachine setting', Commands\SettingsCommand::class );

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * WP-CLI Workspace Command
+ *
+ * Provides CLI access to the agent workspace — a managed directory
+ * for cloning repos and working with files outside the web root.
+ *
+ * @package DataMachine\Cli\Commands
+ * @since 0.31.0
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Core\FilesRepository\Workspace;
+
+defined( 'ABSPATH' ) || exit;
+
+class WorkspaceCommand extends BaseCommand {
+
+	/**
+	 * Show the workspace directory path.
+	 *
+	 * Displays the resolved workspace path. The path is determined by:
+	 * 1. DATAMACHINE_WORKSPACE_PATH constant (if defined)
+	 * 2. /var/lib/datamachine/workspace (if writable)
+	 * 3. wp-content/uploads/datamachine-files/workspace (fallback)
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--ensure]
+	 * : Create the directory if it doesn't exist.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Show workspace path
+	 *     wp datamachine workspace path
+	 *
+	 *     # Show path and create if missing
+	 *     wp datamachine workspace path --ensure
+	 *
+	 * @subcommand path
+	 */
+	public function path( array $args, array $assoc_args ): void {
+		$workspace = new Workspace();
+		$path      = $workspace->get_path();
+		$exists    = is_dir( $path );
+
+		if ( ! empty( $assoc_args['ensure'] ) ) {
+			$result = $workspace->ensure_exists();
+			if ( ! $result['success'] ) {
+				WP_CLI::error( $result['message'] );
+				return;
+			}
+			if ( ! empty( $result['created'] ) ) {
+				WP_CLI::success( sprintf( 'Created workspace: %s', $path ) );
+				return;
+			}
+		}
+
+		WP_CLI::log( $path );
+
+		if ( ! $exists && empty( $assoc_args['ensure'] ) ) {
+			WP_CLI::warning( 'Directory does not exist yet. Use --ensure to create it.' );
+		}
+	}
+
+	/**
+	 * List repositories in the workspace.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # List workspace repos
+	 *     wp datamachine workspace list
+	 *
+	 *     # List as JSON
+	 *     wp datamachine workspace list --format=json
+	 *
+	 * @subcommand list
+	 */
+	public function list_repos( array $args, array $assoc_args ): void {
+		$workspace = new Workspace();
+		$result    = $workspace->list_repos();
+
+		if ( empty( $result['repos'] ) ) {
+			$path = $workspace->get_path();
+			WP_CLI::log( sprintf( 'No repos in workspace (%s).', $path ) );
+			WP_CLI::log( 'Clone one with: wp datamachine workspace clone <url>' );
+			return;
+		}
+
+		$items = array_map(
+			function ( $repo ) {
+				return array(
+					'name'   => $repo['name'],
+					'branch' => $repo['branch'] ?? '-',
+					'remote' => $repo['remote'] ?? '-',
+					'git'    => $repo['git'] ? 'yes' : 'no',
+					'path'   => $repo['path'],
+				);
+			},
+			$result['repos']
+		);
+
+		$this->format_items(
+			$items,
+			array( 'name', 'branch', 'remote', 'git' ),
+			$assoc_args,
+			'name'
+		);
+	}
+
+	/**
+	 * Clone a git repository into the workspace.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <url>
+	 * : Git repository URL to clone.
+	 *
+	 * [--name=<name>]
+	 * : Directory name in workspace (derived from URL if omitted).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Clone a repo
+	 *     wp datamachine workspace clone https://github.com/Extra-Chill/homeboy.git
+	 *
+	 *     # Clone with custom name
+	 *     wp datamachine workspace clone https://github.com/Extra-Chill/homeboy.git --name=homeboy-dev
+	 *
+	 * @subcommand clone
+	 */
+	public function clone_repo( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) ) {
+			WP_CLI::error( 'Repository URL is required.' );
+			return;
+		}
+
+		$url  = $args[0];
+		$name = $assoc_args['name'] ?? null;
+
+		$workspace = new Workspace();
+		$result    = $workspace->clone_repo( $url, $name );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['message'] );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] );
+		WP_CLI::log( sprintf( 'Path: %s', $result['path'] ) );
+	}
+
+	/**
+	 * Remove a repository from the workspace.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <name>
+	 * : Repository directory name to remove.
+	 *
+	 * [--yes]
+	 * : Skip confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Remove a repo (with confirmation)
+	 *     wp datamachine workspace remove homeboy
+	 *
+	 *     # Remove without confirmation
+	 *     wp datamachine workspace remove homeboy --yes
+	 *
+	 * @subcommand remove
+	 */
+	public function remove_repo( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) ) {
+			WP_CLI::error( 'Repository name is required.' );
+			return;
+		}
+
+		$name      = $args[0];
+		$workspace = new Workspace();
+		$repo_path = $workspace->get_repo_path( $name );
+
+		if ( ! is_dir( $repo_path ) ) {
+			WP_CLI::error( sprintf( 'Repository "%s" not found in workspace.', $name ) );
+			return;
+		}
+
+		// Confirm unless --yes is passed.
+		if ( empty( $assoc_args['yes'] ) ) {
+			WP_CLI::confirm( sprintf( 'Remove "%s" from workspace? This deletes %s', $name, $repo_path ) );
+		}
+
+		$result = $workspace->remove_repo( $name );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['message'] );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] );
+	}
+
+	/**
+	 * Show detailed info about a workspace repo.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <name>
+	 * : Repository directory name.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Show repo info
+	 *     wp datamachine workspace show homeboy
+	 *
+	 * @subcommand show
+	 */
+	public function show( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) ) {
+			WP_CLI::error( 'Repository name is required.' );
+			return;
+		}
+
+		$name      = $args[0];
+		$workspace = new Workspace();
+		$repo_path = $workspace->get_repo_path( $name );
+
+		if ( ! is_dir( $repo_path ) ) {
+			WP_CLI::error( sprintf( 'Repository "%s" not found in workspace.', $name ) );
+			return;
+		}
+
+		$escaped = escapeshellarg( $repo_path );
+
+		// Gather info.
+		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		$branch = trim( (string) exec( sprintf( 'git -C %s rev-parse --abbrev-ref HEAD 2>/dev/null', $escaped ) ) );
+		$remote = trim( (string) exec( sprintf( 'git -C %s config --get remote.origin.url 2>/dev/null', $escaped ) ) );
+		$commit = trim( (string) exec( sprintf( 'git -C %s log -1 --format="%%h %%s" 2>/dev/null', $escaped ) ) );
+		$status = trim( (string) exec( sprintf( 'git -C %s status --porcelain 2>/dev/null | wc -l', $escaped ) ) );
+		// phpcs:enable
+
+		WP_CLI::log( sprintf( 'Name:     %s', $name ) );
+		WP_CLI::log( sprintf( 'Path:     %s', $repo_path ) );
+		WP_CLI::log( sprintf( 'Branch:   %s', $branch ?: '-' ) );
+		WP_CLI::log( sprintf( 'Remote:   %s', $remote ?: '-' ) );
+		WP_CLI::log( sprintf( 'Latest:   %s', $commit ?: '-' ) );
+		WP_CLI::log( sprintf( 'Dirty:    %s', ( '0' === $status ) ? 'no' : "yes ({$status} files)" ) );
+	}
+}

--- a/inc/Core/FilesRepository/DirectoryManager.php
+++ b/inc/Core/FilesRepository/DirectoryManager.php
@@ -96,6 +96,37 @@ class DirectoryManager {
 	}
 
 	/**
+	 * Get workspace directory path.
+	 *
+	 * Returns the managed workspace for agent file operations (cloning repos, etc.).
+	 * Path resolution order:
+	 * 1. DATAMACHINE_WORKSPACE_PATH constant (if defined)
+	 * 2. /var/lib/datamachine/workspace (if writable or creatable)
+	 * 3. Fallback: wp-content/uploads/datamachine-files/workspace
+	 *
+	 * @since 0.31.0
+	 * @return string Full path to workspace directory.
+	 */
+	public function get_workspace_directory(): string {
+		// 1. Explicit constant override.
+		if ( defined( 'DATAMACHINE_WORKSPACE_PATH' ) ) {
+			return rtrim( DATAMACHINE_WORKSPACE_PATH, '/' );
+		}
+
+		// 2. System-level default (outside web root).
+		$system_path = '/var/lib/datamachine/workspace';
+		$system_base = dirname( $system_path );
+		if ( is_writable( $system_base ) || ( ! file_exists( $system_base ) && is_writable( dirname( $system_base ) ) ) ) {
+			return $system_path;
+		}
+
+		// 3. Fallback inside uploads (shared hosting, restricted permissions).
+		$upload_dir = wp_upload_dir();
+		$base       = trailingslashit( $upload_dir['basedir'] ) . self::REPOSITORY_DIR;
+		return "{$base}/workspace";
+	}
+
+	/**
 	 * Ensure directory exists
 	 *
 	 * @param string $directory Directory path

--- a/inc/Core/FilesRepository/Workspace.php
+++ b/inc/Core/FilesRepository/Workspace.php
@@ -1,0 +1,347 @@
+<?php
+/**
+ * Agent Workspace
+ *
+ * Provides a managed directory for agent file operations — cloning repos,
+ * storing working files, etc. Lives outside the web root when possible
+ * for security.
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since 0.31.0
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+class Workspace {
+
+	/**
+	 * @var DirectoryManager
+	 */
+	private DirectoryManager $directory_manager;
+
+	/**
+	 * @var string Resolved workspace path.
+	 */
+	private string $workspace_path;
+
+	public function __construct() {
+		$this->directory_manager = new DirectoryManager();
+		$this->workspace_path   = $this->directory_manager->get_workspace_directory();
+	}
+
+	/**
+	 * Get the workspace base path.
+	 *
+	 * @return string
+	 */
+	public function get_path(): string {
+		return $this->workspace_path;
+	}
+
+	/**
+	 * Get the full path to a repo within the workspace.
+	 *
+	 * @param string $name Repository name (directory name).
+	 * @return string Full path.
+	 */
+	public function get_repo_path( string $name ): string {
+		return $this->workspace_path . '/' . $this->sanitize_name( $name );
+	}
+
+	/**
+	 * Ensure the workspace directory exists with correct permissions.
+	 *
+	 * @return array{success: bool, path: string, message?: string, created?: bool}
+	 */
+	public function ensure_exists(): array {
+		$path = $this->workspace_path;
+
+		if ( is_dir( $path ) ) {
+			return array(
+				'success' => true,
+				'path'    => $path,
+				'created' => false,
+			);
+		}
+
+		$created = $this->directory_manager->ensure_directory_exists( $path );
+
+		if ( ! $created ) {
+			return array(
+				'success' => false,
+				'path'    => $path,
+				'message' => sprintf( 'Failed to create workspace directory: %s', $path ),
+			);
+		}
+
+		// Add .htaccess to block web access if inside web root.
+		$this->protect_directory( $path );
+
+		return array(
+			'success' => true,
+			'path'    => $path,
+			'created' => true,
+		);
+	}
+
+	/**
+	 * List repositories in the workspace.
+	 *
+	 * @return array{success: bool, repos: array, path: string}
+	 */
+	public function list_repos(): array {
+		$path = $this->workspace_path;
+
+		if ( ! is_dir( $path ) ) {
+			return array(
+				'success' => true,
+				'repos'   => array(),
+				'path'    => $path,
+			);
+		}
+
+		$repos   = array();
+		$entries = scandir( $path );
+
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+
+			$entry_path = $path . '/' . $entry;
+			if ( ! is_dir( $entry_path ) ) {
+				continue;
+			}
+
+			$repo_info = array(
+				'name' => $entry,
+				'path' => $entry_path,
+				'git'  => is_dir( $entry_path . '/.git' ),
+			);
+
+			// Get git remote if available.
+			if ( $repo_info['git'] ) {
+				$remote = $this->git_get_remote( $entry_path );
+				if ( null !== $remote ) {
+					$repo_info['remote'] = $remote;
+				}
+
+				$branch = $this->git_get_branch( $entry_path );
+				if ( null !== $branch ) {
+					$repo_info['branch'] = $branch;
+				}
+			}
+
+			$repos[] = $repo_info;
+		}
+
+		return array(
+			'success' => true,
+			'repos'   => $repos,
+			'path'    => $path,
+		);
+	}
+
+	/**
+	 * Clone a git repository into the workspace.
+	 *
+	 * @param string      $url  Git clone URL.
+	 * @param string|null $name Directory name override (derived from URL if null).
+	 * @return array{success: bool, name?: string, path?: string, message?: string}
+	 */
+	public function clone_repo( string $url, ?string $name = null ): array {
+		// Validate URL.
+		if ( empty( $url ) ) {
+			return array(
+				'success' => false,
+				'message' => 'Repository URL is required.',
+			);
+		}
+
+		// Derive name from URL if not provided.
+		if ( null === $name || '' === $name ) {
+			$name = $this->derive_repo_name( $url );
+			if ( null === $name ) {
+				return array(
+					'success' => false,
+					'message' => sprintf( 'Could not derive repository name from URL: %s. Use --name to specify.', $url ),
+				);
+			}
+		}
+
+		$name      = $this->sanitize_name( $name );
+		$repo_path = $this->workspace_path . '/' . $name;
+
+		// Check if already exists.
+		if ( is_dir( $repo_path ) ) {
+			return array(
+				'success' => false,
+				'name'    => $name,
+				'path'    => $repo_path,
+				'message' => sprintf( 'Directory already exists: %s. Use "remove" first to re-clone.', $name ),
+			);
+		}
+
+		// Ensure workspace exists.
+		$ensure = $this->ensure_exists();
+		if ( ! $ensure['success'] ) {
+			return $ensure;
+		}
+
+		// Clone.
+		$escaped_url  = escapeshellarg( $url );
+		$escaped_path = escapeshellarg( $repo_path );
+		$command      = sprintf( 'git clone %s %s 2>&1', $escaped_url, $escaped_path );
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		exec( $command, $output, $exit_code );
+
+		if ( 0 !== $exit_code ) {
+			return array(
+				'success' => false,
+				'name'    => $name,
+				'message' => sprintf( 'Git clone failed (exit %d): %s', $exit_code, implode( "\n", $output ) ),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'name'    => $name,
+			'path'    => $repo_path,
+			'message' => sprintf( 'Cloned %s into workspace as "%s".', $url, $name ),
+		);
+	}
+
+	/**
+	 * Remove a repository from the workspace.
+	 *
+	 * @param string $name Repository directory name.
+	 * @return array{success: bool, message: string}
+	 */
+	public function remove_repo( string $name ): array {
+		$name      = $this->sanitize_name( $name );
+		$repo_path = $this->workspace_path . '/' . $name;
+
+		if ( ! is_dir( $repo_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Repository "%s" not found in workspace.', $name ),
+			);
+		}
+
+		// Safety: ensure path is within workspace.
+		$real_workspace = realpath( $this->workspace_path );
+		$real_repo      = realpath( $repo_path );
+
+		if ( false === $real_workspace || false === $real_repo ) {
+			return array(
+				'success' => false,
+				'message' => 'Could not resolve path. Refusing to remove.',
+			);
+		}
+
+		if ( 0 !== strpos( $real_repo, $real_workspace . '/' ) ) {
+			return array(
+				'success' => false,
+				'message' => 'Path traversal detected. Refusing to remove.',
+			);
+		}
+
+		// Remove recursively.
+		$escaped = escapeshellarg( $real_repo );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		exec( sprintf( 'rm -rf %s 2>&1', $escaped ), $output, $exit_code );
+
+		if ( 0 !== $exit_code ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to remove (exit %d): %s', $exit_code, implode( "\n", $output ) ),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'message' => sprintf( 'Removed "%s" from workspace.', $name ),
+		);
+	}
+
+	// =========================================================================
+	// Internal helpers
+	// =========================================================================
+
+	/**
+	 * Derive a repo name from a git URL.
+	 *
+	 * @param string $url Git URL.
+	 * @return string|null Derived name or null.
+	 */
+	private function derive_repo_name( string $url ): ?string {
+		// Handle https://github.com/org/repo.git and git@github.com:org/repo.git
+		$name = basename( $url );
+		$name = preg_replace( '/\.git$/', '', $name );
+		$name = $this->sanitize_name( $name );
+
+		return ( '' !== $name ) ? $name : null;
+	}
+
+	/**
+	 * Sanitize a directory name for use in the workspace.
+	 *
+	 * @param string $name Raw name.
+	 * @return string Sanitized name (alphanumeric, hyphens, underscores, dots).
+	 */
+	private function sanitize_name( string $name ): string {
+		return preg_replace( '/[^a-zA-Z0-9._-]/', '', $name );
+	}
+
+	/**
+	 * Get the origin remote URL for a git repo.
+	 *
+	 * @param string $repo_path Path to repo.
+	 * @return string|null Remote URL or null.
+	 */
+	private function git_get_remote( string $repo_path ): ?string {
+		$escaped = escapeshellarg( $repo_path );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		$remote = exec( sprintf( 'git -C %s config --get remote.origin.url 2>/dev/null', $escaped ) );
+		return ( '' !== $remote ) ? $remote : null;
+	}
+
+	/**
+	 * Get the current branch for a git repo.
+	 *
+	 * @param string $repo_path Path to repo.
+	 * @return string|null Branch name or null.
+	 */
+	private function git_get_branch( string $repo_path ): ?string {
+		$escaped = escapeshellarg( $repo_path );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		$branch = exec( sprintf( 'git -C %s rev-parse --abbrev-ref HEAD 2>/dev/null', $escaped ) );
+		return ( '' !== $branch ) ? $branch : null;
+	}
+
+	/**
+	 * Add .htaccess protection if the workspace is inside the web root.
+	 *
+	 * @param string $path Directory path.
+	 */
+	private function protect_directory( string $path ): void {
+		// Only needed if path is under ABSPATH (web root).
+		$abspath = rtrim( ABSPATH, '/' );
+		if ( 0 !== strpos( $path, $abspath ) ) {
+			return;
+		}
+
+		$htaccess = $path . '/.htaccess';
+		if ( ! file_exists( $htaccess ) ) {
+			file_put_contents( $htaccess, "Deny from all\n" );
+		}
+
+		$index = $path . '/index.php';
+		if ( ! file_exists( $index ) ) {
+			file_put_contents( $index, "<?php\n// Silence is golden.\n" );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a managed workspace system for agents to clone repos and work with files outside the web root. Closes #337.

- **Core class** (`Workspace.php`) — clone, list, remove, show operations with path traversal protection
- **WP-CLI commands** — `wp datamachine workspace {path, list, clone, remove, show}`
- **Abilities** — read-only `workspace-path` and `workspace-list` for chat agent discoverability
- **Path resolution** — configurable via `DATAMACHINE_WORKSPACE_PATH`, defaults to `/var/lib/datamachine/workspace`, falls back to uploads on shared hosting

## Tested on chubes.net

```
$ wp datamachine workspace path --ensure
Success: Created workspace: /var/lib/datamachine/workspace

$ wp datamachine workspace clone https://github.com/Extra-Chill/homeboy.git
Success: Cloned into workspace as "homeboy".

$ wp datamachine workspace list
name             branch  remote                                          git
homeboy          main    https://github.com/Extra-Chill/homeboy.git      yes
homeboy-modules  main    https://github.com/Extra-Chill/homeboy-modules  yes

$ wp datamachine workspace show homeboy
Name:     homeboy
Path:     /var/lib/datamachine/workspace/homeboy
Branch:   main
Remote:   https://github.com/Extra-Chill/homeboy.git
Latest:   a749ea5 feat: add dedicated flags to component set...
Dirty:    no
```

## Design decisions

- Clone/remove operations are **CLI-only** for now — chat agent gets read-only abilities. See #338 for future coding capabilities exploration.
- `.htaccess` + `index.php` protection is auto-added when workspace falls inside the web root (shared hosting fallback).
- `remove` requires `--yes` flag or interactive confirmation to prevent accidents.