### PR TITLE
fix: create-flow scheduling race — AS action never registered

### DIFF
--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -170,11 +170,15 @@ class CreateFlowAbility {
 		$scheduling_config = $input['scheduling_config'] ?? array( 'interval' => 'manual' );
 		$flow_config       = $input['flow_config'] ?? array();
 
+		// Store scheduling_config as manual initially. The actual scheduling
+		// (AS recurring action) is created by handle_scheduling_update() below.
+		// If we stored the real interval here, handle_scheduling_update() would
+		// see "nothing changed" and skip creating the AS action.
 		$flow_data = array(
 			'pipeline_id'       => $pipeline_id,
 			'flow_name'         => $flow_name,
 			'flow_config'       => $flow_config,
-			'scheduling_config' => $scheduling_config,
+			'scheduling_config' => array( 'interval' => 'manual' ),
 		);
 
 		if ( null !== $agent_id && $agent_id > 0 ) {


### PR DESCRIPTION
## Bug
`create-flow` saved `scheduling_config` to DB first, then called `handle_scheduling_update()`. But that function reads the flow back, sees the interval is already set, and returns early ("nothing changed"). The AS recurring action was never created.

## Fix
Create the flow with `interval=manual`, then let `handle_scheduling_update()` see the transition from `manual` → `daily` and register the AS action.

## Impact
All 68 venue scraper flows created via `extrachill/add-venue` had no schedule until manually fixed. Closes #869.