### PR TITLE
Add FlowStepNormalizer::getEffectiveSlug() — centralize config slug resolution

### DIFF
--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -241,10 +241,10 @@ class ConfigureFlowStepsAbility {
 					}
 				}
 
-				$existing_handler_slug   = FlowStepNormalizer::getPrimaryHandlerSlug( $step_config );
+				$existing_handler_slug   = FlowStepNormalizer::getEffectiveSlug( $step_config );
 				$existing_handler_config = FlowStepNormalizer::getPrimaryHandlerConfig( $step_config );
 
-				$effective_handler_slug = $target_handler_slug ?? $existing_handler_slug;
+				$effective_handler_slug = FlowStepNormalizer::getEffectiveSlug( $step_config, $target_handler_slug ?? '' );
 
 				if ( empty( $effective_handler_slug ) ) {
 					$errors[] = array(
@@ -547,7 +547,7 @@ class ConfigureFlowStepsAbility {
 				$handler_config = $config['handler_config'] ?? array();
 				$user_message   = $config['user_message'] ?? null;
 
-				$effective_slug = $handler_slug ?? FlowStepNormalizer::getPrimaryHandlerSlug( $flow_config[ $flow_step_id ] );
+				$effective_slug = FlowStepNormalizer::getEffectiveSlug( $flow_config[ $flow_step_id ], $handler_slug ?? '' );
 
 				if ( ! empty( $handler_config ) && ! empty( $effective_slug ) ) {
 					$validation_result = $this->validateHandlerConfig( $effective_slug, $handler_config );
@@ -762,10 +762,10 @@ class ConfigureFlowStepsAbility {
 			$flow_id      = (int) $flow['flow_id'];
 			$flow_name    = $flow['flow_name'] ?? __( 'Unnamed Flow', 'data-machine' );
 
-			$existing_handler_slug   = FlowStepNormalizer::getPrimaryHandlerSlug( $step_config );
+			$existing_handler_slug   = FlowStepNormalizer::getEffectiveSlug( $step_config );
 			$existing_handler_config = FlowStepNormalizer::getPrimaryHandlerConfig( $step_config );
 
-			$effective_handler_slug = $target_handler_slug ?? $existing_handler_slug;
+			$effective_handler_slug = FlowStepNormalizer::getEffectiveSlug( $step_config, $target_handler_slug ?? '' );
 			$is_switching           = ! empty( $target_handler_slug ) && $target_handler_slug !== $existing_handler_slug;
 
 			if ( $is_switching && ! empty( $existing_handler_config ) ) {

--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -272,11 +272,7 @@ trait FlowStepHelpers {
 		// Normalize the existing step config to use plural fields as source of truth.
 		$flow_config[ $flow_step_id ] = FlowStepNormalizer::normalizeHandlerFields( $flow_config[ $flow_step_id ] );
 
-		// Priority: explicit handler_slug > existing handler_slugs[0] > step_type (for non-handler steps like agent_ping).
-		$effective_slug = ! empty( $handler_slug )
-			? $handler_slug
-			: ( FlowStepNormalizer::getPrimaryHandlerSlug( $flow_config[ $flow_step_id ] )
-				?: ( $flow_config[ $flow_step_id ]['step_type'] ?? null ) );
+		$effective_slug = FlowStepNormalizer::getEffectiveSlug( $flow_config[ $flow_step_id ], $handler_slug );
 
 		if ( empty( $effective_slug ) ) {
 			do_action( 'datamachine_log', 'error', 'No handler slug or step_type available for flow step update', array( 'flow_step_id' => $flow_step_id ) );

--- a/inc/Abilities/FlowStep/FlowStepNormalizer.php
+++ b/inc/Abilities/FlowStep/FlowStepNormalizer.php
@@ -71,6 +71,37 @@ class FlowStepNormalizer {
 	}
 
 	/**
+	 * Resolve the effective config slug for a flow step.
+	 *
+	 * Single source of truth for determining which slug to use when reading
+	 * or writing handler_configs. Works for both handler-based steps (fetch,
+	 * publish, update) and self-configuring steps (agent_ping, webhook_gate,
+	 * system_task) that use step_type as their config key.
+	 *
+	 * Priority:
+	 * 1. Explicit slug (caller override, e.g. from API input)
+	 * 2. Primary slug from handler_slugs[0] (normalized data)
+	 * 3. Legacy handler_slug (pre-normalization data)
+	 * 4. step_type (self-configuring steps)
+	 *
+	 * @param array  $step_config   Step configuration array.
+	 * @param string $explicit_slug Optional caller-provided slug (highest priority).
+	 * @return string Resolved slug, or empty string if none available.
+	 */
+	public static function getEffectiveSlug( array $step_config, string $explicit_slug = '' ): string {
+		if ( ! empty( $explicit_slug ) ) {
+			return $explicit_slug;
+		}
+
+		$primary = self::getPrimaryHandlerSlug( $step_config );
+		if ( ! empty( $primary ) ) {
+			return $primary;
+		}
+
+		return $step_config['step_type'] ?? '';
+	}
+
+	/**
 	 * Get the primary handler config from a normalized step config.
 	 *
 	 * @param array $step_config Step configuration array.

--- a/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
+++ b/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
@@ -132,12 +132,7 @@ class UpdateFlowStepAbility {
 		$updated_fields = array();
 
 		if ( $has_handler_update ) {
-			// Priority: explicit handler_slug > existing handler_slug > step_type (for non-handler steps like agent_ping).
-			$effective_slug = ! empty( $handler_slug )
-				? $handler_slug
-				: ( ! empty( FlowStepNormalizer::getPrimaryHandlerSlug( $existing_step ) )
-					? FlowStepNormalizer::getPrimaryHandlerSlug( $existing_step )
-					: ( $existing_step['step_type'] ?? '' ) );
+			$effective_slug = FlowStepNormalizer::getEffectiveSlug( $existing_step, $handler_slug ?? '' );
 
 			if ( empty( $effective_slug ) ) {
 				return array(

--- a/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
+++ b/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
@@ -206,8 +206,8 @@ class ValidateFlowStepsConfigAbility {
 
 				++$total_matching_steps;
 
-				$existing_handler_slug  = FlowStepNormalizer::getPrimaryHandlerSlug( $step_config );
-				$effective_handler_slug = $target_handler_slug ?? $existing_handler_slug;
+				$existing_handler_slug  = FlowStepNormalizer::getEffectiveSlug( $step_config );
+				$effective_handler_slug = FlowStepNormalizer::getEffectiveSlug( $step_config, $target_handler_slug ?? '' );
 
 				if ( empty( $effective_handler_slug ) ) {
 					$validation_errors[] = array(

--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -37,12 +37,8 @@ class FlowFormatter {
 			$step_data['handler_slug']   = FlowStepNormalizer::getPrimaryHandlerSlug( $step_data );
 			$step_data['handler_config'] = FlowStepNormalizer::getPrimaryHandlerConfig( $step_data );
 
-			$step_type    = $step_data['step_type'] ?? '';
-			$handler_slug = $step_data['handler_slug'] ?? '';
-
-			// For step types with usesHandler: false, use step_type as effective handler_slug
-			// This ensures settings_display is generated for steps like agent_ping
-			$effective_slug = ! empty( $handler_slug ) ? $handler_slug : $step_type;
+			$step_type      = $step_data['step_type'] ?? '';
+			$effective_slug = FlowStepNormalizer::getEffectiveSlug( $step_data );
 
 			// Skip steps with no handler or step type
 			if ( empty( $effective_slug ) ) {

--- a/inc/Core/Steps/Settings/SettingsDisplayService.php
+++ b/inc/Core/Steps/Settings/SettingsDisplayService.php
@@ -48,15 +48,8 @@ class SettingsDisplayService {
 			return array();
 		}
 
-		// Data is normalized at the DB layer.
-		$handler_slug     = FlowStepNormalizer::getPrimaryHandlerSlug( $flow_step_config );
+		$handler_slug     = FlowStepNormalizer::getEffectiveSlug( $flow_step_config );
 		$current_settings = FlowStepNormalizer::getPrimaryHandlerConfig( $flow_step_config );
-
-		// For step types with usesHandler: false, fall back to step_type as settings key
-		// This allows steps like agent_ping to display their config without a traditional handler
-		if ( empty( $handler_slug ) && ! empty( $step_type ) ) {
-			$handler_slug = $step_type;
-		}
 
 		return $this->getDisplayForHandler( $handler_slug, $current_settings );
 	}
@@ -89,12 +82,8 @@ class SettingsDisplayService {
 
 		// Fallback: build from primary handler when configs are empty.
 		if ( empty( $handler_configs ) ) {
-			$handler_slug     = FlowStepNormalizer::getPrimaryHandlerSlug( $flow_step_config );
+			$handler_slug     = FlowStepNormalizer::getEffectiveSlug( $flow_step_config );
 			$current_settings = FlowStepNormalizer::getPrimaryHandlerConfig( $flow_step_config );
-
-			if ( empty( $handler_slug ) && ! empty( $step_type ) ) {
-				$handler_slug = $step_type;
-			}
 
 			if ( empty( $handler_slug ) ) {
 				return array();


### PR DESCRIPTION
## Summary

Closes #488 — replaces 9 scattered `$handler_slug ?: $step_type` patterns with one authoritative method: `FlowStepNormalizer::getEffectiveSlug()`.

## The Problem

Self-configuring steps (agent_ping, webhook_gate, system_task) don't use handlers — they store config directly in `handler_configs[step_type]`. Every place in the codebase that needs to resolve a config slug was independently implementing the same fallback:

```php
$effective_slug = $handler_slug ?: ($existing_slug ?: $step_type);
```

This was done **inconsistently** across 7 files — some had the `step_type` fallback, some didn't. The inconsistency caused #485 (normalizer wiped agent_ping config) and two other locations (`ConfigureFlowStepsAbility`, `ValidateFlowStepsConfigAbility`) had the same latent bug.

## The Fix

One method with documented priority order:

```php
FlowStepNormalizer::getEffectiveSlug( $step_config, $explicit_slug = '' ): string
```

1. Explicit slug (caller override, e.g. from API input)
2. `handler_slugs[0]` (normalized data)
3. Legacy `handler_slug` (pre-normalization data)
4. `step_type` (self-configuring steps)

## Changes

| File | Before | After |
|------|--------|-------|
| `FlowStepNormalizer.php` | — | New `getEffectiveSlug()` method |
| `FlowStepHelpers.php` | 5-line ternary | 1-line call |
| `UpdateFlowStepAbility.php` | 6-line ternary | 1-line call |
| `FlowFormatter.php` | 4-line fallback | 1-line call |
| `SettingsDisplayService.php` | Two 4-line fallbacks | Two 1-line calls |
| `ConfigureFlowStepsAbility.php` | 3 locations missing step_type fallback | 3 correct calls |
| `ValidateFlowStepsConfigAbility.php` | Missing step_type fallback | Correct call |

**7 files, +44/-37 lines.** Net reduction + bug prevention.

## Not Changed

`Api/Handlers.php` — its handler-vs-step-type fallback is an API boundary concern (slug lookup), not a config resolution. Left as-is with existing clear comments.