### PR TITLE
fix: remove agent status field — dead weight

### DIFF
--- a/inc/Api/Agents.php
+++ b/inc/Api/Agents.php
@@ -131,12 +131,6 @@ class Agents {
 							'required'    => false,
 							'description' => __( 'New configuration (replaces existing).', 'data-machine' ),
 						),
-						'status'       => array(
-							'type'              => 'string',
-							'required'          => false,
-							'description'       => __( 'New status (active, inactive, archived).', 'data-machine' ),
-							'sanitize_callback' => 'sanitize_text_field',
-						),
 					),
 				),
 				array(
@@ -363,7 +357,6 @@ class Agents {
 			'agent_slug' => $agent['agent_slug'],
 			'agent_name' => $agent['agent_name'],
 			'owner_id'   => (int) $agent['owner_id'],
-			'status'     => $agent['status'] ?? 'active',
 			'site_url'   => get_site_url(),
 			'site_name'  => get_bloginfo( 'name' ),
 		);
@@ -515,9 +508,6 @@ class Agents {
 		}
 		if ( array_key_exists( 'agent_config', $json_params ) ) {
 			$input['agent_config'] = $json_params['agent_config'];
-		}
-		if ( array_key_exists( 'status', $json_params ) ) {
-			$input['status'] = $json_params['status'];
 		}
 
 		$result = AgentAbilities::updateAgent( $input );

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentListTab.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentListTab.jsx
@@ -2,8 +2,8 @@
  * AgentListTab Component
  *
  * Agent management list table with create and delete functionality.
- * WordPress admin-style list table showing all agents with status,
- * owner, and timestamps.
+ * WordPress admin-style list table showing all agents with owner
+ * and timestamps.
  */
 
 /**
@@ -27,15 +27,6 @@ import {
 } from '../queries/agents';
 import CreateAgentModal from '@shared/components/CreateAgentModal';
 import { useAgentStore } from '@shared/stores/agentStore';
-
-/**
- * Status badge colors.
- */
-const STATUS_STYLES = {
-	active: { background: '#d4edda', color: '#155724' },
-	inactive: { background: '#fff3cd', color: '#856404' },
-	archived: { background: '#f8d7da', color: '#721c24' },
-};
 
 /**
  * Format a date string for display.
@@ -127,9 +118,6 @@ const AgentListTab = ( { onSelectAgent } ) => {
 							<th className="column-slug">
 								{ __( 'Slug', 'data-machine' ) }
 							</th>
-							<th className="column-status">
-								{ __( 'Status', 'data-machine' ) }
-							</th>
 							<th className="column-created">
 								{ __( 'Created', 'data-machine' ) }
 							</th>
@@ -157,18 +145,6 @@ const AgentListTab = ( { onSelectAgent } ) => {
 								</td>
 								<td className="column-slug">
 									<code>{ agent.agent_slug }</code>
-								</td>
-								<td className="column-status">
-									<span
-										className="datamachine-status-badge"
-										style={
-											STATUS_STYLES[
-												agent.status
-											] || {}
-										}
-									>
-										{ agent.status }
-									</span>
 								</td>
 								<td className="column-created">
 									{ formatDate( agent.created_at ) }

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -81,7 +81,6 @@ class AgentBundler {
 				'agent_name'   => $agent['agent_name'],
 				'agent_config' => $agent['agent_config'] ?? array(),
 				'site_scope'   => $agent['site_scope'],
-				'status'       => $agent['status'],
 			),
 		);
 

--- a/inc/Core/Auth/AgentAuthMiddleware.php
+++ b/inc/Core/Auth/AgentAuthMiddleware.php
@@ -96,7 +96,7 @@ class AgentAuthMiddleware {
 		$agent_id = (int) $token_record['agent_id'];
 		$token_id = (int) $token_record['token_id'];
 
-		// Verify agent exists and is active.
+		// Verify agent exists.
 		$agents_repo = new Agents();
 		$agent       = $agents_repo->get_agent( $agent_id );
 
@@ -105,14 +105,6 @@ class AgentAuthMiddleware {
 				'datamachine_agent_not_found',
 				__( 'Agent associated with this token no longer exists.', 'data-machine' ),
 				array( 'status' => 401 )
-			);
-		}
-
-		if ( 'active' !== ( $agent['status'] ?? '' ) ) {
-			return new \WP_Error(
-				'datamachine_agent_inactive',
-				__( 'Agent is not active.', 'data-machine' ),
-				array( 'status' => 403 )
 			);
 		}
 

--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -51,13 +51,11 @@ class Agents extends BaseRepository {
 			owner_id BIGINT(20) UNSIGNED NOT NULL,
 			site_scope BIGINT(20) UNSIGNED NULL DEFAULT NULL,
 			agent_config LONGTEXT NULL,
-			status VARCHAR(20) NOT NULL DEFAULT 'active',
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			PRIMARY KEY (agent_id),
 			UNIQUE KEY agent_slug (agent_slug),
 			KEY owner_id (owner_id),
-			KEY status (status),
 			KEY site_scope (site_scope)
 		) {$charset_collate};";
 
@@ -202,7 +200,7 @@ class Agents extends BaseRepository {
 	 * Update an agent's mutable fields.
 	 *
 	 * Only updates fields that are present in the $data array.
-	 * Allowed fields: agent_name, agent_config, status.
+	 * Allowed fields: agent_name, agent_config.
 	 *
 	 * @since 0.43.0
 	 * @param int   $agent_id Agent ID.
@@ -210,7 +208,7 @@ class Agents extends BaseRepository {
 	 * @return bool True on success, false on DB failure or no valid fields.
 	 */
 	public function update_agent( int $agent_id, array $data ): bool {
-		$allowed = array( 'agent_name', 'agent_config', 'status' );
+		$allowed = array( 'agent_name', 'agent_config' );
 		$update  = array();
 		$formats = array();
 
@@ -326,9 +324,8 @@ class Agents extends BaseRepository {
 				'agent_name'   => $agent_name,
 				'owner_id'     => $owner_id,
 				'agent_config' => wp_json_encode( $agent_config ),
-				'status'       => 'active',
 			),
-			array( '%s', '%s', '%d', '%s', '%s' )
+			array( '%s', '%s', '%d', '%s' )
 		);
 
 		return (int) $this->wpdb->insert_id;

--- a/inc/migrations/network-scope.php
+++ b/inc/migrations/network-scope.php
@@ -239,11 +239,10 @@ function datamachine_migrate_agents_to_network_scope() {
 					'owner_id'     => (int) $agent['owner_id'],
 					'site_scope'   => (int) $blog_id,
 					'agent_config' => $agent['agent_config'],
-					'status'       => $agent['status'],
 					'created_at'   => $agent['created_at'],
 					'updated_at'   => $agent['updated_at'],
 				),
-				array( '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%s' )
+				array( '%s', '%s', '%d', '%d', '%s', '%s', '%s' )
 			);
 
 			$new_agent_id = (int) $wpdb->insert_id;


