### PR TITLE
fix: guard scaffold ability lookups to prevent test failures

### DIFF
--- a/inc/Abilities/File/ScaffoldAbilities.php
+++ b/inc/Abilities/File/ScaffoldAbilities.php
@@ -104,6 +104,27 @@ class ScaffoldAbilities {
 		);
 	}
 
+	/**
+	 * Get the scaffold ability safely, without triggering _doing_it_wrong.
+	 *
+	 * Returns null if the Abilities API hasn't loaded yet (e.g. in test
+	 * environments or very early execution contexts). All callers should
+	 * use this instead of wp_get_ability() directly.
+	 *
+	 * @since 0.50.0
+	 *
+	 * @return \WP_Ability|null The scaffold ability, or null if not available.
+	 */
+	public static function get_ability(): ?\WP_Ability {
+		if ( ! class_exists( 'WP_Abilities_Registry' ) ) {
+			return null;
+		}
+		if ( ! \WP_Abilities_Registry::get_instance()->is_registered( 'datamachine/scaffold-memory-file' ) ) {
+			return null;
+		}
+		return wp_get_ability( 'datamachine/scaffold-memory-file' );
+	}
+
 	// =========================================================================
 	// Execution
 	// =========================================================================

--- a/inc/Core/FilesRepository/AgentMemory.php
+++ b/inc/Core/FilesRepository/AgentMemory.php
@@ -401,7 +401,7 @@ class AgentMemory {
 	 */
 	private function ensure_file_exists(): void {
 		if ( ! file_exists( $this->file_path ) ) {
-			$ability = wp_get_ability( 'datamachine/scaffold-memory-file' );
+			$ability = \DataMachine\Abilities\File\ScaffoldAbilities::get_ability();
 			if ( $ability ) {
 				$ability->execute( array(
 					'filename' => 'MEMORY.md',

--- a/inc/Core/FilesRepository/DailyMemory.php
+++ b/inc/Core/FilesRepository/DailyMemory.php
@@ -195,7 +195,7 @@ class DailyMemory {
 
 		// If file doesn't exist, scaffold it with date header via ability.
 		if ( ! file_exists( $file_path ) ) {
-			$ability = wp_get_ability( 'datamachine/scaffold-memory-file' );
+			$ability = \DataMachine\Abilities\File\ScaffoldAbilities::get_ability();
 			if ( $ability ) {
 				$ability->execute( array(
 					'filename' => "daily/{$year}/{$month}/{$day}.md",

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -61,7 +61,7 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 		);
 
 		// Auto-scaffold missing user-layer files (e.g. USER.md) on first chat.
-		$scaffold_ability = wp_get_ability( 'datamachine/scaffold-memory-file' );
+		$scaffold_ability = \DataMachine\Abilities\File\ScaffoldAbilities::get_ability();
 		if ( $user_id > 0 && $scaffold_ability ) {
 			$scaffold_ability->execute( array(
 				'layer'   => MemoryFileRegistry::LAYER_USER,

--- a/inc/migrations.php
+++ b/inc/migrations.php
@@ -1069,7 +1069,7 @@ function datamachine_copy_directory_recursive( string $source_dir, string $targe
  * @since 0.30.0
  */
 function datamachine_ensure_default_memory_files() {
-	$ability = wp_get_ability( 'datamachine/scaffold-memory-file' );
+	$ability = \DataMachine\Abilities\File\ScaffoldAbilities::get_ability();
 	if ( ! $ability ) {
 		return;
 	}


### PR DESCRIPTION
## Summary

Fixes #903 — test failures caused by `wp_get_ability('datamachine/scaffold-memory-file')` firing `_doing_it_wrong` notices in test environments where `wp_abilities_api_init` hasn't fired.

## Problem

`wp_get_ability()` triggers a `_doing_it_wrong` notice when the requested ability isn't registered. In PHPUnit, WP treats `_doing_it_wrong` as a test error — causing 298 test failures across the suite even though the callers already guarded with `if ($ability)`.

The `AltTextTask` tests were the first to surface this because `execute()` calls `DirectoryManager::ensure_agent_files()` which triggers `AgentMemory::ensure_file_exists()` → `wp_get_ability('datamachine/scaffold-memory-file')` → `_doing_it_wrong`.

## Fix

- Added `ScaffoldAbilities::get_ability()` — safe accessor that checks `WP_Abilities_Registry::is_registered()` before calling `wp_get_ability()`
- Updated all 4 callsites to use the helper:
  - `AgentMemory::ensure_file_exists()`
  - `DailyMemory::ensure_write()`
  - `CoreMemoryFilesDirective::generate()`
  - `datamachine_ensure_default_memory_files()`