### PR TITLE
refactor: rename executeUpdate() → executeUpsert() to complete upsert rename

### DIFF
--- a/inc/Core/Steps/Upsert/Handlers/UpsertHandler.php
+++ b/inc/Core/Steps/Upsert/Handlers/UpsertHandler.php
@@ -2,7 +2,7 @@
 /**
  * Base class for Update handlers providing standardized engine data access.
  *
- * Post tracking is automatic — after executeUpdate() returns a successful
+ * Post tracking is automatic — after executeUpsert() returns a successful
  * result with a post_id, the base class writes origin metadata (handler,
  * flow, pipeline) without any action needed from subclasses.
  *
@@ -46,18 +46,18 @@ abstract class UpsertHandler {
 	}
 
 	/**
-	 * Execute update operation.
+	 * Execute upsert operation.
 	 *
 	 * @param array $parameters Tool parameters including job_id
 	 * @param array $handler_config Handler configuration
 	 * @return array Success/failure response
 	 */
-	abstract protected function executeUpdate( array $parameters, array $handler_config ): array;
+	abstract protected function executeUpsert( array $parameters, array $handler_config ): array;
 
 	/**
 	 * Handle tool call with job_id validation and automatic post tracking.
 	 *
-	 * After executeUpdate() returns, if the result is successful and contains
+	 * After executeUpsert() returns, if the result is successful and contains
 	 * a post_id, origin metadata is written automatically. Subclasses never
 	 * need to call any tracking methods.
 	 *
@@ -80,7 +80,7 @@ abstract class UpsertHandler {
 		$parameters['engine'] = $engine;
 
 		$handler_config = $tool_def['handler_config'] ?? array();
-		$result         = $this->executeUpdate( $parameters, $handler_config );
+		$result         = $this->executeUpsert( $parameters, $handler_config );
 
 		// Post origin tracking is applied centrally in ToolExecutor::executeTool()
 		// after every tool call — handler tools and ability tools share the same

--- a/inc/Core/Steps/Upsert/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Upsert/Handlers/WordPress/WordPress.php
@@ -103,7 +103,7 @@ class WordPress extends UpsertHandler {
 		return $tools;
 	}
 
-	protected function executeUpdate( array $parameters, array $handler_config ): array {
+	protected function executeUpsert( array $parameters, array $handler_config ): array {
 		$job_id     = $parameters['job_id'] ?? null;
 		$source_url = $parameters['source_url'] ?? '';
 


### PR DESCRIPTION
## Summary

PR #1097 renamed the step type from `update` to `upsert` across the codebase:
- `UpdateHandler` → `UpsertHandler`
- `inc/Core/Steps/Update/` → `inc/Core/Steps/Upsert/`
- step type slug `'update'` → `'upsert'`

But the abstract method was left as `executeUpdate()`. This PR completes the rename so the method name matches the class and step-type naming.

## Changes

- `UpsertHandler::executeUpdate()` → `UpsertHandler::executeUpsert()` (abstract method)
- `UpsertHandler::handle_tool_call()` calls updated to use new name
- Internal docblocks updated to reference `executeUpsert()`
- Core WordPress handler (`WordPress\WordPress.php`) updated to override `executeUpsert()`

## Breaking Change

Any handler extending `UpsertHandler` must rename their override method:
```php
// Before
protected function executeUpdate( array $parameters, array $handler_config ): array {

// After
protected function executeUpsert( array $parameters, array $handler_config ): array {
```

## Coordinated Changes

Companion PRs update extension handlers:
- `data-machine-code`: `GitHubUpsert::executeUpdate()` → `executeUpsert()`
- `data-machine-events`: `EventUpsert::executeUpdate()` → `executeUpsert()`

All three should be released and deployed together.

## Non-Breaking

Other `executeUpdate*()` methods across the codebase (ability classes for updating pipelines, flows, steps, settings, taxonomies) are CRUD update operations and remain unchanged — those are unrelated to the upsert handler pattern.