### PR TITLE
Fix: restore datamachine/pagespeed ability name

### DIFF
--- a/inc/Abilities/Analytics/PageSpeedAbilities.php
+++ b/inc/Abilities/Analytics/PageSpeedAbilities.php
@@ -83,7 +83,7 @@ class PageSpeedAbilities {
 	private function registerAbilities(): void {
 		$register_callback = function () {
 			wp_register_ability(
-				'datamachine-pagespeed',
+				'datamachine/pagespeed',
 				array(
 					'label'               => 'PageSpeed Insights',
 					'description'         => 'Run Lighthouse audits via PageSpeed Insights API for performance, accessibility, SEO, and best practices scores',


### PR DESCRIPTION
## Summary

- The category slug migration in #1066 accidentally changed the ability name from `datamachine/pagespeed` to `datamachine-pagespeed`
- Category slugs use dashes (`datamachine-analytics`) but ability names require a forward slash (`datamachine/pagespeed`) per the WordPress 6.9 Abilities API regex: `/^[a-z0-9-]+\/[a-z0-9-]+$/`
- This caused a `_doing_it_wrong` notice on every CLI call and the PageSpeed ability silently failed to register

## Root Cause

The find-and-replace in #1066 that converted `datamachine/xxx` category references to `datamachine-xxx` was too broad — it also caught this ability name which happened to have the same `datamachine/` prefix format.

## Fix

One-line change: `datamachine-pagespeed` → `datamachine/pagespeed` in `PageSpeedAbilities.php` line 86.