### PR TITLE
refactor: rename `update` step type to `upsert`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Engine & execution
 Core architecture
 
 - **Abilities-First Architecture**: All service logic has been migrated to the WordPress 6.9 Abilities API. The Services directory is empty.
-- Base classes for `Step`, `FetchHandler`, `PublishHandler`, `UpdateHandler`, `SettingsHandler`, and `DataPacket` provide consistent behavior and reduce duplication.
+- Base classes for `Step`, `FetchHandler`, `PublishHandler`, `UpsertHandler`, `SettingsHandler`, and `DataPacket` provide consistent behavior and reduce duplication.
 - Base authentication provider architecture (`BaseAuthProvider`, `BaseOAuth1Provider`, `BaseOAuth2Provider`) centralizes option storage and authentication validation across all providers (@since v0.2.6).
 - FilesRepository is modular (storage, cleanup, validation, download, retrieval) and provides flow-isolated file handling.
 - EngineData provides platform-agnostic data access (single source of truth for engine parameters).

--- a/data-machine.php
+++ b/data-machine.php
@@ -343,7 +343,7 @@ function datamachine_load_handlers() {
 	new \DataMachine\Core\Steps\Fetch\Handlers\Email\Email();
 	new \DataMachine\Core\Steps\Fetch\Handlers\Files\Files();
 
-	// Update Handlers
+	// Upsert Handlers
 	new \DataMachine\Core\Steps\Upsert\Handlers\WordPress\WordPress();
 }
 

