### PR TITLE
refactor: remove dead legacy fan-out skip path from UpsertStep

### DIFF
--- a/inc/Core/Steps/Upsert/UpsertStep.php
+++ b/inc/Core/Steps/Upsert/UpsertStep.php
@@ -86,26 +86,6 @@ class UpsertStep extends Step {
 			return $this->create_update_entry_from_tool_result( $tool_result_entry, $this->dataPackets, $primary_handler_slug, $this->flow_step_id );
 		}
 
-		// Legacy fan-out skip: kept as a narrow safety net for the pre-batch
-		// fan-out model where multiple packets landed in the same job and only
-		// one sibling carried the handler result. Batch children created by
-		// PipelineBatchScheduler each carry their own ai_handler_complete
-		// packet — if a batch child reaches this branch with missing handler
-		// data, that's a real failure (upstream filtering regression or handler
-		// tool not called) and should be logged as such, not silenced.
-		if ( $this->isLegacyFanOutChild() ) {
-			$this->log(
-				'debug',
-				'Legacy fan-out child missing handler result (sibling handled it)',
-				array(
-					'required_handler_slugs'    => $required_handler_slugs,
-					'missing_required_handlers' => $missing_required_handlers,
-				)
-			);
-
-			return $this->buildFanOutSkipPacket( $configured_handler_slugs, $required_handler_slugs, $missing_required_handlers );
-		}
-
 		$this->log(
 			'warning',
 			'Upsert step required handler tool was not executed by AI',
@@ -220,85 +200,6 @@ class UpsertStep extends Step {
 		);
 
 		return $packet->addTo( $dataPackets );
-	}
-
-	/**
-	 * Check if this job is a LEGACY fan-out child that should silently skip.
-	 *
-	 * Two scenarios produce a job with parent_job_id:
-	 *
-	 * 1. Legacy fan-out: multiple packets landed in the same job and only
-	 *    one sibling carried the handler result. Missing handler data is
-	 *    expected for the other siblings — skip silently.
-	 *
-	 * 2. PipelineBatchScheduler child: each child job gets its OWN packet
-	 *    with its own ai_handler_complete metadata. If such a child reaches
-	 *    this branch with missing handler data, that's a real failure
-	 *    (upstream filtering regression or AI didn't call the handler tool)
-	 *    and must NOT be silenced — the item should be retried, not
-	 *    marked completed_no_items.
-	 *
-	 * Batch children are identifiable because their parent's engine_data
-	 * carries the 'batch' flag set by PipelineBatchScheduler::fanOut().
-	 * Presence of that flag means we're the non-legacy case and should
-	 * fall through to the normal failure path.
-	 *
-	 * @return bool True only for legacy fan-out children that should skip silently.
-	 */
-	private function isLegacyFanOutChild(): bool {
-		$engine_data = $this->engine_data ?? array();
-		$job_context = $engine_data['job'] ?? array();
-		$parent_id   = $job_context['parent_job_id'] ?? null;
-
-		if ( empty( $parent_id ) ) {
-			return false;
-		}
-
-		// If the parent is a batch parent (PipelineBatchScheduler), this child
-		// owns its own packet and a missing handler result is a real failure.
-		$parent_engine = datamachine_get_engine_data( (int) $parent_id );
-		if ( ! empty( $parent_engine['batch'] ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Build a skip packet for fan-out children that don't have the handler result.
-	 *
-	 * Uses status_override = 'completed_no_items' so the routing layer
-	 * completes the job silently instead of logging a noisy failure.
-	 *
-	 * @param array $configured_handler_slugs Configured handler slugs.
-	 * @param array $required_handler_slugs   Required handler slugs.
-	 * @param array $missing_required_handlers Missing required handlers.
-	 * @return array
-	 */
-	private function buildFanOutSkipPacket( array $configured_handler_slugs, array $required_handler_slugs, array $missing_required_handlers ): array {
-		// Set job_status override in engine_data so the routing layer
-		// completes with 'completed_no_items' instead of a generic 'completed'.
-		datamachine_merge_engine_data( $this->job_id, array(
-			'job_status' => 'completed_no_items',
-		) );
-
-		$packet = new DataPacket(
-			array(
-				'update_result' => array(),
-				'updated_at'    => current_time( 'mysql', true ),
-			),
-			array(
-				'step_type'                 => 'upsert',
-				'handler'                   => $required_handler_slugs[0] ?? ( $configured_handler_slugs[0] ?? '' ),
-				'flow_step_id'              => $this->flow_step_id,
-				'success'                   => true,
-				'fanout_sibling_handled'    => true,
-				'missing_required_handlers' => $missing_required_handlers,
-			),
-			'upsert'
-		);
-
-		return $packet->addTo( $this->dataPackets );
 	}
 
 	/**

--- a/tests/Unit/Core/Steps/Upsert/UpsertStepTest.php
+++ b/tests/Unit/Core/Steps/Upsert/UpsertStepTest.php
@@ -118,15 +118,12 @@ class UpsertStepTest extends WP_UnitTestCase {
 	/**
 	 * Regression test for issue #1096.
 	 *
-	 * Batch children created by PipelineBatchScheduler each carry their own
-	 * ai_handler_complete packet. If such a child reaches UpsertStep without
-	 * the expected handler result (e.g. upstream filter regression or AI not
-	 * calling the handler tool), it must NOT be silenced via the legacy
-	 * fan-out skip path — that produced 8,030 orphaned jobs with status
-	 * 'completed_no_items' across 7 days on events.extrachill.com.
-	 *
-	 * The parent job's engine_data['batch'] flag is the signal that this
-	 * child owns its own packet (set by PipelineBatchScheduler::fanOut()).
+	 * A missing handler result at the upsert step is always a real failure —
+	 * there is no longer a silent-skip path. Every child job created by
+	 * PipelineBatchScheduler carries its own packet, so a missing handler
+	 * result means the AI didn't call the tool (or an upstream filter
+	 * regression dropped it). The legacy "sibling handled it" fan-out model
+	 * has been removed entirely; see commit removing isLegacyFanOutChild().
 	 */
 	public function test_batch_child_with_missing_handler_produces_real_failure(): void {
 		$parent_job_id = 999001;
@@ -177,46 +174,5 @@ class UpsertStepTest extends WP_UnitTestCase {
 
 		// Clean up engine data.
 		datamachine_set_engine_data( $parent_job_id, array() );
-	}
-
-	/**
-	 * Legacy fan-out siblings (no batch flag on parent) still skip silently.
-	 *
-	 * Preserves the original safety-net behavior for the legacy fan-out model
-	 * where multiple packets land in one job and only one sibling owns the
-	 * handler result.
-	 */
-	public function test_legacy_fanout_child_without_batch_parent_skips_silently(): void {
-		$parent_job_id = 999003;
-		$child_job_id  = 999004;
-
-		// Parent has NO batch flag — legacy fan-out scenario.
-		datamachine_set_engine_data( $parent_job_id, array() );
-
-		$step = new UpsertStep();
-
-		$result = $step->execute(
-			$this->buildPayload(
-				array(
-					'handler_slugs'   => array( 'upsert_event' ),
-					'handler_configs' => array(),
-				),
-				array(),
-				array(
-					'job_id'        => $child_job_id,
-					'parent_job_id' => $parent_job_id,
-				)
-			)
-		);
-
-		$this->assertNotEmpty( $result );
-		$last = $result[ array_key_last( $result ) ];
-
-		$this->assertSame( 'upsert', $last['type'] ?? '' );
-		$this->assertTrue(
-			(bool) ( $last['metadata']['fanout_sibling_handled'] ?? false ),
-			'Legacy fan-out children should still skip silently as a safety net.'
-		);
-		$this->assertTrue( (bool) ( $last['metadata']['success'] ?? false ) );
 	}
 }


### PR DESCRIPTION
## Summary

The `isLegacyFanOutChild()` / `buildFanOutSkipPacket()` code path in `UpsertStep` was kept as a "narrow safety net" after the #1096 fix. Reviewing the actual fan-out surface, that safety net catches a scenario that cannot happen anymore. Deleting it.

## Why it's dead code

Only two places in the codebase set `parent_job_id`:

1. **`PipelineBatchScheduler`** — writes `engine_data['batch'] = true` on the parent. `isLegacyFanOutChild()` explicitly returns `false` when the batch flag is set, so batch children never hit the skip path.
2. **`SystemTaskStep`** — creates tracking jobs for system tasks. These don't invoke `UpsertStep`.

There is no remaining producer of "legacy fan-out" children where multiple packets land in the same job and only one sibling carries the handler result. The safety net guards against nothing.

## What it was silencing

Any job that reached `UpsertStep` with a missing handler result but wasn't a batch child got marked `completed_no_items` with `fanout_sibling_handled: true`. In practice today that only fires when something unexpected happens — and we should hear about that, not swallow it.

## Changes

- Removed `UpsertStep::isLegacyFanOutChild()` (35 lines)
- Removed `UpsertStep::buildFanOutSkipPacket()` (25 lines)
- Removed the skip branch from `executeStep()` (20 lines + comment)
- Removed `test_legacy_fanout_child_without_batch_parent_skips_silently` test
- Updated comment on the remaining `test_batch_child_with_missing_handler_produces_real_failure` — the assertion now covers **all** missing-handler scenarios, not just batch children

Net: -149 lines, +6 lines.

## Behavior change

Before: unexpected parent-without-batch-flag jobs → silent `completed_no_items`
After: any missing handler result at upsert → loud failure → retried naturally by the processed-items system

This is a fail-loud refactor. Any code path that was secretly relying on the skip will now surface as a real failure in jobs, which is what we want.