### PR TITLE
Add unified posts list command with combinable tracking filters

### DIFF
--- a/inc/Abilities/PostQueryAbilities.php
+++ b/inc/Abilities/PostQueryAbilities.php
@@ -110,6 +110,73 @@ class PostQueryAbilities {
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
+
+			wp_register_ability(
+				'datamachine/list-posts',
+				array(
+					'label'               => __( 'List Posts', 'data-machine' ),
+					'description'         => __( 'List Data Machine posts with combinable filters (handler, flow, pipeline)', 'data-machine' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'handler'     => array(
+								'type'        => 'string',
+								'description' => __( 'Filter by handler slug', 'data-machine' ),
+							),
+							'flow_id'     => array(
+								'type'        => 'integer',
+								'description' => __( 'Filter by flow ID', 'data-machine' ),
+							),
+							'pipeline_id' => array(
+								'type'        => 'integer',
+								'description' => __( 'Filter by pipeline ID', 'data-machine' ),
+							),
+							'post_type'   => array(
+								'type'        => 'string',
+								'default'     => 'any',
+								'description' => __( 'Post type to query', 'data-machine' ),
+							),
+							'post_status' => array(
+								'type'        => 'string',
+								'default'     => 'publish',
+								'description' => __( 'Post status to query', 'data-machine' ),
+							),
+							'per_page'    => array(
+								'type'    => 'integer',
+								'default' => self::DEFAULT_PER_PAGE,
+								'minimum' => 1,
+								'maximum' => 100,
+							),
+							'offset'      => array(
+								'type'    => 'integer',
+								'default' => 0,
+							),
+							'orderby'     => array(
+								'type'    => 'string',
+								'default' => 'date',
+							),
+							'order'       => array(
+								'type'    => 'string',
+								'default' => 'DESC',
+								'enum'    => array( 'ASC', 'DESC' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'posts'    => array( 'type' => 'array' ),
+							'total'    => array( 'type' => 'integer' ),
+							'per_page' => array( 'type' => 'integer' ),
+							'offset'   => array( 'type' => 'integer' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'executeQueryPostsList' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
 		};
 
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
@@ -192,6 +259,107 @@ class PostQueryAbilities {
 					'compare' => 'EXISTS',
 				),
 			),
+		);
+
+		$query = new \WP_Query( $args );
+
+		$posts = array();
+		foreach ( $query->posts as $post ) {
+			$posts[] = $this->format_post_result( $post );
+		}
+
+		return array(
+			'posts'    => $posts,
+			'total'    => $query->found_posts,
+			'per_page' => $per_page,
+			'offset'   => $offset,
+		);
+	}
+
+	/**
+	 * Query posts with combinable tracking filters.
+	 *
+	 * Supports any combination of handler, flow_id, and pipeline_id filters
+	 * applied as an AND meta_query. Omitted filters are ignored.
+	 *
+	 * @since 0.34.0
+	 *
+	 * @param array $input {
+	 *     @type string $handler     Handler slug to filter by.
+	 *     @type int    $flow_id     Flow ID to filter by.
+	 *     @type int    $pipeline_id Pipeline ID to filter by.
+	 *     @type string $post_type   Post type (default: 'any').
+	 *     @type string $post_status Post status (default: 'publish').
+	 *     @type int    $per_page    Results per page (default: 20, max: 100).
+	 *     @type int    $offset      Offset for pagination.
+	 *     @type string $orderby     Order by field (default: 'date').
+	 *     @type string $order       Sort direction (default: 'DESC').
+	 * }
+	 * @return array Result with posts array, total count, per_page, and offset.
+	 */
+	public function executeQueryPostsList( array $input ): array {
+		$handler     = sanitize_text_field( $input['handler'] ?? '' );
+		$flow_id     = (int) ( $input['flow_id'] ?? 0 );
+		$pipeline_id = (int) ( $input['pipeline_id'] ?? 0 );
+		$post_type   = $input['post_type'] ?? 'any';
+		$post_status = $input['post_status'] ?? 'publish';
+		$per_page    = min( max( (int) ( $input['per_page'] ?? self::DEFAULT_PER_PAGE ), 1 ), 100 );
+		$offset      = max( (int) ( $input['offset'] ?? 0 ), 0 );
+		$orderby     = $input['orderby'] ?? 'date';
+		$order       = strtoupper( $input['order'] ?? 'DESC' );
+
+		if ( ! in_array( $order, array( 'ASC', 'DESC' ), true ) ) {
+			$order = 'DESC';
+		}
+
+		// Build meta_query from provided filters.
+		$meta_query = array();
+
+		if ( ! empty( $handler ) ) {
+			$meta_query[] = array(
+				'key'     => PostTracking::HANDLER_META_KEY,
+				'value'   => $handler,
+				'compare' => '=',
+			);
+		}
+
+		if ( $flow_id > 0 ) {
+			$meta_query[] = array(
+				'key'     => PostTracking::FLOW_ID_META_KEY,
+				'value'   => $flow_id,
+				'compare' => '=',
+			);
+		}
+
+		if ( $pipeline_id > 0 ) {
+			$meta_query[] = array(
+				'key'     => PostTracking::PIPELINE_ID_META_KEY,
+				'value'   => $pipeline_id,
+				'compare' => '=',
+			);
+		}
+
+		// If no filters provided, require at least the handler meta key to exist
+		// (i.e. only show DM-managed posts).
+		if ( empty( $meta_query ) ) {
+			$meta_query[] = array(
+				'key'     => PostTracking::HANDLER_META_KEY,
+				'compare' => 'EXISTS',
+			);
+		}
+
+		if ( count( $meta_query ) > 1 ) {
+			$meta_query['relation'] = 'AND';
+		}
+
+		$args = array(
+			'post_type'      => $post_type,
+			'post_status'    => $post_status,
+			'posts_per_page' => $per_page,
+			'offset'         => $offset,
+			'orderby'        => $orderby,
+			'order'          => $order,
+			'meta_query'     => $meta_query,
 		);
 
 		$query = new \WP_Query( $args );

--- a/inc/Cli/Commands/PostsCommand.php
+++ b/inc/Cli/Commands/PostsCommand.php
@@ -25,6 +25,162 @@ class PostsCommand extends BaseCommand {
 	private array $default_fields = array( 'id', 'title', 'post_type', 'status', 'handler', 'flow_id', 'pipeline_id', 'date' );
 
 	/**
+	 * List posts managed by Data Machine with combinable filters.
+	 *
+	 * Queries posts with optional handler, flow, and pipeline filters.
+	 * When multiple filters are provided, they combine with AND logic.
+	 * With no filters, lists all DM-managed posts (newest first).
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--handler=<handler_slug>]
+	 * : Filter by handler slug (e.g., "universal_web_scraper", "upsert_event").
+	 *
+	 * [--flow-id=<flow_id>]
+	 * : Filter by source flow ID.
+	 *
+	 * [--pipeline-id=<pipeline_id>]
+	 * : Filter by source pipeline ID.
+	 *
+	 * [--post_type=<post_type>]
+	 * : Post type to query.
+	 * ---
+	 * default: any
+	 * ---
+	 *
+	 * [--post_status=<status>]
+	 * : Post status to query.
+	 * ---
+	 * default: publish
+	 * ---
+	 *
+	 * [--per_page=<number>]
+	 * : Number of posts to return.
+	 * ---
+	 * default: 20
+	 * ---
+	 *
+	 * [--offset=<number>]
+	 * : Offset for pagination.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * [--orderby=<field>]
+	 * : Order by field.
+	 * ---
+	 * default: date
+	 * options:
+	 *   - date
+	 *   - title
+	 *   - ID
+	 *   - modified
+	 * ---
+	 *
+	 * [--order=<direction>]
+	 * : Sort direction.
+	 * ---
+	 * default: DESC
+	 * options:
+	 *   - ASC
+	 *   - DESC
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 *   - ids
+	 *   - count
+	 * ---
+	 *
+	 * [--fields=<fields>]
+	 * : Limit output to specific fields (comma-separated).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # List all DM-managed posts
+	 *     wp datamachine posts list
+	 *
+	 *     # List posts created by a specific flow
+	 *     wp datamachine posts list --flow-id=293
+	 *
+	 *     # List posts by handler type
+	 *     wp datamachine posts list --handler=upsert_event
+	 *
+	 *     # List posts by pipeline
+	 *     wp datamachine posts list --pipeline-id=72
+	 *
+	 *     # Combine filters (AND logic)
+	 *     wp datamachine posts list --flow-id=293 --handler=upsert_event
+	 *
+	 *     # Filter by post type and format
+	 *     wp datamachine posts list --handler=wordpress_publish --post_type=post --format=csv
+	 *
+	 *     # Paginate through results
+	 *     wp datamachine posts list --flow-id=7 --per_page=50 --offset=50
+	 *
+	 *     # Sort by title ascending
+	 *     wp datamachine posts list --orderby=title --order=ASC
+	 *
+	 *     # Output only IDs
+	 *     wp datamachine posts list --flow-id=7 --format=ids
+	 *
+	 * @subcommand list
+	 */
+	public function list_posts( array $args, array $assoc_args ): void {
+		$handler     = $assoc_args['handler'] ?? '';
+		$flow_id     = (int) ( $assoc_args['flow-id'] ?? 0 );
+		$pipeline_id = (int) ( $assoc_args['pipeline-id'] ?? 0 );
+		$post_type   = $assoc_args['post_type'] ?? 'any';
+		$post_status = $assoc_args['post_status'] ?? 'publish';
+		$per_page    = (int) ( $assoc_args['per_page'] ?? 20 );
+		$offset      = (int) ( $assoc_args['offset'] ?? 0 );
+		$orderby     = $assoc_args['orderby'] ?? 'date';
+		$order       = $assoc_args['order'] ?? 'DESC';
+		$format      = $assoc_args['format'] ?? 'table';
+
+		$ability = new \DataMachine\Abilities\PostQueryAbilities();
+		$result  = $ability->executeQueryPostsList(
+			array(
+				'handler'     => $handler,
+				'flow_id'     => $flow_id,
+				'pipeline_id' => $pipeline_id,
+				'post_type'   => $post_type,
+				'post_status' => $post_status,
+				'per_page'    => $per_page,
+				'offset'      => $offset,
+				'orderby'     => $orderby,
+				'order'       => $order,
+			)
+		);
+
+		$this->outputPostResult( $result, $assoc_args, $format );
+
+		// Show active filters in table mode for clarity.
+		if ( 'table' === $format ) {
+			$filters = array();
+			if ( ! empty( $handler ) ) {
+				$filters[] = "handler={$handler}";
+			}
+			if ( $flow_id > 0 ) {
+				$filters[] = "flow_id={$flow_id}";
+			}
+			if ( $pipeline_id > 0 ) {
+				$filters[] = "pipeline_id={$pipeline_id}";
+			}
+			if ( ! empty( $filters ) ) {
+				WP_CLI::log( 'Filters: ' . implode( ', ', $filters ) );
+			}
+		}
+	}
+
+	/**
 	 * Query posts by handler slug.
 	 *
 	 * ## OPTIONS


### PR DESCRIPTION
## Summary

Closes #465

Adds a unified `wp datamachine posts list` command that supports combinable `--handler`, `--flow-id`, and `--pipeline-id` filters with AND logic. Previously, each filter required a separate subcommand (`by-handler`, `by-flow`, `by-pipeline`), and there was no way to combine them (e.g., "which posts did flow 293 create via the upsert_event handler?").

## What's New

### CLI: `wp datamachine posts list`

```bash
# List all DM-managed posts (newest first)
wp datamachine posts list

# Filter by flow
wp datamachine posts list --flow-id=293

# Filter by handler
wp datamachine posts list --handler=upsert_event

# Combine filters (AND logic)
wp datamachine posts list --flow-id=293 --handler=upsert_event

# Pagination + sorting
wp datamachine posts list --flow-id=7 --per_page=50 --offset=50 --orderby=title --order=ASC

# Output formats
wp datamachine posts list --flow-id=7 --format=ids
wp datamachine posts list --handler=wordpress_publish --format=csv
```

Shows active filters in table output for clarity.

### Ability: `datamachine/list-posts`

New ability with optional `handler`, `flow_id`, `pipeline_id` inputs. All filters are optional and stackable. With no filters, returns all DM-managed posts.

### Backwards Compatible

Existing `by-handler`, `by-flow`, `by-pipeline`, and `recent` subcommands are preserved.

## Files Changed

- `inc/Cli/Commands/PostsCommand.php` — Added `list` subcommand
- `inc/Abilities/PostQueryAbilities.php` — Added `executeQueryPostsList()` method + `datamachine/list-posts` ability registration