### PR TITLE
fix: system task status showing stale failure + add auth providers settings tab

### DIFF
--- a/inc/Api/Auth.php
+++ b/inc/Api/Auth.php
@@ -43,6 +43,16 @@ class Auth {
 	public static function register_routes() {
 		register_rest_route(
 			'datamachine/v1',
+			'/auth/providers',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( self::class, 'handle_list_providers' ),
+				'permission_callback' => array( self::class, 'check_permission' ),
+			)
+		);
+
+		register_rest_route(
+			'datamachine/v1',
 			'/auth/(?P<handler_slug>[a-zA-Z0-9_\-]+)',
 			array(
 				array(
@@ -244,6 +254,77 @@ class Auth {
 				'success' => true,
 				'data'    => null,
 				'message' => $result['message'],
+			)
+		);
+	}
+
+	/**
+	 * List all registered auth providers with status and configuration.
+	 *
+	 * GET /datamachine/v1/auth/providers
+	 *
+	 * Returns each provider with its type (oauth2, oauth1, simple),
+	 * authentication status, config fields, callback URL, and connected
+	 * account details — everything the Settings UI needs.
+	 *
+	 * @since 0.44.1
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response Provider list.
+	 */
+	public static function handle_list_providers( $request ) {
+		$request;
+		$abilities = self::getAbilities();
+		$providers = $abilities->getAllProviders();
+
+		$data = array();
+
+		foreach ( $providers as $provider_key => $instance ) {
+			$auth_type = 'simple';
+			if ( $instance instanceof \DataMachine\Core\OAuth\BaseOAuth2Provider ) {
+				$auth_type = 'oauth2';
+			} elseif ( $instance instanceof \DataMachine\Core\OAuth\BaseOAuth1Provider ) {
+				$auth_type = 'oauth1';
+			}
+
+			$is_authenticated = false;
+			if ( method_exists( $instance, 'is_authenticated' ) ) {
+				$is_authenticated = $instance->is_authenticated();
+			}
+
+			$entry = array(
+				'provider_key'     => $provider_key,
+				'label'            => ucfirst( str_replace( '_', ' ', $provider_key ) ),
+				'auth_type'        => $auth_type,
+				'is_configured'    => method_exists( $instance, 'is_configured' ) ? $instance->is_configured() : false,
+				'is_authenticated' => $is_authenticated,
+				'auth_fields'      => method_exists( $instance, 'get_config_fields' ) ? $instance->get_config_fields() : array(),
+				'callback_url'     => null,
+				'account_details'  => null,
+			);
+
+			if ( in_array( $auth_type, array( 'oauth1', 'oauth2' ), true ) && method_exists( $instance, 'get_callback_url' ) ) {
+				$entry['callback_url'] = $instance->get_callback_url();
+			}
+
+			if ( $is_authenticated && method_exists( $instance, 'get_account_details' ) ) {
+				$entry['account_details'] = $instance->get_account_details();
+			}
+
+			$data[] = $entry;
+		}
+
+		// Sort: authenticated first, then alphabetically by label.
+		usort( $data, function ( $a, $b ) {
+			if ( $a['is_authenticated'] !== $b['is_authenticated'] ) {
+				return $a['is_authenticated'] ? -1 : 1;
+			}
+			return strcasecmp( $a['label'], $b['label'] );
+		} );
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'data'    => $data,
 			)
 		);
 	}

--- a/inc/Core/Admin/Settings/assets/css/settings-page.css
+++ b/inc/Core/Admin/Settings/assets/css/settings-page.css
@@ -478,3 +478,189 @@
 .datamachine-toggle-visibility {
     flex-shrink: 0;
 }
