### PR TITLE
fix: harden agent files API error handling to prevent React crash

### DIFF
--- a/inc/Api/AgentFiles.php
+++ b/inc/Api/AgentFiles.php
@@ -317,10 +317,18 @@ class AgentFiles {
 			$input['agent_id'] = (int) $agent_id;
 		}
 
-		$result = self::getAbilities()->executeListAgentFiles( $input );
+		try {
+			$result = self::getAbilities()->executeListAgentFiles( $input );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error(
+				'list_agent_files_error',
+				$e->getMessage(),
+				array( 'status' => 500 )
+			);
+		}
 
 		if ( ! $result['success'] ) {
-			return new WP_Error( 'list_agent_files_error', $result['error'], array( 'status' => 500 ) );
+			return new \WP_Error( 'list_agent_files_error', $result['error'], array( 'status' => 500 ) );
 		}
 
 		return rest_ensure_response( array(
@@ -340,11 +348,19 @@ class AgentFiles {
 			$input['agent_id'] = (int) $agent_id;
 		}
 
-		$result = self::getAbilities()->executeGetAgentFile( $input );
+		try {
+			$result = self::getAbilities()->executeGetAgentFile( $input );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error(
+				'get_agent_file_error',
+				$e->getMessage(),
+				array( 'status' => 500 )
+			);
+		}
 
 		if ( ! $result['success'] ) {
 			$status = false !== strpos( $result['error'] ?? '', 'not found' ) ? 404 : 400;
-			return new WP_Error( 'get_agent_file_error', $result['error'], array( 'status' => $status ) );
+			return new \WP_Error( 'get_agent_file_error', $result['error'], array( 'status' => $status ) );
 		}
 
 		return rest_ensure_response( array(

--- a/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/AgentApp.jsx
@@ -59,7 +59,7 @@ const NoAgentSelectedMessage = ( { message } ) => (
 const AgentApp = () => {
 	const [ selectedFile, setSelectedFile ] = useState( null );
 	const { data: files } = useAgentFiles();
-	const hasFiles = files && files.length > 0;
+	const hasFiles = Array.isArray( files ) && files.length > 0;
 
 	// Get selected agent from store
 	const { selectedAgentId } = useAgentStore();

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentFileList.jsx
@@ -171,7 +171,9 @@ const AgentFileList = ( { selectedFile, onSelectFile } ) => {
 		}
 
 		// Check for duplicates among core files.
-		const coreFiles = files?.filter( ( f ) => f.type !== 'daily_summary' ) ?? [];
+		const coreFiles = Array.isArray( files )
+			? files.filter( ( f ) => f.type !== 'daily_summary' )
+			: [];
 		if ( coreFiles.some( ( f ) => f.filename === name ) ) {
 			setAddError( 'A file with this name already exists.' );
 			return;

--- a/inc/Core/Admin/Pages/Agent/assets/react/queries/agentFiles.js
+++ b/inc/Core/Admin/Pages/Agent/assets/react/queries/agentFiles.js
@@ -35,7 +35,10 @@ export const useAgentFiles = () => {
 	return useQuery( {
 		queryKey: KEYS.list( agentId ),
 		queryFn: api.listAgentFiles,
-		select: ( response ) => response?.data ?? response ?? [],
+		select: ( response ) => {
+			const data = response?.data;
+			return Array.isArray( data ) ? data : [];
+		},
 	} );
 };
 


### PR DESCRIPTION
## Summary

- **Wraps** `list_agent_files` and `get_agent_file` REST handlers in `try/catch (\Throwable)` so uncaught exceptions (e.g. missing DB tables during scaffolding) return proper `WP_Error` responses instead of raw 500s
- **Fixes** `useAgentFiles` query `select` function to always return an array via `Array.isArray()` — previously, API error objects (`{ success: false, data: null }`) passed through the nullish coalescing chain as truthy non-arrays, causing `.filter()` crashes
- **Hardens** `.filter()` call in `handleCreateFile` and `hasFiles` check in `AgentApp` with `Array.isArray()` guards

## Bug

When loading the Agent admin page, if the `/files/agent` or `/files/agent/SOUL.md` endpoints return 500 errors, the React UI crashes with:

```
TypeError: a.filter is not a function
    at st (agent-react.js:1:45153)
```

The root cause is a cascading failure:
1. PHP handlers throw uncaught exceptions → raw 500
2. API client catches the error and returns `{ success: false, data: null }`
3. Query `select: (response) => response?.data ?? response ?? []` evaluates to the error object (truthy), not `[]`
4. Component calls `.filter()` on an object → crash

## Testing

1. Trigger a 500 on `/files/agent` (e.g. missing agents table)
2. Navigate to Agent admin page → should show "Failed to load files" instead of crashing
3. Normal operation with working API → file list loads as before