### PR TITLE
feat: OAuth2 support for public clients, implicit flow, and PKCE

### DIFF
--- a/inc/Core/OAuth/BaseOAuth2Provider.php
+++ b/inc/Core/OAuth/BaseOAuth2Provider.php
@@ -564,6 +564,94 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 	 */
 	abstract public function handle_oauth_callback();
 
+	// -------------------------------------------------------------------------
+	// Flow Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Build authorization URL parameters with PKCE support.
+	 *
+	 * Call this from get_authorization_url() to get base params including
+	 * state, response_type, redirect_uri, and PKCE params if enabled.
+	 * Merge the result with provider-specific params (client_id, scope, etc.).
+	 *
+	 * Example usage in a provider's get_authorization_url():
+	 *
+	 *     $params = array_merge(
+	 *         $this->build_auth_url_params(),
+	 *         array( 'client_id' => $config['client_id'], 'scope' => 'global' )
+	 *     );
+	 *     return $this->oauth2->get_authorization_url( $auth_endpoint, $params );
+	 *
+	 * @since 0.66.0
+	 * @return array Query parameters for the authorization URL.
+	 */
+	protected function build_auth_url_params(): array {
+		$params = array(
+			'response_type' => $this->get_oauth_response_type(),
+			'redirect_uri'  => $this->get_callback_url(),
+			'state'         => $this->oauth2->create_state( $this->provider_slug ),
+		);
+
+		if ( $this->uses_pkce() ) {
+			$pkce = $this->oauth2->create_pkce( $this->provider_slug );
+			$params['code_challenge']        = $pkce['challenge'];
+			$params['code_challenge_method'] = $pkce['method'];
+		}
+
+		return $params;
+	}
+
+	/**
+	 * Dispatch an implicit flow callback request.
+	 *
+	 * Call this from handle_oauth_callback() for providers using implicit flow
+	 * (get_oauth_response_type() returns 'token'). Handles both phases:
+	 *
+	 * 1. Initial redirect (no POST data) → renders the JS callback page that
+	 *    extracts the access_token from the URL fragment.
+	 * 2. JS POST (datamachine_implicit_flow=1) → processes the token server-side
+	 *    via handle_implicit_callback().
+	 *
+	 * Example usage in a provider's handle_oauth_callback():
+	 *
+	 *     public function handle_oauth_callback() {
+	 *         $this->dispatch_implicit_callback(
+	 *             fn( array $token_data ) => $this->build_account_from_token( $token_data ),
+	 *             fn( array $account )    => $this->save_account( $account )
+	 *         );
+	 *     }
+	 *
+	 * @since 0.66.0
+	 * @param callable      $account_details_fn Callback to build account data from token data.
+	 *                                          Signature: function(array $token_data): array|WP_Error
+	 * @param callable|null $storage_fn         Callback to store account data.
+	 *                                          Signature: function(array $account_data): bool
+	 *                                          Defaults to $this->save_account() if null.
+	 * @return void Outputs and exits.
+	 */
+	protected function dispatch_implicit_callback( callable $account_details_fn, ?callable $storage_fn = null ): void {
+		$storage_fn = $storage_fn ?? array( $this, 'save_account' );
+
+		// Phase 2: JS has POSTed the token back to us.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified inside handle_implicit_callback.
+		if ( ! empty( $_POST['datamachine_implicit_flow'] ) ) {
+			$this->oauth2->handle_implicit_callback(
+				$this->provider_slug,
+				$account_details_fn,
+				$storage_fn
+			);
+			return; // handle_implicit_callback exits, but just in case.
+		}
+
+		// Phase 1: Provider redirected here with token in URL fragment.
+		// Serve the JS page to extract it.
+		$this->oauth2->render_implicit_callback_page(
+			$this->provider_slug,
+			$this->get_callback_url()
+		);
+	}
+
 	/**
 	 * Refresh token (Legacy — use get_valid_access_token() instead)
 	 *

--- a/inc/Core/OAuth/BaseOAuth2Provider.php
+++ b/inc/Core/OAuth/BaseOAuth2Provider.php
@@ -47,15 +47,74 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 	}
 
 	/**
-	 * Check if provider is properly configured
+	 * Whether this provider requires a client_secret.
+	 *
+	 * Public OAuth2 clients (e.g. WordPress.com implicit flow) don't use a
+	 * client_secret. Subclasses override this to return false when the provider
+	 * is a public client.
+	 *
+	 * @since 0.66.0
+	 * @return bool True if a client_secret is required (default). False for public clients.
+	 */
+	protected function requires_client_secret(): bool {
+		return true;
+	}
+
+	/**
+	 * Get the OAuth2 response type for this provider.
+	 *
+	 * Returns 'code' for standard authorization code flow (default).
+	 * Returns 'token' for implicit flow (legacy public clients).
+	 *
+	 * When 'token' is returned, the callback page renders a JS snippet that
+	 * extracts the access_token from the URL fragment and POSTs it to the
+	 * server via OAuth2Handler::handle_implicit_callback().
+	 *
+	 * @since 0.66.0
+	 * @return string 'code' or 'token'.
+	 */
+	public function get_oauth_response_type(): string {
+		return 'code';
+	}
+
+	/**
+	 * Whether this provider uses PKCE (Proof Key for Code Exchange).
+	 *
+	 * PKCE is the modern replacement for the implicit flow. It allows
+	 * public clients (no client_secret) to use the authorization code
+	 * flow securely by generating a one-time code_verifier/code_challenge
+	 * pair for each authorization request.
+	 *
+	 * When true, OAuth2Handler automatically:
+	 * - Generates code_verifier and code_challenge
+	 * - Stores code_verifier in a transient
+	 * - Adds code_challenge + code_challenge_method to the auth URL
+	 * - Includes code_verifier in the token exchange request
+	 *
+	 * @since 0.66.0
+	 * @return bool True to use PKCE. Default false.
+	 */
+	public function uses_pkce(): bool {
+		return false;
+	}
+
+	/**
+	 * Check if provider is properly configured.
+	 *
+	 * Requires client_id for all providers. Requires client_secret only when
+	 * requires_client_secret() returns true (the default). Public clients
+	 * override requires_client_secret() to skip the secret check.
 	 *
 	 * @return bool True if configured
 	 */
 	public function is_configured(): bool {
 		$config = $this->get_config();
-		// Default check: client_id and client_secret exist
-		// Can be overridden by child classes if keys differ (e.g. app_id vs client_id)
-		return ! empty( $config['client_id'] ) && ! empty( $config['client_secret'] );
+
+		if ( empty( $config['client_id'] ) ) {
+			return false;
+		}
+
+		return ! $this->requires_client_secret() || ! empty( $config['client_secret'] );
 	}
 
 	/**

--- a/inc/Core/OAuth/OAuth2Handler.php
+++ b/inc/Core/OAuth/OAuth2Handler.php
@@ -3,7 +3,11 @@
  * OAuth 2.0 Handler
  *
  * Centralized OAuth 2.0 flow implementation for all OAuth2 providers.
- * Eliminates code duplication across Reddit, Facebook, Threads, and Google Sheets handlers.
+ * Supports three flow types:
+ *
+ * 1. Authorization Code (default) — server apps with a client_secret.
+ * 2. Authorization Code + PKCE — modern public clients, no secret needed.
+ * 3. Implicit (legacy) — token returned in URL fragment, no secret needed.
  *
  * @package DataMachine
  * @subpackage Core\OAuth
@@ -19,6 +23,10 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 class OAuth2Handler {
+
+	// -------------------------------------------------------------------------
+	// State Management
+	// -------------------------------------------------------------------------
 
 	/**
 	 * Create OAuth state nonce and store in transient.
@@ -71,6 +79,84 @@ class OAuth2Handler {
 		return $is_valid;
 	}
 
+	// -------------------------------------------------------------------------
+	// PKCE (Proof Key for Code Exchange)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Generate and store a PKCE code_verifier/code_challenge pair.
+	 *
+	 * The code_verifier is stored in a transient and included in the token
+	 * exchange request. The code_challenge is sent with the authorization URL.
+	 *
+	 * Uses S256 method (SHA-256 hash of the verifier, base64url-encoded).
+	 *
+	 * @since 0.66.0
+	 * @param string $provider_key Provider identifier.
+	 * @return array{verifier: string, challenge: string, method: string} PKCE parameters.
+	 */
+	public function create_pkce( string $provider_key ): array {
+		// Generate a random 32-byte verifier (43-128 chars when base64url-encoded per RFC 7636).
+		$verifier = $this->base64url_encode( random_bytes( 32 ) );
+
+		// S256: SHA-256 hash of the verifier, base64url-encoded.
+		$challenge = $this->base64url_encode( hash( 'sha256', $verifier, true ) );
+
+		// Store verifier for token exchange (15 minutes, same as state).
+		set_transient( "datamachine_{$provider_key}_pkce_verifier", $verifier, 15 * MINUTE_IN_SECONDS );
+
+		do_action(
+			'datamachine_log',
+			'debug',
+			'OAuth2: Created PKCE challenge',
+			array(
+				'provider' => $provider_key,
+				'method'   => 'S256',
+			)
+		);
+
+		return array(
+			'verifier'  => $verifier,
+			'challenge' => $challenge,
+			'method'    => 'S256',
+		);
+	}
+
+	/**
+	 * Retrieve and consume the stored PKCE code_verifier.
+	 *
+	 * The verifier is deleted after retrieval (one-time use).
+	 *
+	 * @since 0.66.0
+	 * @param string $provider_key Provider identifier.
+	 * @return string|null Code verifier, or null if not found/expired.
+	 */
+	public function get_pkce_verifier( string $provider_key ): ?string {
+		$verifier = get_transient( "datamachine_{$provider_key}_pkce_verifier" );
+
+		if ( false === $verifier ) {
+			return null;
+		}
+
+		delete_transient( "datamachine_{$provider_key}_pkce_verifier" );
+		return $verifier;
+	}
+
+	/**
+	 * Base64url-encode a string (RFC 4648 §5, no padding).
+	 *
+	 * @since 0.66.0
+	 * @param string $data Raw binary data.
+	 * @return string Base64url-encoded string.
+	 */
+	private function base64url_encode( string $data ): string {
+		return rtrim( strtr( base64_encode( $data ), '+/', '-_' ), '=' );
+	}
+
+	// -------------------------------------------------------------------------
+	// Authorization URL
+	// -------------------------------------------------------------------------
+
 	/**
 	 * Build authorization URL with parameters.
 	 *
@@ -94,11 +180,18 @@ class OAuth2Handler {
 		return $url;
 	}
 
+	// -------------------------------------------------------------------------
+	// Authorization Code Flow (with optional PKCE)
+	// -------------------------------------------------------------------------
+
 	/**
-	 * Handle OAuth2 callback flow.
+	 * Handle OAuth2 authorization code callback flow.
 	 *
 	 * Verifies state, exchanges authorization code for access token, retrieves account details,
 	 * stores account data, and redirects with success/error messages.
+	 *
+	 * When PKCE is enabled, the stored code_verifier is automatically included
+	 * in the token exchange parameters.
 	 *
 	 * @param string        $provider_key Provider identifier.
 	 * @param string        $token_url Token exchange endpoint URL.
@@ -156,6 +249,19 @@ class OAuth2Handler {
 
 			$this->redirect_with_error( $provider_key, 'invalid_state' );
 			return new \WP_Error( 'invalid_state', __( 'Invalid OAuth state.', 'data-machine' ) );
+		}
+
+		// Include PKCE code_verifier in token exchange if one was stored.
+		$verifier = $this->get_pkce_verifier( $provider_key );
+		if ( null !== $verifier ) {
+			$token_params['code_verifier'] = $verifier;
+
+			do_action(
+				'datamachine_log',
+				'debug',
+				'OAuth2: Including PKCE code_verifier in token exchange',
+				array( 'provider' => $provider_key )
+			);
 		}
 
 		// Exchange authorization code for access token
@@ -258,6 +364,233 @@ class OAuth2Handler {
 		return true;
 	}
 
+	// -------------------------------------------------------------------------
+	// Implicit Flow
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Render a callback page for OAuth2 implicit flow.
+	 *
+	 * In the implicit flow, the provider redirects to the callback URL with
+	 * the access_token in the URL fragment (#access_token=...&token_type=bearer).
+	 * Fragments never reach the server, so this method renders a minimal HTML
+	 * page with JavaScript that:
+	 *
+	 * 1. Extracts token data from window.location.hash
+	 * 2. POSTs it to the same callback URL with a nonce for verification
+	 * 3. The server-side handle_implicit_callback() processes the token
+	 *
+	 * Called by the provider's handle_oauth_callback() when the request has
+	 * no query parameters (first hit from the redirect with only a fragment).
+	 *
+	 * @since 0.66.0
+	 * @param string $provider_key Provider identifier.
+	 * @param string $callback_url The callback URL to POST the token to.
+	 * @return void Outputs HTML and exits.
+	 */
+	public function render_implicit_callback_page( string $provider_key, string $callback_url ): void {
+		$nonce = wp_create_nonce( "datamachine_implicit_{$provider_key}" );
+
+		// Minimal HTML page — extracts fragment params and POSTs to server.
+		header( 'Content-Type: text/html; charset=utf-8' );
+		echo '<!DOCTYPE html><html><head><title>Authenticating…</title></head><body>';
+		echo '<p>Completing authentication…</p>';
+		echo '<script>';
+		echo 'var hash = window.location.hash.substring(1);';
+		echo 'if (!hash) { document.body.innerHTML = "<p>Authentication failed: no token received.</p>"; }';
+		echo 'else {';
+		echo '  var params = new URLSearchParams(hash);';
+		echo '  var token = params.get("access_token");';
+		echo '  if (!token) { document.body.innerHTML = "<p>Authentication failed: no access token in response.</p>"; }';
+		echo '  else {';
+		echo '    var data = new URLSearchParams();';
+		echo '    data.append("datamachine_implicit_flow", "1");';
+		echo '    data.append("_wpnonce", ' . wp_json_encode( $nonce ) . ');';
+		echo '    data.append("provider", ' . wp_json_encode( $provider_key ) . ');';
+		// Forward all fragment params (access_token, token_type, expires_in, site_id, etc.)
+		echo '    params.forEach(function(v, k) { data.append(k, v); });';
+		echo '    fetch(' . wp_json_encode( $callback_url ) . ', {';
+		echo '      method: "POST",';
+		echo '      headers: { "Content-Type": "application/x-www-form-urlencoded" },';
+		echo '      credentials: "same-origin",';
+		echo '      body: data.toString()';
+		echo '    }).then(function(r) { return r.json(); })';
+		echo '    .then(function(result) {';
+		echo '      if (result.success) {';
+		echo '        if (window.opener) {';
+		echo '          window.opener.postMessage({ type: "oauth_callback", success: true, account: result.data || {} }, window.location.origin);';
+		echo '          window.close();';
+		echo '        } else {';
+		echo '          window.location.href = result.redirect || ' . wp_json_encode( admin_url( 'admin.php?page=datamachine-settings&auth_success=1&provider=' . $provider_key ) ) . ';';
+		echo '        }';
+		echo '      } else {';
+		echo '        document.body.innerHTML = "<p>Authentication failed: " + (result.error || "unknown error") + "</p>";';
+		echo '      }';
+		echo '    }).catch(function(err) {';
+		echo '      document.body.innerHTML = "<p>Authentication failed: " + err.message + "</p>";';
+		echo '    });';
+		echo '  }';
+		echo '}';
+		echo '</script></body></html>';
+		exit;
+	}
+
+	/**
+	 * Handle the server-side POST from the implicit flow callback page.
+	 *
+	 * Verifies the nonce, extracts token data from the POST body, calls
+	 * the account details callback, stores the result, and returns a JSON
+	 * response for the JS callback page to handle.
+	 *
+	 * @since 0.66.0
+	 * @param string        $provider_key       Provider identifier.
+	 * @param callable      $account_details_fn Callback to retrieve account details from token data.
+	 *                                          Receives array with 'access_token', 'token_type',
+	 *                                          'expires_in', and any other fragment params.
+	 *                                          Signature: function(array $token_data): array|WP_Error
+	 * @param callable|null $storage_fn         Optional callback to store account data.
+	 *                                          Signature: function(array $account_data): bool
+	 * @return void Outputs JSON and exits.
+	 */
+	public function handle_implicit_callback(
+		string $provider_key,
+		callable $account_details_fn,
+		?callable $storage_fn = null
+	): void {
+		header( 'Content-Type: application/json; charset=utf-8' );
+
+		// Verify nonce.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Verified manually below.
+		$nonce = isset( $_POST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ) : '';
+
+		if ( ! wp_verify_nonce( $nonce, "datamachine_implicit_{$provider_key}" ) ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'OAuth2: Implicit flow nonce verification failed',
+				array( 'provider' => $provider_key )
+			);
+
+			echo wp_json_encode( array( 'success' => false, 'error' => 'Invalid nonce.' ) );
+			exit;
+		}
+
+		// Build token data from POST params.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
+		$access_token = isset( $_POST['access_token'] ) ? sanitize_text_field( wp_unslash( $_POST['access_token'] ) ) : '';
+
+		if ( empty( $access_token ) ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'OAuth2: Implicit flow missing access_token',
+				array( 'provider' => $provider_key )
+			);
+
+			echo wp_json_encode( array( 'success' => false, 'error' => 'No access token received.' ) );
+			exit;
+		}
+
+		// Collect all token-related POST params.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
+		$token_data = array(
+			'access_token' => $access_token,
+			'token_type'   => isset( $_POST['token_type'] ) ? sanitize_text_field( wp_unslash( $_POST['token_type'] ) ) : 'bearer',
+		);
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
+		if ( isset( $_POST['expires_in'] ) ) {
+			$token_data['expires_in'] = absint( $_POST['expires_in'] );
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
+		if ( isset( $_POST['site_id'] ) ) {
+			$token_data['site_id'] = sanitize_text_field( wp_unslash( $_POST['site_id'] ) );
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified above.
+		if ( isset( $_POST['scope'] ) ) {
+			$token_data['scope'] = sanitize_text_field( wp_unslash( $_POST['scope'] ) );
+		}
+
+		do_action(
+			'datamachine_log',
+			'debug',
+			'OAuth2: Implicit flow token received',
+			array(
+				'provider'   => $provider_key,
+				'token_type' => $token_data['token_type'],
+				'expires_in' => $token_data['expires_in'] ?? 'unknown',
+			)
+		);
+
+		// Get account details using provider-specific callback.
+		$account_data = call_user_func( $account_details_fn, $token_data );
+
+		if ( is_wp_error( $account_data ) ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'OAuth2: Implicit flow account details failed',
+				array(
+					'provider' => $provider_key,
+					'error'    => $account_data->get_error_message(),
+				)
+			);
+
+			echo wp_json_encode( array( 'success' => false, 'error' => $account_data->get_error_message() ) );
+			exit;
+		}
+
+		// Store account data.
+		$stored = false;
+		if ( $storage_fn ) {
+			$stored = call_user_func( $storage_fn, $account_data );
+		}
+
+		if ( ! $stored ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'OAuth2: Implicit flow storage failed',
+				array( 'provider' => $provider_key )
+			);
+
+			echo wp_json_encode( array( 'success' => false, 'error' => 'Failed to store account data.' ) );
+			exit;
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'OAuth2: Implicit flow authentication successful',
+			array(
+				'provider'   => $provider_key,
+				'account_id' => $account_data['id'] ?? 'unknown',
+			)
+		);
+
+		$redirect_url = add_query_arg(
+			array(
+				'page'         => 'datamachine-settings',
+				'auth_success' => '1',
+				'provider'     => $provider_key,
+			),
+			admin_url( 'admin.php' )
+		);
+
+		echo wp_json_encode( array(
+			'success'  => true,
+			'data'     => $account_data,
+			'redirect' => $redirect_url,
+		) );
+		exit;
+	}
+
+	// -------------------------------------------------------------------------
+	// Token Exchange
+	// -------------------------------------------------------------------------
+
 	/**
 	 * Exchange authorization code for access token.
 	 *
@@ -307,6 +640,10 @@ class OAuth2Handler {
 
 		return $token_data;
 	}
+
+	// -------------------------------------------------------------------------
+	// Redirects
+	// -------------------------------------------------------------------------
 
 	/**
 	 * Redirect to admin with error message.

--- a/tests/Unit/Core/OAuth/BaseOAuth2ProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseOAuth2ProviderTest.php
@@ -563,4 +563,176 @@ class BaseOAuth2ProviderTest extends WP_UnitTestCase {
 	public function test_is_configured_returns_false_without_credentials(): void {
 		$this->assertFalse( $this->provider->is_configured() );
 	}
+
+	public function test_is_configured_returns_false_without_secret_for_default_provider(): void {
+		$this->provider->save_config( array( 'client_id' => 'id_123' ) );
+		$this->assertFalse( $this->provider->is_configured() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Public client (no client_secret required)
+	// -------------------------------------------------------------------------
+
+	public function test_public_client_is_configured_without_secret(): void {
+		$provider = new TestPublicOAuth2Provider( 'test_public' );
+		$provider->save_config( array( 'client_id' => '128117' ) );
+
+		$this->assertTrue( $provider->is_configured() );
+
+		delete_site_option( 'datamachine_auth_data' );
+	}
+
+	public function test_public_client_is_not_configured_without_client_id(): void {
+		$provider = new TestPublicOAuth2Provider( 'test_public2' );
+
+		$this->assertFalse( $provider->is_configured() );
+
+		delete_site_option( 'datamachine_auth_data' );
+	}
+
+	public function test_public_client_does_not_require_secret(): void {
+		$provider = new TestPublicOAuth2Provider( 'test_public3' );
+
+		// Access the protected method via reflection for testing.
+		$reflection = new \ReflectionMethod( $provider, 'requires_client_secret' );
+		$reflection->setAccessible( true );
+		$this->assertFalse( $reflection->invoke( $provider ) );
+
+		delete_site_option( 'datamachine_auth_data' );
+	}
+
+	// -------------------------------------------------------------------------
+	// Flow type defaults
+	// -------------------------------------------------------------------------
+
+	public function test_default_response_type_is_code(): void {
+		$this->assertSame( 'code', $this->provider->get_oauth_response_type() );
+	}
+
+	public function test_default_uses_pkce_is_false(): void {
+		$this->assertFalse( $this->provider->uses_pkce() );
+	}
+
+	public function test_implicit_provider_returns_token_response_type(): void {
+		$provider = new TestImplicitOAuth2Provider( 'test_implicit' );
+		$this->assertSame( 'token', $provider->get_oauth_response_type() );
+		delete_site_option( 'datamachine_auth_data' );
+	}
+
+	public function test_pkce_provider_uses_pkce(): void {
+		$provider = new TestPkceOAuth2Provider( 'test_pkce' );
+		$this->assertTrue( $provider->uses_pkce() );
+		$this->assertSame( 'code', $provider->get_oauth_response_type() );
+		delete_site_option( 'datamachine_auth_data' );
+	}
+
+	// -------------------------------------------------------------------------
+	// OAuth2Handler PKCE
+	// -------------------------------------------------------------------------
+
+	public function test_pkce_create_returns_verifier_challenge_method(): void {
+		$handler = new \DataMachine\Core\OAuth\OAuth2Handler();
+		$pkce    = $handler->create_pkce( 'test_pkce_flow' );
+
+		$this->assertArrayHasKey( 'verifier', $pkce );
+		$this->assertArrayHasKey( 'challenge', $pkce );
+		$this->assertArrayHasKey( 'method', $pkce );
+		$this->assertSame( 'S256', $pkce['method'] );
+		$this->assertNotEmpty( $pkce['verifier'] );
+		$this->assertNotEmpty( $pkce['challenge'] );
+		$this->assertNotSame( $pkce['verifier'], $pkce['challenge'] );
+
+		// Clean up transient.
+		delete_transient( 'datamachine_test_pkce_flow_pkce_verifier' );
+	}
+
+	public function test_pkce_verifier_stored_and_retrieved(): void {
+		$handler = new \DataMachine\Core\OAuth\OAuth2Handler();
+		$pkce    = $handler->create_pkce( 'test_pkce_store' );
+
+		$verifier = $handler->get_pkce_verifier( 'test_pkce_store' );
+
+		$this->assertSame( $pkce['verifier'], $verifier );
+	}
+
+	public function test_pkce_verifier_consumed_on_retrieval(): void {
+		$handler = new \DataMachine\Core\OAuth\OAuth2Handler();
+		$handler->create_pkce( 'test_pkce_consume' );
+
+		// First retrieval succeeds.
+		$this->assertNotNull( $handler->get_pkce_verifier( 'test_pkce_consume' ) );
+
+		// Second retrieval returns null (consumed).
+		$this->assertNull( $handler->get_pkce_verifier( 'test_pkce_consume' ) );
+	}
+
+	public function test_pkce_verifier_returns_null_when_not_created(): void {
+		$handler = new \DataMachine\Core\OAuth\OAuth2Handler();
+		$this->assertNull( $handler->get_pkce_verifier( 'nonexistent_provider' ) );
+	}
+
+	public function test_pkce_challenge_is_valid_s256(): void {
+		$handler = new \DataMachine\Core\OAuth\OAuth2Handler();
+		$pkce    = $handler->create_pkce( 'test_pkce_s256' );
+
+		// Verify S256: challenge should be base64url(sha256(verifier)).
+		$expected_hash = hash( 'sha256', $pkce['verifier'], true );
+		$expected_challenge = rtrim( strtr( base64_encode( $expected_hash ), '+/', '-_' ), '=' );
+
+		$this->assertSame( $expected_challenge, $pkce['challenge'] );
+
+		delete_transient( 'datamachine_test_pkce_s256_pkce_verifier' );
+	}
+}
+
+/**
+ * Public client test provider (no client_secret, implicit flow).
+ */
+class TestPublicOAuth2Provider extends TestOAuth2Provider {
+
+	protected function requires_client_secret(): bool {
+		return false;
+	}
+
+	public function get_oauth_response_type(): string {
+		return 'token';
+	}
+
+	public function get_config_fields(): array {
+		return array(
+			'client_id' => array(
+				'label'    => 'Client ID',
+				'type'     => 'text',
+				'required' => true,
+			),
+		);
+	}
+}
+
+/**
+ * Implicit flow test provider.
+ */
+class TestImplicitOAuth2Provider extends TestOAuth2Provider {
+
+	protected function requires_client_secret(): bool {
+		return false;
+	}
+
+	public function get_oauth_response_type(): string {
+		return 'token';
+	}
+}
+
+/**
+ * PKCE flow test provider.
+ */
+class TestPkceOAuth2Provider extends TestOAuth2Provider {
+
+	protected function requires_client_secret(): bool {
+		return false;
+	}
+
+	public function uses_pkce(): bool {
+		return true;
+	}
 }


