### PR TITLE
fix(lint): auto-fix 30 Yoda and short ternary violations

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -579,14 +579,14 @@ add_action( 'init', 'datamachine_maybe_run_migrations', 5 );
  */
 function datamachine_get_scaffold_defaults(): array {
 	// --- Site metadata ---
-	$site_name    = get_bloginfo( 'name' ) ?: 'WordPress Site';
+	$site_name    = get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : 'WordPress Site';
 	$site_tagline = get_bloginfo( 'description' );
 	$site_url     = home_url();
 	$timezone     = wp_timezone_string();
 
 	// --- Active theme ---
 	$theme      = wp_get_theme();
-	$theme_name = $theme->get( 'Name' ) ?: 'Unknown';
+	$theme_name = $theme->get( 'Name' ) ? $theme->get( 'Name' ) : 'Unknown';
 
 	// --- Active plugins (exclude Data Machine itself) ---
 	$active_plugins = get_option( 'active_plugins', array() );
@@ -746,13 +746,13 @@ MD;
  * @return string
  */
 function datamachine_get_site_scaffold_content(): string {
-	$site_name        = get_bloginfo( 'name' ) ?: 'WordPress Site';
-	$site_description = get_bloginfo( 'description' ) ?: '';
+	$site_name        = get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : 'WordPress Site';
+	$site_description = get_bloginfo( 'description' ) ? get_bloginfo( 'description' ) : '';
 	$site_url         = home_url();
 	$post_types       = get_post_types( array( 'public' => true ), 'names' );
 	$taxonomies       = get_taxonomies( array( 'public' => true ), 'names' );
 	$active_plugins   = get_option( 'active_plugins', array() );
-	$theme_name       = wp_get_theme()->get( 'Name' ) ?: 'Unknown';
+	$theme_name       = wp_get_theme()->get( 'Name' ) ? wp_get_theme()->get( 'Name' ) : 'Unknown';
 
 	if ( is_multisite() ) {
 		$network_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );

--- a/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
@@ -221,7 +221,7 @@ class FetchWordPressMediaAbility {
 			$content_data = array();
 			if ( $include_parent_content && $post->post_parent > 0 ) {
 				$parent_post = get_post( $post->post_parent );
-				if ( $parent_post && $parent_post->post_status === 'publish' ) {
+				if ( $parent_post && 'publish' === $parent_post->post_status ) {
 					$parent_title = ! empty( $parent_post->post_title ) ? $parent_post->post_title : 'Untitled';
 					$content_data = array(
 						'title'   => $parent_title,

--- a/inc/Abilities/Fetch/GetWordPressPostAbility.php
+++ b/inc/Abilities/Fetch/GetWordPressPostAbility.php
@@ -140,7 +140,7 @@ class GetWordPressPostAbility {
 
 		$post = get_post( $post_id );
 
-		if ( ! $post || $post->post_status === 'trash' ) {
+		if ( ! $post || 'trash' === $post->post_status ) {
 			$logs[] = array(
 				'level'   => 'warning',
 				'message' => 'Post not found or trashed',
@@ -160,7 +160,7 @@ class GetWordPressPostAbility {
 		$post_status  = $post->post_status;
 		$publish_date = get_the_date( 'Y-m-d H:i:s', $post_id );
 		$author_name  = get_the_author_meta( 'display_name', (int) $post->post_author );
-		$site_name    = get_bloginfo( 'name' ) ?: 'Local WordPress';
+		$site_name    = get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : 'Local WordPress';
 
 		$content_length     = strlen( $content );
 		$content_word_count = str_word_count( wp_strip_all_tags( $content ) );
@@ -177,7 +177,7 @@ class GetWordPressPostAbility {
 				$file_path = get_attached_file( $featured_image_id );
 				if ( $file_path && file_exists( $file_path ) ) {
 					$file_size = filesize( $file_path );
-					$mime_type = get_post_mime_type( $featured_image_id ) ?: 'image/jpeg';
+					$mime_type = get_post_mime_type( $featured_image_id ) ? get_post_mime_type( $featured_image_id ) : 'image/jpeg';
 
 					$file_info = array(
 						'file_path' => $file_path,

--- a/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
+++ b/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
@@ -243,7 +243,7 @@ class QueryWordPressPostsAbility {
 			);
 		}
 
-		$site_name      = get_bloginfo( 'name' ) ?: 'Local WordPress';
+		$site_name      = get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : 'Local WordPress';
 		$eligible_items = array();
 
 		foreach ( $unprocessed_posts as $post ) {
@@ -259,7 +259,7 @@ class QueryWordPressPostsAbility {
 				$file_path = get_attached_file( $featured_image_id );
 				if ( $file_path && file_exists( $file_path ) ) {
 					$file_size = filesize( $file_path );
-					$mime_type = get_post_mime_type( $featured_image_id ) ?: 'image/jpeg';
+					$mime_type = get_post_mime_type( $featured_image_id ) ? get_post_mime_type( $featured_image_id ) : 'image/jpeg';
 
 					$file_info = array(
 						'file_path' => $file_path,

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -447,7 +447,7 @@ class FlowsCommand extends BaseCommand {
 					'order'     => $order,
 					'step_type' => $step_type,
 					'handler'   => $slug,
-					'config'    => implode( ', ', $config_parts ) ?: '(default)',
+					'config'    => implode( ', ', $config_parts ) ? implode( ', ', $config_parts ) : '(default)',
 				);
 			}
 		}
@@ -1049,7 +1049,7 @@ class FlowsCommand extends BaseCommand {
 					'flow_step_id' => $sid,
 					'step_type'    => $step_type,
 					'handler'      => $slug,
-					'config'       => implode( ', ', $config_summary ) ?: '(default)',
+					'config'       => implode( ', ', $config_summary ) ? implode( ', ', $config_summary ) : '(default)',
 				);
 			}
 		}

--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -75,7 +75,7 @@ class Agents extends BaseRepository {
 		}
 
 		if ( ! empty( $row['agent_config'] ) ) {
-			$row['agent_config'] = json_decode( $row['agent_config'], true ) ?: array();
+			$row['agent_config'] = json_decode( $row['agent_config'], true ) ? json_decode( $row['agent_config'], true ) : array();
 		}
 
 		return $row;
@@ -103,7 +103,7 @@ class Agents extends BaseRepository {
 		}
 
 		if ( ! empty( $row['agent_config'] ) ) {
-			$row['agent_config'] = json_decode( $row['agent_config'], true ) ?: array();
+			$row['agent_config'] = json_decode( $row['agent_config'], true ) ? json_decode( $row['agent_config'], true ) : array();
 		}
 
 		return $row;

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -208,7 +208,7 @@ class Jobs {
 		}
 
 		// Migrate pipeline_id column: bigint -> varchar(20) for 'direct' execution
-		if ( isset( $columns['pipeline_id'] ) && $columns['pipeline_id']->DATA_TYPE === 'bigint' ) {
+		if ( isset( $columns['pipeline_id'] ) && 'bigint' === $columns['pipeline_id']->DATA_TYPE ) {
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
 			$wpdb->query( "ALTER TABLE {$table_name} MODIFY pipeline_id varchar(20) NOT NULL" );
 			do_action(
@@ -222,7 +222,7 @@ class Jobs {
 		}
 
 		// Migrate flow_id column: bigint -> varchar(20) for 'direct' execution
-		if ( isset( $columns['flow_id'] ) && $columns['flow_id']->DATA_TYPE === 'bigint' ) {
+		if ( isset( $columns['flow_id'] ) && 'bigint' === $columns['flow_id']->DATA_TYPE ) {
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
 			$wpdb->query( "ALTER TABLE {$table_name} MODIFY flow_id varchar(20) NOT NULL" );
 			do_action(

--- a/inc/Core/ExecutionContext.php
+++ b/inc/Core/ExecutionContext.php
@@ -146,7 +146,7 @@ class ExecutionContext {
 	 * @return bool
 	 */
 	public function isDirect(): bool {
-		return $this->mode === self::MODE_DIRECT;
+		return self::MODE_DIRECT === $this->mode;
 	}
 
 	/**
@@ -155,7 +155,7 @@ class ExecutionContext {
 	 * @return bool
 	 */
 	public function isFlow(): bool {
-		return $this->mode === self::MODE_FLOW;
+		return self::MODE_FLOW === $this->mode;
 	}
 
 	/**
@@ -211,7 +211,7 @@ class ExecutionContext {
 	 * @return EngineData
 	 */
 	public function getEngine(): EngineData {
-		if ( $this->engine === null ) {
+		if ( null === $this->engine ) {
 			$data         = $this->job_id ? datamachine_get_engine_data( (int) $this->job_id ) : array();
 			$this->engine = new EngineData( $data, $this->job_id );
 		}

--- a/inc/Core/JobStatus.php
+++ b/inc/Core/JobStatus.php
@@ -148,7 +148,7 @@ class JobStatus {
 	 * Check if this is a failure status.
 	 */
 	public function isFailure(): bool {
-		return $this->baseStatus === self::FAILED;
+		return self::FAILED === $this->baseStatus;
 	}
 
 	/**
@@ -156,7 +156,7 @@ class JobStatus {
 	 */
 	public static function isStatusFailure( string $status ): bool {
 		$base = self::parseBaseStatus( $status );
-		return $base === self::FAILED;
+		return self::FAILED === $base;
 	}
 
 	/**
@@ -170,7 +170,7 @@ class JobStatus {
 	 * Check if this status should increment the no-items counter.
 	 */
 	public function shouldIncrementNoItemsCount(): bool {
-		return $this->baseStatus === self::COMPLETED_NO_ITEMS;
+		return self::COMPLETED_NO_ITEMS === $this->baseStatus;
 	}
 
 	/**
@@ -184,7 +184,7 @@ class JobStatus {
 	 * Check if this is a waiting status (pipeline parked at webhook gate).
 	 */
 	public function isWaiting(): bool {
-		return $this->baseStatus === self::WAITING;
+		return self::WAITING === $this->baseStatus;
 	}
 
 	/**
@@ -192,7 +192,7 @@ class JobStatus {
 	 */
 	public static function isStatusWaiting( string $status ): bool {
 		$base = self::parseBaseStatus( $status );
-		return $base === self::WAITING;
+		return self::WAITING === $base;
 	}
 
 	/**
@@ -206,21 +206,21 @@ class JobStatus {
 	 * Check if this is an agent_skipped status.
 	 */
 	public function isAgentSkipped(): bool {
-		return $this->baseStatus === self::AGENT_SKIPPED;
+		return self::AGENT_SKIPPED === $this->baseStatus;
 	}
 
 	/**
 	 * Check if this is a completed status (not completed_no_items).
 	 */
 	public function isCompleted(): bool {
-		return $this->baseStatus === self::COMPLETED;
+		return self::COMPLETED === $this->baseStatus;
 	}
 
 	/**
 	 * Check if this is a completed_no_items status.
 	 */
 	public function isCompletedNoItems(): bool {
-		return $this->baseStatus === self::COMPLETED_NO_ITEMS;
+		return self::COMPLETED_NO_ITEMS === $this->baseStatus;
 	}
 
 	/**
@@ -241,7 +241,7 @@ class JobStatus {
 	 * Check if this status has a reason.
 	 */
 	public function hasReason(): bool {
-		return $this->reason !== null && $this->reason !== '';
+		return null !== $this->reason && '' !== $this->reason;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Auto-fixed 17 YodaConditions violations (property chains, class constants)
- Auto-fixed 13 DisallowShortTernary violations (function calls, method chains)
- Reduces PHPCS error count from 145 → 115

## Changes
All changes are mechanical transformations applied by `homeboy lint --fix`:
- `$this->baseStatus === self::FAILED` → `self::FAILED === $this->baseStatus`
- `$columns['pipeline_id']->DATA_TYPE === 'bigint'` → `'bigint' === $columns['pipeline_id']->DATA_TYPE`
- `get_bloginfo('name') ?: 'WordPress Site'` → `get_bloginfo('name') ? get_bloginfo('name') : 'WordPress Site'`

## Depends on
- homeboy-extensions PR #100 (fixer improvements that made these fixes possible)