### PR TITLE
Extensible memory file layers — registry-driven, decoupled, layer-aware

### DIFF
--- a/docs/core-system/wordpress-as-agent-memory.md
+++ b/docs/core-system/wordpress-as-agent-memory.md
@@ -46,7 +46,7 @@ Data Machine ships with core memory files across layers:
 
 **USER.md** — Information about the human. Timezone, preferences, communication style, background. Lives in the user layer.
 
-The **CoreMemoryFilesDirective** loads core files directly from the three layer directories (shared → agent → user), then loads any custom files registered via the **MemoryFileRegistry**. Core files are not loaded from the registry — the registry is for extensions only.
+The **CoreMemoryFilesDirective** loads all files from the **MemoryFileRegistry**, resolving each to its layer directory. Core and custom files use the same registration API — the `datamachine_memory_files` action hook provides the extension point for third parties.
 
 **Additional files** serve workflow-specific purposes — editorial strategies, project briefs, content plans. Each pipeline can select which additional files it needs, so a social media workflow doesn't carry the weight of a full content strategy. These are injected at Priority 40 (per-pipeline) or Priority 45 (per-flow).
 
@@ -311,23 +311,24 @@ Data Machine uses a **directive system** — a priority-ordered chain that injec
 
 ### Core Memory Files (Priority 20)
 
-The **CoreMemoryFilesDirective** loads files in two stages:
+The **CoreMemoryFilesDirective** loads all files from the **MemoryFileRegistry**, resolving each to its layer directory:
 
-**Stage 1 — Layer directories:** Loads core files directly from the three-layer directory structure:
 ```
-shared/SITE.md → shared/RULES.md → agents/{slug}/SOUL.md → agents/{slug}/MEMORY.md → users/{id}/USER.md
+Registry priority order → resolve layer → read file → inject as system message
 ```
 
-**Stage 2 — Custom registry:** Loads any additional files registered in the **MemoryFileRegistry** (excluding SOUL.md, USER.md, MEMORY.md which are already loaded from layers):
+All core files register through the same API that plugins use:
 
 ```php
-// Default registrations in bootstrap.php (used for registry tracking, not loading)
-MemoryFileRegistry::register( 'SOUL.md', 10 );
-MemoryFileRegistry::register( 'USER.md', 20 );
-MemoryFileRegistry::register( 'MEMORY.md', 30 );
+// From bootstrap.php — these are just the defaults.
+MemoryFileRegistry::register( 'SITE.md',   10, [ 'layer' => 'shared', 'protected' => true ] );
+MemoryFileRegistry::register( 'RULES.md',  15, [ 'layer' => 'shared', 'protected' => true ] );
+MemoryFileRegistry::register( 'SOUL.md',   20, [ 'layer' => 'agent',  'protected' => true ] );
+MemoryFileRegistry::register( 'USER.md',   25, [ 'layer' => 'user',   'protected' => true ] );
+MemoryFileRegistry::register( 'MEMORY.md', 30, [ 'layer' => 'agent',  'protected' => true ] );
 ```
 
-The priority number within the registry determines **load order** for custom files. Missing files are silently skipped. Empty files are silently skipped.
+The priority number determines **load order**. Missing files are silently skipped. Empty files are silently skipped. Third parties register additional files through the same `register()` API or the `datamachine_memory_files` action hook.
 
 Plugins and themes can register their own memory files through the same API:
 
@@ -548,9 +549,9 @@ The shared/agent/user layer separation serves distinct purposes:
 
 This means a single WordPress site can host multiple agents with distinct identities while sharing common site context.
 
-### Layer directories over registry for core files
+### Registry-driven loading with layer resolution
 
-Core memory files are loaded directly from their layer directories by `CoreMemoryFilesDirective`: SITE.md and RULES.md from shared, SOUL.md and MEMORY.md from agent, USER.md from user. The `MemoryFileRegistry` is used only for custom extensions. This keeps the core loading path simple, predictable, and each file in exactly one layer.
+All memory files — core and custom — register through the same `MemoryFileRegistry` API. Each registration specifies its layer (`shared`, `agent`, `user`), and the `CoreMemoryFilesDirective` resolves each file to the correct directory at runtime. This makes the system fully extensible: plugins register files in any layer through the same API that core uses. No special-casing, no hardcoded file lists.
 
 ### Selective injection over RAG
 
@@ -654,16 +655,65 @@ wp datamachine workspace git status --repo=<name> --allow-root
 
 ### Register Custom Memory Files
 
-Add files to the core injection (Priority 20) via the registry:
+Add files to the core injection (Priority 20) via the registry. Each file specifies its **layer**, which determines where it lives and who can see it:
 
 ```php
 use DataMachine\Engine\AI\MemoryFileRegistry;
 
-// Register a file to be injected into all AI calls
-MemoryFileRegistry::register( 'brand-guidelines.md', 40 );
+// Agent-layer file — scoped to a single agent.
+MemoryFileRegistry::register( 'brand-guidelines.md', 40, [
+    'layer'       => MemoryFileRegistry::LAYER_AGENT,
+    'label'       => 'Brand Guidelines',
+    'description' => 'Voice, tone, and visual brand standards.',
+] );
+
+// Shared-layer file — visible to ALL agents on the site.
+MemoryFileRegistry::register( 'editorial-policy.md', 45, [
+    'layer'       => MemoryFileRegistry::LAYER_SHARED,
+    'label'       => 'Editorial Policy',
+    'description' => 'Site-wide editorial standards.',
+] );
+
+// User-layer file — visible to ALL agents for a specific user.
+MemoryFileRegistry::register( 'work-context.md', 50, [
+    'layer'       => MemoryFileRegistry::LAYER_USER,
+    'label'       => 'Work Context',
+    'description' => 'User-specific project context.',
+] );
+
+// Protected file — cannot be deleted.
+MemoryFileRegistry::register( 'compliance.md', 12, [
+    'layer'     => MemoryFileRegistry::LAYER_SHARED,
+    'protected' => true,
+    'label'     => 'Compliance Rules',
+] );
 ```
 
