### PR TITLE
feat(engine/auth): IterationBudget primitive + cross-site A2A chain depth (closes #1122)

### DIFF
--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -99,6 +99,20 @@ class PermissionHelper {
 	private static ?array $agent_token_capabilities = null;
 
 	/**
+	 * Cross-site caller context for the current request.
+	 *
+	 * Populated by AgentAuthMiddleware from X-Datamachine-Caller-*
+	 * and X-Datamachine-Chain-* headers after bearer-token resolution.
+	 * Describes who is calling and where this request sits in an
+	 * agent-to-agent chain. Null means no A2A caller context is set —
+	 * typically a top-of-chain request (admin UI, CLI, direct /chat call).
+	 *
+	 * @since 0.71.0
+	 * @var \DataMachine\Core\Auth\CallerContext|null
+	 */
+	private static ?\DataMachine\Core\Auth\CallerContext $caller_context = null;
+
+	/**
 	 * Check if current context has admin-level permissions.
 	 *
 	 * Allows execution in:
@@ -256,6 +270,46 @@ class PermissionHelper {
 		self::$acting_token_id          = null;
 		self::$agent_owner_id           = 0;
 		self::$agent_token_capabilities = null;
+		self::$caller_context           = null;
+	}
+
+	/**
+	 * Set the cross-site caller context for the current request.
+	 *
+	 * Called by {@see \DataMachine\Core\Auth\AgentAuthMiddleware} after
+	 * parsing X-Datamachine-Caller-* and X-Datamachine-Chain-* headers.
+	 *
+	 * @since 0.71.0
+	 *
+	 * @param \DataMachine\Core\Auth\CallerContext $context
+	 */
+	public static function set_caller_context( \DataMachine\Core\Auth\CallerContext $context ): void {
+		self::$caller_context = $context;
+	}
+
+	/**
+	 * Get the cross-site caller context for the current request.
+	 *
+	 * @since 0.71.0
+	 *
+	 * @return \DataMachine\Core\Auth\CallerContext|null
+	 */
+	public static function get_caller_context(): ?\DataMachine\Core\Auth\CallerContext {
+		return self::$caller_context;
+	}
+
+	/**
+	 * Whether the current request originated from another DM site.
+	 *
+	 * Convenience wrapper over {@see CallerContext::isCrossSite()} that
+	 * treats the absence of a caller context as "not cross-site".
+	 *
+	 * @since 0.71.0
+	 *
+	 * @return bool
+	 */
+	public static function in_cross_site_context(): bool {
+		return self::$caller_context !== null && self::$caller_context->isCrossSite();
 	}
 
 	/**

--- a/inc/Core/Auth/AgentAuthMiddleware.php
+++ b/inc/Core/Auth/AgentAuthMiddleware.php
@@ -26,6 +26,7 @@ namespace DataMachine\Core\Auth;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Agents\AgentTokens;
+use DataMachine\Engine\AI\IterationBudgetRegistry;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -124,6 +125,51 @@ class AgentAuthMiddleware {
 		// Track token usage.
 		$tokens_repo->touch_last_used( $token_id );
 
+		// Parse cross-site caller context from A2A headers (no-op for non-A2A requests).
+		$request      = self::current_rest_request();
+		$inbound_ctx  = $request !== null
+			? CallerContext::fromRequest( $request )
+			: new CallerContext();
+
+		// Enforce chain_depth budget on the incoming call. Depth >= ceiling
+		// means this call is the Nth+1 hop in a chain that has already
+		// exhausted its budget — reject before running any work.
+		$depth_budget = IterationBudgetRegistry::create( 'chain_depth', $inbound_ctx->chainDepth() );
+
+		if ( $depth_budget->exceeded() ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Agent auth: chain depth exceeded',
+				array_merge(
+					array(
+						'agent_id'   => $agent_id,
+						'agent_slug' => $agent['agent_slug'],
+						'budget'     => $depth_budget->name(),
+						'ceiling'    => $depth_budget->ceiling(),
+						'current'    => $depth_budget->current(),
+					),
+					$inbound_ctx->toLogContext()
+				)
+			);
+
+			return new \WP_Error(
+				'datamachine_chain_depth_exceeded',
+				sprintf(
+					/* translators: %d: max chain depth */
+					__( 'A2A chain depth (%d) exceeded. Refusing to extend the chain further.', 'data-machine' ),
+					$depth_budget->ceiling()
+				),
+				array(
+					'status'      => 429,
+					'retry_after' => 60,
+					'chain_id'    => $inbound_ctx->chainId(),
+					'chain_depth' => $inbound_ctx->chainDepth(),
+					'ceiling'     => $depth_budget->ceiling(),
+				)
+			);
+		}
+
 		// Set WordPress current user to the owner.
 		// This ensures all WordPress capability checks use the owner's role
 		// (the ceiling — the agent can never exceed the owner's capabilities).
