### PR TITLE
fix: display structured error details in jobs show for failed jobs

### DIFF
--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -385,6 +385,35 @@ class JobsCommand extends BaseCommand {
 			WP_CLI::log( sprintf( 'Reason: %s', $parsed_status['reason'] ) );
 		}
 
+		// Display structured error details for failed jobs (persisted by #536).
+		if ( 'failed' === $parsed_status['type'] ) {
+			$engine_data   = $job['engine_data'] ?? array();
+			$error_message = $engine_data['error_message'] ?? null;
+			$error_step_id = $engine_data['error_step_id'] ?? null;
+			$error_trace   = $engine_data['error_trace'] ?? null;
+
+			if ( $error_message ) {
+				WP_CLI::log( '' );
+				WP_CLI::log( WP_CLI::colorize( '%RError:%n ' . $error_message ) );
+
+				if ( $error_step_id ) {
+					WP_CLI::log( sprintf( '  Step: %s', $error_step_id ) );
+				}
+
+				if ( $error_trace ) {
+					WP_CLI::log( '' );
+					WP_CLI::log( '  Stack Trace (truncated):' );
+					$trace_lines = explode( "\n", $error_trace );
+					foreach ( array_slice( $trace_lines, 0, 10 ) as $line ) {
+						WP_CLI::log( '    ' . $line );
+					}
+					if ( count( $trace_lines ) > 10 ) {
+						WP_CLI::log( sprintf( '    ... (%d more lines, use --format=json for full trace)', count( $trace_lines ) - 10 ) );
+					}
+				}
+			}
+		}
+
 		WP_CLI::log( '' );
 		WP_CLI::log( sprintf( 'Created: %s', $job['created_at_display'] ?? $job['created_at'] ?? 'N/A' ) );
 		WP_CLI::log( sprintf( 'Completed: %s', $job['completed_at_display'] ?? $job['completed_at'] ?? '-' ) );
@@ -395,6 +424,9 @@ class JobsCommand extends BaseCommand {
 		}
 
 		$engine_data = $job['engine_data'] ?? array();
+
+		// Strip error keys already displayed in the error section above.
+		unset( $engine_data['error_reason'], $engine_data['error_message'], $engine_data['error_step_id'], $engine_data['error_trace'] );
 
 		if ( ! empty( $engine_data ) ) {
 			WP_CLI::log( '' );


### PR DESCRIPTION
## Summary

- Failed jobs now show `error_message`, `error_step_id`, and truncated stack trace directly in `wp datamachine jobs show` output
- Error keys are stripped from the Engine Data section to avoid duplication
- Stack trace limited to 10 lines with a hint to use `--format=json` for the full trace

## Before

```
Status: failed
Reason: throwable_exception_in_step_execution
Engine Data:
  error_reason: throwable_exception_in_step_execution
  error_message: Call to undefined method ...
  error_trace: array (1 items, 2000 B)
```

## After

```
Status: failed
Reason: throwable_exception_in_step_execution

Error: Call to undefined method FooBar::baz()
  Step: fetch_1_15

  Stack Trace (truncated):
    #0 inc/Handlers/SomeHandler.php(142): ...
    ...

Created: 2 hours ago
Completed: 2 hours ago

Engine Data:
  post_id: 1234
```

Companion to #536 / PR #537 which persists error fields in engine_data.

Fixes #545