### PR TITLE
fix: fail orphaned batch parents instead of leaving processing jobs

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -143,9 +143,10 @@ class PipelineBatchScheduler {
 		$batch_data    = get_transient( $transient_key );
 
 		if ( ! $batch_data ) {
+			$this->failParentIfStillProcessing( $parent_job_id, 'batch_state_missing' );
 			do_action(
 				'datamachine_log',
-				'warning',
+				'error',
 				'Pipeline batch: transient expired or missing',
 				array( 'parent_job_id' => $parent_job_id )
 			);
@@ -216,6 +217,26 @@ class PipelineBatchScheduler {
 		} else {
 			// All items scheduled — clean up transient.
 			delete_transient( $transient_key );
+
+			$child_count = $this->countChildren( $parent_job_id );
+			if ( $child_count < 1 ) {
+				$this->db_jobs->complete_job(
+					$parent_job_id,
+					JobStatus::failed( 'batch_no_children_scheduled' )->toString()
+				);
+
+				do_action(
+					'datamachine_log',
+					'error',
+					'Pipeline batch: no child jobs were scheduled; parent marked failed',
+					array(
+						'parent_job_id' => $parent_job_id,
+						'total'         => $total,
+					)
+				);
+
+				return;
+			}
 
 			do_action(
 				'datamachine_log',
@@ -413,5 +434,47 @@ class PipelineBatchScheduler {
 				'total'         => $total_children,
 			)
 		);
+	}
+
+	/**
+	 * Mark parent as failed when batch state is missing.
+	 *
+	 * @param int    $parent_job_id Parent job ID.
+	 * @param string $reason        Failure reason suffix.
+	 */
+	private function failParentIfStillProcessing( int $parent_job_id, string $reason ): void {
+		$job = $this->db_jobs->get_job( $parent_job_id );
+
+		if ( ! $job ) {
+			return;
+		}
+
+		$current_status = $job['status'] ?? '';
+		if ( JobStatus::PROCESSING !== $current_status ) {
+			return;
+		}
+
+		$this->db_jobs->complete_job( $parent_job_id, JobStatus::failed( $reason )->toString() );
+	}
+
+	/**
+	 * Count child jobs for a parent job.
+	 *
+	 * @param int $parent_job_id Parent job ID.
+	 * @return int
+	 */
+	private function countChildren( int $parent_job_id ): int {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_jobs';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$table} WHERE parent_job_id = %d",
+				$parent_job_id
+			)
+		);
+
+		return $count;
 	}
 }

--- a/tests/Unit/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Engine/PipelineBatchSchedulerTest.php
@@ -203,6 +203,51 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'batch cancelled', $parent_job['status'] );
 	}
 
+	public function test_process_chunk_marks_parent_failed_when_batch_state_is_missing(): void {
+		$parent_id = $this->create_parent_job();
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->processChunk( $parent_id );
+
+		$parent_job = $this->jobs_db->get_job( $parent_id );
+		$this->assertStringContainsString( 'failed', $parent_job['status'] );
+		$this->assertStringContainsString( 'batch_state_missing', $parent_job['status'] );
+	}
+
+	public function test_process_chunk_marks_parent_failed_when_zero_children_scheduled(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+
+		datamachine_merge_engine_data( $parent_id, array(
+			'batch'             => true,
+			'batch_total'       => 0,
+			'batch_scheduled'   => 0,
+			'batch_chunk_size'  => PipelineBatchScheduler::CHUNK_SIZE,
+			'next_flow_step_id' => 'step_empty',
+			'started_at'        => current_time( 'mysql' ),
+		) );
+
+		set_transient(
+			'dm_pipeline_batch_' . $parent_id,
+			array(
+				'parent_job_id'     => $parent_id,
+				'next_flow_step_id' => 'step_empty',
+				'engine_snapshot'   => $engine,
+				'data_packets'      => array(),
+				'total'             => 0,
+				'offset'            => 0,
+			),
+			4 * HOUR_IN_SECONDS
+		);
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->processChunk( $parent_id );
+
+		$parent_job = $this->jobs_db->get_job( $parent_id );
+		$this->assertStringContainsString( 'failed', $parent_job['status'] );
+		$this->assertStringContainsString( 'batch_no_children_scheduled', $parent_job['status'] );
+	}
+
 	public function test_child_labels_use_packet_titles(): void {
 		$parent_id = $this->create_parent_job();
 		$engine    = $this->make_engine_snapshot( $parent_id );


### PR DESCRIPTION
## Summary
- mark parent batch jobs as failed when batch transient state is missing instead of leaving them in `processing`
- fail parent batches when final chunk completes but zero child jobs were actually scheduled
- add unit coverage for both failure paths in `PipelineBatchSchedulerTest`

## Why
On `events.extrachill.com`, parent jobs could remain in `processing` despite Action Scheduler actions completing. This change adds explicit terminal states for orphaned/empty batch paths so queue state stays truthful and scalable.

## Testing
- `homeboy test data-machine --skip-lint --path=\"/var/lib/datamachine/workspace/data-machine\" -- --filter \"PipelineBatchSchedulerTest|ToolResultFinderTest\"`