### PR TITLE
feat: enforce granular data machine permissions (#597)

### DIFF
--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -22,6 +22,21 @@ namespace DataMachine\Abilities;
 class PermissionHelper {
 
 	/**
+	 * Data Machine capability map.
+	 *
+	 * @since 0.37.0
+	 * @var array<string, string>
+	 */
+	private const CAPABILITY_MAP = array(
+		'manage_agents'   => 'datamachine_manage_agents',
+		'manage_flows'    => 'datamachine_manage_flows',
+		'manage_settings' => 'datamachine_manage_settings',
+		'chat'            => 'datamachine_chat',
+		'use_tools'       => 'datamachine_use_tools',
+		'view_logs'       => 'datamachine_view_logs',
+	);
+
+	/**
 	 * Whether the current execution context has been pre-authenticated.
 	 *
 	 * When true, can_manage() returns true without checking WordPress
@@ -37,6 +52,14 @@ class PermissionHelper {
 	private static bool $authenticated_context = false;
 
 	/**
+	 * Acting user ID for pre-authenticated contexts.
+	 *
+	 * @since 0.37.0
+	 * @var int
+	 */
+	private static int $authenticated_user_id = 0;
+
+	/**
 	 * Check if current context has admin-level permissions.
 	 *
 	 * Allows execution in:
@@ -50,36 +73,59 @@ class PermissionHelper {
 	 * @return bool True if permission granted.
 	 */
 	public static function can_manage(): bool {
+		return self::can( 'manage_flows' ) || self::can( 'manage_settings' ) || self::can( 'manage_agents' );
+	}
+
+	/**
+	 * Check whether current context can perform an action.
+	 *
+	 * @since 0.37.0
+	 *
+	 * @param string $action Action key (manage_agents, manage_flows, manage_settings, chat, use_tools, view_logs).
+	 * @return bool
+	 */
+	public static function can( string $action ): bool {
 		// WP-CLI always allowed (filterable for testing).
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			/**
-			 * Filters whether WP-CLI context bypasses permission checks.
-			 *
-			 * In production, WP-CLI always has full access. During testing,
-			 * this filter allows permission denial tests to run by returning false.
-			 *
-			 * @since 0.31.0
-			 *
-			 * @param bool $bypass True to bypass permission check (default: true).
-			 */
 			if ( apply_filters( 'datamachine_cli_bypass_permissions', true ) ) {
 				return true;
 			}
 		}
 
 		// Action Scheduler background processing context.
-		// This is needed because async requests may not have user cookies.
 		if ( doing_action( 'action_scheduler_run_queue' ) ) {
 			return true;
 		}
 
-		// Pre-authenticated context (e.g., webhook trigger with valid Bearer token).
+		// Pre-authenticated context: evaluate acting user if provided.
 		if ( self::$authenticated_context ) {
+			if ( self::$authenticated_user_id > 0 ) {
+				return self::user_can( self::$authenticated_user_id, $action );
+			}
+
 			return true;
 		}
 
-		// Standard capability check for logged-in users.
-		return current_user_can( 'manage_options' );
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		return self::user_can( get_current_user_id(), $action );
+	}
+
+	/**
+	 * Get current acting user ID for permission-bounded execution.
+	 *
+	 * @since 0.37.0
+	 *
+	 * @return int
+	 */
+	public static function acting_user_id(): int {
+		if ( self::$authenticated_context && self::$authenticated_user_id > 0 ) {
+			return self::$authenticated_user_id;
+		}
+
+		return get_current_user_id();
 	}
 
 	/**
@@ -103,13 +149,15 @@ class PermissionHelper {
 	 *
 	 * @throws \Throwable Re-throws any exception from the callback after resetting context.
 	 */
-	public static function run_as_authenticated( callable $callback ) {
+	public static function run_as_authenticated( callable $callback, int $acting_user_id = 0 ) {
 		self::$authenticated_context = true;
+		self::$authenticated_user_id = absint( $acting_user_id );
 
 		try {
 			$result = $callback();
 		} finally {
 			self::$authenticated_context = false;
+			self::$authenticated_user_id = 0;
 		}
 
 		return $result;
@@ -127,5 +175,33 @@ class PermissionHelper {
 	 */
 	public static function is_authenticated_context(): bool {
 		return self::$authenticated_context;
+	}
+
+	/**
+	 * Check capability for a specific user against Data Machine action.
+	 *
+	 * @since 0.37.0
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $action  Action key.
+	 * @return bool
+	 */
+	private static function user_can( int $user_id, string $action ): bool {
+		$mapped_capability = self::CAPABILITY_MAP[ $action ] ?? null;
+
+		if ( empty( $mapped_capability ) ) {
+			return false;
+		}
+
+		if ( user_can( $user_id, $mapped_capability ) ) {
+			return true;
+		}
+
+		// Backward compatibility for legacy installs/roles.
+		if ( user_can( $user_id, 'manage_options' ) ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/inc/Api/Analytics.php
+++ b/inc/Api/Analytics.php
@@ -20,6 +20,7 @@
 
 namespace DataMachine\Api;
 
+use DataMachine\Abilities\PermissionHelper;
 use WP_REST_Server;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -78,7 +79,7 @@ class Analytics {
 	 * @return bool|\WP_Error
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to access analytics data.', 'data-machine' ),

--- a/inc/Api/Auth.php
+++ b/inc/Api/Auth.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Api;
 
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\AuthAbilities;
 use WP_REST_Server;
 
@@ -96,7 +97,7 @@ class Auth {
 	 * Check if user has permission to manage authentication
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_settings' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to manage authentication.', 'data-machine' ),

--- a/inc/Api/Execute.php
+++ b/inc/Api/Execute.php
@@ -9,6 +9,8 @@
 
 namespace DataMachine\Api;
 
+use DataMachine\Abilities\PermissionHelper;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -33,7 +35,7 @@ class Execute {
 				'methods'             => 'POST',
 				'callback'            => array( self::class, 'handle_execute' ),
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return PermissionHelper::can( 'manage_flows' );
 				},
 				'args'                => array(
 					'flow_id'      => array(

--- a/inc/Api/Flows/FlowQueue.php
+++ b/inc/Api/Flows/FlowQueue.php
@@ -10,6 +10,7 @@
 
 namespace DataMachine\Api\Flows;
 
+use DataMachine\Abilities\PermissionHelper;
 use WP_REST_Server;
 
 if ( ! defined( 'WPINC' ) ) {
@@ -212,7 +213,7 @@ class FlowQueue {
 	 * @return bool|\WP_Error
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to manage flow queues.', 'data-machine' ),

--- a/inc/Api/Flows/FlowSteps.php
+++ b/inc/Api/Flows/FlowSteps.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Api\Flows;
 
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\FlowStepAbilities;
 use DataMachine\Abilities\HandlerAbilities;
 use DataMachine\Abilities\StepTypeAbilities;
@@ -216,7 +217,7 @@ class FlowSteps {
 	 * Check if user has permission to manage flow steps
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to manage flow steps.', 'data-machine' ),

--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -10,6 +10,7 @@
 
 namespace DataMachine\Api\Flows;
 
+use DataMachine\Abilities\PermissionHelper;
 use WP_REST_Server;
 
 if ( ! defined( 'WPINC' ) ) {
@@ -245,7 +246,7 @@ class Flows {
 	 * Check if user has permission to manage flows
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to create flows.', 'data-machine' ),

--- a/inc/Api/InternalLinks.php
+++ b/inc/Api/InternalLinks.php
@@ -17,6 +17,7 @@
 
 namespace DataMachine\Api;
 
+use DataMachine\Abilities\PermissionHelper;
 use WP_REST_Server;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -80,7 +81,7 @@ class InternalLinks {
 	 * @return bool|\WP_Error
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to access internal link tools.', 'data-machine' ),

--- a/inc/Api/Jobs.php
+++ b/inc/Api/Jobs.php
@@ -16,6 +16,7 @@
 
 namespace DataMachine\Api;
 
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\JobAbilities;
 
 if ( ! defined( 'WPINC' ) ) {
@@ -149,7 +150,7 @@ class Jobs {
 	 * Check if user has permission to manage jobs
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to manage jobs.', 'data-machine' ),

--- a/inc/Api/Logs.php
+++ b/inc/Api/Logs.php
@@ -18,6 +18,7 @@
 
 namespace DataMachine\Api;
 
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\LogAbilities;
 use DataMachine\Engine\AI\AgentType;
 
@@ -188,7 +189,7 @@ class Logs {
 	 * Check if user has permission to manage logs
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'view_logs' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to manage logs.', 'data-machine' ),

--- a/inc/Api/Pipelines/PipelineFlows.php
+++ b/inc/Api/Pipelines/PipelineFlows.php
@@ -10,6 +10,8 @@
 
 namespace DataMachine\Api\Pipelines;
 
+use DataMachine\Abilities\PermissionHelper;
+
 if ( ! defined( 'WPINC' ) ) {
 	die;
 }
@@ -50,7 +52,7 @@ class PipelineFlows {
 	 * Check if user has permission to access pipeline flows
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to access pipeline flows.', 'data-machine' ),

--- a/inc/Api/Pipelines/PipelineSteps.php
+++ b/inc/Api/Pipelines/PipelineSteps.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Api\Pipelines;
 
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\PipelineStepAbilities;
 use DataMachine\Abilities\StepTypeAbilities;
 use WP_REST_Server;
@@ -212,7 +213,7 @@ class PipelineSteps {
 	 * Check if user has permission to manage pipeline steps
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to manage pipeline steps.', 'data-machine' ),
@@ -423,7 +424,7 @@ class PipelineSteps {
 	 */
 	public static function handle_update_step_config( $request ) {
 		// Validate permissions
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'Insufficient permissions.', 'data-machine' ),

--- a/inc/Api/Pipelines/Pipelines.php
+++ b/inc/Api/Pipelines/Pipelines.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Api\Pipelines;
 
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\PipelineAbilities;
 use DataMachine\Core\Admin\DateFormatter;
 use WP_REST_Server;
@@ -221,7 +222,7 @@ class Pipelines {
 	 * Check if user has permission to access pipelines
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to access pipelines.', 'data-machine' ),

--- a/inc/Api/ProcessedItems.php
+++ b/inc/Api/ProcessedItems.php
@@ -14,6 +14,7 @@
 
 namespace DataMachine\Api;
 
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\ProcessedItemsAbilities;
 
 if ( ! defined( 'WPINC' ) ) {
@@ -72,7 +73,7 @@ class ProcessedItems {
 	 * Check if user has permission to manage processed items
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to manage processed items.', 'data-machine' ),

--- a/inc/Api/Settings.php
+++ b/inc/Api/Settings.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Api;
 
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\SettingsAbilities;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -196,7 +197,7 @@ class Settings {
 	 * Check if user has permission to manage settings
 	 */
 	public static function check_permission( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! PermissionHelper::can( 'manage_settings' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to manage settings.', 'data-machine' ),

--- a/inc/Api/System/System.php
+++ b/inc/Api/System/System.php
@@ -10,6 +10,7 @@
 
 namespace DataMachine\Api\System;
 
+use DataMachine\Abilities\PermissionHelper;
 use WP_REST_Server;
 use WP_REST_Request;
 use WP_Error;
@@ -45,7 +46,7 @@ class System {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( self::class, 'get_status' ),
 				'permission_callback' => function () {
-					return current_user_can('manage_options');
+					return PermissionHelper::can( 'manage_settings' );
 				},
 			)
 		);
@@ -58,7 +59,7 @@ class System {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( self::class, 'get_tasks' ),
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return PermissionHelper::can( 'manage_settings' );
 				},
 			)
 		);

--- a/inc/Core/Admin/Pages/Agent/AgentFilters.php
+++ b/inc/Core/Admin/Pages/Agent/AgentFilters.php
@@ -26,7 +26,7 @@ function datamachine_register_agent_admin_page_filters() {
 			$pages['agent'] = array(
 				'page_title' => __( 'Agent', 'data-machine' ),
 				'menu_title' => __( 'Agent', 'data-machine' ),
-				'capability' => 'manage_options',
+				'capability' => 'datamachine_manage_agents',
 				'position'   => 20,
 				'templates'  => __DIR__ . '/templates/',
 				'assets'     => array(

--- a/inc/Core/Admin/Pages/Jobs/JobsFilters.php
+++ b/inc/Core/Admin/Pages/Jobs/JobsFilters.php
@@ -37,7 +37,7 @@ function datamachine_register_jobs_admin_page_filters() {
 			$pages['jobs'] = array(
 				'page_title' => __( 'Jobs', 'data-machine' ),
 				'menu_title' => __( 'Jobs', 'data-machine' ),
-				'capability' => 'manage_options',
+				'capability' => 'datamachine_manage_flows',
 				'position'   => 20,
 				'templates'  => __DIR__ . '/templates/',
 				'assets'     => array(

--- a/inc/Core/Admin/Pages/Logs/LogsFilters.php
+++ b/inc/Core/Admin/Pages/Logs/LogsFilters.php
@@ -36,7 +36,7 @@ function datamachine_register_logs_admin_page_filters() {
 			$pages['logs'] = array(
 				'page_title' => __( 'Logs', 'data-machine' ),
 				'menu_title' => __( 'Logs', 'data-machine' ),
-				'capability' => 'manage_options',
+				'capability' => 'datamachine_view_logs',
 				'position'   => 30,
 				'templates'  => __DIR__ . '/templates/',
 				'assets'     => array(

--- a/inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php
+++ b/inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php
@@ -31,7 +31,7 @@ function datamachine_register_pipelines_admin_page_filters() {
 			$pages['pipelines'] = array(
 				'page_title' => __( 'Pipelines', 'data-machine' ),
 				'menu_title' => __( 'Pipelines', 'data-machine' ),
-				'capability' => 'manage_options',
+				'capability' => 'datamachine_manage_flows',
 				'position'   => 10,
 				'templates'  => __DIR__ . '/templates/',
 				'assets'     => array(

--- a/inc/Core/Admin/Settings/SettingsFilters.php
+++ b/inc/Core/Admin/Settings/SettingsFilters.php
@@ -20,7 +20,7 @@ function datamachine_register_settings_admin_page_filters() {
 			$pages['settings'] = array(
 				'page_title' => __( 'Data Machine Settings', 'data-machine' ),
 				'menu_title' => __( 'Settings', 'data-machine' ),
-				'capability' => 'manage_options',
+				'capability' => 'datamachine_manage_settings',
 				'position'   => 100,
 				'templates'  => DATAMACHINE_PATH . 'inc/Core/Admin/Settings/templates/',
 				'assets'     => array(


### PR DESCRIPTION
## Summary
- replace broad `manage_options` checks with granular Data Machine capabilities across admin pages and REST surfaces
- extend `PermissionHelper` with action-specific capability checks and authenticated acting-user support
- stack permission enforcement on top of the agent/session work so capability boundaries match the new architecture

## Testing
- `homeboy test data-machine --path /var/lib/datamachine/workspace/data-machine`