### PR TITLE
Add meta description system task for SEO generation

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -132,6 +132,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/SystemAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/AltTextAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/ImageGenerationAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/SEO/MetaDescriptionAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/ImageTemplateAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Analytics/BingWebmasterAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php';
@@ -177,6 +178,7 @@ function datamachine_run_datamachine_plugin() {
 		new \DataMachine\Engine\AI\System\SystemAgentServiceProvider();
 		new \DataMachine\Abilities\Media\AltTextAbilities();
 		new \DataMachine\Abilities\Media\ImageGenerationAbilities();
+		new \DataMachine\Abilities\SEO\MetaDescriptionAbilities();
 		new \DataMachine\Abilities\Media\ImageTemplateAbilities();
 		new \DataMachine\Abilities\Analytics\BingWebmasterAbilities();
 		new \DataMachine\Abilities\Analytics\GoogleAnalyticsAbilities();

--- a/inc/Abilities/SEO/MetaDescriptionAbilities.php
+++ b/inc/Abilities/SEO/MetaDescriptionAbilities.php
@@ -1,0 +1,335 @@
+<?php
+/**
+ * Meta Description Abilities
+ *
+ * Ability endpoints for AI-powered meta description generation and diagnostics.
+ * Delegates async execution to the System Agent infrastructure.
+ *
+ * @package DataMachine\Abilities\SEO
+ * @since 0.31.0
+ */
+
+namespace DataMachine\Abilities\SEO;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\System\SystemAgent;
+use DataMachine\Engine\AI\System\Tasks\MetaDescriptionTask;
+
+defined( 'ABSPATH' ) || exit;
+
+class MetaDescriptionAbilities {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/generate-meta-description',
+				array(
+					'label'               => 'Generate Meta Description',
+					'description'         => 'Queue system agent generation of meta descriptions for posts',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'post_id'   => array(
+								'type'        => 'integer',
+								'description' => 'Post ID to generate meta description for',
+							),
+							'post_type' => array(
+								'type'        => 'string',
+								'description' => 'Post type to batch process (e.g. "post", "page")',
+								'default'     => 'post',
+							),
+							'limit'     => array(
+								'type'        => 'integer',
+								'description' => 'Maximum posts to queue (for batch mode)',
+								'default'     => 50,
+							),
+							'force'     => array(
+								'type'        => 'boolean',
+								'description' => 'Force regeneration even if meta description exists',
+								'default'     => false,
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'      => array( 'type' => 'boolean' ),
+							'queued_count' => array( 'type' => 'integer' ),
+							'post_ids'     => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'integer' ),
+							),
+							'message'      => array( 'type' => 'string' ),
+							'error'        => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'generateMetaDescriptions' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/diagnose-meta-descriptions',
+				array(
+					'label'               => 'Diagnose Meta Descriptions',
+					'description'         => 'Report meta description coverage for posts',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'post_type' => array(
+								'type'        => 'string',
+								'description' => 'Post type to diagnose (default: post)',
+								'default'     => 'post',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'       => array( 'type' => 'boolean' ),
+							'total_posts'   => array( 'type' => 'integer' ),
+							'missing_count' => array( 'type' => 'integer' ),
+							'has_count'     => array( 'type' => 'integer' ),
+							'coverage'      => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'diagnoseMetaDescriptions' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Generate meta descriptions for posts.
+	 *
+	 * Supports single post (post_id) or batch mode (post_type + limit).
+	 *
+	 * @param array $input Ability input.
+	 * @return array Ability response.
+	 */
+	public static function generateMetaDescriptions( array $input ): array {
+		$post_id   = absint( $input['post_id'] ?? 0 );
+		$post_type = sanitize_key( $input['post_type'] ?? 'post' );
+		$limit     = absint( $input['limit'] ?? 50 );
+		$force     = ! empty( $input['force'] );
+
+		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$provider        = $system_defaults['provider'];
+		$model           = $system_defaults['model'];
+
+		if ( empty( $provider ) || empty( $model ) ) {
+			return array(
+				'success'      => false,
+				'queued_count' => 0,
+				'post_ids'     => array(),
+				'message'      => 'No default AI provider/model configured.',
+				'error'        => 'Configure default_provider and default_model in Data Machine settings.',
+			);
+		}
+
+		$meta_key = apply_filters( 'datamachine_meta_description_meta_key', MetaDescriptionTask::DEFAULT_META_KEY );
+
+		// Single post mode.
+		if ( $post_id > 0 ) {
+			$post = get_post( $post_id );
+			if ( ! $post ) {
+				return array(
+					'success'      => false,
+					'queued_count' => 0,
+					'post_ids'     => array(),
+					'error'        => "Post #{$post_id} not found.",
+				);
+			}
+
+			if ( ! $force && ! self::isDescriptionMissing( $post_id, $meta_key ) ) {
+				return array(
+					'success'      => true,
+					'queued_count' => 0,
+					'post_ids'     => array(),
+					'message'      => "Post #{$post_id} already has a meta description. Use --force to regenerate.",
+				);
+			}
+
+			$eligible = array( $post_id );
+		} else {
+			// Batch mode — find posts missing meta descriptions.
+			$eligible = self::findPostsMissingDescription( $post_type, $meta_key, $limit, $force );
+		}
+
+		if ( empty( $eligible ) ) {
+			return array(
+				'success'      => true,
+				'queued_count' => 0,
+				'post_ids'     => array(),
+				'message'      => 'No posts found missing meta descriptions.',
+			);
+		}
+
+		// Build per-item params for batch scheduling.
+		$item_params = array();
+		foreach ( $eligible as $id ) {
+			$item_params[] = array(
+				'post_id' => $id,
+				'force'   => $force,
+				'source'  => 'ability',
+			);
+		}
+
+		$systemAgent = SystemAgent::getInstance();
+		$batch       = $systemAgent->scheduleBatch( 'meta_description_generation', $item_params );
+
+		if ( false === $batch ) {
+			return array(
+				'success'      => false,
+				'queued_count' => 0,
+				'post_ids'     => array(),
+				'error'        => 'System Agent batch scheduling failed.',
+			);
+		}
+
+		return array(
+			'success'      => true,
+			'queued_count' => count( $eligible ),
+			'post_ids'     => $eligible,
+			'batch_id'     => $batch['batch_id'] ?? null,
+			'message'      => sprintf(
+				'Meta description generation scheduled for %d post(s).',
+				count( $eligible )
+			),
+		);
+	}
+
+	/**
+	 * Diagnose meta description coverage.
+	 *
+	 * @param array $input Ability input.
+	 * @return array Ability response.
+	 */
+	public static function diagnoseMetaDescriptions( array $input = array() ): array {
+		global $wpdb;
+
+		$post_type = sanitize_key( $input['post_type'] ?? 'post' );
+		$meta_key  = apply_filters( 'datamachine_meta_description_meta_key', MetaDescriptionTask::DEFAULT_META_KEY );
+
+		$total_posts = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = 'publish'",
+				$post_type
+			)
+		);
+
+		$missing_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*)
+				 FROM {$wpdb->posts} p
+				 LEFT JOIN {$wpdb->postmeta} m
+					ON p.ID = m.post_id AND m.meta_key = %s
+				 WHERE p.post_type = %s
+				 AND p.post_status = 'publish'
+				 AND ( m.meta_id IS NULL OR m.meta_value = '' OR m.meta_value IS NULL )",
+				$meta_key,
+				$post_type
+			)
+		);
+
+		$has_count = $total_posts - $missing_count;
+		$coverage  = $total_posts > 0
+			? round( ( $has_count / $total_posts ) * 100, 1 ) . '%'
+			: '0%';
+
+		return array(
+			'success'       => true,
+			'total_posts'   => $total_posts,
+			'missing_count' => $missing_count,
+			'has_count'     => $has_count,
+			'coverage'      => $coverage,
+			'post_type'     => $post_type,
+			'meta_key'      => $meta_key,
+		);
+	}
+
+	/**
+	 * Find published posts missing a meta description.
+	 *
+	 * @param string $post_type Post type to query.
+	 * @param string $meta_key  Meta key to check.
+	 * @param int    $limit     Maximum results.
+	 * @param bool   $force     If true, return all posts regardless of meta.
+	 * @return int[] Post IDs.
+	 */
+	private static function findPostsMissingDescription( string $post_type, string $meta_key, int $limit, bool $force ): array {
+		global $wpdb;
+
+		if ( $force ) {
+			$results = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT ID FROM {$wpdb->posts}
+					 WHERE post_type = %s AND post_status = 'publish'
+					 ORDER BY ID DESC LIMIT %d",
+					$post_type,
+					$limit
+				)
+			);
+		} else {
+			$results = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT p.ID
+					 FROM {$wpdb->posts} p
+					 LEFT JOIN {$wpdb->postmeta} m
+						ON p.ID = m.post_id AND m.meta_key = %s
+					 WHERE p.post_type = %s
+					 AND p.post_status = 'publish'
+					 AND ( m.meta_id IS NULL OR m.meta_value = '' OR m.meta_value IS NULL )
+					 ORDER BY p.ID DESC
+					 LIMIT %d",
+					$meta_key,
+					$post_type,
+					$limit
+				)
+			);
+		}
+
+		return array_map( 'absint', $results ?: array() );
+	}
+
+	/**
+	 * Check if a post's meta description is missing or empty.
+	 *
+	 * @param int    $post_id  Post ID.
+	 * @param string $meta_key Meta key to check.
+	 * @return bool True if description is missing/empty.
+	 */
+	private static function isDescriptionMissing( int $post_id, string $meta_key ): bool {
+		$description = get_post_meta( $post_id, $meta_key, true );
+		$description = is_string( $description ) ? trim( $description ) : '';
+
+		return '' === $description;
+	}
+}

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -45,3 +45,4 @@ WP_CLI::add_command( 'datamachine link', Commands\LinksCommand::class );
 WP_CLI::add_command( 'datamachine blocks', Commands\BlocksCommand::class );
 WP_CLI::add_command( 'datamachine block', Commands\BlocksCommand::class );
 WP_CLI::add_command( 'datamachine analytics', Commands\AnalyticsCommand::class );
