### PR TITLE
Scope SOUL.md and MEMORY.md to interactive contexts only

### DIFF
--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -106,17 +106,23 @@ MemoryFileRegistry::register( 'RULES.md', 15, array(
 ) );
 
 // Agent layer — identity and knowledge, scoped to a single agent.
+// Injected in interactive contexts only (chat, pipeline). Excluded from
+// system contexts so autonomous maintenance tasks (e.g. daily memory
+// compaction) are not primed with the agent's identity while operating
+// on these files.
 MemoryFileRegistry::register( 'SOUL.md', 20, array(
 	'layer'       => MemoryFileRegistry::LAYER_AGENT,
 	'protected'   => true,
+	'contexts'    => array( 'chat', 'pipeline' ),
 	'label'       => 'Agent Identity',
-	'description' => 'Agent identity, voice, rules. Rarely changes.',
+	'description' => 'Agent identity, voice, rules. Injected in interactive contexts only.',
 ) );
 MemoryFileRegistry::register( 'MEMORY.md', 30, array(
 	'layer'       => MemoryFileRegistry::LAYER_AGENT,
 	'protected'   => true,
+	'contexts'    => array( 'chat', 'pipeline' ),
 	'label'       => 'Agent Memory',
-	'description' => 'Accumulated knowledge. Grows over time.',
+	'description' => 'Accumulated knowledge. Injected in interactive contexts only.',
 ) );
 
 // User layer — human preferences, network-scoped on multisite.


### PR DESCRIPTION
Fixes #1071.

## Summary

`SOUL.md` and `MEMORY.md` were auto-injected into every AI request via `CoreMemoryFilesDirective` (`contexts => ['all']`). This included the `system` context used by `daily_memory_generation`, whose job is to rewrite `MEMORY.md` itself. The resulting priming — SOUL.md declaring \"I am Franklin\" as a system message immediately before MEMORY.md content — caused the LLM to silently normalize identifiers in the file, producing URLs that 404, filesystem paths that don't exist, and PHP filter names that don't match any registered callback.

The compaction prompt itself is clean. The fix is the framing: don't prime autonomous maintenance tasks with the agent's identity while asking them to operate on that identity's memory.

See #1071 for the full reproduction, observed substitutions, and root-cause trace.

## Change

`inc/bootstrap.php` lines 109-120 — both registrations now explicitly scope to interactive contexts:

```php
MemoryFileRegistry::register( 'SOUL.md', 20, array(
    'layer'       => MemoryFileRegistry::LAYER_AGENT,
    'protected'   => true,
    'contexts'    => array( 'chat', 'pipeline' ),  // added
    'label'       => 'Agent Identity',
    'description' => 'Agent identity, voice, rules. Injected in interactive contexts only.',
) );

MemoryFileRegistry::register( 'MEMORY.md', 30, array(
    'layer'       => MemoryFileRegistry::LAYER_AGENT,
    'protected'   => true,
    'contexts'    => array( 'chat', 'pipeline' ),  // added
    'label'       => 'Agent Memory',
    'description' => 'Accumulated knowledge. Injected in interactive contexts only.',
) );
```

`SITE.md`, `RULES.md`, and `NETWORK.md` remain broadly scoped — they are site/environment context, not agent-identity context, and are relevant for system tasks.

## Why this scope

This mirrors the pattern `USER.md` already uses (line 128: `contexts => ['chat', 'editor']`). The argument is the same: files that describe the agent's relationship to a human belong in contexts where a human is present.

- **chat, pipeline** — agent is acting on behalf of a human. SOUL.md and MEMORY.md are relevant.
- **system** — autonomous maintenance tasks. Agent is not in character. No system task requires these files to be auto-injected; tasks that need memory content (like `DailyMemoryTask`) read it directly from disk and inline it into the user message.
- **editor** — not included in the initial scope because it isn't a documented context in `ToolPolicyResolver::CONTEXT_*` constants. Can be added later if a concrete use case requires it.

## Why not change the prompt instead

Hardening the compaction prompt with a \"preserve literal strings exactly\" rule would mask the real issue. Any future memory file registered with `contexts => 'all'` could re-introduce the priming. Correct the registrations — that's the single point of truth.

