### PR TITLE
feat(chat): datamachine_conversation_store filter seam

### DIFF
--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -1081,6 +1081,89 @@ for the full adapter contract.
 - Maximum turn limiting (default: 25)
 - Runtime-swappable via `datamachine_conversation_runner`
 
+### ConversationStoreInterface (`/inc/Core/Database/Chat/ConversationStoreInterface.php`)
+
+**Purpose**: Single seam between chat session persistence and the underlying
+storage backend. The default implementation ([`Chat`](../../../inc/Core/Database/Chat/Chat.php))
+preserves byte-for-byte the MySQL-table behavior the codebase used before
+this seam was introduced — self-hosted users see no change.
+
+**Filter: `datamachine_conversation_store`**
+
+```php
+apply_filters(
+    'datamachine_conversation_store',
+    ConversationStoreInterface $default  // the built-in MySQL-table Chat store
+);
+```
+
+Return a different `ConversationStoreInterface` implementation to swap the
+backend. Return the default (or anything not implementing the interface) to
+keep the built-in store. Misuse falls back to the default and logs via
+`datamachine_log`.
+
+**Use case**: managed-host environments where chat sessions should live in
+a framework-provided conversation store rather than the site DB (e.g.
+Intelligence on WordPress.com routing through `\WPCOM\AI\Services\Conversation_Storage`).
+A consumer plugin ships an adapter and registers it conditionally:
+
+```php
+add_filter( 'datamachine_conversation_store', function ( $store ) {
+    if ( $store instanceof My_AIFramework_Conversation_Store ) {
+        return $store; // already swapped
+    }
+    if ( ! function_exists( 'my_host_is_wpcom' ) || ! my_host_is_wpcom() ) {
+        return $store; // self-hosted — keep MySQL default
+    }
+    return new My_AIFramework_Conversation_Store();
+}, 10, 1 );
+```
+
+**Single consumer of the store**: `\DataMachine\Core\Database\Chat\ConversationStoreFactory::get()`.
+
+Every core caller — `ChatOrchestrator`, the five Chat Session abilities
+(via `ChatSessionHelpers`), `ChatCommand`, `SystemAbilities`, the
+scheduled cleanup action — resolves the store through the factory. The
+factory caches the store per request and applies the filter exactly once.
+
+**Message shape contract**
+
+Stores MUST normalize messages on read to Data Machine message shape:
+
+```php
+[
+    'id'         => string,                 // Stable message identifier
+    'role'       => 'user'|'assistant'|'system'|'tool',
+    'content'    => string|array,
+    'metadata'   => array,                  // Tool calls, tokens, provider-specific fields
+    'created_at' => string,                 // MySQL DATETIME (UTC)
+    'updated_at' => string,                 // MySQL DATETIME (UTC)
+]
+```
+
+The five Chat Session abilities and the DM chat UI consume this shape.
+Adapter stores (e.g. around `WPCOM\AI\Message` with `data` instead of
+`metadata`) are responsible for aliasing on the way out.
+
+**Swap boundary**
+
+- ✅ What stays stable: all 5 chat abilities, REST endpoints, the DM chat
+  UI, the session switcher, title generation, unread counts, last-read logic.
+- 🔄 What swaps: concrete storage (MySQL table vs. framework-managed store
+  vs. in-memory test fixture).
+- ❌ What is NOT a replacement point: session ownership checks, agent
+  adoption, token resolution, title generation. Those stay in the higher-
+  level callers.
+
+**Contract summary** (full signatures in [`ConversationStoreInterface.php`](../../../inc/Core/Database/Chat/ConversationStoreInterface.php)):
+
+- `create_session / get_session / update_session / delete_session`
+- `get_user_sessions / get_user_session_count` — switcher data
+- `get_recent_pending_session` — timeout-retry dedup
+- `update_title / mark_session_read` — UI state
+- `count_unread` — pure derivation from a messages array
+- `cleanup_expired_sessions / cleanup_old_sessions / cleanup_orphaned_sessions` — scheduled cleanup
+
 ### AgentMemoryStoreInterface (`/inc/Core/FilesRepository/AgentMemoryStoreInterface.php`)
 
 **Purpose**: Single seam between agent memory operations and the underlying

--- a/inc/Abilities/Chat/ChatSessionHelpers.php
+++ b/inc/Abilities/Chat/ChatSessionHelpers.php
@@ -12,16 +12,17 @@
 namespace DataMachine\Abilities\Chat;
 
 use DataMachine\Abilities\PermissionHelper;
