### PR TITLE
feat: Workspace file operations and abilities-first refactor

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -2,11 +2,11 @@
 /**
  * Workspace Abilities
  *
- * WordPress 6.9 Abilities API primitives for agent workspace operations.
- * Provides read-only discovery of the workspace path and repo listing.
+ * WordPress 6.9 Abilities API primitives for all agent workspace operations.
+ * These are the canonical entry points — CLI commands and chat tools delegate here.
  *
- * Note: Clone and remove operations are intentionally CLI-only for now.
- * See issue #338 for future exploration of coding capabilities.
+ * Read-only abilities (path, list, show, read, ls) are exposed via REST.
+ * Mutating abilities (clone, remove) are CLI-only (show_in_rest = false).
  *
  * @package DataMachine\Abilities
  * @since 0.31.0
@@ -16,6 +16,8 @@ namespace DataMachine\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\FilesRepository\Workspace;
+use DataMachine\Core\FilesRepository\WorkspaceReader;
+use DataMachine\Core\FilesRepository\WorkspaceWriter;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -38,15 +40,25 @@ class WorkspaceAbilities {
 
 	private function registerAbilities(): void {
 		$register_callback = function () {
+
+			// -----------------------------------------------------------------
+			// Read-only discovery abilities (show_in_rest = true).
+			// -----------------------------------------------------------------
+
 			wp_register_ability(
 				'datamachine/workspace-path',
 				array(
 					'label'               => 'Get Workspace Path',
-					'description'         => 'Get the agent workspace directory path',
+					'description'         => 'Get the agent workspace directory path. Optionally create the directory.',
 					'category'            => 'datamachine',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'properties' => array(),
+						'properties' => array(
+							'ensure' => array(
+								'type'        => 'boolean',
+								'description' => 'Create the workspace directory if it does not exist.',
+							),
+						),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -54,6 +66,7 @@ class WorkspaceAbilities {
 							'success' => array( 'type' => 'boolean' ),
 							'path'    => array( 'type' => 'string' ),
 							'exists'  => array( 'type' => 'boolean' ),
+							'created' => array( 'type' => 'boolean' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'getPath' ),
@@ -66,7 +79,7 @@ class WorkspaceAbilities {
 				'datamachine/workspace-list',
 				array(
 					'label'               => 'List Workspace Repos',
-					'description'         => 'List repositories in the agent workspace',
+					'description'         => 'List repositories in the agent workspace.',
 					'category'            => 'datamachine',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -97,6 +110,281 @@ class WorkspaceAbilities {
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
+
+			wp_register_ability(
+				'datamachine/workspace-show',
+				array(
+					'label'               => 'Show Workspace Repo',
+					'description'         => 'Show detailed info about a workspace repository (branch, remote, latest commit, dirty status).',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'name' => array(
+								'type'        => 'string',
+								'description' => 'Repository directory name.',
+							),
+						),
+						'required'   => array( 'name' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'name'    => array( 'type' => 'string' ),
+							'path'    => array( 'type' => 'string' ),
+							'branch'  => array( 'type' => 'string' ),
+							'remote'  => array( 'type' => 'string' ),
+							'commit'  => array( 'type' => 'string' ),
+							'dirty'   => array( 'type' => 'integer' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'showRepo' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			// -----------------------------------------------------------------
+			// File reading abilities (show_in_rest = true).
+			// -----------------------------------------------------------------
+
+			wp_register_ability(
+				'datamachine/workspace-read',
+				array(
+					'label'               => 'Read Workspace File',
+					'description'         => 'Read the contents of a text file from a workspace repository.',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'repo'     => array(
+								'type'        => 'string',
+								'description' => 'Repository directory name.',
+							),
+							'path'     => array(
+								'type'        => 'string',
+								'description' => 'Relative file path within the repo.',
+							),
+							'max_size' => array(
+								'type'        => 'integer',
+								'description' => 'Maximum file size in bytes (default 1 MB).',
+							),
+						),
+						'required'   => array( 'repo', 'path' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'content' => array( 'type' => 'string' ),
+							'path'    => array( 'type' => 'string' ),
+							'size'    => array( 'type' => 'integer' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'readFile' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/workspace-ls',
+				array(
+					'label'               => 'List Workspace Directory',
+					'description'         => 'List directory contents within a workspace repository.',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'repo' => array(
+								'type'        => 'string',
+								'description' => 'Repository directory name.',
+							),
+							'path' => array(
+								'type'        => 'string',
+								'description' => 'Relative directory path within the repo (omit for root).',
+							),
+						),
+						'required'   => array( 'repo' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'repo'    => array( 'type' => 'string' ),
+							'path'    => array( 'type' => 'string' ),
+							'entries' => array(
+								'type'  => 'array',
+								'items' => array(
+									'type'       => 'object',
+									'properties' => array(
+										'name' => array( 'type' => 'string' ),
+										'type' => array( 'type' => 'string' ),
+										'size' => array( 'type' => 'integer' ),
+									),
+								),
+							),
+						),
+					),
+					'execute_callback'    => array( self::class, 'listDirectory' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			// -----------------------------------------------------------------
+			// Mutating abilities (show_in_rest = false, CLI-only).
+			// -----------------------------------------------------------------
+
+			wp_register_ability(
+				'datamachine/workspace-clone',
+				array(
+					'label'               => 'Clone Workspace Repo',
+					'description'         => 'Clone a git repository into the workspace.',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'url'  => array(
+								'type'        => 'string',
+								'description' => 'Git repository URL to clone.',
+							),
+							'name' => array(
+								'type'        => 'string',
+								'description' => 'Directory name override (derived from URL if omitted).',
+							),
+						),
+						'required'   => array( 'url' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'name'    => array( 'type' => 'string' ),
+							'path'    => array( 'type' => 'string' ),
+							'message' => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'cloneRepo' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/workspace-remove',
+				array(
+					'label'               => 'Remove Workspace Repo',
+					'description'         => 'Remove a repository from the workspace.',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'name' => array(
+								'type'        => 'string',
+								'description' => 'Repository directory name to remove.',
+							),
+						),
+						'required'   => array( 'name' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'message' => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'removeRepo' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/workspace-write',
+				array(
+					'label'               => 'Write Workspace File',
+					'description'         => 'Create or overwrite a file in a workspace repository.',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'repo'    => array(
+								'type'        => 'string',
+								'description' => 'Repository directory name.',
+							),
+							'path'    => array(
+								'type'        => 'string',
+								'description' => 'Relative file path within the repo.',
+							),
+							'content' => array(
+								'type'        => 'string',
+								'description' => 'File content to write.',
+							),
+						),
+						'required'   => array( 'repo', 'path', 'content' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'path'    => array( 'type' => 'string' ),
+							'size'    => array( 'type' => 'integer' ),
+							'created' => array( 'type' => 'boolean' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'writeFile' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/workspace-edit',
+				array(
+					'label'               => 'Edit Workspace File',
+					'description'         => 'Find-and-replace text in a workspace repository file.',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'repo'        => array(
+								'type'        => 'string',
+								'description' => 'Repository directory name.',
+							),
+							'path'        => array(
+								'type'        => 'string',
+								'description' => 'Relative file path within the repo.',
+							),
+							'old_string'  => array(
+								'type'        => 'string',
+								'description' => 'Text to find.',
+							),
+							'new_string'  => array(
+								'type'        => 'string',
+								'description' => 'Replacement text.',
+							),
+							'replace_all' => array(
+								'type'        => 'boolean',
+								'description' => 'Replace all occurrences (default false).',
+							),
+						),
+						'required'   => array( 'repo', 'path', 'old_string', 'new_string' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'      => array( 'type' => 'boolean' ),
+							'path'         => array( 'type' => 'string' ),
+							'replacements' => array( 'type' => 'integer' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'editFile' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
 		};
 
 		if ( did_action( 'wp_abilities_api_init' ) ) {
@@ -106,14 +394,29 @@ class WorkspaceAbilities {
 		}
 	}
 
+	// =========================================================================
+	// Ability callbacks
+	// =========================================================================
+
 	/**
-	 * Get workspace path.
+	 * Get workspace path, optionally ensuring the directory exists.
 	 *
-	 * @param array $input Input parameters (unused).
+	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
 	public static function getPath( array $input ): array {
 		$workspace = new Workspace();
+
+		if ( ! empty( $input['ensure'] ) ) {
+			$result = $workspace->ensure_exists();
+			return array(
+				'success' => $result['success'],
+				'path'    => $workspace->get_path(),
+				'exists'  => $result['success'],
+				'created' => $result['created'] ?? false,
+				'message' => $result['message'] ?? null,
+			);
+		}
 
 		return array(
 			'success' => true,
@@ -125,11 +428,121 @@ class WorkspaceAbilities {
 	/**
 	 * List workspace repos.
 	 *
-	 * @param array $input Input parameters (unused).
+	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
 	public static function listRepos( array $input ): array {
 		$workspace = new Workspace();
 		return $workspace->list_repos();
+	}
+
+	/**
+	 * Show detailed repo info.
+	 *
+	 * @param array $input Input parameters with 'name'.
+	 * @return array Result.
+	 */
+	public static function showRepo( array $input ): array {
+		$workspace = new Workspace();
+		return $workspace->show_repo( $input['name'] ?? '' );
+	}
+
+	/**
+	 * Read a file from a workspace repo.
+	 *
+	 * @param array $input Input parameters with 'repo', 'path', optional 'max_size'.
+	 * @return array Result.
+	 */
+	public static function readFile( array $input ): array {
+		$workspace = new Workspace();
+		$reader    = new WorkspaceReader( $workspace );
+
+		$args = array(
+			$input['repo'] ?? '',
+			$input['path'] ?? '',
+		);
+
+		if ( isset( $input['max_size'] ) ) {
+			$args[] = (int) $input['max_size'];
+		}
+
+		return $reader->read_file( ...$args );
+	}
+
+	/**
+	 * List directory contents within a workspace repo.
+	 *
+	 * @param array $input Input parameters with 'repo', optional 'path'.
+	 * @return array Result.
+	 */
+	public static function listDirectory( array $input ): array {
+		$workspace = new Workspace();
+		$reader    = new WorkspaceReader( $workspace );
+
+		return $reader->list_directory(
+			$input['repo'] ?? '',
+			$input['path'] ?? null
+		);
+	}
+
+	/**
+	 * Clone a git repository into the workspace.
+	 *
+	 * @param array $input Input parameters with 'url', optional 'name'.
+	 * @return array Result.
+	 */
+	public static function cloneRepo( array $input ): array {
+		$workspace = new Workspace();
+		return $workspace->clone_repo(
+			$input['url'] ?? '',
+			$input['name'] ?? null
+		);
+	}
+
+	/**
+	 * Remove a repository from the workspace.
+	 *
+	 * @param array $input Input parameters with 'name'.
+	 * @return array Result.
+	 */
+	public static function removeRepo( array $input ): array {
+		$workspace = new Workspace();
+		return $workspace->remove_repo( $input['name'] ?? '' );
+	}
+
+	/**
+	 * Write (create or overwrite) a file in a workspace repo.
+	 *
+	 * @param array $input Input parameters with 'repo', 'path', 'content'.
+	 * @return array Result.
+	 */
+	public static function writeFile( array $input ): array {
+		$workspace = new Workspace();
+		$writer    = new WorkspaceWriter( $workspace );
+
+		return $writer->write_file(
+			$input['repo'] ?? '',
+			$input['path'] ?? '',
+			$input['content'] ?? ''
+		);
+	}
+
+	/**
+	 * Edit a file in a workspace repo via find-and-replace.
+	 *
+	 * @param array $input Input parameters with 'repo', 'path', 'old_string', 'new_string', optional 'replace_all'.
+	 * @return array Result.
+	 */
+	public static function editFile( array $input ): array {
+		$workspace = new Workspace();
+		$writer    = new WorkspaceWriter( $workspace );
+
+		return $writer->edit_file(
+			$input['repo'] ?? '',
+			$input['path'] ?? '',
+			$input['old_string'] ?? '',
+			$input['new_string'] ?? '',
+			! empty( $input['replace_all'] )
+		);
 	}
 }

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -5,6 +5,10 @@
  * Provides CLI access to the agent workspace — a managed directory
  * for cloning repos and working with files outside the web root.
  *
