### PR TITLE
fix: chat_sessions table not created on SQLite due to COMMENT clauses in dbDelta

### DIFF
--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -42,28 +42,28 @@ class Chat extends BaseRepository {
 		$charset_collate = $wpdb->get_charset_collate();
 
 		$sql = "CREATE TABLE {$table_name} (
-            session_id VARCHAR(50) NOT NULL,
-            user_id BIGINT(20) UNSIGNED NOT NULL,
-            agent_id BIGINT(20) UNSIGNED NULL COMMENT 'First-class agent identity (nullable for backward compatibility)',
-            title VARCHAR(100) NULL COMMENT 'AI-generated or truncated first message title',
-            messages LONGTEXT NOT NULL COMMENT 'JSON array of conversation messages',
-            metadata LONGTEXT NULL COMMENT 'JSON object for session metadata',
-            provider VARCHAR(50) NULL COMMENT 'AI provider (anthropic, openai, etc)',
-            model VARCHAR(100) NULL COMMENT 'AI model identifier',
-	            context VARCHAR(20) NOT NULL DEFAULT 'chat' COMMENT 'Execution context: chat, pipeline, system',
-            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-            last_read_at DATETIME NULL COMMENT 'When the user last read this session',
-            expires_at DATETIME NULL COMMENT 'Auto-cleanup timestamp',
-            PRIMARY KEY  (session_id),
-            KEY user_id (user_id),
-            KEY agent_id (agent_id),
-	            KEY context (context),
-	            KEY user_context (user_id, context),
-            KEY created_at (created_at),
-            KEY updated_at (updated_at),
-            KEY expires_at (expires_at)
-        ) {$charset_collate};";
+			session_id VARCHAR(50) NOT NULL,
+			user_id BIGINT(20) UNSIGNED NOT NULL,
+			agent_id BIGINT(20) UNSIGNED NULL,
+			title VARCHAR(100) NULL,
+			messages LONGTEXT NOT NULL,
+			metadata LONGTEXT NULL,
+			provider VARCHAR(50) NULL,
+			model VARCHAR(100) NULL,
+			context VARCHAR(20) NOT NULL DEFAULT 'chat',
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			last_read_at DATETIME NULL,
+			expires_at DATETIME NULL,
+			PRIMARY KEY  (session_id),
+			KEY user_id (user_id),
+			KEY agent_id (agent_id),
+			KEY context (context),
+			KEY user_context (user_id, context),
+			KEY created_at (created_at),
+			KEY updated_at (updated_at),
+			KEY expires_at (expires_at)
+		) {$charset_collate};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $sql );
@@ -895,6 +895,10 @@ class Chat extends BaseRepository {
 add_action(
 	'datamachine_cleanup_chat_sessions',
 	function () {
+		if ( ! Chat::table_exists() ) {
+			return;
+		}
+
 		$chat_db        = new Chat();
 		$retention_days = \DataMachine\Core\PluginSettings::get( 'chat_retention_days', 90 );
 


### PR DESCRIPTION
## Summary

- **Removes** column `COMMENT` clauses from the `chat_sessions` CREATE TABLE SQL — `dbDelta()` silently fails to parse them (especially strings with parentheses), preventing the table from ever being created on SQLite
- **Fixes** mixed tab/space indentation in the SQL string (matches every other Data Machine table)
- **Adds** `table_exists()` guard to the `datamachine_cleanup_chat_sessions` Action Scheduler callback as defense-in-depth

## Root Cause

`chat_sessions` was the **only** Data Machine table with `COMMENT` clauses in its column definitions. WordPress `dbDelta()` parses SQL with regex and is notoriously fragile with non-standard extensions. The COMMENT strings (e.g. `COMMENT 'First-class agent identity (nullable for backward compatibility)'`) caused `dbDelta()` to silently fail on SQLite via Studio.

The version was still bumped at the end of `datamachine_activate_for_site()`, so the migration never retried. Meanwhile, the scheduled cleanup action fired repeatedly → `DELETE FROM wp_datamachine_chat_sessions` → `no such table` → 70+ identical error log entries.

## After This Fix

On the next deploy/version bump, `datamachine_maybe_run_migrations()` will re-run `Chat::create_table()` with the clean SQL and the table will be created. The cleanup guard prevents log spam if table creation fails for any other reason in the future.