### PR TITLE
fix: enqueue shared tab styles on Logs admin page

### DIFF
--- a/inc/Core/Admin/Pages/Logs/LogsFilters.php
+++ b/inc/Core/Admin/Pages/Logs/LogsFilters.php
@@ -46,6 +46,11 @@ function datamachine_register_logs_admin_page_filters() {
 						'deps'  => array(),
 						'media' => 'all',
 					),
+					'datamachine-tabs'      => array(
+						'file'  => 'inc/Core/Admin/shared/styles/tabs.css',
+						'deps'  => array(),
+						'media' => 'all',
+					),
 					'datamachine-logs-page' => array(
 						'file'  => 'inc/Core/Admin/Pages/Logs/assets/css/logs-page.css',
 						'deps'  => array(),


### PR DESCRIPTION
## Summary

- The Logs page's `LogsAgentTabs` component uses `className="datamachine-tabs"` but `LogsFilters.php` never enqueued the shared `tabs.css` stylesheet
- Adds the `datamachine-tabs` CSS asset to match the Agent page's tab styling pattern

One-line fix in `LogsFilters.php`.