### PR TITLE
fix: merge DailyMemoryTask into single prompt, extensible variables, remove emojis

### DIFF
--- a/inc/Api/System/System.php
+++ b/inc/Api/System/System.php
@@ -292,13 +292,32 @@ class System {
 				$has_override = isset( $overrides[ $task_type ][ $prompt_key ] )
 					&& '' !== $overrides[ $task_type ][ $prompt_key ];
 
+				/**
+				 * Filter prompt variable definitions for the admin UI.
+				 *
+				 * Allows site code that registers runtime variables via
+				 * `datamachine_task_prompt_variables` to also declare them
+				 * here so the UI shows them as available placeholders.
+				 *
+				 * @since 0.44.0
+				 * @param array  $variables  Variable name => description map.
+				 * @param string $task_type  The system task type.
+				 * @param string $prompt_key The prompt key within the task.
+				 */
+				$variables = apply_filters(
+					'datamachine_task_prompt_variable_definitions',
+					$definition['variables'] ?? array(),
+					$task_type,
+					$prompt_key
+				);
+
 				$prompts[] = array(
 					'task_type'    => $task_type,
 					'prompt_key'   => $prompt_key,
 					'label'        => $definition['label'],
 					'description'  => $definition['description'],
 					'default'      => $definition['default'],
-					'variables'    => $definition['variables'],
+					'variables'    => $variables,
 					'has_override' => $has_override,
 					'override'     => $has_override ? $overrides[ $task_type ][ $prompt_key ] : null,
 				);

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/SystemTasksTab.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/SystemTasksTab.jsx
@@ -93,12 +93,7 @@ const formatDate = ( datetime ) => {
 	}
 };
 
