### PR TITLE
feat(memory): MemoryPolicy — per-agent memory file policy (closes #1099)

### DIFF
--- a/docs/core-system/memory-policy.md
+++ b/docs/core-system/memory-policy.md
@@ -1,0 +1,171 @@
+# Memory Policy
+
+**MemoryPolicy** is a per-agent, declarative filter that controls which memory files inject into an AI call. It is the memory-side parallel to [ToolPolicy](./tool-manager.md), and it sits on top of the existing memory layers (registry, pipeline config, flow config) rather than replacing them.
+
+## Why
+
+Not every agent needs the full memory stack. A wiki generator agent's "memory" is the wiki it reads — it does not need `MEMORY.md` accumulating over time, and it does not need the operator's `USER.md` leaking into article output. Before MemoryPolicy, the only ways to suppress memory were to empty the file (fragile), fork the directive stack (heavy), or hope the AI ignored unhelpful context (it does not).
+
+Two shapes of agent:
+
+| Shape | Example | Memory role |
+|---|---|---|
+| Stateful | `chubes-bot`, a personal assistant | Memory is core to identity — default full injection is correct |
+| Stateless | Wiki generator, SEO auditor, one-shot tools | Memory is token cost and context bleed — narrow or disable it |
+
+MemoryPolicy lets the stateless shape declare its posture in config, travel with the agent through bundle export/import, and apply uniformly across every memory injection surface.
+
+## How it fits
+
+Data Machine already has a layered memory injection system. MemoryPolicy does not replace it — it is a subtractive filter that applies across all three existing layers.
+
+```
+MemoryFileRegistry                 CoreMemoryFilesDirective (p20)
+  core files, contexts, layers  ─► ├── MemoryPolicyResolver::resolveRegistered()
+                                   │   (applies agent policy to registered files)
+                                   └── read via AgentMemory
+
+pipeline_config.memory_files       PipelineMemoryFilesDirective (p40)
+  explicit per-pipeline list    ─► ├── MemoryPolicyResolver::filter()
+                                   │   (applies agent policy to scoped filenames)
+                                   └── MemoryFilesReader::read()
+
+flow_config.memory_files           FlowMemoryFilesDirective (p45)
+  explicit per-flow list        ─► ├── MemoryPolicyResolver::filter()
+                                   │   (applies agent policy to scoped filenames)
+                                   └── MemoryFilesReader::read()
+```
+
+Every memory injection path now routes its candidate file list through the resolver before reading. The per-agent `memory_policy` applies consistently whether the file came from the registry, a pipeline config, or a flow config.
+
+## Config shape
+
+Stored at `agent_config.memory_policy` on the agent record. Travels in agent bundles automatically via `AgentBundler`.
+
+```json
+{
+  "memory_policy": {
+    "mode": "default"
+  }
+}
+```
+
+### Modes
+
+| Mode | Behavior |
+|---|---|
+| `default` | No restriction. Current/legacy behavior. A missing `memory_policy` is equivalent. |
+| `deny` | Every registered and scoped file is injected EXCEPT those in `deny`. |
+| `allow_only` | Only files listed in `allow_only` are injected. Empty list means "nothing". |
+
+### Deny example — wiki generator without personal memory
+
+```json
+{
+  "memory_policy": {
+    "mode": "deny",
+    "deny": ["MEMORY.md", "USER.md"]
+  }
+}
+```
+
+The agent still gets `SOUL.md`, `SITE.md`, `RULES.md`, context files, and any pipeline/flow memory — but never the personal-memory layer.
+
+### Allow-only example — minimal context agent
+
+```json
+{
+  "memory_policy": {
+    "mode": "allow_only",
+    "allow_only": ["SOUL.md", "contexts/woocommerce-docs.md"]
+  }
+}
+```
+
+The agent sees only its identity and one domain context file. Everything else is suppressed.
+
+## Resolution precedence
+
+Highest to lowest:
+
+1. **Explicit `deny` in the resolver call** — a directive or system caller can force-deny specific files for one invocation. Always wins.
+2. **Per-agent `memory_policy` deny** — from `agent_config.memory_policy`.
+3. **Per-agent `memory_policy` allow_only** — narrows to the agent's subset.
+4. **Context-level `allow_only` in the resolver call** — a surface can further narrow.
+5. **Context preset** — `MemoryFileRegistry::get_for_context( $context )` honors each file's `contexts` metadata.
+
+A `default` mode short-circuits to null inside `getAgentMemoryPolicy()` so the filter pass is skipped entirely.
+
+## API
+
+### `resolveRegistered( array $context ): array`
+
+Returns a `filename => metadata` map of registered files after policy is applied. Used by `CoreMemoryFilesDirective`.
+
+```php
+$resolver = new MemoryPolicyResolver();
+$files    = $resolver->resolveRegistered( array(
+    'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
+    'agent_id' => $agent_id,
+) );
+```
+
+### `filter( array $filenames, array $context ): array`
+
+Filters an explicit filename list through the policy. Used by `PipelineMemoryFilesDirective` and `FlowMemoryFilesDirective`.
+
+```php
+$resolver    = new MemoryPolicyResolver();
+$memory_files = $resolver->filter( $memory_files, array(
+    'agent_id' => $agent_id,
+    'scope'    => 'pipeline',
+) );
+```
+
+### `getAgentMemoryPolicy( int $agent_id ): ?array`
+
+Reads and validates the policy from an agent's `agent_config`. Returns `null` for invalid, missing, or no-op (`mode=default` / `mode=deny` with empty list) policies.
+
+## Extensibility
+
+Two filters, one per resolution path:
+
+- `datamachine_resolved_memory_files` — fires at the end of `resolveRegistered()`. Receives `( $files, $context_type, $context )`.
+- `datamachine_resolved_scoped_memory_files` — fires at the end of `filter()`. Receives `( $filenames, $context )`.
+
+Use these to inject cross-cutting policy logic (org-wide deny lists, environment-specific overrides, etc.) without touching `agent_config`.
+
+## Context constants
+
+Match `ToolPolicyResolver` for consistency across the policy layer:
+
+```php
+MemoryPolicyResolver::CONTEXT_PIPELINE  // pipeline step AI execution
+MemoryPolicyResolver::CONTEXT_CHAT      // admin chat session
+MemoryPolicyResolver::CONTEXT_SYSTEM    // system task execution
+```
+
+Custom contexts (e.g. `'editor'`, `'automation'`) are supported everywhere the registry accepts them — the resolver just passes them through.
+
+## Relationship to ToolPolicy
+
+Parallel structure, parallel mental model:
+
+| Concern | ToolPolicy | MemoryPolicy |
+|---|---|---|
+| What is scoped | Tools available to agent | Memory files injected into agent |
+| Storage | `agent_config.tool_policy` | `agent_config.memory_policy` |
+| Contexts | pipeline / chat / system | pipeline / chat / system |
+| Modes | `deny`, `allow` | `default`, `deny`, `allow_only` |
+| Resolver | `ToolPolicyResolver` | `MemoryPolicyResolver` |
+| Export path | Travels via `agent_config` in `AgentBundler` | Travels via `agent_config` in `AgentBundler` |
+
+Same precedence model, same extension points, same per-agent config home. An agent's portable definition bundles both policies together with its pipelines, flows, and identity files.
+
+## See also
+
+- [WordPress as Agent Memory](./wordpress-as-agent-memory.md) — the full memory architecture
+- [AI Directives](./ai-directives.md) — directive priorities and execution
+- [Tool Manager](./tool-manager.md) — tool resolution and ToolPolicy reference
+- [Multi-Agent Architecture](./multi-agent-architecture.md) — `agent_config` and per-agent settings
+- [Import/Export](./import-export.md) — `AgentBundler` and bundle round-trips

--- a/inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php
+++ b/inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php
@@ -22,6 +22,7 @@ namespace DataMachine\Core\Steps\AI\Directives;
 
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Engine\AI\Directives\MemoryFilesReader;
+use DataMachine\Engine\AI\Memory\MemoryPolicyResolver;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -56,6 +57,15 @@ class FlowMemoryFilesDirective implements \DataMachine\Engine\AI\Directives\Dire
 
 		$user_id  = (int) ( $payload['user_id'] ?? 0 );
 		$agent_id = (int) ( $payload['agent_id'] ?? 0 );
+
+		// Filter scoped memory files through the per-agent MemoryPolicy so
+		// deny/allow_only applies to flow memory, not just registered
+		// core files.
+		$resolver     = new MemoryPolicyResolver();
+		$memory_files = $resolver->filter( $memory_files, array(
+			'agent_id' => $agent_id,
+			'scope'    => 'flow',
+		) );
 
 		return MemoryFilesReader::read( $memory_files, 'Flow', $flow_id, $user_id, $agent_id );
 	}

