### PR TITLE
refactor: replace agent type with context and agent ids

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -320,6 +320,15 @@ add_filter( 'upload_mimes', 'datamachine_allow_json_upload' );
 
 add_action( 'update_option_datamachine_settings', array( \DataMachine\Core\PluginSettings::class, 'clearCache' ) );
 
+add_action(
+	'plugins_loaded',
+	function () {
+		\DataMachine\Core\Database\Chat\Chat::ensure_context_column();
+		\DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();
+	},
+	6
+);
+
 register_activation_hook( __FILE__, 'datamachine_activate_plugin' );
 register_deactivation_hook( __FILE__, 'datamachine_deactivate_plugin' );
 
@@ -454,6 +463,7 @@ function datamachine_activate_for_site() {
 	$db_processed_items->create_table();
 
 	\DataMachine\Core\Database\Chat\Chat::create_table();
+	\DataMachine\Core\Database\Chat\Chat::ensure_context_column();
 	\DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();
 
 	// Ensure default agent memory files exist.
@@ -509,7 +519,7 @@ function datamachine_resolve_or_create_agent_id( int $user_id ): int {
 
 	$agent_slug  = sanitize_title( (string) $user->user_login );
 	$agent_name  = (string) $user->display_name;
-	$agent_model = \DataMachine\Core\PluginSettings::getAgentModel( 'chat' );
+	$agent_model = \DataMachine\Core\PluginSettings::getContextModel( 'chat' );
 
 	return $agents_repo->create_if_missing(
 		$agent_slug,

--- a/inc/Abilities/Chat/CreateChatSessionAbility.php
+++ b/inc/Abilities/Chat/CreateChatSessionAbility.php
@@ -49,10 +49,10 @@ class CreateChatSessionAbility {
 								'type'        => 'integer',
 								'description' => __( 'First-class agent ID for this session.', 'data-machine' ),
 							),
-							'agent_type' => array(
+							'context'    => array(
 								'type'        => 'string',
 								'default'     => 'chat',
-								'description' => __( 'Agent type (chat, pipeline, system).', 'data-machine' ),
+								'description' => __( 'Execution context (chat, pipeline, system, standalone).', 'data-machine' ),
 							),
 							'source'     => array(
 								'type'        => 'string',
@@ -90,7 +90,7 @@ class CreateChatSessionAbility {
 	/**
 	 * Execute create-chat-session ability.
 	 *
-	 * @param array $input Input parameters with user_id, optional agent_type, source, metadata.
+	 * @param array $input Input parameters with user_id, optional context, source, metadata.
 	 * @return array Result with session_id on success.
 	 */
 	public function execute( array $input ): array {
@@ -101,10 +101,10 @@ class CreateChatSessionAbility {
 			);
 		}
 
-		$user_id    = (int) $input['user_id'];
-		$agent_id   = (int) ( $input['agent_id'] ?? 0 );
-		$agent_type = ! empty( $input['agent_type'] ) ? sanitize_text_field( $input['agent_type'] ) : 'chat';
-		$source     = ! empty( $input['source'] ) ? sanitize_text_field( $input['source'] ) : null;
+		$user_id  = (int) $input['user_id'];
+		$agent_id = (int) ( $input['agent_id'] ?? 0 );
+		$context  = ! empty( $input['context'] ) ? sanitize_text_field( $input['context'] ) : 'chat';
+		$source   = ! empty( $input['source'] ) ? sanitize_text_field( $input['source'] ) : null;
 
 		if ( ! $this->can_access_user_sessions( $user_id ) ) {
 			return array(
@@ -127,7 +127,7 @@ class CreateChatSessionAbility {
 			$session_metadata = array_merge( $session_metadata, $input['metadata'] );
 		}
 
-		$session_id = $this->chat_db->create_session( $user_id, $agent_id, $session_metadata, $agent_type );
+		$session_id = $this->chat_db->create_session( $user_id, $agent_id, $session_metadata, $context );
 
 		if ( empty( $session_id ) ) {
 			return array(

--- a/inc/Abilities/Chat/ListChatSessionsAbility.php
+++ b/inc/Abilities/Chat/ListChatSessionsAbility.php
@@ -2,7 +2,7 @@
 /**
  * List Chat Sessions Ability
  *
- * Lists chat sessions for a given user with pagination and agent type filtering.
+	 * Lists chat sessions for a given user with pagination and context filtering.
  *
  * @package DataMachine\Abilities\Chat
  * @since 0.31.0
@@ -35,7 +35,7 @@ class ListChatSessionsAbility {
 				'datamachine/list-chat-sessions',
 				array(
 					'label'               => __( 'List Chat Sessions', 'data-machine' ),
-					'description'         => __( 'List chat sessions for a user with pagination and agent type filtering.', 'data-machine' ),
+					'description'         => __( 'List chat sessions for a user with pagination and context filtering.', 'data-machine' ),
 					'category'            => 'datamachine',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -58,9 +58,9 @@ class ListChatSessionsAbility {
 								'default'     => 0,
 								'description' => __( 'Pagination offset.', 'data-machine' ),
 							),
-							'agent_type' => array(
+							'context'    => array(
 								'type'        => 'string',
-								'description' => __( 'Agent type filter (chat, pipeline, system).', 'data-machine' ),
+								'description' => __( 'Context filter (chat, pipeline, system, standalone).', 'data-machine' ),
 							),
 						),
 						'required'   => array( 'user_id' ),
@@ -76,7 +76,7 @@ class ListChatSessionsAbility {
 							'total'      => array( 'type' => 'integer' ),
 							'limit'      => array( 'type' => 'integer' ),
 							'offset'     => array( 'type' => 'integer' ),
-							'agent_type' => array( 'type' => 'string' ),
+							'context' => array( 'type' => 'string' ),
 							'error'      => array( 'type' => 'string' ),
 						),
 					),
@@ -103,7 +103,7 @@ class ListChatSessionsAbility {
 	/**
 	 * Execute list-chat-sessions ability.
 	 *
-	 * @param array $input Input parameters with user_id, optional limit, offset, agent_type.
+	 * @param array $input Input parameters with user_id, optional limit, offset, context.
 	 * @return array Result with sessions list and total count.
 	 */
 	public function execute( array $input ): array {
@@ -123,13 +123,13 @@ class ListChatSessionsAbility {
 			);
 		}
 
-		$limit      = min( 100, max( 1, (int) ( $input['limit'] ?? 20 ) ) );
-		$offset     = max( 0, (int) ( $input['offset'] ?? 0 ) );
-		$agent_type = ! empty( $input['agent_type'] ) ? sanitize_text_field( $input['agent_type'] ) : null;
-		$agent_id   = isset( $input['agent_id'] ) && is_numeric( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
+		$limit    = min( 100, max( 1, (int) ( $input['limit'] ?? 20 ) ) );
+		$offset   = max( 0, (int) ( $input['offset'] ?? 0 ) );
+		$context  = ! empty( $input['context'] ) ? sanitize_text_field( $input['context'] ) : null;
+		$agent_id = isset( $input['agent_id'] ) && is_numeric( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
 
-		$sessions = $this->chat_db->get_user_sessions( $user_id, $limit, $offset, $agent_type, $agent_id );
-		$total    = $this->chat_db->get_user_session_count( $user_id, $agent_type, $agent_id );
+		$sessions = $this->chat_db->get_user_sessions( $user_id, $limit, $offset, $context, $agent_id );
+		$total    = $this->chat_db->get_user_session_count( $user_id, $context, $agent_id );
 
 		return array(
 			'success'    => true,
@@ -137,7 +137,7 @@ class ListChatSessionsAbility {
 			'total'      => $total,
 			'limit'      => $limit,
 			'offset'     => $offset,
-			'agent_type' => $agent_type,
+			'context'    => $context,
 		);
 	}
 }

--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -358,7 +358,9 @@ class InternalLinkingAbilities {
 		$dry_run        = ! empty( $input['dry_run'] );
 		$force          = ! empty( $input['force'] );
 
-		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$user_id         = get_current_user_id();
+		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 
@@ -449,7 +451,14 @@ class InternalLinkingAbilities {
 		}
 
 		$systemAgent = SystemAgent::getInstance();
-		$batch       = $systemAgent->scheduleBatch( 'internal_linking', $item_params );
+		$batch       = $systemAgent->scheduleBatch(
+			'internal_linking',
+			$item_params,
+			array(
+				'user_id'  => $user_id,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		if ( false === $batch ) {
 			return array(

--- a/inc/Abilities/Media/AltTextAbilities.php
+++ b/inc/Abilities/Media/AltTextAbilities.php
@@ -144,7 +144,9 @@ class AltTextAbilities {
 		$post_id       = absint( $input['post_id'] ?? 0 );
 		$force         = ! empty( $input['force'] );
 
-		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$user_id         = get_current_user_id();
+		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 
@@ -242,7 +244,14 @@ class AltTextAbilities {
 		}
 
 		$systemAgent = SystemAgent::getInstance();
-		$batch       = $systemAgent->scheduleBatch( 'alt_text_generation', $item_params );
+		$batch       = $systemAgent->scheduleBatch(
+			'alt_text_generation',
+			$item_params,
+			array(
+				'user_id'  => $user_id,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		if ( false === $batch ) {
 			return array(
@@ -352,7 +361,9 @@ class AltTextAbilities {
 			return;
 		}
 
-		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$user_id         = get_current_user_id();
+		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 
@@ -375,6 +386,10 @@ class AltTextAbilities {
 				'attachment_id' => $attachment_id,
 				'force'         => false,
 				'source'        => 'add_attachment',
+			),
+			array(
+				'user_id'  => $user_id,
+				'agent_id' => $agent_id,
 			)
 		);
 	}

--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -281,7 +281,9 @@ class ImageGenerationAbilities {
 	 * @return string|null Refined prompt on success, null on failure.
 	 */
 	public static function refine_prompt( string $raw_prompt, string $post_context = '', array $config = array() ): ?string {
-		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$user_id         = get_current_user_id();
+		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 
@@ -383,7 +385,9 @@ class ImageGenerationAbilities {
 		}
 
 		// Must have a DM AI provider configured.
-		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$user_id         = get_current_user_id();
+		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
 
 		return ! empty( $system_defaults['provider'] ) && ! empty( $system_defaults['model'] );
 	}

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -405,7 +405,7 @@ class PipelineStepAbilities {
 		);
 
 		if ( 'ai' === $step_type ) {
-			$pipeline_defaults    = PluginSettings::getAgentModel( 'pipeline' );
+			$pipeline_defaults    = PluginSettings::getContextModel( 'pipeline' );
 			$new_step['provider'] = $pipeline_defaults['provider'];
 			$new_step['model']    = $pipeline_defaults['model'];
 		}

--- a/inc/Abilities/SEO/MetaDescriptionAbilities.php
+++ b/inc/Abilities/SEO/MetaDescriptionAbilities.php
@@ -142,7 +142,9 @@ class MetaDescriptionAbilities {
 		$limit     = absint( $input['limit'] ?? 50 );
 		$force     = ! empty( $input['force'] );
 
-		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$user_id         = get_current_user_id();
+		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 
@@ -203,7 +205,14 @@ class MetaDescriptionAbilities {
 		}
 
 		$systemAgent = SystemAgent::getInstance();
-		$batch       = $systemAgent->scheduleBatch( 'meta_description_generation', $item_params );
+		$batch       = $systemAgent->scheduleBatch(
+			'meta_description_generation',
+			$item_params,
+			array(
+				'user_id'  => $user_id,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		if ( false === $batch ) {
 			return array(

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -108,9 +108,13 @@ class SettingsAbilities {
 						'daily_memory_enabled'           => array( 'type' => 'boolean' ),
 						'default_provider'               => array( 'type' => 'string' ),
 						'default_model'                  => array( 'type' => 'string' ),
+						'context_models'                 => array(
+							'type'        => 'object',
+							'description' => 'Per-context provider/model overrides keyed by context id',
+						),
 						'agent_models'                   => array(
 							'type'        => 'object',
-							'description' => 'Per-agent-type provider/model overrides keyed by agent type id',
+							'description' => 'Legacy alias for context_models',
 						),
 						'max_turns'                      => array( 'type' => 'integer' ),
 						'disabled_tools'                 => array( 'type' => 'object' ),
@@ -134,7 +138,7 @@ class SettingsAbilities {
 						),
 						'network_settings'               => array(
 							'type'        => 'object',
-							'description' => 'Network-wide defaults (multisite). Keys: default_provider, default_model, agent_models.',
+							'description' => 'Network-wide defaults (multisite). Keys: default_provider, default_model, context_models.',
 						),
 					),
 				),
@@ -371,7 +375,8 @@ class SettingsAbilities {
 				'daily_memory_enabled'           => $settings['daily_memory_enabled'] ?? false,
 				'default_provider'               => $settings['default_provider'] ?? '',
 				'default_model'                  => $settings['default_model'] ?? '',
-				'agent_models'                   => $settings['agent_models'] ?? array(),
+				'context_models'                 => $settings['context_models'] ?? $settings['agent_models'] ?? array(),
+				'agent_models'                   => $settings['context_models'] ?? $settings['agent_models'] ?? array(),
 				'max_turns'                      => $settings['max_turns'] ?? $defaults['max_turns'],
 				'disabled_tools'                 => $settings['disabled_tools'] ?? array(),
 				'ai_provider_keys'               => $masked_keys,
@@ -381,7 +386,8 @@ class SettingsAbilities {
 			'network_settings' => array(
 				'default_provider' => $network_defaults['default_provider'] ?? '',
 				'default_model'    => $network_defaults['default_model'] ?? '',
-				'agent_models'     => $network_defaults['agent_models'] ?? array(),
+				'context_models'   => $network_defaults['context_models'] ?? $network_defaults['agent_models'] ?? array(),
+				'agent_models'     => $network_defaults['context_models'] ?? $network_defaults['agent_models'] ?? array(),
 			),
 			'global_tools'     => $tools_keyed,
 		);
@@ -456,19 +462,28 @@ class SettingsAbilities {
 			$handled_keys[]                = 'default_model';
 		}
 
-		if ( isset( $input['agent_models'] ) && is_array( $input['agent_models'] ) ) {
-			$valid_agent_ids = array_column( PluginSettings::getAgentTypes(), 'id' );
-			$agent_models    = array();
-			foreach ( $input['agent_models'] as $agent_type => $config ) {
-				if ( in_array( $agent_type, $valid_agent_ids, true ) && is_array( $config ) ) {
-					$agent_models[ $agent_type ] = array(
+		$raw_context_models = null;
+		if ( isset( $input['context_models'] ) && is_array( $input['context_models'] ) ) {
+			$raw_context_models = $input['context_models'];
+		} elseif ( isset( $input['agent_models'] ) && is_array( $input['agent_models'] ) ) {
+			$raw_context_models = $input['agent_models'];
+		}
+
+		if ( is_array( $raw_context_models ) ) {
+			$valid_context_ids = array_column( PluginSettings::getContexts(), 'id' );
+			$context_models    = array();
+			foreach ( $raw_context_models as $context => $config ) {
+				if ( in_array( $context, $valid_context_ids, true ) && is_array( $config ) ) {
+					$context_models[ $context ] = array(
 						'provider' => sanitize_text_field( $config['provider'] ?? '' ),
 						'model'    => sanitize_text_field( $config['model'] ?? '' ),
 					);
 				}
 			}
-			$all_settings['agent_models'] = $agent_models;
-			$handled_keys[]               = 'agent_models';
+			$all_settings['context_models'] = $context_models;
+			$all_settings['agent_models']   = $context_models;
+			$handled_keys[]                 = 'context_models';
+			$handled_keys[]                 = 'agent_models';
 		}
 
 		if ( isset( $input['max_turns'] ) ) {
@@ -551,18 +566,26 @@ class SettingsAbilities {
 					$network_values['default_model'] = sanitize_text_field( $input['network_settings']['default_model'] );
 				}
 
-				if ( isset( $input['network_settings']['agent_models'] ) && is_array( $input['network_settings']['agent_models'] ) ) {
-					$valid_agent_ids      = array_column( PluginSettings::getAgentTypes(), 'id' );
-					$network_agent_models = array();
-					foreach ( $input['network_settings']['agent_models'] as $agent_type => $config ) {
-						if ( in_array( $agent_type, $valid_agent_ids, true ) && is_array( $config ) ) {
-							$network_agent_models[ $agent_type ] = array(
+				$raw_network_context_models = null;
+				if ( isset( $input['network_settings']['context_models'] ) && is_array( $input['network_settings']['context_models'] ) ) {
+					$raw_network_context_models = $input['network_settings']['context_models'];
+				} elseif ( isset( $input['network_settings']['agent_models'] ) && is_array( $input['network_settings']['agent_models'] ) ) {
+					$raw_network_context_models = $input['network_settings']['agent_models'];
+				}
+
+				if ( is_array( $raw_network_context_models ) ) {
+					$valid_context_ids     = array_column( PluginSettings::getContexts(), 'id' );
+					$network_context_models = array();
+					foreach ( $raw_network_context_models as $context => $config ) {
+						if ( in_array( $context, $valid_context_ids, true ) && is_array( $config ) ) {
+							$network_context_models[ $context ] = array(
 								'provider' => sanitize_text_field( $config['provider'] ?? '' ),
 								'model'    => sanitize_text_field( $config['model'] ?? '' ),
 							);
 						}
 					}
-					$network_values['agent_models'] = $network_agent_models;
+					$network_values['context_models'] = $network_context_models;
+					$network_values['agent_models']   = $network_context_models;
 				}
 
 				if ( ! empty( $network_values ) ) {

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -433,7 +433,7 @@ class SystemAbilities {
 					'session_id' => $session_id,
 					'title'      => $title,
 					'method'     => $method,
-					'agent_type' => 'system',
+					'context'    => 'system',
 				)
 			);
 		}
@@ -447,7 +447,7 @@ class SystemAbilities {
 	}
 
 	private static function generateAITitle( string $first_user_message, ?string $first_assistant_response ): ?string {
-		$chat_defaults = PluginSettings::getAgentModel( 'chat' );
+		$chat_defaults = PluginSettings::resolveModelForAgentContext( null, 'chat' );
 		$provider      = $chat_defaults['provider'];
 		$model         = $chat_defaults['model'];
 
@@ -456,7 +456,7 @@ class SystemAbilities {
 				'datamachine_log',
 				'warning',
 				'Session title AI generation skipped - no default provider/model configured',
-				array( 'agent_type' => 'system' )
+				array( 'context' => 'system' )
 			);
 			return null;
 		}
@@ -524,10 +524,10 @@ class SystemAbilities {
 					'error',
 					'Session title AI generation failed',
 					array(
-						'error'      => $response['error'] ?? 'Unknown error',
-						'agent_type' => 'system',
-					)
-				);
+					'error'   => $response['error'] ?? 'Unknown error',
+					'context' => 'system',
+				)
+			);
 					return null;
 			}
 
@@ -548,8 +548,8 @@ class SystemAbilities {
 				'error',
 				'Session title AI generation exception',
 				array(
-					'exception'  => $e->getMessage(),
-					'agent_type' => 'system',
+					'exception' => $e->getMessage(),
+					'context'   => 'system',
 				)
 			);
 			return null;

--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -202,14 +202,13 @@ class Chat {
 						'description'       => __( 'Pagination offset', 'data-machine' ),
 						'sanitize_callback' => 'absint',
 					),
-					'agent_type' => array(
+					'context'    => array(
 						'type'              => 'string',
 						'required'          => false,
-						'default'           => 'chat',
-						'description'       => __( 'Agent type filter (chat, pipeline, system)', 'data-machine' ),
+						'description'       => __( 'Context filter (chat, pipeline, system, standalone)', 'data-machine' ),
 						'sanitize_callback' => 'sanitize_text_field',
 						'validate_callback' => function ( $param ) {
-							return in_array( $param, array( 'chat', 'pipeline', 'system' ), true );
+							return in_array( $param, array( 'chat', 'pipeline', 'system', 'standalone' ), true );
 						},
 					),
 					'agent_id'   => array(
@@ -282,7 +281,7 @@ class Chat {
 		$prompt  = sanitize_textarea_field( wp_unslash( $request->get_param( 'prompt' ) ?? '' ) );
 		$context = $request->get_param( 'context' ) ?? array();
 
-		$agent_config = PluginSettings::getAgentModel( 'chat' );
+		$agent_config = PluginSettings::resolveModelForAgentContext( $agent_id, 'chat' );
 		$provider     = $agent_config['provider'];
 		$model        = $agent_config['model'];
 
@@ -335,7 +334,7 @@ class Chat {
 					'agent_id'   => $agent_id,
 					'limit'      => (int) $request->get_param( 'limit' ),
 					'offset'     => (int) $request->get_param( 'offset' ),
-					'agent_type' => $request->get_param( 'agent_type' ),
+					'context'    => $request->get_param( 'context' ),
 				)
 			);
 
@@ -348,14 +347,14 @@ class Chat {
 		}
 
 		// Fallback: direct DB access (should not happen when abilities are loaded).
-		$user_id    = get_current_user_id();
-		$limit      = min( 100, max( 1, (int) $request->get_param( 'limit' ) ) );
-		$offset     = max( 0, (int) $request->get_param( 'offset' ) );
-		$agent_type = $request->get_param( 'agent_type' );
+		$user_id = get_current_user_id();
+		$limit   = min( 100, max( 1, (int) $request->get_param( 'limit' ) ) );
+		$offset  = max( 0, (int) $request->get_param( 'offset' ) );
+		$context = $request->get_param( 'context' );
 
 		$chat_db  = new \DataMachine\Core\Database\Chat\Chat();
-		$sessions = $chat_db->get_user_sessions( $user_id, $limit, $offset, $agent_type, $agent_id );
-		$total    = $chat_db->get_user_session_count( $user_id, $agent_type, $agent_id );
+		$sessions = $chat_db->get_user_sessions( $user_id, $limit, $offset, $context, $agent_id );
+		$total    = $chat_db->get_user_session_count( $user_id, $context, $agent_id );
 
 		return rest_ensure_response(
 			array(
@@ -365,7 +364,7 @@ class Chat {
 					'total'      => $total,
 					'limit'      => $limit,
 					'offset'     => $offset,
-					'agent_type' => $agent_type,
+					'context'    => $context,
 				),
 			)
 		);
@@ -519,7 +518,7 @@ class Chat {
 		$model    = $request->get_param( 'model' );
 
 		if ( empty( $provider ) || empty( $model ) ) {
-			$agent_config = PluginSettings::getAgentModel( 'chat' );
+			$agent_config = PluginSettings::resolveModelForAgentContext( $agent_id, 'chat' );
 			if ( empty( $provider ) ) {
 				$provider = $agent_config['provider'];
 			}

--- a/inc/Api/Chat/ChatAgentDirective.php
+++ b/inc/Api/Chat/ChatAgentDirective.php
@@ -75,9 +75,9 @@ add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
 		$directives[] = array(
-			'class'       => ChatAgentDirective::class,
-			'priority'    => 15,
-			'agent_types' => array( 'chat' ),
+			'class'    => ChatAgentDirective::class,
+			'priority' => 15,
+			'contexts' => array( 'chat' ),
 		);
 		return $directives;
 	}

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -102,7 +102,7 @@ class ChatOrchestrator {
 						'session_id'          => $session_id,
 						'user_id'             => $user_id,
 						'original_created_at' => $pending_session['created_at'],
-						'agent_type'          => 'chat',
+						'context'             => 'chat',
 					)
 				);
 			} else {
@@ -156,7 +156,7 @@ class ChatOrchestrator {
 				'single_turn'          => true,
 				'max_turns'            => $max_turns,
 				'selected_pipeline_id' => $selected_pipeline_id ? $selected_pipeline_id : null,
-				'agent_type'           => 'chat',
+				'context'              => 'chat',
 				'user_id'              => $user_id,
 			)
 		);
@@ -273,7 +273,7 @@ class ChatOrchestrator {
 		}
 
 		$messages             = $session['messages'] ?? array();
-		$chat_defaults        = PluginSettings::getAgentModel( 'chat' );
+		$chat_defaults        = PluginSettings::resolveModelForAgentContext( (int) ( $session['agent_id'] ?? 0 ), 'chat' );
 		$provider             = $session['provider'] ?? $chat_defaults['provider'];
 		$model                = $session['model'] ?? $chat_defaults['model'];
 		$message_count_before = count( $messages );
@@ -288,7 +288,7 @@ class ChatOrchestrator {
 				'single_turn'          => true,
 				'max_turns'            => $max_turns,
 				'selected_pipeline_id' => $selected_pipeline_id,
-				'agent_type'           => 'chat',
+				'context'              => 'chat',
 				'user_id'              => (int) ( $session['user_id'] ?? 0 ),
 			)
 		);
@@ -391,7 +391,7 @@ class ChatOrchestrator {
 			$provider,
 			$model,
 			array(
-				'agent_type' => 'chat',
+				'context' => 'chat',
 				'user_id'    => $user_id,
 			)
 		);
@@ -427,7 +427,7 @@ class ChatOrchestrator {
 			array(
 				'session_id' => $session_id,
 				'turns'      => $result['turn_count'],
-				'agent_type' => 'chat',
+				'context'    => 'chat',
 			)
 		);
 
@@ -462,7 +462,7 @@ class ChatOrchestrator {
 			$input = array(
 				'user_id'    => $user_id,
 				'agent_id'   => $agent_id,
-				'agent_type' => 'chat',
+				'context'    => 'chat',
 			);
 
 			if ( $source ) {
@@ -527,7 +527,7 @@ class ChatOrchestrator {
 	 *     @type bool   $single_turn          Whether to run single turn (default false).
 	 *     @type int    $max_turns             Maximum turns allowed (default 25).
 	 *     @type int    $selected_pipeline_id  Currently selected pipeline ID.
-	 *     @type string $agent_type            Agent type for context (default 'chat').
+	 *     @type string $context               Execution context (default 'chat').
 	 * }
 	 * @return array|WP_Error Result array with messages, final_content, completed, turn_count,
 	 *                        last_tool_calls, and optional warning/max_turns_reached keys.
@@ -543,15 +543,15 @@ class ChatOrchestrator {
 		$single_turn          = $options['single_turn'] ?? false;
 		$max_turns            = $options['max_turns'] ?? PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
 		$selected_pipeline_id = $options['selected_pipeline_id'] ?? null;
-		$agent_type           = $options['agent_type'] ?? 'chat';
+		$context              = $options['context'] ?? ToolPolicyResolver::CONTEXT_CHAT;
+		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
 
 		$chat_db = new ChatDatabase();
 
 		try {
 			$user_id  = $options['user_id'] ?? 0;
-			$agent_id = 0;
 
-			if ( $user_id > 0 && function_exists( 'datamachine_resolve_or_create_agent_id' ) ) {
+			if ( $agent_id <= 0 && $user_id > 0 && function_exists( 'datamachine_resolve_or_create_agent_id' ) ) {
 				$agent_id = datamachine_resolve_or_create_agent_id( $user_id );
 			}
 
@@ -563,6 +563,7 @@ class ChatOrchestrator {
 			$loop_context = array(
 				'session_id' => $session_id,
 				'user_id'    => $user_id,
+				'agent_id'   => $agent_id,
 			);
 			if ( $selected_pipeline_id ) {
 				$loop_context['selected_pipeline_id'] = $selected_pipeline_id;
@@ -574,7 +575,7 @@ class ChatOrchestrator {
 				$all_tools,
 				$provider,
 				$model,
-				$agent_type,
+				$context,
 				$loop_context,
 				$max_turns,
 				$single_turn
@@ -601,7 +602,7 @@ class ChatOrchestrator {
 					array(
 						'session_id' => $session_id,
 						'error'      => $loop_result['error'],
-						'agent_type' => $agent_type,
+						'context'    => $context,
 					)
 				);
 
@@ -629,7 +630,7 @@ class ChatOrchestrator {
 				array(
 					'session_id' => $session_id,
 					'error'      => $e->getMessage(),
-					'agent_type' => $agent_type,
+					'context'    => $context,
 				)
 			);
 

--- a/inc/Api/Chat/ChatPipelinesDirective.php
+++ b/inc/Api/Chat/ChatPipelinesDirective.php
@@ -126,9 +126,9 @@ add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
 		$directives[] = array(
-			'class'       => ChatPipelinesDirective::class,
-			'priority'    => 45,
-			'agent_types' => array( 'chat' ),
+			'class'    => ChatPipelinesDirective::class,
+			'priority' => 45,
+			'contexts' => array( 'chat' ),
 		);
 
 		return $directives;

--- a/inc/Api/Chat/Tools/ManageLogs.php
+++ b/inc/Api/Chat/Tools/ManageLogs.php
@@ -3,7 +3,7 @@
  * Manage Logs Tool
  *
  * Dedicated tool for managing Data Machine log configuration and storage.
- * Supports clearing logs, setting log levels, and getting log metadata.
+ * Supports clearing logs and getting log metadata.
  *
  * @package DataMachine\Api\Chat\Tools
  * @since 0.8.2
@@ -37,17 +37,17 @@ class ManageLogs extends BaseTool {
 				'action'     => array(
 					'type'        => 'string',
 					'required'    => true,
-					'description' => 'Action to perform: "clear", "set_level", or "get_metadata"',
+					'description' => 'Action to perform: "clear" or "get_metadata"',
 				),
-				'agent_type' => array(
+				'agent_id'   => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Agent ID to target. Omit to target all logs.',
+				),
+				'context'    => array(
 					'type'        => 'string',
 					'required'    => false,
-					'description' => 'Agent type: "pipeline", "chat", "system", or "all" (for clear action). Defaults to "pipeline"',
-				),
-				'level'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Log level for set_level action: "debug", "info", "warning", "error", "none"',
+					'description' => 'Deprecated label only. Use agent_id instead.',
 				),
 			),
 		);
@@ -59,25 +59,15 @@ class ManageLogs extends BaseTool {
 	 * @return string Tool description
 	 */
 	private function buildDescription(): string {
-		return 'Manage Data Machine log configuration and storage.
+		return 'Manage Data Machine logs.
 
 ACTIONS:
-- clear: Clear log file for specified agent_type (or "all" to clear all logs)
-- set_level: Set log verbosity level for specified agent_type
-- get_metadata: Get log file info (size, path, current level)
+- clear: Clear logs for a specific agent_id or all logs
+- get_metadata: Get log metadata for a specific agent_id or all logs
 
-LOG LEVELS (for set_level action):
-- debug: Most verbose, includes all messages
-- info: Standard operational messages
-- warning: Warnings and errors only
-- error: Errors only
-- none: Disable logging
-
-AGENT TYPES:
-- pipeline: Job/flow execution logs
-- chat: Chat agent operation logs
-- system: System infrastructure logs (database, OAuth, cleanup, services)
-- all: All agent types (only valid for clear action)';
+NOTES:
+- Logs are scoped by explicit agent_id
+- Context names are presentation labels only and are not resolved here';
 	}
 
 	/**
@@ -88,36 +78,32 @@ AGENT TYPES:
 	 * @return array Tool execution result
 	 */
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
-		$action     = $parameters['action'] ?? '';
-		$agent_type = $parameters['agent_type'] ?? 'pipeline';
+		$action   = $parameters['action'] ?? '';
+		$agent_id = isset( $parameters['agent_id'] ) ? (int) $parameters['agent_id'] : null;
 
 		switch ( $action ) {
 			case 'clear':
-				return $this->clearLogs( $agent_type );
-
-			case 'set_level':
-				$level = $parameters['level'] ?? '';
-				return $this->setLevel( $agent_type, $level );
+				return $this->clearLogs( $agent_id );
 
 			case 'get_metadata':
-				return $this->getMetadata( $agent_type );
+				return $this->getMetadata( $agent_id );
 
 			default:
 				return array(
 					'success'   => false,
-					'error'     => 'Invalid action. Use "clear", "set_level", or "get_metadata"',
+					'error'     => 'Invalid action. Use "clear" or "get_metadata"',
 					'tool_name' => 'manage_logs',
 				);
 		}
 	}
 
 	/**
-	 * Clear logs for specified agent type.
+	 * Clear logs for a specific agent or all agents.
 	 *
-	 * @param string $agent_type Agent type to clear
+	 * @param int|null $agent_id Agent ID to clear, or null for all logs.
 	 * @return array Result
 	 */
-	private function clearLogs( string $agent_type ): array {
+	private function clearLogs( ?int $agent_id ): array {
 		$ability = wp_get_ability( 'datamachine/clear-logs' );
 		if ( ! $ability ) {
 			return array(
@@ -127,7 +113,11 @@ AGENT TYPES:
 			);
 		}
 
-		$result = $ability->execute( array( 'agent_type' => $agent_type ) );
+		$result = $ability->execute(
+			null !== $agent_id && $agent_id > 0
+				? array( 'agent_id' => $agent_id )
+				: array()
+		);
 
 		if ( ! ( $result['success'] ?? false ) ) {
 			return array(
@@ -145,63 +135,12 @@ AGENT TYPES:
 	}
 
 	/**
-	 * Set log level for specified agent type.
+	 * Get log metadata for a specific agent or all agents.
 	 *
-	 * @param string $agent_type Agent type
-	 * @param string $level Log level to set
+	 * @param int|null $agent_id Agent ID, or null for all logs.
 	 * @return array Result
 	 */
-	private function setLevel( string $agent_type, string $level ): array {
-		if ( empty( $level ) ) {
-			return array(
-				'success'   => false,
-				'error'     => 'level parameter is required for set_level action',
-				'tool_name' => 'manage_logs',
-			);
-		}
-
-		$ability = wp_get_ability( 'datamachine/set-log-level' );
-		if ( ! $ability ) {
-			return array(
-				'success'   => false,
-				'error'     => 'Set log level ability not available',
-				'tool_name' => 'manage_logs',
-			);
-		}
-
-		$result = $ability->execute(
-			array(
-				'agent_type' => $agent_type,
-				'level'      => $level,
-			)
-		);
-
-		if ( ! ( $result['success'] ?? false ) ) {
-			return array(
-				'success'   => false,
-				'error'     => $result['error'] ?? $result['message'] ?? 'Failed to set log level',
-				'tool_name' => 'manage_logs',
-			);
-		}
-
-		return array(
-			'success'   => true,
-			'data'      => array(
-				'agent_type' => $result['agent_type'] ?? $agent_type,
-				'level'      => $result['level'] ?? $level,
-				'message'    => $result['message'] ?? 'Log level updated',
-			),
-			'tool_name' => 'manage_logs',
-		);
-	}
-
-	/**
-	 * Get log metadata for specified agent type.
-	 *
-	 * @param string $agent_type Agent type (or 'all' for all types)
-	 * @return array Result
-	 */
-	private function getMetadata( string $agent_type ): array {
+	private function getMetadata( ?int $agent_id ): array {
 		$ability = wp_get_ability( 'datamachine/get-log-metadata' );
 		if ( ! $ability ) {
 			return array(
@@ -211,12 +150,11 @@ AGENT TYPES:
 			);
 		}
 
-		$input = array();
-		if ( 'all' !== $agent_type ) {
-			$input['agent_type'] = $agent_type;
-		}
-
-		$result = $ability->execute( $input );
+		$result = $ability->execute(
+			null !== $agent_id && $agent_id > 0
+				? array( 'agent_id' => $agent_id )
+				: array()
+		);
 
 		if ( ! ( $result['success'] ?? false ) ) {
 			return array(

--- a/inc/Api/Chat/Tools/ReadLogs.php
+++ b/inc/Api/Chat/Tools/ReadLogs.php
@@ -34,10 +34,15 @@ class ReadLogs extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => $this->buildDescription(),
 			'parameters'  => array(
-				'agent_type'  => array(
+				'agent_id'    => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Agent ID to read logs for. Omit for all agents.',
+				),
+				'context'     => array(
 					'type'        => 'string',
 					'required'    => false,
-					'description' => 'Log source: "pipeline" (default) for job execution logs, "chat" for chat agent logs, "system" for system infrastructure operations',
+					'description' => 'Deprecated label only. Use agent_id instead.',
 				),
 				'mode'        => array(
 					'type'        => 'string',
@@ -76,10 +81,9 @@ class ReadLogs extends BaseTool {
 	private function buildDescription(): string {
 		return 'Read Data Machine logs for troubleshooting jobs, flows, pipelines, and system operations.
 
-AGENT TYPES:
-- pipeline (default): Logs from job/flow execution - use this for troubleshooting failed jobs
-- chat: Logs from chat agent operations - use this to check your own activity
-- system: System infrastructure operations - database, OAuth, cleanup, and service initialization
+SCOPE:
+- Filter by explicit agent_id when you want a single agent
+- Omit agent_id to read across all agents
 
 FILTERS (all optional, combined with AND logic):
 - job_id: Filter to specific job execution
@@ -115,10 +119,13 @@ TIPS:
 		}
 
 		$input = array(
-			'agent_type' => $parameters['agent_type'] ?? 'pipeline',
-			'mode'       => $parameters['mode'] ?? 'recent',
-			'limit'      => $parameters['limit'] ?? 200,
+			'mode'  => $parameters['mode'] ?? 'recent',
+			'limit' => $parameters['limit'] ?? 200,
 		);
+
+		if ( isset( $parameters['agent_id'] ) && (int) $parameters['agent_id'] > 0 ) {
+			$input['agent_id'] = (int) $parameters['agent_id'];
+		}
 
 		if ( ! empty( $parameters['job_id'] ) ) {
 			$input['job_id'] = (int) $parameters['job_id'];

--- a/inc/Api/Providers.php
+++ b/inc/Api/Providers.php
@@ -86,8 +86,8 @@ class Providers {
 				'model'    => PluginSettings::get( 'default_model', '' ),
 			);
 
-			$agent_types  = PluginSettings::getAgentTypes();
-			$agent_models = PluginSettings::get( 'agent_models', array() );
+			$contexts       = PluginSettings::getContexts();
+			$context_models = PluginSettings::get( 'context_models', PluginSettings::get( 'agent_models', array() ) );
 
 			return rest_ensure_response(
 				array(
@@ -95,8 +95,8 @@ class Providers {
 					'data'    => array(
 						'providers'    => $providers,
 						'defaults'     => $defaults,
-						'agent_types'  => $agent_types,
-						'agent_models' => $agent_models,
+						'contexts'     => $contexts,
+						'context_models' => $context_models,
 					),
 				)
 			);

--- a/inc/Api/System/SystemAgentDirective.php
+++ b/inc/Api/System/SystemAgentDirective.php
@@ -73,9 +73,9 @@ add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
 		$directives[] = array(
-			'class'       => SystemAgentDirective::class,
-			'priority'    => 20,
-			'agent_types' => array( 'system' ),
+			'class'    => SystemAgentDirective::class,
+			'priority' => 20,
+			'contexts' => array( 'system' ),
 		);
 		return $directives;
 	}

--- a/inc/Cli/Commands/ChatCommand.php
+++ b/inc/Cli/Commands/ChatCommand.php
@@ -26,8 +26,8 @@ class ChatCommand extends BaseCommand {
 	 * [--user=<id>]
 	 * : User ID to list sessions for. Defaults to current user.
 	 *
-	 * [--agent-type=<type>]
-	 * : Filter by agent type (chat, pipeline, system).
+	 * [--context=<type>]
+	 * : Filter by execution context (chat, pipeline, system, standalone).
 	 *
 	 * [--limit=<n>]
 	 * : Maximum number of sessions to return.
@@ -61,8 +61,8 @@ class ChatCommand extends BaseCommand {
 	 *     # List sessions for user 1
 	 *     wp datamachine chat list --user=1
 	 *
-	 *     # List chat-type sessions
-	 *     wp datamachine chat list --user=1 --agent-type=chat
+	 *     # List chat-context sessions
+	 *     wp datamachine chat list --user=1 --context=chat
 	 *
 	 *     # Get session IDs only
 	 *     wp datamachine chat list --user=1 --format=ids
@@ -73,11 +73,11 @@ class ChatCommand extends BaseCommand {
 		$user_id = $this->get_user_id( $assoc_args );
 		$limit   = min( 100, max( 1, (int) ( $assoc_args['limit'] ?? 20 ) ) );
 		$offset  = max( 0, (int) ( $assoc_args['offset'] ?? 0 ) );
-		$agent_type = ! empty( $assoc_args['agent-type'] ) ? sanitize_text_field( $assoc_args['agent-type'] ) : 'chat';
+		$context = ! empty( $assoc_args['context'] ) ? sanitize_text_field( $assoc_args['context'] ) : null;
 
 		$chat_db = new ChatDatabase();
-		$sessions = $chat_db->get_user_sessions( $user_id, $limit, $offset, $agent_type );
-		$total    = $chat_db->get_user_session_count( $user_id, $agent_type );
+		$sessions = $chat_db->get_user_sessions( $user_id, $limit, $offset, $context );
+		$total    = $chat_db->get_user_session_count( $user_id, $context );
 
 		if ( empty( $sessions ) ) {
 			WP_CLI::log( 'No chat sessions found.' );
@@ -91,13 +91,13 @@ class ChatCommand extends BaseCommand {
 			$display_items[] = array(
 				'session_id'   => $session['session_id'],
 				'title'        => $session['title'] ?? '(untitled)',
-				'agent_type'   => $session['agent_type'] ?? 'chat',
+				'context'      => $session['context'] ?? 'chat',
 				'message_count' => $metadata['message_count'] ?? 0,
 				'created_at'   => $metadata['started_at'] ?? $session['created_at'] ?? '-',
 			);
 		}
 
-		$fields = array( 'session_id', 'title', 'agent_type', 'message_count', 'created_at' );
+		$fields = array( 'session_id', 'title', 'context', 'message_count', 'created_at' );
 		$this->format_items( $display_items, $fields, $assoc_args, 'session_id' );
 
 		$format = $assoc_args['format'] ?? 'table';
@@ -171,7 +171,7 @@ class ChatCommand extends BaseCommand {
 		WP_CLI::log( WP_CLI::colorize( '%BSession Metadata:%n' ) );
 		WP_CLI::log( "  Session ID:   {$session['session_id']}" );
 		WP_CLI::log( "  Title:        " . ( $session['title'] ?? '(untitled)' ) );
-		WP_CLI::log( "  Agent Type:   " . ( $session['agent_type'] ?? 'chat' ) );
+		WP_CLI::log( "  Context:      " . ( $session['context'] ?? 'chat' ) );
 		WP_CLI::log( "  User ID:      {$session['user_id']}" );
 		WP_CLI::log( "  Started:      " . ( $metadata['started_at'] ?? '-' ) );
 		WP_CLI::log( "  Messages:     " . count( $messages ) );
@@ -209,8 +209,8 @@ class ChatCommand extends BaseCommand {
 	 * [--agent-id=<id>]
 	 * : First-class agent ID for this session.
 	 *
-	 * [--agent-type=<type>]
-	 * : Agent type (chat, pipeline, system).
+	 * [--context=<type>]
+	 * : Execution context (chat, pipeline, system, standalone).
 	 * ---
 	 * default: chat
 	 * ---
@@ -230,10 +230,10 @@ class ChatCommand extends BaseCommand {
 	 *     wp datamachine chat create --user=1 --agent-id=5
 	 */
 	public function create( array $args, array $assoc_args ): void {
-		$user_id    = $this->get_user_id( $assoc_args );
-		$agent_id   = (int) ( $assoc_args['agent-id'] ?? 0 );
-		$agent_type = sanitize_text_field( $assoc_args['agent-type'] ?? 'chat' );
-		$source     = sanitize_text_field( $assoc_args['source'] ?? 'cli' );
+		$user_id  = $this->get_user_id( $assoc_args );
+		$agent_id = (int) ( $assoc_args['agent-id'] ?? 0 );
+		$context  = sanitize_text_field( $assoc_args['context'] ?? 'chat' );
+		$source   = sanitize_text_field( $assoc_args['source'] ?? 'cli' );
 
 		$metadata = array(
 			'started_at'    => current_time( 'mysql', true ),
@@ -242,7 +242,7 @@ class ChatCommand extends BaseCommand {
 		);
 
 		$chat_db = new ChatDatabase();
-		$session_id = $chat_db->create_session( $user_id, $agent_id, $metadata, $agent_type );
+		$session_id = $chat_db->create_session( $user_id, $agent_id, $metadata, $context );
 
 		if ( empty( $session_id ) ) {
 			WP_CLI::error( 'Failed to create chat session.' );

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentEditView.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentEditView.jsx
@@ -31,6 +31,8 @@ import {
 	useGrantAccess,
 	useRevokeAccess,
 } from '../queries/agents';
+import { useProviders } from '@shared/queries/providers';
+import ProviderModelSelector from '@shared/components/ai/ProviderModelSelector';
 
 /**
  * Status options for the dropdown.
@@ -243,16 +245,24 @@ const AccessPanel = ( { agentId, ownerId } ) => {
 const AgentEditView = ( { agentId, onBack } ) => {
 	const { data: agent, isLoading, error } = useAgent( agentId );
 	const updateMutation = useUpdateAgent();
+	const { data: providersData } = useProviders();
 
 	const [ name, setName ] = useState( '' );
 	const [ status, setStatus ] = useState( 'active' );
+	const [ defaultProvider, setDefaultProvider ] = useState( '' );
+	const [ defaultModel, setDefaultModel ] = useState( '' );
+	const [ contextModels, setContextModels ] = useState( {} );
 	const [ saveMessage, setSaveMessage ] = useState( null );
 
 	// Sync form state when agent data loads.
 	useEffect( () => {
 		if ( agent ) {
+			const config = agent.agent_config || {};
 			setName( agent.agent_name || '' );
 			setStatus( agent.status || 'active' );
+			setDefaultProvider( config.default_provider || '' );
+			setDefaultModel( config.default_model || '' );
+			setContextModels( config.context_models || config.agent_models || {} );
 		}
 	}, [ agent ] );
 
@@ -263,6 +273,12 @@ const AgentEditView = ( { agentId, onBack } ) => {
 			agentId,
 			agent_name: name,
 			status,
+			agent_config: {
+				...( agent.agent_config || {} ),
+				default_provider: defaultProvider,
+				default_model: defaultModel,
+				context_models: contextModels,
+			},
 		} );
 
 		if ( result.success ) {
@@ -304,7 +320,11 @@ const AgentEditView = ( { agentId, onBack } ) => {
 
 	const isDirty =
 		name !== ( agent.agent_name || '' ) ||
-		status !== ( agent.status || 'active' );
+		status !== ( agent.status || 'active' ) ||
+		defaultProvider !== ( agent.agent_config?.default_provider || '' ) ||
+		defaultModel !== ( agent.agent_config?.default_model || '' ) ||
+		JSON.stringify( contextModels ) !==
+			JSON.stringify( agent.agent_config?.context_models || {} );
 
 	return (
 		<div className="datamachine-agent-edit-view">
@@ -394,6 +414,84 @@ const AgentEditView = ( { agentId, onBack } ) => {
 					>
 						{ __( 'Save Changes', 'data-machine' ) }
 					</Button>
+				</CardBody>
+			</Card>
+
+			<Card className="datamachine-agent-models-card">
+				<CardHeader>
+					<h3>{ __( 'AI Model Policy', 'data-machine' ) }</h3>
+				</CardHeader>
+				<CardBody>
+					<p className="description">
+						{ __(
+							'Agent defaults override global settings. Context-specific overrides override the agent default for that context.',
+							'data-machine'
+						) }
+					</p>
+
+					<div className="datamachine-ai-provider-model-settings">
+						<ProviderModelSelector
+							provider={ defaultProvider }
+							model={ defaultModel }
+							onProviderChange={ ( provider ) => {
+								setDefaultProvider( provider );
+								setDefaultModel( '' );
+							} }
+							onModelChange={ setDefaultModel }
+							applyDefaults={ false }
+							providerLabel={ __( 'Agent Default Provider', 'data-machine' ) }
+							modelLabel={ __( 'Agent Default Model', 'data-machine' ) }
+						/>
+					</div>
+
+					{ ( providersData?.contexts || [] ).map( ( contextItem ) => {
+						const value = contextModels?.[ contextItem.id ] || {};
+
+						return (
+							<div
+								key={ contextItem.id }
+								className="datamachine-agent-model-override"
+								style={ {
+									marginTop: '20px',
+									paddingTop: '16px',
+									borderTop: '1px solid #e0e0e0',
+								} }
+							>
+								<h4 style={ { margin: '0 0 4px' } }>
+									{ contextItem.label }
+								</h4>
+								<p className="description" style={ { marginTop: 0 } }>
+									{ contextItem.description }
+								</p>
+								<ProviderModelSelector
+									provider={ value.provider || '' }
+									model={ value.model || '' }
+									onProviderChange={ ( provider ) => {
+										setContextModels( {
+											...contextModels,
+											[ contextItem.id ]: {
+												...value,
+												provider,
+												model: '',
+											},
+										} );
+									} }
+									onModelChange={ ( modelValue ) => {
+										setContextModels( {
+											...contextModels,
+											[ contextItem.id ]: {
+												...value,
+												model: modelValue,
+											},
+										} );
+									} }
+									applyDefaults={ false }
+									providerLabel={ __( 'Provider', 'data-machine' ) }
+									modelLabel={ __( 'Model', 'data-machine' ) }
+								/>
+							</div>
+						);
+					} ) }
 				</CardBody>
 			</Card>
 

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentSettings.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentSettings.jsx
@@ -19,7 +19,7 @@ import { useProviders } from '@shared/queries/providers';
 const EMPTY_FORM = {
 	default_provider: '',
 	default_model: '',
-	agent_models: {},
+	context_models: {},
 	site_context_enabled: false,
 	max_turns: 0,
 };
@@ -88,7 +88,10 @@ const AgentSettings = () => {
 			form.reset( {
 				default_provider: data.settings.default_provider || '',
 				default_model: data.settings.default_model || '',
-				agent_models: data.settings.agent_models || {},
+				context_models:
+					data.settings.context_models ||
+					data.settings.agent_models ||
+					{},
 				site_context_enabled:
 					data.settings.site_context_enabled ?? false,
 				max_turns: data.settings.max_turns ?? maxTurnsDefault,
@@ -155,10 +158,10 @@ const AgentSettings = () => {
 						</td>
 					</tr>
 
-					{ ( providersData?.agent_types || [] ).length > 0 && (
+					{ ( providersData?.contexts || [] ).length > 0 && (
 						<tr>
 							<th scope="row">
-								Per-Agent Model Overrides
+								Per-Context Model Overrides
 							</th>
 							<td>
 								<p
@@ -169,18 +172,18 @@ const AgentSettings = () => {
 									} }
 								>
 									Assign different providers and models to
-									each agent type. Leave empty to use the
+									each execution context. Leave empty to use the
 									global default above.
 								</p>
-								{ ( providersData?.agent_types || [] ).map(
-									( agentType ) => {
-										const agentConfig =
-											form.data.agent_models?.[
-												agentType.id
+								{ ( providersData?.contexts || [] ).map(
+									( contextItem ) => {
+										const contextConfig =
+											form.data.context_models?.[
+												contextItem.id
 											] || {};
 										return (
 											<div
-												key={ agentType.id }
+												key={ contextItem.id }
 												className="datamachine-agent-model-override"
 												style={ {
 													marginBottom: '20px',
@@ -194,7 +197,7 @@ const AgentSettings = () => {
 														margin: '0 0 4px',
 													} }
 												>
-													{ agentType.label }
+													{ contextItem.label }
 												</h4>
 												<p
 													className="description"
@@ -203,31 +206,29 @@ const AgentSettings = () => {
 														marginBottom: '8px',
 													} }
 												>
-													{
-														agentType.description
-													}
-												</p>
-												<ProviderModelSelector
-													provider={
-														agentConfig.provider ||
-														''
-													}
-													model={
-														agentConfig.model ||
-														''
-													}
+														{ contextItem.description }
+													</p>
+													<ProviderModelSelector
+														provider={
+															contextConfig.provider ||
+															''
+														}
+														model={
+															contextConfig.model ||
+															''
+														}
 													onProviderChange={ (
 														provider
 													) => {
-														form.updateData( {
-															agent_models: {
-																...form.data
-																	.agent_models,
-																[ agentType.id ]:
-																	{
-																		...agentConfig,
-																		provider,
-																		model: '',
+															form.updateData( {
+																context_models: {
+																	...form.data
+																		.context_models,
+																	[ contextItem.id ]:
+																		{
+																			...contextConfig,
+																			provider,
+																			model: '',
 																	},
 															},
 														} );
@@ -236,14 +237,14 @@ const AgentSettings = () => {
 													onModelChange={ (
 														model
 													) => {
-														form.updateData( {
-															agent_models: {
-																...form.data
-																	.agent_models,
-																[ agentType.id ]:
-																	{
-																		...agentConfig,
-																		model,
+															form.updateData( {
+																context_models: {
+																	...form.data
+																		.context_models,
+																	[ contextItem.id ]:
+																		{
+																			...contextConfig,
+																			model,
 																	},
 															},
 														} );

--- a/inc/Core/Admin/Pages/Logs/assets/css/logs-page.css
+++ b/inc/Core/Admin/Pages/Logs/assets/css/logs-page.css
@@ -44,6 +44,15 @@
 	gap: 10px;
 }
 
+.datamachine-logs-agent-tabs {
+	margin-bottom: 16px;
+}
+
+.datamachine-logs-agent-tabs .components-tab-panel__tab-content {
+	display: none;
+	padding: 0;
+}
+
 /* Filters */
 .datamachine-logs-filters {
 	display: flex;

--- a/inc/Core/Admin/Pages/Logs/assets/react/LogsApp.jsx
+++ b/inc/Core/Admin/Pages/Logs/assets/react/LogsApp.jsx
@@ -2,13 +2,14 @@
  * LogsApp Component
  *
  * Root container for the Logs admin page.
- * Single filterable log viewer replacing the old tabbed agent-type interface.
+ * Keeps the classic tabbed agent view, now backed by agent IDs.
  */
 
 /**
  * Internal dependencies
  */
 import LogsHeader from './components/LogsHeader';
+import LogsAgentTabs from './components/LogsAgentTabs';
 import LogsFilters from './components/LogsFilters';
 import LogsTable from './components/LogsTable';
 
@@ -16,6 +17,7 @@ const LogsApp = () => {
 	return (
 		<div className="datamachine-logs-app">
 			<LogsHeader />
+			<LogsAgentTabs />
 			<LogsFilters />
 			<LogsTable />
 		</div>

--- a/inc/Core/Admin/Pages/Logs/assets/react/components/LogsAgentTabs.jsx
+++ b/inc/Core/Admin/Pages/Logs/assets/react/components/LogsAgentTabs.jsx
@@ -1,0 +1,75 @@
+/**
+ * LogsAgentTabs Component
+ *
+ * Tabbed agent selector for the Logs page.
+ * Shows only agents the current user can access.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { TabPanel } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+/**
+ * External dependencies
+ */
+import { useQueryClient } from '@tanstack/react-query';
+/**
+ * Internal dependencies
+ */
+import { useAgents, AGENTS_KEY } from '@shared/queries/agents';
+import { useAgentStore } from '@shared/stores/agentStore';
+
+const LOGS_QUERY_KEY = [ 'logs' ];
+const LOGS_METADATA_QUERY_KEY = [ 'log-metadata' ];
+
+export default function LogsAgentTabs() {
+	const { data: agents = [], isLoading } = useAgents();
+	const { selectedAgentId, setSelectedAgentId } = useAgentStore();
+	const queryClient = useQueryClient();
+
+	if ( isLoading ) {
+		return null;
+	}
+
+	const tabs = [
+		{
+			name: 'all',
+			title: __( 'All Agents', 'data-machine' ),
+		},
+		...agents.map( ( agent ) => ( {
+			name: String( agent.agent_id ),
+			title:
+				agent.agent_name ||
+				agent.agent_slug ||
+				__( 'Unnamed Agent', 'data-machine' ),
+		} ) ),
+	];
+
+	const activeTabName =
+		selectedAgentId !== null ? String( selectedAgentId ) : 'all';
+
+	const handleSelect = ( tabName ) => {
+		const newId = tabName === 'all' ? null : Number( tabName );
+		if ( newId === selectedAgentId ) {
+			return;
+		}
+
+		setSelectedAgentId( newId );
+
+		queryClient.invalidateQueries( { queryKey: LOGS_QUERY_KEY } );
+		queryClient.invalidateQueries( { queryKey: LOGS_METADATA_QUERY_KEY } );
+	};
+
+	return (
+		<TabPanel
+			className="datamachine-tabs datamachine-logs-agent-tabs"
+			tabs={ tabs }
+			activeClass="is-active"
+			onSelect={ handleSelect }
+			initialTabName={ activeTabName }
+		>
+			{ () => null }
+		</TabPanel>
+	);
+}

--- a/inc/Core/Admin/Pages/Logs/assets/react/components/LogsHeader.jsx
+++ b/inc/Core/Admin/Pages/Logs/assets/react/components/LogsHeader.jsx
@@ -1,7 +1,7 @@
 /**
  * LogsHeader Component
  *
- * Page title, agent switcher, and global clear button.
+ * Page title and clear button for current agent scope.
  */
 
 /**
@@ -12,28 +12,29 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import AgentSwitcher from '@shared/components/AgentSwitcher';
-/**
- * Internal dependencies
- */
 import { useClearLogs, useLogMetadata } from '../queries/logs';
+import { useAgentStore } from '@shared/stores/agentStore';
 
 const LogsHeader = () => {
 	const clearMutation = useClearLogs();
-	const { data: metadata } = useLogMetadata();
+	const selectedAgentId = useAgentStore( ( state ) => state.selectedAgentId );
+	const { data: metadata } = useLogMetadata( selectedAgentId ?? undefined );
 
 	const totalEntries = metadata?.total_entries || 0;
 
 	const handleClearAll = () => {
+		const scopeLabel = selectedAgentId
+			? __( 'the selected agent', 'data-machine' )
+			: __( 'ALL agents', 'data-machine' );
+
 		if (
 			window.confirm( // eslint-disable-line no-alert
-				__(
-					'Are you sure you want to clear ALL logs? This action cannot be undone.',
-					'data-machine'
-				)
+				`${ __( 'Are you sure you want to clear logs for', 'data-machine' ) } ${ scopeLabel }? ${ __( 'This action cannot be undone.', 'data-machine' ) }`
 			)
 		) {
-			clearMutation.mutate( {} );
+			clearMutation.mutate(
+				selectedAgentId ? { agent_id: selectedAgentId } : {}
+			);
 		}
 	};
 
@@ -51,7 +52,6 @@ const LogsHeader = () => {
 				) }
 			</div>
 			<div className="datamachine-logs-header-actions">
-				<AgentSwitcher />
 				<Button
 					variant="secondary"
 					isDestructive

--- a/inc/Core/Admin/Pages/Logs/assets/react/components/LogsTable.jsx
+++ b/inc/Core/Admin/Pages/Logs/assets/react/components/LogsTable.jsx
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useLogs } from '../queries/logs';
+import { useAgentStore } from '@shared/stores/agentStore';
 
 /**
  * Level badge color mapping.
@@ -29,6 +30,7 @@ const LEVEL_COLORS = {
 const LogsTable = () => {
 	const [ page, setPage ] = useState( 1 );
 	const perPage = 50;
+	const selectedAgentId = useAgentStore( ( state ) => state.selectedAgentId );
 
 	// Read filters from window (set by LogsFilters).
 	const filters = window.__dmLogsFilters || {};
@@ -37,6 +39,10 @@ const LogsTable = () => {
 		per_page: perPage,
 		page,
 	};
+
+	if ( selectedAgentId ) {
+		queryFilters.agent_id = selectedAgentId;
+	}
 
 	if ( filters.level ) {
 		queryFilters.level = filters.level;

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/chat.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/chat.js
@@ -94,16 +94,16 @@ export function useChatMutation() {
  * injects agent_id when an agent is selected in the AgentSwitcher.
  *
  * @param {number} limit     - Maximum sessions to return
- * @param {string} agentType - Agent type filter (chat, cli)
- * @return {Object} TanStack Query object with sessions data
- */
-export function useChatSessions( limit = 20, agentType = 'chat' ) {
+	 * @param {string|null} context - Optional session context filter
+	 * @return {Object} TanStack Query object with sessions data
+	 */
+export function useChatSessions( limit = 20, context = null ) {
 	return useQuery( {
-		queryKey: [ 'chat-sessions', limit, agentType ],
+		queryKey: [ 'chat-sessions', limit, context ],
 		queryFn: async () => {
 			const response = await client.get( '/chat/sessions', {
 				limit,
-				agent_type: agentType,
+				context: context || undefined,
 			} );
 
 			if ( ! response.success ) {

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -50,15 +50,15 @@ class Chat extends BaseRepository {
             metadata LONGTEXT NULL COMMENT 'JSON object for session metadata',
             provider VARCHAR(50) NULL COMMENT 'AI provider (anthropic, openai, etc)',
             model VARCHAR(100) NULL COMMENT 'AI model identifier',
-            agent_type VARCHAR(20) NOT NULL DEFAULT 'chat' COMMENT 'Agent type: chat, pipeline, system',
+	            context VARCHAR(20) NOT NULL DEFAULT 'chat' COMMENT 'Execution context: chat, pipeline, system, standalone',
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
             updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             expires_at DATETIME NULL COMMENT 'Auto-cleanup timestamp',
             PRIMARY KEY  (session_id),
             KEY user_id (user_id),
             KEY agent_id (agent_id),
-            KEY agent_type (agent_type),
-            KEY user_agent (user_id, agent_type),
+	            KEY context (context),
+	            KEY user_context (user_id, context),
             KEY created_at (created_at),
             KEY updated_at (updated_at),
             KEY expires_at (expires_at)
@@ -94,6 +94,43 @@ class Chat extends BaseRepository {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
 		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD KEY agent_id (agent_id)', $table_name ) );
+	}
+
+	/**
+	 * Ensure context column exists and migrate legacy agent_type data.
+	 *
+	 * @return void
+	 */
+	public static function ensure_context_column(): void {
+		global $wpdb;
+
+		$table_name = self::get_prefixed_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$context_column = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $table_name, 'context' ) );
+
+		if ( ! $context_column ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$legacy_agent_type = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $table_name, 'agent_type' ) );
+
+			if ( $legacy_agent_type ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i CHANGE COLUMN agent_type context VARCHAR(20) NOT NULL DEFAULT %s', $table_name, 'chat' ) );
+			} else {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN context VARCHAR(20) NOT NULL DEFAULT %s AFTER model', $table_name, 'chat' ) );
+			}
+		}
+
+		// Best-effort index creation / normalization.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP KEY agent_type', $table_name ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP KEY user_agent', $table_name ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD KEY context (context)', $table_name ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD KEY user_context (user_id, context)', $table_name ) );
 	}
 
 	/**
@@ -139,16 +176,16 @@ class Chat extends BaseRepository {
 	/**
 	 * Create new chat session
 	 *
-	 * @param int    $user_id    WordPress user ID
-	 * @param array  $metadata   Optional session metadata
-	 * @param string $agent_type Agent type (chat, pipeline, system)
+	 * @param int    $user_id  WordPress user ID
+	 * @param array  $metadata Optional session metadata
+	 * @param string $context  Execution context (chat, pipeline, system, standalone)
 	 * @return string Session ID (UUID)
 	 */
 	public function create_session(
 		int $user_id,
 		int $agent_id = 0,
 		array $metadata = array(),
-		string $agent_type = 'chat'
+		string $context = 'chat'
 	): string {
 		global $wpdb;
 
@@ -166,7 +203,7 @@ class Chat extends BaseRepository {
 				'metadata'   => wp_json_encode( $metadata ),
 				'provider'   => null,
 				'model'      => null,
-				'agent_type' => $agent_type,
+				'context'    => $context,
 				'expires_at' => null,
 			),
 			array( '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' )
@@ -180,7 +217,7 @@ class Chat extends BaseRepository {
 				array(
 					'user_id'    => $user_id,
 					'error'      => $wpdb->last_error,
-					'agent_type' => $agent_type,
+					'context'    => $context,
 				)
 			);
 			return '';
@@ -194,7 +231,7 @@ class Chat extends BaseRepository {
 				'session_id' => $session_id,
 				'user_id'    => $user_id,
 				'agent_id'   => $agent_id,
-				'agent_type' => $agent_type,
+				'context'    => $context,
 			)
 		);
 
@@ -287,7 +324,7 @@ class Chat extends BaseRepository {
 				array(
 					'session_id' => $session_id,
 					'error'      => $wpdb->last_error,
-					'agent_type' => 'chat',
+					'context'    => 'chat',
 				)
 			);
 			return false;
@@ -322,7 +359,7 @@ class Chat extends BaseRepository {
 				array(
 					'session_id' => $session_id,
 					'error'      => $wpdb->last_error,
-					'agent_type' => 'chat',
+					'context'    => 'chat',
 				)
 			);
 			return false;
@@ -334,7 +371,7 @@ class Chat extends BaseRepository {
 			'Chat session deleted',
 			array(
 				'session_id' => $session_id,
-				'agent_type' => 'chat',
+				'context'    => 'chat',
 			)
 		);
 
@@ -367,7 +404,7 @@ class Chat extends BaseRepository {
 				'Cleaned up expired chat sessions',
 				array(
 					'deleted_count' => $deleted,
-					'agent_type'    => 'chat',
+					'context'       => 'chat',
 				)
 			);
 		}
@@ -378,33 +415,59 @@ class Chat extends BaseRepository {
 	/**
 	 * Get all sessions for a user
 	 *
-	 * @param int      $user_id    WordPress user ID
-	 * @param int      $limit      Maximum sessions to return
-	 * @param int      $offset     Pagination offset
-	 * @param string   $agent_type Agent type filter (chat, pipeline, system)
-	 * @param int|null $agent_id   Optional agent ID filter (null = no filter)
+	 * @param int         $user_id  WordPress user ID
+	 * @param int         $limit    Maximum sessions to return
+	 * @param int         $offset   Pagination offset
+	 * @param string|null $context  Optional context filter
+	 * @param int|null    $agent_id Optional agent ID filter (null = no filter)
 	 * @return array Array of session data
 	 */
 	public function get_user_sessions(
 		int $user_id,
 		int $limit = 20,
 		int $offset = 0,
-		string $agent_type = 'chat',
+		?string $context = null,
 		?int $agent_id = null
 	): array {
 		global $wpdb;
 
 		$table_name = self::get_prefixed_table_name();
 
-		if ( null !== $agent_id ) {
+		if ( null !== $agent_id && null !== $context && '' !== $context ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$sessions = $wpdb->get_results(
 				$wpdb->prepare(
-					'SELECT * FROM %i WHERE user_id = %d AND agent_type = %s AND agent_id = %d ORDER BY updated_at DESC LIMIT %d OFFSET %d',
+					'SELECT * FROM %i WHERE user_id = %d AND context = %s AND agent_id = %d ORDER BY updated_at DESC LIMIT %d OFFSET %d',
 					$table_name,
 					$user_id,
-					$agent_type,
+					$context,
 					$agent_id,
+					$limit,
+					$offset
+				),
+				ARRAY_A
+			);
+		} elseif ( null !== $agent_id ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$sessions = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT * FROM %i WHERE user_id = %d AND agent_id = %d ORDER BY updated_at DESC LIMIT %d OFFSET %d',
+					$table_name,
+					$user_id,
+					$agent_id,
+					$limit,
+					$offset
+				),
+				ARRAY_A
+			);
+		} elseif ( null !== $context && '' !== $context ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$sessions = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT * FROM %i WHERE user_id = %d AND context = %s ORDER BY updated_at DESC LIMIT %d OFFSET %d',
+					$table_name,
+					$user_id,
+					$context,
 					$limit,
 					$offset
 				),
@@ -414,10 +477,9 @@ class Chat extends BaseRepository {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$sessions = $wpdb->get_results(
 				$wpdb->prepare(
-					'SELECT * FROM %i WHERE user_id = %d AND agent_type = %s ORDER BY updated_at DESC LIMIT %d OFFSET %d',
+					'SELECT * FROM %i WHERE user_id = %d ORDER BY updated_at DESC LIMIT %d OFFSET %d',
 					$table_name,
 					$user_id,
-					$agent_type,
 					$limit,
 					$offset
 				),
@@ -443,6 +505,7 @@ class Chat extends BaseRepository {
 			$result[] = array(
 				'session_id'    => $session['session_id'],
 				'title'         => $session['title'] ?? null,
+				'context'       => $session['context'] ?? 'chat',
 				'first_message' => mb_substr( $first_message, 0, 100 ),
 				'message_count' => count( $messages ),
 				'created_at'    => DateFormatter::format_for_api( $session['created_at'] ?? null ),
@@ -456,39 +519,58 @@ class Chat extends BaseRepository {
 	/**
 	 * Get total session count for a user
 	 *
-	 * @param int      $user_id    WordPress user ID
-	 * @param string   $agent_type Agent type filter (chat, pipeline, system)
-	 * @param int|null $agent_id   Optional agent ID filter (null = no filter)
+	 * @param int         $user_id  WordPress user ID
+	 * @param string|null $context  Optional context filter
+	 * @param int|null    $agent_id Optional agent ID filter (null = no filter)
 	 * @return int Total session count
 	 */
 	public function get_user_session_count(
 		int $user_id,
-		string $agent_type = 'chat',
+		?string $context = null,
 		?int $agent_id = null
 	): int {
 		global $wpdb;
 
 		$table_name = self::get_prefixed_table_name();
 
-		if ( null !== $agent_id ) {
+		if ( null !== $agent_id && null !== $context && '' !== $context ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$count = $wpdb->get_var(
 				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i WHERE user_id = %d AND agent_type = %s AND agent_id = %d',
+					'SELECT COUNT(*) FROM %i WHERE user_id = %d AND context = %s AND agent_id = %d',
 					$table_name,
 					$user_id,
-					$agent_type,
+					$context,
 					$agent_id
+				)
+			);
+		} elseif ( null !== $agent_id ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$count = $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT COUNT(*) FROM %i WHERE user_id = %d AND agent_id = %d',
+					$table_name,
+					$user_id,
+					$agent_id
+				)
+			);
+		} elseif ( null !== $context && '' !== $context ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$count = $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT COUNT(*) FROM %i WHERE user_id = %d AND context = %s',
+					$table_name,
+					$user_id,
+					$context
 				)
 			);
 		} else {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$count = $wpdb->get_var(
 				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i WHERE user_id = %d AND agent_type = %s',
+					'SELECT COUNT(*) FROM %i WHERE user_id = %d',
 					$table_name,
-					$user_id,
-					$agent_type
+					$user_id
 				)
 			);
 		}
@@ -510,15 +592,15 @@ class Chat extends BaseRepository {
 	 * instead of creating a new one.
 	 *
 	 * @since 0.9.8
-	 * @param int    $user_id    WordPress user ID
-	 * @param int    $seconds    Lookback window in seconds (default 600 = 10 minutes)
-	 * @param string $agent_type Agent type filter (chat, pipeline, system)
+	 * @param int    $user_id WordPress user ID
+	 * @param int    $seconds Lookback window in seconds (default 600 = 10 minutes)
+	 * @param string $context Context filter
 	 * @return array|null Session data or null if none found
 	 */
 	public function get_recent_pending_session(
 		int $user_id,
 		int $seconds = 600,
-		string $agent_type = 'chat'
+		string $context = 'chat'
 	): ?array {
 		global $wpdb;
 
@@ -530,7 +612,7 @@ class Chat extends BaseRepository {
 			$wpdb->prepare(
 				"SELECT * FROM %i
 				WHERE user_id = %d
-				AND agent_type = %s
+				AND context = %s
 				AND created_at >= %s
 				AND (
 					(messages = '[]' OR messages = '' OR messages IS NULL)
@@ -540,7 +622,7 @@ class Chat extends BaseRepository {
 				LIMIT 1",
 				$table_name,
 				$user_id,
-				$agent_type,
+				$context,
 				$cutoff_time,
 				'%"status":"processing"%'
 			),
@@ -586,7 +668,7 @@ class Chat extends BaseRepository {
 				array(
 					'session_id' => $session_id,
 					'error'      => $wpdb->last_error,
-					'agent_type' => 'chat',
+					'context'    => 'chat',
 				)
 			);
 			return false;
@@ -625,7 +707,7 @@ class Chat extends BaseRepository {
 					'deleted_count'  => $deleted,
 					'retention_days' => $retention_days,
 					'cutoff_date'    => $cutoff_date,
-					'agent_type'     => 'chat',
+					'context'        => 'chat',
 				)
 			);
 		}
@@ -673,7 +755,7 @@ class Chat extends BaseRepository {
 					'deleted_count'   => $deleted,
 					'hours_threshold' => $hours,
 					'cutoff_time'     => $cutoff_time,
-					'agent_type'      => 'chat',
+					'context'         => 'chat',
 				)
 			);
 		}

--- a/inc/Core/NetworkSettings.php
+++ b/inc/Core/NetworkSettings.php
@@ -31,6 +31,7 @@ class NetworkSettings {
 	const NETWORK_KEYS = array(
 		'default_provider',
 		'default_model',
+		'context_models',
 		'agent_models',
 	);
 

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -12,6 +12,8 @@
 
 namespace DataMachine\Core;
 
+use DataMachine\Core\Database\Agents\Agents;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -21,6 +23,7 @@ class PluginSettings {
 	public const DEFAULT_MAX_TURNS = 25;
 
 	private static ?array $cache = null;
+	private static array $agent_model_cache = array();
 
 	/**
 	 * Get default queue tuning values.
@@ -108,36 +111,36 @@ class PluginSettings {
 	}
 
 	/**
-	 * Get provider and model for a specific agent type.
+	 * Get provider and model for a specific execution context.
 	 *
 	 * Resolution order:
-	 * 1. Per-site agent-specific override from agent_models setting
-	 * 2. Network agent-specific override from network agent_models
+	 * 1. Per-site context-specific override from context_models setting (or legacy agent_models)
+	 * 2. Network context-specific override from network context_models (or legacy agent_models)
 	 * 3. Per-site global default_provider / default_model
 	 * 4. Network global default_provider / default_model
 	 * 5. Empty strings
 	 *
-	 * @param string $agent_type Agent type: 'chat', 'pipeline', 'system'.
+	 * @param string $context Execution context: 'chat', 'pipeline', 'system', 'standalone'.
 	 * @return array{ provider: string, model: string }
 	 */
-	public static function getAgentModel( string $agent_type ): array {
-		// Step 1: Check per-site agent-specific override.
-		$site_agent_models = self::get( 'agent_models', array() );
-		$site_agent_config = $site_agent_models[ $agent_type ] ?? array();
+	public static function getContextModel( string $context ): array {
+		// Step 1: Check per-site context-specific override.
+		$site_context_models = self::get( 'context_models', self::get( 'agent_models', array() ) );
+		$site_context_config = $site_context_models[ $context ] ?? array();
 
-		$provider = ! empty( $site_agent_config['provider'] ) ? $site_agent_config['provider'] : '';
-		$model    = ! empty( $site_agent_config['model'] ) ? $site_agent_config['model'] : '';
+		$provider = ! empty( $site_context_config['provider'] ) ? $site_context_config['provider'] : '';
+		$model    = ! empty( $site_context_config['model'] ) ? $site_context_config['model'] : '';
 
-		// Step 2: Fall back to network agent-specific override.
+		// Step 2: Fall back to network context-specific override.
 		if ( empty( $provider ) || empty( $model ) ) {
-			$network_agent_models = NetworkSettings::get( 'agent_models', array() );
-			$network_agent_config = $network_agent_models[ $agent_type ] ?? array();
+			$network_context_models = NetworkSettings::get( 'context_models', NetworkSettings::get( 'agent_models', array() ) );
+			$network_context_config = $network_context_models[ $context ] ?? array();
 
-			if ( empty( $provider ) && ! empty( $network_agent_config['provider'] ) ) {
-				$provider = $network_agent_config['provider'];
+			if ( empty( $provider ) && ! empty( $network_context_config['provider'] ) ) {
+				$provider = $network_context_config['provider'];
 			}
-			if ( empty( $model ) && ! empty( $network_agent_config['model'] ) ) {
-				$model = $network_agent_config['model'];
+			if ( empty( $model ) && ! empty( $network_context_config['model'] ) ) {
+				$model = $network_context_config['model'];
 			}
 		}
 
@@ -156,11 +159,68 @@ class PluginSettings {
 	}
 
 	/**
-	 * Get the list of known agent types.
+	 * Resolve provider/model for an agent within an execution context.
 	 *
-	 * @return array Array of agent type definitions with id, label, and description.
+	 * Resolution order:
+	 * 1. agent_config.context_models[context]
+	 * 2. agent_config.default_provider/default_model
+	 * 3. site/network context-specific overrides
+	 * 4. site/network global defaults
+	 *
+	 * @param int|null $agent_id Agent ID or null/0 for no agent-specific override.
+	 * @param string   $context  Execution context.
+	 * @return array{ provider: string, model: string }
 	 */
-	public static function getAgentTypes(): array {
+	public static function resolveModelForAgentContext( ?int $agent_id, string $context ): array {
+		$agent_id = (int) $agent_id;
+		$cache_key = $agent_id . ':' . $context;
+
+		if ( isset( self::$agent_model_cache[ $cache_key ] ) ) {
+			return self::$agent_model_cache[ $cache_key ];
+		}
+
+		if ( $agent_id > 0 ) {
+			$agents_repo = new Agents();
+			$agent       = $agents_repo->get_agent( $agent_id );
+			$config      = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
+
+			$context_models = is_array( $config['context_models'] ?? null )
+				? $config['context_models']
+				: ( is_array( $config['agent_models'] ?? null ) ? $config['agent_models'] : array() );
+			$context_model  = is_array( $context_models[ $context ] ?? null ) ? $context_models[ $context ] : array();
+
+			$provider = sanitize_text_field( $context_model['provider'] ?? '' );
+			$model    = sanitize_text_field( $context_model['model'] ?? '' );
+
+			if ( empty( $provider ) ) {
+				$provider = sanitize_text_field( $config['default_provider'] ?? '' );
+			}
+
+			if ( empty( $model ) ) {
+				$model = sanitize_text_field( $config['default_model'] ?? '' );
+			}
+
+			if ( ! empty( $provider ) && ! empty( $model ) ) {
+				self::$agent_model_cache[ $cache_key ] = array(
+					'provider' => $provider,
+					'model'    => $model,
+				);
+
+				return self::$agent_model_cache[ $cache_key ];
+			}
+		}
+
+		self::$agent_model_cache[ $cache_key ] = self::getContextModel( $context );
+
+		return self::$agent_model_cache[ $cache_key ];
+	}
+
+	/**
+	 * Get the list of known execution contexts.
+	 *
+	 * @return array Array of context definitions with id, label, and description.
+	 */
+	public static function getContexts(): array {
 		return array(
 			array(
 				'id'          => 'chat',
@@ -177,6 +237,11 @@ class PluginSettings {
 				'label'       => __( 'System Agent', 'data-machine' ),
 				'description' => __( 'Background tasks like alt text generation and issue creation.', 'data-machine' ),
 			),
+			array(
+				'id'          => 'standalone',
+				'label'       => __( 'Standalone Context', 'data-machine' ),
+				'description' => __( 'Direct or ad-hoc execution outside pipeline and chat flows.', 'data-machine' ),
+			),
 		);
 	}
 
@@ -187,6 +252,7 @@ class PluginSettings {
 	 */
 	public static function clearCache(): void {
 		self::$cache = null;
+		self::$agent_model_cache = array();
 	}
 
 	/**

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -70,7 +70,9 @@ class AIStep extends Step {
 		$pipeline_step_id = $this->flow_step_config['pipeline_step_id'];
 
 		$pipeline_step_config = $this->engine->getPipelineStepConfig( $pipeline_step_id );
-		$pipeline_defaults    = PluginSettings::getAgentModel( 'pipeline' );
+		$job_snapshot         = $this->engine->get( 'job' );
+		$agent_id             = (int) ( $job_snapshot['agent_id'] ?? 0 );
+		$pipeline_defaults    = PluginSettings::resolveModelForAgentContext( $agent_id, 'pipeline' );
 		$provider_name        = $pipeline_step_config['provider'] ?? $pipeline_defaults['provider'];
 		if ( empty( $provider_name ) ) {
 			do_action(
@@ -177,9 +179,7 @@ class AIStep extends Step {
 		$max_turns = PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
 
 		// Resolve user_id and agent_id from engine snapshot (set by RunFlowAbility).
-		$job_snapshot = $this->engine->get( 'job' );
 		$user_id      = (int) ( $job_snapshot['user_id'] ?? 0 );
-		$agent_id     = (int) ( $job_snapshot['agent_id'] ?? 0 );
 
 		$payload = array(
 			'job_id'       => $this->job_id,
@@ -224,7 +224,7 @@ class AIStep extends Step {
 			'engine_data'          => $engine_data,
 		) );
 
-		$pipeline_agent_defaults = PluginSettings::getAgentModel( 'pipeline' );
+		$pipeline_agent_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'pipeline' );
 		$provider_name           = $pipeline_step_config['provider'] ?? $pipeline_agent_defaults['provider'];
 
 		// Execute conversation loop
@@ -234,7 +234,7 @@ class AIStep extends Step {
 			$available_tools,
 			$provider_name,
 			$pipeline_step_config['model'] ?? $pipeline_agent_defaults['model'],
-			'pipeline',
+			ToolPolicyResolver::CONTEXT_PIPELINE,
 			$payload,
 			$max_turns
 		);

--- a/inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php
+++ b/inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php
@@ -66,9 +66,9 @@ add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
 		$directives[] = array(
-			'class'       => FlowMemoryFilesDirective::class,
-			'priority'    => 45,
-			'agent_types' => array( 'pipeline' ),
+			'class'    => FlowMemoryFilesDirective::class,
+			'priority' => 45,
+			'contexts' => array( 'pipeline' ),
 		);
 		return $directives;
 	}

--- a/inc/Core/Steps/AI/Directives/PipelineCoreDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineCoreDirective.php
@@ -69,9 +69,9 @@ add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
 		$directives[] = array(
-			'class'       => PipelineCoreDirective::class,
-			'priority'    => 10,
-			'agent_types' => array( 'pipeline' ),
+			'class'    => PipelineCoreDirective::class,
+			'priority' => 10,
+			'contexts' => array( 'pipeline' ),
 		);
 		return $directives;
 	}

--- a/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
@@ -62,9 +62,9 @@ add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
 		$directives[] = array(
-			'class'       => PipelineMemoryFilesDirective::class,
-			'priority'    => 40,
-			'agent_types' => array( 'pipeline' ),
+			'class'    => PipelineMemoryFilesDirective::class,
+			'priority' => 40,
+			'contexts' => array( 'pipeline' ),
 		);
 		return $directives;
 	}

--- a/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
@@ -159,9 +159,9 @@ add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
 		$directives[] = array(
-			'class'       => PipelineSystemPromptDirective::class,
-			'priority'    => 50,
-			'agent_types' => array( 'pipeline' ),
+			'class'    => PipelineSystemPromptDirective::class,
+			'priority' => 50,
+			'contexts' => array( 'pipeline' ),
 		);
 		return $directives;
 	}

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -33,7 +33,7 @@ class AIConversationLoop {
 	 * @param array  $tools          Available tools for AI
 	 * @param string $provider       AI provider (openai, anthropic, etc.)
 	 * @param string $model          AI model identifier
-	 * @param string $agent_type     Agent type: 'pipeline' or 'chat'
+	 * @param string $context        Execution context: 'pipeline' or 'chat'
 	 * @param array  $payload        Step payload (job_id, flow_step_id, data, flow_step_config)
 	 * @param int    $max_turns      Maximum conversation turns (default 25)
 	 * @param bool   $single_turn    Execute exactly one turn and return (default false)
@@ -50,7 +50,7 @@ class AIConversationLoop {
 		array $tools,
 		string $provider,
 		string $model,
-		string $agent_type,
+		string $context,
 		array $payload = array(),
 		int $max_turns = PluginSettings::DEFAULT_MAX_TURNS,
 		bool $single_turn = false
@@ -73,7 +73,7 @@ class AIConversationLoop {
 		// Build base log context from payload for consistent logging
 		$base_log_context = array_filter(
 			array(
-				'agent_type'   => $agent_type,
+				'context'      => $context,
 				'job_id'       => $payload['job_id'] ?? null,
 				'flow_step_id' => $payload['flow_step_id'] ?? null,
 			),
@@ -89,7 +89,7 @@ class AIConversationLoop {
 				$provider,
 				$model,
 				$tools,
-				$agent_type,
+				$context,
 				$payload
 			);
 
@@ -133,7 +133,7 @@ class AIConversationLoop {
 				$messages[] = $ai_message;
 
 				// Fire hook for AI response events (used for system operations like title generation)
-				do_action( 'datamachine_ai_response_received', $agent_type, $messages, $payload );
+				do_action( 'datamachine_ai_response_received', $context, $messages, $payload );
 			}
 
 			// Process tool calls
@@ -237,7 +237,7 @@ class AIConversationLoop {
 
 					// Track handler tool execution in pipeline mode.
 					// Only complete when ALL configured handlers have fired (multi-handler support).
-					if ( 'pipeline' === $agent_type && $is_handler_tool && ( $tool_result['success'] ?? false ) ) {
+					if ( 'pipeline' === $context && $is_handler_tool && ( $tool_result['success'] ?? false ) ) {
 						$handler_slug = $tool_def['handler'] ?? null;
 						if ( $handler_slug ) {
 							$executed_handler_slugs[] = $handler_slug;

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -174,9 +174,9 @@ add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
 		$directives[] = array(
-			'class'       => CoreMemoryFilesDirective::class,
-			'priority'    => 20,
-			'agent_types' => array( 'all' ),
+			'class'    => CoreMemoryFilesDirective::class,
+			'priority' => 20,
+			'contexts' => array( 'all' ),
 		);
 		return $directives;
 	}

--- a/inc/Engine/AI/Directives/DailyMemorySelectorDirective.php
+++ b/inc/Engine/AI/Directives/DailyMemorySelectorDirective.php
@@ -312,9 +312,9 @@ add_filter(
 	'datamachine_directives',
 	function ( $directives ) {
 		$directives[] = array(
-			'class'       => DailyMemorySelectorDirective::class,
-			'priority'    => 46,
-			'agent_types' => array( 'pipeline' ),
+			'class'    => DailyMemorySelectorDirective::class,
+			'priority' => 46,
+			'contexts' => array( 'pipeline' ),
 		);
 		return $directives;
 	}

--- a/inc/Engine/AI/Directives/SiteContextDirective.php
+++ b/inc/Engine/AI/Directives/SiteContextDirective.php
@@ -71,9 +71,9 @@ if ( $datamachine_site_context_directive ) {
 		'datamachine_directives',
 		function ( $directives ) use ( $datamachine_site_context_directive ) {
 			$directives[] = array(
-				'class'       => $datamachine_site_context_directive,
-				'priority'    => 80,
-				'agent_types' => array( 'all' ),
+				'class'    => $datamachine_site_context_directive,
+				'priority' => 80,
+				'contexts' => array( 'all' ),
 			);
 			return $directives;
 		}

--- a/inc/Engine/AI/PromptBuilder.php
+++ b/inc/Engine/AI/PromptBuilder.php
@@ -73,14 +73,14 @@ class PromptBuilder {
 	 *
 	 * @param string|object $directive Directive class name or instance
 	 * @param int           $priority Priority for ordering (lower = applied first)
-	 * @param array         $agentTypes Agent types this directive applies to ('all' for global)
+	 * @param array         $contexts Contexts this directive applies to ('all' for global)
 	 * @return self
 	 */
-	public function addDirective( $directive, int $priority, array $agentTypes = array( 'all' ) ): self {
+	public function addDirective( $directive, int $priority, array $contexts = array( 'all' ) ): self {
 		$this->directives[] = array(
-			'directive'  => $directive,
-			'priority'   => $priority,
-			'agentTypes' => $agentTypes,
+			'directive' => $directive,
+			'priority'  => $priority,
+			'contexts'  => $contexts,
 		);
 		return $this;
 	}
@@ -88,12 +88,12 @@ class PromptBuilder {
 	/**
 	 * Build the final AI request with directives applied
 	 *
-	 * @param string $agentType Agent type ('pipeline', 'chat', etc.)
+	 * @param string $context Execution context ('pipeline', 'chat', etc.)
 	 * @param string $provider AI provider name
 	 * @param array  $payload Request payload
 	 * @return array Request array with 'messages', 'tools', and 'applied_directives' metadata
 	 */
-	public function build( string $agentType, string $provider, array $payload = array() ): array {
+	public function build( string $context, string $provider, array $payload = array() ): array {
 		usort(
 			$this->directives,
 			function ( $a, $b ) {
@@ -106,10 +106,10 @@ class PromptBuilder {
 		$applied_directives    = array();
 
 		foreach ( $this->directives as $directiveConfig ) {
-			$directive  = $directiveConfig['directive'];
-			$agentTypes = $directiveConfig['agentTypes'];
+			$directive = $directiveConfig['directive'];
+			$contexts  = $directiveConfig['contexts'];
 
-			if ( ! in_array( 'all', $agentTypes, true ) && ! in_array( $agentType, $agentTypes, true ) ) {
+			if ( ! in_array( 'all', $contexts, true ) && ! in_array( $context, $contexts, true ) ) {
 				continue;
 			}
 

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -2,7 +2,7 @@
 /**
  * AI Request Builder - Centralized AI request construction for all agents
  *
- * Single source of truth for building standardized AI requests across Chat and Pipeline agents.
+	 * Single source of truth for building standardized AI requests across chat and pipeline contexts.
  * Ensures consistent request structure, tool formatting, and directive application to prevent
  * architectural drift between different AI agent types.
  *
@@ -17,9 +17,9 @@ defined( 'ABSPATH' ) || exit;
 class RequestBuilder {
 
 	/**
-	 * Build standardized AI request for any agent type
+	 * Build standardized AI request for any context.
 	 *
-	 * Centralizes request construction logic to ensure Chat and Pipeline agents
+	 * Centralizes request construction logic to ensure chat and pipeline flows
 	 * build identical request structures. Handles tool restructuring, directive
 	 * application via PromptBuilder, and consistent chubes_ai_request filter invocation.
 	 *
@@ -27,7 +27,7 @@ class RequestBuilder {
 	 * @param string $provider    AI provider name (openai, anthropic, google, grok, openrouter)
 	 * @param string $model       Model identifier
 	 * @param array  $tools       Raw tools array from filters
-	 * @param string $agent_type  Agent type: 'chat' or 'pipeline'
+	 * @param string $context     Execution context: 'chat' or 'pipeline'
 	 * @param array  $payload     Step payload (session_id, job_id, flow_step_id, data, etc)
 	 * @return array AI response from provider
 	 */
@@ -36,7 +36,7 @@ class RequestBuilder {
 		string $provider,
 		string $model,
 		array $tools,
-		string $agent_type,
+		string $context,
 		array $payload = array()
 	): array {
 
@@ -61,12 +61,12 @@ class RequestBuilder {
 			$promptBuilder->addDirective(
 				$directive['class'],
 				$directive['priority'],
-				$directive['agent_types'] ?? array( 'all' )
+				$directive['contexts'] ?? array( 'all' )
 			);
 		}
 
 		// Build the request with directives applied
-		$request            = $promptBuilder->build( $agent_type, $provider, $payload );
+		$request            = $promptBuilder->build( $context, $provider, $payload );
 		$applied_directives = $request['applied_directives'] ?? array();
 		unset( $request['applied_directives'] );
 		$request['model'] = $model;
@@ -77,7 +77,7 @@ class RequestBuilder {
 			'AI request built',
 			array_filter(
 				array(
-					'agent_type'    => $agent_type,
+					'context'       => $context,
 					'job_id'        => $payload['job_id'] ?? null,
 					'flow_step_id'  => $payload['flow_step_id'] ?? null,
 					'provider'      => $provider,
@@ -99,8 +99,8 @@ class RequestBuilder {
 			$structured_tools,
 			$payload['step_id'] ?? $payload['session_id'] ?? null,
 			array(
-				'agent_type' => $agent_type,
-				'payload'    => $payload,
+				'context' => $context,
+				'payload' => $payload,
 			)
 		);
 	}

--- a/inc/Engine/AI/System/SystemAgent.php
+++ b/inc/Engine/AI/System/SystemAgent.php
@@ -72,10 +72,10 @@ class SystemAgent {
 				'error',
 				"System Agent: Unknown task type '{$taskType}'",
 				array(
-					'task_type'  => $taskType,
-					'agent_type' => 'system',
-					'params'     => $params,
-					'context'    => $context,
+					'task_type' => $taskType,
+					'context'   => 'system',
+					'params'    => $params,
+					'route'     => $context,
 				)
 			);
 			return false;
@@ -88,6 +88,7 @@ class SystemAgent {
 			'flow_id'     => 'direct',
 			'source'      => 'system',
 			'label'       => ucfirst( str_replace( '_', ' ', $taskType ) ),
+			'user_id'     => (int) ( $context['user_id'] ?? 0 ),
 		);
 
 		if ( $parentJobId > 0 ) {
@@ -102,8 +103,8 @@ class SystemAgent {
 				'error',
 				'System Agent: Failed to create job for task',
 				array(
-					'task_type'  => $taskType,
-					'agent_type' => 'system',
+					'task_type' => $taskType,
+					'context'   => 'system',
 				)
 			);
 			return false;
@@ -140,10 +141,10 @@ class SystemAgent {
 					array(
 						'job_id'     => $job_id,
 						'action_id'  => $action_id,
-						'task_type'  => $taskType,
-						'agent_type' => 'system',
-						'params'     => $params,
-						'context'    => $context,
+						'task_type' => $taskType,
+						'context'   => 'system',
+						'params'    => $params,
+						'route'     => $context,
 					)
 				);
 
@@ -198,9 +199,9 @@ class SystemAgent {
 				'error',
 				"System Agent: Cannot schedule batch for unknown task type '{$taskType}'",
 				array(
-					'task_type'  => $taskType,
-					'agent_type' => 'system',
-					'count'      => count( $itemParams ),
+					'task_type' => $taskType,
+					'context'   => 'system',
+					'count'     => count( $itemParams ),
 				)
 			);
 			return false;
@@ -311,10 +312,10 @@ class SystemAgent {
 			array(
 				'batch_id'     => $batch_id,
 				'batch_job_id' => $batch_job_id,
-				'task_type'    => $taskType,
-				'agent_type'   => 'system',
-				'total'        => count( $itemParams ),
-				'chunk_size'   => $chunkSize,
+				'task_type'  => $taskType,
+				'context'    => 'system',
+				'total'      => count( $itemParams ),
+				'chunk_size' => $chunkSize,
 			)
 		);
 
@@ -348,8 +349,8 @@ class SystemAgent {
 				'warning',
 				"System Agent: Batch {$batchId} not found or expired",
 				array(
-					'batch_id'   => $batchId,
-					'agent_type' => 'system',
+					'batch_id' => $batchId,
+					'context'  => 'system',
 				)
 			);
 			return;
@@ -382,10 +383,10 @@ class SystemAgent {
 						array(
 							'batch_id'     => $batchId,
 							'batch_job_id' => $batch_job_id,
-							'task_type'    => $task_type,
-							'agent_type'   => 'system',
-							'offset'       => $offset,
-							'total'        => $total,
+						'task_type' => $task_type,
+						'context'   => 'system',
+						'offset'    => $offset,
+						'total'     => $total,
 						)
 					);
 					return;
@@ -430,12 +431,12 @@ class SystemAgent {
 			array(
 				'batch_id'     => $batchId,
 				'batch_job_id' => $batch_job_id,
-				'task_type'    => $task_type,
-				'agent_type'   => 'system',
-				'offset'       => $offset,
-				'chunk_size'   => $chunk_size,
-				'scheduled'    => $scheduled,
-				'remaining'    => max( 0, $total - $new_offset ),
+				'task_type'  => $task_type,
+				'context'    => 'system',
+				'offset'     => $offset,
+				'chunk_size' => $chunk_size,
+				'scheduled'  => $scheduled,
+				'remaining'  => max( 0, $total - $new_offset ),
 			)
 		);
 
@@ -471,9 +472,9 @@ class SystemAgent {
 				array(
 					'batch_id'     => $batchId,
 					'batch_job_id' => $batch_job_id,
-					'task_type'    => $task_type,
-					'agent_type'   => 'system',
-					'total'        => $total,
+					'task_type' => $task_type,
+					'context'   => 'system',
+					'total'     => $total,
 				)
 			);
 		}
@@ -580,16 +581,16 @@ class SystemAgent {
 			delete_transient( $transient_key );
 		}
 
-		do_action(
-			'datamachine_log',
-			'info',
-			sprintf( 'System Agent batch cancelled: job #%d (%s)', $batchJobId, $engine_data['task_type'] ?? '' ),
-			array(
-				'batch_job_id' => $batchJobId,
-				'task_type'    => $engine_data['task_type'] ?? '',
-				'agent_type'   => 'system',
-			)
-		);
+			do_action(
+				'datamachine_log',
+				'info',
+				sprintf( 'System Agent batch cancelled: job #%d (%s)', $batchJobId, $engine_data['task_type'] ?? '' ),
+				array(
+					'batch_job_id' => $batchJobId,
+					'task_type'    => $engine_data['task_type'] ?? '',
+					'context'      => 'system',
+				)
+			);
 
 		return true;
 	}
@@ -647,8 +648,8 @@ class SystemAgent {
 				'error',
 				"System Agent: Job {$jobId} not found",
 				array(
-					'job_id'     => $jobId,
-					'agent_type' => 'system',
+					'job_id'  => $jobId,
+					'context' => 'system',
 				)
 			);
 			return;
@@ -664,7 +665,7 @@ class SystemAgent {
 				"System Agent: No task type found in job {$jobId}",
 				array(
 					'job_id'      => $jobId,
-					'agent_type'  => 'system',
+					'context'     => 'system',
 					'engine_data' => $engine_data,
 				)
 			);
@@ -679,9 +680,9 @@ class SystemAgent {
 				'error',
 				"System Agent: Unknown task type '{$task_type}' for job {$jobId}",
 				array(
-					'job_id'     => $jobId,
-					'task_type'  => $task_type,
-					'agent_type' => 'system',
+					'job_id'    => $jobId,
+					'task_type' => $task_type,
+					'context'   => 'system',
 				)
 			);
 
@@ -703,7 +704,7 @@ class SystemAgent {
 				array(
 					'job_id'         => $jobId,
 					'task_type'      => $task_type,
-					'agent_type'     => 'system',
+					'context'        => 'system',
 					'handler_class'  => $handler_class,
 					'exception'      => $e->getMessage(),
 					'exception_file' => $e->getFile(),

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -209,7 +209,7 @@ class SystemAgentServiceProvider {
 					array(
 						'attachment_id'   => $attachmentId,
 						'pipeline_job_id' => $pipelineJobId,
-						'agent_type'      => 'system',
+						'context'         => 'system',
 					)
 				);
 				return;
@@ -249,7 +249,7 @@ class SystemAgentServiceProvider {
 				'attachment_id'   => $attachmentId,
 				'pipeline_job_id' => $pipelineJobId,
 				'attempt'         => $attempt,
-				'agent_type'      => 'system',
+				'context'         => 'system',
 			)
 		);
 	}

--- a/inc/Engine/AI/System/Tasks/AltTextTask.php
+++ b/inc/Engine/AI/System/Tasks/AltTextTask.php
@@ -55,7 +55,7 @@ class AltTextTask extends SystemTask {
 			return;
 		}
 
-		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$system_defaults = $this->resolveSystemModel( $params );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -45,7 +45,7 @@ class DailyMemoryTask extends SystemTask {
 			return;
 		}
 
-		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$system_defaults = $this->resolveSystemModel( $params );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 
@@ -183,9 +183,9 @@ class DailyMemoryTask extends SystemTask {
 			$provider,
 			$model,
 			array(),
-			'system',
-			array()
-		);
+				'system',
+				array()
+			);
 
 		if ( empty( $response['success'] ) ) {
 			do_action(
@@ -519,7 +519,7 @@ PROMPT;
 		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		$sessions = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT session_id, title, agent_type, created_at
+				"SELECT session_id, title, context, created_at
 				 FROM {$table}
 				 WHERE DATE(created_at) = %s
 				 ORDER BY created_at ASC",
@@ -536,8 +536,8 @@ PROMPT;
 		$lines = array();
 		foreach ( $sessions as $session ) {
 			$title   = $session['title'] ? $session['title'] : 'Untitled session';
-			$type    = $session['agent_type'] ?? 'chat';
-			$lines[] = "- [{$type}] {$title}";
+			$context = $session['context'] ?? 'chat';
+			$lines[] = "- [{$context}] {$title}";
 		}
 
 		return implode( "\n", $lines );

--- a/inc/Engine/AI/System/Tasks/ImageGenerationTask.php
+++ b/inc/Engine/AI/System/Tasks/ImageGenerationTask.php
@@ -91,7 +91,7 @@ class ImageGenerationTask extends SystemTask {
 				array(
 					'job_id'        => $jobId,
 					'task_type'     => $this->getTaskType(),
-					'agent_type'    => 'system',
+					'context'       => 'system',
 					'prediction_id' => $prediction_id,
 					'error'         => $result['error'] ?? 'Unknown HTTP error',
 				)
@@ -166,11 +166,11 @@ class ImageGenerationTask extends SystemTask {
 				'warning',
 				"System Agent: Image sideload failed for job {$jobId}: " . $sideload_result->get_error_message(),
 				array(
-					'job_id'     => $jobId,
-					'task_type'  => $this->getTaskType(),
-					'agent_type' => 'system',
-					'image_url'  => $image_url,
-					'error'      => $sideload_result->get_error_message(),
+					'job_id'    => $jobId,
+					'task_type' => $this->getTaskType(),
+					'context'   => 'system',
+					'image_url' => $image_url,
+					'error'     => $sideload_result->get_error_message(),
 				)
 			);
 			// Don't fail the job — we still have the remote URL
@@ -281,7 +281,7 @@ class ImageGenerationTask extends SystemTask {
 					'job_id'        => $jobId,
 					'post_id'       => $post_id,
 					'attachment_id' => $attachmentId,
-					'agent_type'    => 'system',
+					'context'       => 'system',
 				)
 			);
 			return array();
@@ -299,7 +299,7 @@ class ImageGenerationTask extends SystemTask {
 					'job_id'        => $jobId,
 					'post_id'       => $post_id,
 					'attachment_id' => $attachmentId,
-					'agent_type'    => 'system',
+					'context'       => 'system',
 				)
 			);
 
@@ -320,7 +320,7 @@ class ImageGenerationTask extends SystemTask {
 				'job_id'        => $jobId,
 				'post_id'       => $post_id,
 				'attachment_id' => $attachmentId,
-				'agent_type'    => 'system',
+				'context'       => 'system',
 			)
 		);
 
@@ -359,7 +359,7 @@ class ImageGenerationTask extends SystemTask {
 			array(
 				'attachment_id'   => $attachmentId,
 				'pipeline_job_id' => $pipelineJobId,
-				'agent_type'      => 'system',
+				'context'         => 'system',
 			)
 		);
 	}
@@ -443,7 +443,7 @@ class ImageGenerationTask extends SystemTask {
 				'attachment_id'  => $attachment_id,
 				'attachment_url' => $attachment_url,
 				'model'          => $model,
-				'agent_type'     => 'system',
+				'context'        => 'system',
 			)
 		);
 
@@ -495,7 +495,7 @@ class ImageGenerationTask extends SystemTask {
 				'datamachine_log',
 				'warning',
 				'System Agent: JPEG conversion failed, using original file: ' . $converted->get_error_message(),
-				array( 'agent_type' => 'system' )
+				array( 'context' => 'system' )
 			);
 			// Fall back to original file — non-critical failure.
 			return $tmp_file;
@@ -510,7 +510,7 @@ class ImageGenerationTask extends SystemTask {
 			"System Agent: Converted {$current_mime} to JPEG for sideload",
 			array(
 				'original_mime' => $current_mime,
-				'agent_type'    => 'system',
+				'context'       => 'system',
 			)
 		);
 
@@ -543,7 +543,7 @@ class ImageGenerationTask extends SystemTask {
 			do_action( 'datamachine_log', 'warning', "System Agent: Cannot insert image — no post_id available for job {$jobId}", array(
 				'job_id'        => $jobId,
 				'attachment_id' => $attachmentId,
-				'agent_type'    => 'system',
+				'context'       => 'system',
 			) );
 			return array();
 		}
@@ -551,8 +551,8 @@ class ImageGenerationTask extends SystemTask {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			do_action( 'datamachine_log', 'warning', "System Agent: Post #{$post_id} not found for image insert", array(
-				'job_id'     => $jobId,
-				'agent_type' => 'system',
+				'job_id'  => $jobId,
+				'context' => 'system',
 			) );
 			return array();
 		}
@@ -590,14 +590,14 @@ class ImageGenerationTask extends SystemTask {
 			'post_content' => $new_content,
 		) );
 
-		do_action( 'datamachine_log', 'info', "System Agent: Image inserted into post #{$post_id} content at position '{$position}' (attachment #{$attachmentId})", array(
-			'job_id'        => $jobId,
-			'post_id'       => $post_id,
-			'attachment_id' => $attachmentId,
-			'position'      => $position,
-			'insert_index'  => $insert_index,
-			'agent_type'    => 'system',
-		) );
+			do_action( 'datamachine_log', 'info', "System Agent: Image inserted into post #{$post_id} content at position '{$position}' (attachment #{$attachmentId})", array(
+				'job_id'        => $jobId,
+				'post_id'       => $post_id,
+				'attachment_id' => $attachmentId,
+				'position'      => $position,
+				'insert_index'  => $insert_index,
+				'context'       => 'system',
+			) );
 
 		// Build effects for undo.
 		$effects = array();

--- a/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
+++ b/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
@@ -104,7 +104,7 @@ class InternalLinkingTask extends SystemTask {
 		}
 
 		// Build AI request config.
-		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$system_defaults = $this->resolveSystemModel( $params );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 

--- a/inc/Engine/AI/System/Tasks/MetaDescriptionTask.php
+++ b/inc/Engine/AI/System/Tasks/MetaDescriptionTask.php
@@ -73,7 +73,7 @@ class MetaDescriptionTask extends SystemTask {
 			return;
 		}
 
-		$system_defaults = PluginSettings::getAgentModel( 'system' );
+		$system_defaults = $this->resolveSystemModel( $params );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -26,6 +26,7 @@ defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\PluginSettings;
 
 abstract class SystemTask {
 
@@ -60,6 +61,20 @@ abstract class SystemTask {
 			'setting_key'     => null,
 			'default_enabled' => true,
 		);
+	}
+
+	/**
+	 * Resolve the effective system-context model for this job.
+	 *
+	 * Prefers the explicit agent_id stored in task params or nested context.
+	 * Falls back to global system context defaults when no agent is available.
+	 *
+	 * @param array $params Task params / engine_data.
+	 * @return array{ provider: string, model: string }
+	 */
+	protected function resolveSystemModel( array $params ): array {
+		$agent_id = (int) ( $params['agent_id'] ?? ( $params['context']['agent_id'] ?? 0 ) );
+		return PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
 	}
 
 	/**
@@ -382,10 +397,10 @@ abstract class SystemTask {
 			'info',
 			"System Agent task completed successfully for job {$jobId}",
 			array(
-				'job_id'     => $jobId,
-				'task_type'  => $this->getTaskType(),
-				'agent_type' => 'system',
-				'result'     => $result,
+				'job_id'    => $jobId,
+				'task_type' => $this->getTaskType(),
+				'context'   => 'system',
+				'result'    => $result,
 			)
 		);
 	}
@@ -417,10 +432,10 @@ abstract class SystemTask {
 			'error',
 			"System Agent task failed for job {$jobId}: {$reason}",
 			array(
-				'job_id'     => $jobId,
-				'task_type'  => $this->getTaskType(),
-				'agent_type' => 'system',
-				'error'      => $reason,
+				'job_id'    => $jobId,
+				'task_type' => $this->getTaskType(),
+				'context'   => 'system',
+				'error'     => $reason,
 			)
 		);
 	}
@@ -477,10 +492,10 @@ abstract class SystemTask {
 				'debug',
 				"System Agent task rescheduled for job {$jobId} (attempt {$attempts}/{$max_attempts})",
 				array(
-					'job_id'        => $jobId,
-					'task_type'     => $this->getTaskType(),
-					'agent_type'    => 'system',
-					'attempts'      => $attempts,
+				'job_id'        => $jobId,
+				'task_type'     => $this->getTaskType(),
+				'context'       => 'system',
+				'attempts'      => $attempts,
 					'max_attempts'  => $max_attempts,
 					'delay_seconds' => $delaySeconds,
 				)

--- a/inc/Engine/Logger.php
+++ b/inc/Engine/Logger.php
@@ -84,9 +84,6 @@ function datamachine_log_message( string $level, string|\Stringable $message, ar
 			}
 		}
 
-		// Clean context: remove routing fields that are now handled structurally.
-		unset( $context['agent_type'] );
-
 		$repo->log( $level, (string) $message, $context, $agent_id, $user_id );
 	} catch ( \Exception $e ) {
 		// Prevent logging failures from crashing the application.

--- a/inc/migrations.php
+++ b/inc/migrations.php
@@ -474,7 +474,7 @@ function datamachine_migrate_to_layered_architecture(): void {
 			$user        = get_user_by( 'id', $user_id );
 			$agent_slug  = $user ? sanitize_title( $user->user_login ) : 'user-' . $user_id;
 			$agent_name  = $user ? $user->display_name : 'User ' . $user_id;
-			$agent_model = \DataMachine\Core\PluginSettings::getAgentModel( 'chat' );
+			$agent_model = \DataMachine\Core\PluginSettings::getContextModel( 'chat' );
 
 			$agent_id = $agents_repo->create_if_missing(
 				$agent_slug,
@@ -577,7 +577,7 @@ function datamachine_migrate_to_layered_architecture(): void {
 		$default_user    = get_user_by( 'id', $default_user_id );
 		$default_slug    = $default_user ? sanitize_title( $default_user->user_login ) : 'user-' . $default_user_id;
 		$default_name    = $default_user ? $default_user->display_name : 'User ' . $default_user_id;
-		$default_model   = \DataMachine\Core\PluginSettings::getAgentModel( 'chat' );
+		$default_model   = \DataMachine\Core\PluginSettings::getContextModel( 'chat' );
 
 		$agents_repo->create_if_missing(
 			$default_slug,

--- a/tests/Unit/Core/NetworkSettingsTest.php
+++ b/tests/Unit/Core/NetworkSettingsTest.php
@@ -161,7 +161,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 		$this->assertSame( 12, PluginSettings::resolve( 'max_turns', 12 ) );
 	}
 
-	// --- getAgentModel() cascade ---
+	// --- getContextModel() cascade ---
 
 	public function test_get_agent_model_site_override_wins(): void {
 		update_option( 'datamachine_settings', array(
@@ -177,7 +177,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 			),
 		) );
 
-		$result = PluginSettings::getAgentModel( 'chat' );
+		$result = PluginSettings::getContextModel( 'chat' );
 
 		$this->assertSame( 'openai', $result['provider'] );
 		$this->assertSame( 'gpt-4o', $result['model'] );
@@ -193,7 +193,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 			),
 		) );
 
-		$result = PluginSettings::getAgentModel( 'pipeline' );
+		$result = PluginSettings::getContextModel( 'pipeline' );
 
 		$this->assertSame( 'openai', $result['provider'] );
 		$this->assertSame( 'gpt-4o-mini', $result['model'] );
@@ -208,7 +208,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 			'default_model'    => 'claude-sonnet-4-20250514',
 		) );
 
-		$result = PluginSettings::getAgentModel( 'system' );
+		$result = PluginSettings::getContextModel( 'system' );
 
 		$this->assertSame( 'anthropic', $result['provider'] );
 		$this->assertSame( 'claude-sonnet-4-20250514', $result['model'] );
@@ -218,7 +218,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 		update_option( 'datamachine_settings', array() );
 		PluginSettings::clearCache();
 
-		$result = PluginSettings::getAgentModel( 'chat' );
+		$result = PluginSettings::getContextModel( 'chat' );
 
 		$this->assertSame( '', $result['provider'] );
 		$this->assertSame( '', $result['model'] );
@@ -240,7 +240,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 			),
 		) );
 
-		$result = PluginSettings::getAgentModel( 'chat' );
+		$result = PluginSettings::getContextModel( 'chat' );
 
 		// Provider from site, model from network.
 		$this->assertSame( 'openai', $result['provider'] );


### PR DESCRIPTION
## Summary
- remove `agent_type` as a runtime concept and replace chat/runtime/API/CLI flows with `context` plus explicit `agent_id`
- migrate chat persistence to use `context`, keep only migration-only legacy handling for the old `agent_type` column, and restore the logs UI to tab by accessible agents using `agent_id`
- add agent-aware model resolution so chat, pipeline, and system execution can resolve model policy as `agent context override -> agent default -> global context override -> global default`

## Details
- added `PluginSettings::resolveModelForAgentContext()`
- wired async system tasks to honor agent-specific `system` context models
- added per-agent AI model policy controls in the agent edit UI
- fixed cleanup issues found during review: broken log tools, over-broad logs tab invalidation, redundant chat agent lookup, legacy `agent_models` fallback for agent config, and boot-time chat schema migration safety

## Validation
- targeted `php -l` checks passed on the changed PHP files
- repo-wide grep confirmed remaining `agent_type` references are limited to chat DB migration code