### PR TITLE
docs: define System Agent model and context terminology

### DIFF
--- a/docs/core-system/system-agent-runtime-model.md
+++ b/docs/core-system/system-agent-runtime-model.md
@@ -1,0 +1,59 @@
+# System Agent and Runtime Model
+
+This document defines the canonical agent architecture for Data Machine.
+
+## Core Model
+
+- **System Agent**: Data Machine's orchestration engine inside WordPress.
+  - Schedules and routes tasks
+  - Applies directives and policies
+  - Selects tools and context
+- **Agent Runtime**: The execution runtime that carries out requests.
+  - External runtimes can execute now (for example, OpenCode sessions)
+  - `data-machine-agent` is the planned first-party runtime
+- **Contexts**: Execution scopes for the same System Agent.
+  - `pipeline`
+  - `chat`
+  - `system`
+
+## Why this distinction matters
+
+`agent_type` exists in APIs and storage today. In practice, it identifies **context**,
+not separate agent identities. This distinction keeps behavior aligned across entry points
+without breaking compatibility.
+
+## Compatibility rule
+
+For backward compatibility:
+
+- Keep existing fields and keys (`agent_type`, `agent_models`, etc.)
+- Use **context language** in docs and UI copy where appropriate
+- Treat `agent_type` values as context identifiers
+
+## Mental model
+
+```text
+                  +--------------------------+
+                  |       System Agent       |
+                  | orchestration + policy   |
+                  +------------+-------------+
+                               |
+                +--------------+--------------+
+                |              |              |
+          +-----v-----+  +-----v-----+  +-----v-----+
+          | pipeline  |  |   chat    |  |  system   |
+          | context   |  | context   |  | context   |
+          +-----+-----+  +-----+-----+  +-----+-----+
+                \              |              /
+                 \             |             /
+                  +------------v------------+
+                  |      Agent Runtime      |
+                  | executes model/tool loop|
+                  +-------------------------+
+```
+
+## Implementation notes
+
+- `SystemAgent` remains the task orchestration primitive
+- Runtime details should not leak into orchestration interfaces
+- Context-specific behavior should be additive and filter-driven

--- a/docs/core-system/universal-engine.md
+++ b/docs/core-system/universal-engine.md
@@ -2,13 +2,16 @@
 
 **Since**: 0.2.0
 
-The Universal Engine is a shared AI infrastructure layer that provides consistent request building, tool execution, and conversation management for both Pipeline AI and Chat API agents in Data Machine.
+> **Terminology note:** `agent_type` in Data Machine primarily identifies execution
+> contexts (`pipeline`, `chat`, `system`) for the same System Agent orchestration layer.
+
+The Universal Engine is a shared AI infrastructure layer that provides consistent request building, tool execution, and conversation management for both Pipeline and Chat contexts in Data Machine.
 
 ## Overview
 
-Prior to v0.2.0, Pipeline AI and Chat agents maintained separate implementations of conversation loops, tool execution, and request building. This architectural duplication created maintenance overhead and potential behavioral drift between agent types.
+Prior to v0.2.0, Pipeline and Chat contexts maintained separate implementations of conversation loops, tool execution, and request building. This architectural duplication created maintenance overhead and potential behavioral drift between contexts.
 
-The Universal Engine consolidates this shared functionality into a centralized layer at `/inc/Engine/AI/`, enabling both agent types to leverage identical AI infrastructure while maintaining their specialized behaviors through filter-based integration. Since v0.2.2, it includes ToolManager for centralized tool management and BaseTool for unified tool inheritance.
+The Universal Engine consolidates this shared functionality into a centralized layer at `/inc/Engine/AI/`, enabling both contexts to leverage identical AI infrastructure while maintaining their specialized behaviors through filter-based integration. Since v0.2.2, it includes ToolManager for centralized tool management and BaseTool for unified tool inheritance.
 
 ## Architecture
 
@@ -45,7 +48,7 @@ The Universal Engine consolidates this shared functionality into a centralized l
         │                               │
         ▼                               ▼
 ┌──────────────────┐          ┌──────────────────┐