-The file must exist in the agent's directory (`wp-content/uploads/datamachine-files/agents/{agent_slug}/`). Missing files are silently skipped.
+**Registration arguments:**
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `layer` | string | `'agent'` | One of `shared`, `agent`, `user` |
+| `protected` | bool | `false` | Protected files cannot be deleted or blanked |
+| `label` | string | *derived from filename* | Human-readable display label |
+| `description` | string | `''` | Purpose description shown in the admin UI |
+
+Files are resolved to their layer directory at runtime. Missing files are silently skipped.
+
+### Extension Hook
+
+Third parties can register files via the `datamachine_memory_files` action, which fires once per request when the registry is first consumed:
+
+```php
+add_action( 'datamachine_memory_files', function( $current_files ) {
+    // Inspect existing registrations if needed.
+    // Register additional files via the standard API.
+    MemoryFileRegistry::register( 'my-plugin-context.md', 60, [
+        'layer' => MemoryFileRegistry::LAYER_AGENT,
+        'label' => 'My Plugin Context',
+    ] );
+} );
+```
 
 ### Custom Directives
 

--- a/inc/Abilities/File/AgentFileAbilities.php
+++ b/inc/Abilities/File/AgentFileAbilities.php
@@ -3,11 +3,15 @@
  * Agent File Abilities
  *
  * Abilities API primitives for agent memory file operations.
- * Handles the agent identity layer (SOUL.md, MEMORY.md, custom files)
- * and composes with the user layer (USER.md) for a unified view.
+ * Supports all three layers (shared, agent, user) with routing
+ * driven by the MemoryFileRegistry for registered files.
+ *
+ * New files default to the agent layer. A `layer` parameter can
+ * explicitly target shared or user layers.
  *
  * @package DataMachine\Abilities\File
  * @since   0.38.0
+ * @since   0.42.0 Layer-aware CRUD via MemoryFileRegistry.
  */
 
 namespace DataMachine\Abilities\File;
