### PR TITLE
feat: add datamachine_oauth_callback_url filter hook

### DIFF
--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -61,12 +61,27 @@ abstract class BaseAuthProvider {
 	}
 
 	/**
-	 * Get the callback URL for this provider
+	 * Get the callback URL for this provider.
+	 *
+	 * @since 0.67.0
 	 *
 	 * @return string Callback URL
 	 */
 	public function get_callback_url(): string {
-		return site_url( "/datamachine-auth/{$this->provider_slug}/" );
+		$url = site_url( "/datamachine-auth/{$this->provider_slug}/" );
+
+		/**
+		 * Filters the OAuth callback URL for an auth provider.
+		 *
+		 * Allows plugins to customize the callback URL to match their
+		 * OAuth client's registered redirect URI.
+		 *
+		 * @since 0.67.0
+		 *
+		 * @param string $url           The default callback URL.
+		 * @param string $provider_slug The provider slug (e.g. 'wpcom', 'twitter').
+		 */
+		return apply_filters( 'datamachine_oauth_callback_url', $url, $this->provider_slug );
 	}
 
 	/**

--- a/inc/Engine/Filters/OAuth.php
+++ b/inc/Engine/Filters/OAuth.php
@@ -16,7 +16,10 @@ if ( ! defined( 'WPINC' ) ) {
  * @return string Callback URL
  */
 function datamachine_get_oauth_callback_url( string $provider ): string {
-	return site_url( "/datamachine-auth/{$provider}/" );
+	$url = site_url( "/datamachine-auth/{$provider}/" );
+
+	/** This filter is documented in inc/Core/OAuth/BaseAuthProvider.php */
+	return apply_filters( 'datamachine_oauth_callback_url', $url, $provider );
 }
 
 // Legacy storage functions removed. Use BaseAuthProvider methods instead.

--- a/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
@@ -174,4 +174,64 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( '/datamachine-auth/test_provider/', $url );
 	}
+
+	public function test_callback_url_is_filterable(): void {
+		$custom_url = 'https://example.com/oauth/callback';
+
+		add_filter(
+			'datamachine_oauth_callback_url',
+			function ( $url, $slug ) use ( $custom_url ) {
+				if ( 'test_provider' === $slug ) {
+					return $custom_url;
+				}
+				return $url;
+			},
+			10,
+			2
+		);
+
+		$this->assertSame( $custom_url, $this->provider->get_callback_url() );
+
+		remove_all_filters( 'datamachine_oauth_callback_url' );
+	}
+
+	public function test_callback_url_filter_passes_provider_slug(): void {
+		$received_slug = null;
+
+		add_filter(
+			'datamachine_oauth_callback_url',
+			function ( $url, $slug ) use ( &$received_slug ) {
+				$received_slug = $slug;
+				return $url;
+			},
+			10,
+			2
+		);
+
+		$this->provider->get_callback_url();
+
+		$this->assertSame( 'test_provider', $received_slug );
+
+		remove_all_filters( 'datamachine_oauth_callback_url' );
+	}
+
+	public function test_callback_url_filter_does_not_affect_other_providers(): void {
+		add_filter(
+			'datamachine_oauth_callback_url',
+			function ( $url, $slug ) {
+				if ( 'other_provider' === $slug ) {
+					return 'https://example.com/other/callback';
+				}
+				return $url;
+			},
+			10,
+			2
+		);
+
+		$url = $this->provider->get_callback_url();
+
+		$this->assertStringContainsString( '/datamachine-auth/test_provider/', $url );
+
+		remove_all_filters( 'datamachine_oauth_callback_url' );
+	}
 }


### PR DESCRIPTION
## Summary

- Adds `datamachine_oauth_callback_url` filter to `BaseAuthProvider::get_callback_url()` so extension plugins can customize the OAuth redirect URI per provider
- Applies the same filter to the legacy `datamachine_get_oauth_callback_url()` helper for consistency
- Adds 3 tests covering filter behavior, slug passthrough, and provider isolation

## Context

Closes #1041. Intelligence registers a WordPress.com OAuth provider (client_id 128117, shared with mcp-context-a8c) that expects `/oauth/callback` as the redirect path, not `/datamachine-auth/wpcom/`. This filter lets Intelligence hook in cleanly:

```php
add_filter( 'datamachine_oauth_callback_url', function ( $url, $slug ) {
    if ( 'wpcom' === $slug ) {
        return site_url( '/oauth/callback' );
    }
    return $url;
}, 10, 2 );
```

Default behavior is unchanged — the filter passes through if no one hooks it.

## Testing

All 19 BaseAuthProvider tests pass (16 existing + 3 new).