-│  Pipeline Agent  │          │    Chat Agent    │
+│ Pipeline Context │          │  Chat Context    │
 │  (/inc/Core/     │          │   (/inc/Api/     │
 │   Steps/AI/)     │          │    Chat/)        │
 │                  │          │                  │
@@ -82,7 +85,7 @@ Centralized tool management system that replaces distributed tool discovery and 
 
 #### Key Responsibilities
 
-- **Tool Discovery**: Discovers all tools available for a given agent type and execution context
+- **Tool Discovery**: Discovers all tools available for a given context and execution scope
 - **Enablement Validation**: Three-layer validation (global settings → step configuration → runtime validation)
 - **Configuration Management**: Checks if tools have required configuration (API keys, OAuth credentials)
 - **Opt-Out Pattern**: WordPress-native tools without configuration requirements
@@ -151,7 +154,7 @@ Unified abstract base class for all AI tools (global and chat) that provides sta
 #### Key Features
 
 - **Unified Inheritance**: Single base class for all tools (global and chat)
-- **Agent-Agnostic Registration**: `registerTool()` method handles all agent types
+- **Context-Agnostic Registration**: `registerTool()` method handles all contexts
 - **Dynamic Filter Creation**: Automatically creates `datamachine_{agentType}_tools` filters
 - **Error Handling**: Standardized error response building with classification
 - **Configuration Integration**: Automatic configuration handler registration