+ * All commands delegate to WordPress Abilities API primitives registered
+ * in WorkspaceAbilities. The CLI layer handles argument parsing, confirmation
+ * prompts, and output formatting only.
+ *
  * @package DataMachine\Cli\Commands
  * @since 0.31.0
  */
@@ -43,25 +47,29 @@ class WorkspaceCommand extends BaseCommand {
 	 * @subcommand path
 	 */
 	public function path( array $args, array $assoc_args ): void {
-		$workspace = new Workspace();
-		$path      = $workspace->get_path();
-		$exists    = is_dir( $path );
-
-		if ( ! empty( $assoc_args['ensure'] ) ) {
-			$result = $workspace->ensure_exists();
-			if ( ! $result['success'] ) {
-				WP_CLI::error( $result['message'] );
-				return;
-			}
-			if ( ! empty( $result['created'] ) ) {
-				WP_CLI::success( sprintf( 'Created workspace: %s', $path ) );
-				return;
-			}
+		$ability = wp_get_ability( 'datamachine/workspace-path' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace path ability not available.' );
+			return;
 		}
 
-		WP_CLI::log( $path );
+		$result = $ability->execute( array(
+			'ensure' => ! empty( $assoc_args['ensure'] ),
+		) );
 
-		if ( ! $exists && empty( $assoc_args['ensure'] ) ) {
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( ! empty( $result['created'] ) ) {
+			WP_CLI::success( sprintf( 'Created workspace: %s', $result['path'] ) );
+			return;
+		}
+
+		WP_CLI::log( $result['path'] );
+
+		if ( empty( $result['exists'] ) && empty( $assoc_args['ensure'] ) ) {
 			WP_CLI::warning( 'Directory does not exist yet. Use --ensure to create it.' );
 		}
 	}
@@ -93,12 +101,21 @@ class WorkspaceCommand extends BaseCommand {
 	 * @subcommand list
 	 */
 	public function list_repos( array $args, array $assoc_args ): void {
-		$workspace = new Workspace();
-		$result    = $workspace->list_repos();
+		$ability = wp_get_ability( 'datamachine/workspace-list' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace list ability not available.' );
+			return;
+		}
+
+		$result = $ability->execute( array() );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( empty( $result['repos'] ) ) {
-			$path = $workspace->get_path();
-			WP_CLI::log( sprintf( 'No repos in workspace (%s).', $path ) );
+			WP_CLI::log( sprintf( 'No repos in workspace (%s).', $result['path'] ?? '' ) );
 			WP_CLI::log( 'Clone one with: wp datamachine workspace clone <url>' );
 			return;
 		}
@@ -151,11 +168,21 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		$url  = $args[0];
-		$name = $assoc_args['name'] ?? null;
+		$ability = wp_get_ability( 'datamachine/workspace-clone' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace clone ability not available.' );
+			return;
+		}
 
-		$workspace = new Workspace();
-		$result    = $workspace->clone_repo( $url, $name );
+		$result = $ability->execute( array(
+			'url'  => $args[0],
+			'name' => $assoc_args['name'] ?? null,
+		) );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['message'] );
@@ -193,21 +220,27 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		$name      = $args[0];
-		$workspace = new Workspace();
-		$repo_path = $workspace->get_repo_path( $name );
+		$name = $args[0];
 
-		if ( ! is_dir( $repo_path ) ) {
-			WP_CLI::error( sprintf( 'Repository "%s" not found in workspace.', $name ) );
-			return;
-		}
-
-		// Confirm unless --yes is passed.
+		// Confirm unless --yes is passed. This stays in CLI — abilities don't prompt.
 		if ( empty( $assoc_args['yes'] ) ) {
+			$workspace = new Workspace();
+			$repo_path = $workspace->get_repo_path( $name );
 			WP_CLI::confirm( sprintf( 'Remove "%s" from workspace? This deletes %s', $name, $repo_path ) );
 		}
 
-		$result = $workspace->remove_repo( $name );
+		$ability = wp_get_ability( 'datamachine/workspace-remove' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace remove ability not available.' );
+			return;
+		}
+
+		$result = $ability->execute( array( 'name' => $name ) );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['message'] );
@@ -238,30 +271,348 @@ class WorkspaceCommand extends BaseCommand {
 			return;
 		}
 
-		$name      = $args[0];
-		$workspace = new Workspace();
-		$repo_path = $workspace->get_repo_path( $name );
-
-		if ( ! is_dir( $repo_path ) ) {
-			WP_CLI::error( sprintf( 'Repository "%s" not found in workspace.', $name ) );
+		$ability = wp_get_ability( 'datamachine/workspace-show' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace show ability not available.' );
 			return;
 		}
 
-		$escaped = escapeshellarg( $repo_path );
+		$result = $ability->execute( array( 'name' => $args[0] ) );
 
-		// Gather info.
-		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
-		$branch = trim( (string) exec( sprintf( 'git -C %s rev-parse --abbrev-ref HEAD 2>/dev/null', $escaped ) ) );
-		$remote = trim( (string) exec( sprintf( 'git -C %s config --get remote.origin.url 2>/dev/null', $escaped ) ) );
-		$commit = trim( (string) exec( sprintf( 'git -C %s log -1 --format="%%h %%s" 2>/dev/null', $escaped ) ) );
-		$status = trim( (string) exec( sprintf( 'git -C %s status --porcelain 2>/dev/null | wc -l', $escaped ) ) );
-		// phpcs:enable
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
-		WP_CLI::log( sprintf( 'Name:     %s', $name ) );
-		WP_CLI::log( sprintf( 'Path:     %s', $repo_path ) );
-		WP_CLI::log( sprintf( 'Branch:   %s', $branch ?: '-' ) );
-		WP_CLI::log( sprintf( 'Remote:   %s', $remote ?: '-' ) );
-		WP_CLI::log( sprintf( 'Latest:   %s', $commit ?: '-' ) );
-		WP_CLI::log( sprintf( 'Dirty:    %s', ( '0' === $status ) ? 'no' : "yes ({$status} files)" ) );
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['message'] );
+			return;
+		}
+
+		WP_CLI::log( sprintf( 'Name:     %s', $result['name'] ) );
+		WP_CLI::log( sprintf( 'Path:     %s', $result['path'] ) );
+		WP_CLI::log( sprintf( 'Branch:   %s', $result['branch'] ?? '-' ) );
+		WP_CLI::log( sprintf( 'Remote:   %s', $result['remote'] ?? '-' ) );
+		WP_CLI::log( sprintf( 'Latest:   %s', $result['commit'] ?? '-' ) );
+
+		$dirty = $result['dirty'] ?? 0;
+		WP_CLI::log( sprintf( 'Dirty:    %s', ( 0 === $dirty ) ? 'no' : "yes ({$dirty} files)" ) );
+	}
+
+	/**
+	 * Read a file from a workspace repo.
+	 *
+	 * Reads text file contents from a cloned repository in the workspace.
+	 * Binary files are detected and rejected. Large files are limited by
+	 * --max-size (default 1 MB).
+	 *
+	 * ## OPTIONS
+	 *
+	 * <repo>
+	 * : Repository directory name.
+	 *
+	 * <path>
+	 * : Relative file path within the repo.
+	 *
+	 * [--max-size=<bytes>]
+	 * : Maximum file size in bytes.
+	 * ---
+	 * default: 1048576
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Read a file
+	 *     wp datamachine workspace read homeboy src/main.rs
+	 *
+	 *     # Read with custom size limit
+	 *     wp datamachine workspace read homeboy Cargo.toml --max-size=2097152
+	 *
+	 * @subcommand read
+	 */
+	public function read( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) || empty( $args[1] ) ) {
+			WP_CLI::error( 'Usage: wp datamachine workspace read <repo> <path>' );
+			return;
+		}
+
+		$ability = wp_get_ability( 'datamachine/workspace-read' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace read ability not available.' );
+			return;
+		}
+
+		$input = array(
+			'repo' => $args[0],
+			'path' => $args[1],
+		);
+
+		if ( isset( $assoc_args['max-size'] ) ) {
+			$input['max_size'] = (int) $assoc_args['max-size'];
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['message'] );
+			return;
+		}
+
+		// Output raw content — suitable for piping.
+		WP_CLI::log( $result['content'] );
+	}
+
+	/**
+	 * List directory contents within a workspace repo.
+	 *
+	 * Lists files and directories. Directories are listed first, then
+	 * files, both sorted alphabetically.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <repo>
+	 * : Repository directory name.
+	 *
+	 * [<path>]
+	 * : Relative directory path within the repo (defaults to root).
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # List repo root
+	 *     wp datamachine workspace ls homeboy
+	 *
+	 *     # List subdirectory
+	 *     wp datamachine workspace ls homeboy src/commands
+	 *
+	 *     # List as JSON
+	 *     wp datamachine workspace ls homeboy --format=json
+	 *
+	 * @subcommand ls
+	 */
+	public function ls( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) ) {
+			WP_CLI::error( 'Usage: wp datamachine workspace ls <repo> [<path>]' );
+			return;
+		}
+
+		$ability = wp_get_ability( 'datamachine/workspace-ls' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace ls ability not available.' );
+			return;
+		}
+
+		$input = array( 'repo' => $args[0] );
+
+		if ( ! empty( $args[1] ) ) {
+			$input['path'] = $args[1];
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['message'] );
+			return;
+		}
+
+		if ( empty( $result['entries'] ) ) {
+			WP_CLI::log( 'Empty directory.' );
+			return;
+		}
+
+		$items = array_map(
+			function ( $entry ) {
+				return array(
+					'name' => $entry['name'],
+					'type' => $entry['type'],
+					'size' => isset( $entry['size'] ) ? size_format( $entry['size'] ) : '-',
+				);
+			},
+			$result['entries']
+		);
+
+		$this->format_items(
+			$items,
+			array( 'name', 'type', 'size' ),
+			$assoc_args,
+			'name'
+		);
+	}
+
+	/**
+	 * Write a file to a workspace repo.
+	 *
+	 * Creates or overwrites a file. Parent directories are created as needed.
+	 * Content can be passed via --content flag or piped via stdin.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <repo>
+	 * : Repository directory name.
+	 *
+	 * <path>
+	 * : Relative file path within the repo.
+	 *
+	 * [--content=<content>]
+	 * : File content to write. If omitted, reads from stdin.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Write with content flag
+	 *     wp datamachine workspace write homeboy src/new.rs --content="fn main() {}"
+	 *
+	 *     # Write from stdin
+	 *     cat local-file.rs | wp datamachine workspace write homeboy src/main.rs
+	 *
+	 * @subcommand write
+	 */
+	public function write( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) || empty( $args[1] ) ) {
+			WP_CLI::error( 'Usage: wp datamachine workspace write <repo> <path> --content=<content>' );
+			return;
+		}
+
+		$ability = wp_get_ability( 'datamachine/workspace-write' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace write ability not available.' );
+			return;
+		}
+
+		$content = $assoc_args['content'] ?? null;
+
+		// Read from stdin if --content not provided.
+		if ( null === $content ) {
+			if ( function_exists( 'posix_isatty' ) && posix_isatty( STDIN ) ) {
+				WP_CLI::error( 'No content provided. Use --content=<content> or pipe content via stdin.' );
+				return;
+			}
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$content = file_get_contents( 'php://stdin' );
+			if ( false === $content ) {
+				WP_CLI::error( 'Failed to read from stdin.' );
+				return;
+			}
+		}
+
+		$result = $ability->execute( array(
+			'repo'    => $args[0],
+			'path'    => $args[1],
+			'content' => $content,
+		) );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['message'] );
+			return;
+		}
+
+		$action = ! empty( $result['created'] ) ? 'Created' : 'Updated';
+		WP_CLI::success( sprintf( '%s %s (%s)', $action, $result['path'], size_format( $result['size'] ) ) );
+	}
+
+	/**
+	 * Edit a file in a workspace repo via find-and-replace.
+	 *
+	 * Performs exact string replacement. Fails if the old string is not found,
+	 * or if multiple matches exist (unless --replace-all is used).
+	 *
+	 * ## OPTIONS
+	 *
+	 * <repo>
+	 * : Repository directory name.
+	 *
+	 * <path>
+	 * : Relative file path within the repo.
+	 *
+	 * --old=<string>
+	 * : Text to find.
+	 *
+	 * --new=<string>
+	 * : Replacement text.
+	 *
+	 * [--replace-all]
+	 * : Replace all occurrences instead of requiring a unique match.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Replace a single occurrence
+	 *     wp datamachine workspace edit homeboy src/main.rs --old="old_func" --new="new_func"
+	 *
+	 *     # Replace all occurrences
+	 *     wp datamachine workspace edit homeboy src/main.rs --old="v1" --new="v2" --replace-all
+	 *
+	 * @subcommand edit
+	 */
+	public function edit( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) || empty( $args[1] ) ) {
+			WP_CLI::error( 'Usage: wp datamachine workspace edit <repo> <path> --old=<string> --new=<string>' );
+			return;
+		}
+
+		if ( ! isset( $assoc_args['old'] ) || ! isset( $assoc_args['new'] ) ) {
+			WP_CLI::error( 'Both --old and --new flags are required.' );
+			return;
+		}
+
+		$ability = wp_get_ability( 'datamachine/workspace-edit' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Workspace edit ability not available.' );
+			return;
+		}
+
+		$input = array(
+			'repo'       => $args[0],
+			'path'       => $args[1],
+			'old_string' => $assoc_args['old'],
+			'new_string' => $assoc_args['new'],
+		);
+
+		if ( ! empty( $assoc_args['replace-all'] ) ) {
+			$input['replace_all'] = true;
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['message'] );
+			return;
+		}
+
+		$count = $result['replacements'] ?? 1;
+		WP_CLI::success( sprintf(
+			'Edited %s (%d replacement%s)',
+			$result['path'],
+			$count,
+			1 === $count ? '' : 's'
+		) );
 	}
 }

