### PR TITLE
feat: processed-items audit and enhanced clear CLI

### DIFF
--- a/inc/Cli/Commands/ProcessedItemsCommand.php
+++ b/inc/Cli/Commands/ProcessedItemsCommand.php
@@ -13,6 +13,7 @@ namespace DataMachine\Cli\Commands;
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\ProcessedItemsAbilities;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -24,7 +25,137 @@ defined( 'ABSPATH' ) || exit;
 class ProcessedItemsCommand extends BaseCommand {
 
 	/**
-	 * Clear processed items for a pipeline or flow.
+	 * Audit processed items vs actual published posts per flow.
+	 *
+	 * Shows how many items were marked as "processed" in dedup tracking
+	 * versus how many posts were actually published. A large gap indicates
+	 * items that were fetched and deduped but never imported (the max_items
+	 * burn bug).
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--handler=<handler_type>]
+	 * : Filter to a specific handler type (e.g., "ticketmaster", "dice_fm", "universal_web_scraper").
+	 *
+	 * [--pipeline=<pipeline_id>]
+	 * : Filter to a specific pipeline.
+	 *
+	 * [--min-waste=<count>]
+	 * : Only show flows with at least this many wasted items. Default: 10.
+	 *
+	 * [--format=<format>]
+	 * : Output format. Default: table.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine processed-items audit
+	 *     wp datamachine processed-items audit --handler=ticketmaster
+	 *     wp datamachine processed-items audit --pipeline=3 --min-waste=0
+	 *
+	 * @subcommand audit
+	 */
+	public function audit( array $args, array $assoc_args ): void {
+		global $wpdb;
+
+		$handler_filter  = $assoc_args['handler'] ?? null;
+		$pipeline_filter = $assoc_args['pipeline'] ?? null;
+		$min_waste       = (int) ( $assoc_args['min-waste'] ?? 10 );
+		$format          = $assoc_args['format'] ?? 'table';
+
+		$db    = new ProcessedItems();
+		$table = $db->get_table_name();
+
+		// Get processed items grouped by flow_step_id and source_type.
+		$where_clauses = array();
+		$prepare_args  = array( $table );
+
+		if ( $handler_filter ) {
+			$where_clauses[] = 'source_type = %s';
+			$prepare_args[]  = $handler_filter;
+		}
+
+		$where_sql = ! empty( $where_clauses ) ? 'WHERE ' . implode( ' AND ', $where_clauses ) : '';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT
+					flow_step_id,
+					source_type,
+					COUNT(*) as processed_count,
+					MIN(processed_timestamp) as first_processed,
+					MAX(processed_timestamp) as last_processed,
+					CAST(SUBSTRING_INDEX(flow_step_id, '_', -1) AS UNSIGNED) as flow_id
+				FROM %i
+				{$where_sql}
+				GROUP BY flow_step_id, source_type
+				ORDER BY processed_count DESC",
+				...$prepare_args
+			),
+			ARRAY_A
+		);
+
+		if ( empty( $results ) ) {
+			WP_CLI::log( 'No processed items found.' );
+			return;
+		}
+
+		// Enrich with flow names and filter by pipeline.
+		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
+		$rows     = array();
+
+		foreach ( $results as $row ) {
+			$flow_id = (int) $row['flow_id'];
+			$flow    = $db_flows->get_flow( $flow_id );
+
+			if ( ! $flow ) {
+				continue;
+			}
+
+			if ( $pipeline_filter && (int) $flow['pipeline_id'] !== (int) $pipeline_filter ) {
+				continue;
+			}
+
+			$processed = (int) $row['processed_count'];
+			$waste     = $processed; // Conservative: all processed items are "waste" until proven otherwise.
+
+			if ( $waste < $min_waste ) {
+				continue;
+			}
+
+			$rows[] = array(
+				'flow_id'         => $flow_id,
+				'flow_name'       => $flow['flow_name'] ?? '?',
+				'pipeline_id'     => $flow['pipeline_id'] ?? '?',
+				'handler'         => $row['source_type'],
+				'processed'       => $processed,
+				'first_seen'      => $row['first_processed'],
+				'last_seen'       => $row['last_processed'],
+			);
+		}
+
+		if ( empty( $rows ) ) {
+			WP_CLI::log( 'No flows match the criteria.' );
+			return;
+		}
+
+		// Summary.
+		$total_processed = array_sum( array_column( $rows, 'processed' ) );
+		WP_CLI::log( sprintf( 'Total processed items across %d flows: %s', count( $rows ), number_format( $total_processed ) ) );
+		WP_CLI::log( '' );
+
+		WP_CLI\Utils\format_items( $format, $rows, array_keys( $rows[0] ) );
+	}
+
+	/**
+	 * Clear processed items for a pipeline, flow, handler, or date range.
 	 *
 	 * Resets deduplication tracking so items can be re-processed.
 	 *
@@ -36,6 +167,21 @@ class ProcessedItemsCommand extends BaseCommand {
 	 * [--flow=<flow_id>]
 	 * : Clear all processed items for this flow ID.
 	 *
+	 * [--handler=<handler_type>]
+	 * : Clear all processed items for this handler type (e.g., "ticketmaster", "dice_fm").
+	 *
+	 * [--after=<date>]
+	 * : Only clear items processed after this date (YYYY-MM-DD or datetime).
+	 *
+	 * [--before=<date>]
+	 * : Only clear items processed before this date (YYYY-MM-DD or datetime).
+	 *
+	 * [--all]
+	 * : Clear ALL processed items. Requires --yes.
+	 *
+	 * [--dry-run]
+	 * : Show what would be deleted without actually deleting.
+	 *
 	 * [--yes]
 	 * : Skip confirmation prompt.
 	 *
@@ -43,22 +189,42 @@ class ProcessedItemsCommand extends BaseCommand {
 	 *
 	 *     wp datamachine processed-items clear --pipeline=12
 	 *     wp datamachine processed-items clear --flow=42
-	 *     wp datamachine processed-items clear --pipeline=12 --yes
+	 *     wp datamachine processed-items clear --handler=ticketmaster --yes
+	 *     wp datamachine processed-items clear --handler=ticketmaster --after=2025-01-01
+	 *     wp datamachine processed-items clear --all --yes
+	 *     wp datamachine processed-items clear --handler=dice_fm --dry-run
 	 *
 	 * @subcommand clear
 	 */
 	public function clear( array $args, array $assoc_args ): void {
+		global $wpdb;
+
 		$pipeline_id  = $assoc_args['pipeline'] ?? null;
 		$flow_id      = $assoc_args['flow'] ?? null;
+		$handler      = $assoc_args['handler'] ?? null;
+		$after        = $assoc_args['after'] ?? null;
+		$before       = $assoc_args['before'] ?? null;
+		$clear_all    = isset( $assoc_args['all'] );
+		$dry_run      = isset( $assoc_args['dry-run'] );
 		$skip_confirm = isset( $assoc_args['yes'] );
 
-		if ( $pipeline_id && $flow_id ) {
-			WP_CLI::error( 'Specify either --pipeline or --flow, not both.' );
+		// Validate: need at least one filter.
+		$has_filter = $pipeline_id || $flow_id || $handler || $after || $before || $clear_all;
+		if ( ! $has_filter ) {
+			WP_CLI::error( 'Specify at least one of: --pipeline, --flow, --handler, --after, --before, or --all.' );
 			return;
 		}
 
-		if ( ! $pipeline_id && ! $flow_id ) {
-			WP_CLI::error( 'Either --pipeline=<id> or --flow=<id> is required.' );
+		// If --handler or date filters are used, go direct to DB.
+		// Otherwise use the abilities API for pipeline/flow clearing.
+		if ( $handler || $after || $before || $clear_all ) {
+			$this->clear_with_filters( $assoc_args );
+			return;
+		}
+
+		// Legacy path: pipeline or flow via abilities.
+		if ( $pipeline_id && $flow_id ) {
+			WP_CLI::error( 'Specify either --pipeline or --flow, not both.' );
 			return;
 		}
 
@@ -85,6 +251,133 @@ class ProcessedItemsCommand extends BaseCommand {
 		}
 
 		WP_CLI::success( $result['message'] );
+	}
+
+	/**
+	 * Clear processed items using handler/date filters via direct DB queries.
+	 *
+	 * @param array $assoc_args CLI associative args.
+	 */
+	private function clear_with_filters( array $assoc_args ): void {
+		global $wpdb;
+
+		$handler      = $assoc_args['handler'] ?? null;
+		$pipeline_id  = $assoc_args['pipeline'] ?? null;
+		$flow_id      = $assoc_args['flow'] ?? null;
+		$after        = $assoc_args['after'] ?? null;
+		$before       = $assoc_args['before'] ?? null;
+		$clear_all    = isset( $assoc_args['all'] );
+		$dry_run      = isset( $assoc_args['dry-run'] );
+		$skip_confirm = isset( $assoc_args['yes'] );
+
+		$db    = new ProcessedItems();
+		$table = $db->get_table_name();
+
+		$where_parts = array();
+		$values      = array( $table );
+
+		if ( $handler ) {
+			$where_parts[] = 'source_type = %s';
+			$values[]      = $handler;
+		}
+
+		if ( $flow_id ) {
+			$where_parts[] = 'flow_step_id LIKE %s';
+			$values[]      = '%_' . $flow_id;
+		}
+
+		if ( $pipeline_id ) {
+			// Get flows for this pipeline and build OR condition.
+			$db_flows = new \DataMachine\Core\Database\Flows\Flows();
+			$flows    = $db_flows->get_flows_for_pipeline( (int) $pipeline_id );
+
+			if ( empty( $flows ) ) {
+				WP_CLI::error( sprintf( 'No flows found for pipeline %s.', $pipeline_id ) );
+				return;
+			}
+
+			$flow_patterns = array();
+			foreach ( $flows as $flow ) {
+				$flow_patterns[] = "flow_step_id LIKE %s";
+				$values[]        = '%_' . $flow['flow_id'];
+			}
+			$where_parts[] = '(' . implode( ' OR ', $flow_patterns ) . ')';
+		}
+
+		if ( $after ) {
+			$where_parts[] = 'processed_timestamp >= %s';
+			$values[]      = $after;
+		}
+
+		if ( $before ) {
+			$where_parts[] = 'processed_timestamp <= %s';
+			$values[]      = $before;
+		}
+
+		if ( ! $clear_all && empty( $where_parts ) ) {
+			WP_CLI::error( 'No valid filters provided.' );
+			return;
+		}
+
+		$where_sql = ! empty( $where_parts ) ? 'WHERE ' . implode( ' AND ', $where_parts ) : '';
+
+		// Count first.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM %i {$where_sql}", ...$values )
+		);
+
+		if ( 0 === $count ) {
+			WP_CLI::log( 'No processed items match the criteria.' );
+			return;
+		}
+
+		// Build description for confirmation.
+		$desc_parts = array();
+		if ( $handler ) {
+			$desc_parts[] = "handler={$handler}";
+		}
+		if ( $pipeline_id ) {
+			$desc_parts[] = "pipeline={$pipeline_id}";
+		}
+		if ( $flow_id ) {
+			$desc_parts[] = "flow={$flow_id}";
+		}
+		if ( $after ) {
+			$desc_parts[] = "after={$after}";
+		}
+		if ( $before ) {
+			$desc_parts[] = "before={$before}";
+		}
+		if ( $clear_all ) {
+			$desc_parts[] = 'ALL';
+		}
+
+		$desc = implode( ', ', $desc_parts );
+
+		if ( $dry_run ) {
+			WP_CLI::log( sprintf( 'DRY RUN: Would delete %s processed items matching: %s', number_format( $count ), $desc ) );
+			return;
+		}
+
+		if ( ! $skip_confirm ) {
+			WP_CLI::confirm(
+				sprintf( 'Delete %s processed items matching: %s?', number_format( $count ), $desc )
+			);
+		}
+
+		// Delete.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$deleted = $wpdb->query(
+			$wpdb->prepare( "DELETE FROM %i {$where_sql}", ...$values )
+		);
+
+		if ( false === $deleted ) {
+			WP_CLI::error( 'Database error during deletion: ' . $wpdb->last_error );
+			return;
+		}
+
+		WP_CLI::success( sprintf( 'Deleted %s processed items (%s).', number_format( $deleted ), $desc ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- New `audit` subcommand: per-flow stats of processed items with flow names, handler types, date ranges
- Enhanced `clear`: supports `--handler`, `--after`, `--before`, `--all`, `--dry-run`, and combinations

## New Commands
```bash
# Audit — see the damage
wp datamachine processed-items audit
wp datamachine processed-items audit --handler=ticketmaster
wp datamachine processed-items audit --pipeline=3 --min-waste=0

# Clear with filters
wp datamachine processed-items clear --handler=ticketmaster --yes
wp datamachine processed-items clear --handler=ticketmaster --after=2025-01-01
wp datamachine processed-items clear --all --yes
wp datamachine processed-items clear --handler=dice_fm --dry-run
```

## Why
Supports diagnosing and remediating the dedup-burn bug (#842) where items were marked as processed but never imported due to the max_items cap running after dedup marking.