### PR TITLE
feat: Agent self-identity in SOUL.md scaffolding and name-change propagation

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -495,6 +495,16 @@ class AgentAbilities {
 		$agent_dir         = $directory_manager->get_agent_identity_directory( $slug );
 		$directory_manager->ensure_directory_exists( $agent_dir );
 
+		// Scaffold agent-layer memory files (SOUL.md, MEMORY.md) with identity context.
+		$scaffold_ability = \DataMachine\Abilities\File\ScaffoldAbilities::get_ability();
+		if ( $scaffold_ability ) {
+			$scaffold_ability->execute( array(
+				'layer'      => 'agent',
+				'agent_slug' => $slug,
+				'agent_id'   => $agent_id,
+			) );
+		}
+
 		return array(
 			'success'    => true,
 			'agent_id'   => $agent_id,
@@ -620,6 +630,9 @@ class AgentAbilities {
 			);
 		}
 
+		// Capture old name before update for propagation.
+		$old_name = (string) $agent['agent_name'];
+
 		$ok = $agents_repo->update_agent( $agent_id, $update );
 
 		if ( ! $ok ) {
@@ -629,8 +642,104 @@ class AgentAbilities {
 			);
 		}
 
+		// Propagate name change to agent memory files.
+		if ( isset( $update['agent_name'] ) && $update['agent_name'] !== $old_name ) {
+			self::propagateNameChange(
+				(string) $agent['agent_slug'],
+				$old_name,
+				$update['agent_name']
+			);
+		}
+
 		// Return the updated agent.
 		return self::getAgent( array( 'agent_id' => $agent_id ) );
+	}
+
+	/**
+	 * Propagate an agent name change across memory files.
+	 *
+	 * Performs a find-and-replace of the old name with the new name in
+	 * SOUL.md and MEMORY.md. Only touches files that exist and contain
+	 * the old name. Uses whole-word matching to avoid partial replacements.
+	 *
+	 * @since 0.51.0
+	 *
+	 * @param string $agent_slug Agent slug (for directory resolution).
+	 * @param string $old_name   Previous agent display name.
+	 * @param string $new_name   New agent display name.
+	 * @return array { files_updated: string[], files_skipped: string[] }
+	 */
+	private static function propagateNameChange( string $agent_slug, string $old_name, string $new_name ): array {
+		$directory_manager = new DirectoryManager();
+		$agent_dir         = $directory_manager->get_agent_identity_directory( $agent_slug );
+
+		if ( ! is_dir( $agent_dir ) ) {
+			return array(
+				'files_updated' => array(),
+				'files_skipped' => array(),
+			);
+		}
+
+		$target_files  = array( 'SOUL.md', 'MEMORY.md' );
+		$files_updated = array();
+		$files_skipped = array();
+
+		global $wp_filesystem;
+		if ( ! $wp_filesystem ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			WP_Filesystem();
+		}
+
+		foreach ( $target_files as $filename ) {
+			$filepath = trailingslashit( $agent_dir ) . $filename;
+
+			if ( ! file_exists( $filepath ) ) {
+				$files_skipped[] = $filename;
+				continue;
+			}
+
+			$content = $wp_filesystem->get_contents( $filepath );
+
+			if ( false === $content || false === strpos( $content, $old_name ) ) {
+				$files_skipped[] = $filename;
+				continue;
+			}
+
+			$updated_content = str_replace( $old_name, $new_name, $content );
+
+			if ( $updated_content === $content ) {
+				$files_skipped[] = $filename;
+				continue;
+			}
+
+			$wp_filesystem->put_contents( $filepath, $updated_content, FS_CHMOD_FILE );
+			$files_updated[] = $filename;
+		}
+
+		if ( ! empty( $files_updated ) ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				sprintf(
+					'Agent name changed from "%s" to "%s". Updated: %s.',
+					$old_name,
+					$new_name,
+					implode( ', ', $files_updated )
+				),
+				array(
+					'agent_slug'    => $agent_slug,
+					'old_name'      => $old_name,
+					'new_name'      => $new_name,
+					'files_updated' => $files_updated,
+					'files_skipped' => $files_skipped,
+				)
+			);
+		}
+
+		return array(
+			'files_updated' => $files_updated,
+			'files_skipped' => $files_skipped,
+		);
 	}
 
 	/**

--- a/inc/migrations.php
+++ b/inc/migrations.php
@@ -170,10 +170,12 @@ add_action( 'init', 'datamachine_maybe_run_migrations', 5 );
  * of empty placeholder comments.
  *
  * @since 0.32.0
+ * @since 0.51.0 Accepts optional $agent_name for identity-aware SOUL.md scaffolding.
  *
+ * @param string $agent_name Optional agent display name to include in SOUL.md identity.
  * @return array<string, string> Filename => content map for SOUL.md, USER.md, MEMORY.md.
  */
