### PR TITLE
Fix conversation loop multi-handler bug (#328)

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -192,6 +192,21 @@ class AIStep extends Step {
 		$next_flow_step_id = $navigator->get_next_flow_step_id( $this->flow_step_id, $payload );
 		$next_step_config  = $next_flow_step_id ? $this->engine->getFlowStepConfig( $next_flow_step_id ) : null;
 
+		// Collect handler slugs from adjacent steps for multi-handler tracking.
+		$all_handler_slugs = array();
+		foreach ( array( $previous_step_config, $next_step_config ) as $adj_step_config ) {
+			if ( ! $adj_step_config ) {
+				continue;
+			}
+			$handler_slugs     = $adj_step_config['handler_slugs'] ?? array();
+			$all_handler_slugs = array_merge( $all_handler_slugs, $handler_slugs );
+		}
+		if ( ! empty( $all_handler_slugs ) ) {
+			$payload['flow_step_config'] = array(
+				'handler_slugs' => array_unique( $all_handler_slugs ),
+			);
+		}
+
 		$engine_data     = $this->engine->all();
 		$available_tools = ToolExecutor::getAvailableTools( $previous_step_config, $next_step_config, $pipeline_step_id, $engine_data );
 


### PR DESCRIPTION
## Problem

In `AIStep.php`, the payload passed to `AIConversationLoop::execute()` did not include `flow_step_config` with `handler_slugs`. The loop already has multi-handler tracking logic that reads `$payload['flow_step_config']['handler_slugs']`, but since AIStep never provided this, `$configured_handlers` was always empty and the loop fell back to legacy behavior — completing on first handler success.

This meant multi-handler publish steps would exit after the first handler tool succeeded, so handlers like `image_generation` never ran.

## Fix

After loading adjacent step configs (`previous_step_config` and `next_step_config`), collect all `handler_slugs` from them and add to the payload as `flow_step_config.handler_slugs`. This allows the existing multi-handler tracking in `AIConversationLoop` to properly wait for all configured handlers to complete.

**Single file changed:** `inc/Core/Steps/AI/AIStep.php` (+15 lines)