### PR TITLE
security: Remove uploads fallback for workspace directory

### DIFF
--- a/inc/Core/FilesRepository/Workspace.php
+++ b/inc/Core/FilesRepository/Workspace.php
@@ -58,6 +58,14 @@ class Workspace {
 	public function ensure_exists(): array {
 		$path = $this->workspace_path;
 
+		if ( '' === $path ) {
+			return array(
+				'success' => false,
+				'path'    => '',
+				'message' => 'Workspace unavailable: no writable path outside the web root. Define DATAMACHINE_WORKSPACE_PATH in wp-config.php or ensure /var/lib/datamachine/ is writable.',
+			);
+		}
+
 		if ( is_dir( $path ) ) {
 			return array(
 				'success' => true,


### PR DESCRIPTION
## Summary

- Removes the `wp-content/uploads/` fallback from workspace directory resolution
- Adds clear error message when no out-of-web-root path is available

## Why

The workspace now supports write operations (#360). Placing writable agent files inside `wp-content/uploads/` creates a remote code execution risk:

1. Agent writes a `.php` file to workspace
2. Workspace is inside uploads (web root)
3. `.htaccess` gets bypassed (Nginx ignores it, `AllowOverride None` disables it)
4. PHP file is web-executable → RCE

## Changes

**`DirectoryManager::get_workspace_directory()`** — removed option 3 (uploads fallback). Now returns empty string if no out-of-web-root path resolves, with a logged error message.

**`Workspace::ensure_exists()`** — added explicit check for empty path with actionable error: *"Define DATAMACHINE_WORKSPACE_PATH in wp-config.php or ensure /var/lib/datamachine/ is writable."*

## Path resolution (after)

```
1. DATAMACHINE_WORKSPACE_PATH constant    ← explicit override
2. /var/lib/datamachine/workspace/        ← system default
3. (none — fail with clear error)
```

Closes #361