### PR TITLE
fix: establish agent execution context in pipeline AI steps

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -2,6 +2,8 @@
 
 namespace DataMachine\Core\Steps\AI;
 
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\DataPacket;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\Steps\Step;
@@ -276,16 +278,63 @@ class AIStep extends Step {
 		$provider_name = $context_model['provider'];
 		$model_name    = $context_model['model'];
 
-		// Execute conversation loop via runtime-adapter-aware entry point.
-		$loop_result = AIConversationLoop::run(
-			$messages,
-			$available_tools,
-			$provider_name,
-			$model_name,
-			ToolPolicyResolver::CONTEXT_PIPELINE,
-			$payload,
-			$max_turns
-		);
+		// Establish agent execution context before firing the conversation loop.
+		//
+		// Pipelines run inside the Action Scheduler queue where no WordPress user
+		// is set — get_current_user_id() returns 0 and any ability invoked as a
+		// tool call (wp_insert_post, wiki writes, taxonomy edits, etc.) either
+		// falls through to a "first administrator" fallback or relies on the
+		// blanket action_scheduler_run_queue bypass in PermissionHelper::can().
+		//
+		// When the job is owned by an agent, we resolve that agent's owner user
+		// and run the loop as that user, mirroring how AgentAuthMiddleware does
+		// this for REST bearer-token requests and ChatOrchestrator does it for
+		// in-browser chat. Tools fired inside the loop then execute with the
+		// correct identity, post_author resolves to the agent owner, and
+		// per-agent capability ceilings are enforced in pipelines the same way
+		// they are in REST.
+		$owner_id = 0;
+		if ( $agent_id > 0 ) {
+			$agents_repo  = new Agents();
+			$agent_record = $agents_repo->get_agent( $agent_id );
+			if ( $agent_record ) {
+				$owner_id = (int) ( $agent_record['owner_id'] ?? 0 );
+			}
+		}
+		if ( $owner_id <= 0 && $user_id > 0 ) {
+			// Legacy / agent-less flows: fall back to the flow's user_id.
+			$owner_id = $user_id;
+		}
+
+		$previous_user_id = get_current_user_id();
+		$context_set      = false;
+		if ( $owner_id > 0 ) {
+			wp_set_current_user( $owner_id );
+			if ( $agent_id > 0 ) {
+				PermissionHelper::set_agent_context( $agent_id, $owner_id );
+				$context_set = true;
+			}
+		}
+
+		try {
+			// Execute conversation loop via runtime-adapter-aware entry point.
+			$loop_result = AIConversationLoop::run(
+				$messages,
+				$available_tools,
+				$provider_name,
+				$model_name,
+				ToolPolicyResolver::CONTEXT_PIPELINE,
+				$payload,
+				$max_turns
+			);
+		} finally {
+			if ( $context_set ) {
+				PermissionHelper::clear_agent_context();
+			}
+			if ( $owner_id > 0 && $previous_user_id !== $owner_id ) {
+				wp_set_current_user( $previous_user_id );
+			}
+		}
 
 		// Check for errors
 		if ( isset( $loop_result['error'] ) ) {


### PR DESCRIPTION
## Summary

Bring pipeline AI steps to parity with the other three paths into `AIConversationLoop::run()`: **REST bearer auth**, **in-browser chat**, and **webhook triggers** all establish a WordPress user + `PermissionHelper` agent context before the loop fires. **`AIStep` does not.** This PR closes that gap.

## The gap today

All four entry points eventually call `AIConversationLoop::run()`:

| Entry point | Establishes context? | Where |
|---|---|---|
| REST bearer token | ✅ | `AgentAuthMiddleware::authenticate()` — `wp_set_current_user()` + `set_agent_context()` |
| In-browser chat | ✅ | `ChatOrchestrator` — `PermissionHelper::run_as_authenticated()` |
| Webhook trigger | ✅ | `WebhookTrigger` — `run_as_authenticated()` |
| **Pipeline AI step** | ❌ | `AIStep::execute()` — nothing |

`AIStep` already reads `agent_id` and `user_id` out of the job snapshot (set by `RunFlowAbility`), but never applies them to WordPress state or `PermissionHelper` before calling the conversation loop. Result: every pipeline tool call runs with `get_current_user_id() === 0` and no agent context.

## Concrete symptoms this causes

### 1. `post_author` falls through to "first administrator" on multi-agent installs

`WordPressSettingsResolver::getPostAuthor()` uses this chain:

1. System-wide `default_author_id` from settings
2. Handler config `post_author`
3. `get_current_user_id()` — "interactive contexts only"
4. **First administrator user** — "headless/cron fallback"

In pipeline context, step 3 always returns 0, so every DM-published post on a multi-agent install lands on step 4. Every agent's pipelines attribute content to the same first-admin account, regardless of which agent produced it.

### 2. Agent token capability ceilings don't apply to pipelines

`PermissionHelper::agent_can()` enforces the ceiling "agent can never exceed owner's WP capabilities" and token-level capability restrictions (e.g. a token scoped to `datamachine_chat` only). This only fires when `set_agent_context()` has been called — which currently happens for REST/chat/webhook, but not for pipelines. In pipelines the blanket `doing_action('action_scheduler_run_queue')` bypass in `PermissionHelper::can()` grants full access regardless of the agent's scope.

### 3. `current_user_can()` in abilities is a no-op during pipelines

Any ability that does proper capability checks evaluates against user 0, and only survives because of the AS queue bypass. Per-ability permission resolution (#924) can't evaluate against real roles in pipeline mode today.

### 4. Third-party integrations see user 0

Plugins hooking `wp_insert_post`, `user_has_cap`, `map_meta_cap`, editorial-workflow / membership plugins, audit trails — all see "nobody did this" on pipeline runs.

## The fix

In `AIStep::execute()`, immediately before calling `AIConversationLoop::run()`:

1. Resolve the agent's `owner_id` from `agent_id` via the `Agents` repo (authoritative).
2. Fall back to the flow's `user_id` from the job snapshot if no agent is set (legacy / agent-less flows).
3. Run the loop inside a `wp_set_current_user($owner_id)` + `PermissionHelper::set_agent_context($agent_id, $owner_id)` envelope.
4. Unwind in `finally` so the context never leaks past the loop.

~60 lines, one file, no schema change, no new class.

## Backward compatibility

- **Agent-less flows** (`$agent_id === 0`): no `set_agent_context()` call, falls back to `wp_set_current_user($user_id)` only if `user_id > 0`. If the flow has no user either, the envelope is a no-op and behavior is unchanged from today — `getPostAuthor()` still falls through to the first-administrator fallback.
- **Flows with explicit `default_author_id` or handler `post_author`** configured: unchanged. Those resolve at step 1 or 2 of `getPostAuthor()`, before `get_current_user_id()` is consulted.
- **Only new behavior**: agent-owned flows on multi-agent installs now attribute to the agent's owner instead of the first admin. This is the correct behavior for a feature that was already on paper.

## Why this is a parity fix, not a new feature

The scaffolding it needs (`PermissionHelper::set_agent_context`, `run_as_authenticated`, token capability ceiling, agent-access grants) all shipped in 0.47.0 and is already exercised by REST, chat, and webhook. This PR just wires the same established pattern into the one caller that was missed.

## Effects downstream

- **DM publish handlers** (WordPress, WordPressUpdate, Media, Taxonomy) now attribute to the correct user on multi-agent installs with no config change.
- **DM-Code extension**: git commits and GitHub API calls made from scheduled pipelines can now resolve per-agent credentials and attribute to the agent owner.
- **DM-Events / DM-Socials / any downstream extension**: same correctness improvement for attribution.
- **Abilities that stamp ownership** can now call `PermissionHelper::in_agent_context()` / `get_acting_agent_id()` inside pipeline tool execution.
- **Unblocks #924** (ability-linked permission resolution): `permission_callback` can evaluate against a real user in pipeline context instead of being short-circuited by the AS bypass.
- **Unblocks #919** (scoped non-admin agent creation): pipelines respect the owner's capability ceiling during background execution.

## Testing

Syntax-verified with `php -l`. The existing `AIStepTest` only covers static helpers; the `execute()` path needs an integration test with the homeboy WP environment to exercise the context envelope end-to-end. Happy to add one if the reviewer prefers — wasn't sure whether you'd want that in this PR or as a follow-up given the scope.

## Related

- Pairs with Automattic/intelligence#78 (wiki-generator agent) — this is the "DM-B1" blocker in that issue's blocker list.
- Related open DM issues that benefit: #924 (permission resolution), #919 (non-admin agent scoping).