### PR TITLE
Clean up side effects, namespace placement, and duplicated date parsing

### DIFF
--- a/inc/Abilities/DailyMemoryAbilities.php
+++ b/inc/Abilities/DailyMemoryAbilities.php
@@ -149,7 +149,7 @@ class DailyMemoryAbilities {
 		$daily = new DailyMemory();
 		$date  = $input['date'] ?? gmdate( 'Y-m-d' );
 
-		$parts = self::parseDate( $date );
+		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
 			return array(
 				'success' => false,
@@ -179,7 +179,7 @@ class DailyMemoryAbilities {
 		$date    = $input['date'] ?? gmdate( 'Y-m-d' );
 		$mode    = $input['mode'] ?? 'append';
 
-		$parts = self::parseDate( $date );
+		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
 			return array(
 				'success' => false,
@@ -203,23 +203,5 @@ class DailyMemoryAbilities {
 	public static function listDaily( array $input ): array {
 		$daily = new DailyMemory();
 		return $daily->list_all();
-	}
-
-	/**
-	 * Parse a YYYY-MM-DD date string.
-	 *
-	 * @param string $date Date string.
-	 * @return array{year: string, month: string, day: string}|null
-	 */
-	private static function parseDate( string $date ): ?array {
-		if ( ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ) {
-			return null;
-		}
-
-		return array(
-			'year'  => $matches[1],
-			'month' => $matches[2],
-			'day'   => $matches[3],
-		);
 	}
 }

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -297,8 +297,9 @@ class MemoryCommand extends BaseCommand {
 	 * Read a daily memory file.
 	 */
 	private function daily_read( DailyMemory $daily, string $date ): void {
-		$parts = $this->parse_date( $date );
+		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
+			WP_CLI::error( sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ) );
 			return;
 		}
 
@@ -331,8 +332,9 @@ class MemoryCommand extends BaseCommand {
 			$content = $args[1];
 		}
 
-		$parts = $this->parse_date( $date );
+		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
+			WP_CLI::error( sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ) );
 			return;
 		}
 
@@ -364,8 +366,9 @@ class MemoryCommand extends BaseCommand {
 			$content = $args[1];
 		}
 
-		$parts = $this->parse_date( $date );
+		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
+			WP_CLI::error( sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ) );
 			return;
 		}
 
@@ -383,8 +386,9 @@ class MemoryCommand extends BaseCommand {
 	 * Delete a daily memory file.
 	 */
 	private function daily_delete( DailyMemory $daily, string $date ): void {
-		$parts = $this->parse_date( $date );
+		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
+			WP_CLI::error( sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ) );
 			return;
 		}
 
@@ -398,22 +402,4 @@ class MemoryCommand extends BaseCommand {
 		WP_CLI::success( $result['message'] );
 	}
 
-	/**
-	 * Parse a YYYY-MM-DD date string into parts.
-	 *
-	 * @param string $date Date string.
-	 * @return array{year: string, month: string, day: string}|null Parsed parts or null on error.
-	 */
-	private function parse_date( string $date ): ?array {
-		if ( ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ) {
-			WP_CLI::error( sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ) );
-			return null;
-		}
-
-		return array(
-			'year'  => $matches[1],
-			'month' => $matches[2],
-			'day'   => $matches[3],
-		);
-	}
 }

--- a/inc/Core/WordPress/SiteContext.php
+++ b/inc/Core/WordPress/SiteContext.php
@@ -3,7 +3,7 @@
  * Cached WordPress site metadata for AI context injection.
  */
 
-namespace DataMachine\Engine\AI\Directives;
+namespace DataMachine\Core\WordPress;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -177,5 +177,3 @@ class SiteContext {
 		add_action( 'update_option_siteurl', array( __CLASS__, 'clear_cache' ) );
 	}
 }
-
-add_action( 'init', array( SiteContext::class, 'register_cache_invalidation' ) );

--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -338,21 +338,3 @@ class ConversationManager {
 		return self::formatToolResultMessage( $tool_name, $tool_result, array(), false, $turn_count );
 	}
 }
-
-// AI library error logging - universal handler for all AI interactions (pipeline agents, chat agents)
-add_action(
-	'chubes_ai_library_error',
-	function ( $error_data ) {
-		do_action(
-			'datamachine_log',
-			'error',
-			'AI Library Error: ' . $error_data['component'] . ' - ' . $error_data['message'],
-			array(
-				'component' => $error_data['component'],
-				'message'   => $error_data['message'],
-				'context'   => $error_data['context'],
-				'timestamp' => $error_data['timestamp'],
-			)
-		);
-	}
-);

--- a/inc/Engine/AI/Directives/SiteContextDirective.php
+++ b/inc/Engine/AI/Directives/SiteContextDirective.php
@@ -19,6 +19,7 @@
 namespace DataMachine\Engine\AI\Directives;
 
 use DataMachine\Core\PluginSettings;
