### PR TITLE
docs: stabilize datamachine_duplicate_strategies extension point (#1074)

### DIFF
--- a/docs/core-system/abilities-api.md
+++ b/docs/core-system/abilities-api.md
@@ -214,6 +214,8 @@ Internal abilities for the pipeline execution engine.
 | `datamachine/check-duplicate` | Check if similar content exists as published post or in queue | `DuplicateCheck/DuplicateCheckAbility.php` |
 | `datamachine/titles-match` | Compare two titles for semantic equivalence using similarity engine | `DuplicateCheck/DuplicateCheckAbility.php` |
 
+> **Extensions:** `datamachine/check-duplicate` runs extension strategies before core's generic matching via the `datamachine_duplicate_strategies` filter. See [Duplicate Detection Filters](../development/hooks/core-filters.md#duplicate-detection-filters) for the strategy contract and registration example.
+
 ### Post Query (2 abilities)
 
 | Ability | Description | Location |

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -673,6 +673,142 @@ $data = apply_filters('datamachine_data_packet', $data, $packet_data, $flow_step
 **Return**: Boolean processed status
 
 
+## Duplicate Detection Filters
+
+### `datamachine_duplicate_strategies`
+
+**Since**: v0.39.0
+
+**Purpose**: Register domain-specific duplicate detection strategies for the `datamachine/check-duplicate` ability. Extensions use this to add post-type-specific matching logic (e.g., event identity via venue + date + ticket URL) that runs before core's generic title/source-URL strategies.
+
+**Parameters**:
+- `$strategies` (array) - Array of strategy definitions (see structure below)
+- `$post_type` (string) - The post type being checked
+
+**Return**: Array of strategy definitions
+
+**Strategy Definition Structure**:
+```php
+[
+    'id'        => 'event_identity_index',      // string, required. Stable id, surfaced as `strategy` in the ability result.
+    'post_type' => 'data_machine_events',       // string, required. Specific post type or '*' for all types.
+    'callback'  => [Strategy::class, 'check'],  // callable, required. See callback contract below.
+    'priority'  => 5,                           // int, optional (default: 50). Lower runs first.
+]
+```
+
+**Cascade Order**:
+1. Extension strategies registered on this filter (sorted by `priority`, lowest first).
+2. Core `published_post_source_url` match (exact source URL via `PostIdentityIndex`).
+3. Core `published_post` title match (similarity engine).
+4. Core `queue_item` Jaccard match (only when `scope` includes `queue`).
+
+First strategy to return a `duplicate` verdict short-circuits the cascade.
+
+**Callback Contract**:
+
+The callback receives the full ability input merged with normalized `title`, `post_type`, and `context`:
+
+```php
+function(array $input): ?array {
+    // $input['title']      string — incoming title
+    // $input['post_type']  string — resolved post type
+    // $input['context']    array  — domain-specific payload (venue, startDate, ticketUrl, ...)
+    // $input['source_url'] string — optional canonical source URL
+    // ...plus any other fields the caller passed to datamachine/check-duplicate
+}
+```
+
+Return `null` to pass (let the cascade continue), or an array with:
+
+```php
+[
+    'verdict'  => 'duplicate',              // string, required — must be 'duplicate' to short-circuit
+    'source'   => 'identity_index',         // string, optional — origin of the match
+    'match'    => [                         // array, required — match details
+        'post_id' => 123,
+        'title'   => 'Existing Post',
+        'url'     => 'https://example.com/existing',
+        // strategy-specific fields are allowed
+    ],
+    'reason'   => 'Matched existing ...',   // string, optional — human-readable explanation
+    'strategy' => 'event_identity_index',   // string, optional — overrides `id` in the final result
+]
+```
+
+Any non-`duplicate` verdict (or missing `verdict`) is treated as a pass.
+
+**Usage Example** (from `data-machine-events`):
+
+```php
+namespace DataMachineEvents\Core\DuplicateDetection;
+
+class EventDuplicateStrategy {
+
+    public static function register(): void {
+        add_filter( 'datamachine_duplicate_strategies', [ static::class, 'addStrategy' ] );
+    }
+
+    public static function addStrategy( array $strategies ): array {
+        $strategies[] = [
+            'id'        => 'event_identity_index',
+            'post_type' => 'data_machine_events',
+            'callback'  => [ static::class, 'check' ],
+            'priority'  => 5, // Run before core strategies.
+        ];
+        return $strategies;
+    }
+
+    public static function check( array $input ): ?array {
+        $title   = $input['title'] ?? '';
+        $context = $input['context'] ?? [];
+        $venue   = $context['venue'] ?? '';
+        $date    = $context['startDate'] ?? '';
+
+        if ( empty( $title ) || empty( $date ) ) {
+            return null;
+        }
+
+        // ... domain-specific lookup against PostIdentityIndex ...
+        $post_id = $this->lookup( $title, $venue, $date );
+
+        if ( ! $post_id ) {
+            return null;
+        }
+
+        return [
+            'verdict' => 'duplicate',
+            'source'  => 'identity_index',
+            'match'   => [
+                'post_id' => $post_id,
+                'title'   => get_the_title( $post_id ),
+                'url'     => get_permalink( $post_id ),
+            ],
+            'reason'  => 'Matched existing event via venue + date.',
+        ];
+    }
+}
+```
+
+**Working with `PostIdentityIndex`**:
+
+Core ships `DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex` — an indexed lookup table (post_id, source_url, title_hash, event-related columns) used by the core source-URL strategy. Extensions have three options:
+
+1. **Use the index** for lookups (indexed columns → fast). Safe for reading. See `EventDuplicateStrategy::findByTicketUrl()` for a canonical example.
+2. **Write to the index** via the same writers core uses (e.g., `EventIdentityWriter::syncIdentityRow()` in `data-machine-events`). Recommended when your extension owns a custom post type and wants fast identity lookups.
+3. **Maintain your own lookup** (e.g., an existing indexed column on `wp_posts` like `post_name` + `post_parent`). Valid for cases where the identity index would be redundant.
+
+There is no requirement to use `PostIdentityIndex` — the filter accepts any callback. Choose based on what's already indexed for your post type.
+
+**Stability**:
+
+This filter, the strategy definition shape, the callback signature, and the return array shape are considered a public API as of 0.39.0. They will not change in a backward-incompatible way without a deprecation cycle.
+
+**See Also**:
+- Source: `inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php::getStrategies()`
+- Canonical consumer: `data-machine-events/inc/Core/DuplicateDetection/EventDuplicateStrategy.php`
+- Ability docs: [datamachine/check-duplicate](../../ai-tools/) in ai-tools reference
+
 ## Files Repository Filters
 
 ### `datamachine_files_repository`

--- a/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php
+++ b/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php
@@ -310,9 +310,60 @@ class DuplicateCheckAbility {
 		/**
 		 * Filter the registered duplicate detection strategies.
 		 *
-		 * @since 0.39.0
+		 * Public extension point for registering domain-specific duplicate
+		 * detection strategies. Strategies run before core's published-post
+		 * title match and queue-item Jaccard match. First strategy to return
+		 * a `duplicate` verdict short-circuits the cascade.
 		 *
-		 * @param array  $strategies Array of strategy definitions.
+		 * ## Strategy definition shape
+		 *
+		 *     [
+		 *         'id'        => 'event_identity_index', // string, required. Stable id, used in `strategy` field of result.
+		 *         'post_type' => 'data_machine_events',  // string, required. Specific post type or '*' for all types.
+		 *         'callback'  => [Strategy::class, 'check'], // callable, required. Signature: function(array $input): ?array
+		 *         'priority'  => 5,                      // int, optional (default: 50). Lower runs first.
+		 *     ]
+		 *
+		 * ## Callback contract
+		 *
+		 * The callback receives the full ability input merged with normalized
+		 * `title`, `post_type`, and `context`:
+		 *
+		 *     function(array $input): ?array {
+		 *         // $input['title']     string  — incoming title
+		 *         // $input['post_type'] string  — resolved post type
+		 *         // $input['context']   array   — domain-specific payload (venue, startDate, etc.)
+		 *         // $input['source_url'] string — optional canonical source URL
+		 *         // ...plus any other fields the caller passed
+		 *     }
+		 *
+		 * Return `null` to pass (let the cascade continue), or an array with:
+		 *
+		 *     [
+		 *         'verdict'  => 'duplicate',          // string, required — must be 'duplicate' to short-circuit
+		 *         'source'   => 'identity_index',     // string, optional — origin of the match
+		 *         'match'    => [                     // array, required — match details
+		 *             'post_id' => 123,
+		 *             'title'   => 'Existing Post',
+		 *             'url'     => 'https://example.com/existing',
+		 *             // ...strategy-specific fields allowed
+		 *         ],
+		 *         'reason'   => 'Matched existing ...', // string, optional — human-readable explanation
+		 *         'strategy' => 'event_identity_index', // string, optional — overrides 'id' in the result
+		 *     ]
+		 *
+		 * Any non-`duplicate` verdict (or missing `verdict`) is treated as a pass.
+		 *
+		 * ## Stability
+		 *
+		 * This filter and the strategy contract above are considered a public
+		 * API as of 0.39.0. The callback signature, return shape, and the
+		 * input fields documented above will not change in a backward-incompatible
+		 * way without a deprecation cycle.
+		 *
+		 * @since 0.39.0 Public extension point.
+		 *
+		 * @param array  $strategies Array of strategy definitions (see shape above).
 		 * @param string $post_type  The post type being checked.
 		 */
 		$strategies = apply_filters( 'datamachine_duplicate_strategies', array(), $post_type );


### PR DESCRIPTION
Closes #1074.

## Summary

Promotes `datamachine_duplicate_strategies` from implementation detail to **documented public API**. No behavior changes — the filter and ability work today and will continue to work the same way.

## Changes

**`inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php`**
- Expanded the `apply_filters( 'datamachine_duplicate_strategies', ... )` docblock with the full strategy shape, callback signature (`function(array $input): ?array`), input field contract, and return array contract.
- Explicit **stability promise** from 0.39.0: shape will not change in a backward-incompatible way without a deprecation cycle.

**`docs/development/hooks/core-filters.md`**
- New `## Duplicate Detection Filters` section covering:
  - Cascade order (extension strategies → source URL → title similarity → queue Jaccard)
  - Strategy definition structure + callback contract
  - Full working example lifted from `data-machine-events`' `EventDuplicateStrategy`
  - `PostIdentityIndex` guidance: three options (use / write / maintain your own)
  - Stability statement

**`docs/core-system/abilities-api.md`**
- Added cross-link note under the Duplicate Check ability table so the extension point is discoverable from the ability reference.

## Acceptance checklist (from the issue)

- [x] Docs section explaining strategy registration with a minimal example
- [x] Explicit `@since` on the filter's docblock confirming public-API promise
- [x] Confirmation that the strategy callback signature + return shape is frozen for external consumers

## Why now

Unblocks third-party extensions that want to register against a stable contract, starting with intelligence's `WikiDuplicateStrategy` for the `wiki` CPT. The `data-machine-events` strategy proves the contract end-to-end; this PR makes that contract an intentional public surface instead of an implementation detail.

## Non-goals

- No code behavior changes
- No rewrite of the ability or strategy cascade
- No changes to `PostIdentityIndex` — guidance only