### PR TITLE
fix(ui): agent switcher at tabs header + manage tab refactor

### DIFF
--- a/inc/Core/Admin/Pages/Agent/assets/css/agent-page.css
+++ b/inc/Core/Admin/Pages/Agent/assets/css/agent-page.css
@@ -13,7 +13,7 @@
 
 /* Header */
 .datamachine-agent-header {
-	margin-bottom: 20px;
+	margin-bottom: 0;
 	padding-bottom: 15px;
 	border-bottom: 1px solid #ddd;
 }
@@ -23,6 +23,42 @@
 	font-size: 23px;
 	font-weight: 400;
 	line-height: 1.3;
+}
+
+/* Tabs Header with Agent Switcher */
+.datamachine-agent-tabs-header {
+	display: flex;
+	align-items: center;
+	gap: 20px;
+	margin-bottom: 0;
+	padding: 12px 0;
+	border-bottom: 1px solid #c3c4c7;
+}
+
+.datamachine-agent-tabs-header .datamachine-agent-switcher {
+	margin-bottom: 0;
+}
+
+/* Empty state for tabs requiring agent selection */
+.datamachine-agent-tab-empty {
+	padding: 40px 20px;
+	text-align: center;
+	background: #fcfcfc;
+	border: 1px solid #e0e0e0;
+	margin-top: 20px;
+}
+
+.datamachine-agent-tab-empty p {
+	margin: 0;
+	color: #646970;
+	font-size: 14px;
+}
+
+.datamachine-agent-loading {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	padding: 60px 20px;
 }
 
 /* Two-Panel Layout */

--- a/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
@@ -2,7 +2,8 @@
  * AgentApp Component
  *
  * Root container for the Agent admin page.
- * Tabbed layout: Manage, Memory, System Tasks, Tools, and Configuration.
+ * Tabbed layout: Memory, Manage, System Tasks, Tools, and Configuration.
+ * Agent switcher at top left of tabs for quick agent selection.
  */
 
 /**
@@ -10,6 +11,7 @@
  */
 import { useState } from '@wordpress/element';
 import { TabPanel } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * External dependencies
@@ -23,18 +25,30 @@ import AgentFileEditor from './components/AgentFileEditor';
 import AgentEmptyState from './components/AgentEmptyState';
 import AgentSettings from './components/AgentSettings';
 import AgentToolsTab from './components/AgentToolsTab';
-import AgentListTab from './components/AgentListTab';
 import AgentEditView from './components/AgentEditView';
 import SystemTasksTab from './components/SystemTasksTab';
 import { useAgentFiles } from './queries/agentFiles';
+import { useAgentStore } from '@shared/stores/agentStore';
 
 const TABS = [
-	{ name: 'manage', title: 'Manage' },
 	{ name: 'memory', title: 'Memory' },
+	{ name: 'manage', title: 'Manage' },
 	{ name: 'system-tasks', title: 'System Tasks' },
 	{ name: 'tools', title: 'Tools' },
 	{ name: 'configuration', title: 'Configuration' },
 ];
+
+/**
+ * Empty state when no agent is selected.
+ *
+ * @param {string} message Message to display.
+ * @return {React.ReactElement}
+ */
+const NoAgentSelectedMessage = ( { message } ) => (
+	<div className="datamachine-agent-tab-empty">
+		<p>{ message }</p>
+	</div>
+);
 
 /**
  * Selection model:
@@ -44,47 +58,58 @@ const TABS = [
  */
 const AgentApp = () => {
 	const [ selectedFile, setSelectedFile ] = useState( null );
-	const [ editingAgentId, setEditingAgentId ] = useState( null );
 	const { data: files } = useAgentFiles();
 	const hasFiles = files && files.length > 0;
+
+	// Get selected agent from store
+	const { selectedAgentId } = useAgentStore();
 
 	return (
 		<div className="datamachine-agent-app">
 			<div className="datamachine-agent-header">
 				<h1 className="datamachine-agent-title">Agents</h1>
+			</div>
+			<div className="datamachine-agent-tabs-header">
 				<AgentSwitcher />
 			</div>
 			<TabPanel
 				className="datamachine-tabs"
 				tabs={ TABS }
 				onSelect={ () => {
-					// Reset edit view when switching tabs.
-					setEditingAgentId( null );
+					// No state to reset when switching tabs now.
 				} }
 			>
 				{ ( tab ) => {
 					if ( tab.name === 'manage' ) {
-						if ( editingAgentId ) {
+						// Manage tab: show selected agent's edit view,
+						// or prompt to select an agent if none selected.
+						if ( ! selectedAgentId ) {
 							return (
-								<AgentEditView
-									agentId={ editingAgentId }
-									onBack={ () =>
-										setEditingAgentId( null )
-									}
+								<NoAgentSelectedMessage
+									message={ __(
+										'Select an agent from the dropdown above to manage its settings.',
+										'data-machine'
+									) }
 								/>
 							);
 						}
 
-						return (
-							<AgentListTab
-								onSelectAgent={ ( agent ) =>
-									setEditingAgentId( agent.agent_id )
-								}
-							/>
-						);
+						return <AgentEditView agentId={ selectedAgentId } />;
 					}
 
 					if ( tab.name === 'memory' ) {
+						// Memory tab: require an agent to be selected
+						if ( ! selectedAgentId ) {
+							return (
+								<NoAgentSelectedMessage
+									message={ __(
+										'Select an agent from the dropdown above to view its memory files.',
+										'data-machine'
+									) }
+								/>
+							);
+						}
+
 						return (
 							<div className="datamachine-agent-layout">
 								<AgentFileList
@@ -107,13 +132,36 @@ const AgentApp = () => {
 					}
 
 					if ( tab.name === 'system-tasks' ) {
+						// System Tasks: require agent selection
+						if ( ! selectedAgentId ) {
+							return (
+								<NoAgentSelectedMessage
+									message={ __(
+										'Select an agent from the dropdown above to view its system tasks.',
+										'data-machine'
+									) }
+								/>
+							);
+						}
 						return <SystemTasksTab />;
 					}
 
 					if ( tab.name === 'tools' ) {
+						// Tools: require agent selection
+						if ( ! selectedAgentId ) {
+							return (
+								<NoAgentSelectedMessage
+									message={ __(
+										'Select an agent from the dropdown above to view its tools configuration.',
+										'data-machine'
+									) }
+								/>
+							);
+						}
 						return <AgentToolsTab />;
 					}
 
+					// Configuration tab works without agent selection (global config)
 					return <AgentSettings />;
 				} }
 			</TabPanel>


### PR DESCRIPTION
## Problem
1. Agent switcher was in the header - not prominent enough
2. Manage tab showed list of all agents - should manage selected agent

## Solution
1. Moved AgentSwitcher to top of tabs area
2. Manage tab now shows selected agent's edit view directly
3. Memory, System Tasks, Tools tabs require agent selection
4. Configuration remains available without agent selection

## Changes
- AgentApp.jsx: Restructured with tabs header containing switcher
- AgentApp.jsx: Manage tab renders AgentEditView for selectedAgentId
- agent-page.css: Added styles for tabs header and empty states

Ready to iterate if needed.