@@ -194,9 +197,9 @@ class GoogleSearch extends BaseTool {
 #### Benefits
 
 - **Unified Architecture**: One base class for all tools eliminates trait usage
-- **Agent Agnostic**: Dynamic filter creation per agent type
+- **Context Agnostic**: Dynamic filter creation per context
 - **Error Handling**: Standardized error classification (not_found, validation, permission, system)
-- **Extensibility**: Easy to add new agent types without updating tools
+- **Extensibility**: Easy to add new contexts without updating tools
 - **Maintainability**: Centralized registration and error handling logic
 
 See [BaseTool documentation](base-tool.md) for complete details.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,37 +1,41 @@
 # Data Machine User Documentation
 
-**AI-first WordPress plugin for automating and orchestrating content workflows with a visual pipeline builder, conversational chat agent, REST API, and extensibility through handlers and tools.**
+**AI-first WordPress plugin for automating and orchestrating content workflows with a visual pipeline builder, chat context, REST API, and extensibility through handlers and tools.**
 
-## Agent-First Architecture
+## System Agent Architecture
 
-Data Machine is designed for AI agents as primary users, not just tool operators.
+Data Machine is designed around a **System Agent** orchestration layer that can be used by different runtimes and entry points.
+
+- **System Agent**: orchestration, scheduling, policies, directives
+- **Agent Runtime**: execution loop (external today, first-party runtime planned)
+- **Contexts**: `pipeline`, `chat`, and `system`
 
 ### The Self-Orchestration Pattern
 
-While humans use Data Machine to automate content workflows, AI agents can use it to **automate themselves**:
+While humans use Data Machine to automate content workflows, AI runtimes can use it to **automate themselves**:
 
 ```
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│   AGENT     │ ──▶ │   QUEUE     │ ──▶ │  PIPELINE   │ ──▶ │ AGENT PING  │
-│ queues task │     │  persists   │     │  executes   │     │  wakes agent│
+│  RUNTIME    │ ──▶ │   QUEUE     │ ──▶ │  PIPELINE   │ ──▶ │ AGENT PING  │
+│ queues task │     │  persists   │     │  executes   │     │ wakes runtime│
 │             │     │  context    │     │             │     │             │
 └─────────────┘     └─────────────┘     └─────────────┘     └──────┬──────┘
        ▲                                                          │
        └──────────────────────────────────────────────────────────┘
-                         Agent processes, queues next task
+                        Runtime processes, queues next task
 ```
 
 **Key concepts:**
 
 - **Prompt Queue as Project Memory**: Queue items persist across sessions, storing project context that survives context window limits. Your multi-week project becomes a series of queued prompts.
 
-- **Agent Ping for Continuity**: The `agent_ping` step type triggers external agents (via webhook) after pipeline completion. This is how the loop closes — you get notified when it's your turn to act. Agent Ping is outbound-only; inbound triggers use the REST API.
+- **Agent Ping for Continuity**: The `agent_ping` step type triggers external runtimes (via webhook) after pipeline completion. This is how the loop closes — you get notified when it's your turn to act. Agent Ping is outbound-only; inbound triggers use the REST API.
 
-- **Phased Execution**: Complex projects execute in stages over days or weeks. Each stage completes, pings the agent, and the agent queues the next stage.
+- **Phased Execution**: Complex projects execute in stages over days or weeks. Each stage completes, pings the runtime, and the runtime queues the next stage.
 
-- **Autonomous Loops**: An agent can run indefinitely: process result → queue next task → sleep → wake on ping → repeat. Use explicit stop conditions to avoid runaway loops.
+- **Autonomous Loops**: A runtime can run indefinitely: process result → queue next task → sleep → wake on ping → repeat. Use explicit stop conditions to avoid runaway loops.
 
-This transforms Data Machine from a content automation tool into a **self-scheduling execution layer for AI agents**.
+This transforms Data Machine from a content automation tool into a **self-scheduling execution layer for AI runtimes**.
 
 ## System Architecture
 
@@ -57,15 +61,15 @@ Abilities are the single source of truth for REST endpoints, CLI commands, and C
 
 ## Data Flow
 
-- **DataPacket** standardizes the payload (content, metadata, attachments) that AI agents receive, keeping packets chronological and clean of URLs when not needed.
+- **DataPacket** standardizes the payload (content, metadata, attachments) that AI requests receive, keeping packets chronological and clean of URLs when not needed.
 - **EngineData** stores engine-specific parameters such as `source_url`, `image_url`, and flow context, which fetch handlers persist via the `datamachine_engine_data` filter for downstream handlers.
 - **FilesRepository modules** (DirectoryManager, FileStorage, RemoteFileDownloader, ImageValidator, FileCleanup, FileRetrieval) isolate file storage per flow, validate uploads, and enforce automatic cleanup after jobs complete.
 
 ## AI Integration
 
-- **Tool-first architecture** enables AI agents (pipeline and chat) to call tools that interact with handlers, external APIs, or workflow metadata.
+- **Tool-first architecture** enables AI contexts (pipeline and chat) to call tools that interact with handlers, external APIs, or workflow metadata.
 - **PromptBuilder + RequestBuilder** apply layered directives via the `datamachine_directives` filter so every request includes identity, context, and site-specific instructions.
-- **Global tools** (Google Search, Local Search, Web Fetch, WordPress Post Reader) are registered under `/inc/Engine/AI/Tools/` and available to all agents.
+- **Global tools** (Google Search, Local Search, Web Fetch, WordPress Post Reader) are registered under `/inc/Engine/AI/Tools/` and available to all contexts.
 - **Chat-specific tools** (AddPipelineStep, ApiQuery, AuthenticateHandler, ConfigureFlowSteps, ConfigurePipelineStep, CopyFlow, CreateFlow, CreatePipeline, CreateTaxonomyTerm, ExecuteWorkflowTool, GetHandlerDefaults, ManageLogs, ReadLogs, RunFlow, SearchTaxonomyTerms, SetHandlerDefaults, UpdateFlow) orchestrate pipeline and flow management within conversations.
 - **ToolParameters + ToolResultFinder** gather parameter metadata for tools and interpret results inside data packets to keep conversations consistent.
 

--- a/inc/Api/Logs.php
+++ b/inc/Api/Logs.php
@@ -3,15 +3,15 @@
  * Logs REST API Endpoints
  *
  * Provides REST API access to log file operations and configuration.
- * Supports per-agent-type log files and levels.
+ * Supports per-context log files and levels.
  * Requires WordPress manage_options capability for all operations.
  *
  * Endpoints:
- * - GET /datamachine/v1/logs/agent-types - Get available agent types
- * - GET /datamachine/v1/logs - Get log metadata (requires agent_type param)
- * - GET /datamachine/v1/logs/content - Get log file content (requires agent_type param)
- * - DELETE /datamachine/v1/logs - Clear log file (requires agent_type param, or agent_type=all)
- * - PUT /datamachine/v1/logs/level - Update log level (requires agent_type param)
+ * - GET /datamachine/v1/logs/agent-types - Get available contexts
+ * - GET /datamachine/v1/logs - Get log metadata (requires agent_type context param)
+ * - GET /datamachine/v1/logs/content - Get log file content (requires agent_type context param)
+ * - DELETE /datamachine/v1/logs - Clear log file (requires agent_type context param, or agent_type=all)
+ * - PUT /datamachine/v1/logs/level - Update log level (requires agent_type context param)
  *
  * @package DataMachine\Api
  */
@@ -39,7 +39,7 @@ class Logs {
 	 */
 	public static function register_routes() {
 
-		// GET /datamachine/v1/logs/agent-types - Get available agent types
+		// GET /datamachine/v1/logs/agent-types - Get available contexts
 		register_rest_route(
 			'datamachine/v1',
 			'/logs/agent-types',
@@ -62,7 +62,7 @@ class Logs {
 					'agent_type' => array(
 						'required'          => true,
 						'type'              => 'string',
-						'description'       => __( 'Agent type to clear logs for, or "all" to clear all logs', 'data-machine' ),
+						'description'       => __( 'Context to clear logs for, or "all" to clear all logs', 'data-machine' ),
 						'validate_callback' => function ( $param ) {
 							return 'all' === $param || AgentType::isValid( $param );
 						},
@@ -83,7 +83,7 @@ class Logs {
 					'agent_type'  => array(
 						'required'          => true,
 						'type'              => 'string',
-						'description'       => __( 'Agent type to get logs for', 'data-machine' ),
+						'description'       => __( 'Context to get logs for', 'data-machine' ),
 						'validate_callback' => function ( $param ) {
 							return AgentType::isValid( $param );
 						},
@@ -144,7 +144,7 @@ class Logs {
 					'agent_type' => array(
 						'required'          => false,
 						'type'              => 'string',
-						'description'       => __( 'Agent type to get metadata for. If omitted, returns metadata for all agent types.', 'data-machine' ),
+						'description'       => __( 'Context to get metadata for. If omitted, returns metadata for all contexts.', 'data-machine' ),
 						'validate_callback' => function ( $param ) {
 							return empty( $param ) || AgentType::isValid( $param );
 						},
@@ -165,7 +165,7 @@ class Logs {
 					'agent_type' => array(
 						'required'          => true,
 						'type'              => 'string',
-						'description'       => __( 'Agent type to set log level for', 'data-machine' ),
+						'description'       => __( 'Context to set log level for', 'data-machine' ),
 						'validate_callback' => function ( $param ) {
 							return AgentType::isValid( $param );
 						},
@@ -200,7 +200,7 @@ class Logs {
 	}
 
 	/**
-	 * Handle get agent types request
+	 * Handle get contexts request
 	 *
 	 * GET /datamachine/v1/logs/agent-types
 	 */
@@ -245,7 +245,7 @@ class Logs {
 					'success' => true,
 					'data'    => null,
 					'message' => sprintf(
-						/* translators: %s: agent type label (e.g., Pipeline, Chat, System) */
+						/* translators: %s: context label (e.g., Pipeline Context, Chat Context, System Context) */
 						__( '%s logs cleared successfully.', 'data-machine' ),
 						$agent_label
 					),

--- a/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
@@ -41,7 +41,7 @@ const AgentApp = () => {
 	return (
 		<div className="datamachine-agent-app">
 			<div className="datamachine-agent-header">
-				<h1 className="datamachine-agent-title">Agent</h1>
+				<h1 className="datamachine-agent-title">System Agent</h1>
 			</div>
 			<TabPanel
 				className="datamachine-tabs"

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentSettings.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentSettings.jsx
@@ -212,13 +212,13 @@ const AgentSettings = () => {
 															</Button>
 														) }
 
-														{ isConfigured ? (
-															<label className="datamachine-tool-enabled-toggle">
-																<input
-																	type="checkbox"
-																	checked={
-																		isEnabled
-																	}
+								{ isConfigured ? (
+									<label className="datamachine-tool-enabled-toggle">
+										<input
+													type="checkbox"
+													checked={
+														isEnabled
+													}
 																	onChange={ (
 																		e
 																	) =>
@@ -229,11 +229,10 @@ const AgentSettings = () => {
 																				.checked
 																		)
 																	}
-																/>
-																Enable for
-																agents
-															</label>
-														) : (
+													/>
+										Enable in contexts
+									</label>
+								) : (
 															<label className="datamachine-tool-enabled-toggle datamachine-tool-disabled">
 																<input
 																	type="checkbox"
@@ -275,7 +274,7 @@ const AgentSettings = () => {
 							</div>
 							<p className="description">
 								Fallback provider and model used when no
-								agent-specific override is set below.
+								context-specific override is set below.
 							</p>
 						</td>
 					</tr>
@@ -283,20 +282,20 @@ const AgentSettings = () => {
 					{ ( providersData?.agent_types || [] ).length > 0 && (
 						<tr>
 							<th scope="row">
-								Per-Agent Model Overrides
+								Per-Context Model Overrides
 							</th>
 							<td>
-								<p
-									className="description"
-									style={ {
-										marginTop: 0,
-										marginBottom: '16px',
-									} }
-								>
-									Assign different providers and models to
-									each agent type. Leave empty to use the
-									global default above.
-								</p>
+							<p
+								className="description"
+								style={ {
+									marginTop: 0,
+									marginBottom: '16px',
+								} }
+							>
+								Assign different providers and models to
+								each context. Leave empty to use the
+								global default above.
+							</p>
 								{ ( providersData?.agent_types || [] ).map(
 									( agentType ) => {
 										const agentConfig =
@@ -387,7 +386,7 @@ const AgentSettings = () => {
 					) }
 
 					<tr>
-						<th scope="row">Provide site context to agents</th>
+						<th scope="row">Provide site context to AI requests</th>
 						<td>
 							<fieldset>
 								<label htmlFor="site_context_enabled">
@@ -407,13 +406,13 @@ const AgentSettings = () => {
 									Include WordPress site context in AI
 									requests
 								</label>
-								<p className="description">
-									Automatically provides site information
-									(post types, taxonomies, user stats) to AI
-									agents for better context awareness.
-								</p>
-							</fieldset>
-						</td>
+							<p className="description">
+								Automatically provides site information
+								(post types, taxonomies, user stats) to AI
+								requests for better context awareness.
+							</p>
+						</fieldset>
+					</td>
 					</tr>
 
 					<tr>
@@ -447,23 +446,23 @@ const AgentSettings = () => {
 								className="small-text"
 							/>
 							<p className="description">
-								Maximum number of conversation turns allowed for
-								AI agents (1-50). Applies to both pipeline and
-								chat conversations.
+								Maximum number of conversation turns allowed per
+								AI request (1-50). Applies to both pipeline and
+								chat contexts.
 							</p>
 						</td>
 					</tr>
 
 					<tr>
-						<th scope="row">Chat Agent Webhook</th>
+						<th scope="row">Chat Context Webhook</th>
 						<td>
 							<div className="datamachine-ping-secret-section">
-								<p className="description" style={ { marginTop: 0 } }>
-									Allow external services to send messages to
-									your chat agent via webhook. Use this
-									endpoint URL and secret token in Agent Ping
-									step configurations.
-								</p>
+							<p className="description" style={ { marginTop: 0 } }>
+								Allow external services to send messages to
+								your chat context via webhook. Use this
+								endpoint URL and secret token in Agent Ping
+								step configurations.
+							</p>
 
 								<div style={ { marginBottom: '12px' } }>
 									<strong>Endpoint URL:</strong>{ ' ' }

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/SystemTasksTab.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/SystemTasksTab.jsx
@@ -1,7 +1,7 @@
 /**
  * SystemTasksTab Component
  *
- * Displays registered system agent tasks in a table with
+ * Displays registered system tasks in a table with
  * enable/disable toggles, last run info, and result status.
  *
  * @since 0.32.0

--- a/inc/Core/Admin/Pages/Logs/assets/react/api/logs.js
+++ b/inc/Core/Admin/Pages/Logs/assets/react/api/logs.js
@@ -12,22 +12,22 @@
 import { client } from '@shared/utils/api';
 
 /**
- * Fetch available agent types
- * @return {Promise<Object>} Agent types with labels and descriptions
+ * Fetch available contexts
+ * @return {Promise<Object>} Contexts with labels and descriptions
  */
 export const fetchAgentTypes = () => client.get( '/logs/agent-types' );
 
 /**
- * Fetch log metadata for a specific agent type
- * @param {string} agentType - Agent type (pipeline, chat)
+ * Fetch log metadata for a specific context
+ * @param {string} agentType - Context id (pipeline, chat, system)
  * @return {Promise<Object>} Log metadata including file info and configuration
  */
 export const fetchLogMetadata = ( agentType ) =>
 	client.get( '/logs', { agent_type: agentType } );
 
 /**
- * Fetch log content for a specific agent type
- * @param {string} agentType  Agent type (pipeline, chat)
+ * Fetch log content for a specific context
+ * @param {string} agentType  Context id (pipeline, chat, system)
  * @param {string} mode  Content mode: 'full' or 'recent'
  * @param {number} limit  Number of entries when mode is 'recent'
  * @return {Promise<Object>}  Log content and metadata
@@ -36,23 +36,23 @@ export const fetchLogContent = ( agentType, mode = 'recent', limit = 200 ) =>
 	client.get( '/logs/content', { agent_type: agentType, mode, limit } );
 
 /**
- * Clear logs for a specific agent type
- * @param {string} agentType - Agent type (pipeline, chat)
+ * Clear logs for a specific context
+ * @param {string} agentType - Context id (pipeline, chat, system)
  * @return {Promise<Object>} Clear operation result
  */
 export const clearLogs = ( agentType ) =>
 	client.delete( '/logs', { agent_type: agentType } );
 
 /**
- * Clear all logs for all agent types
+ * Clear all logs for all contexts
  * @return {Promise<Object>} Clear operation result
  */
 export const clearAllLogs = () =>
 	client.delete( '/logs', { agent_type: 'all' } );
 
 /**
- * Update log level for a specific agent type
- * @param {string} agentType - Agent type (pipeline, chat)
+ * Update log level for a specific context
+ * @param {string} agentType - Context id (pipeline, chat, system)
  * @param {string} level     - Log level (debug, error, none)
  * @return {Promise<Object>} Update operation result
  */

--- a/inc/Core/Admin/Pages/Logs/assets/react/components/LogsTabs.jsx
+++ b/inc/Core/Admin/Pages/Logs/assets/react/components/LogsTabs.jsx
@@ -1,7 +1,7 @@
 /**
  * LogsTabs Component
  *
- * Tabbed interface for per-agent-type log viewing.
+ * Tabbed interface for per-context log viewing.
  */
 
 /**
@@ -30,12 +30,12 @@ const LogsTabs = () => {
 	if ( isError || ! agentTypes ) {
 		return (
 			<div className="datamachine-logs-tabs-error">
-				{ __( 'Failed to load agent types.', 'data-machine' ) }
+				{ __( 'Failed to load contexts.', 'data-machine' ) }
 			</div>
 		);
 	}
 
-	// Build tabs from agent types
+	// Build tabs from contexts
 	const tabs = Object.entries( agentTypes ).map( ( [ key, info ] ) => ( {
 		name: key,
 		title: info.label,

--- a/inc/Core/Admin/Pages/Logs/assets/react/queries/logs.js
+++ b/inc/Core/Admin/Pages/Logs/assets/react/queries/logs.js
@@ -30,7 +30,7 @@ export const logsKeys = {
 };
 
 /**
- * Fetch available agent types
+ * Fetch available contexts
  */
 export const useAgentTypes = () =>
 	useQuery( {
@@ -39,16 +39,16 @@ export const useAgentTypes = () =>
 			const response = await logsApi.fetchAgentTypes();
 			if ( ! response.success ) {
 				throw new Error(
-					response.message || 'Failed to fetch agent types'
+					response.message || 'Failed to fetch contexts'
 				);
 			}
 			return response.data;
 		},
-		staleTime: 10 * 60 * 1000, // Agent types rarely change
+		staleTime: 10 * 60 * 1000, // Context types rarely change
 	} );
 
 /**
- * Fetch log metadata for a specific agent type
+ * Fetch log metadata for a specific context
  * @param agentType
  */
 export const useLogMetadata = ( agentType ) =>
@@ -67,7 +67,7 @@ export const useLogMetadata = ( agentType ) =>
 	} );
 
 /**
- * Fetch log content for a specific agent type
+ * Fetch log content for a specific context
  * @param agentType
  * @param mode
  * @param limit
@@ -92,7 +92,7 @@ export const useLogContent = ( agentType, mode = 'recent', limit = 200 ) =>
 	} );
 
 /**
- * Clear logs for a specific agent type
+ * Clear logs for a specific context
  */
 export const useClearLogs = () => {
 	const queryClient = useQueryClient();
@@ -206,7 +206,7 @@ export const useClearAllLogs = () => {
 };
 
 /**
- * Update log level for a specific agent type
+ * Update log level for a specific context
  */
 export const useUpdateLogLevel = () => {
 	const queryClient = useQueryClient();

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -129,26 +129,26 @@ class PluginSettings {
 	}
 
 	/**
-	 * Get the list of known agent types.
+	 * Get the list of known execution contexts.
 	 *
-	 * @return array Array of agent type definitions with id, label, and description.
+	 * @return array Array of context definitions with id, label, and description.
 	 */
 	public static function getAgentTypes(): array {
 		return array(
 			array(
 				'id'          => 'chat',
-				'label'       => __( 'Chat Agent', 'data-machine' ),
-				'description' => __( 'Interactive chat conversations. Benefits from capable models for complex reasoning.', 'data-machine' ),
+				'label'       => __( 'Chat Context', 'data-machine' ),
+				'description' => __( 'Interactive chat execution context. Benefits from capable models for complex reasoning.', 'data-machine' ),
 			),
 			array(
 				'id'          => 'pipeline',
-				'label'       => __( 'Pipeline Agent', 'data-machine' ),
-				'description' => __( 'Structured workflow execution. Operates within defined steps — efficient models work well.', 'data-machine' ),
+				'label'       => __( 'Pipeline Context', 'data-machine' ),
+				'description' => __( 'Structured workflow execution context. Operates within defined steps — efficient models work well.', 'data-machine' ),
 			),
 			array(
 				'id'          => 'system',
-				'label'       => __( 'System Agent', 'data-machine' ),
-				'description' => __( 'Background tasks like alt text generation and issue creation.', 'data-machine' ),
+				'label'       => __( 'System Context', 'data-machine' ),
+				'description' => __( 'Background task execution context (for example, alt text generation and issue creation).', 'data-machine' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/AgentContext.php
+++ b/inc/Engine/AI/AgentContext.php
@@ -2,7 +2,7 @@
 /**
  * Agent Context
  *
- * Runtime tracking of the current agent type executing.
+ * Runtime tracking of the current execution context.
  * Used by the logging system to route logs to the correct file
  * when agent_type is not explicitly passed in log context.
  *
@@ -21,25 +21,25 @@ final class AgentContext {
 	private static ?string $currentAgentType = null;
 
 	/**
-	 * Set the current agent type context.
+	 * Set the current execution context.
 	 *
-	 * @param string $agentType Agent type (use AgentType constants)
+	 * @param string $agentType Context identifier (use AgentType constants)
 	 */
 	public static function set( string $agentType ): void {
 		self::$currentAgentType = $agentType;
 	}
 
 	/**
-	 * Get the current agent type context.
+	 * Get the current execution context.
 	 *
-	 * @return string|null Current agent type or null if not set
+	 * @return string|null Current context or null if not set
 	 */
 	public static function get(): ?string {
 		return self::$currentAgentType;
 	}
 
 	/**
-	 * Clear the current agent type context.
+	 * Clear the current execution context.
 	 */
 	public static function clear(): void {
 		self::$currentAgentType = null;

--- a/inc/Engine/AI/AgentType.php
+++ b/inc/Engine/AI/AgentType.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Agent Type Registry
+ * Agent Context Registry
  *
- * Defines agent type constants and provides a filterable registry
- * for discovering available agent types throughout the system.
+ * Defines context constants and provides a filterable registry
+ * for discovering available execution contexts throughout the system.
  *
  * @package DataMachine\Engine\AI
  * @since 0.7.2
@@ -23,7 +23,7 @@ final class AgentType {
 	public const ALL      = 'all';
 
 	/**
-	 * Get all registered agent types.
+	 * Get all registered execution contexts.
 	 *
 	 * @return array<string, array{label: string, description: string}>
 	 */
@@ -32,25 +32,25 @@ final class AgentType {
 			'datamachine_agent_types',
 			array(
 				self::PIPELINE => array(
-					'label'       => __( 'Pipeline', 'data-machine' ),
-					'description' => __( 'Automated workflow execution', 'data-machine' ),
+					'label'       => __( 'Pipeline Context', 'data-machine' ),
+					'description' => __( 'Automated workflow execution context', 'data-machine' ),
 				),
 				self::CHAT     => array(
-					'label'       => __( 'Chat', 'data-machine' ),
-					'description' => __( 'Conversational interface', 'data-machine' ),
+					'label'       => __( 'Chat Context', 'data-machine' ),
+					'description' => __( 'Conversational execution context', 'data-machine' ),
 				),
 				self::SYSTEM   => array(
-					'label'       => __( 'System', 'data-machine' ),
-					'description' => __( 'Infrastructure and system operations', 'data-machine' ),
+					'label'       => __( 'System Context', 'data-machine' ),
+					'description' => __( 'Infrastructure and background operations context', 'data-machine' ),
 				),
 			)
 		);
 	}
 
 	/**
-	 * Check if a given agent type is valid.
+	 * Check if a given context is valid.
 	 *
-	 * @param string $type Agent type to validate
+	 * @param string $type Context to validate
 	 * @return bool
 	 */
 	public static function isValid( string $type ): bool {
@@ -58,9 +58,9 @@ final class AgentType {
 	}
 
 	/**
-	 * Get the log filename for a given agent type.
+	 * Get the log filename for a given context.
 	 *
-	 * @param string $type Agent type
+	 * @param string $type Context identifier
 	 * @return string Filename without path (e.g., 'datamachine-pipeline.log')
 	 */
 	public static function getLogFilename( string $type ): string {


### PR DESCRIPTION
## Summary
- formalize the architecture boundary between **System Agent** (orchestration) and **Agent Runtime** (execution) with a dedicated core-system doc
- shift terminology in key docs and admin copy from ambiguous “agent type” language toward **context** language (`pipeline`, `chat`, `system`) while keeping `agent_type` API/storage compatibility
- update labels/descriptions for context metadata and logs endpoints/UI so the model is consistent across docs, PHP metadata, and React admin surfaces

## Why
Data Machine currently uses “agent” for multiple concepts, which creates confusion between orchestration identity and execution/runtime concerns. This PR makes the architecture explicit now, so `data-machine-agent` runtime integration can land on a clean mental model without breaking existing clients.

## Notes
- No REST field or DB schema breakage in this phase
- Existing `agent_type` keys remain intact for backward compatibility
- Follows #639 and #640