--- a/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
@@ -22,6 +22,7 @@ namespace DataMachine\Core\Steps\AI\Directives;
 
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Engine\AI\Directives\MemoryFilesReader;
+use DataMachine\Engine\AI\Memory\MemoryPolicyResolver;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -52,6 +53,17 @@ class PipelineMemoryFilesDirective implements \DataMachine\Engine\AI\Directives\
 		$memory_files = $db_pipelines->get_pipeline_memory_files( (int) $pipeline_id );
 		$user_id      = (int) ( $payload['user_id'] ?? 0 );
 		$agent_id     = (int) ( $payload['agent_id'] ?? 0 );
+
+		// Filter scoped memory files through the per-agent MemoryPolicy so
+		// deny/allow_only applies to pipeline memory, not just registered
+		// core files. A wiki-generator agent configured to deny MEMORY.md
+		// gets the same treatment whether the file is injected by the
+		// registry or by explicit pipeline config.
+		$resolver     = new MemoryPolicyResolver();
+		$memory_files = $resolver->filter( $memory_files, array(
+			'agent_id' => $agent_id,
+			'scope'    => 'pipeline',
+		) );
 
 		return MemoryFilesReader::read( $memory_files, 'Pipeline', (int) $pipeline_id, $user_id, $agent_id );
 	}

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -27,6 +27,7 @@ namespace DataMachine\Engine\AI\Directives;
 
 use DataMachine\Core\FilesRepository\AgentMemory;
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Engine\AI\Memory\MemoryPolicyResolver;
 use DataMachine\Engine\AI\MemoryFileRegistry;
 
 defined( 'ABSPATH' ) || exit;
@@ -61,11 +62,14 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 
 		$outputs = array();
 
-		// Load registered files applicable to the current execution context.
+		// Load registered files applicable to the current execution context,
+		// filtered through the per-agent MemoryPolicy.
 		$context       = $payload['context'] ?? '';
