### PR TITLE
fix(#698): log auto-rotation, cleanup logic fix, all log levels

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -398,6 +398,7 @@ function datamachine_deactivate_plugin() {
 	if ( function_exists( 'as_unschedule_all_actions' ) ) {
 		as_unschedule_all_actions( 'datamachine_cleanup_stale_claims', array(), 'datamachine-maintenance' );
 		as_unschedule_all_actions( 'datamachine_cleanup_failed_jobs', array(), 'datamachine-maintenance' );
+		as_unschedule_all_actions( 'datamachine_cleanup_logs', array(), 'datamachine-maintenance' );
 	}
 }
 

--- a/inc/Cli/Commands/LogsCommand.php
+++ b/inc/Cli/Commands/LogsCommand.php
@@ -31,7 +31,7 @@ class LogsCommand extends BaseCommand {
 	 *
 	 * @var array
 	 */
-	private array $valid_levels = array( 'debug', 'error', 'none' );
+	private array $valid_levels = array( 'debug', 'info', 'warning', 'error', 'none' );
 
 	/**
 	 * Read log entries for a specific agent type.
@@ -217,7 +217,7 @@ class LogsCommand extends BaseCommand {
 	 * : The agent type (pipeline, system, chat).
 	 *
 	 * [<level>]
-	 * : Log level to set (debug, error, none). If omitted, shows current level.
+	 * : Log level to set (debug, info, warning, error, none). If omitted, shows current level.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/inc/Core/ActionScheduler/LogCleanup.php
+++ b/inc/Core/ActionScheduler/LogCleanup.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Scheduled Log Cleanup
+ *
+ * Periodically cleans up log files that exceed size limits.
+ * Prevents unbounded log growth on high-volume sites (e.g. events pipeline).
+ *
+ * @package DataMachine\Core\ActionScheduler
+ * @since 0.37.1
+ */
+
+namespace DataMachine\Core\ActionScheduler;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the log cleanup action handler.
+ */
+add_action(
+	'datamachine_cleanup_logs',
+	function () {
+		/**
+		 * Filter the maximum log file size in MB before cleanup.
+		 *
+		 * @since 0.37.1
+		 *
+		 * @param int $max_size_mb Maximum log file size in MB. Default 50.
+		 */
+		$max_size_mb = apply_filters( 'datamachine_log_max_size_mb', 50 );
+
+		/**
+		 * Filter the maximum log file age in days before cleanup.
+		 *
+		 * @since 0.37.1
+		 *
+		 * @param int $max_age_days Maximum log file age in days. Default 30.
+		 */
+		$max_age_days = apply_filters( 'datamachine_log_max_age_days', 30 );
+
+		$cleaned = datamachine_cleanup_log_files( $max_size_mb, $max_age_days );
+
+		if ( $cleaned ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Scheduled log cleanup completed',
+				array(
+					'max_size_mb'  => $max_size_mb,
+					'max_age_days' => $max_age_days,
+				)
+			);
+		}
+	}
+);
+
+/**
+ * Schedule the log cleanup after Action Scheduler is initialized.
+ * Runs daily to catch any logs that have grown too large.
+ */
+add_action(
+	'action_scheduler_init',
+	function () {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		if ( ! as_next_scheduled_action( 'datamachine_cleanup_logs', array(), 'datamachine-maintenance' ) ) {
+			as_schedule_recurring_action(
+				time() + DAY_IN_SECONDS,
+				DAY_IN_SECONDS,
+				'datamachine_cleanup_logs',
+				array(),
+				'datamachine-maintenance'
+			);
+		}
+	}
+);

--- a/inc/Engine/Logger.php
+++ b/inc/Engine/Logger.php
@@ -68,20 +68,19 @@ function datamachine_get_monolog_instance( string $agent_type = AgentType::PIPEL
 /**
  * Convert string log level to Monolog Level.
  *
- * @param string $level_string Log level string (debug, error, none)
+ * @param string $level_string Log level string (debug, info, warning, error, none)
  * @return Level|null Monolog level constant, null for 'none'
  */
 function datamachine_get_monolog_level( string $level_string ): ?Level {
-	switch ( strtolower( $level_string ) ) {
-		case 'debug':
-			return Level::Debug;
-		case 'error':
-			return Level::Error;
-		case 'none':
-			return null;
-		default:
-			return Level::Debug;
-	}
+	return match ( strtolower( $level_string ) ) {
+		'debug'    => Level::Debug,
+		'info'     => Level::Info,
+		'warning'  => Level::Warning,
+		'error'    => Level::Error,
+		'critical' => Level::Critical,
+		'none'     => null,
+		default    => Level::Debug,
+	};
 }
 
 /**
@@ -229,11 +228,15 @@ function datamachine_get_recent_logs( string $agent_type = AgentType::PIPELINE, 
 /**
  * Clean up log files based on size or age criteria.
  *
- * @param int $max_size_mb Maximum log file size in MB
- * @param int $max_age_days Maximum log file age in days
+ * Triggers cleanup when EITHER condition is met:
+ * - File exceeds max size (prevents unbounded growth on active logs)
+ * - File exceeds max age (cleans up stale logs from inactive agents)
+ *
+ * @param int $max_size_mb  Maximum log file size in MB before cleanup. Default 50.
+ * @param int $max_age_days Maximum log file age in days before cleanup. Default 30.
  * @return bool True if cleanup was performed on any file
  */
-function datamachine_cleanup_log_files( int $max_size_mb = 10, int $max_age_days = 30 ): bool {
+function datamachine_cleanup_log_files( int $max_size_mb = 50, int $max_age_days = 30 ): bool {
 	$upload_dir = wp_upload_dir();
 	$log_dir    = $upload_dir['basedir'] . DATAMACHINE_LOG_DIR;
 
@@ -251,11 +254,14 @@ function datamachine_cleanup_log_files( int $max_size_mb = 10, int $max_age_days
 			continue;
 		}
 
-		$size_exceeds = filesize( $log_file ) > $max_size_bytes;
+		$file_size    = filesize( $log_file );
+		$size_exceeds = $file_size > $max_size_bytes;
 		$age_exceeds  = ( time() - filemtime( $log_file ) ) / DAY_IN_SECONDS > $max_age_days;
 
-		if ( $size_exceeds && $age_exceeds ) {
-			datamachine_log_debug( "Log file cleanup triggered for {$agent_type}: Size and age limits exceeded" );
+		if ( $size_exceeds || $age_exceeds ) {
+			$reason = $size_exceeds ? 'size' : 'age';
+			$size_mb = round( $file_size / 1024 / 1024, 2 );
+			datamachine_log_info( "Log cleanup triggered for {$agent_type}: {$reason} limit exceeded ({$size_mb} MB)" );
 			if ( datamachine_clear_log_file( $agent_type ) ) {
 				$cleaned = true;
 			}
@@ -362,14 +368,16 @@ function datamachine_get_valid_log_levels(): array {
 }
 
 /**
- * Get user-configurable log levels for admin interface.
+ * Get user-configurable log levels for admin interface and CLI.
  *
  * @return array Array of log levels with descriptions for user selection
  */
 function datamachine_get_available_log_levels(): array {
 	return array(
-		'debug' => 'Debug (full logging)',
-		'error' => 'Error (problems only)',
-		'none'  => 'None (disable logging)',
+		'debug'   => 'Debug (full logging)',
+		'info'    => 'Info (operational events)',
+		'warning' => 'Warning (potential issues)',
+		'error'   => 'Error (problems only)',
+		'none'    => 'None (disable logging)',
 	);
 }

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -72,4 +72,5 @@ require_once __DIR__ . '/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php';
 require_once __DIR__ . '/Core/FilesRepository/FileCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/ClaimsCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/JobsCleanup.php';
+require_once __DIR__ . '/Core/ActionScheduler/LogCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/QueueTuning.php';


### PR DESCRIPTION
## Summary

Fixes #698 — the logging system had three related problems: no scheduled cleanup, flawed cleanup logic, and only 3 of 5 log levels exposed.

## Changes

### 1. Scheduled log cleanup (`LogCleanup.php`)
- New daily Action Scheduler job (`datamachine_cleanup_logs`) in `datamachine-maintenance` group
- Filterable thresholds: `datamachine_log_max_size_mb` (default 50) and `datamachine_log_max_age_days` (default 30)
- Follows existing `ClaimsCleanup`/`JobsCleanup` pattern
- Unscheduled on plugin deactivation

### 2. Fix cleanup logic: AND → OR
- `datamachine_cleanup_log_files()` required BOTH size AND age to exceed limits — active logs that grew to 233MB were never cleaned because they never passed the age check
- Now triggers on EITHER condition, with descriptive log message showing which threshold was hit
- Default max size bumped from 10MB to 50MB

### 3. Expose all 5 log levels
- `datamachine_get_available_log_levels()`: `debug` / `info` / `warning` / `error` / `none`
- `datamachine_get_monolog_level()`: maps all 5 + `critical`, replaced `switch` with `match`
- CLI `valid_levels` array and help text updated
- Previously only `debug` / `error` / `none` were available

## Context

The events pipeline log grew to 233MB unchecked — there was no scheduled job calling `datamachine_cleanup_log_files()`, and even if called manually, the AND logic prevented active logs from ever being cleaned.