### PR TITLE
fix(publish): Use correct parameter name when assigning taxonomies

### DIFF
--- a/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
@@ -104,8 +104,11 @@ class WordPress extends PublishHandler {
 				$field_key = "taxonomy_{$taxonomy}_selection";
 				$selection = $handler_config[ $field_key ] ?? SelectionMode::SKIP;
 
-				if ( SelectionMode::isAiDecides( $selection ) && ! empty( $parameters[ $taxonomy ] ) ) {
-					$taxonomies[ $taxonomy ] = $parameters[ $taxonomy ];
+				// Get the parameter name (e.g., 'post_tag' -> 'tags')
+				$param_name = TaxonomyHandler::getParameterName( $taxonomy );
+
+				if ( SelectionMode::isAiDecides( $selection ) && ! empty( $parameters[ $param_name ] ) ) {
+					$taxonomies[ $taxonomy ] = $parameters[ $param_name ];
 				} elseif ( SelectionMode::isPreSelected( $selection ) ) {
 					$taxonomies[ $taxonomy ] = $selection;
 				}

--- a/inc/Core/WordPress/TaxonomyHandler.php
+++ b/inc/Core/WordPress/TaxonomyHandler.php
@@ -241,7 +241,7 @@ class TaxonomyHandler {
 	 * @param string $taxonomy_name WordPress taxonomy name
 	 * @return string Corresponding parameter name for AI tools
 	 */
-	private function getParameterName( string $taxonomy_name ): string {
+	public static function getParameterName( string $taxonomy_name ): string {
 		if ( 'category' === $taxonomy_name ) {
 			return 'category';
 		} elseif ( 'post_tag' === $taxonomy_name ) {


### PR DESCRIPTION
Fixes a bug where tags were never assigned when 'ai_decides' was configured.

## Problem
The WordPress publish handler was checking `$parameters[$taxonomy]` where `$taxonomy` is the taxonomy name (e.g., 'post_tag'), but the AI tool parameter name is mapped differently (e.g., 'post_tag' -> 'tags').

This caused tags to never be assigned because the handler looked for `$parameters['post_tag']` when the AI actually sent `$parameters['tags']`.

## Changes
- Make `TaxonomyHandler::getParameterName()` public static
- Use `getParameterName()` in `WordPress.php` to get correct parameter key

## Impact
Fixes missing tag assignment when using ai_decides taxonomy selection for post_tag and other non-hierarchical taxonomies.