### PR TITLE
fix: Featured image not set after image generation (#385)

### DIFF
--- a/inc/Abilities/Publish/PublishWordPressAbility.php
+++ b/inc/Abilities/Publish/PublishWordPressAbility.php
@@ -307,8 +307,7 @@ class PublishWordPressAbility {
 		}
 
 		if ( $job_id ) {
-			do_action(
-				'datamachine_merge_engine_data',
+			datamachine_merge_engine_data(
 				$job_id,
 				array(
 					'post_id'       => $post_id,


### PR DESCRIPTION
## Summary

- **Fixes #385** — Image generation completes but `_thumbnail_id` never set on post

## Root Cause

`PublishWordPressAbility::execute()` used `do_action('datamachine_merge_engine_data', ...)` to persist `post_id` and `published_url` to engine data after publishing. But `datamachine_merge_engine_data()` is a **plain PHP function** (defined in `inc/Engine/Filters/EngineData.php`), not a WordPress hook callback — no `add_action()` is registered for it anywhere.

Every other caller in the codebase calls it correctly as a direct function. This was the only `do_action()` misuse.

**Result:** `post_id` was never written to engine data. When `ImageGenerationTask::trySetFeaturedImage()` read the pipeline job's engine data looking for `post_id`, it got nothing. The deferred retry mechanism (`handleDeferredFeaturedImage`) exhausted all 12 attempts over 3 minutes without finding a post to attach the image to.

## Fix

One-line change: `do_action(` → `datamachine_merge_engine_data(` — direct function call instead of firing a hook with no listener.

## Impact

This also fixes `published_url` never being available in engine data for downstream steps (Agent Ping, etc.), since it was part of the same dead `do_action()` call.