### PR TITLE
fix: MetaDescriptionTask writes to post_excerpt instead of custom meta key

### DIFF
--- a/inc/Abilities/SEO/MetaDescriptionAbilities.php
+++ b/inc/Abilities/SEO/MetaDescriptionAbilities.php
@@ -5,6 +5,9 @@
  * Ability endpoints for AI-powered meta description generation and diagnostics.
  * Delegates async execution to the System Agent infrastructure.
  *
+ * Meta descriptions are stored in the WordPress post_excerpt field — the
+ * standard WordPress field that SEO plugins read from.
+ *
  * @package DataMachine\Abilities\SEO
  * @since 0.31.0
  */
@@ -14,7 +17,6 @@ namespace DataMachine\Abilities\SEO;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\System\SystemAgent;
-use DataMachine\Engine\AI\System\Tasks\MetaDescriptionTask;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -41,7 +43,7 @@ class MetaDescriptionAbilities {
 				'datamachine/generate-meta-description',
 				array(
 					'label'               => 'Generate Meta Description',
-					'description'         => 'Queue system agent generation of meta descriptions for posts',
+					'description'         => 'Queue system agent generation of meta descriptions (saved to post excerpt)',
 					'category'            => 'datamachine',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -62,7 +64,7 @@ class MetaDescriptionAbilities {
 							),
 							'force'     => array(
 								'type'        => 'boolean',
-								'description' => 'Force regeneration even if meta description exists',
+								'description' => 'Force regeneration even if post excerpt exists',
 								'default'     => false,
 							),
 						),
@@ -90,7 +92,7 @@ class MetaDescriptionAbilities {
 				'datamachine/diagnose-meta-descriptions',
 				array(
 					'label'               => 'Diagnose Meta Descriptions',
-					'description'         => 'Report meta description coverage for posts',
+					'description'         => 'Report post excerpt (meta description) coverage for posts',
 					'category'            => 'datamachine',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -154,8 +156,6 @@ class MetaDescriptionAbilities {
 			);
 		}
 
-		$meta_key = apply_filters( 'datamachine_meta_description_meta_key', MetaDescriptionTask::DEFAULT_META_KEY );
-
 		// Single post mode.
 		if ( $post_id > 0 ) {
 			$post = get_post( $post_id );
@@ -168,19 +168,19 @@ class MetaDescriptionAbilities {
 				);
 			}
 
-			if ( ! $force && ! self::isDescriptionMissing( $post_id, $meta_key ) ) {
+			if ( ! $force && ! self::isExcerptMissing( $post ) ) {
 				return array(
 					'success'      => true,
 					'queued_count' => 0,
 					'post_ids'     => array(),
-					'message'      => "Post #{$post_id} already has a meta description. Use --force to regenerate.",
+					'message'      => "Post #{$post_id} already has an excerpt. Use --force to regenerate.",
 				);
 			}
 
 			$eligible = array( $post_id );
 		} else {
-			// Batch mode — find posts missing meta descriptions.
-			$eligible = self::findPostsMissingDescription( $post_type, $meta_key, $limit, $force );
+			// Batch mode — find posts missing excerpts.
+			$eligible = self::findPostsMissingExcerpt( $post_type, $limit, $force );
 		}
 
 		if ( empty( $eligible ) ) {
@@ -188,7 +188,7 @@ class MetaDescriptionAbilities {
 				'success'      => true,
 				'queued_count' => 0,
 				'post_ids'     => array(),
-				'message'      => 'No posts found missing meta descriptions.',
+				'message'      => 'No posts found missing excerpts (meta descriptions).',
 			);
 		}
 
@@ -227,7 +227,7 @@ class MetaDescriptionAbilities {
 	}
 
 	/**
-	 * Diagnose meta description coverage.
+	 * Diagnose meta description coverage by checking post_excerpt.
 	 *
 	 * @param array $input Ability input.
 	 * @return array Ability response.
@@ -236,25 +236,21 @@ class MetaDescriptionAbilities {
 		global $wpdb;
 
 		$post_type = sanitize_key( $input['post_type'] ?? 'post' );
-		$meta_key  = apply_filters( 'datamachine_meta_description_meta_key', MetaDescriptionTask::DEFAULT_META_KEY );
 
 		$total_posts = (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = 'publish'",
+				"SELECT COUNT(*) FROM {$wpdb->posts}
+				 WHERE post_type = %s AND post_status = 'publish'",
 				$post_type
 			)
 		);
 
 		$missing_count = (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT(*)
-				 FROM {$wpdb->posts} p
-				 LEFT JOIN {$wpdb->postmeta} m
-					ON p.ID = m.post_id AND m.meta_key = %s
-				 WHERE p.post_type = %s
-				 AND p.post_status = 'publish'
-				 AND ( m.meta_id IS NULL OR m.meta_value = '' OR m.meta_value IS NULL )",
-				$meta_key,
+				"SELECT COUNT(*) FROM {$wpdb->posts}
+				 WHERE post_type = %s
+				 AND post_status = 'publish'
+				 AND ( post_excerpt IS NULL OR post_excerpt = '' )",
 				$post_type
 			)
 		);
@@ -271,20 +267,18 @@ class MetaDescriptionAbilities {
 			'has_count'     => $has_count,
 			'coverage'      => $coverage,
 			'post_type'     => $post_type,
-			'meta_key'      => $meta_key,
 		);
 	}
 
 	/**
-	 * Find published posts missing a meta description.
+	 * Find published posts missing a post_excerpt.
 	 *
 	 * @param string $post_type Post type to query.
-	 * @param string $meta_key  Meta key to check.
 	 * @param int    $limit     Maximum results.
-	 * @param bool   $force     If true, return all posts regardless of meta.
+	 * @param bool   $force     If true, return all posts regardless of excerpt.
 	 * @return int[] Post IDs.
 	 */
-	private static function findPostsMissingDescription( string $post_type, string $meta_key, int $limit, bool $force ): array {
+	private static function findPostsMissingExcerpt( string $post_type, int $limit, bool $force ): array {
 		global $wpdb;
 
 		if ( $force ) {
@@ -300,16 +294,12 @@ class MetaDescriptionAbilities {
 		} else {
 			$results = $wpdb->get_col(
 				$wpdb->prepare(
-					"SELECT p.ID
-					 FROM {$wpdb->posts} p
-					 LEFT JOIN {$wpdb->postmeta} m
-						ON p.ID = m.post_id AND m.meta_key = %s
-					 WHERE p.post_type = %s
-					 AND p.post_status = 'publish'
-					 AND ( m.meta_id IS NULL OR m.meta_value = '' OR m.meta_value IS NULL )
-					 ORDER BY p.ID DESC
+					"SELECT ID FROM {$wpdb->posts}
+					 WHERE post_type = %s
+					 AND post_status = 'publish'
+					 AND ( post_excerpt IS NULL OR post_excerpt = '' )
+					 ORDER BY ID DESC
 					 LIMIT %d",
-					$meta_key,
 					$post_type,
 					$limit
 				)
@@ -320,16 +310,12 @@ class MetaDescriptionAbilities {
 	}
 
 	/**
-	 * Check if a post's meta description is missing or empty.
+	 * Check if a post's excerpt is missing or empty.
 	 *
-	 * @param int    $post_id  Post ID.
-	 * @param string $meta_key Meta key to check.
-	 * @return bool True if description is missing/empty.
+	 * @param \WP_Post $post Post object.
+	 * @return bool True if excerpt is missing/empty.
 	 */
-	private static function isDescriptionMissing( int $post_id, string $meta_key ): bool {
-		$description = get_post_meta( $post_id, $meta_key, true );
-		$description = is_string( $description ) ? trim( $description ) : '';
-
-		return '' === $description;
+	private static function isExcerptMissing( \WP_Post $post ): bool {
+		return '' === trim( $post->post_excerpt );
 	}
 }

--- a/inc/Engine/AI/System/Tasks/MetaDescriptionTask.php
+++ b/inc/Engine/AI/System/Tasks/MetaDescriptionTask.php
@@ -3,8 +3,12 @@
  * Meta Description Generation Task for System Agent.
  *
  * Generates AI-powered meta descriptions for posts. Gathers post title,
- * excerpt, content, and taxonomy context, sends to the configured AI
- * provider, normalizes the response, and saves to the configured meta key.
+ * content, and taxonomy context, sends to the configured AI provider,
+ * normalizes the response, and saves to the WordPress post_excerpt field.
+ *
+ * WordPress post_excerpt is the standard field for meta descriptions.
+ * SEO plugins (including extrachill-seo) read from post_excerpt as their
+ * primary source for meta description output.
  *
  * @package DataMachine\Engine\AI\System\Tasks
  * @since 0.31.0
@@ -18,14 +22,6 @@ use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\RequestBuilder;
 
 class MetaDescriptionTask extends SystemTask {
-
-	/**
-	 * Meta key for storing the generated description.
-	 *
-	 * Defaults to _lean_seo_description (Lean SEO). Configurable via the
-	 * datamachine_meta_description_meta_key filter for other SEO plugins.
-	 */
-	const DEFAULT_META_KEY = '_lean_seo_description';
 
 	/**
 	 * Maximum character length for meta descriptions.
@@ -66,13 +62,13 @@ class MetaDescriptionTask extends SystemTask {
 			return;
 		}
 
-		$meta_key = $this->getMetaKey();
+		$current_excerpt = trim( $post->post_excerpt );
 
-		if ( ! $force && ! $this->isDescriptionMissing( $post_id, $meta_key ) ) {
+		if ( ! $force && '' !== $current_excerpt ) {
 			$this->completeJob( $jobId, array(
 				'skipped' => true,
 				'post_id' => $post_id,
-				'reason'  => 'Meta description already exists',
+				'reason'  => 'Post excerpt already exists',
 			) );
 			return;
 		}
@@ -116,31 +112,35 @@ class MetaDescriptionTask extends SystemTask {
 			return;
 		}
 
-		// Save the meta description.
-		$current_value = get_post_meta( $post_id, $meta_key, true );
-		$updated       = update_post_meta( $post_id, $meta_key, $description );
+		// Save to the WordPress post_excerpt field.
+		$result = wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_excerpt' => $description,
+			),
+			true
+		);
 
-		if ( ! $updated && $current_value !== $description ) {
-			$this->failJob( $jobId, 'Failed to save meta description to post meta' );
+		if ( is_wp_error( $result ) ) {
+			$this->failJob( $jobId, 'Failed to update post excerpt: ' . $result->get_error_message() );
 			return;
 		}
 
 		// Build standardized effects array for undo.
 		$effects = array(
 			array(
-				'type'           => 'post_meta_set',
+				'type'           => 'post_field_set',
 				'target'         => array(
-					'post_id'  => $post_id,
-					'meta_key' => $meta_key,
+					'post_id' => $post_id,
+					'field'   => 'post_excerpt',
 				),
-				'previous_value' => ! empty( $current_value ) ? $current_value : null,
+				'previous_value' => '' !== $current_excerpt ? $current_excerpt : null,
 			),
 		);
 
 		$this->completeJob( $jobId, array(
 			'meta_description' => $description,
 			'post_id'          => $post_id,
-			'meta_key'         => $meta_key,
 			'char_count'       => mb_strlen( $description ),
 			'effects'          => $effects,
 			'completed_at'     => current_time( 'mysql' ),
@@ -162,14 +162,14 @@ class MetaDescriptionTask extends SystemTask {
 	public static function getTaskMeta(): array {
 		return array(
 			'label'           => 'Meta Description Generation',
-			'description'     => 'Generate SEO meta descriptions for posts using AI.',
+			'description'     => 'Generate SEO meta descriptions and save to post excerpt.',
 			'setting_key'     => 'meta_description_auto_generate_enabled',
 			'default_enabled' => true,
 		);
 	}
 
 	/**
-	 * Meta description generation supports undo — restores previous value.
+	 * Meta description generation supports undo — restores previous excerpt.
 	 *
 	 * @return bool
 	 */
@@ -178,18 +178,10 @@ class MetaDescriptionTask extends SystemTask {
 	}
 
 	/**
-	 * Get the meta key to write descriptions to.
-	 *
-	 * Filterable so sites using Yoast, Rank Math, etc. can override.
-	 *
-	 * @return string
-	 */
-	private function getMetaKey(): string {
-		return apply_filters( 'datamachine_meta_description_meta_key', self::DEFAULT_META_KEY );
-	}
-
-	/**
 	 * Build the AI prompt with post context.
+	 *
+	 * Note: The current excerpt is intentionally excluded from prompt context
+	 * since we are generating a replacement for it.
 	 *
 	 * @param \WP_Post $post Post object.
 	 * @return string Prompt text.
@@ -200,11 +192,6 @@ class MetaDescriptionTask extends SystemTask {
 		$title = wp_strip_all_tags( $post->post_title );
 		if ( ! empty( $title ) ) {
 			$context_lines[] = 'Title: ' . $title;
-		}
-
-		$excerpt = wp_strip_all_tags( $post->post_excerpt );
-		if ( ! empty( $excerpt ) ) {
-			$context_lines[] = 'Excerpt: ' . $excerpt;
 		}
 
 		// Get a clean text snippet of the post content.
@@ -246,20 +233,6 @@ class MetaDescriptionTask extends SystemTask {
 		}
 
 		return $prompt;
-	}
-
-	/**
-	 * Check if a post's meta description is missing or empty.
-	 *
-	 * @param int    $post_id  Post ID.
-	 * @param string $meta_key Meta key to check.
-	 * @return bool True if description is missing/empty.
-	 */
-	private function isDescriptionMissing( int $post_id, string $meta_key ): bool {
-		$description = get_post_meta( $post_id, $meta_key, true );
-		$description = is_string( $description ) ? trim( $description ) : '';
-
-		return '' === $description;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- **MetaDescriptionTask** was writing AI-generated meta descriptions to `_lean_seo_description` custom meta key — a key from Lean SEO, a plugin that doesn't exist in our ecosystem
- WordPress `post_excerpt` is the standard field for meta descriptions — extrachill-seo already reads from it as the primary source
- This removes all custom meta key plumbing and writes directly to `post_excerpt` via `wp_update_post()`

## Changes

### `MetaDescriptionTask.php`
- Removed `DEFAULT_META_KEY` constant (`_lean_seo_description`)
- Removed `getMetaKey()` method and `datamachine_meta_description_meta_key` filter
- Removed `isDescriptionMissing()` (was checking postmeta)
- Now checks `$post->post_excerpt` emptiness directly
- Saves via `wp_update_post(['ID' => $post_id, 'post_excerpt' => $description])`
- Undo effect type: `post_meta_set` → `post_field_set`
- Prompt no longer includes current excerpt as context (since we're replacing it)

### `MetaDescriptionAbilities.php`
- `diagnoseMetaDescriptions()` — queries `post_excerpt` column directly instead of LEFT JOIN against postmeta
- `findPostsMissingExcerpt()` — replaces `findPostsMissingDescription()`, uses `WHERE post_excerpt = ''`
- `isExcerptMissing()` — replaces `isDescriptionMissing()`, checks `$post->post_excerpt`
- Removed all references to `MetaDescriptionTask::DEFAULT_META_KEY` and `datamachine_meta_description_meta_key` filter

## Result

DM generates description → saves to `post_excerpt` → extrachill-seo reads excerpt → outputs `<meta name="description">`. No custom meta keys, no filters, no bridge code needed.

Net: **-41 lines**