### PR TITLE
fix: Bing API date parsing, staleness detection, and --days filter

### DIFF
--- a/inc/Abilities/Analytics/BingWebmasterAbilities.php
+++ b/inc/Abilities/Analytics/BingWebmasterAbilities.php
@@ -44,6 +44,17 @@ class BingWebmasterAbilities {
 	 */
 	const DEFAULT_LIMIT = 20;
 
+	/**
+	 * Regex to parse Bing's /Date(timestamp)/ format.
+	 *
+	 * Captures the millisecond Unix timestamp from Bing's WCF date format.
+	 * Example: "/Date(1316156400000-0700)/" → 1316156400000
+	 *
+	 * @var string
+	 */
+	const DATE_REGEX = '/^\/Date\((\d+)([+-]\d{4})?\)\/$/';
+
+
 	private static bool $registered = false;
 
 	public function __construct() {
@@ -83,6 +94,10 @@ class BingWebmasterAbilities {
 								'type'        => 'integer',
 								'description' => 'Maximum number of results to return (default: 20).',
 							),
+							'days'     => array(
+								'type'        => 'integer',
+								'description' => 'Only return data from the last N days (client-side filter).',
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -91,6 +106,15 @@ class BingWebmasterAbilities {
 							'success'       => array( 'type' => 'boolean' ),
 							'action'        => array( 'type' => 'string' ),
 							'results_count' => array( 'type' => 'integer' ),
+							'date_range'    => array(
+								'type'       => 'object',
+								'properties' => array(
+									'start_date' => array( 'type' => 'string' ),
+									'end_date'   => array( 'type' => 'string' ),
+									'days_ago'   => array( 'type' => 'integer' ),
+									'span_days'  => array( 'type' => 'integer' ),
+								),
+							),
 							'results'       => array( 'type' => 'array' ),
 							'error'         => array( 'type' => 'string' ),
 						),
@@ -111,6 +135,10 @@ class BingWebmasterAbilities {
 
 	/**
 	 * Fetch stats from Bing Webmaster Tools API.
+	 *
+	 * Parses Bing's /Date(timestamp)/ format into ISO 8601 dates, adds
+	 * date range metadata, and supports client-side day filtering since
+	 * the Bing API does not accept date parameters.
 	 *
 	 * @param array $input Ability input.
 	 * @return array Ability response.
@@ -136,6 +164,7 @@ class BingWebmasterAbilities {
 
 		$site_url = ! empty( $input['site_url'] ) ? sanitize_text_field( $input['site_url'] ) : ( $config['site_url'] ?? get_site_url() );
 		$limit    = ! empty( $input['limit'] ) ? (int) $input['limit'] : self::DEFAULT_LIMIT;
+		$days     = ! empty( $input['days'] ) ? (int) $input['days'] : 0;
 		$endpoint = self::ACTION_ENDPOINTS[ $action ];
 
 		$request_url = add_query_arg(
@@ -175,15 +204,80 @@ class BingWebmasterAbilities {
 
 		$results = $data['d'] ?? array();
 
-		if ( is_array( $results ) && count( $results ) > $limit ) {
+		if ( ! is_array( $results ) ) {
+			$results = array();
+		}
+
+		// Parse Bing /Date(timestamp)/ format into ISO 8601 and compute date range.
+		$parsed_dates = array();
+		foreach ( $results as &$row ) {
+			if ( isset( $row['Date'] ) ) {
+				$parsed = self::parseBingDate( $row['Date'] );
+				if ( $parsed ) {
+					$row['Date']    = $parsed['iso'];
+					$parsed_dates[] = $parsed['timestamp'];
+				}
+			}
+		}
+		unset( $row );
+
+		// Client-side date filtering (Bing API does not accept date params).
+		if ( $days > 0 && ! empty( $parsed_dates ) ) {
+			$cutoff  = time() - ( $days * DAY_IN_SECONDS );
+			$results = array_values( array_filter( $results, function ( $row ) use ( $cutoff ) {
+				if ( empty( $row['Date'] ) ) {
+					return true;
+				}
+				$ts = strtotime( $row['Date'] );
+				return $ts !== false && $ts >= $cutoff;
+			} ) );
+		}
+
+		// Apply limit after date filtering.
+		if ( count( $results ) > $limit ) {
 			$results = array_slice( $results, 0, $limit );
+		}
+
+		// Build date range metadata — uses start_date/end_date to match
+		// the key names expected by AnalyticsCommand::execute_ability().
+		$date_range = array();
+		if ( ! empty( $parsed_dates ) ) {
+			$min_ts = min( $parsed_dates );
+			$max_ts = max( $parsed_dates );
+			$date_range = array(
+				'start_date' => gmdate( 'Y-m-d', $min_ts ),
+				'end_date'   => gmdate( 'Y-m-d', $max_ts ),
+				'days_ago'   => (int) floor( ( time() - $max_ts ) / DAY_IN_SECONDS ),
+				'span_days'  => (int) floor( ( $max_ts - $min_ts ) / DAY_IN_SECONDS ),
+			);
 		}
 
 		return array(
 			'success'       => true,
 			'action'        => $action,
-			'results_count' => is_array( $results ) ? count( $results ) : 0,
+			'results_count' => count( $results ),
+			'date_range'    => $date_range,
 			'results'       => $results,
+		);
+	}
+
+	/**
+	 * Parse Bing's WCF /Date(timestamp)/ format.
+	 *
+	 * @param string $date_string Bing date string like "/Date(1316156400000-0700)/".
+	 * @return array|null Array with 'timestamp' (Unix) and 'iso' (Y-m-d) keys, or null.
+	 */
+	public static function parseBingDate( string $date_string ): ?array {
+		if ( ! preg_match( self::DATE_REGEX, $date_string, $matches ) ) {
+			return null;
+		}
+
+		$ms        = (int) $matches[1];
+		$timestamp = (int) floor( $ms / 1000 );
+
+		return array(
+			'timestamp' => $timestamp,
+			'iso'       => gmdate( 'Y-m-d', $timestamp ),
 		);
 	}
 

--- a/inc/Cli/Commands/AnalyticsCommand.php
+++ b/inc/Cli/Commands/AnalyticsCommand.php
@@ -104,6 +104,9 @@ class AnalyticsCommand extends BaseCommand {
 	 * [--limit=<number>]
 	 * : Maximum number of results (default: 20).
 	 *
+	 * [--days=<number>]
+	 * : Only show data from the last N days (client-side filter).
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -125,6 +128,9 @@ class AnalyticsCommand extends BaseCommand {
 	 *     # Crawl stats with limit
 	 *     wp datamachine analytics bing crawl_stats --limit=50
 	 *
+	 *     # Only last 30 days of data
+	 *     wp datamachine analytics bing traffic_stats --days=30
+	 *
 	 * @subcommand bing
 	 */
 	public function bing( array $args, array $assoc_args ): void {
@@ -134,6 +140,7 @@ class AnalyticsCommand extends BaseCommand {
 
 		$this->map_optional( $input, $assoc_args, array(
 			'limit' => 'limit',
+			'days'  => 'days',
 		) );
 
 		$this->execute_ability( 'datamachine/bing-webmaster', $input, $assoc_args );
@@ -345,15 +352,23 @@ class AnalyticsCommand extends BaseCommand {
 			$this->format_items( $flat_results, $fields, $assoc_args );
 		}
 
-		// Show summary.
+		// Show summary with date range if available.
 		$count = $result['results_count'] ?? count( $results );
-		if ( isset( $result['date_range'] ) ) {
-			WP_CLI::log( sprintf(
-				'%d results (%s to %s)',
-				$count,
-				$result['date_range']['start_date'] ?? '?',
-				$result['date_range']['end_date'] ?? '?'
-			) );
+		if ( ! empty( $result['date_range'] ) ) {
+			$range    = $result['date_range'];
+			$start    = $range['start_date'] ?? '?';
+			$end      = $range['end_date'] ?? '?';
+			$days_ago = $range['days_ago'] ?? null;
+
+			WP_CLI::log( sprintf( '%d results (%s to %s)', $count, $start, $end ) );
+
+			if ( null !== $days_ago && $days_ago > 30 ) {
+				WP_CLI::warning( sprintf(
+					'Data is %d days stale (latest: %s). Check API key and site verification.',
+					$days_ago,
+					$end
+				) );
+			}
 		} else {
 			WP_CLI::log( sprintf( '%d results', $count ) );
 		}


### PR DESCRIPTION
## Summary

- **Parses Bing's `/Date(timestamp)/` WCF format** into ISO 8601 (`Y-m-d`) for human-readable output
- **Adds `date_range` metadata** to Bing ability responses (`start_date`, `end_date`, `days_ago`, `span_days`)
- **Adds `--days` CLI flag** for client-side date filtering (e.g. `--days=30` for last 30 days only)
- **Shows staleness warning** when data is >30 days old, prompting users to check their API key/site verification
- **`parseBingDate()` static method** for reuse across tools and tests

## Problem

`wp datamachine analytics bing traffic_stats` returned data from Nov 2024 — 436 days stale — with no indication anything was wrong. The raw output showed opaque `/Date(1316156400000-0700)/` strings.

After investigating the Bing Webmaster API docs: **the API does not accept date parameters**. It returns whatever data window Bing provides. The staleness is a Bing-side issue (likely expired API key or lapsed site verification), not a missing parameter.

## What this fixes

```
# Before: opaque dates, no staleness signal
Date: /Date(1730419200000-0700)/

# After: readable dates + clear warning
Date: 2024-11-01
20 results (2024-11-01 to 2024-12-20)
Warning: Data is 436 days stale (latest: 2024-12-20). Check API key and site verification.
```

## New CLI usage

```bash
# Show only last 30 days of data
wp datamachine analytics bing traffic_stats --days=30

# Full output with dates parsed
wp datamachine analytics bing query_stats --format=json
```

Fixes #476