### PR TITLE
feat: image optimization system task — diagnose + fix oversized images

### DIFF
--- a/inc/Abilities/Media/ImageOptimizationAbilities.php
+++ b/inc/Abilities/Media/ImageOptimizationAbilities.php
@@ -1,0 +1,382 @@
+<?php
+/**
+ * Image Optimization Abilities
+ *
+ * Diagnose and fix oversized/unoptimized images in the WordPress media library.
+ * Uses WordPress's native image editor (Imagick or GD) for compression and
+ * WebP conversion — no external API or plugin dependencies.
+ *
+ * @package DataMachine\Abilities\Media
+ * @since 0.42.0
+ */
+
+namespace DataMachine\Abilities\Media;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Engine\Tasks\TaskScheduler;
+
+defined( 'ABSPATH' ) || exit;
+
+class ImageOptimizationAbilities {
+
+	/**
+	 * Default file size threshold in bytes (200KB).
+	 */
+	const DEFAULT_SIZE_THRESHOLD = 204800;
+
+	/**
+	 * Default JPEG/WebP quality for compression.
+	 */
+	const DEFAULT_QUALITY = 82;
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/diagnose-images',
+				array(
+					'label'               => 'Diagnose Images',
+					'description'         => 'Scan the media library for oversized images, missing WebP variants, and missing thumbnail sizes.',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'size_threshold' => array(
+								'type'        => 'integer',
+								'description' => 'File size threshold in bytes. Images larger than this are flagged. Default: 204800 (200KB).',
+								'default'     => self::DEFAULT_SIZE_THRESHOLD,
+							),
+							'limit'          => array(
+								'type'        => 'integer',
+								'description' => 'Maximum images to scan. Default: 500.',
+								'default'     => 500,
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'            => array( 'type' => 'boolean' ),
+							'total_images'       => array( 'type' => 'integer' ),
+							'total_size'         => array( 'type' => 'integer' ),
+							'oversized_count'    => array( 'type' => 'integer' ),
+							'missing_webp_count' => array( 'type' => 'integer' ),
+							'potential_savings'   => array( 'type' => 'integer' ),
+							'oversized_images'   => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'object' ),
+							),
+						),
+					),
+					'execute_callback'    => array( self::class, 'diagnoseImages' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/optimize-images',
+				array(
+					'label'               => 'Optimize Images',
+					'description'         => 'Compress oversized images and generate WebP variants. Uses WordPress image editor (Imagick/GD). Batch-aware.',
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'attachment_id'  => array(
+								'type'        => 'integer',
+								'description' => 'Specific attachment ID to optimize.',
+							),
+							'size_threshold' => array(
+								'type'        => 'integer',
+								'description' => 'Only optimize images larger than this (bytes). Default: 204800 (200KB).',
+								'default'     => self::DEFAULT_SIZE_THRESHOLD,
+							),
+							'quality'        => array(
+								'type'        => 'integer',
+								'description' => 'JPEG/WebP compression quality (1-100). Default: 82.',
+								'default'     => self::DEFAULT_QUALITY,
+							),
+							'webp'           => array(
+								'type'        => 'boolean',
+								'description' => 'Generate WebP variant. Default: true.',
+								'default'     => true,
+							),
+							'limit'          => array(
+								'type'        => 'integer',
+								'description' => 'Maximum images to optimize in one batch. Default: 50.',
+								'default'     => 50,
+							),
+							'dry_run'        => array(
+								'type'        => 'boolean',
+								'description' => 'Preview changes without applying them. Default: false.',
+								'default'     => false,
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'      => array( 'type' => 'boolean' ),
+							'queued_count' => array( 'type' => 'integer' ),
+							'batch_id'     => array( 'type' => array( 'integer', 'null' ) ),
+							'message'      => array( 'type' => 'string' ),
+							'error'        => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'optimizeImages' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Diagnose image optimization issues across the media library.
+	 *
+	 * Scans for oversized images, missing WebP variants, and reports
+	 * potential savings from compression.
+	 *
+	 * @param array $input Ability input.
+	 * @return array Diagnostic results.
+	 */
+	public static function diagnoseImages( array $input = array() ): array {
+		$size_threshold = absint( $input['size_threshold'] ?? self::DEFAULT_SIZE_THRESHOLD );
+		$limit          = absint( $input['limit'] ?? 500 );
+
+		$attachments = get_posts(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image',
+				'post_status'    => 'inherit',
+				'posts_per_page' => $limit,
+				'fields'         => 'ids',
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			)
+		);
+
+		$total_size         = 0;
+		$oversized_count    = 0;
+		$missing_webp_count = 0;
+		$potential_savings   = 0;
+		$oversized_images   = array();
+
+		foreach ( $attachments as $attachment_id ) {
+			$file_path = get_attached_file( $attachment_id );
+			if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+				continue;
+			}
+
+			$file_size = filesize( $file_path );
+			$total_size += $file_size;
+			$metadata   = wp_get_attachment_metadata( $attachment_id );
+			$mime_type  = get_post_mime_type( $attachment_id );
+
+			// Check for WebP variant.
+			$has_webp    = false;
+			$webp_path   = preg_replace( '/\.(jpe?g|png|gif)$/i', '.webp', $file_path );
+			if ( file_exists( $webp_path ) ) {
+				$has_webp = true;
+			}
+
+			// Also check WP's sources array (WP 6.1+ generates WebP subsizes).
+			if ( ! $has_webp && ! empty( $metadata['sources'] ) ) {
+				foreach ( $metadata['sources'] as $source ) {
+					if ( 'image/webp' === ( $source['mime'] ?? '' ) ) {
+						$has_webp = true;
+						break;
+					}
+				}
+			}
+
+			if ( ! $has_webp && in_array( $mime_type, array( 'image/jpeg', 'image/png' ), true ) ) {
+				++$missing_webp_count;
+			}
+
+			// Check oversized.
+			if ( $file_size > $size_threshold ) {
+				++$oversized_count;
+
+				// Estimate savings (target ~60% reduction for heavily oversized).
+				$estimated_savings = (int) ( $file_size * 0.4 );
+				$potential_savings += $estimated_savings;
+
+				$width  = $metadata['width'] ?? 0;
+				$height = $metadata['height'] ?? 0;
+
+				$oversized_images[] = array(
+					'attachment_id' => $attachment_id,
+					'title'         => get_the_title( $attachment_id ),
+					'file_size'     => $file_size,
+					'file_size_hr'  => size_format( $file_size ),
+					'dimensions'    => $width . 'x' . $height,
+					'mime_type'     => $mime_type,
+					'has_webp'      => $has_webp,
+				);
+			}
+		}
+
+		// Sort oversized by file size descending.
+		usort( $oversized_images, fn( $a, $b ) => $b['file_size'] - $a['file_size'] );
+
+		return array(
+			'success'            => true,
+			'total_images'       => count( $attachments ),
+			'total_size'         => $total_size,
+			'total_size_hr'      => size_format( $total_size ),
+			'oversized_count'    => $oversized_count,
+			'missing_webp_count' => $missing_webp_count,
+			'potential_savings'   => $potential_savings,
+			'potential_savings_hr' => size_format( $potential_savings ),
+			'size_threshold'     => $size_threshold,
+			'size_threshold_hr'  => size_format( $size_threshold ),
+			'oversized_images'   => $oversized_images,
+		);
+	}
+
+	/**
+	 * Queue image optimization for oversized images.
+	 *
+	 * Finds eligible images and schedules them for batch optimization
+	 * via the TaskScheduler. Each image is optimized individually as
+	 * a system task (compression + optional WebP generation).
+	 *
+	 * @param array $input Ability input.
+	 * @return array Scheduling result.
+	 */
+	public static function optimizeImages( array $input = array() ): array {
+		$attachment_id  = absint( $input['attachment_id'] ?? 0 );
+		$size_threshold = absint( $input['size_threshold'] ?? self::DEFAULT_SIZE_THRESHOLD );
+		$quality        = absint( $input['quality'] ?? self::DEFAULT_QUALITY );
+		$webp           = $input['webp'] ?? true;
+		$limit          = absint( $input['limit'] ?? 50 );
+		$dry_run        = ! empty( $input['dry_run'] );
+
+		$quality = max( 1, min( 100, $quality ) );
+
+		// Resolve eligible attachment IDs.
+		$attachment_ids = array();
+
+		if ( $attachment_id > 0 ) {
+			$attachment_ids[] = $attachment_id;
+		} else {
+			$all = get_posts(
+				array(
+					'post_type'      => 'attachment',
+					'post_mime_type' => 'image',
+					'post_status'    => 'inherit',
+					'posts_per_page' => $limit,
+					'fields'         => 'ids',
+					'orderby'        => 'date',
+					'order'          => 'DESC',
+				)
+			);
+
+			foreach ( $all as $id ) {
+				$file_path = get_attached_file( $id );
+				if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+					continue;
+				}
+
+				$file_size = filesize( $file_path );
+				if ( $file_size > $size_threshold ) {
+					$attachment_ids[] = $id;
+				}
+			}
+		}
+
+		if ( empty( $attachment_ids ) ) {
+			return array(
+				'success'      => true,
+				'queued_count' => 0,
+				'message'      => 'No oversized images found to optimize.',
+			);
+		}
+
+		if ( $dry_run ) {
+			$preview = array();
+			foreach ( $attachment_ids as $id ) {
+				$file_path = get_attached_file( $id );
+				$file_size = $file_path ? filesize( $file_path ) : 0;
+				$preview[] = array(
+					'attachment_id' => $id,
+					'title'         => get_the_title( $id ),
+					'file_size'     => size_format( $file_size ),
+					'mime_type'     => get_post_mime_type( $id ),
+				);
+			}
+
+			return array(
+				'success'      => true,
+				'queued_count' => 0,
+				'dry_run'      => true,
+				'would_optimize' => $preview,
+				'message'      => sprintf( '%d image(s) would be optimized (dry run).', count( $preview ) ),
+			);
+		}
+
+		// Build per-item params for batch scheduling.
+		$item_params = array();
+		foreach ( $attachment_ids as $id ) {
+			$item_params[] = array(
+				'attachment_id' => $id,
+				'quality'       => $quality,
+				'webp'          => $webp,
+				'source'        => 'ability',
+			);
+		}
+
+		$user_id  = get_current_user_id();
+		$agent_id = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
+
+		$batch = TaskScheduler::scheduleBatch(
+			'image_optimization',
+			$item_params,
+			array(
+				'user_id'  => $user_id,
+				'agent_id' => $agent_id,
+			)
+		);
+
+		if ( false === $batch ) {
+			return array(
+				'success'      => false,
+				'queued_count' => 0,
+				'message'      => 'Failed to schedule optimization batch.',
+				'error'        => 'Task batch scheduling failed.',
+			);
+		}
+
+		return array(
+			'success'      => true,
+			'queued_count' => count( $attachment_ids ),
+			'batch_id'     => $batch['batch_id'] ?? null,
+			'message'      => sprintf(
+				'Image optimization scheduled for %d image(s).',
+				count( $attachment_ids )
+			),
+		);
+	}
+}

