### PR TITLE
Add IndexNow integration for instant search engine notification

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -133,6 +133,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/Media/AltTextAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/ImageGenerationAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/SEO/MetaDescriptionAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/SEO/IndexNowAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/ImageTemplateAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Analytics/BingWebmasterAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php';
@@ -179,6 +180,7 @@ function datamachine_run_datamachine_plugin() {
 		new \DataMachine\Abilities\Media\AltTextAbilities();
 		new \DataMachine\Abilities\Media\ImageGenerationAbilities();
 		new \DataMachine\Abilities\SEO\MetaDescriptionAbilities();
+		new \DataMachine\Abilities\SEO\IndexNowAbilities();
 		new \DataMachine\Abilities\Media\ImageTemplateAbilities();
 		new \DataMachine\Abilities\Analytics\BingWebmasterAbilities();
 		new \DataMachine\Abilities\Analytics\GoogleAnalyticsAbilities();

--- a/inc/Abilities/SEO/IndexNowAbilities.php
+++ b/inc/Abilities/SEO/IndexNowAbilities.php
@@ -1,0 +1,619 @@
+<?php
+/**
+ * IndexNow Abilities
+ *
+ * Instant search engine notification when content changes.
+ * Supports Bing, Yandex, DuckDuckGo, and any IndexNow-compatible engine.
+ *
+ * Provides:
+ * - Auto-ping on post publish/update via transition_post_status
+ * - Manual URL submission via abilities and CLI
+ * - Batch submission (up to 10,000 URLs per request)
+ * - API key management with auto-generation
+ * - Key file verification endpoint
+ *
+ * Settings (in datamachine_settings):
+ * - indexnow_enabled  (bool)   Enable/disable auto-ping on publish
+ * - indexnow_api_key  (string) API key (auto-generated UUID if empty)
+ *
+ * @package DataMachine\Abilities\SEO
+ * @since 0.36.0
+ */
+
+namespace DataMachine\Abilities\SEO;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+use DataMachine\Core\PluginSettings;
+
+defined( 'ABSPATH' ) || exit;
+
+class IndexNowAbilities {
+
+	/**
+	 * IndexNow API endpoint.
+	 *
+	 * @var string
+	 */
+	const API_ENDPOINT = 'https://api.indexnow.org/indexnow';
+
+	/**
+	 * Maximum URLs per batch submission.
+	 *
+	 * @var int
+	 */
+	const MAX_BATCH_SIZE = 10000;
+
+	/**
+	 * Whether the abilities have been registered.
+	 *
+	 * @var bool
+	 */
+	private static bool $registered = false;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
+			$this->register_hooks();
+			self::$registered = true;
+			return;
+		}
+
+		$this->registerAbilities();
+		$this->register_hooks();
+		self::$registered = true;
+	}
+
+	/**
+	 * Register WordPress hooks for auto-ping and key file serving.
+	 *
+	 * @return void
+	 */
+	private function register_hooks(): void {
+		add_action( 'wp_after_insert_post', array( __CLASS__, 'on_post_saved' ), 10, 4 );
+		add_action( 'parse_request', array( __CLASS__, 'serve_key_file' ) );
+	}
+
+	// =========================================================================
+	// WordPress Hooks
+	// =========================================================================
+
+	/**
+	 * Auto-submit URL to IndexNow when a post is published or updated.
+	 *
+	 * Uses wp_after_insert_post (since WP 5.6) which fires after the post,
+	 * its terms, and its meta are fully saved. This is the recommended hook
+	 * for post-publish side effects per WordPress core docs.
+	 *
+	 * @param int           $post_id     Post ID.
+	 * @param \WP_Post      $post        Post object after changes.
+	 * @param bool          $update      Whether this is an update.
+	 * @param \WP_Post|null $post_before Post object before changes, or null if new.
+	 * @return void
+	 */
+	public static function on_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Post $post_before = null ): void {
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+
+		if ( ! PluginSettings::get( 'indexnow_enabled', false ) ) {
+			return;
+		}
+
+		$post_type_obj = get_post_type_object( $post->post_type );
+		if ( ! $post_type_obj || ! $post_type_obj->public ) {
+			return;
+		}
+
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
+
+		$url = get_permalink( $post_id );
+		if ( empty( $url ) ) {
+			return;
+		}
+
+		$old_status = $post_before ? $post_before->post_status : 'new';
+
+		$result = self::submit_urls( array( $url ) );
+
+		$log_level = $result['success'] ? 'debug' : 'warning';
+		$log_msg   = $result['success']
+			? 'IndexNow: Submitted URL on publish'
+			: 'IndexNow: Failed to submit URL on publish';
+
+		do_action(
+			'datamachine_log',
+			$log_level,
+			$log_msg,
+			array(
+				'url'         => $url,
+				'post_id'     => $post_id,
+				'post_type'   => $post->post_type,
+				'old_status'  => $old_status,
+				'response'    => $result['message'] ?? $result['error'] ?? '',
+				'status_code' => $result['status_code'] ?? '',
+			)
+		);
+	}
+
+	/**
+	 * Serve the IndexNow key verification file.
+	 *
+	 * Hooks into parse_request to intercept requests for /{key}.txt
+	 * before WordPress processes them as 404s. No rewrite rules needed.
+	 *
+	 * @param \WP $wp WordPress request object.
+	 * @return void
+	 */
+	public static function serve_key_file( \WP $wp ): void {
+		$api_key = self::get_api_key();
+		if ( empty( $api_key ) ) {
+			return;
+		}
+
+		$request = trim( $wp->request, '/' );
+		if ( $request !== $api_key . '.txt' ) {
+			return;
+		}
+
+		header( 'Content-Type: text/plain; charset=utf-8' );
+		header( 'X-Robots-Tag: noindex' );
+		header( 'Cache-Control: public, max-age=86400' );
+		status_header( 200 );
+		echo esc_html( $api_key );
+		exit;
+	}
+
+	// =========================================================================
+	// Core Logic
+	// =========================================================================
+
+	/**
+	 * Submit one or more URLs to IndexNow.
+	 *
+	 * Uses the batch endpoint when multiple URLs are provided.
+	 * Automatically gets or generates the API key.
+	 *
+	 * @param array $urls Array of full URLs to submit.
+	 * @return array Result with success, message, status_code keys.
+	 */
+	public static function submit_urls( array $urls ): array {
+		if ( empty( $urls ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No URLs provided',
+			);
+		}
+
+		$api_key = self::get_or_generate_key();
+		if ( empty( $api_key ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Could not generate IndexNow API key',
+			);
+		}
+
+		$urls = array_values( array_unique( array_filter( $urls ) ) );
+		if ( count( $urls ) > self::MAX_BATCH_SIZE ) {
+			$urls = array_slice( $urls, 0, self::MAX_BATCH_SIZE );
+		}
+
+		$parsed = wp_parse_url( $urls[0] );
+		$host   = $parsed['host'] ?? wp_parse_url( home_url(), PHP_URL_HOST );
+
+		$body = array(
+			'host'        => $host,
+			'key'         => $api_key,
+			'keyLocation' => home_url( '/' . $api_key . '.txt' ),
+			'urlList'     => $urls,
+		);
+
+		$result = HttpClient::post(
+			self::API_ENDPOINT,
+			array(
+				'headers' => array( 'Content-Type' => 'application/json; charset=utf-8' ),
+				'body'    => wp_json_encode( $body ),
+				'timeout' => 30,
+				'context' => 'IndexNow Submission',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success'     => false,
+				'error'       => $result['error'] ?? 'HTTP request failed',
+				'status_code' => $result['status_code'] ?? 0,
+			);
+		}
+
+		$status_code = $result['status_code'] ?? 0;
+
+		// IndexNow returns:
+		// 200 = URL submitted successfully
+		// 202 = URL received, will be processed later
+		// 400 = Invalid request
+		// 403 = Key not valid
+		// 422 = URL doesn't belong to host
+		// 429 = Too many requests
+		$success_codes = array( 200, 202 );
+
+		if ( in_array( $status_code, $success_codes, true ) ) {
+			return array(
+				'success'     => true,
+				'message'     => 200 === $status_code ? 'URL submitted and accepted' : 'URL received, will be processed',
+				'status_code' => $status_code,
+				'url_count'   => count( $urls ),
+			);
+		}
+
+		$error_messages = array(
+			400 => 'Invalid request — check URL format',
+			403 => 'API key not valid — verify key file is accessible',
+			422 => 'URL does not belong to the host',
+			429 => 'Too many requests — rate limited',
+		);
+
+		return array(
+			'success'     => false,
+			'error'       => $error_messages[ $status_code ] ?? 'Unexpected response code: ' . $status_code,
+			'status_code' => $status_code,
+		);
+	}
+
+	/**
+	 * Get the IndexNow API key from settings.
+	 *
+	 * @return string API key or empty string.
+	 */
+	public static function get_api_key(): string {
+		return PluginSettings::get( 'indexnow_api_key', '' );
+	}
+
+	/**
+	 * Get existing API key or generate a new one.
+	 *
+	 * @return string API key.
+	 */
+	public static function get_or_generate_key(): string {
+		$key = self::get_api_key();
+
+		if ( ! empty( $key ) ) {
+			return $key;
+		}
+
+		return self::generate_key();
+	}
+
+	/**
+	 * Generate a new IndexNow API key and save it.
+	 *
+	 * Key format: 32-character hex string (like a UUID without hyphens).
+	 * IndexNow requires keys to be at least 8 characters, alphanumeric + dashes.
+	 *
+	 * @return string Generated key.
+	 */
+	public static function generate_key(): string {
+		$key = wp_generate_uuid4();
+		$key = str_replace( '-', '', $key );
+
+		$settings = get_option( 'datamachine_settings', array() );
+		$settings['indexnow_api_key'] = $key;
+		update_option( 'datamachine_settings', $settings );
+
+		PluginSettings::clearCache();
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'IndexNow: Generated new API key',
+			array( 'key_preview' => substr( $key, 0, 8 ) . '...' )
+		);
+
+		return $key;
+	}
+
+	/**
+	 * Verify that the key file is accessible at the expected URL.
+	 *
+	 * @return array Result with success, url, and message keys.
+	 */
+	public static function verify_key_file(): array {
+		$api_key = self::get_api_key();
+
+		if ( empty( $api_key ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No API key configured. Generate one first.',
+			);
+		}
+
+		$key_url = home_url( '/' . $api_key . '.txt' );
+		$result  = HttpClient::get(
+			$key_url,
+			array(
+				'timeout' => 10,
+				'context' => 'IndexNow Key Verification',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'url'     => $key_url,
+				'error'   => 'Key file not accessible: ' . ( $result['error'] ?? 'unknown error' ),
+			);
+		}
+
+		$body = trim( $result['data'] ?? '' );
+
+		if ( $body !== $api_key ) {
+			return array(
+				'success' => false,
+				'url'     => $key_url,
+				'error'   => 'Key file content does not match API key',
+			);
+		}
+
+		return array(
+			'success' => true,
+			'url'     => $key_url,
+			'message' => 'Key file verified successfully',
+		);
+	}
+
+	/**
+	 * Get IndexNow status including enabled state, key, and verification.
+	 *
+	 * @return array Status information.
+	 */
+	public static function get_status(): array {
+		$enabled = PluginSettings::get( 'indexnow_enabled', false );
+		$api_key = self::get_api_key();
+
+		return array(
+			'enabled'      => (bool) $enabled,
+			'has_key'      => ! empty( $api_key ),
+			'key_preview'  => ! empty( $api_key ) ? substr( $api_key, 0, 8 ) . '...' : '',
+			'key_file_url' => ! empty( $api_key ) ? home_url( '/' . $api_key . '.txt' ) : '',
+			'endpoint'     => self::API_ENDPOINT,
+		);
+	}
+
+	// =========================================================================
+	// Abilities Registration
+	// =========================================================================
+
+	/**
+	 * Register all IndexNow abilities.
+	 *
+	 * @return void
+	 */
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			$this->registerSubmitAbility();
+			$this->registerStatusAbility();
+			$this->registerGenerateKeyAbility();
+			$this->registerVerifyKeyAbility();
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Register the submit URL(s) ability.
+	 *
+	 * @return void
+	 */
+	private function registerSubmitAbility(): void {
+		wp_register_ability(
+			'datamachine/indexnow-submit',
+			array(
+				'label'               => __( 'IndexNow Submit', 'data-machine' ),
+				'description'         => __( 'Submit one or more URLs to IndexNow for instant search engine indexing.', 'data-machine' ),
+				'category'            => 'datamachine',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'urls' ),
+					'properties' => array(
+						'urls' => array(
+							'type'        => 'array',
+							'description' => __( 'Array of full URLs to submit', 'data-machine' ),
+							'items'       => array( 'type' => 'string' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'message'     => array( 'type' => 'string' ),
+						'url_count'   => array( 'type' => 'integer' ),
+						'status_code' => array( 'type' => 'integer' ),
+						'error'       => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeSubmit' ),
+				'permission_callback' => fn() => PermissionHelper::can_manage(),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Register the status ability.
+	 *
+	 * @return void
+	 */
+	private function registerStatusAbility(): void {
+		wp_register_ability(
+			'datamachine/indexnow-status',
+			array(
+				'label'               => __( 'IndexNow Status', 'data-machine' ),
+				'description'         => __( 'Get IndexNow integration status including enabled state and API key.', 'data-machine' ),
+				'category'            => 'datamachine',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'enabled'      => array( 'type' => 'boolean' ),
+						'has_key'      => array( 'type' => 'boolean' ),
+						'key_preview'  => array( 'type' => 'string' ),
+						'key_file_url' => array( 'type' => 'string' ),
+						'endpoint'     => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeStatus' ),
+				'permission_callback' => fn() => PermissionHelper::can_manage(),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Register the generate key ability.
+	 *
+	 * @return void
+	 */
+	private function registerGenerateKeyAbility(): void {
+		wp_register_ability(
+			'datamachine/indexnow-generate-key',
+			array(
+				'label'               => __( 'IndexNow Generate Key', 'data-machine' ),
+				'description'         => __( 'Generate a new IndexNow API key and save it to settings.', 'data-machine' ),
+				'category'            => 'datamachine',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'key_preview'  => array( 'type' => 'string' ),
+						'key_file_url' => array( 'type' => 'string' ),
+						'message'      => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeGenerateKey' ),
+				'permission_callback' => fn() => PermissionHelper::can_manage(),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Register the verify key ability.
+	 *
+	 * @return void
+	 */
+	private function registerVerifyKeyAbility(): void {
+		wp_register_ability(
+			'datamachine/indexnow-verify-key',
+			array(
+				'label'               => __( 'IndexNow Verify Key', 'data-machine' ),
+				'description'         => __( 'Verify that the IndexNow key file is accessible and correct.', 'data-machine' ),
+				'category'            => 'datamachine',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success' => array( 'type' => 'boolean' ),
+						'url'     => array( 'type' => 'string' ),
+						'message' => array( 'type' => 'string' ),
+						'error'   => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeVerifyKey' ),
+				'permission_callback' => fn() => PermissionHelper::can_manage(),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	// =========================================================================
+	// Ability Executors
+	// =========================================================================
+
+	/**
+	 * Execute submit ability.
+	 *
+	 * @param array $input Input with 'urls' array.
+	 * @return array Result.
+	 */
+	public function executeSubmit( array $input ): array {
+		$urls = $input['urls'] ?? array();
+
+		if ( empty( $urls ) || ! is_array( $urls ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'urls parameter is required and must be a non-empty array',
+			);
+		}
+
+		$urls = array_map( 'esc_url_raw', $urls );
+		$urls = array_filter( $urls );
+
+		if ( empty( $urls ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No valid URLs after sanitization',
+			);
+		}
+
+		return self::submit_urls( $urls );
+	}
+
+	/**
+	 * Execute status ability.
+	 *
+	 * @param array $input Input (unused).
+	 * @return array Status information.
+	 */
+	public function executeStatus( array $input ): array {
+		$status            = self::get_status();
+		$status['success'] = true;
+		return $status;
+	}
+
+	/**
+	 * Execute generate key ability.
+	 *
+	 * @param array $input Input (unused).
+	 * @return array Result with key preview.
+	 */
+	public function executeGenerateKey( array $input ): array {
+		$key = self::generate_key();
+
+		return array(
+			'success'      => true,
+			'key_preview'  => substr( $key, 0, 8 ) . '...',
+			'key_file_url' => home_url( '/' . $key . '.txt' ),
+			'message'      => 'New IndexNow API key generated',
+		);
+	}
+
+	/**
+	 * Execute verify key ability.
+	 *
+	 * @param array $input Input (unused).
+	 * @return array Verification result.
+	 */
+	public function executeVerifyKey( array $input ): array {
+		return self::verify_key_file();
+	}
+}

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -47,3 +47,4 @@ WP_CLI::add_command( 'datamachine blocks', Commands\BlocksCommand::class );
 WP_CLI::add_command( 'datamachine block', Commands\BlocksCommand::class );
 WP_CLI::add_command( 'datamachine analytics', Commands\AnalyticsCommand::class );
 WP_CLI::add_command( 'datamachine meta-description', Commands\MetaDescriptionCommand::class );
+WP_CLI::add_command( 'datamachine indexnow', Commands\IndexNowCommand::class );

--- a/inc/Cli/Commands/IndexNowCommand.php
+++ b/inc/Cli/Commands/IndexNowCommand.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * IndexNow CLI Command
+ *
+ * Submit URLs to IndexNow, manage API keys, and check integration status.
+ *
+ * @package DataMachine\Cli\Commands
+ * @since 0.36.0
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Abilities\SEO\IndexNowAbilities;
+use DataMachine\Core\PluginSettings;
+
+class IndexNowCommand extends BaseCommand {
+
+	/**
+	 * Submit one or more URLs to IndexNow for instant search engine indexing.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<url>...]
+	 * : One or more URLs to submit.
+	 *
+	 * [--post-id=<id>]
+	 * : Submit the permalink for a WordPress post ID.
+	 *
+	 * [--post-type=<type>]
+	 * : Submit all published posts of this type.
+	 *
+	 * [--limit=<number>]
+	 * : Limit the number of URLs when using --post-type. Default 100.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Submit a single URL
+	 *     wp datamachine indexnow submit https://example.com/my-post/
+	 *
+	 *     # Submit multiple URLs
+	 *     wp datamachine indexnow submit https://example.com/post-1/ https://example.com/post-2/
+	 *
+	 *     # Submit by post ID
+	 *     wp datamachine indexnow submit --post-id=42
+	 *
+	 *     # Submit all published events
+	 *     wp datamachine indexnow submit --post-type=event --limit=50
+	 *
+	 * @subcommand submit
+	 */
+	public function submit( array $args, array $assoc_args ): void {
+		$urls = array();
+
+		$post_id   = $assoc_args['post-id'] ?? null;
+		$post_type = $assoc_args['post-type'] ?? null;
+		$limit     = intval( $assoc_args['limit'] ?? 100 );
+
+		if ( $post_id ) {
+			$url = get_permalink( intval( $post_id ) );
+			if ( ! $url ) {
+				WP_CLI::error( "Could not get permalink for post ID {$post_id}" );
+			}
+			$urls[] = $url;
+		} elseif ( $post_type ) {
+			$posts = get_posts(
+				array(
+					'post_type'      => $post_type,
+					'post_status'    => 'publish',
+					'posts_per_page' => min( $limit, IndexNowAbilities::MAX_BATCH_SIZE ),
+					'fields'         => 'ids',
+				)
+			);
+
+			if ( empty( $posts ) ) {
+				WP_CLI::error( "No published posts found for post type '{$post_type}'" );
+			}
+
+			foreach ( $posts as $pid ) {
+				$url = get_permalink( $pid );
+				if ( $url ) {
+					$urls[] = $url;
+				}
+			}
+		} else {
+			$urls = $args;
+		}
+
+		if ( empty( $urls ) ) {
+			WP_CLI::error( 'No URLs provided. Pass URLs as arguments, or use --post-id or --post-type.' );
+		}
+
+		$count = count( $urls );
+		WP_CLI::log( "Submitting {$count} URL(s) to IndexNow..." );
+
+		$result = IndexNowAbilities::submit_urls( $urls );
+
+		if ( $result['success'] ) {
+			WP_CLI::success( $result['message'] . " ({$count} URL" . ( $count > 1 ? 's' : '' ) . ')' );
+		} else {
+			$error_msg = $result['error'] ?? 'Unknown error';
+			$code      = $result['status_code'] ?? '';
+			if ( $code ) {
+				$error_msg .= " (HTTP {$code})";
+			}
+			WP_CLI::error( $error_msg );
+		}
+	}
+
+	/**
+	 * Show IndexNow integration status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine indexnow status
+	 *
+	 * @subcommand status
+	 */
+	public function status( array $args, array $assoc_args ): void {
+		$status = IndexNowAbilities::get_status();
+
+		WP_CLI::log( '' );
+		WP_CLI::log( 'IndexNow Integration Status' );
+		WP_CLI::log( str_repeat( '─', 40 ) );
+		WP_CLI::log( 'Enabled:       ' . ( $status['enabled'] ? WP_CLI::colorize( '%GYes%n' ) : WP_CLI::colorize( '%RNo%n' ) ) );
+		WP_CLI::log( 'API Key:       ' . ( $status['has_key'] ? $status['key_preview'] : WP_CLI::colorize( '%RNot set%n' ) ) );
+
+		if ( $status['has_key'] ) {
+			WP_CLI::log( 'Key File URL:  ' . $status['key_file_url'] );
+		}
+
+		WP_CLI::log( 'Endpoint:      ' . $status['endpoint'] );
+		WP_CLI::log( '' );
+
+		if ( ! $status['has_key'] ) {
+			WP_CLI::log( WP_CLI::colorize( '%YRun `wp datamachine indexnow key generate` to create an API key.%n' ) );
+		} elseif ( ! $status['enabled'] ) {
+			WP_CLI::log( WP_CLI::colorize( '%YRun `wp datamachine settings set indexnow_enabled true` to enable auto-ping on publish.%n' ) );
+		}
+	}
+
+	/**
+	 * Manage the IndexNow API key.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Action to perform: generate, verify, show
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Generate a new API key
+	 *     wp datamachine indexnow key generate
+	 *
+	 *     # Verify the key file is accessible
+	 *     wp datamachine indexnow key verify
+	 *
+	 *     # Show the current key
+	 *     wp datamachine indexnow key show
+	 *
+	 * @subcommand key
+	 */
+	public function key( array $args, array $assoc_args ): void {
+		$action = $args[0] ?? '';
+
+		switch ( $action ) {
+			case 'generate':
+				$key = IndexNowAbilities::generate_key();
+				WP_CLI::success( 'Generated new IndexNow API key: ' . substr( $key, 0, 8 ) . '...' );
+				WP_CLI::log( 'Key file URL: ' . home_url( '/' . $key . '.txt' ) );
+
+				// Flush rewrite rules so the key file route is active.
+				flush_rewrite_rules();
+				WP_CLI::log( 'Rewrite rules flushed.' );
+				break;
+
+			case 'verify':
+				WP_CLI::log( 'Verifying key file accessibility...' );
+				$result = IndexNowAbilities::verify_key_file();
+
+				if ( $result['success'] ) {
+					WP_CLI::success( $result['message'] );
+					WP_CLI::log( 'URL: ' . $result['url'] );
+				} else {
+					WP_CLI::error( $result['error'] . ( isset( $result['url'] ) ? "\nURL: " . $result['url'] : '' ) );
+				}
+				break;
+
+			case 'show':
+				$key = IndexNowAbilities::get_api_key();
+				if ( empty( $key ) ) {
+					WP_CLI::error( 'No IndexNow API key configured. Run: wp datamachine indexnow key generate' );
+				}
+				WP_CLI::log( $key );
+				break;
+
+			default:
+				WP_CLI::error( 'Unknown action: ' . $action . '. Valid actions: generate, verify, show' );
+		}
+	}
+
+	/**
+	 * Enable IndexNow auto-ping on publish.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine indexnow enable
+	 *
+	 * @subcommand enable
+	 */
+	public function enable( array $args, array $assoc_args ): void {
+		$settings = get_option( 'datamachine_settings', array() );
+		$settings['indexnow_enabled'] = true;
+		update_option( 'datamachine_settings', $settings );
+		PluginSettings::clearCache();
+
+		// Ensure API key exists.
+		$key = IndexNowAbilities::get_or_generate_key();
+
+		WP_CLI::success( 'IndexNow auto-ping enabled. URLs will be submitted when posts are published.' );
+		WP_CLI::log( 'API key: ' . substr( $key, 0, 8 ) . '...' );
+	}
+
+	/**
+	 * Disable IndexNow auto-ping on publish.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine indexnow disable
+	 *
+	 * @subcommand disable
+	 */
+	public function disable( array $args, array $assoc_args ): void {
+		$settings = get_option( 'datamachine_settings', array() );
+		$settings['indexnow_enabled'] = false;
+		update_option( 'datamachine_settings', $settings );
+		PluginSettings::clearCache();
+
+		WP_CLI::success( 'IndexNow auto-ping disabled.' );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds IndexNow protocol support — auto-pings Bing, Yandex, DuckDuckGo when posts are published or updated
- Uses `wp_after_insert_post` hook (WP 5.6+, recommended per WordPress core docs) for auto-ping
- Key file served via `parse_request` — no rewrite rules to flush
- Full CLI and Abilities API for manual/batch submission

## CLI Commands
```
wp datamachine indexnow status              # Show integration status
wp datamachine indexnow enable              # Enable auto-ping on publish
wp datamachine indexnow disable             # Disable auto-ping
wp datamachine indexnow key generate        # Generate API key + flush rewrites
wp datamachine indexnow key verify          # Verify key file is accessible
wp datamachine indexnow key show            # Show full API key
wp datamachine indexnow submit <url>        # Submit URL(s)
wp datamachine indexnow submit --post-id=42 # Submit by post ID
wp datamachine indexnow submit --post-type=event --limit=50  # Batch submit
```

## Abilities
- `datamachine/indexnow-submit` — submit URL(s)
- `datamachine/indexnow-status` — get integration status
- `datamachine/indexnow-generate-key` — generate new API key
- `datamachine/indexnow-verify-key` — verify key file accessibility

## Settings
- `indexnow_enabled` (bool) — auto-ping on publish
- `indexnow_api_key` (string) — auto-generated 32-char hex key

## Tested
- Key generation, file serving, verification all working on chubes.net
- URL submission returns HTTP 200/202 from IndexNow API
- Batch submission (post-type) works
- Enable/disable toggles correctly

Closes #443