### PR TITLE
feat: memory file editability — read-only SITE.md/NETWORK.md, admin-gated RULES.md

### DIFF
--- a/inc/Abilities/File/AgentFileAbilities.php
+++ b/inc/Abilities/File/AgentFileAbilities.php
@@ -333,6 +333,7 @@ class AgentFileAbilities {
 						'type'        => 'core',
 						'layer'       => $registry_meta ? $registry_meta['layer'] : $layer,
 						'protected'   => MemoryFileRegistry::is_protected( $entry ),
+						'editable'    => MemoryFileRegistry::is_editable( $entry ),
 						'registered'  => null !== $registry_meta,
 						'label'       => $registry_meta['label'] ?? self::filename_to_label( $entry ),
 						'description' => $registry_meta['description'] ?? '',
@@ -417,6 +418,26 @@ class AgentFileAbilities {
 	public function executeWriteAgentFile( array $input ): array {
 		$filename = sanitize_file_name( $input['filename'] ?? '' );
 		$content  = $input['content'] ?? '';
+
+		// Editability gate: check before any write.
+		$user_id_for_edit = (int) ( $input['user_id'] ?? 0 );
+		if ( $user_id_for_edit <= 0 ) {
+			$user_id_for_edit = PermissionHelper::acting_user_id();
+		}
+
+		if ( ! MemoryFileRegistry::is_editable( $filename, $user_id_for_edit ) ) {
+			$edit_cap = MemoryFileRegistry::get_edit_capability( $filename );
+			if ( false === $edit_cap ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'File %s is read-only and cannot be edited.', $filename ),
+				);
+			}
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'You do not have permission to edit %s. Required capability: %s', $filename, $edit_cap ),
+			);
+		}
 
 		if ( MemoryFileRegistry::is_protected( $filename ) && '' === trim( $content ) ) {
 			return array(

--- a/inc/Abilities/File/FileConstants.php
+++ b/inc/Abilities/File/FileConstants.php
@@ -70,6 +70,31 @@ class FileConstants {
 	}
 
 	/**
+	 * Check if a file is editable by the given (or current) user.
+	 *
+	 * @since 0.50.0
+	 *
+	 * @param string $filename Filename to check.
+	 * @param int    $user_id  Optional. User ID. 0 = current user.
+	 * @return bool
+	 */
+	public static function is_editable( string $filename, int $user_id = 0 ): bool {
+		return MemoryFileRegistry::is_editable( $filename, $user_id );
+	}
+
+	/**
+	 * Get the raw edit capability for a file.
+	 *
+	 * @since 0.50.0
+	 *
+	 * @param string $filename Filename to check.
+	 * @return bool|string|null true, false, capability string, or null if unregistered.
+	 */
+	public static function get_edit_capability( string $filename ) {
+		return MemoryFileRegistry::get_edit_capability( $filename );
+	}
+
+	/**
 	 * Legacy constant — kept for backward compatibility.
 	 * Use is_protected() or get_protected_files() instead.
 	 *

--- a/inc/Api/AgentFiles.php
+++ b/inc/Api/AgentFiles.php
@@ -287,6 +287,17 @@ class AgentFiles {
 	}
 
 	public static function put_agent_file( WP_REST_Request $request ) {
+		$filename = sanitize_file_name( wp_unslash( $request['filename'] ) );
+
+		// Defense-in-depth: block writes to non-editable files at the REST layer.
+		if ( ! \DataMachine\Engine\AI\MemoryFileRegistry::is_editable( $filename ) ) {
+			$edit_cap = \DataMachine\Engine\AI\MemoryFileRegistry::get_edit_capability( $filename );
+			$message  = false === $edit_cap
+				? sprintf( 'File %s is read-only and cannot be edited.', $filename )
+				: sprintf( 'You do not have permission to edit %s.', $filename );
+			return new WP_Error( 'put_agent_file_error', $message, array( 'status' => 403 ) );
+		}
+
 		// Content may arrive as JSON body param (admin UI) or raw body (API clients).
 		$content = $request->get_param( 'content' );
 		if ( null === $content ) {
@@ -294,7 +305,7 @@ class AgentFiles {
 		}
 
 		$input = array(
-			'filename' => sanitize_file_name( wp_unslash( $request['filename'] ) ),
+			'filename' => $filename,
 			'content'  => $content,
 			'user_id'  => self::resolve_scoped_user_id( $request ),
 		);

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -728,6 +728,13 @@ class MemoryCommand extends BaseCommand {
 			return;
 		}
 
+		// Editability check — warn for read-only files.
+		$edit_cap = \DataMachine\Engine\AI\MemoryFileRegistry::get_edit_capability( $safe_name );
+		if ( false === $edit_cap ) {
+			WP_CLI::error( sprintf( 'File %s is read-only. It is auto-generated and can only be extended via PHP filters.', $safe_name ) );
+			return;
+		}
+
 		$agent_dir = $this->get_agent_dir( $user_id, $agent_id );
 		$filepath  = $agent_dir . '/' . $safe_name;
 

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileEditor.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileEditor.jsx
@@ -26,8 +26,9 @@ import {
 
 /**
  * Core file editor — uses existing agent file API.
+ * Renders read-only for non-editable files (e.g. SITE.md, NETWORK.md).
  */
-const CoreFileEditor = ( { filename } ) => {
+const CoreFileEditor = ( { filename, editable = true } ) => {
 	const { data: file, isLoading, error } = useAgentFile( filename );
 	const saveMutation = useSaveAgentFile();
 	const [ content, setContent ] = useState( '' );
@@ -82,18 +83,32 @@ const CoreFileEditor = ( { filename } ) => {
 		<div className="datamachine-agent-editor">
 			<div className="datamachine-agent-editor-header">
 				<h3>{ filename }</h3>
+				{ ! editable && (
+					<span className="datamachine-agent-editor-readonly-badge">
+						Read-only
+					</span>
+				) }
 			</div>
+			{ ! editable && (
+				<div className="datamachine-agent-editor-readonly-notice">
+					This file is auto-generated and cannot be edited here.
+					Use PHP filters to extend its content.
+				</div>
+			) }
 			<textarea
 				className="datamachine-agent-editor-textarea code"
 				value={ content }
 				onChange={ handleContentChange }
 				spellCheck={ false }
+				readOnly={ ! editable }
 			/>
-			<SettingsSaveBar
-				hasChanges={ hasChanges }
-				saveStatus={ saveStatus }
-				onSave={ handleSave }
-			/>
+			{ editable && (
+				<SettingsSaveBar
+					hasChanges={ hasChanges }
+					saveStatus={ saveStatus }
+					onSave={ handleSave }
+				/>
+			) }
 		</div>
 	);
 };
@@ -202,7 +217,12 @@ const AgentFileEditor = ( { selectedFile } ) => {
 		);
 	}
 
-	return <CoreFileEditor filename={ selectedFile.filename } />;
+	return (
+		<CoreFileEditor
+			filename={ selectedFile.filename }
+			editable={ selectedFile.editable !== false }
+		/>
+	);
 };
 
 export default AgentFileEditor;

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
@@ -369,6 +369,7 @@ const AgentFileList = ( { selectedFile, onSelectFile } ) => {
 										onSelectFile( {
 											type: 'core',
 											filename: file.filename,
+											editable: file.editable !== false,
 										} )
 									}
 									role="button"
@@ -381,6 +382,7 @@ const AgentFileList = ( { selectedFile, onSelectFile } ) => {
 											onSelectFile( {
 												type: 'core',
 												filename: file.filename,
+												editable: file.editable !== false,
 											} );
 										}
 									} }
