### PR TITLE
feat: automatic data retention policies for jobs, logs, processed items, and AS actions

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -422,11 +422,16 @@ function datamachine_remove_capabilities(): void {
 function datamachine_deactivate_plugin() {
 	datamachine_remove_capabilities();
 
-	// Unschedule recurring maintenance actions.
+	// Unschedule all recurring maintenance actions.
 	if ( function_exists( 'as_unschedule_all_actions' ) ) {
 		as_unschedule_all_actions( 'datamachine_cleanup_stale_claims', array(), 'datamachine-maintenance' );
 		as_unschedule_all_actions( 'datamachine_cleanup_failed_jobs', array(), 'datamachine-maintenance' );
+		as_unschedule_all_actions( 'datamachine_cleanup_completed_jobs', array(), 'datamachine-maintenance' );
 		as_unschedule_all_actions( 'datamachine_cleanup_logs', array(), 'datamachine-maintenance' );
+		as_unschedule_all_actions( 'datamachine_cleanup_processed_items', array(), 'datamachine-maintenance' );
+		as_unschedule_all_actions( 'datamachine_cleanup_as_actions', array(), 'datamachine-maintenance' );
+		as_unschedule_all_actions( 'datamachine_cleanup_old_files', array(), 'datamachine-files' );
+		as_unschedule_all_actions( 'datamachine_cleanup_chat_sessions', array(), 'datamachine-chat' );
 	}
 }
 

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -40,6 +40,7 @@ WP_CLI::add_command( 'datamachine handlers', Commands\HandlersCommand::class );
 WP_CLI::add_command( 'datamachine taxonomy', Commands\TaxonomyCommand::class );
 WP_CLI::add_command( 'datamachine step-types', Commands\StepTypesCommand::class );
 WP_CLI::add_command( 'datamachine processed-items', Commands\ProcessedItemsCommand::class );
+WP_CLI::add_command( 'datamachine retention', Commands\RetentionCommand::class );
 
 // Aliases for AI agent compatibility (singular/plural variants).
 WP_CLI::add_command( 'datamachine setting', Commands\SettingsCommand::class );

--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -1,0 +1,376 @@
+<?php
+/**
+ * WP-CLI Retention Command
+ *
+ * Provides CLI access to Data Machine data retention policies,
+ * table size visibility, and manual cleanup execution.
+ *
+ * @package DataMachine\Cli\Commands
+ * @since 0.40.0
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use WP_CLI;
+use DataMachine\Cli\BaseCommand;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manage data retention policies and cleanup.
+ *
+ * ## EXAMPLES
+ *
+ *     # Show current retention policies and table sizes
+ *     wp datamachine retention show
+ *
+ *     # Preview what would be purged
+ *     wp datamachine retention run --dry-run
+ *
+ *     # Execute cleanup now
+ *     wp datamachine retention run
+ */
+class RetentionCommand extends BaseCommand {
+
+	/**
+	 * Show current retention policies and table sizes.
+	 *
+	 * Displays the configured retention thresholds for each data domain
+	 * alongside current table sizes to help operators understand database
+	 * pressure.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine retention show
+	 *     wp datamachine retention show --format=json
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function show( array $args, array $assoc_args ): void {
+		$policies = $this->get_retention_policies();
+		$sizes    = $this->get_table_sizes();
+
+		WP_CLI::log( '' );
+		WP_CLI::log( WP_CLI::colorize( '%BRetention Policies%n' ) );
+		WP_CLI::log( '' );
+
+		$policy_items = array();
+		foreach ( $policies as $domain => $policy ) {
+			$size_info       = $sizes[ $domain ] ?? array();
+			$policy_items[] = array(
+				'domain'    => $domain,
+				'retention' => $policy['retention'],
+				'filter'    => $policy['filter'],
+				'rows'      => $size_info['rows'] ?? 'N/A',
+				'size_mb'   => $size_info['size_mb'] ?? 'N/A',
+			);
+		}
+
+		$this->format_items(
+			$policy_items,
+			array( 'domain', 'retention', 'rows', 'size_mb', 'filter' ),
+			$assoc_args
+		);
+
+		// Show total.
+		$total_mb = 0;
+		foreach ( $sizes as $size_info ) {
+			$total_mb += (float) ( $size_info['size_mb'] ?? 0 );
+		}
+
+		WP_CLI::log( '' );
+		WP_CLI::log( sprintf( 'Total tracked table size: %.1f MB', $total_mb ) );
+	}
+
+	/**
+	 * Execute retention cleanup for all data domains.
+	 *
+	 * Runs all configured cleanup routines immediately, regardless of
+	 * their scheduled timing. Use --dry-run to preview what would be
+	 * deleted without making changes.
+	 *
+	 * [--dry-run]
+	 * : Preview what would be purged without deleting anything.
+	 *
+	 * [--yes]
+	 * : Skip confirmation prompt.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine retention run --dry-run
+	 *     wp datamachine retention run --yes
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function run( array $args, array $assoc_args ): void {
+		$dry_run = isset( $assoc_args['dry-run'] );
+		$results = array();
+
+		// 1. Completed jobs.
+		$completed_days = (int) apply_filters( 'datamachine_completed_jobs_max_age_days', 14 );
+		$db_jobs        = new \DataMachine\Core\Database\Jobs\Jobs();
+		$count          = $db_jobs->count_old_jobs( 'completed', $completed_days );
+		$results[]      = array(
+			'domain'    => 'Completed jobs',
+			'threshold' => $completed_days . ' days',
+			'eligible'  => $count,
+			'action'    => $dry_run ? 'would delete' : 'deleted',
+		);
+		if ( ! $dry_run && $count > 0 ) {
+			$db_jobs->delete_old_jobs( 'completed', $completed_days );
+		}
+
+		// 2. Failed jobs.
+		$failed_days = (int) apply_filters( 'datamachine_failed_jobs_max_age_days', 30 );
+		$count       = $db_jobs->count_old_jobs( 'failed', $failed_days );
+		$results[]   = array(
+			'domain'    => 'Failed jobs',
+			'threshold' => $failed_days . ' days',
+			'eligible'  => $count,
+			'action'    => $dry_run ? 'would delete' : 'deleted',
+		);
+		if ( ! $dry_run && $count > 0 ) {
+			$db_jobs->delete_old_jobs( 'failed', $failed_days );
+		}
+
+		// 3. Logs.
+		$log_days = (int) apply_filters( 'datamachine_log_max_age_days', 7 );
+		$count    = $this->count_old_logs( $log_days );
+		$results[] = array(
+			'domain'    => 'Pipeline logs',
+			'threshold' => $log_days . ' days',
+			'eligible'  => $count,
+			'action'    => $dry_run ? 'would delete' : 'deleted',
+		);
+		if ( ! $dry_run && $count > 0 ) {
+			$repo = new \DataMachine\Core\Database\Logs\LogRepository();
+			$repo->prune_before( gmdate( 'Y-m-d H:i:s', time() - ( $log_days * DAY_IN_SECONDS ) ) );
+		}
+
+		// 4. Processed items.
+		$processed_days = (int) apply_filters( 'datamachine_processed_items_max_age_days', 30 );
+		$db_processed   = new \DataMachine\Core\Database\ProcessedItems\ProcessedItems();
+		$count          = $db_processed->count_old_processed_items( $processed_days );
+		$results[]      = array(
+			'domain'    => 'Processed items',
+			'threshold' => $processed_days . ' days',
+			'eligible'  => $count,
+			'action'    => $dry_run ? 'would delete' : 'deleted',
+		);
+		if ( ! $dry_run && $count > 0 ) {
+			$db_processed->delete_old_processed_items( $processed_days );
+		}
+
+		// 5. Action Scheduler actions + logs.
+		$as_days  = (int) apply_filters( 'datamachine_as_actions_max_age_days', 7 );
+		$as_count = $this->count_old_as_actions( $as_days );
+		$results[] = array(
+			'domain'    => 'AS actions + logs',
+			'threshold' => $as_days . ' days',
+			'eligible'  => $as_count,
+			'action'    => $dry_run ? 'would delete' : 'deleted',
+		);
+		if ( ! $dry_run && $as_count > 0 ) {
+			do_action( 'datamachine_cleanup_as_actions' );
+		}
+
+		if ( $dry_run ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( WP_CLI::colorize( '%YDry run — no data was deleted.%n' ) );
+			WP_CLI::log( '' );
+		} else {
+			WP_CLI::log( '' );
+		}
+
+		$this->format_items(
+			$results,
+			array( 'domain', 'threshold', 'eligible', 'action' ),
+			$assoc_args
+		);
+
+		if ( ! $dry_run ) {
+			$total = array_sum( array_column( $results, 'eligible' ) );
+			WP_CLI::success( sprintf( 'Retention cleanup complete. %d total rows processed.', $total ) );
+		}
+	}
+
+	/**
+	 * Get the current retention policy configuration.
+	 *
+	 * @return array<string, array{retention: string, filter: string}>
+	 */
+	private function get_retention_policies(): array {
+		return array(
+			'Completed jobs'  => array(
+				'retention' => apply_filters( 'datamachine_completed_jobs_max_age_days', 14 ) . ' days',
+				'filter'    => 'datamachine_completed_jobs_max_age_days',
+			),
+			'Failed jobs'     => array(
+				'retention' => apply_filters( 'datamachine_failed_jobs_max_age_days', 30 ) . ' days',
+				'filter'    => 'datamachine_failed_jobs_max_age_days',
+			),
+			'Pipeline logs'   => array(
+				'retention' => apply_filters( 'datamachine_log_max_age_days', 7 ) . ' days',
+				'filter'    => 'datamachine_log_max_age_days',
+			),
+			'Processed items' => array(
+				'retention' => apply_filters( 'datamachine_processed_items_max_age_days', 30 ) . ' days',
+				'filter'    => 'datamachine_processed_items_max_age_days',
+			),
+			'AS actions'      => array(
+				'retention' => apply_filters( 'datamachine_as_actions_max_age_days', 7 ) . ' days',
+				'filter'    => 'datamachine_as_actions_max_age_days',
+			),
+			'Stale claims'    => array(
+				'retention' => round( apply_filters( 'datamachine_stale_claim_max_age', DAY_IN_SECONDS ) / 3600 ) . ' hours',
+				'filter'    => 'datamachine_stale_claim_max_age',
+			),
+			'Chat sessions'   => array(
+				'retention' => \DataMachine\Core\PluginSettings::get( 'chat_retention_days', 90 ) . ' days',
+				'filter'    => 'setting: chat_retention_days',
+			),
+			'File cleanup'    => array(
+				'retention' => \DataMachine\Core\PluginSettings::get( 'file_retention_days', 7 ) . ' days',
+				'filter'    => 'setting: file_retention_days',
+			),
+		);
+	}
+
+	/**
+	 * Get current table sizes for Data Machine and Action Scheduler tables.
+	 *
+	 * @return array<string, array{rows: int, size_mb: string}>
+	 */
+	private function get_table_sizes(): array {
+		global $wpdb;
+
+		$sizes  = array();
+		$tables = array(
+			'Completed jobs'  => $wpdb->prefix . 'datamachine_jobs',
+			'Failed jobs'     => $wpdb->prefix . 'datamachine_jobs',
+			'Pipeline logs'   => $wpdb->prefix . 'datamachine_logs',
+			'Processed items' => $wpdb->prefix . 'datamachine_processed_items',
+			'AS actions'      => $wpdb->prefix . 'actionscheduler_actions',
+			'Stale claims'    => $wpdb->prefix . 'actionscheduler_claims',
+			'Chat sessions'   => $wpdb->prefix . 'datamachine_chat_sessions',
+		);
+
+		// Deduplicate tables for the query (jobs appears twice).
+		$unique_tables = array_unique( array_values( $tables ) );
+		$placeholders  = implode( ',', array_fill( 0, count( $unique_tables ), '%s' ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$results = $wpdb->get_results(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->prepare(
+				"SELECT table_name, table_rows,
+					ROUND((data_length + index_length) / 1024 / 1024, 1) AS size_mb
+				FROM information_schema.tables
+				WHERE table_schema = DATABASE()
+				AND table_name IN ({$placeholders})",
+				...$unique_tables
+			)
+		);
+
+		$table_data = array();
+		if ( $results ) {
+			foreach ( $results as $row ) {
+				$table_data[ $row->table_name ] = array(
+					'rows'    => (int) $row->table_rows,
+					'size_mb' => $row->size_mb,
+				);
+			}
+		}
+
+		foreach ( $tables as $domain => $table_name ) {
+			$sizes[ $domain ] = $table_data[ $table_name ] ?? array(
+				'rows'    => 0,
+				'size_mb' => '0.0',
+			);
+		}
+
+		return $sizes;
+	}
+
+	/**
+	 * Count log entries older than a given number of days.
+	 *
+	 * @param int $older_than_days Age threshold.
+	 * @return int Row count.
+	 */
+	private function count_old_logs( int $older_than_days ): int {
+		global $wpdb;
+
+		$cutoff = gmdate( 'Y-m-d H:i:s', time() - ( $older_than_days * DAY_IN_SECONDS ) );
+		$table  = $wpdb->prefix . 'datamachine_logs';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$table} WHERE created_at < %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$cutoff
+			)
+		);
+	}
+
+	/**
+	 * Count completed/failed/canceled AS actions older than a given number of days.
+	 *
+	 * @param int $older_than_days Age threshold.
+	 * @return int Row count (actions + their log entries).
+	 */
+	private function count_old_as_actions( int $older_than_days ): int {
+		global $wpdb;
+
+		$cutoff        = gmdate( 'Y-m-d H:i:s', time() - ( $older_than_days * DAY_IN_SECONDS ) );
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$logs_table    = $wpdb->prefix . 'actionscheduler_logs';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$actions_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$actions_table}
+				WHERE status IN ('complete', 'failed', 'canceled')
+				AND last_attempt_gmt < %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$cutoff
+			)
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$logs_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$logs_table} l
+				INNER JOIN {$actions_table} a ON l.action_id = a.action_id
+				WHERE a.status IN ('complete', 'failed', 'canceled')
+				AND a.last_attempt_gmt < %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$cutoff
+			)
+		);
+
+		return $actions_count + $logs_count;
+	}
+}

