### PR TITLE
feat(memory): list_subtree + route daily memory and context files through store

### DIFF
--- a/inc/Abilities/File/AgentFileAbilities.php
+++ b/inc/Abilities/File/AgentFileAbilities.php
@@ -356,31 +356,34 @@ class AgentFileAbilities {
 			}
 		}
 
-		// Include context memory files.
-		$agent_context = array(
-			'agent_id' => (int) ( $input['agent_id'] ?? 0 ),
-			'user_id'  => $user_id,
+		// Include context memory files (contexts/*.md inside the agent layer).
+		// Goes through the store seam so this works on any backend.
+		$context_entries = AgentMemory::list_subtree(
+			MemoryFileRegistry::LAYER_AGENT,
+			$user_id,
+			(int) ( $input['agent_id'] ?? 0 ),
+			'contexts'
 		);
-		$contexts_dir  = $dm->get_contexts_directory( $agent_context );
 
-		if ( is_dir( $contexts_dir ) ) {
-			foreach ( glob( trailingslashit( $contexts_dir ) . '*.md' ) as $filepath ) {
-				$filename = basename( $filepath );
-				$slug     = pathinfo( $filename, PATHINFO_FILENAME );
-				$files[]  = array(
-					'filename'     => $filename,
-					'size'         => filesize( $filepath ),
-					'modified'     => gmdate( 'c', filemtime( $filepath ) ),
-					'type'         => 'context',
-					'layer'        => 'context',
-					'protected'    => false,
-					'editable'     => true,
-					'registered'   => false,
-					'label'        => ucfirst( $slug ) . ' Context',
-					'description'  => "Context-scoped instructions loaded when execution context is '{$slug}'.",
-					'context_slug' => $slug,
-				);
+		foreach ( $context_entries as $entry ) {
+			$basename = basename( $entry->filename );
+			if ( '.md' !== substr( $basename, -3 ) ) {
+				continue;
 			}
+			$slug    = substr( $basename, 0, -3 );
+			$files[] = array(
+				'filename'     => $basename,
+				'size'         => $entry->bytes,
+				'modified'     => null !== $entry->updated_at ? gmdate( 'c', $entry->updated_at ) : '',
+				'type'         => 'context',
+				'layer'        => 'context',
+				'protected'    => false,
+				'editable'     => true,
+				'registered'   => false,
+				'label'        => ucfirst( $slug ) . ' Context',
+				'description'  => "Context-scoped instructions loaded when execution context is '{$slug}'.",
+				'context_slug' => $slug,
+			);
 		}
 
 		// Include daily memory summary.

--- a/inc/Api/AgentFiles.php
+++ b/inc/Api/AgentFiles.php
@@ -563,43 +563,71 @@ class AgentFiles {
 	// =========================================================================
 
 	/**
-	 * Resolve the contexts directory for the current agent.
+	 * Path prefix within the agent layer for context memory files.
 	 *
-	 * @param WP_REST_Request $request REST request.
-	 * @return string Full path to the contexts directory.
+	 * Context files are addressed as relative paths inside the agent
+	 * layer (`contexts/<slug>.md`), so they ride the same store seam
+	 * as MEMORY.md / SOUL.md / daily memory.
+	 *
+	 * @since next
 	 */
-	private static function resolve_contexts_dir( WP_REST_Request $request ): string {
-		$dm      = new \DataMachine\Core\FilesRepository\DirectoryManager();
-		$user_id = $dm->get_effective_user_id( self::resolve_scoped_user_id( $request ) );
+	private const CONTEXTS_PREFIX = 'contexts';
 
-		$context = array( 'user_id' => $user_id );
+	/**
+	 * Build the relative filename for a context slug.
+	 *
+	 * @since next
+	 */
+	private static function context_filename( string $slug ): string {
+		return self::CONTEXTS_PREFIX . '/' . $slug . '.md';
+	}
 
+	/**
+	 * Build an AgentMemory facade for a context slug from a request.
+	 *
+	 * @since next
+	 */
+	private static function context_memory( WP_REST_Request $request, string $slug ): \DataMachine\Core\FilesRepository\AgentMemory {
+		$user_id  = self::resolve_scoped_user_id( $request );
 		$agent_id = $request->get_param( 'agent_id' );
-		if ( null !== $agent_id && '' !== $agent_id ) {
-			$context['agent_id'] = (int) $agent_id;
-		}
+		$agent_id = ( null !== $agent_id && '' !== $agent_id ) ? (int) $agent_id : 0;
 
-		return $dm->get_contexts_directory( $context );
+		return new \DataMachine\Core\FilesRepository\AgentMemory(
+			$user_id,
+			$agent_id,
+			self::context_filename( $slug ),
+			\DataMachine\Engine\AI\MemoryFileRegistry::LAYER_AGENT
+		);
 	}
 
 	/**
 	 * List all context memory files.
 	 */
 	public static function list_context_files( WP_REST_Request $request ) {
-		$dir = self::resolve_contexts_dir( $request );
+		$user_id  = self::resolve_scoped_user_id( $request );
+		$agent_id = $request->get_param( 'agent_id' );
+		$agent_id = ( null !== $agent_id && '' !== $agent_id ) ? (int) $agent_id : 0;
+
+		$entries = \DataMachine\Core\FilesRepository\AgentMemory::list_subtree(
+			\DataMachine\Engine\AI\MemoryFileRegistry::LAYER_AGENT,
+			$user_id,
+			$agent_id,
+			self::CONTEXTS_PREFIX
+		);
 
 		$files = array();
-		if ( is_dir( $dir ) ) {
-			foreach ( glob( trailingslashit( $dir ) . '*.md' ) as $filepath ) {
-				$filename = basename( $filepath );
-				$slug     = pathinfo( $filename, PATHINFO_FILENAME );
-				$files[]  = array(
-					'slug'     => $slug,
-					'filename' => $filename,
-					'size'     => filesize( $filepath ),
-					'modified' => gmdate( 'c', filemtime( $filepath ) ),
-				);
+		foreach ( $entries as $entry ) {
+			$basename = basename( $entry->filename );
+			if ( '.md' !== substr( $basename, -3 ) ) {
+				continue;
 			}
+			$slug    = substr( $basename, 0, -3 );
+			$files[] = array(
+				'slug'     => $slug,
+				'filename' => $basename,
+				'size'     => $entry->bytes,
+				'modified' => null !== $entry->updated_at ? gmdate( 'c', $entry->updated_at ) : '',
+			);
 		}
 
 		return rest_ensure_response( array(
@@ -612,18 +640,12 @@ class AgentFiles {
 	 * Read a context memory file.
 	 */
 	public static function get_context_file( WP_REST_Request $request ) {
-		$dir      = self::resolve_contexts_dir( $request );
-		$slug     = sanitize_title( $request['context_slug'] );
-		$filepath = trailingslashit( $dir ) . $slug . '.md';
+		$slug   = sanitize_title( $request['context_slug'] );
+		$memory = self::context_memory( $request, $slug );
+		$read   = $memory->read();
 
-		if ( ! file_exists( $filepath ) ) {
+		if ( ! $read->exists ) {
 			return new WP_Error( 'not_found', "Context file '{$slug}.md' not found.", array( 'status' => 404 ) );
-		}
-
-		global $wp_filesystem;
-		if ( ! $wp_filesystem ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-			\WP_Filesystem();
 		}
 
 		return rest_ensure_response( array(
@@ -631,9 +653,9 @@ class AgentFiles {
 			'data'    => array(
 				'slug'     => $slug,
 				'filename' => $slug . '.md',
-				'content'  => $wp_filesystem->get_contents( $filepath ),
-				'size'     => filesize( $filepath ),
-				'modified' => gmdate( 'c', filemtime( $filepath ) ),
+				'content'  => $read->content,
+				'size'     => $read->bytes,
+				'modified' => null !== $read->updated_at ? gmdate( 'c', $read->updated_at ) : '',
 			),
 		) );
 	}
@@ -642,31 +664,21 @@ class AgentFiles {
 	 * Create or update a context memory file.
 	 */
 	public static function put_context_file( WP_REST_Request $request ) {
-		$dir  = self::resolve_contexts_dir( $request );
-		$slug = sanitize_title( $request['context_slug'] );
-
-		// Ensure the contexts directory exists.
-		$dm = new \DataMachine\Core\FilesRepository\DirectoryManager();
-		if ( ! $dm->ensure_directory_exists( $dir ) ) {
-			return new WP_Error( 'create_dir_failed', 'Failed to create contexts directory.', array( 'status' => 500 ) );
-		}
-
+		$slug    = sanitize_title( $request['context_slug'] );
 		$content = $request->get_param( 'content' );
 		if ( null === $content ) {
 			$content = $request->get_body();
 		}
 
-		global $wp_filesystem;
-		if ( ! $wp_filesystem ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-			\WP_Filesystem();
-		}
+		$memory = self::context_memory( $request, $slug );
+		$result = $memory->replace_all( (string) $content );
 
-		$filepath = trailingslashit( $dir ) . $slug . '.md';
-		$written  = $wp_filesystem->put_contents( $filepath, $content, FS_CHMOD_FILE );
-
-		if ( ! $written ) {
-			return new WP_Error( 'write_failed', "Failed to write context file '{$slug}.md'.", array( 'status' => 500 ) );
+		if ( empty( $result['success'] ) ) {
+			return new WP_Error(
+				'write_failed',
+				$result['message'] ?? "Failed to write context file '{$slug}.md'.",
+				array( 'status' => 500 )
+			);
 		}
 
 		return rest_ensure_response( array(
@@ -680,22 +692,21 @@ class AgentFiles {
 	 * Delete a context memory file.
 	 */
 	public static function delete_context_file( WP_REST_Request $request ) {
-		$dir      = self::resolve_contexts_dir( $request );
-		$slug     = sanitize_title( $request['context_slug'] );
-		$filepath = trailingslashit( $dir ) . $slug . '.md';
+		$slug   = sanitize_title( $request['context_slug'] );
+		$memory = self::context_memory( $request, $slug );
 
-		if ( ! file_exists( $filepath ) ) {
+		if ( ! $memory->exists() ) {
 			return new WP_Error( 'not_found', "Context file '{$slug}.md' not found.", array( 'status' => 404 ) );
 		}
 
-		global $wp_filesystem;
-		if ( ! $wp_filesystem ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-			\WP_Filesystem();
-		}
+		$result = $memory->delete();
 
-		if ( ! $wp_filesystem->delete( $filepath ) ) {
-			return new WP_Error( 'delete_failed', "Failed to delete context file '{$slug}.md'.", array( 'status' => 500 ) );
+		if ( empty( $result['success'] ) ) {
+			return new WP_Error(
+				'delete_failed',
+				$result['message'] ?? "Failed to delete context file '{$slug}.md'.",
+				array( 'status' => 500 )
+			);
 		}
 
 		return rest_ensure_response( array(

--- a/inc/Core/FilesRepository/AgentMemory.php
+++ b/inc/Core/FilesRepository/AgentMemory.php
@@ -226,6 +226,34 @@ class AgentMemory {
 	}
 
 	/**
+	 * List all files under a path prefix within a layer.
+	 *
+	 * Static facade over {@see AgentMemoryStoreInterface::list_subtree()}.
+	 * Recursive — entries' filenames are full relative paths from the
+	 * layer root (e.g. `daily/2026/04/17.md`, `contexts/chat.md`).
+	 *
+	 * Used for path-namespaced file families that don't fit the
+	 * top-level layer model: daily memory under `daily/YYYY/MM/`, context
+	 * files under `contexts/`, future plugin-added subtrees.
+	 *
+	 * @since next
+	 *
+	 * @param string $layer    Layer identifier (shared|agent|user|network).
+	 * @param int    $user_id  WordPress user ID. 0 = default agent.
+	 * @param int    $agent_id Agent ID for direct resolution. 0 = resolve from user_id.
+	 * @param string $prefix   Path prefix without trailing slash (e.g. 'daily', 'contexts').
+	 * @return AgentMemoryListEntry[]
+	 */
+	public static function list_subtree( string $layer, int $user_id, int $agent_id, string $prefix ): array {
+		$dm                = new DirectoryManager();
+		$effective_user_id = $dm->get_effective_user_id( $user_id );
+		$scope_query       = new AgentMemoryScope( $layer, $effective_user_id, $agent_id, '' );
+		$store             = AgentMemoryStoreFactory::for_scope( $scope_query );
+
+		return $store->list_subtree( $scope_query, $prefix );
+	}
+
+	/**
 	 * List all section headers in the file.
 	 *
 	 * Sections are defined by markdown ## headers.

--- a/inc/Core/FilesRepository/AgentMemoryStoreInterface.php
+++ b/inc/Core/FilesRepository/AgentMemoryStoreInterface.php
@@ -76,14 +76,38 @@ interface AgentMemoryStoreInterface {
 	public function delete( AgentMemoryScope $scope ): AgentMemoryWriteResult;
 
 	/**
-	 * List all files in a single layer for the given identity.
+	 * List all top-level files in a single layer for the given identity.
 	 *
 	 * The $scope_query's `filename` field is ignored — list operations
 	 * return all files matching `(layer, user_id, agent_id)`. The
 	 * `layer` field is required.
 	 *
+	 * Top-level only: subdirectories under the layer (e.g. `daily/`,
+	 * `contexts/`) are NOT recursed into. Use {@see self::list_subtree()}
+	 * to enumerate those.
+	 *
 	 * @param AgentMemoryScope $scope_query Layer + identity to enumerate.
 	 * @return AgentMemoryListEntry[]
 	 */
 	public function list_layer( AgentMemoryScope $scope_query ): array;
+
+	/**
+	 * List all files under a path prefix within a layer.
+	 *
+	 * Recursive — descends into all subdirectories beneath the prefix.
+	 * Filenames in the returned entries include the full relative path
+	 * (e.g. when listing prefix `daily`, an entry's `filename` is
+	 * `daily/2026/04/17.md`, not `2026/04/17.md`).
+	 *
+	 * Used for path-namespaced file families like daily memory
+	 * (`daily/YYYY/MM/DD.md`) and context files (`contexts/<slug>.md`).
+	 *
+	 * @since next
+	 *
+	 * @param AgentMemoryScope $scope_query Layer + identity. `filename` is ignored.
+	 * @param string           $prefix      Path prefix without trailing slash
+	 *                                      (e.g. 'daily', 'contexts'). Required.
+	 * @return AgentMemoryListEntry[]
+	 */
+	public function list_subtree( AgentMemoryScope $scope_query, string $prefix ): array;
 }

--- a/inc/Core/FilesRepository/DailyMemory.php
+++ b/inc/Core/FilesRepository/DailyMemory.php
@@ -10,26 +10,43 @@
  * It is NOT logs (operational telemetry). It persists agent knowledge and
  * is never auto-cleared.
  *
+ * Persistence is delegated to the {@see AgentMemoryStoreInterface}
+ * registered for the agent layer (resolved through the
+ * `datamachine_memory_store` filter). Daily files are addressed as
+ * relative paths within the agent layer (`daily/YYYY/MM/DD.md`), so a
+ * single store swap covers MEMORY.md, daily memory, and context files
+ * uniformly.
+ *
+ * Plugins that need a completely different daily backend (separate from
+ * the memory store swap) can still implement {@see DailyMemoryStorage}
+ * and register it via the `datamachine_daily_memory_storage` filter —
+ * this class is the default implementation.
+ *
  * @package DataMachine\Core\FilesRepository
  * @since 0.32.0
+ * @since next   Whole-file IO delegated to AgentMemory facade / store.
  * @see https://github.com/Extra-Chill/data-machine/issues/348
  */
 
 namespace DataMachine\Core\FilesRepository;
+
+use DataMachine\Engine\AI\MemoryFileRegistry;
 
 defined( 'ABSPATH' ) || exit;
 
 class DailyMemory implements DailyMemoryStorage {
 
 	/**
+	 * Path prefix within the agent layer that scopes all daily files.
+	 *
+	 * @var string
+	 */
+	private const PREFIX = 'daily';
+
+	/**
 	 * @var DirectoryManager
 	 */
 	private DirectoryManager $directory_manager;
-
-	/**
-	 * @var string Base path for daily memory files (agent/daily/).
-	 */
-	private string $base_path;
 
 	/**
 	 * Effective scoped user ID.
@@ -38,6 +55,14 @@ class DailyMemory implements DailyMemoryStorage {
 	 * @var int
 	 */
 	private int $user_id;
+
+	/**
+	 * Agent ID for direct scope resolution. 0 = resolve from user_id.
+	 *
+	 * @since next
+	 * @var int
+	 */
+	private int $agent_id;
 
 	/**
 	 * @since 0.37.0 Added $user_id parameter for multi-agent partitioning.
@@ -49,24 +74,30 @@ class DailyMemory implements DailyMemoryStorage {
 	public function __construct( int $user_id = 0, int $agent_id = 0 ) {
 		$this->directory_manager = new DirectoryManager();
 		$this->user_id           = $this->directory_manager->get_effective_user_id( $user_id );
-		$agent_dir               = $this->directory_manager->resolve_agent_directory( array(
-			'agent_id' => $agent_id,
-			'user_id'  => $this->user_id,
-		) );
-		$this->base_path         = "{$agent_dir}/daily";
+		$this->agent_id          = $agent_id;
 	}
 
 	/**
 	 * Get the base path for daily memory files.
 	 *
+	 * Disk-only convenience — returns the directory daily files would
+	 * live in if backed by the disk store. Non-disk stores persist
+	 * elsewhere; the path may not exist in those environments.
+	 *
 	 * @return string
 	 */
 	public function get_base_path(): string {
-		return $this->base_path;
+		$agent_dir = $this->directory_manager->resolve_agent_directory( array(
+			'agent_id' => $this->agent_id,
+			'user_id'  => $this->user_id,
+		) );
+		return "{$agent_dir}/" . self::PREFIX;
 	}
 
 	/**
 	 * Build the file path for a given date.
+	 *
+	 * Disk-only convenience — see {@see self::get_base_path()}.
 	 *
 	 * @param string $year  Four-digit year (e.g. '2026').
 	 * @param string $month Two-digit month (e.g. '02').
@@ -74,7 +105,7 @@ class DailyMemory implements DailyMemoryStorage {
 	 * @return string Full file path.
 	 */
 	public function get_file_path( string $year, string $month, string $day ): string {
-		return "{$this->base_path}/{$year}/{$month}/{$day}.md";
+		return $this->get_base_path() . "/{$year}/{$month}/{$day}.md";
 	}
 
 	/**
@@ -91,6 +122,32 @@ class DailyMemory implements DailyMemoryStorage {
 	}
 
 	/**
+	 * Build the relative filename within the agent layer for a given date.
+	 *
+	 * @since next
+	 *
+	 * @param string $year  Four-digit year.
+	 * @param string $month Two-digit month.
+	 * @param string $day   Two-digit day.
+	 * @return string Relative filename (e.g. 'daily/2026/04/17.md').
+	 */
+	private function relative_filename( string $year, string $month, string $day ): string {
+		return self::PREFIX . "/{$year}/{$month}/{$day}.md";
+	}
+
+	/**
+	 * Build an AgentMemory facade for a given daily date.
+	 */
+	private function memory_for( string $year, string $month, string $day ): AgentMemory {
+		return new AgentMemory(
+			$this->user_id,
+			$this->agent_id,
+			$this->relative_filename( $year, $month, $day ),
+			MemoryFileRegistry::LAYER_AGENT
+		);
+	}
+
+	/**
 	 * Check if a daily file exists.
 	 *
 	 * @param string $year  Four-digit year.
@@ -99,7 +156,7 @@ class DailyMemory implements DailyMemoryStorage {
 	 * @return bool
 	 */
 	public function exists( string $year, string $month, string $day ): bool {
-		return file_exists( $this->get_file_path( $year, $month, $day ) );
+		return $this->memory_for( $year, $month, $day )->exists();
 	}
 
 	/**
@@ -111,29 +168,24 @@ class DailyMemory implements DailyMemoryStorage {
 	 * @return array{success: bool, content?: string, date?: string, message?: string}
 	 */
 	public function read( string $year, string $month, string $day ): array {
-		$fs        = FilesystemHelper::get();
-		$file_path = $this->get_file_path( $year, $month, $day );
+		$result = $this->memory_for( $year, $month, $day )->read();
 
-		if ( ! file_exists( $file_path ) ) {
+		if ( ! $result->exists ) {
 			return array(
 				'success' => false,
 				'message' => sprintf( 'No daily memory for %s-%s-%s.', $year, $month, $day ),
 			);
 		}
 
-		$content = $fs->get_contents( $file_path );
-
 		return array(
 			'success' => true,
 			'date'    => "{$year}-{$month}-{$day}",
-			'content' => $content,
+			'content' => $result->content,
 		);
 	}
 
 	/**
 	 * Write (replace) content for a daily memory file.
-	 *
-	 * Creates the directory structure if needed.
 	 *
 	 * @param string $year    Four-digit year.
 	 * @param string $month   Two-digit month.
@@ -142,27 +194,14 @@ class DailyMemory implements DailyMemoryStorage {
 	 * @return array{success: bool, message: string}
 	 */
 	public function write( string $year, string $month, string $day, string $content ): array {
-		$fs        = FilesystemHelper::get();
-		$file_path = $this->get_file_path( $year, $month, $day );
-		$dir       = dirname( $file_path );
+		$result = $this->memory_for( $year, $month, $day )->replace_all( $content );
 
-		if ( ! $this->ensure_daily_directory( $dir ) ) {
+		if ( empty( $result['success'] ) ) {
 			return array(
 				'success' => false,
-				'message' => sprintf( 'Failed to create directory for %s-%s-%s.', $year, $month, $day ),
+				'message' => $result['message'] ?? sprintf( 'Failed to write daily memory for %s-%s-%s.', $year, $month, $day ),
 			);
 		}
-
-		$written = $fs->put_contents( $file_path, $content );
-
-		if ( false === $written ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Failed to write daily memory for %s-%s-%s.', $year, $month, $day ),
-			);
-		}
-
-		FilesystemHelper::make_group_writable( $file_path );
 
 		return array(
 			'success' => true,
@@ -182,46 +221,28 @@ class DailyMemory implements DailyMemoryStorage {
 	 * @return array{success: bool, message: string}
 	 */
 	public function append( string $year, string $month, string $day, string $content ): array {
-		$fs        = FilesystemHelper::get();
-		$file_path = $this->get_file_path( $year, $month, $day );
-		$dir       = dirname( $file_path );
+		$memory  = $this->memory_for( $year, $month, $day );
+		$current = $memory->read();
 
-		if ( ! $this->ensure_daily_directory( $dir ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Failed to create directory for %s-%s-%s.', $year, $month, $day ),
-			);
-		}
-
-		// If file doesn't exist, scaffold it with date header via ability.
-		if ( ! file_exists( $file_path ) ) {
-			$ability = \DataMachine\Abilities\File\ScaffoldAbilities::get_ability();
-			if ( $ability ) {
-				$ability->execute( array(
-					'filename' => "daily/{$year}/{$month}/{$day}.md",
-					'filepath' => $file_path,
-					'date'     => "{$year}-{$month}-{$day}",
-				) );
-			}
-
-			// Append content after the scaffolded header.
-			$_existing_content = $fs->get_contents( $file_path );
-			$_existing_content = ( false !== $_existing_content ) ? $_existing_content : '';
-			$written           = $fs->put_contents( $file_path, $_existing_content . "\n" . $content . "\n" );
+		if ( ! $current->exists ) {
+			// First write of the day: scaffold a date header inline.
+			// (The previous ScaffoldAbilities path was disk-coupled; we
+			// keep the same header format to preserve agent-readable
+			// structure across stores.)
+			$header  = "# Daily Memory: {$year}-{$month}-{$day}\n\n";
+			$payload = $header . $content . "\n";
 		} else {
-			$_existing_content = $fs->get_contents( $file_path );
-			$_existing_content = ( false !== $_existing_content ) ? $_existing_content : '';
-			$written           = $fs->put_contents( $file_path, $_existing_content . $content . "\n" );
+			$payload = $current->content . $content . "\n";
 		}
 
-		if ( false === $written ) {
+		$result = $memory->replace_all( $payload );
+
+		if ( empty( $result['success'] ) ) {
 			return array(
 				'success' => false,
-				'message' => sprintf( 'Failed to append to daily memory for %s-%s-%s.', $year, $month, $day ),
+				'message' => $result['message'] ?? sprintf( 'Failed to append to daily memory for %s-%s-%s.', $year, $month, $day ),
 			);
 		}
-
-		FilesystemHelper::make_group_writable( $file_path );
 
 		return array(
 			'success' => true,
@@ -238,22 +259,21 @@ class DailyMemory implements DailyMemoryStorage {
 	 * @return array{success: bool, message: string}
 	 */
 	public function delete( string $year, string $month, string $day ): array {
-		$file_path = $this->get_file_path( $year, $month, $day );
+		$memory = $this->memory_for( $year, $month, $day );
 
-		if ( ! file_exists( $file_path ) ) {
+		if ( ! $memory->exists() ) {
 			return array(
 				'success' => false,
 				'message' => sprintf( 'No daily memory for %s-%s-%s to delete.', $year, $month, $day ),
 			);
 		}
 
-		wp_delete_file( $file_path );
+		$result = $memory->delete();
 
-		// wp_delete_file returns void, check if file still exists.
-		if ( file_exists( $file_path ) ) {
+		if ( empty( $result['success'] ) ) {
 			return array(
 				'success' => false,
-				'message' => sprintf( 'Failed to delete daily memory for %s-%s-%s.', $year, $month, $day ),
+				'message' => $result['message'] ?? sprintf( 'Failed to delete daily memory for %s-%s-%s.', $year, $month, $day ),
 			);
 		}
 
@@ -271,41 +291,51 @@ class DailyMemory implements DailyMemoryStorage {
 	 * @return array{success: bool, months: array<string, string[]>}
 	 */
 	public function list_all(): array {
+		$entries = AgentMemory::list_subtree(
+			MemoryFileRegistry::LAYER_AGENT,
+			$this->user_id,
+			$this->agent_id,
+			self::PREFIX
+		);
+
 		$months = array();
 
-		if ( ! is_dir( $this->base_path ) ) {
-			return array(
-				'success' => true,
-				'months'  => $months,
-			);
-		}
+		foreach ( $entries as $entry ) {
+			// Filename is relative to the layer root, e.g. 'daily/2026/04/17.md'.
+			// Strip the prefix and the .md extension, then split into Y/M/D.
+			$path = substr( $entry->filename, strlen( self::PREFIX ) + 1 );
 
-		$year_dirs = $this->scan_sorted_dirs( $this->base_path );
-
-		foreach ( $year_dirs as $year ) {
-			if ( ! preg_match( '/^\d{4}$/', $year ) ) {
+			if ( '.md' !== substr( $path, -3 ) ) {
 				continue;
 			}
 
-			$year_path  = "{$this->base_path}/{$year}";
-			$month_dirs = $this->scan_sorted_dirs( $year_path );
+			$path  = substr( $path, 0, -3 );
+			$parts = explode( '/', $path );
 
-			foreach ( $month_dirs as $month ) {
-				if ( ! preg_match( '/^\d{2}$/', $month ) ) {
-					continue;
-				}
-
-				$month_path = "{$year_path}/{$month}";
-				$day_files  = $this->scan_sorted_files( $month_path, '.md' );
-
-				if ( ! empty( $day_files ) ) {
-					$key            = "{$year}/{$month}";
-					$months[ $key ] = $day_files;
-				}
+			if ( 3 !== count( $parts ) ) {
+				continue;
 			}
+
+			[ $year, $month, $day ] = $parts;
+
+			if ( ! preg_match( '/^\d{4}$/', $year )
+				|| ! preg_match( '/^\d{2}$/', $month )
+				|| ! preg_match( '/^\d{2}$/', $day ) ) {
+				continue;
+			}
+
+			$key = "{$year}/{$month}";
+			if ( ! isset( $months[ $key ] ) ) {
+				$months[ $key ] = array();
+			}
+			$months[ $key ][] = $day;
 		}
 
-		// Sort by key descending (newest months first).
+		// Days within each month sorted ascending; months descending (newest first).
+		foreach ( $months as $key => $days ) {
+			sort( $days );
+			$months[ $key ] = $days;
+		}
 		krsort( $months );
 
 		return array(
@@ -345,7 +375,7 @@ class DailyMemory implements DailyMemoryStorage {
 		$query_lower = mb_strtolower( $query );
 
 		foreach ( $all['months'] as $month_key => $days ) {
-			list( $year, $month ) = explode( '/', $month_key );
+			[ $year, $month ] = explode( '/', $month_key );
 
 			foreach ( $days as $day ) {
 				$date = "{$year}-{$month}-{$day}";
@@ -396,41 +426,6 @@ class DailyMemory implements DailyMemoryStorage {
 		);
 	}
 
-	// =========================================================================
-	// Internal Helpers
-	// =========================================================================
-
-	/**
-	 * Ensure a daily memory directory exists with group-writable permissions.
-	 *
-	 * Creates all intermediate directories (daily/YYYY/MM/) and sets 0775
-	 * so the coding agent user can also write daily memory files.
-	 *
-	 * @since 0.32.0
-	 * @param string $dir Directory path.
-	 * @return bool True if directory exists.
-	 */
-	private function ensure_daily_directory( string $dir ): bool {
-		if ( ! $this->directory_manager->ensure_directory_exists( $dir ) ) {
-			return false;
-		}
-
-		$perms = FilesystemHelper::AGENT_DIR_PERMISSIONS;
-
-		// Walk up from the leaf (MM/) through YYYY/ and daily/ — set each.
-		$current = $dir;
-		$stops   = 3; // MM, YYYY, daily.
-		for ( $i = 0; $i < $stops; $i++ ) {
-			if ( is_dir( $current ) ) {
-				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
-				chmod( $current, $perms );
-			}
-			$current = dirname( $current );
-		}
-
-		return true;
-	}
-
 	/**
 	 * Parse a YYYY-MM-DD date string into year/month/day components.
 	 *
@@ -447,46 +442,5 @@ class DailyMemory implements DailyMemoryStorage {
 			'month' => $matches[2],
 			'day'   => $matches[3],
 		);
-	}
-
-	/**
-	 * Scan a directory for sorted subdirectory names.
-	 *
-	 * @param string $path Directory to scan.
-	 * @return string[] Sorted directory names.
-	 */
-	private function scan_sorted_dirs( string $path ): array {
-		$entries = array();
-
-		foreach ( array_diff( scandir( $path ), array( '.', '..' ) ) as $entry ) {
-			if ( is_dir( "{$path}/{$entry}" ) ) {
-				$entries[] = $entry;
-			}
-		}
-		sort( $entries );
-
-		return $entries;
-	}
-
-	/**
-	 * Scan a directory for sorted file names (without extension).
-	 *
-	 * @param string $path      Directory to scan.
-	 * @param string $extension File extension to filter by (e.g. '.md').
-	 * @return string[] Sorted file basenames (without extension).
-	 */
-	private function scan_sorted_files( string $path, string $extension ): array {
-		$entries = array();
-
-		$ext_len = strlen( $extension );
-
-		foreach ( array_diff( scandir( $path ), array( '.', '..' ) ) as $entry ) {
-			if ( is_file( "{$path}/{$entry}" ) && substr( $entry, -$ext_len ) === $extension ) {
-				$entries[] = substr( $entry, 0, -$ext_len );
-			}
-		}
-		sort( $entries );
-
-		return $entries;
 	}
 }

--- a/inc/Core/FilesRepository/DiskAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/DiskAgentMemoryStore.php
@@ -155,6 +155,62 @@ class DiskAgentMemoryStore implements AgentMemoryStoreInterface {
 		return $entries;
 	}
 
+	/**
+	 * @inheritDoc
+	 *
+	 * Walks the filesystem recursively under `{layer_dir}/{prefix}/`.
+	 * Returned filenames are relative paths from the layer root,
+	 * including the prefix (e.g. `daily/2026/04/17.md`).
+	 */
+	public function list_subtree( AgentMemoryScope $scope_query, string $prefix ): array {
+		$prefix = trim( $prefix, '/' );
+		if ( '' === $prefix ) {
+			return array();
+		}
+
+		$layer_dir   = $this->resolve_layer_directory( $scope_query );
+		$subtree_dir = $layer_dir . '/' . $prefix;
+
+		if ( ! is_dir( $subtree_dir ) ) {
+			return array();
+		}
+
+		$entries  = array();
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $subtree_dir, \FilesystemIterator::SKIP_DOTS )
+		);
+
+		foreach ( $iterator as $file_info ) {
+			if ( ! $file_info->isFile() ) {
+				continue;
+			}
+
+			$path = $file_info->getPathname();
+			if ( 'index.php' === basename( $path ) ) {
+				continue;
+			}
+
+			// Compute filename relative to the layer root (with prefix).
+			$relative = ltrim( substr( $path, strlen( $layer_dir ) ), '/' );
+
+			$mtime     = $file_info->getMTime();
+			$entries[] = new AgentMemoryListEntry(
+				$relative,
+				$scope_query->layer,
+				(int) $file_info->getSize(),
+				false === $mtime ? null : (int) $mtime,
+			);
+		}
+
+		// Stable ordering — callers can rely on filename-sorted output.
+		usort(
+			$entries,
+			static fn( $a, $b ) => strcmp( $a->filename, $b->filename )
+		);
+
+		return $entries;
+	}
+
 	// =========================================================================
 	// Internal path resolution
 	// =========================================================================


### PR DESCRIPTION
Closes the UI-parity gap left in #1086: daily memory and context-file REST routes (and the inclusion of both in the React Agent UI's file list) were still disk-direct. They now ride the same memory store seam as MEMORY.md / SOUL.md / USER.md / NETWORK.md.

Without this, the **Daily Memory** and **Context Files** tabs in the DM Agent UI rendered empty on managed hosts (WP.com, VIP) where the disk path isn't available — and the daily memory archive write inside DailyMemoryTask was a silent no-op.

## Interface change

\`AgentMemoryStoreInterface\` gains one new method:

\`\`\`php
public function list_subtree( AgentMemoryScope \$scope_query, string \$prefix ): array;
\`\`\`

Recursive — descends into all subdirectories beneath the prefix. Filenames in returned entries include the full relative path (e.g. \`daily/2026/04/17.md\`, \`contexts/chat.md\`). \`DiskAgentMemoryStore\` implements it via \`RecursiveIteratorIterator\` walking under \`{layer_dir}/{prefix}/\`.

**Companion PR:** [Automattic/intelligence](https://github.com/Automattic/intelligence)'s DB store needs to implement \`list_subtree\` so daily/context files persist in the DB on managed hosts. Shipping in parallel.

## AgentMemory facade

New static helper paralleling \`list_layer\`:

\`\`\`php
AgentMemory::list_subtree( \$layer, \$user_id, \$agent_id, \$prefix ): array
\`\`\`

Same single-coupling pattern as everything else in the facade — outside callers go through \`AgentMemory\`, never reach for \`AgentMemoryStoreFactory\` directly.

## DailyMemory refactor

All disk-direct calls replaced with AgentMemory facade calls. Daily files are now addressed as relative paths within the agent layer (\`daily/YYYY/MM/DD.md\`), so the underlying memory store swap applies uniformly.

| Method | Before | After |
|---|---|---|
| \`read\` / \`write\` / \`delete\` / \`exists\` / \`append\` | \`FilesystemHelper\` direct | \`new AgentMemory(...)->read/replace_all/delete/exists\` |
| \`list_all\` | \`scandir\` walk of \`daily/YYYY/MM/\` | \`AgentMemory::list_subtree(..., 'daily')\` + parse-by-path grouping |
| \`search\` | unchanged shape (uses list_all + read) | unchanged shape |

The \`append()\` helper now scaffolds a date header inline (\`# Daily Memory: YYYY-MM-DD\`) instead of going through the disk-coupled \`ScaffoldAbilities\` path. Same agent-readable structure.

The \`datamachine_daily_memory_storage\` filter is **preserved** for external implementers — the default \`DailyMemory\` class IS the one that now goes through the store, so any swap registered via that filter remains effective.

## Context file REST refactor

\`AgentFiles::{list,get,put,delete}_context_file\` methods all now go through AgentMemory facade. Context files addressed as \`contexts/<slug>.md\` relative paths inside the agent layer. \`global \$wp_filesystem\` / \`glob()\` / \`file_exists()\` calls all gone from these handlers.

## AgentFileAbilities::executeListAgentFiles

The \"Include context memory files\" block now calls \`AgentMemory::list_subtree(..., 'contexts')\` instead of \`glob(\$dm->get_contexts_directory(...))\`. The \"Include daily memory summary\" block already calls \`DailyMemory::list_all()\`, which now routes through the store automatically — no change needed there.

## Audit after this PR

\`\`\`
\$ grep -rn 'FilesystemHelper\\|wp_filesystem\\|file_get_contents\\|file_put_contents\\|wp_delete_file\\|glob(' \\
    inc/Core/FilesRepository/DailyMemory.php \\
    inc/Api/AgentFiles.php
(empty)
\`\`\`

The store seam is the single seam for daily memory and context files too, not just MEMORY.md. Layered consistently with #1088's facade-consolidation invariant.

## What this lights up on WP.com

| Surface | Before this PR | After this PR (with intelligence companion PR) |
|---|---|---|
| Core memory tab (MEMORY.md, SOUL.md, USER.md, etc.) | ✅ works | ✅ works |
| Daily Memory tab — list, view, edit, delete | ❌ empty | ✅ works |
| Context Files tab — list, view, edit, delete | ❌ empty | ✅ works |
| DailyMemoryTask scheduled cleanup writing the archive | ❌ silent no-op | ✅ persists to DB |
| In-WP chat agent reading context-specific instructions | ❌ silent miss | ✅ reads context file |

## Out of scope

- The \`datamachine_daily_memory_storage\` filter is preserved for back-compat. Eventual deprecation could happen once \`AgentMemory\` is universally adopted, but that's not part of this PR — external implementers would break otherwise.
- No new abilities, no new REST routes, no React UI changes. The diff stays in the storage / data-flow layer.

## Tests

- \`php -l\` clean across all touched files
- Manual smoke test on this dev site (Studio + DiskAgentMemoryStore) planned post-merge — confirm core memory tab unchanged, daily memory tab still works, context files still work
- WP.com smoke test happens after the Intelligence companion PR merges + a release goes out

## Diff stats

\`\`\`
6 files changed, 340 insertions(+), 264 deletions(-)
\`\`\`

Net +76 lines: the \`list_subtree\` interface + impl + helper add ~100 lines, the daily-memory rewrite is roughly net-zero (kept all the same surface, swapped the bottom).

## References

- Upstream seam: [#1086](https://github.com/Extra-Chill/data-machine/pull/1086)
- Upstream consolidation: [#1088](https://github.com/Extra-Chill/data-machine/pull/1088)
- Companion: [Automattic/intelligence — feat: implement list_subtree in DB store](https://github.com/Automattic/intelligence) (PR link to follow)