### PR TITLE
fix: agent files created with group-writable permissions (#467)

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -584,7 +584,7 @@ function datamachine_ensure_default_memory_files() {
 	$directory_manager = new \DataMachine\Core\FilesRepository\DirectoryManager();
 	$agent_dir         = $directory_manager->get_agent_directory();
 
-	if ( ! $directory_manager->ensure_directory_exists( $agent_dir ) ) {
+	if ( ! $directory_manager->ensure_agent_directory_writable() ) {
 		return;
 	}
 
@@ -603,6 +603,7 @@ function datamachine_ensure_default_memory_files() {
 		}
 
 		$fs->put_contents( $filepath, $content . "\n", FS_CHMOD_FILE );
+		\DataMachine\Core\FilesRepository\FilesystemHelper::make_group_writable( $filepath );
 
 		do_action(
 			'datamachine_log',

--- a/inc/Abilities/FileAbilities.php
+++ b/inc/Abilities/FileAbilities.php
@@ -1090,6 +1090,8 @@ class FileAbilities {
 			);
 		}
 
+		FilesystemHelper::make_group_writable( $filepath );
+
 		do_action(
 			'datamachine_log',
 			'info',

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -22,6 +22,7 @@ use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\AgentMemoryAbilities;
 use DataMachine\Core\FilesRepository\DailyMemory;
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Core\FilesRepository\FilesystemHelper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -683,6 +684,8 @@ class MemoryCommand extends BaseCommand {
 			WP_CLI::error( sprintf( 'Failed to write file: %s', $safe_name ) );
 			return;
 		}
+
+		FilesystemHelper::make_group_writable( $filepath );
 
 		WP_CLI::success( sprintf( 'Wrote %s (%s).', $safe_name, size_format( $written ) ) );
 	}

--- a/inc/Core/FilesRepository/AgentMemory.php
+++ b/inc/Core/FilesRepository/AgentMemory.php
@@ -375,8 +375,7 @@ class AgentMemory {
 	 * so a recreated MEMORY.md includes the standard sections.
 	 */
 	private function ensure_file_exists(): void {
-		$agent_dir = $this->directory_manager->get_agent_directory();
-		$this->directory_manager->ensure_directory_exists( $agent_dir );
+		$this->directory_manager->ensure_agent_directory_writable();
 
 		if ( ! file_exists( $this->file_path ) ) {
 			$content = "# Agent Memory\n";
@@ -389,6 +388,7 @@ class AgentMemory {
 			}
 
 			file_put_contents( $this->file_path, $content );
+			FilesystemHelper::make_group_writable( $this->file_path );
 
 			do_action(
 				'datamachine_log',
@@ -409,6 +409,7 @@ class AgentMemory {
 	 */
 	private function write_file( string $content ): int {
 		file_put_contents( $this->file_path, $content );
+		FilesystemHelper::make_group_writable( $this->file_path );
 		$size = strlen( $content );
 
 		if ( $size > self::MAX_FILE_SIZE ) {

--- a/inc/Core/FilesRepository/DailyMemory.php
+++ b/inc/Core/FilesRepository/DailyMemory.php
@@ -125,7 +125,7 @@ class DailyMemory {
 		$file_path = $this->get_file_path( $year, $month, $day );
 		$dir       = dirname( $file_path );
 
-		if ( ! $this->directory_manager->ensure_directory_exists( $dir ) ) {
+		if ( ! $this->ensure_daily_directory( $dir ) ) {
 			return array(
 				'success' => false,
 				'message' => sprintf( 'Failed to create directory for %s-%s-%s.', $year, $month, $day ),
@@ -140,6 +140,8 @@ class DailyMemory {
 				'message' => sprintf( 'Failed to write daily memory for %s-%s-%s.', $year, $month, $day ),
 			);
 		}
+
+		FilesystemHelper::make_group_writable( $file_path );
 
 		return array(
 			'success' => true,
@@ -162,7 +164,7 @@ class DailyMemory {
 		$file_path = $this->get_file_path( $year, $month, $day );
 		$dir       = dirname( $file_path );
 
-		if ( ! $this->directory_manager->ensure_directory_exists( $dir ) ) {
+		if ( ! $this->ensure_daily_directory( $dir ) ) {
 			return array(
 				'success' => false,
 				'message' => sprintf( 'Failed to create directory for %s-%s-%s.', $year, $month, $day ),
@@ -183,6 +185,8 @@ class DailyMemory {
 				'message' => sprintf( 'Failed to append to daily memory for %s-%s-%s.', $year, $month, $day ),
 			);
 		}
+
+		FilesystemHelper::make_group_writable( $file_path );
 
 		return array(
 			'success' => true,
@@ -360,6 +364,37 @@ class DailyMemory {
 	// =========================================================================
 	// Internal Helpers
 	// =========================================================================
+
+	/**
+	 * Ensure a daily memory directory exists with group-writable permissions.
+	 *
+	 * Creates all intermediate directories (daily/YYYY/MM/) and sets 0775
+	 * so the coding agent user can also write daily memory files.
+	 *
+	 * @since 0.32.0
+	 * @param string $dir Directory path.
+	 * @return bool True if directory exists.
+	 */
+	private function ensure_daily_directory( string $dir ): bool {
+		if ( ! $this->directory_manager->ensure_directory_exists( $dir ) ) {
+			return false;
+		}
+
+		$perms = FilesystemHelper::AGENT_DIR_PERMISSIONS;
+
+		// Walk up from the leaf (MM/) through YYYY/ and daily/ — set each.
+		$current = $dir;
+		$stops   = 3; // MM, YYYY, daily.
+		for ( $i = 0; $i < $stops; $i++ ) {
+			if ( is_dir( $current ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+				chmod( $current, $perms );
+			}
+			$current = dirname( $current );
+		}
+
+		return true;
+	}
 
 	/**
 	 * Parse a YYYY-MM-DD date string into year/month/day components.

--- a/inc/Core/FilesRepository/DirectoryManager.php
+++ b/inc/Core/FilesRepository/DirectoryManager.php
@@ -204,4 +204,37 @@ class DirectoryManager {
 		}
 		return true;
 	}
+
+	/**
+	 * Ensure the agent directory and its parents are group-writable.
+	 *
+	 * Agent files need to be writable by both the web server user (www-data)
+	 * and the coding agent user (e.g. opencode). This method creates the
+	 * agent directory if needed and sets 0775 permissions on the agent
+	 * directory and its parent (datamachine-files/).
+	 *
+	 * @since 0.32.0
+	 * @return bool True if directory exists and permissions were set.
+	 */
+	public function ensure_agent_directory_writable(): bool {
+		$agent_dir = $this->get_agent_directory();
+
+		if ( ! $this->ensure_directory_exists( $agent_dir ) ) {
+			return false;
+		}
+
+		$perms = FilesystemHelper::AGENT_DIR_PERMISSIONS;
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+		chmod( $agent_dir, $perms );
+
+		// Also set the parent datamachine-files/ directory.
+		$parent = dirname( $agent_dir );
+		if ( is_dir( $parent ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+			chmod( $parent, $perms );
+		}
+
+		return true;
+	}
 }

--- a/inc/Core/FilesRepository/FilesystemHelper.php
+++ b/inc/Core/FilesRepository/FilesystemHelper.php
@@ -18,6 +18,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FilesystemHelper {
 
 	/**
+	 * Group-writable file permissions for agent files.
+	 *
+	 * Agent files live in wp-content/uploads/datamachine-files/agent/ and are
+	 * written by PHP (www-data) but also need to be writable by the coding
+	 * agent user (e.g. opencode) which runs in the www-data group.
+	 *
+	 * Using 0664 (owner rw, group rw, other r) instead of the default 0644
+	 * ensures both users can read and write agent memory files.
+	 *
+	 * @since 0.32.0
+	 * @var int
+	 */
+	const AGENT_FILE_PERMISSIONS = 0664;
+
+	/**
+	 * Group-writable directory permissions for agent directories.
+	 *
+	 * @since 0.32.0
+	 * @var int
+	 */
+	const AGENT_DIR_PERMISSIONS = 0775;
+
+	/**
 	 * Cached initialization result
 	 *
 	 * @var bool|null
@@ -53,6 +76,25 @@ class FilesystemHelper {
 		}
 		global $wp_filesystem;
 		return $wp_filesystem;
+	}
+
+	/**
+	 * Set group-writable permissions on an agent file.
+	 *
+	 * Call this after writing any file in the agent directory to ensure
+	 * both the web server user (www-data) and the coding agent user
+	 * (e.g. opencode) can read and write the file.
+	 *
+	 * @since 0.32.0
+	 * @param string $filepath Absolute path to the file.
+	 * @return bool True if permissions were set, false on failure.
+	 */
+	public static function make_group_writable( string $filepath ): bool {
+		if ( ! file_exists( $filepath ) ) {
+			return false;
+		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+		return chmod( $filepath, self::AGENT_FILE_PERMISSIONS );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Adds `FilesystemHelper::AGENT_FILE_PERMISSIONS` (`0664`) and `AGENT_DIR_PERMISSIONS` (`0775`) constants
- Adds `FilesystemHelper::make_group_writable()` — call after every agent file write
- Adds `DirectoryManager::ensure_agent_directory_writable()` — creates agent dir with `0775`
- All 6 agent file write paths now set group-writable permissions:
  - `AgentMemory::write_file()` and `ensure_file_exists()`
  - `DailyMemory::write()` and `append()`
  - `MemoryCommand` CLI (`agent files write`)
  - `FileAbilities` (AI agent writes)
  - `datamachine_ensure_default_memory_files()` scaffold

## The problem

PHP's default umask produces `0644` files (owner rw, group/others read-only). The coding agent user (e.g. `opencode`) runs in the `www-data` group but can't write to agent files created by WordPress because group write isn't set.

## The fix

`0664` for files, `0775` for directories. Both the web server user and any user in the `www-data` group can now read and write agent memory files.

Closes #467