### PR TITLE
Fix batch child jobs created as 'processing' instead of 'pending'

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -102,6 +102,13 @@ class ExecuteStepAbility {
 		$job_id       = (int) ( $input['job_id'] ?? 0 );
 		$flow_step_id = (string) ( $input['flow_step_id'] ?? '' );
 
+		// Transition job to 'processing' now that Action Scheduler is actually
+		// executing it. For parent jobs this is a no-op (already processing via
+		// RunFlowAbility). For batch child jobs this is the real transition from
+		// 'pending' → 'processing', ensuring recover-stuck only catches jobs
+		// that genuinely started but never finished.
+		$this->db_jobs->start_job( $job_id );
+
 		try {
 			$engine_snapshot = datamachine_get_engine_data( $job_id );
 			$engine          = new EngineData( $engine_snapshot, $job_id );

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -314,7 +314,10 @@ class PipelineBatchScheduler {
 		}
 
 		datamachine_set_engine_data( $child_job_id, $child_engine );
-		$this->db_jobs->start_job( $child_job_id );
+
+		// Child job stays 'pending' until Action Scheduler actually picks it up.
+		// ExecuteStepAbility transitions to 'processing' at execution time,
+		// so recover-stuck only catches genuinely stuck jobs.
 
 		// Schedule the next step with this single DataPacket.
 		// Uses the normal engine path — the child is a real pipeline job.

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -99,8 +99,9 @@ class TaskScheduler {
 			'scheduled_at' => current_time( 'mysql' ),
 		) ) );
 
-		// Mark job as processing.
-		$jobs_db->start_job( (int) $job_id, JobStatus::PROCESSING );
+		// Job stays 'pending' until Action Scheduler fires handleTask().
+		// The transition to 'processing' happens there, so recover-stuck
+		// only catches jobs that genuinely started but never finished.
 
 		// Schedule Action Scheduler action.
 		if ( function_exists( 'as_schedule_single_action' ) ) {
@@ -448,7 +449,11 @@ class TaskScheduler {
 	 */
 	public static function handleTask( int $jobId ): void {
 		$jobs_db = new Jobs();
-		$job     = $jobs_db->get_job( $jobId );
+
+		// Transition from 'pending' → 'processing' now that AS is running this.
+		$jobs_db->start_job( $jobId, JobStatus::PROCESSING );
+
+		$job = $jobs_db->get_job( $jobId );
 
 		if ( ! $job ) {
 			do_action(


### PR DESCRIPTION
## Summary

Fixes #858 — batch fan-out child jobs were immediately set to `processing` at creation time, before Action Scheduler picked them up. After 2 hours, `recover-stuck` would mark them as timed out even though they were just waiting in the AS queue.

## Root cause

```
PipelineBatchScheduler::createChildJob()
  1. create_job()     → status = 'pending'  ✓
  2. start_job()      → status = 'processing'  ← BUG: premature
  3. schedule_next_step()  → AS queues it for later
  
  // 2 hours pass, AS hasn't gotten to it yet...
  recover-stuck sees: status='processing', age > 2h → marks FAILED
```

Same pattern in `TaskScheduler::scheduleTask()`.

## Fix

Move the `pending` → `processing` transition to the **actual moment of execution**:

| Location | Before | After |
|----------|--------|-------|
| `PipelineBatchScheduler::createChildJob()` | `start_job()` after `create_job()` | Removed — child stays `pending` |
| `ExecuteStepAbility::execute()` | No status change | Added `start_job()` at entry — transitions to `processing` when AS fires |
| `TaskScheduler::scheduleTask()` | `start_job()` after `create_job()` | Removed — task stays `pending` |
| `TaskScheduler::handleTask()` | No status change | Added `start_job()` at entry — transitions to `processing` when AS fires |

For **parent jobs**, the `start_job()` in `ExecuteStepAbility` is a no-op (already `processing` via `RunFlowAbility`). For **child jobs**, it's the real transition.

## Result

- `recover-stuck` only catches genuinely stuck jobs (started processing but never finished)
- Jobs waiting in the AS queue stay `pending` and won't be incorrectly timed out
- No changes to the recover-stuck logic itself — it correctly targets `processing` status

## Testing

- 873/873 tests pass (29 pre-existing failures on main, unchanged)
- Lint passes with no new findings