--- a/data-machine.php
+++ b/data-machine.php
@@ -320,7 +320,7 @@ add_action( 'plugins_loaded', 'datamachine_run_datamachine_plugin', 20 );
 function datamachine_load_step_types() {
 	new \DataMachine\Core\Steps\Fetch\FetchStep();
 	new \DataMachine\Core\Steps\Publish\PublishStep();
-	new \DataMachine\Core\Steps\Update\UpdateStep();
+	new \DataMachine\Core\Steps\Upsert\UpsertStep();
 	new \DataMachine\Core\Steps\AI\AIStep();
 	new \DataMachine\Core\Steps\WebhookGate\WebhookGateStep();
 	new \DataMachine\Core\Steps\SystemTask\SystemTaskStep();
@@ -344,7 +344,7 @@ function datamachine_load_handlers() {
 	new \DataMachine\Core\Steps\Fetch\Handlers\Files\Files();
 
 	// Update Handlers
-	new \DataMachine\Core\Steps\Update\Handlers\WordPress\WordPress();
+	new \DataMachine\Core\Steps\Upsert\Handlers\WordPress\WordPress();
 }
 
 /**
@@ -599,6 +599,9 @@ function datamachine_activate_for_site() {
 
 	// Migrate agent_ping step types to flow configs (idempotent).
 	datamachine_migrate_agent_ping_to_system_task();
+
+	// Migrate `update` step type to `upsert` in pipeline/flow configs (idempotent).
+	datamachine_migrate_update_to_upsert_step_type();
 
 	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
 	datamachine_drop_redundant_post_pipeline_meta();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -226,7 +226,7 @@ All notable changes to Data Machine will be documented in this file.
 
 ### Fixed
 - use get_blog_option() for multisite log level check
-- silence fan-out grandchild handler-miss noise in UpdateStep
+- silence fan-out grandchild handler-miss noise in UpsertStep
 - inline continuation for single-packet step transitions
 - prevent duplicate tool calls with full conversation history dedup
 - enforce concise skip_item reasons (2-5 words max)
@@ -308,7 +308,7 @@ All notable changes to Data Machine will be documented in this file.
 - add $meta parameter to HandlerRegistrationTrait
 
 ### Fixed
-- engine_data clobber in AIStep + revert UpdateStep fallback + transport safety
+- engine_data clobber in AIStep + revert UpsertStep fallback + transport safety
 
 ## [0.50.1] - 2026-03-21
 
@@ -626,7 +626,7 @@ All notable changes to Data Machine will be documented in this file.
 - ImageGenerationPromptRefinement and JobAbilities test rewrites (#606)
 - AI step emitting conversation turns as DataPackets (#609)
 - fail orphaned batch parents instead of leaving stuck processing jobs (#627)
-- classify update-step tool misses as agent_skipped (#628)
+- classify upsert-step tool misses as agent_skipped (#628)
 - include schedule and max_items in flows list output (#629)
 - align global AI tool classes with BaseTool conventions (#632)
 - complete global tool convention methods for QueueValidator
@@ -2192,7 +2192,7 @@ This release marks a new era of Data Machine with systematic flow monitoring and
 
 ### Removed
 - **Legacy Logs Assets** - Deleted legacy `admin-logs.js` and associated PHP template logic.
-- **Step Filter Classes** - Removed `AIStepFilters`, `FetchStepFilters`, `PublishStepFilters`, and `UpdateStepFilters`.
+- **Step Filter Classes** - Removed `AIStepFilters`, `FetchStepFilters`, `PublishStepFilters`, and `UpsertStepFilters`.
 
 ## [0.7.1] - 2026-01-02
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,14 +24,14 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 - **Parameter Systems**: Unified parameter handling across tools and handlers.
 - **Tool Result Finder**: Utility for interpreting tool responses inside data packets.
 - **OAuth Handlers**: Base classes for OAuth1/OAuth2 providers and app-password flows.
-- **Handler Registration Trait**: Centralized registration pattern for fetch, publish, and update handlers.
+- **Handler Registration Trait**: Centralized registration pattern for fetch, publish, and upsert handlers.
 - **HTTP Client**: Standardized outbound request flow for handlers with structured logging and browser-mode header support.
 - **Import/Export System**: Pipeline configuration backup, migration, and sharing functionality.
 
 ### Handler Documentation
 - **Fetch Handlers**: Source-specific data retrieval with deduplication, filtering, and engine data storage.
 - **Publish Handlers**: Modular destination integrations with consistent response formatting and logging.
-- **Update Handlers**: Idempotent WordPress updates that respect engine parameters.
+- **Upsert Handlers**: Identity-aware create-or-update operations — find existing content by identity strategy, update if changed, create if new.
 
 ### AI Tools
 - **Tools Overview**: Global and context-aware tools available to AI agents.

--- a/docs/ai-tools/add-pipeline-step.md
+++ b/docs/ai-tools/add-pipeline-step.md
@@ -9,7 +9,7 @@ The `add_pipeline_step` tool allows AI agents to add new steps to existing pipel
 ## Parameters
 
 - **pipeline_id** (integer, required): The ID of the pipeline to add the step to
-- **step_type** (string, required): The type of step to add. Valid types include: fetch, ai, publish, update
+- **step_type** (string, required): The type of step to add. Valid types include: fetch, ai, publish, upsert
 
 ## Usage
 

--- a/docs/ai-tools/api-query.md
+++ b/docs/ai-tools/api-query.md
@@ -22,7 +22,7 @@ The `api_query` tool enables chat agents to query the Data Machine REST API (via
 
 ### Discovery
 - `GET /datamachine/v1/handlers` - List all handlers
-- `GET /datamachine/v1/handlers?step_type={fetch|publish|update}` - Filter by type
+- `GET /datamachine/v1/handlers?step_type={fetch|publish|upsert}` - Filter by type
 - `GET /datamachine/v1/handlers/{slug}` - Handler details and config schema
 - `GET /datamachine/v1/auth/{handler}/status` - Check OAuth connection status
 - `GET /datamachine/v1/providers` - List AI providers and models

--- a/docs/ai-tools/configure-flow-steps.md
+++ b/docs/ai-tools/configure-flow-steps.md
@@ -15,7 +15,7 @@ The `configure_flow_steps` tool enables configuration of flow steps after creati
 |-----------|------|----------|-------------|
 | `flow_step_id` | string | No* | Flow step ID for single-step mode |
 | `pipeline_id` | integer | No* | Pipeline ID for bulk mode |
-| `step_type` | string | No** | Filter by step type (fetch, publish, update, ai) |
+| `step_type` | string | No** | Filter by step type (fetch, publish, upsert, ai) |
 | `handler_slug` | string | No | Handler slug to set (single) or filter by (bulk) |
 | `target_handler_slug` | string | No | Handler to switch TO. When provided, `handler_slug` filters existing handlers (bulk) and `target_handler_slug` sets the new handler. |
 | `field_map` | object | No | Field mappings when switching handlers, e.g. `{"endpoint_url": "source_url"}`. |

--- a/docs/ai-tools/create-pipeline.md
+++ b/docs/ai-tools/create-pipeline.md
@@ -19,7 +19,7 @@ Each step in the `steps` array supports:
 
 ```json
 {
-  "step_type": "fetch|ai|publish|update",
+  "step_type": "fetch|ai|publish|upsert",
   "handler_slug": "handler_name",
   "handler_config": {
     // Handler-specific configuration
@@ -135,7 +135,7 @@ This tool automatically creates a flow because:
 
 Validates all step definitions:
 - Checks `step_type` against available types
-- Validates `handler_slug` for fetch/publish/update steps
+- Validates `handler_slug` for fetch/publish/upsert steps
 - Ensures AI steps have required provider/model when specified
 - Verifies execution order and step relationships
 

--- a/docs/ai-tools/execute-workflow.md
+++ b/docs/ai-tools/execute-workflow.md
@@ -58,7 +58,7 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 }
 ```
 
-### Update Steps
+### Upsert Steps
 ```json
 {
   "step_type": "update",

--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -150,7 +150,7 @@ Available only to chat AI agents via `datamachine_chat_tools` filter. These spec
   - **Bulk mode**: Configure matching steps across all flows in a pipeline.
   - **Handler Switching**: Use `target_handler_slug` to switch handlers with optional `field_map` for data migration.
   - **Per-Flow Config**: Support for unique settings per flow in bulk mode via `flow_configs`.
-- **Use Cases**: Setting up fetch/publish/update handlers, customizing AI prompts, bulk configuration changes across pipelines, migrating handlers.
+- **Use Cases**: Setting up fetch/publish/upsert handlers, customizing AI prompts, bulk configuration changes across pipelines, migrating handlers.
 
 **ConfigurePipelineStep** (`configure_pipeline_step`) (@since v0.4.4)
 - **Purpose**: Configure pipeline-level AI settings including system prompt, provider, model, and enabled tools
@@ -512,7 +512,7 @@ $parameters = \DataMachine\Engine\AI\ToolParameters::buildParameters(
 // Returns: ['content_string' => ..., 'title' => ..., 'job_id' => ..., 'flow_step_id' => ...]
 ```
 
-**Handler Tools** (publish/update handlers):
+**Handler Tools** (publish/upsert handlers):
 ```php
 $parameters = \DataMachine\Engine\AI\ToolParameters::buildForHandlerTool(
     $data,

--- a/docs/api/endpoints/handlers.md
+++ b/docs/api/endpoints/handlers.md
@@ -77,8 +77,8 @@ curl https://example.com/wp-json/datamachine/v1/handlers?step_type=update \
       "requires_auth": false
     },
     "wordpress-update": {
-      "type": "update",
-      "class": "DataMachine\\Core\\Steps\\Update\\Handlers\\WordPress\\WordPress",
+      "type": "upsert",
+      "class": "DataMachine\\Core\\Steps\\Upsert\\Handlers\\WordPress\\WordPress",
       "label": "WordPress Update",
       "description": "Update existing WordPress content",
       "requires_auth": false

--- a/docs/api/endpoints/handlers.md
+++ b/docs/api/endpoints/handlers.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-The Handlers endpoint provides information about registered fetch, publish, and update handlers available in Data Machine.
+The Handlers endpoint provides information about registered fetch, publish, and upsert handlers available in Data Machine.
 
 ## Authentication
 
@@ -23,7 +23,7 @@ Retrieve list of available handlers with metadata.
 **Purpose**: Discover available handlers for pipeline configuration
 
 **Parameters**:
-- `step_type` (string, optional): Filter by step type (`fetch`, `publish`, `update`)
+- `step_type` (string, optional): Filter by step type (`fetch`, `publish`, `upsert`)
 
 **Example Requests**:
 
@@ -40,7 +40,7 @@ curl https://example.com/wp-json/datamachine/v1/handlers?step_type=publish \
 curl https://example.com/wp-json/datamachine/v1/handlers?step_type=fetch \
   -u username:application_password
 
-# Get update handlers only
+# Get upsert handlers only
 curl https://example.com/wp-json/datamachine/v1/handlers?step_type=update \
   -u username:application_password
 ```
@@ -92,7 +92,7 @@ curl https://example.com/wp-json/datamachine/v1/handlers?step_type=update \
 - `data` (object): Object of handler definitions keyed by handler slug
 
 **Handler Definition Fields**:
-- `type` (string): Handler type (`fetch`, `publish`, `update`)
+- `type` (string): Handler type (`fetch`, `publish`, `upsert`)
 - `class` (string): PHP class implementing the handler
 - `label` (string): Human-readable handler name
 - `description` (string): Handler description
@@ -136,11 +136,11 @@ Publish content to destinations.
 | **wordpress** | Config | No limit | WordPress post creation |
 | **google-sheets-output** | OAuth2 | No limit | Google Sheets row insertion |
 
-### Update Handlers
+### Upsert Handlers
 
 Modify existing content.
 
-**Available Update Handlers**:
+**Available Upsert Handlers**:
 
 | Handler | Auth | Description |
 |---------|------|-------------|

--- a/docs/api/endpoints/parameter-systems.md
+++ b/docs/api/endpoints/parameter-systems.md
@@ -140,7 +140,7 @@ class MyPublishHandler {
 }
 ```
 
-### Update Handlers (Engine Data)
+### Upsert Handlers (Engine Data)
 Require `source_url` from engine data stored by fetch handlers and delivered on the payload:
 
 ```php
@@ -303,7 +303,7 @@ $data = $payload['data']; // Array of data packets
 
 // Each data packet structure:
 [
-    'type' => 'fetch|ai|publish|update',
+    'type' => 'fetch|ai|publish|upsert',
     'handler' => 'rss|twitter|etc',
     'content' => ['title' => $title, 'body' => $content],
     'metadata' => ['source_type' => $type, 'source_url' => $url],

--- a/docs/api/endpoints/pipelines.md
+++ b/docs/api/endpoints/pipelines.md
@@ -164,7 +164,7 @@ Add a step to an existing pipeline.
 
 **Parameters**:
 - `pipeline_id` (integer, required): Pipeline ID (in URL path)
-- `step_type` (string, required): Step type (`fetch`, `ai`, `publish`, `update`)
+- `step_type` (string, required): Step type (`fetch`, `ai`, `publish`, `upsert`)
 
 **Example Request**:
 

--- a/docs/api/endpoints/step-types.md
+++ b/docs/api/endpoints/step-types.md
@@ -139,16 +139,18 @@ curl https://example.com/wp-json/datamachine/v1/step-types \
 - Share to multiple platforms
 - Archive to spreadsheets
 
-### Update
+### Upsert
 
-**Type ID**: `update`
+**Type ID**: `upsert`
 
-**Purpose**: Update existing content
+**Purpose**: Create or update content with identity-aware detection
 
-**Description**: Update steps modify existing content rather than creating new items. Requires source_url from fetch handlers to identify target content.
+**Description**: Upsert steps perform find-or-create-or-update against a target system. Handlers can be update-only (modify existing content by source_url), full upsert (find-by-identity, update if changed, create if new), or create-only-if-new. Identity resolution uses the `datamachine_duplicate_strategies` filter per post type.
 
 **Available Handlers**:
-- WordPress Update
+- WordPress Update (update-only mode)
+- Event Upsert (events plugin; full upsert by title+venue+startDate)
+- GitHub Update (data-machine-code; full upsert via Contents API SHA)
 
 **Use Cases**:
 - Enhance existing posts
@@ -314,4 +316,4 @@ curl https://example.com/wp-json/datamachine/v1/step-types \
 **Base URL**: `/wp-json/datamachine/v1/step-types`
 **Permission**: `manage_options` capability required
 **Implementation**: `inc/Api/StepTypes.php`
-**Available Types**: fetch, ai, publish, update
+**Available Types**: fetch, ai, publish, upsert

--- a/docs/api/endpoints/step-types.md
+++ b/docs/api/endpoints/step-types.md
@@ -53,9 +53,9 @@ curl https://example.com/wp-json/datamachine/v1/step-types \
       "description": "Publish content to destinations"
     },
     {
-      "type": "update",
-      "label": "Update",
-      "description": "Update existing content"
+      "type": "upsert",
+      "label": "Upsert",
+      "description": "Create or update content with identity-aware detection"
     }
   ]
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,7 +304,7 @@ Data Machine v0.2.0 introduced a universal Engine layer (`/inc/Engine/AI/`) that
 
 ### Filter-Based Discovery
 All components self-register via WordPress filters:
-- `datamachine_handlers` - Register fetch/publish/update handlers
+- `datamachine_handlers` - Register fetch/publish/upsert handlers
 - `chubes_ai_tools` - Register AI tools and capabilities
 - `datamachine_auth_providers` - Register authentication providers
 - `datamachine_step_types` - Register custom step types

--- a/docs/core-system/fetch-handler.md
+++ b/docs/core-system/fetch-handler.md
@@ -133,7 +133,7 @@ class MyFetchHandler extends FetchHandler {
 
 ## Engine Data Parameters
 
-Fetch handlers should store relevant parameters for publish/update handlers:
+Fetch handlers should store relevant parameters for publish/upsert handlers:
 
 | Parameter | Description | Used By |
 |-----------|-------------|---------|

--- a/docs/core-system/handler-registration-trait.md
+++ b/docs/core-system/handler-registration-trait.md
@@ -172,7 +172,7 @@ function datamachine_register_rss_filters() {
 datamachine_register_rss_filters();
 ```
 
-### Update Handler Example
+### Upsert Handler Example
 
 ```php
 use DataMachine\Core\Steps\HandlerRegistrationTrait;

--- a/docs/core-system/tool-execution.md
+++ b/docs/core-system/tool-execution.md
@@ -473,7 +473,7 @@ foreach ($engine_parameters as $key => $value) {
 ### Handler Tools
 
 **Registration**: `chubes_ai_tools` filter
-**Scope**: Step-specific (publish, update handlers)
+**Scope**: Step-specific (publish, upsert handlers)
 **Enablement**: Automatic if handler matches
 **Examples**: `twitter_publish`, `wordpress_publish`, `bluesky_publish`
 

--- a/docs/core-system/tool-result-finder.md
+++ b/docs/core-system/tool-result-finder.md
@@ -273,7 +273,7 @@ if ($result) {
 ### Code Reuse
 
 Single implementation of tool result search logic eliminates duplication across:
-- Update steps
+- Upsert steps
 - Custom step types
 - Handler verification utilities
 - Debugging tools
@@ -338,4 +338,4 @@ $result = ToolResultFinder::findHandlerResult($data, 'twitter', $type = 'tool_re
 **File**: `/inc/Engine/AI/Tools/ToolResultFinder.php`
 **Since**: 0.2.0
 **Methods**: `findHandlerResult(array $data, string $handler): ?array`
-**Usage**: Update steps, custom step types, handler verification utilities
+**Usage**: Upsert steps, custom step types, handler verification utilities

--- a/docs/core-system/tool-result-finder.md
+++ b/docs/core-system/tool-result-finder.md
@@ -101,14 +101,14 @@ if ($result) {
 
 ## Integration Patterns
 
-### Update Step Integration
+### Upsert Step Integration
 
-The Update step (`/inc/Core/Steps/Update/UpdateStep.php`) uses ToolResultFinder to locate handler tool results:
+The Upsert step (`/inc/Core/Steps/Upsert/UpsertStep.php`) uses ToolResultFinder to locate handler tool results:
 
 ```php
 use DataMachine\Engine\AI\ToolResultFinder;
 
-class UpdateStep {
+class UpsertStep {
     public function execute(array $payload): array {
         $data = $payload['data'] ?? [];
         $flow_step_config = $payload['flow_step_config'] ?? [];
@@ -128,7 +128,7 @@ class UpdateStep {
         }
 
         // AI did not execute handler tool - fail cleanly
-        do_action('datamachine_log', 'error', 'UpdateStep: AI did not execute handler tool', [
+        do_action('datamachine_log', 'error', 'UpsertStep: AI did not execute handler tool', [
             'expected_handler' => $handler_slug
         ]);
 

--- a/docs/core-system/wordpress-as-agent-memory.md
+++ b/docs/core-system/wordpress-as-agent-memory.md
@@ -518,7 +518,7 @@ Both humans and agents can update memory files:
 - **Humans** edit via the WordPress admin Agent page or any text editor with server access
 - **Agents** update via REST API, Abilities API, or direct file write during workflows
 - **DailyMemoryTask** automatically archives session-specific content from MEMORY.md
-- **Pipelines** can include memory-update steps that append learned information
+- **Pipelines** can include memory-upsert steps that append learned information
 
 The most effective pattern is **agent writes, human reviews** — the agent appends what it learns, DailyMemoryTask keeps it pruned, and the human periodically curates for accuracy and relevance.
 

--- a/docs/core-system/wordpress-components.md
+++ b/docs/core-system/wordpress-components.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The WordPress Shared Components are a collection of centralized WordPress functionality introduced in version 0.2.1. These components reduce code duplication and provide consistent WordPress integration across handlers, particularly the WordPress publish and update handlers.
+The WordPress Shared Components are a collection of centralized WordPress functionality introduced in version 0.2.1. These components reduce code duplication and provide consistent WordPress integration across handlers, particularly the WordPress publish and upsert handlers.
 
 As of v0.2.7, WordPress-specific publishing operations are provided by WordPressPublishHelper, while EngineData serves as a platform-agnostic data access layer.
 

--- a/docs/core-system/wordpress-settings-handler.md
+++ b/docs/core-system/wordpress-settings-handler.md
@@ -8,7 +8,7 @@ Provides reusable WordPress-specific settings utilities for taxonomy fields, pos
 
 ## Overview
 
-The WordPressSettingsHandler centralizes common WordPress settings logic used across fetch, publish, and update handlers. It eliminates code duplication by providing shared methods for taxonomy field generation, post type options, and user selection.
+The WordPressSettingsHandler centralizes common WordPress settings logic used across fetch, publish, and upsert handlers. It eliminates code duplication by providing shared methods for taxonomy field generation, post type options, and user selection.
 
 ## Architecture
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -6,7 +6,7 @@ Comprehensive reference for all WordPress filters used by Data Machine for servi
 
 ### `datamachine_handlers`
 
-**Purpose**: Register fetch, publish, and update handlers
+**Purpose**: Register fetch, publish, and upsert handlers
 
 **Parameters**:
 - `$handlers` (array) - Current handlers array
@@ -16,7 +16,7 @@ Comprehensive reference for all WordPress filters used by Data Machine for servi
 **Handler Structure**:
 ```php
 $handlers['handler_slug'] = [
-    'type' => 'fetch|publish|update',
+    'type' => 'fetch|publish|upsert',
     'class' => 'HandlerClassName',
     'label' => __('Human Readable Name', 'data-machine'),
     'description' => __('Handler description', 'data-machine'),

--- a/docs/development/rest-integration.md
+++ b/docs/development/rest-integration.md
@@ -15,7 +15,7 @@ This guide explains how Data Machine extensions integrate with the REST API ecos
 ### When to Use
 
 Use filter-based integration when your extension:
-- Provides handlers for Data Machine pipelines (fetch, publish, update)
+- Provides handlers for Data Machine pipelines (fetch, publish, upsert)
 - Adds AI tools to existing workflows
 - Extends handler types with new capabilities
 - Integrates with Data Machine's execution engine

--- a/docs/handlers/upsert/wordpress-update.md
+++ b/docs/handlers/upsert/wordpress-update.md
@@ -212,7 +212,7 @@ return [];
 **Benefits**:
 - Universal search utility shared across all update handlers
 - Consistent tool result detection across step types
-- Simplified update handler implementation
+- Simplified upsert handler implementation
 - Centralized maintenance for search improvements
 
 **Metadata Preservation**: Maintains existing post metadata, publication dates, and author information.

--- a/docs/handlers/upsert/wordpress-update.md
+++ b/docs/handlers/upsert/wordpress-update.md
@@ -179,13 +179,13 @@ $parameters = [
 
 **Source URL Requirement**: Requires source URL from centralized engine data via datamachine_engine_data filter for post identification, making it suitable for content update workflows.
 
-**ToolResultFinder Integration** (@since v0.2.0): UpdateStep uses the `ToolResultFinder` utility class for locating handler tool execution results in data packets.
+**ToolResultFinder Integration** (@since v0.2.0): UpsertStep uses the `ToolResultFinder` utility class for locating handler tool execution results in data packets.
 
 **Tool Result Search Pattern**:
 ```php
 use DataMachine\Engine\AI\ToolResultFinder;
 
-// UpdateStep.php
+// UpsertStep.php
 $tool_result_entry = ToolResultFinder::findHandlerResult($data, $handler_slug);
 
 if ($tool_result_entry) {
@@ -199,7 +199,7 @@ if ($tool_result_entry) {
 }
 
 // AI did not execute handler tool - fail cleanly
-do_action('datamachine_log', 'error', 'UpdateStep: AI did not execute handler tool');
+do_action('datamachine_log', 'error', 'UpsertStep: AI did not execute handler tool');
 return [];
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -178,7 +178,7 @@ wp datamachine jobs undo <job_id> --dry-run --allow-root
 ## Key Capabilities
 
 - **Multi-agent support** with isolated identity, memory, and resources per agent on a single WordPress installation.
-- **Multi-platform publishing** via dedicated fetch/publish/update handlers for files, RSS, Reddit, Google Sheets, WordPress, Twitter, Threads, Bluesky, Facebook, and Google Sheets output.
+- **Multi-platform publishing** via dedicated fetch/publish/upsert handlers for files, RSS, Reddit, Google Sheets, WordPress, Twitter, Threads, Bluesky, Facebook, and Google Sheets output.
 - **Daily memory system** for automatic temporal knowledge management with AI-driven pruning.
 - **System tasks** for background AI operations (image generation, alt text, internal linking, meta descriptions) with undo support.
 - **Extension points** through filters such as `datamachine_handlers`, `chubes_ai_tools`, `datamachine_step_types`, `datamachine_auth_providers`, and `datamachine_engine_data`.

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -443,7 +443,7 @@ class ExecuteStepAbility {
 				// Inline continuation: when a step produces 0-1 DataPackets,
 				// schedule the next step directly on the same job instead of
 				// creating child jobs. This eliminates recursive fan-out where
-				// children spawn grandchildren (e.g., AI step → update step).
+				// children spawn grandchildren (e.g., AI step → upsert step).
 				//
 				// Fan-out is only meaningful when a step produces MULTIPLE
 				// packets that need parallel processing (e.g., fetch step

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -483,7 +483,7 @@ class ExecuteStepAbility {
 				}
 
 				// Filter packets before fan-out: only handler-complete packets
-				// carry data that downstream steps (UpdateStep) can use.
+				// carry data that downstream steps (UpsertStep) can use.
 				// Non-handler packets (tool_result, ai_response) would create
 				// child jobs guaranteed to fail with 'required_handler_tool_not_called'.
 				$handler_packets = array_values(

--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -52,7 +52,7 @@ class ConfigureFlowStepsAbility {
 							),
 							'step_type'           => array(
 								'type'        => 'string',
-								'description' => __( 'Filter by step type (fetch, publish, update, ai)', 'data-machine' ),
+								'description' => __( 'Filter by step type (fetch, publish, upsert, ai)', 'data-machine' ),
 							),
 							'handler_slug'        => array(
 								'type'        => 'string',

--- a/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
+++ b/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
@@ -45,7 +45,7 @@ class ValidateFlowStepsConfigAbility {
 							),
 							'step_type'           => array(
 								'type'        => 'string',
-								'description' => __( 'Filter by step type (fetch, publish, update, ai)', 'data-machine' ),
+								'description' => __( 'Filter by step type (fetch, publish, upsert, ai)', 'data-machine' ),
 							),
 							'handler_slug'        => array(
 								'type'        => 'string',

--- a/inc/Abilities/HandlerAbilities.php
+++ b/inc/Abilities/HandlerAbilities.php
@@ -108,7 +108,7 @@ class HandlerAbilities {
 						),
 						'step_type'    => array(
 							'type'        => array( 'string', 'null' ),
-							'description' => __( 'Step type filter (fetch, publish, update, etc.)', 'data-machine' ),
+							'description' => __( 'Step type filter (fetch, publish, upsert, etc.)', 'data-machine' ),
 						),
 					),
 				),

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -96,7 +96,7 @@ class PipelineStepAbilities {
 	private function registerAddPipelineStepAbility(): void {
 		$step_type_abilities = new StepTypeAbilities();
 		$valid_types         = array_keys( $step_type_abilities->getAllStepTypes() );
-		$types_list          = ! empty( $valid_types ) ? implode( ', ', $valid_types ) : 'fetch, ai, publish, update';
+		$types_list          = ! empty( $valid_types ) ? implode( ', ', $valid_types ) : 'fetch, ai, publish, upsert';
 
 		wp_register_ability(
 			'datamachine/add-pipeline-step',

--- a/inc/Api/Chat/Tools/AddPipelineStep.php
+++ b/inc/Api/Chat/Tools/AddPipelineStep.php
@@ -37,7 +37,7 @@ class AddPipelineStep extends BaseTool {
 	 */
 	public function getToolDefinition(): array {
 		$valid_types = self::getValidStepTypes();
-		$types_list  = ! empty( $valid_types ) ? implode( ', ', $valid_types ) : 'fetch, ai, publish, update';
+		$types_list  = ! empty( $valid_types ) ? implode( ', ', $valid_types ) : 'fetch, ai, publish, upsert';
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',

--- a/inc/Api/Chat/Tools/ApiQuery.php
+++ b/inc/Api/Chat/Tools/ApiQuery.php
@@ -66,7 +66,7 @@ MODES:
 - Batch: {requests: [{endpoint, key?}, ...]}
 
 KEY ENDPOINTS:
-/datamachine/v1/handlers - List handlers (?step_type=fetch|publish|update)
+/datamachine/v1/handlers - List handlers (?step_type=fetch|publish|upsert)
 /datamachine/v1/handlers/{slug} - Handler config schema
 /datamachine/v1/pipelines - List pipelines
 /datamachine/v1/pipelines/{id} - Pipeline with flows

--- a/inc/Api/Chat/Tools/ConfigureFlowSteps.php
+++ b/inc/Api/Chat/Tools/ConfigureFlowSteps.php
@@ -79,7 +79,7 @@ class ConfigureFlowSteps extends BaseTool {
 				'step_type'           => array(
 					'type'        => 'string',
 					'required'    => false,
-					'description' => 'Filter by step type (fetch, publish, update, ai)',
+					'description' => 'Filter by step type (fetch, publish, upsert, ai)',
 				),
 				'handler_slug'        => array(
 					'type'        => 'string',

--- a/inc/Api/Chat/Tools/CreateFlow.php
+++ b/inc/Api/Chat/Tools/CreateFlow.php
@@ -261,11 +261,11 @@ class CreateFlow extends BaseTool {
 	 */
 	private function applyStepConfigs( int $flow_id, array $step_configs ): array {
 		$handler_abilities   = new HandlerAbilities();
-		$update_step_ability = wp_get_ability( 'datamachine/update-flow-step' );
+		$upsert_step_ability = wp_get_ability( 'datamachine/update-flow-step' );
 		$applied             = array();
 		$errors              = array();
 
-		if ( ! $update_step_ability ) {
+		if ( ! $upsert_step_ability ) {
 			return array(
 				'applied' => array(),
 				'errors'  => array(
@@ -291,7 +291,7 @@ class CreateFlow extends BaseTool {
 					continue;
 				}
 
-				$result = $update_step_ability->execute(
+				$result = $upsert_step_ability->execute(
 					array(
 						'flow_step_id'   => $flow_step_id,
 						'handler_slug'   => $config['handler_slug'],
@@ -310,7 +310,7 @@ class CreateFlow extends BaseTool {
 			}
 
 			if ( ! empty( $config['user_message'] ) ) {
-				$result = $update_step_ability->execute(
+				$result = $upsert_step_ability->execute(
 					array(
 						'flow_step_id' => $flow_step_id,
 						'user_message' => $config['user_message'],

--- a/inc/Api/Chat/Tools/CreatePipeline.php
+++ b/inc/Api/Chat/Tools/CreatePipeline.php
@@ -37,7 +37,7 @@ class CreatePipeline extends BaseTool {
 	 */
 	public function getToolDefinition(): array {
 		$valid_types = self::getValidStepTypes();
-		$types_list  = ! empty( $valid_types ) ? implode( '|', $valid_types ) : 'fetch|ai|publish|update';
+		$types_list  = ! empty( $valid_types ) ? implode( '|', $valid_types ) : 'fetch|ai|publish|upsert';
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',

--- a/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
+++ b/inc/Api/Chat/Tools/ExecuteWorkflowTool.php
@@ -31,7 +31,7 @@ class ExecuteWorkflowTool extends BaseTool {
 	 */
 	public function getToolDefinition(): array {
 		$step_types_ability = wp_get_ability( 'datamachine/get-step-types' );
-		$type_slugs         = array( 'fetch', 'ai', 'publish', 'update' );
+		$type_slugs         = array( 'fetch', 'ai', 'publish', 'upsert' );
 
 		if ( $step_types_ability ) {
 			$result = $step_types_ability->execute( array() );

--- a/inc/Api/Pipelines/PipelineSteps.php
+++ b/inc/Api/Pipelines/PipelineSteps.php
@@ -140,13 +140,13 @@ class PipelineSteps {
 			array(
 				array(
 					'methods'             => 'PUT',
-					'callback'            => array( self::class, 'handle_update_step_config' ),
+					'callback'            => array( self::class, 'handle_upsert_step_config' ),
 					'permission_callback' => array( self::class, 'check_permission' ),
 					'args'                => self::get_step_config_args( false ),
 				),
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( self::class, 'handle_update_step_config' ),
+					'callback'            => array( self::class, 'handle_upsert_step_config' ),
 					'permission_callback' => array( self::class, 'check_permission' ),
 					'args'                => self::get_step_config_args( true ),
 				),
@@ -425,7 +425,7 @@ class PipelineSteps {
 	 *
 	 * PUT /datamachine/v1/pipelines/steps/{pipeline_step_id}/config
 	 */
-	public static function handle_update_step_config( $request ) {
+	public static function handle_upsert_step_config( $request ) {
 		// Validate permissions
 		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(

--- a/inc/Cli/Commands/Flows/BulkConfigCommand.php
+++ b/inc/Cli/Commands/Flows/BulkConfigCommand.php
@@ -48,7 +48,7 @@ class BulkConfigCommand extends BaseCommand {
 	 * : Flow ID (required for flow scope).
 	 *
 	 * [--step_type=<type>]
-	 * : Filter by step type (fetch, publish, update, ai).
+	 * : Filter by step type (fetch, publish, upsert, ai).
 	 *
 	 * [--dry-run]
 	 * : Preview changes without executing.

--- a/inc/Cli/Commands/HandlersCommand.php
+++ b/inc/Cli/Commands/HandlersCommand.php
@@ -29,7 +29,7 @@ class HandlersCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * [--step-type=<step_type>]
-	 * : Filter by step type (fetch, publish, update, etc.).
+	 * : Filter by step type (fetch, publish, upsert, etc.).
 	 *
 	 * [--format=<format>]
 	 * : Output format.

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/HandlerSelectionModal.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/HandlerSelectionModal.jsx
@@ -21,7 +21,7 @@ import { useHandlerContext } from '../../context/HandlerProvider';
  *
  * @param {Object}   props                 - Component props
  * @param {Function} props.onClose         - Close handler
- * @param {string}   props.stepType        - Step type (fetch, publish, update)
+ * @param {string}   props.stepType        - Step type (fetch, publish, upsert)
  * @param {Function} props.onSelectHandler - Handler selection callback
  * @param {Object}   props.handlers        - All available handlers
  * @return {React.ReactElement|null} Handler selection modal

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/hooks/useHandlersAPI.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/hooks/useHandlersAPI.js
@@ -17,7 +17,7 @@ import { getHandlers } from '../utils/api';
 /**
  * Fetch handlers from REST API
  *
- * @param {string|null} stepType - Optional step type filter (fetch, publish, update)
+ * @param {string|null} stepType - Optional step type filter (fetch, publish, upsert)
  * @return {Object} Handlers data with loading and error states
  */
 export const useHandlersAPI = ( stepType = null ) => {

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -103,7 +103,7 @@ export const deletePipeline = async ( pipelineId ) => {
  * Add a step to a pipeline
  *
  * @param {number} pipelineId     - Pipeline ID
- * @param {string} stepType       - Step type (fetch, ai, publish, update)
+ * @param {string} stepType       - Step type (fetch, ai, publish, upsert)
  * @param {number} executionOrder - Step position
  * @return {Promise<Object>} Created step data
  */

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -462,7 +462,7 @@ class AIStep extends Step {
 
 		// Process tool execution results into output packets.
 		// Only handler completions and tool results are emitted — these are
-		// consumed by downstream steps (PublishStep, UpdateStep) via ToolResultFinder.
+		// consumed by downstream steps (PublishStep, UpsertStep) via ToolResultFinder.
 		// Input DataPackets are NOT included — they cause ghost child jobs.
 		$input_source_type = $inputDataPackets[0]['metadata']['source_type'] ?? 'unknown';
 

--- a/inc/Core/Steps/FlowStepConfig.php
+++ b/inc/Core/Steps/FlowStepConfig.php
@@ -19,7 +19,7 @@ class FlowStepConfig {
 	 *
 	 * Single source of truth for determining which slug to use when reading
 	 * or writing handler_configs. Works for both handler-based steps (fetch,
-	 * publish, update) and self-configuring steps (agent_ping, webhook_gate,
+	 * publish, upsert) and self-configuring steps (agent_ping, webhook_gate,
 	 * system_task) that use step_type as their config key.
 	 *
 	 * Priority:

--- a/inc/Core/Steps/Step.php
+++ b/inc/Core/Steps/Step.php
@@ -70,7 +70,7 @@ abstract class Step {
 	/**
 	 * Initialize step with type identifier.
 	 *
-	 * @param string $step_type Step type identifier (fetch, ai, publish, update)
+	 * @param string $step_type Step type identifier (fetch, ai, publish, upsert)
 	 */
 	public function __construct( string $step_type ) {
 		$this->step_type = $step_type;

--- a/inc/Core/Steps/Upsert/Handlers/UpsertHandler.php
+++ b/inc/Core/Steps/Upsert/Handlers/UpsertHandler.php
@@ -6,16 +6,16 @@
  * result with a post_id, the base class writes origin metadata (handler,
  * flow, pipeline) without any action needed from subclasses.
  *
- * @package DataMachine\Core\Steps\Update\Handlers
+ * @package DataMachine\Core\Steps\Upsert\Handlers
  */
 
-namespace DataMachine\Core\Steps\Update\Handlers;
+namespace DataMachine\Core\Steps\Upsert\Handlers;
 
 use DataMachine\Core\EngineData;
 
 defined( 'ABSPATH' ) || exit;
 
-abstract class UpdateHandler {
+abstract class UpsertHandler {
 
 	/**
 	 * Get all engine data for the current job.
@@ -99,7 +99,7 @@ abstract class UpdateHandler {
 	 * @return array Error response
 	 */
 	protected function errorResponse( string $message, array $context = array(), string $level = 'error' ): array {
-		do_action( 'datamachine_log', $level, 'Update Handler Error: ' . $message, $context );
+		do_action( 'datamachine_log', $level, 'Upsert Handler Error: ' . $message, $context );
 		return array(
 			'success'   => false,
 			'error'     => $message,

--- a/inc/Core/Steps/Upsert/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Upsert/Handlers/WordPress/WordPress.php
@@ -4,26 +4,26 @@
  *
  * Delegates to UpdateWordPressAbility for business logic.
  *
- * @package DataMachine\Core\Steps\Update\Handlers\WordPress
+ * @package DataMachine\Core\Steps\Upsert\Handlers\WordPress
  */
 
-namespace DataMachine\Core\Steps\Update\Handlers\WordPress;
+namespace DataMachine\Core\Steps\Upsert\Handlers\WordPress;
 
-use DataMachine\Core\Steps\Update\Handlers\UpdateHandler;
+use DataMachine\Core\Steps\Upsert\Handlers\UpsertHandler;
 use DataMachine\Core\Steps\HandlerRegistrationTrait;
-use DataMachine\Core\Steps\Update\Handlers\WordPress\WordPressSettings;
+use DataMachine\Core\Steps\Upsert\Handlers\WordPress\WordPressSettings;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class WordPress extends UpdateHandler {
+class WordPress extends UpsertHandler {
 	use HandlerRegistrationTrait;
 
 	public function __construct() {
 		self::registerHandler(
 			'wordpress_update',
-			'update',
+			'upsert',
 			self::class,
 			'WordPress Update',
 			'Update existing WordPress posts and pages',

--- a/inc/Core/Steps/Upsert/Handlers/WordPress/WordPressSettings.php
+++ b/inc/Core/Steps/Upsert/Handlers/WordPress/WordPressSettings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WordPress Update Handler Settings
+ * WordPress Upsert Handler Settings
  *
  * Defines settings fields and sanitization for WordPress update handler.
  * Part of the modular handler architecture.
@@ -9,7 +9,7 @@
  * @since 1.0.0
  */
 
-namespace DataMachine\Core\Steps\Update\Handlers\WordPress;
+namespace DataMachine\Core\Steps\Upsert\Handlers\WordPress;
 
 use DataMachine\Core\Steps\Settings\SettingsHandler;
 use DataMachine\Core\WordPress\WordPressSettingsHandler;

--- a/inc/Core/Steps/Upsert/UpsertStep.php
+++ b/inc/Core/Steps/Upsert/UpsertStep.php
@@ -2,10 +2,10 @@
 /**
  * Update step with AI tool-calling architecture.
  *
- * @package DataMachine\Core\Steps\Update
+ * @package DataMachine\Core\Steps\Upsert
  */
 
-namespace DataMachine\Core\Steps\Update;
+namespace DataMachine\Core\Steps\Upsert;
 
 use DataMachine\Core\DataPacket;
 use DataMachine\Core\Steps\Step;
@@ -16,20 +16,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class UpdateStep extends Step {
+class UpsertStep extends Step {
 
 	use StepTypeRegistrationTrait;
 
 	/**
-	 * Initialize update step.
+	 * Initialize upsert step.
 	 */
 	public function __construct() {
-		parent::__construct( 'update' );
+		parent::__construct( 'upsert' );
 
 		self::registerStepType(
-			slug: 'update',
-			label: 'Update',
-			description: 'Update existing content on external platforms',
+			slug: 'upsert',
+			label: 'Upsert',
+			description: 'Create or update content with identity-aware detection (find existing, update if changed, create if new)',
 			class_name: self::class,
 			position: 40,
 			usesHandler: true,
@@ -171,7 +171,7 @@ class UpdateStep extends Step {
 		do_action(
 			'datamachine_fail_job',
 			$this->job_id,
-			'update_step_exception',
+			'upsert_step_exception',
 			array(
 				'flow_step_id'      => $this->flow_step_id,
 				'exception_message' => $e->getMessage(),
@@ -200,14 +200,14 @@ class UpdateStep extends Step {
 				'updated_at'    => current_time( 'mysql', true ),
 			),
 			array(
-				'step_type'           => 'update',
+				'step_type'           => 'upsert',
 				'handler'             => $handler,
 				'flow_step_id'        => $flow_step_id,
 				'success'             => $tool_result_data['success'] ?? false,
 				'executed_via'        => 'ai_tool_call',
 				'tool_execution_data' => $tool_result_data,
 			),
-			'update'
+			'upsert'
 		);
 
 		return $packet->addTo( $dataPackets );
@@ -252,14 +252,14 @@ class UpdateStep extends Step {
 				'updated_at'    => current_time( 'mysql', true ),
 			),
 			array(
-				'step_type'                 => 'update',
+				'step_type'                 => 'upsert',
 				'handler'                   => $required_handler_slugs[0] ?? ( $configured_handler_slugs[0] ?? '' ),
 				'flow_step_id'              => $this->flow_step_id,
 				'success'                   => true,
 				'fanout_sibling_handled'    => true,
 				'missing_required_handlers' => $missing_required_handlers,
 			),
-			'update'
+			'upsert'
 		);
 
 		return $packet->addTo( $this->dataPackets );
@@ -280,7 +280,7 @@ class UpdateStep extends Step {
 				'updated_at'    => current_time( 'mysql', true ),
 			),
 			array(
-				'step_type'                 => 'update',
+				'step_type'                 => 'upsert',
 				'handler'                   => $required_handler_slugs[0] ?? ( $configured_handler_slugs[0] ?? '' ),
 				'flow_step_id'              => $this->flow_step_id,
 				'success'                   => false,
@@ -290,7 +290,7 @@ class UpdateStep extends Step {
 				'required_handler_slugs'    => $required_handler_slugs,
 				'missing_required_handlers' => $missing_required_handlers,
 			),
-			'update'
+			'upsert'
 		);
 
 		return $packet->addTo( $this->dataPackets );

--- a/inc/Core/Steps/Upsert/UpsertStep.php
+++ b/inc/Core/Steps/Upsert/UpsertStep.php
@@ -1,6 +1,11 @@
 <?php
 /**
- * Update step with AI tool-calling architecture.
+ * Upsert step with AI tool-calling architecture.
+ *
+ * Identity-aware create-or-update step. Handlers registered here can be
+ * update-only (e.g. wordpress_update), full upsert (e.g. upsert_event,
+ * github_update), or create-always-if-new (future). The AI calls the
+ * configured handler tool; this step routes the result into a packet.
  *
  * @package DataMachine\Core\Steps\Upsert
  */
@@ -38,7 +43,7 @@ class UpsertStep extends Step {
 	}
 
 	/**
-	 * Execute update step logic.
+	 * Execute upsert step logic.
 	 *
 	 * @return array
 	 */
@@ -56,7 +61,7 @@ class UpsertStep extends Step {
 			if ( ! is_array( $tool_result_entry ) ) {
 				$this->log(
 					'error',
-					'Update step missing primary tool result despite required handlers being satisfied',
+					'Upsert step missing primary tool result despite required handlers being satisfied',
 					array(
 						'primary_handler_slug' => $primary_handler_slug,
 					)
@@ -103,7 +108,7 @@ class UpsertStep extends Step {
 
 		$this->log(
 			'warning',
-			'Update step required handler tool was not executed by AI',
+			'Upsert step required handler tool was not executed by AI',
 			array(
 				'configured_handlers'       => $configured_handler_slugs,
 				'required_handler_slugs'    => $required_handler_slugs,
@@ -115,7 +120,7 @@ class UpsertStep extends Step {
 	}
 
 	/**
-	 * Validate update step configuration.
+	 * Validate upsert step configuration.
 	 *
 	 * @return bool
 	 */
@@ -137,7 +142,7 @@ class UpsertStep extends Step {
 		if ( empty( $raw_required_handlers ) && count( $configured_handler_slugs ) > 1 ) {
 			$this->log(
 				'warning',
-				'Multi-handler update step has no required_handler_slugs set; defaulting to first handler',
+				'Multi-handler upsert step has no required_handler_slugs set; defaulting to first handler',
 				array(
 					'configured_handlers' => $configured_handler_slugs,
 					'default_required'    => array( $configured_handler_slugs[0] ),
@@ -328,7 +333,7 @@ class UpsertStep extends Step {
 	}
 
 	/**
-	 * Resolve required handler slugs for this update step.
+	 * Resolve required handler slugs for this upsert step.
 	 *
 	 * @param array $configured_handler_slugs Configured handler slugs.
 	 * @return array

--- a/inc/Core/WordPress/PostTracking.php
+++ b/inc/Core/WordPress/PostTracking.php
@@ -9,7 +9,7 @@
  *
  * Tracking is invoked centrally in ToolExecutor::executeTool() after
  * every successful tool call whose result carries an extractable post_id,
- * covering both handler tools (PublishHandler / UpdateHandler subclasses)
+ * covering both handler tools (PublishHandler / UpsertHandler subclasses)
  * and ability tools (PublishWordPressAbility, InsertContentAbility,
  * EditPostBlocksAbility, ReplacePostBlocksAbility, third-party abilities
  * registered as pipeline tools). Individual handlers and abilities do

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -22,3 +22,4 @@ require_once __DIR__ . '/network-scope.php';
 require_once __DIR__ . '/composable-files.php';
 require_once __DIR__ . '/flows.php';
 require_once __DIR__ . '/post-pipeline-meta.php';
+require_once __DIR__ . '/update-to-upsert.php';

--- a/inc/migrations/update-to-upsert.php
+++ b/inc/migrations/update-to-upsert.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Data Machine — Update-to-Upsert step type migration.
+ *
+ * Renames the `update` step type to `upsert` in stored pipeline and flow
+ * configs. Reflects the semantic reality that "update" steps are actually
+ * identity-aware upsert operations — extensions like data-machine-events
+ * already treat the step as an upsert (EventUpsert under step_type: 'update').
+ *
+ * The wordpress_update handler slug is intentionally left unchanged; only
+ * the step type it registers under changes. Handlers are free to be
+ * update-only modes of the broader upsert step.
+ *
+ * @package DataMachine
+ * @since 0.70.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Migrate `update` step type to `upsert` in pipeline and flow configs.
+ *
+ * Idempotent: guarded by datamachine_update_to_upsert_migrated option.
+ *
+ * @since 0.70.0
+ */
+function datamachine_migrate_update_to_upsert_step_type(): void {
+	if ( get_option( 'datamachine_update_to_upsert_migrated', false ) ) {
+		return;
+	}
+
+	global $wpdb;
+	$pipelines_table = $wpdb->prefix . 'datamachine_pipelines';
+	$flows_table     = $wpdb->prefix . 'datamachine_flows';
+
+	$pipelines_migrated = datamachine_rewrite_update_step_type_in_table(
+		$pipelines_table,
+		'pipeline_id',
+		'pipeline_config'
+	);
+	$flows_migrated     = datamachine_rewrite_update_step_type_in_table(
+		$flows_table,
+		'flow_id',
+		'flow_config'
+	);
+
+	update_option( 'datamachine_update_to_upsert_migrated', true, true );
+
+	if ( $pipelines_migrated > 0 || $flows_migrated > 0 ) {
+		do_action(
+			'datamachine_log',
+			'info',
+			'Migrated `update` step type to `upsert` in pipeline and flow configs',
+			array(
+				'pipelines_updated' => $pipelines_migrated,
+				'flows_updated'     => $flows_migrated,
+			)
+		);
+	}
+}
+
+/**
+ * Rewrite `step_type: 'update'` → `'upsert'` inside a table's JSON config column.
+ *
+ * Walks every row, decodes the JSON config (keyed by step_id), and rewrites
+ * any entry whose step_type is `update` to `upsert`. Also updates the
+ * `handler_configs` key if it was keyed by `'update'` (it shouldn't be — those
+ * are keyed by handler slug like `wordpress_update` — but we're defensive).
+ *
+ * @param string $table       Fully-qualified table name.
+ * @param string $id_column   Primary key column name.
+ * @param string $config_col  JSON config column name.
+ * @return int Number of rows updated.
+ */
+function datamachine_rewrite_update_step_type_in_table( string $table, string $id_column, string $config_col ): int {
+	global $wpdb;
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL
+	$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+	if ( ! $table_exists ) {
+		return 0;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL
+	$rows = $wpdb->get_results( "SELECT {$id_column}, {$config_col} FROM {$table}", ARRAY_A );
+	if ( empty( $rows ) ) {
+		return 0;
+	}
+
+	$migrated = 0;
+
+	foreach ( $rows as $row ) {
+		$config = json_decode( $row[ $config_col ] ?? '', true );
+		if ( ! is_array( $config ) ) {
+			continue;
+		}
+
+		$changed = false;
+
+		foreach ( $config as $step_id => &$step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+
+			if ( 'update' === ( $step['step_type'] ?? '' ) ) {
+				$step['step_type'] = 'upsert';
+				$changed           = true;
+			}
+		}
+		unset( $step );
+
+		if ( $changed ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->update(
+				$table,
+				array( $config_col => wp_json_encode( $config ) ),
+				array( $id_column => $row[ $id_column ] ),
+				array( '%s' ),
+				array( '%d' )
+			);
+			++$migrated;
+		}
+	}
+
+	return $migrated;
+}

--- a/readme.txt
+++ b/readme.txt
@@ -50,7 +50,7 @@ Publish Destinations:
 * WordPress (with modular components for images, taxonomies, and source attribution)
 * Google Sheets
 
-Update Handlers:
+Upsert Handlers:
 * WordPress Update (modify existing posts/pages)
 
 AI Tools:

--- a/tests/Unit/Core/Steps/Upsert/UpsertStepTest.php
+++ b/tests/Unit/Core/Steps/Upsert/UpsertStepTest.php
@@ -1,20 +1,20 @@
 <?php
 /**
- * UpdateStep tests.
+ * UpsertStep tests.
  *
- * @package DataMachine\Tests\Unit\Core\Steps\Update
+ * @package DataMachine\Tests\Unit\Core\Steps\Upsert
  */
 
-namespace DataMachine\Tests\Unit\Core\Steps\Update;
+namespace DataMachine\Tests\Unit\Core\Steps\Upsert;
 
 use DataMachine\Core\EngineData;
-use DataMachine\Core\Steps\Update\UpdateStep;
+use DataMachine\Core\Steps\Upsert\UpsertStep;
 use WP_UnitTestCase;
 
-class UpdateStepTest extends WP_UnitTestCase {
+class UpsertStepTest extends WP_UnitTestCase {
 
 	/**
-	 * Build payload for UpdateStep execution.
+	 * Build payload for UpsertStep execution.
 	 *
 	 * @param array $flow_step_config Flow step config.
 	 * @param array $data_packets Existing data packets.
@@ -46,7 +46,7 @@ class UpdateStepTest extends WP_UnitTestCase {
 	}
 
 	public function test_missing_required_handler_tool_sets_explicit_failure_reason(): void {
-		$step = new UpdateStep();
+		$step = new UpsertStep();
 
 		$result = $step->execute(
 			$this->buildPayload(
@@ -67,7 +67,7 @@ class UpdateStepTest extends WP_UnitTestCase {
 	}
 
 	public function test_required_handler_slugs_allows_non_first_handler_when_configured(): void {
-		$step = new UpdateStep();
+		$step = new UpsertStep();
 
 		$data_packets = array(
 			array(


### PR DESCRIPTION
## Summary

Renames the `update` step type to `upsert` to match reality. The step has always been semantically upsert — `data-machine-events` registers `EventUpsert` under `step_type: 'update'`, and its own directory is literally named `inc/Steps/Upsert/Events/`. This PR stops the naming lie.

Closes #1078.

## What changes

| Before | After |
|--------|-------|
| `inc/Core/Steps/Update/` | `inc/Core/Steps/Upsert/` |
| `class UpdateStep` | `class UpsertStep` |
| `abstract class UpdateHandler` | `abstract class UpsertHandler` |
| step slug `'update'`, label `'Update'` | `'upsert'`, label `'Upsert'` |
| "Update existing content on external platforms" | "Create or update content with identity-aware detection (find existing, update if changed, create if new)" |
| `wordpress_update` under `'update'` step type | `wordpress_update` under `'upsert'` step type (handler slug unchanged) |

The `wordpress_update` handler keeps its slug because it's genuinely update-only — a valid mode of the broader upsert step. Full-upsert handlers like `upsert_event` (events) live alongside it.

## DB migration

`inc/migrations/update-to-upsert.php` — idempotent migration that rewrites `step_type: 'update'` → `'upsert'` in both `datamachine_pipelines.pipeline_config` and `datamachine_flows.flow_config`. Guarded by `datamachine_update_to_upsert_migrated` option.

## Breaking change — no BC shim

This is a deliberate breaking change in service of naming honesty. Coordinated with:

- **Extra-Chill/data-machine-events** — `EventUpsertFilters::register()` must flip from `'update'` to `'upsert'` (separate PR)
- **chubes4/intelligence** — forthcoming `wiki_upsert` handler must register under `'upsert'` from day one
- **Extra-Chill/data-machine-code #27** — the in-flight `GitHubUpdate` handler PR needs to extend `UpsertHandler` and register under `'upsert'` before merge

Deploy order: merge this first, then the companion PRs above.

Before deploy, bleed the job queue to drain in-flight jobs registered under the old step type (migration handles stored configs but in-flight queued jobs would fail).

## Tooling

Most of the mechanical rename was done via `homeboy refactor rename` (case-variant aware, scope-filtered). String literals for `step_type: 'update'` were hand-edited because `'update'` also appears in unrelated CLI subcommand `case` statements, `AgentMemory::handleUpdate()`, queue management actions, etc.

## Tests

`homeboy test data-machine` → passed.