### PR TITLE
feat: add MEMORY.md cleanup phase to daily memory task

### DIFF
--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -6,6 +6,11 @@
  * and uses AI to synthesize a concise daily memory entry. Runs once daily
  * via Action Scheduler when daily_memory_enabled is active.
  *
+ * After generating the daily summary, runs a memory cleanup phase that
+ * reads MEMORY.md, identifies session-specific content that should be
+ * archived to daily files, and rewrites MEMORY.md with only persistent
+ * knowledge. This keeps the memory file lean for context window budget.
+ *
  * @package DataMachine\Engine\AI\System\Tasks
  * @since 0.32.0
  * @see https://github.com/Extra-Chill/data-machine/issues/357
@@ -16,6 +21,7 @@ namespace DataMachine\Engine\AI\System\Tasks;
 defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Core\PluginSettings;
+use DataMachine\Core\FilesRepository\AgentMemory;
 use DataMachine\Core\FilesRepository\DailyMemory;
 use DataMachine\Engine\AI\RequestBuilder;
 
@@ -45,19 +51,120 @@ class DailyMemoryTask extends SystemTask {
 			return;
 		}
 
-		// Gather today's activity context.
-		$context = $this->gatherContext( $params );
+		$date  = $params['date'] ?? gmdate( 'Y-m-d' );
+		$daily = new DailyMemory();
+		$parts = explode( '-', $date );
 
