### PR TITLE
feat: preview mode for content abilities + server-side diff resolution

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -164,9 +164,11 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/ChatAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/InternalLinkingAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Content/BlockSanitizer.php';
+	require_once __DIR__ . '/inc/Abilities/Content/PendingDiffStore.php';
 	require_once __DIR__ . '/inc/Abilities/Content/GetPostBlocksAbility.php';
 	require_once __DIR__ . '/inc/Abilities/Content/EditPostBlocksAbility.php';
 	require_once __DIR__ . '/inc/Abilities/Content/ReplacePostBlocksAbility.php';
+	require_once __DIR__ . '/inc/Abilities/Content/ResolveDiffAbility.php';
 	// GitHubAbilities moved to data-machine-code extension.
 	require_once __DIR__ . '/inc/Abilities/Fetch/FetchFilesAbility.php';
 	require_once __DIR__ . '/inc/Abilities/Email/EmailAbilities.php';
@@ -224,6 +226,7 @@ function datamachine_run_datamachine_plugin() {
 		new \DataMachine\Abilities\Content\EditPostBlocksAbility();
 		new \DataMachine\Abilities\Content\ReplacePostBlocksAbility();
 		new \DataMachine\Abilities\Content\InsertContentAbility();
+		new \DataMachine\Abilities\Content\ResolveDiffAbility();
 		// GitHubAbilities moved to data-machine-code extension.
 		new \DataMachine\Abilities\Fetch\FetchFilesAbility();
 		new \DataMachine\Abilities\Email\EmailAbilities();

--- a/inc/Abilities/Content/EditPostBlocksAbility.php
+++ b/inc/Abilities/Content/EditPostBlocksAbility.php
@@ -46,28 +46,32 @@ class EditPostBlocksAbility {
 								'type'        => 'integer',
 								'description' => __( 'Post ID to edit', 'data-machine' ),
 							),
-							'edits'   => array(
-								'type'        => 'array',
-								'description' => __( 'Array of edit operations', 'data-machine' ),
-								'items'       => array(
-									'type'       => 'object',
-									'required'   => array( 'block_index', 'find', 'replace' ),
-									'properties' => array(
-										'block_index' => array(
-											'type'        => 'integer',
-											'description' => __( 'Zero-based block index to edit', 'data-machine' ),
-										),
-										'find'        => array(
-											'type'        => 'string',
-											'description' => __( 'Text to find within the block', 'data-machine' ),
-										),
-										'replace'     => array(
-											'type'        => 'string',
-											'description' => __( 'Replacement text', 'data-machine' ),
-										),
+					'edits'   => array(
+							'type'        => 'array',
+							'description' => __( 'Array of edit operations', 'data-machine' ),
+							'items'       => array(
+								'type'       => 'object',
+								'required'   => array( 'block_index', 'find', 'replace' ),
+								'properties' => array(
+									'block_index' => array(
+										'type'        => 'integer',
+										'description' => __( 'Zero-based block index to edit', 'data-machine' ),
+									),
+									'find'        => array(
+										'type'        => 'string',
+										'description' => __( 'Text to find within the block', 'data-machine' ),
+									),
+									'replace'     => array(
+										'type'        => 'string',
+										'description' => __( 'Replacement text', 'data-machine' ),
 									),
 								),
 							),
+						),
+						'preview' => array(
+							'type'        => 'boolean',
+							'description' => __( 'When true, return diff preview without applying changes', 'data-machine' ),
+						),
 						),
 					),
 					'output_schema'       => array(
@@ -119,7 +123,7 @@ class EditPostBlocksAbility {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handleChatToolCall',
-			'description' => 'Surgical find/replace within specific Gutenberg blocks by index. Use get_post_blocks first to identify target blocks and indices.',
+			'description' => 'Surgical find/replace within specific Gutenberg blocks by index. Use get_post_blocks first to identify target blocks and indices. Set preview=true to return a diff preview without applying changes.',
 			'parameters'  => array(
 				'post_id' => array(
 					'type'        => 'integer',
@@ -130,6 +134,10 @@ class EditPostBlocksAbility {
 					'type'        => 'array',
 					'required'    => true,
 					'description' => 'Array of { block_index, find, replace } operations',
+				),
+				'preview' => array(
+					'type'        => 'boolean',
+					'description' => 'When true, return diff preview data without applying changes. The user can then accept or reject.',
 				),
 			),
 		);
@@ -162,6 +170,7 @@ class EditPostBlocksAbility {
 	public static function execute( array $input ): array {
 		$post_id = absint( $input['post_id'] ?? 0 );
 		$edits   = $input['edits'] ?? array();
+		$preview = ! empty( $input['preview'] );
 
 		if ( $post_id <= 0 ) {
 			return array(
@@ -251,7 +260,7 @@ class EditPostBlocksAbility {
 			);
 		}
 
-		// Only save if at least one edit succeeded.
+		// Only save/preview if at least one edit succeeded.
 		$successful = array_filter( $changes, fn( $c ) => ! empty( $c['success'] ) );
 
 		if ( empty( $successful ) ) {
@@ -264,7 +273,52 @@ class EditPostBlocksAbility {
 		}
 
 		$new_content = BlockSanitizer::sanitizeAndSerialize( $blocks );
-		$result      = wp_update_post(
+
+		// --- Preview mode: store pending edit, return diff data ---
+		if ( $preview ) {
+			$diff_id = PendingDiffStore::generate_id();
+
+			// Build per-edit diff data for the frontend.
+			$diffs = array();
+			foreach ( $edits as $edit ) {
+				$block_index = absint( $edit['block_index'] ?? 0 );
+				if ( $block_index < $total_blocks && ! empty( $edit['find'] ) ) {
+					$diffs[] = array(
+						'block_index'        => $block_index,
+						'originalContent'    => $edit['find'],
+						'replacementContent' => $edit['replace'] ?? '',
+					);
+				}
+			}
+
+			PendingDiffStore::store( $diff_id, array(
+				'type'    => 'edit_post_blocks',
+				'post_id' => $post_id,
+				'input'   => array(
+					'post_id' => $post_id,
+					'edits'   => $edits,
+				),
+			) );
+
+			return array(
+				'success' => true,
+				'preview' => true,
+				'post_id' => $post_id,
+				'diff_id' => $diff_id,
+				'diff'    => array(
+					'diffId'             => $diff_id,
+					'diffType'           => 'edit',
+					'originalContent'    => implode( "\n", array_column( $diffs, 'originalContent' ) ),
+					'replacementContent' => implode( "\n", array_column( $diffs, 'replacementContent' ) ),
+					'edits'              => $diffs,
+				),
+				'changes_applied' => $changes,
+				'message'         => 'Preview generated. Accept or reject to apply changes.',
+			);
+		}
+
+		// --- Normal mode: apply immediately ---
+		$result = wp_update_post(
 			array(
 				'ID'           => $post_id,
 				'post_content' => $new_content,

--- a/inc/Abilities/Content/PendingDiffStore.php
+++ b/inc/Abilities/Content/PendingDiffStore.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * PendingDiffStore — server-side storage for preview diffs awaiting resolution.
+ *
+ * When an edit/replace ability runs in preview mode, the pending edit is
+ * stored here instead of being applied. The resolve endpoint later retrieves
+ * and applies (or discards) the stored edit.
+ *
+ * Uses WordPress transients with a 1-hour TTL. Pending diffs auto-expire
+ * if never resolved.
+ *
+ * @package DataMachine\Abilities\Content
+ * @since 0.60.0
+ */
+
+namespace DataMachine\Abilities\Content;
+
+defined( 'ABSPATH' ) || exit;
+
+class PendingDiffStore {
+
+	/** Transient TTL in seconds (1 hour). */
+	private const TTL = HOUR_IN_SECONDS;
+
+	/** Transient key prefix. */
+	private const PREFIX = 'dm_pending_diff_';
+
+	/**
+	 * Store a pending diff.
+	 *
+	 * @param string $diff_id   Unique diff identifier.
+	 * @param array  $diff_data The pending edit data.
+	 * @return bool Whether the transient was set.
+	 */
+	public static function store( string $diff_id, array $diff_data ): bool {
+		$diff_data['stored_at'] = time();
+		$diff_data['diff_id']   = $diff_id;
+
+		return set_transient( self::PREFIX . $diff_id, $diff_data, self::TTL );
+	}
+
+	/**
+	 * Retrieve a pending diff.
+	 *
+	 * @param string $diff_id Diff identifier.
+	 * @return array|null The diff data, or null if not found / expired.
+	 */
+	public static function get( string $diff_id ): ?array {
+		$data = get_transient( self::PREFIX . $diff_id );
+
+		if ( false === $data || ! is_array( $data ) ) {
+			return null;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Delete a pending diff (after resolution).
+	 *
+	 * @param string $diff_id Diff identifier.
+	 * @return bool Whether the transient was deleted.
+	 */
+	public static function delete( string $diff_id ): bool {
+		return delete_transient( self::PREFIX . $diff_id );
+	}
+
+	/**
+	 * Generate a unique diff ID.
+	 *
+	 * @return string A unique diff identifier.
+	 */
+	public static function generate_id(): string {
+		return 'diff_' . wp_generate_uuid4();
+	}
+}

--- a/inc/Abilities/Content/ReplacePostBlocksAbility.php
+++ b/inc/Abilities/Content/ReplacePostBlocksAbility.php
@@ -46,23 +46,27 @@ class ReplacePostBlocksAbility {
 								'description' => __( 'Post ID to edit', 'data-machine' ),
 							),
 							'replacements' => array(
-								'type'        => 'array',
-								'description' => __( 'Array of block replacement operations', 'data-machine' ),
-								'items'       => array(
-									'type'       => 'object',
-									'required'   => array( 'block_index', 'new_content' ),
-									'properties' => array(
-										'block_index' => array(
-											'type'        => 'integer',
-											'description' => __( 'Zero-based block index to replace', 'data-machine' ),
-										),
-										'new_content' => array(
-											'type'        => 'string',
-											'description' => __( 'New innerHTML for the block', 'data-machine' ),
-										),
+							'type'        => 'array',
+							'description' => __( 'Array of block replacement operations', 'data-machine' ),
+							'items'       => array(
+								'type'       => 'object',
+								'required'   => array( 'block_index', 'new_content' ),
+								'properties' => array(
+									'block_index' => array(
+										'type'        => 'integer',
+										'description' => __( 'Zero-based block index to replace', 'data-machine' ),
+									),
+									'new_content' => array(
+										'type'        => 'string',
+										'description' => __( 'New innerHTML for the block', 'data-machine' ),
 									),
 								),
 							),
+						),
+						'preview'      => array(
+							'type'        => 'boolean',
+							'description' => __( 'When true, return diff preview without applying changes', 'data-machine' ),
+						),
 						),
 					),
 					'output_schema'       => array(
@@ -114,7 +118,7 @@ class ReplacePostBlocksAbility {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handleChatToolCall',
-			'description' => 'Replace entire Gutenberg block content by index. Use get_post_blocks first to find the right indices. Ideal for AI-rewritten paragraphs.',
+			'description' => 'Replace entire Gutenberg block content by index. Use get_post_blocks first to find the right indices. Ideal for AI-rewritten paragraphs. Set preview=true to return a diff preview without applying changes.',
 			'parameters'  => array(
 				'post_id'      => array(
 					'type'        => 'integer',
@@ -125,6 +129,10 @@ class ReplacePostBlocksAbility {
 					'type'        => 'array',
 					'required'    => true,
 					'description' => 'Array of { block_index, new_content } operations',
+				),
+				'preview'      => array(
+					'type'        => 'boolean',
+					'description' => 'When true, return diff preview data without applying changes. The user can then accept or reject.',
 				),
 			),
 		);
@@ -157,6 +165,7 @@ class ReplacePostBlocksAbility {
 	public static function execute( array $input ): array {
 		$post_id      = absint( $input['post_id'] ?? 0 );
 		$replacements = $input['replacements'] ?? array();
+		$preview      = ! empty( $input['preview'] );
 
 		if ( $post_id <= 0 ) {
 			return array(
@@ -226,11 +235,13 @@ class ReplacePostBlocksAbility {
 			}
 
 			$changes[] = array(
-				'block_index' => $block_index,
-				'block_name'  => $blocks[ $block_index ]['blockName'] ?? 'unknown',
-				'old_length'  => strlen( $old_html ),
-				'new_length'  => strlen( $new_content ),
-				'success'     => true,
+				'block_index'        => $block_index,
+				'block_name'         => $blocks[ $block_index ]['blockName'] ?? 'unknown',
+				'old_length'         => strlen( $old_html ),
+				'new_length'         => strlen( $new_content ),
+				'originalContent'    => $old_html,
+				'replacementContent' => $new_content,
+				'success'            => true,
 			);
 		}
 
@@ -246,7 +257,55 @@ class ReplacePostBlocksAbility {
 		}
 
 		$new_content = BlockSanitizer::sanitizeAndSerialize( $blocks );
-		$result      = wp_update_post(
+
+		// --- Preview mode: store pending edit, return diff data ---
+		if ( $preview ) {
+			$diff_id = PendingDiffStore::generate_id();
+
+			// Build per-block diff data for the frontend.
+			$diffs = array();
+			foreach ( $successful as $change ) {
+				$diffs[] = array(
+					'block_index'        => $change['block_index'],
+					'originalContent'    => $change['originalContent'],
+					'replacementContent' => $change['replacementContent'],
+				);
+			}
+
+			PendingDiffStore::store( $diff_id, array(
+				'type'    => 'replace_post_blocks',
+				'post_id' => $post_id,
+				'input'   => array(
+					'post_id'      => $post_id,
+					'replacements' => $replacements,
+				),
+			) );
+
+			// Strip raw HTML from the changes returned to the AI.
+			$clean_changes = array_map( function ( $c ) {
+				unset( $c['originalContent'], $c['replacementContent'] );
+				return $c;
+			}, $changes );
+
+			return array(
+				'success' => true,
+				'preview' => true,
+				'post_id' => $post_id,
+				'diff_id' => $diff_id,
+				'diff'    => array(
+					'diffId'             => $diff_id,
+					'diffType'           => 'replace',
+					'originalContent'    => implode( "\n", array_column( $diffs, 'originalContent' ) ),
+					'replacementContent' => implode( "\n", array_column( $diffs, 'replacementContent' ) ),
+					'replacements'       => $diffs,
+				),
+				'blocks_replaced' => $clean_changes,
+				'message'         => 'Preview generated. Accept or reject to apply changes.',
+			);
+		}
+
+		// --- Normal mode: apply immediately ---
+		$result = wp_update_post(
 			array(
 				'ID'           => $post_id,
 				'post_content' => $new_content,
@@ -273,11 +332,17 @@ class ReplacePostBlocksAbility {
 			)
 		);
 
+		// Strip raw HTML from changes in normal mode too (not needed in response).
+		$clean_changes = array_map( function ( $c ) {
+			unset( $c['originalContent'], $c['replacementContent'] );
+			return $c;
+		}, $changes );
+
 		return array(
 			'success'         => true,
 			'post_id'         => $post_id,
 			'post_url'        => get_permalink( $post_id ),
-			'blocks_replaced' => $changes,
+			'blocks_replaced' => $clean_changes,
 		);
 	}
 }

--- a/inc/Abilities/Content/ResolveDiffAbility.php
+++ b/inc/Abilities/Content/ResolveDiffAbility.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * ResolveDiffAbility — accept or reject a pending diff.
+ *
+ * When a content ability runs in preview mode, the pending edit is stored
+ * server-side via PendingDiffStore. This ability retrieves the stored edit
+ * and either applies it (accept) or discards it (reject).
+ *
+ * Provides both an Abilities API registration and a REST endpoint so any
+ * consumer (Roadie, editor, CLI) can resolve diffs universally.
+ *
+ * @package DataMachine\Abilities\Content
+ * @since 0.60.0
+ */
+
+namespace DataMachine\Abilities\Content;
+
+use DataMachine\Abilities\PermissionHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+class ResolveDiffAbility {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
+			return;
+		}
+
+		$this->register_ability();
+		$this->register_rest_route();
+		self::$registered = true;
+	}
+
+	/**
+	 * Register the WordPress ability.
+	 */
+	private function register_ability(): void {
+		$register = function () {
+			wp_register_ability( 'datamachine/resolve-diff', array(
+				'label'               => __( 'Resolve Diff', 'data-machine' ),
+				'description'         => __( 'Accept or reject a pending content diff.', 'data-machine' ),
+				'category'            => 'datamachine',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'diff_id', 'decision' ),
+					'properties' => array(
+						'diff_id'  => array(
+							'type'        => 'string',
+							'description' => __( 'The pending diff identifier.', 'data-machine' ),
+						),
+						'decision' => array(
+							'type'        => 'string',
+							'enum'        => array( 'accepted', 'rejected' ),
+							'description' => __( 'Whether to apply or discard the change.', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'  => array( 'type' => 'boolean' ),
+						'decision' => array( 'type' => 'string' ),
+						'diff_id'  => array( 'type' => 'string' ),
+						'post_id'  => array( 'type' => 'integer' ),
+						'error'    => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( self::class, 'execute' ),
+				'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			) );
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register );
+		}
+	}
+
+	/**
+	 * Register the REST route.
+	 */
+	private function register_rest_route(): void {
+		add_action( 'rest_api_init', function () {
+			register_rest_route( 'datamachine/v1', '/diff/resolve', array(
+				'methods'             => 'POST',
+				'callback'            => array( self::class, 'handle_rest' ),
+				'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
+				'args'                => array(
+					'diff_id'  => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'decision' => array(
+						'required'          => true,
+						'type'              => 'string',
+						'enum'              => array( 'accepted', 'rejected' ),
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			) );
+		} );
+	}
+
+	/**
+	 * REST handler — delegates to execute.
+	 *
+	 * @param \WP_REST_Request $request The REST request.
+	 * @return \WP_REST_Response
+	 */
+	public static function handle_rest( \WP_REST_Request $request ): \WP_REST_Response {
+		$result = self::execute( array(
+			'diff_id'  => $request->get_param( 'diff_id' ),
+			'decision' => $request->get_param( 'decision' ),
+		) );
+
+		return new \WP_REST_Response( $result, $result['success'] ? 200 : 400 );
+	}
+
+	/**
+	 * Execute: accept or reject a pending diff.
+	 *
+	 * Accept → re-run the original ability without preview to apply the write.
+	 * Reject → discard the stored edit, no changes made.
+	 *
+	 * @param array $input { diff_id, decision }.
+	 * @return array
+	 */
+	public static function execute( array $input ): array {
+		$diff_id  = $input['diff_id'] ?? '';
+		$decision = $input['decision'] ?? '';
+
+		if ( '' === $diff_id || '' === $decision ) {
+			return array(
+				'success' => false,
+				'error'   => 'diff_id and decision are required.',
+			);
+		}
+
+		if ( ! in_array( $decision, array( 'accepted', 'rejected' ), true ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'decision must be "accepted" or "rejected".',
+			);
+		}
+
+		$pending = PendingDiffStore::get( $diff_id );
+
+		if ( null === $pending ) {
+			return array(
+				'success' => false,
+				'error'   => 'Pending diff not found or expired.',
+				'diff_id' => $diff_id,
+			);
+		}
+
+		$post_id = absint( $pending['post_id'] ?? 0 );
+		$type    = $pending['type'] ?? '';
+
+		// Verify the user can edit this post.
+		if ( $post_id > 0 && ! current_user_can( 'edit_post', $post_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'You do not have permission to edit this post.',
+				'diff_id' => $diff_id,
+			);
+		}
+
+		// Always clean up the stored diff.
+		PendingDiffStore::delete( $diff_id );
+
+		// Reject: nothing to do, just discard.
+		if ( 'rejected' === $decision ) {
+			do_action( 'datamachine_diff_resolved', $decision, $diff_id, $post_id, $type );
+
+			return array(
+				'success'  => true,
+				'decision' => 'rejected',
+				'diff_id'  => $diff_id,
+				'post_id'  => $post_id,
+			);
+		}
+
+		// Accept: re-execute the original ability without preview.
+		$original_input = $pending['input'] ?? array();
+
+		$apply_result = self::apply( $type, $original_input );
+
+		do_action( 'datamachine_diff_resolved', $decision, $diff_id, $post_id, $type );
+
+		if ( ! $apply_result['success'] ) {
+			return array(
+				'success'  => false,
+				'decision' => 'accepted',
+				'diff_id'  => $diff_id,
+				'post_id'  => $post_id,
+				'error'    => $apply_result['error'] ?? 'Failed to apply the pending edit.',
+			);
+		}
+
+		return array(
+			'success'  => true,
+			'decision' => 'accepted',
+			'diff_id'  => $diff_id,
+			'post_id'  => $post_id,
+			'post_url' => $apply_result['post_url'] ?? '',
+		);
+	}
+
+	/**
+	 * Re-execute the original ability to apply the write.
+	 *
+	 * @param string $type  The ability type ('edit_post_blocks' or 'replace_post_blocks').
+	 * @param array  $input The original input parameters (without preview).
+	 * @return array
+	 */
+	private static function apply( string $type, array $input ): array {
+		// Ensure preview is not set — we want the real write.
+		unset( $input['preview'] );
+
+		switch ( $type ) {
+			case 'edit_post_blocks':
+				return EditPostBlocksAbility::execute( $input );
+
+			case 'replace_post_blocks':
+				return ReplacePostBlocksAbility::execute( $input );
+
+			default:
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'Unknown pending diff type: %s', $type ),
+				);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Preview mode** for `EditPostBlocksAbility` and `ReplacePostBlocksAbility` — when `preview: true`, abilities compute the diff without saving. Pending edit stored server-side via `PendingDiffStore`.
- **`ResolveDiffAbility`** — universal accept/reject with REST endpoint at `/datamachine/v1/diff/resolve`. Retrieves stored edit, re-executes the original ability (accept) or discards (reject).
- **`PendingDiffStore`** — transient-backed storage with 1hr TTL for pending diffs.

## Architecture

```
                  preview: true
AI tool call ──────────────────► Ability computes diff
                                      │
                                      ▼
                              PendingDiffStore
                              (transient, 1hr TTL)
                                      │
                          ┌───────────┼───────────┐
                          ▼           │           ▼
                      DiffCard        │     datamachine/diff
                     (Roadie)         │       (Gutenberg)
                          │           │           │
                          ▼           │           ▼
                  POST /diff/resolve  │  POST /editor/diff/resolve
                          │           │           │
                          └───────────┼───────────┘
                                      ▼
                            ResolveDiffAbility
                         (re-execute or discard)
```

## Phase 2 of the Portable Diff System

```
Phase 1: DiffCard + toolRenderers in @extrachill/chat ✅ (merged)
Phase 2: preview_mode + resolve in DM core (this PR)
Phase 3: onToolCalls handler in Roadie (next)
```

## Preview response shape

Both abilities return this when `preview: true`:

```json
{
  "success": true,
  "preview": true,
  "post_id": 123,
  "diff_id": "diff_abc-123",
  "diff": {
    "diffId": "diff_abc-123",
    "diffType": "edit",
    "originalContent": "Hello world",
    "replacementContent": "Hello universe",
    "edits": [...]
  },
  "message": "Preview generated. Accept or reject to apply changes."
}
```

This maps directly to `DiffData` from `@extrachill/chat`'s `DiffCard` component.

## Backwards compatible

- Without `preview` parameter, abilities behave exactly as before (immediate apply)
- Existing callers (CLI `BlocksCommand`, `UpdateWordPressAbility`, `InternalLinkingTask`) are unaffected
- Chat tool definitions now expose `preview` as an optional parameter