### PR TITLE
Fix AI conversation never completing due to non-AI handler slugs in completion gate

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -693,6 +693,14 @@ class ExecuteStepAbility {
 	 * pre-#1096 implementation filtered on metadata.source_type, which was a
 	 * silent no-op that let every packet fan out into doomed child jobs.
 	 *
+	 * After filtering to handler packets, duplicates are removed. When the
+	 * AI conversation loop fails to terminate early (e.g. misconfigured
+	 * handler_slugs), the AI may call the same handler tool multiple times
+	 * across turns, producing duplicate ai_handler_complete packets. These
+	 * would fan out into child jobs that all process the same data.
+	 * Dedup keeps only the first packet per handler tool name.
+	 * See: https://github.com/Extra-Chill/data-machine/issues/1108
+	 *
 	 * If filtering removes all packets, the originals are returned unchanged
 	 * — the step may not require handlers, or the packets may use a different
 	 * convention (backward compatibility).
@@ -710,7 +718,38 @@ class ExecuteStepAbility {
 			)
 		);
 
-		return ! empty( $handler_packets ) ? $handler_packets : $dataPackets;
+		if ( empty( $handler_packets ) ) {
+			return $dataPackets;
+		}
+
+		// Deduplicate handler packets by tool_name. When the AI calls
+		// the same handler tool multiple times (e.g. upsert_event called
+		// on consecutive turns because the conversation didn't terminate),
+		// each call produces a separate ai_handler_complete packet with
+		// the same tool_name but possibly varied parameters. Only the
+		// first invocation per tool_name is kept — subsequent duplicates
+		// would create child jobs processing identical data.
+		$seen_tools = array();
+		$deduped    = array();
+
+		foreach ( $handler_packets as $packet ) {
+			$tool_name = $packet['metadata']['tool_name'] ?? '';
+
+			if ( '' === $tool_name ) {
+				// No tool_name — keep unconditionally.
+				$deduped[] = $packet;
+				continue;
+			}
+
+			if ( isset( $seen_tools[ $tool_name ] ) ) {
+				continue;
+			}
+
+			$seen_tools[ $tool_name ] = true;
+			$deduped[]                = $packet;
+		}
+
+		return $deduped;
 	}
 
 	/**

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -247,11 +247,6 @@ class AIStep extends Step {
 			$handler_slugs     = $adj_step_config['handler_slugs'] ?? array();
 			$all_handler_slugs = array_merge( $all_handler_slugs, $handler_slugs );
 		}
-		if ( ! empty( $all_handler_slugs ) ) {
-			$payload['flow_step_config'] = array(
-				'handler_slugs' => array_unique( $all_handler_slugs ),
-			);
-		}
 
 		$engine_data = $this->engine->all();
 
@@ -272,6 +267,26 @@ class AIStep extends Step {
 			'engine_data'          => $engine_data,
 			'categories'           => $tool_categories,
 		) );
+
+		// Filter handler slugs to only those that are actual AI tools.
+		// Previous-step handler slugs (e.g. 'universal_web_scraper') are
+		// pipeline-level fetch handlers, not AI-callable tools. Including
+		// them in configured_handlers causes the conversation loop to wait
+		// forever for a handler that can never fire, resulting in the AI
+		// calling the same handler tool on every turn until max_turns.
+		// See: https://github.com/Extra-Chill/data-machine/issues/1108
+		if ( ! empty( $all_handler_slugs ) ) {
+			$ai_tool_handler_slugs = array_values( array_intersect(
+				array_unique( $all_handler_slugs ),
+				array_keys( $available_tools )
+			) );
+
+			if ( ! empty( $ai_tool_handler_slugs ) ) {
+				$payload['flow_step_config'] = array(
+					'handler_slugs' => $ai_tool_handler_slugs,
+				);
+			}
+		}
 
 		// Model/provider resolved exclusively via context system — pipeline config is ignored.
 		$context_model = PluginSettings::resolveModelForAgentContext( $agent_id, 'pipeline' );

--- a/tests/Unit/Abilities/Engine/ExecuteStepFanOutFilterTest.php
+++ b/tests/Unit/Abilities/Engine/ExecuteStepFanOutFilterTest.php
@@ -57,20 +57,59 @@ class ExecuteStepFanOutFilterTest extends WP_UnitTestCase {
 		$this->assertSame( 'ai_handler_complete', $filtered[0]['type'] );
 	}
 
-	public function test_filter_preserves_multiple_ai_handler_complete_packets(): void {
+	/**
+	 * When the AI calls different handler tools, each gets its own child job.
+	 * Multi-handler pipelines (e.g. upsert_event + publish_post) need this.
+	 */
+	public function test_filter_preserves_packets_with_different_tool_names(): void {
 		$packets = array(
-			$this->make_packet( 'ai_handler_complete', array( 'handler_tool' => 'upsert_event' ) ),
-			$this->make_packet( 'ai_handler_complete', array( 'handler_tool' => 'upsert_event' ) ),
-			$this->make_packet( 'ai_handler_complete', array( 'handler_tool' => 'upsert_event' ) ),
+			$this->make_packet( 'ai_handler_complete', array( 'tool_name' => 'upsert_event', 'handler_tool' => 'upsert_event' ) ),
+			$this->make_packet( 'ai_handler_complete', array( 'tool_name' => 'publish_post', 'handler_tool' => 'publish_post' ) ),
 			$this->make_packet( 'tool_result', array( 'tool_name' => 'search' ) ),
 		);
 
 		$filtered = ExecuteStepAbility::filterPacketsForFanOut( $packets );
 
-		$this->assertCount( 3, $filtered );
-		foreach ( $filtered as $packet ) {
-			$this->assertSame( 'ai_handler_complete', $packet['type'] );
-		}
+		$this->assertCount( 2, $filtered );
+		$this->assertSame( 'upsert_event', $filtered[0]['metadata']['tool_name'] );
+		$this->assertSame( 'publish_post', $filtered[1]['metadata']['tool_name'] );
+	}
+
+	/**
+	 * Regression test for #1108: when the AI calls the same handler tool
+	 * multiple times (e.g. conversation loop didn't terminate), duplicate
+	 * ai_handler_complete packets must be collapsed to one per tool_name.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine/issues/1108
+	 */
+	public function test_filter_deduplicates_same_tool_name_handler_packets(): void {
+		$packets = array(
+			$this->make_packet( 'ai_handler_complete', array( 'tool_name' => 'upsert_event', 'handler_tool' => 'upsert_event' ) ),
+			$this->make_packet( 'ai_handler_complete', array( 'tool_name' => 'upsert_event', 'handler_tool' => 'upsert_event' ) ),
+			$this->make_packet( 'ai_handler_complete', array( 'tool_name' => 'upsert_event', 'handler_tool' => 'upsert_event' ) ),
+			$this->make_packet( 'tool_result', array( 'tool_name' => 'search' ) ),
+		);
+
+		$filtered = ExecuteStepAbility::filterPacketsForFanOut( $packets );
+
+		$this->assertCount( 1, $filtered, 'Duplicate handler tool calls should be collapsed to one per tool_name' );
+		$this->assertSame( 'ai_handler_complete', $filtered[0]['type'] );
+		$this->assertSame( 'upsert_event', $filtered[0]['metadata']['tool_name'] );
+	}
+
+	/**
+	 * Handler packets without a tool_name should be kept unconditionally
+	 * for backward compatibility.
+	 */
+	public function test_filter_keeps_handler_packets_without_tool_name(): void {
+		$packets = array(
+			$this->make_packet( 'ai_handler_complete', array( 'handler_tool' => 'upsert_event' ) ),
+			$this->make_packet( 'ai_handler_complete', array( 'handler_tool' => 'upsert_event' ) ),
+		);
+
+		$filtered = ExecuteStepAbility::filterPacketsForFanOut( $packets );
+
+		$this->assertCount( 2, $filtered, 'Packets without tool_name cannot be deduped and should pass through' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes the AI conversation loop never terminating when `configured_handlers` includes non-AI handler slugs (e.g. fetch handlers from adjacent steps).

- **Primary fix**: Filter `all_handler_slugs` against `$available_tools` keys so only AI-callable handlers gate conversation completion
- **Safety net**: Deduplicate `ai_handler_complete` packets by `tool_name` in `filterPacketsForFanOut()` so runaway conversations produce at most one child job per handler tool

## Root Cause

`AIStep::executeStep()` collected `handler_slugs` from both previous and next step configs. For `event_import → ai → upsert` flows, this produced `configured_handlers = ['universal_web_scraper', 'upsert_event']`. The `AIConversationLoop` waited for ALL configured handlers to fire, but `universal_web_scraper` is a fetch handler that never exists as an AI tool — so the conversation never completed, looping through `max_turns` and calling `upsert_event` on every turn.

## Scope

- **8,251** affected batch parents
- **38,258** duplicate child jobs  
- **~302M tokens** consumed on events.extrachill.com since January 2026

## Changes

| File | Change |
|------|--------|
| `inc/Core/Steps/AI/AIStep.php` | Filter handler_slugs against available AI tools before passing to conversation loop |
| `inc/Abilities/Engine/ExecuteStepAbility.php` | Dedup `ai_handler_complete` packets by `tool_name` in `filterPacketsForFanOut()` |
| `tests/Unit/Abilities/Engine/ExecuteStepFanOutFilterTest.php` | Updated + new tests for dedup behavior |

Closes #1108