### PR TITLE
ci: add concurrency group to cancel stale PR runs

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -8,6 +8,10 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+concurrency:
+  group: homeboy-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Summary

- Adds `concurrency` group keyed by PR number (or ref for non-PR events)
- `cancel-in-progress` only on PR events — push-to-main runs are serialized but not cancelled
- Prevents wasted CI minutes when pushing rapid commits to a PR