### PR TITLE
Exclude all core memory files from pipeline memory picker

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineMemoryFiles.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineMemoryFiles.jsx
@@ -23,7 +23,7 @@ import {
 /**
  * Files to exclude from the memory files picker (always injected separately).
  */
-const EXCLUDED_FILES = [ 'SOUL.md' ];
+const EXCLUDED_FILES = [ 'SOUL.md', 'USER.md', 'MEMORY.md' ];
 
 /**
  * Pipeline Memory Files Component

--- a/inc/Core/FilesRepository/DailyMemory.php
+++ b/inc/Core/FilesRepository/DailyMemory.php
@@ -293,6 +293,24 @@ class DailyMemory {
 	// =========================================================================
 
 	/**
+	 * Parse a YYYY-MM-DD date string into year/month/day components.
+	 *
+	 * @param string $date Date string (e.g. '2026-02-24').
+	 * @return array{year: string, month: string, day: string}|null Parsed parts or null if invalid.
+	 */
+	public static function parse_date( string $date ): ?array {
+		if ( ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ) {
+			return null;
+		}
+
+		return array(
+			'year'  => $matches[1],
+			'month' => $matches[2],
+			'day'   => $matches[3],
+		);
+	}
+
+	/**
 	 * Scan a directory for sorted subdirectory names.
 	 *
 	 * @param string $path Directory to scan.


### PR DESCRIPTION
## Summary

One-line fix: the pipeline memory file picker only excluded SOUL.md from selection. USER.md and MEMORY.md were still selectable, which would cause them to be injected twice — once at priority 20 (CoreMemoryFilesDirective) and again at priority 40 (PipelineMemoryFilesDirective).

## Change

```diff
- const EXCLUDED_FILES = [ 'SOUL.md' ];
+ const EXCLUDED_FILES = [ 'SOUL.md', 'USER.md', 'MEMORY.md' ];
```

No behavior change for existing pipelines that already selected these files — they just won't appear in the picker for new selections.

Closes #370