### PR DESCRIPTION
## Summary

The `status` column on `datamachine_agents` (active/inactive/archived) was never meaningfully used. Every agent is created `active`, nothing changes it, and the one enforcement point was weaker than token revocation. Kill it.

## What changed

| File | Change |
|------|--------|
| `AgentAuthMiddleware.php` | Remove `active` status check — token revocation is the right gate |
| `Api/Agents.php` | Remove `status` from REST response, update params, and handler |
| `Agents.php` | Remove `status` from `update_agent` allowed fields and `create_if_missing` insert |
| `AgentListTab.jsx` | Remove status column, badge, and `STATUS_STYLES` constant |
| `AgentBundler.php` | Remove `status` from export bundle |
| `network-scope.php` | Remove `status` from migration insert |

## Why not just add enforcement (PR #1075)?

Because the field itself doesn't earn its place:
- **Block external access?** Revoke the bearer token.
- **Block a user?** Suspend their WordPress account.
- **Block an agent from chat?** That should be a feature flag or permission, not a status column that nothing in the stack checks.

Adding enforcement to a field that shouldn't exist is just adding more surface area to something nobody uses.

## Schema

The `status` column stays in the table — no schema migration. It just defaults to `active` forever and nothing reads or writes it. Can be dropped in a future schema cleanup if desired.

Closes #852, Closes #1079