### PR TITLE
Auto-regenerate composable files on plugin activation/deactivation

### DIFF
--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -147,6 +147,10 @@ add_action( 'init', 'datamachine_register_site_md_invalidation' );
 // Only registers hooks on multisite installs (guard is inside the function).
 add_action( 'init', 'datamachine_register_network_md_invalidation' );
 
+// Composable file auto-regeneration — rebuilds AGENTS.md (and any other composable files)
+// when plugins are activated/deactivated, since those events change which sections are registered.
+add_action( 'init', 'datamachine_register_composable_file_invalidation' );
+
 require_once __DIR__ . '/Engine/AI/Directives/ClientContextDirective.php';
 require_once __DIR__ . '/Engine/AI/Directives/DailyMemorySelectorDirective.php';
 require_once __DIR__ . '/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php';

--- a/inc/migrations/composable-files.php
+++ b/inc/migrations/composable-files.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Data Machine — Composable file auto-regeneration.
+ *
+ * Regenerates composable files (e.g. AGENTS.md) when the plugin landscape
+ * changes (activation/deactivation), since those events add or remove
+ * registered sections.
+ *
+ * @package DataMachine
+ * @since   0.68.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Regenerate all composable files.
+ *
+ * Debounced via a 60-second transient to prevent excessive writes during
+ * bulk plugin operations. Uses ComposableFileGenerator::regenerate_all()
+ * which iterates every composable file in the MemoryFileRegistry.
+ *
+ * @since 0.68.0
+ * @return void
+ */
+function datamachine_regenerate_composable_files(): void {
+	// Debounce: skip if we regenerated in the last 60 seconds.
+	if ( get_transient( 'datamachine_composable_regenerating' ) ) {
+		return;
+	}
+	set_transient( 'datamachine_composable_regenerating', 1, 60 );
+
+	if ( ! class_exists( '\DataMachine\Engine\AI\ComposableFileGenerator' ) ) {
+		return;
+	}
+
+	\DataMachine\Engine\AI\ComposableFileGenerator::regenerate_all();
+}
+
+/**
+ * Register hooks that trigger composable file regeneration.
+ *
+ * Plugin activation/deactivation can add or remove SectionRegistry entries,
+ * so the composable files must be rebuilt to reflect the new section set.
+ *
+ * @since 0.68.0
+ * @return void
+ */
+function datamachine_register_composable_file_invalidation(): void {
+	$callback = 'datamachine_regenerate_composable_files';
+
+	add_action( 'activated_plugin', $callback );
+	add_action( 'deactivated_plugin', $callback );
+}

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -19,4 +19,5 @@ require_once __DIR__ . '/scaffolding.php';
 require_once __DIR__ . '/site-md.php';
 require_once __DIR__ . '/backfill.php';
 require_once __DIR__ . '/network-scope.php';
+require_once __DIR__ . '/composable-files.php';
 require_once __DIR__ . '/flows.php';


### PR DESCRIPTION
## Summary

- Add `datamachine_regenerate_composable_files()` with 60s debounce
- Hook `activated_plugin` and `deactivated_plugin` to trigger regeneration
- Follows the same pattern as existing SITE.md auto-regeneration

## Problem

AGENTS.md is assembled from sections registered by plugins via `SectionRegistry`. When a plugin is activated or deactivated (adding/removing sections), the file was never rebuilt. Agents read a stale AGENTS.md missing entire sections (e.g. Intelligence's wiki commands).

## Fix

Add auto-regeneration hooks that call `ComposableFileGenerator::regenerate_all()` when plugins change. Uses a 60-second transient debounce to prevent excessive writes during bulk operations.

Fixes #1058

## Related

- Extra-Chill/data-machine-code#18 — filterable WP-CLI prefix
- Automattic/intelligence PR for the Studio filter hook