### PR TITLE
fix: normalizer uses step_type as implicit handler slug, remove multi-pattern check

### DIFF
--- a/inc/Abilities/FlowStep/FlowStepNormalizer.php
+++ b/inc/Abilities/FlowStep/FlowStepNormalizer.php
@@ -36,9 +36,13 @@ class FlowStepNormalizer {
 		$slug   = $step_config['handler_slug'] ?? '';
 		$config = $step_config['handler_config'] ?? array();
 
-		if ( ! empty( $slug ) ) {
-			$step_config['handler_slugs']   = array( $slug );
-			$step_config['handler_configs'] = array( $slug => $config );
+		// Resolve effective slug: explicit handler_slug, or step_type for non-handler
+		// steps that store config directly (e.g. agent_ping).
+		$effective_slug = ! empty( $slug ) ? $slug : ( $step_config['step_type'] ?? '' );
+
+		if ( ! empty( $effective_slug ) && ( ! empty( $slug ) || ! empty( $config ) ) ) {
+			$step_config['handler_slugs']   = array( $effective_slug );
+			$step_config['handler_configs'] = array( $effective_slug => $config );
 			unset( $step_config['handler_slug'], $step_config['handler_config'] );
 		} else {
 			$step_config['handler_slugs']   = array();

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -850,7 +850,8 @@ class FlowsCommand extends BaseCommand {
 
 		$handler_steps = array();
 		foreach ( $flow_config as $step_id => $step_data ) {
-			if ( $this->stepHasHandlerConfig( $step_data ) ) {
+			$normalized = \DataMachine\Abilities\FlowStep\FlowStepNormalizer::normalizeHandlerFields( $step_data );
+			if ( ! empty( $normalized['handler_slugs'] ) ) {
 				$handler_steps[] = $step_id;
 			}
 		}
@@ -858,7 +859,7 @@ class FlowsCommand extends BaseCommand {
 		if ( empty( $handler_steps ) ) {
 			return array(
 				'step_id' => null,
-				'error'   => 'Flow has no configurable steps (no handler_slugs, handler_slug, handler_config, or step_type with config found)',
+				'error'   => 'Flow has no handler steps',
 			);
 		}
 
@@ -866,7 +867,7 @@ class FlowsCommand extends BaseCommand {
 			return array(
 				'step_id' => null,
 				'error'   => sprintf(
-					'Flow has multiple configurable steps. Use --step=<id> to specify. Available: %s',
+					'Flow has multiple handler steps. Use --step=<id> to specify. Available: %s',
 					implode( ', ', $handler_steps )
 				),
 			);
@@ -876,45 +877,5 @@ class FlowsCommand extends BaseCommand {
 			'step_id' => $handler_steps[0],
 			'error'   => null,
 		);
-	}
-
-	/**
-	 * Check if a step has handler configuration (modern, legacy, or non-handler step with config).
-	 *
-	 * Detects:
-	 * - handler_slugs (modern plural format)
-	 * - handler_slug (legacy singular format)
-	 * - handler_config / handler_configs (step with config but no explicit handler slug, e.g. agent_ping)
-	 * - step_type that matches a registered handler settings provider (e.g. agent_ping)
-	 *
-	 * @param array $step_data Step configuration data.
-	 * @return bool True if the step has configurable handler settings.
-	 */
-	private function stepHasHandlerConfig( array $step_data ): bool {
-		// Modern plural format.
-		if ( ! empty( $step_data['handler_slugs'] ) ) {
-			return true;
-		}
-
-		// Legacy singular format.
-		if ( ! empty( $step_data['handler_slug'] ) ) {
-			return true;
-		}
-
-		// Step has handler config directly (e.g. agent_ping stores config without handler_slug).
-		if ( ! empty( $step_data['handler_config'] ) || ! empty( $step_data['handler_configs'] ) ) {
-			return true;
-		}
-
-		// Non-handler step types that register their own settings (e.g. agent_ping).
-		$step_type = $step_data['step_type'] ?? '';
-		if ( ! empty( $step_type ) ) {
-			$all_settings = apply_filters( 'datamachine_handler_settings', array(), $step_type );
-			if ( isset( $all_settings[ $step_type ] ) ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 }


### PR DESCRIPTION
## Summary
Follow-up to #459 — fixes the actual root cause instead of working around it.

- **`FlowStepNormalizer::normalizeHandlerFields`** now falls back to `step_type` as the handler slug when no explicit `handler_slug` exists but `handler_config` is present. This is the real fix for agent_ping config being wiped — the normalizer was setting `handler_slugs = []` and `handler_configs = []` for these steps, destroying their config data.
- **Removes `stepHasHandlerConfig`** — the four-pattern detection method from #459 was architectural drift (checking four formats instead of normalizing first). `resolveHandlerStep` now normalizes each step via `FlowStepNormalizer` and checks the single canonical `handler_slugs` field.
- Net -35 lines. Fix at the source, not at the call site.