### PR TITLE
feat(chat): route raw-SQL chat leaks through ConversationStoreInterface

### DIFF
--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -1163,6 +1163,8 @@ Adapter stores (e.g. around `WPCOM\AI\Message` with `data` instead of
 - `update_title / mark_session_read` — UI state
 - `count_unread` — pure derivation from a messages array
 - `cleanup_expired_sessions / cleanup_old_sessions / cleanup_orphaned_sessions` — scheduled cleanup
+- `list_sessions_for_day` — day-scoped summary rows for the Daily Memory Task
+- `get_storage_metrics` — row count + on-disk size for the `wp datamachine retention status` CLI; return `null` to opt out
 
 ### AgentMemoryStoreInterface (`/inc/Core/FilesRepository/AgentMemoryStoreInterface.php`)
 

--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -14,6 +14,7 @@ namespace DataMachine\Cli\Commands;
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Core\Database\BaseRepository;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -277,7 +278,6 @@ class RetentionCommand extends BaseCommand {
 			'Processed items' => $wpdb->prefix . 'datamachine_processed_items',
 			'AS actions'      => $wpdb->prefix . 'actionscheduler_actions',
 			'Stale claims'    => $wpdb->prefix . 'actionscheduler_claims',
-			'Chat sessions'   => $wpdb->prefix . 'datamachine_chat_sessions',
 		);
 
 		// Deduplicate tables for the query (jobs appears twice).
@@ -328,6 +328,14 @@ class RetentionCommand extends BaseCommand {
 				'rows'    => 0,
 				'size_mb' => '0.0',
 			);
+		}
+
+		// Chat sessions routes through the conversation store so swapped
+		// backends (e.g. AI Framework adapters) can opt into the metrics
+		// table or bow out by returning null.
+		$chat_metrics = ConversationStoreFactory::get()->get_storage_metrics();
+		if ( null !== $chat_metrics ) {
+			$sizes['Chat sessions'] = $chat_metrics;
 		}
 
 		return $sizes;

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -915,6 +915,112 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 
 		return (int) $deleted;
 	}
