### PR TITLE
fix(#687): CLI returns all data when no --user flag provided

### DIFF
--- a/inc/Cli/UserResolver.php
+++ b/inc/Cli/UserResolver.php
@@ -12,7 +12,6 @@
 
 namespace DataMachine\Cli;
 
-use DataMachine\Core\FilesRepository\DirectoryManager;
 use WP_CLI;
 
 defined( 'ABSPATH' ) || exit;
@@ -22,15 +21,21 @@ class UserResolver {
 	/**
 	 * Resolve a --user flag to a WordPress user ID.
 	 *
+	 * Returns 0 when no --user flag is provided, which means "no user filter"
+	 * (show all data regardless of owner). This is the correct default for CLI
+	 * commands where admins expect to see all pipelines, flows, and jobs —
+	 * including pre-multi-agent data with user_id=0.
+	 *
 	 * @param array $assoc_args Command arguments (checks for 'user' key).
 	 * @return int WordPress user ID, or 0 if not specified.
 	 */
 	public static function resolve( array $assoc_args ): int {
 		$user_value = $assoc_args['user'] ?? null;
 
+		// No --user flag: return 0 (unscoped). CLI callers pass this as null
+		// to ability queries, which then return all data regardless of owner.
 		if ( null === $user_value || '' === $user_value ) {
-			$directory_manager = new DirectoryManager();
-			return $directory_manager->get_default_agent_user_id();
+			return 0;
 		}
 
 		// Numeric: treat as user ID.


### PR DESCRIPTION
## Summary

Fixes #687 — All CLI list commands (`pipelines list`, `flows list`, `jobs list`) return empty results on sites with pre-v0.37.0 data.

## Root Cause

`UserResolver::resolve()` defaulted to `DirectoryManager::get_default_agent_user_id()` (returns user_id=1, first admin) when no `--user` flag was provided. All data created before v0.37.0 has `user_id=0` in the database, so the ability query filtered by `user_id=1` and found nothing.

**Impact on events.extrachill.com:** 60 pipelines, 182 flows, and 6,000+ events were all invisible to CLI commands.

## Fix

`UserResolver::resolve()` now returns `0` when no `--user` flag is provided:
- `0` means "no user filter" — show all data regardless of owner
- CLI callers already handle this correctly: `$user_id > 0 ? $user_id : null` passes `null` to ability queries, which disables the user filter
- User scoping via `--user=<id>` still works for multi-agent scenarios
- Removes unused `DirectoryManager` import

## Design Decision

The default-to-admin-user behavior belongs in **runtime contexts** (pipeline execution, REST API, chat) where you need to scope operations to the acting agent. CLI is different — admins run it with `--allow-root` and expect to see all data. The `--user` flag exists for explicit scoping when needed.

## Files Changed

- `inc/Cli/UserResolver.php` — return 0 instead of default agent user ID