### PR TITLE
Fix WP-CLI writes to cap-gated memory files

### DIFF
--- a/inc/Abilities/AgentMemoryAbilities.php
+++ b/inc/Abilities/AgentMemoryAbilities.php
@@ -280,6 +280,17 @@ class AgentMemoryAbilities {
 		if ( 'MEMORY.md' !== $filename ) {
 			$editable = \DataMachine\Engine\AI\MemoryFileRegistry::is_editable( $filename );
 			if ( ! $editable ) {
+				$edit_cap = \DataMachine\Engine\AI\MemoryFileRegistry::get_edit_capability( $filename );
+				if ( is_string( $edit_cap ) ) {
+					return array(
+						'success' => false,
+						'message' => sprintf(
+							'File %s requires capability \'%s\' to edit. Pass --user=<admin-id> or run as an authenticated admin.',
+							$filename,
+							$edit_cap
+						),
+					);
+				}
 				return array(
 					'success' => false,
 					'message' => sprintf( 'File %s is read-only and cannot be edited via section write.', $filename ),

--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -200,6 +200,14 @@ class MemoryFileRegistry {
 		// Capability string: check against user.
 		if ( is_string( $editable ) && ! empty( $editable ) ) {
 			$check_user = $user_id > 0 ? $user_id : get_current_user_id();
+
+			// WP-CLI is inherently privileged — it's how admins bootstrap,
+			// migrate, and recover sites. When no --user is set, treat the
+			// invocation as authorized rather than rejecting as anonymous.
+			if ( defined( 'WP_CLI' ) && WP_CLI && $check_user <= 0 ) {
+				return true;
+			}
+
 			return $check_user > 0 && user_can( $check_user, $editable );
 		}
 


### PR DESCRIPTION
## Summary

`MemoryFileRegistry::is_editable()` rejected capability-gated files (like RULES.md with `editable='manage_options'`) under WP-CLI without `--user` because `get_current_user_id()` returns 0 and the guard treated that as unauthorized. WP-CLI is inherently an admin context — other core WP-CLI commands don't require `--user` for admin operations.

## Changes

**`MemoryFileRegistry::is_editable()`** — When running under WP-CLI with no authenticated user (`$check_user <= 0`), treat the invocation as trusted instead of rejecting as anonymous. Respects `--user` when provided.

**`AgentMemoryAbilities::updateMemory()`** — Distinguish capability-gated rejections from truly read-only files in the error message. Now names the required capability and suggests `--user=<admin-id>` instead of the misleading "read-only" message.

## Testing

```bash
# Before: fails with misleading "read-only" error
$ studio wp datamachine agent write RULES.md "Investigation" "- new rule"
Error: File RULES.md is read-only and cannot be edited via section write.

# After: succeeds without --user
$ studio wp datamachine agent write RULES.md "Investigation" "- new rule"
Success: Section "Investigation" updated.
```

Closes #1081