### PR TITLE
refactor: extract tool config save into BaseTool, remove wp_send_json exits

### DIFF
--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -677,7 +677,30 @@ class SettingsAbilities {
 				: sanitize_text_field( $value );
 		}
 
-		$result = array(
+		/**
+		 * Save tool configuration via registered handlers.
+		 *
+		 * Tools hook into this filter via BaseTool::registerConfigurationHandlers().
+		 * Each handler checks if it owns the tool_id and returns a result array
+		 * with 'success' and 'message' or 'error' keys. Handlers that don't own
+		 * the tool_id pass through the $result unchanged.
+		 *
+		 * @since 0.36.0
+		 *
+		 * @param array|null $result         Result from a previous handler, or null if none handled it yet.
+		 * @param string     $tool_id        Tool identifier.
+		 * @param array      $sanitized_config Sanitized configuration data.
+		 */
+		$result = apply_filters( 'datamachine_save_tool_config', null, $tool_id, $sanitized_config );
+
+		if ( is_array( $result ) && isset( $result['success'] ) ) {
+			if ( $result['success'] ) {
+				$result['tool_id'] = $tool_id;
+			}
+			return $result;
+		}
+
+		return array(
 			'success' => false,
 			'error'   => sprintf(
 				/* translators: %s: tool ID */
@@ -685,24 +708,6 @@ class SettingsAbilities {
 				$tool_id
 			),
 		);
-
-		$handler_fired = apply_filters( 'datamachine_save_tool_config_ability', false, $tool_id, $sanitized_config );
-
-		if ( $handler_fired ) {
-			return array(
-				'success' => true,
-				'tool_id' => $tool_id,
-				'message' => sprintf(
-					/* translators: %s: tool ID */
-					__( 'Configuration saved for tool: %s', 'data-machine' ),
-					$tool_id
-				),
-			);
-		}
-
-		do_action( 'datamachine_save_tool_config', $tool_id, $sanitized_config );
-
-		return $result;
 	}
 
 	public function executeGetHandlerDefaults( array $input ): array {

--- a/inc/Engine/AI/Tools/BaseTool.php
+++ b/inc/Engine/AI/Tools/BaseTool.php
@@ -69,15 +69,114 @@ abstract class BaseTool {
 	}
 
 	/**
+	 * Tool identifier for configuration management.
+	 *
+	 * Set by registerConfigurationHandlers(). Used by save_configuration()
+	 * to check if this tool should handle the save request.
+	 *
+	 * @var string
+	 */
+	protected string $config_tool_id = '';
+
+	/**
 	 * Register configuration management handlers for tools that need them.
 	 *
 	 * @param string $tool_id Tool identifier for configuration
 	 */
 	protected function registerConfigurationHandlers( string $tool_id ): void {
+		$this->config_tool_id = $tool_id;
 		add_filter( 'datamachine_tool_configured', array( $this, 'check_configuration' ), 10, 2 );
 		add_filter( 'datamachine_get_tool_config', array( $this, 'get_configuration' ), 10, 2 );
 		add_filter( 'datamachine_get_tool_config_fields', array( $this, 'get_config_fields' ), 10, 2 );
-		add_action( 'datamachine_save_tool_config', array( $this, 'save_configuration' ), 10, 2 );
+		add_filter( 'datamachine_save_tool_config', array( $this, 'save_configuration' ), 10, 3 );
+	}
+
+	/**
+	 * Save tool configuration via the datamachine_save_tool_config filter.
+	 *
+	 * Handles the common pattern: check tool_id ownership, validate input,
+	 * build config, save to option, run post-save hooks. Subclasses override
+	 * validate_and_build_config() to define their specific validation and
+	 * config shape.
+	 *
+	 * Tools that need fully custom save logic can override this method directly.
+	 *
+	 * @param array|null $result      Result from a previous handler, or null.
+	 * @param string     $tool_id     Tool identifier.
+	 * @param array      $config_data Sanitized configuration data.
+	 * @return array|null Result array with success/error, or passthrough null.
+	 */
+	public function save_configuration( $result, $tool_id, $config_data ) {
+		if ( $this->config_tool_id !== $tool_id ) {
+			return $result;
+		}
+
+		$config_option = $this->get_config_option_name();
+		if ( empty( $config_option ) ) {
+			return $result;
+		}
+
+		$validated = $this->validate_and_build_config( $config_data );
+
+		if ( isset( $validated['error'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => $validated['error'],
+			);
+		}
+
+		$this->before_config_save( $config_data );
+
+		if ( update_site_option( $config_option, $validated['config'] ) ) {
+			return array(
+				'success' => true,
+				'message' => $validated['message'] ?? __( 'Configuration saved successfully', 'data-machine' ),
+			);
+		}
+
+		return array(
+			'success' => false,
+			'error'   => __( 'Failed to save configuration', 'data-machine' ),
+		);
+	}
+
+	/**
+	 * Get the option name used to store this tool's configuration.
+	 *
+	 * Override in subclasses. Return empty string if the tool does not use
+	 * the standard save_configuration() flow.
+	 *
+	 * @return string Option name, or empty string.
+	 */
+	protected function get_config_option_name(): string {
+		return '';
+	}
+
+	/**
+	 * Validate input and build the config array to save.
+	 *
+	 * Override in subclasses. Return an array with either:
+	 * - 'config' key: the validated config array to pass to update_site_option()
+	 * - 'message' key (optional): custom success message
+	 * OR:
+	 * - 'error' key: validation error message (save will be aborted)
+	 *
+	 * @param array $config_data Sanitized input from the ability.
+	 * @return array{config: array, message?: string}|array{error: string}
+	 */
+	protected function validate_and_build_config( array $config_data ): array {
+		return array( 'config' => $config_data );
+	}
+
+	/**
+	 * Hook called before saving config to the option.
+	 *
+	 * Override in subclasses to clear transients, invalidate caches, etc.
+	 *
+	 * @param array $config_data The raw config data being saved.
+	 */
+	protected function before_config_save( array $config_data ): void {
+		// No-op by default. Subclasses override as needed.
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/AmazonAffiliateLink.php
+++ b/inc/Engine/AI/Tools/Global/AmazonAffiliateLink.php
@@ -343,46 +343,37 @@ class AmazonAffiliateLink extends BaseTool {
 	 * @param string $tool_id     Tool identifier.
 	 * @param array  $config_data Configuration data from form.
 	 */
-	public function save_configuration( $tool_id, $config_data ) {
-		if ( 'amazon_affiliate_link' !== $tool_id ) {
-			return;
-		}
+	protected function get_config_option_name(): string {
+		return self::CONFIG_OPTION;
+	}
 
+	protected function validate_and_build_config( array $config_data ): array {
 		$client_id     = sanitize_text_field( $config_data['client_id'] ?? '' );
 		$client_secret = sanitize_text_field( $config_data['client_secret'] ?? '' );
 		$partner_tag   = sanitize_text_field( $config_data['partner_tag'] ?? '' );
 		$marketplace   = sanitize_text_field( $config_data['marketplace'] ?? 'www.amazon.com' );
 
 		if ( empty( $client_id ) || empty( $client_secret ) || empty( $partner_tag ) ) {
-			wp_send_json_error( array( 'message' => __( 'Credential ID, Credential Secret, and Partner Tag are required.', 'data-machine' ) ) );
-			return;
+			return array( 'error' => __( 'Credential ID, Credential Secret, and Partner Tag are required.', 'data-machine' ) );
 		}
 
 		if ( ! isset( self::REGION_MAP[ $marketplace ] ) ) {
-			wp_send_json_error( array( 'message' => __( 'Invalid marketplace selected.', 'data-machine' ) ) );
-			return;
+			return array( 'error' => __( 'Invalid marketplace selected.', 'data-machine' ) );
 		}
 
-		$saved = array(
-			'client_id'     => $client_id,
-			'client_secret' => $client_secret,
-			'partner_tag'   => $partner_tag,
-			'marketplace'   => $marketplace,
+		return array(
+			'config'  => array(
+				'client_id'     => $client_id,
+				'client_secret' => $client_secret,
+				'partner_tag'   => $partner_tag,
+				'marketplace'   => $marketplace,
+			),
+			'message' => __( 'Amazon Affiliate configuration saved successfully.', 'data-machine' ),
 		);
+	}
 
-		// Clear cached token when credentials change.
+	protected function before_config_save( array $config_data ): void {
 		delete_transient( self::TOKEN_TRANSIENT );
-
-		if ( update_site_option( self::CONFIG_OPTION, $saved ) ) {
-			wp_send_json_success(
-				array(
-					'message'    => __( 'Amazon Affiliate configuration saved successfully.', 'data-machine' ),
-					'configured' => true,
-				)
-			);
-		} else {
-			wp_send_json_error( array( 'message' => __( 'Failed to save configuration.', 'data-machine' ) ) );
-		}
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/BingWebmaster.php
+++ b/inc/Engine/AI/Tools/Global/BingWebmaster.php
@@ -144,34 +144,24 @@ class BingWebmaster extends BaseTool {
 	 * @param string $tool_id     Tool identifier.
 	 * @param array  $config_data Configuration data.
 	 */
-	public function save_configuration( $tool_id, $config_data ) {
-		if ( 'bing_webmaster' !== $tool_id ) {
-			return;
-		}
+	protected function get_config_option_name(): string {
+		return BingWebmasterAbilities::CONFIG_OPTION;
+	}
 
-		$api_key  = sanitize_text_field( $config_data['api_key'] ?? '' );
-		$site_url = esc_url_raw( $config_data['site_url'] ?? '' );
+	protected function validate_and_build_config( array $config_data ): array {
+		$api_key = sanitize_text_field( $config_data['api_key'] ?? '' );
 
 		if ( empty( $api_key ) ) {
-			wp_send_json_error( array( 'message' => __( 'Bing Webmaster API key is required', 'data-machine' ) ) );
-			return;
+			return array( 'error' => __( 'Bing Webmaster API key is required', 'data-machine' ) );
 		}
 
-		$config = array(
-			'api_key'  => $api_key,
-			'site_url' => $site_url,
+		return array(
+			'config'  => array(
+				'api_key'  => $api_key,
+				'site_url' => esc_url_raw( $config_data['site_url'] ?? '' ),
+			),
+			'message' => __( 'Bing Webmaster Tools configuration saved successfully', 'data-machine' ),
 		);
-
-		if ( update_site_option( BingWebmasterAbilities::CONFIG_OPTION, $config ) ) {
-			wp_send_json_success(
-				array(
-					'message'    => __( 'Bing Webmaster Tools configuration saved successfully', 'data-machine' ),
-					'configured' => true,
-				)
-			);
-		} else {
-			wp_send_json_error( array( 'message' => __( 'Failed to save configuration', 'data-machine' ) ) );
-		}
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
+++ b/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
@@ -160,55 +160,43 @@ class GoogleAnalytics extends BaseTool {
 	 * @param string $tool_id     Tool identifier.
 	 * @param array  $config_data Configuration data.
 	 */
-	public function save_configuration( $tool_id, $config_data ) {
-		if ( 'google_analytics' !== $tool_id ) {
-			return;
-		}
+	protected function get_config_option_name(): string {
+		return GoogleAnalyticsAbilities::CONFIG_OPTION;
+	}
 
+	protected function validate_and_build_config( array $config_data ): array {
 		$service_account_json = $config_data['service_account_json'] ?? '';
 		$property_id          = sanitize_text_field( $config_data['property_id'] ?? '' );
 
 		if ( empty( $service_account_json ) ) {
-			wp_send_json_error( array( 'message' => __( 'Service Account JSON is required', 'data-machine' ) ) );
-			return;
+			return array( 'error' => __( 'Service Account JSON is required', 'data-machine' ) );
 		}
 
 		if ( empty( $property_id ) ) {
-			wp_send_json_error( array( 'message' => __( 'GA4 Property ID is required', 'data-machine' ) ) );
-			return;
+			return array( 'error' => __( 'GA4 Property ID is required', 'data-machine' ) );
 		}
 
-		// Validate the JSON is parseable and has required fields.
 		$parsed = json_decode( $service_account_json, true );
 
 		if ( json_last_error() !== JSON_ERROR_NONE ) {
-			wp_send_json_error( array( 'message' => __( 'Invalid JSON in Service Account field', 'data-machine' ) ) );
-			return;
+			return array( 'error' => __( 'Invalid JSON in Service Account field', 'data-machine' ) );
 		}
 
 		if ( empty( $parsed['client_email'] ) || empty( $parsed['private_key'] ) ) {
-			wp_send_json_error( array( 'message' => __( 'Service Account JSON must contain client_email and private_key', 'data-machine' ) ) );
-			return;
+			return array( 'error' => __( 'Service Account JSON must contain client_email and private_key', 'data-machine' ) );
 		}
 
-		$config = array(
-			'service_account_json' => $service_account_json,
-			'property_id'          => $property_id,
+		return array(
+			'config'  => array(
+				'service_account_json' => $service_account_json,
+				'property_id'          => $property_id,
+			),
+			'message' => __( 'Google Analytics configuration saved successfully', 'data-machine' ),
 		);
+	}
 
-		// Clear cached token when config changes.
+	protected function before_config_save( array $config_data ): void {
 		delete_transient( GoogleAnalyticsAbilities::TOKEN_TRANSIENT );
-
-		if ( update_site_option( GoogleAnalyticsAbilities::CONFIG_OPTION, $config ) ) {
-			wp_send_json_success(
-				array(
-					'message'    => __( 'Google Analytics configuration saved successfully', 'data-machine' ),
-					'configured' => true,
-				)
-			);
-		} else {
-			wp_send_json_error( array( 'message' => __( 'Failed to save configuration', 'data-machine' ) ) );
-		}
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/GoogleSearch.php
+++ b/inc/Engine/AI/Tools/Global/GoogleSearch.php
@@ -192,17 +192,28 @@ class GoogleSearch extends BaseTool {
 		return self::get_config();
 	}
 
-	public function save_configuration( $tool_id, $config_data ) {
+	/**
+	 * GoogleSearch uses a nested key inside a shared option, so it overrides
+	 * save_configuration() directly instead of using the base flow.
+	 *
+	 * @param array|null $result      Previous handler result.
+	 * @param string     $tool_id     Tool identifier.
+	 * @param array      $config_data Sanitized configuration data.
+	 * @return array|null
+	 */
+	public function save_configuration( $result, $tool_id, $config_data ) {
 		if ( 'google_search' !== $tool_id ) {
-			return;
+			return $result;
 		}
 
 		$api_key          = sanitize_text_field( $config_data['api_key'] ?? '' );
 		$search_engine_id = sanitize_text_field( $config_data['search_engine_id'] ?? '' );
 
 		if ( empty( $api_key ) || empty( $search_engine_id ) ) {
-			wp_send_json_error( array( 'message' => __( 'API Key and Search Engine ID are required', 'data-machine' ) ) );
-			return;
+			return array(
+				'success' => false,
+				'error'   => __( 'API Key and Search Engine ID are required', 'data-machine' ),
+			);
 		}
 
 		$stored_config                  = get_site_option( 'datamachine_search_config', array() );
@@ -212,15 +223,16 @@ class GoogleSearch extends BaseTool {
 		);
 
 		if ( update_site_option( 'datamachine_search_config', $stored_config ) ) {
-			wp_send_json_success(
-				array(
-					'message'    => __( 'Google Search configuration saved successfully', 'data-machine' ),
-					'configured' => true,
-				)
+			return array(
+				'success' => true,
+				'message' => __( 'Google Search configuration saved successfully', 'data-machine' ),
 			);
-		} else {
-			wp_send_json_error( array( 'message' => __( 'Failed to save configuration', 'data-machine' ) ) );
 		}
+
+		return array(
+			'success' => false,
+			'error'   => __( 'Failed to save configuration', 'data-machine' ),
+		);
 	}
 
 	public function get_config_fields( $fields = array(), $tool_id = '' ) {

--- a/inc/Engine/AI/Tools/Global/GoogleSearchConsole.php
+++ b/inc/Engine/AI/Tools/Global/GoogleSearchConsole.php
@@ -174,50 +174,39 @@ class GoogleSearchConsole extends BaseTool {
 	 * @param string $tool_id     Tool identifier.
 	 * @param array  $config_data Configuration data.
 	 */
-	public function save_configuration( $tool_id, $config_data ) {
-		if ( 'google_search_console' !== $tool_id ) {
-			return;
-		}
+	protected function get_config_option_name(): string {
+		return GoogleSearchConsoleAbilities::CONFIG_OPTION;
+	}
 
+	protected function validate_and_build_config( array $config_data ): array {
 		$service_account_json = $config_data['service_account_json'] ?? '';
 		$site_url             = sanitize_text_field( $config_data['site_url'] ?? '' );
 
 		if ( empty( $service_account_json ) ) {
-			wp_send_json_error( array( 'message' => __( 'Service Account JSON is required', 'data-machine' ) ) );
-			return;
+			return array( 'error' => __( 'Service Account JSON is required', 'data-machine' ) );
 		}
 
-		// Validate the JSON is parseable and has required fields.
 		$parsed = json_decode( $service_account_json, true );
 
 		if ( json_last_error() !== JSON_ERROR_NONE ) {
-			wp_send_json_error( array( 'message' => __( 'Invalid JSON in Service Account field', 'data-machine' ) ) );
-			return;
+			return array( 'error' => __( 'Invalid JSON in Service Account field', 'data-machine' ) );
 		}
 
 		if ( empty( $parsed['client_email'] ) || empty( $parsed['private_key'] ) ) {
-			wp_send_json_error( array( 'message' => __( 'Service Account JSON must contain client_email and private_key', 'data-machine' ) ) );
-			return;
+			return array( 'error' => __( 'Service Account JSON must contain client_email and private_key', 'data-machine' ) );
 		}
 
-		$config = array(
-			'service_account_json' => $service_account_json,
-			'site_url'             => $site_url,
+		return array(
+			'config'  => array(
+				'service_account_json' => $service_account_json,
+				'site_url'             => $site_url,
+			),
+			'message' => __( 'Google Search Console configuration saved successfully', 'data-machine' ),
 		);
+	}
 
-		// Clear cached token when config changes.
+	protected function before_config_save( array $config_data ): void {
 		delete_transient( GoogleSearchConsoleAbilities::TOKEN_TRANSIENT );
-
-		if ( update_site_option( GoogleSearchConsoleAbilities::CONFIG_OPTION, $config ) ) {
-			wp_send_json_success(
-				array(
-					'message'    => __( 'Google Search Console configuration saved successfully', 'data-machine' ),
-					'configured' => true,
-				)
-			);
-		} else {
-			wp_send_json_error( array( 'message' => __( 'Failed to save configuration', 'data-machine' ) ) );
-		}
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/ImageGeneration.php
+++ b/inc/Engine/AI/Tools/Global/ImageGeneration.php
@@ -164,36 +164,27 @@ class ImageGeneration extends BaseTool {
 	 * @param string $tool_id     Tool identifier.
 	 * @param array  $config_data Configuration data.
 	 */
-	public function save_configuration( $tool_id, $config_data ) {
-		if ( 'image_generation' !== $tool_id ) {
-			return;
-		}
+	protected function get_config_option_name(): string {
+		return ImageGenerationAbilities::CONFIG_OPTION;
+	}
 
+	protected function validate_and_build_config( array $config_data ): array {
 		$api_key = sanitize_text_field( $config_data['api_key'] ?? '' );
 
 		if ( empty( $api_key ) ) {
-			wp_send_json_error( array( 'message' => __( 'Replicate API key is required', 'data-machine' ) ) );
-			return;
+			return array( 'error' => __( 'Replicate API key is required', 'data-machine' ) );
 		}
 
-		$config = array(
-			'api_key'                   => $api_key,
-			'default_model'             => sanitize_text_field( $config_data['default_model'] ?? ImageGenerationAbilities::DEFAULT_MODEL ),
-			'default_aspect_ratio'      => sanitize_text_field( $config_data['default_aspect_ratio'] ?? ImageGenerationAbilities::DEFAULT_ASPECT_RATIO ),
-			'prompt_refinement_enabled' => ! empty( $config_data['prompt_refinement_enabled'] ),
-			'prompt_style_guide'        => sanitize_textarea_field( $config_data['prompt_style_guide'] ?? '' ),
+		return array(
+			'config'  => array(
+				'api_key'                   => $api_key,
+				'default_model'             => sanitize_text_field( $config_data['default_model'] ?? ImageGenerationAbilities::DEFAULT_MODEL ),
+				'default_aspect_ratio'      => sanitize_text_field( $config_data['default_aspect_ratio'] ?? ImageGenerationAbilities::DEFAULT_ASPECT_RATIO ),
+				'prompt_refinement_enabled' => ! empty( $config_data['prompt_refinement_enabled'] ),
+				'prompt_style_guide'        => sanitize_textarea_field( $config_data['prompt_style_guide'] ?? '' ),
+			),
+			'message' => __( 'Image generation configuration saved successfully', 'data-machine' ),
 		);
-
-		if ( update_site_option( ImageGenerationAbilities::CONFIG_OPTION, $config ) ) {
-			wp_send_json_success(
-				array(
-					'message'    => __( 'Image generation configuration saved successfully', 'data-machine' ),
-					'configured' => true,
-				)
-			);
-		} else {
-			wp_send_json_error( array( 'message' => __( 'Failed to save configuration', 'data-machine' ) ) );
-		}
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/PageSpeed.php
+++ b/inc/Engine/AI/Tools/Global/PageSpeed.php
@@ -145,27 +145,17 @@ class PageSpeed extends BaseTool {
 	 * @param string $tool_id     Tool identifier.
 	 * @param array  $config_data Configuration data.
 	 */
-	public function save_configuration( $tool_id, $config_data ) {
-		if ( 'pagespeed' !== $tool_id ) {
-			return;
-		}
+	protected function get_config_option_name(): string {
+		return PageSpeedAbilities::CONFIG_OPTION;
+	}
 
-		$api_key = sanitize_text_field( $config_data['api_key'] ?? '' );
-
-		$config = array(
-			'api_key' => $api_key,
+	protected function validate_and_build_config( array $config_data ): array {
+		return array(
+			'config'  => array(
+				'api_key' => sanitize_text_field( $config_data['api_key'] ?? '' ),
+			),
+			'message' => __( 'PageSpeed Insights configuration saved successfully', 'data-machine' ),
 		);
-
-		if ( update_site_option( PageSpeedAbilities::CONFIG_OPTION, $config ) ) {
-			wp_send_json_success(
-				array(
-					'message'    => __( 'PageSpeed Insights configuration saved successfully', 'data-machine' ),
-					'configured' => true,
-				)
-			);
-		} else {
-			wp_send_json_error( array( 'message' => __( 'Failed to save configuration', 'data-machine' ) ) );
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Closes #535

### The bug
All 7 configurable tools called `wp_send_json_success()` / `wp_send_json_error()` inside `save_configuration()` — which **exits PHP**. The ability never returned its result array. This meant:
- REST API handler's error checking code was dead (the JSON was already sent)
- Programmatic callers (CLI, other abilities) would get their process killed
- The `datamachine_save_tool_config_ability` filter was dead code (nothing hooked into it)

### The fix

**BaseTool** now provides a base `save_configuration()` with the common pattern. Tools override two small methods:

| Method | Purpose |
|--------|---------|
| `get_config_option_name()` | Returns the `update_site_option` key |
| `validate_and_build_config($data)` | Validates input, returns `{config: [...]}` or `{error: "..."}` |
| `before_config_save($data)` | (optional) Side effects like `delete_transient()` |

**Before** (each tool, ~30 lines of duplicated boilerplate):
```php
public function save_configuration($tool_id, $config_data) {
    if ('pagespeed' !== $tool_id) return;
    // validate...
    if (update_site_option(...)) {
        wp_send_json_success([...]); // EXITS PHP
    } else {
        wp_send_json_error([...]);   // EXITS PHP
    }
}
```

**After** (each tool, ~10 lines of unique logic):
```php
protected function get_config_option_name(): string {
    return PageSpeedAbilities::CONFIG_OPTION;
}

protected function validate_and_build_config(array $data): array {
    return ['config' => ['api_key' => sanitize_text_field($data['api_key'] ?? '')]];
}
```

### Tools refactored (7)
- **PageSpeed** — simplest, just api_key
- **BingWebmaster** — api_key + site_url, required validation
- **ImageGeneration** — api_key required + 4 optional fields
- **GoogleAnalytics** — service account JSON validation + transient clear
- **GoogleSearchConsole** — same pattern as GA
- **AmazonAffiliateLink** — marketplace validation + transient clear
- **GoogleSearch** — overrides `save_configuration()` directly (nested key in shared option)

### Also removed
- Dead `datamachine_save_tool_config_ability` filter (nothing hooked into it)
- Changed `datamachine_save_tool_config` from action to filter so results flow back properly