### PR TITLE
docs: Add comprehensive documentation for all analytics tools

### DIFF
--- a/docs/ai-tools/bing-webmaster.md
+++ b/docs/ai-tools/bing-webmaster.md
@@ -1,0 +1,153 @@
+# Bing Webmaster Tools
+
+**Tool ID**: `bing_webmaster`
+
+**Ability**: `datamachine/bing-webmaster`
+
+**File Locations**:
+- Tool: `inc/Engine/AI/Tools/Global/BingWebmaster.php`
+- Ability: `inc/Abilities/Analytics/BingWebmasterAbilities.php`
+
+**Registration**: `datamachine_global_tools` filter (available to all AI agents — pipeline + chat)
+
+**@since**: 0.23.0
+
+Fetches search analytics data from Bing Webmaster Tools API. Provides search query stats, traffic and ranking data, page performance, and crawl statistics.
+
+## Architecture
+
+Two-layer pattern shared by all analytics tools:
+
+1. **Ability** (`BingWebmasterAbilities`) — business logic, API calls, result formatting. Registered as a WordPress ability (`datamachine/bing-webmaster`).
+2. **Tool** (`BingWebmaster`) — AI agent wrapper, settings UI, configuration management. Delegates execution to the ability via `wp_get_ability()`.
+
+All access layers (AI tool, CLI, REST) route through the ability.
+
+## Configuration
+
+### Required Setup
+
+**API Key**
+- Purpose: Authenticates requests to the Bing Webmaster API
+- Source: Bing Webmaster Tools → Settings → API Access → API Key
+- Format: String
+
+**Site URL**
+- Purpose: Identifies the site to query
+- Default: Falls back to `get_site_url()` if not configured
+- Format: Full URL (e.g., `https://chubes.net`)
+
+### Configuration Storage
+
+**Option Key**: `datamachine_bing_webmaster_config`
+
+**Structure**:
+```php
+[
+    'api_key'  => 'your-bing-api-key',
+    'site_url' => 'https://chubes.net',
+]
+```
+
+## Tool Parameters
+
+### Required
+
+**action** (string)
+- `query_stats` — Search query performance (keywords, impressions, clicks)
+- `traffic_stats` — Rank and traffic statistics over time
+- `page_stats` — Per-page performance metrics
+- `crawl_stats` — Bing crawler activity and statistics
+
+### Optional
+
+**site_url** (string)
+- Override the configured site URL
+- Default: Value from config, then `get_site_url()`
+
+**limit** (integer)
+- Default: 20
+- Truncates results beyond this count
+
+## API Integration
+
+### Bing Webmaster API
+
+**Base URL**: `https://ssl.bing.com/webmaster/api.svc/json/`
+
+**Authentication**: API key passed as `apikey` query parameter.
+
+**Action-to-Endpoint Mapping**:
+
+| Action | API Endpoint |
+|--------|-------------|
+| `query_stats` | `GetQueryStats` |
+| `traffic_stats` | `GetRankAndTrafficStats` |
+| `page_stats` | `GetPageStats` |
+| `crawl_stats` | `GetCrawlStats` |
+
+All requests are GET with `apikey` and `siteUrl` query parameters.
+
+### Response Format
+
+```php
+[
+    'success'       => true,
+    'action'        => 'query_stats',
+    'results_count' => 20,
+    'results'       => [
+        // Raw data from Bing's 'd' response key, limited to $limit rows
+    ],
+]
+```
+
+The results array contains the raw response from Bing's API `d` key, truncated to the requested limit.
+
+## CLI Usage
+
+```bash
+# Query performance stats
+wp datamachine analytics bing query_stats --allow-root
+
+# Traffic stats as JSON
+wp datamachine analytics bing traffic_stats --format=json --allow-root
+
+# Crawl stats with limit
+wp datamachine analytics bing crawl_stats --limit=50 --allow-root
+
+# Page stats
+wp datamachine analytics bing page_stats --allow-root
+```
+
+**Flags**: `--limit`, `--format` (table|json|csv)
+
+## REST API
+
+```
+POST /wp-json/datamachine/v1/analytics/bing
+```
+
+**Authentication**: Requires `manage_options` capability.
+
+**Request Body**:
+```json
+{
+    "action": "query_stats",
+    "limit": 50
+}
+```
+
+## Error Handling
+
+**Configuration Errors**:
+- Missing API key → `"Bing Webmaster Tools not configured. Add an API key in Settings."`
+
+**API Errors**:
+- Network failure → `"Failed to connect to Bing Webmaster API: {error}"`
+- Parse failure → `"Failed to parse Bing Webmaster API response."`
+
+## Performance
+
+**Timeout**: 15 seconds per API request
+**No result caching**: Fresh data on each request
+**No token caching**: API key auth has no token exchange step