+WP_CLI::add_command( 'datamachine meta-description', Commands\MetaDescriptionCommand::class );

--- a/inc/Cli/Commands/MetaDescriptionCommand.php
+++ b/inc/Cli/Commands/MetaDescriptionCommand.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * WP-CLI Meta Description Command
+ *
+ * Provides CLI access to meta description diagnostics and generation.
+ * Wraps MetaDescriptionAbilities API primitives.
+ *
+ * @package DataMachine\Cli\Commands
+ * @since 0.31.0
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Abilities\SEO\MetaDescriptionAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class MetaDescriptionCommand extends BaseCommand {
+
+	/**
+	 * Diagnose meta description coverage for posts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--post_type=<type>]
+	 * : Post type to diagnose.
+	 * ---
+	 * default: post
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * [--fields=<fields>]
+	 * : Limit output to specific fields (comma-separated).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Diagnose meta description coverage
+	 *     wp datamachine meta-description diagnose
+	 *
+	 *     # Diagnose pages
+	 *     wp datamachine meta-description diagnose --post_type=page
+	 *
+	 *     # JSON output
+	 *     wp datamachine meta-description diagnose --format=json
+	 *
+	 * @subcommand diagnose
+	 */
+	public function diagnose( array $args, array $assoc_args ): void {
+		$post_type = $assoc_args['post_type'] ?? 'post';
+		$format    = $assoc_args['format'] ?? 'table';
+
+		$result = MetaDescriptionAbilities::diagnoseMetaDescriptions(
+			array( 'post_type' => $post_type )
+		);
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to diagnose meta descriptions.' );
+			return;
+		}
+
+		$total   = (int) ( $result['total_posts'] ?? 0 );
+		$missing = (int) ( $result['missing_count'] ?? 0 );
+		$has     = (int) ( $result['has_count'] ?? 0 );
+
+		if ( 'json' === $format ) {
+			WP_CLI::line(
+				\wp_json_encode(
+					array(
+						'post_type'     => $result['post_type'] ?? $post_type,
+						'meta_key'      => $result['meta_key'] ?? '',
+						'total_posts'   => $total,
+						'has_count'     => $has,
+						'missing_count' => $missing,
+						'coverage'      => $result['coverage'] ?? '0%',
+					),
+					JSON_PRETTY_PRINT
+				)
+			);
+			return;
+		}
+
+		$items = array(
+			array(
+				'post_type'     => $result['post_type'] ?? $post_type,
+				'total_posts'   => $total,
+				'has_count'     => $has,
+				'missing_count' => $missing,
+				'coverage'      => $result['coverage'] ?? '0%',
+			),
+		);
+
+		$this->format_items(
+			$items,
+			array( 'post_type', 'total_posts', 'has_count', 'missing_count', 'coverage' ),
+			$assoc_args
+		);
+	}
+
+	/**
+	 * Queue meta description generation for posts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--post_id=<id>]
+	 * : Single post ID to generate a description for.
+	 *
+	 * [--post_type=<type>]
+	 * : Post type to batch process (used when --post_id is not set).
+	 * ---
+	 * default: post
+	 * ---
+	 *
+	 * [--limit=<number>]
+	 * : Maximum posts to queue in batch mode.
+	 * ---
+	 * default: 50
+	 * ---
+	 *
+	 * [--force]
+	 * : Force regeneration even if meta description exists.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * [--fields=<fields>]
+	 * : Limit output to specific fields (comma-separated).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Generate for a specific post
+	 *     wp datamachine meta-description generate --post_id=123
+	 *
+	 *     # Batch generate for posts missing descriptions
+	 *     wp datamachine meta-description generate --limit=100
+	 *
+	 *     # Batch generate for pages
+	 *     wp datamachine meta-description generate --post_type=page --limit=50
+	 *
+	 *     # Force regeneration for a specific post
+	 *     wp datamachine meta-description generate --post_id=123 --force
+	 *
+	 * @subcommand generate
+	 */
+	public function generate( array $args, array $assoc_args ): void {
+		$post_id   = isset( $assoc_args['post_id'] ) ? \absint( $assoc_args['post_id'] ) : 0;
+		$post_type = $assoc_args['post_type'] ?? 'post';
+		$limit     = isset( $assoc_args['limit'] ) ? \absint( $assoc_args['limit'] ) : 50;
+		$force     = isset( $assoc_args['force'] );
+		$format    = $assoc_args['format'] ?? 'table';
+
+		$result = MetaDescriptionAbilities::generateMetaDescriptions(
+			array(
+				'post_id'   => $post_id,
+				'post_type' => $post_type,
+				'limit'     => $limit,
+				'force'     => $force,
+			)
+		);
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to queue meta description generation.' );
+			return;
+		}
+
+		$queued_count = (int) ( $result['queued_count'] ?? 0 );
+		$post_ids     = $result['post_ids'] ?? array();
+		$post_ids     = is_array( $post_ids ) ? array_values( array_map( 'intval', $post_ids ) ) : array();
+
+		if ( 'json' === $format ) {
+			WP_CLI::line(
+				\wp_json_encode(
+					array(
+						'queued_count' => $queued_count,
+						'post_ids'     => $post_ids,
+						'batch_id'     => $result['batch_id'] ?? null,
+					),
+					JSON_PRETTY_PRINT
+				)
+			);
+			return;
+		}
+
+		if ( 'table' === $format && ! empty( $result['message'] ) ) {
+			WP_CLI::success( $result['message'] );
+		}
+
+		$items = array(
+			array(
+				'queued_count' => $queued_count,
+				'post_ids'     => empty( $post_ids ) ? '' : implode( ', ', $post_ids ),
+			),
+		);
+
+		$this->format_items( $items, array( 'queued_count', 'post_ids' ), $assoc_args );
+	}
+}

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -18,6 +18,7 @@ use DataMachine\Engine\AI\System\Tasks\DailyMemoryTask;
 use DataMachine\Engine\AI\System\Tasks\GitHubIssueTask;
 use DataMachine\Engine\AI\System\Tasks\ImageGenerationTask;
 use DataMachine\Engine\AI\System\Tasks\InternalLinkingTask;
