### PR TITLE
Migrate engine execution actions to Abilities API

### DIFF
--- a/inc/Abilities/Engine/EngineHelpers.php
+++ b/inc/Abilities/Engine/EngineHelpers.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Engine Helpers Trait
+ *
+ * Shared helper methods used across Engine ability classes.
+ * Provides database access and permission checks for engine operations.
+ *
+ * @package DataMachine\Abilities\Engine
+ * @since 0.30.0
+ */
+
+namespace DataMachine\Abilities\Engine;
+
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+
+defined( 'ABSPATH' ) || exit;
+
+trait EngineHelpers {
+
+	protected Flows $db_flows;
+	protected Jobs $db_jobs;
+	protected Pipelines $db_pipelines;
+	protected ProcessedItems $db_processed_items;
+
+	/**
+	 * Initialize database instances.
+	 */
+	protected function initDatabases(): void {
+		$this->db_flows           = new Flows();
+		$this->db_jobs            = new Jobs();
+		$this->db_pipelines       = new Pipelines();
+		$this->db_processed_items = new ProcessedItems();
+	}
+
+	/**
+	 * Permission callback for engine abilities.
+	 *
+	 * Engine operations are system-level (triggered by Action Scheduler),
+	 * but restrict direct invocation to administrators.
+	 *
+	 * @return bool True if permitted.
+	 */
+	public function checkPermission(): bool {
+		return \DataMachine\Abilities\PermissionHelper::can_manage();
+	}
+}

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -1,0 +1,523 @@
+<?php
+/**
+ * Execute Step Ability
+ *
+ * Executes a single step in a pipeline flow. Resolves step configuration,
+ * runs the step class, evaluates success, and routes to the appropriate
+ * outcome: next step, job completion, or failure.
+ *
+ * Backs the datamachine_execute_step action hook.
+ *
+ * @package DataMachine\Abilities\Engine
+ * @since 0.30.0
+ */
+
+namespace DataMachine\Abilities\Engine;
+
+use DataMachine\Abilities\StepTypeAbilities;
+use DataMachine\Core\EngineData;
+use DataMachine\Core\FilesRepository\FileCleanup;
+use DataMachine\Core\FilesRepository\FileRetrieval;
+use DataMachine\Core\JobStatus;
+use DataMachine\Engine\AI\AgentType;
+use DataMachine\Engine\AI\AgentContext;
+use DataMachine\Engine\StepNavigator;
+
+defined( 'ABSPATH' ) || exit;
+
+class ExecuteStepAbility {
+
+	use EngineHelpers;
+
+	public function __construct() {
+		$this->initDatabases();
+
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		$this->registerAbility();
+	}
+
+	/**
+	 * Register the datamachine/execute-step ability.
+	 */
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/execute-step',
+				array(
+					'label'               => __( 'Execute Step', 'data-machine' ),
+					'description'         => __( 'Execute a single pipeline step. Resolves config, runs the step, routes to next step or completion.', 'data-machine' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'job_id', 'flow_step_id' ),
+						'properties' => array(
+							'job_id'       => array(
+								'type'        => 'integer',
+								'description' => __( 'Job ID for the execution.', 'data-machine' ),
+							),
+							'flow_step_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Flow step ID to execute.', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'      => array( 'type' => 'boolean' ),
+							'step_success' => array( 'type' => 'boolean' ),
+							'outcome'      => array( 'type' => 'string' ),
+							'error'        => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array(
+						'show_in_rest' => false,
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => false,
+						),
+					),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Execute the execute-step ability.
+	 *
+	 * @param array $input Input with job_id and flow_step_id.
+	 * @return array Result with step execution outcome.
+	 */
+	public function execute( array $input ): array {
+		AgentContext::set( AgentType::PIPELINE );
+
+		$job_id       = (int) ( $input['job_id'] ?? 0 );
+		$flow_step_id = (string) ( $input['flow_step_id'] ?? '' );
+
+		try {
+			$engine_snapshot = datamachine_get_engine_data( $job_id );
+			$engine          = new EngineData( $engine_snapshot, $job_id );
+
+			$flow_step_config = $this->resolveFlowStepConfig( $engine, $flow_step_id, $job_id, $engine_snapshot );
+
+			if ( ! isset( $flow_step_config['flow_id'] ) || empty( $flow_step_config['flow_id'] ) ) {
+				do_action(
+					'datamachine_fail_job',
+					$job_id,
+					'step_execution_failure',
+					array(
+						'flow_step_id' => $flow_step_id,
+						'reason'       => 'missing_flow_id_in_step_config',
+					)
+				);
+				return array(
+					'success' => false,
+					'error'   => 'Missing flow_id in step config.',
+				);
+			}
+
+			$flow_id = $flow_step_config['flow_id'];
+
+			/** @var array $context */
+			$context     = datamachine_get_file_context( $flow_id );
+			$retrieval   = new FileRetrieval();
+			$dataPackets = $retrieval->retrieve_data_by_job_id( $job_id, $context );
+
+			if ( ! isset( $flow_step_config['step_type'] ) || empty( $flow_step_config['step_type'] ) ) {
+				do_action(
+					'datamachine_fail_job',
+					$job_id,
+					'step_execution_failure',
+					array(
+						'flow_step_id' => $flow_step_id,
+						'reason'       => 'missing_step_type_in_flow_step_config',
+					)
+				);
+				return array(
+					'success' => false,
+					'error'   => 'Missing step_type in flow step config.',
+				);
+			}
+
+			$step_type       = $flow_step_config['step_type'];
+			$step_definition = $this->resolveStepDefinition( $step_type, $flow_step_id, $job_id );
+
+			if ( ! $step_definition ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'Step type "%s" not found in registry.', $step_type ),
+				);
+			}
+
+			$step_class = $step_definition['class'] ?? '';
+			$flow_step  = new $step_class();
+
+			$payload = array(
+				'job_id'       => $job_id,
+				'flow_step_id' => $flow_step_id,
+				'data'         => $dataPackets,
+				'engine'       => $engine,
+			);
+
+			$dataPackets = $flow_step->execute( $payload );
+
+			if ( ! is_array( $dataPackets ) ) {
+				do_action(
+					'datamachine_fail_job',
+					$job_id,
+					'step_execution_failure',
+					array(
+						'flow_step_id' => $flow_step_id,
+						'class'        => $step_class,
+						'reason'       => 'non_array_payload_returned',
+					)
+				);
+				return array(
+					'success' => false,
+					'error'   => 'Step returned non-array payload.',
+				);
+			}
+
+			$payload['data'] = $dataPackets;
+			$step_success    = $this->evaluateStepSuccess( $dataPackets, $job_id, $flow_step_id );
+
+			// Refresh engine data to capture changes made during step execution.
+			$refreshed_engine_data = datamachine_get_engine_data( $job_id );
+			$engine                = new EngineData( $refreshed_engine_data, $job_id );
+			$status_override       = $engine->get( 'job_status' );
+
+			do_action(
+				'datamachine_log',
+				'debug',
+				'Engine: status_override check',
+				array(
+					'job_id'                 => $job_id,
+					'status_override'        => $status_override,
+					'has_override'           => ! empty( $status_override ),
+					'engine_data_job_status' => $refreshed_engine_data['job_status'] ?? 'not_set',
+				)
+			);
+
+			return $this->routeAfterExecution(
+				$job_id,
+				$flow_step_id,
+				$flow_id,
+				$flow_step_config,
+				$step_type,
+				$step_class,
+				$dataPackets,
+				$payload,
+				$step_success,
+				$status_override
+			);
+		} catch ( \Throwable $e ) {
+			do_action(
+				'datamachine_fail_job',
+				$job_id,
+				'step_execution_failure',
+				array(
+					'flow_step_id'      => $flow_step_id,
+					'exception_message' => $e->getMessage(),
+					'exception_trace'   => $e->getTraceAsString(),
+					'reason'            => 'throwable_exception_in_step_execution',
+				)
+			);
+			return array(
+				'success' => false,
+				'error'   => $e->getMessage(),
+			);
+		}
+	}
+
+	/**
+	 * Resolve flow step config, falling back to database lookup if missing from snapshot.
+	 *
+	 * @param EngineData $engine          Engine data instance.
+	 * @param string     $flow_step_id    Flow step ID.
+	 * @param int        $job_id          Job ID.
+	 * @param array      $engine_snapshot Raw engine snapshot data.
+	 * @return array|null Flow step config or null.
+	 */
+	private function resolveFlowStepConfig( EngineData $engine, string $flow_step_id, int $job_id, array $engine_snapshot ): ?array {
+		$flow_step_config = $engine->getFlowStepConfig( $flow_step_id );
+
+		if ( ! $flow_step_config ) {
+			$flow_step_config = $this->db_flows->get_flow_step_config( $flow_step_id, $job_id, true );
+
+			if ( $flow_step_config ) {
+				$existing_flow_config                  = $engine_snapshot['flow_config'] ?? array();
+				$existing_flow_config[ $flow_step_id ] = $flow_step_config;
+				datamachine_merge_engine_data(
+					$job_id,
+					array(
+						'flow_config' => $existing_flow_config,
+					)
+				);
+			}
+		}
+
+		return $flow_step_config;
+	}
+
+	/**
+	 * Resolve and validate step type definition from the abilities registry.
+	 *
+	 * @param string $step_type    Step type identifier.
+	 * @param string $flow_step_id Flow step ID (for error context).
+	 * @param int    $job_id       Job ID (for error context).
+	 * @return array|null Step definition or null on failure.
+	 */
+	private function resolveStepDefinition( string $step_type, string $flow_step_id, int $job_id ): ?array {
+		$step_type_abilities = new StepTypeAbilities();
+		$step_definition     = $step_type_abilities->getStepType( $step_type );
+
+		if ( ! $step_definition ) {
+			do_action(
+				'datamachine_fail_job',
+				$job_id,
+				'step_execution_failure',
+				array(
+					'flow_step_id' => $flow_step_id,
+					'step_type'    => $step_type,
+					'reason'       => 'step_type_not_found_in_registry',
+				)
+			);
+			return null;
+		}
+
+		return $step_definition;
+	}
+
+	/**
+	 * Evaluate whether the step execution was successful.
+	 *
+	 * @param array  $dataPackets  Returned data packets.
+	 * @param int    $job_id       Job ID (for logging).
+	 * @param string $flow_step_id Flow step ID (for logging).
+	 * @return bool True if step succeeded.
+	 */
+	private function evaluateStepSuccess( array $dataPackets, int $job_id, string $flow_step_id ): bool {
+		$step_success = ! empty( $dataPackets );
+
+		if ( $step_success ) {
+			foreach ( $dataPackets as $packet ) {
+				$metadata = $packet['metadata'] ?? array();
+				if ( isset( $metadata['success'] ) && false === $metadata['success'] ) {
+					$step_success = false;
+					do_action(
+						'datamachine_log',
+						'warning',
+						'Step returned failure packet',
+						array(
+							'job_id'        => $job_id,
+							'flow_step_id'  => $flow_step_id,
+							'packet_type'   => $packet['type'] ?? 'unknown',
+							'error_message' => $packet['data']['body'] ?? 'No error message',
+						)
+					);
+					break;
+				}
+			}
+		}
+
+		return $step_success;
+	}
+
+	/**
+	 * Route execution after step completes.
+	 *
+	 * @param int    $job_id           Job ID.
+	 * @param string $flow_step_id     Flow step ID.
+	 * @param mixed  $flow_id          Flow ID.
+	 * @param array  $flow_step_config Flow step configuration.
+	 * @param string $step_type        Step type identifier.
+	 * @param string $step_class       Step class name.
+	 * @param array  $dataPackets      Returned data packets.
+	 * @param array  $payload          Full step payload.
+	 * @param bool   $step_success     Whether step succeeded.
+	 * @param mixed  $status_override  Status override from engine data.
+	 * @return array Result with outcome details.
+	 */
+	private function routeAfterExecution(
+		int $job_id,
+		string $flow_step_id,
+		$flow_id,
+		array $flow_step_config,
+		string $step_type,
+		string $step_class,
+		array $dataPackets,
+		array $payload,
+		bool $step_success,
+		$status_override
+	): array {
+		$pipeline_id = $flow_step_config['pipeline_id'] ?? null;
+
+		// Waiting status: pipeline is parked at a webhook gate.
+		if ( $status_override && JobStatus::isStatusWaiting( $status_override ) ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Pipeline parked in waiting state (webhook gate)',
+				array(
+					'job_id'       => $job_id,
+					'pipeline_id'  => $pipeline_id,
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+				)
+			);
+			return array(
+				'success'      => true,
+				'step_success' => $step_success,
+				'outcome'      => 'waiting',
+			);
+		}
+
+		// Status override: complete with override status and clean up.
+		if ( $status_override ) {
+			$this->db_jobs->complete_job( $job_id, $status_override );
+
+			do_action(
+				'datamachine_log',
+				'debug',
+				'Engine: complete_job called with status_override',
+				array(
+					'job_id' => $job_id,
+					'status' => $status_override,
+				)
+			);
+
+			$cleanup = new FileCleanup();
+			$context = datamachine_get_file_context( $flow_id );
+			$cleanup->cleanup_job_data_packets( $job_id, $context );
+
+			do_action(
+				'datamachine_log',
+				'info',
+				'Pipeline execution completed with status override',
+				array(
+					'job_id'          => $job_id,
+					'pipeline_id'     => $pipeline_id,
+					'flow_id'         => $flow_id,
+					'flow_step_id'    => $flow_step_id,
+					'final_status'    => $status_override,
+					'override_source' => 'engine_data',
+				)
+			);
+
+			return array(
+				'success'      => true,
+				'step_success' => $step_success,
+				'outcome'      => 'completed_override',
+			);
+		}
+
+		// Success: advance to next step or complete.
+		if ( $step_success ) {
+			$navigator         = new StepNavigator();
+			$next_flow_step_id = $navigator->get_next_flow_step_id( $flow_step_id, $payload );
+
+			if ( $next_flow_step_id ) {
+				do_action( 'datamachine_schedule_next_step', $job_id, $next_flow_step_id, $dataPackets );
+				return array(
+					'success'      => true,
+					'step_success' => true,
+					'outcome'      => 'next_step_scheduled',
+				);
+			}
+
+			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED );
+			$cleanup = new FileCleanup();
+			$context = datamachine_get_file_context( $flow_id );
+			$cleanup->cleanup_job_data_packets( $job_id, $context );
+
+			do_action(
+				'datamachine_log',
+				'info',
+				'Pipeline execution completed successfully',
+				array(
+					'job_id'             => $job_id,
+					'pipeline_id'        => $pipeline_id,
+					'flow_id'            => $flow_id,
+					'flow_step_id'       => $flow_step_id,
+					'final_packet_count' => count( $dataPackets ),
+					'final_status'       => JobStatus::COMPLETED,
+				)
+			);
+
+			return array(
+				'success'      => true,
+				'step_success' => true,
+				'outcome'      => 'completed',
+			);
+		}
+
+		// Failure: check for "no new items" vs actual failure.
+		$is_fetch_step = ( 'fetch' === $step_type );
+		$has_history   = $this->db_processed_items->has_processed_items( $flow_step_id );
+
+		if ( $is_fetch_step && $has_history ) {
+			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED_NO_ITEMS );
+			do_action(
+				'datamachine_log',
+				'info',
+				'Flow completed with no new items to process',
+				array(
+					'job_id'       => $job_id,
+					'pipeline_id'  => $pipeline_id,
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+					'step_type'    => $step_type,
+				)
+			);
+			return array(
+				'success'      => true,
+				'step_success' => false,
+				'outcome'      => 'completed_no_items',
+			);
+		}
+
+		// Actual failure.
+		do_action(
+			'datamachine_log',
+			'error',
+			'Step execution failed - empty data packet',
+			array(
+				'job_id'       => $job_id,
+				'pipeline_id'  => $pipeline_id,
+				'flow_id'      => $flow_id,
+				'flow_step_id' => $flow_step_id,
+				'step_class'   => $step_class,
+				'step_type'    => $step_type,
+				'has_history'  => $has_history,
+			)
+		);
+		do_action(
+			'datamachine_fail_job',
+			$job_id,
+			'step_execution_failure',
+			array(
+				'flow_step_id' => $flow_step_id,
+				'class'        => $step_class,
+				'reason'       => 'empty_data_packet_returned',
+			)
+		);
+
+		return array(
+			'success'      => true,
+			'step_success' => false,
+			'outcome'      => 'failed',
+		);
+	}
+}

