### PR TITLE
feat: Multi-modal chat messages — image attachments and media in tool responses

### DIFF
--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -93,6 +93,21 @@ class Chat {
 						'description'       => __( 'Currently selected pipeline ID for context', 'data-machine' ),
 						'sanitize_callback' => 'absint',
 					),
+					'attachments'          => array(
+						'type'              => 'array',
+						'required'          => false,
+						'description'       => __( 'Media attachments for multi-modal messages. Each item: {url, media_id, mime_type, filename}.', 'data-machine' ),
+						'items'             => array(
+							'type'       => 'object',
+							'properties' => array(
+								'url'       => array( 'type' => 'string' ),
+								'media_id'  => array( 'type' => 'integer' ),
+								'mime_type' => array( 'type' => 'string' ),
+								'filename'  => array( 'type' => 'string' ),
+							),
+						),
+						'sanitize_callback' => array( self::class, 'sanitize_attachments' ),
+					),
 				),
 			)
 		);
@@ -547,6 +562,14 @@ class Chat {
 			);
 		}
 
+		// --- Resolve attachments ---
+		$attachments = $request->get_param( 'attachments' );
+		if ( ! empty( $attachments ) && is_array( $attachments ) ) {
+			$attachments = self::resolve_attachment_paths( $attachments );
+		} else {
+			$attachments = array();
+		}
+
 		// --- Delegate to orchestrator ---
 		$result = ChatOrchestrator::processChat(
 			$message,
@@ -558,6 +581,7 @@ class Chat {
 				'selected_pipeline_id' => (int) $request->get_param( 'selected_pipeline_id' ),
 				'request_id'           => $request_id,
 				'agent_id'             => $agent_id,
+				'attachments'          => $attachments,
 			)
 		);
 
@@ -602,5 +626,109 @@ class Chat {
 				'data'    => $result,
 			)
 		);
+	}
+
+	/**
+	 * Sanitize attachments array from REST request.
+	 *
+	 * @since 0.53.0
+	 *
+	 * @param array $attachments Raw attachments from request.
+	 * @return array Sanitized attachments.
+	 */
+	public static function sanitize_attachments( $attachments ): array {
+		if ( ! is_array( $attachments ) ) {
+			return array();
+		}
+
+		$sanitized = array();
+
+		foreach ( $attachments as $attachment ) {
+			if ( ! is_array( $attachment ) ) {
+				continue;
+			}
+
+			$item = array();
+
+			if ( ! empty( $attachment['url'] ) ) {
+				$item['url'] = esc_url_raw( $attachment['url'] );
+			}
+
+			if ( ! empty( $attachment['media_id'] ) ) {
+				$item['media_id'] = absint( $attachment['media_id'] );
+			}
+
+			if ( ! empty( $attachment['mime_type'] ) ) {
+				$item['mime_type'] = sanitize_mime_type( $attachment['mime_type'] );
+			}
+
+			if ( ! empty( $attachment['filename'] ) ) {
+				$item['filename'] = sanitize_file_name( $attachment['filename'] );
+			}
+
+			// Must have at least a URL or media_id.
+			if ( ! empty( $item['url'] ) || ! empty( $item['media_id'] ) ) {
+				$sanitized[] = $item;
+			}
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Resolve attachment file paths from URLs or media IDs.
+	 *
+	 * Converts REST attachment metadata into the format expected by
+	 * ConversationManager::buildMultiModalContent() — adding file_path
+	 * when possible for providers that support direct file upload.
+	 *
+	 * @since 0.53.0
+	 *
+	 * @param array $attachments Sanitized attachments array.
+	 * @return array Attachments with file_path resolved where possible.
+	 */
+	private static function resolve_attachment_paths( array $attachments ): array {
+		$resolved = array();
+
+		foreach ( $attachments as $attachment ) {
+			$item = $attachment;
+
+			// Resolve media_id to file path and URL.
+			if ( ! empty( $attachment['media_id'] ) ) {
+				$media_id  = (int) $attachment['media_id'];
+				$file_path = get_attached_file( $media_id );
+
+				if ( $file_path && file_exists( $file_path ) ) {
+					$item['file_path'] = $file_path;
+				}
+
+				if ( empty( $item['url'] ) ) {
+					$item['url'] = wp_get_attachment_url( $media_id );
+				}
+
+				if ( empty( $item['mime_type'] ) ) {
+					$item['mime_type'] = get_post_mime_type( $media_id );
+				}
+			}
+
+			// Resolve URL to local file path if it's a local upload.
+			if ( empty( $item['file_path'] ) && ! empty( $item['url'] ) ) {
+				$upload_dir = wp_get_upload_dir();
+				$upload_url = $upload_dir['baseurl'];
+
+				if ( strpos( $item['url'], $upload_url ) === 0 ) {
+					$relative_path = str_replace( $upload_url, '', $item['url'] );
+					$local_path    = $upload_dir['basedir'] . $relative_path;
+
+					if ( file_exists( $local_path ) ) {
+						$item['file_path'] = $local_path;
+					}
+				}
+			}
+
+			$resolved[] = $item;
+		}
+
+		return $resolved;
 	}
 }

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -118,8 +118,16 @@ class ChatOrchestrator {
 			}
 		}
 
