### PR TITLE
perf(pipelines): scale Pipelines admin page — N+1 queries + selector search

### DIFF
--- a/inc/Abilities/Pipeline/GetPipelinesAbility.php
+++ b/inc/Abilities/Pipeline/GetPipelinesAbility.php
@@ -75,6 +75,11 @@ class GetPipelinesAbility {
 								'default'     => 'full',
 								'description' => __( 'Output mode: full=all data with flows, summary=key fields only, ids=just pipeline_ids', 'data-machine' ),
 							),
+							'include_flows' => array(
+								'type'        => 'boolean',
+								'default'     => true,
+								'description' => __( 'Include full flows array per pipeline in "full" mode. Set false for list views — response returns flow_count only and avoids N+1 flow queries.', 'data-machine' ),
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -111,19 +116,22 @@ class GetPipelinesAbility {
 	 */
 	public function execute( array $input ): array {
 		try {
-			$pipeline_id = $input['pipeline_id'] ?? null;
-			$user_id     = isset( $input['user_id'] ) ? (int) $input['user_id'] : null;
-			$agent_id    = isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
-			$per_page    = (int) ( $input['per_page'] ?? self::DEFAULT_PER_PAGE );
-			$offset      = (int) ( $input['offset'] ?? 0 );
-			$output_mode = $input['output_mode'] ?? 'full';
-			$search      = isset( $input['search'] ) && '' !== $input['search'] ? sanitize_text_field( $input['search'] ) : null;
+			$pipeline_id   = $input['pipeline_id'] ?? null;
+			$user_id       = isset( $input['user_id'] ) ? (int) $input['user_id'] : null;
+			$agent_id      = isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
+			$per_page      = (int) ( $input['per_page'] ?? self::DEFAULT_PER_PAGE );
+			$offset        = (int) ( $input['offset'] ?? 0 );
+			$output_mode   = $input['output_mode'] ?? 'full';
+			$search        = isset( $input['search'] ) && '' !== $input['search'] ? sanitize_text_field( $input['search'] ) : null;
+			$include_flows = array_key_exists( 'include_flows', $input ) ? (bool) $input['include_flows'] : true;
 
 			if ( ! in_array( $output_mode, array( 'full', 'summary', 'ids' ), true ) ) {
 				$output_mode = 'full';
 			}
 
 			// Direct pipeline lookup by ID - bypasses pagination.
+			// Single-pipeline fetches always embed flows for backward compatibility
+			// (this is what callers like the REST /pipelines/{id} endpoint rely on).
 			if ( null !== $pipeline_id ) {
 				if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
 					return array(
@@ -145,7 +153,11 @@ class GetPipelinesAbility {
 					);
 				}
 
-				$formatted_pipeline = $this->formatPipelineByMode( $pipeline, $output_mode );
+				$formatted_pipeline = $this->formatPipelineByMode(
+					$pipeline,
+					$output_mode,
+					true
+				);
 
 				return array(
 					'success'     => true,
@@ -157,11 +169,22 @@ class GetPipelinesAbility {
 				);
 			}
 
-			$all_pipelines = $this->db_pipelines->get_all_pipelines( $user_id, $agent_id, $search );
-			$total         = count( $all_pipelines );
-			$pipelines     = array_slice( $all_pipelines, $offset, $per_page );
+			// List mode: paginate at the SQL layer instead of loading all rows
+			// into memory and slicing. Count runs as a separate COUNT(*) query.
+			$pipelines = $this->db_pipelines->get_all_pipelines(
+				$user_id,
+				$agent_id,
+				$search,
+				$per_page,
+				$offset
+			);
+			$total     = $this->db_pipelines->get_pipelines_count( $user_id, $agent_id, $search );
 
-			$formatted_pipelines = $this->formatPipelinesByMode( $pipelines, $output_mode );
+			$formatted_pipelines = $this->formatPipelinesByMode(
+				$pipelines,
+				$output_mode,
+				$include_flows
+			);
 
 			return array(
 				'success'     => true,

--- a/inc/Abilities/Pipeline/PipelineHelpers.php
+++ b/inc/Abilities/Pipeline/PipelineHelpers.php
@@ -43,11 +43,17 @@ trait PipelineHelpers {
 	/**
 	 * Format pipelines based on output mode.
 	 *
-	 * @param array  $pipelines Pipelines to format.
-	 * @param string $output_mode Output mode (full, summary, ids).
+	 * Batch-fetches flow counts (and optionally full flows) in a single query to
+	 * avoid N+1 per-pipeline lookups when formatting the admin list.
+	 *
+	 * @param array  $pipelines     Pipelines to format.
+	 * @param string $output_mode   Output mode (full, summary, ids).
+	 * @param bool   $include_flows When true, embed the full flows array on each pipeline
+	 *                              (only honored in 'full' mode). Defaults to true for
+	 *                              backward compatibility.
 	 * @return array Formatted pipelines.
 	 */
-	protected function formatPipelinesByMode( array $pipelines, string $output_mode ): array {
+	protected function formatPipelinesByMode( array $pipelines, string $output_mode, bool $include_flows = true ): array {
 		if ( 'ids' === $output_mode ) {
 			return array_map(
 				function ( $pipeline ) {
@@ -57,9 +63,35 @@ trait PipelineHelpers {
 			);
 		}
 
+		// Batch flow data to avoid N+1 queries across the list.
+		$pipeline_ids = array_map( fn( $p ) => (int) $p['pipeline_id'], $pipelines );
+
+		$flow_counts = array();
+		$flows_by_pipeline = array();
+
+		if ( ! empty( $pipeline_ids ) ) {
+			if ( 'full' === $output_mode && $include_flows ) {
+				// Legacy behavior: hydrate full flows per pipeline.
+				foreach ( $pipeline_ids as $pid ) {
+					$pipeline_flows            = $this->db_flows->get_flows_for_pipeline( $pid );
+					$flows_by_pipeline[ $pid ] = $pipeline_flows;
+					$flow_counts[ $pid ]       = count( $pipeline_flows );
+				}
+			} else {
+				// Lightweight: single aggregate query for counts only.
+				$flow_counts = $this->db_flows->count_flows_grouped_by_pipeline( $pipeline_ids );
+			}
+		}
+
 		return array_map(
-			function ( $pipeline ) use ( $output_mode ) {
-				return $this->formatPipelineByMode( $pipeline, $output_mode );
+			function ( $pipeline ) use ( $output_mode, $include_flows, $flow_counts, $flows_by_pipeline ) {
+				return $this->formatPipelineByMode(
+					$pipeline,
+					$output_mode,
+					$include_flows,
+					$flow_counts,
+					$flows_by_pipeline
+				);
 			},
 			$pipelines
 		);
@@ -68,30 +100,56 @@ trait PipelineHelpers {
 	/**
 	 * Format a single pipeline based on output mode.
 	 *
-	 * @param array  $pipeline Pipeline data.
-	 * @param string $output_mode Output mode.
+	 * @param array $pipeline           Pipeline data.
+	 * @param string $output_mode       Output mode.
+	 * @param bool  $include_flows      When true, embed the full flows array (full mode only).
+	 * @param array $flow_counts        Pre-fetched map of pipeline_id => flow_count.
+	 * @param array $flows_by_pipeline  Pre-fetched map of pipeline_id => flows[].
 	 * @return array|int Formatted pipeline data or ID.
 	 */
-	protected function formatPipelineByMode( array $pipeline, string $output_mode ): array|int {
+	protected function formatPipelineByMode(
+		array $pipeline,
+		string $output_mode,
+		bool $include_flows = true,
+		array $flow_counts = array(),
+		array $flows_by_pipeline = array()
+	): array|int {
+		$pipeline_id = (int) $pipeline['pipeline_id'];
+
 		if ( 'ids' === $output_mode ) {
-			return (int) $pipeline['pipeline_id'];
+			return $pipeline_id;
 		}
 
 		if ( 'summary' === $output_mode ) {
+			$count = array_key_exists( $pipeline_id, $flow_counts )
+				? (int) $flow_counts[ $pipeline_id ]
+				: $this->db_flows->count_flows_for_pipeline( $pipeline_id );
+
 			return array(
-				'pipeline_id'   => (int) $pipeline['pipeline_id'],
+				'pipeline_id'   => $pipeline_id,
 				'pipeline_name' => $pipeline['pipeline_name'] ?? '',
-				'flow_count'    => $this->db_flows->count_flows_for_pipeline( (int) $pipeline['pipeline_id'] ),
+				'flow_count'    => $count,
 			);
 		}
 
 		$pipeline = $this->addDisplayFields( $pipeline );
-		$flows    = $this->db_flows->get_flows_for_pipeline( (int) $pipeline['pipeline_id'] );
 
-		return array_merge(
-			$pipeline,
-			array( 'flows' => $flows )
-		);
+		if ( $include_flows ) {
+			$flows = array_key_exists( $pipeline_id, $flows_by_pipeline )
+				? $flows_by_pipeline[ $pipeline_id ]
+				: $this->db_flows->get_flows_for_pipeline( $pipeline_id );
+
+			$pipeline['flows']      = $flows;
+			$pipeline['flow_count'] = count( $flows );
+			return $pipeline;
+		}
+
+		// Lightweight list mode: expose flow_count, omit flows payload entirely.
+		$pipeline['flow_count'] = array_key_exists( $pipeline_id, $flow_counts )
+			? (int) $flow_counts[ $pipeline_id ]
+			: $this->db_flows->count_flows_for_pipeline( $pipeline_id );
+
+		return $pipeline;
 	}
 
 	/**

--- a/inc/Api/Pipelines/Pipelines.php
+++ b/inc/Api/Pipelines/Pipelines.php
@@ -82,6 +82,30 @@ class Pipelines {
 							'description'       => __( 'Filter pipelines by name (substring match)', 'data-machine' ),
 							'sanitize_callback' => 'sanitize_text_field',
 						),
+						'per_page'    => array(
+							'required'          => false,
+							'type'              => 'integer',
+							'default'           => 20,
+							'minimum'           => 1,
+							'maximum'           => 100,
+							'description'       => __( 'Number of pipelines per page', 'data-machine' ),
+							'sanitize_callback' => 'absint',
+						),
+						'offset'      => array(
+							'required'          => false,
+							'type'              => 'integer',
+							'default'           => 0,
+							'minimum'           => 0,
+							'description'       => __( 'Offset for pagination', 'data-machine' ),
+							'sanitize_callback' => 'absint',
+						),
+						'include_flows' => array(
+							'required'          => false,
+							'type'              => 'boolean',
+							'default'           => true,
+							'description'       => __( 'Include full flows array per pipeline. Set false for list views — response returns flow_count only.', 'data-machine' ),
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						),
 					),
 				),
 				array(
@@ -255,6 +279,9 @@ class Pipelines {
 		$format          = $request->get_param( 'format' ) ?? 'json';
 		$ids             = $request->get_param( 'ids' );
 		$search          = $request->get_param( 'search' );
+		$per_page_param  = $request->get_param( 'per_page' );
+		$offset_param    = $request->get_param( 'offset' );
+		$include_flows_param = $request->get_param( 'include_flows' );
 		$scoped_user_id  = PermissionHelper::resolve_scoped_user_id( $request );
 		$scoped_agent_id = PermissionHelper::resolve_scoped_agent_id( $request );
 
@@ -336,10 +363,20 @@ class Pipelines {
 				)
 			);
 		} else {
+			$per_page = ( null !== $per_page_param ) ? max( 1, (int) $per_page_param ) : 20;
+			$offset   = ( null !== $offset_param ) ? max( 0, (int) $offset_param ) : 0;
+			// Default include_flows to false for list mode — callers explicitly
+			// opt-in when they need full flows embedded. This avoids the N+1
+			// flow query and the large payload on admin list loads.
+			$include_flows = ( null !== $include_flows_param )
+				? (bool) $include_flows_param
+				: false;
+
 			$input = array(
-				'per_page'    => 100,
-				'offset'      => 0,
-				'output_mode' => 'full',
+				'per_page'      => $per_page,
+				'offset'        => $offset,
+				'output_mode'   => 'full',
+				'include_flows' => $include_flows,
 			);
 			if ( null !== $scoped_agent_id ) {
 				$input['agent_id'] = $scoped_agent_id;
@@ -372,8 +409,11 @@ class Pipelines {
 
 			return rest_ensure_response(
 				array(
-					'success' => true,
-					'data'    => array(
+					'success'  => true,
+					'per_page' => $result['per_page'] ?? $per_page,
+					'offset'   => $result['offset'] ?? $offset,
+					'total'    => $result['total'],
+					'data'     => array(
 						'pipelines' => $pipelines,
 						'total'     => $result['total'],
 					),

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx
@@ -14,7 +14,11 @@ import { Spinner, Notice, Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { usePipelines, useCreatePipeline } from './queries/pipelines';
+import {
+	usePipelines,
+	usePipeline,
+	useCreatePipeline,
+} from './queries/pipelines';
 import { useFlows } from './queries/flows';
 /**
  * External dependencies
@@ -80,18 +84,35 @@ export default function PipelinesApp() {
 			setSelectedPipelineId( pipelineId );
 		},
 	} );
-	// Find selected pipeline from pipelines array
-	const selectedPipeline = pipelines?.find( ( p ) =>
+
+	// Resolve the selected pipeline: prefer the list cache, fall back to a
+	// single-pipeline fetch so the admin page works even when the selection
+	// isn't in the current selector search results (or the list is paginated).
+	const selectedFromList = pipelines?.find( ( p ) =>
 		isSameId( p.pipeline_id, selectedPipelineId )
 	);
-	const selectedPipelineLoading = false; // No separate loading for selected pipeline
-	const selectedPipelineError = null; // No separate error for selected pipeline
+	const {
+		data: fetchedSelectedPipeline,
+		isLoading: fetchedSelectedLoading,
+		error: fetchedSelectedError,
+	} = usePipeline(
+		selectedPipelineId && ! selectedFromList ? selectedPipelineId : null
+	);
+	const selectedPipeline = selectedFromList || fetchedSelectedPipeline;
+	const selectedPipelineLoading =
+		selectedPipelineId && ! selectedFromList && fetchedSelectedLoading;
+	const selectedPipelineError = fetchedSelectedError;
 
 	const [ isCreatingPipeline, setIsCreatingPipeline ] = useState( false );
 
 	/**
 	 * Set selected pipeline when pipelines load or when selected pipeline is deleted.
 	 * Waits for Zustand hydration AND pipelines query to complete before applying default selection.
+	 *
+	 * The selection is only cleared when the pipeline is confirmed to not exist
+	 * anywhere — not just missing from the paginated list. This lets the admin
+	 * hold a selection beyond the first page of pipelines without it getting
+	 * auto-reset on every reload.
 	 */
 	useEffect( () => {
 		if ( ! hasHydrated || pipelinesLoading ) {
@@ -100,16 +121,28 @@ export default function PipelinesApp() {
 
 		if ( pipelines.length > 0 && ! selectedPipelineId ) {
 			setSelectedPipelineId( pipelines[ 0 ].pipeline_id );
-		} else if ( pipelines.length > 0 && selectedPipelineId ) {
-			// Check if selected pipeline still exists, if not, select next available
-			const selectedPipelineExists = pipelines.some( ( p ) =>
-				isSameId( p.pipeline_id, selectedPipelineId )
-			);
-			if ( ! selectedPipelineExists ) {
-				setSelectedPipelineId( pipelines[ 0 ].pipeline_id );
-			}
-		} else if ( pipelines.length === 0 ) {
-			// No pipelines available
+			return;
+		}
+
+		if ( pipelines.length === 0 && ! selectedPipelineId ) {
+			return;
+		}
+
+		// Selection confirmed to exist if it's either in the list cache or
+		// the single-pipeline fetch resolved to a record.
+		const existsInList = pipelines.some( ( p ) =>
+			isSameId( p.pipeline_id, selectedPipelineId )
+		);
+		const existsOnServer = !! fetchedSelectedPipeline;
+
+		if ( existsInList || existsOnServer || fetchedSelectedLoading ) {
+			return;
+		}
+
+		// Only reach here once the single-pipeline fetch has resolved to null.
+		if ( pipelines.length > 0 ) {
+			setSelectedPipelineId( pipelines[ 0 ].pipeline_id );
+		} else {
 			setSelectedPipelineId( null );
 		}
 	}, [
@@ -118,6 +151,8 @@ export default function PipelinesApp() {
 		setSelectedPipelineId,
 		hasHydrated,
 		pipelinesLoading,
+		fetchedSelectedPipeline,
+		fetchedSelectedLoading,
 	] );
 
 	/**

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/ImportExportModal.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/ImportExportModal.jsx
@@ -15,21 +15,28 @@ import { __ } from '@wordpress/i18n';
  */
 import ExportTab from './import-export/ExportTab';
 import ImportTab from './import-export/ImportTab';
+import { usePipelines } from '../../queries/pipelines';
 
 /**
  * Import/Export Modal Component
  *
+ * Fetches the shared lightweight pipelines list (no flows embedded, flow_count
+ * exposed per row) so the Export tab shows the same set the admin page sees.
+ *
  * @param {Object}   props           - Component props
  * @param {Function} props.onClose   - Close handler
- * @param {Array}    props.pipelines - All available pipelines
+ * @param {Array}    [props.pipelines] - Optional preloaded pipelines (falls back to the list query)
  * @param {Function} props.onSuccess - Success callback
  * @return {React.ReactElement|null} Import/export modal
  */
 export default function ImportExportModal( {
 	onClose,
-	pipelines = [],
+	pipelines: pipelinesProp,
 	onSuccess,
 } ) {
+	const { data: queriedPipelines = [] } = usePipelines();
+	const pipelines = pipelinesProp ?? queriedPipelines;
+
 	/**
 	 * Tab configuration
 	 */

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/import-export/PipelineCheckboxTable.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/import-export/PipelineCheckboxTable.jsx
@@ -100,7 +100,12 @@ export default function PipelineCheckboxTable( {
 						const stepCount = Object.keys(
 							pipeline.pipeline_config || {}
 						).length;
-						const flowCount = pipeline.flows?.length || 0;
+						// Prefer the lightweight flow_count field exposed by the
+						// /pipelines list endpoint. Fall back to counting an
+						// embedded flows array (include_flows=true responses)
+						// for back-compat.
+						const flowCount =
+							pipeline.flow_count ?? pipeline.flows?.length ?? 0;
 						const isSelected = includesId(
 							selectedIds,
 							pipeline.pipeline_id

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineSelector.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineSelector.jsx
@@ -1,63 +1,166 @@
 /**
  * Pipeline Selector Component
  *
- * Dropdown selector for switching between pipelines.
- * Syncs with user preferences and URL parameters.
+ * Typeahead selector backed by a server-side search query. Lets the admin page
+ * scale to hundreds/thousands of pipelines without returning every pipeline to
+ * the browser.
+ *
+ * The selected pipeline stays visible even when the current search filters it
+ * out — we stash a pinned option (id + name) pulled from the selected-pipeline
+ * cache so users never lose their current context while searching.
  */
 
 /**
  * WordPress dependencies
  */
-import { SelectControl } from '@wordpress/components';
+import { ComboboxControl } from '@wordpress/components';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { usePipelines } from '../../queries/pipelines';
+import { usePipelineSearch, usePipeline } from '../../queries/pipelines';
 import { useUIStore } from '../../stores/uiStore';
+import { isSameId } from '../../utils/ids';
+
+const SEARCH_DEBOUNCE_MS = 200;
 
 /**
- * Pipeline dropdown selector
+ * Pipeline combobox selector with server-side search.
  *
  * @return {React.ReactElement|null} Selector component or null if no pipelines
  */
 export default function PipelineSelector() {
-	// Use TanStack Query for data
-	const { data: pipelines = [], isLoading: loading } = usePipelines();
-
-	// Use Zustand for UI state
 	const { selectedPipelineId, setSelectedPipelineId } = useUIStore();
 
-	// Don't render if no pipelines or still loading
-	if ( loading || pipelines.length === 0 ) {
+	// Raw input text + debounced term sent to the server.
+	const [ inputValue, setInputValue ] = useState( '' );
+	const [ debouncedSearch, setDebouncedSearch ] = useState( '' );
+	const debounceTimer = useRef( null );
+
+	useEffect( () => {
+		if ( debounceTimer.current ) {
+			clearTimeout( debounceTimer.current );
+		}
+		debounceTimer.current = setTimeout( () => {
+			setDebouncedSearch( inputValue );
+		}, SEARCH_DEBOUNCE_MS );
+
+		return () => {
+			if ( debounceTimer.current ) {
+				clearTimeout( debounceTimer.current );
+			}
+		};
+	}, [ inputValue ] );
+
+	const {
+		data: searchData,
+		isLoading: searchLoading,
+	} = usePipelineSearch( { search: debouncedSearch } );
+
+	const results = searchData?.pipelines ?? [];
+	const total = searchData?.total ?? 0;
+
+	// Keep the selected pipeline visible in the list even when the search
+	// filters it out. Falls back to a single-pipeline fetch if the selection
+	// isn't in the current results — cheap because the cache is shared.
+	const selectedInResults = useMemo(
+		() =>
+			selectedPipelineId
+				? results.find( ( p ) =>
+						isSameId( p.pipeline_id, selectedPipelineId )
+				  )
+				: null,
+		[ results, selectedPipelineId ]
+	);
+
+	const { data: fetchedSelectedPipeline } = usePipeline(
+		selectedPipelineId && ! selectedInResults ? selectedPipelineId : null
+	);
+
+	// Build options: selected pipeline (pinned) + search results, de-duplicated.
+	const options = useMemo( () => {
+		const entries = [];
+		const seen = new Set();
+
+		const push = ( pipeline ) => {
+			if ( ! pipeline ) {
+				return;
+			}
+			const id = String( pipeline.pipeline_id );
+			if ( seen.has( id ) ) {
+				return;
+			}
+			seen.add( id );
+			entries.push( {
+				label:
+					pipeline.pipeline_name ||
+					__( 'Untitled Pipeline', 'data-machine' ),
+				value: id,
+			} );
+		};
+
+		// Pinned selection (if not already in results).
+		if ( selectedPipelineId && ! selectedInResults ) {
+			push( fetchedSelectedPipeline );
+		}
+
+		results.forEach( push );
+
+		return entries;
+	}, [
+		selectedPipelineId,
+		selectedInResults,
+		fetchedSelectedPipeline,
+		results,
+	] );
+
+	/**
+	 * Nothing to render when the user has no pipelines at all. We intentionally
+	 * keep the selector visible while a search is in-flight so the UI does not
+	 * flicker between states.
+	 */
+	if ( ! selectedPipelineId && options.length === 0 && ! searchLoading ) {
 		return null;
 	}
 
-	// Map pipelines to SelectControl options format
-	const options = pipelines.map( ( pipeline ) => ( {
-		label:
-			pipeline.pipeline_name || __( 'Untitled Pipeline', 'data-machine' ),
-		value: String( pipeline.pipeline_id ),
-	} ) );
+	const currentValue = selectedPipelineId
+		? String( selectedPipelineId )
+		: options[ 0 ]?.value ?? '';
 
-	/**
-	 * Handle pipeline selection change
-	 *
-	 * @param {string} pipelineId - Selected pipeline ID
-	 */
-	const handleChange = ( pipelineId ) => {
-		setSelectedPipelineId( pipelineId );
+	const handleChange = ( value ) => {
+		if ( ! value ) {
+			return;
+		}
+		setSelectedPipelineId( value );
 	};
+
+	// When results are capped, surface a hint so users know to refine search.
+	const showOverflowHint =
+		total > results.length && options.length >= results.length;
 
 	return (
 		<div className="datamachine-pipeline-selector-wrapper datamachine-spacing--margin-bottom-20">
-			<SelectControl
+			<ComboboxControl
 				label={ __( 'Select Pipeline', 'data-machine' ) }
-				value={ selectedPipelineId || options[ 0 ]?.value || '' }
+				value={ currentValue }
 				options={ options }
 				onChange={ handleChange }
+				onFilterValueChange={ setInputValue }
 				className="datamachine-pipeline-selector"
+				__experimentalRenderItem={ undefined }
+				allowReset={ false }
 			/>
+			{ showOverflowHint && (
+				<p className="datamachine-pipeline-selector__hint datamachine-color--text-muted">
+					{ __(
+						'Showing first %1$d of %2$d pipelines. Keep typing to narrow the list.',
+						'data-machine'
+					)
+						.replace( '%1$d', results.length )
+						.replace( '%2$d', total ) }
+				</p>
+			) }
 		</div>
 	);
 }

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
@@ -30,14 +30,110 @@ import {
 import { isSameId } from '../utils/ids';
 
 // Queries
+
+/**
+ * Lightweight pipelines list used by most of the admin UI.
+ *
+ * Fetches up to `perPage` pipelines without embedding flows. Each pipeline
+ * carries a numeric `flow_count` for list-view displays. Mutations in this
+ * file continue to write to the legacy `[ 'pipelines' ]` cache key so
+ * optimistic updates stay in place.
+ *
+ * For scalable search/pagination (ComboboxControl-style), use
+ * {@link usePipelineSearch}. For a single pipeline (including hydration
+ * when the selected pipeline isn't in the list cache), use
+ * {@link usePipeline}.
+ */
 export const usePipelines = () =>
 	useQuery( {
 		queryKey: [ 'pipelines' ],
 		queryFn: async () => {
 			const response = await fetchPipelines();
-			return response.success ? response.data.pipelines : [];
+			if ( ! response.success ) {
+				return [];
+			}
+			return response.data.pipelines ?? [];
 		},
 	} );
+
+/**
+ * Server-side search for pipelines — debounce the `search` argument in the
+ * caller. Designed for the PipelineSelector and similar typeahead UIs.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.search]  Filter by pipeline_name substring.
+ * @param {number} [options.perPage] Items per page (default 50).
+ */
+export const usePipelineSearch = ( { search = '', perPage = 50 } = {} ) => {
+	const normalizedSearch = search ? search.trim() : '';
+
+	return useQuery( {
+		queryKey: [ 'pipelines', 'search', { search: normalizedSearch, perPage } ],
+		queryFn: async () => {
+			const response = await fetchPipelines( null, {
+				perPage,
+				offset: 0,
+				includeFlows: false,
+				search: normalizedSearch || null,
+			} );
+			if ( ! response.success ) {
+				return { pipelines: [], total: 0 };
+			}
+			return {
+				pipelines: response.data.pipelines ?? [],
+				total: response.total ?? response.data.total ?? 0,
+			};
+		},
+		keepPreviousData: true,
+		staleTime: 5_000,
+	} );
+};
+
+/**
+ * Fetch a single pipeline by ID. Falls back to the `[ 'pipelines' ]` list
+ * cache so reads are free when the pipeline is already in memory.
+ *
+ * @param {number|string|null} pipelineId
+ */
+export const usePipeline = ( pipelineId ) => {
+	const queryClient = useQueryClient();
+
+	return useQuery( {
+		queryKey: [
+			'pipelines',
+			'single',
+			pipelineId ? String( pipelineId ) : null,
+		],
+		queryFn: async () => {
+			// Prefer the list cache when the pipeline is already there.
+			const cachedList = queryClient.getQueryData( [ 'pipelines' ] );
+			if ( Array.isArray( cachedList ) ) {
+				const hit = cachedList.find( ( p ) =>
+					isSameId( p.pipeline_id, pipelineId )
+				);
+				if ( hit ) {
+					return hit;
+				}
+			}
+
+			const response = await fetchPipelines( pipelineId );
+			if ( ! response.success ) {
+				return null;
+			}
+			const pipelineRecord = response.data?.pipeline ?? null;
+			const flows = response.data?.flows ?? [];
+
+			if ( ! pipelineRecord ) {
+				return null;
+			}
+
+			// Match the shape the admin app expects when this pipeline comes
+			// from the /pipelines list endpoint.
+			return { ...pipelineRecord, flows };
+		},
+		enabled: !! pipelineId,
+	} );
+};
 
 export const useContextFiles = ( pipelineId ) =>
 	useQuery( {

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -27,16 +27,40 @@ const getAgentPayload = () => {
  */
 
 /**
- * Fetch all pipelines or a specific pipeline
+ * Fetch pipelines list or a specific pipeline.
  *
- * @param {number|null} pipelineId - Optional pipeline ID
+ * In list mode, defaults to lightweight responses (include_flows=false) so the
+ * admin UI can render hundreds of pipelines without the server embedding every
+ * flow. Each pipeline still exposes flow_count for display purposes, and the
+ * selected pipeline's flows are fetched separately via /flows.
+ *
+ * @param {number|null} pipelineId             - Optional pipeline ID (single-pipeline mode ignores list params)
+ * @param {Object}      [options]              - List-mode options
+ * @param {number}      [options.perPage]      - Items per page (default 100)
+ * @param {number}      [options.offset]       - Pagination offset (default 0)
+ * @param {boolean}     [options.includeFlows] - Embed flows per pipeline (default false)
+ * @param {string|null} [options.search]       - Filter by pipeline name (substring)
  * @return {Promise<Object>} Pipeline data
  */
-export const fetchPipelines = async ( pipelineId = null ) => {
-	return await client.get(
-		'/pipelines',
-		pipelineId ? { pipeline_id: pipelineId } : {}
-	);
+export const fetchPipelines = async (
+	pipelineId = null,
+	{ perPage = 100, offset = 0, includeFlows = false, search = null } = {}
+) => {
+	if ( pipelineId ) {
+		return await client.get( '/pipelines', { pipeline_id: pipelineId } );
+	}
+
+	const params = {
+		per_page: perPage,
+		offset,
+		include_flows: includeFlows,
+	};
+
+	if ( search ) {
+		params.search = search;
+	}
+
+	return await client.get( '/pipelines', params );
 };
 
 /**

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -350,6 +350,55 @@ class Flows extends BaseRepository {
 	}
 
 	/**
+	 * Count flows grouped by pipeline ID.
+	 *
+	 * Single aggregate query replacing N per-pipeline COUNT queries — used by
+	 * the Pipelines admin list to show a flow_count per pipeline without
+	 * embedding full flow records.
+	 *
+	 * @since 0.60.0
+	 *
+	 * @param array $pipeline_ids Pipeline IDs to count flows for.
+	 * @return array<int, int> Map of pipeline_id => flow_count. Missing pipelines return 0.
+	 */
+	public function count_flows_grouped_by_pipeline( array $pipeline_ids ): array {
+		$result = array();
+		foreach ( $pipeline_ids as $pid ) {
+			$result[ (int) $pid ] = 0;
+		}
+
+		if ( empty( $pipeline_ids ) ) {
+			return $result;
+		}
+
+		$pipeline_ids = array_map( 'intval', $pipeline_ids );
+		$placeholders = implode( ',', array_fill( 0, count( $pipeline_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				"SELECT pipeline_id, COUNT(*) AS flow_count
+				FROM %i
+				WHERE pipeline_id IN ({$placeholders})
+				GROUP BY pipeline_id",
+				array_merge( array( $this->table_name ), $pipeline_ids )
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( null === $rows ) {
+			return $result;
+		}
+
+		foreach ( $rows as $row ) {
+			$result[ (int) $row['pipeline_id'] ] = (int) $row['flow_count'];
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Get all flows with pagination (single query, no per-pipeline loop).
 	 *
 	 * @since 0.54.2

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -112,12 +112,23 @@ class Pipelines extends BaseRepository {
 	/**
 	 * Get all pipelines from the database.
 	 *
+	 * When $per_page is a positive integer, results are paginated at the SQL layer.
+	 * When $per_page is null (default), all matching pipelines are returned.
+	 *
 	 * @param int|null    $user_id  Optional user ID to filter by.
 	 * @param int|null    $agent_id Optional agent ID to filter by.
 	 * @param string|null $search   Optional search term to filter by pipeline name (LIKE).
-	 * @return array Array of all pipeline records
+	 * @param int|null    $per_page Optional SQL LIMIT. Null returns all rows.
+	 * @param int         $offset   SQL OFFSET (only honored when $per_page is set).
+	 * @return array Array of pipeline records
 	 */
-	public function get_all_pipelines( ?int $user_id = null, ?int $agent_id = null, ?string $search = null ): array {
+	public function get_all_pipelines(
+		?int $user_id = null,
+		?int $agent_id = null,
+		?string $search = null,
+		?int $per_page = null,
+		int $offset = 0
+	): array {
 		$where_clauses = array();
 		$where_values  = array();
 
@@ -139,11 +150,19 @@ class Pipelines extends BaseRepository {
 			$where = ' WHERE ' . implode( ' AND ', $where_clauses );
 		}
 
+		$limit_clause = '';
+		$limit_values = array();
+		if ( null !== $per_page && $per_page > 0 ) {
+			$limit_clause   = ' LIMIT %d OFFSET %d';
+			$limit_values[] = (int) $per_page;
+			$limit_values[] = max( 0, (int) $offset );
+		}
+
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.NotPrepared
 		$results = $this->wpdb->get_results(
 			$this->wpdb->prepare(
-				"SELECT * FROM %i{$where} ORDER BY updated_at DESC",
-				array_merge( array( $this->table_name ), $where_values )
+				"SELECT * FROM %i{$where} ORDER BY updated_at DESC{$limit_clause}",
+				array_merge( array( $this->table_name ), $where_values, $limit_values )
 			),
 			ARRAY_A
 		);
@@ -385,19 +404,30 @@ class Pipelines extends BaseRepository {
 	/**
 	 * Get pipeline count.
 	 *
-	 * @param int|null $user_id  Optional user ID to filter by.
-	 * @param int|null $agent_id Optional agent ID to filter by.
+	 * @param int|null    $user_id  Optional user ID to filter by.
+	 * @param int|null    $agent_id Optional agent ID to filter by.
+	 * @param string|null $search   Optional search term to filter by pipeline name (LIKE).
 	 */
-	public function get_pipelines_count( ?int $user_id = null, ?int $agent_id = null ): int {
-		$where        = '';
-		$where_values = array();
+	public function get_pipelines_count( ?int $user_id = null, ?int $agent_id = null, ?string $search = null ): int {
+		$where_clauses = array();
+		$where_values  = array();
 
 		if ( null !== $agent_id ) {
-			$where          = ' WHERE agent_id = %d';
-			$where_values[] = $agent_id;
+			$where_clauses[] = 'agent_id = %d';
+			$where_values[]  = $agent_id;
 		} elseif ( null !== $user_id ) {
-			$where          = ' WHERE user_id = %d';
-			$where_values[] = $user_id;
+			$where_clauses[] = 'user_id = %d';
+			$where_values[]  = $user_id;
+		}
+
+		if ( null !== $search && '' !== $search ) {
+			$where_clauses[] = 'pipeline_name LIKE %s';
+			$where_values[]  = '%' . $this->wpdb->esc_like( $search ) . '%';
+		}
+
+		$where = '';
+		if ( ! empty( $where_clauses ) ) {
+			$where = ' WHERE ' . implode( ' AND ', $where_clauses );
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.NotPrepared

--- a/tests/Unit/Abilities/PipelineAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineAbilitiesTest.php
@@ -162,6 +162,30 @@ class PipelineAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'pipeline_name', $first_pipeline );
 		$this->assertArrayHasKey( 'pipeline_config', $first_pipeline );
 		$this->assertArrayHasKey( 'flows', $first_pipeline );
+		$this->assertArrayHasKey( 'flow_count', $first_pipeline );
+	}
+
+	public function test_output_mode_full_without_flows_embed(): void {
+		$result = $this->pipeline_abilities->executeGetPipelines(
+			array(
+				'output_mode'   => 'full',
+				'per_page'      => 20,
+				'offset'        => 0,
+				'include_flows' => false,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertEquals( 'full', $result['output_mode'] );
+		$this->assertGreaterThan( 0, count( $result['pipelines'] ) );
+
+		$first_pipeline = $result['pipelines'][0];
+		$this->assertArrayHasKey( 'pipeline_id', $first_pipeline );
+		$this->assertArrayHasKey( 'pipeline_name', $first_pipeline );
+		$this->assertArrayHasKey( 'pipeline_config', $first_pipeline );
+		$this->assertArrayHasKey( 'flow_count', $first_pipeline );
+		$this->assertArrayNotHasKey( 'flows', $first_pipeline );
+		$this->assertIsInt( $first_pipeline['flow_count'] );
 	}
 
 	public function test_output_mode_summary(): void {


### PR DESCRIPTION
## Summary

Two wins on the Pipelines admin page as it grows:

1. **Eliminate N+1 flow queries** when loading the pipelines list.
2. **Server-side search in the PipelineSelector** so the dropdown stays usable at 100s of pipelines.

Ships as two focused commits:

- `perf(pipelines): eliminate N+1 flow queries on admin list load` — backend + lightweight list mode.
- `feat(pipelines): server-side search in PipelineSelector via ComboboxControl` — frontend UX.

---

## Commit 1 — N+1 elimination

The `/pipelines` list was issuing **1 + N SQL queries** (one per pipeline) to hydrate every flow, even though the UI actually renders flows from a separate paginated `/flows` call. Pagination was also happening in PHP via `array_slice` after loading every pipeline row into memory.

- **`GetPipelinesAbility`** gains an `include_flows` input (default `true`). When `false`, each pipeline is returned with a single `flow_count` int sourced from one grouped `COUNT(*)` query instead of hydrating every flow. Pagination now runs at the SQL layer via new `per_page` / `offset` args passed down to `Pipelines::get_all_pipelines()`, with totals from `get_pipelines_count()` (which now supports `search`).
- **`Flows::count_flows_grouped_by_pipeline(array \$pipeline_ids)`** — single aggregate query returning `pipeline_id => flow_count` for a batch of pipelines.
- **REST `/pipelines`** gains `per_page`, `offset`, and `include_flows` query params. Admin list calls default to `include_flows=false`.
- **React `fetchPipelines`** accepts `{ perPage, offset, includeFlows, search }` and defaults to lightweight mode.
- **`PipelineCheckboxTable`** prefers the new `flow_count` field, falling back to `flows?.length`.

### Back-compat
- CLI `wp datamachine pipeline list` still passes no `include_flows`, so the ability defaults to embedding flows — the existing list-table output works unchanged.
- Single-pipeline REST fetches (`/pipelines/{id}`) and the ability's single-pipeline branch always embed flows.

### Impact
```
BEFORE (100 pipelines, 10 flows each)
  GET /pipelines
   └─ SELECT * FROM pipelines                 (1 query)
   └─ for each pipeline:
       SELECT * FROM flows WHERE pipeline_id=? (100 queries)
   └─ payload: 100 × (pipeline + 10 full flows)

AFTER
  GET /pipelines?include_flows=false&per_page=20
   └─ SELECT ... LIMIT 20 OFFSET 0             (1 query)
   └─ SELECT COUNT(*) FROM pipelines           (1 query)
   └─ SELECT pipeline_id, COUNT(*) FROM flows
      GROUP BY pipeline_id                     (1 query)
   └─ payload: 20 pipelines, flow_count int per row
```

---

## Commit 2 — Selector search

The \`PipelineSelector\` was a flat \`SelectControl\` over the full first-100 pipelines. Becomes unusable past ~50 and can't even see pipelines 101+.

- **\`usePipelineSearch({ search, perPage })\`** — debounced (200ms) server-side search hook using \`keepPreviousData\` to avoid flicker while typing. Hits the list endpoint with \`include_flows=false\`.
- **\`usePipeline(pipelineId)\`** — single-pipeline fetch with cache-first lookup against the list. Used to keep the selected pipeline visible even when it's filtered out of the current search results or sits past the first page of the list.
- **\`PipelineSelector\`** becomes a \`ComboboxControl\` with typeahead search, a pinned option for the current selection, and an overflow hint when results are truncated.
- **\`PipelinesApp\`** no longer clears the selection just because the pipeline isn't in the paginated list — only when the server confirms the pipeline doesn't exist.
- **\`ImportExportModal\`** now falls back to \`usePipelines()\` internally when no \`pipelines\` prop is passed (it was previously getting an empty array, so the Export tab has been effectively empty).

---

## Verification

- \`homeboy test data-machine\` → **934 passed / 4 skipped / 0 failed** (including new \`test_output_mode_full_without_flows_embed\`).
- No new lint errors introduced on touched files; remaining PHPStan findings are pre-existing in unrelated files.