### PR TITLE
feat: display batch parent/child relationships on Jobs page

### DIFF
--- a/inc/Abilities/Job/GetJobsAbility.php
+++ b/inc/Abilities/Job/GetJobsAbility.php
@@ -220,6 +220,16 @@ class GetJobsAbility {
 			$filters_applied['since'] = $args['since'];
 		}
 
+		if ( isset( $input['parent_job_id'] ) ) {
+			$args['parent_job_id']            = (int) $input['parent_job_id'];
+			$filters_applied['parent_job_id'] = $args['parent_job_id'];
+		}
+
+		if ( ! empty( $input['hide_children'] ) ) {
+			$args['hide_children']            = true;
+			$filters_applied['hide_children'] = true;
+		}
+
 		$jobs  = $this->db_jobs->get_jobs_for_list_table( $args );
 		$total = $this->db_jobs->get_jobs_count( $args );
 

--- a/inc/Api/Jobs.php
+++ b/inc/Api/Jobs.php
@@ -98,13 +98,24 @@ class Jobs {
 						'type'        => 'string',
 						'description' => __( 'Filter by job status', 'data-machine' ),
 					),
-					'user_id'     => array(
-						'required'          => false,
-						'type'              => 'integer',
-						'description'       => __( 'Filter by user ID (admin only, non-admins always see own data)', 'data-machine' ),
-						'sanitize_callback' => 'absint',
-					),
+				'user_id'        => array(
+					'required'          => false,
+					'type'              => 'integer',
+					'description'       => __( 'Filter by user ID (admin only, non-admins always see own data)', 'data-machine' ),
+					'sanitize_callback' => 'absint',
 				),
+				'parent_job_id'  => array(
+					'required'    => false,
+					'type'        => 'integer',
+					'description' => __( 'Filter by parent job ID (for batch child jobs)', 'data-machine' ),
+				),
+				'hide_children'  => array(
+					'required'    => false,
+					'type'        => 'boolean',
+					'default'     => false,
+					'description' => __( 'Hide child jobs from top-level list', 'data-machine' ),
+				),
+			),
 			)
 		);
 
@@ -197,6 +208,12 @@ class Jobs {
 		}
 		if ( $request->get_param( 'status' ) ) {
 			$input['status'] = sanitize_text_field( $request->get_param( 'status' ) );
+		}
+		if ( $request->get_param( 'parent_job_id' ) ) {
+			$input['parent_job_id'] = (int) $request->get_param( 'parent_job_id' );
+		}
+		if ( $request->get_param( 'hide_children' ) ) {
+			$input['hide_children'] = true;
 		}
 
 		$result = self::getAbilities()->executeGetJobs( $input );

--- a/inc/Core/Admin/Pages/Jobs/assets/css/jobs-page.css
+++ b/inc/Core/Admin/Pages/Jobs/assets/css/jobs-page.css
@@ -176,6 +176,95 @@
 	margin: 16px 0 0;
 }
 
