### PR TITLE
feat(#741): Context resolver rename + per-agent tool policies (Phases 2-3)

### DIFF
--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -549,12 +549,18 @@ class ChatOrchestrator {
 		$chat_db = new ChatDatabase();
 
 		try {
+			$user_id  = $options['user_id'] ?? 0;
+			$agent_id = 0;
+
+			if ( $user_id > 0 && function_exists( 'datamachine_resolve_or_create_agent_id' ) ) {
+				$agent_id = datamachine_resolve_or_create_agent_id( $user_id );
+			}
+
 			$resolver  = new ToolPolicyResolver();
 			$all_tools = $resolver->resolve( array(
-				'surface' => ToolPolicyResolver::SURFACE_CHAT,
+				'context'  => ToolPolicyResolver::CONTEXT_CHAT,
+				'agent_id' => $agent_id,
 			) );
-
-			$user_id      = $options['user_id'] ?? 0;
 			$loop_context = array(
 				'session_id' => $session_id,
 				'user_id'    => $user_id,

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -177,9 +177,10 @@ class AIStep extends Step {
 
 		$max_turns = PluginSettings::get( 'max_turns', 12 );
 
-		// Resolve user_id from engine snapshot (set by RunFlowAbility).
+		// Resolve user_id and agent_id from engine snapshot (set by RunFlowAbility).
 		$job_snapshot = $this->engine->get( 'job' );
 		$user_id      = (int) ( $job_snapshot['user_id'] ?? 0 );
+		$agent_id     = (int) ( $job_snapshot['agent_id'] ?? 0 );
 
 		$payload = array(
 			'job_id'       => $this->job_id,
@@ -216,7 +217,8 @@ class AIStep extends Step {
 		$engine_data     = $this->engine->all();
 		$resolver        = new ToolPolicyResolver();
 		$available_tools = $resolver->resolve( array(
-			'surface'             => ToolPolicyResolver::SURFACE_PIPELINE,
+			'context'              => ToolPolicyResolver::CONTEXT_PIPELINE,
+			'agent_id'             => $agent_id,
 			'previous_step_config' => $previous_step_config,
 			'next_step_config'     => $next_step_config,
 			'pipeline_step_id'     => $pipeline_step_id,

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -19,7 +19,7 @@ class ToolExecutor {
 	/**
 	 * Get available tools for AI agent execution.
 	 *
-	 * @deprecated 0.39.0 Use ToolPolicyResolver::resolve() with SURFACE_PIPELINE instead.
+	 * @deprecated 0.39.0 Use ToolPolicyResolver::resolve() with CONTEXT_PIPELINE instead.
 	 *             Delegates to ToolPolicyResolver internally.
 	 *
 	 * @param  array|null  $previous_step_config     Previous step configuration (pipeline only)
@@ -32,7 +32,7 @@ class ToolExecutor {
 		$resolver = new ToolPolicyResolver();
 
 		return $resolver->resolve( array(
-			'surface'              => ToolPolicyResolver::SURFACE_PIPELINE,
+			'context'              => ToolPolicyResolver::CONTEXT_PIPELINE,
 			'previous_step_config' => $previous_step_config,
 			'next_step_config'     => $next_step_config,
 			'pipeline_step_id'     => $current_pipeline_step_id,

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -471,7 +471,7 @@ class ToolManager {
 	/**
 	 * Get all available tools for chat context.
 	 *
-	 * @deprecated 0.39.0 Use ToolPolicyResolver::resolve() with SURFACE_CHAT instead.
+	 * @deprecated 0.39.0 Use ToolPolicyResolver::resolve() with CONTEXT_CHAT instead.
 	 *             Delegates to ToolPolicyResolver internally.
 	 *
 	 * @return array Available tools for chat agents
@@ -480,7 +480,7 @@ class ToolManager {
 		$resolver = new ToolPolicyResolver( $this );
 
 		return $resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_CHAT,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 	}
 }

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -4,13 +4,16 @@
  *
  * Single entry point for determining which tools are available for any
  * execution context. Reads from the unified `datamachine_tools` registry
- * and filters by context (pipeline/chat/standalone/system).
+ * and filters by context (pipeline/chat/standalone/system), then applies
+ * per-agent tool policies from agent_config.
  *
  * Resolution precedence (highest to lowest):
  * 1. Explicit deny list (always wins)
- * 2. Surface preset (pipeline/chat/standalone/system)
- * 3. Global enablement settings
- * 4. Tool configuration requirements
+ * 2. Per-agent tool policy (deny/allow mode from agent_config)
+ * 3. Context-level allow_only (narrows to explicit subset)
+ * 4. Context preset (pipeline/chat/standalone/system)
+ * 5. Global enablement settings
+ * 6. Tool configuration requirements
  *
  * @package DataMachine\Engine\AI\Tools
  * @since 0.39.0
@@ -18,17 +21,27 @@
 
 namespace DataMachine\Engine\AI\Tools;
 
+use DataMachine\Core\Database\Agents\Agents;
+
 defined( 'ABSPATH' ) || exit;
 
 class ToolPolicyResolver {
 
 	/**
-	 * Surface presets define which tool pools are available.
+	 * Context presets define which tool pools are available.
 	 */
-	public const SURFACE_PIPELINE   = 'pipeline';
-	public const SURFACE_CHAT       = 'chat';
-	public const SURFACE_STANDALONE = 'standalone';
-	public const SURFACE_SYSTEM     = 'system';
+	public const CONTEXT_PIPELINE   = 'pipeline';
+	public const CONTEXT_CHAT       = 'chat';
+	public const CONTEXT_STANDALONE = 'standalone';
+	public const CONTEXT_SYSTEM     = 'system';
+
+	/**
+	 * @deprecated Use CONTEXT_* constants instead.
+	 */
+	public const SURFACE_PIPELINE   = self::CONTEXT_PIPELINE;
+	public const SURFACE_CHAT       = self::CONTEXT_CHAT;
+	public const SURFACE_STANDALONE = self::CONTEXT_STANDALONE;
+	public const SURFACE_SYSTEM     = self::CONTEXT_SYSTEM;
 
 	private ToolManager $tool_manager;
 
@@ -44,54 +57,64 @@ class ToolPolicyResolver {
 	 * @param array $context {
 	 *     Execution context describing the request.
 	 *
-	 *     @type string      $surface             Required. One of the SURFACE_* constants.
-	 *     @type array|null  $previous_step_config Pipeline only: previous step config with handler_slugs.
-	 *     @type array|null  $next_step_config     Pipeline only: next step config with handler_slugs.
-	 *     @type string|null $pipeline_step_id     Pipeline only: current pipeline step ID for per-step filtering.
-	 *     @type array       $engine_data          Engine data snapshot for dynamic tool generation.
-	 *     @type array       $deny                 Tool names to explicitly deny (highest precedence).
-	 *     @type array       $allow_only           If set, only these tools are allowed (allowlist mode).
-	 *     @type string|null $cache_scope          Scope key for tool cache (e.g. flow_step_id).
+	 *     @type string      $context              Required. One of the CONTEXT_* constants.
+	 *     @type string      $surface              Deprecated alias for $context.
+	 *     @type int|null    $agent_id              Agent ID for per-agent tool policy filtering.
+	 *     @type array|null  $previous_step_config  Pipeline only: previous step config with handler_slugs.
+	 *     @type array|null  $next_step_config      Pipeline only: next step config with handler_slugs.
+	 *     @type string|null $pipeline_step_id      Pipeline only: current pipeline step ID for per-step filtering.
+	 *     @type array       $engine_data           Engine data snapshot for dynamic tool generation.
+	 *     @type array       $deny                  Tool names to explicitly deny (highest precedence).
+	 *     @type array       $allow_only            If set, only these tools are allowed (allowlist mode).
+	 *     @type string|null $cache_scope           Scope key for tool cache (e.g. flow_step_id).
 	 * }
 	 * @return array Resolved tools array keyed by tool name.
 	 */
 	public function resolve( array $context ): array {
-		$surface = $context['surface'] ?? self::SURFACE_PIPELINE;
-		$deny    = $context['deny'] ?? array();
+		// Accept 'context' key, fall back to deprecated 'surface' key.
+		$context_type = $context['context'] ?? $context['surface'] ?? self::CONTEXT_PIPELINE;
+		$deny         = $context['deny'] ?? array();
+		$agent_id     = isset( $context['agent_id'] ) ? (int) $context['agent_id'] : 0;
 
-		// 1. Gather tools based on surface preset.
-		$tools = $this->gatherBySurface( $surface, $context );
+		// 1. Gather tools based on context preset.
+		$tools = $this->gatherByContext( $context_type, $context );
 
-		// 2. Apply allowlist if specified (narrows to explicit subset).
+		// 2. Apply per-agent tool policy (from agent_config).
+		if ( $agent_id > 0 ) {
+			$agent_policy = $this->getAgentToolPolicy( $agent_id );
+			$tools        = $this->applyAgentPolicy( $tools, $agent_policy );
+		}
+
+		// 3. Apply allowlist if specified (narrows to explicit subset).
 		$allow_only = $context['allow_only'] ?? array();
 		if ( ! empty( $allow_only ) ) {
 			$tools = array_intersect_key( $tools, array_flip( $allow_only ) );
 		}
 
-		// 3. Apply deny list (always wins).
+		// 4. Apply deny list (always wins).
 		if ( ! empty( $deny ) ) {
 			$tools = array_diff_key( $tools, array_flip( $deny ) );
 		}
 
-		// 4. Allow external filtering of resolved tools.
-		$tools = apply_filters( 'datamachine_resolved_tools', $tools, $surface, $context );
+		// 5. Allow external filtering of resolved tools.
+		$tools = apply_filters( 'datamachine_resolved_tools', $tools, $context_type, $context );
 
 		return $tools;
 	}
 
 	/**
-	 * Gather tools by surface preset.
+	 * Gather tools by context preset.
 	 *
-	 * @param string $surface Surface preset constant.
-	 * @param array  $context Full execution context.
+	 * @param string $context_type Context preset string.
+	 * @param array  $context      Full execution context.
 	 * @return array Tools array.
 	 */
-	private function gatherBySurface( string $surface, array $context ): array {
-		return match ( $surface ) {
-			self::SURFACE_PIPELINE   => $this->gatherPipelineTools( $context ),
-			self::SURFACE_CHAT       => $this->gatherChatTools( $context ),
-			self::SURFACE_STANDALONE => $this->gatherStandaloneTools( $context ),
-			self::SURFACE_SYSTEM     => $this->gatherSystemTools( $context ),
+	private function gatherByContext( string $context_type, array $context ): array {
+		return match ( $context_type ) {
+			self::CONTEXT_PIPELINE   => $this->gatherPipelineTools( $context ),
+			self::CONTEXT_CHAT       => $this->gatherChatTools( $context ),
+			self::CONTEXT_STANDALONE => $this->gatherStandaloneTools( $context ),
+			self::CONTEXT_SYSTEM     => $this->gatherSystemTools( $context ),
 			default                  => $this->gatherFallbackTools( $context ),
 		};
 	}
@@ -99,22 +122,22 @@ class ToolPolicyResolver {
 	/**
 	 * Filter resolved tools by context.
 	 *
-	 * @param array  $tools   Resolved tools array.
-	 * @param string $context Context string to filter by (e.g. 'chat', 'pipeline').
+	 * @param array  $tools        Resolved tools array.
+	 * @param string $context_type Context string to filter by (e.g. 'chat', 'pipeline').
 	 * @return array Filtered tools.
 	 */
-	private function filterByContext( array $tools, string $context ): array {
+	private function filterByContext( array $tools, string $context_type ): array {
 		return array_filter(
 			$tools,
-			function ( $tool ) use ( $context ) {
+			function ( $tool ) use ( $context_type ) {
 				$contexts = $tool['contexts'] ?? array();
-				return in_array( $context, $contexts, true );
+				return in_array( $context_type, $contexts, true );
 			}
 		);
 	}
 
 	/**
-	 * Pipeline surface: context-filtered tools + handler tools from adjacent steps.
+	 * Pipeline context: context-filtered tools + handler tools from adjacent steps.
 	 */
 	private function gatherPipelineTools( array $context ): array {
 		$available_tools  = array();
@@ -162,7 +185,7 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * Chat surface: all tools with 'chat' context.
+	 * Chat context: all tools with 'chat' context.
 	 *
 	 * Tools with configuration requirements go through is_tool_available().
 	 * Chat-only tools (those without requires_config) are included if they
@@ -198,7 +221,7 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * Standalone surface: tools with 'standalone' context.
+	 * Standalone context: tools with 'standalone' context.
 	 *
 	 * For standalone jobs that need AI tool access without pipeline context.
 	 */
@@ -218,7 +241,7 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * System surface: tools with 'system' context.
+	 * System context: tools with 'system' context.
 	 *
 	 * Only includes tools that system tasks explicitly need.
 	 * Today most system tasks call abilities directly, but this provides
@@ -240,23 +263,106 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * Fallback: standalone tools for unknown surfaces.
+	 * Fallback: standalone tools for unknown contexts.
 	 */
 	private function gatherFallbackTools( array $context ): array {
 		return $this->gatherStandaloneTools( $context );
 	}
 
 	/**
-	 * Get available surface presets.
+	 * Get tool policy from an agent's config.
 	 *
-	 * @return array<string, string> Surface name => description.
+	 * Reads the `tool_policy` key from the agent's `agent_config` JSON.
+	 * Returns null if the agent doesn't exist or has no tool policy configured.
+	 *
+	 * @since 0.42.0
+	 * @param int $agent_id Agent ID.
+	 * @return array|null Tool policy array with 'mode' and 'tools' keys, or null.
+	 */
+	public function getAgentToolPolicy( int $agent_id ): ?array {
+		if ( $agent_id <= 0 ) {
+			return null;
+		}
+
+		$agents_repo = new Agents();
+		$agent       = $agents_repo->get_agent( $agent_id );
+
+		if ( ! $agent ) {
+			return null;
+		}
+
+		$config = $agent['agent_config'] ?? array();
+
+		if ( empty( $config['tool_policy'] ) || ! is_array( $config['tool_policy'] ) ) {
+			return null;
+		}
+
+		$policy = $config['tool_policy'];
+
+		// Validate structure: must have 'mode' and 'tools'.
+		if ( ! isset( $policy['mode'] ) || ! isset( $policy['tools'] ) || ! is_array( $policy['tools'] ) ) {
+			return null;
+		}
+
+		// Validate mode is one of the allowed values.
+		if ( ! in_array( $policy['mode'], array( 'deny', 'allow' ), true ) ) {
+			return null;
+		}
+
+		return $policy;
+	}
+
+	/**
+	 * Apply an agent's tool policy to a set of resolved tools.
+	 *
+	 * - `deny` mode: agent can use everything EXCEPT listed tools.
+	 * - `allow` mode: agent can ONLY use listed tools.
+	 * - No policy (null): no restrictions (backward compatible).
+	 *
+	 * @since 0.42.0
+	 * @param array      $tools  Resolved tools array keyed by tool name.
+	 * @param array|null $policy Tool policy from getAgentToolPolicy(), or null for no restrictions.
+	 * @return array Filtered tools array.
+	 */
+	public function applyAgentPolicy( array $tools, ?array $policy ): array {
+		if ( null === $policy ) {
+			return $tools;
+		}
+
+		$mode       = $policy['mode'];
+		$tool_names = $policy['tools'];
+
+		if ( empty( $tool_names ) ) {
+			// deny with empty list = no restrictions; allow with empty list = no tools.
+			return 'allow' === $mode ? array() : $tools;
+		}
+
+		if ( 'deny' === $mode ) {
+			return array_diff_key( $tools, array_flip( $tool_names ) );
+		}
+
+		// 'allow' mode: only keep tools in the list.
+		return array_intersect_key( $tools, array_flip( $tool_names ) );
+	}
+
+	/**
+	 * Get available context presets.
+	 *
+	 * @return array<string, string> Context name => description.
+	 */
+	public static function getContexts(): array {
+		return array(
+			self::CONTEXT_PIPELINE   => 'Pipeline execution with handler tools from adjacent steps',
+			self::CONTEXT_CHAT       => 'Chat interaction with full management tools',
+			self::CONTEXT_STANDALONE => 'Standalone job execution with global tools only',
+			self::CONTEXT_SYSTEM     => 'System task execution with minimal toolset',
+		);
+	}
+
+	/**
+	 * @deprecated Use getContexts() instead.
 	 */
 	public static function getSurfaces(): array {
-		return array(
-			self::SURFACE_PIPELINE   => 'Pipeline execution with handler tools from adjacent steps',
-			self::SURFACE_CHAT       => 'Chat interaction with full management tools',
-			self::SURFACE_STANDALONE => 'Standalone job execution with global tools only',
-			self::SURFACE_SYSTEM     => 'System task execution with minimal toolset',
-		);
+		return self::getContexts();
 	}
 }

--- a/tests/Unit/AI/Tools/ChatToolsAvailabilityTest.php
+++ b/tests/Unit/AI/Tools/ChatToolsAvailabilityTest.php
@@ -21,7 +21,7 @@ class ChatToolsAvailabilityTest extends WP_UnitTestCase {
 
 	public function test_chat_tools_include_update_flow(): void {
 		$tools = $this->resolver->resolve( [
-			'surface' => ToolPolicyResolver::SURFACE_CHAT,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		] );
 
 		$this->assertIsArray( $tools );
@@ -33,7 +33,7 @@ class ChatToolsAvailabilityTest extends WP_UnitTestCase {
 
 	public function test_chat_tools_include_web_fetch(): void {
 		$tools = $this->resolver->resolve( [
-			'surface' => ToolPolicyResolver::SURFACE_CHAT,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		] );
 
 		$this->assertIsArray( $tools );

--- a/tests/Unit/AI/Tools/PipelineToolsAvailabilityTest.php
+++ b/tests/Unit/AI/Tools/PipelineToolsAvailabilityTest.php
@@ -46,7 +46,7 @@ class PipelineToolsAvailabilityTest extends WP_UnitTestCase {
 		$this->assertTrue( $updated );
 
 		$tools_without_disabled = $this->resolver->resolve( [
-			'surface'          => ToolPolicyResolver::SURFACE_PIPELINE,
+			'context'          => ToolPolicyResolver::CONTEXT_PIPELINE,
 			'pipeline_step_id' => $pipeline_step_id,
 		] );
 		$this->assertIsArray( $tools_without_disabled );
@@ -59,7 +59,7 @@ class PipelineToolsAvailabilityTest extends WP_UnitTestCase {
 		$this->assertTrue( $updated_again );
 
 		$tools_with_disabled = $this->resolver->resolve( [
-			'surface'          => ToolPolicyResolver::SURFACE_PIPELINE,
+			'context'          => ToolPolicyResolver::CONTEXT_PIPELINE,
 			'pipeline_step_id' => $pipeline_step_id,
 		] );
 		$this->assertIsArray( $tools_with_disabled );
@@ -90,7 +90,7 @@ class PipelineToolsAvailabilityTest extends WP_UnitTestCase {
 		$this->assertTrue( $updated );
 
 		$tools = $this->resolver->resolve( [
-			'surface'          => ToolPolicyResolver::SURFACE_PIPELINE,
+			'context'          => ToolPolicyResolver::CONTEXT_PIPELINE,
 			'pipeline_step_id' => $pipeline_step_id,
 		] );
 		$this->assertIsArray( $tools );

--- a/tests/Unit/AI/Tools/ToolPolicyResolverTest.php
+++ b/tests/Unit/AI/Tools/ToolPolicyResolverTest.php
@@ -7,6 +7,7 @@
 
 namespace DataMachine\Tests\Unit\AI\Tools;
 
+use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Engine\AI\Tools\ToolManager;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
@@ -28,35 +29,33 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	// ============================================
-	// STANDALONE SURFACE
+	// STANDALONE CONTEXT
 	// ============================================
 
 	public function test_standalone_returns_global_tools(): void {
 		$tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_STANDALONE,
+			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
 		) );
 
 		$this->assertIsArray( $tools );
-		// Global tools like web_fetch should be present.
 		$this->assertArrayHasKey( 'web_fetch', $tools );
 	}
 
 	public function test_standalone_excludes_chat_tools(): void {
 		$tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_STANDALONE,
+			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
 		) );
 
-		// Chat-only tools like update_flow should not appear in standalone.
 		$this->assertArrayNotHasKey( 'update_flow', $tools );
 	}
 
 	// ============================================
-	// CHAT SURFACE
+	// CHAT CONTEXT
 	// ============================================
 
 	public function test_chat_includes_global_tools(): void {
 		$tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_CHAT,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 
 		$this->assertIsArray( $tools );
@@ -65,19 +64,16 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 	public function test_chat_includes_chat_tools(): void {
 		$tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_CHAT,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 
 		$this->assertIsArray( $tools );
-		// update_flow is registered as a chat tool.
 		$this->assertArrayHasKey( 'update_flow', $tools );
 	}
 
 	public function test_chat_tools_pass_availability_check(): void {
-		// This is the bug fix: chat tools now go through is_tool_available().
-		// Verify by checking a known chat tool is present and valid.
 		$tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_CHAT,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 
 		foreach ( $tools as $tool_name => $tool_config ) {
@@ -86,12 +82,12 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	// ============================================
-	// PIPELINE SURFACE
+	// PIPELINE CONTEXT
 	// ============================================
 
 	public function test_pipeline_includes_global_tools(): void {
 		$tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_PIPELINE,
+			'context' => ToolPolicyResolver::CONTEXT_PIPELINE,
 		) );
 
 		$this->assertIsArray( $tools );
@@ -100,7 +96,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 	public function test_pipeline_excludes_chat_tools(): void {
 		$tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_PIPELINE,
+			'context' => ToolPolicyResolver::CONTEXT_PIPELINE,
 		) );
 
 		$this->assertArrayNotHasKey( 'update_flow', $tools );
@@ -126,7 +122,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		) );
 
 		$tools = $this->resolver->resolve( array(
-			'surface'          => ToolPolicyResolver::SURFACE_PIPELINE,
+			'context'          => ToolPolicyResolver::CONTEXT_PIPELINE,
 			'pipeline_step_id' => $pipeline_step_id,
 		) );
 
@@ -134,22 +130,20 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	// ============================================
-	// SYSTEM SURFACE
+	// SYSTEM CONTEXT
 	// ============================================
 
 	public function test_system_returns_only_system_context_tools(): void {
 		$tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_SYSTEM,
+			'context' => ToolPolicyResolver::CONTEXT_SYSTEM,
 		) );
 
 		$this->assertIsArray( $tools );
-		// No tools currently register with 'system' context,
-		// so the system surface should be empty by default.
+		// No tools currently register with 'system' context.
 		$this->assertArrayNotHasKey( 'web_fetch', $tools );
 	}
 
 	public function test_system_includes_system_context_tools(): void {
-		// Register a system-only tool via unified filter.
 		add_filter( 'datamachine_tools', function ( $tools ) {
 			$tools['test_system_tool'] = array(
 				'label'       => 'Test System Tool',
@@ -165,12 +159,11 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		ToolManager::clearCache();
 
 		$tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_SYSTEM,
+			'context' => ToolPolicyResolver::CONTEXT_SYSTEM,
 		) );
 
 		$this->assertArrayHasKey( 'test_system_tool', $tools );
 
-		// Clean up.
 		remove_all_filters( 'datamachine_tools' );
 		ToolManager::clearCache();
 	}
@@ -181,7 +174,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 	public function test_deny_list_removes_tools(): void {
 		$tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_STANDALONE,
+			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
 			'deny'    => array( 'web_fetch' ),
 		) );
 
@@ -189,9 +182,8 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_deny_list_overrides_allowlist(): void {
-		// A tool in both allow and deny should be denied (deny wins).
 		$tools = $this->resolver->resolve( array(
-			'surface'    => ToolPolicyResolver::SURFACE_STANDALONE,
+			'context'    => ToolPolicyResolver::CONTEXT_STANDALONE,
 			'allow_only' => array( 'web_fetch' ),
 			'deny'       => array( 'web_fetch' ),
 		) );
@@ -205,18 +197,17 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 	public function test_allowlist_narrows_tools(): void {
 		$tools = $this->resolver->resolve( array(
-			'surface'    => ToolPolicyResolver::SURFACE_STANDALONE,
+			'context'    => ToolPolicyResolver::CONTEXT_STANDALONE,
 			'allow_only' => array( 'web_fetch' ),
 		) );
 
 		$this->assertArrayHasKey( 'web_fetch', $tools );
-		// Should only contain web_fetch.
 		$this->assertCount( 1, $tools );
 	}
 
 	public function test_allowlist_with_nonexistent_tool_returns_empty(): void {
 		$tools = $this->resolver->resolve( array(
-			'surface'    => ToolPolicyResolver::SURFACE_STANDALONE,
+			'context'    => ToolPolicyResolver::CONTEXT_STANDALONE,
 			'allow_only' => array( 'completely_fake_tool_xyz' ),
 		) );
 
@@ -228,8 +219,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	// ============================================
 
 	public function test_resolved_tools_filter_can_modify_output(): void {
-		add_filter( 'datamachine_resolved_tools', function ( $tools, $surface, $context ) {
-			// Add a custom tool.
+		add_filter( 'datamachine_resolved_tools', function ( $tools, $context_type, $context ) {
 			$tools['injected_tool'] = array(
 				'label'       => 'Injected Tool',
 				'description' => 'Added via filter.',
@@ -241,66 +231,88 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		}, 10, 3 );
 
 		$tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_STANDALONE,
+			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
 		) );
 
 		$this->assertArrayHasKey( 'injected_tool', $tools );
 
-		// Clean up.
 		remove_all_filters( 'datamachine_resolved_tools' );
 	}
 
-	public function test_resolved_tools_filter_receives_surface_and_context(): void {
-		$captured_surface = null;
-		$captured_context = null;
+	public function test_resolved_tools_filter_receives_context_type(): void {
+		$captured_context_type = null;
+		$captured_context      = null;
 
-		add_filter( 'datamachine_resolved_tools', function ( $tools, $surface, $context ) use ( &$captured_surface, &$captured_context ) {
-			$captured_surface = $surface;
-			$captured_context = $context;
+		add_filter( 'datamachine_resolved_tools', function ( $tools, $context_type, $context ) use ( &$captured_context_type, &$captured_context ) {
+			$captured_context_type = $context_type;
+			$captured_context      = $context;
 			return $tools;
 		}, 10, 3 );
 
 		$this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_CHAT,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 
-		$this->assertSame( ToolPolicyResolver::SURFACE_CHAT, $captured_surface );
+		$this->assertSame( ToolPolicyResolver::CONTEXT_CHAT, $captured_context_type );
 		$this->assertIsArray( $captured_context );
 
 		remove_all_filters( 'datamachine_resolved_tools' );
 	}
 
 	// ============================================
-	// SURFACE DEFAULTS & EDGE CASES
+	// DEFAULTS & EDGE CASES
 	// ============================================
 
-	public function test_default_surface_is_pipeline(): void {
-		// No surface provided — should default to pipeline.
+	public function test_default_context_is_pipeline(): void {
 		$tools = $this->resolver->resolve( array() );
 
 		$this->assertIsArray( $tools );
-		// Pipeline default includes global tools.
 		$this->assertArrayHasKey( 'web_fetch', $tools );
 	}
 
-	public function test_unknown_surface_falls_back_to_global_tools(): void {
+	public function test_unknown_context_falls_back_to_standalone(): void {
 		$tools = $this->resolver->resolve( array(
-			'surface' => 'unknown_surface_type',
+			'context' => 'unknown_context_type',
 		) );
 
 		$this->assertIsArray( $tools );
-		// Fallback = global tools.
 		$this->assertArrayHasKey( 'web_fetch', $tools );
 	}
 
-	public function test_getSurfaces_returns_all_four_presets(): void {
-		$surfaces = ToolPolicyResolver::getSurfaces();
+	public function test_getContexts_returns_all_four_presets(): void {
+		$contexts = ToolPolicyResolver::getContexts();
 
-		$this->assertArrayHasKey( ToolPolicyResolver::SURFACE_PIPELINE, $surfaces );
-		$this->assertArrayHasKey( ToolPolicyResolver::SURFACE_CHAT, $surfaces );
-		$this->assertArrayHasKey( ToolPolicyResolver::SURFACE_STANDALONE, $surfaces );
-		$this->assertArrayHasKey( ToolPolicyResolver::SURFACE_SYSTEM, $surfaces );
-		$this->assertCount( 4, $surfaces );
+		$this->assertArrayHasKey( ToolPolicyResolver::CONTEXT_PIPELINE, $contexts );
+		$this->assertArrayHasKey( ToolPolicyResolver::CONTEXT_CHAT, $contexts );
+		$this->assertArrayHasKey( ToolPolicyResolver::CONTEXT_STANDALONE, $contexts );
+		$this->assertArrayHasKey( ToolPolicyResolver::CONTEXT_SYSTEM, $contexts );
+		$this->assertCount( 4, $contexts );
+	}
+
+	// ============================================
+	// BACKWARD COMPATIBILITY
+	// ============================================
+
+	public function test_surface_key_still_works(): void {
+		// The deprecated 'surface' key should still resolve correctly.
+		$tools = $this->resolver->resolve( array(
+			'surface' => ToolPolicyResolver::SURFACE_CHAT,
+		) );
+
+		$this->assertIsArray( $tools );
+		$this->assertArrayHasKey( 'web_fetch', $tools );
+		$this->assertArrayHasKey( 'update_flow', $tools );
+	}
+
+	public function test_surface_constants_alias_context_constants(): void {
+		$this->assertSame( ToolPolicyResolver::CONTEXT_PIPELINE, ToolPolicyResolver::SURFACE_PIPELINE );
+		$this->assertSame( ToolPolicyResolver::CONTEXT_CHAT, ToolPolicyResolver::SURFACE_CHAT );
+		$this->assertSame( ToolPolicyResolver::CONTEXT_STANDALONE, ToolPolicyResolver::SURFACE_STANDALONE );
+		$this->assertSame( ToolPolicyResolver::CONTEXT_SYSTEM, ToolPolicyResolver::SURFACE_SYSTEM );
+	}
+
+	public function test_getSurfaces_delegates_to_getContexts(): void {
+		$this->assertSame( ToolPolicyResolver::getSurfaces(), ToolPolicyResolver::getContexts() );
 	}
 
 	// ============================================
@@ -308,24 +320,300 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	// ============================================
 
 	public function test_deprecated_executor_delegates_to_resolver(): void {
-		// ToolExecutor::getAvailableTools() now delegates to the resolver.
-		// Verify identical output.
 		$executor_tools = \DataMachine\Engine\AI\Tools\ToolExecutor::getAvailableTools( null, null, null, array() );
 		$resolver_tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_PIPELINE,
+			'context' => ToolPolicyResolver::CONTEXT_PIPELINE,
 		) );
 
 		$this->assertSame( $executor_tools, $resolver_tools );
 	}
 
 	public function test_deprecated_manager_delegates_to_resolver(): void {
-		// ToolManager::getAvailableToolsForChat() now delegates to the resolver.
-		// Verify identical output.
 		$manager_tools  = ( new ToolManager() )->getAvailableToolsForChat();
 		$resolver_tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_CHAT,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 
 		$this->assertSame( $manager_tools, $resolver_tools );
+	}
+
+	// ============================================
+	// AGENT TOOL POLICY
+	// ============================================
+
+	/**
+	 * Helper: create an agent with a given tool_policy in agent_config.
+	 *
+	 * @param array|null $tool_policy Tool policy array, or null for no policy.
+	 * @return int Agent ID.
+	 */
+	private function createAgentWithPolicy( ?array $tool_policy ): int {
+		$agents_repo = new Agents();
+		$config      = array();
+
+		if ( null !== $tool_policy ) {
+			$config['tool_policy'] = $tool_policy;
+		}
+
+		$slug = 'test-agent-' . wp_generate_uuid4();
+
+		return $agents_repo->create_if_missing( $slug, 'Test Agent', 1, $config );
+	}
+
+	public function test_no_agent_id_means_no_restrictions(): void {
+		$tools_without = $this->resolver->resolve( array(
+			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+		) );
+
+		$tools_with_zero = $this->resolver->resolve( array(
+			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'agent_id' => 0,
+		) );
+
+		$this->assertSame( $tools_without, $tools_with_zero );
+	}
+
+	public function test_agent_without_policy_no_restrictions(): void {
+		$agent_id = $this->createAgentWithPolicy( null );
+
+		$tools_no_agent = $this->resolver->resolve( array(
+			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+		) );
+
+		$tools_with_agent = $this->resolver->resolve( array(
+			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertSame( $tools_no_agent, $tools_with_agent );
+	}
+
+	public function test_agent_deny_mode_removes_listed_tools(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'  => 'deny',
+			'tools' => array( 'web_fetch' ),
+		) );
+
+		$tools = $this->resolver->resolve( array(
+			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertArrayNotHasKey( 'web_fetch', $tools );
+		// Other tools should still be present.
+		$this->assertNotEmpty( $tools );
+	}
+
+	public function test_agent_allow_mode_keeps_only_listed_tools(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'  => 'allow',
+			'tools' => array( 'web_fetch' ),
+		) );
+
+		$tools = $this->resolver->resolve( array(
+			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertArrayHasKey( 'web_fetch', $tools );
+		$this->assertCount( 1, $tools );
+	}
+
+	public function test_agent_allow_mode_empty_tools_returns_empty(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'  => 'allow',
+			'tools' => array(),
+		) );
+
+		$tools = $this->resolver->resolve( array(
+			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertEmpty( $tools );
+	}
+
+	public function test_agent_deny_mode_empty_tools_no_restrictions(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'  => 'deny',
+			'tools' => array(),
+		) );
+
+		$tools_no_agent = $this->resolver->resolve( array(
+			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+		) );
+
+		$tools_with_agent = $this->resolver->resolve( array(
+			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertSame( $tools_no_agent, $tools_with_agent );
+	}
+
+	public function test_nonexistent_agent_id_no_restrictions(): void {
+		$tools_no_agent = $this->resolver->resolve( array(
+			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+		) );
+
+		$tools_bad_id = $this->resolver->resolve( array(
+			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'agent_id' => 999999,
+		) );
+
+		$this->assertSame( $tools_no_agent, $tools_bad_id );
+	}
+
+	public function test_explicit_deny_overrides_agent_allow_policy(): void {
+		// Agent allows only web_fetch, but explicit deny removes it.
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'  => 'allow',
+			'tools' => array( 'web_fetch' ),
+		) );
+
+		$tools = $this->resolver->resolve( array(
+			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'agent_id' => $agent_id,
+			'deny'     => array( 'web_fetch' ),
+		) );
+
+		$this->assertEmpty( $tools );
+	}
+
+	public function test_agent_policy_applies_to_chat_context(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'  => 'deny',
+			'tools' => array( 'update_flow' ),
+		) );
+
+		$tools = $this->resolver->resolve( array(
+			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertArrayNotHasKey( 'update_flow', $tools );
+		// Other chat tools should still be present.
+		$this->assertArrayHasKey( 'web_fetch', $tools );
+	}
+
+	public function test_agent_policy_applies_to_pipeline_context(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'  => 'deny',
+			'tools' => array( 'web_fetch' ),
+		) );
+
+		$tools = $this->resolver->resolve( array(
+			'context'  => ToolPolicyResolver::CONTEXT_PIPELINE,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertArrayNotHasKey( 'web_fetch', $tools );
+	}
+
+	public function test_agent_invalid_policy_mode_ignored(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'  => 'invalid_mode',
+			'tools' => array( 'web_fetch' ),
+		) );
+
+		$tools_no_agent = $this->resolver->resolve( array(
+			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+		) );
+
+		$tools_with_agent = $this->resolver->resolve( array(
+			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertSame( $tools_no_agent, $tools_with_agent );
+	}
+
+	public function test_agent_malformed_policy_ignored(): void {
+		// Missing 'tools' key.
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode' => 'deny',
+		) );
+
+		$tools_no_agent = $this->resolver->resolve( array(
+			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+		) );
+
+		$tools_with_agent = $this->resolver->resolve( array(
+			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertSame( $tools_no_agent, $tools_with_agent );
+	}
+
+	public function test_getAgentToolPolicy_returns_valid_policy(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'  => 'deny',
+			'tools' => array( 'web_fetch', 'send_ping' ),
+		) );
+
+		$policy = $this->resolver->getAgentToolPolicy( $agent_id );
+
+		$this->assertIsArray( $policy );
+		$this->assertSame( 'deny', $policy['mode'] );
+		$this->assertSame( array( 'web_fetch', 'send_ping' ), $policy['tools'] );
+	}
+
+	public function test_getAgentToolPolicy_returns_null_for_no_policy(): void {
+		$agent_id = $this->createAgentWithPolicy( null );
+
+		$policy = $this->resolver->getAgentToolPolicy( $agent_id );
+
+		$this->assertNull( $policy );
+	}
+
+	public function test_getAgentToolPolicy_returns_null_for_invalid_agent(): void {
+		$policy = $this->resolver->getAgentToolPolicy( 999999 );
+
+		$this->assertNull( $policy );
+	}
+
+	public function test_applyAgentPolicy_null_returns_unchanged(): void {
+		$tools = array( 'tool_a' => array(), 'tool_b' => array() );
+
+		$result = $this->resolver->applyAgentPolicy( $tools, null );
+
+		$this->assertSame( $tools, $result );
+	}
+
+	public function test_applyAgentPolicy_deny_removes_tools(): void {
+		$tools  = array(
+			'tool_a' => array( 'label' => 'A' ),
+			'tool_b' => array( 'label' => 'B' ),
+			'tool_c' => array( 'label' => 'C' ),
+		);
+		$policy = array(
+			'mode'  => 'deny',
+			'tools' => array( 'tool_b' ),
+		);
+
+		$result = $this->resolver->applyAgentPolicy( $tools, $policy );
+
+		$this->assertArrayHasKey( 'tool_a', $result );
+		$this->assertArrayNotHasKey( 'tool_b', $result );
+		$this->assertArrayHasKey( 'tool_c', $result );
+	}
+
+	public function test_applyAgentPolicy_allow_keeps_only_listed(): void {
+		$tools  = array(
+			'tool_a' => array( 'label' => 'A' ),
+			'tool_b' => array( 'label' => 'B' ),
+			'tool_c' => array( 'label' => 'C' ),
+		);
+		$policy = array(
+			'mode'  => 'allow',
+			'tools' => array( 'tool_a', 'tool_c' ),
+		);
+
+		$result = $this->resolver->applyAgentPolicy( $tools, $policy );
+
+		$this->assertArrayHasKey( 'tool_a', $result );
+		$this->assertArrayNotHasKey( 'tool_b', $result );
+		$this->assertArrayHasKey( 'tool_c', $result );
 	}
 }

--- a/tests/Unit/AI/Tools/WorkspaceScopedToolsTest.php
+++ b/tests/Unit/AI/Tools/WorkspaceScopedToolsTest.php
@@ -34,7 +34,7 @@ class WorkspaceScopedToolsTest extends WP_UnitTestCase {
 		);
 
 		$tools = $this->resolver->resolve( [
-			'surface'              => ToolPolicyResolver::SURFACE_PIPELINE,
+			'context'              => ToolPolicyResolver::CONTEXT_PIPELINE,
 			'previous_step_config' => $previous_step,
 		] );
 
@@ -59,7 +59,7 @@ class WorkspaceScopedToolsTest extends WP_UnitTestCase {
 		);
 
 		$tools = $this->resolver->resolve( [
-			'surface'          => ToolPolicyResolver::SURFACE_PIPELINE,
+			'context'          => ToolPolicyResolver::CONTEXT_PIPELINE,
 			'next_step_config' => $next_step,
 		] );
 

--- a/tests/Unit/AI/Tools/WorkspaceToolsAvailabilityTest.php
+++ b/tests/Unit/AI/Tools/WorkspaceToolsAvailabilityTest.php
@@ -25,7 +25,7 @@ class WorkspaceToolsAvailabilityTest extends WP_UnitTestCase {
 	 */
 	public function test_chat_tools_include_workspace_global_read_tools(): void {
 		$tools = $this->resolver->resolve( [
-			'surface' => ToolPolicyResolver::SURFACE_CHAT,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		] );
 
 		$this->assertIsArray( $tools );
@@ -69,7 +69,7 @@ class WorkspaceToolsAvailabilityTest extends WP_UnitTestCase {
 		$this->assertTrue( $updated );
 
 		$tools = $this->resolver->resolve( [
-			'surface'          => ToolPolicyResolver::SURFACE_PIPELINE,
+			'context'          => ToolPolicyResolver::CONTEXT_PIPELINE,
 			'pipeline_step_id' => $pipeline_step_id,
 		] );
 


### PR DESCRIPTION
## Summary

Phases 2 and 3 of #741 — modernizing the tool system's resolver layer and adding per-agent tool policies.

### Phase 2: Surface → Context rename
- Renamed `SURFACE_*` constants to `CONTEXT_*` (with deprecated `SURFACE_*` aliases)
- Renamed `gatherBySurface()` → `gatherByContext()`, `getSurfaces()` → `getContexts()`
- `resolve()` accepts `'context'` key (falls back to deprecated `'surface'` key)
- Updated all callers: AIStep, ChatOrchestrator, ToolExecutor, ToolManager
- Updated all 5 test files to use new API
- Full backward compatibility preserved

### Phase 3: Per-agent tool policies
- `tool_policy` in `agent_config` JSON: `{ "mode": "deny"|"allow", "tools": ["tool_name", ...] }`
- `deny` mode: agent can use everything EXCEPT listed tools
- `allow` mode: agent can ONLY use listed tools
- No policy = no restrictions (backward compatible)
- `getAgentToolPolicy(agent_id)` reads policy from Agents DB
- `applyAgentPolicy(tools, policy)` filters by deny/allow mode
- `resolve()` applies agent policy between context filtering and explicit deny list
- ChatOrchestrator resolves `agent_id` from `user_id` and passes to resolver
- AIStep reads `agent_id` from job snapshot and passes to resolver

### Resolution precedence (updated)
1. Explicit deny list (always wins)
2. Per-agent tool policy (deny/allow from `agent_config`)
3. Context-level `allow_only`
4. Context preset (pipeline/chat/standalone/system)
5. Global enablement / config requirements

### Testing
- **785 tests, 0 failures** (full suite)
- 18 new agent policy tests covering: deny mode, allow mode, no policy, missing agent, empty tool lists, malformed policy, invalid mode, precedence with explicit deny, cross-context application
- 3 skipped tests are pre-existing fixture tests

### Files changed
- `ToolPolicyResolver.php` — core changes (context rename + agent policy methods)
- `ChatOrchestrator.php` — wired `agent_id` into resolver
- `AIStep.php` — wired `agent_id` from job snapshot into resolver
- `ToolExecutor.php`, `ToolManager.php` — updated to use `CONTEXT_*` constants
- 5 test files updated + 18 new tests

Closes phase 2-3 of #741