-		$context_files = ! empty( $context )
-			? MemoryFileRegistry::get_for_context( $context )
-			: MemoryFileRegistry::get_all();
+		$resolver      = new MemoryPolicyResolver();
+		$context_files = $resolver->resolveRegistered( array(
+			'context'  => $context,
+			'agent_id' => $agent_id,
+		) );
 
 		foreach ( $context_files as $filename => $meta ) {
 			$layer  = $meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;

--- a/inc/Engine/AI/Memory/MemoryPolicyResolver.php
+++ b/inc/Engine/AI/Memory/MemoryPolicyResolver.php
@@ -1,0 +1,308 @@
+<?php
+/**
+ * Memory Policy Resolver
+ *
+ * Single entry point for determining which agent memory files inject
+ * into an AI call. Aggregates the existing memory sources
+ * (MemoryFileRegistry for core files, pipeline_config.memory_files,
+ * flow_config.memory_files) and applies a per-agent MemoryPolicy on
+ * top.
+ *
+ * This is the memory-side parallel to ToolPolicyResolver. It does NOT
+ * replace the registry or the additive pipeline/flow config; it
+ * sits after them as a subtractive agent-scoped filter.
+ *
+ * Resolution precedence (highest to lowest):
+ * 1. Explicit deny list passed in context (always wins)
+ * 2. Per-agent policy deny list (from agent_config.memory_policy)
+ * 3. Per-agent policy allow-only (narrows to subset)
+ * 4. Context-level allow_only (narrows to subset)
+ * 5. Context preset (registry's get_for_context)
+ *
+ * @package DataMachine\Engine\AI\Memory
+ * @since   0.67.0
+ */
+
+namespace DataMachine\Engine\AI\Memory;
+
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Engine\AI\MemoryFileRegistry;
+
+defined( 'ABSPATH' ) || exit;
+
+class MemoryPolicyResolver {
+
+	/**
+	 * Context presets, aligned with ToolPolicyResolver for consistency.
+	 */
+	public const CONTEXT_PIPELINE = 'pipeline';
+	public const CONTEXT_CHAT     = 'chat';
+	public const CONTEXT_SYSTEM   = 'system';
+
+	/**
+	 * Resolve the set of registered memory files applicable to a context
+	 * after agent policy is applied.
+	 *
+	 * Used by CoreMemoryFilesDirective to replace its direct
+	 * MemoryFileRegistry::get_for_context() call. The registry remains
+	 * the source of truth for which files exist and where they live;
+	 * this method is a per-agent filter on top.
+	 *
+	 * @param array $context {
+	 *     Execution context describing the request.
+	 *
+	 *     @type string   $context    Required. Execution context slug (e.g. 'chat', 'pipeline').
+	 *     @type int|null $agent_id   Optional agent ID for per-agent policy filtering.
+	 *     @type array    $deny       Filenames to explicitly deny (highest precedence).
+	 *     @type array    $allow_only Context-level allowlist narrowing.
+	 * }
+	 * @return array<string, array> Filename => metadata map, sorted by priority ascending.
+	 */
+	public function resolveRegistered( array $context ): array {
+		$context_type = $context['context'] ?? '';
+		$agent_id     = isset( $context['agent_id'] ) ? (int) $context['agent_id'] : 0;
+
+		// 1. Start with registry output filtered by context (already priority-sorted).
+		$files = ! empty( $context_type )
+			? MemoryFileRegistry::get_for_context( $context_type )
+			: MemoryFileRegistry::get_all();
+
+		// 2. Apply per-agent policy.
+		if ( $agent_id > 0 ) {
+			$policy = $this->getAgentMemoryPolicy( $agent_id );
+			$files  = $this->applyAgentPolicyToRegistered( $files, $policy );
+		}
+
+		// 3. Context-level allow_only (narrows to explicit subset).
+		$allow_only = $context['allow_only'] ?? array();
+		if ( ! empty( $allow_only ) ) {
+			$files = array_intersect_key( $files, array_flip( array_map( 'sanitize_file_name', $allow_only ) ) );
+		}
+
+		// 4. Explicit deny list (always wins).
+		$deny = $context['deny'] ?? array();
+		if ( ! empty( $deny ) ) {
+			$files = array_diff_key( $files, array_flip( array_map( 'sanitize_file_name', $deny ) ) );
+		}
+
+		// 5. Allow external filtering of the resolved registered set.
+		$files = apply_filters( 'datamachine_resolved_memory_files', $files, $context_type, $context );
+
+		return $files;
+	}
+
+	/**
+	 * Filter an explicit list of filenames (e.g. from pipeline_config or
+	 * flow_config) through the per-agent memory policy.
+	 *
+	 * Used by PipelineMemoryFilesDirective and FlowMemoryFilesDirective
+	 * so that per-agent deny/allow applies consistently to all three
+	 * memory injection surfaces, not just core registered files.
+	 *
+	 * @param array $filenames List of memory filenames from scope config.
+	 * @param array $context   {
+	 *     Execution context describing the request.
+	 *
+	 *     @type int|null $agent_id Agent ID for per-agent policy filtering.
+	 *     @type array    $deny    Filenames to explicitly deny.
+	 *     @type string   $scope   Optional scope label for logging ('pipeline', 'flow').
+	 * }
+	 * @return array Filtered list of filenames (preserves input order).
+	 */
+	public function filter( array $filenames, array $context ): array {
+		if ( empty( $filenames ) ) {
+			return $filenames;
+		}
+
+		// Normalize input.
+		$filenames = array_values( array_map( 'sanitize_file_name', $filenames ) );
+
+		$agent_id = isset( $context['agent_id'] ) ? (int) $context['agent_id'] : 0;
+
+		// 1. Per-agent policy.
+		if ( $agent_id > 0 ) {
+			$policy    = $this->getAgentMemoryPolicy( $agent_id );
+			$filenames = $this->applyAgentPolicyToList( $filenames, $policy );
+		}
+
+		// 2. Explicit deny (always wins).
+		$deny = $context['deny'] ?? array();
+		if ( ! empty( $deny ) ) {
+			$deny_set  = array_flip( array_map( 'sanitize_file_name', $deny ) );
+			$filenames = array_values( array_filter(
+				$filenames,
+				function ( $name ) use ( $deny_set ) {
+					return ! isset( $deny_set[ $name ] );
+				}
+			) );
+		}
+
+		/**
+		 * Filter the filtered explicit-list memory filenames.
+		 *
+		 * Fires for pipeline- and flow-scoped memory file lists after
+		 * the per-agent MemoryPolicy is applied. The registered-file
+		 * path fires `datamachine_resolved_memory_files` instead.
+		 *
+		 * @since 0.67.0
+		 *
+		 * @param string[] $filenames Filtered filenames.
+		 * @param array    $context   Resolution context.
+		 */
+		return apply_filters( 'datamachine_resolved_scoped_memory_files', $filenames, $context );
+	}
+
+	/**
+	 * Read an agent's memory policy from agent_config.
+	 *
+	 * Returns null when the agent does not exist, has no policy, or the
+	 * policy is structurally invalid. Returns null for effectively
+	 * no-op policies (mode=deny with empty deny list and no allow_only)
+	 * to avoid a wasted filter pass.
+	 *
+	 * @param int $agent_id Agent ID.
+	 * @return array|null { mode, deny?, allow_only? } or null.
+	 */
+	public function getAgentMemoryPolicy( int $agent_id ): ?array {
+		if ( $agent_id <= 0 ) {
+			return null;
+		}
+
+		$agents_repo = new Agents();
+		$agent       = $agents_repo->get_agent( $agent_id );
+
+		if ( ! $agent ) {
+			return null;
+		}
+
+		$config = $agent['agent_config'] ?? array();
+
+		if ( empty( $config['memory_policy'] ) || ! is_array( $config['memory_policy'] ) ) {
+			return null;
+		}
+
+		$policy = $config['memory_policy'];
+
+		// Must have a recognizable mode.
+		$mode = $policy['mode'] ?? 'default';
+		if ( ! in_array( $mode, array( 'default', 'deny', 'allow_only' ), true ) ) {
+			return null;
+		}
+
+		// Default mode is a no-op: behave as if no policy is set.
+		if ( 'default' === $mode ) {
+			return null;
+		}
+
+		$deny       = isset( $policy['deny'] ) && is_array( $policy['deny'] )
+			? array_values( array_map( 'sanitize_file_name', $policy['deny'] ) )
+			: array();
+		$allow_only = isset( $policy['allow_only'] ) && is_array( $policy['allow_only'] )
+			? array_values( array_map( 'sanitize_file_name', $policy['allow_only'] ) )
+			: array();
+
+		// Deny mode with empty deny list is a no-op.
+		if ( 'deny' === $mode && empty( $deny ) ) {
+			return null;
+		}
+
+		// allow_only mode is meaningful even with an empty list (means "nothing").
+
+		return array(
+			'mode'       => $mode,
+			'deny'       => $deny,
+			'allow_only' => $allow_only,
+		);
+	}
+
+	/**
+	 * Apply an agent policy to a registered-file metadata map.
+	 *
+	 * Preserves file metadata (layer, priority, etc.) so downstream
+	 * readers (MemoryFilesReader, AgentMemory) continue to resolve
+	 * files correctly.
+	 *
+	 * @param array      $files  Filename => metadata map.
+	 * @param array|null $policy Policy from getAgentMemoryPolicy() or null.
+	 * @return array Filtered map.
+	 */
+	private function applyAgentPolicyToRegistered( array $files, ?array $policy ): array {
+		if ( null === $policy ) {
+			return $files;
+		}
+
+		$mode = $policy['mode'];
+
+		if ( 'deny' === $mode ) {
+			if ( empty( $policy['deny'] ) ) {
+				return $files;
+			}
+			return array_diff_key( $files, array_flip( $policy['deny'] ) );
+		}
+
+		if ( 'allow_only' === $mode ) {
+			if ( empty( $policy['allow_only'] ) ) {
+				return array();
+			}
+			return array_intersect_key( $files, array_flip( $policy['allow_only'] ) );
+		}
+
+		return $files;
+	}
+
+	/**
+	 * Apply an agent policy to a plain filename list.
+	 *
+	 * @param string[]   $filenames List of filenames.
+	 * @param array|null $policy    Policy from getAgentMemoryPolicy() or null.
+	 * @return string[] Filtered filenames (indices reset).
+	 */
+	private function applyAgentPolicyToList( array $filenames, ?array $policy ): array {
+		if ( null === $policy ) {
+			return $filenames;
+		}
+
+		$mode = $policy['mode'];
+
+		if ( 'deny' === $mode ) {
+			if ( empty( $policy['deny'] ) ) {
+				return $filenames;
+			}
+			$deny_set = array_flip( $policy['deny'] );
+			return array_values( array_filter(
+				$filenames,
+				function ( $name ) use ( $deny_set ) {
+					return ! isset( $deny_set[ $name ] );
+				}
+			) );
+		}
+
+		if ( 'allow_only' === $mode ) {
+			if ( empty( $policy['allow_only'] ) ) {
+				return array();
+			}
+			$allow_set = array_flip( $policy['allow_only'] );
+			return array_values( array_filter(
+				$filenames,
+				function ( $name ) use ( $allow_set ) {
+					return isset( $allow_set[ $name ] );
+				}
+			) );
+		}
+
+		return $filenames;
+	}
+
+	/**
+	 * Get available context presets.
+	 *
+	 * @return array<string, string> Context key => description.
+	 */
+	public static function getContexts(): array {
+		return array(
+			self::CONTEXT_PIPELINE => 'Pipeline step AI execution',
+			self::CONTEXT_CHAT     => 'Admin chat session',
+			self::CONTEXT_SYSTEM   => 'System task execution',
+		);
+	}
+}

--- a/tests/Unit/AI/Memory/MemoryPolicyResolverTest.php
+++ b/tests/Unit/AI/Memory/MemoryPolicyResolverTest.php
@@ -1,0 +1,484 @@
+<?php
+/**
+ * Tests for MemoryPolicyResolver — per-agent memory file policy.
+ *
+ * @package DataMachine\Tests\Unit\AI\Memory
+ */
+
+namespace DataMachine\Tests\Unit\AI\Memory;
+
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Engine\AI\Memory\MemoryPolicyResolver;
+use DataMachine\Engine\AI\MemoryFileRegistry;
+use WP_UnitTestCase;
+
+/**
+ * @covers \DataMachine\Engine\AI\Memory\MemoryPolicyResolver
+ */
+class MemoryPolicyResolverTest extends WP_UnitTestCase {
+
+	private MemoryPolicyResolver $resolver;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		// Reset the memory file registry before each test so we control
+		// exactly which files are registered.
+		MemoryFileRegistry::reset();
+
+		// Seed a small, known set of registered files so assertions are
+		// stable across test runs. The real core registrations happen in
+		// bootstrap code we don't need here.
+		MemoryFileRegistry::register( 'SOUL.md', 10, array(
+			'layer'    => MemoryFileRegistry::LAYER_AGENT,
+			'contexts' => array( 'all' ),
+		) );
+		MemoryFileRegistry::register( 'MEMORY.md', 20, array(
+			'layer'    => MemoryFileRegistry::LAYER_AGENT,
+			'contexts' => array( 'all' ),
+		) );
+		MemoryFileRegistry::register( 'USER.md', 30, array(
+			'layer'    => MemoryFileRegistry::LAYER_USER,
+			'contexts' => array( 'chat', 'pipeline' ),
+		) );
+		MemoryFileRegistry::register( 'CHAT_ONLY.md', 40, array(
+			'layer'    => MemoryFileRegistry::LAYER_AGENT,
+			'contexts' => array( 'chat' ),
+		) );
+
+		$this->resolver = new MemoryPolicyResolver();
+	}
+
+	public function tear_down(): void {
+		MemoryFileRegistry::reset();
+		remove_all_filters( 'datamachine_resolved_memory_files' );
+		remove_all_filters( 'datamachine_resolved_scoped_memory_files' );
+		parent::tear_down();
+	}
+
+	// ============================================
+	// resolveRegistered() — context filtering (no agent)
+	// ============================================
+
+	public function test_registered_chat_context_includes_all_and_chat_files(): void {
+		$files = $this->resolver->resolveRegistered( array(
+			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
+		) );
+
+		$this->assertArrayHasKey( 'SOUL.md', $files );
+		$this->assertArrayHasKey( 'MEMORY.md', $files );
+		$this->assertArrayHasKey( 'USER.md', $files );
+		$this->assertArrayHasKey( 'CHAT_ONLY.md', $files );
+	}
+
+	public function test_registered_pipeline_context_excludes_chat_only(): void {
+		$files = $this->resolver->resolveRegistered( array(
+			'context' => MemoryPolicyResolver::CONTEXT_PIPELINE,
+		) );
+
+		$this->assertArrayHasKey( 'SOUL.md', $files );
+		$this->assertArrayHasKey( 'MEMORY.md', $files );
+		$this->assertArrayHasKey( 'USER.md', $files );
+		$this->assertArrayNotHasKey( 'CHAT_ONLY.md', $files );
+	}
+
+	public function test_registered_preserves_metadata(): void {
+		$files = $this->resolver->resolveRegistered( array(
+			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
+		) );
+
+		$this->assertSame( MemoryFileRegistry::LAYER_AGENT, $files['SOUL.md']['layer'] );
+		$this->assertSame( MemoryFileRegistry::LAYER_USER, $files['USER.md']['layer'] );
+	}
+
+	// ============================================
+	// resolveRegistered() — explicit context deny/allow_only
+	// ============================================
+
+	public function test_context_deny_removes_files(): void {
+		$files = $this->resolver->resolveRegistered( array(
+			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
+			'deny'    => array( 'MEMORY.md' ),
+		) );
+
+		$this->assertArrayNotHasKey( 'MEMORY.md', $files );
+		$this->assertArrayHasKey( 'SOUL.md', $files );
+	}
+
+	public function test_context_allow_only_narrows_to_subset(): void {
+		$files = $this->resolver->resolveRegistered( array(
+			'context'    => MemoryPolicyResolver::CONTEXT_CHAT,
+			'allow_only' => array( 'SOUL.md' ),
+		) );
+
+		$this->assertArrayHasKey( 'SOUL.md', $files );
+		$this->assertArrayNotHasKey( 'MEMORY.md', $files );
+		$this->assertCount( 1, $files );
+	}
+
+	// ============================================
+	// resolveRegistered() — per-agent policy
+	// ============================================
+
+	public function test_no_agent_id_means_no_agent_filter(): void {
+		$without = $this->resolver->resolveRegistered( array(
+			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
+		) );
+
+		$with_zero = $this->resolver->resolveRegistered( array(
+			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
+			'agent_id' => 0,
+		) );
+
+		$this->assertSame( $without, $with_zero );
+	}
+
+	public function test_agent_default_mode_is_noop(): void {
+		$agent_id = $this->createAgentWithPolicy( array( 'mode' => 'default' ) );
+
+		$without = $this->resolver->resolveRegistered( array(
+			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
+		) );
+
+		$with = $this->resolver->resolveRegistered( array(
+			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertSame( $without, $with );
+	}
+
+	public function test_agent_deny_mode_removes_listed_files(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode' => 'deny',
+			'deny' => array( 'MEMORY.md', 'USER.md' ),
+		) );
+
+		$files = $this->resolver->resolveRegistered( array(
+			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertArrayHasKey( 'SOUL.md', $files );
+		$this->assertArrayHasKey( 'CHAT_ONLY.md', $files );
+		$this->assertArrayNotHasKey( 'MEMORY.md', $files );
+		$this->assertArrayNotHasKey( 'USER.md', $files );
+	}
+
+	public function test_agent_allow_only_narrows_to_listed_files(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'       => 'allow_only',
+			'allow_only' => array( 'SOUL.md' ),
+		) );
+
+		$files = $this->resolver->resolveRegistered( array(
+			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertArrayHasKey( 'SOUL.md', $files );
+		$this->assertArrayNotHasKey( 'MEMORY.md', $files );
+		$this->assertCount( 1, $files );
+	}
+
+	public function test_agent_allow_only_empty_returns_nothing(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'       => 'allow_only',
+			'allow_only' => array(),
+		) );
+
+		$files = $this->resolver->resolveRegistered( array(
+			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertSame( array(), $files );
+	}
+
+	public function test_agent_deny_empty_list_is_noop(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode' => 'deny',
+			'deny' => array(),
+		) );
+
+		$without = $this->resolver->resolveRegistered( array(
+			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
+		) );
+
+		$with = $this->resolver->resolveRegistered( array(
+			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertSame( $without, $with );
+	}
+
+	public function test_agent_allow_only_ignores_unknown_files(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'       => 'allow_only',
+			'allow_only' => array( 'SOUL.md', 'DOES_NOT_EXIST.md' ),
+		) );
+
+		$files = $this->resolver->resolveRegistered( array(
+			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
+			'agent_id' => $agent_id,
+		) );
+
+		$this->assertArrayHasKey( 'SOUL.md', $files );
+		$this->assertArrayNotHasKey( 'DOES_NOT_EXIST.md', $files );
+		$this->assertCount( 1, $files );
+	}
+
+	// ============================================
+	// Precedence: explicit deny wins over agent policy
+	// ============================================
+
+	public function test_explicit_deny_wins_over_agent_allow_only(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'       => 'allow_only',
+			'allow_only' => array( 'SOUL.md', 'MEMORY.md' ),
+		) );
+
+		$files = $this->resolver->resolveRegistered( array(
+			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
+			'agent_id' => $agent_id,
+			'deny'     => array( 'MEMORY.md' ),
+		) );
+
+		$this->assertArrayHasKey( 'SOUL.md', $files );
+		$this->assertArrayNotHasKey( 'MEMORY.md', $files );
+	}
+
+	// ============================================
+	// datamachine_resolved_memory_files filter
+	// ============================================
+
+	public function test_resolved_filter_fires_with_context_and_files(): void {
+		$captured = null;
+		add_filter(
+			'datamachine_resolved_memory_files',
+			function ( $files, $context_type, $context ) use ( &$captured ) {
+				$captured = array(
+					'files'        => $files,
+					'context_type' => $context_type,
+					'context'      => $context,
+				);
+				return $files;
+			},
+			10,
+			3
+		);
+
+		$this->resolver->resolveRegistered( array(
+			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
+			'agent_id' => 0,
+		) );
+
+		$this->assertNotNull( $captured );
+		$this->assertSame( MemoryPolicyResolver::CONTEXT_CHAT, $captured['context_type'] );
+		$this->assertArrayHasKey( 'SOUL.md', $captured['files'] );
+	}
+
+	public function test_resolved_filter_can_mutate_output(): void {
+		add_filter(
+			'datamachine_resolved_memory_files',
+			function ( $files ) {
+				unset( $files['SOUL.md'] );
+				return $files;
+			}
+		);
+
+		$files = $this->resolver->resolveRegistered( array(
+			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
+		) );
+
+		$this->assertArrayNotHasKey( 'SOUL.md', $files );
+		$this->assertArrayHasKey( 'MEMORY.md', $files );
+	}
+
+	// ============================================
+	// filter() — scoped filename lists (pipeline/flow)
+	// ============================================
+
+	public function test_filter_empty_list_is_noop(): void {
+		$this->assertSame( array(), $this->resolver->filter( array(), array() ) );
+	}
+
+	public function test_filter_no_agent_returns_input_order(): void {
+		$out = $this->resolver->filter(
+			array( 'a.md', 'b.md', 'c.md' ),
+			array()
+		);
+
+		$this->assertSame( array( 'a.md', 'b.md', 'c.md' ), $out );
+	}
+
+	public function test_filter_agent_deny_removes_files(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode' => 'deny',
+			'deny' => array( 'brand-voice.md' ),
+		) );
+
+		$out = $this->resolver->filter(
+			array( 'brand-voice.md', 'seo-checklist.md' ),
+			array( 'agent_id' => $agent_id )
+		);
+
+		$this->assertSame( array( 'seo-checklist.md' ), $out );
+	}
+
+	public function test_filter_agent_allow_only_narrows_list(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'       => 'allow_only',
+			'allow_only' => array( 'seo-checklist.md' ),
+		) );
+
+		$out = $this->resolver->filter(
+			array( 'brand-voice.md', 'seo-checklist.md', 'tone.md' ),
+			array( 'agent_id' => $agent_id )
+		);
+
+		$this->assertSame( array( 'seo-checklist.md' ), $out );
+	}
+
+	public function test_filter_explicit_deny_applies_after_agent_policy(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode' => 'deny',
+			'deny' => array( 'brand-voice.md' ),
+		) );
+
+		$out = $this->resolver->filter(
+			array( 'brand-voice.md', 'seo-checklist.md', 'tone.md' ),
+			array(
+				'agent_id' => $agent_id,
+				'deny'     => array( 'tone.md' ),
+			)
+		);
+
+		$this->assertSame( array( 'seo-checklist.md' ), $out );
+	}
+
+	public function test_scoped_filter_fires_for_filter_method(): void {
+		$captured = null;
+		add_filter(
+			'datamachine_resolved_scoped_memory_files',
+			function ( $filenames, $context ) use ( &$captured ) {
+				$captured = array(
+					'filenames' => $filenames,
+					'context'   => $context,
+				);
+				return $filenames;
+			},
+			10,
+			2
+		);
+
+		$this->resolver->filter(
+			array( 'a.md' ),
+			array( 'scope' => 'pipeline' )
+		);
+
+		$this->assertNotNull( $captured );
+		$this->assertSame( array( 'a.md' ), $captured['filenames'] );
+		$this->assertSame( 'pipeline', $captured['context']['scope'] );
+	}
+
+	// ============================================
+	// getAgentMemoryPolicy() — validation
+	// ============================================
+
+	public function test_get_policy_returns_null_for_invalid_agent_id(): void {
+		$this->assertNull( $this->resolver->getAgentMemoryPolicy( 0 ) );
+		$this->assertNull( $this->resolver->getAgentMemoryPolicy( -1 ) );
+		$this->assertNull( $this->resolver->getAgentMemoryPolicy( 999999 ) );
+	}
+
+	public function test_get_policy_returns_null_for_agent_without_policy(): void {
+		$agent_id = $this->createAgentWithPolicy( null );
+		$this->assertNull( $this->resolver->getAgentMemoryPolicy( $agent_id ) );
+	}
+
+	public function test_get_policy_returns_null_for_default_mode(): void {
+		$agent_id = $this->createAgentWithPolicy( array( 'mode' => 'default' ) );
+		$this->assertNull( $this->resolver->getAgentMemoryPolicy( $agent_id ) );
+	}
+
+	public function test_get_policy_returns_null_for_invalid_mode(): void {
+		$agent_id = $this->createAgentWithPolicy( array( 'mode' => 'nonsense' ) );
+		$this->assertNull( $this->resolver->getAgentMemoryPolicy( $agent_id ) );
+	}
+
+	public function test_get_policy_returns_null_for_deny_with_empty_list(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode' => 'deny',
+			'deny' => array(),
+		) );
+		$this->assertNull( $this->resolver->getAgentMemoryPolicy( $agent_id ) );
+	}
+
+	public function test_get_policy_returns_structure_for_valid_deny(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode' => 'deny',
+			'deny' => array( 'MEMORY.md' ),
+		) );
+
+		$policy = $this->resolver->getAgentMemoryPolicy( $agent_id );
+
+		$this->assertIsArray( $policy );
+		$this->assertSame( 'deny', $policy['mode'] );
+		$this->assertSame( array( 'MEMORY.md' ), $policy['deny'] );
+		$this->assertSame( array(), $policy['allow_only'] );
+	}
+
+	public function test_get_policy_returns_structure_for_valid_allow_only(): void {
+		$agent_id = $this->createAgentWithPolicy( array(
+			'mode'       => 'allow_only',
+			'allow_only' => array( 'SOUL.md' ),
+		) );
+
+		$policy = $this->resolver->getAgentMemoryPolicy( $agent_id );
+
+		$this->assertIsArray( $policy );
+		$this->assertSame( 'allow_only', $policy['mode'] );
+		$this->assertSame( array( 'SOUL.md' ), $policy['allow_only'] );
+		$this->assertSame( array(), $policy['deny'] );
+	}
+
+	// ============================================
+	// getContexts()
+	// ============================================
+
+	public function test_get_contexts_returns_all_three_presets(): void {
+		$contexts = MemoryPolicyResolver::getContexts();
+
+		$this->assertArrayHasKey( MemoryPolicyResolver::CONTEXT_PIPELINE, $contexts );
+		$this->assertArrayHasKey( MemoryPolicyResolver::CONTEXT_CHAT, $contexts );
+		$this->assertArrayHasKey( MemoryPolicyResolver::CONTEXT_SYSTEM, $contexts );
+	}
+
+	// ============================================
+	// Helpers
+	// ============================================
+
+	/**
+	 * Create a test agent with an optional memory policy.
+	 *
+	 * @param array|null $memory_policy The memory_policy to store, or null for no policy.
+	 * @return int Agent ID.
+	 */
+	private function createAgentWithPolicy( ?array $memory_policy ): int {
+		$agents_repo = new Agents();
+		$config      = array();
+
+		if ( null !== $memory_policy ) {
+			$config['memory_policy'] = $memory_policy;
+		}
+
+		$slug = 'test-agent-' . wp_generate_uuid4();
+
+		return $agents_repo->create_if_missing( $slug, 'Test Agent', 1, $config );
+	}
+}


