### PR TITLE
fix(tests): match trySetFeaturedImage return type with parent class

### DIFF
--- a/tests/Unit/AI/System/Tasks/ImageGenerationTaskTest.php
+++ b/tests/Unit/AI/System/Tasks/ImageGenerationTaskTest.php
@@ -24,12 +24,13 @@ class TestableImageGenerationTask extends ImageGenerationTask {
 		];
 	}
 
-	protected function trySetFeaturedImage( int $jobId, int $attachmentId, array $params ): void {
+	protected function trySetFeaturedImage( int $jobId, int $attachmentId, array $params ): array {
 		$this->set_featured_image_calls[] = [
 			'job_id'         => $jobId,
 			'attachment_id'  => $attachmentId,
 			'params'         => $params,
 		];
+		return [];
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix return type mismatch that prevented PHPUnit from loading the test file.

`TestableImageGenerationTask::trySetFeaturedImage()` was declared as returning `void`, but the parent class `ImageGenerationTask::trySetFeaturedImage()` returns `array`. PHP strict mode causes a fatal error, preventing PHPUnit from even discovering the test class.

Found while debugging homeboy-modules #215 (test runner fix).