### PR TITLE
fix: agent file save returns 400 — apiFetch sends JSON, not text/plain

### DIFF
--- a/inc/Api/AgentFiles.php
+++ b/inc/Api/AgentFiles.php
@@ -273,9 +273,15 @@ class AgentFiles {
 	}
 
 	public static function put_agent_file( WP_REST_Request $request ) {
+		// Content may arrive as JSON body param (admin UI) or raw body (API clients).
+		$content = $request->get_param( 'content' );
+		if ( null === $content ) {
+			$content = $request->get_body();
+		}
+
 		$result = self::getAbilities()->executeWriteAgentFile( array(
 			'filename' => sanitize_file_name( wp_unslash( $request['filename'] ) ),
-			'content'  => $request->get_body(),
+			'content'  => $content,
 			'user_id'  => self::resolve_scoped_user_id( $request ),
 		) );
 
@@ -357,10 +363,17 @@ class AgentFiles {
 	}
 
 	public static function put_daily_file( WP_REST_Request $request ) {
-		$date   = sprintf( '%s-%s-%s', $request['year'], $request['month'], $request['day'] );
+		$date = sprintf( '%s-%s-%s', $request['year'], $request['month'], $request['day'] );
+
+		// Content may arrive as JSON body param (admin UI) or raw body (API clients).
+		$content = $request->get_param( 'content' );
+		if ( null === $content ) {
+			$content = $request->get_body();
+		}
+
 		$result = DailyMemoryAbilities::writeDaily( array(
 			'date'    => $date,
-			'content' => $request->get_body(),
+			'content' => $content,
 			'mode'    => 'write',
 			'user_id' => self::resolve_scoped_user_id( $request ),
 		) );

--- a/inc/Core/Admin/Pages/Agent/assets/react/api/agentFiles.js
+++ b/inc/Core/Admin/Pages/Agent/assets/react/api/agentFiles.js
@@ -31,8 +31,7 @@ export const putAgentFile = async ( filename, content ) => {
 	return apiFetch( {
 		path: `/${ config.restNamespace }/files/agent/${ filename }`,
 		method: 'PUT',
-		body: content,
-		headers: { 'Content-Type': 'text/plain' },
+		data: { content },
 	} );
 };
 
@@ -65,8 +64,7 @@ export const putDailyFile = async ( year, month, day, content ) => {
 	return apiFetch( {
 		path: `/${ config.restNamespace }/files/agent/daily/${ year }/${ month }/${ day }`,
 		method: 'PUT',
-		body: content,
-		headers: { 'Content-Type': 'text/plain' },
+		data: { content },
 	} );
 };
 


### PR DESCRIPTION
## Summary

- **Root cause**: `@wordpress/api-fetch` middleware overrides `Content-Type: text/plain` to `application/json`. WordPress REST then tries to parse the raw markdown body as JSON → `400 Invalid JSON body passed.`
- **JS fix**: use `data: { content }` instead of `body: content` + custom headers — lets apiFetch properly serialize to JSON
- **PHP fix**: read content from `$request->get_param('content')` first (JSON body), fall back to `$request->get_body()` for raw API clients
- Applies to both agent file and daily memory file PUT endpoints