### PR TITLE
Batch scheduling to prevent Action Scheduler flooding

### DIFF
--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -89,6 +89,11 @@ class SystemAgentServiceProvider {
 		);
 
 		add_action(
+			'datamachine_system_agent_process_batch',
+			array( $this, 'handleBatchChunk' )
+		);
+
+		add_action(
 			'datamachine_system_agent_set_featured_image',
 			array( $this, 'handleDeferredFeaturedImage' ),
 			10,
@@ -159,6 +164,21 @@ class SystemAgentServiceProvider {
 	public function handleScheduledTask( int $jobId ): void {
 		$systemAgent = SystemAgent::getInstance();
 		$systemAgent->handleTask( $jobId );
+	}
+
+	/**
+	 * Handle a batch chunk (Action Scheduler callback).
+	 *
+	 * Processes the next chunk of items from a batch and schedules
+	 * the following chunk if items remain.
+	 *
+	 * @since 0.32.0
+	 *
+	 * @param string $batchId Batch identifier.
+	 */
+	public function handleBatchChunk( string $batchId ): void {
+		$systemAgent = SystemAgent::getInstance();
+		$systemAgent->processBatchChunk( $batchId );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes #417 — bulk queue operations (internal linking, alt text) no longer flood Action Scheduler with hundreds of immediate actions.

## Problem

`queueInternalLinking` and `queueBulkAltText` called `scheduleTask()` in a tight `foreach` loop. Queuing 675 posts created 675 AS actions at once, blocking all other system tasks (image gen, alt text) for hours.

## Solution

New `SystemAgent::scheduleBatch()` method stores all items in a transient and processes them in chunks:

```
scheduleBatch('internal_linking', [675 items])
    → Store items in transient (4hr TTL)
    → Schedule chunk 1 (items 1-10)  → process → schedule individual tasks
    → 30s delay
    → Schedule chunk 2 (items 11-20) → process → schedule individual tasks
    → 30s delay
    → ... until all items processed
    → Delete transient
```

Between chunks, other task types can run in Action Scheduler — no more starvation.

### Constants
- `BATCH_CHUNK_SIZE = 10` — items per chunk
- `BATCH_CHUNK_DELAY = 30` — seconds between chunks

### Smart bypass
Batches smaller than chunk size skip the transient/chunking overhead and schedule directly via `scheduleTask()`.

## Files changed
- **`SystemAgent.php`** — Added `scheduleBatch()`, `processBatchChunk()`, constants
- **`SystemAgentServiceProvider.php`** — Registered `datamachine_system_agent_process_batch` hook
- **`InternalLinkingAbilities.php`** — Uses `scheduleBatch()` instead of foreach loop
- **`AltTextAbilities.php`** — Uses `scheduleBatch()` instead of foreach loop

## Testing
- All existing tests pass
- No new lint errors (87 errors baseline, 163 warnings — unchanged)