### PR TITLE
feat: Inbound webhook trigger for flow execution

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -90,6 +90,7 @@ function datamachine_run_datamachine_plugin() {
 	\DataMachine\Engine\AI\Tools\ToolServiceProvider::register();
 
 	\DataMachine\Api\Execute::register();
+	\DataMachine\Api\WebhookTrigger::register();
 	\DataMachine\Api\Pipelines\Pipelines::register();
 	\DataMachine\Api\Pipelines\PipelineSteps::register();
 	\DataMachine\Api\Pipelines\PipelineFlows::register();

--- a/inc/Abilities/Flow/WebhookTriggerAbility.php
+++ b/inc/Abilities/Flow/WebhookTriggerAbility.php
@@ -1,0 +1,439 @@
+<?php
+/**
+ * Webhook Trigger Ability
+ *
+ * Manages per-flow webhook trigger tokens: enable, disable, regenerate, and status.
+ * Tokens are stored in the flow's scheduling_config JSON field.
+ *
+ * @package DataMachine\Abilities\Flow
+ * @since 0.30.0
+ * @see https://github.com/Extra-Chill/data-machine/issues/342
+ */
+
+namespace DataMachine\Abilities\Flow;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Webhook Trigger Ability handler.
+ *
+ * Registers and executes abilities for managing per-flow webhook
+ * trigger tokens: enable, disable, regenerate, and status.
+ */
+class WebhookTriggerAbility {
+
+	use FlowHelpers;
+
+	/**
+	 * Initialize database connections and register abilities.
+	 */
+	public function __construct() {
+		$this->initDatabases();
+
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		$this->registerAbilities();
+	}
+
+	/**
+	 * Register all webhook trigger abilities.
+	 */
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/webhook-trigger-enable',
+				array(
+					'label'               => __( 'Enable Webhook Trigger', 'data-machine' ),
+					'description'         => __( 'Enable webhook trigger for a flow and generate a Bearer token. External services can POST to the trigger URL to start flow executions.', 'data-machine' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'flow_id' ),
+						'properties' => array(
+							'flow_id' => array(
+								'type'        => 'integer',
+								'description' => __( 'Flow ID to enable webhook trigger for', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'     => array( 'type' => 'boolean' ),
+							'flow_id'     => array( 'type' => 'integer' ),
+							'webhook_url' => array( 'type' => 'string' ),
+							'token'       => array( 'type' => 'string' ),
+							'message'     => array( 'type' => 'string' ),
+							'error'       => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'executeEnable' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/webhook-trigger-disable',
+				array(
+					'label'               => __( 'Disable Webhook Trigger', 'data-machine' ),
+					'description'         => __( 'Disable webhook trigger for a flow. Revokes the token and stops accepting inbound webhooks.', 'data-machine' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'flow_id' ),
+						'properties' => array(
+							'flow_id' => array(
+								'type'        => 'integer',
+								'description' => __( 'Flow ID to disable webhook trigger for', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'flow_id' => array( 'type' => 'integer' ),
+							'message' => array( 'type' => 'string' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'executeDisable' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/webhook-trigger-regenerate',
+				array(
+					'label'               => __( 'Regenerate Webhook Token', 'data-machine' ),
+					'description'         => __( 'Regenerate the webhook trigger token for a flow. The old token is immediately invalidated.', 'data-machine' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'flow_id' ),
+						'properties' => array(
+							'flow_id' => array(
+								'type'        => 'integer',
+								'description' => __( 'Flow ID to regenerate webhook token for', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'     => array( 'type' => 'boolean' ),
+							'flow_id'     => array( 'type' => 'integer' ),
+							'webhook_url' => array( 'type' => 'string' ),
+							'token'       => array( 'type' => 'string' ),
+							'message'     => array( 'type' => 'string' ),
+							'error'       => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'executeRegenerate' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/webhook-trigger-status',
+				array(
+					'label'               => __( 'Webhook Trigger Status', 'data-machine' ),
+					'description'         => __( 'Get the webhook trigger status for a flow, including URL and whether it is enabled.', 'data-machine' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'flow_id' ),
+						'properties' => array(
+							'flow_id' => array(
+								'type'        => 'integer',
+								'description' => __( 'Flow ID to check webhook trigger status for', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'         => array( 'type' => 'boolean' ),
+							'flow_id'         => array( 'type' => 'integer' ),
+							'flow_name'       => array( 'type' => 'string' ),
+							'webhook_enabled' => array( 'type' => 'boolean' ),
+							'webhook_url'     => array( 'type' => 'string' ),
+							'created_at'      => array( 'type' => 'string' ),
+							'error'           => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'executeStatus' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Enable webhook trigger for a flow.
+	 *
+	 * Generates a new token and stores it in scheduling_config.
+	 * If already enabled, returns the existing token and URL.
+	 *
+	 * @param array $input Input with flow_id.
+	 * @return array Result with token and webhook URL.
+	 */
+	public function executeEnable( array $input ): array {
+		$flow_id = (int) ( $input['flow_id'] ?? 0 );
+
+		if ( $flow_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_id must be a positive integer',
+			);
+		}
+
+		$flow = $this->db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow %d not found', $flow_id ),
+			);
+		}
+
+		$scheduling_config = $flow['scheduling_config'] ?? array();
+
+		// If already enabled with a valid token, return existing.
+		if ( ! empty( $scheduling_config['webhook_enabled'] ) && ! empty( $scheduling_config['webhook_token'] ) ) {
+			return array(
+				'success'     => true,
+				'flow_id'     => $flow_id,
+				'webhook_url' => self::get_webhook_url( $flow_id ),
+				'token'       => $scheduling_config['webhook_token'],
+				'message'     => 'Webhook trigger already enabled.',
+			);
+		}
+
+		// Generate new token.
+		$token = self::generate_token();
+
+		$scheduling_config['webhook_enabled']    = true;
+		$scheduling_config['webhook_token']      = $token;
+		$scheduling_config['webhook_created_at'] = gmdate( 'Y-m-d\TH:i:s\Z' );
+
+		$updated = $this->db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
+
+		if ( ! $updated ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to update flow scheduling config',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Webhook trigger enabled for flow',
+			array( 'flow_id' => $flow_id )
+		);
+
+		return array(
+			'success'     => true,
+			'flow_id'     => $flow_id,
+			'webhook_url' => self::get_webhook_url( $flow_id ),
+			'token'       => $token,
+			'message'     => sprintf( 'Webhook trigger enabled for flow %d.', $flow_id ),
+		);
+	}
+
+	/**
+	 * Disable webhook trigger for a flow.
+	 *
+	 * Removes the token and disables webhook triggering.
+	 *
+	 * @param array $input Input with flow_id.
+	 * @return array Result with success status.
+	 */
+	public function executeDisable( array $input ): array {
+		$flow_id = (int) ( $input['flow_id'] ?? 0 );
+
+		if ( $flow_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_id must be a positive integer',
+			);
+		}
+
+		$flow = $this->db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow %d not found', $flow_id ),
+			);
+		}
+
+		$scheduling_config = $flow['scheduling_config'] ?? array();
+
+		unset( $scheduling_config['webhook_enabled'] );
+		unset( $scheduling_config['webhook_token'] );
+		unset( $scheduling_config['webhook_created_at'] );
+
+		$updated = $this->db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
+
+		if ( ! $updated ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to update flow scheduling config',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Webhook trigger disabled for flow',
+			array( 'flow_id' => $flow_id )
+		);
+
+		return array(
+			'success' => true,
+			'flow_id' => $flow_id,
+			'message' => sprintf( 'Webhook trigger disabled for flow %d.', $flow_id ),
+		);
+	}
+
+	/**
+	 * Regenerate webhook token for a flow.
+	 *
+	 * The old token is immediately invalidated.
+	 *
+	 * @param array $input Input with flow_id.
+	 * @return array Result with new token and webhook URL.
+	 */
+	public function executeRegenerate( array $input ): array {
+		$flow_id = (int) ( $input['flow_id'] ?? 0 );
+
+		if ( $flow_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_id must be a positive integer',
+			);
+		}
+
+		$flow = $this->db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow %d not found', $flow_id ),
+			);
+		}
+
+		$scheduling_config = $flow['scheduling_config'] ?? array();
+
+		if ( empty( $scheduling_config['webhook_enabled'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Webhook trigger is not enabled for flow %d. Enable it first.', $flow_id ),
+			);
+		}
+
+		// Generate new token — old one is immediately invalidated.
+		$token = self::generate_token();
+
+		$scheduling_config['webhook_token']      = $token;
+		$scheduling_config['webhook_created_at'] = gmdate( 'Y-m-d\TH:i:s\Z' );
+
+		$updated = $this->db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
+
+		if ( ! $updated ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to update flow scheduling config',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Webhook trigger token regenerated for flow',
+			array( 'flow_id' => $flow_id )
+		);
+
+		return array(
+			'success'     => true,
+			'flow_id'     => $flow_id,
+			'webhook_url' => self::get_webhook_url( $flow_id ),
+			'token'       => $token,
+			'message'     => sprintf( 'Webhook token regenerated for flow %d. Old token is invalidated.', $flow_id ),
+		);
+	}
+
+	/**
+	 * Get webhook trigger status for a flow.
+	 *
+	 * Does NOT return the token — use enable/regenerate for that.
+	 *
+	 * @param array $input Input with flow_id.
+	 * @return array Result with webhook status.
+	 */
+	public function executeStatus( array $input ): array {
+		$flow_id = (int) ( $input['flow_id'] ?? 0 );
+
+		if ( $flow_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_id must be a positive integer',
+			);
+		}
+
+		$flow = $this->db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow %d not found', $flow_id ),
+			);
+		}
+
+		$scheduling_config = $flow['scheduling_config'] ?? array();
+		$enabled           = ! empty( $scheduling_config['webhook_enabled'] );
+
+		$result = array(
+			'success'         => true,
+			'flow_id'         => $flow_id,
+			'flow_name'       => $flow['flow_name'] ?? '',
+			'webhook_enabled' => $enabled,
+		);
+
+		if ( $enabled ) {
+			$result['webhook_url'] = self::get_webhook_url( $flow_id );
+			$result['created_at']  = $scheduling_config['webhook_created_at'] ?? '';
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Generate a cryptographically secure webhook token.
+	 *
+	 * @return string 64-character hex token.
+	 */
+	public static function generate_token(): string {
+		return bin2hex( random_bytes( 32 ) );
+	}
+
+	/**
+	 * Get the webhook trigger URL for a flow.
+	 *
+	 * @param int $flow_id Flow ID.
+	 * @return string Full webhook trigger URL.
+	 */
+	public static function get_webhook_url( int $flow_id ): string {
+		return rest_url( "datamachine/v1/trigger/{$flow_id}" );
+	}
+}

--- a/inc/Abilities/FlowAbilities.php
+++ b/inc/Abilities/FlowAbilities.php
@@ -19,6 +19,7 @@ use DataMachine\Abilities\Flow\UpdateFlowAbility;
 use DataMachine\Abilities\Flow\DeleteFlowAbility;
 use DataMachine\Abilities\Flow\DuplicateFlowAbility;
 use DataMachine\Abilities\Flow\QueueAbility;
+use DataMachine\Abilities\Flow\WebhookTriggerAbility;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -32,6 +33,7 @@ class FlowAbilities {
 	private DeleteFlowAbility $delete_flow;
 	private DuplicateFlowAbility $duplicate_flow;
 	private QueueAbility $queue;
+	private WebhookTriggerAbility $webhook_trigger;
 
 	public function __construct() {
 		// Always initialize queue - CLI commands need it regardless of WP_Ability
@@ -43,11 +45,12 @@ class FlowAbilities {
 
 		$this->registerCategory();
 
-		$this->get_flows      = new GetFlowsAbility();
-		$this->create_flow    = new CreateFlowAbility();
-		$this->update_flow    = new UpdateFlowAbility();
-		$this->delete_flow    = new DeleteFlowAbility();
-		$this->duplicate_flow = new DuplicateFlowAbility();
+		$this->get_flows       = new GetFlowsAbility();
+		$this->create_flow     = new CreateFlowAbility();
+		$this->update_flow     = new UpdateFlowAbility();
+		$this->delete_flow     = new DeleteFlowAbility();
+		$this->duplicate_flow  = new DuplicateFlowAbility();
+		$this->webhook_trigger = new WebhookTriggerAbility();
 
 		self::$registered = true;
 	}

--- a/inc/Api/WebhookTrigger.php
+++ b/inc/Api/WebhookTrigger.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Webhook Trigger REST Endpoint
+ *
+ * Public endpoint for triggering flows via inbound HTTP requests.
+ * Authenticated via per-flow Bearer tokens, not WordPress capabilities.
+ *
+ * Complementary to the existing /execute endpoint (admin-only) and
+ * WebhookGate step (mid-pipeline pause/resume). This endpoint starts
+ * new flow executions from external services.
+ *
+ * @package DataMachine\Api
+ * @since 0.30.0
+ * @see https://github.com/Extra-Chill/data-machine/issues/342
+ */
+
+namespace DataMachine\Api;
+
+use DataMachine\Abilities\Job\ExecuteWorkflowAbility;
+use DataMachine\Core\Database\Flows\Flows;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Webhook Trigger REST API handler.
+ *
+ * Registers and handles the public /trigger/{flow_id} endpoint
+ * for inbound webhook-driven flow execution.
+ */
+class WebhookTrigger {
+
+	/**
+	 * Initialize REST API hooks.
+	 */
+	public static function register() {
+		add_action( 'rest_api_init', array( self::class, 'register_routes' ) );
+	}
+
+	/**
+	 * Register webhook trigger REST route.
+	 */
+	public static function register_routes() {
+		register_rest_route(
+			'datamachine/v1',
+			'/trigger/(?P<flow_id>\d+)',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( self::class, 'handle_trigger' ),
+				'permission_callback' => '__return_true', // Auth via Bearer token, not WP capabilities.
+				'args'                => array(
+					'flow_id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'validate_callback' => function ( $value ) {
+							return is_numeric( $value ) && (int) $value > 0;
+						},
+						'sanitize_callback' => function ( $value ) {
+							return (int) $value;
+						},
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Handle inbound webhook trigger.
+	 *
+	 * Authentication flow:
+	 * 1. Extract Bearer token from Authorization header
+	 * 2. Load flow by ID
+	 * 3. Verify webhook_enabled in scheduling_config
+	 * 4. Constant-time token comparison via hash_equals()
+	 * 5. Delegate to execute-workflow ability
+	 *
+	 * Returns generic 401 for all auth failures to prevent information leakage.
+	 *
+	 * @param \WP_REST_Request $request REST request object.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public static function handle_trigger( \WP_REST_Request $request ) {
+		$flow_id = (int) $request->get_param( 'flow_id' );
+
+		// Extract Bearer token from Authorization header.
+		$auth_header = $request->get_header( 'authorization' );
+		$token       = self::extract_bearer_token( $auth_header );
+
+		if ( ! $token ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: Missing or malformed Authorization header',
+				array(
+					'flow_id'   => $flow_id,
+					'remote_ip' => self::get_remote_ip( $request ),
+				)
+			);
+
+			return new \WP_Error(
+				'unauthorized',
+				'Invalid or missing authorization.',
+				array( 'status' => 401 )
+			);
+		}
+
+		// Validate token format before database lookup.
+		if ( ! preg_match( '/^[a-f0-9]{64}$/', $token ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: Invalid token format',
+				array(
+					'flow_id'   => $flow_id,
+					'remote_ip' => self::get_remote_ip( $request ),
+				)
+			);
+
+			return new \WP_Error(
+				'unauthorized',
+				'Invalid or missing authorization.',
+				array( 'status' => 401 )
+			);
+		}
+
+		// Load flow and validate webhook configuration.
+		$db_flows = new Flows();
+		$flow     = $db_flows->get_flow( $flow_id );
+
+		if ( ! $flow ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: Flow not found',
+				array(
+					'flow_id'   => $flow_id,
+					'remote_ip' => self::get_remote_ip( $request ),
+				)
+			);
+
+			// Generic 401 — don't reveal whether the flow exists.
+			return new \WP_Error(
+				'unauthorized',
+				'Invalid or missing authorization.',
+				array( 'status' => 401 )
+			);
+		}
+
+		$scheduling_config = $flow['scheduling_config'] ?? array();
+		$webhook_enabled   = ! empty( $scheduling_config['webhook_enabled'] );
+		$stored_token      = $scheduling_config['webhook_token'] ?? '';
+
+		if ( ! $webhook_enabled || empty( $stored_token ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: Webhook not enabled for flow',
+				array(
+					'flow_id'   => $flow_id,
+					'remote_ip' => self::get_remote_ip( $request ),
+				)
+			);
+
+			return new \WP_Error(
+				'unauthorized',
+				'Invalid or missing authorization.',
+				array( 'status' => 401 )
+			);
+		}
+
+		// Constant-time token comparison to prevent timing attacks.
+		if ( ! hash_equals( $stored_token, $token ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: Token mismatch',
+				array(
+					'flow_id'   => $flow_id,
+					'remote_ip' => self::get_remote_ip( $request ),
+				)
+			);
+
+			return new \WP_Error(
+				'unauthorized',
+				'Invalid or missing authorization.',
+				array( 'status' => 401 )
+			);
+		}
+
+		// Auth passed — execute the flow.
+		// Instantiate directly to bypass the Abilities API permission check.
+		// The webhook trigger has already authenticated via Bearer token.
+		$ability = new ExecuteWorkflowAbility();
+
+		// Build webhook payload from request body.
+		$webhook_body = $request->get_json_params();
+		if ( empty( $webhook_body ) ) {
+			$webhook_body = $request->get_body_params();
+		}
+		if ( empty( $webhook_body ) ) {
+			$webhook_body = array();
+		}
+
+		// Execute the flow with webhook metadata in initial_data.
+		$input = array(
+			'flow_id'      => $flow_id,
+			'initial_data' => array(
+				'webhook_trigger' => array(
+					'payload'     => $webhook_body,
+					'received_at' => gmdate( 'Y-m-d\TH:i:s\Z' ),
+					'remote_ip'   => self::get_remote_ip( $request ),
+					'headers'     => self::get_safe_headers( $request ),
+				),
+			),
+		);
+
+		$result = $ability->execute( $input );
+
+		if ( ! ( $result['success'] ?? false ) ) {
+			$error = $result['error'] ?? __( 'Flow execution failed', 'data-machine' );
+
+			do_action(
+				'datamachine_log',
+				'error',
+				'Webhook trigger: Flow execution failed',
+				array(
+					'flow_id' => $flow_id,
+					'error'   => $error,
+				)
+			);
+
+			return new \WP_Error(
+				'execution_failed',
+				$error,
+				array( 'status' => 500 )
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Webhook trigger: Flow executed successfully',
+			array(
+				'flow_id'      => $flow_id,
+				'flow_name'    => $result['flow_name'] ?? '',
+				'job_id'       => $result['job_id'] ?? null,
+				'remote_ip'    => self::get_remote_ip( $request ),
+				'payload_keys' => array_keys( $webhook_body ),
+			)
+		);
+
+		return rest_ensure_response(
+			array(
+				'success'   => true,
+				'flow_id'   => $flow_id,
+				'flow_name' => $result['flow_name'] ?? '',
+				'job_id'    => $result['job_id'] ?? null,
+				'message'   => $result['message'] ?? __( 'Flow triggered successfully', 'data-machine' ),
+			)
+		);
+	}
+
+	/**
+	 * Extract Bearer token from Authorization header.
+	 *
+	 * @param string|null $auth_header Authorization header value.
+	 * @return string|null Token string or null if not found.
+	 */
+	private static function extract_bearer_token( ?string $auth_header ): ?string {
+		if ( empty( $auth_header ) ) {
+			return null;
+		}
+
+		if ( 0 !== strpos( $auth_header, 'Bearer ' ) ) {
+			return null;
+		}
+
+		$token = substr( $auth_header, 7 );
+
+		return ! empty( $token ) ? trim( $token ) : null;
+	}
+
+	/**
+	 * Get remote IP address from request.
+	 *
+	 * @param \WP_REST_Request $request REST request object.
+	 * @return string Remote IP address.
+	 */
+	private static function get_remote_ip( \WP_REST_Request $request ): string {
+		$forwarded = $request->get_header( 'x-forwarded-for' );
+		if ( $forwarded ) {
+			// Take the first IP if multiple are chained.
+			$ips = explode( ',', $forwarded );
+			return trim( $ips[0] );
+		}
+
+		return sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '' ) );
+	}
+
+	/**
+	 * Get safe subset of request headers for logging.
+	 *
+	 * Excludes the Authorization header to avoid logging tokens.
+	 *
+	 * @param \WP_REST_Request $request REST request object.
+	 * @return array Filtered headers.
+	 */
+	private static function get_safe_headers( \WP_REST_Request $request ): array {
+		$safe_keys = array(
+			'content-type',
+			'user-agent',
+			'x-github-event',
+			'x-github-delivery',
+			'x-hub-signature-256',
+			'x-webhook-id',
+			'x-request-id',
+		);
+
+		$headers = array();
+		foreach ( $safe_keys as $key ) {
+			$value = $request->get_header( $key );
+			if ( $value ) {
+				$headers[ $key ] = $value;
+			}
+		}
+
+		return $headers;
+	}
+}


### PR DESCRIPTION
## Summary

Adds a public REST endpoint for triggering flows via inbound HTTP requests, closing the gap where Data Machine could only poll (schedule-based) but never be pushed to by external services.

- **New endpoint**: `POST /datamachine/v1/trigger/{flow_id}` with per-flow Bearer token auth
- **Token management**: 4 abilities (enable, disable, regenerate, status) + full CLI support
- **Payload passthrough**: webhook body stored in `engine_data.webhook_trigger.payload` for flow access
- **`initial_data` for database flows**: `ExecuteWorkflowAbility.executeDatabaseFlow` now supports `initial_data`, previously ephemeral-only

## Architecture

Two thin HTTP handlers, one shared ability — no business logic duplication:

```
┌─────────────────┐     ┌──────────────────────┐
│  /execute       │────▶│                      │
│  (admin auth)   │     │  execute-workflow    │
└─────────────────┘     │  ability             │
                        │                      │
┌─────────────────┐     │  (creates job,       │
│  /trigger/{id}  │────▶│   runs flow)         │
│  (token auth)   │     │                      │
└─────────────────┘     └──────────────────────┘
```

## Security

- 64-char hex tokens via `bin2hex(random_bytes(32))`
- `hash_equals()` for constant-time comparison
- Generic 401 for all auth failures (doesn't leak flow existence)
- Safe header logging (Authorization header excluded)
- Token stored in `scheduling_config` JSON field alongside scheduling data

## CLI

```bash
wp datamachine flows webhook enable 42      # Generate token, show URL + curl example
wp datamachine flows webhook disable 42     # Revoke token
wp datamachine flows webhook regenerate 42  # New token, old invalidated
wp datamachine flows webhook status 42      # Show URL and status
wp datamachine flows webhook list           # All webhook-enabled flows
```

## Files

| File | Change |
|------|--------|
| `inc/Api/WebhookTrigger.php` | **NEW** — REST endpoint |
| `inc/Abilities/Flow/WebhookTriggerAbility.php` | **NEW** — 4 token management abilities |
| `inc/Abilities/FlowAbilities.php` | Register WebhookTriggerAbility in facade |
| `inc/Abilities/Job/ExecuteWorkflowAbility.php` | Add `initial_data` support for database flows |
| `inc/Cli/Commands/FlowsCommand.php` | Add `webhook` subcommand with 5 actions |
| `data-machine.php` | Register WebhookTrigger API |

## Tested

- ✅ No auth → 401
- ✅ Wrong token → 401
- ✅ Wrong flow_id → 401 (generic, no leak)
- ✅ Correct token → 200 + job created
- ✅ Payload stored in engine_data
- ✅ Token regeneration invalidates old token
- ✅ Disable revokes access
- ✅ All CLI commands working

## Known limitations / follow-ups

- No rate limiting (should be added per-flow)
- Ability permission bypass: instantiates `ExecuteWorkflowAbility` directly since the Abilities API permission check blocks unauthenticated REST contexts. The webhook has its own auth but the ability framework doesn't know that.
- FlowsCommand.php is growing large (~1750 lines) — webhook and queue subcommands could be extracted into separate command classes
- No `jobs delete` CLI command (discovered during testing)

Closes #342