### PR TITLE
fix: rewrite system task prompts to use injected memory instead of generic identity

### DIFF
--- a/inc/Api/System/SystemAgentDirective.php
+++ b/inc/Api/System/SystemAgentDirective.php
@@ -2,7 +2,7 @@
 /**
  * System Agent Directive
  *
- * System prompt defining system agent identity and capabilities for infrastructure operations.
+ * Operational context for system tasks. Identity comes from memory files (SOUL.md, etc.).
  *
  * @package DataMachine\Api\System
  * @since   0.13.7
@@ -38,17 +38,16 @@ class SystemAgentDirective implements \DataMachine\Engine\AI\Directives\Directiv
 	 * @return string System prompt
 	 */
 	private static function get_directive( $tools ): string {
-		$directive = '# Data Machine System Agent' . "\n\n"
-		. 'You are a system infrastructure specialist. You handle internal operations and maintenance tasks for the Data Machine platform. Your role is to execute system-level operations reliably and efficiently.' . "\n\n"
+		$directive = '# System Task Context' . "\n\n"
+		. 'This is a background system task — not a chat session. Your identity and knowledge are already loaded from your memory files above. Use that context.' . "\n\n"
+		. '## Task Behavior' . "\n\n"
+		. '- Execute the task described in the user message below.' . "\n"
+		. '- Return exactly what the task asks for — no extra commentary, no meta-discussion.' . "\n"
+		. '- Apply your knowledge of this site, its voice, and its conventions from your memory files.' . "\n\n"
 		. '## Session Title Generation' . "\n\n"
-		. 'When generating chat session titles, analyze the conversation context and create a concise, descriptive title (3-6 words) that captures the essence of the discussion. Focus on the user\'s intent and the assistant\'s response.' . "\n\n"
-		. 'Return ONLY the title text, nothing else. Keep titles under 100 characters. Make them descriptive but concise.' . "\n\n"
-		. 'Examples:' . "\n"
-		. '- User asks about API configuration → "API Configuration Help"' . "\n"
-		. '- User wants to create a workflow → "Workflow Creation Assistance"' . "\n"
-		. '- User reports an issue → "Bug Report Discussion"' . "\n\n"
+		. 'When asked to generate a chat session title: create a concise, descriptive title (3-6 words) capturing the discussion essence. Return ONLY the title text, under 100 characters.' . "\n\n"
 		. '## GitHub Issue Creation' . "\n\n"
-		. 'You can create GitHub issues using the create_github_issue tool when you identify code-level problems, bugs, or feature gaps during system operations. Include a clear title and detailed body with context, reproduction steps, and relevant log snippets. Use labels to categorize (e.g., "bug", "enhancement"). Route issues to the most appropriate repo based on context. Only create issues for genuine problems — never create duplicates.';
+		. 'When using create_github_issue: include a clear title and detailed body with context, reproduction steps, and relevant log snippets. Use labels to categorize. Route to the most appropriate repo. Never create duplicates.';
 
 		// List available repos dynamically.
 		if ( class_exists( '\DataMachine\Abilities\Fetch\GitHubAbilities' ) ) {
@@ -60,9 +59,6 @@ class SystemAgentDirective implements \DataMachine\Engine\AI\Directives\Directiv
 				}
 			}
 		}
-
-		$directive .= "\n\n" . '## System Operations' . "\n\n"
-		. 'Execute system tasks with precision. Log all operations appropriately. Handle errors gracefully and provide clear feedback.';
 
 		return $directive;
 	}

