### PR TITLE
feat: pipeline batch fan-out — PipelineBatchScheduler

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -429,11 +429,22 @@ class ExecuteStepAbility {
 			$next_flow_step_id = $navigator->get_next_flow_step_id( $flow_step_id, $payload );
 
 			if ( $next_flow_step_id ) {
-				do_action( 'datamachine_schedule_next_step', $job_id, $next_flow_step_id, $dataPackets );
+				// Fan out: each DataPacket becomes its own child job
+				// continuing through the remaining pipeline steps.
+				$engine_snapshot = datamachine_get_engine_data( $job_id );
+				$batch_scheduler = new PipelineBatchScheduler();
+				$batch_result    = $batch_scheduler->fanOut(
+					$job_id,
+					$next_flow_step_id,
+					$dataPackets,
+					$engine_snapshot
+				);
+
 				return array(
 					'success'      => true,
 					'step_success' => true,
-					'outcome'      => 'next_step_scheduled',
+					'outcome'      => 'batch_scheduled',
+					'batch'        => $batch_result,
 				);
 			}
 
@@ -464,7 +475,7 @@ class ExecuteStepAbility {
 		}
 
 		// Failure: check for "no new items" vs actual failure.
-		$is_fetch_step = ( 'fetch' === $step_type );
+		$is_fetch_step = in_array( $step_type, array( 'fetch', 'event_import' ), true );
 		$has_history   = $this->db_processed_items->has_processed_items( $flow_step_id );
 
 		if ( $is_fetch_step && $has_history ) {

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -1,0 +1,406 @@
+<?php
+/**
+ * Pipeline Batch Scheduler
+ *
+ * Handles fan-out of multiple DataPackets into child jobs. When a pipeline
+ * step returns N DataPackets, this scheduler creates N child jobs that each
+ * carry one DataPacket through the remaining pipeline steps independently.
+ *
+ * The original job becomes the parent and tracks overall progress. Child
+ * jobs use the same engine_data (flow_config, pipeline_config) but operate
+ * on their own DataPacket.
+ *
+ * This is not a special mode — it's how the engine works. A single DataPacket
+ * is simply a batch of one.
+ *
+ * @package DataMachine\Abilities\Engine
+ * @since 0.35.0
+ */
+
+namespace DataMachine\Abilities\Engine;
+
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\JobStatus;
+
+defined( 'ABSPATH' ) || exit;
+
+class PipelineBatchScheduler {
+
+	/**
+	 * Number of child jobs to schedule per chunk.
+	 *
+	 * Between chunks, other Action Scheduler actions can run,
+	 * preventing queue flooding.
+	 */
+	const CHUNK_SIZE = 10;
+
+	/**
+	 * Delay in seconds between scheduling chunks.
+	 */
+	const CHUNK_DELAY = 30;
+
+	/**
+	 * Action Scheduler hook for processing batch chunks.
+	 */
+	const BATCH_HOOK = 'datamachine_pipeline_batch_chunk';
+
+	/**
+	 * @var Jobs
+	 */
+	private Jobs $db_jobs;
+
+	public function __construct() {
+		$this->db_jobs = new Jobs();
+	}
+
+	/**
+	 * Fan out DataPackets into child jobs.
+	 *
+	 * Converts the parent job into a batch parent and creates child jobs
+	 * for each DataPacket. Each child continues through the remaining
+	 * pipeline steps independently.
+	 *
+	 * @param int    $parent_job_id     The current job ID (becomes the parent).
+	 * @param string $next_flow_step_id The next step to execute on each child.
+	 * @param array  $dataPackets       Array of DataPacket arrays from the fetch step.
+	 * @param array  $engine_snapshot   The parent's engine_data to clone to children.
+	 * @return array Result with batch details.
+	 */
+	public function fanOut(
+		int $parent_job_id,
+		string $next_flow_step_id,
+		array $dataPackets,
+		array $engine_snapshot
+	): array {
+		$total       = count( $dataPackets );
+		$pipeline_id = $engine_snapshot['job']['pipeline_id'] ?? 0;
+		$flow_id     = $engine_snapshot['job']['flow_id'] ?? 0;
+		$flow_name   = $engine_snapshot['flow']['name'] ?? '';
+
+		// Store batch metadata on the parent job.
+		datamachine_merge_engine_data( $parent_job_id, array(
+			'batch'              => true,
+			'batch_total'        => $total,
+			'batch_scheduled'    => 0,
+			'batch_chunk_size'   => self::CHUNK_SIZE,
+			'next_flow_step_id'  => $next_flow_step_id,
+			'started_at'         => current_time( 'mysql' ),
+		) );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			sprintf( 'Pipeline batch: fanning out %d items for flow "%s"', $total, $flow_name ),
+			array(
+				'parent_job_id'     => $parent_job_id,
+				'pipeline_id'       => $pipeline_id,
+				'flow_id'           => $flow_id,
+				'total'             => $total,
+				'next_flow_step_id' => $next_flow_step_id,
+			)
+		);
+
+		// Store all DataPackets in a transient for chunked scheduling.
+		$transient_key = 'dm_pipeline_batch_' . $parent_job_id;
+		$batch_data    = array(
+			'parent_job_id'     => $parent_job_id,
+			'next_flow_step_id' => $next_flow_step_id,
+			'engine_snapshot'   => $engine_snapshot,
+			'data_packets'      => $dataPackets,
+			'total'             => $total,
+			'offset'            => 0,
+		);
+
+		set_transient( $transient_key, $batch_data, 4 * HOUR_IN_SECONDS );
+
+		// Schedule first chunk immediately.
+		if ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action(
+				time(),
+				self::BATCH_HOOK,
+				array( 'parent_job_id' => $parent_job_id ),
+				'data-machine'
+			);
+		}
+
+		return array(
+			'parent_job_id' => $parent_job_id,
+			'total'         => $total,
+			'chunk_size'    => self::CHUNK_SIZE,
+		);
+	}
+
+	/**
+	 * Process a chunk of the batch.
+	 *
+	 * Called by Action Scheduler. Creates child jobs for the current chunk,
+	 * then schedules the next chunk with a delay.
+	 *
+	 * @param int $parent_job_id The parent job ID.
+	 */
+	public function processChunk( int $parent_job_id ): void {
+		$transient_key = 'dm_pipeline_batch_' . $parent_job_id;
+		$batch_data    = get_transient( $transient_key );
+
+		if ( ! $batch_data ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Pipeline batch: transient expired or missing',
+				array( 'parent_job_id' => $parent_job_id )
+			);
+			return;
+		}
+
+		// Check for cancellation.
+		$parent_engine = datamachine_get_engine_data( $parent_job_id );
+		if ( ! empty( $parent_engine['cancelled'] ) ) {
+			delete_transient( $transient_key );
+			$this->db_jobs->complete_job( $parent_job_id, 'cancelled' );
+			return;
+		}
+
+		$next_flow_step_id = $batch_data['next_flow_step_id'];
+		$engine_snapshot   = $batch_data['engine_snapshot'];
+		$all_packets       = $batch_data['data_packets'];
+		$total             = $batch_data['total'];
+		$offset            = $batch_data['offset'];
+		$chunk             = array_slice( $all_packets, $offset, self::CHUNK_SIZE );
+
+		$scheduled = 0;
+
+		foreach ( $chunk as $single_packet ) {
+			$child_job_id = $this->createChildJob(
+				$parent_job_id,
+				$next_flow_step_id,
+				$single_packet,
+				$engine_snapshot
+			);
+
+			if ( $child_job_id ) {
+				++$scheduled;
+			}
+		}
+
+		$new_offset = $offset + self::CHUNK_SIZE;
+
+		// Update parent progress.
+		$parent_engine                    = datamachine_get_engine_data( $parent_job_id );
+		$parent_engine['batch_scheduled'] = ( $parent_engine['batch_scheduled'] ?? 0 ) + $scheduled;
+		$parent_engine['batch_offset']    = min( $new_offset, $total );
+		datamachine_set_engine_data( $parent_job_id, $parent_engine );
+
+		do_action(
+			'datamachine_log',
+			'debug',
+			sprintf( 'Pipeline batch chunk: scheduled %d/%d (offset %d)', $scheduled, $total, $new_offset ),
+			array(
+				'parent_job_id' => $parent_job_id,
+				'scheduled'     => $scheduled,
+				'offset'        => $new_offset,
+				'total'         => $total,
+			)
+		);
+
+		if ( $new_offset < $total ) {
+			// More items — schedule next chunk with delay.
+			$batch_data['offset'] = $new_offset;
+			set_transient( $transient_key, $batch_data, 4 * HOUR_IN_SECONDS );
+
+			as_schedule_single_action(
+				time() + self::CHUNK_DELAY,
+				self::BATCH_HOOK,
+				array( 'parent_job_id' => $parent_job_id ),
+				'data-machine'
+			);
+		} else {
+			// All items scheduled — clean up transient.
+			delete_transient( $transient_key );
+
+			do_action(
+				'datamachine_log',
+				'info',
+				sprintf( 'Pipeline batch: all %d items scheduled', $total ),
+				array( 'parent_job_id' => $parent_job_id )
+			);
+		}
+	}
+
+	/**
+	 * Create a single child job for one DataPacket.
+	 *
+	 * Clones the parent's engine_data, stores the single DataPacket to
+	 * the filesystem, and schedules the next step via the normal engine path.
+	 *
+	 * @param int    $parent_job_id     Parent job ID.
+	 * @param string $next_flow_step_id Next step to execute.
+	 * @param array  $single_packet     A single DataPacket (the array structure, not the object).
+	 * @param array  $engine_snapshot   Engine data to clone to child.
+	 * @return int|false Child job ID or false on failure.
+	 */
+	private function createChildJob(
+		int $parent_job_id,
+		string $next_flow_step_id,
+		array $single_packet,
+		array $engine_snapshot
+	): int|false {
+		$pipeline_id = $engine_snapshot['job']['pipeline_id'] ?? 0;
+		$flow_id     = $engine_snapshot['job']['flow_id'] ?? 0;
+		$flow_name   = $engine_snapshot['flow']['name'] ?? '';
+		$item_title  = $single_packet['data']['title'] ?? 'Untitled';
+
+		// Create child job linked to parent.
+		$child_job_id = $this->db_jobs->create_job( array(
+			'pipeline_id'   => $pipeline_id,
+			'flow_id'       => $flow_id,
+			'source'        => 'pipeline',
+			'label'         => $item_title,
+			'parent_job_id' => $parent_job_id,
+		) );
+
+		if ( ! $child_job_id ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Pipeline batch: failed to create child job',
+				array(
+					'parent_job_id' => $parent_job_id,
+					'item_title'    => $item_title,
+				)
+			);
+			return false;
+		}
+
+		// Clone engine_data to child, updating the job context.
+		$child_engine            = $engine_snapshot;
+		$child_engine['job']     = array(
+			'job_id'        => $child_job_id,
+			'flow_id'       => $flow_id,
+			'pipeline_id'   => $pipeline_id,
+			'created_at'    => current_time( 'mysql', true ),
+			'parent_job_id' => $parent_job_id,
+		);
+
+		datamachine_set_engine_data( $child_job_id, $child_engine );
+		$this->db_jobs->start_job( $child_job_id );
+
+		// Schedule the next step with this single DataPacket.
+		// Uses the normal engine path — the child is a real pipeline job.
+		do_action(
+			'datamachine_schedule_next_step',
+			$child_job_id,
+			$next_flow_step_id,
+			array( $single_packet )
+		);
+
+		return $child_job_id;
+	}
+
+	/**
+	 * Handle child job completion.
+	 *
+	 * Called via datamachine_job_complete hook. Checks if all children
+	 * of the parent are finished and updates the parent accordingly.
+	 *
+	 * @param int    $job_id Job ID that just completed.
+	 * @param string $status The completion status.
+	 */
+	public static function onChildComplete( int $job_id, string $status ): void {
+		$jobs_db = new Jobs();
+		$job     = $jobs_db->get_job( $job_id );
+
+		if ( ! $job ) {
+			return;
+		}
+
+		$parent_job_id = $job['parent_job_id'] ?? 0;
+
+		if ( empty( $parent_job_id ) ) {
+			return; // Not a child job.
+		}
+
+		// Check parent is a pipeline batch.
+		$parent_engine = datamachine_get_engine_data( (int) $parent_job_id );
+		if ( empty( $parent_engine['batch'] ) ) {
+			return; // Not a pipeline batch parent.
+		}
+
+		// Count child statuses.
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_jobs';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$counts = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT
+					COUNT(*) as total,
+					SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
+					SUM(CASE WHEN status LIKE 'failed%%' THEN 1 ELSE 0 END) as failed,
+					SUM(CASE WHEN status LIKE 'agent_skipped%%' THEN 1 ELSE 0 END) as skipped,
+					SUM(CASE WHEN status = 'processing' OR status = 'pending' THEN 1 ELSE 0 END) as active
+				FROM {$table}
+				WHERE parent_job_id = %d",
+				$parent_job_id
+			),
+			ARRAY_A
+		);
+
+		if ( ! $counts ) {
+			return;
+		}
+
+		$total_children = (int) $counts['total'];
+		$active         = (int) $counts['active'];
+		$batch_total    = (int) ( $parent_engine['batch_total'] ?? $total_children );
+
+		// Still have active children or not all scheduled yet.
+		if ( $active > 0 || $total_children < $batch_total ) {
+			return;
+		}
+
+		// All children are done. Complete the parent.
+		$completed = (int) $counts['completed'];
+		$failed    = (int) $counts['failed'];
+		$skipped   = (int) $counts['skipped'];
+
+		if ( $completed > 0 ) {
+			$parent_status = JobStatus::COMPLETED;
+		} elseif ( $failed === $total_children ) {
+			$parent_status = JobStatus::failed(
+				sprintf( 'All %d child jobs failed', $total_children )
+			)->toString();
+		} else {
+			$parent_status = JobStatus::COMPLETED_NO_ITEMS;
+		}
+
+		$parent_engine['batch_results'] = array(
+			'completed' => $completed,
+			'failed'    => $failed,
+			'skipped'   => $skipped,
+			'total'     => $total_children,
+		);
+
+		datamachine_set_engine_data( (int) $parent_job_id, $parent_engine );
+		$jobs_db->complete_job( (int) $parent_job_id, $parent_status );
+
+		$flow_name = $parent_engine['flow']['name'] ?? '';
+
+		do_action(
+			'datamachine_log',
+			'info',
+			sprintf(
+				'Pipeline batch complete: %d/%d succeeded for flow "%s"',
+				$completed,
+				$total_children,
+				$flow_name
+			),
+			array(
+				'parent_job_id' => $parent_job_id,
+				'completed'     => $completed,
+				'failed'        => $failed,
+				'skipped'       => $skipped,
+				'total'         => $total_children,
+			)
+		);
+	}
+}

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -47,6 +47,7 @@ require_once __DIR__ . '/ImportExport.php';
 require_once __DIR__ . '/Engine.php';
 
 use DataMachine\Abilities\EngineAbilities;
