### PR TITLE
refactor(list-agents): scope-aware defaults, per-user access resolution

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -13,6 +13,7 @@ namespace DataMachine\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\Agents\AgentAccess;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 
 defined( 'ABSPATH' ) || exit;
@@ -77,11 +78,33 @@ class AgentAbilities {
 				'datamachine/list-agents',
 				array(
 					'label'               => 'List Agents',
-					'description'         => 'List all registered agent identities',
+					'description'         => 'List agents accessible to the caller. Defaults to the caller\'s own accessible agents; admins can escalate to all agents or query other users.',
 					'category'            => 'datamachine-agent',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'properties' => new \stdClass(),
+						'properties' => array(
+							'scope'        => array(
+								'type'        => 'string',
+								'enum'        => array( 'mine', 'all' ),
+								'description' => '"mine" (default) returns agents the caller can access (owned + granted). "all" returns every agent on the site (admin-only).',
+							),
+							'user_id'      => array(
+								'type'        => 'integer',
+								'description' => 'Resolve accessible agents for this user instead of the caller. Non-admins are forced to themselves. Ignored when scope=all.',
+							),
+							'site_id'      => array(
+								'type'        => 'integer',
+								'description' => 'Filter by site_scope. Matches the exact site OR network-wide (NULL) agents. Defaults to current blog.',
+							),
+							'status'       => array(
+								'type'        => 'string',
+								'description' => 'Filter by agent status. Defaults to "active". Pass "any" to skip status filtering.',
+							),
+							'include_role' => array(
+								'type'        => 'boolean',
+								'description' => 'When true, enriches each row with the resolved user\'s role on that agent.',
+							),
+						),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -92,18 +115,22 @@ class AgentAbilities {
 								'items' => array(
 									'type'       => 'object',
 									'properties' => array(
-										'agent_id'   => array( 'type' => 'integer' ),
-										'agent_slug' => array( 'type' => 'string' ),
-										'agent_name' => array( 'type' => 'string' ),
-										'owner_id'   => array( 'type' => 'integer' ),
-										'status'     => array( 'type' => 'string' ),
+										'agent_id'    => array( 'type' => 'integer' ),
+										'agent_slug'  => array( 'type' => 'string' ),
+										'agent_name'  => array( 'type' => 'string' ),
+										'owner_id'    => array( 'type' => 'integer' ),
+										'site_scope'  => array( 'type' => array( 'integer', 'null' ) ),
+										'status'      => array( 'type' => 'string' ),
+										'description' => array( 'type' => 'string' ),
+										'is_owner'    => array( 'type' => 'boolean' ),
+										'user_role'   => array( 'type' => array( 'string', 'null' ) ),
 									),
 								),
 							),
 						),
 					),
 					'execute_callback'    => array( self::class, 'listAgents' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'chat' ) || PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -413,21 +440,143 @@ class AgentAbilities {
 	 * @param array $input Input parameters (unused).
 	 * @return array Result.
 	 */
-	public static function listAgents( array $input ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by WP_Ability interface.
-		$agents_repo = new Agents();
-		$rows        = $agents_repo->get_all( array( 'site_id' => get_current_blog_id() ) );
+	public static function listAgents( array $input ): array {
+		// ---- Parameter resolution ----------------------------------------
+		$scope        = isset( $input['scope'] ) ? (string) $input['scope'] : 'mine';
+		$requested_user_id = isset( $input['user_id'] ) ? (int) $input['user_id'] : 0;
+		$site_id      = isset( $input['site_id'] ) ? (int) $input['site_id'] : get_current_blog_id();
+		$status       = isset( $input['status'] ) ? (string) $input['status'] : 'active';
+		$include_role = ! empty( $input['include_role'] );
 
+		if ( ! in_array( $scope, array( 'mine', 'all' ), true ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Invalid scope. Allowed values: "mine", "all".',
+			);
+		}
+
+		$is_admin  = PermissionHelper::can_manage();
+		$caller_id = PermissionHelper::acting_user_id();
+
+		// ---- Escalation checks -------------------------------------------
+		if ( 'all' === $scope && ! $is_admin ) {
+			return array(
+				'success' => false,
+				'error'   => 'scope=all requires admin privileges.',
+			);
+		}
+
+		// Non-admins are always forced to self. Admin omitting user_id also
+		// defaults to self (the intuitive "show me MY accessible agents").
+		if ( $requested_user_id > 0 && $requested_user_id !== $caller_id && ! $is_admin ) {
+			return array(
+				'success' => false,
+				'error'   => 'Querying another user\'s agents requires admin privileges.',
+			);
+		}
+
+		$target_user_id = $requested_user_id > 0 ? $requested_user_id : $caller_id;
+
+		$agents_repo = new Agents();
+		$access_repo = new AgentAccess();
+
+		// ---- Resolve candidate rows --------------------------------------
+		if ( 'all' === $scope ) {
+			// Admin firehose: all agents on the requested site.
+			$candidates = $agents_repo->get_all( array( 'site_id' => $site_id ) );
+		} else {
+			if ( $target_user_id <= 0 ) {
+				return array(
+					'success' => true,
+					'agents'  => array(),
+				);
+			}
+
+			// Union of agents the target user OWNS plus agents they have
+			// ACCESS GRANTS to. The owner relationship lives on
+			// datamachine_agents.owner_id, not on agent_access, so merging
+			// both sides is the only way to get the complete picture.
+			$owned        = $agents_repo->get_all_by_owner_id( $target_user_id );
+			$owned_ids    = array_map( static fn( $a ) => (int) $a['agent_id'], $owned );
+			$granted_ids  = array_map( 'intval', $access_repo->get_agent_ids_for_user( $target_user_id ) );
+			$extra_ids    = array_values( array_diff( $granted_ids, $owned_ids ) );
+			$granted_rows = ! empty( $extra_ids ) ? $agents_repo->get_agents_by_ids( $extra_ids ) : array();
+
+			$candidates = array_merge( $owned, $granted_rows );
+
+			// Site scoping: match the requested site OR network-wide (NULL).
+			$candidates = array_values(
+				array_filter(
+					$candidates,
+					static function ( $row ) use ( $site_id ) {
+						$scope_value = $row['site_scope'] ?? null;
+						return null === $scope_value || (int) $scope_value === $site_id;
+					}
+				)
+			);
+		}
+
+		// ---- Status filter -----------------------------------------------
+		if ( 'any' !== $status ) {
+			$candidates = array_values(
+				array_filter(
+					$candidates,
+					static fn( $row ) => ( $row['status'] ?? '' ) === $status
+				)
+			);
+		}
+
+		// ---- Final access gate (mine only) -------------------------------
+		//
+		// When listing the caller's OWN agents, defence-in-depth: run each
+		// row through can_access_agent() so the filter `datamachine_can_access_agent`
+		// still has the final say. When the admin queries another user via
+		// `user_id`, this gate is skipped — the admin permission check above
+		// is authoritative and we must not accidentally filter out agents
+		// the target user can actually access.
+		if ( 'mine' === $scope && $target_user_id === $caller_id ) {
+			$candidates = array_values(
+				array_filter(
+					$candidates,
+					static fn( $row ) => PermissionHelper::can_access_agent( (int) $row['agent_id'] )
+				)
+			);
+		}
+
+		// ---- Role enrichment (optional) ----------------------------------
+		// Computed against $target_user_id so `include_role=true` reflects
+		// the resolved user's role even when an admin queries on their behalf.
 		$agents = array();
 
-		foreach ( $rows as $row ) {
-			$agents[] = array(
-				'agent_id'   => (int) $row['agent_id'],
-				'agent_slug' => (string) $row['agent_slug'],
-				'agent_name' => (string) $row['agent_name'],
-				'owner_id'   => (int) $row['owner_id'],
-				'site_scope' => isset( $row['site_scope'] ) ? (int) $row['site_scope'] : null,
-				'status'     => (string) $row['status'],
+		foreach ( $candidates as $row ) {
+			$agent_id   = (int) $row['agent_id'];
+			$owner_id   = (int) $row['owner_id'];
+			$config     = is_array( $row['agent_config'] ?? null ) ? $row['agent_config'] : array();
+			$description = isset( $config['description'] ) ? (string) $config['description'] : '';
+
+			$item = array(
+				'agent_id'    => $agent_id,
+				'agent_slug'  => (string) $row['agent_slug'],
+				'agent_name'  => (string) $row['agent_name'],
+				'owner_id'    => $owner_id,
+				'site_scope'  => isset( $row['site_scope'] ) ? (int) $row['site_scope'] : null,
+				'status'      => (string) ( $row['status'] ?? '' ),
+				'description' => $description,
+				'is_owner'    => $target_user_id > 0 && $owner_id === $target_user_id,
 			);
+
+			if ( $include_role ) {
+				if ( $target_user_id > 0 && $owner_id === $target_user_id ) {
+					$item['user_role'] = 'admin';
+				} elseif ( $target_user_id > 0 ) {
+					$grant             = $access_repo->get_access( $agent_id, $target_user_id );
+					$item['user_role'] = $grant && isset( $grant['role'] ) ? (string) $grant['role'] : null;
+				} else {
+					$item['user_role'] = null;
+				}
+			}
+
+			$agents[] = $item;
 		}
 
 		return array(

--- a/inc/Api/Agents.php
+++ b/inc/Api/Agents.php
@@ -383,70 +383,77 @@ class Agents {
 	 * @param WP_REST_Request $request REST request.
 	 * @return \WP_REST_Response|WP_Error
 	 */
-	public static function handle_list( WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
-		$agents_repo  = new AgentsRepository();
-		$access_repo  = new AgentAccess();
-		$user_id      = get_current_user_id();
-		$current_site = get_current_blog_id();
-		$is_admin     = PermissionHelper::can( 'manage_agents' );
+	public static function handle_list( WP_REST_Request $request ) {
+		// Delegate to the scope-aware listAgents ability. The ability is the
+		// single source of truth for permission escalation, owned+granted
+		// resolution, and role enrichment — the REST controller just passes
+		// query params through and shapes the response envelope.
+		//
+		// Supported query params:
+		//   scope=mine|all      (default 'mine'; 'all' requires admin)
+		//   user_id=<int>       (admin-only; defaults to caller)
+		//   status=<string>     (default 'active'; 'any' to skip)
+		//   include_role=1      (optional; on for list UI by default below)
 
-		if ( $is_admin ) {
-			// Admins see agents scoped to the current site + network-wide agents.
-			$all_agents = $agents_repo->get_all( array( 'site_id' => $current_site ) );
-		} else {
-			// Non-admin: union of OWNED agents and ACCESS-GRANTED agents.
-			//
-			// The owner relationship lives on `datamachine_agents.owner_id` —
-			// not in `agent_access` — so a missing access grant (race, migration
-			// gap, manual DB edit) used to cause owners to vanish from their own
-			// list. Merging here is the source-of-truth fix for that bug.
-			$owned_agents   = $agents_repo->get_all_by_owner_id( $user_id );
-			$owned_ids      = array_map( static fn( $a ) => (int) $a['agent_id'], $owned_agents );
-			$accessible_ids = array_map( 'intval', $access_repo->get_agent_ids_for_user( $user_id ) );
-			$all_ids        = array_values( array_unique( array_merge( $owned_ids, $accessible_ids ) ) );
+		$input = array(
+			'include_role' => true, // Admin UIs depend on this — enable by default.
+		);
 
-			if ( empty( $all_ids ) ) {
-				return rest_ensure_response(
-					array(
-						'success' => true,
-						'data'    => array(),
-					)
-				);
-			}
-
-			// Single batched query replaces the previous N+1 get_agent() loop.
-			$candidate_agents = $agents_repo->get_agents_by_ids( $all_ids );
-
-			// Apply site scoping (current site + network-wide).
-			$all_agents = array();
-			foreach ( $candidate_agents as $agent ) {
-				$scope = $agent['site_scope'] ?? null;
-				if ( null === $scope || (int) $scope === $current_site ) {
-					$all_agents[] = $agent;
-				}
-			}
+		$scope_param = $request->get_param( 'scope' );
+		if ( null !== $scope_param && '' !== $scope_param ) {
+			$input['scope'] = sanitize_key( $scope_param );
 		}
 
-		$data = array();
-		foreach ( $all_agents as $agent ) {
-			// Resolve the requesting user's role on this agent so the frontend
-			// can make UI decisions (show edit button, hide config tab, etc.).
-			// Owners are normalized to 'admin' even when no explicit access row
-			// exists, so the frontend has a single role enum to switch on.
-			$user_role = null;
+		$user_id_param = $request->get_param( 'user_id' );
+		if ( null !== $user_id_param && '' !== $user_id_param ) {
+			$input['user_id'] = (int) $user_id_param;
+		}
 
-			if ( $is_admin ) {
-				$user_role = 'admin';
-			} elseif ( (int) $agent['owner_id'] === $user_id ) {
-				$user_role = 'admin';
-			} else {
-				$grant = $access_repo->get_access( (int) $agent['agent_id'], $user_id );
-				if ( $grant && isset( $grant['role'] ) ) {
-					$user_role = (string) $grant['role'];
-				}
+		$status_param = $request->get_param( 'status' );
+		if ( null !== $status_param && '' !== $status_param ) {
+			$input['status'] = sanitize_key( $status_param );
+		}
+
+		$include_role = $request->get_param( 'include_role' );
+		if ( null !== $include_role ) {
+			$input['include_role'] = rest_sanitize_boolean( $include_role );
+		}
+
+		$result = AgentAbilities::listAgents( $input );
+
+		if ( empty( $result['success'] ) ) {
+			return new WP_Error(
+				'list_agents_failed',
+				$result['error'] ?? __( 'Failed to list agents.', 'data-machine' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Shape the ability output for REST consumers. The ability already
+		// returns the canonical per-agent fields; we just attach timestamps
+		// (which REST historically exposes) and drop `description`/`is_owner`
+		// only when they're empty/default to keep the payload lean.
+		$data = array();
+		foreach ( $result['agents'] as $agent ) {
+			$item = array(
+				'agent_id'   => (int) $agent['agent_id'],
+				'agent_slug' => (string) $agent['agent_slug'],
+				'agent_name' => (string) $agent['agent_name'],
+				'owner_id'   => (int) $agent['owner_id'],
+				'site_scope' => $agent['site_scope'] ?? null,
+				'status'     => (string) ( $agent['status'] ?? '' ),
+				'is_owner'   => (bool) ( $agent['is_owner'] ?? false ),
+			);
+
+			if ( ! empty( $agent['description'] ) ) {
+				$item['description'] = (string) $agent['description'];
 			}
 
-			$data[] = self::shape_list_item( $agent, $user_role );
+			if ( array_key_exists( 'user_role', $agent ) && null !== $agent['user_role'] ) {
+				$item['user_role'] = (string) $agent['user_role'];
+			}
+
+			$data[] = $item;
 		}
 
 		return rest_ensure_response(
@@ -822,39 +829,6 @@ class Agents {
 	// ---------------------------------------------------------------
 	// Helpers
 	// ---------------------------------------------------------------
-
-	/**
-	 * Shape an agent row for list output (excludes config which may contain secrets).
-	 *
-	 * @since 0.41.0
-	 * @since 0.57.0 Added site_scope to output.
-	 * @since 0.69.2 Added user_role for frontend role-based UI decisions.
-	 *
-	 * @param array       $agent     Agent database row.
-	 * @param string|null $user_role The requesting user's role on this agent
-	 *                               (admin/operator/viewer). Owners and admin
-	 *                               capability holders are normalized to 'admin'.
-	 *                               Null when not resolved.
-	 * @return array Shaped output.
-	 */
-	private static function shape_list_item( array $agent, ?string $user_role = null ): array {
-		$item = array(
-			'agent_id'   => (int) $agent['agent_id'],
-			'agent_slug' => (string) $agent['agent_slug'],
-			'agent_name' => (string) $agent['agent_name'],
-			'owner_id'   => (int) $agent['owner_id'],
-			'site_scope' => isset( $agent['site_scope'] ) ? (int) $agent['site_scope'] : null,
-			'status'     => (string) $agent['status'],
-			'created_at' => $agent['created_at'] ?? '',
-			'updated_at' => $agent['updated_at'] ?? '',
-		);
-
-		if ( null !== $user_role ) {
-			$item['user_role'] = $user_role;
-		}
-
-		return $item;
-	}
 
 	/**
 	 * Permission callback — any logged-in user can list their agents.

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -30,6 +30,27 @@ class AgentsCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--scope=<scope>]
+	 * : Which agents to list.
+	 * ---
+	 * default: all
+	 * options:
+	 *   - mine
+	 *   - all
+	 * ---
+	 *
+	 * [--user_id=<id>]
+	 * : List accessible agents for a specific user (implies scope=mine).
+	 *
+	 * [--status=<status>]
+	 * : Filter by agent status. Use "any" to skip status filtering.
+	 * ---
+	 * default: any
+	 * ---
+	 *
+	 * [--include_role]
+	 * : Include the resolved user's role per agent in the output.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -43,21 +64,52 @@ class AgentsCommand extends BaseCommand {
 	 *
 	 * ## EXAMPLES
 	 *
+	 *     # All agents on the current site (admin default)
 	 *     wp datamachine agents list
+	 *
+	 *     # Agents accessible to a specific user
+	 *     wp datamachine agents list --user_id=5
+	 *
+	 *     # My own accessible agents with role info
+	 *     wp datamachine agents list --scope=mine --include_role
+	 *
 	 *     wp datamachine agents list --format=json
 	 *
 	 * @subcommand list
 	 */
 	public function list_agents( array $args, array $assoc_args ): void {
-		$result = AgentAbilities::listAgents( array() );
+		$input = array(
+			'status' => (string) \WP_CLI\Utils\get_flag_value( $assoc_args, 'status', 'any' ),
+		);
+
+		$user_id_flag = \WP_CLI\Utils\get_flag_value( $assoc_args, 'user_id', null );
+		if ( null !== $user_id_flag ) {
+			$input['user_id'] = (int) $user_id_flag;
+			// Passing --user_id implies scope=mine for that user.
+			$input['scope'] = (string) \WP_CLI\Utils\get_flag_value( $assoc_args, 'scope', 'mine' );
+		} else {
+			$input['scope'] = (string) \WP_CLI\Utils\get_flag_value( $assoc_args, 'scope', 'all' );
+		}
+
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'include_role', false ) ) {
+			$input['include_role'] = true;
+		}
+
+		$result = AgentAbilities::listAgents( $input );
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to list agents.' );
+			return;
+		}
 
 		if ( empty( $result['agents'] ) ) {
-			WP_CLI::warning( 'No agents registered.' );
+			WP_CLI::warning( 'No agents found for the given scope.' );
 			return;
 		}
 
 		$directory_manager = new DirectoryManager();
 		$items             = array();
+		$include_role      = ! empty( $input['include_role'] );
 
 		foreach ( $result['agents'] as $agent ) {
 			$owner_id = (int) $agent['owner_id'];
@@ -65,18 +117,29 @@ class AgentsCommand extends BaseCommand {
 			$slug     = (string) $agent['agent_slug'];
 
 			$agent_dir = $directory_manager->get_agent_identity_directory( $slug );
-			$items[]   = array(
+			$row       = array(
 				'agent_id'    => (int) $agent['agent_id'],
 				'agent_slug'  => $slug,
 				'agent_name'  => (string) $agent['agent_name'],
 				'owner_id'    => $owner_id,
 				'owner_login' => $user ? $user->user_login : '(deleted)',
 				'has_files'   => is_dir( $agent_dir ) ? 'Yes' : 'No',
-				'status'      => (string) $agent['status'],
+				'status'      => (string) ( $agent['status'] ?? '' ),
 			);
+
+			if ( $include_role ) {
+				$role             = $agent['user_role'] ?? null;
+				$row['user_role'] = ( null === $role || '' === $role ) ? '-' : (string) $role;
+			}
+
+			$items[] = $row;
 		}
 
 		$fields = array( 'agent_id', 'agent_slug', 'agent_name', 'owner_id', 'owner_login', 'has_files', 'status' );
+		if ( $include_role ) {
+			$fields[] = 'user_role';
+		}
+
 		$this->format_items( $items, $fields, $assoc_args, 'agent_id' );
 
 		WP_CLI::log( sprintf( 'Total: %d agent(s).', count( $items ) ) );

--- a/tests/Unit/Abilities/ListAgentsAbilityTest.php
+++ b/tests/Unit/Abilities/ListAgentsAbilityTest.php
@@ -1,0 +1,299 @@
+<?php
+/**
+ * datamachine/list-agents Scope-Aware Tests
+ *
+ * Coverage for the refactored listAgents() ability (#996):
+ * - Default scope ('mine') returns owned + access-granted agents
+ * - scope=all requires admin, returns everything on site
+ * - user_id escalation is admin-only
+ * - Role enrichment (include_role=true) resolves correctly
+ * - Description extracted from agent_config
+ * - is_owner flag reflects target user, not caller
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\AgentAbilities;
+use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
+use DataMachine\Core\Database\Agents\AgentAccess;
+use WP_UnitTestCase;
+
+class ListAgentsAbilityTest extends WP_UnitTestCase {
+
+	private AgentsRepository $repo;
+	private AgentAccess $access_repo;
+	private int $admin_user;
+	private int $owner_user;
+	private int $granted_user;
+	private int $bystander_user;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->repo        = new AgentsRepository();
+		$this->access_repo = new AgentAccess();
+
+		$this->admin_user     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->owner_user     = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->granted_user   = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->bystander_user = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	public function tear_down(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agents" );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agent_access" );
+
+		parent::tear_down();
+	}
+
+	// ---------------------------------------------------------------
+	// scope=mine (default)
+	// ---------------------------------------------------------------
+
+	public function test_default_scope_returns_owned_agents_for_non_admin(): void {
+		$agent_id = $this->repo->create_if_missing( 'mine', 'Mine', $this->owner_user );
+
+		wp_set_current_user( $this->owner_user );
+		$result = AgentAbilities::listAgents( array() );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 1, $result['agents'] );
+		$this->assertSame( $agent_id, $result['agents'][0]['agent_id'] );
+		$this->assertTrue( $result['agents'][0]['is_owner'] );
+	}
+
+	public function test_default_scope_returns_granted_agents_for_non_admin(): void {
+		$agent_id = $this->repo->create_if_missing( 'shared', 'Shared', $this->owner_user );
+		$this->access_repo->grant_access( $agent_id, $this->granted_user, 'operator' );
+
+		wp_set_current_user( $this->granted_user );
+		$result = AgentAbilities::listAgents( array() );
+
+		$this->assertCount( 1, $result['agents'] );
+		$this->assertSame( $agent_id, $result['agents'][0]['agent_id'] );
+		$this->assertFalse( $result['agents'][0]['is_owner'] );
+	}
+
+	public function test_default_scope_unions_owned_and_granted_without_dupes(): void {
+		$owned_id   = $this->repo->create_if_missing( 'owned', 'Owned', $this->granted_user );
+		$granted_id = $this->repo->create_if_missing( 'granted', 'Granted', $this->owner_user );
+		$this->access_repo->grant_access( $granted_id, $this->granted_user, 'viewer' );
+
+		// Also grant access on an agent the user owns — must not duplicate the row.
+		$this->access_repo->grant_access( $owned_id, $this->granted_user, 'viewer' );
+
+		wp_set_current_user( $this->granted_user );
+		$result = AgentAbilities::listAgents( array() );
+
+		$this->assertCount( 2, $result['agents'] );
+
+		$ids = array_map( static fn( $a ) => $a['agent_id'], $result['agents'] );
+		$this->assertContains( $owned_id, $ids );
+		$this->assertContains( $granted_id, $ids );
+	}
+
+	public function test_bystander_gets_empty_list(): void {
+		$this->repo->create_if_missing( 'shared', 'Shared', $this->owner_user );
+
+		wp_set_current_user( $this->bystander_user );
+		$result = AgentAbilities::listAgents( array() );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array(), $result['agents'] );
+	}
+
+	public function test_default_scope_filters_by_status(): void {
+		$active_id = $this->repo->create_if_missing( 'active-agent', 'Active', $this->owner_user );
+		$this->repo->update_agent(
+			$this->repo->create_if_missing( 'inactive-agent', 'Inactive', $this->owner_user ),
+			array( 'status' => 'inactive' )
+		);
+
+		wp_set_current_user( $this->owner_user );
+		$result = AgentAbilities::listAgents( array( 'status' => 'active' ) );
+
+		$this->assertCount( 1, $result['agents'] );
+		$this->assertSame( $active_id, $result['agents'][0]['agent_id'] );
+	}
+
+	public function test_status_any_skips_status_filter(): void {
+		$this->repo->create_if_missing( 'active-agent', 'Active', $this->owner_user );
+		$this->repo->update_agent(
+			$this->repo->create_if_missing( 'inactive-agent', 'Inactive', $this->owner_user ),
+			array( 'status' => 'inactive' )
+		);
+
+		wp_set_current_user( $this->owner_user );
+		$result = AgentAbilities::listAgents( array( 'status' => 'any' ) );
+
+		$this->assertCount( 2, $result['agents'] );
+	}
+
+	// ---------------------------------------------------------------
+	// scope=all
+	// ---------------------------------------------------------------
+
+	public function test_scope_all_denied_for_non_admin(): void {
+		$this->repo->create_if_missing( 'shared', 'Shared', $this->owner_user );
+
+		wp_set_current_user( $this->granted_user );
+		$result = AgentAbilities::listAgents( array( 'scope' => 'all' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'admin', strtolower( $result['error'] ) );
+	}
+
+	public function test_scope_all_returns_all_agents_for_admin(): void {
+		$this->repo->create_if_missing( 'one', 'One', $this->owner_user );
+		$this->repo->create_if_missing( 'two', 'Two', $this->granted_user );
+		$this->repo->create_if_missing( 'three', 'Three', $this->bystander_user );
+
+		wp_set_current_user( $this->admin_user );
+		$result = AgentAbilities::listAgents( array( 'scope' => 'all' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertGreaterThanOrEqual( 3, count( $result['agents'] ) );
+	}
+
+	public function test_admin_default_scope_is_mine_not_all(): void {
+		$this->repo->create_if_missing( 'not-mine', 'Not Mine', $this->owner_user );
+
+		// Admin with no owned agents calling with defaults gets THEIR accessible
+		// agents (i.e. none), not the firehose. Backward-compat note in #996 body.
+		wp_set_current_user( $this->admin_user );
+		$result = AgentAbilities::listAgents( array() );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array(), $result['agents'] );
+	}
+
+	// ---------------------------------------------------------------
+	// user_id escalation
+	// ---------------------------------------------------------------
+
+	public function test_admin_can_query_other_user_agents(): void {
+		$agent_id = $this->repo->create_if_missing( 'target', 'Target', $this->owner_user );
+
+		wp_set_current_user( $this->admin_user );
+		$result = AgentAbilities::listAgents( array( 'user_id' => $this->owner_user ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 1, $result['agents'] );
+		$this->assertSame( $agent_id, $result['agents'][0]['agent_id'] );
+		$this->assertTrue( $result['agents'][0]['is_owner'], 'is_owner must reflect target user, not caller' );
+	}
+
+	public function test_non_admin_cannot_query_other_user(): void {
+		$this->repo->create_if_missing( 'target', 'Target', $this->owner_user );
+
+		wp_set_current_user( $this->granted_user );
+		$result = AgentAbilities::listAgents( array( 'user_id' => $this->owner_user ) );
+
+		$this->assertFalse( $result['success'] );
+	}
+
+	public function test_non_admin_can_explicitly_query_self(): void {
+		$agent_id = $this->repo->create_if_missing( 'mine', 'Mine', $this->owner_user );
+
+		wp_set_current_user( $this->owner_user );
+		$result = AgentAbilities::listAgents( array( 'user_id' => $this->owner_user ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 1, $result['agents'] );
+		$this->assertSame( $agent_id, $result['agents'][0]['agent_id'] );
+	}
+
+	// ---------------------------------------------------------------
+	// Role enrichment
+	// ---------------------------------------------------------------
+
+	public function test_include_role_returns_admin_for_owner(): void {
+		$this->repo->create_if_missing( 'mine', 'Mine', $this->owner_user );
+
+		wp_set_current_user( $this->owner_user );
+		$result = AgentAbilities::listAgents( array( 'include_role' => true ) );
+
+		$this->assertSame( 'admin', $result['agents'][0]['user_role'] );
+	}
+
+	public function test_include_role_returns_granted_role(): void {
+		$agent_id = $this->repo->create_if_missing( 'shared', 'Shared', $this->owner_user );
+		$this->access_repo->grant_access( $agent_id, $this->granted_user, 'operator' );
+
+		wp_set_current_user( $this->granted_user );
+		$result = AgentAbilities::listAgents( array( 'include_role' => true ) );
+
+		$this->assertSame( 'operator', $result['agents'][0]['user_role'] );
+	}
+
+	public function test_include_role_reflects_target_user_not_caller(): void {
+		$agent_id = $this->repo->create_if_missing( 'shared', 'Shared', $this->owner_user );
+		$this->access_repo->grant_access( $agent_id, $this->granted_user, 'viewer' );
+
+		// Admin queries on behalf of granted_user — role must be 'viewer' (granted_user's role),
+		// not 'admin' (caller's role).
+		wp_set_current_user( $this->admin_user );
+		$result = AgentAbilities::listAgents(
+			array(
+				'user_id'      => $this->granted_user,
+				'include_role' => true,
+			)
+		);
+
+		$this->assertSame( 'viewer', $result['agents'][0]['user_role'] );
+	}
+
+	public function test_omitting_include_role_leaves_user_role_absent(): void {
+		$this->repo->create_if_missing( 'mine', 'Mine', $this->owner_user );
+
+		wp_set_current_user( $this->owner_user );
+		$result = AgentAbilities::listAgents( array() );
+
+		$this->assertArrayNotHasKey( 'user_role', $result['agents'][0] );
+	}
+
+	// ---------------------------------------------------------------
+	// Description extraction
+	// ---------------------------------------------------------------
+
+	public function test_description_extracted_from_agent_config(): void {
+		$this->repo->create_if_missing(
+			'described',
+			'Described',
+			$this->owner_user,
+			array( 'description' => 'Your AI assistant.' )
+		);
+
+		wp_set_current_user( $this->owner_user );
+		$result = AgentAbilities::listAgents( array() );
+
+		$this->assertSame( 'Your AI assistant.', $result['agents'][0]['description'] );
+	}
+
+	public function test_description_empty_when_config_missing_description(): void {
+		$this->repo->create_if_missing( 'plain', 'Plain', $this->owner_user, array() );
+
+		wp_set_current_user( $this->owner_user );
+		$result = AgentAbilities::listAgents( array() );
+
+		$this->assertSame( '', $result['agents'][0]['description'] );
+	}
+
+	// ---------------------------------------------------------------
+	// Input validation
+	// ---------------------------------------------------------------
+
+	public function test_invalid_scope_rejected(): void {
+		wp_set_current_user( $this->owner_user );
+		$result = AgentAbilities::listAgents( array( 'scope' => 'garbage' ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'scope', strtolower( $result['error'] ) );
+	}
+}


### PR DESCRIPTION
## Summary

Closes #996.

Refactors \`datamachine/list-agents\` from an admin-only firehose into a **scope-aware primitive** that serves all callers (chat tools, frontend UIs, REST endpoint, CLI). One ability, one source of truth.

## Behavior change

- **Before:** admin-only, always returned every agent on the site.
- **After:** default \`scope=mine\` returns the caller's accessible agents (owned + access-granted, deduped). Admins can escalate via \`scope=all\` or \`user_id=<id>\` to query any user.

### Backward compat

The ability was admin-only before, so only admin code called it. Admin callers that want the old firehose now pass \`scope=all\`. The CLI \`list\` subcommand defaults to \`scope=all\` to preserve its historical behavior without forcing every operator to re-learn flags.

## Parameters

| Param          | Default       | Notes                                                 |
|----------------|---------------|-------------------------------------------------------|
| \`scope\`        | \`mine\`        | \`all\` requires admin                                  |
| \`user_id\`      | acting user   | non-admins forced to self                             |
| \`site_id\`      | current blog  | filters by \`site_scope\` + network-wide (\`NULL\`)       |
| \`status\`       | \`active\`      | \`any\` skips status filtering                          |
| \`include_role\` | \`false\`       | enriches each row with the resolved user's role       |

## Response shape additions

- \`description\` — extracted from \`agent_config.description\`
- \`is_owner\` — boolean; reflects **target user** (not the caller)
- \`user_role\` — when \`include_role=true\`, resolved against target user

## REST integration

\`GET /datamachine/v1/agents\` now delegates to the ability. All permission escalation, owned+granted resolution, and role enrichment live in one place. The REST controller becomes a thin parameter pass-through + response shaper. Supported query params: \`scope\`, \`user_id\`, \`status\`, \`include_role\`.

The dead \`shape_list_item()\` helper is removed (its logic moved into the ability).

## CLI integration

\`wp datamachine agents list\` gets new flags:

- \`--scope=mine|all\` (default: \`all\`)
- \`--user_id=<id>\` (implies \`scope=mine\`)
- \`--status=<status>\` (default: \`any\`)
- \`--include_role\`

Examples from the docblock:

\`\`\`
wp datamachine agents list                         # all agents (admin firehose)
wp datamachine agents list --user_id=5             # agents user 5 can access
wp datamachine agents list --scope=mine --include_role
\`\`\`

## Permission model

- **Base:** \`can('chat')\` OR \`can_manage()\` — non-admin chat capability holders can now discover their accessible agents through the ability.
- **Escalation** to \`scope=all\` or other-user \`user_id\`: \`can_manage()\`
- **Defence-in-depth:** per-agent \`can_access_agent()\` filter still runs for \`scope=mine\` self-queries, preserving the \`datamachine_can_access_agent\` override hook semantics. Skipped when admins query on behalf of another user so we don't accidentally drop agents the target user can actually access.

## Tests

\`tests/Unit/Abilities/ListAgentsAbilityTest.php\` — **17 cases** covering:

- **scope=mine:** owned, granted, union dedup, bystander empty, status filter, \`any\` bypass
- **scope=all:** admin-only gate, admin-default-is-mine-not-all
- **user_id escalation:** admin can query other user, non-admin denied, non-admin can explicitly query self
- **Role enrichment:** owner normalization to \`admin\`, granted role returned, target-user-not-caller semantics, absent when \`include_role=false\`
- **Description extraction:** present when config has it, empty string otherwise
- **Invalid scope rejected**

## What this unblocks

- **#972** (per-user dynamic toolsets) — chat tools can now discover a user's accessible agents through the primitive.
- **#919** (non-admin scoped agent creation) — the last-mile tickets can call \`list-agents\` without permission workarounds.
- **Multi-agent frontend chat UI** — the widget can render an agent switcher by calling the ability directly, no special-casing.

## Diff stats

\`\`\`
 inc/Abilities/AgentAbilities.php    | ~180 lines (new listAgents impl + schema)
 inc/Api/Agents.php                  | handle_list becomes thin delegation; shape_list_item removed
 inc/Cli/Commands/AgentsCommand.php  | new --scope/--user_id/--status/--include_role flags
 tests/Unit/Abilities/ListAgentsAbilityTest.php | new, 17 cases
\`\`\`

## Lint / PHPStan

Zero new violations introduced. Pre-existing repo-wide baseline unchanged.