### PR TITLE
ci: split data-machine checks into shared comment jobs

### DIFF
--- a/.github/workflows/homeboy-release.yml
+++ b/.github/workflows/homeboy-release.yml
@@ -1,0 +1,55 @@
+name: Homeboy Release Check
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  release-check:
+    name: Homeboy Release Check
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: ''
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+          MYSQL_DATABASE: homeboy_wptests
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, intl, pdo_sqlite, mysqli
+          tools: composer:v2
+          coverage: none
+
+      - name: Install project dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - uses: Extra-Chill/homeboy-action@feat/shared-pr-comment-aggregation
+        with:
+          version: 'latest'
+          extension: wordpress
+          commands: lint,test,audit
+          component: data-machine
+          settings: '{"database_type": "mysql"}'
+          php-version: '8.2'
+          node-version: '20'
+          auto-issue: true

--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -3,9 +3,6 @@ name: Homeboy
 on:
   pull_request:
     branches: [main]
-  push:
-    tags:
-      - 'v*'
 
 permissions:
   contents: read
@@ -117,48 +114,3 @@ jobs:
           component: data-machine
           php-version: '8.2'
           node-version: '20'
-
-  release-check:
-    if: github.event_name != 'pull_request'
-    name: Homeboy Release Check
-    runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: ''
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-          MYSQL_DATABASE: homeboy_wptests
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
-          extensions: mbstring, intl, pdo_sqlite, mysqli
-          tools: composer:v2
-          coverage: none
-
-      - name: Install project dependencies
-        run: composer install --no-interaction --prefer-dist
-
-      - uses: Extra-Chill/homeboy-action@feat/shared-pr-comment-aggregation
-        with:
-          version: 'latest'
-          extension: wordpress
-          commands: lint,test,audit
-          component: data-machine
-          settings: '{"database_type": "mysql"}'
-          php-version: '8.2'
-          node-version: '20'
-          auto-issue: true


### PR DESCRIPTION
## Summary
- split PR-time Homeboy checks into separate lint, test, and audit jobs for clearer signal
- route each job through the shared-comment Homeboy Action branch so PR feedback consolidates into one bot comment
- keep tag-time release validation combined to avoid duplicate non-PR issue filing