### PR TITLE
fix: update .buildignore to exclude staging dir instead of build/

### DIFF
--- a/.buildignore
+++ b/.buildignore
@@ -8,10 +8,10 @@
 .eslintrc.js
 **/.eslintrc.js
 
-# Build system (exclude build files but not the final product)
+# Build system
 build.sh
 .buildignore
-/build/
+/.homeboy-build/
 
 # Testing
 tests/


### PR DESCRIPTION
## Summary

- Replace `/build/` exclusion with `/.homeboy-build/` in `.buildignore`
- The build script now uses `.homeboy-build/` as the staging directory (Extra-Chill/homeboy-extensions#180), so excluding `/build/` was preventing `@wordpress/scripts` webpack output from being included in the production ZIP
- This is the Data Machine companion change for homeboy#1085

Ref: Extra-Chill/homeboy#1085