### PR TITLE
feat: Daily memory system — YYYY/MM/DD.md files for agent cognitive history

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -135,6 +135,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/AgentPingAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/TaxonomyAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/AgentMemoryAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/DailyMemoryAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/WorkspaceAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/InternalLinkingAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Content/BlockSanitizer.php';
@@ -175,6 +176,7 @@ function datamachine_run_datamachine_plugin() {
 		new \DataMachine\Abilities\AgentPingAbilities();
 		new \DataMachine\Abilities\TaxonomyAbilities();
 		new \DataMachine\Abilities\AgentMemoryAbilities();
+		new \DataMachine\Abilities\DailyMemoryAbilities();
 		new \DataMachine\Abilities\WorkspaceAbilities();
 		new \DataMachine\Abilities\InternalLinkingAbilities();
 		new \DataMachine\Abilities\Content\GetPostBlocksAbility();

--- a/inc/Abilities/DailyMemoryAbilities.php
+++ b/inc/Abilities/DailyMemoryAbilities.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Daily Memory Abilities
+ *
+ * WordPress 6.9 Abilities API primitives for daily memory operations.
+ * Provides read/write/list access to daily memory files (YYYY/MM/DD.md).
+ *
+ * @package DataMachine\Abilities
+ * @since 0.32.0
+ * @see https://github.com/Extra-Chill/data-machine/issues/348
+ */
+
+namespace DataMachine\Abilities;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\FilesRepository\DailyMemory;
+
+defined( 'ABSPATH' ) || exit;
+
+class DailyMemoryAbilities {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/daily-memory-read',
+				array(
+					'label'               => 'Read Daily Memory',
+					'description'         => 'Read a daily memory file by date. Defaults to today if no date provided.',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'date' => array(
+								'type'        => 'string',
+								'description' => 'Date in YYYY-MM-DD format. Defaults to today.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'date'    => array( 'type' => 'string' ),
+							'content' => array( 'type' => 'string' ),
+							'message' => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'readDaily' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/daily-memory-write',
+				array(
+					'label'               => 'Write Daily Memory',
+					'description'         => 'Write or append to a daily memory file. Use mode "append" to add without replacing.',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'content' => array(
+								'type'        => 'string',
+								'description' => 'Content to write.',
+							),
+							'date'    => array(
+								'type'        => 'string',
+								'description' => 'Date in YYYY-MM-DD format. Defaults to today.',
+							),
+							'mode'    => array(
+								'type'        => 'string',
+								'enum'        => array( 'write', 'append' ),
+								'description' => 'Write mode: "write" replaces the file, "append" adds to end. Defaults to "append".',
+							),
+						),
+						'required'   => array( 'content' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'message' => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'writeDaily' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/daily-memory-list',
+				array(
+					'label'               => 'List Daily Memory Files',
+					'description'         => 'List all daily memory files grouped by month',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'months'  => array(
+								'type'        => 'object',
+								'description' => 'Object with month keys (YYYY/MM) mapping to arrays of day strings',
+							),
+						),
+					),
+					'execute_callback'    => array( self::class, 'listDaily' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Read a daily memory file.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result.
+	 */
+	public static function readDaily( array $input ): array {
+		$daily = new DailyMemory();
+		$date  = $input['date'] ?? gmdate( 'Y-m-d' );
+
+		$parts = self::parseDate( $date );
+		if ( ! $parts ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ),
+			);
+		}
+
+		return $daily->read( $parts['year'], $parts['month'], $parts['day'] );
+	}
+
+	/**
+	 * Write or append to a daily memory file.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result.
+	 */
+	public static function writeDaily( array $input ): array {
+		$daily   = new DailyMemory();
+		$content = $input['content'];
+		$date    = $input['date'] ?? gmdate( 'Y-m-d' );
+		$mode    = $input['mode'] ?? 'append';
+
+		$parts = self::parseDate( $date );
+		if ( ! $parts ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ),
+			);
+		}
+
+		if ( 'write' === $mode ) {
+			return $daily->write( $parts['year'], $parts['month'], $parts['day'], $content );
+		}
+
+		return $daily->append( $parts['year'], $parts['month'], $parts['day'], $content );
+	}
+
+	/**
+	 * List all daily memory files.
+	 *
+	 * @param array $input Input parameters (unused).
+	 * @return array Result.
+	 */
+	public static function listDaily( array $input ): array {
+		$daily = new DailyMemory();
+		return $daily->list_all();
+	}
+
+	/**
+	 * Parse a YYYY-MM-DD date string.
+	 *
+	 * @param string $date Date string.
+	 * @return array{year: string, month: string, day: string}|null
+	 */
+	private static function parseDate( string $date ): ?array {
+		if ( ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ) {
+			return null;
+		}
+
+		return array(
+			'year'  => $matches[1],
+			'month' => $matches[2],
+			'day'   => $matches[3],
+		);
+	}
+}

