### PR TITLE
feat(#731): unify duplicate detection with SimilarityEngine and check-duplicate ability

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -127,6 +127,9 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/PostQueryAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/PipelineAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/PipelineStepAbilities.php';
+	require_once __DIR__ . '/inc/Core/Similarity/SimilarityResult.php';
+	require_once __DIR__ . '/inc/Core/Similarity/SimilarityEngine.php';
+	require_once __DIR__ . '/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php';
 	require_once __DIR__ . '/inc/Abilities/ProcessedItemsAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/SettingsAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/HandlerAbilities.php';
@@ -175,6 +178,7 @@ function datamachine_run_datamachine_plugin() {
 		new \DataMachine\Abilities\PostQueryAbilities();
 		new \DataMachine\Abilities\PipelineAbilities();
 		new \DataMachine\Abilities\PipelineStepAbilities();
+		new \DataMachine\Abilities\DuplicateCheck\DuplicateCheckAbility();
 		new \DataMachine\Abilities\ProcessedItemsAbilities();
 		new \DataMachine\Abilities\SettingsAbilities();
 		new \DataMachine\Abilities\HandlerAbilities();

--- a/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php
+++ b/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php
@@ -1,0 +1,512 @@
+<?php
+/**
+ * Unified Duplicate Check Ability
+ *
+ * Single entry point for content-similarity duplicate detection.
+ * Replaces the three prior systems (QueueValidator published-post check,
+ * DuplicateDetection publish-time check, and extension-specific checks)
+ * with one Ability that runs a strategy cascade.
+ *
+ * Core provides a default "title match against published posts" strategy.
+ * Extensions register domain-specific strategies via the
+ * `datamachine_duplicate_strategies` filter (e.g., events adds
+ * venue + date + ticket URL matching).
+ *
+ * @package DataMachine\Abilities\DuplicateCheck
+ * @since   0.39.0
+ * @see     https://github.com/Extra-Chill/data-machine/issues/731
+ */
+
+namespace DataMachine\Abilities\DuplicateCheck;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Similarity\SimilarityEngine;
+use DataMachine\Core\Similarity\SimilarityResult;
+
+defined( 'ABSPATH' ) || exit;
+
+class DuplicateCheckAbility {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			$this->registerCheckDuplicate();
+			$this->registerTitlesMatch();
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Ability: datamachine/check-duplicate
+	// -----------------------------------------------------------------------
+
+	private function registerCheckDuplicate(): void {
+		wp_register_ability(
+			'datamachine/check-duplicate',
+			array(
+				'label'               => __( 'Check Duplicate', 'data-machine' ),
+				'description'         => __( 'Check if similar content already exists as a published post, in a queue, or via extension-registered strategies. Returns match details or clear verdict.', 'data-machine' ),
+				'category'            => 'datamachine',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'title' ),
+					'properties' => array(
+						'title'          => array(
+							'type'        => 'string',
+							'description' => __( 'Title or topic to check for duplicates', 'data-machine' ),
+						),
+						'post_type'      => array(
+							'type'        => 'string',
+							'description' => __( 'WordPress post type to check against (default: "post")', 'data-machine' ),
+						),
+						'lookback_days'  => array(
+							'type'        => 'integer',
+							'description' => __( 'How many days back to search (default: 14)', 'data-machine' ),
+						),
+						'scope'          => array(
+							'type'        => 'string',
+							'enum'        => array( 'published', 'queue', 'both' ),
+							'description' => __( 'What to check: published posts, queue items, or both (default: "published")', 'data-machine' ),
+						),
+						'flow_id'        => array(
+							'type'        => 'integer',
+							'description' => __( 'Flow ID for queue check (required when scope includes queue)', 'data-machine' ),
+						),
+						'flow_step_id'   => array(
+							'type'        => 'string',
+							'description' => __( 'Flow step ID for queue check (required when scope includes queue)', 'data-machine' ),
+						),
+						'threshold'      => array(
+							'type'        => 'number',
+							'description' => __( 'Jaccard similarity threshold for queue checks (default: 0.65)', 'data-machine' ),
+						),
+						'context'        => array(
+							'type'        => 'object',
+							'description' => __( 'Domain-specific context for extension strategies (e.g., venue, startDate, ticketUrl for events)', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'verdict'  => array( 'type' => 'string' ),
+						'source'   => array( 'type' => 'string' ),
+						'match'    => array( 'type' => 'object' ),
+						'reason'   => array( 'type' => 'string' ),
+						'strategy' => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeCheckDuplicate' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Execute the unified duplicate check.
+	 *
+	 * Runs the strategy cascade:
+	 * 1. Extension strategies (via filter, highest priority first)
+	 * 2. Core published-post title match
+	 * 3. Core queue-item Jaccard match (if scope includes queue)
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result with verdict, source, match details, reason.
+	 */
+	public function executeCheckDuplicate( array $input ): array {
+		$title         = sanitize_text_field( $input['title'] ?? '' );
+		$post_type     = ! empty( $input['post_type'] ) ? sanitize_text_field( $input['post_type'] ) : 'post';
+		$lookback_days = ! empty( $input['lookback_days'] ) ? (int) $input['lookback_days'] : 14;
+		$scope         = ! empty( $input['scope'] ) ? sanitize_text_field( $input['scope'] ) : 'published';
+		$threshold     = ! empty( $input['threshold'] ) ? (float) $input['threshold'] : SimilarityEngine::DEFAULT_JACCARD_THRESHOLD;
+		$context       = $input['context'] ?? array();
+
+		if ( empty( $title ) ) {
+			return array(
+				'verdict' => 'error',
+				'reason'  => 'title is required',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'DuplicateCheck: checking',
+			array(
+				'title'     => $title,
+				'post_type' => $post_type,
+				'scope'     => $scope,
+			)
+		);
+
+		// Phase 1: Run extension strategies (if any match the post_type).
+		$strategies = $this->getStrategies( $post_type );
+		foreach ( $strategies as $strategy ) {
+			$strategy_input = array_merge(
+				$input,
+				array(
+					'title'     => $title,
+					'post_type' => $post_type,
+					'context'   => $context,
+				)
+			);
+
+			$result = call_user_func( $strategy['callback'], $strategy_input );
+
+			if ( is_array( $result ) && ! empty( $result['verdict'] ) && 'duplicate' === $result['verdict'] ) {
+				$result['strategy'] = $strategy['id'] ?? 'extension';
+				return $result;
+			}
+		}
+
+		// Phase 2: Core published-post title match.
+		if ( in_array( $scope, array( 'published', 'both' ), true ) ) {
+			$post_result = $this->checkPublishedPosts( $title, $post_type, $lookback_days );
+			if ( null !== $post_result ) {
+				return $post_result;
+			}
+		}
+
+		// Phase 3: Core queue-item Jaccard match.
+		if ( in_array( $scope, array( 'queue', 'both' ), true ) ) {
+			$flow_id      = ! empty( $input['flow_id'] ) ? (int) $input['flow_id'] : 0;
+			$flow_step_id = ! empty( $input['flow_step_id'] ) ? sanitize_text_field( $input['flow_step_id'] ) : '';
+
+			if ( $flow_id > 0 && ! empty( $flow_step_id ) ) {
+				$queue_result = $this->checkQueueItems( $title, $threshold, $flow_id, $flow_step_id );
+				if ( null !== $queue_result ) {
+					return $queue_result;
+				}
+			}
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'DuplicateCheck: CLEAR',
+			array( 'title' => $title )
+		);
+
+		return array(
+			'verdict'  => 'clear',
+			'title'    => $title,
+			'reason'   => sprintf( 'No duplicates found for "%s".', $title ),
+			'strategy' => 'none',
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Ability: datamachine/titles-match
+	// -----------------------------------------------------------------------
+
+	private function registerTitlesMatch(): void {
+		wp_register_ability(
+			'datamachine/titles-match',
+			array(
+				'label'               => __( 'Titles Match', 'data-machine' ),
+				'description'         => __( 'Compare two titles for semantic equivalence using the unified similarity engine. Returns match result with score and strategy.', 'data-machine' ),
+				'category'            => 'datamachine',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'title1', 'title2' ),
+					'properties' => array(
+						'title1' => array(
+							'type'        => 'string',
+							'description' => __( 'First title', 'data-machine' ),
+						),
+						'title2' => array(
+							'type'        => 'string',
+							'description' => __( 'Second title', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'match'        => array( 'type' => 'boolean' ),
+						'score'        => array( 'type' => 'number' ),
+						'strategy'     => array( 'type' => 'string' ),
+						'normalized_a' => array( 'type' => 'string' ),
+						'normalized_b' => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeTitlesMatch' ),
+				'permission_callback' => '__return_true',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Compare two titles using the unified similarity engine.
+	 *
+	 * @param array $input { title1: string, title2: string }
+	 * @return array SimilarityResult as array.
+	 */
+	public function executeTitlesMatch( array $input ): array {
+		$title1 = $input['title1'] ?? '';
+		$title2 = $input['title2'] ?? '';
+
+		return SimilarityEngine::titlesMatch( $title1, $title2 )->toArray();
+	}
+
+	// -----------------------------------------------------------------------
+	// Strategy registry
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Get registered duplicate detection strategies for a post type.
+	 *
+	 * Extensions register strategies via the `datamachine_duplicate_strategies` filter:
+	 *
+	 *     add_filter('datamachine_duplicate_strategies', function($strategies) {
+	 *         $strategies[] = [
+	 *             'id'        => 'event',
+	 *             'post_type' => 'event',
+	 *             'callback'  => [EventDuplicateStrategy::class, 'check'],
+	 *             'priority'  => 10,
+	 *         ];
+	 *         return $strategies;
+	 *     });
+	 *
+	 * Strategies with post_type '*' run for all post types.
+	 * Sorted by priority (lower = runs first).
+	 *
+	 * @param string $post_type The post type being checked.
+	 * @return array Filtered and sorted strategies.
+	 */
+	private function getStrategies( string $post_type ): array {
+		/**
+		 * Filter the registered duplicate detection strategies.
+		 *
+		 * @since 0.39.0
+		 *
+		 * @param array  $strategies Array of strategy definitions.
+		 * @param string $post_type  The post type being checked.
+		 */
+		$strategies = apply_filters( 'datamachine_duplicate_strategies', array(), $post_type );
+
+		if ( ! is_array( $strategies ) ) {
+			return array();
+		}
+
+		// Filter to strategies that match this post type (or wildcard).
+		$strategies = array_filter(
+			$strategies,
+			function ( $strategy ) use ( $post_type ) {
+				if ( ! is_array( $strategy ) || ! is_callable( $strategy['callback'] ?? null ) ) {
+					return false;
+				}
+				$strategy_type = $strategy['post_type'] ?? '*';
+				return '*' === $strategy_type || $strategy_type === $post_type;
+			}
+		);
+
+		// Sort by priority (lower = runs first).
+		usort(
+			$strategies,
+			function ( $a, $b ) {
+				return ( $a['priority'] ?? 50 ) - ( $b['priority'] ?? 50 );
+			}
+		);
+
+		return $strategies;
+	}
+
+	// -----------------------------------------------------------------------
+	// Core strategies
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Check published posts for matching titles using the similarity engine.
+	 *
+	 * @param string $title         Title to check.
+	 * @param string $post_type     Post type to search.
+	 * @param int    $lookback_days How many days back to search.
+	 * @return array|null Duplicate result or null if clear.
+	 */
+	private function checkPublishedPosts( string $title, string $post_type, int $lookback_days ): ?array {
+		if ( empty( $title ) || empty( $post_type ) ) {
+			return null;
+		}
+
+		if ( $lookback_days <= 0 ) {
+			$lookback_days = 14;
+		}
+
+		$cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$lookback_days} days" ) );
+
+		$candidates = get_posts(
+			array(
+				'post_type'      => $post_type,
+				'post_status'    => array( 'publish', 'draft', 'pending' ),
+				// phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- intentional batch query
+				'posts_per_page' => 200,
+				'date_query'     => array(
+					array(
+						'after'     => $cutoff_date,
+						'inclusive' => true,
+					),
+				),
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			)
+		);
+
+		if ( empty( $candidates ) ) {
+			return null;
+		}
+
+		foreach ( $candidates as $candidate_id ) {
+			$candidate_title = get_the_title( $candidate_id );
+			$result          = SimilarityEngine::titlesMatch( $title, $candidate_title );
+
+			if ( $result->match ) {
+				do_action(
+					'datamachine_log',
+					'info',
+					'DuplicateCheck: found matching published post',
+					array(
+						'incoming_title' => $title,
+						'existing_id'    => $candidate_id,
+						'existing_title' => $candidate_title,
+						'score'          => $result->score,
+						'strategy'       => $result->strategy,
+					)
+				);
+
+				return array(
+					'verdict'  => 'duplicate',
+					'source'   => 'published_post',
+					'match'    => array(
+						'post_id'    => (int) $candidate_id,
+						'title'      => $candidate_title,
+						'url'        => get_permalink( $candidate_id ),
+						'score'      => $result->score,
+						'similarity' => $result->score,
+					),
+					'reason'   => sprintf(
+						'Rejected: "%s" matches existing post "%s" (ID %d) via %s (score: %.2f).',
+						$title,
+						$candidate_title,
+						$candidate_id,
+						$result->strategy,
+						$result->score
+					),
+					'strategy' => 'core_published_post',
+				);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check queue items for similar prompts using Jaccard similarity.
+	 *
+	 * @param string $title        Title to check.
+	 * @param float  $threshold    Jaccard threshold.
+	 * @param int    $flow_id      Flow ID.
+	 * @param string $flow_step_id Flow step ID.
+	 * @return array|null Duplicate result or null if clear.
+	 */
+	private function checkQueueItems( string $title, float $threshold, int $flow_id, string $flow_step_id ): ?array {
+		$db_flows_class = 'DataMachine\\Core\\Database\\Flows\\Flows';
+		if ( ! class_exists( $db_flows_class ) ) {
+			return null;
+		}
+
+		$db_flows = new $db_flows_class();
+		$flow     = $db_flows->get_flow( $flow_id );
+
+		if ( ! $flow ) {
+			return null;
+		}
+
+		$flow_config = $flow['flow_config'] ?? array();
+
+		if ( ! isset( $flow_config[ $flow_step_id ] ) ) {
+			return null;
+		}
+
+		$prompt_queue = $flow_config[ $flow_step_id ]['prompt_queue'] ?? array();
+
+		if ( empty( $prompt_queue ) ) {
+			return null;
+		}
+
+		$best_match = null;
+		$best_score = 0.0;
+
+		foreach ( $prompt_queue as $index => $item ) {
+			$prompt = $item['prompt'] ?? '';
+			$result = SimilarityEngine::jaccardMatch( $title, $prompt, $threshold );
+
+			if ( $result->match && $result->score > $best_score ) {
+				$best_score = $result->score;
+				$best_match = array(
+					'index'      => (int) $index,
+					'prompt'     => $prompt,
+					'similarity' => round( $result->score, 3 ),
+				);
+			}
+		}
+
+		if ( null !== $best_match ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'DuplicateCheck: found matching queue item',
+				array(
+					'title'  => $title,
+					'match'  => $best_match,
+				)
+			);
+
+			return array(
+				'verdict'  => 'duplicate',
+				'source'   => 'queue',
+				'match'    => $best_match,
+				'reason'   => sprintf(
+					'Rejected: "%s" is %.0f%% similar to queued item "%s" (index %d).',
+					$title,
+					$best_match['similarity'] * 100,
+					$best_match['prompt'],
+					$best_match['index']
+				),
+				'strategy' => 'core_queue_item',
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Permission callback.
+	 *
+	 * @return bool
+	 */
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+}

--- a/inc/Core/Similarity/SimilarityEngine.php
+++ b/inc/Core/Similarity/SimilarityEngine.php
@@ -1,0 +1,382 @@
+<?php
+/**
+ * Unified similarity engine for duplicate detection.
+ *
+ * Consolidates title normalization, fuzzy matching, Jaccard similarity,
+ * and tokenization from three prior implementations:
+ *
+ * - DuplicateDetection (Core/WordPress) — publish-level fuzzy title match
+ * - QueueValidator (Engine/AI/Tools) — Jaccard word-set similarity
+ * - EventIdentifierGenerator (data-machine-events) — event title/venue matching
+ *
+ * All similarity math lives here. Consumers (QueueValidator, publish handlers,
+ * DuplicateCheckAbility, extension strategies) call these pure functions.
+ *
+ * @package DataMachine\Core\Similarity
+ * @since   0.39.0
+ * @see     https://github.com/Extra-Chill/data-machine/issues/731
+ */
+
+namespace DataMachine\Core\Similarity;
+
+defined( 'ABSPATH' ) || exit;
+
+class SimilarityEngine {
+
+	/**
+	 * Default Jaccard similarity threshold.
+	 *
+	 * @var float
+	 */
+	const DEFAULT_JACCARD_THRESHOLD = 0.65;
+
+	/**
+	 * Default Levenshtein tolerance (fraction of max length).
+	 *
+	 * @var float
+	 */
+	const DEFAULT_LEVENSHTEIN_TOLERANCE = 0.15;
+
+	/**
+	 * Minimum title length for Levenshtein comparison.
+	 *
+	 * @var int
+	 */
+	const MIN_LEVENSHTEIN_LENGTH = 15;
+
+	/**
+	 * Minimum prefix length for prefix matching.
+	 *
+	 * @var int
+	 */
+	const MIN_PREFIX_LENGTH = 5;
+
+	/**
+	 * Stop words excluded from Jaccard tokenization.
+	 *
+	 * @var array
+	 */
+	const STOP_WORDS = array(
+		'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to',
+		'for', 'of', 'with', 'by', 'from', 'is', 'it', 'are', 'was',
+		'were', 'be', 'been', 'being', 'have', 'has', 'had', 'do', 'does',
+		'did', 'will', 'would', 'could', 'should', 'may', 'might', 'shall',
+		'can', 'not', 'no', 'if', 'when', 'what', 'why', 'how', 'who',
+		'where', 'which', 'that', 'this', 'you', 'your', 'my', 'am',
+		'me', 'we', 'they', 'them', 'its',
+	);
+
+	// -----------------------------------------------------------------------
+	// Title comparison
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Compare two titles for semantic match.
+	 *
+	 * Runs a cascade of strategies in order of strictness:
+	 * 1. Exact match after normalization
+	 * 2. Prefix match (one core title starts with the other, min 5 chars)
+	 * 3. Levenshtein distance (≤15% diff for titles ≥15 chars)
+	 *
+	 * Returns a SimilarityResult with match, score, and strategy.
+	 *
+	 * @param string $title1 First title.
+	 * @param string $title2 Second title.
+	 * @return SimilarityResult
+	 */
+	public static function titlesMatch( string $title1, string $title2 ): SimilarityResult {
+		$core1 = self::normalizeTitle( $title1 );
+		$core2 = self::normalizeTitle( $title2 );
+
+		// Strategy 1: Exact match after normalization.
+		if ( $core1 === $core2 ) {
+			return new SimilarityResult( true, 1.0, SimilarityResult::STRATEGY_EXACT, $core1, $core2 );
+		}
+
+		// Strategy 2: Prefix match.
+		$shorter = strlen( $core1 ) <= strlen( $core2 ) ? $core1 : $core2;
+		$longer  = strlen( $core1 ) <= strlen( $core2 ) ? $core2 : $core1;
+
+		if ( strlen( $shorter ) >= self::MIN_PREFIX_LENGTH && str_starts_with( $longer, $shorter ) ) {
+			// Score proportional to how much of the longer title the prefix covers.
+			$score = strlen( $shorter ) / strlen( $longer );
+			return new SimilarityResult( true, $score, SimilarityResult::STRATEGY_PREFIX, $core1, $core2 );
+		}
+
+		// Strategy 3: Levenshtein distance for very similar titles.
+		$len1 = strlen( $core1 );
+		$len2 = strlen( $core2 );
+
+		if ( $len1 >= self::MIN_LEVENSHTEIN_LENGTH && $len2 >= self::MIN_LEVENSHTEIN_LENGTH ) {
+			$max_len  = max( $len1, $len2 );
+			$distance = levenshtein( $core1, $core2 );
+
+			if ( $distance <= (int) ( $max_len * self::DEFAULT_LEVENSHTEIN_TOLERANCE ) ) {
+				$score = 1.0 - ( $distance / $max_len );
+				return new SimilarityResult( true, $score, SimilarityResult::STRATEGY_EDIT, $core1, $core2 );
+			}
+		}
+
+		return SimilarityResult::noMatch( $core1, $core2 );
+	}
+
+	// -----------------------------------------------------------------------
+	// Jaccard similarity (word-set)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Compare two texts using Jaccard similarity on tokenized word sets.
+	 *
+	 * Useful for topically-similar content where wording differs significantly
+	 * (e.g., "Best Phish Shows of 2025" vs "Top Phish Concerts from 2025").
+	 *
+	 * @param string $text1     First text.
+	 * @param string $text2     Second text.
+	 * @param float  $threshold Minimum Jaccard coefficient to count as a match.
+	 * @return SimilarityResult
+	 */
+	public static function jaccardMatch( string $text1, string $text2, float $threshold = self::DEFAULT_JACCARD_THRESHOLD ): SimilarityResult {
+		$set_a = self::tokenize( $text1 );
+		$set_b = self::tokenize( $text2 );
+		$score = self::jaccard( $set_a, $set_b );
+
+		if ( $score >= $threshold ) {
+			return new SimilarityResult( true, $score, SimilarityResult::STRATEGY_JACCARD, implode( ' ', $set_a ), implode( ' ', $set_b ) );
+		}
+
+		return SimilarityResult::noMatch( implode( ' ', $set_a ), implode( ' ', $set_b ) );
+	}
+
+	/**
+	 * Compute Jaccard coefficient between two word sets.
+	 *
+	 * @param array $set_a First word set.
+	 * @param array $set_b Second word set.
+	 * @return float Similarity coefficient between 0.0 and 1.0.
+	 */
+	public static function jaccard( array $set_a, array $set_b ): float {
+		if ( empty( $set_a ) || empty( $set_b ) ) {
+			return 0.0;
+		}
+
+		$intersection = array_intersect( $set_a, $set_b );
+		$union        = array_unique( array_merge( $set_a, $set_b ) );
+
+		return count( $intersection ) / count( $union );
+	}
+
+	// -----------------------------------------------------------------------
+	// Title normalization
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Extract the core identifying portion of a title.
+	 *
+	 * Consolidated from DuplicateDetection::extractCoreTitle() and
+	 * EventIdentifierGenerator::extractCoreTitle(). Handles:
+	 *
+	 * - HTML entity decoding
+	 * - Unicode dash normalization
+	 * - Subreddit reference removal (core DuplicateDetection)
+	 * - Reaction/attribution suffix removal (core DuplicateDetection)
+	 * - Delimiter splitting: dashes, colons, pipes, featuring/with/+
+	 *   (events EventIdentifierGenerator)
+	 * - Comma-separated artist list handling (events EventIdentifierGenerator)
+	 * - Article removal, non-alnum stripping, whitespace collapse
+	 *
+	 * @param string $title Title to normalize.
+	 * @return string Normalized core title for comparison.
+	 */
+	public static function normalizeTitle( string $title ): string {
+		// Decode HTML entities.
+		$text = html_entity_decode( $title, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+
+		// Normalize unicode dashes to ASCII hyphen.
+		$text = self::normalizeDashes( $text );
+
+		// Lowercase.
+		$text = strtolower( $text );
+
+		// Remove subreddit references: "on r/bonnaroo", "from r/coachella", etc.
+		$text = preg_replace( '/\s+(on|from|via|at)\s+r\/\w+/i', '', $text );
+		$text = preg_replace( '/\s*r\/\w+/i', '', $text );
+
+		// Remove reaction/attribution suffixes.
+		$suffixes = array(
+			'reddit reacts',
+			'fans react on reddit',
+			'fans react',
+			'redditors react',
+			'reddit reactions',
+			'reddit buzz',
+			'reddit thread',
+			'reddit weighs in',
+			'redditors say',
+			'redditors share',
+		);
+		foreach ( $suffixes as $suffix ) {
+			$escaped = preg_quote( $suffix, '/' );
+			$text    = preg_replace( '/\s*[-—–]\s*' . $escaped . '\s*$/i', '', $text );
+			$text    = preg_replace( '/\s*[-—–:]\s*' . $escaped . '/i', '', $text );
+		}
+
+		// Split on common delimiters that separate headline from supporting info.
+		// Superset of delimiters from both DuplicateDetection and EventIdentifierGenerator.
+		$delimiters = array(
+			' - ',           // ASCII hyphen with spaces (catches normalized em/en dash)
+			' — ',           // em dash with spaces (pre-normalization)
+			' – ',           // en dash with spaces (pre-normalization)
+			' : ',           // colon with spaces
+			': ',            // colon
+			' | ',           // pipe with spaces
+			'|',             // pipe
+			' featuring ',
+			' feat. ',
+			' feat ',
+			' ft. ',
+			' ft ',
+			' with ',
+			' w/ ',
+			' + ',
+		);
+
+		$best_pos   = PHP_INT_MAX;
+		$best_delim = null;
+
+		foreach ( $delimiters as $delimiter ) {
+			$pos = strpos( $text, $delimiter );
+			if ( false !== $pos && $pos > 0 && $pos < $best_pos ) {
+				$best_pos   = $pos;
+				$best_delim = $delimiter;
+			}
+		}
+
+		if ( null !== $best_delim ) {
+			$text = substr( $text, 0, $best_pos );
+		}
+
+		// Comma-separated artist lists: treat first segment as the headliner.
+		// "Comfort Club, Valories, Barb" → "Comfort Club"
+		if ( strpos( $text, ',' ) !== false ) {
+			$comma_parts = explode( ',', $text, 2 );
+			$first       = trim( $comma_parts[0] );
+			if ( strlen( $first ) > 2 ) {
+				$text = $first;
+			}
+		}
+
+		// Remove articles at word boundaries.
+		$text = preg_replace( '/\b(the|a|an)\b/i', '', $text );
+
+		// Remove non-alphanumeric characters (keep spaces and digits).
+		$text = preg_replace( '/[^a-z0-9\s]/i', '', $text );
+
+		// Collapse whitespace and trim.
+		$text = trim( preg_replace( '/\s+/', ' ', $text ) );
+
+		// If result is too short, return a basic normalization instead.
+		if ( strlen( $text ) < 3 ) {
+			return self::normalizeBasic( $title );
+		}
+
+		return $text;
+	}
+
+	// -----------------------------------------------------------------------
+	// Tokenization
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Tokenize text into a set of significant lowercase words.
+	 *
+	 * Strips stop words and short words (< 2 chars) to focus on
+	 * content-bearing terms for Jaccard comparison.
+	 *
+	 * @param string $text Input text.
+	 * @return array Set of significant words (unique).
+	 */
+	public static function tokenize( string $text ): array {
+		preg_match_all( '/[a-z0-9]+/', strtolower( $text ), $matches );
+
+		$words = array();
+		foreach ( $matches[0] as $word ) {
+			if ( strlen( $word ) >= 2 && ! in_array( $word, self::STOP_WORDS, true ) ) {
+				$words[ $word ] = true;
+			}
+		}
+
+		return array_keys( $words );
+	}
+
+	/**
+	 * Get the most distinctive search word from a text.
+	 *
+	 * Returns the longest significant word (3+ chars, not a stop word)
+	 * for use as a WP_Query keyword search to fetch candidates.
+	 *
+	 * @param string $text Input text.
+	 * @return string|null Best search word, or null if none found.
+	 */
+	public static function getBestSearchWord( string $text ): ?string {
+		preg_match_all( '/[a-z0-9]+/', strtolower( $text ), $matches );
+
+		$candidates = array();
+		foreach ( $matches[0] as $word ) {
+			if ( strlen( $word ) >= 3 && ! in_array( $word, self::STOP_WORDS, true ) ) {
+				$candidates[] = $word;
+			}
+		}
+
+		if ( empty( $candidates ) ) {
+			return null;
+		}
+
+		usort( $candidates, fn( $a, $b ) => strlen( $b ) - strlen( $a ) );
+
+		return $candidates[0];
+	}
+
+	// -----------------------------------------------------------------------
+	// Text normalization utilities
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Normalize unicode dash characters to ASCII hyphen.
+	 *
+	 * Consolidated from DuplicateDetection::normalizeDashes() and
+	 * EventIdentifierGenerator::normalize_dashes() — identical implementations.
+	 *
+	 * @param string $text Input text.
+	 * @return string Text with all unicode dashes replaced by ASCII hyphen.
+	 */
+	public static function normalizeDashes( string $text ): string {
+		$unicode_dashes = array(
+			"\u{2010}", // hyphen
+			"\u{2011}", // non-breaking hyphen
+			"\u{2012}", // figure dash
+			"\u{2013}", // en dash
+			"\u{2014}", // em dash
+			"\u{2015}", // horizontal bar
+			"\u{FE58}", // small em dash
+			"\u{FE63}", // small hyphen-minus
+			"\u{FF0D}", // fullwidth hyphen-minus
+		);
+
+		return str_replace( $unicode_dashes, '-', $text );
+	}
+
+	/**
+	 * Basic text normalization (fallback for very short titles).
+	 *
+	 * @param string $text Input text.
+	 * @return string Normalized text.
+	 */
+	public static function normalizeBasic( string $text ): string {
+		$text = html_entity_decode( $text, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		$text = self::normalizeDashes( $text );
+		$text = strtolower( $text );
+		$text = trim( preg_replace( '/\s+/', ' ', $text ) );
+		$text = preg_replace( '/^(the|a|an)\s+/i', '', $text );
+		return $text;
+	}
+}

--- a/inc/Core/Similarity/SimilarityResult.php
+++ b/inc/Core/Similarity/SimilarityResult.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Value object representing the result of a similarity comparison.
+ *
+ * Immutable data carrier returned by SimilarityEngine methods.
+ * Carries the match verdict, confidence score, and which strategy
+ * produced the match — so callers can log, display, or act on it
+ * without inspecting internals.
+ *
+ * @package DataMachine\Core\Similarity
+ * @since   0.39.0
+ */
+
+namespace DataMachine\Core\Similarity;
+
+defined( 'ABSPATH' ) || exit;
+
+class SimilarityResult {
+
+	/**
+	 * Strategy constants.
+	 */
+	const STRATEGY_EXACT    = 'exact';
+	const STRATEGY_PREFIX   = 'prefix';
+	const STRATEGY_EDIT     = 'levenshtein';
+	const STRATEGY_JACCARD  = 'jaccard';
+	const STRATEGY_NONE     = 'none';
+
+	/**
+	 * Whether the comparison matched.
+	 *
+	 * @var bool
+	 */
+	public bool $match;
+
+	/**
+	 * Confidence score between 0.0 and 1.0.
+	 *
+	 * For exact/prefix matches this is 1.0.
+	 * For Levenshtein it's (1 - distance/maxLen).
+	 * For Jaccard it's the Jaccard coefficient.
+	 *
+	 * @var float
+	 */
+	public float $score;
+
+	/**
+	 * Which strategy produced the match (or 'none' if no match).
+	 *
+	 * @var string
+	 */
+	public string $strategy;
+
+	/**
+	 * Normalized form of the first input.
+	 *
+	 * @var string
+	 */
+	public string $normalized_a;
+
+	/**
+	 * Normalized form of the second input.
+	 *
+	 * @var string
+	 */
+	public string $normalized_b;
+
+	/**
+	 * @param bool   $match        Whether the comparison matched.
+	 * @param float  $score        Confidence score (0.0–1.0).
+	 * @param string $strategy     Strategy that matched (use class constants).
+	 * @param string $normalized_a Normalized first input.
+	 * @param string $normalized_b Normalized second input.
+	 */
+	public function __construct(
+		bool $match,
+		float $score,
+		string $strategy,
+		string $normalized_a = '',
+		string $normalized_b = ''
+	) {
+		$this->match        = $match;
+		$this->score        = $score;
+		$this->strategy     = $strategy;
+		$this->normalized_a = $normalized_a;
+		$this->normalized_b = $normalized_b;
+	}
+
+	/**
+	 * Convenience factory for a non-match.
+	 *
+	 * @param string $normalized_a Normalized first input.
+	 * @param string $normalized_b Normalized second input.
+	 * @return self
+	 */
+	public static function noMatch( string $normalized_a = '', string $normalized_b = '' ): self {
+		return new self( false, 0.0, self::STRATEGY_NONE, $normalized_a, $normalized_b );
+	}
+
+	/**
+	 * Convert to array for structured responses.
+	 *
+	 * @return array
+	 */
+	public function toArray(): array {
+		return array(
+			'match'        => $this->match,
+			'score'        => $this->score,
+			'strategy'     => $this->strategy,
+			'normalized_a' => $this->normalized_a,
+			'normalized_b' => $this->normalized_b,
+		);
+	}
+}

--- a/inc/Core/WordPress/DuplicateDetection.php
+++ b/inc/Core/WordPress/DuplicateDetection.php
@@ -2,16 +2,21 @@
 /**
  * Publish-level duplicate detection for WordPress posts.
  *
- * Provides fuzzy title matching to prevent cross-flow duplicate publishing.
- * Ported and simplified from data-machine-events EventIdentifierGenerator —
- * events use venue + date + ticket URL for richer matching, but the core
- * title normalization and fuzzy comparison logic is shared here.
+ * Thin wrapper around the unified SimilarityEngine. All similarity math
+ * is delegated to DataMachine\Core\Similarity\SimilarityEngine.
  *
- * @package DataMachine\Core\WordPress
- * @since   0.38.0
+ * Retained for backward compatibility — existing call sites
+ * (WordPress publish handler, tests) continue to work unchanged.
+ * New code should use DuplicateCheckAbility or SimilarityEngine directly.
+ *
+ * @package    DataMachine\Core\WordPress
+ * @since      0.38.0
+ * @deprecated 0.39.0 Use DuplicateCheckAbility or SimilarityEngine directly.
  */
 
 namespace DataMachine\Core\WordPress;
+
+use DataMachine\Core\Similarity\SimilarityEngine;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -24,9 +29,6 @@ class DuplicateDetection {
 
 	/**
 	 * Find an existing published post with a matching title.
-	 *
-	 * Queries recent posts of the same post type and runs fuzzy title
-	 * comparison to catch near-duplicates (same story from different sources).
 	 *
 	 * @param string $title         Title of the post being published.
 	 * @param string $post_type     WordPress post type to search.
@@ -44,7 +46,6 @@ class DuplicateDetection {
 
 		$cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$lookback_days} days" ) );
 
-		// Query recent posts of the same type.
 		$candidates = get_posts(
 			array(
 				'post_type'      => $post_type,
@@ -66,8 +67,6 @@ class DuplicateDetection {
 			return null;
 		}
 
-		$incoming_core = self::extractCoreTitle( $title );
-
 		foreach ( $candidates as $candidate_id ) {
 			$candidate_title = get_the_title( $candidate_id );
 			if ( self::titlesMatch( $title, $candidate_title ) ) {
@@ -77,7 +76,7 @@ class DuplicateDetection {
 					'DuplicateDetection: Found existing post with matching title',
 					array(
 						'incoming_title' => $title,
-						'incoming_core'  => $incoming_core,
+						'incoming_core'  => self::extractCoreTitle( $title ),
 						'existing_id'    => $candidate_id,
 						'existing_title' => $candidate_title,
 						'existing_core'  => self::extractCoreTitle( $candidate_title ),
@@ -93,165 +92,37 @@ class DuplicateDetection {
 	/**
 	 * Compare two titles for semantic match.
 	 *
-	 * Returns true if core titles match after extraction and normalization.
-	 * Handles variations like different suffixes, subreddit attributions,
-	 * "Reddit Reacts" / "Fans React" additions, etc.
+	 * Delegates to SimilarityEngine::titlesMatch().
 	 *
 	 * @param string $title1 First title.
 	 * @param string $title2 Second title.
 	 * @return bool True if titles represent the same story.
 	 */
 	public static function titlesMatch( string $title1, string $title2 ): bool {
-		$core1 = self::extractCoreTitle( $title1 );
-		$core2 = self::extractCoreTitle( $title2 );
-
-		// Exact match after normalization.
-		if ( $core1 === $core2 ) {
-			return true;
-		}
-
-		// One core is a prefix of the other (catches cases where one version
-		// has extra context appended, e.g. "— fans react on r/WhenWeWereYoung").
-		$shorter = strlen( $core1 ) <= strlen( $core2 ) ? $core1 : $core2;
-		$longer  = strlen( $core1 ) <= strlen( $core2 ) ? $core2 : $core1;
-
-		if ( strlen( $shorter ) >= 8 && str_starts_with( $longer, $shorter ) ) {
-			return true;
-		}
-
-		// Levenshtein distance for very similar titles (typos, minor wording).
-		// Only apply to titles of similar length to avoid false positives.
-		$len1 = strlen( $core1 );
-		$len2 = strlen( $core2 );
-
-		if ( $len1 >= 15 && $len2 >= 15 ) {
-			$max_len  = max( $len1, $len2 );
-			$distance = levenshtein( $core1, $core2 );
-
-			// Allow up to 15% character difference.
-			if ( $distance <= (int) ( $max_len * 0.15 ) ) {
-				return true;
-			}
-		}
-
-		return false;
+		return SimilarityEngine::titlesMatch( $title1, $title2 )->match;
 	}
 
 	/**
 	 * Extract the core identifying portion of a title.
 	 *
-	 * Strips reaction suffixes, subreddit attributions, common filler phrases,
-	 * and normalizes for comparison.
+	 * Delegates to SimilarityEngine::normalizeTitle().
 	 *
 	 * @param string $title Post title.
 	 * @return string Normalized core title for comparison.
 	 */
 	public static function extractCoreTitle( string $title ): string {
-		// Decode HTML entities.
-		$text = html_entity_decode( $title, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
-
-		// Normalize unicode dashes to ASCII hyphen.
-		$text = self::normalizeDashes( $text );
-
-		// Lowercase.
-		$text = strtolower( $text );
-
-		// Remove subreddit references: "on r/bonnaroo", "from r/coachella", etc.
-		$text = preg_replace( '/\s+(on|from|via|at)\s+r\/\w+/i', '', $text );
-		// Remove standalone "r/subreddit" references.
-		$text = preg_replace( '/\s*r\/\w+/i', '', $text );
-
-		// Remove reaction/attribution suffixes.
-		$suffixes = array(
-			'reddit reacts',
-			'fans react on reddit',
-			'fans react',
-			'redditors react',
-			'reddit reactions',
-			'reddit buzz',
-			'reddit thread',
-			'reddit weighs in',
-			'redditors say',
-			'redditors share',
-		);
-		foreach ( $suffixes as $suffix ) {
-			$text = preg_replace( '/\s*[-—–]\s*' . preg_quote( $suffix, '/' ) . '\s*$/i', '', $text );
-			$text = preg_replace( '/\s*[-—–:]\s*' . preg_quote( $suffix, '/' ) . '/i', '', $text );
-		}
-
-		// Split on common delimiters that separate headline from attribution.
-		$delimiters = array(
-			' - ',
-			' — ',
-			' – ',
-		);
-		$best_pos   = PHP_INT_MAX;
-		$best_delim = null;
-
-		foreach ( $delimiters as $delimiter ) {
-			$pos = strpos( $text, $delimiter );
-			// Only split if the part before the delimiter is substantial.
-			if ( false !== $pos && $pos >= 15 && $pos < $best_pos ) {
-				$best_pos   = $pos;
-				$best_delim = $delimiter;
-			}
-		}
-
-		if ( null !== $best_delim ) {
-			$text = substr( $text, 0, $best_pos );
-		}
-
-		// Remove articles at word boundaries.
-		$text = preg_replace( '/\b(the|a|an)\b/i', '', $text );
-
-		// Remove non-alphanumeric characters (keep spaces and digits).
-		$text = preg_replace( '/[^a-z0-9\s]/i', '', $text );
-
-		// Collapse whitespace and trim.
-		$text = trim( preg_replace( '/\s+/', ' ', $text ) );
-
-		// If result is too short, return a basic normalization instead.
-		if ( strlen( $text ) < 5 ) {
-			return self::normalizeBasic( $title );
-		}
-
-		return $text;
+		return SimilarityEngine::normalizeTitle( $title );
 	}
 
 	/**
 	 * Normalize unicode dash characters to ASCII hyphen.
 	 *
+	 * Delegates to SimilarityEngine::normalizeDashes().
+	 *
 	 * @param string $text Input text.
 	 * @return string Text with all dashes normalized.
 	 */
-	private static function normalizeDashes( string $text ): string {
-		$unicode_dashes = array(
-			"\u{2010}", // hyphen
-			"\u{2011}", // non-breaking hyphen
-			"\u{2012}", // figure dash
-			"\u{2013}", // en dash
-			"\u{2014}", // em dash
-			"\u{2015}", // horizontal bar
-			"\u{FE58}", // small em dash
-			"\u{FE63}", // small hyphen-minus
-			"\u{FF0D}", // fullwidth hyphen-minus
-		);
-
-		return str_replace( $unicode_dashes, '-', $text );
-	}
-
-	/**
-	 * Basic normalization fallback.
-	 *
-	 * @param string $text Input text.
-	 * @return string Normalized text.
-	 */
-	private static function normalizeBasic( string $text ): string {
-		$text = html_entity_decode( $text, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
-		$text = self::normalizeDashes( $text );
-		$text = strtolower( $text );
-		$text = trim( preg_replace( '/\s+/', ' ', $text ) );
-		$text = preg_replace( '/^(the|a|an)\s+/i', '', $text );
-		return $text;
+	public static function normalizeDashes( string $text ): string {
+		return SimilarityEngine::normalizeDashes( $text );
 	}
 }

--- a/inc/Engine/AI/Tools/Global/QueueValidator.php
+++ b/inc/Engine/AI/Tools/Global/QueueValidator.php
@@ -2,10 +2,12 @@
 /**
  * Queue Validator tool for duplicate detection.
  *
- * Checks whether a topic already exists as a published post or in a
- * Data Machine queue before content generation begins. Returns a clear
- * verdict with match details so agents (and humans in the dashboard)
- * can see exactly what was caught and why.
+ * AI-facing tool that checks whether a topic already exists as a published
+ * post or in a Data Machine queue before content generation begins.
+ *
+ * Delegates all similarity math to the unified SimilarityEngine.
+ * The published-post check can also be routed through the
+ * DuplicateCheckAbility for strategy-aware checking.
  *
  * @package DataMachine\Engine\AI\Tools\Global
  */
@@ -15,82 +17,10 @@ namespace DataMachine\Engine\AI\Tools\Global;
 defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Core\Database\Flows\Flows as DB_Flows;
+use DataMachine\Core\Similarity\SimilarityEngine;
 use DataMachine\Engine\AI\Tools\BaseTool;
 
 class QueueValidator extends BaseTool {
-
-	/**
-	 * Default Jaccard similarity threshold.
-	 *
-	 * @var float
-	 */
-	const DEFAULT_THRESHOLD = 0.65;
-
-	/**
-	 * Stop words excluded from similarity comparison.
-	 *
-	 * @var array
-	 */
-	const STOP_WORDS = array(
-		'the',
-		'a',
-		'an',
-		'and',
-		'or',
-		'but',
-		'in',
-		'on',
-		'at',
-		'to',
-		'for',
-		'of',
-		'with',
-		'by',
-		'from',
-		'is',
-		'it',
-		'are',
-		'was',
-		'were',
-		'be',
-		'been',
-		'being',
-		'have',
-		'has',
-		'had',
-		'do',
-		'does',
-		'did',
-		'will',
-		'would',
-		'could',
-		'should',
-		'may',
-		'might',
-		'shall',
-		'can',
-		'not',
-		'no',
-		'if',
-		'when',
-		'what',
-		'why',
-		'how',
-		'who',
-		'where',
-		'which',
-		'that',
-		'this',
-		'you',
-		'your',
-		'my',
-		'am',
-		'me',
-		'we',
-		'they',
-		'them',
-		'its',
-	);
 
 	public function __construct() {
 		$this->registerGlobalTool( 'queue_validator', array( $this, 'getToolDefinition' ) );
@@ -120,13 +50,6 @@ class QueueValidator extends BaseTool {
 		return self::is_configured();
 	}
 
-	/**
-	 * Validate a topic against published posts and queue items.
-	 *
-	 * @param array $parameters Tool call parameters.
-	 * @param array $tool_def   Tool definition (unused).
-	 * @return array Validation result with verdict and match details.
-	 */
 	/**
 	 * Core duplicate-check logic. Returns a structured result usable by
 	 * both the AI tool interface and the queue-add ability.
@@ -170,7 +93,7 @@ class QueueValidator extends BaseTool {
 			)
 		);
 
-		// Check 1: Existing published posts.
+		// Check 1: Existing published posts — use SimilarityEngine title match.
 		$post_match = $this->checkPublishedPosts( $topic, $threshold, $post_type );
 
 		if ( null !== $post_match ) {
@@ -283,7 +206,7 @@ class QueueValidator extends BaseTool {
 	 * Check published posts for similar titles.
 	 *
 	 * Uses WP_Query with a keyword search for candidate fetch, then
-	 * Jaccard similarity on tokenized words for accurate matching.
+	 * Jaccard similarity via SimilarityEngine for accurate matching.
 	 *
 	 * @param string $topic     Topic to check.
 	 * @param float  $threshold Similarity threshold.
@@ -291,7 +214,7 @@ class QueueValidator extends BaseTool {
 	 * @return array|null Best match above threshold, or null.
 	 */
 	private function checkPublishedPosts( string $topic, float $threshold, string $post_type = 'post' ): ?array {
-		$search_word = $this->getBestSearchWord( $topic );
+		$search_word = SimilarityEngine::getBestSearchWord( $topic );
 
 		if ( empty( $search_word ) ) {
 			return null;
@@ -312,14 +235,14 @@ class QueueValidator extends BaseTool {
 			return null;
 		}
 
-		$topic_words = $this->tokenize( $topic );
+		$topic_words = SimilarityEngine::tokenize( $topic );
 		$best_match  = null;
 		$best_score  = 0.0;
 
 		foreach ( $query->posts as $post_id ) {
 			$title       = get_the_title( $post_id );
-			$title_words = $this->tokenize( $title );
-			$score       = $this->jaccard( $topic_words, $title_words );
+			$title_words = SimilarityEngine::tokenize( $title );
+			$score       = SimilarityEngine::jaccard( $topic_words, $title_words );
 
 			if ( $score > $best_score ) {
 				$best_score = $score;
@@ -368,14 +291,14 @@ class QueueValidator extends BaseTool {
 			return null;
 		}
 
-		$topic_words = $this->tokenize( $topic );
+		$topic_words = SimilarityEngine::tokenize( $topic );
 		$best_match  = null;
 		$best_score  = 0.0;
 
 		foreach ( $prompt_queue as $index => $item ) {
 			$prompt     = $item['prompt'] ?? '';
-			$item_words = $this->tokenize( $prompt );
-			$score      = $this->jaccard( $topic_words, $item_words );
+			$item_words = SimilarityEngine::tokenize( $prompt );
+			$score      = SimilarityEngine::jaccard( $topic_words, $item_words );
 
 			if ( $score > $best_score ) {
 				$best_score = $score;
@@ -395,74 +318,6 @@ class QueueValidator extends BaseTool {
 	}
 
 	/**
-	 * Tokenize text into a set of significant lowercase words.
-	 *
-	 * Strips stop words and short words (< 2 chars) to focus on
-	 * content-bearing terms for similarity comparison.
-	 *
-	 * @param string $text Input text.
-	 * @return array Set of significant words (unique).
-	 */
-	public function tokenize( string $text ): array {
-		preg_match_all( '/[a-z0-9]+/', strtolower( $text ), $matches );
-
-		$words = array();
-		foreach ( $matches[0] as $word ) {
-			if ( strlen( $word ) >= 2 && ! in_array( $word, self::STOP_WORDS, true ) ) {
-				$words[ $word ] = true;
-			}
-		}
-
-		return array_keys( $words );
-	}
-
-	/**
-	 * Compute Jaccard similarity between two word sets.
-	 *
-	 * @param array $set_a First word set.
-	 * @param array $set_b Second word set.
-	 * @return float Similarity score between 0.0 and 1.0.
-	 */
-	public function jaccard( array $set_a, array $set_b ): float {
-		if ( empty( $set_a ) || empty( $set_b ) ) {
-			return 0.0;
-		}
-
-		$intersection = array_intersect( $set_a, $set_b );
-		$union        = array_unique( array_merge( $set_a, $set_b ) );
-
-		return count( $intersection ) / count( $union );
-	}
-
-	/**
-	 * Get the best search word for WP_Query candidate fetch.
-	 *
-	 * Returns the longest significant word (3+ chars, not a stop word)
-	 * to cast a wide net for potential matches.
-	 *
-	 * @param string $text Input text.
-	 * @return string|null Best search word, or null if none found.
-	 */
-	private function getBestSearchWord( string $text ): ?string {
-		preg_match_all( '/[a-z0-9]+/', strtolower( $text ), $matches );
-
-		$candidates = array();
-		foreach ( $matches[0] as $word ) {
-			if ( strlen( $word ) >= 3 && ! in_array( $word, self::STOP_WORDS, true ) ) {
-				$candidates[] = $word;
-			}
-		}
-
-		if ( empty( $candidates ) ) {
-			return null;
-		}
-
-		usort( $candidates, fn( $a, $b ) => strlen( $b ) - strlen( $a ) );
-
-		return $candidates[0];
-	}
-
-	/**
 	 * Resolve the similarity threshold from parameters.
 	 *
 	 * @param array $parameters Tool call parameters.
@@ -476,7 +331,7 @@ class QueueValidator extends BaseTool {
 			}
 		}
 
-		return self::DEFAULT_THRESHOLD;
+		return SimilarityEngine::DEFAULT_JACCARD_THRESHOLD;
 	}
 
 	/**

--- a/tests/Unit/AI/Tools/QueueValidatorTest.php
+++ b/tests/Unit/AI/Tools/QueueValidatorTest.php
@@ -7,6 +7,7 @@
 
 namespace DataMachine\Tests\Unit\AI\Tools;
 
+use DataMachine\Core\Similarity\SimilarityEngine;
 use DataMachine\Engine\AI\Tools\Global\QueueValidator;
 use WP_UnitTestCase;
 
@@ -111,7 +112,7 @@ class QueueValidatorTest extends WP_UnitTestCase {
 	 * Test tokenize strips stop words and short words.
 	 */
 	public function test_tokenize_strips_stop_words(): void {
-		$tokens = $this->validator->tokenize( 'The Spiritual Meaning of a Blue Jay' );
+		$tokens = SimilarityEngine::tokenize( 'The Spiritual Meaning of a Blue Jay' );
 
 		$this->assertContains( 'spiritual', $tokens );
 		$this->assertContains( 'meaning', $tokens );
@@ -126,7 +127,7 @@ class QueueValidatorTest extends WP_UnitTestCase {
 	 * Test tokenize returns unique words.
 	 */
 	public function test_tokenize_returns_unique_words(): void {
-		$tokens = $this->validator->tokenize( 'blue blue blue jay jay' );
+		$tokens = SimilarityEngine::tokenize( 'blue blue blue jay jay' );
 
 		$this->assertCount( 2, $tokens );
 		$this->assertContains( 'blue', $tokens );
@@ -137,7 +138,7 @@ class QueueValidatorTest extends WP_UnitTestCase {
 	 * Test jaccard similarity with identical sets.
 	 */
 	public function test_jaccard_identical_sets(): void {
-		$score = $this->validator->jaccard( array( 'blue', 'jay' ), array( 'blue', 'jay' ) );
+		$score = SimilarityEngine::jaccard( array( 'blue', 'jay' ), array( 'blue', 'jay' ) );
 		$this->assertSame( 1.0, $score );
 	}
 
@@ -145,7 +146,7 @@ class QueueValidatorTest extends WP_UnitTestCase {
 	 * Test jaccard similarity with no overlap.
 	 */
 	public function test_jaccard_no_overlap(): void {
-		$score = $this->validator->jaccard( array( 'blue', 'jay' ), array( 'red', 'cardinal' ) );
+		$score = SimilarityEngine::jaccard( array( 'blue', 'jay' ), array( 'red', 'cardinal' ) );
 		$this->assertSame( 0.0, $score );
 	}
 
@@ -153,7 +154,7 @@ class QueueValidatorTest extends WP_UnitTestCase {
 	 * Test jaccard similarity with partial overlap.
 	 */
 	public function test_jaccard_partial_overlap(): void {
-		$score = $this->validator->jaccard( array( 'blue', 'jay', 'meaning' ), array( 'blue', 'jay', 'symbolism' ) );
+		$score = SimilarityEngine::jaccard( array( 'blue', 'jay', 'meaning' ), array( 'blue', 'jay', 'symbolism' ) );
 		$this->assertSame( 0.5, $score ); // 2 intersect / 4 union.
 	}
 
@@ -161,9 +162,9 @@ class QueueValidatorTest extends WP_UnitTestCase {
 	 * Test jaccard with empty sets returns 0.
 	 */
 	public function test_jaccard_empty_sets(): void {
-		$this->assertSame( 0.0, $this->validator->jaccard( array(), array( 'word' ) ) );
-		$this->assertSame( 0.0, $this->validator->jaccard( array( 'word' ), array() ) );
-		$this->assertSame( 0.0, $this->validator->jaccard( array(), array() ) );
+		$this->assertSame( 0.0, SimilarityEngine::jaccard( array(), array( 'word' ) ) );
+		$this->assertSame( 0.0, SimilarityEngine::jaccard( array( 'word' ), array() ) );
+		$this->assertSame( 0.0, SimilarityEngine::jaccard( array(), array() ) );
 	}
 
 	/**

--- a/tests/Unit/Abilities/AllAbilitiesRegisteredTest.php
+++ b/tests/Unit/Abilities/AllAbilitiesRegisteredTest.php
@@ -102,6 +102,9 @@ class AllAbilitiesRegisteredTest extends WP_UnitTestCase {
 			'datamachine/query-posts',
 			// LocalSearchAbilities (1)
 			'datamachine/local-search',
+			// DuplicateCheckAbility (2)
+			'datamachine/check-duplicate',
+			'datamachine/titles-match',
 		);
 
 		$missing = array();

--- a/tests/Unit/Abilities/DuplicateCheckAbilityTest.php
+++ b/tests/Unit/Abilities/DuplicateCheckAbilityTest.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * DuplicateCheckAbility Tests
+ *
+ * Tests for the unified duplicate check ability — core strategies,
+ * extension strategy registry, and titles-match ability.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\DuplicateCheck\DuplicateCheckAbility;
+use WP_UnitTestCase;
+
+class DuplicateCheckAbilityTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		new DuplicateCheckAbility();
+	}
+
+	// -----------------------------------------------------------------------
+	// Ability registration
+	// -----------------------------------------------------------------------
+
+	public function test_check_duplicate_ability_registered(): void {
+		$ability = wp_get_ability( 'datamachine/check-duplicate' );
+		$this->assertNotNull( $ability, 'datamachine/check-duplicate ability should be registered' );
+	}
+
+	public function test_titles_match_ability_registered(): void {
+		$ability = wp_get_ability( 'datamachine/titles-match' );
+		$this->assertNotNull( $ability, 'datamachine/titles-match ability should be registered' );
+	}
+
+	// -----------------------------------------------------------------------
+	// datamachine/titles-match
+	// -----------------------------------------------------------------------
+
+	public function test_titles_match_ability_returns_match(): void {
+		$ability = wp_get_ability( 'datamachine/titles-match' );
+		$result  = $ability->execute( array(
+			'title1' => 'Andy Frasco & the U.N.',
+			'title2' => 'Andy Frasco',
+		) );
+
+		$this->assertTrue( $result['match'] );
+		$this->assertArrayHasKey( 'score', $result );
+		$this->assertArrayHasKey( 'strategy', $result );
+	}
+
+	public function test_titles_match_ability_returns_no_match(): void {
+		$ability = wp_get_ability( 'datamachine/titles-match' );
+		$result  = $ability->execute( array(
+			'title1' => 'Best Restaurants in Austin',
+			'title2' => 'Live Music Venues in Nashville',
+		) );
+
+		$this->assertFalse( $result['match'] );
+	}
+
+	// -----------------------------------------------------------------------
+	// datamachine/check-duplicate — published posts
+	// -----------------------------------------------------------------------
+
+	public function test_check_duplicate_finds_published_post(): void {
+		// Create a test post.
+		$post_id = self::factory()->post->create( array(
+			'post_title'  => 'Best Phish Shows of All Time',
+			'post_status' => 'publish',
+			'post_type'   => 'post',
+		) );
+
+		$ability = wp_get_ability( 'datamachine/check-duplicate' );
+		$result  = $ability->execute( array(
+			'title'     => 'Best Phish Shows of All Time',
+			'post_type' => 'post',
+			'scope'     => 'published',
+		) );
+
+		$this->assertSame( 'duplicate', $result['verdict'] );
+		$this->assertSame( 'published_post', $result['source'] );
+		$this->assertSame( $post_id, $result['match']['post_id'] );
+	}
+
+	public function test_check_duplicate_clears_when_no_match(): void {
+		$ability = wp_get_ability( 'datamachine/check-duplicate' );
+		$result  = $ability->execute( array(
+			'title'     => 'Unique Title That Does Not Exist Anywhere ' . uniqid(),
+			'post_type' => 'post',
+			'scope'     => 'published',
+		) );
+
+		$this->assertSame( 'clear', $result['verdict'] );
+	}
+
+	public function test_check_duplicate_respects_post_type(): void {
+		// Create a post with type 'post'.
+		self::factory()->post->create( array(
+			'post_title'  => 'TypeTest Duplicate Title',
+			'post_status' => 'publish',
+			'post_type'   => 'post',
+		) );
+
+		$ability = wp_get_ability( 'datamachine/check-duplicate' );
+
+		// Check against 'page' type — should be clear.
+		$result = $ability->execute( array(
+			'title'     => 'TypeTest Duplicate Title',
+			'post_type' => 'page',
+			'scope'     => 'published',
+		) );
+
+		$this->assertSame( 'clear', $result['verdict'] );
+	}
+
+	public function test_check_duplicate_requires_title(): void {
+		$ability = wp_get_ability( 'datamachine/check-duplicate' );
+		$result  = $ability->execute( array(
+			'title'     => '',
+			'post_type' => 'post',
+		) );
+
+		$this->assertSame( 'error', $result['verdict'] );
+	}
+
+	// -----------------------------------------------------------------------
+	// datamachine/check-duplicate — fuzzy matching
+	// -----------------------------------------------------------------------
+
+	public function test_check_duplicate_catches_fuzzy_match(): void {
+		self::factory()->post->create( array(
+			'post_title'  => 'Andy Frasco & the U.N. — Growing Pains Tour with Candi Jenkins',
+			'post_status' => 'publish',
+			'post_type'   => 'post',
+		) );
+
+		$ability = wp_get_ability( 'datamachine/check-duplicate' );
+		$result  = $ability->execute( array(
+			'title'     => 'Andy Frasco',
+			'post_type' => 'post',
+			'scope'     => 'published',
+		) );
+
+		$this->assertSame( 'duplicate', $result['verdict'] );
+	}
+
+	// -----------------------------------------------------------------------
+	// Strategy registry
+	// -----------------------------------------------------------------------
+
+	public function test_extension_strategy_runs_before_core(): void {
+		// Register a strategy that always returns duplicate.
+		add_filter( 'datamachine_duplicate_strategies', function ( $strategies ) {
+			$strategies[] = array(
+				'id'        => 'test_always_dup',
+				'post_type' => 'post',
+				'callback'  => function ( $input ) {
+					return array(
+						'verdict' => 'duplicate',
+						'source'  => 'test_extension',
+						'match'   => array( 'reason' => 'test' ),
+						'reason'  => 'Caught by test extension strategy',
+					);
+				},
+				'priority'  => 5,
+			);
+			return $strategies;
+		} );
+
+		$ability = wp_get_ability( 'datamachine/check-duplicate' );
+		$result  = $ability->execute( array(
+			'title'     => 'Anything',
+			'post_type' => 'post',
+			'scope'     => 'published',
+		) );
+
+		$this->assertSame( 'duplicate', $result['verdict'] );
+		$this->assertSame( 'test_extension', $result['source'] );
+		$this->assertSame( 'test_always_dup', $result['strategy'] );
+
+		// Clean up filter.
+		remove_all_filters( 'datamachine_duplicate_strategies' );
+	}
+
+	public function test_extension_strategy_scoped_to_post_type(): void {
+		// Register a strategy only for 'event' post type.
+		add_filter( 'datamachine_duplicate_strategies', function ( $strategies ) {
+			$strategies[] = array(
+				'id'        => 'test_event_only',
+				'post_type' => 'event',
+				'callback'  => function ( $input ) {
+					return array(
+						'verdict' => 'duplicate',
+						'source'  => 'event_strategy',
+						'match'   => array(),
+						'reason'  => 'Event duplicate',
+					);
+				},
+				'priority'  => 5,
+			);
+			return $strategies;
+		} );
+
+		$ability = wp_get_ability( 'datamachine/check-duplicate' );
+
+		// Check against 'post' — event strategy should NOT run.
+		$result = $ability->execute( array(
+			'title'     => 'Unique Test Title ' . uniqid(),
+			'post_type' => 'post',
+			'scope'     => 'published',
+		) );
+
+		$this->assertSame( 'clear', $result['verdict'] );
+
+		// Clean up filter.
+		remove_all_filters( 'datamachine_duplicate_strategies' );
+	}
+}

--- a/tests/Unit/Core/SimilarityEngineTest.php
+++ b/tests/Unit/Core/SimilarityEngineTest.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * SimilarityEngine Tests
+ *
+ * Tests for the unified similarity engine — title normalization,
+ * fuzzy matching, Jaccard similarity, and tokenization.
+ *
+ * @package DataMachine\Tests\Unit\Core
+ */
+
+namespace DataMachine\Tests\Unit\Core;
+
+use DataMachine\Core\Similarity\SimilarityEngine;
+use DataMachine\Core\Similarity\SimilarityResult;
+use WP_UnitTestCase;
+
+class SimilarityEngineTest extends WP_UnitTestCase {
+
+	// -----------------------------------------------------------------------
+	// normalizeDashes
+	// -----------------------------------------------------------------------
+
+	public function test_normalize_dashes_converts_em_dash(): void {
+		$this->assertSame( 'foo - bar', SimilarityEngine::normalizeDashes( "foo \u{2014} bar" ) );
+	}
+
+	public function test_normalize_dashes_converts_en_dash(): void {
+		$this->assertSame( 'foo - bar', SimilarityEngine::normalizeDashes( "foo \u{2013} bar" ) );
+	}
+
+	public function test_normalize_dashes_converts_multiple_types(): void {
+		$input = "a\u{2010}b\u{2013}c\u{2014}d";
+		$this->assertSame( 'a-b-c-d', SimilarityEngine::normalizeDashes( $input ) );
+	}
+
+	public function test_normalize_dashes_preserves_ascii_hyphen(): void {
+		$this->assertSame( 'foo-bar', SimilarityEngine::normalizeDashes( 'foo-bar' ) );
+	}
+
+	// -----------------------------------------------------------------------
+	// normalizeTitle
+	// -----------------------------------------------------------------------
+
+	public function test_normalize_title_lowercases(): void {
+		$this->assertSame( 'hello world', SimilarityEngine::normalizeTitle( 'Hello World' ) );
+	}
+
+	public function test_normalize_title_strips_articles(): void {
+		$result = SimilarityEngine::normalizeTitle( 'The Quick Brown Fox' );
+		$this->assertStringNotContainsString( 'the', $result );
+		$this->assertStringContainsString( 'quick', $result );
+	}
+
+	public function test_normalize_title_strips_subreddit_references(): void {
+		$result = SimilarityEngine::normalizeTitle( 'Great Show on r/bonnaroo and from r/coachella' );
+		$this->assertStringNotContainsString( 'bonnaroo', $result );
+		$this->assertStringNotContainsString( 'coachella', $result );
+	}
+
+	public function test_normalize_title_strips_reaction_suffixes(): void {
+		$result = SimilarityEngine::normalizeTitle( 'Band Announces Tour — Reddit Reacts' );
+		$this->assertStringNotContainsString( 'reddit', $result );
+		$this->assertStringNotContainsString( 'reacts', $result );
+	}
+
+	public function test_normalize_title_splits_on_dash_delimiter(): void {
+		$result = SimilarityEngine::normalizeTitle( 'Andy Frasco - Growing Pains Tour' );
+		$this->assertSame( 'andy frasco', $result );
+	}
+
+	public function test_normalize_title_splits_on_featuring(): void {
+		$result = SimilarityEngine::normalizeTitle( 'Andy Frasco featuring Candi Jenkins' );
+		$this->assertSame( 'andy frasco', $result );
+	}
+
+	public function test_normalize_title_splits_on_with(): void {
+		$result = SimilarityEngine::normalizeTitle( 'Andy Frasco with Candi Jenkins' );
+		$this->assertSame( 'andy frasco', $result );
+	}
+
+	public function test_normalize_title_splits_on_plus(): void {
+		$result = SimilarityEngine::normalizeTitle( 'Andy Frasco + Candi Jenkins' );
+		$this->assertSame( 'andy frasco', $result );
+	}
+
+	public function test_normalize_title_handles_comma_separated_artists(): void {
+		$result = SimilarityEngine::normalizeTitle( 'Comfort Club, Valories, Barb' );
+		$this->assertSame( 'comfort club', $result );
+	}
+
+	public function test_normalize_title_decodes_html_entities(): void {
+		$result = SimilarityEngine::normalizeTitle( "C-Boy&#039;s Heart &amp; Soul" );
+		// After normalization, special chars stripped, just alphanumeric + spaces
+		$this->assertStringContainsString( 'cboys', $result );
+	}
+
+	public function test_normalize_title_handles_unicode_dashes_in_delimiters(): void {
+		// The em dash should be normalized to ASCII, then split happens.
+		$result = SimilarityEngine::normalizeTitle( "Andy Frasco \u{2014} Growing Pains Tour" );
+		$this->assertSame( 'andy frasco', $result );
+	}
+
+	public function test_normalize_title_short_fallback(): void {
+		// Very short title falls back to normalizeBasic.
+		$result = SimilarityEngine::normalizeTitle( 'Hi' );
+		$this->assertSame( 'hi', $result );
+	}
+
+	// -----------------------------------------------------------------------
+	// titlesMatch
+	// -----------------------------------------------------------------------
+
+	public function test_titles_match_exact(): void {
+		$result = SimilarityEngine::titlesMatch( 'Andy Frasco', 'Andy Frasco' );
+		$this->assertTrue( $result->match );
+		$this->assertSame( SimilarityResult::STRATEGY_EXACT, $result->strategy );
+		$this->assertSame( 1.0, $result->score );
+	}
+
+	public function test_titles_match_case_insensitive(): void {
+		$result = SimilarityEngine::titlesMatch( 'Andy Frasco', 'ANDY FRASCO' );
+		$this->assertTrue( $result->match );
+		$this->assertSame( SimilarityResult::STRATEGY_EXACT, $result->strategy );
+	}
+
+	public function test_titles_match_with_article_differences(): void {
+		$result = SimilarityEngine::titlesMatch( 'The Blue Note', 'Blue Note' );
+		$this->assertTrue( $result->match );
+	}
+
+	public function test_titles_match_prefix(): void {
+		// "colombian jazz experience" matches "colombian jazz experience sahara"
+		$result = SimilarityEngine::titlesMatch(
+			'Colombian Jazz Experience',
+			'Colombian Jazz Experience at Sahara'
+		);
+		$this->assertTrue( $result->match );
+		$this->assertSame( SimilarityResult::STRATEGY_PREFIX, $result->strategy );
+	}
+
+	public function test_titles_match_prefix_requires_minimum_length(): void {
+		// Too short to trigger prefix match.
+		$result = SimilarityEngine::titlesMatch( 'Hi', 'Hiking Trip' );
+		$this->assertFalse( $result->match );
+	}
+
+	public function test_titles_match_levenshtein(): void {
+		// Long titles with minor word differences that survive normalization.
+		// "programming" vs "programing" (typo) — different after normalization.
+		$result = SimilarityEngine::titlesMatch(
+			'advanced programming techniques explained',
+			'advanced programing techniques explained'
+		);
+		$this->assertTrue( $result->match );
+		$this->assertSame( SimilarityResult::STRATEGY_EDIT, $result->strategy );
+	}
+
+	public function test_titles_match_levenshtein_requires_minimum_length(): void {
+		// Short titles don't get Levenshtein.
+		$result = SimilarityEngine::titlesMatch( 'Cat', 'Car' );
+		$this->assertFalse( $result->match );
+	}
+
+	public function test_titles_no_match_different_content(): void {
+		$result = SimilarityEngine::titlesMatch(
+			'Best Restaurants in Austin',
+			'Live Music Venues in Nashville'
+		);
+		$this->assertFalse( $result->match );
+		$this->assertSame( SimilarityResult::STRATEGY_NONE, $result->strategy );
+	}
+
+	public function test_titles_match_with_supporting_acts_stripped(): void {
+		$result = SimilarityEngine::titlesMatch(
+			'Andy Frasco & the U.N. — Growing Pains Tour with Candi Jenkins',
+			'Andy Frasco & The U.N.'
+		);
+		$this->assertTrue( $result->match );
+	}
+
+	public function test_titles_match_returns_similarity_result(): void {
+		$result = SimilarityEngine::titlesMatch( 'Foo', 'Bar' );
+		$this->assertInstanceOf( SimilarityResult::class, $result );
+		$this->assertIsBool( $result->match );
+		$this->assertIsFloat( $result->score );
+		$this->assertIsString( $result->strategy );
+	}
+
+	// -----------------------------------------------------------------------
+	// tokenize
+	// -----------------------------------------------------------------------
+
+	public function test_tokenize_removes_stop_words(): void {
+		$tokens = SimilarityEngine::tokenize( 'The cat is on the mat' );
+		$this->assertContains( 'cat', $tokens );
+		$this->assertContains( 'mat', $tokens );
+		$this->assertNotContains( 'the', $tokens );
+		$this->assertNotContains( 'is', $tokens );
+		$this->assertNotContains( 'on', $tokens );
+	}
+
+	public function test_tokenize_removes_short_words(): void {
+		$tokens = SimilarityEngine::tokenize( 'I go to a bar' );
+		$this->assertNotContains( 'i', $tokens );
+		$this->assertContains( 'go', $tokens );
+		$this->assertContains( 'bar', $tokens );
+	}
+
+	public function test_tokenize_returns_unique_words(): void {
+		$tokens = SimilarityEngine::tokenize( 'cat cat cat dog dog' );
+		$this->assertCount( 2, $tokens );
+	}
+
+	public function test_tokenize_lowercases(): void {
+		$tokens = SimilarityEngine::tokenize( 'HELLO World' );
+		$this->assertContains( 'hello', $tokens );
+		$this->assertContains( 'world', $tokens );
+	}
+
+	// -----------------------------------------------------------------------
+	// jaccard
+	// -----------------------------------------------------------------------
+
+	public function test_jaccard_identical_sets(): void {
+		$this->assertSame( 1.0, SimilarityEngine::jaccard( array( 'cat', 'dog' ), array( 'cat', 'dog' ) ) );
+	}
+
+	public function test_jaccard_disjoint_sets(): void {
+		$this->assertSame( 0.0, SimilarityEngine::jaccard( array( 'cat' ), array( 'dog' ) ) );
+	}
+
+	public function test_jaccard_partial_overlap(): void {
+		// { cat, dog } ∩ { cat, fish } = { cat }
+		// { cat, dog } ∪ { cat, fish } = { cat, dog, fish }
+		// Jaccard = 1/3 ≈ 0.333
+		$score = SimilarityEngine::jaccard( array( 'cat', 'dog' ), array( 'cat', 'fish' ) );
+		$this->assertEqualsWithDelta( 1 / 3, $score, 0.001 );
+	}
+
+	public function test_jaccard_empty_sets(): void {
+		$this->assertSame( 0.0, SimilarityEngine::jaccard( array(), array( 'cat' ) ) );
+		$this->assertSame( 0.0, SimilarityEngine::jaccard( array( 'cat' ), array() ) );
+		$this->assertSame( 0.0, SimilarityEngine::jaccard( array(), array() ) );
+	}
+
+	// -----------------------------------------------------------------------
+	// jaccardMatch
+	// -----------------------------------------------------------------------
+
+	public function test_jaccard_match_above_threshold(): void {
+		$result = SimilarityEngine::jaccardMatch(
+			'Best Phish Shows of 2025',
+			'Top Phish Concerts from 2025',
+			0.3
+		);
+		$this->assertTrue( $result->match );
+		$this->assertSame( SimilarityResult::STRATEGY_JACCARD, $result->strategy );
+	}
+
+	public function test_jaccard_match_below_threshold(): void {
+		$result = SimilarityEngine::jaccardMatch(
+			'Best Restaurants in Austin',
+			'Live Music Venues in Nashville',
+			0.65
+		);
+		$this->assertFalse( $result->match );
+	}
+
+	// -----------------------------------------------------------------------
+	// getBestSearchWord
+	// -----------------------------------------------------------------------
+
+	public function test_get_best_search_word_returns_longest(): void {
+		$word = SimilarityEngine::getBestSearchWord( 'The cat sat on the comfortable chair' );
+		$this->assertSame( 'comfortable', $word );
+	}
+
+	public function test_get_best_search_word_skips_stop_words(): void {
+		$word = SimilarityEngine::getBestSearchWord( 'what is the meaning' );
+		$this->assertSame( 'meaning', $word );
+	}
+
+	public function test_get_best_search_word_returns_null_for_only_stop_words(): void {
+		$word = SimilarityEngine::getBestSearchWord( 'it is the' );
+		$this->assertNull( $word );
+	}
+
+	// -----------------------------------------------------------------------
+	// SimilarityResult
+	// -----------------------------------------------------------------------
+
+	public function test_similarity_result_to_array(): void {
+		$result = new SimilarityResult( true, 0.95, SimilarityResult::STRATEGY_EXACT, 'foo', 'foo' );
+		$array  = $result->toArray();
+
+		$this->assertTrue( $array['match'] );
+		$this->assertSame( 0.95, $array['score'] );
+		$this->assertSame( 'exact', $array['strategy'] );
+		$this->assertSame( 'foo', $array['normalized_a'] );
+		$this->assertSame( 'foo', $array['normalized_b'] );
+	}
+
+	public function test_similarity_result_no_match_factory(): void {
+		$result = SimilarityResult::noMatch( 'foo', 'bar' );
+
+		$this->assertFalse( $result->match );
+		$this->assertSame( 0.0, $result->score );
+		$this->assertSame( SimilarityResult::STRATEGY_NONE, $result->strategy );
+	}
+
+	// -----------------------------------------------------------------------
+	// normalizeBasic
+	// -----------------------------------------------------------------------
+
+	public function test_normalize_basic_strips_leading_article(): void {
+		$this->assertSame( 'foo bar', SimilarityEngine::normalizeBasic( 'The Foo Bar' ) );
+	}
+
+	public function test_normalize_basic_lowercases_and_trims(): void {
+		$this->assertSame( 'hello world', SimilarityEngine::normalizeBasic( '  Hello   World  ' ) );
+	}
+}


### PR DESCRIPTION
## Summary

Consolidates Data Machine's three independent duplicate detection algorithms into a shared similarity engine and a single Ability-based entry point, as proposed in #731.

- **SimilarityEngine** (`inc/Core/Similarity/`): pure math layer with `normalizeTitle()`, `tokenize()`, `jaccard()`, `titlesMatch()`, `getBestSearchWord()` — no dependencies on engine/steps/AI runtime
- **DuplicateCheckAbility**: `datamachine/check-duplicate` ability with extensible strategy registry via `datamachine_duplicate_strategies` filter, plus `datamachine/titles-match` utility ability
- **DuplicateDetection** and **QueueValidator** rewritten as thin wrappers delegating similarity math to `SimilarityEngine`

## What Changed

### New files
| File | Purpose |
|------|---------|
| `inc/Core/Similarity/SimilarityEngine.php` | Unified similarity math (normalize, tokenize, Jaccard, prefix matching) |
| `inc/Core/Similarity/SimilarityResult.php` | Value object for match results |
| `inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php` | Ability + strategy registry |
| `tests/Unit/Core/SimilarityEngineTest.php` | 43 tests |
| `tests/Unit/Abilities/DuplicateCheckAbilityTest.php` | 10 tests |

### Modified files
| File | Change |
|------|--------|
| `inc/Core/WordPress/DuplicateDetection.php` | Rewritten as thin wrapper → `SimilarityEngine` |
| `inc/Engine/AI/Tools/Global/QueueValidator.php` | Delegates similarity math → `SimilarityEngine` |
| `data-machine.php` | Bootstrap: requires + instantiation for new classes |
| `tests/Unit/AI/Tools/QueueValidatorTest.php` | Updated to use `SimilarityEngine::` static methods |
| `tests/Unit/Abilities/AllAbilitiesRegisteredTest.php` | Added 2 new abilities |

## Design Decisions

- **ProcessedItems stays separate** — it answers "have I fetched this exact source item?" (identity), not "does similar content exist?" (similarity). Different concern.
- **`normalizeTitle()` merges the best of both plugins** — core's subreddit/reaction suffix stripping + events plugin's broader delimiter set (`featuring`, `with`, `w/`, `+`, comma-split). Min prefix length uses events' battle-tested 5 chars.
- **Strategy registry** — default strategies handle published-post title match and queue-item Jaccard match. Extensions (like `data-machine-events`) can register domain-specific strategies via the `datamachine_duplicate_strategies` filter.

## Test Results

```
Tests: 764, Assertions: 2743, Skipped: 3 (pre-existing WebScraper fixture skips)
Failed: 0
```

## Future Work (separate PRs)

- **Events plugin migration**: `EventIdentifierGenerator` delegates to `SimilarityEngine`, registers event strategy on `datamachine_duplicate_strategies`
- **WordPress publish handler**: call `datamachine/check-duplicate` ability directly instead of `DuplicateDetection`
- **QueueAbility**: call `datamachine/check-duplicate` ability instead of instantiating `QueueValidator` directly

Closes #731 (core phases 1–2)