### PR TITLE
feat: add $meta parameter to handler registration

### DIFF
--- a/inc/Core/Steps/HandlerRegistrationTrait.php
+++ b/inc/Core/Steps/HandlerRegistrationTrait.php
@@ -32,6 +32,7 @@ trait HandlerRegistrationTrait {
 	 * @param string|null $settingsClass Settings class name
 	 * @param callable|null $aiToolCallback AI tool registration callback
 	 * @param string|null $authProviderKey Optional custom auth provider key for shared authentication
+	 * @param array $meta Optional arbitrary metadata (e.g. charLimit, maxImages). Passed through to /handlers API.
 	 */
 	protected static function registerHandler(
 		string $slug,
@@ -43,14 +44,15 @@ trait HandlerRegistrationTrait {
 		?string $authClass = null,
 		?string $settingsClass = null,
 		?callable $aiToolCallback = null,
-		?string $authProviderKey = null
+		?string $authProviderKey = null,
+		array $meta = array()
 	): void {
 		// Compute auth provider key for both handler metadata and auth registration
 		$provider_key = $authProviderKey ?? $slug;
 
 		// Handler registration
 		add_filter('datamachine_handlers', function($handlers, $step_type = null)
-			use ($slug, $type, $class_name, $label, $description, $requiresAuth, $provider_key) {
+			use ($slug, $type, $class_name, $label, $description, $requiresAuth, $provider_key, $meta) {
 			if ( null === $step_type || $step_type === $type ) {
 				$handlers[ $slug ] = array(
 					'type'              => $type,
@@ -59,6 +61,7 @@ trait HandlerRegistrationTrait {
 					'description'       => $description,
 					'requires_auth'     => $requiresAuth,
 					'auth_provider_key' => $requiresAuth ? $provider_key : null,
+					'meta'              => $meta,
 				);
 			}
 			return $handlers;


### PR DESCRIPTION
## Summary

Adds an optional `$meta` array parameter to `HandlerRegistrationTrait::registerHandler()`. Handlers can now self-declare arbitrary metadata during registration that flows through to the `/handlers` REST endpoint automatically.

## What changed

`HandlerRegistrationTrait.php` — one new parameter:

```php
protected static function registerHandler(
    // ... existing params ...
    ?string $authProviderKey = null,
    array $meta = array()  // ← NEW
): void
```

The `meta` array is stored in the handler definition and included in the `datamachine_handlers` filter output. The `/datamachine/v1/handlers` API already passes the full handler array through, so `meta` appears in API responses with zero additional work.

## Use case

Social handlers use this to declare platform constraints (charLimit, maxImages, aspectRatios, etc.) at registration time. The socials `/platforms` endpoint then assembles from the handler registry instead of maintaining a hardcoded array. Any new handler that registers with `$meta` gets its metadata exposed automatically.

## Backward compatible

Default is `array()` — existing handlers that don't pass `$meta` are unaffected.

## Merge order

1. **This PR first** (core primitive)
2. `data-machine-socials#89` — handlers declare `$meta`, `/platforms` assembles from registry
3. `extrachill-api-client#4` — type update
4. `extrachill-studio#6` — frontend