### PR TITLE
refactor(memory): consolidate file consumers behind AgentMemory facade

### DIFF
--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -992,14 +992,25 @@ add_filter( 'datamachine_memory_store', function ( $store, $scope ) {
 - `list_layer( $scope_query )` → `AgentMemoryListEntry[]` (enumerates one layer)
 
 Section parsing, scaffolding, editability gating, and registry-driven
-convention-path semantics stay in the higher-level callers (`AgentMemory`,
-`AgentFileAbilities`, `MemoryFileRegistry`). The store is the dumb
-persistence layer underneath.
+convention-path semantics stay in `AgentMemory` (the high-level facade).
+The store is the dumb persistence layer underneath.
 
-**Consumers** (all whole-file IO routes through the store):
-- `\DataMachine\Core\FilesRepository\AgentMemory` — section ops on MEMORY.md / SOUL.md / USER.md / NETWORK.md
+**Single consumer of the store**: `\DataMachine\Core\FilesRepository\AgentMemory`.
+
+`AgentMemory` is the only class in core that talks to `AgentMemoryStoreFactory`. It exposes:
+
+- Section-level ops: `get_section()`, `set_section()`, `append_to_section()`, `get_sections()`, `search()`
+- Whole-file ops: `read()` (returns `AgentMemoryReadResult`), `get_all()`, `replace_all()`, `exists()`, `delete()`
+- Static layer enumerator: `AgentMemory::list_layer( $layer, $user_id, $agent_id )` → `AgentMemoryListEntry[]`
+
+Higher-level consumers all go through this facade rather than instantiating store types directly:
+
 - `\DataMachine\Abilities\File\AgentFileAbilities` — whole-file ops backing the `/datamachine/v1/files/agent` REST routes (the React Agent UI)
 - `\DataMachine\Engine\AI\Directives\CoreMemoryFilesDirective` — file content injected into every AI conversation
+- `\DataMachine\Engine\AI\System\Tasks\DailyMemoryTask` — full-file rewrite during scheduled compaction
+- `\DataMachine\Abilities\AgentMemoryAbilities` — Abilities API surface for memory operations
+
+Outside plugins and extensions should follow the same pattern: instantiate `AgentMemory`, never reach for `AgentMemoryStoreFactory` directly.
 
 ### ConversationManager (`/inc/Engine/AI/ConversationManager.php`)
 

--- a/inc/Abilities/File/AgentFileAbilities.php
+++ b/inc/Abilities/File/AgentFileAbilities.php
@@ -17,8 +17,7 @@
 namespace DataMachine\Abilities\File;
 
 use DataMachine\Abilities\PermissionHelper;
-use DataMachine\Core\FilesRepository\AgentMemoryScope;
-use DataMachine\Core\FilesRepository\AgentMemoryStoreFactory;
+use DataMachine\Core\FilesRepository\AgentMemory;
 use DataMachine\Core\FilesRepository\DailyMemory;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Core\FilesRepository\FilesystemHelper;
@@ -296,14 +295,13 @@ class AgentFileAbilities {
 		$files = array();
 		$seen  = array();
 
-		// First, include convention-path / registered files via the store.
+		// First, include convention-path / registered files via AgentMemory.
 		// Convention-path files (e.g. AGENTS.md at site root) live outside
 		// the layer directories but should still appear in the file list.
 		foreach ( MemoryFileRegistry::get_all() as $filename => $registry_meta ) {
-			$layer = $registry_meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
-			$scope = new AgentMemoryScope( $layer, $user_id, $agent_id, $filename );
-			$store = AgentMemoryStoreFactory::for_scope( $scope );
-			$read  = $store->read( $scope );
+			$layer  = $registry_meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
+			$memory = new AgentMemory( $user_id, $agent_id, $filename, $layer );
+			$read   = $memory->read();
 
 			if ( ! $read->exists ) {
 				continue;
@@ -325,8 +323,9 @@ class AgentFileAbilities {
 			$seen[ $filename ] = true;
 		}
 
-		// Enumerate each layer through the store. Agent layer wins on
-		// filename conflicts with user layer; shared layer is always included.
+		// Enumerate each layer through the AgentMemory facade. Agent layer
+		// wins on filename conflicts with user layer; shared layer is
+		// always included.
 		$layer_order = array(
 			MemoryFileRegistry::LAYER_SHARED,
 			MemoryFileRegistry::LAYER_AGENT,
@@ -334,10 +333,7 @@ class AgentFileAbilities {
 		);
 
 		foreach ( $layer_order as $layer ) {
-			$scope_query = new AgentMemoryScope( $layer, $user_id, $agent_id, '' );
-			$store       = AgentMemoryStoreFactory::for_scope( $scope_query );
-
-			foreach ( $store->list_layer( $scope_query ) as $entry ) {
+			foreach ( AgentMemory::list_layer( $layer, $user_id, $agent_id ) as $entry ) {
 				if ( isset( $seen[ $entry->filename ] ) ) {
 					continue;
 				}
@@ -426,16 +422,17 @@ class AgentFileAbilities {
 		$user_id  = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
 
-		$resolved = $this->resolveScope( $filename, $user_id, $agent_id );
+		$located = $this->locateMemory( $filename, $user_id, $agent_id );
 
-		if ( null === $resolved ) {
+		if ( null === $located ) {
 			return array(
 				'success' => false,
 				'error'   => sprintf( 'File %s not found in any layer', $filename ),
 			);
 		}
 
-		[ $scope, $store, $read ] = $resolved;
+		[ $memory, $read ] = $located;
+		unset( $memory );
 
 		return array(
 			'success' => true,
@@ -497,23 +494,17 @@ class AgentFileAbilities {
 		$registry_layer = MemoryFileRegistry::get_layer( $filename );
 		$target_layer   = $explicit_layer ?? $registry_layer ?? MemoryFileRegistry::LAYER_AGENT;
 
-		$dm      = new DirectoryManager();
-		$user_id = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
+		$dm       = new DirectoryManager();
+		$user_id  = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
+		$agent_id = (int) ( $input['agent_id'] ?? 0 );
 
-		$scope = new AgentMemoryScope(
-			$target_layer,
-			$user_id,
-			(int) ( $input['agent_id'] ?? 0 ),
-			$filename
-		);
-		$store = AgentMemoryStoreFactory::for_scope( $scope );
+		$memory = new AgentMemory( $user_id, $agent_id, $filename, $target_layer );
+		$result = $memory->replace_all( $content );
 
-		$write = $store->write( $scope, $content );
-
-		if ( ! $write->success ) {
+		if ( empty( $result['success'] ) ) {
 			return array(
 				'success' => false,
-				'error'   => sprintf( 'Failed to write file (%s)', $write->error ?? 'unknown' ),
+				'error'   => $result['message'] ?? 'Failed to write file',
 			);
 		}
 
@@ -553,24 +544,24 @@ class AgentFileAbilities {
 		$dm       = new DirectoryManager();
 		$user_id  = $dm->get_effective_user_id( (int) ( $input['user_id'] ?? 0 ) );
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$resolved = $this->resolveScope( $filename, $user_id, $agent_id );
+		$located  = $this->locateMemory( $filename, $user_id, $agent_id );
 
-		if ( null === $resolved ) {
+		if ( null === $located ) {
 			return array(
 				'success' => false,
 				'error'   => sprintf( 'File %s not found in any layer', $filename ),
 			);
 		}
 
-		[ $scope, $store, $read ] = $resolved;
+		[ $memory, $read ] = $located;
 		unset( $read );
 
-		$delete = $store->delete( $scope );
+		$delete = $memory->delete();
 
-		if ( ! $delete->success ) {
+		if ( empty( $delete['success'] ) ) {
 			return array(
 				'success' => false,
-				'error'   => sprintf( 'Failed to delete file (%s)', $delete->error ?? 'unknown' ),
+				'error'   => $delete['message'] ?? 'Failed to delete file',
 			);
 		}
 
@@ -636,14 +627,12 @@ class AgentFileAbilities {
 			);
 		}
 
-		$scope = new AgentMemoryScope( $target_layer, $user_id, $agent_id, $filename );
-		$store = AgentMemoryStoreFactory::for_scope( $scope );
-
-		$write = $store->write( $scope, (string) $content );
-		if ( ! $write->success ) {
+		$memory = new AgentMemory( $user_id, $agent_id, $filename, $target_layer );
+		$write  = $memory->replace_all( (string) $content );
+		if ( empty( $write['success'] ) ) {
 			return array(
 				'success' => false,
-				'error'   => sprintf( 'Failed to store file (%s)', $write->error ?? 'unknown' ),
+				'error'   => $write['message'] ?? 'Failed to store file',
 			);
 		}
 
@@ -659,20 +648,22 @@ class AgentFileAbilities {
 	// =========================================================================
 
 	/**
-	 * Resolve a filename to a (scope, store, read-result) triple by
-	 * trying the registered layer first, then falling back agent → user
-	 * → shared.
+	 * Locate a filename across layers and return the AgentMemory facade
+	 * already bound to the layer where the file lives.
 	 *
-	 * Returns null if the file does not exist in any layer.
+	 * Tries the registered layer first, then falls back agent → user →
+	 * shared. Returns null if the file does not exist in any layer.
 	 *
-	 * @since next Replaces the disk-only resolveFilePath helper.
+	 * @since next Replaces the store-direct resolveScope helper, routing
+	 *             location through the AgentMemory facade so the React UI
+	 *             surface shares one entry point with section-level callers.
 	 *
 	 * @param string $filename Filename to resolve.
 	 * @param int    $user_id  Effective user ID.
 	 * @param int    $agent_id Agent ID for direct resolution. 0 = resolve from user_id.
-	 * @return array{0: AgentMemoryScope, 1: \DataMachine\Core\FilesRepository\AgentMemoryStoreInterface, 2: \DataMachine\Core\FilesRepository\AgentMemoryReadResult}|null
+	 * @return array{0: AgentMemory, 1: \DataMachine\Core\FilesRepository\AgentMemoryReadResult}|null
 	 */
-	private function resolveScope( string $filename, int $user_id, int $agent_id ): ?array {
+	private function locateMemory( string $filename, int $user_id, int $agent_id ): ?array {
 		$layer_order = array();
 
 		// If file is registered, check its canonical layer first.
@@ -689,42 +680,15 @@ class AgentFileAbilities {
 		}
 
 		foreach ( $layer_order as $layer ) {
-			$scope = new AgentMemoryScope( $layer, $user_id, $agent_id, $filename );
-			$store = AgentMemoryStoreFactory::for_scope( $scope );
-			$read  = $store->read( $scope );
+			$memory = new AgentMemory( $user_id, $agent_id, $filename, $layer );
+			$read   = $memory->read();
 
 			if ( $read->exists ) {
-				return array( $scope, $store, $read );
+				return array( $memory, $read );
 			}
 		}
 
 		return null;
-	}
-
-	/**
-	 * Resolve a layer identifier to its directory path.
-	 *
-	 * @param DirectoryManager $dm        Directory manager instance.
-	 * @param string           $layer     Layer identifier ('shared', 'agent', 'user', 'network').
-	 * @param int              $user_id   Effective user ID.
-	 * @param int              $agent_id  Agent ID.
-	 * @return string Directory path.
-	 */
-	private function resolveLayerDirectory( DirectoryManager $dm, string $layer, int $user_id, int $agent_id = 0 ): string {
-		switch ( $layer ) {
-			case MemoryFileRegistry::LAYER_SHARED:
-				return $dm->get_shared_directory();
-			case MemoryFileRegistry::LAYER_USER:
-				return $dm->get_user_directory( $user_id );
-			case MemoryFileRegistry::LAYER_NETWORK:
-				return $dm->get_network_directory();
-			case MemoryFileRegistry::LAYER_AGENT:
-			default:
-				return $dm->resolve_agent_directory( array(
-					'agent_id' => $agent_id,
-					'user_id'  => $user_id,
-				) );
-		}
 	}
 
 	/**

--- a/inc/Core/FilesRepository/AgentMemory.php
+++ b/inc/Core/FilesRepository/AgentMemory.php
@@ -55,18 +55,21 @@ class AgentMemory {
 	 * @since 0.41.0 Added $agent_id parameter for agent-first resolution.
 	 * @since 0.45.0 Added $filename parameter for any-file support.
 	 * @since next   Switched whole-file IO to AgentMemoryStoreInterface.
+	 * @since next   Optional $layer override for explicit-layer addressing.
 	 *
-	 * @param int    $user_id  WordPress user ID. 0 = legacy shared directory.
-	 * @param int    $agent_id Agent ID for direct resolution. 0 = resolve from user_id.
-	 * @param string $filename Target filename. Defaults to MEMORY.md for backwards compatibility.
+	 * @param int         $user_id  WordPress user ID. 0 = legacy shared directory.
+	 * @param int         $agent_id Agent ID for direct resolution. 0 = resolve from user_id.
+	 * @param string      $filename Target filename. Defaults to MEMORY.md for backwards compatibility.
+	 * @param string|null $layer    Optional explicit layer. When null, resolved from the registry
+	 *                              (agent layer for unregistered files).
 	 */
-	public function __construct( int $user_id = 0, int $agent_id = 0, string $filename = 'MEMORY.md' ) {
+	public function __construct( int $user_id = 0, int $agent_id = 0, string $filename = 'MEMORY.md', ?string $layer = null ) {
 		$this->directory_manager = new DirectoryManager();
 		$effective_user_id       = $this->directory_manager->get_effective_user_id( $user_id );
 		$safe_filename           = $this->sanitize_filename( $filename );
 
 		$this->scope = new AgentMemoryScope(
-			$this->resolve_layer( $safe_filename ),
+			$layer ?? self::resolve_layer_for( $safe_filename ),
 			$effective_user_id,
 			$agent_id,
 			$safe_filename
@@ -78,10 +81,12 @@ class AgentMemory {
 	}
 
 	/**
-	 * Resolve which layer this filename belongs to via the registry,
+	 * Resolve which layer a filename belongs to via the registry,
 	 * defaulting to the agent layer for unregistered files.
+	 *
+	 * @since next  Static so other consumers can reuse the resolution.
 	 */
-	private function resolve_layer( string $filename ): string {
+	public static function resolve_layer_for( string $filename ): string {
 		$registered = MemoryFileRegistry::get_layer( $filename );
 		return $registered ?? MemoryFileRegistry::LAYER_AGENT;
 	}
@@ -144,6 +149,80 @@ class AgentMemory {
 			'file'    => $this->scope->filename,
 			'content' => $result->content,
 		);
+	}
+
+	/**
+	 * Low-level read returning the raw store result.
+	 *
+	 * Exposes the underlying {@see AgentMemoryReadResult} (content, hash,
+	 * bytes, updated_at, exists) for consumers that need richer metadata
+	 * than {@see self::get_all()}'s human-shaped response — e.g. directives
+	 * that want byte counts for size budgeting, the React UI's whole-file
+	 * GET that needs modified-at, or anything that wants the content hash
+	 * for compare-and-swap upstream.
+	 *
+	 * @since next
+	 * @return AgentMemoryReadResult
+	 */
+	public function read(): AgentMemoryReadResult {
+		return $this->store->read( $this->scope );
+	}
+
+	/**
+	 * Whether the underlying file exists in the store.
+	 *
+	 * @since next
+	 * @return bool
+	 */
+	public function exists(): bool {
+		return $this->store->exists( $this->scope );
+	}
+
+	/**
+	 * Delete this file from the store. Idempotent — deleting a missing
+	 * file returns success.
+	 *
+	 * @since next
+	 * @return array{success: bool, message: string}
+	 */
+	public function delete(): array {
+		$result = $this->store->delete( $this->scope );
+
+		if ( ! $result->success ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Failed to delete %s (%s).', $this->scope->filename, $result->error ?? 'unknown' ),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'message' => sprintf( '%s deleted.', $this->scope->filename ),
+		);
+	}
+
+	/**
+	 * List all files in a single layer for the given identity.
+	 *
+	 * Static facade over {@see AgentMemoryStoreInterface::list_layer()}
+	 * so directory enumeration goes through the same swap point as
+	 * single-file IO. Callers receive a list of {@see AgentMemoryListEntry}
+	 * value objects.
+	 *
+	 * @since next
+	 *
+	 * @param string $layer    Layer identifier (shared|agent|user|network).
+	 * @param int    $user_id  WordPress user ID. 0 = default agent.
+	 * @param int    $agent_id Agent ID for direct resolution. 0 = resolve from user_id.
+	 * @return AgentMemoryListEntry[]
+	 */
+	public static function list_layer( string $layer, int $user_id = 0, int $agent_id = 0 ): array {
+		$dm                = new DirectoryManager();
+		$effective_user_id = $dm->get_effective_user_id( $user_id );
+		$scope_query       = new AgentMemoryScope( $layer, $effective_user_id, $agent_id, '' );
+		$store             = AgentMemoryStoreFactory::for_scope( $scope_query );
+
+		return $store->list_layer( $scope_query );
 	}
 
 	/**

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -26,8 +26,6 @@
 namespace DataMachine\Engine\AI\Directives;
 
 use DataMachine\Core\FilesRepository\AgentMemory;
-use DataMachine\Core\FilesRepository\AgentMemoryScope;
-use DataMachine\Core\FilesRepository\AgentMemoryStoreFactory;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Engine\AI\MemoryFileRegistry;
 
@@ -70,10 +68,9 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 			: MemoryFileRegistry::get_all();
 
 		foreach ( $context_files as $filename => $meta ) {
-			$layer = $meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
-			$scope = new AgentMemoryScope( $layer, $user_id, $agent_id, $filename );
-			$store = AgentMemoryStoreFactory::for_scope( $scope );
-			$read  = $store->read( $scope );
+			$layer  = $meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
+			$memory = new AgentMemory( $user_id, $agent_id, $filename, $layer );
+			$read   = $memory->read();
 
 			if ( ! $read->exists ) {
 				continue;
@@ -94,17 +91,12 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 		// context slug comes from the payload, which the PromptBuilder
 		// passes through from the execution context ('chat', 'pipeline',
 		// 'system', etc.). Filename is a relative path inside the agent
-		// layer so the store handles it like any other agent-scoped file.
+		// layer so the AgentMemory facade handles it like any other
+		// agent-scoped file.
 		if ( ! empty( $context ) ) {
 			$context_filename = 'contexts/' . sanitize_file_name( $context ) . '.md';
-			$context_scope    = new AgentMemoryScope(
-				MemoryFileRegistry::LAYER_AGENT,
-				$user_id,
-				$agent_id,
-				$context_filename
-			);
-			$context_store    = AgentMemoryStoreFactory::for_scope( $context_scope );
-			$context_read     = $context_store->read( $context_scope );
+			$context_memory   = new AgentMemory( $user_id, $agent_id, $context_filename, MemoryFileRegistry::LAYER_AGENT );
+			$context_read     = $context_memory->read();
 
 			if ( $context_read->exists ) {
 				$content = self::normalize_for_injection( $context_read->content, $context_read->bytes, $context_filename );


### PR DESCRIPTION
Closes #1087. Follow-up to #1086.

## What this does

Pure refactor. After the memory store seam landed in #1086, three consumers (`AgentFileAbilities`, `CoreMemoryFilesDirective`, `DailyMemoryTask`) were calling `AgentMemoryStoreFactory` directly even though `AgentMemory` could front them. This collapses the four call sites into one: **`AgentMemory` is now the sole class in core that talks to the store.**

\`\`\`
Before #1086:                     After #1086:                       After this PR:
  AgentMemory     ─→ disk          AgentMemory          ─┐           AgentMemory ─→ Store ─→ disk
  AgentFileAbil.  ─→ disk          AgentFileAbilities   ─┼─→ Store     ↑
  CoreMemoryDir.  ─→ disk          CoreMemoryFilesDir.  ─┤             │
  DailyMemoryTask ─→ disk          DailyMemoryTask      ─┘             ├── AgentFileAbilities
                                                                       ├── CoreMemoryFilesDirective
                                                                       └── DailyMemoryTask (already routed via replace_all in #1086)
\`\`\`

No behavior change visible to the React UI, REST callers, abilities, or any external plugin. Same byte-level outputs as the disk default before #1086 ever shipped.

## AgentMemory facade additions

| Method | Purpose |
|---|---|
| `public function read(): AgentMemoryReadResult` | Low-level read returning richer metadata (content, hash, bytes, updated_at) than `get_all()`'s human-shaped response. Used where callers need byte counts, modified-at, or hash. |
| `public function exists(): bool` | Cheap existence check. |
| `public function delete(): array` | Idempotent file delete via the store. |
| `public static function list_layer( \$layer, \$user_id, \$agent_id ): array` | Layer enumeration through the same store seam as single-file IO. Returns `AgentMemoryListEntry[]`. |
| `public static function resolve_layer_for( \$filename ): string` | Promoted from private — registry-driven layer resolution as a reusable helper. |
| Constructor: optional `\$layer` override | Explicit-layer addressing (used by `executeWriteAgentFile`, which accepts an explicit `layer` input parameter). |

## Refactored consumers

### `AgentFileAbilities` (the React UI surface)

| Method | Before | After |
|---|---|---|
| `executeListAgentFiles` | `AgentMemoryStoreFactory::for_scope` per file + `\$store->list_layer` per layer | `new AgentMemory(...)->read()` per registered file + `AgentMemory::list_layer()` per layer |
| `executeGetAgentFile` | `resolveScope()` returning `(scope, store, read)` triple | `locateMemory()` returning `(AgentMemory, AgentMemoryReadResult)` pair |
| `executeWriteAgentFile` | `AgentMemoryStoreFactory::for_scope(...)->write()` | `new AgentMemory(...)->replace_all()` |
| `executeDeleteAgentFile` | `\$store->delete(\$scope)` | `\$memory->delete()` |
| `executeUploadAgentFile` | `AgentMemoryStoreFactory::for_scope(...)->write()` | `new AgentMemory(...)->replace_all()` |

Dead helpers removed: `resolveLayerDirectory()`. (No longer needed once layer resolution moved into `AgentMemory`.)

### `CoreMemoryFilesDirective` (LLM context injection)

`new AgentMemoryScope(...)` + `AgentMemoryStoreFactory::for_scope(...)` + `\$store->read(...)` → `new AgentMemory(...)->read()`. Same for the context-file path (`contexts/{slug}.md`).

### `DailyMemoryTask` (scheduled compaction)

Already routed through `\$memory->replace_all()` in #1086. No change in this PR.

## Why

- **One coupling to the store interface instead of four.** Future store changes (signature tweaks, new methods, telemetry wrappers) touch one file.
- **One self-heal/scaffold path.** `AgentMemory::ensure_file_exists()` is the only place that scaffolds; the others assume the file may not exist and skip.
- **One place to attach observability.** Logs, metrics, slow-write warnings land in one method.
- **Future filters that want to wrap reads/writes** (audit, encryption, telemetry) wrap one facade instead of four call sites.
- **Cleaner extension story for outside plugins:** \"instantiate `AgentMemory`, never reach for `AgentMemoryStoreFactory` directly.\" Documented in `core-filters.md`.

## Audit: who still calls the store directly?

After this PR:

\`\`\`
\$ grep -rn 'AgentMemoryStoreFactory\\|new AgentMemoryScope' inc/ --include='*.php'
inc/Core/FilesRepository/AgentMemoryStoreFactory.php:21:class AgentMemoryStoreFactory {
inc/Core/FilesRepository/AgentMemory.php:71:        \$this->scope = new AgentMemoryScope(...)
inc/Core/FilesRepository/AgentMemory.php:77:        \$this->store = AgentMemoryStoreFactory::for_scope(...)
inc/Core/FilesRepository/AgentMemory.php:222: \$scope_query = new AgentMemoryScope(...)
inc/Core/FilesRepository/AgentMemory.php:223: \$store       = AgentMemoryStoreFactory::for_scope(...)
\`\`\`

Only `AgentMemory` itself. Goal achieved.

## Out of scope

- The `DailyMemoryAbilities` and context-file CRUD routes (`/files/agent/contexts/...`) still use disk-direct paths — those weren't refactored in #1086 either. Tracked separately; not regressed by this PR.
- No new abilities, no new REST routes, no React/UI changes.

## Tests

- `php -l` clean across all touched PHP files.
- Existing `AgentMemoryAbilities` test surface is unchanged (public methods on `AgentMemory` retained their signatures; new methods added alongside).
- Manual UI smoke test on this dev site planned post-merge.

## Diff stats

\`\`\`
4 files changed, 151 insertions(+), 105 deletions(-)
\`\`\`

Net +46 lines is mostly the new facade methods + their docblocks; the consumer changes are mostly subtractive.