### PR TITLE
feat(#573): multi-agent UI scoping — REST API user_id filtering and ownership guards

### DIFF
--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -178,6 +178,67 @@ class PermissionHelper {
 	}
 
 	/**
+	 * Resolve user_id for scoped REST API queries.
+	 *
+	 * Determines whose data should be returned based on the request:
+	 * - If `user_id` param is present and caller is admin → use that user_id
+	 * - If caller is admin and no `user_id` param → return null (all users)
+	 * - If caller is non-admin → always return their own user_id
+	 *
+	 * @since 0.40.0
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @param string           $action  Action key for admin check (default: 'manage_flows').
+	 * @return int|null User ID to filter by, or null for all users (admin default).
+	 */
+	public static function resolve_scoped_user_id( \WP_REST_Request $request, string $action = 'manage_flows' ): ?int {
+		$requested_user_id = $request->get_param( 'user_id' );
+		$is_admin          = self::can( $action );
+
+		// Admin with explicit user filter → scope to that user.
+		if ( $is_admin && null !== $requested_user_id && '' !== $requested_user_id ) {
+			return (int) $requested_user_id;
+		}
+
+		// Admin with no filter → all users.
+		if ( $is_admin ) {
+			return null;
+		}
+
+		// Non-admin → always their own data.
+		return self::acting_user_id();
+	}
+
+	/**
+	 * Check if the acting user owns a resource.
+	 *
+	 * Returns true if:
+	 * - Resource has user_id 0 (single-agent mode, anyone can access)
+	 * - Resource belongs to the acting user
+	 * - Acting user is an admin (can manage any resource)
+	 *
+	 * @since 0.40.0
+	 *
+	 * @param int    $resource_user_id User ID on the resource record.
+	 * @param string $action           Action key for admin check (default: 'manage_flows').
+	 * @return bool True if the acting user can access this resource.
+	 */
+	public static function owns_resource( int $resource_user_id, string $action = 'manage_flows' ): bool {
+		// Single-agent mode resources (user_id 0) are accessible to anyone with the capability.
+		if ( 0 === $resource_user_id ) {
+			return true;
+		}
+
+		// Admins can access any resource.
+		if ( self::can( $action ) && ( self::is_authenticated_context() || current_user_can( 'manage_options' ) ) ) {
+			return true;
+		}
+
+		// Owner check.
+		return self::acting_user_id() === $resource_user_id;
+	}
+
+	/**
 	 * Check capability for a specific user against Data Machine action.
 	 *
 	 * @since 0.37.0

--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -103,6 +103,12 @@ class Flows {
 						'sanitize_callback' => 'absint',
 						'description'       => __( 'Offset for pagination', 'data-machine' ),
 					),
+					'user_id'     => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'description'       => __( 'Filter by user ID (admin only, non-admins always see own data)', 'data-machine' ),
+						'sanitize_callback' => 'absint',
+					),
 				),
 			)
 		);
@@ -270,6 +276,7 @@ class Flows {
 		$input = array(
 			'pipeline_id' => (int) $request->get_param( 'pipeline_id' ),
 			'flow_name'   => $request->get_param( 'flow_name' ) ?? 'Flow',
+			'user_id'     => PermissionHelper::acting_user_id(),
 		);
 
 		if ( $request->get_param( 'flow_config' ) ) {
@@ -301,6 +308,20 @@ class Flows {
 	 * Handle flow deletion request
 	 */
 	public static function handle_delete_flow( $request ) {
+		$flow_id = (int) $request->get_param( 'flow_id' );
+
+		// Verify ownership before deleting.
+		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
+		$flow     = $db_flows->get_flow( $flow_id );
+
+		if ( $flow && ! PermissionHelper::owns_resource( (int) ( $flow['user_id'] ?? 0 ) ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to delete this flow.', 'data-machine' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		$ability = wp_get_ability( 'datamachine/delete-flow' );
 		if ( ! $ability ) {
 			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
@@ -308,7 +329,7 @@ class Flows {
 
 		$result = $ability->execute(
 			array(
-				'flow_id' => (int) $request->get_param( 'flow_id' ),
+				'flow_id' => $flow_id,
 			)
 		);
 
@@ -327,6 +348,20 @@ class Flows {
 	 * Handle flow duplication request
 	 */
 	public static function handle_duplicate_flow( $request ) {
+		$flow_id = (int) $request->get_param( 'flow_id' );
+
+		// Verify ownership before duplicating.
+		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
+		$flow     = $db_flows->get_flow( $flow_id );
+
+		if ( $flow && ! PermissionHelper::owns_resource( (int) ( $flow['user_id'] ?? 0 ) ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to duplicate this flow.', 'data-machine' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		$ability = wp_get_ability( 'datamachine/duplicate-flow' );
 		if ( ! $ability ) {
 			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
@@ -334,7 +369,8 @@ class Flows {
 
 		$result = $ability->execute(
 			array(
-				'source_flow_id' => (int) $request->get_param( 'flow_id' ),
+				'source_flow_id' => $flow_id,
+				'user_id'        => PermissionHelper::acting_user_id(),
 			)
 		);
 
@@ -353,22 +389,25 @@ class Flows {
 	 * Handle flows retrieval request with pagination support
 	 */
 	public static function handle_get_flows( $request ) {
-		$pipeline_id = $request->get_param( 'pipeline_id' );
-		$per_page    = $request->get_param( 'per_page' ) ?? 20;
-		$offset      = $request->get_param( 'offset' ) ?? 0;
+		$pipeline_id    = $request->get_param( 'pipeline_id' );
+		$per_page       = $request->get_param( 'per_page' ) ?? 20;
+		$offset         = $request->get_param( 'offset' ) ?? 0;
+		$scoped_user_id = PermissionHelper::resolve_scoped_user_id( $request );
 
 		$ability = wp_get_ability( 'datamachine/get-flows' );
 		if ( ! $ability ) {
 			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
 		}
 
-		$result = $ability->execute(
-			array(
-				'pipeline_id' => $pipeline_id,
-				'per_page'    => $per_page,
-				'offset'      => $offset,
-			)
+		$input = array(
+			'pipeline_id' => $pipeline_id,
+			'per_page'    => $per_page,
+			'offset'      => $offset,
 		);
+		if ( null !== $scoped_user_id ) {
+			$input['user_id'] = $scoped_user_id;
+		}
+		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
 			return $result;
@@ -444,13 +483,27 @@ class Flows {
 	 * PATCH /datamachine/v1/flows/{id}
 	 */
 	public static function handle_update_flow( $request ) {
+		$flow_id = (int) $request->get_param( 'flow_id' );
+
+		// Verify ownership before updating.
+		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
+		$flow     = $db_flows->get_flow( $flow_id );
+
+		if ( $flow && ! PermissionHelper::owns_resource( (int) ( $flow['user_id'] ?? 0 ) ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to update this flow.', 'data-machine' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		$ability = wp_get_ability( 'datamachine/update-flow' );
 		if ( ! $ability ) {
 			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
 		}
 
 		$input = array(
-			'flow_id' => (int) $request->get_param( 'flow_id' ),
+			'flow_id' => $flow_id,
 		);
 
 		$flow_name         = $request->get_param( 'flow_name' );
@@ -566,6 +619,14 @@ class Flows {
 			);
 		}
 
+		if ( ! PermissionHelper::owns_resource( (int) ( $flow['user_id'] ?? 0 ) ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to access this flow.', 'data-machine' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		$memory_files = $db_flows->get_flow_memory_files( $flow_id );
 
 		return rest_ensure_response(
@@ -597,6 +658,14 @@ class Flows {
 				'flow_not_found',
 				__( 'Flow not found.', 'data-machine' ),
 				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! PermissionHelper::owns_resource( (int) ( $flow['user_id'] ?? 0 ) ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to update this flow.', 'data-machine' ),
+				array( 'status' => 403 )
 			);
 		}
 

--- a/inc/Api/Jobs.php
+++ b/inc/Api/Jobs.php
@@ -98,6 +98,12 @@ class Jobs {
 						'type'        => 'string',
 						'description' => __( 'Filter by job status', 'data-machine' ),
 					),
+					'user_id'     => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'description'       => __( 'Filter by user ID (admin only, non-admins always see own data)', 'data-machine' ),
+						'sanitize_callback' => 'absint',
+					),
 				),
 			)
 		);
@@ -168,6 +174,8 @@ class Jobs {
 	 * GET /datamachine/v1/jobs
 	 */
 	public static function handle_get_jobs( $request ) {
+		$scoped_user_id = PermissionHelper::resolve_scoped_user_id( $request );
+
 		$input = array(
 			'orderby'  => $request->get_param( 'orderby' ),
 			'order'    => $request->get_param( 'order' ),
@@ -175,6 +183,9 @@ class Jobs {
 			'offset'   => $request->get_param( 'offset' ),
 		);
 
+		if ( null !== $scoped_user_id ) {
+			$input['user_id'] = $scoped_user_id;
+		}
 		if ( $request->get_param( 'pipeline_id' ) ) {
 			$input['pipeline_id'] = (int) $request->get_param( 'pipeline_id' );
 		}

--- a/inc/Api/Pipelines/Pipelines.php
+++ b/inc/Api/Pipelines/Pipelines.php
@@ -70,6 +70,12 @@ class Pipelines {
 							'description'       => __( 'Comma-separated pipeline IDs for export', 'data-machine' ),
 							'sanitize_callback' => 'sanitize_text_field',
 						),
+						'user_id'     => array(
+							'required'          => false,
+							'type'              => 'integer',
+							'description'       => __( 'Filter by user ID (admin only, non-admins always see own data)', 'data-machine' ),
+							'sanitize_callback' => 'absint',
+						),
 					),
 				),
 				array(
@@ -238,10 +244,11 @@ class Pipelines {
 	 * Handle pipeline retrieval request
 	 */
 	public static function handle_get_pipelines( $request ) {
-		$pipeline_id = $request->get_param( 'pipeline_id' );
-		$fields      = $request->get_param( 'fields' );
-		$format      = $request->get_param( 'format' ) ?? 'json';
-		$ids         = $request->get_param( 'ids' );
+		$pipeline_id    = $request->get_param( 'pipeline_id' );
+		$fields         = $request->get_param( 'fields' );
+		$format         = $request->get_param( 'format' ) ?? 'json';
+		$ids            = $request->get_param( 'ids' );
+		$scoped_user_id = PermissionHelper::resolve_scoped_user_id( $request );
 
 		$abilities = new PipelineAbilities();
 
@@ -283,12 +290,14 @@ class Pipelines {
 		}
 
 		if ( $pipeline_id ) {
-			$result = $abilities->executeGetPipelines(
-				array(
-					'pipeline_id' => (int) $pipeline_id,
-					'output_mode' => 'full',
-				)
+			$input = array(
+				'pipeline_id' => (int) $pipeline_id,
+				'output_mode' => 'full',
 			);
+			if ( null !== $scoped_user_id ) {
+				$input['user_id'] = $scoped_user_id;
+			}
+			$result = $abilities->executeGetPipelines( $input );
 
 			if ( ! $result['success'] || empty( $result['pipelines'] ) ) {
 				return new \WP_Error(
@@ -317,13 +326,15 @@ class Pipelines {
 				)
 			);
 		} else {
-			$result = $abilities->executeGetPipelines(
-				array(
-					'per_page'    => 100,
-					'offset'      => 0,
-					'output_mode' => 'full',
-				)
+			$input = array(
+				'per_page'    => 100,
+				'offset'      => 0,
+				'output_mode' => 'full',
 			);
+			if ( null !== $scoped_user_id ) {
+				$input['user_id'] = $scoped_user_id;
+			}
+			$result = $abilities->executeGetPipelines( $input );
 
 			if ( ! $result['success'] ) {
 				return new \WP_Error(
@@ -375,6 +386,7 @@ class Pipelines {
 				'pipeline_name' => $params['pipeline_name'],
 				'steps'         => $params['steps'] ?? array(),
 				'flow_config'   => $params['flow_config'] ?? array(),
+				'user_id'       => PermissionHelper::acting_user_id(),
 			)
 		);
 
@@ -399,6 +411,18 @@ class Pipelines {
 	 */
 	public static function handle_delete_pipeline( $request ) {
 		$pipeline_id = (int) $request->get_param( 'pipeline_id' );
+
+		// Verify ownership before deleting.
+		$db_pipelines = new \DataMachine\Core\Database\Pipelines\Pipelines();
+		$pipeline     = $db_pipelines->get_pipeline( $pipeline_id );
+
+		if ( $pipeline && ! PermissionHelper::owns_resource( (int) ( $pipeline['user_id'] ?? 0 ) ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to delete this pipeline.', 'data-machine' ),
+				array( 'status' => 403 )
+			);
+		}
 
 		$abilities = new PipelineAbilities();
 		$result    = $abilities->executeDeletePipeline( array( 'pipeline_id' => $pipeline_id ) );
@@ -432,6 +456,18 @@ class Pipelines {
 				'rest_invalid_param',
 				__( 'Pipeline ID and name are required.', 'data-machine' ),
 				array( 'status' => 400 )
+			);
+		}
+
+		// Verify ownership before updating.
+		$db_pipelines = new \DataMachine\Core\Database\Pipelines\Pipelines();
+		$pipeline     = $db_pipelines->get_pipeline( $pipeline_id );
+
+		if ( $pipeline && ! PermissionHelper::owns_resource( (int) ( $pipeline['user_id'] ?? 0 ) ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to update this pipeline.', 'data-machine' ),
+				array( 'status' => 403 )
 			);
 		}
 
@@ -487,6 +523,14 @@ class Pipelines {
 			);
 		}
 
+		if ( ! PermissionHelper::owns_resource( (int) ( $pipeline['user_id'] ?? 0 ) ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to access this pipeline.', 'data-machine' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		$memory_files = $db_pipelines->get_pipeline_memory_files( $pipeline_id );
 
 		return rest_ensure_response(
@@ -516,6 +560,14 @@ class Pipelines {
 				'pipeline_not_found',
 				__( 'Pipeline not found.', 'data-machine' ),
 				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! PermissionHelper::owns_resource( (int) ( $pipeline['user_id'] ?? 0 ) ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to update this pipeline.', 'data-machine' ),
+				array( 'status' => 403 )
 			);
 		}
 


### PR DESCRIPTION
## Summary

Adds server-side user scoping to all pipeline, flow, and job REST endpoints so each user sees only their own data in WP-Admin. Admins see everything by default with an optional `?user_id=X` filter.

- **Non-admins**: always scoped to their own data — can't see or modify other users' pipelines/flows/jobs
- **Admins**: see all by default, can filter by `?user_id=X` for a specific user
- **Mutations**: all update/delete/duplicate endpoints verify ownership before executing
- **Single-agent mode**: `user_id=0` resources remain accessible to anyone with the capability (backward compatible)

## What Changed

| File | Change |
|------|--------|
| `inc/Abilities/PermissionHelper.php` | Added `resolve_scoped_user_id()` and `owns_resource()` methods |
| `inc/Api/Pipelines/Pipelines.php` | GET scoped, POST stamps user_id, PATCH/DELETE verify ownership, memory-file endpoints verify ownership |
| `inc/Api/Flows/Flows.php` | GET scoped, POST stamps user_id, PATCH/DELETE/duplicate verify ownership, memory-file endpoints verify ownership |
| `inc/Api/Jobs.php` | GET scoped by user_id |

## How It Works

### Query Scoping (GET endpoints)

```php
// PermissionHelper::resolve_scoped_user_id($request)
// Non-admin → returns their user_id (always scoped)
// Admin + no ?user_id → returns null (all users)
// Admin + ?user_id=5 → returns 5 (filtered)
```

The resolved user_id is passed to the existing abilities (`GetPipelinesAbility`, `GetFlowsAbility`, `GetJobsAbility`) which already accept `user_id` and pass it to the DB layer. No DB or abilities changes needed.

### Ownership Guards (mutation endpoints)

```php
// PermissionHelper::owns_resource($resource_user_id)
// user_id=0 (single-agent) → always true
// Admin → always true
// Owner match → true
// Otherwise → false (403)
```

### React Frontend

No React changes in this PR. The frontend doesn't need to send `user_id` — the server auto-injects scoping from the authenticated user. A future PR can add an admin user-filter dropdown, but the scoping works transparently without it.

## Test Results

```
Tests: 764, Passed: 761, Failed: 0, Skipped: 3
```

## Architecture Note

The existing pattern from `Api/AgentFiles.php` was the model — it already had `resolve_scoped_user_id()` and ownership checks. This PR extends the same pattern to pipelines, flows, and jobs using a centralized `PermissionHelper` instead of per-class methods.

Closes #573