### PR TITLE
feat: flows get shows detailed view with step configs (#469)

### DIFF
--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -284,6 +284,12 @@ class FlowsCommand extends BaseCommand {
 			return;
 		}
 
+		// Single flow detail view: show full data including step configs.
+		if ( $flow_id && 1 === count( $flows ) ) {
+			$this->showFlowDetail( $flows[0], $format );
+			return;
+		}
+
 		// Transform flows to flat row format.
 		$items = array_map(
 			function ( $flow ) {
@@ -303,6 +309,132 @@ class FlowsCommand extends BaseCommand {
 		$this->format_items( $items, $this->default_fields, $assoc_args, 'id' );
 		$this->output_pagination( $offset, count( $flows ), $total, $format, 'flows' );
 		$this->outputFilters( $result['filters_applied'] ?? array(), $format );
+	}
+
+	/**
+	 * Show detailed view of a single flow including step configs.
+	 *
+	 * For JSON format: outputs the full flow data with flow_config intact.
+	 * For table format: outputs key-value pairs followed by a step configs table.
+	 *
+	 * @param array  $flow   Full flow data from FlowAbilities.
+	 * @param string $format Output format (table, json, csv, yaml).
+	 */
+	private function showFlowDetail( array $flow, string $format ): void {
+		// JSON/YAML: output the full flow data including flow_config.
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $flow, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( 'yaml' === $format ) {
+			WP_CLI\Utils\format_items( 'yaml', array( $flow ), array_keys( $flow ) );
+			return;
+		}
+
+		// Table format: show flow summary, then step configs.
+		$scheduling = $flow['scheduling_config'] ?? array();
+		$interval   = $scheduling['interval'] ?? 'manual';
+
+		WP_CLI::log( sprintf( 'Flow ID:      %d', $flow['flow_id'] ) );
+		WP_CLI::log( sprintf( 'Name:         %s', $flow['flow_name'] ) );
+		WP_CLI::log( sprintf( 'Pipeline ID:  %s', $flow['pipeline_id'] ?? 'N/A' ) );
+		WP_CLI::log( sprintf( 'Scheduling:   %s', $interval ) );
+		WP_CLI::log( sprintf( 'Last run:     %s', $flow['last_run_display'] ?? 'Never' ) );
+		WP_CLI::log( sprintf( 'Next run:     %s', $flow['next_run_display'] ?? 'Not scheduled' ) );
+		WP_CLI::log( sprintf( 'Running:      %s', ( $flow['is_running'] ?? false ) ? 'Yes' : 'No' ) );
+		WP_CLI::log( '' );
+
+		// Step configs section.
+		$config = $flow['flow_config'] ?? array();
+
+		if ( empty( $config ) ) {
+			WP_CLI::log( 'Steps: (none)' );
+			return;
+		}
+
+		$rows = array();
+		foreach ( $config as $step_id => $step_data ) {
+			$step_type = $step_data['step_type'] ?? '';
+			$order     = $step_data['execution_order'] ?? '';
+			$slugs     = $step_data['handler_slugs'] ?? array();
+			$configs   = $step_data['handler_configs'] ?? array();
+
+			// Show pipeline-level prompt if set.
+			$pipeline_prompt = $step_data['pipeline_config']['prompt'] ?? '';
+
+			if ( empty( $slugs ) ) {
+				// Step with no handlers (e.g. AI step with only pipeline config).
+				$config_display = '';
+
+				if ( $pipeline_prompt ) {
+					$config_display = 'prompt=' . $this->truncateValue( $pipeline_prompt, 60 );
+				}
+
+				$rows[] = array(
+					'step_id'    => $step_id,
+					'order'      => $order,
+					'step_type'  => $step_type,
+					'handler'    => '—',
+					'config'     => $config_display ?: '(default)',
+				);
+				continue;
+			}
+
+			foreach ( $slugs as $slug ) {
+				$handler_config = $configs[ $slug ] ?? array();
+				$config_parts   = array();
+
+				foreach ( $handler_config as $key => $value ) {
+					$config_parts[] = $key . '=' . $this->formatConfigValue( $value );
+				}
+
+				$rows[] = array(
+					'step_id'    => $step_id,
+					'order'      => $order,
+					'step_type'  => $step_type,
+					'handler'    => $slug,
+					'config'     => implode( ', ', $config_parts ) ?: '(default)',
+				);
+			}
+		}
+
+		WP_CLI::log( 'Steps:' );
+
+		$step_fields = array( 'step_id', 'order', 'step_type', 'handler', 'config' );
+		WP_CLI\Utils\format_items( 'table', $rows, $step_fields );
+	}
+
+	/**
+	 * Truncate a display value to a maximum length.
+	 *
+	 * @param string $value Value to truncate.
+	 * @param int    $max   Maximum characters.
+	 * @return string Truncated value.
+	 */
+	private function truncateValue( string $value, int $max = 40 ): string {
+		$value = str_replace( array( "\n", "\r" ), ' ', $value );
+		if ( mb_strlen( $value ) > $max ) {
+			return mb_substr( $value, 0, $max - 3 ) . '...';
+		}
+		return $value;
+	}
+
+	/**
+	 * Format a config value for display in the step configs table.
+	 *
+	 * @param mixed $value Config value.
+	 * @return string Formatted value.
+	 */
+	private function formatConfigValue( $value ): string {
+		if ( is_bool( $value ) ) {
+			return $value ? 'true' : 'false';
+		}
+		if ( is_array( $value ) ) {
+			return wp_json_encode( $value );
+		}
+		$str = (string) $value;
+		return $this->truncateValue( $str );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- `flows get <id>` now shows a **detailed view** with flow metadata + step configs table instead of a single-row summary
- `--format=json` outputs the **full flow data** including `flow_config` with `handler_slugs`, `handler_configs`, and all step-level settings
- List view (`flows` without a flow_id) is unchanged

## Before

```
$ wp datamachine flows get 42
id  name       pipeline_id  handlers  prompt  status  next_run
42  My Flow    5            rss       ...     Never   Not scheduled
```

## After

```
$ wp datamachine flows get 42
Flow ID:      42
Name:         My Flow
Pipeline ID:  5
Scheduling:   daily
Last run:     Never
Next run:     Not scheduled
Running:      No

Steps:
step_id    order  step_type  handler  config
abc_123    0      fetch      rss      feed_url=https://example.com/feed, max_items=10
def_456    1      ai         —        (default)
ghi_789    2      publish    —        (default)
```

## Why

`flows get` was hiding the most important part — handler configs like `min_upvotes`, `sort_by`, `feed_url`, etc. Debugging required knowing to run `flows list-handlers` separately. Now a single command shows everything.

Tested against local chubes.net install with real pipeline/flow creation.

Closes #469