### PR TITLE
refactor: remove standalone tool context — redundant with default model

### DIFF
--- a/inc/Abilities/Chat/CreateChatSessionAbility.php
+++ b/inc/Abilities/Chat/CreateChatSessionAbility.php
@@ -52,7 +52,7 @@ class CreateChatSessionAbility {
 							'context'    => array(
 								'type'        => 'string',
 								'default'     => 'chat',
-								'description' => __( 'Execution context (chat, pipeline, system, standalone).', 'data-machine' ),
+								'description' => __( 'Execution context (chat, pipeline, system).', 'data-machine' ),
 							),
 							'source'     => array(
 								'type'        => 'string',

--- a/inc/Abilities/Chat/ListChatSessionsAbility.php
+++ b/inc/Abilities/Chat/ListChatSessionsAbility.php
@@ -60,7 +60,7 @@ class ListChatSessionsAbility {
 							),
 							'context'    => array(
 								'type'        => 'string',
-								'description' => __( 'Context filter (chat, pipeline, system, standalone).', 'data-machine' ),
+								'description' => __( 'Context filter (chat, pipeline, system).', 'data-machine' ),
 							),
 						),
 						'required'   => array( 'user_id' ),

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -267,7 +267,7 @@ class PipelineBatchScheduler {
 		$flow_name   = $engine_snapshot['flow']['name'] ?? '';
 		$item_title  = $single_packet['data']['title'] ?? 'Untitled';
 
-		// Normalize: 0 → null for standalone compatibility.
+		// Normalize: 0 → null when no pipeline/flow context.
 		$pipeline_id = ( empty( $pipeline_id ) && ! is_string( $pipeline_id ) ) ? null : $pipeline_id;
 		$flow_id     = ( empty( $flow_id ) && ! is_string( $flow_id ) ) ? null : $flow_id;
 
@@ -275,7 +275,7 @@ class PipelineBatchScheduler {
 		$child_job_id = $this->db_jobs->create_job( array(
 			'pipeline_id'   => $pipeline_id,
 			'flow_id'       => $flow_id,
-			'source'        => $pipeline_id ? 'pipeline' : 'standalone',
+			'source'        => $pipeline_id ? 'pipeline' : 'direct',
 			'label'         => $item_title,
 			'parent_job_id' => $parent_job_id,
 		) );

--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -98,7 +98,7 @@ class ImageGenerationAbilities {
 							),
 							'post_id'         => array(
 								'type'        => 'integer',
-								'description' => 'Post ID to set the generated image as featured image (for standalone/direct calls).',
+								'description' => 'Post ID to set the generated image as featured image (for direct calls).',
 							),
 
 							'mode'            => array(

--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -205,10 +205,10 @@ class Chat {
 					'context'    => array(
 						'type'              => 'string',
 						'required'          => false,
-						'description'       => __( 'Context filter (chat, pipeline, system, standalone)', 'data-machine' ),
+						'description'       => __( 'Context filter (chat, pipeline, system)', 'data-machine' ),
 						'sanitize_callback' => 'sanitize_text_field',
 						'validate_callback' => function ( $param ) {
-							return in_array( $param, array( 'chat', 'pipeline', 'system', 'standalone' ), true );
+							return in_array( $param, array( 'chat', 'pipeline', 'system' ), true );
 						},
 					),
 					'agent_id'   => array(

--- a/inc/Api/FlowFiles.php
+++ b/inc/Api/FlowFiles.php
@@ -221,9 +221,9 @@ class FlowFiles {
 	 * Get file context array from flow ID.
 	 *
 	 * Supports database flows (numeric ID), direct execution ('direct'),
-	 * and standalone jobs (null flow_id).
+	 * and jobs without flow context (null flow_id).
 	 *
-	 * @param int|string|null $flow_id Flow ID, 'direct', or null for standalone.
+	 * @param int|string|null $flow_id Flow ID, 'direct', or null.
 	 * @return array Context array with pipeline_id and flow_id.
 	 */
 	public static function get_file_context( int|string|null $flow_id ): array {

--- a/inc/Api/Tools.php
+++ b/inc/Api/Tools.php
@@ -47,7 +47,7 @@ class Tools {
 				'args'                => array(
 					'context' => array(
 						'type'        => 'string',
-						'enum'        => array( 'pipeline', 'chat', 'standalone', 'system' ),
+						'enum'        => array( 'pipeline', 'chat', 'system' ),
 						'required'    => false,
 						'description' => 'Filter tools by execution context. Returns only tools available in the specified context.',
 					),

--- a/inc/Cli/Commands/ChatCommand.php
+++ b/inc/Cli/Commands/ChatCommand.php
@@ -27,7 +27,7 @@ class ChatCommand extends BaseCommand {
 	 * : User ID to list sessions for. Defaults to current user.
 	 *
 	 * [--context=<type>]
-	 * : Filter by execution context (chat, pipeline, system, standalone).
+	 * : Filter by execution context (chat, pipeline, system).
 	 *
 	 * [--limit=<n>]
 	 * : Maximum number of sessions to return.
@@ -210,7 +210,7 @@ class ChatCommand extends BaseCommand {
 	 * : First-class agent ID for this session.
 	 *
 	 * [--context=<type>]
-	 * : Execution context (chat, pipeline, system, standalone).
+	 * : Execution context (chat, pipeline, system).
 	 * ---
 	 * default: chat
 	 * ---

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -533,7 +533,7 @@ export const getProviders = async () => {
 /**
  * Get available tools
  *
- * @param {string|null} context - Optional context filter ('pipeline', 'chat', 'standalone', 'system')
+ * @param {string|null} context - Optional context filter ('pipeline', 'chat', 'system')
  * @return {Promise<Object>} Tools configuration
  */
 export const getTools = async ( context = null ) => {

--- a/inc/Core/Admin/Settings/assets/react/components/tabs/HandlerDefaultsTab.jsx
+++ b/inc/Core/Admin/Settings/assets/react/components/tabs/HandlerDefaultsTab.jsx
@@ -66,20 +66,22 @@ const HandlerDefaultsTab = () => {
 				Existing flows are not affected.
 			</p>
 
-			<div className="datamachine-step-types-list">
-				{ Object.entries( data ).map(
-					( [ stepTypeSlug, stepTypeData ] ) => (
-						<StepTypeAccordion
-							key={ stepTypeSlug }
-							stepTypeSlug={ stepTypeSlug }
-							stepTypeData={ stepTypeData }
-							expandedHandler={ expandedHandler }
-							setExpandedHandler={ setExpandedHandler }
-							onSave={ handleSave }
-							savingHandler={ savingHandler }
-						/>
-					)
-				) }
+		<div className="datamachine-step-types-list">
+			{ Object.entries( data )
+				.filter(
+					( [ , stepTypeData ] ) => stepTypeData.uses_handler
+				)
+				.map( ( [ stepTypeSlug, stepTypeData ] ) => (
+					<StepTypeAccordion
+						key={ stepTypeSlug }
+						stepTypeSlug={ stepTypeSlug }
+						stepTypeData={ stepTypeData }
+						expandedHandler={ expandedHandler }
+						setExpandedHandler={ setExpandedHandler }
+						onSave={ handleSave }
+						savingHandler={ savingHandler }
+					/>
+				) ) }
 			</div>
 		</div>
 	);

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -50,7 +50,7 @@ class Chat extends BaseRepository {
             metadata LONGTEXT NULL COMMENT 'JSON object for session metadata',
             provider VARCHAR(50) NULL COMMENT 'AI provider (anthropic, openai, etc)',
             model VARCHAR(100) NULL COMMENT 'AI model identifier',
-	            context VARCHAR(20) NOT NULL DEFAULT 'chat' COMMENT 'Execution context: chat, pipeline, system, standalone',
+	            context VARCHAR(20) NOT NULL DEFAULT 'chat' COMMENT 'Execution context: chat, pipeline, system',
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
             updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             expires_at DATETIME NULL COMMENT 'Auto-cleanup timestamp',
@@ -190,7 +190,7 @@ class Chat extends BaseRepository {
 	 *
 	 * @param int    $user_id  WordPress user ID
 	 * @param array  $metadata Optional session metadata
-	 * @param string $context  Execution context (chat, pipeline, system, standalone)
+	 * @param string $context  Execution context (chat, pipeline, system)
 	 * @return string Session ID (UUID)
 	 */
 	public function create_session(

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -125,7 +125,7 @@ class Jobs {
 		// pipeline_id and flow_id are VARCHAR to support multiple execution modes:
 		// - Numeric string: database flow execution (e.g. '123')
 		// - 'direct': ephemeral workflow execution
-		// - NULL: standalone job execution (no pipeline/flow)
+		// - NULL: job execution without pipeline/flow context
 		// status is VARCHAR(255) to support compound statuses with reasons
 		$sql = "CREATE TABLE $table_name (
             job_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -211,7 +211,7 @@ class Jobs {
 			);
 		}
 
-		// Migrate pipeline_id column: bigint -> varchar(20) NULL for standalone job support
+		// Migrate pipeline_id column: bigint -> varchar(20) NULL for contextless job support
 		if ( isset( $columns['pipeline_id'] ) && 'bigint' === $columns['pipeline_id']->DATA_TYPE ) {
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
 			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
@@ -227,7 +227,7 @@ class Jobs {
 			);
 		}
 
-		// Migrate flow_id column: bigint -> varchar(20) NULL for standalone job support
+		// Migrate flow_id column: bigint -> varchar(20) NULL for contextless job support
 		if ( isset( $columns['flow_id'] ) && 'bigint' === $columns['flow_id']->DATA_TYPE ) {
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
 			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
@@ -243,7 +243,7 @@ class Jobs {
 			);
 		}
 
-		// Migrate pipeline_id/flow_id from NOT NULL to NULL for standalone job support.
+		// Migrate pipeline_id/flow_id from NOT NULL to NULL for contextless job support.
 		// Runs on existing varchar(20) installs that haven't been updated yet.
 		if ( isset( $columns['pipeline_id'] ) && 'varchar' === $columns['pipeline_id']->DATA_TYPE && 'NO' === $columns['pipeline_id']->IS_NULLABLE ) {
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange

--- a/inc/Core/Database/Jobs/JobsOperations.php
+++ b/inc/Core/Database/Jobs/JobsOperations.php
@@ -37,10 +37,10 @@ class JobsOperations extends BaseRepository {
 		// Database flow: both must be valid numeric IDs > 0
 		$is_database_flow = ( is_numeric( $pipeline_id ) && (int) $pipeline_id > 0 && is_numeric( $flow_id ) && (int) $flow_id > 0 );
 
-		// Standalone: both are null (no pipeline/flow context)
-		$is_standalone = ( null === $pipeline_id && null === $flow_id );
+		// No pipeline/flow context: both are null.
+		$is_contextless = ( null === $pipeline_id && null === $flow_id );
 
-		if ( ! $is_direct_execution && ! $is_database_flow && ! $is_standalone ) {
+		if ( ! $is_direct_execution && ! $is_database_flow && ! $is_contextless ) {
 			do_action(
 				'datamachine_log',
 				'error',
@@ -53,15 +53,15 @@ class JobsOperations extends BaseRepository {
 			return false;
 		}
 
-		// Normalize to string for database storage (null stays null for standalone)
+		// Normalize to string for database storage (null stays null when no context).
 		if ( $is_database_flow ) {
 			$pipeline_id = (string) absint( $pipeline_id );
 			$flow_id     = (string) absint( $flow_id );
 		}
-		// Direct and standalone keep their values ('direct' or null)
+		// Direct and contextless keep their values ('direct' or null).
 
 		// Sanitize source — accept any string, don't gatekeep values.
-		$default_source = $is_standalone ? 'standalone' : ( $is_direct_execution ? 'direct' : 'pipeline' );
+		$default_source = $is_contextless ? 'direct' : ( $is_direct_execution ? 'direct' : 'pipeline' );
 		$source         = sanitize_key( $job_data['source'] ?? $default_source );
 
 		$label = isset( $job_data['label'] ) ? sanitize_text_field( $job_data['label'] ) : null;
@@ -85,7 +85,7 @@ class JobsOperations extends BaseRepository {
 		}
 
 		// Only include pipeline_id/flow_id when they have values (NULL omission lets DB default apply).
-		if ( ! $is_standalone ) {
+		if ( ! $is_contextless ) {
 			$data['pipeline_id'] = $pipeline_id;
 			$data['flow_id']     = $flow_id;
 			$format[]            = '%s';

--- a/inc/Core/ExecutionContext.php
+++ b/inc/Core/ExecutionContext.php
@@ -8,7 +8,8 @@
  * Supports three execution modes:
  * - 'direct': Direct execution without database persistence (CLI tools, ephemeral workflows)
  * - 'flow': Standard flow-based execution with full pipeline/flow context
- * - 'standalone': Job execution without pipeline/flow context (system tasks, ad-hoc jobs)
+ * - 'standalone': Job execution without pipeline/flow context (system tasks, ad-hoc jobs).
+ *   Uses the default model — no separate model override needed.
  *
  * In direct mode, pipeline_id and flow_id are set to the string 'direct' for consistent
  * end-to-end traceability throughout the system.

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -120,7 +120,7 @@ class PluginSettings {
 	 * 4. Network global default_provider / default_model
 	 * 5. Empty strings
 	 *
-	 * @param string $context Execution context: 'chat', 'pipeline', 'system', 'standalone'.
+	 * @param string $context Execution context: 'chat', 'pipeline', 'system'.
 	 * @return array{ provider: string, model: string }
 	 */
 	public static function getContextModel( string $context ): array {
@@ -236,11 +236,6 @@ class PluginSettings {
 				'id'          => 'system',
 				'label'       => __( 'System Agent', 'data-machine' ),
 				'description' => __( 'Background tasks like alt text generation and issue creation.', 'data-machine' ),
-			),
-			array(
-				'id'          => 'standalone',
-				'label'       => __( 'Standalone Context', 'data-machine' ),
-				'description' => __( 'Direct or ad-hoc execution outside pipeline and chat flows.', 'data-machine' ),
 			),
 		);
 	}

--- a/inc/Core/Steps/Update/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Update/Handlers/WordPress/WordPress.php
@@ -11,6 +11,7 @@ namespace DataMachine\Core\Steps\Update\Handlers\WordPress;
 
 use DataMachine\Core\Steps\Update\Handlers\UpdateHandler;
 use DataMachine\Core\Steps\HandlerRegistrationTrait;
+use DataMachine\Core\Steps\Update\Handlers\WordPress\WordPressSettings;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -28,7 +29,7 @@ class WordPress extends UpdateHandler {
 			'Update existing WordPress posts and pages',
 			false,
 			null,
-			null,
+			WordPressSettings::class,
 			array( self::class, 'registerTools' )
 		);
 	}

--- a/inc/Engine/AI/System/Tasks/ImageGenerationTask.php
+++ b/inc/Engine/AI/System/Tasks/ImageGenerationTask.php
@@ -250,7 +250,7 @@ class ImageGenerationTask extends SystemTask {
 		$pipeline_job_id = $context['pipeline_job_id'] ?? 0;
 		$direct_post_id  = $context['post_id'] ?? 0;
 
-		// Direct post_id takes priority (standalone/direct ability calls)
+		// Direct post_id takes priority (direct ability calls)
 		if ( ! empty( $direct_post_id ) ) {
 			$post_id = (int) $direct_post_id;
 		} elseif ( ! empty( $pipeline_job_id ) ) {

--- a/inc/Engine/AI/Tools/BaseTool.php
+++ b/inc/Engine/AI/Tools/BaseTool.php
@@ -27,7 +27,7 @@ abstract class BaseTool {
 	 *
 	 * All tools register via the single `datamachine_tools` filter. Each tool
 	 * must declare its contexts — the surfaces where it's available (e.g.
-	 * 'chat', 'pipeline', 'standalone').
+	 * 'chat', 'pipeline').
 	 *
 	 * When the definition is a callable (for lazy evaluation), the contexts
 	 * are stored alongside so they're available before the callable is resolved.

--- a/inc/Engine/AI/Tools/GitHubIssueTool.php
+++ b/inc/Engine/AI/Tools/GitHubIssueTool.php
@@ -26,7 +26,7 @@ class GitHubIssueTool extends BaseTool {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->registerTool( 'create_github_issue', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'create_github_issue', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
@@ -21,7 +21,7 @@ use DataMachine\Core\FilesRepository\DirectoryManager;
 class AgentDailyMemory extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/AgentMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentMemory.php
@@ -20,7 +20,7 @@ use DataMachine\Core\FilesRepository\DirectoryManager;
 class AgentMemory extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'agent_memory', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'agent_memory', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/AmazonAffiliateLink.php
+++ b/inc/Engine/AI/Tools/Global/AmazonAffiliateLink.php
@@ -84,7 +84,7 @@ class AmazonAffiliateLink extends BaseTool {
 	 */
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'amazon_affiliate_link' );
-		$this->registerTool( 'amazon_affiliate_link', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'amazon_affiliate_link', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/BingWebmaster.php
+++ b/inc/Engine/AI/Tools/Global/BingWebmaster.php
@@ -19,7 +19,7 @@ class BingWebmaster extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'bing_webmaster' );
-		$this->registerTool( 'bing_webmaster', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'bing_webmaster', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/GitHubTools.php
+++ b/inc/Engine/AI/Tools/Global/GitHubTools.php
@@ -23,7 +23,7 @@ class GitHubTools extends BaseTool {
 	 * Constructor — register all GitHub tools as global tools.
 	 */
 	public function __construct() {
-		$contexts = array( 'chat', 'pipeline', 'standalone' );
+		$contexts = array( 'chat', 'pipeline' );
 		$this->registerTool( 'list_github_issues', array( $this, 'getListIssuesDefinition' ), $contexts );
 		$this->registerTool( 'get_github_issue', array( $this, 'getGetIssueDefinition' ), $contexts );
 		$this->registerTool( 'manage_github_issue', array( $this, 'getManageIssueDefinition' ), $contexts );

--- a/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
+++ b/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
@@ -20,7 +20,7 @@ class GoogleAnalytics extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'google_analytics' );
-		$this->registerTool( 'google_analytics', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'google_analytics', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/GoogleSearch.php
+++ b/inc/Engine/AI/Tools/Global/GoogleSearch.php
@@ -16,7 +16,7 @@ class GoogleSearch extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'google_search' );
-		$this->registerTool( 'google_search', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'google_search', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/GoogleSearchConsole.php
+++ b/inc/Engine/AI/Tools/Global/GoogleSearchConsole.php
@@ -19,7 +19,7 @@ class GoogleSearchConsole extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'google_search_console' );
-		$this->registerTool( 'google_search_console', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'google_search_console', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/ImageGeneration.php
+++ b/inc/Engine/AI/Tools/Global/ImageGeneration.php
@@ -26,7 +26,7 @@ class ImageGeneration extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'image_generation' );
-		$this->registerTool( 'image_generation', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'image_generation', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/InternalLinkAudit.php
+++ b/inc/Engine/AI/Tools/Global/InternalLinkAudit.php
@@ -23,7 +23,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class InternalLinkAudit extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'internal_link_audit', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'internal_link_audit', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {

--- a/inc/Engine/AI/Tools/Global/LocalSearch.php
+++ b/inc/Engine/AI/Tools/Global/LocalSearch.php
@@ -17,7 +17,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class LocalSearch extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'local_search', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'local_search', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {

--- a/inc/Engine/AI/Tools/Global/PageSpeed.php
+++ b/inc/Engine/AI/Tools/Global/PageSpeed.php
@@ -20,7 +20,7 @@ class PageSpeed extends BaseTool {
 
 	public function __construct() {
 		$this->registerConfigurationHandlers( 'pagespeed' );
-		$this->registerTool( 'pagespeed', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'pagespeed', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/QueueValidator.php
+++ b/inc/Engine/AI/Tools/Global/QueueValidator.php
@@ -23,7 +23,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class QueueValidator extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'queue_validator', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'queue_validator', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/WebFetch.php
+++ b/inc/Engine/AI/Tools/Global/WebFetch.php
@@ -14,7 +14,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class WebFetch extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'web_fetch', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'web_fetch', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {

--- a/inc/Engine/AI/Tools/Global/WordPressPostReader.php
+++ b/inc/Engine/AI/Tools/Global/WordPressPostReader.php
@@ -17,7 +17,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class WordPressPostReader extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'wordpress_post_reader', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline', 'standalone' ) );
+		$this->registerTool( 'wordpress_post_reader', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ) );
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {

--- a/inc/Engine/AI/Tools/Global/WorkspaceTools.php
+++ b/inc/Engine/AI/Tools/Global/WorkspaceTools.php
@@ -53,7 +53,7 @@ class WorkspaceTools extends BaseTool {
 	 * Constructor — register all workspace read tools as global tools.
 	 */
 	public function __construct() {
-		$contexts = array( 'chat', 'pipeline', 'standalone' );
+		$contexts = array( 'chat', 'pipeline' );
 		$this->registerTool( 'workspace_path', array( $this, 'getPathDefinition' ), $contexts );
 		$this->registerTool( 'workspace_list', array( $this, 'getListDefinition' ), $contexts );
 		$this->registerTool( 'workspace_show', array( $this, 'getShowDefinition' ), $contexts );

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -447,7 +447,7 @@ class ToolManager {
 	/**
 	 * Get tools for REST API response.
 	 *
-	 * @param string|null $context Optional context to filter tools ('pipeline', 'chat', 'standalone', 'system').
+	 * @param string|null $context Optional context to filter tools ('pipeline', 'chat', 'system').
 	 *                            When null, returns all tools.
 	 * @return array Tools formatted for API
 	 */

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -4,14 +4,14 @@
  *
  * Single entry point for determining which tools are available for any
  * execution context. Reads from the unified `datamachine_tools` registry
- * and filters by context (pipeline/chat/standalone/system), then applies
+ * and filters by context (pipeline/chat/system), then applies
  * per-agent tool policies from agent_config.
  *
  * Resolution precedence (highest to lowest):
  * 1. Explicit deny list (always wins)
  * 2. Per-agent tool policy (deny/allow mode from agent_config)
  * 3. Context-level allow_only (narrows to explicit subset)
- * 4. Context preset (pipeline/chat/standalone/system)
+ * 4. Context preset (pipeline/chat/system)
  * 5. Global enablement settings
  * 6. Tool configuration requirements
  *
@@ -30,18 +30,16 @@ class ToolPolicyResolver {
 	/**
 	 * Context presets define which tool pools are available.
 	 */
-	public const CONTEXT_PIPELINE   = 'pipeline';
-	public const CONTEXT_CHAT       = 'chat';
-	public const CONTEXT_STANDALONE = 'standalone';
-	public const CONTEXT_SYSTEM     = 'system';
+	public const CONTEXT_PIPELINE = 'pipeline';
+	public const CONTEXT_CHAT     = 'chat';
+	public const CONTEXT_SYSTEM   = 'system';
 
 	/**
 	 * @deprecated Use CONTEXT_* constants instead.
 	 */
-	public const SURFACE_PIPELINE   = self::CONTEXT_PIPELINE;
-	public const SURFACE_CHAT       = self::CONTEXT_CHAT;
-	public const SURFACE_STANDALONE = self::CONTEXT_STANDALONE;
-	public const SURFACE_SYSTEM     = self::CONTEXT_SYSTEM;
+	public const SURFACE_PIPELINE = self::CONTEXT_PIPELINE;
+	public const SURFACE_CHAT     = self::CONTEXT_CHAT;
+	public const SURFACE_SYSTEM   = self::CONTEXT_SYSTEM;
 
 	private ToolManager $tool_manager;
 
@@ -110,13 +108,14 @@ class ToolPolicyResolver {
 	 * @return array Tools array.
 	 */
 	private function gatherByContext( string $context_type, array $context ): array {
-		return match ( $context_type ) {
-			self::CONTEXT_PIPELINE   => $this->gatherPipelineTools( $context ),
-			self::CONTEXT_CHAT       => $this->gatherChatTools( $context ),
-			self::CONTEXT_STANDALONE => $this->gatherStandaloneTools( $context ),
-			self::CONTEXT_SYSTEM     => $this->gatherSystemTools( $context ),
-			default                  => $this->gatherFallbackTools( $context ),
-		};
+		// Pipeline has special handling for adjacent step handler tools.
+		if ( self::CONTEXT_PIPELINE === $context_type ) {
+			return $this->gatherPipelineTools( $context );
+		}
+
+		// All other contexts (chat, system, and any custom contexts) use
+		// the generic gatherer — filter tools by their declared contexts.
+		return $this->gatherToolsForContext( $context_type );
 	}
 
 	/**
@@ -185,32 +184,34 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * Chat context: all tools with 'chat' context.
+	 * Gather tools for any context string.
 	 *
-	 * Tools with configuration requirements go through is_tool_available().
-	 * Chat-only tools (those without requires_config) are included if they
-	 * resolve to a valid definition.
+	 * Filters the tool registry by declared contexts, then applies availability
+	 * and enablement checks. Works with built-in contexts (chat, system) and
+	 * any custom context — third parties can register tools with custom context
+	 * strings and resolve them through the same path.
+	 *
+	 * @param string $context_type Context string to filter by (e.g. 'chat', 'system', 'automation').
+	 * @return array Available tools for this context.
 	 */
-	private function gatherChatTools( array $context ): array {
+	private function gatherToolsForContext( string $context_type ): array {
 		$available_tools = array();
 
-		$all_tools  = $this->tool_manager->get_all_tools();
-		$chat_tools = $this->filterByContext( $all_tools, 'chat' );
+		$all_tools      = $this->tool_manager->get_all_tools();
+		$context_tools  = $this->filterByContext( $all_tools, $context_type );
 
-		foreach ( $chat_tools as $tool_name => $tool_config ) {
+		foreach ( $context_tools as $tool_name => $tool_config ) {
 			if ( ! is_array( $tool_config ) || empty( $tool_config ) ) {
 				continue;
 			}
 
 			// Tools with requires_config go through availability checks.
-			// Tools without it (chat-only management tools) are always available.
+			// Tools without it are always available unless globally disabled.
 			if ( ! empty( $tool_config['requires_config'] ) ) {
 				if ( ! $this->tool_manager->is_tool_available( $tool_name, null ) ) {
 					continue;
 				}
 			} elseif ( ! $this->tool_manager->is_globally_enabled( $tool_name ) ) {
-				// Check global enablement for tools that can be disabled.
-				// For tools not in the disabled list, is_globally_enabled returns true.
 				continue;
 			}
 
@@ -218,55 +219,6 @@ class ToolPolicyResolver {
 		}
 
 		return $available_tools;
-	}
-
-	/**
-	 * Standalone context: tools with 'standalone' context.
-	 *
-	 * For standalone jobs that need AI tool access without pipeline context.
-	 */
-	private function gatherStandaloneTools( array $context ): array {
-		$available_tools = array();
-
-		$all_tools        = $this->tool_manager->get_all_tools();
-		$standalone_tools = $this->filterByContext( $all_tools, 'standalone' );
-
-		foreach ( $standalone_tools as $tool_name => $tool_config ) {
-			if ( is_array( $tool_config ) && $this->tool_manager->is_tool_available( $tool_name, null ) ) {
-				$available_tools[ $tool_name ] = $tool_config;
-			}
-		}
-
-		return $available_tools;
-	}
-
-	/**
-	 * System context: tools with 'system' context.
-	 *
-	 * Only includes tools that system tasks explicitly need.
-	 * Today most system tasks call abilities directly, but this provides
-	 * the hook point for when system tasks need AI tool access.
-	 */
-	private function gatherSystemTools( array $context ): array {
-		$available_tools = array();
-
-		$all_tools    = $this->tool_manager->get_all_tools();
-		$system_tools = $this->filterByContext( $all_tools, 'system' );
-
-		foreach ( $system_tools as $tool_name => $tool_config ) {
-			if ( is_array( $tool_config ) && $this->tool_manager->is_tool_available( $tool_name, null ) ) {
-				$available_tools[ $tool_name ] = $tool_config;
-			}
-		}
-
-		return $available_tools;
-	}
-
-	/**
-	 * Fallback: standalone tools for unknown contexts.
-	 */
-	private function gatherFallbackTools( array $context ): array {
-		return $this->gatherStandaloneTools( $context );
 	}
 
 	/**
@@ -352,10 +304,9 @@ class ToolPolicyResolver {
 	 */
 	public static function getContexts(): array {
 		return array(
-			self::CONTEXT_PIPELINE   => 'Pipeline execution with handler tools from adjacent steps',
-			self::CONTEXT_CHAT       => 'Chat interaction with full management tools',
-			self::CONTEXT_STANDALONE => 'Standalone job execution with global tools only',
-			self::CONTEXT_SYSTEM     => 'System task execution with minimal toolset',
+			self::CONTEXT_PIPELINE => 'Pipeline execution with handler tools from adjacent steps',
+			self::CONTEXT_CHAT     => 'Chat interaction with full management tools',
+			self::CONTEXT_SYSTEM   => 'System task execution with minimal toolset',
 		);
 	}
 

--- a/inc/Engine/AI/Tools/ToolServiceProvider.php
+++ b/inc/Engine/AI/Tools/ToolServiceProvider.php
@@ -4,7 +4,7 @@
  *
  * Centralizes registration of all tools via the unified `datamachine_tools` filter.
  * Each tool declares a `contexts` array specifying where it's available
- * (e.g. 'chat', 'pipeline', 'standalone').
+ * (e.g. 'chat', 'pipeline').
  *
  * @package DataMachine\Engine\AI\Tools
  * @since   0.27.0
@@ -14,7 +14,7 @@ namespace DataMachine\Engine\AI\Tools;
 
 defined( 'ABSPATH' ) || exit;
 
-// Tools available in chat, pipeline, and standalone contexts.
+// Tools available in chat and pipeline contexts.
 use DataMachine\Engine\AI\Tools\Global\AgentDailyMemory;
 use DataMachine\Engine\AI\Tools\Global\AgentMemory;
 use DataMachine\Engine\AI\Tools\Global\AmazonAffiliateLink;
@@ -71,7 +71,7 @@ class ToolServiceProvider {
 	/**
 	 * Register all tools.
 	 *
-	 * Tools with contexts ['chat', 'pipeline', 'standalone'] are registered
+	 * Tools with contexts ['chat', 'pipeline'] are registered
 	 * first because chat-only tools may depend on handlers and step types
 	 * that they provide.
 	 */
@@ -83,7 +83,7 @@ class ToolServiceProvider {
 	 * Register all tools with their context declarations.
 	 */
 	private static function registerTools(): void {
-		// Tools available in chat, pipeline, and standalone contexts.
+		// Tools available in chat and pipeline contexts.
 		new AgentDailyMemory();
 		new AgentMemory();
 		new AmazonAffiliateLink();

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -33,7 +33,7 @@ function datamachine_normalize_engine_config( $config ): array {
 /**
  * Get file context array from flow ID.
  *
- * @param int|string|null $flow_id Flow ID, 'direct', or null for standalone.
+ * @param int|string|null $flow_id Flow ID, 'direct', or null.
  * @return array Context array with pipeline/flow metadata.
  */
 function datamachine_get_file_context( int|string|null $flow_id ): array {

--- a/tests/Unit/AI/Tools/ToolPolicyResolverTest.php
+++ b/tests/Unit/AI/Tools/ToolPolicyResolverTest.php
@@ -29,27 +29,6 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	// ============================================
-	// STANDALONE CONTEXT
-	// ============================================
-
-	public function test_standalone_returns_global_tools(): void {
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
-		) );
-
-		$this->assertIsArray( $tools );
-		$this->assertArrayHasKey( 'web_fetch', $tools );
-	}
-
-	public function test_standalone_excludes_chat_tools(): void {
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
-		) );
-
-		$this->assertArrayNotHasKey( 'update_flow', $tools );
-	}
-
-	// ============================================
 	// CHAT CONTEXT
 	// ============================================
 
@@ -174,7 +153,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 	public function test_deny_list_removes_tools(): void {
 		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 			'deny'    => array( 'web_fetch' ),
 		) );
 
@@ -183,7 +162,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 	public function test_deny_list_overrides_allowlist(): void {
 		$tools = $this->resolver->resolve( array(
-			'context'    => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'    => ToolPolicyResolver::CONTEXT_CHAT,
 			'allow_only' => array( 'web_fetch' ),
 			'deny'       => array( 'web_fetch' ),
 		) );
@@ -197,7 +176,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 	public function test_allowlist_narrows_tools(): void {
 		$tools = $this->resolver->resolve( array(
-			'context'    => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'    => ToolPolicyResolver::CONTEXT_CHAT,
 			'allow_only' => array( 'web_fetch' ),
 		) );
 
@@ -207,7 +186,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 	public function test_allowlist_with_nonexistent_tool_returns_empty(): void {
 		$tools = $this->resolver->resolve( array(
-			'context'    => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'    => ToolPolicyResolver::CONTEXT_CHAT,
 			'allow_only' => array( 'completely_fake_tool_xyz' ),
 		) );
 
@@ -231,7 +210,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		}, 10, 3 );
 
 		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 
 		$this->assertArrayHasKey( 'injected_tool', $tools );
@@ -270,23 +249,56 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'web_fetch', $tools );
 	}
 
-	public function test_unknown_context_falls_back_to_standalone(): void {
+	public function test_unknown_context_returns_empty_tools(): void {
+		// Unknown contexts resolve via the generic gatherer — no tools
+		// are registered for this context, so the result is empty.
+		// This is correct: custom contexts only get tools that explicitly
+		// declare them, making the system extensible.
 		$tools = $this->resolver->resolve( array(
 			'context' => 'unknown_context_type',
 		) );
 
 		$this->assertIsArray( $tools );
-		$this->assertArrayHasKey( 'web_fetch', $tools );
+		$this->assertEmpty( $tools );
 	}
 
-	public function test_getContexts_returns_all_four_presets(): void {
+	public function test_custom_context_resolves_registered_tools(): void {
+		// Third parties can register tools with custom contexts and
+		// resolve them through the same path as built-in contexts.
+		add_filter( 'datamachine_tools', function ( $tools ) {
+			$tools['custom_automation_tool'] = array(
+				'label'       => 'Custom Automation Tool',
+				'description' => 'Only available in the automation context.',
+				'class'       => 'NonExistentClass',
+				'method'      => 'handle_tool_call',
+				'parameters'  => array(),
+				'contexts'    => array( 'automation' ),
+			);
+			return $tools;
+		} );
+
+		ToolManager::clearCache();
+
+		$tools = $this->resolver->resolve( array(
+			'context' => 'automation',
+		) );
+
+		$this->assertArrayHasKey( 'custom_automation_tool', $tools );
+
+		// Built-in tools that don't declare 'automation' are excluded.
+		$this->assertArrayNotHasKey( 'web_fetch', $tools );
+
+		remove_all_filters( 'datamachine_tools' );
+		ToolManager::clearCache();
+	}
+
+	public function test_getContexts_returns_all_three_presets(): void {
 		$contexts = ToolPolicyResolver::getContexts();
 
 		$this->assertArrayHasKey( ToolPolicyResolver::CONTEXT_PIPELINE, $contexts );
 		$this->assertArrayHasKey( ToolPolicyResolver::CONTEXT_CHAT, $contexts );
-		$this->assertArrayHasKey( ToolPolicyResolver::CONTEXT_STANDALONE, $contexts );
 		$this->assertArrayHasKey( ToolPolicyResolver::CONTEXT_SYSTEM, $contexts );
-		$this->assertCount( 4, $contexts );
+		$this->assertCount( 3, $contexts );
 	}
 
 	// ============================================
@@ -307,7 +319,6 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	public function test_surface_constants_alias_context_constants(): void {
 		$this->assertSame( ToolPolicyResolver::CONTEXT_PIPELINE, ToolPolicyResolver::SURFACE_PIPELINE );
 		$this->assertSame( ToolPolicyResolver::CONTEXT_CHAT, ToolPolicyResolver::SURFACE_CHAT );
-		$this->assertSame( ToolPolicyResolver::CONTEXT_STANDALONE, ToolPolicyResolver::SURFACE_STANDALONE );
 		$this->assertSame( ToolPolicyResolver::CONTEXT_SYSTEM, ToolPolicyResolver::SURFACE_SYSTEM );
 	}
 
@@ -362,11 +373,11 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 	public function test_no_agent_id_means_no_restrictions(): void {
 		$tools_without = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 
 		$tools_with_zero = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
 			'agent_id' => 0,
 		) );
 
@@ -377,11 +388,11 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		$agent_id = $this->createAgentWithPolicy( null );
 
 		$tools_no_agent = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 
 		$tools_with_agent = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
 			'agent_id' => $agent_id,
 		) );
 
@@ -395,7 +406,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		) );
 
 		$tools = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
 			'agent_id' => $agent_id,
 		) );
 
@@ -411,7 +422,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		) );
 
 		$tools = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
 			'agent_id' => $agent_id,
 		) );
 
@@ -426,7 +437,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		) );
 
 		$tools = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
 			'agent_id' => $agent_id,
 		) );
 
@@ -440,11 +451,11 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		) );
 
 		$tools_no_agent = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 
 		$tools_with_agent = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
 			'agent_id' => $agent_id,
 		) );
 
@@ -453,11 +464,11 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 	public function test_nonexistent_agent_id_no_restrictions(): void {
 		$tools_no_agent = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 
 		$tools_bad_id = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
 			'agent_id' => 999999,
 		) );
 
@@ -472,7 +483,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		) );
 
 		$tools = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
 			'agent_id' => $agent_id,
 			'deny'     => array( 'web_fetch' ),
 		) );
@@ -517,11 +528,11 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		) );
 
 		$tools_no_agent = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 
 		$tools_with_agent = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
 			'agent_id' => $agent_id,
 		) );
 
@@ -535,11 +546,11 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		) );
 
 		$tools_no_agent = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context' => ToolPolicyResolver::CONTEXT_CHAT,
 		) );
 
 		$tools_with_agent = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_STANDALONE,
+			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
 			'agent_id' => $agent_id,
 		) );
 


### PR DESCRIPTION
## Summary

- **Remove standalone tool context** — every tool registered for `standalone` was also registered for `chat` and `pipeline`. Zero tools were standalone-only. The separate context added complexity (constants, gather methods, UI model override) with no functional benefit. Unknown contexts now fall back to `chat`.
- **Fix WordPress Update handler** — `WordPressSettings::class` was registered as `null`, hiding configurable fields (allow_title_updates, allow_content_updates, taxonomy fields) on the settings page.
- **Filter settings page** — step types without handlers (`ai`, `webhook_gate`, `system_task`, `agent_ping`) no longer show on the Handler Defaults tab.

## What changed (40 files)

| Area | Change |
|------|--------|
| `ToolPolicyResolver` | Remove `CONTEXT_STANDALONE`, `SURFACE_STANDALONE`, `gatherStandaloneTools()`, `gatherFallbackTools()`. Unknown contexts fall back to `gatherChatTools()` |
| 17 tool files | `['chat', 'pipeline', 'standalone']` → `['chat', 'pipeline']` |
| `PluginSettings` | Remove standalone from `getContexts()` — no more model override on agents page |
| REST API | Remove standalone from enums and validation |
| CLI/Abilities | Update description strings |
| Database | Update comments in Jobs schema and JobsOperations |
| Tests | Remove standalone-specific tests, fix context counts (4→3) |
| WordPress handler | Register `WordPressSettings::class` |
| HandlerDefaultsTab | Filter to only show step types with `uses_handler: true` |

## What's preserved

`ExecutionContext::MODE_STANDALONE` and `isStandalone()` remain — they represent valid internal state for jobs without pipeline/flow context. This PR only removes standalone as a **tool context** and **model override**.

## Tests

891 passed, 6 failed (pre-existing image generation failures — same 5 failures exist on main).