### PR TITLE
Extension plugins can register GitHub repos for issue creation

### DIFF
--- a/inc/Abilities/Fetch/GitHubAbilities.php
+++ b/inc/Abilities/Fetch/GitHubAbilities.php
@@ -897,6 +897,104 @@ class GitHubAbilities {
 	}
 
 	/**
+	 * Get all registered GitHub repos for issue creation.
+	 *
+	 * Extension plugins register their repos via the datamachine_github_issue_repos
+	 * filter. The default repo from settings is always included if set.
+	 *
+	 * Each entry has: owner, repo, label (human-readable name).
+	 *
+	 * Usage in extension plugins:
+	 *
+	 *     add_filter( 'datamachine_github_issue_repos', function ( $repos ) {
+	 *         $repos[] = array(
+	 *             'owner' => 'Extra-Chill',
+	 *             'repo'  => 'data-machine-socials',
+	 *             'label' => 'Social Media Extension',
+	 *         );
+	 *         return $repos;
+	 *     } );
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return array Array of repo definitions with owner, repo, label keys.
+	 */
+	public static function getRegisteredRepos(): array {
+		$repos = array();
+
+		// Always include the default repo from settings if configured.
+		$default_repo = self::getDefaultRepo();
+		if ( ! empty( $default_repo ) && str_contains( $default_repo, '/' ) ) {
+			$parts  = explode( '/', $default_repo, 2 );
+			$repos[] = array(
+				'owner' => $parts[0],
+				'repo'  => $parts[1],
+				'label' => 'Default (from settings)',
+			);
+		}
+
+		/**
+		 * Filter the list of GitHub repos available for issue creation.
+		 *
+		 * Extension plugins should append their repo to this array so the
+		 * AI agent and CLI can target the correct repo for bugs/features.
+		 *
+		 * @since 0.36.0
+		 *
+		 * @param array $repos Array of repo definitions. Each entry:
+		 *     - owner (string) GitHub org or username.
+		 *     - repo  (string) Repository name.
+		 *     - label (string) Human-readable label for display.
+		 */
+		$repos = apply_filters( 'datamachine_github_issue_repos', $repos );
+
+		// Deduplicate by owner/repo.
+		$seen   = array();
+		$unique = array();
+		foreach ( $repos as $entry ) {
+			$key = strtolower( ( $entry['owner'] ?? '' ) . '/' . ( $entry['repo'] ?? '' ) );
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+			$unique[]     = $entry;
+		}
+
+		return $unique;
+	}
+
+	/**
+	 * Resolve the best repo for issue creation.
+	 *
+	 * Resolution order:
+	 * 1. Explicit repo from input (if provided)
+	 * 2. Default repo from settings
+	 * 3. First registered repo from the filter
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string $repo Explicit repo in owner/repo format, or empty.
+	 * @return string Resolved repo in owner/repo format, or empty if none available.
+	 */
+	public static function resolveRepo( string $repo = '' ): string {
+		if ( ! empty( $repo ) ) {
+			return $repo;
+		}
+
+		$default = self::getDefaultRepo();
+		if ( ! empty( $default ) ) {
+			return $default;
+		}
+
+		$registered = self::getRegisteredRepos();
+		if ( ! empty( $registered ) ) {
+			return $registered[0]['owner'] . '/' . $registered[0]['repo'];
+		}
+
+		return '';
+	}
+
+	/**
 	 * Return standard PAT-not-configured error.
 	 *
 	 * @return array

--- a/inc/Api/System/SystemAgentDirective.php
+++ b/inc/Api/System/SystemAgentDirective.php
@@ -38,7 +38,7 @@ class SystemAgentDirective implements \DataMachine\Engine\AI\Directives\Directiv
 	 * @return string System prompt
 	 */
 	private static function get_directive( $tools ): string {
-		return '# Data Machine System Agent' . "\n\n"
+		$directive = '# Data Machine System Agent' . "\n\n"
 		. 'You are a system infrastructure specialist. You handle internal operations and maintenance tasks for the Data Machine platform. Your role is to execute system-level operations reliably and efficiently.' . "\n\n"
 		. '## Session Title Generation' . "\n\n"
 		. 'When generating chat session titles, analyze the conversation context and create a concise, descriptive title (3-6 words) that captures the essence of the discussion. Focus on the user\'s intent and the assistant\'s response.' . "\n\n"
@@ -48,9 +48,23 @@ class SystemAgentDirective implements \DataMachine\Engine\AI\Directives\Directiv
 		. '- User wants to create a workflow → "Workflow Creation Assistance"' . "\n"
 		. '- User reports an issue → "Bug Report Discussion"' . "\n\n"
 		. '## GitHub Issue Creation' . "\n\n"
-		. 'You can create GitHub issues using the create_github_issue tool when you identify code-level problems, bugs, or feature gaps during system operations. Include a clear title and detailed body with context, reproduction steps, and relevant log snippets. Use labels to categorize (e.g., "bug", "enhancement"). The repo parameter is optional if a default repository is configured in settings. Only create issues for genuine problems — never create duplicates.' . "\n\n"
-		. '## System Operations' . "\n\n"
+		. 'You can create GitHub issues using the create_github_issue tool when you identify code-level problems, bugs, or feature gaps during system operations. Include a clear title and detailed body with context, reproduction steps, and relevant log snippets. Use labels to categorize (e.g., "bug", "enhancement"). Route issues to the most appropriate repo based on context. Only create issues for genuine problems — never create duplicates.';
+
+		// List available repos dynamically.
+		if ( class_exists( '\DataMachine\Abilities\Fetch\GitHubAbilities' ) ) {
+			$repos = \DataMachine\Abilities\Fetch\GitHubAbilities::getRegisteredRepos();
+			if ( ! empty( $repos ) ) {
+				$directive .= "\n\n" . 'Available repositories for issue creation:' . "\n";
+				foreach ( $repos as $entry ) {
+					$directive .= '- ' . $entry['owner'] . '/' . $entry['repo'] . ' — ' . $entry['label'] . "\n";
+				}
+			}
+		}
+
+		$directive .= "\n\n" . '## System Operations' . "\n\n"
 		. 'Execute system tasks with precision. Log all operations appropriately. Handle errors gracefully and provide clear feedback.';
+
+		return $directive;
 	}
 }
 

