### PR TITLE
feat: Ability-linked tool permissions — permission-aware resolution via Abilities API

### DIFF
--- a/inc/Engine/AI/Tools/BaseTool.php
+++ b/inc/Engine/AI/Tools/BaseTool.php
@@ -29,6 +29,11 @@ abstract class BaseTool {
 	 * must declare its contexts — the surfaces where it's available (e.g.
 	 * 'chat', 'pipeline').
 	 *
+	 * Tools should also declare which ability they wrap via the `ability` key
+	 * (or `abilities` for composed tools). The ToolPolicyResolver uses this to
+	 * check the ability's permission_callback before offering the tool to AI agents.
+	 * Tools without an ability declaration default to admin-only access.
+	 *
 	 * When the definition is a callable (for lazy evaluation), the contexts
 	 * are stored alongside so they're available before the callable is resolved.
 	 * The ToolManager merges contexts into the resolved definition.
@@ -37,14 +42,23 @@ abstract class BaseTool {
 	 * calling the method directly. This enables lazy evaluation after translations
 	 * are loaded, preventing WordPress 6.7+ translation timing errors.
 	 *
+	 * @since 0.14.10
+	 * @since 0.54.0 Added ability, abilities, and access_level metadata for permission-aware resolution.
+	 *
 	 * @param string         $toolName       Tool identifier.
 	 * @param array|callable $toolDefinition Tool definition array OR callable that returns it.
 	 * @param array          $contexts       Contexts where this tool is available (e.g. ['chat', 'pipeline']).
+	 * @param array          $meta           Optional metadata for permission resolution. {
+	 *     @type string   $ability      Single ability slug this tool wraps (e.g. 'datamachine/local-search').
+	 *     @type string[] $abilities    Multiple ability slugs for composed tools. ALL must pass permission check.
+	 *     @type string   $access_level Fallback for tools without a linked ability.
+	 *                                  One of: 'authenticated', 'author', 'editor', 'admin'. Default: 'admin'.
+	 * }
 	 */
-	protected function registerTool( string $toolName, array|callable $toolDefinition, array $contexts = array() ): void {
+	protected function registerTool( string $toolName, array|callable $toolDefinition, array $contexts = array(), array $meta = array() ): void {
 		add_filter(
 			'datamachine_tools',
-			function ( $tools ) use ( $toolName, $toolDefinition, $contexts ) {
+			function ( $tools ) use ( $toolName, $toolDefinition, $contexts, $meta ) {
 				if ( is_callable( $toolDefinition ) ) {
 					// Wrap callable with contexts for pre-resolution filtering.
 					$tools[ $toolName ] = array(
@@ -56,6 +70,18 @@ abstract class BaseTool {
 					$toolDefinition['contexts'] = $contexts;
 					$tools[ $toolName ]         = $toolDefinition;
 				}
+
+				// Merge permission metadata into the tool entry.
+				if ( ! empty( $meta['ability'] ) ) {
+					$tools[ $toolName ]['ability'] = $meta['ability'];
+				}
+				if ( ! empty( $meta['abilities'] ) ) {
+					$tools[ $toolName ]['abilities'] = $meta['abilities'];
+				}
+				if ( ! empty( $meta['access_level'] ) ) {
+					$tools[ $toolName ]['access_level'] = $meta['access_level'];
+				}
+
 				return $tools;
 			}
 		);

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -22,6 +22,7 @@
 namespace DataMachine\Engine\AI\Tools;
 
 use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Abilities\PermissionHelper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -68,36 +69,150 @@ class ToolPolicyResolver {
 	 * }
 	 * @return array Resolved tools array keyed by tool name.
 	 */
+	/**
+	 * Valid access levels for tools without a linked ability, ordered from
+	 * least to most privileged. Used by filterByAccessLevel().
+	 *
+	 * @since 0.54.0
+	 */
+	private const ACCESS_LEVELS = array(
+		'authenticated' => 'datamachine_chat',
+		'author'        => 'datamachine_use_tools',
+		'editor'        => 'datamachine_view_logs',
+		'admin'         => 'datamachine_manage_settings',
+	);
+
 	public function resolve( array $context ): array {
 		// Accept 'context' key, fall back to deprecated 'surface' key.
 		$context_type = $context['context'] ?? $context['surface'] ?? self::CONTEXT_PIPELINE;
 		$deny         = $context['deny'] ?? array();
 		$agent_id     = isset( $context['agent_id'] ) ? (int) $context['agent_id'] : 0;
 
+		// 0. Baseline gate: if the acting user lacks datamachine_use_tools, return no tools.
+		//    Pipeline and system contexts bypass this (they run as admin/cron).
+		if ( self::CONTEXT_CHAT === $context_type && ! PermissionHelper::can( 'use_tools' ) ) {
+			return array();
+		}
+
 		// 1. Gather tools based on context preset.
 		$tools = $this->gatherByContext( $context_type, $context );
 
-		// 2. Apply per-agent tool policy (from agent_config).
+		// 2. Filter by linked ability permissions (from Abilities API).
+		//    Only applies in chat context — pipeline/system run as admin.
+		if ( self::CONTEXT_CHAT === $context_type ) {
+			$tools = $this->filterByAbilityPermissions( $tools );
+		}
+
+		// 3. Apply per-agent tool policy (from agent_config).
 		if ( $agent_id > 0 ) {
 			$agent_policy = $this->getAgentToolPolicy( $agent_id );
 			$tools        = $this->applyAgentPolicy( $tools, $agent_policy );
 		}
 
-		// 3. Apply allowlist if specified (narrows to explicit subset).
+		// 4. Apply allowlist if specified (narrows to explicit subset).
 		$allow_only = $context['allow_only'] ?? array();
 		if ( ! empty( $allow_only ) ) {
 			$tools = array_intersect_key( $tools, array_flip( $allow_only ) );
 		}
 
-		// 4. Apply deny list (always wins).
+		// 5. Apply deny list (always wins).
 		if ( ! empty( $deny ) ) {
 			$tools = array_diff_key( $tools, array_flip( $deny ) );
 		}
 
-		// 5. Allow external filtering of resolved tools.
+		// 6. Allow external filtering of resolved tools.
 		$tools = apply_filters( 'datamachine_resolved_tools', $tools, $context_type, $context );
 
 		return $tools;
+	}
+
+	/**
+	 * Filter tools by their linked ability permissions.
+	 *
+	 * For each tool that declares an `ability` or `abilities` key, checks
+	 * the ability's permission_callback via WP_Abilities_Registry. If ANY
+	 * linked ability fails the permission check, the tool is removed.
+	 *
+	 * Tools without a linked ability fall back to their `access_level` field.
+	 * Tools with neither default to 'admin' (safe fallback — untagged tools
+	 * are admin-only until explicitly categorized).
+	 *
+	 * @since 0.54.0
+	 *
+	 * @param array $tools Resolved tools array keyed by tool name.
+	 * @return array Filtered tools.
+	 */
+	private function filterByAbilityPermissions( array $tools ): array {
+		$registry = function_exists( 'WP_Abilities_Registry' )
+			? null
+			: ( class_exists( 'WP_Abilities_Registry' ) ? \WP_Abilities_Registry::get_instance() : null );
+
+		$filtered = array();
+
+		foreach ( $tools as $name => $tool ) {
+			if ( ! is_array( $tool ) ) {
+				continue;
+			}
+
+			// Collect all ability slugs to check.
+			$ability_slugs = array();
+
+			if ( ! empty( $tool['ability'] ) ) {
+				$ability_slugs[] = $tool['ability'];
+			}
+
+			if ( ! empty( $tool['abilities'] ) && is_array( $tool['abilities'] ) ) {
+				$ability_slugs = array_merge( $ability_slugs, $tool['abilities'] );
+			}
+
+			// Tools with linked abilities: check each ability's permission.
+			if ( ! empty( $ability_slugs ) && $registry ) {
+				$permitted = true;
+
+				foreach ( $ability_slugs as $slug ) {
+					$ability = $registry->get_registered( $slug );
+
+					if ( ! $ability ) {
+						// Ability not registered — deny (safe default).
+						$permitted = false;
+						break;
+					}
+
+					if ( ! $ability->check_permissions() ) {
+						$permitted = false;
+						break;
+					}
+				}
+
+				if ( $permitted ) {
+					$filtered[ $name ] = $tool;
+				}
+
+				continue;
+			}
+
+			// No linked ability — fall back to access_level.
+			$access_level = $tool['access_level'] ?? 'admin';
+
+			if ( $this->checkAccessLevel( $access_level ) ) {
+				$filtered[ $name ] = $tool;
+			}
+		}
+
+		return $filtered;
+	}
+
+	/**
+	 * Check if the current user meets an access level requirement.
+	 *
+	 * @since 0.54.0
+	 *
+	 * @param string $access_level One of: 'authenticated', 'author', 'editor', 'admin'.
+	 * @return bool Whether the current user has sufficient capabilities.
+	 */
+	private function checkAccessLevel( string $access_level ): bool {
+		$required_cap = self::ACCESS_LEVELS[ $access_level ] ?? self::ACCESS_LEVELS['admin'];
+		return current_user_can( $required_cap );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Tools can now declare which **ability** they wrap via `ability` / `abilities` metadata
- `ToolPolicyResolver` checks the ability's `permission_callback` before offering tools to AI agents
- `datamachine_use_tools` enforced as baseline gate — subscribers get zero tools in chat
- Unlinked tools (no ability declared) default to **admin-only** — safe until tagged

## How it works

```
Tool registration:
    $this->registerTool('local_search', $def, ['chat'], [
        'ability' => 'datamachine/local-search',
    ]);

Resolution (ToolPolicyResolver::resolve):
    1. Baseline: user has datamachine_use_tools? No → zero tools
    2. For each tool with ability/abilities:
       → WP_Abilities_Registry->get_registered($slug)->check_permissions()
       → Denied? Tool removed from set
    3. For tools without ability: check access_level (default: 'admin')
    4. Per-agent policy (existing)
    5. Allow/deny lists (existing)
```

The permission check flows from the Abilities API — no duplicated permission logic. When an ability's `permission_callback` changes, tool access changes automatically.

## Changes

### `inc/Engine/AI/Tools/BaseTool.php` (+30 lines)
- `registerTool()` accepts new `$meta` parameter (4th arg, backward compatible)
- Supported meta keys: `ability` (string), `abilities` (string[]), `access_level` (string)
- Metadata merged into tool entry alongside contexts

### `inc/Engine/AI/Tools/ToolPolicyResolver.php` (+123 lines)
- **Baseline gate**: `datamachine_use_tools` checked for chat context at top of `resolve()`
- **`filterByAbilityPermissions()`**: new method, checks each tool's linked ability via `WP_Abilities_Registry::check_permissions()`
- **`checkAccessLevel()`**: new method, maps access_level strings to WordPress capabilities
- **`ACCESS_LEVELS` constant**: maps tiers to capabilities (authenticated → chat, author → use_tools, editor → view_logs, admin → manage_settings)
- Pipeline and system contexts bypass permission checks (they run as admin/cron)

## What happens now (Phase 1)

No tools are tagged yet, so all 83 chat tools fall through to the `admin` default for `access_level`. This means:

- **Admins**: All 83 tools (unchanged behavior)
- **Everyone else**: Zero tools in chat (baseline gate + admin default)

This is **safe by design** — we've closed the gap where non-admin agents got all tools. Phase 2 (tagging each tool with its ability) will progressively open tools to lower permission tiers.

## What Phase 2 looks like

```php
// In each tool class, add the ability slug:
$this->registerTool('local_search', [$this, 'getToolDefinition'], ['chat'], [
    'ability' => 'datamachine/local-search',
]);

// For composed tools:
$this->registerTool('execute_workflow', [$this, 'getToolDefinition'], ['chat'], [
    'abilities' => ['datamachine/create-pipeline', 'datamachine/create-flow', 'datamachine/run-flow'],
]);

// For tools without an ability (external APIs):
$this->registerTool('web_fetch', [$this, 'getToolDefinition'], ['chat'], [
    'access_level' => 'authenticated',
]);
```

## Testing

- Lint: passes
- Tool tests: 84 pass, 41 fail — **10 fewer failures** than main (51 fail on main)

## Related

- #924 — Parent architecture issue
- #919 — Scoped agent creation
- [Extra-Chill/homeboy#903](https://github.com/Extra-Chill/homeboy/issues/903) — Homeboy audit + refactor support for wrapper-to-implementation inference