### PR TITLE
fix: enable publish dedup by default, add source-URL dedup, forward pre-selected taxonomies

### DIFF
--- a/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php
+++ b/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php
@@ -20,6 +20,7 @@
 namespace DataMachine\Abilities\DuplicateCheck;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\WordPress\PostTracking;
 use DataMachine\Core\Similarity\SimilarityEngine;
 use DataMachine\Core\Similarity\SimilarityResult;
 
@@ -99,6 +100,10 @@ class DuplicateCheckAbility {
 							'type'        => 'number',
 							'description' => __( 'Jaccard similarity threshold for queue checks (default: 0.65)', 'data-machine' ),
 						),
+						'source_url'    => array(
+							'type'        => 'string',
+							'description' => __( 'Canonical source URL to check for exact-match duplicates before title similarity.', 'data-machine' ),
+						),
 						'context'       => array(
 							'type'        => 'object',
 							'description' => __( 'Domain-specific context for extension strategies (e.g., venue, startDate, ticketUrl for events)', 'data-machine' ),
@@ -139,6 +144,7 @@ class DuplicateCheckAbility {
 		$lookback_days = ! empty( $input['lookback_days'] ) ? (int) $input['lookback_days'] : 14;
 		$scope         = ! empty( $input['scope'] ) ? sanitize_text_field( $input['scope'] ) : 'published';
 		$threshold     = ! empty( $input['threshold'] ) ? (float) $input['threshold'] : SimilarityEngine::DEFAULT_JACCARD_THRESHOLD;
+		$source_url    = ! empty( $input['source_url'] ) ? esc_url_raw( $input['source_url'] ) : '';
 		$context       = $input['context'] ?? array();
 
 		if ( empty( $title ) ) {
@@ -181,6 +187,11 @@ class DuplicateCheckAbility {
 
 		// Phase 2: Core published-post title match.
 		if ( in_array( $scope, array( 'published', 'both' ), true ) ) {
+			$source_result = $this->checkPublishedPostsBySourceUrl( $source_url, $post_type, $lookback_days );
+			if ( null !== $source_result ) {
+				return $source_result;
+			}
+
 			$post_result = $this->checkPublishedPosts( $title, $post_type, $lookback_days );
 			if ( null !== $post_result ) {
 				return $post_result;
@@ -419,6 +430,85 @@ class DuplicateCheckAbility {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Check published posts for exact source URL matches.
+	 *
+	 * @param string $source_url    Canonical source URL.
+	 * @param string $post_type     Post type to search.
+	 * @param int    $lookback_days How many days back to search.
+	 * @return array|null Duplicate result or null if clear.
+	 */
+	private function checkPublishedPostsBySourceUrl( string $source_url, string $post_type, int $lookback_days ): ?array {
+		if ( empty( $source_url ) || empty( $post_type ) ) {
+			return null;
+		}
+
+		if ( $lookback_days <= 0 ) {
+			$lookback_days = 14;
+		}
+
+		$cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$lookback_days} days" ) );
+
+		$query = new \WP_Query(
+			array(
+				'post_type'      => $post_type,
+				'post_status'    => array( 'publish', 'draft', 'pending' ),
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'date_query'     => array(
+					array(
+						'after'     => $cutoff_date,
+						'inclusive' => true,
+					),
+				),
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Required for source URL dedup.
+				'meta_query'     => array(
+					array(
+						'key'   => PostTracking::SOURCE_URL_META_KEY,
+						'value' => $source_url,
+					),
+				),
+			)
+		);
+
+		if ( empty( $query->posts ) ) {
+			return null;
+		}
+
+		$candidate_id    = (int) $query->posts[0];
+		$candidate_title = get_the_title( $candidate_id );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'DuplicateCheck: found matching published post by source URL',
+			array(
+				'source_url'     => $source_url,
+				'existing_id'    => $candidate_id,
+				'existing_title' => $candidate_title,
+				'post_type'      => $post_type,
+			)
+		);
+
+		return array(
+			'verdict'  => 'duplicate',
+			'source'   => 'published_post_source_url',
+			'match'    => array(
+				'post_id'    => $candidate_id,
+				'title'      => $candidate_title,
+				'url'        => get_permalink( $candidate_id ),
+				'source_url' => $source_url,
+			),
+			'reason'   => sprintf(
+				'Rejected: source URL already exists on post "%s" (ID %d).',
+				$candidate_title,
+				$candidate_id
+			),
+			'strategy' => 'core_published_source_url',
+		);
 	}
 
 	/**

--- a/inc/Abilities/Publish/PublishWordPressAbility.php
+++ b/inc/Abilities/Publish/PublishWordPressAbility.php
@@ -11,6 +11,7 @@
 namespace DataMachine\Abilities\Publish;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\WordPress\PostTracking;
 use DataMachine\Core\WordPress\WordPressSettingsResolver;
 
 defined( 'ABSPATH' ) || exit;
@@ -318,6 +319,10 @@ class PublishWordPressAbility {
 					'published_url' => get_permalink( $post_id ),
 				)
 			);
+		}
+
+		if ( ! empty( $source_url ) ) {
+			update_post_meta( $post_id, PostTracking::SOURCE_URL_META_KEY, esc_url_raw( $source_url ) );
 		}
 
 		$logs[] = array(

--- a/inc/Core/Steps/Publish/Handlers/PublishHandlerSettings.php
+++ b/inc/Core/Steps/Publish/Handlers/PublishHandlerSettings.php
@@ -44,8 +44,8 @@ abstract class PublishHandlerSettings extends SettingsHandler {
 			'dedup_enabled'       => array(
 				'type'        => 'checkbox',
 				'label'       => __( 'Duplicate Detection', 'data-machine' ),
-				'description' => __( 'Skip publishing if a post with a similar title already exists. Prevents cross-flow duplicates when multiple flows process the same content.', 'data-machine' ),
-				'default'     => false,
+				'description' => __( 'Skip publishing if a post with a similar title or source URL already exists. Prevents duplicate posts from parallel jobs, cross-flow overlap, and retry scenarios. Enabled by default.', 'data-machine' ),
+				'default'     => true,
 			),
 			'dedup_lookback_days' => array(
 				'type'        => 'number',

--- a/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
@@ -106,19 +106,43 @@ class WordPress extends PublishHandler {
 
 				if ( SelectionMode::isAiDecides( $selection ) && ! empty( $parameters[ $taxonomy ] ) ) {
 					$taxonomies[ $taxonomy ] = $parameters[ $taxonomy ];
+				} elseif ( SelectionMode::isPreSelected( $selection ) ) {
+					$taxonomies[ $taxonomy ] = $selection;
 				}
 			}
 		}
 
-		// Duplicate detection — check before publishing
-		$dedup_enabled = ! empty( $handler_config['dedup_enabled'] );
+		// Duplicate detection — check before publishing (enabled by default)
+		$dedup_enabled = ! isset( $handler_config['dedup_enabled'] ) || ! empty( $handler_config['dedup_enabled'] );
 		if ( $dedup_enabled ) {
 			$title     = $parameters['title'] ?? '';
 			$post_type = $handler_config['post_type'] ?? '';
 
 			if ( ! empty( $title ) && ! empty( $post_type ) ) {
-				$lookback_days = (int) ( $handler_config['dedup_lookback_days'] ?? DuplicateDetection::DEFAULT_LOOKBACK_DAYS );
-				$existing_id   = DuplicateDetection::findExistingPostByTitle( $title, $post_type, $lookback_days );
+				$lookback_days   = (int) ( $handler_config['dedup_lookback_days'] ?? DuplicateDetection::DEFAULT_LOOKBACK_DAYS );
+				$duplicate_check = wp_get_ability( 'datamachine/check-duplicate' );
+				$source_url      = $engine->getSourceUrl();
+				$existing_id     = null;
+
+				if ( $duplicate_check ) {
+					$duplicate_result = $duplicate_check->execute(
+						array(
+							'title'         => $title,
+							'post_type'     => $post_type,
+							'lookback_days' => $lookback_days,
+							'scope'         => 'published',
+							'source_url'    => $source_url,
+						)
+					);
+
+					if ( is_array( $duplicate_result ) && 'duplicate' === ( $duplicate_result['verdict'] ?? '' ) ) {
+						$existing_id = (int) ( $duplicate_result['match']['post_id'] ?? 0 );
+					}
+				}
+
+				if ( ! $existing_id ) {
+					$existing_id = DuplicateDetection::findExistingPostByTitle( $title, $post_type, $lookback_days );
+				}
 
 				if ( $existing_id ) {
 					$this->log(
@@ -158,7 +182,7 @@ class WordPress extends PublishHandler {
 			'featured_image_path'    => $media['image_file_path'],
 			'featured_image_url'     => $media['image_url'],
 			'source_url'             => $engine->getSourceUrl(),
-			'add_source_attribution' => true,
+			'add_source_attribution' => 'append' === ( $handler_config['link_handling'] ?? 'append' ),
 			'job_id'                 => $parameters['job_id'] ?? null,
 		);
 

--- a/inc/Core/WordPress/PostTracking.php
+++ b/inc/Core/WordPress/PostTracking.php
@@ -31,6 +31,7 @@ class PostTracking {
 	public const HANDLER_META_KEY     = '_datamachine_post_handler';
 	public const FLOW_ID_META_KEY     = '_datamachine_post_flow_id';
 	public const PIPELINE_ID_META_KEY = '_datamachine_post_pipeline_id';
+	public const SOURCE_URL_META_KEY  = '_datamachine_source_url';
 
 	/**
 	 * Store post tracking metadata from tool call context.

--- a/tests/Unit/Abilities/DuplicateCheckAbilityTest.php
+++ b/tests/Unit/Abilities/DuplicateCheckAbilityTest.php
@@ -11,6 +11,7 @@
 namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\DuplicateCheck\DuplicateCheckAbility;
+use DataMachine\Core\WordPress\PostTracking;
 use WP_UnitTestCase;
 
 class DuplicateCheckAbilityTest extends WP_UnitTestCase {
@@ -148,6 +149,32 @@ class DuplicateCheckAbilityTest extends WP_UnitTestCase {
 		) );
 
 		$this->assertSame( 'duplicate', $result['verdict'] );
+	}
+
+	public function test_check_duplicate_finds_published_post_by_source_url(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Original Bonnaroo Story',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		update_post_meta( $post_id, PostTracking::SOURCE_URL_META_KEY, 'https://www.reddit.com/r/bonnaroo/comments/abc123/original_story/' );
+
+		$ability = wp_get_ability( 'datamachine/check-duplicate' );
+		$result  = $ability->execute(
+			array(
+				'title'      => 'Completely Rewritten Bonnaroo Headline',
+				'post_type'  => 'post',
+				'scope'      => 'published',
+				'source_url' => 'https://www.reddit.com/r/bonnaroo/comments/abc123/original_story/',
+			)
+		);
+
+		$this->assertSame( 'duplicate', $result['verdict'] );
+		$this->assertSame( 'published_post_source_url', $result['source'] );
+		$this->assertSame( $post_id, $result['match']['post_id'] );
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Publish dedup enabled by default** — `dedup_enabled` now defaults to `true` and treats missing config as enabled. No more opt-in malarkey.
- **Source URL dedup** — published posts store `_datamachine_source_url` meta. The `datamachine/check-duplicate` ability checks source URL before title similarity, preventing same-source republishing even with different AI-rewritten titles.
- **Pre-selected taxonomy forwarding** — the WordPress publish handler now passes pre-selected taxonomy selections (e.g., fixed festival/location assignments) through to the publish ability. Previously only `ai_decides` selections were forwarded.
- **Respects `link_handling` config** for source attribution instead of always appending.

## Root cause

Wire was publishing 3 copies of the same Reddit thread because:
1. Triple root jobs were spawned per scheduled run (fixed by batch_state_missing fix in v0.42.0)
2. Parallel fetches grabbed the same data before processed-items could mark it
3. Publish dedup was **disabled by default** so nothing caught it downstream
4. Pre-selected taxonomies were silently dropped, leaving ~300 Wire posts without festival/location

## Testing

- Added `test_check_duplicate_finds_published_post_by_source_url` to DuplicateCheckAbilityTest
- Syntax validated all changed files