### PR TITLE
fix: remove AI model config from Manage tab, clarify Configuration labels

### DIFF
--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentEditView.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentEditView.jsx
@@ -31,8 +31,6 @@ import {
 	useGrantAccess,
 	useRevokeAccess,
 } from '../queries/agents';
-import { useProviders } from '@shared/queries/providers';
-import ProviderModelSelector from '@shared/components/ai/ProviderModelSelector';
 
 /**
  * Status options for the dropdown.
@@ -245,24 +243,16 @@ const AccessPanel = ( { agentId, ownerId } ) => {
 const AgentEditView = ( { agentId, onBack } ) => {
 	const { data: agent, isLoading, error } = useAgent( agentId );
 	const updateMutation = useUpdateAgent();
-	const { data: providersData } = useProviders();
 
 	const [ name, setName ] = useState( '' );
 	const [ status, setStatus ] = useState( 'active' );
-	const [ defaultProvider, setDefaultProvider ] = useState( '' );
-	const [ defaultModel, setDefaultModel ] = useState( '' );
-	const [ contextModels, setContextModels ] = useState( {} );
 	const [ saveMessage, setSaveMessage ] = useState( null );
 
 	// Sync form state when agent data loads.
 	useEffect( () => {
 		if ( agent ) {
-			const config = agent.agent_config || {};
 			setName( agent.agent_name || '' );
 			setStatus( agent.status || 'active' );
-			setDefaultProvider( config.default_provider || '' );
-			setDefaultModel( config.default_model || '' );
-			setContextModels( config.context_models || config.agent_models || {} );
 		}
 	}, [ agent ] );
 
@@ -273,12 +263,6 @@ const AgentEditView = ( { agentId, onBack } ) => {
 			agentId,
 			agent_name: name,
 			status,
-			agent_config: {
-				...( agent.agent_config || {} ),
-				default_provider: defaultProvider,
-				default_model: defaultModel,
-				context_models: contextModels,
-			},
 		} );
 
 		if ( result.success ) {
@@ -320,11 +304,7 @@ const AgentEditView = ( { agentId, onBack } ) => {
 
 	const isDirty =
 		name !== ( agent.agent_name || '' ) ||
-		status !== ( agent.status || 'active' ) ||
-		defaultProvider !== ( agent.agent_config?.default_provider || '' ) ||
-		defaultModel !== ( agent.agent_config?.default_model || '' ) ||
-		JSON.stringify( contextModels ) !==
-			JSON.stringify( agent.agent_config?.context_models || {} );
+		status !== ( agent.status || 'active' );
 
 	return (
 		<div className="datamachine-agent-edit-view">
@@ -414,84 +394,6 @@ const AgentEditView = ( { agentId, onBack } ) => {
 					>
 						{ __( 'Save Changes', 'data-machine' ) }
 					</Button>
-				</CardBody>
-			</Card>
-
-			<Card className="datamachine-agent-models-card">
-				<CardHeader>
-					<h3>{ __( 'AI Model Policy', 'data-machine' ) }</h3>
-				</CardHeader>
-				<CardBody>
-					<p className="description">
-						{ __(
-							'Agent defaults override global settings. Context-specific overrides override the agent default for that context.',
-							'data-machine'
-						) }
-					</p>
-
-					<div className="datamachine-ai-provider-model-settings">
-						<ProviderModelSelector
-							provider={ defaultProvider }
-							model={ defaultModel }
-							onProviderChange={ ( provider ) => {
-								setDefaultProvider( provider );
-								setDefaultModel( '' );
-							} }
-							onModelChange={ setDefaultModel }
-							applyDefaults={ false }
-							providerLabel={ __( 'Agent Default Provider', 'data-machine' ) }
-							modelLabel={ __( 'Agent Default Model', 'data-machine' ) }
-						/>
-					</div>
-
-					{ ( providersData?.contexts || [] ).map( ( contextItem ) => {
-						const value = contextModels?.[ contextItem.id ] || {};
-
-						return (
-							<div
-								key={ contextItem.id }
-								className="datamachine-agent-model-override"
-								style={ {
-									marginTop: '20px',
-									paddingTop: '16px',
-									borderTop: '1px solid #e0e0e0',
-								} }
-							>
-								<h4 style={ { margin: '0 0 4px' } }>
-									{ contextItem.label }
-								</h4>
-								<p className="description" style={ { marginTop: 0 } }>
-									{ contextItem.description }
-								</p>
-								<ProviderModelSelector
-									provider={ value.provider || '' }
-									model={ value.model || '' }
-									onProviderChange={ ( provider ) => {
-										setContextModels( {
-											...contextModels,
-											[ contextItem.id ]: {
-												...value,
-												provider,
-												model: '',
-											},
-										} );
-									} }
-									onModelChange={ ( modelValue ) => {
-										setContextModels( {
-											...contextModels,
-											[ contextItem.id ]: {
-												...value,
-												model: modelValue,
-											},
-										} );
-									} }
-									applyDefaults={ false }
-									providerLabel={ __( 'Provider', 'data-machine' ) }
-									modelLabel={ __( 'Model', 'data-machine' ) }
-								/>
-							</div>
-						);
-					} ) }
 				</CardBody>
 			</Card>
 

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentSettings.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentSettings.jsx
@@ -147,13 +147,13 @@ const AgentSettings = () => {
 										updateField( 'default_model', model )
 									}
 									applyDefaults={ false }
-									providerLabel="Global Default Provider"
-									modelLabel="Global Default Model"
+									providerLabel="Default Provider"
+									modelLabel="Default Model"
 								/>
 							</div>
 							<p className="description">
-								Fallback provider and model used when no
-								agent-specific override is set below.
+								The default provider and model used for all
+								contexts unless overridden below.
 							</p>
 						</td>
 					</tr>
@@ -171,9 +171,10 @@ const AgentSettings = () => {
 										marginBottom: '16px',
 									} }
 								>
-									Assign different providers and models to
-									each execution context. Leave empty to use the
-									global default above.
+									The same agent runs in different contexts
+									with different toolkits. Override the default
+									model for specific contexts — leave empty to
+									use the default above.
 								</p>
 								{ ( providersData?.contexts || [] ).map(
 									( contextItem ) => {


### PR DESCRIPTION
## Summary

- **Removes the AI Model Policy card from the Manage tab** — it was duplicating the Configuration tab's model selection. Manage tab now only handles identity (slug, name, status) and access management, which is what it should do
- **Updates Configuration tab labels** — drops "Global" prefix from provider/model labels, rewords the per-context override description to reflect reality: same agent, different execution contexts with different toolkits

## Before → After

**Manage tab** (before): Identity + AI Model Policy + Access Management
**Manage tab** (after): Identity + Access Management

**Configuration tab**: Unchanged structurally, just clearer labels

The backend model resolution cascade is untouched — per-agent overrides still work via REST API and CLI for multi-agent installs.