### PR TITLE
refactor: drop redundant _datamachine_post_pipeline_id (#1091)

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -600,6 +600,9 @@ function datamachine_activate_for_site() {
 	// Migrate agent_ping step types to flow configs (idempotent).
 	datamachine_migrate_agent_ping_to_system_task();
 
+	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
+	datamachine_drop_redundant_post_pipeline_meta();
+
 	// Regenerate SITE.md with enriched content and clean up legacy SiteContext transient.
 	datamachine_regenerate_site_md();
 	delete_transient( 'datamachine_site_context_data' );

--- a/inc/Abilities/PostQueryAbilities.php
+++ b/inc/Abilities/PostQueryAbilities.php
@@ -32,10 +32,35 @@ class PostQueryAbilities {
 				'meta_key'   => PostTracking::FLOW_ID_META_KEY,
 				'value_type' => 'integer',
 			),
+			// Pipeline filters resolve to a flow_id IN (...) clause rather
+			// than a direct meta match, because pipeline_id is no longer
+			// stored on posts (#1091). See build_pipeline_meta_query().
 			'pipeline' => array(
-				'meta_key'   => PostTracking::PIPELINE_ID_META_KEY,
+				'meta_key'   => PostTracking::FLOW_ID_META_KEY,
 				'value_type' => 'integer',
+				'resolver'   => 'pipeline',
 			),
+		);
+	}
+
+	/**
+	 * Build a meta_query clause that matches posts whose flow_id belongs
+	 * to the given pipeline. Returns null when the pipeline has no flows,
+	 * which should force the outer query to return no results.
+	 *
+	 * @param int $pipeline_id Pipeline ID to filter by.
+	 * @return array|null meta_query clause, or null if pipeline has no flows.
+	 */
+	private static function build_pipeline_meta_query( int $pipeline_id ): ?array {
+		$flow_ids = PostTracking::getFlowIdsForPipeline( $pipeline_id );
+		if ( empty( $flow_ids ) ) {
+			return null;
+		}
+
+		return array(
+			'key'     => PostTracking::FLOW_ID_META_KEY,
+			'value'   => $flow_ids,
+			'compare' => 'IN',
 		);
 	}
 
@@ -336,11 +361,17 @@ class PostQueryAbilities {
 		}
 
 		if ( $pipeline_id > 0 ) {
-			$meta_query[] = array(
-				'key'     => PostTracking::PIPELINE_ID_META_KEY,
-				'value'   => $pipeline_id,
-				'compare' => '=',
-			);
+			$pipeline_clause = self::build_pipeline_meta_query( $pipeline_id );
+			if ( null === $pipeline_clause ) {
+				// Pipeline has no flows, so no posts can match it.
+				return array(
+					'posts'    => array(),
+					'total'    => 0,
+					'per_page' => $per_page,
+					'offset'   => $offset,
+				);
+			}
+			$meta_query[] = $pipeline_clause;
 		}
 
 		// If no filters provided, require at least the handler meta key to exist
