### PR TITLE
ci: drop cron schedule — push to main covers release

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-  schedule:
-    - cron: '*/15 * * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Remove `schedule: '*/15 * * * *'` cron trigger from CI workflow
- Push to main already triggers the release pipeline via homeboy-action
- Branch protection ensures all merges go through PRs → push event fires on merge

## Impact

- Eliminates **96 unnecessary CI runs per day**
- Reduces GitHub Actions queue contention (PR checks no longer compete with cron runs)
- Zero behavior change — releases still trigger on push to main and tag pushes