### PR TITLE
Remove pipeline-level model/provider overrides — context system is the authority

### DIFF
--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -502,11 +502,9 @@ class ExecuteWorkflowAbility {
 				'flow_id'          => 'direct',
 			);
 
-			// Pipeline config (AI settings only)
+			// Pipeline config (AI settings only — model/provider resolved via context system, not stored here).
 			if ( 'ai' === $step['type'] ) {
 				$pipeline_config[ $pipeline_step_id ] = array(
-					'provider'       => $step['provider'] ?? '',
-					'model'          => $step['model'] ?? '',
 					'system_prompt'  => $step['system_prompt'] ?? '',
 					'disabled_tools' => $step['disabled_tools'] ?? array(),
 				);

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -148,7 +148,7 @@ class PipelineStepAbilities {
 			'datamachine/update-pipeline-step',
 			array(
 				'label'               => __( 'Update Pipeline Step', 'data-machine' ),
-				'description'         => __( 'Update pipeline step configuration (system prompt, provider, model, enabled tools).', 'data-machine' ),
+				'description'         => __( 'Update pipeline step configuration (system prompt, disabled tools). Model/provider are configured via context_models setting.', 'data-machine' ),
 				'category'            => 'datamachine',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -161,14 +161,6 @@ class PipelineStepAbilities {
 						'system_prompt'    => array(
 							'type'        => 'string',
 							'description' => __( 'System prompt for AI step', 'data-machine' ),
-						),
-						'provider'         => array(
-							'type'        => 'string',
-							'description' => __( 'AI provider slug (e.g., "anthropic", "openai")', 'data-machine' ),
-						),
-						'model'            => array(
-							'type'        => 'string',
-							'description' => __( 'AI model identifier', 'data-machine' ),
 						),
 						'disabled_tools'   => array(
 							'type'        => 'array',
@@ -508,14 +500,15 @@ class PipelineStepAbilities {
 		}
 
 		$system_prompt  = $input['system_prompt'] ?? null;
-		$provider       = $input['provider'] ?? null;
-		$model          = $input['model'] ?? null;
 		$disabled_tools = $input['disabled_tools'] ?? null;
 
-		if ( null === $system_prompt && null === $provider && null === $model && null === $disabled_tools ) {
+		// provider/model are no longer configurable at the pipeline step level.
+		// Model resolution is handled exclusively by the context system (context_models setting).
+
+		if ( null === $system_prompt && null === $disabled_tools ) {
 			return array(
 				'success' => false,
-				'error'   => 'At least one of system_prompt, provider, model, or disabled_tools is required',
+				'error'   => 'At least one of system_prompt or disabled_tools is required',
 			);
 		}
 
@@ -547,27 +540,6 @@ class PipelineStepAbilities {
 		if ( null !== $system_prompt ) {
 			$step_config_data['system_prompt'] = wp_unslash( $system_prompt );
 			$updated_fields[]                  = 'system_prompt';
-		}
-
-		if ( null !== $provider ) {
-			$step_config_data['provider'] = sanitize_text_field( $provider );
-			$updated_fields[]             = 'provider';
-		}
-
-		if ( null !== $model ) {
-			$step_config_data['model'] = sanitize_text_field( $model );
-			$updated_fields[]          = 'model';
-
-			$provider_for_model = $provider ?? ( $existing_config['provider'] ?? '' );
-			if ( ! empty( $provider_for_model ) ) {
-				if ( ! isset( $step_config_data['providers'] ) ) {
-					$step_config_data['providers'] = $existing_config['providers'] ?? array();
-				}
-				if ( ! isset( $step_config_data['providers'][ $provider_for_model ] ) ) {
-					$step_config_data['providers'][ $provider_for_model ] = array();
-				}
-				$step_config_data['providers'][ $provider_for_model ]['model'] = sanitize_text_field( $model );
-			}
 		}
 
 		if ( null !== $disabled_tools && is_array( $disabled_tools ) ) {

--- a/inc/Api/Chat/Tools/ConfigurePipelineStep.php
+++ b/inc/Api/Chat/Tools/ConfigurePipelineStep.php
@@ -33,7 +33,7 @@ class ConfigurePipelineStep extends BaseTool {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',
-			'description' => 'Configure pipeline-level AI step settings including system prompt, provider, model, and enabled tools. Use this for AI steps after creating a pipeline. For flow-level settings (handler, handler_config, user_message), use configure_flow_steps instead.',
+			'description' => 'Configure pipeline-level AI step settings: system prompt and disabled tools. Model/provider are managed via the context_models site setting, not per-pipeline. For flow-level settings (handler, handler_config, user_message), use configure_flow_steps instead.',
 			'parameters'  => array(
 				'pipeline_step_id' => array(
 					'type'        => 'string',
@@ -44,16 +44,6 @@ class ConfigurePipelineStep extends BaseTool {
 					'type'        => 'string',
 					'required'    => false,
 					'description' => 'System prompt for the AI step - defines the AI persona and instructions',
-				),
-				'provider'         => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'AI provider slug (e.g., "anthropic", "openai")',
-				),
-				'model'            => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'AI model identifier (e.g., "claude-sonnet-4", "gpt-4o")',
 				),
 				'disabled_tools'   => array(
 					'type'        => 'array',

--- a/inc/Api/Chat/Tools/CreatePipeline.php
+++ b/inc/Api/Chat/Tools/CreatePipeline.php
@@ -328,12 +328,7 @@ class CreatePipeline extends BaseTool {
 				'handler_configs' => ! empty( $handler_slug ) ? array( $handler_slug => $handler_config ) : array(),
 			);
 
-			if ( isset( $step['provider'] ) ) {
-				$normalized_step['provider'] = $step['provider'];
-			}
-			if ( isset( $step['model'] ) ) {
-				$normalized_step['model'] = $step['model'];
-			}
+			// provider/model are not stored at pipeline level — context system handles resolution.
 			if ( isset( $step['system_prompt'] ) ) {
 				$normalized_step['system_prompt'] = $step['system_prompt'];
 			}

--- a/inc/Api/Pipelines/PipelineSteps.php
+++ b/inc/Api/Pipelines/PipelineSteps.php
@@ -491,49 +491,18 @@ class PipelineSteps {
 		$pipeline_config = $pipeline['pipeline_config'] ?? array();
 		$existing_config = $pipeline_config[ $pipeline_step_id ] ?? array();
 
-		// Build step configuration data for AI steps
+		// Build step configuration data for AI steps.
+		// Note: provider/model are NOT configurable at the pipeline step level.
+		// Model resolution is handled by the context system (context_models setting).
 		$step_config_data = array();
 		$api_key_saved    = false;
 
-		// Handle AI step configuration.
-		$has_provider       = $request->has_param( 'provider' );
-		$has_model          = $request->has_param( 'model' );
 		$has_system_prompt  = $request->has_param( 'system_prompt' );
 		$has_disabled_tools = $request->has_param( 'disabled_tools' );
 		$has_api_key        = $request->has_param( 'ai_api_key' );
 
-		$effective_provider = $has_provider
-			? sanitize_text_field( $request->get_param( 'provider' ) )
-			: ( $existing_config['provider'] ?? '' );
-		$effective_model    = $has_model
-			? sanitize_text_field( $request->get_param( 'model' ) )
-			: ( $existing_config['model'] ?? '' );
-		$system_prompt      = $has_system_prompt
-			? sanitize_textarea_field( $request->get_param( 'system_prompt' ) )
-			: null;
-
-		if ( $has_provider ) {
-			$step_config_data['provider'] = $effective_provider;
-		}
-
-		if ( $has_model ) {
-			$step_config_data['model'] = $effective_model;
-
-			$provider_for_model = $has_provider ? $effective_provider : ( $existing_config['provider'] ?? '' );
-
-			if ( ! empty( $provider_for_model ) && ! empty( $effective_model ) ) {
-				if ( ! isset( $step_config_data['providers'] ) ) {
-					$step_config_data['providers'] = array();
-				}
-				if ( ! isset( $step_config_data['providers'][ $provider_for_model ] ) ) {
-					$step_config_data['providers'][ $provider_for_model ] = array();
-				}
-				$step_config_data['providers'][ $provider_for_model ]['model'] = $effective_model;
-			}
-		}
-
 		if ( $has_system_prompt ) {
-			$step_config_data['system_prompt'] = $system_prompt;
+			$step_config_data['system_prompt'] = sanitize_textarea_field( $request->get_param( 'system_prompt' ) );
 		}
 
 		if ( $has_disabled_tools ) {

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -72,8 +72,11 @@ class AIStep extends Step {
 		$pipeline_step_config = $this->engine->getPipelineStepConfig( $pipeline_step_id );
 		$job_snapshot         = $this->engine->get( 'job' );
 		$agent_id             = (int) ( $job_snapshot['agent_id'] ?? 0 );
-		$pipeline_defaults    = PluginSettings::resolveModelForAgentContext( $agent_id, 'pipeline' );
-		$provider_name        = $pipeline_step_config['provider'] ?? $pipeline_defaults['provider'];
+
+		// Model/provider resolved exclusively via context system (agent → site → network).
+		// Pipeline-level model/provider fields are ignored — context_models is the authority.
+		$context_model = PluginSettings::resolveModelForAgentContext( $agent_id, 'pipeline' );
+		$provider_name = $context_model['provider'];
 		if ( empty( $provider_name ) ) {
 			do_action(
 				'datamachine_fail_job',
@@ -82,8 +85,8 @@ class AIStep extends Step {
 				array(
 					'flow_step_id'     => $this->flow_step_id,
 					'pipeline_step_id' => $pipeline_step_id,
-					'error_message'    => 'AI step requires provider configuration. Please configure an AI provider in step settings or set a default provider in plugin settings.',
-					'solution'         => 'Configure AI provider in pipeline step settings or set default provider in Data Machine settings',
+					'error_message'    => 'AI step requires provider configuration. Set a default provider in Data Machine settings or configure context_models.',
+					'solution'         => 'Set default_provider in Data Machine settings or configure context_models for the pipeline context',
 				)
 			);
 			return false;
@@ -226,8 +229,10 @@ class AIStep extends Step {
 			'engine_data'          => $engine_data,
 		) );
 
-		$pipeline_agent_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'pipeline' );
-		$provider_name           = $pipeline_step_config['provider'] ?? $pipeline_agent_defaults['provider'];
+		// Model/provider resolved exclusively via context system — pipeline config is ignored.
+		$context_model = PluginSettings::resolveModelForAgentContext( $agent_id, 'pipeline' );
+		$provider_name = $context_model['provider'];
+		$model_name    = $context_model['model'];
 
 		// Execute conversation loop
 		$loop        = new AIConversationLoop();
@@ -235,7 +240,7 @@ class AIStep extends Step {
 			$messages,
 			$available_tools,
 			$provider_name,
-			$pipeline_step_config['model'] ?? $pipeline_agent_defaults['model'],
+			$model_name,
 			ToolPolicyResolver::CONTEXT_PIPELINE,
 			$payload,
 			$max_turns


### PR DESCRIPTION
## Summary
- Fixes #886 — pipeline AI step configs silently override the `context_models` resolution system
- 76 event pipelines + 1 wire pipeline all had `gpt-5-mini` hardcoded, blocking the `default_model: gpt-5.4-nano` setting from taking effect (~40M tokens/day on the wrong model)
- **-71 lines** — removes the override paths, not just the data

## What changed

**`AIStep.php`** — The critical fix. Model/provider now resolved exclusively via `resolveModelForAgentContext()`. Pipeline config `model`/`provider` fields are ignored.

**Write paths cleaned** — 5 files that previously stored `model`/`provider`/`providers` into pipeline step configs:
- `PipelineStepAbilities` — ability schema + execution
- `PipelineSteps.php` — REST endpoint
- `ConfigurePipelineStep` — chat tool
- `CreatePipeline` — chat tool
- `ExecuteWorkflowAbility` — direct execution

**Preserved:**
- Pipeline `system_prompt` — alive, used by `PipelineSystemPromptDirective`
- Pipeline `disabled_tools` — alive, used by `ToolPolicyResolver` via `ToolManager`

## Resolution order (after merge)

```
agent context_models[pipeline] → site context_models[pipeline] → 
network context_models[pipeline] → site default_model → network default_model
```

No pipeline-level model override. One place to change, one place to check.

## Also confirmed dead (no code changes needed)

- `global_system_prompt` site setting — zero code references, fully superseded by directive/memory system. Orphaned DB data, harmless.
- `enabled_tools` pipeline field — 74/76 empty, superseded by `ToolPolicyResolver`. Old data ignored.