### PR TITLE
fix: batch child jobs silently skip update step (#1096)

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -486,18 +486,7 @@ class ExecuteStepAbility {
 				// carry data that downstream steps (UpdateStep) can use.
 				// Non-handler packets (tool_result, ai_response) would create
 				// child jobs guaranteed to fail with 'required_handler_tool_not_called'.
-				$handler_packets = array_values(
-					array_filter(
-						$dataPackets,
-						function ( $packet ) {
-							return ( $packet['metadata']['source_type'] ?? '' ) === 'ai_handler_complete';
-						}
-					)
-				);
-
-				// If filtering removed all packets, keep the originals — the step
-				// may not require handlers, or the packets may use a different convention.
-				$fanout_packets = ! empty( $handler_packets ) ? $handler_packets : $dataPackets;
+				$fanout_packets = self::filterPacketsForFanOut( $dataPackets );
 
 				// After filtering, check if we're back to ≤1 packet — inline instead of fan-out.
 				if ( count( $fanout_packets ) <= 1 ) {
@@ -686,6 +675,42 @@ class ExecuteStepAbility {
 				'fetch_flow_step_id' => $fetch_flow_step_id,
 			)
 		);
+	}
+
+	/**
+	 * Filter data packets to only those safe to fan out into child jobs.
+	 *
+	 * When the AI step produces multiple packets, the batch scheduler creates
+	 * one child job per packet. Only 'ai_handler_complete' packets carry the
+	 * handler result that downstream steps (UpdateStep, PublishStep) need via
+	 * ToolResultFinder. Non-handler packets ('tool_result', 'ai_response')
+	 * would create child jobs that fail with 'required_handler_tool_not_called'.
+	 *
+	 * The DataPacket structure stores the packet kind in the top-level 'type'
+	 * key (set by DataPacket::__construct's third argument).
+	 * 'metadata.source_type' carries the ORIGINAL input source_type (e.g.
+	 * 'ticketmaster', 'web_scraper') — never 'ai_handler_complete'. The
+	 * pre-#1096 implementation filtered on metadata.source_type, which was a
+	 * silent no-op that let every packet fan out into doomed child jobs.
+	 *
+	 * If filtering removes all packets, the originals are returned unchanged
+	 * — the step may not require handlers, or the packets may use a different
+	 * convention (backward compatibility).
+	 *
+	 * @param array $dataPackets Data packets returned from the step.
+	 * @return array Packets safe to fan out.
+	 */
+	public static function filterPacketsForFanOut( array $dataPackets ): array {
+		$handler_packets = array_values(
+			array_filter(
+				$dataPackets,
+				static function ( $packet ) {
+					return ( $packet['type'] ?? '' ) === 'ai_handler_complete';
+				}
+			)
+		);
+
+		return ! empty( $handler_packets ) ? $handler_packets : $dataPackets;
 	}
 
 	/**

--- a/inc/Core/Steps/Update/UpdateStep.php
+++ b/inc/Core/Steps/Update/UpdateStep.php
@@ -81,13 +81,17 @@ class UpdateStep extends Step {
 			return $this->create_update_entry_from_tool_result( $tool_result_entry, $this->dataPackets, $primary_handler_slug, $this->flow_step_id );
 		}
 
-		// Fan-out child jobs often receive a data packet that doesn't contain
-		// the handler result — a sibling job got it instead. This is expected
-		// behavior, not a failure. Complete silently to avoid log noise.
-		if ( $this->isFanOutChild() ) {
+		// Legacy fan-out skip: kept as a narrow safety net for the pre-batch
+		// fan-out model where multiple packets landed in the same job and only
+		// one sibling carried the handler result. Batch children created by
+		// PipelineBatchScheduler each carry their own ai_handler_complete
+		// packet — if a batch child reaches this branch with missing handler
+		// data, that's a real failure (upstream filtering regression or handler
+		// tool not called) and should be logged as such, not silenced.
+		if ( $this->isLegacyFanOutChild() ) {
 			$this->log(
 				'debug',
-				'Fan-out child missing handler result (sibling handled it)',
+				'Legacy fan-out child missing handler result (sibling handled it)',
 				array(
 					'required_handler_slugs'    => $required_handler_slugs,
 					'missing_required_handlers' => $missing_required_handlers,
@@ -214,18 +218,45 @@ class UpdateStep extends Step {
 	}
 
 	/**
-	 * Check if this job is a fan-out child (has a parent job).
+	 * Check if this job is a LEGACY fan-out child that should silently skip.
 	 *
-	 * Fan-out children receive individual data packets from the parent's
-	 * output. Only one sibling gets the handler result — the rest are
-	 * expected to miss it. This is normal, not a failure.
+	 * Two scenarios produce a job with parent_job_id:
 	 *
-	 * @return bool
+	 * 1. Legacy fan-out: multiple packets landed in the same job and only
+	 *    one sibling carried the handler result. Missing handler data is
+	 *    expected for the other siblings — skip silently.
+	 *
+	 * 2. PipelineBatchScheduler child: each child job gets its OWN packet
+	 *    with its own ai_handler_complete metadata. If such a child reaches
+	 *    this branch with missing handler data, that's a real failure
+	 *    (upstream filtering regression or AI didn't call the handler tool)
+	 *    and must NOT be silenced — the item should be retried, not
+	 *    marked completed_no_items.
+	 *
+	 * Batch children are identifiable because their parent's engine_data
+	 * carries the 'batch' flag set by PipelineBatchScheduler::fanOut().
+	 * Presence of that flag means we're the non-legacy case and should
+	 * fall through to the normal failure path.
+	 *
+	 * @return bool True only for legacy fan-out children that should skip silently.
 	 */
-	private function isFanOutChild(): bool {
+	private function isLegacyFanOutChild(): bool {
 		$engine_data = $this->engine_data ?? array();
 		$job_context = $engine_data['job'] ?? array();
-		return ! empty( $job_context['parent_job_id'] );
+		$parent_id   = $job_context['parent_job_id'] ?? null;
+
+		if ( empty( $parent_id ) ) {
+			return false;
+		}
+
+		// If the parent is a batch parent (PipelineBatchScheduler), this child
+		// owns its own packet and a missing handler result is a real failure.
+		$parent_engine = datamachine_get_engine_data( (int) $parent_id );
+		if ( ! empty( $parent_engine['batch'] ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/Unit/Abilities/Engine/ExecuteStepFanOutFilterTest.php
+++ b/tests/Unit/Abilities/Engine/ExecuteStepFanOutFilterTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Tests for ExecuteStepAbility::filterPacketsForFanOut().
+ *
+ * Regression coverage for issue #1096 — the pre-fix implementation filtered
+ * on metadata.source_type instead of the top-level 'type' key, which was a
+ * silent no-op. Every packet (including tool_result and ai_response) was
+ * fanned out into doomed child jobs that silently completed with status
+ * 'completed_no_items' — producing 8,030 orphaned jobs across 7 days on
+ * events.extrachill.com.
+ *
+ * @package DataMachine\Tests\Unit\Abilities\Engine
+ */
+
+namespace DataMachine\Tests\Unit\Abilities\Engine;
+
+use DataMachine\Abilities\Engine\ExecuteStepAbility;
+use DataMachine\Core\DataPacket;
+use WP_UnitTestCase;
+
+class ExecuteStepFanOutFilterTest extends WP_UnitTestCase {
+
+	/**
+	 * Build a packet using the real DataPacket class to guarantee the
+	 * structure matches what the engine actually produces.
+	 */
+	private function make_packet( string $type, array $metadata = array() ): array {
+		$dp     = new DataPacket(
+			array( 'title' => 'Test', 'body' => 'Test body' ),
+			$metadata,
+			$type
+		);
+		$result = $dp->addTo( array() );
+
+		return $result[0];
+	}
+
+	public function test_filter_keeps_only_ai_handler_complete_packets(): void {
+		$packets = array(
+			$this->make_packet(
+				'ai_handler_complete',
+				array( 'handler_tool' => 'upsert_event', 'source_type' => 'ticketmaster' )
+			),
+			$this->make_packet(
+				'tool_result',
+				array( 'tool_name' => 'daily_memory', 'source_type' => 'ticketmaster' )
+			),
+			$this->make_packet(
+				'ai_response',
+				array( 'source_type' => 'ticketmaster' )
+			),
+		);
+
+		$filtered = ExecuteStepAbility::filterPacketsForFanOut( $packets );
+
+		$this->assertCount( 1, $filtered );
+		$this->assertSame( 'ai_handler_complete', $filtered[0]['type'] );
+	}
+
+	public function test_filter_preserves_multiple_ai_handler_complete_packets(): void {
+		$packets = array(
+			$this->make_packet( 'ai_handler_complete', array( 'handler_tool' => 'upsert_event' ) ),
+			$this->make_packet( 'ai_handler_complete', array( 'handler_tool' => 'upsert_event' ) ),
+			$this->make_packet( 'ai_handler_complete', array( 'handler_tool' => 'upsert_event' ) ),
+			$this->make_packet( 'tool_result', array( 'tool_name' => 'search' ) ),
+		);
+
+		$filtered = ExecuteStepAbility::filterPacketsForFanOut( $packets );
+
+		$this->assertCount( 3, $filtered );
+		foreach ( $filtered as $packet ) {
+			$this->assertSame( 'ai_handler_complete', $packet['type'] );
+		}
+	}
+
+	/**
+	 * Regression guard: the pre-#1096 implementation filtered on
+	 * metadata.source_type. The original input source_type is 'ticketmaster',
+	 * 'web_scraper', etc. — NEVER 'ai_handler_complete'. If the filter
+	 * accidentally reverts to checking metadata.source_type, this test will
+	 * fail because tool_result and ai_response packets will leak through.
+	 */
+	public function test_filter_does_not_confuse_metadata_source_type_with_packet_type(): void {
+		$packets = array(
+			$this->make_packet(
+				'ai_handler_complete',
+				array( 'handler_tool' => 'upsert_event', 'source_type' => 'ticketmaster' )
+			),
+			// Craft a malicious-looking tool_result whose metadata.source_type
+			// is literally 'ai_handler_complete' — must still be filtered out.
+			$this->make_packet(
+				'tool_result',
+				array(
+					'tool_name'   => 'daily_memory',
+					'source_type' => 'ai_handler_complete', // would fool the old filter
+				)
+			),
+		);
+
+		$filtered = ExecuteStepAbility::filterPacketsForFanOut( $packets );
+
+		$this->assertCount( 1, $filtered, 'Filter must key on top-level type, not metadata.source_type.' );
+		$this->assertSame( 'ai_handler_complete', $filtered[0]['type'] );
+		$this->assertSame( 'upsert_event', $filtered[0]['metadata']['handler_tool'] );
+	}
+
+	public function test_filter_returns_originals_when_nothing_matches(): void {
+		// Backward-compat: steps that don't emit handler packets (e.g. pure
+		// tool_result producers) should still fan out their originals.
+		$packets = array(
+			$this->make_packet( 'tool_result', array( 'tool_name' => 'search' ) ),
+			$this->make_packet( 'ai_response', array( 'source_type' => 'custom' ) ),
+		);
+
+		$filtered = ExecuteStepAbility::filterPacketsForFanOut( $packets );
+
+		$this->assertCount( 2, $filtered );
+	}
+
+	public function test_filter_handles_empty_array(): void {
+		$this->assertSame( array(), ExecuteStepAbility::filterPacketsForFanOut( array() ) );
+	}
+
+	public function test_filter_handles_packets_without_type_key(): void {
+		$packets = array(
+			array( 'metadata' => array(), 'data' => array() ),
+			$this->make_packet( 'ai_handler_complete', array() ),
+		);
+
+		$filtered = ExecuteStepAbility::filterPacketsForFanOut( $packets );
+
+		$this->assertCount( 1, $filtered );
+		$this->assertSame( 'ai_handler_complete', $filtered[0]['type'] );
+	}
+}

--- a/tests/Unit/Core/Steps/Update/UpdateStepTest.php
+++ b/tests/Unit/Core/Steps/Update/UpdateStepTest.php
@@ -20,25 +20,30 @@ class UpdateStepTest extends WP_UnitTestCase {
 	 * @param array $data_packets Existing data packets.
 	 * @return array
 	 */
-	private function buildPayload( array $flow_step_config, array $data_packets = array() ): array {
+	private function buildPayload( array $flow_step_config, array $data_packets = array(), array $job_context_overrides = array() ): array {
 		$flow_step_id = 'step_update_1';
+
+		$job_context = array_merge(
+			array(
+				'job_id'      => 123,
+				'flow_id'     => 1,
+				'pipeline_id' => 1,
+			),
+			$job_context_overrides
+		);
 
 		$engine = new EngineData(
 			array(
-				'job'         => array(
-					'job_id'      => 123,
-					'flow_id'     => 1,
-					'pipeline_id' => 1,
-				),
+				'job'         => $job_context,
 				'flow_config' => array(
 					$flow_step_id => $flow_step_config,
 				),
 			),
-			123
+			(int) $job_context['job_id']
 		);
 
 		return array(
-			'job_id'       => 123,
+			'job_id'       => (int) $job_context['job_id'],
 			'flow_step_id' => $flow_step_id,
 			'data'         => $data_packets,
 			'engine'       => $engine,
@@ -108,5 +113,110 @@ class UpdateStepTest extends WP_UnitTestCase {
 		$this->assertSame( 'publish_post', $update_packet['metadata']['handler'] ?? '' );
 		$this->assertTrue( (bool) ( $update_packet['metadata']['success'] ?? false ) );
 		$this->assertArrayNotHasKey( 'failure_reason', $update_packet['metadata'] ?? array() );
+	}
+
+	/**
+	 * Regression test for issue #1096.
+	 *
+	 * Batch children created by PipelineBatchScheduler each carry their own
+	 * ai_handler_complete packet. If such a child reaches UpdateStep without
+	 * the expected handler result (e.g. upstream filter regression or AI not
+	 * calling the handler tool), it must NOT be silenced via the legacy
+	 * fan-out skip path — that produced 8,030 orphaned jobs with status
+	 * 'completed_no_items' across 7 days on events.extrachill.com.
+	 *
+	 * The parent job's engine_data['batch'] flag is the signal that this
+	 * child owns its own packet (set by PipelineBatchScheduler::fanOut()).
+	 */
+	public function test_batch_child_with_missing_handler_produces_real_failure(): void {
+		$parent_job_id = 999001;
+		$child_job_id  = 999002;
+
+		// Mark parent as a batch parent — the exact structure
+		// PipelineBatchScheduler::fanOut() writes to engine_data.
+		datamachine_set_engine_data(
+			$parent_job_id,
+			array(
+				'batch'       => true,
+				'batch_total' => 5,
+			)
+		);
+
+		$step = new UpdateStep();
+
+		$result = $step->execute(
+			$this->buildPayload(
+				array(
+					'handler_slugs'   => array( 'upsert_event' ),
+					'handler_configs' => array(),
+				),
+				array(), // No handler result packet.
+				array(
+					'job_id'        => $child_job_id,
+					'parent_job_id' => $parent_job_id,
+				)
+			)
+		);
+
+		$this->assertNotEmpty( $result );
+		$last = $result[ array_key_last( $result ) ];
+
+		// Must be a real failure, NOT a fan-out skip packet.
+		$this->assertSame( 'update', $last['type'] ?? '' );
+		$this->assertSame(
+			'required_handler_tool_not_called',
+			$last['metadata']['failure_reason'] ?? '',
+			'Batch children with missing handler results must fail loudly, not skip silently.'
+		);
+		$this->assertTrue( (bool) ( $last['metadata']['missing_handler_tool'] ?? false ) );
+		$this->assertArrayNotHasKey(
+			'fanout_sibling_handled',
+			$last['metadata'] ?? array(),
+			'Batch child must not be treated as a sibling-handled fan-out skip.'
+		);
+
+		// Clean up engine data.
+		datamachine_set_engine_data( $parent_job_id, array() );
+	}
+
+	/**
+	 * Legacy fan-out siblings (no batch flag on parent) still skip silently.
+	 *
+	 * Preserves the original safety-net behavior for the legacy fan-out model
+	 * where multiple packets land in one job and only one sibling owns the
+	 * handler result.
+	 */
+	public function test_legacy_fanout_child_without_batch_parent_skips_silently(): void {
+		$parent_job_id = 999003;
+		$child_job_id  = 999004;
+
+		// Parent has NO batch flag — legacy fan-out scenario.
+		datamachine_set_engine_data( $parent_job_id, array() );
+
+		$step = new UpdateStep();
+
+		$result = $step->execute(
+			$this->buildPayload(
+				array(
+					'handler_slugs'   => array( 'upsert_event' ),
+					'handler_configs' => array(),
+				),
+				array(),
+				array(
+					'job_id'        => $child_job_id,
+					'parent_job_id' => $parent_job_id,
+				)
+			)
+		);
+
+		$this->assertNotEmpty( $result );
+		$last = $result[ array_key_last( $result ) ];
+
+		$this->assertSame( 'update', $last['type'] ?? '' );
+		$this->assertTrue(
+			(bool) ( $last['metadata']['fanout_sibling_handled'] ?? false ),
+			'Legacy fan-out children should still skip silently as a safety net.'
+		);
+		$this->assertTrue( (bool) ( $last['metadata']['success'] ?? false ) );
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1096. **The pre-#956 filter meant to stop non-handler packets from fanning out was keying on the wrong field and was effectively a silent no-op** — producing 8,030 orphaned batch child jobs across 7 days on events.extrachill.com (38% overall failure rate, up to 99.4% on worst-affected flows like "The High Low").

## The bug

In `ExecuteStepAbility::routeAfterExecution()`:

```php
// BEFORE (wrong)
return ( $packet['metadata']['source_type'] ?? '' ) === 'ai_handler_complete';
```

The `DataPacket` structure stores the packet kind in the **top-level `type`** key (set by `DataPacket::__construct`'s third arg). `metadata.source_type` carries the **original input source** (`ticketmaster`, `web_scraper`, etc.) — never `ai_handler_complete`.

```php
// AFTER
return ( $packet['type'] ?? '' ) === 'ai_handler_complete';
```

This matches `ToolResultFinder`, which reads the same field correctly (line 41):
```php
if ( 'ai_handler_complete' === $entry_type ) { ... }
```

## Impact chain (why the noop caused 8k orphans)

1. AI step calls a handler tool (`upsert_event`) **plus** non-handler tools (`daily_memory`, `search`, etc.) in one turn
2. `processLoopResults()` emits 1 `ai_handler_complete` packet + N `tool_result` packets
3. Filter-that-does-nothing lets all N+1 packets through
4. Batch scheduler creates N+1 child jobs — only one has the handler result
5. The N children with `tool_result` packets hit `UpdateStep::isFanOutChild()` → silent skip → `completed_no_items`
6. Source items marked "processed" in dedup table — never retried

## Changes

### 1. `ExecuteStepAbility::filterPacketsForFanOut()` (new static method)
- Checks `$packet['type']` instead of `metadata.source_type`
- Extracted from inline logic so it can be unit-tested in isolation

### 2. `UpdateStep::isLegacyFanOutChild()` (replaces `isFanOutChild()`)
Defense in depth. Now distinguishes two parent-job scenarios:
- **Legacy fan-out** (parent has no `batch` flag): multiple packets landed in one job — sibling got the handler, child should skip silently. **Preserved.**
- **Batch child** (parent has `batch: true` from `PipelineBatchScheduler::fanOut()`): child owns its own packet — a missing handler result is a real failure and must surface, not be silenced as `completed_no_items`.

### 3. Regression tests
- `tests/Unit/Abilities/Engine/ExecuteStepFanOutFilterTest.php` — 6 cases including one that crafts a `tool_result` packet with `metadata.source_type = 'ai_handler_complete'` to catch any regression back to the broken field.
- `tests/Unit/Core/Steps/Update/UpdateStepTest.php` — 2 new cases:
  - `test_batch_child_with_missing_handler_produces_real_failure`
  - `test_legacy_fanout_child_without_batch_parent_skips_silently`

## Test results

```
Full suite: 946 tests, 3162 assertions, 0 failed, 4 skipped (pre-existing)
New tests: 12 added, all pass
Lint: no new findings on touched files
```

## Out of scope (next step)

Per issue #1096's recovery plan — the ~2,021 already-orphaned processed items on events.extrachill.com still need the SQL cleanup + flow re-run. That's an operational follow-up after this deploys and we verify new jobs upsert correctly. Happy to cut that as a separate WP-CLI task.

## Historical context

- PR #954 added the `isFanOutChild()` silencing (this PR narrows it)
- PR #956 introduced the broken filter (this PR corrects it)

Both PRs addressed symptoms from the right direction but landed on the wrong field name — understandable since `source_type` appears in the packet metadata and was a plausible-looking target. The fix ties the filter to the actual `DataPacket` contract.

Refs #1096