### PR TITLE
feat: add datamachine/get-backlinks ability

### DIFF
--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -5,11 +5,12 @@
  * Ability endpoints for AI-powered internal link insertion and diagnostics.
  * Delegates async execution to the System Agent infrastructure.
  *
- * Six abilities:
+ * Seven abilities:
  * - datamachine/internal-linking        — Queue system agent link insertion.
  * - datamachine/diagnose-internal-links — Meta-based coverage report.
  * - datamachine/audit-internal-links    — Scan content, build + cache link graph.
  * - datamachine/get-orphaned-posts      — Read orphaned posts from cached graph.
+ * - datamachine/get-backlinks           — Get all posts linking to a given post.
  * - datamachine/check-broken-links      — HTTP HEAD checks on cached graph links.
  * - datamachine/link-opportunities      — Ranked linking opportunities from GSC + link graph.
  *
@@ -229,6 +230,54 @@ class InternalLinkingAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'getOrphanedPosts' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/get-backlinks',
+				array(
+					'label'               => 'Get Backlinks',
+					'description'         => 'Get all posts that link to a given post. Returns source posts with titles and permalinks from the cached link graph. Runs audit automatically if no cache exists.',
+					'category'            => 'datamachine/seo',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'post_id' ),
+						'properties' => array(
+							'post_id'   => array(
+								'type'        => 'integer',
+								'description' => 'The post ID to get backlinks for.',
+							),
+							'post_type' => array(
+								'type'        => 'string',
+								'description' => 'Post type scope for the link graph. Default: post.',
+								'default'     => 'post',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'        => array( 'type' => 'boolean' ),
+							'post_id'        => array( 'type' => 'integer' ),
+							'backlink_count' => array( 'type' => 'integer' ),
+							'backlinks'      => array(
+								'type'  => 'array',
+								'items' => array(
+									'type'       => 'object',
+									'properties' => array(
+										'source_id'  => array( 'type' => 'integer' ),
+										'title'      => array( 'type' => 'string' ),
+										'permalink'  => array( 'type' => 'string' ),
+										'link_count' => array( 'type' => 'integer' ),
+									),
+								),
+							),
+							'from_cache'     => array( 'type' => 'boolean' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'getBacklinks' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
@@ -707,6 +756,79 @@ class InternalLinkingAbilities {
 			'orphaned_count' => count( $graph['orphaned_posts'] ?? array() ),
 			'total_scanned'  => $graph['total_scanned'] ?? 0,
 			'orphaned_posts' => $orphaned,
+			'from_cache'     => $from_cache,
+		);
+	}
+
+	/**
+	 * Get all posts that link to a given post (backlinks).
+	 *
+	 * Reads from the cached link graph. If no cache exists, runs an audit
+	 * automatically. Groups multiple links from the same source into a
+	 * single entry with a link_count.
+	 *
+	 * @since 0.68.0
+	 *
+	 * @param array $input Ability input with required 'post_id'.
+	 * @return array Ability response.
+	 */
+	public static function getBacklinks( array $input = array() ): array {
+		$post_id    = absint( $input['post_id'] ?? 0 );
+		$post_type  = sanitize_text_field( $input['post_type'] ?? 'post' );
+		$from_cache = true;
+
+		if ( 0 === $post_id ) {
+			return array(
+				'success' => false,
+				'error'   => 'post_id is required.',
+			);
+		}
+
+		$graph = get_transient( self::GRAPH_TRANSIENT_KEY );
+		if ( false === $graph || ! is_array( $graph ) || ( $graph['post_type'] ?? '' ) !== $post_type ) {
+			// No cache — run audit.
+			$graph = self::buildLinkGraph( $post_type, '', array() );
+			if ( isset( $graph['error'] ) ) {
+				return $graph;
+			}
+			set_transient( self::GRAPH_TRANSIENT_KEY, $graph, self::GRAPH_CACHE_TTL );
+			$from_cache = false;
+		}
+
+		$all_links   = $graph['_all_links'] ?? array();
+		$id_to_title = $graph['_id_to_title'] ?? array();
+
+		// Filter links where target_id matches, group by source_id.
+		$sources = array();
+		foreach ( $all_links as $link ) {
+			if ( ( $link['target_id'] ?? null ) === $post_id ) {
+				$source_id = $link['source_id'];
+				if ( ! isset( $sources[ $source_id ] ) ) {
+					$sources[ $source_id ] = 0;
+				}
+				++$sources[ $source_id ];
+			}
+		}
+
+		// Build the response array with titles and permalinks.
+		$backlinks = array();
+		foreach ( $sources as $source_id => $link_count ) {
+			$backlinks[] = array(
+				'source_id'  => $source_id,
+				'title'      => $id_to_title[ $source_id ] ?? '',
+				'permalink'  => get_permalink( $source_id ) ?: '',
+				'link_count' => $link_count,
+			);
+		}
+
+		// Sort by link count descending (most links first).
+		usort( $backlinks, fn( $a, $b ) => $b['link_count'] <=> $a['link_count'] );
+
+		return array(
+			'success'        => true,
+			'post_id'        => $post_id,
+			'backlink_count' => count( $backlinks ),
+			'backlinks'      => $backlinks,
 			'from_cache'     => $from_cache,
 		);
 	}

--- a/inc/Api/InternalLinks.php
+++ b/inc/Api/InternalLinks.php
@@ -3,10 +3,11 @@
  * Internal Links REST API Endpoints
  *
  * Provides REST API access to internal link audit and diagnostics:
- * - POST /datamachine/v1/links/audit    — Build + cache link graph.
- * - GET  /datamachine/v1/links/orphans  — Orphaned posts from cached graph.
- * - POST /datamachine/v1/links/broken   — HTTP HEAD check for broken links.
- * - GET  /datamachine/v1/links/diagnose — Meta-based coverage report.
+ * - POST /datamachine/v1/links/audit      — Build + cache link graph.
+ * - GET  /datamachine/v1/links/orphans    — Orphaned posts from cached graph.
+ * - GET  /datamachine/v1/links/backlinks  — Posts linking to a given post.
+ * - POST /datamachine/v1/links/broken     — HTTP HEAD check for broken links.
+ * - GET  /datamachine/v1/links/diagnose   — Meta-based coverage report.
  *
  * Each endpoint delegates to InternalLinkingAbilities via wp_get_ability().
  * All endpoints require manage_options capability.
@@ -36,11 +37,15 @@ class InternalLinks {
 			'ability' => 'datamachine/audit-internal-links',
 			'method'  => WP_REST_Server::CREATABLE,
 		),
-		'orphans'  => array(
+		'orphans'   => array(
 			'ability' => 'datamachine/get-orphaned-posts',
 			'method'  => WP_REST_Server::READABLE,
 		),
-		'broken'   => array(
+		'backlinks' => array(
+			'ability' => 'datamachine/get-backlinks',
+			'method'  => WP_REST_Server::READABLE,
+		),
+		'broken'    => array(
 			'ability' => 'datamachine/check-broken-links',
 			'method'  => WP_REST_Server::CREATABLE,
 		),

--- a/inc/Cli/Commands/LinksCommand.php
+++ b/inc/Cli/Commands/LinksCommand.php
@@ -10,6 +10,7 @@
  * - diagnose       — Meta-based coverage report.
  * - audit          — Scan content, build + cache link graph.
  * - orphans        — List orphaned posts (zero inbound links).
+ * - backlinks      — Get all posts linking to a given post.
  * - opportunities  — Ranked linking opportunities (GSC traffic + link graph).
  * - broken         — HTTP HEAD checks for broken internal links.
  *
@@ -529,6 +530,99 @@ class LinksCommand extends BaseCommand {
 		);
 
 		WP_CLI::success( sprintf( '%d orphaned post(s) out of %d scanned.', $orphaned_count, $total_scanned ) );
+	}
+
+	/**
+	 * Get all posts that link to a given post (backlinks).
+	 *
+	 * Reads from the cached link graph. Runs a full audit automatically
+	 * if no cache exists.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_id>
+	 * : The post ID to get backlinks for.
+	 *
+	 * [--post_type=<type>]
+	 * : Post type scope for the link graph.
+	 * ---
+	 * default: post
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * [--fields=<fields>]
+	 * : Limit output to specific fields (comma-separated).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Get backlinks for post 42
+	 *     wp datamachine links backlinks 42
+	 *
+	 *     # JSON output
+	 *     wp datamachine links backlinks 42 --format=json
+	 *
+	 *     # Scan wiki post type
+	 *     wp datamachine links backlinks 42 --post_type=wiki
+	 *
+	 * @subcommand backlinks
+	 */
+	public function backlinks( array $args, array $assoc_args ): void {
+		$post_id   = absint( $args[0] ?? 0 );
+		$format    = $assoc_args['format'] ?? 'table';
+		$post_type = $assoc_args['post_type'] ?? 'post';
+
+		if ( 0 === $post_id ) {
+			WP_CLI::error( 'post_id is required.' );
+			return;
+		}
+
+		$result = InternalLinkingAbilities::getBacklinks(
+			array(
+				'post_id'   => $post_id,
+				'post_type' => $post_type,
+			)
+		);
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to get backlinks.' );
+			return;
+		}
+
+		$backlink_count = (int) ( $result['backlink_count'] ?? 0 );
+		$from_cache     = $result['from_cache'] ?? false;
+
+		if ( $from_cache ) {
+			WP_CLI::log( 'Reading from cached link graph.' );
+		} else {
+			WP_CLI::log( 'No cache found — ran full audit.' );
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( \wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		if ( empty( $result['backlinks'] ) ) {
+			WP_CLI::success( sprintf( 'No backlinks found for post %d.', $post_id ) );
+			return;
+		}
+
+		$this->format_items(
+			$result['backlinks'],
+			array( 'source_id', 'title', 'link_count', 'permalink' ),
+			$assoc_args
+		);
+
+		WP_CLI::success( sprintf( '%d post(s) link to post %d.', $backlink_count, $post_id ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/InternalLinkAudit.php
+++ b/inc/Engine/AI/Tools/Global/InternalLinkAudit.php
@@ -6,9 +6,10 @@
  * Delegates to InternalLinkingAbilities for execution.
  *
  * Available actions:
- * - audit:   Scan content and build link graph (cached 24hr).
- * - orphans: Get orphaned posts from cached graph.
- * - broken:  HTTP HEAD checks for broken links (internal, external, or all).
+ * - audit:     Scan content and build link graph (cached 24hr).
+ * - orphans:   Get orphaned posts from cached graph.
+ * - backlinks: Get all posts linking to a given post.
+ * - broken:    HTTP HEAD checks for broken links (internal, external, or all).
  *
  * @package DataMachine\Engine\AI\Tools\Global
  * @since 0.32.0
@@ -23,21 +24,22 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class InternalLinkAudit extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'internal_link_audit', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'abilities' => array( 'datamachine/audit-internal-links', 'datamachine/get-orphaned-posts', 'datamachine/check-broken-links' ) ) );
+		$this->registerTool( 'internal_link_audit', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'abilities' => array( 'datamachine/audit-internal-links', 'datamachine/get-orphaned-posts', 'datamachine/get-backlinks', 'datamachine/check-broken-links' ) ) );
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
 		$action = $parameters['action'] ?? 'audit';
 
 		$ability_map = array(
-			'audit'   => 'datamachine/audit-internal-links',
-			'orphans' => 'datamachine/get-orphaned-posts',
-			'broken'  => 'datamachine/check-broken-links',
+			'audit'     => 'datamachine/audit-internal-links',
+			'orphans'   => 'datamachine/get-orphaned-posts',
+			'backlinks' => 'datamachine/get-backlinks',
+			'broken'    => 'datamachine/check-broken-links',
 		);
 
 		if ( ! isset( $ability_map[ $action ] ) ) {
 			return $this->buildErrorResponse(
-				sprintf( 'Invalid action "%s". Valid: audit, orphans, broken.', $action ),
+				sprintf( 'Invalid action "%s". Valid: audit, orphans, backlinks, broken.', $action ),
 				'internal_link_audit'
 			);
 		}
@@ -89,14 +91,19 @@ class InternalLinkAudit extends BaseTool {
 		return array(
 			'class'           => __CLASS__,
 			'method'          => 'handle_tool_call',
-			'description'     => 'Audit links on this WordPress site. Three actions: "audit" scans post content to build a link graph (cached 24hr), "orphans" lists posts with zero inbound links from the cached graph, "broken" performs HTTP HEAD checks on cached links to find broken URLs (expensive, supports internal/external/all scope). Always run "audit" first, then use "orphans" or "broken" for specific checks.',
+			'description'     => 'Audit links on this WordPress site. Four actions: "audit" scans post content to build a link graph (cached 24hr), "orphans" lists posts with zero inbound links, "backlinks" gets all posts linking to a given post_id, "broken" performs HTTP HEAD checks for broken URLs (expensive, supports internal/external/all scope). Always run "audit" first, then use other actions for specific checks.',
 			'requires_config' => false,
 			'parameters'      => array(
 				'action'    => array(
 					'type'        => 'string',
 					'required'    => true,
-					'description' => 'Action to perform: "audit" (scan + cache link graph), "orphans" (list orphaned posts), or "broken" (HTTP check for broken links).',
-					'enum'        => array( 'audit', 'orphans', 'broken' ),
+					'description' => 'Action to perform: "audit" (scan + cache link graph), "orphans" (list orphaned posts), "backlinks" (get posts linking to a given post_id), or "broken" (HTTP check for broken links).',
+					'enum'        => array( 'audit', 'orphans', 'backlinks', 'broken' ),
+				),
+				'post_id'   => array(
+					'type'        => 'integer',
+					'required'    => false,
+					'description' => 'Post ID to get backlinks for (backlinks action only).',
 				),
 				'post_type' => array(
 					'type'        => 'string',


### PR DESCRIPTION
## Summary

- New **`datamachine/get-backlinks`** ability — given a post ID, returns all posts that link to it
- No new scanning infrastructure — reads from the existing cached link graph built by `audit-internal-links`
- Groups multiple links from the same source post into a single entry with `link_count`
- Sorted by link count descending (most links first)

## Surfaces

| Interface | Endpoint |
|-----------|----------|
| **Ability** | `datamachine/get-backlinks` |
| **REST API** | `GET /datamachine/v1/links/backlinks?post_id=42` |
| **WP-CLI** | `wp datamachine links backlinks 42 [--post_type=wiki]` |
| **AI Tool** | `internal_link_audit` action=`backlinks` post_id=42 |

## Why

The link graph already tracks `source_id → target_id` for every internal link. Backlinks is just the reverse query — "which posts link TO this post?" This was the missing piece for Intelligence to render "Linked from" panels on wiki articles, and it's useful for any site running Data Machine (SEO diagnostics, content strategy, knowledge base navigation).

## Design

Follows the exact same pattern as `getOrphanedPosts`:
1. Read from cached graph (transient)
2. If no cache, auto-run `buildLinkGraph()`
3. Filter `_all_links` where `target_id` matches
4. Group by `source_id`, include title + permalink

Related Intelligence issue: Automattic/intelligence#46