--- a/inc/Engine/AI/System/Tasks/AltTextTask.php
+++ b/inc/Engine/AI/System/Tasks/AltTextTask.php
@@ -181,12 +181,14 @@ class AltTextTask extends SystemTask {
 			'generate' => array(
 				'label'       => __( 'Alt Text Prompt', 'data-machine' ),
 				'description' => __( 'Prompt used to generate alt text for images.', 'data-machine' ),
-				'default'     => "Write alt text for the provided image using these guidelines:\n"
-					. "- Write 1-2 sentences describing the image\n"
+				'default'     => "Write alt text for this image.\n\n"
+					. "Guidelines:\n"
+					. "- 1-2 sentences describing the image\n"
 					. "- Don't start with 'Image of' or 'Photo of'\n"
 					. "- Capitalize first word, end with period\n"
-					. "- Describe what's visually present, focus on purpose\n"
-					. "- For complex images (charts/diagrams), provide brief summary only\n\n"
+					. "- Describe what's visually present, focus on its purpose in context\n"
+					. "- For charts/diagrams, provide a brief summary only\n"
+					. "- Match the voice and tone of this site\n\n"
 					. "Return ONLY the alt text, nothing else.\n\n"
 					. "Context:\n{{context}}",
 				'variables'   => array(

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -146,14 +146,13 @@ class DailyMemoryTask extends SystemTask {
 			'daily_summary'  => array(
 				'label'       => __( 'Daily Summary Prompt', 'data-machine' ),
 				'description' => __( 'Prompt used to synthesize a daily memory entry from the day\'s activity.', 'data-machine' ),
-				'default'     => "You are a system agent generating a daily memory entry for an AI agent's memory library.\n\n"
-					. "Below is a summary of today's activity on this WordPress site — jobs that ran, chat sessions that occurred, and their outcomes.\n\n"
-					. "Your task: Synthesize this into a concise, useful daily memory entry in markdown format. Focus on:\n"
-					. "- What happened (key events, not every job)\n"
-					. "- What was accomplished\n"
+				'default'     => "Write a daily memory entry from today's activity data below.\n\n"
+					. "This entry will be stored in your daily memory files — the ones you already know about from your memory. Write it as your own notes for future sessions.\n\n"
+					. "Focus on:\n"
+					. "- Key events and what was accomplished (not every individual job)\n"
 					. "- Notable outcomes, failures, or patterns worth remembering\n"
-					. "- Any context that would help a future agent session understand what this day was about\n\n"
-					. "Keep it concise — a few paragraphs at most. Use ### headings for sections if needed. Do NOT include raw job IDs or technical metadata. Write as if you're creating notes that a colleague would find useful tomorrow.\n\n"
+					. "- Context that would help you in a future session understand what today was about\n\n"
+					. "Keep it concise — a few paragraphs at most. Use ### headings if needed. Skip raw job IDs and technical metadata. Write in your own voice.\n\n"
 					. "---\n\n"
 					. "{{context}}",
 				'variables'   => array(
@@ -163,21 +162,18 @@ class DailyMemoryTask extends SystemTask {
 			'memory_cleanup' => array(
 				'label'       => __( 'Memory Cleanup Prompt', 'data-machine' ),
 				'description' => __( 'Prompt used to split MEMORY.md into persistent knowledge and session-specific content for archival.', 'data-machine' ),
-				'default'     => "You are maintaining an AI agent's MEMORY.md file. This file is injected into every AI context window, so it must stay lean — only persistent knowledge that helps across all future sessions.\n\n"
+				'default'     => "Clean up your MEMORY.md. You can see its current content in your system context above — it's the same file. It needs to stay lean because it's injected into every session.\n\n"
 					. "## Principle\n\n"
-					. "Ask yourself for each piece of content: \"Would a fresh session need this to do its job?\" If yes, it's persistent. If it only makes sense in the context of a specific session or time period, it should be archived.\n\n"
-					. "## Your Task\n\n"
-					. "Split the MEMORY.md content below into two parts:\n\n"
+					. "For each piece of content ask: \"Would a fresh session need this to do its job?\" If yes, keep it. If it only makes sense in the context of a specific session or time period, archive it.\n\n"
+					. "## Split into two parts:\n\n"
 					. "### PERSISTENT — stays in MEMORY.md\n"
-					. "Knowledge that is useful regardless of when or why the next session runs:\n"
 					. "- How things work (architecture, patterns, conventions)\n"
 					. "- Where things are (paths, URLs, config locations, tool names)\n"
-					. "- Current state of ongoing work (just the status, not the journey)\n"
+					. "- Current state of ongoing work (status, not the journey)\n"
 					. "- Rules and constraints learned from experience\n"
 					. "- Relationships between systems, people, and services\n\n"
-					. "When condensing, prefer the **lasting fact** over the **story of how we learned it**. Merge overlapping entries. Remove detail that duplicates what's already in daily files or source code.\n\n"
+					. "Prefer the **lasting fact** over the **story of how you learned it**. Merge overlapping entries. Remove detail that duplicates what's in daily files or source code.\n\n"
 					. "### ARCHIVED — moves to the daily file for {{date}}\n"
-					. "Content tied to a specific session, investigation, or moment in time:\n"
 					. "- Play-by-play narratives of what happened in a session\n"
 					. "- Debugging traces and investigation logs\n"
 					. "- Temporary state that will be outdated soon\n"

--- a/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
+++ b/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
@@ -345,10 +345,11 @@ class InternalLinkingTask extends SystemTask {
 			'insert_link' => array(
 				'label'       => __( 'Internal Link Insertion Prompt', 'data-machine' ),
 				'description' => __( 'Prompt used to weave internal links into existing paragraph text.', 'data-machine' ),
-				'default'     => "Here is a paragraph from a blog post. Weave in a link to the URL below by wrapping "
-					. "a relevant existing phrase in an anchor tag. Do NOT add new text or change meaning. "
-					. "Return ONLY the updated paragraph HTML. If no natural insertion point exists, "
-					. "return the paragraph unchanged.\n\n"
+				'default'     => "Weave an internal link into this paragraph by wrapping a relevant existing phrase in an anchor tag.\n\n"
+					. "Rules:\n"
+					. "- Do NOT add new text or change meaning\n"
+					. "- Return ONLY the updated paragraph HTML\n"
+					. "- If no natural insertion point exists, return the paragraph unchanged\n\n"
 					. "URL: {{url}}\n"
 					. "Title: {{title}}\n\n"
 					. "Paragraph:\n{{paragraph}}",

--- a/inc/Engine/AI/System/Tasks/MetaDescriptionTask.php
+++ b/inc/Engine/AI/System/Tasks/MetaDescriptionTask.php
@@ -191,14 +191,13 @@ class MetaDescriptionTask extends SystemTask {
 			'generate' => array(
 				'label'       => __( 'Meta Description Prompt', 'data-machine' ),
 				'description' => __( 'Prompt used to generate meta descriptions for posts.', 'data-machine' ),
-				'default'     => "Write a meta description for the following web page.\n\n"
+				'default'     => "Write a meta description for this page. Use your knowledge of this site's voice and audience.\n\n"
 					. "Guidelines:\n"
-					. '- Maximum ' . self::MAX_LENGTH . " characters (this is strict — do not exceed)\n"
+					. '- Maximum ' . self::MAX_LENGTH . " characters (strict limit)\n"
 					. "- Lead with the direct answer or hook — what will the reader learn or get?\n"
 					. "- Include the primary topic/keyword naturally\n"
 					. "- Create curiosity or value to encourage clicks\n"
-					. "- Do NOT duplicate the title — expand on it\n"
-					. "- Write in a warm, conversational tone\n"
+					. "- Don't duplicate the title — expand on it\n"
 					. "- No quotes around the description\n"
 					. "- One or two sentences\n\n"
 					. "Return ONLY the meta description text, nothing else.\n\n"


### PR DESCRIPTION
## Summary

- System tasks already receive SOUL.md, MEMORY.md, USER.md via `CoreMemoryFilesDirective` (contexts `['all']`), but the prompts were written as if the AI had zero context — re-introducing identity with generic "you are a system agent" framing that competed with the actual agent identity
- **SystemAgentDirective**: replaced "you are a system infrastructure specialist" with operational context that tells the AI its memory files are already loaded
- **DailyMemoryTask**: reframed from third-person "you are a system agent generating a daily memory entry for an AI agent's memory library" to first-person "write your own notes for future sessions"
- **Memory cleanup**: "clean up your MEMORY.md" instead of "you are maintaining an AI agent's MEMORY.md file"
- **AltTextTask / MetaDescriptionTask**: added "match the voice and tone of this site" / "use your knowledge of this site's voice" — actually leveraging the site knowledge that's already in the context
- **InternalLinkingTask**: tightened to direct task instructions

The core principle: **the memory files define who the agent is** — task prompts should give task instructions, not create a competing generic identity.