### PR TITLE
feat: add inject-category deterministic internal link injection

### DIFF
--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -1167,8 +1167,7 @@ class InternalLinkingAbilities {
 			}
 
 			// Fallback: if fewer matches than needed, fill with random
-			// category siblings. All posts in the same category are related
-			// by topic — e.g. all "Why Am I Craving X?" posts.
+			// category siblings. Posts in the same category share a topic.
 			if ( count( $matches ) < $links_per_post && 0 === $min_score ) {
 				$used_ids    = array_column( $matches, 'post_id' );
 				$used_ids[]  = $post_id;
@@ -1258,8 +1257,12 @@ class InternalLinkingAbilities {
 	/**
 	 * Extract significant keywords from a post title.
 	 *
-	 * Strips common stop words, question patterns, and site-specific
+	 * Strips common stop words, question patterns, and configurable
 	 * prefixes to isolate the meaningful topic words.
+	 *
+	 * Use the `datamachine_title_strip_patterns` filter to add
+	 * site-specific patterns (e.g. "Why Am I Craving", "Spiritual
+	 * Meaning Of") without modifying this plugin.
 	 *
 	 * @since 0.34.0
 	 *
@@ -1269,25 +1272,15 @@ class InternalLinkingAbilities {
 	private static function extractTitleKeywords( string $title ): array {
 		$title = strtolower( $title );
 
-		// Remove common patterns from saraichinwag.com titles.
+		// Generic title patterns common across WordPress sites.
 		// Order matters — longer/more specific patterns first.
 		$patterns = array(
-			// Listicle templates.
-			'/^\d+\s+(amazing|incredible|mind[\s\-]melting|surprising|unique|unusual|weird|fun|cool|interesting|common)\s+facts?\s+about\s*/i',
-			'/^\d+\s+(unique\s+)?uses?\s+for\s*/i',
-			'/^\d+\s+things\s+\w+\s+know\s+about\s*/i',
+			// Listicle number prefixes.
 			'/^\d+\s+(most\s+common|ways\s+to|things\s+that|reasons?\s+why)\s*/i',
-			// Craving patterns.
-			'/^why am i craving\s*/i',
-			// Spiritual/meaning patterns.
-			'/^the spiritual meaning of\s*/i',
-			'/^spiritual meaning of\s*/i',
-			'/^the meaning of\s+.*\s+in\s+dreams?\s*/i',
-			'/^the meaning of\s*/i',
-			'/^meaning of\s*/i',
-			'/^the symbolism of\s*/i',
-			'/^symbolism of\s*/i',
-			// Question patterns.
+			'/^\d+\s+things\s+\w+\s+know\s+about\s*/i',
+			'/^\d+\s+\w+\s+facts?\s+about\s*/i',
+			'/^\d+\s+(unique\s+)?uses?\s+for\s*/i',
+			// Common question patterns.
 			'/^what does it mean (when|to|if)\s*/i',
 			'/^what (does|do|is|are|happens?\s+if|happens?\s+when)\s*/i',
 			'/^how (do|does|to|can|are)\s*/i',
@@ -1300,6 +1293,20 @@ class InternalLinkingAbilities {
 			'/\s*\([^)]*\)\s*/i', // Remove parenthetical text.
 			'/\?$/',               // Remove trailing question mark.
 		);
+
+		/**
+		 * Filter the regex patterns used to strip non-keyword prefixes
+		 * from post titles during keyword extraction.
+		 *
+		 * Add site-specific patterns here. Patterns are applied in order
+		 * against the lowercased title, so place longer/more specific
+		 * patterns before shorter/generic ones.
+		 *
+		 * @since 0.34.0
+		 *
+		 * @param array $patterns Array of regex pattern strings.
+		 */
+		$patterns = apply_filters( 'datamachine_title_strip_patterns', $patterns );
 
 		foreach ( $patterns as $pattern ) {
 			$title = preg_replace( $pattern, '', $title );

--- a/inc/Cli/Commands/LinksCommand.php
+++ b/inc/Cli/Commands/LinksCommand.php
@@ -538,8 +538,7 @@ class LinksCommand extends BaseCommand {
 	 * scores all other posts in the same category by overlap, and
 	 * appends a "Related Reading" section with the top matches.
 	 *
-	 * Bypasses the crosslinker System Agent entirely — safe to run
-	 * while issue #479 (template title bias) is open.
+	 * Bypasses the crosslinker System Agent entirely.
 	 *
 	 * ## OPTIONS
 	 *
@@ -555,8 +554,8 @@ class LinksCommand extends BaseCommand {
 	 * [--min-score=<number>]
 	 * : Minimum keyword overlap score to qualify as a match.
 	 *   Use 0 to allow category-sibling fallback when no keyword
-	 *   overlap exists (useful for single-keyword title categories
-	 *   like Cravings where all posts are topically related).
+	 *   overlap exists (useful for categories where all posts
+	 *   share a topical pattern).
 	 * ---
 	 * default: 0
 	 * ---
@@ -582,17 +581,17 @@ class LinksCommand extends BaseCommand {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Preview links for the Cravings category
-	 *     wp datamachine links inject-category --category=cravings --dry-run
+	 *     # Preview links for a category
+	 *     wp datamachine links inject-category --category=tutorials --dry-run
 	 *
-	 *     # Inject links for Cravings (orphans only, 3 links each)
-	 *     wp datamachine links inject-category --category=cravings --orphans-only
+	 *     # Inject links (orphans only, 3 links each)
+	 *     wp datamachine links inject-category --category=tutorials --orphans-only
 	 *
-	 *     # Process Science category with higher match threshold
-	 *     wp datamachine links inject-category --category=science --min-score=2
+	 *     # Process with higher match threshold
+	 *     wp datamachine links inject-category --category=reviews --min-score=2
 	 *
 	 *     # JSON output for scripting
-	 *     wp datamachine links inject-category --category=colors --dry-run --format=json
+	 *     wp datamachine links inject-category --category=news --dry-run --format=json
 	 *
 	 * @subcommand inject-category
 	 */


### PR DESCRIPTION
## Summary

- Adds `wp datamachine links inject-category` subcommand + `datamachine/inject-category-links` ability for batch internal link injection within a single category
- Deterministic keyword-overlap scoring (exact, stem, substring match) with category-sibling fallback — **no AI calls, no cost**
- Title keyword extraction uses generic patterns with a `datamachine_title_strip_patterns` filter for site-specific customization
- Bypasses the crosslinker System Agent entirely

Closes #520

## How It Works

```
wp datamachine links inject-category --category=tutorials --dry-run
wp datamachine links inject-category --category=reviews --orphans-only
```

For each post in the category:
1. Extracts keywords from title (strips generic patterns like listicle numbers, question starters)
2. Sites add their own patterns via the `datamachine_title_strip_patterns` filter
3. Scores all other posts by keyword overlap (exact=2pts, stem/substring=1pt)
4. When `--min-score=0` (default), fills remaining slots with category siblings
5. Appends a WordPress block-format "Related Reading" section
6. Skips posts that already have one

## Extensibility

```php
// Example: add site-specific title patterns via mu-plugin or theme
add_filter( 'datamachine_title_strip_patterns', function ( array $patterns ): array {
    $site_patterns = array(
        '/^why am i craving\s*/i',
        '/^the spiritual meaning of\s*/i',
    );
    return array_merge( $site_patterns, $patterns );
} );
```

## Options

| Flag | Default | Description |
|------|---------|-------------|
| `--category=<slug>` | required | Category to process |
| `--links-per-post=<n>` | 3 | Max related links per post |
| `--min-score=<n>` | 0 | Min keyword overlap (0=allow sibling fallback) |
| `--orphans-only` | false | Only process posts with zero existing internal links |
| `--dry-run` | false | Preview without writing |
| `--format=<fmt>` | table | table/json/csv |