### PR TITLE
Fix: flows update --handler-config unwraps handler slug correctly

### DIFF
--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -811,20 +811,37 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		if ( null !== $handler_config ) {
-			$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
-			$step_result  = $step_ability->execute(
-				array(
-					'flow_step_id'   => $step,
-					'handler_config' => $handler_config,
-				)
+			// --handler-config accepts handler-keyed JSON, e.g. {"reddit":{"subreddit":"test"}}.
+			// Unwrap: the key is the handler slug, the value is the config.
+			$handler_slug       = null;
+			$unwrapped_config   = $handler_config;
+			$handler_config_keys = array_keys( $handler_config );
+
+			// If the top-level keys look like handler slugs (single key wrapping a config object),
+			// unwrap the handler slug from the JSON structure.
+			if ( count( $handler_config_keys ) === 1 && is_array( $handler_config[ $handler_config_keys[0] ] ) ) {
+				$handler_slug     = $handler_config_keys[0];
+				$unwrapped_config = $handler_config[ $handler_slug ];
+			}
+
+			$step_input = array(
+				'flow_step_id'   => $step,
+				'handler_config' => $unwrapped_config,
 			);
+
+			if ( $handler_slug ) {
+				$step_input['handler_slug'] = $handler_slug;
+			}
+
+			$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
+			$step_result  = $step_ability->execute( $step_input );
 
 			if ( ! $step_result['success'] ) {
 				WP_CLI::error( $step_result['error'] ?? 'Failed to update handler config' );
 				return;
 			}
 
-			$updated_keys = implode( ', ', array_keys( $handler_config ) );
+			$updated_keys = implode( ', ', array_keys( $unwrapped_config ) );
 			WP_CLI::success( sprintf( 'Handler config updated for step %s: %s', $step, $updated_keys ) );
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes #891 — `flows update --handler-config` passed handler-keyed JSON directly to `UpdateFlowStepAbility` without unwrapping
- Same class of bug as #883 (create path), fixed in PR #884

## Before
```bash
wp datamachine flows update 4 --handler-config='{"agent_ping":{"prompt":"new prompt"}}'
# Error: Unknown handler_config fields for agent_ping: agent_ping
```

## After
```bash
wp datamachine flows update 4 --handler-config='{"agent_ping":{"prompt":"new prompt"}}'
# Success: Handler config updated for step ...: prompt
```

## Details
When `--handler-config` is a single-key object where the key is a handler slug wrapping a config object (e.g. `{"reddit":{"subreddit":"test"}}`), the CLI now unwraps it into separate `handler_slug` and `handler_config` fields for `UpdateFlowStepAbility`. This matches how the create path works after PR #884.

Non-handler-keyed JSON (e.g. `{"subreddit":"test"}` without the handler wrapper) still works as before — passed directly as `handler_config` and the ability resolves the slug from the existing flow step.