--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Run Flow Ability
+ *
+ * Executes a flow immediately. Loads flow/pipeline configurations,
+ * creates a job record if needed, builds the engine snapshot, and
+ * schedules the first step.
+ *
+ * Backs the datamachine_run_flow_now action hook.
+ *
+ * @package DataMachine\Abilities\Engine
+ * @since 0.30.0
+ */
+
+namespace DataMachine\Abilities\Engine;
+
+use DataMachine\Engine\AI\AgentType;
+use DataMachine\Engine\AI\AgentContext;
+
+defined( 'ABSPATH' ) || exit;
+
+class RunFlowAbility {
+
+	use EngineHelpers;
+
+	public function __construct() {
+		$this->initDatabases();
+
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		$this->registerAbility();
+	}
+
+	/**
+	 * Register the datamachine/run-flow ability.
+	 */
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/run-flow',
+				array(
+					'label'               => __( 'Run Flow', 'data-machine' ),
+					'description'         => __( 'Execute a flow immediately. Loads configs, creates job if needed, schedules first step.', 'data-machine' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'flow_id' ),
+						'properties' => array(
+							'flow_id' => array(
+								'type'        => 'integer',
+								'description' => __( 'Flow ID to execute.', 'data-machine' ),
+							),
+							'job_id'  => array(
+								'type'        => array( 'integer', 'null' ),
+								'description' => __( 'Pre-created job ID (optional, for API-triggered executions).', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'    => array( 'type' => 'boolean' ),
+							'flow_id'    => array( 'type' => 'integer' ),
+							'job_id'     => array( 'type' => 'integer' ),
+							'first_step' => array( 'type' => 'string' ),
+							'error'      => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array(
+						'show_in_rest' => false,
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => false,
+						),
+					),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Execute the run-flow ability.
+	 *
+	 * @param array $input Input with flow_id and optional job_id.
+	 * @return array Result with success status and execution details.
+	 */
+	public function execute( array $input ): array {
+		AgentContext::set( AgentType::PIPELINE );
+
+		$flow_id = (int) ( $input['flow_id'] ?? 0 );
+		$job_id  = $input['job_id'] ?? null;
+
+		$flow = $this->db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			do_action( 'datamachine_log', 'error', 'Flow execution failed - flow not found', array( 'flow_id' => $flow_id ) );
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow %d not found.', $flow_id ),
+			);
+		}
+
+		$pipeline_id = (int) $flow['pipeline_id'];
+
+		// Use provided job_id or create new one (for scheduled/recurring flows).
+		if ( ! $job_id ) {
+			$job_id = $this->db_jobs->create_job(
+				array(
+					'pipeline_id' => $pipeline_id,
+					'flow_id'     => $flow_id,
+					'source'      => 'pipeline',
+					'label'       => $flow['flow_name'] ?? null,
+				)
+			);
+			if ( ! $job_id ) {
+				do_action(
+					'datamachine_log',
+					'error',
+					'Job creation failed - database insert failed',
+					array(
+						'flow_id'     => $flow_id,
+						'pipeline_id' => $pipeline_id,
+					)
+				);
+				return array(
+					'success' => false,
+					'error'   => 'Job creation failed - database insert failed.',
+				);
+			}
+			do_action(
+				'datamachine_log',
+				'debug',
+				'Job created',
+				array(
+					'job_id'      => $job_id,
+					'flow_id'     => $flow_id,
+					'pipeline_id' => $pipeline_id,
+				)
+			);
+		}
+
+		// Transition job from pending to processing.
+		$this->db_jobs->start_job( $job_id );
+
+		$flow_config       = $flow['flow_config'] ?? array();
+		$scheduling_config = $flow['scheduling_config'] ?? array();
+
+		// Load pipeline config.
+		$pipeline        = $this->db_pipelines->get_pipeline( $pipeline_id );
+		$pipeline_config = $pipeline['pipeline_config'] ?? array();
+
+		$flow_config     = datamachine_normalize_engine_config( $flow_config );
+		$pipeline_config = datamachine_normalize_engine_config( $pipeline_config );
+
+		$engine_snapshot = array(
+			'job'             => array(
+				'job_id'      => $job_id,
+				'flow_id'     => $flow_id,
+				'pipeline_id' => $pipeline_id,
+				'created_at'  => current_time( 'mysql', true ),
+			),
+			'flow'            => array(
+				'name'        => $flow['flow_name'] ?? '',
+				'description' => $flow['flow_description'] ?? '',
+				'scheduling'  => $scheduling_config,
+			),
+			'pipeline'        => array(
+				'name'        => $pipeline['pipeline_name'] ?? '',
+				'description' => $pipeline['pipeline_description'] ?? '',
+			),
+			'flow_config'     => $flow_config,
+			'pipeline_config' => $pipeline_config,
+		);
+
+		datamachine_set_engine_data( $job_id, $engine_snapshot );
+
+		$first_flow_step_id = null;
+		foreach ( $flow_config as $flow_step_id => $config ) {
+			if ( ( $config['execution_order'] ?? -1 ) === 0 ) {
+				$first_flow_step_id = $flow_step_id;
+				break;
+			}
+		}
+
+		if ( ! $first_flow_step_id ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Flow execution failed - no first step found',
+				array(
+					'job_id'      => $job_id,
+					'pipeline_id' => $pipeline_id,
+					'flow_id'     => $flow_id,
+				)
+			);
+			return array(
+				'success' => false,
+				'error'   => 'Flow execution failed - no first step found.',
+			);
+		}
+
+		do_action( 'datamachine_schedule_next_step', $job_id, $first_flow_step_id, array() );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Flow execution started successfully',
+			array(
+				'flow_id'    => $flow_id,
+				'job_id'     => $job_id,
+				'first_step' => $first_flow_step_id,
+			)
+		);
+
+		return array(
+			'success'    => true,
+			'flow_id'    => $flow_id,
+			'job_id'     => $job_id,
+			'first_step' => $first_flow_step_id,
+		);
+	}
+}