@@ -134,21 +180,58 @@ class AgentAuthMiddleware {
 		$token_capabilities = $token_record['capabilities'] ?? null;
 		PermissionHelper::set_agent_context( $agent_id, $owner_id, $token_capabilities, $token_id );
 
+		// Expose the caller context for downstream code (ChatOrchestrator,
+		// abilities, logging) that wants to know who's calling and where
+		// in the chain this request lives.
+		PermissionHelper::set_caller_context( $inbound_ctx );
+
 		do_action(
 			'datamachine_log',
 			'debug',
 			'Agent auth: token authenticated',
-			array(
-				'agent_id'             => $agent_id,
-				'agent_slug'           => $agent['agent_slug'],
-				'owner_id'             => $owner_id,
-				'token_id'             => $token_id,
-				'token_label'          => $token_record['label'] ?? '',
-				'has_cap_restrictions' => null !== $token_capabilities,
+			array_merge(
+				array(
+					'agent_id'             => $agent_id,
+					'agent_slug'           => $agent['agent_slug'],
+					'owner_id'             => $owner_id,
+					'token_id'             => $token_id,
+					'token_label'          => $token_record['label'] ?? '',
+					'has_cap_restrictions' => null !== $token_capabilities,
+				),
+				$inbound_ctx->toLogContext()
 			)
 		);
 
 		return true;
+	}
+
+	/**
+	 * Best-effort access to the current REST request for header parsing.
+	 *
+	 * The `rest_authentication_errors` filter runs before the dispatcher
+	 * assigns the request to a handler, so WP_REST_Request isn't directly
+	 * available here. Fall back to synthesizing one from $_SERVER so
+	 * CallerContext can resolve headers consistently via the same API
+	 * it uses in tests.
+	 *
+	 * @return \WP_REST_Request|null
+	 */
+	private static function current_rest_request(): ?\WP_REST_Request {
+		if ( ! class_exists( '\\WP_REST_Request' ) ) {
+			return null;
+		}
+
+		$request = new \WP_REST_Request();
+
+		foreach ( $_SERVER as $key => $value ) {
+			if ( ! is_string( $key ) || strpos( $key, 'HTTP_' ) !== 0 ) {
+				continue;
+			}
+			$header_name = strtolower( str_replace( '_', '-', substr( $key, 5 ) ) );
+			$request->set_header( $header_name, (string) $value );
+		}
+
+		return $request;
 	}
 
 	/**

--- a/inc/Core/Auth/CallerContext.php
+++ b/inc/Core/Auth/CallerContext.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Caller Context
+ *
+ * Identifies WHO made the current inbound request and WHERE in a
+ * cross-site agent chain it lives. Populated by {@see AgentAuthMiddleware}
+ * after bearer-token resolution from `X-Datamachine-Caller-*` and
+ * `X-Datamachine-Chain-*` headers, and consulted by any code that cares
+ * whether it's being called by an agent on another site vs. a human vs.
+ * a pipeline step.
+ *
+ * The companion to this class is {@see RemoteAgentClient}, which
+ * generates the headers on outbound calls so receiving sites can
+ * reconstruct a CallerContext symmetrically.
+ *
+ * Value object. Immutable. Safe to pass around.
+ *
+ * @package DataMachine\Core\Auth
+ * @since 0.71.0
+ */
+
+namespace DataMachine\Core\Auth;
+
+defined( 'ABSPATH' ) || exit;
+
+final class CallerContext {
+
+	/**
+	 * Header names, canonical casing. Keep in sync with
+	 * {@see RemoteAgentClient::buildCallerHeaders()}.
+	 */
+	public const HEADER_CALLER_SITE  = 'X-Datamachine-Caller-Site';
+	public const HEADER_CALLER_AGENT = 'X-Datamachine-Caller-Agent';
+	public const HEADER_CHAIN_ID     = 'X-Datamachine-Chain-Id';
+	public const HEADER_CHAIN_DEPTH  = 'X-Datamachine-Chain-Depth';
+
+	/**
+	 * @param string $caller_site  Fully-qualified host of the calling site.
+	 *                             Empty string means "unknown" (e.g. non-A2A call).
+	 * @param string $caller_agent Slug of the calling agent on its own site.
+	 *                             Empty string means "unknown" or non-agent caller.
+	 * @param string $chain_id     Stable UUID correlating all hops of a single A2A chain.
+	 *                             Generated fresh if absent from incoming headers.
+	 * @param int    $chain_depth  How many A2A hops have already happened in this chain.
+	 *                             Zero for a top-of-chain request.
+	 */
+	public function __construct(
+		private string $caller_site = '',
+		private string $caller_agent = '',
+		private string $chain_id = '',
+		private int $chain_depth = 0,
+	) {
+	}
+
+	/**
+	 * Build a CallerContext from an incoming request's headers.
+	 *
+	 * Missing headers resolve to safe defaults: empty strings for
+	 * identity fields, a freshly-generated UUID for chain_id, and zero
+	 * for chain_depth. A request without any A2A headers becomes a
+	 * valid top-of-chain CallerContext with no caller identity.
+	 *
+	 * @param array|object|\WP_REST_Request $source Header source. Accepts:
+	 *                                              - WP_REST_Request (uses get_header)
+	 *                                              - array of headers (case-insensitive lookup)
+	 * @return self
+	 */
+	public static function fromRequest( $source ): self {
+		$get = self::header_accessor( $source );
+
+		$site  = (string) $get( self::HEADER_CALLER_SITE );
+		$agent = (string) $get( self::HEADER_CALLER_AGENT );
+		$chain = (string) $get( self::HEADER_CHAIN_ID );
+		$depth = (int) $get( self::HEADER_CHAIN_DEPTH );
+
+		if ( '' === $chain ) {
+			$chain = self::generate_chain_id();
+		}
+
+		if ( $depth < 0 ) {
+			$depth = 0;
+		}
+
+		return new self( $site, $agent, $chain, $depth );
+	}
+
+	/**
+	 * Build a CallerContext for the site's own outbound call.
+	 *
+	 * Used by {@see RemoteAgentClient} to mint the caller identity for
+	 * this request: the calling site's host, the acting agent's slug,
+	 * and either the incoming chain's ID+depth (propagating) or a fresh
+	 * chain if this is the top of a new chain.
+	 *
+	 * @param string      $caller_site  This site's host.
+	 * @param string      $caller_agent Acting agent slug on this site (empty if unknown).
+	 * @param self|null   $inbound      Incoming caller context to propagate from,
+	 *                                  or null to start a fresh chain.
+	 * @return self
+	 */
+	public static function forOutbound( string $caller_site, string $caller_agent, ?self $inbound = null ): self {
+		$chain_id    = $inbound !== null && '' !== $inbound->chain_id ? $inbound->chain_id : self::generate_chain_id();
+		$chain_depth = $inbound !== null ? $inbound->chain_depth + 1 : 1;
+
+		return new self( $caller_site, $caller_agent, $chain_id, $chain_depth );
+	}
+
+	/**
+	 * Emit headers suitable for wp_remote_request().
+	 *
+	 * @return array<string,string>
+	 */
+	public function toOutboundHeaders(): array {
+		$headers = array(
+			self::HEADER_CHAIN_ID    => $this->chain_id,
+			self::HEADER_CHAIN_DEPTH => (string) $this->chain_depth,
+		);
+
+		if ( '' !== $this->caller_site ) {
+			$headers[ self::HEADER_CALLER_SITE ] = $this->caller_site;
+		}
+
+		if ( '' !== $this->caller_agent ) {
+			$headers[ self::HEADER_CALLER_AGENT ] = $this->caller_agent;
+		}
+
+		return $headers;
+	}
+
+	public function callerSite(): string {
+		return $this->caller_site;
+	}
+
+	public function callerAgent(): string {
+		return $this->caller_agent;
+	}
+
+	public function chainId(): string {
+		return $this->chain_id;
+	}
+
+	public function chainDepth(): int {
+		return $this->chain_depth;
+	}
+
+	/**
+	 * Whether this context describes an actual cross-site agent caller.
+	 *
+	 * Top-of-chain (chain_depth=0, no caller_site) means the request
+	 * originated locally (e.g. admin UI, a CLI command, a human
+	 * triggering /chat directly). Any depth >= 1 with a caller_site
+	 * means it came from another site.
+	 */
+	public function isCrossSite(): bool {
+		return $this->chain_depth >= 1 && '' !== $this->caller_site;
+	}
+
+	public function toLogContext(): array {
+		return array(
+			'caller_site'  => $this->caller_site,
+			'caller_agent' => $this->caller_agent,
+			'chain_id'     => $this->chain_id,
+			'chain_depth'  => $this->chain_depth,
+		);
+	}
+
+	/**
+	 * Build a case-insensitive header accessor over a request-ish value.
+	 *
+	 * @param array|object|\WP_REST_Request $source
+	 * @return callable(string): string
+	 */
+	private static function header_accessor( $source ): callable {
+		if ( $source instanceof \WP_REST_Request ) {
+			return function ( string $name ) use ( $source ): string {
+				$value = $source->get_header( $name );
+				return null === $value ? '' : (string) $value;
+			};
+		}
+
+		// Normalize array keys to lower-case for case-insensitive lookup.
+		$normalized = array();
+		if ( is_array( $source ) ) {
+			foreach ( $source as $k => $v ) {
+				$normalized[ strtolower( (string) $k ) ] = is_array( $v ) ? (string) reset( $v ) : (string) $v;
+			}
+		}
+
+		return function ( string $name ) use ( $normalized ): string {
+			return $normalized[ strtolower( $name ) ] ?? '';
+		};
+	}
+
+	/**
+	 * Generate a chain ID.
+	 *
+	 * Uses wp_generate_uuid4() when available (WordPress runtime),
+	 * falls back to a hex random string for testability in environments
+	 * where WordPress functions aren't loaded.
+	 */
+	private static function generate_chain_id(): string {
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return wp_generate_uuid4();
+		}
+
+		return bin2hex( random_bytes( 16 ) );
+	}
+}

