### PR TITLE
fix: stop AI step from emitting conversation turns as DataPackets

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -245,19 +245,15 @@ class AIStep extends Step {
 	}
 
 	/**
-	 * Process AI conversation loop results into pipeline data packets.
-	 *
-	 * @param array $loop_result Result from AIConversationLoop
-	 * @param array $dataPackets Current data packet array
-	 * @param array $payload Step payload
-	 * @param array $available_tools Available tool definitions
-	 * @return array Updated data packet array
-	 */
-	/**
 	 * Process AI conversation loop results into data packets.
 	 *
+	 * Only emits actionable packets (handler completions, tool results) that
+	 * downstream steps depend on. Conversation turns are tracked as metadata
+	 * but not emitted as individual DataPackets — doing so causes the batch
+	 * scheduler to fan them out as ghost child jobs.
+	 *
 	 * @param array $loop_result Results from AIConversationLoop
-	 * @param array $data Current data packet array
+	 * @param array $dataPackets Current data packet array
 	 * @param array $payload Step payload
 	 * @param array $available_tools Tools available during conversation
 	 * @return array Updated data packet array
@@ -270,54 +266,25 @@ class AIStep extends Step {
 		$flow_step_id           = $payload['flow_step_id'];
 		$messages               = $loop_result['messages'] ?? array();
 		$tool_execution_results = $loop_result['tool_execution_results'] ?? array();
-		$turn_count             = 0;
-		$handler_completed      = false;
 
-		// Process conversation messages to build data packets
+		// Count conversation turns for metadata (not emitted as packets).
+		$turn_count        = 0;
+		$handler_completed = false;
+		$final_ai_content  = '';
+
 		foreach ( $messages as $message ) {
-			$role = $message['role'] ?? '';
-
-			// Track turns by counting assistant messages
-			if ( 'assistant' === $role ) {
+			if ( 'assistant' === ( $message['role'] ?? '' ) ) {
 				++$turn_count;
-			}
-
-			// Process assistant responses (AI content or tool calls)
-			if ( 'assistant' === $role ) {
-				$content    = $message['content'] ?? '';
-				$tool_calls = $message['tool_calls'] ?? array();
-
-				if ( ! empty( $content ) || ! empty( $tool_calls ) ) {
-					if ( ! empty( $content ) ) {
-						$content_lines = explode( "\n", trim( $content ), 2 );
-						$ai_title      = ( strlen( $content_lines[0] ) <= 100 ) ? $content_lines[0] : "AI Response - Turn {$turn_count}";
-						$response_body = $content;
-					} else {
-						$ai_title      = "AI Tool Execution - Turn {$turn_count}";
-						$tool_names    = array_column( $tool_calls, 'name' );
-						$response_body = 'AI executed ' . count( $tool_calls ) . ' tool(s): ' . implode( ', ', $tool_names );
-					}
-
-					$packet      = new DataPacket(
-						array(
-							'title' => $ai_title,
-							'body'  => $response_body,
-						),
-						array(
-							'source_type'       => 'ai_response',
-							'flow_step_id'      => $flow_step_id,
-							'conversation_turn' => $turn_count,
-							'has_tool_calls'    => ! empty( $tool_calls ),
-							'tool_count'        => count( $tool_calls ),
-						),
-						'ai_response'
-					);
-					$dataPackets = $packet->addTo( $dataPackets );
+				$content = $message['content'] ?? '';
+				if ( ! empty( $content ) ) {
+					$final_ai_content = $content;
 				}
 			}
 		}
 
-		// Process tool execution results into data packets
+		// Process tool execution results into data packets.
+		// Only handler completions and tool results are emitted — these are
+		// consumed by downstream steps (PublishStep, UpdateStep) via ToolResultFinder.
 		foreach ( $tool_execution_results as $tool_result_data ) {
 			$tool_name         = $tool_result_data['tool_name'] ?? '';
 			$tool_result       = $tool_result_data['result'] ?? array();
@@ -382,6 +349,27 @@ class AIStep extends Step {
 				);
 				$dataPackets = $packet->addTo( $dataPackets );
 			}
+		}
+
+		// If no handler completed and no tool results were added, emit a single
+		// summary packet so the step doesn't appear to have produced nothing.
+		if ( ! $handler_completed && count( $dataPackets ) === 0 && ! empty( $final_ai_content ) ) {
+			$content_lines = explode( "\n", trim( $final_ai_content ), 2 );
+			$ai_title      = ( strlen( $content_lines[0] ) <= 100 ) ? $content_lines[0] : 'AI Response';
+
+			$packet      = new DataPacket(
+				array(
+					'title' => $ai_title,
+					'body'  => $final_ai_content,
+				),
+				array(
+					'source_type'       => 'ai_response',
+					'flow_step_id'      => $flow_step_id,
+					'conversation_turn' => $turn_count,
+				),
+				'ai_response'
+			);
+			$dataPackets = $packet->addTo( $dataPackets );
 		}
 
 		return $dataPackets;


### PR DESCRIPTION
## Summary

Closes #609

The AI step's `processLoopResults()` was creating a DataPacket for **every** assistant message and tool call in the conversation. The batch scheduler then fans each packet into its own child job — polluting the jobs table with entries like:

- `"AI Response - Turn 1"`
- `"Done — event upserted to the New Orleans calendar."`
- `"Handler Tool Executed: upsert_event"`

### What changed

**Removed:** per-turn `ai_response` DataPackets. Conversation turns are now counted for metadata only.

**Kept:** `ai_handler_complete` and `tool_result` packets — downstream steps (`PublishStep`, `UpdateStep`) consume these via `ToolResultFinder`.

**Added:** fallback — if no tools executed and no input packets existed (pure text conversation with no prior data), a single `ai_response` packet is emitted so the step doesn't appear empty.

### Single file change

Only `inc/Core/Steps/AI/AIStep.php` is modified. No changes to the batch scheduler, step registration, or engine routing — those are working correctly. The fix is at the source: the AI step was producing noise packets that shouldn't exist.

### Before (4 child jobs per event)

```
14195  PORTRAYAL OF GUILT...          ai_response           failed
14194  AI Response - Turn 1          ai_response           failed  
14193  Done — event upserted...      ai_response           failed
14192  Handler Tool Executed...       ai_handler_complete   completed
```

### After (1 child job per event)

```
14192  Handler Tool Executed...       ai_handler_complete   completed
```