### PR TITLE
feat: Self-service agent creation for non-admin users

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -372,6 +372,7 @@ function datamachine_register_capabilities(): void {
 		'datamachine_chat',
 		'datamachine_use_tools',
 		'datamachine_view_logs',
+		'datamachine_create_own_agent',
 	);
 
 	$administrator = get_role( 'administrator' );
@@ -386,17 +387,20 @@ function datamachine_register_capabilities(): void {
 		$editor->add_cap( 'datamachine_chat' );
 		$editor->add_cap( 'datamachine_use_tools' );
 		$editor->add_cap( 'datamachine_view_logs' );
+		$editor->add_cap( 'datamachine_create_own_agent' );
 	}
 
 	$author = get_role( 'author' );
 	if ( $author ) {
 		$author->add_cap( 'datamachine_chat' );
 		$author->add_cap( 'datamachine_use_tools' );
+		$author->add_cap( 'datamachine_create_own_agent' );
 	}
 
 	$subscriber = get_role( 'subscriber' );
 	if ( $subscriber ) {
 		$subscriber->add_cap( 'datamachine_chat' );
+		$subscriber->add_cap( 'datamachine_create_own_agent' );
 	}
 }
 
@@ -414,6 +418,7 @@ function datamachine_remove_capabilities(): void {
 		'datamachine_chat',
 		'datamachine_use_tools',
 		'datamachine_view_logs',
+		'datamachine_create_own_agent',
 	);
 
 	$roles = array( 'administrator', 'editor', 'author', 'subscriber' );

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -112,11 +112,11 @@ class AgentAbilities {
 				'datamachine/create-agent',
 				array(
 					'label'               => 'Create Agent',
-					'description'         => 'Create a new agent identity with filesystem directory and owner access',
+					'description'         => 'Create a new agent identity with filesystem directory and owner access. Admins can create agents for any user. Non-admins with create_own_agent can create one agent for themselves.',
 					'category'            => 'datamachine',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'required'   => array( 'agent_slug', 'owner_id' ),
+						'required'   => array( 'agent_slug' ),
 						'properties' => array(
 							'agent_slug' => array(
 								'type'        => 'string',
@@ -128,7 +128,7 @@ class AgentAbilities {
 							),
 							'owner_id'   => array(
 								'type'        => 'integer',
-								'description' => 'WordPress user ID of the agent owner.',
+								'description' => 'WordPress user ID of the agent owner. Non-admins can only create agents for themselves (this field is ignored).',
 							),
 							'config'     => array(
 								'type'        => 'object',
@@ -150,7 +150,7 @@ class AgentAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'createAgent' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can_manage() || PermissionHelper::can( 'create_own_agent' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -451,6 +451,63 @@ class AgentAbilities {
 			$name = $slug;
 		}
 
+		// Self-service creation: non-admins can only create agents for themselves.
+		$is_admin = PermissionHelper::can_manage();
+
+		if ( ! $is_admin ) {
+			// Force owner to the acting user — non-admins cannot create agents for others.
+			$owner_id = PermissionHelper::acting_user_id();
+
+			if ( $owner_id <= 0 ) {
+				return array(
+					'success' => false,
+					'error'   => 'Could not determine acting user for self-service agent creation.',
+				);
+			}
+
+			// Enforce per-user agent limit for non-admins.
+			$agents_repo = new Agents();
+			$existing    = $agents_repo->get_by_owner_id( $owner_id );
+
+			/**
+			 * Filter the maximum number of agents a non-admin user can create.
+			 *
+			 * @since 0.52.0
+			 *
+			 * @param int $limit    Maximum agents per user. Default 1.
+			 * @param int $owner_id The user creating the agent.
+			 */
+			$max_agents = (int) apply_filters( 'datamachine_max_agents_per_user', 1, $owner_id );
+
+			if ( $existing && $max_agents <= 1 ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf(
+						'You already have an agent ("%s"). Non-admin users are limited to %d agent.',
+						$existing['agent_name'],
+						$max_agents
+					),
+				);
+			}
+
+			// For limits > 1, count all agents owned by this user.
+			if ( $max_agents > 1 ) {
+				$all_agents = $agents_repo->get_all();
+				$owned      = array_filter( $all_agents, fn( $a ) => (int) $a['owner_id'] === $owner_id );
+
+				if ( count( $owned ) >= $max_agents ) {
+					return array(
+						'success' => false,
+						'error'   => sprintf(
+							'You already have %d agent(s). Non-admin users are limited to %d.',
+							count( $owned ),
+							$max_agents
+						),
+					);
+				}
+			}
+		}
+
 		if ( $owner_id <= 0 ) {
 			return array(
 				'success' => false,
@@ -466,7 +523,7 @@ class AgentAbilities {
 			);
 		}
 
-		$agents_repo = new Agents();
+		$agents_repo = isset( $agents_repo ) ? $agents_repo : new Agents();
 
 		// Check for conflict.
 		$existing = $agents_repo->get_by_slug( $slug );

--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -28,12 +28,13 @@ class PermissionHelper {
 	 * @var array<string, string>
 	 */
 	private const CAPABILITY_MAP = array(
-		'manage_agents'   => 'datamachine_manage_agents',
-		'manage_flows'    => 'datamachine_manage_flows',
-		'manage_settings' => 'datamachine_manage_settings',
-		'chat'            => 'datamachine_chat',
-		'use_tools'       => 'datamachine_use_tools',
-		'view_logs'       => 'datamachine_view_logs',
+		'manage_agents'    => 'datamachine_manage_agents',
+		'manage_flows'     => 'datamachine_manage_flows',
+		'manage_settings'  => 'datamachine_manage_settings',
+		'chat'             => 'datamachine_chat',
+		'use_tools'        => 'datamachine_use_tools',
+		'view_logs'        => 'datamachine_view_logs',
+		'create_own_agent' => 'datamachine_create_own_agent',
 	);
 
 	/**

--- a/inc/Api/Agents.php
+++ b/inc/Api/Agents.php
@@ -54,7 +54,9 @@ class Agents {
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( self::class, 'handle_create' ),
-					'permission_callback' => $manage_permission,
+					'permission_callback' => function () {
+						return PermissionHelper::can( 'manage_agents' ) || PermissionHelper::can( 'create_own_agent' );
+					},
 					'args'                => array(
 						'agent_slug' => array(
 							'type'              => 'string',


### PR DESCRIPTION
## Summary

- Adds `datamachine_create_own_agent` capability so non-admin users can create their own AI agent
- Non-admins are constrained: self-only ownership, 1 agent per user (configurable)
- Foundational unlock for artist agents, mobile app agents, and any future user-scoped AI features

## Context

The full permission infrastructure was shipped in v0.37.0 (#597, #600, #601, #602):
- 6 granular capabilities on 4 roles
- Agent bearer tokens with capability ceilings
- Scoped queries, agent access table, ownership checks

What was missing: non-admin users couldn't **create** an agent. This PR adds that last primitive.

## Changes

### `data-machine.php`
- Register `datamachine_create_own_agent` on Subscriber, Author, Editor, Administrator roles
- Add to removal function for clean deactivation

### `inc/Abilities/PermissionHelper.php`
- Add `create_own_agent` → `datamachine_create_own_agent` to capability map

### `inc/Abilities/AgentAbilities.php`
- `datamachine/create-agent` permission callback: allow `create_own_agent` OR `can_manage()`
- `createAgent()` enforces two constraints for non-admins:
  1. **Self-only**: `owner_id` is forced to `PermissionHelper::acting_user_id()` — cannot create agents for other users
  2. **Per-user limit**: default 1 agent per non-admin user, configurable via `datamachine_max_agents_per_user` filter

### `inc/Api/Agents.php`
- REST `POST /agents` permission callback updated to match ability

## Capability map after this PR

| Role | Capabilities |
|---|---|
| Administrator | manage_settings, manage_agents, manage_flows, chat, use_tools, view_logs, **create_own_agent** |
| Editor | chat, use_tools, view_logs, **create_own_agent** |
| Author | chat, use_tools, **create_own_agent** |
| Subscriber | chat, **create_own_agent** |

## Testing

- Lint: passes (no change from baseline)
- Agent tests: 75 pass, 38 fail — identical to main (all pre-existing)

## Related

- #919 — Scoped agent creation (parent issue)
- #597 (closed) — Multi-agent architecture
- #600 (closed) — Custom capabilities
- [extrachill-artist-platform#17](https://github.com/Extra-Chill/extrachill-artist-platform/issues/17) — Artist Agent Manager (future consumer)