--- a/inc/Core/FilesRepository/WorkspaceReader.php
+++ b/inc/Core/FilesRepository/WorkspaceReader.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Workspace File Reader
+ *
+ * Read-only file operations within the agent workspace — reading file
+ * contents and listing directory entries in cloned repositories.
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since 0.32.0
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+class WorkspaceReader {
+
+	/**
+	 * @var Workspace
+	 */
+	private Workspace $workspace;
+
+	/**
+	 * @param Workspace $workspace Workspace instance for path resolution and validation.
+	 */
+	public function __construct( Workspace $workspace ) {
+		$this->workspace = $workspace;
+	}
+
+	/**
+	 * Read a file from a workspace repo.
+	 *
+	 * @param string $name     Repository directory name.
+	 * @param string $path     Relative file path within the repo.
+	 * @param int    $max_size Maximum file size in bytes.
+	 * @return array{success: bool, content?: string, path?: string, size?: int, message?: string}
+	 */
+	public function read_file( string $name, string $path, int $max_size = Workspace::MAX_READ_SIZE ): array {
+		$repo_path = $this->workspace->get_repo_path( $name );
+		$path      = ltrim( $path, '/' );
+
+		if ( ! is_dir( $repo_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Repository "%s" not found in workspace.', $name ),
+			);
+		}
+
+		$file_path  = $repo_path . '/' . $path;
+		$validation = $this->workspace->validate_containment( $file_path, $repo_path );
+
+		if ( ! $validation['valid'] ) {
+			return array(
+				'success' => false,
+				'message' => $validation['message'],
+			);
+		}
+
+		$real_path = $validation['real_path'];
+
+		if ( ! is_file( $real_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'File not found: %s', $path ),
+			);
+		}
+
+		if ( ! is_readable( $real_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'File not readable: %s', $path ),
+			);
+		}
+
+		$size = filesize( $real_path );
+
+		if ( $size > $max_size ) {
+			return array(
+				'success' => false,
+				'message' => sprintf(
+					'File too large: %s (%s). Maximum: %s.',
+					$path,
+					size_format( $size ),
+					size_format( $max_size )
+				),
+			);
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$content = file_get_contents( $real_path );
+
+		if ( false === $content ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to read file: %s', $path ),
+			);
+		}
+
+		// Detect binary: check for null bytes in first 8 KB.
+		$sample = substr( $content, 0, 8192 );
+		if ( false !== strpos( $sample, "\0" ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Binary file detected: %s. Only text files can be read.', $path ),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'content' => $content,
+			'path'    => $path,
+			'size'    => $size,
+		);
+	}
+
+	/**
+	 * List directory contents within a workspace repo.
+	 *
+	 * @param string      $name Repository directory name.
+	 * @param string|null $path Relative directory path within the repo (null for root).
+	 * @return array{success: bool, repo?: string, path?: string, entries?: array, message?: string}
+	 */
+	public function list_directory( string $name, ?string $path = null ): array {
+		$repo_path = $this->workspace->get_repo_path( $name );
+
+		if ( ! is_dir( $repo_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Repository "%s" not found in workspace.', $name ),
+			);
+		}
+
+		$target_path = $repo_path;
+
+		if ( null !== $path && '' !== $path ) {
+			$path        = ltrim( $path, '/' );
+			$target_path = $repo_path . '/' . $path;
+
+			$validation = $this->workspace->validate_containment( $target_path, $repo_path );
+
+			if ( ! $validation['valid'] ) {
+				return array(
+					'success' => false,
+					'message' => $validation['message'],
+				);
+			}
+
+			$target_path = $validation['real_path'];
+		}
+
+		if ( ! is_dir( $target_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Directory not found: %s', $path ?? '/' ),
+			);
+		}
+
+		$entries = scandir( $target_path );
+		$items   = array();
+
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+
+			$entry_path = $target_path . '/' . $entry;
+			$is_dir     = is_dir( $entry_path );
+
+			$item = array(
+				'name' => $entry,
+				'type' => $is_dir ? 'directory' : 'file',
+			);
+
+			if ( ! $is_dir ) {
+				$item['size'] = filesize( $entry_path );
+			}
+
+			$items[] = $item;
+		}
+
+		// Sort: directories first, then alphabetical.
+		usort(
+			$items,
+			function ( $a, $b ) {
+				if ( $a['type'] !== $b['type'] ) {
+					return ( 'directory' === $a['type'] ) ? -1 : 1;
+				}
+				return strcasecmp( $a['name'], $b['name'] );
+			}
+		);
+
+		return array(
+			'success' => true,
+			'repo'    => $name,
+			'path'    => $path ?? '/',
+			'entries' => $items,
+		);
+	}
+}

