### PR TITLE
Add datamachine_conversation_runner filter for runtime adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,27 @@ Full REST API under `datamachine/v1`:
 
 OpenAI, Anthropic, Google, Grok, OpenRouter — configure a global default per-site, with per-context overrides for pipeline, chat, and system.
 
+## Runtime Adapters
+
+Data Machine ships its own multi-turn conversation loop and uses it by default. The loop is also swappable: a single filter (`datamachine_conversation_runner`) lets an external runtime take over while Data Machine still provides pipelines, flows, tool resolution, abilities, and memory.
+
+```php
+add_filter(
+    'datamachine_conversation_runner',
+    function ( $result, $messages, $tools, $provider, $model, $context, $payload, $max_turns, $single_turn ) {
+        // Return an array matching AIConversationLoop::execute()'s shape to
+        // replace the built-in loop, or null to let Data Machine run it.
+        return my_runtime_run( ... );
+    },
+    10,
+    9
+);
+```
+
+This mirrors the provider pattern used by the bundled AI HTTP Client: providers swap how the LLM is called; runtime adapters swap how the conversation is run. Data Machine makes no assumptions about the host runtime — the filter is the entire contract.
+
+See [`docs/core-system/ai-conversation-loop.md`](docs/core-system/ai-conversation-loop.md#runtime-adapters) for the full adapter contract and return-shape reference.
+
 ## Requirements
 
 - WordPress 6.9+ (Abilities API)

--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -106,77 +106,178 @@ if ($turn_count >= $max_turns && !$conversation_complete) {
 
 ## Usage
 
-### Basic Usage
+### Canonical entry point
+
+All callers should use the static `AIConversationLoop::run()` entry point. It
+accepts the same arguments as `execute()` and returns the same result shape,
+but first gives a registered runtime adapter (via the `datamachine_conversation_runner`
+filter) the opportunity to short-circuit the built-in loop. See
+[Runtime Adapters](#runtime-adapters) below.
 
 ```php
 use DataMachine\Engine\AI\AIConversationLoop;
 
-$loop = new AIConversationLoop();
-$result = $loop->execute(
+$result = AIConversationLoop::run(
     $messages,        // Initial conversation messages
     $tools,           // Available tools for AI
     $provider,        // AI provider (openai, anthropic, etc.)
     $model,           // AI model identifier
-    $agent_type,      // 'pipeline' or 'chat'
-    $context,         // Agent-specific context data
-    $max_turns        // Maximum conversation turns (default: 8)
+    $context,         // 'pipeline' or 'chat'
+    $payload,         // Agent-specific payload data
+    $max_turns,       // Maximum conversation turns (default: 25)
+    $single_turn      // Execute exactly one turn (default: false)
 );
 ```
 
 ### Pipeline Agent Example
 
 ```php
-// Pipeline agent context includes job_id, flow_step_id, payload
-$context = [
-    'step_id' => $flow_step_id,
-    'payload' => [
-        'job_id' => $job_id,
-        'flow_step_id' => $flow_step_id,
-        'data' => $data,
-        'flow_step_config' => $flow_step_config,
-        'engine_data' => $engine_data
-    ]
+// Pipeline payload includes job_id, flow_step_id, data, flow_step_config
+$payload = [
+    'job_id'           => $job_id,
+    'flow_step_id'     => $flow_step_id,
+    'data'             => $data,
+    'flow_step_config' => $flow_step_config,
 ];
 
-$loop = new AIConversationLoop();
-$result = $loop->execute(
+$result = AIConversationLoop::run(
     $messages,
     $tools,
     $provider,
     $model,
     'pipeline',
-    $context,
-    8
+    $payload,
+    $max_turns
 );
 
 $final_data = $result['messages'];
 $turn_count = $result['turn_count'];
-$completed = $result['completed'];
+$completed  = $result['completed'];
 ```
 
 ### Chat Agent Example
 
 ```php
-// Chat agent context includes session_id
-$context = [
-    'session_id' => $session_id
+// Chat payload includes session_id, user_id, agent_id
+$payload = [
+    'session_id' => $session_id,
+    'user_id'    => $user_id,
+    'agent_id'   => $agent_id,
 ];
 
-$loop = new AIConversationLoop();
-$result = $loop->execute(
+$result = AIConversationLoop::run(
     $messages,
     $tools,
     $provider,
     $model,
     'chat',
-    $context,
-    8
+    $payload,
+    $max_turns,
+    $single_turn
 );
 
 $final_messages = $result['messages'];
-$final_content = $result['final_content'];
-$turn_count = $result['turn_count'];
+$final_content  = $result['final_content'];
+$turn_count     = $result['turn_count'];
 ```
+
+## Runtime Adapters
+
+Data Machine's built-in loop is the default, but the entire conversation
+runtime is swappable via a single filter. This lets a consumer plug Data
+Machine's pipelines, flows, tools, and memory into a different agent runtime
+(for example, a host platform that already provides its own agent loop,
+conversation storage, and channels) without Data Machine knowing anything
+about that runtime.
+
+### The filter
+
+```php
+apply_filters(
+    'datamachine_conversation_runner',
+    null,           // Return non-null to short-circuit the built-in loop
+    $messages,
+    $tools,
+    $provider,
+    $model,
+    $context,
+    $payload,
+    $max_turns,
+    $single_turn
+);
+```
+
+Return an array matching `AIConversationLoop::execute()`'s documented return
+shape to replace the built-in loop. Return `null` (the default) to let Data
+Machine run the conversation itself.
+
+### Adapter contract
+
+An adapter is responsible for:
+
+1. Executing tool calls and appending tool-result messages to `$messages`.
+2. Managing turn count and termination against `$max_turns`.
+3. Returning the exact shape `execute()` returns — `messages`, `final_content`,
+   `turn_count`, `completed`, `last_tool_calls`, `tool_execution_results`,
+   `has_pending_tools`, `usage`, plus optional `error`, `warning`, and
+   `max_turns_reached` keys.
+
+Data Machine makes no assumptions about how the adapter produces that result.
+A consumer can delegate to any external runtime — its own `Agent` subclass, a
+remote RPC service, a different language — as long as the return shape is
+honored.
+
+### Minimal adapter example
+
+```php
+add_filter(
+    'datamachine_conversation_runner',
+    function ( $result, $messages, $tools, $provider, $model, $context, $payload, $max_turns, $single_turn ) {
+        // Only take over for a specific context.
+        if ( 'chat' !== $context ) {
+            return $result;
+        }
+
+        // Delegate to an external runtime that returns the expected shape.
+        return my_external_runtime_run( [
+            'messages'    => $messages,
+            'tools'       => $tools,
+            'provider'    => $provider,
+            'model'       => $model,
+            'payload'     => $payload,
+            'max_turns'   => $max_turns,
+            'single_turn' => $single_turn,
+        ] );
+    },
+    10,
+    9
+);
+```
+
+### Mirrors the AI HTTP Client provider pattern
+
+This is the same extension shape Data Machine's AI HTTP Client uses to allow
+different LLM providers (OpenAI, Anthropic, Gemini, Grok, OpenRouter) to be
+registered via `chubes_ai_request`. A runtime adapter is the same idea, one
+layer up: providers swap how the LLM is called; runtime adapters swap how the
+conversation is run.
+
+### Relationship to wp-ai-client migration (#1027)
+
+Runtime adapters and the upcoming wp-ai-client migration operate at different
+layers and are independent:
+
+- `datamachine_conversation_runner` replaces the **conversation loop** — turn
+  management, tool execution, completion detection.
+- The wp-ai-client migration (see Extra-Chill/data-machine#1027) replaces the
+  **LLM request layer** that the built-in loop calls internally — a single
+  HTTP call to an LLM provider.
+
+When wp-ai-client lands, Data Machine's built-in `execute()` will call
+`wp_ai_client_prompt()` in place of `apply_filters('chubes_ai_request', ...)`.
+The `run()` entry point and the `datamachine_conversation_runner` filter
+contract are unchanged, and adapters that replace the entire loop are
+unaffected — they bring their own LLM client as part of their runtime.
 
 ## Configuration
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -902,27 +902,48 @@ Builds parameters for handler-specific tools with engine data merging (source_ur
 
 **Purpose**: Multi-turn conversation execution with automatic tool calling.
 
-**Core Method**:
+**Canonical entry point**:
 
-#### `execute()`
 ```php
-$loop = new \DataMachine\Engine\AI\AIConversationLoop();
-$final_response = $loop->execute(
-    array $initial_messages,
-    array $available_tools,
-    string $provider_name,
+$final_response = \DataMachine\Engine\AI\AIConversationLoop::run(
+    array $messages,
+    array $tools,
+    string $provider,
     string $model,
-    string $agent_type,      // 'pipeline' or 'chat'
-    array $context
+    string $context,         // 'pipeline', 'chat', etc.
+    array $payload = [],
+    int $max_turns = 25,
+    bool $single_turn = false
 ): array
 ```
+
+`run()` internally applies the `datamachine_conversation_runner` filter, giving
+a registered runtime adapter the chance to short-circuit the built-in loop. If
+no adapter returns an array, Data Machine's built-in `execute()` runs.
+
+**Filter: `datamachine_conversation_runner`**
+
+```php
+apply_filters(
+    'datamachine_conversation_runner',
+    null,           // Return non-null array to short-circuit
+    $messages, $tools, $provider, $model,
+    $context, $payload, $max_turns, $single_turn
+);
+```
+
+Return an array matching `execute()`'s documented return shape to replace the
+built-in loop. Return `null` (the default) to let Data Machine run the
+conversation. See [ai-conversation-loop.md](../../core-system/ai-conversation-loop.md#runtime-adapters)
+for the full adapter contract.
 
 **Features**:
 - Automatic tool execution during conversation turns
 - Conversation completion detection
 - Turn-based state management with chronological ordering
 - Duplicate message prevention
-- Maximum turn limiting (default: 10)
+- Maximum turn limiting (default: 25)
+- Runtime-swappable via `datamachine_conversation_runner`
 
 ### ConversationManager (`/inc/Engine/AI/ConversationManager.php`)
 

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -670,8 +670,7 @@ class ChatOrchestrator {
 				$loop_context['client_context'] = $client_context;
 			}
 
-			$loop        = new AIConversationLoop();
-			$loop_result = $loop->execute(
+			$loop_result = AIConversationLoop::run(
 				$messages,
 				$all_tools,
 				$provider,

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -276,9 +276,8 @@ class AIStep extends Step {
 		$provider_name = $context_model['provider'];
 		$model_name    = $context_model['model'];
 
-		// Execute conversation loop
-		$loop        = new AIConversationLoop();
-		$loop_result = $loop->execute(
+		// Execute conversation loop via runtime-adapter-aware entry point.
+		$loop_result = AIConversationLoop::run(
 			$messages,
 			$available_tools,
 			$provider_name,

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -27,6 +27,95 @@ if ( ! defined( 'ABSPATH' ) ) {
 class AIConversationLoop {
 
 	/**
+	 * Run a conversation, optionally delegating to an external runtime adapter.
+	 *
+	 * This is the canonical entry point every caller should use instead of
+	 * instantiating AIConversationLoop directly. It exposes a single filter
+	 * (`datamachine_conversation_runner`) that lets a consumer short-circuit the
+	 * built-in loop with an alternative runtime while receiving the exact
+	 * same argument list and returning the exact same result shape. If the
+	 * filter returns null (the default), the built-in loop runs unchanged.
+	 *
+	 * Adapters MUST return an array matching {@see self::execute()}'s
+	 * documented return shape.
+	 *
+	 * @param array  $messages      Initial conversation messages.
+	 * @param array  $tools         Available tools for AI.
+	 * @param string $provider      AI provider identifier.
+	 * @param string $model         AI model identifier.
+	 * @param string $context       Execution context ('pipeline', 'chat', ...).
+	 * @param array  $payload       Step payload / loop context.
+	 * @param int    $max_turns     Maximum conversation turns.
+	 * @param bool   $single_turn   Execute exactly one turn and return.
+	 * @return array Result array matching self::execute() shape.
+	 */
+	public static function run(
+		array $messages,
+		array $tools,
+		string $provider,
+		string $model,
+		string $context,
+		array $payload = array(),
+		int $max_turns = PluginSettings::DEFAULT_MAX_TURNS,
+		bool $single_turn = false
+	): array {
+		/**
+		 * Filter: allow a consumer to replace Data Machine's built-in
+		 * conversation loop with an alternative runtime.
+		 *
+		 * Return an array matching {@see AIConversationLoop::execute()}'s
+		 * documented return shape to short-circuit the built-in loop.
+		 * Return null (the default) to let the built-in loop run.
+		 *
+		 * Data Machine makes no assumptions about the consumer's runtime —
+		 * the filter is the only contract. Adapters are responsible for
+		 * executing tools, managing turns, and producing the expected
+		 * result shape.
+		 *
+		 * @since next
+		 *
+		 * @param array|null $result       Null to run the built-in loop, or an
+		 *                                 AIConversationLoop::execute() return array.
+		 * @param array      $messages     Initial conversation messages.
+		 * @param array      $tools        Available tools for AI.
+		 * @param string     $provider     AI provider identifier.
+		 * @param string     $model        AI model identifier.
+		 * @param string     $context      Execution context.
+		 * @param array      $payload      Step payload / loop context.
+		 * @param int        $max_turns    Maximum conversation turns.
+		 * @param bool       $single_turn  Single-turn mode flag.
+		 */
+		$result = apply_filters(
+			'datamachine_conversation_runner',
+			null,
+			$messages,
+			$tools,
+			$provider,
+			$model,
+			$context,
+			$payload,
+			$max_turns,
+			$single_turn
+		);
+
+		if ( is_array( $result ) ) {
+			return $result;
+		}
+
+		$loop = new self();
+		return $loop->execute(
+			$messages,
+			$tools,
+			$provider,
+			$model,
+			$context,
+			$payload,
+			$max_turns,
+			$single_turn
+		);
+	}
+
+	/**
 	 * Execute conversation loop
 	 *
 	 * @param array  $messages      Initial conversation messages


### PR DESCRIPTION
## Summary

Introduce a single filter (`datamachine_conversation_runner`) that lets a consumer swap Data Machine's built-in conversation loop with an alternative agent runtime, while keeping pipelines, flows, tool resolution, abilities, and memory intact. Data Machine makes no assumptions about the host runtime — the filter is the entire contract.

## Motivation

Data Machine is solid agent infrastructure — pipelines, flows, scheduled jobs, handler tools, abilities, ability categories, multi-agent identity. Consumers that want to run on top of a different conversation loop (for example, a host platform that provides its own agent base class, conversation storage, and channels) currently can't. This adds one extension point so that becomes possible without Data Machine knowing anything about the consumer.

Mirrors the AI HTTP Client provider extension pattern: LLM providers are registered via `chubes_ai_request`, runtime adapters are registered via `datamachine_conversation_runner`. Same shape, one layer up — providers swap how the LLM is called, runtime adapters swap how the conversation is run.

## Changes

### Code (3 files)
- `inc/Engine/AI/AIConversationLoop.php` — new `public static function run(...)` that applies `datamachine_conversation_runner` and falls through to `new self()->execute(...)` if no adapter short-circuits. `execute()` itself is unchanged.
- `inc/Core/Steps/AI/AIStep.php` — call `AIConversationLoop::run(...)` instead of `new AIConversationLoop(); $loop->execute(...)`
- `inc/Api/Chat/ChatOrchestrator.php` — same swap

### Docs (3 files)
- `docs/core-system/ai-conversation-loop.md` — updated usage examples to `::run()`, added "Runtime Adapters" section with filter signature, adapter contract, minimal example, and cross-reference to #1027
- `docs/development/hooks/core-filters.md` — updated AIConversationLoop entry with `::run()` as canonical and documented the filter
- `README.md` — added `## Runtime Adapters` section alongside `## AI Providers`

## Filter signature

```php
apply_filters(
    'datamachine_conversation_runner',
    null,           // Return non-null array to short-circuit the built-in loop
    $messages,
    $tools,
    $provider,
    $model,
    $context,       // 'pipeline', 'chat', etc.
    $payload,
    $max_turns,
    $single_turn
);
```

Adapters return an array matching `AIConversationLoop::execute()`'s documented return shape to replace the built-in loop. Returning `null` (the default) runs the built-in loop unchanged.

## Behavior when no adapter is registered

Identical. `::run()` falls straight through to `new self()->execute(...)` with the same arguments. Zero behavior change for existing installs.

## Relationship to wp-ai-client migration (#1027)

The two changes operate at different layers and are independent:

- `datamachine_conversation_runner` replaces the **conversation loop** — turn management, tool execution, completion detection
- #1027 replaces the **LLM request layer** that the built-in loop calls internally — a single HTTP call to an LLM provider

When #1027 lands, the internals of `execute()` will switch from `apply_filters('chubes_ai_request', ...)` to `wp_ai_client_prompt()`. The `run()` entry point and the filter contract are unchanged. Adapters that replace the entire loop are unaffected — they bring their own LLM client as part of their runtime.

## Testing

- `php -l` clean on all three modified PHP files
- `execute()` method body untouched — existing behavior preserved
- Both call sites (pipeline AI step, chat orchestrator) now go through `::run()`; grepped for any remaining `new AIConversationLoop` outside docs