### PR TITLE
refactor: decouple Jobs from pipeline_id/flow_id requirement

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -262,16 +262,20 @@ class PipelineBatchScheduler {
 		array $single_packet,
 		array $engine_snapshot
 	): int|false {
-		$pipeline_id = $engine_snapshot['job']['pipeline_id'] ?? 0;
-		$flow_id     = $engine_snapshot['job']['flow_id'] ?? 0;
+		$pipeline_id = $engine_snapshot['job']['pipeline_id'] ?? null;
+		$flow_id     = $engine_snapshot['job']['flow_id'] ?? null;
 		$flow_name   = $engine_snapshot['flow']['name'] ?? '';
 		$item_title  = $single_packet['data']['title'] ?? 'Untitled';
+
+		// Normalize: 0 → null for standalone compatibility.
+		$pipeline_id = ( empty( $pipeline_id ) && ! is_string( $pipeline_id ) ) ? null : $pipeline_id;
+		$flow_id     = ( empty( $flow_id ) && ! is_string( $flow_id ) ) ? null : $flow_id;
 
 		// Create child job linked to parent.
 		$child_job_id = $this->db_jobs->create_job( array(
 			'pipeline_id'   => $pipeline_id,
 			'flow_id'       => $flow_id,
-			'source'        => 'pipeline',
+			'source'        => $pipeline_id ? 'pipeline' : 'standalone',
 			'label'         => $item_title,
 			'parent_job_id' => $parent_job_id,
 		) );

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -115,28 +115,33 @@ class ScheduleNextStepAbility {
 			$engine           = new EngineData( $engine_snapshot, $job_id );
 			$flow_step_config = $engine->getFlowStepConfig( $flow_step_id );
 
-			$flow_id = (int) ( $flow_step_config['flow_id'] ?? ( $engine->getJobContext()['flow_id'] ?? 0 ) );
+			$raw_flow_id = $flow_step_config['flow_id'] ?? ( $engine->getJobContext()['flow_id'] ?? null );
 
-			if ( $flow_id <= 0 ) {
-				do_action(
-					'datamachine_log',
-					'error',
-					'Flow ID missing during data storage',
-					array(
-						'job_id'       => $job_id,
-						'flow_step_id' => $flow_step_id,
-					)
-				);
-				return array(
-					'success' => false,
-					'error'   => 'Flow ID missing during data storage.',
-				);
+			// Standalone jobs (null flow_id) skip file-based data storage.
+			if ( null !== $raw_flow_id && 'direct' !== $raw_flow_id ) {
+				$flow_id = (int) $raw_flow_id;
+
+				if ( $flow_id <= 0 ) {
+					do_action(
+						'datamachine_log',
+						'error',
+						'Flow ID missing during data storage',
+						array(
+							'job_id'       => $job_id,
+							'flow_step_id' => $flow_step_id,
+						)
+					);
+					return array(
+						'success' => false,
+						'error'   => 'Flow ID missing during data storage.',
+					);
+				}
+
+				$context = datamachine_get_file_context( $flow_id );
+
+				$storage = new FileStorage();
+				$storage->store_data_packet( $dataPackets, $job_id, $context );
 			}
-
-			$context = datamachine_get_file_context( $flow_id );
-
-			$storage = new FileStorage();
-			$storage->store_data_packet( $dataPackets, $job_id, $context );
 		}
 
 		// Action Scheduler only receives IDs.

--- a/inc/Api/FlowFiles.php
+++ b/inc/Api/FlowFiles.php
@@ -220,12 +220,20 @@ class FlowFiles {
 	/**
 	 * Get file context array from flow ID.
 	 *
-	 * Supports both database flows (numeric ID) and direct execution ('direct').
+	 * Supports database flows (numeric ID), direct execution ('direct'),
+	 * and standalone jobs (null flow_id).
 	 *
-	 * @param int|string $flow_id Flow ID or 'direct' for ephemeral workflows.
+	 * @param int|string|null $flow_id Flow ID, 'direct', or null for standalone.
 	 * @return array Context array with pipeline_id and flow_id.
 	 */
-	public static function get_file_context( int|string $flow_id ): array {
+	public static function get_file_context( int|string|null $flow_id ): array {
+		if ( null === $flow_id ) {
+			return array(
+				'pipeline_id' => null,
+				'flow_id'     => null,
+			);
+		}
+
 		if ( 'direct' === $flow_id ) {
 			return array(
 				'pipeline_id' => 'direct',

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -122,14 +122,16 @@ class Jobs {
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-		// pipeline_id and flow_id are VARCHAR to support 'direct' execution mode
-		// where these values store the string 'direct' instead of numeric IDs
+		// pipeline_id and flow_id are VARCHAR to support multiple execution modes:
+		// - Numeric string: database flow execution (e.g. '123')
+		// - 'direct': ephemeral workflow execution
+		// - NULL: standalone job execution (no pipeline/flow)
 		// status is VARCHAR(255) to support compound statuses with reasons
 		$sql = "CREATE TABLE $table_name (
             job_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
             user_id bigint(20) unsigned NOT NULL DEFAULT 0,
-            pipeline_id varchar(20) NOT NULL,
-            flow_id varchar(20) NOT NULL,
+            pipeline_id varchar(20) NULL DEFAULT NULL,
+            flow_id varchar(20) NULL DEFAULT NULL,
             source varchar(50) NOT NULL DEFAULT 'pipeline',
             label varchar(255) NULL DEFAULT NULL,
             parent_job_id bigint(20) unsigned NULL DEFAULT NULL,
@@ -178,7 +180,7 @@ class Jobs {
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$columns = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH 
+				"SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, IS_NULLABLE
                  FROM information_schema.COLUMNS 
                  WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s 
                  AND COLUMN_NAME IN ('status', 'pipeline_id', 'flow_id', 'source', 'parent_job_id', 'user_id')",
@@ -209,36 +211,51 @@ class Jobs {
 			);
 		}
 
-		// Migrate pipeline_id column: bigint -> varchar(20) for 'direct' execution
+		// Migrate pipeline_id column: bigint -> varchar(20) NULL for standalone job support
 		if ( isset( $columns['pipeline_id'] ) && 'bigint' === $columns['pipeline_id']->DATA_TYPE ) {
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
 			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
-			$wpdb->query( "ALTER TABLE {$table_name} MODIFY pipeline_id varchar(20) NOT NULL" );
+			$wpdb->query( "ALTER TABLE {$table_name} MODIFY pipeline_id varchar(20) NULL DEFAULT NULL" );
 			// phpcs:enable WordPress.DB.PreparedSQL
 			do_action(
 				'datamachine_log',
 				'info',
-				'Migrated jobs.pipeline_id column to varchar(20) for direct execution support',
+				'Migrated jobs.pipeline_id column to varchar(20) NULL',
 				array(
 					'table_name' => $table_name,
 				)
 			);
 		}
 
-		// Migrate flow_id column: bigint -> varchar(20) for 'direct' execution
+		// Migrate flow_id column: bigint -> varchar(20) NULL for standalone job support
 		if ( isset( $columns['flow_id'] ) && 'bigint' === $columns['flow_id']->DATA_TYPE ) {
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
 			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
-			$wpdb->query( "ALTER TABLE {$table_name} MODIFY flow_id varchar(20) NOT NULL" );
+			$wpdb->query( "ALTER TABLE {$table_name} MODIFY flow_id varchar(20) NULL DEFAULT NULL" );
 			// phpcs:enable WordPress.DB.PreparedSQL
 			do_action(
 				'datamachine_log',
 				'info',
-				'Migrated jobs.flow_id column to varchar(20) for direct execution support',
+				'Migrated jobs.flow_id column to varchar(20) NULL',
 				array(
 					'table_name' => $table_name,
 				)
 			);
+		}
+
+		// Migrate pipeline_id/flow_id from NOT NULL to NULL for standalone job support.
+		// Runs on existing varchar(20) installs that haven't been updated yet.
+		if ( isset( $columns['pipeline_id'] ) && 'varchar' === $columns['pipeline_id']->DATA_TYPE && 'NO' === $columns['pipeline_id']->IS_NULLABLE ) {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+			$wpdb->query( "ALTER TABLE {$table_name} MODIFY pipeline_id varchar(20) NULL DEFAULT NULL" );
+			// phpcs:enable WordPress.DB.PreparedSQL
+		}
+		if ( isset( $columns['flow_id'] ) && 'varchar' === $columns['flow_id']->DATA_TYPE && 'NO' === $columns['flow_id']->IS_NULLABLE ) {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+			$wpdb->query( "ALTER TABLE {$table_name} MODIFY flow_id varchar(20) NULL DEFAULT NULL" );
+			// phpcs:enable WordPress.DB.PreparedSQL
 		}
 
 		// Add source and label columns for pipeline decoupling.

--- a/inc/Core/Database/Jobs/JobsOperations.php
+++ b/inc/Core/Database/Jobs/JobsOperations.php
@@ -18,14 +18,12 @@ class JobsOperations extends BaseRepository {
 	/**
 	 * Create a new job record.
 	 *
-	 * Supports two execution modes:
+	 * Supports three execution modes:
 	 * - Direct execution: pipeline_id='direct', flow_id='direct' (chat/API workflows without saved pipeline/flow)
 	 * - Database flow: pipeline_id and flow_id are numeric strings (saved pipelines and flows)
+	 * - Standalone: pipeline_id=null, flow_id=null (jobs without pipeline/flow context)
 	 *
-	 * Validation is strict: null values are rejected. Callers must explicitly pass 'direct'
-	 * for ephemeral workflows or valid numeric IDs for database flows.
-	 *
-	 * @param array $job_data Job data with pipeline_id and flow_id
+	 * @param array $job_data Job data with optional pipeline_id and flow_id
 	 * @return int|false Job ID on success, false on failure
 	 */
 	public function create_job( array $job_data ): int|false {
@@ -39,11 +37,14 @@ class JobsOperations extends BaseRepository {
 		// Database flow: both must be valid numeric IDs > 0
 		$is_database_flow = ( is_numeric( $pipeline_id ) && (int) $pipeline_id > 0 && is_numeric( $flow_id ) && (int) $flow_id > 0 );
 
-		if ( ! $is_direct_execution && ! $is_database_flow ) {
+		// Standalone: both are null (no pipeline/flow context)
+		$is_standalone = ( null === $pipeline_id && null === $flow_id );
+
+		if ( ! $is_direct_execution && ! $is_database_flow && ! $is_standalone ) {
 			do_action(
 				'datamachine_log',
 				'error',
-				'Invalid job data: must provide both IDs as "direct" or both as valid numeric IDs',
+				'Invalid job data: must provide both IDs as "direct", both as valid numeric IDs, or both as null',
 				array(
 					'pipeline_id' => $pipeline_id,
 					'flow_id'     => $flow_id,
@@ -52,12 +53,16 @@ class JobsOperations extends BaseRepository {
 			return false;
 		}
 
-		// Normalize to string for database storage
-		$pipeline_id = $is_direct_execution ? 'direct' : (string) absint( $pipeline_id );
-		$flow_id     = $is_direct_execution ? 'direct' : (string) absint( $flow_id );
+		// Normalize to string for database storage (null stays null for standalone)
+		if ( $is_database_flow ) {
+			$pipeline_id = (string) absint( $pipeline_id );
+			$flow_id     = (string) absint( $flow_id );
+		}
+		// Direct and standalone keep their values ('direct' or null)
 
 		// Sanitize source — accept any string, don't gatekeep values.
-		$source = sanitize_key( $job_data['source'] ?? ( $is_direct_execution ? 'direct' : 'pipeline' ) );
+		$default_source = $is_standalone ? 'standalone' : ( $is_direct_execution ? 'direct' : 'pipeline' );
+		$source         = sanitize_key( $job_data['source'] ?? $default_source );
 
 		$label = isset( $job_data['label'] ) ? sanitize_text_field( $job_data['label'] ) : null;
 
@@ -65,15 +70,21 @@ class JobsOperations extends BaseRepository {
 		$user_id       = isset( $job_data['user_id'] ) ? absint( $job_data['user_id'] ) : 0;
 
 		$data = array(
-			'pipeline_id' => $pipeline_id,
-			'flow_id'     => $flow_id,
 			'user_id'     => $user_id,
 			'source'      => $source,
 			'label'       => $label,
 			'status'      => 'pending',
 		);
 
-		$format = array( '%s', '%s', '%d', '%s', '%s', '%s' );
+		$format = array( '%d', '%s', '%s', '%s' );
+
+		// Only include pipeline_id/flow_id when they have values (NULL omission lets DB default apply).
+		if ( ! $is_standalone ) {
+			$data['pipeline_id'] = $pipeline_id;
+			$data['flow_id']     = $flow_id;
+			$format[]            = '%s';
+			$format[]            = '%s';
+		}
 
 		if ( $parent_job_id > 0 ) {
 			$data['parent_job_id'] = $parent_job_id;

--- a/inc/Core/ExecutionContext.php
+++ b/inc/Core/ExecutionContext.php
@@ -5,9 +5,10 @@
  * Encapsulates execution mode and provides a unified interface for all handler types.
  * Centralizes deduplication, engine data access, file storage context, and logging.
  *
- * Supports two execution modes:
+ * Supports three execution modes:
  * - 'direct': Direct execution without database persistence (CLI tools, ephemeral workflows)
  * - 'flow': Standard flow-based execution with full pipeline/flow context
+ * - 'standalone': Job execution without pipeline/flow context (system tasks, ad-hoc jobs)
  *
  * In direct mode, pipeline_id and flow_id are set to the string 'direct' for consistent
  * end-to-end traceability throughout the system.
@@ -25,8 +26,9 @@ defined( 'ABSPATH' ) || exit;
 
 class ExecutionContext {
 
-	public const MODE_DIRECT = 'direct';
-	public const MODE_FLOW   = 'flow';
+	public const MODE_DIRECT     = 'direct';
+	public const MODE_FLOW       = 'flow';
+	public const MODE_STANDALONE = 'standalone';
 
 	private string $mode;
 	private int|string|null $pipeline_id;
@@ -106,6 +108,27 @@ class ExecutionContext {
 	}
 
 	/**
+	 * Factory: Standalone execution (no pipeline/flow).
+	 *
+	 * Use for system tasks, ad-hoc jobs, and standalone operations that
+	 * don't belong to a pipeline or flow.
+	 *
+	 * @param string|null $job_id Job ID
+	 * @param string      $handler_type Handler type identifier
+	 * @return self
+	 */
+	public static function standalone( ?string $job_id = null, string $handler_type = '' ): self {
+		return new self(
+			self::MODE_STANDALONE,
+			null,
+			null,
+			null,
+			$job_id,
+			$handler_type
+		);
+	}
+
+	/**
 	 * Factory: Create from handler config array.
 	 *
 	 * Provides backward compatibility with existing config structures.
@@ -129,6 +152,11 @@ class ExecutionContext {
 				$job_id,
 				$handler_type
 			);
+		}
+
+		// Standalone: both null — no pipeline/flow context.
+		if ( null === $pipeline_id && null === $flow_id ) {
+			return self::standalone( $job_id, $handler_type );
 		}
 
 		return self::fromFlow(
@@ -159,9 +187,18 @@ class ExecutionContext {
 	}
 
 	/**
+	 * Check if this is standalone execution mode (no pipeline/flow).
+	 *
+	 * @return bool
+	 */
+	public function isStandalone(): bool {
+		return self::MODE_STANDALONE === $this->mode;
+	}
+
+	/**
 	 * Get execution mode.
 	 *
-	 * @return string 'direct' or 'flow'
+	 * @return string 'direct', 'flow', or 'standalone'
 	 */
 	public function getMode(): string {
 		return $this->mode;
@@ -176,7 +213,7 @@ class ExecutionContext {
 	 * @return bool True if already processed
 	 */
 	public function isItemProcessed( string $item_id ): bool {
-		if ( $this->isDirect() || ! $this->flow_step_id ) {
+		if ( $this->isDirect() || $this->isStandalone() || ! $this->flow_step_id ) {
 			return false;
 		}
 		$db_processed_items = new ProcessedItems();
@@ -191,7 +228,7 @@ class ExecutionContext {
 	 * @param string $item_id Item identifier
 	 */
 	public function markItemProcessed( string $item_id ): void {
-		if ( $this->isDirect() || ! $this->flow_step_id ) {
+		if ( $this->isDirect() || $this->isStandalone() || ! $this->flow_step_id ) {
 			return;
 		}
 		do_action(
@@ -258,6 +295,9 @@ class ExecutionContext {
 		if ( $this->isDirect() ) {
 			return 'direct';
 		}
+		if ( $this->isStandalone() ) {
+			return 'standalone' . ( $this->job_id ? "/job-{$this->job_id}" : '' );
+		}
 		return "pipeline-{$this->pipeline_id}/flow-{$this->flow_id}";
 	}
 
@@ -275,6 +315,14 @@ class ExecutionContext {
 				'pipeline_name' => 'direct',
 				'flow_id'       => 'direct',
 				'flow_name'     => 'direct',
+			);
+		}
+		if ( $this->isStandalone() ) {
+			return array(
+				'pipeline_id'   => null,
+				'pipeline_name' => 'standalone',
+				'flow_id'       => null,
+				'flow_name'     => 'standalone',
 			);
 		}
 		return array(

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -33,10 +33,10 @@ function datamachine_normalize_engine_config( $config ): array {
 /**
  * Get file context array from flow ID.
  *
- * @param int|string $flow_id Flow ID or 'direct' for ephemeral workflows.
+ * @param int|string|null $flow_id Flow ID, 'direct', or null for standalone.
  * @return array Context array with pipeline/flow metadata.
  */
-function datamachine_get_file_context( int|string $flow_id ): array {
+function datamachine_get_file_context( int|string|null $flow_id ): array {
 	return \DataMachine\Api\FlowFiles::get_file_context( $flow_id );
 }
 

--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -127,7 +127,7 @@ class FailJobHandler {
 
 		if ( $cleanup_files ) {
 			$job = $db_jobs->get_job( $job_id );
-			if ( $job && function_exists( 'datamachine_get_file_context' ) ) {
+			if ( $job && function_exists( 'datamachine_get_file_context' ) && ! empty( $job['flow_id'] ) ) {
 				$cleanup       = new \DataMachine\Core\FilesRepository\FileCleanup();
 				$context       = datamachine_get_file_context( $job['flow_id'] );
 				$deleted_count = $cleanup->cleanup_job_data_packets( $job_id, $context );

--- a/tests/Unit/Core/StandaloneJobTest.php
+++ b/tests/Unit/Core/StandaloneJobTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Tests for standalone job creation and execution (null pipeline_id/flow_id).
+ *
+ * @package DataMachine\Tests\Unit\Core
+ */
+
+namespace DataMachine\Tests\Unit\Core;
+
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\ExecutionContext;
+use WP_UnitTestCase;
+
+class StandaloneJobTest extends WP_UnitTestCase {
+
+	private Jobs $db_jobs;
+
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+
+		if ( function_exists( 'datamachine_activate_for_site' ) ) {
+			datamachine_activate_for_site();
+		}
+	}
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->db_jobs = new Jobs();
+	}
+
+	// -- create_job --
+
+	public function test_create_standalone_job_with_null_ids(): void {
+		$job_id = $this->db_jobs->create_job( array(
+			'source' => 'system_task',
+			'label'  => 'Standalone test job',
+		) );
+
+		$this->assertIsInt( $job_id );
+		$this->assertGreaterThan( 0, $job_id );
+	}
+
+	public function test_standalone_job_has_null_pipeline_and_flow(): void {
+		$job_id = $this->db_jobs->create_job( array(
+			'label' => 'Null IDs check',
+		) );
+
+		$job = $this->db_jobs->get_job( $job_id );
+
+		$this->assertNull( $job['pipeline_id'] );
+		$this->assertNull( $job['flow_id'] );
+	}
+
+	public function test_standalone_job_defaults_source_to_standalone(): void {
+		$job_id = $this->db_jobs->create_job( array(
+			'label' => 'Default source check',
+		) );
+
+		$job = $this->db_jobs->get_job( $job_id );
+
+		$this->assertSame( 'standalone', $job['source'] );
+	}
+
+	public function test_standalone_job_accepts_custom_source(): void {
+		$job_id = $this->db_jobs->create_job( array(
+			'source' => 'system_task',
+			'label'  => 'Custom source',
+		) );
+
+		$job = $this->db_jobs->get_job( $job_id );
+
+		$this->assertSame( 'system_task', $job['source'] );
+	}
+
+	public function test_mixed_null_and_numeric_ids_rejected(): void {
+		// pipeline_id set but flow_id omitted = invalid (neither all-null nor all-numeric).
+		$result = $this->db_jobs->create_job( array(
+			'pipeline_id' => 1,
+			'label'       => 'Invalid mix',
+		) );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_pipeline_jobs_still_work(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$pipeline = wp_get_ability( 'datamachine/create-pipeline' )->execute(
+			array( 'pipeline_name' => 'Standalone test pipeline' )
+		);
+		$flow = wp_get_ability( 'datamachine/create-flow' )->execute(
+			array( 'pipeline_id' => $pipeline['pipeline_id'], 'flow_name' => 'Standalone test flow' )
+		);
+
+		$job_id = $this->db_jobs->create_job( array(
+			'pipeline_id' => $pipeline['pipeline_id'],
+			'flow_id'     => $flow['flow_id'],
+			'source'      => 'pipeline',
+		) );
+
+		$this->assertIsInt( $job_id );
+
+		$job = $this->db_jobs->get_job( $job_id );
+		$this->assertSame( (string) $pipeline['pipeline_id'], $job['pipeline_id'] );
+		$this->assertSame( (string) $flow['flow_id'], $job['flow_id'] );
+	}
+
+	public function test_direct_jobs_still_work(): void {
+		$job_id = $this->db_jobs->create_job( array(
+			'pipeline_id' => 'direct',
+			'flow_id'     => 'direct',
+			'source'      => 'direct',
+		) );
+
+		$this->assertIsInt( $job_id );
+
+		$job = $this->db_jobs->get_job( $job_id );
+		$this->assertSame( 'direct', $job['pipeline_id'] );
+		$this->assertSame( 'direct', $job['flow_id'] );
+	}
+
+	// -- ExecutionContext --
+
+	public function test_standalone_execution_context(): void {
+		$ctx = ExecutionContext::standalone( '99', 'test_handler' );
+
+		$this->assertTrue( $ctx->isStandalone() );
+		$this->assertFalse( $ctx->isDirect() );
+		$this->assertFalse( $ctx->isFlow() );
+		$this->assertSame( 'standalone', $ctx->getMode() );
+		$this->assertNull( $ctx->getPipelineId() );
+		$this->assertNull( $ctx->getFlowId() );
+		$this->assertSame( '99', $ctx->getJobId() );
+	}
+
+	public function test_standalone_storage_path_includes_job_id(): void {
+		$ctx = ExecutionContext::standalone( '42' );
+
+		$this->assertSame( 'standalone/job-42', $ctx->getStoragePath() );
+	}
+
+	public function test_standalone_storage_path_without_job_id(): void {
+		$ctx = ExecutionContext::standalone();
+
+		$this->assertSame( 'standalone', $ctx->getStoragePath() );
+	}
+
+	public function test_standalone_file_context_has_null_ids(): void {
+		$ctx = ExecutionContext::standalone( '42' );
+
+		$file_context = $ctx->getFileContext();
+		$this->assertNull( $file_context['pipeline_id'] );
+		$this->assertNull( $file_context['flow_id'] );
+		$this->assertSame( 'standalone', $file_context['pipeline_name'] );
+		$this->assertSame( 'standalone', $file_context['flow_name'] );
+	}
+
+	public function test_from_config_detects_standalone(): void {
+		$ctx = ExecutionContext::fromConfig( array(
+			'pipeline_id' => null,
+			'flow_id'     => null,
+		), '99' );
+
+		$this->assertTrue( $ctx->isStandalone() );
+	}
+
+	public function test_standalone_skips_deduplication(): void {
+		$ctx = ExecutionContext::standalone( '42', 'test_handler' );
+
+		// Should always return false (no deduplication for standalone).
+		$this->assertFalse( $ctx->isItemProcessed( 'test-item-123' ) );
+	}
+
+	// -- FlowFiles --
+
+	public function test_flow_files_null_flow_id_returns_null_context(): void {
+		$context = \DataMachine\Api\FlowFiles::get_file_context( null );
+
+		$this->assertNull( $context['pipeline_id'] );
+		$this->assertNull( $context['flow_id'] );
+	}
+
+	public function test_flow_files_direct_still_works(): void {
+		$context = \DataMachine\Api\FlowFiles::get_file_context( 'direct' );
+
+		$this->assertSame( 'direct', $context['pipeline_id'] );
+		$this->assertSame( 'direct', $context['flow_id'] );
+	}
+}


### PR DESCRIPTION
## Summary
- Closes #571
- Jobs no longer require `pipeline_id` and `flow_id` — they can now exist as **standalone** entities with both set to NULL
- Fully additive — existing pipeline and direct jobs work exactly the same

## The three job modes

```
Pipeline job:   pipeline_id = '123',    flow_id = '456'     (existing)
Direct job:     pipeline_id = 'direct', flow_id = 'direct'  (existing)
Standalone job: pipeline_id = NULL,     flow_id = NULL       (NEW)
```

## What changed (8 files)

### Database
- **Jobs.php**: Schema `NOT NULL` → `NULL DEFAULT NULL` with migration for existing installs (checks `IS_NULLABLE` column metadata)
- **JobsOperations.php**: `create_job()` now accepts null as third valid pattern. Defaults source to `'standalone'`. NULL pipeline_id/flow_id are omitted from INSERT (DB default applies)

### Execution context
- **ExecutionContext.php**: New `MODE_STANDALONE` constant + `standalone()` factory method. `fromConfig()` auto-detects null IDs. Null-safe `getStoragePath()` (`standalone/job-{id}`) and `getFileContext()`. `isStandalone()` check. Deduplication skipped for standalone.

### Engine pipeline
- **FlowFiles.php**: `get_file_context()` accepts `null` flow_id, returns `{pipeline_id: null, flow_id: null}`
- **Engine.php**: Updated type hint to `int|string|null`
- **ScheduleNextStepAbility.php**: Skips file-based data storage when flow_id is null (standalone jobs don't have flow directories)
- **FailJobHandler.php**: Guards against null flow_id before file cleanup
- **PipelineBatchScheduler.php**: Child jobs inherit null IDs from parent, normalizes 0→null

## Tests
- **15 new tests** in `StandaloneJobTest.php` covering:
  - Standalone job creation (null IDs, default source, custom source)
  - Mixed null/numeric rejection
  - Pipeline and direct backward compatibility
  - ExecutionContext standalone factory + all methods
  - FlowFiles null handling
- **0 regressions** — full suite passes

## What this unblocks
- System tasks as first-class jobs (no fake pipeline)
- Chat-initiated actions without pipeline/flow scaffolding
- Ad-hoc tool calls with proper job tracking
- #645 (execution policy) — job context without pipeline assumptions
- #636 (editable prompts) — system tasks with own job identity