### PR TITLE
feat: add flow-scoped memory files

### DIFF
--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -183,6 +183,47 @@ class Flows {
 
 		register_rest_route(
 			'datamachine/v1',
+			'/flows/(?P<flow_id>\d+)/memory-files',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( self::class, 'handle_get_memory_files' ),
+					'permission_callback' => array( self::class, 'check_permission' ),
+					'args'                => array(
+						'flow_id' => array(
+							'required'          => true,
+							'type'              => 'integer',
+							'sanitize_callback' => 'absint',
+							'description'       => __( 'Flow ID', 'data-machine' ),
+						),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( self::class, 'handle_update_memory_files' ),
+					'permission_callback' => array( self::class, 'check_permission' ),
+					'args'                => array(
+						'flow_id'      => array(
+							'required'          => true,
+							'type'              => 'integer',
+							'sanitize_callback' => 'absint',
+							'description'       => __( 'Flow ID', 'data-machine' ),
+						),
+						'memory_files' => array(
+							'required'    => true,
+							'type'        => 'array',
+							'description' => __( 'Array of agent memory filenames', 'data-machine' ),
+							'items'       => array(
+								'type' => 'string',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'datamachine/v1',
 			'/flows/problems',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
@@ -490,6 +531,85 @@ class Flows {
 					'failing'       => $result['failing'] ?? array(),
 					'idle'          => $result['idle'] ?? array(),
 				),
+			)
+		);
+	}
+
+	/**
+	 * Handle get memory files request for a flow.
+	 *
+	 * GET /datamachine/v1/flows/{flow_id}/memory-files
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|\WP_Error Response.
+	 */
+	public static function handle_get_memory_files( $request ) {
+		$flow_id = (int) $request->get_param( 'flow_id' );
+
+		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
+		$flow     = $db_flows->get_flow( $flow_id );
+
+		if ( ! $flow ) {
+			return new \WP_Error(
+				'flow_not_found',
+				__( 'Flow not found.', 'data-machine' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$memory_files = $db_flows->get_flow_memory_files( $flow_id );
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'data'    => $memory_files,
+			)
+		);
+	}
+
+	/**
+	 * Handle update memory files request for a flow.
+	 *
+	 * PUT/POST /datamachine/v1/flows/{flow_id}/memory-files
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|\WP_Error Response.
+	 */
+	public static function handle_update_memory_files( $request ) {
+		$flow_id      = (int) $request->get_param( 'flow_id' );
+		$params       = $request->get_json_params();
+		$memory_files = $params['memory_files'] ?? array();
+
+		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
+		$flow     = $db_flows->get_flow( $flow_id );
+
+		if ( ! $flow ) {
+			return new \WP_Error(
+				'flow_not_found',
+				__( 'Flow not found.', 'data-machine' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Sanitize filenames.
+		$memory_files = array_map( 'sanitize_file_name', $memory_files );
+		$memory_files = array_values( array_filter( $memory_files ) );
+
+		$result = $db_flows->update_flow_memory_files( $flow_id, $memory_files );
+
+		if ( ! $result ) {
+			return new \WP_Error(
+				'update_failed',
+				__( 'Failed to update memory files.', 'data-machine' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'data'    => $memory_files,
+				'message' => __( 'Flow memory files updated successfully.', 'data-machine' ),
 			)
 		);
 	}

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -103,6 +103,12 @@ class FlowsCommand extends BaseCommand {
 	 * [--step=<flow_step_id>]
 	 * : Target a specific flow step for prompt update or handler config update (auto-resolved if flow has exactly one handler step).
 	 *
+	 * [--add=<filename>]
+	 * : Attach a memory file to a flow (memory-files subcommand).
+	 *
+	 * [--remove=<filename>]
+	 * : Detach a memory file from a flow (memory-files subcommand).
+	 *
 	 * [--dry-run]
 	 * : Validate without creating (create subcommand).
 	 *
@@ -147,6 +153,15 @@ class FlowsCommand extends BaseCommand {
 	 *     # List handlers on a flow
 	 *     wp datamachine flows list-handlers 42
 	 *
+	 *     # List memory files for a flow
+	 *     wp datamachine flows memory-files 42
+	 *
+	 *     # Attach a memory file to a flow
+	 *     wp datamachine flows memory-files 42 --add=content-briefing.md
+	 *
+	 *     # Detach a memory file from a flow
+	 *     wp datamachine flows memory-files 42 --remove=content-briefing.md
+	 *
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
 		$flow_id     = null;
@@ -169,6 +184,16 @@ class FlowsCommand extends BaseCommand {
 		if ( ! empty( $args ) && 'webhook' === $args[0] ) {
 			$webhook = new WebhookCommand();
 			$webhook->dispatch( array_slice( $args, 1 ), $assoc_args );
+			return;
+		}
+
+		// Handle 'memory-files' subcommand.
+		if ( ! empty( $args ) && 'memory-files' === $args[0] ) {
+			if ( ! isset( $args[1] ) ) {
+				WP_CLI::error( 'Usage: wp datamachine flows memory-files <flow_id> [--add=<filename>] [--remove=<filename>]' );
+				return;
+			}
+			$this->memoryFiles( (int) $args[1], $assoc_args );
 			return;
 		}
 
@@ -353,8 +378,20 @@ class FlowsCommand extends BaseCommand {
 			return;
 		}
 
+		// Show memory files if attached.
+		$memory_files = $config['memory_files'] ?? array();
+		if ( ! empty( $memory_files ) ) {
+			WP_CLI::log( sprintf( 'Memory files: %s', implode( ', ', $memory_files ) ) );
+			WP_CLI::log( '' );
+		}
+
 		$rows = array();
 		foreach ( $config as $step_id => $step_data ) {
+			// Skip flow-level metadata keys — only display step configs.
+			if ( ! is_array( $step_data ) || ! isset( $step_data['step_type'] ) ) {
+				continue;
+			}
+
 			$step_type = $step_data['step_type'] ?? '';
 			$order     = $step_data['execution_order'] ?? '';
 			$slugs     = $step_data['handler_slugs'] ?? array();
@@ -900,6 +937,11 @@ class FlowsCommand extends BaseCommand {
 		$rows   = array();
 
 		foreach ( $config as $sid => $step ) {
+			// Skip flow-level metadata keys.
+			if ( ! is_array( $step ) || ! isset( $step['step_type'] ) ) {
+				continue;
+			}
+
 			if ( $step_id && $sid !== $step_id ) {
 				continue;
 			}
@@ -1008,5 +1050,104 @@ class FlowsCommand extends BaseCommand {
 			'step_id' => $handler_steps[0],
 			'error'   => null,
 		);
+	}
+
+	/**
+	 * Manage memory files attached to a flow.
+	 *
+	 * Without --add or --remove, lists current memory files.
+	 * With --add, attaches a file. With --remove, detaches a file.
+	 *
+	 * @param int   $flow_id    Flow ID.
+	 * @param array $assoc_args Arguments (add, remove, format).
+	 */
+	private function memoryFiles( int $flow_id, array $assoc_args ): void {
+		if ( $flow_id <= 0 ) {
+			WP_CLI::error( 'flow_id must be a positive integer' );
+			return;
+		}
+
+		$format   = $assoc_args['format'] ?? 'table';
+		$add_file = $assoc_args['add'] ?? null;
+		$rm_file  = $assoc_args['remove'] ?? null;
+
+		$db = new \DataMachine\Core\Database\Flows\Flows();
+
+		// Verify flow exists.
+		$flow = $db->get_flow( $flow_id );
+		if ( ! $flow ) {
+			WP_CLI::error( "Flow {$flow_id} not found" );
+			return;
+		}
+
+		$current_files = $db->get_flow_memory_files( $flow_id );
+
+		// Add a file.
+		if ( $add_file ) {
+			$add_file = sanitize_file_name( $add_file );
+
+			if ( in_array( $add_file, $current_files, true ) ) {
+				WP_CLI::warning( sprintf( '"%s" is already attached to flow %d.', $add_file, $flow_id ) );
+				return;
+			}
+
+			$current_files[] = $add_file;
+			$result          = $db->update_flow_memory_files( $flow_id, $current_files );
+
+			if ( ! $result ) {
+				WP_CLI::error( 'Failed to update memory files' );
+				return;
+			}
+
+			WP_CLI::success( sprintf( 'Added "%s" to flow %d. Files: %s', $add_file, $flow_id, implode( ', ', $current_files ) ) );
+			return;
+		}
+
+		// Remove a file.
+		if ( $rm_file ) {
+			$rm_file = sanitize_file_name( $rm_file );
+
+			if ( ! in_array( $rm_file, $current_files, true ) ) {
+				WP_CLI::warning( sprintf( '"%s" is not attached to flow %d.', $rm_file, $flow_id ) );
+				return;
+			}
+
+			$current_files = array_values( array_diff( $current_files, array( $rm_file ) ) );
+			$result        = $db->update_flow_memory_files( $flow_id, $current_files );
+
+			if ( ! $result ) {
+				WP_CLI::error( 'Failed to update memory files' );
+				return;
+			}
+
+			WP_CLI::success( sprintf( 'Removed "%s" from flow %d.', $rm_file, $flow_id ) );
+
+			if ( ! empty( $current_files ) ) {
+				WP_CLI::log( sprintf( 'Remaining: %s', implode( ', ', $current_files ) ) );
+			} else {
+				WP_CLI::log( 'No memory files attached.' );
+			}
+			return;
+		}
+
+		// List files.
+		if ( empty( $current_files ) ) {
+			WP_CLI::log( sprintf( 'Flow %d has no memory files attached.', $flow_id ) );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $current_files, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$items = array_map(
+			function ( $filename ) {
+				return array( 'filename' => $filename );
+			},
+			$current_files
+		);
+
+		\WP_CLI\Utils\format_items( $format, $items, array( 'filename' ) );
 	}
 }

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowCard.jsx
@@ -191,6 +191,19 @@ function FlowCardContent( props ) {
 	);
 
 	/**
+	 * Handle memory files button click - opens flow memory files modal
+	 */
+	const handleMemoryFiles = useCallback(
+		( flowId ) => {
+			openModal( MODAL_TYPES.FLOW_MEMORY_FILES, {
+				flowId,
+				flowName: currentFlowData.flow_name,
+			} );
+		},
+		[ currentFlowData.flow_id, currentFlowData.flow_name, openModal ]
+	);
+
+	/**
 	 * Handle queue button click - opens queue management modal
 	 */
 	const handleQueue = useCallback(
@@ -284,6 +297,7 @@ function FlowCardContent( props ) {
 					onDuplicate={ handleDuplicate }
 					onRun={ handleRun }
 					onSchedule={ handleSchedule }
+					onMemoryFiles={ handleMemoryFiles }
 					runSuccess={ runSuccess }
 				/>
 

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowHeader.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowHeader.jsx
@@ -26,8 +26,9 @@ import { AUTO_SAVE_DELAY } from '../../utils/constants';
  * @param {Function} props.onDelete     - Delete handler.
  * @param {Function} props.onDuplicate  - Duplicate handler.
  * @param {Function} props.onRun        - Run handler.
- * @param {Function} props.onSchedule   - Schedule handler.
- * @param {boolean}  props.runSuccess   - Whether run was just successful.
+ * @param {Function} props.onSchedule    - Schedule handler.
+ * @param {Function} props.onMemoryFiles - Memory files handler.
+ * @param {boolean}  props.runSuccess    - Whether run was just successful.
  * @return {JSX.Element} Flow header.
  */
 export default function FlowHeader( {
@@ -38,6 +39,7 @@ export default function FlowHeader( {
 	onDuplicate,
 	onRun,
 	onSchedule,
+	onMemoryFiles,
 	runSuccess = false,
 } ) {
 	const [ localName, setLocalName ] = useState( flowName );
@@ -151,6 +153,13 @@ export default function FlowHeader( {
 					onClick={ () => onSchedule && onSchedule( flowId ) }
 				>
 					{ __( 'Schedule', 'data-machine' ) }
+				</Button>
+
+				<Button
+					variant="secondary"
+					onClick={ () => onMemoryFiles && onMemoryFiles( flowId ) }
+				>
+					{ __( 'Memory', 'data-machine' ) }
 				</Button>
 
 				<Button

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowMemoryFiles.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowMemoryFiles.jsx
@@ -1,0 +1,38 @@
+/**
+ * Flow Memory Files Component
+ *
+ * Allows selecting agent memory files to include in flow AI context.
+ * Flow memory files are additive — they inject alongside pipeline memory files.
+ * Delegates to the shared MemoryFilesSelector component.
+ */
+
+/**
+ * Internal dependencies
+ */
+import MemoryFilesSelector from '../shared/MemoryFilesSelector';
+import {
+	useFlowMemoryFiles,
+	useUpdateFlowMemoryFiles,
+} from '../../queries/flows';
+
+/**
+ * Flow Memory Files Component
+ *
+ * @param {Object} props        - Component props
+ * @param {number} props.flowId - Flow ID
+ * @return {React.ReactElement} Memory files selector for flow scope
+ */
+export default function FlowMemoryFiles( { flowId } ) {
+	const { data: selectedFiles = [], isLoading } =
+		useFlowMemoryFiles( flowId );
+	const updateMutation = useUpdateFlowMemoryFiles( flowId );
+
+	return (
+		<MemoryFilesSelector
+			scopeLabel="flow"
+			selectedFiles={ selectedFiles }
+			isLoading={ isLoading }
+			updateMutation={ updateMutation }
+		/>
+	);
+}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/FlowMemoryFilesModal.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/FlowMemoryFilesModal.jsx
@@ -1,0 +1,37 @@
+/**
+ * Flow Memory Files Modal Component
+ *
+ * Modal for selecting agent memory files for flow AI context.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import FlowMemoryFiles from '../flows/FlowMemoryFiles';
+
+/**
+ * Flow Memory Files Modal Component
+ *
+ * @param {Object}   props        - Component props
+ * @param {Function} props.onClose - Close handler
+ * @param {number}   props.flowId  - Flow ID
+ * @return {React.ReactElement} Flow memory files modal
+ */
+export default function FlowMemoryFilesModal( { onClose, flowId } ) {
+	return (
+		<Modal
+			title={ __( 'Flow Memory Files', 'data-machine' ) }
+			onRequestClose={ onClose }
+			className="datamachine-memory-files-modal"
+		>
+			<div className="datamachine-modal-content">
+				<FlowMemoryFiles flowId={ flowId } />
+			</div>
+		</Modal>
+	);
+}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/index.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/index.js
@@ -14,3 +14,4 @@ export { default as ImportExportModal } from './ImportExportModal';
 export { default as OAuthAuthenticationModal } from './OAuthAuthenticationModal';
 export { default as ContextFilesModal } from './ContextFilesModal';
 export { default as MemoryFilesModal } from './MemoryFilesModal';
+export { default as FlowMemoryFilesModal } from './FlowMemoryFilesModal';

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineMemoryFiles.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineMemoryFiles.jsx
@@ -2,185 +2,36 @@
  * Pipeline Memory Files Component
  *
  * Allows selecting agent memory files to include in pipeline AI context.
- * SOUL.md is excluded (always injected separately at Priority 20).
+ * Delegates to the shared MemoryFilesSelector component.
  */
 
-/**
- * WordPress dependencies
- */
-import { useState, useEffect } from '@wordpress/element';
-import { CheckboxControl, Button, Notice, Spinner } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import MemoryFilesSelector from '../shared/MemoryFilesSelector';
 import {
-	useAgentFiles,
 	usePipelineMemoryFiles,
 	useUpdatePipelineMemoryFiles,
 } from '../../queries/pipelines';
-
-/**
- * Files to exclude from the memory files picker (always injected separately).
- */
-const EXCLUDED_FILES = [ 'SOUL.md', 'USER.md', 'MEMORY.md' ];
 
 /**
  * Pipeline Memory Files Component
  *
  * @param {Object} props            - Component props
  * @param {number} props.pipelineId - Pipeline ID
- * @return {React.ReactElement} Memory files selector
+ * @return {React.ReactElement} Memory files selector for pipeline scope
  */
 export default function PipelineMemoryFiles( { pipelineId } ) {
-	const { data: agentFiles = [], isLoading: loadingAgent } =
-		useAgentFiles();
-	const { data: selectedFiles = [], isLoading: loadingSelected } =
+	const { data: selectedFiles = [], isLoading } =
 		usePipelineMemoryFiles( pipelineId );
 	const updateMutation = useUpdatePipelineMemoryFiles( pipelineId );
 
-	const [ localSelected, setLocalSelected ] = useState( [] );
-	const [ success, setSuccess ] = useState( null );
-
-	// Sync local state when server data loads.
-	useEffect( () => {
-		setLocalSelected( selectedFiles );
-	}, [ selectedFiles ] );
-
-	const loading = loadingAgent || loadingSelected;
-
-	// Filter out SOUL.md and non-text files.
-	const availableFiles = agentFiles
-		.map( ( f ) => ( typeof f === 'string' ? f : f.name || f.filename ) )
-		.filter( ( name ) => name && ! EXCLUDED_FILES.includes( name ) );
-
-	const handleToggle = ( filename, checked ) => {
-		setLocalSelected( ( prev ) =>
-			checked
-				? [ ...prev, filename ]
-				: prev.filter( ( f ) => f !== filename )
-		);
-	};
-
-	const handleSave = async () => {
-		setSuccess( null );
-		try {
-			await updateMutation.mutateAsync( localSelected );
-			setSuccess(
-				__( 'Memory files updated successfully!', 'data-machine' )
-			);
-		} catch ( err ) {
-			// eslint-disable-next-line no-console
-			console.error( 'Memory files save error:', err );
-		}
-	};
-
-	const isDirty =
-		JSON.stringify( [ ...localSelected ].sort() ) !==
-		JSON.stringify( [ ...selectedFiles ].sort() );
-
 	return (
-		<div className="datamachine-pipeline-memory-files">
-			<h3
-				style={ {
-					margin: '0 0 8px 0',
-					fontSize: '16px',
-					fontWeight: '600',
-				} }
-			>
-				{ __( 'Agent Memory Files', 'data-machine' ) }
-			</h3>
-			<p
-				style={ {
-					margin: '0 0 16px 0',
-					color: '#757575',
-					fontSize: '13px',
-				} }
-			>
-				{ __(
-					'Select agent memory files to include as AI context for this pipeline.',
-					'data-machine'
-				) }
-			</p>
-
-			{ success && (
-				<Notice
-					status="success"
-					isDismissible
-					onRemove={ () => setSuccess( null ) }
-				>
-					<p>{ success }</p>
-				</Notice>
-			) }
-
-			{ updateMutation.isError && (
-				<Notice status="error" isDismissible={ false }>
-					<p>
-						{ __(
-							'Failed to save memory files.',
-							'data-machine'
-						) }
-					</p>
-				</Notice>
-			) }
-
-			{ loading ? (
-				<div
-					style={ {
-						textAlign: 'center',
-						padding: '20px',
-						color: '#757575',
-					} }
-				>
-					<Spinner />
-				</div>
-			) : availableFiles.length === 0 ? (
-				<p
-					style={ {
-						color: '#757575',
-						fontStyle: 'italic',
-						padding: '12px 0',
-					} }
-				>
-					{ __(
-						'No agent memory files available. Upload files to the agent directory first.',
-						'data-machine'
-					) }
-				</p>
-			) : (
-				<>
-					<div
-						style={ {
-							display: 'flex',
-							flexDirection: 'column',
-							gap: '8px',
-							marginBottom: '16px',
-						} }
-					>
-						{ availableFiles.map( ( filename ) => (
-							<CheckboxControl
-								key={ filename }
-								label={ filename }
-								checked={ localSelected.includes( filename ) }
-								onChange={ ( checked ) =>
-									handleToggle( filename, checked )
-								}
-							/>
-						) ) }
-					</div>
-
-					<Button
-						variant="primary"
-						onClick={ handleSave }
-						disabled={ ! isDirty || updateMutation.isPending }
-						isBusy={ updateMutation.isPending }
-					>
-						{ updateMutation.isPending
-							? __( 'Saving…', 'data-machine' )
-							: __( 'Save Memory Files', 'data-machine' ) }
-					</Button>
-				</>
-			) }
-		</div>
+		<MemoryFilesSelector
+			scopeLabel="pipeline"
+			selectedFiles={ selectedFiles }
+			isLoading={ isLoading }
+			updateMutation={ updateMutation }
+		/>
 	);
 }

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/MemoryFilesSelector.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/MemoryFilesSelector.jsx
@@ -1,0 +1,187 @@
+/**
+ * Memory Files Selector Component (Shared)
+ *
+ * Reusable component for selecting agent memory files.
+ * Used by both pipeline-scoped and flow-scoped memory file UIs.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { CheckboxControl, Button, Notice, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { useAgentFiles } from '../../queries/pipelines';
+
+/**
+ * Files to exclude from the memory files picker (always injected separately).
+ */
+const EXCLUDED_FILES = [ 'SOUL.md', 'USER.md', 'MEMORY.md' ];
+
+/**
+ * Memory Files Selector Component
+ *
+ * @param {Object}   props               - Component props
+ * @param {string}   props.scopeLabel    - Label for the scope (e.g. 'pipeline', 'flow')
+ * @param {Array}    props.selectedFiles - Currently selected filenames
+ * @param {boolean}  props.isLoading     - Whether selected files are loading
+ * @param {Object}   props.updateMutation - TanStack mutation for saving
+ * @return {React.ReactElement} Memory files selector
+ */
+export default function MemoryFilesSelector( {
+	scopeLabel,
+	selectedFiles = [],
+	isLoading: loadingSelected = false,
+	updateMutation,
+} ) {
+	const { data: agentFiles = [], isLoading: loadingAgent } =
+		useAgentFiles();
+
+	const [ localSelected, setLocalSelected ] = useState( [] );
+	const [ success, setSuccess ] = useState( null );
+
+	// Sync local state when server data loads.
+	useEffect( () => {
+		setLocalSelected( selectedFiles );
+	}, [ selectedFiles ] );
+
+	const loading = loadingAgent || loadingSelected;
+
+	// Filter out core files and non-text files.
+	const availableFiles = agentFiles
+		.map( ( f ) => ( typeof f === 'string' ? f : f.name || f.filename ) )
+		.filter( ( name ) => name && ! EXCLUDED_FILES.includes( name ) );
+
+	const handleToggle = ( filename, checked ) => {
+		setLocalSelected( ( prev ) =>
+			checked
+				? [ ...prev, filename ]
+				: prev.filter( ( f ) => f !== filename )
+		);
+	};
+
+	const handleSave = async () => {
+		setSuccess( null );
+		try {
+			await updateMutation.mutateAsync( localSelected );
+			setSuccess(
+				__( 'Memory files updated successfully!', 'data-machine' )
+			);
+		} catch ( err ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Memory files save error:', err );
+		}
+	};
+
+	const isDirty =
+		JSON.stringify( [ ...localSelected ].sort() ) !==
+		JSON.stringify( [ ...selectedFiles ].sort() );
+
+	return (
+		<div className="datamachine-memory-files-selector">
+			<h3
+				style={ {
+					margin: '0 0 8px 0',
+					fontSize: '16px',
+					fontWeight: '600',
+				} }
+			>
+				{ __( 'Agent Memory Files', 'data-machine' ) }
+			</h3>
+			<p
+				style={ {
+					margin: '0 0 16px 0',
+					color: '#757575',
+					fontSize: '13px',
+				} }
+			>
+				{ __(
+					`Select agent memory files to include as AI context for this ${ scopeLabel }.`,
+					'data-machine'
+				) }
+			</p>
+
+			{ success && (
+				<Notice
+					status="success"
+					isDismissible
+					onRemove={ () => setSuccess( null ) }
+				>
+					<p>{ success }</p>
+				</Notice>
+			) }
+
+			{ updateMutation.isError && (
+				<Notice status="error" isDismissible={ false }>
+					<p>
+						{ __(
+							'Failed to save memory files.',
+							'data-machine'
+						) }
+					</p>
+				</Notice>
+			) }
+
+			{ loading ? (
+				<div
+					style={ {
+						textAlign: 'center',
+						padding: '20px',
+						color: '#757575',
+					} }
+				>
+					<Spinner />
+				</div>
+			) : availableFiles.length === 0 ? (
+				<p
+					style={ {
+						color: '#757575',
+						fontStyle: 'italic',
+						padding: '12px 0',
+					} }
+				>
+					{ __(
+						'No agent memory files available. Upload files to the agent directory first.',
+						'data-machine'
+					) }
+				</p>
+			) : (
+				<>
+					<div
+						style={ {
+							display: 'flex',
+							flexDirection: 'column',
+							gap: '8px',
+							marginBottom: '16px',
+						} }
+					>
+						{ availableFiles.map( ( filename ) => (
+							<CheckboxControl
+								key={ filename }
+								label={ filename }
+								checked={ localSelected.includes( filename ) }
+								onChange={ ( checked ) =>
+									handleToggle( filename, checked )
+								}
+							/>
+						) ) }
+					</div>
+
+					<Button
+						variant="primary"
+						onClick={ handleSave }
+						disabled={ ! isDirty || updateMutation.isPending }
+						isBusy={ updateMutation.isPending }
+					>
+						{ updateMutation.isPending
+							? __( 'Saving…', 'data-machine' )
+							: __( 'Save Memory Files', 'data-machine' ) }
+					</Button>
+				</>
+			) }
+		</div>
+	);
+}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalSwitch.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalSwitch.jsx
@@ -22,6 +22,7 @@ import {
 	OAuthAuthenticationModal,
 	ContextFilesModal,
 	MemoryFilesModal,
+	FlowMemoryFilesModal,
 } from '../modals';
 
 export default function ModalSwitch( { activeModal, baseProps } ) {
@@ -77,6 +78,9 @@ export default function ModalSwitch( { activeModal, baseProps } ) {
 
 		case MODAL_TYPES.MEMORY_FILES:
 			return <MemoryFilesModal { ...baseProps } />;
+
+		case MODAL_TYPES.FLOW_MEMORY_FILES:
+			return <FlowMemoryFilesModal { ...baseProps } />;
 
 		default:
 			console.warn( `Unknown modal type: ${ activeModal }` );

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
@@ -24,6 +24,8 @@ import {
 	updateUserMessage,
 	updateFlowSchedule,
 	updateFlowStepConfig,
+	fetchFlowMemoryFiles,
+	updateFlowMemoryFiles,
 } from '../utils/api';
 import { isSameId, normalizeId } from '../utils/ids';
 
@@ -476,6 +478,30 @@ export const useUpdateFlowSchedule = () => {
 			}
 
 			setFlowInCache( queryClient, response.data );
+		},
+	} );
+};
+
+// Flow Memory Files
+export const useFlowMemoryFiles = ( flowId ) =>
+	useQuery( {
+		queryKey: [ 'flow-memory-files', flowId ],
+		queryFn: async () => {
+			const response = await fetchFlowMemoryFiles( flowId );
+			return response.success ? response.data : [];
+		},
+		enabled: !! flowId,
+	} );
+
+export const useUpdateFlowMemoryFiles = ( flowId ) => {
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( filenames ) =>
+			updateFlowMemoryFiles( flowId, filenames ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( {
+				queryKey: [ 'flow-memory-files', flowId ],
+			} );
 		},
 	} );
 };

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -452,6 +452,29 @@ export const updatePipelineMemoryFiles = async ( pipelineId, memoryFiles ) => {
 };
 
 /**
+ * Fetch memory files for a flow
+ *
+ * @param {number} flowId - Flow ID
+ * @return {Promise<Object>} Array of memory filenames
+ */
+export const fetchFlowMemoryFiles = async ( flowId ) => {
+	return await client.get( `/flows/${ flowId }/memory-files` );
+};
+
+/**
+ * Update memory files for a flow
+ *
+ * @param {number}        flowId      - Flow ID
+ * @param {Array<string>} memoryFiles - Array of filenames
+ * @return {Promise<Object>} Update confirmation
+ */
+export const updateFlowMemoryFiles = async ( flowId, memoryFiles ) => {
+	return await client.put( `/flows/${ flowId }/memory-files`, {
+		memory_files: memoryFiles,
+	} );
+};
+
+/**
  * Fetch available agent files
  *
  * @return {Promise<Object>} Array of agent files

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/constants.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/constants.js
@@ -19,6 +19,7 @@ export const MODAL_TYPES = {
 	CONFIRM_DELETE: 'confirm-delete',
 	CONTEXT_FILES: 'context-files',
 	MEMORY_FILES: 'memory-files',
+	FLOW_MEMORY_FILES: 'flow-memory-files',
 };
 
 /**

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -128,8 +128,19 @@ class Flows extends BaseRepository {
 	 * @param array $flow_config Decoded flow config from database.
 	 * @return array Normalized flow config.
 	 */
+	/**
+	 * Keys in flow_config that are flow-level metadata, not step configs.
+	 *
+	 * @var array
+	 */
+	private const FLOW_CONFIG_META_KEYS = array( 'memory_files' );
+
 	private function normalizeFlowConfig( array $flow_config ): array {
 		foreach ( $flow_config as $step_id => $step_config ) {
+			// Skip flow-level metadata keys — only normalize step configs.
+			if ( in_array( $step_id, self::FLOW_CONFIG_META_KEYS, true ) ) {
+				continue;
+			}
 			$flow_config[ $step_id ] = FlowStepNormalizer::normalizeHandlerFields( $step_config );
 		}
 		return $flow_config;
@@ -595,6 +606,56 @@ class Flows extends BaseRepository {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Get flow memory files from flow config.
+	 *
+	 * @param int $flow_id Flow ID.
+	 * @return array Array of memory filenames.
+	 */
+	public function get_flow_memory_files( int $flow_id ): array {
+		$flow = $this->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return array();
+		}
+		return $flow['flow_config']['memory_files'] ?? array();
+	}
+
+	/**
+	 * Update flow memory files in flow config.
+	 *
+	 * @param int   $flow_id      Flow ID.
+	 * @param array $memory_files Array of memory filenames.
+	 * @return bool True on success, false on failure.
+	 */
+	public function update_flow_memory_files( int $flow_id, array $memory_files ): bool {
+		if ( empty( $flow_id ) ) {
+			return false;
+		}
+
+		// Read raw flow_config JSON to avoid normalization side effects.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$raw_config_json = $this->wpdb->get_var(
+			$this->wpdb->prepare( 'SELECT flow_config FROM %i WHERE flow_id = %d', $this->table_name, $flow_id )
+		);
+
+		if ( null === $raw_config_json ) {
+			return false;
+		}
+
+		$flow_config                 = json_decode( $raw_config_json, true ) ?? array();
+		$flow_config['memory_files'] = $memory_files;
+
+		$result = $this->wpdb->update(
+			$this->table_name,
+			array( 'flow_config' => wp_json_encode( $flow_config ) ),
+			array( 'flow_id' => $flow_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		return false !== $result;
 	}
 
 	/**

--- a/inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php
+++ b/inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Flow Memory Files Directive - Priority 45
+ *
+ * Injects agent memory files referenced by flow configuration into AI context.
+ * Flow memory files are additive — they inject alongside pipeline memory files.
+ *
+ * Priority Order in Directive System:
+ * 1. Priority 10 - Plugin Core Directive (agent identity)
+ * 2. Priority 20 - Core Memory Files (SOUL.md, USER.md, MEMORY.md, etc.)
+ * 3. Priority 40 - Pipeline Memory Files (per-pipeline selectable)
+ * 4. Priority 45 - Flow Memory Files (THIS CLASS - per-flow selectable)
+ * 5. Priority 50 - Pipeline System Prompt (pipeline instructions)
+ * 6. Priority 60 - Pipeline Context Files
+ * 7. Priority 70 - Tool Definitions (available tools and workflow)
+ * 8. Priority 80 - Site Context (WordPress metadata)
+ *
+ * @package DataMachine\Core\Steps\AI\Directives
+ */
+
+namespace DataMachine\Core\Steps\AI\Directives;
+
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Engine\AI\Directives\MemoryFilesReader;
+
+defined( 'ABSPATH' ) || exit;
+
+class FlowMemoryFilesDirective implements \DataMachine\Engine\AI\Directives\DirectiveInterface {
+
+	/**
+	 * Get directive outputs for flow memory files.
+	 *
+	 * @param string      $provider_name AI provider name.
+	 * @param array       $tools         Available tools.
+	 * @param string|null $step_id       Pipeline step ID.
+	 * @param array       $payload       Additional payload data (contains flow_step_id).
+	 * @return array Directive outputs.
+	 */
+	public static function get_outputs( string $provider_name, array $tools, ?string $step_id = null, array $payload = array() ): array {
+		$flow_step_id = $payload['flow_step_id'] ?? null;
+
+		if ( empty( $flow_step_id ) ) {
+			return array();
+		}
+
+		// Extract flow_id from flow_step_id via the DM filter.
+		$parts = apply_filters( 'datamachine_split_flow_step_id', null, $flow_step_id );
+		if ( ! $parts || empty( $parts['flow_id'] ) ) {
+			return array();
+		}
+
+		$flow_id = (int) $parts['flow_id'];
+
+		$db_flows     = new Flows();
+		$memory_files = $db_flows->get_flow_memory_files( $flow_id );
+
+		return MemoryFilesReader::read( $memory_files, 'Flow', $flow_id );
+	}
+}
+
+// Register at Priority 45 — between pipeline memory files (40) and pipeline system prompt (50).
+add_filter(
+	'datamachine_directives',
+	function ( $directives ) {
+		$directives[] = array(
+			'class'       => FlowMemoryFilesDirective::class,
+			'priority'    => 45,
+			'agent_types' => array( 'pipeline' ),
+		);
+		return $directives;
+	}
+);

--- a/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
@@ -9,10 +9,11 @@
  * 1. Priority 10 - Plugin Core Directive (agent identity)
  * 2. Priority 20 - Core Memory Files (SOUL.md, USER.md, MEMORY.md, etc.)
  * 3. Priority 40 - Pipeline Memory Files (THIS CLASS - per-pipeline selectable)
- * 4. Priority 50 - Pipeline System Prompt (pipeline instructions)
- * 5. Priority 60 - Pipeline Context Files
- * 6. Priority 70 - Tool Definitions (available tools and workflow)
- * 7. Priority 80 - Site Context (WordPress metadata)
+ * 4. Priority 45 - Flow Memory Files (per-flow selectable)
+ * 5. Priority 50 - Pipeline System Prompt (pipeline instructions)
+ * 6. Priority 60 - Pipeline Context Files
+ * 7. Priority 70 - Tool Definitions (available tools and workflow)
+ * 8. Priority 80 - Site Context (WordPress metadata)
  *
  * @package DataMachine\Core\Steps\AI\Directives
  */
@@ -20,7 +21,7 @@
 namespace DataMachine\Core\Steps\AI\Directives;
 
 use DataMachine\Core\Database\Pipelines\Pipelines;
-use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Engine\AI\Directives\MemoryFilesReader;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -50,60 +51,11 @@ class PipelineMemoryFilesDirective implements \DataMachine\Engine\AI\Directives\
 
 		$memory_files = $db_pipelines->get_pipeline_memory_files( (int) $pipeline_id );
 
-		if ( empty( $memory_files ) ) {
-			return array();
-		}
-
-		$directory_manager = new DirectoryManager();
-		$agent_dir         = $directory_manager->get_agent_directory();
-		$outputs           = array();
-
-		foreach ( $memory_files as $filename ) {
-			$safe_filename = sanitize_file_name( $filename );
-			$filepath      = "{$agent_dir}/{$safe_filename}";
-
-			if ( ! file_exists( $filepath ) ) {
-				do_action(
-					'datamachine_log',
-					'warning',
-					'Pipeline Memory Files: File not found',
-					array(
-						'filename'    => $safe_filename,
-						'pipeline_id' => $pipeline_id,
-					)
-				);
-				continue;
-			}
-
-			$content = file_get_contents( $filepath );
-			if ( empty( trim( $content ) ) ) {
-				continue;
-			}
-
-			$outputs[] = array(
-				'type'    => 'system_text',
-				'content' => "## Memory File: {$safe_filename}\n{$content}",
-			);
-		}
-
-		if ( ! empty( $outputs ) ) {
-			do_action(
-				'datamachine_log',
-				'debug',
-				'Pipeline Memory Files: Injected memory files',
-				array(
-					'pipeline_id' => $pipeline_id,
-					'file_count'  => count( $outputs ),
-					'files'       => $memory_files,
-				)
-			);
-		}
-
-		return $outputs;
+		return MemoryFilesReader::read( $memory_files, 'Pipeline', (int) $pipeline_id );
 	}
 }
 
-// Register at Priority 40 — between core memory files (20) and pipeline system prompt (50).
+// Register at Priority 40 — between core memory files (20) and flow memory files (45).
 add_filter(
 	'datamachine_directives',
 	function ( $directives ) {

--- a/inc/Engine/AI/Directives/MemoryFilesReader.php
+++ b/inc/Engine/AI/Directives/MemoryFilesReader.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Memory Files Reader
+ *
+ * Shared helper for reading agent memory files and producing directive outputs.
+ * Used by both PipelineMemoryFilesDirective and FlowMemoryFilesDirective
+ * to avoid duplicating the file-reading logic.
+ *
+ * @package DataMachine\Engine\AI\Directives
+ */
+
+namespace DataMachine\Engine\AI\Directives;
+
+use DataMachine\Core\FilesRepository\DirectoryManager;
+
+defined( 'ABSPATH' ) || exit;
+
+class MemoryFilesReader {
+
+	/**
+	 * Read memory files from the agent directory and produce directive outputs.
+	 *
+	 * @param array  $memory_files Array of memory filenames.
+	 * @param string $scope_label  Label for logging (e.g. 'Pipeline', 'Flow').
+	 * @param int    $scope_id     Entity ID for logging (e.g. pipeline_id, flow_id).
+	 * @return array Array of directive outputs (type => system_text, content => ...).
+	 */
+	public static function read( array $memory_files, string $scope_label, int $scope_id ): array {
+		if ( empty( $memory_files ) ) {
+			return array();
+		}
+
+		$directory_manager = new DirectoryManager();
+		$agent_dir         = $directory_manager->get_agent_directory();
+		$outputs           = array();
+
+		foreach ( $memory_files as $filename ) {
+			$safe_filename = sanitize_file_name( $filename );
+			$filepath      = "{$agent_dir}/{$safe_filename}";
+
+			if ( ! file_exists( $filepath ) ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					"{$scope_label} Memory Files: File not found",
+					array(
+						'filename' => $safe_filename,
+						'scope_id' => $scope_id,
+					)
+				);
+				continue;
+			}
+
+			$content = file_get_contents( $filepath );
+			if ( empty( trim( $content ) ) ) {
+				continue;
+			}
+
+			$outputs[] = array(
+				'type'    => 'system_text',
+				'content' => "## Memory File: {$safe_filename}\n{$content}",
+			);
+		}
+
+		if ( ! empty( $outputs ) ) {
+			do_action(
+				'datamachine_log',
+				'debug',
+				"{$scope_label} Memory Files: Injected memory files",
+				array(
+					'scope_id'   => $scope_id,
+					'file_count' => count( $outputs ),
+					'files'      => $memory_files,
+				)
+			);
+		}
+
+		return $outputs;
+	}
+}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -68,6 +68,7 @@ require_once __DIR__ . '/Api/Chat/ChatAgentDirective.php';
 require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineCoreDirective.php';
 require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php';
 require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php';
+require_once __DIR__ . '/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php';
 require_once __DIR__ . '/Core/FilesRepository/FileCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/ClaimsCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/QueueTuning.php';


### PR DESCRIPTION
## Summary

Implements flow-scoped memory files as described in #471. Flows can now have their own memory files that inject into AI context alongside (not instead of) pipeline memory files.

## Architecture

```
Priority 20: Core memory (SOUL.md, USER.md, MEMORY.md) — always
Priority 40: Pipeline memory files — per pipeline
Priority 45: Flow memory files — per flow (NEW)
Priority 50: Pipeline system prompt
```

- **Shared `MemoryFilesReader`** — extracts the file-reading/output-building logic into a single helper used by both pipeline and flow directives. Zero duplication.
- **`FlowMemoryFilesDirective`** (priority 45) — resolves `flow_id` from `payload['flow_step_id']`, reads flow memory files, delegates to shared reader
- **Refactored `PipelineMemoryFilesDirective`** — now delegates to shared reader instead of inline logic
- **`flow_config` storage** — `memory_files` stored as a top-level metadata key in the flow_config JSON. `normalizeFlowConfig()` updated with `FLOW_CONFIG_META_KEYS` to skip non-step keys.

## Changes

### Backend (PHP)
- `MemoryFilesReader` — shared directive helper (`inc/Engine/AI/Directives/`)
- `FlowMemoryFilesDirective` — new directive at priority 45
- `PipelineMemoryFilesDirective` — refactored to use shared reader
- `Flows.php` DB — `get_flow_memory_files()`, `update_flow_memory_files()`, `FLOW_CONFIG_META_KEYS`
- `Flows.php` REST API — `GET/PUT /flows/{id}/memory-files`
- `FlowsCommand.php` CLI — `wp datamachine flows memory-files <id> [--add|--remove]`
- `bootstrap.php` — registers new directive file

### Frontend (React)
- `MemoryFilesSelector` — shared component extracted from `PipelineMemoryFiles`
- `FlowMemoryFiles` — flow-scoped wrapper using shared selector
- `FlowMemoryFilesModal` — modal wrapper
- `PipelineMemoryFiles` — refactored to use shared selector
- Flow query hooks — `useFlowMemoryFiles`, `useUpdateFlowMemoryFiles`
- API functions — `fetchFlowMemoryFiles`, `updateFlowMemoryFiles`
- `FlowHeader` — "Memory" button added
- `FlowCard` — wired `handleMemoryFiles` to open modal
- `ModalSwitch` + `constants` — `FLOW_MEMORY_FILES` modal type

## Use Cases
- Content Ideation flow gets `content-briefing.md`
- Dev Task Runner flow gets `coding-standards.md`
- Recipe Ideation gets nothing extra (core memory is enough)
- All sharing the same pipeline

Closes #471