### PR TITLE
feat(agents): multi-agent DB primitives + REST list bugfixes

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -500,8 +500,7 @@ class AgentAbilities {
 
 			// For limits > 1, count all agents owned by this user.
 			if ( $max_agents > 1 ) {
-				$all_agents = $agents_repo->get_all();
-				$owned      = array_filter( $all_agents, fn( $a ) => (int) $a['owner_id'] === $owner_id );
+				$owned = $agents_repo->get_all_by_owner_id( $owner_id );
 
 				if ( count( $owned ) >= $max_agents ) {
 					return array(

--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -454,6 +454,43 @@ class PermissionHelper {
 	}
 
 	/**
+	 * Resolve all agent IDs the acting user can access.
+	 *
+	 * Multi-agent companion to {@see self::resolve_scoped_agent_id()}. Returns
+	 * the union of agents the user OWNS plus agents granted to them via the
+	 * access table. Admins (callers with the given $action capability) get an
+	 * empty array, which by convention means "no scoping — see everything."
+	 *
+	 * @since 0.69.2
+	 *
+	 * @param string $action Action key for admin check (default: 'manage_flows').
+	 * @return int[] Agent IDs the user can access. Empty array for admins
+	 *               (no scoping) OR for unauthenticated callers (no access).
+	 *               Use {@see self::can()} to disambiguate if needed.
+	 */
+	public static function resolve_all_accessible_agent_ids( string $action = 'manage_flows' ): array {
+		// Admins get no scoping — empty array signals "see everything."
+		if ( self::can( $action ) ) {
+			return array();
+		}
+
+		$user_id = self::acting_user_id();
+
+		if ( $user_id <= 0 ) {
+			return array();
+		}
+
+		$agents_repo = new \DataMachine\Core\Database\Agents\Agents();
+		$owned       = $agents_repo->get_all_by_owner_id( $user_id );
+		$owned_ids   = array_map( static fn( $a ) => (int) $a['agent_id'], $owned );
+
+		$access_repo    = new \DataMachine\Core\Database\Agents\AgentAccess();
+		$accessible_ids = $access_repo->get_agent_ids_for_user( $user_id );
+
+		return array_values( array_unique( array_merge( $owned_ids, array_map( 'intval', $accessible_ids ) ) ) );
+	}
+
+	/**
 	 * Check if the acting user can access an agent.
 	 *
 	 * Returns true if:

--- a/inc/Api/Agents.php
+++ b/inc/Api/Agents.php
@@ -385,17 +385,27 @@ class Agents {
 	 */
 	public static function handle_list( WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		$agents_repo  = new AgentsRepository();
+		$access_repo  = new AgentAccess();
 		$user_id      = get_current_user_id();
 		$current_site = get_current_blog_id();
+		$is_admin     = PermissionHelper::can( 'manage_agents' );
 
-		if ( PermissionHelper::can( 'manage_agents' ) ) {
+		if ( $is_admin ) {
 			// Admins see agents scoped to the current site + network-wide agents.
 			$all_agents = $agents_repo->get_all( array( 'site_id' => $current_site ) );
 		} else {
-			$access_repo    = new AgentAccess();
-			$accessible_ids = $access_repo->get_agent_ids_for_user( $user_id );
+			// Non-admin: union of OWNED agents and ACCESS-GRANTED agents.
+			//
+			// The owner relationship lives on `datamachine_agents.owner_id` —
+			// not in `agent_access` — so a missing access grant (race, migration
+			// gap, manual DB edit) used to cause owners to vanish from their own
+			// list. Merging here is the source-of-truth fix for that bug.
+			$owned_agents   = $agents_repo->get_all_by_owner_id( $user_id );
+			$owned_ids      = array_map( static fn( $a ) => (int) $a['agent_id'], $owned_agents );
+			$accessible_ids = array_map( 'intval', $access_repo->get_agent_ids_for_user( $user_id ) );
+			$all_ids        = array_values( array_unique( array_merge( $owned_ids, $accessible_ids ) ) );
 
-			if ( empty( $accessible_ids ) ) {
+			if ( empty( $all_ids ) ) {
 				return rest_ensure_response(
 					array(
 						'success' => true,
@@ -404,14 +414,12 @@ class Agents {
 				);
 			}
 
-			// Filter accessible agents by site scope (current site + network-wide).
-			$all_agents = array();
-			foreach ( $accessible_ids as $agent_id ) {
-				$agent = $agents_repo->get_agent( $agent_id );
-				if ( ! $agent ) {
-					continue;
-				}
+			// Single batched query replaces the previous N+1 get_agent() loop.
+			$candidate_agents = $agents_repo->get_agents_by_ids( $all_ids );
 
+			// Apply site scoping (current site + network-wide).
+			$all_agents = array();
+			foreach ( $candidate_agents as $agent ) {
 				$scope = $agent['site_scope'] ?? null;
 				if ( null === $scope || (int) $scope === $current_site ) {
 					$all_agents[] = $agent;
@@ -421,7 +429,24 @@ class Agents {
 
 		$data = array();
 		foreach ( $all_agents as $agent ) {
-			$data[] = self::shape_list_item( $agent );
+			// Resolve the requesting user's role on this agent so the frontend
+			// can make UI decisions (show edit button, hide config tab, etc.).
+			// Owners are normalized to 'admin' even when no explicit access row
+			// exists, so the frontend has a single role enum to switch on.
+			$user_role = null;
+
+			if ( $is_admin ) {
+				$user_role = 'admin';
+			} elseif ( (int) $agent['owner_id'] === $user_id ) {
+				$user_role = 'admin';
+			} else {
+				$grant = $access_repo->get_access( (int) $agent['agent_id'], $user_id );
+				if ( $grant && isset( $grant['role'] ) ) {
+					$user_role = (string) $grant['role'];
+				}
+			}
+
+			$data[] = self::shape_list_item( $agent, $user_role );
 		}
 
 		return rest_ensure_response(
@@ -803,12 +828,17 @@ class Agents {
 	 *
 	 * @since 0.41.0
 	 * @since 0.57.0 Added site_scope to output.
+	 * @since 0.69.2 Added user_role for frontend role-based UI decisions.
 	 *
-	 * @param array $agent Agent database row.
+	 * @param array       $agent     Agent database row.
+	 * @param string|null $user_role The requesting user's role on this agent
+	 *                               (admin/operator/viewer). Owners and admin
+	 *                               capability holders are normalized to 'admin'.
+	 *                               Null when not resolved.
 	 * @return array Shaped output.
 	 */
-	private static function shape_list_item( array $agent ): array {
-		return array(
+	private static function shape_list_item( array $agent, ?string $user_role = null ): array {
+		$item = array(
 			'agent_id'   => (int) $agent['agent_id'],
 			'agent_slug' => (string) $agent['agent_slug'],
 			'agent_name' => (string) $agent['agent_name'],
@@ -818,6 +848,12 @@ class Agents {
 			'created_at' => $agent['created_at'] ?? '',
 			'updated_at' => $agent['updated_at'] ?? '',
 		);
+
+		if ( null !== $user_role ) {
+			$item['user_role'] = $user_role;
+		}
+
+		return $item;
 	}
 
 	/**

--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -118,6 +118,9 @@ class Agents extends BaseRepository {
 	/**
 	 * Get agent by owner ID.
 	 *
+	 * Returns the first agent owned by the user (oldest by agent_id). For
+	 * multi-agent contexts, prefer {@see self::get_all_by_owner_id()}.
+	 *
 	 * @param int $owner_id Owner user ID.
 	 * @return array|null
 	 */
@@ -142,6 +145,101 @@ class Agents extends BaseRepository {
 		}
 
 		return $row;
+	}
+
+	/**
+	 * Get all agents owned by a user.
+	 *
+	 * Replaces the legacy `get_all() + array_filter()` pattern. Issues a single
+	 * indexed query against the `owner_id` key instead of fetching the whole
+	 * table and filtering in PHP.
+	 *
+	 * @since 0.69.2
+	 *
+	 * @param int $owner_id Owner user ID.
+	 * @return array List of agent rows owned by the user (may be empty).
+	 */
+	public function get_all_by_owner_id( int $owner_id ): array {
+		if ( $owner_id <= 0 ) {
+			return array();
+		}
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				'SELECT * FROM %i WHERE owner_id = %d ORDER BY agent_id ASC',
+				$this->table_name,
+				$owner_id
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( ! $rows ) {
+			return array();
+		}
+
+		foreach ( $rows as &$row ) {
+			if ( ! empty( $row['agent_config'] ) ) {
+				$decoded             = json_decode( $row['agent_config'], true );
+				$row['agent_config'] = is_array( $decoded ) ? $decoded : array();
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Batch fetch agents by ID.
+	 *
+	 * Replaces the N+1 pattern of looping `get_agent()` calls. Returns rows in
+	 * the same order they were requested when present; missing IDs are silently
+	 * dropped.
+	 *
+	 * @since 0.69.2
+	 *
+	 * @param int[] $agent_ids Agent IDs to fetch.
+	 * @return array List of agent rows (may be empty if no IDs match).
+	 */
+	public function get_agents_by_ids( array $agent_ids ): array {
+		// Sanitize: dedupe, cast to int, drop non-positive values.
+		$agent_ids = array_values(
+			array_unique(
+				array_filter(
+					array_map( 'intval', $agent_ids ),
+					static fn( $id ) => $id > 0
+				)
+			)
+		);
+
+		if ( empty( $agent_ids ) ) {
+			return array();
+		}
+
+		$placeholders = implode( ',', array_fill( 0, count( $agent_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$rows = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				"SELECT * FROM %i WHERE agent_id IN ({$placeholders}) ORDER BY agent_id ASC",
+				array_merge( array( $this->table_name ), $agent_ids )
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		if ( ! $rows ) {
+			return array();
+		}
+
+		foreach ( $rows as &$row ) {
+			if ( ! empty( $row['agent_config'] ) ) {
+				$decoded             = json_decode( $row['agent_config'], true );
+				$row['agent_config'] = is_array( $decoded ) ? $decoded : array();
+			}
+		}
+
+		return $rows;
 	}
 
 	/**
@@ -255,28 +353,44 @@ class Agents extends BaseRepository {
 	 * @param array $args {
 	 *     Optional. Query arguments.
 	 *
-	 *     @type int|null $site_id Blog ID to filter by. Agents with this site_scope
-	 *                             OR site_scope IS NULL (network-wide) are returned.
-	 *                             Default null (no filtering — all agents).
+	 *     @type int|null $site_id  Blog ID to filter by. Agents with this site_scope
+	 *                              OR site_scope IS NULL (network-wide) are returned.
+	 *                              Default null (no filtering — all agents).
+	 *     @type int|null $owner_id User ID to filter by. Returns only agents owned by
+	 *                              this user. Combines with site_id when both present.
+	 *                              Default null (no owner filtering).
 	 * }
 	 * @return array List of agent rows.
 	 */
 	public function get_all( array $args = array() ): array {
-		$site_id = $args['site_id'] ?? null;
+		$site_id  = $args['site_id'] ?? null;
+		$owner_id = $args['owner_id'] ?? null;
+
+		$where        = array();
+		$where_values = array();
 
 		if ( null !== $site_id ) {
-			$site_id = (int) $site_id;
+			$where[]        = '(site_scope = %d OR site_scope IS NULL)';
+			$where_values[] = (int) $site_id;
+		}
 
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		if ( null !== $owner_id ) {
+			$where[]        = 'owner_id = %d';
+			$where_values[] = (int) $owner_id;
+		}
+
+		if ( ! empty( $where ) ) {
+			$sql = 'SELECT * FROM %i WHERE ' . implode( ' AND ', $where ) . ' ORDER BY agent_id ASC';
+
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$rows = $this->wpdb->get_results(
 				$this->wpdb->prepare(
-					'SELECT * FROM %i WHERE site_scope = %d OR site_scope IS NULL ORDER BY agent_id ASC',
-					$this->table_name,
-					$site_id
+					$sql,
+					array_merge( array( $this->table_name ), $where_values )
 				),
 				ARRAY_A
 			);
-			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		} else {
 			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 			$rows = $this->wpdb->get_results(

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -519,6 +519,24 @@ class Chat extends BaseRepository {
 			return array();
 		}
 
+		// Batch-load the agents referenced by these sessions so each row can
+		// expose agent_name/agent_slug without an N+1 query inside the loop.
+		$agent_ids_in_sessions = array();
+		foreach ( $sessions as $session ) {
+			$session_agent_id = isset( $session['agent_id'] ) ? (int) $session['agent_id'] : 0;
+			if ( $session_agent_id > 0 ) {
+				$agent_ids_in_sessions[] = $session_agent_id;
+			}
+		}
+
+		$agents_by_id = array();
+		if ( ! empty( $agent_ids_in_sessions ) ) {
+			$agents_repo = new \DataMachine\Core\Database\Agents\Agents();
+			foreach ( $agents_repo->get_agents_by_ids( $agent_ids_in_sessions ) as $agent_row ) {
+				$agents_by_id[ (int) $agent_row['agent_id'] ] = $agent_row;
+			}
+		}
+
 		$result = array();
 		foreach ( $sessions as $session ) {
 			$messages      = json_decode( $session['messages'] ?? '[]', true ) ?? array();
@@ -530,7 +548,9 @@ class Chat extends BaseRepository {
 				}
 			}
 
-			$last_read_at = $session['last_read_at'] ?? null;
+			$last_read_at     = $session['last_read_at'] ?? null;
+			$session_agent_id = isset( $session['agent_id'] ) ? (int) $session['agent_id'] : 0;
+			$agent_row        = $session_agent_id > 0 ? ( $agents_by_id[ $session_agent_id ] ?? null ) : null;
 
 			$result[] = array(
 				'session_id'    => $session['session_id'],
@@ -539,6 +559,9 @@ class Chat extends BaseRepository {
 				'first_message' => mb_substr( $first_message, 0, 100 ),
 				'message_count' => count( $messages ),
 				'unread_count'  => $this->count_unread( $messages, $last_read_at ),
+				'agent_id'      => $session_agent_id > 0 ? $session_agent_id : null,
+				'agent_slug'    => $agent_row ? (string) $agent_row['agent_slug'] : null,
+				'agent_name'    => $agent_row ? (string) $agent_row['agent_name'] : null,
 				'created_at'    => DateFormatter::format_for_api( $session['created_at'] ?? null ),
 				'updated_at'    => DateFormatter::format_for_api( $session['updated_at'] ?? $session['created_at'] ?? null ),
 			);

--- a/tests/Unit/Api/AgentsListEndpointTest.php
+++ b/tests/Unit/Api/AgentsListEndpointTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Agents REST List Endpoint Tests
+ *
+ * Coverage for the bug fixes added in #994:
+ * - Non-admin path returns OWNED agents even when no access grant exists
+ * - Non-admin path uses batched get_agents_by_ids() (no N+1)
+ * - Response includes user_role per agent
+ *
+ * @package DataMachine\Tests\Unit\Api
+ */
+
+namespace DataMachine\Tests\Unit\Api;
+
+use DataMachine\Api\Agents as AgentsRest;
+use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
+use DataMachine\Core\Database\Agents\AgentAccess;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
+class AgentsListEndpointTest extends WP_UnitTestCase {
+
+	private AgentsRepository $repo;
+	private AgentAccess $access_repo;
+	private int $admin_user;
+	private int $owner_user;
+	private int $granted_user;
+	private int $bystander_user;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->repo        = new AgentsRepository();
+		$this->access_repo = new AgentAccess();
+
+		$this->admin_user     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->owner_user     = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->granted_user   = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->bystander_user = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	public function tear_down(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agents" );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agent_access" );
+
+		parent::tear_down();
+	}
+
+	private function call_handle_list(): array {
+		$request  = new WP_REST_Request( 'GET', '/datamachine/v1/agents' );
+		$response = AgentsRest::handle_list( $request );
+
+		return $response->get_data();
+	}
+
+	/**
+	 * Bug 1 regression: a non-admin user OWNS an agent but has no access grant
+	 * (e.g. migration gap, manual DB edit). Pre-fix, the endpoint silently
+	 * dropped their own agent because it only consulted the access table.
+	 */
+	public function test_non_admin_owner_sees_their_agent_without_access_grant(): void {
+		$agent_id = $this->repo->create_if_missing( 'owned-agent', 'Owned Agent', $this->owner_user );
+
+		// Deliberately do NOT call $access_repo->grant_access() / bootstrap_owner_access().
+		wp_set_current_user( $this->owner_user );
+		$result = $this->call_handle_list();
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 1, $result['data'] );
+		$this->assertSame( $agent_id, $result['data'][0]['agent_id'] );
+	}
+
+	/**
+	 * Owners get user_role = 'admin' regardless of whether an access row exists.
+	 * Frontend depends on this normalization to switch on a single role enum.
+	 */
+	public function test_non_admin_owner_role_normalizes_to_admin(): void {
+		$this->repo->create_if_missing( 'owned-agent', 'Owned Agent', $this->owner_user );
+
+		wp_set_current_user( $this->owner_user );
+		$result = $this->call_handle_list();
+
+		$this->assertSame( 'admin', $result['data'][0]['user_role'] );
+	}
+
+	/**
+	 * Access-granted (non-owner) users see the agent and get the granted role.
+	 */
+	public function test_non_admin_granted_user_sees_agent_with_granted_role(): void {
+		$agent_id = $this->repo->create_if_missing( 'shared-agent', 'Shared Agent', $this->owner_user );
+		$this->access_repo->grant_access( $agent_id, $this->granted_user, 'operator' );
+
+		wp_set_current_user( $this->granted_user );
+		$result = $this->call_handle_list();
+
+		$this->assertCount( 1, $result['data'] );
+		$this->assertSame( $agent_id, $result['data'][0]['agent_id'] );
+		$this->assertSame( 'operator', $result['data'][0]['user_role'] );
+	}
+
+	/**
+	 * Owned + granted agents are merged (union) without duplicates.
+	 */
+	public function test_non_admin_sees_union_of_owned_and_granted_agents(): void {
+		$owned_id   = $this->repo->create_if_missing( 'owned', 'Owned', $this->granted_user );
+		$granted_id = $this->repo->create_if_missing( 'granted', 'Granted', $this->owner_user );
+		$this->access_repo->grant_access( $granted_id, $this->granted_user, 'viewer' );
+
+		wp_set_current_user( $this->granted_user );
+		$result = $this->call_handle_list();
+
+		$this->assertCount( 2, $result['data'] );
+
+		$ids = array_map( static fn( $row ) => $row['agent_id'], $result['data'] );
+		$this->assertContains( $owned_id, $ids );
+		$this->assertContains( $granted_id, $ids );
+
+		// Roles correctly assigned per agent.
+		$by_id = array();
+		foreach ( $result['data'] as $row ) {
+			$by_id[ $row['agent_id'] ] = $row['user_role'];
+		}
+
+		$this->assertSame( 'admin', $by_id[ $owned_id ] );
+		$this->assertSame( 'viewer', $by_id[ $granted_id ] );
+	}
+
+	/**
+	 * Owner who also has an explicit grant doesn't get a duplicate row,
+	 * and owner-as-admin wins over the explicit access role.
+	 */
+	public function test_owned_and_granted_dedupes_with_admin_role_wins(): void {
+		$agent_id = $this->repo->create_if_missing( 'mine', 'Mine', $this->owner_user );
+		$this->access_repo->grant_access( $agent_id, $this->owner_user, 'viewer' );
+
+		wp_set_current_user( $this->owner_user );
+		$result = $this->call_handle_list();
+
+		$this->assertCount( 1, $result['data'], 'Owner+grant must not duplicate the agent' );
+		$this->assertSame( 'admin', $result['data'][0]['user_role'], 'Owner role should normalize to admin' );
+	}
+
+	/**
+	 * Bystander with neither ownership nor a grant gets an empty list.
+	 */
+	public function test_non_admin_bystander_sees_empty_list(): void {
+		$this->repo->create_if_missing( 'shared', 'Shared', $this->owner_user );
+
+		wp_set_current_user( $this->bystander_user );
+		$result = $this->call_handle_list();
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array(), $result['data'] );
+	}
+
+	/**
+	 * Admins see all agents on the current site and get user_role = 'admin'.
+	 */
+	public function test_admin_sees_all_agents_with_admin_role(): void {
+		$this->repo->create_if_missing( 'one', 'One', $this->owner_user );
+		$this->repo->create_if_missing( 'two', 'Two', $this->granted_user );
+
+		wp_set_current_user( $this->admin_user );
+		$result = $this->call_handle_list();
+
+		$this->assertGreaterThanOrEqual( 2, count( $result['data'] ) );
+
+		foreach ( $result['data'] as $row ) {
+			$this->assertSame( 'admin', $row['user_role'] );
+		}
+	}
+}

--- a/tests/Unit/Core/Database/Agents/AgentsRepositoryTest.php
+++ b/tests/Unit/Core/Database/Agents/AgentsRepositoryTest.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Agents Repository Tests
+ *
+ * Coverage for the multi-agent database primitives added in #993:
+ * - get_all_by_owner_id()
+ * - get_agents_by_ids()
+ * - get_all() with owner_id filter
+ *
+ * @package DataMachine\Tests\Unit\Core\Database\Agents
+ */
+
+namespace DataMachine\Tests\Unit\Core\Database\Agents;
+
+use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
+use WP_UnitTestCase;
+
+class AgentsRepositoryTest extends WP_UnitTestCase {
+
+	private AgentsRepository $repo;
+	private int $owner_a;
+	private int $owner_b;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		$this->repo    = new AgentsRepository();
+		$this->owner_a = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->owner_b = self::factory()->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function tear_down(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agents" );
+
+		parent::tear_down();
+	}
+
+	private function create_agent( string $slug, int $owner_id, array $config = array() ): int {
+		return $this->repo->create_if_missing( $slug, $slug, $owner_id, $config );
+	}
+
+	// ---------------------------------------------------------------
+	// get_all_by_owner_id()
+	// ---------------------------------------------------------------
+
+	public function test_get_all_by_owner_id_returns_only_owned_agents(): void {
+		$id_a1 = $this->create_agent( 'a-one', $this->owner_a );
+		$id_a2 = $this->create_agent( 'a-two', $this->owner_a );
+		$this->create_agent( 'b-one', $this->owner_b );
+
+		$result = $this->repo->get_all_by_owner_id( $this->owner_a );
+
+		$this->assertCount( 2, $result );
+
+		$ids = array_map( static fn( $a ) => (int) $a['agent_id'], $result );
+		$this->assertContains( $id_a1, $ids );
+		$this->assertContains( $id_a2, $ids );
+	}
+
+	public function test_get_all_by_owner_id_returns_empty_for_unknown_user(): void {
+		$this->create_agent( 'a-one', $this->owner_a );
+
+		$this->assertSame( array(), $this->repo->get_all_by_owner_id( 99999 ) );
+	}
+
+	public function test_get_all_by_owner_id_returns_empty_for_invalid_id(): void {
+		$this->create_agent( 'a-one', $this->owner_a );
+
+		$this->assertSame( array(), $this->repo->get_all_by_owner_id( 0 ) );
+		$this->assertSame( array(), $this->repo->get_all_by_owner_id( -1 ) );
+	}
+
+	public function test_get_all_by_owner_id_decodes_agent_config(): void {
+		$this->create_agent( 'a-one', $this->owner_a, array( 'foo' => 'bar' ) );
+
+		$result = $this->repo->get_all_by_owner_id( $this->owner_a );
+
+		$this->assertIsArray( $result[0]['agent_config'] );
+		$this->assertSame( 'bar', $result[0]['agent_config']['foo'] );
+	}
+
+	public function test_get_all_by_owner_id_orders_by_agent_id_ascending(): void {
+		$id_first  = $this->create_agent( 'a-one', $this->owner_a );
+		$id_second = $this->create_agent( 'a-two', $this->owner_a );
+
+		$result = $this->repo->get_all_by_owner_id( $this->owner_a );
+
+		$this->assertSame( $id_first, (int) $result[0]['agent_id'] );
+		$this->assertSame( $id_second, (int) $result[1]['agent_id'] );
+	}
+
+	// ---------------------------------------------------------------
+	// get_agents_by_ids()
+	// ---------------------------------------------------------------
+
+	public function test_get_agents_by_ids_batches_a_single_query(): void {
+		$id_a = $this->create_agent( 'a-one', $this->owner_a );
+		$id_b = $this->create_agent( 'b-one', $this->owner_b );
+
+		$result = $this->repo->get_agents_by_ids( array( $id_a, $id_b ) );
+
+		$this->assertCount( 2, $result );
+
+		$ids = array_map( static fn( $a ) => (int) $a['agent_id'], $result );
+		$this->assertContains( $id_a, $ids );
+		$this->assertContains( $id_b, $ids );
+	}
+
+	public function test_get_agents_by_ids_returns_empty_for_empty_input(): void {
+		$this->create_agent( 'a-one', $this->owner_a );
+
+		$this->assertSame( array(), $this->repo->get_agents_by_ids( array() ) );
+	}
+
+	public function test_get_agents_by_ids_silently_drops_missing_ids(): void {
+		$id_a = $this->create_agent( 'a-one', $this->owner_a );
+
+		$result = $this->repo->get_agents_by_ids( array( $id_a, 99999 ) );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( $id_a, (int) $result[0]['agent_id'] );
+	}
+
+	public function test_get_agents_by_ids_dedupes_input(): void {
+		$id_a = $this->create_agent( 'a-one', $this->owner_a );
+
+		$result = $this->repo->get_agents_by_ids( array( $id_a, $id_a, $id_a ) );
+
+		$this->assertCount( 1, $result );
+	}
+
+	public function test_get_agents_by_ids_drops_non_positive_ids(): void {
+		$id_a = $this->create_agent( 'a-one', $this->owner_a );
+
+		// Should not crash on 0, negatives, or strings — all sanitized away.
+		$result = $this->repo->get_agents_by_ids( array( $id_a, 0, -5, 'not-an-id' ) );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( $id_a, (int) $result[0]['agent_id'] );
+	}
+
+	public function test_get_agents_by_ids_decodes_agent_config(): void {
+		$id_a = $this->create_agent( 'a-one', $this->owner_a, array( 'tools' => array( 'x', 'y' ) ) );
+
+		$result = $this->repo->get_agents_by_ids( array( $id_a ) );
+
+		$this->assertIsArray( $result[0]['agent_config'] );
+		$this->assertSame( array( 'x', 'y' ), $result[0]['agent_config']['tools'] );
+	}
+
+	// ---------------------------------------------------------------
+	// get_all() with owner_id filter
+	// ---------------------------------------------------------------
+
+	public function test_get_all_filters_by_owner_id(): void {
+		$id_a1 = $this->create_agent( 'a-one', $this->owner_a );
+		$this->create_agent( 'a-two', $this->owner_a );
+		$this->create_agent( 'b-one', $this->owner_b );
+
+		$result = $this->repo->get_all( array( 'owner_id' => $this->owner_a ) );
+
+		$this->assertCount( 2, $result );
+
+		foreach ( $result as $row ) {
+			$this->assertSame( $this->owner_a, (int) $row['owner_id'] );
+		}
+
+		$ids = array_map( static fn( $a ) => (int) $a['agent_id'], $result );
+		$this->assertContains( $id_a1, $ids );
+	}
+
+	public function test_get_all_with_no_args_returns_everything(): void {
+		$this->create_agent( 'a-one', $this->owner_a );
+		$this->create_agent( 'b-one', $this->owner_b );
+
+		$result = $this->repo->get_all();
+
+		$this->assertGreaterThanOrEqual( 2, count( $result ) );
+	}
+}


### PR DESCRIPTION
## Summary

Closes #993 and #994.

Adds the database primitives and REST surface fixes needed for multi-agent frontend chat (agent switching, personal agents, multi-agent session lists).

## DB primitives (#993)

- `Agents::get_all_by_owner_id(int)` — single indexed query against `owner_id`. Replaces the legacy `get_all() + array_filter()` pattern that fetched the whole agents table and filtered in PHP.
- `Agents::get_agents_by_ids(array)` — batch fetch by ID with input sanitization (dedupe, drop non-positive). Eliminates N+1 patterns across callers.
- `Agents::get_all()` learns an `owner_id` arg, composable with `site_id`.
- `PermissionHelper::resolve_all_accessible_agent_ids()` — multi-agent companion to `resolve_scoped_agent_id()`. Returns the union of OWNED and ACCESS-GRANTED agents; admins get `[]` (signals "no scoping").
- `Chat::get_user_sessions()` now returns `agent_id`, `agent_slug`, `agent_name` per row (batched lookup, no N+1). The frontend can render multi-agent session lists without follow-up requests.
- `AgentAbilities::createAgent()` swaps its limit-counting path to `get_all_by_owner_id()`.

## REST list bugfixes (#994)

### Bug 1: Non-admin owners were dropped from their own list

`inc/Api/Agents::handle_list()` non-admin path now merges OWNED agents with ACCESS-GRANTED agents. The owner relationship lives on \`datamachine_agents.owner_id\`, not in \`agent_access\` — pre-fix, a missing access grant (race condition, migration gap, manual DB edit) silently dropped owners from their own list.

### Bug 2: N+1 query

The non-admin path was calling \`get_agent()\` in a loop. Now a single \`get_agents_by_ids()\` batch query.

### Enhancement: \`user_role\` per agent

Each row carries \`user_role\` (admin/operator/viewer). Owners and admin-capability holders normalize to \`'admin'\` so the frontend has a single enum to switch on.

## Tests

- \`tests/Unit/Core/Database/Agents/AgentsRepositoryTest.php\` — coverage for \`get_all_by_owner_id\` (owned-only filter, empty/invalid input, config decode, ordering), \`get_agents_by_ids\` (dedup, missing IDs, non-positive sanitization, config decode), and \`get_all\` \`owner_id\` filter.
- \`tests/Unit/Api/AgentsListEndpointTest.php\` — regression coverage for the missing-grant bug, owner role normalization, owned+granted union, dedupe (owner+grant on same agent), bystander empty list, and admin path.

## Touched files

\`\`\`
 inc/Abilities/AgentAbilities.php    |   3 +-
 inc/Abilities/PermissionHelper.php  |  37 +++++
 inc/Api/Agents.php                  |  68 +++++++++---
 inc/Core/Database/Agents/Agents.php | 134 ++++++++++++++++++++++-
 inc/Core/Database/Chat/Chat.php     |  25 +++-
 tests/Unit/Api/AgentsListEndpointTest.php                  | new
 tests/Unit/Core/Database/Agents/AgentsRepositoryTest.php   | new
\`\`\`

## Lint / PHPStan

Verified zero new violations introduced in any touched file. Pre-existing repo-wide lint/PHPStan baseline is unchanged.