### PR TITLE
ci: enable automated releases via cron schedule

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  schedule:
+    - cron: '*/15 * * * *'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Adds `schedule` trigger (`*/15 * * * *`) to the Homeboy CI workflow
- This is the only missing piece — homeboy-action v2 already maps `cron` context → `release` command automatically

## What this enables
Every 15 minutes, CI checks for releasable conventional commits since the last tag. If found:
1. `homeboy release` runs the quality gate (audit/lint/test)
2. Bumps version based on commit types (`fix:` → patch, `feat:` → minor)
3. Updates changelog, commits, tags, pushes
4. Tag push re-triggers CI for the release build

No human input needed for releases. Version is computed from conventional commit prefixes.

## What already works (no changes needed)
- **Autofix on PRs** — app-token is wired up, action auto-enables autofix commits
- **Autofix PRs on push-to-main** — action auto-opens PRs when non-PR autofix finds fixes
- **Categorized auto-issues** — audit/lint/test failures file/update GitHub issues