### PR TITLE
fix: prevent LogHandler crash during test bootstrap

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -643,7 +643,7 @@ function datamachine_ensure_default_memory_files() {
 
 		do_action(
 			'datamachine_log',
-			'notice',
+			'info',
 			sprintf( 'Self-healing: created missing agent file %s with scaffold defaults.', $filename ),
 			array( 'filename' => $filename )
 		);

--- a/inc/Engine/Actions/Handlers/LogHandler.php
+++ b/inc/Engine/Actions/Handlers/LogHandler.php
@@ -33,7 +33,10 @@ class LogHandler {
 		if ( ! in_array( $level, $valid_levels, true ) ) {
 			if ( class_exists( 'WP_Ability' ) ) {
 				$ability = wp_get_ability( 'datamachine/write-to-log' );
-				$result  = $ability->execute(
+				if ( ! $ability ) {
+					return false;
+				}
+				$result = $ability->execute(
 					array(
 						'level'   => $level,
 						'message' => $message,


### PR DESCRIPTION
## Summary

- Add null guard on `wp_get_ability()` result in `LogHandler::handle()` — prevents fatal error when abilities aren't registered yet
- Change invalid log level `'notice'` → `'info'` in `datamachine_ensure_default_memory_files()` — `'notice'` isn't a valid DM log level, which caused LogHandler to take the abilities fallback path

## Problem

The entire PHPUnit test suite crashes on bootstrap:

```
Error in bootstrap script: Error:
Call to a member function execute() on null
#0 LogHandler::handle()
```

**Root cause chain:**

```
init → datamachine_maybe_run_migrations()
  → datamachine_activate_for_site()
    → datamachine_ensure_default_memory_files()
      → do_action('datamachine_log', 'notice', ...)   ← invalid level
        → LogHandler: 'notice' not in valid_levels
          → wp_get_ability('datamachine/write-to-log') returns null
            → null->execute()  💥
```

Two bugs compound:
1. `'notice'` isn't a valid DM log level (`debug`, `info`, `warning`, `error`, `critical`) so the fast-path `datamachine_log_notice()` lookup fails
2. The fallback path calls `wp_get_ability()` without null-checking — during bootstrap, abilities aren't registered yet

## Files Changed

- `inc/Engine/Actions/Handlers/LogHandler.php` — null guard before `$ability->execute()`
- `data-machine.php` — `'notice'` → `'info'` in `datamachine_ensure_default_memory_files()`