### PR TITLE
fix: add null guard to get_workspace_directory() filesystem access

### DIFF
--- a/inc/Core/FilesRepository/DirectoryManager.php
+++ b/inc/Core/FilesRepository/DirectoryManager.php
@@ -305,7 +305,6 @@ class DirectoryManager {
 	 * @return string Full path to workspace directory, or empty string if unavailable.
 	 */
 	public function get_workspace_directory(): string {
-		$fs = FilesystemHelper::get();
 		// 1. Explicit constant override.
 		if ( defined( 'DATAMACHINE_WORKSPACE_PATH' ) ) {
 			return rtrim( DATAMACHINE_WORKSPACE_PATH, '/' );
@@ -314,7 +313,16 @@ class DirectoryManager {
 		// 2. System-level default (outside web root).
 		$system_path = '/var/lib/datamachine/workspace';
 		$system_base = dirname( $system_path );
-		if ( $fs->is_writable( $system_base ) || ( ! file_exists( $system_base ) && $fs->is_writable( dirname( $system_base ) ) ) ) {
+		$fs          = FilesystemHelper::get();
+		$base_writable = $fs
+			? $fs->is_writable( $system_base )
+			: is_writable( $system_base ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
+		$parent_writable = ! $base_writable && ! file_exists( $system_base ) && (
+			$fs
+				? $fs->is_writable( dirname( $system_base ) )
+				: is_writable( dirname( $system_base ) ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
+		);
+		if ( $base_writable || $parent_writable ) {
 			return $system_path;
 		}
 


### PR DESCRIPTION
## Summary

Closes #713

- Adds null safety guard to `DirectoryManager::get_workspace_directory()` — `FilesystemHelper::get()` can return `null` when `WP_Filesystem` fails to initialize (e.g. early CLI contexts). Falls back to native `is_writable()` when unavailable.
- Moves `$fs` initialization after the `DATAMACHINE_WORKSPACE_PATH` early return so it's only loaded when needed.

## Context

The original crash reported by Sarai was the **doubled accessor bug** (`$fs->$fs->is_writable()`) introduced by the lint fixer in PR #668 and already fixed on `main` in PR #669. Her site just needs to be updated to the latest version.

This PR adds defense-in-depth for the separate null case that could still crash if WP_Filesystem initialization fails.