### PR TITLE
fix: actionable error message on PageSpeed 429 rate limiting

### DIFF
--- a/inc/Abilities/Analytics/PageSpeedAbilities.php
+++ b/inc/Abilities/Analytics/PageSpeedAbilities.php
@@ -199,9 +199,20 @@ class PageSpeedAbilities {
 		);
 
 		if ( ! $result['success'] ) {
+			$error_msg = $result['error'] ?? 'Unknown error';
+
+			// Detect rate limiting and provide actionable guidance.
+			$status_code = $result['status_code'] ?? 0;
+			if ( 429 === $status_code || false !== strpos( $error_msg, '429' ) ) {
+				$has_key = ! empty( $config['api_key'] );
+				$error_msg = $has_key
+					? 'PageSpeed API rate limit exceeded even with an API key. Wait a few minutes and try again, or check your Google Cloud Console quota.'
+					: 'PageSpeed API rate limit exceeded. Configure a Google API key in Data Machine settings (Tools → PageSpeed) for higher limits. Get a free key at https://console.cloud.google.com/apis/credentials (enable PageSpeed Insights API).';
+			}
+
 			return array(
 				'success' => false,
-				'error'   => 'Failed to connect to PageSpeed Insights API: ' . ( $result['error'] ?? 'Unknown error' ),
+				'error'   => $error_msg,
 			);
 		}
 


### PR DESCRIPTION
## Summary

- **Detects HTTP 429 responses from PageSpeed API** and replaces the generic error with actionable guidance
- **Without API key**: tells user to configure one in Data Machine settings, includes Google Cloud Console link
- **With API key**: suggests waiting or checking quota instead

## Problem

`wp datamachine analytics pagespeed analyze` returns a raw error:

```
Error: Failed to connect to PageSpeed Insights API: PageSpeed Insights API GET returned HTTP 429
```

Users don't know that the fix is to configure a Google API key — even though the infrastructure already exists (settings UI field, save handler, ability reads `?key=` param).

Confirmed live on chubes.net — the 429 fires without a key configured.

## After fix

```
Error: PageSpeed API rate limit exceeded. Configure a Google API key in
Data Machine settings (Tools → PageSpeed) for higher limits. Get a free
key at https://console.cloud.google.com/apis/credentials (enable
PageSpeed Insights API).
```

## Note

The API key plumbing was already complete — this was just a UX gap in the error message.

Fixes #477