### PR TITLE
fix: PublishWordPressAbility bypasses WordPressSettingsResolver for post_author

### DIFF
--- a/inc/Abilities/Publish/PublishWordPressAbility.php
+++ b/inc/Abilities/Publish/PublishWordPressAbility.php
@@ -11,6 +11,7 @@
 namespace DataMachine\Abilities\Publish;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\WordPress\WordPressSettingsResolver;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -205,7 +206,9 @@ class PublishWordPressAbility {
 			'post_content' => $content,
 			'post_status'  => $post_status,
 			'post_type'    => $post_type,
-			'post_author'  => $post_author > 0 ? $post_author : get_current_user_id(),
+			'post_author'  => WordPressSettingsResolver::getPostAuthor(
+				array( 'post_author' => $post_author )
+			),
 		);
 
 		$logs[] = array(

--- a/inc/Core/WordPress/WordPressSettingsResolver.php
+++ b/inc/Core/WordPress/WordPressSettingsResolver.php
@@ -41,26 +41,52 @@ class WordPressSettingsResolver {
 	/**
 	 * Get effective post author from handler config with system defaults override.
 	 *
-	 * System-wide defaults always take precedence over handler-specific configuration.
+	 * Resolution order:
+	 * 1. System-wide default_author_id from wordpress_settings
+	 * 2. Handler-specific post_author from config
+	 * 3. Current logged-in user (interactive contexts only)
+	 * 4. First administrator user (headless/cron fallback)
 	 *
 	 * @param array $handler_config Handler configuration
-	 * @param int   $default Default author ID if not configured (default: 1)
 	 * @return int Post author ID
 	 */
-	public static function getPostAuthor( array $handler_config, int $default = 1 ): int {
+	public static function getPostAuthor( array $handler_config ): int {
 		$wp_settings       = PluginSettings::get( 'wordpress_settings', array() );
 		$default_author_id = $wp_settings['default_author_id'] ?? 0;
 
 		if ( ! empty( $default_author_id ) ) {
-			return $default_author_id;
+			return (int) $default_author_id;
 		}
 
 		$author = $handler_config['post_author'] ?? 0;
 		if ( $author > 0 ) {
-			return $author;
+			return (int) $author;
 		}
 
 		$current_user = get_current_user_id();
-		return $current_user > 0 ? $current_user : $default;
+		if ( $current_user > 0 ) {
+			return $current_user;
+		}
+
+		return self::getFirstAdministratorId();
+	}
+
+	/**
+	 * Get the first administrator user ID as a last-resort fallback.
+	 *
+	 * @return int Administrator user ID, or 0 if none found.
+	 */
+	private static function getFirstAdministratorId(): int {
+		$admins = get_users(
+			array(
+				'role'    => 'administrator',
+				'number'  => 1,
+				'orderby' => 'ID',
+				'order'   => 'ASC',
+				'fields'  => 'ID',
+			)
+		);
+
+		return ! empty( $admins ) ? (int) $admins[0] : 0;
 	}
 }


### PR DESCRIPTION
## Summary

- **PublishWordPressAbility** now delegates to `WordPressSettingsResolver::getPostAuthor()` instead of falling back to `get_current_user_id()` directly — respects system `default_author_id` in all contexts including cron, Action Scheduler, and Agent Ping
- **WordPressSettingsResolver** replaces the hardcoded user ID `1` fallback with a dynamic lookup for the first administrator user via `get_users()`

## Resolution Order (updated)

1. System-wide `default_author_id` from `wordpress_settings`
2. Handler/ability-specific `post_author` from config
3. Current logged-in user (interactive contexts only)
4. First administrator user (headless/cron fallback)

## Files Changed

- `inc/Abilities/Publish/PublishWordPressAbility.php` — import and delegate to `WordPressSettingsResolver::getPostAuthor()`
- `inc/Core/WordPress/WordPressSettingsResolver.php` — remove hardcoded `$default = 1`, add `getFirstAdministratorId()` method

Fixes #525