### PR TITLE
fix: memory system improvements

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -431,6 +431,9 @@ Write in a clear, helpful tone.
 
 ## Context
 <!-- Add background about your site, audience, brand, or domain expertise here -->
+
+## Continuity
+SOUL.md (this file) defines who you are. USER.md profiles your human. MEMORY.md tracks persistent knowledge. Daily memory files (daily/YYYY/MM/DD.md) capture session activity — the system generates daily summaries automatically. Keep MEMORY.md lean: persistent facts only, not session logs.
 MD,
 		'USER.md'   => <<<'MD'
 # User Profile

--- a/inc/Abilities/FileAbilities.php
+++ b/inc/Abilities/FileAbilities.php
@@ -931,7 +931,7 @@ class FileAbilities {
 					$files[] = array(
 						'filename' => $entry,
 						'size'     => filesize( $filepath ),
-						'modified' => filemtime( $filepath ),
+						'modified' => gmdate( 'c', filemtime( $filepath ) ),
 						'type'     => 'core',
 					);
 				}
@@ -989,7 +989,7 @@ class FileAbilities {
 				array(
 					'filename' => $filename,
 					'size'     => filesize( $filepath ),
-					'modified' => filemtime( $filepath ),
+					'modified' => gmdate( 'c', filemtime( $filepath ) ),
 					'content'  => file_get_contents( $filepath ),
 				)
 			),

--- a/inc/Core/FilesRepository/FileStorage.php
+++ b/inc/Core/FilesRepository/FileStorage.php
@@ -114,7 +114,7 @@ class FileStorage {
 					'filename' => $filename,
 					'path'     => $file_path,
 					'size'     => filesize( $file_path ),
-					'modified' => filemtime( $file_path ),
+					'modified' => gmdate( 'c', filemtime( $file_path ) ),
 				);
 			}
 		}

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -85,6 +85,11 @@ class DailyMemoryTask extends SystemTask {
 			return;
 		}
 
+		// Normalize literal \n sequences to actual newlines. LLMs sometimes output
+		// the two-character string \n instead of a real newline when generating
+		// structured text — this is model behavior, not a serialization bug.
+		$content = str_replace( '\n', "\n", $content );
+
 		// Write to the target date's daily memory file.
 		$date  = $params['date'] ?? gmdate( 'Y-m-d' );
 		$daily = new DailyMemory();

