### PR TITLE
feat: GA4 CLI batch — new actions, sorting, hostname filter, period comparison

### DIFF
--- a/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
+++ b/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
@@ -87,6 +87,18 @@ class GoogleAnalyticsAbilities {
 			'dimensions' => array( 'country', 'deviceCategory' ),
 			'metrics'    => array( 'sessions', 'activeUsers', 'screenPageViews' ),
 		),
+		'landing_pages'     => array(
+			'dimensions' => array( 'landingPage' ),
+			'metrics'    => array( 'sessions', 'activeUsers', 'bounceRate', 'averageSessionDuration', 'engagementRate' ),
+		),
+		'engagement'        => array(
+			'dimensions' => array( 'pagePath', 'pageTitle' ),
+			'metrics'    => array( 'engagementRate', 'averageSessionDuration', 'engagedSessions', 'sessionsPerUser', 'screenPageViewsPerSession', 'userEngagementDuration' ),
+		),
+		'new_vs_returning'  => array(
+			'dimensions' => array( 'newVsReturning' ),
+			'metrics'    => array( 'sessions', 'activeUsers', 'engagementRate', 'screenPageViewsPerSession', 'averageSessionDuration' ),
+		),
 	);
 
 	private static bool $registered = false;
@@ -118,7 +130,7 @@ class GoogleAnalyticsAbilities {
 						'properties' => array(
 							'action'      => array(
 								'type'        => 'string',
-								'description' => 'Action to perform: page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics.',
+								'description' => 'Action to perform: page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics, landing_pages, engagement, new_vs_returning.',
 							),
 							'property_id' => array(
 								'type'        => 'string',
@@ -139,6 +151,22 @@ class GoogleAnalyticsAbilities {
 							'page_filter' => array(
 								'type'        => 'string',
 								'description' => 'Filter results to pages with paths containing this string.',
+							),
+							'hostname'    => array(
+								'type'        => 'string',
+								'description' => 'Filter to pages on this hostname (for multisite GA4 properties).',
+							),
+							'sort_by'     => array(
+								'type'        => 'string',
+								'description' => 'Sort results by this metric or dimension field name.',
+							),
+							'order'       => array(
+								'type'        => 'string',
+								'description' => 'Sort direction: asc or desc (default: desc).',
+							),
+							'compare'     => array(
+								'type'        => 'boolean',
+								'description' => 'Compare against the previous period of equal length. Adds delta columns.',
 							),
 						),
 					),
@@ -242,6 +270,7 @@ class GoogleAnalyticsAbilities {
 		$start_date = ! empty( $input['start_date'] ) ? sanitize_text_field( $input['start_date'] ) : gmdate( 'Y-m-d', strtotime( '-28 days' ) );
 		$end_date   = ! empty( $input['end_date'] ) ? sanitize_text_field( $input['end_date'] ) : gmdate( 'Y-m-d', strtotime( '-1 day' ) );
 		$limit      = ! empty( $input['limit'] ) ? min( (int) $input['limit'], self::MAX_LIMIT ) : self::DEFAULT_LIMIT;
+		$compare    = ! empty( $input['compare'] );
 
 		$dimensions = array_map(
 			function ( $dim ) {
@@ -257,29 +286,104 @@ class GoogleAnalyticsAbilities {
 			$report_config['metrics']
 		);
 
-		$request_body = array(
-			'dateRanges' => array(
-				array(
-					'startDate' => $start_date,
-					'endDate'   => $end_date,
-				),
+		// Build date ranges — add comparison period if requested.
+		$date_ranges = array(
+			array(
+				'startDate' => $start_date,
+				'endDate'   => $end_date,
 			),
+		);
+
+		if ( $compare ) {
+			$period_length    = (int) ( ( strtotime( $end_date ) - strtotime( $start_date ) ) / 86400 );
+			$compare_end_ts   = strtotime( $start_date ) - 86400;
+			$compare_start_ts = $compare_end_ts - ( $period_length * 86400 );
+			$date_ranges[]    = array(
+				'startDate' => gmdate( 'Y-m-d', $compare_start_ts ),
+				'endDate'   => gmdate( 'Y-m-d', $compare_end_ts ),
+			);
+		}
+
+		$request_body = array(
+			'dateRanges' => $date_ranges,
 			'dimensions' => $dimensions,
 			'metrics'    => $metrics,
 			'limit'      => $limit,
 		);
 
-		// Build dimension filter if page_filter provided and action includes pagePath.
-		if ( ! empty( $input['page_filter'] ) && in_array( 'pagePath', $report_config['dimensions'], true ) ) {
-			$request_body['dimensionFilter'] = array(
+		// Build dimension filters.
+		$filters = array();
+
+		// Page path filter (for actions with pagePath or landingPage dimension).
+		if ( ! empty( $input['page_filter'] ) ) {
+			$path_dim = null;
+			if ( in_array( 'pagePath', $report_config['dimensions'], true ) ) {
+				$path_dim = 'pagePath';
+			} elseif ( in_array( 'landingPage', $report_config['dimensions'], true ) ) {
+				$path_dim = 'landingPage';
+			}
+
+			if ( $path_dim ) {
+				$filters[] = array(
+					'filter' => array(
+						'fieldName'    => $path_dim,
+						'stringFilter' => array(
+							'matchType' => 'CONTAINS',
+							'value'     => sanitize_text_field( $input['page_filter'] ),
+						),
+					),
+				);
+			}
+		}
+
+		// Hostname filter for multisite properties.
+		if ( ! empty( $input['hostname'] ) ) {
+			$filters[] = array(
 				'filter' => array(
-					'fieldName'    => 'pagePath',
+					'fieldName'    => 'hostName',
 					'stringFilter' => array(
-						'matchType' => 'CONTAINS',
-						'value'     => sanitize_text_field( $input['page_filter'] ),
+						'matchType' => 'EXACT',
+						'value'     => sanitize_text_field( $input['hostname'] ),
 					),
 				),
 			);
+		}
+
+		if ( count( $filters ) === 1 ) {
+			$request_body['dimensionFilter'] = $filters[0];
+		} elseif ( count( $filters ) > 1 ) {
+			$request_body['dimensionFilter'] = array(
+				'andGroup' => array(
+					'expressions' => $filters,
+				),
+			);
+		}
+
+		// Sort order.
+		if ( ! empty( $input['sort_by'] ) ) {
+			$sort_field  = sanitize_text_field( $input['sort_by'] );
+			$sort_order  = 'asc' === strtolower( $input['order'] ?? 'desc' ) ? 'ASCENDING' : 'DESCENDING';
+			$all_metrics = $report_config['metrics'];
+			$all_dims    = $report_config['dimensions'];
+
+			if ( in_array( $sort_field, $all_metrics, true ) ) {
+				$request_body['orderBys'] = array(
+					array(
+						'metric' => array( 'metricName' => $sort_field ),
+						'desc'   => 'DESCENDING' === $sort_order,
+					),
+				);
+			} elseif ( in_array( $sort_field, $all_dims, true ) ) {
+				$request_body['orderBys'] = array(
+					array(
+						'dimension' => array(
+							'dimensionName' => $sort_field,
+							'orderType'     => 'ALPHANUMERIC',
+						),
+						'desc'      => 'DESCENDING' === $sort_order,
+					),
+				);
+			}
 		}
 
 		$api_url = self::API_BASE . $property_id . ':runReport';
@@ -321,9 +425,11 @@ class GoogleAnalyticsAbilities {
 			);
 		}
 
-		$rows = self::formatReportRows( $data, $report_config );
+		$rows = $compare
+			? self::formatComparisonRows( $data, $report_config )
+			: self::formatReportRows( $data, $report_config );
 
-		return array(
+		$response = array(
 			'success'       => true,
 			'action'        => $action,
 			'date_range'    => array(
@@ -333,6 +439,15 @@ class GoogleAnalyticsAbilities {
 			'results_count' => count( $rows ),
 			'results'       => $rows,
 		);
+
+		if ( $compare ) {
+			$response['compare_date_range'] = array(
+				'start_date' => $date_ranges[1]['startDate'],
+				'end_date'   => $date_ranges[1]['endDate'],
+			);
+		}
+
+		return $response;
 	}
 
 	/**
@@ -455,6 +570,69 @@ class GoogleAnalyticsAbilities {
 					$formatted[ $name ] = strpos( $value, '.' ) !== false ? (float) $value : (int) $value;
 				} else {
 					$formatted[ $name ] = $value;
+				}
+			}
+
+			$rows[] = $formatted;
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Format GA4 comparison rows with delta columns.
+	 *
+	 * When two date ranges are used, the API returns rows with metricValues
+	 * containing values for each date range. This interleaves current and
+	 * previous values, then computes percentage deltas.
+	 *
+	 * @param array $data          Raw GA4 API response.
+	 * @param array $report_config Report configuration.
+	 * @return array Formatted rows with delta columns.
+	 */
+	private static function formatComparisonRows( array $data, array $report_config ): array {
+		$dimension_headers = wp_list_pluck( $data['dimensionHeaders'] ?? array(), 'name' );
+		$metric_headers    = wp_list_pluck( $data['metricHeaders'] ?? array(), 'name' );
+		$metric_count      = count( $metric_headers );
+
+		$rows = array();
+
+		foreach ( ( $data['rows'] ?? array() ) as $row ) {
+			$dim_values    = wp_list_pluck( $row['dimensionValues'] ?? array(), 'value' );
+			$metric_values = wp_list_pluck( $row['metricValues'] ?? array(), 'value' );
+
+			$formatted = array();
+			foreach ( $dimension_headers as $i => $name ) {
+				// Skip the dateRange dimension GA4 adds for multi-range requests.
+				if ( 'dateRange' === $name ) {
+					continue;
+				}
+				$formatted[ $name ] = $dim_values[ $i ] ?? '';
+			}
+
+			// GA4 returns metric values as [current_m1, current_m2, ..., previous_m1, previous_m2, ...].
+			for ( $i = 0; $i < $metric_count; $i++ ) {
+				$name     = $metric_headers[ $i ];
+				$current  = $metric_values[ $i ] ?? '0';
+				$previous = $metric_values[ $i + $metric_count ] ?? '0';
+
+				$current_num  = is_numeric( $current ) ? (float) $current : 0;
+				$previous_num = is_numeric( $previous ) ? (float) $previous : 0;
+
+				// Format current value.
+				if ( is_numeric( $current ) ) {
+					$formatted[ $name ] = strpos( $current, '.' ) !== false ? (float) $current : (int) $current;
+				} else {
+					$formatted[ $name ] = $current;
+				}
+
+				// Compute delta percentage.
+				if ( 0.0 !== $previous_num ) {
+					$delta = ( ( $current_num - $previous_num ) / $previous_num ) * 100;
+					$sign  = $delta >= 0 ? '+' : '';
+					$formatted[ "\xCE\x94 " . $name ] = $sign . round( $delta, 1 ) . '%';
+				} else {
+					$formatted[ "\xCE\x94 " . $name ] = $current_num > 0 ? 'new' : '-';
 				}
 			}
 

--- a/inc/Cli/Commands/AnalyticsCommand.php
+++ b/inc/Cli/Commands/AnalyticsCommand.php
@@ -152,7 +152,7 @@ class AnalyticsCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * <action>
-	 * : Action to perform: page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics.
+	 * : Action to perform: page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics, landing_pages, engagement, new_vs_returning.
 	 *
 	 * [--start-date=<date>]
 	 * : Start date in YYYY-MM-DD format (default: 28 days ago). Not used for realtime.
@@ -165,6 +165,18 @@ class AnalyticsCommand extends BaseCommand {
 	 *
 	 * [--page-filter=<string>]
 	 * : Filter results to pages with paths containing this string.
+	 *
+	 * [--hostname=<string>]
+	 * : Filter to pages on this hostname (for multisite GA4 properties).
+	 *
+	 * [--sort-by=<field>]
+	 * : Sort results by this metric or dimension field name.
+	 *
+	 * [--order=<direction>]
+	 * : Sort direction: asc or desc (default: desc).
+	 *
+	 * [--compare]
+	 * : Compare against the previous period of equal length. Adds delta columns.
 	 *
 	 * [--format=<format>]
 	 * : Output format.
@@ -193,6 +205,24 @@ class AnalyticsCommand extends BaseCommand {
 	 *     # Top events
 	 *     wp datamachine analytics ga top_events
 	 *
+	 *     # Landing pages with highest engagement
+	 *     wp datamachine analytics ga landing_pages --sort-by=engagementRate --order=desc
+	 *
+	 *     # Engagement metrics for specific section
+	 *     wp datamachine analytics ga engagement --page-filter=/blog/
+	 *
+	 *     # New vs returning users
+	 *     wp datamachine analytics ga new_vs_returning
+	 *
+	 *     # Filter by hostname for multisite
+	 *     wp datamachine analytics ga page_stats --hostname=events.extrachill.com
+	 *
+	 *     # Compare last 28 days vs previous 28 days
+	 *     wp datamachine analytics ga page_stats --compare
+	 *
+	 *     # Sort by bounce rate ascending (worst engagement)
+	 *     wp datamachine analytics ga page_stats --sort-by=bounceRate --order=asc --limit=10
+	 *
 	 * @subcommand ga
 	 */
 	public function ga( array $args, array $assoc_args ): void {
@@ -205,7 +235,15 @@ class AnalyticsCommand extends BaseCommand {
 			'end-date'    => 'end_date',
 			'limit'       => 'limit',
 			'page-filter' => 'page_filter',
+			'hostname'    => 'hostname',
+			'sort-by'     => 'sort_by',
+			'order'       => 'order',
 		) );
+
+		// --compare is a boolean flag (no value).
+		if ( isset( $assoc_args['compare'] ) ) {
+			$input['compare'] = true;
+		}
 
 		$this->execute_ability( 'datamachine/google-analytics', $input, $assoc_args );
 	}

--- a/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
+++ b/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
@@ -69,13 +69,13 @@ class GoogleAnalytics extends BaseTool {
 		return array(
 			'class'           => __CLASS__,
 			'method'          => 'handle_tool_call',
-			'description'     => 'Fetch visitor analytics from Google Analytics (GA4). Get page performance metrics, traffic sources, daily trends, real-time active users, top events, and user demographics. Use to analyze site traffic, identify popular content, understand visitor behavior, and spot trends.',
+			'description'     => 'Fetch visitor analytics from Google Analytics (GA4). Get page performance metrics, traffic sources, daily trends, real-time active users, top events, user demographics, landing pages, engagement metrics, and new-vs-returning user breakdown. Supports sorting, hostname filtering for multisite, and period-over-period comparison.',
 			'requires_config' => true,
 			'parameters'      => array(
 				'action'      => array(
 					'type'        => 'string',
 					'required'    => true,
-					'description' => 'Action to perform: page_stats (per-page views, sessions, bounce rate), traffic_sources (where visitors come from), date_stats (daily trends over time), realtime (active users right now), top_events (most triggered events), user_demographics (visitor country and device breakdown).',
+					'description' => 'Action to perform: page_stats (per-page views, sessions, bounce rate), traffic_sources (where visitors come from), date_stats (daily trends over time), realtime (active users right now), top_events (most triggered events), user_demographics (visitor country and device breakdown), landing_pages (entry pages with session metrics), engagement (engagement rate, session quality, pages/session), new_vs_returning (new vs returning user comparison).',
 				),
 				'property_id' => array(
 					'type'        => 'string',
@@ -101,6 +101,26 @@ class GoogleAnalytics extends BaseTool {
 					'type'        => 'string',
 					'required'    => false,
 					'description' => 'Filter results to pages with paths containing this string.',
+				),
+				'hostname'    => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Filter to pages on this hostname (for multisite GA4 properties).',
+				),
+				'sort_by'     => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Sort results by this metric or dimension field name (e.g. bounceRate, sessions, engagementRate).',
+				),
+				'order'       => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Sort direction: asc or desc (default: desc).',
+				),
+				'compare'     => array(
+					'type'        => 'boolean',
+					'required'    => false,
+					'description' => 'Compare against the previous period of equal length. Adds delta percentage columns.',
 				),
 			),
 		);


### PR DESCRIPTION
## Summary

Batch implementation of 6 GA4 CLI issues (#538, #539, #540, #546, #547, #548). All follow the same pattern — extending the existing abilities-first architecture with new actions, flags, and API parameters.

## Changes

### New Actions (#540, #546, #547)
- **`landing_pages`** — entry pages with sessions, activeUsers, bounceRate, averageSessionDuration, engagementRate
- **`engagement`** — per-page engagement rate, engaged sessions, sessions/user, pages/session, engagement duration
- **`new_vs_returning`** — new vs returning user breakdown with engagement comparison

### New Flags (#538, #539, #548)
- **`--sort-by=<field>`** — sort by any metric or dimension (uses GA4 API `orderBys`)
- **`--order=<direction>`** — asc or desc (default: desc)
- **`--hostname=<string>`** — filter by hostname for multisite GA4 properties (EXACT match on `hostName` dimension)
- **`--compare`** — compare against previous period of equal length, adds Δ delta columns with percentage change

### Implementation Details
- `page_filter` now also works with `landingPage` dimension (not just `pagePath`)
- Multiple dimension filters compose via `andGroup` (e.g. hostname + page_filter together)
- `--compare` uses GA4's native dual `dateRanges` in a single API call — no double requests
- Delta formatting shows `+8.2%` / `-3.1%` / `new` / `-` for comparison columns
- Sort validates field name against the action's configured metrics/dimensions before sending
- All 3 layers updated: Ability (business logic), CLI (command flags), AI Tool (agent parameters)

## Files Changed
- `inc/Abilities/Analytics/GoogleAnalyticsAbilities.php` — core logic
- `inc/Cli/Commands/AnalyticsCommand.php` — CLI flags and docblocks
- `inc/Engine/AI/Tools/Global/GoogleAnalytics.php` — AI tool parameters

Closes #538, #539, #540, #546, #547, #548