-const TRIGGER_ICONS = {
-	event: '\u26A1',
-	cron: '\u23F0',
-	manual: '\u270B',
-	tool: '\uD83E\uDD16',
-};
+
 
 /**
  * PromptEditor — expandable section for a single prompt definition.
@@ -181,7 +176,6 @@ const TaskCard = ( {
 	const status = formatStatus( task.last_status );
 	const hasToggle = Boolean( task.setting_key );
 	const lastRunDate = formatDate( task.last_run_at );
-	const triggerIcon = TRIGGER_ICONS[ task.trigger_type ] || '';
 	const hasPrompts = prompts.length > 0;
 
 	return (
@@ -220,7 +214,7 @@ const TaskCard = ( {
 						Trigger
 					</span>
 					<span className="datamachine-task-card-meta-value">
-						{ triggerIcon } { task.trigger }
+						{ task.trigger }
 					</span>
 				</div>
 
@@ -272,7 +266,7 @@ const TaskCard = ( {
 						className="button button-secondary button-small"
 						onClick={ () => setShowPrompts( ! showPrompts ) }
 					>
-						{ showPrompts ? 'Hide Prompts' : 'Edit Prompts' }
+						{ showPrompts ? 'Hide Prompt' : 'Edit Prompt' }
 					</button>
 				) }
 			</div>

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/import-export/CSVDropzone.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/import-export/CSVDropzone.jsx
@@ -122,7 +122,7 @@ export default function CSVDropzone( {
 				onDrop={ dragDrop.handleDrop.bind( null, handleDrop ) }
 				onClick={ ! disabled ? handleBrowseClick : undefined }
 			>
-				<div className="datamachine-csv-dropzone__icon">📄</div>
+				<div className="datamachine-csv-dropzone__icon"></div>
 
 				<p className="datamachine-csv-dropzone__title">
 					{ fileName

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/FileUploadDropzone.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/FileUploadDropzone.jsx
@@ -157,7 +157,7 @@ export default function FileUploadDropzone( {
 				}` }
 				onClick={ ! disabled ? handleBrowseClick : undefined }
 			>
-				<div className="datamachine-dropzone-icon">📁</div>
+				<div className="datamachine-dropzone-icon"></div>
 
 				<p className="datamachine-dropzone-title">
 					{ uploadText || defaultUploadText }

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -1,15 +1,16 @@
 <?php
 /**
- * Daily Memory Generation Task
+ * Daily Memory Task
  *
- * System agent task that gathers the day's activity (jobs, chat sessions)
- * and uses AI to synthesize a concise daily memory entry. Runs once daily
- * via Action Scheduler when daily_memory_enabled is active.
+ * System agent task that maintains MEMORY.md — the persistent memory file
+ * injected into every AI session. Reads the current MEMORY.md, gathers
+ * available activity context, and uses a single AI call to:
  *
- * After generating the daily summary, runs a memory cleanup phase that
- * reads MEMORY.md, identifies session-specific content that should be
- * archived to daily files, and rewrites MEMORY.md with only persistent
- * knowledge. This keeps the memory file lean for context window budget.
+ * - Move day-specific/session-specific content to a daily archive file
+ * - Compress and clean: remove redundancies, outdated info, verbose language
+ * - Preserve all persistent knowledge without losing anything important
+ *
+ * Runs once daily via Action Scheduler when daily_memory_enabled is active.
  *
  * @package DataMachine\Engine\AI\System\Tasks
  * @since 0.32.0
@@ -28,7 +29,10 @@ use DataMachine\Engine\AI\RequestBuilder;
 class DailyMemoryTask extends SystemTask {
 
 	/**
-	 * Execute daily memory generation.
+	 * Execute daily memory maintenance.
+	 *
+	 * Single-phase operation: read MEMORY.md, gather activity context,
+	 * send one AI call to clean/compress/archive, write results.
 	 *
 	 * @param int   $jobId  Job ID from DM Jobs table.
 	 * @param array $params Task parameters from engine_data.
@@ -56,55 +60,186 @@ class DailyMemoryTask extends SystemTask {
 
 		$date  = $params['date'] ?? gmdate( 'Y-m-d' );
 		$daily = new DailyMemory();
-		$parts = explode( '-', $date );
 
-		// Phase 1: Generate daily summary from DM activity (jobs, chat sessions).
-		$summary_length = 0;
-		$context        = $this->gatherContext( $params );
+		// Read current MEMORY.md.
+		$memory = new AgentMemory();
+		$result = $memory->get_all();
 
-		if ( ! empty( $context ) ) {
-			$prompt   = $this->buildPrompt( $context );
-			$messages = array(
+		if ( empty( $result['success'] ) || empty( $result['content'] ) ) {
+			$this->completeJob(
+				$jobId,
 				array(
-					'role'    => 'user',
-					'content' => $prompt,
-				),
+					'skipped' => true,
+					'reason'  => 'MEMORY.md not found or empty.',
+				)
 			);
-
-			$response = RequestBuilder::build(
-				$messages,
-				$provider,
-				$model,
-				array(),
-				'system',
-				array()
-			);
-
-			if ( ! empty( $response['success'] ) ) {
-				$content = trim( $response['data']['content'] ?? '' );
-				// Normalize literal \n sequences to actual newlines.
-				$content = str_replace( '\n', "\n", $content );
-
-				if ( ! empty( $content ) ) {
-					$result = $daily->append( $parts[0], $parts[1], $parts[2], $content . "\n" );
-					if ( ! empty( $result['success'] ) ) {
-						$summary_length = strlen( $content );
-					}
-				}
-			}
+			return;
 		}
 
-		// Phase 2: Clean up MEMORY.md — move session-specific content to daily file.
-		// This runs regardless of whether Phase 1 found DM activity, because most
-		// agent work happens via Kimaki sessions which don't create DM jobs.
-		$cleanup_result = $this->cleanupMemory( $date, $provider, $model, $daily );
+		$memory_content = $result['content'];
+		$original_size  = strlen( $memory_content );
+
+		// Skip if MEMORY.md is within the recommended threshold and no activity context.
+		$context = $this->gatherContext( $params );
+		if ( $original_size <= AgentMemory::MAX_FILE_SIZE && empty( $context ) ) {
+			$this->completeJob(
+				$jobId,
+				array(
+					'skipped'       => true,
+					'reason'        => 'MEMORY.md within size threshold and no activity to process.',
+					'original_size' => $original_size,
+				)
+			);
+			return;
+		}
+
+		// Build prompt with all available context.
+		$max_size         = size_format( AgentMemory::MAX_FILE_SIZE );
+		$activity_section = '';
+		if ( ! empty( $context ) ) {
+			$activity_section = "## Today's Activity\n\n" . $context . "\n\n";
+		}
+
+		$prompt = $this->buildPromptFromTemplate(
+			'daily_memory',
+			array(
+				'memory_content'   => $memory_content,
+				'date'             => $date,
+				'max_size'         => $max_size,
+				'activity_section' => $activity_section,
+			)
+		);
+
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => $prompt,
+			),
+		);
+
+		$response = RequestBuilder::build(
+			$messages,
+			$provider,
+			$model,
+			array(),
+			'system',
+			array()
+		);
+
+		if ( empty( $response['success'] ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Daily memory AI request failed: ' . ( $response['error'] ?? 'Unknown error' ),
+				array( 'date' => $date )
+			);
+			$this->failJob( $jobId, 'AI request failed: ' . ( $response['error'] ?? 'Unknown error' ) );
+			return;
+		}
+
+		$ai_output = trim( $response['data']['content'] ?? '' );
+		$ai_output = str_replace( '\n', "\n", $ai_output );
+
+		if ( empty( $ai_output ) ) {
+			$this->failJob( $jobId, 'AI returned empty response.' );
+			return;
+		}
+
+		// Parse the AI output into persistent and archived sections.
+		$parsed = $this->parseCleanupResponse( $ai_output );
+
+		if ( empty( $parsed['persistent'] ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Daily memory parse failed -- no persistent section found. MEMORY.md unchanged.',
+				array(
+					'date'             => $date,
+					'ai_output_length' => strlen( $ai_output ),
+				)
+			);
+			$this->failJob( $jobId, 'Could not parse AI response -- persistent section missing.' );
+			return;
+		}
+
+		// Write the cleaned MEMORY.md.
+		$new_content = $parsed['persistent'];
+		$new_size    = strlen( $new_content );
+
+		// Safety check: don't write if the new content is suspiciously small.
+		$target_size     = AgentMemory::MAX_FILE_SIZE;
+		$oversize_factor = $original_size / max( $target_size, 1 );
+
+		if ( $oversize_factor > 2 ) {
+			// File is more than 2x over budget -- allow reduction down to half the target.
+			$min_size = intval( $target_size * 0.5 );
+		} else {
+			// File is near budget -- don't allow reduction below 10% of original.
+			$min_size = intval( $original_size * 0.10 );
+		}
+
+		if ( $new_size < $min_size ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				sprintf(
+					'Daily memory aborted -- new content (%s) is below minimum (%s). AI may have been too aggressive.',
+					size_format( $new_size ),
+					size_format( $min_size )
+				),
+				array(
+					'date'          => $date,
+					'original_size' => $original_size,
+					'new_size'      => $new_size,
+					'min_size'      => $min_size,
+				)
+			);
+			$this->failJob( $jobId, 'Output too small -- safety check prevented write.' );
+			return;
+		}
+
+		// Write cleaned MEMORY.md.
+		$fs = \DataMachine\Core\FilesRepository\FilesystemHelper::get();
+		$fs->put_contents( $memory->get_file_path(), $new_content );
+		\DataMachine\Core\FilesRepository\FilesystemHelper::make_group_writable( $memory->get_file_path() );
+
+		// Archive extracted content to the daily file.
+		$archived_size = 0;
+		$parts         = explode( '-', $date );
+
+		if ( ! empty( $parsed['archived'] ) ) {
+			$archive_header = "\n### Archived from MEMORY.md\n\n";
+			$archive_text   = $archive_header . $parsed['archived'] . "\n";
+			$archived_size  = strlen( $parsed['archived'] );
+
+			$daily->append( $parts[0], $parts[1], $parts[2], $archive_text );
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			sprintf(
+				'Daily memory complete: %s -> %s (%s archived to daily/%s)',
+				size_format( $original_size ),
+				size_format( $new_size ),
+				size_format( $archived_size ),
+				$date
+			),
+			array(
+				'date'          => $date,
+				'original_size' => $original_size,
+				'new_size'      => $new_size,
+				'archived_size' => $archived_size,
+			)
+		);
 
 		$this->completeJob(
 			$jobId,
 			array(
-				'date'           => $date,
-				'summary_length' => $summary_length,
-				'cleanup'        => $cleanup_result,
+				'date'          => $date,
+				'original_size' => $original_size,
+				'new_size'      => $new_size,
+				'archived_size' => $archived_size,
 			)
 		);
 	}
@@ -122,7 +257,7 @@ class DailyMemoryTask extends SystemTask {
 	public static function getTaskMeta(): array {
 		return array(
 			'label'           => 'Daily Memory',
-			'description'     => 'AI-generated daily summary of activity and automatic MEMORY.md cleanup — archives session-specific content to daily files.',
+			'description'     => 'Automated MEMORY.md maintenance -- archives session-specific content to daily files, compresses and cleans persistent knowledge.',
 			'setting_key'     => 'daily_memory_enabled',
 			'default_enabled' => false,
 			'trigger'         => 'Daily at midnight UTC',
@@ -132,48 +267,35 @@ class DailyMemoryTask extends SystemTask {
 	}
 
 	/**
-	 * Get editable prompt definitions for this task.
+	 * Get the single editable prompt definition for this task.
 	 *
-	 * Daily memory has two prompts:
-	 * - daily_summary: synthesizes the day's DM activity into a concise entry
-	 * - memory_cleanup: splits MEMORY.md into persistent vs session-specific content
+	 * One prompt handles the full memory maintenance cycle: read MEMORY.md,
+	 * incorporate activity context, clean/compress, split into persistent
+	 * and archived sections.
 	 *
 	 * @return array Prompt definitions keyed by prompt key.
 	 * @since 0.41.0
 	 */
 	public function getPromptDefinitions(): array {
 		return array(
-			'daily_summary'  => array(
-				'label'       => __( 'Daily Summary Prompt', 'data-machine' ),
-				'description' => __( 'Prompt used to synthesize a daily memory entry from the day\'s activity.', 'data-machine' ),
-				'default'     => "Write a daily memory entry from today's activity data below.\n\n"
-					. "This entry will be stored in your daily memory files — the ones you already know about from your memory. Write it as your own notes for future sessions.\n\n"
-					. "Focus on:\n"
-					. "- Key events and what was accomplished (not every individual job)\n"
-					. "- Notable outcomes, failures, or patterns worth remembering\n"
-					. "- Context that would help you in a future session understand what today was about\n\n"
-					. "Keep it concise — a few paragraphs at most. Use ### headings if needed. Skip raw job IDs and technical metadata. Write in your own voice.\n\n"
-					. "---\n\n"
-					. "{{context}}",
-				'variables'   => array(
-					'context' => 'Gathered activity context: jobs completed and chat sessions from the day',
-				),
-			),
-			'memory_cleanup' => array(
-				'label'       => __( 'Memory Cleanup Prompt', 'data-machine' ),
-				'description' => __( 'Prompt used to split MEMORY.md into persistent knowledge and session-specific content for archival.', 'data-machine' ),
-				'default'     => "Clean up your MEMORY.md. You can see its current content in your system context above — it's the same file. It needs to stay lean because it's injected into every session.\n\n"
+			'daily_memory' => array(
+				'label'       => __( 'Daily Memory Prompt', 'data-machine' ),
+				'description' => __( 'Prompt for automated MEMORY.md maintenance. Cleans, compresses, and archives session-specific content.', 'data-machine' ),
+				'default'     => "You are maintaining an AI agent's MEMORY.md file. This file is injected into every AI context window, so it must stay lean -- only persistent knowledge that helps across all future sessions.\n\n"
 					. "## Principle\n\n"
 					. "For each piece of content ask: \"Would a fresh session need this to do its job?\" If yes, keep it. If it only makes sense in the context of a specific session or time period, archive it.\n\n"
-					. "## Split into two parts:\n\n"
-					. "### PERSISTENT — stays in MEMORY.md\n"
+					. "## Your Task\n\n"
+					. "Split the MEMORY.md content below into two parts:\n\n"
+					. "### PERSISTENT -- stays in MEMORY.md\n"
+					. "Knowledge useful regardless of when or why the next session runs:\n"
 					. "- How things work (architecture, patterns, conventions)\n"
 					. "- Where things are (paths, URLs, config locations, tool names)\n"
-					. "- Current state of ongoing work (status, not the journey)\n"
+					. "- Current state of ongoing work (just the status, not the journey)\n"
 					. "- Rules and constraints learned from experience\n"
 					. "- Relationships between systems, people, and services\n\n"
-					. "Prefer the **lasting fact** over the **story of how you learned it**. Merge overlapping entries. Remove detail that duplicates what's in daily files or source code.\n\n"
-					. "### ARCHIVED — moves to the daily file for {{date}}\n"
+					. "When condensing, prefer the **lasting fact** over the **story of how we learned it**. Merge overlapping entries. Remove detail that duplicates what is already in daily files or source code.\n\n"
+					. "### ARCHIVED -- moves to the daily file for {{date}}\n"
+					. "Content tied to a specific session, investigation, or moment in time:\n"
 					. "- Play-by-play narratives of what happened in a session\n"
 					. "- Debugging traces and investigation logs\n"
 					. "- Temporary state that will be outdated soon\n"
@@ -181,217 +303,31 @@ class DailyMemoryTask extends SystemTask {
 					. "## Output Format\n\n"
 					. "Respond in EXACTLY this format:\n\n"
 					. "===PERSISTENT===\n"
-					. "(cleaned MEMORY.md content — preserve existing section structure)\n\n"
+					. "(cleaned MEMORY.md content -- preserve existing section structure)\n\n"
 					. "===ARCHIVED===\n"
 					. "(extracted session-specific content, organized by topic)\n\n"
 					. "## Rules\n"
-					. "- NEVER discard information — everything goes to either PERSISTENT or ARCHIVED\n"
+					. "- NEVER discard information -- everything goes to either PERSISTENT or ARCHIVED\n"
 					. "- Target size for persistent section: under {{max_size}}\n"
 					. "- Preserve the document's existing heading structure\n"
 					. "- If a section is entirely temporal, archive the whole section\n"
 					. "- If a section mixes persistent facts with session detail, keep the facts and archive the detail\n\n"
+					. "{{activity_section}}"
 					. "---\n\n"
 					. "## Current MEMORY.md Content\n\n"
 					. "{{memory_content}}",
 				'variables'   => array(
-					'memory_content' => 'Current full content of MEMORY.md',
-					'date'           => 'Target date for archival context (YYYY-MM-DD)',
-					'max_size'       => 'Recommended maximum file size (human-readable, e.g. "8 KB")',
+					'memory_content'   => 'Current full content of MEMORY.md',
+					'date'             => 'Target date for archival context (YYYY-MM-DD)',
+					'max_size'         => 'Recommended maximum file size (human-readable, e.g. "8 KB")',
+					'activity_section' => 'Activity context section (jobs and chat sessions from the day, if any)',
 				),
 			),
 		);
 	}
 
 	/**
-	 * Clean up MEMORY.md by archiving session-specific content to the daily file.
-	 *
-	 * Reads the full MEMORY.md, sends it to AI with instructions to separate
-	 * persistent knowledge from session-specific detail, rewrites MEMORY.md
-	 * with only persistent content, and appends the extracted session content
-	 * to the day's daily memory file.
-	 *
-	 * Skips cleanup if MEMORY.md is already within the recommended size threshold
-	 * (AgentMemory::MAX_FILE_SIZE). Cleanup failures are logged but do not fail
-	 * the overall daily memory job — the daily summary is already written.
-	 *
-	 * @since 0.38.0
-	 * @param string      $date     Target date (YYYY-MM-DD).
-	 * @param string      $provider AI provider slug.
-	 * @param string      $model    AI model identifier.
-	 * @param DailyMemory $daily    DailyMemory service instance (reused from summary phase).
-	 * @return array{skipped?: bool, reason?: string, original_size?: int, new_size?: int, archived_size?: int}
-	 */
-	private function cleanupMemory( string $date, string $provider, string $model, DailyMemory $daily ): array {
-		$memory = new AgentMemory();
-		$result = $memory->get_all();
-
-		if ( empty( $result['success'] ) || empty( $result['content'] ) ) {
-			return array(
-				'skipped' => true,
-				'reason'  => 'MEMORY.md not found or empty.',
-			);
-		}
-
-		$memory_content = $result['content'];
-		$original_size  = strlen( $memory_content );
-
-		// Only clean up if MEMORY.md exceeds the recommended threshold.
-		if ( $original_size <= AgentMemory::MAX_FILE_SIZE ) {
-			return array(
-				'skipped'       => true,
-				'reason'        => 'MEMORY.md within recommended size threshold.',
-				'original_size' => $original_size,
-			);
-		}
-
-		$prompt   = $this->buildCleanupPrompt( $memory_content, $date );
-		$messages = array(
-			array(
-				'role'    => 'user',
-				'content' => $prompt,
-			),
-		);
-
-		$response = RequestBuilder::build(
-			$messages,
-			$provider,
-			$model,
-			array(),
-				'system',
-				array()
-			);
-
-		if ( empty( $response['success'] ) ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Memory cleanup AI request failed: ' . ( $response['error'] ?? 'Unknown error' ),
-				array( 'date' => $date )
-			);
-			return array(
-				'skipped' => true,
-				'reason'  => 'AI request failed: ' . ( $response['error'] ?? 'Unknown error' ),
-			);
-		}
-
-		$ai_output = trim( $response['data']['content'] ?? '' );
-		$ai_output = str_replace( '\n', "\n", $ai_output );
-
-		if ( empty( $ai_output ) ) {
-			return array(
-				'skipped' => true,
-				'reason'  => 'AI returned empty cleanup response.',
-			);
-		}
-
-		// Parse the AI output into the two sections.
-		$parsed = $this->parseCleanupResponse( $ai_output );
-
-		if ( empty( $parsed['persistent'] ) ) {
-			// Safety: never wipe MEMORY.md if parsing failed.
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Memory cleanup parse failed — no persistent section found. MEMORY.md unchanged.',
-				array(
-					'date'             => $date,
-					'ai_output_length' => strlen( $ai_output ),
-				)
-			);
-			return array(
-				'skipped' => true,
-				'reason'  => 'Could not parse AI cleanup response — persistent section missing.',
-			);
-		}
-
-		// Write the cleaned MEMORY.md.
-		$new_content = $parsed['persistent'];
-		$new_size    = strlen( $new_content );
-
-		// Safety check: don't write if the new content is suspiciously small.
-		// When the file is massively oversized, the TARGET size is a small
-		// percentage of the original, so the minimum ratio must scale accordingly.
-		// For a file that's 12x over budget, the target IS ~8% of original.
-		$target_size     = AgentMemory::MAX_FILE_SIZE;
-		$oversize_factor = $original_size / max( $target_size, 1 );
-
-		if ( $oversize_factor > 2 ) {
-			// File is more than 2x over budget — allow reduction down to half the target.
-			$min_size = intval( $target_size * 0.5 );
-		} else {
-			// File is near budget — don't allow reduction below 10% of original.
-			$min_size = intval( $original_size * 0.10 );
-		}
-
-		if ( $new_size < $min_size ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				sprintf(
-					'Memory cleanup aborted — new content (%s) is below minimum (%s). AI may have been too aggressive.',
-					size_format( $new_size ),
-					size_format( $min_size )
-				),
-				array(
-					'date'          => $date,
-					'original_size' => $original_size,
-					'new_size'      => $new_size,
-					'min_size'      => $min_size,
-				)
-			);
-			return array(
-				'skipped'       => true,
-				'reason'        => 'Cleanup produced suspiciously small output — safety check prevented write.',
-				'original_size' => $original_size,
-				'new_size'      => $new_size,
-			);
-		}
-
-		// Write cleaned MEMORY.md via the AgentMemory service.
-		// AgentMemory doesn't have a "replace all" method, so we write directly
-		// via the filesystem helper using the same path.
-		$fs = \DataMachine\Core\FilesRepository\FilesystemHelper::get();
-		$fs->put_contents( $memory->get_file_path(), $new_content );
-		\DataMachine\Core\FilesRepository\FilesystemHelper::make_group_writable( $memory->get_file_path() );
-
-		// Archive extracted content to the daily file.
-		$archived_size = 0;
-		if ( ! empty( $parsed['archived'] ) ) {
-			$archive_header = "\n### Archived from MEMORY.md\n\n";
-			$archive_text   = $archive_header . $parsed['archived'] . "\n";
-			$archived_size  = strlen( $parsed['archived'] );
-			$parts          = explode( '-', $date );
-
-			$daily->append( $parts[0], $parts[1], $parts[2], $archive_text );
-		}
-
-		do_action(
-			'datamachine_log',
-			'info',
-			sprintf(
-				'Memory cleanup complete: %s → %s (%s archived to daily/%s)',
-				size_format( $original_size ),
-				size_format( $new_size ),
-				size_format( $archived_size ),
-				$date
-			),
-			array(
-				'date'          => $date,
-				'original_size' => $original_size,
-				'new_size'      => $new_size,
-				'archived_size' => $archived_size,
-			)
-		);
-
-		return array(
-			'original_size' => $original_size,
-			'new_size'      => $new_size,
-			'archived_size' => $archived_size,
-		);
-	}
-
-	/**
-	 * Parse the AI cleanup response into persistent and archived sections.
+	 * Parse the AI response into persistent and archived sections.
 	 *
 	 * Expects the AI output to contain two clearly delimited sections:
 	 * - `===PERSISTENT===` followed by the cleaned MEMORY.md content
@@ -410,7 +346,7 @@ class DailyMemoryTask extends SystemTask {
 		$archived_pos   = strpos( $ai_output, '===ARCHIVED===' );
 
 		if ( false !== $persistent_pos && false !== $archived_pos ) {
-			// Both sections present — extract content between delimiters.
+			// Both sections present -- extract content between delimiters.
 			$persistent_start = $persistent_pos + strlen( '===PERSISTENT===' );
 
 			if ( $archived_pos > $persistent_pos ) {
@@ -424,34 +360,13 @@ class DailyMemoryTask extends SystemTask {
 				$persistent     = trim( substr( $ai_output, $persistent_start ) );
 			}
 		} elseif ( false !== $persistent_pos ) {
-			// Only PERSISTENT section — no content to archive (memory was all persistent).
+			// Only PERSISTENT section -- no content to archive.
 			$persistent = trim( substr( $ai_output, $persistent_pos + strlen( '===PERSISTENT===' ) ) );
 		}
 
 		return array(
 			'persistent' => $persistent,
 			'archived'   => $archived,
-		);
-	}
-
-	/**
-	 * Build the AI prompt for MEMORY.md cleanup.
-	 *
-	 * @since 0.38.0
-	 * @param string $memory_content Current MEMORY.md content.
-	 * @param string $date           Target date for archival context.
-	 * @return string
-	 */
-	private function buildCleanupPrompt( string $memory_content, string $date ): string {
-		$max_size = size_format( AgentMemory::MAX_FILE_SIZE );
-
-		return $this->buildPromptFromTemplate(
-			'memory_cleanup',
-			array(
-				'memory_content' => $memory_content,
-				'date'           => $date,
-				'max_size'       => $max_size,
-			)
 		);
 	}
 
