### PR TITLE
fix: resolve lint/audit findings (#982, #981, #835, #865)

### DIFF
--- a/inc/Abilities/Content/InsertContentAbility.php
+++ b/inc/Abilities/Content/InsertContentAbility.php
@@ -247,7 +247,7 @@ class InsertContentAbility {
 				'post_id'        => $post_id,
 				'post_url'       => get_permalink( $post_id ),
 				'position'       => $position,
-				'insertion_point'=> $insertion_point,
+				'insertion_point' => $insertion_point,
 				'new_content'    => $new_content,
 			);
 		}
@@ -275,7 +275,7 @@ class InsertContentAbility {
 				'searchPattern'      => '',
 				'caseSensitive'      => false,
 				'isPreview'          => true,
-				'previewBlockContent'=> $block_content,
+				'previewBlockContent' => $block_content,
 				'originalBlockContent' => '',
 				'originalBlockType'  => 'core/paragraph',
 			),

--- a/inc/Abilities/Email/EmailAbilities.php
+++ b/inc/Abilities/Email/EmailAbilities.php
@@ -955,7 +955,7 @@ class EmailAbilities {
 			}
 		}
 
-		$has_one_click = stripos( $post_header, 'List-Unsubscribe=One-Click' ) !== false;
+		$has_one_click = false !== stripos( $post_header, 'List-Unsubscribe=One-Click' );
 
 		return array(
 			'urls'          => $urls,

--- a/inc/Api/Email.php
+++ b/inc/Api/Email.php
@@ -243,7 +243,7 @@ class Email {
 		);
 	}
 
-	public static function check_permission(): bool {
+	public static function check_permission( \WP_REST_Request $request ): bool {
 		return PermissionHelper::can_manage();
 	}
 

--- a/inc/Api/System/System.php
+++ b/inc/Api/System/System.php
@@ -449,6 +449,7 @@ class System {
 		if ( ! isset( $handlers[ $task_type ] ) ) {
 			return new WP_Error(
 				'invalid_task_type',
+			// translators: %s: task type identifier.
 				sprintf( __( 'Unknown task type: %s', 'data-machine' ), $task_type ),
 				array( 'status' => 404 )
 			);
@@ -459,6 +460,7 @@ class System {
 		if ( ! class_exists( $handler_class ) ) {
 			return new WP_Error(
 				'task_class_missing',
+			// translators: %s: fully-qualified task handler class name.
 				sprintf( __( 'Task handler class not found: %s', 'data-machine' ), $handler_class ),
 				array( 'status' => 500 )
 			);
@@ -470,6 +472,7 @@ class System {
 		if ( ! isset( $definitions[ $prompt_key ] ) ) {
 			return new WP_Error(
 				'invalid_prompt_key',
+			// translators: 1: prompt key name, 2: task type identifier.
 				sprintf( __( 'Unknown prompt key "%1$s" for task type "%2$s".', 'data-machine' ), $prompt_key, $task_type ),
 				array( 'status' => 404 )
 			);


### PR DESCRIPTION
## Summary

Fixes 4 real lint/audit findings and documents 3 false positives filed against homeboy.

### Real fixes

| Issue | File | Fix |
|-------|------|-----|
| #982 — yoda (1) | `EmailAbilities.php` | Flip `stripos() !== false` to Yoda: `false !== stripos()` |
| #981 — whitespace (2) | `InsertContentAbility.php` | Add missing spaces before `=>` in array pairs |
| #835 — signature mismatch (1) | `inc/Api/Email.php` | Add `WP_REST_Request $request` param to `check_permission()` |
| #865 — i18n (3) | `inc/Api/System/System.php` | Add `translators:` comments above `__()` calls with placeholders |

### False positives filed against homeboy

| Issue | Root cause |
|-------|------------|
| homeboy#1134 | `namespace_mismatch` on PHP reserved word `Global` in namespace segment |
| homeboy#1135 | `missing_import` flags same-namespace references and self-imports |
| homeboy#1136 | `unused_function_parameter` flags required REST/filter contract params |

Fixes #982, Fixes #981, Fixes #835, Fixes #865