### PR TITLE
feat: add filter hooks to fully override daily memory storage backend

### DIFF
--- a/inc/Abilities/DailyMemoryAbilities.php
+++ b/inc/Abilities/DailyMemoryAbilities.php
@@ -3,7 +3,14 @@
  * Daily Memory Abilities
  *
  * WordPress 6.9 Abilities API primitives for daily memory operations.
- * Provides read/write/list access to daily memory files (YYYY/MM/DD.md).
+ * Provides read/write/list/search/delete access to daily memory.
+ *
+ * Each operation fires a filter (`datamachine_daily_memory_{operation}`) that
+ * allows plugins to completely replace the storage backend. If the filter
+ * returns a non-null value, the flat-file operation is skipped entirely.
+ * This enables consumers like Intelligence to store daily memory as
+ * WordPress pages, external services, or anything else — Data Machine
+ * doesn't need to know or care.
  *
  * @package DataMachine\Abilities
  * @since 0.32.0
@@ -250,10 +257,7 @@ class DailyMemoryAbilities {
 	 * @return array Result.
 	 */
 	public static function readDaily( array $input ): array {
-		$user_id  = (int) ( $input['user_id'] ?? 0 );
-		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$daily    = new DailyMemory( $user_id, $agent_id );
-		$date     = $input['date'] ?? gmdate( 'Y-m-d' );
+		$date = $input['date'] ?? gmdate( 'Y-m-d' );
 
 		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
@@ -262,6 +266,30 @@ class DailyMemoryAbilities {
 				'message' => sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ),
 			);
 		}
+
+		/**
+		 * Filters the daily memory read result.
+		 *
+		 * Return a non-null array to completely replace the flat-file read.
+		 * The array should match the standard result format:
+		 * `{ success: bool, date?: string, content?: string, message?: string }`
+		 *
+		 * @since 0.47.0
+		 *
+		 * @param array|null $result   Default null (flat-file read proceeds).
+		 *                             Return an array to short-circuit.
+		 * @param string     $date     The requested date (YYYY-MM-DD).
+		 * @param array      $input    Full input parameters (includes user_id, agent_id).
+		 */
+		$result = apply_filters( 'datamachine_daily_memory_read', null, $date, $input );
+
+		if ( null !== $result ) {
+			return $result;
+		}
+
+		$user_id  = (int) ( $input['user_id'] ?? 0 );
+		$agent_id = (int) ( $input['agent_id'] ?? 0 );
+		$daily    = new DailyMemory( $user_id, $agent_id );
 
 		return $daily->read( $parts['year'], $parts['month'], $parts['day'] );
 	}
@@ -280,12 +308,9 @@ class DailyMemoryAbilities {
 			);
 		}
 
-		$user_id  = (int) ( $input['user_id'] ?? 0 );
-		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$daily    = new DailyMemory( $user_id, $agent_id );
-		$content  = $input['content'];
-		$date     = $input['date'] ?? gmdate( 'Y-m-d' );
-		$mode     = $input['mode'] ?? 'append';
+		$date    = $input['date'] ?? gmdate( 'Y-m-d' );
+		$content = $input['content'];
+		$mode    = $input['mode'] ?? 'append';
 
 		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
@@ -294,6 +319,31 @@ class DailyMemoryAbilities {
 				'message' => sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ),
 			);
 		}
