### PR TITLE
feat: capture token usage from AI providers

### DIFF
--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -176,6 +176,24 @@ class ChatOrchestrator {
 			'has_pending_tools' => ! $is_completed,
 		);
 
+		// Accumulate token usage across turns in session metadata.
+		$turn_usage = $result['usage'] ?? array();
+		if ( ! empty( $turn_usage ) && ( $turn_usage['total_tokens'] ?? 0 ) > 0 ) {
+			$existing_session  = $chat_db->get_session( $session_id );
+			$existing_metadata = ! empty( $existing_session['metadata'] ) ? json_decode( $existing_session['metadata'], true ) : array();
+			$existing_usage    = $existing_metadata['token_usage'] ?? array(
+				'prompt_tokens'     => 0,
+				'completion_tokens' => 0,
+				'total_tokens'      => 0,
+			);
+
+			$metadata['token_usage'] = array(
+				'prompt_tokens'     => (int) $existing_usage['prompt_tokens'] + (int) ( $turn_usage['prompt_tokens'] ?? 0 ),
+				'completion_tokens' => (int) $existing_usage['completion_tokens'] + (int) ( $turn_usage['completion_tokens'] ?? 0 ),
+				'total_tokens'      => (int) $existing_usage['total_tokens'] + (int) ( $turn_usage['total_tokens'] ?? 0 ),
+			);
+		}
+
 		if ( $selected_pipeline_id ) {
 			$metadata['selected_pipeline_id'] = $selected_pipeline_id;
 		}
@@ -312,6 +330,21 @@ class ChatOrchestrator {
 			'has_pending_tools' => ! $is_completed,
 		);
 
+		// Accumulate token usage across continuation turns.
+		$turn_usage     = $result['usage'] ?? array();
+		$existing_usage = $metadata['token_usage'] ?? array(
+			'prompt_tokens'     => 0,
+			'completion_tokens' => 0,
+			'total_tokens'      => 0,
+		);
+		if ( ! empty( $turn_usage ) && ( $turn_usage['total_tokens'] ?? 0 ) > 0 ) {
+			$updated_metadata['token_usage'] = array(
+				'prompt_tokens'     => (int) $existing_usage['prompt_tokens'] + (int) ( $turn_usage['prompt_tokens'] ?? 0 ),
+				'completion_tokens' => (int) $existing_usage['completion_tokens'] + (int) ( $turn_usage['completion_tokens'] ?? 0 ),
+				'total_tokens'      => (int) $existing_usage['total_tokens'] + (int) ( $turn_usage['total_tokens'] ?? 0 ),
+			);
+		}
+
 		if ( $selected_pipeline_id ) {
 			$updated_metadata['selected_pipeline_id'] = $selected_pipeline_id;
 		}
@@ -400,16 +433,23 @@ class ChatOrchestrator {
 			return $result;
 		}
 
-		// Update session to completed with ping source.
+		// Update session to completed with ping source and token usage.
+		$ping_metadata = array(
+			'status'        => 'completed',
+			'last_activity' => current_time( 'mysql', true ),
+			'message_count' => count( $result['messages'] ),
+			'source'        => 'ping',
+		);
+
+		$ping_usage = $result['usage'] ?? array();
+		if ( ! empty( $ping_usage ) && ( $ping_usage['total_tokens'] ?? 0 ) > 0 ) {
+			$ping_metadata['token_usage'] = $ping_usage;
+		}
+
 		$chat_db->update_session(
 			$session_id,
 			$result['messages'],
-			array(
-				'status'        => 'completed',
-				'last_activity' => current_time( 'mysql', true ),
-				'message_count' => count( $result['messages'] ),
-				'source'        => 'ping',
-			),
+			$ping_metadata,
 			$provider,
 			$model
 		);
