### PR TITLE
fix: route tool access level checks through PermissionHelper for manage_options fallback

### DIFF
--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -230,8 +230,17 @@ class ToolPolicyResolver {
 			return true;
 		}
 
-		$required_cap = self::ACCESS_LEVELS[ $access_level ] ?? self::ACCESS_LEVELS['admin'];
-		return current_user_can( $required_cap );
+		// Map access levels to PermissionHelper actions for consistent
+		// permission resolution (WP-CLI bypass, manage_options fallback).
+		$action_map = array(
+			'authenticated' => 'chat',
+			'author'        => 'use_tools',
+			'editor'        => 'view_logs',
+			'admin'         => 'manage_settings',
+		);
+
+		$action = $action_map[ $access_level ] ?? 'manage_settings';
+		return \DataMachine\Abilities\PermissionHelper::can( $action );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes a production bug where chat tools are silently empty for admins on installs where `datamachine_register_capabilities()` hasn't re-run after a plugin update (no deactivation/reactivation cycle).

- **Root cause:** `ToolPolicyResolver::checkAccessLevel()` called `current_user_can('datamachine_manage_settings')` directly. Every other permission check in Data Machine routes through `PermissionHelper::can()`, which has a `manage_options` fallback. This method did not.
- **Impact:** Admins without the custom capability see **zero chat tools** — the chat sidebar appears functional but the AI has no tools available.
- **Fix:** Route through `PermissionHelper::can()` which provides WP-CLI bypass, Action Scheduler bypass, `manage_options` fallback, and pre-authenticated context support.

## Changes

**`inc/Engine/AI/Tools/ToolPolicyResolver.php`** — `checkAccessLevel()` method

| Before | After |
|--------|-------|
| `current_user_can($required_cap)` | `PermissionHelper::can($action)` |
| No fallback for missing custom caps | Falls back to `manage_options` |
| No WP-CLI bypass | WP-CLI always passes |

## Discovery

Found while investigating 10 related test failures in `ToolPolicyResolverTest` and `ChatToolsAvailabilityTest` (all chat context tool resolution). Test fixes will follow in a separate PR.