### PR TITLE
fix(#695): Move handler config sanitization into ability layer

### DIFF
--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -129,6 +129,41 @@ trait FlowStepHelpers {
 	}
 
 	/**
+	 * Sanitize handler configuration values via the handler's settings class.
+	 *
+	 * Delegates to the handler's SettingsClass::sanitize() method, which performs
+	 * type coercion, term ID resolution, and value validation. This ensures all
+	 * write paths (REST, CLI, chat tools, abilities API) produce consistent data.
+	 *
+	 * @since 0.38.0
+	 * @param string $handler_slug Handler slug.
+	 * @param array  $handler_config Raw configuration values to sanitize.
+	 * @return array Sanitized configuration values.
+	 */
+	protected function sanitizeHandlerConfig( string $handler_slug, array $handler_config ): array {
+		$settings_class = $this->handler_abilities->getSettingsClass( $handler_slug );
+
+		if ( ! $settings_class || ! method_exists( $settings_class, 'sanitize' ) ) {
+			return $handler_config;
+		}
+
+		try {
+			return $settings_class->sanitize( $handler_config );
+		} catch ( \Exception $e ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Handler config sanitization failed, using raw values',
+				array(
+					'handler_slug' => $handler_slug,
+					'error'        => $e->getMessage(),
+				)
+			);
+			return $handler_config;
+		}
+	}
+
+	/**
 	 * Validate handler_config fields against handler schema.
 	 *
 	 * Returns structured error data with field specs when validation fails,
@@ -304,6 +339,9 @@ trait FlowStepHelpers {
 			}
 		}
 
+		// Sanitize incoming values via handler's settings class before merge.
+		$handler_settings = $this->sanitizeHandlerConfig( $effective_slug, $handler_settings );
+
 		// Merge and store in handler_configs.
 		$merged_config = array_merge( $existing_handler_config, $handler_settings );
 		$flow_config[ $flow_step_id ]['handler_configs'][ $effective_slug ] = $this->handler_abilities->applyDefaults( $effective_slug, $merged_config );
@@ -384,11 +422,12 @@ trait FlowStepHelpers {
 		$existing_slugs[]      = $handler_slug;
 		$step['handler_slugs'] = $existing_slugs;
 
-		// Store per-handler config.
+		// Sanitize and store per-handler config.
 		$handler_configs = $step['handler_configs'] ?? array();
 
 		if ( ! empty( $handler_config ) ) {
-			$validated_config                 = $this->handler_abilities->applyDefaults( $handler_slug, $handler_config );
+			$sanitized_config                 = $this->sanitizeHandlerConfig( $handler_slug, $handler_config );
+			$validated_config                 = $this->handler_abilities->applyDefaults( $handler_slug, $sanitized_config );
 			$handler_configs[ $handler_slug ] = $validated_config;
 		} else {
 			$handler_configs[ $handler_slug ] = $this->handler_abilities->applyDefaults( $handler_slug, array() );

--- a/inc/Api/Flows/FlowSteps.php
+++ b/inc/Api/Flows/FlowSteps.php
@@ -328,7 +328,9 @@ class FlowSteps {
 			);
 		}
 
-		$handler_settings = self::process_handler_settings( $handler_slug, $request->get_params() );
+		// Raw settings are passed to the ability, which handles sanitization.
+		$raw_settings     = $request->get_param( 'settings' );
+		$handler_settings = is_array( $raw_settings ) ? $raw_settings : array();
 
 		$parts = apply_filters( 'datamachine_split_flow_step_id', null, $flow_step_id );
 		if ( ! isset( $parts['flow_id'] ) || ! isset( $parts['pipeline_step_id'] ) ) {
@@ -454,31 +456,4 @@ class FlowSteps {
 		);
 	}
 
-	/**
-	 * Process handler settings from request parameters
-	 *
-	 * @param string $handler_slug Handler identifier
-	 * @param array  $params Request parameters
-	 * @return array Sanitized handler settings
-	 */
-	private static function process_handler_settings( $handler_slug, $params ) {
-		$handler_abilities = new HandlerAbilities();
-		$handler_settings  = $handler_abilities->getSettingsClass( $handler_slug );
-
-		if ( ! $handler_settings || ! method_exists( $handler_settings, 'sanitize' ) ) {
-			return array();
-		}
-
-		$raw_settings = $params['settings'] ?? array();
-
-		if ( ! is_array( $raw_settings ) ) {
-			$raw_settings = array();
-		}
-
-		try {
-			return $handler_settings->sanitize( $raw_settings );
-		} catch ( \Exception $e ) {
-			return array();
-		}
-	}
 }


### PR DESCRIPTION
## Summary

- Moves handler config sanitization from the REST API layer into the Abilities API (`FlowStepHelpers` trait), making it the universal enforcement point for all write paths
- Removes `process_handler_settings()` from `FlowSteps.php` — the ability now handles sanitization
- One-time migration already run on production: normalized 121 flows on events.extrachill.com from string term names to integer term IDs

## Problem

Handler config sanitization (type coercion, taxonomy term ID resolution, value validation) only ran on the React UI's PUT endpoint via `process_handler_settings()`. Three other write paths — PATCH endpoint, chat tools, and direct ability execution — bypassed it entirely, causing inconsistent data (e.g., `taxonomy_location_selection: "Austin"` vs `1628`).

## Changes

### `FlowStepHelpers.php` (+43 lines)
- Added `sanitizeHandlerConfig()` method that delegates to the handler's `SettingsClass::sanitize()` with graceful fallback
- Called from `updateHandler()` before merge-and-write
- Called from `addHandler()` before `applyDefaults()`

### `FlowSteps.php` (-28 lines)
- Removed `process_handler_settings()` private method (dead code — ability handles it now)
- PUT handler now passes raw settings to the ability

## Architecture

```
Before:  PUT → sanitize() → Ability → DB  ✅
         PATCH/CLI/Chat → Ability → DB    🔴

After:   All paths → Ability → sanitize() → DB  ✅
```

Closes #695