### PR TITLE
feat: seed child job engine data from DataPacket metadata (#513)

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -229,8 +229,9 @@ class PipelineBatchScheduler {
 	/**
 	 * Create a single child job for one DataPacket.
 	 *
-	 * Clones the parent's engine_data, stores the single DataPacket to
-	 * the filesystem, and schedules the next step via the normal engine path.
+	 * Clones the parent's engine_data, seeds per-item engine data from
+	 * the DataPacket's _engine_data metadata key, and schedules the next
+	 * step via the normal engine path.
 	 *
 	 * @param int    $parent_job_id     Parent job ID.
 	 * @param string $next_flow_step_id Next step to execute.
@@ -280,6 +281,16 @@ class PipelineBatchScheduler {
 			'created_at'    => current_time( 'mysql', true ),
 			'parent_job_id' => $parent_job_id,
 		);
+
+		// Seed per-item engine data from DataPacket metadata.
+		// Handlers put per-item context (venue data, source_url, etc.)
+		// into metadata['_engine_data'] so each child job gets its own
+		// copy instead of sharing the parent's (which would be the last
+		// item's data overwriting all previous items).
+		$item_engine_data = $single_packet['metadata']['_engine_data'] ?? array();
+		if ( ! empty( $item_engine_data ) && is_array( $item_engine_data ) ) {
+			$child_engine = array_merge( $child_engine, $item_engine_data );
+		}
 
 		datamachine_set_engine_data( $child_job_id, $child_engine );
 		$this->db_jobs->start_job( $child_job_id );

--- a/tests/Unit/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Engine/PipelineBatchSchedulerTest.php
@@ -303,6 +303,81 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'failed', $parent_job['status'] );
 	}
 
+	public function test_child_jobs_receive_per_item_engine_data(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+
+		// Two packets with different _engine_data (per-item venue context).
+		$packet_a             = $this->make_data_packet( 'Show at Venue A' );
+		$packet_a['metadata']['_engine_data'] = array(
+			'venue'        => 'The Continental Club',
+			'venueCity'    => 'Austin',
+			'venueState'   => 'TX',
+			'venue_context' => array( 'name' => 'The Continental Club', 'city' => 'Austin' ),
+		);
+
+		$packet_b             = $this->make_data_packet( 'Show at Venue B' );
+		$packet_b['metadata']['_engine_data'] = array(
+			'venue'        => 'Hotel Vegas',
+			'venueCity'    => 'Austin',
+			'venueState'   => 'TX',
+			'venue_context' => array( 'name' => 'Hotel Vegas', 'city' => 'Austin' ),
+		);
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_abc_123', array( $packet_a, $packet_b ), $engine );
+		$scheduler->processChunk( $parent_id );
+
+		// Get child jobs.
+		global $wpdb;
+		$table    = $wpdb->prefix . 'datamachine_jobs';
+		$children = $wpdb->get_results(
+			$wpdb->prepare( "SELECT job_id, label FROM {$table} WHERE parent_job_id = %d ORDER BY job_id", $parent_id ),
+			ARRAY_A
+		);
+
+		$this->assertCount( 2, $children );
+
+		// Child A should have Venue A's engine data.
+		$child_a_engine = datamachine_get_engine_data( (int) $children[0]['job_id'] );
+		$this->assertEquals( 'The Continental Club', $child_a_engine['venue'] );
+		$this->assertEquals( 'Austin', $child_a_engine['venueCity'] );
+		$this->assertEquals( 'The Continental Club', $child_a_engine['venue_context']['name'] );
+
+		// Child B should have Venue B's engine data.
+		$child_b_engine = datamachine_get_engine_data( (int) $children[1]['job_id'] );
+		$this->assertEquals( 'Hotel Vegas', $child_b_engine['venue'] );
+		$this->assertEquals( 'Austin', $child_b_engine['venueCity'] );
+		$this->assertEquals( 'Hotel Vegas', $child_b_engine['venue_context']['name'] );
+	}
+
+	public function test_child_jobs_work_without_engine_data_key(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+
+		// Packet without _engine_data — should still work fine.
+		$packet = $this->make_data_packet( 'Basic Event' );
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_abc_123', array( $packet ), $engine );
+		$scheduler->processChunk( $parent_id );
+
+		global $wpdb;
+		$table    = $wpdb->prefix . 'datamachine_jobs';
+		$children = $wpdb->get_results(
+			$wpdb->prepare( "SELECT job_id FROM {$table} WHERE parent_job_id = %d", $parent_id ),
+			ARRAY_A
+		);
+
+		$this->assertCount( 1, $children );
+
+		// Child should have the parent snapshot's keys but no extra seeded data.
+		$child_engine = datamachine_get_engine_data( (int) $children[0]['job_id'] );
+		$this->assertArrayHasKey( 'job', $child_engine );
+		$this->assertArrayHasKey( 'flow', $child_engine );
+		$this->assertArrayNotHasKey( 'venue', $child_engine );
+	}
+
 	public function test_on_child_complete_ignores_non_batch_parents(): void {
 		// Create a parent job WITHOUT batch metadata.
 		$parent_id = $this->create_parent_job();


### PR DESCRIPTION
## Summary

- **PipelineBatchScheduler::createChildJob()** now merges `metadata['_engine_data']` from each DataPacket into the child job's engine data
- Two new integration tests verify per-item seeding works and absence of `_engine_data` doesn't break anything

## Why

In batch fan-out, handlers call `storeEventContext()` during fetch, writing to the parent job's engine data. Each item overwrites the previous, so all children end up with the **last item's** venue context. This is wrong — each child needs its own.

The `_engine_data` metadata key is the fix: handlers put per-item engine context there, and the scheduler seeds it into each child independently.

## How it works

```
Handler returns item:
  { title: "Phish at MSG", content: "...", metadata: {
      source_type: "ticketmaster",
      _engine_data: {           ← NEW: per-item engine context
        venue: "Madison Square Garden",
        venueCity: "New York",
        startDate: "2026-08-15",
        venue_context: { name: "Madison Square Garden", ... }
      }
  }}

PipelineBatchScheduler::createChildJob():
  $child_engine = $engine_snapshot;                     // clone parent
  $child_engine = array_merge($child_engine, _engine_data);  // seed per-item
  datamachine_set_engine_data($child_job_id, $child_engine); // write to child
```

## Next step

Event handlers need to be updated to populate `_engine_data` instead of calling `storeEventContext()` directly. That's a data-machine-events PR.

Closes #513