### PR TITLE
feat: add post_parent support to wordpress_publish

### DIFF
--- a/inc/Abilities/Publish/PublishWordPressAbility.php
+++ b/inc/Abilities/Publish/PublishWordPressAbility.php
@@ -87,6 +87,11 @@ class PublishWordPressAbility {
 								'default'     => true,
 								'description' => __( 'Whether to append source attribution to content', 'data-machine' ),
 							),
+							'post_parent'            => array(
+								'type'        => 'integer',
+								'default'     => 0,
+								'description' => __( 'Parent post ID for hierarchical post types (pages, etc.)', 'data-machine' ),
+							),
 							'job_id'                 => array(
 								'type'        => 'integer',
 								'default'     => null,
@@ -211,6 +216,12 @@ class PublishWordPressAbility {
 				array( 'post_author' => $post_author )
 			),
 		);
+
+		// Support hierarchical post types (pages, custom hierarchical CPTs).
+		$post_parent = (int) ( $config['post_parent'] ?? 0 );
+		if ( $post_parent > 0 ) {
+			$post_data['post_parent'] = $post_parent;
+		}
 
 		$logs[] = array(
 			'level'   => 'debug',
@@ -359,6 +370,7 @@ class PublishWordPressAbility {
 			'featured_image_path'    => '',
 			'source_url'             => '',
 			'add_source_attribution' => true,
+			'post_parent'            => 0,
 			'job_id'                 => null,
 		);
 


### PR DESCRIPTION
## Summary

- Adds `post_parent` parameter to the `wordpress_publish` ability input schema (integer, default 0)
- Passes `post_parent` through to `wp_insert_post()` when set to a non-zero value
- Adds `post_parent` to `normalizeConfig()` defaults
- Enables publishing to hierarchical post types (pages, custom CPTs) with a parent relationship

## Use case

Any pipeline that needs to publish to a hierarchical CPT and place the new post under an existing parent. Concrete examples: pages under a section, knowledge base articles under a topic, wiki entries under a parent.

Fixes #1073