@@ -16,6 +20,7 @@ use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\FilesRepository\DailyMemory;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Core\FilesRepository\FilesystemHelper;
+use DataMachine\Engine\AI\MemoryFileRegistry;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -61,7 +66,7 @@ class AgentFileAbilities {
 			'datamachine/list-agent-files',
 			array(
 				'label'               => __( 'List Agent Files', 'data-machine' ),
-				'description'         => __( 'List memory files from the agent identity and user layers.', 'data-machine' ),
+				'description'         => __( 'List memory files from all layers (shared, agent, user).', 'data-machine' ),
 				'category'            => 'datamachine',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -130,7 +135,7 @@ class AgentFileAbilities {
 			'datamachine/write-agent-file',
 			array(
 				'label'               => __( 'Write Agent File', 'data-machine' ),
-				'description'         => __( 'Write or update content for an agent memory file. Protected files cannot be blanked.', 'data-machine' ),
+				'description'         => __( 'Write or update content for a memory file. Layer is resolved from the registry, or can be explicitly specified.', 'data-machine' ),
 				'category'            => 'datamachine',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -138,11 +143,16 @@ class AgentFileAbilities {
 					'properties' => array(
 						'filename' => array(
 							'type'        => 'string',
-							'description' => __( 'Name of the agent file to write', 'data-machine' ),
+							'description' => __( 'Name of the memory file to write', 'data-machine' ),
 						),
 						'content'  => array(
 							'type'        => 'string',
 							'description' => __( 'Content to write to the file', 'data-machine' ),
+						),
+						'layer'    => array(
+							'type'        => 'string',
+							'description' => __( 'Target layer: shared, agent, or user. For registered files, defaults to the registered layer. For new files, defaults to agent.', 'data-machine' ),
+							'enum'        => array( 'shared', 'agent', 'user' ),
 						),
 						'user_id'  => array(
 							'type'        => 'integer',
@@ -156,6 +166,7 @@ class AgentFileAbilities {
 					'properties' => array(
 						'success'  => array( 'type' => 'boolean' ),
 						'filename' => array( 'type' => 'string' ),
+						'layer'    => array( 'type' => 'string' ),
 						'error'    => array( 'type' => 'string' ),
 					),
 				),
@@ -171,7 +182,7 @@ class AgentFileAbilities {
 			'datamachine/delete-agent-file',
 			array(
 				'label'               => __( 'Delete Agent File', 'data-machine' ),
-				'description'         => __( 'Delete an agent memory file. Protected files (SOUL.md, MEMORY.md) cannot be deleted.', 'data-machine' ),
+				'description'         => __( 'Delete a memory file. Protected files cannot be deleted.', 'data-machine' ),
 				'category'            => 'datamachine',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -208,7 +219,7 @@ class AgentFileAbilities {
 			'datamachine/upload-agent-file',
 			array(
 				'label'               => __( 'Upload Agent File', 'data-machine' ),
-				'description'         => __( 'Upload a file to the agent memory directory.', 'data-machine' ),
+				'description'         => __( 'Upload a file to a memory layer directory.', 'data-machine' ),
 				'category'            => 'datamachine',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -224,6 +235,11 @@ class AgentFileAbilities {
 								'error'    => array( 'type' => 'integer' ),
 								'size'     => array( 'type' => 'integer' ),
 							),
+						),
+						'layer'     => array(
+							'type'        => 'string',
+							'description' => __( 'Target layer for the uploaded file. Default agent.', 'data-machine' ),
+							'enum'        => array( 'shared', 'agent', 'user' ),
 						),
 						'user_id'   => array(
 							'type'        => 'integer',
@@ -263,7 +279,7 @@ class AgentFileAbilities {
 	// =========================================================================
 
 	/**
-	 * List agent memory files from both identity and user layers.
+	 * List agent memory files from all layers.
 	 *
 	 * @param array $input Input parameters.
 	 * @return array Result with files list.
@@ -309,12 +325,17 @@ class AgentFileAbilities {
 
 				$filepath = "{$dir}/{$entry}";
 				if ( is_file( $filepath ) ) {
+					$registry_meta  = MemoryFileRegistry::get( $entry );
 					$files[]        = array(
-						'filename' => $entry,
-						'size'     => filesize( $filepath ),
-						'modified' => gmdate( 'c', filemtime( $filepath ) ),
-						'type'     => 'core',
-						'layer'    => $layer,
+						'filename'    => $entry,
+						'size'        => filesize( $filepath ),
+						'modified'    => gmdate( 'c', filemtime( $filepath ) ),
+						'type'        => 'core',
+						'layer'       => $registry_meta ? $registry_meta['layer'] : $layer,
+						'protected'   => MemoryFileRegistry::is_protected( $entry ),
+						'registered'  => null !== $registry_meta,
+						'label'       => $registry_meta['label'] ?? self::filename_to_label( $entry ),
+						'description' => $registry_meta['description'] ?? '',
 					);
 					$seen[ $entry ] = true;
 				}
@@ -365,7 +386,7 @@ class AgentFileAbilities {
 		if ( ! $filepath ) {
 			return array(
 				'success' => false,
-				'error'   => sprintf( 'File %s not found in agent directory', $filename ),
+				'error'   => sprintf( 'File %s not found in any layer', $filename ),
 			);
 		}
 
@@ -383,9 +404,12 @@ class AgentFileAbilities {
 	}
 
 	/**
-	 * Write content to an agent file.
+	 * Write content to a memory file.
 	 *
-	 * Routes to the correct layer: USER.md → user dir, everything else → agent identity dir.
+	 * Layer resolution order:
+	 * 1. Explicit `layer` parameter (if provided)
+	 * 2. Registry layer (if file is registered)
+	 * 3. Default: agent layer
 	 *
 	 * @param array $input Input parameters.
 	 * @return array Result with write status.
@@ -394,26 +418,27 @@ class AgentFileAbilities {
 		$filename = sanitize_file_name( $input['filename'] ?? '' );
 		$content  = $input['content'] ?? '';
 
-		if ( in_array( $filename, FileConstants::PROTECTED_FILES, true ) && '' === trim( $content ) ) {
+		if ( MemoryFileRegistry::is_protected( $filename ) && '' === trim( $content ) ) {
 			return array(
 				'success' => false,
 				'error'   => sprintf( 'Cannot write empty content to protected file: %s', $filename ),
 			);
 		}
 
-		$dm         = new DirectoryManager();
-		$user_id    = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
-		$target_dir = in_array( $filename, FileConstants::USER_LAYER_FILES, true )
-			? $dm->get_user_directory( $user_id )
-			: $dm->resolve_agent_directory( array(
-				'agent_id' => (int) ( $input['agent_id'] ?? 0 ),
-				'user_id'  => $user_id,
-			) );
+		// Resolve target layer.
+		$explicit_layer = $input['layer'] ?? null;
+		$registry_layer = MemoryFileRegistry::get_layer( $filename );
+		$target_layer   = $explicit_layer ?? $registry_layer ?? MemoryFileRegistry::LAYER_AGENT;
+
+		$dm      = new DirectoryManager();
+		$user_id = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
+
+		$target_dir = $this->resolveLayerDirectory( $dm, $target_layer, $user_id, (int) ( $input['agent_id'] ?? 0 ) );
 
 		if ( ! $dm->ensure_directory_exists( $target_dir ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'Failed to create agent directory',
+				'error'   => 'Failed to create target directory',
 			);
 		}
 
@@ -442,17 +467,21 @@ class AgentFileAbilities {
 			'datamachine_log',
 			'info',
 			'Agent file written via ability',
-			array( 'filename' => $filename )
+			array(
+				'filename' => $filename,
+				'layer'    => $target_layer,
+			)
 		);
 
 		return array(
 			'success'  => true,
 			'filename' => $filename,
+			'layer'    => $target_layer,
 		);
 	}
 
 	/**
-	 * Delete an agent file.
+	 * Delete a memory file.
 	 *
 	 * @param array $input Input parameters.
 	 * @return array Result with deletion status.
@@ -460,7 +489,7 @@ class AgentFileAbilities {
 	public function executeDeleteAgentFile( array $input ): array {
 		$filename = sanitize_file_name( $input['filename'] ?? '' );
 
-		if ( in_array( $filename, FileConstants::PROTECTED_FILES, true ) ) {
+		if ( MemoryFileRegistry::is_protected( $filename ) ) {
 			return array(
 				'success' => false,
 				'error'   => sprintf( 'Cannot delete protected file: %s', $filename ),
@@ -475,7 +504,7 @@ class AgentFileAbilities {
 		if ( ! $filepath ) {
 			return array(
 				'success' => false,
-				'error'   => sprintf( 'File %s not found in agent directory', $filename ),
+				'error'   => sprintf( 'File %s not found in any layer', $filename ),
 			);
 		}
 
@@ -494,12 +523,12 @@ class AgentFileAbilities {
 
 		return array(
 			'success' => true,
-			'message' => sprintf( 'File %s deleted from agent directory', $filename ),
+			'message' => sprintf( 'File %s deleted', $filename ),
 		);
 	}
 
 	/**
-	 * Upload a file to the agent memory directory.
+	 * Upload a file to a memory layer directory.
 	 *
 	 * @param array $input Input parameters.
 	 * @return array Result with updated file list.
@@ -514,28 +543,26 @@ class AgentFileAbilities {
 			);
 		}
 
-		$dm        = new DirectoryManager();
-		$user_id   = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
-		$agent_id  = (int) ( $input['agent_id'] ?? 0 );
-		$agent_dir = $dm->resolve_agent_directory( array(
-			'agent_id' => $agent_id,
-			'user_id'  => $user_id,
-		) );
+		$dm           = new DirectoryManager();
+		$user_id      = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
+		$agent_id     = (int) ( $input['agent_id'] ?? 0 );
+		$target_layer = $input['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
+		$target_dir   = $this->resolveLayerDirectory( $dm, $target_layer, $user_id, $agent_id );
 
-		if ( ! $dm->ensure_directory_exists( $agent_dir ) ) {
+		if ( ! $dm->ensure_directory_exists( $target_dir ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'Failed to create agent directory',
+				'error'   => 'Failed to create target directory',
 			);
 		}
 
-		$destination = "{$agent_dir}/{$file['name']}";
+		$destination = "{$target_dir}/{$file['name']}";
 
 		$fs = FilesystemHelper::get();
 		if ( ! $fs || ! $fs->copy( $file['tmp_name'], $destination, true ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'Failed to store file in agent directory',
+				'error'   => 'Failed to store file',
 			);
 		}
 
@@ -551,11 +578,13 @@ class AgentFileAbilities {
 	// =========================================================================
 
 	/**
-	 * Resolve a filename to its absolute path across agent layers.
+	 * Resolve a filename to its absolute path across layers.
 	 *
-	 * Checks the agent identity directory first, then the user directory.
+	 * For registered files, checks the registered layer first.
+	 * Falls back to: agent → user → shared.
 	 *
 	 * @since 0.41.0 Added $agent_id parameter for agent-first resolution.
+	 * @since 0.42.0 Registry-aware layer resolution.
 	 *
 	 * @param DirectoryManager $dm       Directory manager instance.
 	 * @param int              $user_id  Effective user ID.
@@ -568,23 +597,53 @@ class AgentFileAbilities {
 			'agent_id' => $agent_id,
 			'user_id'  => $user_id,
 		) );
-		$agent_path = $agent_dir . '/' . $filename;
-		if ( file_exists( $agent_path ) ) {
-			return $agent_path;
+		$user_dir   = $dm->get_user_directory( $user_id );
+		$shared_dir = $dm->get_shared_directory();
+
+		// If file is registered, check its canonical layer first.
+		$registered_layer = MemoryFileRegistry::get_layer( $filename );
+		if ( $registered_layer ) {
+			$primary_dir  = $this->resolveLayerDirectory( $dm, $registered_layer, $user_id, $agent_id );
+			$primary_path = $primary_dir . '/' . $filename;
+			if ( file_exists( $primary_path ) ) {
+				return $primary_path;
+			}
 		}
 
-		$user_path = $dm->get_user_directory( $user_id ) . '/' . $filename;
-		if ( file_exists( $user_path ) ) {
-			return $user_path;
-		}
-
-		// Shared layer (site-wide files like SITE.md).
-		$shared_path = $dm->get_shared_directory() . '/' . $filename;
-		if ( file_exists( $shared_path ) ) {
-			return $shared_path;
+		// Fallback: check all layers (agent → user → shared).
+		$search_order = array( $agent_dir, $user_dir, $shared_dir );
+		foreach ( $search_order as $dir ) {
+			$path = $dir . '/' . $filename;
+			if ( file_exists( $path ) ) {
+				return $path;
+			}
 		}
 
 		return null;
+	}
+
+	/**
+	 * Resolve a layer identifier to its directory path.
+	 *
+	 * @param DirectoryManager $dm        Directory manager instance.
+	 * @param string           $layer     Layer identifier ('shared', 'agent', 'user').
+	 * @param int              $user_id   Effective user ID.
+	 * @param int              $agent_id  Agent ID.
+	 * @return string Directory path.
+	 */
+	private function resolveLayerDirectory( DirectoryManager $dm, string $layer, int $user_id, int $agent_id = 0 ): string {
+		switch ( $layer ) {
+			case MemoryFileRegistry::LAYER_SHARED:
+				return $dm->get_shared_directory();
+			case MemoryFileRegistry::LAYER_USER:
+				return $dm->get_user_directory( $user_id );
+			case MemoryFileRegistry::LAYER_AGENT:
+			default:
+				return $dm->resolve_agent_directory( array(
+					'agent_id' => $agent_id,
+					'user_id'  => $user_id,
+				) );
+		}
 	}
 
 	/**
@@ -609,5 +668,16 @@ class AgentFileAbilities {
 		}
 
 		return $sanitized;
+	}
+
+	/**
+	 * Derive a human-readable label from a filename.
+	 *
+	 * @param string $filename The filename.
+	 * @return string Label.
+	 */
+	private static function filename_to_label( string $filename ): string {
+		$name = pathinfo( $filename, PATHINFO_FILENAME );
+		return ucwords( str_replace( array( '-', '_' ), ' ', $name ) );
 	}
 }

--- a/inc/Abilities/File/FileConstants.php
+++ b/inc/Abilities/File/FileConstants.php
@@ -1,27 +1,88 @@
 <?php
 /**
- * Shared constants for file abilities.
+ * Shared constants and helpers for file abilities.
+ *
+ * Protection and layer routing are now driven by the MemoryFileRegistry.
+ * The static methods here provide a stable API for consumers that need
+ * to check protection status or layer routing without importing the
+ * registry directly.
  *
  * @package DataMachine\Abilities\File
  * @since   0.38.0
+ * @since   0.42.0 Delegated to MemoryFileRegistry for protection and layer.
  */
 
 namespace DataMachine\Abilities\File;
+
+use DataMachine\Engine\AI\MemoryFileRegistry;
 
 defined( 'ABSPATH' ) || exit;
 
 class FileConstants {
 
 	/**
-	 * Core agent identity files that cannot be deleted.
+	 * Check if a file is protected from deletion.
 	 *
-	 * @var string[]
+	 * @param string $filename Filename to check.
+	 * @return bool
 	 */
-	const PROTECTED_FILES = array( 'SOUL.md', 'MEMORY.md' );
+	public static function is_protected( string $filename ): bool {
+		return MemoryFileRegistry::is_protected( $filename );
+	}
 
 	/**
-	 * Files that belong in the user layer rather than the agent identity layer.
+	 * Get all protected filenames.
 	 *
+	 * @return string[]
+	 */
+	public static function get_protected_files(): array {
+		return MemoryFileRegistry::get_protected_filenames();
+	}
+
+	/**
+	 * Get the layer a file belongs to, or null if not registered.
+	 *
+	 * @param string $filename Filename to check.
+	 * @return string|null 'shared', 'agent', 'user', or null.
+	 */
+	public static function get_layer( string $filename ): ?string {
+		return MemoryFileRegistry::get_layer( $filename );
+	}
+
+	/**
+	 * Check if a file belongs to the user layer.
+	 *
+	 * @param string $filename Filename to check.
+	 * @return bool
+	 */
+	public static function is_user_layer( string $filename ): bool {
+		return MemoryFileRegistry::LAYER_USER === MemoryFileRegistry::get_layer( $filename );
+	}
+
+	/**
+	 * Check if a file belongs to the shared layer.
+	 *
+	 * @param string $filename Filename to check.
+	 * @return bool
+	 */
+	public static function is_shared_layer( string $filename ): bool {
+		return MemoryFileRegistry::LAYER_SHARED === MemoryFileRegistry::get_layer( $filename );
+	}
+
+	/**
+	 * Legacy constant — kept for backward compatibility.
+	 * Use is_protected() or get_protected_files() instead.
+	 *
+	 * @deprecated 0.42.0 Use FileConstants::is_protected() or MemoryFileRegistry::is_protected().
+	 * @var string[]
+	 */
+	const PROTECTED_FILES = array( 'SOUL.md', 'MEMORY.md', 'SITE.md', 'RULES.md', 'USER.md' );
+
+	/**
+	 * Legacy constant — kept for backward compatibility.
+	 * Use is_user_layer() or get_layer() instead.
+	 *
+	 * @deprecated 0.42.0 Use FileConstants::is_user_layer() or MemoryFileRegistry::get_layer().
 	 * @var string[]
 	 */
 	const USER_LAYER_FILES = array( 'USER.md' );

--- a/inc/Api/AgentFiles.php
+++ b/inc/Api/AgentFiles.php
@@ -324,7 +324,7 @@ class AgentFiles {
 		$filename = sanitize_file_name( wp_unslash( $request['filename'] ) );
 
 		// Defense-in-depth: block deletion of protected files at the REST layer.
-		if ( in_array( $filename, FileConstants::PROTECTED_FILES, true ) ) {
+		if ( FileConstants::is_protected( $filename ) ) {
 			return new WP_Error(
 				'delete_agent_file_error',
 				sprintf( 'Cannot delete protected file: %s', $filename ),

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
@@ -24,7 +24,6 @@ import {
 } from '../queries/agentFiles';
 
 const SOUL_FILE = 'SOUL.md';
-const PROTECTED_FILES = [ 'SOUL.md', 'MEMORY.md' ];
 
 /**
  * Format bytes to human-readable size.
@@ -398,7 +397,7 @@ const AgentFileList = ( { selectedFile, onSelectFile } ) => {
 												) }` }
 										</span>
 									</div>
-									{ ! PROTECTED_FILES.includes( file.filename ) && ! isShared && (
+									{ ! file.protected && ! isShared && (
 										<button
 											className="datamachine-agent-file-item-delete"
 											title={ `Delete ${ file.filename }` }

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/MemoryFilesSelector.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/MemoryFilesSelector.jsx
@@ -20,9 +20,12 @@ import { useAgentFiles } from '../../queries/pipelines';
 import DailyMemorySelector from './DailyMemorySelector';
 
 /**
- * Files to exclude from the memory files picker (always injected separately).
+ * Core registered files are always injected at Priority 20 by
+ * CoreMemoryFilesDirective. The picker only shows additional files
+ * that pipelines/flows can opt into. We filter using the `registered`
+ * flag from the API response — registered files with `protected: true`
+ * are always-injected core files and should be excluded from the picker.
  */
-const EXCLUDED_FILES = [ 'SOUL.md', 'USER.md', 'MEMORY.md' ];
 
 /**
  * Default daily memory config.
@@ -67,11 +70,13 @@ export default function MemoryFilesSelector( {
 
 	const loading = loadingAgent || loadingSelected;
 
-	// Filter out core files, non-text files, and daily_summary type.
+	// Filter out always-injected core files, non-text files, and daily_summary type.
+	// Core files (registered + protected) are always injected at Priority 20.
 	const availableFiles = agentFiles
 		.filter( ( f ) => f.type !== 'daily_summary' )
+		.filter( ( f ) => ! ( f.registered && f.protected ) )
 		.map( ( f ) => ( typeof f === 'string' ? f : f.name || f.filename ) )
-		.filter( ( name ) => name && ! EXCLUDED_FILES.includes( name ) );
+		.filter( Boolean );
 
 	const handleToggle = ( filename, checked ) => {
 		setLocalSelected( ( prev ) =>

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -2,10 +2,12 @@
 /**
  * Core Memory Files Directive - Priority 20
  *
- * Loads core memory files from three directory layers and injects them
- * into every AI call: SITE.md + RULES.md (shared), SOUL.md + MEMORY.md
- * (agent), USER.md (user). Custom files from the MemoryFileRegistry are
- * loaded separately from the agent directory.
+ * Loads memory files from the MemoryFileRegistry and injects them into
+ * every AI call. Files are resolved to their layer directories:
+ *   shared → agents/{slug} → users/{id}
+ *
+ * The registry is the single source of truth for which files exist,
+ * what layer they belong to, and what order they load in.
  *
  * Priority Order in Directive System:
  * 1. Priority 10 - Plugin Core Directive (agent identity)
@@ -18,6 +20,7 @@
  *
  * @package DataMachine\Engine\AI\Directives
  * @since   0.30.0
+ * @since   0.42.0 Driven entirely by MemoryFileRegistry with layer resolution.
  */
 
 namespace DataMachine\Engine\AI\Directives;
@@ -45,69 +48,25 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 
 		$directory_manager = new DirectoryManager();
 		$user_id           = $directory_manager->get_effective_user_id( (int) ( $payload['user_id'] ?? 0 ) );
-		$shared_dir        = $directory_manager->get_shared_directory();
-		$agent_dir         = $directory_manager->resolve_agent_directory( array(
-			'agent_id' => (int) ( $payload['agent_id'] ?? 0 ),
-			'user_id'  => $user_id,
-		) );
-		$user_dir          = $directory_manager->get_user_directory( $user_id );
-		$outputs           = array();
 
-		$core_layer_files = array(
-			// Site layer.
-			array(
-				'directory' => $shared_dir,
-				'filename'  => 'SITE.md',
-			),
-			array(
-				'directory' => $shared_dir,
-				'filename'  => 'RULES.md',
-			),
-
-			// Agent layer.
-			array(
-				'directory' => $agent_dir,
-				'filename'  => 'SOUL.md',
-			),
-			array(
-				'directory' => $agent_dir,
-				'filename'  => 'MEMORY.md',
-			),
-
-			// User layer.
-			array(
-				'directory' => $user_dir,
-				'filename'  => 'USER.md',
-			),
+		// Resolve layer directories once.
+		$layer_dirs = array(
+			MemoryFileRegistry::LAYER_SHARED => $directory_manager->get_shared_directory(),
+			MemoryFileRegistry::LAYER_AGENT  => $directory_manager->resolve_agent_directory( array(
+				'agent_id' => (int) ( $payload['agent_id'] ?? 0 ),
+				'user_id'  => $user_id,
+			) ),
+			MemoryFileRegistry::LAYER_USER   => $directory_manager->get_user_directory( $user_id ),
 		);
 
-		foreach ( $core_layer_files as $entry ) {
-			$filepath = trailingslashit( $entry['directory'] ) . $entry['filename'];
+		$outputs = array();
 
-			if ( ! file_exists( $filepath ) ) {
-				continue;
-			}
+		// Load all registered files, resolved to their layer directory.
+		foreach ( MemoryFileRegistry::get_all() as $filename => $meta ) {
+			$layer = $meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
+			$dir   = $layer_dirs[ $layer ] ?? $layer_dirs[ MemoryFileRegistry::LAYER_AGENT ];
 
-			$content = self::get_file_content_for_output( $filepath, $entry['filename'] );
-			if ( null === $content ) {
-				continue;
-			}
-
-			$outputs[] = array(
-				'type'    => 'system_text',
-				'content' => $content,
-			);
-		}
-
-		// Backward-compatible extension point: custom registered memory files
-		// are loaded from the agent identity layer.
-		$custom_files = array_diff(
-			MemoryFileRegistry::get_filenames(),
-			array( 'SOUL.md', 'USER.md', 'MEMORY.md' )
-		);
-
-		foreach ( $custom_files as $filename ) {
-			$filepath = trailingslashit( $agent_dir ) . $filename;
+			$filepath = trailingslashit( $dir ) . $filename;
 
 			if ( ! file_exists( $filepath ) ) {
 				continue;

--- a/inc/Engine/AI/Directives/MemoryFilesReader.php
+++ b/inc/Engine/AI/Directives/MemoryFilesReader.php
@@ -6,22 +6,33 @@
  * Used by both PipelineMemoryFilesDirective and FlowMemoryFilesDirective
  * to avoid duplicating the file-reading logic.
  *
+ * Resolves each file to the correct layer directory using the
+ * MemoryFileRegistry. Falls back to the agent directory for
+ * unregistered files (backward compatibility).
+ *
  * @package DataMachine\Engine\AI\Directives
+ * @since   0.37.0
+ * @since   0.42.0 Layer-aware resolution via MemoryFileRegistry.
  */
 
 namespace DataMachine\Engine\AI\Directives;
 
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Engine\AI\MemoryFileRegistry;
 
 defined( 'ABSPATH' ) || exit;
 
 class MemoryFilesReader {
 
 	/**
-	 * Read memory files from the agent directory and produce directive outputs.
+	 * Read memory files and produce directive outputs.
+	 *
+	 * Each file is resolved to the directory matching its registered layer.
+	 * Unregistered files fall back to the agent directory.
 	 *
 	 * @since 0.37.0 Added $user_id parameter for multi-agent partitioning.
 	 * @since 0.41.0 Added $agent_id parameter for agent-first resolution.
+	 * @since 0.42.0 Layer-aware resolution via MemoryFileRegistry.
 	 *
 	 * @param array  $memory_files Array of memory filenames.
 	 * @param string $scope_label  Label for logging (e.g. 'Pipeline', 'Flow').
@@ -38,15 +49,27 @@ class MemoryFilesReader {
 
 		$directory_manager = new DirectoryManager();
 		$user_id           = $directory_manager->get_effective_user_id( $user_id );
-		$agent_dir         = $directory_manager->resolve_agent_directory( array(
-			'agent_id' => $agent_id,
-			'user_id'  => $user_id,
-		) );
-		$outputs           = array();
+
+		// Resolve all layer directories once.
+		$layer_dirs = array(
+			MemoryFileRegistry::LAYER_SHARED => $directory_manager->get_shared_directory(),
+			MemoryFileRegistry::LAYER_AGENT  => $directory_manager->resolve_agent_directory( array(
+				'agent_id' => $agent_id,
+				'user_id'  => $user_id,
+			) ),
+			MemoryFileRegistry::LAYER_USER   => $directory_manager->get_user_directory( $user_id ),
+		);
+
+		$outputs = array();
 
 		foreach ( $memory_files as $filename ) {
 			$safe_filename = sanitize_file_name( $filename );
-			$filepath      = "{$agent_dir}/{$safe_filename}";
+
+			// Resolve directory from registry layer, fall back to agent dir.
+			$layer = MemoryFileRegistry::get_layer( $safe_filename );
+			$dir   = $layer_dirs[ $layer ?? MemoryFileRegistry::LAYER_AGENT ];
+
+			$filepath = "{$dir}/{$safe_filename}";
 
 			if ( ! file_exists( $filepath ) ) {
 				do_action(
@@ -56,6 +79,7 @@ class MemoryFilesReader {
 					array(
 						'filename' => $safe_filename,
 						'scope_id' => $scope_id,
+						'layer'    => $layer ?? 'agent (fallback)',
 					)
 				);
 				continue;

--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -3,11 +3,17 @@
  * Memory File Registry
  *
  * Central registry for agent memory files injected into AI calls.
- * Pure container — no hardcoded files. Everything registers through
- * the same public API.
+ * Each file has a layer (shared, agent, user), priority, protection
+ * status, and optional metadata. Core files register through the same
+ * API that plugins and themes use.
+ *
+ * Extension point: the `datamachine_memory_files` filter fires once
+ * per request when the registry is first consumed, allowing third
+ * parties to register additional files.
  *
  * @package DataMachine\Engine\AI
  * @since   0.30.0
+ * @since   0.42.0 Added layer-aware registration with metadata.
  */
 
 namespace DataMachine\Engine\AI;
@@ -17,27 +23,63 @@ defined( 'ABSPATH' ) || exit;
 class MemoryFileRegistry {
 
 	/**
+	 * Valid layer identifiers.
+	 */
+	const LAYER_SHARED = 'shared';
+	const LAYER_AGENT  = 'agent';
+	const LAYER_USER   = 'user';
+
+	/**
 	 * Registered memory files.
 	 *
-	 * @var array<string, int> Filename => priority.
+	 * @var array<string, array> Filename => file metadata.
 	 */
 	private static array $files = array();
 
 	/**
+	 * Whether the filter has been applied.
+	 *
+	 * @var bool
+	 */
+	private static bool $filter_applied = false;
+
+	/**
 	 * Register a memory file.
 	 *
-	 * @param string $filename Filename relative to the agent directory.
-	 * @param int    $priority Sort order. Lower numbers load first.
+	 * @since 0.42.0 Accepts $args array with layer, protected, label, description.
+	 *
+	 * @param string    $filename Filename (e.g. 'SOUL.md', 'brand-guidelines.md').
+	 * @param int       $priority Sort order. Lower numbers load first.
+	 * @param array     $args     {
+	 *     Optional. Registration arguments.
+	 *
+	 *     @type string $layer       One of 'shared', 'agent', 'user'. Default 'agent'.
+	 *     @type bool   $protected   Whether the file is protected from deletion. Default false.
+	 *     @type string $label       Human-readable display label. Default derived from filename.
+	 *     @type string $description Optional description of the file's purpose.
+	 * }
 	 * @return void
 	 */
-	public static function register( string $filename, int $priority = 50 ): void {
+	public static function register( string $filename, int $priority = 50, array $args = array() ): void {
 		$filename = sanitize_file_name( $filename );
 
 		if ( empty( $filename ) ) {
 			return;
 		}
 
-		self::$files[ $filename ] = $priority;
+		$layer = $args['layer'] ?? self::LAYER_AGENT;
+		if ( ! in_array( $layer, array( self::LAYER_SHARED, self::LAYER_AGENT, self::LAYER_USER ), true ) ) {
+			$layer = self::LAYER_AGENT;
+		}
+
+		self::$files[ $filename ] = array(
+			'filename'    => $filename,
+			'priority'    => $priority,
+			'layer'       => $layer,
+			'protected'   => (bool) ( $args['protected'] ?? false ),
+			'label'       => $args['label'] ?? self::filename_to_label( $filename ),
+			'description' => $args['description'] ?? '',
+		);
 	}
 
 	/**
@@ -57,18 +99,52 @@ class MemoryFileRegistry {
 	 * @return bool
 	 */
 	public static function is_registered( string $filename ): bool {
-		return isset( self::$files[ sanitize_file_name( $filename ) ] );
+		$resolved = self::get_resolved();
+		return isset( $resolved[ sanitize_file_name( $filename ) ] );
+	}
+
+	/**
+	 * Check if a file is protected from deletion.
+	 *
+	 * @param string $filename Filename to check.
+	 * @return bool
+	 */
+	public static function is_protected( string $filename ): bool {
+		$resolved = self::get_resolved();
+		$filename = sanitize_file_name( $filename );
+		return isset( $resolved[ $filename ] ) && $resolved[ $filename ]['protected'];
+	}
+
+	/**
+	 * Get the layer for a registered file.
+	 *
+	 * @param string $filename Filename to look up.
+	 * @return string|null Layer identifier, or null if not registered.
+	 */
+	public static function get_layer( string $filename ): ?string {
+		$resolved = self::get_resolved();
+		$filename = sanitize_file_name( $filename );
+		return $resolved[ $filename ]['layer'] ?? null;
+	}
+
+	/**
+	 * Get metadata for a single file.
+	 *
+	 * @param string $filename Filename to look up.
+	 * @return array|null File metadata, or null if not registered.
+	 */
+	public static function get( string $filename ): ?array {
+		$resolved = self::get_resolved();
+		return $resolved[ sanitize_file_name( $filename ) ] ?? null;
 	}
 
 	/**
 	 * Get all registered files sorted by priority.
 	 *
-	 * @return array<string, int> Filename => priority, sorted ascending.
+	 * @return array<string, array> Filename => metadata, sorted by priority ascending.
 	 */
 	public static function get_all(): array {
-		$files = self::$files;
-		asort( $files );
-		return $files;
+		return self::get_resolved();
 	}
 
 	/**
@@ -77,7 +153,48 @@ class MemoryFileRegistry {
 	 * @return string[]
 	 */
 	public static function get_filenames(): array {
-		return array_keys( self::get_all() );
+		return array_keys( self::get_resolved() );
+	}
+
+	/**
+	 * Get all files for a specific layer.
+	 *
+	 * @param string $layer Layer identifier ('shared', 'agent', 'user').
+	 * @return array<string, array> Filtered and sorted file metadata.
+	 */
+	public static function get_by_layer( string $layer ): array {
+		return array_filter(
+			self::get_resolved(),
+			function ( $meta ) use ( $layer ) {
+				return $meta['layer'] === $layer;
+			}
+		);
+	}
+
+	/**
+	 * Get all protected filenames.
+	 *
+	 * @return string[]
+	 */
+	public static function get_protected_filenames(): array {
+		return array_keys(
+			array_filter(
+				self::get_resolved(),
+				function ( $meta ) {
+					return $meta['protected'];
+				}
+			)
+		);
+	}
+
+	/**
+	 * Get filenames that belong to a specific layer.
+	 *
+	 * @param string $layer Layer identifier.
+	 * @return string[]
+	 */
+	public static function get_layer_filenames( string $layer ): array {
+		return array_keys( self::get_by_layer( $layer ) );
 	}
 
 	/**
@@ -86,6 +203,55 @@ class MemoryFileRegistry {
 	 * @return void
 	 */
 	public static function reset(): void {
-		self::$files = array();
+		self::$files          = array();
+		self::$filter_applied = false;
+	}
+
+	/**
+	 * Get the resolved registry (with filter applied).
+	 *
+	 * The `datamachine_memory_files` filter fires once per request,
+	 * allowing plugins/themes to register additional files.
+	 *
+	 * @return array<string, array> Sorted by priority ascending.
+	 */
+	private static function get_resolved(): array {
+		if ( ! self::$filter_applied ) {
+			/**
+			 * Filter the memory file registry.
+			 *
+			 * Third parties can add files by calling MemoryFileRegistry::register()
+			 * inside this filter callback. The $files array is the current state
+			 * of the registry for inspection — modifications to the array itself
+			 * are ignored; use the register/deregister API instead.
+			 *
+			 * @since 0.42.0
+			 *
+			 * @param array<string, array> $files Current registry state (read-only snapshot).
+			 */
+			do_action( 'datamachine_memory_files', self::$files );
+			self::$filter_applied = true;
+		}
+
+		$files = self::$files;
+		uasort(
+			$files,
+			function ( $a, $b ) {
+				return $a['priority'] <=> $b['priority'];
+			}
+		);
+
+		return $files;
+	}
+
+	/**
+	 * Derive a human-readable label from a filename.
+	 *
+	 * @param string $filename The filename.
+	 * @return string Label.
+	 */
+	private static function filename_to_label( string $filename ): string {
+		$name = pathinfo( $filename, PATHINFO_FILENAME );
+		return ucwords( str_replace( array( '-', '_' ), ' ', $name ) );
 	}
 }

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -55,13 +55,47 @@ require_once __DIR__ . '/Engine/AI/Directives/CoreMemoryFilesDirective.php';
 |--------------------------------------------------------------------------
 | Default memory file registrations
 |--------------------------------------------------------------------------
-| These register through the same API any plugin or theme would use.
-| Nothing special about them — they're just the defaults.
+| Core files register through the same API any plugin or theme would use.
+| Each specifies its layer, protection status, and metadata.
 */
 
-\DataMachine\Engine\AI\MemoryFileRegistry::register( 'SOUL.md', 10 );
-\DataMachine\Engine\AI\MemoryFileRegistry::register( 'USER.md', 20 );
-\DataMachine\Engine\AI\MemoryFileRegistry::register( 'MEMORY.md', 30 );
+use DataMachine\Engine\AI\MemoryFileRegistry;
+
+// Shared layer — site-wide context, visible to all agents.
+MemoryFileRegistry::register( 'SITE.md', 10, array(
+	'layer'       => MemoryFileRegistry::LAYER_SHARED,
+	'protected'   => true,
+	'label'       => 'Site Context',
+	'description' => 'Site-wide context shared by all agents.',
+) );
+MemoryFileRegistry::register( 'RULES.md', 15, array(
+	'layer'       => MemoryFileRegistry::LAYER_SHARED,
+	'protected'   => true,
+	'label'       => 'Site Rules',
+	'description' => 'Behavioral constraints that apply to every agent.',
+) );
+
+// Agent layer — identity and knowledge, scoped to a single agent.
+MemoryFileRegistry::register( 'SOUL.md', 20, array(
+	'layer'       => MemoryFileRegistry::LAYER_AGENT,
+	'protected'   => true,
+	'label'       => 'Agent Identity',
+	'description' => 'Agent identity, voice, rules. Rarely changes.',
+) );
+MemoryFileRegistry::register( 'MEMORY.md', 30, array(
+	'layer'       => MemoryFileRegistry::LAYER_AGENT,
+	'protected'   => true,
+	'label'       => 'Agent Memory',
+	'description' => 'Accumulated knowledge. Grows over time.',
+) );
+
+// User layer — human preferences, visible to all agents for this user.
+MemoryFileRegistry::register( 'USER.md', 25, array(
+	'layer'       => MemoryFileRegistry::LAYER_USER,
+	'protected'   => true,
+	'label'       => 'User Profile',
+	'description' => 'Information about the human the agent works with.',
+) );
 // SiteContext is autoloaded (Core\WordPress\SiteContext) — register its cache invalidation hook here.
 add_action( 'init', array( \DataMachine\Core\WordPress\SiteContext::class, 'register_cache_invalidation' ) );
 require_once __DIR__ . '/Api/Chat/ChatAgentDirective.php';


### PR DESCRIPTION
## Summary

Memory files now follow the same registration pattern as handlers and step types: **rich metadata, WordPress hooks, and a single registry as the source of truth.**

- All three layers (shared, agent, user) are extensible — plugins can register files in any layer
- Core files register through the same API that third parties use — no special-casing
- Every file specifies its layer, protection status, label, and description
- `datamachine_memory_files` action hook provides the third-party extension point

## Before → After

```
Before: Hardcoded file lists in CoreMemoryFilesDirective, FileConstants,
        AgentFileList.jsx, and MemoryFilesSelector.jsx. Custom files
        only loaded from agent directory.

After:  Single MemoryFileRegistry with layer-aware metadata. Everything
        driven by the registry. Files resolved to correct layer directory
        at runtime.
```

## Architecture

```
┌──────────────────────────────────────────────────────────────────┐
│                    MemoryFileRegistry                            │
│  register('SITE.md',   10, {layer:'shared', protected:true})    │
│  register('SOUL.md',   20, {layer:'agent',  protected:true})    │
│  register('USER.md',   25, {layer:'user',   protected:true})    │
│  register('MEMORY.md', 30, {layer:'agent',  protected:true})    │
│  register('my-ctx.md', 60, {layer:'agent'})  ← plugin           │
│                                                                  │
│  Extension hook: do_action('datamachine_memory_files')           │
├──────────────┬───────────────────┬───────────────────────────────┤
│ Consumers:   │                   │                               │
│              ▼                   ▼                               ▼
│  CoreMemoryFilesDirective   MemoryFilesReader    AgentFileAbilities
│  (Priority 20 injection)    (Pipeline/Flow)      (CRUD + layer routing)
│                              Now layer-aware      Now layer-aware
└──────────────────────────────────────────────────────────────────┘
```

## Files changed (10)

| File | What changed |
|------|-------------|
| `MemoryFileRegistry.php` | Added layer, protected, label, description metadata + `datamachine_memory_files` action hook |
| `bootstrap.php` | All 5 core files now register with full metadata |
| `CoreMemoryFilesDirective.php` | Driven entirely by registry — no hardcoded file list |
| `MemoryFilesReader.php` | Resolves layer from registry (fixes: shared/user files now work in pipeline/flow selection) |
| `AgentFileAbilities.php` | Write/upload support `layer` parameter; delete uses registry protection |
| `FileConstants.php` | Delegates to registry; legacy constants kept for backward compat |
| `AgentFiles.php` (REST) | Uses `FileConstants::is_protected()` instead of `in_array()` |
| `AgentFileList.jsx` | Uses `file.protected` from API instead of hardcoded array |
| `MemoryFilesSelector.jsx` | Uses `registered + protected` flags from API instead of hardcoded `EXCLUDED_FILES` |
| `wordpress-as-agent-memory.md` | Updated extension docs with layer-aware registration examples |

## Key behavior changes

1. **Pipeline/flow memory file selection now works across all layers** — previously only loaded from agent directory, silently missing shared/user files
2. **All 5 core files are now protected from deletion** (previously only SOUL.md and MEMORY.md were)
3. **Write operations accept a `layer` parameter** — registered files route to their registered layer; new files can target any layer
4. **Frontend uses API metadata** instead of hardcoded file lists for protection and exclusion checks

## Testing

- PHP syntax: all 7 modified PHP files pass `php -l`
- PHPUnit: 873 passed, 26 failed (all pre-existing, none related to this PR)
- No existing tests for these components