### PR TITLE
Remove user-layer MEMORY.md — agent-only, period

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Data Machine turns a WordPress site into an agent runtime — persistent identit
 
 - **Pipelines** — Multi-step workflows: fetch content, process with AI, publish anywhere
 - **Abilities API** — Typed, permissioned functions that agents and extensions call (`datamachine/upload-media`, `datamachine/validate-media`, etc.)
-- **Agent memory** — Persistent SOUL.md, USER.md, MEMORY.md files that define who the agent is and what it knows
+- **Agent memory** — Layered markdown files (SOUL.md + MEMORY.md in agent layer, USER.md in user layer) injected into every AI context
 - **Multi-agent** — Multiple agents with scoped pipelines, flows, jobs, and filesystem directories
 - **Workspace** — Managed directory for repo clones and file operations with security sandboxing
 - **Self-scheduling** — Agents schedule their own recurring tasks using flows, prompt queues, and Agent Pings

--- a/docs/ai-directives.md
+++ b/docs/ai-directives.md
@@ -37,7 +37,7 @@ Specialized directive for the conversational chat interface. It instructs the ag
 Defines the system agent identity for internal operations — session title generation, GitHub issue creation, and system maintenance tasks. Dynamically lists available GitHub repos at runtime.
 
 ### CoreMemoryFilesDirective (Priority 20)
-Reads memory files from three directory layers (site shared, per-agent, per-user) and injects them as system messages. Self-healing — creates missing agent files before reading. Applied to **all** agent types.
+Reads core memory files from three directory layers and injects them as system messages: SITE.md + RULES.md (shared), SOUL.md + MEMORY.md (agent), USER.md (user). Self-healing — creates missing agent files before reading. Applied to **all** agent types.
 
 ### PipelineMemoryFilesDirective (Priority 40)
 Injects agent memory files selected for a specific pipeline. Files are stored in the agent directory and selected per-pipeline via the admin UI. SOUL.md is excluded (always injected separately at Priority 20). This enables pipelines to access strategy documents, reference material, or other persistent context.

--- a/docs/core-system/ai-directives.md
+++ b/docs/core-system/ai-directives.md
@@ -105,7 +105,6 @@ Reads core memory files from three directory layers and injects them as system m
 
 **User Layer** (per-user):
 - `USER.md` — User-specific preferences and context
-- `MEMORY.md` — User persistent memory
 
 **Custom registered files** — Any additional files registered via `MemoryFileRegistry` are also loaded from the agent directory.
 

--- a/docs/core-system/wordpress-as-agent-memory.md
+++ b/docs/core-system/wordpress-as-agent-memory.md
@@ -29,8 +29,8 @@ Four layers, each serving a different purpose:
 | Layer | Directory | Contents |
 |-------|-----------|----------|
 | **Shared** (site-wide) | `shared/` | `SITE.md`, `RULES.md` — site-level context shared by all agents |
-| **Agent** (identity) | `agents/{agent_slug}/` | `SOUL.md`, `MEMORY.md`, `daily/` — agent-specific identity and knowledge |
-| **User** (personal) | `users/{user_id}/` | `USER.md`, `MEMORY.md` — user preferences and user-scoped knowledge |
+| **Agent** (identity + knowledge) | `agents/{agent_slug}/` | `SOUL.md`, `MEMORY.md`, `daily/` — agent-specific identity and knowledge |
+| **User** (personal) | `users/{user_id}/` | `USER.md` — user preferences that follow the human across agents |
 
 Markdown files stored on the WordPress filesystem. The agent reads these to know who it is, who it works with, and what it knows.
 
@@ -42,7 +42,7 @@ Data Machine ships with core memory files across layers:
 
 **SOUL.md** — Agent identity. Who the agent is, how it communicates, what rules it follows. Injected into every AI request. Rarely changes. Lives in the agent layer.
 
-**MEMORY.md** — Accumulated knowledge. Facts, decisions, lessons learned, project state. Grows and changes over time as the agent learns. Exists in both agent and user layers.
+**MEMORY.md** — Accumulated knowledge. Facts, decisions, lessons learned, project state. Grows and changes over time as the agent learns. Lives in the agent layer.
 
 **USER.md** — Information about the human. Timezone, preferences, communication style, background. Lives in the user layer.
 