+use DataMachine\Core\WordPress\SiteContext;
 use DataMachine\Engine\AI\Directives\DirectiveInterface;
 
 defined( 'ABSPATH' ) || exit;

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -65,6 +65,24 @@ function datamachine_register_core_actions() {
 	add_action( 'datamachine_log', array( LogHandler::class, 'handle' ), 10, 3 );
 	add_action( 'datamachine_log_manage', array( LogManageHandler::class, 'handle' ), 10, 4 );
 
+	// AI library error logging — universal handler for all AI interactions (pipeline agents, chat agents).
+	add_action(
+		'chubes_ai_library_error',
+		function ( $error_data ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'AI Library Error: ' . $error_data['component'] . ' - ' . $error_data['message'],
+				array(
+					'component' => $error_data['component'],
+					'message'   => $error_data['message'],
+					'context'   => $error_data['context'],
+					'timestamp' => $error_data['timestamp'],
+				)
+			);
+		}
+	);
+
 	\DataMachine\Engine\Actions\ImportExport::register();
 	datamachine_register_execution_engine();
 }

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -62,7 +62,8 @@ require_once __DIR__ . '/Engine/AI/Directives/CoreMemoryFilesDirective.php';
 \DataMachine\Engine\AI\MemoryFileRegistry::register( 'SOUL.md', 10 );
 \DataMachine\Engine\AI\MemoryFileRegistry::register( 'USER.md', 20 );
 \DataMachine\Engine\AI\MemoryFileRegistry::register( 'MEMORY.md', 30 );
-require_once __DIR__ . '/Engine/AI/Directives/SiteContext.php';
+// SiteContext is autoloaded (Core\WordPress\SiteContext) — register its cache invalidation hook here.
+add_action( 'init', array( \DataMachine\Core\WordPress\SiteContext::class, 'register_cache_invalidation' ) );
 require_once __DIR__ . '/Api/Chat/ChatAgentDirective.php';
 require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineCoreDirective.php';
 require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php';


### PR DESCRIPTION
## Summary

Three quick-fix cleanup issues — no behavior changes, pure code hygiene.

- **#373** — File-level side effect in autoloaded `ConversationManager.php`
- **#372** — `SiteContext.php` in Directives namespace despite not being a directive
- **#371** — Identical date parsing logic duplicated across two files

## Changes

### #373 — ConversationManager.php side effect

The `chubes_ai_library_error` hook was registered at file scope (lines 342-358), outside the class. Since this file is PSR-4 autoloaded, the hook fired on every request that touched the autoloader — even non-AI requests.

**Moved to:** `datamachine_register_core_actions()` in `DataMachineActions.php` — the central place for all action hook registrations.

### #372 — SiteContext.php namespace

`SiteContext` is a cached WordPress metadata provider (site name, post types, taxonomies). It lived in `Engine\AI\Directives` alongside the actual `SiteContextDirective`, but it doesn't implement `DirectiveInterface` — it's a data class.

**Moved to:** `Core\WordPress\SiteContext` — alongside `TaxonomyHandler`, `WordPressFilters`, etc. where WordPress metadata utilities belong.

Also removed its file-level `add_action('init', ...)` side effect. The cache invalidation hook is now registered in `bootstrap.php` (which explicitly exists for side-effect registrations). `SiteContext.php` is now a pure autoloaded class.

### #371 — Duplicated date parsing

Identical `YYYY-MM-DD` regex parsing existed in:
- `DailyMemoryAbilities::parseDate()` (private static)
- `MemoryCommand::parse_date()` (private instance)

**Consolidated into:** `DailyMemory::parse_date()` — the storage class that owns the date format. Both consumers now delegate to it.

## Files Changed

| File | What |
|------|------|
| `inc/Engine/AI/ConversationManager.php` | Remove file-level action hook |
| `inc/Engine/Actions/DataMachineActions.php` | Add the hook to core actions registration |
| `inc/Core/WordPress/SiteContext.php` | **Moved** from `Engine/AI/Directives/`, new namespace, no side effect |
| `inc/Engine/AI/Directives/SiteContextDirective.php` | Add `use` import for moved class |
| `inc/bootstrap.php` | Replace `require_once` with cache invalidation hook registration |
| `inc/Core/FilesRepository/DailyMemory.php` | Add canonical `parse_date()` static method |
| `inc/Abilities/DailyMemoryAbilities.php` | Delegate to `DailyMemory::parse_date()`, remove private method |
| `inc/Cli/Commands/MemoryCommand.php` | Delegate to `DailyMemory::parse_date()`, remove private method |

Closes #373, closes #372, closes #371