### PR TITLE
ci: run main push workflow on release tags only

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -4,13 +4,8 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
-    paths:
-      - data-machine.php
-      - readme.txt
-      - package.json
-      - docs/CHANGELOG.md
-      - VERSION
+    tags:
+      - 'v*'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- change Homeboy workflow `push` trigger to tag-only (`v*`)
- keep PR workflow checks on pull requests to `main`
- keep main/release validation on tagged releases instead of every merge commit

## Why
This follows the recommended split: PR checks for normal development, main/release checks for release events.