### PR TITLE
feat: HTML-aware smart text replace in EditPostBlocksAbility

### DIFF
--- a/inc/Abilities/Content/EditPostBlocksAbility.php
+++ b/inc/Abilities/Content/EditPostBlocksAbility.php
@@ -226,7 +226,7 @@ class EditPostBlocksAbility {
 				continue;
 			}
 
-			$new_html                            = str_replace( $find, $replace, $inner_html );
+			$new_html                            = self::smart_text_replace( $inner_html, $find, $replace );
 			$blocks[ $block_index ]['innerHTML'] = $new_html;
 
 			// Also update innerContent entries that match.
@@ -234,7 +234,7 @@ class EditPostBlocksAbility {
 				$blocks[ $block_index ]['innerContent'] = array_map(
 					function ( $content ) use ( $find, $replace ) {
 						if ( is_string( $content ) ) {
-							return str_replace( $find, $replace, $content );
+							return self::smart_text_replace( $content, $find, $replace );
 						}
 						return $content;
 					},
@@ -297,5 +297,51 @@ class EditPostBlocksAbility {
 			'post_url'        => get_permalink( $post_id ),
 			'changes_applied' => $changes,
 		);
+	}
+
+	/**
+	 * HTML-aware text replacement.
+	 *
+	 * Splits content into HTML tags and text nodes, only performs
+	 * replacement within text nodes. This prevents corruption of
+	 * HTML attributes (href, class, src, etc.) when the search text
+	 * matches attribute values.
+	 *
+	 * Ported from Wordsurf's edit_post tool.
+	 *
+	 * @since 0.58.0
+	 *
+	 * @param string $content        HTML content.
+	 * @param string $find           Text to search for.
+	 * @param string $replace        Replacement text.
+	 * @param bool   $case_sensitive Case-sensitive search (default true).
+	 * @return string Modified content.
+	 */
+	private static function smart_text_replace( string $content, string $find, string $replace, bool $case_sensitive = true ): string {
+		// No HTML tags — simple replacement.
+		if ( false === strpos( $content, '<' ) ) {
+			return $case_sensitive
+				? str_replace( $find, $replace, $content )
+				: str_ireplace( $find, $replace, $content );
+		}
+
+		// Split into HTML tags and text nodes.
+		$parts  = preg_split( '/(<[^>]+>)/', $content, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
+		$result = '';
+
+		foreach ( $parts as $part ) {
+			// HTML tag — pass through untouched.
+			if ( str_starts_with( $part, '<' ) && str_ends_with( $part, '>' ) ) {
+				$result .= $part;
+				continue;
+			}
+
+			// Text node — safe to replace.
+			$result .= $case_sensitive
+				? str_replace( $find, $replace, $part )
+				: str_ireplace( $find, $replace, $part );
+		}
+
+		return $result;
 	}
 }


### PR DESCRIPTION
## Summary

Replaces plain `str_replace` with `smart_text_replace` that only modifies text nodes, leaving HTML tags untouched.

## Problem

When the AI edits content containing `<a href="https://example.com/some-text">some text</a>` and searches for "some text", the plain `str_replace` also corrupts the `href` attribute. This breaks links, image sources, and CSS classes.

## Fix

`smart_text_replace()` splits content into HTML tags and text nodes via `preg_split('/(<[^>]+>)/')`, then only performs replacement within text nodes. HTML tags pass through unchanged.

Ported from Wordsurf's `edit_post.php` as part of the Phase 2 migration (Extra-Chill/wordsurf#1).

## Changes

- `EditPostBlocksAbility::smart_text_replace()` — new private static method
- `execute()` — calls `smart_text_replace()` instead of `str_replace()` for both `innerHTML` and `innerContent`