+
+	/**
+	 * List lightweight session summaries for a single calendar day.
+	 *
+	 * Used by the Daily Memory Task so it can summarize "today's chats"
+	 * without loading the full messages blob for every row.
+	 *
+	 * @param string $date Date string in `Y-m-d` format.
+	 * @return array<int, array{session_id: string, title: string|null, context: string, created_at: string}>
+	 */
+	public function list_sessions_for_day( string $date ): array {
+		global $wpdb;
+
+		if ( ! self::table_exists() ) {
+			return array();
+		}
+
+		$table_name = self::get_prefixed_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT session_id, title, context, created_at
+				 FROM %i
+				 WHERE DATE(created_at) = %s
+				 ORDER BY created_at ASC',
+				$table_name,
+				$date
+			),
+			ARRAY_A
+		);
+
+		if ( ! $rows ) {
+			return array();
+		}
+
+		$result = array();
+		foreach ( $rows as $row ) {
+			$result[] = array(
+				'session_id' => (string) $row['session_id'],
+				'title'      => isset( $row['title'] ) ? (string) $row['title'] : null,
+				'context'    => isset( $row['context'] ) ? (string) $row['context'] : 'chat',
+				'created_at' => (string) $row['created_at'],
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Storage metrics for the retention CLI.
+	 *
+	 * Returns the row count and on-disk size for the MySQL-backed chat
+	 * sessions table. SQLite installs report rows but cannot compute
+	 * table size, so `size_mb` is `'0.0'` there.
+	 *
+	 * @return array{rows: int, size_mb: string}|null
+	 */
+	public function get_storage_metrics(): ?array {
+		global $wpdb;
+
+		if ( ! self::table_exists() ) {
+			return array(
+				'rows'    => 0,
+				'size_mb' => '0.0',
+			);
+		}
+
+		$table_name = self::get_prefixed_table_name();
+
+		if ( self::is_sqlite() ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$count = (int) $wpdb->get_var(
+				$wpdb->prepare( 'SELECT COUNT(*) FROM %i', $table_name )
+			);
+			return array(
+				'rows'    => $count,
+				'size_mb' => '0.0',
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT table_rows,
+					ROUND((data_length + index_length) / 1024 / 1024, 1) AS size_mb
+				FROM information_schema.tables
+				WHERE table_schema = DATABASE()
+				AND table_name = %s',
+				$table_name
+			),
+			ARRAY_A
+		);
+
+		if ( ! $row ) {
+			return array(
+				'rows'    => 0,
+				'size_mb' => '0.0',
+			);
+		}
+
+		return array(
+			'rows'    => (int) $row['table_rows'],
+			'size_mb' => (string) $row['size_mb'],
+		);
+	}
 }
 
 /**

--- a/inc/Core/Database/Chat/ConversationStoreInterface.php
+++ b/inc/Core/Database/Chat/ConversationStoreInterface.php
@@ -180,4 +180,37 @@ interface ConversationStoreInterface {
 	 * @return int Number of sessions deleted.
 	 */
 	public function cleanup_orphaned_sessions( int $hours = 1 ): int;
+
+	/**
+	 * List lightweight session summaries created on the given date.
+	 *
+	 * Returns rows with `{session_id, title, context, created_at}`.
+	 * Used by the Daily Memory Task to summarize a day's chat activity
+	 * without loading the full messages array.
+	 *
+	 * Implementations determine their own date comparison semantics.
+	 * The default MySQL store uses `DATE(created_at) = $date` on the
+	 * stored timestamp (MySQL-server timezone, which in a WordPress
+	 * install is typically UTC for Data Machine DATETIME columns).
+	 *
+	 * @param string $date Date string in `Y-m-d` format.
+	 * @return array<int, array{session_id: string, title: string|null, context: string, created_at: string}>
+	 */
+	public function list_sessions_for_day( string $date ): array;
+
+	/**
+	 * Report storage metrics for the retention CLI.
+	 *
+	 * Returns `['rows' => int, 'size_mb' => string]` for the default
+	 * MySQL store. Stores that cannot report byte size (e.g. an external
+	 * API-backed store) return `size_mb => '0.0'`. Stores that cannot
+	 * report rows either return `null` to opt out of the metrics table.
+	 *
+	 * The CLI displays the "Chat sessions" row only when this method
+	 * returns a non-null value, so the metrics table stays meaningful
+	 * regardless of backend.
+	 *
+	 * @return array{rows: int, size_mb: string}|null
+	 */
+	public function get_storage_metrics(): ?array;
 }

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -21,6 +21,7 @@ namespace DataMachine\Engine\AI\System\Tasks;
 
 defined( 'ABSPATH' ) || exit;
 
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\FilesRepository\AgentMemory;
 use DataMachine\Core\FilesRepository\DailyMemory;
