### PR TITLE
fix: sync version targets and add modules to homeboy.json

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,10 +1,22 @@
 {
+  "modules": {
+    "wordpress": {}
+  },
   "version_targets": [
     {
       "file": "data-machine.php",
       "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"
+    },
+    {
+      "file": "readme.txt",
+      "pattern": "(?m)^Stable tag:\\s*([0-9.]+)"
+    },
+    {
+      "file": "package.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
   ],
   "changelog_target": "docs/CHANGELOG.md",
+  "build_command": "npm run build",
   "auto_cleanup": false
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "datamachine",
-	"version": "0.10.2",
+	"version": "0.32.0",
 	"description": "AI-first WordPress plugin with Pipeline+Flow architecture",
 	"private": true,
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, automation, content, workflow, pipeline
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 0.15.2
+Stable tag: 0.32.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary

- **3 version targets now tracked** — `data-machine.php`, `readme.txt` (Stable tag), `package.json`
- **Synced stale versions** — readme.txt was at 0.15.2, package.json at 0.10.2, both now 0.32.0
- **Added `modules.wordpress`** — declares the test module dependency portably
- **Added `build_command`** — `npm run build` (wp-scripts)

The VPS-side config was also trimmed to only machine-specific fields (`local_path`, `remote_path`). Everything else now comes from the portable `homeboy.json` in the repo, which is the right pattern — config travels with the code.