### PR TITLE
fix: remove bogus Logger class import that caused fatal redeclare crash in tests

### DIFF
--- a/inc/Abilities/LogAbilities.php
+++ b/inc/Abilities/LogAbilities.php
@@ -12,7 +12,6 @@ namespace DataMachine\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
 
-use DataMachine\Engine\Logger;
 use DataMachine\Engine\AI\AgentType;
 
 defined( 'ABSPATH' ) || exit;
@@ -280,9 +279,18 @@ class LogAbilities {
 		$message = $input['message'];
 		$context = $input['context'] ?? array();
 
-		$logged = Logger::write( $level, $message, $context );
+		$valid_levels = datamachine_get_valid_log_levels();
+		if ( ! in_array( $level, $valid_levels, true ) ) {
+			return array(
+				'success'    => false,
+				'error_code' => 'invalid_level',
+				'error'      => 'Invalid log level: ' . $level,
+			);
+		}
 
-		if ( $logged ) {
+		$function_name = 'datamachine_log_' . $level;
+		if ( function_exists( $function_name ) ) {
+			$function_name( $message, $context );
 			return array(
 				'success' => true,
 				'message' => 'Log entry written',


### PR DESCRIPTION
## Summary

- Removes `use DataMachine\Engine\Logger;` from `LogAbilities.php` — this imported a class that **doesn't exist** and triggered Composer's PSR-4 autoloader to re-include the procedural `Logger.php` file, causing a fatal `Cannot redeclare datamachine_get_monolog_instance()` crash
- Replaces the non-existent `Logger::write()` static call with direct calls to existing `datamachine_log_*()` procedural functions

## Root Cause

`Logger.php` is a **procedural file** (no namespace, no class) that defines global functions like `datamachine_get_monolog_instance()`. It's loaded via `require_once` in `bootstrap.php`.

`LogAbilities.php` had `use DataMachine\Engine\Logger;` — which told PHP to resolve `Logger` as `DataMachine\Engine\Logger`. When `Logger::write()` was called, Composer's autoloader mapped this to `inc/Engine/Logger.php` via the PSR-4 rule `DataMachine\Engine\ → inc/Engine/`. Composer's autoloader uses `include` (not `include_once`), so the file was loaded a **second time**, triggering the fatal redeclare error.

## Impact

**Before:** 308 tests ran before the fatal crash — 216 passed, 91 failed, 1 risky
**After:** **514 tests** run to completion — **374 passed**, 139 failed, 1 risky

Unblocked **206 tests** that were previously invisible. 158 of those pass.

Closes #580