--- a/docs/ai-tools/google-analytics.md
+++ b/docs/ai-tools/google-analytics.md
@@ -1,0 +1,226 @@
+# Google Analytics (GA4) Tool
+
+**Tool ID**: `google_analytics`
+
+**Ability**: `datamachine/google-analytics`
+
+**File Locations**:
+- Tool: `inc/Engine/AI/Tools/Global/GoogleAnalytics.php`
+- Ability: `inc/Abilities/Analytics/GoogleAnalyticsAbilities.php`
+
+**Registration**: `datamachine_global_tools` filter (available to all AI agents — pipeline + chat)
+
+**@since**: 0.31.0
+
+Fetches visitor analytics from Google Analytics (GA4) Data API. Provides page performance metrics, traffic sources, daily trends, real-time active users, top events, and user demographics.
+
+## Architecture
+
+Two-layer pattern shared by all analytics tools:
+
+1. **Ability** (`GoogleAnalyticsAbilities`) — business logic, API calls, JWT authentication, result formatting. Registered as a WordPress ability (`datamachine/google-analytics`).
+2. **Tool** (`GoogleAnalytics`) — AI agent wrapper, settings UI, configuration management. Delegates execution to the ability via `wp_get_ability()`.
+
+All access layers (AI tool, CLI, REST) route through the ability.
+
+## Configuration
+
+### Required Setup
+
+**Service Account JSON**
+- Purpose: Authenticates via JWT to Google APIs (RS256 signed)
+- Source: Google Cloud Console → IAM & Admin → Service Accounts → Keys
+- Format: Full JSON key file contents
+- Required fields: `client_email`, `private_key`
+- Scope: `https://www.googleapis.com/auth/analytics.readonly`
+
+**GA4 Property ID**
+- Purpose: Identifies the GA4 property to query
+- Source: Google Analytics Admin → Property Settings
+- Format: Numeric string (e.g., `"123456789"`)
+
+The same service account used for Google Search Console can be reused if the Analytics Data API is enabled in the Google Cloud project.
+
+### Configuration Storage
+
+**Option Key**: `datamachine_ga_config`
+
+**Structure**:
+```php
+[
+    'service_account_json' => '{"client_email":"...","private_key":"..."}',
+    'property_id'          => '123456789',
+]
+```
+
+### Authentication Flow
+
+1. Build RS256 JWT with `client_email` as issuer and `analytics.readonly` scope
+2. Exchange JWT for OAuth2 access token at `https://oauth2.googleapis.com/token`
+3. Cache access token in transient (`datamachine_ga_access_token`) for ~58 minutes
+4. Include Bearer token in all API requests
+
+## Tool Parameters
+
+### Required
+
+**action** (string)
+- `page_stats` — Per-page views, sessions, bounce rate, average session duration, active users
+- `traffic_sources` — Where visitors come from (source/medium breakdown)
+- `date_stats` — Daily trends over a date range
+- `realtime` — Active users right now (ignores date parameters)
+- `top_events` — Most triggered GA4 events with per-user counts
+- `user_demographics` — Visitor country and device category breakdown
+
+### Optional
+
+**property_id** (string)
+- Override the configured GA4 property ID
+- Default: Value from `datamachine_ga_config`
+
+**start_date** (string)
+- Format: `YYYY-MM-DD`
+- Default: 28 days ago
+- Not used for `realtime` action
+
+**end_date** (string)
+- Format: `YYYY-MM-DD`
+- Default: Yesterday
+- Not used for `realtime` action
+
+**limit** (integer)
+- Default: 25
+- Maximum: 10,000
+
+**page_filter** (string)
+- Filter results to pages with paths containing this string
+- Only applies to actions that include `pagePath` as a dimension (`page_stats`)
+- Silently ignored on incompatible actions
+
+## API Integration
+
+### GA4 Data API v1beta
+
+**Base URL**: `https://analyticsdata.googleapis.com/v1beta/properties/`
+
+**Standard Reports** (`POST /{property_id}:runReport`):
+- Used by: `page_stats`, `traffic_sources`, `date_stats`, `top_events`, `user_demographics`
+- Request body includes `dateRanges`, `dimensions`, `metrics`, `limit`, and optional `dimensionFilter`
+
+**Realtime Reports** (`POST /{property_id}:runRealtimeReport`):
+- Used by: `realtime`
+- Dimensions: `unifiedScreenName`
+- Metrics: `activeUsers`, `screenPageViews`
+- Fixed limit of 25 rows
+
+### Action-to-Report Mapping
+
+| Action | Dimensions | Metrics |
+|--------|-----------|---------|
+| `page_stats` | `pagePath`, `pageTitle` | `screenPageViews`, `sessions`, `bounceRate`, `averageSessionDuration`, `activeUsers` |
+| `traffic_sources` | `sessionSource`, `sessionMedium` | `sessions`, `activeUsers`, `screenPageViews`, `bounceRate` |
+| `date_stats` | `date` | `sessions`, `screenPageViews`, `activeUsers`, `bounceRate`, `averageSessionDuration` |
+| `top_events` | `eventName` | `eventCount`, `eventCountPerUser` |
+| `user_demographics` | `country`, `deviceCategory` | `sessions`, `activeUsers`, `screenPageViews` |
+
+### Response Format
+
+**Standard report**:
+```php
+[
+    'success'       => true,
+    'action'        => 'page_stats',
+    'date_range'    => ['start_date' => '2026-01-28', 'end_date' => '2026-02-24'],
+    'results_count' => 25,
+    'results'       => [
+        [
+            'pagePath'                => '/about/',
+            'pageTitle'               => 'About',
+            'screenPageViews'         => 1234,
+            'sessions'                => 890,
+            'bounceRate'              => 0.45,
+            'averageSessionDuration'  => 120.5,
+            'activeUsers'             => 780,
+        ],
+    ],
+]
+```
+
+**Realtime report**:
+```php
+[
+    'success'            => true,
+    'action'             => 'realtime',
+    'total_active_users' => 12,
+    'total_page_views'   => 18,
+    'results_count'      => 5,
+    'results'            => [
+        ['unifiedScreenName' => 'Home', 'activeUsers' => 5, 'screenPageViews' => 8],
+    ],
+]
+```
+
+## CLI Usage
+
+```bash
+# Page performance stats
+wp datamachine analytics ga page_stats --allow-root
+
+# Traffic sources with limit
+wp datamachine analytics ga traffic_sources --limit=50 --allow-root
+
+# Real-time active users
+wp datamachine analytics ga realtime --allow-root
+
+# Daily trends for blog pages as JSON
+wp datamachine analytics ga date_stats --page-filter=/blog/ --format=json --allow-root
+
+# Top events
+wp datamachine analytics ga top_events --allow-root
+
+# User demographics
+wp datamachine analytics ga user_demographics --allow-root
+```
+
+**Flags**: `--start-date`, `--end-date`, `--limit`, `--page-filter`, `--format` (table|json|csv)
+
+## REST API
+
+```
+POST /wp-json/datamachine/v1/analytics/ga
+```
+
+**Authentication**: Requires `manage_options` capability.
+
+**Request Body**:
+```json
+{
+    "action": "page_stats",
+    "start_date": "2026-01-01",
+    "end_date": "2026-02-24",
+    "limit": 50,
+    "page_filter": "/blog/"
+}
+```
+
+## Error Handling
+
+**Configuration Errors**:
+- Missing service account JSON → `"Google Analytics not configured. Add service account JSON in Settings."`
+- Invalid JSON (missing `client_email`/`private_key`) → `"Invalid service account JSON."`
+- Missing property ID → `"No GA4 property ID configured or provided."`
+
+**Authentication Errors**:
+- JWT signing failure → `"Failed to sign JWT. Check private key."`
+- Token exchange failure → `"Failed to get access token: {reason}"`
+
+**API Errors**:
+- Network failure → `"Failed to connect to Google Analytics API: {error}"`
+- GA4 API error → `"GA4 API error: {message}"`
+- Parse failure → `"Failed to parse Google Analytics API response."`
+
+## Performance
+
+**Token Caching**: Access tokens cached for ~58 minutes (3500s transient)
+**Timeout**: 30 seconds per API request
+**No result caching**: Real-time data priority

