### PR TITLE
Include network-activated plugins in multisite scaffolding

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -418,7 +418,14 @@ function datamachine_get_scaffold_defaults(): array {
 
 	// --- Active plugins (exclude Data Machine itself) ---
 	$active_plugins = get_option( 'active_plugins', array() );
-	$plugin_names   = array();
+
+	// On multisite, include network-activated plugins too.
+	if ( is_multisite() ) {
+		$network_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
+		$active_plugins  = array_unique( array_merge( $active_plugins, $network_plugins ) );
+	}
+
+	$plugin_names = array();
 
 	foreach ( $active_plugins as $plugin_file ) {
 		if ( 0 === strpos( $plugin_file, 'data-machine/' ) ) {


### PR DESCRIPTION
## Summary

Follow-up to #410. On multisite, `get_option('active_plugins')` only returns subsite-activated plugins. Network-activated plugins (stored in `active_sitewide_plugins` site option) were missing from the scaffolded SOUL.md.

Now merges both lists with `array_unique()` so the plugin inventory is complete regardless of activation method.

## What changed

5 lines added to `datamachine_get_scaffold_defaults()`:

```php
if ( is_multisite() ) {
    $network_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
    $active_plugins  = array_unique( array_merge( $active_plugins, $network_plugins ) );
}
```

Note: `active_sitewide_plugins` stores plugins as `plugin-file => timestamp` (keys are the plugin paths), hence `array_keys()`.