### PR TITLE
Self-healing scaffolding: recreate missing agent files on first read

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -570,8 +570,9 @@ MD;
 /**
  * Create default agent memory files if they don't exist.
  *
- * Called on activation to ensure fresh installs have starter templates
- * for all default memory files. Existing files are never overwritten.
+ * Called on activation and lazily on any request that reads agent files
+ * (via DirectoryManager::ensure_agent_files()). Existing files are never
+ * overwritten — only missing files are recreated from scaffold defaults.
  *
  * @since 0.30.0
  */
@@ -598,6 +599,13 @@ function datamachine_ensure_default_memory_files() {
 		}
 
 		$fs->put_contents( $filepath, $content . "\n", FS_CHMOD_FILE );
+
+		do_action(
+			'datamachine_log',
+			'notice',
+			sprintf( 'Self-healing: created missing agent file %s with scaffold defaults.', $filename ),
+			array( 'filename' => $filename )
+		);
 	}
 }
 

--- a/inc/Abilities/FileAbilities.php
+++ b/inc/Abilities/FileAbilities.php
@@ -906,6 +906,9 @@ class FileAbilities {
 	 * @return array Result with files.
 	 */
 	private function listAgentFiles(): array {
+		// Self-heal: ensure agent files exist before listing.
+		DirectoryManager::ensure_agent_files();
+
 		$directory_manager = new DirectoryManager();
 		$agent_dir         = $directory_manager->get_agent_directory();
 
@@ -972,6 +975,9 @@ class FileAbilities {
 	 * @return array Result with file data.
 	 */
 	private function getAgentFile( string $filename ): array {
+		// Self-heal: ensure agent files exist before retrieval.
+		DirectoryManager::ensure_agent_files();
+
 		$directory_manager = new DirectoryManager();
 		$agent_dir         = $directory_manager->get_agent_directory();
 		$filepath          = "{$agent_dir}/{$filename}";

--- a/inc/Core/FilesRepository/DirectoryManager.php
+++ b/inc/Core/FilesRepository/DirectoryManager.php
@@ -24,6 +24,49 @@ class DirectoryManager {
 	private const REPOSITORY_DIR = 'datamachine-files';
 
 	/**
+	 * Whether agent file scaffolding has been verified this request.
+	 *
+	 * @var bool
+	 */
+	private static bool $agent_files_ensured = false;
+
+	/**
+	 * Ensure default agent files exist (SOUL.md, USER.md, MEMORY.md).
+	 *
+	 * Lazy self-healing: runs at most once per PHP request on the first
+	 * call. If any registered memory files are missing, recreates them
+	 * from scaffold defaults without overwriting existing files.
+	 *
+	 * Call this from any read path that depends on agent files existing
+	 * (directives, REST API, CLI, etc.). The static flag makes repeated
+	 * calls free.
+	 *
+	 * @since 0.32.0
+	 * @return void
+	 */
+	public static function ensure_agent_files(): void {
+		if ( self::$agent_files_ensured ) {
+			return;
+		}
+
+		self::$agent_files_ensured = true;
+
+		if ( function_exists( 'datamachine_ensure_default_memory_files' ) ) {
+			datamachine_ensure_default_memory_files();
+		}
+	}
+
+	/**
+	 * Reset the ensure-agent-files flag. For testing only.
+	 *
+	 * @since 0.32.0
+	 * @return void
+	 */
+	public static function reset_ensure_flag(): void {
+		self::$agent_files_ensured = false;
+	}
+
+	/**
 	 * Get pipeline directory path
 	 *
 	 * @param int|string $pipeline_id Pipeline ID or 'direct' for direct execution

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -45,6 +45,9 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 			return array();
 		}
 
+		// Self-heal: ensure agent files exist before reading.
+		DirectoryManager::ensure_agent_files();
+
 		$directory_manager = new DirectoryManager();
 		$agent_dir         = $directory_manager->get_agent_directory();
 		$outputs           = array();
@@ -53,6 +56,12 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 			$filepath = "{$agent_dir}/{$filename}";
 
 			if ( ! file_exists( $filepath ) ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					sprintf( 'Core memory file %s missing from agent directory after scaffolding check.', $filename ),
+					array( 'filename' => $filename )
+				);
 				continue;
 			}
 


### PR DESCRIPTION
## Summary

Closes #408 — Agent files (SOUL.md, USER.md, MEMORY.md) were only created during `register_activation_hook`. If the plugin was deployed via Homeboy, rsync, or git pull without triggering activation, the agent silently operated without its identity files.

## Changes

- **`DirectoryManager::ensure_agent_files()`** — New static method with a once-per-request flag. Calls `datamachine_ensure_default_memory_files()` lazily on the first access. Repeated calls are free (static bool guard).

- **`CoreMemoryFilesDirective::get_outputs()`** — Calls `ensure_agent_files()` before reading memory files. This is the universal funnel for all AI calls. Also now logs a warning if files are still missing after the scaffolding attempt.

- **`AgentMemory` constructor** — Calls `ensure_agent_files()` on instantiation. Covers all CLI and API memory operations.

- **`FileAbilities::listAgentFiles()` / `getAgentFile()`** — Calls `ensure_agent_files()` before listing or retrieving agent files via REST API.

- **`AgentMemory::ensure_file_exists()`** — Upgraded from bare `# Agent Memory\n` stub to using `datamachine_get_scaffold_defaults()` content, so a recreated MEMORY.md includes the standard sections (State, Lessons Learned, Context).

- **`datamachine_ensure_default_memory_files()`** — Added `notice`-level logging when files are recreated, providing visibility into self-healing events.

## How it works

```
Request touches agent files (AI call, CLI, REST API)
  → DirectoryManager::ensure_agent_files()     [static flag: once per request]
    → datamachine_ensure_default_memory_files() [creates missing files, skips existing]
      → Logs "Self-healing: created missing agent file X" for each recreated file
  → Normal read continues with files guaranteed to exist
```

## Coverage

| Access path | Self-healing point |
|---|---|
| Every AI call (chat, pipelines) | `CoreMemoryFilesDirective::get_outputs()` |
| CLI `wp datamachine memory *` | `AgentMemory` constructor |
| REST API `GET /files/agent` | `FileAbilities::listAgentFiles()` |
| REST API `GET /files/agent/{file}` | `FileAbilities::getAgentFile()` |
| REST API `PUT /files/agent/{file}` | `AgentMemory::ensure_file_exists()` (write path) |