### PR TITLE
Network-wide settings with per-site override cascade

### DIFF
--- a/inc/Core/NetworkSettings.php
+++ b/inc/Core/NetworkSettings.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Network Settings Accessor
+ *
+ * Centralized access point for datamachine_network_settings site option.
+ * Stores network-wide defaults that individual sites can override via
+ * PluginSettings. On single-site installs, get_site_option() behaves
+ * identically to get_option(), so this is transparent.
+ *
+ * @package DataMachine\Core
+ * @since 0.32.0
+ */
+
+namespace DataMachine\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class NetworkSettings {
+
+	/**
+	 * Option name for network-wide settings.
+	 */
+	const OPTION_NAME = 'datamachine_network_settings';
+
+	/**
+	 * Keys that are valid at the network level.
+	 * Only these keys can be stored/retrieved from network settings.
+	 */
+	const NETWORK_KEYS = array(
+		'default_provider',
+		'default_model',
+		'agent_models',
+	);
+
+	private static ?array $cache = null;
+
+	/**
+	 * Get all network settings.
+	 *
+	 * @return array
+	 */
+	public static function all(): array {
+		if ( null === self::$cache ) {
+			self::$cache = get_site_option( self::OPTION_NAME, array() );
+		}
+		return self::$cache;
+	}
+
+	/**
+	 * Get a specific network setting value.
+	 *
+	 * @param string $key     Setting key.
+	 * @param mixed  $default Default value if key not found.
+	 * @return mixed
+	 */
+	public static function get( string $key, mixed $default = null ): mixed {
+		if ( ! in_array( $key, self::NETWORK_KEYS, true ) ) {
+			return $default;
+		}
+
+		$settings = self::all();
+		return $settings[ $key ] ?? $default;
+	}
+
+	/**
+	 * Update network settings (partial merge).
+	 *
+	 * Only keys listed in NETWORK_KEYS are accepted. Other keys are silently
+	 * ignored so callers can safely pass a mixed bag of settings.
+	 *
+	 * @param array $values Key-value pairs to merge into network settings.
+	 * @return bool True on success.
+	 */
+	public static function update( array $values ): bool {
+		$current  = self::all();
+		$filtered = array();
+
+		foreach ( $values as $key => $value ) {
+			if ( in_array( $key, self::NETWORK_KEYS, true ) ) {
+				$filtered[ $key ] = $value;
+			}
+		}
+
+		if ( empty( $filtered ) ) {
+			return false;
+		}
+
+		$merged = array_merge( $current, $filtered );
+		$result = update_site_option( self::OPTION_NAME, $merged );
+
+		self::$cache = $merged;
+
+		return $result;
+	}
+
+	/**
+	 * Check if a key is a network-level setting.
+	 *
+	 * @param string $key Setting key.
+	 * @return bool
+	 */
+	public static function isNetworkKey( string $key ): bool {
+		return in_array( $key, self::NETWORK_KEYS, true );
+	}
+
+	/**
+	 * Clear the settings cache.
+	 *
+	 * @return void
+	 */
+	public static function clearCache(): void {
+		self::$cache = null;
+	}
+}

