### PR TITLE
feat(#761): Granular daily memory selection for flows

### DIFF
--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -634,12 +634,16 @@ class Flows {
 			);
 		}
 
-		$memory_files = $db_flows->get_flow_memory_files( $flow_id );
+		$memory_files  = $db_flows->get_flow_memory_files( $flow_id );
+		$daily_memory  = $db_flows->get_flow_daily_memory( $flow_id );
 
 		return rest_ensure_response(
 			array(
 				'success' => true,
-				'data'    => $memory_files,
+				'data'    => array(
+					'memory_files' => $memory_files,
+					'daily_memory' => $daily_memory,
+				),
 			)
 		);
 	}
@@ -653,9 +657,10 @@ class Flows {
 	 * @return \WP_REST_Response|\WP_Error Response.
 	 */
 	public static function handle_update_memory_files( $request ) {
-		$flow_id      = (int) $request->get_param( 'flow_id' );
-		$params       = $request->get_json_params();
-		$memory_files = $params['memory_files'] ?? array();
+		$flow_id       = (int) $request->get_param( 'flow_id' );
+		$params        = $request->get_json_params();
+		$memory_files  = $params['memory_files'] ?? array();
+		$daily_memory  = $params['daily_memory'] ?? null;
 
 		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
 		$flow     = $db_flows->get_flow( $flow_id );
@@ -681,7 +686,12 @@ class Flows {
 		$memory_files = array_map( 'sanitize_file_name', $memory_files );
 		$memory_files = array_values( array_filter( $memory_files ) );
 
-		$result = $db_flows->update_flow_memory_files( $flow_id, $memory_files );
+		// Sanitize daily_memory config if provided.
+		if ( null !== $daily_memory ) {
+			$daily_memory = self::sanitize_daily_memory( $daily_memory );
+		}
+
+		$result = $db_flows->update_flow_memory_files( $flow_id, $memory_files, $daily_memory );
 
 		if ( ! $result ) {
 			return new \WP_Error(
@@ -694,9 +704,78 @@ class Flows {
 		return rest_ensure_response(
 			array(
 				'success' => true,
-				'data'    => $memory_files,
+				'data'    => array(
+					'memory_files' => $memory_files,
+					'daily_memory' => $daily_memory ?? $db_flows->get_flow_daily_memory( $flow_id ),
+				),
 				'message' => __( 'Flow memory files updated successfully.', 'data-machine' ),
 			)
 		);
+	}
+
+	/**
+	 * Sanitize daily memory configuration.
+	 *
+	 * @since 0.40.0
+	 *
+	 * @param array $config Raw daily memory config.
+	 * @return array Sanitized config.
+	 */
+	private static function sanitize_daily_memory( array $config ): array {
+		$allowed_modes = array( 'none', 'recent_days', 'specific_dates', 'date_range', 'months' );
+		$mode          = $config['mode'] ?? 'none';
+
+		if ( ! in_array( $mode, $allowed_modes, true ) ) {
+			$mode = 'none';
+		}
+
+		$sanitized = array( 'mode' => $mode );
+
+		switch ( $mode ) {
+			case 'recent_days':
+				$sanitized['days'] = min( max( (int) ( $config['days'] ?? 7 ), 1 ), 90 );
+				break;
+
+			case 'specific_dates':
+				$dates = $config['dates'] ?? array();
+				$sanitized['dates'] = array_values(
+					array_filter(
+						array_map(
+							function ( $date ) {
+								return preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ? $date : null;
+							},
+							(array) $dates
+						)
+					)
+				);
+				break;
+
+			case 'date_range':
+				$from = $config['from'] ?? null;
+				$to   = $config['to'] ?? null;
+				if ( $from && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $from ) ) {
+					$sanitized['from'] = $from;
+				}
+				if ( $to && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $to ) ) {
+					$sanitized['to'] = $to;
+				}
+				break;
+
+			case 'months':
+				$months = $config['months'] ?? array();
+				$sanitized['months'] = array_values(
+					array_filter(
+						array_map(
+							function ( $month ) {
+								return preg_match( '/^\d{4}\/\d{2}$/', $month ) ? $month : null;
+							},
+							(array) $months
+						)
+					)
+				);
+				break;
+		}
+
+		return $sanitized;
 	}
 }

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowMemoryFiles.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowMemoryFiles.jsx
@@ -4,6 +4,8 @@
  * Allows selecting agent memory files to include in flow AI context.
  * Flow memory files are additive — they inject alongside pipeline memory files.
  * Delegates to the shared MemoryFilesSelector component.
+ *
+ * @since 0.40.0 Added daily memory support.
  */
 
 /**
@@ -23,16 +25,21 @@ import {
  * @return {React.ReactElement} Memory files selector for flow scope
  */
 export default function FlowMemoryFiles( { flowId } ) {
-	const { data: selectedFiles = [], isLoading } =
-		useFlowMemoryFiles( flowId );
+	const { data, isLoading } = useFlowMemoryFiles( flowId );
 	const updateMutation = useUpdateFlowMemoryFiles( flowId );
+
+	// Extract memory files and daily memory from the query response.
+	const selectedFiles = data?.memoryFiles || [];
+	const dailyMemory = data?.dailyMemory || { mode: 'none' };
 
 	return (
 		<MemoryFilesSelector
 			scopeLabel="flow"
 			selectedFiles={ selectedFiles }
+			dailyMemory={ dailyMemory }
 			isLoading={ isLoading }
 			updateMutation={ updateMutation }
+			showDailyMemory={ true }
 		/>
 	);
 }

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineMemoryFiles.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineMemoryFiles.jsx
@@ -3,6 +3,9 @@
  *
  * Allows selecting agent memory files to include in pipeline AI context.
  * Delegates to the shared MemoryFilesSelector component.
+ *
+ * Note: Daily memory selection is flow-scoped, not pipeline-scoped.
+ * Pipelines only select custom memory files.
  */
 
 /**
@@ -32,6 +35,7 @@ export default function PipelineMemoryFiles( { pipelineId } ) {
 			selectedFiles={ selectedFiles }
 			isLoading={ isLoading }
 			updateMutation={ updateMutation }
+			showDailyMemory={ false }
 		/>
 	);
 }

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/DailyMemorySelector.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/DailyMemorySelector.jsx
@@ -1,0 +1,564 @@
+/**
+ * Daily Memory Selector Component
+ *
+ * UI for selecting which daily memory files to include in AI context.
+ * Supports multiple selection modes: recent days, specific dates,
+ * date ranges, and entire months.
+ *
+ * @since 0.40.0
+ * @see https://github.com/Extra-Chill/data-machine/issues/761
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
+import {
+	RadioControl,
+	NumberControl,
+	DatePicker,
+	CheckboxControl,
+	Button,
+	Spinner,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { useAgentFiles } from '../../queries/pipelines';
+
+/**
+ * Default daily memory config.
+ */
+const DEFAULT_CONFIG = {
+	mode: 'none',
+	days: 7,
+	dates: [],
+	from: null,
+	to: null,
+	months: [],
+};
+
+/**
+ * Format a date string for display.
+ *
+ * @param {string} dateStr Date in YYYY-MM-DD format.
+ * @return {string} Human-readable date.
+ */
+const formatDateLabel = ( dateStr ) => {
+	try {
+		const date = new Date( dateStr + 'T00:00:00' );
+		return date.toLocaleDateString( undefined, {
+			weekday: 'short',
+			month: 'short',
+			day: 'numeric',
+		} );
+	} catch {
+		return dateStr;
+	}
+};
+
+/**
+ * Format a month key (YYYY/MM) for display.
+ *
+ * @param {string} monthKey Month key like '2026/03'.
+ * @return {string} Human-readable month like 'March 2026'.
+ */
+const formatMonthLabel = ( monthKey ) => {
+	const [ year, month ] = monthKey.split( '/' );
+	const date = new Date( parseInt( year, 10 ), parseInt( month, 10 ) - 1 );
+	return date.toLocaleDateString( undefined, {
+		year: 'numeric',
+		month: 'long',
+	} );
+};
+
+/**
+ * Get today's date in YYYY-MM-DD format.
+ *
+ * @return {string} Today's date.
+ */
+const getTodayDate = () => {
+	const now = new Date();
+	return now.toISOString().split( 'T' )[ 0 ];
+};
+
+/**
+ * Daily Memory Selector Component
+ *
+ * @param {Object}   props               - Component props
+ * @param {Object}   props.config        - Current daily memory config
+ * @param {Function} props.onChange      - Callback when config changes
+ * @param {boolean}  props.disabled      - Whether the selector is disabled
+ * @return {React.ReactElement} Daily memory selector UI
+ */
+export default function DailyMemorySelector( { config, onChange, disabled = false } ) {
+	const { data: agentFiles = [], isLoading } = useAgentFiles();
+
+	// Extract daily memory summary from agent files.
+	const dailySummary = useMemo( () => {
+		return agentFiles.find( ( f ) => f.type === 'daily_summary' );
+	}, [ agentFiles ] );
+
+	// Available months from the daily memory files.
+	const availableMonths = useMemo( () => {
+		if ( ! dailySummary?.months ) {
+			return [];
+		}
+		return Object.keys( dailySummary.months );
+	}, [ dailySummary ] );
+
+	// Available dates grouped by month.
+	const availableDatesByMonth = useMemo( () => {
+		if ( ! dailySummary?.months ) {
+			return {};
+		}
+		const result = {};
+		for ( const [ monthKey, days ] of Object.entries( dailySummary.months ) ) {
+			const [ year, month ] = monthKey.split( '/' );
+			result[ monthKey ] = days.map( ( day ) => `${ year }-${ month }-${ day }` );
+		}
+		return result;
+	}, [ dailySummary ] );
+
+	// Local state for the config.
+	const [ localConfig, setLocalConfig ] = useState( config || DEFAULT_CONFIG );
+
+	// Sync local state when prop changes.
+	useEffect( () => {
+		setLocalConfig( config || DEFAULT_CONFIG );
+	}, [ config ] );
+
+	// Update a single field in the config.
+	const updateConfig = useCallback(
+		( key, value ) => {
+			const newConfig = { ...localConfig, [ key ]: value };
+			setLocalConfig( newConfig );
+			onChange( newConfig );
+		},
+		[ localConfig, onChange ]
+	);
+
+	// Handle mode change - reset mode-specific fields.
+	const handleModeChange = useCallback(
+		( newMode ) => {
+			const newConfig = {
+				mode: newMode,
+				days: newMode === 'recent_days' ? 7 : undefined,
+				dates: newMode === 'specific_dates' ? [] : undefined,
+				from: newMode === 'date_range' ? null : undefined,
+				to: newMode === 'date_range' ? null : undefined,
+				months: newMode === 'months' ? [] : undefined,
+			};
+			setLocalConfig( newConfig );
+			onChange( newConfig );
+		},
+		[ onChange ]
+	);
+
+	// Toggle a specific date in the dates array.
+	const toggleDate = useCallback(
+		( date ) => {
+			const currentDates = localConfig.dates || [];
+			const newDates = currentDates.includes( date )
+				? currentDates.filter( ( d ) => d !== date )
+				: [ ...currentDates, date ];
+			updateConfig( 'dates', newDates );
+		},
+		[ localConfig.dates, updateConfig ]
+	);
+
+	// Toggle a month in the months array.
+	const toggleMonth = useCallback(
+		( monthKey ) => {
+			const currentMonths = localConfig.months || [];
+			const newMonths = currentMonths.includes( monthKey )
+				? currentMonths.filter( ( m ) => m !== monthKey )
+				: [ ...currentMonths, monthKey ];
+			updateConfig( 'months', newMonths );
+		},
+		[ localConfig.months, updateConfig ]
+	);
+
+	// Select all dates in a month.
+	const selectAllInMonth = useCallback(
+		( monthKey ) => {
+			const monthDates = availableDatesByMonth[ monthKey ] || [];
+			const currentDates = localConfig.dates || [];
+			const allSelected = monthDates.every( ( d ) =>
+				currentDates.includes( d )
+			);
+
+			let newDates;
+			if ( allSelected ) {
+				// Deselect all in this month.
+				newDates = currentDates.filter(
+					( d ) => ! monthDates.includes( d )
+				);
+			} else {
+				// Select all in this month (merge with existing).
+				newDates = [ ...new Set( [ ...currentDates, ...monthDates ] ) ];
+			}
+			updateConfig( 'dates', newDates );
+		},
+		[ availableDatesByMonth, localConfig.dates, updateConfig ]
+	);
+
+	if ( isLoading ) {
+		return (
+			<div
+				style={ {
+					textAlign: 'center',
+					padding: '20px',
+					color: '#757575',
+				} }
+			>
+				<Spinner />
+			</div>
+		);
+	}
+
+	// No daily memory files available.
+	if ( ! dailySummary || ! availableMonths.length ) {
+		return (
+			<div
+				style={ {
+					color: '#757575',
+					fontStyle: 'italic',
+					padding: '12px 0',
+				} }
+			>
+				{ __(
+					'No daily memory files available. Daily memory will appear here once generated.',
+					'data-machine'
+				) }
+			</div>
+		);
+	}
+
+	const modeOptions = [
+		{ label: __( 'None', 'data-machine' ), value: 'none' },
+		{
+			label: __( 'Recent days', 'data-machine' ),
+			value: 'recent_days',
+		},
+		{
+			label: __( 'Specific dates', 'data-machine' ),
+			value: 'specific_dates',
+		},
+		{
+			label: __( 'Date range', 'data-machine' ),
+			value: 'date_range',
+		},
+		{
+			label: __( 'Entire months', 'data-machine' ),
+			value: 'months',
+		},
+	];
+
+	return (
+		<div className="datamachine-daily-memory-selector">
+			<h4
+				style={ {
+					margin: '0 0 12px 0',
+					fontSize: '14px',
+					fontWeight: '600',
+				} }
+			>
+				{ __( 'Daily Memory', 'data-machine' ) }
+			</h4>
+			<p
+				style={ {
+					margin: '0 0 12px 0',
+					color: '#757575',
+					fontSize: '13px',
+				} }
+			>
+				{ __(
+					'Select which daily memory files to include in AI context.',
+					'data-machine'
+				) }
+			</p>
+
+			<RadioControl
+				selected={ localConfig.mode || 'none' }
+				options={ modeOptions }
+				onChange={ handleModeChange }
+				disabled={ disabled }
+			/>
+
+			{/* Recent Days Mode */}
+			{ localConfig.mode === 'recent_days' && (
+				<div
+					style={ {
+						marginTop: '12px',
+						padding: '12px',
+						background: '#f9f9f9',
+						borderRadius: '4px',
+					} }
+				>
+					<NumberControl
+						label={ __( 'Number of days', 'data-machine' ) }
+						value={ localConfig.days || 7 }
+						onChange={ ( value ) =>
+							updateConfig(
+								'days',
+								Math.max( 1, Math.min( 90, value || 7 ) )
+							)
+						}
+						min={ 1 }
+						max={ 90 }
+						disabled={ disabled }
+					/>
+					<p
+						className="description"
+						style={ { marginTop: '8px' } }
+					>
+						{ __(
+							'Include daily memory from the past N days (max 90).',
+							'data-machine'
+						) }
+					</p>
+				</div>
+			) }
+
+			{/* Specific Dates Mode */}
+			{ localConfig.mode === 'specific_dates' && (
+				<div
+					style={ {
+						marginTop: '12px',
+						padding: '12px',
+						background: '#f9f9f9',
+						borderRadius: '4px',
+						maxHeight: '300px',
+						overflowY: 'auto',
+					} }
+				>
+					<p
+						style={ {
+							margin: '0 0 8px 0',
+							fontSize: '13px',
+							fontWeight: '500',
+						} }
+					>
+						{ __( 'Select specific dates:', 'data-machine' ) }
+					</p>
+					{ availableMonths.map( ( monthKey ) => {
+						const monthDates =
+							availableDatesByMonth[ monthKey ] || [];
+						const allSelected = monthDates.every( ( d ) =>
+							( localConfig.dates || [] ).includes( d )
+						);
+						const someSelected = monthDates.some( ( d ) =>
+							( localConfig.dates || [] ).includes( d )
+						);
+
+						return (
+							<div
+								key={ monthKey }
+								style={ { marginBottom: '12px' } }
+							>
+								<div
+									style={ {
+										display: 'flex',
+										alignItems: 'center',
+										gap: '8px',
+										marginBottom: '4px',
+									} }
+								>
+									<CheckboxControl
+										checked={ allSelected }
+										onChange={ () =>
+											selectAllInMonth( monthKey )
+										}
+										disabled={ disabled }
+										__nextHasNoMarginBottom
+									/>
+									<strong>{ formatMonthLabel( monthKey ) }</strong>
+									<span
+										style={ {
+											color: '#757575',
+											fontSize: '12px',
+										} }
+									>
+										({ monthDates.length } days)
+									</span>
+								</div>
+								<div
+									style={ {
+										display: 'flex',
+										flexWrap: 'wrap',
+										gap: '4px',
+										marginLeft: '24px',
+									} }
+								>
+									{ monthDates
+										.sort()
+										.reverse()
+										.map( ( date ) => (
+											<CheckboxControl
+												key={ date }
+												label={ formatDateLabel( date ) }
+												checked={ (
+													localConfig.dates || []
+												).includes( date ) }
+												onChange={ () =>
+													toggleDate( date )
+												}
+												disabled={ disabled }
+												__nextHasNoMarginBottom
+											/>
+										) ) }
+								</div>
+							</div>
+						);
+					} ) }
+				</div>
+			) }
+
+			{/* Date Range Mode */}
+			{ localConfig.mode === 'date_range' && (
+				<div
+					style={ {
+						marginTop: '12px',
+						padding: '12px',
+						background: '#f9f9f9',
+						borderRadius: '4px',
+					} }
+				>
+					<div
+						style={ {
+							display: 'flex',
+							gap: '16px',
+							flexWrap: 'wrap',
+						} }
+					>
+						<div>
+							<label
+								style={ {
+									display: 'block',
+									marginBottom: '4px',
+									fontSize: '13px',
+									fontWeight: '500',
+								} }
+							>
+								{ __( 'From', 'data-machine' ) }
+							</label>
+							<input
+								type="date"
+								value={ localConfig.from || '' }
+								onChange={ ( e ) =>
+									updateConfig( 'from', e.target.value || null )
+								}
+								disabled={ disabled }
+								max={ localConfig.to || getTodayDate() }
+							/>
+						</div>
+						<div>
+							<label
+								style={ {
+									display: 'block',
+									marginBottom: '4px',
+									fontSize: '13px',
+									fontWeight: '500',
+								} }
+							>
+								{ __( 'To', 'data-machine' ) }
+							</label>
+							<input
+								type="date"
+								value={ localConfig.to || '' }
+								onChange={ ( e ) =>
+									updateConfig( 'to', e.target.value || null )
+								}
+								disabled={ disabled }
+								min={ localConfig.from || undefined }
+								max={ getTodayDate() }
+							/>
+						</div>
+					</div>
+					<p
+						className="description"
+						style={ { marginTop: '8px' } }
+					>
+						{ __(
+							'Include all daily memory files within the date range.',
+							'data-machine'
+						) }
+					</p>
+				</div>
+			) }
+
+			{/* Months Mode */}
+			{ localConfig.mode === 'months' && (
+				<div
+					style={ {
+						marginTop: '12px',
+						padding: '12px',
+						background: '#f9f9f9',
+						borderRadius: '4px',
+					} }
+				>
+					<p
+						style={ {
+							margin: '0 0 8px 0',
+							fontSize: '13px',
+							fontWeight: '500',
+						} }
+					>
+						{ __( 'Select months:', 'data-machine' ) }
+					</p>
+					<div
+						style={ {
+							display: 'flex',
+							flexDirection: 'column',
+							gap: '8px',
+						} }
+					>
+						{ availableMonths.map( ( monthKey ) => {
+							const dayCount =
+								dailySummary.months[ monthKey ]?.length || 0;
+							return (
+								<CheckboxControl
+									key={ monthKey }
+									label={ `${ formatMonthLabel( monthKey) } (${ dayCount } days)` }
+									checked={ (
+										localConfig.months || []
+									).includes( monthKey ) }
+									onChange={ () => toggleMonth( monthKey ) }
+									disabled={ disabled }
+									__nextHasNoMarginBottom
+								/>
+							);
+						} ) }
+					</div>
+				</div>
+			) }
+
+			{/* Summary */}
+			{ localConfig.mode !== 'none' && (
+				<div
+					style={ {
+						marginTop: '12px',
+						padding: '8px 12px',
+						background: '#e7f3ff',
+						borderRadius: '4px',
+						fontSize: '13px',
+					} }
+				>
+					<strong>{ __( 'Selection:', 'data-machine' ) }</strong>{ ' ' }
+					{ localConfig.mode === 'recent_days' &&
+						`Past ${ localConfig.days || 7 } days` }
+					{ localConfig.mode === 'specific_dates' &&
+						`${ ( localConfig.dates || [] ).length } date(s) selected` }
+					{ localConfig.mode === 'date_range' &&
+						( localConfig.from || localConfig.to
+							? `${ localConfig.from || '...' } to ${ localConfig.to || '...' }`
+							: 'No range set' ) }
+					{ localConfig.mode === 'months' &&
+						`${ ( localConfig.months || [] ).length } month(s) selected` }
+				</div>
+			) }
+		</div>
+	);
+}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/MemoryFilesSelector.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/MemoryFilesSelector.jsx
@@ -3,18 +3,21 @@
  *
  * Reusable component for selecting agent memory files.
  * Used by both pipeline-scoped and flow-scoped memory file UIs.
+ *
+ * @since 0.40.0 Added daily memory selector support.
  */
 
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useCallback } from '@wordpress/element';
 import { CheckboxControl, Button, Notice, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
 import { useAgentFiles } from '../../queries/pipelines';
+import DailyMemorySelector from './DailyMemorySelector';
 
 /**
  * Files to exclude from the memory files picker (always injected separately).
@@ -22,25 +25,35 @@ import { useAgentFiles } from '../../queries/pipelines';
 const EXCLUDED_FILES = [ 'SOUL.md', 'USER.md', 'MEMORY.md' ];
 
 /**
+ * Default daily memory config.
+ */
+const DEFAULT_DAILY_MEMORY = { mode: 'none' };
+
+/**
  * Memory Files Selector Component
  *
- * @param {Object}   props               - Component props
- * @param {string}   props.scopeLabel    - Label for the scope (e.g. 'pipeline', 'flow')
- * @param {Array}    props.selectedFiles - Currently selected filenames
- * @param {boolean}  props.isLoading     - Whether selected files are loading
- * @param {Object}   props.updateMutation - TanStack mutation for saving
+ * @param {Object}   props                  - Component props
+ * @param {string}   props.scopeLabel       - Label for the scope (e.g. 'pipeline', 'flow')
+ * @param {Array}    props.selectedFiles    - Currently selected filenames
+ * @param {Object}   props.dailyMemory      - Current daily memory config
+ * @param {boolean}  props.isLoading        - Whether selected files are loading
+ * @param {Object}   props.updateMutation   - TanStack mutation for saving
+ * @param {boolean}  props.showDailyMemory  - Whether to show daily memory selector (default: true)
  * @return {React.ReactElement} Memory files selector
  */
 export default function MemoryFilesSelector( {
 	scopeLabel,
 	selectedFiles = [],
+	dailyMemory = DEFAULT_DAILY_MEMORY,
 	isLoading: loadingSelected = false,
 	updateMutation,
+	showDailyMemory = true,
 } ) {
 	const { data: agentFiles = [], isLoading: loadingAgent } =
 		useAgentFiles();
 
 	const [ localSelected, setLocalSelected ] = useState( [] );
+	const [ localDailyMemory, setLocalDailyMemory ] = useState( DEFAULT_DAILY_MEMORY );
 	const [ success, setSuccess ] = useState( null );
 
 	// Sync local state when server data loads.
@@ -48,10 +61,15 @@ export default function MemoryFilesSelector( {
 		setLocalSelected( selectedFiles );
 	}, [ selectedFiles ] );
 
+	useEffect( () => {
+		setLocalDailyMemory( dailyMemory || DEFAULT_DAILY_MEMORY );
+	}, [ dailyMemory ] );
+
 	const loading = loadingAgent || loadingSelected;
 
-	// Filter out core files and non-text files.
+	// Filter out core files, non-text files, and daily_summary type.
 	const availableFiles = agentFiles
+		.filter( ( f ) => f.type !== 'daily_summary' )
 		.map( ( f ) => ( typeof f === 'string' ? f : f.name || f.filename ) )
 		.filter( ( name ) => name && ! EXCLUDED_FILES.includes( name ) );
 
@@ -63,10 +81,19 @@ export default function MemoryFilesSelector( {
 		);
 	};
 
+	const handleDailyMemoryChange = useCallback( ( newConfig ) => {
+		setLocalDailyMemory( newConfig );
+	}, [] );
+
 	const handleSave = async () => {
 		setSuccess( null );
 		try {
-			await updateMutation.mutateAsync( localSelected );
+			// Check if the mutation expects the new format.
+			// The mutation function receives { memoryFiles, dailyMemory }.
+			await updateMutation.mutateAsync( {
+				memoryFiles: localSelected,
+				dailyMemory: localDailyMemory,
+			} );
 			setSuccess(
 				__( 'Memory files updated successfully!', 'data-machine' )
 			);
@@ -76,9 +103,12 @@ export default function MemoryFilesSelector( {
 		}
 	};
 
+	// Check if either memory files or daily memory have changed.
 	const isDirty =
 		JSON.stringify( [ ...localSelected ].sort() ) !==
-		JSON.stringify( [ ...selectedFiles ].sort() );
+			JSON.stringify( [ ...selectedFiles ].sort() ) ||
+		JSON.stringify( localDailyMemory ) !==
+			JSON.stringify( dailyMemory || DEFAULT_DAILY_MEMORY );
 
 	return (
 		<div className="datamachine-memory-files-selector">
@@ -135,46 +165,69 @@ export default function MemoryFilesSelector( {
 				>
 					<Spinner />
 				</div>
-			) : availableFiles.length === 0 ? (
-				<p
-					style={ {
-						color: '#757575',
-						fontStyle: 'italic',
-						padding: '12px 0',
-					} }
-				>
-					{ __(
-						'No agent memory files available. Upload files to the agent directory first.',
-						'data-machine'
-					) }
-				</p>
 			) : (
 				<>
-					<div
-						style={ {
-							display: 'flex',
-							flexDirection: 'column',
-							gap: '8px',
-							marginBottom: '16px',
-						} }
-					>
-						{ availableFiles.map( ( filename ) => (
-							<CheckboxControl
-								key={ filename }
-								label={ filename }
-								checked={ localSelected.includes( filename ) }
-								onChange={ ( checked ) =>
-									handleToggle( filename, checked )
-								}
+					{/* Custom Memory Files Section */}
+					{ availableFiles.length > 0 && (
+						<div
+							style={ {
+								display: 'flex',
+								flexDirection: 'column',
+								gap: '8px',
+								marginBottom: '16px',
+							} }
+						>
+							{ availableFiles.map( ( filename ) => (
+								<CheckboxControl
+									key={ filename }
+									label={ filename }
+									checked={ localSelected.includes( filename ) }
+									onChange={ ( checked ) =>
+										handleToggle( filename, checked )
+									}
+								/>
+							) ) }
+						</div>
+					) }
+
+					{ availableFiles.length === 0 && (
+						<p
+							style={ {
+								color: '#757575',
+								fontStyle: 'italic',
+								padding: '12px 0',
+							} }
+						>
+							{ __(
+								'No custom memory files available. Add .md files to the agent directory.',
+								'data-machine'
+							) }
+						</p>
+					) }
+
+					{/* Daily Memory Selector Section */}
+					{ showDailyMemory && (
+						<div
+							style={ {
+								marginTop: '20px',
+								paddingTop: '20px',
+								borderTop: '1px solid #ddd',
+							} }
+						>
+							<DailyMemorySelector
+								config={ localDailyMemory }
+								onChange={ handleDailyMemoryChange }
+								disabled={ updateMutation.isPending }
 							/>
-						) ) }
-					</div>
+						</div>
+					) }
 
 					<Button
 						variant="primary"
 						onClick={ handleSave }
 						disabled={ ! isDirty || updateMutation.isPending }
 						isBusy={ updateMutation.isPending }
+						style={ { marginTop: '16px' } }
 					>
 						{ updateMutation.isPending
 							? __( 'Saving…', 'data-machine' )

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
@@ -488,7 +488,21 @@ export const useFlowMemoryFiles = ( flowId ) =>
 		queryKey: [ 'flow-memory-files', flowId ],
 		queryFn: async () => {
 			const response = await fetchFlowMemoryFiles( flowId );
-			return response.success ? response.data : [];
+			if ( response.success && response.data ) {
+				// Handle new format with memory_files and daily_memory
+				if ( typeof response.data === 'object' && ! Array.isArray( response.data ) ) {
+					return {
+						memoryFiles: response.data.memory_files || [],
+						dailyMemory: response.data.daily_memory || { mode: 'none' },
+					};
+				}
+				// Backward compat: old format was just an array
+				return {
+					memoryFiles: response.data,
+					dailyMemory: { mode: 'none' },
+				};
+			}
+			return { memoryFiles: [], dailyMemory: { mode: 'none' } };
 		},
 		enabled: !! flowId,
 	} );
@@ -496,8 +510,8 @@ export const useFlowMemoryFiles = ( flowId ) =>
 export const useUpdateFlowMemoryFiles = ( flowId ) => {
 	const queryClient = useQueryClient();
 	return useMutation( {
-		mutationFn: ( filenames ) =>
-			updateFlowMemoryFiles( flowId, filenames ),
+		mutationFn: ( { memoryFiles, dailyMemory } ) =>
+			updateFlowMemoryFiles( flowId, memoryFiles, dailyMemory ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'flow-memory-files', flowId ],

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
@@ -289,8 +289,11 @@ export const usePipelineMemoryFiles = ( pipelineId ) =>
 export const useUpdatePipelineMemoryFiles = ( pipelineId ) => {
 	const queryClient = useQueryClient();
 	return useMutation( {
-		mutationFn: ( filenames ) =>
-			updatePipelineMemoryFiles( pipelineId, filenames ),
+		mutationFn: ( data ) => {
+			// Support both old format (array) and new format ({ memoryFiles, dailyMemory }).
+			const filenames = Array.isArray( data ) ? data : data.memoryFiles;
+			return updatePipelineMemoryFiles( pipelineId, filenames );
+		},
 		onSuccess: () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'pipeline-memory-files', pipelineId ],

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -455,7 +455,7 @@ export const updatePipelineMemoryFiles = async ( pipelineId, memoryFiles ) => {
  * Fetch memory files for a flow
  *
  * @param {number} flowId - Flow ID
- * @return {Promise<Object>} Array of memory filenames
+ * @return {Promise<Object>} Object with memory_files and daily_memory
  */
 export const fetchFlowMemoryFiles = async ( flowId ) => {
 	return await client.get( `/flows/${ flowId }/memory-files` );
@@ -464,14 +464,17 @@ export const fetchFlowMemoryFiles = async ( flowId ) => {
 /**
  * Update memory files for a flow
  *
- * @param {number}        flowId      - Flow ID
- * @param {Array<string>} memoryFiles - Array of filenames
+ * @param {number}        flowId       - Flow ID
+ * @param {Array<string>} memoryFiles  - Array of filenames
+ * @param {Object|null}   dailyMemory  - Optional daily memory config
  * @return {Promise<Object>} Update confirmation
  */
-export const updateFlowMemoryFiles = async ( flowId, memoryFiles ) => {
-	return await client.put( `/flows/${ flowId }/memory-files`, {
-		memory_files: memoryFiles,
-	} );
+export const updateFlowMemoryFiles = async ( flowId, memoryFiles, dailyMemory = null ) => {
+	const payload = { memory_files: memoryFiles };
+	if ( dailyMemory !== null ) {
+		payload.daily_memory = dailyMemory;
+	}
+	return await client.put( `/flows/${ flowId }/memory-files`, payload );
 };
 
 /**

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -744,13 +744,30 @@ class Flows extends BaseRepository {
 	}
 
 	/**
+	 * Get flow daily memory config from flow config.
+	 *
+	 * @since 0.40.0
+	 *
+	 * @param int $flow_id Flow ID.
+	 * @return array Daily memory config with 'mode' and mode-specific fields.
+	 */
+	public function get_flow_daily_memory( int $flow_id ): array {
+		$flow = $this->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return array( 'mode' => 'none' );
+		}
+		return $flow['flow_config']['daily_memory'] ?? array( 'mode' => 'none' );
+	}
+
+	/**
 	 * Update flow memory files in flow config.
 	 *
-	 * @param int   $flow_id      Flow ID.
-	 * @param array $memory_files Array of memory filenames.
+	 * @param int   $flow_id       Flow ID.
+	 * @param array $memory_files  Array of memory filenames.
+	 * @param array $daily_memory  Optional. Daily memory config array.
 	 * @return bool True on success, false on failure.
 	 */
-	public function update_flow_memory_files( int $flow_id, array $memory_files ): bool {
+	public function update_flow_memory_files( int $flow_id, array $memory_files, array $daily_memory = null ): bool {
 		if ( empty( $flow_id ) ) {
 			return false;
 		}
@@ -769,6 +786,11 @@ class Flows extends BaseRepository {
 
 		$flow_config                 = json_decode( $raw_config_json, true ) ?? array();
 		$flow_config['memory_files'] = $memory_files;
+
+		// Update daily_memory if provided.
+		if ( null !== $daily_memory ) {
+			$flow_config['daily_memory'] = $daily_memory;
+		}
 
 		$result = $this->wpdb->update(
 			$this->table_name,

--- a/inc/Engine/AI/Directives/DailyMemorySelectorDirective.php
+++ b/inc/Engine/AI/Directives/DailyMemorySelectorDirective.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * Daily Memory Selector Directive - Priority 46
+ *
+ * Injects daily memory files based on flow configuration.
+ * Supports multiple selection modes: recent days, specific dates,
+ * date ranges, and entire months.
+ *
+ * Priority Order in Directive System:
+ * 1. Priority 10 - Plugin Core Directive (agent identity)
+ * 2. Priority 20 - Core Memory Files (SOUL.md, USER.md, MEMORY.md, etc.)
+ * 3. Priority 40 - Pipeline Memory Files (per-pipeline selectable)
+ * 4. Priority 45 - Flow Memory Files (per-flow selectable)
+ * 5. Priority 46 - Daily Memory Selector (THIS CLASS - per-flow daily config)
+ * 6. Priority 50 - Pipeline System Prompt (pipeline instructions)
+ * 7. Priority 60 - Pipeline Context Files
+ * 8. Priority 70 - Tool Definitions (available tools and workflow)
+ * 9. Priority 80 - Site Context (WordPress metadata)
+ *
+ * @package DataMachine\Engine\AI\Directives
+ * @since   0.40.0
+ * @see     https://github.com/Extra-Chill/data-machine/issues/761
+ */
+
+namespace DataMachine\Engine\AI\Directives;
+
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\FilesRepository\DailyMemory;
+use DataMachine\Core\FilesRepository\DirectoryManager;
+
+defined( 'ABSPATH' ) || exit;
+
+class DailyMemorySelectorDirective implements DirectiveInterface {
+
+	/**
+	 * Maximum total size of daily memory content to inject (in bytes).
+	 *
+	 * @var int
+	 */
+	private const MAX_TOTAL_SIZE = 100 * 1024; // 100KB
+
+	/**
+	 * Get directive outputs for daily memory files based on flow config.
+	 *
+	 * @param string      $provider_name AI provider name.
+	 * @param array       $tools         Available tools.
+	 * @param string|null $step_id       Pipeline step ID.
+	 * @param array       $payload       Additional payload data (contains flow_step_id).
+	 * @return array Directive outputs.
+	 */
+	public static function get_outputs( string $provider_name, array $tools, ?string $step_id = null, array $payload = array() ): array {
+		$flow_step_id = $payload['flow_step_id'] ?? null;
+
+		if ( empty( $flow_step_id ) ) {
+			return array();
+		}
+
+		// Extract flow_id from flow_step_id via the DM filter.
+		$parts = apply_filters( 'datamachine_split_flow_step_id', null, $flow_step_id );
+		if ( ! $parts || empty( $parts['flow_id'] ) ) {
+			return array();
+		}
+
+		$flow_id         = (int) $parts['flow_id'];
+		$user_id         = (int) ( $payload['user_id'] ?? 0 );
+		$agent_id        = (int) ( $payload['agent_id'] ?? 0 );
+		$daily_memory    = new DailyMemory( $user_id, $agent_id );
+		$daily_config    = self::get_daily_memory_config( $flow_id );
+		$dates_to_inject = self::resolve_dates( $daily_config, $daily_memory );
+
+		if ( empty( $dates_to_inject ) ) {
+			return array();
+		}
+
+		$outputs     = array();
+		$total_size  = 0;
+		$files_added = 0;
+
+		// Sort dates descending (newest first).
+		rsort( $dates_to_inject );
+
+		foreach ( $dates_to_inject as $date ) {
+			$parts = DailyMemory::parse_date( $date );
+			if ( ! $parts ) {
+				continue;
+			}
+
+			$result = $daily_memory->read( $parts['year'], $parts['month'], $parts['day'] );
+			if ( ! $result['success'] || empty( trim( $result['content'] ?? '' ) ) ) {
+				continue;
+			}
+
+			$content      = trim( $result['content'] );
+			$content_size = strlen( $content );
+
+			// Enforce total size limit.
+			if ( $total_size + $content_size > self::MAX_TOTAL_SIZE ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					'Daily Memory Selector: Size limit reached, truncating',
+					array(
+						'flow_id'     => $flow_id,
+						'files_added' => $files_added,
+						'total_size'  => $total_size,
+						'max_size'    => self::MAX_TOTAL_SIZE,
+					)
+				);
+				break;
+			}
+
+			$outputs[]   = array(
+				'type'    => 'system_text',
+				'content' => "## Daily Memory: {$date}\n{$content}",
+			);
+			$total_size  += $content_size;
+			$files_added += 1;
+		}
+
+		if ( ! empty( $outputs ) ) {
+			do_action(
+				'datamachine_log',
+				'debug',
+				'Daily Memory Selector: Injected daily memory files',
+				array(
+					'flow_id'     => $flow_id,
+					'mode'        => $daily_config['mode'] ?? 'none',
+					'files_added' => $files_added,
+					'total_size'  => $total_size,
+				)
+			);
+		}
+
+		return $outputs;
+	}
+
+	/**
+	 * Get the daily memory configuration for a flow.
+	 *
+	 * @param int $flow_id Flow ID.
+	 * @return array Daily memory config with 'mode' and mode-specific fields.
+	 */
+	private static function get_daily_memory_config( int $flow_id ): array {
+		$db_flows = new Flows();
+		$flow     = $db_flows->get_flow( $flow_id );
+
+		if ( ! $flow ) {
+			return array( 'mode' => 'none' );
+		}
+
+		$config = $flow['flow_config']['daily_memory'] ?? array();
+
+		// Normalize legacy boolean to new format.
+		if ( ! isset( $config['mode'] ) ) {
+			// Check for legacy include_daily flag.
+			$include_daily = $flow['flow_config']['include_daily'] ?? false;
+			if ( $include_daily ) {
+				return array(
+					'mode' => 'recent_days',
+					'days' => 7,
+				);
+			}
+			return array( 'mode' => 'none' );
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Resolve the daily memory config to a list of dates.
+	 *
+	 * @param array        $config    Daily memory config.
+	 * @param DailyMemory  $daily     Daily memory service.
+	 * @return string[] Array of dates in YYYY-MM-DD format.
+	 */
+	private static function resolve_dates( array $config, DailyMemory $daily ): array {
+		$mode = $config['mode'] ?? 'none';
+
+		switch ( $mode ) {
+			case 'recent_days':
+				return self::get_recent_dates( (int) ( $config['days'] ?? 7 ) );
+
+			case 'specific_dates':
+				return self::validate_dates( $config['dates'] ?? array(), $daily );
+
+			case 'date_range':
+				return self::get_date_range(
+					$config['from'] ?? null,
+					$config['to'] ?? null,
+					$daily
+				);
+
+			case 'months':
+				return self::get_month_dates( $config['months'] ?? array(), $daily );
+
+			case 'none':
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Get the N most recent dates.
+	 *
+	 * @param int $days Number of days to include.
+	 * @return string[] Array of dates.
+	 */
+	private static function get_recent_dates( int $days ): array {
+		$dates = array();
+		$max   = min( $days, 90 ); // Cap at 90 days.
+
+		for ( $i = 0; $i < $max; $i++ ) {
+			$dates[] = gmdate( 'Y-m-d', strtotime( "-{$i} days" ) );
+		}
+
+		return $dates;
+	}
+
+	/**
+	 * Validate and filter specific dates to only those that exist.
+	 *
+	 * @param string[]     $dates Array of YYYY-MM-DD dates.
+	 * @param DailyMemory  $daily Daily memory service.
+	 * @return string[] Valid dates that have files.
+	 */
+	private static function validate_dates( array $dates, DailyMemory $daily ): array {
+		$valid = array();
+
+		foreach ( $dates as $date ) {
+			$parts = DailyMemory::parse_date( $date );
+			if ( ! $parts ) {
+				continue;
+			}
+
+			if ( $daily->exists( $parts['year'], $parts['month'], $parts['day'] ) ) {
+				$valid[] = $date;
+			}
+		}
+
+		return $valid;
+	}
+
+	/**
+	 * Get all dates within a date range that have daily memory files.
+	 *
+	 * @param string|null  $from  Start date (YYYY-MM-DD).
+	 * @param string|null  $to    End date (YYYY-MM-DD).
+	 * @param DailyMemory  $daily Daily memory service.
+	 * @return string[] Dates with files.
+	 */
+	private static function get_date_range( ?string $from, ?string $to, DailyMemory $daily ): array {
+		if ( ! $from && ! $to ) {
+			return array();
+		}
+
+		// Get all available dates.
+		$all      = $daily->list_all();
+		$dates    = array();
+
+		foreach ( $all['months'] as $month_key => $days ) {
+			list( $year, $month ) = explode( '/', $month_key );
+			foreach ( $days as $day ) {
+				$date = "{$year}-{$month}-{$day}";
+
+				// Apply range filter.
+				if ( null !== $from && $date < $from ) {
+					continue;
+				}
+				if ( null !== $to && $date > $to ) {
+					continue;
+				}
+
+				$dates[] = $date;
+			}
+		}
+
+		return $dates;
+	}
+
+	/**
+	 * Get all dates for selected months.
+	 *
+	 * @param string[]     $months Array of month keys (YYYY/MM).
+	 * @param DailyMemory  $daily  Daily memory service.
+	 * @return string[] Dates in those months.
+	 */
+	private static function get_month_dates( array $months, DailyMemory $daily ): array {
+		if ( empty( $months ) ) {
+			return array();
+		}
+
+		$all   = $daily->list_all();
+		$dates = array();
+
+		foreach ( $months as $month_key ) {
+			if ( ! isset( $all['months'][ $month_key ] ) ) {
+				continue;
+			}
+
+			list( $year, $month ) = explode( '/', $month_key );
+			foreach ( $all['months'][ $month_key ] as $day ) {
+				$dates[] = "{$year}-{$month}-{$day}";
+			}
+		}
+
+		return $dates;
+	}
+}
+
+// Register at Priority 46 — after flow memory files (45), before pipeline system prompt (50).
+add_filter(
+	'datamachine_directives',
+	function ( $directives ) {
+		$directives[] = array(
+			'class'       => DailyMemorySelectorDirective::class,
+			'priority'    => 46,
+			'agent_types' => array( 'pipeline' ),
+		);
+		return $directives;
+	}
+);


### PR DESCRIPTION
## Summary

Implements granular daily memory selection for flows, replacing the binary all-or-nothing approach with multiple selection modes.

Closes #761

## Selection Modes

1. **None** - Don't include any daily memory (default)
2. **Recent days** - Include the past N days (max 90)
3. **Specific dates** - Pick individual days from a calendar/list
4. **Date range** - From date X to date Y
5. **Entire months** - Select whole months at once

## Changes

### Backend
- `DailyMemorySelectorDirective` (Priority 46) - injects selected daily files into AI context
- `Flows.php` - added `get_flow_daily_memory()` and updated `update_flow_memory_files()` to handle daily_memory config
- `Api/Flows/Flows.php` - updated REST endpoints to include daily_memory in GET/PUT responses

### Frontend
- `DailyMemorySelector.jsx` - new React component with all selection modes
- `MemoryFilesSelector.jsx` - updated to include daily memory selector
- `FlowMemoryFiles.jsx` - updated to pass daily memory data
- Queries/mutations updated for new data format

## Database Schema

Daily memory config stored in `flow_config` JSON:
```json
{
  "memory_files": ["custom-file-1.md"],
  "daily_memory": {
    "mode": "recent_days",
    "days": 7
  }
}
```

## Testing

1. Open a flow's Memory Files modal
2. Scroll to Daily Memory section
3. Try each selection mode
4. Save and verify the config persists
5. Run the flow and check logs for injected daily memory

## Site

saraichinwag.com running DM v0.39.0