### PR TITLE
feat: CLI commands for system, handlers, taxonomy, step-types, and processed-items

### DIFF
--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -34,6 +34,11 @@ WP_CLI::add_command( 'datamachine batch', Commands\BatchCommand::class );
 WP_CLI::add_command( 'datamachine image', Commands\ImageCommand::class );
 WP_CLI::add_command( 'datamachine github', Commands\GitHubCommand::class );
 WP_CLI::add_command( 'datamachine auth', Commands\AuthCommand::class );
+WP_CLI::add_command( 'datamachine system', Commands\SystemCommand::class );
+WP_CLI::add_command( 'datamachine handlers', Commands\HandlersCommand::class );
+WP_CLI::add_command( 'datamachine taxonomy', Commands\TaxonomyCommand::class );
+WP_CLI::add_command( 'datamachine step-types', Commands\StepTypesCommand::class );
+WP_CLI::add_command( 'datamachine processed-items', Commands\ProcessedItemsCommand::class );
 
 // Aliases for AI agent compatibility (singular/plural variants).
 WP_CLI::add_command( 'datamachine setting', Commands\SettingsCommand::class );
@@ -50,3 +55,6 @@ WP_CLI::add_command( 'datamachine analytics', Commands\AnalyticsCommand::class )
 WP_CLI::add_command( 'datamachine meta-description', Commands\MetaDescriptionCommand::class );
 WP_CLI::add_command( 'datamachine indexnow', Commands\IndexNowCommand::class );
 WP_CLI::add_command( 'datamachine chat', Commands\ChatCommand::class );
+WP_CLI::add_command( 'datamachine handler', Commands\HandlersCommand::class );
+WP_CLI::add_command( 'datamachine step-type', Commands\StepTypesCommand::class );
+WP_CLI::add_command( 'datamachine processed-item', Commands\ProcessedItemsCommand::class );

