### PR TITLE
fix: remove brain emoji from SOUL.md badge, rename Agent page to Agents

### DIFF
--- a/inc/Core/Admin/Pages/Agent/AgentFilters.php
+++ b/inc/Core/Admin/Pages/Agent/AgentFilters.php
@@ -24,8 +24,8 @@ function datamachine_register_agent_admin_page_filters() {
 		'datamachine_admin_pages',
 		function ( $pages ) {
 			$pages['agent'] = array(
-				'page_title' => __( 'Agent', 'data-machine' ),
-				'menu_title' => __( 'Agent', 'data-machine' ),
+				'page_title' => __( 'Agents', 'data-machine' ),
+				'menu_title' => __( 'Agents', 'data-machine' ),
 				'capability' => 'manage_options',
 				'position'   => 20,
 				'templates'  => __DIR__ . '/templates/',

--- a/inc/Core/Admin/Pages/Agent/assets/css/agent-page.css
+++ b/inc/Core/Admin/Pages/Agent/assets/css/agent-page.css
@@ -101,10 +101,6 @@
 	padding-left: 12px;
 }
 
-.datamachine-agent-file-item.is-soul .datamachine-agent-file-item-name {
-	font-weight: 600;
-}
-
 .datamachine-agent-file-item-info {
 	display: flex;
 	flex-direction: column;
@@ -119,10 +115,6 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-}
-
-.datamachine-agent-file-soul-badge {
-	margin-right: 4px;
 }
 
 .datamachine-agent-file-item-meta {

--- a/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
@@ -33,7 +33,7 @@ const AgentApp = () => {
 	return (
 		<div className="datamachine-agent-app">
 			<div className="datamachine-agent-header">
-				<h1 className="datamachine-agent-title">Agent</h1>
+				<h1 className="datamachine-agent-title">Agents</h1>
 			</div>
 			<TabPanel
 				className="datamachine-tabs"

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
@@ -265,7 +265,7 @@ const AgentFileList = ( { selectedFile, onSelectFile } ) => {
 							key={ file.filename }
 							className={ `datamachine-agent-file-item${
 								isSelected ? ' is-selected' : ''
-							}${ isSoul ? ' is-soul' : '' }` }
+							}` }
 							onClick={ () => onSelectFile( file.filename ) }
 							role="button"
 							tabIndex={ 0 }
@@ -277,14 +277,6 @@ const AgentFileList = ( { selectedFile, onSelectFile } ) => {
 						>
 							<div className="datamachine-agent-file-item-info">
 								<span className="datamachine-agent-file-item-name">
-									{ isSoul && (
-										<span
-											className="datamachine-agent-file-soul-badge"
-											title="Agent identity"
-										>
-											🧠
-										</span>
-									) }
 									{ file.filename }
 								</span>
 								<span className="datamachine-agent-file-item-meta">


### PR DESCRIPTION
## Summary
- Replace brain emoji (🧠) on SOUL.md file badge with text label "SOUL"
- Rename "Agent" → "Agents" in page title, menu title, and React heading

Closes #736