@@ -212,9 +212,9 @@ Created on activation with a starter template, same as SOUL.md and MEMORY.md.
 <!-- Schedule, availability, things the agent should know about how you work -->
 ```
 
-### MEMORY.md — What the Agent Knows (Agent + User Layers)
+### MEMORY.md — What the Agent Knows (Agent Layer)
 
-MEMORY.md is the agent's **accumulated knowledge** — facts, decisions, lessons, context that builds up over time. It exists in both the agent layer (shared agent knowledge) and user layer (user-specific knowledge). Structure it for scanability:
+MEMORY.md is the agent's **accumulated knowledge** — facts, decisions, lessons, context that builds up over time. It lives in the agent layer alongside SOUL.md. Structure it for scanability:
 
 - **Use clear section headers** — the agent needs to find relevant info quickly
 - **Be factual, not narrative** — bullet points over paragraphs
@@ -300,7 +300,7 @@ Data Machine uses a **directive system** — a priority-ordered chain that injec
 |----------|-----------|---------|-----------------|
 | 10 | `PipelineCoreDirective` | Pipeline | Base Data Machine identity for pipelines |
 | **15** | **`ChatAgentDirective`** | **Chat** | **Chat agent identity and instructions** |
-| **20** | **`CoreMemoryFilesDirective`** | **All** | **SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md from layer dirs + custom registry files** |
+| **20** | **`CoreMemoryFilesDirective`** | **All** | **SITE.md, RULES.md (shared), SOUL.md, MEMORY.md (agent), USER.md (user) + custom registry files** |
 | **20** | **`SystemAgentDirective`** | **System** | **System task agent identity** |
 | 40 | `PipelineMemoryFilesDirective` | Pipeline | Per-pipeline selected additional files |
 | **45** | **`ChatPipelinesDirective`** | **Chat** | **Pipeline/flow context for chat** |
@@ -315,7 +315,7 @@ The **CoreMemoryFilesDirective** loads files in two stages:
 
 **Stage 1 — Layer directories:** Loads core files directly from the three-layer directory structure:
 ```
