### PR TITLE
feat: handler multi-return — all fetch abilities and handlers return all eligible items

### DIFF
--- a/inc/Abilities/Fetch/FetchFilesAbility.php
+++ b/inc/Abilities/Fetch/FetchFilesAbility.php
@@ -137,15 +137,68 @@ class FetchFilesAbility {
 			$uploaded_files = $repo_files;
 		}
 
-		// Find next unprocessed file
-		$next_file = $this->findNextUnprocessedFile( $uploaded_files, $processed_items );
+		// Collect all unprocessed files
+		$eligible_items = array();
 
-		if ( ! $next_file ) {
+		foreach ( $uploaded_files as $file ) {
+			$file_identifier = $file['persistent_path'] ?? '';
+
+			if ( empty( $file_identifier ) ) {
+				continue;
+			}
+
+			if ( in_array( $file_identifier, $processed_items, true ) ) {
+				continue;
+			}
+
+			// Verify file exists
+			if ( ! file_exists( $file['persistent_path'] ) ) {
+				$logs[] = array(
+					'level'   => 'warning',
+					'message' => 'Files: File not found, skipping.',
+					'data'    => array( 'file_path' => $file['persistent_path'] ),
+				);
+				continue;
+			}
+
+			$mime_type = $file['mime_type'] ?? 'application/octet-stream';
+			$is_image  = strpos( $mime_type, 'image/' ) === 0;
+
+			$file_info = array(
+				'file_path' => $file['persistent_path'],
+				'file_name' => $file['original_name'],
+				'mime_type' => $mime_type,
+				'file_size' => $file['size'] ?? 0,
+			);
+
+			$metadata = array(
+				'source_type'            => 'files',
+				'item_identifier_to_log' => $file_identifier,
+				'original_id'            => $file_identifier,
+				'original_title'         => $file['original_name'],
+				'original_date_gmt'      => $file['uploaded_at'] ?? gmdate( 'Y-m-d H:i:s' ),
+				'source_url'             => '',
+			);
+
+			if ( $is_image ) {
+				$metadata['image_file_path'] = $file['persistent_path'];
+			}
+
+			$eligible_items[] = array(
+				'title'     => $file['original_name'],
+				'content'   => 'File: ' . $file['original_name'] . "\nType: " . $mime_type . "\nSize: " . ( $file['size'] ?? 0 ) . ' bytes',
+				'metadata'  => $metadata,
+				'file_info' => $file_info,
+			);
+		}
+
+		if ( empty( $eligible_items ) ) {
 			$logs[] = array(
 				'level'   => 'debug',
 				'message' => 'Files: No unprocessed files available.',
 				'data'    => array( 'total_files' => count( $uploaded_files ) ),
 			);
+
 			return array(
 				'success' => true,
 				'data'    => array(),
@@ -153,73 +206,16 @@ class FetchFilesAbility {
 			);
 		}
 
-		// Verify file exists
-		if ( ! file_exists( $next_file['persistent_path'] ) ) {
-			$logs[] = array(
-				'level'   => 'error',
-				'message' => 'Files: File not found.',
-				'data'    => array( 'file_path' => $next_file['persistent_path'] ),
-			);
-			return array(
-				'success' => false,
-				'error'   => 'File not found: ' . $next_file['persistent_path'],
-				'logs'    => $logs,
-			);
-		}
-
-		$file_identifier = $next_file['persistent_path'];
-		$mime_type       = $next_file['mime_type'] ?? 'application/octet-stream';
-		$is_image        = strpos( $mime_type, 'image/' ) === 0;
-
-		$content_data = array(
-			'title'   => $next_file['original_name'],
-			'content' => 'File: ' . $next_file['original_name'] . "\nType: " . $mime_type . "\nSize: " . ( $next_file['size'] ?? 0 ) . ' bytes',
-		);
-
-		$file_info = array(
-			'file_path' => $next_file['persistent_path'],
-			'file_name' => $next_file['original_name'],
-			'mime_type' => $mime_type,
-			'file_size' => $next_file['size'] ?? 0,
-		);
-
-		$metadata = array(
-			'source_type'            => 'files',
-			'item_identifier_to_log' => $file_identifier,
-			'original_id'            => $file_identifier,
-			'original_title'         => $next_file['original_name'],
-			'original_date_gmt'      => $next_file['uploaded_at'] ?? gmdate( 'Y-m-d H:i:s' ),
-		);
-
-		$raw_data = array(
-			'title'     => $content_data['title'],
-			'content'   => $content_data['content'],
-			'metadata'  => $metadata,
-			'file_info' => $file_info,
-		);
-
-		// Add image file path to engine data for images
-		$engine_data = array( 'source_url' => '' );
-		if ( $is_image ) {
-			$engine_data['image_file_path'] = $next_file['persistent_path'];
-		}
-		$raw_data['engine_data'] = $engine_data;
-
 		$logs[] = array(
-			'level'   => 'debug',
-			'message' => 'Files: Found unprocessed file for processing.',
-			'data'    => array(
-				'file_path' => $file_identifier,
-				'is_image'  => $is_image,
-			),
+			'level'   => 'info',
+			'message' => sprintf( 'Files: Found %d unprocessed files.', count( $eligible_items ) ),
+			'data'    => array( 'eligible' => count( $eligible_items ) ),
 		);
 
 		return array(
-			'success'         => true,
-			'data'            => $raw_data,
-			'item_identifier' => $file_identifier,
-			'is_image'        => $is_image,
-			'logs'            => $logs,
+			'success' => true,
+			'data'    => array( 'items' => $eligible_items ),
+			'logs'    => $logs,
 		);
 	}
 
@@ -278,32 +274,5 @@ class FetchFilesAbility {
 		return $files;
 	}
 
-	/**
-	 * Find the next unprocessed file.
-	 *
-	 * @param array $uploaded_files List of files.
-	 * @param array $processed_items List of already processed identifiers.
-	 * @return array|null The next unprocessed file or null if none found.
-	 */
-	private function findNextUnprocessedFile( array $uploaded_files, array $processed_items ): ?array {
-		if ( empty( $uploaded_files ) ) {
-			return null;
-		}
 
-		foreach ( $uploaded_files as $file ) {
-			$file_identifier = $file['persistent_path'] ?? '';
-
-			if ( empty( $file_identifier ) ) {
-				continue;
-			}
-
-			if ( in_array( $file_identifier, $processed_items, true ) ) {
-				continue;
-			}
-
-			return $file;
-		}
-
-		return null;
-	}
 }

