### PR TITLE
feat(memory): AgentMemoryStoreInterface + datamachine_memory_store filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,28 @@ This mirrors the provider pattern used by the bundled AI HTTP Client: providers 
 
 See [`docs/core-system/ai-conversation-loop.md`](docs/core-system/ai-conversation-loop.md#runtime-adapters) for the full adapter contract and return-shape reference.
 
+## Memory Storage Adapters
+
+Agent memory files (MEMORY.md, SOUL.md, USER.md, NETWORK.md, AGENTS.md, plus any custom files registered through `MemoryFileRegistry`) persist on the local filesystem by default. The persistence layer is swappable through a single filter (`datamachine_memory_store`), enabling DB-backed implementations on managed hosts that don't expose a writable filesystem.
+
+```php
+add_filter(
+    'datamachine_memory_store',
+    function ( $store, $scope ) {
+        // Return an AgentMemoryStoreInterface to replace the disk default
+        // for this scope, or null to let Data Machine read/write through
+        // the filesystem.
+        return new My_DB_Agent_Memory_Store();
+    },
+    10,
+    2
+);
+```
+
+Section parsing, scaffolding, and editability gating stay in Data Machine; the store is just the bytes layer underneath. All consumer paths — section reads/writes (`AgentMemory`), the React Agent UI (`AgentFileAbilities`), and AI context injection (`CoreMemoryFilesDirective`) — flow through the same store, so a single swap makes the entire memory surface backend-agnostic.
+
+See [`docs/development/hooks/core-filters.md`](docs/development/hooks/core-filters.md#agentmemorystoreinterface-inccorefilesrepositoryagentmemorystoreinterfacephp) for the full interface contract.
+
 ## Requirements
 
 - WordPress 6.9+ (Abilities API)

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -945,6 +945,62 @@ for the full adapter contract.
 - Maximum turn limiting (default: 25)
 - Runtime-swappable via `datamachine_conversation_runner`
 
+### AgentMemoryStoreInterface (`/inc/Core/FilesRepository/AgentMemoryStoreInterface.php`)
+
+**Purpose**: Single seam between agent memory operations and the underlying
+persistence backend. The disk default ([`DiskAgentMemoryStore`](../../../inc/Core/FilesRepository/DiskAgentMemoryStore.php))
+preserves byte-for-byte the filesystem behavior the codebase used before this
+seam was introduced.
+
+**Filter: `datamachine_memory_store`**
+
+```php
+apply_filters(
+    'datamachine_memory_store',
+    null,                       // Return AgentMemoryStoreInterface to short-circuit
+    AgentMemoryScope $scope     // Identifies (layer, user_id, agent_id, filename)
+);
+```
+
+Return an [`AgentMemoryStoreInterface`](../../../inc/Core/FilesRepository/AgentMemoryStoreInterface.php)
+implementation to replace the disk default for this scope. Return `null` (the
+default) to let Data Machine read and write through the filesystem.
+
+**Use case**: managed-host environments where the local filesystem is not
+writable (e.g. WordPress.com, VIP). A consumer plugin (e.g. Intelligence)
+ships a DB-backed implementation and registers it conditionally:
+
+```php
+add_filter( 'datamachine_memory_store', function ( $store, $scope ) {
+    if ( $store instanceof AgentMemoryStoreInterface ) {
+        return $store;  // someone else already swapped
+    }
+    if ( filesystem_is_writable_here() ) {
+        return $store;  // disk default wins
+    }
+    return new \My_Plugin\DB_Agent_Memory_Store();
+}, 10, 2 );
+```
+
+**Contract**:
+- `read( $scope )` → `AgentMemoryReadResult { exists, content, hash, bytes, updated_at }`
+- `write( $scope, $content, $if_match = null )` → `AgentMemoryWriteResult`
+  (implementations supporting concurrency MUST honor `$if_match` and return
+  `error = 'conflict'` on hash mismatch)
+- `exists( $scope )` → `bool`
+- `delete( $scope )` → `AgentMemoryWriteResult` (idempotent)
+- `list_layer( $scope_query )` → `AgentMemoryListEntry[]` (enumerates one layer)
+
+Section parsing, scaffolding, editability gating, and registry-driven
+convention-path semantics stay in the higher-level callers (`AgentMemory`,
+`AgentFileAbilities`, `MemoryFileRegistry`). The store is the dumb
+persistence layer underneath.
+
+**Consumers** (all whole-file IO routes through the store):
+- `\DataMachine\Core\FilesRepository\AgentMemory` — section ops on MEMORY.md / SOUL.md / USER.md / NETWORK.md
+- `\DataMachine\Abilities\File\AgentFileAbilities` — whole-file ops backing the `/datamachine/v1/files/agent` REST routes (the React Agent UI)
+- `\DataMachine\Engine\AI\Directives\CoreMemoryFilesDirective` — file content injected into every AI conversation
+
 ### ConversationManager (`/inc/Engine/AI/ConversationManager.php`)
 
 **Purpose**: Message formatting utilities for AI requests.

--- a/inc/Abilities/File/AgentFileAbilities.php
+++ b/inc/Abilities/File/AgentFileAbilities.php
@@ -17,6 +17,8 @@
 namespace DataMachine\Abilities\File;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\FilesRepository\AgentMemoryScope;
+use DataMachine\Core\FilesRepository\AgentMemoryStoreFactory;
 use DataMachine\Core\FilesRepository\DailyMemory;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Core\FilesRepository\FilesystemHelper;
@@ -287,37 +289,32 @@ class AgentFileAbilities {
 	public function executeListAgentFiles( array $input ): array {
 		DirectoryManager::ensure_agent_files();
 
-		$dm      = new DirectoryManager();
-		$user_id = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
-
-		$shared_dir = $dm->get_shared_directory();
-		$agent_dir  = $dm->resolve_agent_directory( array(
-			'agent_id' => (int) ( $input['agent_id'] ?? 0 ),
-			'user_id'  => $user_id,
-		) );
-		$user_dir   = $dm->get_user_directory( $user_id );
+		$dm       = new DirectoryManager();
+		$user_id  = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
+		$agent_id = (int) ( $input['agent_id'] ?? 0 );
 
 		$files = array();
 		$seen  = array();
 
-		// First, include convention-path files (e.g. AGENTS.md at site root).
-		// These live outside the layer directories but should still appear in the file list.
+		// First, include convention-path / registered files via the store.
+		// Convention-path files (e.g. AGENTS.md at site root) live outside
+		// the layer directories but should still appear in the file list.
 		foreach ( MemoryFileRegistry::get_all() as $filename => $registry_meta ) {
-			if ( empty( $registry_meta['convention_path'] ) ) {
-				continue;
-			}
+			$layer = $registry_meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
+			$scope = new AgentMemoryScope( $layer, $user_id, $agent_id, $filename );
+			$store = AgentMemoryStoreFactory::for_scope( $scope );
+			$read  = $store->read( $scope );
 
-			$filepath = rtrim( ABSPATH, '/' ) . '/' . $registry_meta['convention_path'];
-			if ( ! file_exists( $filepath ) ) {
+			if ( ! $read->exists ) {
 				continue;
 			}
 
 			$files[]           = array(
 				'filename'    => $filename,
-				'size'        => filesize( $filepath ),
-				'modified'    => gmdate( 'c', filemtime( $filepath ) ),
+				'size'        => $read->bytes,
+				'modified'    => null !== $read->updated_at ? gmdate( 'c', $read->updated_at ) : '',
 				'type'        => 'core',
-				'layer'       => $registry_meta['layer'],
+				'layer'       => $layer,
 				'protected'   => MemoryFileRegistry::is_protected( $filename ),
 				'editable'    => MemoryFileRegistry::is_editable( $filename ),
 				'contexts'    => $registry_meta['contexts'] ?? array( MemoryFileRegistry::CONTEXT_ALL ),
@@ -328,47 +325,38 @@ class AgentFileAbilities {
 			$seen[ $filename ] = true;
 		}
 
-		// Scan directories in priority order: shared (site-wide), agent identity, user.
-		// Agent layer wins on filename conflicts with user layer.
-		// Shared layer is always included (tagged separately, read-only in UI).
-		$layers = array(
-			'shared' => $shared_dir,
-			'agent'  => $agent_dir,
-			'user'   => $user_dir,
+		// Enumerate each layer through the store. Agent layer wins on
+		// filename conflicts with user layer; shared layer is always included.
+		$layer_order = array(
+			MemoryFileRegistry::LAYER_SHARED,
+			MemoryFileRegistry::LAYER_AGENT,
+			MemoryFileRegistry::LAYER_USER,
 		);
 
-		foreach ( $layers as $layer => $dir ) {
-			if ( ! file_exists( $dir ) ) {
-				continue;
-			}
+		foreach ( $layer_order as $layer ) {
+			$scope_query = new AgentMemoryScope( $layer, $user_id, $agent_id, '' );
+			$store       = AgentMemoryStoreFactory::for_scope( $scope_query );
 
-			foreach ( array_diff( scandir( $dir ), array( '.', '..' ) ) as $entry ) {
-				if ( 'index.php' === $entry ) {
+			foreach ( $store->list_layer( $scope_query ) as $entry ) {
+				if ( isset( $seen[ $entry->filename ] ) ) {
 					continue;
 				}
 
-				if ( isset( $seen[ $entry ] ) ) {
-					continue;
-				}
-
-				$filepath = "{$dir}/{$entry}";
-				if ( is_file( $filepath ) ) {
-					$registry_meta  = MemoryFileRegistry::get( $entry );
-					$files[]        = array(
-						'filename'    => $entry,
-						'size'        => filesize( $filepath ),
-						'modified'    => gmdate( 'c', filemtime( $filepath ) ),
-						'type'        => 'core',
-						'layer'       => $registry_meta ? $registry_meta['layer'] : $layer,
-						'protected'   => MemoryFileRegistry::is_protected( $entry ),
-						'editable'    => MemoryFileRegistry::is_editable( $entry ),
-						'contexts'    => $registry_meta['contexts'] ?? array( MemoryFileRegistry::CONTEXT_ALL ),
-						'registered'  => null !== $registry_meta,
-						'label'       => $registry_meta['label'] ?? self::filename_to_label( $entry ),
-						'description' => $registry_meta['description'] ?? '',
-					);
-					$seen[ $entry ] = true;
-				}
+				$registry_meta = MemoryFileRegistry::get( $entry->filename );
+				$files[]       = array(
+					'filename'    => $entry->filename,
+					'size'        => $entry->bytes,
+					'modified'    => null !== $entry->updated_at ? gmdate( 'c', $entry->updated_at ) : '',
+					'type'        => 'core',
+					'layer'       => $registry_meta ? $registry_meta['layer'] : $layer,
+					'protected'   => MemoryFileRegistry::is_protected( $entry->filename ),
+					'editable'    => MemoryFileRegistry::is_editable( $entry->filename ),
+					'contexts'    => $registry_meta['contexts'] ?? array( MemoryFileRegistry::CONTEXT_ALL ),
+					'registered'  => null !== $registry_meta,
+					'label'       => $registry_meta['label'] ?? self::filename_to_label( $entry->filename ),
+					'description' => $registry_meta['description'] ?? '',
+				);
+				$seen[ $entry->filename ] = true;
 			}
 		}
 
@@ -431,30 +419,32 @@ class AgentFileAbilities {
 	 * @return array Result with file data.
 	 */
 	public function executeGetAgentFile( array $input ): array {
-		$fs = FilesystemHelper::get();
 		DirectoryManager::ensure_agent_files();
 
 		$filename = sanitize_file_name( $input['filename'] ?? '' );
 		$dm       = new DirectoryManager();
 		$user_id  = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$filepath = $this->resolveFilePath( $dm, $user_id, $filename, $agent_id );
 
-		if ( ! $filepath ) {
+		$resolved = $this->resolveScope( $filename, $user_id, $agent_id );
+
+		if ( null === $resolved ) {
 			return array(
 				'success' => false,
 				'error'   => sprintf( 'File %s not found in any layer', $filename ),
 			);
 		}
 
+		[ $scope, $store, $read ] = $resolved;
+
 		return array(
 			'success' => true,
 			'file'    => $this->sanitizeFileEntry(
 				array(
 					'filename' => $filename,
-					'size'     => filesize( $filepath ),
-					'modified' => gmdate( 'c', filemtime( $filepath ) ),
-					'content'  => $fs->get_contents( $filepath ),
+					'size'     => $read->bytes,
+					'modified' => null !== $read->updated_at ? gmdate( 'c', $read->updated_at ) : '',
+					'content'  => $read->content,
 				)
 			),
 		);
@@ -510,35 +500,22 @@ class AgentFileAbilities {
 		$dm      = new DirectoryManager();
 		$user_id = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
 
-		$target_dir = $this->resolveLayerDirectory( $dm, $target_layer, $user_id, (int) ( $input['agent_id'] ?? 0 ) );
+		$scope = new AgentMemoryScope(
+			$target_layer,
+			$user_id,
+			(int) ( $input['agent_id'] ?? 0 ),
+			$filename
+		);
+		$store = AgentMemoryStoreFactory::for_scope( $scope );
 
-		if ( ! $dm->ensure_directory_exists( $target_dir ) ) {
+		$write = $store->write( $scope, $content );
+
+		if ( ! $write->success ) {
 			return array(
 				'success' => false,
-				'error'   => 'Failed to create target directory',
+				'error'   => sprintf( 'Failed to write file (%s)', $write->error ?? 'unknown' ),
 			);
 		}
-
-		$filepath = "{$target_dir}/{$filename}";
-
-		$fs = FilesystemHelper::get();
-		if ( ! $fs ) {
-			return array(
-				'success' => false,
-				'error'   => 'Filesystem not available',
-			);
-		}
-
-		$written = $fs->put_contents( $filepath, $content, FS_CHMOD_FILE );
-
-		if ( ! $written ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to write file',
-			);
-		}
-
-		FilesystemHelper::make_group_writable( $filepath );
 
 		do_action(
 			'datamachine_log',
@@ -576,16 +553,26 @@ class AgentFileAbilities {
 		$dm       = new DirectoryManager();
 		$user_id  = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$filepath = $this->resolveFilePath( $dm, $user_id, $filename, $agent_id );
+		$resolved = $this->resolveScope( $filename, $user_id, $agent_id );
 
-		if ( ! $filepath ) {
+		if ( null === $resolved ) {
 			return array(
 				'success' => false,
 				'error'   => sprintf( 'File %s not found in any layer', $filename ),
 			);
 		}
 
-		wp_delete_file( $filepath );
+		[ $scope, $store, $read ] = $resolved;
+		unset( $read );
+
+		$delete = $store->delete( $scope );
+
+		if ( ! $delete->success ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Failed to delete file (%s)', $delete->error ?? 'unknown' ),
+			);
+		}
 
 		do_action(
 			'datamachine_log',
@@ -605,7 +592,11 @@ class AgentFileAbilities {
 	}
 
 	/**
-	 * Upload a file to a memory layer directory.
+	 * Upload a file to a memory layer.
+	 *
+	 * Reads the uploaded tmp file into memory and persists it through the
+	 * configured store, so the upload path works on any backend (disk or
+	 * DB) and not just on writable filesystems.
 	 *
 	 * @param array $input Input parameters.
 	 * @return array Result with updated file list.
@@ -613,7 +604,7 @@ class AgentFileAbilities {
 	public function executeUploadAgentFile( array $input ): array {
 		$file = $input['file_data'] ?? null;
 
-		if ( ! $file || empty( $file['tmp_name'] ) ) {
+		if ( ! $file || empty( $file['tmp_name'] ) || empty( $file['name'] ) ) {
 			return array(
 				'success' => false,
 				'error'   => 'No file data provided',
@@ -624,22 +615,35 @@ class AgentFileAbilities {
 		$user_id      = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
 		$agent_id     = (int) ( $input['agent_id'] ?? 0 );
 		$target_layer = $input['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
-		$target_dir   = $this->resolveLayerDirectory( $dm, $target_layer, $user_id, $agent_id );
+		$filename     = sanitize_file_name( (string) $file['name'] );
 
-		if ( ! $dm->ensure_directory_exists( $target_dir ) ) {
+		// Read tmp content via the WP filesystem helper. The uploaded
+		// tmp_name lives on the local FS (PHP's upload mechanism); we then
+		// hand bytes off to the store, which decides where they land.
+		$fs = FilesystemHelper::get();
+		if ( ! $fs ) {
 			return array(
 				'success' => false,
-				'error'   => 'Failed to create target directory',
+				'error'   => 'Filesystem not available',
 			);
 		}
 
-		$destination = "{$target_dir}/{$file['name']}";
-
-		$fs = FilesystemHelper::get();
-		if ( ! $fs || ! $fs->copy( $file['tmp_name'], $destination, true ) ) {
+		$content = $fs->get_contents( $file['tmp_name'] );
+		if ( false === $content ) {
 			return array(
 				'success' => false,
-				'error'   => 'Failed to store file',
+				'error'   => 'Failed to read uploaded file',
+			);
+		}
+
+		$scope = new AgentMemoryScope( $target_layer, $user_id, $agent_id, $filename );
+		$store = AgentMemoryStoreFactory::for_scope( $scope );
+
+		$write = $store->write( $scope, (string) $content );
+		if ( ! $write->success ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Failed to store file (%s)', $write->error ?? 'unknown' ),
 			);
 		}
 
@@ -655,46 +659,42 @@ class AgentFileAbilities {
 	// =========================================================================
 
 	/**
-	 * Resolve a filename to its absolute path across layers.
+	 * Resolve a filename to a (scope, store, read-result) triple by
+	 * trying the registered layer first, then falling back agent → user
+	 * → shared.
 	 *
-	 * For registered files, checks the registered layer first.
-	 * Falls back to: agent → user → shared.
+	 * Returns null if the file does not exist in any layer.
 	 *
-	 * @since 0.41.0 Added $agent_id parameter for agent-first resolution.
-	 * @since 0.42.0 Registry-aware layer resolution.
+	 * @since next Replaces the disk-only resolveFilePath helper.
 	 *
-	 * @param DirectoryManager $dm       Directory manager instance.
-	 * @param int              $user_id  Effective user ID.
-	 * @param string           $filename Filename to resolve.
-	 * @param int              $agent_id Agent ID for direct resolution. 0 = resolve from user_id.
-	 * @return string|null Absolute file path, or null if not found.
+	 * @param string $filename Filename to resolve.
+	 * @param int    $user_id  Effective user ID.
+	 * @param int    $agent_id Agent ID for direct resolution. 0 = resolve from user_id.
+	 * @return array{0: AgentMemoryScope, 1: \DataMachine\Core\FilesRepository\AgentMemoryStoreInterface, 2: \DataMachine\Core\FilesRepository\AgentMemoryReadResult}|null
 	 */
-	private function resolveFilePath( DirectoryManager $dm, int $user_id, string $filename, int $agent_id = 0 ): ?string {
-		$agent_dir  = $dm->resolve_agent_directory( array(
-			'agent_id' => $agent_id,
-			'user_id'  => $user_id,
-		) );
-		$user_dir   = $dm->get_user_directory( $user_id );
-		$shared_dir = $dm->get_shared_directory();
+	private function resolveScope( string $filename, int $user_id, int $agent_id ): ?array {
+		$layer_order = array();
 
-		// If file is registered, check its canonical location first.
-		// Convention-path files (e.g. AGENTS.md) live at ABSPATH, not the layer directory.
+		// If file is registered, check its canonical layer first.
 		$registered_layer = MemoryFileRegistry::get_layer( $filename );
 		if ( $registered_layer ) {
-			$primary_dir  = $this->resolveLayerDirectory( $dm, $registered_layer, $user_id, $agent_id );
-			$primary_path = MemoryFileRegistry::resolve_filepath( $filename, $primary_dir )
-				?? $primary_dir . '/' . $filename;
-			if ( file_exists( $primary_path ) ) {
-				return $primary_path;
+			$layer_order[] = $registered_layer;
+		}
+
+		// Fallback: check remaining layers (agent → user → shared) without dupes.
+		foreach ( array( MemoryFileRegistry::LAYER_AGENT, MemoryFileRegistry::LAYER_USER, MemoryFileRegistry::LAYER_SHARED ) as $layer ) {
+			if ( ! in_array( $layer, $layer_order, true ) ) {
+				$layer_order[] = $layer;
 			}
 		}
 
-		// Fallback: check all layers (agent → user → shared).
-		$search_order = array( $agent_dir, $user_dir, $shared_dir );
-		foreach ( $search_order as $dir ) {
-			$path = $dir . '/' . $filename;
-			if ( file_exists( $path ) ) {
-				return $path;
+		foreach ( $layer_order as $layer ) {
+			$scope = new AgentMemoryScope( $layer, $user_id, $agent_id, $filename );
+			$store = AgentMemoryStoreFactory::for_scope( $scope );
+			$read  = $store->read( $scope );
+
+			if ( $read->exists ) {
+				return array( $scope, $store, $read );
 			}
 		}
 

--- a/inc/Core/FilesRepository/AgentMemory.php
+++ b/inc/Core/FilesRepository/AgentMemory.php
@@ -6,12 +6,20 @@
  * Parses markdown sections and supports section-level operations
  * on any agent file (MEMORY.md, SOUL.md, USER.md, etc.).
  *
+ * Persistence is delegated to an {@see AgentMemoryStoreInterface} resolved
+ * via the `datamachine_memory_store` filter. The default store
+ * ({@see DiskAgentMemoryStore}) preserves the byte-for-byte filesystem
+ * behavior the codebase used before the store seam was introduced.
+ *
  * @package DataMachine\Core\FilesRepository
  * @since 0.30.0
  * @since 0.45.0 Generalized to support any agent file via $filename parameter.
+ * @since next   Whole-file IO delegated to AgentMemoryStoreInterface.
  */
 
 namespace DataMachine\Core\FilesRepository;
+
+use DataMachine\Engine\AI\MemoryFileRegistry;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -33,30 +41,20 @@ class AgentMemory {
 	private DirectoryManager $directory_manager;
 
 	/**
-	 * @var string
+	 * @var AgentMemoryScope
 	 */
-	private string $file_path;
+	private AgentMemoryScope $scope;
 
 	/**
-	 * WordPress user ID for per-agent partitioning. 0 = legacy shared directory.
-	 *
-	 * @since 0.37.0
-	 * @var int
+	 * @var AgentMemoryStoreInterface
 	 */
-	private int $user_id;
-
-	/**
-	 * Target filename (e.g. MEMORY.md, SOUL.md, USER.md).
-	 *
-	 * @since 0.45.0
-	 * @var string
-	 */
-	private string $filename;
+	private AgentMemoryStoreInterface $store;
 
 	/**
 	 * @since 0.37.0 Added $user_id parameter for multi-agent partitioning.
 	 * @since 0.41.0 Added $agent_id parameter for agent-first resolution.
 	 * @since 0.45.0 Added $filename parameter for any-file support.
+	 * @since next   Switched whole-file IO to AgentMemoryStoreInterface.
 	 *
 	 * @param int    $user_id  WordPress user ID. 0 = legacy shared directory.
 	 * @param int    $agent_id Agent ID for direct resolution. 0 = resolve from user_id.
@@ -64,68 +62,56 @@ class AgentMemory {
 	 */
 	public function __construct( int $user_id = 0, int $agent_id = 0, string $filename = 'MEMORY.md' ) {
 		$this->directory_manager = new DirectoryManager();
-		$this->user_id           = $this->directory_manager->get_effective_user_id( $user_id );
-		$this->filename          = $this->sanitize_filename( $filename );
-		$this->file_path         = $this->resolve_file_path( $agent_id );
+		$effective_user_id       = $this->directory_manager->get_effective_user_id( $user_id );
+		$safe_filename           = $this->sanitize_filename( $filename );
+
+		$this->scope = new AgentMemoryScope(
+			$this->resolve_layer( $safe_filename ),
+			$effective_user_id,
+			$agent_id,
+			$safe_filename
+		);
+		$this->store = AgentMemoryStoreFactory::for_scope( $this->scope );
 
 		// Self-heal: ensure agent files exist on first use.
 		DirectoryManager::ensure_agent_files();
 	}
 
 	/**
-	 * Resolve the file path using MemoryFileRegistry layer awareness.
-	 *
-	 * For registered files, uses the canonical layer (shared, agent, user, network).
-	 * For unregistered files, defaults to the agent directory.
-	 *
-	 * @since 0.45.0
-	 * @param int $agent_id Agent ID for directory resolution.
-	 * @return string Absolute file path.
+	 * Resolve which layer this filename belongs to via the registry,
+	 * defaulting to the agent layer for unregistered files.
 	 */
-	private function resolve_file_path( int $agent_id ): string {
-		$registry_layer = \DataMachine\Engine\AI\MemoryFileRegistry::get_layer( $this->filename );
-		$dm             = $this->directory_manager;
-
-		if ( null !== $registry_layer ) {
-			$layer_dir = null;
-
-			switch ( $registry_layer ) {
-				case 'shared':
-					$layer_dir = $dm->get_shared_directory();
-					break;
-				case 'user':
-					$layer_dir = $dm->get_user_directory( $this->user_id );
-					break;
-				case 'network':
-					$layer_dir = $dm->get_network_directory();
-					break;
-				case 'agent':
-				default:
-					break; // Fall through to agent directory below.
-			}
-
-			if ( null !== $layer_dir ) {
-				// Convention-path files (e.g. AGENTS.md) live at ABSPATH.
-				return \DataMachine\Engine\AI\MemoryFileRegistry::resolve_filepath( $this->filename, $layer_dir )
-					?? $layer_dir . '/' . $this->filename;
-			}
-		}
-
-		// Default: agent directory.
-		$agent_dir = $dm->resolve_agent_directory( array(
-			'agent_id' => $agent_id,
-			'user_id'  => $this->user_id,
-		) );
-		return "{$agent_dir}/{$this->filename}";
+	private function resolve_layer( string $filename ): string {
+		$registered = MemoryFileRegistry::get_layer( $filename );
+		return $registered ?? MemoryFileRegistry::LAYER_AGENT;
 	}
 
 	/**
-	 * Get the full path to the target file.
+	 * Get the resolved scope for this memory file.
+	 *
+	 * @since next
+	 * @return AgentMemoryScope
+	 */
+	public function get_scope(): AgentMemoryScope {
+		return $this->scope;
+	}
+
+	/**
+	 * Get the full path to the target file (disk-only convenience).
+	 *
+	 * Preserved for backward compatibility with callers that still need
+	 * to reason about an on-disk path. The path is computed from the
+	 * registry + DirectoryManager regardless of which store is active —
+	 * useful for self-hosted CLI/debug inspectors. Non-disk stores
+	 * persist content elsewhere; the returned path may not exist in
+	 * those environments. Prefer the store interface for new callers.
 	 *
 	 * @return string
 	 */
 	public function get_file_path(): string {
-		return $this->file_path;
+		$layer_dir = $this->resolve_layer_directory();
+		return MemoryFileRegistry::resolve_filepath( $this->scope->filename, $layer_dir )
+			?? $layer_dir . '/' . $this->scope->filename;
 	}
 
 	/**
@@ -135,7 +121,7 @@ class AgentMemory {
 	 * @return string
 	 */
 	public function get_filename(): string {
-		return $this->filename;
+		return $this->scope->filename;
 	}
 
 	/**
@@ -144,20 +130,19 @@ class AgentMemory {
 	 * @return array{success: bool, content?: string, file?: string, message?: string}
 	 */
 	public function get_all(): array {
-		$fs = FilesystemHelper::get();
-		if ( ! file_exists( $this->file_path ) ) {
+		$result = $this->store->read( $this->scope );
+
+		if ( ! $result->exists ) {
 			return array(
 				'success' => false,
-				'message' => sprintf( 'File %s does not exist.', $this->filename ),
+				'message' => sprintf( 'File %s does not exist.', $this->scope->filename ),
 			);
 		}
 
-		$content = $fs->get_contents( $this->file_path );
-
 		return array(
 			'success' => true,
-			'file'    => $this->filename,
-			'content' => $content,
+			'file'    => $this->scope->filename,
+			'content' => $result->content,
 		);
 	}
 
@@ -169,21 +154,19 @@ class AgentMemory {
 	 * @return array{success: bool, sections?: string[], file?: string, message?: string}
 	 */
 	public function get_sections(): array {
-		$fs = FilesystemHelper::get();
-		if ( ! file_exists( $this->file_path ) ) {
+		$result = $this->store->read( $this->scope );
+
+		if ( ! $result->exists ) {
 			return array(
 				'success' => false,
-				'message' => sprintf( 'File %s does not exist.', $this->filename ),
+				'message' => sprintf( 'File %s does not exist.', $this->scope->filename ),
 			);
 		}
 
-		$content  = $fs->get_contents( $this->file_path );
-		$sections = $this->parse_section_headers( $content );
-
 		return array(
 			'success'  => true,
-			'file'     => $this->filename,
-			'sections' => $sections,
+			'file'     => $this->scope->filename,
+			'sections' => $this->parse_section_headers( $result->content ),
 		);
 	}
 
@@ -194,23 +177,22 @@ class AgentMemory {
 	 * @return array{success: bool, section?: string, content?: string, message?: string}
 	 */
 	public function get_section( string $section_name ): array {
-		$fs = FilesystemHelper::get();
-		if ( ! file_exists( $this->file_path ) ) {
+		$result = $this->store->read( $this->scope );
+
+		if ( ! $result->exists ) {
 			return array(
 				'success' => false,
-				'message' => sprintf( 'File %s does not exist.', $this->filename ),
+				'message' => sprintf( 'File %s does not exist.', $this->scope->filename ),
 			);
 		}
 
-		$content = $fs->get_contents( $this->file_path );
-		$parsed  = $this->parse_section( $content, $section_name );
+		$parsed = $this->parse_section( $result->content, $section_name );
 
 		if ( null === $parsed ) {
-			$sections = $this->parse_section_headers( $content );
 			return array(
 				'success'            => false,
 				'message'            => sprintf( 'Section "%s" not found.', $section_name ),
-				'available_sections' => $sections,
+				'available_sections' => $this->parse_section_headers( $result->content ),
 			);
 		}
 
@@ -219,6 +201,41 @@ class AgentMemory {
 			'section' => $section_name,
 			'content' => $parsed,
 		);
+	}
+
+	/**
+	 * Replace the entire file content. Creates the file if missing.
+	 *
+	 * Used by full-file rewrites (e.g. daily memory cleanup) that
+	 * already have the final content composed in PHP and don't need
+	 * section-level merging.
+	 *
+	 * @since next
+	 * @param string $content New full file content.
+	 * @return array{success: bool, message: string, file_size?: int, warning?: string}
+	 */
+	public function replace_all( string $content ): array {
+		$write = $this->store->write( $this->scope, $content );
+
+		if ( ! $write->success ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to write %s (%s).', $this->scope->filename, $write->error ?? 'unknown' ),
+			);
+		}
+
+		$result = array(
+			'success'   => true,
+			'message'   => sprintf( '%s written.', $this->scope->filename ),
+			'file_size' => $write->bytes,
+		);
+
+		if ( $write->bytes > self::MAX_FILE_SIZE ) {
+			$result['warning'] = self::size_warning( $write->bytes );
+			$this->log_size_warning( $write->bytes );
+		}
+
+		return $result;
 	}
 
 	/**
@@ -231,31 +248,36 @@ class AgentMemory {
 	 * @return array{success: bool, message: string}
 	 */
 	public function set_section( string $section_name, string $content ): array {
-		$fs = FilesystemHelper::get();
 		$this->ensure_file_exists();
 
-		$file_content = $fs->get_contents( $this->file_path );
+		$current      = $this->store->read( $this->scope );
+		$file_content = $current->exists ? $current->content : '';
 		$section_pos  = $this->find_section_position( $file_content, $section_name );
 
 		if ( null === $section_pos ) {
-			// Append new section at end of file.
-			$new_section   = "\n## {$section_name}\n{$content}\n";
-			$file_content .= $new_section;
+			$file_content .= "\n## {$section_name}\n{$content}\n";
 		} else {
-			// Replace existing section content.
 			$file_content = $this->replace_section_content( $file_content, $section_pos, $content );
 		}
 
-		$file_size = $this->write_file( $file_content );
+		$write = $this->store->write( $this->scope, $file_content, $current->exists ? $current->hash : null );
+
+		if ( ! $write->success ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to update section "%s" (%s).', $section_name, $write->error ?? 'unknown' ),
+			);
+		}
 
 		$result = array(
 			'success'   => true,
 			'message'   => sprintf( 'Section "%s" updated.', $section_name ),
-			'file_size' => $file_size,
+			'file_size' => $write->bytes,
 		);
 
-		if ( $file_size > self::MAX_FILE_SIZE ) {
-			$result['warning'] = self::size_warning( $file_size );
+		if ( $write->bytes > self::MAX_FILE_SIZE ) {
+			$result['warning'] = self::size_warning( $write->bytes );
+			$this->log_size_warning( $write->bytes );
 		}
 
 		return $result;
@@ -271,33 +293,38 @@ class AgentMemory {
 	 * @return array{success: bool, message: string}
 	 */
 	public function append_to_section( string $section_name, string $content ): array {
-		$fs = FilesystemHelper::get();
 		$this->ensure_file_exists();
 
-		$file_content = $fs->get_contents( $this->file_path );
+		$current      = $this->store->read( $this->scope );
+		$file_content = $current->exists ? $current->content : '';
 		$section_pos  = $this->find_section_position( $file_content, $section_name );
 
 		if ( null === $section_pos ) {
-			// Create section with the content.
-			$new_section   = "\n## {$section_name}\n{$content}\n";
-			$file_content .= $new_section;
+			$file_content .= "\n## {$section_name}\n{$content}\n";
 		} else {
-			// Append to existing section.
-			$existing     = $this->parse_section( $file_content, $section_name );
+			$existing     = $this->parse_section( $file_content, $section_name ) ?? '';
 			$merged       = rtrim( $existing ) . "\n" . $content . "\n";
 			$file_content = $this->replace_section_content( $file_content, $section_pos, $merged );
 		}
 
-		$file_size = $this->write_file( $file_content );
+		$write = $this->store->write( $this->scope, $file_content, $current->exists ? $current->hash : null );
+
+		if ( ! $write->success ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to append to section "%s" (%s).', $section_name, $write->error ?? 'unknown' ),
+			);
+		}
 
 		$result = array(
 			'success'   => true,
 			'message'   => sprintf( 'Content appended to section "%s".', $section_name ),
-			'file_size' => $file_size,
+			'file_size' => $write->bytes,
 		);
 
-		if ( $file_size > self::MAX_FILE_SIZE ) {
-			$result['warning'] = self::size_warning( $file_size );
+		if ( $write->bytes > self::MAX_FILE_SIZE ) {
+			$result['warning'] = self::size_warning( $write->bytes );
+			$this->log_size_warning( $write->bytes );
 		}
 
 		return $result;
@@ -333,17 +360,18 @@ class AgentMemory {
 	 * @return array{success: bool, query: string, matches: array, match_count: int}
 	 */
 	public function search( string $query, ?string $section = null, int $context_lines = 2 ): array {
-		$fs = FilesystemHelper::get();
-		if ( ! file_exists( $this->file_path ) ) {
+		$result = $this->store->read( $this->scope );
+
+		if ( ! $result->exists ) {
 			return array(
 				'success'     => false,
-				'message'     => sprintf( 'File %s does not exist.', $this->filename ),
+				'message'     => sprintf( 'File %s does not exist.', $this->scope->filename ),
 				'matches'     => array(),
 				'match_count' => 0,
 			);
 		}
 
-		$content         = $fs->get_contents( $this->file_path );
+		$content         = $result->content;
 		$lines           = explode( "\n", $content );
 		$matches         = array();
 		$current_section = null;
@@ -462,77 +490,93 @@ class AgentMemory {
 	}
 
 	/**
-	 * Ensure the target file and directory exist.
+	 * Ensure the target file exists in the store.
 	 *
-	 * Uses scaffold defaults when available instead of a bare stub,
-	 * so a recreated file includes the standard sections.
+	 * Uses scaffold defaults when available so a recreated file includes
+	 * the standard sections. When no scaffold template exists, writes a
+	 * minimal stub so subsequent section operations have something to
+	 * read–modify–write.
 	 */
 	private function ensure_file_exists(): void {
-		if ( ! file_exists( $this->file_path ) ) {
-			$ability = \DataMachine\Abilities\File\ScaffoldAbilities::get_ability();
-			if ( $ability ) {
-				$ability->execute( array(
-					'filename' => $this->filename,
-					'user_id'  => $this->user_id,
-				) );
-			}
+		if ( $this->store->exists( $this->scope ) ) {
+			return;
+		}
 
-			// If scaffold didn't create it (no template for this file), create empty.
-			if ( ! file_exists( $this->file_path ) ) {
-				$dir = dirname( $this->file_path );
-				$dm  = new DirectoryManager();
-				$dm->ensure_directory_exists( $dir );
+		$ability = \DataMachine\Abilities\File\ScaffoldAbilities::get_ability();
+		if ( $ability ) {
+			$ability->execute( array(
+				'filename' => $this->scope->filename,
+				'user_id'  => $this->scope->user_id,
+			) );
+		}
 
-				$fs = FilesystemHelper::get();
-				$fs->put_contents( $this->file_path, "# {$this->filename}\n" );
-				FilesystemHelper::make_group_writable( $this->file_path );
-			}
+		// If scaffold didn't create it (no template for this file), create a stub.
+		if ( ! $this->store->exists( $this->scope ) ) {
+			$this->store->write( $this->scope, "# {$this->scope->filename}\n", null );
 		}
 	}
 
 	/**
 	 * Sanitize a filename to prevent directory traversal.
 	 *
+	 * Allows forward-slashes so callers can address relative paths within
+	 * a layer (e.g. 'contexts/chat.md', 'daily/2026/04/17.md'); each
+	 * segment is run through basename's allow-list.
+	 *
 	 * @since 0.45.0
-	 * @param string $filename Raw filename.
+	 * @param string $filename Raw filename or relative path.
 	 * @return string Sanitized filename.
 	 */
 	private function sanitize_filename( string $filename ): string {
-		return preg_replace( '/[^a-zA-Z0-9._-]/', '', basename( $filename ) );
+		$segments = array_filter( explode( '/', $filename ), 'strlen' );
+		$clean    = array();
+		foreach ( $segments as $segment ) {
+			$clean[] = preg_replace( '/[^a-zA-Z0-9._-]/', '', basename( $segment ) );
+		}
+		return implode( '/', $clean );
 	}
 
 	/**
-	 * Write content to the target file.
+	 * Resolve the on-disk directory for the current scope's layer.
 	 *
-	 * Logs a warning if the resulting file exceeds MAX_FILE_SIZE.
-	 *
-	 * @param string $content File content.
-	 * @return int Written file size in bytes.
+	 * Used only by get_file_path() to keep backward compatibility with
+	 * callers that need a filesystem path.
 	 */
-	private function write_file( string $content ): int {
-		$fs = FilesystemHelper::get();
-		$fs->put_contents( $this->file_path, $content );
-		FilesystemHelper::make_group_writable( $this->file_path );
-		$size = strlen( $content );
-
-		if ( $size > self::MAX_FILE_SIZE ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				sprintf(
-					'Agent memory file exceeds recommended size: %s (%s, threshold %s)',
-					basename( $this->file_path ),
-					size_format( $size ),
-					size_format( self::MAX_FILE_SIZE )
-				),
-				array(
-					'file' => basename( $this->file_path ),
-					'size' => $size,
-					'max'  => self::MAX_FILE_SIZE,
-				)
-			);
+	private function resolve_layer_directory(): string {
+		switch ( $this->scope->layer ) {
+			case MemoryFileRegistry::LAYER_SHARED:
+				return $this->directory_manager->get_shared_directory();
+			case MemoryFileRegistry::LAYER_USER:
+				return $this->directory_manager->get_user_directory( $this->scope->user_id );
+			case MemoryFileRegistry::LAYER_NETWORK:
+				return $this->directory_manager->get_network_directory();
+			case MemoryFileRegistry::LAYER_AGENT:
+			default:
+				return $this->directory_manager->resolve_agent_directory( array(
+					'agent_id' => $this->scope->agent_id,
+					'user_id'  => $this->scope->user_id,
+				) );
 		}
+	}
 
-		return $size;
+	/**
+	 * Emit the size warning log entry. Side-effect-only.
+	 */
+	private function log_size_warning( int $size ): void {
+		do_action(
+			'datamachine_log',
+			'warning',
+			sprintf(
+				'Agent memory file exceeds recommended size: %s (%s, threshold %s)',
+				$this->scope->filename,
+				size_format( $size ),
+				size_format( self::MAX_FILE_SIZE )
+			),
+			array(
+				'file' => $this->scope->filename,
+				'size' => $size,
+				'max'  => self::MAX_FILE_SIZE,
+			)
+		);
 	}
 }

--- a/inc/Core/FilesRepository/AgentMemoryListEntry.php
+++ b/inc/Core/FilesRepository/AgentMemoryListEntry.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Agent Memory List Entry
+ *
+ * Immutable value object representing a single file in a layer listing
+ * returned by AgentMemoryStoreInterface::list_layer().
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since   next
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+final class AgentMemoryListEntry {
+
+	/**
+	 * @param string   $filename   Filename or relative path within the layer.
+	 * @param string   $layer      Layer the file belongs to (shared|agent|user|network).
+	 * @param int      $bytes      Content length in bytes.
+	 * @param int|null $updated_at Unix timestamp of last modification, or null if unknown.
+	 */
+	public function __construct(
+		public readonly string $filename,
+		public readonly string $layer,
+		public readonly int $bytes,
+		public readonly ?int $updated_at,
+	) {}
+}

--- a/inc/Core/FilesRepository/AgentMemoryReadResult.php
+++ b/inc/Core/FilesRepository/AgentMemoryReadResult.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Agent Memory Read Result
+ *
+ * Immutable value object returned by AgentMemoryStoreInterface::read().
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since   next
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+final class AgentMemoryReadResult {
+
+	/**
+	 * @param bool        $exists     Whether the file exists in the store.
+	 * @param string      $content    File content (empty when !exists).
+	 * @param string      $hash       Content hash (sha1) for compare-and-swap. Empty when !exists.
+	 * @param int         $bytes      Content length in bytes.
+	 * @param int|null    $updated_at Unix timestamp of last modification, or null if unknown.
+	 */
+	public function __construct(
+		public readonly bool $exists,
+		public readonly string $content,
+		public readonly string $hash,
+		public readonly int $bytes,
+		public readonly ?int $updated_at,
+	) {}
+
+	/**
+	 * Sentinel for "file does not exist."
+	 *
+	 * @return self
+	 */
+	public static function not_found(): self {
+		return new self( false, '', '', 0, null );
+	}
+}

--- a/inc/Core/FilesRepository/AgentMemoryScope.php
+++ b/inc/Core/FilesRepository/AgentMemoryScope.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Agent Memory Scope
+ *
+ * Immutable value object that uniquely identifies an agent memory file
+ * across the four-tuple primary key (layer, user_id, agent_id, filename).
+ *
+ * Same identity model as the on-disk path encoding, just decoupled from
+ * the filesystem so an alternate store (e.g. database-backed) can map it
+ * to its own physical key.
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since   next
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+final class AgentMemoryScope {
+
+	/**
+	 * @param string $layer    One of MemoryFileRegistry::LAYER_* (shared|agent|user|network).
+	 * @param int    $user_id  Effective WordPress user ID. 0 = legacy shared / no user.
+	 * @param int    $agent_id Agent ID for direct resolution. 0 = resolve from user_id.
+	 * @param string $filename Filename or relative path within the layer
+	 *                         (e.g. 'MEMORY.md', 'contexts/chat.md', 'daily/2026/04/17.md').
+	 */
+	public function __construct(
+		public readonly string $layer,
+		public readonly int $user_id,
+		public readonly int $agent_id,
+		public readonly string $filename,
+	) {}
+
+	/**
+	 * Stable string key for caching / map lookups.
+	 *
+	 * @return string
+	 */
+	public function key(): string {
+		return sprintf( '%s:%d:%d:%s', $this->layer, $this->user_id, $this->agent_id, $this->filename );
+	}
+}

--- a/inc/Core/FilesRepository/AgentMemoryStoreFactory.php
+++ b/inc/Core/FilesRepository/AgentMemoryStoreFactory.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Agent Memory Store Factory
+ *
+ * Resolves the active {@see AgentMemoryStoreInterface} implementation
+ * via the `datamachine_memory_store` filter, falling back to the
+ * built-in {@see DiskAgentMemoryStore}.
+ *
+ * Single resolution point so every consumer (AgentMemory, AgentFileAbilities,
+ * CoreMemoryFilesDirective) gets the same swap mechanism without duplicating
+ * the filter call.
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since   next
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+class AgentMemoryStoreFactory {
+
+	/**
+	 * Resolve the store for a given scope.
+	 *
+	 * The filter receives a null default and the scope being acted on,
+	 * letting consumers route different scopes to different backends if
+	 * they ever want to. Most consumers will return a single store
+	 * instance regardless of scope.
+	 *
+	 * @param AgentMemoryScope $scope Scope the caller is about to operate on.
+	 * @return AgentMemoryStoreInterface
+	 */
+	public static function for_scope( AgentMemoryScope $scope ): AgentMemoryStoreInterface {
+		/**
+		 * Filter: swap the agent memory persistence backend.
+		 *
+		 * Return an {@see AgentMemoryStoreInterface} instance to short-circuit
+		 * the default disk-backed store. Return null (the default) to use the
+		 * built-in {@see DiskAgentMemoryStore}.
+		 *
+		 * The disk default preserves byte-for-byte the behavior Data Machine
+		 * had before this seam was introduced — self-hosted users see no
+		 * change. Managed-host consumers (e.g. Intelligence on WordPress.com)
+		 * can register a DB-backed implementation.
+		 *
+		 * @since next
+		 *
+		 * @param AgentMemoryStoreInterface|null $store Null to use the disk default,
+		 *                                              or a swap implementation.
+		 * @param AgentMemoryScope               $scope The scope being acted on.
+		 */
+		$store = apply_filters( 'datamachine_memory_store', null, $scope );
+
+		if ( $store instanceof AgentMemoryStoreInterface ) {
+			return $store;
+		}
+
+		return new DiskAgentMemoryStore();
+	}
+}

--- a/inc/Core/FilesRepository/AgentMemoryStoreInterface.php
+++ b/inc/Core/FilesRepository/AgentMemoryStoreInterface.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Agent Memory Store Interface
+ *
+ * Single seam between agent memory operations and the underlying
+ * persistence backend. Default implementation ({@see DiskAgentMemoryStore})
+ * preserves today's filesystem behavior. Consumers can swap in an
+ * alternate store via the `datamachine_memory_store` filter
+ * (e.g. a DB-backed store on managed hosts where the filesystem is
+ * not writable).
+ *
+ * Implementations are responsible for:
+ * - translating an {@see AgentMemoryScope} to a physical key (path, row, URL);
+ * - returning a stable content hash so callers can implement
+ *   compare-and-swap concurrency via the `if_match` write parameter;
+ * - honoring the layer + user_id + agent_id + filename four-tuple as the
+ *   identity model.
+ *
+ * Section parsing, scaffolding, editability gating, and registry-driven
+ * convention-path semantics all stay in the higher-level callers
+ * ({@see AgentMemory}, {@see \DataMachine\Abilities\File\AgentFileAbilities},
+ * {@see \DataMachine\Engine\AI\MemoryFileRegistry}). The store is the
+ * dumb persistence layer underneath.
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since   next
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+interface AgentMemoryStoreInterface {
+
+	/**
+	 * Read the full content of the file identified by $scope.
+	 *
+	 * @param AgentMemoryScope $scope Identifies the target file.
+	 * @return AgentMemoryReadResult Returns ::not_found() when the file does not exist.
+	 */
+	public function read( AgentMemoryScope $scope ): AgentMemoryReadResult;
+
+	/**
+	 * Write the full content of the file identified by $scope.
+	 *
+	 * Implementations that support concurrency MUST honor $if_match: when
+	 * non-null, the write succeeds only if the current stored content has
+	 * a matching hash. On hash mismatch, return a failure result with
+	 * error = 'conflict'.
+	 *
+	 * Implementations without concurrency support (e.g. the disk default)
+	 * MAY ignore $if_match.
+	 *
+	 * @param AgentMemoryScope $scope    Identifies the target file.
+	 * @param string           $content  Full content to persist.
+	 * @param string|null      $if_match Optional content hash for compare-and-swap.
+	 * @return AgentMemoryWriteResult
+	 */
+	public function write( AgentMemoryScope $scope, string $content, ?string $if_match = null ): AgentMemoryWriteResult;
+
+	/**
+	 * Check whether the file identified by $scope exists in the store.
+	 *
+	 * @param AgentMemoryScope $scope Identifies the target file.
+	 * @return bool
+	 */
+	public function exists( AgentMemoryScope $scope ): bool;
+
+	/**
+	 * Delete the file identified by $scope. Idempotent: a delete on a
+	 * non-existent file returns success.
+	 *
+	 * @param AgentMemoryScope $scope Identifies the target file.
+	 * @return AgentMemoryWriteResult
+	 */
+	public function delete( AgentMemoryScope $scope ): AgentMemoryWriteResult;
+
+	/**
+	 * List all files in a single layer for the given identity.
+	 *
+	 * The $scope_query's `filename` field is ignored — list operations
+	 * return all files matching `(layer, user_id, agent_id)`. The
+	 * `layer` field is required.
+	 *
+	 * @param AgentMemoryScope $scope_query Layer + identity to enumerate.
+	 * @return AgentMemoryListEntry[]
+	 */
+	public function list_layer( AgentMemoryScope $scope_query ): array;
+}

--- a/inc/Core/FilesRepository/AgentMemoryWriteResult.php
+++ b/inc/Core/FilesRepository/AgentMemoryWriteResult.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Agent Memory Write Result
+ *
+ * Immutable value object returned by AgentMemoryStoreInterface::write()
+ * and ::delete().
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since   next
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+final class AgentMemoryWriteResult {
+
+	/**
+	 * @param bool        $success Whether the operation succeeded.
+	 * @param string      $hash    Hash (sha1) of the post-write content. Empty on failure or on delete.
+	 * @param int         $bytes   Post-write content length in bytes. Zero on failure or on delete.
+	 * @param string|null $error   Machine-readable error code on failure ('conflict', 'capability',
+	 *                             'io', 'not_found', etc.) or null on success.
+	 */
+	public function __construct(
+		public readonly bool $success,
+		public readonly string $hash,
+		public readonly int $bytes,
+		public readonly ?string $error,
+	) {}
+
+	public static function ok( string $hash, int $bytes ): self {
+		return new self( true, $hash, $bytes, null );
+	}
+
+	public static function failure( string $error ): self {
+		return new self( false, '', 0, $error );
+	}
+}

--- a/inc/Core/FilesRepository/DiskAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/DiskAgentMemoryStore.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Disk Agent Memory Store
+ *
+ * Default implementation of {@see AgentMemoryStoreInterface} that persists
+ * agent memory files on the local filesystem under wp-uploads. Preserves
+ * the byte-for-byte behavior the codebase used before the store seam was
+ * introduced.
+ *
+ * Concurrency: this implementation does not implement compare-and-swap.
+ * The `$if_match` parameter on write() is accepted but ignored — the
+ * single-host disk model historically relied on infrequent collisions.
+ * Callers requiring CAS should use a store that supports it.
+ *
+ * @package DataMachine\Core\FilesRepository
+ * @since   next
+ */
+
+namespace DataMachine\Core\FilesRepository;
+
+use DataMachine\Engine\AI\MemoryFileRegistry;
+
+defined( 'ABSPATH' ) || exit;
+
+class DiskAgentMemoryStore implements AgentMemoryStoreInterface {
+
+	/**
+	 * @var DirectoryManager
+	 */
+	private DirectoryManager $directory_manager;
+
+	public function __construct( ?DirectoryManager $directory_manager = null ) {
+		$this->directory_manager = $directory_manager ?? new DirectoryManager();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function read( AgentMemoryScope $scope ): AgentMemoryReadResult {
+		$filepath = $this->resolve_filepath( $scope );
+
+		if ( ! file_exists( $filepath ) ) {
+			return AgentMemoryReadResult::not_found();
+		}
+
+		$fs = FilesystemHelper::get();
+		if ( ! $fs ) {
+			return AgentMemoryReadResult::not_found();
+		}
+
+		$content    = (string) $fs->get_contents( $filepath );
+		$bytes      = strlen( $content );
+		$updated_at = filemtime( $filepath );
+
+		return new AgentMemoryReadResult(
+			true,
+			$content,
+			sha1( $content ),
+			$bytes,
+			false === $updated_at ? null : (int) $updated_at,
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * `$if_match` is intentionally ignored — see class docblock.
+	 */
+	public function write( AgentMemoryScope $scope, string $content, ?string $if_match = null ): AgentMemoryWriteResult {
+		$filepath = $this->resolve_filepath( $scope );
+		$dir      = dirname( $filepath );
+
+		if ( ! $this->directory_manager->ensure_directory_exists( $dir ) ) {
+			return AgentMemoryWriteResult::failure( 'io' );
+		}
+
+		$fs = FilesystemHelper::get();
+		if ( ! $fs ) {
+			return AgentMemoryWriteResult::failure( 'io' );
+		}
+
+		$ok = $fs->put_contents( $filepath, $content, FS_CHMOD_FILE );
+
+		if ( false === $ok ) {
+			return AgentMemoryWriteResult::failure( 'io' );
+		}
+
+		FilesystemHelper::make_group_writable( $filepath );
+
+		$bytes = strlen( $content );
+		return AgentMemoryWriteResult::ok( sha1( $content ), $bytes );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function exists( AgentMemoryScope $scope ): bool {
+		return file_exists( $this->resolve_filepath( $scope ) );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function delete( AgentMemoryScope $scope ): AgentMemoryWriteResult {
+		$filepath = $this->resolve_filepath( $scope );
+
+		if ( ! file_exists( $filepath ) ) {
+			// Idempotent: deleting a missing file is success.
+			return AgentMemoryWriteResult::ok( '', 0 );
+		}
+
+		$deleted = wp_delete_file( $filepath );
+
+		// wp_delete_file returns void; verify by re-checking existence.
+		if ( file_exists( $filepath ) ) {
+			return AgentMemoryWriteResult::failure( 'io' );
+		}
+
+		unset( $deleted );
+		return AgentMemoryWriteResult::ok( '', 0 );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function list_layer( AgentMemoryScope $scope_query ): array {
+		$layer_dir = $this->resolve_layer_directory( $scope_query );
+
+		if ( ! is_dir( $layer_dir ) ) {
+			return array();
+		}
+
+		$entries = array();
+
+		foreach ( array_diff( scandir( $layer_dir ), array( '.', '..' ) ) as $entry ) {
+			if ( 'index.php' === $entry ) {
+				continue;
+			}
+
+			$path = $layer_dir . '/' . $entry;
+
+			if ( ! is_file( $path ) ) {
+				continue;
+			}
+
+			$mtime     = filemtime( $path );
+			$entries[] = new AgentMemoryListEntry(
+				$entry,
+				$scope_query->layer,
+				(int) filesize( $path ),
+				false === $mtime ? null : (int) $mtime,
+			);
+		}
+
+		return $entries;
+	}
+
+	// =========================================================================
+	// Internal path resolution
+	// =========================================================================
+
+	/**
+	 * Resolve a scope to its absolute filesystem path, honoring registered
+	 * convention paths (e.g. AGENTS.md at ABSPATH).
+	 */
+	private function resolve_filepath( AgentMemoryScope $scope ): string {
+		$layer_dir = $this->resolve_layer_directory( $scope );
+
+		// Convention-path files (e.g. AGENTS.md) override the layer directory.
+		$convention = MemoryFileRegistry::resolve_filepath( $scope->filename, $layer_dir );
+		if ( null !== $convention ) {
+			return $convention;
+		}
+
+		return $layer_dir . '/' . ltrim( $scope->filename, '/' );
+	}
+
+	/**
+	 * Resolve the on-disk directory for a given (layer, user_id, agent_id).
+	 */
+	private function resolve_layer_directory( AgentMemoryScope $scope ): string {
+		switch ( $scope->layer ) {
+			case MemoryFileRegistry::LAYER_SHARED:
+				return $this->directory_manager->get_shared_directory();
+			case MemoryFileRegistry::LAYER_USER:
+				return $this->directory_manager->get_user_directory( $scope->user_id );
+			case MemoryFileRegistry::LAYER_NETWORK:
+				return $this->directory_manager->get_network_directory();
+			case MemoryFileRegistry::LAYER_AGENT:
+			default:
+				return $this->directory_manager->resolve_agent_directory( array(
+					'agent_id' => $scope->agent_id,
+					'user_id'  => $scope->user_id,
+				) );
+		}
+	}
+}

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -26,6 +26,8 @@
 namespace DataMachine\Engine\AI\Directives;
 
 use DataMachine\Core\FilesRepository\AgentMemory;
+use DataMachine\Core\FilesRepository\AgentMemoryScope;
+use DataMachine\Core\FilesRepository\AgentMemoryStoreFactory;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Engine\AI\MemoryFileRegistry;
 
@@ -48,17 +50,7 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 
 		$directory_manager = new DirectoryManager();
 		$user_id           = $directory_manager->get_effective_user_id( (int) ( $payload['user_id'] ?? 0 ) );
-
-		// Resolve layer directories once.
-		$layer_dirs = array(
-			MemoryFileRegistry::LAYER_SHARED  => $directory_manager->get_shared_directory(),
-			MemoryFileRegistry::LAYER_AGENT   => $directory_manager->resolve_agent_directory( array(
-				'agent_id' => (int) ( $payload['agent_id'] ?? 0 ),
-				'user_id'  => $user_id,
-			) ),
-			MemoryFileRegistry::LAYER_USER    => $directory_manager->get_user_directory( $user_id ),
-			MemoryFileRegistry::LAYER_NETWORK => $directory_manager->get_network_directory(),
-		);
+		$agent_id          = (int) ( $payload['agent_id'] ?? 0 );
 
 		// Auto-scaffold missing user-layer files (e.g. USER.md) on first chat.
 		$scaffold_ability = \DataMachine\Abilities\File\ScaffoldAbilities::get_ability();
@@ -79,17 +71,15 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 
 		foreach ( $context_files as $filename => $meta ) {
 			$layer = $meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
-			$dir   = $layer_dirs[ $layer ] ?? $layer_dirs[ MemoryFileRegistry::LAYER_AGENT ];
+			$scope = new AgentMemoryScope( $layer, $user_id, $agent_id, $filename );
+			$store = AgentMemoryStoreFactory::for_scope( $scope );
+			$read  = $store->read( $scope );
 
-			// Convention-path files (e.g. AGENTS.md) live at ABSPATH, not the layer directory.
-			$filepath = MemoryFileRegistry::resolve_filepath( $filename, $dir )
-				?? trailingslashit( $dir ) . $filename;
-
-			if ( ! file_exists( $filepath ) ) {
+			if ( ! $read->exists ) {
 				continue;
 			}
 
-			$content = self::get_file_content_for_output( $filepath, $filename );
+			$content = self::normalize_for_injection( $read->content, $read->bytes, $filename );
 			if ( null === $content ) {
 				continue;
 			}
@@ -100,20 +90,24 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 			);
 		}
 
-		// Load context-specific memory file (contexts/{context}.md).
-		// The context slug comes from the payload, which the PromptBuilder
-		// passes through from the execution context ('chat', 'pipeline', 'system', etc.).
+		// Load context-specific memory file (contexts/{context}.md). The
+		// context slug comes from the payload, which the PromptBuilder
+		// passes through from the execution context ('chat', 'pipeline',
+		// 'system', etc.). Filename is a relative path inside the agent
+		// layer so the store handles it like any other agent-scoped file.
 		if ( ! empty( $context ) ) {
-			$agent_context = array(
-				'agent_id' => (int) ( $payload['agent_id'] ?? 0 ),
-				'user_id'  => $user_id,
+			$context_filename = 'contexts/' . sanitize_file_name( $context ) . '.md';
+			$context_scope    = new AgentMemoryScope(
+				MemoryFileRegistry::LAYER_AGENT,
+				$user_id,
+				$agent_id,
+				$context_filename
 			);
-			$contexts_dir  = $directory_manager->get_contexts_directory( $agent_context );
-			$context_file  = sanitize_file_name( $context ) . '.md';
-			$context_path  = trailingslashit( $contexts_dir ) . $context_file;
+			$context_store    = AgentMemoryStoreFactory::for_scope( $context_scope );
+			$context_read     = $context_store->read( $context_scope );
 
-			if ( file_exists( $context_path ) ) {
-				$content = self::get_file_content_for_output( $context_path, "contexts/{$context_file}" );
+			if ( $context_read->exists ) {
+				$content = self::normalize_for_injection( $context_read->content, $context_read->bytes, $context_filename );
 				if ( null !== $content ) {
 					$outputs[] = array(
 						'type'    => 'system_text',
@@ -127,42 +121,38 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 	}
 
 	/**
-	 * Read a memory file and return normalized directive content.
+	 * Normalize file content for context injection.
 	 *
-	 * @param string $filepath Full file path.
-	 * @param string $filename Filename for logs.
+	 * Logs a size-budget warning, runs the `datamachine_memory_file_content`
+	 * filter, and trims. Returns null when the content is effectively
+	 * empty so callers can skip the directive entirely.
+	 *
+	 * @since next  Renamed from get_file_content_for_output and switched
+	 *              to operate on already-read content from the store.
+	 *
+	 * @param string $content  Raw file content (already loaded by caller).
+	 * @param int    $bytes    Content length in bytes (already known by caller).
+	 * @param string $filename Filename for logs and the content filter.
 	 * @return string|null
 	 */
-	private static function get_file_content_for_output( string $filepath, string $filename ): ?string {
-		global $wp_filesystem;
-
-		// Ensure WP_Filesystem is initialized (not available by default in REST API context).
-		if ( ! $wp_filesystem ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-			WP_Filesystem();
-		}
-
-		$file_size = filesize( $filepath );
-
-		if ( $file_size > AgentMemory::MAX_FILE_SIZE ) {
+	private static function normalize_for_injection( string $content, int $bytes, string $filename ): ?string {
+		if ( $bytes > AgentMemory::MAX_FILE_SIZE ) {
 			do_action(
 				'datamachine_log',
 				'warning',
 				sprintf(
 					'Memory file %s exceeds recommended size for context injection: %s (threshold %s)',
 					$filename,
-					size_format( $file_size ),
+					size_format( $bytes ),
 					size_format( AgentMemory::MAX_FILE_SIZE )
 				),
 				array(
 					'filename' => $filename,
-					'size'     => $file_size,
+					'size'     => $bytes,
 					'max'      => AgentMemory::MAX_FILE_SIZE,
 				)
 			);
 		}
-
-		$content = $wp_filesystem->get_contents( $filepath );
 
 		if ( empty( trim( $content ) ) ) {
 			return null;

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -198,10 +198,13 @@ class DailyMemoryTask extends SystemTask {
 			return;
 		}
 
-		// Write cleaned MEMORY.md.
-		$fs = \DataMachine\Core\FilesRepository\FilesystemHelper::get();
-		$fs->put_contents( $memory->get_file_path(), $new_content );
-		\DataMachine\Core\FilesRepository\FilesystemHelper::make_group_writable( $memory->get_file_path() );
+		// Write cleaned MEMORY.md through the configured store so this
+		// path stays backend-agnostic (works on disk and on swap-in stores).
+		$write_result = $memory->replace_all( $new_content );
+		if ( empty( $write_result['success'] ) ) {
+			$this->failJob( $jobId, $write_result['message'] ?? 'Failed to persist cleaned memory.' );
+			return;
+		}
 
 		// Archive extracted content to the daily file.
 		$archived_size = 0;


### PR DESCRIPTION
Closes #1085.

## Summary

Adds a single seam — `AgentMemoryStoreInterface` resolved via a new `datamachine_memory_store` filter — between agent memory operations and the underlying persistence backend. The default implementation (`DiskAgentMemoryStore`) preserves byte-for-byte the filesystem behavior the codebase used before this seam was introduced. Self-hosted users see no change.

Consumers can swap in alternate stores (e.g. a DB-backed store on managed hosts where the local filesystem is not writable) by returning an `AgentMemoryStoreInterface` from the filter.

## Why

Today every path that reads or writes an agent memory file goes straight to the filesystem via `FilesystemHelper`. That blocks Data Machine from running usefully on managed hosts (WordPress.com, VIP, any PaaS without a writable site-owned filesystem). The two existing memory hooks (`datamachine_memory_files` for registration, `datamachine_memory_file_content` for content transform) don't intercept the actual `file_get_contents` / `file_put_contents` that hit disk.

This PR adds the missing storage seam, mirroring the same generic-mechanism / consumer-bend pattern as the shipped `datamachine_conversation_runner` filter. See #1085 for full design discussion.

## What's in the PR

### New interface (inc/Core/FilesRepository/)

```php
interface AgentMemoryStoreInterface {
    public function read(  AgentMemoryScope \$scope ): AgentMemoryReadResult;
    public function write( AgentMemoryScope \$scope, string \$content, ?string \$if_match = null ): AgentMemoryWriteResult;
    public function exists( AgentMemoryScope \$scope ): bool;
    public function delete( AgentMemoryScope \$scope ): AgentMemoryWriteResult;
    public function list_layer( AgentMemoryScope \$scope_query ): array;
}
```

Plus immutable value objects:

- `AgentMemoryScope { layer, user_id, agent_id, filename }` — the four-tuple primary key
- `AgentMemoryReadResult { exists, content, hash, bytes, updated_at }` — `hash` enables compare-and-swap for stores that need it
- `AgentMemoryWriteResult { success, hash, bytes, error }` — `error` is a machine-readable code (`'conflict'`, `'io'`, etc.) on failure
- `AgentMemoryListEntry { filename, layer, bytes, updated_at }`

### New filter

```php
add_filter( 'datamachine_memory_store', function ( \$store, \$scope ) {
    if ( \$store instanceof AgentMemoryStoreInterface ) {
        return \$store;  // someone else already swapped
    }
    if ( filesystem_is_writable_here() ) {
        return \$store;  // disk default wins
    }
    return new \\My_Plugin\\DB_Agent_Memory_Store();
}, 10, 2 );
```

Default = null = disk. Resolution is centralized in `AgentMemoryStoreFactory::for_scope()` so every consumer goes through the same swap point.

### Disk default — `DiskAgentMemoryStore`

Extracts the current `FilesystemHelper`-based behavior into the new interface. Preserves:
- `MemoryFileRegistry::resolve_filepath()` convention-path semantics (e.g. AGENTS.md at ABSPATH)
- `DirectoryManager` layer resolution (shared / agent / user / network)
- `wp_delete_file` for deletes, group-writable chmod for writes, FS_CHMOD_FILE permissions

`if_match` is accepted but ignored (single-host disk model historically relied on infrequent collisions). Hash is returned on read for callers that want CAS upstream.

### Refactored consumers (all whole-file IO routes through the store)

| File | Before | After |
|---|---|---|
| `inc/Core/FilesRepository/AgentMemory.php` | `FilesystemHelper::get()->put_contents/get_contents` for section ops | Section parsing stays in PHP; whole-file IO via `\$store->read()/write()`. New `replace_all()` helper. |
| `inc/Abilities/File/AgentFileAbilities.php` | Direct `scandir`, `filesize`, `filemtime`, `wp_delete_file`, `$fs->put_contents` for the React UI | `\$store->list_layer()` per layer; `\$store->read/write/delete()` for single-file ops. New `resolveScope()` helper replaces `resolveFilePath()`. |
| `inc/Engine/AI/Directives/CoreMemoryFilesDirective.php` | `\$wp_filesystem->get_contents()` at LLM injection time | `\$store->read()`; `normalize_for_injection()` operates on already-loaded content. |
| `inc/Engine/AI/System/Tasks/DailyMemoryTask.php` | `\$fs->put_contents( \$memory->get_file_path(), ... )` for the cleanup write | `\$memory->replace_all( \$content )` — store-agnostic. |

The only remaining `FilesystemHelper` calls in the changed files are intentional reads of the PHP-uploaded `tmp_name` in `executeUploadAgentFile`, which always lives on local disk regardless of where the destination store persists.

## Migration story

**None.** The default store IS the disk implementation, byte-for-byte identical behavior. Existing self-hosted users never see a non-default store unless a downstream plugin explicitly registers one (and gates on its own conditions, e.g. \"only swap when filesystem is unavailable\").

## UI impact

**Zero.** The React Agent UI calls `/datamachine/v1/files/agent/...`. REST shape, ability contracts, and React queries are all unchanged. Backend swap is transparent.

## Tests

- `php -l` clean across all touched files.
- Existing `AgentMemoryAbilities` tests should continue to pass — the public method shapes (`get_all`, `get_section`, `set_section`, `append_to_section`, `search`, `get_sections`) are unchanged. Section parsing is byte-identical (it stayed in PHP).
- Manual end-to-end testing planned post-merge against the React UI on this dev site (per the smoke-test discipline noted in this repo's testing notes — pure-PHP tests don't catch ability/REST integration issues).

## Non-goals

- No DB-backed store in this repo. The implementation for WP.com lives downstream in [Automattic/intelligence](https://github.com/Automattic/intelligence) (separate PR, separate repo, gated on `!class_exists('\\DataMachineCode\\Environment') || !Environment::has_writable_fs()`).
- No migration tool yet. `wp datamachine memory migrate` is a follow-up.
- Not touching the chat conversation store — that's the separately-planned `datamachine_conversation_store` filter covering `ChatDatabase` / `datamachine_chat_sessions`.
- Daily memory CRUD (`DailyMemoryAbilities`) and context-file routes still write to disk directly. The interface supports them via relative-path filenames; refactoring those call sites is a tight follow-up if we want full DM Agent UI parity on swapped backends. The `DailyMemoryTask` cleanup write (which is what daily files are actually rewritten through in production) is fixed in this PR.

## References

- Related shipped filter: `datamachine_conversation_runner` (same pattern, turn loop swap) — see `docs/development/hooks/core-filters.md` and `docs/core-system/ai-conversation-loop.md`.
- Related planned filter: `datamachine_conversation_store` (same pattern, chat session storage swap).
- Downstream consumer this unblocks: Intelligence on WP.com — closes the last open item from [Automattic/intelligence#95](https://github.com/Automattic/intelligence/issues/95).