### PR TITLE
Fix: Filter tools by context in pipeline UI

### DIFF
--- a/inc/Api/Tools.php
+++ b/inc/Api/Tools.php
@@ -44,7 +44,14 @@ class Tools {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( self::class, 'handle_get_tools' ),
 				'permission_callback' => '__return_true', // Public endpoint
-				'args'                => array(),
+				'args'                => array(
+					'context' => array(
+						'type'        => 'string',
+						'enum'        => array( 'pipeline', 'chat', 'standalone', 'system' ),
+						'required'    => false,
+						'description' => 'Filter tools by execution context. Returns only tools available in the specified context.',
+					),
+				),
 			)
 		);
 	}
@@ -56,11 +63,13 @@ class Tools {
 	 * Filters to only global tools (excludes handler-specific tools).
 	 *
 	 * @since 0.1.2
+	 * @param \WP_REST_Request $request REST request object.
 	 * @return \WP_REST_Response Tools response
 	 */
-	public static function handle_get_tools() {
+	public static function handle_get_tools( $request ) {
+		$context      = $request->get_param( 'context' );
 		$tool_manager = new \DataMachine\Engine\AI\Tools\ToolManager();
-		$tools        = $tool_manager->get_tools_for_api();
+		$tools        = $tool_manager->get_tools_for_api( $context );
 
 		return rest_ensure_response(
 			array(

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/config.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/config.js
@@ -43,11 +43,11 @@ export const useSchedulingIntervals = () =>
 		staleTime: Infinity, // Scheduling intervals don't change
 	} );
 
-export const useTools = () =>
+export const useTools = ( context = 'pipeline' ) =>
 	useQuery( {
-		queryKey: [ 'config', 'tools' ],
+		queryKey: [ 'config', 'tools', context ],
 		queryFn: async () => {
-			const result = await getTools();
+			const result = await getTools( context );
 			return result.success ? result.data : {};
 		},
 		staleTime: 30 * 60 * 1000, // 30 minutes - tools don't change often

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -517,10 +517,12 @@ export const getProviders = async () => {
 /**
  * Get available tools
  *
+ * @param {string|null} context - Optional context filter ('pipeline', 'chat', 'standalone', 'system')
  * @return {Promise<Object>} Tools configuration
  */
-export const getTools = async () => {
-	return await client.get( '/tools' );
+export const getTools = async ( context = null ) => {
+	const params = context ? { context } : {};
+	return await client.get( '/tools', params );
 };
 
 /**

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -447,10 +447,19 @@ class ToolManager {
 	/**
 	 * Get tools for REST API response.
 	 *
+	 * @param string|null $context Optional context to filter tools ('pipeline', 'chat', 'standalone', 'system').
+	 *                            When null, returns all tools.
 	 * @return array Tools formatted for API
 	 */
-	public function get_tools_for_api(): array {
-		$tools     = $this->get_global_tools();
+	public function get_tools_for_api( ?string $context = null ): array {
+		// If context specified, use ToolPolicyResolver to filter appropriately
+		if ( null !== $context ) {
+			$resolver = new ToolPolicyResolver( $this );
+			$tools    = $resolver->resolve( array( 'context' => $context ) );
+		} else {
+			$tools = $this->get_global_tools();
+		}
+
 		$formatted = array();
 
 		foreach ( $tools as $tool_id => $tool_config ) {
@@ -462,6 +471,7 @@ class ToolManager {
 				'requires_config'  => $this->requires_configuration( $tool_id ),
 				'configured'       => $this->is_tool_configured( $tool_id ),
 				'globally_enabled' => $is_globally_enabled,
+				'contexts'         => $tool_config['contexts'] ?? array(),
 			);
 		}
 


### PR DESCRIPTION
## Problem
The pipeline admin page was showing all tools regardless of their declared contexts. Tools registered only for 'chat' context were appearing in pipeline step configuration, causing confusion since those tools would never actually be available at runtime.

## Solution
- **ToolManager::get_tools_for_api()** - Added optional `$context` parameter that uses ToolPolicyResolver to filter tools by their declared contexts
- **REST API /tools endpoint** - Added `context` query parameter (enum: pipeline, chat, standalone, system)
- **React useTools() hook** - Updated to default to 'pipeline' context, ensuring only pipeline-compatible tools are shown
- **API response** - Added `contexts` field to each tool for transparency

## Backward Compatibility
- No context parameter = returns all tools (unchanged behavior)
- React hook defaults to 'pipeline' for the pipeline admin context

## Testing
- ToolPolicyResolver tests pass (context filtering already tested)
- No breaking changes to existing functionality

Fixes UI inconsistency where tool availability at config time didn't match runtime behavior.