--- a/inc/Core/ActionScheduler/ActionsCleanup.php
+++ b/inc/Core/ActionScheduler/ActionsCleanup.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Action Scheduler Completed Actions Cleanup
+ *
+ * Periodically removes old completed and canceled actions from the
+ * actionscheduler_actions and actionscheduler_logs tables.
+ *
+ * Action Scheduler has its own ActionScheduler_QueueCleaner, but it defaults
+ * to 31-day retention and modest batch sizes. On high-throughput Data Machine
+ * sites generating hundreds of actions per day, these tables become the
+ * second-largest database consumers.
+ *
+ * @package DataMachine\Core\ActionScheduler
+ * @since 0.40.0
+ */
+
+namespace DataMachine\Core\ActionScheduler;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the cleanup action handler.
+ */
+add_action(
+	'datamachine_cleanup_as_actions',
+	function () {
+		global $wpdb;
+
+		/**
+		 * Filter the maximum age (in days) for completed Action Scheduler actions.
+		 *
+		 * Completed, failed, and canceled actions older than this threshold
+		 * will be deleted along with their associated log entries.
+		 *
+		 * @since 0.40.0
+		 *
+		 * @param int $max_age_days Maximum age in days. Default 7.
+		 */
+		$max_age_days = (int) apply_filters( 'datamachine_as_actions_max_age_days', 7 );
+
+		if ( $max_age_days < 1 ) {
+			$max_age_days = 7;
+		}
+
+		$cutoff_datetime = gmdate( 'Y-m-d H:i:s', time() - ( $max_age_days * DAY_IN_SECONDS ) );
+		$actions_table   = $wpdb->prefix . 'actionscheduler_actions';
+		$logs_table      = $wpdb->prefix . 'actionscheduler_logs';
+
+		// Delete AS log entries for old completed/failed/canceled actions first (FK-safe order).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$logs_deleted = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE l FROM {$logs_table} l
+				INNER JOIN {$actions_table} a ON l.action_id = a.action_id
+				WHERE a.status IN ('complete', 'failed', 'canceled')
+				AND a.last_attempt_gmt < %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$cutoff_datetime
+			)
+		);
+
+		// Delete the completed/failed/canceled actions themselves.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$actions_deleted = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$actions_table}
+				WHERE status IN ('complete', 'failed', 'canceled')
+				AND last_attempt_gmt < %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$cutoff_datetime
+			)
+		);
+
+		$total_deleted = ( false !== $logs_deleted ? $logs_deleted : 0 )
+			+ ( false !== $actions_deleted ? $actions_deleted : 0 );
+
+		if ( $total_deleted > 0 ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Scheduled cleanup: deleted old Action Scheduler actions and logs',
+				array(
+					'actions_deleted' => false !== $actions_deleted ? $actions_deleted : 0,
+					'logs_deleted'    => false !== $logs_deleted ? $logs_deleted : 0,
+					'max_age_days'    => $max_age_days,
+				)
+			);
+		}
+	}
+);
+
+/**
+ * Schedule the cleanup job after Action Scheduler is initialized.
+ * Only runs in admin context to avoid database queries on frontend.
+ */
+add_action(
+	'action_scheduler_init',
+	function () {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		if ( ! as_next_scheduled_action( 'datamachine_cleanup_as_actions', array(), 'datamachine-maintenance' ) ) {
+			as_schedule_recurring_action(
+				time() + DAY_IN_SECONDS,
+				DAY_IN_SECONDS,
+				'datamachine_cleanup_as_actions',
+				array(),
+				'datamachine-maintenance'
+			);
+		}
+	}
+);