+/* ========================================================================
+   BATCH HIERARCHY
+   ======================================================================== */
+
+/* Batch parent row */
+.datamachine-batch-parent {
+	background: #f9f9f9;
+}
+
+.datamachine-batch-parent:hover {
+	background: #f0f0f1;
+}
+
+.datamachine-batch-parent.is-expanded {
+	background: #eef3f8;
+	border-bottom: none;
+}
+
+/* Expand/collapse arrow */
+.datamachine-batch-arrow {
+	display: inline-block;
+	width: 16px;
+	font-size: 10px;
+	color: #646970;
+	margin-right: 4px;
+}
+
+/* Batch progress badge */
+.datamachine-batch-badge {
+	display: inline-block;
+	font-size: 11px;
+	font-weight: 500;
+	padding: 2px 8px;
+	border-radius: 3px;
+	margin-left: 8px;
+	vertical-align: middle;
+	background: #f0f0f1;
+	color: #646970;
+}
+
+.datamachine-batch-badge--complete {
+	background: #d1f5d3;
+	color: #00a32a;
+}
+
+.datamachine-batch-badge--warning {
+	background: #fce4e4;
+	color: #d63638;
+}
+
+.datamachine-batch-badge--progress {
+	background: #e7f3ff;
+	color: #0073aa;
+}
+
+/* Child rows */
+.datamachine-child-row {
+	background: #f6f7f7 !important;
+}
+
+.datamachine-child-row td {
+	border-top: 1px solid #eee;
+}
+
+.datamachine-child-id {
+	padding-left: 24px !important;
+}
+
+.datamachine-child-indicator {
+	color: #a0a5aa;
+	margin-right: 6px;
+	font-size: 14px;
+}
+
+.datamachine-child-loading {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 0;
+	color: #646970;
+	font-size: 13px;
+}
+
+.datamachine-child-empty {
+	color: #646970;
+	font-style: italic;
+	padding: 8px 24px !important;
+}
+
 /* Responsive */
 @media screen and (max-width: 782px) {
 	.datamachine-jobs-header {
@@ -187,5 +276,11 @@
 	.datamachine-col-created,
 	.datamachine-col-completed {
 		display: none;
+	}
+
+	.datamachine-batch-badge {
+		display: block;
+		margin-left: 0;
+		margin-top: 4px;
 	}
 }

--- a/inc/Core/Admin/Pages/Jobs/assets/react/api/jobs.js
+++ b/inc/Core/Admin/Pages/Jobs/assets/react/api/jobs.js
@@ -20,13 +20,19 @@ import { client } from '@shared/utils/api';
  * @param {string} params.status Optional status filter
  * @return {Promise<Object>} Jobs list response
  */
-export const fetchJobs = ( { page = 1, perPage = 50, status } = {} ) => {
+export const fetchJobs = ( {
+	page = 1,
+	perPage = 50,
+	status,
+	hideChildren = true,
+} = {} ) => {
 	const offset = ( page - 1 ) * perPage;
 	const params = {
 		orderby: 'job_id',
 		order: 'DESC',
 		per_page: perPage,
 		offset,
+		hide_children: hideChildren ? 1 : 0,
 	};
 
 	if ( status && status !== 'all' ) {
@@ -34,6 +40,22 @@ export const fetchJobs = ( { page = 1, perPage = 50, status } = {} ) => {
 	}
 
 	return client.get( '/jobs', params );
+};
+
+/**
+ * Fetch child jobs for a batch parent
+ *
+ * @param {number} parentJobId Parent job ID
+ * @return {Promise<Object>} Child jobs list response
+ */
+export const fetchChildJobs = ( parentJobId ) => {
+	return client.get( '/jobs', {
+		parent_job_id: parentJobId,
+		orderby: 'job_id',
+		order: 'ASC',
+		per_page: 100,
+		offset: 0,
+	} );
 };
 
 /**

--- a/inc/Core/Admin/Pages/Jobs/assets/react/components/JobsTable.jsx
+++ b/inc/Core/Admin/Pages/Jobs/assets/react/components/JobsTable.jsx
@@ -1,14 +1,24 @@
 /**
  * JobsTable Component
  *
- * Displays the jobs list in a table format with loading and empty states.
+ * Displays the jobs list with batch parent/child hierarchy.
+ * Parent jobs show a batch progress badge and expand to reveal child jobs.
+ * Child jobs are hidden from the top-level list and lazy-loaded on expand.
+ *
+ * @since 0.44.2
  */
 
 /**
  * WordPress dependencies
  */
+import { useState, useCallback } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useChildJobs } from '../queries/jobs';
 
 const getStatusClass = ( status ) => {
 	if ( ! status ) {
@@ -34,12 +44,229 @@ const formatStatus = ( status ) => {
 	);
 };
 
+/**
+ * Determine if a job is a batch parent from engine_data.
+ */
+const isBatchParent = ( job ) => {
+	if ( ! job.engine_data ) {
+		return false;
+	}
+	const ed =
+		typeof job.engine_data === 'string'
+			? JSON.parse( job.engine_data )
+			: job.engine_data;
+	return !! ed.batch;
+};
+
+/**
+ * Extract batch results from a parent job's engine_data.
+ */
+const getBatchResults = ( job ) => {
+	if ( ! job.engine_data ) {
+		return null;
+	}
+	const ed =
+		typeof job.engine_data === 'string'
+			? JSON.parse( job.engine_data )
+			: job.engine_data;
+	return ed.batch_results || null;
+};
+
+/**
+ * Extract batch total (scheduled count) from engine_data.
+ */
+const getBatchTotal = ( job ) => {
+	if ( ! job.engine_data ) {
+		return 0;
+	}
+	const ed =
+		typeof job.engine_data === 'string'
+			? JSON.parse( job.engine_data )
+			: job.engine_data;
+	return ed.batch_total || ed.batch_scheduled || 0;
+};
+
+/**
+ * Batch progress badge for parent jobs.
+ */
+const BatchBadge = ( { job } ) => {
+	const results = getBatchResults( job );
+	const total = getBatchTotal( job );
+
+	if ( ! total ) {
+		return (
+			<span className="datamachine-batch-badge">
+				{ __( 'Batch', 'data-machine' ) }
+			</span>
+		);
+	}
+
+	if ( results ) {
+		const parts = [];
+		if ( results.completed > 0 ) {
+			parts.push(
+				`${ results.completed }/${ results.total } ${ __(
+					'completed',
+					'data-machine'
+				) }`
+			);
+		}
+		if ( results.failed > 0 ) {
+			parts.push(
+				`${ results.failed } ${ __( 'failed', 'data-machine' ) }`
+			);
+		}
+		if ( results.skipped > 0 ) {
+			parts.push(
+				`${ results.skipped } ${ __( 'skipped', 'data-machine' ) }`
+			);
+		}
+
+		const hasFailures = results.failed > 0;
+
+		return (
+			<span
+				className={ `datamachine-batch-badge ${
+					hasFailures
+						? 'datamachine-batch-badge--warning'
+						: 'datamachine-batch-badge--complete'
+				}` }
+			>
+				{ parts.join( ', ' ) }
+			</span>
+		);
+	}
+
+	// Batch in progress — no results yet.
+	return (
+		<span className="datamachine-batch-badge datamachine-batch-badge--progress">
+			{ `${ __( 'Batch:', 'data-machine' ) } ${ total } ${ __(
+				'items',
+				'data-machine'
+			) }` }
+		</span>
+	);
+};
+
+/**
+ * Expandable child rows for a batch parent.
+ */
+const ChildRows = ( { parentJobId } ) => {
+	const { data: children, isLoading, isError } = useChildJobs( parentJobId );
+
+	if ( isLoading ) {
+		return (
+			<tr className="datamachine-child-row datamachine-child-row--loading">
+				<td colSpan="5">
+					<div className="datamachine-child-loading">
+						<Spinner />
+						<span>
+							{ __( 'Loading child jobs\u2026', 'data-machine' ) }
+						</span>
+					</div>
+				</td>
+			</tr>
+		);
+	}
+
+	if ( isError || ! children || children.length === 0 ) {
+		return (
+			<tr className="datamachine-child-row">
+				<td colSpan="5" className="datamachine-child-empty">
+					{ __( 'No child jobs found.', 'data-machine' ) }
+				</td>
+			</tr>
+		);
+	}
+
+	return children.map( ( child ) => (
+		<tr key={ child.job_id } className="datamachine-child-row">
+			<td className="datamachine-child-id">
+				<span className="datamachine-child-indicator">
+					{ '\u21b3' }
+				</span>
+				{ child.job_id }
+			</td>
+			<td>
+				{ child.display_label ||
+					child.label ||
+					__( 'Child job', 'data-machine' ) }
+			</td>
+			<td>
+				<span className={ getStatusClass( child.status ) }>
+					{ formatStatus( child.status ) }
+				</span>
+			</td>
+			<td>{ child.created_at_display || '' }</td>
+			<td>{ child.completed_at_display || '' }</td>
+		</tr>
+	) );
+};
+
+/**
+ * Single job row — handles expand/collapse for batch parents.
+ */
+const JobRow = ( { job, isExpanded, onToggle } ) => {
+	const isBatch = isBatchParent( job );
+
+	return (
+		<>
+			<tr
+				className={ `${
+					isBatch ? 'datamachine-batch-parent' : ''
+				} ${ isExpanded ? 'is-expanded' : '' }` }
+				onClick={ isBatch ? onToggle : undefined }
+				style={ isBatch ? { cursor: 'pointer' } : undefined }
+			>
+				<td>
+					<strong>
+						{ isBatch && (
+							<span
+								className="datamachine-batch-arrow"
+								aria-hidden="true"
+							>
+								{ isExpanded ? '\u25bc' : '\u25b6' }
+							</span>
+						) }
+						{ job.job_id }
+					</strong>
+				</td>
+				<td>
+					{ job.display_label ||
+						job.label ||
+						( job.pipeline_name && job.flow_name
+							? `${ job.pipeline_name } \u2192 ${ job.flow_name }`
+							: __( 'Unknown', 'data-machine' ) ) }
+					{ isBatch && <BatchBadge job={ job } /> }
+				</td>
+				<td>
+					<span className={ getStatusClass( job.status ) }>
+						{ formatStatus( job.status ) }
+					</span>
+				</td>
+				<td>{ job.created_at_display || '' }</td>
+				<td>{ job.completed_at_display || '' }</td>
+			</tr>
+			{ isExpanded && <ChildRows parentJobId={ job.job_id } /> }
+		</>
+	);
+};
+
 const JobsTable = ( { jobs, isLoading, isError, error } ) => {
+	const [ expandedJobs, setExpandedJobs ] = useState( {} );
+
+	const toggleExpand = useCallback( ( jobId ) => {
+		setExpandedJobs( ( prev ) => ( {
+			...prev,
+			[ jobId ]: ! prev[ jobId ],
+		} ) );
+	}, [] );
+
 	if ( isLoading ) {
 		return (
 			<div className="datamachine-jobs-loading">
 				<Spinner />
-				<span>{ __( 'Loading jobs…', 'data-machine' ) }</span>
+				<span>{ __( 'Loading jobs\u2026', 'data-machine' ) }</span>
 			</div>
 		);
 	}
@@ -88,27 +315,12 @@ const JobsTable = ( { jobs, isLoading, isError, error } ) => {
 				</thead>
 				<tbody>
 					{ jobs.map( ( job ) => (
-						<tr key={ job.job_id }>
-							<td>
-								<strong>{ job.job_id }</strong>
-							</td>
-							<td>
-								{ job.display_label ||
-									job.label ||
-									( job.pipeline_name && job.flow_name
-										? `${ job.pipeline_name } → ${ job.flow_name }`
-										: __( 'Unknown', 'data-machine' ) ) }
-							</td>
-							<td>
-								<span
-									className={ getStatusClass( job.status ) }
-								>
-									{ formatStatus( job.status ) }
-								</span>
-							</td>
-							<td>{ job.created_at_display || '' }</td>
-							<td>{ job.completed_at_display || '' }</td>
-						</tr>
+						<JobRow
+							key={ job.job_id }
+							job={ job }
+							isExpanded={ !! expandedJobs[ job.job_id ] }
+							onToggle={ () => toggleExpand( job.job_id ) }
+						/>
 					) ) }
 				</tbody>
 			</table>

--- a/inc/Core/Admin/Pages/Jobs/assets/react/queries/jobs.js
+++ b/inc/Core/Admin/Pages/Jobs/assets/react/queries/jobs.js
@@ -19,6 +19,7 @@ import * as jobsApi from '../api/jobs';
 export const jobsKeys = {
 	all: [ 'jobs' ],
 	list: ( params ) => [ ...jobsKeys.all, 'list', params ],
+	children: ( parentJobId ) => [ ...jobsKeys.all, 'children', parentJobId ],
 	pipelines: () => [ 'pipelines', 'dropdown' ],
 	flows: ( pipelineId ) => [ 'flows', 'dropdown', pipelineId ],
 };
@@ -38,6 +39,7 @@ export const useJobs = ( { page = 1, perPage = 50, status } = {} ) =>
 				page,
 				perPage,
 				status,
+				hideChildren: true,
 			} );
 			if ( ! response.success ) {
 				throw new Error( response.message || 'Failed to fetch jobs' );
@@ -75,6 +77,27 @@ export const useClearProcessedItems = () => {
 			jobsApi.clearProcessedItems( clearType, targetId ),
 	} );
 };
+
+/**
+ * Fetch child jobs for a batch parent (lazy-loaded on expand)
+ *
+ * @param {number|null} parentJobId Parent job ID (null = disabled)
+ */
+export const useChildJobs = ( parentJobId ) =>
+	useQuery( {
+		queryKey: jobsKeys.children( parentJobId ),
+		queryFn: async () => {
+			const response = await jobsApi.fetchChildJobs( parentJobId );
+			if ( ! response.success ) {
+				throw new Error(
+					response.message || 'Failed to fetch child jobs'
+				);
+			}
+			return response.data || [];
+		},
+		enabled: !! parentJobId,
+		staleTime: 30 * 1000,
+	} );
 
 /**
  * Fetch pipelines for dropdown

--- a/inc/Core/Database/Jobs/JobsOperations.php
+++ b/inc/Core/Database/Jobs/JobsOperations.php
@@ -187,6 +187,15 @@ class JobsOperations extends BaseRepository {
 			$where_values[]  = sanitize_text_field( $args['since'] );
 		}
 
+		if ( isset( $args['parent_job_id'] ) ) {
+			$where_clauses[] = 'parent_job_id = %d';
+			$where_values[]  = absint( $args['parent_job_id'] );
+		}
+
+		if ( ! empty( $args['hide_children'] ) ) {
+			$where_clauses[] = '(parent_job_id IS NULL OR parent_job_id = 0)';
+		}
+
 		$where_sql = '';
 		if ( ! empty( $where_clauses ) ) {
 			$where_sql = 'WHERE ' . implode( ' AND ', $where_clauses );
@@ -286,6 +295,15 @@ class JobsOperations extends BaseRepository {
 		if ( ! empty( $args['since'] ) ) {
 			$where_clauses[] = 'j.created_at >= %s';
 			$where_values[]  = sanitize_text_field( $args['since'] );
+		}
+
+		if ( isset( $args['parent_job_id'] ) ) {
+			$where_clauses[] = 'j.parent_job_id = %d';
+			$where_values[]  = absint( $args['parent_job_id'] );
+		}
+
+		if ( ! empty( $args['hide_children'] ) ) {
+			$where_clauses[] = '(j.parent_job_id IS NULL OR j.parent_job_id = 0)';
 		}
 
 		$where_sql = '';


### PR DESCRIPTION
## Summary

Implements batch parent/child job hierarchy on the Jobs admin page. Closes #569.

- **Child jobs hidden by default** from the top-level list via `hide_children` filter — no more clutter
- **Batch parent badge** shows progress from `engine_data.batch_results`: "12/15 completed, 2 failed, 1 skipped"
- **Expandable child rows** — click a parent job to lazy-load and display its children inline
- **Child job indicators** — indented rows with ↳ arrow linking back to the parent

## Changes

### Backend (3 files)
- `JobsOperations.php` — Added `parent_job_id` and `hide_children` WHERE clauses to both `get_jobs_for_list_table()` and `get_jobs_count()`
- `Jobs.php` (REST API) — Registered `parent_job_id` (integer) and `hide_children` (boolean) params on `GET /jobs`, passed through in `handle_get_jobs()`
- `GetJobsAbility.php` — Pass-through for both new filters into the DB layer

### Frontend (4 files)
- `api/jobs.js` — `fetchJobs()` now sends `hide_children=1` by default; new `fetchChildJobs(parentJobId)` function
- `queries/jobs.js` — New `useChildJobs(parentJobId)` hook with lazy loading (`enabled: !!parentJobId`), new `children` query key
- `JobsTable.jsx` — Rewritten with `JobRow`, `BatchBadge`, `ChildRows` components. Batch parents are clickable with expand/collapse state. Child rows render indented with status
- `jobs-page.css` — Batch badge styles (complete/warning/progress variants), child row indentation, expand/collapse visual states

## Technical Notes

- `parent_job_id` column is already indexed (`KEY parent_job_id`)
- `engine_data.batch` and `engine_data.batch_results` are set by `PipelineBatchScheduler` — no changes needed there
- Child jobs are fetched ASC by job_id for chronological display
- The `hide_children` filter uses `(parent_job_id IS NULL OR parent_job_id = 0)` to handle both NULL and zero values