### PR TITLE
fix: reject chat sessions for inactive/archived agents

### DIFF
--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -543,6 +543,28 @@ class ChatOrchestrator {
 				: 0;
 		}
 
+		// Reject chat if the agent is not active.
+		if ( $agent_id > 0 ) {
+			$agents_repo = new \DataMachine\Core\Database\Agents\Agents();
+			$agent       = $agents_repo->get_agent( $agent_id );
+
+			if ( $agent && 'active' !== ( $agent['status'] ?? 'active' ) ) {
+				$status = $agent['status'];
+				if ( 'archived' === $status ) {
+					return new WP_Error(
+						'agent_archived',
+						__( 'This agent has been archived.', 'data-machine' ),
+						array( 'status' => 403 )
+					);
+				}
+				return new WP_Error(
+					'agent_inactive',
+					__( 'Your chat agent is currently disabled.', 'data-machine' ),
+					array( 'status' => 403 )
+				);
+			}
+		}
+
 		$ability = wp_get_ability( 'datamachine/create-chat-session' );
 
 		if ( $ability ) {


### PR DESCRIPTION
## Summary

- Adds agent status check in `ChatOrchestrator::createSession()` before a new chat session is created
- Active agents proceed normally
- Inactive agents return 403 with "Your chat agent is currently disabled."
- Archived agents return 403 with "This agent has been archived."
- Existing sessions are **not** interrupted — guard applies only at session creation time

## Why

The `status` column on `datamachine_agents` supports `active`, `inactive`, and `archived` states, but nothing checked it before allowing chat. An inactive or archived agent could still receive new sessions. This gives admins a kill switch for individual agents without deleting them.

Fixes #852