### PR TITLE
fix: scaffold shared-layer files (RULES.md) during agent creation

### DIFF
--- a/inc/migrations.php
+++ b/inc/migrations.php
@@ -1093,6 +1093,7 @@ function datamachine_ensure_default_memory_files(): bool {
 
 	$default_user_id = \DataMachine\Core\FilesRepository\DirectoryManager::get_default_agent_user_id();
 
+	$ability->execute( array( 'layer' => 'shared' ) );
 	$ability->execute( array( 'layer' => 'agent', 'user_id' => $default_user_id ) );
 	$ability->execute( array( 'layer' => 'user', 'user_id' => $default_user_id ) );
 

--- a/inc/migrations/scaffolding.php
+++ b/inc/migrations/scaffolding.php
@@ -245,6 +245,7 @@ function datamachine_ensure_default_memory_files(): bool {
 		return false;
 	}
 
+	$ability->execute( array( 'layer' => 'shared' ) );
 	$ability->execute( array_merge( $scaffold_context, array( 'layer' => 'agent' ) ) );
 	$ability->execute( array_merge( $scaffold_context, array( 'layer' => 'user' ) ) );
 


### PR DESCRIPTION
## Summary

- `datamachine_ensure_default_memory_files()` scaffolded agent and user layers but never the shared layer
- RULES.md was registered in `MemoryFileRegistry` with a content generator but never actually created on disk
- Adds `$ability->execute( array( 'layer' => 'shared' ) )` before the agent/user layer scaffolds

## Root Cause

The function only called scaffold for `layer: agent` and `layer: user`. RULES.md is registered at `layer: shared` (bootstrap.php line 100), so it was invisible to the scaffolding flow. The content generator (`datamachine_scaffold_rules_content`) existed and worked — it just never got invoked.

## Changes

Both copies of `datamachine_ensure_default_memory_files()` are fixed:
- `inc/migrations.php` (active monolith)
- `inc/migrations/scaffolding.php` (split refactor, not yet loaded)

**Note:** The split `inc/migrations/` directory is never loaded — `data-machine.php` still requires the monolith. Both were fixed so the split is ready when it ships.

## What about NETWORK.md?

NETWORK.md is also at a non-scaffolded layer (network), but it's `editable: false` and auto-generated with its own regeneration system (`datamachine_regenerate_network_md()`). It doesn't need scaffolding through this path.

Fixes #1030