### PR TITLE
feat(tasks): generic recurring-schedule helper for system tasks

### DIFF
--- a/docs/core-system/daily-memory-system.md
+++ b/docs/core-system/daily-memory-system.md
@@ -134,12 +134,14 @@ SystemTask::setPromptOverride('daily_memory_generation', 'memory_cleanup', 'Your
 
 ### Scheduling
 
-The `SystemAgentServiceProvider` manages the recurring Action Scheduler action:
+The `SystemAgentServiceProvider` wires the generic recurring-schedule helper (`TaskScheduler::ensureRecurringSchedule()`) for every task whose metadata declares `trigger_type='cron'` + a `setting_key`. Daily memory is just the first task to use it:
 
-- **Hook:** `datamachine_system_agent_daily_memory`
-- **Schedule:** Daily at midnight UTC (via `as_schedule_recurring_action`)
-- **Setting:** `daily_memory_enabled` (default: false) — when disabled, the schedule is unregistered
+- **Hook:** `datamachine_recurring_daily_memory_generation` (derived from task type)
+- **Schedule:** Daily at midnight UTC (via `as_schedule_recurring_action`, interval filterable via `datamachine_task_recurring_interval`)
+- **Setting:** `daily_memory_enabled` (default: false) — when disabled, the schedule is unregistered on the next `action_scheduler_init`
 - **Manual run:** Supported (`supports_run: true` in task meta) — can be triggered via CLI
+
+> Pre-0.48 installs used the hook `datamachine_system_agent_daily_memory`. On upgrade, that legacy action is auto-unscheduled by `SystemAgentServiceProvider::manageRecurringSchedules()` and replaced with the new generic hook.
 
 ### Task Metadata
 

--- a/docs/core-system/system-tasks.md
+++ b/docs/core-system/system-tasks.md
@@ -202,14 +202,25 @@ Hooks the `datamachine_tasks` filter to register the seven built-in task types:
 | `datamachine_task_handle` | `handleScheduledTask` | Dispatches a scheduled task job |
 | `datamachine_task_process_batch` | `handleBatchChunk` | Processes a batch chunk |
 | `datamachine_system_agent_set_featured_image` | `handleDeferredFeaturedImage` | Retries featured image assignment (up to 12 × 15s = 3 minutes) |
-| `datamachine_system_agent_daily_memory` | `handleDailyMemoryGeneration` | Triggers daily memory task |
+| `datamachine_recurring_<task_type>` | `TaskScheduler::handleRecurringHook` | Fires a recurring task — generic hook auto-registered for every task whose metadata declares `trigger_type='cron'` and a `setting_key` |
 
-### Daily Memory Schedule Management
+### Recurring Schedule Management
 
-On every page load (fast check via `as_next_scheduled_action`):
+Any task whose metadata declares both `trigger_type='cron'` and a `setting_key` is automatically managed by `TaskScheduler::ensureRecurringSchedule()` on every `action_scheduler_init`:
 
-- If `daily_memory_enabled` is true and no schedule exists → create recurring schedule at midnight UTC
-- If `daily_memory_enabled` is false and a schedule exists → unschedule all actions
+- If the setting is `true` and no schedule exists → create recurring action on hook `datamachine_recurring_<task_type>`.
+- If the setting is `false` and a schedule exists → unschedule all matching actions.
+- Otherwise → no-op (idempotent).
+
+Defaults are filterable per task type:
+
+| Filter | Default | Notes |
+|--------|---------|-------|
+| `datamachine_task_recurring_interval` | `DAY_IN_SECONDS` | Clamped to `HOUR_IN_SECONDS` minimum |
+| `datamachine_task_recurring_start_time` | Next midnight UTC for daily+, else `time()+interval` | Unix timestamp for the first run |
+| `datamachine_task_recurring_params` | `[]` | Params passed to `TaskScheduler::schedule()` when the hook fires |
+
+Extensions that register a task with this metadata shape (e.g. `data-machine-code`'s `worktree_cleanup`) get automatic schedule management with zero additional glue.
 
 ## SystemTaskStep
 

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -23,14 +23,19 @@ use DataMachine\Engine\AI\System\Tasks\InternalLinkingTask;
 use DataMachine\Engine\AI\System\Tasks\MetaDescriptionTask;
 use DataMachine\Engine\Tasks\TaskRegistry;
 use DataMachine\Engine\Tasks\TaskScheduler;
-use DataMachine\Core\PluginSettings;
 
 class SystemAgentServiceProvider {
 
 	/**
-	 * Action Scheduler hook name for daily memory generation.
+	 * Legacy Action Scheduler hook name for the daily memory task.
+	 *
+	 * Kept only so `manageRecurringSchedules()` can unschedule any action
+	 * left over from plugin versions before the generic recurring helper
+	 * landed. New code should use `TaskScheduler::getRecurringHook()`.
+	 *
+	 * @deprecated 0.48.0 Replaced by generic `datamachine_recurring_<task_type>` hooks.
 	 */
-	const DAILY_MEMORY_HOOK = 'datamachine_system_agent_daily_memory';
+	const LEGACY_DAILY_MEMORY_HOOK = 'datamachine_system_agent_daily_memory';
 
 	/**
 	 * Constructor - registers all task infrastructure.
@@ -39,7 +44,8 @@ class SystemAgentServiceProvider {
 		$this->registerTaskHandlers();
 		$this->initializeRegistry();
 		$this->registerActionSchedulerHooks();
-		add_action( 'action_scheduler_init', array( $this, 'manageDailyMemorySchedule' ) );
+		$this->registerRecurringTaskHooks();
+		add_action( 'action_scheduler_init', array( $this, 'manageRecurringSchedules' ) );
 	}
 
 	/**
@@ -105,50 +111,58 @@ class SystemAgentServiceProvider {
 			10,
 			3
 		);
-
-		add_action(
-			self::DAILY_MEMORY_HOOK,
-			array( $this, 'handleDailyMemoryGeneration' )
-		);
 	}
 
 	/**
-	 * Manage the daily memory recurring schedule.
+	 * Register one Action Scheduler callback per recurring task type.
 	 *
-	 * Ensures the recurring Action Scheduler action exists when enabled
-	 * and is removed when disabled. Deferred to action_scheduler_init
-	 * to avoid calling AS functions before the data store is initialized.
+	 * Iterates the task registry and binds
+	 * `datamachine_recurring_<task_type>` for every task that opts in via
+	 * `trigger_type='cron'` + `setting_key`. The callback fires
+	 * `TaskScheduler::handleRecurringHook($taskType)`, which in turn
+	 * creates a DM Job through the standard schedule() path.
 	 *
-	 * @since 0.32.0
+	 * Registered at bootstrap (before `action_scheduler_init`) so Action
+	 * Scheduler can locate the callback when recurring actions fire.
+	 *
+	 * @since 0.48.0
 	 */
-	public function manageDailyMemorySchedule(): void {
-		$enabled        = (bool) PluginSettings::get( 'daily_memory_enabled', false );
-		$next_scheduled = as_next_scheduled_action( self::DAILY_MEMORY_HOOK, array(), 'data-machine' );
-
-		if ( $enabled && ! $next_scheduled ) {
-			// Schedule daily at midnight UTC.
-			$midnight = strtotime( 'tomorrow midnight' );
-			as_schedule_recurring_action(
-				$midnight,
-				DAY_IN_SECONDS,
-				self::DAILY_MEMORY_HOOK,
-				array(),
-				'data-machine'
+	private function registerRecurringTaskHooks(): void {
+		foreach ( TaskScheduler::getRecurringTasks() as $task_type => $_meta ) {
+			$hook = TaskScheduler::getRecurringHook( $task_type );
+			add_action(
+				$hook,
+				static function () use ( $task_type ) {
+					TaskScheduler::handleRecurringHook( $task_type );
+				}
 			);
-		} elseif ( ! $enabled && $next_scheduled ) {
-			as_unschedule_all_actions( self::DAILY_MEMORY_HOOK, array(), 'data-machine' );
 		}
 	}
 
 	/**
-	 * Handle the daily memory generation Action Scheduler callback.
+	 * Reconcile recurring Action Scheduler schedules with current task settings.
 	 *
-	 * @since 0.32.0
+	 * Iterates every cron-triggered task in the registry and calls
+	 * `TaskScheduler::ensureRecurringSchedule()` — scheduling when enabled,
+	 * unscheduling when disabled. Idempotent. Deferred to
+	 * `action_scheduler_init` so the AS data store is ready.
+	 *
+	 * Also cleans up any legacy `datamachine_system_agent_daily_memory`
+	 * action left behind by pre-0.48 installs. Safe to remove after a
+	 * release or two when the legacy hook is no longer in flight.
+	 *
+	 * @since 0.48.0
 	 */
-	public function handleDailyMemoryGeneration(): void {
-		TaskScheduler::schedule( 'daily_memory_generation', array(
-			'date' => gmdate( 'Y-m-d' ),
-		) );
+	public function manageRecurringSchedules(): void {
+		// Remove leftover legacy daily-memory schedule from pre-0.48 installs.
+		if ( function_exists( 'as_next_scheduled_action' )
+			&& as_next_scheduled_action( self::LEGACY_DAILY_MEMORY_HOOK, array(), 'data-machine' ) ) {
+			as_unschedule_all_actions( self::LEGACY_DAILY_MEMORY_HOOK, array(), 'data-machine' );
+		}
+
+		foreach ( TaskScheduler::getRecurringTasks() as $task_type => $_meta ) {
+			TaskScheduler::ensureRecurringSchedule( $task_type );
+		}
 	}
 
 	/**

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -36,6 +36,209 @@ class TaskScheduler {
 	const BATCH_CHUNK_DELAY = 30;
 
 	/**
+	 * Hook prefix for recurring task Action Scheduler actions.
+	 *
+	 * Each cron-triggered task gets a hook named "{prefix}{task_type}".
+	 * Extensions may rely on this prefix when introspecting scheduled
+	 * actions, but the preferred lookup is via getRecurringHook().
+	 *
+	 * @since 0.48.0
+	 */
+	const RECURRING_HOOK_PREFIX = 'datamachine_recurring_';
+
+	/**
+	 * Derive the Action Scheduler hook name for a recurring task.
+	 *
+	 * @since 0.48.0
+	 *
+	 * @param string $taskType Task type identifier.
+	 * @return string Hook name (e.g. "datamachine_recurring_daily_memory_generation").
+	 */
+	public static function getRecurringHook( string $taskType ): string {
+		return self::RECURRING_HOOK_PREFIX . $taskType;
+	}
+
+	/**
+	 * Get task types that qualify for automatic recurring-schedule management.
+	 *
+	 * A task qualifies when its metadata declares both:
+	 * - `trigger_type` === 'cron'
+	 * - a non-empty `setting_key` so enable/disable can be toggled
+	 *
+	 * @since 0.48.0
+	 *
+	 * @return array<string, array> Task type => registry entry.
+	 */
+	public static function getRecurringTasks(): array {
+		$recurring = array();
+
+		foreach ( TaskRegistry::getRegistry() as $task_type => $meta ) {
+			if ( ( $meta['trigger_type'] ?? '' ) !== 'cron' ) {
+				continue;
+			}
+			if ( empty( $meta['setting_key'] ) ) {
+				continue;
+			}
+			$recurring[ $task_type ] = $meta;
+		}
+
+		return $recurring;
+	}
+
+	/**
+	 * Ensure a recurring Action Scheduler action exists that matches the task's setting.
+	 *
+	 * Idempotent — safe to call on every `action_scheduler_init`. Performs the
+	 * minimal transition to reconcile setting state with scheduled state:
+	 *
+	 * - setting enabled  + no scheduled action → schedule recurring action
+	 * - setting disabled + scheduled action    → unschedule all instances
+	 * - otherwise                              → no-op
+	 *
+	 * Does nothing for tasks that are not `trigger_type='cron'` or lack a
+	 * `setting_key`. Does nothing when Action Scheduler is not loaded.
+	 *
+	 * @since 0.48.0
+	 *
+	 * @param string $taskType Task type identifier.
+	 * @return void
+	 */
+	public static function ensureRecurringSchedule( string $taskType ): void {
+		if ( ! function_exists( 'as_next_scheduled_action' ) ) {
+			return;
+		}
+
+		$registry = TaskRegistry::getRegistry();
+		if ( ! isset( $registry[ $taskType ] ) ) {
+			return;
+		}
+
+		$meta = $registry[ $taskType ];
+		if ( ( $meta['trigger_type'] ?? '' ) !== 'cron' ) {
+			return;
+		}
+		if ( empty( $meta['setting_key'] ) ) {
+			return;
+		}
+
+		$hook    = self::getRecurringHook( $taskType );
+		$enabled = (bool) ( $meta['enabled'] ?? false );
+		$next    = as_next_scheduled_action( $hook, array(), 'data-machine' );
+
+		if ( $enabled && ! $next ) {
+			/**
+			 * Filter the interval (in seconds) for a recurring task schedule.
+			 *
+			 * Default is DAY_IN_SECONDS. Values below HOUR_IN_SECONDS are
+			 * clamped to HOUR_IN_SECONDS to prevent accidental self-DoS.
+			 *
+			 * @since 0.48.0
+			 *
+			 * @param int    $interval Interval in seconds. Default DAY_IN_SECONDS.
+			 * @param string $taskType Task type identifier.
+			 */
+			$interval = (int) apply_filters(
+				'datamachine_task_recurring_interval',
+				DAY_IN_SECONDS,
+				$taskType
+			);
+
+			if ( $interval < HOUR_IN_SECONDS ) {
+				$interval = HOUR_IN_SECONDS;
+			}
+
+			// Default start time: next midnight UTC for daily (or slower) cadences,
+			// otherwise the first slot one interval from now. Filterable for full control.
+			$default_start = $interval >= DAY_IN_SECONDS
+				? strtotime( 'tomorrow midnight' )
+				: time() + $interval;
+
+			/**
+			 * Filter the first-run timestamp for a recurring task schedule.
+			 *
+			 * @since 0.48.0
+			 *
+			 * @param int    $start    Unix timestamp for the first scheduled run.
+			 * @param string $taskType Task type identifier.
+			 * @param int    $interval Interval in seconds (post-clamp).
+			 */
+			$start = (int) apply_filters(
+				'datamachine_task_recurring_start_time',
+				$default_start,
+				$taskType,
+				$interval
+			);
+
+			as_schedule_recurring_action(
+				$start,
+				$interval,
+				$hook,
+				array(),
+				'data-machine'
+			);
+
+			do_action(
+				'datamachine_log',
+				'info',
+				"Recurring task scheduled: {$taskType}",
+				array(
+					'task_type' => $taskType,
+					'hook'      => $hook,
+					'interval'  => $interval,
+					'start'     => $start,
+					'context'   => 'system',
+				)
+			);
+		} elseif ( ! $enabled && $next ) {
+			as_unschedule_all_actions( $hook, array(), 'data-machine' );
+
+			do_action(
+				'datamachine_log',
+				'info',
+				"Recurring task unscheduled: {$taskType}",
+				array(
+					'task_type' => $taskType,
+					'hook'      => $hook,
+					'context'   => 'system',
+				)
+			);
+		}
+	}
+
+	/**
+	 * Action Scheduler callback for a recurring task hook.
+	 *
+	 * Invoked when the recurring action fires. Creates a proper DM Job
+	 * via TaskScheduler::schedule() so the task runs through the standard
+	 * job pipeline (pending → processing → completed/failed).
+	 *
+	 * Params default to an empty array and are filterable per task type.
+	 *
+	 * @since 0.48.0
+	 *
+	 * @param string $taskType Task type identifier.
+	 * @return void
+	 */
+	public static function handleRecurringHook( string $taskType ): void {
+		/**
+		 * Filter the parameters passed to TaskScheduler::schedule() when a
+		 * recurring task hook fires.
+		 *
+		 * @since 0.48.0
+		 *
+		 * @param array  $params   Task parameters. Default empty array.
+		 * @param string $taskType Task type identifier.
+		 */
+		$params = apply_filters( 'datamachine_task_recurring_params', array(), $taskType );
+
+		if ( ! is_array( $params ) ) {
+			$params = array();
+		}
+
+		self::schedule( $taskType, $params );
+	}
+
+	/**
 	 * Schedule an async task.
 	 *
 	 * Creates a DM Job record and schedules an Action Scheduler action for


### PR DESCRIPTION
## Summary

Extracts the hardcoded daily-memory scheduling glue into a reusable helper on `TaskScheduler`. Any task whose metadata declares `trigger_type='cron'` + a `setting_key` now gets automatic recurring-schedule management — extension plugins ship cron tasks with zero core modifications.

Closes a concrete shortcoming flagged in #1047 without waiting for the full SystemTask-into-flows unification. Unblocks downstream Extra-Chill/data-machine-code#35.

Refs: #1114, #1047.

## What changed

**New on `TaskScheduler`**
- `getRecurringHook(string $taskType): string` — derives hook name `datamachine_recurring_<task_type>`.
- `getRecurringTasks(): array` — returns tasks eligible for auto-scheduling (cron + setting_key).
- `ensureRecurringSchedule(string $taskType): void` — idempotent reconciler. Schedules when the setting is true and no AS action exists; unschedules when the setting is false and one does. No-op otherwise or for tasks that don't opt in.
- `handleRecurringHook(string $taskType): void` — generic AS callback that delegates to `TaskScheduler::schedule()` so tasks still flow through the standard job pipeline.

**Rewired `SystemAgentServiceProvider`**
- Dropped task-specific `DAILY_MEMORY_HOOK`, `manageDailyMemorySchedule()`, `handleDailyMemoryGeneration()`.
- `registerRecurringTaskHooks()` — iterates the registry at bootstrap and `add_action`s one callback per cron task.
- `manageRecurringSchedules()` — runs on `action_scheduler_init` and calls `ensureRecurringSchedule()` for every cron task.
- Auto-cleans the legacy `datamachine_system_agent_daily_memory` action so existing installs migrate seamlessly to the new hook naming. The constant is kept as `LEGACY_DAILY_MEMORY_HOOK` for the one-shot cleanup.

**New filters (all per `$task_type`)**
- `datamachine_task_recurring_interval` — default `DAY_IN_SECONDS`, clamped to `HOUR_IN_SECONDS` floor.
- `datamachine_task_recurring_start_time` — default: next midnight UTC for daily+ cadences, else `time() + $interval`.
- `datamachine_task_recurring_params` — default `[]`; passed to `TaskScheduler::schedule()` when the hook fires.

## Behavior preservation

`DailyMemoryTask` still runs daily at midnight UTC and still honors `daily_memory_enabled`. The only user-visible change is the AS hook name (now `datamachine_recurring_daily_memory_generation`). On upgrade, the legacy hook is auto-unscheduled on the first `action_scheduler_init`. `DailyMemoryTask::execute()` already falls back to `gmdate('Y-m-d')` when params are empty, so the switch from explicit `['date' => ...]` to empty params is transparent.

No changes to `TaskScheduler::schedule()`, `TaskRegistry::getRegistry()`, or `SystemTask` public APIs.

## Acceptance tests run on intelligence-chubes4

1. **Baseline preserved** — after install, `datamachine_recurring_daily_memory_generation` is scheduled for next midnight UTC.
2. **Legacy cleanup** — the old `datamachine_system_agent_daily_memory` action was auto-canceled on the first `action_scheduler_init` tick.
3. **Toggle off** — setting `daily_memory_enabled=false` + running the manager → recurring action unscheduled (pending list empty).
4. **Toggle on** — setting it back to `true` → new recurring action scheduled at next midnight.
5. **Fake task** — registered a throwaway `fake_recurring_test` task with `trigger_type='cron'` + `setting_key='test_task_enabled'`, enabled the setting, called `ensureRecurringSchedule('fake_recurring_test')` → AS action `datamachine_recurring_fake_recurring_test` created, confirming the generic path works for any task without per-task code.

## Scope

- No changes to `data-machine-code`. That repo's PR #35 picks this up.
- `#1047` intentionally stays open — this is a targeted step toward the larger unification, not the unification itself.