--- a/inc/Core/Auth/RemoteAgentClient.php
+++ b/inc/Core/Auth/RemoteAgentClient.php
@@ -29,6 +29,9 @@
 
 namespace DataMachine\Core\Auth;
 
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Database\Agents\Agents;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -130,11 +133,28 @@ class RemoteAgentClient {
 			'Accept'        => 'application/json',
 		);
 
+		// Attach A2A caller identity + chain correlation headers so the
+		// receiving site can tell this is an agent call, know which agent
+		// on which site is calling, enforce its own chain_depth budget,
+		// and correlate logs across sites via chain_id. Propagates the
+		// incoming chain if we're extending one, or starts a fresh chain
+		// if we're top-of-chain.
+		$caller_ctx = self::build_outbound_caller_context();
+		$headers    = array_merge( $headers, $caller_ctx->toOutboundHeaders() );
+
 		if ( ! empty( $args['headers'] ) && is_array( $args['headers'] ) ) {
-			// Caller-provided headers win except for Authorization, which
-			// we always control to guarantee the stored token is used.
+			// Caller-provided headers win except for Authorization and
+			// our A2A headers, which we always control so downstream
+			// code can trust chain_depth + chain_id semantics.
 			$caller_headers = $args['headers'];
-			unset( $caller_headers['Authorization'], $caller_headers['authorization'] );
+			unset(
+				$caller_headers['Authorization'],
+				$caller_headers['authorization'],
+				$caller_headers[ CallerContext::HEADER_CALLER_SITE ],
+				$caller_headers[ CallerContext::HEADER_CALLER_AGENT ],
+				$caller_headers[ CallerContext::HEADER_CHAIN_ID ],
+				$caller_headers[ CallerContext::HEADER_CHAIN_DEPTH ]
+			);
 			$headers = array_merge( $headers, $caller_headers );
 		}
 
@@ -356,5 +376,41 @@ class RemoteAgentClient {
 			'url'         => $url,
 			'error'       => $error,
 		);
