### PR TITLE
feat: GitHub integration — fetch handler, abilities, CLI, chat tools

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -148,6 +148,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/Content/GetPostBlocksAbility.php';
 	require_once __DIR__ . '/inc/Abilities/Content/EditPostBlocksAbility.php';
 	require_once __DIR__ . '/inc/Abilities/Content/ReplacePostBlocksAbility.php';
+	require_once __DIR__ . '/inc/Abilities/Fetch/GitHubAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Fetch/FetchFilesAbility.php';
 	require_once __DIR__ . '/inc/Abilities/Fetch/FetchRssAbility.php';
 	require_once __DIR__ . '/inc/Abilities/Fetch/FetchWordPressApiAbility.php';
@@ -191,6 +192,7 @@ function datamachine_run_datamachine_plugin() {
 		new \DataMachine\Abilities\Content\GetPostBlocksAbility();
 		new \DataMachine\Abilities\Content\EditPostBlocksAbility();
 		new \DataMachine\Abilities\Content\ReplacePostBlocksAbility();
+		new \DataMachine\Abilities\Fetch\GitHubAbilities();
 		new \DataMachine\Abilities\Fetch\FetchFilesAbility();
 		new \DataMachine\Abilities\Fetch\FetchRssAbility();
 		new \DataMachine\Abilities\Fetch\FetchWordPressApiAbility();
@@ -265,6 +267,7 @@ function datamachine_load_handlers() {
 	new \DataMachine\Core\Steps\Fetch\Handlers\WordPressMedia\WordPressMedia();
 	new \DataMachine\Core\Steps\Fetch\Handlers\Rss\Rss();
 	new \DataMachine\Core\Steps\Fetch\Handlers\Files\Files();
+	new \DataMachine\Core\Steps\Fetch\Handlers\GitHub\GitHub();
 
 	// Update Handlers
 	new \DataMachine\Core\Steps\Update\Handlers\WordPress\WordPress();

--- a/inc/Abilities/Fetch/GitHubAbilities.php
+++ b/inc/Abilities/Fetch/GitHubAbilities.php
@@ -1,0 +1,862 @@
+<?php
+/**
+ * GitHub Abilities
+ *
+ * Core business logic for GitHub API interactions: listing issues, PRs,
+ * repos, and managing issues (update, close, comment). All GitHub
+ * operations — CLI, REST, chat tools, fetch handler — route through here.
+ *
+ * Auth: Uses the github_pat stored in PluginSettings.
+ *
+ * @package DataMachine\Abilities\Fetch
+ * @since 0.33.0
+ */
+
+namespace DataMachine\Abilities\Fetch;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\PluginSettings;
+
+defined( 'ABSPATH' ) || exit;
+
+class GitHubAbilities {
+
+	private static bool $registered = false;
+
+	/**
+	 * GitHub API base URL.
+	 *
+	 * @var string
+	 */
+	const API_BASE = 'https://api.github.com';
+
+	/**
+	 * Default per_page for API requests.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_PER_PAGE = 30;
+
+	/**
+	 * Maximum per_page for API requests.
+	 *
+	 * @var int
+	 */
+	const MAX_PER_PAGE = 100;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+		if ( self::$registered ) {
+			return;
+		}
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/list-github-issues',
+				array(
+					'label'               => 'List GitHub Issues',
+					'description'         => 'List issues from a GitHub repository with optional filters',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo' ),
+						'properties' => array(
+							'repo'     => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'state'    => array(
+								'type'        => 'string',
+								'description' => 'Issue state: open, closed, all (default: open).',
+							),
+							'labels'   => array(
+								'type'        => 'string',
+								'description' => 'Comma-separated list of label names to filter by.',
+							),
+							'assignee' => array(
+								'type'        => 'string',
+								'description' => 'Filter by assignee username.',
+							),
+							'since'    => array(
+								'type'        => 'string',
+								'description' => 'ISO 8601 timestamp to filter issues updated after this date.',
+							),
+							'per_page' => array(
+								'type'        => 'integer',
+								'description' => 'Results per page (default: 30, max: 100).',
+							),
+							'page'     => array(
+								'type'        => 'integer',
+								'description' => 'Page number for pagination (default: 1).',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'issues'  => array( 'type' => 'array' ),
+							'count'   => array( 'type' => 'integer' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'listIssues' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/get-github-issue',
+				array(
+					'label'               => 'Get GitHub Issue',
+					'description'         => 'Get a single GitHub issue with full details',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'issue_number' ),
+						'properties' => array(
+							'repo'         => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'issue_number' => array(
+								'type'        => 'integer',
+								'description' => 'Issue number.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'issue'   => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'getIssue' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/update-github-issue',
+				array(
+					'label'               => 'Update GitHub Issue',
+					'description'         => 'Update a GitHub issue (title, body, labels, assignees, state)',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'issue_number' ),
+						'properties' => array(
+							'repo'         => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'issue_number' => array(
+								'type'        => 'integer',
+								'description' => 'Issue number.',
+							),
+							'title'        => array(
+								'type'        => 'string',
+								'description' => 'New issue title.',
+							),
+							'body'         => array(
+								'type'        => 'string',
+								'description' => 'New issue body.',
+							),
+							'state'        => array(
+								'type'        => 'string',
+								'description' => 'Issue state: open or closed.',
+							),
+							'labels'       => array(
+								'type'        => 'array',
+								'description' => 'Labels to set on the issue (replaces existing).',
+							),
+							'assignees'    => array(
+								'type'        => 'array',
+								'description' => 'Assignees to set on the issue (replaces existing).',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'issue'   => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'updateIssue' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/comment-github-issue',
+				array(
+					'label'               => 'Comment on GitHub Issue',
+					'description'         => 'Add a comment to a GitHub issue',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo', 'issue_number', 'body' ),
+						'properties' => array(
+							'repo'         => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'issue_number' => array(
+								'type'        => 'integer',
+								'description' => 'Issue number.',
+							),
+							'body'         => array(
+								'type'        => 'string',
+								'description' => 'Comment body (supports GitHub Markdown).',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'comment' => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'commentOnIssue' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/list-github-pulls',
+				array(
+					'label'               => 'List GitHub Pull Requests',
+					'description'         => 'List pull requests from a GitHub repository',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'repo' ),
+						'properties' => array(
+							'repo'     => array(
+								'type'        => 'string',
+								'description' => 'Repository in owner/repo format.',
+							),
+							'state'    => array(
+								'type'        => 'string',
+								'description' => 'PR state: open, closed, all (default: open).',
+							),
+							'per_page' => array(
+								'type'        => 'integer',
+								'description' => 'Results per page (default: 30, max: 100).',
+							),
+							'page'     => array(
+								'type'        => 'integer',
+								'description' => 'Page number (default: 1).',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'pulls'   => array( 'type' => 'array' ),
+							'count'   => array( 'type' => 'integer' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'listPulls' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/list-github-repos',
+				array(
+					'label'               => 'List GitHub Repositories',
+					'description'         => 'List repositories for a user or organization',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'owner' ),
+						'properties' => array(
+							'owner'    => array(
+								'type'        => 'string',
+								'description' => 'GitHub user or organization name.',
+							),
+							'type'     => array(
+								'type'        => 'string',
+								'description' => 'For orgs: all, public, private, forks, sources, member (default: all). For users: all, owner, member (default: owner).',
+							),
+							'sort'     => array(
+								'type'        => 'string',
+								'description' => 'Sort by: created, updated, pushed, full_name (default: updated).',
+							),
+							'per_page' => array(
+								'type'        => 'integer',
+								'description' => 'Results per page (default: 30, max: 100).',
+							),
+							'page'     => array(
+								'type'        => 'integer',
+								'description' => 'Page number (default: 1).',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'repos'   => array( 'type' => 'array' ),
+							'count'   => array( 'type' => 'integer' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'listRepos' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Ability Callbacks
+	// -------------------------------------------------------------------------
+
+	/**
+	 * List issues from a GitHub repository.
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	public static function listIssues( array $input ): array {
+		$repo = sanitize_text_field( $input['repo'] ?? '' );
+		if ( empty( $repo ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Repository is required (owner/repo format).',
+			);
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$query_params = array(
+			'state'    => sanitize_text_field( $input['state'] ?? 'open' ),
+			'per_page' => self::clampPerPage( $input['per_page'] ?? self::DEFAULT_PER_PAGE ),
+			'page'     => max( 1, (int) ( $input['page'] ?? 1 ) ),
+		);
+
+		if ( ! empty( $input['labels'] ) ) {
+			$query_params['labels'] = sanitize_text_field( $input['labels'] );
+		}
+		if ( ! empty( $input['assignee'] ) ) {
+			$query_params['assignee'] = sanitize_text_field( $input['assignee'] );
+		}
+		if ( ! empty( $input['since'] ) ) {
+			$query_params['since'] = sanitize_text_field( $input['since'] );
+		}
+
+		$url      = sprintf( '%s/repos/%s/issues', self::API_BASE, $repo );
+		$response = self::apiGet( $url, $query_params, $pat );
+
+		if ( ! $response['success'] ) {
+			return $response;
+		}
+
+		// GitHub issues API includes PRs — filter them out.
+		$issues = array_filter( $response['data'], function ( $item ) {
+			return empty( $item['pull_request'] );
+		} );
+		$issues = array_values( $issues );
+
+		$normalized = array_map( array( self::class, 'normalizeIssue' ), $issues );
+
+		return array(
+			'success' => true,
+			'issues'  => $normalized,
+			'count'   => count( $normalized ),
+		);
+	}
+
+	/**
+	 * Get a single GitHub issue.
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	public static function getIssue( array $input ): array {
+		$repo         = sanitize_text_field( $input['repo'] ?? '' );
+		$issue_number = (int) ( $input['issue_number'] ?? 0 );
+
+		if ( empty( $repo ) || $issue_number <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'Repository (owner/repo) and issue_number are required.',
+			);
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$url      = sprintf( '%s/repos/%s/issues/%d', self::API_BASE, $repo, $issue_number );
+		$response = self::apiGet( $url, array(), $pat );
+
+		if ( ! $response['success'] ) {
+			return $response;
+		}
+
+		return array(
+			'success' => true,
+			'issue'   => self::normalizeIssue( $response['data'] ),
+		);
+	}
+
+	/**
+	 * Update a GitHub issue.
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	public static function updateIssue( array $input ): array {
+		$repo         = sanitize_text_field( $input['repo'] ?? '' );
+		$issue_number = (int) ( $input['issue_number'] ?? 0 );
+
+		if ( empty( $repo ) || $issue_number <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'Repository (owner/repo) and issue_number are required.',
+			);
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$body = array();
+		if ( isset( $input['title'] ) ) {
+			$body['title'] = $input['title'];
+		}
+		if ( isset( $input['body'] ) ) {
+			$body['body'] = $input['body'];
+		}
+		if ( isset( $input['state'] ) ) {
+			$body['state'] = $input['state'];
+		}
+		if ( isset( $input['labels'] ) && is_array( $input['labels'] ) ) {
+			$body['labels'] = $input['labels'];
+		}
+		if ( isset( $input['assignees'] ) && is_array( $input['assignees'] ) ) {
+			$body['assignees'] = $input['assignees'];
+		}
+
+		if ( empty( $body ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No fields to update. Provide title, body, state, labels, or assignees.',
+			);
+		}
+
+		$url      = sprintf( '%s/repos/%s/issues/%d', self::API_BASE, $repo, $issue_number );
+		$response = self::apiRequest( 'PATCH', $url, $body, $pat );
+
+		if ( ! $response['success'] ) {
+			return $response;
+		}
+
+		return array(
+			'success' => true,
+			'issue'   => self::normalizeIssue( $response['data'] ),
+			'message' => sprintf( 'Issue #%d updated.', $issue_number ),
+		);
+	}
+
+	/**
+	 * Add a comment to a GitHub issue.
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	public static function commentOnIssue( array $input ): array {
+		$repo         = sanitize_text_field( $input['repo'] ?? '' );
+		$issue_number = (int) ( $input['issue_number'] ?? 0 );
+		$body         = $input['body'] ?? '';
+
+		if ( empty( $repo ) || $issue_number <= 0 || empty( $body ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Repository, issue_number, and body are required.',
+			);
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$url      = sprintf( '%s/repos/%s/issues/%d/comments', self::API_BASE, $repo, $issue_number );
+		$response = self::apiRequest( 'POST', $url, array( 'body' => $body ), $pat );
+
+		if ( ! $response['success'] ) {
+			return $response;
+		}
+
+		return array(
+			'success' => true,
+			'comment' => array(
+				'id'         => $response['data']['id'] ?? 0,
+				'html_url'   => $response['data']['html_url'] ?? '',
+				'created_at' => $response['data']['created_at'] ?? '',
+			),
+			'message' => sprintf( 'Comment added to issue #%d.', $issue_number ),
+		);
+	}
+
+	/**
+	 * List pull requests from a repository.
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	public static function listPulls( array $input ): array {
+		$repo = sanitize_text_field( $input['repo'] ?? '' );
+		if ( empty( $repo ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Repository is required (owner/repo format).',
+			);
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$query_params = array(
+			'state'    => sanitize_text_field( $input['state'] ?? 'open' ),
+			'per_page' => self::clampPerPage( $input['per_page'] ?? self::DEFAULT_PER_PAGE ),
+			'page'     => max( 1, (int) ( $input['page'] ?? 1 ) ),
+		);
+
+		$url      = sprintf( '%s/repos/%s/pulls', self::API_BASE, $repo );
+		$response = self::apiGet( $url, $query_params, $pat );
+
+		if ( ! $response['success'] ) {
+			return $response;
+		}
+
+		$normalized = array_map( array( self::class, 'normalizePull' ), $response['data'] );
+
+		return array(
+			'success' => true,
+			'pulls'   => $normalized,
+			'count'   => count( $normalized ),
+		);
+	}
+
+	/**
+	 * List repositories for a user or organization.
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	public static function listRepos( array $input ): array {
+		$owner = sanitize_text_field( $input['owner'] ?? '' );
+		if ( empty( $owner ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Owner (user or org) is required.',
+			);
+		}
+
+		$pat = self::getPat();
+		if ( empty( $pat ) ) {
+			return self::patError();
+		}
+
+		$query_params = array(
+			'per_page' => self::clampPerPage( $input['per_page'] ?? self::DEFAULT_PER_PAGE ),
+			'page'     => max( 1, (int) ( $input['page'] ?? 1 ) ),
+			'sort'     => sanitize_text_field( $input['sort'] ?? 'updated' ),
+		);
+
+		if ( ! empty( $input['type'] ) ) {
+			$query_params['type'] = sanitize_text_field( $input['type'] );
+		}
+
+		// Try org endpoint first, fall back to user.
+		$url      = sprintf( '%s/orgs/%s/repos', self::API_BASE, $owner );
+		$response = self::apiGet( $url, $query_params, $pat );
+
+		if ( ! $response['success'] ) {
+			// Not an org — try user endpoint.
+			$url      = sprintf( '%s/users/%s/repos', self::API_BASE, $owner );
+			$response = self::apiGet( $url, $query_params, $pat );
+
+			if ( ! $response['success'] ) {
+				return $response;
+			}
+		}
+
+		$normalized = array_map( array( self::class, 'normalizeRepo' ), $response['data'] );
+
+		return array(
+			'success' => true,
+			'repos'   => $normalized,
+			'count'   => count( $normalized ),
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// HTTP Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Make a GET request to the GitHub API.
+	 *
+	 * @param string $url          API endpoint URL.
+	 * @param array  $query_params Query parameters.
+	 * @param string $pat          Personal Access Token.
+	 * @return array
+	 */
+	public static function apiGet( string $url, array $query_params, string $pat ): array {
+		if ( ! empty( $query_params ) ) {
+			$url = add_query_arg( $query_params, $url );
+		}
+
+		$response = wp_remote_get(
+			$url,
+			array(
+				'headers' => self::getHeaders( $pat ),
+				'timeout' => 30,
+			)
+		);
+
+		return self::parseResponse( $response );
+	}
+
+	/**
+	 * Make a POST/PATCH/DELETE request to the GitHub API.
+	 *
+	 * @param string $method HTTP method.
+	 * @param string $url    API endpoint URL.
+	 * @param array  $body   Request body.
+	 * @param string $pat    Personal Access Token.
+	 * @return array
+	 */
+	public static function apiRequest( string $method, string $url, array $body, string $pat ): array {
+		$response = wp_remote_request(
+			$url,
+			array(
+				'method'  => $method,
+				'headers' => self::getHeaders( $pat ),
+				'body'    => wp_json_encode( $body ),
+				'timeout' => 30,
+			)
+		);
+
+		return self::parseResponse( $response );
+	}
+
+	/**
+	 * Parse a GitHub API response.
+	 *
+	 * @param array|\WP_Error $response WordPress HTTP response.
+	 * @return array Normalized result with 'success' and 'data' or 'error'.
+	 */
+	private static function parseResponse( $response ): array {
+		if ( is_wp_error( $response ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'GitHub API request failed: ' . $response->get_error_message(),
+			);
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( $status_code >= 400 ) {
+			$message = $body['message'] ?? 'Unknown error';
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'GitHub API error (%d): %s', $status_code, $message ),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => $body,
+		);
+	}
+
+	/**
+	 * Get standard GitHub API headers.
+	 *
+	 * @param string $pat Personal Access Token.
+	 * @return array
+	 */
+	private static function getHeaders( string $pat ): array {
+		return array(
+			'Authorization' => 'token ' . $pat,
+			'Accept'        => 'application/vnd.github.v3+json',
+			'User-Agent'    => 'DataMachine',
+			'Content-Type'  => 'application/json',
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Normalizers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Normalize a GitHub issue to a consistent shape.
+	 *
+	 * @param array $issue Raw GitHub API issue data.
+	 * @return array
+	 */
+	public static function normalizeIssue( array $issue ): array {
+		return array(
+			'number'     => $issue['number'] ?? 0,
+			'title'      => $issue['title'] ?? '',
+			'state'      => $issue['state'] ?? '',
+			'body'       => $issue['body'] ?? '',
+			'html_url'   => $issue['html_url'] ?? '',
+			'user'       => $issue['user']['login'] ?? '',
+			'labels'     => array_map( function ( $label ) {
+				return $label['name'] ?? '';
+			}, $issue['labels'] ?? array() ),
+			'assignees'  => array_map( function ( $a ) {
+				return $a['login'] ?? '';
+			}, $issue['assignees'] ?? array() ),
+			'comments'   => $issue['comments'] ?? 0,
+			'created_at' => $issue['created_at'] ?? '',
+			'updated_at' => $issue['updated_at'] ?? '',
+			'closed_at'  => $issue['closed_at'] ?? '',
+		);
+	}
+
+	/**
+	 * Normalize a GitHub pull request.
+	 *
+	 * @param array $pr Raw GitHub API PR data.
+	 * @return array
+	 */
+	public static function normalizePull( array $pr ): array {
+		return array(
+			'number'     => $pr['number'] ?? 0,
+			'title'      => $pr['title'] ?? '',
+			'state'      => $pr['state'] ?? '',
+			'body'       => $pr['body'] ?? '',
+			'html_url'   => $pr['html_url'] ?? '',
+			'user'       => $pr['user']['login'] ?? '',
+			'head'       => $pr['head']['ref'] ?? '',
+			'base'       => $pr['base']['ref'] ?? '',
+			'draft'      => $pr['draft'] ?? false,
+			'merged'     => ! empty( $pr['merged_at'] ),
+			'labels'     => array_map( function ( $label ) {
+				return $label['name'] ?? '';
+			}, $pr['labels'] ?? array() ),
+			'created_at' => $pr['created_at'] ?? '',
+			'updated_at' => $pr['updated_at'] ?? '',
+			'closed_at'  => $pr['closed_at'] ?? '',
+			'merged_at'  => $pr['merged_at'] ?? '',
+		);
+	}
+
+	/**
+	 * Normalize a GitHub repository.
+	 *
+	 * @param array $repo Raw GitHub API repo data.
+	 * @return array
+	 */
+	public static function normalizeRepo( array $repo ): array {
+		return array(
+			'full_name'        => $repo['full_name'] ?? '',
+			'description'      => $repo['description'] ?? '',
+			'html_url'         => $repo['html_url'] ?? '',
+			'private'          => $repo['private'] ?? false,
+			'fork'             => $repo['fork'] ?? false,
+			'language'         => $repo['language'] ?? '',
+			'stargazers_count' => $repo['stargazers_count'] ?? 0,
+			'open_issues'      => $repo['open_issues_count'] ?? 0,
+			'default_branch'   => $repo['default_branch'] ?? 'main',
+			'pushed_at'        => $repo['pushed_at'] ?? '',
+			'updated_at'       => $repo['updated_at'] ?? '',
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Utilities
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Get the GitHub PAT from settings.
+	 *
+	 * @return string
+	 */
+	public static function getPat(): string {
+		return trim( PluginSettings::get( 'github_pat', '' ) );
+	}
+
+	/**
+	 * Check if GitHub integration is configured.
+	 *
+	 * @return bool
+	 */
+	public static function isConfigured(): bool {
+		return ! empty( self::getPat() );
+	}
+
+	/**
+	 * Get the default repo from settings.
+	 *
+	 * @return string
+	 */
+	public static function getDefaultRepo(): string {
+		return trim( PluginSettings::get( 'github_default_repo', '' ) );
+	}
+
+	/**
+	 * Return standard PAT-not-configured error.
+	 *
+	 * @return array
+	 */
+	private static function patError(): array {
+		return array(
+			'success' => false,
+			'error'   => 'GitHub Personal Access Token not configured. Set github_pat in Data Machine settings.',
+		);
+	}
+
+	/**
+	 * Clamp per_page to valid range.
+	 *
+	 * @param int|string $per_page Requested per_page.
+	 * @return int Clamped value.
+	 */
+	private static function clampPerPage( $per_page ): int {
+		return max( 1, min( self::MAX_PER_PAGE, (int) $per_page ) );
+	}
+}

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -31,6 +31,7 @@ WP_CLI::add_command( 'datamachine memory', Commands\MemoryCommand::class );
 WP_CLI::add_command( 'datamachine workspace', Commands\WorkspaceCommand::class );
 WP_CLI::add_command( 'datamachine batch', Commands\BatchCommand::class );
 WP_CLI::add_command( 'datamachine image', Commands\ImageCommand::class );
+WP_CLI::add_command( 'datamachine github', Commands\GitHubCommand::class );
 
 // Aliases for AI agent compatibility (singular/plural variants).
 WP_CLI::add_command( 'datamachine setting', Commands\SettingsCommand::class );

--- a/inc/Cli/Commands/GitHubCommand.php
+++ b/inc/Cli/Commands/GitHubCommand.php
@@ -1,0 +1,546 @@
+<?php
+/**
+ * WP-CLI GitHub Command
+ *
+ * Provides CLI access to GitHub integration: listing issues, PRs, repos,
+ * and managing issues (view, close, comment). Wraps GitHubAbilities.
+ *
+ * @package DataMachine\Cli\Commands
+ * @since 0.33.0
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Abilities\Fetch\GitHubAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class GitHubCommand extends BaseCommand {
+
+	/**
+	 * List issues from a GitHub repository.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--repo=<repo>]
+	 * : Repository in owner/repo format. Falls back to default repo in settings.
+	 *
+	 * [--state=<state>]
+	 * : Issue state: open, closed, all (default: open).
+	 *
+	 * [--labels=<labels>]
+	 * : Comma-separated label names to filter by.
+	 *
+	 * [--assignee=<assignee>]
+	 * : Filter by assignee username.
+	 *
+	 * [--per_page=<count>]
+	 * : Results per page (default: 30, max: 100).
+	 *
+	 * [--page=<page>]
+	 * : Page number (default: 1).
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # List open issues for a repo
+	 *     $ wp datamachine github issues --repo=Extra-Chill/data-machine
+	 *
+	 *     # List issues with specific labels
+	 *     $ wp datamachine github issues --repo=Extra-Chill/data-machine --labels=enhancement
+	 *
+	 *     # List closed issues
+	 *     $ wp datamachine github issues --repo=Extra-Chill/data-machine --state=closed --per_page=10
+	 *
+	 * @subcommand issues
+	 */
+	public function issues( array $args, array $assoc_args ): void {
+		$this->requireConfig();
+
+		$input = $this->buildInput( $assoc_args, array( 'repo', 'state', 'labels', 'assignee', 'per_page', 'page' ) );
+		$input = $this->resolveRepo( $input );
+
+		$result = GitHubAbilities::listIssues( $input );
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to list issues.' );
+			return;
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( \wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$issues = $result['issues'] ?? array();
+
+		if ( empty( $issues ) ) {
+			WP_CLI::log( 'No issues found.' );
+			return;
+		}
+
+		$items = array();
+		foreach ( $issues as $issue ) {
+			$items[] = array(
+				'number'     => $issue['number'],
+				'state'      => $issue['state'],
+				'title'      => mb_substr( $issue['title'], 0, 60 ),
+				'labels'     => implode( ', ', $issue['labels'] ?? array() ),
+				'assignees'  => implode( ', ', $issue['assignees'] ?? array() ),
+				'comments'   => $issue['comments'],
+				'created_at' => $this->shortDate( $issue['created_at'] ),
+			);
+		}
+
+		$this->format_items( $items, array( 'number', 'state', 'title', 'labels', 'comments', 'created_at' ), $assoc_args );
+		WP_CLI::log( sprintf( '%d issue(s) returned.', count( $items ) ) );
+	}
+
+	/**
+	 * View a single GitHub issue.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <issue_number>
+	 * : Issue number.
+	 *
+	 * [--repo=<repo>]
+	 * : Repository in owner/repo format.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp datamachine github view 413 --repo=Extra-Chill/data-machine
+	 *
+	 * @subcommand view
+	 */
+	public function view( array $args, array $assoc_args ): void {
+		$this->requireConfig();
+
+		$issue_number = \absint( $args[0] ?? 0 );
+		if ( $issue_number <= 0 ) {
+			WP_CLI::error( 'Please provide a valid issue number.' );
+			return;
+		}
+
+		$input         = array( 'issue_number' => $issue_number );
+		$input['repo'] = $assoc_args['repo'] ?? '';
+		$input         = $this->resolveRepo( $input );
+
+		$result = GitHubAbilities::getIssue( $input );
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to fetch issue.' );
+			return;
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( \wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$issue = $result['issue'];
+
+		WP_CLI::log( WP_CLI::colorize( sprintf( '%%G#%d%%n %s', $issue['number'], $issue['title'] ) ) );
+		WP_CLI::log( sprintf( 'State: %s | Author: %s | Comments: %d', $issue['state'], $issue['user'], $issue['comments'] ) );
+
+		if ( ! empty( $issue['labels'] ) ) {
+			WP_CLI::log( 'Labels: ' . implode( ', ', $issue['labels'] ) );
+		}
+		if ( ! empty( $issue['assignees'] ) ) {
+			WP_CLI::log( 'Assignees: ' . implode( ', ', $issue['assignees'] ) );
+		}
+
+		WP_CLI::log( 'Created: ' . $issue['created_at'] );
+		WP_CLI::log( 'URL: ' . $issue['html_url'] );
+
+		if ( ! empty( $issue['body'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( $issue['body'] );
+		}
+	}
+
+	/**
+	 * Close a GitHub issue.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <issue_number>
+	 * : Issue number to close.
+	 *
+	 * [--repo=<repo>]
+	 * : Repository in owner/repo format.
+	 *
+	 * [--comment=<comment>]
+	 * : Optional comment to add before closing.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp datamachine github close 315 --repo=Extra-Chill/data-machine
+	 *
+	 *     $ wp datamachine github close 315 --repo=Extra-Chill/data-machine --comment="Fixed in v0.33.0"
+	 *
+	 * @subcommand close
+	 */
+	public function close_issue( array $args, array $assoc_args ): void {
+		$this->requireConfig();
+
+		$issue_number = \absint( $args[0] ?? 0 );
+		if ( $issue_number <= 0 ) {
+			WP_CLI::error( 'Please provide a valid issue number.' );
+			return;
+		}
+
+		$input = $this->resolveRepo( array(
+			'repo'         => $assoc_args['repo'] ?? '',
+			'issue_number' => $issue_number,
+		) );
+
+		// Add comment first if provided.
+		if ( ! empty( $assoc_args['comment'] ) ) {
+			$comment_result = GitHubAbilities::commentOnIssue( array(
+				'repo'         => $input['repo'],
+				'issue_number' => $issue_number,
+				'body'         => $assoc_args['comment'],
+			) );
+
+			if ( empty( $comment_result['success'] ) ) {
+				WP_CLI::warning( 'Failed to add comment: ' . ( $comment_result['error'] ?? 'Unknown error' ) );
+			}
+		}
+
+		$input['state'] = 'closed';
+		$result         = GitHubAbilities::updateIssue( $input );
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to close issue.' );
+			return;
+		}
+
+		WP_CLI::success( sprintf( 'Issue #%d closed.', $issue_number ) );
+	}
+
+	/**
+	 * Comment on a GitHub issue.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <issue_number>
+	 * : Issue number to comment on.
+	 *
+	 * <body>
+	 * : Comment body (supports Markdown).
+	 *
+	 * [--repo=<repo>]
+	 * : Repository in owner/repo format.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp datamachine github comment 315 "Investigating this now."
+	 *
+	 * @subcommand comment
+	 */
+	public function comment( array $args, array $assoc_args ): void {
+		$this->requireConfig();
+
+		$issue_number = \absint( $args[0] ?? 0 );
+		$body         = $args[1] ?? '';
+
+		if ( $issue_number <= 0 || empty( $body ) ) {
+			WP_CLI::error( 'Required: <issue_number> <body>' );
+			return;
+		}
+
+		$input = $this->resolveRepo( array(
+			'repo'         => $assoc_args['repo'] ?? '',
+			'issue_number' => $issue_number,
+			'body'         => $body,
+		) );
+
+		$result = GitHubAbilities::commentOnIssue( $input );
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to add comment.' );
+			return;
+		}
+
+		WP_CLI::success( sprintf( 'Comment added to issue #%d.', $issue_number ) );
+	}
+
+	/**
+	 * List pull requests from a repository.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--repo=<repo>]
+	 * : Repository in owner/repo format.
+	 *
+	 * [--state=<state>]
+	 * : PR state: open, closed, all (default: open).
+	 *
+	 * [--per_page=<count>]
+	 * : Results per page (default: 30, max: 100).
+	 *
+	 * [--page=<page>]
+	 * : Page number (default: 1).
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp datamachine github pulls --repo=Extra-Chill/data-machine
+	 *
+	 * @subcommand pulls
+	 */
+	public function pulls( array $args, array $assoc_args ): void {
+		$this->requireConfig();
+
+		$input = $this->buildInput( $assoc_args, array( 'repo', 'state', 'per_page', 'page' ) );
+		$input = $this->resolveRepo( $input );
+
+		$result = GitHubAbilities::listPulls( $input );
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to list pull requests.' );
+			return;
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( \wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$pulls = $result['pulls'] ?? array();
+
+		if ( empty( $pulls ) ) {
+			WP_CLI::log( 'No pull requests found.' );
+			return;
+		}
+
+		$items = array();
+		foreach ( $pulls as $pr ) {
+			$status = $pr['state'];
+			if ( ! empty( $pr['merged'] ) ) {
+				$status = 'merged';
+			} elseif ( ! empty( $pr['draft'] ) ) {
+				$status = 'draft';
+			}
+
+			$items[] = array(
+				'number'     => $pr['number'],
+				'status'     => $status,
+				'title'      => mb_substr( $pr['title'], 0, 60 ),
+				'branch'     => $pr['head'] ?? '',
+				'user'       => $pr['user'] ?? '',
+				'created_at' => $this->shortDate( $pr['created_at'] ),
+			);
+		}
+
+		$this->format_items( $items, array( 'number', 'status', 'title', 'branch', 'user', 'created_at' ), $assoc_args );
+		WP_CLI::log( sprintf( '%d PR(s) returned.', count( $items ) ) );
+	}
+
+	/**
+	 * List repositories for a user or organization.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <owner>
+	 * : GitHub user or organization name.
+	 *
+	 * [--sort=<sort>]
+	 * : Sort by: created, updated, pushed, full_name (default: updated).
+	 *
+	 * [--per_page=<count>]
+	 * : Results per page (default: 30, max: 100).
+	 *
+	 * [--page=<page>]
+	 * : Page number (default: 1).
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp datamachine github repos Extra-Chill
+	 *
+	 *     $ wp datamachine github repos chubes4 --sort=pushed
+	 *
+	 * @subcommand repos
+	 */
+	public function repos( array $args, array $assoc_args ): void {
+		$this->requireConfig();
+
+		$owner = $args[0] ?? '';
+		if ( empty( $owner ) ) {
+			WP_CLI::error( 'Required: <owner> (GitHub user or organization name).' );
+			return;
+		}
+
+		$input          = $this->buildInput( $assoc_args, array( 'sort', 'per_page', 'page' ) );
+		$input['owner'] = $owner;
+
+		$result = GitHubAbilities::listRepos( $input );
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to list repositories.' );
+			return;
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( \wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$repos = $result['repos'] ?? array();
+
+		if ( empty( $repos ) ) {
+			WP_CLI::log( 'No repositories found.' );
+			return;
+		}
+
+		$items = array();
+		foreach ( $repos as $repo ) {
+			$items[] = array(
+				'repo'        => $repo['full_name'],
+				'language'    => $repo['language'] ?? '',
+				'stars'       => $repo['stargazers_count'],
+				'open_issues' => $repo['open_issues'],
+				'private'     => $repo['private'] ? 'yes' : 'no',
+				'last_push'   => $this->shortDate( $repo['pushed_at'] ),
+			);
+		}
+
+		$this->format_items( $items, array( 'repo', 'language', 'stars', 'open_issues', 'private', 'last_push' ), $assoc_args );
+		WP_CLI::log( sprintf( '%d repo(s) returned.', count( $items ) ) );
+	}
+
+	/**
+	 * Check GitHub integration status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp datamachine github status
+	 *
+	 * @subcommand status
+	 */
+	public function status( array $args, array $assoc_args ): void {
+		$configured   = GitHubAbilities::isConfigured();
+		$default_repo = GitHubAbilities::getDefaultRepo();
+
+		$items = array(
+			array(
+				'setting' => 'GitHub PAT',
+				'value'   => $configured ? 'Configured' : 'Not configured',
+			),
+			array(
+				'setting' => 'Default Repository',
+				'value'   => $default_repo ? $default_repo : 'Not set',
+			),
+		);
+
+		$this->format_items( $items, array( 'setting', 'value' ), $assoc_args );
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Require GitHub to be configured.
+	 */
+	private function requireConfig(): void {
+		if ( ! GitHubAbilities::isConfigured() ) {
+			WP_CLI::error( 'GitHub PAT not configured. Set github_pat in Data Machine settings.' );
+		}
+	}
+
+	/**
+	 * Resolve repo — use provided value or fall back to default.
+	 *
+	 * @param array $input Input array with optional 'repo' key.
+	 * @return array Input with resolved repo.
+	 */
+	private function resolveRepo( array $input ): array {
+		if ( empty( $input['repo'] ) ) {
+			$input['repo'] = GitHubAbilities::getDefaultRepo();
+		}
+		if ( empty( $input['repo'] ) ) {
+			WP_CLI::error( 'Required: --repo=<owner/repo> (or set a default repo in settings).' );
+		}
+		return $input;
+	}
+
+	/**
+	 * Build ability input from assoc_args.
+	 *
+	 * @param array $assoc_args Command arguments.
+	 * @param array $keys       Keys to extract.
+	 * @return array
+	 */
+	private function buildInput( array $assoc_args, array $keys ): array {
+		$input = array();
+		foreach ( $keys as $key ) {
+			if ( isset( $assoc_args[ $key ] ) ) {
+				$input[ $key ] = $assoc_args[ $key ];
+			}
+		}
+		return $input;
+	}
+
+	/**
+	 * Format an ISO date to a shorter form.
+	 *
+	 * @param string $date ISO 8601 date string.
+	 * @return string Short date (Y-m-d).
+	 */
+	private function shortDate( string $date ): string {
+		if ( empty( $date ) ) {
+			return '';
+		}
+		$timestamp = strtotime( $date );
+		return $timestamp ? gmdate( 'Y-m-d', $timestamp ) : $date;
+	}
+}

--- a/inc/Core/Steps/Fetch/Handlers/GitHub/GitHub.php
+++ b/inc/Core/Steps/Fetch/Handlers/GitHub/GitHub.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * GitHub Fetch Handler
+ *
+ * Fetches issues or pull requests from a GitHub repository and returns
+ * them as DataPackets for pipeline processing. Supports deduplication
+ * via processed items, timeframe filtering, and keyword search.
+ *
+ * @package DataMachine\Core\Steps\Fetch\Handlers\GitHub
+ * @since 0.33.0
+ */
+
+namespace DataMachine\Core\Steps\Fetch\Handlers\GitHub;
+
+use DataMachine\Abilities\Fetch\GitHubAbilities;
+use DataMachine\Core\ExecutionContext;
+use DataMachine\Core\Steps\Fetch\Handlers\FetchHandler;
+use DataMachine\Core\Steps\HandlerRegistrationTrait;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GitHub extends FetchHandler {
+
+	use HandlerRegistrationTrait;
+
+	public function __construct() {
+		parent::__construct( 'github' );
+
+		self::registerHandler(
+			'github',
+			'fetch',
+			self::class,
+			'GitHub',
+			'Fetch issues and pull requests from GitHub repositories',
+			false,
+			null,
+			GitHubSettings::class,
+			null
+		);
+	}
+
+	/**
+	 * Fetch GitHub data and return as a DataPacket-compatible array.
+	 *
+	 * @param array            $config  Handler configuration.
+	 * @param ExecutionContext  $context Execution context.
+	 * @return array DataPacket-compatible array or empty on no data.
+	 */
+	protected function executeFetch( array $config, ExecutionContext $context ): array {
+		$repo        = $config['repo'] ?? '';
+		$data_source = $config['data_source'] ?? 'issues';
+		$state       = $config['state'] ?? 'open';
+		$labels      = $config['labels'] ?? '';
+
+		if ( empty( $repo ) ) {
+			$repo = GitHubAbilities::getDefaultRepo();
+		}
+
+		if ( empty( $repo ) ) {
+			$context->log( 'error', 'GitHub: No repository configured and no default repo set.' );
+			return array();
+		}
+
+		if ( ! GitHubAbilities::isConfigured() ) {
+			$context->log( 'error', 'GitHub: Personal Access Token not configured.' );
+			return array();
+		}
+
+		$context->log( 'debug', 'GitHub: Fetching data', array(
+			'repo'        => $repo,
+			'data_source' => $data_source,
+			'state'       => $state,
+		) );
+
+		$input = array(
+			'repo'     => $repo,
+			'state'    => $state,
+			'per_page' => GitHubAbilities::MAX_PER_PAGE,
+		);
+
+		if ( ! empty( $labels ) ) {
+			$input['labels'] = $labels;
+		}
+
+		if ( 'pulls' === $data_source ) {
+			$result = GitHubAbilities::listPulls( $input );
+			$items  = $result['pulls'] ?? array();
+		} else {
+			$result = GitHubAbilities::listIssues( $input );
+			$items  = $result['issues'] ?? array();
+		}
+
+		if ( ! $result['success'] ) {
+			$context->log( 'error', 'GitHub: API error — ' . ( $result['error'] ?? 'Unknown' ) );
+			return array();
+		}
+
+		if ( empty( $items ) ) {
+			$context->log( 'info', 'GitHub: No items found.' );
+			return array();
+		}
+
+		$context->log( 'info', sprintf( 'GitHub: Found %d %s.', count( $items ), $data_source ) );
+
+		// Find first unprocessed item (deduplication).
+		$search           = $config['search'] ?? '';
+		$exclude_keywords = $config['exclude_keywords'] ?? '';
+		$timeframe_limit  = $config['timeframe_limit'] ?? 'all_time';
+
+		foreach ( $items as $item ) {
+			$guid = sprintf( 'github_%s_%s_%d', $repo, $data_source, $item['number'] );
+
+			// Check if already processed.
+			if ( $context->isItemProcessed( $guid ) ) {
+				continue;
+			}
+
+			$searchable_text = ( $item['title'] ?? '' ) . ' ' . ( $item['body'] ?? '' );
+
+			// Apply keyword search filter.
+			if ( ! empty( $search ) && ! $this->applyKeywordSearch( $searchable_text, $search ) ) {
+				continue;
+			}
+
+			// Apply exclude keywords filter.
+			if ( ! empty( $exclude_keywords ) && ! $this->applyExcludeKeywords( $searchable_text, $exclude_keywords ) ) {
+				continue;
+			}
+
+			// Apply timeframe filter.
+			if ( 'all_time' !== $timeframe_limit && ! empty( $item['created_at'] ) ) {
+				$timestamp = strtotime( $item['created_at'] );
+				if ( $timestamp && ! $this->applyTimeframeFilter( $timestamp, $timeframe_limit ) ) {
+					continue;
+				}
+			}
+
+			// Mark as processed.
+			$context->markItemProcessed( $guid );
+
+			// Build the DataPacket-compatible return.
+			$labels_str = ! empty( $item['labels'] ) ? implode( ', ', $item['labels'] ) : '';
+
+			if ( 'pulls' === $data_source ) {
+				$title   = sprintf( 'PR #%d: %s', $item['number'], $item['title'] );
+				$content = $this->buildPrContent( $item );
+			} else {
+				$title   = sprintf( 'Issue #%d: %s', $item['number'], $item['title'] );
+				$content = $this->buildIssueContent( $item );
+			}
+
+			$context->storeEngineData( array(
+				'source_url'   => $item['html_url'] ?? '',
+				'github_repo'  => $repo,
+				'github_type'  => $data_source,
+				'issue_number' => $item['number'],
+			) );
+
+			return array(
+				'title'    => $title,
+				'content'  => $content,
+				'metadata' => array(
+					'source_type'       => 'github',
+					'original_id'       => $guid,
+					'original_title'    => $item['title'] ?? '',
+					'original_date_gmt' => $item['created_at'] ?? '',
+					'github_repo'       => $repo,
+					'github_type'       => $data_source,
+					'github_number'     => $item['number'],
+					'github_state'      => $item['state'] ?? '',
+					'github_labels'     => $labels_str,
+					'github_user'       => $item['user'] ?? '',
+					'github_url'        => $item['html_url'] ?? '',
+				),
+			);
+		}
+
+		$context->log( 'info', 'GitHub: All items already processed or filtered out.' );
+		return array();
+	}
+
+	/**
+	 * Build content string for an issue.
+	 *
+	 * @param array $issue Normalized issue data.
+	 * @return string
+	 */
+	private function buildIssueContent( array $issue ): string {
+		$parts = array();
+
+		$parts[] = sprintf( '**State:** %s', $issue['state'] ?? 'unknown' );
+		$parts[] = sprintf( '**Author:** %s', $issue['user'] ?? 'unknown' );
+
+		if ( ! empty( $issue['labels'] ) ) {
+			$parts[] = sprintf( '**Labels:** %s', implode( ', ', $issue['labels'] ) );
+		}
+		if ( ! empty( $issue['assignees'] ) ) {
+			$parts[] = sprintf( '**Assignees:** %s', implode( ', ', $issue['assignees'] ) );
+		}
+		$parts[] = sprintf( '**Comments:** %d', $issue['comments'] ?? 0 );
+		$parts[] = sprintf( '**Created:** %s', $issue['created_at'] ?? '' );
+		$parts[] = sprintf( '**URL:** %s', $issue['html_url'] ?? '' );
+		$parts[] = '';
+
+		if ( ! empty( $issue['body'] ) ) {
+			$parts[] = $issue['body'];
+		}
+
+		return implode( "\n", $parts );
+	}
+
+	/**
+	 * Build content string for a pull request.
+	 *
+	 * @param array $pr Normalized PR data.
+	 * @return string
+	 */
+	private function buildPrContent( array $pr ): string {
+		$parts = array();
+
+		$parts[] = sprintf( '**State:** %s', $pr['state'] ?? 'unknown' );
+		$parts[] = sprintf( '**Author:** %s', $pr['user'] ?? 'unknown' );
+		$parts[] = sprintf( '**Branch:** %s → %s', $pr['head'] ?? '?', $pr['base'] ?? '?' );
+
+		if ( ! empty( $pr['draft'] ) ) {
+			$parts[] = '**Draft:** Yes';
+		}
+		if ( ! empty( $pr['merged'] ) ) {
+			$parts[] = sprintf( '**Merged:** %s', $pr['merged_at'] ?? 'Yes' );
+		}
+		if ( ! empty( $pr['labels'] ) ) {
+			$parts[] = sprintf( '**Labels:** %s', implode( ', ', $pr['labels'] ) );
+		}
+		$parts[] = sprintf( '**Created:** %s', $pr['created_at'] ?? '' );
+		$parts[] = sprintf( '**URL:** %s', $pr['html_url'] ?? '' );
+		$parts[] = '';
+
+		if ( ! empty( $pr['body'] ) ) {
+			$parts[] = $pr['body'];
+		}
+
+		return implode( "\n", $parts );
+	}
+
+	/**
+	 * Get the display label for the GitHub handler.
+	 *
+	 * @return string
+	 */
+	public static function get_label(): string {
+		return __( 'GitHub', 'data-machine' );
+	}
+}

--- a/inc/Core/Steps/Fetch/Handlers/GitHub/GitHubSettings.php
+++ b/inc/Core/Steps/Fetch/Handlers/GitHub/GitHubSettings.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * GitHub Fetch Handler Settings
+ *
+ * Defines settings fields for the GitHub fetch handler UI.
+ *
+ * @package DataMachine\Core\Steps\Fetch\Handlers\GitHub
+ * @since 0.33.0
+ */
+
+namespace DataMachine\Core\Steps\Fetch\Handlers\GitHub;
+
+use DataMachine\Core\Steps\Fetch\Handlers\FetchHandlerSettings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GitHubSettings extends FetchHandlerSettings {
+
+	/**
+	 * Get settings fields for GitHub fetch handler.
+	 *
+	 * @return array
+	 */
+	public static function get_fields(): array {
+		$fields = array(
+			'repo'        => array(
+				'type'        => 'text',
+				'label'       => __( 'Repository', 'data-machine' ),
+				'description' => __( 'GitHub repository in owner/repo format (e.g., Extra-Chill/data-machine). Falls back to default repo in settings.', 'data-machine' ),
+				'required'    => false,
+			),
+			'data_source' => array(
+				'type'        => 'select',
+				'label'       => __( 'Data Source', 'data-machine' ),
+				'description' => __( 'What to fetch from the repository.', 'data-machine' ),
+				'required'    => true,
+				'default'     => 'issues',
+				'options'     => array(
+					'issues' => __( 'Issues', 'data-machine' ),
+					'pulls'  => __( 'Pull Requests', 'data-machine' ),
+				),
+			),
+			'state'       => array(
+				'type'        => 'select',
+				'label'       => __( 'State Filter', 'data-machine' ),
+				'description' => __( 'Filter by issue/PR state.', 'data-machine' ),
+				'required'    => false,
+				'default'     => 'open',
+				'options'     => array(
+					'open'   => __( 'Open', 'data-machine' ),
+					'closed' => __( 'Closed', 'data-machine' ),
+					'all'    => __( 'All', 'data-machine' ),
+				),
+			),
+			'labels'      => array(
+				'type'        => 'text',
+				'label'       => __( 'Label Filter', 'data-machine' ),
+				'description' => __( 'Comma-separated label names to filter by (issues only).', 'data-machine' ),
+				'required'    => false,
+			),
+		);
+
+		return array_merge( $fields, parent::get_common_fields() );
+	}
+}

--- a/inc/Engine/AI/Tools/Global/GitHubTools.php
+++ b/inc/Engine/AI/Tools/Global/GitHubTools.php
@@ -1,0 +1,327 @@
+<?php
+/**
+ * GitHub Tools — AI agent tools for GitHub read/write operations.
+ *
+ * Complements the existing GitHubIssueTool (create-only) with read and
+ * management capabilities: list issues, list PRs, view issue, close issue,
+ * comment on issue, list repos.
+ *
+ * @package DataMachine\Engine\AI\Tools\Global
+ * @since 0.33.0
+ */
+
+namespace DataMachine\Engine\AI\Tools\Global;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachine\Abilities\Fetch\GitHubAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class GitHubTools extends BaseTool {
+
+	/**
+	 * Constructor — register all GitHub tools as global tools.
+	 */
+	public function __construct() {
+		$this->registerGlobalTool( 'list_github_issues', array( $this, 'getListIssuesDefinition' ) );
+		$this->registerGlobalTool( 'get_github_issue', array( $this, 'getGetIssueDefinition' ) );
+		$this->registerGlobalTool( 'manage_github_issue', array( $this, 'getManageIssueDefinition' ) );
+		$this->registerGlobalTool( 'list_github_pulls', array( $this, 'getListPullsDefinition' ) );
+		$this->registerGlobalTool( 'list_github_repos', array( $this, 'getListReposDefinition' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// List Issues
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Handle list_github_issues tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @param array $tool_def   Tool definition.
+	 * @return array
+	 */
+	public function handleListIssues( array $parameters, array $tool_def = array() ): array {
+		$result = GitHubAbilities::listIssues( $parameters );
+
+		if ( empty( $result['success'] ) ) {
+			return $this->buildErrorResponse( $result['error'] ?? 'Failed to list issues.', 'list_github_issues' );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'list_github_issues',
+		);
+	}
+
+	/**
+	 * Get tool definition for list_github_issues.
+	 *
+	 * @return array
+	 */
+	public function getListIssuesDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleListIssues',
+			'description' => 'List issues from a GitHub repository. Returns issue numbers, titles, states, labels, and assignees. Use to review open issues, track progress, or find specific issues by label.',
+			'parameters'  => array(
+				'repo'     => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format (e.g., Extra-Chill/data-machine).',
+				),
+				'state'    => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Issue state: open, closed, or all. Default: open.',
+				),
+				'labels'   => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Comma-separated label names to filter by.',
+				),
+				'per_page' => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Results per page (max: 100). Default: 30.',
+				),
+			),
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Get Issue
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Handle get_github_issue tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @param array $tool_def   Tool definition.
+	 * @return array
+	 */
+	public function handleGetIssue( array $parameters, array $tool_def = array() ): array {
+		$result = GitHubAbilities::getIssue( $parameters );
+
+		if ( empty( $result['success'] ) ) {
+			return $this->buildErrorResponse( $result['error'] ?? 'Failed to get issue.', 'get_github_issue' );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'get_github_issue',
+		);
+	}
+
+	/**
+	 * Get tool definition for get_github_issue.
+	 *
+	 * @return array
+	 */
+	public function getGetIssueDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleGetIssue',
+			'description' => 'Get a single GitHub issue with full details including body, labels, assignees, and comment count.',
+			'parameters'  => array(
+				'repo'         => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'issue_number' => array(
+					'type'        => 'integer',
+					'required'    => true,
+					'description' => 'Issue number.',
+				),
+			),
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Manage Issue (update, close, comment)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Handle manage_github_issue tool call.
+	 *
+	 * Supports three actions: update, close, comment.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @param array $tool_def   Tool definition.
+	 * @return array
+	 */
+	public function handleManageIssue( array $parameters, array $tool_def = array() ): array {
+		$action = $parameters['action'] ?? '';
+
+		if ( 'comment' === $action ) {
+			$result = GitHubAbilities::commentOnIssue( $parameters );
+		} elseif ( 'close' === $action ) {
+			$parameters['state'] = 'closed';
+			$result              = GitHubAbilities::updateIssue( $parameters );
+		} else {
+			// Default: update.
+			$result = GitHubAbilities::updateIssue( $parameters );
+		}
+
+		if ( empty( $result['success'] ) ) {
+			return $this->buildErrorResponse( $result['error'] ?? 'Failed to manage issue.', 'manage_github_issue' );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'manage_github_issue',
+		);
+	}
+
+	/**
+	 * Get tool definition for manage_github_issue.
+	 *
+	 * @return array
+	 */
+	public function getManageIssueDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleManageIssue',
+			'description' => 'Update, close, or comment on a GitHub issue. Use action "update" to change title/body/labels, "close" to close the issue, or "comment" to add a comment.',
+			'parameters'  => array(
+				'repo'         => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'issue_number' => array(
+					'type'        => 'integer',
+					'required'    => true,
+					'description' => 'Issue number.',
+				),
+				'action'       => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Action: update, close, or comment.',
+				),
+				'title'        => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'New issue title (update action).',
+				),
+				'body'         => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'New issue body (update action) or comment text (comment action).',
+				),
+				'labels'       => array(
+					'type'        => 'array',
+					'required'    => false,
+					'description' => 'Labels to set (update action). Replaces existing labels.',
+				),
+			),
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// List Pulls
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Handle list_github_pulls tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @param array $tool_def   Tool definition.
+	 * @return array
+	 */
+	public function handleListPulls( array $parameters, array $tool_def = array() ): array {
+		$result = GitHubAbilities::listPulls( $parameters );
+
+		if ( empty( $result['success'] ) ) {
+			return $this->buildErrorResponse( $result['error'] ?? 'Failed to list pull requests.', 'list_github_pulls' );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'list_github_pulls',
+		);
+	}
+
+	/**
+	 * Get tool definition for list_github_pulls.
+	 *
+	 * @return array
+	 */
+	public function getListPullsDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleListPulls',
+			'description' => 'List pull requests from a GitHub repository. Returns PR numbers, titles, states, branches, and merge status.',
+			'parameters'  => array(
+				'repo'  => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'Repository in owner/repo format.',
+				),
+				'state' => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'PR state: open, closed, or all. Default: open.',
+				),
+			),
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// List Repos
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Handle list_github_repos tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @param array $tool_def   Tool definition.
+	 * @return array
+	 */
+	public function handleListRepos( array $parameters, array $tool_def = array() ): array {
+		$result = GitHubAbilities::listRepos( $parameters );
+
+		if ( empty( $result['success'] ) ) {
+			return $this->buildErrorResponse( $result['error'] ?? 'Failed to list repos.', 'list_github_repos' );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'list_github_repos',
+		);
+	}
+
+	/**
+	 * Get tool definition for list_github_repos.
+	 *
+	 * @return array
+	 */
+	public function getListReposDefinition(): array {
+		return array(
+			'class'       => __CLASS__,
+			'method'      => 'handleListRepos',
+			'description' => 'List GitHub repositories for a user or organization. Shows repo names, languages, stars, open issues, and last push date.',
+			'parameters'  => array(
+				'owner' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'GitHub user or organization name.',
+				),
+				'sort'  => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Sort by: created, updated, pushed, full_name. Default: updated.',
+				),
+			),
+		);
+	}
+}
+
+// Self-register the tools.
+new GitHubTools();


### PR DESCRIPTION
## Summary

Full-stack GitHub integration following existing handler patterns. Makes GitHub a first-class data source in Data Machine pipelines.

### What's new

- **6 Abilities** — `list-github-issues`, `get-github-issue`, `update-github-issue`, `comment-github-issue`, `list-github-pulls`, `list-github-repos`
- **Fetch Handler** — GitHub as a pipeline data source (issues or PRs), with deduplication, timeframe filtering, keyword search
- **CLI** — `wp datamachine github {issues, view, close, comment, pulls, repos, status}`
- **5 Chat Tools** — `list_github_issues`, `get_github_issue`, `manage_github_issue`, `list_github_pulls`, `list_github_repos`
- **Handler Settings UI** — repo, data source (issues/pulls), state filter, label filter

### Auth

Uses existing `github_pat` from PluginSettings (same as the v0.24.0 `GitHubIssueTask`). Completes the read/write loop — DM could already create issues, now it can read and manage them too.

### Tested

All 7 CLI subcommands verified against live Extra-Chill/data-machine repo. Zero lint errors in new files.

Closes #413