### PR TITLE
feat: agent files CLI — multi-file operations and staleness detection

### DIFF
--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -24,10 +24,10 @@ WP_CLI::add_command( 'datamachine jobs', Commands\JobsCommand::class );
 WP_CLI::add_command( 'datamachine pipelines', Commands\PipelinesCommand::class );
 WP_CLI::add_command( 'datamachine posts', Commands\PostsCommand::class );
 WP_CLI::add_command( 'datamachine logs', Commands\LogsCommand::class );
-WP_CLI::add_command( 'datamachine memory', Commands\MemoryCommand::class );
-
-// Backwards-compatible alias: `wp datamachine agent` → MemoryCommand.
 WP_CLI::add_command( 'datamachine agent', Commands\MemoryCommand::class );
+
+// Backwards-compatible alias: `wp datamachine memory` → agent.
+WP_CLI::add_command( 'datamachine memory', Commands\MemoryCommand::class );
 WP_CLI::add_command( 'datamachine workspace', Commands\WorkspaceCommand::class );
 WP_CLI::add_command( 'datamachine batch', Commands\BatchCommand::class );
 

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -1,13 +1,18 @@
 <?php
 /**
- * WP-CLI Memory Command
+ * WP-CLI Agent Command
  *
- * Provides CLI access to the agent Memory Library — core memory files
- * (SOUL.md, MEMORY.md, USER.md) and daily memory (YYYY/MM/DD.md).
+ * Provides CLI access to the agent Memory Library — core agent files
+ * (SOUL.md, USER.md, MEMORY.md), MEMORY.md section operations, and
+ * daily memory (YYYY/MM/DD.md).
+ *
+ * Primary command: `wp datamachine agent`.
+ * Backwards-compatible alias: `wp datamachine memory`.
  *
  * @package DataMachine\Cli\Commands
  * @since 0.30.0 Originally as AgentCommand.
  * @since 0.32.0 Renamed to MemoryCommand, registered as `wp datamachine memory`.
+ * @since 0.33.0 Primary namespace changed to `wp datamachine agent`, `memory` kept as alias.
  */
 
 namespace DataMachine\Cli\Commands;
@@ -40,13 +45,13 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # Read full memory file
-	 *     wp datamachine memory read
+	 *     wp datamachine agent read
 	 *
 	 *     # Read a specific section
-	 *     wp datamachine memory read "Fleet"
+	 *     wp datamachine agent read "Fleet"
 	 *
 	 *     # Read lessons learned
-	 *     wp datamachine memory read "Lessons Learned"
+	 *     wp datamachine agent read "Lessons Learned"
 	 *
 	 * @subcommand read
 	 */
@@ -91,10 +96,10 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # List memory sections
-	 *     wp datamachine memory sections
+	 *     wp datamachine agent sections
 	 *
 	 *     # List as JSON
-	 *     wp datamachine memory sections --format=json
+	 *     wp datamachine agent sections --format=json
 	 *
 	 * @subcommand sections
 	 */
@@ -146,13 +151,13 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # Replace a section
-	 *     wp datamachine memory write "State" "- Data Machine v0.30.0 installed"
+	 *     wp datamachine agent write "State" "- Data Machine v0.30.0 installed"
 	 *
 	 *     # Append to a section
-	 *     wp datamachine memory write "Lessons Learned" "- Always check file permissions" --mode=append
+	 *     wp datamachine agent write "Lessons Learned" "- Always check file permissions" --mode=append
 	 *
 	 *     # Create a new section
-	 *     wp datamachine memory write "New Section" "Initial content"
+	 *     wp datamachine agent write "New Section" "Initial content"
 	 *
 	 * @subcommand write
 	 */
@@ -201,10 +206,10 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # Search all memory
-	 *     wp datamachine memory search "homeboy"
+	 *     wp datamachine agent search "homeboy"
 	 *
 	 *     # Search within a section
-	 *     wp datamachine memory search "docker" --section="Lessons Learned"
+	 *     wp datamachine agent search "docker" --section="Lessons Learned"
 	 *
 	 * @subcommand search
 	 */
@@ -260,34 +265,34 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # List all daily memory files
-	 *     wp datamachine memory daily list
+	 *     wp datamachine agent daily list
 	 *
 	 *     # Read today's daily memory
-	 *     wp datamachine memory daily read
+	 *     wp datamachine agent daily read
 	 *
 	 *     # Read a specific date
-	 *     wp datamachine memory daily read 2026-02-24
+	 *     wp datamachine agent daily read 2026-02-24
 	 *
 	 *     # Write to today's daily memory (replaces content)
-	 *     wp datamachine memory daily write "## Session notes"
+	 *     wp datamachine agent daily write "## Session notes"
 	 *
 	 *     # Append to a specific date
-	 *     wp datamachine memory daily append 2026-02-24 "- Additional discovery"
+	 *     wp datamachine agent daily append 2026-02-24 "- Additional discovery"
 	 *
 	 *     # Delete a daily file
-	 *     wp datamachine memory daily delete 2026-02-24
+	 *     wp datamachine agent daily delete 2026-02-24
 	 *
 	 *     # Search daily memory
-	 *     wp datamachine memory daily search "homeboy"
+	 *     wp datamachine agent daily search "homeboy"
 	 *
 	 *     # Search with date range