+	}
+
+	/**
+	 * Build the {@see CallerContext} to emit on this outbound call.
+	 *
+	 * Resolves the calling site's host and the acting agent's slug
+	 * (from PermissionHelper if we're running in an agent context),
+	 * then propagates the incoming chain context if one exists on
+	 * PermissionHelper — otherwise starts a fresh chain.
+	 *
+	 * @return CallerContext
+	 */
+	private static function build_outbound_caller_context(): CallerContext {
+		$site = '';
+		if ( function_exists( 'network_home_url' ) ) {
+			$host = wp_parse_url( network_home_url(), PHP_URL_HOST );
+			$site = is_string( $host ) ? (string) $host : '';
+		}
+
+		$agent_slug = '';
+		if ( class_exists( PermissionHelper::class ) ) {
+			$agent_id = PermissionHelper::get_acting_agent_id();
+			if ( null !== $agent_id && class_exists( Agents::class ) ) {
+				$repo  = new Agents();
+				$agent = $repo->get_agent( (int) $agent_id );
+				if ( $agent && isset( $agent['agent_slug'] ) ) {
+					$agent_slug = (string) $agent['agent_slug'];
+				}
+			}
+		}
+
+		$inbound = class_exists( PermissionHelper::class )
+			? PermissionHelper::get_caller_context()
+			: null;
+
+		return CallerContext::forOutbound( $site, $agent_slug, $inbound );
 	}
 }

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -457,8 +457,9 @@ class AIConversationLoop {
 				array_merge(
 					$base_log_context,
 					array(
-						'max_turns'            => $max_turns,
-						'final_turn_count'     => $turn_count,
+						'budget'               => $turn_budget->name(),
+						'ceiling'              => $turn_budget->ceiling(),
+						'current'              => $turn_budget->current(),
 						'still_had_tool_calls' => ! empty( $last_tool_calls ),
 					)
 				)

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Engine\AI;
 
 use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\IterationBudgetRegistry;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -145,8 +146,14 @@ class AIConversationLoop {
 		int $max_turns = PluginSettings::DEFAULT_MAX_TURNS,
 		bool $single_turn = false
 	): array {
-		// Ensure max_turns is within reasonable bounds
-		$max_turns              = max( 1, min( 50, $max_turns ) );
+		// Bound the conversation with the shared IterationBudget primitive.
+		// Ceiling resolution + clamp lives in IterationBudgetRegistry; the
+		// caller-supplied $max_turns is an override that still gets clamped
+		// to the registered bounds (currently [1, 50]). $turn_count mirrors
+		// the budget's current value so the rest of this method keeps its
+		// existing local-int semantics for log payloads and message formatting.
+		$turn_budget            = IterationBudgetRegistry::create( 'conversation_turns', 0, $max_turns );
+		$max_turns              = $turn_budget->ceiling();
 		$conversation_complete  = false;
 		$turn_count             = 0;
 		$final_content          = '';
@@ -178,7 +185,8 @@ class AIConversationLoop {
 		);
 
 		do {
-			++$turn_count;
+			$turn_budget->increment();
+			$turn_count = $turn_budget->current();
 
 			// Build AI request using centralized RequestBuilder
 			$ai_response = RequestBuilder::build(
@@ -438,10 +446,10 @@ class AIConversationLoop {
 			if ( $single_turn ) {
 				break;
 			}
-		} while ( ! $conversation_complete && $turn_count < $max_turns );
+		} while ( ! $conversation_complete && ! $turn_budget->exceeded() );
 
 		// Log if max turns reached
-		if ( $turn_count >= $max_turns && ! $conversation_complete ) {
+		if ( $turn_budget->exceeded() && ! $conversation_complete ) {
 			do_action(
 				'datamachine_log',
 				'warning',
@@ -473,12 +481,12 @@ class AIConversationLoop {
 			'usage'                  => $total_usage,
 		);
 
-		if ( $turn_count >= $max_turns && ! $conversation_complete ) {
+		if ( $turn_budget->exceeded() && ! $conversation_complete ) {
 			$result['warning'] = 'Maximum conversation turns (' . $max_turns . ') reached. Response may be incomplete.';
 		}
 
 		// Add max_turns_reached flag for single-turn mode
-		if ( $single_turn && $turn_count >= $max_turns ) {
+		if ( $single_turn && $turn_budget->exceeded() ) {
 			$result['max_turns_reached'] = true;
 		}
 

--- a/inc/Engine/AI/IterationBudget.php
+++ b/inc/Engine/AI/IterationBudget.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Iteration Budget
+ *
+ * Generic primitive for bounded iteration with a configurable ceiling.
+ * Counts a named dimension (e.g. conversation turns, A2A chain depth,
+ * retry attempts) and exposes a uniform API for checking exceedance,
+ * formatting warnings, and surfacing response flags.
+ *
+ * A budget is a stateful value object — call {@see increment()} at each
+ * iteration, then {@see exceeded()} to decide whether to continue.
+ *
+ * Register named budget configurations via
+ * {@see IterationBudgetRegistry::register()}, then instantiate per-run
+ * via {@see IterationBudgetRegistry::create()}. This separates
+ * "how much is allowed" (site config) from "where are we now" (runtime
+ * counter) cleanly, and lets consumers share a consistent pattern
+ * across turns, chain depth, and whatever else wants bounded iteration
+ * semantics.
+ *
+ * @package DataMachine\Engine\AI
+ * @since 0.71.0
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+final class IterationBudget {
+
+	/**
+	 * Budget name (e.g. "conversation_turns", "chain_depth").
+	 *
+	 * @var string
+	 */
+	private string $name;
+
+	/**
+	 * Maximum allowed value (inclusive ceiling — exceeded when current >= ceiling).
+	 *
+	 * @var int
+	 */
+	private int $ceiling;
+
+	/**
+	 * Current counter value.
+	 *
+	 * @var int
+	 */
+	private int $current;
+
+	/**
+	 * @param string $name    Budget name. Used in response flags and warnings.
+	 * @param int    $ceiling Maximum allowed value (must be >= 1).
+	 * @param int    $current Starting counter value (default 0). Negative values are clamped to 0.
+	 *                        Values already at or above the ceiling are preserved (already-exceeded budget).
+	 */
+	public function __construct( string $name, int $ceiling, int $current = 0 ) {
+		$this->name    = $name;
+		$this->ceiling = max( 1, $ceiling );
+		$this->current = max( 0, $current );
+	}
+
+	/**
+	 * Increment the counter by one.
+	 */
+	public function increment(): void {
+		++$this->current;
+	}
+
+	/**
+	 * Whether the counter has reached or exceeded the ceiling.
+	 *
+	 * @return bool True when current >= ceiling.
+	 */
+	public function exceeded(): bool {
+		return $this->current >= $this->ceiling;
+	}
+
+	/**
+	 * Remaining iterations before exceedance.
+	 *
+	 * @return int Zero when exceeded, otherwise ceiling - current.
+	 */
+	public function remaining(): int {
+		return max( 0, $this->ceiling - $this->current );
+	}
+
+	/**
+	 * Budget name.
+	 */
+	public function name(): string {
+		return $this->name;
+	}
+
+	/**
+	 * Current counter value.
+	 */
+	public function current(): int {
+		return $this->current;
+	}
+
+	/**
+	 * Ceiling for this budget.
+	 */
+	public function ceiling(): int {
+		return $this->ceiling;
+	}
+
+	/**
+	 * Response flag key signaling this budget was exceeded.
+	 *
+	 * Convention: "max_{name}_reached" — e.g. "max_conversation_turns_reached".
+	 *
+	 * Callers with legacy response shapes (pre-primitive) may continue to
+	 * emit their own flag keys instead; this helper exists for new budgets
+	 * that want the standard shape.
+	 *
+	 * @return string
+	 */
+	public function toResponseFlag(): string {
+		return 'max_' . $this->name . '_reached';
+	}
+
+	/**
+	 * Human-readable warning describing exceedance.
+	 *
+	 * Legacy callers with a specific warning format should not use this;
+	 * it exists for new budgets that want the standard shape.
+	 *
+	 * @return string
+	 */
+	public function toWarning(): string {
+		return sprintf(
+			'Maximum %s (%d) reached.',
+			str_replace( '_', ' ', $this->name ),
+			$this->ceiling
+		);
+	}
+}

--- a/inc/Engine/AI/IterationBudgetRegistry.php
+++ b/inc/Engine/AI/IterationBudgetRegistry.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Iteration Budget Registry
+ *
+ * Registry for named bounded-iteration budgets. Each registration
+ * declares the budget's ceiling resolution rules (default, site-setting
+ * key, clamp bounds) so consumers can instantiate a fresh
+ * {@see IterationBudget} at runtime without duplicating config-lookup
+ * boilerplate.
+ *
+ * Ceiling resolution order (per {@see create()}):
+ *   1. $ceiling_override argument — caller-supplied value, always wins.
+ *   2. PluginSettings option named by config['setting'], if set.
+ *   3. config['default'].
+ * Then clamped to [config['min'], config['max']].
+ *
+ * Side-effect free: registration mutates a static map, instantiation
+ * reads options and returns a new value object. Safe to call from any
+ * context. Idempotent across duplicate registrations.
+ *
+ * @package DataMachine\Engine\AI
+ * @since 0.71.0
+ */
+
+namespace DataMachine\Engine\AI;
+
+use DataMachine\Core\PluginSettings;
+
+defined( 'ABSPATH' ) || exit;
+
+final class IterationBudgetRegistry {
+
+	/**
+	 * Registered budget configurations, keyed by budget name.
+	 *
+	 * @var array<string, array{default:int, min:int, max:int, setting:string}>
+	 */
+	private static array $registered = array();
+
+	/**
+	 * Register a named budget configuration.
+	 *
+	 * @param string $name   Budget name. Unique per registry.
+	 * @param array  $config Configuration:
+	 *                       - default (int, required): ceiling when no override or setting.
+	 *                       - min (int, optional): floor after clamp. Default 1.
+	 *                       - max (int, optional): ceiling after clamp. Default 100.
+	 *                       - setting (string, optional): PluginSettings key for per-site override.
+	 */
+	public static function register( string $name, array $config ): void {
+		if ( '' === $name ) {
+			return;
+		}
+
+		$defaults = array(
+			'default' => 10,
+			'min'     => 1,
+			'max'     => 100,
+			'setting' => '',
+		);
+
+		self::$registered[ $name ] = array_merge( $defaults, $config );
+	}
+
+	/**
+	 * Whether a budget is registered.
+	 *
+	 * @param string $name Budget name.
+	 * @return bool
+	 */
+	public static function is_registered( string $name ): bool {
+		return isset( self::$registered[ $name ] );
+	}
+
+	/**
+	 * Get a registered budget's config (read-only).
+	 *
+	 * @param string $name Budget name.
+	 * @return array|null
+	 */
+	public static function get_config( string $name ): ?array {
+		return self::$registered[ $name ] ?? null;
+	}
+
+	/**
+	 * All registered budget names.
+	 *
+	 * @return string[]
+	 */
+	public static function registered_names(): array {
+		return array_keys( self::$registered );
+	}
+
+	/**
+	 * Create a fresh budget for a named registration.
+	 *
+	 * Resolves the ceiling through the documented fallback chain and
+	 * returns a new {@see IterationBudget} seeded at $current.
+	 *
+	 * Unregistered names return a permissive budget so callers using a
+	 * name-that-might-be-registered don't need conditional logic — the
+	 * budget simply uses a safe default. This is intentional: registries
+	 * exist to share config, not to gate correctness.
+	 *
+	 * @param string   $name             Budget name.
+	 * @param int      $current          Starting counter value (default 0).
+	 * @param int|null $ceiling_override Optional caller-provided ceiling that
+	 *                                   bypasses the setting/default lookup but
+	 *                                   is still clamped to registered bounds.
+	 * @return IterationBudget
+	 */
+	public static function create(
+		string $name,
+		int $current = 0,
+		?int $ceiling_override = null
+	): IterationBudget {
+		$config = self::$registered[ $name ] ?? array(
+			'default' => 10,
+			'min'     => 1,
+			'max'     => 100,
+			'setting' => '',
+		);
+
+		if ( null !== $ceiling_override ) {
+			$ceiling = (int) $ceiling_override;
+		} elseif ( '' !== $config['setting'] && class_exists( PluginSettings::class ) ) {
+			$ceiling = (int) PluginSettings::get( $config['setting'], $config['default'] );
+		} else {
+			$ceiling = (int) $config['default'];
+		}
+
+		$ceiling = max( (int) $config['min'], min( (int) $config['max'], $ceiling ) );
+
+		return new IterationBudget( $name, $ceiling, $current );
+	}
+}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -85,6 +85,18 @@ IterationBudgetRegistry::register( 'conversation_turns', array(
 	'setting' => 'max_turns',
 ) );
 
+// A2A chain depth — bounds how many cross-site agent hops a single
+// chain can contain before being refused. Prevents runaway recursion
+// when agents on different sites can call each other's /chat endpoints.
+// Default 3 is deliberately low; raise via the `max_chain_depth` site
+// setting if a real chain genuinely needs more hops.
+IterationBudgetRegistry::register( 'chain_depth', array(
+	'default' => 3,
+	'min'     => 1,
+	'max'     => 10,
+	'setting' => 'max_chain_depth',
+) );
+
 /*
 |--------------------------------------------------------------------------
 | Execution mode registrations

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -62,6 +62,28 @@ require_once __DIR__ . '/Engine/AI/Directives/AgentModeDirective.php';
 
 use DataMachine\Engine\AI\MemoryFileRegistry;
 use DataMachine\Engine\AI\AgentModeRegistry;
+use DataMachine\Engine\AI\IterationBudgetRegistry;
+use DataMachine\Core\PluginSettings;
+
+/*
+|--------------------------------------------------------------------------
+| Iteration budget registrations
+|--------------------------------------------------------------------------
+| Named bounded-iteration budgets shared across the engine. Each budget
+| declares its ceiling-resolution rules (default, site-setting key,
+| clamp bounds). Consumers instantiate a fresh IterationBudget per run
+| via IterationBudgetRegistry::create().
+|
+| Registration is side-effect free (static map mutation) and safe to
+| run at file-load time — instance creation reads options lazily.
+*/
+
+IterationBudgetRegistry::register( 'conversation_turns', array(
+	'default' => PluginSettings::DEFAULT_MAX_TURNS,
+	'min'     => 1,
+	'max'     => 50,
+	'setting' => 'max_turns',
+) );
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/AI/IterationBudgetTest.php
+++ b/tests/Unit/AI/IterationBudgetTest.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Tests for IterationBudget and IterationBudgetRegistry.
+ *
+ * @package DataMachine\Tests\Unit\AI
+ */
+
+namespace DataMachine\Tests\Unit\AI;
+
+use DataMachine\Engine\AI\IterationBudget;
+use DataMachine\Engine\AI\IterationBudgetRegistry;
+use WP_UnitTestCase;
+
+class IterationBudgetTest extends WP_UnitTestCase {
+
+	/**
+	 * Unique registry key per test to avoid cross-test contamination.
+	 */
+	private string $test_budget_name;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->test_budget_name = 'test_budget_' . uniqid();
+	}
+
+	public function test_budget_starts_below_ceiling(): void {
+		$budget = new IterationBudget( 'x', 5 );
+		$this->assertSame( 0, $budget->current() );
+		$this->assertSame( 5, $budget->ceiling() );
+		$this->assertSame( 5, $budget->remaining() );
+		$this->assertFalse( $budget->exceeded() );
+	}
+
+	public function test_increment_advances_counter(): void {
+		$budget = new IterationBudget( 'x', 3 );
+		$budget->increment();
+		$this->assertSame( 1, $budget->current() );
+		$this->assertSame( 2, $budget->remaining() );
+		$this->assertFalse( $budget->exceeded() );
+	}
+
+	public function test_exceeded_at_ceiling(): void {
+		$budget = new IterationBudget( 'x', 2 );
+		$budget->increment();
+		$budget->increment();
+		$this->assertSame( 2, $budget->current() );
+		$this->assertSame( 0, $budget->remaining() );
+		$this->assertTrue( $budget->exceeded() );
+	}
+
+	public function test_exceeded_above_ceiling(): void {
+		$budget = new IterationBudget( 'x', 2 );
+		$budget->increment();
+		$budget->increment();
+		$budget->increment();
+		$this->assertSame( 3, $budget->current() );
+		$this->assertSame( 0, $budget->remaining() );
+		$this->assertTrue( $budget->exceeded() );
+	}
+
+	public function test_ceiling_minimum_enforced(): void {
+		$budget = new IterationBudget( 'x', 0 );
+		$this->assertSame( 1, $budget->ceiling(), 'Ceiling floor of 1 enforced' );
+	}
+
+	public function test_negative_starting_current_clamped_to_zero(): void {
+		$budget = new IterationBudget( 'x', 5, -3 );
+		$this->assertSame( 0, $budget->current() );
+	}
+
+	public function test_already_exceeded_start_preserved(): void {
+		$budget = new IterationBudget( 'x', 3, 7 );
+		$this->assertSame( 7, $budget->current() );
+		$this->assertTrue( $budget->exceeded() );
+	}
+
+	public function test_response_flag_naming(): void {
+		$budget = new IterationBudget( 'chain_depth', 3 );
+		$this->assertSame( 'max_chain_depth_reached', $budget->toResponseFlag() );
+	}
+
+	public function test_warning_format(): void {
+		$budget = new IterationBudget( 'chain_depth', 3 );
+		$this->assertSame( 'Maximum chain depth (3) reached.', $budget->toWarning() );
+	}
+
+	public function test_registry_register_and_get_config(): void {
+		IterationBudgetRegistry::register( $this->test_budget_name, array(
+			'default' => 7,
+			'min'     => 2,
+			'max'     => 12,
+		) );
+
+		$this->assertTrue( IterationBudgetRegistry::is_registered( $this->test_budget_name ) );
+
+		$config = IterationBudgetRegistry::get_config( $this->test_budget_name );
+		$this->assertSame( 7, $config['default'] );
+		$this->assertSame( 2, $config['min'] );
+		$this->assertSame( 12, $config['max'] );
+	}
+
+	public function test_registry_create_uses_default_when_no_override(): void {
+		IterationBudgetRegistry::register( $this->test_budget_name, array(
+			'default' => 8,
+			'min'     => 1,
+			'max'     => 20,
+		) );
+
+		$budget = IterationBudgetRegistry::create( $this->test_budget_name );
+		$this->assertSame( 8, $budget->ceiling() );
+		$this->assertSame( 0, $budget->current() );
+	}
+
+	public function test_registry_create_override_wins_over_default(): void {
+		IterationBudgetRegistry::register( $this->test_budget_name, array(
+			'default' => 8,
+			'min'     => 1,
+			'max'     => 20,
+		) );
+
+		$budget = IterationBudgetRegistry::create( $this->test_budget_name, 0, 15 );
+		$this->assertSame( 15, $budget->ceiling() );
+	}
+
+	public function test_registry_create_clamps_override_to_max(): void {
+		IterationBudgetRegistry::register( $this->test_budget_name, array(
+			'default' => 5,
+			'min'     => 1,
+			'max'     => 10,
+		) );
+
+		$budget = IterationBudgetRegistry::create( $this->test_budget_name, 0, 999 );
+		$this->assertSame( 10, $budget->ceiling() );
+	}
+
+	public function test_registry_create_clamps_override_to_min(): void {
+		IterationBudgetRegistry::register( $this->test_budget_name, array(
+			'default' => 5,
+			'min'     => 3,
+			'max'     => 10,
+		) );
+
+		$budget = IterationBudgetRegistry::create( $this->test_budget_name, 0, 0 );
+		$this->assertSame( 3, $budget->ceiling() );
+	}
+
+	public function test_registry_create_seeds_current_counter(): void {
+		IterationBudgetRegistry::register( $this->test_budget_name, array(
+			'default' => 10,
+			'min'     => 1,
+			'max'     => 20,
+		) );
+
+		$budget = IterationBudgetRegistry::create( $this->test_budget_name, 4 );
+		$this->assertSame( 4, $budget->current() );
+	}
+
+	public function test_registry_create_unregistered_name_returns_permissive_budget(): void {
+		$budget = IterationBudgetRegistry::create( 'never_registered_' . uniqid() );
+		$this->assertGreaterThan( 0, $budget->ceiling() );
+		$this->assertSame( 0, $budget->current() );
+		$this->assertFalse( $budget->exceeded() );
+	}
+
+	public function test_conversation_turns_budget_registered_at_boot(): void {
+		// The bootstrap file registers 'conversation_turns' at load time.
+		// This test documents that registration and guards against
+		// accidental removal.
+		$this->assertTrue(
+			IterationBudgetRegistry::is_registered( 'conversation_turns' ),
+			'conversation_turns budget should be registered at boot by inc/bootstrap.php'
+		);
+
+		$config = IterationBudgetRegistry::get_config( 'conversation_turns' );
+		$this->assertSame( 'max_turns', $config['setting'] );
+		$this->assertSame( 1, $config['min'] );
+		$this->assertSame( 50, $config['max'] );
+	}
+}

--- a/tests/Unit/Auth/CallerContextTest.php
+++ b/tests/Unit/Auth/CallerContextTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Tests for CallerContext value object.
+ *
+ * @package DataMachine\Tests\Unit\Auth
+ */
+
+namespace DataMachine\Tests\Unit\Auth;
+
+use DataMachine\Core\Auth\CallerContext;
+use WP_UnitTestCase;
+
+class CallerContextTest extends WP_UnitTestCase {
+
+	public function test_default_construction(): void {
+		$ctx = new CallerContext();
+		$this->assertSame( '', $ctx->callerSite() );
+		$this->assertSame( '', $ctx->callerAgent() );
+		$this->assertSame( '', $ctx->chainId() );
+		$this->assertSame( 0, $ctx->chainDepth() );
+		$this->assertFalse( $ctx->isCrossSite() );
+	}
+
+	public function test_from_request_with_full_headers(): void {
+		$request = new \WP_REST_Request();
+		$request->set_header( CallerContext::HEADER_CALLER_SITE, 'chubes.net' );
+		$request->set_header( CallerContext::HEADER_CALLER_AGENT, 'franklin' );
+		$request->set_header( CallerContext::HEADER_CHAIN_ID, 'abc-123' );
+		$request->set_header( CallerContext::HEADER_CHAIN_DEPTH, '2' );
+
+		$ctx = CallerContext::fromRequest( $request );
+
+		$this->assertSame( 'chubes.net', $ctx->callerSite() );
+		$this->assertSame( 'franklin', $ctx->callerAgent() );
+		$this->assertSame( 'abc-123', $ctx->chainId() );
+		$this->assertSame( 2, $ctx->chainDepth() );
+		$this->assertTrue( $ctx->isCrossSite() );
+	}
+
+	public function test_from_request_missing_chain_id_generates_one(): void {
+		$request = new \WP_REST_Request();
+
+		$ctx = CallerContext::fromRequest( $request );
+
+		$this->assertNotEmpty( $ctx->chainId(), 'Missing chain_id header auto-generates a UUID' );
+		$this->assertSame( 0, $ctx->chainDepth() );
+		$this->assertFalse( $ctx->isCrossSite() );
+	}
+
+	public function test_from_request_negative_depth_clamped_to_zero(): void {
+		$request = new \WP_REST_Request();
+		$request->set_header( CallerContext::HEADER_CHAIN_DEPTH, '-5' );
+
+		$ctx = CallerContext::fromRequest( $request );
+
+		$this->assertSame( 0, $ctx->chainDepth() );
+	}
+
+	public function test_from_request_accepts_plain_header_array(): void {
+		$headers = array(
+			CallerContext::HEADER_CALLER_SITE  => 'extrachill.com',
+			CallerContext::HEADER_CALLER_AGENT => 'sarai',
+			CallerContext::HEADER_CHAIN_ID     => 'chain-xyz',
+			CallerContext::HEADER_CHAIN_DEPTH  => '1',
+		);
+
+		$ctx = CallerContext::fromRequest( $headers );
+
+		$this->assertSame( 'extrachill.com', $ctx->callerSite() );
+		$this->assertSame( 'sarai', $ctx->callerAgent() );
+		$this->assertSame( 'chain-xyz', $ctx->chainId() );
+		$this->assertSame( 1, $ctx->chainDepth() );
+	}
+
+	public function test_from_request_header_lookup_is_case_insensitive(): void {
+		$headers = array(
+			'x-datamachine-caller-site'  => 'chubes.net',
+			'X-DATAMACHINE-CHAIN-ID'     => 'mixed-case',
+			'x-datamachine-chain-depth'  => '3',
+		);
+
+		$ctx = CallerContext::fromRequest( $headers );
+
+		$this->assertSame( 'chubes.net', $ctx->callerSite() );
+		$this->assertSame( 'mixed-case', $ctx->chainId() );
+		$this->assertSame( 3, $ctx->chainDepth() );
+	}
+
+	public function test_is_cross_site_requires_both_depth_and_site(): void {
+		// Depth without site — not cross-site.
+		$a = new CallerContext( '', 'some-agent', 'cid', 2 );
+		$this->assertFalse( $a->isCrossSite() );
+
+		// Site without depth — not cross-site (depth 0 = top of chain).
+		$b = new CallerContext( 'chubes.net', 'some-agent', 'cid', 0 );
+		$this->assertFalse( $b->isCrossSite() );
+
+		// Both — cross-site.
+		$c = new CallerContext( 'chubes.net', 'some-agent', 'cid', 1 );
+		$this->assertTrue( $c->isCrossSite() );
+	}
+
+	public function test_for_outbound_fresh_chain(): void {
+		$ctx = CallerContext::forOutbound( 'intelligence-chubes4.local', 'franklin' );
+
+		$this->assertSame( 'intelligence-chubes4.local', $ctx->callerSite() );
+		$this->assertSame( 'franklin', $ctx->callerAgent() );
+		$this->assertNotEmpty( $ctx->chainId(), 'Fresh chain generates a UUID' );
+		$this->assertSame( 1, $ctx->chainDepth(), 'Top-of-chain outbound is depth 1' );
+	}
+
+	public function test_for_outbound_propagates_inbound_chain(): void {
+		$inbound = new CallerContext( 'chubes.net', 'chubes-bot', 'original-chain', 2 );
+		$ctx     = CallerContext::forOutbound( 'intelligence-chubes4.local', 'franklin', $inbound );
+
+		$this->assertSame( 'original-chain', $ctx->chainId(), 'Chain ID propagates from inbound' );
+		$this->assertSame( 3, $ctx->chainDepth(), 'Depth increments by 1 for each hop' );
+		$this->assertSame( 'intelligence-chubes4.local', $ctx->callerSite(), 'Site reflects current site, not inbound' );
+		$this->assertSame( 'franklin', $ctx->callerAgent(), 'Agent reflects current site, not inbound' );
+	}
+
+	public function test_to_outbound_headers_includes_required_fields(): void {
+		$ctx     = new CallerContext( 'chubes.net', 'franklin', 'cid-1', 2 );
+		$headers = $ctx->toOutboundHeaders();
+
+		$this->assertSame( 'chubes.net', $headers[ CallerContext::HEADER_CALLER_SITE ] );
+		$this->assertSame( 'franklin', $headers[ CallerContext::HEADER_CALLER_AGENT ] );
+		$this->assertSame( 'cid-1', $headers[ CallerContext::HEADER_CHAIN_ID ] );
+		$this->assertSame( '2', $headers[ CallerContext::HEADER_CHAIN_DEPTH ] );
+	}
+
+	public function test_to_outbound_headers_omits_empty_identity_fields(): void {
+		$ctx     = new CallerContext( '', '', 'cid-1', 0 );
+		$headers = $ctx->toOutboundHeaders();
+
+		$this->assertArrayNotHasKey( CallerContext::HEADER_CALLER_SITE, $headers );
+		$this->assertArrayNotHasKey( CallerContext::HEADER_CALLER_AGENT, $headers );
+		$this->assertArrayHasKey( CallerContext::HEADER_CHAIN_ID, $headers );
+		$this->assertArrayHasKey( CallerContext::HEADER_CHAIN_DEPTH, $headers );
+	}
+
+	public function test_to_log_context_shape(): void {
+		$ctx = new CallerContext( 'chubes.net', 'franklin', 'cid-1', 2 );
+		$log = $ctx->toLogContext();
+
+		$this->assertSame( 'chubes.net', $log['caller_site'] );
+		$this->assertSame( 'franklin', $log['caller_agent'] );
+		$this->assertSame( 'cid-1', $log['chain_id'] );
+		$this->assertSame( 2, $log['chain_depth'] );
+	}
+
+	public function test_chain_depth_budget_registered_at_boot(): void {
+		$this->assertTrue(
+			\DataMachine\Engine\AI\IterationBudgetRegistry::is_registered( 'chain_depth' ),
+			'chain_depth budget should be registered at boot by inc/bootstrap.php'
+		);
+
+		$config = \DataMachine\Engine\AI\IterationBudgetRegistry::get_config( 'chain_depth' );
+		$this->assertSame( 'max_chain_depth', $config['setting'] );
+		$this->assertSame( 1, $config['min'] );
+		$this->assertSame( 10, $config['max'] );
+	}
+
+	public function test_chain_depth_budget_enforces_ceiling(): void {
+		// At depth 2, budget ceiling default 3: still has room.
+		$budget = \DataMachine\Engine\AI\IterationBudgetRegistry::create( 'chain_depth', 2 );
+		$this->assertFalse( $budget->exceeded() );
+
+		// At depth 3, budget at ceiling: exceeded.
+		$budget = \DataMachine\Engine\AI\IterationBudgetRegistry::create( 'chain_depth', 3 );
+		$this->assertTrue( $budget->exceeded() );
+
+		// At depth 7, budget well over ceiling: still exceeded.
+		$budget = \DataMachine\Engine\AI\IterationBudgetRegistry::create( 'chain_depth', 7 );
+		$this->assertTrue( $budget->exceeded() );
+	}
+}


### PR DESCRIPTION
Closes #1122. Also closes the architectural follow-up question raised on #1125's initial scope: consolidates Phase A (primitive extraction) and Phase B (chain-depth + caller context) into one coherent PR because they share a design.

## Shape

```
Phase A (0260fa41)                     Phase B (31e1496a)
─────────────────────────              ─────────────────────────
IterationBudget primitive              chain_depth budget
  ↓  registered at boot                  registered at boot
  ↓                                      ↓
AIConversationLoop migrated             AgentAuthMiddleware
  to use primitive                        reads caller headers,
  (zero behavior change)                  enforces chain_depth,
                                          sets caller context
                                        RemoteAgentClient
                                          propagates caller +
                                          chain headers outbound
                                        PermissionHelper
                                          exposes caller context
```

Both phases share the `IterationBudget` primitive. Phase B is ~200 LOC on top of Phase A's primitive because the budget is already there — the chain_depth implementation is just one new `register()` call, one middleware check, and one outbound header set.

## What's in

### Phase A: `IterationBudget` + `IterationBudgetRegistry`

Generic primitive for bounded-iteration budgets. One stateful counter object with uniform API: `increment()`, `exceeded()`, `remaining()`, `current()`, `ceiling()`, `name()`, `toResponseFlag()`, `toWarning()`. Registry declares name → config (default, min, max, site-setting key) so consumers instantiate fresh budgets per run without duplicating clamp/lookup boilerplate.

`max_turns` migrated to use the primitive. External behavior byte-identical:

- Warning text: `"Maximum conversation turns (N) reached. Response may be incomplete."`
- `max_turns_reached` response flag (single_turn mode)
- `turn_count` response field
- Clamp `[1, 50]`
- `datamachine_conversation_runner` filter contract

Log shape for budget-exceeded cases standardized: `budget` / `ceiling` / `current` fields replace the inconsistent `max_turns` / `final_turn_count` / `turn_count` mix that had accumulated. Future budgets all log the same shape — queryable by budget name, consistent field names across consumers.

### Phase B: Chain depth + caller context

**`CallerContext` value object** — parses A2A headers from incoming requests, emits them on outbound. `fromRequest()` accepts `WP_REST_Request` or a plain header array (case-insensitive). `forOutbound()` propagates an incoming chain (incrementing depth) or starts a fresh one. Generates chain_id UUID lazily.

**`chain_depth` budget** — registered at boot with `default=3, min=1, max=10, setting='max_chain_depth'`. Enforced by middleware at every inbound authenticated request. Exceedance returns:

```
HTTP 429
{
  "code": "datamachine_chain_depth_exceeded",
  "message": "A2A chain depth (3) exceeded. Refusing to extend the chain further.",
  "data": { "status": 429, "retry_after": 60, "chain_id": "...", "chain_depth": 3, "ceiling": 3 }
}
```

**`AgentAuthMiddleware` integration** — after bearer-token resolution, parses `CallerContext::fromRequest()` from `$_SERVER`, instantiates the chain_depth budget seeded from incoming depth, bails with WP_Error if exceeded, otherwise stores caller context on `PermissionHelper` for downstream code.

**`RemoteAgentClient` integration** — every outbound call emits the four headers (`Caller-Site`, `Caller-Agent`, `Chain-Id`, `Chain-Depth`). The site host comes from `network_home_url`; the agent slug comes from `PermissionHelper::get_acting_agent_id()` resolved via the Agents repo. Caller-provided headers cannot override A2A headers (same protection already applied to Authorization).

**`PermissionHelper`** gains `set_caller_context()`, `get_caller_context()`, `in_cross_site_context()`. Cleared alongside agent context.

## What's NOT in this PR (follow-ups to #1122)

- Target agent routing (`target_agent_slug` param on `/chat`) — multi-agent sites concern, separable.
- Caller context system-prompt injection in `ChatOrchestrator` — receiving agent UX layer on top of the plumbing. Logic for "what the model sees" lives one level up.
- Structured refusal response shape in `/chat` body — the middleware returns the WP_Error shape which is sufficient; a bespoke refusal body for `/chat` can layer on.
- CLI commands to inspect chains (e.g. `wp datamachine external chains --tail`) — observability nice-to-have.

## Tests

- `tests/Unit/AI/IterationBudgetTest.php` — primitive + registry semantics, boot-time registration guard for `conversation_turns`.
- `tests/Unit/Auth/CallerContextTest.php` — header parsing, case-insensitive lookup, UUID generation on missing chain_id, cross-site detection edge cases, outbound propagation (fresh + inherited), log context shape, boot-time registration guard for `chain_depth`, and budget exceedance at/above ceiling.

Both test files register the guard-tests against the budgets to prevent accidental removal from `inc/bootstrap.php` — registration silently disappearing would break the system without test failures otherwise.

## Risk

Phase A is a pure refactor with external byte-identical behavior except the log-shape cleanup (which had no consumers). Phase B introduces new behavior only on requests that carry A2A headers — non-A2A requests observe no change because `chain_depth` starts at 0 and the budget ceiling of 3 is not reached in a single hop.

The default `chain_depth=3` is deliberately conservative. If real-world chains need more hops, the `max_chain_depth` site setting raises the ceiling without any code change.

## Related

- #1121 — outbound client (shipped in #1123). Phase B extends `RemoteAgentClient` with A2A header propagation but doesn't depend on any internal changes from #1123 other than the client existing.
- Pattern #3 (chat A2A) from the `projects/agent-to-site-authentication` wiki article is unblocked by this PR for manual / one-hop use; automated deep chains can now depend on `chain_depth` enforcement not to run away.