### PR TITLE
refactor(composable): drop unused header arg from MemoryFileRegistry

### DIFF
--- a/inc/Engine/AI/ComposableFileGenerator.php
+++ b/inc/Engine/AI/ComposableFileGenerator.php
@@ -72,14 +72,6 @@ class ComposableFileGenerator {
 			);
 		}
 
-		// Prepend the registrar-owned header, if any. Core does not inject
-		// editorial content (titles, warnings) — the file's owner supplies
-		// its own header via MemoryFileRegistry::register( ..., array( 'header' => ... ) ).
-		$header = isset( $meta['header'] ) && is_string( $meta['header'] ) ? trim( $meta['header'] ) : '';
-		if ( '' !== $header ) {
-			$content = $header . "\n\n" . $content;
-		}
-
 		// Resolve write target.
 		// Files with a convention_path write ONLY to that path (e.g. AGENTS.md → site root).
 		// Files without one write to their layer directory as before.

--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -82,10 +82,6 @@ class MemoryFileRegistry {
 	 *                                        demand and are not hand-editable. Default false.
 	 *     @type string      $convention_path Relative path from ABSPATH where a convention copy of this
 	 *                                        file should also be written (e.g. 'AGENTS.md'). Optional.
-	 *     @type string      $header          Optional header content prepended to composable output
-	 *                                        during regeneration (e.g. a top-level title). Only used
-	 *                                        when `composable` is true. The registrar owns this
-	 *                                        string — core does not inject editorial content.
 	 * }
 	 * @return void
 	 */
@@ -121,9 +117,6 @@ class MemoryFileRegistry {
 		// Convention path: relative path from ABSPATH for an additional copy.
 		$convention_path = isset( $args['convention_path'] ) ? ltrim( $args['convention_path'], '/' ) : '';
 
-		// Optional composable header (owned by the registrar, not core).
-		$header = isset( $args['header'] ) && is_string( $args['header'] ) ? $args['header'] : '';
-
 		self::$files[ $filename ] = array(
 			'filename'        => $filename,
 			'priority'        => $priority,
@@ -135,7 +128,6 @@ class MemoryFileRegistry {
 			'contexts'        => $contexts,
 			'label'           => $args['label'] ?? self::filename_to_label( $filename ),
 			'description'     => $args['description'] ?? '',
-			'header'          => $header,
 		);
 	}
 


### PR DESCRIPTION
## Summary

Reverts the `header` arg added in #1126. That PR exposed a registrar-owned header slot on `MemoryFileRegistry::register()` so `data-machine-code` could keep the `# AI Instructions` H1 on regenerated AGENTS.md without core hard-coding it. A minute later we realized: **the H1 itself is redundant chrome** — the filename tells every reader it's agent instructions, the H1 carries no signal, and it shipped a dead line into every agent's system prompt every turn.

If a future composable file genuinely needs a title line, the right mechanism is a priority-0 `SectionRegistry::register()` callback that emits it. Sections are already the composition primitive; a parallel `header` concept on the file registry was redundant surface area.

## Change

- `MemoryFileRegistry::register()`: drop the `header` arg from the docblock and the registered metadata.
- `ComposableFileGenerator::regenerate()`: drop the `$meta['header']` prepend block. Generated content is now strictly the output of `SectionRegistry::generate()`.

## Paired PRs

- **Extra-Chill/data-machine-code** `chore/flatten-agents-md-sections` — drops `'header' => '# AI Instructions'` from the AGENTS.md registration and promotes the plugin's own AGENTS.md sections from H3 to H2.
- **Automattic/intelligence** `chore/flatten-agents-md-sections` — promotes the Intelligence section's headings from H3/H4 to H2/H3 so the full assembled AGENTS.md has a valid hierarchy.

## Test

Grepped for any other consumer of the `header` metadata key — only the three files in #1126 referenced it, all reverted here.