### PR TITLE
fix: WP 6.9 Abilities API compatibility — move annotations into meta

### DIFF
--- a/inc/Abilities/Chat/DeleteChatSessionAbility.php
+++ b/inc/Abilities/Chat/DeleteChatSessionAbility.php
@@ -62,10 +62,12 @@ class DeleteChatSessionAbility {
 					),
 					'execute_callback'    => array( $this, 'execute' ),
 					'permission_callback' => array( $this, 'checkPermission' ),
-					'annotations'         => array(
-						'destructive' => true,
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'destructive' => true,
+						),
 					),
-					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
 		};

--- a/inc/Abilities/Chat/GetChatSessionAbility.php
+++ b/inc/Abilities/Chat/GetChatSessionAbility.php
@@ -64,11 +64,13 @@ class GetChatSessionAbility {
 					),
 					'execute_callback'    => array( $this, 'execute' ),
 					'permission_callback' => array( $this, 'checkPermission' ),
-					'annotations'         => array(
-						'readonly'   => true,
-						'idempotent' => true,
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'   => true,
+							'idempotent' => true,
+						),
 					),
-					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
 		};

--- a/inc/Abilities/Chat/ListChatSessionsAbility.php
+++ b/inc/Abilities/Chat/ListChatSessionsAbility.php
@@ -78,11 +78,13 @@ class ListChatSessionsAbility {
 					),
 					'execute_callback'    => array( $this, 'execute' ),
 					'permission_callback' => array( $this, 'checkPermission' ),
-					'annotations'         => array(
-						'readonly'   => true,
-						'idempotent' => true,
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'   => true,
+							'idempotent' => true,
+						),
 					),
-					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
 		};


### PR DESCRIPTION
## Summary

- **Moves `annotations` from top-level property into `meta.annotations`** on 3 chat session abilities
- Fixes `_doing_it_wrong` warnings on every WP-CLI call

## Problem

The chat session abilities (`list-chat-sessions`, `get-chat-session`, `delete-chat-session`) passed `annotations` as a top-level arg to `wp_register_ability()`:

```php
// Before (wrong):
'annotations' => array( 'readonly' => true ),
'meta'        => array( 'show_in_rest' => true ),
```

WP 6.9's `WP_Ability::__construct()` doesn't accept `annotations` as a top-level property — it belongs inside `meta.annotations` per the Abilities API spec.

## Fix

```php
// After (correct):
'meta' => array(
    'show_in_rest' => true,
    'annotations'  => array( 'readonly' => true ),
),
```

The Engine abilities (ScheduleFlow, ExecuteStep, etc.) already had this correct. Only the Chat abilities were wrong.

## Note on issue scope

Issue #478 mentioned 3 distinct problems (missing category label, invalid ability names, annotations). After investigation:
- **Category label**: Already present — `FlowAbilities::registerCategory()` includes `label`
- **Invalid ability names**: All 151 abilities use valid `datamachine/name` format
- **Annotations**: This was the only real issue — fixed here

The other two warnings may have been from an older DM version or a different WP 6.9 beta.

Fixes #478