--- a/docs/ai-tools/google-search-console.md
+++ b/docs/ai-tools/google-search-console.md
@@ -1,0 +1,244 @@
+# Google Search Console Tool
+
+**Tool ID**: `google_search_console`
+
+**Ability**: `datamachine/google-search-console`
+
+**File Locations**:
+- Tool: `inc/Engine/AI/Tools/Global/GoogleSearchConsole.php`
+- Ability: `inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php`
+
+**Registration**: `datamachine_global_tools` filter (available to all AI agents — pipeline + chat)
+
+**@since**: 0.25.0
+
+Fetches search analytics data from Google Search Console. Provides search query performance, page-level stats, URL inspection, and sitemap management.
+
+## Architecture
+
+Two-layer pattern shared by all analytics tools:
+
+1. **Ability** (`GoogleSearchConsoleAbilities`) — business logic, API calls, JWT authentication. Registered as a WordPress ability (`datamachine/google-search-console`).
+2. **Tool** (`GoogleSearchConsole`) — AI agent wrapper, settings UI, configuration management. Delegates execution to the ability via `wp_get_ability()`.
+
+All access layers (AI tool, CLI, REST) route through the ability.
+
+## Configuration
+
+### Required Setup
+
+**Service Account JSON**
+- Purpose: Authenticates via JWT to Google APIs (RS256 signed)
+- Source: Google Cloud Console → IAM & Admin → Service Accounts → Keys
+- Format: Full JSON key file contents
+- Required fields: `client_email`, `private_key`
+- Scope: `https://www.googleapis.com/auth/webmasters.readonly`
+- The service account email must be added as a user in GSC property settings
+
+**Site URL**
+- Purpose: Identifies the Search Console property to query
+- Format: `sc-domain:example.com` (domain property) or `https://example.com/` (URL prefix)
+
+### Configuration Storage
+
+**Option Key**: `datamachine_gsc_config`
+
+**Structure**:
+```php
+[
+    'service_account_json' => '{"client_email":"...","private_key":"..."}',
+    'site_url'             => 'sc-domain:chubes.net',
+]
+```
+
+### Authentication Flow
+
+1. Build RS256 JWT with `client_email` as issuer and `webmasters.readonly` scope
+2. Exchange JWT for OAuth2 access token at `https://oauth2.googleapis.com/token`
+3. Cache access token in transient (`datamachine_gsc_access_token`) for ~58 minutes
+4. Include Bearer token in all API requests
+
+## Tool Parameters
+
+### Required
+
+**action** (string)
+
+Search Analytics actions:
+- `query_stats` — Top search queries with clicks, impressions, CTR, position
+- `page_stats` — Per-page search performance
+- `query_page_stats` — Combined query + page breakdown
+- `date_stats` — Daily search performance trends
+
+URL & Sitemap actions:
+- `inspect_url` — Check indexing status of a specific URL (requires `url` parameter)
+- `list_sitemaps` — List all submitted sitemaps
+- `get_sitemap` — Get details for a specific sitemap (requires `sitemap_url` parameter)
+- `submit_sitemap` — Submit a sitemap to Google (requires `sitemap_url` parameter)
+
+### Optional
+
+**site_url** (string)
+- Override the configured site URL
+- Default: Value from `datamachine_gsc_config`
+
+**start_date** (string)
+- Format: `YYYY-MM-DD`
+- Default: 28 days ago
+
+**end_date** (string)
+- Format: `YYYY-MM-DD`
+- Default: 3 days ago (for finalized data)
+
+**limit** (integer)
+- Default: 25
+- Maximum: 25,000
+
+**url_filter** (string)
+- Filter results to URLs containing this string
+
+**query_filter** (string)
+- Filter results to queries containing this string
+
+**url** (string)
+- Required for `inspect_url` action — the full URL to inspect
+
+**sitemap_url** (string)
+- Required for `get_sitemap` and `submit_sitemap` actions
+
+## API Integration
+
+### Search Analytics API
+
+**Endpoint**: `POST https://www.googleapis.com/webmasters/v3/sites/{site_url}/searchAnalytics/query`
+
+**Action-to-Dimensions Mapping**:
+
+| Action | Dimensions |
+|--------|-----------|
+| `query_stats` | `query` |
+| `page_stats` | `page` |
+| `query_page_stats` | `query`, `page` |
+| `date_stats` | `date` |
+
+All search analytics responses include: `clicks`, `impressions`, `ctr`, `position` per row, plus dimension keys.
+
+### URL Inspection API
+
+**Endpoint**: `POST https://searchconsole.googleapis.com/v1/urlInspection/index:inspect`
+
+Returns indexing status, mobile usability, and rich results information for a specific URL.
+
+### Sitemaps API
+
+**List**: `GET https://www.googleapis.com/webmasters/v3/sites/{site_url}/sitemaps`
+**Get**: `GET https://www.googleapis.com/webmasters/v3/sites/{site_url}/sitemaps/{sitemap_url}`
+**Submit**: `PUT https://www.googleapis.com/webmasters/v3/sites/{site_url}/sitemaps/{sitemap_url}`
+
+### Response Format
+
+**Search analytics**:
+```php
+[
+    'success'       => true,
+    'action'        => 'query_stats',
+    'results_count' => 25,
+    'results'       => [
+        [
+            'keys'        => ['wordpress analytics'],
+            'clicks'      => 45,
+            'impressions' => 1200,
+            'ctr'         => 0.0375,
+            'position'    => 8.2,
+        ],
+    ],
+]
+```
+
+**URL inspection**:
+```php
+[
+    'success'          => true,
+    'action'           => 'inspect_url',
+    'url'              => 'https://chubes.net/about/',
+    'index_status'     => [
+        'verdict'          => 'PASS',
+        'coverage_state'   => 'Submitted and indexed',
+        'indexing_state'   => 'INDEXING_ALLOWED',
+        'last_crawl_time'  => '2026-02-20T10:30:00Z',
+        'page_fetch_state' => 'SUCCESSFUL',
+        'google_canonical' => 'https://chubes.net/about/',
+        'user_canonical'   => 'https://chubes.net/about/',
+        'crawled_as'       => 'DESKTOP',
+        'robots_txt_state' => 'ALLOWED',
+        'referring_urls'   => [],
+        'sitemap'          => [],
+    ],
+    'mobile_usability' => ['verdict' => 'PASS', 'issues' => []],
+    'rich_results'     => ['verdict' => 'PASS', 'detected_items' => []],
+]
+```
+
+## CLI Usage
+
+```bash
+# Top search queries
+wp datamachine analytics gsc query_stats --allow-root
+
+# Page stats with URL filter
+wp datamachine analytics gsc page_stats --url-filter=/blog/ --limit=50 --allow-root
+
+# Daily trends as JSON
+wp datamachine analytics gsc date_stats --format=json --allow-root
+
+# Inspect a URL
+wp datamachine analytics gsc inspect_url --url=https://chubes.net/about/ --allow-root
+
+# List sitemaps
+wp datamachine analytics gsc list_sitemaps --allow-root
+
+# Submit a sitemap
+wp datamachine analytics gsc submit_sitemap --sitemap-url=https://chubes.net/sitemap.xml --allow-root
+```
+
+**Flags**: `--start-date`, `--end-date`, `--limit`, `--url-filter`, `--query-filter`, `--url`, `--sitemap-url`, `--format` (table|json|csv)
+
+## REST API
+
+```
+POST /wp-json/datamachine/v1/analytics/gsc
+```
+
+**Authentication**: Requires `manage_options` capability.
+
+**Request Body**:
+```json
+{
+    "action": "query_stats",
+    "start_date": "2026-01-01",
+    "end_date": "2026-02-24",
+    "limit": 50,
+    "query_filter": "wordpress"
+}
+```
+
+## Error Handling
+
+**Configuration Errors**:
+- Missing service account JSON → `"Google Search Console not configured. Add service account JSON in Settings."`
+- Invalid JSON → `"Invalid service account JSON. Ensure it contains client_email and private_key."`
+- Missing site URL → `"No site URL configured or provided."`
+
+**Authentication Errors**:
+- JWT signing failure → `"Failed to sign JWT. Check private key."`
+- Token exchange failure → `"Failed to get access token: {reason}"`
+
+**API Errors**:
+- Network failure → `"Failed to connect to Google Search Console API: {error}"`
+- GSC API error → `"GSC API error: {message}"`
+
+## Performance
+
+**Token Caching**: Access tokens cached for ~58 minutes (3500s transient)
+**Timeout**: 30 seconds per API request
+**Data Freshness**: GSC data is finalized ~3 days after collection (default end_date is 3 days ago)

