### PR TITLE
Fix: flows update unwraps handler-keyed --handler-config JSON

### DIFF
--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -811,20 +811,41 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		if ( null !== $handler_config ) {
+			// Unwrap handler-keyed JSON, e.g. {"agent_ping":{"prompt":"..."}}.
+			// The outer key is the handler slug; the inner object is the actual config.
+			// This mirrors the --handler-config parsing in createFlow().
+			$resolved_slug   = null;
+			$resolved_config = $handler_config;
+
+			$handler_abilities = new \DataMachine\Abilities\HandlerAbilities();
+			$all_handlers      = $handler_abilities->getAllHandlers();
+
+			if ( 1 === count( $handler_config ) ) {
+				$first_key = array_key_first( $handler_config );
+				if ( isset( $all_handlers[ $first_key ] ) && is_array( $handler_config[ $first_key ] ) ) {
+					$resolved_slug   = $first_key;
+					$resolved_config = $handler_config[ $first_key ];
+				}
+			}
+
 			$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
-			$step_result  = $step_ability->execute(
-				array(
-					'flow_step_id'   => $step,
-					'handler_config' => $handler_config,
-				)
+			$step_input   = array(
+				'flow_step_id'   => $step,
+				'handler_config' => $resolved_config,
 			);
+
+			if ( null !== $resolved_slug ) {
+				$step_input['handler_slug'] = $resolved_slug;
+			}
+
+			$step_result = $step_ability->execute( $step_input );
 
 			if ( ! $step_result['success'] ) {
 				WP_CLI::error( $step_result['error'] ?? 'Failed to update handler config' );
 				return;
 			}
 
-			$updated_keys = implode( ', ', array_keys( $handler_config ) );
+			$updated_keys = implode( ', ', array_keys( $resolved_config ) );
 			WP_CLI::success( sprintf( 'Handler config updated for step %s: %s', $step, $updated_keys ) );
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes #891 — `wp datamachine flows update` rejected handler-keyed `--handler-config` JSON (e.g. `{"agent_ping":{"prompt":"..."}}`) because it treated the handler slug key as a config field name
- Applies the same unwrapping pattern from #884 (which fixed `create`): detects when the JSON has a single key matching a registered handler slug, extracts the inner config, and passes `handler_slug` + `handler_config` separately to `UpdateFlowStepAbility`

## Before
```bash
wp datamachine flows update 4 --handler-config='{"agent_ping":{"prompt":"new prompt"}}'
# Error: Unknown handler_config fields for agent_ping: agent_ping. Valid fields: webhook_url, prompt, ...
```

## After
```bash
wp datamachine flows update 4 --handler-config='{"agent_ping":{"prompt":"new prompt"}}'
# Success: Handler config updated for step ...: prompt
```

## Details
The fix checks if `--handler-config` JSON has exactly one key that matches a registered handler slug. If so, it unwraps the slug as `handler_slug` and the inner object as `handler_config` before passing to the ability. Flat config JSON (e.g. `{"prompt":"..."}`) continues to work as before — backward compatible.

## Related
- #883 / #884 — same bug on `flows create`, already fixed and merged