-	 *     wp datamachine memory daily search "deploy" --from=2026-02-01 --to=2026-02-28
+	 *     wp datamachine agent daily search "deploy" --from=2026-02-01 --to=2026-02-28
 	 *
 	 * @subcommand daily
 	 */
 	public function daily( array $args, array $assoc_args ): void {
 		if ( empty( $args ) ) {
-			WP_CLI::error( 'Usage: wp datamachine memory daily <list|read|write|append|delete> [date] [content]' );
+			WP_CLI::error( 'Usage: wp datamachine agent daily <list|read|write|append|delete> [date] [content]' );
 			return;
 		}
 
@@ -311,7 +316,7 @@ class MemoryCommand extends BaseCommand {
 			case 'delete':
 				$date = $args[1] ?? null;
 				if ( ! $date ) {
-					WP_CLI::error( 'Date is required for delete. Usage: wp datamachine memory daily delete 2026-02-24' );
+					WP_CLI::error( 'Date is required for delete. Usage: wp datamachine agent daily delete 2026-02-24' );
 					return;
 				}
 				$this->daily_delete( $daily, $date );
@@ -319,7 +324,7 @@ class MemoryCommand extends BaseCommand {
 			case 'search':
 				$search_query = $args[1] ?? null;
 				if ( ! $search_query ) {
-					WP_CLI::error( 'Search query is required. Usage: wp datamachine memory daily search "query" [--from=...] [--to=...]' );
+					WP_CLI::error( 'Search query is required. Usage: wp datamachine agent daily search "query" [--from=...] [--to=...]' );
 					return;
 				}
 				$this->daily_search( $daily, $search_query, $assoc_args );
@@ -390,7 +395,7 @@ class MemoryCommand extends BaseCommand {
 	private function daily_write( DailyMemory $daily, array $args ): void {
 		// write [date] <content> — date defaults to today.
 		if ( count( $args ) < 2 ) {
-			WP_CLI::error( 'Content is required. Usage: wp datamachine memory daily write [date] <content>' );
+			WP_CLI::error( 'Content is required. Usage: wp datamachine agent daily write [date] <content>' );
 			return;
 		}
 
@@ -425,7 +430,7 @@ class MemoryCommand extends BaseCommand {
 	private function daily_append( DailyMemory $daily, array $args ): void {
 		// append [date] <content> — date defaults to today.
 		if ( count( $args ) < 2 ) {
-			WP_CLI::error( 'Content is required. Usage: wp datamachine memory daily append [date] <content>' );
+			WP_CLI::error( 'Content is required. Usage: wp datamachine agent daily append [date] <content>' );
 			return;
 		}
 

--- a/skills/data-machine/SKILL.md
+++ b/skills/data-machine/SKILL.md
@@ -57,9 +57,9 @@ GET/PUT/DELETE  /datamachine/v1/files/agent/{filename}
 Date-based logs at `YYYY/MM/DD.md` — useful for per-run notes, progress tracking.
 
 ```bash
-wp datamachine memory daily list
-wp datamachine memory daily read [<date>]
-wp datamachine memory daily append <date> --content="..."
+wp datamachine agent daily list
+wp datamachine agent daily read [<date>]
+wp datamachine agent daily append <date> --content="..."
 ```
 
 ---
@@ -138,19 +138,23 @@ wp datamachine jobs retry <id> [--force]
 wp datamachine jobs recover-stuck [--dry-run] [--flow=<id>]
 ```
 
-### Memory
+### Agent
 
 ```bash
-wp datamachine memory read <filename>
-wp datamachine memory write <filename> --content="..."
-wp datamachine memory search <query>
-wp datamachine memory sections <filename>
+wp datamachine agent read <filename>
+wp datamachine agent write <filename> --content="..."
+wp datamachine agent search <query>
+wp datamachine agent sections <filename>
+wp datamachine agent files list
+wp datamachine agent files read <filename>
+wp datamachine agent files write <filename>       # from stdin
+wp datamachine agent files check [--days=<n>]
 # Daily: list, read, write, append, delete, search
-wp datamachine memory daily list [--limit=<n>]
-wp datamachine memory daily append <date> --content="..."
+wp datamachine agent daily list [--limit=<n>]
+wp datamachine agent daily append <date> --content="..."
 ```
 
-Alias: `wp datamachine agent` = `wp datamachine memory`
+Alias: `wp datamachine memory` = `wp datamachine agent`
 
 ### Posts
 


### PR DESCRIPTION
## Summary

Adds a `files` subcommand to `wp datamachine agent` (and `wp datamachine memory`) for managing all agent memory files, not just MEMORY.md.

Resolves #444.

## New Commands

```bash
# List all agent files with size, modified time, and age
wp datamachine agent files list

# Read any agent file
wp datamachine agent files read SOUL.md

# Write to any agent file from stdin
cat updated-soul.md | wp datamachine agent files write SOUL.md

# Staleness report (default 7 days)
wp datamachine agent files check

# Custom staleness threshold
wp datamachine agent files check --days=14
```

## Example Output

```
$ wp datamachine agent files list
file        size    modified             age
MEMORY.md   11 KB   2026-02-27 10:17:19  0d
SOUL.md     2 KB    2026-02-25 01:40:40  2d
USER.md     2 KB    2026-02-25 01:28:32  2d

$ wp datamachine agent files check --days=1
file        modified             age  status
MEMORY.md   2026-02-27 10:17:19  0d   OK
SOUL.md     2026-02-25 01:40:40  2d   STALE
USER.md     2026-02-25 01:28:32  2d   STALE
Warning: 2 file(s) not updated in 1+ days. Review for accuracy.
```

## Testing

- PHP syntax validated
- PHPUnit tests pass
- Manually tested all four subcommands on chubes.net