### PR DESCRIPTION
## Summary

Introduces **MemoryPolicy** — a per-agent, declarative filter controlling which memory files inject into an AI call. It is the memory-side parallel to `ToolPolicyResolver`, and it layers on top of the existing memory injection systems (`MemoryFileRegistry`, `pipeline_config.memory_files`, `flow_config.memory_files`) rather than replacing them.

Closes #1099. Supersedes #502.

## Motivation

Not every agent needs the full memory stack. A wiki generator doesn't need `MEMORY.md` accumulating over time, and it doesn't need the operator's `USER.md` leaking into article output. Before this PR, suppressing memory required fragile workarounds (emptying files, forking the directive stack) with no declarative surface. MemoryPolicy gives stateless agents a first-class way to narrow or disable memory that travels with them through bundle export/import.

## What changes

### New: `DataMachine\Engine\AI\Memory\MemoryPolicyResolver`

Two public entry points:

- **`resolveRegistered( array $context ): array`** — returns a `filename => metadata` map of registered files after context filtering and per-agent policy are applied. Used by `CoreMemoryFilesDirective`. Preserves layer metadata so downstream readers (`AgentMemory`, `MemoryFilesReader`) continue to resolve directories correctly.
- **`filter( array $filenames, array $context ): array`** — filters an explicit filename list through the per-agent policy. Used by `PipelineMemoryFilesDirective` and `FlowMemoryFilesDirective`, so deny/allow_only applies uniformly across all three injection surfaces, not just registered core files.

