### PR TITLE
fix: use valid JobStatus for batch cancellation

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -156,7 +156,7 @@ class PipelineBatchScheduler {
 		$parent_engine = datamachine_get_engine_data( $parent_job_id );
 		if ( ! empty( $parent_engine['cancelled'] ) ) {
 			delete_transient( $transient_key );
-			$this->db_jobs->complete_job( $parent_job_id, 'cancelled' );
+			$this->db_jobs->complete_job( $parent_job_id, JobStatus::failed( 'batch cancelled' )->toString() );
 			return;
 		}
 

--- a/tests/Unit/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Engine/PipelineBatchSchedulerTest.php
@@ -16,6 +16,15 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 
 	private Jobs $jobs_db;
 
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+
+		// Ensure Data Machine tables exist (activation hook doesn't fire in tests).
+		if ( function_exists( 'datamachine_activate_for_site' ) ) {
+			datamachine_activate_for_site();
+		}
+	}
+
 	public function set_up(): void {
 		parent::set_up();
 		$this->jobs_db = new Jobs();
@@ -188,9 +197,10 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 
 		$this->assertEquals( 0, $count );
 
-		// Parent should be cancelled.
+		// Parent should be failed with cancellation reason.
 		$parent_job = $this->jobs_db->get_job( $parent_id );
-		$this->assertStringContainsString( 'cancelled', $parent_job['status'] );
+		$this->assertStringContainsString( 'failed', $parent_job['status'] );
+		$this->assertStringContainsString( 'batch cancelled', $parent_job['status'] );
 	}
 
 	public function test_child_labels_use_packet_titles(): void {


### PR DESCRIPTION
## Summary
- **Bug**: `PipelineBatchScheduler::processChunk()` was calling `complete_job()` with `'cancelled'` as the status, but `'cancelled'` is not in `JobStatus::FINAL_STATUSES`. The DB layer rejected the update silently, leaving the parent job stuck in `'processing'`.
- **Fix**: Uses `JobStatus::failed('batch cancelled')->toString()` which produces a valid compound status `'failed - batch cancelled'`.
- **Test fix**: Adds `set_up_before_class()` to `PipelineBatchSchedulerTest` to run `datamachine_activate_for_site()` — the activation hook doesn't fire in the test context, so plugin tables must be created explicitly.

## Testing
All 10 PipelineBatchSchedulerTest assertions pass (53 total assertions):
```
Pipeline Batch Scheduler (DataMachine\Tests\Unit\Engine\PipelineBatchScheduler)
 ✔ Fanout creates batch metadata on parent
 ✔ Fanout stores transient
 ✔ Process chunk creates child jobs
 ✔ Process chunk respects cancellation
 ✔ Child labels use packet titles
 ✔ On child complete marks parent done when all children finish
 ✔ On child complete marks parent failed when all children fail
 ✔ Child jobs receive per item engine data
 ✔ Child jobs work without engine data key
 ✔ On child complete ignores non batch parents
```

Run with: `homeboy test data-machine --skip-lint --path=<workspace> --setting database_type=mysql --setting mysql_database=extrachill --setting mysql_user=extrachill --setting mysql_password=<pw> -- --filter PipelineBatchSchedulerTest`