--- a/inc/Cli/Commands/ImageCommand.php
+++ b/inc/Cli/Commands/ImageCommand.php
@@ -15,6 +15,7 @@ namespace DataMachine\Cli\Commands;
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\Media\ImageGenerationAbilities;
+use DataMachine\Abilities\Media\ImageOptimizationAbilities;
 use DataMachine\Abilities\Media\ImageTemplateAbilities;
 
 defined( 'ABSPATH' ) || exit;
@@ -371,5 +372,227 @@ class ImageCommand extends BaseCommand {
 		);
 
 		$this->format_items( $items, array( 'setting', 'value' ), $assoc_args );
+	}
+
+	/**
+	 * Diagnose image optimization issues in the media library.
+	 *
+	 * Scans for oversized images, missing WebP variants, and reports
+	 * potential savings from compression.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--size_threshold=<bytes>]
+	 * : File size threshold in bytes. Images larger are flagged.
+	 * ---
+	 * default: 204800
+	 * ---
+	 *
+	 * [--limit=<number>]
+	 * : Maximum images to scan.
+	 * ---
+	 * default: 500
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * [--fields=<fields>]
+	 * : Limit output to specific fields (comma-separated).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Diagnose with default 200KB threshold
+	 *     wp datamachine image diagnose
+	 *
+	 *     # Flag images over 100KB
+	 *     wp datamachine image diagnose --size_threshold=102400
+	 *
+	 *     # JSON output
+	 *     wp datamachine image diagnose --format=json
+	 *
+	 * @subcommand diagnose
+	 */
+	public function diagnose( array $args, array $assoc_args ): void {
+		$format         = $assoc_args['format'] ?? 'table';
+		$size_threshold = absint( $assoc_args['size_threshold'] ?? ImageOptimizationAbilities::DEFAULT_SIZE_THRESHOLD );
+		$limit          = absint( $assoc_args['limit'] ?? 500 );
+
+		WP_CLI::log( sprintf( 'Scanning up to %d images (threshold: %s)...', $limit, size_format( $size_threshold ) ) );
+
+		$result = ImageOptimizationAbilities::diagnoseImages(
+			array(
+				'size_threshold' => $size_threshold,
+				'limit'          => $limit,
+			)
+		);
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( \wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$total   = $result['total_images'] ?? 0;
+		$over    = $result['oversized_count'] ?? 0;
+		$webp    = $result['missing_webp_count'] ?? 0;
+		$savings = $result['potential_savings_hr'] ?? '0 B';
+
+		WP_CLI::log( '' );
+		WP_CLI::log( sprintf( 'Total images scanned:  %d', $total ) );
+		WP_CLI::log( sprintf( 'Total size:            %s', $result['total_size_hr'] ?? '0 B' ) );
+		WP_CLI::log( sprintf( 'Oversized (>%s):  %d', $result['size_threshold_hr'] ?? '200 KB', $over ) );
+		WP_CLI::log( sprintf( 'Missing WebP:          %d', $webp ) );
+		WP_CLI::log( sprintf( 'Potential savings:     ~%s', $savings ) );
+		WP_CLI::log( '' );
+
+		$oversized = $result['oversized_images'] ?? array();
+		if ( empty( $oversized ) ) {
+			WP_CLI::success( 'No oversized images found.' );
+			return;
+		}
+
+		$this->format_items(
+			$oversized,
+			array( 'attachment_id', 'title', 'file_size_hr', 'dimensions', 'mime_type', 'has_webp' ),
+			$assoc_args
+		);
+
+		WP_CLI::warning( sprintf(
+			'%d oversized image(s) found. Run "wp datamachine image optimize" to compress them.',
+			$over
+		) );
+	}
+
+	/**
+	 * Optimize oversized images in the media library.
+	 *
+	 * Compresses images and generates WebP variants using WordPress image
+	 * editor (Imagick or GD). No external API dependencies.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--attachment_id=<id>]
+	 * : Specific attachment ID to optimize.
+	 *
+	 * [--size_threshold=<bytes>]
+	 * : Only optimize images larger than this (bytes).
+	 * ---
+	 * default: 204800
+	 * ---
+	 *
+	 * [--quality=<number>]
+	 * : JPEG/WebP compression quality (1-100).
+	 * ---
+	 * default: 82
+	 * ---
+	 *
+	 * [--no-webp]
+	 * : Skip WebP generation.
+	 *
+	 * [--limit=<number>]
+	 * : Maximum images to optimize.
+	 * ---
+	 * default: 50
+	 * ---
+	 *
+	 * [--dry-run]
+	 * : Preview what would be optimized without making changes.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Optimize all oversized images
+	 *     wp datamachine image optimize
+	 *
+	 *     # Dry run to preview
+	 *     wp datamachine image optimize --dry-run
+	 *
+	 *     # Optimize a specific image at quality 75
+	 *     wp datamachine image optimize --attachment_id=1527 --quality=75
+	 *
+	 *     # Skip WebP generation
+	 *     wp datamachine image optimize --no-webp
+	 *
+	 * @subcommand optimize
+	 */
+	public function optimize( array $args, array $assoc_args ): void {
+		$format         = $assoc_args['format'] ?? 'table';
+		$attachment_id  = absint( $assoc_args['attachment_id'] ?? 0 );
+		$size_threshold = absint( $assoc_args['size_threshold'] ?? ImageOptimizationAbilities::DEFAULT_SIZE_THRESHOLD );
+		$quality        = absint( $assoc_args['quality'] ?? ImageOptimizationAbilities::DEFAULT_QUALITY );
+		$webp           = ! isset( $assoc_args['no-webp'] );
+		$limit          = absint( $assoc_args['limit'] ?? 50 );
+		$dry_run        = isset( $assoc_args['dry-run'] );
+
+		if ( $dry_run ) {
+			WP_CLI::log( 'Dry run — previewing what would be optimized...' );
+		} else {
+			WP_CLI::log( sprintf( 'Optimizing images (quality: %d, WebP: %s)...', $quality, $webp ? 'yes' : 'no' ) );
+		}
+
+		$result = ImageOptimizationAbilities::optimizeImages(
+			array(
+				'attachment_id'  => $attachment_id,
+				'size_threshold' => $size_threshold,
+				'quality'        => $quality,
+				'webp'           => $webp,
+				'limit'          => $limit,
+				'dry_run'        => $dry_run,
+			)
+		);
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( \wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Optimization failed.' );
+			return;
+		}
+
+		if ( $dry_run ) {
+			$preview = $result['would_optimize'] ?? array();
+			if ( empty( $preview ) ) {
+				WP_CLI::success( 'No images need optimization.' );
+				return;
+			}
+
+			$this->format_items(
+				$preview,
+				array( 'attachment_id', 'title', 'file_size', 'mime_type' ),
+				$assoc_args
+			);
+
+			WP_CLI::log( $result['message'] ?? '' );
+			return;
+		}
+
+		$queued = $result['queued_count'] ?? 0;
+		if ( 0 === $queued ) {
+			WP_CLI::success( 'No oversized images found to optimize.' );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] ?? sprintf( '%d image(s) queued for optimization.', $queued ) );
+
+		if ( ! empty( $result['batch_id'] ) ) {
+			WP_CLI::log( sprintf( 'Batch ID: %d — track progress with: wp datamachine jobs list --parent_id=%d', $result['batch_id'], $result['batch_id'] ) );
+		}
 	}
 }

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -17,6 +17,7 @@ use DataMachine\Engine\AI\System\Tasks\AltTextTask;
 use DataMachine\Engine\AI\System\Tasks\DailyMemoryTask;
 use DataMachine\Engine\AI\System\Tasks\GitHubIssueTask;
 use DataMachine\Engine\AI\System\Tasks\ImageGenerationTask;