--- a/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
@@ -1,0 +1,299 @@
+<?php
+/**
+ * Agent Daily Memory AI Tool - Session-specific daily journal entries
+ *
+ * Delegates to DailyMemoryAbilities for read/write/search operations
+ * on daily memory files (YYYY/MM/DD.md). Gives agents the ability to
+ * record session activity, search past daily entries, and manage the
+ * boundary between persistent memory (MEMORY.md) and temporal daily logs.
+ *
+ * @package DataMachine\Engine\AI\Tools\Global
+ * @since   0.33.0
+ */
+
+namespace DataMachine\Engine\AI\Tools\Global;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+class AgentDailyMemory extends BaseTool {
+
+	public function __construct() {
+		$this->registerGlobalTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ) );
+	}
+
+	/**
+	 * Handle tool call by routing to the appropriate ability.
+	 *
+	 * @param array $parameters Tool parameters from AI.
+	 * @param array $tool_def   Tool definition context.
+	 * @return array Response array.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$action = $parameters['action'] ?? '';
+
+		return match ( $action ) {
+			'read'   => $this->handleRead( $parameters ),
+			'write'  => $this->handleWrite( $parameters ),
+			'list'   => $this->handleList(),
+			'search' => $this->handleSearch( $parameters ),
+			default  => $this->buildErrorResponse(
+				'Invalid action "' . $action . '". Use "read", "write", "list", or "search".',
+				'agent_daily_memory'
+			),
+		};
+	}
+
+	/**
+	 * Read a daily memory file.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array Response.
+	 */
+	private function handleRead( array $parameters ): array {
+		$ability = wp_get_ability( 'datamachine/daily-memory-read' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'Daily Memory ability not registered. Ensure WordPress 6.9+ and DailyMemoryAbilities is loaded.',
+				'agent_daily_memory'
+			);
+		}
+
+		$result = $ability->execute(
+			array(
+				'date' => $parameters['date'] ?? gmdate( 'Y-m-d' ),
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'agent_daily_memory' );
+		}
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return $this->buildErrorResponse(
+				$this->getAbilityError( $result, 'Failed to read daily memory.' ),
+				'agent_daily_memory'
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'agent_daily_memory',
+		);
+	}
+
+	/**
+	 * Write or append to a daily memory file.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array Response.
+	 */
+	private function handleWrite( array $parameters ): array {
+		$content = $parameters['content'] ?? '';
+
+		if ( '' === $content ) {
+			return $this->buildErrorResponse(
+				'Parameter "content" is required for write action.',
+				'agent_daily_memory'
+			);
+		}
+
+		$ability = wp_get_ability( 'datamachine/daily-memory-write' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'Daily Memory ability not registered. Ensure WordPress 6.9+ and DailyMemoryAbilities is loaded.',
+				'agent_daily_memory'
+			);
+		}
+
+		$result = $ability->execute(
+			array(
+				'content' => $content,
+				'date'    => $parameters['date'] ?? gmdate( 'Y-m-d' ),
+				'mode'    => $parameters['mode'] ?? 'append',
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'agent_daily_memory' );
+		}
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return $this->buildErrorResponse(
+				$this->getAbilityError( $result, 'Failed to write daily memory.' ),
+				'agent_daily_memory'
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'agent_daily_memory',
+		);
+	}
+
+	/**
+	 * List all daily memory files grouped by month.
+	 *
+	 * @return array Response.
+	 */
+	private function handleList(): array {
+		$ability = wp_get_ability( 'datamachine/daily-memory-list' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'Daily Memory ability not registered. Ensure WordPress 6.9+ and DailyMemoryAbilities is loaded.',
+				'agent_daily_memory'
+			);
+		}
+
+		$result = $ability->execute( array() );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'agent_daily_memory' );
+		}
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return $this->buildErrorResponse(
+				$this->getAbilityError( $result, 'Failed to list daily memory files.' ),
+				'agent_daily_memory'
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'agent_daily_memory',
+		);
+	}
+
+	/**
+	 * Search across daily memory files.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return array Response.
+	 */
+	private function handleSearch( array $parameters ): array {
+		$query = $parameters['query'] ?? '';
+
+		if ( '' === $query ) {
+			return $this->buildErrorResponse(
+				'Parameter "query" is required for search action.',
+				'agent_daily_memory'
+			);
+		}
+
+		$ability = wp_get_ability( 'datamachine/search-daily-memory' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'Daily Memory search ability not registered. Ensure WordPress 6.9+ and DailyMemoryAbilities is loaded.',
+				'agent_daily_memory'
+			);
+		}
+
+		$result = $ability->execute(
+			array(
+				'query' => $query,
+				'from'  => $parameters['from'] ?? null,
+				'to'    => $parameters['to'] ?? null,
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'agent_daily_memory' );
+		}
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return $this->buildErrorResponse(
+				$this->getAbilityError( $result, 'Failed to search daily memory.' ),
+				'agent_daily_memory'
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'agent_daily_memory',
+		);
+	}
+
+	/**
+	 * Tool definition for AI agent discovery.
+	 *
+	 * @return array Tool schema.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'           => __CLASS__,
+			'method'          => 'handle_tool_call',
+			'description'     => 'Manage daily memory journal entries (daily/YYYY/MM/DD.md). Use for session activity, temporal events, and work logs. Use "write" to record today\'s session notes (defaults to append mode). Use "read" to review a specific day. Use "search" to find past entries by keyword. Use "list" to see which days have entries. Daily memory captures WHAT HAPPENED — persistent knowledge belongs in agent_memory (MEMORY.md) instead.',
+			'requires_config' => false,
+			'parameters'      => array(
+				'action'  => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Action to perform: "read" (get daily file), "write" (add to daily file), "list" (show all daily files), or "search" (find entries by keyword).',
+				),
+				'date'    => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Date in YYYY-MM-DD format. Defaults to today. Used by "read" and "write".',
+				),
+				'content' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Content to write. Required for "write" action. Use markdown format with ### headings for session sections.',
+				),
+				'mode'    => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Write mode: "append" adds to end of file (default), "write" replaces the entire file. Prefer "append" to preserve earlier entries from the same day.',
+				),
+				'query'   => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Search term for "search" action. Case-insensitive substring match across all daily files.',
+				),
+				'from'    => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Start date (YYYY-MM-DD) for "search" action. Omit for no lower bound.',
+				),
+				'to'      => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'End date (YYYY-MM-DD) for "search" action. Omit for no upper bound.',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Always configured — no external dependencies.
+	 *
+	 * @return bool
+	 */
+	public static function is_configured(): bool {
+		return true;
+	}
+
+	/**
+	 * Configuration check filter handler.
+	 *
+	 * @param bool   $configured Current configuration state.
+	 * @param string $tool_id    Tool identifier.
+	 * @return bool
+	 */
+	public function check_configuration( $configured, $tool_id ) {
+		if ( 'agent_daily_memory' !== $tool_id ) {
+			return $configured;
+		}
+
+		return self::is_configured();
+	}
+}

