### PR TITLE
feat(auth): outbound client for cross-site agent calls

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -160,6 +160,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Analytics/PageSpeedAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/AgentPingAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/AgentRemoteCallAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/TaxonomyAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/AgentAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/AgentMemoryAbilities.php';
@@ -228,6 +229,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\Analytics\GoogleSearchConsoleAbilities();
 	new \DataMachine\Abilities\Analytics\PageSpeedAbilities();
 	new \DataMachine\Abilities\AgentPingAbilities();
+	new \DataMachine\Abilities\AgentRemoteCallAbilities();
 	new \DataMachine\Abilities\TaxonomyAbilities();
 	new \DataMachine\Abilities\AgentAbilities();
 	new \DataMachine\Abilities\AgentTokenAbilities();

--- a/inc/Abilities/AgentRemoteCall/AgentRemoteCallAbility.php
+++ b/inc/Abilities/AgentRemoteCall/AgentRemoteCallAbility.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Agent Remote Call Ability
+ *
+ * Makes authenticated HTTP requests to another Data Machine site using
+ * a stored bearer token (from the authorize flow or manual registration).
+ *
+ * This is the agent-facing surface on top of {@see RemoteAgentClient}.
+ * Pipelines, chat tools, and REST consumers all go through this ability
+ * instead of instantiating the client directly.
+ *
+ * @package DataMachine\Abilities\AgentRemoteCall
+ * @since 0.71.0
+ */
+
+namespace DataMachine\Abilities\AgentRemoteCall;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Auth\RemoteAgentClient;
+
+defined( 'ABSPATH' ) || exit;
+
+class AgentRemoteCallAbility {
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			return;
+		}
+
+		$this->registerAbility();
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/agent-remote-call',
+				array(
+					'label'               => __( 'Call Remote Agent Site', 'data-machine' ),
+					'description'         => __( 'Make an authenticated HTTP request to another Data Machine site using a stored bearer token. Used for cross-site agent workflows (publishing, reading wiki, querying abilities, chatting with a peer agent).', 'data-machine' ),
+					'category'            => 'datamachine-agent',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'remote_site', 'agent_slug', 'method', 'path' ),
+						'properties' => array(
+							'remote_site' => array(
+								'type'        => 'string',
+								'description' => __( 'Remote site domain (e.g., "chubes.net"). Scheme optional.', 'data-machine' ),
+							),
+							'agent_slug'  => array(
+								'type'        => 'string',
+								'description' => __( 'Agent slug on the remote site. Combined with remote_site to look up the stored bearer token.', 'data-machine' ),
+							),
+							'method'      => array(
+								'type'        => 'string',
+								'enum'        => array( 'GET', 'POST', 'PUT', 'PATCH', 'DELETE' ),
+								'description' => __( 'HTTP method.', 'data-machine' ),
+							),
+							'path'        => array(
+								'type'        => 'string',
+								'description' => __( 'Path on the remote site starting with "/" (e.g., "/wp-json/wp/v2/posts"). Full URLs are also accepted if the host matches remote_site.', 'data-machine' ),
+							),
+							'body'        => array(
+								'type'        => array( 'object', 'array', 'string' ),
+								'description' => __( 'Request body. Arrays and objects are JSON-encoded with Content-Type: application/json.', 'data-machine' ),
+							),
+							'query'       => array(
+								'type'        => 'object',
+								'description' => __( 'Query parameters to append to the URL.', 'data-machine' ),
+							),
+							'headers'     => array(
+								'type'        => 'object',
+								'description' => __( 'Additional request headers. The Authorization header is always controlled by the stored token and cannot be overridden.', 'data-machine' ),
+							),
+							'timeout'     => array(
+								'type'        => 'integer',
+								'minimum'     => 1,
+								'maximum'     => 300,
+								'description' => __( 'Request timeout in seconds. Default 30.', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'     => array( 'type' => 'boolean' ),
+							'status_code' => array( 'type' => 'integer' ),
+							'body'        => array(
+								'type'        => array( 'object', 'array', 'string', 'null' ),
+								'description' => __( 'Decoded JSON body, or raw string if the response is not JSON.', 'data-machine' ),
+							),
+							'url'         => array( 'type' => 'string' ),
+							'error'       => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Permission callback for ability execution.
+	 *
+	 * Cross-site calls fan out to other Data Machine instances with the
+	 * owner's ceiling on the remote side, so we gate on local admin here.
+	 * Agents invoking this via the pipeline run under their owner's
+	 * context (see PermissionHelper), so this check still applies.
+	 *
+	 * @return bool True if the current user has permission.
+	 */
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	/**
+	 * Execute a remote agent call.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result envelope from {@see RemoteAgentClient::request()}.
+	 */
+	public function execute( array $input ): array {
+		$remote_site = (string) ( $input['remote_site'] ?? '' );
+		$agent_slug  = (string) ( $input['agent_slug'] ?? '' );
+		$method      = (string) ( $input['method'] ?? '' );
+		$path        = (string) ( $input['path'] ?? '' );
+
+		$args = array();
+
+		if ( array_key_exists( 'body', $input ) ) {
+			$args['body'] = $input['body'];
+		}
+
+		if ( ! empty( $input['query'] ) && is_array( $input['query'] ) ) {
+			$args['query'] = $input['query'];
+		}
+
+		if ( ! empty( $input['headers'] ) && is_array( $input['headers'] ) ) {
+			$args['headers'] = $input['headers'];
+		}
+
+		if ( isset( $input['timeout'] ) ) {
+			$args['timeout'] = (int) $input['timeout'];
+		}
+
+		return RemoteAgentClient::request( $remote_site, $agent_slug, $method, $path, $args );
+	}
+}

--- a/inc/Abilities/AgentRemoteCallAbilities.php
+++ b/inc/Abilities/AgentRemoteCallAbilities.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Agent Remote Call Abilities
+ *
+ * Facade that loads and registers cross-site agent call abilities.
+ *
+ * @package DataMachine\Abilities
+ * @since 0.71.0
+ */
+
+namespace DataMachine\Abilities;
+
+use DataMachine\Abilities\AgentRemoteCall\AgentRemoteCallAbility;
+
+defined( 'ABSPATH' ) || exit;
+
+class AgentRemoteCallAbilities {
+
+	private static bool $registered = false;
+
+	private AgentRemoteCallAbility $remote_call;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
+			return;
+		}
+
+		$this->remote_call = new AgentRemoteCallAbility();
+
+		self::$registered = true;
+	}
+}