+
+/* ========================================================================
+   AUTH PROVIDERS TAB
+   ======================================================================== */
+
+.datamachine-auth-providers-tab {
+    max-width: 900px;
+}
+
+.datamachine-auth-providers-tab > .description {
+    margin-bottom: 20px;
+    font-size: 14px;
+}
+
+.datamachine-auth-providers-loading,
+.datamachine-auth-providers-empty {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 20px;
+}
+
+.datamachine-auth-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+/* Provider Card */
+.datamachine-auth-card {
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 16px;
+    background: #fff;
+}
+
+.datamachine-auth-card--connected {
+    border-left: 3px solid #00a32a;
+}
+
+.datamachine-auth-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 4px;
+}
+
+.datamachine-auth-card-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.datamachine-auth-card-title strong {
+    font-size: 14px;
+}
+
+/* Auth type badge */
+.datamachine-auth-type-badge {
+    font-size: 11px;
+    font-weight: 500;
+    color: #646970;
+    background: #f0f0f1;
+    padding: 2px 8px;
+    border-radius: 3px;
+}
+
+/* Status badges */
+.datamachine-auth-badge {
+    font-size: 12px;
+    font-weight: 500;
+    padding: 2px 10px;
+    border-radius: 3px;
+}
+
+.datamachine-auth-badge--connected {
+    background: #d1f5d3;
+    color: #00a32a;
+}
+
+.datamachine-auth-badge--configured {
+    background: #fff3cd;
+    color: #856404;
+}
+
+.datamachine-auth-badge--disconnected {
+    background: #f0f0f1;
+    color: #646970;
+}
+
+/* Account details inline */
+.datamachine-auth-account {
+    font-size: 13px;
+    color: #50575e;
+    margin-bottom: 8px;
+}
+
+/* Card notice */
+.datamachine-auth-card-notice {
+    margin: 8px 0 !important;
+}
+
+/* Card actions */
+.datamachine-auth-card-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 10px;
+}
+
+/* Config section */
+.datamachine-auth-card-config {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid #eee;
+}
+
+/* Callback URL display */
+.datamachine-auth-callback {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+    padding: 8px 12px;
+    background: #f6f7f7;
+    border-radius: 3px;
+    font-size: 13px;
+}
+
+.datamachine-auth-callback-label {
+    font-weight: 500;
+    flex-shrink: 0;
+}
+
+.datamachine-auth-callback-url {
+    font-size: 12px;
+    word-break: break-all;
+    flex: 1;
+}
+
+.datamachine-auth-callback-copy {
+    flex-shrink: 0;
+}
+
+/* Config form */
+.datamachine-auth-config-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.datamachine-auth-config-field label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 4px;
+    font-size: 13px;
+}
+
+.datamachine-auth-config-field input,
+.datamachine-auth-config-field select {
+    max-width: 400px;
+    width: 100%;
+}
+
+.datamachine-auth-config-field .description {
+    margin-top: 4px;
+    font-size: 12px;
+    color: #646970;
+}
+
+.datamachine-auth-config-actions {
+    margin-top: 4px;
+}
+
+/* Responsive */
+@media screen and (max-width: 782px) {
+    .datamachine-auth-card-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+
+    .datamachine-auth-callback {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}

--- a/inc/Core/Admin/Settings/assets/react/SettingsApp.jsx
+++ b/inc/Core/Admin/Settings/assets/react/SettingsApp.jsx
@@ -16,6 +16,7 @@ import { TabPanel } from '@wordpress/components';
 import GeneralTab from './components/tabs/GeneralTab';
 import ApiKeysTab from './components/tabs/ApiKeysTab';
 import HandlerDefaultsTab from './components/tabs/HandlerDefaultsTab';
+import AuthProvidersTab from './components/tabs/AuthProvidersTab';
 
 const STORAGE_KEY = 'datamachine_settings_active_tab';
 
@@ -23,6 +24,7 @@ const TABS = [
 	{ name: 'general', title: 'General' },
 	{ name: 'api-keys', title: 'API Keys' },
 	{ name: 'handler-defaults', title: 'Handler Defaults' },
+	{ name: 'auth-providers', title: 'Auth Providers' },
 ];
 
 const getInitialTab = () => {
@@ -49,12 +51,14 @@ const SettingsApp = () => {
 					switch ( tab.name ) {
 						case 'general':
 							return <GeneralTab />;
-						case 'api-keys':
-							return <ApiKeysTab />;
-						case 'handler-defaults':
-							return <HandlerDefaultsTab />;
-						default:
-							return <GeneralTab />;
+					case 'api-keys':
+						return <ApiKeysTab />;
+					case 'handler-defaults':
+						return <HandlerDefaultsTab />;
+					case 'auth-providers':
+						return <AuthProvidersTab />;
+					default:
+						return <GeneralTab />;
 					}
 				} }
 			</TabPanel>

--- a/inc/Core/Admin/Settings/assets/react/components/tabs/AuthProvidersTab.jsx
+++ b/inc/Core/Admin/Settings/assets/react/components/tabs/AuthProvidersTab.jsx
@@ -1,0 +1,471 @@
+/**
+ * AuthProvidersTab Component
+ *
+ * Card-based display of all registered auth providers with connection
+ * status, config fields, and connect/disconnect actions. Provides a
+ * single view to manage all authentication outside the pipeline page.
+ *
+ * @since 0.44.1
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useCallback } from '@wordpress/element';
+import { Button, Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	useAuthProviders,
+	useSaveAuthConfig,
+	useDisconnectAuth,
+} from '../../queries/authProviders';
+
+const AUTH_TYPE_LABELS = {
+	oauth2: 'OAuth 2.0',
+	oauth1: 'OAuth 1.0a',
+	simple: 'Credentials',
+};
+
+/**
+ * Inline connection status badge.
+ */
+const StatusBadge = ( { connected, configured } ) => {
+	if ( connected ) {
+		return (
+			<span className="datamachine-auth-badge datamachine-auth-badge--connected">
+				{ '\u2713' } { __( 'Connected', 'data-machine' ) }
+			</span>
+		);
+	}
+	if ( configured ) {
+		return (
+			<span className="datamachine-auth-badge datamachine-auth-badge--configured">
+				{ __( 'Configured', 'data-machine' ) }
+			</span>
+		);
+	}
+	return (
+		<span className="datamachine-auth-badge datamachine-auth-badge--disconnected">
+			{ __( 'Not connected', 'data-machine' ) }
+		</span>
+	);
+};
+
+/**
+ * Display connected account details inline.
+ */
+const InlineAccountDetails = ( { account } ) => {
+	if ( ! account || Object.keys( account ).length === 0 ) {
+		return null;
+	}
+
+	const username =
+		account.username || account.name || account.screen_name || null;
+	const email = account.email || null;
+
+	const details = [];
+	if ( username ) {
+		details.push( username );
+	}
+	if ( email && email !== username ) {
+		details.push( email );
+	}
+
+	// Include any other simple string/number fields not already shown.
+	const skipKeys = [
+		'username',
+		'name',
+		'screen_name',
+		'email',
+		'id',
+		'user_id',
+	];
+	Object.entries( account ).forEach( ( [ key, value ] ) => {
+		if (
+			skipKeys.includes( key ) ||
+			typeof value === 'object' ||
+			typeof value === 'function'
+		) {
+			return;
+		}
+		details.push( `${ key }: ${ value }` );
+	} );
+
+	if ( details.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div className="datamachine-auth-account">
+			{ details.join( ' \u00b7 ' ) }
+		</div>
+	);
+};
+
+/**
+ * Config form for a single provider (API keys, credentials).
+ */
+const ConfigForm = ( { provider, onSave, isSaving } ) => {
+	const fields = provider.auth_fields || {};
+	const fieldEntries = Object.entries( fields );
+
+	const [ values, setValues ] = useState( () => {
+		const initial = {};
+		fieldEntries.forEach( ( [ key, field ] ) => {
+			initial[ key ] = field.default || '';
+		} );
+		return initial;
+	} );
+
+	if ( fieldEntries.length === 0 ) {
+		return (
+			<p className="description">
+				{ __(
+					'No configuration fields available for this provider.',
+					'data-machine'
+				) }
+			</p>
+		);
+	}
+
+	const handleChange = ( key, value ) => {
+		setValues( ( prev ) => ( { ...prev, [ key ]: value } ) );
+	};
+
+	const handleSubmit = ( e ) => {
+		e.preventDefault();
+		onSave( provider.provider_key, values );
+	};
+
+	return (
+		<form onSubmit={ handleSubmit } className="datamachine-auth-config-form">
+			{ fieldEntries.map( ( [ key, field ] ) => (
+				<div key={ key } className="datamachine-auth-config-field">
+					<label htmlFor={ `auth-${ provider.provider_key }-${ key }` }>
+						{ field.label }
+						{ field.required && (
+							<span className="required"> *</span>
+						) }
+					</label>
+					{ field.type === 'select' ? (
+						<select
+							id={ `auth-${ provider.provider_key }-${ key }` }
+							value={ values[ key ] || '' }
+							onChange={ ( e ) =>
+								handleChange( key, e.target.value )
+							}
+						>
+							{ Object.entries( field.options || {} ).map(
+								( [ optVal, optLabel ] ) => (
+									<option key={ optVal } value={ optVal }>
+										{ optLabel }
+									</option>
+								)
+							) }
+						</select>
+					) : (
+						<input
+							id={ `auth-${ provider.provider_key }-${ key }` }
+							type={ field.type === 'password' ? 'password' : 'text' }
+							value={ values[ key ] || '' }
+							onChange={ ( e ) =>
+								handleChange( key, e.target.value )
+							}
+							placeholder={ field.placeholder || '' }
+							className="regular-text"
+						/>
+					) }
+					{ field.description && (
+						<p className="description">{ field.description }</p>
+					) }
+				</div>
+			) ) }
+
+			<div className="datamachine-auth-config-actions">
+				<Button
+					variant="primary"
+					type="submit"
+					isBusy={ isSaving }
+					disabled={ isSaving }
+				>
+					{ isSaving
+						? __( 'Saving\u2026', 'data-machine' )
+						: __( 'Save Configuration', 'data-machine' ) }
+				</Button>
+			</div>
+		</form>
+	);
+};
+
+/**
+ * Callback URL display for OAuth providers.
+ */
+const CallbackUrlDisplay = ( { url } ) => {
+	if ( ! url ) {
+		return null;
+	}
+
+	const [ copied, setCopied ] = useState( false );
+
+	const handleCopy = () => {
+		navigator.clipboard.writeText( url ).then( () => {
+			setCopied( true );
+			setTimeout( () => setCopied( false ), 2000 );
+		} );
+	};
+
+	return (
+		<div className="datamachine-auth-callback">
+			<span className="datamachine-auth-callback-label">
+				{ __( 'Redirect URL:', 'data-machine' ) }
+			</span>
+			<code className="datamachine-auth-callback-url">{ url }</code>
+			<Button
+				variant="link"
+				className="datamachine-auth-callback-copy"
+				onClick={ handleCopy }
+			>
+				{ copied
+					? __( 'Copied!', 'data-machine' )
+					: __( 'Copy', 'data-machine' ) }
+			</Button>
+		</div>
+	);
+};
+
+/**
+ * Single provider card.
+ */
+const ProviderCard = ( {
+	provider,
+	onSave,
+	onDisconnect,
+	isSaving,
+	isDisconnecting,
+} ) => {
+	const [ showConfig, setShowConfig ] = useState( false );
+	const [ feedback, setFeedback ] = useState( null );
+
+	const handleSave = useCallback(
+		async ( providerKey, config ) => {
+			try {
+				await onSave( providerKey, config );
+				setFeedback( {
+					type: 'success',
+					message: __( 'Configuration saved.', 'data-machine' ),
+				} );
+				setShowConfig( false );
+			} catch ( err ) {
+				setFeedback( {
+					type: 'error',
+					message:
+						err.message ||
+						__( 'Failed to save configuration.', 'data-machine' ),
+				} );
+			}
+		},
+		[ onSave ]
+	);
+
+	const handleDisconnect = useCallback( async () => {
+		if (
+			! confirm(
+				__(
+					'Are you sure you want to disconnect this account? This will remove the access token but keep your API configuration.',
+					'data-machine'
+				)
+			)
+		) {
+			return;
+		}
+		try {
+			await onDisconnect( provider.provider_key );
+			setFeedback( {
+				type: 'success',
+				message: __( 'Account disconnected.', 'data-machine' ),
+			} );
+		} catch ( err ) {
+			setFeedback( {
+				type: 'error',
+				message:
+					err.message ||
+					__( 'Failed to disconnect.', 'data-machine' ),
+			} );
+		}
+	}, [ onDisconnect, provider.provider_key ] );
+
+	return (
+		<div
+			className={ `datamachine-auth-card ${
+				provider.is_authenticated
+					? 'datamachine-auth-card--connected'
+					: ''
+			}` }
+		>
+			<div className="datamachine-auth-card-header">
+				<div className="datamachine-auth-card-title">
+					<strong>{ provider.label }</strong>
+					<span className="datamachine-auth-type-badge">
+						{ AUTH_TYPE_LABELS[ provider.auth_type ] ||
+							provider.auth_type }
+					</span>
+				</div>
+				<StatusBadge
+					connected={ provider.is_authenticated }
+					configured={ provider.is_configured }
+				/>
+			</div>
+
+			{ provider.is_authenticated && (
+				<InlineAccountDetails account={ provider.account_details } />
+			) }
+
+			{ feedback && (
+				<Notice
+					status={ feedback.type }
+					isDismissible
+					onRemove={ () => setFeedback( null ) }
+					className="datamachine-auth-card-notice"
+				>
+					{ feedback.message }
+				</Notice>
+			) }
+
+			<div className="datamachine-auth-card-actions">
+				{ provider.is_authenticated && (
+					<Button
+						variant="secondary"
+						isDestructive
+						onClick={ handleDisconnect }
+						isBusy={ isDisconnecting }
+						disabled={ isDisconnecting }
+						className="button-small"
+					>
+						{ isDisconnecting
+							? __( 'Disconnecting\u2026', 'data-machine' )
+							: __( 'Disconnect', 'data-machine' ) }
+					</Button>
+				) }
+
+				{ Object.keys( provider.auth_fields || {} ).length > 0 && (
+					<Button
+						variant="secondary"
+						onClick={ () => setShowConfig( ! showConfig ) }
+						className="button-small"
+					>
+						{ showConfig
+							? __( 'Hide Config', 'data-machine' )
+							: provider.is_authenticated
+							? __( 'Edit Config', 'data-machine' )
+							: __( 'Configure', 'data-machine' ) }
+					</Button>
+				) }
+			</div>
+
+			{ showConfig && (
+				<div className="datamachine-auth-card-config">
+					<CallbackUrlDisplay url={ provider.callback_url } />
+					<ConfigForm
+						provider={ provider }
+						onSave={ handleSave }
+						isSaving={ isSaving }
+					/>
+				</div>
+			) }
+		</div>
+	);
+};
+
+const AuthProvidersTab = () => {
+	const { data: providers, isLoading, error } = useAuthProviders();
+	const saveMutation = useSaveAuthConfig();
+	const disconnectMutation = useDisconnectAuth();
+	const [ savingProvider, setSavingProvider ] = useState( null );
+	const [ disconnectingProvider, setDisconnectingProvider ] = useState( null );
+
+	const handleSave = async ( providerKey, config ) => {
+		setSavingProvider( providerKey );
+		try {
+			await saveMutation.mutateAsync( { providerKey, config } );
+		} finally {
+			setSavingProvider( null );
+		}
+	};
+
+	const handleDisconnect = async ( providerKey ) => {
+		setDisconnectingProvider( providerKey );
+		try {
+			await disconnectMutation.mutateAsync( providerKey );
+		} finally {
+			setDisconnectingProvider( null );
+		}
+	};
+
+	if ( isLoading ) {
+		return (
+			<div className="datamachine-auth-providers-loading">
+				<span className="spinner is-active"></span>
+				<span>{ __( 'Loading auth providers\u2026', 'data-machine' ) }</span>
+			</div>
+		);
+	}
+
+	if ( error ) {
+		return (
+			<div className="notice notice-error">
+				<p>
+					{ __(
+						'Error loading auth providers:',
+						'data-machine'
+					) }{ ' ' }
+					{ error.message }
+				</p>
+			</div>
+		);
+	}
+
+	if ( ! providers || providers.length === 0 ) {
+		return (
+			<div className="datamachine-auth-providers-empty">
+				<p className="description">
+					{ __(
+						'No auth providers registered. Providers are registered by handlers that require authentication (OAuth, API keys, etc.).',
+						'data-machine'
+					) }
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="datamachine-auth-providers-tab">
+			<p className="description">
+				{ __(
+					'Manage authentication for all registered providers. Configure API keys, connect OAuth accounts, and check connection status.',
+					'data-machine'
+				) }
+			</p>
+
+			<div className="datamachine-auth-cards">
+				{ providers.map( ( provider ) => (
+					<ProviderCard
+						key={ provider.provider_key }
+						provider={ provider }
+						onSave={ handleSave }
+						onDisconnect={ handleDisconnect }
+						isSaving={ savingProvider === provider.provider_key }
+						isDisconnecting={
+							disconnectingProvider === provider.provider_key
+						}
+					/>
+				) ) }
+			</div>
+		</div>
+	);
+};
+
+export default AuthProvidersTab;

--- a/inc/Core/Admin/Settings/assets/react/queries/authProviders.js
+++ b/inc/Core/Admin/Settings/assets/react/queries/authProviders.js
@@ -1,0 +1,86 @@
+/**
+ * Auth Providers Query Hooks
+ *
+ * TanStack Query hooks for the auth providers list endpoint.
+ *
+ * @since 0.44.1
+ */
+
+/**
+ * External dependencies
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { client } from '@shared/utils/api';
+
+/**
+ * Query key for auth providers list
+ */
+export const AUTH_PROVIDERS_KEY = [ 'authProviders' ];
+
+/**
+ * Fetch all registered auth providers with status
+ */
+export const useAuthProviders = () => {
+	return useQuery( {
+		queryKey: AUTH_PROVIDERS_KEY,
+		queryFn: async () => {
+			const response = await client.get( '/auth/providers' );
+			if ( ! response.success ) {
+				throw new Error(
+					response.message || 'Failed to fetch auth providers'
+				);
+			}
+			return response.data;
+		},
+		staleTime: 30 * 1000,
+	} );
+};
+
+/**
+ * Save auth config for a provider
+ */
+export const useSaveAuthConfig = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation( {
+		mutationFn: async ( { providerKey, config } ) => {
+			const response = await client.put(
+				`/auth/${ providerKey }`,
+				config
+			);
+			if ( ! response.success ) {
+				throw new Error(
+					response.message || 'Failed to save auth config'
+				);
+			}
+			return response.data;
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: AUTH_PROVIDERS_KEY } );
+		},
+	} );
+};
+
+/**
+ * Disconnect an auth provider
+ */
+export const useDisconnectAuth = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation( {
+		mutationFn: async ( providerKey ) => {
+			const response = await client.delete(
+				`/auth/${ providerKey }`
+			);
+			if ( ! response.success ) {
+				throw new Error(
+					response.message || 'Failed to disconnect account'
+				);
+			}
+			return response.data;
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: AUTH_PROVIDERS_KEY } );
+		},
+	} );
+};

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -564,16 +564,18 @@ abstract class SystemTask {
 	/**
 	 * Complete a job with successful results.
 	 *
-	 * Updates the job's engine_data with the result and marks it as completed.
+	 * Merges the result into existing engine_data (preserving scheduler
+	 * metadata like task_type and context) and marks the job as completed.
 	 *
 	 * @param int   $jobId Job ID.
-	 * @param array $result Result data to store in engine_data.
+	 * @param array $result Result data to merge into engine_data.
 	 */
 	protected function completeJob( int $jobId, array $result ): void {
 		$jobs_db = new Jobs();
 
-		// Store result in engine_data
-		$jobs_db->store_engine_data( $jobId, $result );
+		// Merge result into existing engine_data to preserve scheduler metadata (task_type, context, etc.).
+		$existing = $jobs_db->retrieve_engine_data( $jobId );
+		$jobs_db->store_engine_data( $jobId, array_merge( $existing, $result ) );
 
 		// Mark job as completed
 		$jobs_db->complete_job( $jobId, JobStatus::COMPLETED );
@@ -594,7 +596,8 @@ abstract class SystemTask {
 	/**
 	 * Fail a job with error reason.
 	 *
-	 * Updates the job's engine_data with error details and marks it as failed.
+	 * Merges error details into existing engine_data (preserving scheduler
+	 * metadata like task_type and context) and marks the job as failed.
 	 *
 	 * @param int    $jobId  Job ID.
 	 * @param string $reason Failure reason.
@@ -602,12 +605,13 @@ abstract class SystemTask {
 	protected function failJob( int $jobId, string $reason ): void {
 		$jobs_db = new Jobs();
 
-		// Store error in engine_data
-		$error_data = array(
+		// Merge error into existing engine_data to preserve scheduler metadata.
+		$existing   = $jobs_db->retrieve_engine_data( $jobId );
+		$error_data = array_merge( $existing, array(
 			'error'     => $reason,
 			'failed_at' => current_time( 'mysql' ),
 			'task_type' => $this->getTaskType(),
-		);
+		) );
 		$jobs_db->store_engine_data( $jobId, $error_data );
 
 		// Mark job as failed


### PR DESCRIPTION
## Summary

- **Fix system task status display**: `SystemTask::completeJob()` was overwriting `engine_data` with only the result array, losing the `task_type` field that `TaskScheduler::schedule()` originally stored. The `get_last_runs()` SQL query uses `JSON_EXTRACT(engine_data, '$.task_type')` to find matching jobs — so it could only find **failed** jobs (where `failJob()` re-added `task_type`) and completely missed all successful runs. Both `completeJob()` and `failJob()` now merge results into existing `engine_data` instead of overwriting.

- **Add Auth Providers tab** to the Settings page — a single view to manage all registered auth providers with connection status, configuration, and connect/disconnect actions. Previously this was only accessible per-handler from the pipeline page.

## Changes

### Bug fix: SystemTask engine_data preservation
- `inc/Engine/AI/System/Tasks/SystemTask.php` — `completeJob()` and `failJob()` now read existing `engine_data` via `retrieve_engine_data()` and merge the result/error data into it, preserving scheduler metadata (`task_type`, `context`, `scheduled_at`)

### New: Auth Providers Settings Tab
- `inc/Api/Auth.php` — New `GET /datamachine/v1/auth/providers` endpoint returning all registered providers with type, status, config fields, callback URL, and account details
- `inc/Core/Admin/Settings/assets/react/queries/authProviders.js` — TanStack Query hooks (`useAuthProviders`, `useSaveAuthConfig`, `useDisconnectAuth`)
- `inc/Core/Admin/Settings/assets/react/components/tabs/AuthProvidersTab.jsx` — Card-based UI with inline status badges, config forms, callback URL display, and disconnect actions
- `inc/Core/Admin/Settings/assets/react/SettingsApp.jsx` — Register new tab
- `inc/Core/Admin/Settings/assets/css/settings-page.css` — Full responsive styles for auth provider cards