+
+		/**
+		 * Filters the daily memory write result.
+		 *
+		 * Return a non-null array to completely replace the flat-file write.
+		 * The array should match: `{ success: bool, message?: string }`
+		 *
+		 * @since 0.47.0
+		 *
+		 * @param array|null $result   Default null (flat-file write proceeds).
+		 *                             Return an array to short-circuit.
+		 * @param string     $date     The target date (YYYY-MM-DD).
+		 * @param string     $content  The content to write.
+		 * @param string     $mode     Write mode: 'write' or 'append'.
+		 * @param array      $input    Full input parameters (includes user_id, agent_id).
+		 */
+		$result = apply_filters( 'datamachine_daily_memory_write', null, $date, $content, $mode, $input );
+
+		if ( null !== $result ) {
+			return $result;
+		}
+
+		$user_id  = (int) ( $input['user_id'] ?? 0 );
+		$agent_id = (int) ( $input['agent_id'] ?? 0 );
+		$daily    = new DailyMemory( $user_id, $agent_id );
 
 		if ( 'write' === $mode ) {
 			return $daily->write( $parts['year'], $parts['month'], $parts['day'], $content );
@@ -305,10 +355,28 @@ class DailyMemoryAbilities {
 	/**
 	 * List all daily memory files.
 	 *
-	 * @param array $input Input parameters (unused).
+	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
 	public static function listDaily( array $input ): array {
+		/**
+		 * Filters the daily memory list result.
+		 *
+		 * Return a non-null array to completely replace the flat-file listing.
+		 * The array should match: `{ months: { 'YYYY/MM': ['DD', ...], ... } }`
+		 *
+		 * @since 0.47.0
+		 *
+		 * @param array|null $result   Default null (flat-file list proceeds).
+		 *                             Return an array to short-circuit.
+		 * @param array      $input    Full input parameters (includes user_id, agent_id).
+		 */
+		$result = apply_filters( 'datamachine_daily_memory_list', null, $input );
+
+		if ( null !== $result ) {
+			return $result;
+		}
+
 		$user_id  = (int) ( $input['user_id'] ?? 0 );
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
 		$daily    = new DailyMemory( $user_id, $agent_id );
@@ -322,12 +390,35 @@ class DailyMemoryAbilities {
 	 * @return array Search results.
 	 */
 	public static function searchDaily( array $input ): array {
+		$query = $input['query'];
+		$from  = $input['from'] ?? null;
+		$to    = $input['to'] ?? null;
+
+		/**
+		 * Filters the daily memory search result.
+		 *
+		 * Return a non-null array to completely replace the flat-file search.
+		 * The array should match:
+		 * `{ success: bool, query: string, match_count: int, matches: [...] }`
+		 *
+		 * @since 0.47.0
+		 *
+		 * @param array|null  $result  Default null (flat-file search proceeds).
+		 *                             Return an array to short-circuit.
+		 * @param string      $query   The search term.
+		 * @param string|null $from    Start date (YYYY-MM-DD) or null.
+		 * @param string|null $to      End date (YYYY-MM-DD) or null.
+		 * @param array       $input   Full input parameters (includes user_id, agent_id).
+		 */
+		$result = apply_filters( 'datamachine_daily_memory_search', null, $query, $from, $to, $input );
+
+		if ( null !== $result ) {
+			return $result;
+		}
+
 		$user_id  = (int) ( $input['user_id'] ?? 0 );
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
 		$daily    = new DailyMemory( $user_id, $agent_id );
-		$query    = $input['query'];
-		$from     = $input['from'] ?? null;
-		$to       = $input['to'] ?? null;
 
 		return $daily->search( $query, $from, $to );
 	}
@@ -348,10 +439,7 @@ class DailyMemoryAbilities {
 			);
 		}
 
-		$user_id  = (int) ( $input['user_id'] ?? 0 );
-		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$daily    = new DailyMemory( $user_id, $agent_id );
-		$date     = $input['date'] ?? gmdate( 'Y-m-d' );
+		$date = $input['date'] ?? gmdate( 'Y-m-d' );
 
 		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
@@ -360,6 +448,29 @@ class DailyMemoryAbilities {
 				'message' => sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ),
 			);
 		}
+
+		/**
+		 * Filters the daily memory delete result.
+		 *
+		 * Return a non-null array to completely replace the flat-file delete.
+		 * The array should match: `{ success: bool, message?: string }`
+		 *
+		 * @since 0.47.0
+		 *
+		 * @param array|null $result   Default null (flat-file delete proceeds).
+		 *                             Return an array to short-circuit.
+		 * @param string     $date     The target date (YYYY-MM-DD).
+		 * @param array      $input    Full input parameters (includes user_id, agent_id).
+		 */
+		$result = apply_filters( 'datamachine_daily_memory_delete', null, $date, $input );
+
+		if ( null !== $result ) {
+			return $result;
+		}
+
+		$user_id  = (int) ( $input['user_id'] ?? 0 );
+		$agent_id = (int) ( $input['agent_id'] ?? 0 );
+		$daily    = new DailyMemory( $user_id, $agent_id );
 
 		return $daily->delete( $parts['year'], $parts['month'], $parts['day'] );
 	}

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -226,6 +226,9 @@ class DailyMemoryTask extends SystemTask {
 			 * an external service, etc.). When `true` is returned, the flat-file
 			 * write to `daily/YYYY/MM/DD.md` is skipped entirely.
 			 *
