### PR TITLE
fix: make daily memory parameter explicitly nullable

### DIFF
--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -767,7 +767,7 @@ class Flows extends BaseRepository {
 	 * @param array $daily_memory  Optional. Daily memory config array.
 	 * @return bool True on success, false on failure.
 	 */
-	public function update_flow_memory_files( int $flow_id, array $memory_files, array $daily_memory = null ): bool {
+	public function update_flow_memory_files( int $flow_id, array $memory_files, ?array $daily_memory = null ): bool {
 		if ( empty( $flow_id ) ) {
 			return false;
 		}


### PR DESCRIPTION
## Summary
- fix the PHP 8.4 deprecation in \
- make the \ parameter explicitly nullable with \

## Why
PHP 8.4 deprecates implicitly nullable typed parameters. This warning is currently surfacing on the live Extra Chill site during WP-CLI/deploy operations after updating Data Machine to 0.42.0.

Closes #814