### PR TITLE
fix(#730): queue-add uses unified check-duplicate instead of QueueValidator

### DIFF
--- a/inc/Abilities/Flow/QueueAbility.php
+++ b/inc/Abilities/Flow/QueueAbility.php
@@ -12,7 +12,7 @@
 namespace DataMachine\Abilities\Flow;
 
 use DataMachine\Core\Database\Flows\Flows as DB_Flows;
-use DataMachine\Engine\AI\Tools\Global\QueueValidator;
+use DataMachine\Abilities\DuplicateCheck\DuplicateCheckAbility;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -81,6 +81,10 @@ class QueueAbility {
 							'type'        => 'boolean',
 							'description' => __( 'Skip duplicate validation (default: false). Use only when intentionally re-adding a known prompt.', 'data-machine' ),
 						),
+						'context'         => array(
+							'type'        => 'object',
+							'description' => __( 'Domain-specific context for duplicate detection strategies (e.g., venue, startDate for events).', 'data-machine' ),
+						),
 					),
 				),
 				'output_schema'       => array(
@@ -95,6 +99,7 @@ class QueueAbility {
 						'reason'       => array( 'type' => 'string' ),
 						'match'        => array( 'type' => 'object' ),
 						'source'       => array( 'type' => 'string' ),
+						'strategy'     => array( 'type' => 'string' ),
 					),
 				),
 				'execute_callback'    => array( $this, 'executeQueueAdd' ),
@@ -445,23 +450,26 @@ class QueueAbility {
 			// for custom post types (quizzes, recipes, events, etc.).
 			$post_type = $input['post_type'] ?? $this->resolvePublishPostType( $flow_config );
 
-			$validator = new QueueValidator();
-			$result    = $validator->validate( array(
-				'topic'        => $prompt,
+			$dedup  = new DuplicateCheckAbility();
+			$result = $dedup->executeCheckDuplicate( array(
+				'title'        => $prompt,
+				'post_type'    => $post_type,
+				'scope'        => 'both',
 				'flow_id'      => $flow_id,
 				'flow_step_id' => $flow_step_id,
-				'post_type'    => $post_type,
+				'context'      => $input['context'] ?? array(),
 			) );
 
 			if ( 'duplicate' === $result['verdict'] ) {
 				return array(
-					'success' => false,
-					'error'   => 'duplicate_rejected',
-					'reason'  => $result['reason'],
-					'match'   => $result['match'] ?? array(),
-					'source'  => $result['source'] ?? 'unknown',
-					'flow_id' => $flow_id,
-					'message' => sprintf( 'Rejected: "%s" is a duplicate. %s', $prompt, $result['reason'] ),
+					'success'  => false,
+					'error'    => 'duplicate_rejected',
+					'reason'   => $result['reason'] ?? '',
+					'match'    => $result['match'] ?? array(),
+					'source'   => $result['source'] ?? 'unknown',
+					'strategy' => $result['strategy'] ?? '',
+					'flow_id'  => $flow_id,
+					'message'  => sprintf( 'Rejected: "%s" is a duplicate. %s', $prompt, $result['reason'] ?? '' ),
 				);
 			}
 		}
@@ -1115,7 +1123,6 @@ class QueueAbility {
 		return $popped_item;
 	}
 
-	/**
 	/**
 	 * Resolve the post_type from the flow's publish step handler config.
 	 *


### PR DESCRIPTION
## Summary

Replaces direct `QueueValidator` instantiation in `QueueAbility::executeQueueAdd()` with the unified `DuplicateCheckAbility::executeCheckDuplicate()`, completing the dedup unification from #731.

- Queue-add now runs the **full strategy cascade**: extension strategies (via `datamachine_duplicate_strategies` filter) → published-post title match → queue-item Jaccard match
- Adds `context` input parameter so callers can pass domain-specific data (venue, startDate, etc.) through to extension strategies
- Adds `strategy` output field so callers know which strategy caught the duplicate

## Before vs After

```
Before: QueueAbility → new QueueValidator() → Jaccard only
After:  QueueAbility → DuplicateCheckAbility → strategy cascade
                                                 ├── extension strategies (events, etc.)
                                                 ├── published-post title match
                                                 └── queue-item Jaccard match
```

## What Changed

| File | Change |
|------|--------|
| `inc/Abilities/Flow/QueueAbility.php` | Import `DuplicateCheckAbility` instead of `QueueValidator`; call `executeCheckDuplicate(scope: 'both')`; add `context` input + `strategy` output; fix stale `/**` docblock |

## Test Results

```
Tests: 764, Passed: 761, Failed: 0, Skipped: 3
```

`QueueValidator` still exists as a class for the AI tool interface — this PR only changes the queue-add ability's internal wiring.

Closes #730