--- a/inc/Engine/AI/Tools/Global/AgentMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentMemory.php
@@ -187,7 +187,7 @@ class AgentMemory extends BaseTool {
 		return array(
 			'class'           => __CLASS__,
 			'method'          => 'handle_tool_call',
-			'description'     => 'Manage persistent agent memory that survives across sessions. Memory is stored as markdown sections (## headers) in MEMORY.md. Use "list_sections" to see what exists, "get" to read content, and "update" to write. Use "append" mode to add new information without losing existing content. Use "set" mode to replace a section entirely.',
+			'description'     => 'Manage persistent agent memory (MEMORY.md) — long-lived knowledge that survives across sessions. Stored as markdown sections (## headers). Use "list_sections" to see what exists, "get" to read content, and "update" to write. Use "append" mode to add new information without losing existing content. Use "set" mode to replace a section entirely. For session activity and temporal events, use agent_daily_memory instead.',
 			'requires_config' => false,
 			'parameters'      => array(
 				'action'  => array(

--- a/inc/Engine/AI/Tools/ToolServiceProvider.php
+++ b/inc/Engine/AI/Tools/ToolServiceProvider.php
@@ -15,6 +15,7 @@ namespace DataMachine\Engine\AI\Tools;
 defined( 'ABSPATH' ) || exit;
 
 // Global tools.
+use DataMachine\Engine\AI\Tools\Global\AgentDailyMemory;
 use DataMachine\Engine\AI\Tools\Global\AgentMemory;
 use DataMachine\Engine\AI\Tools\Global\AmazonAffiliateLink;
 use DataMachine\Engine\AI\Tools\Global\BingWebmaster;
@@ -82,6 +83,7 @@ class ToolServiceProvider {
 	 * These tools are available to all agent types (pipeline, system, chat).
 	 */
 	private static function registerGlobalTools(): void {
+		new AgentDailyMemory();
 		new AgentMemory();
 		new AmazonAffiliateLink();
 		new BingWebmaster();


### PR DESCRIPTION
## Summary

Fixes 4 bugs in the memory system and adds a new AI tool for daily memory management.

## Changes

### Bug Fixes

1. **Date display bug (1/21/70)** — `FileAbilities.php` and `FileStorage.php` returned `filemtime()` as Unix seconds, but JavaScript's `Date()` constructor interprets numbers as milliseconds. Changed to `gmdate('c', filemtime())` to return ISO 8601 strings.

2. **Literal `\n` in daily memory files** — `DailyMemoryTask` passes AI response content directly to `DailyMemory::append()`. Some providers return escaped newline sequences in text content. Added `str_replace('\n', "\n", $content)` normalization.

3. **`agent_memory` tool description** — Updated to clarify it's for persistent knowledge and to reference the new `agent_daily_memory` tool for temporal content.

### New Feature

4. **`agent_daily_memory` AI tool** — New global tool giving all agent types (chat, pipeline, system) the ability to read, write, search, and list daily memory files. Delegates to existing `DailyMemoryAbilities`. Without this tool, agents had no way to write daily files — everything got dumped into MEMORY.md.

5. **Default SOUL.md memory guidance** — The activation template now includes a `## Memory System` section with file roles, routing rules, and hygiene guidance. Every new DM installation gets clear instructions for what goes in MEMORY.md vs daily memory.

## Why

The root cause of messy MEMORY.md files was a directive gap: agents only had the `agent_memory` tool (writes to MEMORY.md) with no tool for daily files and no guidance about what belongs where. MEMORY.md became a junk drawer because it was the only drawer the agent could open.