### PR TITLE
fix: jobs list status prefix matching and --since date filter

### DIFF
--- a/inc/Abilities/Job/GetJobsAbility.php
+++ b/inc/Abilities/Job/GetJobsAbility.php
@@ -77,12 +77,16 @@ class GetJobsAbility {
 								'default'     => 'j.job_id',
 								'description' => __( 'Column to order by', 'data-machine' ),
 							),
-							'order'       => array(
-								'type'        => 'string',
-								'enum'        => array( 'ASC', 'DESC' ),
-								'default'     => 'DESC',
-								'description' => __( 'Sort order', 'data-machine' ),
-							),
+						'order'       => array(
+							'type'        => 'string',
+							'enum'        => array( 'ASC', 'DESC' ),
+							'default'     => 'DESC',
+							'description' => __( 'Sort order', 'data-machine' ),
+						),
+						'since'       => array(
+							'type'        => array( 'string', 'null' ),
+							'description' => __( 'Filter jobs created at or after this datetime (Y-m-d H:i:s)', 'data-machine' ),
+						),
 						),
 					),
 					'output_schema'       => array(
@@ -123,6 +127,7 @@ class GetJobsAbility {
 		$pipeline_id = $input['pipeline_id'] ?? null;
 		$status      = $input['status'] ?? null;
 		$source      = $input['source'] ?? null;
+		$since       = $input['since'] ?? null;
 		$per_page    = (int) ( $input['per_page'] ?? self::DEFAULT_PER_PAGE );
 		$offset      = (int) ( $input['offset'] ?? 0 );
 		$orderby     = $input['orderby'] ?? 'j.job_id';
@@ -190,6 +195,11 @@ class GetJobsAbility {
 		if ( null !== $source && '' !== $source ) {
 			$args['source']            = sanitize_text_field( $source );
 			$filters_applied['source'] = $args['source'];
+		}
+
+		if ( null !== $since && '' !== $since ) {
+			$args['since']            = sanitize_text_field( $since );
+			$filters_applied['since'] = $args['since'];
 		}
 
 		$jobs  = $this->db_jobs->get_jobs_for_list_table( $args );

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -151,6 +151,9 @@ class JobsCommand extends BaseCommand {
 	 * [--source=<source>]
 	 * : Filter by source (pipeline, system).
 	 *
+	 * [--since=<datetime>]
+	 * : Show jobs created after this time. Accepts ISO datetime or relative strings (e.g., "1 hour ago", "today", "yesterday").
+	 *
 	 * [--limit=<limit>]
 	 * : Number of jobs to show.
 	 * ---
@@ -196,6 +199,12 @@ class JobsCommand extends BaseCommand {
 	 *     # JSON output
 	 *     wp datamachine jobs list --format=json
 	 *
+	 *     # Show failed jobs from the last 2 hours
+	 *     wp datamachine jobs list --status=failed --since="2 hours ago"
+	 *
+	 *     # Show all jobs since midnight
+	 *     wp datamachine jobs list --since=today
+	 *
 	 * @subcommand list
 	 */
 	public function list_jobs( array $args, array $assoc_args ): void {
@@ -224,6 +233,16 @@ class JobsCommand extends BaseCommand {
 
 		if ( $flow_id ) {
 			$input['flow_id'] = $flow_id;
+		}
+
+		$since = $assoc_args['since'] ?? null;
+		if ( $since ) {
+			$timestamp = strtotime( $since );
+			if ( false === $timestamp ) {
+				WP_CLI::error( sprintf( 'Invalid --since value: "%s". Use ISO datetime or relative string (e.g., "1 hour ago", "today").', $since ) );
+				return;
+			}
+			$input['since'] = gmdate( 'Y-m-d H:i:s', $timestamp );
 		}
 
 		$result = $this->abilities->executeGetJobs( $input );

--- a/inc/Core/Database/Jobs/JobsOperations.php
+++ b/inc/Core/Database/Jobs/JobsOperations.php
@@ -143,13 +143,19 @@ class JobsOperations extends BaseRepository {
 		}
 
 		if ( ! empty( $args['status'] ) ) {
-			$where_clauses[] = 'status = %s';
-			$where_values[]  = sanitize_text_field( $args['status'] );
+			$status_value    = sanitize_text_field( $args['status'] );
+			$where_clauses[] = 'status LIKE %s';
+			$where_values[]  = $this->wpdb->esc_like( $status_value ) . '%';
 		}
 
 		if ( ! empty( $args['source'] ) ) {
 			$where_clauses[] = 'source = %s';
 			$where_values[]  = sanitize_text_field( $args['source'] );
+		}
+
+		if ( ! empty( $args['since'] ) ) {
+			$where_clauses[] = 'created_at >= %s';
+			$where_values[]  = sanitize_text_field( $args['since'] );
 		}
 
 		$where_sql = '';
@@ -227,13 +233,20 @@ class JobsOperations extends BaseRepository {
 		}
 
 		if ( ! empty( $args['status'] ) ) {
-			$where_clauses[] = 'j.status = %s';
-			$where_values[]  = sanitize_text_field( $args['status'] );
+			$status_value = sanitize_text_field( $args['status'] );
+			// Prefix match: --status=failed matches "failed", "failed:reason", etc.
+			$where_clauses[] = 'j.status LIKE %s';
+			$where_values[]  = $this->wpdb->esc_like( $status_value ) . '%';
 		}
 
 		if ( ! empty( $args['source'] ) ) {
 			$where_clauses[] = 'j.source = %s';
 			$where_values[]  = sanitize_text_field( $args['source'] );
+		}
+
+		if ( ! empty( $args['since'] ) ) {
+			$where_clauses[] = 'j.created_at >= %s';
+			$where_values[]  = sanitize_text_field( $args['since'] );
 		}
 
 		$where_sql = '';


### PR DESCRIPTION
## Summary

**#543 — Status filtering shows wrong jobs:**
- `--status=failed` used exact match (`=`), so it only found old jobs with plain `failed` status
- Newer jobs use compound statuses like `failed:throwable_exception_in_step_execution`
- Fixed: both `get_jobs_for_list_table` and `get_jobs_count` now use `LIKE` prefix matching

**#544 — `--since` date filter:**
- New `--since` parameter on `wp datamachine jobs list`
- Accepts ISO datetime (`2026-03-03T12:00:00`) or relative strings via `strtotime()` (`"1 hour ago"`, `"today"`, `"yesterday"`)
- Added to CLI, ability input schema (works via REST too), and both DB query methods

## Examples

```bash
# Show recent failed jobs (now finds compound statuses)
wp datamachine jobs list --status=failed

# Show failed jobs from the last 2 hours
wp datamachine jobs list --status=failed --since="2 hours ago"

# Show all jobs since midnight
wp datamachine jobs list --since=today
```

## Files Changed

- `inc/Cli/Commands/JobsCommand.php` — add `--since` option with `strtotime()` parsing
- `inc/Abilities/Job/GetJobsAbility.php` — add `since` to input schema and execute passthrough
- `inc/Core/Database/Jobs/JobsOperations.php` — `LIKE` prefix for status, `created_at >=` for since

Fixes #543, fixes #544