### PR TITLE
fix: green test suite — 0 failures, 933 passing (#1004)

### DIFF
--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -208,7 +208,7 @@ class Agents extends BaseRepository {
 	 * @return bool True on success, false on DB failure or no valid fields.
 	 */
 	public function update_agent( int $agent_id, array $data ): bool {
-		$allowed = array( 'agent_name', 'agent_config' );
+		$allowed = array( 'agent_name', 'agent_config', 'status' );
 		$update  = array();
 		$formats = array();
 

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -477,28 +477,31 @@ class ToolPolicyResolver {
 
 		$policy = $config['tool_policy'];
 
-		// Validate structure: must have 'mode' and at least 'tools' or 'categories'.
+		// Validate structure: must have 'mode'.
 		if ( ! isset( $policy['mode'] ) ) {
-			return null;
-		}
-
-		// Ensure tools is present and an array (may be empty if only categories are used).
-		if ( ! isset( $policy['tools'] ) || ! is_array( $policy['tools'] ) ) {
-			$policy['tools'] = array();
-		}
-
-		// Normalize categories to an array.
-		if ( isset( $policy['categories'] ) && ! is_array( $policy['categories'] ) ) {
-			return null;
-		}
-
-		// Must have at least tools or categories to be a valid policy.
-		if ( empty( $policy['tools'] ) && empty( $policy['categories'] ?? array() ) ) {
 			return null;
 		}
 
 		// Validate mode is one of the allowed values.
 		if ( ! in_array( $policy['mode'], array( 'deny', 'allow' ), true ) ) {
+			return null;
+		}
+
+		// Ensure tools is present and an array (may be empty — see note below).
+		if ( ! isset( $policy['tools'] ) || ! is_array( $policy['tools'] ) ) {
+			$policy['tools'] = array();
+		}
+
+		// Normalize categories: must be an array if present.
+		if ( isset( $policy['categories'] ) && ! is_array( $policy['categories'] ) ) {
+			return null;
+		}
+
+		// An empty tools + empty categories list is only meaningful for allow
+		// mode (means "allow nothing"). Deny mode with empty lists is a no-op
+		// and we treat it as no policy to avoid a wasted pass through
+		// applyAgentPolicy.
+		if ( empty( $policy['tools'] ) && empty( $policy['categories'] ?? array() ) && 'allow' !== $policy['mode'] ) {
 			return null;
 		}
 

--- a/tests/Unit/AI/System/Tasks/AltTextTaskTest.php
+++ b/tests/Unit/AI/System/Tasks/AltTextTaskTest.php
@@ -23,6 +23,14 @@ class AltTextTaskTest extends WP_UnitTestCase {
 		parent::set_up();
 		$this->task = new AltTextTask();
 
+		// The bundled ai-http-client vendor registers its own \`chubes_ai_request\`
+		// filter at priority 99 that ignores the \$request payload and always
+		// attempts a real provider call (returning an error when no API key is
+		// configured, as in the test environment). That overrides any lower-
+		// priority mock we register, so we clear the hook before each test and
+		// let each test register its own mock in isolation.
+		remove_all_filters( 'chubes_ai_request' );
+
 		// Create a test image file
 		$upload_dir = wp_upload_dir();
 		$this->test_image_path = $upload_dir['path'] . '/test-image.jpg';

--- a/tests/Unit/AI/Tools/ToolPolicyResolverTest.php
+++ b/tests/Unit/AI/Tools/ToolPolicyResolverTest.php
@@ -68,7 +68,13 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_chat_does_not_require_use_tools_cap_by_default(): void {
-		add_filter( 'user_has_cap', array( $this, 'deny_all_datamachine_caps' ), 10, 4 );
+		// The semantic being tested: a subscriber who lacks datamachine_use_tools
+		// but retains the baseline datamachine_chat cap should still see tools
+		// whose access_level is 'authenticated'. The legacy all-or-nothing gate
+		// (which required use_tools for ANY chat tool) is disabled by default
+		// and is only restored via the datamachine_require_use_tools_for_chat_tools
+		// filter. Only the use_tools cap is stripped here — chat remains.
+		add_filter( 'user_has_cap', array( $this, 'deny_use_tools_cap' ), 10, 4 );
 
 		add_filter( 'datamachine_tools', function ( $tools ) {
 			$tools['test_authenticated_tool'] = array(
@@ -95,7 +101,7 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'test_authenticated_tool', $tools );
 
-		remove_filter( 'user_has_cap', array( $this, 'deny_all_datamachine_caps' ), 10 );
+		remove_filter( 'user_has_cap', array( $this, 'deny_use_tools_cap' ), 10 );
 		remove_all_filters( 'datamachine_tools' );
 		wp_set_current_user( 0 );
 		ToolManager::clearCache();
@@ -517,6 +523,17 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 			}
 		}
 
+		return $allcaps;
+	}
+
+	/**
+	 * Deny only the datamachine_use_tools cap, leaving other datamachine
+	 * caps (chat, view_logs, etc.) intact. Used to test that the default
+	 * chat tool resolution path no longer gates on use_tools.
+	 */
+	public function deny_use_tools_cap( array $allcaps, array $caps, array $args, $user ): array {
+		unset( $caps, $args, $user );
+		$allcaps['datamachine_use_tools'] = false;
 		return $allcaps;
 	}
 

--- a/tests/Unit/Abilities/ImageGenerationPromptRefinementTest.php
+++ b/tests/Unit/Abilities/ImageGenerationPromptRefinementTest.php
@@ -15,7 +15,14 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 
 	public function set_up(): void {
 		parent::set_up();
-		
+
+		// The bundled ai-http-client vendor registers its own \`chubes_ai_request\`
+		// filter at priority 99 that ignores the \$request payload and always
+		// attempts a real provider call (returning an error when no API key is
+		// configured, as in the test environment). That overrides any lower-
+		// priority mock we register, so we clear the hook before each test.
+		remove_all_filters( 'chubes_ai_request' );
+
 		// Mock the RequestBuilder for testing AI requests
 		add_filter( 'chubes_ai_request', [ $this, 'mock_ai_response' ], 10, 6 );
 	}


### PR DESCRIPTION
## Summary

Takes the test suite from **9 failures / 937 tests** to **0 failures / 933 passing** by fixing two real bugs and one test-isolation issue. Three commits, one per root cause.

Closes #1004.

## Context

#1004 was filed automatically on 2026-04-01 reporting 294 failures out of 906 tests. A re-run on `main` today (after #1090 and #1092 landed) showed that most of those have already been fixed incrementally — the current suite state is 9 failures out of 937. This PR is the final cleanup to get to green.

## The three fixes

### 1. `fix: allow status updates through Agents::update_agent()`

Agent status writes were silent no-ops. `AgentAbilities::updateAgent()` validates and accepts `status` as a mutable field and builds a write payload for it, but `Agents::update_agent()` filtered it out because `status` was missing from the allowed-fields list — that list only contained `agent_name` and `agent_config`. The `status` column exists in the schema; it just wasn't wired through the write path.

**One-line fix.** Adds `'status'` to the allowed list. No schema change, no migration.

Fixes `AgentAbilitiesTest::test_updateAgent_status` and `::test_updateAgent_multiple_fields`.

### 2. `fix: treat allow-mode with empty tools list as valid 'allow nothing' policy`

`ToolPolicyResolver::getAgentToolPolicy()` and `ToolPolicyResolver::applyAgentPolicy()` disagreed on the meaning of an allow-mode policy with empty tools + empty categories:

| Method | Behavior on `{mode: allow, tools: [], categories: []}` |
|---|---|
| `applyAgentPolicy()` | Returns empty array (correct — "allow nothing") |
| `getAgentToolPolicy()` | Returned null (treats policy as invalid) |

`applyAgentPolicy` short-circuits when it receives null, so the bogus "invalid policy" verdict from `getAgentToolPolicy` meant an agent owner's explicit "restrict this agent to no tools" policy was silently ignored. The only way to actually restrict an agent to no tools was to pass a non-empty allow list with a tool name that doesn't exist — unintuitive and a bug.

Fix: empty tools + empty categories is only treated as "no policy" for deny mode (where it would be a no-op anyway). For allow mode it's a valid "allow nothing" policy and `getAgentToolPolicy` returns the full structure so `applyAgentPolicy` can produce the empty tool set.

Also updates `test_chat_does_not_require_use_tools_cap_by_default` to strip only the `datamachine_use_tools` cap (not every `datamachine_*` cap). The original test used `deny_all_datamachine_caps` including stripping `datamachine_chat`, which is what `access_level: 'authenticated'` gates on — so the test was actually asserting that authenticated tools work with no caps at all (which they correctly don't). Only stripping `use_tools` reproduces the original test intent.

Fixes `ToolPolicyResolverTest::test_chat_does_not_require_use_tools_cap_by_default` and `::test_agent_allow_mode_empty_tools_returns_empty`.

### 3. `test: isolate chubes_ai_request mocks from bundled vendor filter`

`vendor/chubes4/ai-http-client/src/Filters/Requests.php` registers a `chubes_ai_request` filter at **priority 99** that ignores the `$request` payload and always attempts a real provider call (returning an error response when no API key is configured, as in the test environment).

Tests registered their mocks at priority 10, which correctly ran first and returned the mocked success payload — but the vendor callback at priority 99 then ignored that payload entirely, tried to make its own provider call, and overwrote the return with an error response. The tests observed an empty alt text / null refined prompt and failed despite correctly intercepting the filter.

**Fix:** call `remove_all_filters('chubes_ai_request')` at the top of each affected test's `set_up()` so the vendor callback is unhooked. Since the vendor registration is an anonymous closure, there's no callback reference to pass to `remove_filter` — clearing all handlers is the only mechanism, and it's safe because the bundled vendor is eventually being replaced by core wp-ai-client (#1027).

Fixes `AltTextTaskTest::test_execute_success`, `::test_execute_force_override`, `::test_alt_text_normalization`, `ImageGenerationPromptRefinementTest::test_refine_prompt_returns_refined_text_when_successful`, and `::test_generate_image_applies_refinement_when_enabled`.

## Test run

```
Total: 937, Passed: 933, Failed: 0, Skipped: 4
```

(The 4 skipped tests are ajax/ms-files/external-http groups excluded by default from the PHPUnit config, not new skips.)

## What this unblocks

- Closes #1004.
- New eyes on the DM codebase (RSM pair work with Miguel Lezama starting Monday, plus the Intelligence maintainers at Automattic) land in a repo with a **green test suite** rather than a 294-failure banner. That's the real credibility signal.
- Future PRs can use test-pass as an actual quality gate rather than a baseline drift check.