@@ -566,18 +481,5 @@ class DailyMemoryTask extends SystemTask {
 		}
 
 		return implode( "\n", $lines );
-	}
-
-	/**
-	 * Build the AI prompt for daily memory synthesis.
-	 *
-	 * @param string $context Gathered activity context.
-	 * @return string
-	 */
-	private function buildPrompt( string $context ): string {
-		return $this->buildPromptFromTemplate(
-			'daily_summary',
-			array( 'context' => $context )
-		);
 	}
 }

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -141,6 +141,19 @@ abstract class SystemTask {
 	 * Resolve and interpolate a prompt in one call.
 	 *
 	 * Convenience method combining resolvePrompt() + interpolatePrompt().
+	 * After gathering the task's own variables, applies the
+	 * `datamachine_task_prompt_variables` filter so site code can inject
+	 * additional variables (or override existing ones) without modifying
+	 * the task class.
+	 *
+	 * Example usage in a theme or plugin:
+	 *
+	 *     add_filter( 'datamachine_task_prompt_variables', function( $vars, $task_type, $prompt_key ) {
+	 *         if ( 'daily_memory_generation' === $task_type ) {
+	 *             $vars['git_commits'] = my_get_todays_commits();
+	 *         }
+	 *         return $vars;
+	 *     }, 10, 3 );
 	 *
 	 * @param string $prompt_key The prompt key.
 	 * @param array  $variables  Context variables for interpolation.
@@ -148,7 +161,23 @@ abstract class SystemTask {
 	 * @since 0.41.0
 	 */
 	protected function buildPromptFromTemplate( string $prompt_key, array $variables = array() ): string {
-		$template = $this->resolvePrompt( $prompt_key );
+		$template  = $this->resolvePrompt( $prompt_key );
+		$task_type = $this->getTaskType();
+
+		/**
+		 * Filter prompt template variables before interpolation.
+		 *
+		 * Allows site code to inject additional variables or override
+		 * existing ones for any system task prompt. The prompt template
+		 * can reference these via {{variable_name}} placeholders.
+		 *
+		 * @since 0.44.0
+		 * @param array  $variables  Key-value pairs of variable_name => value.
+		 * @param string $task_type  The system task type (e.g. 'daily_memory_generation').
+		 * @param string $prompt_key The prompt key within the task.
+		 */
+		$variables = apply_filters( 'datamachine_task_prompt_variables', $variables, $task_type, $prompt_key );
+
 		return $this->interpolatePrompt( $template, $variables );
 	}
 


### PR DESCRIPTION
## Summary

- **DailyMemoryTask**: merged two prompts (`daily_summary` + `memory_cleanup`) into one (`daily_memory`). One AI call handles the full memory maintenance cycle instead of a redundant Phase 1/Phase 2 flow.
- **Extensible prompt variables**: added `datamachine_task_prompt_variables` filter (runtime values) and `datamachine_task_prompt_variable_definitions` filter (UI display). Built-in variables go through the same filter path as external ones.
- **UI**: "Edit Prompts" -> "Edit Prompt" (singular). Removed all emoji usage from trigger icons, file upload dropzone, and CSV dropzone.

## Prompt override migration

Existing `memory_cleanup` prompt override migrated to `daily_memory` key on chubes.net via `wp option update`. The `{{activity_section}}` variable was added to the migrated override.