### PR TITLE
feat: add datamachine_can_access_agent filter

### DIFF
--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -460,7 +460,23 @@ class PermissionHelper {
 
 		// Check explicit access grants.
 		$access_repo = new \DataMachine\Core\Database\Agents\AgentAccess();
-		return $access_repo->user_can_access( $agent_id, $user_id, $minimum_role );
+		$can_access  = $access_repo->user_can_access( $agent_id, $user_id, $minimum_role );
+
+		/**
+		 * Filter whether a user can access an agent.
+		 *
+		 * Allows plugins to grant or deny agent access based on custom logic
+		 * (e.g. team membership, organization roles, subscription status).
+		 * Returning true from this filter overrides the default access check.
+		 *
+		 * @since 0.62.0
+		 *
+		 * @param bool   $can_access   Whether the user can access the agent.
+		 * @param int    $agent_id     Agent ID.
+		 * @param int    $user_id      User ID.
+		 * @param string $minimum_role Minimum role required.
+		 */
+		return apply_filters( 'datamachine_can_access_agent', $can_access, $agent_id, $user_id, $minimum_role );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds a `datamachine_can_access_agent` filter to `PermissionHelper::can_access_agent()`, allowing plugins to grant or deny agent access based on custom logic (e.g. team membership, organization roles, subscription status).

## What changed

- `inc/Abilities/PermissionHelper.php` — `can_access_agent()` now applies `datamachine_can_access_agent` filter after the default access check (admin/owner/explicit grants)

## Filter signature

```php
apply_filters( 'datamachine_can_access_agent', bool $can_access, int $agent_id, int $user_id, string $minimum_role )
```

Consumers can return `true` to grant access or `false` to deny, overriding the default.

## Why

The frontend chat widget (`data-machine-frontend-chat`) uses `can_access_agent()` to determine widget visibility. EC has a custom team membership system (`ec_is_team_member()`) that needs to grant access to the roadie agent. Without this filter, there's no way for external plugins to extend agent access without directly inserting rows into `agent_access`.

## Testing

- Existing tests should pass — the filter only adds a `apply_filters` call, defaulting to the existing `$can_access` value
- No behavior change without a consumer hooking the filter