### PR TITLE
fix: align GitHubAbilities and GitHubTools with codebase conventions

### DIFF
--- a/inc/Abilities/Fetch/GitHubAbilities.php
+++ b/inc/Abilities/Fetch/GitHubAbilities.php
@@ -336,6 +336,64 @@ class GitHubAbilities {
 		}
 	}
 
+	/**
+	 * Permission callback for abilities.
+	 *
+	 * @return bool True if user has permission.
+	 */
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	/**
+	 * Execute a GitHub ability by name.
+	 *
+	 * Dispatches to the appropriate static method based on the ability_name input.
+	 *
+	 * @param array $input Input parameters including 'ability_name' for dispatch.
+	 * @return array Result array.
+	 */
+	public function execute( array $input ): array {
+		$ability = $input['ability_name'] ?? 'list_issues';
+		$config  = $this->normalizeConfig( $input );
+
+		return match ( $ability ) {
+			'list_issues'    => self::listIssues( $config ),
+			'get_issue'      => self::getIssue( $config ),
+			'update_issue'   => self::updateIssue( $config ),
+			'comment'        => self::commentOnIssue( $config ),
+			'list_pulls'     => self::listPulls( $config ),
+			'list_repos'     => self::listRepos( $config ),
+			default          => array(
+				'success' => false,
+				'error'   => "Unknown GitHub ability: {$ability}",
+			),
+		};
+	}
+
+	/**
+	 * Normalize input configuration with defaults.
+	 *
+	 * @param array $input Raw input.
+	 * @return array Normalized config.
+	 */
+	private function normalizeConfig( array $input ): array {
+		$defaults = array(
+			'repo'         => '',
+			'owner'        => '',
+			'state'        => 'open',
+			'per_page'     => self::DEFAULT_PER_PAGE,
+			'page'         => 1,
+			'labels'       => '',
+			'assignee'     => '',
+			'since'        => '',
+			'issue_number' => 0,
+			'sort'         => 'updated',
+		);
+
+		return array_merge( $defaults, $input );
+	}
+
 	// -------------------------------------------------------------------------
 	// Ability Callbacks
 	// -------------------------------------------------------------------------

--- a/inc/Engine/AI/Tools/Global/GitHubTools.php
+++ b/inc/Engine/AI/Tools/Global/GitHubTools.php
@@ -30,6 +30,53 @@ class GitHubTools extends BaseTool {
 		$this->registerGlobalTool( 'list_github_repos', array( $this, 'getListReposDefinition' ) );
 	}
 
+	/**
+	 * Handle tool call — dispatches to the appropriate handler based on tool_def.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @param array $tool_def   Tool definition with 'method' key.
+	 * @return array
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$method = $tool_def['method'] ?? 'handleListIssues';
+		if ( method_exists( $this, $method ) ) {
+			return $this->{$method}( $parameters, $tool_def );
+		}
+		return $this->buildErrorResponse( "Unknown method: {$method}", 'github_tools' );
+	}
+
+	/**
+	 * Check if GitHub tools are properly configured.
+	 *
+	 * @param bool   $configured Current configuration status.
+	 * @param string $tool_id    Tool identifier to check.
+	 * @return bool True if configured.
+	 */
+	public function check_configuration( $configured, $tool_id ) {
+		$github_tools = array(
+			'list_github_issues',
+			'get_github_issue',
+			'manage_github_issue',
+			'list_github_pulls',
+			'list_github_repos',
+		);
+		if ( ! in_array( $tool_id, $github_tools, true ) ) {
+			return $configured;
+		}
+		return GitHubAbilities::isConfigured();
+	}
+
+	/**
+	 * Get tool definition — returns the primary tool definition (list issues).
+	 *
+	 * Individual tools use their own definition methods via registerGlobalTool.
+	 *
+	 * @return array Tool definition array.
+	 */
+	public function getToolDefinition(): array {
+		return $this->getListIssuesDefinition();
+	}
+
 	// -------------------------------------------------------------------------
 	// List Issues
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes architectural drift in the GitHub integration I shipped today (PR #456). Discovered via `homeboy audit`.

- **GitHubAbilities**: adds `checkPermission()`, `execute()`, `normalizeConfig()` to match Fetch convention (FetchRssAbility pattern)
- **GitHubTools**: adds `handle_tool_call()`, `check_configuration()`, `getToolDefinition()` to match Global tools convention (GoogleSearch pattern)
- Audit status: Fetch convention now **clean** (was drift), Global convention GitHubTools drift resolved