### PR TITLE
fix: remove brain emoji and special styling from SOUL.md, rename Agent page to Agents

### DIFF
--- a/inc/Core/Admin/Pages/Agent/AgentFilters.php
+++ b/inc/Core/Admin/Pages/Agent/AgentFilters.php
@@ -24,8 +24,8 @@ function datamachine_register_agent_admin_page_filters() {
 		'datamachine_admin_pages',
 		function ( $pages ) {
 			$pages['agent'] = array(
-				'page_title' => __( 'Agent', 'data-machine' ),
-				'menu_title' => __( 'Agent', 'data-machine' ),
+				'page_title' => __( 'Agents', 'data-machine' ),
+				'menu_title' => __( 'Agents', 'data-machine' ),
 				'capability' => 'datamachine_manage_agents',
 				'position'   => 20,
 				'templates'  => __DIR__ . '/templates/',

--- a/inc/Core/Admin/Pages/Agent/assets/css/agent-page.css
+++ b/inc/Core/Admin/Pages/Agent/assets/css/agent-page.css
@@ -101,10 +101,6 @@
 	padding-left: 12px;
 }
 
-.datamachine-agent-file-item.is-soul .datamachine-agent-file-item-name {
-	font-weight: 600;
-}
-
 .datamachine-agent-file-item-info {
 	display: flex;
 	flex-direction: column;
@@ -119,10 +115,6 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-}
-
-.datamachine-agent-file-soul-badge {
-	margin-right: 4px;
 }
 
 .datamachine-agent-file-item-meta {

--- a/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
@@ -43,7 +43,7 @@ const AgentApp = () => {
 	return (
 		<div className="datamachine-agent-app">
 			<div className="datamachine-agent-header">
-				<h1 className="datamachine-agent-title">Agent</h1>
+				<h1 className="datamachine-agent-title">Agents</h1>
 			</div>
 			<TabPanel
 				className="datamachine-tabs"

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
@@ -335,7 +335,7 @@ const AgentFileList = ( { selectedFile, onSelectFile } ) => {
 							key={ file.filename }
 							className={ `datamachine-agent-file-item${
 								selected ? ' is-selected' : ''
-							}${ isSoul ? ' is-soul' : '' }` }
+							}` }
 							onClick={ () =>
 								onSelectFile( {
 									type: 'core',
@@ -358,14 +358,6 @@ const AgentFileList = ( { selectedFile, onSelectFile } ) => {
 						>
 							<div className="datamachine-agent-file-item-info">
 								<span className="datamachine-agent-file-item-name">
-									{ isSoul && (
-										<span
-											className="datamachine-agent-file-soul-badge"
-											title="Agent identity"
-										>
-											&#x1f9e0;
-										</span>
-									) }
 									{ file.filename }
 								</span>
 								<span className="datamachine-agent-file-item-meta">


### PR DESCRIPTION
## Summary
- Remove brain emoji (🧠) and special styling from SOUL.md file badge — treat it like other memory files
- Remove `.is-soul` and `.soul-badge` CSS rules
- Rename "Agent" → "Agents" in page title, menu title, and React heading

Closes #736