### PR TITLE
feat(#742): agent audit trail — structured action logging

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -102,6 +102,7 @@ function datamachine_run_datamachine_plugin() {
 	\DataMachine\Api\FlowFiles::register();
 	\DataMachine\Api\Users::register();
 	\DataMachine\Api\Agents::register();
+	\DataMachine\Api\AgentLog::register();
 	\DataMachine\Api\Logs::register();
 	\DataMachine\Api\ProcessedItems::register();
 	\DataMachine\Api\Jobs::register();
@@ -405,6 +406,7 @@ function datamachine_deactivate_plugin() {
 	if ( function_exists( 'as_unschedule_all_actions' ) ) {
 		as_unschedule_all_actions( 'datamachine_cleanup_stale_claims', array(), 'datamachine-maintenance' );
 		as_unschedule_all_actions( 'datamachine_cleanup_failed_jobs', array(), 'datamachine-maintenance' );
+		as_unschedule_all_actions( 'datamachine_cleanup_audit_log', array(), 'datamachine-maintenance' );
 	}
 }
 
@@ -434,9 +436,10 @@ function datamachine_activate_plugin( $network_wide = false ) {
 function datamachine_activate_for_site() {
 	datamachine_register_capabilities();
 
-	// Ensure first-class agents table exists.
+	// Ensure first-class agents tables exist.
 	\DataMachine\Core\Database\Agents\Agents::create_table();
 	\DataMachine\Core\Database\Agents\AgentAccess::create_table();
+	\DataMachine\Core\Database\Agents\AgentLog::create_table();
 
 	$db_pipelines = new \DataMachine\Core\Database\Pipelines\Pipelines();
 	$db_pipelines->create_table();

--- a/inc/Abilities/AgentMemoryAbilities.php
+++ b/inc/Abilities/AgentMemoryAbilities.php
@@ -243,10 +243,26 @@ class AgentMemoryAbilities {
 		$mode    = $input['mode'];
 
 		if ( 'append' === $mode ) {
-			return $memory->append_to_section( $section, $content );
+			$result = $memory->append_to_section( $section, $content );
+		} else {
+			$result = $memory->set_section( $section, $content );
 		}
 
-		return $memory->set_section( $section, $content );
+		if ( ! empty( $result['success'] ) ) {
+			\DataMachine\Engine\AuditLogger::record(
+				'memory.write',
+				'allowed',
+				array(
+					'agent_id' => $agent_id,
+					'metadata' => array(
+						'section' => $section,
+						'mode'    => $mode,
+					),
+				)
+			);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -235,6 +235,20 @@ class RunFlowAbility {
 			)
 		);
 
+		\DataMachine\Engine\AuditLogger::record(
+			'flow.run',
+			'allowed',
+			array(
+				'agent_id'      => (int) ( $flow['agent_id'] ?? 0 ),
+				'resource_type' => 'flow',
+				'resource_id'   => $flow_id,
+				'metadata'      => array(
+					'job_id'      => $job_id,
+					'pipeline_id' => $pipeline_id,
+				),
+			)
+		);
+
 		return array(
 			'success'    => true,
 			'flow_id'    => $flow_id,

--- a/inc/Abilities/Pipeline/CreatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/CreatePipelineAbility.php
@@ -250,6 +250,20 @@ class CreatePipelineAbility {
 			)
 		);
 
+		\DataMachine\Engine\AuditLogger::record(
+			'pipeline.create',
+			'allowed',
+			array(
+				'resource_type' => 'pipeline',
+				'resource_id'   => $pipeline_id,
+				'metadata'      => array(
+					'pipeline_name' => $pipeline_name,
+					'steps_created' => $steps_created,
+					'flow_id'       => $flow_result['flow_id'] ?? null,
+				),
+			)
+		);
+
 		return array(
 			'success'       => true,
 			'pipeline_id'   => $pipeline_id,

--- a/inc/Abilities/Pipeline/DeletePipelineAbility.php
+++ b/inc/Abilities/Pipeline/DeletePipelineAbility.php
@@ -148,6 +148,19 @@ class DeletePipelineAbility {
 			)
 		);
 
+		\DataMachine\Engine\AuditLogger::record(
+			'pipeline.delete',
+			'allowed',
+			array(
+				'resource_type' => 'pipeline',
+				'resource_id'   => $pipeline_id,
+				'metadata'      => array(
+					'pipeline_name' => $pipeline_name,
+					'deleted_flows' => $flow_count,
+				),
+			)
+		);
+
 		return array(
 			'success'       => true,
 			'pipeline_id'   => $pipeline_id,

--- a/inc/Api/AgentLog.php
+++ b/inc/Api/AgentLog.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * REST API Agent Log Endpoint
+ *
+ * Provides queryable audit trail for agent actions.
+ *
+ * @package DataMachine\Api
+ * @since 0.42.0
+ */
+
+namespace DataMachine\Api;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Database\Agents\AgentLog as AgentLogRepository;
+use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
+use WP_REST_Request;
+use WP_REST_Server;
+use WP_Error;
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+class AgentLog {
+
+	/**
+	 * Register REST API routes.
+	 */
+	public static function register(): void {
+		add_action( 'rest_api_init', array( self::class, 'register_routes' ) );
+	}
+
+	/**
+	 * Register /datamachine/v1/agents/<id>/log route.
+	 */
+	public static function register_routes(): void {
+		register_rest_route(
+			'datamachine/v1',
+			'/agents/(?P<agent_id>\d+)/log',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( self::class, 'handle_list' ),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'args'                => array(
+					'agent_id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'action'   => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'result'   => array(
+						'type' => 'string',
+						'enum' => array( 'allowed', 'denied', 'error' ),
+					),
+					'resource_type' => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'period'   => array(
+						'type'    => 'string',
+						'default' => '7d',
+						'enum'    => array( '1h', '24h', '7d', '30d', 'all' ),
+					),
+					'per_page' => array(
+						'type'    => 'integer',
+						'default' => 50,
+						'minimum' => 1,
+						'maximum' => 200,
+					),
+					'page'     => array(
+						'type'    => 'integer',
+						'default' => 1,
+						'minimum' => 1,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission callback — operators and admins can view agent logs.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return true|WP_Error
+	 */
+	public static function check_permission( WP_REST_Request $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to view agent logs.', 'data-machine' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		$agent_id = (int) $request->get_param( 'agent_id' );
+		if ( ! PermissionHelper::can_access_agent( $agent_id, 'operator' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to view this agent\'s logs.', 'data-machine' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Handle GET /agents/{id}/log — list audit log entries.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public static function handle_list( WP_REST_Request $request ) {
+		$agent_id = (int) $request->get_param( 'agent_id' );
+
+		// Verify agent exists.
+		$agents_repo = new AgentsRepository();
+		$agent       = $agents_repo->get_agent( $agent_id );
+		if ( ! $agent ) {
+			return new WP_Error(
+				'agent_not_found',
+				__( 'Agent not found.', 'data-machine' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$filters = array(
+			'per_page' => (int) $request->get_param( 'per_page' ),
+			'page'     => (int) $request->get_param( 'page' ),
+		);
+
+		// Map period to since datetime.
+		$period = $request->get_param( 'period' );
+		if ( 'all' !== $period ) {
+			$since = self::period_to_datetime( $period );
+			if ( $since ) {
+				$filters['since'] = $since;
+			}
+		}
+
+		// Optional filters.
+		$action = $request->get_param( 'action' );
+		if ( $action ) {
+			$filters['action'] = $action;
+		}
+
+		$result = $request->get_param( 'result' );
+		if ( $result ) {
+			$filters['result'] = $result;
+		}
+
+		$resource_type = $request->get_param( 'resource_type' );
+		if ( $resource_type ) {
+			$filters['resource_type'] = $resource_type;
+		}
+
+		$log_repo = new AgentLogRepository();
+		$data     = $log_repo->get_for_agent( $agent_id, $filters );
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'data'    => $data['items'],
+				'meta'    => array(
+					'total' => $data['total'],
+					'page'  => $data['page'],
+					'pages' => $data['pages'],
+				),
+			)
+		);
+	}
+
+	/**
+	 * Convert a period string to a UTC datetime.
+	 *
+	 * @param string $period Period string (1h, 24h, 7d, 30d).
+	 * @return string|null UTC datetime string, or null for invalid input.
+	 */
+	private static function period_to_datetime( string $period ): ?string {
+		$intervals = array(
+			'1h'  => '-1 hour',
+			'24h' => '-24 hours',
+			'7d'  => '-7 days',
+			'30d' => '-30 days',
+		);
+
+		if ( ! isset( $intervals[ $period ] ) ) {
+			return null;
+		}
+
+		$dt = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
+		$dt->modify( $intervals[ $period ] );
+
+		return $dt->format( 'Y-m-d H:i:s' );
+	}
+}

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -13,6 +13,8 @@ namespace DataMachine\Cli\Commands;
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\AgentAbilities;
+use DataMachine\Core\Database\Agents\AgentLog;
+use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 
 defined( 'ABSPATH' ) || exit;
@@ -134,5 +136,147 @@ class AgentsCommand extends BaseCommand {
 		} else {
 			WP_CLI::error( $result['message'] );
 		}
+	}
+
+	/**
+	 * View audit trail for an agent.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <agent-slug>
+	 * : Agent slug to view logs for.
+	 *
+	 * [--period=<period>]
+	 * : Time period to show.
+	 * ---
+	 * default: 7d
+	 * options:
+	 *   - 1h
+	 *   - 24h
+	 *   - 7d
+	 *   - 30d
+	 *   - all
+	 * ---
+	 *
+	 * [--action=<action>]
+	 * : Filter by action (e.g. flow.run, pipeline.create, job.fail).
+	 *
+	 * [--result=<result>]
+	 * : Filter by result.
+	 * ---
+	 * options:
+	 *   - allowed
+	 *   - denied
+	 *   - error
+	 * ---
+	 *
+	 * [--limit=<limit>]
+	 * : Maximum entries to show.
+	 * ---
+	 * default: 50
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine agents log chubes-bot
+	 *     wp datamachine agents log chubes-bot --period=24h
+	 *     wp datamachine agents log chubes-bot --action=flow.run --result=error
+	 *     wp datamachine agents log chubes-bot --format=json
+	 *
+	 * @subcommand log
+	 */
+	public function log( array $args, array $assoc_args ): void {
+		$agent_slug = sanitize_title( $args[0] );
+		$agents_repo = new Agents();
+		$agent       = $agents_repo->get_by_slug( $agent_slug );
+
+		if ( ! $agent ) {
+			WP_CLI::error( sprintf( 'Agent "%s" not found.', $agent_slug ) );
+		}
+
+		$agent_id = (int) $agent['agent_id'];
+		$period   = $assoc_args['period'] ?? '7d';
+		$limit    = (int) ( $assoc_args['limit'] ?? 50 );
+
+		$filters = array( 'per_page' => $limit );
+
+		// Map period to since datetime.
+		if ( 'all' !== $period ) {
+			$intervals = array(
+				'1h'  => '-1 hour',
+				'24h' => '-24 hours',
+				'7d'  => '-7 days',
+				'30d' => '-30 days',
+			);
+
+			if ( isset( $intervals[ $period ] ) ) {
+				$dt = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
+				$dt->modify( $intervals[ $period ] );
+				$filters['since'] = $dt->format( 'Y-m-d H:i:s' );
+			}
+		}
+
+		if ( ! empty( $assoc_args['action'] ) ) {
+			$filters['action'] = sanitize_text_field( $assoc_args['action'] );
+		}
+
+		if ( ! empty( $assoc_args['result'] ) ) {
+			$filters['result'] = sanitize_text_field( $assoc_args['result'] );
+		}
+
+		$log_repo = new AgentLog();
+		$data     = $log_repo->get_for_agent( $agent_id, $filters );
+
+		if ( empty( $data['items'] ) ) {
+			WP_CLI::warning( sprintf( 'No audit log entries found for "%s" in the %s period.', $agent_slug, $period ) );
+			return;
+		}
+
+		// Format items for display.
+		$items = array();
+		foreach ( $data['items'] as $entry ) {
+			$metadata_str = '';
+			if ( ! empty( $entry['metadata'] ) && is_array( $entry['metadata'] ) ) {
+				$parts = array();
+				foreach ( $entry['metadata'] as $key => $value ) {
+					$parts[] = "{$key}=" . ( is_scalar( $value ) ? $value : wp_json_encode( $value ) );
+				}
+				$metadata_str = implode( ', ', $parts );
+			}
+
+			$items[] = array(
+				'id'            => (int) $entry['id'],
+				'action'        => $entry['action'],
+				'result'        => $entry['result'],
+				'resource_type' => $entry['resource_type'] ?? '-',
+				'resource_id'   => $entry['resource_id'] ?? '-',
+				'user_id'       => $entry['user_id'] ?? '-',
+				'metadata'      => $metadata_str ?: '-',
+				'created_at'    => $entry['created_at'],
+			);
+		}
+
+		$fields = array( 'id', 'action', 'result', 'resource_type', 'resource_id', 'created_at' );
+
+		// Show metadata in JSON format.
+		$format = $assoc_args['format'] ?? 'table';
+		if ( 'json' === $format || 'yaml' === $format ) {
+			$fields[] = 'user_id';
+			$fields[] = 'metadata';
+		}
+
+		$this->format_items( $items, $fields, $assoc_args, 'id' );
+		WP_CLI::log( sprintf( 'Showing %d of %d entries.', count( $items ), $data['total'] ) );
 	}
 }

--- a/inc/Core/ActionScheduler/AuditCleanup.php
+++ b/inc/Core/ActionScheduler/AuditCleanup.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Audit Log Cleanup
+ *
+ * Periodically removes old audit log entries to prevent indefinite
+ * accumulation. Default retention: 30 days.
+ *
+ * @package DataMachine\Core\ActionScheduler
+ * @since 0.42.0
+ */
+
+namespace DataMachine\Core\ActionScheduler;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the cleanup action handler.
+ */
+add_action(
+	'datamachine_cleanup_audit_log',
+	function () {
+		$log_repo = new \DataMachine\Core\Database\Agents\AgentLog();
+
+		/**
+		 * Filter the maximum age (in days) for audit log entries before cleanup.
+		 *
+		 * Entries older than this threshold will be deleted.
+		 *
+		 * @since 0.42.0
+		 *
+		 * @param int $max_age_days Maximum age in days. Default 30.
+		 */
+		$max_age_days = (int) apply_filters( 'datamachine_audit_log_max_age_days', 30 );
+
+		if ( $max_age_days < 1 ) {
+			$max_age_days = 30;
+		}
+
+		$cutoff_date = gmdate( 'Y-m-d H:i:s', time() - ( $max_age_days * DAY_IN_SECONDS ) );
+		$deleted     = $log_repo->prune_before( $cutoff_date );
+
+		if ( false !== $deleted && $deleted > 0 ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Scheduled cleanup: deleted old audit log entries',
+				array(
+					'entries_deleted' => $deleted,
+					'max_age_days'    => $max_age_days,
+				)
+			);
+		}
+	}
+);
+
+/**
+ * Schedule the cleanup job after Action Scheduler is initialized.
+ * Only runs in admin context to avoid database queries on frontend.
+ */
+add_action(
+	'action_scheduler_init',
+	function () {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		if ( ! as_next_scheduled_action( 'datamachine_cleanup_audit_log', array(), 'datamachine-maintenance' ) ) {
+			as_schedule_recurring_action(
+				time() + DAY_IN_SECONDS,
+				DAY_IN_SECONDS,
+				'datamachine_cleanup_audit_log',
+				array(),
+				'datamachine-maintenance'
+			);
+		}
+	}
+);

--- a/inc/Core/Database/Agents/AgentAccess.php
+++ b/inc/Core/Database/Agents/AgentAccess.php
@@ -92,22 +92,41 @@ class AgentAccess extends BaseRepository {
 				array( '%d', '%d' )
 			);
 
-			return false !== $result;
+			$success = false !== $result;
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$result = $this->wpdb->insert(
+				$this->table_name,
+				array(
+					'agent_id'   => $agent_id,
+					'user_id'    => $user_id,
+					'role'       => $role,
+					'granted_at' => current_time( 'mysql', true ),
+				),
+				array( '%d', '%d', '%s', '%s' )
+			);
+
+			$success = false !== $result;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-		$result = $this->wpdb->insert(
-			$this->table_name,
-			array(
-				'agent_id'   => $agent_id,
-				'user_id'    => $user_id,
-				'role'       => $role,
-				'granted_at' => current_time( 'mysql', true ),
-			),
-			array( '%d', '%d', '%s', '%s' )
-		);
+		if ( $success && class_exists( '\\DataMachine\\Engine\\AuditLogger' ) ) {
+			\DataMachine\Engine\AuditLogger::record(
+				'agent.access.grant',
+				'allowed',
+				array(
+					'agent_id'      => $agent_id,
+					'resource_type' => 'agent',
+					'resource_id'   => $agent_id,
+					'metadata'      => array(
+						'granted_user_id' => $user_id,
+						'role'            => $role,
+						'was_update'      => null !== $existing,
+					),
+				)
+			);
+		}
 
-		return false !== $result;
+		return $success;
 	}
 
 	/**
@@ -128,7 +147,24 @@ class AgentAccess extends BaseRepository {
 			array( '%d', '%d' )
 		);
 
-		return false !== $result && $result > 0;
+		$success = false !== $result && $result > 0;
+
+		if ( $success && class_exists( '\\DataMachine\\Engine\\AuditLogger' ) ) {
+			\DataMachine\Engine\AuditLogger::record(
+				'agent.access.revoke',
+				'allowed',
+				array(
+					'agent_id'      => $agent_id,
+					'resource_type' => 'agent',
+					'resource_id'   => $agent_id,
+					'metadata'      => array(
+						'revoked_user_id' => $user_id,
+					),
+				)
+			);
+		}
+
+		return $success;
 	}
 
 	/**

--- a/inc/Core/Database/Agents/AgentLog.php
+++ b/inc/Core/Database/Agents/AgentLog.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Agent Audit Log Repository
+ *
+ * Structured audit trail for agent actions. Every ability invocation,
+ * permission check, and resource mutation by an agent is recorded here.
+ *
+ * Separate from Monolog operational logs — this is queryable by agent,
+ * action, time range, and result for compliance and debugging.
+ *
+ * @package DataMachine\Core\Database\Agents
+ * @since 0.42.0
+ */
+
+namespace DataMachine\Core\Database\Agents;
+
+use DataMachine\Core\Database\BaseRepository;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class AgentLog extends BaseRepository {
+
+	/**
+	 * Table name (without prefix).
+	 */
+	const TABLE_NAME = 'datamachine_agent_log';
+
+	/**
+	 * Valid result values.
+	 */
+	const VALID_RESULTS = array( 'allowed', 'denied', 'error' );
+
+	/**
+	 * Create agent_log table.
+	 *
+	 * @return void
+	 */
+	public static function create_table(): void {
+		global $wpdb;
+
+		$table_name      = $wpdb->prefix . self::TABLE_NAME;
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE {$table_name} (
+			id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+			agent_id BIGINT(20) UNSIGNED NOT NULL,
+			user_id BIGINT(20) UNSIGNED DEFAULT NULL,
+			action VARCHAR(255) NOT NULL,
+			resource_type VARCHAR(100) DEFAULT NULL,
+			resource_id BIGINT(20) UNSIGNED DEFAULT NULL,
+			result VARCHAR(20) NOT NULL DEFAULT 'allowed',
+			metadata LONGTEXT DEFAULT NULL,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			KEY idx_agent_time (agent_id, created_at),
+			KEY idx_action (action),
+			KEY idx_result_time (result, created_at),
+			KEY idx_resource (resource_type, resource_id)
+		) {$charset_collate};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Record an audit log entry.
+	 *
+	 * @param int    $agent_id      Agent ID.
+	 * @param string $action        Action identifier (e.g. 'flow.run', 'pipeline.create').
+	 * @param string $result        Result: 'allowed', 'denied', or 'error'.
+	 * @param array  $options {
+	 *     Optional parameters.
+	 *
+	 *     @type int    $user_id       Acting user ID.
+	 *     @type string $resource_type Resource type (e.g. 'flow', 'pipeline', 'job').
+	 *     @type int    $resource_id   Resource ID.
+	 *     @type array  $metadata      Additional context (stored as JSON).
+	 * }
+	 * @return int|false Inserted row ID, or false on failure.
+	 */
+	public function log( int $agent_id, string $action, string $result = 'allowed', array $options = array() ) {
+		if ( ! in_array( $result, self::VALID_RESULTS, true ) ) {
+			$result = 'allowed';
+		}
+
+		$data = array(
+			'agent_id'   => $agent_id,
+			'action'     => mb_substr( $action, 0, 255 ),
+			'result'     => $result,
+			'created_at' => current_time( 'mysql', true ),
+		);
+
+		$formats = array( '%d', '%s', '%s', '%s' );
+
+		// Optional user_id.
+		if ( isset( $options['user_id'] ) && $options['user_id'] > 0 ) {
+			$data['user_id'] = (int) $options['user_id'];
+			$formats[]       = '%d';
+		}
+
+		// Optional resource_type.
+		if ( ! empty( $options['resource_type'] ) ) {
+			$data['resource_type'] = mb_substr( sanitize_text_field( $options['resource_type'] ), 0, 100 );
+			$formats[]             = '%s';
+		}
+
+		// Optional resource_id.
+		if ( isset( $options['resource_id'] ) && $options['resource_id'] > 0 ) {
+			$data['resource_id'] = (int) $options['resource_id'];
+			$formats[]           = '%d';
+		}
+
+		// Optional metadata.
+		if ( ! empty( $options['metadata'] ) && is_array( $options['metadata'] ) ) {
+			$data['metadata'] = wp_json_encode( $options['metadata'] );
+			$formats[]        = '%s';
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$inserted = $this->wpdb->insert( $this->table_name, $data, $formats );
+
+		if ( false === $inserted ) {
+			$this->log_db_error( 'AgentLog::log insert failed', array( 'agent_id' => $agent_id, 'action' => $action ) );
+			return false;
+		}
+
+		return (int) $this->wpdb->insert_id;
+	}
+
+	/**
+	 * Get audit log entries for an agent with optional filters.
+	 *
+	 * @param int   $agent_id Agent ID.
+	 * @param array $filters {
+	 *     Optional filters.
+	 *
+	 *     @type string $action        Filter by action (exact match).
+	 *     @type string $result        Filter by result.
+	 *     @type string $resource_type Filter by resource type.
+	 *     @type string $since         ISO datetime — only entries after this time.
+	 *     @type string $before        ISO datetime — only entries before this time.
+	 *     @type int    $per_page      Items per page (default 50, max 200).
+	 *     @type int    $page          Page number (1-indexed, default 1).
+	 * }
+	 * @return array {
+	 *     @type array[] $items   Log entries.
+	 *     @type int     $total   Total matching entries.
+	 *     @type int     $page    Current page.
+	 *     @type int     $pages   Total pages.
+	 * }
+	 */
+	public function get_for_agent( int $agent_id, array $filters = array() ): array {
+		$where      = array( 'agent_id = %d' );
+		$params     = array( $agent_id );
+		$per_page   = min( max( (int) ( $filters['per_page'] ?? 50 ), 1 ), 200 );
+		$page       = max( (int) ( $filters['page'] ?? 1 ), 1 );
+		$offset     = ( $page - 1 ) * $per_page;
+
+		if ( ! empty( $filters['action'] ) ) {
+			$where[]  = 'action = %s';
+			$params[] = $filters['action'];
+		}
+
+		if ( ! empty( $filters['result'] ) && in_array( $filters['result'], self::VALID_RESULTS, true ) ) {
+			$where[]  = 'result = %s';
+			$params[] = $filters['result'];
+		}
+
+		if ( ! empty( $filters['resource_type'] ) ) {
+			$where[]  = 'resource_type = %s';
+			$params[] = $filters['resource_type'];
+		}
+
+		if ( ! empty( $filters['since'] ) ) {
+			$where[]  = 'created_at >= %s';
+			$params[] = $filters['since'];
+		}
+
+		if ( ! empty( $filters['before'] ) ) {
+			$where[]  = 'created_at <= %s';
+			$params[] = $filters['before'];
+		}
+
+		$where_sql = implode( ' AND ', $where );
+
+		// Count total.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$total = (int) $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				"SELECT COUNT(*) FROM {$this->table_name} WHERE {$where_sql}",
+				...$params
+			)
+		);
+
+		// Fetch items.
+		$items = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				"SELECT * FROM {$this->table_name} WHERE {$where_sql} ORDER BY created_at DESC LIMIT %d OFFSET %d",
+				...array_merge( $params, array( $per_page, $offset ) )
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		// Decode metadata JSON.
+		if ( $items ) {
+			foreach ( $items as &$item ) {
+				if ( ! empty( $item['metadata'] ) ) {
+					$decoded          = json_decode( $item['metadata'], true );
+					$item['metadata'] = is_array( $decoded ) ? $decoded : array();
+				} else {
+					$item['metadata'] = array();
+				}
+			}
+			unset( $item );
+		}
+
+		return array(
+			'items' => $items ?: array(),
+			'total' => $total,
+			'page'  => $page,
+			'pages' => (int) ceil( $total / $per_page ),
+		);
+	}
+
+	/**
+	 * Get recent log entries for an agent.
+	 *
+	 * @param int $agent_id Agent ID.
+	 * @param int $limit    Max entries to return (default 20).
+	 * @return array[] Log entries.
+	 */
+	public function get_recent( int $agent_id, int $limit = 20 ): array {
+		$result = $this->get_for_agent( $agent_id, array( 'per_page' => $limit ) );
+		return $result['items'];
+	}
+
+	/**
+	 * Count log entries for an agent.
+	 *
+	 * @param int   $agent_id Agent ID.
+	 * @param array $filters  Same filters as get_for_agent().
+	 * @return int Entry count.
+	 */
+	public function count_for_agent( int $agent_id, array $filters = array() ): int {
+		$result = $this->get_for_agent( $agent_id, array_merge( $filters, array( 'per_page' => 1 ) ) );
+		return $result['total'];
+	}
+
+	/**
+	 * Delete log entries older than a given datetime.
+	 *
+	 * @param string $before_datetime ISO datetime string (UTC).
+	 * @return int|false Number of deleted rows, or false on error.
+	 */
+	public function prune_before( string $before_datetime ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$deleted = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"DELETE FROM {$this->table_name} WHERE created_at < %s",
+				$before_datetime
+			)
+		);
+
+		return $deleted;
+	}
+}

--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -150,6 +150,25 @@ class FailJobHandler {
 			)
 		);
 
+		// Audit trail: record job failure.
+		$job = $db_jobs->get_job( $job_id );
+		if ( $job ) {
+			$agent_id = (int) ( is_array( $job ) ? ( $job['agent_id'] ?? 0 ) : ( $job->agent_id ?? 0 ) );
+			\DataMachine\Engine\AuditLogger::record(
+				'job.fail',
+				'error',
+				array(
+					'agent_id'      => $agent_id,
+					'resource_type' => 'job',
+					'resource_id'   => $job_id,
+					'metadata'      => array(
+						'reason'  => $specific_reason,
+						'flow_id' => (int) ( is_array( $job ) ? ( $job['flow_id'] ?? 0 ) : ( $job->flow_id ?? 0 ) ),
+					),
+				)
+			);
+		}
+
 		return true;
 	}
 }

--- a/inc/Engine/Actions/Handlers/JobCompleteHandler.php
+++ b/inc/Engine/Actions/Handlers/JobCompleteHandler.php
@@ -28,6 +28,29 @@ class JobCompleteHandler {
 		// stays as one_time — revert it so the UI correctly shows "Manual" instead of
 		// a stale one_time with a past timestamp.
 		self::cleanup_one_time_flow( $job_id );
+
+		// Audit trail: record job completion (success only — failures go through FailJobHandler).
+		if ( 0 !== strpos( $status, 'failed' ) ) {
+			$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
+			$job     = $db_jobs->get_job( $job_id );
+
+			if ( $job ) {
+				$agent_id = (int) ( is_array( $job ) ? ( $job['agent_id'] ?? 0 ) : ( $job->agent_id ?? 0 ) );
+				\DataMachine\Engine\AuditLogger::record(
+					'job.complete',
+					'allowed',
+					array(
+						'agent_id'      => $agent_id,
+						'resource_type' => 'job',
+						'resource_id'   => (int) $job_id,
+						'metadata'      => array(
+							'status'  => $status,
+							'flow_id' => (int) ( is_array( $job ) ? ( $job['flow_id'] ?? 0 ) : ( $job->flow_id ?? 0 ) ),
+						),
+					)
+				);
+			}
+		}
 	}
 
 	/**

--- a/inc/Engine/AuditLogger.php
+++ b/inc/Engine/AuditLogger.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Audit Logger
+ *
+ * Thin static helper for recording agent audit trail events.
+ * Resolves agent_id and user_id from the current execution context,
+ * then delegates to the AgentLog repository.
+ *
+ * Usage:
+ *
+ *     AuditLogger::record( 'flow.run', 'allowed', [
+ *         'resource_type' => 'flow',
+ *         'resource_id'   => 42,
+ *         'metadata'      => [ 'pipeline_id' => 7 ],
+ *     ] );
+ *
+ * @package DataMachine\Engine
+ * @since 0.42.0
+ */
+
+namespace DataMachine\Engine;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Database\Agents\AgentLog;
+use DataMachine\Core\Database\Agents\Agents;
+
+defined( 'ABSPATH' ) || exit;
+
+class AuditLogger {
+
+	/**
+	 * Record an audit event for the current agent context.
+	 *
+	 * Resolves agent_id automatically from:
+	 * 1. Explicit agent_id in $options
+	 * 2. PermissionHelper context (request param, pre-authenticated context)
+	 * 3. Owner lookup from acting user
+	 *
+	 * If no agent can be resolved, the event is silently dropped
+	 * (single-agent installs with no agent row).
+	 *
+	 * @param string $action  Action identifier (e.g. 'flow.run', 'pipeline.create').
+	 * @param string $result  Result: 'allowed', 'denied', or 'error'. Default 'allowed'.
+	 * @param array  $options {
+	 *     Optional parameters.
+	 *
+	 *     @type int    $agent_id       Explicit agent ID (skips auto-resolution).
+	 *     @type int    $user_id        Acting user ID (defaults to PermissionHelper::acting_user_id()).
+	 *     @type string $resource_type  Resource type (e.g. 'flow', 'pipeline', 'job').
+	 *     @type int    $resource_id    Resource ID.
+	 *     @type array  $metadata       Additional context (stored as JSON).
+	 * }
+	 * @return void
+	 */
+	public static function record( string $action, string $result = 'allowed', array $options = array() ): void {
+		$agent_id = self::resolve_agent_id( $options );
+
+		if ( 0 === $agent_id ) {
+			// No agent context — silently skip (single-agent mode without agent row).
+			return;
+		}
+
+		$user_id = (int) ( $options['user_id'] ?? PermissionHelper::acting_user_id() );
+
+		$log_options = array(
+			'user_id' => $user_id,
+		);
+
+		if ( ! empty( $options['resource_type'] ) ) {
+			$log_options['resource_type'] = $options['resource_type'];
+		}
+
+		if ( ! empty( $options['resource_id'] ) ) {
+			$log_options['resource_id'] = (int) $options['resource_id'];
+		}
+
+		if ( ! empty( $options['metadata'] ) && is_array( $options['metadata'] ) ) {
+			$log_options['metadata'] = $options['metadata'];
+		}
+
+		$repo = new AgentLog();
+		$repo->log( $agent_id, $action, $result, $log_options );
+
+		/**
+		 * Fires after an audit event is recorded.
+		 *
+		 * @since 0.42.0
+		 *
+		 * @param array $event {
+		 *     @type int    $agent_id      Agent ID.
+		 *     @type int    $user_id       Acting user ID.
+		 *     @type string $action        Action identifier.
+		 *     @type string $result        Result (allowed, denied, error).
+		 *     @type string $resource_type Resource type.
+		 *     @type int    $resource_id   Resource ID.
+		 *     @type array  $metadata      Additional context.
+		 * }
+		 */
+		do_action(
+			'datamachine_audit_event',
+			array_merge(
+				array(
+					'agent_id' => $agent_id,
+					'user_id'  => $user_id,
+					'action'   => $action,
+					'result'   => $result,
+				),
+				$log_options
+			)
+		);
+	}
+
+	/**
+	 * Resolve agent_id from options or current context.
+	 *
+	 * @param array $options Options that may contain agent_id.
+	 * @return int Agent ID, or 0 if none could be resolved.
+	 */
+	private static function resolve_agent_id( array $options ): int {
+		// 1. Explicit agent_id.
+		if ( ! empty( $options['agent_id'] ) ) {
+			return (int) $options['agent_id'];
+		}
+
+		// 2. Look up from acting user's owned agent.
+		$user_id = PermissionHelper::acting_user_id();
+		if ( $user_id > 0 ) {
+			$agents_repo = new Agents();
+			$agent       = $agents_repo->get_by_owner_id( $user_id );
+
+			if ( $agent ) {
+				return (int) $agent['agent_id'];
+			}
+		}
+
+		return 0;
+	}
+}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -70,6 +70,7 @@ require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineSystemPromptDirective.
 require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php';
 require_once __DIR__ . '/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php';
 require_once __DIR__ . '/Core/FilesRepository/FileCleanup.php';
+require_once __DIR__ . '/Core/ActionScheduler/AuditCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/ClaimsCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/JobsCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/LogCleanup.php';


### PR DESCRIPTION
## Summary

Adds a **queryable audit trail** for all agent actions. Every ability invocation, permission change, and resource mutation is recorded in a structured database table — separate from Monolog operational logs, designed for compliance queries and debugging.

**Part of the agent-as-service-account architecture** (follows #738, precedes #740 agent runtime auth).

## What's new

### Database
- `datamachine_agent_log` table — structured rows with `agent_id`, `action`, `result`, `resource_type`, `resource_id`, JSON `metadata`, timestamps
- Indexes on `(agent_id, created_at)`, `action`, `(result, created_at)`, `(resource_type, resource_id)`

### Core
- **`AuditLogger::record()`** — static helper that resolves agent context from `PermissionHelper` automatically, then writes to DB and fires `datamachine_audit_event` action for extensibility
- **`AgentLog` repository** — full CRUD with paginated filtered queries and bulk prune

### REST API
- `GET /datamachine/v1/agents/{id}/log` — paginated, filterable by `period` (1h/24h/7d/30d/all), `action`, `result`, `resource_type`
- Permission: `can_access_agent($id, 'operator')` — operators and admins

### CLI
- `wp datamachine agents log <slug>` with `--period`, `--action`, `--result`, `--limit`, `--format`

### Retention
- `AuditCleanup` Action Scheduler task — daily recurring, 30-day default (filterable via `datamachine_audit_log_max_age_days`)
- Unscheduled on plugin deactivation

### Audit hooks (8 trigger points)

| Action | Location | Trigger |
|---|---|---|
| `flow.run` | RunFlowAbility | Flow execution started |
| `job.complete` | JobCompleteHandler | Job finished successfully |
| `job.fail` | FailJobHandler | Job failed |
| `pipeline.create` | CreatePipelineAbility | Pipeline created |
| `pipeline.delete` | DeletePipelineAbility | Pipeline deleted |
| `agent.access.grant` | AgentAccess | Access granted/updated |
| `agent.access.revoke` | AgentAccess | Access revoked |
| `memory.write` | AgentMemoryAbilities | Agent memory modified |

## Architecture

```
Agent action occurs (flow.run, pipeline.create, etc.)
    │
    ▼
AuditLogger::record('flow.run', 'allowed', options)
    │
    ├── Resolves agent_id from PermissionHelper context
    ├── Resolves user_id from PermissionHelper::acting_user_id()
    ├── Writes to datamachine_agent_log table
    └── Fires do_action('datamachine_audit_event', $event)
```

## Testing

- 764 tests, 0 failures (full suite passes)
- All 14 files pass `php -l` syntax check
- New files follow existing patterns: `BaseRepository`, `ActionScheduler` cleanup, REST API registration

## Future hooks (when #740/#741 land)

- `auth.token.used` — bearer token authenticated
- `auth.token.failed` — invalid token attempt  
- `policy.denied` — tool policy blocked an ability

Closes #742