--- a/inc/Abilities/Fetch/FetchRssAbility.php
+++ b/inc/Abilities/Fetch/FetchRssAbility.php
@@ -204,7 +204,8 @@ class FetchRssAbility {
 			);
 		}
 
-		$total_checked = 0;
+		$total_checked   = 0;
+		$eligible_items  = array();
 
 		foreach ( $items as $item ) {
 			++$total_checked;
@@ -252,11 +253,6 @@ class FetchRssAbility {
 			$categories    = $this->extractItemCategories( $item );
 			$enclosure_url = $this->extractItemEnclosure( $item );
 
-			$content_data = array(
-				'title'   => $title,
-				'content' => $description,
-			);
-
 			$metadata = array(
 				'source_type'            => 'rss',
 				'item_identifier_to_log' => $guid,
@@ -265,6 +261,8 @@ class FetchRssAbility {
 				'original_date_gmt'      => $pub_date ? gmdate( 'Y-m-d\TH:i:s\Z', strtotime( $pub_date ) ) : null,
 				'author'                 => $author,
 				'categories'             => $categories,
+				'guid'                   => $guid,
+				'source_url'             => $link ? $link : '',
 			);
 
 			$file_info = null;
@@ -287,8 +285,8 @@ class FetchRssAbility {
 			}
 
 			$raw_data = array(
-				'title'    => $content_data['title'],
-				'content'  => $content_data['content'],
+				'title'    => $title,
+				'content'  => $description,
 				'metadata' => $metadata,
 			);
 
@@ -306,24 +304,35 @@ class FetchRssAbility {
 				),
 			);
 
+			$eligible_items[] = $raw_data;
+		}
+
+		if ( empty( $eligible_items ) ) {
+			$logs[] = array(
+				'level'   => 'debug',
+				'message' => 'Rss: No eligible items found in RSS feed.',
+				'data'    => array( 'total_checked' => $total_checked ),
+			);
+
 			return array(
-				'success'    => true,
-				'data'       => $raw_data,
-				'guid'       => $guid,
-				'source_url' => $link ? $link : '',
-				'logs'       => $logs,
+				'success' => true,
+				'data'    => array(),
+				'logs'    => $logs,
 			);
 		}
 
 		$logs[] = array(
-			'level'   => 'debug',
-			'message' => 'Rss: No eligible items found in RSS feed.',
-			'data'    => array( 'total_checked' => $total_checked ),
+			'level'   => 'info',
+			'message' => sprintf( 'Rss: Found %d eligible items.', count( $eligible_items ) ),
+			'data'    => array(
+				'total_checked' => $total_checked,
+				'eligible'      => count( $eligible_items ),
+			),
 		);
 
 		return array(
 			'success' => true,
-			'data'    => array(),
+			'data'    => array( 'items' => $eligible_items ),
 			'logs'    => $logs,
 		);
 	}

--- a/inc/Abilities/Fetch/FetchWordPressApiAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressApiAbility.php
@@ -220,8 +220,9 @@ class FetchWordPressApiAbility {
 			);
 		}
 
-		$total_checked = 0;
-		$site_name     = $this->extractSiteNameFromUrl( $endpoint_url );
+		$total_checked  = 0;
+		$site_name      = $this->extractSiteNameFromUrl( $endpoint_url );
+		$eligible_items = array();
 
 		foreach ( $items as $item ) {
 			++$total_checked;
@@ -234,49 +235,31 @@ class FetchWordPressApiAbility {
 			$unique_id = md5( $endpoint_url . '_' . $item_id );
 
 			if ( in_array( $unique_id, $processed_items, true ) ) {
-				$logs[] = array(
-					'level'   => 'debug',
-					'message' => 'WordPressAPI: Skipping item (already processed).',
-					'data'    => array( 'item_id' => $unique_id ),
-				);
 				continue;
 			}
 
-			// Extract item data flexibly
+			// Extract item data flexibly.
 			$title       = $this->extractTitle( $item );
 			$content     = $this->extractContent( $item );
 			$excerpt     = $this->extractExcerpt( $item );
 			$source_link = $this->extractSourceLink( $item );
 			$item_date   = $this->extractDate( $item );
 
-			// Apply timeframe filtering
+			// Apply timeframe filtering.
 			if ( $item_date ) {
 				$item_timestamp = strtotime( $item_date );
 				if ( $item_timestamp && ! $this->applyTimeframeFilter( $item_timestamp, $timeframe_limit ) ) {
-					$logs[] = array(
-						'level'   => 'debug',
-						'message' => 'WordPressAPI: Skipping item outside timeframe.',
-						'data'    => array(
-							'item_id'   => $unique_id,
-							'item_date' => $item_date,
-						),
-					);
 					continue;
 				}
 			}
 
-			// Apply keyword search filter
+			// Apply keyword search filter.
 			$search_text = $title . ' ' . wp_strip_all_tags( $content . ' ' . $excerpt );
 			if ( ! $this->applyKeywordSearch( $search_text, $search ) ) {
-				$logs[] = array(
-					'level'   => 'debug',
-					'message' => 'WordPressAPI: Skipping item (search filter).',
-					'data'    => array( 'item_id' => $unique_id ),
-				);
 				continue;
 			}
 
-			// Extract image URL
+			// Extract image URL.
 			$image_url  = $this->extractImageUrl( $item );
 			$image_info = null;
 
@@ -292,7 +275,7 @@ class FetchWordPressApiAbility {
 				}
 			}
 
-			// Prepare raw data
+			// Prepare raw data.
 			$raw_data = array(
 				'title'    => $title,
 				'content'  => wp_strip_all_tags( $content ),
@@ -303,15 +286,16 @@ class FetchWordPressApiAbility {
 					'original_title'         => $title,
 					'original_date_gmt'      => $item_date,
 					'site_name'              => $site_name,
+					'source_url'             => $source_link,
 				),
 			);
 
-			// Add excerpt if present
+			// Add excerpt if present.
 			if ( ! empty( $excerpt ) ) {
 				$raw_data['content'] .= "\n\nExcerpt: " . wp_strip_all_tags( $excerpt );
 			}
 
-			// Add image info if present
+			// Add image info if present.
 			if ( $image_info ) {
 				$raw_data['file_info'] = array(
 					'url'       => $image_info['url'],
@@ -319,34 +303,35 @@ class FetchWordPressApiAbility {
 				);
 			}
 
+			$eligible_items[] = $raw_data;
+		}
+
+		if ( empty( $eligible_items ) ) {
 			$logs[] = array(
 				'level'   => 'debug',
-				'message' => 'WordPressAPI: Successfully fetched item.',
-				'data'    => array(
-					'item_id'   => $unique_id,
-					'title'     => $title,
-					'has_image' => ! empty( $image_info ),
-				),
+				'message' => 'WordPressAPI: No eligible items found.',
+				'data'    => array( 'total_checked' => $total_checked ),
 			);
 
 			return array(
-				'success'    => true,
-				'data'       => $raw_data,
-				'item_id'    => $unique_id,
-				'source_url' => $source_link,
-				'logs'       => $logs,
+				'success' => true,
+				'data'    => array(),
+				'logs'    => $logs,
 			);
 		}
 
 		$logs[] = array(
-			'level'   => 'debug',
-			'message' => 'WordPressAPI: No eligible items found.',
-			'data'    => array( 'total_checked' => $total_checked ),
+			'level'   => 'info',
+			'message' => sprintf( 'WordPressAPI: Found %d eligible items.', count( $eligible_items ) ),
+			'data'    => array(
+				'total_checked' => $total_checked,
+				'eligible'      => count( $eligible_items ),
+			),
 		);
 
 		return array(
 			'success' => true,
-			'data'    => array(),
+			'data'    => array( 'items' => $eligible_items ),
 			'logs'    => $logs,
 		);
 	}

