### PR TITLE
Fix: treat empty fetch/event_import as completed_no_items regardless of history

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -474,11 +474,12 @@ class ExecuteStepAbility {
 			);
 		}
 
-		// Failure: check for "no new items" vs actual failure.
+		// Fetch/event_import steps: empty data means "nothing to process", not failure.
+		// This applies regardless of whether the flow has historical processed items —
+		// a new flow checking a source with no events is not broken, it just has nothing yet.
 		$is_fetch_step = in_array( $step_type, array( 'fetch', 'event_import' ), true );
-		$has_history   = $this->db_processed_items->has_processed_items( $flow_step_id );
 
-		if ( $is_fetch_step && $has_history ) {
+		if ( $is_fetch_step ) {
 			$this->db_jobs->complete_job( $job_id, JobStatus::COMPLETED_NO_ITEMS );
 			do_action(
 				'datamachine_log',
@@ -499,7 +500,7 @@ class ExecuteStepAbility {
 			);
 		}
 
-		// Actual failure.
+		// Non-fetch steps: empty data packet is an actual failure.
 		do_action(
 			'datamachine_log',
 			'error',
@@ -511,7 +512,6 @@ class ExecuteStepAbility {
 				'flow_step_id' => $flow_step_id,
 				'step_class'   => $step_class,
 				'step_type'    => $step_type,
-				'has_history'  => $has_history,
 			)
 		);
 		do_action(


### PR DESCRIPTION
## Summary

- Empty fetch/event_import steps are now `completed_no_items` regardless of whether the flow has prior processed items
- Removes the `has_history` gate that caused new flows (no prior imports) to be marked as `failed - empty_data_packet_returned`
- Eliminates ~79 false failures per day on events.extrachill.com

## Problem

`ExecuteStepAbility` had a two-tier check for empty fetch results:
1. If `is_fetch_step && has_history` → `completed_no_items` ✅
2. Otherwise → `failed - empty_data_packet_returned` ❌

New flows checking sources with no events (e.g. Dice.fm in 50+ small cities) had no history, so they always hit path 2 and were marked as failures. An empty fetch is not a failure — it means "nothing to import right now."

## Fix

Removed the `has_history` requirement. All fetch/event_import steps returning empty data get `completed_no_items`.

## Impact

- **Before**: 79 false failures/day, 24% apparent failure rate
- **After**: ~38 real failures/day, ~7% failure rate (the actual number)
- No behavior change for non-fetch steps (AI, update, etc.)

## Related

- #699 — Batch state transient issue (separate, filed)