### PR TITLE
fix: resolve undefined $agent_id and $job_snapshot in AIStep::executeStep()

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -179,7 +179,9 @@ class AIStep extends Step {
 		$max_turns = PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
 
 		// Resolve user_id and agent_id from engine snapshot (set by RunFlowAbility).
-		$user_id = (int) ( $job_snapshot['user_id'] ?? 0 );
+		$job_snapshot = $this->engine->get( 'job' );
+		$agent_id     = (int) ( $job_snapshot['agent_id'] ?? 0 );
+		$user_id      = (int) ( $job_snapshot['user_id'] ?? 0 );
 
 		$payload = array(
 			'job_id'       => $this->job_id,


### PR DESCRIPTION
## Summary

- `$job_snapshot` and `$agent_id` were defined in `validateStepConfiguration()` but referenced in the separate method `executeStep()` without being re-defined
- PHP treated both as `null`, which silently broke two things:
  1. **Per-agent tool policies** — `ToolPolicyResolver` received `agent_id = 0`, skipping all agent-specific tool filtering
  2. **Per-agent model overrides** — `resolveModelForAgentContext()` received `null`, always returning global defaults instead of agent-specific model config
- Also caused PHP Warning noise in `debug.log` every 5 minutes (`Undefined variable $agent_id` on lines 220/227)

## Fix

Two lines added at the top of `executeStep()`, matching the exact pattern already used in `validateStepConfiguration()`:

```php
$job_snapshot = $this->engine->get( 'job' );
$agent_id     = (int) ( $job_snapshot['agent_id'] ?? 0 );
```

## Impact

- Eliminates PHP Warning log noise
- Enables per-agent tool policies to actually apply during pipeline AI execution
- Enables per-agent model overrides to work in pipeline context
- No behavioral change for flows without agent-specific config (they already fall through to global defaults)