### PR TITLE
fix: gate batch fan-out to steps that produce batch items

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -220,7 +220,8 @@ class ExecuteStepAbility {
 				$dataPackets,
 				$payload,
 				$step_success,
-				$status_override
+				$status_override,
+				$step_definition
 			);
 		} catch ( \Throwable $e ) {
 			do_action(
@@ -348,6 +349,7 @@ class ExecuteStepAbility {
 	 * @param array  $payload          Full step payload.
 	 * @param bool   $step_success     Whether step succeeded.
 	 * @param mixed  $status_override  Status override from engine data.
+	 * @param array  $step_definition  Step type definition from registry.
 	 * @return array Result with outcome details.
 	 */
 	private function routeAfterExecution(
@@ -360,7 +362,8 @@ class ExecuteStepAbility {
 		array $dataPackets,
 		array $payload,
 		bool $step_success,
-		$status_override
+		$status_override,
+		array $step_definition = array()
 	): array {
 		$pipeline_id = $flow_step_config['pipeline_id'] ?? null;
 
@@ -429,22 +432,43 @@ class ExecuteStepAbility {
 			$next_flow_step_id = $navigator->get_next_flow_step_id( $flow_step_id, $payload );
 
 			if ( $next_flow_step_id ) {
-				// Fan out: each DataPacket becomes its own child job
-				// continuing through the remaining pipeline steps.
-				$engine_snapshot = datamachine_get_engine_data( $job_id );
-				$batch_scheduler = new PipelineBatchScheduler();
-				$batch_result    = $batch_scheduler->fanOut(
-					$job_id,
-					$next_flow_step_id,
-					$dataPackets,
-					$engine_snapshot
+				$produces_batch_items = ! empty( $step_definition['produces_batch_items'] );
+
+				if ( $produces_batch_items ) {
+					// Fan out: each DataPacket becomes its own child job
+					// continuing through the remaining pipeline steps.
+					$engine_snapshot = datamachine_get_engine_data( $job_id );
+					$batch_scheduler = new PipelineBatchScheduler();
+					$batch_result    = $batch_scheduler->fanOut(
+						$job_id,
+						$next_flow_step_id,
+						$dataPackets,
+						$engine_snapshot
+					);
+
+					return array(
+						'success'      => true,
+						'step_success' => true,
+						'outcome'      => 'batch_scheduled',
+						'batch'        => $batch_result,
+					);
+				}
+
+				// Non-batch step: advance the same job to the next step.
+				$schedule_ability = new ScheduleNextStepAbility();
+				$schedule_result  = $schedule_ability->execute(
+					array(
+						'job_id'       => $job_id,
+						'flow_step_id' => $next_flow_step_id,
+						'data_packets' => $dataPackets,
+					)
 				);
 
 				return array(
 					'success'      => true,
 					'step_success' => true,
-					'outcome'      => 'batch_scheduled',
-					'batch'        => $batch_result,
+					'outcome'      => 'next_step_scheduled',
+					'action_id'    => $schedule_result['action_id'] ?? null,
 				);
 			}
 

--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -38,7 +38,8 @@ class FetchStep extends Step {
 			class: self::class,
 			position: 10,
 			usesHandler: true,
-			hasPipelineConfig: false
+			hasPipelineConfig: false,
+			producesBatchItems: true
 		);
 	}
 

--- a/inc/Core/Steps/StepTypeRegistrationTrait.php
+++ b/inc/Core/Steps/StepTypeRegistrationTrait.php
@@ -42,6 +42,8 @@ trait StepTypeRegistrationTrait {
 	 * @param bool       $hasPipelineConfig Whether step has pipeline-level configuration
 	 * @param bool       $consumeAllPackets Whether step consumes all packets at once
 	 * @param array|null $stepSettings Optional UI settings for pipeline step configuration
+	 * @param bool       $showSettingsDisplay Whether to show settings display in UI
+	 * @param bool       $producesBatchItems Whether step outputs multiple items that should fan out into child jobs
 	 */
 	protected static function registerStepType(
 		string $slug,
@@ -53,7 +55,8 @@ trait StepTypeRegistrationTrait {
 		bool $hasPipelineConfig = false,
 		bool $consumeAllPackets = false,
 		?array $stepSettings = null,
-		bool $showSettingsDisplay = true
+		bool $showSettingsDisplay = true,
+		bool $producesBatchItems = false
 	): void {
 		// Prevent duplicate registration when step class is instantiated multiple times
 		if ( isset( self::$registered_step_types[ $slug ] ) ) {
@@ -72,7 +75,8 @@ trait StepTypeRegistrationTrait {
 				$usesHandler,
 				$hasPipelineConfig,
 				$consumeAllPackets,
-				$showSettingsDisplay
+				$showSettingsDisplay,
+				$producesBatchItems
 			) {
 				$steps[ $slug ] = array(
 					'label'                 => $label,
@@ -83,6 +87,7 @@ trait StepTypeRegistrationTrait {
 					'has_pipeline_config'   => $hasPipelineConfig,
 					'consume_all_packets'   => $consumeAllPackets,
 					'show_settings_display' => $showSettingsDisplay,
+					'produces_batch_items'  => $producesBatchItems,
 				);
 				return $steps;
 			}


### PR DESCRIPTION
## Summary

Closes #609

- Adds `producesBatchItems` parameter to step type registration (defaults to `false`)
- Only `fetch` step opts in — `PipelineBatchScheduler::fanOut()` only triggers for steps that produce batch items
- Non-batch steps (AI, publish, update, etc.) advance the same job to the next step via `ScheduleNextStepAbility`
- Stops AI conversation artifacts ("AI Response - Turn 1", "Handler Tool Executed: upsert_event") from being fanned out as ghost child jobs

## Companion PR

`data-machine-events` needs the same `producesBatchItems: true` on its `event_import` step. Will submit that PR separately.

## Before

Jobs list polluted with conversation artifacts as labels:

```
14195  PORTRAYAL OF GUILT with STREET SECTS and TARANEH   failed
14194  AI Response - Turn 1                               failed
14193  Done — event upserted to the New Orleans calendar. failed
14192  Handler Tool Executed: upsert_event                completed
```

## After

Only fetch/event_import steps fan out. AI step advances to the next step inline with the same job — no ghost children.