### PR TITLE
Add one-time scheduled flow execution

### DIFF
--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -554,6 +554,11 @@ class SettingsAbilities {
 			'label' => __( 'Manual only', 'data-machine' ),
 		);
 
+		$frontend_intervals[] = array(
+			'value' => 'one_time',
+			'label' => __( 'One Time (scheduled)', 'data-machine' ),
+		);
+
 		foreach ( $intervals as $key => $interval_data ) {
 			$frontend_intervals[] = array(
 				'value' => $key,

--- a/inc/Api/Flows/FlowScheduling.php
+++ b/inc/Api/Flows/FlowScheduling.php
@@ -197,6 +197,11 @@ class FlowScheduling {
 				);
 			}
 
+			// Clear any existing schedule first (prevents duplicate actions on re-schedule).
+			if ( function_exists( 'as_unschedule_all_actions' ) ) {
+				as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+			}
+
 			as_schedule_single_action(
 				$timestamp,
 				'datamachine_run_flow_now',

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -92,7 +92,10 @@ class FlowsCommand extends BaseCommand {
 	 * : JSON object with step configurations keyed by step_type (create subcommand).
 	 *
 	 * [--scheduling=<interval>]
-	 * : Scheduling interval (manual, hourly, daily, etc.) or cron expression (e.g. "0 9 * * 1-5").
+	 * : Scheduling interval (manual, hourly, daily, one_time, etc.) or cron expression (e.g. "0 9 * * 1-5").
+	 *
+	 * [--scheduled-at=<datetime>]
+	 * : ISO-8601 datetime for one-time scheduling (e.g. "2026-03-20T15:00:00Z"). Implies --scheduling=one_time.
 	 *
 	 * [--set-prompt=<text>]
 	 * : Update the prompt for a handler step (requires handler step to exist).
@@ -498,9 +501,10 @@ class FlowsCommand extends BaseCommand {
 	private function createFlow( array $assoc_args ): void {
 		$pipeline_id = isset( $assoc_args['pipeline_id'] ) ? (int) $assoc_args['pipeline_id'] : null;
 		$flow_name   = $assoc_args['name'] ?? null;
-		$scheduling  = $assoc_args['scheduling'] ?? 'manual';
-		$dry_run     = isset( $assoc_args['dry-run'] );
-		$format      = $assoc_args['format'] ?? 'table';
+		$scheduling   = $assoc_args['scheduling'] ?? 'manual';
+		$scheduled_at = $assoc_args['scheduled-at'] ?? null;
+		$dry_run      = isset( $assoc_args['dry-run'] );
+		$format       = $assoc_args['format'] ?? 'table';
 
 		if ( ! $pipeline_id ) {
 			WP_CLI::error( 'Required: --pipeline_id=<id>' );
@@ -526,7 +530,7 @@ class FlowsCommand extends BaseCommand {
 			$step_configs = $decoded ?? array();
 		}
 
-		$scheduling_config = self::build_scheduling_config( $scheduling );
+		$scheduling_config = self::build_scheduling_config( $scheduling, $scheduled_at );
 
 		$input = array(
 			'pipeline_id'       => $pipeline_id,
@@ -681,6 +685,7 @@ class FlowsCommand extends BaseCommand {
 
 		$name           = $assoc_args['name'] ?? null;
 		$scheduling     = $assoc_args['scheduling'] ?? null;
+		$scheduled_at   = $assoc_args['scheduled-at'] ?? null;
 		$prompt         = isset( $assoc_args['set-prompt'] )
 			? wp_kses_post( wp_unslash( $assoc_args['set-prompt'] ) )
 			: null;
@@ -689,13 +694,18 @@ class FlowsCommand extends BaseCommand {
 			: null;
 		$step           = $assoc_args['step'] ?? null;
 
+		// --scheduled-at implies --scheduling=one_time.
+		if ( $scheduled_at && null === $scheduling ) {
+			$scheduling = 'one_time';
+		}
+
 		if ( null !== $handler_config && ! is_array( $handler_config ) ) {
 			WP_CLI::error( 'Invalid JSON in --handler-config. Must be a JSON object.' );
 			return;
 		}
 
 		if ( null === $name && null === $scheduling && null === $prompt && null === $handler_config ) {
-			WP_CLI::error( 'Must provide --name, --scheduling, --set-prompt, or --handler-config to update' );
+			WP_CLI::error( 'Must provide --name, --scheduling, --set-prompt, --scheduled-at, or --handler-config to update' );
 			return;
 		}
 
@@ -719,7 +729,7 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		if ( null !== $scheduling ) {
-			$input['scheduling_config'] = self::build_scheduling_config( $scheduling );
+			$input['scheduling_config'] = self::build_scheduling_config( $scheduling, $scheduled_at );
 		}
 
 		if ( null !== $name || null !== $scheduling ) {
@@ -1229,11 +1239,29 @@ class FlowsCommand extends BaseCommand {
 	 * Detects cron expressions and routes them correctly:
 	 * - Cron expression (e.g. "0 * /3 * * *") → interval=cron + cron_expression
 	 * - Interval key (e.g. "daily") → interval=<key>
+	 * - One-time (scheduling=one_time) → interval=one_time + timestamp (requires $scheduled_at)
 	 *
-	 * @param string $scheduling Value from --scheduling CLI flag.
+	 * @param string      $scheduling   Value from --scheduling CLI flag.
+	 * @param string|null $scheduled_at ISO-8601 datetime for one-time scheduling.
 	 * @return array Scheduling config array.
 	 */
-	private static function build_scheduling_config( string $scheduling ): array {
+	private static function build_scheduling_config( string $scheduling, ?string $scheduled_at = null ): array {
+		// If --scheduled-at is provided, treat as one_time regardless of --scheduling value.
+		if ( $scheduled_at ) {
+			$timestamp = strtotime( $scheduled_at );
+			if ( ! $timestamp ) {
+				\WP_CLI::error( "Invalid --scheduled-at value: {$scheduled_at}. Use ISO-8601 format (e.g. 2026-03-20T15:00:00Z)." );
+			}
+			return array(
+				'interval'  => 'one_time',
+				'timestamp' => $timestamp,
+			);
+		}
+
+		if ( 'one_time' === $scheduling ) {
+			\WP_CLI::error( 'one_time scheduling requires --scheduled-at=<datetime> (ISO-8601 format).' );
+		}
+
 		if ( \DataMachine\Api\Flows\FlowScheduling::looks_like_cron_expression( $scheduling ) ) {
 			return array(
 				'interval'        => 'cron',

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowCard.jsx
@@ -318,6 +318,8 @@ function FlowCardContent( props ) {
 					flowId={ currentFlowData.flow_id }
 					scheduling={ {
 						interval: currentFlowData.scheduling_config?.interval,
+						scheduled_time:
+							currentFlowData.scheduling_config?.scheduled_time,
 						last_run_display:
 							optimisticLastRunDisplay ||
 							currentFlowData.last_run_display,

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowFooter.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowFooter.jsx
@@ -67,16 +67,23 @@ const formatStatus = ( status ) => {
 export default function FlowFooter( { flowId, scheduling } ) {
 	const {
 		interval,
+		scheduled_time,
 		last_run_display,
 		last_run_status,
 		is_running,
 		next_run_display,
 	} = scheduling || {};
 
-	const scheduleDisplay =
-		interval && interval !== 'manual'
-			? interval
-			: __( 'Manual', 'data-machine' );
+	let scheduleDisplay;
+	if ( interval === 'one_time' && scheduled_time ) {
+		scheduleDisplay =
+			__( 'One Time: ', 'data-machine' ) +
+			new Date( scheduled_time ).toLocaleString();
+	} else if ( interval && interval !== 'manual' ) {
+		scheduleDisplay = interval;
+	} else {
+		scheduleDisplay = __( 'Manual', 'data-machine' );
+	}
 
 	// When running, show "Running" status; otherwise format the job status
 	const displayStatus = is_running

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/FlowScheduleModal.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/FlowScheduleModal.jsx
@@ -7,7 +7,12 @@
 /**
  * WordPress dependencies
  */
-import { Modal, Button, SelectControl } from '@wordpress/components';
+import {
+	Modal,
+	Button,
+	SelectControl,
+	DateTimePicker,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -43,14 +48,34 @@ export default function FlowScheduleModal( {
 
 	// Form state for interval selection
 	const formState = useFormState( {
-		initialData: { selectedInterval: currentInterval || 'manual' },
+		initialData: {
+			selectedInterval: currentInterval || 'manual',
+			scheduledDate: null,
+		},
 		onSubmit: async ( data ) => {
 			try {
+				const schedulingConfig = {
+					interval: data.selectedInterval,
+				};
+
+				// Add timestamp for one-time scheduling.
+				if ( data.selectedInterval === 'one_time' ) {
+					if ( ! data.scheduledDate ) {
+						throw new Error(
+							__(
+								'Please select a date and time.',
+								'data-machine'
+							)
+						);
+					}
+					schedulingConfig.timestamp = Math.floor(
+						new Date( data.scheduledDate ).getTime() / 1000
+					);
+				}
+
 				await updateScheduleMutation.mutateAsync( {
 					flowId,
-					schedulingConfig: {
-						interval: data.selectedInterval,
-					},
+					schedulingConfig,
 				} );
 
 				if ( onSuccess ) {
@@ -108,7 +133,19 @@ export default function FlowScheduleModal( {
 					) }
 				/>
 
-				{ formState.data.selectedInterval === 'manual' && (
+				{ formState.data.selectedInterval === 'one_time' && (
+				<div className="datamachine-modal-spacing--mb-20">
+					<DateTimePicker
+						currentDate={ formState.data.scheduledDate }
+						onChange={ ( date ) =>
+							formState.updateField( 'scheduledDate', date )
+						}
+						is12Hour={ true }
+					/>
+				</div>
+			) }
+
+			{ formState.data.selectedInterval === 'manual' && (
 					<div className="datamachine-modal-info-box datamachine-modal-info-box--highlight">
 						<p>
 							<strong>
@@ -122,22 +159,40 @@ export default function FlowScheduleModal( {
 					</div>
 				) }
 
-				{ formState.data.selectedInterval !== 'manual' && (
-					<div className="datamachine-modal-info-box datamachine-modal-info-box--note">
-						<p>
-							<strong>
-								{ __(
-									'Automatic Scheduling:',
-									'data-machine'
-								) }
-							</strong>{ ' ' }
+			{ formState.data.selectedInterval === 'one_time' && (
+				<div className="datamachine-modal-info-box datamachine-modal-info-box--note">
+					<p>
+						<strong>
 							{ __(
-								'Flow will run automatically based on the selected interval. You can still trigger it manually anytime.',
+								'One-Time Execution:',
 								'data-machine'
 							) }
-						</p>
-					</div>
-				) }
+						</strong>{ ' ' }
+						{ __(
+							'Flow will run once at the selected date and time, then revert to manual mode.',
+							'data-machine'
+						) }
+					</p>
+				</div>
+			) }
+
+			{ formState.data.selectedInterval !== 'manual' &&
+				formState.data.selectedInterval !== 'one_time' && (
+				<div className="datamachine-modal-info-box datamachine-modal-info-box--note">
+					<p>
+						<strong>
+							{ __(
+								'Automatic Scheduling:',
+								'data-machine'
+							) }
+						</strong>{ ' ' }
+						{ __(
+							'Flow will run automatically based on the selected interval. You can still trigger it manually anytime.',
+							'data-machine'
+						) }
+					</p>
+				</div>
+			) }
 
 				<div className="datamachine-modal-actions">
 					<Button

--- a/inc/Engine/Actions/Handlers/JobCompleteHandler.php
+++ b/inc/Engine/Actions/Handlers/JobCompleteHandler.php
@@ -22,5 +22,43 @@ class JobCompleteHandler {
 	public static function handle( $job_id, $status ) {
 		$jobs_ops = new \DataMachine\Core\Database\Jobs\JobsOperations();
 		$jobs_ops->update_flow_health_cache( $job_id, $status );
+
+		// Revert one-time flows to manual after execution.
+		// The Action Scheduler single action auto-completes, but the scheduling_config
+		// stays as one_time — revert it so the UI correctly shows "Manual" instead of
+		// a stale one_time with a past timestamp.
+		self::cleanup_one_time_flow( $job_id );
+	}
+
+	/**
+	 * Revert a one-time flow's scheduling config to manual after execution.
+	 *
+	 * @param int $job_id Job ID.
+	 */
+	private static function cleanup_one_time_flow( $job_id ) {
+		$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
+		$job     = $db_jobs->get_job( $job_id );
+
+		if ( ! $job || empty( $job->flow_id ) ) {
+			return;
+		}
+
+		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
+		$flow     = $db_flows->get_flow( $job->flow_id );
+
+		if ( ! $flow ) {
+			return;
+		}
+
+		$scheduling = is_string( $flow->scheduling_config )
+			? json_decode( $flow->scheduling_config, true )
+			: (array) $flow->scheduling_config;
+
+		if ( ( $scheduling['interval'] ?? '' ) === 'one_time' ) {
+			$db_flows->update_flow_scheduling(
+				$job->flow_id,
+				array( 'interval' => 'manual' )
+			);
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Exposes the existing `one_time` scheduling type across all interfaces (React UI, CLI, and fixes backend edge cases). Flows can now be scheduled to run once at a specific future datetime, then automatically revert to manual mode after execution.

Closes #657

## Changes

**Backend fixes:**
- `FlowScheduling`: call `as_unschedule_all_actions` before one_time re-scheduling to prevent duplicate Action Scheduler actions
- `JobCompleteHandler`: revert one_time flows to `manual` after execution completes, so the UI shows correct state instead of a stale one_time with a past timestamp

**Frontend:**
- `SettingsAbilities`: add `one_time` option to the scheduling intervals dropdown
- `FlowScheduleModal`: render `DateTimePicker` when one_time is selected, send `{interval: "one_time", timestamp: <unix>}` in the scheduling config
- `FlowFooter`: display human-readable scheduled datetime for one_time flows
- `FlowCard`: pass `scheduled_time` from `scheduling_config` to `FlowFooter`

**CLI:**
- Add `--scheduled-at=<datetime>` flag for `flows create` and `flows update` (ISO-8601 format, implies `--scheduling=one_time`)
- `build_scheduling_config()` validates the datetime and produces the correct config

## Usage

**CLI:**
```bash
# Schedule a flow to run once on March 20 at 3pm UTC
wp datamachine flows create --pipeline_id=3 --name="SEO Check" --scheduled-at="2026-03-20T15:00:00Z"

# Update an existing flow to run once
wp datamachine flows update 42 --scheduled-at="2026-03-20T15:00:00Z"
```

**React UI:** Select "One Time (scheduled)" from the schedule dropdown → pick a date/time → save.

**After execution:** Flow automatically reverts to "Manual" mode. The Action Scheduler single action auto-completes and won't fire again.