## Why not introduce a new context slug

An earlier draft of #1071 proposed adding `system_memory_maintenance` as a distinct context. That's more invasive than necessary. The existing `system` context is correct for memory-maintenance tasks; the fix is correcting *what the existing contexts auto-inject*, not adding new contexts.

## Audit

Grepped `inc/Engine/AI/System/` and `inc/Abilities/` for references to `SOUL.md` / `MEMORY.md` / `AgentMemory::`. No system task, system ability, or background job depends on these files being auto-injected into the prompt context. All references are either:
- Direct reads via `AgentMemory::*` (unaffected by directive scoping)
- Tool schemas that expose the files for agent use (invoked from interactive contexts)
- Protected-file permission checks (static constant, not prompt-related)

## Testing

Verified on a local Studio site running the Intelligence agent where the real user is `chubes` (GitHub `chubes4`, macOS `/Users/chubes/...`) but the agent's SOUL.md says \"I am Franklin\".

### Pre-fix state (from #1071 reproduction, already ran)

One `daily_memory_generation` run silently rewrote MEMORY.md with 8 incorrect substitutions:

| Before | After | Kind |
|---|---|---|
| `intelligence-chubes4` | `intelligence-Franklin4` | agent slug |
| `/Users/chubes/Developer/...` | `/Users/Franklin/Developer/...` | filesystem path |
| `github.com/chubes4/markdown-database-integration` | `github.com/Franklin4/...` | GitHub URL |
| `github.com/chubes4/html-to-blocks-converter` | `github.com/Franklin4/...` | GitHub URL |
| `chubes4/studio` | `Franklin4/studio` | GitHub fork |
| `chubes4/wordpress-playground` | `Franklin4/wordpress-playground` | GitHub fork |
| `chubes_ai_tools` | `Franklin_ai_tools` | PHP filter hook |
| literal \"admin\" | literal \"Franklin\" | DM default agent string |

### Registration plumbing (post-fix)

```
$ wp eval 'MemoryFileRegistry::get_for_context(\"system\")'
  NETWORK.md
  AGENTS.md
  SITE.md
  RULES.md
  # SOUL.md and MEMORY.md correctly absent

$ wp eval 'MemoryFileRegistry::get_for_context(\"chat\")'
  NETWORK.md
  AGENTS.md
  SITE.md
  RULES.md
  SOUL.md
  USER.md
  MEMORY.md
  # All interactive files present
```

### End-to-end test (post-fix)

Ran `wp datamachine system run daily_memory_generation` against the same MEMORY.md (282 lines, 11 `chubes` references, 3 legitimate `Franklin` references from a self-correction note in the file).

Result:
- Job completed successfully (34 seconds, `gpt-5.4-mini`)
- MEMORY.md: 282 → 282 lines (already tight; prior compaction had done the work)
- `chubes` references: 11 → 11 ✓
- `Franklin` references: 3 → 3 ✓
- Bad substitution patterns (`Franklin4`, `/Users/Franklin`, `Franklin_ai_tools`): **zero in MEMORY.md, zero in the daily archive** ✓

## AI assistance disclosure

Per WordPress's [AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/), disclosing meaningful AI assistance on this contribution:

- I used Claude Code to investigate the root cause (tracing `DailyMemoryTask::execute()` through `RequestBuilder` and `CoreMemoryFilesDirective` to the `MemoryFileRegistry` registrations in `bootstrap.php`).
- Claude Code identified the existing `USER.md` precedent in `bootstrap.php` as the right pattern to follow and verified the registration plumbing by reading `MemoryFileRegistry::get_for_context()`.
- The architectural decision — scope the two registrations to `['chat', 'pipeline']` rather than introduce a new context slug or harden the prompt defensively — was made by me after reviewing the options.
- Claude Code drafted the commit message and PR body per my direction.
- I tested the fix end-to-end on a live Studio site and verified both the registration plumbing and the actual daily memory run produced no identity substitutions.

All substantive design decisions and the testing were my own; AI was used for investigation, pattern recognition, and drafting.