-shared/SITE.md → shared/RULES.md → agents/{slug}/SOUL.md → agents/{slug}/MEMORY.md → users/{id}/USER.md → users/{id}/MEMORY.md
+shared/SITE.md → shared/RULES.md → agents/{slug}/SOUL.md → agents/{slug}/MEMORY.md → users/{id}/USER.md
 ```
 
 **Stage 2 — Custom registry:** Loads any additional files registered in the **MemoryFileRegistry** (excluding SOUL.md, USER.md, MEMORY.md which are already loaded from layers):
@@ -543,14 +543,14 @@ Agent memory is stored as **files on disk**, not in `wp_options` or custom table
 
 The shared/agent/user layer separation serves distinct purposes:
 - **Shared** — site-wide facts all agents need (SITE.md, RULES.md)
-- **Agent** — identity and accumulated knowledge specific to one agent (SOUL.md, MEMORY.md)
-- **User** — human preferences that follow the user across agents (USER.md)
+- **Agent** — identity and accumulated knowledge specific to one agent (SOUL.md, MEMORY.md, daily/)
+- **User** — human preferences that follow the user across agents (USER.md only)
 
 This means a single WordPress site can host multiple agents with distinct identities while sharing common site context.
 
 ### Layer directories over registry for core files
 
-Core memory files (SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md) are loaded directly from their layer directories by `CoreMemoryFilesDirective`. The `MemoryFileRegistry` is used only for custom extensions. This keeps the core loading path simple and predictable while maintaining extensibility for plugins.
+Core memory files are loaded directly from their layer directories by `CoreMemoryFilesDirective`: SITE.md and RULES.md from shared, SOUL.md and MEMORY.md from agent, USER.md from user. The `MemoryFileRegistry` is used only for custom extensions. This keeps the core loading path simple, predictable, and each file in exactly one layer.
 
 ### Selective injection over RAG
 

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -2,9 +2,9 @@
 /**
  * WP-CLI Agent Command
  *
- * Provides CLI access to the agent Memory Library — core agent files
- * (SOUL.md, USER.md, MEMORY.md), MEMORY.md section operations, and
- * daily memory (YYYY/MM/DD.md).
+ * Provides CLI access to the agent Memory Library — core memory files
+ * across layers (SOUL.md + MEMORY.md in agent layer, USER.md in user layer),
+ * MEMORY.md section operations, and daily memory (YYYY/MM/DD.md).
  *
  * Primary command: `wp datamachine agent`.
  * Backwards-compatible alias: `wp datamachine memory`.

--- a/inc/Core/FilesRepository/DirectoryManager.php
+++ b/inc/Core/FilesRepository/DirectoryManager.php
@@ -31,7 +31,7 @@ class DirectoryManager {
 	private static bool $agent_files_ensured = false;
 
 	/**
-	 * Ensure default agent files exist (SOUL.md, USER.md, MEMORY.md).
+	 * Ensure default memory files exist across layers (SOUL.md + MEMORY.md in agent, USER.md in user).
 	 *
 	 * Lazy self-healing: runs at most once per PHP request on the first
 	 * call. If any registered memory files are missing, recreates them

--- a/inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php
+++ b/inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php
@@ -7,7 +7,7 @@
  *
  * Priority Order in Directive System:
  * 1. Priority 10 - Plugin Core Directive (agent identity)
- * 2. Priority 20 - Core Memory Files (SOUL.md, USER.md, MEMORY.md, etc.)
+ * 2. Priority 20 - Core Memory Files (SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md)
  * 3. Priority 40 - Pipeline Memory Files (per-pipeline selectable)
  * 4. Priority 45 - Flow Memory Files (THIS CLASS - per-flow selectable)
  * 5. Priority 50 - Pipeline System Prompt (pipeline instructions)

--- a/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
@@ -7,7 +7,7 @@
  *
  * Priority Order in Directive System:
  * 1. Priority 10 - Plugin Core Directive (agent identity)
- * 2. Priority 20 - Core Memory Files (SOUL.md, USER.md, MEMORY.md, etc.)
+ * 2. Priority 20 - Core Memory Files (SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md)
  * 3. Priority 40 - Pipeline Memory Files (THIS CLASS - per-pipeline selectable)
  * 4. Priority 45 - Flow Memory Files (per-flow selectable)
  * 5. Priority 50 - Pipeline System Prompt (pipeline instructions)

--- a/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
@@ -9,7 +9,7 @@
  *
  * Priority Order in Directive System:
  * 1. Priority 10 - Plugin Core Directive
- * 2. Priority 20 - Core Memory Files (SOUL.md, USER.md, MEMORY.md, etc.)
+ * 2. Priority 20 - Core Memory Files (SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md)
  * 3. Priority 40 - Pipeline Memory Files (per-pipeline selectable)
  * 4. Priority 50 - Pipeline System Prompt (THIS CLASS)
  * 5. Priority 60 - Pipeline Context Files

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -2,9 +2,10 @@
 /**
  * Core Memory Files Directive - Priority 20
  *
- * Loads agent memory files from the MemoryFileRegistry and injects them
- * into every AI call. The registry is a pure container — this directive
- * just reads from it.
+ * Loads core memory files from three directory layers and injects them
+ * into every AI call: SITE.md + RULES.md (shared), SOUL.md + MEMORY.md
+ * (agent), USER.md (user). Custom files from the MemoryFileRegistry are
+ * loaded separately from the agent directory.
  *
  * Priority Order in Directive System:
  * 1. Priority 10 - Plugin Core Directive (agent identity)
@@ -77,10 +78,6 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 			array(
 				'directory' => $user_dir,
 				'filename'  => 'USER.md',
-			),
-			array(
-				'directory' => $user_dir,
-				'filename'  => 'MEMORY.md',
 			),
 		);
 

--- a/inc/Engine/AI/Directives/DailyMemorySelectorDirective.php
+++ b/inc/Engine/AI/Directives/DailyMemorySelectorDirective.php
@@ -8,7 +8,7 @@
  *
  * Priority Order in Directive System:
  * 1. Priority 10 - Plugin Core Directive (agent identity)
- * 2. Priority 20 - Core Memory Files (SOUL.md, USER.md, MEMORY.md, etc.)
+ * 2. Priority 20 - Core Memory Files (SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md)
  * 3. Priority 40 - Pipeline Memory Files (per-pipeline selectable)
  * 4. Priority 45 - Flow Memory Files (per-flow selectable)
  * 5. Priority 46 - Daily Memory Selector (THIS CLASS - per-flow daily config)

--- a/inc/Engine/AI/Directives/SiteContextDirective.php
+++ b/inc/Engine/AI/Directives/SiteContextDirective.php
@@ -8,7 +8,7 @@
  *
  * Priority Order in Directive System:
  * 1. Priority 10 - Plugin Core Directive
- * 2. Priority 20 - Core Memory Files (SOUL.md, USER.md, MEMORY.md, etc.)
+ * 2. Priority 20 - Core Memory Files (SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md)
  * 3. Priority 40 - Pipeline Memory Files (per-pipeline selectable)
  * 4. Priority 50 - Pipeline System Prompt
  * 5. Priority 60 - Pipeline Context Files

--- a/skills/data-machine/SKILL.md
+++ b/skills/data-machine/SKILL.md
@@ -66,12 +66,14 @@ Automated content workflows that run on schedules.
 
 ## Memory System
 
-Agent files live in `{uploads}/datamachine-files/agent/` and are injected as system context into every AI call:
+Agent memory uses a three-layer directory system under `{uploads}/datamachine-files/`. Core files are injected as system context into every AI call:
 
-- **SOUL.md** — identity, voice, rules (always injected)
-- **USER.md** — human user profile (always injected)
-- **MEMORY.md** — accumulated knowledge (always injected)
-- **daily/YYYY/MM/DD.md** — temporal session logs
+- **shared/SITE.md** — site-wide context (shared layer)
+- **shared/RULES.md** — site-wide rules (shared layer)
+- **agents/{slug}/SOUL.md** — identity, voice, rules (agent layer)
+- **agents/{slug}/MEMORY.md** — accumulated knowledge (agent layer)
+- **users/{id}/USER.md** — human user profile (user layer)
+- **agents/{slug}/daily/YYYY/MM/DD.md** — temporal session logs
 
 Manage via `wp datamachine agent` (aliased as `wp datamachine memory`). Run `wp help datamachine agent` to see all subcommands.
 


### PR DESCRIPTION
## Summary

- **MEMORY.md belongs in the agent layer only.** The code was wired to also load `MEMORY.md` from the user layer (`users/{id}/MEMORY.md`), but the file never existed on disk and the dual-layer concept muddied the clean separation.
- Removes the user-layer `MEMORY.md` entry from `CoreMemoryFilesDirective.php`
- Fixes docs and PHP docblocks across 13 files that grouped all core files without layer distinction, described MEMORY.md as existing in "both layers", or used legacy single-directory paths

## Clean model

```
shared/   → SITE.md, RULES.md
agents/   → SOUL.md, MEMORY.md, daily/
users/    → USER.md
```

Each file lives in exactly one layer. No ambiguity.

## Files changed

| File | What changed |
|------|-------------|
| `CoreMemoryFilesDirective.php` | Removed `users/{id}/MEMORY.md` from core layer files array |
| `wordpress-as-agent-memory.md` | Fixed layer table, MEMORY.md descriptions, loading chain, design decisions |
| `ai-directives.md` (both) | Removed user-layer MEMORY.md from directive description |
| `README.md` | Clarified agent memory description with layer info |
| `SKILL.md` | Updated from legacy flat paths to three-layer architecture |
| 6 PHP directive files | Updated priority docblock from `(SOUL.md, USER.md, MEMORY.md, etc.)` to explicit layer list |
| `MemoryCommand.php` | Updated docblock to distinguish layers |
| `DirectoryManager.php` | Updated docblock to distinguish layers |