### PR TITLE
Fix: flows create respects --handler-config flag

### DIFF
--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -536,6 +536,38 @@ class FlowsCommand extends BaseCommand {
 			$step_configs = $decoded ?? array();
 		}
 
+		// Convert --handler-config to step_configs entries.
+		// --handler-config accepts handler-keyed JSON, e.g. {"reddit":{"subreddit":"test"}}.
+		// Each handler slug is resolved to its step type and merged into step_configs.
+		if ( isset( $assoc_args['handler-config'] ) ) {
+			$handler_config_input = json_decode( wp_unslash( $assoc_args['handler-config'] ), true );
+			if ( ! is_array( $handler_config_input ) ) {
+				WP_CLI::error( 'Invalid JSON in --handler-config. Must be a JSON object.' );
+				return;
+			}
+
+			$handler_abilities = new \DataMachine\Abilities\HandlerAbilities();
+			$all_handlers      = $handler_abilities->getAllHandlers();
+
+			foreach ( $handler_config_input as $handler_slug => $config ) {
+				if ( ! isset( $all_handlers[ $handler_slug ] ) ) {
+					WP_CLI::error( "Unknown handler '{$handler_slug}'. Use --handler-config with valid handler slugs." );
+					return;
+				}
+
+				$step_type = $all_handlers[ $handler_slug ]['type'] ?? '';
+				if ( empty( $step_type ) ) {
+					WP_CLI::error( "Cannot determine step type for handler '{$handler_slug}'." );
+					return;
+				}
+
+				$step_configs[ $step_type ] = array(
+					'handler_slug'   => $handler_slug,
+					'handler_config' => $config,
+				);
+			}
+		}
+
 		$scheduling_config = self::build_scheduling_config( $scheduling, $scheduled_at );
 
 		$input = array(


### PR DESCRIPTION
## Summary
- Fixes #883 — `wp datamachine flows create` ignored `--handler-config`, causing all new flows to default to `wordpress_posts` instead of the specified handler
- Resolves handler slugs to their step type via `HandlerAbilities::getAllHandlers()` and converts to the `step_configs` format that `applyStepConfigsToFlow()` expects

## Before
```bash
wp datamachine flows create --pipeline_id=1 --name="r/test" \
  --handler-config='{"reddit":{"subreddit":"test"}}'
# Result: flow created with handler_slugs: ["wordpress_posts"]
```

## After
```bash
wp datamachine flows create --pipeline_id=1 --name="r/test" \
  --handler-config='{"reddit":{"subreddit":"test"}}'
# Result: flow created with handler_slugs: ["reddit"], correct config applied
```

## Details
The `--handler-config` flag was only wired up in the `update` code path. During `create`, the flag was silently ignored. The flow would be created, `syncStepsToFlow` would set empty `handler_slugs`, and then `applySiteDefaultsToUnconfiguredSteps` would pick the first handler with site defaults — `wordpress_posts`.

The fix adds `--handler-config` parsing to `createFlow()`. Each handler slug key in the JSON is looked up via `HandlerAbilities::getAllHandlers()` to determine its step type, then merged into `step_configs` with the proper `handler_slug` + `handler_config` structure.