### PR TITLE
feat(#741): unify tool registry — single datamachine_tools filter with context arrays

### DIFF
--- a/inc/Abilities/Content/EditPostBlocksAbility.php
+++ b/inc/Abilities/Content/EditPostBlocksAbility.php
@@ -99,9 +99,12 @@ class EditPostBlocksAbility {
 
 	private function registerChatTool(): void {
 		add_filter(
-			'datamachine_chat_tools',
+			'datamachine_tools',
 			function ( $tools ) {
-				$tools['edit_post_blocks'] = array( self::class, 'getChatTool' );
+				$tools['edit_post_blocks'] = array(
+					'_callable' => array( self::class, 'getChatTool' ),
+					'contexts'  => array( 'chat' ),
+				);
 				return $tools;
 			}
 		);

--- a/inc/Abilities/Content/GetPostBlocksAbility.php
+++ b/inc/Abilities/Content/GetPostBlocksAbility.php
@@ -93,9 +93,12 @@ class GetPostBlocksAbility {
 
 	private function registerChatTool(): void {
 		add_filter(
-			'datamachine_chat_tools',
+			'datamachine_tools',
 			function ( $tools ) {
-				$tools['get_post_blocks'] = array( self::class, 'getChatTool' );
+				$tools['get_post_blocks'] = array(
+					'_callable' => array( self::class, 'getChatTool' ),
+					'contexts'  => array( 'chat' ),
+				);
 				return $tools;
 			}
 		);

--- a/inc/Abilities/Content/ReplacePostBlocksAbility.php
+++ b/inc/Abilities/Content/ReplacePostBlocksAbility.php
@@ -94,9 +94,12 @@ class ReplacePostBlocksAbility {
 
 	private function registerChatTool(): void {
 		add_filter(
-			'datamachine_chat_tools',
+			'datamachine_tools',
 			function ( $tools ) {
-				$tools['replace_post_blocks'] = array( self::class, 'getChatTool' );
+				$tools['replace_post_blocks'] = array(
+					'_callable' => array( self::class, 'getChatTool' ),
+					'contexts'  => array( 'chat' ),
+				);
 				return $tools;
 			}
 		);

--- a/inc/Abilities/PostQueryAbilities.php
+++ b/inc/Abilities/PostQueryAbilities.php
@@ -188,9 +188,12 @@ class PostQueryAbilities {
 
 	private function registerChatTool(): void {
 		add_filter(
-			'datamachine_chat_tools',
+			'datamachine_tools',
 			function ( $tools ) {
-				$tools['query_posts'] = array( $this, 'getQueryPostsTool' );
+				$tools['query_posts'] = array(
+					'_callable' => array( $this, 'getQueryPostsTool' ),
+					'contexts'  => array( 'chat' ),
+				);
 				return $tools;
 			}
 		);

--- a/inc/Api/Chat/Tools/AddPipelineStep.php
+++ b/inc/Api/Chat/Tools/AddPipelineStep.php
@@ -21,7 +21,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class AddPipelineStep extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'add_pipeline_step', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'add_pipeline_step', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	private static function getValidStepTypes(): array {

--- a/inc/Api/Chat/Tools/ApiQuery.php
+++ b/inc/Api/Chat/Tools/ApiQuery.php
@@ -24,7 +24,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ApiQuery extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'api_query', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'api_query', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/AssignTaxonomyTerm.php
+++ b/inc/Api/Chat/Tools/AssignTaxonomyTerm.php
@@ -21,7 +21,7 @@ use DataMachine\Abilities\Taxonomy\ResolveTermAbility;
 class AssignTaxonomyTerm extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'assign_taxonomy_term', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'assign_taxonomy_term', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/AuthenticateHandler.php
+++ b/inc/Api/Chat/Tools/AuthenticateHandler.php
@@ -23,7 +23,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class AuthenticateHandler extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'authenticate_handler', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'authenticate_handler', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ConfigureFlowSteps.php
+++ b/inc/Api/Chat/Tools/ConfigureFlowSteps.php
@@ -21,7 +21,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ConfigureFlowSteps extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'configure_flow_steps', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'configure_flow_steps', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ConfigurePipelineStep.php
+++ b/inc/Api/Chat/Tools/ConfigurePipelineStep.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ConfigurePipelineStep extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'configure_pipeline_step', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'configure_pipeline_step', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/CopyFlow.php
+++ b/inc/Api/Chat/Tools/CopyFlow.php
@@ -21,7 +21,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class CopyFlow extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'copy_flow', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'copy_flow', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/CreateFlow.php
+++ b/inc/Api/Chat/Tools/CreateFlow.php
@@ -21,7 +21,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class CreateFlow extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'create_flow', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'create_flow', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/CreatePipeline.php
+++ b/inc/Api/Chat/Tools/CreatePipeline.php
@@ -21,7 +21,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class CreatePipeline extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'create_pipeline', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'create_pipeline', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	private static function getValidStepTypes(): array {

--- a/inc/Api/Chat/Tools/CreateTaxonomyTerm.php
+++ b/inc/Api/Chat/Tools/CreateTaxonomyTerm.php
@@ -21,7 +21,7 @@ use DataMachine\Abilities\Taxonomy\ResolveTermAbility;
 class CreateTaxonomyTerm extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'create_taxonomy_term', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'create_taxonomy_term', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/DeleteFile.php
+++ b/inc/Api/Chat/Tools/DeleteFile.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class DeleteFile extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'delete_file', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'delete_file', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/DeleteFlow.php
+++ b/inc/Api/Chat/Tools/DeleteFlow.php
@@ -18,7 +18,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class DeleteFlow extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'delete_flow', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'delete_flow', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/DeletePipeline.php
+++ b/inc/Api/Chat/Tools/DeletePipeline.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class DeletePipeline extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'delete_pipeline', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'delete_pipeline', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/DeletePipelineStep.php
+++ b/inc/Api/Chat/Tools/DeletePipelineStep.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class DeletePipelineStep extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'delete_pipeline_step', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'delete_pipeline_step', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
+++ b/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ExecuteWorkflowTool extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'execute_workflow', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'execute_workflow', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/GetHandlerDefaults.php
+++ b/inc/Api/Chat/Tools/GetHandlerDefaults.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class GetHandlerDefaults extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'get_handler_defaults', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'get_handler_defaults', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/GetProblemFlows.php
+++ b/inc/Api/Chat/Tools/GetProblemFlows.php
@@ -24,7 +24,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class GetProblemFlows extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'get_problem_flows', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'get_problem_flows', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ListFlows.php
+++ b/inc/Api/Chat/Tools/ListFlows.php
@@ -17,7 +17,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ListFlows extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'list_flows', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'list_flows', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/ManageJobs.php
+++ b/inc/Api/Chat/Tools/ManageJobs.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ManageJobs extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'manage_jobs', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'manage_jobs', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ManageLogs.php
+++ b/inc/Api/Chat/Tools/ManageLogs.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ManageLogs extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'manage_logs', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'manage_logs', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ManageQueue.php
+++ b/inc/Api/Chat/Tools/ManageQueue.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ManageQueue extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'manage_queue', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'manage_queue', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/MergeTaxonomyTerms.php
+++ b/inc/Api/Chat/Tools/MergeTaxonomyTerms.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class MergeTaxonomyTerms extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'merge_taxonomy_terms', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'merge_taxonomy_terms', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/ReadLogs.php
+++ b/inc/Api/Chat/Tools/ReadLogs.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ReadLogs extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'read_logs', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'read_logs', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/ReorderPipelineSteps.php
+++ b/inc/Api/Chat/Tools/ReorderPipelineSteps.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ReorderPipelineSteps extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'reorder_pipeline_steps', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'reorder_pipeline_steps', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/RunFlow.php
+++ b/inc/Api/Chat/Tools/RunFlow.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class RunFlow extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'run_flow', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'run_flow', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/SearchTaxonomyTerms.php
+++ b/inc/Api/Chat/Tools/SearchTaxonomyTerms.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class SearchTaxonomyTerms extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'search_taxonomy_terms', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'search_taxonomy_terms', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/SendPing.php
+++ b/inc/Api/Chat/Tools/SendPing.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class SendPing extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'send_ping', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'send_ping', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/SetHandlerDefaults.php
+++ b/inc/Api/Chat/Tools/SetHandlerDefaults.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class SetHandlerDefaults extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'set_handler_defaults', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'set_handler_defaults', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/SystemHealthCheck.php
+++ b/inc/Api/Chat/Tools/SystemHealthCheck.php
@@ -19,7 +19,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class SystemHealthCheck extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'system_health_check', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'system_health_check', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/UpdateFlow.php
+++ b/inc/Api/Chat/Tools/UpdateFlow.php
@@ -18,7 +18,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class UpdateFlow extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'update_flow', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'update_flow', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	/**

--- a/inc/Api/Chat/Tools/UpdateTaxonomyTerm.php
+++ b/inc/Api/Chat/Tools/UpdateTaxonomyTerm.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class UpdateTaxonomyTerm extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'update_taxonomy_term', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'update_taxonomy_term', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Engine/AI/Tools/BaseTool.php
+++ b/inc/Engine/AI/Tools/BaseTool.php
@@ -23,49 +23,42 @@ abstract class BaseTool {
 	protected bool $async = false;
 
 	/**
-	 * Register a tool for any agent type.
+	 * Register a tool with the unified tool registry.
 	 *
-	 * Agent-agnostic tool registration that dynamically creates the appropriate filter
-	 * based on the agent type. Enables unlimited agent specialization while maintaining
-	 * consistent registration patterns.
+	 * All tools register via the single `datamachine_tools` filter. Each tool
+	 * must declare its contexts — the surfaces where it's available (e.g.
+	 * 'chat', 'pipeline', 'standalone').
+	 *
+	 * When the definition is a callable (for lazy evaluation), the contexts
+	 * are stored alongside so they're available before the callable is resolved.
+	 * The ToolManager merges contexts into the resolved definition.
 	 *
 	 * IMPORTANT: Pass a callable (e.g., [$this, 'getToolDefinition']) instead of
 	 * calling the method directly. This enables lazy evaluation after translations
 	 * are loaded, preventing WordPress 6.7+ translation timing errors.
 	 *
-	 * @param string         $agentType Agent type (global, chat, frontend, supportbot, etc.)
-	 * @param string         $toolName Tool identifier
-	 * @param array|callable $toolDefinition Tool definition array OR callable that returns it
+	 * @param string         $toolName       Tool identifier.
+	 * @param array|callable $toolDefinition Tool definition array OR callable that returns it.
+	 * @param array          $contexts       Contexts where this tool is available (e.g. ['chat', 'pipeline']).
 	 */
-	protected function registerTool( string $agentType, string $toolName, array|callable $toolDefinition ): void {
-		$filterName = "datamachine_{$agentType}_tools";
+	protected function registerTool( string $toolName, array|callable $toolDefinition, array $contexts = array() ): void {
 		add_filter(
-			$filterName,
-			function ( $tools ) use ( $toolName, $toolDefinition ) {
-				$tools[ $toolName ] = $toolDefinition;
+			'datamachine_tools',
+			function ( $tools ) use ( $toolName, $toolDefinition, $contexts ) {
+				if ( is_callable( $toolDefinition ) ) {
+					// Wrap callable with contexts for pre-resolution filtering.
+					$tools[ $toolName ] = array(
+						'_callable' => $toolDefinition,
+						'contexts'  => $contexts,
+					);
+				} else {
+					// Array definition — merge contexts directly.
+					$toolDefinition['contexts'] = $contexts;
+					$tools[ $toolName ]          = $toolDefinition;
+				}
 				return $tools;
 			}
 		);
-	}
-
-	/**
-	 * Register a global tool available to all AI agents.
-	 *
-	 * @param string         $tool_name Tool identifier
-	 * @param array|callable $tool_definition Tool definition array OR callable
-	 */
-	protected function registerGlobalTool( string $tool_name, array|callable $tool_definition ): void {
-		$this->registerTool( 'global', $tool_name, $tool_definition );
-	}
-
-	/**
-	 * Register a chat-specific tool.
-	 *
-	 * @param string         $tool_name Tool identifier
-	 * @param array|callable $tool_definition Tool definition array OR callable
-	 */
-	protected function registerChatTool( string $tool_name, array|callable $tool_definition ): void {
-		$this->registerTool( 'chat', $tool_name, $tool_definition );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/GitHubIssueTool.php
+++ b/inc/Engine/AI/Tools/GitHubIssueTool.php
@@ -26,7 +26,7 @@ class GitHubIssueTool extends BaseTool {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->registerGlobalTool( 'create_github_issue', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'create_github_issue', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
@@ -21,7 +21,7 @@ use DataMachine\Core\FilesRepository\DirectoryManager;
 class AgentDailyMemory extends BaseTool {
 
 	public function __construct() {
-		$this->registerGlobalTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/AgentMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentMemory.php
@@ -20,7 +20,7 @@ use DataMachine\Core\FilesRepository\DirectoryManager;
 class AgentMemory extends BaseTool {
 
 	public function __construct() {
-		$this->registerGlobalTool( 'agent_memory', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'agent_memory', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/AmazonAffiliateLink.php
+++ b/inc/Engine/AI/Tools/Global/AmazonAffiliateLink.php
@@ -84,7 +84,7 @@ class AmazonAffiliateLink extends BaseTool {
 	 */
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'amazon_affiliate_link' );
-		$this->registerGlobalTool( 'amazon_affiliate_link', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'amazon_affiliate_link', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/BingWebmaster.php
+++ b/inc/Engine/AI/Tools/Global/BingWebmaster.php
@@ -19,7 +19,7 @@ class BingWebmaster extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'bing_webmaster' );
-		$this->registerGlobalTool( 'bing_webmaster', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'bing_webmaster', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/GitHubTools.php
+++ b/inc/Engine/AI/Tools/Global/GitHubTools.php
@@ -23,11 +23,12 @@ class GitHubTools extends BaseTool {
 	 * Constructor — register all GitHub tools as global tools.
 	 */
 	public function __construct() {
-		$this->registerGlobalTool( 'list_github_issues', array( $this, 'getListIssuesDefinition' ) );
-		$this->registerGlobalTool( 'get_github_issue', array( $this, 'getGetIssueDefinition' ) );
-		$this->registerGlobalTool( 'manage_github_issue', array( $this, 'getManageIssueDefinition' ) );
-		$this->registerGlobalTool( 'list_github_pulls', array( $this, 'getListPullsDefinition' ) );
-		$this->registerGlobalTool( 'list_github_repos', array( $this, 'getListReposDefinition' ) );
+		$contexts = array( 'chat', 'pipeline', 'standalone' );
+		$this->registerTool( 'list_github_issues', array( $this, 'getListIssuesDefinition' ), $contexts );
+		$this->registerTool( 'get_github_issue', array( $this, 'getGetIssueDefinition' ), $contexts );
+		$this->registerTool( 'manage_github_issue', array( $this, 'getManageIssueDefinition' ), $contexts );
+		$this->registerTool( 'list_github_pulls', array( $this, 'getListPullsDefinition' ), $contexts );
+		$this->registerTool( 'list_github_repos', array( $this, 'getListReposDefinition' ), $contexts );
 	}
 
 	/**
@@ -78,7 +79,7 @@ class GitHubTools extends BaseTool {
 	/**
 	 * Get tool definition — returns the primary tool definition (list issues).
 	 *
-	 * Individual tools use their own definition methods via registerGlobalTool.
+	 * Individual tools use their own definition methods via registerTool.
 	 *
 	 * @return array Tool definition array.
 	 */

--- a/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
+++ b/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
@@ -20,7 +20,7 @@ class GoogleAnalytics extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'google_analytics' );
-		$this->registerGlobalTool( 'google_analytics', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'google_analytics', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/GoogleSearch.php
+++ b/inc/Engine/AI/Tools/Global/GoogleSearch.php
@@ -16,7 +16,7 @@ class GoogleSearch extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'google_search' );
-		$this->registerGlobalTool( 'google_search', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'google_search', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/GoogleSearchConsole.php
+++ b/inc/Engine/AI/Tools/Global/GoogleSearchConsole.php
@@ -19,7 +19,7 @@ class GoogleSearchConsole extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'google_search_console' );
-		$this->registerGlobalTool( 'google_search_console', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'google_search_console', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/ImageGeneration.php
+++ b/inc/Engine/AI/Tools/Global/ImageGeneration.php
@@ -26,7 +26,7 @@ class ImageGeneration extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'image_generation' );
-		$this->registerGlobalTool( 'image_generation', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'image_generation', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/InternalLinkAudit.php
+++ b/inc/Engine/AI/Tools/Global/InternalLinkAudit.php
@@ -23,7 +23,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class InternalLinkAudit extends BaseTool {
 
 	public function __construct() {
-		$this->registerGlobalTool( 'internal_link_audit', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'internal_link_audit', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {

--- a/inc/Engine/AI/Tools/Global/LocalSearch.php
+++ b/inc/Engine/AI/Tools/Global/LocalSearch.php
@@ -17,7 +17,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class LocalSearch extends BaseTool {
 
 	public function __construct() {
-		$this->registerGlobalTool( 'local_search', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'local_search', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {

--- a/inc/Engine/AI/Tools/Global/PageSpeed.php
+++ b/inc/Engine/AI/Tools/Global/PageSpeed.php
@@ -20,7 +20,7 @@ class PageSpeed extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'pagespeed' );
-		$this->registerGlobalTool( 'pagespeed', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'pagespeed', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/QueueValidator.php
+++ b/inc/Engine/AI/Tools/Global/QueueValidator.php
@@ -23,7 +23,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class QueueValidator extends BaseTool {
 
 	public function __construct() {
-		$this->registerGlobalTool( 'queue_validator', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'queue_validator', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/WebFetch.php
+++ b/inc/Engine/AI/Tools/Global/WebFetch.php
@@ -14,7 +14,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class WebFetch extends BaseTool {
 
 	public function __construct() {
-		$this->registerGlobalTool( 'web_fetch', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'web_fetch', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {

--- a/inc/Engine/AI/Tools/Global/WordPressPostReader.php
+++ b/inc/Engine/AI/Tools/Global/WordPressPostReader.php
@@ -17,7 +17,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class WordPressPostReader extends BaseTool {
 
 	public function __construct() {
-		$this->registerGlobalTool( 'wordpress_post_reader', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'wordpress_post_reader', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {

--- a/inc/Engine/AI/Tools/Global/WorkspaceTools.php
+++ b/inc/Engine/AI/Tools/Global/WorkspaceTools.php
@@ -53,11 +53,12 @@ class WorkspaceTools extends BaseTool {
 	 * Constructor — register all workspace read tools as global tools.
 	 */
 	public function __construct() {
-		$this->registerGlobalTool( 'workspace_path', array( $this, 'getPathDefinition' ) );
-		$this->registerGlobalTool( 'workspace_list', array( $this, 'getListDefinition' ) );
-		$this->registerGlobalTool( 'workspace_show', array( $this, 'getShowDefinition' ) );
-		$this->registerGlobalTool( 'workspace_ls', array( $this, 'getLsDefinition' ) );
-		$this->registerGlobalTool( 'workspace_read', array( $this, 'getReadDefinition' ) );
+		$contexts = array( 'chat', 'pipeline', 'standalone' );
+		$this->registerTool( 'workspace_path', array( $this, 'getPathDefinition' ), $contexts );
+		$this->registerTool( 'workspace_list', array( $this, 'getListDefinition' ), $contexts );
+		$this->registerTool( 'workspace_show', array( $this, 'getShowDefinition' ), $contexts );
+		$this->registerTool( 'workspace_ls', array( $this, 'getLsDefinition' ), $contexts );
+		$this->registerTool( 'workspace_read', array( $this, 'getReadDefinition' ), $contexts );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -89,13 +89,17 @@ class ToolManager {
 	 * Handles lazy evaluation of tool definitions. Callables are invoked
 	 * and their results cached. Arrays are returned as-is.
 	 *
+	 * Supports the unified registry wrapper format where a callable is stored
+	 * as `['_callable' => callable, 'contexts' => [...]]`. The callable is
+	 * resolved and contexts are merged into the result.
+	 *
 	 * Cache keys are scoped: when a $cache_scope is provided, the key
 	 * becomes "$cache_scope|$tool_id" so that the same tool_id can hold
 	 * different definitions for different contexts (e.g. different flows
 	 * configure upsert_event with different taxonomy selections).
 	 *
 	 * @param string $tool_id     Tool identifier.
-	 * @param mixed  $definition  Tool definition (array or callable).
+	 * @param mixed  $definition  Tool definition (array, callable, or wrapper with _callable key).
 	 * @param string $cache_scope Optional scope prefix for the cache key.
 	 * @return array Resolved tool definition.
 	 */
@@ -121,6 +125,13 @@ class ToolManager {
 			);
 		}
 
+		// Handle unified registry wrapper: ['_callable' => callable, 'contexts' => [...]]
+		$contexts = array();
+		if ( is_array( $definition ) && isset( $definition['_callable'] ) ) {
+			$contexts   = $definition['contexts'] ?? array();
+			$definition = $definition['_callable'];
+		}
+
 		// Resolve callable or use array directly
 		if ( is_callable( $definition ) ) {
 			$resolved = $definition();
@@ -130,6 +141,11 @@ class ToolManager {
 
 		// Ensure result is an array
 		$resolved = is_array( $resolved ) ? $resolved : array();
+
+		// Merge contexts into resolved definition (registry contexts take precedence)
+		if ( ! empty( $contexts ) ) {
+			$resolved['contexts'] = $contexts;
+		}
 
 		// Cache the resolved definition
 		self::$resolved_cache[ $cache_key ] = $resolved;
@@ -160,14 +176,51 @@ class ToolManager {
 	// ============================================
 
 	/**
-	 * Get all global tools (handler-agnostic).
+	 * Get all registered tools from the unified registry.
 	 * Resolves any callable definitions before returning.
 	 *
-	 * @return array All global tools with resolved definitions
+	 * @return array All tools with resolved definitions.
+	 */
+	public function get_all_tools(): array {
+		$raw_tools = apply_filters( 'datamachine_tools', array() );
+		return $this->resolveAllTools( $raw_tools );
+	}
+
+	/**
+	 * Get all registered tools (raw, unresolved).
+	 *
+	 * Returns the raw registry including callables and wrapper arrays.
+	 * Useful when you need to check contexts without resolving all definitions.
+	 *
+	 * @return array Raw tools array.
+	 */
+	public function get_raw_tools(): array {
+		return apply_filters( 'datamachine_tools', array() );
+	}
+
+	/**
+	 * Get contexts for a tool from its raw (unresolved) definition.
+	 *
+	 * Extracts contexts without resolving callable definitions.
+	 *
+	 * @param mixed $definition Raw tool definition (array, callable, or wrapper).
+	 * @return array Contexts array.
+	 */
+	public static function get_tool_contexts( mixed $definition ): array {
+		if ( is_array( $definition ) ) {
+			return $definition['contexts'] ?? array();
+		}
+		return array();
+	}
+
+	/**
+	 * Alias for get_all_tools() — backward compatibility.
+	 *
+	 * @deprecated Use get_all_tools() instead.
+	 * @return array All tools with resolved definitions.
 	 */
 	public function get_global_tools(): array {
-		$raw_tools = apply_filters( 'datamachine_global_tools', array() );
-		return $this->resolveAllTools( $raw_tools );
+		return $this->get_all_tools();
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -3,8 +3,8 @@
  * Tool Policy Resolver
  *
  * Single entry point for determining which tools are available for any
- * execution context. Replaces fragmented tool assembly across ToolExecutor,
- * ToolManager, and ChatOrchestrator with one deterministic resolution path.
+ * execution context. Reads from the unified `datamachine_tools` registry
+ * and filters by context (pipeline/chat/standalone/system).
  *
  * Resolution precedence (highest to lowest):
  * 1. Explicit deny list (always wins)
@@ -92,19 +92,36 @@ class ToolPolicyResolver {
 			self::SURFACE_CHAT       => $this->gatherChatTools( $context ),
 			self::SURFACE_STANDALONE => $this->gatherStandaloneTools( $context ),
 			self::SURFACE_SYSTEM     => $this->gatherSystemTools( $context ),
-			default                  => $this->gatherGlobalTools( $context ),
+			default                  => $this->gatherFallbackTools( $context ),
 		};
 	}
 
 	/**
-	 * Pipeline surface: global tools + handler tools from adjacent steps.
+	 * Filter resolved tools by context.
+	 *
+	 * @param array  $tools   Resolved tools array.
+	 * @param string $context Context string to filter by (e.g. 'chat', 'pipeline').
+	 * @return array Filtered tools.
+	 */
+	private function filterByContext( array $tools, string $context ): array {
+		return array_filter(
+			$tools,
+			function ( $tool ) use ( $context ) {
+				$contexts = $tool['contexts'] ?? array();
+				return in_array( $context, $contexts, true );
+			}
+		);
+	}
+
+	/**
+	 * Pipeline surface: context-filtered tools + handler tools from adjacent steps.
 	 */
 	private function gatherPipelineTools( array $context ): array {
-		$available_tools     = array();
-		$pipeline_step_id    = $context['pipeline_step_id'] ?? null;
-		$engine_data         = $context['engine_data'] ?? array();
+		$available_tools  = array();
+		$pipeline_step_id = $context['pipeline_step_id'] ?? null;
+		$engine_data      = $context['engine_data'] ?? array();
 
-		// Handler tools from adjacent steps.
+		// Handler tools from adjacent steps (dynamic, not part of the static registry).
 		foreach ( array( $context['previous_step_config'] ?? null, $context['next_step_config'] ?? null ) as $step_config ) {
 			if ( ! $step_config ) {
 				continue;
@@ -131,9 +148,11 @@ class ToolPolicyResolver {
 			}
 		}
 
-		// Global tools filtered for pipeline availability.
-		$global_tools = $this->tool_manager->get_global_tools();
-		foreach ( $global_tools as $tool_name => $tool_config ) {
+		// Static registry tools filtered for 'pipeline' context.
+		$all_tools      = $this->tool_manager->get_all_tools();
+		$pipeline_tools = $this->filterByContext( $all_tools, 'pipeline' );
+
+		foreach ( $pipeline_tools as $tool_name => $tool_config ) {
 			if ( is_array( $tool_config ) && $this->tool_manager->is_tool_available( $tool_name, $pipeline_step_id ) ) {
 				$available_tools[ $tool_name ] = $tool_config;
 			}
@@ -143,49 +162,53 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * Chat surface: global tools + chat-specific tools.
+	 * Chat surface: all tools with 'chat' context.
 	 *
-	 * Global tools go through is_tool_available() for enablement/config checks.
-	 * Chat-specific tools are included if they have a valid definition — they
-	 * register via datamachine_chat_tools and are outside the global enablement
-	 * system (is_tool_available() only knows about global tools).
+	 * Tools with configuration requirements go through is_tool_available().
+	 * Chat-only tools (those without requires_config) are included if they
+	 * resolve to a valid definition.
 	 */
 	private function gatherChatTools( array $context ): array {
 		$available_tools = array();
 
-		// Global tools filtered for chat availability.
-		$global_tools = $this->tool_manager->get_global_tools();
-		foreach ( $global_tools as $tool_name => $tool_config ) {
-			if ( $this->tool_manager->is_tool_available( $tool_name, null ) ) {
-				$available_tools[ $tool_name ] = $tool_config;
-			}
-		}
-
-		// Chat-specific tools — included if they resolve to a valid definition.
-		// These are outside the global enablement system (they have their own
-		// registration path via datamachine_chat_tools filter).
-		$raw_chat_tools = apply_filters( 'datamachine_chat_tools', array() );
-		$chat_tools     = $this->tool_manager->resolveAllTools( $raw_chat_tools );
+		$all_tools  = $this->tool_manager->get_all_tools();
+		$chat_tools = $this->filterByContext( $all_tools, 'chat' );
 
 		foreach ( $chat_tools as $tool_name => $tool_config ) {
-			if ( is_array( $tool_config ) && ! empty( $tool_config ) ) {
-				$available_tools[ $tool_name ] = $tool_config;
+			if ( ! is_array( $tool_config ) || empty( $tool_config ) ) {
+				continue;
 			}
+
+			// Tools with requires_config go through availability checks.
+			// Tools without it (chat-only management tools) are always available.
+			if ( ! empty( $tool_config['requires_config'] ) ) {
+				if ( ! $this->tool_manager->is_tool_available( $tool_name, null ) ) {
+					continue;
+				}
+			} elseif ( ! $this->tool_manager->is_globally_enabled( $tool_name ) ) {
+				// Check global enablement for tools that can be disabled.
+				// For tools not in the disabled list, is_globally_enabled returns true.
+				continue;
+			}
+
+			$available_tools[ $tool_name ] = $tool_config;
 		}
 
 		return $available_tools;
 	}
 
 	/**
-	 * Standalone surface: global tools only (no handler or chat tools).
+	 * Standalone surface: tools with 'standalone' context.
 	 *
 	 * For standalone jobs that need AI tool access without pipeline context.
 	 */
 	private function gatherStandaloneTools( array $context ): array {
 		$available_tools = array();
 
-		$global_tools = $this->tool_manager->get_global_tools();
-		foreach ( $global_tools as $tool_name => $tool_config ) {
+		$all_tools        = $this->tool_manager->get_all_tools();
+		$standalone_tools = $this->filterByContext( $all_tools, 'standalone' );
+
+		foreach ( $standalone_tools as $tool_name => $tool_config ) {
 			if ( is_array( $tool_config ) && $this->tool_manager->is_tool_available( $tool_name, null ) ) {
 				$available_tools[ $tool_name ] = $tool_config;
 			}
@@ -195,7 +218,7 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * System surface: minimal toolset for system tasks.
+	 * System surface: tools with 'system' context.
 	 *
 	 * Only includes tools that system tasks explicitly need.
 	 * Today most system tasks call abilities directly, but this provides
@@ -204,21 +227,11 @@ class ToolPolicyResolver {
 	private function gatherSystemTools( array $context ): array {
 		$available_tools = array();
 
-		// System tasks get global tools that are explicitly marked as system-compatible,
-		// or all global tools if no system-specific filtering exists.
-		$global_tools = $this->tool_manager->get_global_tools();
-		foreach ( $global_tools as $tool_name => $tool_config ) {
-			if ( is_array( $tool_config ) && $this->tool_manager->is_tool_available( $tool_name, null ) ) {
-				$available_tools[ $tool_name ] = $tool_config;
-			}
-		}
-
-		// System-specific tools (if any register via this filter).
-		$raw_system_tools = apply_filters( 'datamachine_system_tools', array() );
-		$system_tools     = $this->tool_manager->resolveAllTools( $raw_system_tools );
+		$all_tools    = $this->tool_manager->get_all_tools();
+		$system_tools = $this->filterByContext( $all_tools, 'system' );
 
 		foreach ( $system_tools as $tool_name => $tool_config ) {
-			if ( is_array( $tool_config ) && ! empty( $tool_config ) ) {
+			if ( is_array( $tool_config ) && $this->tool_manager->is_tool_available( $tool_name, null ) ) {
 				$available_tools[ $tool_name ] = $tool_config;
 			}
 		}
@@ -227,9 +240,9 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * Fallback: global tools only.
+	 * Fallback: standalone tools for unknown surfaces.
 	 */
-	private function gatherGlobalTools( array $context ): array {
+	private function gatherFallbackTools( array $context ): array {
 		return $this->gatherStandaloneTools( $context );
 	}
 

--- a/inc/Engine/AI/Tools/ToolServiceProvider.php
+++ b/inc/Engine/AI/Tools/ToolServiceProvider.php
@@ -2,9 +2,9 @@
 /**
  * Tool Service Provider.
  *
- * Centralizes registration of all global and chat tools.
- * Global tools are registered first, then chat tools (which depend
- * on step types and handlers already being registered).
+ * Centralizes registration of all tools via the unified `datamachine_tools` filter.
+ * Each tool declares a `contexts` array specifying where it's available
+ * (e.g. 'chat', 'pipeline', 'standalone').
  *
  * @package DataMachine\Engine\AI\Tools
  * @since   0.27.0
@@ -14,7 +14,7 @@ namespace DataMachine\Engine\AI\Tools;
 
 defined( 'ABSPATH' ) || exit;
 
-// Global tools.
+// Tools available in chat, pipeline, and standalone contexts.
 use DataMachine\Engine\AI\Tools\Global\AgentDailyMemory;
 use DataMachine\Engine\AI\Tools\Global\AgentMemory;
 use DataMachine\Engine\AI\Tools\Global\AmazonAffiliateLink;
@@ -31,7 +31,7 @@ use DataMachine\Engine\AI\Tools\Global\WebFetch;
 use DataMachine\Engine\AI\Tools\Global\WorkspaceTools;
 use DataMachine\Engine\AI\Tools\Global\WordPressPostReader;
 
-// Chat tools.
+// Chat-only tools.
 use DataMachine\Api\Chat\Tools\AddPipelineStep;
 use DataMachine\Api\Chat\Tools\ApiQuery;
 use DataMachine\Api\Chat\Tools\AssignTaxonomyTerm;
@@ -64,27 +64,26 @@ use DataMachine\Api\Chat\Tools\UpdateFlow;
 use DataMachine\Api\Chat\Tools\UpdateTaxonomyTerm;
 
 /**
- * Registers all global and chat tools.
+ * Registers all tools via the unified datamachine_tools filter.
  */
 class ToolServiceProvider {
 
 	/**
 	 * Register all tools.
 	 *
-	 * Global tools are registered first because chat tools may depend
-	 * on handlers and step types that global tools provide.
+	 * Tools with contexts ['chat', 'pipeline', 'standalone'] are registered
+	 * first because chat-only tools may depend on handlers and step types
+	 * that they provide.
 	 */
 	public static function register(): void {
-		self::registerGlobalTools();
-		self::registerChatTools();
+		self::registerTools();
 	}
 
 	/**
-	 * Register global tools.
-	 *
-	 * These tools are available to all agent types (pipeline, system, chat).
+	 * Register all tools with their context declarations.
 	 */
-	private static function registerGlobalTools(): void {
+	private static function registerTools(): void {
+		// Tools available in chat, pipeline, and standalone contexts.
 		new AgentDailyMemory();
 		new AgentMemory();
 		new AmazonAffiliateLink();
@@ -100,15 +99,8 @@ class ToolServiceProvider {
 		new WebFetch();
 		new WorkspaceTools();
 		new WordPressPostReader();
-	}
 
-	/**
-	 * Register chat tools.
-	 *
-	 * These tools are only available to the chat agent and depend on
-	 * step types and handlers being already registered.
-	 */
-	private static function registerChatTools(): void {
+		// Chat-only tools.
 		new ApiQuery();
 		new CreatePipeline();
 		new AddPipelineStep();

--- a/tests/Unit/AI/Tools/ImageGenerationTest.php
+++ b/tests/Unit/AI/Tools/ImageGenerationTest.php
@@ -117,8 +117,8 @@ class ImageGenerationTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'not configured', $result['error'] );
 	}
 
-	public function test_tool_registers_as_global_tool(): void {
-		$tools = apply_filters( 'datamachine_global_tools', [] );
+	public function test_tool_registers_in_unified_registry(): void {
+		$tools = apply_filters( 'datamachine_tools', [] );
 		$this->assertArrayHasKey( 'image_generation', $tools );
 	}
 

--- a/tests/Unit/AI/Tools/ToolPolicyResolverTest.php
+++ b/tests/Unit/AI/Tools/ToolPolicyResolverTest.php
@@ -137,27 +137,32 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	// SYSTEM SURFACE
 	// ============================================
 
-	public function test_system_returns_global_tools(): void {
+	public function test_system_returns_only_system_context_tools(): void {
 		$tools = $this->resolver->resolve( array(
 			'surface' => ToolPolicyResolver::SURFACE_SYSTEM,
 		) );
 
 		$this->assertIsArray( $tools );
-		$this->assertArrayHasKey( 'web_fetch', $tools );
+		// No tools currently register with 'system' context,
+		// so the system surface should be empty by default.
+		$this->assertArrayNotHasKey( 'web_fetch', $tools );
 	}
 
-	public function test_system_includes_system_filter_tools(): void {
-		// Register a system-only tool via filter.
-		add_filter( 'datamachine_system_tools', function ( $tools ) {
+	public function test_system_includes_system_context_tools(): void {
+		// Register a system-only tool via unified filter.
+		add_filter( 'datamachine_tools', function ( $tools ) {
 			$tools['test_system_tool'] = array(
 				'label'       => 'Test System Tool',
 				'description' => 'Only available to system tasks.',
 				'class'       => 'NonExistentClass',
 				'method'      => 'handle_tool_call',
 				'parameters'  => array(),
+				'contexts'    => array( 'system' ),
 			);
 			return $tools;
 		} );
+
+		ToolManager::clearCache();
 
 		$tools = $this->resolver->resolve( array(
 			'surface' => ToolPolicyResolver::SURFACE_SYSTEM,
@@ -166,7 +171,8 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'test_system_tool', $tools );
 
 		// Clean up.
-		remove_all_filters( 'datamachine_system_tools' );
+		remove_all_filters( 'datamachine_tools' );
+		ToolManager::clearCache();
 	}
 
 	// ============================================

--- a/tests/Unit/Api/Chat/Tools/ListFlowsTest.php
+++ b/tests/Unit/Api/Chat/Tools/ListFlowsTest.php
@@ -44,10 +44,13 @@ class ListFlowsTest extends WP_UnitTestCase {
 	}
 
 	public function test_tool_registered(): void {
-		$tools = apply_filters('datamachine_chat_tools', []);
+		$tools = apply_filters('datamachine_tools', []);
 
 		$this->assertArrayHasKey('list_flows', $tools);
-		$definition = is_callable( $tools['list_flows'] ) ? call_user_func( $tools['list_flows'] ) : $tools['list_flows'];
+		$raw = $tools['list_flows'];
+		// Unified registry wraps callables with _callable key.
+		$callable   = $raw['_callable'] ?? $raw;
+		$definition = is_callable( $callable ) ? call_user_func( $callable ) : $callable;
 		$this->assertSame(ListFlows::class, $definition['class']);
 	}
 


### PR DESCRIPTION
## Summary

Phase 1 of #741: Replace the 3 separate tool registration channels with a single unified `datamachine_tools` filter. Every tool now declares a `contexts` array specifying where it's available.

- **Single filter**: `datamachine_tools` replaces `datamachine_global_tools`, `datamachine_chat_tools`, `datamachine_system_tools`
- **Context arrays**: Each tool declares `contexts: ['chat', 'pipeline', 'standalone']` (or subset)
- **No backward compatibility bridge** — all callers updated directly

## Changes

### BaseTool.php
- `registerTool(toolName, toolDefinition, contexts)` replaces the old 3-param `(agentType, toolName, toolDefinition)` signature
- Deleted `registerGlobalTool()` and `registerChatTool()`
- Callable definitions wrapped with `_callable` key to keep contexts available pre-resolution

### ToolManager.php
- `get_all_tools()` reads from `datamachine_tools` filter (replaces `get_global_tools()`)
- `get_global_tools()` kept as deprecated alias
- `get_raw_tools()` and `get_tool_contexts()` added for pre-resolution context checks
- `resolveToolDefinition()` handles `_callable` wrapper format, merging contexts into resolved result

### ToolPolicyResolver.php
- `filterByContext()` helper filters resolved tools by context string
- `gatherPipelineTools()`: filters to `'pipeline'` context + handler tools from `chubes_ai_tools`
- `gatherChatTools()`: filters to `'chat'` context with availability/enablement checks
- `gatherStandaloneTools()`: filters to `'standalone'` context
- `gatherSystemTools()`: filters to `'system'` context (currently empty — no tools register with system context)
- Surface constants kept for Phase 2 rename

### ToolServiceProvider.php
- Merged `registerGlobalTools()` + `registerChatTools()` into single `registerTools()`

### 46+ tool registration sites updated
- **Former global tools** → `contexts: ['chat', 'pipeline', 'standalone']`
- **Former chat-only tools** → `contexts: ['chat']`
- **Ability-registered tools** (PostQuery, GetPostBlocks, EditPostBlocks, ReplacePostBlocks) → `datamachine_tools` filter with `'chat'` context

### Tests
- `ToolPolicyResolverTest`: system surface test updated (no tools have `system` context now)
- `ImageGenerationTest`: `datamachine_global_tools` → `datamachine_tools`
- `ListFlowsTest`: `datamachine_chat_tools` → `datamachine_tools` with `_callable` unwrapping

## Test Results

764 tests, 0 failures, 3 skipped (pre-existing)

## What's NOT in this PR (Phase 2)

- Renaming `SURFACE_*` constants to `CONTEXT_*` in ToolPolicyResolver
- Full ToolPolicyResolver rewrite with context-first architecture