### PR TITLE
fix: GSC submit_sitemap — scope and Content-Length bugs

### DIFF
--- a/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php
+++ b/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php
@@ -555,8 +555,9 @@ class GoogleSearchConsoleAbilities {
 				'method'  => 'PUT',
 				'timeout' => 30,
 				'headers' => array(
-					'Authorization' => 'Bearer ' . $access_token,
-					'Content-Type'  => 'application/json',
+					'Authorization'  => 'Bearer ' . $access_token,
+					'Content-Type'   => 'application/json',
+					'Content-Length' => '0',
 				),
 				'body'    => '',
 			)
@@ -606,7 +607,7 @@ class GoogleSearchConsoleAbilities {
 		$now    = time();
 		$claims = self::base64url_encode( wp_json_encode( array(
 			'iss'   => $service_account['client_email'],
-			'scope' => 'https://www.googleapis.com/auth/webmasters.readonly',
+			'scope' => 'https://www.googleapis.com/auth/webmasters',
 			'aud'   => 'https://oauth2.googleapis.com/token',
 			'iat'   => $now,
 			'exp'   => $now + 3600,


### PR DESCRIPTION
## Summary

Fixes two bugs that prevented the `submit_sitemap` action from working in the Google Search Console ability:

- **OAuth scope too restrictive** — The JWT was requesting `webmasters.readonly`, which blocks write operations (HTTP 403 "insufficient authentication scopes"). Changed to `webmasters` (read-write), which is a superset that still covers all existing read operations.
- **Missing Content-Length header** — The PUT request sent an empty body (`''`) without a `Content-Length: 0` header, causing the GSC API to return HTTP 411 "Length Required". Added the header.

Also deleted the cached `datamachine_gsc_access_token` transient on the live site so the next request will fetch a new token with the correct scope.

## Changes

`inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php`:
- Line 609: `webmasters.readonly` → `webmasters`
- Line 557-560: Added `'Content-Length' => '0'` to the PUT request headers