### PR TITLE
feat: extract DailyMemoryStorage interface with pluggable storage filter

### DIFF
--- a/inc/Abilities/DailyMemoryAbilities.php
+++ b/inc/Abilities/DailyMemoryAbilities.php
@@ -3,7 +3,13 @@
  * Daily Memory Abilities
  *
  * WordPress 6.9 Abilities API primitives for daily memory operations.
- * Provides read/write/list access to daily memory files (YYYY/MM/DD.md).
+ * Provides read/write/list/search/delete access to daily memory.
+ *
+ * Storage is resolved via the `datamachine_daily_memory_storage` filter.
+ * The default implementation is DailyMemory (flat markdown files).
+ * Plugins can return any object implementing DailyMemoryStorage to
+ * completely replace the storage backend — Data Machine doesn't need
+ * to know or care what's behind it.
  *
  * @package DataMachine\Abilities
  * @since 0.32.0
@@ -14,6 +20,7 @@ namespace DataMachine\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\FilesRepository\DailyMemory;
+use DataMachine\Core\FilesRepository\DailyMemoryStorage;
 use DataMachine\Core\PluginSettings;
 
 defined( 'ABSPATH' ) || exit;
@@ -33,6 +40,44 @@ class DailyMemoryAbilities {
 
 		$this->registerAbilities();
 		self::$registered = true;
+	}
+
+	/**
+	 * Resolve the daily memory storage backend for a given context.
+	 *
+	 * Returns the default filesystem-backed DailyMemory unless a plugin
+	 * provides an alternative via the `datamachine_daily_memory_storage` filter.
+	 *
+	 * @since 0.47.0
+	 *
+	 * @param int $user_id  WordPress user ID.
+	 * @param int $agent_id Agent ID.
+	 * @return DailyMemoryStorage
+	 */
+	private static function resolveStorage( int $user_id, int $agent_id ): DailyMemoryStorage {
+		$default = new DailyMemory( $user_id, $agent_id );
+
+		/**
+		 * Filters the daily memory storage backend.
+		 *
+		 * Return any object implementing DailyMemoryStorage to completely
+		 * replace the flat-file storage. All daily memory operations (read,
+		 * write, append, list, search, delete) will use the returned backend.
+		 *
+		 * @since 0.47.0
+		 *
+		 * @param DailyMemoryStorage $storage  Default filesystem implementation.
+		 * @param int                $user_id  WordPress user ID.
+		 * @param int                $agent_id Agent ID.
+		 */
+		$storage = apply_filters( 'datamachine_daily_memory_storage', $default, $user_id, $agent_id );
+
+		// Safety: if the filter returns something that doesn't implement the interface, fall back.
+		if ( ! ( $storage instanceof DailyMemoryStorage ) ) {
+			return $default;
+		}
+
+		return $storage;
 	}
 
 	private function registerAbilities(): void {
@@ -250,10 +295,7 @@ class DailyMemoryAbilities {
 	 * @return array Result.
 	 */
 	public static function readDaily( array $input ): array {
-		$user_id  = (int) ( $input['user_id'] ?? 0 );
-		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$daily    = new DailyMemory( $user_id, $agent_id );
-		$date     = $input['date'] ?? gmdate( 'Y-m-d' );
+		$date = $input['date'] ?? gmdate( 'Y-m-d' );
 
 		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
@@ -263,7 +305,11 @@ class DailyMemoryAbilities {
 			);
 		}
 
-		return $daily->read( $parts['year'], $parts['month'], $parts['day'] );
+		$user_id  = (int) ( $input['user_id'] ?? 0 );
+		$agent_id = (int) ( $input['agent_id'] ?? 0 );
+		$storage  = self::resolveStorage( $user_id, $agent_id );
+
+		return $storage->read( $parts['year'], $parts['month'], $parts['day'] );
 	}
 
 	/**
@@ -280,12 +326,9 @@ class DailyMemoryAbilities {
 			);
 		}
 
-		$user_id  = (int) ( $input['user_id'] ?? 0 );
-		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$daily    = new DailyMemory( $user_id, $agent_id );
-		$content  = $input['content'];
-		$date     = $input['date'] ?? gmdate( 'Y-m-d' );
-		$mode     = $input['mode'] ?? 'append';
+		$date    = $input['date'] ?? gmdate( 'Y-m-d' );
+		$content = $input['content'];
+		$mode    = $input['mode'] ?? 'append';
 
 		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
@@ -295,24 +338,29 @@ class DailyMemoryAbilities {
 			);
 		}
 
+		$user_id  = (int) ( $input['user_id'] ?? 0 );
+		$agent_id = (int) ( $input['agent_id'] ?? 0 );
+		$storage  = self::resolveStorage( $user_id, $agent_id );
+
 		if ( 'write' === $mode ) {
-			return $daily->write( $parts['year'], $parts['month'], $parts['day'], $content );
+			return $storage->write( $parts['year'], $parts['month'], $parts['day'], $content );
 		}
 
-		return $daily->append( $parts['year'], $parts['month'], $parts['day'], $content );
+		return $storage->append( $parts['year'], $parts['month'], $parts['day'], $content );
 	}
 
 	/**
 	 * List all daily memory files.
 	 *
-	 * @param array $input Input parameters (unused).
+	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
 	public static function listDaily( array $input ): array {
 		$user_id  = (int) ( $input['user_id'] ?? 0 );
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$daily    = new DailyMemory( $user_id, $agent_id );
-		return $daily->list_all();
+		$storage  = self::resolveStorage( $user_id, $agent_id );
+
+		return $storage->list_all();
 	}
 
 	/**
@@ -324,12 +372,13 @@ class DailyMemoryAbilities {
 	public static function searchDaily( array $input ): array {
 		$user_id  = (int) ( $input['user_id'] ?? 0 );
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$daily    = new DailyMemory( $user_id, $agent_id );
-		$query    = $input['query'];
-		$from     = $input['from'] ?? null;
-		$to       = $input['to'] ?? null;
+		$storage  = self::resolveStorage( $user_id, $agent_id );
 
-		return $daily->search( $query, $from, $to );
+		$query = $input['query'];
+		$from  = $input['from'] ?? null;
+		$to    = $input['to'] ?? null;
+
+		return $storage->search( $query, $from, $to );
 	}
 
 	/**
@@ -348,10 +397,7 @@ class DailyMemoryAbilities {
 			);
 		}
 
-		$user_id  = (int) ( $input['user_id'] ?? 0 );
-		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$daily    = new DailyMemory( $user_id, $agent_id );
-		$date     = $input['date'] ?? gmdate( 'Y-m-d' );
+		$date = $input['date'] ?? gmdate( 'Y-m-d' );
 
 		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
@@ -361,6 +407,10 @@ class DailyMemoryAbilities {
 			);
 		}
 
-		return $daily->delete( $parts['year'], $parts['month'], $parts['day'] );
+		$user_id  = (int) ( $input['user_id'] ?? 0 );
+		$agent_id = (int) ( $input['agent_id'] ?? 0 );
+		$storage  = self::resolveStorage( $user_id, $agent_id );
+
+		return $storage->delete( $parts['year'], $parts['month'], $parts['day'] );
 	}
 }

--- a/inc/Core/FilesRepository/DailyMemory.php
+++ b/inc/Core/FilesRepository/DailyMemory.php
@@ -19,7 +19,7 @@ namespace DataMachine\Core\FilesRepository;
 
 defined( 'ABSPATH' ) || exit;
 
-class DailyMemory {
+class DailyMemory implements DailyMemoryStorage {
 
 	/**
 	 * @var DirectoryManager

--- a/inc/Core/FilesRepository/DailyMemoryStorage.php
+++ b/inc/Core/FilesRepository/DailyMemoryStorage.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Daily Memory Storage Interface
+ *
+ * Contract for daily memory storage backends. The default implementation
+ * is DailyMemory (flat markdown files). Plugins can provide alternative
+ * implementations (WordPress pages, external services, etc.) by filtering
+ * `datamachine_daily_memory_storage` in DailyMemoryAbilities.
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since 0.47.0
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+interface DailyMemoryStorage {
+
+	/**
+	 * Read a daily memory entry.
+	 *
+	 * @param string $year  Four-digit year.
+	 * @param string $month Two-digit month.
+	 * @param string $day   Two-digit day.
+	 * @return array{success: bool, content?: string, date?: string, message?: string}
+	 */
+	public function read( string $year, string $month, string $day ): array;
+
+	/**
+	 * Write (replace) content for a daily memory entry.
+	 *
+	 * @param string $year    Four-digit year.
+	 * @param string $month   Two-digit month.
+	 * @param string $day     Two-digit day.
+	 * @param string $content Full content.
+	 * @return array{success: bool, message: string}
+	 */
+	public function write( string $year, string $month, string $day, string $content ): array;
+
+	/**
+	 * Append content to a daily memory entry.
+	 *
+	 * @param string $year    Four-digit year.
+	 * @param string $month   Two-digit month.
+	 * @param string $day     Two-digit day.
+	 * @param string $content Content to append.
+	 * @return array{success: bool, message: string}
+	 */
+	public function append( string $year, string $month, string $day, string $content ): array;
+
+	/**
+	 * Delete a daily memory entry.
+	 *
+	 * @param string $year  Four-digit year.
+	 * @param string $month Two-digit month.
+	 * @param string $day   Two-digit day.
+	 * @return array{success: bool, message: string}
+	 */
+	public function delete( string $year, string $month, string $day ): array;
+
+	/**
+	 * List all daily memory entries grouped by month.
+	 *
+	 * @return array{success: bool, months: array<string, string[]>}
+	 */
+	public function list_all(): array;
+
+	/**
+	 * Search across daily memory entries.
+	 *
+	 * @param string      $query         Search term.
+	 * @param string|null $from          Start date (YYYY-MM-DD, inclusive).
+	 * @param string|null $to            End date (YYYY-MM-DD, inclusive).
+	 * @param int         $context_lines Number of context lines around matches.
+	 * @return array{success: bool, query: string, matches: array, match_count: int}
+	 */
+	public function search( string $query, ?string $from = null, ?string $to = null, int $context_lines = 2 ): array;
+}

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -226,6 +226,9 @@ class DailyMemoryTask extends SystemTask {
 			 * an external service, etc.). When `true` is returned, the flat-file
 			 * write to `daily/YYYY/MM/DD.md` is skipped entirely.
 			 *
