### PR TITLE
Preserve initial_data when RunFlowAbility builds engine snapshot

### DIFF
--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -190,6 +190,13 @@ class RunFlowAbility {
 			'pipeline_config' => $pipeline_config,
 		);
 
+		// Preserve any pre-existing engine data (e.g. initial_data from ExecuteWorkflowAbility
+		// which may contain submission context, webhook payloads, etc.).
+		$existing_data = \DataMachine\Core\EngineData::retrieve( $job_id );
+		if ( ! empty( $existing_data ) ) {
+			$engine_snapshot = array_merge( $existing_data, $engine_snapshot );
+		}
+
 		datamachine_set_engine_data( $job_id, $engine_snapshot );
 
 		$first_flow_step_id = null;


### PR DESCRIPTION
## Summary

- **Bug:** `ExecuteWorkflowAbility` stores `initial_data` (submission context, webhook payloads, etc.) on a job's engine data before scheduling `datamachine_run_flow_now`. But `RunFlowAbility` rebuilds the engine snapshot from scratch and calls `datamachine_set_engine_data()`, which **overwrites** the initial_data completely.
- **Impact:** Event submission `user_id`, contact info, and any other initial_data passed via `datamachine/execute-workflow` was silently lost before the first step ever ran.
- **Fix:** Retrieve any pre-existing engine data and merge it with the new snapshot. The snapshot's canonical keys (`job`, `flow`, `pipeline`, `flow_config`, `pipeline_config`) take precedence, while initial_data keys like `submission` survive.

## Context

This is the companion fix to [data-machine-events#127](https://github.com/Extra-Chill/data-machine-events/pull/127) which attributes event submissions to the submitting user. Without this fix, the `submission.user_id` stored by `EventSubmissionAbilities` was always erased before `EventUpsert` could read it.