### PR DESCRIPTION
## Summary

Adds three OAuth2 flow types to the base system so any provider can use the right one:

| Flow | `response_type` | Secret | Override |
|------|----------------|--------|----------|
| **Auth Code** (default) | `code` | Yes | Nothing — existing behavior |
| **Auth Code + PKCE** | `code` | No | `uses_pkce() → true`, `requires_client_secret() → false` |
| **Implicit** (legacy) | `token` | No | `get_oauth_response_type() → 'token'`, `requires_client_secret() → false` |

## Changes

### BaseOAuth2Provider — 3 new override points

- **`requires_client_secret(): bool`** — `false` for public clients. Updates `is_configured()` to skip secret check.
- **`get_oauth_response_type(): string`** — `'token'` for implicit flow. Providers use this when building their auth URL.
- **`uses_pkce(): bool`** — `true` to enable PKCE. OAuth2Handler auto-generates `code_verifier`/`code_challenge` and includes them in auth URL + token exchange.

### OAuth2Handler — PKCE + Implicit flow

**PKCE:**
- `create_pkce($provider)` — generates S256 `code_verifier`/`code_challenge` pair, stores verifier in transient
- `get_pkce_verifier($provider)` — retrieves and consumes stored verifier (one-time use)
- `handle_callback()` — auto-includes `code_verifier` in token exchange when PKCE verifier exists

