### PR TITLE
fix: auto-run DB migrations on deploy without activation hook

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -21,7 +21,7 @@ if ( ! datamachine_check_requirements() ) {
 	return;
 }
 
-define( 'DATAMACHINE_VERSION', '0.34.0' );
+define( 'DATAMACHINE_VERSION', '0.35.0' );
 
 define( 'DATAMACHINE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DATAMACHINE_URL', plugin_dir_url( __FILE__ ) );
@@ -367,6 +367,9 @@ function datamachine_activate_for_site() {
 
 	// Re-schedule any flows with non-manual scheduling
 	datamachine_activate_scheduled_flows();
+
+	// Track DB schema version so deploy-time migrations auto-run.
+	update_option( 'datamachine_db_version', DATAMACHINE_VERSION, true );
 }
 
 /**
@@ -404,6 +407,30 @@ function datamachine_on_new_site( \WP_Site $new_site ) {
 	restore_current_blog();
 }
 add_action( 'wp_initialize_site', 'datamachine_on_new_site', 200 );
+
+/**
+ * Auto-run DB migrations when code version is ahead of stored DB version.
+ *
+ * Deploys via rsync/homeboy don't trigger activation hooks, so new columns
+ * are silently missing until someone manually reactivates. This check runs
+ * on every request and calls the idempotent activation function when the
+ * deployed code version exceeds the stored DB schema version.
+ *
+ * Pattern used by WooCommerce, bbPress, and most plugins with custom tables.
+ *
+ * @since 0.35.0
+ */
+function datamachine_maybe_run_migrations() {
+	$db_version = get_option( 'datamachine_db_version', '0.0.0' );
+
+	if ( version_compare( $db_version, DATAMACHINE_VERSION, '>=' ) ) {
+		return;
+	}
+
+	datamachine_activate_for_site();
+	update_option( 'datamachine_db_version', DATAMACHINE_VERSION, true );
+}
+add_action( 'init', 'datamachine_maybe_run_migrations', 5 );
 
 /**
  * Build scaffold defaults for agent memory files using WordPress site data.

--- a/homeboy.json
+++ b/homeboy.json
@@ -8,6 +8,10 @@
       "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"
     },
     {
+      "file": "data-machine.php",
+      "pattern": "DATAMACHINE_VERSION',\\s*'([0-9.]+)'"
+    },
+    {
       "file": "readme.txt",
       "pattern": "(?m)^Stable tag:\\s*([0-9.]+)"
     },


### PR DESCRIPTION
## Summary

- Adds `datamachine_maybe_run_migrations()` hooked to `init` at priority 5 — compares stored `datamachine_db_version` option against `DATAMACHINE_VERSION` and runs `datamachine_activate_for_site()` when code is ahead of DB
- Sets `datamachine_db_version` during normal activation too, so the check is a no-op on fresh installs
- Fixes `DATAMACHINE_VERSION` constant drift (`0.34.0` → `0.35.0`)
- Adds `DATAMACHINE_VERSION` as a homeboy version target so the constant can't drift from the header again

## Why

Deploys via rsync/homeboy don't trigger WordPress activation hooks. New DB columns added in a release are silently missing on multisite subsites until someone manually reactivates. This has caused **3 silent failures** (Feb 25, Mar 3 × 2) where jobs were silently dropped because columns didn't exist.

## How It Works

```
init (priority 5)
  → get_option('datamachine_db_version') // '0.34.0' or '0.0.0'
  → version_compare vs DATAMACHINE_VERSION // '0.35.0'
  → if behind: datamachine_activate_for_site() // idempotent — dbDelta + migrate_columns
  → update_option('datamachine_db_version', '0.35.0')
```

Standard pattern used by WooCommerce, bbPress, and most plugins with custom tables.

## Files Changed

- `data-machine.php` — add migration check, fix constant, set db_version on activation
- `homeboy.json` — add DATAMACHINE_VERSION as 4th version target

Fixes #531