--- a/docs/ai-tools/pagespeed-insights.md
+++ b/docs/ai-tools/pagespeed-insights.md
@@ -1,0 +1,219 @@
+# PageSpeed Insights Tool
+
+**Tool ID**: `pagespeed`
+
+**Ability**: `datamachine/pagespeed`
+
+**File Locations**:
+- Tool: `inc/Engine/AI/Tools/Global/PageSpeed.php`
+- Ability: `inc/Abilities/Analytics/PageSpeedAbilities.php`
+
+**Registration**: `datamachine_global_tools` filter (available to all AI agents — pipeline + chat)
+
+**@since**: 0.31.0
+
+Runs Google PageSpeed Insights (Lighthouse) audits on any URL. Returns performance scores, Core Web Vitals, accessibility and SEO scores, and actionable optimization opportunities with estimated savings.
+
+## Architecture
+
+Two-layer pattern shared by all analytics tools:
+
+1. **Ability** (`PageSpeedAbilities`) — API calls, Lighthouse result parsing, action-specific formatting. Registered as a WordPress ability (`datamachine/pagespeed`).
+2. **Tool** (`PageSpeed`) — AI agent wrapper, settings UI, configuration management. Delegates execution to the ability via `wp_get_ability()`.
+
+All access layers (AI tool, CLI, REST) route through the ability.
+
+## Configuration
+
+### Optional Setup
+
+PageSpeed Insights works **without any API key** but gets rate-limited (HTTP 429). An optional API key removes rate limits.
+
+**Google API Key**
+- Purpose: Increases rate limits for PageSpeed API
+- Source: Google Cloud Console → APIs & Services → Credentials
+- Format: String (e.g., `AIzaSyD...`)
+- Required: No — tool is always considered "configured"
+
+### Configuration Storage
+
+**Option Key**: `datamachine_pagespeed_config`
+
+**Structure**:
+```php
+[
+    'api_key' => 'AIzaSyD...',  // Optional
+]
+```
+
+### Tool Configuration Flag
+
+`requires_config` is set to `false` — this tool appears as available even without an API key.
+
+## Tool Parameters
+
+### Required
+
+**action** (string)
+- `analyze` — Full Lighthouse audit with all category scores (performance, accessibility, best-practices, SEO) and key performance metrics
+- `performance` — Focused Core Web Vitals and performance metrics only
+- `opportunities` — Optimization suggestions sorted by estimated savings (ms and bytes)
+
+### Optional
+
+**url** (string)
+- URL to analyze
+- Default: WordPress site home URL (`home_url('/')`)
+- Can target any publicly accessible URL
+
+**strategy** (string)
+- `mobile` (default) — Simulates mobile device
+- `desktop` — Simulates desktop device
+
+## API Integration
+
+### PageSpeed Insights API v5
+
+**Endpoint**: `https://www.googleapis.com/pagespeedonline/v5/runPagespeed`
+**Method**: GET
+**Authentication**: Optional API key parameter
+
+**Category values**: lowercase (`performance`, `accessibility`, `best-practices`, `seo`)
+
+**Request behavior by action**:
+- `analyze` and `opportunities`: Request all four categories
+- `performance`: Request only the `performance` category
+
+### Core Web Vitals Metrics
+
+The following metrics are extracted from Lighthouse audits:
+
+| Metric Key | Audit ID | Description |
+|-----------|----------|-------------|
+| `first_contentful_paint` | `first-contentful-paint` | Time to first visual content |
+| `largest_contentful_paint` | `largest-contentful-paint` | Time to largest content element |
+| `total_blocking_time` | `total-blocking-time` | Sum of blocking time from long tasks |
+| `cumulative_layout_shift` | `cumulative-layout-shift` | Visual stability score |
+| `speed_index` | `speed-index` | How quickly content is visually populated |
+| `interaction_to_next_paint` | `interaction-to-next-paint` | Responsiveness to user input |
+
+Each metric includes:
+- `value` — Human-readable display value (e.g., `"2.1 s"`)
+- `numeric` — Raw numeric value in milliseconds (or unitless for CLS)
+- `score` — 0-100 integer score
+
+### Response Format
+
+**analyze**:
+```php
+[
+    'success'  => true,
+    'action'   => 'analyze',
+    'url'      => 'https://chubes.net/',
+    'strategy' => 'mobile',
+    'scores'   => [
+        'performance'    => 85,
+        'accessibility'  => 92,
+        'best-practices' => 100,
+        'seo'            => 91,
+    ],
+    'metrics'  => [
+        'first_contentful_paint'    => ['value' => '1.2 s', 'numeric' => 1234.5, 'score' => 90],
+        'largest_contentful_paint'  => ['value' => '2.1 s', 'numeric' => 2100.0, 'score' => 75],
+        'total_blocking_time'       => ['value' => '120 ms', 'numeric' => 120.0, 'score' => 85],
+        'cumulative_layout_shift'   => ['value' => '0.05', 'numeric' => 0.05, 'score' => 95],
+        'speed_index'               => ['value' => '2.5 s', 'numeric' => 2500.0, 'score' => 80],
+        'interaction_to_next_paint' => ['value' => '200 ms', 'numeric' => 200.0, 'score' => 70],
+    ],
+]
+```
+
+**performance**:
+```php
+[
+    'success'           => true,
+    'action'            => 'performance',
+    'url'               => 'https://chubes.net/',
+    'strategy'          => 'mobile',
+    'performance_score' => 85,
+    'metrics'           => [ /* same as analyze */ ],
+]
+```
+
+**opportunities**:
+```php
+[
+    'success'       => true,
+    'action'        => 'opportunities',
+    'url'           => 'https://chubes.net/',
+    'strategy'      => 'mobile',
+    'scores'        => [ /* all category scores */ ],
+    'results_count' => 3,
+    'results'       => [
+        [
+            'id'            => 'render-blocking-resources',
+            'title'         => 'Eliminate render-blocking resources',
+            'description'   => 'Resources are blocking the first paint...',
+            'score'         => 20,
+            'savings_ms'    => 1200,
+            'savings_bytes' => 45000,
+        ],
+    ],
+]
+```
+
+Opportunities are sorted by `savings_ms` descending (highest savings first).
+
+## CLI Usage
+
+```bash
+# Full Lighthouse audit (mobile)
+wp datamachine analytics pagespeed analyze --allow-root
+
+# Desktop performance check
+wp datamachine analytics pagespeed performance --strategy=desktop --allow-root
+
+# Optimization opportunities for a specific page
+wp datamachine analytics pagespeed opportunities --url=https://chubes.net/blog/ --allow-root
+
+# Full audit as JSON
+wp datamachine analytics pagespeed analyze --format=json --allow-root
+```
+
+**Flags**: `--url`, `--strategy`, `--format` (table|json|csv)
+
+## REST API
+
+```
+POST /wp-json/datamachine/v1/analytics/pagespeed
+```
+
+**Authentication**: Requires `manage_options` capability.
+
+**Request Body**:
+```json
+{
+    "action": "analyze",
+    "url": "https://chubes.net/",
+    "strategy": "desktop"
+}
+```
+
+## Error Handling
+
+**Input Validation**:
+- Invalid action → `"Invalid action. Must be one of: analyze, performance, opportunities"`
+- Invalid strategy → `"Invalid strategy. Must be mobile or desktop."`
+
+**API Errors**:
+- Network failure → `"Failed to connect to PageSpeed Insights API: {error}"`
+- Rate limiting (no API key) → HTTP 429 from Google API
+- Parse failure → `"Failed to parse PageSpeed Insights API response."`
+- No Lighthouse results → `"No Lighthouse results returned."`
+- API error → `"PageSpeed API error: {message}"`
+
+## Performance
+
+**Timeout**: 60 seconds (Lighthouse audits can be slow)
+**No result caching**: Each request runs a fresh Lighthouse audit
+**Rate limits**: Without API key, Google enforces rate limiting. With API key, standard Google API quotas apply.

