### PR TITLE
fix(ci): prevent duplicate inline reviews from parallel jobs

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -84,6 +84,7 @@ jobs:
           settings: '{"database_type": "mysql"}'
           php-version: '8.2'
           node-version: '20'
+          inline-review: 'false'
 
   audit:
     if: github.event_name == 'pull_request'
@@ -114,3 +115,4 @@ jobs:
           component: data-machine
           php-version: '8.2'
           node-version: '20'
+          inline-review: 'false'


### PR DESCRIPTION
## Summary
- Only the lint job posts inline review comments
- Test and audit jobs set `inline-review: false` to avoid racing and creating duplicate reviews
- Depends on homeboy-action v1 update (already pushed) that adds the `inline-review` input

## Context
On PR #690, the lint, test, and audit jobs each independently ran `post-inline-review.sh`, creating duplicate "Collateral damage" reviews. The collateral damage layer was also removed from homeboy-action entirely — affected-file analysis is handled by the audit engine via `--changed-since` scoping, not the review layer.