### PR TITLE
feat: deterministic scheduling stagger + consolidate scheduling code paths

### DIFF
--- a/tests/Unit/Api/Flows/FlowSchedulingStaggerTest.php
+++ b/tests/Unit/Api/Flows/FlowSchedulingStaggerTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * FlowScheduling Stagger Tests
+ *
+ * Tests for the deterministic stagger offset in flow scheduling.
+ *
+ * @package DataMachine\Tests\Unit\Api\Flows
+ */
+
+namespace DataMachine\Tests\Unit\Api\Flows;
+
+use DataMachine\Api\Flows\FlowScheduling;
+use WP_UnitTestCase;
+
+class FlowSchedulingStaggerTest extends WP_UnitTestCase {
+
+	/**
+	 * Stagger offset should be deterministic — same flow ID always produces same offset.
+	 */
+	public function test_stagger_is_deterministic(): void {
+		$offset_a = FlowScheduling::calculate_stagger_offset( 42, 86400 );
+		$offset_b = FlowScheduling::calculate_stagger_offset( 42, 86400 );
+
+		$this->assertSame( $offset_a, $offset_b, 'Same flow_id should produce identical offsets' );
+	}
+
+	/**
+	 * Different flow IDs should (usually) produce different offsets.
+	 */
+	public function test_different_flows_get_different_offsets(): void {
+		$offsets = array();
+		for ( $i = 1; $i <= 50; $i++ ) {
+			$offsets[] = FlowScheduling::calculate_stagger_offset( $i, 3600 );
+		}
+
+		$unique = array_unique( $offsets );
+		// With 50 flows in a 3600s window, we expect significant spread.
+		// Allow some collisions but most should be unique.
+		$this->assertGreaterThan( 30, count( $unique ), 'Most flow IDs should produce distinct offsets' );
+	}
+
+	/**
+	 * Offset should never exceed the interval.
+	 */
+	public function test_offset_bounded_by_interval(): void {
+		for ( $flow_id = 1; $flow_id <= 100; $flow_id++ ) {
+			$offset = FlowScheduling::calculate_stagger_offset( $flow_id, 300 );
+			$this->assertGreaterThanOrEqual( 0, $offset );
+			$this->assertLessThan( 300, $offset );
+		}
+	}
+
+	/**
+	 * Offset should be capped at MAX_STAGGER_SECONDS (3600) even for large intervals.
+	 */
+	public function test_offset_capped_for_large_intervals(): void {
+		for ( $flow_id = 1; $flow_id <= 100; $flow_id++ ) {
+			// Weekly interval = 604800 seconds, but stagger should cap at 3600.
+			$offset = FlowScheduling::calculate_stagger_offset( $flow_id, 604800 );
+			$this->assertGreaterThanOrEqual( 0, $offset );
+			$this->assertLessThan( 3600, $offset );
+		}
+	}
+
+	/**
+	 * Zero or negative interval should return 0 offset.
+	 */
+	public function test_zero_interval_returns_zero(): void {
+		$this->assertSame( 0, FlowScheduling::calculate_stagger_offset( 1, 0 ) );
+		$this->assertSame( 0, FlowScheduling::calculate_stagger_offset( 1, -100 ) );
+	}
+
+	/**
+	 * Very small intervals should still produce valid offsets.
+	 */
+	public function test_small_interval(): void {
+		$offset = FlowScheduling::calculate_stagger_offset( 42, 60 );
+		$this->assertGreaterThanOrEqual( 0, $offset );
+		$this->assertLessThan( 60, $offset );
+	}
+}


### PR DESCRIPTION
## Summary

- **Scheduling stagger**: Flows with the same interval no longer fire simultaneously. Each flow gets a deterministic offset based on its ID, spreading executions across up to 1 hour.
- **Code consolidation**: 3 duplicate scheduling code paths reduced to 1. `FlowScheduling::handle_scheduling_update()` is now the single source of truth.

## The Problem

When 96 city flows were created with the same interval, all of them would fire at `time() + interval_seconds` — the exact same second. This causes:
- Ticketmaster API rate limit exhaustion
- Action Scheduler batch saturation
- PHP-FPM worker pool contention
- AI API cost spikes from burst traffic

## The Fix

### Stagger (`FlowScheduling::calculate_stagger_offset()`)

```php
// Deterministic hash — same flow always gets same offset
$offset = crc32('dm_stagger_' . $flow_id) % min($interval_seconds, 3600);
```

- **Deterministic**: Same flow ID always produces the same offset (no drift on reschedule)
- **Bounded**: Offset capped at `min(interval, 3600s)` — max 1 hour spread
- **Even distribution**: 50 flows on a daily interval produce 49 unique offsets across 58 minutes

### Consolidation

Before: 3 independent places scheduled flows with `as_schedule_recurring_action()`:
1. `FlowScheduling::handle_scheduling_update()` — used by CreateFlow/UpdateFlow/DuplicateFlow
2. `ScheduleFlowAbility::scheduleRecurring()` — backed `datamachine_run_flow_later` hook (never called by anything)
3. `datamachine_activate_scheduled_flows()` — plugin activation inline logic

After: All 3 delegate to `FlowScheduling::handle_scheduling_update()`. The stagger, validation, and AS registration logic lives in one place.

**Net -26 lines** despite adding a feature.

## Files Changed

| File | Change |
|------|--------|
| `inc/Api/Flows/FlowScheduling.php` | Added `calculate_stagger_offset()`, applied stagger to `handle_scheduling_update()` |
| `inc/Abilities/Engine/ScheduleFlowAbility.php` | `scheduleRecurring()` now delegates to `FlowScheduling` |
| `data-machine.php` | `datamachine_activate_scheduled_flows()` now delegates to `FlowScheduling` |
| `tests/Unit/Api/Flows/FlowSchedulingStaggerTest.php` | **NEW** — unit tests for stagger offset |

## Tests

Unit test covers: determinism, uniqueness across flow IDs, interval bounding, max cap at 3600s, zero/negative intervals, small intervals.

⚠️ Tests cannot currently run on the Extra Chill VPS due to homeboy test infrastructure issues (#214, #215). Stagger logic verified via inline PHP execution.

## Refs

- extrachill-events#14 (scheduling stagger)