### PR TITLE
feat: wire chat sessions to first-class agents (#599)

### DIFF
--- a/inc/Abilities/Chat/ChatSessionHelpers.php
+++ b/inc/Abilities/Chat/ChatSessionHelpers.php
@@ -30,7 +30,23 @@ trait ChatSessionHelpers {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'chat' );
+	}
+
+	/**
+	 * Check whether a requester can access a target user's chat sessions.
+	 *
+	 * @param int $target_user_id Target user ID.
+	 * @return bool
+	 */
+	protected function can_access_user_sessions( int $target_user_id ): bool {
+		$acting_user_id = PermissionHelper::acting_user_id();
+
+		if ( $acting_user_id > 0 && $acting_user_id === $target_user_id ) {
+			return true;
+		}
+
+		return PermissionHelper::can( 'manage_agents' );
 	}
 
 	/**

--- a/inc/Abilities/Chat/CreateChatSessionAbility.php
+++ b/inc/Abilities/Chat/CreateChatSessionAbility.php
@@ -47,6 +47,10 @@ class CreateChatSessionAbility {
 								'type'        => 'integer',
 								'description' => __( 'User ID who owns the session.', 'data-machine' ),
 							),
+							'agent_id'   => array(
+								'type'        => 'integer',
+								'description' => __( 'First-class agent ID for this session.', 'data-machine' ),
+							),
 							'agent_type' => array(
 								'type'        => 'string',
 								'default'     => 'chat',
@@ -100,8 +104,16 @@ class CreateChatSessionAbility {
 		}
 
 		$user_id    = (int) $input['user_id'];
+		$agent_id   = (int) ( $input['agent_id'] ?? 0 );
 		$agent_type = ! empty( $input['agent_type'] ) ? sanitize_text_field( $input['agent_type'] ) : AgentType::CHAT;
 		$source     = ! empty( $input['source'] ) ? sanitize_text_field( $input['source'] ) : null;
+
+		if ( ! $this->can_access_user_sessions( $user_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'session_access_denied',
+			);
+		}
 
 		$session_metadata = array(
 			'started_at'    => current_time( 'mysql', true ),
@@ -117,7 +129,7 @@ class CreateChatSessionAbility {
 			$session_metadata = array_merge( $session_metadata, $input['metadata'] );
 		}
 
-		$session_id = $this->chat_db->create_session( $user_id, $session_metadata, $agent_type );
+		$session_id = $this->chat_db->create_session( $user_id, $agent_id, $session_metadata, $agent_type );
 
 		if ( empty( $session_id ) ) {
 			return array(

--- a/inc/Abilities/Chat/DeleteChatSessionAbility.php
+++ b/inc/Abilities/Chat/DeleteChatSessionAbility.php
@@ -103,6 +103,13 @@ class DeleteChatSessionAbility {
 		$session_id = sanitize_text_field( $input['session_id'] );
 		$user_id    = (int) $input['user_id'];
 
+		if ( ! $this->can_access_user_sessions( $user_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'session_access_denied',
+			);
+		}
+
 		$session = $this->verifySessionOwnership( $session_id, $user_id );
 
 		if ( isset( $session['error'] ) ) {

--- a/inc/Abilities/Chat/GetChatSessionAbility.php
+++ b/inc/Abilities/Chat/GetChatSessionAbility.php
@@ -106,6 +106,13 @@ class GetChatSessionAbility {
 		$session_id = sanitize_text_field( $input['session_id'] );
 		$user_id    = (int) $input['user_id'];
 
+		if ( ! $this->can_access_user_sessions( $user_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'session_access_denied',
+			);
+		}
+
 		$session = $this->verifySessionOwnership( $session_id, $user_id );
 
 		if ( isset( $session['error'] ) ) {

--- a/inc/Abilities/Chat/ListChatSessionsAbility.php
+++ b/inc/Abilities/Chat/ListChatSessionsAbility.php
@@ -111,6 +111,14 @@ class ListChatSessionsAbility {
 		}
 
 		$user_id    = (int) $input['user_id'];
+
+		if ( ! $this->can_access_user_sessions( $user_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'session_access_denied',
+			);
+		}
+
 		$limit      = min( 100, max( 1, (int) ( $input['limit'] ?? 20 ) ) );
 		$offset     = max( 0, (int) ( $input['offset'] ?? 0 ) );
 		$agent_type = ! empty( $input['agent_type'] ) ? sanitize_text_field( $input['agent_type'] ) : null;

--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -14,6 +14,7 @@
 
 namespace DataMachine\Api\Chat;
 
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\AgentType;
 use WP_REST_Response;
@@ -44,15 +45,17 @@ class Chat {
 	 * Register chat endpoints.
 	 */
 	public static function register_routes() {
+		$chat_permission_callback = function () {
+			return PermissionHelper::can( 'chat' );
+		};
+
 		register_rest_route(
 			'datamachine/v1',
 			'/chat',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( self::class, 'handle_chat' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => $chat_permission_callback,
 				'args'                => array(
 					'message'              => array(
 						'type'              => 'string',
@@ -101,9 +104,7 @@ class Chat {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( self::class, 'handle_continue' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => $chat_permission_callback,
 				'args'                => array(
 					'session_id' => array(
 						'type'              => 'string',
@@ -121,9 +122,7 @@ class Chat {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( self::class, 'get_session' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => $chat_permission_callback,
 				'args'                => array(
 					'session_id' => array(
 						'type'              => 'string',
@@ -141,9 +140,7 @@ class Chat {
 			array(
 				'methods'             => WP_REST_Server::DELETABLE,
 				'callback'            => array( self::class, 'delete_session' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => $chat_permission_callback,
 				'args'                => array(
 					'session_id' => array(
 						'type'              => 'string',
@@ -190,9 +187,7 @@ class Chat {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( self::class, 'list_sessions' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => $chat_permission_callback,
 				'args'                => array(
 					'limit'      => array(
 						'type'              => 'integer',

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -453,11 +453,16 @@ class ChatOrchestrator {
 	 * @return string|WP_Error Session ID on success, WP_Error on failure.
 	 */
 	private static function createSession( int $user_id, string $source = '' ): string|WP_Error {
+		$agent_id = function_exists( 'datamachine_resolve_or_create_agent_id' )
+			? datamachine_resolve_or_create_agent_id( $user_id )
+			: 0;
+
 		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/create-chat-session' ) : null;
 
 		if ( $ability ) {
 			$input = array(
 				'user_id'    => $user_id,
+				'agent_id'   => $agent_id,
 				'agent_type' => AgentType::CHAT,
 			);
 
@@ -493,7 +498,7 @@ class ChatOrchestrator {
 			$metadata['source'] = $source;
 		}
 
-		$session_id = $chat_db->create_session( $user_id, $metadata, AgentType::CHAT );
+		$session_id = $chat_db->create_session( $user_id, $agent_id, $metadata, AgentType::CHAT );
 
 		if ( empty( $session_id ) ) {
 			return new WP_Error(

--- a/inc/Api/Users.php
+++ b/inc/Api/Users.php
@@ -9,6 +9,7 @@
 
 namespace DataMachine\Api;
 
+use DataMachine\Abilities\PermissionHelper;
 use WP_REST_Request;
 use WP_REST_Server;
 use WP_Error;
@@ -204,7 +205,11 @@ class Users {
 			);
 		}
 
-		if ( current_user_can( 'manage_options' ) || get_current_user_id() === $target_user_id ) {
+		if ( PermissionHelper::can( 'manage_flows' ) || get_current_user_id() === $target_user_id ) {
+			return true;
+		}
+
+		if ( PermissionHelper::can( 'manage_agents' ) ) {
 			return true;
 		}
 

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -14,6 +14,7 @@ namespace DataMachine\Cli\Commands;
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Core\Database\Agents\Agents;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -62,6 +63,73 @@ class AgentsCommand extends BaseCommand {
 	 * @param array $assoc_args Associative arguments.
 	 */
 	public function list_agents( array $args, array $assoc_args ): void {
+		global $wpdb;
+
+		$items = array();
+		$agent_repository = new Agents();
+		$agents_table     = $wpdb->prefix . Agents::TABLE_NAME;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$table_exists = ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $agents_table ) ) === $agents_table );
+
+		if ( ! $table_exists ) {
+			WP_CLI::warning( 'datamachine_agents table not found. Falling back to legacy user listing.' );
+			$this->list_legacy_agents( $assoc_args );
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$agents = $wpdb->get_results(
+			$wpdb->prepare( 'SELECT * FROM %i ORDER BY agent_id ASC', $agents_table ),
+			ARRAY_A
+		);
+
+		$pipelines_table = $wpdb->prefix . 'datamachine_pipelines';
+		$flows_table     = $wpdb->prefix . 'datamachine_flows';
+
+		$directory_manager = new DirectoryManager();
+
+		foreach ( $agents as $agent ) {
+			$owner_id = (int) ( $agent['owner_id'] ?? 0 );
+			$user     = $owner_id > 0 ? get_user_by( 'id', $owner_id ) : false;
+			$slug     = (string) ( $agent['agent_slug'] ?? '' );
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$user_pipelines = (int) $wpdb->get_var(
+				$wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE user_id = %d', $pipelines_table, $owner_id )
+			);
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$user_flows = (int) $wpdb->get_var(
+				$wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE user_id = %d', $flows_table, $owner_id )
+			);
+
+			$agent_dir = $directory_manager->get_agent_identity_directory( $slug );
+			$items[]   = array(
+				'agent_id'    => (int) ( $agent['agent_id'] ?? 0 ),
+				'agent_slug'  => $slug,
+				'agent_name'  => (string) ( $agent['agent_name'] ?? '' ),
+				'owner_id'    => $owner_id,
+				'owner_login' => $user ? $user->user_login : '(deleted)',
+				'pipelines'   => $user_pipelines,
+				'flows'       => $user_flows,
+				'has_files'   => is_dir( $agent_dir ) ? 'Yes' : 'No',
+				'status'      => (string) ( $agent['status'] ?? 'active' ),
+			);
+		}
+
+		$fields = array( 'agent_id', 'agent_slug', 'agent_name', 'owner_id', 'owner_login', 'pipelines', 'flows', 'has_files', 'status' );
+		$this->format_items( $items, $fields, $assoc_args, 'agent_id' );
+
+		WP_CLI::log( sprintf( 'Total: %d agent(s).', count( $items ) ) );
+	}
+
+	/**
+	 * Legacy fallback listing for pre-migration installs.
+	 *
+	 * @param array $assoc_args Command args.
+	 * @return void
+	 */
+	private function list_legacy_agents( array $assoc_args ): void {
 		global $wpdb;
 
 		$items = array();

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -146,6 +146,7 @@ class Chat extends BaseRepository {
 	 */
 	public function create_session(
 		int $user_id,
+		int $agent_id = 0,
 		array $metadata = array(),
 		string $agent_type = \DataMachine\Engine\AI\AgentType::CHAT
 	): string {
@@ -160,6 +161,7 @@ class Chat extends BaseRepository {
 			array(
 				'session_id' => $session_id,
 				'user_id'    => $user_id,
+				'agent_id'   => $agent_id > 0 ? $agent_id : null,
 				'messages'   => wp_json_encode( array() ),
 				'metadata'   => wp_json_encode( $metadata ),
 				'provider'   => null,
@@ -167,7 +169,7 @@ class Chat extends BaseRepository {
 				'agent_type' => $agent_type,
 				'expires_at' => null,
 			),
-			array( '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s' )
+			array( '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' )
 		);
 
 		if ( false === $result ) {
@@ -191,6 +193,7 @@ class Chat extends BaseRepository {
 			array(
 				'session_id' => $session_id,
 				'user_id'    => $user_id,
+				'agent_id'   => $agent_id,
 				'agent_type' => $agent_type,
 			)
 		);


### PR DESCRIPTION
## Summary
- persist `agent_id` on chat sessions and resolve/create first-class agents for user-owned chats
- make chat session permissions agent-aware instead of relying on implicit user-as-agent assumptions
- stack this on top of the permission and layered memory branches so agent identity is available everywhere it is used

## Testing
- `homeboy test data-machine`