### PR TITLE
feat: Webhook trigger rate limiting

### DIFF
--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -18,7 +18,7 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 
 // Primary commands.
 WP_CLI::add_command( 'datamachine settings', Commands\SettingsCommand::class );
-WP_CLI::add_command( 'datamachine flows', Commands\FlowsCommand::class );
+WP_CLI::add_command( 'datamachine flows', Commands\Flows\FlowsCommand::class );
 WP_CLI::add_command( 'datamachine alt-text', Commands\AltTextCommand::class );
 WP_CLI::add_command( 'datamachine jobs', Commands\JobsCommand::class );
 WP_CLI::add_command( 'datamachine pipelines', Commands\PipelinesCommand::class );
@@ -29,7 +29,7 @@ WP_CLI::add_command( 'datamachine workspace', Commands\WorkspaceCommand::class )
 
 // Aliases for AI agent compatibility (singular/plural variants).
 WP_CLI::add_command( 'datamachine setting', Commands\SettingsCommand::class );
-WP_CLI::add_command( 'datamachine flow', Commands\FlowsCommand::class );
+WP_CLI::add_command( 'datamachine flow', Commands\Flows\FlowsCommand::class );
 WP_CLI::add_command( 'datamachine job', Commands\JobsCommand::class );
 WP_CLI::add_command( 'datamachine pipeline', Commands\PipelinesCommand::class );
 WP_CLI::add_command( 'datamachine post', Commands\PostsCommand::class );

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -6,15 +6,15 @@
  * Wraps FlowAbilities API primitive.
  *
  * Queue and webhook subcommands are handled by dedicated command classes:
- * - FlowsQueueCommand (flows queue)
- * - FlowsWebhookCommand (flows webhook)
+ * - QueueCommand (flows queue)
+ * - WebhookCommand (flows webhook)
  *
- * @package DataMachine\Cli\Commands
+ * @package DataMachine\Cli\Commands\Flows
  * @since 0.15.3 Added create subcommand.
  * @since 0.31.0 Extracted queue and webhook to dedicated command classes.
  */
 
-namespace DataMachine\Cli\Commands;
+namespace DataMachine\Cli\Commands\Flows;
 
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
@@ -161,16 +161,16 @@ class FlowsCommand extends BaseCommand {
 			return;
 		}
 
-		// Delegate 'queue' subcommand to FlowsQueueCommand.
+		// Delegate 'queue' subcommand to QueueCommand.
 		if ( ! empty( $args ) && 'queue' === $args[0] ) {
-			$queue = new FlowsQueueCommand();
+			$queue = new QueueCommand();
 			$queue->dispatch( array_slice( $args, 1 ), $assoc_args );
 			return;
 		}
 
-		// Delegate 'webhook' subcommand to FlowsWebhookCommand.
+		// Delegate 'webhook' subcommand to WebhookCommand.
 		if ( ! empty( $args ) && 'webhook' === $args[0] ) {
-			$webhook = new FlowsWebhookCommand();
+			$webhook = new WebhookCommand();
 			$webhook->dispatch( array_slice( $args, 1 ), $assoc_args );
 			return;
 		}

--- a/inc/Cli/Commands/Flows/QueueCommand.php
+++ b/inc/Cli/Commands/Flows/QueueCommand.php
@@ -5,19 +5,19 @@
  * Manages the prompt queue for flow steps.
  * Extracted from FlowsCommand to follow the focused command pattern.
  *
- * @package DataMachine\Cli\Commands
+ * @package DataMachine\Cli\Commands\Flows
  * @since 0.31.0
  * @see https://github.com/Extra-Chill/data-machine/issues/345
  */
 
-namespace DataMachine\Cli\Commands;
+namespace DataMachine\Cli\Commands\Flows;
 
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 
 defined( 'ABSPATH' ) || exit;
 
-class FlowsQueueCommand extends BaseCommand {
+class QueueCommand extends BaseCommand {
 
 	/**
 	 * Dispatch a queue subcommand.


### PR DESCRIPTION
## Summary

- Adds per-flow rate limiting for the `POST /datamachine/v1/trigger/{flow_id}` webhook endpoint
- Transient-based fixed-window counter — default 60 requests per 60 seconds per flow
- Returns **429 Too Many Requests** with `Retry-After` header when exceeded
- New ability: `datamachine/webhook-trigger-rate-limit` for configuring limits
- CLI: `wp datamachine flows webhook rate-limit` for viewing and configuring
- Status command now includes rate limit info in output

## How it works

```
Request → Auth check → Rate limit check → Execute flow
                          ↓ (if exceeded)
                       429 + Retry-After header
```

Rate limit config stored in `scheduling_config.webhook_rate_limit`:
```json
{
  "webhook_rate_limit": {
    "max": 60,
    "window": 60
  }
}
```

Uses WordPress transients as a simple fixed-window counter per flow. Counter resets when the TTL expires.

## CLI

```bash
# View current rate limit
wp datamachine flows webhook rate-limit 42

# Set custom limit
wp datamachine flows webhook rate-limit 42 --max=100 --window=120

# Disable rate limiting
wp datamachine flows webhook rate-limit 42 --max=0
```

## Design decisions

- **Default on** — all webhook-enabled flows get 60/60 rate limiting automatically
- **max=0 disables** — explicit opt-out for trusted internal services
- **Transient-based** — no external deps, works everywhere WordPress runs
- **Fixed window** — simpler than sliding window, sufficient for defense-in-depth

Closes #347