### PR TITLE
docs: Align documentation with codebase reality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,29 +48,6 @@ This file provides a concise, present-tense technical reference for contributors
 - Ability execution: Each ability implements `execute_callback` with `permission_callback` (checks `manage_options` or WP_CLI)
 - REST API endpoints, CLI commands, and Chat tools delegate to abilities for business logic
 
-Build system
-
-- **Homeboy** is used for all build operations (versioning, packaging, deployment)
-- Homeboy provides full WordPress test environment for running tests (no local WordPress setup required)
-- Build command: `homeboy build data-machine` - runs tests, lints code, builds frontend, creates production ZIP
-- Test command: `homeboy test data-machine` - runs PHPUnit tests using homeboy's WordPress environment
-- Lint command: `homeboy lint data-machine` - runs PHP CodeSniffer with WordPress coding standards
-- Auto-fix: `homeboy lint data-machine --fix` - runs PHPCBF to auto-fix formatting issues before validating
-
-Testing
-
-- PHPUnit tests located in `tests/Unit/` directory
-- Tests use `WP_UnitTestCase` with homeboy's WordPress test environment
-- Run tests: `homeboy test data-machine` (uses homeboy's WordPress installation)
-- Run build: `homeboy build data-machine` (runs tests, lints code, builds frontend assets, creates production ZIP)
-
-Abilities API
-
-- WordPress 6.9 Abilities API provides standardized capability discovery and execution for all Data Machine operations
-- Ability classes in `inc/Abilities/`: PipelineAbilities, PipelineStepAbilities, FlowAbilities, FlowStepAbilities, JobAbilities, FileAbilities, ProcessedItemsAbilities, SettingsAbilities, AuthAbilities, LogAbilities, HandlerAbilities, StepTypeAbilities, PostQueryAbilities, LocalSearchAbilities
-- Category registration: `datamachine` category registered via `wp_register_ability_category()` on `wp_abilities_api_categories_init` hook
-- Ability execution: Each ability implements `execute_callback` with `permission_callback` (checks `manage_options` or WP_CLI)
-- REST API endpoints, CLI commands, and Chat tools delegate to abilities for business logic
 
 Engine & execution
 
@@ -118,6 +95,7 @@ Agent guidance (for automated editors)
 - Use present-tense language and remove references to deleted functionality or historical counts.
 - Do not modify source code when aligning documentation unless explicitly authorized.
 - Do not create new top-level documentation directories. Creating or updating `.md` files is allowed only within existing directories.
+- **Extension-based commands**: The `wp datamachine workspace` and `wp datamachine github` commands have been moved to the `data-machine-code` extension plugin. Core documentation should not reference these commands.
 
 Agent orchestration patterns
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ wp datamachine settings         # Plugin settings
 wp datamachine posts            # Query Data Machine-created posts
 wp datamachine logs             # Log operations
 wp datamachine memory           # Agent memory read/write
-wp datamachine workspace        # Workspace file operations
 wp datamachine handlers         # List registered handlers
 wp datamachine step-types       # List registered step types
 wp datamachine chat             # Chat agent interface
@@ -167,7 +166,6 @@ wp datamachine links            # Internal linking
 wp datamachine blocks           # Gutenberg block operations
 wp datamachine image            # Image generation
 wp datamachine meta-description # SEO meta descriptions
-wp datamachine github           # GitHub integration
 wp datamachine auth             # OAuth provider management
 wp datamachine taxonomy         # Taxonomy operations
 wp datamachine batch            # Batch operations

--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -55,22 +55,17 @@ Available to all AI agents (pipeline + chat + standalone) via `datamachine_globa
 - **Features**: Post type and category filtering, force rebuild option, internal/external/all scope for broken link checks, configurable result limits
 - **Use Cases**: SEO link auditing, orphaned content discovery, broken link detection
 
-**GitHub Tools** — multi-tool class (@since v0.33.0)
+**GitHub Tools** — multi-tool class (@since v0.24.0, **moved to data-machine-code extension**)
+- `create_github_issue` — Create a GitHub issue in a repository. Async — uses System Agent for execution.
 - `list_github_issues` — List issues from a GitHub repository with state, label, and pagination filters
 - `get_github_issue` — Get a single GitHub issue with full details including body, labels, and comments
 - `manage_github_issue` — Update, close, or comment on a GitHub issue
 - `list_github_pulls` — List pull requests from a repository with state filtering
 - `list_github_repos` — List GitHub repositories for a user or organization
 - **Configuration**: GitHub PAT required
-- **Use Cases**: Issue tracking, PR monitoring, repository discovery
-
-**GitHub Issue Creator** (`create_github_issue`) (@since v0.24.0)
-- **Purpose**: Create a GitHub issue in a repository. Async — uses System Agent for execution.
-- **Configuration**: GitHub PAT required
-- **Features**: Supports title, body (GitHub Markdown), labels, and repo selection from configured defaults
 - **Use Cases**: Bug reports, feature requests, task tracking from AI workflows
 
-**Workspace Tools** — multi-tool class (@since v0.37.0)
+**Workspace Tools** — multi-tool class (@since v0.37.0, **moved to data-machine-code extension**)
 - `workspace_path` — Get the Data Machine workspace path, optionally ensure it exists
 - `workspace_list` — List repositories currently present in the workspace
 - `workspace_show` — Show detailed repo info (branch, remote, latest commit, dirty count)
@@ -353,10 +348,10 @@ Global tools are located in `/inc/Engine/AI/Tools/Global/`:
 - `QueueValidator.php` - Flow queue duplicate validation before content generation
 - `WebFetch.php` - Web page content retrieval
 - `WordPressPostReader.php` - Single post analysis
-- `WorkspaceTools.php` - Workspace repository operations (list, show, read, browse — multi-tool)
+- `WorkspaceTools.php` - Workspace repository operations (**moved to data-machine-code extension**)
 
 Additional global tools outside the Global directory:
-- `GitHubIssueTool.php` (`/inc/Engine/AI/Tools/`) - GitHub issue creation (async, System Agent)
+- `GitHubIssueTool.php` (`/inc/Engine/AI/Tools/`) - GitHub issue creation (**moved to data-machine-code extension**)
 
 Analytics abilities are located in `/inc/Abilities/Analytics/`:
 - `GoogleSearchConsoleAbilities.php` - GSC API integration and JWT auth

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,13 +153,13 @@ GitHubIssueTask  MetaDescriptionTask
 
 ### Workspace System
 
-Secure file management outside the web root for agent operations:
+Secure file management outside the web root for agent operations. **Moved to data-machine-code extension.**
 
 - **Location**: `/var/lib/datamachine/workspace/` (or `DATAMACHINE_WORKSPACE_PATH`)
 - **Git-aware**: Clone, status, pull, add, commit, push, log, diff
 - **File ops**: Read (with pagination), write, edit (find-replace), list directory
 - **Security**: Outside web root; mutating ops are CLI-only (not REST-exposed)
-- **CLI**: `wp datamachine workspace {path,list,clone,remove,show,read,ls,write,edit,git}`
+- **CLI**: `wp datamachine-code workspace {path,list,clone,remove,show,read,ls,write,edit,git}`
 
 ### Engine Data Architecture
 
@@ -296,7 +296,7 @@ Data Machine v0.2.0 introduced a universal Engine layer (`/inc/Engine/AI/`) that
 **Tool Categories**:
 - Handler-specific tools for publish/update operations
 - Global tools for search and analysis (GoogleSearch, LocalSearch, WebFetch, WordPressPostReader)
-- Workspace-scoped tools (WorkspaceTools, WorkspaceScopedTools) for agent file operations
+- Workspace-scoped tools (WorkspaceTools, WorkspaceScopedTools) for agent file operations (**moved to data-machine-code extension**)
 - Agent memory tools (AgentMemory, AgentDailyMemory) for runtime memory access
 - Chat-only tools for workflow building (@since v0.4.3):
   - AddPipelineStep, ApiQuery, AuthenticateHandler, ConfigureFlowSteps, ConfigurePipelineStep, CopyFlow, CreateFlow, CreatePipeline, CreateTaxonomyTerm, ExecuteWorkflowTool, GetHandlerDefaults, ManageLogs, ReadLogs, RunFlow, SearchTaxonomyTerms, SetHandlerDefaults, UpdateFlow

--- a/docs/core-system/wordpress-as-agent-memory.md
+++ b/docs/core-system/wordpress-as-agent-memory.md
@@ -441,23 +441,24 @@ This makes WordPress the single source of truth for agent memory, regardless of 
 
 ### Reading Memory via WP-CLI
 
-Agents with shell access can use workspace commands for structured access:
+Agents with shell access can use the `agent` command for structured access:
 
 ```bash
 # Discover file paths (canonical command for external consumers)
 wp datamachine agent paths --allow-root
 
-# Read memory file via workspace
-wp datamachine workspace read MEMORY.md --allow-root
+# Read memory file
+wp datamachine agent files read SOUL.md --allow-root
+wp datamachine agent files read MEMORY.md --allow-root
 
 # List agent directory contents
-wp datamachine workspace ls agents/my-agent/ --allow-root
+wp datamachine agent files list --allow-root
 
 # Read daily memory
-wp datamachine memory daily read --date=2026-03-15 --allow-root
+wp datamachine agent daily read 2026-03-15 --allow-root
 
 # Search daily memory
-wp datamachine memory daily search --query="deployment" --allow-root
+wp datamachine agent daily search "deployment" --allow-root
 ```
 
 ### The Key Principle
@@ -638,18 +639,17 @@ wp datamachine agents create --slug=bot --name="My Bot" --allow-root
 wp datamachine agents rename old-slug new-slug --allow-root
 ```
 
-### Workspace Commands
+### Agent File Commands
 
 ```bash
-wp datamachine workspace path --allow-root
-wp datamachine workspace list --allow-root
-wp datamachine workspace read <file> --allow-root
-wp datamachine workspace ls <dir> --allow-root
-wp datamachine workspace write <file> --content="..." --allow-root
-wp datamachine workspace edit <file> --old="..." --new="..." --allow-root
-wp datamachine workspace clone <repo-url> --allow-root
-wp datamachine workspace git status --repo=<name> --allow-root
+wp datamachine agent paths --allow-root
+wp datamachine agent files list --allow-root
+wp datamachine agent files read <file> --allow-root
+wp datamachine agent files write <file> --content="..." --allow-root
+wp datamachine agent files edit <file> --old="..." --new="..." --allow-root
 ```
+
+> **Note:** For workspace/git operations, install the `data-machine-code` extension and use `wp datamachine-code workspace`.
 
 ## Extending the Memory System
 

--- a/docs/core-system/workspace-system.md
+++ b/docs/core-system/workspace-system.md
@@ -1,5 +1,7 @@
 # Workspace System
 
+> **Important:** The workspace system has been moved to the `data-machine-code` extension plugin as of v0.45.0. This documentation is preserved for reference. Install the extension to use workspace functionality.
+
 The workspace system provides a managed external directory where Data Machine agents can clone, read, write, and perform Git operations on repositories. Unlike agent memory files (which live inside `wp-content/uploads/`), workspace repos live **outside the web root** for security and to support build tooling that shouldn't be publicly accessible.
 
 ## Overview
@@ -11,7 +13,7 @@ The workspace system consists of:
 3. **WorkspaceAbilities** — WordPress 6.9 Abilities API (16 abilities)
 4. **WorkspaceTools / WorkspaceScopedTools** — AI chat tools for global and handler-scoped access
 5. **Fetch and Publish handlers** — pipeline integration for reading from and writing to workspace repos
-6. **CLI** — full `wp datamachine workspace` command set
+6. **CLI** — full `wp datamachine-code workspace` command set (in extension)
 
 ## Workspace Directory
 
@@ -164,7 +166,9 @@ Read-only abilities have `show_in_rest: true`. Mutating abilities have `show_in_
 
 ### Global Tools (WorkspaceTools)
 
-**Source:** `inc/Engine/AI/Tools/Global/WorkspaceTools.php`
+> **Note:** WorkspaceTools have been moved to the `data-machine-code` extension plugin.
+
+**Source:** `inc/Engine/AI/Tools/Global/WorkspaceTools.php` (in extension)
 **Tool ID:** Various (`workspace_path`, `workspace_list`, `workspace_show`, `workspace_ls`, `workspace_read`)
 **Contexts:** `chat`, `pipeline`, `standalone`
 

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -1,6 +1,8 @@
 # WP-CLI Commands
 
-Data Machine provides 25 WP-CLI command namespaces for managing pipelines, flows, jobs, agents, workspace, and more from the command line. All commands are registered under the `datamachine` namespace via `inc/Cli/Bootstrap.php`.
+Data Machine provides 23 WP-CLI command namespaces for managing pipelines, flows, jobs, agents, and more from the command line. All commands are registered under the `datamachine` namespace via `inc/Cli/Bootstrap.php`.
+
+> **Note:** The `wp datamachine workspace` and `wp datamachine github` commands have been moved to the `data-machine-code` extension plugin.
 
 ## Available Commands
 
@@ -249,56 +251,6 @@ wp datamachine agent paths
 wp datamachine agent paths --agent=my-agent --format=json
 ```
 
-**Options**: `--user`, `--agent`, `--format`, `--relative`
-
-### datamachine workspace
-
-Manage the agent workspace (cloned repositories). **Since**: 0.31.0
-
-```bash
-# Show workspace path
-wp datamachine workspace path
-wp datamachine workspace path --ensure  # create if missing
-
-# List repos
-wp datamachine workspace list
-
-# Clone a repository
-wp datamachine workspace clone https://github.com/user/repo.git
-wp datamachine workspace clone https://github.com/user/repo.git --name=my-repo
-
-# Show repo info (branch, remote, dirty status)
-wp datamachine workspace show my-repo
-
-# Read a file
-wp datamachine workspace read my-repo src/index.php
-wp datamachine workspace read my-repo src/index.php --offset=10 --limit=50
-
-# List directory contents
-wp datamachine workspace ls my-repo src/
-
-# Write a file
-wp datamachine workspace write my-repo src/config.php --content="<?php // config"
-echo "content" | wp datamachine workspace write my-repo src/file.txt
-
-# Edit a file (find and replace)
-wp datamachine workspace edit my-repo src/file.php --old="oldText" --new="newText"
-wp datamachine workspace edit my-repo src/file.php --old="oldText" --new="newText" --replace-all
-
-# Git operations
-wp datamachine workspace git status my-repo
-wp datamachine workspace git pull my-repo
-wp datamachine workspace git add my-repo --path=src/
-wp datamachine workspace git commit my-repo "commit message"
-wp datamachine workspace git push my-repo
-wp datamachine workspace git log my-repo --limit=10
-wp datamachine workspace git diff my-repo --staged
-
-# Remove a repo
-wp datamachine workspace remove my-repo --yes
-```
-
-### datamachine system
 
 System tasks and health checks. **Since**: 0.41.0
 
@@ -335,37 +287,6 @@ wp datamachine batch status 42
 
 # Cancel a running batch
 wp datamachine batch cancel 42
-```
-
-### datamachine github
-
-GitHub integration. **Since**: 0.33.0
-
-```bash
-# Check integration status
-wp datamachine github status
-
-# List issues
-wp datamachine github issues --repo=user/repo --state=open --labels=bug
-
-# View an issue
-wp datamachine github view 42 --repo=user/repo
-
-# Close an issue
-wp datamachine github close 42 --repo=user/repo --comment="Fixed in v1.2"
-
-# Comment on an issue
-wp datamachine github comment 42 "Working on this" --repo=user/repo
-
-# List pull requests
-wp datamachine github pulls --repo=user/repo --state=open
-
-# List repos for a user/org
-wp datamachine github repos Extra-Chill
-```
-
-**Options**: `--repo`, `--state`, `--labels`, `--assignee`, `--per_page`, `--page`, `--format`
-
 ### datamachine image
 
 Image generation and optimization. **Since**: 0.33.0
@@ -754,15 +675,3 @@ fi
 wp datamachine agent read
 wp datamachine agent write "## Status" "All systems operational"
 wp datamachine agent search "operational"
-```
-
-### Workspace git workflow
-
-```bash
-# Clone, edit, commit, push
-wp datamachine workspace clone https://github.com/user/repo.git
-wp datamachine workspace edit repo src/config.php --old="v1.0" --new="v1.1"
-wp datamachine workspace git add repo --path=src/config.php
-wp datamachine workspace git commit repo "bump version to 1.1"
-wp datamachine workspace git push repo
-```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -96,7 +96,7 @@ The Abilities API (DataMachine\Abilities) provides direct method calls for core 
 - `AgentAbilities` manages agent CRUD, renaming (with filesystem migration), and deletion.
 - `AgentMemoryAbilities` provides section-based read, write, append, and search operations on memory files.
 - `DailyMemoryAbilities` manages daily memory files — read, write, list, search, and delete by date.
-- `WorkspaceAbilities` provides git-aware workspace operations: clone, read, write, edit files, and run git commands.
+- `WorkspaceAbilities` provides git-aware workspace operations: clone, read, write, edit files, and run git commands. **Moved to data-machine-code extension.**
 
 **Remaining Services** (utilities for cross-cutting concerns):
 - `LogsManager` aggregates log entries in the `wp_datamachine_logs` table for filtering in the admin UI.
@@ -119,7 +119,6 @@ System tasks are background operations that run outside the normal pipeline exec
 | `image_generation` | `ImageGenerationTask` | AI-powered image generation |
 | `image_optimization` | `ImageOptimizationTask` | Image compression and optimization |
 | `alt_text_generation` | `AltTextTask` | AI-generated alt text for images |
-| `github_create_issue` | `GitHubIssueTask` | Create GitHub issues from agent context |
 | `internal_linking` | `InternalLinkingTask` | Automated internal link injection |
 | `daily_memory_generation` | `DailyMemoryTask` | Daily memory synthesis and MEMORY.md cleanup |
 | `meta_description_generation` | `MetaDescriptionTask` | AI-generated meta descriptions |
@@ -140,6 +139,8 @@ wp datamachine jobs undo <job_id> --dry-run --allow-root
 
 ## Workspace System
 
+> **Note:** The workspace system has been moved to the `data-machine-code` extension plugin. The following documentation is for reference only.
+
 The workspace provides a **secure file management layer outside the web root** for agent operations:
 
 - **Location**: `/var/lib/datamachine/workspace/` (configurable via `DATAMACHINE_WORKSPACE_PATH`)
@@ -147,11 +148,12 @@ The workspace provides a **secure file management layer outside the web root** f
 - **File operations**: Read, write, edit files with `@file` syntax support in CLI
 - **Security**: Located outside the web root; mutating operations are CLI-only (not exposed via REST)
 
+Commands (requires data-machine-code extension):
 ```bash
-wp datamachine workspace list --allow-root
-wp datamachine workspace clone https://github.com/org/repo.git --allow-root
-wp datamachine workspace read path/to/file --allow-root
-wp datamachine workspace git status --repo=my-repo --allow-root
+wp datamachine-code workspace list --allow-root
+wp datamachine-code workspace clone https://github.com/org/repo.git --allow-root
+wp datamachine-code workspace read path/to/file --allow-root
+wp datamachine-code workspace git status --repo=my-repo --allow-root
 ```
 
 ## Data Flow
@@ -200,7 +202,7 @@ wp datamachine workspace git status --repo=my-repo --allow-root
 - **Multi-platform publishing** via dedicated fetch/publish/update handlers for files, RSS, Reddit, Google Sheets, WordPress, Twitter, Threads, Bluesky, Facebook, and Google Sheets output.
 - **Daily memory system** for automatic temporal knowledge management with AI-driven pruning.
 - **System tasks** for background AI operations (image generation, alt text, internal linking, meta descriptions) with undo support.
-- **Workspace system** for secure git-aware file management outside the web root.
+- **Workspace system** for secure git-aware file management outside the web root (moved to data-machine-code extension).
 - **Extension points** through filters such as `datamachine_handlers`, `chubes_ai_tools`, `datamachine_step_types`, `datamachine_auth_providers`, and `datamachine_engine_data`.
 - **Directive orchestration** ensures every AI request is context-aware, tool-enabled, and consistent with site policies.
 - **Chartable logging, deduplication, and error handling** keep operators informed about job outcomes and prevent duplicate processing.

--- a/skills/data-machine/SKILL.md
+++ b/skills/data-machine/SKILL.md
@@ -79,7 +79,7 @@ Manage via `wp datamachine agent` (aliased as `wp datamachine memory`). Run `wp 
 
 ## AI Tools (During Pipeline Execution)
 
-When running inside a pipeline, the AI step has access to tools. These are NOT CLI commands — they're available to the AI model during flow execution. Key tools include: local_search, image_generation, agent_memory, web_fetch, wordpress_post_reader, google_search, google_search_console, bing_webmaster, skip_item, queue_validator, github_create_issue.
+When running inside a pipeline, the AI step has access to tools. These are NOT CLI commands — they're available to the AI model during flow execution. Key tools include: local_search, image_generation, agent_memory, web_fetch, wordpress_post_reader, google_search, google_search_console, bing_webmaster, skip_item, queue_validator.
 
 The tool list is managed by the plugin and may grow. Check pipeline logs to see which tools are available.
 


### PR DESCRIPTION
## Summary

Aligns Data Machine documentation with the current codebase reality.

## Changes

- **AGENTS.md**: Removed duplicated 'Build system' and 'Testing' sections that appeared twice. Added note about extension-based commands.

- **README.md**: Removed  and  from CLI command list (moved to extension).

- **docs/core-system/wp-cli.md**: 
  - Updated command count (23 not 25)
  - Removed workspace and github command sections
  - Added note about data-machine-code extension
  - Removed 'Workspace git workflow' example

- **docs/overview.md**: 
  - Updated WorkspaceAbilities and workspace system references
  - Removed github_create_issue from system tasks table
  - Added extension notes throughout

- **docs/core-system/workspace-system.md**: 
  - Added prominent extension notice at top
  - Updated CLI references to 

- **docs/core-system/wordpress-as-agent-memory.md**: 
  - Fixed incorrect  references for agent files
  - Corrected to use  commands

- **docs/architecture.md**: 
  - Updated workspace references with extension notes

- **docs/ai-tools/tools-overview.md**: 
  - Updated GitHub and Workspace tools sections
  - Removed duplicate GitHub section
  - Added extension notes

- **skills/data-machine/SKILL.md**: 
  - Removed  from tools list

## Key Finding

The  and  commands, along with related tools (WorkspaceTools, GitHubIssueTool), have been moved to the  extension plugin. All documentation now reflects this change.

## Files Changed

9 files changed, 43 insertions(+), 157 deletions(-)