--- a/inc/Core/FilesRepository/WorkspaceWriter.php
+++ b/inc/Core/FilesRepository/WorkspaceWriter.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Workspace File Writer
+ *
+ * Write and edit operations within the agent workspace — creating new files,
+ * overwriting existing files, and performing find-and-replace edits in
+ * cloned repositories.
+ *
+ * All operations are contained within the workspace via path validation.
+ * Mutating abilities are CLI-only (show_in_rest = false) for safety.
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since 0.32.0
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+class WorkspaceWriter {
+
+	/**
+	 * @var Workspace
+	 */
+	private Workspace $workspace;
+
+	/**
+	 * @param Workspace $workspace Workspace instance for path resolution and validation.
+	 */
+	public function __construct( Workspace $workspace ) {
+		$this->workspace = $workspace;
+	}
+
+	/**
+	 * Write (create or overwrite) a file in a workspace repo.
+	 *
+	 * Creates parent directories as needed. Path traversal is blocked
+	 * by rejecting ".." and "." components in the path.
+	 *
+	 * @param string $name    Repository directory name.
+	 * @param string $path    Relative file path within the repo.
+	 * @param string $content File content to write.
+	 * @return array{success: bool, path?: string, size?: int, created?: bool, message?: string}
+	 */
+	public function write_file( string $name, string $path, string $content ): array {
+		$repo_path = $this->workspace->get_repo_path( $name );
+		$path      = ltrim( $path, '/' );
+
+		if ( ! is_dir( $repo_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Repository "%s" not found in workspace.', $name ),
+			);
+		}
+
+		if ( '' === $path ) {
+			return array(
+				'success' => false,
+				'message' => 'File path is required.',
+			);
+		}
+
+		// Reject path traversal components.
+		if ( $this->has_traversal( $path ) ) {
+			return array(
+				'success' => false,
+				'message' => 'Path traversal detected. Access denied.',
+			);
+		}
+
+		$file_path = $repo_path . '/' . $path;
+		$existed   = file_exists( $file_path );
+
+		// Ensure parent directory exists.
+		$parent = dirname( $file_path );
+		if ( ! is_dir( $parent ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+			$created = mkdir( $parent, 0755, true );
+			if ( ! $created ) {
+				return array(
+					'success' => false,
+					'message' => sprintf( 'Failed to create directory: %s', dirname( $path ) ),
+				);
+			}
+		}
+
+		// Write the file.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$bytes = file_put_contents( $file_path, $content );
+
+		if ( false === $bytes ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to write file: %s', $path ),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'path'    => $path,
+			'size'    => $bytes,
+			'created' => ! $existed,
+		);
+	}
+
+	/**
+	 * Edit a file in a workspace repo via find-and-replace.
+	 *
+	 * Finds an exact match of old_string and replaces it with new_string.
+	 * Fails if old_string is not found or has multiple matches (unless
+	 * replace_all is true).
+	 *
+	 * @param string $name        Repository directory name.
+	 * @param string $path        Relative file path within the repo.
+	 * @param string $old_string  Text to find.
+	 * @param string $new_string  Replacement text.
+	 * @param bool   $replace_all Replace all occurrences (default false).
+	 * @return array{success: bool, path?: string, replacements?: int, message?: string}
+	 */
+	public function edit_file( string $name, string $path, string $old_string, string $new_string, bool $replace_all = false ): array {
+		$repo_path = $this->workspace->get_repo_path( $name );
+		$path      = ltrim( $path, '/' );
+
+		if ( ! is_dir( $repo_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Repository "%s" not found in workspace.', $name ),
+			);
+		}
+
+		$file_path  = $repo_path . '/' . $path;
+		$validation = $this->workspace->validate_containment( $file_path, $repo_path );
+
+		if ( ! $validation['valid'] ) {
+			return array(
+				'success' => false,
+				'message' => $validation['message'],
+			);
+		}
+
+		$real_path = $validation['real_path'];
+
+		if ( ! is_file( $real_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'File not found: %s', $path ),
+			);
+		}
+
+		if ( ! is_readable( $real_path ) || ! is_writable( $real_path ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'File not readable/writable: %s', $path ),
+			);
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$content = file_get_contents( $real_path );
+
+		if ( false === $content ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to read file: %s', $path ),
+			);
+		}
+
+		if ( $old_string === $new_string ) {
+			return array(
+				'success' => false,
+				'message' => 'old_string and new_string are identical.',
+			);
+		}
+
+		// Count occurrences.
+		$count = substr_count( $content, $old_string );
+
+		if ( 0 === $count ) {
+			return array(
+				'success' => false,
+				'message' => 'old_string not found in file content.',
+			);
+		}
+
+		if ( $count > 1 && ! $replace_all ) {
+			return array(
+				'success' => false,
+				'message' => sprintf(
+					'Found %d matches for old_string. Use replace_all to replace all, or provide more context to make the match unique.',
+					$count
+				),
+			);
+		}
+
+		// Perform replacement.
+		if ( $replace_all ) {
+			$new_content = str_replace( $old_string, $new_string, $content );
+		} else {
+			$pos         = strpos( $content, $old_string );
+			$new_content = substr_replace( $content, $new_string, $pos, strlen( $old_string ) );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$bytes = file_put_contents( $real_path, $new_content );
+
+		if ( false === $bytes ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to write file: %s', $path ),
+			);
+		}
+
+		return array(
+			'success'      => true,
+			'path'         => $path,
+			'replacements' => $replace_all ? $count : 1,
+		);
+	}
+
+	/**
+	 * Check if a relative path contains traversal components.
+	 *
+	 * @param string $path Relative path to check.
+	 * @return bool True if path contains ".." or "." components.
+	 */
+	private function has_traversal( string $path ): bool {
+		$parts = explode( '/', $path );
+		foreach ( $parts as $part ) {
+			if ( '..' === $part || '.' === $part ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary

- Adds **read, write, edit, ls** commands to the workspace CLI — full file operation support for workspace repos
- Refactors **all existing workspace CLI commands** to delegate through the Abilities API (abilities-first architecture)
- New `WorkspaceReader` and `WorkspaceWriter` classes modularize file operations away from the core `Workspace` class

## Why this matters

The workspace at `/var/lib/datamachine/workspace/` is outside the web root, which means Claude Code's permission sandbox prompts for every file access. By tunneling file operations through WP-CLI → Abilities API → PHP, agents can read/write workspace files **without permission prompts** while maintaining security through:

- `validate_containment()` — realpath-based path traversal protection
- `has_traversal()` — rejects `..` / `.` components in write paths
- Ability `permission_callback` — requires `manage_options` or WP-CLI
- Workspace isolation — completely separate from the web root

## New commands

| Command | Description |
|---------|------------|
| `workspace read <repo> <path>` | Read a text file (binary detection, 1MB limit) |
| `workspace write <repo> <path>` | Create/overwrite a file (auto-creates parent dirs) |
| `workspace edit <repo> <path>` | Find-and-replace in a file |
| `workspace ls <repo> [<path>]` | List directory contents |

## Refactored commands

All existing commands (`path`, `list`, `clone`, `remove`, `show`) now delegate to abilities instead of calling `Workspace.php` directly.

## New abilities

| Ability | REST | Type |
|---------|------|------|
| `workspace-path` | ✅ | Read-only (updated: supports `ensure` param) |
| `workspace-list` | ✅ | Read-only |
| `workspace-show` | ✅ | Read-only |
| `workspace-read` | ✅ | Read-only |
| `workspace-ls` | ✅ | Read-only |
| `workspace-clone` | ❌ | Mutating (CLI-only) |
| `workspace-remove` | ❌ | Destructive (CLI-only) |
| `workspace-write` | ❌ | Mutating (CLI-only) |
| `workspace-edit` | ❌ | Mutating (CLI-only) |

## Architecture

```
Workspace.php          ← Core: path resolution, repo CRUD, containment validation
WorkspaceReader.php    ← Read-only: read_file(), list_directory()
WorkspaceWriter.php    ← Mutations: write_file(), edit_file()
WorkspaceAbilities.php ← Abilities API primitives (the canonical entry points)
WorkspaceCommand.php   ← CLI thin wrapper (delegates to abilities)
```

## Note

The uploads directory fallback in `DirectoryManager::get_workspace_directory()` should be revisited now that the workspace has write capabilities. Writing files inside `wp-content/uploads/` is a security concern — the workspace should refuse to operate if it can't get an out-of-web-root path.

Closes #359