+			 * For a complete storage backend override (read, list, search, delete),
+			 * see the `datamachine_daily_memory_*` filters in DailyMemoryAbilities.
+			 *
 			 * @since 0.46.0
 			 *
 			 * @param bool   $handled Whether a handler has already stored the content.
@@ -256,36 +259,6 @@ class DailyMemoryTask extends SystemTask {
 
 				$daily->append( $parts[0], $parts[1], $parts[2], $archive_text );
 			}
-
-			/**
-			 * Fires after daily memory archived content has been processed.
-			 *
-			 * This action fires regardless of whether the content was written to a
-			 * flat file or handled by a `datamachine_daily_memory_pre_archive` filter.
-			 * Use this for post-processing, notifications, or secondary storage.
-			 *
-			 * @since 0.46.0
-			 *
-			 * @param string $content The archived content extracted from MEMORY.md.
-			 * @param string $date    The archive date (YYYY-MM-DD).
-			 * @param bool   $handled Whether a filter handled storage (true = flat file skipped).
-			 * @param array  $context {
-			 *     Additional context about the daily memory operation.
-			 *
-			 *     @type string $persistent    The persistent content remaining in MEMORY.md.
-			 *     @type int    $original_size Original MEMORY.md size in bytes.
-			 *     @type int    $new_size      New MEMORY.md size in bytes after cleanup.
-			 *     @type int    $archived_size Archived content size in bytes.
-			 *     @type int    $job_id        The job ID for this task execution.
-			 * }
-			 */
-			do_action(
-				'datamachine_daily_memory_archived',
-				$parsed['archived'],
-				$date,
-				$handled,
-				$archive_context
-			);
 		}
 
 		do_action(


### PR DESCRIPTION
## Summary

Adds `datamachine_daily_memory_{read,write,list,search,delete}` filters to `DailyMemoryAbilities` so a consumer plugin can **completely replace the daily memory storage mechanism**.

Each filter receives `null` by default. Return a non-null result array to short-circuit the flat-file operation entirely. If nothing hooks the filter, behavior is 100% unchanged.

Removes the duplicative `datamachine_daily_memory_archived` action from `DailyMemoryTask` — the `pre_archive` filter already handles the write override, and the new ability-level filters cover read-back.

## Why

PR #1046 added `datamachine_daily_memory_pre_archive` which lets plugins intercept the **archive write**. But the read, list, search, and delete paths all go straight to the filesystem. If a consumer stores archives as WordPress pages and skips the flat file, agents can't read their knowledge back.

These filters complete the picture — a plugin like Intelligence can hook all 5 operations and own the entire storage layer. Data Machine fires the filters and falls back to flat files. It doesn't need to know or care what's behind them.

## Filters

| Filter | Parameters | Short-circuit |
|---|---|---|
| `datamachine_daily_memory_read` | `$result, $date, $input` | Return result array |
| `datamachine_daily_memory_write` | `$result, $date, $content, $mode, $input` | Return result array |
| `datamachine_daily_memory_list` | `$result, $input` | Return result array |
| `datamachine_daily_memory_search` | `$result, $query, $from, $to, $input` | Return result array |
| `datamachine_daily_memory_delete` | `$result, $date, $input` | Return result array |

All filters pass the full `$input` array which includes `user_id` and `agent_id` for scoping.

## Example usage

```php
// Intelligence plugin: store daily archives as WordPress pages.
add_filter( 'datamachine_daily_memory_read', function ( $result, $date, $input ) {
    $agent_id = $input['agent_id'] ?? 0;
    // Query WordPress for this agent's daily archive page...
    $post = get_daily_knowledge_post( $agent_id, $date );
    if ( $post ) {
        return [ 'success' => true, 'date' => $date, 'content' => $post->post_content ];
    }
    return null; // Fall back to flat file.
}, 10, 3 );
```

## Changes

- `inc/Abilities/DailyMemoryAbilities.php` — Add 5 filter hooks with full PHPDoc
- `inc/Engine/AI/System/Tasks/DailyMemoryTask.php` — Remove `datamachine_daily_memory_archived` action, add cross-reference to new filters in `pre_archive` docblock