--- a/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
@@ -190,6 +190,8 @@ class FetchWordPressMediaAbility {
 			'data'    => array( 'media_found' => count( $posts ) ),
 		);
 
+		$eligible_items = array();
+
 		foreach ( $posts as $post ) {
 			$post_id = (string) $post->ID;
 
@@ -217,7 +219,6 @@ class FetchWordPressMediaAbility {
 			$site_name   = ! empty( $site_name ) ? $site_name : 'Local WordPress';
 
 			$content_data = array();
-			$parent_post  = null;
 			if ( $include_parent_content && $post->post_parent > 0 ) {
 				$parent_post = get_post( $post->post_parent );
 				if ( $parent_post && $parent_post->post_status === 'publish' ) {
@@ -242,58 +243,53 @@ class FetchWordPressMediaAbility {
 				'file_size_formatted' => $file_size > 0 ? size_format( $file_size ) : null,
 			);
 
-			$metadata = array(
-				'source_type'            => 'wordpress_media',
-				'item_identifier_to_log' => $post->ID,
-				'original_id'            => $post->ID,
-				'parent_post_id'         => $post->post_parent,
-				'original_title'         => $title,
-				'original_date_gmt'      => $post->post_date_gmt,
-				'mime_type'              => $file_type,
-				'file_size'              => $file_size,
-				'site_name'              => $site_name,
-			);
-
-			$data = array(
-				'media_id'  => $post->ID,
-				'title'     => $content_data['title'] ?? '',
-				'content'   => $content_data['content'] ?? '',
-				'metadata'  => $metadata,
-				'file_info' => $file_info,
-			);
-
 			$source_url = '';
 			if ( $include_parent_content && $post->post_parent > 0 ) {
 				$source_url = get_permalink( $post->post_parent ) ?? '';
 			}
 
+			$eligible_items[] = array(
+				'title'    => $content_data['title'] ?? '',
+				'content'  => $content_data['content'] ?? '',
+				'metadata' => array(
+					'source_type'            => 'wordpress_media',
+					'item_identifier_to_log' => $post->ID,
+					'original_id'            => $post->ID,
+					'parent_post_id'         => $post->post_parent,
+					'original_title'         => $title,
+					'original_date_gmt'      => $post->post_date_gmt,
+					'mime_type'              => $file_type,
+					'file_size'              => $file_size,
+					'site_name'              => $site_name,
+					'source_url'             => $source_url,
+					'image_file_path'        => $file_path,
+				),
+				'file_info' => $file_info,
+			);
+		}
+
+		if ( empty( $eligible_items ) ) {
 			$logs[] = array(
 				'level'   => 'debug',
-				'message' => 'Retrieved unprocessed media item',
-				'data'    => array(
-					'media_id'           => $post->ID,
-					'title'              => $title,
-					'has_parent_content' => ! empty( $content_data ),
-				),
+				'message' => 'All media items already processed or filtered out',
 			);
 
 			return array(
-				'success'         => true,
-				'data'            => $data,
-				'source_url'      => $source_url,
-				'image_file_path' => $file_path,
-				'logs'            => $logs,
+				'success' => true,
+				'data'    => array(),
+				'logs'    => $logs,
 			);
 		}
 
 		$logs[] = array(
-			'level'   => 'debug',
-			'message' => 'All media items already processed or filtered out',
+			'level'   => 'info',
+			'message' => sprintf( 'Found %d unprocessed media items.', count( $eligible_items ) ),
+			'data'    => array( 'eligible' => count( $eligible_items ) ),
 		);
 
 		return array(
 			'success' => true,
-			'data'    => array(),
+			'data'    => array( 'items' => $eligible_items ),
 			'logs'    => $logs,
 		);
 	}

--- a/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
+++ b/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
@@ -210,17 +210,17 @@ class QueryWordPressPostsAbility {
 			),
 		);
 
-		// Process posts
+		// Collect all unprocessed posts.
 		$unprocessed_posts = array();
 		foreach ( $posts as $post ) {
 			$post_id = (string) $post->ID;
 
-			// Skip already processed items
+			// Skip already processed items.
 			if ( in_array( $post_id, $processed_items, true ) ) {
 				continue;
 			}
 
-			// Client-side search if needed
+			// Client-side search if needed.
 			if ( $use_client_side_search && ! empty( $search ) ) {
 				$search_text = $post->post_title . ' ' . wp_strip_all_tags( $post->post_content . ' ' . $post->post_excerpt );
 				if ( ! $this->applyKeywordSearch( $search_text, $search ) ) {
@@ -237,90 +237,73 @@ class QueryWordPressPostsAbility {
 				'message' => 'All posts already processed or filtered out',
 			);
 			return array(
-				'success'  => true,
-				'data'     => array(),
-				'has_more' => false,
-				'logs'     => $logs,
+				'success' => true,
+				'data'    => array(),
+				'logs'    => $logs,
 			);
 		}
 
-		// Return first unprocessed post
-		$post    = $unprocessed_posts[0];
-		$post_id = $post->ID;
+		$site_name      = get_bloginfo( 'name' ) ?: 'Local WordPress';
+		$eligible_items = array();
 
-		$title     = ! empty( $post->post_title ) ? $post->post_title : 'N/A';
-		$content   = $post->post_content;
-		$site_name = get_bloginfo( 'name' ) ?: 'Local WordPress';
+		foreach ( $unprocessed_posts as $post ) {
+			$post_id = $post->ID;
+			$title   = ! empty( $post->post_title ) ? $post->post_title : 'N/A';
+			$content = $post->post_content;
 
-		// Get featured image
-		$file_info         = null;
-		$featured_image_id = get_post_thumbnail_id( $post_id );
+			// Get featured image.
+			$file_info         = null;
+			$featured_image_id = get_post_thumbnail_id( $post_id );
 
-		if ( $featured_image_id && $include_file_info ) {
-			$file_path = get_attached_file( $featured_image_id );
-			if ( $file_path && file_exists( $file_path ) ) {
-				$file_size = filesize( $file_path );
-				$mime_type = get_post_mime_type( $featured_image_id ) ?: 'image/jpeg';
+			if ( $featured_image_id && $include_file_info ) {
+				$file_path = get_attached_file( $featured_image_id );
+				if ( $file_path && file_exists( $file_path ) ) {
+					$file_size = filesize( $file_path );
+					$mime_type = get_post_mime_type( $featured_image_id ) ?: 'image/jpeg';
 
-				$file_info = array(
-					'file_path' => $file_path,
-					'mime_type' => $mime_type,
-					'file_size' => $file_size,
-				);
-
-				$logs[] = array(
-					'level'   => 'debug',
-					'message' => 'Including featured image file_info for AI processing',
-					'data'    => array(
-						'post_id'           => $post_id,
-						'featured_image_id' => $featured_image_id,
-						'file_path'         => $file_path,
-						'file_size'         => $file_size,
-					),
-				);
+					$file_info = array(
+						'file_path' => $file_path,
+						'mime_type' => $mime_type,
+						'file_size' => $file_size,
+					);
+				}
 			}
+
+			$item_data = array(
+				'title'    => $title,
+				'content'  => $content,
+				'metadata' => array(
+					'source_type'            => 'wordpress_local',
+					'item_identifier_to_log' => $post_id,
+					'original_id'            => $post_id,
+					'original_title'         => $title,
+					'original_date_gmt'      => $post->post_date_gmt,
+					'post_type'              => $post->post_type,
+					'post_status'            => $post->post_status,
+					'site_name'              => $site_name,
+					'permalink'              => get_permalink( $post_id ) ?? '',
+					'excerpt'                => $post->post_excerpt,
+					'author'                 => get_the_author_meta( 'display_name', (int) $post->post_author ),
+				),
+			);
+
+			if ( $file_info ) {
+				$item_data['file_info'] = $file_info;
+			}
+
+			$eligible_items[] = $item_data;
 		}
-
-		// Prepare response data
-		$data = array(
-			'post_id'           => $post_id,
-			'title'             => $title,
-			'content'           => $content,
-			'excerpt'           => $post->post_excerpt,
-			'permalink'         => get_permalink( $post_id ) ?? '',
-			'post_type'         => $post->post_type,
-			'post_status'       => $post->post_status,
-			'publish_date'      => $post->post_date_gmt,
-			'author'            => get_the_author_meta( 'display_name', (int) $post->post_author ),
-			'site_name'         => $site_name,
-			'featured_image_id' => $featured_image_id,
-			'original_id'       => $post_id,
-			'original_title'    => $title,
-			'original_date_gmt' => $post->post_date_gmt,
-		);
-
-		if ( $file_info ) {
-			$data['file_info'] = $file_info;
-		}
-
-		$has_more = count( $unprocessed_posts ) > 1;
 
 		$logs[] = array(
-			'level'   => 'debug',
-			'message' => 'Retrieved unprocessed post',
-			'data'    => array(
-				'post_id'            => $post_id,
-				'title'              => $title,
-				'has_featured_image' => ! empty( $featured_image_id ),
-				'has_more'           => $has_more,
-			),
+			'level'   => 'info',
+			'message' => sprintf( 'Found %d unprocessed posts.', count( $eligible_items ) ),
+			'data'    => array( 'eligible' => count( $eligible_items ) ),
 		);
 
 		return array(
-			'success'  => true,
-			'data'     => $data,
-			'has_more' => $has_more,
-			'logs'     => $logs,
+			'success' => true,
+			'data'    => array( 'items' => $eligible_items ),
+			'logs'    => $logs,
 		);
 	}
 

--- a/inc/Core/Steps/Fetch/Handlers/Files/Files.php
+++ b/inc/Core/Steps/Fetch/Handlers/Files/Files.php
@@ -40,15 +40,14 @@ class Files extends FetchHandler {
 
 	/**
 	 * Process uploaded files with universal image handling.
-	 * For images: stores image_file_path via datamachine_engine_data filter.
-	 *
 	 * Delegates to FetchFilesAbility for core logic.
+	 * Returns all eligible items for batch fan-out.
 	 */
 	protected function executeFetch( array $config, ExecutionContext $context ): array {
 		$uploaded_files = $config['uploaded_files'] ?? array();
 
 		// Build processed items array from context
-		$processed_items = array();
+		$processed_items = $this->getProcessedItems( $context );
 
 		// Delegate to ability
 		$ability_input = array(
@@ -61,38 +60,58 @@ class Files extends FetchHandler {
 		$result  = $ability->execute( $ability_input );
 
 		// Log ability logs
-		if ( ! empty( $result['logs'] ) && is_array( $result['logs'] ) ) {
-			foreach ( $result['logs'] as $log_entry ) {
-				$context->log(
-					$log_entry['level'] ?? 'debug',
-					$log_entry['message'] ?? '',
-					$log_entry['data'] ?? array()
-				);
+		foreach ( $result['logs'] ?? array() as $log_entry ) {
+			$context->log(
+				$log_entry['level'] ?? 'debug',
+				$log_entry['message'] ?? '',
+				$log_entry['data'] ?? array()
+			);
+		}
+
+		if ( ! $result['success'] || empty( $result['data'] ) ) {
+			return array();
+		}
+
+		$data  = $result['data'];
+		$items = $data['items'] ?? array( $data );
+
+		$processed_items = array();
+
+		foreach ( $items as $item ) {
+			$item_id = $item['metadata']['item_identifier_to_log'] ?? '';
+
+			// Mark item as processed.
+			if ( ! empty( $item_id ) ) {
+				$context->markItemProcessed( $item_id );
 			}
+
+			$processed_items[] = $item;
 		}
 
-		if ( ! $result['success'] ) {
+		if ( empty( $processed_items ) ) {
 			return array();
 		}
 
-		// If no data returned, return empty
-		if ( empty( $result['data'] ) ) {
+		return array( 'items' => $processed_items );
+	}
+
+	/**
+	 * Get processed items for deduplication.
+	 *
+	 * @param ExecutionContext $context Execution context.
+	 * @return array Array of processed item IDs.
+	 */
+	private function getProcessedItems( ExecutionContext $context ): array {
+		if ( $context->isDirect() ) {
 			return array();
 		}
 
-		$data            = $result['data'];
-		$item_identifier = $result['item_identifier'] ?? ( $data['metadata']['original_id'] ?? '' );
-
-		// Mark item as processed
-		if ( $item_identifier ) {
-			$context->markItemProcessed( $item_identifier );
+		$flow_step_id = $context->getFlowStepId();
+		if ( empty( $flow_step_id ) ) {
+			return array();
 		}
 
-		// Store engine data if present
-		if ( ! empty( $data['engine_data'] ) ) {
-			$context->storeEngineData( $data['engine_data'] );
-		}
-
-		return $data;
+		$processed_items_table = new \DataMachine\Core\Database\ProcessedItems\ProcessedItems();
+		return $processed_items_table->get_processed_item_ids( $flow_step_id );
 	}
 }

--- a/inc/Core/Steps/Fetch/Handlers/GitHub/GitHub.php
+++ b/inc/Core/Steps/Fetch/Handlers/GitHub/GitHub.php
@@ -104,10 +104,11 @@ class GitHub extends FetchHandler {
 
 		$context->log( 'info', sprintf( 'GitHub: Found %d %s.', count( $items ), $data_source ) );
 
-		// Find first unprocessed item (deduplication).
+		// Find all unprocessed items (deduplication + filters).
 		$search           = $config['search'] ?? '';
 		$exclude_keywords = $config['exclude_keywords'] ?? '';
 		$timeframe_limit  = $config['timeframe_limit'] ?? 'all_time';
+		$eligible_items   = array();
 
 		foreach ( $items as $item ) {
 			$guid = sprintf( 'github_%s_%s_%d', $repo, $data_source, $item['number'] );
@@ -140,7 +141,7 @@ class GitHub extends FetchHandler {
 			// Mark as processed.
 			$context->markItemProcessed( $guid );
 
-			// Build the DataPacket-compatible return.
+			// Build the item.
 			$labels_str = ! empty( $item['labels'] ) ? implode( ', ', $item['labels'] ) : '';
 
 			if ( 'pulls' === $data_source ) {
@@ -151,14 +152,7 @@ class GitHub extends FetchHandler {
 				$content = $this->buildIssueContent( $item );
 			}
 
-			$context->storeEngineData( array(
-				'source_url'   => $item['html_url'] ?? '',
-				'github_repo'  => $repo,
-				'github_type'  => $data_source,
-				'issue_number' => $item['number'],
-			) );
-
-			return array(
+			$eligible_items[] = array(
 				'title'    => $title,
 				'content'  => $content,
 				'metadata' => array(
@@ -173,12 +167,18 @@ class GitHub extends FetchHandler {
 					'github_labels'     => $labels_str,
 					'github_user'       => $item['user'] ?? '',
 					'github_url'        => $item['html_url'] ?? '',
+					'source_url'        => $item['html_url'] ?? '',
 				),
 			);
 		}
 
-		$context->log( 'info', 'GitHub: All items already processed or filtered out.' );
-		return array();
+		if ( empty( $eligible_items ) ) {
+			$context->log( 'info', 'GitHub: All items already processed or filtered out.' );
+			return array();
+		}
+
+		$context->log( 'info', sprintf( 'GitHub: Found %d eligible items.', count( $eligible_items ) ) );
+		return array( 'items' => $eligible_items );
 	}
 
 	/**

--- a/inc/Core/Steps/Fetch/Handlers/Rss/Rss.php
+++ b/inc/Core/Steps/Fetch/Handlers/Rss/Rss.php
@@ -40,10 +40,11 @@ class Rss extends FetchHandler {
 	/**
 	 * Fetch RSS/Atom content with timeframe and keyword filtering.
 	 *
-	 * Delegates to FetchRssAbility for core logic.
+	 * Delegates to FetchRssAbility which returns all eligible items.
+	 * Each item is marked as processed and has images downloaded.
+	 * Returns { items: [...] } for batch fan-out.
 	 */
 	protected function executeFetch( array $config, ExecutionContext $context ): array {
-		// Delegate to ability
 		$ability_input = array(
 			'feed_url'        => $config['feed_url'] ?? '',
 			'timeframe_limit' => $config['timeframe_limit'] ?? 'all_time',
@@ -55,7 +56,7 @@ class Rss extends FetchHandler {
 		$ability = new FetchRssAbility();
 		$result  = $ability->execute( $ability_input );
 
-		// Log ability logs
+		// Log ability logs.
 		if ( ! empty( $result['logs'] ) && is_array( $result['logs'] ) ) {
 			foreach ( $result['logs'] as $log_entry ) {
 				$context->log(
@@ -66,63 +67,53 @@ class Rss extends FetchHandler {
 			}
 		}
 
-		if ( ! $result['success'] ) {
-			return array();
-		}
-
-		// If no data returned, return empty
-		if ( empty( $result['data'] ) ) {
+		if ( ! $result['success'] || empty( $result['data'] ) ) {
 			return array();
 		}
 
 		$data = $result['data'];
-		$guid = $result['guid'] ?? ( $data['metadata']['original_id'] ?? '' );
 
-		// Mark item as processed
-		if ( $guid ) {
-			$context->markItemProcessed( $guid );
-		}
+		// Ability returns { items: [...] } for multi-item.
+		$items = $data['items'] ?? array( $data );
 
-		// Download image if present
-		if ( ! empty( $data['file_info'] ) && ! empty( $data['file_info']['url'] ) ) {
-			$filename        = 'rss_image_' . time() . '_' . sanitize_file_name( basename( wp_parse_url( $data['file_info']['url'], PHP_URL_PATH ) ) );
-			$download_result = $context->downloadFile( $data['file_info']['url'], $filename );
+		$processed_items = array();
 
-			if ( $download_result ) {
-				$data['file_info']['file_path'] = $download_result['path'];
-				$data['file_info']['file_size'] = $download_result['size'];
-				unset( $data['file_info']['url'] );
+		foreach ( $items as &$item ) {
+			$guid = $item['metadata']['guid'] ?? ( $item['metadata']['original_id'] ?? '' );
 
-				$context->log(
-					'debug',
-					'Rss: Downloaded remote image for AI processing',
-					array(
-						'guid'       => $guid,
-						'source_url' => $data['file_info']['url'] ?? '',
-						'local_path' => $download_result['path'],
-						'file_size'  => $download_result['size'],
-					)
-				);
-			} else {
-				$context->log(
-					'warning',
-					'Rss: Failed to download remote image',
-					array(
-						'guid'          => $guid,
-						'enclosure_url' => $data['file_info']['url'] ?? '',
-					)
-				);
+			// Mark item as processed.
+			if ( $guid ) {
+				$context->markItemProcessed( $guid );
 			}
+
+			// Download image if present.
+			if ( ! empty( $item['file_info'] ) && ! empty( $item['file_info']['url'] ) ) {
+				$image_url       = $item['file_info']['url'];
+				$filename        = 'rss_image_' . time() . '_' . sanitize_file_name( basename( wp_parse_url( $image_url, PHP_URL_PATH ) ) );
+				$download_result = $context->downloadFile( $image_url, $filename );
+
+				if ( $download_result ) {
+					$item['file_info']['file_path'] = $download_result['path'];
+					$item['file_info']['file_size'] = $download_result['size'];
+					unset( $item['file_info']['url'] );
+				} else {
+					$context->log(
+						'warning',
+						'Rss: Failed to download remote image',
+						array( 'guid' => $guid, 'enclosure_url' => $image_url )
+					);
+				}
+			}
+
+			$processed_items[] = $item;
+		}
+		unset( $item );
+
+		if ( empty( $processed_items ) ) {
+			return array();
 		}
 
-		// Store engine data
-		$engine_data = array( 'source_url' => $result['source_url'] ?? '' );
-		if ( ! empty( $data['file_info'] ) && isset( $data['file_info']['file_path'] ) ) {
-			$engine_data['image_file_path'] = $data['file_info']['file_path'];
-		}
-		$context->storeEngineData( $engine_data );
-
-		return $data;
+		return array( 'items' => $processed_items );
 	}
 	/**
 	 * Get the display label for the RSS handler.

--- a/inc/Core/Steps/Fetch/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Fetch/Handlers/WordPress/WordPress.php
@@ -131,9 +131,11 @@ class WordPress extends FetchHandler {
 
 	/**
 	 * Fetch posts via query using QueryWordPressPostsAbility.
+	 *
+	 * Returns all eligible posts as { items: [...] }.
 	 */
 	private function fetch_posts_via_query( array $config, ExecutionContext $context ): array {
-		// Build taxonomy query
+		// Build taxonomy query.
 		$tax_query = array();
 		foreach ( $config as $field_key => $field_value ) {
 			if ( strpos( $field_key, 'taxonomy_' ) === 0 && strpos( $field_key, '_filter' ) !== false ) {
@@ -149,7 +151,6 @@ class WordPress extends FetchHandler {
 			}
 		}
 
-		// Build ability input
 		$ability_input = array(
 			'post_type'         => sanitize_text_field( $config['post_type'] ?? 'post' ),
 			'post_status'       => sanitize_text_field( $config['post_status'] ?? 'publish' ),
@@ -164,7 +165,7 @@ class WordPress extends FetchHandler {
 		$ability = new QueryWordPressPostsAbility();
 		$result  = $ability->execute( $ability_input );
 
-		// Log ability logs
+		// Log ability logs.
 		if ( ! empty( $result['logs'] ) && is_array( $result['logs'] ) ) {
 			foreach ( $result['logs'] as $log_entry ) {
 				$context->log(
@@ -179,48 +180,34 @@ class WordPress extends FetchHandler {
 			return array();
 		}
 
-		$data    = $result['data'];
-		$post_id = $data['post_id'];
+		$data  = $result['data'];
+		$items = $data['items'] ?? array( $data );
 
-		// Mark as processed
-		$context->markItemProcessed( (string) $post_id );
+		$processed_items = array();
 
-		// Build response for pipeline
-		$raw_data = array(
-			'title'    => $data['title'],
-			'content'  => $data['content'],
-			'metadata' => array(
-				'source_type'            => 'wordpress_local',
-				'item_identifier_to_log' => $post_id,
-				'original_id'            => $post_id,
-				'original_title'         => $data['original_title'],
-				'original_date_gmt'      => $data['original_date_gmt'],
-				'post_type'              => $data['post_type'],
-				'post_status'            => $data['post_status'],
-				'site_name'              => $data['site_name'],
-			),
-		);
+		foreach ( $items as &$item ) {
+			$post_id = $item['metadata']['original_id'] ?? '';
 
-		// Add excerpt if present
-		if ( ! empty( $data['excerpt'] ) ) {
-			$raw_data['content'] .= "\n\nExcerpt: " . $data['excerpt'];
+			// Mark as processed.
+			if ( $post_id ) {
+				$context->markItemProcessed( (string) $post_id );
+			}
+
+			// Append excerpt to content if present.
+			$excerpt = $item['metadata']['excerpt'] ?? '';
+			if ( ! empty( $excerpt ) ) {
+				$item['content'] .= "\n\nExcerpt: " . $excerpt;
+			}
+
+			$processed_items[] = $item;
+		}
+		unset( $item );
+
+		if ( empty( $processed_items ) ) {
+			return array();
 		}
 
-		// Add file_info if featured image is available
-		if ( ! empty( $data['file_info'] ) ) {
-			$raw_data['file_info'] = $data['file_info'];
-		}
-
-		// Store engine data
-		$image_file_path = $data['file_info']['file_path'] ?? '';
-		$context->storeEngineData(
-			array(
-				'source_url'      => $data['permalink'] ?? '',
-				'image_file_path' => $image_file_path,
-			)
-		);
-
-		return $raw_data;
+		return array( 'items' => $processed_items );
 	}
 
 	public static function get_label(): string {

--- a/inc/Core/Steps/Fetch/Handlers/WordPressAPI/WordPressAPI.php
+++ b/inc/Core/Steps/Fetch/Handlers/WordPressAPI/WordPressAPI.php
@@ -93,92 +93,57 @@ class WordPressAPI extends FetchHandler {
 			);
 		}
 
-		// Handle failure
-		if ( ! $result['success'] ) {
+		if ( ! $result['success'] || empty( $result['data'] ) ) {
 			return array();
 		}
 
-		// Handle empty result
-		if ( empty( $result['data'] ) ) {
+		$data  = $result['data'];
+		$items = $data['items'] ?? array( $data );
+
+		$processed_items = array();
+
+		foreach ( $items as &$item ) {
+			$item_id = $item['metadata']['item_identifier_to_log'] ?? '';
+
+			// Mark item as processed.
+			if ( ! empty( $item_id ) ) {
+				$context->markItemProcessed( $item_id );
+			}
+
+			// Download image if present in file_info.
+			if ( isset( $item['file_info'] ) && ! empty( $item['file_info']['url'] ) ) {
+				$image_url = $item['file_info']['url'];
+				$url_path  = wp_parse_url( $image_url, PHP_URL_PATH );
+				$extension = $url_path ? pathinfo( $url_path, PATHINFO_EXTENSION ) : 'jpg';
+				if ( empty( $extension ) ) {
+					$extension = 'jpg';
+				}
+				$filename = 'wp_api_image_' . time() . '_' . sanitize_file_name( basename( $url_path ? $url_path : 'image' ) ) . '.' . $extension;
+
+				$download_result = $context->downloadFile( $image_url, $filename );
+
+				if ( $download_result ) {
+					$file_check            = wp_check_filetype( $filename );
+					$mime_type             = $file_check['type'] ? $file_check['type'] : 'image/jpeg';
+					$item['file_info']     = array(
+						'file_path' => $download_result['path'],
+						'mime_type' => $mime_type,
+						'file_size' => $download_result['size'],
+					);
+				} else {
+					unset( $item['file_info'] );
+				}
+			}
+
+			$processed_items[] = $item;
+		}
+		unset( $item );
+
+		if ( empty( $processed_items ) ) {
 			return array();
 		}
 
-		$raw_data   = $result['data'];
-		$item_id    = $result['item_id'] ?? '';
-		$source_url = $result['source_url'] ?? '';
-
-		// Mark item as processed
-		if ( ! empty( $item_id ) ) {
-			$context->markItemProcessed( $item_id );
-		}
-
-		// Download image if present in file_info
-		$file_info       = null;
-		$download_result = null;
-		if ( isset( $raw_data['file_info'] ) && ! empty( $raw_data['file_info']['url'] ) ) {
-			$image_url = $raw_data['file_info']['url'];
-
-			// Generate filename from URL
-			$url_path  = wp_parse_url( $image_url, PHP_URL_PATH );
-			$extension = $url_path ? pathinfo( $url_path, PATHINFO_EXTENSION ) : 'jpg';
-			if ( empty( $extension ) ) {
-				$extension = 'jpg';
-			}
-			$filename = 'wp_api_image_' . time() . '_' . sanitize_file_name( basename( $url_path ? $url_path : 'image' ) ) . '.' . $extension;
-
-			$download_result = $context->downloadFile( $image_url, $filename );
-
-			if ( $download_result ) {
-				$file_check = wp_check_filetype( $filename );
-				$mime_type  = $file_check['type'] ? $file_check['type'] : 'image/jpeg';
-
-				$file_info = array(
-					'file_path' => $download_result['path'],
-					'mime_type' => $mime_type,
-					'file_size' => $download_result['size'],
-				);
-
-				$context->log(
-					'debug',
-					'WordPressAPI: Downloaded remote image for AI processing',
-					array(
-						'item_id'    => $item_id,
-						'source_url' => $image_url,
-						'local_path' => $download_result['path'],
-						'file_size'  => $download_result['size'],
-					)
-				);
-
-				// Update raw_data with downloaded file info
-				$raw_data['file_info'] = $file_info;
-			} else {
-				$context->log(
-					'warning',
-					'WordPressAPI: Failed to download remote image',
-					array(
-						'item_id'   => $item_id,
-						'image_url' => $image_url,
-					)
-				);
-				unset( $raw_data['file_info'] );
-			}
-		}
-
-		// Store URLs and file path in engine_data via centralized filter
-		$image_file_path = '';
-		if ( $download_result ) {
-			$image_file_path = $download_result['path'];
-		}
-
-		$context->storeEngineData(
-			array(
-				'source_url'      => $source_url,
-				'image_file_path' => $image_file_path,
-			)
-		);
-
-		// Return raw data for DataPacket creation
-		return $raw_data;
+		return array( 'items' => $processed_items );
 	}
 
 	/**

--- a/inc/Core/Steps/Fetch/Handlers/WordPressMedia/WordPressMedia.php
+++ b/inc/Core/Steps/Fetch/Handlers/WordPressMedia/WordPressMedia.php
@@ -43,12 +43,11 @@ class WordPressMedia extends FetchHandler {
 	/**
 	 * Fetch WordPress media attachments with parent content integration.
 	 * Delegates to FetchWordPressMediaAbility for core functionality.
+	 * Returns all eligible items for batch fan-out.
 	 */
 	protected function executeFetch( array $config, ExecutionContext $context ): array {
 		// Build processed items list from context
-		$processed_items = array();
-		// Get processed items from the context's processed items tracking
-		// The ability expects an array of already processed IDs
+		$processed_items = $this->getProcessedItems( $context );
 
 		// Build ability input
 		$ability_input = array(
@@ -64,49 +63,58 @@ class WordPressMedia extends FetchHandler {
 		$result  = $ability->execute( $ability_input );
 
 		// Log ability logs
-		if ( ! empty( $result['logs'] ) && is_array( $result['logs'] ) ) {
-			foreach ( $result['logs'] as $log_entry ) {
-				$context->log(
+		foreach ( $result['logs'] ?? array() as $log_entry ) {
+			$context->log(
 				$log_entry['level'] ?? 'debug',
 				$log_entry['message'] ?? '',
 				$log_entry['data'] ?? array()
-				);
-			}
+			);
 		}
 
 		if ( ! $result['success'] || empty( $result['data'] ) ) {
 			return array();
 		}
 
-		$data     = $result['data'];
-		$media_id = $data['media_id'] ?? null;
+		$data  = $result['data'];
+		$items = $data['items'] ?? array( $data );
 
-		if ( ! $media_id ) {
+		$processed_items = array();
+
+		foreach ( $items as $item ) {
+			$item_id = $item['metadata']['item_identifier_to_log'] ?? '';
+
+			// Mark item as processed.
+			if ( ! empty( $item_id ) ) {
+				$context->markItemProcessed( (string) $item_id );
+			}
+
+			$processed_items[] = $item;
+		}
+
+		if ( empty( $processed_items ) ) {
 			return array();
 		}
 
-		// Mark as processed
-		$context->markItemProcessed( (string) $media_id );
+		return array( 'items' => $processed_items );
+	}
 
-		// Prepare raw data for DataPacket creation
-		$raw_data = array(
-			'title'     => $data['title'] ?? '',
-			'content'   => $data['content'] ?? '',
-			'metadata'  => $data['metadata'] ?? array(),
-			'file_info' => $data['file_info'] ?? array(),
-		);
+	/**
+	 * Get processed items for deduplication.
+	 *
+	 * @param ExecutionContext $context Execution context.
+	 * @return array Array of processed item IDs.
+	 */
+	private function getProcessedItems( ExecutionContext $context ): array {
+		if ( $context->isDirect() ) {
+			return array();
+		}
 
-		// Store URLs in engine_data via centralized filter
-		$source_url      = $result['source_url'] ?? '';
-		$image_file_path = $result['image_file_path'] ?? '';
+		$flow_step_id = $context->getFlowStepId();
+		if ( empty( $flow_step_id ) ) {
+			return array();
+		}
 
-		$context->storeEngineData(
-		array(
-			'source_url'      => $source_url,
-			'image_file_path' => $image_file_path,
-		)
-		);
-
-		return $raw_data;
+		$processed_items_table = new \DataMachine\Core\Database\ProcessedItems\ProcessedItems();
+		return $processed_items_table->get_processed_item_ids( $flow_step_id );
 	}
 }


### PR DESCRIPTION
## Summary

Converts all fetch abilities and handlers from early-return-first-match to accumulator pattern, returning all eligible items for batch fan-out.

**This is PR 3 of the pipeline batch fan-out series:**
1. ✅ **PR #504** — PipelineBatchScheduler (fan-out engine)
2. ✅ **PR #506** — Unified DataPacket wrapping in FetchHandler (base branch for this PR)
3. **This PR** — Handler multi-return (all abilities + handlers)
4. ⏳ data-machine-events handlers (separate repo)
5. ⏳ data-machine-socials Reddit handler (separate repo)
6. ⏳ extrachill-events WeeklyRoundup handler (separate repo)

## What changed

### Abilities (5 files)
All dedup abilities now collect **all** unprocessed items instead of early-returning on first match. Each returns `{ data: { items: [...] } }` with `source_url` and `image_file_path` in per-item metadata.

- **FetchRssAbility** — accumulator loop, `guid` and `source_url` in metadata
- **FetchWordPressApiAbility** — accumulator loop, `source_url` in metadata
- **FetchWordPressMediaAbility** — accumulator loop, `source_url` and `image_file_path` in metadata
- **QueryWordPressPostsAbility** — accumulator loop, permalink/excerpt/author in metadata
- **FetchFilesAbility** — accumulator loop, removed `findNextUnprocessedFile()`. Missing files logged as warning and skipped (not fatal)

### Handlers (6 files)
All handlers now iterate items from their ability, call `markItemProcessed` per item, and return `{ items: [...] }`.

- **Rss** — iterates items, downloads images per item
- **WordPress** — `fetch_posts_via_query()` iterates items (`fetch_single_post()` unchanged — single-item by nature)
- **WordPressAPI** — iterates items, downloads images per item
- **WordPressMedia** — iterates items, added `getProcessedItems()` helper
- **Files** — iterates items, added `getProcessedItems()` helper
- **GitHub** — inline dedup loop converted to accumulator

### Unchanged (by design)
- **GetWordPressPostAbility** — single-item lookup by ID, no dedup
- **GitHubAbilities** — API wrapper class, already returns full result sets

## Testing
- All 23 existing unit tests pass (15 FetchHandler + 8 PipelineBatchScheduler)
- All 11 modified files pass `php -l` syntax check
- No new dependencies

## Follow-up
- Dedup consolidation into FetchHandler base class (separate issue — every ability reimplements the same skip-processed loop)
- Per-item engine data propagation in child jobs (DataPacket metadata replaces global storeEngineData)