+use DataMachine\Engine\AI\System\Tasks\MetaDescriptionTask;
 use DataMachine\Core\PluginSettings;
 
 class SystemAgentServiceProvider {
@@ -61,7 +62,8 @@ class SystemAgentServiceProvider {
 		$tasks['alt_text_generation']     = AltTextTask::class;
 		$tasks['github_create_issue']     = GitHubIssueTask::class;
 		$tasks['internal_linking']        = InternalLinkingTask::class;
-		$tasks['daily_memory_generation'] = DailyMemoryTask::class;
+		$tasks['daily_memory_generation']       = DailyMemoryTask::class;
+		$tasks['meta_description_generation']   = MetaDescriptionTask::class;
 
 		return $tasks;
 	}

--- a/inc/Engine/AI/System/Tasks/MetaDescriptionTask.php
+++ b/inc/Engine/AI/System/Tasks/MetaDescriptionTask.php
@@ -1,0 +1,303 @@
+<?php
+/**
+ * Meta Description Generation Task for System Agent.
+ *
+ * Generates AI-powered meta descriptions for posts. Gathers post title,
+ * excerpt, content, and taxonomy context, sends to the configured AI
+ * provider, normalizes the response, and saves to the configured meta key.
+ *
+ * @package DataMachine\Engine\AI\System\Tasks
+ * @since 0.31.0
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\RequestBuilder;
+
+class MetaDescriptionTask extends SystemTask {
+
+	/**
+	 * Meta key for storing the generated description.
+	 *
+	 * Defaults to _lean_seo_description (Lean SEO). Configurable via the
+	 * datamachine_meta_description_meta_key filter for other SEO plugins.
+	 */
+	const DEFAULT_META_KEY = '_lean_seo_description';
+
+	/**
+	 * Maximum character length for meta descriptions.
+	 *
+	 * Google truncates at ~155-160 characters. Targeting 155 to stay safe.
+	 */
+	const MAX_LENGTH = 155;
+
+	/**
+	 * Maximum content characters to include in the prompt.
+	 */
+	const CONTENT_EXCERPT_LENGTH = 1500;
+
+	/**
+	 * Execute meta description generation for a specific post.
+	 *
+	 * @param int   $jobId  Job ID from DM Jobs table.
+	 * @param array $params Task parameters from engine_data.
+	 */
+	public function execute( int $jobId, array $params ): void {
+		$post_id = absint( $params['post_id'] ?? 0 );
+		$force   = ! empty( $params['force'] );
+
+		if ( $post_id <= 0 ) {
+			$this->failJob( $jobId, 'Missing or invalid post_id' );
+			return;
+		}
+
+		$post = get_post( $post_id );
+
+		if ( ! $post ) {
+			$this->failJob( $jobId, "Post #{$post_id} not found" );
+			return;
+		}
+
+		if ( 'publish' !== $post->post_status && 'future' !== $post->post_status ) {
+			$this->failJob( $jobId, "Post #{$post_id} is not published (status: {$post->post_status})" );
+			return;
+		}
+
+		$meta_key = $this->getMetaKey();
+
+		if ( ! $force && ! $this->isDescriptionMissing( $post_id, $meta_key ) ) {
+			$this->completeJob( $jobId, array(
+				'skipped' => true,
+				'post_id' => $post_id,
+				'reason'  => 'Meta description already exists',
+			) );
+			return;
+		}
+
+		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$provider        = $system_defaults['provider'];
+		$model           = $system_defaults['model'];
+
+		if ( empty( $provider ) || empty( $model ) ) {
+			$this->failJob( $jobId, 'No default AI provider/model configured' );
+			return;
+		}
+
+		$prompt   = $this->buildPrompt( $post );
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => $prompt,
+			),
+		);
+
+		$response = RequestBuilder::build(
+			$messages,
+			$provider,
+			$model,
+			array(),
+			'system',
+			array( 'post_id' => $post_id )
+		);
+
+		if ( empty( $response['success'] ) ) {
+			$this->failJob( $jobId, 'AI request failed: ' . ( $response['error'] ?? 'Unknown error' ) );
+			return;
+		}
+
+		$content     = $response['data']['content'] ?? '';
+		$description = $this->normalizeDescription( $content );
+
+		if ( empty( $description ) ) {
+			$this->failJob( $jobId, 'AI returned empty meta description' );
+			return;
+		}
+
+		// Save the meta description.
+		$current_value = get_post_meta( $post_id, $meta_key, true );
+		$updated       = update_post_meta( $post_id, $meta_key, $description );
+
+		if ( ! $updated && $current_value !== $description ) {
+			$this->failJob( $jobId, 'Failed to save meta description to post meta' );
+			return;
+		}
+
+		// Build standardized effects array for undo.
+		$effects = array(
+			array(
+				'type'           => 'post_meta_set',
+				'target'         => array(
+					'post_id'  => $post_id,
+					'meta_key' => $meta_key,
+				),
+				'previous_value' => ! empty( $current_value ) ? $current_value : null,
+			),
+		);
+
+		$this->completeJob( $jobId, array(
+			'meta_description' => $description,
+			'post_id'          => $post_id,
+			'meta_key'         => $meta_key,
+			'char_count'       => mb_strlen( $description ),
+			'effects'          => $effects,
+			'completed_at'     => current_time( 'mysql' ),
+		) );
+	}
+
+	/**
+	 * Get the task type identifier.
+	 *
+	 * @return string
+	 */
+	public function getTaskType(): string {
+		return 'meta_description_generation';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Meta Description Generation',
+			'description'     => 'Generate SEO meta descriptions for posts using AI.',
+			'setting_key'     => 'meta_description_auto_generate_enabled',
+			'default_enabled' => true,
+		);
+	}
+
+	/**
+	 * Meta description generation supports undo — restores previous value.
+	 *
+	 * @return bool
+	 */
+	public function supportsUndo(): bool {
+		return true;
+	}
+
+	/**
+	 * Get the meta key to write descriptions to.
+	 *
+	 * Filterable so sites using Yoast, Rank Math, etc. can override.
+	 *
+	 * @return string
+	 */
+	private function getMetaKey(): string {
+		return apply_filters( 'datamachine_meta_description_meta_key', self::DEFAULT_META_KEY );
+	}
+
+	/**
+	 * Build the AI prompt with post context.
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return string Prompt text.
+	 */
+	private function buildPrompt( \WP_Post $post ): string {
+		$context_lines = array();
+
+		$title = wp_strip_all_tags( $post->post_title );
+		if ( ! empty( $title ) ) {
+			$context_lines[] = 'Title: ' . $title;
+		}
+
+		$excerpt = wp_strip_all_tags( $post->post_excerpt );
+		if ( ! empty( $excerpt ) ) {
+			$context_lines[] = 'Excerpt: ' . $excerpt;
+		}
+
+		// Get a clean text snippet of the post content.
+		$content = wp_strip_all_tags( strip_shortcodes( $post->post_content ) );
+		$content = preg_replace( '/\s+/', ' ', trim( $content ) );
+		if ( ! empty( $content ) ) {
+			$snippet = mb_substr( $content, 0, self::CONTENT_EXCERPT_LENGTH );
+			if ( mb_strlen( $content ) > self::CONTENT_EXCERPT_LENGTH ) {
+				$snippet .= '…';
+			}
+			$context_lines[] = 'Content: ' . $snippet;
+		}
+
+		// Gather taxonomy context.
+		$categories = wp_get_post_categories( $post->ID, array( 'fields' => 'names' ) );
+		if ( ! empty( $categories ) && ! is_wp_error( $categories ) ) {
+			$context_lines[] = 'Categories: ' . implode( ', ', $categories );
+		}
+
+		$tags = wp_get_post_tags( $post->ID, array( 'fields' => 'names' ) );
+		if ( ! empty( $tags ) && ! is_wp_error( $tags ) ) {
+			$context_lines[] = 'Tags: ' . implode( ', ', $tags );
+		}
+
+		$prompt = "Write a meta description for the following web page.\n\n"
+			. "Guidelines:\n"
+			. "- Maximum " . self::MAX_LENGTH . " characters (this is strict — do not exceed)\n"
+			. "- Lead with the direct answer or hook — what will the reader learn or get?\n"
+			. "- Include the primary topic/keyword naturally\n"
+			. "- Create curiosity or value to encourage clicks\n"
+			. "- Do NOT duplicate the title — expand on it\n"
+			. "- Write in a warm, conversational tone\n"
+			. "- No quotes around the description\n"
+			. "- One or two sentences\n\n"
+			. "Return ONLY the meta description text, nothing else.";
+
+		if ( ! empty( $context_lines ) ) {
+			$prompt .= "\n\nPage context:\n" . implode( "\n", $context_lines );
+		}
+
+		return $prompt;
+	}
+
+	/**
+	 * Check if a post's meta description is missing or empty.
+	 *
+	 * @param int    $post_id  Post ID.
+	 * @param string $meta_key Meta key to check.
+	 * @return bool True if description is missing/empty.
+	 */
+	private function isDescriptionMissing( int $post_id, string $meta_key ): bool {
+		$description = get_post_meta( $post_id, $meta_key, true );
+		$description = is_string( $description ) ? trim( $description ) : '';
+
+		return '' === $description;
+	}
+
+	/**
+	 * Normalize AI response to a clean meta description string.
+	 *
+	 * @param string $raw Raw AI response.
+	 * @return string Normalized meta description.
+	 */
+	private function normalizeDescription( string $raw ): string {
+		$description = trim( $raw );
+
+		// Strip wrapping quotes (AI sometimes wraps in quotes).
+		$description = trim( $description, " \t\n\r\0\x0B\"'" );
+
+		// Strip any markdown formatting.
+		$description = preg_replace( '/^#+\s*/', '', $description );
+		$description = preg_replace( '/\*\*(.*?)\*\*/', '$1', $description );
+
+		$description = sanitize_text_field( $description );
+
+		if ( '' === $description ) {
+			return '';
+		}
+
+		// Truncate to max length, breaking at word boundary.
+		if ( mb_strlen( $description ) > self::MAX_LENGTH ) {
+			$description = mb_substr( $description, 0, self::MAX_LENGTH );
+			$last_space  = mb_strrpos( $description, ' ' );
+			if ( false !== $last_space && $last_space > self::MAX_LENGTH - 30 ) {
+				$description = mb_substr( $description, 0, $last_space );
+			}
+			// Ensure it ends cleanly.
+			$description = rtrim( $description, ' ,;:-' );
+			if ( ! preg_match( '/[.!?]$/', $description ) ) {
+				$description .= '.';
+			}
+		}
+
+		return $description;
+	}
+}


### PR DESCRIPTION
## Summary

Closes #480

Adds a new system task that generates AI-powered meta descriptions for WordPress posts, following the established AltText task pattern.

## What's New

- **`MetaDescriptionTask`** — System task that builds a prompt from post title, content excerpt, and taxonomies, calls AI to generate a ~155 character meta description, and saves it to `_lean_seo_description` post meta (filterable via `datamachine_meta_description_meta_key`). Supports undo via `post_meta_set` effects.

- **`MetaDescriptionAbilities`** — Abilities layer providing:
  - `generateMetaDescriptions()` — single or batch generation with `--force` support
  - `diagnoseMetaDescriptions()` — coverage statistics (total posts, with/without descriptions, coverage %)
  - Batch scheduling via `SystemAgent::scheduleBatch()`

- **`MetaDescriptionCommand`** — WP-CLI command (`wp datamachine meta-description`) with:
  - `diagnose` — show meta description coverage stats
  - `generate` — generate descriptions with `--post_id`, `--post_type`, `--limit`, `--force`, `--format` options

## Registration

- Task registered in `SystemAgentServiceProvider::getBuiltInTasks()`
- Abilities loaded in `data-machine.php` (require_once + init instantiation)
- CLI command registered in `Bootstrap.php`