### PR TITLE
fix: centralize post origin tracking across all tool executions

### DIFF
--- a/inc/Core/Steps/Publish/Handlers/PublishHandler.php
+++ b/inc/Core/Steps/Publish/Handlers/PublishHandler.php
@@ -17,7 +17,6 @@ namespace DataMachine\Core\Steps\Publish\Handlers;
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Core\EngineData;
 use DataMachine\Core\HttpClient;
-use DataMachine\Core\WordPress\PostTracking;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -69,13 +68,10 @@ abstract class PublishHandler {
 		$handler_config = $tool_def['handler_config'] ?? array();
 		$result         = $this->executePublish( $parameters, $handler_config );
 
-		// Automatic post tracking — write origin metadata on successful results
-		if ( ! empty( $result['success'] ) ) {
-			$post_id = PostTracking::extractPostId( $result );
-			if ( $post_id > 0 ) {
-				PostTracking::store( $post_id, $tool_def, $job_id );
-			}
-		}
+		// Post origin tracking is applied centrally in ToolExecutor::executeTool()
+		// after every tool call — handler tools and ability tools share the same
+		// path now, so individual base classes no longer need to call
+		// PostTracking::store() themselves.
 
 		return $result;
 	}

--- a/inc/Core/Steps/Update/Handlers/UpdateHandler.php
+++ b/inc/Core/Steps/Update/Handlers/UpdateHandler.php
@@ -12,7 +12,6 @@
 namespace DataMachine\Core\Steps\Update\Handlers;
 
 use DataMachine\Core\EngineData;
-use DataMachine\Core\WordPress\PostTracking;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -83,13 +82,10 @@ abstract class UpdateHandler {
 		$handler_config = $tool_def['handler_config'] ?? array();
 		$result         = $this->executeUpdate( $parameters, $handler_config );
 
-		// Automatic post tracking — write origin metadata on successful results
-		if ( ! empty( $result['success'] ) ) {
-			$post_id = PostTracking::extractPostId( $result );
-			if ( $post_id > 0 ) {
-				PostTracking::store( $post_id, $tool_def, $job_id );
-			}
-		}
+		// Post origin tracking is applied centrally in ToolExecutor::executeTool()
+		// after every tool call — handler tools and ability tools share the same
+		// path now, so individual base classes no longer need to call
+		// PostTracking::store() themselves.
 
 		return $result;
 	}

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Engine\AI\Tools;
 
