### PR TITLE
Fix flows create --step_configs not applying handler configs

### DIFF
--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -517,16 +517,56 @@ trait FlowHelpers {
 				continue;
 			}
 
+			// Normalize plural forms to the singular keys that UpdateFlowStepAbility expects.
+			// CLI and admin UI naturally pass handler_slugs (array) and handler_configs (keyed object),
+			// but the ability expects handler_slug (string) and handler_config (object).
+			$handler_slugs  = $config['handler_slugs'] ?? array();
+			$handler_configs = $config['handler_configs'] ?? array();
+
+			// If singular forms are provided, use those directly (backward compat with --handler-config path).
+			$single_slug   = $config['handler_slug'] ?? '';
+			$single_config = $config['handler_config'] ?? array();
+
+			// When handler_slugs is provided, add each handler with its config from handler_configs.
+			if ( ! empty( $handler_slugs ) ) {
+				foreach ( $handler_slugs as $slug ) {
+					$slug_config = $handler_configs[ $slug ] ?? array();
+					$add_result  = $flow_step_abilities->executeUpdateFlowStep(
+						array(
+							'flow_step_id'     => $flow_step_id,
+							'add_handler'      => $slug,
+							'add_handler_config' => $slug_config,
+						)
+					);
+					if ( ! $add_result['success'] ) {
+						$errors[] = array(
+							'step_type'    => $step_type,
+							'flow_step_id' => $flow_step_id,
+							'handler'      => $slug,
+							'error'        => $add_result['error'] ?? 'Failed to add handler',
+						);
+					}
+				}
+			}
+
+			// Build the base update input for singular handler_slug / handler_config / user_message.
 			$update_input = array( 'flow_step_id' => $flow_step_id );
 
-			if ( ! empty( $config['handler_slug'] ) ) {
-				$update_input['handler_slug'] = $config['handler_slug'];
+			if ( ! empty( $single_slug ) ) {
+				$update_input['handler_slug'] = $single_slug;
 			}
-			if ( ! empty( $config['handler_config'] ) ) {
-				$update_input['handler_config'] = $config['handler_config'];
+			if ( ! empty( $single_config ) ) {
+				$update_input['handler_config'] = $single_config;
 			}
 			if ( ! empty( $config['user_message'] ) ) {
 				$update_input['user_message'] = $config['user_message'];
+			}
+
+			// Only call update if there's something beyond the flow_step_id to apply.
+			if ( count( $update_input ) <= 1 && ! empty( $handler_slugs ) ) {
+				// Already handled via add_handler above — mark as applied.
+				$applied[] = $flow_step_id;
+				continue;
 			}
 
 			$result = $flow_step_abilities->executeUpdateFlowStep( $update_input );


### PR DESCRIPTION
Closes #1001

## Summary

- `applyStepConfigsToFlow()` in `FlowHelpers` only accepted singular `handler_slug` and `handler_config` keys, but the CLI `--step_configs` JSON and admin UI pass plural forms (`handler_slugs` array and `handler_configs` keyed object)
- This caused `flows create --step_configs` to create steps with empty handler configs, requiring 3 separate commands per step as a workaround

## Fix

`applyStepConfigsToFlow()` now handles both plural and singular forms:
- **`handler_slugs`** (array): iterates each slug and calls `add_handler` with its matching config from `handler_configs`
- **`handler_slug`/`handler_config`** (singular): still works as before for backward compat with the `--handler-config` CLI path

## Before

```bash
# This left handler_configs empty:
wp datamachine flows create --pipeline_id=205 --name="Bar Freda" \
  --step_configs='{"event_import":{"handler_slugs":["universal_web_scraper"],"handler_configs":{"universal_web_scraper":{"source_url":"..."}}}}'

# Required 3 separate commands per step as workaround:
wp datamachine flows add-handler 716 --handler=universal_web_scraper --step=...
wp datamachine flows update 716 --step=... --handler-config='{...}'
```

## After

The single `flows create --step_configs` command works correctly — handlers and their configs are applied in one shot.