--- a/inc/Core/ActionScheduler/CompletedJobsCleanup.php
+++ b/inc/Core/ActionScheduler/CompletedJobsCleanup.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Completed Jobs Cleanup
+ *
+ * Periodically removes old completed jobs from the jobs table.
+ * Completed jobs accumulate quickly on active sites because every flow run
+ * creates job records with full engine_data JSON. Without cleanup, this
+ * table becomes the largest consumer of database memory.
+ *
+ * @package DataMachine\Core\ActionScheduler
+ * @since 0.40.0
+ */
+
+namespace DataMachine\Core\ActionScheduler;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the cleanup action handler.
+ */
+add_action(
+	'datamachine_cleanup_completed_jobs',
+	function () {
+		$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
+
+		/**
+		 * Filter the maximum age (in days) for completed jobs before cleanup.
+		 *
+		 * Jobs with a "completed" status (including compound statuses like
+		 * "completed_no_items") older than this threshold will be deleted.
+		 *
+		 * @since 0.40.0
+		 *
+		 * @param int $max_age_days Maximum age in days. Default 14.
+		 */
+		$max_age_days = (int) apply_filters( 'datamachine_completed_jobs_max_age_days', 14 );
+
+		if ( $max_age_days < 1 ) {
+			$max_age_days = 14;
+		}
+
+		$deleted = $db_jobs->delete_old_jobs( 'completed', $max_age_days );
+
+		if ( false !== $deleted && $deleted > 0 ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Scheduled cleanup: deleted old completed jobs',
+				array(
+					'jobs_deleted' => $deleted,
+					'max_age_days' => $max_age_days,
+				)
+			);
+		}
+	}
+);
+
+/**
+ * Schedule the cleanup job after Action Scheduler is initialized.
+ * Only runs in admin context to avoid database queries on frontend.
+ */
+add_action(
+	'action_scheduler_init',
+	function () {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		if ( ! as_next_scheduled_action( 'datamachine_cleanup_completed_jobs', array(), 'datamachine-maintenance' ) ) {
+			as_schedule_recurring_action(
+				time() + DAY_IN_SECONDS,
+				DAY_IN_SECONDS,
+				'datamachine_cleanup_completed_jobs',
+				array(),
+				'datamachine-maintenance'
+			);
+		}
+	}
+);