--- a/inc/Cli/Commands/ExternalCommand.php
+++ b/inc/Cli/Commands/ExternalCommand.php
@@ -14,6 +14,7 @@ namespace DataMachine\Cli\Commands;
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Core\Auth\AgentAuthCallback;
+use DataMachine\Core\Auth\RemoteAgentClient;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -303,54 +304,266 @@ class ExternalCommand extends BaseCommand {
 			return;
 		}
 
-		$data  = $tokens[ $key ];
-		$site  = $data['remote_site'];
-		$token = $data['token'];
+		$data       = $tokens[ $key ];
+		$site       = (string) ( $data['remote_site'] ?? '' );
+		$agent_slug = (string) ( $data['agent_slug'] ?? '' );
 
 		WP_CLI::log( sprintf( 'Testing connection to %s...', $site ) );
 
 		// Test 1: Authentication.
-		$response = wp_remote_get(
-			sprintf( 'https://%s/wp-json/wp/v2/users/me', $site ),
-			array(
-				'headers' => array( 'Authorization' => 'Bearer ' . $token ),
-				'timeout' => 15,
+		$auth = RemoteAgentClient::request( $site, $agent_slug, 'GET', '/wp-json/wp/v2/users/me', array( 'timeout' => 15 ) );
+
+		if ( ! $auth['success'] ) {
+			WP_CLI::error( sprintf( 'Authentication failed: %s', $auth['error'] ?? 'unknown error' ) );
+			return;
+		}
+
+		$user_body = is_array( $auth['body'] ) ? $auth['body'] : array();
+		WP_CLI::log(
+			sprintf(
+				'  Auth:      OK — %s (ID: %d)',
+				$user_body['name'] ?? 'unknown',
+				(int) ( $user_body['id'] ?? 0 )
 			)
 		);
-
-		if ( is_wp_error( $response ) ) {
-			WP_CLI::error( sprintf( 'Connection failed: %s', $response->get_error_message() ) );
-			return;
-		}
-
-		$code = wp_remote_retrieve_response_code( $response );
-		$body = json_decode( wp_remote_retrieve_body( $response ), true );
-
-		if ( 200 !== $code ) {
-			WP_CLI::error( sprintf( 'Authentication failed: HTTP %d — %s', $code, $body['message'] ?? 'Unknown error' ) );
-			return;
-		}
-
-		WP_CLI::log( sprintf( '  Auth:      OK — %s (ID: %d)', $body['name'] ?? 'unknown', $body['id'] ?? 0 ) );
 
 		// Test 2: Agent memory access.
-		$memory_response = wp_remote_get(
-			sprintf( 'https://%s/wp-json/datamachine/v1/files/agent', $site ),
-			array(
-				'headers' => array( 'Authorization' => 'Bearer ' . $token ),
-				'timeout' => 15,
-			)
-		);
+		$memory = RemoteAgentClient::request( $site, $agent_slug, 'GET', '/wp-json/datamachine/v1/files/agent', array( 'timeout' => 15 ) );
 
-		$memory_code = wp_remote_retrieve_response_code( $memory_response );
-		if ( 200 === $memory_code ) {
-			$files = json_decode( wp_remote_retrieve_body( $memory_response ), true );
-			$count = is_array( $files ) ? count( $files ) : 0;
-			WP_CLI::log( sprintf( '  Memory:    OK — %d file(s) accessible', $count ) );
+		if ( $memory['success'] ) {
+			$files = is_array( $memory['body'] ) ? $memory['body'] : array();
+			WP_CLI::log( sprintf( '  Memory:    OK — %d file(s) accessible', count( $files ) ) );
 		} else {
-			WP_CLI::log( sprintf( '  Memory:    HTTP %d (Data Machine may not be active on this site)', $memory_code ) );
+			WP_CLI::log( sprintf( '  Memory:    HTTP %d (Data Machine may not be active on this site)', $memory['status_code'] ) );
 		}
 
 		WP_CLI::success( sprintf( 'Connection to %s is working.', $site ) );
+	}
+
+	/**
+	 * Print the authorize URL to initiate the cross-site agent auth flow.
+	 *
+	 * The remote Data Machine site hosts an authorize endpoint that mints
+	 * a bearer token after the human approves access via a consent screen.
+	 * This command builds the URL for the user to open in a browser.
+	 *
+	 * After the user clicks Authorize on the remote site, the token is
+	 * delivered to this site's /agent/auth/callback endpoint and stored
+	 * automatically. The connection will then appear in `external list`.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <site>
+	 * : Remote site domain (e.g., chubes.net).
+	 *
+	 * <agent_slug>
+	 * : Agent slug on the remote site (e.g., chubes-bot).
+	 *
+	 * [--label=<label>]
+	 * : Optional token label (shown in the remote agent's token list).
+	 *
+	 * [--redirect-uri=<uri>]
+	 * : Custom callback URL. Defaults to this site's
+	 *   /wp-json/datamachine/v1/agent/auth/callback endpoint.
+	 *
+	 * [--open]
+	 * : Attempt to open the URL in the system browser (macOS/Linux/Windows).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Print the URL for manual opening
+	 *     wp datamachine external connect chubes.net chubes-bot
+	 *
+	 *     # Label the token so it's identifiable on the remote side
+	 *     wp datamachine external connect chubes.net chubes-bot --label="franklin-intelligence-chubes4"
+	 *
+	 *     # Attempt to open the URL in a browser
+	 *     wp datamachine external connect chubes.net chubes-bot --open
+	 *
+	 * @subcommand connect
+	 */
+	public function connect( array $args, array $assoc_args ): void {
+		$site       = $args[0] ?? '';
+		$agent_slug = $args[1] ?? '';
+
+		if ( '' === $site || '' === $agent_slug ) {
+			WP_CLI::error( 'Usage: wp datamachine external connect <site> <agent_slug> [--label=...] [--redirect-uri=...]' );
+			return;
+		}
+
+		$site = RemoteAgentClient::normalize_site( $site );
+
+		if ( '' === $site ) {
+			WP_CLI::error( 'Invalid site.' );
+			return;
+		}
+
+		$redirect_uri = (string) ( $assoc_args['redirect-uri'] ?? '' );
+		$label        = (string) ( $assoc_args['label'] ?? '' );
+
+		$url = RemoteAgentClient::build_authorize_url( $site, $agent_slug, $redirect_uri, $label );
+
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Open the following URL in a browser while logged in to the remote site as a user with access to the agent:' );
+		WP_CLI::log( '' );
+		WP_CLI::log( '  ' . $url );
+		WP_CLI::log( '' );
+		WP_CLI::log( sprintf( 'After you click Authorize, a bearer token will be delivered to this site and stored as "%s/%s".', $site, $agent_slug ) );
+		WP_CLI::log( 'Verify afterwards with: wp datamachine external list' );
+
+		if ( ! empty( $assoc_args['open'] ) ) {
+			$opener = '';
+			if ( stripos( PHP_OS, 'DAR' ) === 0 ) {
+				$opener = 'open';
+			} elseif ( stripos( PHP_OS, 'WIN' ) === 0 ) {
+				$opener = 'start ""';
+			} elseif ( function_exists( 'shell_exec' ) ) {
+				$opener = 'xdg-open';
+			}
+
+			if ( '' !== $opener && function_exists( 'shell_exec' ) ) {
+				@shell_exec( sprintf( '%s %s > /dev/null 2>&1 &', $opener, escapeshellarg( $url ) ) );
+				WP_CLI::log( '(Attempted to open URL in your default browser.)' );
+			}
+		}
+	}
+
+	/**
+	 * Make an ad-hoc authenticated call to a connected external site.
+	 *
+	 * Useful for debugging cross-site agent workflows without wiring
+	 * up an ability call. Uses the stored bearer token for the given
+	 * connection key and prints the response.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <key>
+	 * : Connection key (site/agent_slug, e.g., "chubes.net/chubes-bot").
+	 *
+	 * <method>
+	 * : HTTP method: GET, POST, PUT, PATCH, DELETE.
+	 *
+	 * <path>
+	 * : Path on the remote site (e.g., "/wp-json/wp/v2/posts") or full URL.
+	 *
+	 * [--body=<json>]
+	 * : JSON-encoded request body.
+	 *
+	 * [--header=<header>]
+	 * : Additional header in "Name: value" form. Repeatable.
+	 *
+	 * [--timeout=<seconds>]
+	 * : Request timeout in seconds. Default 30.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - json
+	 *   - raw
+	 *   - table
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Who am I on the remote site?
+	 *     wp datamachine external call chubes.net/chubes-bot GET /wp-json/wp/v2/users/me
+	 *
+	 *     # List wiki articles
+	 *     wp datamachine external call chubes.net/chubes-bot GET /wp-json/wp/v2/wiki
+	 *
+	 *     # Send a chat message to the peer agent
+	 *     wp datamachine external call chubes.net/chubes-bot POST /wp-json/datamachine/v1/chat \
+	 *         --body='{"message":"hello from franklin"}'
+	 *
+	 * @subcommand call
+	 */
+	public function call( array $args, array $assoc_args ): void {
+		$key    = $args[0] ?? '';
+		$method = $args[1] ?? '';
+		$path   = $args[2] ?? '';
+
+		if ( '' === $key || '' === $method || '' === $path ) {
+			WP_CLI::error( 'Usage: wp datamachine external call <key> <method> <path> [--body=<json>]' );
+			return;
+		}
+
+		$tokens = get_option( AgentAuthCallback::OPTION_KEY, array() );
+		if ( ! isset( $tokens[ $key ] ) ) {
+			WP_CLI::error( sprintf( 'No connection found for "%s". Run `wp datamachine external list` to see registered connections.', $key ) );
+			return;
+		}
+
+		$data       = $tokens[ $key ];
+		$site       = (string) ( $data['remote_site'] ?? '' );
+		$agent_slug = (string) ( $data['agent_slug'] ?? '' );
+
+		$request_args = array();
+
+		if ( isset( $assoc_args['timeout'] ) ) {
+			$request_args['timeout'] = (int) $assoc_args['timeout'];
+		}
+
+		if ( isset( $assoc_args['body'] ) && '' !== $assoc_args['body'] ) {
+			$decoded = json_decode( (string) $assoc_args['body'], true );
+			if ( JSON_ERROR_NONE === json_last_error() ) {
+				$request_args['body'] = $decoded;
+			} else {
+				$request_args['body'] = (string) $assoc_args['body'];
+			}
+		}
+
+		$raw_headers = $assoc_args['header'] ?? array();
+		if ( ! is_array( $raw_headers ) ) {
+			$raw_headers = array( $raw_headers );
+		}
+
+		$headers = array();
+		foreach ( $raw_headers as $line ) {
+			$line = trim( (string) $line );
+			if ( '' === $line || false === strpos( $line, ':' ) ) {
+				continue;
+			}
+			list( $name, $value ) = explode( ':', $line, 2 );
+			$headers[ trim( $name ) ] = trim( $value );
+		}
+		if ( ! empty( $headers ) ) {
+			$request_args['headers'] = $headers;
+		}
+
+		$result = RemoteAgentClient::request( $site, $agent_slug, $method, $path, $request_args );
+
+		$format = (string) ( $assoc_args['format'] ?? 'json' );
+
+		if ( 'raw' === $format ) {
+			WP_CLI::log( $result['raw_body'] );
+		} elseif ( 'table' === $format ) {
+			WP_CLI::log( sprintf( 'URL:         %s', $result['url'] ) );
+			WP_CLI::log( sprintf( 'Status:      %d', $result['status_code'] ) );
+			WP_CLI::log( sprintf( 'Success:     %s', $result['success'] ? 'yes' : 'no' ) );
+			if ( ! empty( $result['error'] ) ) {
+				WP_CLI::log( sprintf( 'Error:       %s', $result['error'] ) );
+			}
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Body:' );
+			WP_CLI::log( wp_json_encode( $result['body'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		} else {
+			// Default: full JSON envelope minus the headers/raw_body noise.
+			$output = array(
+				'success'     => $result['success'],
+				'status_code' => $result['status_code'],
+				'url'         => $result['url'],
+				'body'        => $result['body'],
+			);
+			if ( ! empty( $result['error'] ) ) {
+				$output['error'] = $result['error'];
+			}
+			WP_CLI::log( wp_json_encode( $output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		}
+
+		if ( ! $result['success'] ) {
+			WP_CLI::halt( 1 );
+		}
 	}
 }

--- a/inc/Core/Auth/RemoteAgentClient.php
+++ b/inc/Core/Auth/RemoteAgentClient.php
@@ -1,0 +1,360 @@
+<?php
+/**
+ * Remote Agent Client
+ *
+ * Outbound HTTP client for cross-site agent communication. Looks up
+ * bearer tokens stored by {@see AgentAuthCallback} and attaches them
+ * to wp_remote_request() calls targeting another Data Machine site.
+ *
+ * This is the complement to {@see AgentAuthMiddleware} (which validates
+ * inbound bearer tokens) — it consumes stored external tokens so this
+ * site's agents can act on behalf of agents on other DM sites.
+ *
+ * Usage:
+ *   $result = RemoteAgentClient::request(
+ *       'chubes.net',
+ *       'chubes-bot',
+ *       'POST',
+ *       '/wp-json/datamachine/v1/chat',
+ *       array( 'body' => array( 'message' => 'hello' ) )
+ *   );
+ *
+ *   if ( $result['success'] ) {
+ *       // $result['body'] is the decoded JSON response
+ *   }
+ *
+ * @package DataMachine\Core\Auth
+ * @since 0.71.0
+ */
+
+namespace DataMachine\Core\Auth;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class RemoteAgentClient {
+
+	/**
+	 * Default request timeout in seconds.
+	 */
+	const DEFAULT_TIMEOUT = 30;
+
+	/**
+	 * Allowed HTTP methods.
+	 */
+	const ALLOWED_METHODS = array( 'GET', 'POST', 'PUT', 'PATCH', 'DELETE' );
+
+	/**
+	 * Send an authenticated request to a remote Data Machine site.
+	 *
+	 * Looks up the stored bearer token for ($remote_site, $agent_slug),
+	 * attaches it as an Authorization header, and returns a structured
+	 * response suitable for ability output or CLI display.
+	 *
+	 * The response shape is stable:
+	 *   array{
+	 *     success: bool,
+	 *     status_code: int,
+	 *     body: mixed,            // decoded JSON, or raw string if not JSON
+	 *     raw_body: string,
+	 *     headers: array<string,string>,
+	 *     url: string,
+	 *     error?: string,
+	 *   }
+	 *
+	 * @param string $remote_site  Remote site domain (e.g., "chubes.net"). Scheme optional.
+	 * @param string $agent_slug   Agent slug on the remote site.
+	 * @param string $method       HTTP method: GET, POST, PUT, PATCH, DELETE.
+	 * @param string $path         Path starting with "/" (e.g., "/wp-json/wp/v2/users/me")
+	 *                             or a full URL. If a full URL, its host must match $remote_site.
+	 * @param array  $args         Optional args:
+	 *                             - body: array|string   Request body (arrays are JSON-encoded)
+	 *                             - headers: array       Additional headers (merged)
+	 *                             - timeout: int         Timeout in seconds (default 30)
+	 *                             - query: array         Query params to append to the URL
+	 * @return array Structured response (see shape above).
+	 */
+	public static function request(
+		string $remote_site,
+		string $agent_slug,
+		string $method,
+		string $path,
+		array $args = array()
+	): array {
+		$remote_site = self::normalize_site( $remote_site );
+		$method      = strtoupper( trim( $method ) );
+
+		if ( '' === $remote_site ) {
+			return self::error_response( '', 'remote_site is required.' );
+		}
+
+		if ( '' === $agent_slug ) {
+			return self::error_response( '', 'agent_slug is required.' );
+		}
+
+		if ( ! in_array( $method, self::ALLOWED_METHODS, true ) ) {
+			return self::error_response(
+				'',
+				sprintf(
+					'Unsupported HTTP method "%s". Allowed: %s.',
+					$method,
+					implode( ', ', self::ALLOWED_METHODS )
+				)
+			);
+		}
+
+		$token = AgentAuthCallback::get_token( $remote_site, $agent_slug );
+
+		if ( null === $token ) {
+			return self::error_response(
+				'',
+				sprintf(
+					'No stored token for "%s/%s". Run `wp datamachine external connect %s %s` to initiate the authorize flow, or `wp datamachine external add` to register a token manually.',
+					$remote_site,
+					$agent_slug,
+					$remote_site,
+					$agent_slug
+				)
+			);
+		}
+
+		$url = self::build_url( $remote_site, $path, $args['query'] ?? array() );
+
+		if ( '' === $url ) {
+			return self::error_response( '', 'Invalid path or URL.' );
+		}
+
+		$headers = array(
+			'Authorization' => 'Bearer ' . $token,
+			'Accept'        => 'application/json',
+		);
+
+		if ( ! empty( $args['headers'] ) && is_array( $args['headers'] ) ) {
+			// Caller-provided headers win except for Authorization, which
+			// we always control to guarantee the stored token is used.
+			$caller_headers = $args['headers'];
+			unset( $caller_headers['Authorization'], $caller_headers['authorization'] );
+			$headers = array_merge( $headers, $caller_headers );
+		}
+
+		$body_raw = null;
+		if ( isset( $args['body'] ) && null !== $args['body'] ) {
+			if ( is_array( $args['body'] ) || is_object( $args['body'] ) ) {
+				$body_raw = wp_json_encode( $args['body'] );
+				if ( ! isset( $headers['Content-Type'] ) ) {
+					$headers['Content-Type'] = 'application/json';
+				}
+			} else {
+				$body_raw = (string) $args['body'];
+			}
+		}
+
+		$timeout = isset( $args['timeout'] ) ? max( 1, (int) $args['timeout'] ) : self::DEFAULT_TIMEOUT;
+
+		$response = wp_remote_request(
+			$url,
+			array(
+				'method'  => $method,
+				'headers' => $headers,
+				'body'    => $body_raw,
+				'timeout' => $timeout,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			$err = $response->get_error_message();
+
+			do_action(
+				'datamachine_log',
+				'warning',
+				'RemoteAgentClient request failed (transport error)',
+				array(
+					'remote_site' => $remote_site,
+					'agent_slug'  => $agent_slug,
+					'method'      => $method,
+					'url'         => $url,
+					'error'       => $err,
+				)
+			);
+
+			return self::error_response( $url, $err );
+		}
+
+		$status_code   = (int) wp_remote_retrieve_response_code( $response );
+		$raw_body      = (string) wp_remote_retrieve_body( $response );
+		$response_hdrs = wp_remote_retrieve_headers( $response );
+
+		// Decode JSON if the response looks like JSON; otherwise return raw string.
+		$decoded = null;
+		if ( '' !== $raw_body ) {
+			$decoded = json_decode( $raw_body, true );
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
+				$decoded = null;
+			}
+		}
+
+		$success = $status_code >= 200 && $status_code < 300;
+
+		$headers_array = array();
+		if ( is_object( $response_hdrs ) && method_exists( $response_hdrs, 'getAll' ) ) {
+			$headers_array = (array) $response_hdrs->getAll();
+		} elseif ( is_array( $response_hdrs ) ) {
+			$headers_array = $response_hdrs;
+		}
+
+		do_action(
+			'datamachine_log',
+			$success ? 'debug' : 'warning',
+			'RemoteAgentClient request completed',
+			array(
+				'remote_site' => $remote_site,
+				'agent_slug'  => $agent_slug,
+				'method'      => $method,
+				'url'         => $url,
+				'status_code' => $status_code,
+			)
+		);
+
+		$result = array(
+			'success'     => $success,
+			'status_code' => $status_code,
+			'body'        => null !== $decoded ? $decoded : $raw_body,
+			'raw_body'    => $raw_body,
+			'headers'     => $headers_array,
+			'url'         => $url,
+		);
+
+		if ( ! $success ) {
+			// Surface the remote error message if the body is a WP_Error-style payload.
+			$msg = null;
+			if ( is_array( $decoded ) ) {
+				if ( isset( $decoded['message'] ) && is_string( $decoded['message'] ) ) {
+					$msg = $decoded['message'];
+				} elseif ( isset( $decoded['error'] ) && is_string( $decoded['error'] ) ) {
+					$msg = $decoded['error'];
+				}
+			}
+			$result['error'] = $msg ?? sprintf( 'HTTP %d', $status_code );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Build the authorize URL for a remote Data Machine site.
+	 *
+	 * The caller opens this URL in a browser, the human approves on the
+	 * remote site, and the remote site redirects to the receiving site's
+	 * /agent/auth/callback endpoint with a bearer token.
+	 *
+	 * @param string $remote_site      Remote site domain.
+	 * @param string $remote_agent     Agent slug on the remote site.
+	 * @param string $redirect_uri     Callback URL on the receiving site.
+	 *                                 Defaults to this site's /agent/auth/callback.
+	 * @param string $label            Optional token label.
+	 * @return string The authorize URL.
+	 */
+	public static function build_authorize_url(
+		string $remote_site,
+		string $remote_agent,
+		string $redirect_uri = '',
+		string $label = ''
+	): string {
+		$remote_site = self::normalize_site( $remote_site );
+
+		if ( '' === $redirect_uri ) {
+			$redirect_uri = rest_url( 'datamachine/v1/agent/auth/callback' );
+		}
+
+		$query = array(
+			'agent_slug'   => $remote_agent,
+			'redirect_uri' => $redirect_uri,
+		);
+
+		if ( '' !== $label ) {
+			$query['label'] = $label;
+		}
+
+		return add_query_arg(
+			$query,
+			sprintf( 'https://%s/wp-json/datamachine/v1/agent/authorize', $remote_site )
+		);
+	}
+
+	/**
+	 * Normalize a remote site string to just the host.
+	 *
+	 * Strips scheme, trailing slashes, and whitespace.
+	 *
+	 * @param string $site Raw input.
+	 * @return string Normalized host, or empty string on failure.
+	 */
+	public static function normalize_site( string $site ): string {
+		$site = trim( $site );
+		$site = preg_replace( '#^https?://#i', '', $site );
+		$site = rtrim( (string) $site, '/' );
+
+		if ( '' === $site || false !== strpos( $site, ' ' ) ) {
+			return '';
+		}
+
+		return $site;
+	}
+
+	/**
+	 * Build a full URL from a site + path (or validated full URL).
+	 *
+	 * @param string $remote_site Normalized host.
+	 * @param string $path        Path starting with "/" or a full URL.
+	 * @param array  $query       Optional query params to append.
+	 * @return string Full URL, or empty string if invalid.
+	 */
+	private static function build_url( string $remote_site, string $path, array $query = array() ): string {
+		$path = trim( $path );
+
+		if ( '' === $path ) {
+			return '';
+		}
+
+		// Full URL — validate host matches.
+		if ( preg_match( '#^https?://#i', $path ) ) {
+			$parsed = wp_parse_url( $path );
+			$host   = $parsed['host'] ?? '';
+			if ( strcasecmp( $host, $remote_site ) !== 0 ) {
+				return '';
+			}
+			$url = $path;
+		} else {
+			if ( '/' !== $path[0] ) {
+				$path = '/' . $path;
+			}
+			$url = sprintf( 'https://%s%s', $remote_site, $path );
+		}
+
+		if ( ! empty( $query ) ) {
+			$url = add_query_arg( $query, $url );
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Build an error response envelope matching the success response shape.
+	 *
+	 * @param string $url   Target URL (may be empty if URL building failed).
+	 * @param string $error Error message.
+	 * @return array Error response.
+	 */
+	private static function error_response( string $url, string $error ): array {
+		return array(
+			'success'     => false,
+			'status_code' => 0,
+			'body'        => null,
+			'raw_body'    => '',
+			'headers'     => array(),
+			'url'         => $url,
+			'error'       => $error,
+		);
+	}
+}


### PR DESCRIPTION
Closes #1121.

## Summary

The authorize flow (`AgentAuthorize` + `AgentAuthCallback` + `AgentAuthMiddleware`) is fully wired on both ends — minting, storing, and validating bearer tokens. What was missing was the **outbound consumer**: a code path that picks up a stored external token and actually calls the remote site with it. `AgentAuthCallback::get_token()` existed but had zero consumers.

This PR adds the minimum needed to close that gap.

## What's in

### `DataMachine\Core\Auth\RemoteAgentClient`

Canonical outbound helper. Complement to `AgentAuthMiddleware`.

```php
$result = RemoteAgentClient::request(
    'chubes.net',            // remote site
    'chubes-bot',             // agent slug on remote site
    'POST',
    '/wp-json/datamachine/v1/chat',
    array( 'body' => array( 'message' => 'hello from franklin' ) )
);
```

- Looks up the stored token, attaches `Authorization: Bearer` on `wp_remote_request`.
- Always controls the Authorization header — caller headers cannot override the stored credential.
- Returns a stable envelope: `success`, `status_code`, `body` (decoded JSON or raw string), `raw_body`, `headers`, `url`, optional `error`.
- Surfaces remote WP_Error-style messages into the top-level `error` field when a request fails.
- Exposes `build_authorize_url()` so callers (CLI, UI) can bootstrap new connections without duplicating URL-building logic.

### `datamachine/agent-remote-call` ability

Agent-facing surface on top of the helper. Pipeline steps, chat tools, and REST consumers all go through this instead of instantiating the client directly.

- Inputs: `remote_site`, `agent_slug`, `method`, `path`, optional `body` / `query` / `headers` / `timeout`.
- Gated on `PermissionHelper::can_manage()` — consistent with other agent-scoped abilities.
- Category `datamachine-agent`.

### `wp datamachine external connect <site> <agent_slug>`

Prints the authorize URL for the browser:

```
Open the following URL in a browser while logged in to the remote site as a user with access to the agent:

  https://chubes.net/wp-json/datamachine/v1/agent/authorize?agent_slug=chubes-bot&redirect_uri=https%3A%2F%2Flocal-site.test%2Fwp-json%2Fdatamachine%2Fv1%2Fagent%2Fauth%2Fcallback

After you click Authorize, a bearer token will be delivered to this site and stored as "chubes.net/chubes-bot".
```

Supports `--label` (tags the minted token on the remote side), `--redirect-uri` (override callback), `--open` (attempt to open in the system browser).

Previously, users had to construct this URL by hand before running `external add` manually. With `connect`, the existing `/agent/authorize` + `/agent/auth/callback` flow closes the loop without any manual token copying.

### `wp datamachine external call <key> <method> <path>`

Ad-hoc authenticated request for debugging cross-site workflows without wiring up an ability call:

```
# Who am I on the remote site?
wp datamachine external call chubes.net/chubes-bot GET /wp-json/wp/v2/users/me

# Send a chat message to the peer agent (cross-site A2A)
wp datamachine external call chubes.net/chubes-bot POST /wp-json/datamachine/v1/chat \
    --body='{"message":"hello from franklin"}'
```

Supports `--body=<json>`, `--header="Name: value"` (repeatable), `--timeout`, `--format=json|raw|table`. Non-2xx responses exit with status 1.

### `ExternalCommand::test()` refactor

Dropped the inlined `wp_remote_get` calls in favor of `RemoteAgentClient::request()`, so all four outbound code paths (helper, ability, `call`, `test`) now share one implementation.

## What unlocks

Concrete workflows the ability surface enables:

- **Cross-site agent messaging** via `POST /wp-json/datamachine/v1/chat` — two agents on two sites holding a conversation with independent memory (the A2A story from #1122).
- **Cross-site wiki access** via Intelligence's REST namespace — reading private wiki articles on another site.
- **Pipeline delegation** — a DM pipeline step that calls an ability on another DM site.
- **Federated search lane 3** — Intelligence's `search-remote` can add authenticated DM REST sources alongside MCP servers.

## Not in scope

- A2A semantics (caller identity headers, loop prevention, chain correlation) — tracked separately as #1122 and should layer on top of this foundation without refactoring anything here.
- Admin UI for managing connections — the CLI covers the scripting need; admin surface can come later.
- OAuth 2.1 metadata endpoint (`.well-known/oauth-authorization-server`) — would make DM sites speak OAuth 2.1 to any MCP client, but that's additive.

## Testing notes

- `php -l` clean on all modified files.
- Bootstrap order matches existing pattern (`require_once` + `new …()` after `AgentPingAbilities`).
- PSR-4 mapping already covers `DataMachine\Abilities\AgentRemoteCall\` and `DataMachine\Core\Auth\` — no composer.json changes needed.
- Composer autoloader is regenerated at build time so new classes are picked up automatically.
- Existing `ExternalCommand::test` behavior is preserved end-to-end; refactor is internal.

Manual smoke test plan for whoever reviews:

1. On this site, run `wp datamachine external connect <remote> <agent_slug>` and open the URL in a browser logged in to the remote site.
2. Approve on the consent screen — token should land via callback and appear in `wp datamachine external list`.
3. Run `wp datamachine external test <remote>/<agent>` — should report `Auth: OK` and `Memory: OK`.
4. Run `wp datamachine external call <remote>/<agent> GET /wp-json/wp/v2/users/me` — should return the remote owner's user payload.
5. Verify `datamachine/agent-remote-call` is registered: `wp abilities list | grep agent-remote-call`.