--- a/inc/Abilities/Engine/ScheduleFlowAbility.php
+++ b/inc/Abilities/Engine/ScheduleFlowAbility.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Schedule Flow Ability
+ *
+ * Schedules flow execution for later. Handles manual (clear schedule),
+ * one-time execution at specific timestamps, and recurring execution
+ * at defined intervals.
+ *
+ * Backs the datamachine_run_flow_later action hook.
+ *
+ * @package DataMachine\Abilities\Engine
+ * @since 0.30.0
+ */
+
+namespace DataMachine\Abilities\Engine;
+
+defined( 'ABSPATH' ) || exit;
+
+class ScheduleFlowAbility {
+
+	use EngineHelpers;
+
+	public function __construct() {
+		$this->initDatabases();
+
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		$this->registerAbility();
+	}
+
+	/**
+	 * Register the datamachine/schedule-flow ability.
+	 */
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/schedule-flow',
+				array(
+					'label'               => __( 'Schedule Flow', 'data-machine' ),
+					'description'         => __( 'Schedule flow execution: manual (clear), one-time timestamp, or recurring interval.', 'data-machine' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'flow_id', 'interval_or_timestamp' ),
+						'properties' => array(
+							'flow_id'               => array(
+								'type'        => 'integer',
+								'description' => __( 'Flow ID to schedule.', 'data-machine' ),
+							),
+							'interval_or_timestamp' => array(
+								'type'        => array( 'string', 'integer' ),
+								'description' => __( "Either 'manual', numeric timestamp, or interval key.", 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'        => array( 'type' => 'boolean' ),
+							'flow_id'        => array( 'type' => 'integer' ),
+							'schedule_type'  => array( 'type' => 'string' ),
+							'action_id'      => array( 'type' => 'integer' ),
+							'scheduled_time' => array( 'type' => 'string' ),
+							'error'          => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array(
+						'show_in_rest' => false,
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => true,
+						),
+					),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Execute the schedule-flow ability.
+	 *
+	 * @param array $input Input with flow_id and interval_or_timestamp.
+	 * @return array Result with scheduling details.
+	 */
+	public function execute( array $input ): array {
+		$flow_id               = (int) ( $input['flow_id'] ?? 0 );
+		$interval_or_timestamp = $input['interval_or_timestamp'] ?? null;
+
+		// Always unschedule existing to prevent duplicates.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+		}
+
+		if ( 'manual' === $interval_or_timestamp ) {
+			return $this->clearSchedule( $flow_id );
+		}
+
+		if ( is_numeric( $interval_or_timestamp ) ) {
+			return $this->scheduleOneTime( $flow_id, (int) $interval_or_timestamp );
+		}
+
+		return $this->scheduleRecurring( $flow_id, $interval_or_timestamp );
+	}
+
+	/**
+	 * Clear an existing schedule (set to manual).
+	 *
+	 * @param int $flow_id Flow ID.
+	 * @return array Result.
+	 */
+	private function clearSchedule( int $flow_id ): array {
+		$scheduling_config = array( 'interval' => 'manual' );
+		$this->db_flows->update_flow_scheduling( $flow_id, $scheduling_config );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Flow schedule cleared (set to manual)',
+			array( 'flow_id' => $flow_id )
+		);
+
+		return array(
+			'success'       => true,
+			'flow_id'       => $flow_id,
+			'schedule_type' => 'manual',
+		);
+	}
+
+	/**
+	 * Schedule a one-time execution at a specific timestamp.
+	 *
+	 * @param int $flow_id   Flow ID.
+	 * @param int $timestamp Unix timestamp for execution.
+	 * @return array Result.
+	 */
+	private function scheduleOneTime( int $flow_id, int $timestamp ): array {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Action Scheduler not available.',
+			);
+		}
+
+		$action_id = as_schedule_single_action(
+			$timestamp,
+			'datamachine_run_flow_now',
+			array( $flow_id ),
+			'data-machine'
+		);
+
+		$scheduling_config = array(
+			'interval'       => 'one_time',
+			'timestamp'      => $timestamp,
+			'scheduled_time' => wp_date( 'c', $timestamp ),
+		);
+		$this->db_flows->update_flow_scheduling( $flow_id, $scheduling_config );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Flow scheduled for one-time execution',
+			array(
+				'flow_id'        => $flow_id,
+				'timestamp'      => $timestamp,
+				'scheduled_time' => wp_date( 'c', $timestamp ),
+				'action_id'      => $action_id,
+			)
+		);
+
+		return array(
+			'success'        => true,
+			'flow_id'        => $flow_id,
+			'schedule_type'  => 'one_time',
+			'action_id'      => $action_id,
+			'scheduled_time' => wp_date( 'c', $timestamp ),
+		);
+	}
+
+	/**
+	 * Schedule recurring execution at a defined interval.
+	 *
+	 * @param int    $flow_id  Flow ID.
+	 * @param string $interval Interval key from datamachine_scheduler_intervals filter.
+	 * @return array Result.
+	 */
+	private function scheduleRecurring( int $flow_id, string $interval ): array {
+		$intervals        = apply_filters( 'datamachine_scheduler_intervals', array() );
+		$interval_seconds = $intervals[ $interval ]['seconds'] ?? null;
+
+		if ( ! $interval_seconds ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Invalid schedule interval',
+				array(
+					'flow_id'             => $flow_id,
+					'interval'            => $interval,
+					'available_intervals' => array_keys( $intervals ),
+				)
+			);
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Invalid interval: %s', $interval ),
+			);
+		}
+
+		if ( ! function_exists( 'as_schedule_recurring_action' ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Action Scheduler not available.',
+			);
+		}
+
+		$action_id = as_schedule_recurring_action(
+			time() + $interval_seconds,
+			$interval_seconds,
+			'datamachine_run_flow_now',
+			array( $flow_id ),
+			'data-machine'
+		);
+
+		$scheduling_config = array(
+			'interval'         => $interval,
+			'interval_seconds' => $interval_seconds,
+			'first_run'        => wp_date( 'c', time() + $interval_seconds ),
+		);
+		$this->db_flows->update_flow_scheduling( $flow_id, $scheduling_config );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Flow scheduled for recurring execution',
+			array(
+				'flow_id'          => $flow_id,
+				'interval'         => $interval,
+				'interval_seconds' => $interval_seconds,
+				'first_run'        => wp_date( 'c', time() + $interval_seconds ),
+				'action_id'        => $action_id,
+			)
+		);
+
+		return array(
+			'success'        => true,
+			'flow_id'        => $flow_id,
+			'schedule_type'  => 'recurring',
+			'action_id'      => $action_id,
+			'scheduled_time' => wp_date( 'c', time() + $interval_seconds ),
+		);
+	}
+}

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Schedule Next Step Ability
+ *
+ * Stores data packets in the file repository and schedules the next
+ * step for execution via Action Scheduler.
+ *
+ * Backs the datamachine_schedule_next_step action hook.
+ *
+ * @package DataMachine\Abilities\Engine
+ * @since 0.30.0
+ */
+
+namespace DataMachine\Abilities\Engine;
+
+use DataMachine\Core\EngineData;
+use DataMachine\Core\FilesRepository\FileStorage;
+
+defined( 'ABSPATH' ) || exit;
+
+class ScheduleNextStepAbility {
+
+	use EngineHelpers;
+
+	public function __construct() {
+		$this->initDatabases();
+
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		$this->registerAbility();
+	}
+
+	/**
+	 * Register the datamachine/schedule-next-step ability.
+	 */
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/schedule-next-step',
+				array(
+					'label'               => __( 'Schedule Next Step', 'data-machine' ),
+					'description'         => __( 'Store data packets and schedule the next pipeline step via Action Scheduler.', 'data-machine' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'job_id', 'flow_step_id' ),
+						'properties' => array(
+							'job_id'       => array(
+								'type'        => 'integer',
+								'description' => __( 'Job ID for the execution.', 'data-machine' ),
+							),
+							'flow_step_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Flow step ID to schedule.', 'data-machine' ),
+							),
+							'data_packets' => array(
+								'type'        => 'array',
+								'default'     => array(),
+								'description' => __( 'Data packets to pass to the next step.', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'   => array( 'type' => 'boolean' ),
+							'action_id' => array( 'type' => 'integer' ),
+							'error'     => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array(
+						'show_in_rest' => false,
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => false,
+							'idempotent'  => false,
+						),
+					),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Execute the schedule-next-step ability.
+	 *
+	 * @param array $input Input with job_id, flow_step_id, and optional data_packets.
+	 * @return array Result with success status and action_id.
+	 */
+	public function execute( array $input ): array {
+		$job_id       = (int) ( $input['job_id'] ?? 0 );
+		$flow_step_id = $input['flow_step_id'] ?? '';
+		$dataPackets  = $input['data_packets'] ?? array();
+
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Action Scheduler not available.',
+			);
+		}
+
+		// Store data by job_id (if present).
+		if ( ! empty( $dataPackets ) ) {
+			$engine_snapshot  = datamachine_get_engine_data( $job_id );
+			$engine           = new EngineData( $engine_snapshot, $job_id );
+			$flow_step_config = $engine->getFlowStepConfig( $flow_step_id );
+
+			$flow_id = (int) ( $flow_step_config['flow_id'] ?? ( $engine->getJobContext()['flow_id'] ?? 0 ) );
+
+			if ( $flow_id <= 0 ) {
+				do_action(
+					'datamachine_log',
+					'error',
+					'Flow ID missing during data storage',
+					array(
+						'job_id'       => $job_id,
+						'flow_step_id' => $flow_step_id,
+					)
+				);
+				return array(
+					'success' => false,
+					'error'   => 'Flow ID missing during data storage.',
+				);
+			}
+
+			$context = datamachine_get_file_context( $flow_id );
+
+			$storage = new FileStorage();
+			$storage->store_data_packet( $dataPackets, $job_id, $context );
+		}
+
+		// Action Scheduler only receives IDs.
+		$action_id = as_schedule_single_action(
+			time(),
+			'datamachine_execute_step',
+			array(
+				'job_id'       => $job_id,
+				'flow_step_id' => $flow_step_id,
+			),
+			'data-machine'
+		);
+
+		if ( ! empty( $dataPackets ) ) {
+			do_action(
+				'datamachine_log',
+				'debug',
+				'Next step scheduled via Action Scheduler',
+				array(
+					'job_id'       => $job_id,
+					'flow_step_id' => $flow_step_id,
+					'action_id'    => $action_id,
+					'success'      => ( false !== $action_id ),
+				)
+			);
+		}
+
+		return array(
+			'success'   => false !== $action_id,
+			'action_id' => $action_id,
+		);
+	}
+}