-		if ( empty( $context ) ) {
-			$this->completeJob( $jobId, array(
-				'skipped' => true,
-				'reason'  => 'No activity found for today.',
-			) );
-			return;
+		// Phase 1: Generate daily summary from DM activity (jobs, chat sessions).
+		$summary_length = 0;
+		$context        = $this->gatherContext( $params );
+
+		if ( ! empty( $context ) ) {
+			$prompt   = $this->buildPrompt( $context );
+			$messages = array(
+				array(
+					'role'    => 'user',
+					'content' => $prompt,
+				),
+			);
+
+			$response = RequestBuilder::build(
+				$messages,
+				$provider,
+				$model,
+				array(),
+				'system',
+				array()
+			);
+
+			if ( ! empty( $response['success'] ) ) {
+				$content = trim( $response['data']['content'] ?? '' );
+				// Normalize literal \n sequences to actual newlines.
+				$content = str_replace( '\n', "\n", $content );
+
+				if ( ! empty( $content ) ) {
+					$result = $daily->append( $parts[0], $parts[1], $parts[2], $content . "\n" );
+					if ( ! empty( $result['success'] ) ) {
+						$summary_length = strlen( $content );
+					}
+				}
+			}
 		}
 
-		// Build prompt and call AI.
-		$prompt   = $this->buildPrompt( $context );
+		// Phase 2: Clean up MEMORY.md — move session-specific content to daily file.
+		// This runs regardless of whether Phase 1 found DM activity, because most
+		// agent work happens via Kimaki sessions which don't create DM jobs.
+		$cleanup_result = $this->cleanupMemory( $date, $provider, $model, $daily );
+
+		$this->completeJob( $jobId, array(
+			'date'           => $date,
+			'summary_length' => $summary_length,
+			'cleanup'        => $cleanup_result,
+		) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getTaskType(): string {
+		return 'daily_memory_generation';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Daily Memory',
+			'description'     => 'AI-generated daily summary of activity and automatic MEMORY.md cleanup — archives session-specific content to daily files.',
+			'setting_key'     => 'daily_memory_enabled',
+			'default_enabled' => false,
+		);
+	}
+
+	/**
+	 * Clean up MEMORY.md by archiving session-specific content to the daily file.
+	 *
+	 * Reads the full MEMORY.md, sends it to AI with instructions to separate
+	 * persistent knowledge from session-specific detail, rewrites MEMORY.md
+	 * with only persistent content, and appends the extracted session content
+	 * to the day's daily memory file.
+	 *
+	 * Skips cleanup if MEMORY.md is already within the recommended size threshold
+	 * (AgentMemory::MAX_FILE_SIZE). Cleanup failures are logged but do not fail
+	 * the overall daily memory job — the daily summary is already written.
+	 *
+	 * @since 0.38.0
+	 * @param string      $date     Target date (YYYY-MM-DD).
+	 * @param string      $provider AI provider slug.
+	 * @param string      $model    AI model identifier.
+	 * @param DailyMemory $daily    DailyMemory service instance (reused from summary phase).
+	 * @return array{skipped?: bool, reason?: string, original_size?: int, new_size?: int, archived_size?: int}
+	 */
+	private function cleanupMemory( string $date, string $provider, string $model, DailyMemory $daily ): array {
+		$memory = new AgentMemory();
+		$result = $memory->get_all();
+
+		if ( empty( $result['success'] ) || empty( $result['content'] ) ) {
+			return array(
+				'skipped' => true,
+				'reason'  => 'MEMORY.md not found or empty.',
+			);
+		}
+
+		$memory_content = $result['content'];
+		$original_size  = strlen( $memory_content );
+
+		// Only clean up if MEMORY.md exceeds the recommended threshold.
+		if ( $original_size <= AgentMemory::MAX_FILE_SIZE ) {
+			return array(
+				'skipped'       => true,
+				'reason'        => 'MEMORY.md within recommended size threshold.',
+				'original_size' => $original_size,
+			);
+		}
+
+		$prompt   = $this->buildCleanupPrompt( $memory_content, $date );
 		$messages = array(
 			array(
 				'role'    => 'user',
@@ -75,56 +182,231 @@ class DailyMemoryTask extends SystemTask {
 		);
 
 		if ( empty( $response['success'] ) ) {
-			$this->failJob( $jobId, 'AI request failed: ' . ( $response['error'] ?? 'Unknown error' ) );
-			return;
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Memory cleanup AI request failed: ' . ( $response['error'] ?? 'Unknown error' ),
+				array( 'date' => $date )
+			);
+			return array(
+				'skipped' => true,
+				'reason'  => 'AI request failed: ' . ( $response['error'] ?? 'Unknown error' ),
+			);
 		}
 
-		$content = trim( $response['data']['content'] ?? '' );
-		if ( empty( $content ) ) {
-			$this->failJob( $jobId, 'AI returned empty response.' );
-			return;
+		$ai_output = trim( $response['data']['content'] ?? '' );
+		$ai_output = str_replace( '\n', "\n", $ai_output );
+
+		if ( empty( $ai_output ) ) {
+			return array(
+				'skipped' => true,
+				'reason'  => 'AI returned empty cleanup response.',
+			);
 		}
 
-		// Normalize literal \n sequences to actual newlines. LLMs sometimes output
-		// the two-character string \n instead of a real newline when generating
-		// structured text — this is model behavior, not a serialization bug.
-		$content = str_replace( '\n', "\n", $content );
+		// Parse the AI output into the two sections.
+		$parsed = $this->parseCleanupResponse( $ai_output );
 
-		// Write to the target date's daily memory file.
-		$date  = $params['date'] ?? gmdate( 'Y-m-d' );
-		$daily = new DailyMemory();
-		$parts = explode( '-', $date );
-
-		$result = $daily->append( $parts[0], $parts[1], $parts[2], $content . "\n" );
-
-		if ( empty( $result['success'] ) ) {
-			$this->failJob( $jobId, 'Failed to write daily memory: ' . ( $result['message'] ?? 'Unknown error' ) );
-			return;
+		if ( empty( $parsed['persistent'] ) ) {
+			// Safety: never wipe MEMORY.md if parsing failed.
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Memory cleanup parse failed — no persistent section found. MEMORY.md unchanged.',
+				array( 'date' => $date, 'ai_output_length' => strlen( $ai_output ) )
+			);
+			return array(
+				'skipped' => true,
+				'reason'  => 'Could not parse AI cleanup response — persistent section missing.',
+			);
 		}
 
-		$this->completeJob( $jobId, array(
-			'date'           => $date,
-			'content_length' => strlen( $content ),
-		) );
-	}
+		// Write the cleaned MEMORY.md.
+		$new_content = $parsed['persistent'];
+		$new_size    = strlen( $new_content );
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public function getTaskType(): string {
-		return 'daily_memory_generation';
-	}
+		// Safety check: don't write if the new content is suspiciously small
+		// compared to the original (less than 10% — AI may have been too aggressive).
+		$min_ratio = 0.10;
+		if ( $new_size < ( $original_size * $min_ratio ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				sprintf(
+					'Memory cleanup aborted — new content (%s) is less than %d%% of original (%s). AI may have been too aggressive.',
+					size_format( $new_size ),
+					intval( $min_ratio * 100 ),
+					size_format( $original_size )
+				),
+				array(
+					'date'          => $date,
+					'original_size' => $original_size,
+					'new_size'      => $new_size,
+				)
+			);
+			return array(
+				'skipped'       => true,
+				'reason'        => 'Cleanup produced suspiciously small output — safety check prevented write.',
+				'original_size' => $original_size,
+				'new_size'      => $new_size,
+			);
+		}
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public static function getTaskMeta(): array {
-		return array(
-			'label'           => 'Daily Memory',
-			'description'     => 'AI-generated daily summary of activity — jobs, chat sessions, and key events.',
-			'setting_key'     => 'daily_memory_enabled',
-			'default_enabled' => false,
+		// Write cleaned MEMORY.md via the AgentMemory service.
+		// AgentMemory doesn't have a "replace all" method, so we write directly
+		// via the filesystem helper using the same path.
+		$fs = \DataMachine\Core\FilesRepository\FilesystemHelper::get();
+		$fs->put_contents( $memory->get_file_path(), $new_content );
+		\DataMachine\Core\FilesRepository\FilesystemHelper::make_group_writable( $memory->get_file_path() );
+
+		// Archive extracted content to the daily file.
+		$archived_size = 0;
+		if ( ! empty( $parsed['archived'] ) ) {
+			$archive_header = "\n### Archived from MEMORY.md\n\n";
+			$archive_text   = $archive_header . $parsed['archived'] . "\n";
+			$archived_size  = strlen( $parsed['archived'] );
+			$parts          = explode( '-', $date );
+
+			$daily->append( $parts[0], $parts[1], $parts[2], $archive_text );
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			sprintf(
+				'Memory cleanup complete: %s → %s (%s archived to daily/%s)',
+				size_format( $original_size ),
+				size_format( $new_size ),
+				size_format( $archived_size ),
+				$date
+			),
+			array(
+				'date'          => $date,
+				'original_size' => $original_size,
+				'new_size'      => $new_size,
+				'archived_size' => $archived_size,
+			)
 		);
+
+		return array(
+			'original_size' => $original_size,
+			'new_size'      => $new_size,
+			'archived_size' => $archived_size,
+		);
+	}
+
+	/**
+	 * Parse the AI cleanup response into persistent and archived sections.
+	 *
+	 * Expects the AI output to contain two clearly delimited sections:
+	 * - `===PERSISTENT===` followed by the cleaned MEMORY.md content
+	 * - `===ARCHIVED===` followed by the session-specific content to archive
+	 *
+	 * @since 0.38.0
+	 * @param string $ai_output Raw AI response text.
+	 * @return array{persistent: string|null, archived: string|null}
+	 */
+	private function parseCleanupResponse( string $ai_output ): array {
+		$persistent = null;
+		$archived   = null;
+
+		// Find the delimiters.
+		$persistent_pos = strpos( $ai_output, '===PERSISTENT===' );
+		$archived_pos   = strpos( $ai_output, '===ARCHIVED===' );
+
+		if ( false !== $persistent_pos && false !== $archived_pos ) {
+			// Both sections present — extract content between delimiters.
+			$persistent_start = $persistent_pos + strlen( '===PERSISTENT===' );
+
+			if ( $archived_pos > $persistent_pos ) {
+				// Normal order: PERSISTENT then ARCHIVED.
+				$persistent = trim( substr( $ai_output, $persistent_start, $archived_pos - $persistent_start ) );
+				$archived   = trim( substr( $ai_output, $archived_pos + strlen( '===ARCHIVED===' ) ) );
+			} else {
+				// Reversed order: ARCHIVED then PERSISTENT.
+				$archived_start = $archived_pos + strlen( '===ARCHIVED===' );
+				$archived       = trim( substr( $ai_output, $archived_start, $persistent_pos - $archived_start ) );
+				$persistent     = trim( substr( $ai_output, $persistent_start ) );
+			}
+		} elseif ( false !== $persistent_pos ) {
+			// Only PERSISTENT section — no content to archive (memory was all persistent).
+			$persistent = trim( substr( $ai_output, $persistent_pos + strlen( '===PERSISTENT===' ) ) );
+		}
+
+		return array(
+			'persistent' => $persistent,
+			'archived'   => $archived,
+		);
+	}
+
+	/**
+	 * Build the AI prompt for MEMORY.md cleanup.
+	 *
+	 * @since 0.38.0
+	 * @param string $memory_content Current MEMORY.md content.
+	 * @param string $date           Target date for archival context.
+	 * @return string
+	 */
+	private function buildCleanupPrompt( string $memory_content, string $date ): string {
+		$max_size = size_format( AgentMemory::MAX_FILE_SIZE );
+		return <<<PROMPT
+You are a system agent responsible for keeping an AI agent's MEMORY.md file lean and useful.
+
+MEMORY.md is injected into every AI context window, so it must contain ONLY persistent knowledge that is useful across ALL sessions. Session-specific detail belongs in daily memory files, not in MEMORY.md.
+
+## Your Task
+
+Read the MEMORY.md content below and split it into two parts:
+
+### 1. PERSISTENT (stays in MEMORY.md)
+Content that should remain because it is useful in every future session:
+- Architecture decisions and patterns (how systems are built)
+- Configuration facts (paths, URLs, credentials locations, tool names)
+- Active project state (what's deployed, what's in progress — NOT session logs)
+- Key relationships (repos, people, services and how they connect)
+- Lessons learned that prevent repeating mistakes (the RULE, not the story)
+- Current status of long-running efforts (just the state, not the history)
+
+Condense aggressively:
+- Collapse detailed PR/commit histories into one-line status summaries
+- Remove "Session N did X" narratives — extract only the lasting fact
+- Merge duplicate/overlapping sections
+- Remove anything already captured in daily memory files
+- Drop version numbers (they go stale — check live instead)
+- Drop "Lessons Learned (continued)" sprawl — keep only unique, actionable rules
+
+### 2. ARCHIVED (moves to daily memory file for {$date})
+Content that is session-specific or historical detail:
+- Detailed PR descriptions and commit-by-commit narratives
+- "What we did in this session" logs
+- Debugging stories and investigation traces
+- Temporary state that will change soon
+- Redundant detail already covered by a condensed persistent entry
+
+## Output Format
+
+You MUST output your response in EXACTLY this format with these delimiters:
+
+===PERSISTENT===
+(cleaned MEMORY.md content here — start with the # header, include all sections)
+
+===ARCHIVED===
+(session-specific content extracted from MEMORY.md, organized by topic)
+
+## Rules
+- NEVER drop information entirely — if it's not persistent, it goes to ARCHIVED
+- The persistent section should ideally be under {$max_size} (currently it is much larger)
+- Preserve the ## section header structure in MEMORY.md
+- Keep the # Agent Memory top-level header
+- If a section is entirely session-specific, archive the whole section
+- If a section has a mix, keep the persistent facts and archive the detail
+
+---
+
+## Current MEMORY.md Content
+
+{$memory_content}
+PROMPT;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Extends the daily memory task with an automatic MEMORY.md cleanup phase
- After generating the daily activity summary, reads MEMORY.md and uses AI to split it into persistent knowledge (stays in MEMORY.md) and session-specific detail (archived to daily file)
- Keeps MEMORY.md lean for context window budget — currently 99KB, target is under 8KB

## How It Works
1. **Phase 1** (existing): Generate daily summary from DM jobs/chat sessions → append to daily file
2. **Phase 2** (new): Read MEMORY.md → AI separates persistent vs session-specific → rewrite MEMORY.md → archive extracted content to daily file

Phase 2 runs **regardless of Phase 1 results** — most agent work happens via Kimaki sessions which don't create DM jobs, but MEMORY.md still grows.

## Safety Measures
- Skips cleanup if MEMORY.md is already under 8KB threshold
- Parse validation: won't write if AI output lacks `===PERSISTENT===` delimiter
- Size ratio check: aborts if new content is <10% of original (AI too aggressive)
- Cleanup failures are logged but **never fail the overall job** — the daily summary is already written
- No information is ever dropped — everything goes to either persistent or archived

## Behavioral Change
Previously, when there was no DM activity (no jobs, no chat sessions), the task returned early and did nothing. Now it still runs the cleanup phase, which is the more valuable operation since most agent work is via Kimaki.