### PR TITLE
Drop orphaned per-site agent tables

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -553,6 +553,9 @@ function datamachine_activate_for_site() {
 	// Migrate per-site agents to network-scoped tables (idempotent).
 	datamachine_migrate_agents_to_network_scope();
 
+	// Drop orphaned per-site agent tables left behind by the migration (idempotent).
+	datamachine_drop_orphaned_agent_tables();
+
 	// Regenerate SITE.md with enriched content and clean up legacy SiteContext transient.
 	datamachine_regenerate_site_md();
 	delete_transient( 'datamachine_site_context_data' );

--- a/inc/migrations.php
+++ b/inc/migrations.php
@@ -2224,3 +2224,77 @@ function datamachine_migrate_agents_to_network_scope() {
 		);
 	}
 }
+
+/**
+ * Drop orphaned per-site agent tables after network migration.
+ *
+ * After datamachine_migrate_agents_to_network_scope() has consolidated
+ * all agent data into the network-scoped tables (base_prefix), the
+ * per-site copies (e.g. c8c_7_datamachine_agents) serve no purpose.
+ * They can't be queried (all repositories use base_prefix) and their
+ * presence is confusing.
+ *
+ * This function drops the orphaned per-site agent, access, and token
+ * tables for every subsite. Idempotent — safe to call multiple times.
+ * Only runs on multisite after the network migration flag is set.
+ *
+ * @since 0.43.0
+ */
+function datamachine_drop_orphaned_agent_tables() {
+	if ( ! is_multisite() ) {
+		return;
+	}
+
+	if ( ! get_site_option( 'datamachine_agents_network_migrated' ) ) {
+		return;
+	}
+
+	if ( get_site_option( 'datamachine_orphaned_agent_tables_dropped' ) ) {
+		return;
+	}
+
+	global $wpdb;
+
+	$table_suffixes = array(
+		'datamachine_agents',
+		'datamachine_agent_access',
+		'datamachine_agent_tokens',
+	);
+
+	$sites   = get_sites( array( 'fields' => 'ids' ) );
+	$dropped = 0;
+
+	foreach ( $sites as $blog_id ) {
+		$site_prefix = $wpdb->get_blog_prefix( $blog_id );
+
+		// Skip the main site — its prefix IS the base_prefix,
+		// so these are the canonical network tables.
+		if ( $site_prefix === $wpdb->base_prefix ) {
+			continue;
+		}
+
+		foreach ( $table_suffixes as $suffix ) {
+			$table_name = $site_prefix . $suffix;
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
+
+			if ( $exists ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$wpdb->query( "DROP TABLE `{$table_name}`" );
+				++$dropped;
+			}
+		}
+	}
+
+	update_site_option( 'datamachine_orphaned_agent_tables_dropped', true );
+
+	if ( $dropped > 0 ) {
+		do_action(
+			'datamachine_log',
+			'info',
+			'Dropped orphaned per-site agent tables after network migration',
+			array( 'tables_dropped' => $dropped )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `datamachine_drop_orphaned_agent_tables()` to clean up per-site agent tables left behind by the network migration
- Runs during activation, after `datamachine_migrate_agents_to_network_scope()`
- Guarded by `datamachine_orphaned_agent_tables_dropped` site option (idempotent)

## Problem

The network migration consolidated agent data into `c8c_datamachine_agents` (base_prefix) but left orphaned per-site copies:
- `c8c_7_datamachine_agents` (events)
- `c8c_11_datamachine_agents` (wire)
- `c8c_12_datamachine_agents` (studio)
- Plus corresponding `_agent_access` and `_agent_tokens` tables

These are never queried (all 3 repos override to `base_prefix`) but their existence is confusing — the studio site had a duplicate "roadie" agent (ID 1) in its per-site table while the canonical one is ID 7 in the network table.

## Already cleaned up on production

The orphaned tables have been dropped manually on the live server and the flag set. This PR ensures the cleanup runs automatically on future deploys/activations.