### PR TITLE
fix: resolve last 2 test failures — flow_id type cast and QueueAbility re-registration

### DIFF
--- a/inc/Abilities/FlowAbilities.php
+++ b/inc/Abilities/FlowAbilities.php
@@ -36,15 +36,13 @@ class FlowAbilities {
 	private WebhookTriggerAbility $webhook_trigger;
 
 	public function __construct() {
-		// Always initialize queue - CLI commands need it regardless of WP_Ability
-		$this->queue = new QueueAbility();
-
 		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
 			return;
 		}
 
 		$this->registerCategory();
 
+		$this->queue           = new QueueAbility();
 		$this->get_flows       = new GetFlowsAbility();
 		$this->create_flow     = new CreateFlowAbility();
 		$this->update_flow     = new UpdateFlowAbility();
@@ -157,6 +155,9 @@ class FlowAbilities {
 	 * @return array Result with queue status.
 	 */
 	public function executeQueueAdd( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
 		return $this->queue->executeQueueAdd( $input );
 	}
 
@@ -167,6 +168,9 @@ class FlowAbilities {
 	 * @return array Result with queue items.
 	 */
 	public function executeQueueList( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
 		return $this->queue->executeQueueList( $input );
 	}
 
@@ -177,6 +181,9 @@ class FlowAbilities {
 	 * @return array Result with cleared count.
 	 */
 	public function executeQueueClear( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
 		return $this->queue->executeQueueClear( $input );
 	}
 
@@ -187,6 +194,9 @@ class FlowAbilities {
 	 * @return array Result with removed prompt info.
 	 */
 	public function executeQueueRemove( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
 		return $this->queue->executeQueueRemove( $input );
 	}
 
@@ -197,6 +207,9 @@ class FlowAbilities {
 	 * @return array Result with update status.
 	 */
 	public function executeQueueUpdate( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
 		return $this->queue->executeQueueUpdate( $input );
 	}
 
@@ -207,6 +220,9 @@ class FlowAbilities {
 	 * @return array Result with move status.
 	 */
 	public function executeQueueMove( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
 		return $this->queue->executeQueueMove( $input );
 	}
 }

--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -81,7 +81,7 @@ class FlowFormatter {
 		unset( $step_data );
 
 		$scheduling_config = $flow['scheduling_config'] ?? array();
-		$flow_id           = $flow['flow_id'] ?? null;
+		$flow_id           = isset( $flow['flow_id'] ) ? (int) $flow['flow_id'] : null;
 
 		$last_run_at     = $latest_job['created_at'] ?? null;
 		$last_run_status = $latest_job['status'] ?? null;
@@ -92,7 +92,7 @@ class FlowFormatter {
 		return array(
 			'flow_id'           => $flow_id,
 			'flow_name'         => $flow['flow_name'] ?? '',
-			'pipeline_id'       => $flow['pipeline_id'] ?? null,
+			'pipeline_id'       => isset( $flow['pipeline_id'] ) ? (int) $flow['pipeline_id'] : null,
 			'flow_config'       => $flow_config,
 			'scheduling_config' => $scheduling_config,
 			'last_run'          => $last_run_at,

--- a/tests/Unit/Abilities/FlowAbilitiesTest.php
+++ b/tests/Unit/Abilities/FlowAbilitiesTest.php
@@ -165,21 +165,19 @@ class FlowAbilitiesTest extends WP_UnitTestCase {
 			],
 		] );
 
+		// Use step_configs to set handlers through the proper API contract.
+		// Passing flow_config directly gets overwritten by syncStepsToFlow.
 		$flow = $flow_ability->execute( [
-			'pipeline_id' => $pipeline['pipeline_id'],
-			'flow_name'   => 'Multi-Handler Flow',
-			'flow_config' => [
-				'step1' => [
-					'step_type'        => 'fetch',
-					'handler_slugs'    => [ 'rss' ],
-					'handler_configs'  => [ 'rss' => [] ],
-					'pipeline_step_id' => 'step1',
+			'pipeline_id'  => $pipeline['pipeline_id'],
+			'flow_name'    => 'Multi-Handler Flow',
+			'step_configs' => [
+				'fetch'   => [
+					'handler_slug'   => 'rss',
+					'handler_config' => [],
 				],
-				'step2' => [
-					'step_type'        => 'publish',
-					'handler_slugs'    => [ 'wordpress_publish' ],
-					'handler_configs'  => [ 'wordpress_publish' => [] ],
-					'pipeline_step_id' => 'step2',
+				'publish' => [
+					'handler_slug'   => 'wordpress_publish',
+					'handler_config' => [],
 				],
 			],
 		] );


### PR DESCRIPTION
## Summary
- Fixes the last 2 PHPUnit test failures in the data-machine suite, bringing it to **0 failures**
- Fixes a hidden bug where `QueueAbility` was re-registered on every `FlowAbilities` instantiation

## Changes

### FlowFormatter — integer type casting
`flow_id` and `pipeline_id` from the database come as strings. `FlowFormatter::format_flow_for_response()` passed them through without casting, causing strict comparison (`===`) mismatches when test code compared against integer IDs from create responses.

### FlowAbilities — QueueAbility registration guard
`QueueAbility` was instantiated **outside** the `self::$registered` guard in `FlowAbilities::__construct()`. Every `new FlowAbilities()` call re-registered all 7 queue abilities, triggering `_doing_it_wrong` notices. Moved inside the guard and added lazy init to all 6 queue facade methods (matching the pattern used by every other ability in the class).

### FlowAbilitiesTest — proper API usage
`test_handler_slug_any_step_match` passed `flow_config` with `handler_slugs` directly, but `syncStepsToFlow()` overwrites flow_config with scaffolded steps. Switched to `step_configs` which is the proper API contract for configuring handlers during flow creation.

## Result
Full test suite: **0 failures** (was 2 before this PR, was 91 before the recent CI triage effort)

## Related
- Closes the test failures tracked in #590
- Filed homeboy#592 for `homeboy test` incorrectly reporting BUILD FAILED when all tests pass but lint has warnings