### PR TITLE
feat: unified DataPacket wrapping in FetchHandler.get_fetch_data()

### DIFF
--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -14,6 +14,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Data fetching step for Data Machine pipelines.
  *
+ * Delegates to FetchHandler::get_fetch_data() which returns DataPacket[].
+ * Each DataPacket is added to the step's data packet array. When the
+ * PipelineBatchScheduler is active, multiple packets trigger fan-out
+ * into child jobs.
+ *
  * @package DataMachine
  */
 class FetchStep extends Step {
@@ -40,7 +45,7 @@ class FetchStep extends Step {
 	/**
 	 * Execute fetch step logic.
 	 *
-	 * @return array
+	 * @return array Updated data packet array.
 	 */
 	protected function executeStep(): array {
 		$handler          = $this->getHandlerSlug();
@@ -63,20 +68,42 @@ class FetchStep extends Step {
 		$handler_settings['pipeline_id']  = $this->flow_step_config['pipeline_id'];
 		$handler_settings['flow_id']      = $this->flow_step_config['flow_id'];
 
-		$packet = $this->execute_handler( $handler, $this->flow_step_config, $handler_settings, (string) $this->job_id );
+		$packets = $this->execute_handler( $handler, $handler_settings, (string) $this->job_id );
 
-		if ( ! $packet ) {
+		if ( empty( $packets ) ) {
 			$this->log( 'error', 'Fetch handler returned no content' );
 			return $this->dataPackets;
 		}
 
-		return $packet->addTo( $this->dataPackets );
+		$this->log(
+			'info',
+			'Fetch handler returned data',
+			array(
+				'handler'      => $handler,
+				'packet_count' => count( $packets ),
+			)
+		);
+
+		$result = $this->dataPackets;
+		foreach ( $packets as $packet ) {
+			$result = $packet->addTo( $result );
+		}
+
+		return $result;
 	}
 
 	/**
-	 * Executes handler and builds standardized fetch entry with content extraction.
+	 * Execute handler and return DataPackets.
+	 *
+	 * FetchHandler::get_fetch_data() now returns DataPacket[] directly.
+	 * This method just resolves the handler object and delegates.
+	 *
+	 * @param string $handler_name    Handler slug.
+	 * @param array  $handler_settings Handler settings (includes pipeline_id, flow_id).
+	 * @param string $job_id          Job ID.
+	 * @return DataPacket[] Array of DataPackets, or empty array on failure.
 	 */
-	private function execute_handler( string $handler_name, array $flow_step_config, array $handler_settings, string $job_id ): ?DataPacket {
+	private function execute_handler( string $handler_name, array $handler_settings, string $job_id ): array {
 		$handler = $this->get_handler_object( $handler_name );
 		if ( ! $handler ) {
 			$this->log(
@@ -86,93 +113,18 @@ class FetchStep extends Step {
 					'handler' => $handler_name,
 				)
 			);
-			return null;
+			return array();
 		}
 
 		try {
-			if ( ! isset( $flow_step_config['pipeline_id'] ) || empty( $flow_step_config['pipeline_id'] ) ) {
-				$this->log( 'error', 'Pipeline ID not found in step config' );
-				return null;
-			}
-			if ( ! isset( $flow_step_config['flow_id'] ) || empty( $flow_step_config['flow_id'] ) ) {
-				$this->log( 'error', 'Flow ID not found in step config' );
-				return null;
+			$pipeline_id = $handler_settings['pipeline_id'] ?? null;
+
+			if ( empty( $pipeline_id ) ) {
+				$this->log( 'error', 'Pipeline ID not found in handler settings' );
+				return array();
 			}
 
-			$pipeline_id = $flow_step_config['pipeline_id'];
-			$flow_id     = $flow_step_config['flow_id'];
-
-			$result = $handler->get_fetch_data( $pipeline_id, $handler_settings, $job_id );
-
-			if ( empty( $result ) ) {
-				return null;
-			}
-
-			try {
-				if ( ! is_array( $result ) ) {
-					throw new \InvalidArgumentException( 'Handler output must be an array or null' );
-				}
-
-				$title     = $result['title'] ?? '';
-				$content   = $result['content'] ?? '';
-				$file_info = $result['file_info'] ?? null;
-				$metadata  = $result['metadata'] ?? array();
-
-				$this->log(
-					'debug',
-					'Content extraction',
-					array(
-						'handler'       => $handler_name,
-						'has_title'     => ! empty( $title ),
-						'has_content'   => ! empty( $content ),
-						'has_file_info' => ! empty( $file_info ),
-						'metadata_keys' => array_keys( $metadata ),
-					)
-				);
-
-				if ( empty( $title ) && empty( $content ) && empty( $file_info ) ) {
-					$this->log(
-						'error',
-						'Handler returned no content after extraction',
-						array(
-							'handler' => $handler_name,
-						)
-					);
-					return null;
-				}
-
-				$content_array = array(
-					'title' => $title,
-					'body'  => $content,
-				);
-
-				if ( $file_info ) {
-					$content_array['file_info'] = $file_info;
-				}
-
-				$packet_metadata = array_merge(
-					array(
-						'source_type' => $handler_name,
-						'pipeline_id' => $pipeline_id,
-						'flow_id'     => $flow_id,
-						'handler'     => $handler_name,
-					),
-					$metadata
-				);
-
-				return new DataPacket( $content_array, $packet_metadata, 'fetch' );
-			} catch ( \Exception $e ) {
-				$this->log(
-					'error',
-					'Failed to create data packet from handler output',
-					array(
-						'handler'     => $handler_name,
-						'result_type' => gettype( $result ),
-						'error'       => $e->getMessage(),
-					)
-				);
-				return null;
-			}
+			return $handler->get_fetch_data( $pipeline_id, $handler_settings, $job_id );
 		} catch ( \Exception $e ) {
 			$this->log(
 				'error',
@@ -182,7 +134,7 @@ class FetchStep extends Step {
 					'exception' => $e->getMessage(),
 				)
 			);
-			return null;
+			return array();
 		}
 	}
 

--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -18,6 +18,7 @@
 namespace DataMachine\Core\Steps\Fetch\Handlers;
 
 use DataMachine\Abilities\AuthAbilities;
+use DataMachine\Core\DataPacket;
 use DataMachine\Core\ExecutionContext;
 use DataMachine\Core\FilesRepository\FileStorage;
 use DataMachine\Core\HttpClient;
@@ -39,20 +40,96 @@ abstract class FetchHandler {
 	}
 
 	/**
-	 * Template method - final entry point for all fetch handlers
+	 * Template method — final entry point for all fetch handlers.
 	 *
-	 * Creates ExecutionContext and delegates to child class implementation.
+	 * Creates ExecutionContext, delegates to child class, and wraps raw
+	 * handler output into DataPacket objects. Handlers never need to know
+	 * about DataPacket — they return plain arrays.
 	 *
-	 * @param int|string  $pipeline_id     Pipeline ID or 'direct' for direct execution
-	 * @param array       $handler_config  Handler configuration array
-	 * @param string|null $job_id          Optional job ID
-	 * @return array Processed items array
+	 * Accepts any handler output shape and normalizes it into items:
+	 *
+	 * - `{ items: [ {title, content, metadata}, ... ] }` — explicit item list.
+	 * - `{ title, content, metadata, file_info }` — single item (treated as list of one).
+	 * - `[]` or non-array — empty result.
+	 *
+	 * @param int|string  $pipeline_id    Pipeline ID or 'direct' for direct execution.
+	 * @param array       $handler_config Handler configuration array.
+	 * @param string|null $job_id         Optional job ID.
+	 * @return DataPacket[] Array of DataPackets (empty on failure/no data).
 	 */
 	final public function get_fetch_data( int|string $pipeline_id, array $handler_config, ?string $job_id = null ): array {
 		$config  = $this->extractConfig( $handler_config );
 		$context = ExecutionContext::fromConfig( $handler_config, $job_id, $this->handler_type );
 
-		return $this->executeFetch( $config, $context );
+		$result = $this->executeFetch( $config, $context );
+
+		if ( empty( $result ) || ! is_array( $result ) ) {
+			return array();
+		}
+
+		$flow_id = $handler_config['flow_id'] ?? null;
+
+		// Normalize: if handler returned { items: [...] }, use that list.
+		// Otherwise treat the entire result as a single item.
+		$items = ( isset( $result['items'] ) && is_array( $result['items'] ) )
+			? $result['items']
+			: array( $result );
+
+		return $this->toDataPackets( $items, $pipeline_id, $flow_id );
+	}
+
+	/**
+	 * Convert raw item arrays into DataPackets.
+	 *
+	 * One method handles any number of items — zero, one, or many.
+	 * Each item is expected to have title, content, metadata, and/or file_info.
+	 * Items with no content are silently dropped.
+	 *
+	 * @param array      $items       Array of raw item arrays.
+	 * @param int|string $pipeline_id Pipeline ID.
+	 * @param mixed      $flow_id     Flow ID.
+	 * @return DataPacket[] Array of DataPackets.
+	 */
+	private function toDataPackets( array $items, int|string $pipeline_id, mixed $flow_id ): array {
+		$packets = array();
+
+		foreach ( $items as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			$title     = $item['title'] ?? '';
+			$content   = $item['content'] ?? '';
+			$file_info = $item['file_info'] ?? null;
+			$metadata  = $item['metadata'] ?? array();
+
+			if ( empty( $title ) && empty( $content ) && empty( $file_info ) ) {
+				continue;
+			}
+
+			$content_array = array(
+				'title' => $title,
+				'body'  => $content,
+			);
+
+			if ( $file_info ) {
+				$content_array['file_info'] = $file_info;
+			}
+
+			$packet_metadata = array_merge(
+				array(
+					'source_type' => $this->handler_type,
+					'pipeline_id' => $pipeline_id,
+					'flow_id'     => $flow_id,
+					'handler'     => $this->handler_type,
+				),
+				$metadata
+			);
+
+			$packets[] = new DataPacket( $content_array, $packet_metadata, 'fetch' );
+		}
+
+		return $packets;
 	}
 
 	/**

--- a/tests/Unit/Core/Steps/Fetch/FetchHandlerDataPacketTest.php
+++ b/tests/Unit/Core/Steps/Fetch/FetchHandlerDataPacketTest.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Tests for FetchHandler DataPacket wrapping via toDataPackets().
+ *
+ * Verifies that FetchHandler::get_fetch_data() correctly normalizes handler
+ * output and wraps it into DataPacket[] through a single toDataPackets() method.
+ *
+ * @package DataMachine\Tests\Unit\Core\Steps\Fetch
+ */
+
+namespace DataMachine\Tests\Unit\Core\Steps\Fetch;
+
+use PHPUnit\Framework\TestCase;
+use DataMachine\Core\DataPacket;
+use DataMachine\Core\Steps\Fetch\Handlers\FetchHandler;
+use ReflectionMethod;
+
+/**
+ * Concrete test double for FetchHandler.
+ *
+ * Allows tests to control what executeFetch() returns without needing
+ * real HTTP, ExecutionContext, or WordPress functions.
+ */
+class StubFetchHandler extends FetchHandler {
+
+	/** @var array The return value for executeFetch(). */
+	private array $stub_result;
+
+	public function __construct( string $handler_type, array $stub_result ) {
+		$this->handler_type = $handler_type;
+		$this->stub_result  = $stub_result;
+		// Skip parent __construct to avoid side effects.
+	}
+
+	protected function executeFetch( array $config, \DataMachine\Core\ExecutionContext $context ): array {
+		return $this->stub_result;
+	}
+}
+
+class FetchHandlerDataPacketTest extends TestCase {
+
+	// ---------------------------------------------------------------
+	// toDataPackets — the single wrapping method
+	// ---------------------------------------------------------------
+
+	public function test_single_item_creates_one_packet(): void {
+		$handler = $this->createStubHandler( 'rss', array() );
+		$method  = $this->getToDataPackets();
+
+		$items  = array(
+			array( 'title' => 'Article', 'content' => 'Body text', 'metadata' => array( 'original_id' => '42' ) ),
+		);
+		$result = $method->invoke( $handler, $items, 10, 5 );
+
+		$this->assertCount( 1, $result );
+		$this->assertInstanceOf( DataPacket::class, $result[0] );
+
+		$packets = $result[0]->addTo( array() );
+		$this->assertSame( 'fetch', $packets[0]['type'] );
+		$this->assertSame( 'Article', $packets[0]['data']['title'] );
+		$this->assertSame( 'Body text', $packets[0]['data']['body'] );
+		$this->assertSame( 'rss', $packets[0]['metadata']['handler'] );
+		$this->assertSame( 10, $packets[0]['metadata']['pipeline_id'] );
+		$this->assertSame( 5, $packets[0]['metadata']['flow_id'] );
+		$this->assertSame( '42', $packets[0]['metadata']['original_id'] );
+	}
+
+	public function test_multiple_items_creates_multiple_packets(): void {
+		$handler = $this->createStubHandler( 'ticketmaster', array() );
+		$method  = $this->getToDataPackets();
+
+		$items = array(
+			array( 'title' => 'Event 1', 'content' => 'Band A', 'metadata' => array() ),
+			array( 'title' => 'Event 2', 'content' => 'Band B', 'metadata' => array() ),
+			array( 'title' => 'Event 3', 'content' => 'Band C', 'metadata' => array() ),
+		);
+
+		$result = $method->invoke( $handler, $items, 10, 5 );
+
+		$this->assertCount( 3, $result );
+		$this->assertContainsOnlyInstancesOf( DataPacket::class, $result );
+
+		// Verify each has correct title.
+		$titles = array_map( function ( $packet ) {
+			$arr = $packet->addTo( array() );
+			return $arr[0]['data']['title'];
+		}, $result );
+		$this->assertSame( array( 'Event 1', 'Event 2', 'Event 3' ), $titles );
+	}
+
+	public function test_empty_items_are_filtered_out(): void {
+		$handler = $this->createStubHandler( 'rss', array() );
+		$method  = $this->getToDataPackets();
+
+		$items = array(
+			array( 'title' => 'Good', 'content' => 'Content' ),
+			array( 'title' => '', 'content' => '' ),                // empty → dropped
+			array( 'title' => 'Also Good', 'content' => 'More' ),
+		);
+
+		$result = $method->invoke( $handler, $items, 1, 1 );
+		$this->assertCount( 2, $result );
+	}
+
+	public function test_all_empty_items_returns_empty(): void {
+		$handler = $this->createStubHandler( 'rss', array() );
+		$method  = $this->getToDataPackets();
+
+		$items = array(
+			array( 'title' => '', 'content' => '' ),
+			array( 'title' => '', 'content' => '' ),
+		);
+
+		$result = $method->invoke( $handler, $items, 1, 1 );
+		$this->assertEmpty( $result );
+	}
+
+	public function test_non_array_items_are_skipped(): void {
+		$handler = $this->createStubHandler( 'rss', array() );
+		$method  = $this->getToDataPackets();
+
+		$items = array(
+			array( 'title' => 'Valid', 'content' => 'Content' ),
+			'not an array',
+			null,
+			42,
+			array( 'title' => 'Also Valid', 'content' => 'More' ),
+		);
+
+		$result = $method->invoke( $handler, $items, 1, 1 );
+		$this->assertCount( 2, $result );
+	}
+
+	public function test_file_info_included_in_packet(): void {
+		$handler = $this->createStubHandler( 'files', array() );
+		$method  = $this->getToDataPackets();
+
+		$items = array(
+			array(
+				'title'     => '',
+				'content'   => '',
+				'file_info' => array( 'file_path' => '/tmp/image.jpg', 'mime_type' => 'image/jpeg' ),
+			),
+		);
+
+		$result = $method->invoke( $handler, $items, 1, 1 );
+		$this->assertCount( 1, $result );
+
+		$packets = $result[0]->addTo( array() );
+		$this->assertArrayHasKey( 'file_info', $packets[0]['data'] );
+		$this->assertSame( '/tmp/image.jpg', $packets[0]['data']['file_info']['file_path'] );
+	}
+
+	public function test_handler_metadata_merges_with_defaults(): void {
+		$handler = $this->createStubHandler( 'github', array() );
+		$method  = $this->getToDataPackets();
+
+		$items = array(
+			array(
+				'title'    => 'Issue #1',
+				'content'  => 'Bug report',
+				'metadata' => array(
+					'source_type'   => 'github_custom',
+					'github_number' => 1,
+				),
+			),
+		);
+
+		$result  = $method->invoke( $handler, $items, 5, 3 );
+		$packets = $result[0]->addTo( array() );
+
+		// Handler metadata overwrites defaults via array_merge.
+		$this->assertSame( 'github_custom', $packets[0]['metadata']['source_type'] );
+		$this->assertSame( 1, $packets[0]['metadata']['github_number'] );
+		// Defaults still present.
+		$this->assertSame( 5, $packets[0]['metadata']['pipeline_id'] );
+		$this->assertSame( 3, $packets[0]['metadata']['flow_id'] );
+		$this->assertSame( 'github', $packets[0]['metadata']['handler'] );
+	}
+
+	public function test_zero_items_returns_empty(): void {
+		$handler = $this->createStubHandler( 'rss', array() );
+		$method  = $this->getToDataPackets();
+
+		$result = $method->invoke( $handler, array(), 1, 1 );
+		$this->assertEmpty( $result );
+	}
+
+	// ---------------------------------------------------------------
+	// Contract / structural tests
+	// ---------------------------------------------------------------
+
+	public function test_get_fetch_data_is_final(): void {
+		$method = new ReflectionMethod( FetchHandler::class, 'get_fetch_data' );
+		$this->assertTrue( $method->isFinal() );
+		$this->assertTrue( $method->isPublic() );
+	}
+
+	public function test_get_fetch_data_return_type_is_array(): void {
+		$method      = new ReflectionMethod( FetchHandler::class, 'get_fetch_data' );
+		$return_type = $method->getReturnType();
+		$this->assertNotNull( $return_type );
+		$this->assertSame( 'array', $return_type->getName() );
+	}
+
+	public function test_to_data_packets_is_private(): void {
+		$method = new ReflectionMethod( FetchHandler::class, 'toDataPackets' );
+		$this->assertTrue( $method->isPrivate() );
+	}
+
+	public function test_no_wrap_single_item_method_exists(): void {
+		$this->assertFalse(
+			method_exists( FetchHandler::class, 'wrapSingleItem' ),
+			'wrapSingleItem should not exist — toDataPackets handles all cardinalities'
+		);
+	}
+
+	public function test_no_wrap_items_method_exists(): void {
+		$this->assertFalse(
+			method_exists( FetchHandler::class, 'wrapItems' ),
+			'wrapItems should not exist — toDataPackets handles all cardinalities'
+		);
+	}
+
+	// ---------------------------------------------------------------
+	// FetchStep contract tests
+	// ---------------------------------------------------------------
+
+	public function test_fetchstep_exists_and_extends_step(): void {
+		$this->assertTrue( class_exists( \DataMachine\Core\Steps\Fetch\FetchStep::class ) );
+		$reflection = new \ReflectionClass( \DataMachine\Core\Steps\Fetch\FetchStep::class );
+		$this->assertTrue( $reflection->isSubclassOf( \DataMachine\Core\Steps\Step::class ) );
+	}
+
+	public function test_fetchstep_execute_handler_returns_array(): void {
+		$method = new ReflectionMethod( \DataMachine\Core\Steps\Fetch\FetchStep::class, 'execute_handler' );
+		$this->assertTrue( $method->isPrivate() );
+
+		$return_type = $method->getReturnType();
+		$this->assertNotNull( $return_type );
+		$this->assertSame( 'array', $return_type->getName() );
+	}
+
+	// ---------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------
+
+	private function createStubHandler( string $handler_type, array $stub_result ): StubFetchHandler {
+		return new StubFetchHandler( $handler_type, $stub_result );
+	}
+
+	private function getToDataPackets(): ReflectionMethod {
+		$method = new ReflectionMethod( FetchHandler::class, 'toDataPackets' );
+		$method->setAccessible( true );
+		return $method;
+	}
+}

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Bootstrap for unit tests that don't require WordPress.
+ *
+ * Defines ABSPATH to prevent the early-exit guards in plugin files,
+ * then loads the Composer autoloader.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', '/tmp/' );
+}
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
## Summary

Replaces PR #505 (closed). Moves DataPacket creation from FetchStep into `FetchHandler::get_fetch_data()` — the single `final` entry point all fetch handlers pass through. One method handles any number of items.

## What changed

### `FetchHandler.php` (the important part)
- **`get_fetch_data()` now returns `DataPacket[]`** instead of a raw array
- Normalizes handler output: `{ items: [...] }` → use items list; `{ title, content }` → wrap as list of one
- **Single `toDataPackets()` method** — iterates items, creates DataPackets, drops empties. No separate `wrapSingleItem` / `wrapItems`. One path for 0, 1, or N items.

### `FetchStep.php` (simplified)
- `execute_handler()` no longer wraps anything — just calls `get_fetch_data()` and receives `DataPacket[]`
- `executeStep()` iterates the packets and adds them to the payload
- All the old wrapping logic (~60 lines including nested try/catch) is gone

### Tests
- `tests/bootstrap-unit.php` — minimal bootstrap for pure unit tests (defines ABSPATH, loads autoloader)
- `FetchHandlerDataPacketTest.php` — **15 tests, 36 assertions** covering:
  - Single item → 1 packet
  - Multiple items → N packets
  - Empty items filtered out
  - Non-array items skipped
  - file_info included when present
  - Handler metadata merges with defaults
  - Zero items → empty result
  - Contract tests (final, private, return types)
  - Verifies old `wrapSingleItem`/`wrapItems` methods don't exist

## Design

```
Handler.executeFetch()     →  raw array (unchanged)
        ↓
FetchHandler.get_fetch_data()  →  normalizes to items[] → toDataPackets() → DataPacket[]
        ↓
FetchStep.execute_handler()    →  receives DataPacket[], no wrapping
        ↓
PipelineBatchScheduler         →  fans out child jobs (PR #504)
```

Handlers never import DataPacket. They return plain arrays. The `final` template method in the base class is the single wrapping boundary.

## Backwards compatible

Fully. Handlers that return `{ title, content, metadata }` (all current handlers) work identically — normalized into a 1-element items list. Handlers that opt into batch return `{ items: [...] }` and get N packets.

## Depends on

- #504 (PipelineBatchScheduler — fans out multiple DataPackets into child jobs)