--- a/inc/Abilities/EngineAbilities.php
+++ b/inc/Abilities/EngineAbilities.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Engine Abilities
+ *
+ * Facade that registers all engine execution abilities.
+ * These are internal abilities backing the four core action hooks
+ * that drive pipeline execution via Action Scheduler.
+ *
+ * @package DataMachine\Abilities
+ * @since 0.30.0
+ */
+
+namespace DataMachine\Abilities;
+
+use DataMachine\Abilities\Engine\RunFlowAbility;
+use DataMachine\Abilities\Engine\ExecuteStepAbility;
+use DataMachine\Abilities\Engine\ScheduleNextStepAbility;
+use DataMachine\Abilities\Engine\ScheduleFlowAbility;
+
+defined( 'ABSPATH' ) || exit;
+
+class EngineAbilities {
+
+	private static bool $registered = false;
+
+	private RunFlowAbility $run_flow;
+	private ExecuteStepAbility $execute_step;
+	private ScheduleNextStepAbility $schedule_next_step;
+	private ScheduleFlowAbility $schedule_flow;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
+			return;
+		}
+
+		$this->run_flow           = new RunFlowAbility();
+		$this->execute_step       = new ExecuteStepAbility();
+		$this->schedule_next_step = new ScheduleNextStepAbility();
+		$this->schedule_flow      = new ScheduleFlowAbility();
+
+		self::$registered = true;
+	}
+}

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -46,6 +46,7 @@ if ( ! defined( 'WPINC' ) ) {
 require_once __DIR__ . '/ImportExport.php';
 require_once __DIR__ . '/Engine.php';
 
+use DataMachine\Abilities\EngineAbilities;
 use DataMachine\Engine\Actions\Handlers\MarkItemProcessedHandler;
 use DataMachine\Engine\Actions\Handlers\FailJobHandler;
 use DataMachine\Engine\Actions\Handlers\JobCompleteHandler;
@@ -84,5 +85,8 @@ function datamachine_register_core_actions() {
 	);
 
 	\DataMachine\Engine\Actions\ImportExport::register();
+
+	// Register engine abilities (business logic) before hook bridges.
+	new EngineAbilities();
 	datamachine_register_execution_engine();
 }

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -1,6 +1,10 @@
 <?php
 /**
- * Four-action execution engine.
+ * Execution engine — shared utilities and action hook bridges.
+ *
+ * Business logic lives in Abilities\Engine\* classes. The action hooks
+ * registered here are thin bridges required by Action Scheduler, which
+ * can only fire do_action() calls.
  *
  * Execution cycle: datamachine_run_flow_now → datamachine_execute_step → datamachine_schedule_next_step
  * Scheduling cycle: datamachine_run_flow_later → Action Scheduler → datamachine_run_flow_now
@@ -9,10 +13,6 @@
  */
 
 defined( 'ABSPATH' ) || exit;