-		// --- Persist user message immediately (survives navigation away) ---
-		$messages[] = ConversationManager::buildConversationMessage( 'user', $message, array( 'type' => 'text' ) );
+		// --- Build user message (text or multi-modal with attachments) ---
+		$attachments = $options['attachments'] ?? array();
+
+		if ( ! empty( $attachments ) ) {
+			$content    = ConversationManager::buildMultiModalContent( $message, $attachments );
+			$metadata   = array( 'type' => 'multimodal', 'attachments' => $attachments );
+			$messages[] = ConversationManager::buildConversationMessage( 'user', $content, $metadata );
+		} else {
+			$messages[] = ConversationManager::buildConversationMessage( 'user', $message, array( 'type' => 'text' ) );
+		}
 
 		$chat_db->update_session(
 			$session_id,

--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -18,17 +18,95 @@ class ConversationManager {
 	/**
 	 * Build standardized conversation message structure.
 	 *
-	 * @param string $role Role identifier (user, assistant, system)
-	 * @param string $content Message content
-	 * @param array  $metadata Optional metadata for the message (e.g., type, tool_data)
-	 * @return array Message array with role, content, and metadata
+	 * Content can be a plain string (text-only messages) or an array of content
+	 * blocks for multi-modal messages (text + images). When an array is provided,
+	 * each element should follow the content block format expected by AI providers:
+	 *
+	 *     [
+	 *         ['type' => 'text', 'text' => 'Describe this image'],
+	 *         ['type' => 'file', 'file_path' => '/path/to/image.jpg', 'mime_type' => 'image/jpeg'],
+	 *     ]
+	 *
+	 * The ai-http-client provider layer (Anthropic, OpenAI, Gemini, OpenRouter)
+	 * already handles array content via process_multimodal_messages().
+	 *
+	 * @since 0.2.1
+	 * @since 0.53.0 Accepts array content for multi-modal messages.
+	 *
+	 * @param string       $role     Role identifier (user, assistant, system).
+	 * @param string|array $content  Message content — string for text, array for multi-modal content blocks.
+	 * @param array        $metadata Optional metadata for the message (e.g., type, tool_data, attachments).
+	 * @return array Message array with role, content, and metadata.
 	 */
-	public static function buildConversationMessage( string $role, string $content, array $metadata = array() ): array {
+	public static function buildConversationMessage( string $role, $content, array $metadata = array() ): array {
 		return array(
 			'role'     => $role,
 			'content'  => $content,
 			'metadata' => array_merge( array( 'timestamp' => gmdate( 'c' ) ), $metadata ),
 		);
+	}
+
+	/**
+	 * Build multi-modal content blocks from text and attachments.
+	 *
+	 * Takes a text message and an array of attachment metadata, and produces
+	 * the content block array format expected by AI providers.
+	 *
+	 * @since 0.53.0
+	 *
+	 * @param string $text        The text portion of the message.
+	 * @param array  $attachments Array of attachment metadata, each with:
+	 *                            - url (string)        Required. Public URL of the media.
+	 *                            - file_path (string)   Optional. Local filesystem path (preferred for Anthropic file uploads).
+	 *                            - mime_type (string)   Optional. MIME type (auto-detected from URL if omitted).
+	 *                            - type (string)        Optional. 'image', 'video', or 'file'. Auto-detected from mime_type.
+	 *                            - media_id (int)       Optional. WordPress attachment ID.
+	 *                            - filename (string)    Optional. Original filename.
+	 * @return array Content blocks array suitable for buildConversationMessage().
+	 */
+	public static function buildMultiModalContent( string $text, array $attachments ): array {
+		$content_blocks = array();
+
+		// Text block first.
+		if ( '' !== $text ) {
+			$content_blocks[] = array(
+				'type' => 'text',
+				'text' => $text,
+			);
+		}
+
+		foreach ( $attachments as $attachment ) {
+			$url       = $attachment['url'] ?? '';
+			$file_path = $attachment['file_path'] ?? '';
+			$mime_type = $attachment['mime_type'] ?? '';
+
+			// Skip empty attachments.
+			if ( empty( $url ) && empty( $file_path ) ) {
+				continue;
+			}
+
+			// Auto-detect MIME type from file path if available.
+			if ( empty( $mime_type ) && ! empty( $file_path ) && file_exists( $file_path ) ) {
+				$mime_type = mime_content_type( $file_path );
+			}
+
+			// Prefer local file path for providers that support direct file upload (Anthropic).
+			if ( ! empty( $file_path ) && file_exists( $file_path ) ) {
+				$content_blocks[] = array(
+					'type'      => 'file',
+					'file_path' => $file_path,
+					'mime_type' => $mime_type,
+				);
+			} elseif ( ! empty( $url ) ) {
+				// Fall back to URL-based image reference.
+				$content_blocks[] = array(
+					'type'      => 'image_url',
+					'image_url' => array( 'url' => $url ),
+				);
+			}
+		}
+
+		return $content_blocks;
 	}
 
 	/**
@@ -94,6 +172,13 @@ class ConversationManager {
 			if ( ! $is_handler_tool ) {
 				$content .= "\n\n" . wp_json_encode( $tool_result['data'] );
 			}
+		}
+
+		// Propagate media attachments from tool results to message metadata.
+		// Tools can include a 'media' array in their result to signal renderable
+		// media (images, videos) that the frontend should display inline.
+		if ( ! empty( $tool_result['media'] ) ) {
+			$metadata['media'] = $tool_result['media'];
 		}
 
 		if ( isset( $tool_result['error'] ) ) {
@@ -337,5 +422,46 @@ class ConversationManager {
 		);
 
 		return self::formatToolResultMessage( $tool_name, $tool_result, array(), false, $turn_count );
+	}
+
+	/**
+	 * Build a standard media entry for tool results.
+	 *
+	 * Tools that produce media (images, videos) should include a 'media'
+	 * array in their result using this format. The frontend detects media
+	 * entries in tool result metadata and renders them inline.
+	 *
+	 * Usage in a tool:
+	 *
+	 *     return [
+	 *         'success' => true,
+	 *         'media'   => [
+	 *             ConversationManager::buildMediaEntry( 'image', $url, $alt_text ),
+	 *         ],
+	 *     ];
+	 *
+	 * @since 0.53.0
+	 *
+	 * @param string $type     Media type: 'image', 'video', or 'file'.
+	 * @param string $url      Public URL of the media.
+	 * @param string $alt      Alt text or description.
+	 * @param int    $media_id Optional WordPress attachment ID.
+	 * @return array Standard media entry.
+	 */
+	public static function buildMediaEntry( string $type, string $url, string $alt = '', int $media_id = 0 ): array {
+		$entry = array(
+			'type' => $type,
+			'url'  => $url,
+		);
+
+		if ( '' !== $alt ) {
+			$entry['alt'] = $alt;
+		}
+
+		if ( $media_id > 0 ) {
+			$entry['media_id'] = $media_id;
+		}
+
+		return $entry;
 	}
 }


### PR DESCRIPTION
## Summary

- Chat REST endpoint now accepts **image attachments** alongside text messages
- **ConversationManager** supports `string|array` content for multi-modal AI provider messages
- Tool results can include **renderable media** via standard `media` key in metadata
- **Zero schema changes** — backward compatible, text-only messages work unchanged

## How it works

### Sending images

```
POST /datamachine/v1/chat
{
    "message": "What's in this image?",
    "attachments": [
        { "media_id": 1234 },
        { "url": "https://example.com/photo.jpg", "mime_type": "image/jpeg" }
    ]
}
```

The backend resolves `media_id` to file paths, detects local uploads, and builds multi-modal content blocks:

```php
// What gets sent to the AI provider:
'content' => [
    ['type' => 'text', 'text' => "What's in this image?"],
    ['type' => 'file', 'file_path' => '/path/to/image.jpg', 'mime_type' => 'image/jpeg'],
]
```

The ai-http-client's existing `process_multimodal_messages()` in all four providers (Anthropic, OpenAI, Gemini, OpenRouter) handles it from there.

### Tool result media

Tools can include a `media` array in their results:

```php
return [
    'success' => true,
    'media'   => [
        ConversationManager::buildMediaEntry('image', $url, 'Generated landscape'),
    ],
];
```

This propagates to message metadata where the frontend can detect and render it inline.

## Changes

### `inc/Engine/AI/ConversationManager.php` (+136 lines)
- `buildConversationMessage()` — accepts `string|array` content (was string-only)
- `buildMultiModalContent()` — **new** — builds content block arrays from text + attachments
- `buildMediaEntry()` — **new** — standard media entry format for tool results
- `formatToolResultMessage()` — propagates `media` key from tool results to metadata

### `inc/Api/Chat/Chat.php` (+128 lines)
- `attachments` parameter added to `POST /chat` endpoint (array of objects)
- `sanitize_attachments()` — **new** — validates URL, media_id, mime_type, filename
- `resolve_attachment_paths()` — **new** — converts media_id → file_path, resolves local upload URLs

### `inc/Api/Chat/ChatOrchestrator.php` (+12/-1 lines)
- `processChat()` — detects `options['attachments']`, builds multi-modal content, stores in metadata

## Why no schema changes

The `datamachine_chat_sessions.messages` column is `LONGTEXT` storing JSON. Multi-modal content arrays and attachment metadata in messages serialize cleanly. Existing text-only messages deserialize unchanged.

## Testing

- Lint: passes (no change from baseline)
- Chat tests: 2 pass, 12 fail — identical to main (all pre-existing)

## Related

- #922 — Chat media support (parent issue)
- [Extra-Chill/chat#6](https://github.com/Extra-Chill/chat/issues/6) — @extrachill/chat package media support (frontend)
- [Extra-Chill/extrachill-chat#3](https://github.com/Extra-Chill/extrachill-chat/issues/3) — Chat plugin block media support