--- a/inc/Core/ActionScheduler/LogCleanup.php
+++ b/inc/Core/ActionScheduler/LogCleanup.php
@@ -24,10 +24,11 @@ add_action(
 		 * Filter the maximum log entry age in days before cleanup.
 		 *
 		 * @since 0.37.1
+		 * @since 0.40.0 Default reduced from 30 to 7 days.
 		 *
-		 * @param int $max_age_days Maximum log entry age in days. Default 30.
+		 * @param int $max_age_days Maximum log entry age in days. Default 7.
 		 */
-		$max_age_days = apply_filters( 'datamachine_log_max_age_days', 30 );
+		$max_age_days = apply_filters( 'datamachine_log_max_age_days', 7 );
 
 		$before_datetime = gmdate( 'Y-m-d H:i:s', time() - ( $max_age_days * DAY_IN_SECONDS ) );
 

--- a/inc/Core/ActionScheduler/ProcessedItemsCleanup.php
+++ b/inc/Core/ActionScheduler/ProcessedItemsCleanup.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Processed Items Cleanup
+ *
+ * Periodically removes old dedup records from the processed_items table.
+ * These records prevent re-processing of already-seen items, but entries
+ * older than the retention threshold are unlikely to be re-encountered.
+ *
+ * @package DataMachine\Core\ActionScheduler
+ * @since 0.40.0
+ */
+
+namespace DataMachine\Core\ActionScheduler;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the cleanup action handler.
+ */
+add_action(
+	'datamachine_cleanup_processed_items',
+	function () {
+		$db_processed = new \DataMachine\Core\Database\ProcessedItems\ProcessedItems();
+
+		/**
+		 * Filter the maximum age (in days) for processed items before cleanup.
+		 *
+		 * Dedup records older than this threshold will be deleted. Items not
+		 * re-encountered within this window can be safely re-processed if they
+		 * appear again.
+		 *
+		 * @since 0.40.0
+		 *
+		 * @param int $max_age_days Maximum age in days. Default 30.
+		 */
+		$max_age_days = (int) apply_filters( 'datamachine_processed_items_max_age_days', 30 );
+
+		if ( $max_age_days < 1 ) {
+			$max_age_days = 30;
+		}
+
+		$deleted = $db_processed->delete_old_processed_items( $max_age_days );
+
+		if ( false !== $deleted && $deleted > 0 ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Scheduled cleanup: deleted old processed items',
+				array(
+					'items_deleted' => $deleted,
+					'max_age_days'  => $max_age_days,
+				)
+			);
+		}
+	}
+);
+
+/**
+ * Schedule the cleanup job after Action Scheduler is initialized.
+ * Only runs in admin context to avoid database queries on frontend.
+ */
+add_action(
+	'action_scheduler_init',
+	function () {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		if ( ! as_next_scheduled_action( 'datamachine_cleanup_processed_items', array(), 'datamachine-maintenance' ) ) {
+			as_schedule_recurring_action(
+				time() + DAY_IN_SECONDS,
+				DAY_IN_SECONDS,
+				'datamachine_cleanup_processed_items',
+				array(),
+				'datamachine-maintenance'
+			);
+		}
+	}
+);

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -229,6 +229,80 @@ class ProcessedItems extends BaseRepository {
 	}
 
 	/**
+	 * Delete processed items older than a given number of days.
+	 *
+	 * Used by the scheduled retention cleanup to prevent unbounded growth
+	 * of dedup records. Items older than the threshold are unlikely to be
+	 * re-encountered and can be safely removed.
+	 *
+	 * @since 0.40.0
+	 *
+	 * @param int $older_than_days Delete items older than this many days.
+	 * @return int|false Number of deleted rows, or false on error.
+	 */
+	public function delete_old_processed_items( int $older_than_days ): int|false {
+		if ( $older_than_days < 1 ) {
+			return false;
+		}
+
+		$cutoff_datetime = gmdate( 'Y-m-d H:i:s', time() - ( $older_than_days * DAY_IN_SECONDS ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+		$result = $this->wpdb->query(
+			$this->wpdb->prepare(
+				'DELETE FROM %i WHERE processed_timestamp < %s',
+				$this->table_name,
+				$cutoff_datetime
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Deleted old processed items',
+			array(
+				'older_than_days' => $older_than_days,
+				'cutoff_datetime' => $cutoff_datetime,
+				'items_deleted'   => false !== $result ? $result : 0,
+				'success'         => false !== $result,
+			)
+		);
+
+		return $result;
+	}
+
+	/**
+	 * Count processed items older than a given number of days.
+	 *
+	 * @since 0.40.0
+	 *
+	 * @param int $older_than_days Count items older than this many days.
+	 * @return int Number of matching items.
+	 */
+	public function count_old_processed_items( int $older_than_days ): int {
+		if ( $older_than_days < 1 ) {
+			return 0;
+		}
+
+		$cutoff_datetime = gmdate( 'Y-m-d H:i:s', time() - ( $older_than_days * DAY_IN_SECONDS ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+		$count = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE processed_timestamp < %s',
+				$this->table_name,
+				$cutoff_datetime
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL
+
+		return (int) $count;
+	}
+
+	/**
 	 * Creates or updates the database table schema.
 	 * Should be called on plugin activation.
 	 */

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -122,5 +122,8 @@ require_once __DIR__ . '/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php';
 require_once __DIR__ . '/Core/FilesRepository/FileCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/ClaimsCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/JobsCleanup.php';
+require_once __DIR__ . '/Core/ActionScheduler/CompletedJobsCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/LogCleanup.php';
+require_once __DIR__ . '/Core/ActionScheduler/ProcessedItemsCleanup.php';
+require_once __DIR__ . '/Core/ActionScheduler/ActionsCleanup.php';
 require_once __DIR__ . '/Core/ActionScheduler/QueueTuning.php';


### PR DESCRIPTION
## Summary
- Fixes #879 — Data Machine tables grow unbounded on active sites, eventually pressuring the database server into swap
- Adds automatic retention cleanup for all high-volume tables with sane defaults
- Adds `wp datamachine retention` CLI for visibility and manual cleanup

## New Scheduled Cleanups

| Domain | Hook | Default | Frequency |
|--------|------|---------|-----------|
| Completed jobs | `datamachine_cleanup_completed_jobs` | 14 days | Daily |
| Processed items | `datamachine_cleanup_processed_items` | 30 days | Daily |
| AS actions + logs | `datamachine_cleanup_as_actions` | 7 days | Daily |

## Changes to Existing Cleanup

- **Log retention default reduced from 30 → 7 days** — pipeline debug logs older than a week are rarely useful. Filter `datamachine_log_max_age_days` still allows overriding.

## New CLI

```bash
# Show all retention policies + table sizes
wp datamachine retention show

# Preview what would be purged
wp datamachine retention run --dry-run

# Execute cleanup now
wp datamachine retention run --yes
```

## Other Fixes

- **Deactivation hook** now unschedules all cleanup actions (previously missed `datamachine_cleanup_old_files` and `datamachine_cleanup_chat_sessions`)

## All Retention Policies (complete picture)

| Domain | Default | Filter/Setting | Status |
|--------|---------|----------------|--------|
| Completed jobs | 14 days | `datamachine_completed_jobs_max_age_days` | **New** |
| Failed jobs | 30 days | `datamachine_failed_jobs_max_age_days` | Existing |
| Pipeline logs | 7 days | `datamachine_log_max_age_days` | **Changed** (was 30) |
| Processed items | 30 days | `datamachine_processed_items_max_age_days` | **New** |
| AS actions + logs | 7 days | `datamachine_as_actions_max_age_days` | **New** |
| Stale claims | 24 hours | `datamachine_stale_claim_max_age` | Existing |
| Chat sessions | 90 days | `chat_retention_days` setting | Existing |
| File cleanup | 7 days | `file_retention_days` setting | Existing |

## Impact

On the Extra Chill events site (282 flows, ~620 MB of accumulated data), these policies would reduce steady-state database size by an estimated 80-90%. Any site running DM at scale benefits automatically — no manual intervention required.

## New Files
- `inc/Core/ActionScheduler/CompletedJobsCleanup.php`
- `inc/Core/ActionScheduler/ProcessedItemsCleanup.php`
- `inc/Core/ActionScheduler/ActionsCleanup.php`
- `inc/Cli/Commands/RetentionCommand.php`