+use DataMachine\Engine\AI\System\Tasks\ImageOptimizationTask;
 use DataMachine\Engine\AI\System\Tasks\InternalLinkingTask;
 use DataMachine\Engine\AI\System\Tasks\MetaDescriptionTask;
 use DataMachine\Engine\Tasks\TaskRegistry;
@@ -60,6 +61,7 @@ class SystemAgentServiceProvider {
 	 */
 	public function getBuiltInTasks( array $tasks ): array {
 		$tasks['image_generation']            = ImageGenerationTask::class;
+		$tasks['image_optimization']          = ImageOptimizationTask::class;
 		$tasks['alt_text_generation']         = AltTextTask::class;
 		$tasks['github_create_issue']         = GitHubIssueTask::class;
 		$tasks['internal_linking']            = InternalLinkingTask::class;

--- a/inc/Engine/AI/System/Tasks/ImageOptimizationTask.php
+++ b/inc/Engine/AI/System/Tasks/ImageOptimizationTask.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Image Optimization System Task
+ *
+ * Compresses oversized images and generates WebP variants using WordPress's
+ * native image editor (Imagick or GD). No external API dependencies.
+ *
+ * Follows the diagnose → fix pattern: ImageOptimizationAbilities::diagnoseImages()
+ * identifies issues, this task fixes individual images scheduled via batch.
+ *
+ * @package DataMachine\Engine\AI\System\Tasks
+ * @since 0.42.0
+ */
+
+namespace DataMachine\Engine\AI\System\Tasks;
+
+defined( 'ABSPATH' ) || exit;
+
+class ImageOptimizationTask extends SystemTask {
+
+	/**
+	 * Get the task type identifier.
+	 *
+	 * @return string
+	 */
+	public function getTaskType(): string {
+		return 'image_optimization';
+	}
+
+	/**
+	 * Get task metadata for admin UI and TaskRegistry.
+	 *
+	 * @return array
+	 */
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Image Optimization',
+			'description'     => 'Compress oversized images and generate WebP variants using WordPress image editor (Imagick/GD). No external API needed.',
+			'setting_key'     => '',
+			'default_enabled' => false,
+			'trigger'         => 'On-demand via CLI or ability',
+			'trigger_type'    => 'manual',
+			'supports_run'    => false,
+		);
+	}
+
+	/**
+	 * Whether this task supports undo.
+	 *
+	 * @return bool
+	 */
+	public function supportsUndo(): bool {
+		return true;
+	}
+
+	/**
+	 * Execute image optimization for a single attachment.
+	 *
+	 * @param int   $jobId  DM Job ID.
+	 * @param array $params Engine data with attachment_id, quality, webp.
+	 */
+	public function execute( int $jobId, array $params ): void {
+		$attachment_id = absint( $params['attachment_id'] ?? 0 );
+		$quality       = absint( $params['quality'] ?? 82 );
+		$webp          = $params['webp'] ?? true;
+
+		if ( $attachment_id <= 0 ) {
+			$this->failJob( $jobId, 'Missing attachment_id.' );
+			return;
+		}
+
+		$file_path = get_attached_file( $attachment_id );
+		if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+			$this->failJob( $jobId, 'Attachment file not found: ' . ( $file_path ?: 'empty path' ) );
+			return;
+		}
+
+		$mime_type     = get_post_mime_type( $attachment_id );
+		$original_size = filesize( $file_path );
+		$effects       = array();
+		$results       = array(
+			'attachment_id' => $attachment_id,
+			'original_size' => $original_size,
+			'compressed'    => false,
+			'webp_created'  => false,
+		);
+
+		// ── Compress the original file ────────────────────────────────
+		if ( in_array( $mime_type, array( 'image/jpeg', 'image/png', 'image/webp' ), true ) ) {
+			$compress_result = $this->compressImage( $file_path, $mime_type, $quality, $attachment_id );
+
+			if ( $compress_result['success'] ) {
+				$results['compressed']    = true;
+				$results['new_size']      = $compress_result['new_size'];
+				$results['savings']       = $original_size - $compress_result['new_size'];
+				$results['savings_pct']   = $original_size > 0 ? round( ( $results['savings'] / $original_size ) * 100, 1 ) : 0;
+
+				$effects[] = array(
+					'type'           => 'attachment_file_modified',
+					'target'         => array(
+						'attachment_id' => $attachment_id,
+						'file_path'     => $file_path,
+					),
+					'previous_size'  => $original_size,
+					'new_size'       => $compress_result['new_size'],
+				);
+
+				// Update attachment metadata with new file size.
+				$metadata = wp_get_attachment_metadata( $attachment_id );
+				if ( is_array( $metadata ) ) {
+					$metadata['filesize'] = $compress_result['new_size'];
+					wp_update_attachment_metadata( $attachment_id, $metadata );
+				}
+			}
+		}
+
+		// ── Generate WebP variant ─────────────────────────────────────
+		if ( $webp && in_array( $mime_type, array( 'image/jpeg', 'image/png' ), true ) ) {
+			$webp_result = $this->generateWebP( $file_path, $quality, $attachment_id );
+
+			if ( $webp_result['success'] ) {
+				$results['webp_created'] = true;
+				$results['webp_path']    = $webp_result['webp_path'];
+				$results['webp_size']    = $webp_result['webp_size'];
+
+				$effects[] = array(
+					'type'   => 'file_created',
+					'target' => array(
+						'file_path' => $webp_result['webp_path'],
+					),
+				);
+			}
+		}
+
+		$results['effects']      = $effects;
+		$results['completed_at'] = current_time( 'mysql' );
+
+		$this->completeJob( $jobId, $results );
+	}
+
+	/**
+	 * Compress an image file in place using WordPress image editor.
+	 *
+	 * @param string $file_path     Absolute path to image.
+	 * @param string $mime_type     MIME type of the image.
+	 * @param int    $quality       Compression quality (1-100).
+	 * @param int    $attachment_id Attachment ID for logging.
+	 * @return array{success: bool, new_size: int, error: string}
+	 */
+	private function compressImage( string $file_path, string $mime_type, int $quality, int $attachment_id ): array {
+		$editor = wp_get_image_editor( $file_path );
+
+		if ( is_wp_error( $editor ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Image editor not available: ' . $editor->get_error_message(),
+			);
+		}
+
+		$editor->set_quality( $quality );
+
+		// Save back to same path and format.
+		$saved = $editor->save( $file_path, $mime_type );
+
+		if ( is_wp_error( $saved ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Compression failed: ' . $saved->get_error_message(),
+			);
+		}
+
+		clearstatcache( true, $file_path );
+		$new_size = filesize( $file_path );
+
+		return array(
+			'success'  => true,
+			'new_size' => $new_size,
+		);
+	}
+
+	/**
+	 * Generate a WebP variant of an image.
+	 *
+	 * @param string $file_path     Source image path.
+	 * @param int    $quality       WebP compression quality.
+	 * @param int    $attachment_id Attachment ID for logging.
+	 * @return array{success: bool, webp_path: string, webp_size: int, error: string}
+	 */
+	private function generateWebP( string $file_path, int $quality, int $attachment_id ): array {
+		$webp_path = preg_replace( '/\.(jpe?g|png)$/i', '.webp', $file_path );
+
+		// Skip if WebP already exists.
+		if ( file_exists( $webp_path ) ) {
+			return array(
+				'success'   => true,
+				'webp_path' => $webp_path,
+				'webp_size' => filesize( $webp_path ),
+			);
+		}
+
+		$editor = wp_get_image_editor( $file_path );
+
+		if ( is_wp_error( $editor ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Image editor not available: ' . $editor->get_error_message(),
+			);
+		}
+
+		$editor->set_quality( $quality );
+
+		$saved = $editor->save( $webp_path, 'image/webp' );
+
+		if ( is_wp_error( $saved ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'WebP generation failed: ' . $saved->get_error_message(),
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'webp_path' => $saved['path'],
+			'webp_size' => filesize( $saved['path'] ),
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Closes #495

Adds image optimization to Data Machine following the proven **diagnose → fix** pattern from alt-text and internal links. Uses WordPress's native image editor (Imagick/GD) — no external API, no subscription, no plugin dependency.

## Usage

```bash
# Diagnose — find oversized images
wp datamachine image diagnose
wp datamachine image diagnose --size_threshold=102400  # 100KB threshold

# Preview — see what would be optimized
wp datamachine image optimize --dry-run

# Optimize — compress + generate WebP
wp datamachine image optimize
wp datamachine image optimize --attachment_id=1527 --quality=75
wp datamachine image optimize --no-webp --limit=20
```

## Diagnose Output

```
Total images scanned:  39
Total size:            12.4 MB
Oversized (>200 KB):   8
Missing WebP:          39
Potential savings:     ~3.2 MB

+---------------+--------------------+----------+----------+----------+--------+
| attachment_id | title              | file_size| dimensions| mime_type| has_webp|
+---------------+--------------------+----------+----------+----------+--------+
| 1527          | sunset-header      | 1.9 MB   | 2400x1600| image/jpeg| no    |
| 1562          | profile-photo      | 410 KB   | 1024x1024| image/jpeg| no    |
+---------------+--------------------+----------+----------+----------+--------+
```

## What It Does

### ImageOptimizationAbilities
- `datamachine/diagnose-images` — scans media library for oversized images, missing WebP variants, reports potential savings
- `datamachine/optimize-images` — queues batch optimization via TaskScheduler

### ImageOptimizationTask (SystemTask)
- Compresses originals via `wp_get_image_editor()` at configurable quality (default: 82)
- Generates WebP variants for JPEG/PNG images
- Records effects for undo (`attachment_file_modified`, `file_created`)
- Batch-aware via TaskScheduler (chunks of 10, 30s delay)

### CLI Subcommands (added to existing `wp datamachine image`)
- `diagnose` — table/json/csv output with oversized images ranked by file size
- `optimize` — `--dry-run`, `--attachment_id`, `--quality`, `--no-webp`, `--limit`, `--size_threshold`

## Architecture

```
wp datamachine image diagnose
  → ImageOptimizationAbilities::diagnoseImages()
    → get_posts(attachment, image) → filesize() → wp_get_attachment_metadata()
    → returns oversized list + savings estimate

wp datamachine image optimize
  → ImageOptimizationAbilities::optimizeImages()
    → finds oversized attachments
    → TaskScheduler::scheduleBatch('image_optimization', items)
      → Action Scheduler → ImageOptimizationTask::execute()
        → wp_get_image_editor() → set_quality() → save()
        → WebP generation via save(path, 'image/webp')
        → records effects for undo
```

## Why Not Imagify?

WordPress ships Imagick which handles lossy/lossless compression, resizing, and WebP conversion natively. This is zero-dependency, zero-cost, works offline. For sites that want Imagify's cloud compression, DM could detect it and delegate — but the default path is self-contained.