@@ -487,36 +488,15 @@ class DailyMemoryTask extends SystemTask {
 	/**
 	 * Get a summary of today's chat sessions.
 	 *
+	 * Routes through the conversation store so a swapped backend
+	 * (e.g. an AI Framework adapter on WordPress.com) can feed its
+	 * own session list into the daily summary.
+	 *
 	 * @param string $date Date string (Y-m-d).
 	 * @return string
 	 */
 	private function getChatContext( string $date ): string {
-		global $wpdb;
-		$table = $wpdb->prefix . 'datamachine_chat_sessions';
-
-		// Check if the table exists first.
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$table_exists = $wpdb->get_var(
-			$wpdb->prepare( 'SHOW TABLES LIKE %s', $table )
-		);
-
-		if ( ! $table_exists ) {
-			return '';
-		}
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
-		$sessions = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT session_id, title, context, created_at
-				 FROM {$table}
-				 WHERE DATE(created_at) = %s
-				 ORDER BY created_at ASC",
-				$date
-			),
-			ARRAY_A
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL
+		$sessions = ConversationStoreFactory::get()->list_sessions_for_day( $date );
 
 		if ( empty( $sessions ) ) {
 			return '';
@@ -524,7 +504,7 @@ class DailyMemoryTask extends SystemTask {
 
 		$lines = array();
 		foreach ( $sessions as $session ) {
-			$title   = $session['title'] ? $session['title'] : 'Untitled session';
+			$title   = ! empty( $session['title'] ) ? $session['title'] : 'Untitled session';
 			$context = $session['context'] ?? 'chat';
 			$lines[] = "- [{$context}] {$title}";
 		}

--- a/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
+++ b/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
@@ -116,6 +116,96 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 	// End-to-end: abilities observe the swap through ChatSessionHelpers
 	// -----------------------------------------------------------------
 
+	// -----------------------------------------------------------------
+	// New methods that seal the raw-SQL leaks
+	// -----------------------------------------------------------------
+
+	public function test_list_sessions_for_day_returns_rows_in_chronological_order(): void {
+		$store = new InMemoryConversationStore();
+		$user  = 42;
+
+		// Seed three sessions across two days with explicit created_at values
+		// by updating the in-memory rows directly via reflection — we don't
+		// want test timing to race the day boundary.
+		$today     = gmdate( 'Y-m-d' );
+		$yesterday = gmdate( 'Y-m-d', time() - DAY_IN_SECONDS );
+
+		$a = $store->create_session( $user );
+		$b = $store->create_session( $user );
+		$c = $store->create_session( $user );
+
+		$ref      = new \ReflectionClass( $store );
+		$sessions = $ref->getProperty( 'sessions' );
+		$sessions->setAccessible( true );
+		$raw = $sessions->getValue( $store );
+
+		$raw[ $a ]['created_at'] = "{$today} 09:00:00";
+		$raw[ $a ]['title']      = 'First of today';
+		$raw[ $b ]['created_at'] = "{$today} 14:30:00";
+		$raw[ $b ]['title']      = 'Later today';
+		$raw[ $c ]['created_at'] = "{$yesterday} 23:00:00";
+		$raw[ $c ]['title']      = 'From yesterday';
+
+		$sessions->setValue( $store, $raw );
+
+		$rows = $store->list_sessions_for_day( $today );
+
+		$this->assertCount( 2, $rows );
+		$this->assertSame( 'First of today', $rows[0]['title'] );
+		$this->assertSame( 'Later today', $rows[1]['title'] );
+		// Full shape contract:
+		$this->assertSame( array( 'session_id', 'title', 'context', 'created_at' ), array_keys( $rows[0] ) );
+		$this->assertSame( 'chat', $rows[0]['context'] );
+	}
+
+	public function test_list_sessions_for_day_returns_empty_when_no_sessions(): void {
+		$store = new InMemoryConversationStore();
+		$this->assertSame( array(), $store->list_sessions_for_day( '1999-01-01' ) );
+	}
+
+	public function test_get_storage_metrics_returns_rows_shape(): void {
+		$store = new InMemoryConversationStore();
+
+		$metrics = $store->get_storage_metrics();
+
+		$this->assertIsArray( $metrics );
+		$this->assertArrayHasKey( 'rows', $metrics );
+		$this->assertArrayHasKey( 'size_mb', $metrics );
+		$this->assertSame( 0, $metrics['rows'] );
+
+		$store->create_session( 1 );
+		$store->create_session( 1 );
+		$store->create_session( 2 );
+
+		$metrics = $store->get_storage_metrics();
+		$this->assertSame( 3, $metrics['rows'] );
+	}
+
+	public function test_list_sessions_for_day_observed_by_swapped_store_through_factory(): void {
+		$store = new InMemoryConversationStore();
+		add_filter(
+			'datamachine_conversation_store',
+			static fn() => $store,
+			10,
+			1
+		);
+		ConversationStoreFactory::reset();
+
+		$session_id = $store->create_session( 7, 0, array(), 'chat' );
+		$ref        = new \ReflectionClass( $store );
+		$sessions   = $ref->getProperty( 'sessions' );
+		$sessions->setAccessible( true );
+		$raw                           = $sessions->getValue( $store );
+		$raw[ $session_id ]['title']   = 'Pinned day-scoped session';
+		$raw[ $session_id ]['created_at'] = '2026-04-20 10:00:00';
+		$sessions->setValue( $store, $raw );
+
+		$rows = ConversationStoreFactory::get()->list_sessions_for_day( '2026-04-20' );
+
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 'Pinned day-scoped session', $rows[0]['title'] );
+	}
+
 	public function test_list_chat_sessions_ability_routes_through_swapped_store(): void {
 		$memory_store = new InMemoryConversationStore();
 		$user_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );

--- a/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
+++ b/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
@@ -239,4 +239,32 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 		}
 		return $deleted;
 	}
