### PR TITLE
fix: normalize malformed shared AI key storage

### DIFF
--- a/inc/Engine/Filters/DataMachineFilters.php
+++ b/inc/Engine/Filters/DataMachineFilters.php
@@ -50,6 +50,35 @@ datamachine_register_importexport_filters();
 function datamachine_register_utility_filters() {
 
 	add_filter(
+		'chubes_ai_provider_api_keys',
+		function ( $keys ) {
+			if ( is_array( $keys ) ) {
+				return $keys;
+			}
+
+			if ( ! is_string( $keys ) || '' === $keys ) {
+				return $keys;
+			}
+
+			$normalized = maybe_unserialize( $keys );
+
+			if ( ! is_array( $normalized ) ) {
+				return $keys;
+			}
+
+			$option_name = 'chubes_ai_http_shared_api_keys';
+			$current_raw = get_site_option( $option_name, null );
+
+			if ( $current_raw === $keys ) {
+				update_site_option( $option_name, $normalized );
+			}
+
+			return $normalized;
+		},
+		20
+	);
+
+	add_filter(
 		'datamachine_generate_flow_step_id',
 		function ( $existing_id, $pipeline_step_id, $flow_id ) {
 			if ( empty( $pipeline_step_id ) || empty( $flow_id ) ) {

--- a/tests/Unit/Engine/DataMachineFiltersTest.php
+++ b/tests/Unit/Engine/DataMachineFiltersTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * DataMachineFilters Tests
+ *
+ * Tests for utility filters in Engine/Filters/DataMachineFilters.php.
+ *
+ * @package DataMachine\Tests\Unit\Engine
+ */
+
+namespace DataMachine\Tests\Unit\Engine;
+
+use WP_UnitTestCase;
+
+class DataMachineFiltersTest extends WP_UnitTestCase {
+
+	private string $option_name = 'chubes_ai_http_shared_api_keys';
+
+	public function set_up(): void {
+		parent::set_up();
+		delete_site_option( $this->option_name );
+	}
+
+	public function tear_down(): void {
+		delete_site_option( $this->option_name );
+		parent::tear_down();
+	}
+
+	public function test_provider_key_filter_normalizes_serialized_option_string(): void {
+		$serialized = serialize(
+			array(
+				'openai' => 'sk-test',
+				'gemini' => '',
+			)
+		);
+
+		update_site_option( $this->option_name, $serialized );
+
+		$normalized = apply_filters( 'chubes_ai_provider_api_keys', get_site_option( $this->option_name ) );
+
+		$this->assertIsArray( $normalized );
+		$this->assertSame( 'sk-test', $normalized['openai'] );
+		$this->assertSame( '', $normalized['gemini'] );
+		$this->assertIsArray( get_site_option( $this->option_name ) );
+	}
+
+	public function test_provider_key_filter_leaves_normal_arrays_unchanged(): void {
+		$keys = array(
+			'openai' => 'sk-test',
+			'grok'   => '',
+		);
+
+		update_site_option( $this->option_name, $keys );
+
+		$result = apply_filters( 'chubes_ai_provider_api_keys', $keys );
+
+		$this->assertSame( $keys, $result );
+		$this->assertSame( $keys, get_site_option( $this->option_name ) );
+	}
+}


### PR DESCRIPTION
## Summary
- normalize malformed serialized `chubes_ai_provider_api_keys` values back to arrays at runtime
- self-heal the shared AI key site option when a serialized string is detected
- add focused unit coverage for malformed and normal provider key storage

## Why
On chubes.net, daily memory jobs were failing with `No API key configured` even though an OpenAI key existed. The shared key store had been saved as a serialized string instead of an array, so the AI request path could not resolve `['openai' => ...]` correctly. This hardens the existing storage path without adding new credential UX ahead of the eventual `wp-ai-client` migration.

## Validation
- manually repaired and validated the runtime path on chubes.net
- `homeboy test data-machine -- --filter DataMachineFiltersTest`