### PR TITLE
Fix workspace read offset/limit and directory permissions

### DIFF
--- a/inc/Abilities/WorkspaceAbilities.php
+++ b/inc/Abilities/WorkspaceAbilities.php
@@ -147,6 +147,7 @@ class WorkspaceAbilities {
 
 			// -----------------------------------------------------------------
 			// File reading abilities (show_in_rest = true).
+			// File reading abilities (show_in_rest = true).
 			// -----------------------------------------------------------------
 
 			wp_register_ability(
@@ -158,11 +159,11 @@ class WorkspaceAbilities {
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
-							'repo'     => array(
+							'repo'   => array(
 								'type'        => 'string',
 								'description' => 'Repository directory name.',
 							),
-							'path'     => array(
+							'path'   => array(
 								'type'        => 'string',
 								'description' => 'Relative file path within the repo.',
 							),
@@ -170,16 +171,26 @@ class WorkspaceAbilities {
 								'type'        => 'integer',
 								'description' => 'Maximum file size in bytes (default 1 MB).',
 							),
+							'offset' => array(
+								'type'        => 'integer',
+								'description' => 'Line number to start reading from (1-indexed).',
+							),
+							'limit'  => array(
+								'type'        => 'integer',
+								'description' => 'Maximum number of lines to return.',
+							),
 						),
 						'required'   => array( 'repo', 'path' ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success' => array( 'type' => 'boolean' ),
-							'content' => array( 'type' => 'string' ),
-							'path'    => array( 'type' => 'string' ),
-							'size'    => array( 'type' => 'integer' ),
+							'success'    => array( 'type' => 'boolean' ),
+							'content'    => array( 'type' => 'string' ),
+							'path'       => array( 'type' => 'string' ),
+							'size'       => array( 'type' => 'integer' ),
+							'lines_read' => array( 'type' => 'integer' ),
+							'offset'     => array( 'type' => 'integer' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'readFile' ),
@@ -450,23 +461,20 @@ class WorkspaceAbilities {
 	/**
 	 * Read a file from a workspace repo.
 	 *
-	 * @param array $input Input parameters with 'repo', 'path', optional 'max_size'.
+	 * @param array $input Input parameters with 'repo', 'path', optional 'max_size', 'offset', 'limit'.
 	 * @return array Result.
 	 */
 	public static function readFile( array $input ): array {
 		$workspace = new Workspace();
 		$reader    = new WorkspaceReader( $workspace );
 
-		$args = array(
+		return $reader->read_file(
 			$input['repo'] ?? '',
 			$input['path'] ?? '',
+			isset( $input['max_size'] ) ? (int) $input['max_size'] : Workspace::MAX_READ_SIZE,
+			isset( $input['offset'] ) ? (int) $input['offset'] : null,
+			isset( $input['limit'] ) ? (int) $input['limit'] : null
 		);
-
-		if ( isset( $input['max_size'] ) ) {
-			$args[] = (int) $input['max_size'];
-		}
-
-		return $reader->read_file( ...$args );
 	}
 
 	/**

--- a/inc/Cli/Commands/WorkspaceCommand.php
+++ b/inc/Cli/Commands/WorkspaceCommand.php
@@ -304,7 +304,8 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 * Reads text file contents from a cloned repository in the workspace.
 	 * Binary files are detected and rejected. Large files are limited by
-	 * --max-size (default 1 MB).
+	 * --max-size (default 1 MB). Use --offset and --limit to read specific
+	 * line ranges.
 	 *
 	 * ## OPTIONS
 	 *
@@ -320,6 +321,12 @@ class WorkspaceCommand extends BaseCommand {
 	 * default: 1048576
 	 * ---
 	 *
+	 * [--offset=<line>]
+	 * : Line number to start reading from (1-indexed).
+	 *
+	 * [--limit=<lines>]
+	 * : Maximum number of lines to return.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Read a file
@@ -327,6 +334,9 @@ class WorkspaceCommand extends BaseCommand {
 	 *
 	 *     # Read with custom size limit
 	 *     wp datamachine workspace read homeboy Cargo.toml --max-size=2097152
+	 *
+	 *     # Read lines 100-130 from a file
+	 *     wp datamachine workspace read extrachill style.css --offset=100 --limit=30
 	 *
 	 * @subcommand read
 	 */
@@ -349,6 +359,14 @@ class WorkspaceCommand extends BaseCommand {
 
 		if ( isset( $assoc_args['max-size'] ) ) {
 			$input['max_size'] = (int) $assoc_args['max-size'];
+		}
+
+		if ( isset( $assoc_args['offset'] ) ) {
+			$input['offset'] = (int) $assoc_args['offset'];
+		}
+
+		if ( isset( $assoc_args['limit'] ) ) {
+			$input['limit'] = (int) $assoc_args['limit'];
 		}
 
 		$result = $ability->execute( $input );

--- a/inc/Core/FilesRepository/Workspace.php
+++ b/inc/Core/FilesRepository/Workspace.php
@@ -89,6 +89,9 @@ class Workspace {
 			);
 		}
 
+		// Set permissions for multi-user access (web server group).
+		$this->ensure_group_permissions( $path );
+
 		// Add .htaccess to block web access if inside web root.
 		$this->protect_directory( $path );
 
@@ -400,6 +403,42 @@ class Workspace {
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
 		$branch = exec( sprintf( 'git -C %s rev-parse --abbrev-ref HEAD 2>/dev/null', $escaped ) );
 		return ( '' !== $branch ) ? $branch : null;
+	}
+
+	/**
+	 * Ensure the workspace directory is group-writable.
+	 *
+	 * Sets group ownership to www-data (or the web server's group) and
+	 * permissions to 775 so that non-root users (e.g., coding agents) can
+	 * write to the workspace.
+	 *
+	 * @param string $path Directory path.
+	 */
+	private function ensure_group_permissions( string $path ): void {
+		// Determine the web server group. Try common groups in order of likelihood.
+		$groups = array( 'www-data', 'apache', 'nginx', 'http' );
+		$web_group = null;
+
+		foreach ( $groups as $group ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+			$exists = exec( sprintf( 'getent group %s >/dev/null 2>&1 && echo 1 || echo 0', escapeshellarg( $group ) ) );
+			if ( '1' === trim( $exists ) ) {
+				$web_group = $group;
+				break;
+			}
+		}
+
+		if ( null === $web_group ) {
+			return;
+		}
+
+		// Set group ownership.
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		exec( sprintf( 'chgrp %s %s 2>/dev/null', escapeshellarg( $web_group ), escapeshellarg( $path ) ) );
+
+		// Set permissions to 775 (rwxrwrx).
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+		exec( sprintf( 'chmod 775 %s 2>/dev/null', escapeshellarg( $path ) ) );
 	}
 
 	/**

--- a/inc/Core/FilesRepository/WorkspaceReader.php
+++ b/inc/Core/FilesRepository/WorkspaceReader.php
@@ -30,12 +30,14 @@ class WorkspaceReader {
 	/**
 	 * Read a file from a workspace repo.
 	 *
-	 * @param string $name     Repository directory name.
-	 * @param string $path     Relative file path within the repo.
-	 * @param int    $max_size Maximum file size in bytes.
-	 * @return array{success: bool, content?: string, path?: string, size?: int, message?: string}
+	 * @param string     $name     Repository directory name.
+	 * @param string     $path     Relative file path within the repo.
+	 * @param int        $max_size Maximum file size in bytes.
+	 * @param int|null   $offset   Line number to start reading from (1-indexed).
+	 * @param int|null   $limit    Maximum number of lines to return.
+	 * @return array{success: bool, content?: string, path?: string, size?: int, message?: string, lines_read?: int, offset?: int}
 	 */
-	public function read_file( string $name, string $path, int $max_size = Workspace::MAX_READ_SIZE ): array {
+	public function read_file( string $name, string $path, int $max_size = Workspace::MAX_READ_SIZE, ?int $offset = null, ?int $limit = null ): array {
 		$repo_path = $this->workspace->get_repo_path( $name );
 		$path      = ltrim( $path, '/' );
 
@@ -105,12 +107,39 @@ class WorkspaceReader {
 			);
 		}
 
-		return array(
-			'success' => true,
-			'content' => $content,
-			'path'    => $path,
-			'size'    => $size,
+		// Apply line offset and limit if specified.
+		$lines_read = 0;
+		$start_line = 1;
+		if ( null !== $offset || null !== $limit ) {
+			$lines = explode( "\n", $content );
+			$total_lines = count( $lines );
+
+			if ( null !== $offset ) {
+				$start_line = max( 1, $offset );
+				$lines = array_slice( $lines, $start_line - 1 );
+			}
+
+			if ( null !== $limit ) {
+				$lines = array_slice( $lines, 0, $limit );
+			}
+
+			$content = implode( "\n", $lines );
+			$lines_read = count( $lines );
+		}
+
+		$result = array(
+			'success'   => true,
+			'content'   => $content,
+			'path'      => $path,
+			'size'      => $size,
 		);
+
+		if ( null !== $offset || null !== $limit ) {
+			$result['lines_read'] = $lines_read;
+			$result['offset']     = $start_line;
+		}
+
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- **Issue #452**: Add `--offset` and `--limit` params to workspace read CLI for reading specific line ranges from large files
- **Issues #450/#451**: Fix workspace directory permissions so non-root users (e.g., coding agents) can write to it

## Changes

### Workspace Read Offset/Limit (#452)
- Added `--offset=<line>` (1-indexed) and `--limit=<lines>` CLI options to `wp datamachine workspace read`
- Updated `workspace-read` ability input schema with offset/limit properties
- Updated `WorkspaceReader::read_file()` to support line range reading
- Returns `lines_read` and `offset` in response when line limiting is used

### Workspace Directory Permissions (#450, #451)
- Added `ensure_group_permissions()` method to set group ownership to `www-data` (or apache/nginx/http) and permissions to 775 when workspace directory is created
- This ensures coding agents running as non-root users can write to the workspace

## Testing

- PHP syntax validated
- PHPUnit tests pass (exit_code: 0)