**Implicit flow:**
- `render_implicit_callback_page($provider, $callback_url)` — serves minimal HTML+JS that extracts `access_token` from URL fragment, POSTs to server with nonce
- `handle_implicit_callback($provider, $account_details_fn, $storage_fn)` — receives POSTed token, verifies nonce, stores account, returns JSON
- Supports both popup (postMessage to opener) and redirect workflows

### Tests — 12 new test cases

- Public client `is_configured()` with/without client_id
- `requires_client_secret()` returns false for public providers
- Default flow type values (`code`, no PKCE)
- Implicit provider returns `token` response type
- PKCE provider returns `uses_pkce() = true`
- PKCE generation: verifier/challenge/method structure
- PKCE S256 validation: `challenge === base64url(sha256(verifier))`
- PKCE verifier storage, retrieval, and one-time consumption

## Backward compatibility

All new methods have defaults that preserve current behavior:
- `requires_client_secret() → true`
- `get_oauth_response_type() → 'code'`
- `uses_pkce() → false`

Existing providers (Reddit, Facebook, Instagram, Threads, Pinterest, LinkedIn) change nothing.

## Context

WordPress.com's ContextA8C client (client_id `128117`) is a public client using implicit flow. The Intelligence plugin needs this to register WordPress.com as an auth provider managed by Data Machine instead of storing tokens in `~/.mcp-auth/` on the filesystem. See chubes4/intelligence#6.

Closes #1034