### PR TITLE
fix: multisite log level check reads wrong blog's option

### DIFF
--- a/inc/Engine/Logger.php
+++ b/inc/Engine/Logger.php
@@ -82,7 +82,13 @@ function datamachine_log_message( string $level, string|\Stringable $message, ar
 			'critical' => 4,
 		);
 
-		$min_level    = get_option( 'datamachine_log_level', 'info' );
+		// Use get_blog_option() with the current blog ID to ensure we read the
+		// log level from the same site whose log table we're about to write to.
+		// Plain get_option() can return the wrong site's setting on multisite when
+		// the calling context doesn't match the $wpdb->prefix (e.g., REST API on
+		// blog 1 triggering events-site pipeline logging via switch_to_blog).
+		$blog_id      = is_multisite() ? get_current_blog_id() : 0;
+		$min_level    = $blog_id ? get_blog_option( $blog_id, 'datamachine_log_level', 'info' ) : get_option( 'datamachine_log_level', 'info' );
 		$min_severity = $severity_map[ $min_level ] ?? 1;
 		$msg_severity = $severity_map[ $level ] ?? 0;
 


### PR DESCRIPTION
## Summary

`Logger::datamachine_log_message()` used `get_option('datamachine_log_level')` which reads from whichever blog is current at call time. On multisite, this often returns the main site's default (`info`) even when the log row lands in the events site's table (which has level = `error`).

## Impact

435,439 unnecessary `info`-level rows written to `c8c_7_datamachine_logs` in 4 days (116MB). The events site's `error` level setting was completely bypassed.

## Fix

Replace `get_option()` with `get_blog_option(get_current_blog_id(), ...)` to read the log level from the same blog whose `datamachine_logs` table will receive the write.

Also set `datamachine_log_level = error` on the main site as a belt-and-suspenders measure.