+use DataMachine\Core\WordPress\PostTracking;
+
 defined('ABSPATH') || exit;
 
 class ToolExecutor {
@@ -113,6 +115,22 @@ class ToolExecutor {
 
 		$tool_handler = new $class_name();
 		$tool_result  = $tool_handler->$method($complete_parameters, $tool_def);
+
+		// Automatic post origin tracking — applies to every tool whose result
+		// contains an extractable post_id. This covers both handler tools
+		// (Publish/Update base classes) and ability tools that create or
+		// modify posts (PublishWordPressAbility, InsertContentAbility, wiki
+		// create/update, third-party abilities, etc.). update_post_meta() is
+		// idempotent, so callers that already stamped tracking themselves
+		// (e.g. legacy handler base classes before this was centralized) are
+		// safe to run through this path without double-writes.
+		if ( ! empty( $tool_result['success'] ) ) {
+			$post_id = PostTracking::extractPostId( $tool_result );
+			if ( $post_id > 0 ) {
+				$job_id = (int) ( $payload['job_id'] ?? 0 );
+				PostTracking::store( $post_id, $tool_def, $job_id );
+			}
+		}
 
 		return $tool_result;
 	}


### PR DESCRIPTION
## Summary

`PostTracking::store()` was only invoked from `PublishHandler` and `UpdateHandler` base classes, so origin meta (`_datamachine_post_handler`, `_datamachine_post_flow_id`, `_datamachine_post_pipeline_id`) only landed on posts created or updated by handler-derived tools. Abilities invoked as pipeline tools — including first-party DM abilities like `PublishWordPressAbility` and `InsertContentAbility`, plus third-party abilities on the chat/pipeline surface — silently skipped tracking.

This PR centralizes the tracking call in `ToolExecutor::executeTool()` so every tool invocation, handler or ability, gets the same automatic origin meta when its result carries an extractable post_id.

## The gap

`PostTracking` was wired in only two places in `inc/`:

```
inc/Core/Steps/Update/Handlers/UpdateHandler.php:90:   PostTracking::store(...)
inc/Core/Steps/Publish/Handlers/PublishHandler.php:76: PostTracking::store(...)
```

Meanwhile these abilities create or modify posts without inheriting from a handler base:

| Ability | Behavior | Tracking today |
|---|---|---|
| `PublishWordPressAbility` | `wp_insert_post()` | ❌ none |
| `InsertContentAbility` | `wp_update_post()` | ❌ none |
| `EditPostBlocksAbility` | block edits via `wp_update_post()` | ❌ none |
| `ReplacePostBlocksAbility` | block replacement via `wp_update_post()` | ❌ none |
| Any third-party ability registered as a pipeline tool | varies | ❌ none |

Result: a pipeline that publishes via `PublishWordPressAbility` produces posts with **no origin meta**, so there's no way to answer \"which flow/pipeline created this post?\" from `_datamachine_post_pipeline_id`.

## The fix

Move the `PostTracking::store()` call into `ToolExecutor::executeTool()`, firing after any successful tool result:

```php
$tool_handler = new $class_name();
$tool_result  = $tool_handler->$method( $complete_parameters, $tool_def );

// Automatic post origin tracking — applies to every tool whose result
// contains an extractable post_id.
if ( ! empty( $tool_result['success'] ) ) {
    $post_id = PostTracking::extractPostId( $tool_result );
    if ( $post_id > 0 ) {
        $job_id = (int) ( $payload['job_id'] ?? 0 );
        PostTracking::store( $post_id, $tool_def, $job_id );
    }
}

return $tool_result;
```

Then drop the now-redundant calls from `PublishHandler::handle_tool_call()` and `UpdateHandler::handle_tool_call()` — both handler flows already pass through `ToolExecutor::executeTool()`, so centralizing removes duplication.

## Why this is safe

- `PostTracking::extractPostId()` already handles both result shapes: `data.post_id` / `data.updated_id` from handlers, and top-level `post_id` returned by abilities.
- `PostTracking::store()` uses `update_post_meta()` which is idempotent — even if a legacy ability or third-party tool re-implemented the same tracking manually, the centralized call converges on the same values.
- `$tool_def['handler']` is absent on ability tools, so `HANDLER_META_KEY` (`_datamachine_post_handler`) is correctly skipped for abilities while still being stamped on handler tools. `FLOW_ID` / `PIPELINE_ID` come from the job record and apply uniformly.
- No new meta keys, no new hooks. Same four `_datamachine_post_*` keys as before, just more consistently applied.

## Effects

- **Ability-driven publishes** now carry `_datamachine_post_flow_id` and `_datamachine_post_pipeline_id` automatically. The full tool surface — handlers AND abilities — becomes queryable via the same meta keys.
- **Downstream extensions**: `intelligence/wiki` create action, `data-machine-events` abilities, any future ability registered as a pipeline tool, inherit tracking with zero code changes on their side.
- **Handler behavior is unchanged** — same meta keys, same values, same call order relative to the result being returned to the loop.

## Related

- Pairs with the agent-execution-context fix merged in #1083 — together they mean pipeline-created posts now have correct `post_author` **and** correct origin meta, so \"which agent/pipeline produced this post?\" is answerable via a single meta query + JOIN on `pipelines.agent_id`.
- Unblocks the Intelligence wiki-generator pattern (Automattic/intelligence#78) without requiring any new meta keys.