### PR TITLE
feat: backfill undo support to AltTextTask and ImageGenerationTask

### DIFF
--- a/inc/Engine/AI/System/Tasks/AltTextTask.php
+++ b/inc/Engine/AI/System/Tasks/AltTextTask.php
@@ -116,9 +116,22 @@ class AltTextTask extends SystemTask {
 			return;
 		}
 
+		// Build standardized effects array for undo.
+		$effects = array(
+			array(
+				'type'           => 'post_meta_set',
+				'target'         => array(
+					'post_id'  => $attachment_id,
+					'meta_key' => '_wp_attachment_image_alt',
+				),
+				'previous_value' => ! empty( $current_alt ) ? $current_alt : null,
+			),
+		);
+
 		$this->completeJob( $jobId, array(
 			'alt_text'      => $alt_text,
 			'attachment_id' => $attachment_id,
+			'effects'       => $effects,
 			'completed_at'  => current_time( 'mysql' ),
 		) );
 	}
@@ -142,6 +155,16 @@ class AltTextTask extends SystemTask {
 			'setting_key'     => 'alt_text_auto_generate_enabled',
 			'default_enabled' => true,
 		);
+	}
+
+	/**
+	 * Alt text generation supports undo — restores previous alt text value.
+	 *
+	 * @return bool
+	 * @since 0.33.0
+	 */
+	public function supportsUndo(): bool {
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Backfills the generic undo system (#424) to the remaining two content-modifying tasks, completing coverage across all system tasks that touch WordPress data.

## Changes

### AltTextTask
- `supportsUndo()` → `true`
- Records `post_meta_set` effect for `_wp_attachment_image_alt` with previous value capture
- Undo restores the original alt text (or deletes it if none existed)

### ImageGenerationTask
- `supportsUndo()` → `true`
- Records up to 3 effect types depending on execution path:
  - `attachment_created` (always) — undo deletes the sideloaded attachment + file
  - `featured_image_set` (featured mode) — undo removes or restores previous thumbnail
  - `post_content_modified` (insert mode) — undo restores pre-insert WP revision
- `trySetFeaturedImage()` return type: `void` → `array` (returns effects)
- `insertImageInContent()` return type: `void` → `array` (returns effects, captures revision before content modification)
- `handleSuccess()` collects effects from sub-methods and includes in `completeJob()` result

### Not modified (by design)
- **DailyMemoryTask** — writes agent memory files, not WordPress content. No undo needed.
- **GitHubIssueTask** — creates external GitHub issues. Not reversible via WordPress undo.

## Undo coverage after this PR

| Task | supportsUndo | Effect Types |
|------|:---:|---|
| InternalLinkingTask | ✅ | `post_content_modified`, `post_meta_set` |
| AltTextTask | ✅ | `post_meta_set` |
| ImageGenerationTask | ✅ | `attachment_created`, `featured_image_set`, `post_content_modified` |
| DailyMemoryTask | ❌ | N/A (file-based, non-destructive) |
| GitHubIssueTask | ❌ | N/A (external API) |

No custom `undo()` overrides needed — all effect types are handled by SystemTask's generic handlers.

Ref #424