### PR TITLE
fix(ui): reorder Agent page tabs - Memory first

### DIFF
--- a/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
@@ -2,7 +2,7 @@
  * AgentApp Component
  *
  * Root container for the Agent admin page.
- * Tabbed layout: Manage, Memory, System Tasks, Tools, and Configuration.
+ * Tabbed layout: Memory, Manage, System Tasks, Tools, and Configuration.
  */
 
 /**
@@ -29,8 +29,8 @@ import SystemTasksTab from './components/SystemTasksTab';
 import { useAgentFiles } from './queries/agentFiles';
 
 const TABS = [
-	{ name: 'manage', title: 'Manage' },
 	{ name: 'memory', title: 'Memory' },
+	{ name: 'manage', title: 'Manage' },
 	{ name: 'system-tasks', title: 'System Tasks' },
 	{ name: 'tools', title: 'Tools' },
 	{ name: 'configuration', title: 'Configuration' },


### PR DESCRIPTION
## Problem
The Agent admin page shows "Manage" tab first, but users typically want to access Memory files first.

## Solution
Reorders tabs so Memory appears first:
- Before: Manage, Memory, System Tasks, Tools, Configuration
- After: Memory, Manage, System Tasks, Tools, Configuration

## Changes
- Updated TABS array order in AgentApp.jsx
- Updated doc comment to reflect new order

Ready to iterate if needed.