### PR TITLE
Protect agent files from deletion and enforce abilities-first architecture

### DIFF
--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
@@ -24,6 +24,7 @@ import {
 } from '../queries/agentFiles';
 
 const SOUL_FILE = 'SOUL.md';
+const PROTECTED_FILES = [ 'SOUL.md', 'MEMORY.md' ];
 
 /**
  * Format bytes to human-readable size.
@@ -375,7 +376,7 @@ const AgentFileList = ( { selectedFile, onSelectFile } ) => {
 										) }` }
 								</span>
 							</div>
-							{ ! isSoul && (
+							{ ! PROTECTED_FILES.includes( file.filename ) && (
 								<button
 									className="datamachine-agent-file-item-delete"
 									title={ `Delete ${ file.filename }` }


### PR DESCRIPTION
## Summary

Fixes two security/architecture gaps in the file operations layer:

- **#366 — SOUL.md and MEMORY.md deletion was unprotected in backend.** Only the UI hid the delete button for SOUL.md. Direct API calls or the chat agent could delete core identity files with no recovery path.
- **#367 — REST endpoints bypassed the abilities layer.** `put_agent_file()` wrote directly via DirectoryManager/FilesystemHelper. All 4 daily memory endpoints instantiated `DailyMemory` directly, skipping the `daily_memory_enabled` settings check.

## Changes

### Issue #366 — Protected file deletion

- Add `FileAbilities::PROTECTED_FILES` constant (`SOUL.md`, `MEMORY.md`)
- Guard `deleteAgentFile()` in abilities layer — returns error for protected files
- Defense-in-depth: REST `delete_agent_file()` also checks before delegating
- UI: `AgentFileList.jsx` now protects MEMORY.md alongside SOUL.md (was only SOUL.md)

### Issue #367 — Abilities-first enforcement

- New `datamachine/write-agent-file` ability with `executeWriteAgentFile()` method
- Protected files cannot be blanked (empty content write blocked)
- `put_agent_file()` REST endpoint now delegates to abilities layer
- New `datamachine/daily-memory-delete` ability in `DailyMemoryAbilities`
- All 4 daily memory REST endpoints now delegate to `DailyMemoryAbilities`
- `put_daily_file()` and `delete_daily_file()` now respect `daily_memory_enabled` setting
- Removed direct `DailyMemory`, `DirectoryManager`, `FilesystemHelper` imports from `Files.php`

## Architecture

```
Before:                          After:
REST PUT /agent/file             REST PUT /agent/file
  └─ DirectoryManager (direct)     └─ FileAbilities::executeWriteAgentFile()
                                       ├─ protected file validation
REST DELETE /agent/file                ├─ empty content guard
  └─ FileAbilities (no guard)          └─ DirectoryManager + FilesystemHelper

REST daily endpoints             REST DELETE /agent/file
  └─ new DailyMemory() (direct)    ├─ defense-in-depth protected check
                                    └─ FileAbilities::executeDeleteFile()
                                        └─ protected file guard

                                 REST daily endpoints
                                   └─ DailyMemoryAbilities
                                       ├─ daily_memory_enabled check
                                       └─ DailyMemory storage
```

## Files Changed

| File | What |
|------|------|
| `inc/Abilities/FileAbilities.php` | +PROTECTED_FILES constant, +writeAgentFile ability, +deletion guard |
| `inc/Abilities/DailyMemoryAbilities.php` | +deleteDaily() with settings check, +ability registration |
| `inc/Api/Files.php` | Delegate to abilities, defense-in-depth, remove direct storage imports |
| `AgentFileList.jsx` | Protect MEMORY.md from deletion in UI |

Closes #366, closes #367