-use DataMachine\Core\Database\Chat\Chat as ChatDatabase;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
+use DataMachine\Core\Database\Chat\ConversationStoreInterface;
 
 defined( 'ABSPATH' ) || exit;
 
 trait ChatSessionHelpers {
 
-	protected ChatDatabase $chat_db;
+	protected ConversationStoreInterface $chat_db;
 
 	protected function initDatabase(): void {
-		$this->chat_db = new ChatDatabase();
+		$this->chat_db = ConversationStoreFactory::get();
 	}
 
 	/**

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -14,7 +14,7 @@ namespace DataMachine\Abilities;
 use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Engine\AI\RequestBuilder;
-use DataMachine\Core\Database\Chat\Chat as ChatDatabase;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\Tasks\TaskScheduler;
 use DataMachine\Engine\Tasks\TaskRegistry;
@@ -391,7 +391,7 @@ class SystemAbilities {
 		$session_id = $input['session_id'];
 		$force      = $input['force'] ?? false;
 
-		$chat_db = new ChatDatabase();
+		$chat_db = ConversationStoreFactory::get();
 		$session = $chat_db->get_session($session_id);
 
 		if ( ! $session ) {

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -16,7 +16,7 @@
 
 namespace DataMachine\Api\Chat;
 
-use DataMachine\Core\Database\Chat\Chat as ChatDatabase;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\ConversationManager;
 use DataMachine\Engine\AI\AIConversationLoop;
@@ -64,7 +64,7 @@ class ChatOrchestrator {
 		$request_id           = $options['request_id'] ?? null;
 		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
 
-		$chat_db          = new ChatDatabase();
+		$chat_db          = ConversationStoreFactory::get();
 		$session_metadata = array();
 		$acting_token_id  = \DataMachine\Abilities\PermissionHelper::get_acting_token_id();
 
@@ -293,7 +293,7 @@ class ChatOrchestrator {
 	public static function processContinue( string $session_id, int $user_id ): array|WP_Error {
 		$max_turns = PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
 
-		$chat_db = new ChatDatabase();
+		$chat_db = ConversationStoreFactory::get();
 		$session = $chat_db->get_session( $session_id );
 
 		if ( ! $session ) {
@@ -437,7 +437,7 @@ class ChatOrchestrator {
 		);
 		$user_id     = ! empty( $admin_users ) ? $admin_users[0]->ID : 1;
 
-		$chat_db = new ChatDatabase();
+		$chat_db = ConversationStoreFactory::get();
 
 		$session_id = self::createSession( $user_id, 'ping' );
 
@@ -580,8 +580,8 @@ class ChatOrchestrator {
 			return $result['session_id'];
 		}
 
-		// Fallback: direct DB access.
-		$chat_db  = new ChatDatabase();
+		// Fallback: direct store access.
+		$chat_db  = ConversationStoreFactory::get();
 		$metadata = array(
 			'started_at'    => current_time( 'mysql', true ),
 			'message_count' => 0,
@@ -645,7 +645,7 @@ class ChatOrchestrator {
 		$context              = $options['context'] ?? ToolPolicyResolver::CONTEXT_CHAT;
 		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
 
-		$chat_db = new ChatDatabase();
+		$chat_db = ConversationStoreFactory::get();
 
 		try {
 			$user_id = $options['user_id'] ?? 0;

--- a/inc/Cli/Commands/ChatCommand.php
+++ b/inc/Cli/Commands/ChatCommand.php
@@ -12,7 +12,7 @@ namespace DataMachine\Cli\Commands;
 
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
-use DataMachine\Core\Database\Chat\Chat as ChatDatabase;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -75,7 +75,7 @@ class ChatCommand extends BaseCommand {
 		$offset  = max( 0, (int) ( $assoc_args['offset'] ?? 0 ) );
 		$context = ! empty( $assoc_args['context'] ) ? sanitize_text_field( $assoc_args['context'] ) : null;
 
-		$chat_db  = new ChatDatabase();
+		$chat_db  = ConversationStoreFactory::get();
 		$sessions = $chat_db->get_user_sessions( $user_id, $limit, $offset, $context );
 		$total    = $chat_db->get_user_session_count( $user_id, $context );
 
@@ -142,7 +142,7 @@ class ChatCommand extends BaseCommand {
 		}
 
 		$user_id = $this->get_user_id( $assoc_args );
-		$chat_db = new ChatDatabase();
+		$chat_db = ConversationStoreFactory::get();
 
 		$session = $chat_db->get_session( $session_id );
 
@@ -241,7 +241,7 @@ class ChatCommand extends BaseCommand {
 			'source'        => $source,
 		);
 
-		$chat_db    = new ChatDatabase();
+		$chat_db    = ConversationStoreFactory::get();
 		$session_id = $chat_db->create_session( $user_id, $agent_id, $metadata, $context );
 
 		if ( empty( $session_id ) ) {
@@ -283,7 +283,7 @@ class ChatCommand extends BaseCommand {
 		}
 
 		$user_id = $this->get_user_id( $assoc_args );
-		$chat_db = new ChatDatabase();
+		$chat_db = ConversationStoreFactory::get();
 
 		$session = $chat_db->get_session( $session_id );
 

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -20,8 +20,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Chat Database Manager
+ *
+ * Implements {@see ConversationStoreInterface} so the conversation
+ * storage backend can be swapped via the `datamachine_conversation_store`
+ * filter. Resolve via {@see ConversationStoreFactory::get()} rather than
+ * instantiating this class directly.
  */
-class Chat extends BaseRepository {
+class Chat extends BaseRepository implements ConversationStoreInterface {
 
 	/**
 	 * Table name (without prefix)
@@ -918,11 +923,15 @@ class Chat extends BaseRepository {
 add_action(
 	'datamachine_cleanup_chat_sessions',
 	function () {
-		if ( ! Chat::table_exists() ) {
+		// Route through the factory so a swapped store (e.g. an AI Framework
+		// shim) gets its own cleanup semantics. The default MySQL store gates
+		// on table existence internally.
+		$chat_db = ConversationStoreFactory::get();
+
+		if ( $chat_db instanceof Chat && ! Chat::table_exists() ) {
 			return;
 		}
 
-		$chat_db        = new Chat();
 		$retention_days = \DataMachine\Core\PluginSettings::get( 'chat_retention_days', 90 );
 
 		$deleted_count = $chat_db->cleanup_old_sessions( $retention_days );

--- a/inc/Core/Database/Chat/ConversationStoreFactory.php
+++ b/inc/Core/Database/Chat/ConversationStoreFactory.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Conversation Store Factory
+ *
+ * Resolves the active {@see ConversationStoreInterface} implementation
+ * via the `datamachine_conversation_store` filter, falling back to the
+ * built-in {@see Chat} MySQL-table store.
+ *
+ * Single resolution point so every consumer (ChatOrchestrator, the
+ * Chat Session abilities trait, ChatCommand, SystemAbilities) gets the
+ * same swap mechanism without duplicating the filter call.
+ *
+ * Instances are resolved once per request and cached, mirroring how a
+ * single `new ChatDatabase()` per callsite behaved before — no behavior
+ * change for self-hosted users.
+ *
+ * @package DataMachine\Core\Database\Chat
+ * @since   next
+ */
+
+namespace DataMachine\Core\Database\Chat;
+
+defined( 'ABSPATH' ) || exit;
+
+class ConversationStoreFactory {
+
+	/**
+	 * Per-request cached store instance.
+	 *
+	 * @var ConversationStoreInterface|null
+	 */
+	private static ?ConversationStoreInterface $instance = null;
+
+	/**
+	 * Resolve the active conversation store.
+	 *
+	 * First call runs the filter and caches the result. Subsequent calls
+	 * within the same request return the cached instance. Use
+	 * {@see self::reset()} in tests.
+	 *
+	 * @return ConversationStoreInterface
+	 */
+	public static function get(): ConversationStoreInterface {
+		if ( null !== self::$instance ) {
+			return self::$instance;
+		}
+
+		$default = new Chat();
+
+		/**
+		 * Filter: swap the chat conversation persistence backend.
+		 *
+		 * Return a {@see ConversationStoreInterface} instance to short-circuit
+		 * the default MySQL-table store. Return the default (or anything not
+		 * implementing the interface) to use the built-in {@see Chat} store.
+		 *
+		 * The MySQL default preserves byte-for-byte the behavior Data Machine
+		 * had before this seam was introduced — self-hosted users see no
+		 * change. Managed-host consumers (e.g. Intelligence on WordPress.com)
+		 * can register an AI Framework-backed implementation conditionally:
+		 *
+		 *     add_filter( 'datamachine_conversation_store', function ( $store ) {
+		 *         if ( $store instanceof My_AIFramework_Conversation_Store ) {
+		 *             return $store; // already swapped
+		 *         }
+		 *         if ( ! function_exists( 'my_host_is_wpcom' ) || ! my_host_is_wpcom() ) {
+		 *             return $store; // self-hosted — keep MySQL default
+		 *         }
+		 *         return new My_AIFramework_Conversation_Store();
+		 *     }, 10, 1 );
+		 *
+		 * The store MUST normalize messages on read to Data Machine message
+		 * shape — see docs/development/hooks/core-filters.md for the full
+		 * contract.
+		 *
+		 * @since next
+		 *
+		 * @param ConversationStoreInterface $store Default MySQL-table store.
+		 */
+		$resolved = apply_filters( 'datamachine_conversation_store', $default );
+
+		if ( $resolved instanceof ConversationStoreInterface ) {
+			self::$instance = $resolved;
+			return self::$instance;
+		}
+
+		// Filter returned a non-implementing value. Fall back to default and
+		// log the misuse so developers find the bug.
+		do_action(
+			'datamachine_log',
+			'error',
+			'datamachine_conversation_store filter returned a non-ConversationStoreInterface value. Falling back to default.',
+			array( 'returned_type' => is_object( $resolved ) ? get_class( $resolved ) : gettype( $resolved ) )
+		);
+
+		self::$instance = $default;
+		return self::$instance;
+	}
+
+	/**
+	 * Reset the cached instance. Test-only.
+	 *
+	 * Production code MUST NOT call this — it exists so unit tests can
+	 * install a fresh filter between test cases.
+	 *
+	 * @return void
+	 */
+	public static function reset(): void {
+		self::$instance = null;
+	}
+}

--- a/inc/Core/Database/Chat/ConversationStoreInterface.php
+++ b/inc/Core/Database/Chat/ConversationStoreInterface.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Conversation Store Interface
+ *
+ * Single seam between chat session operations and the underlying
+ * persistence backend. Default implementation ({@see Chat}) preserves
+ * today's MySQL-table behavior. Consumers can swap in an alternate
+ * store via the `datamachine_conversation_store` filter (e.g. an
+ * AI Framework Conversation_Storage shim on managed hosts like
+ * WordPress.com).
+ *
+ * The five Chat Session abilities (list / get / create / delete /
+ * mark-read) and the Chat Orchestrator all route session I/O through
+ * this seam. The DM chat UI and REST surface are unaffected — they
+ * consume the ability contracts, not the store directly.
+ *
+ * Implementations are responsible for:
+ * - normalizing messages on read to Data Machine message shape
+ *   (see docs/development/hooks/core-filters.md#message-shape-contract);
+ * - preserving per-session identity via UUIDv4 session IDs;
+ * - honoring the `(user_id, agent_id, context)` triple when listing.
+ *
+ * Session-scope policy (ownership checks, token resolution, agent
+ * adoption, title generation) stays in the higher-level callers
+ * ({@see \DataMachine\Api\Chat\ChatOrchestrator},
+ * {@see \DataMachine\Abilities\Chat\ChatSessionHelpers}). The store
+ * is the dumb persistence layer underneath.
+ *
+ * @package DataMachine\Core\Database\Chat
+ * @since   next
+ */
+
+namespace DataMachine\Core\Database\Chat;
+
+defined( 'ABSPATH' ) || exit;
+
+interface ConversationStoreInterface {
+
+	/**
+	 * Create a new chat session and return its ID.
+	 *
+	 * @param int    $user_id  WordPress user ID owning the session.
+	 * @param int    $agent_id Agent ID (0 = legacy agent-less session).
+	 * @param array  $metadata Arbitrary session metadata (JSON-serializable).
+	 * @param string $context  Execution context ('chat', 'pipeline', 'system').
+	 * @return string Session ID (UUIDv4), or empty string on failure.
+	 */
+	public function create_session( int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string;
+
+	/**
+	 * Retrieve a session by ID.
+	 *
+	 * Returns the session as an associative array with keys:
+	 * session_id, user_id, agent_id, title, messages (decoded array),
+	 * metadata (decoded array), provider, model, context, created_at,
+	 * updated_at, last_read_at, expires_at.
+	 *
+	 * @param string $session_id Session UUID.
+	 * @return array|null Session data or null if not found.
+	 */
+	public function get_session( string $session_id ): ?array;
+
+	/**
+	 * Replace a session's messages + metadata.
+	 *
+	 * @param string $session_id Session UUID.
+	 * @param array  $messages   Complete messages array (not a delta).
+	 * @param array  $metadata   Updated metadata.
+	 * @param string $provider   Optional AI provider identifier.
+	 * @param string $model      Optional AI model identifier.
+	 * @return bool True on success.
+	 */
+	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '' ): bool;
+
+	/**
+	 * Delete a session by ID. Idempotent.
+	 *
+	 * @param string $session_id Session UUID.
+	 * @return bool True on success.
+	 */
+	public function delete_session( string $session_id ): bool;
+
+	/**
+	 * List sessions for a user with pagination and optional filtering.
+	 *
+	 * Returned entries are summary rows intended for the session switcher
+	 * (session_id, title, context, first_message, message_count,
+	 * unread_count, agent_id, agent_slug, agent_name, created_at,
+	 * updated_at). Implementations MUST include agent metadata so the
+	 * switcher UI can render without an N+1 lookup.
+	 *
+	 * @param int         $user_id  WordPress user ID.
+	 * @param int         $limit    Max rows to return (1-100).
+	 * @param int         $offset   Pagination offset.
+	 * @param string|null $context  Optional context filter.
+	 * @param int|null    $agent_id Optional agent filter (null = all agents).
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function get_user_sessions( int $user_id, int $limit = 20, int $offset = 0, ?string $context = null, ?int $agent_id = null ): array;
+
+	/**
+	 * Total session count for a user, honoring optional filters.
+	 *
+	 * @param int         $user_id  WordPress user ID.
+	 * @param string|null $context  Optional context filter.
+	 * @param int|null    $agent_id Optional agent filter (null = all agents).
+	 * @return int
+	 */
+	public function get_user_session_count( int $user_id, ?string $context = null, ?int $agent_id = null ): int;
+
+	/**
+	 * Find a recent pending session for deduplication after request timeouts.
+	 *
+	 * Returns the most recent session that belongs to $user_id, was created
+	 * within $seconds, and is either empty or actively processing. Used by
+	 * the orchestrator to avoid duplicate sessions when a Cloudflare timeout
+	 * triggers a client retry while PHP keeps executing.
+	 *
+	 * @param int      $user_id  WordPress user ID.
+	 * @param int      $seconds  Lookback window (default 600 = 10 minutes).
+	 * @param string   $context  Context filter.
+	 * @param int|null $token_id Optional token ID for login-scoped dedup.
+	 * @return array|null Session data or null if none.
+	 */
+	public function get_recent_pending_session( int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array;
+
+	/**
+	 * Set a session's display title.
+	 *
+	 * @param string $session_id Session UUID.
+	 * @param string $title      New title.
+	 * @return bool True on success.
+	 */
+	public function update_title( string $session_id, string $title ): bool;
+
+	/**
+	 * Count unread assistant messages in a decoded messages array.
+	 *
+	 * Pure derivation from a messages array — default impl is stateless
+	 * and has no backend I/O. Included on the interface so consumers get
+	 * the same unread semantics regardless of backend.
+	 *
+	 * @param array       $messages     Decoded messages array.
+	 * @param string|null $last_read_at MySQL datetime of last read, or null.
+	 * @return int
+	 */
+	public function count_unread( array $messages, ?string $last_read_at ): int;
+
+	/**
+	 * Mark a session as read (updates last_read_at).
+	 *
+	 * @param string $session_id Session UUID.
+	 * @param int    $user_id    User ID for ownership scope.
+	 * @return string|false New last_read_at MySQL datetime, or false on failure.
+	 */
+	public function mark_session_read( string $session_id, int $user_id );
+
+	/**
+	 * Delete sessions whose `expires_at` has passed.
+	 *
+	 * @return int Number of sessions deleted.
+	 */
+	public function cleanup_expired_sessions(): int;
+
+	/**
+	 * Delete sessions older than the retention window.
+	 *
+	 * @param int $retention_days Days to retain sessions (by updated_at).
+	 * @return int Number of sessions deleted.
+	 */
+	public function cleanup_old_sessions( int $retention_days ): int;
+
+	/**
+	 * Delete sessions that were created but never received a message.
+	 *
+	 * Orphaned sessions are the fallout from request timeouts that left
+	 * empty rows behind. This cleanup keeps the switcher tidy.
+	 *
+	 * @param int $hours Age threshold in hours (default 1).
+	 * @return int Number of sessions deleted.
+	 */
+	public function cleanup_orphaned_sessions( int $hours = 1 ): int;
+}

--- a/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
+++ b/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Conversation Store Factory Tests
+ *
+ * Coverage for the `datamachine_conversation_store` filter seam:
+ * - default resolution returns the built-in Chat store
+ * - a filter can swap the store
+ * - a misbehaving filter (non-interface return) falls back to the default
+ * - the instance is cached per request
+ * - abilities routed through ChatSessionHelpers observe the swap
+ *
+ * @package DataMachine\Tests\Unit\Core\Database\Chat
+ */
+
+namespace DataMachine\Tests\Unit\Core\Database\Chat;
+
+use DataMachine\Abilities\Chat\ListChatSessionsAbility;
+use DataMachine\Core\Database\Chat\Chat;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
+use DataMachine\Core\Database\Chat\ConversationStoreInterface;
+use WP_UnitTestCase;
+
+class ConversationStoreFactoryTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		ConversationStoreFactory::reset();
+	}
+
+	public function tear_down(): void {
+		ConversationStoreFactory::reset();
+		remove_all_filters( 'datamachine_conversation_store' );
+		parent::tear_down();
+	}
+
+	// -----------------------------------------------------------------
+	// Factory contract
+	// -----------------------------------------------------------------
+
+	public function test_default_resolution_returns_builtin_chat_store(): void {
+		$store = ConversationStoreFactory::get();
+
+		$this->assertInstanceOf( ConversationStoreInterface::class, $store );
+		$this->assertInstanceOf( Chat::class, $store );
+	}
+
+	public function test_filter_swaps_the_store(): void {
+		$memory_store = new InMemoryConversationStore();
+
+		add_filter(
+			'datamachine_conversation_store',
+			static fn() => $memory_store,
+			10,
+			1
+		);
+
+		$resolved = ConversationStoreFactory::get();
+
+		$this->assertSame( $memory_store, $resolved );
+		$this->assertNotInstanceOf( Chat::class, $resolved );
+	}
+
+	public function test_misbehaving_filter_falls_back_to_default(): void {
+		add_filter(
+			'datamachine_conversation_store',
+			static fn() => 'not-a-store',
+			10,
+			1
+		);
+
+		$resolved = ConversationStoreFactory::get();
+
+		$this->assertInstanceOf( Chat::class, $resolved );
+	}
+
+	public function test_resolution_is_cached_per_request(): void {
+		$calls = 0;
+		add_filter(
+			'datamachine_conversation_store',
+			static function ( $store ) use ( &$calls ) {
+				++$calls;
+				return $store;
+			},
+			10,
+			1
+		);
+
+		ConversationStoreFactory::get();
+		ConversationStoreFactory::get();
+		ConversationStoreFactory::get();
+
+		$this->assertSame( 1, $calls, 'The filter should run exactly once per request.' );
+	}
+
+	public function test_reset_lets_tests_install_a_fresh_filter(): void {
+		$first = ConversationStoreFactory::get();
+		$this->assertInstanceOf( Chat::class, $first );
+
+		$memory_store = new InMemoryConversationStore();
+		add_filter(
+			'datamachine_conversation_store',
+			static fn() => $memory_store,
+			10,
+			1
+		);
+
+		// Without reset, we'd still see the cached default.
+		$still_cached = ConversationStoreFactory::get();
+		$this->assertInstanceOf( Chat::class, $still_cached );
+
+		ConversationStoreFactory::reset();
+		$this->assertSame( $memory_store, ConversationStoreFactory::get() );
+	}
+
+	// -----------------------------------------------------------------
+	// End-to-end: abilities observe the swap through ChatSessionHelpers
+	// -----------------------------------------------------------------
+
+	public function test_list_chat_sessions_ability_routes_through_swapped_store(): void {
+		$memory_store = new InMemoryConversationStore();
+		$user_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		// Seed the in-memory store with a session under the target user.
+		$session_id = $memory_store->create_session( $user_id, 0, array(), 'chat' );
+		$memory_store->update_session(
+			$session_id,
+			array(
+				array(
+					'role'     => 'user',
+					'content'  => 'hello',
+					'metadata' => array( 'type' => 'text' ),
+				),
+			)
+		);
+
+		add_filter(
+			'datamachine_conversation_store',
+			static fn() => $memory_store,
+			10,
+			1
+		);
+		ConversationStoreFactory::reset();
+
+		$ability = new ListChatSessionsAbility();
+		$result  = $ability->execute(
+			array(
+				'user_id' => $user_id,
+				'limit'   => 10,
+				'offset'  => 0,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $result['total'] );
+		$this->assertCount( 1, $result['sessions'] );
+		$this->assertSame( $session_id, $result['sessions'][0]['session_id'] );
+		$this->assertSame( 'hello', $result['sessions'][0]['first_message'] );
+	}
+}

--- a/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
+++ b/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * In-memory ConversationStoreInterface implementation for tests.
+ *
+ * Reference adapter demonstrating how a third-party store slots into the
+ * `datamachine_conversation_store` filter without depending on `$wpdb`.
+ * Stays in lockstep with {@see \DataMachine\Core\Database\Chat\Chat}'s
+ * observable shape so the chat abilities work identically against it.
+ *
+ * @package DataMachine\Tests\Unit\Core\Database\Chat
+ */
+
+namespace DataMachine\Tests\Unit\Core\Database\Chat;
+
+use DataMachine\Core\Database\Chat\ConversationStoreInterface;
+
+class InMemoryConversationStore implements ConversationStoreInterface {
+
+	/**
+	 * Session rows keyed by session_id.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	private array $sessions = array();
+
+	public function create_session( int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string {
+		$session_id = 'mem-' . bin2hex( random_bytes( 6 ) );
+		$now        = gmdate( 'Y-m-d H:i:s' );
+
+		$this->sessions[ $session_id ] = array(
+			'session_id'   => $session_id,
+			'user_id'      => $user_id,
+			'agent_id'     => $agent_id > 0 ? $agent_id : null,
+			'title'        => null,
+			'messages'     => array(),
+			'metadata'     => $metadata,
+			'provider'     => null,
+			'model'        => null,
+			'context'      => $context,
+			'created_at'   => $now,
+			'updated_at'   => $now,
+			'last_read_at' => null,
+			'expires_at'   => null,
+		);
+
+		return $session_id;
+	}
+
+	public function get_session( string $session_id ): ?array {
+		return $this->sessions[ $session_id ] ?? null;
+	}
+
+	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '' ): bool {
+		if ( ! isset( $this->sessions[ $session_id ] ) ) {
+			return false;
+		}
+
+		$this->sessions[ $session_id ]['messages']   = $messages;
+		$this->sessions[ $session_id ]['metadata']   = $metadata;
+		$this->sessions[ $session_id ]['updated_at'] = gmdate( 'Y-m-d H:i:s' );
+
+		if ( '' !== $provider ) {
+			$this->sessions[ $session_id ]['provider'] = $provider;
+		}
+		if ( '' !== $model ) {
+			$this->sessions[ $session_id ]['model'] = $model;
+		}
+
+		return true;
+	}
+
+	public function delete_session( string $session_id ): bool {
+		unset( $this->sessions[ $session_id ] );
+		return true;
+	}
+
+	public function get_user_sessions( int $user_id, int $limit = 20, int $offset = 0, ?string $context = null, ?int $agent_id = null ): array {
+		$rows = array();
+
+		foreach ( $this->sessions as $session ) {
+			if ( (int) $session['user_id'] !== $user_id ) {
+				continue;
+			}
+			if ( null !== $context && $session['context'] !== $context ) {
+				continue;
+			}
+			if ( null !== $agent_id && (int) ( $session['agent_id'] ?? 0 ) !== $agent_id ) {
+				continue;
+			}
+
+			$messages      = $session['messages'];
+			$first_message = '';
+			foreach ( $messages as $msg ) {
+				if ( ( $msg['role'] ?? '' ) === 'user' ) {
+					$first_message = $msg['content'] ?? '';
+					break;
+				}
+			}
+
+			$rows[] = array(
+				'session_id'    => $session['session_id'],
+				'title'         => $session['title'],
+				'context'       => $session['context'],
+				'first_message' => is_string( $first_message ) ? mb_substr( $first_message, 0, 100 ) : '',
+				'message_count' => count( $messages ),
+				'unread_count'  => $this->count_unread( $messages, $session['last_read_at'] ),
+				'agent_id'      => $session['agent_id'],
+				'agent_slug'    => null,
+				'agent_name'    => null,
+				'created_at'    => $session['created_at'],
+				'updated_at'    => $session['updated_at'],
+			);
+		}
+
+		// ORDER BY updated_at DESC
+		usort( $rows, static fn( $a, $b ) => strcmp( $b['updated_at'], $a['updated_at'] ) );
+
+		return array_slice( $rows, $offset, $limit );
+	}
+
+	public function get_user_session_count( int $user_id, ?string $context = null, ?int $agent_id = null ): int {
+		$count = 0;
+		foreach ( $this->sessions as $session ) {
+			if ( (int) $session['user_id'] !== $user_id ) {
+				continue;
+			}
+			if ( null !== $context && $session['context'] !== $context ) {
+				continue;
+			}
+			if ( null !== $agent_id && (int) ( $session['agent_id'] ?? 0 ) !== $agent_id ) {
+				continue;
+			}
+			++$count;
+		}
+		return $count;
+	}
+
+	public function get_recent_pending_session( int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
+		$cutoff = gmdate( 'Y-m-d H:i:s', time() - $seconds );
+		$best   = null;
+
+		foreach ( $this->sessions as $session ) {
+			if ( (int) $session['user_id'] !== $user_id ) {
+				continue;
+			}
+			if ( $session['context'] !== $context ) {
+				continue;
+			}
+			if ( $session['created_at'] < $cutoff ) {
+				continue;
+			}
+			$is_empty     = empty( $session['messages'] );
+			$is_pending   = ( $session['metadata']['status'] ?? '' ) === 'processing';
+			$token_match  = null === $token_id || (int) ( $session['metadata']['token_id'] ?? 0 ) === $token_id;
+			if ( ( $is_empty || $is_pending ) && $token_match ) {
+				if ( null === $best || $session['created_at'] > $best['created_at'] ) {
+					$best = $session;
+				}
+			}
+		}
+
+		return $best;
+	}
+
+	public function update_title( string $session_id, string $title ): bool {
+		if ( ! isset( $this->sessions[ $session_id ] ) ) {
+			return false;
+		}
+		$this->sessions[ $session_id ]['title'] = $title;
+		return true;
+	}
+
+	public function count_unread( array $messages, ?string $last_read_at ): int {
+		$count = 0;
+		foreach ( $messages as $msg ) {
+			if ( ( $msg['role'] ?? '' ) !== 'assistant' ) {
+				continue;
+			}
+			$type = $msg['metadata']['type'] ?? 'text';
+			if ( 'tool_call' === $type || 'tool_result' === $type ) {
+				continue;
+			}
+			if ( null === $last_read_at ) {
+				++$count;
+				continue;
+			}
+			$timestamp = $msg['metadata']['timestamp'] ?? null;
+			if ( $timestamp && strtotime( $timestamp ) > strtotime( $last_read_at ) ) {
+				++$count;
+			}
+		}
+		return $count;
+	}
+
+	public function mark_session_read( string $session_id, int $user_id ) {
+		if ( ! isset( $this->sessions[ $session_id ] ) ) {
+			return false;
+		}
+		if ( (int) $this->sessions[ $session_id ]['user_id'] !== $user_id ) {
+			return false;
+		}
+		$now = gmdate( 'Y-m-d H:i:s' );
+		$this->sessions[ $session_id ]['last_read_at'] = $now;
+		return $now;
+	}
+
+	public function cleanup_expired_sessions(): int {
+		$now     = gmdate( 'Y-m-d H:i:s' );
+		$deleted = 0;
+		foreach ( $this->sessions as $id => $session ) {
+			if ( ! empty( $session['expires_at'] ) && $session['expires_at'] < $now ) {
+				unset( $this->sessions[ $id ] );
+				++$deleted;
+			}
+		}
+		return $deleted;
+	}
+
+	public function cleanup_old_sessions( int $retention_days ): int {
+		$cutoff  = gmdate( 'Y-m-d H:i:s', strtotime( "-{$retention_days} days" ) );
+		$deleted = 0;
+		foreach ( $this->sessions as $id => $session ) {
+			if ( $session['updated_at'] < $cutoff ) {
+				unset( $this->sessions[ $id ] );
+				++$deleted;
+			}
+		}
+		return $deleted;
+	}
+
+	public function cleanup_orphaned_sessions( int $hours = 1 ): int {
+		$cutoff  = gmdate( 'Y-m-d H:i:s', time() - ( $hours * 3600 ) );
+		$deleted = 0;
+		foreach ( $this->sessions as $id => $session ) {
+			if ( $session['created_at'] < $cutoff && empty( $session['messages'] ) ) {
+				unset( $this->sessions[ $id ] );
+				++$deleted;
+			}
+		}
+		return $deleted;
+	}
+}


### PR DESCRIPTION
## Summary

Add a `ConversationStoreInterface` + `ConversationStoreFactory` so chat session persistence can be swapped via a single generic filter — **without touching the DM chat UI, REST surface, or any of the five Chat Session abilities** (list / get / create / delete / mark-read).

The default implementation (today's `Chat` MySQL-table store) preserves byte-for-byte the behavior DM had before this seam — self-hosted users see no change.

Mirrors the `datamachine_memory_store` / `AgentMemoryStoreInterface` pattern shipped in v0.6.0: one interface, one factory, one filter, all consumers resolve through the factory.

Closes the second step of the three-step plan alongside the already-shipped `datamachine_conversation_runner` filter.

Refs #1116.

## Why

- Pairs with `datamachine_conversation_runner` to unlock tier-3 AI Framework native adapters — e.g. Intelligence on WordPress.com routing conversations through `WPCOM\AI\Services\Conversation_Storage` — without forking DM.
- Without the seam, a swapped runner forces two sources of truth: the framework's conversation store AND DM's `datamachine_chat_sessions` table would both record each turn.
- Makes chat abilities testable without `$wpdb` via `InMemoryConversationStore` (shipped as reference impl + test fixture).

## Architecture

```
DM Chat UI (unchanged)
      │
      ▼
5 Chat Session Abilities (unchanged contract)
      │
      ▼
┌──────────────────────────────────┐
│  ConversationStoreInterface      │
│  ConversationStoreFactory::get() │
└──────────────┬───────────────────┘
               │ apply_filters('datamachine_conversation_store', $default)
               │
      ┌────────┴────────────────────┐
      ▼                             ▼
┌─────────────┐         ┌──────────────────────────┐
│ Default:    │         │ Swap (e.g. Intelligence  │
│ Chat MySQL  │         │ AI Framework shim)       │
└─────────────┘         └──────────────────────────┘
```

## Consumers refactored

| Site | Change |
|---|---|
| `ChatOrchestrator` (5× `new ChatDatabase()`) | → `ConversationStoreFactory::get()` |
| `ChatSessionHelpers` trait (covers 5 abilities) | → `ConversationStoreFactory::get()` |
| `SystemAbilities::generateSessionTitle` | → `ConversationStoreFactory::get()` |
| `ChatCommand` (4× CLI) | → `ConversationStoreFactory::get()` |
| Scheduled cleanup action | Factory-resolved; `table_exists` guard only when default store is in play |

The factory caches the resolved store per request and applies the filter exactly once.

## Message shape contract

Frozen in `core-filters.md` so adapter stores can alias cleanly on the way out:

\`\`\`php
[
    'id'         => string,
    'role'       => 'user'|'assistant'|'system'|'tool',
    'content'    => string|array,
    'metadata'   => array,
    'created_at' => string,  // MySQL DATETIME UTC
    'updated_at' => string,
]
\`\`\`

Adapter stores around e.g. `WPCOM\AI\Message` (which uses `data` instead of `metadata`) are responsible for aliasing on read.

## Out of scope (follow-up PR)

Raw-SQL leaks that bypass the store entirely are left for a second PR since they need new interface methods:

- `DailyMemoryTask::getChatContext` — raw `SELECT` against `datamachine_chat_sessions` → needs `list_sessions_for_day()`
- `RetentionCommand::get_table_sizes` — bare table name → needs `get_storage_metrics()`
- `uninstall.php` — direct `DROP` → needs `Store::uninstall()`

This PR is intentionally scoped to the seam itself so review focuses on the contract. Leak-closing comes next.

## Testing

\`WP_UnitTestCase\` coverage in `tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php`:

- ✅ default resolution returns the built-in `Chat` store
- ✅ a filter swaps the store
- ✅ a misbehaving filter (non-interface return) falls back to the default and logs
- ✅ the instance is cached per request (filter runs once)
- ✅ `::reset()` lets tests install a fresh filter
- ✅ end-to-end: `list-chat-sessions` ability observes a swapped store via `ChatSessionHelpers`

`InMemoryConversationStore` (~230 lines) lives under `tests/Unit/Core/Database/Chat/` and serves as both the test fixture and a reference adapter for third-party integrators.

## Swap boundary

- ✅ **Stable**: 5 chat abilities, REST endpoints, DM chat UI, session switcher, title generation, unread counts, last-read logic.
- 🔄 **Swaps**: concrete storage (MySQL table vs. framework-managed store vs. in-memory).
- ❌ **Not replaceable here**: session ownership checks, agent adoption, token resolution, title generation. Those stay in the higher-level callers.

## Files

\`\`\`
 docs/development/hooks/core-filters.md                        | +83
 inc/Abilities/Chat/ChatSessionHelpers.php                     | +4 -3
 inc/Abilities/SystemAbilities.php                             | +2 -2
 inc/Api/Chat/ChatOrchestrator.php                             | +7 -7
 inc/Cli/Commands/ChatCommand.php                              | +5 -5
 inc/Core/Database/Chat/Chat.php                               | +12 -3
 inc/Core/Database/Chat/ConversationStoreFactory.php           | +NEW
 inc/Core/Database/Chat/ConversationStoreInterface.php         | +NEW
 tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php | +NEW
 tests/Unit/Core/Database/Chat/InMemoryConversationStore.php   | +NEW
 10 files changed, 809 insertions(+), 20 deletions(-)
\`\`\`

## Example: Intelligence consumer

\`\`\`php
add_filter( 'datamachine_conversation_store', function ( $store ) {
    if ( $store instanceof Intelligence\\AIFramework_Conversation_Store ) {
        return $store; // already swapped
    }
    if ( ! Intelligence\\WPCom_Environment::is_managed_host() ) {
        return $store; // self-hosted — keep MySQL default
    }
    return new Intelligence\\AIFramework_Conversation_Store();
}, 10, 1 );
\`\`\`

No DM core change required. The Intelligence plugin ships the adapter.