### PR TITLE
fix: scope agent memory files to selected agent in admin UI

### DIFF
--- a/inc/Api/AgentFiles.php
+++ b/inc/Api/AgentFiles.php
@@ -438,9 +438,16 @@ class AgentFiles {
 	// =========================================================================
 
 	public static function list_daily_files( WP_REST_Request $request ) {
-		$result = DailyMemoryAbilities::listDaily( array(
+		$input = array(
 			'user_id' => self::resolve_scoped_user_id( $request ),
-		) );
+		);
+
+		$agent_id = $request->get_param( 'agent_id' );
+		if ( null !== $agent_id && '' !== $agent_id ) {
+			$input['agent_id'] = (int) $agent_id;
+		}
+
+		$result = DailyMemoryAbilities::listDaily( $input );
 
 		return rest_ensure_response( array(
 			'success' => true,
@@ -449,11 +456,18 @@ class AgentFiles {
 	}
 
 	public static function get_daily_file( WP_REST_Request $request ) {
-		$date   = sprintf( '%s-%s-%s', $request['year'], $request['month'], $request['day'] );
-		$result = DailyMemoryAbilities::readDaily( array(
+		$date  = sprintf( '%s-%s-%s', $request['year'], $request['month'], $request['day'] );
+		$input = array(
 			'date'    => $date,
 			'user_id' => self::resolve_scoped_user_id( $request ),
-		) );
+		);
+
+		$agent_id = $request->get_param( 'agent_id' );
+		if ( null !== $agent_id && '' !== $agent_id ) {
+			$input['agent_id'] = (int) $agent_id;
+		}
+
+		$result = DailyMemoryAbilities::readDaily( $input );
 
 		if ( ! $result['success'] ) {
 			return new WP_Error( 'daily_file_not_found', $result['message'], array( 'status' => 404 ) );
@@ -477,12 +491,19 @@ class AgentFiles {
 			$content = $request->get_body();
 		}
 
-		$result = DailyMemoryAbilities::writeDaily( array(
+		$input = array(
 			'date'    => $date,
 			'content' => $content,
 			'mode'    => 'write',
 			'user_id' => self::resolve_scoped_user_id( $request ),
-		) );
+		);
+
+		$agent_id = $request->get_param( 'agent_id' );
+		if ( null !== $agent_id && '' !== $agent_id ) {
+			$input['agent_id'] = (int) $agent_id;
+		}
+
+		$result = DailyMemoryAbilities::writeDaily( $input );
 
 		if ( ! $result['success'] ) {
 			$status = false !== strpos( $result['message'] ?? '', 'disabled' ) ? 403 : 500;
@@ -497,11 +518,18 @@ class AgentFiles {
 	}
 
 	public static function delete_daily_file( WP_REST_Request $request ) {
-		$date   = sprintf( '%s-%s-%s', $request['year'], $request['month'], $request['day'] );
-		$result = DailyMemoryAbilities::deleteDaily( array(
+		$date  = sprintf( '%s-%s-%s', $request['year'], $request['month'], $request['day'] );
+		$input = array(
 			'date'    => $date,
 			'user_id' => self::resolve_scoped_user_id( $request ),
-		) );
+		);
+
+		$agent_id = $request->get_param( 'agent_id' );
+		if ( null !== $agent_id && '' !== $agent_id ) {
+			$input['agent_id'] = (int) $agent_id;
+		}
+
+		$result = DailyMemoryAbilities::deleteDaily( $input );
 
 		if ( ! $result['success'] ) {
 			$status = false !== strpos( $result['message'] ?? '', 'disabled' ) ? 403 : 404;

--- a/inc/Core/Admin/Pages/Agent/assets/react/api/agentFiles.js
+++ b/inc/Core/Admin/Pages/Agent/assets/react/api/agentFiles.js
@@ -2,94 +2,79 @@
  * Agent Files API
  *
  * REST client functions for agent memory file operations.
+ * Uses the shared API client for automatic agent interceptor support.
  */
 
 /**
- * WordPress dependencies
+ * Internal dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
+import { client } from '@shared/utils/api';
+import { useAgentStore } from '@shared/stores/agentStore';
 
-const getConfig = () => {
-	const config = window.dataMachineAgentConfig || {};
-	return { restNamespace: config.restNamespace || 'datamachine/v1' };
+/**
+ * Get agent_id params for mutation requests (PUT/DELETE).
+ * The shared client interceptor only injects into GET requests,
+ * so mutations must include agent_id explicitly.
+ *
+ * @return {Object} Object with agent_id if one is selected, empty otherwise.
+ */
+const getAgentParams = () => {
+	const { selectedAgentId } = useAgentStore.getState();
+	return selectedAgentId !== null ? { agent_id: selectedAgentId } : {};
 };
 
 export const listAgentFiles = async () => {
-	const config = getConfig();
-	return apiFetch( { path: `/${ config.restNamespace }/files/agent` } );
+	return client.get( '/files/agent' );
 };
 
 export const getAgentFile = async ( filename ) => {
-	const config = getConfig();
-	return apiFetch( {
-		path: `/${ config.restNamespace }/files/agent/${ filename }`,
-	} );
+	return client.get( `/files/agent/${ filename }` );
 };
 
 export const putAgentFile = async ( filename, content ) => {
-	const config = getConfig();
-	return apiFetch( {
-		path: `/${ config.restNamespace }/files/agent/${ filename }`,
-		method: 'PUT',
-		data: { content },
+	return client.put( `/files/agent/${ filename }`, {
+		content,
+		...getAgentParams(),
 	} );
 };
 
 export const deleteAgentFile = async ( filename ) => {
-	const config = getConfig();
-	return apiFetch( {
-		path: `/${ config.restNamespace }/files/agent/${ filename }`,
-		method: 'DELETE',
-	} );
+	return client.delete( `/files/agent/${ filename }`, getAgentParams() );
 };
 
 // Daily memory file operations.
 
 export const listDailyFiles = async () => {
-	const config = getConfig();
-	return apiFetch( {
-		path: `/${ config.restNamespace }/files/agent/daily`,
-	} );
+	return client.get( '/files/agent/daily' );
 };
 
 export const getDailyFile = async ( year, month, day ) => {
-	const config = getConfig();
-	return apiFetch( {
-		path: `/${ config.restNamespace }/files/agent/daily/${ year }/${ month }/${ day }`,
-	} );
+	return client.get( `/files/agent/daily/${ year }/${ month }/${ day }` );
 };
 
 export const putDailyFile = async ( year, month, day, content ) => {
-	const config = getConfig();
-	return apiFetch( {
-		path: `/${ config.restNamespace }/files/agent/daily/${ year }/${ month }/${ day }`,
-		method: 'PUT',
-		data: { content },
+	return client.put( `/files/agent/daily/${ year }/${ month }/${ day }`, {
+		content,
+		...getAgentParams(),
 	} );
 };
 
 export const deleteDailyFile = async ( year, month, day ) => {
-	const config = getConfig();
-	return apiFetch( {
-		path: `/${ config.restNamespace }/files/agent/daily/${ year }/${ month }/${ day }`,
-		method: 'DELETE',
-	} );
+	return client.delete(
+		`/files/agent/daily/${ year }/${ month }/${ day }`,
+		getAgentParams()
+	);
 };
 
 // Context memory file operations.
 
 export const getContextFile = async ( slug ) => {
-	const config = getConfig();
-	return apiFetch( {
-		path: `/${ config.restNamespace }/files/agent/contexts/${ slug }`,
-	} );
+	return client.get( `/files/agent/contexts/${ slug }` );
 };
 
 export const putContextFile = async ( slug, content ) => {
-	const config = getConfig();
-	return apiFetch( {
-		path: `/${ config.restNamespace }/files/agent/contexts/${ slug }`,
-		method: 'PUT',
-		data: { content },
+	return client.put( `/files/agent/contexts/${ slug }`, {
+		content,
+		...getAgentParams(),
 	} );
 };

--- a/inc/Core/Admin/Pages/Agent/assets/react/queries/agentFiles.js
+++ b/inc/Core/Admin/Pages/Agent/assets/react/queries/agentFiles.js
@@ -2,6 +2,8 @@
  * Agent Files TanStack Query Hooks
  *
  * Query and mutation hooks for agent memory file operations.
+ * All query keys include the selected agent ID so each agent's files
+ * are cached independently and refetch automatically on agent switch.
  */
 
 /**
@@ -13,36 +15,52 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
  * Internal dependencies
  */
 import * as api from '../api/agentFiles';
+import { useAgentStore } from '@shared/stores/agentStore';
+
+/**
+ * Hook to read the current agent ID from the store (reactive).
+ *
+ * @return {number|null} Selected agent ID.
+ */
+const useSelectedAgentId = () =>
+	useAgentStore( ( state ) => state.selectedAgentId );
 
 const KEYS = {
-	list: [ 'agent-files' ],
-	detail: ( filename ) => [ 'agent-files', filename ],
+	list: ( agentId ) => [ 'agent-files', { agentId } ],
+	detail: ( filename, agentId ) => [ 'agent-files', filename, { agentId } ],
 };
 
-export const useAgentFiles = () =>
-	useQuery( {
-		queryKey: KEYS.list,
+export const useAgentFiles = () => {
+	const agentId = useSelectedAgentId();
+	return useQuery( {
+		queryKey: KEYS.list( agentId ),
 		queryFn: api.listAgentFiles,
 		select: ( response ) => response?.data ?? response ?? [],
 	} );
+};
 
-export const useAgentFile = ( filename ) =>
-	useQuery( {
-		queryKey: KEYS.detail( filename ),
+export const useAgentFile = ( filename ) => {
+	const agentId = useSelectedAgentId();
+	return useQuery( {
+		queryKey: KEYS.detail( filename, agentId ),
 		queryFn: () => api.getAgentFile( filename ),
 		enabled: !! filename,
 		select: ( response ) => response?.data ?? response ?? {},
 	} );
+};
 
 export const useSaveAgentFile = () => {
 	const queryClient = useQueryClient();
+	const agentId = useSelectedAgentId();
 	return useMutation( {
 		mutationFn: ( { filename, content } ) =>
 			api.putAgentFile( filename, content ),
 		onSuccess: ( _data, { filename } ) => {
-			queryClient.invalidateQueries( { queryKey: KEYS.list } );
 			queryClient.invalidateQueries( {
-				queryKey: KEYS.detail( filename ),
+				queryKey: KEYS.list( agentId ),
+			} );
+			queryClient.invalidateQueries( {
+				queryKey: KEYS.detail( filename, agentId ),
 			} );
 		},
 	} );
@@ -50,10 +68,13 @@ export const useSaveAgentFile = () => {
 
 export const useDeleteAgentFile = () => {
 	const queryClient = useQueryClient();
+	const agentId = useSelectedAgentId();
 	return useMutation( {
 		mutationFn: ( filename ) => api.deleteAgentFile( filename ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: KEYS.list } );
+			queryClient.invalidateQueries( {
+				queryKey: KEYS.list( agentId ),
+			} );
 		},
 	} );
 };
@@ -61,49 +82,69 @@ export const useDeleteAgentFile = () => {
 // Daily memory hooks.
 
 const DAILY_KEYS = {
-	list: [ 'daily-files' ],
-	detail: ( year, month, day ) => [ 'daily-files', year, month, day ],
+	list: ( agentId ) => [ 'daily-files', { agentId } ],
+	detail: ( year, month, day, agentId ) => [
+		'daily-files',
+		year,
+		month,
+		day,
+		{ agentId },
+	],
 };
 
-export const useDailyFiles = () =>
-	useQuery( {
-		queryKey: DAILY_KEYS.list,
+export const useDailyFiles = () => {
+	const agentId = useSelectedAgentId();
+	return useQuery( {
+		queryKey: DAILY_KEYS.list( agentId ),
 		queryFn: api.listDailyFiles,
 		select: ( response ) => response?.data ?? response ?? {},
 	} );
+};
 
-export const useDailyFile = ( year, month, day ) =>
-	useQuery( {
-		queryKey: DAILY_KEYS.detail( year, month, day ),
+export const useDailyFile = ( year, month, day ) => {
+	const agentId = useSelectedAgentId();
+	return useQuery( {
+		queryKey: DAILY_KEYS.detail( year, month, day, agentId ),
 		queryFn: () => api.getDailyFile( year, month, day ),
 		enabled: !! year && !! month && !! day,
 		select: ( response ) => response?.data ?? response ?? {},
 	} );
+};
 
 export const useSaveDailyFile = () => {
 	const queryClient = useQueryClient();
+	const agentId = useSelectedAgentId();
 	return useMutation( {
 		mutationFn: ( { year, month, day, content } ) =>
 			api.putDailyFile( year, month, day, content ),
 		onSuccess: ( _data, { year, month, day } ) => {
-			queryClient.invalidateQueries( { queryKey: DAILY_KEYS.list } );
 			queryClient.invalidateQueries( {
-				queryKey: DAILY_KEYS.detail( year, month, day ),
+				queryKey: DAILY_KEYS.list( agentId ),
+			} );
+			queryClient.invalidateQueries( {
+				queryKey: DAILY_KEYS.detail( year, month, day, agentId ),
 			} );
 			// Also refresh the agent files list (includes daily summary).
-			queryClient.invalidateQueries( { queryKey: KEYS.list } );
+			queryClient.invalidateQueries( {
+				queryKey: KEYS.list( agentId ),
+			} );
 		},
 	} );
 };
 
 export const useDeleteDailyFile = () => {
 	const queryClient = useQueryClient();
+	const agentId = useSelectedAgentId();
 	return useMutation( {
 		mutationFn: ( { year, month, day } ) =>
 			api.deleteDailyFile( year, month, day ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: DAILY_KEYS.list } );
-			queryClient.invalidateQueries( { queryKey: KEYS.list } );
+			queryClient.invalidateQueries( {
+				queryKey: DAILY_KEYS.list( agentId ),
+			} );
+			queryClient.invalidateQueries( {
+				queryKey: KEYS.list( agentId ),
+			} );
 		},
 	} );
 };
@@ -111,27 +152,32 @@ export const useDeleteDailyFile = () => {
 // Context memory hooks.
 
 const CONTEXT_KEYS = {
-	detail: ( slug ) => [ 'context-files', slug ],
+	detail: ( slug, agentId ) => [ 'context-files', slug, { agentId } ],
 };
 
-export const useContextFile = ( slug ) =>
-	useQuery( {
-		queryKey: CONTEXT_KEYS.detail( slug ),
+export const useContextFile = ( slug ) => {
+	const agentId = useSelectedAgentId();
+	return useQuery( {
+		queryKey: CONTEXT_KEYS.detail( slug, agentId ),
 		queryFn: () => api.getContextFile( slug ),
 		enabled: !! slug,
 		select: ( response ) => response?.data ?? response ?? {},
 	} );
+};
 
 export const useSaveContextFile = () => {
 	const queryClient = useQueryClient();
+	const agentId = useSelectedAgentId();
 	return useMutation( {
 		mutationFn: ( { slug, content } ) =>
 			api.putContextFile( slug, content ),
 		onSuccess: ( _data, { slug } ) => {
 			queryClient.invalidateQueries( {
-				queryKey: CONTEXT_KEYS.detail( slug ),
+				queryKey: CONTEXT_KEYS.detail( slug, agentId ),
 			} );
-			queryClient.invalidateQueries( { queryKey: KEYS.list } );
+			queryClient.invalidateQueries( {
+				queryKey: KEYS.list( agentId ),
+			} );
 		},
 	} );
 };


### PR DESCRIPTION
## Summary

When switching agents in the dropdown on the Agents admin page, the MEMORY.md content (and all memory files) never changed — it always showed the same agent's data.

## Root Cause

`agentFiles.js` used raw `@wordpress/api-fetch` instead of the shared `client` from `@shared/utils/api`, completely bypassing the agent ID interceptor. The `agent_id` param was never sent to the REST API, so the backend always fell back to the default agent.

## Fixes

- **`api/agentFiles.js`** — Replaced raw `apiFetch` with the shared `client`. GET requests now receive `agent_id` via the interceptor automatically. PUT/DELETE mutations pass `agent_id` explicitly from the Zustand store since the interceptor only covers GET.

- **`queries/agentFiles.js`** — Added `selectedAgentId` to all TanStack Query cache keys (`KEYS`, `DAILY_KEYS`, `CONTEXT_KEYS`) so each agent's files are cached independently and refetch automatically on agent switch.

- **`Api/AgentFiles.php`** — The 4 daily memory REST handlers (`list_daily_files`, `get_daily_file`, `put_daily_file`, `delete_daily_file`) now extract `agent_id` from the request and forward it to `DailyMemoryAbilities`, matching the pattern already used by the core agent file handlers above them.