-
-use DataMachine\Core\JobStatus;
-use DataMachine\Engine\AI\AgentType;
-use DataMachine\Engine\AI\AgentContext;
 
 /**
  * Normalize stored configuration blobs into arrays.
@@ -31,463 +31,57 @@ function datamachine_normalize_engine_config( $config ): array {
 }
 
 /**
- * Get file context array from flow ID
+ * Get file context array from flow ID.
  *
- * @param int|string $flow_id Flow ID or 'direct' for ephemeral workflows
- * @return array Context array with pipeline/flow metadata
+ * @param int|string $flow_id Flow ID or 'direct' for ephemeral workflows.
+ * @return array Context array with pipeline/flow metadata.
  */
 function datamachine_get_file_context( int|string $flow_id ): array {
 	return \DataMachine\Api\Files::get_file_context( $flow_id );
 }
 
 /**
- * Register execution engine action hooks.
+ * Register execution engine action hooks as thin bridges to abilities.
  *
- * Registers the four core execution actions:
- * - datamachine_run_flow_now
- * - datamachine_execute_step
- * - datamachine_schedule_next_step
- * - datamachine_run_flow_later
+ * Action Scheduler fires do_action() — these hooks delegate immediately
+ * to the corresponding ability via wp_get_ability()->execute().
  */
 function datamachine_register_execution_engine() {
 
 	/**
-	 * Execute flow immediately.
-	 *
-	 * Loads flow/pipeline configurations and schedules the first step for execution.
-	 * Creates a job record if one is not provided (for scheduled/recurring flows).
-	 *
-	 * @param int $flow_id Flow ID to execute
-	 * @param int|null $job_id Pre-created job ID (optional, for API-triggered executions)
-	 * @return bool True on success, false on failure
+	 * Bridge: datamachine_run_flow_now → datamachine/run-flow ability.
 	 */
 	add_action(
 		'datamachine_run_flow_now',
 		function ( $flow_id, $job_id = null ) {
-			// Set pipeline agent context for all logging during flow execution
-			AgentContext::set( AgentType::PIPELINE );
-
-			$db_flows = new \DataMachine\Core\Database\Flows\Flows();
-			$db_jobs  = new \DataMachine\Core\Database\Jobs\Jobs();
-
-			$flow = $db_flows->get_flow( $flow_id );
-			if ( ! $flow ) {
-				do_action( 'datamachine_log', 'error', 'Flow execution failed - flow not found', array( 'flow_id' => $flow_id ) );
-				return false;
-			}
-
-			$pipeline_id = (int) $flow['pipeline_id'];
-
-			// Use provided job_id or create new one (for scheduled/recurring flows)
-			if ( ! $job_id ) {
-				$job_id = $db_jobs->create_job(
+			$ability = wp_get_ability( 'datamachine/run-flow' );
+			if ( $ability ) {
+				$ability->execute(
 					array(
-						'pipeline_id' => $pipeline_id,
-						'flow_id'     => $flow_id,
-						'source'      => 'pipeline',
-						'label'       => $flow['flow_name'] ?? null,
-					)
-				);
-				if ( ! $job_id ) {
-					do_action(
-						'datamachine_log',
-						'error',
-						'Job creation failed - database insert failed',
-						array(
-							'flow_id'     => $flow_id,
-							'pipeline_id' => $pipeline_id,
-						)
-					);
-					return false;
-				}
-				do_action(
-					'datamachine_log',
-					'debug',
-					'Job created',
-					array(
-						'job_id'      => $job_id,
-						'flow_id'     => $flow_id,
-						'pipeline_id' => $pipeline_id,
+						'flow_id' => (int) $flow_id,
+						'job_id'  => $job_id ? (int) $job_id : null,
 					)
 				);
 			}
-
-			// Transition job from pending to processing
-			$db_jobs->start_job( $job_id );
-
-			$flow_config       = $flow['flow_config'] ?? array();
-			$scheduling_config = $flow['scheduling_config'] ?? array();
-
-			// Load pipeline config
-			$db_pipelines    = new \DataMachine\Core\Database\Pipelines\Pipelines();
-			$pipeline        = $db_pipelines->get_pipeline( $pipeline_id );
-			$pipeline_config = $pipeline['pipeline_config'] ?? array();
-
-			$flow_config     = datamachine_normalize_engine_config( $flow_config );
-			$pipeline_config = datamachine_normalize_engine_config( $pipeline_config );
-
-			$engine_snapshot = array(
-				'job'             => array(
-					'job_id'      => $job_id,
-					'flow_id'     => $flow_id,
-					'pipeline_id' => $pipeline_id,
-					'created_at'  => current_time( 'mysql', true ),
-				),
-				'flow'            => array(
-					'name'        => $flow['flow_name'] ?? '',
-					'description' => $flow['flow_description'] ?? '',
-					'scheduling'  => $scheduling_config,
-				),
-				'pipeline'        => array(
-					'name'        => $pipeline['pipeline_name'] ?? '',
-					'description' => $pipeline['pipeline_description'] ?? '',
-				),
-				'flow_config'     => $flow_config,
-				'pipeline_config' => $pipeline_config,
-			);
-
-			datamachine_set_engine_data( $job_id, $engine_snapshot );
-
-			$first_flow_step_id = null;
-			foreach ( $flow_config as $flow_step_id => $config ) {
-				if ( ( $config['execution_order'] ?? -1 ) === 0 ) {
-					$first_flow_step_id = $flow_step_id;
-					break;
-				}
-			}
-
-			if ( ! $first_flow_step_id ) {
-				do_action(
-					'datamachine_log',
-					'error',
-					'Flow execution failed - no first step found',
-					array(
-						'job_id'      => $job_id,
-						'pipeline_id' => $pipeline_id,
-						'flow_id'     => $flow_id,
-					)
-				);
-				return false;
-			}
-
-			do_action( 'datamachine_schedule_next_step', $job_id, $first_flow_step_id, array() );
-
-			do_action(
-				'datamachine_log',
-				'info',
-				'Flow execution started successfully',
-				array(
-					'flow_id'    => $flow_id,
-					'job_id'     => $job_id,
-					'first_step' => $first_flow_step_id,
-				)
-			);
-
-			return true;
 		},
 		10,
 		2
 	);
 
 	/**
-	 * Execute a single step in a pipeline flow.
-	 *
-	 * @param int $job_id Job ID for the execution
-	 * @param string $flow_step_id Flow step ID to execute
-	 * @param array|null $data Input data for the step
-	 * @return bool True on success, false on failure
+	 * Bridge: datamachine_execute_step → datamachine/execute-step ability.
 	 */
 	add_action(
 		'datamachine_execute_step',
 		function ( $job_id, string $flow_step_id, ?array $dataPackets = null ) {
-			// Set pipeline agent context for all logging during step execution
-			AgentContext::set( AgentType::PIPELINE );
-
-			$job_id  = (int) $job_id;
-			$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
-
-			try {
-				$engine_snapshot = datamachine_get_engine_data( $job_id );
-				$engine          = new \DataMachine\Core\EngineData( $engine_snapshot, $job_id );
-
-				$flow_step_config = $engine->getFlowStepConfig( $flow_step_id );
-
-				if ( ! $flow_step_config ) {
-					$db_flows         = new \DataMachine\Core\Database\Flows\Flows();
-					$flow_step_config = $db_flows->get_flow_step_config( $flow_step_id, $job_id, true );
-
-					if ( $flow_step_config ) {
-						$existing_flow_config                  = $engine_snapshot['flow_config'] ?? array();
-						$existing_flow_config[ $flow_step_id ] = $flow_step_config;
-						datamachine_merge_engine_data(
-							$job_id,
-							array(
-								'flow_config' => $existing_flow_config,
-							)
-						);
-						$engine = new \DataMachine\Core\EngineData( datamachine_get_engine_data( $job_id ), $job_id );
-					}
-				}
-
-				if ( ! isset( $flow_step_config['flow_id'] ) || empty( $flow_step_config['flow_id'] ) ) {
-					do_action(
-						'datamachine_fail_job',
-						$job_id,
-						'step_execution_failure',
-						array(
-							'flow_step_id' => $flow_step_id,
-							'reason'       => 'missing_flow_id_in_step_config',
-						)
-					);
-					return false;
-				}
-
-				$flow_id = $flow_step_config['flow_id'];
-
-				/** @var array $context */
-				$context = datamachine_get_file_context( $flow_id );
-
-				$retrieval   = new \DataMachine\Core\FilesRepository\FileRetrieval();
-				$dataPackets = $retrieval->retrieve_data_by_job_id( $job_id, $context );
-
-				if ( ! isset( $flow_step_config['step_type'] ) || empty( $flow_step_config['step_type'] ) ) {
-					do_action(
-						'datamachine_fail_job',
-						$job_id,
-						'step_execution_failure',
-						array(
-							'flow_step_id' => $flow_step_id,
-							'reason'       => 'missing_step_type_in_flow_step_config',
-						)
-					);
-					return false;
-				}
-
-				$step_type           = $flow_step_config['step_type'];
-				$step_type_abilities = new \DataMachine\Abilities\StepTypeAbilities();
-				$step_definition     = $step_type_abilities->getStepType( $step_type );
-
-				if ( ! $step_definition ) {
-					do_action(
-						'datamachine_fail_job',
-						$job_id,
-						'step_execution_failure',
-						array(
-							'flow_step_id' => $flow_step_id,
-							'step_type'    => $step_type,
-							'reason'       => 'step_type_not_found_in_registry',
-						)
-					);
-					return false;
-				}
-
-				$step_class = $step_definition['class'] ?? '';
-				$flow_step  = new $step_class();
-
-				$payload = array(
-					'job_id'       => $job_id,
-					'flow_step_id' => $flow_step_id,
-					'data'         => $dataPackets,
-					'engine'       => $engine,
-				);
-
-				$dataPackets = $flow_step->execute( $payload );
-
-				if ( ! is_array( $dataPackets ) ) {
-					do_action(
-						'datamachine_fail_job',
-						$job_id,
-						'step_execution_failure',
-						array(
-							'flow_step_id' => $flow_step_id,
-							'class'        => $step_class,
-							'reason'       => 'non_array_payload_returned',
-						)
-					);
-					return false;
-				}
-
-				$payload['data'] = $dataPackets;
-
-				// Check for step success: non-empty packets AND no failure indicators
-				$step_success = ! empty( $dataPackets );
-
-				// Check if any packet explicitly indicates failure (metadata.success === false)
-				if ( $step_success ) {
-					foreach ( $dataPackets as $packet ) {
-						$metadata = $packet['metadata'] ?? array();
-						if ( isset( $metadata['success'] ) && false === $metadata['success'] ) {
-							$step_success = false;
-							do_action(
-								'datamachine_log',
-								'warning',
-								'Step returned failure packet',
-								array(
-									'job_id'        => $job_id,
-									'flow_step_id'  => $flow_step_id,
-									'packet_type'   => $packet['type'] ?? 'unknown',
-									'error_message' => $packet['data']['body'] ?? 'No error message',
-								)
-							);
-							break;
-						}
-					}
-				}
-
-				// Refresh engine data to capture any changes made during step execution (e.g., job_status from skip_item)
-				$refreshed_engine_data = datamachine_get_engine_data( $job_id );
-				$engine                = new \DataMachine\Core\EngineData( $refreshed_engine_data, $job_id );
-
-				// Check for status override from tools (e.g., skip_item sets agent_skipped)
-				// If set, complete the job immediately without scheduling next step
-				$status_override = $engine->get( 'job_status' );
-
-				do_action(
-					'datamachine_log',
-					'debug',
-					'Engine: status_override check',
+			$ability = wp_get_ability( 'datamachine/execute-step' );
+			if ( $ability ) {
+				$ability->execute(
 					array(
-						'job_id'                 => $job_id,
-						'status_override'        => $status_override,
-						'has_override'           => ! empty( $status_override ),
-						'engine_data_job_status' => $refreshed_engine_data['job_status'] ?? 'not_set',
+						'job_id'       => (int) $job_id,
+						'flow_step_id' => $flow_step_id,
 					)
 				);
-
-				if ( $status_override && JobStatus::isStatusWaiting( $status_override ) ) {
-					// Waiting status: pipeline is parked at a webhook gate.
-					// Job status was already set by the step. Do not schedule next step.
-					// Do not clean up data packets (needed when pipeline resumes).
-					do_action(
-						'datamachine_log',
-						'info',
-						'Pipeline parked in waiting state (webhook gate)',
-						array(
-							'job_id'       => $job_id,
-							'pipeline_id'  => $flow_step_config['pipeline_id'] ?? null,
-							'flow_id'      => $flow_id,
-							'flow_step_id' => $flow_step_id,
-						)
-					);
-				} elseif ( $status_override ) {
-					$complete_result = $db_jobs->complete_job( $job_id, $status_override );
-
-					do_action(
-						'datamachine_log',
-						'debug',
-						'Engine: complete_job called with status_override',
-						array(
-							'job_id' => $job_id,
-							'status' => $status_override,
-							'result' => $complete_result,
-						)
-					);
-					$cleanup = new \DataMachine\Core\FilesRepository\FileCleanup();
-					$context = datamachine_get_file_context( $flow_id );
-					$cleanup->cleanup_job_data_packets( $job_id, $context );
-					do_action(
-						'datamachine_log',
-						'info',
-						'Pipeline execution completed with status override',
-						array(
-							'job_id'          => $job_id,
-							'pipeline_id'     => $flow_step_config['pipeline_id'] ?? null,
-							'flow_id'         => $flow_id,
-							'flow_step_id'    => $flow_step_id,
-							'final_status'    => $status_override,
-							'override_source' => 'engine_data',
-						)
-					);
-				} elseif ( $step_success ) {
-					$navigator         = new \DataMachine\Engine\StepNavigator();
-					$next_flow_step_id = $navigator->get_next_flow_step_id( $flow_step_id, $payload );
-
-					if ( $next_flow_step_id ) {
-						do_action( 'datamachine_schedule_next_step', $job_id, $next_flow_step_id, $dataPackets );
-					} else {
-						$db_jobs->complete_job( $job_id, JobStatus::COMPLETED );
-						$cleanup = new \DataMachine\Core\FilesRepository\FileCleanup();
-						$context = datamachine_get_file_context( $flow_id );
-						$cleanup->cleanup_job_data_packets( $job_id, $context );
-						do_action(
-							'datamachine_log',
-							'info',
-							'Pipeline execution completed successfully',
-							array(
-								'job_id'             => $job_id,
-								'pipeline_id'        => $flow_step_config['pipeline_id'] ?? null,
-								'flow_id'            => $flow_id,
-								'flow_step_id'       => $flow_step_id,
-								'final_packet_count' => count( $dataPackets ),
-								'final_status'       => JobStatus::COMPLETED,
-							)
-						);
-					}
-				} else {
-					// Check if this is a fetch step with processed items history
-					// If so, empty result means "no new items" not "failure"
-					$is_fetch_step      = ( 'fetch' === $step_type );
-					$db_processed_items = new \DataMachine\Core\Database\ProcessedItems\ProcessedItems();
-					$has_history        = $db_processed_items->has_processed_items( $flow_step_id );
-
-					if ( $is_fetch_step && $has_history ) {
-						// Flow has processed items before - this is "no new items", not a failure
-						$db_jobs->complete_job( $job_id, JobStatus::COMPLETED_NO_ITEMS );
-						do_action(
-							'datamachine_log',
-							'info',
-							'Flow completed with no new items to process',
-							array(
-								'job_id'       => $job_id,
-								'pipeline_id'  => $flow_step_config['pipeline_id'] ?? null,
-								'flow_id'      => $flow_id,
-								'flow_step_id' => $flow_step_id,
-								'step_type'    => $step_type,
-							)
-						);
-					} else {
-						// First run with no items, or non-fetch step failed
-						do_action(
-							'datamachine_log',
-							'error',
-							'Step execution failed - empty data packet',
-							array(
-								'job_id'       => $job_id,
-								'pipeline_id'  => $flow_step_config['pipeline_id'] ?? null,
-								'flow_id'      => $flow_id,
-								'flow_step_id' => $flow_step_id,
-								'step_class'   => $step_class,
-								'step_type'    => $step_type,
-								'has_history'  => $has_history,
-							)
-						);
-						do_action(
-							'datamachine_fail_job',
-							$job_id,
-							'step_execution_failure',
-							array(
-								'flow_step_id' => $flow_step_id,
-								'class'        => $step_class,
-								'reason'       => 'empty_data_packet_returned',
-							)
-						);
-					}
-				}
-
-				return $step_success;
-			} catch ( \Throwable $e ) {
-				do_action(
-					'datamachine_fail_job',
-					$job_id,
-					'step_execution_failure',
-					array(
-						'flow_step_id'      => $flow_step_id,
-						'exception_message' => $e->getMessage(),
-						'exception_trace'   => $e->getTraceAsString(),
-						'reason'            => 'throwable_exception_in_step_execution',
-					)
-				);
-				return false;
 			}
 		},
 		10,
@@ -495,202 +89,43 @@ function datamachine_register_execution_engine() {
 	);
 
 	/**
-	 * Schedule next step in flow execution.
-	 *
-	 * Stores data packet in repository if needed, then schedules
-	 * the step execution via Action Scheduler.
-	 *
-	 * @param int $job_id Job ID for the execution
-	 * @param string $flow_step_id Flow step ID to schedule
-	 * @param array $dataPackets Data packets to pass to the next step
-	 * @return bool True on successful scheduling, false on failure
+	 * Bridge: datamachine_schedule_next_step → datamachine/schedule-next-step ability.
 	 */
 	add_action(
 		'datamachine_schedule_next_step',
 		function ( $job_id, $flow_step_id, $dataPackets = array() ) {
-			$job_id = (int) $job_id; // Ensure job_id is int for database operations
-
-			if ( ! function_exists( 'as_schedule_single_action' ) ) {
-				return false;
-			}
-
-			// Store data by job_id (if present)
-			if ( ! empty( $dataPackets ) ) {
-				$engine_snapshot  = datamachine_get_engine_data( $job_id );
-				$engine           = new \DataMachine\Core\EngineData( $engine_snapshot, $job_id );
-				$flow_step_config = $engine->getFlowStepConfig( $flow_step_id );
-
-				$flow_id = (int) ( $flow_step_config['flow_id'] ?? ( $engine->getJobContext()['flow_id'] ?? 0 ) );
-
-				if ( $flow_id <= 0 ) {
-					do_action(
-						'datamachine_log',
-						'error',
-						'Flow ID missing during data storage',
-						array(
-							'job_id'       => $job_id,
-							'flow_step_id' => $flow_step_id,
-						)
-					);
-					return false;
-				}
-
-				$context = datamachine_get_file_context( $flow_id );
-
-				$storage = new \DataMachine\Core\FilesRepository\FileStorage();
-				$storage->store_data_packet( $dataPackets, $job_id, $context );
-			}
-
-			// Action Scheduler only receives IDs
-			$action_id = as_schedule_single_action(
-				time(),
-				'datamachine_execute_step',
-				array(
-					'job_id'       => $job_id,
-					'flow_step_id' => $flow_step_id,
-				),
-				'data-machine'
-			);
-
-			if ( ! empty( $dataPackets ) ) {
-				do_action(
-					'datamachine_log',
-					'debug',
-					'Next step scheduled via Action Scheduler',
+			$ability = wp_get_ability( 'datamachine/schedule-next-step' );
+			if ( $ability ) {
+				$ability->execute(
 					array(
-						'job_id'       => $job_id,
+						'job_id'       => (int) $job_id,
 						'flow_step_id' => $flow_step_id,
-						'action_id'    => $action_id,
-						'success'      => ( false !== $action_id ),
+						'data_packets' => $dataPackets,
 					)
 				);
 			}
-
-			return false !== $action_id;
 		},
 		10,
 		3
 	);
 
 	/**
-	 * Schedule flow execution for later.
-	 *
-	 * Handles both one-time execution at specific timestamps and
-	 * recurring execution at defined intervals. Use 'manual' to
-	 * clear existing schedules.
-	 *
-	 * @param int $flow_id Flow ID to schedule
-	 * @param string|int $interval_or_timestamp Either 'manual', numeric timestamp, or interval key
+	 * Bridge: datamachine_run_flow_later → datamachine/schedule-flow ability.
 	 */
 	add_action(
 		'datamachine_run_flow_later',
 		function ( $flow_id, $interval_or_timestamp ) {
-			$db_flows = new \DataMachine\Core\Database\Flows\Flows();
-
-			// 1. Always unschedule existing to prevent duplicates
-			if ( function_exists( 'as_unschedule_all_actions' ) ) {
-				as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
-			}
-
-			// 2. Handle 'manual' case
-			if ( 'manual' === $interval_or_timestamp ) {
-				$scheduling_config = array( 'interval' => 'manual' );
-				$db_flows->update_flow_scheduling( $flow_id, $scheduling_config );
-
-				do_action(
-					'datamachine_log',
-					'info',
-					'Flow schedule cleared (set to manual)',
+			$ability = wp_get_ability( 'datamachine/schedule-flow' );
+			if ( $ability ) {
+				$ability->execute(
 					array(
-						'flow_id' => $flow_id,
+						'flow_id'               => (int) $flow_id,
+						'interval_or_timestamp' => $interval_or_timestamp,
 					)
 				);
-				return;
-			}
-
-			// 3. Determine if timestamp (numeric) or interval string
-			if ( is_numeric( $interval_or_timestamp ) ) {
-				// One-time execution at specific timestamp
-				if ( function_exists( 'as_schedule_single_action' ) ) {
-					$action_id = as_schedule_single_action(
-						$interval_or_timestamp,
-						'datamachine_run_flow_now',
-						array( $flow_id ),
-						'data-machine'
-					);
-
-					// Update database with scheduling configuration
-					$scheduling_config = array(
-						'interval'       => 'one_time',
-						'timestamp'      => $interval_or_timestamp,
-						'scheduled_time' => wp_date( 'c', $interval_or_timestamp ),
-					);
-					$db_flows->update_flow_scheduling( $flow_id, $scheduling_config );
-
-					do_action(
-						'datamachine_log',
-						'info',
-						'Flow scheduled for one-time execution',
-						array(
-							'flow_id'        => $flow_id,
-							'timestamp'      => $interval_or_timestamp,
-							'scheduled_time' => wp_date( 'c', $interval_or_timestamp ),
-							'action_id'      => $action_id,
-						)
-					);
-				}
-			} else {
-				// Recurring execution
-				$intervals        = apply_filters( 'datamachine_scheduler_intervals', array() );
-				$interval_seconds = $intervals[ $interval_or_timestamp ]['seconds'] ?? null;
-
-				if ( ! $interval_seconds ) {
-					do_action(
-						'datamachine_log',
-						'error',
-						'Invalid schedule interval',
-						array(
-							'flow_id'             => $flow_id,
-							'interval'            => $interval_or_timestamp,
-							'available_intervals' => array_keys( $intervals ),
-						)
-					);
-					return;
-				}
-
-				if ( function_exists( 'as_schedule_recurring_action' ) ) {
-					$action_id = as_schedule_recurring_action(
-						time() + $interval_seconds,
-						$interval_seconds,
-						'datamachine_run_flow_now',
-						array( $flow_id ),
-						'data-machine'
-					);
-
-					// Update database with scheduling configuration
-					$scheduling_config = array(
-						'interval'         => $interval_or_timestamp,
-						'interval_seconds' => $interval_seconds,
-						'first_run'        => wp_date( 'c', time() + $interval_seconds ),
-					);
-					$db_flows->update_flow_scheduling( $flow_id, $scheduling_config );
-
-					do_action(
-						'datamachine_log',
-						'info',
-						'Flow scheduled for recurring execution',
-						array(
-							'flow_id'          => $flow_id,
-							'interval'         => $interval_or_timestamp,
-							'interval_seconds' => $interval_seconds,
-							'first_run'        => wp_date( 'c', time() + $interval_seconds ),
-							'action_id'        => $action_id,
-						)
-					);
-				}
 			}
 		},
 		10,
 		2
 	);
-} // End datamachine_register_execution_engine()
+}


### PR DESCRIPTION
## Summary

- Moves the four core engine closures from `Engine.php` into proper Ability classes under `Abilities/Engine/`
- `Engine.php` drops from 697 lines to ~130 — retains utility functions and thin action hook bridges that delegate to abilities via `wp_get_ability()->execute()`
- Adds `EngineAbilities` facade and `EngineHelpers` trait following established codebase patterns

## New abilities

| Ability | Backs hook | Purpose |
|---|---|---|
| `datamachine/run-flow` | `datamachine_run_flow_now` | Load configs, create job, schedule first step |
| `datamachine/execute-step` | `datamachine_execute_step` | Resolve step, run it, route to next or complete |
| `datamachine/schedule-next-step` | `datamachine_schedule_next_step` | Store data packets, schedule via Action Scheduler |
| `datamachine/schedule-flow` | `datamachine_run_flow_later` | Manual/one-time/recurring scheduling |

All four are internal (`show_in_rest: false`) with proper `annotations` meta.

## Architecture

Action hooks remain for Action Scheduler compatibility but are now one-liner bridges:

```php
add_action('datamachine_run_flow_now', function($flow_id, $job_id = null) {
    wp_get_ability('datamachine/run-flow')->execute([
        'flow_id' => (int) $flow_id,
        'job_id'  => $job_id ? (int) $job_id : null,
    ]);
}, 10, 2);
```

Abilities are flat primitives — no sub-ability calls. Composition happens through action hooks.

Closes #386