--- a/inc/Cli/Commands/HandlersCommand.php
+++ b/inc/Cli/Commands/HandlersCommand.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * WP-CLI Handlers Command
+ *
+ * Wraps HandlerAbilities for handler discovery and configuration.
+ *
+ * @package DataMachine\Cli\Commands
+ * @since 0.41.0
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Abilities\HandlerAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handler discovery and configuration.
+ *
+ * @since 0.41.0
+ */
+class HandlersCommand extends BaseCommand {
+
+	/**
+	 * List registered handlers.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--step-type=<step_type>]
+	 * : Filter by step type (fetch, publish, update, etc.).
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine handlers list
+	 *     wp datamachine handlers list --step-type=fetch
+	 *     wp datamachine handlers list --format=json
+	 *
+	 * @subcommand list
+	 */
+	public function list_handlers( array $args, array $assoc_args ): void {
+		$step_type = $assoc_args['step-type'] ?? null;
+		$format    = $assoc_args['format'] ?? 'table';
+
+		$ability = new HandlerAbilities();
+		$result  = $ability->executeGetHandlers(
+			array(
+				'step_type' => $step_type,
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to get handlers.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( empty( $result['handlers'] ) ) {
+			$msg = $step_type
+				? sprintf( 'No handlers found for step type "%s".', $step_type )
+				: 'No handlers registered.';
+			WP_CLI::warning( $msg );
+			return;
+		}
+
+		$items = array();
+		foreach ( $result['handlers'] as $slug => $handler ) {
+			$items[] = array(
+				'slug'      => $slug,
+				'label'     => $handler['label'] ?? '',
+				'step_type' => $handler['step_type'] ?? '',
+			);
+		}
+
+		$fields = array( 'slug', 'label', 'step_type' );
+		$this->format_items( $items, $fields, $assoc_args, 'slug' );
+
+		WP_CLI::log( sprintf( 'Total: %d handler(s).', $result['count'] ) );
+	}
+
+	/**
+	 * Validate a handler slug.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Handler slug to validate.
+	 *
+	 * [--step-type=<step_type>]
+	 * : Optional step type constraint.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine handlers validate rss-feed
+	 *     wp datamachine handlers validate rss-feed --step-type=fetch
+	 *
+	 * @subcommand validate
+	 */
+	public function validate( array $args, array $assoc_args ): void {
+		$slug      = $args[0] ?? '';
+		$step_type = $assoc_args['step-type'] ?? null;
+
+		if ( empty( $slug ) ) {
+			WP_CLI::error( 'Handler slug is required.' );
+			return;
+		}
+
+		$ability = new HandlerAbilities();
+		$result  = $ability->executeValidateHandler(
+			array(
+				'handler_slug' => $slug,
+				'step_type'    => $step_type,
+			)
+		);
+
+		if ( $result['valid'] ) {
+			WP_CLI::success( sprintf( 'Handler "%s" is valid.', $slug ) );
+		} else {
+			WP_CLI::error( $result['error'] ?? sprintf( 'Handler "%s" is not valid.', $slug ) );
+		}
+	}
+
+	/**
+	 * Get configuration fields for a handler.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Handler slug.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine handlers fields rss-feed
+	 *     wp datamachine handlers fields rss-feed --format=json
+	 *
+	 * @subcommand fields
+	 */
+	public function fields( array $args, array $assoc_args ): void {
+		$slug   = $args[0] ?? '';
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $slug ) ) {
+			WP_CLI::error( 'Handler slug is required.' );
+			return;
+		}
+
+		$ability = new HandlerAbilities();
+		$result  = $ability->executeGetHandlerConfigFields(
+			array(
+				'handler_slug' => $slug,
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to get config fields.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( empty( $result['fields'] ) ) {
+			WP_CLI::warning( sprintf( 'No config fields defined for handler "%s".', $slug ) );
+			return;
+		}
+
+		$items = array();
+		foreach ( $result['fields'] as $key => $field ) {
+			$default_val = isset( $field['default'] ) ? wp_json_encode( $field['default'] ) : '';
+			$items[]     = array(
+				'key'      => $key,
+				'type'     => $field['type'] ?? 'text',
+				'label'    => $field['label'] ?? $key,
+				'required' => ! empty( $field['required'] ) ? 'yes' : 'no',
+				'default'  => $default_val,
+			);
+		}
+
+		$fields = array( 'key', 'type', 'label', 'required', 'default' );
+		$this->format_items( $items, $fields, $assoc_args, 'key' );
+	}
+
+	/**
+	 * Get site-wide handler defaults.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<slug>]
+	 * : Optional handler slug to filter defaults.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - json
+	 *   - table
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine handlers defaults
+	 *     wp datamachine handlers defaults rss-feed
+	 *
+	 * @subcommand defaults
+	 */
+	public function defaults( array $args, array $assoc_args ): void {
+		$slug   = $args[0] ?? null;
+		$format = $assoc_args['format'] ?? 'json';
+
+		$ability = new HandlerAbilities();
+		$result  = $ability->executeGetHandlerSiteDefaults(
+			array(
+				'handler_slug' => $slug,
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to get handler defaults.' );
+			return;
+		}
+
+		if ( empty( $result['defaults'] ) ) {
+			$msg = $slug
+				? sprintf( 'No defaults configured for handler "%s".', $slug )
+				: 'No handler defaults configured.';
+			WP_CLI::warning( $msg );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result['defaults'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		// Table format: flatten to key/value pairs.
+		$items = array();
+		foreach ( $result['defaults'] as $key => $value ) {
+			$items[] = array(
+				'key'   => $key,
+				'value' => is_array( $value ) ? wp_json_encode( $value ) : (string) $value,
+			);
+		}
+
+		$this->format_items( $items, array( 'key', 'value' ), $assoc_args, 'key' );
+	}
+}

--- a/inc/Cli/Commands/ProcessedItemsCommand.php
+++ b/inc/Cli/Commands/ProcessedItemsCommand.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * WP-CLI Processed Items Command
+ *
+ * Wraps ProcessedItemsAbilities for deduplication tracking management.
+ *
+ * @package DataMachine\Cli\Commands
+ * @since 0.41.0
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Abilities\ProcessedItemsAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Processed items (deduplication) management.
+ *
+ * @since 0.41.0
+ */
+class ProcessedItemsCommand extends BaseCommand {
+
+	/**
+	 * Clear processed items for a pipeline or flow.
+	 *
+	 * Resets deduplication tracking so items can be re-processed.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--pipeline=<pipeline_id>]
+	 * : Clear all processed items for this pipeline ID.
+	 *
+	 * [--flow=<flow_id>]
+	 * : Clear all processed items for this flow ID.
+	 *
+	 * [--yes]
+	 * : Skip confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine processed-items clear --pipeline=12
+	 *     wp datamachine processed-items clear --flow=42
+	 *     wp datamachine processed-items clear --pipeline=12 --yes
+	 *
+	 * @subcommand clear
+	 */
+	public function clear( array $args, array $assoc_args ): void {
+		$pipeline_id  = $assoc_args['pipeline'] ?? null;
+		$flow_id      = $assoc_args['flow'] ?? null;
+		$skip_confirm = isset( $assoc_args['yes'] );
+
+		if ( $pipeline_id && $flow_id ) {
+			WP_CLI::error( 'Specify either --pipeline or --flow, not both.' );
+			return;
+		}
+
+		if ( ! $pipeline_id && ! $flow_id ) {
+			WP_CLI::error( 'Either --pipeline=<id> or --flow=<id> is required.' );
+			return;
+		}
+
+		$clear_type = $pipeline_id ? 'pipeline' : 'flow';
+		$target_id  = (int) ( $pipeline_id ?? $flow_id );
+
+		if ( ! $skip_confirm ) {
+			WP_CLI::confirm(
+				sprintf( 'Clear all processed items for %s %d? This resets deduplication.', $clear_type, $target_id )
+			);
+		}
+
+		$ability = new ProcessedItemsAbilities();
+		$result  = $ability->executeClearProcessedItems(
+			array(
+				'clear_type' => $clear_type,
+				'target_id'  => $target_id,
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to clear processed items.' );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] );
+	}
+
+	/**
+	 * Check if a specific item has been processed.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --flow-step=<flow_step_id>
+	 * : Flow step ID in format "{pipeline_step_id}_{flow_id}".
+	 *
+	 * --source=<source_type>
+	 * : Source type (e.g., "rss", "reddit", "WordPress").
+	 *
+	 * --item=<item_identifier>
+	 * : Item identifier (GUID, URL, or post ID).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine processed-items check --flow-step=3_12 --source=rss --item="https://example.com/post-1"
+	 *
+	 * @subcommand check
+	 */
+	public function check( array $args, array $assoc_args ): void {
+		$flow_step_id    = $assoc_args['flow-step'] ?? '';
+		$source_type     = $assoc_args['source'] ?? '';
+		$item_identifier = $assoc_args['item'] ?? '';
+
+		if ( empty( $flow_step_id ) ) {
+			WP_CLI::error( 'Flow step ID is required (--flow-step=<id>).' );
+			return;
+		}
+
+		if ( empty( $source_type ) ) {
+			WP_CLI::error( 'Source type is required (--source=<type>).' );
+			return;
+		}
+
+		if ( empty( $item_identifier ) ) {
+			WP_CLI::error( 'Item identifier is required (--item=<identifier>).' );
+			return;
+		}
+
+		$ability = new ProcessedItemsAbilities();
+		$result  = $ability->executeCheckProcessedItem(
+			array(
+				'flow_step_id'    => $flow_step_id,
+				'source_type'     => $source_type,
+				'item_identifier' => $item_identifier,
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to check processed item.' );
+			return;
+		}
+
+		if ( $result['is_processed'] ) {
+			WP_CLI::log( 'Status: PROCESSED' );
+			WP_CLI::log( sprintf( 'Item "%s" has already been processed for flow step %s.', $item_identifier, $flow_step_id ) );
+		} else {
+			WP_CLI::log( 'Status: NOT PROCESSED' );
+			WP_CLI::log( sprintf( 'Item "%s" has not been processed for flow step %s.', $item_identifier, $flow_step_id ) );
+		}
+	}
+
+	/**
+	 * Check if a flow step has any processing history.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --flow-step=<flow_step_id>
+	 * : Flow step ID in format "{pipeline_step_id}_{flow_id}".
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine processed-items history --flow-step=3_12
+	 *
+	 * @subcommand history
+	 */
+	public function history( array $args, array $assoc_args ): void {
+		$flow_step_id = $assoc_args['flow-step'] ?? '';
+
+		if ( empty( $flow_step_id ) ) {
+			WP_CLI::error( 'Flow step ID is required (--flow-step=<id>).' );
+			return;
+		}
+
+		$ability = new ProcessedItemsAbilities();
+		$result  = $ability->executeHasProcessedHistory(
+			array(
+				'flow_step_id' => $flow_step_id,
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to check processing history.' );
+			return;
+		}
+
+		if ( $result['has_history'] ) {
+			WP_CLI::success( sprintf( 'Flow step %s has processing history.', $flow_step_id ) );
+		} else {
+			WP_CLI::log( sprintf( 'Flow step %s has no processing history (first run or cleared).', $flow_step_id ) );
+		}
+	}
+}

--- a/inc/Cli/Commands/StepTypesCommand.php
+++ b/inc/Cli/Commands/StepTypesCommand.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * WP-CLI Step Types Command
+ *
+ * Wraps StepTypeAbilities for step type discovery and validation.
+ *
+ * @package DataMachine\Cli\Commands
+ * @since 0.41.0
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Abilities\StepTypeAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Step type discovery and validation.
+ *
+ * @since 0.41.0
+ */
+class StepTypesCommand extends BaseCommand {
+
+	/**
+	 * List all registered step types.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine step-types list
+	 *     wp datamachine step-types list --format=json
+	 *
+	 * @subcommand list
+	 */
+	public function list_step_types( array $args, array $assoc_args ): void {
+		$format = $assoc_args['format'] ?? 'table';
+
+		$ability = new StepTypeAbilities();
+		$result  = $ability->executeGetStepTypes( array() );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to get step types.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( empty( $result['step_types'] ) ) {
+			WP_CLI::warning( 'No step types registered.' );
+			return;
+		}
+
+		$items = array();
+		foreach ( $result['step_types'] as $slug => $step_type ) {
+			$items[] = array(
+				'slug'         => $slug,
+				'label'        => $step_type['label'] ?? '',
+				'uses_handler' => ! empty( $step_type['uses_handler'] ) ? 'yes' : 'no',
+			);
+		}
+
+		$fields = array( 'slug', 'label', 'uses_handler' );
+		$this->format_items( $items, $fields, $assoc_args, 'slug' );
+
+		WP_CLI::log( sprintf( 'Total: %d step type(s).', $result['count'] ) );
+	}
+
+	/**
+	 * Get a specific step type by slug.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Step type slug.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - json
+	 *   - table
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine step-types get fetch
+	 *     wp datamachine step-types get publish --format=json
+	 *
+	 * @subcommand get
+	 */
+	public function get( array $args, array $assoc_args ): void {
+		$slug   = $args[0] ?? '';
+		$format = $assoc_args['format'] ?? 'json';
+
+		if ( empty( $slug ) ) {
+			WP_CLI::error( 'Step type slug is required.' );
+			return;
+		}
+
+		$ability = new StepTypeAbilities();
+		$result  = $ability->executeGetStepTypes(
+			array( 'step_type_slug' => $slug )
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to get step type.' );
+			return;
+		}
+
+		if ( empty( $result['step_types'] ) ) {
+			WP_CLI::error( sprintf( 'Step type "%s" not found.', $slug ) );
+			return;
+		}
+
+		$step_type = $result['step_types'][ $slug ] ?? reset( $result['step_types'] );
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $step_type, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::log( sprintf( 'Slug:         %s', $slug ) );
+		WP_CLI::log( sprintf( 'Label:        %s', $step_type['label'] ?? '' ) );
+		WP_CLI::log( sprintf( 'Uses handler: %s', ! empty( $step_type['uses_handler'] ) ? 'yes' : 'no' ) );
+
+		if ( ! empty( $step_type['description'] ) ) {
+			WP_CLI::log( sprintf( 'Description:  %s', $step_type['description'] ) );
+		}
+	}
+
+	/**
+	 * Validate a step type slug.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Step type slug to validate.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine step-types validate fetch
+	 *     wp datamachine step-types validate nonexistent
+	 *
+	 * @subcommand validate
+	 */
+	public function validate( array $args, array $assoc_args ): void {
+		$slug = $args[0] ?? '';
+
+		if ( empty( $slug ) ) {
+			WP_CLI::error( 'Step type slug is required.' );
+			return;
+		}
+
+		$ability = new StepTypeAbilities();
+		$result  = $ability->executeValidateStepType(
+			array( 'step_type' => $slug )
+		);
+
+		if ( $result['valid'] ) {
+			WP_CLI::success( sprintf( 'Step type "%s" is valid.', $slug ) );
+		} else {
+			WP_CLI::error( $result['error'] ?? sprintf( 'Step type "%s" is not valid.', $slug ) );
+		}
+	}
+}

--- a/inc/Cli/Commands/SystemCommand.php
+++ b/inc/Cli/Commands/SystemCommand.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * WP-CLI System Command
+ *
+ * Wraps SystemAbilities for health checks and session title generation.
+ *
+ * @package DataMachine\Cli\Commands
+ * @since 0.41.0
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Abilities\SystemAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * System health checks and diagnostics.
+ *
+ * @since 0.41.0
+ */
+class SystemCommand extends BaseCommand {
+
+	/**
+	 * Run system health checks.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--types=<types>]
+	 * : Comma-separated check types to run. Use "all" for all default checks.
+	 * ---
+	 * default: all
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine system health
+	 *     wp datamachine system health --types=system
+	 *     wp datamachine system health --format=json
+	 *
+	 * @subcommand health
+	 */
+	public function health( array $args, array $assoc_args ): void {
+		$types_raw = $assoc_args['types'] ?? 'all';
+		$format    = $assoc_args['format'] ?? 'table';
+		$types     = array_map( 'trim', explode( ',', $types_raw ) );
+
+		$ability = new SystemAbilities();
+		$result  = $ability->executeHealthCheck( array( 'types' => $types ) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Health check failed.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		// Table output.
+		WP_CLI::log( $result['summary'] );
+		WP_CLI::log( '' );
+
+		foreach ( $result['results'] as $type_id => $data ) {
+			WP_CLI::log( sprintf( '--- %s ---', $data['label'] ) );
+
+			$check_result = $data['result'] ?? array();
+
+			if ( isset( $check_result['version'] ) ) {
+				WP_CLI::log( sprintf( '  Plugin version: %s', $check_result['version'] ) );
+			}
+			if ( isset( $check_result['php_version'] ) ) {
+				WP_CLI::log( sprintf( '  PHP version:    %s', $check_result['php_version'] ) );
+			}
+			if ( isset( $check_result['wp_version'] ) ) {
+				WP_CLI::log( sprintf( '  WP version:     %s', $check_result['wp_version'] ) );
+			}
+			if ( isset( $check_result['abilities'] ) ) {
+				WP_CLI::log( sprintf( '  Abilities:      %d registered', count( $check_result['abilities'] ) ) );
+			}
+			if ( isset( $check_result['rest_status'] ) ) {
+				$rest_ok = $check_result['rest_status']['namespace_registered'] ?? false;
+				WP_CLI::log( sprintf( '  REST API:       %s', $rest_ok ? 'registered' : 'NOT registered' ) );
+			}
+
+			WP_CLI::log( '' );
+		}
+
+		WP_CLI::log( sprintf( 'Available check types: %s', implode( ', ', $result['available'] ) ) );
+	}
+
+	/**
+	 * Generate a title for a chat session.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <session_id>
+	 * : UUID of the chat session.
+	 *
+	 * [--force]
+	 * : Force regeneration even if title already exists.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine system title abc123-def456
+	 *     wp datamachine system title abc123-def456 --force
+	 *
+	 * @subcommand title
+	 */
+	public function title( array $args, array $assoc_args ): void {
+		$session_id = $args[0] ?? '';
+		$force      = isset( $assoc_args['force'] );
+		$format     = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $session_id ) ) {
+			WP_CLI::error( 'Session ID is required.' );
+			return;
+		}
+
+		$result = SystemAbilities::generateSessionTitle(
+			array(
+				'session_id' => $session_id,
+				'force'      => $force,
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? $result['message'] ?? 'Title generation failed.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] );
+		WP_CLI::log( sprintf( 'Title:  %s', $result['title'] ) );
+		WP_CLI::log( sprintf( 'Method: %s', $result['method'] ) );
+	}
+}

--- a/inc/Cli/Commands/TaxonomyCommand.php
+++ b/inc/Cli/Commands/TaxonomyCommand.php
@@ -1,0 +1,405 @@
+<?php
+/**
+ * WP-CLI Taxonomy Command
+ *
+ * Wraps TaxonomyAbilities for taxonomy term management.
+ *
+ * @package DataMachine\Cli\Commands
+ * @since 0.41.0
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Abilities\TaxonomyAbilities;
+use DataMachine\Abilities\Taxonomy\ResolveTermAbility;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Taxonomy term management.
+ *
+ * @since 0.41.0
+ */
+class TaxonomyCommand extends BaseCommand {
+
+	/**
+	 * List taxonomy terms.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --taxonomy=<taxonomy>
+	 * : Taxonomy slug (category, post_tag, etc.).
+	 *
+	 * [--search=<search>]
+	 * : Filter terms by name.
+	 *
+	 * [--parent=<parent>]
+	 * : Parent term ID.
+	 *
+	 * [--number=<number>]
+	 * : Maximum number of terms to return.
+	 * ---
+	 * default: 50
+	 * ---
+	 *
+	 * [--offset=<offset>]
+	 * : Number of terms to skip.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * [--orderby=<orderby>]
+	 * : Order by field.
+	 * ---
+	 * default: name
+	 * options:
+	 *   - name
+	 *   - slug
+	 *   - term_id
+	 *   - count
+	 * ---
+	 *
+	 * [--order=<order>]
+	 * : Sort order.
+	 * ---
+	 * default: ASC
+	 * options:
+	 *   - ASC
+	 *   - DESC
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine taxonomy list --taxonomy=category
+	 *     wp datamachine taxonomy list --taxonomy=post_tag --search=php
+	 *     wp datamachine taxonomy list --taxonomy=category --format=json
+	 *
+	 * @subcommand list
+	 */
+	public function list_terms( array $args, array $assoc_args ): void {
+		$taxonomy = $assoc_args['taxonomy'] ?? '';
+		$format   = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $taxonomy ) ) {
+			WP_CLI::error( 'Taxonomy is required (--taxonomy=<slug>).' );
+			return;
+		}
+
+		$ability = new TaxonomyAbilities();
+		$input   = array(
+			'taxonomy'   => $taxonomy,
+			'hide_empty' => false,
+			'number'     => (int) ( $assoc_args['number'] ?? 50 ),
+			'offset'     => (int) ( $assoc_args['offset'] ?? 0 ),
+			'orderby'    => $assoc_args['orderby'] ?? 'name',
+			'order'      => $assoc_args['order'] ?? 'ASC',
+		);
+
+		if ( ! empty( $assoc_args['search'] ) ) {
+			$input['search'] = $assoc_args['search'];
+		}
+		if ( isset( $assoc_args['parent'] ) ) {
+			$input['parent'] = (int) $assoc_args['parent'];
+		}
+
+		$result = $ability->executeGetTaxonomyTerms( $input );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to get taxonomy terms.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		$terms = $result['terms'] ?? array();
+
+		if ( empty( $terms ) ) {
+			WP_CLI::warning( sprintf( 'No terms found in taxonomy "%s".', $taxonomy ) );
+			return;
+		}
+
+		$items = array();
+		foreach ( $terms as $term ) {
+			$items[] = array(
+				'term_id' => $term['term_id'] ?? '',
+				'name'    => $term['name'] ?? '',
+				'slug'    => $term['slug'] ?? '',
+				'parent'  => $term['parent'] ?? 0,
+				'count'   => $term['count'] ?? 0,
+			);
+		}
+
+		$fields = array( 'term_id', 'name', 'slug', 'parent', 'count' );
+		$this->format_items( $items, $fields, $assoc_args, 'term_id' );
+
+		$total = $result['total'] ?? count( $items );
+		$this->output_pagination( $input['offset'], count( $items ), $total, $format, 'terms' );
+	}
+
+	/**
+	 * Create a taxonomy term.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --name=<name>
+	 * : Term name.
+	 *
+	 * --taxonomy=<taxonomy>
+	 * : Taxonomy slug.
+	 *
+	 * [--parent=<parent>]
+	 * : Parent term ID.
+	 *
+	 * [--slug=<slug>]
+	 * : Term slug.
+	 *
+	 * [--description=<description>]
+	 * : Term description.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine taxonomy create --name="New Category" --taxonomy=category
+	 *     wp datamachine taxonomy create --name="Sub Cat" --taxonomy=category --parent=5
+	 *
+	 * @subcommand create
+	 */
+	public function create( array $args, array $assoc_args ): void {
+		$name     = $assoc_args['name'] ?? '';
+		$taxonomy = $assoc_args['taxonomy'] ?? '';
+		$format   = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $name ) ) {
+			WP_CLI::error( 'Term name is required (--name=<name>).' );
+			return;
+		}
+
+		if ( empty( $taxonomy ) ) {
+			WP_CLI::error( 'Taxonomy is required (--taxonomy=<slug>).' );
+			return;
+		}
+
+		$input = array(
+			'name'     => $name,
+			'taxonomy' => $taxonomy,
+		);
+
+		if ( isset( $assoc_args['parent'] ) ) {
+			$input['parent'] = (int) $assoc_args['parent'];
+		}
+		if ( isset( $assoc_args['slug'] ) ) {
+			$input['slug'] = $assoc_args['slug'];
+		}
+		if ( isset( $assoc_args['description'] ) ) {
+			$input['description'] = $assoc_args['description'];
+		}
+
+		$ability = new TaxonomyAbilities();
+		$result  = $ability->executeCreateTaxonomyTerm( $input );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to create term.' );
+			return;
+		}
+
+		WP_CLI::success( sprintf( 'Created term "%s" (ID: %d).', $result['name'] ?? $name, $result['term_id'] ?? 0 ) );
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		}
+	}
+
+	/**
+	 * Update a taxonomy term.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <term_id>
+	 * : Term ID to update.
+	 *
+	 * [--name=<name>]
+	 * : New term name.
+	 *
+	 * [--slug=<slug>]
+	 * : New term slug.
+	 *
+	 * [--description=<description>]
+	 * : New term description.
+	 *
+	 * [--parent=<parent>]
+	 * : New parent term ID.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine taxonomy update 5 --name="Renamed Category"
+	 *     wp datamachine taxonomy update 5 --slug=renamed-cat
+	 *
+	 * @subcommand update
+	 */
+	public function update( array $args, array $assoc_args ): void {
+		$term_id = (int) ( $args[0] ?? 0 );
+
+		if ( $term_id <= 0 ) {
+			WP_CLI::error( 'Valid term ID is required.' );
+			return;
+		}
+
+		$input = array( 'term_id' => $term_id );
+
+		if ( isset( $assoc_args['name'] ) ) {
+			$input['name'] = $assoc_args['name'];
+		}
+		if ( isset( $assoc_args['slug'] ) ) {
+			$input['slug'] = $assoc_args['slug'];
+		}
+		if ( isset( $assoc_args['description'] ) ) {
+			$input['description'] = $assoc_args['description'];
+		}
+		if ( isset( $assoc_args['parent'] ) ) {
+			$input['parent'] = (int) $assoc_args['parent'];
+		}
+
+		$ability = new TaxonomyAbilities();
+		$result  = $ability->executeUpdateTaxonomyTerm( $input );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to update term.' );
+			return;
+		}
+
+		WP_CLI::success( sprintf( 'Updated term %d.', $term_id ) );
+	}
+
+	/**
+	 * Delete a taxonomy term.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <term_id>
+	 * : Term ID to delete.
+	 *
+	 * [--yes]
+	 * : Skip confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine taxonomy delete 5
+	 *     wp datamachine taxonomy delete 5 --yes
+	 *
+	 * @subcommand delete
+	 */
+	public function delete( array $args, array $assoc_args ): void {
+		$term_id      = (int) ( $args[0] ?? 0 );
+		$skip_confirm = isset( $assoc_args['yes'] );
+
+		if ( $term_id <= 0 ) {
+			WP_CLI::error( 'Valid term ID is required.' );
+			return;
+		}
+
+		if ( ! $skip_confirm ) {
+			WP_CLI::confirm( sprintf( 'Delete term %d?', $term_id ) );
+		}
+
+		$ability = new TaxonomyAbilities();
+		$result  = $ability->executeDeleteTaxonomyTerm( array( 'term_id' => $term_id ) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to delete term.' );
+			return;
+		}
+
+		WP_CLI::success( sprintf( 'Deleted term %d.', $term_id ) );
+	}
+
+	/**
+	 * Resolve a term by name, slug, or ID.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <identifier>
+	 * : Term name, slug, or numeric ID.
+	 *
+	 * --taxonomy=<taxonomy>
+	 * : Taxonomy slug.
+	 *
+	 * [--create]
+	 * : Create the term if not found.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine taxonomy resolve "Uncategorized" --taxonomy=category
+	 *     wp datamachine taxonomy resolve "New Tag" --taxonomy=post_tag --create
+	 *     wp datamachine taxonomy resolve 42 --taxonomy=category
+	 *
+	 * @subcommand resolve
+	 */
+	public function resolve( array $args, array $assoc_args ): void {
+		$identifier = $args[0] ?? '';
+		$taxonomy   = $assoc_args['taxonomy'] ?? '';
+		$create     = isset( $assoc_args['create'] );
+		$format     = $assoc_args['format'] ?? 'table';
+
+		if ( empty( $identifier ) ) {
+			WP_CLI::error( 'Term identifier is required.' );
+			return;
+		}
+
+		if ( empty( $taxonomy ) ) {
+			WP_CLI::error( 'Taxonomy is required (--taxonomy=<slug>).' );
+			return;
+		}
+
+		$result = ResolveTermAbility::resolve( $identifier, $taxonomy, $create );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Term not found.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		$action = ! empty( $result['created'] ) ? 'Created' : 'Resolved';
+		WP_CLI::success( sprintf( '%s term "%s".', $action, $result['name'] ) );
+		WP_CLI::log( sprintf( 'Term ID:  %d', $result['term_id'] ) );
+		WP_CLI::log( sprintf( 'Name:     %s', $result['name'] ) );
+		WP_CLI::log( sprintf( 'Slug:     %s', $result['slug'] ) );
+		WP_CLI::log( sprintf( 'Taxonomy: %s', $result['taxonomy'] ) );
+	}
+}


### PR DESCRIPTION
## Summary

Adds 5 new WP-CLI command classes wrapping existing Abilities that previously had no CLI access.

## New Commands

### `wp datamachine system`
- `health` — run system health checks (version, PHP, WP, abilities count, REST status)
- `title <session_id>` — generate/regenerate chat session title

### `wp datamachine handlers`
- `list` — list registered handlers, filterable by `--step-type`
- `validate <slug>` — check if a handler slug exists
- `fields <slug>` — show config field definitions for a handler
- `defaults [slug]` — show site-wide handler defaults

### `wp datamachine taxonomy`
- `list --taxonomy=<slug>` — list terms with pagination
- `create --name=<name> --taxonomy=<slug>` — create a term
- `update <term_id>` — update a term's name/slug/description
- `delete <term_id>` — delete a term (with confirmation)
- `resolve <identifier> --taxonomy=<slug>` — resolve by name/slug/ID, optionally `--create`

### `wp datamachine step-types`
- `list` — list all registered step types
- `get <slug>` — show detail for a step type
- `validate <slug>` — check if a step type slug exists

### `wp datamachine processed-items`
- `clear --pipeline=<id>|--flow=<id>` — reset dedup tracking (with confirmation)
- `check --flow-step=<id> --source=<type> --item=<id>` — check if an item was processed
- `history --flow-step=<id>` — check if a flow step has any history

## Pattern

All commands follow the established codebase pattern:
- Extend `BaseCommand` for `format_items()` / `output_pagination()`
- Delegate to Abilities classes (no business logic in CLI layer)
- Support `--format=table|json|csv|yaml` where appropriate
- Singular/plural aliases registered for AI agent compatibility

## Testing

All commands tested on live site (chubes.net). No lint issues in new files.

Closes #766, #767, #768, #769, #770