@@ -388,6 +390,14 @@ const AgentFileList = ( { selectedFile, onSelectFile } ) => {
 									<div className="datamachine-agent-file-item-info">
 										<span className="datamachine-agent-file-item-name">
 											{ file.filename }
+											{ file.editable === false && (
+												<span
+													className="datamachine-agent-file-readonly-icon"
+													title="Read-only"
+												>
+													&#x1f512;
+												</span>
+											) }
 										</span>
 										<span className="datamachine-agent-file-item-meta">
 											{ formatSize( file.size ) }

--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -14,6 +14,7 @@
  * @package DataMachine\Engine\AI
  * @since   0.30.0
  * @since   0.42.0 Added layer-aware registration with metadata.
+ * @since   0.50.0 Added editability control with capability gating.
  */
 
 namespace DataMachine\Engine\AI;
@@ -48,16 +49,21 @@ class MemoryFileRegistry {
 	 * Register a memory file.
 	 *
 	 * @since 0.42.0 Accepts $args array with layer, protected, label, description.
+	 * @since 0.50.0 Added `editable` argument for write-permission gating.
 	 *
 	 * @param string    $filename Filename (e.g. 'SOUL.md', 'brand-guidelines.md').
 	 * @param int       $priority Sort order. Lower numbers load first.
 	 * @param array     $args     {
 	 *     Optional. Registration arguments.
 	 *
-	 *     @type string $layer       One of 'shared', 'agent', 'user', 'network'. Default 'agent'.
-	 *     @type bool   $protected   Whether the file is protected from deletion. Default false.
-	 *     @type string $label       Human-readable display label. Default derived from filename.
-	 *     @type string $description Optional description of the file's purpose.
+	 *     @type string      $layer       One of 'shared', 'agent', 'user', 'network'. Default 'agent'.
+	 *     @type bool        $protected   Whether the file is protected from deletion. Default false.
+	 *     @type string      $label       Human-readable display label. Default derived from filename.
+	 *     @type string      $description Optional description of the file's purpose.
+	 *     @type bool|string $editable    Write-permission control. true = editable by anyone with
+	 *                                    can_manage(). false = read-only (backend/filters only).
+	 *                                    A capability string (e.g. 'manage_options') = editable only
+	 *                                    by users with that WordPress capability. Default true.
 	 * }
 	 * @return void
 	 */
@@ -73,11 +79,18 @@ class MemoryFileRegistry {
 			$layer = self::LAYER_AGENT;
 		}
 
+		// Normalize editable: true (default), false, or a WordPress capability string.
+		$editable = $args['editable'] ?? true;
+		if ( ! is_bool( $editable ) && ! is_string( $editable ) ) {
+			$editable = true;
+		}
+
 		self::$files[ $filename ] = array(
 			'filename'    => $filename,
 			'priority'    => $priority,
 			'layer'       => $layer,
 			'protected'   => (bool) ( $args['protected'] ?? false ),
+			'editable'    => $editable,
 			'label'       => $args['label'] ?? self::filename_to_label( $filename ),
 			'description' => $args['description'] ?? '',
 		);
@@ -114,6 +127,68 @@ class MemoryFileRegistry {
 		$resolved = self::get_resolved();
 		$filename = sanitize_file_name( $filename );
 		return isset( $resolved[ $filename ] ) && $resolved[ $filename ]['protected'];
+	}
+
+	/**
+	 * Check if a file is editable by the current user.
+	 *
+	 * Resolution:
+	 * - Unregistered files: editable (custom user files).
+	 * - `editable === false`: not editable (auto-generated, backend-only).
+	 * - `editable === true`: editable by anyone who passes can_manage().
+	 * - `editable` is a capability string: editable if the user has that capability.
+	 *
+	 * @since 0.50.0
+	 *
+	 * @param string $filename Filename to check.
+	 * @param int    $user_id  Optional. User ID to check against. 0 = current user.
+	 * @return bool
+	 */
+	public static function is_editable( string $filename, int $user_id = 0 ): bool {
+		$resolved = self::get_resolved();
+		$filename = sanitize_file_name( $filename );
+
+		if ( ! isset( $resolved[ $filename ] ) ) {
+			return true; // Unregistered files are editable.
+		}
+
+		$editable = $resolved[ $filename ]['editable'];
+
+		if ( false === $editable ) {
+			return false;
+		}
+
+		if ( true === $editable ) {
+			return true;
+		}
+
+		// Capability string: check against user.
+		if ( is_string( $editable ) && ! empty( $editable ) ) {
+			$check_user = $user_id > 0 ? $user_id : get_current_user_id();
+			return $check_user > 0 && user_can( $check_user, $editable );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the raw edit capability for a file.
+	 *
+	 * Returns:
+	 * - true if editable by any manager.
+	 * - false if not editable.
+	 * - A capability string if gated by a specific WordPress capability.
+	 * - null if not registered.
+	 *
+	 * @since 0.50.0
+	 *
+	 * @param string $filename Filename to look up.
+	 * @return bool|string|null
+	 */
+	public static function get_edit_capability( string $filename ) {
+		$resolved = self::get_resolved();
+		$filename = sanitize_file_name( $filename );
+		return $resolved[ $filename ]['editable'] ?? null;
 	}
 
 	/**

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -65,14 +65,16 @@ use DataMachine\Engine\AI\MemoryFileRegistry;
 MemoryFileRegistry::register( 'SITE.md', 10, array(
 	'layer'       => MemoryFileRegistry::LAYER_SHARED,
 	'protected'   => true,
+	'editable'    => false,
 	'label'       => 'Site Context',
-	'description' => 'Site-wide context shared by all agents.',
+	'description' => 'Auto-generated site context. Read-only — extend via PHP filters.',
 ) );
 MemoryFileRegistry::register( 'RULES.md', 15, array(
 	'layer'       => MemoryFileRegistry::LAYER_SHARED,
 	'protected'   => true,
+	'editable'    => 'manage_options',
 	'label'       => 'Site Rules',
-	'description' => 'Behavioral constraints that apply to every agent.',
+	'description' => 'Behavioral constraints that apply to every agent. Admin-editable.',
 ) );
 
 // Agent layer — identity and knowledge, scoped to a single agent.
@@ -101,8 +103,9 @@ MemoryFileRegistry::register( 'USER.md', 25, array(
 MemoryFileRegistry::register( 'NETWORK.md', 5, array(
 	'layer'       => MemoryFileRegistry::LAYER_NETWORK,
 	'protected'   => true,
+	'editable'    => false,
 	'label'       => 'Network Context',
-	'description' => 'WordPress multisite network topology and shared resources.',
+	'description' => 'Auto-generated multisite network topology. Read-only — extend via PHP filters.',
 ) );
 // SITE.md auto-regeneration — replaces the former SiteContext + SiteContextDirective system.
 // SITE.md is now the single source of truth for site context, auto-refreshing on structural changes.

--- a/inc/migrations.php
+++ b/inc/migrations.php
@@ -569,7 +569,20 @@ function datamachine_get_site_scaffold_content(): string {
 		$lines[] = '- **Custom namespaces:** ' . implode( ', ', $rest_namespaces );
 	}
 
-	return implode( "\n", $lines ) . "\n";
+	$content = implode( "\n", $lines ) . "\n";
+
+	/**
+	 * Filter the auto-generated SITE.md content.
+	 *
+	 * Allows plugins and themes to append or modify the site context
+	 * that is injected into AI agent calls. SITE.md is read-only in the
+	 * admin UI; this filter is the only extension point.
+	 *
+	 * @since 0.50.0
+	 *
+	 * @param string $content The generated SITE.md markdown content.
+	 */
+	return apply_filters( 'datamachine_site_scaffold_content', $content );
 }
 
 /**
@@ -579,10 +592,11 @@ function datamachine_get_site_scaffold_content(): string {
  * themes, post types, taxonomies, options). Debounced via a short-lived
  * transient to avoid excessive writes during bulk operations.
  *
- * Preserves user-added content below the auto-generated section by
- * looking for a <!-- CUSTOM --> marker.
+ * SITE.md is read-only — it is fully regenerated from live WordPress data.
+ * To extend SITE.md content, use the `datamachine_site_scaffold_content` filter.
  *
  * @since 0.48.0
+ * @since 0.50.0 Removed <!-- CUSTOM --> marker; SITE.md is now read-only.
  * @return void
  */
 function datamachine_regenerate_site_md(): void {
@@ -606,22 +620,7 @@ function datamachine_regenerate_site_md(): void {
 		return;
 	}
 
-	// Preserve user-added content below <!-- CUSTOM --> marker.
-	$custom_content = '';
-	if ( file_exists( $site_md_path ) ) {
-		$existing = $fs->get_contents( $site_md_path );
-		$marker   = '<!-- CUSTOM -->';
-		$pos      = strpos( $existing, $marker );
-		if ( false !== $pos ) {
-			$custom_content = substr( $existing, $pos );
-		}
-	}
-
 	$content = datamachine_get_site_scaffold_content();
-
-	if ( ! empty( $custom_content ) ) {
-		$content .= "\n" . $custom_content;
-	}
 
 	if ( ! is_dir( $shared_dir ) ) {
 		wp_mkdir_p( $shared_dir );
@@ -682,10 +681,13 @@ function datamachine_register_site_md_invalidation(): void {
  * Same pattern as datamachine_regenerate_site_md():
  * - 60-second debounce via transient
  * - Respects site_context_enabled setting
- * - Preserves user-added content below <!-- CUSTOM --> marker
  * - Only runs on multisite installs
  *
+ * NETWORK.md is read-only — fully regenerated from live multisite data.
+ * To extend NETWORK.md content, use the `datamachine_network_scaffold_content` filter.
+ *
  * @since 0.49.1
+ * @since 0.50.0 Removed <!-- CUSTOM --> marker; NETWORK.md is now read-only.
  * @return void
  */
 function datamachine_regenerate_network_md(): void {
@@ -714,25 +716,10 @@ function datamachine_regenerate_network_md(): void {
 		return;
 	}
 
-	// Preserve user-added content below <!-- CUSTOM --> marker.
-	$custom_content = '';
-	if ( file_exists( $network_md_path ) ) {
-		$existing = $fs->get_contents( $network_md_path );
-		$marker   = '<!-- CUSTOM -->';
-		$pos      = strpos( $existing, $marker );
-		if ( false !== $pos ) {
-			$custom_content = substr( $existing, $pos );
-		}
-	}
-
 	$content = datamachine_get_network_scaffold_content();
 
 	if ( empty( $content ) ) {
 		return;
-	}
-
-	if ( ! empty( $custom_content ) ) {
-		$content .= "\n" . $custom_content;
 	}
 
 	if ( ! is_dir( $network_dir ) ) {
@@ -1108,6 +1095,7 @@ function datamachine_register_scaffold_generators(): void {
 	add_filter( 'datamachine_scaffold_content', 'datamachine_scaffold_soul_content', 10, 3 );
 	add_filter( 'datamachine_scaffold_content', 'datamachine_scaffold_memory_content', 10, 3 );
 	add_filter( 'datamachine_scaffold_content', 'datamachine_scaffold_daily_content', 10, 3 );
+	add_filter( 'datamachine_scaffold_content', 'datamachine_scaffold_rules_content', 10, 3 );
 }
 add_action( 'plugins_loaded', 'datamachine_register_scaffold_generators', 5 );
 
@@ -1214,6 +1202,47 @@ function datamachine_scaffold_memory_content( string $content, string $filename,
 
 	$defaults = datamachine_get_scaffold_defaults();
 	return $defaults['MEMORY.md'] ?? '';
+}
+
+/**
+ * Generate RULES.md scaffold content.
+ *
+ * Creates a starter template for site-wide behavioral constraints.
+ * RULES.md is admin-editable and applies to every agent on the site.
+ *
+ * @since 0.50.0
+ *
+ * @param string $content  Current content.
+ * @param string $filename Filename being scaffolded.
+ * @param array  $context  Scaffolding context.
+ * @return string
+ */
+function datamachine_scaffold_rules_content( string $content, string $filename, array $context ): string {
+	if ( 'RULES.md' !== $filename || '' !== $content ) {
+		return $content;
+	}
+
+	$site_name = get_bloginfo( 'name' ) ?: 'this site';
+
+	return <<<MD
+# Site Rules
+
+Behavioral constraints that apply to every agent on {$site_name}.
+
+## General
+- Be helpful, accurate, and concise.
+- Follow the site's voice and tone.
+- Do not make up facts or hallucinate information.
+
+## Safety
+- Never expose private user data.
+- Never run destructive operations without confirmation.
+- When in doubt, ask before acting.
+
+## Content
+- Respect the site's content guidelines.
+- Do not publish or modify content without authorization.
+MD;
 }
 
 /**
@@ -1570,7 +1599,20 @@ function datamachine_get_network_scaffold_content(): string {
 	$lines[] = '- **Users:** network-wide (see USER.md)';
 	$lines[] = '- **Media:** per-site uploads';
 
-	return implode( "\n", $lines ) . "\n";
+	$content = implode( "\n", $lines ) . "\n";
+
+	/**
+	 * Filter the auto-generated NETWORK.md content.
+	 *
+	 * Allows plugins and themes to append or modify the network context
+	 * that is injected into AI agent calls. NETWORK.md is read-only in
+	 * the admin UI; this filter is the only extension point.
+	 *
+	 * @since 0.50.0
+	 *
+	 * @param string $content The generated NETWORK.md markdown content.
+	 */
+	return apply_filters( 'datamachine_network_scaffold_content', $content );
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a generic `editable` property to `MemoryFileRegistry` that controls write permissions per memory file across the full stack (abilities, REST, CLI, admin UI).

## Changes

### Registry (`MemoryFileRegistry`)
- New `editable` registration arg: `true` (default), `false` (read-only), or a **capability string** (e.g. `'manage_options'`) for per-file permission gating
- `is_editable($filename, $user_id)` — resolves editability for a specific user
- `get_edit_capability($filename)` — returns the raw capability requirement

### File permissions
| File | Editable | Meaning |
|---|---|---|
| **SITE.md** | `false` | Read-only. Auto-generated, extend via `datamachine_site_scaffold_content` filter |
| **NETWORK.md** | `false` | Read-only. Auto-generated, extend via `datamachine_network_scaffold_content` filter |
| **RULES.md** | `'manage_options'` | Admin-only editable. New scaffold generator for initial content |
| SOUL.md | `true` | Editable by any manager (unchanged) |
| MEMORY.md | `true` | Editable by any manager (unchanged) |
| USER.md | `true` | Editable by any manager (unchanged) |

### Enforcement layers
- **Ability** (`executeWriteAgentFile`) — blocks writes to non-editable files with clear error messages
- **REST** (`PUT /files/agent/{filename}`) — defense-in-depth 403 for non-editable files
- **CLI** (`files write`) — blocks writes to read-only files with guidance
- **Admin UI** — `readOnly` textarea, "Read-only" badge, info notice, hidden save bar, lock icon in sidebar

### Removed
- `<!-- CUSTOM -->` marker preservation in SITE.md and NETWORK.md regeneration — replaced by PHP filters

### Added
- `datamachine_site_scaffold_content` filter — extend SITE.md content from PHP
- `datamachine_network_scaffold_content` filter — extend NETWORK.md content from PHP  
- `datamachine_scaffold_rules_content` — RULES.md scaffold generator
- `FileConstants::is_editable()` and `get_edit_capability()` delegation methods