### PR TITLE
Pass enabled_tools through to handler_slugs in ephemeral workflows

### DIFF
--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -489,12 +489,21 @@ class ExecuteWorkflowAbility {
 			$handler_slug   = $step['handler_slug'] ?? '';
 			$handler_config = $step['handler_config'] ?? array();
 
+			// Resolve handler_slugs: explicit handler_slug for non-AI steps,
+			// or enabled_tools for AI steps (tells the AI which tools it must call).
+			$handler_slugs = array();
+			if ( ! empty( $handler_slug ) ) {
+				$handler_slugs = array( $handler_slug );
+			} elseif ( ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
+				$handler_slugs = $step['enabled_tools'];
+			}
+
 			$flow_config[ $step_id ] = array(
 				'flow_step_id'     => $step_id,
 				'pipeline_step_id' => $pipeline_step_id,
 				'step_type'        => $step['type'],
 				'execution_order'  => $index,
-				'handler_slugs'    => ! empty( $handler_slug ) ? array( $handler_slug ) : array(),
+				'handler_slugs'    => $handler_slugs,
 				'handler_configs'  => ! empty( $handler_slug ) ? array( $handler_slug => $handler_config ) : array(),
 				'user_message'     => $step['user_message'] ?? '',
 				'disabled_tools'   => $step['disabled_tools'] ?? array(),


### PR DESCRIPTION
## Summary

- **Bug:** `buildConfigsFromWorkflow()` silently dropped the `enabled_tools` array from step definitions when building `flow_config` for ephemeral workflows. Only `handler_slug` (singular, for non-AI steps) was mapped to `handler_slugs`.
- **Impact:** AI steps in ephemeral workflows never knew which tools they needed to call. The conversation loop saw `handler_slugs: []`, ran the AI without tool requirements, and the subsequent update step failed with `required_handler_tool_not_called`.
- **Affected:** Event submission ephemeral workflows, any `datamachine/execute-workflow` call with AI steps that specify `enabled_tools`.
- **Fix:** When `handler_slug` is empty (AI steps), fall back to `enabled_tools` array from the step definition. This maps to `handler_slugs` in the flow config, which the `AIConversationLoop` uses to enforce tool calling.

## Context

Third of three fixes needed for end-to-end event submission:
1. [data-machine-events#127](https://github.com/Extra-Chill/data-machine-events/pull/127) — Attribute submissions to submitting user
2. [data-machine#907](https://github.com/Extra-Chill/data-machine/pull/907) — Preserve initial_data in engine snapshot
3. **This PR** — Enable AI tools in ephemeral workflows