--- a/tests/Unit/Core/NetworkSettingsTest.php
+++ b/tests/Unit/Core/NetworkSettingsTest.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * NetworkSettings Tests
+ *
+ * Tests for network-level settings storage and the resolve cascade.
+ *
+ * @package DataMachine\Tests\Unit\Core
+ */
+
+namespace DataMachine\Tests\Unit\Core;
+
+use DataMachine\Core\NetworkSettings;
+use DataMachine\Core\PluginSettings;
+use WP_UnitTestCase;
+
+class NetworkSettingsTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		delete_site_option( NetworkSettings::OPTION_NAME );
+		delete_option( 'datamachine_settings' );
+		NetworkSettings::clearCache();
+		PluginSettings::clearCache();
+	}
+
+	public function tear_down(): void {
+		delete_site_option( NetworkSettings::OPTION_NAME );
+		delete_option( 'datamachine_settings' );
+		NetworkSettings::clearCache();
+		PluginSettings::clearCache();
+		parent::tear_down();
+	}
+
+	// --- NetworkSettings basic CRUD ---
+
+	public function test_all_returns_empty_array_when_no_data(): void {
+		$this->assertSame( array(), NetworkSettings::all() );
+	}
+
+	public function test_get_returns_default_when_no_data(): void {
+		$this->assertSame( 'fallback', NetworkSettings::get( 'default_provider', 'fallback' ) );
+	}
+
+	public function test_get_rejects_non_network_keys(): void {
+		update_site_option( NetworkSettings::OPTION_NAME, array( 'disabled_tools' => array( 'foo' ) ) );
+		NetworkSettings::clearCache();
+
+		$this->assertNull( NetworkSettings::get( 'disabled_tools' ) );
+	}
+
+	public function test_update_stores_network_keys(): void {
+		NetworkSettings::update( array(
+			'default_provider' => 'anthropic',
+			'default_model'    => 'claude-sonnet-4-20250514',
+		) );
+
+		NetworkSettings::clearCache();
+
+		$this->assertSame( 'anthropic', NetworkSettings::get( 'default_provider' ) );
+		$this->assertSame( 'claude-sonnet-4-20250514', NetworkSettings::get( 'default_model' ) );
+	}
+
+	public function test_update_ignores_non_network_keys(): void {
+		NetworkSettings::update( array(
+			'default_provider'  => 'openai',
+			'site_context_enabled' => true, // not a network key
+		) );
+
+		NetworkSettings::clearCache();
+
+		$this->assertSame( 'openai', NetworkSettings::get( 'default_provider' ) );
+		$this->assertNull( NetworkSettings::get( 'site_context_enabled' ) );
+	}
+
+	public function test_update_merges_with_existing(): void {
+		NetworkSettings::update( array( 'default_provider' => 'openai' ) );
+		NetworkSettings::update( array( 'default_model' => 'gpt-4o' ) );
+
+		NetworkSettings::clearCache();
+
+		$this->assertSame( 'openai', NetworkSettings::get( 'default_provider' ) );
+		$this->assertSame( 'gpt-4o', NetworkSettings::get( 'default_model' ) );
+	}
+
+	public function test_update_returns_false_when_no_valid_keys(): void {
+		$result = NetworkSettings::update( array( 'bogus_key' => 'value' ) );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_is_network_key(): void {
+		$this->assertTrue( NetworkSettings::isNetworkKey( 'default_provider' ) );
+		$this->assertTrue( NetworkSettings::isNetworkKey( 'default_model' ) );
+		$this->assertTrue( NetworkSettings::isNetworkKey( 'agent_models' ) );
+		$this->assertFalse( NetworkSettings::isNetworkKey( 'disabled_tools' ) );
+		$this->assertFalse( NetworkSettings::isNetworkKey( 'site_context_enabled' ) );
+	}
+
+	public function test_data_stored_via_site_option(): void {
+		NetworkSettings::update( array( 'default_provider' => 'anthropic' ) );
+
+		$raw = get_site_option( NetworkSettings::OPTION_NAME, array() );
+
+		$this->assertArrayHasKey( 'default_provider', $raw );
+		$this->assertSame( 'anthropic', $raw['default_provider'] );
+	}
+
+	public function test_agent_models_stored_at_network_level(): void {
+		$agent_models = array(
+			'chat'     => array( 'provider' => 'anthropic', 'model' => 'claude-sonnet-4-20250514' ),
+			'pipeline' => array( 'provider' => 'openai', 'model' => 'gpt-4o-mini' ),
+		);
+
+		NetworkSettings::update( array( 'agent_models' => $agent_models ) );
+		NetworkSettings::clearCache();
+
+		$this->assertSame( $agent_models, NetworkSettings::get( 'agent_models' ) );
+	}
+
+	// --- PluginSettings::resolve() cascade ---
+
+	public function test_resolve_returns_site_value_when_set(): void {
+		update_option( 'datamachine_settings', array( 'default_provider' => 'openai' ) );
+		PluginSettings::clearCache();
+
+		NetworkSettings::update( array( 'default_provider' => 'anthropic' ) );
+
+		$this->assertSame( 'openai', PluginSettings::resolve( 'default_provider' ) );
+	}
+
+	public function test_resolve_falls_back_to_network_when_site_empty(): void {
+		update_option( 'datamachine_settings', array( 'default_provider' => '' ) );
+		PluginSettings::clearCache();
+
+		NetworkSettings::update( array( 'default_provider' => 'anthropic' ) );
+
+		$this->assertSame( 'anthropic', PluginSettings::resolve( 'default_provider' ) );
+	}
+
+	public function test_resolve_falls_back_to_network_when_site_unset(): void {
+		update_option( 'datamachine_settings', array() );
+		PluginSettings::clearCache();
+
+		NetworkSettings::update( array( 'default_provider' => 'gemini' ) );
+
+		$this->assertSame( 'gemini', PluginSettings::resolve( 'default_provider' ) );
+	}
+
+	public function test_resolve_returns_default_when_both_empty(): void {
+		update_option( 'datamachine_settings', array() );
+		PluginSettings::clearCache();
+
+		$this->assertSame( 'none', PluginSettings::resolve( 'default_provider', 'none' ) );
+	}
+
+	public function test_resolve_non_network_key_skips_cascade(): void {
+		update_option( 'datamachine_settings', array() );
+		PluginSettings::clearCache();
+
+		// Even if somehow stored, resolve shouldn't look at network for non-network keys.
+		$this->assertSame( 12, PluginSettings::resolve( 'max_turns', 12 ) );
+	}
+
+	// --- getAgentModel() cascade ---
+
+	public function test_get_agent_model_site_override_wins(): void {
+		update_option( 'datamachine_settings', array(
+			'agent_models' => array(
+				'chat' => array( 'provider' => 'openai', 'model' => 'gpt-4o' ),
+			),
+		) );
+		PluginSettings::clearCache();
+
+		NetworkSettings::update( array(
+			'agent_models' => array(
+				'chat' => array( 'provider' => 'anthropic', 'model' => 'claude-sonnet-4-20250514' ),
+			),
+		) );
+
+		$result = PluginSettings::getAgentModel( 'chat' );
+
+		$this->assertSame( 'openai', $result['provider'] );
+		$this->assertSame( 'gpt-4o', $result['model'] );
+	}
+
+	public function test_get_agent_model_falls_back_to_network_agent_models(): void {
+		update_option( 'datamachine_settings', array() );
+		PluginSettings::clearCache();
+
+		NetworkSettings::update( array(
+			'agent_models' => array(
+				'pipeline' => array( 'provider' => 'openai', 'model' => 'gpt-4o-mini' ),
+			),
+		) );
+
+		$result = PluginSettings::getAgentModel( 'pipeline' );
+
+		$this->assertSame( 'openai', $result['provider'] );
+		$this->assertSame( 'gpt-4o-mini', $result['model'] );
+	}
+
+	public function test_get_agent_model_falls_back_to_network_global_defaults(): void {
+		update_option( 'datamachine_settings', array() );
+		PluginSettings::clearCache();
+
+		NetworkSettings::update( array(
+			'default_provider' => 'anthropic',
+			'default_model'    => 'claude-sonnet-4-20250514',
+		) );
+
+		$result = PluginSettings::getAgentModel( 'system' );
+
+		$this->assertSame( 'anthropic', $result['provider'] );
+		$this->assertSame( 'claude-sonnet-4-20250514', $result['model'] );
+	}
+
+	public function test_get_agent_model_returns_empty_when_nothing_configured(): void {
+		update_option( 'datamachine_settings', array() );
+		PluginSettings::clearCache();
+
+		$result = PluginSettings::getAgentModel( 'chat' );
+
+		$this->assertSame( '', $result['provider'] );
+		$this->assertSame( '', $result['model'] );
+	}
+
+	public function test_get_agent_model_mixed_cascade(): void {
+		// Site has provider override for chat, but no model.
+		// Network has model for chat.
+		update_option( 'datamachine_settings', array(
+			'agent_models' => array(
+				'chat' => array( 'provider' => 'openai', 'model' => '' ),
+			),
+		) );
+		PluginSettings::clearCache();
+
+		NetworkSettings::update( array(
+			'agent_models' => array(
+				'chat' => array( 'provider' => 'anthropic', 'model' => 'claude-sonnet-4-20250514' ),
+			),
+		) );
+
+		$result = PluginSettings::getAgentModel( 'chat' );
+
+		// Provider from site, model from network.
+		$this->assertSame( 'openai', $result['provider'] );
+		$this->assertSame( 'claude-sonnet-4-20250514', $result['model'] );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -137,6 +137,7 @@ function datamachine_uninstall_network_options() {
 		'datamachine_search_config',
 		'datamachine_amazon_config',
 		'datamachine_auth_data',
+		'datamachine_network_settings',
 	);
 
 	foreach ( $datamachine_network_options as $datamachine_option ) {


### PR DESCRIPTION
## Summary

Adds a network-level settings layer so multisite installs can configure AI provider/model defaults once and share them across subsites — **without requiring network activation**.

This closes the last multisite gap from #382: AI provider settings were stuck in per-site `get_option()`, requiring manual configuration on every subsite. Now they cascade: site → network → default.

## What changed

- **`NetworkSettings` class** (`inc/Core/NetworkSettings.php`) — stores `default_provider`, `default_model`, `agent_models` via `get_site_option()`. On single-site, this is identical to `get_option()` — zero impact.
- **`PluginSettings::resolve()`** — new cascade method: checks per-site value first, falls back to network default, then hardcoded default. Empty strings and empty arrays are treated as "not set" to allow the cascade to continue.
- **`PluginSettings::getAgentModel()`** — updated to use full cascade (site agent override → network agent override → site global default → network global default → empty)
- **`SettingsAbilities`** — `get-settings` response now includes `network_settings` object. `update-settings` accepts `network_settings` input (requires super admin on multisite).
- **`uninstall.php`** — `datamachine_network_settings` added to network options cleanup list.

## Cascade diagram

```
Per-site override  →  Network default  →  Hardcoded fallback
   (get_option)       (get_site_option)
```

## Behavior

- **Single-site:** Zero change. `get_site_option()` === `get_option()`, NetworkSettings is transparent.
- **Multisite (per-site activation):** Set network defaults from any site with DM active. All DM-active sites inherit. Per-site overrides still work.
- **Multisite (network activation):** Same behavior, all sites inherit.

## Tests

20 tests covering:
- NetworkSettings CRUD, key validation, merge behavior
- `resolve()` cascade (site wins, network fallback, both empty)
- `getAgentModel()` with mixed site/network overrides
- Non-network keys are rejected from network storage

## Related

- Addresses #382 (multisite compatibility audit — AI provider key resolution)
- Builds on #414 (auth provider credentials shared via get_site_option)