@@ -621,6 +661,7 @@ class ChatOrchestrator {
 				'last_tool_calls'   => $loop_result['last_tool_calls'] ?? array(),
 				'warning'           => $loop_result['warning'] ?? null,
 				'max_turns_reached' => $loop_result['max_turns_reached'] ?? false,
+				'usage'             => $loop_result['usage'] ?? array(),
 			);
 		} catch ( \Throwable $e ) {
 			do_action(

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -256,6 +256,15 @@ class AIStep extends Step {
 			return array();
 		}
 
+		// Store token usage in job engine_data (read-then-merge — store_engine_data is a full overwrite).
+		$usage = $loop_result['usage'] ?? array();
+		if ( ! empty( $usage ) && $this->job_id > 0 && ( $usage['total_tokens'] ?? 0 ) > 0 ) {
+			$jobs_db       = new \DataMachine\Core\Database\Jobs\Jobs();
+			$existing_data = $engine_data;
+			$existing_data['token_usage'] = $usage;
+			$jobs_db->store_engine_data( $this->job_id, $existing_data );
+		}
+
 		// Process loop results into data packets
 		return self::processLoopResults( $loop_result, $this->dataPackets, $payload, $available_tools );
 	}

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -43,6 +43,7 @@ class AIConversationLoop {
 	 *     @type int    $turn_count      Number of turns executed
 	 *     @type bool   $completed       Whether loop finished naturally (no tool calls)
 	 *     @type array  $last_tool_calls Last set of tool calls (if any)
+	 *     @type array  $usage           Accumulated token usage {prompt_tokens, completion_tokens, total_tokens}
 	 * }
 	 */
 	public function execute(
@@ -62,6 +63,13 @@ class AIConversationLoop {
 		$final_content          = '';
 		$last_tool_calls        = array();
 		$tool_execution_results = array();
+
+		// Accumulate token usage across all turns.
+		$total_usage = array(
+			'prompt_tokens'     => 0,
+			'completion_tokens' => 0,
+			'total_tokens'      => 0,
+		);
 
 		// Track which handler tools have been executed for multi-handler support.
 		// In pipeline mode, conversation should only complete when ALL configured
@@ -116,11 +124,20 @@ class AIConversationLoop {
 					'completed'       => false,
 					'last_tool_calls' => array(),
 					'error'           => $ai_response['error'] ?? 'AI request failed',
+					'usage'           => $total_usage,
 				);
 			}
 
 			$tool_calls = $ai_response['data']['tool_calls'] ?? array();
 			$ai_content = $ai_response['data']['content'] ?? '';
+
+			// Accumulate token usage from this turn.
+			$turn_usage = $ai_response['data']['usage'] ?? array();
+			if ( ! empty( $turn_usage ) ) {
+				$total_usage['prompt_tokens']     += (int) ( $turn_usage['prompt_tokens'] ?? 0 );
+				$total_usage['completion_tokens'] += (int) ( $turn_usage['completion_tokens'] ?? 0 );
+				$total_usage['total_tokens']      += (int) ( $turn_usage['total_tokens'] ?? 0 );
+			}
 
 			// Store final content from this turn
 			if ( ! empty( $ai_content ) ) {
@@ -355,6 +372,7 @@ class AIConversationLoop {
 			'last_tool_calls'        => $last_tool_calls,
 			'tool_execution_results' => $tool_execution_results,
 			'has_pending_tools'      => ! empty( $last_tool_calls ) && ! $conversation_complete,
+			'usage'                  => $total_usage,
 		);
 
 		if ( $turn_count >= $max_turns && ! $conversation_complete ) {


### PR DESCRIPTION
## Summary

Stops dropping token usage data on the floor. Every AI provider in `ai-http-client` already parses `prompt_tokens`, `completion_tokens`, and `total_tokens` from API responses — Data Machine was just ignoring them.

## The data flow

```
ai-http-client                     Data Machine
┌──────────────┐     ┌────────────────────────────────────────────┐
│ Provider      │     │ AIConversationLoop                         │
│ format_       │────▶│ accumulates usage across turns              │
│ response()    │     │                                            │
│ returns usage │     │     ┌──────────────┐  ┌──────────────────┐ │
│               │     │     │ AIStep       │  │ ChatOrchestrator │ │
│               │     │     │ → engine_data│  │ → metadata       │ │
│               │     │     │   .token_    │  │   .token_usage   │ │
│               │     │     │    usage     │  │                  │ │
└──────────────┘     │     └──────────────┘  └──────────────────┘ │
                      └────────────────────────────────────────────┘
```

## Changes (3 files, 75 lines added)

| File | What changed |
|------|-------------|
| `AIConversationLoop.php` | Accumulates `usage` from `$ai_response['data']['usage']` across all turns. Adds `usage` to return value (including error returns). |
| `AIStep.php` | After loop completes, writes `token_usage` to job `engine_data` via read-then-merge pattern. |
| `ChatOrchestrator.php` | Stores `token_usage` in session metadata. Accumulates across multi-turn conversations. All three entry points covered: `processChat`, `processContinue`, `processPing`. |

## Storage format

**Jobs** (`engine_data` JSON):
```json
{
  "task_type": "...",
  "token_usage": {
    "prompt_tokens": 2450,
    "completion_tokens": 380,
    "total_tokens": 2830
  }
}
```

**Chat sessions** (`metadata` JSON):
```json
{
  "status": "completed",
  "token_usage": {
    "prompt_tokens": 15200,
    "completion_tokens": 3400,
    "total_tokens": 18600
  }
}
```

## Testing

- All 3 files pass `php -l`
- PHPUnit: 906 tests, same pass/fail as main
- No schema changes — uses existing JSON fields

## Future work

- CLI/REST endpoints to query usage per agent, per time period
- Budget enforcement (#852 agent status + usage limits)
- Usage dashboard in admin UI

Closes #849.