--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -37,6 +37,33 @@ Available to all AI agents (pipeline + chat) via `datamachine_global_tools` filt
 - **Use Cases**: Correcting venue details, updating artist bios, managing taxonomy hierarchies.
 - **Documentation**: [Update Taxonomy Term](update-taxonomy-term.md)
 
+**Google Search Console** (`google_search_console`) (@since v0.25.0)
+- **Purpose**: Fetch search analytics from Google Search Console — query performance, page stats, URL inspection, and sitemap management.
+- **Configuration**: Service account JSON + site URL required
+- **Features**: 8 actions (query_stats, page_stats, query_page_stats, date_stats, inspect_url, list_sitemaps, get_sitemap, submit_sitemap), URL and query filters, date range control
+- **Use Cases**: SEO monitoring, indexing verification, search performance analysis
+- **Documentation**: [Google Search Console](google-search-console.md)
+
+**Bing Webmaster Tools** (`bing_webmaster`) (@since v0.23.0)
+- **Purpose**: Fetch search analytics from Bing Webmaster Tools — query stats, traffic stats, page stats, and crawl stats.
+- **Configuration**: API key required
+- **Features**: 4 actions (query_stats, traffic_stats, page_stats, crawl_stats), configurable result limits
+- **Use Cases**: Bing search performance, crawl monitoring, multi-engine SEO
+- **Documentation**: [Bing Webmaster Tools](bing-webmaster.md)
+
+**Google Analytics** (`google_analytics`) (@since v0.31.0)
+- **Purpose**: Fetch visitor analytics from Google Analytics (GA4) — page performance, traffic sources, daily trends, real-time users, top events, demographics.
+- **Configuration**: Service account JSON + GA4 property ID required (can reuse GSC service account)
+- **Features**: 6 actions (page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics), date range control, page path filtering
+- **Use Cases**: Traffic analysis, content performance, visitor behavior, real-time monitoring
+- **Documentation**: [Google Analytics (GA4)](google-analytics.md)
+
+**PageSpeed Insights** (`pagespeed`) (@since v0.31.0)
+- **Purpose**: Run Lighthouse audits via PageSpeed Insights API — performance scores, Core Web Vitals, accessibility, SEO, and optimization opportunities.
+- **Configuration**: None required (optional API key for higher rate limits)
+- **Features**: 3 actions (analyze, performance, opportunities), mobile/desktop strategies, any public URL
+- **Use Cases**: Performance auditing, Core Web Vitals monitoring, optimization planning
+- **Documentation**: [PageSpeed Insights](pagespeed-insights.md)
 
 ### Chat-Specific Tools
 