### Routed: three existing directives

`CoreMemoryFilesDirective`, `PipelineMemoryFilesDirective`, and `FlowMemoryFilesDirective` now consult the resolver before reading files. No other behavior changes.

### New config: `agent_config.memory_policy`

```json
{
  "memory_policy": {
    "mode": "default"            // or "deny" or "allow_only"
  }
}
```

| Mode | Behavior |
|---|---|
| `default` | No restriction. Legacy behavior. Missing key is equivalent. |
| `deny` | All registered + scoped files EXCEPT those in `deny`. |
| `allow_only` | Only files in `allow_only`. Empty list means "nothing". |

### Precedence

Highest to lowest:

1. Explicit `deny` passed in the resolver call
2. Per-agent `memory_policy` deny
3. Per-agent `memory_policy` allow_only
4. Context-level `allow_only`
5. Registry context filter (honors per-file `contexts` metadata)

A `default`-mode policy short-circuits inside `getAgentMemoryPolicy()` so the filter pass is skipped entirely.

## Bundler compatibility

`memory_policy` travels with `agent_config` through `AgentBundler::export()` / `import()` automatically — bundled agents carry their memory posture with them. **No bundler changes required.**

## Extensibility

Two filters:

- `datamachine_resolved_memory_files` — fires at the end of `resolveRegistered()`. Receives `( $files, $context_type, $context )`.
- `datamachine_resolved_scoped_memory_files` — fires at the end of `filter()`. Receives `( $filenames, $context )`.

