### PR TITLE
fix: CLI handler-config validation rejects base FetchHandlerSettings fields

### DIFF
--- a/inc/Abilities/HandlerAbilities.php
+++ b/inc/Abilities/HandlerAbilities.php
@@ -553,7 +553,18 @@ class HandlerAbilities {
 			return array();
 		}
 
-		$fields                                     = $settings_class::get_fields();
+		$fields = $settings_class::get_fields();
+
+		// Ensure base handler settings fields are always included, even if
+		// an external handler's get_fields() forgot to merge them.
+		if ( $settings_class instanceof \DataMachine\Core\Steps\Fetch\Handlers\FetchHandlerSettings ) {
+			$common_fields = \DataMachine\Core\Steps\Fetch\Handlers\FetchHandlerSettings::get_common_fields();
+			$fields        = array_merge( $common_fields, $fields );
+		} elseif ( $settings_class instanceof \DataMachine\Core\Steps\Publish\Handlers\PublishHandlerSettings ) {
+			$common_fields = \DataMachine\Core\Steps\Publish\Handlers\PublishHandlerSettings::get_common_fields();
+			$fields        = array_merge( $common_fields, $fields );
+		}
+
 		self::$config_fields_cache[ $handler_slug ] = $fields;
 
 		return $fields;

--- a/inc/Core/Steps/Fetch/Handlers/FetchHandlerSettings.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandlerSettings.php
@@ -23,7 +23,7 @@ abstract class FetchHandlerSettings extends SettingsHandler {
 	 *
 	 * @return array Common field definitions.
 	 */
-	protected static function get_common_fields(): array {
+	public static function get_common_fields(): array {
 		return array(
 			'timeframe_limit'  => array(
 				'type'        => 'select',

--- a/inc/Core/Steps/Publish/Handlers/PublishHandlerSettings.php
+++ b/inc/Core/Steps/Publish/Handlers/PublishHandlerSettings.php
@@ -23,7 +23,7 @@ abstract class PublishHandlerSettings extends SettingsHandler {
 	 *
 	 * @return array Common field definitions.
 	 */
-	protected static function get_common_fields(): array {
+	public static function get_common_fields(): array {
 		return array(
 			'link_handling'  => array(
 				'type'        => 'select',


### PR DESCRIPTION
## Summary

- `HandlerAbilities::getConfigFields()` now merges base common fields from `FetchHandlerSettings` and `PublishHandlerSettings` as a safety net — even if an external handler's `get_fields()` forgot to call `parent::get_common_fields()`
- `get_common_fields()` visibility widened from `protected` to `public` on both base settings classes

## Problem

```
$ wp datamachine flows update <id> --handler-config='{"max_items": 10}'
Error: Unknown handler_config fields for ticketmaster: max_items
```

`max_items` is defined in `FetchHandlerSettings::get_common_fields()` but the Ticketmaster handler (external plugin) doesn't merge base fields in its `get_fields()`. The validation in `FlowStepHelpers::validateHandlerConfig()` calls `getConfigFields()` which only returned handler-specific fields, so it rejected valid base fields.

## How It Works

```
getConfigFields('ticketmaster')
  → settings_class::get_fields()           // handler-specific only
  → settings_class instanceof FetchHandlerSettings?
    → array_merge(common_fields, fields)   // safety net merge
  → cached result includes max_items, timeframe_limit, search, exclude_keywords
```

For handlers that already merge common fields (RSS, WordPress, GitHub, etc.), `array_merge` is idempotent — duplicate keys take the handler's value.

## Files Changed

- `inc/Abilities/HandlerAbilities.php` — merge common fields in `getConfigFields()`
- `inc/Core/Steps/Fetch/Handlers/FetchHandlerSettings.php` — `protected` → `public`
- `inc/Core/Steps/Publish/Handlers/PublishHandlerSettings.php` — `protected` → `public`

Fixes #532