@@ -147,6 +174,16 @@ Global tools are located in `/inc/Engine/AI/Tools/Global/`:
 - `LocalSearch.php` - WordPress internal search
 - `WebFetch.php` - Web page content retrieval
 - `WordPressPostReader.php` - Single post analysis
+- `GoogleSearchConsole.php` - Google Search Console analytics (delegates to `GoogleSearchConsoleAbilities`)
+- `BingWebmaster.php` - Bing Webmaster Tools analytics (delegates to `BingWebmasterAbilities`)
+- `GoogleAnalytics.php` - Google Analytics GA4 data (delegates to `GoogleAnalyticsAbilities`)
+- `PageSpeed.php` - PageSpeed Insights Lighthouse audits (delegates to `PageSpeedAbilities`)
+
+Analytics abilities are located in `/inc/Abilities/Analytics/`:
+- `GoogleSearchConsoleAbilities.php` - GSC API integration and JWT auth
+- `BingWebmasterAbilities.php` - Bing Webmaster API integration
+- `GoogleAnalyticsAbilities.php` - GA4 Data API integration and JWT auth
+- `PageSpeedAbilities.php` - PageSpeed Insights API integration
 
 Chat-specific tools at `/inc/Api/Chat/Tools/`:
 - `ExecuteWorkflowTool.php` - Direct workflow execution with Execute API delegation

