### PR TITLE
Fix normalizer wiping handler config for non-handler steps

### DIFF
--- a/inc/Abilities/FlowStep/FlowStepNormalizer.php
+++ b/inc/Abilities/FlowStep/FlowStepNormalizer.php
@@ -41,9 +41,17 @@ class FlowStepNormalizer {
 			$step_config['handler_configs'] = array( $slug => $config );
 			unset( $step_config['handler_slug'], $step_config['handler_config'] );
 		} else {
-			$step_config['handler_slugs']   = array();
-			$step_config['handler_configs'] = array();
-			unset( $step_config['handler_slug'] );
+			// No handler_slug — use step_type as key for non-handler steps (agent_ping, webhook_gate, etc.)
+			// that store config in handler_config without a handler_slug.
+			$step_type = $step_config['step_type'] ?? '';
+			if ( ! empty( $step_type ) && ! empty( $config ) ) {
+				$step_config['handler_slugs']   = array( $step_type );
+				$step_config['handler_configs'] = array( $step_type => $config );
+			} else {
+				$step_config['handler_slugs']   = array();
+				$step_config['handler_configs'] = array();
+			}
+			unset( $step_config['handler_slug'], $step_config['handler_config'] );
 		}
 
 		return $step_config;


### PR DESCRIPTION
## Summary

Fixes #485 — editing a flow's prompt via CLI wiped `auth_token` (and all other handler config) for agent_ping steps.

## Root Cause

`FlowStepNormalizer::normalizeHandlerFields()` has three branches:
1. Step already has `handler_slugs` → keep/migrate `handler_configs` ✓
2. Step has legacy `handler_slug` → migrate to `handler_configs[slug]` ✓
3. Step has neither → **set `handler_configs = {}`, wiping all config** ✗

Agent ping steps hit branch 3 because they store config in `handler_config` but have no `handler_slug` — they use `step_type` as their pseudo-handler. The normalizer didn't account for this, so `updateHandler()` found an empty `handler_configs['agent_ping']`, merged with just `{ prompt: "..." }`, and `applyDefaults()` filled `auth_token` with its schema default: empty string.

## Fix

Branch 3 now checks for `step_type` + existing config data. When both are present, it migrates `handler_config` into `handler_configs[step_type]` — the same effective slug resolution pattern used by `UpdateFlowStepAbility`, `FlowStepHelpers`, and `FlowFormatter`.

## Impact

- Prevents silent credential loss on any non-handler step type (agent_ping, webhook_gate)
- One-file, 11-line change in `FlowStepNormalizer.php`
- No behavioral change for handler-based steps (AI, Publish, etc.)