--- a/inc/Abilities/FileAbilities.php
+++ b/inc/Abilities/FileAbilities.php
@@ -14,6 +14,7 @@ use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\FilesRepository\DailyMemory;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Core\FilesRepository\FileCleanup;
 use DataMachine\Core\FilesRepository\FileStorage;
@@ -855,10 +856,30 @@ class FileAbilities {
 						'filename' => $entry,
 						'size'     => filesize( $filepath ),
 						'modified' => filemtime( $filepath ),
+						'type'     => 'core',
 					);
 				}
 			}
 			closedir( $handle );
+		}
+
+		// Include daily memory summary if the directory exists.
+		$daily        = new DailyMemory();
+		$daily_result = $daily->list_all();
+
+		if ( ! empty( $daily_result['months'] ) ) {
+			$total_days = 0;
+			foreach ( $daily_result['months'] as $days ) {
+				$total_days += count( $days );
+			}
+
+			$files[] = array(
+				'filename'    => 'daily',
+				'type'        => 'daily_summary',
+				'month_count' => count( $daily_result['months'] ),
+				'day_count'   => $total_days,
+				'months'      => $daily_result['months'],
+			);
 		}
 
 		return array(

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -102,6 +102,7 @@ class SettingsAbilities {
 						'flows_per_page'                 => array( 'type' => 'integer' ),
 						'jobs_per_page'                  => array( 'type' => 'integer' ),
 						'site_context_enabled'           => array( 'type' => 'boolean' ),
+						'daily_memory_enabled'           => array( 'type' => 'boolean' ),
 						'default_provider'               => array( 'type' => 'string' ),
 						'default_model'                  => array( 'type' => 'string' ),
 						'agent_models'                   => array(
@@ -348,6 +349,7 @@ class SettingsAbilities {
 				'flows_per_page'                 => $settings['flows_per_page'] ?? 20,
 				'jobs_per_page'                  => $settings['jobs_per_page'] ?? 50,
 				'site_context_enabled'           => $settings['site_context_enabled'] ?? false,
+				'daily_memory_enabled'           => $settings['daily_memory_enabled'] ?? false,
 				'default_provider'               => $settings['default_provider'] ?? '',
 				'default_model'                  => $settings['default_model'] ?? '',
 				'agent_models'                   => $settings['agent_models'] ?? array(),
@@ -406,6 +408,10 @@ class SettingsAbilities {
 
 		if ( isset( $input['site_context_enabled'] ) ) {
 			$all_settings['site_context_enabled'] = (bool) $input['site_context_enabled'];
+		}
+
+		if ( isset( $input['daily_memory_enabled'] ) ) {
+			$all_settings['daily_memory_enabled'] = (bool) $input['daily_memory_enabled'];
 		}
 
 		if ( isset( $input['default_provider'] ) ) {

--- a/inc/Core/Admin/Pages/Agent/assets/css/agent-page.css
+++ b/inc/Core/Admin/Pages/Agent/assets/css/agent-page.css
@@ -278,6 +278,89 @@
 	text-align: center;
 }
 
+/* Daily Memory Section */
+.datamachine-agent-daily-section {
+	border-top: 1px solid #ddd;
+	margin-top: 4px;
+}
+
+.datamachine-agent-daily-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 10px 15px;
+	background: #f6f7f7;
+	border-bottom: 1px solid #e0e0e0;
+}
+
+.datamachine-agent-daily-title {
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: #50575e;
+}
+
+.datamachine-agent-daily-count {
+	font-size: 11px;
+	color: #757575;
+	background: #e0e0e0;
+	padding: 1px 6px;
+	border-radius: 10px;
+}
+
+.datamachine-agent-daily-month-toggle {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	width: 100%;
+	padding: 8px 15px;
+	background: none;
+	border: none;
+	border-bottom: 1px solid #f0f0f0;
+	cursor: pointer;
+	font-size: 12px;
+	color: #1e1e1e;
+	text-align: left;
+}
+
+.datamachine-agent-daily-month-toggle:hover {
+	background: #f6f7f7;
+}
+
+.datamachine-agent-daily-chevron {
+	font-size: 8px;
+	transition: transform 0.15s;
+	color: #757575;
+}
+
+.datamachine-agent-daily-chevron.is-expanded {
+	transform: rotate(90deg);
+}
+
+.datamachine-agent-daily-month-count {
+	margin-left: auto;
+	color: #757575;
+	font-size: 11px;
+}
+
+.datamachine-agent-daily-days {
+	background: #fafafa;
+}
+
+.datamachine-agent-daily-item {
+	padding-left: 30px !important;
+}
+
+.datamachine-agent-daily-item .datamachine-agent-file-item-name {
+	font-size: 12px;
+	font-family: 'SF Mono', Monaco, Menlo, 'Ubuntu Mono', Consolas, monospace;
+}
+
+.datamachine-agent-daily-badge {
+	margin-right: 6px;
+}
+
 /* Responsive */
 @media screen and (max-width: 782px) {
 	.datamachine-agent-layout {

--- a/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
@@ -25,6 +25,12 @@ const TABS = [
 	{ name: 'configuration', title: 'Configuration' },
 ];
 
+/**
+ * Selection model:
+ * - Core file: { type: 'core', filename: 'MEMORY.md' }
+ * - Daily file: { type: 'daily', year: '2026', month: '02', day: '24' }
+ * - null: nothing selected
+ */
 const AgentApp = () => {
 	const [ selectedFile, setSelectedFile ] = useState( null );
 	const { data: files } = useAgentFiles();
@@ -50,7 +56,7 @@ const AgentApp = () => {
 								<div className="datamachine-agent-editor-panel">
 									{ selectedFile ? (
 										<AgentFileEditor
-											filename={ selectedFile }
+											selectedFile={ selectedFile }
 										/>
 									) : (
 										<AgentEmptyState

--- a/inc/Core/Admin/Pages/Agent/assets/react/api/agentFiles.js
+++ b/inc/Core/Admin/Pages/Agent/assets/react/api/agentFiles.js
@@ -43,3 +43,37 @@ export const deleteAgentFile = async ( filename ) => {
 		method: 'DELETE',
 	} );
 };
+
+// Daily memory file operations.
+
+export const listDailyFiles = async () => {
+	const config = getConfig();
+	return apiFetch( {
+		path: `/${ config.restNamespace }/files/agent/daily`,
+	} );
+};
+
+export const getDailyFile = async ( year, month, day ) => {
+	const config = getConfig();
+	return apiFetch( {
+		path: `/${ config.restNamespace }/files/agent/daily/${ year }/${ month }/${ day }`,
+	} );
+};
+
+export const putDailyFile = async ( year, month, day, content ) => {
+	const config = getConfig();
+	return apiFetch( {
+		path: `/${ config.restNamespace }/files/agent/daily/${ year }/${ month }/${ day }`,
+		method: 'PUT',
+		body: content,
+		headers: { 'Content-Type': 'text/plain' },
+	} );
+};
+
+export const deleteDailyFile = async ( year, month, day ) => {
+	const config = getConfig();
+	return apiFetch( {
+		path: `/${ config.restNamespace }/files/agent/daily/${ year }/${ month }/${ day }`,
+		method: 'DELETE',
+	} );
+};

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileEditor.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileEditor.jsx
@@ -2,6 +2,7 @@
  * AgentFileEditor Component
  *
  * Markdown editor panel for agent memory files with save bar.
+ * Handles both core files (SOUL.md, MEMORY.md) and daily memory files.
  */
 
 /**
@@ -16,14 +17,21 @@ import { Spinner } from '@wordpress/components';
 import SettingsSaveBar, {
 	useSaveStatus,
 } from '@shared/components/SettingsSaveBar';
-import { useAgentFile, useSaveAgentFile } from '../queries/agentFiles';
+import {
+	useAgentFile,
+	useSaveAgentFile,
+	useDailyFile,
+	useSaveDailyFile,
+} from '../queries/agentFiles';
 
-const AgentFileEditor = ( { filename } ) => {
+/**
+ * Core file editor — uses existing agent file API.
+ */
+const CoreFileEditor = ( { filename } ) => {
 	const { data: file, isLoading, error } = useAgentFile( filename );
 	const saveMutation = useSaveAgentFile();
 	const [ content, setContent ] = useState( '' );
 
-	// Sync content when file data loads or filename changes.
 	useEffect( () => {
 		if ( file?.content !== undefined ) {
 			setContent( file.content );
@@ -45,7 +53,6 @@ const AgentFileEditor = ( { filename } ) => {
 		[ markChanged ]
 	);
 
-	// Reset dirty state when switching files.
 	useEffect( () => {
 		setHasChanges( false );
 	}, [ filename, setHasChanges ] );
@@ -89,6 +96,113 @@ const AgentFileEditor = ( { filename } ) => {
 			/>
 		</div>
 	);
+};
+
+/**
+ * Daily file editor — uses daily memory API routes.
+ */
+const DailyFileEditor = ( { year, month, day } ) => {
+	const { data: file, isLoading, error } = useDailyFile( year, month, day );
+	const saveMutation = useSaveDailyFile();
+	const [ content, setContent ] = useState( '' );
+	const dateLabel = `${ year }-${ month }-${ day }`;
+
+	useEffect( () => {
+		if ( file?.content !== undefined ) {
+			setContent( file.content );
+		}
+	}, [ file ] );
+
+	const { saveStatus, hasChanges, markChanged, handleSave, setHasChanges } =
+		useSaveStatus( {
+			onSave: async () => {
+				await saveMutation.mutateAsync( {
+					year,
+					month,
+					day,
+					content,
+				} );
+			},
+		} );
+
+	const handleContentChange = useCallback(
+		( e ) => {
+			setContent( e.target.value );
+			markChanged();
+		},
+		[ markChanged ]
+	);
+
+	useEffect( () => {
+		setHasChanges( false );
+	}, [ year, month, day, setHasChanges ] );
+
+	if ( isLoading ) {
+		return (
+			<div className="datamachine-agent-editor">
+				<div className="datamachine-agent-editor-loading">
+					<Spinner />
+					<span>Loading daily memory...</span>
+				</div>
+			</div>
+		);
+	}
+
+	if ( error ) {
+		return (
+			<div className="datamachine-agent-editor">
+				<div className="datamachine-agent-editor-error">
+					Failed to load daily memory:{' '}
+					{ error.message || 'Unknown error' }
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="datamachine-agent-editor">
+			<div className="datamachine-agent-editor-header">
+				<h3>
+					<span className="datamachine-agent-daily-badge">
+						&#x1f4c5;
+					</span>
+					{ dateLabel }
+				</h3>
+			</div>
+			<textarea
+				className="datamachine-agent-editor-textarea code"
+				value={ content }
+				onChange={ handleContentChange }
+				spellCheck={ false }
+			/>
+			<SettingsSaveBar
+				hasChanges={ hasChanges }
+				saveStatus={ saveStatus }
+				onSave={ handleSave }
+			/>
+		</div>
+	);
+};
+
+/**
+ * Router component — dispatches to core or daily editor.
+ */
+const AgentFileEditor = ( { selectedFile } ) => {
+	if ( ! selectedFile ) {
+		return null;
+	}
+
+	if ( selectedFile.type === 'daily' ) {
+		return (
+			<DailyFileEditor
+				year={ selectedFile.year }
+				month={ selectedFile.month }
+				day={ selectedFile.day }
+			/>
+		);
+	}
+
+	return <CoreFileEditor filename={ selectedFile.filename } />;
 };
 
 export default AgentFileEditor;

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentSettings.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentSettings.jsx
@@ -23,6 +23,7 @@ const DEFAULTS = {
 	default_model: '',
 	agent_models: {},
 	site_context_enabled: false,
+	daily_memory_enabled: false,
 	max_turns: 12,
 };
 
@@ -94,6 +95,8 @@ const AgentSettings = () => {
 				agent_models: data.settings.agent_models || {},
 				site_context_enabled:
 					data.settings.site_context_enabled ?? false,
+				daily_memory_enabled:
+					data.settings.daily_memory_enabled ?? false,
 				max_turns: data.settings.max_turns ?? 12,
 			} );
 			save.setHasChanges( false );
@@ -411,6 +414,36 @@ const AgentSettings = () => {
 									Automatically provides site information
 									(post types, taxonomies, user stats) to AI
 									agents for better context awareness.
+								</p>
+							</fieldset>
+						</td>
+					</tr>
+
+					<tr>
+						<th scope="row">Daily memory</th>
+						<td>
+							<fieldset>
+								<label htmlFor="daily_memory_enabled">
+									<input
+										type="checkbox"
+										id="daily_memory_enabled"
+										checked={
+											form.data.daily_memory_enabled
+										}
+										onChange={ ( e ) =>
+											updateField(
+												'daily_memory_enabled',
+												e.target.checked
+											)
+										}
+									/>
+									Enable daily memory files
+								</label>
+								<p className="description">
+									Automatically create daily memory files
+									(YYYY/MM/DD.md) for agent session history.
+									Daily memory is append-only cognitive
+									history — not logs.
 								</p>
 							</fieldset>
 						</td>

--- a/inc/Core/FilesRepository/DailyMemory.php
+++ b/inc/Core/FilesRepository/DailyMemory.php
@@ -1,0 +1,355 @@
+<?php
+/**
+ * Daily Memory Service
+ *
+ * Provides structured read/write operations for daily agent memory files.
+ * Files are stored at agent/daily/YYYY/MM/DD.md following the WordPress
+ * Media Library date convention (wp-content/uploads/YYYY/MM/).
+ *
+ * Daily memory is append-only cognitive history — what happened each day.
+ * It is NOT logs (operational telemetry). It persists agent knowledge and
+ * is never auto-cleared.
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since 0.32.0
+ * @see https://github.com/Extra-Chill/data-machine/issues/348
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+class DailyMemory {
+
+	/**
+	 * @var DirectoryManager
+	 */
+	private DirectoryManager $directory_manager;
+
+	/**
+	 * @var string Base path for daily memory files (agent/daily/).
+	 */
+	private string $base_path;
+
+	public function __construct() {
+		$this->directory_manager = new DirectoryManager();
+		$agent_dir               = $this->directory_manager->get_agent_directory();
+		$this->base_path         = "{$agent_dir}/daily";
+	}
+
+	/**
+	 * Get the base path for daily memory files.
+	 *
+	 * @return string
+	 */
+	public function get_base_path(): string {
+		return $this->base_path;
+	}
+
+	/**
+	 * Build the file path for a given date.
+	 *
+	 * @param string $year  Four-digit year (e.g. '2026').
+	 * @param string $month Two-digit month (e.g. '02').
+	 * @param string $day   Two-digit day (e.g. '24').
+	 * @return string Full file path.
+	 */
+	public function get_file_path( string $year, string $month, string $day ): string {
+		return "{$this->base_path}/{$year}/{$month}/{$day}.md";
+	}
+
+	/**
+	 * Get today's file path.
+	 *
+	 * @return string Full file path for today.
+	 */
+	public function get_today_path(): string {
+		return $this->get_file_path(
+			gmdate( 'Y' ),
+			gmdate( 'm' ),
+			gmdate( 'd' )
+		);
+	}
+
+	/**
+	 * Check if a daily file exists.
+	 *
+	 * @param string $year  Four-digit year.
+	 * @param string $month Two-digit month.
+	 * @param string $day   Two-digit day.
+	 * @return bool
+	 */
+	public function exists( string $year, string $month, string $day ): bool {
+		return file_exists( $this->get_file_path( $year, $month, $day ) );
+	}
+
+	/**
+	 * Read a daily memory file.
+	 *
+	 * @param string $year  Four-digit year.
+	 * @param string $month Two-digit month.
+	 * @param string $day   Two-digit day.
+	 * @return array{success: bool, content?: string, date?: string, message?: string}
+	 */
+	public function read( string $year, string $month, string $day ): array {
+		$file_path = $this->get_file_path( $year, $month, $day );
+
+		if ( ! file_exists( $file_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'No daily memory for %s-%s-%s.', $year, $month, $day ),
+			);
+		}
+
+		$content = file_get_contents( $file_path );
+
+		return array(
+			'success' => true,
+			'date'    => "{$year}-{$month}-{$day}",
+			'content' => $content,
+		);
+	}
+
+	/**
+	 * Write (replace) content for a daily memory file.
+	 *
+	 * Creates the directory structure if needed.
+	 *
+	 * @param string $year    Four-digit year.
+	 * @param string $month   Two-digit month.
+	 * @param string $day     Two-digit day.
+	 * @param string $content Full file content.
+	 * @return array{success: bool, message: string}
+	 */
+	public function write( string $year, string $month, string $day, string $content ): array {
+		$file_path = $this->get_file_path( $year, $month, $day );
+		$dir       = dirname( $file_path );
+
+		if ( ! $this->directory_manager->ensure_directory_exists( $dir ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to create directory for %s-%s-%s.', $year, $month, $day ),
+			);
+		}
+
+		$written = file_put_contents( $file_path, $content );
+
+		if ( false === $written ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to write daily memory for %s-%s-%s.', $year, $month, $day ),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'message' => sprintf( 'Daily memory for %s-%s-%s saved.', $year, $month, $day ),
+		);
+	}
+
+	/**
+	 * Append content to a daily memory file.
+	 *
+	 * Creates the file with a date header if it doesn't exist.
+	 *
+	 * @param string $year    Four-digit year.
+	 * @param string $month   Two-digit month.
+	 * @param string $day     Two-digit day.
+	 * @param string $content Content to append.
+	 * @return array{success: bool, message: string}
+	 */
+	public function append( string $year, string $month, string $day, string $content ): array {
+		$file_path = $this->get_file_path( $year, $month, $day );
+		$dir       = dirname( $file_path );
+
+		if ( ! $this->directory_manager->ensure_directory_exists( $dir ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to create directory for %s-%s-%s.', $year, $month, $day ),
+			);
+		}
+
+		// If file doesn't exist, create with date header.
+		if ( ! file_exists( $file_path ) ) {
+			$header  = "# {$year}-{$month}-{$day}\n\n";
+			$written = file_put_contents( $file_path, $header . $content . "\n" );
+		} else {
+			$written = file_put_contents( $file_path, $content . "\n", FILE_APPEND );
+		}
+
+		if ( false === $written ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to append to daily memory for %s-%s-%s.', $year, $month, $day ),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'message' => sprintf( 'Content appended to daily memory for %s-%s-%s.', $year, $month, $day ),
+		);
+	}
+
+	/**
+	 * Delete a daily memory file.
+	 *
+	 * @param string $year  Four-digit year.
+	 * @param string $month Two-digit month.
+	 * @param string $day   Two-digit day.
+	 * @return array{success: bool, message: string}
+	 */
+	public function delete( string $year, string $month, string $day ): array {
+		$file_path = $this->get_file_path( $year, $month, $day );
+
+		if ( ! file_exists( $file_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'No daily memory for %s-%s-%s to delete.', $year, $month, $day ),
+			);
+		}
+
+		wp_delete_file( $file_path );
+
+		// wp_delete_file returns void, check if file still exists.
+		if ( file_exists( $file_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to delete daily memory for %s-%s-%s.', $year, $month, $day ),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'message' => sprintf( 'Daily memory for %s-%s-%s deleted.', $year, $month, $day ),
+		);
+	}
+
+	/**
+	 * List all daily memory files grouped by month.
+	 *
+	 * Returns structure: [ '2026/02' => [ '24', '25' ], '2026/01' => [ '15' ] ]
+	 *
+	 * @return array{success: bool, months: array<string, string[]>}
+	 */
+	public function list_all(): array {
+		$months = array();
+
+		if ( ! is_dir( $this->base_path ) ) {
+			return array(
+				'success' => true,
+				'months'  => $months,
+			);
+		}
+
+		$year_dirs = $this->scan_sorted_dirs( $this->base_path );
+
+		foreach ( $year_dirs as $year ) {
+			if ( ! preg_match( '/^\d{4}$/', $year ) ) {
+				continue;
+			}
+
+			$year_path  = "{$this->base_path}/{$year}";
+			$month_dirs = $this->scan_sorted_dirs( $year_path );
+
+			foreach ( $month_dirs as $month ) {
+				if ( ! preg_match( '/^\d{2}$/', $month ) ) {
+					continue;
+				}
+
+				$month_path = "{$year_path}/{$month}";
+				$day_files  = $this->scan_sorted_files( $month_path, '.md' );
+
+				if ( ! empty( $day_files ) ) {
+					$key            = "{$year}/{$month}";
+					$months[ $key ] = $day_files;
+				}
+			}
+		}
+
+		// Sort by key descending (newest months first).
+		krsort( $months );
+
+		return array(
+			'success' => true,
+			'months'  => $months,
+		);
+	}
+
+	/**
+	 * List months that have daily memory files.
+	 *
+	 * @return array{success: bool, months: string[]}
+	 */
+	public function list_months(): array {
+		$result = $this->list_all();
+		return array(
+			'success' => true,
+			'months'  => array_keys( $result['months'] ),
+		);
+	}
+
+	// =========================================================================
+	// Internal Helpers
+	// =========================================================================
+
+	/**
+	 * Scan a directory for sorted subdirectory names.
+	 *
+	 * @param string $path Directory to scan.
+	 * @return string[] Sorted directory names.
+	 */
+	private function scan_sorted_dirs( string $path ): array {
+		$entries = array();
+		$handle  = opendir( $path );
+
+		if ( ! $handle ) {
+			return $entries;
+		}
+
+		while ( false !== ( $entry = readdir( $handle ) ) ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			if ( is_dir( "{$path}/{$entry}" ) ) {
+				$entries[] = $entry;
+			}
+		}
+
+		closedir( $handle );
+		sort( $entries );
+
+		return $entries;
+	}
+
+	/**
+	 * Scan a directory for sorted file names (without extension).
+	 *
+	 * @param string $path      Directory to scan.
+	 * @param string $extension File extension to filter by (e.g. '.md').
+	 * @return string[] Sorted file basenames (without extension).
+	 */
+	private function scan_sorted_files( string $path, string $extension ): array {
+		$entries = array();
+		$handle  = opendir( $path );
+
+		if ( ! $handle ) {
+			return $entries;
+		}
+
+		$ext_len = strlen( $extension );
+
+		while ( false !== ( $entry = readdir( $handle ) ) ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			if ( is_file( "{$path}/{$entry}" ) && substr( $entry, -$ext_len ) === $extension ) {
+				$entries[] = substr( $entry, 0, -$ext_len );
+			}
+		}
+
+		closedir( $handle );
+		sort( $entries );
+
+		return $entries;
+	}
+}


### PR DESCRIPTION
## Summary

Full-stack implementation of daily memory files for agent cognitive history, following the WordPress Media Library date convention (`agent/daily/YYYY/MM/DD.md`).

Closes #348

## What's included

### PHP Backend
- **`DailyMemory.php`** — Core class with write, append, read, delete, list_all, list_months, exists
- **`Files.php`** — REST routes: `GET/PUT/DELETE /files/agent/daily/{year}/{month}/{day}` + list endpoint
- **`DailyMemoryAbilities.php`** — Three abilities for AI agent tools (read, write, list)
- **`FileAbilities.php`** — `listAgentFiles()` now includes daily memory summary with month/day counts
- **`SettingsAbilities.php`** — `daily_memory_enabled` setting (off by default)
- **`AgentCommand.php`** — CLI: `wp datamachine agent daily [list|read|write|append|delete]`

### React Frontend
- **`AgentFileList.jsx`** — Grouped sidebar: core files section + collapsible daily memory section by month
- **`AgentFileEditor.jsx`** — Handles both core files and daily files (different API routes)
- **`AgentSettings.jsx`** — Daily memory enabled toggle
- **`agentFiles.js`** (api + queries) — TanStack Query hooks for daily file CRUD
- **`agent-page.css`** — Styles for daily memory sections, month toggles, chevron animations

## Design decisions
- **Off by default** — Opt-in via Configuration tab. Not every DM install uses agents.
- **NOT logs** — Daily memory is cognitive persistence (never auto-cleared), distinct from operational telemetry.
- **Append-only by default** — The `append` mode creates files with date headers automatically.
- **Selection model** — Changed from simple string to `{ type: 'core', filename }` or `{ type: 'daily', year, month, day }` objects.