+use DataMachine\Abilities\Engine\PipelineBatchScheduler;
 use DataMachine\Engine\Actions\Handlers\MarkItemProcessedHandler;
 use DataMachine\Engine\Actions\Handlers\FailJobHandler;
 use DataMachine\Engine\Actions\Handlers\JobCompleteHandler;
@@ -85,6 +86,18 @@ function datamachine_register_core_actions() {
 	);
 
 	\DataMachine\Engine\Actions\ImportExport::register();
+
+	// Pipeline batch fan-out: process chunks and track child completion.
+	add_action(
+		PipelineBatchScheduler::BATCH_HOOK,
+		function ( $parent_job_id ) {
+			$scheduler = new PipelineBatchScheduler();
+			$scheduler->processChunk( (int) $parent_job_id );
+		},
+		10,
+		1
+	);
+	add_action( 'datamachine_job_complete', array( PipelineBatchScheduler::class, 'onChildComplete' ), 20, 2 );
 
 	// Register engine abilities (business logic) before hook bridges.
 	new EngineAbilities();

--- a/tests/Unit/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Engine/PipelineBatchSchedulerTest.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * Tests for PipelineBatchScheduler.
+ *
+ * @package DataMachine\Tests\Unit\Engine
+ */
+
+namespace DataMachine\Tests\Unit\Engine;
+
+use DataMachine\Abilities\Engine\PipelineBatchScheduler;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\JobStatus;
+use WP_UnitTestCase;
+
+class PipelineBatchSchedulerTest extends WP_UnitTestCase {
+
+	private Jobs $jobs_db;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->jobs_db = new Jobs();
+	}
+
+	/**
+	 * Build a minimal engine snapshot for testing.
+	 */
+	private function make_engine_snapshot( int $job_id, int $flow_id = 1, int $pipeline_id = 1 ): array {
+		return array(
+			'job'             => array(
+				'job_id'      => $job_id,
+				'flow_id'     => $flow_id,
+				'pipeline_id' => $pipeline_id,
+				'created_at'  => current_time( 'mysql', true ),
+			),
+			'flow'            => array(
+				'name'        => 'Test Flow',
+				'description' => '',
+				'scheduling'  => array(),
+			),
+			'pipeline'        => array(
+				'name'        => 'Test Pipeline',
+				'description' => '',
+			),
+			'flow_config'     => array(),
+			'pipeline_config' => array(),
+		);
+	}
+
+	/**
+	 * Build a DataPacket array (mimics what handlers return after addTo()).
+	 */
+	private function make_data_packet( string $title = 'Test Event' ): array {
+		return array(
+			'type'      => 'event_import',
+			'timestamp' => time(),
+			'data'      => array(
+				'title' => $title,
+				'body'  => wp_json_encode( array( 'event' => array( 'title' => $title ) ) ),
+			),
+			'metadata'  => array(
+				'source_type'      => 'ticketmaster',
+				'event_identifier' => md5( $title ),
+				'success'          => true,
+			),
+		);
+	}
+
+	/**
+	 * Create a parent job in the DB and store engine data.
+	 */
+	private function create_parent_job(): int {
+		$job_id = $this->jobs_db->create_job( array(
+			'pipeline_id' => 1,
+			'flow_id'     => 1,
+			'source'      => 'pipeline',
+			'label'       => 'Test Flow',
+		) );
+
+		$this->assertNotFalse( $job_id );
+		$this->jobs_db->start_job( (int) $job_id );
+
+		$engine = $this->make_engine_snapshot( (int) $job_id );
+		datamachine_set_engine_data( (int) $job_id, $engine );
+
+		return (int) $job_id;
+	}
+
+	public function test_fanout_creates_batch_metadata_on_parent(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+		$packets   = array(
+			$this->make_data_packet( 'Event A' ),
+			$this->make_data_packet( 'Event B' ),
+			$this->make_data_packet( 'Event C' ),
+		);
+
+		$scheduler = new PipelineBatchScheduler();
+		$result    = $scheduler->fanOut( $parent_id, 'step_abc_123', $packets, $engine );
+
+		$this->assertEquals( $parent_id, $result['parent_job_id'] );
+		$this->assertEquals( 3, $result['total'] );
+		$this->assertEquals( PipelineBatchScheduler::CHUNK_SIZE, $result['chunk_size'] );
+
+		// Check batch metadata was stored on parent.
+		$parent_engine = datamachine_get_engine_data( $parent_id );
+		$this->assertTrue( $parent_engine['batch'] );
+		$this->assertEquals( 3, $parent_engine['batch_total'] );
+		$this->assertEquals( 0, $parent_engine['batch_scheduled'] );
+		$this->assertEquals( 'step_abc_123', $parent_engine['next_flow_step_id'] );
+	}
+
+	public function test_fanout_stores_transient(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+		$packets   = array(
+			$this->make_data_packet( 'Event A' ),
+		);
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_abc_123', $packets, $engine );
+
+		$transient = get_transient( 'dm_pipeline_batch_' . $parent_id );
+		$this->assertNotFalse( $transient );
+		$this->assertEquals( $parent_id, $transient['parent_job_id'] );
+		$this->assertEquals( 1, $transient['total'] );
+		$this->assertCount( 1, $transient['data_packets'] );
+	}
+
+	public function test_process_chunk_creates_child_jobs(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+		$packets   = array(
+			$this->make_data_packet( 'Event A' ),
+			$this->make_data_packet( 'Event B' ),
+		);
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_abc_123', $packets, $engine );
+
+		// Process the chunk manually (normally AS would call this).
+		$scheduler->processChunk( $parent_id );
+
+		// Check child jobs were created.
+		global $wpdb;
+		$table    = $wpdb->prefix . 'datamachine_jobs';
+		$children = $wpdb->get_results(
+			$wpdb->prepare( "SELECT * FROM {$table} WHERE parent_job_id = %d", $parent_id ),
+			ARRAY_A
+		);
+
+		$this->assertCount( 2, $children );
+
+		foreach ( $children as $child ) {
+			$this->assertEquals( $parent_id, $child['parent_job_id'] );
+			$this->assertEquals( 'pipeline', $child['source'] );
+			$this->assertEquals( '1', $child['pipeline_id'] );
+			$this->assertEquals( '1', $child['flow_id'] );
+		}
+
+		// Check parent progress was updated.
+		$parent_engine = datamachine_get_engine_data( $parent_id );
+		$this->assertEquals( 2, $parent_engine['batch_scheduled'] );
+	}
+
+	public function test_process_chunk_respects_cancellation(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+		$packets   = array(
+			$this->make_data_packet( 'Event A' ),
+		);
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_abc_123', $packets, $engine );
+
+		// Set cancellation flag.
+		$parent_engine              = datamachine_get_engine_data( $parent_id );
+		$parent_engine['cancelled'] = true;
+		datamachine_set_engine_data( $parent_id, $parent_engine );
+
+		$scheduler->processChunk( $parent_id );
+
+		// No child jobs should have been created.
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_jobs';
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE parent_job_id = %d", $parent_id )
+		);
+
+		$this->assertEquals( 0, $count );
+
+		// Parent should be cancelled.
+		$parent_job = $this->jobs_db->get_job( $parent_id );
+		$this->assertStringContainsString( 'cancelled', $parent_job['status'] );
+	}
+
+	public function test_child_labels_use_packet_titles(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+		$packets   = array(
+			$this->make_data_packet( 'Phish at MSG' ),
+			$this->make_data_packet( 'Dead & Co Final Tour' ),
+		);
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_abc_123', $packets, $engine );
+		$scheduler->processChunk( $parent_id );
+
+		global $wpdb;
+		$table  = $wpdb->prefix . 'datamachine_jobs';
+		$labels = $wpdb->get_col(
+			$wpdb->prepare( "SELECT label FROM {$table} WHERE parent_job_id = %d ORDER BY job_id", $parent_id )
+		);
+
+		$this->assertContains( 'Phish at MSG', $labels );
+		$this->assertContains( 'Dead & Co Final Tour', $labels );
+	}
+
+	public function test_on_child_complete_marks_parent_done_when_all_children_finish(): void {
+		$parent_id = $this->create_parent_job();
+
+		// Store batch metadata on parent.
+		$parent_engine          = datamachine_get_engine_data( $parent_id );
+		$parent_engine['batch'] = true;
+		$parent_engine['batch_total'] = 2;
+		datamachine_set_engine_data( $parent_id, $parent_engine );
+
+		// Create two child jobs.
+		$child_1 = $this->jobs_db->create_job( array(
+			'pipeline_id'   => 1,
+			'flow_id'       => 1,
+			'source'        => 'pipeline',
+			'label'         => 'Child 1',
+			'parent_job_id' => $parent_id,
+		) );
+		$this->jobs_db->start_job( (int) $child_1 );
+
+		$child_2 = $this->jobs_db->create_job( array(
+			'pipeline_id'   => 1,
+			'flow_id'       => 1,
+			'source'        => 'pipeline',
+			'label'         => 'Child 2',
+			'parent_job_id' => $parent_id,
+		) );
+		$this->jobs_db->start_job( (int) $child_2 );
+
+		// Complete first child.
+		$this->jobs_db->complete_job( (int) $child_1, JobStatus::COMPLETED );
+		PipelineBatchScheduler::onChildComplete( (int) $child_1, JobStatus::COMPLETED );
+
+		// Parent should still be processing (child 2 not done).
+		$parent_job = $this->jobs_db->get_job( $parent_id );
+		$this->assertEquals( 'processing', $parent_job['status'] );
+
+		// Complete second child.
+		$this->jobs_db->complete_job( (int) $child_2, JobStatus::COMPLETED );
+		PipelineBatchScheduler::onChildComplete( (int) $child_2, JobStatus::COMPLETED );
+
+		// Parent should now be completed.
+		$parent_job = $this->jobs_db->get_job( $parent_id );
+		$this->assertEquals( JobStatus::COMPLETED, $parent_job['status'] );
+
+		// Check batch results in engine data.
+		$parent_engine = datamachine_get_engine_data( $parent_id );
+		$this->assertEquals( 2, $parent_engine['batch_results']['completed'] );
+		$this->assertEquals( 0, $parent_engine['batch_results']['failed'] );
+	}
+
+	public function test_on_child_complete_marks_parent_failed_when_all_children_fail(): void {
+		$parent_id = $this->create_parent_job();
+
+		$parent_engine                = datamachine_get_engine_data( $parent_id );
+		$parent_engine['batch']       = true;
+		$parent_engine['batch_total'] = 2;
+		datamachine_set_engine_data( $parent_id, $parent_engine );
+
+		$child_1 = $this->jobs_db->create_job( array(
+			'pipeline_id'   => 1,
+			'flow_id'       => 1,
+			'source'        => 'pipeline',
+			'label'         => 'Child 1',
+			'parent_job_id' => $parent_id,
+		) );
+		$this->jobs_db->start_job( (int) $child_1 );
+
+		$child_2 = $this->jobs_db->create_job( array(
+			'pipeline_id'   => 1,
+			'flow_id'       => 1,
+			'source'        => 'pipeline',
+			'label'         => 'Child 2',
+			'parent_job_id' => $parent_id,
+		) );
+		$this->jobs_db->start_job( (int) $child_2 );
+
+		$fail_status = JobStatus::failed( 'test error' )->toString();
+
+		$this->jobs_db->complete_job( (int) $child_1, $fail_status );
+		PipelineBatchScheduler::onChildComplete( (int) $child_1, $fail_status );
+
+		$this->jobs_db->complete_job( (int) $child_2, $fail_status );
+		PipelineBatchScheduler::onChildComplete( (int) $child_2, $fail_status );
+
+		$parent_job = $this->jobs_db->get_job( $parent_id );
+		$this->assertStringContainsString( 'failed', $parent_job['status'] );
+	}
+
+	public function test_on_child_complete_ignores_non_batch_parents(): void {
+		// Create a parent job WITHOUT batch metadata.
+		$parent_id = $this->create_parent_job();
+
+		$child = $this->jobs_db->create_job( array(
+			'pipeline_id'   => 1,
+			'flow_id'       => 1,
+			'source'        => 'pipeline',
+			'label'         => 'Child',
+			'parent_job_id' => $parent_id,
+		) );
+		$this->jobs_db->start_job( (int) $child );
+		$this->jobs_db->complete_job( (int) $child, JobStatus::COMPLETED );
+
+		// Should not throw or modify parent.
+		PipelineBatchScheduler::onChildComplete( (int) $child, JobStatus::COMPLETED );
+
+		$parent_job = $this->jobs_db->get_job( $parent_id );
+		$this->assertEquals( 'processing', $parent_job['status'] );
+	}
+}