-function datamachine_get_scaffold_defaults(): array {
+function datamachine_get_scaffold_defaults( string $agent_name = '' ): array {
 	// --- Site metadata ---
 	$site_name    = get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : 'WordPress Site';
 	$site_tagline = get_bloginfo( 'description' );
@@ -269,11 +271,21 @@ function datamachine_get_scaffold_defaults(): array {
 	$soul_context = implode( "\n", $context_items ) . $multisite_line;
 
 	// --- SOUL.md ---
+	$identity_line = ! empty( $agent_name )
+		? "You are **{$agent_name}**, an AI assistant managing {$site_name}."
+		: "You are an AI assistant managing {$site_name}.";
+
+	$identity_meta = '';
+	if ( ! empty( $agent_name ) ) {
+		$identity_meta = "\n- **Name:** {$agent_name}";
+	}
+
 	$soul = <<<MD
-# Agent Soul
+# Agent Soul — {$site_name}
 
 ## Identity
-You are an AI assistant managing {$site_name}.
+{$identity_line}
+{$identity_meta}
 
 ## Voice & Tone
 Write in a clear, helpful tone.
@@ -1081,6 +1093,54 @@ function datamachine_ensure_default_memory_files() {
 }
 
 /**
+ * Resolve agent display name from scaffolding context.
+ *
+ * Looks up the agent record from the provided context identifiers
+ * (agent_slug, agent_id, or user_id) and returns the display name.
+ * Returns empty string when no agent can be resolved.
+ *
+ * @since 0.51.0
+ *
+ * @param array $context Scaffolding context with agent_slug, agent_id, or user_id.
+ * @return string Agent display name, or empty string.
+ */
+function datamachine_resolve_agent_name_from_context( array $context ): string {
+	if ( ! class_exists( '\\DataMachine\\Core\\Database\\Agents\\Agents' ) ) {
+		return '';
+	}
+
+	$agents_repo = new \DataMachine\Core\Database\Agents\Agents();
+
+	// 1) Explicit agent_slug.
+	if ( ! empty( $context['agent_slug'] ) ) {
+		$agent = $agents_repo->get_by_slug( sanitize_title( (string) $context['agent_slug'] ) );
+		if ( ! empty( $agent['agent_name'] ) ) {
+			return (string) $agent['agent_name'];
+		}
+	}
+
+	// 2) Agent ID.
+	$agent_id = (int) ( $context['agent_id'] ?? 0 );
+	if ( $agent_id > 0 ) {
+		$agent = $agents_repo->get_agent( $agent_id );
+		if ( ! empty( $agent['agent_name'] ) ) {
+			return (string) $agent['agent_name'];
+		}
+	}
+
+	// 3) User ID → owner lookup.
+	$user_id = (int) ( $context['user_id'] ?? 0 );
+	if ( $user_id > 0 ) {
+		$agent = $agents_repo->get_by_owner_id( $user_id );
+		if ( ! empty( $agent['agent_name'] ) ) {
+			return (string) $agent['agent_name'];
+		}
+	}
+
+	return '';
+}
+
+/**
  * Register default content generators for datamachine/scaffold-memory-file.
  *
  * Each generator handles one filename and builds content from the
@@ -1169,11 +1229,16 @@ MD;
 /**
  * Generate SOUL.md content from site and agent context.
  *
+ * Uses scaffolding context (agent_slug, agent_id) to resolve the agent's
+ * display name from the database and embed it in the identity section.
+ * Falls back to the generic template when no agent context is available.
+ *
  * @since 0.50.0
+ * @since 0.51.0 Resolves agent_name from context for identity-aware scaffolding.
  *
  * @param string $content  Current content.
  * @param string $filename Filename being scaffolded.
- * @param array  $context  Scaffolding context.
+ * @param array  $context  Scaffolding context with agent_slug, agent_id, or user_id.
  * @return string
  */
 function datamachine_scaffold_soul_content( string $content, string $filename, array $context ): string {
@@ -1181,7 +1246,10 @@ function datamachine_scaffold_soul_content( string $content, string $filename, a
 		return $content;
 	}
 
-	$defaults = datamachine_get_scaffold_defaults();
+	// Resolve agent identity from context.
+	$agent_name = datamachine_resolve_agent_name_from_context( $context );
+
+	$defaults = datamachine_get_scaffold_defaults( $agent_name );
 	return $defaults['SOUL.md'] ?? '';
 }
 


### PR DESCRIPTION
## Summary

- **SOUL.md now includes the agent's display name** when scaffolded, so agents know their own identity from session one
- **Name changes propagate** to SOUL.md and MEMORY.md automatically when updated via admin UI, REST API, or CLI
- **createAgent() eagerly scaffolds** agent-layer memory files at creation time instead of deferring to lazy first-read

## Problem

When a new agent was created, its SOUL.md started with:

```markdown
# Agent Soul

## Identity
You are an AI assistant managing Extra Chill.
```

No agent name. The agent had no idea who it was — it thought it was `# Agent Soul`. Meanwhile the database had `agent_name: "Chubes"` but that never made it into the soul file. And if someone later changed the agent name in wp-admin, the database updated but SOUL.md was never touched.

## Changes

### `inc/migrations.php`

1. **`datamachine_get_scaffold_defaults()`** — accepts optional `$agent_name` parameter, builds identity-aware SOUL.md:
   ```markdown
   # Agent Soul — Extra Chill

   ## Identity
   You are **Chubes**, an AI assistant managing Extra Chill.
   - **Name:** Chubes
   ```

2. **`datamachine_scaffold_soul_content()`** — resolves agent name from scaffolding context before generating content

3. **`datamachine_resolve_agent_name_from_context()`** — new helper that looks up agent display name via agent_slug → agent_id → user_id fallback chain

### `inc/Abilities/AgentAbilities.php`

4. **`createAgent()`** — now calls `ScaffoldAbilities::execute()` with `agent_slug` + `agent_id` context immediately after directory creation

5. **`updateAgent()`** — detects name changes and calls new `propagateNameChange()` method

6. **`propagateNameChange()`** — new private method that find-and-replaces old name with new name in SOUL.md and MEMORY.md, with logging

## Testing

- Lint passes (`homeboy lint data-machine` — no change from baseline)
- Agent tests: 75 pass, 38 fail — **identical to main** (all failures pre-existing)
- No new test regressions introduced