Use for cross-cutting policy (org-wide deny lists, environment overrides) without touching `agent_config`.

## Tests

29 new unit tests in `tests/Unit/AI/Memory/MemoryPolicyResolverTest.php`:

- Context filtering (chat/pipeline includes/excludes)
- Metadata preservation through the resolver
- Context-level deny and allow_only
- Per-agent default/deny/allow_only modes
- Empty list semantics (deny empty = no-op; allow_only empty = nothing)
- Unknown files in allow_only ignored
- Precedence: explicit deny wins over agent allow_only
- `filter()` path: empty lists, deny, allow_only, explicit deny
- Filter hooks fire with expected payloads
- `getAgentMemoryPolicy()` validation: invalid IDs, missing policy, invalid mode, no-op policies

**Full suite status:** 971 passed, 0 failed, 4 pre-existing skips. No regressions.

## Lint

The new files introduce zero lint findings. The existing `homeboy lint data-machine` baseline predates this PR and is unchanged by it.

## Docs

New file: `docs/core-system/memory-policy.md` — architecture, config shape, precedence, API, and relationship to ToolPolicy.

## Example: wiki-generator agent

```json
{
  "agent_config": {
    "memory_policy": {
      "mode": "deny",
      "deny": ["MEMORY.md", "USER.md"]
    }
  }
}
```

This agent still gets `SOUL.md`, `SITE.md`, `RULES.md`, context files, and any pipeline/flow memory — but never the personal-memory layer. Bundled and shared via `wp datamachine agents export`, this posture travels with the agent.

## Files changed

- `inc/Engine/AI/Memory/MemoryPolicyResolver.php` — new, ~280 lines
- `inc/Engine/AI/Directives/CoreMemoryFilesDirective.php` — route through resolver
- `inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php` — route through resolver
- `inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php` — route through resolver
- `tests/Unit/AI/Memory/MemoryPolicyResolverTest.php` — new, 29 tests
- `docs/core-system/memory-policy.md` — new

## Out of scope (follow-ups welcome)

- Admin UI picker for memory policy — CLI/JSON only in v1, matches how ToolPolicy shipped
- `wp datamachine agents policy <slug> --memory` CLI subcommand — configurable today via direct `agent_config` edit
- Converting `ConfigureStepModal`'s memory file selector to visualize effective-after-policy files
