### PR TITLE
feat: System Task Runner step type (#277)

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -248,6 +248,7 @@ function datamachine_load_step_types() {
 	new \DataMachine\Core\Steps\AI\AIStep();
 	new \DataMachine\Core\Steps\AgentPing\AgentPingStep();
 	new \DataMachine\Core\Steps\WebhookGate\WebhookGateStep();
+	new \DataMachine\Core\Steps\SystemTask\SystemTaskStep();
 }
 
 /**

--- a/inc/Core/Steps/SystemTask/SystemTaskSettings.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskSettings.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * System Task Step Settings
+ *
+ * Defines configuration fields for the System Task step type.
+ * Used by the admin UI to render configuration forms.
+ *
+ * @package DataMachine\Core\Steps\SystemTask
+ * @since 0.34.0
+ */
+
+namespace DataMachine\Core\Steps\SystemTask;
+
+use DataMachine\Core\Steps\Settings\SettingsHandler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SystemTaskSettings extends SettingsHandler {
+
+	/**
+	 * Get settings fields for System Task step.
+	 *
+	 * @return array Field definitions for the configuration UI.
+	 */
+	public static function get_fields(): array {
+		return array(
+			'task'   => array(
+				'type'        => 'select',
+				'label'       => __( 'Task Type', 'data-machine' ),
+				'description' => __( 'The system task to execute. Available tasks are registered by Data Machine and plugins.', 'data-machine' ),
+				'required'    => true,
+				'options'     => self::getTaskOptions(),
+			),
+			'params' => array(
+				'type'        => 'json',
+				'label'       => __( 'Task Parameters', 'data-machine' ),
+				'description' => __( 'JSON object of task-specific parameters. Pipeline context (post_id) is injected automatically.', 'data-machine' ),
+				'default'     => '{}',
+			),
+		);
+	}
+
+	/**
+	 * Get available task types as select options.
+	 *
+	 * Reads from the System Agent's registered task handlers.
+	 *
+	 * @return array<string, string> Task type slug => display label.
+	 */
+	private static function getTaskOptions(): array {
+		$options = array();
+
+		// SystemAgent may not be initialized during early bootstrap.
+		if ( ! class_exists( '\DataMachine\Engine\AI\System\SystemAgent' ) ) {
+			return $options;
+		}
+
+		$system_agent = \DataMachine\Engine\AI\System\SystemAgent::getInstance();
+		$handlers     = $system_agent->getTaskHandlers();
+
+		foreach ( $handlers as $task_type => $handler_class ) {
+			$label = ucfirst( str_replace( '_', ' ', $task_type ) );
+
+			// Use task metadata label if available.
+			if ( method_exists( $handler_class, 'getTaskMeta' ) ) {
+				$meta = $handler_class::getTaskMeta();
+				if ( ! empty( $meta['label'] ) ) {
+					$label = $meta['label'];
+				}
+			}
+
+			$options[ $task_type ] = $label;
+		}
+
+		return $options;
+	}
+}

--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * System Task Step - Run registered system tasks inline in a pipeline.
+ *
+ * Bridges the System Agent task system into the pipeline engine. Allows
+ * mechanical/deterministic tasks (internal linking, alt text generation)
+ * to run as pipeline steps without a full agent turn.
+ *
+ * Configuration is at the flow step level via handler_config:
+ *   task   - Task type identifier (e.g., 'internal_linking')
+ *   params - Task-specific parameters merged with pipeline context
+ *
+ * Pipeline context (post_id from Publish step) is injected automatically
+ * into the task params.
+ *
+ * @package DataMachine\Core\Steps\SystemTask
+ * @since 0.34.0
+ */
+
+namespace DataMachine\Core\Steps\SystemTask;
+
+use DataMachine\Core\DataPacket;
+use DataMachine\Core\Steps\Step;
+use DataMachine\Core\Steps\StepTypeRegistrationTrait;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\JobStatus;
+use DataMachine\Engine\AI\System\SystemAgent;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SystemTaskStep extends Step {
+
+	use StepTypeRegistrationTrait;
+
+	/**
+	 * Initialize System Task step.
+	 */
+	public function __construct() {
+		parent::__construct( 'system_task' );
+
+		self::registerStepType(
+			slug: 'system_task',
+			label: 'System Task',
+			description: 'Run a registered system task (internal linking, alt text, etc.) inline in the pipeline',
+			class: self::class,
+			position: 70,
+			usesHandler: false,
+			hasPipelineConfig: false,
+			consumeAllPackets: false,
+			stepSettings: array(
+				'config_type' => 'handler',
+				'modal_type'  => 'configure-step',
+				'button_text' => 'Configure',
+				'label'       => 'System Task Configuration',
+			),
+			showSettingsDisplay: false
+		);
+
+		self::registerStepSettings();
+	}
+
+	/**
+	 * Register System Task settings class for UI display.
+	 */
+	private static function registerStepSettings(): void {
+		static $registered = false;
+		if ( $registered ) {
+			return;
+		}
+		$registered = true;
+
+		add_filter(
+			'datamachine_handler_settings',
+			function ( $all_settings, $handler_slug = null ) {
+				if ( null === $handler_slug || 'system_task' === $handler_slug ) {
+					$all_settings['system_task'] = new SystemTaskSettings();
+				}
+				return $all_settings;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Validate System Task step configuration.
+	 *
+	 * Requires a valid task type in handler_config.
+	 *
+	 * @return bool
+	 */
+	protected function validateStepConfiguration(): bool {
+		$handler_config = $this->getHandlerConfig();
+		$task_type      = $handler_config['task'] ?? '';
+
+		if ( empty( $task_type ) ) {
+			do_action(
+				'datamachine_fail_job',
+				$this->job_id,
+				'system_task_missing_task_type',
+				array(
+					'flow_step_id'  => $this->flow_step_id,
+					'error_message' => 'System Task step requires a task type in handler_config.',
+				)
+			);
+			return false;
+		}
+
+		// Verify task type is registered.
+		$system_agent = SystemAgent::getInstance();
+		$handlers     = $system_agent->getTaskHandlers();
+
+		if ( ! isset( $handlers[ $task_type ] ) ) {
+			$available = implode( ', ', array_keys( $handlers ) );
+			do_action(
+				'datamachine_fail_job',
+				$this->job_id,
+				'system_task_unknown_type',
+				array(
+					'flow_step_id'  => $this->flow_step_id,
+					'task_type'     => $task_type,
+					'error_message' => "Unknown system task type '{$task_type}'. Available: {$available}",
+				)
+			);
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Execute System Task step logic.
+	 *
+	 * Creates a child DM job for tracking, resolves the task handler,
+	 * and executes it synchronously. The child job captures effects
+	 * and completion status independently from the pipeline job.
+	 *
+	 * @return array Updated data packets.
+	 */
+	protected function executeStep(): array {
+		$handler_config = $this->getHandlerConfig();
+		$task_type      = $handler_config['task'];
+		$task_params    = $handler_config['params'] ?? array();
+
+		// Inject pipeline context into task params.
+		$post_id = $this->engine->get( 'post_id' );
+		if ( $post_id && ! isset( $task_params['post_id'] ) ) {
+			$task_params['post_id'] = $post_id;
+		}
+
+		// Resolve the task handler class.
+		$system_agent  = SystemAgent::getInstance();
+		$handlers      = $system_agent->getTaskHandlers();
+		$handler_class = $handlers[ $task_type ];
+
+		// Create a child job for independent tracking.
+		$jobs_db     = new Jobs();
+		$job_context = $this->engine->getJobContext();
+		$child_job_id = $jobs_db->create_job(
+			array(
+				'pipeline_id'   => $job_context['pipeline_id'] ?? 'direct',
+				'flow_id'       => $job_context['flow_id'] ?? 'direct',
+				'source'        => 'pipeline_system_task',
+				'label'         => ucfirst( str_replace( '_', ' ', $task_type ) ),
+				'parent_job_id' => $this->job_id,
+			)
+		);
+
+		if ( ! $child_job_id ) {
+			$this->log( 'error', 'Failed to create child job for system task', array( 'task_type' => $task_type ) );
+
+			$result_packet = new DataPacket(
+				array(
+					'title' => 'System Task Failed',
+					'body'  => "Failed to create tracking job for task '{$task_type}'",
+				),
+				array(
+					'source_type'  => 'system_task',
+					'flow_step_id' => $this->flow_step_id,
+					'task_type'    => $task_type,
+					'success'      => false,
+				),
+				'system_task_result'
+			);
+
+			return $result_packet->addTo( $this->dataPackets );
+		}
+
+		// Store task params in child job engine_data.
+		$child_engine_data = array_merge( $task_params, array(
+			'task_type'        => $task_type,
+			'pipeline_job_id'  => $this->job_id,
+			'pipeline_step_id' => $this->flow_step_id,
+			'scheduled_at'     => current_time( 'mysql' ),
+		) );
+		$jobs_db->store_engine_data( (int) $child_job_id, $child_engine_data );
+		$jobs_db->start_job( (int) $child_job_id, JobStatus::PROCESSING );
+
+		$this->log(
+			'info',
+			"Executing system task '{$task_type}' as pipeline step (child job #{$child_job_id})",
+			array(
+				'task_type'    => $task_type,
+				'child_job_id' => $child_job_id,
+				'post_id'      => $post_id ?? null,
+			)
+		);
+
+		// Execute the task synchronously.
+		$success    = true;
+		$error_msg  = '';
+
+		try {
+			$handler = new $handler_class();
+			$handler->execute( (int) $child_job_id, $child_engine_data );
+		} catch ( \Throwable $e ) {
+			$success   = false;
+			$error_msg = $e->getMessage();
+
+			$this->log(
+				'error',
+				"System task '{$task_type}' threw exception: {$error_msg}",
+				array(
+					'task_type'    => $task_type,
+					'child_job_id' => $child_job_id,
+					'exception'    => $error_msg,
+				)
+			);
+
+			// Mark child job as failed if the task didn't already.
+			$child_job = $jobs_db->get_job( $child_job_id );
+			$status    = $child_job['status'] ?? '';
+			if ( 'PROCESSING' === $status ) {
+				$jobs_db->complete_job( $child_job_id, JobStatus::failed( 'Exception: ' . $error_msg )->toString() );
+			}
+		}
+
+		// Read child job result to determine success.
+		$child_job    = $jobs_db->get_job( $child_job_id );
+		$child_status = $child_job['status'] ?? '';
+		$child_data   = $child_job['engine_data'] ?? array();
+
+		// Check if the task itself reported failure.
+		if ( $success && str_starts_with( $child_status, 'FAILED' ) ) {
+			$success   = false;
+			$error_msg = $child_data['error'] ?? 'Task reported failure';
+		}
+
+		// Determine if pipeline should continue on task failure.
+		// Skipped tasks (already processed) are not failures.
+		$skipped = ! empty( $child_data['skipped'] );
+		if ( $skipped ) {
+			$success = true;
+		}
+
+		$body = $success
+			? ( $skipped
+				? "System task '{$task_type}' skipped: " . ( $child_data['reason'] ?? 'already processed' )
+				: "System task '{$task_type}' completed successfully" )
+			: "System task '{$task_type}' failed: {$error_msg}";
+
+		$result_packet = new DataPacket(
+			array(
+				'title' => $success ? 'System Task Completed' : 'System Task Failed',
+				'body'  => $body,
+			),
+			array(
+				'source_type'  => 'system_task',
+				'flow_step_id' => $this->flow_step_id,
+				'task_type'    => $task_type,
+				'child_job_id' => $child_job_id,
+				'child_status' => $child_status,
+				'skipped'      => $skipped,
+				'success'      => $success,
+			),
+			'system_task_result'
+		);
+
+		return $result_packet->addTo( $this->dataPackets );
+	}
+}


### PR DESCRIPTION
## Summary

New **system_task** pipeline step type that bridges the System Agent task system into the pipeline engine. Mechanical tasks (internal linking, alt text, image generation) can now run as pipeline steps instead of requiring a full agent turn via Agent Ping.

## How it works

```
Fetch → AI → Publish → System Task (internal_linking) → Agent Ping
```

**Flow step config:**
```json
{
  "step_type": "system_task",
  "handler_configs": {
    "system_task": {
      "task": "internal_linking",
      "params": { "links_per_post": 3 }
    }
  }
}
```

## Design decisions

- **Synchronous execution** — Task runs inline in the pipeline (already in Action Scheduler). No second AS hop.
- **Child job tracking** — Creates a child DM job (`parent_job_id` = pipeline job) so the system task has its own job record, effects, and undo support. Doesn't corrupt the pipeline job's engine_data.
- **Context injection** — `post_id` from the Publish step is automatically injected into task params.
- **Skipped = success** — Tasks that report "already processed" don't fail the pipeline.
- **Task validation** — Validates task type against `SystemAgent::getTaskHandlers()` before execution.
- **Handler-free** — Like AgentPingStep: `usesHandler: false`, config stored under step type slug.

## Files

| File | Purpose |
|------|---------|
| `inc/Core/Steps/SystemTask/SystemTaskStep.php` | Step type implementation (284 lines) |
| `inc/Core/Steps/SystemTask/SystemTaskSettings.php` | UI settings fields (task select + params JSON) |
| `data-machine.php` | Bootstrap registration in `datamachine_load_step_types()` |

## What's NOT included (follow-ups)

- **Auto-fire suppression** — When a pipeline includes a system_task step for alt text, the implicit `add_attachment` auto-fire should be suppressed to avoid double-processing. Better as a separate PR.
- **Pipeline-level batch** — Making the Fetch step return N items with N child pipeline jobs. Separate from this step type.

Closes #277