### PR TITLE
Remove Rules and Context from SOUL.md template, remove ghost content guidelines from RULES.md

### DIFF
--- a/inc/migrations/scaffolding.php
+++ b/inc/migrations/scaffolding.php
@@ -133,15 +133,14 @@ function datamachine_get_scaffold_defaults( string $agent_name = '' ): array {
 	$soul = <<<MD
 # Agent Soul — {$site_name}
 
+This file defines your personality. Customize it to shape how you communicate.
+
 ## Identity
 {$identity_line}
 {$identity_meta}
 
 ## Voice & Tone
-Write in a clear, helpful tone.
-
-## Continuity
-SOUL.md (this file) defines who you are. RULES.md contains behavioral constraints. USER.md profiles your human. MEMORY.md tracks persistent knowledge. Daily memory files (daily/YYYY/MM/DD.md) capture session activity — the system generates daily summaries automatically. Keep MEMORY.md lean: persistent facts only, not session logs.
+You are {$agent_name}. Write like {$agent_name} would — not like a generic assistant. Ask your human how they want you to communicate, then write the answer here. If they'd rather just work, match their tone from how they talk to you.
 MD;
 
 	// --- USER.md ---
@@ -158,6 +157,8 @@ MD;
 	$user = <<<MD
 # User Profile
 
+This file profiles your human. Update it when you learn new things about them.
+
 ## About
 {$user_about}
 
@@ -171,6 +172,8 @@ MD;
 	// --- MEMORY.md ---
 	$memory = <<<MD
 # Agent Memory
+
+This file tracks persistent knowledge. Keep it lean — persistent facts only, not session logs.
 
 ## State
 - Data Machine v{$dm_version} activated on {$created}

--- a/inc/migrations/scaffolding.php
+++ b/inc/migrations/scaffolding.php
@@ -140,7 +140,7 @@ This file defines your personality. Customize it to shape how you communicate.
 {$identity_meta}
 
 ## Voice & Tone
-You are {$agent_name}. Write like {$agent_name} would — not like a generic assistant. Ask your human how they want you to communicate, then write the answer here. If they'd rather just work, match their tone from how they talk to you.
+Write in a clear, helpful tone. Match the communication style your human prefers — observe how they talk to you and adapt.
 MD;
 
 	// --- USER.md ---

--- a/inc/migrations/scaffolding.php
+++ b/inc/migrations/scaffolding.php
@@ -140,15 +140,8 @@ function datamachine_get_scaffold_defaults( string $agent_name = '' ): array {
 ## Voice & Tone
 Write in a clear, helpful tone.
 
-## Rules
-- Follow the site's content guidelines
-- Ask for clarification when instructions are ambiguous
-
-## Context
-{$soul_context}
-
 ## Continuity
-SOUL.md (this file) defines who you are. USER.md profiles your human. MEMORY.md tracks persistent knowledge. Daily memory files (daily/YYYY/MM/DD.md) capture session activity — the system generates daily summaries automatically. Keep MEMORY.md lean: persistent facts only, not session logs.
+SOUL.md (this file) defines who you are. RULES.md contains behavioral constraints. USER.md profiles your human. MEMORY.md tracks persistent knowledge. Daily memory files (daily/YYYY/MM/DD.md) capture session activity — the system generates daily summaries automatically. Keep MEMORY.md lean: persistent facts only, not session logs.
 MD;
 
 	// --- USER.md ---
@@ -635,7 +628,6 @@ Behavioral constraints that apply to every agent on {$site_name}.
 - When in doubt, ask before acting.
 
 ## Content
-- Respect the site's content guidelines.
 - Do not publish or modify content without authorization.
 MD;
 }


### PR DESCRIPTION
## Problem

SOUL.md had a `## Rules` section and a `## Context` section that don't belong there:

- **Rules** belong in `RULES.md` — the shared, admin-editable behavioral constraints file. Having rules in SOUL.md means they can't be centrally managed, and they duplicate what RULES.md already says.
- **Context** (site URL, theme, plugins, timezone) is already provided by `SITE.md`, which gets injected into the same context window. Pure duplication.
- "Follow the site's content guidelines" in both SOUL.md and RULES.md referenced a document that **doesn't exist** — hallucination bait.

## Changes

- **SOUL.md template**: Remove `## Rules` section (already in RULES.md)
- **SOUL.md template**: Remove `## Context` section (already in SITE.md)
- **SOUL.md template**: Add RULES.md reference to Continuity section so agents know where to find constraints
- **RULES.md template**: Remove "Respect the site's content guidelines." (ghost reference to nonexistent document)

## Design rationale

File responsibilities should be clean and non-overlapping:
- **SOUL.md** = personality (identity, voice, continuity pointers)
- **RULES.md** = behavioral constraints (what the agent must/must not do)
- **SITE.md** = site metadata (URL, theme, plugins, timezone)

Existing sites with already-scaffolded files are unaffected — this only changes the template for new scaffolds.