### PR TITLE
fix: single-handler steps show blank settings display (#528)

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepHandler.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepHandler.jsx
@@ -53,18 +53,6 @@ export default function FlowStepHandler( {
 	const perHandlerDisplays = handlerSettingsDisplays || {};
 	const hasPerHandler = Object.keys( perHandlerDisplays ).length > 0;
 
-	// Legacy flat display — used when per-handler data isn't available.
-	const flatDisplaySettings = ! hasPerHandler && Array.isArray( settingsDisplay )
-		? settingsDisplay.reduce( ( acc, setting ) => {
-				acc[ setting.key ] = {
-					label: setting.label,
-					value: setting.display_value ?? setting.value,
-				};
-				return acc;
-		  }, {} )
-		: {};
-	const hasFlatSettings = Object.keys( flatDisplaySettings ).length > 0;
-
 	/**
 	 * Resolve a handler label from handlers registry, step types, or slug.
 	 *
@@ -90,6 +78,26 @@ export default function FlowStepHandler( {
 					return acc;
 			  }, {} )
 			: {};
+
+	// Unified display: for single-handler, extract from per-handler data; else use legacy flat.
+	const flatDisplaySettings = ( () => {
+		// Single handler with per-handler data — extract the one handler's display.
+		if ( hasPerHandler && slugs.length === 1 ) {
+			return toDisplayMap( perHandlerDisplays[ slugs[ 0 ] ] || [] );
+		}
+		// Legacy flat display — used when per-handler data isn't available.
+		if ( ! hasPerHandler && Array.isArray( settingsDisplay ) ) {
+			return settingsDisplay.reduce( ( acc, setting ) => {
+				acc[ setting.key ] = {
+					label: setting.label,
+					value: setting.display_value ?? setting.value,
+				};
+				return acc;
+			}, {} );
+		}
+		return {};
+	} )();
+	const hasFlatSettings = Object.keys( flatDisplaySettings ).length > 0;
 
 	const isMultiHandler = slugs.length > 1;
 


### PR DESCRIPTION
## Summary

- **Fixes #528** — Single-handler flow steps show blank settings summary on the pipelines admin page
- After the multi-handler normalization refactor, `handler_settings_displays` is always populated (even for single-handler steps), which short-circuited the legacy `flatDisplaySettings` derivation
- The single-handler branch in the JSX relied on `hasFlatSettings` which was always `false`

## Changes

**`FlowStepHandler.jsx`** — 1 file, minimal change:

1. Moved `toDisplayMap` helper above `flatDisplaySettings` (declaration order fix)
2. Replaced the old short-circuit ternary with a unified IIFE that:
   - For single-handler + per-handler data: extracts display from `perHandlerDisplays[slug]`
   - For legacy (no per-handler data): falls back to flat `settingsDisplay` array
   - Multi-handler path is completely untouched

## Testing

- Single-handler steps should now show their settings summary (e.g., "Subreddit: shakyknees")
- Multi-handler steps are unaffected (same `isMultiHandler && hasPerHandler` branch)
- Legacy path (no per-handler data) still works as fallback