### PR TITLE
fix: move Agents above Pipelines in wp-admin menu

### DIFF
--- a/inc/Core/Admin/Pages/Agent/AgentFilters.php
+++ b/inc/Core/Admin/Pages/Agent/AgentFilters.php
@@ -27,7 +27,7 @@ function datamachine_register_agent_admin_page_filters() {
 				'page_title' => __( 'Agents', 'data-machine' ),
 				'menu_title' => __( 'Agents', 'data-machine' ),
 				'capability' => 'datamachine_manage_agents',
-				'position'   => 20,
+				'position'   => 5,
 				'templates'  => __DIR__ . '/templates/',
 				'assets'     => array(
 					'css' => array(


### PR DESCRIPTION
## Summary
- Sets Agents menu position to `5` (was `20`) so it appears as the **first** Data Machine submenu item in wp-admin, above Pipelines (`10`).

**Before:** Pipelines → Agents → Jobs → Logs → Settings
**After:** Agents → Pipelines → Jobs → Logs → Settings