--- a/inc/Cli/Commands/GitHubCommand.php
+++ b/inc/Cli/Commands/GitHubCommand.php
@@ -482,6 +482,23 @@ class GitHubCommand extends BaseCommand {
 		);
 
 		$this->format_items( $items, array( 'setting', 'value' ), $assoc_args );
+
+		// Show registered repos from the filter.
+		$repos = GitHubAbilities::getRegisteredRepos();
+		if ( ! empty( $repos ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Registered repos for issue creation:' );
+
+			$repo_items = array();
+			foreach ( $repos as $entry ) {
+				$repo_items[] = array(
+					'repo'  => ( $entry['owner'] ?? '' ) . '/' . ( $entry['repo'] ?? '' ),
+					'label' => $entry['label'] ?? '',
+				);
+			}
+
+			$this->format_items( $repo_items, array( 'repo', 'label' ), $assoc_args );
+		}
 	}
 
 	// -------------------------------------------------------------------------
@@ -504,11 +521,9 @@ class GitHubCommand extends BaseCommand {
 	 * @return array Input with resolved repo.
 	 */
 	private function resolveRepo( array $input ): array {
+		$input['repo'] = GitHubAbilities::resolveRepo( $input['repo'] ?? '' );
 		if ( empty( $input['repo'] ) ) {
-			$input['repo'] = GitHubAbilities::getDefaultRepo();
-		}
-		if ( empty( $input['repo'] ) ) {
-			WP_CLI::error( 'Required: --repo=<owner/repo> (or set a default repo in settings).' );
+			WP_CLI::error( 'Required: --repo=<owner/repo> (or set a default repo in settings, or register repos via datamachine_github_issue_repos filter).' );
 		}
 		return $input;
 	}

--- a/inc/Engine/AI/System/Tasks/GitHubIssueTask.php
+++ b/inc/Engine/AI/System/Tasks/GitHubIssueTask.php
@@ -12,12 +12,15 @@ namespace DataMachine\Engine\AI\System\Tasks;
 
 defined( 'ABSPATH' ) || exit;
 
+use DataMachine\Abilities\Fetch\GitHubAbilities;
 use DataMachine\Core\PluginSettings;
 
 class GitHubIssueTask extends SystemTask {
 
 	/**
 	 * Execute GitHub issue creation.
+	 *
+	 * Repo resolution: explicit param → default setting → first registered repo.
 	 *
 	 * @since 0.24.0
 	 *
@@ -28,11 +31,7 @@ class GitHubIssueTask extends SystemTask {
 		$title  = trim( $params['title'] ?? '' );
 		$body   = $params['body'] ?? '';
 		$labels = $params['labels'] ?? array();
-		$repo   = trim( $params['repo'] ?? '' );
-
-		if ( empty( $repo ) ) {
-			$repo = trim( PluginSettings::get( 'github_default_repo', '' ) );
-		}
+		$repo   = GitHubAbilities::resolveRepo( trim( $params['repo'] ?? '' ) );
 
 		if ( empty( $title ) ) {
 			$this->failJob( $jobId, 'Missing required parameter: title' );
@@ -40,7 +39,7 @@ class GitHubIssueTask extends SystemTask {
 		}
 
 		if ( empty( $repo ) ) {
-			$this->failJob( $jobId, 'Missing required parameter: repo (and no default configured)' );
+			$this->failJob( $jobId, 'Missing required parameter: repo (no default configured and no repos registered via datamachine_github_issue_repos filter)' );
 			return;
 		}
 

--- a/inc/Engine/AI/Tools/GitHubIssueTool.php
+++ b/inc/Engine/AI/Tools/GitHubIssueTool.php
@@ -90,15 +90,32 @@ class GitHubIssueTool extends BaseTool {
 	/**
 	 * Get tool definition for AI agents.
 	 *
+	 * Dynamically includes available repos in the description so the AI
+	 * agent knows which repos are valid targets for issue creation.
+	 *
 	 * @since 0.24.0
 	 *
 	 * @return array Tool definition array.
 	 */
 	public function getToolDefinition(): array {
+		$description = 'Create a GitHub issue in a repository. Requires a GitHub PAT configured in settings. Use for bug reports, feature requests, and task tracking.';
+
+		$repos = \DataMachine\Abilities\Fetch\GitHubAbilities::getRegisteredRepos();
+		if ( ! empty( $repos ) ) {
+			$repo_list = array_map(
+				function ( $r ) {
+					return $r['owner'] . '/' . $r['repo'] . ' (' . $r['label'] . ')';
+				},
+				$repos
+			);
+			$description .= ' Available repos: ' . implode( ', ', $repo_list ) . '.';
+			$description .= ' Route issues to the most appropriate repo based on context.';
+		}
+
 		return array(
 			'class'       => __CLASS__,
 			'method'      => 'handle_tool_call',
-			'description' => 'Create a GitHub issue in a repository. Requires a GitHub PAT configured in settings. Use for bug reports, feature requests, and task tracking.',
+			'description' => $description,
 			'parameters'  => array(
 				'title'  => array(
 					'type'        => 'string',
@@ -108,7 +125,7 @@ class GitHubIssueTool extends BaseTool {
 				'repo'   => array(
 					'type'        => 'string',
 					'required'    => false,
-					'description' => 'Repository in owner/repo format. Falls back to default repo in settings.',
+					'description' => 'Repository in owner/repo format. Falls back to default repo, then first registered repo.',
 				),
 				'body'   => array(
 					'type'        => 'string',


### PR DESCRIPTION
## Summary
- Adds `datamachine_github_issue_repos` filter so extension plugins can register their repos
- AI agent and CLI now see all registered repos and can route issues to the right one
- Centralizes repo resolution into `GitHubAbilities::resolveRepo()`

## How Extensions Use It
```php
add_filter( 'datamachine_github_issue_repos', function ( $repos ) {
    $repos[] = array(
        'owner' => 'Extra-Chill',
        'repo'  => 'data-machine-socials',
        'label' => 'Social Media Extension',
    );
    return $repos;
} );
```

## What Changed

**GitHubAbilities** — `getRegisteredRepos()` collects from filter (with dedup), `resolveRepo()` centralizes fallback chain: explicit → default setting → first registered

**GitHubIssueTask** — uses `resolveRepo()` instead of duplicating fallback logic

**GitHubIssueTool** — dynamically injects available repos into the AI tool description

**SystemAgentDirective** — lists registered repos in the system agent prompt so the AI knows where to file issues

**CLI `github status`** — shows registered repos table

## Tested
- Default repo auto-registers from settings
- Filter adds extension repos correctly
- Dedup prevents same repo appearing twice
- `resolveRepo()` falls through correctly: explicit → default → first registered
- CLI status displays all registered repos

Closes #315