### PR TITLE
fix: move post tracking meta keys from namespace constants to class constants

### DIFF
--- a/inc/Core/WordPress/PostTrackingTrait.php
+++ b/inc/Core/WordPress/PostTrackingTrait.php
@@ -23,14 +23,14 @@ use DataMachine\Core\Database\Jobs\Jobs;
 
 defined( 'ABSPATH' ) || exit;
 
-const DATAMACHINE_POST_HANDLER_META_KEY     = '_datamachine_post_handler';
-const DATAMACHINE_POST_FLOW_ID_META_KEY     = '_datamachine_post_flow_id';
-const DATAMACHINE_POST_PIPELINE_ID_META_KEY = '_datamachine_post_pipeline_id';
-
 /**
  * Static utility for post origin tracking.
  */
 class PostTracking {
+
+	public const HANDLER_META_KEY     = '_datamachine_post_handler';
+	public const FLOW_ID_META_KEY     = '_datamachine_post_flow_id';
+	public const PIPELINE_ID_META_KEY = '_datamachine_post_pipeline_id';
 
 	/**
 	 * Store post tracking metadata from tool call context.
@@ -63,15 +63,15 @@ class PostTracking {
 		}
 
 		if ( ! empty( $handler_slug ) ) {
-			update_post_meta( $post_id, DATAMACHINE_POST_HANDLER_META_KEY, sanitize_text_field( $handler_slug ) );
+			update_post_meta( $post_id, self::HANDLER_META_KEY, sanitize_text_field( $handler_slug ) );
 		}
 
 		if ( $flow_id > 0 ) {
-			update_post_meta( $post_id, DATAMACHINE_POST_FLOW_ID_META_KEY, $flow_id );
+			update_post_meta( $post_id, self::FLOW_ID_META_KEY, $flow_id );
 		}
 
 		if ( $pipeline_id > 0 ) {
-			update_post_meta( $post_id, DATAMACHINE_POST_PIPELINE_ID_META_KEY, $pipeline_id );
+			update_post_meta( $post_id, self::PIPELINE_ID_META_KEY, $pipeline_id );
 		}
 
 		do_action(


### PR DESCRIPTION
## Summary

- **Hotfix for fatal error** introduced by PR #464 — namespace-level constants in `PostTrackingTrait.php` are not autoloaded by PSR-4, causing `Undefined constant` fatal when `PostQueryAbilities` loads first
- Moves constants into `PostTracking` class as `public const HANDLER_META_KEY`, `FLOW_ID_META_KEY`, `PIPELINE_ID_META_KEY`
- Converts `FILTER_TYPES` class constant to `get_filter_types()` method (deferred evaluation avoids class-load-time constant resolution)

## Root Cause

PHP's `use const` statement does not trigger PSR-4 autoloading. The namespace constants were defined as a side-effect of including `PostTrackingTrait.php`, but if `PostQueryAbilities` was loaded first (e.g., during ability registration), the file hadn't been included yet and the constants were undefined.

## Already deployed

This fix is already live on production — the site was down until this was applied.