### PR TITLE
fix: default max_items to 1 at runtime to prevent unbounded batch fan-out

### DIFF
--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -80,8 +80,10 @@ abstract class FetchHandler {
 		// Items without dedup_key pass through unchanged.
 		$items = $this->dedup( $items, $context );
 
-		// Apply max_items cap when configured.
-		$max_items = (int) ( $config['max_items'] ?? 0 );
+		// Apply max_items cap.
+		// Default to 1 to prevent unbounded fan-out when flows lack an
+		// explicit max_items value. Set to 0 for unlimited.
+		$max_items = (int) ( $config['max_items'] ?? 1 );
 		if ( $max_items > 0 && count( $items ) > $max_items ) {
 			$items = array_slice( $items, 0, $max_items );
 		}


### PR DESCRIPTION
## Summary

- **Fixes unbounded batch fan-out** caused by `max_items` defaulting to `0` (unlimited) at runtime when flows lack a persisted value
- Changes `$config['max_items'] ?? 0` → `$config['max_items'] ?? 1` in `FetchHandler::get_fetch_data()`

## Problem

The `FetchHandlerSettings` UI defines `'default' => 1` for `max_items`, but that's only a form pre-fill hint — it's never applied when the field is absent from stored config. At runtime, `?? 0` meant unlimited.

Every Ticketmaster/Dice.fm/Reddit fetch returned ALL items, each fanning out into a child job with its own LLM call. Dice.fm Chicago alone returned 99 events → 99 child jobs. Across 46 parent batches, **309 child jobs** were created with **261 stuck in processing**, flooding the Action Scheduler queue with 331+ pending actions.

## Fix

One-line change: runtime fallback matches the settings UI default. Flows that explicitly want batch fan-out must set `max_items` > 1 in the handler settings UI.

**Already hotfixed on production** — this PR formalizes the fix.