@@ -402,6 +433,7 @@ class PostQueryAbilities {
 		$filter_config = $filter_types[ $filter_by ];
 		$meta_key      = $filter_config['meta_key'];
 		$value_type    = $filter_config['value_type'];
+		$resolver      = $filter_config['resolver'] ?? null;
 
 		if ( 'string' === $value_type ) {
 			$filter_value = sanitize_text_field( $filter_value );
@@ -423,6 +455,26 @@ class PostQueryAbilities {
 			}
 		}
 
+		if ( 'pipeline' === $resolver ) {
+			$pipeline_clause = self::build_pipeline_meta_query( (int) $filter_value );
+			if ( null === $pipeline_clause ) {
+				// Pipeline has no flows, so no posts can match it.
+				return array(
+					'posts'    => array(),
+					'total'    => 0,
+					'per_page' => $per_page,
+					'offset'   => $offset,
+				);
+			}
+			$meta_clause = $pipeline_clause;
+		} else {
+			$meta_clause = array(
+				'key'     => $meta_key,
+				'value'   => $filter_value,
+				'compare' => '=',
+			);
+		}
+
 		$args = array(
 			'post_type'      => $post_type,
 			'post_status'    => $post_status,
@@ -430,13 +482,7 @@ class PostQueryAbilities {
 			'offset'         => $offset,
 			'orderby'        => 'date',
 			'order'          => 'DESC',
-			'meta_query'     => array(
-				array(
-					'key'     => $meta_key,
-					'value'   => $filter_value,
-					'compare' => '=',
-				),
-			),
+			'meta_query'     => array( $meta_clause ),
 		);
 
 		$query = new \WP_Query( $args );
@@ -484,7 +530,7 @@ class PostQueryAbilities {
 			'post_modified' => $post->post_modified,
 			'handler_slug'  => get_post_meta( $post->ID, PostTracking::HANDLER_META_KEY, true ),
 			'flow_id'       => (int) get_post_meta( $post->ID, PostTracking::FLOW_ID_META_KEY, true ),
-			'pipeline_id'   => (int) get_post_meta( $post->ID, PostTracking::PIPELINE_ID_META_KEY, true ),
+			'pipeline_id'   => PostTracking::getPipelineIdForPost( $post->ID ),
 			'post_url'      => get_permalink( $post->ID ),
 		);
 	}

--- a/inc/Core/WordPress/PostTracking.php
+++ b/inc/Core/WordPress/PostTracking.php
@@ -3,7 +3,9 @@
  * Data Machine Post Tracking
  *
  * Automatic post origin tracking for every tool invocation that produces
- * a post. Stores handler_slug, flow_id, and pipeline_id as post meta.
+ * a post. Stores handler_slug and flow_id as post meta; pipeline_id,
+ * agent_id, and user_id are derivable from the flows table via the
+ * flow_id and resolved on demand (see getPipelineIdForPost()).
  *
  * Tracking is invoked centrally in ToolExecutor::executeTool() after
  * every successful tool call whose result carries an extractable post_id,
@@ -20,10 +22,15 @@
  * @since 0.69.0 Tracking moved to ToolExecutor::executeTool() so ability
  *               tools receive the same origin meta as handler tools
  *               (#1084).
+ * @since 0.69.1 Dropped redundant pipeline_id post meta — derivable from
+ *               flow_id via the flows table (#1091). Existing legacy rows
+ *               are cleared by the datamachine_drop_redundant_post_pipeline_meta
+ *               migration.
  */
 
 namespace DataMachine\Core\WordPress;
 
+use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Jobs\Jobs;
 
 defined( 'ABSPATH' ) || exit;
@@ -33,20 +40,20 @@ defined( 'ABSPATH' ) || exit;
  */
 class PostTracking {
 
-	public const HANDLER_META_KEY     = '_datamachine_post_handler';
-	public const FLOW_ID_META_KEY     = '_datamachine_post_flow_id';
-	public const PIPELINE_ID_META_KEY = '_datamachine_post_pipeline_id';
-	public const SOURCE_URL_META_KEY  = '_datamachine_source_url';
+	public const HANDLER_META_KEY    = '_datamachine_post_handler';
+	public const FLOW_ID_META_KEY    = '_datamachine_post_flow_id';
+	public const SOURCE_URL_META_KEY = '_datamachine_source_url';
 
 	/**
 	 * Store post tracking metadata from tool call context.
 	 *
-	 * Extracts handler_slug from the tool definition and flow_id/pipeline_id
-	 * from the job record. Writes non-empty values as post meta.
+	 * Extracts handler_slug from the tool definition and flow_id from the
+	 * job record. Writes non-empty values as post meta. pipeline_id is not
+	 * stored — it is derivable from flow_id via the flows table.
 	 *
 	 * @param int   $post_id  WordPress post ID
 	 * @param array $tool_def Tool definition (contains 'handler' key)
-	 * @param int   $job_id   Job ID for flow/pipeline lookup
+	 * @param int   $job_id   Job ID for flow lookup
 	 */
 	public static function store( int $post_id, array $tool_def, int $job_id ): void {
 		if ( $post_id <= 0 ) {
@@ -55,16 +62,14 @@ class PostTracking {
 
 		$handler_slug = $tool_def['handler'] ?? '';
 		$flow_id      = 0;
-		$pipeline_id  = 0;
 
-		// Look up flow and pipeline from the job record
+		// Look up flow from the job record
 		if ( $job_id > 0 ) {
 			$jobs_db = new Jobs();
 			$job     = $jobs_db->get_job( $job_id );
 
 			if ( $job ) {
-				$flow_id     = (int) ( $job['flow_id'] ?? 0 );
-				$pipeline_id = (int) ( $job['pipeline_id'] ?? 0 );
+				$flow_id = (int) ( $job['flow_id'] ?? 0 );
 			}
 		}
 
@@ -76,10 +81,6 @@ class PostTracking {
 			update_post_meta( $post_id, self::FLOW_ID_META_KEY, $flow_id );
 		}
 
-		if ( $pipeline_id > 0 ) {
-			update_post_meta( $post_id, self::PIPELINE_ID_META_KEY, $pipeline_id );
-		}
-
 		do_action(
 			'datamachine_log',
 			'debug',
@@ -88,9 +89,58 @@ class PostTracking {
 				'post_id'      => $post_id,
 				'handler_slug' => $handler_slug,
 				'flow_id'      => $flow_id,
-				'pipeline_id'  => $pipeline_id,
 			)
 		);
+	}
+
+	/**
+	 * Resolve the pipeline ID for a DM-produced post.
+	 *
+	 * Reads _datamachine_post_flow_id from post meta and resolves the
+	 * pipeline ID via the flows table (datamachine_flows.pipeline_id is
+	 * immutable, so the resolution is stable).
+	 *
+	 * @param int $post_id WordPress post ID.
+	 * @return int Pipeline ID, or 0 if the post was not produced by DM
+	 *             or the flow row has since been deleted.
+	 */
+	public static function getPipelineIdForPost( int $post_id ): int {
+		if ( $post_id <= 0 ) {
+			return 0;
+		}
+
+		$flow_id = (int) get_post_meta( $post_id, self::FLOW_ID_META_KEY, true );
+		if ( $flow_id <= 0 ) {
+			return 0;
+		}
+
+		$flow = ( new Flows() )->get_flow( $flow_id );
+		if ( ! $flow || empty( $flow['pipeline_id'] ) ) {
+			return 0;
+		}
+
+		return (int) $flow['pipeline_id'];
+	}
+
+	/**
+	 * Collect the flow IDs that belong to a given pipeline.
+	 *
+	 * Used to translate "posts in pipeline N" queries into meta_query
+	 * clauses on _datamachine_post_flow_id, since pipeline_id is no
+	 * longer stored directly on posts.
+	 *
+	 * @param int $pipeline_id Pipeline ID.
+	 * @return int[] Flow IDs belonging to the pipeline. Empty array if none.
+	 */
+	public static function getFlowIdsForPipeline( int $pipeline_id ): array {
+		if ( $pipeline_id <= 0 ) {
+			return array();
+		}
+
+		$flows_db = new Flows();
+		$flows    = $flows_db->get_flows_for_pipeline( $pipeline_id );
+
+		return array_map( static fn ( array $flow ): int => (int) $flow['flow_id'], $flows );
 	}
 
 	/**

--- a/inc/Core/WordPress/PostTracking.php
+++ b/inc/Core/WordPress/PostTracking.php
@@ -2,19 +2,24 @@
 /**
  * Data Machine Post Tracking
  *
- * Automatic post origin tracking for all Data Machine handlers.
- * Stores handler_slug, flow_id, and pipeline_id as post meta on every
- * post created or updated by a handler tool call.
+ * Automatic post origin tracking for every tool invocation that produces
+ * a post. Stores handler_slug, flow_id, and pipeline_id as post meta.
  *
- * Tracking is handled automatically by the base handler classes
- * (UpdateHandler, PublishHandler) after executeUpdate/executePublish
- * returns a successful result containing a post_id. Individual handlers
- * do not need to call any tracking methods.
+ * Tracking is invoked centrally in ToolExecutor::executeTool() after
+ * every successful tool call whose result carries an extractable post_id,
+ * covering both handler tools (PublishHandler / UpdateHandler subclasses)
+ * and ability tools (PublishWordPressAbility, InsertContentAbility,
+ * EditPostBlocksAbility, ReplacePostBlocksAbility, third-party abilities
+ * registered as pipeline tools). Individual handlers and abilities do
+ * not call any tracking methods themselves.
  *
  * @package DataMachine\Core\WordPress
  * @since 0.12.0
- * @since 0.32.0 Refactored from trait to static utility. Tracking is now
+ * @since 0.32.0 Refactored from trait to static utility. Tracking is
  *               automatic in base handler handle_tool_call() methods.
+ * @since 0.69.0 Tracking moved to ToolExecutor::executeTool() so ability
+ *               tools receive the same origin meta as handler tools
+ *               (#1084).
  */
 
 namespace DataMachine\Core\WordPress;

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -21,3 +21,4 @@ require_once __DIR__ . '/backfill.php';
 require_once __DIR__ . '/network-scope.php';
 require_once __DIR__ . '/composable-files.php';
 require_once __DIR__ . '/flows.php';
+require_once __DIR__ . '/post-pipeline-meta.php';

--- a/inc/migrations/post-pipeline-meta.php
+++ b/inc/migrations/post-pipeline-meta.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Data Machine — Drop redundant _datamachine_post_pipeline_id post meta (#1091).
+ *
+ * pipeline_id is fully derivable from _datamachine_post_flow_id via the
+ * flows table (datamachine_flows.pipeline_id is immutable). The redundant
+ * meta was written by PostTracking::store() on every publish until v0.69.1;
+ * this migration removes the stale rows from wp_postmeta.
+ *
+ * Runs once per site via the version-gated datamachine_maybe_run_migrations
+ * flow. Stores its completion flag in the site option
+ * datamachine_post_pipeline_meta_dropped so repeated activation calls are
+ * no-ops.
+ *
+ * @package DataMachine
+ * @since 0.69.1
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Delete all _datamachine_post_pipeline_id rows from wp_postmeta.
+ *
+ * Idempotent: the completion flag prevents repeat execution, and the
+ * underlying DELETE is safe to re-run (matches zero rows after the first
+ * successful pass).
+ *
+ * @since 0.69.1
+ */
+function datamachine_drop_redundant_post_pipeline_meta(): void {
+	$already_done = get_option( 'datamachine_post_pipeline_meta_dropped', false );
+	if ( $already_done ) {
+		return;
+	}
+
+	global $wpdb;
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	$deleted = $wpdb->delete(
+		$wpdb->postmeta,
+		array( 'meta_key' => '_datamachine_post_pipeline_id' ),
+		array( '%s' )
+	);
+
+	if ( false === $deleted ) {
+		do_action(
+			'datamachine_log',
+			'error',
+			'Failed to drop redundant _datamachine_post_pipeline_id rows',
+			array(
+				'db_error' => $wpdb->last_error,
+			)
+		);
+		return;
+	}
+
+	update_option( 'datamachine_post_pipeline_meta_dropped', true, true );
+
+	if ( $deleted > 0 ) {
+		do_action(
+			'datamachine_log',
+			'info',
+			'Dropped redundant _datamachine_post_pipeline_id rows (#1091)',
+			array(
+				'rows_deleted' => (int) $deleted,
+			)
+		);
+	}
+}

--- a/tests/Unit/Abilities/PostQueryAbilitiesTest.php
+++ b/tests/Unit/Abilities/PostQueryAbilitiesTest.php
@@ -10,6 +10,7 @@
 namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\PostQueryAbilities;
+use DataMachine\Core\Database\Flows\Flows;
 use WP_UnitTestCase;
 
 class PostQueryAbilitiesTest extends WP_UnitTestCase {
@@ -29,6 +30,27 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+	/**
+	 * Create a real flow row bound to the given pipeline ID and return its flow_id.
+	 * Pipeline filter queries resolve via the flows table (#1091), so tests that
+	 * exercise pipeline filtering need a real flow-to-pipeline binding.
+	 */
+	private function create_flow_for_pipeline( int $pipeline_id, string $flow_name = 'Test Flow' ): int {
+		$flows_db = new Flows();
+		$flow_id  = $flows_db->create_flow(
+			array(
+				'pipeline_id'       => $pipeline_id,
+				'user_id'           => get_current_user_id(),
+				'flow_name'         => $flow_name,
+				'flow_config'       => array(),
+				'scheduling_config' => array(),
+			)
+		);
+		$this->assertIsInt( $flow_id );
+		$this->assertGreaterThan( 0, $flow_id );
+		return (int) $flow_id;
+	}
+
 	public function test_query_posts_ability_registered(): void {
 		$ability = wp_get_ability( 'datamachine/query-posts' );
 
@@ -37,6 +59,9 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_query_posts_by_handler(): void {
+		$pipeline_id = 456;
+		$flow_id     = $this->create_flow_for_pipeline( $pipeline_id );
+
 		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'post',
@@ -46,8 +71,7 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 		);
 
 		update_post_meta( $post_id, '_datamachine_post_handler', 'universal_web_scraper' );
-		update_post_meta( $post_id, '_datamachine_post_flow_id', 123 );
-		update_post_meta( $post_id, '_datamachine_post_pipeline_id', 456 );
+		update_post_meta( $post_id, '_datamachine_post_flow_id', $flow_id );
 
 		$result = $this->post_query_abilities->executeQueryPosts(
 			array(
@@ -68,8 +92,9 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 		$first_post = $result['posts'][0];
 		$this->assertEquals( $post_id, $first_post['id'] );
 		$this->assertEquals( 'universal_web_scraper', $first_post['handler_slug'] );
-		$this->assertEquals( 123, $first_post['flow_id'] );
-		$this->assertEquals( 456, $first_post['pipeline_id'] );
+		$this->assertEquals( $flow_id, $first_post['flow_id'] );
+		// pipeline_id is resolved via the flows table (#1091), not from post meta.
+		$this->assertEquals( $pipeline_id, $first_post['pipeline_id'] );
 	}
 
 	public function test_query_posts_by_flow(): void {
@@ -105,6 +130,9 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_query_posts_by_pipeline(): void {
+		$pipeline_id = 999;
+		$flow_id     = $this->create_flow_for_pipeline( $pipeline_id, 'Pipeline Query Flow' );
+
 		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'post',
@@ -113,14 +141,13 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		update_post_meta( $post_id, '_datamachine_post_pipeline_id', 999 );
-		update_post_meta( $post_id, '_datamachine_post_flow_id', 100 );
+		update_post_meta( $post_id, '_datamachine_post_flow_id', $flow_id );
 		update_post_meta( $post_id, '_datamachine_post_handler', 'ics_feed' );
 
 		$result = $this->post_query_abilities->executeQueryPosts(
 			array(
 				'filter_by'    => 'pipeline',
-				'filter_value' => 999,
+				'filter_value' => $pipeline_id,
 				'post_type'    => 'post',
 				'post_status'  => 'publish',
 				'per_page'     => 20,
@@ -134,7 +161,71 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 
 		$first_post = $result['posts'][0];
 		$this->assertEquals( $post_id, $first_post['id'] );
-		$this->assertEquals( 999, $first_post['pipeline_id'] );
+		$this->assertEquals( $pipeline_id, $first_post['pipeline_id'] );
+		$this->assertEquals( $flow_id, $first_post['flow_id'] );
+	}
+
+	public function test_query_posts_by_pipeline_with_no_flows_returns_empty(): void {
+		// Pipeline ID that has no flows in the flows table. The query should
+		// short-circuit to an empty result, not fall through and match every
+		// DM-tracked post.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Unrelated DM Post',
+			)
+		);
+		update_post_meta( $post_id, '_datamachine_post_handler', 'rss' );
+		update_post_meta( $post_id, '_datamachine_post_flow_id', 424242 );
+
+		$result = $this->post_query_abilities->executeQueryPosts(
+			array(
+				'filter_by'    => 'pipeline',
+				'filter_value' => 7777777,
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'per_page'     => 20,
+				'offset'       => 0,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( 0, $result['total'] );
+		$this->assertCount( 0, $result['posts'] );
+		$this->assertArrayNotHasKey( 'error', $result );
+	}
+
+	public function test_format_post_result_pipeline_id_is_zero_without_flow(): void {
+		// A tracked post whose flow_id is missing (either never set or whose
+		// flow row has been deleted) has no resolvable pipeline. The resolver
+		// returns 0 rather than consulting a redundant cached key.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Handler-only Tracked Post',
+			)
+		);
+
+		update_post_meta( $post_id, '_datamachine_post_handler', 'rss' );
+
+		$result = $this->post_query_abilities->executeQueryPosts(
+			array(
+				'filter_by'    => 'handler',
+				'filter_value' => 'rss',
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'per_page'     => 20,
+				'offset'       => 0,
+			)
+		);
+
+		$this->assertGreaterThan( 0, $result['total'] );
+
+		$first_post = $result['posts'][0];
+		$this->assertEquals( $post_id, $first_post['id'] );
+		$this->assertSame( 0, $first_post['pipeline_id'] );
 	}
 
 	public function test_query_posts_invalid_filter_by(): void {
@@ -263,6 +354,9 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_format_post_result(): void {
+		$pipeline_id = 456;
+		$flow_id     = $this->create_flow_for_pipeline( $pipeline_id, 'Format Test Flow' );
+
 		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'post',
@@ -272,8 +366,7 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 		);
 
 		update_post_meta( $post_id, '_datamachine_post_handler', 'universal_web_scraper' );
-		update_post_meta( $post_id, '_datamachine_post_flow_id', 123 );
-		update_post_meta( $post_id, '_datamachine_post_pipeline_id', 456 );
+		update_post_meta( $post_id, '_datamachine_post_flow_id', $flow_id );
 
 		$result = $this->post_query_abilities->executeQueryPosts(
 			array(
@@ -301,6 +394,7 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'flow_id', $post );
 		$this->assertArrayHasKey( 'pipeline_id', $post );
 		$this->assertArrayHasKey( 'post_url', $post );
+		$this->assertEquals( $pipeline_id, $post['pipeline_id'] );
 	}
 
 	public function test_permission_callback_with_cli(): void {

--- a/tests/Unit/Migrations/PostPipelineMetaMigrationTest.php
+++ b/tests/Unit/Migrations/PostPipelineMetaMigrationTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Post pipeline meta migration tests (#1091).
+ *
+ * @package DataMachine\Tests\Unit\Migrations
+ */
+
+namespace DataMachine\Tests\Unit\Migrations;
+
+use WP_UnitTestCase;
+
+class PostPipelineMetaMigrationTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		delete_option( 'datamachine_post_pipeline_meta_dropped' );
+	}
+
+	public function test_migration_deletes_legacy_pipeline_id_rows(): void {
+		$post_a = self::factory()->post->create();
+		$post_b = self::factory()->post->create();
+		$post_c = self::factory()->post->create();
+
+		update_post_meta( $post_a, '_datamachine_post_pipeline_id', 100 );
+		update_post_meta( $post_b, '_datamachine_post_pipeline_id', 200 );
+		update_post_meta( $post_c, '_datamachine_post_handler', 'rss' );
+		update_post_meta( $post_c, '_datamachine_post_flow_id', 5 );
+
+		datamachine_drop_redundant_post_pipeline_meta();
+
+		$this->assertSame( '', get_post_meta( $post_a, '_datamachine_post_pipeline_id', true ) );
+		$this->assertSame( '', get_post_meta( $post_b, '_datamachine_post_pipeline_id', true ) );
+		// Non-pipeline meta untouched on post C.
+		$this->assertSame( 'rss', get_post_meta( $post_c, '_datamachine_post_handler', true ) );
+		$this->assertSame( '5', get_post_meta( $post_c, '_datamachine_post_flow_id', true ) );
+	}
+
+	public function test_migration_sets_completion_flag(): void {
+		$this->assertFalse( get_option( 'datamachine_post_pipeline_meta_dropped', false ) );
+
+		datamachine_drop_redundant_post_pipeline_meta();
+
+		$this->assertTrue( (bool) get_option( 'datamachine_post_pipeline_meta_dropped' ) );
+	}
+
+	public function test_migration_is_idempotent_after_completion(): void {
+		datamachine_drop_redundant_post_pipeline_meta();
+
+		// Subsequent rows should NOT be touched because the flag short-circuits
+		// the migration — protecting any intentional writes after completion.
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, '_datamachine_post_pipeline_id', 42 );
+
+		datamachine_drop_redundant_post_pipeline_meta();
+
+		$this->assertSame( '42', get_post_meta( $post_id, '_datamachine_post_pipeline_id', true ) );
+	}
+
+	public function test_migration_no_op_when_no_legacy_rows_exist(): void {
+		// Clean site with no DM history — migration should still set the flag
+		// and do nothing else.
+		datamachine_drop_redundant_post_pipeline_meta();
+
+		$this->assertTrue( (bool) get_option( 'datamachine_post_pipeline_meta_dropped' ) );
+	}
+}

--- a/tests/Unit/WordPress/PostTrackingTest.php
+++ b/tests/Unit/WordPress/PostTrackingTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * PostTracking Tests
+ *
+ * Covers the post-tracking write path (PostTracking::store) and the
+ * pipeline_id resolver / fallback introduced by #1091.
+ *
+ * @package DataMachine\Tests\Unit\WordPress
+ */
+
+namespace DataMachine\Tests\Unit\WordPress;
+
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\Jobs\JobsOperations;
+use DataMachine\Core\WordPress\PostTracking;
+use WP_UnitTestCase;
+
+class PostTrackingTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+	}
+
+	public function test_store_writes_handler_and_flow_id_only(): void {
+		$pipeline_id = 123;
+		$flow_id     = $this->create_flow( $pipeline_id );
+		$job_id      = $this->create_job( $flow_id, $pipeline_id );
+
+		$post_id = self::factory()->post->create();
+
+		PostTracking::store(
+			$post_id,
+			array( 'handler' => 'rss' ),
+			$job_id
+		);
+
+		$this->assertSame( 'rss', get_post_meta( $post_id, PostTracking::HANDLER_META_KEY, true ) );
+		$this->assertSame( (string) $flow_id, get_post_meta( $post_id, PostTracking::FLOW_ID_META_KEY, true ) );
+		// pipeline_id is no longer stored on posts (#1091) — derivable from flow_id.
+		$this->assertSame( '', get_post_meta( $post_id, '_datamachine_post_pipeline_id', true ) );
+	}
+
+	public function test_store_skips_invalid_post_id(): void {
+		PostTracking::store( 0, array( 'handler' => 'rss' ), 0 );
+		PostTracking::store( -1, array( 'handler' => 'rss' ), 0 );
+		// No exception, no fatal — nothing to assert beyond the absence of error.
+		$this->assertTrue( true );
+	}
+
+	public function test_get_pipeline_id_for_post_resolves_via_flow_row(): void {
+		$pipeline_id = 555;
+		$flow_id     = $this->create_flow( $pipeline_id );
+
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, PostTracking::FLOW_ID_META_KEY, $flow_id );
+
+		$this->assertSame( $pipeline_id, PostTracking::getPipelineIdForPost( $post_id ) );
+	}
+
+	public function test_get_pipeline_id_for_post_returns_zero_when_flow_row_missing(): void {
+		// Post has a flow_id meta pointing at a flow that does not exist
+		// (either never created or since deleted). The resolver returns 0
+		// rather than consulting redundant cached meta.
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, PostTracking::FLOW_ID_META_KEY, 987654321 );
+
+		$this->assertSame( 0, PostTracking::getPipelineIdForPost( $post_id ) );
+	}
+
+	public function test_get_pipeline_id_for_post_returns_zero_for_untracked_post(): void {
+		$post_id = self::factory()->post->create();
+		$this->assertSame( 0, PostTracking::getPipelineIdForPost( $post_id ) );
+	}
+
+	public function test_get_pipeline_id_for_post_returns_zero_for_invalid_post_id(): void {
+		$this->assertSame( 0, PostTracking::getPipelineIdForPost( 0 ) );
+		$this->assertSame( 0, PostTracking::getPipelineIdForPost( -5 ) );
+	}
+
+	public function test_get_flow_ids_for_pipeline_returns_flow_ids(): void {
+		$pipeline_id = 222;
+		$a           = $this->create_flow( $pipeline_id, 'Flow A' );
+		$b           = $this->create_flow( $pipeline_id, 'Flow B' );
+		// A flow bound to a different pipeline should not appear.
+		$this->create_flow( 333, 'Other Pipeline Flow' );
+
+		$result = PostTracking::getFlowIdsForPipeline( $pipeline_id );
+
+		$this->assertContains( $a, $result );
+		$this->assertContains( $b, $result );
+		$this->assertCount( 2, $result );
+	}
+
+	public function test_get_flow_ids_for_pipeline_empty_when_no_flows(): void {
+		$this->assertSame( array(), PostTracking::getFlowIdsForPipeline( 999999 ) );
+		$this->assertSame( array(), PostTracking::getFlowIdsForPipeline( 0 ) );
+		$this->assertSame( array(), PostTracking::getFlowIdsForPipeline( -1 ) );
+	}
+
+	public function test_extract_post_id_from_various_result_shapes(): void {
+		$this->assertSame( 42, PostTracking::extractPostId( array( 'data' => array( 'post_id' => 42 ) ) ) );
+		$this->assertSame( 99, PostTracking::extractPostId( array( 'post_id' => 99 ) ) );
+		$this->assertSame( 0, PostTracking::extractPostId( array() ) );
+		$this->assertSame( 0, PostTracking::extractPostId( array( 'data' => array( 'post_id' => 0 ) ) ) );
+	}
+
+	private function create_flow( int $pipeline_id, string $flow_name = 'Test Flow' ): int {
+		$flows_db = new Flows();
+		$flow_id  = $flows_db->create_flow(
+			array(
+				'pipeline_id'       => $pipeline_id,
+				'user_id'           => get_current_user_id(),
+				'flow_name'         => $flow_name,
+				'flow_config'       => array(),
+				'scheduling_config' => array(),
+			)
+		);
+		$this->assertIsInt( $flow_id );
+		$this->assertGreaterThan( 0, $flow_id );
+		return (int) $flow_id;
+	}
+
+	private function create_job( int $flow_id, int $pipeline_id ): int {
+		$jobs_db = new Jobs();
+		$ops     = new JobsOperations( $jobs_db );
+		$job_id  = $ops->create_job(
+			array(
+				'flow_id'     => $flow_id,
+				'pipeline_id' => $pipeline_id,
+				'user_id'     => get_current_user_id(),
+				'status'      => 'pending',
+			)
+		);
+		$this->assertIsInt( $job_id );
+		$this->assertGreaterThan( 0, $job_id );
+		return (int) $job_id;
+	}
+}


### PR DESCRIPTION
## Summary

- Drop the redundant `_datamachine_post_pipeline_id` post meta — `pipeline_id` is fully derivable from `_datamachine_post_flow_id` via the flows table (`datamachine_flows.pipeline_id` is `NOT NULL` and immutable).
- Add `PostTracking::getPipelineIdForPost()` as the canonical resolver and `PostTracking::getFlowIdsForPipeline()` for "posts in pipeline N" query translation.
- Ship a one-shot idempotent migration that deletes legacy `_datamachine_post_pipeline_id` rows from `wp_postmeta` on upgrade.
- Fix the outdated `PostTracking` class docblock that still claimed tracking lived in the handler base classes (stopped being true in #1084 / v0.69.0).

Closes #1091.

## Why

`wp_postmeta` is the worst-scaling table on busy WordPress sites. Every DM-produced post was carrying an extra meta row + `(meta_key, meta_value)` index entry per publish, for a value a single JOIN can always recover. At ~110 bytes per row + index overhead:

| Posts | Saved rows | Approx saved |
|---|---|---|
| 10,000 | 10,000 | ~1.1 MB + index reduction |
| 100,000 | 100,000 | ~11 MB + index reduction |
| 1,000,000 | 1,000,000 | ~110 MB + index reduction |

The architectural principle: normalize across the table that scales catastrophically (`postmeta`); denormalize on the table that doesn't (`datamachine_flows` — fixed-ish ceiling of a few hundred rows per site).

## The new provenance model

```
┌────────────────────────────────────────────────────────────┐
│  Post meta (3 keys total)                                  │
├────────────────────────────────────────────────────────────┤
│  _datamachine_post_handler   — handler/origin slug         │
│  _datamachine_post_flow_id   — single provenance key       │
│  _datamachine_source_url     — upstream URL (unrelated)    │
└────────────────────────────────────────────────────────────┘

Resolver path:
  flow_id → datamachine_flows → { pipeline_id, agent_id, user_id, ... }
```

Everything about a post's origin is one JOIN away. No drift, no denormalization debt.

## No legacy fallback — deliberate

`getPipelineIdForPost()` does **not** consult `_datamachine_post_pipeline_id` as a secondary source. A dangling legacy value without a matching flow row is a tombstone — it tells you a pipeline existed without letting you traverse to flow, agent, or user. Returning `0` (the same "no provenance" answer as any other unresolvable post) is honest; preserving tombstones would keep a deprecated code path alive forever without preserving real functionality.

`PIPELINE_ID_META_KEY` constant is removed. Callers reading the key directly will produce a fatal at the call site so the migration path is impossible to miss rather than silently returning stale data.

## Migration

`datamachine_drop_redundant_post_pipeline_meta()` deletes all `_datamachine_post_pipeline_id` rows from `wp_postmeta`. Idempotent via the `datamachine_post_pipeline_meta_dropped` site option. Runs as part of the version-gated `datamachine_maybe_run_migrations` sequence, so existing sites clean up on the first request after upgrade with no operator action required.

## Testing

29 tests, 115 assertions, all green. Three test suites added/updated:

- **PostQueryAbilitiesTest** — pipeline-filter tests now create real flow rows. Added tests for pipeline filter with no flows (short-circuits to empty, does not match every DM post) and for `format_post_result` returning `pipeline_id=0` when the flow row is absent.
- **PostTrackingTest** (new) — direct coverage of `store()` (writes only handler + flow_id), `getPipelineIdForPost()` (resolver path, flow-missing returns 0, untracked returns 0, invalid post id returns 0), `getFlowIdsForPipeline()`, and `extractPostId()`.
- **PostPipelineMetaMigrationTest** (new) — migration deletes only `_datamachine_post_pipeline_id` rows, leaves handler/flow_id meta intact, sets the completion flag, is idempotent after completion, and is a clean no-op on sites with no legacy rows.

```
OK (29 tests, 115 assertions)
```

## Bonus commit

First commit in the branch fixes a separate issue discovered while reading `PostTracking`: the class-level docblock still claimed tracking was invoked from the handler base classes. That stopped being true in #1084 (v0.69.0) when the `store()` call moved into `ToolExecutor::executeTool()` so ability tools receive the same origin meta. Docblock now reflects the current call site.

## Intentionally NOT in this PR

- No content migration of existing flow-less posts. Posts whose `_datamachine_post_flow_id` was never set continue to report `pipeline_id = 0` from the resolver — same answer as any untracked post.
- No deprecation shim for the removed `PIPELINE_ID_META_KEY` constant. Callers relying on it hit a fatal; the correct fix is `getPipelineIdForPost()`.
- No broader cleanup of the other three tracking keys. `_datamachine_post_handler` is not derivable from `flow_id` alone (a flow can have multiple publish/update steps with different handlers) and stays. `_datamachine_source_url` is content provenance, not pipeline provenance, and is a separate concern.
