### PR TITLE
Add PostIdentityIndex table for fast post deduplication

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -229,6 +229,15 @@ function datamachine_run_datamachine_plugin() {
 		new \DataMachine\Abilities\Publish\SendEmailAbility();
 		new \DataMachine\Abilities\Update\UpdateWordPressAbility();
 	} );
+
+	// Clean up identity index rows when posts are permanently deleted.
+	add_action(
+		'before_delete_post',
+		function ( $post_id ) {
+			$index = new \DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex();
+			$index->delete( (int) $post_id );
+		}
+	);
 }
 
 
@@ -484,6 +493,9 @@ function datamachine_activate_for_site() {
 
 	$db_processed_items = new \DataMachine\Core\Database\ProcessedItems\ProcessedItems();
 	$db_processed_items->create_table();
+
+	$db_identity_index = new \DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex();
+	$db_identity_index->create_table();
 
 	\DataMachine\Core\Database\Chat\Chat::create_table();
 	\DataMachine\Core\Database\Chat\Chat::ensure_context_column();

--- a/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php
+++ b/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php
@@ -435,6 +435,9 @@ class DuplicateCheckAbility {
 	/**
 	 * Check published posts for exact source URL matches.
 	 *
+	 * Tries the PostIdentityIndex first (indexed lookup), then falls back
+	 * to meta_query for posts not yet in the index.
+	 *
 	 * @param string $source_url    Canonical source URL.
 	 * @param string $post_type     Post type to search.
 	 * @param int    $lookback_days How many days back to search.
@@ -445,6 +448,49 @@ class DuplicateCheckAbility {
 			return null;
 		}
 
+		// Fast path: check the identity index first (indexed column lookup).
+		$index = new \DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex();
+		$match = $index->find_by_source_url( $source_url );
+
+		if ( $match ) {
+			$candidate_id = (int) $match['post_id'];
+			$post_status  = get_post_status( $candidate_id );
+
+			if ( $post_status && in_array( $post_status, array( 'publish', 'draft', 'pending' ), true ) ) {
+				$candidate_title = get_the_title( $candidate_id );
+
+				do_action(
+					'datamachine_log',
+					'info',
+					'DuplicateCheck: found matching post by source URL (identity index)',
+					array(
+						'source_url'     => $source_url,
+						'existing_id'    => $candidate_id,
+						'existing_title' => $candidate_title,
+						'post_type'      => $post_type,
+					)
+				);
+
+				return array(
+					'verdict'  => 'duplicate',
+					'source'   => 'published_post_source_url',
+					'match'    => array(
+						'post_id'    => $candidate_id,
+						'title'      => $candidate_title,
+						'url'        => get_permalink( $candidate_id ),
+						'source_url' => $source_url,
+					),
+					'reason'   => sprintf(
+						'Rejected: source URL already exists on post "%s" (ID %d).',
+						$candidate_title,
+						$candidate_id
+					),
+					'strategy' => 'core_published_source_url',
+				);
+			}
+		}
+
+		// Fallback: meta_query for posts not yet in the identity index.
 		if ( $lookback_days <= 0 ) {
 			$lookback_days = 14;
 		}
@@ -464,7 +510,7 @@ class DuplicateCheckAbility {
 						'inclusive' => true,
 					),
 				),
-				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Required for source URL dedup.
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Fallback for pre-index posts.
 				'meta_query'     => array(
 					array(
 						'key'   => PostTracking::SOURCE_URL_META_KEY,
@@ -484,7 +530,7 @@ class DuplicateCheckAbility {
 		do_action(
 			'datamachine_log',
 			'info',
-			'DuplicateCheck: found matching published post by source URL',
+			'DuplicateCheck: found matching published post by source URL (meta fallback)',
 			array(
 				'source_url'     => $source_url,
 				'existing_id'    => $candidate_id,

--- a/inc/Core/Database/PostIdentityIndex/PostIdentityIndex.php
+++ b/inc/Core/Database/PostIdentityIndex/PostIdentityIndex.php
@@ -1,0 +1,402 @@
+<?php
+/**
+ * Post Identity Index — indexed lookup table for fast post deduplication.
+ *
+ * Replaces slow wp_postmeta LIKE scans with purpose-built indexed columns.
+ * Extensions register identity fields and write identity rows; the core
+ * provides schema, CRUD, and query primitives.
+ *
+ * The table stores denormalized identity columns (event_date, venue_term_id,
+ * ticket_url, title_hash, source_url) that map back to a post_id. Each post
+ * has at most one identity row. Queries hit composite indexes instead of
+ * scanning the generic postmeta EAV table.
+ *
+ * @package    DataMachine\Core\Database\PostIdentityIndex
+ * @since      0.50.0
+ */
+
+namespace DataMachine\Core\Database\PostIdentityIndex;
+
+use DataMachine\Core\Database\BaseRepository;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class PostIdentityIndex extends BaseRepository {
+
+	const TABLE_NAME = 'datamachine_post_identity';
+
+	/**
+	 * Create or update the table schema.
+	 *
+	 * Called on plugin activation and version migrations.
+	 */
+	public function create_table(): void {
+		$charset_collate = $this->wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE {$this->table_name} (
+			post_id BIGINT(20) UNSIGNED NOT NULL,
+			post_type VARCHAR(20) NOT NULL DEFAULT '',
+			event_date DATE DEFAULT NULL,
+			venue_term_id BIGINT(20) UNSIGNED DEFAULT NULL,
+			ticket_url VARCHAR(512) DEFAULT NULL,
+			title_hash VARCHAR(32) NOT NULL DEFAULT '',
+			source_url VARCHAR(512) DEFAULT NULL,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY  (post_id),
+			KEY idx_date_venue (event_date, venue_term_id),
+			KEY idx_date_title (event_date, title_hash),
+			KEY idx_ticket_date (ticket_url(191), event_date),
+			KEY idx_source_url (source_url(191)),
+			KEY idx_post_type (post_type)
+		) $charset_collate;";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+
+		do_action(
+			'datamachine_log',
+			'debug',
+			'PostIdentityIndex: table created/updated',
+			array(
+				'table_name' => $this->table_name,
+			)
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Write operations
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Insert or update an identity row for a post.
+	 *
+	 * Uses REPLACE INTO for atomic upsert — if the post_id already exists,
+	 * the row is replaced entirely.
+	 *
+	 * @param int   $post_id Post ID (primary key).
+	 * @param array $fields  Identity fields: event_date, venue_term_id,
+	 *                       ticket_url, title_hash, source_url, post_type.
+	 * @return bool True on success.
+	 */
+	public function upsert( int $post_id, array $fields ): bool {
+		if ( $post_id <= 0 ) {
+			return false;
+		}
+
+		$data = array(
+			'post_id'   => $post_id,
+			'post_type' => $fields['post_type'] ?? '',
+		);
+
+		$formats = array( '%d', '%s' );
+
+		if ( isset( $fields['event_date'] ) && '' !== $fields['event_date'] ) {
+			$data['event_date'] = $fields['event_date'];
+			$formats[]          = '%s';
+		}
+
+		if ( isset( $fields['venue_term_id'] ) && $fields['venue_term_id'] > 0 ) {
+			$data['venue_term_id'] = (int) $fields['venue_term_id'];
+			$formats[]             = '%d';
+		}
+
+		if ( isset( $fields['ticket_url'] ) && '' !== $fields['ticket_url'] ) {
+			$data['ticket_url'] = $fields['ticket_url'];
+			$formats[]          = '%s';
+		}
+
+		if ( isset( $fields['title_hash'] ) && '' !== $fields['title_hash'] ) {
+			$data['title_hash'] = $fields['title_hash'];
+			$formats[]          = '%s';
+		}
+
+		if ( isset( $fields['source_url'] ) && '' !== $fields['source_url'] ) {
+			$data['source_url'] = $fields['source_url'];
+			$formats[]          = '%s';
+		}
+
+		// Build REPLACE INTO for atomic upsert.
+		$columns      = implode( ', ', array_keys( $data ) );
+		$placeholders = implode( ', ', $formats );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $this->wpdb->query(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$this->wpdb->prepare(
+				"REPLACE INTO {$this->table_name} ({$columns}) VALUES ({$placeholders})",
+				...array_values( $data )
+			)
+		);
+
+		if ( false === $result ) {
+			$this->log_db_error( 'PostIdentityIndex::upsert', array( 'post_id' => $post_id ) );
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Delete the identity row for a post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool True on success.
+	 */
+	public function delete( int $post_id ): bool {
+		return $this->delete_by_id( 'post_id', $post_id );
+	}
+
+	/**
+	 * Get the identity row for a post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array|null Identity fields or null.
+	 */
+	public function get( int $post_id ): ?array {
+		return $this->find_by_id( 'post_id', $post_id );
+	}
+
+	// -----------------------------------------------------------------------
+	// Query operations — used by dedup strategies
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Find posts by event date and venue.
+	 *
+	 * Primary dedup query for events with known venue.
+	 * Uses idx_date_venue composite index.
+	 *
+	 * @param string   $event_date    Date in YYYY-MM-DD format.
+	 * @param int|null $venue_term_id Venue taxonomy term ID (null for any venue).
+	 * @param int      $limit         Max results.
+	 * @return array Array of identity rows.
+	 */
+	public function find_by_date_and_venue( string $event_date, ?int $venue_term_id = null, int $limit = 20 ): array {
+		if ( empty( $event_date ) ) {
+			return array();
+		}
+
+		if ( null !== $venue_term_id && $venue_term_id > 0 ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			return $this->wpdb->get_results(
+				$this->wpdb->prepare(
+					"SELECT * FROM {$this->table_name} WHERE event_date = %s AND venue_term_id = %d LIMIT %d",
+					$event_date,
+					$venue_term_id,
+					$limit
+				),
+				ARRAY_A
+			) ?: array();
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				"SELECT * FROM {$this->table_name} WHERE event_date = %s LIMIT %d",
+				$event_date,
+				$limit
+			),
+			ARRAY_A
+		) ?: array();
+	}
+
+	/**
+	 * Find posts by event date and title hash.
+	 *
+	 * For exact title dedup. Uses idx_date_title composite index.
+	 *
+	 * @param string $event_date Date in YYYY-MM-DD format.
+	 * @param string $title_hash MD5 hash of normalized title.
+	 * @return array|null First matching identity row or null.
+	 */
+	public function find_by_date_and_title_hash( string $event_date, string $title_hash ): ?array {
+		if ( empty( $event_date ) || empty( $title_hash ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				"SELECT * FROM {$this->table_name} WHERE event_date = %s AND title_hash = %s LIMIT 1",
+				$event_date,
+				$title_hash
+			),
+			ARRAY_A
+		);
+
+		return $row ?: null;
+	}
+
+	/**
+	 * Find posts by ticket URL and event date.
+	 *
+	 * Most reliable dedup — same ticket URL on same date is definitively the same event.
+	 * Uses idx_ticket_date composite index.
+	 *
+	 * @param string $ticket_url Normalized ticket URL.
+	 * @param string $event_date Date in YYYY-MM-DD format.
+	 * @return array|null First matching identity row or null.
+	 */
+	public function find_by_ticket_url_and_date( string $ticket_url, string $event_date ): ?array {
+		if ( empty( $ticket_url ) || empty( $event_date ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				"SELECT * FROM {$this->table_name} WHERE ticket_url = %s AND event_date = %s LIMIT 1",
+				$ticket_url,
+				$event_date
+			),
+			ARRAY_A
+		);
+
+		return $row ?: null;
+	}
+
+	/**
+	 * Find posts by source URL.
+	 *
+	 * Used by wire/publish dedup. Uses idx_source_url index.
+	 *
+	 * @param string $source_url Source URL to match.
+	 * @return array|null First matching identity row or null.
+	 */
+	public function find_by_source_url( string $source_url ): ?array {
+		if ( empty( $source_url ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				"SELECT * FROM {$this->table_name} WHERE source_url = %s LIMIT 1",
+				$source_url
+			),
+			ARRAY_A
+		);
+
+		return $row ?: null;
+	}
+
+	/**
+	 * Find all posts with ticket URLs on a given date.
+	 *
+	 * Used for canonical ticket identity comparison (affiliate URL unwrapping).
+	 *
+	 * @param string $event_date Date in YYYY-MM-DD format.
+	 * @param int    $limit      Max results.
+	 * @return array Array of identity rows that have ticket_url set.
+	 */
+	public function find_with_ticket_url_on_date( string $event_date, int $limit = 50 ): array {
+		if ( empty( $event_date ) ) {
+			return array();
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				"SELECT * FROM {$this->table_name} WHERE event_date = %s AND ticket_url IS NOT NULL AND ticket_url != '' LIMIT %d",
+				$event_date,
+				$limit
+			),
+			ARRAY_A
+		) ?: array();
+	}
+
+	/**
+	 * Find posts by event date only.
+	 *
+	 * Broadest date query — used for venue-agnostic fuzzy title fallback.
+	 *
+	 * @param string $event_date Date in YYYY-MM-DD format.
+	 * @param int    $limit      Max results.
+	 * @return array Array of identity rows.
+	 */
+	public function find_by_date( string $event_date, int $limit = 50 ): array {
+		if ( empty( $event_date ) ) {
+			return array();
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				"SELECT * FROM {$this->table_name} WHERE event_date = %s LIMIT %d",
+				$event_date,
+				$limit
+			),
+			ARRAY_A
+		) ?: array();
+	}
+
+	// -----------------------------------------------------------------------
+	// Bulk operations — used by backfill/audit CLI
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Count total identity rows.
+	 *
+	 * @param string $post_type Optional post type filter.
+	 * @return int Row count.
+	 */
+	public function count( string $post_type = '' ): int {
+		if ( '' !== $post_type ) {
+			return $this->count_rows( 'post_type = %s', array( $post_type ) );
+		}
+		return $this->count_rows();
+	}
+
+	/**
+	 * Get post IDs that are missing from the identity index.
+	 *
+	 * Used by backfill to find posts that need identity rows.
+	 *
+	 * @param string $post_type Post type to check.
+	 * @param int    $limit     Max results.
+	 * @param int    $offset    Offset for pagination.
+	 * @return array Array of post IDs.
+	 */
+	public function find_missing_post_ids( string $post_type, int $limit = 500, int $offset = 0 ): array {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT p.ID FROM {$wpdb->posts} p
+				LEFT JOIN {$this->table_name} idx ON p.ID = idx.post_id
+				WHERE p.post_type = %s
+				AND p.post_status IN ('publish', 'draft', 'pending')
+				AND idx.post_id IS NULL
+				ORDER BY p.ID ASC
+				LIMIT %d OFFSET %d",
+				$post_type,
+				$limit,
+				$offset
+			)
+		);
+
+		return array_map( 'intval', $results ?: array() );
+	}
+
+	/**
+	 * Bulk delete identity rows for a post type.
+	 *
+	 * @param string $post_type Post type.
+	 * @return int Number of rows deleted.
+	 */
+	public function delete_by_post_type( string $post_type ): int {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$result = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"DELETE FROM {$this->table_name} WHERE post_type = %s",
+				$post_type
+			)
+		);
+
+		return false === $result ? 0 : $result;
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a purpose-built indexed lookup table (`datamachine_post_identity`) to replace slow `wp_postmeta` LIKE scans during post deduplication
- Table provides indexed columns for `event_date`, `venue_term_id`, `ticket_url`, `title_hash`, `source_url` — all the fields that handlers need for identity matching
- `DuplicateCheckAbility` enhanced to use the identity index for source URL checks (with meta_query fallback for pre-index posts)

## Why

Event upsert dedup queries use `LIKE '%2026-04-07%'` on `_datamachine_event_datetime` in postmeta (162K rows). Leading-wildcard LIKE **cannot use indexes** — it does a full table scan every time. With 282 flows running concurrently, this pegs MariaDB at 100% CPU and causes 2-10s TTFB spikes across all sites.

The identity index replaces these O(n) scans with O(log n) indexed lookups. Same dedup intelligence, dramatically faster queries.

## What's in this PR (core only)

- `PostIdentityIndex` class: schema with composite indexes, CRUD methods, bulk query operations
- Wired into plugin activation/migration path via `datamachine_activate_for_site()`
- Post deletion cleanup hook (`before_delete_post`)
- `DuplicateCheckAbility.checkPublishedPostsBySourceUrl()` uses identity index first, meta_query fallback second

## Companion PR

The events plugin PR ([data-machine-events](https://github.com/Extra-Chill/data-machine-events/pulls)) registers an event dedup strategy via `datamachine_duplicate_strategies` that queries this table, plus an identity writer that keeps rows in sync.