+
+	public function list_sessions_for_day( string $date ): array {
+		$result = array();
+
+		foreach ( $this->sessions as $session ) {
+			if ( substr( (string) $session['created_at'], 0, 10 ) !== $date ) {
+				continue;
+			}
+			$result[] = array(
+				'session_id' => (string) $session['session_id'],
+				'title'      => $session['title'],
+				'context'    => (string) $session['context'],
+				'created_at' => (string) $session['created_at'],
+			);
+		}
+
+		usort( $result, static fn( $a, $b ) => strcmp( $a['created_at'], $b['created_at'] ) );
+
+		return $result;
+	}
+
+	public function get_storage_metrics(): ?array {
+		// In-memory fixture reports row count only; on-disk size is meaningless.
+		return array(
+			'rows'    => count( $this->sessions ),
+			'size_mb' => '0.0',
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #1118. Seals the two remaining raw-SQL leaks that bypassed the conversation store seam, so a swapped backend (e.g. an AI Framework adapter on WordPress.com) can feed its own data into both the Daily Memory Task and the retention CLI.

**Stacked on top of #1118** (`feat/conversation-store-filter`). Merge #1118 first, then this. Alternatively, retarget to `main` after #1118 lands.

Refs #1116.

## Sealed leaks

| Site | Before | After |
|---|---|---|
| `DailyMemoryTask::getChatContext` | raw `SELECT … FROM datamachine_chat_sessions` via `$wpdb` | `ConversationStoreFactory::get()->list_sessions_for_day(\$date)` |
| `RetentionCommand::get_table_sizes` | hardcoded `datamachine_chat_sessions` in the metrics query | `ConversationStoreFactory::get()->get_storage_metrics()` |

## Interface additions

\`\`\`php
// Day-scoped summary rows for the Daily Memory Task.
public function list_sessions_for_day( string \$date ): array;

// Row count + on-disk size for \`wp datamachine retention status\`;
// return null to opt out of the metrics table.
public function get_storage_metrics(): ?array;
\`\`\`

### `list_sessions_for_day`

Returns lightweight rows — `{session_id, title, context, created_at}` — for a single calendar day. Default MySQL impl preserves the existing `DATE(created_at) = \$date` semantics. Short, cheap query that doesn't load the full messages blob.

### `get_storage_metrics`

Returns `{rows: int, size_mb: string}` or `null`. The CLI hides the "Chat sessions" row when `null` is returned, so the metrics table stays meaningful regardless of backend. External/API-backed stores that cannot report byte size return `size_mb => '0.0'`; stores that cannot report rows either return `null`.

## Not addressed (intentional)

**`uninstall.php` still drops the table directly.** That is not a real leak:

- A defensive `DROP TABLE IF EXISTS` is correct behavior whether or not the store was swapped (the table may be empty but always present on a DM install that ran `dbDelta`).
- A swapped-store plugin handles its own teardown in its own `uninstall.php`.
- No autoloader is guaranteed inside `uninstall.php`, so calling factory-resolved code from there would be fragile.

Called out in the commit message so this isn't a surprise later.

## Tests

Added to `ConversationStoreFactoryTest`:

- ✅ `list_sessions_for_day` returns rows in chronological order for the target day only
- ✅ `list_sessions_for_day` returns empty array for a day with no sessions
- ✅ `list_sessions_for_day` returns the full `{session_id, title, context, created_at}` shape
- ✅ `get_storage_metrics` returns `{rows, size_mb}` shape with accurate row count
- ✅ End-to-end: a swapped store's `list_sessions_for_day` is observed through `ConversationStoreFactory::get()`

`InMemoryConversationStore` gets both methods as a reference implementation for third-party adapters.

## Files

\`\`\`
 docs/development/hooks/core-filters.md                                  | +2 -1
 inc/Cli/Commands/RetentionCommand.php                                   | +10 -3
 inc/Core/Database/Chat/Chat.php                                         | +99
 inc/Core/Database/Chat/ConversationStoreInterface.php                   | +31
 inc/Engine/AI/System/Tasks/DailyMemoryTask.php                          | +5 -27
 tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php          | +88
 tests/Unit/Core/Database/Chat/InMemoryConversationStore.php             | +29
 7 files changed, 275 insertions(+), 28 deletions(-)
\`\`\`

## After this

The chat storage seam is fully sealed. Every code path that reads or writes conversation data — abilities, orchestrator, CLI, daily memory task, retention metrics, scheduled cleanup — goes through `ConversationStoreInterface`. Third-party adapters have a complete contract to implement against.

Unblocks Automattic/intelligence#67 (Tier-3 AI Framework native adapter) with no additional DM core changes needed beyond these two PRs.