### PR TITLE
fix: engine_data clobber in AIStep + revert UpdateStep fallback + transport safety

### DIFF
--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -140,7 +140,21 @@ class ScheduleNextStepAbility {
 				$context = datamachine_get_file_context( $flow_id );
 
 				$storage = new FileStorage();
-				$storage->store_data_packet( $dataPackets, $job_id, $context );
+				$result  = $storage->store_data_packet( $dataPackets, $job_id, $context );
+
+				if ( false === $result ) {
+					do_action(
+						'datamachine_log',
+						'error',
+						'Failed to persist data packets to filesystem — step will have no input data',
+						array(
+							'job_id'       => $job_id,
+							'flow_step_id' => $flow_step_id,
+							'flow_id'      => $flow_id,
+							'packet_count' => count( $dataPackets ),
+						)
+					);
+				}
 			}
 		}
 

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -261,13 +261,12 @@ class AIStep extends Step {
 			return array();
 		}
 
-		// Store token usage in job engine_data (read-then-merge — store_engine_data is a full overwrite).
+		// Store token usage in job engine_data via merge to avoid clobbering
+		// data written by handler tools during the conversation loop (e.g.
+		// event_id, event_url, post_id written via datamachine_merge_engine_data).
 		$usage = $loop_result['usage'] ?? array();
 		if ( ! empty( $usage ) && $this->job_id > 0 && ( $usage['total_tokens'] ?? 0 ) > 0 ) {
-			$jobs_db       = new \DataMachine\Core\Database\Jobs\Jobs();
-			$existing_data = $engine_data;
-			$existing_data['token_usage'] = $usage;
-			$jobs_db->store_engine_data( $this->job_id, $existing_data );
+			datamachine_merge_engine_data( $this->job_id, array( 'token_usage' => $usage ) );
 		}
 
 		// Process loop results into data packets

--- a/inc/Core/Steps/Update/UpdateStep.php
+++ b/inc/Core/Steps/Update/UpdateStep.php
@@ -81,41 +81,6 @@ class UpdateStep extends Step {
 			return $this->create_update_entry_from_tool_result( $tool_result_entry, $this->dataPackets, $primary_handler_slug, $this->flow_step_id );
 		}
 
-		// Fallback: check if the handler tool actually ran successfully but data packets
-		// were lost during the AI→update step handoff. Handler tools store results directly
-		// in engine data (e.g. event_id, event_url, post_id) via datamachine_merge_engine_data().
-		// If those exist, the tool completed — the data packets just didn't survive.
-		$engine_evidence = $this->checkEngineDataForHandlerCompletion( $required_handler_slugs );
-		if ( $engine_evidence ) {
-			$this->log(
-				'info',
-				'Update step: handler result missing from data packets but engine data confirms completion',
-				array(
-					'configured_handlers'  => $configured_handler_slugs,
-					'required_handlers'    => $required_handler_slugs,
-					'engine_evidence_keys' => array_keys( $engine_evidence ),
-				)
-			);
-
-			$primary_handler_slug = $required_handler_slugs[0];
-			$packet               = new DataPacket(
-				array(
-					'update_result' => $engine_evidence,
-					'updated_at'    => current_time( 'mysql', true ),
-				),
-				array(
-					'step_type'    => 'update',
-					'handler'      => $primary_handler_slug,
-					'flow_step_id' => $this->flow_step_id,
-					'success'      => true,
-					'executed_via' => 'engine_data_fallback',
-				),
-				'update'
-			);
-
-			return $packet->addTo( $this->dataPackets );
-		}
-
 		$this->log(
 			'warning',
 			'Update step required handler tool was not executed by AI',
@@ -335,45 +300,4 @@ class UpdateStep extends Step {
 		return $results;
 	}
 
-	/**
-	 * Check engine data for evidence that a handler tool completed successfully.
-	 *
-	 * Handler tools (e.g. upsert_event) store results directly in engine data
-	 * via datamachine_merge_engine_data() during execution. If data packets were
-	 * lost during the AI→update step handoff, the engine data still has proof
-	 * the tool ran.
-	 *
-	 * Checks for common handler-result keys that tools write to engine data.
-	 * Returns the evidence as an associative array, or null if no evidence found.
-	 *
-	 * @param array $required_handler_slugs Required handler slugs.
-	 * @return array|null Evidence array or null.
-	 */
-	private function checkEngineDataForHandlerCompletion( array $required_handler_slugs ): ?array {
-		$engine_data = $this->engine->all();
-
-		// Handler tools store these keys in engine data on success.
-		// This is a generic check — any handler that writes to engine data benefits.
-		$evidence_keys = array( 'event_id', 'event_url', 'post_id', 'post_url', 'published_url' );
-		$evidence      = array();
-
-		foreach ( $evidence_keys as $key ) {
-			$value = $engine_data[ $key ] ?? null;
-			if ( null !== $value && '' !== $value ) {
-				$evidence[ $key ] = $value;
-			}
-		}
-
-		if ( empty( $evidence ) ) {
-			return null;
-		}
-
-		// Also check that the handler slug matches what we expect.
-		$post_handler = $engine_data['_datamachine_post_handler'] ?? null;
-		if ( $post_handler && ! in_array( $post_handler, $required_handler_slugs, true ) ) {
-			return null;
-		}
-
-		return $evidence;
-	}
 }


### PR DESCRIPTION
## Summary

Root-cause fix for the false-positive `required_handler_tool_not_called` failures (#911 was a workaround).

- **AIStep token_usage write was clobbering handler tool data.** Used a stale pre-loop `$engine_data` snapshot via `$jobs_db->store_engine_data()` (full DB overwrite, bypassed `wp_cache`). Handler tools writing `event_id`, `event_url`, `post_id` etc. via `datamachine_merge_engine_data()` during the conversation loop were silently nuked. Replaced with `datamachine_merge_engine_data()` which reads current state and updates both DB and cache atomically.
- **Reverts #911 engine_data fallback in UpdateStep.** Step types should not sniff engine_data for handler results — that breaks the separation between the content pipeline (data packets) and configuration layer (engine_data). With the root cause fixed, the fallback is unnecessary.
- **Adds return-value checking in ScheduleNextStepAbility.** `store_data_packet()` failures were silently ignored — the step was scheduled anyway with no input data, causing downstream steps to fail with misleading errors. Now logs an explicit error when filesystem persistence fails.

## The bug

```
AIStep.executeStep():
  line 221: $engine_data = $this->engine->all()        ← snapshot BEFORE loop
  line 238: $loop_result = $loop->execute(...)          ← handler tools write to engine_data here
  line 270: $jobs_db->store_engine_data($id, $stale)   ← FULL OVERWRITE with pre-loop data
```

`$jobs_db->store_engine_data()` writes directly to DB without updating `wp_cache`, creating a DB↔cache divergence. Any engine_data written by handler tools during the conversation loop was lost on the next cold-cache read.

## Changes

| File | What |
|------|------|
| `AIStep.php` | Replace `$jobs_db->store_engine_data()` with `datamachine_merge_engine_data()` |
| `UpdateStep.php` | Remove `checkEngineDataForHandlerCompletion()` and the fallback path (revert #911) |
| `ScheduleNextStepAbility.php` | Check `store_data_packet()` return value, log on failure |

## Testing

All 10 relevant tests pass (AIStepTest, UpdateStepTest, ToolResultFinderTest).