### PR DESCRIPTION
## Summary

- **PipelineBatchScheduler** — new class that fans out multiple DataPackets from a fetch step into independent child jobs, each continuing through the remaining pipeline steps
- Replaces the single `do_action('datamachine_schedule_next_step')` call in `ExecuteStepAbility::routeAfterExecution()` with `PipelineBatchScheduler::fanOut()`
- Fixes `is_fetch_step` check to include `event_import` step type alongside `fetch`

## How it works

```
Fetch step returns N DataPackets
  → PipelineBatchScheduler.fanOut()
    → Parent job becomes batch parent (stores metadata)
    → DataPackets stored in transient for chunked processing
    → Action Scheduler processes chunks of 10 with 30s delay
    → Each DataPacket → child job → continues pipeline independently
    → datamachine_job_complete hook tracks child completion
    → Parent completes when all children finish
```

A single DataPacket is a batch of one — no branching, no special mode.

## PR sequence

This is **PR 1 of 6** in the batch fan-out feature:

1. **Engine fan-out** (this PR) — `PipelineBatchScheduler`
2. **FetchStep multi-item** — `FetchStep::execute_handler()` supports N items
3. **Core handler multi-return** — RSS, Reddit, WordPress abilities return all matches
4. **Event handler multi-return** — Ticketmaster, DiceFm, WebScraper accumulate
5. **Reddit multi-return** — `data-machine-socials`
6. **WeeklyRoundup** — `extrachill-events`

PRs 2+ are incremental — each unblocks more handlers to produce batches.

## Tests

8 unit tests in `PipelineBatchSchedulerTest`:
- `test_fanout_creates_batch_metadata_on_parent`
- `test_fanout_stores_transient`
- `test_process_chunk_creates_child_jobs`
- `test_process_chunk_respects_cancellation`
- `test_child_labels_use_packet_titles`
- `test_on_child_complete_marks_parent_done_when_all_children_finish`
- `test_on_child_complete_marks_parent_failed_when_all_children_fail`
- `test_on_child_complete_ignores_non_batch_parents`

> **Note:** Tests require homeboy#366 fix (`--path` doesn't override `HOMEBOY_COMPONENT_PATH`) to run via `homeboy test`. Can be run directly with PHPUnit in the meantime.