### PR TITLE
feat: Add flow pause/resume with non-destructive enabled boolean

### DIFF
--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -105,6 +105,22 @@ class RunFlowAbility {
 			);
 		}
 
+		// Check if flow is paused (enabled=false). Safety net for AS hooks
+		// that were already queued before the flow was paused.
+		$scheduling_config = $flow['scheduling_config'] ?? array();
+		if ( ! \DataMachine\Core\Database\Flows\Flows::is_flow_enabled( $scheduling_config ) ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Flow execution skipped - flow is paused',
+				array( 'flow_id' => $flow_id )
+			);
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow %d is paused.', $flow_id ),
+			);
+		}
+
 		$pipeline_id = (int) $flow['pipeline_id'];
 
 		// Use provided job_id or create new one (for scheduled/recurring flows).

--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -222,6 +222,7 @@ trait FlowHelpers {
 
 		$scheduling_config = $flow['scheduling_config'] ?? array();
 		$last_run_at       = $latest_job['created_at'] ?? null;
+		$is_enabled        = \DataMachine\Core\Database\Flows\Flows::is_flow_enabled( $scheduling_config );
 
 		$next_run = null;
 		if ( null !== $next_runs && array_key_exists( $flow_id, $next_runs ) ) {
@@ -234,6 +235,7 @@ trait FlowHelpers {
 			'pipeline_id'       => isset( $flow['pipeline_id'] ) ? (int) $flow['pipeline_id'] : null,
 			'flow_config'       => $flow['flow_config'] ?? array(),
 			'scheduling_config' => $scheduling_config,
+			'enabled'           => $is_enabled,
 			'last_run'          => $last_run_at,
 			'last_run_status'   => $latest_job['status'] ?? null,
 			'last_run_display'  => \DataMachine\Core\Admin\DateFormatter::format_for_display( $last_run_at ),

--- a/inc/Abilities/Flow/PauseFlowAbility.php
+++ b/inc/Abilities/Flow/PauseFlowAbility.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Pause Flow Ability
+ *
+ * Pauses one or more flows by setting enabled=false in scheduling_config.
+ * Preserves the original schedule so flows can be resumed without reconfiguration.
+ * Unschedules Action Scheduler hooks for paused flows.
+ *
+ * Supports three scoping levels:
+ * - Single flow: flow_id
+ * - All flows in a pipeline: pipeline_id
+ * - All flows for an agent: agent_id
+ *
+ * @package DataMachine\Abilities\Flow
+ * @since 0.59.0
+ */
+
+namespace DataMachine\Abilities\Flow;
+
+use DataMachine\Api\Flows\FlowScheduling;
+
+defined( 'ABSPATH' ) || exit;
+
+class PauseFlowAbility {
+
+	use FlowHelpers;
+
+	public function __construct() {
+		$this->initDatabases();
+
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		$this->registerAbility();
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/pause-flow',
+				array(
+					'label'               => __( 'Pause Flow', 'data-machine' ),
+					'description'         => __( 'Pause one or more flows. Preserves schedule for later resume.', 'data-machine' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'flow_id'     => array(
+								'type'        => 'integer',
+								'description' => __( 'Single flow ID to pause.', 'data-machine' ),
+							),
+							'pipeline_id' => array(
+								'type'        => 'integer',
+								'description' => __( 'Pause all flows in this pipeline.', 'data-machine' ),
+							),
+							'agent_id'    => array(
+								'type'        => 'integer',
+								'description' => __( 'Pause all flows for this agent.', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'paused'  => array( 'type' => 'integer' ),
+							'skipped' => array( 'type' => 'integer' ),
+							'flows'   => array( 'type' => 'array' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Execute pause flow ability.
+	 *
+	 * @param array $input Input with flow_id, pipeline_id, or agent_id.
+	 * @return array Result with pause counts and affected flow IDs.
+	 */
+	public function execute( array $input ): array {
+		$flow_id     = isset( $input['flow_id'] ) ? (int) $input['flow_id'] : null;
+		$pipeline_id = isset( $input['pipeline_id'] ) ? (int) $input['pipeline_id'] : null;
+		$agent_id    = isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
+
+		if ( null === $flow_id && null === $pipeline_id && null === $agent_id ) {
+			return array(
+				'success' => false,
+				'error'   => 'Must provide flow_id, pipeline_id, or agent_id.',
+			);
+		}
+
+		$flows = $this->resolveFlows( $flow_id, $pipeline_id, $agent_id );
+
+		if ( empty( $flows ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No flows found matching the specified criteria.',
+			);
+		}
+
+		$paused  = 0;
+		$skipped = 0;
+		$details = array();
+
+		foreach ( $flows as $flow ) {
+			$fid              = (int) $flow['flow_id'];
+			$scheduling       = $flow['scheduling_config'] ?? array();
+
+			// Already paused — skip.
+			if ( isset( $scheduling['enabled'] ) && false === $scheduling['enabled'] ) {
+				++$skipped;
+				$details[] = array(
+					'flow_id' => $fid,
+					'status'  => 'already_paused',
+				);
+				continue;
+			}
+
+			// Set enabled=false, preserving all other scheduling fields.
+			$scheduling['enabled'] = false;
+			$this->db_flows->update_flow_scheduling( $fid, $scheduling );
+
+			// Unschedule Action Scheduler hooks so paused flows don't fire.
+			if ( function_exists( 'as_unschedule_all_actions' ) ) {
+				as_unschedule_all_actions( 'datamachine_run_flow_now', array( $fid ), 'data-machine' );
+			}
+
+			++$paused;
+			$details[] = array(
+				'flow_id' => $fid,
+				'status'  => 'paused',
+			);
+		}
+
+		$scope = $flow_id ? "flow {$flow_id}" : ( $pipeline_id ? "pipeline {$pipeline_id}" : "agent {$agent_id}" );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			"Flows paused for {$scope}",
+			array(
+				'paused'  => $paused,
+				'skipped' => $skipped,
+			)
+		);
+
+		return array(
+			'success' => true,
+			'paused'  => $paused,
+			'skipped' => $skipped,
+			'flows'   => $details,
+			'message' => sprintf( 'Paused %d flow(s), skipped %d (already paused).', $paused, $skipped ),
+		);
+	}
+
+	/**
+	 * Resolve flows from the given scope.
+	 *
+	 * @param int|null $flow_id     Single flow ID.
+	 * @param int|null $pipeline_id Pipeline ID for bulk scope.
+	 * @param int|null $agent_id    Agent ID for bulk scope.
+	 * @return array Array of flow records.
+	 */
+	private function resolveFlows( ?int $flow_id, ?int $pipeline_id, ?int $agent_id ): array {
+		if ( null !== $flow_id ) {
+			$flow = $this->db_flows->get_flow( $flow_id );
+			return $flow ? array( $flow ) : array();
+		}
+
+		if ( null !== $pipeline_id ) {
+			return $this->db_flows->get_flows_for_pipeline( $pipeline_id );
+		}
+
+		if ( null !== $agent_id ) {
+			return $this->db_flows->get_all_flows( null, $agent_id );
+		}
+
+		return array();
+	}
+}

--- a/inc/Abilities/Flow/ResumeFlowAbility.php
+++ b/inc/Abilities/Flow/ResumeFlowAbility.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Resume Flow Ability
+ *
+ * Resumes one or more paused flows by setting enabled=true in scheduling_config.
+ * Re-registers Action Scheduler hooks from the preserved schedule.
+ *
+ * Supports three scoping levels:
+ * - Single flow: flow_id
+ * - All flows in a pipeline: pipeline_id
+ * - All flows for an agent: agent_id
+ *
+ * @package DataMachine\Abilities\Flow
+ * @since 0.59.0
+ */
+
+namespace DataMachine\Abilities\Flow;
+
+use DataMachine\Api\Flows\FlowScheduling;
+
+defined( 'ABSPATH' ) || exit;
+
+class ResumeFlowAbility {
+
+	use FlowHelpers;
+
+	public function __construct() {
+		$this->initDatabases();
+
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		$this->registerAbility();
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/resume-flow',
+				array(
+					'label'               => __( 'Resume Flow', 'data-machine' ),
+					'description'         => __( 'Resume one or more paused flows. Re-registers schedules.', 'data-machine' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'flow_id'     => array(
+								'type'        => 'integer',
+								'description' => __( 'Single flow ID to resume.', 'data-machine' ),
+							),
+							'pipeline_id' => array(
+								'type'        => 'integer',
+								'description' => __( 'Resume all flows in this pipeline.', 'data-machine' ),
+							),
+							'agent_id'    => array(
+								'type'        => 'integer',
+								'description' => __( 'Resume all flows for this agent.', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'resumed' => array( 'type' => 'integer' ),
+							'skipped' => array( 'type' => 'integer' ),
+							'errors'  => array( 'type' => 'integer' ),
+							'flows'   => array( 'type' => 'array' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Execute resume flow ability.
+	 *
+	 * @param array $input Input with flow_id, pipeline_id, or agent_id.
+	 * @return array Result with resume counts and affected flow IDs.
+	 */
+	public function execute( array $input ): array {
+		$flow_id     = isset( $input['flow_id'] ) ? (int) $input['flow_id'] : null;
+		$pipeline_id = isset( $input['pipeline_id'] ) ? (int) $input['pipeline_id'] : null;
+		$agent_id    = isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
+
+		if ( null === $flow_id && null === $pipeline_id && null === $agent_id ) {
+			return array(
+				'success' => false,
+				'error'   => 'Must provide flow_id, pipeline_id, or agent_id.',
+			);
+		}
+
+		$flows = $this->resolveFlows( $flow_id, $pipeline_id, $agent_id );
+
+		if ( empty( $flows ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No flows found matching the specified criteria.',
+			);
+		}
+
+		$resumed = 0;
+		$skipped = 0;
+		$errors  = 0;
+		$details = array();
+
+		foreach ( $flows as $flow ) {
+			$fid        = (int) $flow['flow_id'];
+			$scheduling = $flow['scheduling_config'] ?? array();
+
+			// Not paused — skip.
+			if ( ! isset( $scheduling['enabled'] ) || false !== $scheduling['enabled'] ) {
+				++$skipped;
+				$details[] = array(
+					'flow_id' => $fid,
+					'status'  => 'not_paused',
+				);
+				continue;
+			}
+
+			// Remove the enabled key (default is enabled) and re-register schedule.
+			unset( $scheduling['enabled'] );
+			$this->db_flows->update_flow_scheduling( $fid, $scheduling );
+
+			// Re-register Action Scheduler hooks from the preserved schedule.
+			$interval = $scheduling['interval'] ?? 'manual';
+			if ( 'manual' !== $interval ) {
+				$result = FlowScheduling::handle_scheduling_update( $fid, $scheduling, true );
+				if ( is_wp_error( $result ) ) {
+					++$errors;
+					$details[] = array(
+						'flow_id' => $fid,
+						'status'  => 'resume_error',
+						'error'   => $result->get_error_message(),
+					);
+					continue;
+				}
+			}
+
+			++$resumed;
+			$details[] = array(
+				'flow_id' => $fid,
+				'status'  => 'resumed',
+			);
+		}
+
+		$scope = $flow_id ? "flow {$flow_id}" : ( $pipeline_id ? "pipeline {$pipeline_id}" : "agent {$agent_id}" );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			"Flows resumed for {$scope}",
+			array(
+				'resumed' => $resumed,
+				'skipped' => $skipped,
+				'errors'  => $errors,
+			)
+		);
+
+		return array(
+			'success' => true,
+			'resumed' => $resumed,
+			'skipped' => $skipped,
+			'errors'  => $errors,
+			'flows'   => $details,
+			'message' => sprintf( 'Resumed %d flow(s), skipped %d (not paused), %d error(s).', $resumed, $skipped, $errors ),
+		);
+	}
+
+	/**
+	 * Resolve flows from the given scope.
+	 *
+	 * @param int|null $flow_id     Single flow ID.
+	 * @param int|null $pipeline_id Pipeline ID for bulk scope.
+	 * @param int|null $agent_id    Agent ID for bulk scope.
+	 * @return array Array of flow records.
+	 */
+	private function resolveFlows( ?int $flow_id, ?int $pipeline_id, ?int $agent_id ): array {
+		if ( null !== $flow_id ) {
+			$flow = $this->db_flows->get_flow( $flow_id );
+			return $flow ? array( $flow ) : array();
+		}
+
+		if ( null !== $pipeline_id ) {
+			return $this->db_flows->get_flows_for_pipeline( $pipeline_id );
+		}
+
+		if ( null !== $agent_id ) {
+			return $this->db_flows->get_all_flows( null, $agent_id );
+		}
+
+		return array();
+	}
+}

--- a/inc/Abilities/FlowAbilities.php
+++ b/inc/Abilities/FlowAbilities.php
@@ -18,6 +18,8 @@ use DataMachine\Abilities\Flow\CreateFlowAbility;
 use DataMachine\Abilities\Flow\UpdateFlowAbility;
 use DataMachine\Abilities\Flow\DeleteFlowAbility;
 use DataMachine\Abilities\Flow\DuplicateFlowAbility;
+use DataMachine\Abilities\Flow\PauseFlowAbility;
+use DataMachine\Abilities\Flow\ResumeFlowAbility;
 use DataMachine\Abilities\Flow\QueueAbility;
 use DataMachine\Abilities\Flow\WebhookTriggerAbility;
 
@@ -32,6 +34,8 @@ class FlowAbilities {
 	private UpdateFlowAbility $update_flow;
 	private DeleteFlowAbility $delete_flow;
 	private DuplicateFlowAbility $duplicate_flow;
+	private PauseFlowAbility $pause_flow;
+	private ResumeFlowAbility $resume_flow;
 	private QueueAbility $queue;
 	private WebhookTriggerAbility $webhook_trigger;
 
@@ -48,6 +52,8 @@ class FlowAbilities {
 		$this->update_flow     = new UpdateFlowAbility();
 		$this->delete_flow     = new DeleteFlowAbility();
 		$this->duplicate_flow  = new DuplicateFlowAbility();
+		$this->pause_flow      = new PauseFlowAbility();
+		$this->resume_flow     = new ResumeFlowAbility();
 		$this->webhook_trigger = new WebhookTriggerAbility();
 
 		self::$registered = true;
@@ -146,6 +152,36 @@ class FlowAbilities {
 			$this->duplicate_flow = new DuplicateFlowAbility();
 		}
 		return $this->duplicate_flow->execute( $input );
+	}
+
+	/**
+	 * Execute pause-flow ability.
+	 *
+	 * @since 0.59.0
+	 *
+	 * @param array $input Input parameters (flow_id, pipeline_id, or agent_id).
+	 * @return array Result with pause counts.
+	 */
+	public function executePauseFlow( array $input ): array {
+		if ( ! isset( $this->pause_flow ) ) {
+			$this->pause_flow = new PauseFlowAbility();
+		}
+		return $this->pause_flow->execute( $input );
+	}
+
+	/**
+	 * Execute resume-flow ability.
+	 *
+	 * @since 0.59.0
+	 *
+	 * @param array $input Input parameters (flow_id, pipeline_id, or agent_id).
+	 * @return array Result with resume counts.
+	 */
+	public function executeResumeFlow( array $input ): array {
+		if ( ! isset( $this->resume_flow ) ) {
+			$this->resume_flow = new ResumeFlowAbility();
+		}
+		return $this->resume_flow->execute( $input );
 	}
 
 	/**

--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -172,6 +172,90 @@ class Flows {
 
 		register_rest_route(
 			'datamachine/v1',
+			'/flows/(?P<flow_id>\d+)/pause',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( self::class, 'handle_pause_flow' ),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'args'                => array(
+					'flow_id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+						'description'       => __( 'Flow ID to pause', 'data-machine' ),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'datamachine/v1',
+			'/flows/(?P<flow_id>\d+)/resume',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( self::class, 'handle_resume_flow' ),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'args'                => array(
+					'flow_id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+						'description'       => __( 'Flow ID to resume', 'data-machine' ),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'datamachine/v1',
+			'/flows/pause',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( self::class, 'handle_bulk_pause' ),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'args'                => array(
+					'pipeline_id' => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+						'description'       => __( 'Pause all flows in this pipeline', 'data-machine' ),
+					),
+					'agent_id'    => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+						'description'       => __( 'Pause all flows for this agent', 'data-machine' ),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'datamachine/v1',
+			'/flows/resume',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( self::class, 'handle_bulk_resume' ),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'args'                => array(
+					'pipeline_id' => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+						'description'       => __( 'Resume all flows in this pipeline', 'data-machine' ),
+					),
+					'agent_id'    => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+						'description'       => __( 'Resume all flows for this agent', 'data-machine' ),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'datamachine/v1',
 			'/flows/(?P<flow_id>\d+)/duplicate',
 			array(
 				'methods'             => 'POST',
@@ -561,6 +645,152 @@ class Flows {
 				'message' => __( 'Flow updated successfully', 'data-machine' ),
 			)
 		);
+	}
+
+	/**
+	 * Handle single flow pause request.
+	 *
+	 * POST /datamachine/v1/flows/{flow_id}/pause
+	 *
+	 * @since 0.59.0
+	 */
+	public static function handle_pause_flow( $request ) {
+		$flow_id = (int) $request->get_param( 'flow_id' );
+
+		$ability = wp_get_ability( 'datamachine/pause-flow' );
+		if ( ! $ability ) {
+			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
+		}
+
+		$result = $ability->execute( array( 'flow_id' => $flow_id ) );
+
+		if ( ! $result['success'] ) {
+			return new \WP_Error(
+				'pause_failed',
+				$result['error'] ?? __( 'Failed to pause flow.', 'data-machine' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return rest_ensure_response( $result );
+	}
+
+	/**
+	 * Handle single flow resume request.
+	 *
+	 * POST /datamachine/v1/flows/{flow_id}/resume
+	 *
+	 * @since 0.59.0
+	 */
+	public static function handle_resume_flow( $request ) {
+		$flow_id = (int) $request->get_param( 'flow_id' );
+
+		$ability = wp_get_ability( 'datamachine/resume-flow' );
+		if ( ! $ability ) {
+			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
+		}
+
+		$result = $ability->execute( array( 'flow_id' => $flow_id ) );
+
+		if ( ! $result['success'] ) {
+			return new \WP_Error(
+				'resume_failed',
+				$result['error'] ?? __( 'Failed to resume flow.', 'data-machine' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return rest_ensure_response( $result );
+	}
+
+	/**
+	 * Handle bulk pause request (by pipeline or agent).
+	 *
+	 * POST /datamachine/v1/flows/pause
+	 *
+	 * @since 0.59.0
+	 */
+	public static function handle_bulk_pause( $request ) {
+		$pipeline_id = $request->get_param( 'pipeline_id' );
+		$agent_id    = $request->get_param( 'agent_id' );
+
+		if ( ! $pipeline_id && ! $agent_id ) {
+			return new \WP_Error(
+				'missing_scope',
+				__( 'Must provide pipeline_id or agent_id.', 'data-machine' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$ability = wp_get_ability( 'datamachine/pause-flow' );
+		if ( ! $ability ) {
+			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
+		}
+
+		$input = array();
+		if ( $pipeline_id ) {
+			$input['pipeline_id'] = (int) $pipeline_id;
+		}
+		if ( $agent_id ) {
+			$input['agent_id'] = (int) $agent_id;
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( ! $result['success'] ) {
+			return new \WP_Error(
+				'bulk_pause_failed',
+				$result['error'] ?? __( 'Failed to pause flows.', 'data-machine' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return rest_ensure_response( $result );
+	}
+
+	/**
+	 * Handle bulk resume request (by pipeline or agent).
+	 *
+	 * POST /datamachine/v1/flows/resume
+	 *
+	 * @since 0.59.0
+	 */
+	public static function handle_bulk_resume( $request ) {
+		$pipeline_id = $request->get_param( 'pipeline_id' );
+		$agent_id    = $request->get_param( 'agent_id' );
+
+		if ( ! $pipeline_id && ! $agent_id ) {
+			return new \WP_Error(
+				'missing_scope',
+				__( 'Must provide pipeline_id or agent_id.', 'data-machine' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$ability = wp_get_ability( 'datamachine/resume-flow' );
+		if ( ! $ability ) {
+			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
+		}
+
+		$input = array();
+		if ( $pipeline_id ) {
+			$input['pipeline_id'] = (int) $pipeline_id;
+		}
+		if ( $agent_id ) {
+			$input['agent_id'] = (int) $agent_id;
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( ! $result['success'] ) {
+			return new \WP_Error(
+				'bulk_resume_failed',
+				$result['error'] ?? __( 'Failed to resume flows.', 'data-machine' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return rest_ensure_response( $result );
 	}
 
 	/**

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -123,6 +123,12 @@ class FlowsCommand extends BaseCommand {
 	 * [--dry-run]
 	 * : Validate without creating (create subcommand).
 	 *
+	 * [--pipeline=<id>]
+	 * : Pipeline ID for pause/resume scoping.
+	 *
+	 * [--agent=<slug_or_id>]
+	 * : Agent slug or ID for scoping (pause/resume/list).
+	 *
 	 * [--yes]
 	 * : Skip confirmation prompt (delete subcommand).
 	 *
@@ -172,6 +178,21 @@ class FlowsCommand extends BaseCommand {
 	 *
 	 *     # Detach a memory file from a flow
 	 *     wp datamachine flows memory-files 42 --remove=content-briefing.md
+	 *
+	 *     # Pause a single flow
+	 *     wp datamachine flows pause 42
+	 *
+	 *     # Pause all flows in a pipeline
+	 *     wp datamachine flows pause --pipeline=12
+	 *
+	 *     # Pause all flows for an agent
+	 *     wp datamachine flows pause --agent=my-agent
+	 *
+	 *     # Resume a single flow
+	 *     wp datamachine flows resume 42
+	 *
+	 *     # Resume all flows for an agent
+	 *     wp datamachine flows resume --agent=my-agent
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
 		$flow_id     = null;
@@ -211,6 +232,18 @@ class FlowsCommand extends BaseCommand {
 				return;
 			}
 			$this->memoryFiles( (int) $args[1], $assoc_args );
+			return;
+		}
+
+		// Handle 'pause' subcommand: `flows pause 42` or `flows pause --pipeline=12`.
+		if ( ! empty( $args ) && 'pause' === $args[0] ) {
+			$this->pauseFlows( array_slice( $args, 1 ), $assoc_args );
+			return;
+		}
+
+		// Handle 'resume' subcommand: `flows resume 42` or `flows resume --pipeline=12`.
+		if ( ! empty( $args ) && 'resume' === $args[0] ) {
+			$this->resumeFlows( array_slice( $args, 1 ), $assoc_args );
 			return;
 		}
 
@@ -387,6 +420,8 @@ class FlowsCommand extends BaseCommand {
 		$scheduling = $flow['scheduling_config'] ?? array();
 		$interval   = $scheduling['interval'] ?? 'manual';
 
+		$is_paused = isset( $scheduling['enabled'] ) && false === $scheduling['enabled'];
+
 		WP_CLI::log( sprintf( 'Flow ID:      %d', $flow['flow_id'] ) );
 		WP_CLI::log( sprintf( 'Name:         %s', $flow['flow_name'] ) );
 		WP_CLI::log( sprintf( 'Pipeline ID:  %s', $flow['pipeline_id'] ?? 'N/A' ) );
@@ -395,6 +430,9 @@ class FlowsCommand extends BaseCommand {
 			WP_CLI::log( sprintf( 'Scheduling:   cron (%s) — %s', $scheduling['cron_expression'], $cron_desc ) );
 		} else {
 			WP_CLI::log( sprintf( 'Scheduling:   %s', $interval ) );
+		}
+		if ( $is_paused ) {
+			WP_CLI::log( 'Status:       PAUSED' );
 		}
 		WP_CLI::log( sprintf( 'Last run:     %s', $flow['last_run_display'] ?? 'Never' ) );
 		WP_CLI::log( sprintf( 'Next run:     %s', $flow['next_run_display'] ?? 'Not scheduled' ) );
@@ -1003,12 +1041,18 @@ class FlowsCommand extends BaseCommand {
 	private function extractSchedule( array $flow ): string {
 		$scheduling_config = $flow['scheduling_config'] ?? array();
 		$interval          = $scheduling_config['interval'] ?? 'manual';
+		$is_paused         = isset( $scheduling_config['enabled'] ) && false === $scheduling_config['enabled'];
 
+		$label = $interval;
 		if ( 'cron' === $interval && ! empty( $scheduling_config['cron_expression'] ) ) {
-			return 'cron:' . $scheduling_config['cron_expression'];
+			$label = 'cron:' . $scheduling_config['cron_expression'];
 		}
 
-		return (string) $interval;
+		if ( $is_paused ) {
+			$label .= ' (paused)';
+		}
+
+		return $label;
 	}
 
 	/**
@@ -1361,6 +1405,119 @@ class FlowsCommand extends BaseCommand {
 		);
 
 		\WP_CLI\Utils\format_items( $format, $items, array( 'filename' ) );
+	}
+
+	/**
+	 * Pause one or more flows.
+	 *
+	 * Preserves the original schedule so flows can be resumed later.
+	 *
+	 * ## USAGE
+	 *
+	 *     wp datamachine flows pause <flow_id>
+	 *     wp datamachine flows pause --pipeline=<id>
+	 *     wp datamachine flows pause --agent=<slug_or_id>
+	 *
+	 * @param array $args       Positional args (optional flow_id).
+	 * @param array $assoc_args Associative args (--pipeline, --agent).
+	 */
+	private function pauseFlows( array $args, array $assoc_args ): void {
+		$input = $this->buildPauseResumeInput( $args, $assoc_args );
+		if ( null === $input ) {
+			return; // Error already printed.
+		}
+
+		$ability = new \DataMachine\Abilities\FlowAbilities();
+		$result  = $ability->executePauseFlow( $input );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to pause flows' );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] ?? 'Flows paused.' );
+
+		$format = $assoc_args['format'] ?? 'table';
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+		} else {
+			foreach ( $result['flows'] ?? array() as $detail ) {
+				WP_CLI::log( sprintf( '  Flow %d: %s', $detail['flow_id'], $detail['status'] ) );
+			}
+		}
+	}
+
+	/**
+	 * Resume one or more paused flows.
+	 *
+	 * Re-registers Action Scheduler hooks from the preserved schedule.
+	 *
+	 * ## USAGE
+	 *
+	 *     wp datamachine flows resume <flow_id>
+	 *     wp datamachine flows resume --pipeline=<id>
+	 *     wp datamachine flows resume --agent=<slug_or_id>
+	 *
+	 * @param array $args       Positional args (optional flow_id).
+	 * @param array $assoc_args Associative args (--pipeline, --agent).
+	 */
+	private function resumeFlows( array $args, array $assoc_args ): void {
+		$input = $this->buildPauseResumeInput( $args, $assoc_args );
+		if ( null === $input ) {
+			return; // Error already printed.
+		}
+
+		$ability = new \DataMachine\Abilities\FlowAbilities();
+		$result  = $ability->executeResumeFlow( $input );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to resume flows' );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] ?? 'Flows resumed.' );
+
+		$format = $assoc_args['format'] ?? 'table';
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+		} else {
+			foreach ( $result['flows'] ?? array() as $detail ) {
+				$line = sprintf( '  Flow %d: %s', $detail['flow_id'], $detail['status'] );
+				if ( ! empty( $detail['error'] ) ) {
+					$line .= ' — ' . $detail['error'];
+				}
+				WP_CLI::log( $line );
+			}
+		}
+	}
+
+	/**
+	 * Build input array for pause/resume from CLI args.
+	 *
+	 * @param array $args       Positional args.
+	 * @param array $assoc_args Associative args.
+	 * @return array|null Input array, or null on validation error.
+	 */
+	private function buildPauseResumeInput( array $args, array $assoc_args ): ?array {
+		$flow_id     = ! empty( $args[0] ) ? (int) $args[0] : null;
+		$pipeline_id = isset( $assoc_args['pipeline'] ) ? (int) $assoc_args['pipeline'] : ( isset( $assoc_args['pipeline_id'] ) ? (int) $assoc_args['pipeline_id'] : null );
+		$agent_id    = AgentResolver::resolve( $assoc_args );
+
+		if ( null === $flow_id && null === $pipeline_id && null === $agent_id ) {
+			WP_CLI::error( 'Must provide a flow ID, --pipeline=<id>, or --agent=<slug_or_id>.' );
+			return null;
+		}
+
+		$input = array();
+		if ( null !== $flow_id ) {
+			$input['flow_id'] = $flow_id;
+		} elseif ( null !== $pipeline_id ) {
+			$input['pipeline_id'] = $pipeline_id;
+		} elseif ( null !== $agent_id ) {
+			$input['agent_id'] = $agent_id;
+		}
+
+		return $input;
 	}
 
 	/**

--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -103,15 +103,18 @@ class FlowFormatter {
 			$next_run = self::get_next_run_time( $flow_id );
 		}
 
+		$is_enabled = \DataMachine\Core\Database\Flows\Flows::is_flow_enabled( $scheduling_config );
+
 		return array(
 			'flow_id'           => $flow_id,
 			'flow_name'         => $flow['flow_name'] ?? '',
 			'pipeline_id'       => isset( $flow['pipeline_id'] ) ? (int) $flow['pipeline_id'] : null,
 			'flow_config'       => $flow_config,
 			'scheduling_config' => $scheduling_config,
+			'enabled'           => $is_enabled,
 			'last_run'          => $last_run_at,
 			'last_run_status'   => $last_run_status,
-			'last_run_display'  => DateFormatter::format_for_display( $last_run_at),
+			'last_run_display'  => DateFormatter::format_for_display( $last_run_at ),
 			'is_running'        => $is_running,
 			'next_run'          => $next_run,
 			'next_run_display'  => DateFormatter::format_for_display( $next_run ),

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -701,9 +701,24 @@ class Flows extends BaseRepository {
 	}
 
 	/**
+	 * Check if a flow is enabled (not paused).
+	 *
+	 * A flow is enabled by default. It is disabled when scheduling_config.enabled === false.
+	 *
+	 * @since 0.59.0
+	 *
+	 * @param array $scheduling_config Scheduling configuration array.
+	 * @return bool True if the flow is enabled.
+	 */
+	public static function is_flow_enabled( array $scheduling_config ): bool {
+		return ! isset( $scheduling_config['enabled'] ) || false !== $scheduling_config['enabled'];
+	}
+
+	/**
 	 * Get flows ready for execution based on scheduling.
 	 *
 	 * Uses jobs table to determine last run time (single source of truth).
+	 * Skips paused flows (enabled=false in scheduling_config).
 	 *
 	 * Note: No user_id filter here — the scheduler must run ALL users' flows.
 	 * User-scoping happens at the pipeline/flow management level, not execution.
@@ -712,12 +727,16 @@ class Flows extends BaseRepository {
 
 		$current_time = current_time( 'mysql', true );
 
-		// Get all non-manual flows
+		// Get all non-manual, enabled flows.
+		// Exclude paused flows (enabled=false) and manual flows at the query level.
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		$flows = $this->wpdb->get_results(
 			$this->wpdb->prepare(
-				"SELECT * FROM %i WHERE JSON_EXTRACT(scheduling_config, '$.interval') != 'manual' ORDER BY flow_id ASC",
+				"SELECT * FROM %i
+				WHERE JSON_EXTRACT(scheduling_config, '$.interval') != 'manual'
+				AND (JSON_EXTRACT(scheduling_config, '$.enabled') IS NULL OR JSON_EXTRACT(scheduling_config, '$.enabled') != false)
+				ORDER BY flow_id ASC",
 				$this->table_name
 			),
 			ARRAY_A
@@ -774,6 +793,11 @@ class Flows extends BaseRepository {
 		}
 
 		if ( 'manual' === $scheduling_config['interval'] ) {
+			return false;
+		}
+
+		// Skip paused flows.
+		if ( ! self::is_flow_enabled( $scheduling_config ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Summary

- Adds `enabled` boolean to `scheduling_config` JSON for non-destructive flow pausing
- Pausing preserves the original schedule (cron expressions, intervals, timestamps) — no data loss
- Resuming re-registers Action Scheduler hooks from the preserved schedule

## Scoping

Pause/resume supports three levels — the state lives on each individual flow, bulk commands are scoped sugar:

| Scope | CLI | REST |
|-------|-----|------|
| Single flow | `wp datamachine flows pause 42` | `POST /flows/42/pause` |
| Pipeline | `wp datamachine flows pause --pipeline=12` | `POST /flows/pause?pipeline_id=12` |
| Agent | `wp datamachine flows pause --agent=my-agent` | `POST /flows/pause?agent_id=3` |

## Changes

### Abilities
- **PauseFlowAbility** — sets `enabled: false`, unschedules AS hooks
- **ResumeFlowAbility** — removes `enabled` key, re-registers AS hooks via `FlowScheduling::handle_scheduling_update()`

### Execution gates
- `RunFlowAbility::execute()` — bail early if flow is paused (safety net for already-queued AS hooks)
- `Flows::get_flows_ready_for_execution()` — excludes paused flows at query level
- `Flows::is_flow_ready_for_execution()` — checks enabled flag

### CLI
- `wp datamachine flows pause <flow_id|--pipeline=N|--agent=slug>`
- `wp datamachine flows resume <flow_id|--pipeline=N|--agent=slug>`
- Flow list shows `(paused)` suffix on schedule column
- Flow detail shows `Status: PAUSED` when applicable

### REST API
- `POST /datamachine/v1/flows/{id}/pause` — single flow
- `POST /datamachine/v1/flows/{id}/resume` — single flow
- `POST /datamachine/v1/flows/pause` — bulk by pipeline_id or agent_id
- `POST /datamachine/v1/flows/resume` — bulk by pipeline_id or agent_id

### Output
- `enabled` field added to FlowFormatter response and list mode output
- `Flows::is_flow_enabled()` static helper for consistent checks

## Design

No schema migration needed — `enabled` lives inside the existing `scheduling_config` JSON blob. Absent or `true` means enabled (backward compatible). Only `false` means paused.

## Testing

Tested via CLI:
- ✅ Pause/resume single flow
- ✅ Pause/resume by pipeline
- ✅ Pause/resume by agent slug
- ✅ Idempotent (pause already-paused → skipped, resume not-paused → skipped)
- ✅ JSON output format
- ✅ Flow list shows `(paused)` indicator
- ✅ Flow detail shows `PAUSED` status
- ✅ Error handling (missing args, non-existent flow)