### PR TITLE
feat: support cron expressions for flow scheduling

### DIFF
--- a/inc/Abilities/Engine/ScheduleFlowAbility.php
+++ b/inc/Abilities/Engine/ScheduleFlowAbility.php
@@ -49,10 +49,10 @@ class ScheduleFlowAbility {
 								'type'        => 'integer',
 								'description' => __( 'Flow ID to schedule.', 'data-machine' ),
 							),
-							'interval_or_timestamp' => array(
-								'type'        => array( 'string', 'integer' ),
-								'description' => __( "Either 'manual', numeric timestamp, or interval key.", 'data-machine' ),
-							),
+						'interval_or_timestamp' => array(
+							'type'        => array( 'string', 'integer' ),
+							'description' => __( "Either 'manual', numeric timestamp, interval key, or cron expression.", 'data-machine' ),
+						),
 						),
 					),
 					'output_schema'       => array(
@@ -108,6 +108,13 @@ class ScheduleFlowAbility {
 
 		if ( is_numeric( $interval_or_timestamp ) ) {
 			return $this->scheduleOneTime( $flow_id, (int) $interval_or_timestamp );
+		}
+
+		// Detect cron expressions and route to cron scheduling.
+		if ( is_string( $interval_or_timestamp )
+			&& \DataMachine\Api\Flows\FlowScheduling::looks_like_cron_expression( $interval_or_timestamp )
+		) {
+			return $this->scheduleCron( $flow_id, $interval_or_timestamp );
 		}
 
 		return $this->scheduleRecurring( $flow_id, $interval_or_timestamp );
@@ -184,6 +191,48 @@ class ScheduleFlowAbility {
 			'schedule_type'  => 'one_time',
 			'action_id'      => $action_id,
 			'scheduled_time' => wp_date( 'c', $timestamp ),
+		);
+	}
+
+	/**
+	 * Schedule execution using a cron expression.
+	 *
+	 * Delegates to FlowScheduling::handle_scheduling_update() which uses
+	 * Action Scheduler's native as_schedule_cron_action().
+	 *
+	 * @param int    $flow_id         Flow ID.
+	 * @param string $cron_expression Cron expression string (e.g. "0 9 * * 1-5").
+	 * @return array Result.
+	 */
+	private function scheduleCron( int $flow_id, string $cron_expression ): array {
+		$result = \DataMachine\Api\Flows\FlowScheduling::handle_scheduling_update(
+			$flow_id,
+			array(
+				'interval'        => 'cron',
+				'cron_expression' => $cron_expression,
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success' => false,
+				'error'   => $result->get_error_message(),
+			);
+		}
+
+		// Read back the scheduling config to get the computed next run.
+		$flow              = $this->db_flows->get_flow( $flow_id );
+		$scheduling_config = array();
+		if ( $flow ) {
+			$scheduling_config = json_decode( $flow['scheduling_config'] ?? '{}', true );
+		}
+
+		return array(
+			'success'         => true,
+			'flow_id'         => $flow_id,
+			'schedule_type'   => 'cron',
+			'cron_expression' => $cron_expression,
+			'scheduled_time'  => $scheduling_config['first_run'] ?? null,
 		);
 	}
 

--- a/inc/Api/Flows/FlowScheduling.php
+++ b/inc/Api/Flows/FlowScheduling.php
@@ -46,10 +46,107 @@ class FlowScheduling {
 	}
 
 	/**
+	 * Validate a cron expression string.
+	 *
+	 * Uses Action Scheduler's bundled CronExpression library — no external dependency.
+	 *
+	 * @param string $expression Cron expression to validate.
+	 * @return bool True if valid.
+	 */
+	public static function is_valid_cron_expression( string $expression ): bool {
+		if ( ! class_exists( 'CronExpression' ) ) {
+			return false;
+		}
+
+		try {
+			$cron = \CronExpression::factory( $expression );
+			$cron->getNextRunDate();
+			return true;
+		} catch ( \Exception $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Detect if a string looks like a cron expression.
+	 *
+	 * Cron expressions have 5-6 space-separated parts (minute hour day month weekday [year])
+	 * or start with @ (e.g. @daily, @hourly).
+	 *
+	 * @param string $value Value to check.
+	 * @return bool True if it looks like a cron expression.
+	 */
+	public static function looks_like_cron_expression( string $value ): bool {
+		// @ shortcuts: @yearly, @monthly, @weekly, @daily, @hourly.
+		if ( str_starts_with( $value, '@' ) ) {
+			return true;
+		}
+
+		// Standard cron: 5-6 space-separated parts containing digits, *, /, -, or comma.
+		$parts = preg_split( '/\s+/', trim( $value ) );
+		if ( count( $parts ) < 5 || count( $parts ) > 6 ) {
+			return false;
+		}
+
+		// Each part should only contain valid cron characters.
+		foreach ( $parts as $part ) {
+			if ( ! preg_match( '/^[\d\*\/\-\,\?LW#A-Za-z]+$/', $part ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get a human-readable description of a cron expression.
+	 *
+	 * Provides a basic description for common patterns. Falls back to
+	 * showing the next run time for complex expressions.
+	 *
+	 * @param string $expression Cron expression.
+	 * @return string Human-readable description.
+	 */
+	public static function describe_cron_expression( string $expression ): string {
+		// @ shortcut descriptions.
+		$shortcuts = array(
+			'@yearly'   => 'Once a year (Jan 1, midnight)',
+			'@annually' => 'Once a year (Jan 1, midnight)',
+			'@monthly'  => 'Once a month (1st, midnight)',
+			'@weekly'   => 'Once a week (Sunday, midnight)',
+			'@daily'    => 'Once a day (midnight)',
+			'@hourly'   => 'Once an hour',
+		);
+
+		if ( isset( $shortcuts[ $expression ] ) ) {
+			return $shortcuts[ $expression ];
+		}
+
+		// Compute next run for description.
+		if ( ! class_exists( 'CronExpression' ) ) {
+			return $expression;
+		}
+
+		try {
+			$cron     = \CronExpression::factory( $expression );
+			$next_run = $cron->getNextRunDate();
+			return sprintf( 'Next: %s', $next_run->format( 'Y-m-d H:i:s' ) );
+		} catch ( \Exception $e ) {
+			return $expression;
+		}
+	}
+
+	/**
 	 * Handle scheduling configuration updates for a flow.
 	 *
-	 * scheduling_config now only contains scheduling data (interval, timestamps).
+	 * scheduling_config now only contains scheduling data (interval, timestamps, cron).
 	 * Execution status (last_run, status, counters) is derived from jobs table.
+	 *
+	 * Supports four scheduling types:
+	 * - manual: no schedule (unschedules any existing)
+	 * - one_time: single execution at a timestamp
+	 * - cron: cron expression via as_schedule_cron_action()
+	 * - recurring: interval key from datamachine_scheduler_intervals filter
 	 *
 	 * @param int   $flow_id Flow ID
 	 * @param array $scheduling_config Scheduling configuration
@@ -58,7 +155,7 @@ class FlowScheduling {
 	public static function handle_scheduling_update( $flow_id, $scheduling_config ) {
 		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
 
-		// Validate flow exists
+		// Validate flow exists.
 		$flow = $db_flows->get_flow( $flow_id );
 		if ( ! $flow ) {
 			return new \WP_Error(
@@ -68,9 +165,10 @@ class FlowScheduling {
 			);
 		}
 
-		$interval = $scheduling_config['interval'] ?? null;
+		$interval        = $scheduling_config['interval'] ?? null;
+		$cron_expression = $scheduling_config['cron_expression'] ?? null;
 
-		// Handle manual scheduling (unschedule)
+		// Handle manual scheduling (unschedule).
 		if ( 'manual' === $interval || null === $interval ) {
 			if ( function_exists( 'as_unschedule_all_actions' ) ) {
 				as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
@@ -80,7 +178,7 @@ class FlowScheduling {
 			return true;
 		}
 
-		// Handle one-time scheduling
+		// Handle one-time scheduling.
 		if ( 'one_time' === $interval ) {
 			$timestamp = $scheduling_config['timestamp'] ?? null;
 			if ( ! $timestamp ) {
@@ -117,7 +215,17 @@ class FlowScheduling {
 			return true;
 		}
 
-		// Handle recurring scheduling
+		// Handle cron expression scheduling.
+		if ( 'cron' === $interval && $cron_expression ) {
+			return self::schedule_cron( $flow_id, $cron_expression, $db_flows );
+		}
+
+		// Auto-detect cron expression passed as the interval value.
+		if ( self::looks_like_cron_expression( $interval ) ) {
+			return self::schedule_cron( $flow_id, $interval, $db_flows );
+		}
+
+		// Handle recurring scheduling (interval key lookup).
 		$intervals        = apply_filters( 'datamachine_scheduler_intervals', array() );
 		$interval_seconds = $intervals[ $interval ]['seconds'] ?? null;
 
@@ -137,7 +245,7 @@ class FlowScheduling {
 			);
 		}
 
-		// Clear any existing schedule first
+		// Clear any existing schedule first.
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
 			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
 		}
@@ -162,6 +270,80 @@ class FlowScheduling {
 				'first_run'        => wp_date( 'c', $first_run_time ),
 			)
 		);
+		return true;
+	}
+
+	/**
+	 * Schedule a flow using a cron expression.
+	 *
+	 * Uses Action Scheduler's native as_schedule_cron_action() which handles
+	 * cron expression parsing via its bundled CronExpression library.
+	 *
+	 * @param int                                   $flow_id         Flow ID.
+	 * @param string                                $cron_expression Cron expression string.
+	 * @param \DataMachine\Core\Database\Flows\Flows $db_flows        Flows database instance.
+	 * @return bool|\WP_Error True on success, WP_Error on failure.
+	 */
+	private static function schedule_cron( int $flow_id, string $cron_expression, $db_flows ) {
+		if ( ! self::is_valid_cron_expression( $cron_expression ) ) {
+			return new \WP_Error(
+				'invalid_cron_expression',
+				sprintf( 'Invalid cron expression: "%s"', $cron_expression ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! function_exists( 'as_schedule_cron_action' ) ) {
+			return new \WP_Error(
+				'scheduler_unavailable',
+				'Action Scheduler not available',
+				array( 'status' => 500 )
+			);
+		}
+
+		// Clear any existing schedule first.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+		}
+
+		$action_id = as_schedule_cron_action(
+			time(),
+			$cron_expression,
+			'datamachine_run_flow_now',
+			array( $flow_id ),
+			'data-machine'
+		);
+
+		// Compute next run for storage.
+		$next_run = null;
+		try {
+			$cron     = \CronExpression::factory( $cron_expression );
+			$next_run = $cron->getNextRunDate()->format( 'c' );
+		} catch ( \Exception $e ) {
+			// Non-fatal — next run display is informational.
+		}
+
+		$db_flows->update_flow_scheduling(
+			$flow_id,
+			array(
+				'interval'        => 'cron',
+				'cron_expression' => $cron_expression,
+				'first_run'       => $next_run,
+			)
+		);
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Flow scheduled with cron expression',
+			array(
+				'flow_id'         => $flow_id,
+				'cron_expression' => $cron_expression,
+				'next_run'        => $next_run,
+				'action_id'       => $action_id,
+			)
+		);
+
 		return true;
 	}
 }

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -91,7 +91,7 @@ class FlowsCommand extends BaseCommand {
 	 * : JSON object with step configurations keyed by step_type (create subcommand).
 	 *
 	 * [--scheduling=<interval>]
-	 * : Scheduling interval (manual, hourly, daily, etc.).
+	 * : Scheduling interval (manual, hourly, daily, etc.) or cron expression (e.g. "0 9 * * 1-5").
 	 *
 	 * [--set-prompt=<text>]
 	 * : Update the prompt for a handler step (requires handler step to exist).
@@ -370,7 +370,12 @@ class FlowsCommand extends BaseCommand {
 		WP_CLI::log( sprintf( 'Flow ID:      %d', $flow['flow_id'] ) );
 		WP_CLI::log( sprintf( 'Name:         %s', $flow['flow_name'] ) );
 		WP_CLI::log( sprintf( 'Pipeline ID:  %s', $flow['pipeline_id'] ?? 'N/A' ) );
-		WP_CLI::log( sprintf( 'Scheduling:   %s', $interval ) );
+		if ( 'cron' === $interval && ! empty( $scheduling['cron_expression'] ) ) {
+			$cron_desc = \DataMachine\Api\Flows\FlowScheduling::describe_cron_expression( $scheduling['cron_expression'] );
+			WP_CLI::log( sprintf( 'Scheduling:   cron (%s) — %s', $scheduling['cron_expression'], $cron_desc ) );
+		} else {
+			WP_CLI::log( sprintf( 'Scheduling:   %s', $interval ) );
+		}
 		WP_CLI::log( sprintf( 'Last run:     %s', $flow['last_run_display'] ?? 'Never' ) );
 		WP_CLI::log( sprintf( 'Next run:     %s', $flow['next_run_display'] ?? 'Not scheduled' ) );
 		WP_CLI::log( sprintf( 'Running:      %s', ( $flow['is_running'] ?? false ) ? 'Yes' : 'No' ) );
@@ -516,10 +521,12 @@ class FlowsCommand extends BaseCommand {
 			$step_configs = $decoded ?? array();
 		}
 
+		$scheduling_config = self::build_scheduling_config( $scheduling );
+
 		$input = array(
 			'pipeline_id'       => $pipeline_id,
 			'flow_name'         => $flow_name,
-			'scheduling_config' => array( 'interval' => $scheduling ),
+			'scheduling_config' => $scheduling_config,
 			'step_configs'      => $step_configs,
 		);
 
@@ -529,7 +536,7 @@ class FlowsCommand extends BaseCommand {
 				array(
 					'pipeline_id'       => $pipeline_id,
 					'flow_name'         => $flow_name,
-					'scheduling_config' => array( 'interval' => $scheduling ),
+					'scheduling_config' => $scheduling_config,
 					'step_configs'      => $step_configs,
 				),
 			);
@@ -707,7 +714,7 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		if ( null !== $scheduling ) {
-			$input['scheduling_config'] = array( 'interval' => $scheduling );
+			$input['scheduling_config'] = self::build_scheduling_config( $scheduling );
 		}
 
 		if ( null !== $name || null !== $scheduling ) {
@@ -722,8 +729,11 @@ class FlowsCommand extends BaseCommand {
 			WP_CLI::success( sprintf( 'Flow %d updated.', $flow_id ) );
 			WP_CLI::log( sprintf( 'Name: %s', $result['flow_name'] ?? '' ) );
 
-			if ( isset( $result['flow_data']['scheduling_config']['interval'] ) ) {
-				WP_CLI::log( sprintf( 'Scheduling: %s', $result['flow_data']['scheduling_config']['interval'] ) );
+			$sched = $result['flow_data']['scheduling_config'] ?? array();
+			if ( 'cron' === ( $sched['interval'] ?? '' ) && ! empty( $sched['cron_expression'] ) ) {
+				WP_CLI::log( sprintf( 'Scheduling: cron (%s)', $sched['cron_expression'] ) );
+			} elseif ( isset( $sched['interval'] ) ) {
+				WP_CLI::log( sprintf( 'Scheduling: %s', $sched['interval'] ) );
 			}
 		}
 
@@ -1155,5 +1165,26 @@ class FlowsCommand extends BaseCommand {
 		);
 
 		\WP_CLI\Utils\format_items( $format, $items, array( 'filename' ) );
+	}
+
+	/**
+	 * Build a scheduling_config array from a CLI --scheduling value.
+	 *
+	 * Detects cron expressions and routes them correctly:
+	 * - Cron expression (e.g. "0 * /3 * * *") → interval=cron + cron_expression
+	 * - Interval key (e.g. "daily") → interval=<key>
+	 *
+	 * @param string $scheduling Value from --scheduling CLI flag.
+	 * @return array Scheduling config array.
+	 */
+	private static function build_scheduling_config( string $scheduling ): array {
+		if ( \DataMachine\Api\Flows\FlowScheduling::looks_like_cron_expression( $scheduling ) ) {
+			return array(
+				'interval'        => 'cron',
+				'cron_expression' => $scheduling,
+			);
+		}
+
+		return array( 'interval' => $scheduling );
 	}
 }

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -591,12 +591,24 @@ class Flows extends BaseRepository {
 		}
 
 		if ( null === $last_run_at ) {
-			return true; // Never run before
+			return true; // Never run before.
 		}
 
 		$last_run_timestamp = ( new \DateTime( $last_run_at, new \DateTimeZone( 'UTC' ) ) )->getTimestamp();
 		$current_timestamp  = ( new \DateTime( $current_time, new \DateTimeZone( 'UTC' ) ) )->getTimestamp();
 		$interval           = $scheduling_config['interval'];
+
+		// Cron expression scheduling: check if the next run after last_run is in the past.
+		if ( 'cron' === $interval && ! empty( $scheduling_config['cron_expression'] ) && class_exists( 'CronExpression' ) ) {
+			try {
+				$cron     = \CronExpression::factory( $scheduling_config['cron_expression'] );
+				$last_run = new \DateTime( $last_run_at, new \DateTimeZone( 'UTC' ) );
+				$next_run = $cron->getNextRunDate( $last_run );
+				return $current_timestamp >= $next_run->getTimestamp();
+			} catch ( \Exception $e ) {
+				return false;
+			}
+		}
 
 		$intervals     = apply_filters( 'datamachine_scheduler_intervals', array() );
 		$interval_data = $intervals[ $interval ] ?? null;


### PR DESCRIPTION
## Summary

Closes #482 (backend only — UI is a follow-up)

Adds cron expression support for flow scheduling using **Action Scheduler's native `as_schedule_cron_action()`** — no new dependencies. AS already bundles the `CronExpression` library.

### What changed

**`FlowScheduling`** (the scheduling source of truth):
- New `schedule_cron()` method calls `as_schedule_cron_action()` with the cron expression
- `handle_scheduling_update()` gains a `cron` branch alongside manual/one_time/recurring
- Auto-detection: if the `interval` value looks like a cron expression, routes to cron scheduling automatically
- Validation via `is_valid_cron_expression()` using AS's bundled `CronExpression::factory()`
- `describe_cron_expression()` provides human-readable descriptions for @ shortcuts

**`ScheduleFlowAbility`** (abilities layer):
- Detects cron expressions in `interval_or_timestamp` and routes to new `scheduleCron()` method
- Returns `schedule_type: 'cron'` with the expression and next run time

**`Flows::is_flow_ready_for_execution()`** (polling fallback):
- Handles `cron` interval type using `CronExpression::getNextRunDate()` to check if the next run after `last_run_at` is in the past

**CLI**:
- `--scheduling` flag accepts cron expressions directly (e.g. `--scheduling="0 9 * * 1-5"`)
- @ shortcuts work too (e.g. `--scheduling="@hourly"`)
- `flows show` displays cron expression with human-readable description

### scheduling_config format

```json
{
  "interval": "cron",
  "cron_expression": "0 9 * * 1-5",
  "first_run": "2026-03-04T09:00:00+00:00"
}
```

Existing interval keys (`daily`, `hourly`, etc.) continue to work unchanged.

### Testing on chubes.net

```
$ wp datamachine flows create --pipeline_id=2 --name="Cron Test Flow" --scheduling="0 9 * * 1-5"
Success: Flow created: ID 4

$ wp datamachine flows show 4
Scheduling:   cron (0 9 * * 1-5) — Next: 2026-03-04 09:00:00

$ wp datamachine flows update 4 --scheduling="@hourly"
Scheduling: cron (@hourly)

$ wp datamachine flows update 4 --scheduling="daily"
Scheduling: daily  ← backward compat works

$ wp datamachine flows update 4 --scheduling="99 99 99 99 99"
Error: Invalid cron expression: "99 99 99 99 99"
```

AS action verified in `actionscheduler_actions` table with correct `scheduled_date_gmt`.

### Follow-up (separate issue)
- UI: replace hardcoded interval dropdown with cron expression input + preset shortcuts
- Migration: optionally convert existing interval keys to cron expressions