+			 * For a complete storage backend override (read, list, search, delete),
+			 * see the `datamachine_daily_memory_storage` filter in DailyMemoryAbilities.
+			 *
 			 * @since 0.46.0
 			 *
 			 * @param bool   $handled Whether a handler has already stored the content.
@@ -256,36 +259,6 @@ class DailyMemoryTask extends SystemTask {
 
 				$daily->append( $parts[0], $parts[1], $parts[2], $archive_text );
 			}
-
-			/**
-			 * Fires after daily memory archived content has been processed.
-			 *
-			 * This action fires regardless of whether the content was written to a
-			 * flat file or handled by a `datamachine_daily_memory_pre_archive` filter.
-			 * Use this for post-processing, notifications, or secondary storage.
-			 *
-			 * @since 0.46.0
-			 *
-			 * @param string $content The archived content extracted from MEMORY.md.
-			 * @param string $date    The archive date (YYYY-MM-DD).
-			 * @param bool   $handled Whether a filter handled storage (true = flat file skipped).
-			 * @param array  $context {
-			 *     Additional context about the daily memory operation.
-			 *
-			 *     @type string $persistent    The persistent content remaining in MEMORY.md.
-			 *     @type int    $original_size Original MEMORY.md size in bytes.
-			 *     @type int    $new_size      New MEMORY.md size in bytes after cleanup.
-			 *     @type int    $archived_size Archived content size in bytes.
-			 *     @type int    $job_id        The job ID for this task execution.
-			 * }
-			 */
-			do_action(
-				'datamachine_daily_memory_archived',
-				$parsed['archived'],
-				$date,
-				$handled,
-				$archive_context
-			);
 		}
 
 		do_action(


### PR DESCRIPTION
## Summary

One filter to swap the entire daily memory storage backend:

```php
add_filter( 'datamachine_daily_memory_storage', function ( $default, $user_id, $agent_id ) {
    return new MyWordPressDailyMemory( $user_id, $agent_id );
}, 10, 3 );
```

Supersedes #1050 (closed) which used 5 per-operation filters — that was a code smell pointing at missing abstraction.

## What changed

1. **New `DailyMemoryStorage` interface** (`inc/Core/FilesRepository/DailyMemoryStorage.php`)
   - Contract: `read`, `write`, `append`, `delete`, `list_all`, `search`
   - Same signatures the existing `DailyMemory` class already has

2. **`DailyMemory` implements `DailyMemoryStorage`**
   - Zero behavior change — just adds `implements DailyMemoryStorage` to the class declaration

3. **`DailyMemoryAbilities` resolves storage via filter**
   - New private `resolveStorage($user_id, $agent_id)` method
   - Fires `datamachine_daily_memory_storage` filter with the default `DailyMemory` instance
   - All 5 ability methods use the resolved storage instead of hardcoding `new DailyMemory()`
   - Safety fallback: if filter returns non-`DailyMemoryStorage`, falls back to default

4. **Removed `datamachine_daily_memory_archived` action** from `DailyMemoryTask`
   - Duplicative — the `pre_archive` filter handles write override, the storage interface handles read-back
   - Added cross-reference to `datamachine_daily_memory_storage` in the `pre_archive` docblock

## How Intelligence uses this

Intelligence hooks one filter and returns its own `DailyMemoryStorage` implementation that stores/reads daily memory as WordPress pages. One hook, total replacement. Data Machine doesn't know or care what's behind the interface.

```php
add_filter( 'datamachine_daily_memory_storage', function ( $default, $user_id, $agent_id ) {
    $agent = get_agent( $agent_id );
    if ( $agent && ! empty( $agent['agent_config']['intelligence_kit'] ) ) {
        return new Intelligence_WordPress_Daily_Memory( $user_id, $agent_id );
    }
    return $default; // Non-Intelligence agents keep flat files.
}, 10, 3 );
```

## Files

| File | Change |
|------|--------|
| `inc/Core/FilesRepository/DailyMemoryStorage.php` | **New** — interface with 6 methods |
| `inc/Core/FilesRepository/DailyMemory.php` | Add `implements DailyMemoryStorage` |
| `inc/Abilities/DailyMemoryAbilities.php` | `resolveStorage()` + filter, all methods use it |
| `inc/Engine/AI/System/Tasks/DailyMemoryTask.php` | Remove `datamachine_daily_memory_archived` action |