### PR TITLE
fix: prevent AI step from creating ghost child jobs (#832)

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -319,17 +319,18 @@ class AIStep extends Step {
 	 * Process AI conversation loop results into data packets.
 	 *
 	 * Only emits actionable packets (handler completions, tool results) that
-	 * downstream steps depend on. Conversation turns are tracked as metadata
-	 * but not emitted as individual DataPackets — doing so causes the batch
-	 * scheduler to fan them out as ghost child jobs.
+	 * downstream steps depend on. Input DataPackets from previous steps are
+	 * NOT carried forward — they already served their purpose as AI conversation
+	 * input, and including them causes the batch scheduler to fan them out as
+	 * ghost child jobs that fail at the next step.
 	 *
 	 * @param array $loop_result Results from AIConversationLoop
-	 * @param array $dataPackets Current data packet array
+	 * @param array $inputDataPackets Input data packets (used for metadata extraction only)
 	 * @param array $payload Step payload
 	 * @param array $available_tools Tools available during conversation
-	 * @return array Updated data packet array
+	 * @return array Output data packets (tool results only, not input packets)
 	 */
-	private static function processLoopResults( array $loop_result, array $dataPackets, array $payload, array $available_tools ): array {
+	private static function processLoopResults( array $loop_result, array $inputDataPackets, array $payload, array $available_tools ): array {
 		if ( ! isset( $payload['flow_step_id'] ) || empty( $payload['flow_step_id'] ) ) {
 			throw new \InvalidArgumentException( 'Flow step ID is required in AI step payload' );
 		}
@@ -337,6 +338,9 @@ class AIStep extends Step {
 		$flow_step_id           = $payload['flow_step_id'];
 		$messages               = $loop_result['messages'] ?? array();
 		$tool_execution_results = $loop_result['tool_execution_results'] ?? array();
+
+		// Start with an empty output array — input packets are NOT carried forward.
+		$outputPackets = array();
 
 		// Count conversation turns for metadata (not emitted as packets).
 		$turn_count        = 0;
@@ -353,9 +357,12 @@ class AIStep extends Step {
 			}
 		}
 
-		// Process tool execution results into data packets.
+		// Process tool execution results into output packets.
 		// Only handler completions and tool results are emitted — these are
 		// consumed by downstream steps (PublishStep, UpdateStep) via ToolResultFinder.
+		// Input DataPackets are NOT included — they cause ghost child jobs.
+		$input_source_type = $inputDataPackets[0]['metadata']['source_type'] ?? 'unknown';
+
 		foreach ( $tool_execution_results as $tool_result_data ) {
 			$tool_name         = $tool_result_data['tool_name'] ?? '';
 			$tool_result       = $tool_result_data['result'] ?? array();
@@ -379,7 +386,7 @@ class AIStep extends Step {
 					unset( $clean_tool_parameters[ $handler_key ] );
 				}
 
-				$packet      = new DataPacket(
+				$packet        = new DataPacket(
 					array(
 						'title' => 'Handler Tool Executed: ' . $tool_name,
 						'body'  => 'Tool executed successfully by AI agent in ' . $result_turn_count . ' conversation turns',
@@ -389,21 +396,21 @@ class AIStep extends Step {
 						'handler_tool'      => $tool_def['handler'] ?? null,
 						'tool_parameters'   => $clean_tool_parameters,
 						'handler_config'    => $handler_config,
-						'source_type'       => $dataPackets[0]['metadata']['source_type'] ?? 'unknown',
+						'source_type'       => $input_source_type,
 						'flow_step_id'      => $flow_step_id,
 						'conversation_turn' => $result_turn_count,
 						'tool_result'       => $tool_result,
 					),
 					'ai_handler_complete'
 				);
-				$dataPackets = $packet->addTo( $dataPackets );
+				$outputPackets = $packet->addTo( $outputPackets );
 
 				$handler_completed = true;
 			} else {
 				// Non-handler tool or failed tool - add tool result data packet
 				$success_message = ConversationManager::generateSuccessMessage( $tool_name, $tool_result, $tool_parameters );
 
-				$packet      = new DataPacket(
+				$packet        = new DataPacket(
 					array(
 						'title' => ucwords( str_replace( '_', ' ', $tool_name ) ) . ' Result',
 						'body'  => $success_message,
@@ -414,21 +421,21 @@ class AIStep extends Step {
 						'tool_parameters' => $tool_parameters,
 						'tool_success'    => $tool_result['success'] ?? false,
 						'tool_result'     => $tool_result['data'] ?? array(),
-						'source_type'     => $dataPackets[0]['metadata']['source_type'] ?? 'unknown',
+						'source_type'     => $input_source_type,
 					),
 					'tool_result'
 				);
-				$dataPackets = $packet->addTo( $dataPackets );
+				$outputPackets = $packet->addTo( $outputPackets );
 			}
 		}
 
 		// If no handler completed and no tool results were added, emit a single
 		// summary packet so the step doesn't appear to have produced nothing.
-		if ( ! $handler_completed && count( $dataPackets ) === 0 && ! empty( $final_ai_content ) ) {
+		if ( ! $handler_completed && count( $outputPackets ) === 0 && ! empty( $final_ai_content ) ) {
 			$content_lines = explode( "\n", trim( $final_ai_content ), 2 );
 			$ai_title      = ( strlen( $content_lines[0] ) <= 100 ) ? $content_lines[0] : 'AI Response';
 
-			$packet      = new DataPacket(
+			$packet        = new DataPacket(
 				array(
 					'title' => $ai_title,
 					'body'  => $final_ai_content,
@@ -440,9 +447,9 @@ class AIStep extends Step {
 				),
 				'ai_response'
 			);
-			$dataPackets = $packet->addTo( $dataPackets );
+			$outputPackets = $packet->addTo( $outputPackets );
 		}
 
-		return $dataPackets;
+		return $outputPackets;
 	}
 }

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for AIStep AI payload sanitization.
+ * Tests for AIStep AI payload sanitization and result processing.
  *
  * @package DataMachine\Tests\Unit\Core\Steps\AI
  */
@@ -9,6 +9,7 @@ namespace DataMachine\Tests\Unit\Core\Steps\AI;
 
 use DataMachine\Core\Steps\AI\AIStep;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 class AIStepTest extends TestCase {
 
@@ -75,5 +76,146 @@ class AIStepTest extends TestCase {
 		);
 
 		$this->assertSame( $data_packets, AIStep::sanitizeDataPacketsForAi( $data_packets ) );
+	}
+
+	/**
+	 * Test that processLoopResults does NOT carry forward input DataPackets.
+	 *
+	 * Input packets (e.g., raw HTML from a scraper) should not appear in the
+	 * output. Only tool result packets should be returned. Carrying input
+	 * packets forward causes the batch scheduler to create ghost child jobs
+	 * that fail at the next step.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine/issues/832
+	 */
+	public function test_process_loop_results_does_not_include_input_packets(): void {
+		$method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
+		$method->setAccessible( true );
+
+		$input_packets = array(
+			array(
+				'type'     => 'fetch',
+				'data'     => array(
+					'title' => 'Raw HTML Event Section',
+					'body'  => '<div>Some scraped event HTML</div>',
+				),
+				'metadata' => array(
+					'source_type' => 'universal_web_scraper',
+				),
+			),
+		);
+
+		$loop_result = array(
+			'messages'               => array(
+				array( 'role' => 'user', 'content' => 'Process this event' ),
+				array( 'role' => 'assistant', 'content' => 'I will upsert this event.' ),
+			),
+			'tool_execution_results' => array(
+				array(
+					'tool_name'       => 'upsert_event',
+					'result'          => array( 'success' => true, 'data' => array( 'post_id' => 123 ) ),
+					'parameters'      => array( 'title' => 'Test Event' ),
+					'is_handler_tool' => true,
+					'turn_count'      => 1,
+				),
+			),
+		);
+
+		$payload = array(
+			'flow_step_id' => 'test_step_id',
+		);
+
+		$available_tools = array(
+			'upsert_event' => array(
+				'handler'        => 'upsert_event',
+				'handler_config' => array(),
+			),
+		);
+
+		$result = $method->invoke( null, $loop_result, $input_packets, $payload, $available_tools );
+
+		// Should contain ONLY the handler completion packet, NOT the input packet.
+		$this->assertCount( 1, $result, 'processLoopResults should return only tool result packets, not input packets' );
+		$this->assertSame( 'ai_handler_complete', $result[0]['type'] );
+		$this->assertSame( 'upsert_event', $result[0]['metadata']['tool_name'] );
+
+		// Verify the input packet is NOT in the output.
+		foreach ( $result as $packet ) {
+			$this->assertNotSame( 'fetch', $packet['type'], 'Input fetch packet should not be in output' );
+		}
+	}
+
+	/**
+	 * Test that processLoopResults preserves source_type from input packets.
+	 */
+	public function test_process_loop_results_preserves_source_type_from_input(): void {
+		$method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
+		$method->setAccessible( true );
+
+		$input_packets = array(
+			array(
+				'type'     => 'fetch',
+				'data'     => array( 'title' => 'Test' ),
+				'metadata' => array( 'source_type' => 'ticketmaster' ),
+			),
+		);
+
+		$loop_result = array(
+			'messages'               => array(),
+			'tool_execution_results' => array(
+				array(
+					'tool_name'       => 'upsert_event',
+					'result'          => array( 'success' => true ),
+					'parameters'      => array(),
+					'is_handler_tool' => true,
+					'turn_count'      => 1,
+				),
+			),
+		);
+
+		$result = $method->invoke(
+			null,
+			$loop_result,
+			$input_packets,
+			array( 'flow_step_id' => 'test' ),
+			array( 'upsert_event' => array( 'handler' => 'upsert_event', 'handler_config' => array() ) )
+		);
+
+		$this->assertSame( 'ticketmaster', $result[0]['metadata']['source_type'] );
+	}
+
+	/**
+	 * Test that processLoopResults emits AI response when no tools were called.
+	 */
+	public function test_process_loop_results_emits_ai_response_when_no_tools(): void {
+		$method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
+		$method->setAccessible( true );
+
+		$input_packets = array(
+			array(
+				'type'     => 'fetch',
+				'data'     => array( 'title' => 'Test' ),
+				'metadata' => array( 'source_type' => 'rss' ),
+			),
+		);
+
+		$loop_result = array(
+			'messages'               => array(
+				array( 'role' => 'assistant', 'content' => 'This is my analysis of the content.' ),
+			),
+			'tool_execution_results' => array(),
+		);
+
+		$result = $method->invoke(
+			null,
+			$loop_result,
+			$input_packets,
+			array( 'flow_step_id' => 'test' ),
+			array()
+		);
+
+		// Should emit a single AI response packet, not the input + response.
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'ai_response', $result[0]['type'] );
 	}
 }


### PR DESCRIPTION
## Summary

- **Fixes #832** — AI step `processLoopResults` was carrying forward input DataPackets alongside tool result packets, causing the batch scheduler to create ghost child jobs
- Ghost children received raw HTML packets instead of handler results, failing with `required_handler_tool_not_called`
- Now starts with empty output array; input packets used only for metadata extraction (`source_type`)

## Impact

On `events.extrachill.com` over 48 hours:
- **92 false `required_handler_tool_not_called` failures** eliminated
- ~50% reduction in reported pipeline failures
- OpenAI credit savings from not processing duplicate child jobs
- Events were still being created (first sibling succeeded), so no data loss — this is a reliability/cost fix

## Root Cause

```
Fetch step → 1 HTML section → AI step processes it → returns [original_packet, handler_result_packet]
                                                              ↑ THIS was the bug
Fan-out creates 2 children:
  Child A gets handler_result_packet → succeeds ✅
  Child B gets original_packet       → fails ❌ (no handler result)
```

## Fix

`processLoopResults` now builds output from scratch instead of appending to input:
- `$outputPackets = array()` — fresh output, no input carryover
- `$inputDataPackets` — renamed param, read-only for `source_type` metadata
- 3 new tests covering the ghost job scenario, source_type preservation, and AI-only response fallback