--- a/docs/api/endpoints/analytics.md
+++ b/docs/api/endpoints/analytics.md
@@ -1,0 +1,192 @@
+# Analytics Endpoints
+
+**File Location**: `inc/Api/Analytics.php`
+
+**@since**: 0.31.0
+
+Unified REST API for all analytics integrations. Each endpoint delegates to its respective WordPress ability via `wp_get_ability()`.
+
+## Endpoints
+
+| Method | Route | Tool |
+|--------|-------|------|
+| `POST` | `/datamachine/v1/analytics/gsc` | Google Search Console |
+| `POST` | `/datamachine/v1/analytics/bing` | Bing Webmaster Tools |
+| `POST` | `/datamachine/v1/analytics/ga` | Google Analytics (GA4) |
+| `POST` | `/datamachine/v1/analytics/pagespeed` | PageSpeed Insights |
+
+## Authentication
+
+All endpoints require `manage_options` capability. Returns HTTP 403 if the current user lacks permission.
+
+## Request Format
+
+All endpoints accept JSON POST body with `action` as the only required field. Additional parameters vary by tool.
+
+### Common Parameters
+
+**action** (string, required)
+- The analytics action to perform
+- Valid values depend on the tool (see individual tool documentation)
+
+### Google Search Console Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | Yes | `query_stats`, `page_stats`, `query_page_stats`, `date_stats`, `inspect_url`, `list_sitemaps`, `get_sitemap`, `submit_sitemap` |
+| `start_date` | string | No | `YYYY-MM-DD` (default: 28 days ago) |
+| `end_date` | string | No | `YYYY-MM-DD` (default: 3 days ago) |
+| `limit` | integer | No | Row limit (default: 25, max: 25000) |
+| `url_filter` | string | No | Filter to URLs containing this string |
+| `query_filter` | string | No | Filter to queries containing this string |
+| `url` | string | No | URL for `inspect_url` action |
+| `sitemap_url` | string | No | URL for `get_sitemap`/`submit_sitemap` |
+
+### Bing Webmaster Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | Yes | `query_stats`, `traffic_stats`, `page_stats`, `crawl_stats` |
+| `limit` | integer | No | Row limit (default: 20) |
+
+### Google Analytics (GA4) Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | Yes | `page_stats`, `traffic_sources`, `date_stats`, `realtime`, `top_events`, `user_demographics` |
+| `property_id` | string | No | GA4 property ID (overrides config) |
+| `start_date` | string | No | `YYYY-MM-DD` (default: 28 days ago) |
+| `end_date` | string | No | `YYYY-MM-DD` (default: yesterday) |
+| `limit` | integer | No | Row limit (default: 25, max: 10000) |
+| `page_filter` | string | No | Filter to pages containing this path string |
+
+### PageSpeed Insights Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | Yes | `analyze`, `performance`, `opportunities` |
+| `url` | string | No | URL to analyze (default: site home URL) |
+| `strategy` | string | No | `mobile` (default) or `desktop` |
+
+## Response Format
+
+### Success Response
+
+HTTP 200 with the ability result:
+
+```json
+{
+    "success": true,
+    "action": "page_stats",
+    "results_count": 25,
+    "results": [...]
+}
+```
+
+Response structure varies by tool and action. See individual tool documentation for details.
+
+### Error Responses
+
+**Permission Denied** (HTTP 403):
+```json
+{
+    "code": "rest_forbidden",
+    "message": "You do not have permission to access analytics data.",
+    "data": { "status": 403 }
+}
+```
+
+**Invalid Tool** (HTTP 400):
+```json
+{
+    "code": "invalid_tool",
+    "message": "Invalid analytics tool.",
+    "data": { "status": 400 }
+}
+```
+
+**Ability Not Found** (HTTP 500):
+```json
+{
+    "code": "ability_not_found",
+    "message": "Analytics ability \"datamachine/google-analytics\" not registered. Ensure WordPress 6.9+ and the ability class is loaded.",
+    "data": { "status": 500 }
+}
+```
+
+**Not Configured** (HTTP 422):
+```json
+{
+    "code": "analytics_error",
+    "message": "Google Analytics not configured. Add service account JSON in Settings.",
+    "data": { "status": 422 }
+}
+```
+
+**Action/Parameter Error** (HTTP 400):
+```json
+{
+    "code": "analytics_error",
+    "message": "Invalid action. Must be one of: page_stats, traffic_sources, ...",
+    "data": { "status": 400 }
+}
+```
+
+## Architecture
+
+### Routing
+
+The `Analytics` class registers a single route pattern for each tool. The handler extracts the tool name from the request route path and maps it to an ability slug via `ABILITY_MAP`:
+
+```php
+const ABILITY_MAP = [
+    'gsc'       => 'datamachine/google-search-console',
+    'bing'      => 'datamachine/bing-webmaster',
+    'ga'        => 'datamachine/google-analytics',
+    'pagespeed' => 'datamachine/pagespeed',
+];
+```
+
+### Execution Flow
+
+1. `register_routes()` registers all four POST routes
+2. `check_permission()` validates `manage_options` capability
+3. `handle_request()` extracts tool name from route, looks up ability slug
+4. Ability is retrieved via `wp_get_ability()` and executed with the JSON body
+5. Error responses use HTTP 422 for configuration errors, 400 for input errors
+
+### Ability Delegation
+
+The REST layer is intentionally thin — it performs no data transformation. All business logic (authentication, API calls, result formatting) lives in the ability layer.
+
+## Examples
+
+### cURL — Google Analytics Page Stats
+
+```bash
+curl -X POST https://chubes.net/wp-json/datamachine/v1/analytics/ga \
+  -H "Content-Type: application/json" \
+  -H "X-WP-Nonce: {nonce}" \
+  --cookie "{auth_cookie}" \
+  -d '{"action": "page_stats", "limit": 10}'
+```
+
+### cURL — PageSpeed Audit
+
+```bash
+curl -X POST https://chubes.net/wp-json/datamachine/v1/analytics/pagespeed \
+  -H "Content-Type: application/json" \
+  -H "X-WP-Nonce: {nonce}" \
+  --cookie "{auth_cookie}" \
+  -d '{"action": "analyze", "url": "https://chubes.net/", "strategy": "desktop"}'
+```
+
+### cURL — GSC Query Stats
+
+```bash
+curl -X POST https://chubes.net/wp-json/datamachine/v1/analytics/gsc \
+  -H "Content-Type: application/json" \
+  -H "X-WP-Nonce: {nonce}" \
+  --cookie "{auth_cookie}" \
+  -d '{"action": "query_stats", "limit": 50, "query_filter": "wordpress"}'
+```


### PR DESCRIPTION
## Summary

- Add full reference documentation for all 4 analytics tool integrations
- Add REST API endpoint reference for the unified analytics API
- Update tools overview with analytics tools in the global tools section

## New Files

| File | Description |
|------|-------------|
| `docs/ai-tools/google-analytics.md` | GA4 tool — 6 actions, JWT auth, report mapping, Core Web Vitals |
| `docs/ai-tools/pagespeed-insights.md` | PageSpeed tool — 3 actions, Lighthouse metrics, opportunities |
| `docs/ai-tools/google-search-console.md` | GSC tool — 8 actions (analytics + URL inspection + sitemaps) |
| `docs/ai-tools/bing-webmaster.md` | Bing tool — 4 actions, API key auth |
| `docs/api/endpoints/analytics.md` | Unified REST API — all 4 tools, request/response formats, error codes |

## Modified Files

- `docs/ai-tools/tools-overview.md` — Added all 4 analytics tools to Global Tools section and Tool Directory Structure

## Context

Completes the documentation work for the analytics feature set added in PR #400.
Follows homeboy docs conventions — technical reference only, no setup tutorials.

Closes #397, closes #398, closes #401.