### PR TITLE
feat(tools): consolidate chubes_ai_tools + rename contexts → modes

### DIFF
--- a/docs/ai-directives.md
+++ b/docs/ai-directives.md
@@ -86,7 +86,7 @@ add_filter('datamachine_directives', function($directives) {
     $directives[] = [
         'class'       => MyCustomDirective::class,
         'priority'    => 25,
-        'contexts'    => ['pipeline', 'chat', 'all'],
+        'modes'       => ['pipeline', 'chat', 'all'],
     ];
     return $directives;
 });

--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -292,7 +292,7 @@ Available only to chat AI agents via `datamachine_chat_tools` filter. These spec
 
 ### Handler-Specific Tools
 
-Available only when next step matches the handler type, registered via `chubes_ai_tools` filter:
+Available only when the adjacent step matches the handler slug or type, registered into the unified `datamachine_tools` registry as `_handler_callable` entries:
 
 **Publishing Tools**:
 - `twitter_publish` - Post to Twitter (280 char limit)
@@ -391,7 +391,7 @@ Chat-specific tools at `/inc/Api/Chat/Tools/`:
 - `SystemHealthCheck.php` - System health diagnostics
 - `UpdateFlow.php` - Flow property updates and scheduling modifications
 
-Handler-specific tools registered via `chubes_ai_tools` filter using HandlerRegistrationTrait in each handler class.
+Handler-specific tools registered into the unified `datamachine_tools` registry using HandlerRegistrationTrait in each handler class. Each entry carries a `_handler_callable` that is resolved at pipeline execution time with the adjacent step's runtime handler config.
 
 ## Tool Management
 
@@ -417,22 +417,30 @@ add_filter('datamachine_chat_tools', function($tools) {
 });
 ```
 
-**Handler-Specific Tools** (available when next step matches handler type):
+**Handler-Specific Tools** (available when adjacent step matches handler slug or type):
 ```php
-// Registered via chubes_ai_tools filter with handler context
-add_filter('chubes_ai_tools', function($tools, $handler_slug = null, $handler_config = []) {
-    if ($handler_slug === 'twitter') {
-        $tools['twitter_publish'] = [
-            'class' => 'Twitter\\Handler',
-            'method' => 'handle_tool_call',
-            'handler' => 'twitter',
-            'description' => 'Post to Twitter',
-            'parameters' => ['content' => ['type' => 'string', 'required' => true]],
-            'handler_config' => $handler_config
-        ];
-    }
+// Registered into the unified datamachine_tools registry as a deferred
+// _handler_callable entry. Preferred path is HandlerRegistrationTrait.
+add_filter('datamachine_tools', function($tools) {
+    $tools['__handler_tools_twitter'] = [
+        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
+            return [
+                'twitter_publish' => [
+                    'class'          => 'Twitter\\Handler',
+                    'method'         => 'handle_tool_call',
+                    'handler'        => $handler_slug,
+                    'description'    => 'Post to Twitter',
+                    'parameters'     => ['content' => ['type' => 'string', 'required' => true]],
+                    'handler_config' => $handler_config,
+                ],
+            ];
+        },
+        'handler'      => 'twitter',
+        'contexts'     => ['pipeline'],
+        'access_level' => 'admin',
+    ];
     return $tools;
-}, 10, 3);
+});
 ```
 
 ### Discovery Hierarchy
@@ -480,7 +488,7 @@ $available_tools = \DataMachine\Engine\AI\ToolExecutor::getAvailableTools(
 ```
 
 **Discovery Process**:
-1. **Handler Tools**: Retrieved via `chubes_ai_tools` filter for specific handler
+1. **Handler Tools**: Retrieved from the `datamachine_tools` registry — `_handler_callable` entries resolved per adjacent step
 2. **Global Tools**: Retrieved via `datamachine_global_tools` filter
 3. **Chat Tools**: Retrieved via `datamachine_chat_tools` filter (chat agent only)
 4. **Enablement Check**: Each tool filtered through `datamachine_tool_enabled`

--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -436,7 +436,7 @@ add_filter('datamachine_tools', function($tools) {
             ];
         },
         'handler'      => 'twitter',
-        'contexts'     => ['pipeline'],
+        'modes'        => ['pipeline'],
         'access_level' => 'admin',
     ];
     return $tools;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -305,7 +305,7 @@ Data Machine v0.2.0 introduced a universal Engine layer (`/inc/Engine/AI/`) that
 ### Filter-Based Discovery
 All components self-register via WordPress filters:
 - `datamachine_handlers` - Register fetch/publish/upsert handlers
-- `chubes_ai_tools` - Register AI tools and capabilities
+- `datamachine_tools` - Register AI tools and capabilities (unified static + runtime handler tool registry)
 - `datamachine_auth_providers` - Register authentication providers
 - `datamachine_step_types` - Register custom step types
 - `datamachine_directives` - Register AI context directives

--- a/docs/core-system/ai-directives.md
+++ b/docs/core-system/ai-directives.md
@@ -330,7 +330,7 @@ Several directives integrate with plugin settings:
 $directives[] = [
     'class' => 'My\Directive\Class',
     'priority' => 25,
-    'contexts' => ['chat', 'pipeline', 'all']
+    'modes'    => ['chat', 'pipeline', 'all']
 ];
 ```
 

--- a/docs/core-system/handler-registration-trait.md
+++ b/docs/core-system/handler-registration-trait.md
@@ -97,14 +97,29 @@ add_filter('datamachine_handler_settings', function($settings, $handler_slug_par
 }, 10, 2);
 ```
 
-### 4. chubes_ai_tools
+### 4. datamachine_tools (handler tools)
 
-AI tool registration via callback (conditional on tools_callback provided).
+AI tool registration via callback (conditional on tools_callback provided). The
+trait wires the callback into the unified `datamachine_tools` registry as a
+deferred `_handler_callable` entry. `ToolPolicyResolver::gatherPipelineTools()`
+resolves it at pipeline execution time using the runtime handler config and
+engine data from the adjacent step.
 
 ```php
 // Only registered if tools_callback is provided
-add_filter('chubes_ai_tools', $tools_callback, 10, 3);
+add_filter('datamachine_tools', function($tools) use ($slug, $tools_callback) {
+    $tools['__handler_tools_' . $slug] = [
+        '_handler_callable' => $tools_callback,
+        'handler'           => $slug,
+        'contexts'          => ['pipeline'],
+        'access_level'      => 'admin',
+    ];
+    return $tools;
+});
 ```
+
+The callback receives `(string $handler_slug, array $handler_config, array $engine_data)`
+and returns `['tool_name' => $tool_definition]` (empty array to opt out).
 
 ## Usage Example
 
@@ -126,11 +141,10 @@ class TwitterFilters {
             true,  // Requires OAuth
             TwitterAuth::class,
             TwitterSettings::class,
-            function($tools, $handler_slug, $handler_config) {
-                if ($handler_slug === 'twitter') {
-                    $tools['twitter_publish'] = datamachine_get_twitter_tool($handler_config);
-                }
-                return $tools;
+            function($handler_slug, $handler_config, $engine_data) {
+                return [
+                    'twitter_publish' => datamachine_get_twitter_tool($handler_config),
+                ];
             }
         );
     }
@@ -190,11 +204,10 @@ class WordPressUpdateFilters {
             false,
             null,
             WordPressUpdateSettings::class,
-            function($tools, $handler_slug, $handler_config) {
-                if ($handler_slug === 'wordpress_update') {
-                    $tools['wordpress_update'] = datamachine_get_wordpress_update_tool($handler_config);
-                }
-                return $tools;
+            function($handler_slug, $handler_config, $engine_data) {
+                return [
+                    'wordpress_update' => datamachine_get_wordpress_update_tool($handler_config),
+                ];
             }
         );
     }
@@ -225,7 +238,7 @@ Custom handlers should adopt this pattern by:
    add_filter('datamachine_handlers', function($handlers) { /* ... */ });
    add_filter('datamachine_auth_providers', function($providers) { /* ... */ });
    add_filter('datamachine_handler_settings', function($settings) { /* ... */ });
-   add_filter('chubes_ai_tools', function($tools) { /* ... */ });
+   add_filter('datamachine_tools', function($tools) { /* ... */ });  // manual _handler_callable wiring
 
    // After (trait registration)
    self::registerHandler(
@@ -243,17 +256,19 @@ Custom handlers should adopt this pattern by:
 
 3. **Move tool registration to callback parameter**:
    ```php
-   function($tools, $handler_slug, $handler_config) {
-       if ($handler_slug === 'my_handler') {
-           $tools['my_tool'] = [
+   // Receives (handler_slug, handler_config, engine_data) and returns
+   // [tool_name => definition]. The trait handles routing to the adjacent
+   // step's handler — no manual slug check needed.
+   function($handler_slug, $handler_config, $engine_data) {
+       return [
+           'my_tool' => [
                'class' => MyHandler::class,
                'method' => 'handle_tool_call',
                'handler' => 'my_handler',
                'description' => 'Tool description',
-               'parameters' => [/* ... */]
-           ];
-       }
-       return $tools;
+               'parameters' => [/* ... */],
+           ],
+       ];
    }
    ```
 
@@ -311,12 +326,17 @@ add_filter('datamachine_handler_settings', function($settings, $handler_slug) {
     return $settings;
 }, 10, 2);
 
-add_filter('chubes_ai_tools', function($tools, $handler_slug, $handler_config) {
-    if ($handler_slug === 'my_handler') {
-        $tools['my_tool'] = [/* ... */];
-    }
+add_filter('datamachine_tools', function($tools) {
+    $tools['__handler_tools_my_handler'] = [
+        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
+            return ['my_tool' => [/* ... */]];
+        },
+        'handler'           => 'my_handler',
+        'contexts'          => ['pipeline'],
+        'access_level'      => 'admin',
+    ];
     return $tools;
-}, 10, 3);
+});
 ```
 
 After trait (same functionality):
@@ -331,11 +351,8 @@ self::registerHandler(
     true,
     MyHandlerAuth::class,
     MyHandlerSettings::class,
-    function($tools, $handler_slug, $handler_config) {
-        if ($handler_slug === 'my_handler') {
-            $tools['my_tool'] = [/* ... */];
-        }
-        return $tools;
+    function($handler_slug, $handler_config, $engine_data) {
+        return ['my_tool' => [/* ... */]];
     }
 );
 ```

--- a/docs/core-system/handler-registration-trait.md
+++ b/docs/core-system/handler-registration-trait.md
@@ -111,7 +111,7 @@ add_filter('datamachine_tools', function($tools) use ($slug, $tools_callback) {
     $tools['__handler_tools_' . $slug] = [
         '_handler_callable' => $tools_callback,
         'handler'           => $slug,
-        'contexts'          => ['pipeline'],
+        'modes'             => ['pipeline'],
         'access_level'      => 'admin',
     ];
     return $tools;
@@ -332,7 +332,7 @@ add_filter('datamachine_tools', function($tools) {
             return ['my_tool' => [/* ... */]];
         },
         'handler'           => 'my_handler',
-        'contexts'          => ['pipeline'],
+        'modes'             => ['pipeline'],
         'access_level'      => 'admin',
     ];
     return $tools;

--- a/docs/core-system/memory-policy.md
+++ b/docs/core-system/memory-policy.md
@@ -105,7 +105,7 @@ Returns a `filename => metadata` map of registered files after policy is applied
 ```php
 $resolver = new MemoryPolicyResolver();
 $files    = $resolver->resolveRegistered( array(
-    'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
+    'mode'     => MemoryPolicyResolver::MODE_CHAT,
     'agent_id' => $agent_id,
 ) );
 ```
@@ -140,9 +140,9 @@ Use these to inject cross-cutting policy logic (org-wide deny lists, environment
 Match `ToolPolicyResolver` for consistency across the policy layer:
 
 ```php
-MemoryPolicyResolver::CONTEXT_PIPELINE  // pipeline step AI execution
-MemoryPolicyResolver::CONTEXT_CHAT      // admin chat session
-MemoryPolicyResolver::CONTEXT_SYSTEM    // system task execution
+MemoryPolicyResolver::MODE_PIPELINE  // pipeline step AI execution
+MemoryPolicyResolver::MODE_CHAT      // admin chat session
+MemoryPolicyResolver::MODE_SYSTEM    // system task execution
 ```
 
 Custom contexts (e.g. `'editor'`, `'automation'`) are supported everywhere the registry accepts them — the resolver just passes them through.

--- a/docs/core-system/tool-execution.md
+++ b/docs/core-system/tool-execution.md
@@ -53,31 +53,44 @@ $tools = ToolExecutor::getAvailableTools(null, null, null);
 
 #### 1. Handler Tools (Step-Specific)
 
-Tools registered via `chubes_ai_tools` filter, scoped to specific handlers:
+Tools registered into the unified `datamachine_tools` registry as
+`_handler_callable` entries — runtime-resolved with the adjacent step's
+handler config so parameter shapes can adapt to per-step settings (e.g.
+AI-decides taxonomies, character limits, etc.). The preferred path is
+`HandlerRegistrationTrait::registerHandler()`; manual shape:
 
 ```php
-add_filter('chubes_ai_tools', function($tools, $handler_slug = null, $handler_config = []) {
-    if ($handler_slug === 'twitter') {
-        $tools['twitter_publish'] = [
-            'class' => 'DataMachine\\Core\\Steps\\Publish\\Handlers\\Twitter\\Twitter',
-            'method' => 'handle_tool_call',
-            'handler' => 'twitter',
-            'description' => 'Post content to Twitter (280 character limit)',
-            'parameters' => [
-                'content' => [
-                    'type' => 'string',
-                    'required' => true,
-                    'description' => 'Tweet content (max 280 chars)'
-                ]
-            ],
-            'handler_config' => $handler_config
-        ];
-    }
+add_filter('datamachine_tools', function($tools) {
+    $tools['__handler_tools_twitter'] = [
+        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
+            return [
+                'twitter_publish' => [
+                    'class'          => 'DataMachine\\Core\\Steps\\Publish\\Handlers\\Twitter\\Twitter',
+                    'method'         => 'handle_tool_call',
+                    'handler'        => $handler_slug,
+                    'description'    => 'Post content to Twitter (280 character limit)',
+                    'parameters'     => [
+                        'content' => [
+                            'type'        => 'string',
+                            'required'    => true,
+                            'description' => 'Tweet content (max 280 chars)',
+                        ],
+                    ],
+                    'handler_config' => $handler_config,
+                ],
+            ];
+        },
+        'handler'      => 'twitter',
+        'contexts'     => ['pipeline'],
+        'access_level' => 'admin',
+    ];
     return $tools;
-}, 10, 3);
+});
 ```
 
-**Key**: Tools with `'handler'` field are automatically filtered to matching handler slug.
+**Key**: `ToolPolicyResolver::gatherPipelineTools()` resolves these entries
+against the adjacent pipeline step's `handler_slug` (or `handler_types` for
+cross-cutting tools like `skip_item`).
 
 #### 2. Global Tools (All Agents)
 
@@ -472,14 +485,15 @@ foreach ($engine_parameters as $key => $value) {
 
 ### Handler Tools
 
-**Registration**: `chubes_ai_tools` filter
+**Registration**: `datamachine_tools` filter — `_handler_callable` entries
 **Scope**: Step-specific (publish, upsert handlers)
-**Enablement**: Automatic if handler matches
+**Enablement**: Automatic when adjacent step's handler slug or type matches
 **Examples**: `twitter_publish`, `wordpress_publish`, `bluesky_publish`
 
 **Characteristics**:
-- Registered with `'handler'` field matching handler slug
-- Automatically filtered to current/next step handler
+- Registry entry carries `'handler' => 'slug'` (exact match) or
+  `'handler_types' => [...]` (cross-cutting tools like `skip_item`)
+- Resolved at pipeline execution time with the adjacent step's handler config
 - Receive data packets and engine parameters
 - Execute final workflow actions (publishing, updating)
 
@@ -513,27 +527,34 @@ foreach ($engine_parameters as $key => $value) {
 
 ### Tool Registration
 
-**Handler Tools**:
+**Handler Tools** (preferred path is `HandlerRegistrationTrait::registerHandler()`):
 ```php
-add_filter('chubes_ai_tools', function($tools, $handler_slug, $handler_config) {
-    if ($handler_slug === 'my_handler') {
-        $tools['my_tool'] = [
-            'class' => 'MyNamespace\\MyHandler',
-            'method' => 'handle_tool_call',
-            'handler' => 'my_handler',  // Critical for automatic filtering
-            'description' => 'Clear, concise tool description',
-            'parameters' => [
-                'param_name' => [
-                    'type' => 'string',
-                    'required' => true,
-                    'description' => 'Parameter description for AI'
-                ]
-            ],
-            'handler_config' => $handler_config
-        ];
-    }
+add_filter('datamachine_tools', function($tools) {
+    $tools['__handler_tools_my_handler'] = [
+        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
+            return [
+                'my_tool' => [
+                    'class'          => 'MyNamespace\\MyHandler',
+                    'method'         => 'handle_tool_call',
+                    'handler'        => $handler_slug,
+                    'description'    => 'Clear, concise tool description',
+                    'parameters'     => [
+                        'param_name' => [
+                            'type'        => 'string',
+                            'required'    => true,
+                            'description' => 'Parameter description for AI',
+                        ],
+                    ],
+                    'handler_config' => $handler_config,
+                ],
+            ];
+        },
+        'handler'      => 'my_handler',
+        'contexts'     => ['pipeline'],
+        'access_level' => 'admin',
+    ];
     return $tools;
-}, 10, 3);
+});
 ```
 
 **Global Tools**:

--- a/docs/core-system/tool-execution.md
+++ b/docs/core-system/tool-execution.md
@@ -81,7 +81,7 @@ add_filter('datamachine_tools', function($tools) {
             ];
         },
         'handler'      => 'twitter',
-        'contexts'     => ['pipeline'],
+        'modes'        => ['pipeline'],
         'access_level' => 'admin',
     ];
     return $tools;
@@ -550,7 +550,7 @@ add_filter('datamachine_tools', function($tools) {
             ];
         },
         'handler'      => 'my_handler',
-        'contexts'     => ['pipeline'],
+        'modes'        => ['pipeline'],
         'access_level' => 'admin',
     ];
     return $tools;

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -131,8 +131,10 @@ Authentication provider registration (conditional on `requires_auth=true`)
 #### datamachine_handler_settings
 Settings class registration (always registered if settings_class provided)
 
-#### chubes_ai_tools
-AI tool registration via callback (conditional on tools_callback provided)
+#### datamachine_tools (handler tools)
+AI tool registration via callback (conditional on tools_callback provided). The
+trait wires the callback into the unified `datamachine_tools` registry as a
+deferred `_handler_callable` entry resolved at pipeline execution time.
 
 ### Usage Pattern
 
@@ -182,11 +184,10 @@ class TwitterFilters {
             true,  // Requires OAuth
             TwitterAuth::class,
             TwitterSettings::class,
-            function($tools, $handler_slug, $handler_config) {
-                if ($handler_slug === 'twitter') {
-                    $tools['twitter_publish'] = datamachine_get_twitter_tool($handler_config);
-                }
-                return $tools;
+            function($handler_slug, $handler_config, $engine_data) {
+                return [
+                    'twitter_publish' => datamachine_get_twitter_tool($handler_config),
+                ];
             }
         );
     }
@@ -227,34 +228,104 @@ See Handler Registration Trait for complete documentation.
 
 ## AI Integration Filters
 
-### `chubes_ai_tools`
+### `datamachine_tools`
 
-**Purpose**: Register AI tools for agentic execution
+**Purpose**: Unified registry for every AI tool — static global tools AND per-handler
+runtime-generated tools. Consumed by `ToolPolicyResolver` when gathering the
+available tool set for a pipeline or chat context.
 
 **Parameters**:
-- `$tools` (array) - Current tools array
-- `$handler_slug` (string|null) - Target handler slug (for handler-specific tools)
-- `$handler_config` (array) - Handler configuration
+- `$tools` (array) - Current tools registry (keyed by tool name or internal wrapper key)
 
-**Return**: Array of tool definitions
+**Return**: Modified tools array
 
-**Tool Structure**:
+#### Static tool entry (global tools)
+
 ```php
-$tools['tool_name'] = [
-    'class' => 'ToolClassName',
-    'method' => 'handle_tool_call',
-    'description' => 'Tool description for AI',
-    'parameters' => [
+add_filter('datamachine_tools', function($tools) {
+    $tools['my_tool'] = [
+        '_callable'     => [$this, 'getToolDefinition'],  // Lazy resolution
+        'contexts'      => ['chat', 'pipeline'],
+        'ability'       => 'datamachine/my-ability',      // Links to an ability for permission resolution
+        'access_level'  => 'admin',                       // Fallback when no ability is linked
+    ];
+    return $tools;
+});
+```
+
+The `_callable` resolves to the full tool definition array (name, description,
+parameters, etc.) at first access. See
+[Tool Registration](../../core-system/tool-execution.md) for the resolved
+definition contract.
+
+#### Handler tool entry (dynamic, runtime-generated)
+
+Handler tools are shaped by the runtime handler configuration of the adjacent
+pipeline step (e.g. `ai_decides` taxonomy choices produce different tool
+parameter schemas). The registry entry contains a `_handler_callable` that
+receives runtime context and returns one or more tool definitions.
+
+```php
+add_filter('datamachine_tools', function($tools) {
+    $tools['__handler_tools_wordpress_publish'] = [
+        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
+            return [
+                'wordpress_publish' => [
+                    'class'       => WordPressPublishTool::class,
+                    'method'      => 'handle_tool_call',
+                    'handler'     => $handler_slug,
+                    'description' => 'Publish content to WordPress',
+                    'parameters'  => build_params_from_config($handler_config),
+                ],
+            ];
+        },
+        'handler'      => 'wordpress_publish',  // Exact slug match against adjacent step
+        'contexts'     => ['pipeline'],
+        'access_level' => 'admin',
+    ];
+    return $tools;
+});
+```
+
+Matching modes:
+- `'handler' => 'slug'` — entry applies only when the adjacent step's handler
+  slug equals `'slug'`.
+- `'handler_types' => ['fetch', 'event_import']` — entry applies to any
+  handler whose registered `type` is in the list. Used for cross-cutting
+  tools (e.g. `skip_item` exposed to every fetch-type handler).
+
+The callback signature is `(string $handler_slug, array $handler_config, array $engine_data): array`.
+Returned array is `['tool_name' => $tool_definition]` (empty array to opt out).
+
+**Preferred pattern**: use `HandlerRegistrationTrait::registerHandler()` — the
+trait wires the callback into this filter with the correct wrapper shape. Manual
+registration is only needed for cross-cutting tools that register against
+`handler_types`.
+
+#### Resolved tool definition contract
+
+Whether a tool comes from a static `_callable` or a handler `_handler_callable`,
+the resolved definition follows the same shape:
+
+```php
+[
+    'class'          => 'ToolClassName',
+    'method'         => 'handle_tool_call',
+    'description'    => 'Tool description for AI',
+    'parameters'     => [
         'param_name' => [
-            'type' => 'string|integer|boolean',
-            'required' => true|false,
-            'description' => 'Parameter description'
-        ]
+            'type'        => 'string|integer|boolean',
+            'required'    => true|false,
+            'description' => 'Parameter description',
+        ],
     ],
-    'handler' => 'handler_slug', // Optional: makes tool handler-specific
-    'requires_config' => true|false, // Optional: UI configuration indicator
-    'handler_config' => $handler_config // Optional: passed to tool execution
-];
+    'handler'        => 'handler_slug',      // Optional: handler-owned tool
+    'requires_config' => true|false,         // Optional: UI configuration indicator
+    'handler_config' => $handler_config,     // Optional: passed to tool execution
+    'contexts'       => ['pipeline'],        // Filled by registry wrapper if absent
+    'ability'        => 'datamachine/...',   // Optional: permission link
+    'access_level'   => 'admin',             // Optional: permission fallback
+]
 ```
 
 ### `chubes_ai_request`
@@ -1029,7 +1100,7 @@ Builds parameters for handler-specific tools with engine data merging (source_ur
 ```
 
 **Discovery Process**:
-1. Handler Tools - Retrieved via `chubes_ai_tools` filter
+1. Handler Tools - Retrieved via `datamachine_tools` filter (runtime-resolved `_handler_callable` entries)
 2. Global Tools - Retrieved via `datamachine_global_tools` filter
 3. Chat Tools - Retrieved via `datamachine_chat_tools` filter (chat only)
 4. Enablement Check - Each tool filtered through `datamachine_tool_enabled`

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -245,7 +245,7 @@ available tool set for a pipeline or chat context.
 add_filter('datamachine_tools', function($tools) {
     $tools['my_tool'] = [
         '_callable'     => [$this, 'getToolDefinition'],  // Lazy resolution
-        'contexts'      => ['chat', 'pipeline'],
+        'modes'         => ['chat', 'pipeline'],
         'ability'       => 'datamachine/my-ability',      // Links to an ability for permission resolution
         'access_level'  => 'admin',                       // Fallback when no ability is linked
     ];
@@ -280,7 +280,7 @@ add_filter('datamachine_tools', function($tools) {
             ];
         },
         'handler'      => 'wordpress_publish',  // Exact slug match against adjacent step
-        'contexts'     => ['pipeline'],
+        'modes'        => ['pipeline'],
         'access_level' => 'admin',
     ];
     return $tools;
@@ -322,7 +322,7 @@ the resolved definition follows the same shape:
     'handler'        => 'handler_slug',      // Optional: handler-owned tool
     'requires_config' => true|false,         // Optional: UI configuration indicator
     'handler_config' => $handler_config,     // Optional: passed to tool execution
-    'contexts'       => ['pipeline'],        // Filled by registry wrapper if absent
+    'modes'          => ['pipeline'],        // Filled by registry wrapper if absent
     'ability'        => 'datamachine/...',   // Optional: permission link
     'access_level'   => 'admin',             // Optional: permission fallback
 ]

--- a/docs/handlers/publish/handlers-overview.md
+++ b/docs/handlers/publish/handlers-overview.md
@@ -96,28 +96,37 @@ abstract protected function executePublish(array $parameters, array $handler_con
 
 ### AI Tool Registration
 
-Each handler registers its tool via filters:
+Each handler registers its tool through the unified `datamachine_tools` registry.
+The preferred path is `HandlerRegistrationTrait::registerHandler()` which wires
+the callback for you; the equivalent manual registration shape is:
 
 ```php
-add_filter('chubes_ai_tools', function($tools, $handler_slug = null, $handler_config = []) {
-    if ($handler_slug === 'wordpress_publish') {
-        $tools['wordpress_publish'] = [
-            'class' => 'DataMachine\\Core\\Steps\\Publish\\Handlers\\WordPress\\WordPress',
-            'method' => 'handle_tool_call',
-            'handler' => 'wordpress_publish',
-            'description' => 'Publish content to WordPress',
-            'parameters' => [
-                'content' => [
-                    'type' => 'string',
-                    'required' => true,
-                    'description' => 'Content to publish'
-                ]
-            ],
-            'handler_config' => $handler_config
-        ];
-    }
+add_filter('datamachine_tools', function($tools) {
+    $tools['__handler_tools_wordpress_publish'] = [
+        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
+            return [
+                'wordpress_publish' => [
+                    'class'          => 'DataMachine\\Core\\Steps\\Publish\\Handlers\\WordPress\\WordPress',
+                    'method'         => 'handle_tool_call',
+                    'handler'        => $handler_slug,
+                    'description'    => 'Publish content to WordPress',
+                    'parameters'     => [
+                        'content' => [
+                            'type'        => 'string',
+                            'required'    => true,
+                            'description' => 'Content to publish',
+                        ],
+                    ],
+                    'handler_config' => $handler_config,
+                ],
+            ];
+        },
+        'handler'      => 'wordpress_publish',
+        'contexts'     => ['pipeline'],
+        'access_level' => 'admin',
+    ];
     return $tools;
-}, 10, 3);
+});
 ```
 
 ## Common Features
@@ -335,23 +344,30 @@ class CustomPublishHandler {
 ### Tool Registration
 
 ```php
-add_filter('chubes_ai_tools', function($tools, $handler_slug = null, $handler_config = []) {
-    if ($handler_slug === 'custom_platform') {
-        $tools['custom_publish'] = [
-            'class' => 'CustomPublishHandler',
-            'method' => 'handle_tool_call',
-            'handler' => 'custom_platform',
-            'description' => 'Publish content to custom platform',
-            'parameters' => [
-                'content' => [
-                    'type' => 'string',
-                    'required' => true,
-                    'description' => 'Content to publish'
-                ]
-            ],
-            'handler_config' => $handler_config
-        ];
-    }
+add_filter('datamachine_tools', function($tools) {
+    $tools['__handler_tools_custom_platform'] = [
+        '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
+            return [
+                'custom_publish' => [
+                    'class'          => 'CustomPublishHandler',
+                    'method'         => 'handle_tool_call',
+                    'handler'        => $handler_slug,
+                    'description'    => 'Publish content to custom platform',
+                    'parameters'     => [
+                        'content' => [
+                            'type'        => 'string',
+                            'required'    => true,
+                            'description' => 'Content to publish',
+                        ],
+                    ],
+                    'handler_config' => $handler_config,
+                ],
+            ];
+        },
+        'handler'      => 'custom_platform',
+        'contexts'     => ['pipeline'],
+        'access_level' => 'admin',
+    ];
     return $tools;
-}, 10, 3);
+});
 ```

--- a/docs/handlers/publish/handlers-overview.md
+++ b/docs/handlers/publish/handlers-overview.md
@@ -122,7 +122,7 @@ add_filter('datamachine_tools', function($tools) {
             ];
         },
         'handler'      => 'wordpress_publish',
-        'contexts'     => ['pipeline'],
+        'modes'        => ['pipeline'],
         'access_level' => 'admin',
     ];
     return $tools;
@@ -365,7 +365,7 @@ add_filter('datamachine_tools', function($tools) {
             ];
         },
         'handler'      => 'custom_platform',
-        'contexts'     => ['pipeline'],
+        'modes'        => ['pipeline'],
         'access_level' => 'admin',
     ];
     return $tools;

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -181,6 +181,6 @@ wp datamachine jobs undo <job_id> --dry-run --allow-root
 - **Multi-platform publishing** via dedicated fetch/publish/upsert handlers for files, RSS, Reddit, Google Sheets, WordPress, Twitter, Threads, Bluesky, Facebook, and Google Sheets output.
 - **Daily memory system** for automatic temporal knowledge management with AI-driven pruning.
 - **System tasks** for background AI operations (image generation, alt text, internal linking, meta descriptions) with undo support.
-- **Extension points** through filters such as `datamachine_handlers`, `chubes_ai_tools`, `datamachine_step_types`, `datamachine_auth_providers`, and `datamachine_engine_data`.
+- **Extension points** through filters such as `datamachine_handlers`, `datamachine_tools`, `datamachine_step_types`, `datamachine_auth_providers`, and `datamachine_engine_data`.
 - **Directive orchestration** ensures every AI request is context-aware, tool-enabled, and consistent with site policies.
 - **Chartable logging, deduplication, and error handling** keep operators informed about job outcomes and prevent duplicate processing.

--- a/inc/Abilities/Content/EditPostBlocksAbility.php
+++ b/inc/Abilities/Content/EditPostBlocksAbility.php
@@ -107,7 +107,7 @@ class EditPostBlocksAbility {
 			function ( $tools ) {
 				$tools['edit_post_blocks'] = array(
 					'_callable' => array( self::class, 'getChatTool' ),
-					'contexts'  => array( 'chat' ),
+					'modes'     => array( 'chat' ),
 					'ability'   => 'datamachine/edit-post-blocks',
 				);
 				return $tools;
@@ -292,24 +292,29 @@ class EditPostBlocksAbility {
 				}
 			}
 
-			$diff = CanonicalDiffPreview::build( array(
-				'diff_id'             => $diff_id,
-				'diff_type'           => 'edit',
-				'original_content'    => implode( "\n", array_column( $diffs, 'originalContent' ) ),
-				'replacement_content' => implode( "\n", array_column( $diffs, 'replacementContent' ) ),
-				'summary'             => 'Preview generated. Accept or reject to apply changes.',
-				'items'               => $diffs,
-			) );
+			$diff = CanonicalDiffPreview::build(
+				array(
+					'diff_id'             => $diff_id,
+					'diff_type'           => 'edit',
+					'original_content'    => implode( "\n", array_column( $diffs, 'originalContent' ) ),
+					'replacement_content' => implode( "\n", array_column( $diffs, 'replacementContent' ) ),
+					'summary'             => 'Preview generated. Accept or reject to apply changes.',
+					'items'               => $diffs,
+				)
+			);
 
-			CanonicalDiffPreview::store_pending( $diff_id, array(
-				'type'    => 'edit_post_blocks',
-				'post_id' => $post_id,
-				'input'   => array(
+			CanonicalDiffPreview::store_pending(
+				$diff_id,
+				array(
+					'type'    => 'edit_post_blocks',
 					'post_id' => $post_id,
-					'edits'   => $edits,
-				),
-				'diff'    => $diff,
-			) );
+					'input'   => array(
+						'post_id' => $post_id,
+						'edits'   => $edits,
+					),
+					'diff'    => $diff,
+				)
+			);
 
 			return CanonicalDiffPreview::response(
 				$post_id,

--- a/inc/Abilities/Content/GetPostBlocksAbility.php
+++ b/inc/Abilities/Content/GetPostBlocksAbility.php
@@ -97,7 +97,7 @@ class GetPostBlocksAbility {
 			function ( $tools ) {
 				$tools['get_post_blocks'] = array(
 					'_callable' => array( self::class, 'getChatTool' ),
-					'contexts'  => array( 'chat' ),
+					'modes'     => array( 'chat' ),
 					'ability'   => 'datamachine/get-post-blocks',
 				);
 				return $tools;

--- a/inc/Abilities/Content/InsertContentAbility.php
+++ b/inc/Abilities/Content/InsertContentAbility.php
@@ -2,8 +2,8 @@
 /**
  * InsertContentAbility — positional content insertion with diff preview.
  *
-	 * Inserts new content at the beginning, end, or after a specific paragraph
-	 * in a post. Returns canonical diff preview data for frontend/editor review.
+ * Inserts new content at the beginning, end, or after a specific paragraph
+ * in a post. Returns canonical diff preview data for frontend/editor review.
  *
  * Ported from Wordsurf's insert_content tool (Phase 2 migration).
  *
@@ -36,45 +36,48 @@ class InsertContentAbility {
 	 */
 	private function register_ability(): void {
 		$register = function () {
-			wp_register_ability( 'datamachine/insert-content', array(
-				'label'               => 'Insert Content',
-				'description'         => 'Insert new content at a specific position in a post (beginning, end, or after a paragraph).',
-				'category'            => 'datamachine-content',
-				'input_schema'        => array(
-					'type'       => 'object',
-					'required'   => array( 'post_id', 'content', 'position' ),
-					'properties' => array(
-						'post_id'               => array(
-							'type'        => 'integer',
-							'description' => 'The post to insert content into.',
-						),
-						'content'               => array(
-							'type'        => 'string',
-							'description' => 'The new content to insert (will be wrapped in WordPress paragraph blocks).',
-						),
-						'position'              => array(
-							'type'        => 'string',
-							'enum'        => array( 'beginning', 'end', 'after_paragraph' ),
-							'description' => 'Where to insert: beginning, end, or after_paragraph.',
-						),
-						'target_paragraph_text' => array(
-							'type'        => 'string',
-							'description' => 'Required when position is after_paragraph. A short phrase (3-8 words) from the paragraph to insert after.',
+			wp_register_ability(
+				'datamachine/insert-content',
+				array(
+					'label'               => 'Insert Content',
+					'description'         => 'Insert new content at a specific position in a post (beginning, end, or after a paragraph).',
+					'category'            => 'datamachine-content',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'post_id', 'content', 'position' ),
+						'properties' => array(
+							'post_id'               => array(
+								'type'        => 'integer',
+								'description' => 'The post to insert content into.',
+							),
+							'content'               => array(
+								'type'        => 'string',
+								'description' => 'The new content to insert (will be wrapped in WordPress paragraph blocks).',
+							),
+							'position'              => array(
+								'type'        => 'string',
+								'enum'        => array( 'beginning', 'end', 'after_paragraph' ),
+								'description' => 'Where to insert: beginning, end, or after_paragraph.',
+							),
+							'target_paragraph_text' => array(
+								'type'        => 'string',
+								'description' => 'Required when position is after_paragraph. A short phrase (3-8 words) from the paragraph to insert after.',
+							),
 						),
 					),
-				),
-				'output_schema'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'success' => array( 'type' => 'boolean' ),
-						'diff_id' => array( 'type' => 'string' ),
-						'diff'    => array( 'type' => 'object' ),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'diff_id' => array( 'type' => 'string' ),
+							'diff'    => array( 'type' => 'object' ),
+						),
 					),
-				),
-				'execute_callback'    => array( self::class, 'execute' ),
-				'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
-				'meta'                => array( 'show_in_rest' => false ),
-			) );
+					'execute_callback'    => array( self::class, 'execute' ),
+					'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
 		};
 
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
@@ -93,7 +96,7 @@ class InsertContentAbility {
 			function ( $tools ) {
 				$tools['insert_content'] = array(
 					'_callable' => array( self::class, 'getChatTool' ),
-					'contexts'  => array( 'chat', 'pipeline', 'system', 'editor' ),
+					'modes'     => array( 'chat', 'pipeline', 'system', 'editor' ),
 					'ability'   => 'datamachine/insert-content',
 				);
 				return $tools;
@@ -254,44 +257,49 @@ class InsertContentAbility {
 
 		$diff_id = PendingDiffStore::generate_id();
 
-		$diff = CanonicalDiffPreview::build( array(
-			'diff_id'             => $diff_id,
-			'diff_type'           => 'insert',
-			'original_content'    => '',
-			'replacement_content' => $content,
-			'summary'             => sprintf( 'Prepared content insertion %s.', $insertion_point ),
-			'position'            => $position,
-			'insertion_point'     => $insertion_point,
-			'items'               => array(
-				array(
-					'blockIndex'         => $block_index,
-					'originalContent'    => '',
-					'replacementContent' => $content,
+		$diff = CanonicalDiffPreview::build(
+			array(
+				'diff_id'             => $diff_id,
+				'diff_type'           => 'insert',
+				'original_content'    => '',
+				'replacement_content' => $content,
+				'summary'             => sprintf( 'Prepared content insertion %s.', $insertion_point ),
+				'position'            => $position,
+				'insertion_point'     => $insertion_point,
+				'items'               => array(
+					array(
+						'blockIndex'         => $block_index,
+						'originalContent'    => '',
+						'replacementContent' => $content,
+					),
 				),
-			),
-			'editor'              => array(
-				'toolCallId'           => $input['_original_call_id'] ?? '',
-				'editType'             => 'content',
-				'searchPattern'        => '',
-				'caseSensitive'        => false,
-				'isPreview'            => true,
-				'previewBlockContent'  => $block_content,
-				'originalBlockContent' => '',
-				'originalBlockType'    => 'core/paragraph',
-			),
-		) );
+				'editor'              => array(
+					'toolCallId'           => $input['_original_call_id'] ?? '',
+					'editType'             => 'content',
+					'searchPattern'        => '',
+					'caseSensitive'        => false,
+					'isPreview'            => true,
+					'previewBlockContent'  => $block_content,
+					'originalBlockContent' => '',
+					'originalBlockType'    => 'core/paragraph',
+				),
+			)
+		);
 
-		CanonicalDiffPreview::store_pending( $diff_id, array(
-			'type'    => 'insert_content',
-			'post_id' => $post_id,
-			'input'   => array(
-				'post_id'               => $post_id,
-				'content'               => $content,
-				'position'              => $position,
-				'target_paragraph_text' => $target_paragraph_text,
-			),
-			'diff'    => $diff,
-		) );
+		CanonicalDiffPreview::store_pending(
+			$diff_id,
+			array(
+				'type'    => 'insert_content',
+				'post_id' => $post_id,
+				'input'   => array(
+					'post_id'               => $post_id,
+					'content'               => $content,
+					'position'              => $position,
+					'target_paragraph_text' => $target_paragraph_text,
+				),
+				'diff'    => $diff,
+			)
+		);
 
 		return CanonicalDiffPreview::response(
 			$post_id,

--- a/inc/Abilities/Content/ReplacePostBlocksAbility.php
+++ b/inc/Abilities/Content/ReplacePostBlocksAbility.php
@@ -102,7 +102,7 @@ class ReplacePostBlocksAbility {
 			function ( $tools ) {
 				$tools['replace_post_blocks'] = array(
 					'_callable' => array( self::class, 'getChatTool' ),
-					'contexts'  => array( 'chat' ),
+					'modes'     => array( 'chat' ),
 					'ability'   => 'datamachine/replace-post-blocks',
 				);
 				return $tools;
@@ -273,30 +273,38 @@ class ReplacePostBlocksAbility {
 				);
 			}
 
-			$diff = CanonicalDiffPreview::build( array(
-				'diff_id'             => $diff_id,
-				'diff_type'           => 'replace',
-				'original_content'    => implode( "\n", array_column( $diffs, 'originalContent' ) ),
-				'replacement_content' => implode( "\n", array_column( $diffs, 'replacementContent' ) ),
-				'summary'             => 'Preview generated. Accept or reject to apply changes.',
-				'items'               => $diffs,
-			) );
+			$diff = CanonicalDiffPreview::build(
+				array(
+					'diff_id'             => $diff_id,
+					'diff_type'           => 'replace',
+					'original_content'    => implode( "\n", array_column( $diffs, 'originalContent' ) ),
+					'replacement_content' => implode( "\n", array_column( $diffs, 'replacementContent' ) ),
+					'summary'             => 'Preview generated. Accept or reject to apply changes.',
+					'items'               => $diffs,
+				)
+			);
 
-			CanonicalDiffPreview::store_pending( $diff_id, array(
-				'type'    => 'replace_post_blocks',
-				'post_id' => $post_id,
-				'input'   => array(
-					'post_id'      => $post_id,
-					'replacements' => $replacements,
-				),
-				'diff'    => $diff,
-			) );
+			CanonicalDiffPreview::store_pending(
+				$diff_id,
+				array(
+					'type'    => 'replace_post_blocks',
+					'post_id' => $post_id,
+					'input'   => array(
+						'post_id'      => $post_id,
+						'replacements' => $replacements,
+					),
+					'diff'    => $diff,
+				)
+			);
 
 			// Strip raw HTML from the changes returned to the AI.
-			$clean_changes = array_map( function ( $c ) {
-				unset( $c['originalContent'], $c['replacementContent'] );
-				return $c;
-			}, $changes );
+			$clean_changes = array_map(
+				function ( $c ) {
+					unset( $c['originalContent'], $c['replacementContent'] );
+					return $c;
+				},
+				$changes
+			);
 
 			return CanonicalDiffPreview::response(
 				$post_id,
@@ -337,10 +345,13 @@ class ReplacePostBlocksAbility {
 		);
 
 		// Strip raw HTML from changes in normal mode too (not needed in response).
-		$clean_changes = array_map( function ( $c ) {
-			unset( $c['originalContent'], $c['replacementContent'] );
-			return $c;
-		}, $changes );
+		$clean_changes = array_map(
+			function ( $c ) {
+				unset( $c['originalContent'], $c['replacementContent'] );
+				return $c;
+			},
+			$changes
+		);
 
 		return array(
 			'success'         => true,

--- a/inc/Abilities/File/AgentFileAbilities.php
+++ b/inc/Abilities/File/AgentFileAbilities.php
@@ -315,7 +315,7 @@ class AgentFileAbilities {
 				'layer'       => $layer,
 				'protected'   => MemoryFileRegistry::is_protected( $filename ),
 				'editable'    => MemoryFileRegistry::is_editable( $filename ),
-				'modes'       => $registry_meta['modes'] ?? array( MemoryFileRegistry::CONTEXT_ALL ),
+				'modes'       => $registry_meta['modes'] ?? array( MemoryFileRegistry::MODE_ALL ),
 				'registered'  => true,
 				'label'       => $registry_meta['label'] ?? self::filename_to_label( $filename ),
 				'description' => $registry_meta['description'] ?? '',
@@ -338,8 +338,8 @@ class AgentFileAbilities {
 					continue;
 				}
 
-				$registry_meta = MemoryFileRegistry::get( $entry->filename );
-				$files[]       = array(
+				$registry_meta            = MemoryFileRegistry::get( $entry->filename );
+				$files[]                  = array(
 					'filename'    => $entry->filename,
 					'size'        => $entry->bytes,
 					'modified'    => null !== $entry->updated_at ? gmdate( 'c', $entry->updated_at ) : '',
@@ -347,7 +347,7 @@ class AgentFileAbilities {
 					'layer'       => $registry_meta ? $registry_meta['layer'] : $layer,
 					'protected'   => MemoryFileRegistry::is_protected( $entry->filename ),
 					'editable'    => MemoryFileRegistry::is_editable( $entry->filename ),
-					'modes'       => $registry_meta['modes'] ?? array( MemoryFileRegistry::CONTEXT_ALL ),
+					'modes'       => $registry_meta['modes'] ?? array( MemoryFileRegistry::MODE_ALL ),
 					'registered'  => null !== $registry_meta,
 					'label'       => $registry_meta['label'] ?? self::filename_to_label( $entry->filename ),
 					'description' => $registry_meta['description'] ?? '',
@@ -355,8 +355,6 @@ class AgentFileAbilities {
 				$seen[ $entry->filename ] = true;
 			}
 		}
-
-
 
 		// Include daily memory summary.
 		$daily        = new DailyMemory( $user_id, (int) ( $input['agent_id'] ?? 0 ) );
@@ -612,10 +610,12 @@ class AgentFileAbilities {
 		}
 
 		// Return updated file list.
-		return $this->executeListAgentFiles( array(
-			'user_id'  => $user_id,
-			'agent_id' => $agent_id,
-		) );
+		return $this->executeListAgentFiles(
+			array(
+				'user_id'  => $user_id,
+				'agent_id' => $agent_id,
+			)
+		);
 	}
 
 	// =========================================================================

--- a/inc/Abilities/PostQueryAbilities.php
+++ b/inc/Abilities/PostQueryAbilities.php
@@ -217,7 +217,7 @@ class PostQueryAbilities {
 			function ( $tools ) {
 				$tools['query_posts'] = array(
 					'_callable' => array( $this, 'getQueryPostsTool' ),
-					'contexts'  => array( 'chat' ),
+					'modes'     => array( 'chat' ),
 					'ability'   => 'datamachine/query-posts',
 				);
 				return $tools;

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -175,7 +175,7 @@ class ChatOrchestrator {
 				'single_turn'          => true,
 				'max_turns'            => $max_turns,
 				'selected_pipeline_id' => $selected_pipeline_id ? $selected_pipeline_id : null,
-				'context'              => 'chat',
+				'mode'                 => ToolPolicyResolver::MODE_CHAT,
 				'user_id'              => $user_id,
 				'agent_id'             => $agent_id,
 				'client_context'       => $options['client_context'] ?? array(),
@@ -344,7 +344,7 @@ class ChatOrchestrator {
 				'single_turn'          => true,
 				'max_turns'            => $max_turns,
 				'selected_pipeline_id' => $selected_pipeline_id,
-				'context'              => 'chat',
+				'mode'                 => ToolPolicyResolver::MODE_CHAT,
 				'user_id'              => (int) ( $session['user_id'] ?? 0 ),
 			)
 		);
@@ -467,7 +467,7 @@ class ChatOrchestrator {
 			$provider,
 			$model,
 			array(
-				'context' => 'chat',
+				'mode'    => ToolPolicyResolver::MODE_CHAT,
 				'user_id' => $user_id,
 			)
 		);
@@ -626,7 +626,7 @@ class ChatOrchestrator {
 	 *     @type bool   $single_turn          Whether to run single turn (default false).
 	 *     @type int    $max_turns             Maximum turns allowed (default 25).
 	 *     @type int    $selected_pipeline_id  Currently selected pipeline ID.
-	 *     @type string $context               Execution context (default 'chat').
+	 *     @type string $mode                  Agent mode (default 'chat').
 	 * }
 	 * @return array|WP_Error Result array with messages, final_content, completed, turn_count,
 	 *                        last_tool_calls, and optional warning/max_turns_reached keys.
@@ -642,7 +642,7 @@ class ChatOrchestrator {
 		$single_turn          = $options['single_turn'] ?? false;
 		$max_turns            = $options['max_turns'] ?? PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
 		$selected_pipeline_id = $options['selected_pipeline_id'] ?? null;
-		$context              = $options['context'] ?? ToolPolicyResolver::CONTEXT_CHAT;
+		$mode                 = $options['mode'] ?? ToolPolicyResolver::MODE_CHAT;
 		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
 
 		$chat_db = ConversationStoreFactory::get();
@@ -655,10 +655,12 @@ class ChatOrchestrator {
 			}
 
 			$resolver       = new ToolPolicyResolver();
-			$all_tools      = $resolver->resolve( array(
-				'context'  => ToolPolicyResolver::CONTEXT_CHAT,
-				'agent_id' => $agent_id,
-			) );
+			$all_tools      = $resolver->resolve(
+				array(
+					'mode'     => ToolPolicyResolver::MODE_CHAT,
+					'agent_id' => $agent_id,
+				)
+			);
 			$client_context = $options['client_context'] ?? array();
 
 			$loop_context = array(
@@ -678,7 +680,7 @@ class ChatOrchestrator {
 				$all_tools,
 				$provider,
 				$model,
-				$context,
+				$mode,
 				$loop_context,
 				$max_turns,
 				$single_turn
@@ -705,7 +707,7 @@ class ChatOrchestrator {
 					array(
 						'session_id' => $session_id,
 						'error'      => $loop_result['error'],
-						'context'    => $context,
+						'mode'       => $mode,
 					)
 				);
 
@@ -734,7 +736,7 @@ class ChatOrchestrator {
 				array(
 					'session_id' => $session_id,
 					'error'      => $e->getMessage(),
-					'context'    => $context,
+					'mode'       => $mode,
 				)
 			);
 

--- a/inc/Api/Chat/ChatPipelinesDirective.php
+++ b/inc/Api/Chat/ChatPipelinesDirective.php
@@ -128,7 +128,7 @@ add_filter(
 		$directives[] = array(
 			'class'    => ChatPipelinesDirective::class,
 			'priority' => 45,
-			'contexts' => array( 'chat' ),
+			'modes'    => array( 'chat' ),
 		);
 
 		return $directives;

--- a/inc/Api/Handlers.php
+++ b/inc/Api/Handlers.php
@@ -228,20 +228,23 @@ class Handlers {
 		$settings_display_service = new \DataMachine\Core\Steps\Settings\SettingsDisplayService();
 		$field_state              = $settings_display_service->getFieldState( $handler_slug, $handler_defaults );
 
-		// Get AI tool definition
-		$ai_tool = null;
-		$tools   = apply_filters( 'chubes_ai_tools', array(), $handler_slug, array() );
+		// Resolve handler tool definition from the unified registry using
+		// empty handler_config/engine_data — the admin details endpoint wants
+		// the shape-at-registration-time, not a pipeline-specific rendering.
+		$ai_tool      = null;
+		$tool_manager = new \DataMachine\Engine\AI\Tools\ToolManager();
+		$tools        = $tool_manager->resolveHandlerTools( $handler_slug, array(), array() );
 
-		// Find the tool associated with this handler
 		foreach ( $tools as $tool_name => $tool_def ) {
-			if ( ( $tool_def['handler'] ?? '' ) === $handler_slug ) {
-				$ai_tool = array(
-					'tool_name'   => $tool_name,
-					'description' => $tool_def['description'] ?? '',
-					'parameters'  => $tool_def['parameters'] ?? array(),
-				);
-				break;
+			if ( ( $tool_def['handler'] ?? '' ) !== $handler_slug ) {
+				continue;
 			}
+			$ai_tool = array(
+				'tool_name'   => $tool_name,
+				'description' => $tool_def['description'] ?? '',
+				'parameters'  => $tool_def['parameters'] ?? array(),
+			);
+			break;
 		}
 
 		return rest_ensure_response(

--- a/inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php
+++ b/inc/Core/Admin/Pages/Pipelines/PipelinesFilters.php
@@ -128,18 +128,30 @@ function datamachine_get_ai_providers_for_react() {
 }
 
 /**
- * Get AI tools formatted for React
+ * Get AI tools formatted for React.
+ *
+ * Returns only global (non-handler) tools from the unified `datamachine_tools`
+ * registry. Handler tools are excluded because their definitions are shaped
+ * by runtime handler config and are only meaningful inside a pipeline
+ * execution context.
  *
  * @return array AI tools with configuration status
  */
-function datamachine_get_chubes_ai_tools_for_react() {
-	// Get all available tools
-	$all_tools = apply_filters( 'chubes_ai_tools', array() );
+function datamachine_get_ai_tools_for_react() {
+	$tool_manager = new \DataMachine\Engine\AI\Tools\ToolManager();
+	$all_tools    = $tool_manager->get_all_tools();
 
-	// Filter to only global tools (no handler property)
+	// Filter to only global tools — exclude both per-handler tools (carry
+	// a 'handler' link) and handler tool registry wrappers.
 	$global_tools = array_filter(
 		$all_tools,
 		function ( $tool_def ) {
+			if ( ! is_array( $tool_def ) ) {
+				return false;
+			}
+			if ( isset( $tool_def['_handler_callable'] ) ) {
+				return false;
+			}
 			return ! isset( $tool_def['handler'] );
 		}
 	);

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -110,9 +110,9 @@ class AIStep extends Step {
 		// entirely when identity fields in engine_data match an existing record.
 		//
 		// Filter returns null to proceed normally, or an array with:
-		//   'skip'   => true
-		//   'reason' => string (for logging)
-		//   'status' => string (job status override, e.g. 'completed_no_items')
+		// 'skip'   => true
+		// 'reason' => string (for logging)
+		// 'status' => string (job status override, e.g. 'completed_no_items')
 		$pre_check = apply_filters( 'datamachine_pre_ai_step_check', null, $this->engine, $this->flow_step_config, $this->job_id );
 
 		if ( is_array( $pre_check ) && ! empty( $pre_check['skip'] ) ) {
@@ -258,15 +258,17 @@ class AIStep extends Step {
 			?? array();
 
 		$resolver        = new ToolPolicyResolver();
-		$available_tools = $resolver->resolve( array(
-			'context'              => ToolPolicyResolver::CONTEXT_PIPELINE,
-			'agent_id'             => $agent_id,
-			'previous_step_config' => $previous_step_config,
-			'next_step_config'     => $next_step_config,
-			'pipeline_step_id'     => $pipeline_step_id,
-			'engine_data'          => $engine_data,
-			'categories'           => $tool_categories,
-		) );
+		$available_tools = $resolver->resolve(
+			array(
+				'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+				'agent_id'             => $agent_id,
+				'previous_step_config' => $previous_step_config,
+				'next_step_config'     => $next_step_config,
+				'pipeline_step_id'     => $pipeline_step_id,
+				'engine_data'          => $engine_data,
+				'categories'           => $tool_categories,
+			)
+		);
 
 		// Filter handler slugs to only those that are actual AI tools.
 		// Previous-step handler slugs (e.g. 'universal_web_scraper') are
@@ -276,10 +278,12 @@ class AIStep extends Step {
 		// calling the same handler tool on every turn until max_turns.
 		// See: https://github.com/Extra-Chill/data-machine/issues/1108
 		if ( ! empty( $all_handler_slugs ) ) {
-			$ai_tool_handler_slugs = array_values( array_intersect(
-				array_unique( $all_handler_slugs ),
-				array_keys( $available_tools )
-			) );
+			$ai_tool_handler_slugs = array_values(
+				array_intersect(
+					array_unique( $all_handler_slugs ),
+					array_keys( $available_tools )
+				)
+			);
 
 			if ( ! empty( $ai_tool_handler_slugs ) ) {
 				$payload['flow_step_config'] = array(
@@ -338,7 +342,7 @@ class AIStep extends Step {
 				$available_tools,
 				$provider_name,
 				$model_name,
-				ToolPolicyResolver::CONTEXT_PIPELINE,
+				ToolPolicyResolver::MODE_PIPELINE,
 				$payload,
 				$max_turns
 			);

--- a/inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php
+++ b/inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php
@@ -62,10 +62,13 @@ class FlowMemoryFilesDirective implements \DataMachine\Engine\AI\Directives\Dire
 		// deny/allow_only applies to flow memory, not just registered
 		// core files.
 		$resolver     = new MemoryPolicyResolver();
-		$memory_files = $resolver->filter( $memory_files, array(
-			'agent_id' => $agent_id,
-			'scope'    => 'flow',
-		) );
+		$memory_files = $resolver->filter(
+			$memory_files,
+			array(
+				'agent_id' => $agent_id,
+				'scope'    => 'flow',
+			)
+		);
 
 		return MemoryFilesReader::read( $memory_files, 'Flow', $flow_id, $user_id, $agent_id );
 	}
@@ -78,7 +81,7 @@ add_filter(
 		$directives[] = array(
 			'class'    => FlowMemoryFilesDirective::class,
 			'priority' => 45,
-			'contexts' => array( 'pipeline' ),
+			'modes'    => array( 'pipeline' ),
 		);
 		return $directives;
 	}

--- a/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php
@@ -60,10 +60,13 @@ class PipelineMemoryFilesDirective implements \DataMachine\Engine\AI\Directives\
 		// gets the same treatment whether the file is injected by the
 		// registry or by explicit pipeline config.
 		$resolver     = new MemoryPolicyResolver();
-		$memory_files = $resolver->filter( $memory_files, array(
-			'agent_id' => $agent_id,
-			'scope'    => 'pipeline',
-		) );
+		$memory_files = $resolver->filter(
+			$memory_files,
+			array(
+				'agent_id' => $agent_id,
+				'scope'    => 'pipeline',
+			)
+		);
 
 		return MemoryFilesReader::read( $memory_files, 'Pipeline', (int) $pipeline_id, $user_id, $agent_id );
 	}
@@ -76,7 +79,7 @@ add_filter(
 		$directives[] = array(
 			'class'    => PipelineMemoryFilesDirective::class,
 			'priority' => 40,
-			'contexts' => array( 'pipeline' ),
+			'modes'    => array( 'pipeline' ),
 		);
 		return $directives;
 	}

--- a/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
@@ -161,7 +161,7 @@ add_filter(
 		$directives[] = array(
 			'class'    => PipelineSystemPromptDirective::class,
 			'priority' => 50,
-			'contexts' => array( 'pipeline' ),
+			'modes'    => array( 'pipeline' ),
 		);
 		return $directives;
 	}

--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -417,48 +417,50 @@ abstract class FetchHandler {
 	/**
 	 * Initialize FetchHandler static functionality.
 	 *
-	 * Registers the skip_item tool filter for all fetch-type handlers.
-	 * Called during plugin bootstrap after handlers are loaded.
+	 * Registers the skip_item tool in the unified `datamachine_tools` registry
+	 * as a cross-cutting handler tool — ToolPolicyResolver resolves it for any
+	 * adjacent step whose handler type is `fetch` or `event_import`.
 	 *
 	 * @since 0.9.7
 	 */
 	public static function init(): void {
-		add_filter( 'chubes_ai_tools', array( self::class, 'registerSkipItemTool' ), 10, 4 );
+		add_filter(
+			'datamachine_tools',
+			static function ( array $tools ): array {
+				$tools['__handler_tools_skip_item'] = array(
+					'_handler_callable' => array( self::class, 'resolveSkipItemTool' ),
+					'handler_types'     => array( 'fetch', 'event_import' ),
+					'contexts'          => array( 'pipeline' ),
+					'access_level'      => 'admin',
+				);
+				return $tools;
+			}
+		);
 	}
 
 	/**
-	 * Register skip_item tool for fetch-type handlers.
+	 * Resolve the skip_item tool for a specific fetch-type handler.
 	 *
-	 * The skip_item tool is available when the previous step (before the AI step)
-	 * is a fetch-type handler. This allows the AI to explicitly skip items that
-	 * don't meet processing criteria (e.g., non-music events).
+	 * Invoked lazily by ToolManager::resolveHandlerTools() when ANY adjacent
+	 * step handler's registered type is `fetch` or `event_import`. The tool
+	 * is re-shaped per-handler so the description can reference the concrete
+	 * source in pipeline prompts.
 	 *
-	 * @param array       $tools          Current tools array
-	 * @param string|null $handler_slug   Handler slug being queried
-	 * @param array       $handler_config Handler configuration
-	 * @param array       $engine_data    Engine data snapshot
-	 * @return array Modified tools array
+	 * @param string $handler_slug   Resolved adjacent-step handler slug.
+	 * @param array  $handler_config Handler configuration.
+	 * @param array  $engine_data    Engine data snapshot (unused).
+	 * @return array{skip_item: array} Tool map with the skip_item definition.
 	 * @since 0.9.7
 	 */
-	public static function registerSkipItemTool( array $tools, ?string $handler_slug = null, array $handler_config = array(), array $engine_data = array() ): array {
-		$engine_data;
-		if ( empty( $handler_slug ) ) {
-			return $tools;
-		}
-
-		// Check if this handler_slug is a fetch-type or event_import-type handler
-		$fetch_handlers        = apply_filters( 'datamachine_handlers', array(), 'fetch' );
-		$event_import_handlers = apply_filters( 'datamachine_handlers', array(), 'event_import' );
-		$all_fetch_handlers    = array_merge( $fetch_handlers, $event_import_handlers );
-
-		if ( ! isset( $all_fetch_handlers[ $handler_slug ] ) ) {
-			return $tools;
-		}
-
-		// Register skip_item tool with handler association
-		$tools['skip_item'] = self::getSkipItemToolDefinition( $handler_slug, $handler_config );
-
-		return $tools;
+	public static function resolveSkipItemTool(
+		string $handler_slug,
+		array $handler_config,
+		array $engine_data
+	): array {
+		unset( $engine_data );
+		return array(
+			'skip_item' => self::getSkipItemToolDefinition( $handler_slug, $handler_config ),
+		);
 	}
 
 	/**

--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -430,7 +430,7 @@ abstract class FetchHandler {
 				$tools['__handler_tools_skip_item'] = array(
 					'_handler_callable' => array( self::class, 'resolveSkipItemTool' ),
 					'handler_types'     => array( 'fetch', 'event_import' ),
-					'contexts'          => array( 'pipeline' ),
+					'modes'             => array( 'pipeline' ),
 					'access_level'      => 'admin',
 				);
 				return $tools;

--- a/inc/Core/Steps/HandlerRegistrationTrait.php
+++ b/inc/Core/Steps/HandlerRegistrationTrait.php
@@ -30,7 +30,11 @@ trait HandlerRegistrationTrait {
 	 * @param bool $requiresAuth Whether handler requires authentication
 	 * @param string|null $authClass Authentication class name
 	 * @param string|null $settingsClass Settings class name
-	 * @param callable|null $aiToolCallback AI tool registration callback
+	 * @param callable|null $aiToolCallback AI tool registration callback. Receives
+	 *                                      `(string $handler_slug, array $handler_config, array $engine_data)`
+	 *                                      and returns an `['tool_name' => $tool_definition]` array
+	 *                                      (empty array to opt out). Resolved lazily from the unified
+	 *                                      `datamachine_tools` registry at pipeline execution time.
 	 * @param string|null $authProviderKey Optional custom auth provider key for shared authentication
 	 * @param array $meta Optional arbitrary metadata (e.g. charLimit, maxImages). Passed through to /handlers API.
 	 */
@@ -92,9 +96,28 @@ trait HandlerRegistrationTrait {
 			}, 10, 2);
 		}
 
-		// AI tools registration (4 params: tools, handler_slug, handler_config, engine_data)
+		// AI tools registration — resolved lazily from the unified
+		// datamachine_tools registry at pipeline execution time. The callback
+		// returns [tool_name => definition] shaped by the runtime handler
+		// config and engine data of the adjacent pipeline step.
 		if ( $aiToolCallback ) {
-			add_filter('chubes_ai_tools', $aiToolCallback, 10, 4);
+			add_filter(
+				'datamachine_tools',
+				function ( array $tools ) use ( $slug, $aiToolCallback ): array {
+					// Wrapper entry keyed uniquely per handler slug.
+					// ToolPolicyResolver::gatherPipelineTools detects
+					// `_handler_callable` entries and invokes them with
+					// runtime handler context; this registry entry is
+					// intentionally NOT a directly usable tool definition.
+					$tools[ '__handler_tools_' . $slug ] = array(
+						'_handler_callable' => $aiToolCallback,
+						'handler'           => $slug,
+						'contexts'          => array( 'pipeline' ),
+						'access_level'      => 'admin',
+					);
+					return $tools;
+				}
+			);
 		}
 
 		// Fire action for cache invalidation

--- a/inc/Core/Steps/HandlerRegistrationTrait.php
+++ b/inc/Core/Steps/HandlerRegistrationTrait.php
@@ -112,7 +112,7 @@ trait HandlerRegistrationTrait {
 					$tools[ '__handler_tools_' . $slug ] = array(
 						'_handler_callable' => $aiToolCallback,
 						'handler'           => $slug,
-						'contexts'          => array( 'pipeline' ),
+						'modes'             => array( 'pipeline' ),
 						'access_level'      => 'admin',
 					);
 					return $tools;

--- a/inc/Engine/AI/Directives/AgentDailyMemoryDirective.php
+++ b/inc/Engine/AI/Directives/AgentDailyMemoryDirective.php
@@ -179,7 +179,7 @@ add_filter(
 		$directives[] = array(
 			'class'    => AgentDailyMemoryDirective::class,
 			'priority' => 35,
-			'contexts' => array( 'chat', 'pipeline' ),
+			'modes'    => array( 'chat', 'pipeline' ),
 		);
 		return $directives;
 	}

--- a/inc/Engine/AI/Directives/AgentModeDirective.php
+++ b/inc/Engine/AI/Directives/AgentModeDirective.php
@@ -202,7 +202,7 @@ add_filter(
 		$directives[] = array(
 			'class'    => AgentModeDirective::class,
 			'priority' => 22,
-			'contexts' => array( 'all' ),
+			'modes'    => array( 'all' ),
 		);
 		return $directives;
 	}

--- a/inc/Engine/AI/Directives/ClientContextDirective.php
+++ b/inc/Engine/AI/Directives/ClientContextDirective.php
@@ -164,7 +164,7 @@ add_filter(
 		$directives[] = array(
 			'class'    => ClientContextDirective::class,
 			'priority' => 35,
-			'contexts' => array( 'all' ),
+			'modes'    => array( 'all' ),
 		);
 		return $directives;
 	}

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -54,24 +54,28 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 		// Auto-scaffold missing user-layer files (e.g. USER.md) on first chat.
 		$scaffold_ability = \DataMachine\Abilities\File\ScaffoldAbilities::get_ability();
 		if ( $user_id > 0 && $scaffold_ability ) {
-			$scaffold_ability->execute( array(
-				'layer'   => MemoryFileRegistry::LAYER_USER,
-				'user_id' => $user_id,
-			) );
+			$scaffold_ability->execute(
+				array(
+					'layer'   => MemoryFileRegistry::LAYER_USER,
+					'user_id' => $user_id,
+				)
+			);
 		}
 
 		$outputs = array();
 
-		// Load registered files applicable to the current execution mode,
+		// Load registered files applicable to the current agent mode,
 		// filtered through the per-agent MemoryPolicy.
-		$context       = $payload['agent_mode'] ?? '';
-		$resolver      = new MemoryPolicyResolver();
-		$context_files = $resolver->resolveRegistered( array(
-			'context'  => $context,
-			'agent_id' => $agent_id,
-		) );
+		$mode       = $payload['agent_mode'] ?? '';
+		$resolver   = new MemoryPolicyResolver();
+		$mode_files = $resolver->resolveRegistered(
+			array(
+				'mode'     => $mode,
+				'agent_id' => $agent_id,
+			)
+		);
 
-		foreach ( $context_files as $filename => $meta ) {
+		foreach ( $mode_files as $filename => $meta ) {
 			$layer  = $meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
 			$memory = new AgentMemory( $user_id, $agent_id, $filename, $layer );
 			$read   = $memory->read();
@@ -169,7 +173,7 @@ add_filter(
 		$directives[] = array(
 			'class'    => CoreMemoryFilesDirective::class,
 			'priority' => 20,
-			'contexts' => array( 'all' ),
+			'modes'    => array( 'all' ),
 		);
 		return $directives;
 	}

--- a/inc/Engine/AI/Memory/MemoryPolicyResolver.php
+++ b/inc/Engine/AI/Memory/MemoryPolicyResolver.php
@@ -17,7 +17,7 @@
  * 2. Per-agent policy deny list (from agent_config.memory_policy)
  * 3. Per-agent policy allow-only (narrows to subset)
  * 4. Context-level allow_only (narrows to subset)
- * 5. Context preset (registry's get_for_context)
+ * 5. Mode preset (registry's get_for_mode)
  *
  * @package DataMachine\Engine\AI\Memory
  * @since   0.67.0
@@ -33,38 +33,38 @@ defined( 'ABSPATH' ) || exit;
 class MemoryPolicyResolver {
 
 	/**
-	 * Context presets, aligned with ToolPolicyResolver for consistency.
+	 * Agent mode presets, aligned with ToolPolicyResolver for consistency.
 	 */
-	public const CONTEXT_PIPELINE = 'pipeline';
-	public const CONTEXT_CHAT     = 'chat';
-	public const CONTEXT_SYSTEM   = 'system';
+	public const MODE_PIPELINE = 'pipeline';
+	public const MODE_CHAT     = 'chat';
+	public const MODE_SYSTEM   = 'system';
 
 	/**
-	 * Resolve the set of registered memory files applicable to a context
+	 * Resolve the set of registered memory files applicable to a mode
 	 * after agent policy is applied.
 	 *
 	 * Used by CoreMemoryFilesDirective to replace its direct
-	 * MemoryFileRegistry::get_for_context() call. The registry remains
+	 * MemoryFileRegistry::get_for_mode() call. The registry remains
 	 * the source of truth for which files exist and where they live;
 	 * this method is a per-agent filter on top.
 	 *
-	 * @param array $context {
-	 *     Execution context describing the request.
+	 * @param array $args {
+	 *     Resolution arguments describing the request.
 	 *
-	 *     @type string   $context    Required. Execution context slug (e.g. 'chat', 'pipeline').
+	 *     @type string   $mode       Required. Agent mode slug (e.g. 'chat', 'pipeline').
 	 *     @type int|null $agent_id   Optional agent ID for per-agent policy filtering.
 	 *     @type array    $deny       Filenames to explicitly deny (highest precedence).
-	 *     @type array    $allow_only Context-level allowlist narrowing.
+	 *     @type array    $allow_only Mode-level allowlist narrowing.
 	 * }
 	 * @return array<string, array> Filename => metadata map, sorted by priority ascending.
 	 */
-	public function resolveRegistered( array $context ): array {
-		$context_type = $context['context'] ?? '';
-		$agent_id     = isset( $context['agent_id'] ) ? (int) $context['agent_id'] : 0;
+	public function resolveRegistered( array $args ): array {
+		$mode     = $args['mode'] ?? '';
+		$agent_id = isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0;
 
-		// 1. Start with registry output filtered by context (already priority-sorted).
-		$files = ! empty( $context_type )
-			? MemoryFileRegistry::get_for_context( $context_type )
+		// 1. Start with registry output filtered by mode (already priority-sorted).
+		$files = ! empty( $mode )
+			? MemoryFileRegistry::get_for_mode( $mode )
 			: MemoryFileRegistry::get_all();
 
 		// 2. Apply per-agent policy.
@@ -73,20 +73,20 @@ class MemoryPolicyResolver {
 			$files  = $this->applyAgentPolicyToRegistered( $files, $policy );
 		}
 
-		// 3. Context-level allow_only (narrows to explicit subset).
-		$allow_only = $context['allow_only'] ?? array();
+		// 3. Mode-level allow_only (narrows to explicit subset).
+		$allow_only = $args['allow_only'] ?? array();
 		if ( ! empty( $allow_only ) ) {
 			$files = array_intersect_key( $files, array_flip( array_map( 'sanitize_file_name', $allow_only ) ) );
 		}
 
 		// 4. Explicit deny list (always wins).
-		$deny = $context['deny'] ?? array();
+		$deny = $args['deny'] ?? array();
 		if ( ! empty( $deny ) ) {
 			$files = array_diff_key( $files, array_flip( array_map( 'sanitize_file_name', $deny ) ) );
 		}
 
 		// 5. Allow external filtering of the resolved registered set.
-		$files = apply_filters( 'datamachine_resolved_memory_files', $files, $context_type, $context );
+		$files = apply_filters( 'datamachine_resolved_memory_files', $files, $mode, $args );
 
 		return $files;
 	}
@@ -129,12 +129,14 @@ class MemoryPolicyResolver {
 		$deny = $context['deny'] ?? array();
 		if ( ! empty( $deny ) ) {
 			$deny_set  = array_flip( array_map( 'sanitize_file_name', $deny ) );
-			$filenames = array_values( array_filter(
-				$filenames,
-				function ( $name ) use ( $deny_set ) {
-					return ! isset( $deny_set[ $name ] );
-				}
-			) );
+			$filenames = array_values(
+				array_filter(
+					$filenames,
+					function ( $name ) use ( $deny_set ) {
+						return ! isset( $deny_set[ $name ] );
+					}
+				)
+			);
 		}
 
 		/**
@@ -269,12 +271,14 @@ class MemoryPolicyResolver {
 				return $filenames;
 			}
 			$deny_set = array_flip( $policy['deny'] );
-			return array_values( array_filter(
-				$filenames,
-				function ( $name ) use ( $deny_set ) {
-					return ! isset( $deny_set[ $name ] );
-				}
-			) );
+			return array_values(
+				array_filter(
+					$filenames,
+					function ( $name ) use ( $deny_set ) {
+						return ! isset( $deny_set[ $name ] );
+					}
+				)
+			);
 		}
 
 		if ( 'allow_only' === $mode ) {
@@ -282,27 +286,29 @@ class MemoryPolicyResolver {
 				return array();
 			}
 			$allow_set = array_flip( $policy['allow_only'] );
-			return array_values( array_filter(
-				$filenames,
-				function ( $name ) use ( $allow_set ) {
-					return isset( $allow_set[ $name ] );
-				}
-			) );
+			return array_values(
+				array_filter(
+					$filenames,
+					function ( $name ) use ( $allow_set ) {
+						return isset( $allow_set[ $name ] );
+					}
+				)
+			);
 		}
 
 		return $filenames;
 	}
 
 	/**
-	 * Get available context presets.
+	 * Get available agent mode presets.
 	 *
-	 * @return array<string, string> Context key => description.
+	 * @return array<string, string> Mode slug => description.
 	 */
-	public static function getContexts(): array {
+	public static function getModes(): array {
 		return array(
-			self::CONTEXT_PIPELINE => 'Pipeline step AI execution',
-			self::CONTEXT_CHAT     => 'Admin chat session',
-			self::CONTEXT_SYSTEM   => 'System task execution',
+			self::MODE_PIPELINE => 'Pipeline step AI execution',
+			self::MODE_CHAT     => 'Admin chat session',
+			self::MODE_SYSTEM   => 'System task execution',
 		);
 	}
 }

--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -36,7 +36,7 @@ class MemoryFileRegistry {
 	/**
 	 * Special context value meaning "inject in all contexts."
 	 */
-	const CONTEXT_ALL = 'all';
+	const MODE_ALL = 'all';
 
 	/**
 	 * Registered memory files.
@@ -59,10 +59,10 @@ class MemoryFileRegistry {
 	 * @since 0.50.0 Added `editable` argument for write-permission gating.
 	 * @since 0.60.0 Added `contexts` argument for context-aware injection.
 	 *
-	 * @param string    $filename Filename (e.g. 'SOUL.md', 'brand-guidelines.md').
-	 * @param int       $priority Sort order. Lower numbers load first.
-	 * @param array     $args     {
-	 *     Optional. Registration arguments.
+	 * @param string $filename Filename (e.g. 'SOUL.md', 'brand-guidelines.md').
+	 * @param int    $priority Sort order. Lower numbers load first.
+	 * @param array  $args     {
+	 *  Optional. Registration arguments.
 	 *
 	 *     @type string      $layer           One of 'shared', 'agent', 'user', 'network'. Default 'agent'.
 	 *     @type bool        $protected       Whether the file is protected from deletion. Default false.
@@ -108,9 +108,9 @@ class MemoryFileRegistry {
 		}
 
 		// Normalize modes: array of slugs, or ['all'] (default).
-		$modes = $args['modes'] ?? array( self::CONTEXT_ALL );
+		$modes = $args['modes'] ?? array( self::MODE_ALL );
 		if ( ! is_array( $modes ) || empty( $modes ) ) {
-			$modes = array( self::CONTEXT_ALL );
+			$modes = array( self::MODE_ALL );
 		}
 		$modes = array_values( array_unique( array_map( 'sanitize_key', $modes ) ) );
 
@@ -352,7 +352,7 @@ class MemoryFileRegistry {
 	}
 
 	/**
-	 * Get all files applicable to a specific execution mode.
+	 * Get all files applicable to a specific agent mode.
 	 *
 	 * Returns files that either list the mode in their `modes` array
 	 * or are registered with `['all']` (the default).
@@ -360,48 +360,48 @@ class MemoryFileRegistry {
 	 * @since 0.60.0
 	 * @since 0.68.0 Internal key renamed from contexts to modes.
 	 *
-	 * @param string $context Execution mode slug (e.g. 'chat', 'pipeline', 'system', 'editor').
+	 * @param string $mode Agent mode slug (e.g. 'chat', 'pipeline', 'system', 'editor').
 	 * @return array<string, array> Filtered and sorted file metadata.
 	 */
-	public static function get_for_context( string $context ): array {
-		$context = sanitize_key( $context );
+	public static function get_for_mode( string $mode ): array {
+		$mode = sanitize_key( $mode );
 
-		if ( empty( $context ) ) {
+		if ( empty( $mode ) ) {
 			return self::get_resolved();
 		}
 
 		return array_filter(
 			self::get_resolved(),
-			function ( $meta ) use ( $context ) {
-				$modes = $meta['modes'] ?? array( self::CONTEXT_ALL );
-				return in_array( self::CONTEXT_ALL, $modes, true )
-					|| in_array( $context, $modes, true );
+			function ( $meta ) use ( $mode ) {
+				$modes = $meta['modes'] ?? array( self::MODE_ALL );
+				return in_array( self::MODE_ALL, $modes, true )
+					|| in_array( $mode, $modes, true );
 			}
 		);
 	}
 
 	/**
-	 * Check if a file applies to a specific execution mode.
+	 * Check if a file applies to a specific agent mode.
 	 *
 	 * @since 0.60.0
 	 * @since 0.68.0 Internal key renamed from contexts to modes.
 	 *
 	 * @param string $filename Filename to check.
-	 * @param string $context  Execution mode slug.
+	 * @param string $mode     Agent mode slug.
 	 * @return bool True if the file should be injected in this mode.
 	 */
-	public static function applies_to_context( string $filename, string $context ): bool {
+	public static function applies_to_mode( string $filename, string $mode ): bool {
 		$resolved = self::get_resolved();
 		$filename = sanitize_file_name( $filename );
-		$context  = sanitize_key( $context );
+		$mode     = sanitize_key( $mode );
 
 		if ( ! isset( $resolved[ $filename ] ) ) {
 			return true; // Unregistered files are included everywhere.
 		}
 
-		$modes = $resolved[ $filename ]['modes'] ?? array( self::CONTEXT_ALL );
-		return in_array( self::CONTEXT_ALL, $modes, true )
-			|| in_array( $context, $modes, true );
+		$modes = $resolved[ $filename ]['modes'] ?? array( self::MODE_ALL );
+		return in_array( self::MODE_ALL, $modes, true )
+			|| in_array( $mode, $modes, true );
 	}
 
 	/**
@@ -416,7 +416,7 @@ class MemoryFileRegistry {
 	public static function get_modes( string $filename ): ?array {
 		$resolved = self::get_resolved();
 		$filename = sanitize_file_name( $filename );
-		return isset( $resolved[ $filename ] ) ? ( $resolved[ $filename ]['modes'] ?? array( self::CONTEXT_ALL ) ) : null;
+		return isset( $resolved[ $filename ] ) ? ( $resolved[ $filename ]['modes'] ?? array( self::MODE_ALL ) ) : null;
 	}
 
 	/**

--- a/inc/Engine/AI/PromptBuilder.php
+++ b/inc/Engine/AI/PromptBuilder.php
@@ -73,14 +73,14 @@ class PromptBuilder {
 	 *
 	 * @param string|object $directive Directive class name or instance
 	 * @param int           $priority Priority for ordering (lower = applied first)
-	 * @param array         $contexts Contexts this directive applies to ('all' for global)
+	 * @param array         $modes    Agent modes this directive applies to ('all' for global)
 	 * @return self
 	 */
-	public function addDirective( $directive, int $priority, array $contexts = array( 'all' ) ): self {
+	public function addDirective( $directive, int $priority, array $modes = array( 'all' ) ): self {
 		$this->directives[] = array(
 			'directive' => $directive,
 			'priority'  => $priority,
-			'contexts'  => $contexts,
+			'modes'     => $modes,
 		);
 		return $this;
 	}
@@ -88,12 +88,12 @@ class PromptBuilder {
 	/**
 	 * Build the final AI request with directives applied
 	 *
-	 * @param string $context Execution context ('pipeline', 'chat', etc.)
+	 * @param string $mode     Agent mode ('pipeline', 'chat', etc.)
 	 * @param string $provider AI provider name
-	 * @param array  $payload Request payload
+	 * @param array  $payload  Request payload
 	 * @return array Request array with 'messages', 'tools', and 'applied_directives' metadata
 	 */
-	public function build( string $context, string $provider, array $payload = array() ): array {
+	public function build( string $mode, string $provider, array $payload = array() ): array {
 		usort(
 			$this->directives,
 			function ( $a, $b ) {
@@ -101,9 +101,9 @@ class PromptBuilder {
 			}
 		);
 
-		// Ensure directives can access the current execution mode.
+		// Ensure directives can access the current agent mode.
 		if ( ! isset( $payload['agent_mode'] ) ) {
-			$payload['agent_mode'] = $context;
+			$payload['agent_mode'] = $mode;
 		}
 
 		$conversation_messages = $this->messages;
@@ -112,9 +112,9 @@ class PromptBuilder {
 
 		foreach ( $this->directives as $directiveConfig ) {
 			$directive = $directiveConfig['directive'];
-			$contexts  = $directiveConfig['contexts'];
+			$modes     = $directiveConfig['modes'];
 
-			if ( ! in_array( 'all', $contexts, true ) && ! in_array( $context, $contexts, true ) ) {
+			if ( ! in_array( 'all', $modes, true ) && ! in_array( $mode, $modes, true ) ) {
 				continue;
 			}
 

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -2,7 +2,7 @@
 /**
  * AI Request Builder - Centralized AI request construction for all agents
  *
-	 * Single source of truth for building standardized AI requests across chat and pipeline contexts.
+ * Single source of truth for building standardized AI requests across chat and pipeline contexts.
  * Ensures consistent request structure, tool formatting, and directive application to prevent
  * architectural drift between different AI agent types.
  *
@@ -61,7 +61,7 @@ class RequestBuilder {
 			$promptBuilder->addDirective(
 				$directive['class'],
 				$directive['priority'],
-				$directive['contexts'] ?? array( 'all' )
+				$directive['modes'] ?? array( 'all' )
 			);
 		}
 

--- a/inc/Engine/AI/Tools/BaseTool.php
+++ b/inc/Engine/AI/Tools/BaseTool.php
@@ -26,7 +26,7 @@ abstract class BaseTool {
 	 * Register a tool with the unified tool registry.
 	 *
 	 * All tools register via the single `datamachine_tools` filter. Each tool
-	 * must declare its contexts — the surfaces where it's available (e.g.
+	 * must declare its modes — the agent modes where it's available (e.g.
 	 * 'chat', 'pipeline').
 	 *
 	 * Tools should also declare which ability they wrap via the `ability` key
@@ -34,9 +34,9 @@ abstract class BaseTool {
 	 * check the ability's permission_callback before offering the tool to AI agents.
 	 * Tools without an ability declaration default to admin-only access.
 	 *
-	 * When the definition is a callable (for lazy evaluation), the contexts
+	 * When the definition is a callable (for lazy evaluation), the modes
 	 * are stored alongside so they're available before the callable is resolved.
-	 * The ToolManager merges contexts into the resolved definition.
+	 * The ToolManager merges modes into the resolved definition.
 	 *
 	 * IMPORTANT: Pass a callable (e.g., [$this, 'getToolDefinition']) instead of
 	 * calling the method directly. This enables lazy evaluation after translations
@@ -47,7 +47,7 @@ abstract class BaseTool {
 	 *
 	 * @param string         $toolName       Tool identifier.
 	 * @param array|callable $toolDefinition Tool definition array OR callable that returns it.
-	 * @param array          $contexts       Contexts where this tool is available (e.g. ['chat', 'pipeline']).
+	 * @param array          $modes          Agent modes where this tool is available (e.g. ['chat', 'pipeline']).
 	 * @param array          $meta           Optional metadata for permission resolution. {
 	 *     @type string   $ability      Single ability slug this tool wraps (e.g. 'datamachine/local-search').
 	 *     @type string[] $abilities    Multiple ability slugs for composed tools. ALL must pass permission check.
@@ -55,20 +55,20 @@ abstract class BaseTool {
 	 *                                  One of: 'public', 'authenticated', 'author', 'editor', 'admin'. Default: 'admin'.
 	 * }
 	 */
-	protected function registerTool( string $toolName, array|callable $toolDefinition, array $contexts = array(), array $meta = array() ): void {
+	protected function registerTool( string $toolName, array|callable $toolDefinition, array $modes = array(), array $meta = array() ): void {
 		add_filter(
 			'datamachine_tools',
-			function ( $tools ) use ( $toolName, $toolDefinition, $contexts, $meta ) {
+			function ( $tools ) use ( $toolName, $toolDefinition, $modes, $meta ) {
 				if ( is_callable( $toolDefinition ) ) {
-					// Wrap callable with contexts for pre-resolution filtering.
+					// Wrap callable with modes for pre-resolution filtering.
 					$tools[ $toolName ] = array(
 						'_callable' => $toolDefinition,
-						'contexts'  => $contexts,
+						'modes'     => $modes,
 					);
 				} else {
-					// Array definition — merge contexts directly.
-					$toolDefinition['contexts'] = $contexts;
-					$tools[ $toolName ]         = $toolDefinition;
+					// Array definition — merge modes directly.
+					$toolDefinition['modes'] = $modes;
+					$tools[ $toolName ]      = $toolDefinition;
 				}
 
 				// Merge permission metadata into the tool entry.

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -13,7 +13,7 @@ namespace DataMachine\Engine\AI\Tools;
 
 use DataMachine\Core\WordPress\PostTracking;
 
-defined('ABSPATH') || exit;
+defined( 'ABSPATH' ) || exit;
 
 class ToolExecutor {
 
@@ -21,7 +21,7 @@ class ToolExecutor {
 	/**
 	 * Get available tools for AI agent execution.
 	 *
-	 * @deprecated 0.39.0 Use ToolPolicyResolver::resolve() with CONTEXT_PIPELINE instead.
+	 * @deprecated 0.39.0 Use ToolPolicyResolver::resolve() with MODE_PIPELINE instead.
 	 *             Delegates to ToolPolicyResolver internally.
 	 *
 	 * @param  array|null  $previous_step_config     Previous step configuration (pipeline only)
@@ -33,13 +33,15 @@ class ToolExecutor {
 	public static function getAvailableTools( ?array $previous_step_config = null, ?array $next_step_config = null, ?string $current_pipeline_step_id = null, array $engine_data = array() ): array {
 		$resolver = new ToolPolicyResolver();
 
-		return $resolver->resolve( array(
-			'context'              => ToolPolicyResolver::CONTEXT_PIPELINE,
-			'previous_step_config' => $previous_step_config,
-			'next_step_config'     => $next_step_config,
-			'pipeline_step_id'     => $current_pipeline_step_id,
-			'engine_data'          => $engine_data,
-		) );
+		return $resolver->resolve(
+			array(
+				'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+				'previous_step_config' => $previous_step_config,
+				'next_step_config'     => $next_step_config,
+				'pipeline_step_id'     => $current_pipeline_step_id,
+				'engine_data'          => $engine_data,
+			)
+		);
 	}
 
 	/**
@@ -62,14 +64,14 @@ class ToolExecutor {
 			);
 		}
 
-		$validation = self::validateRequiredParameters($tool_parameters, $tool_def);
+		$validation = self::validateRequiredParameters( $tool_parameters, $tool_def );
 		if ( ! $validation['valid'] ) {
 			return array(
 				'success'   => false,
 				'error'     => sprintf(
 					'%s requires the following parameters: %s. Please provide these parameters and try again.',
-					ucwords(str_replace('_', ' ', $tool_name)),
-					implode(', ', $validation['missing'])
+					ucwords( str_replace( '_', ' ', $tool_name ) ),
+					implode( ', ', $validation['missing'] )
 				),
 				'tool_name' => $tool_name,
 			);
@@ -82,7 +84,7 @@ class ToolExecutor {
 		);
 
 		// Ensure tool definition has required 'class' key
-		if ( ! isset($tool_def['class']) || empty($tool_def['class']) ) {
+		if ( ! isset( $tool_def['class'] ) || empty( $tool_def['class'] ) ) {
 			return array(
 				'success'   => false,
 				'error'     => "Tool '{$tool_name}' is missing required 'class' definition. This may indicate the tool was not properly resolved from a callable.",
@@ -91,7 +93,7 @@ class ToolExecutor {
 		}
 
 		$class_name = $tool_def['class'];
-		if ( ! class_exists($class_name) ) {
+		if ( ! class_exists( $class_name ) ) {
 			return array(
 				'success'   => false,
 				'error'     => "Tool class '{$class_name}' not found",
@@ -100,7 +102,7 @@ class ToolExecutor {
 		}
 
 		$method = $tool_def['method'] ?? null;
-		if ( ! $method || ! method_exists($class_name, $method) ) {
+		if ( ! $method || ! method_exists( $class_name, $method ) ) {
 			return array(
 				'success'   => false,
 				'error'     => sprintf(
@@ -114,7 +116,7 @@ class ToolExecutor {
 		}
 
 		$tool_handler = new $class_name();
-		$tool_result  = $tool_handler->$method($complete_parameters, $tool_def);
+		$tool_result  = $tool_handler->$method( $complete_parameters, $tool_def );
 
 		// Automatic post origin tracking — applies to every tool whose result
 		// contains an extractable post_id. This covers both handler tools
@@ -149,21 +151,21 @@ class ToolExecutor {
 		$param_defs = $tool_def['parameters'] ?? array();
 
 		foreach ( $param_defs as $param_name => $param_config ) {
-			if ( ! is_array($param_config) ) {
+			if ( ! is_array( $param_config ) ) {
 				continue;
 			}
 
-			if ( ! empty($param_config['required']) ) {
+			if ( ! empty( $param_config['required'] ) ) {
 				$required[] = $param_name;
 
-				if ( ! isset($tool_parameters[ $param_name ]) || '' === $tool_parameters[ $param_name ] ) {
+				if ( ! isset( $tool_parameters[ $param_name ] ) || '' === $tool_parameters[ $param_name ] ) {
 					$missing[] = $param_name;
 				}
 			}
 		}
 
 		return array(
-			'valid'    => empty($missing),
+			'valid'    => empty( $missing ),
 			'required' => $required,
 			'missing'  => $missing,
 		);

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -199,6 +199,152 @@ class ToolManager {
 	}
 
 	/**
+	 * Resolve handler tools for a specific adjacent-step handler.
+	 *
+	 * Iterates the unified `datamachine_tools` registry and resolves every
+	 * entry whose `_handler_callable` matches the given handler slug. Two
+	 * matching modes are supported:
+	 *
+	 * - **Exact slug**: `['handler' => 'wordpress_publish']` — the entry only
+	 *   applies when the adjacent step's handler_slug equals `'wordpress_publish'`.
+	 * - **Type match**: `['handler_types' => ['fetch', 'event_import']]` — the
+	 *   entry applies to any handler whose registered type is in the list
+	 *   (used by cross-cutting tools like `skip_item`).
+	 *
+	 * Callbacks receive `(handler_slug, handler_config, engine_data)` and
+	 * return an `['tool_name' => $tool_definition]` array (empty to opt out).
+	 * Multiple tools per handler are allowed.
+	 *
+	 * Results are cached per `flow_step_id|handler_slug` scope so repeated
+	 * lookups within the same pipeline execution don't re-invoke callbacks.
+	 *
+	 * @since NEXT
+	 *
+	 * @param string $handler_slug   Adjacent step handler slug.
+	 * @param array  $handler_config Handler configuration from flow step.
+	 * @param array  $engine_data    Engine data snapshot for dynamic generation.
+	 * @param string $cache_scope    Scope key (e.g. flow_step_id + handler_slug).
+	 * @return array Resolved tools keyed by tool name.
+	 */
+	public function resolveHandlerTools(
+		string $handler_slug,
+		array $handler_config,
+		array $engine_data,
+		string $cache_scope = ''
+	): array {
+		$cache_key = $cache_scope . '|handler_tools|' . $handler_slug;
+
+		if ( '' !== $cache_scope && isset( self::$resolved_cache[ $cache_key ] ) ) {
+			return self::$resolved_cache[ $cache_key ];
+		}
+
+		$raw_tools        = $this->get_raw_tools();
+		$resolved         = array();
+		$handlers_by_slug = null; // Lazy-loaded only when handler_types matching is needed.
+
+		foreach ( $raw_tools as $definition ) {
+			if ( ! is_array( $definition ) ) {
+				continue;
+			}
+			if ( ! isset( $definition['_handler_callable'] ) || ! is_callable( $definition['_handler_callable'] ) ) {
+				continue;
+			}
+
+			$matches = false;
+
+			// Exact-slug match.
+			if ( isset( $definition['handler'] ) && $definition['handler'] === $handler_slug ) {
+				$matches = true;
+			}
+
+			// Handler-type match (cross-cutting tools).
+			if ( ! $matches && ! empty( $definition['handler_types'] ) && is_array( $definition['handler_types'] ) ) {
+				if ( null === $handlers_by_slug ) {
+					$handlers_by_slug = apply_filters( 'datamachine_handlers', array() );
+				}
+				$handler_meta = $handlers_by_slug[ $handler_slug ] ?? null;
+				$handler_type = $handler_meta['type'] ?? '';
+				if ( $handler_type && in_array( $handler_type, $definition['handler_types'], true ) ) {
+					$matches = true;
+				}
+			}
+
+			if ( ! $matches ) {
+				continue;
+			}
+
+			$tool_map = call_user_func(
+				$definition['_handler_callable'],
+				$handler_slug,
+				$handler_config,
+				$engine_data
+			);
+
+			if ( ! is_array( $tool_map ) ) {
+				continue;
+			}
+
+			$access_level = $definition['access_level'] ?? 'admin';
+			$ability      = $definition['ability'] ?? null;
+
+			foreach ( $tool_map as $tool_name => $tool_def ) {
+				if ( ! is_string( $tool_name ) || '' === $tool_name || ! is_array( $tool_def ) ) {
+					continue;
+				}
+
+				// Ensure a handler link is set so downstream filters (handler
+				// context, permission resolution) know which handler owns
+				// the tool.
+				if ( ! isset( $tool_def['handler'] ) ) {
+					$tool_def['handler'] = $handler_slug;
+				}
+
+				// Apply registry-level meta unless the resolved tool
+				// explicitly overrides.
+				if ( ! isset( $tool_def['contexts'] ) ) {
+					$tool_def['contexts'] = array( 'pipeline' );
+				}
+				if ( null !== $ability && ! isset( $tool_def['ability'] ) ) {
+					$tool_def['ability'] = $ability;
+				}
+				if ( ! isset( $tool_def['access_level'] ) && ! isset( $tool_def['ability'] ) ) {
+					$tool_def['access_level'] = $access_level;
+				}
+
+				$resolved[ $tool_name ] = $tool_def;
+			}
+		}
+
+		if ( '' !== $cache_scope ) {
+			self::$resolved_cache[ $cache_key ] = $resolved;
+		}
+
+		return $resolved;
+	}
+
+	/**
+	 * Get raw registry entries for handler tools.
+	 *
+	 * Returns unresolved entries from `datamachine_tools` that have a
+	 * `_handler_callable` key. Useful for admin UIs that need to enumerate
+	 * registered handler tools without invoking their callbacks.
+	 *
+	 * @since NEXT
+	 *
+	 * @return array Raw entries keyed by registry key.
+	 */
+	public function get_handler_tool_entries(): array {
+		$raw_tools = $this->get_raw_tools();
+
+		return array_filter(
+			$raw_tools,
+			function ( $definition ) {
+				return is_array( $definition ) && isset( $definition['_handler_callable'] );
+			}
+		);
+	}
+
+	/**
 	 * Get contexts for a tool from its raw (unresolved) definition.
 	 *
 	 * Extracts contexts without resolving callable definitions.
@@ -489,8 +635,10 @@ class ToolManager {
 	public function getAvailableToolsForChat(): array {
 		$resolver = new ToolPolicyResolver( $this );
 
-		return $resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		return $resolver->resolve(
+			array(
+				'context' => ToolPolicyResolver::CONTEXT_CHAT,
+			)
+		);
 	}
 }

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -90,12 +90,12 @@ class ToolManager {
 	 * and their results cached. Arrays are returned as-is.
 	 *
 	 * Supports the unified registry wrapper format where a callable is stored
-	 * as `['_callable' => callable, 'contexts' => [...]]`. The callable is
-	 * resolved and contexts are merged into the result.
+	 * as `['_callable' => callable, 'modes' => [...]]`. The callable is
+	 * resolved and modes are merged into the result.
 	 *
 	 * Cache keys are scoped: when a $cache_scope is provided, the key
 	 * becomes "$cache_scope|$tool_id" so that the same tool_id can hold
-	 * different definitions for different contexts (e.g. different flows
+	 * different definitions for different modes (e.g. different flows
 	 * configure upsert_event with different taxonomy selections).
 	 *
 	 * @param string $tool_id     Tool identifier.
@@ -125,10 +125,10 @@ class ToolManager {
 			);
 		}
 
-		// Handle unified registry wrapper: ['_callable' becomes callable, 'contexts' becomes [...]]
-		$contexts = array();
+		// Handle unified registry wrapper: ['_callable' becomes callable, 'modes' becomes [...]]
+		$modes = array();
 		if ( is_array( $definition ) && isset( $definition['_callable'] ) ) {
-			$contexts   = $definition['contexts'] ?? array();
+			$modes      = $definition['modes'] ?? array();
 			$definition = $definition['_callable'];
 		}
 
@@ -142,9 +142,9 @@ class ToolManager {
 		// Ensure result is an array
 		$resolved = is_array( $resolved ) ? $resolved : array();
 
-		// Merge contexts into resolved definition (registry contexts take precedence)
-		if ( ! empty( $contexts ) ) {
-			$resolved['contexts'] = $contexts;
+		// Merge modes into resolved definition (registry modes take precedence)
+		if ( ! empty( $modes ) ) {
+			$resolved['modes'] = $modes;
 		}
 
 		// Cache the resolved definition
@@ -190,7 +190,7 @@ class ToolManager {
 	 * Get all registered tools (raw, unresolved).
 	 *
 	 * Returns the raw registry including callables and wrapper arrays.
-	 * Useful when you need to check contexts without resolving all definitions.
+	 * Useful when you need to check modes without resolving all definitions.
 	 *
 	 * @return array Raw tools array.
 	 */
@@ -301,8 +301,8 @@ class ToolManager {
 
 				// Apply registry-level meta unless the resolved tool
 				// explicitly overrides.
-				if ( ! isset( $tool_def['contexts'] ) ) {
-					$tool_def['contexts'] = array( 'pipeline' );
+				if ( ! isset( $tool_def['modes'] ) ) {
+					$tool_def['modes'] = array( ToolPolicyResolver::MODE_PIPELINE );
 				}
 				if ( null !== $ability && ! isset( $tool_def['ability'] ) ) {
 					$tool_def['ability'] = $ability;
@@ -345,16 +345,16 @@ class ToolManager {
 	}
 
 	/**
-	 * Get contexts for a tool from its raw (unresolved) definition.
+	 * Get agent modes for a tool from its raw (unresolved) definition.
 	 *
-	 * Extracts contexts without resolving callable definitions.
+	 * Extracts modes without resolving callable definitions.
 	 *
 	 * @param mixed $definition Raw tool definition (array, callable, or wrapper).
-	 * @return array Contexts array.
+	 * @return array Modes array.
 	 */
-	public static function get_tool_contexts( mixed $definition ): array {
+	public static function get_tool_modes( mixed $definition ): array {
 		if ( is_array( $definition ) ) {
-			return $definition['contexts'] ?? array();
+			return $definition['modes'] ?? array();
 		}
 		return array();
 	}
@@ -593,15 +593,15 @@ class ToolManager {
 	/**
 	 * Get tools for REST API response.
 	 *
-	 * @param string|null $context Optional context to filter tools ('pipeline', 'chat', 'system').
-	 *                            When null, returns all tools.
+	 * @param string|null $mode Optional agent mode to filter tools ('pipeline', 'chat', 'system').
+	 *                          When null, returns all tools.
 	 * @return array Tools formatted for API
 	 */
-	public function get_tools_for_api( ?string $context = null ): array {
-		// If context specified, use ToolPolicyResolver to filter appropriately
-		if ( null !== $context ) {
+	public function get_tools_for_api( ?string $mode = null ): array {
+		// If mode specified, use ToolPolicyResolver to filter appropriately.
+		if ( null !== $mode ) {
 			$resolver = new ToolPolicyResolver( $this );
-			$tools    = $resolver->resolve( array( 'context' => $context ) );
+			$tools    = $resolver->resolve( array( 'mode' => $mode ) );
 		} else {
 			$tools = $this->get_global_tools();
 		}
@@ -617,7 +617,7 @@ class ToolManager {
 				'requires_config'  => $this->requires_configuration( $tool_id ),
 				'configured'       => $this->is_tool_configured( $tool_id ),
 				'globally_enabled' => $is_globally_enabled,
-				'contexts'         => $tool_config['contexts'] ?? array(),
+				'modes'            => $tool_config['modes'] ?? array(),
 			);
 		}
 
@@ -625,9 +625,9 @@ class ToolManager {
 	}
 
 	/**
-	 * Get all available tools for chat context.
+	 * Get all available tools for chat mode.
 	 *
-	 * @deprecated 0.39.0 Use ToolPolicyResolver::resolve() with CONTEXT_CHAT instead.
+	 * @deprecated 0.39.0 Use ToolPolicyResolver::resolve() with MODE_CHAT instead.
 	 *             Delegates to ToolPolicyResolver internally.
 	 *
 	 * @return array Available tools for chat agents
@@ -637,7 +637,7 @@ class ToolManager {
 
 		return $resolver->resolve(
 			array(
-				'context' => ToolPolicyResolver::CONTEXT_CHAT,
+				'mode' => ToolPolicyResolver::MODE_CHAT,
 			)
 		);
 	}

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -116,7 +116,7 @@ class ToolPolicyResolver {
 		$tools = $this->gatherByContext( $context_type, $context );
 
 		// 2. Filter by linked ability permissions (from Abilities API).
-		//    Only applies in chat context — pipeline/system run as admin.
+		// Only applies in chat context — pipeline/system run as admin.
 		if ( self::CONTEXT_CHAT === $context_type ) {
 			$tools = $this->filterByAbilityPermissions( $tools );
 		}
@@ -128,7 +128,7 @@ class ToolPolicyResolver {
 		}
 
 		// 4. Filter by ability categories (narrows to tools whose linked ability
-		//    belongs to one of the specified categories).
+		// belongs to one of the specified categories).
 		$categories = $context['categories'] ?? array();
 		if ( ! empty( $categories ) ) {
 			$tools = $this->filterByAbilityCategories( $tools, $categories );
@@ -290,13 +290,19 @@ class ToolPolicyResolver {
 
 	/**
 	 * Pipeline context: context-filtered tools + handler tools from adjacent steps.
+	 *
+	 * Handler tools are resolved from the unified `datamachine_tools` registry
+	 * via {@see ToolManager::resolveHandlerTools()}. Each adjacent step contributes
+	 * the handler tools owned by its handler_slug (exact match) plus any
+	 * cross-cutting tools registered against its handler type (e.g. `skip_item`
+	 * for fetch-type handlers).
 	 */
 	private function gatherPipelineTools( array $context ): array {
 		$available_tools  = array();
 		$pipeline_step_id = $context['pipeline_step_id'] ?? null;
 		$engine_data      = $context['engine_data'] ?? array();
 
-		// Handler tools from adjacent steps (dynamic, not part of the static registry).
+		// Handler tools from adjacent steps (dynamic, resolved per-execution).
 		foreach ( array( $context['previous_step_config'] ?? null, $context['next_step_config'] ?? null ) as $step_config ) {
 			if ( ! $step_config ) {
 				continue;
@@ -308,17 +314,15 @@ class ToolPolicyResolver {
 
 			foreach ( $handler_slugs as $slug ) {
 				$handler_config = $handler_configs_map[ $slug ] ?? array();
-				$tools          = apply_filters( 'chubes_ai_tools', array(), $slug, $handler_config, $engine_data );
-				$tools          = $this->tool_manager->resolveAllTools( $tools, $cache_scope );
+				$tools          = $this->tool_manager->resolveHandlerTools(
+					$slug,
+					$handler_config,
+					$engine_data,
+					$cache_scope
+				);
 
 				foreach ( $tools as $tool_name => $tool_config ) {
-					if ( ! is_array( $tool_config ) ) {
-						continue;
-					}
-					// Handler tools only included if they match the current handler.
-					if ( isset( $tool_config['handler'] ) && $tool_config['handler'] === $slug ) {
-						$available_tools[ $tool_name ] = $tool_config;
-					}
+					$available_tools[ $tool_name ] = $tool_config;
 				}
 			}
 		}
@@ -328,7 +332,14 @@ class ToolPolicyResolver {
 		$pipeline_tools = $this->filterByContext( $all_tools, 'pipeline' );
 
 		foreach ( $pipeline_tools as $tool_name => $tool_config ) {
-			if ( is_array( $tool_config ) && $this->tool_manager->is_tool_available( $tool_name, $pipeline_step_id ) ) {
+			if ( ! is_array( $tool_config ) ) {
+				continue;
+			}
+			// Skip handler tool registry wrappers — those are resolved above.
+			if ( isset( $tool_config['_handler_callable'] ) ) {
+				continue;
+			}
+			if ( $this->tool_manager->is_tool_available( $tool_name, $pipeline_step_id ) ) {
 				$available_tools[ $tool_name ] = $tool_config;
 			}
 		}

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -30,18 +30,11 @@ defined( 'ABSPATH' ) || exit;
 class ToolPolicyResolver {
 
 	/**
-	 * Context presets define which tool pools are available.
+	 * Agent mode presets define which tool pools are available.
 	 */
-	public const CONTEXT_PIPELINE = 'pipeline';
-	public const CONTEXT_CHAT     = 'chat';
-	public const CONTEXT_SYSTEM   = 'system';
-
-	/**
-	 * @deprecated Use CONTEXT_* constants instead.
-	 */
-	public const SURFACE_PIPELINE = self::CONTEXT_PIPELINE;
-	public const SURFACE_CHAT     = self::CONTEXT_CHAT;
-	public const SURFACE_SYSTEM   = self::CONTEXT_SYSTEM;
+	public const MODE_PIPELINE = 'pipeline';
+	public const MODE_CHAT     = 'chat';
+	public const MODE_SYSTEM   = 'system';
 
 	private ToolManager $tool_manager;
 
@@ -50,15 +43,14 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * Resolve available tools for a given execution context.
+	 * Resolve available tools for a given agent mode.
 	 *
 	 * This is the single entry point. All tool assembly should go through here.
 	 *
-	 * @param array $context {
-	 *     Execution context describing the request.
+	 * @param array $args {
+	 *     Resolution arguments describing the request.
 	 *
-	 *     @type string      $context              Required. One of the CONTEXT_* constants.
-	 *     @type string      $surface              Deprecated alias for $context.
+	 *     @type string      $mode                  Required. One of the MODE_* constants (or a custom mode slug).
 	 *     @type int|null    $agent_id              Agent ID for per-agent tool policy filtering.
 	 *     @type array|null  $previous_step_config  Pipeline only: previous step config with handler_slugs.
 	 *     @type array|null  $next_step_config      Pipeline only: next step config with handler_slugs.
@@ -86,11 +78,10 @@ class ToolPolicyResolver {
 		'admin'         => 'datamachine_manage_settings',
 	);
 
-	public function resolve( array $context ): array {
-		// Accept 'context' key, fall back to deprecated 'surface' key.
-		$context_type = $context['context'] ?? $context['surface'] ?? self::CONTEXT_PIPELINE;
-		$deny         = $context['deny'] ?? array();
-		$agent_id     = isset( $context['agent_id'] ) ? (int) $context['agent_id'] : 0;
+	public function resolve( array $args ): array {
+		$mode     = $args['mode'] ?? self::MODE_PIPELINE;
+		$deny     = $args['deny'] ?? array();
+		$agent_id = isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0;
 
 		// 0. Optional legacy baseline gate.
 		//
@@ -106,18 +97,18 @@ class ToolPolicyResolver {
 		//
 		// The legacy behavior is still available behind a filter for installs that
 		// want to preserve the coarse gate during migration.
-		$require_use_tools_for_chat = apply_filters( 'datamachine_require_use_tools_for_chat_tools', false, $context );
+		$require_use_tools_for_chat = apply_filters( 'datamachine_require_use_tools_for_chat_tools', false, $args );
 
-		if ( self::CONTEXT_CHAT === $context_type && $require_use_tools_for_chat && ! PermissionHelper::can( 'use_tools' ) ) {
+		if ( self::MODE_CHAT === $mode && $require_use_tools_for_chat && ! PermissionHelper::can( 'use_tools' ) ) {
 			return array();
 		}
 
-		// 1. Gather tools based on context preset.
-		$tools = $this->gatherByContext( $context_type, $context );
+		// 1. Gather tools based on mode preset.
+		$tools = $this->gatherByMode( $mode, $args );
 
 		// 2. Filter by linked ability permissions (from Abilities API).
-		// Only applies in chat context — pipeline/system run as admin.
-		if ( self::CONTEXT_CHAT === $context_type ) {
+		// Only applies in chat mode — pipeline/system run as admin.
+		if ( self::MODE_CHAT === $mode ) {
 			$tools = $this->filterByAbilityPermissions( $tools );
 		}
 
@@ -129,13 +120,13 @@ class ToolPolicyResolver {
 
 		// 4. Filter by ability categories (narrows to tools whose linked ability
 		// belongs to one of the specified categories).
-		$categories = $context['categories'] ?? array();
+		$categories = $args['categories'] ?? array();
 		if ( ! empty( $categories ) ) {
 			$tools = $this->filterByAbilityCategories( $tools, $categories );
 		}
 
 		// 5. Apply allowlist if specified (narrows to explicit subset).
-		$allow_only = $context['allow_only'] ?? array();
+		$allow_only = $args['allow_only'] ?? array();
 		if ( ! empty( $allow_only ) ) {
 			$tools = array_intersect_key( $tools, array_flip( $allow_only ) );
 		}
@@ -146,7 +137,7 @@ class ToolPolicyResolver {
 		}
 
 		// 7. Allow external filtering of resolved tools.
-		$tools = apply_filters( 'datamachine_resolved_tools', $tools, $context_type, $context );
+		$tools = apply_filters( 'datamachine_resolved_tools', $tools, $mode, $args );
 
 		return $tools;
 	}
@@ -254,42 +245,42 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * Gather tools by context preset.
+	 * Gather tools by mode preset.
 	 *
-	 * @param string $context_type Context preset string.
-	 * @param array  $context      Full execution context.
+	 * @param string $mode Agent mode slug.
+	 * @param array  $args Full resolution arguments.
 	 * @return array Tools array.
 	 */
-	private function gatherByContext( string $context_type, array $context ): array {
+	private function gatherByMode( string $mode, array $args ): array {
 		// Pipeline has special handling for adjacent step handler tools.
-		if ( self::CONTEXT_PIPELINE === $context_type ) {
-			return $this->gatherPipelineTools( $context );
+		if ( self::MODE_PIPELINE === $mode ) {
+			return $this->gatherPipelineTools( $args );
 		}
 
-		// All other contexts (chat, system, and any custom contexts) use
-		// the generic gatherer — filter tools by their declared contexts.
-		return $this->gatherToolsForContext( $context_type );
+		// All other modes (chat, system, and any custom modes) use the
+		// generic gatherer — filter tools by their declared modes.
+		return $this->gatherToolsForMode( $mode );
 	}
 
 	/**
-	 * Filter resolved tools by context.
+	 * Filter resolved tools by agent mode.
 	 *
-	 * @param array  $tools        Resolved tools array.
-	 * @param string $context_type Context string to filter by (e.g. 'chat', 'pipeline').
+	 * @param array  $tools Resolved tools array.
+	 * @param string $mode  Mode slug to filter by (e.g. 'chat', 'pipeline').
 	 * @return array Filtered tools.
 	 */
-	private function filterByContext( array $tools, string $context_type ): array {
+	private function filterByMode( array $tools, string $mode ): array {
 		return array_filter(
 			$tools,
-			function ( $tool ) use ( $context_type ) {
-				$contexts = $tool['contexts'] ?? array();
-				return in_array( $context_type, $contexts, true );
+			function ( $tool ) use ( $mode ) {
+				$modes = $tool['modes'] ?? array();
+				return in_array( $mode, $modes, true );
 			}
 		);
 	}
 
 	/**
-	 * Pipeline context: context-filtered tools + handler tools from adjacent steps.
+	 * Pipeline mode: mode-filtered tools + handler tools from adjacent steps.
 	 *
 	 * Handler tools are resolved from the unified `datamachine_tools` registry
 	 * via {@see ToolManager::resolveHandlerTools()}. Each adjacent step contributes
@@ -297,20 +288,20 @@ class ToolPolicyResolver {
 	 * cross-cutting tools registered against its handler type (e.g. `skip_item`
 	 * for fetch-type handlers).
 	 */
-	private function gatherPipelineTools( array $context ): array {
+	private function gatherPipelineTools( array $args ): array {
 		$available_tools  = array();
-		$pipeline_step_id = $context['pipeline_step_id'] ?? null;
-		$engine_data      = $context['engine_data'] ?? array();
+		$pipeline_step_id = $args['pipeline_step_id'] ?? null;
+		$engine_data      = $args['engine_data'] ?? array();
 
 		// Handler tools from adjacent steps (dynamic, resolved per-execution).
-		foreach ( array( $context['previous_step_config'] ?? null, $context['next_step_config'] ?? null ) as $step_config ) {
+		foreach ( array( $args['previous_step_config'] ?? null, $args['next_step_config'] ?? null ) as $step_config ) {
 			if ( ! $step_config ) {
 				continue;
 			}
 
 			$handler_slugs       = $step_config['handler_slugs'] ?? array();
 			$handler_configs_map = $step_config['handler_configs'] ?? array();
-			$cache_scope         = $step_config['flow_step_id'] ?? ( $context['cache_scope'] ?? '' );
+			$cache_scope         = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
 
 			foreach ( $handler_slugs as $slug ) {
 				$handler_config = $handler_configs_map[ $slug ] ?? array();
@@ -327,9 +318,9 @@ class ToolPolicyResolver {
 			}
 		}
 
-		// Static registry tools filtered for 'pipeline' context.
+		// Static registry tools filtered for 'pipeline' mode.
 		$all_tools      = $this->tool_manager->get_all_tools();
-		$pipeline_tools = $this->filterByContext( $all_tools, 'pipeline' );
+		$pipeline_tools = $this->filterByMode( $all_tools, self::MODE_PIPELINE );
 
 		foreach ( $pipeline_tools as $tool_name => $tool_config ) {
 			if ( ! is_array( $tool_config ) ) {
@@ -348,23 +339,23 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * Gather tools for any context string.
+	 * Gather tools for any mode slug.
 	 *
-	 * Filters the tool registry by declared contexts, then applies availability
-	 * and enablement checks. Works with built-in contexts (chat, system) and
-	 * any custom context — third parties can register tools with custom context
-	 * strings and resolve them through the same path.
+	 * Filters the tool registry by declared modes, then applies availability
+	 * and enablement checks. Works with built-in modes (chat, system) and
+	 * any custom mode — third parties can register tools with custom mode
+	 * slugs and resolve them through the same path.
 	 *
-	 * @param string $context_type Context string to filter by (e.g. 'chat', 'system', 'automation').
-	 * @return array Available tools for this context.
+	 * @param string $mode Mode slug to filter by (e.g. 'chat', 'system', 'automation').
+	 * @return array Available tools for this mode.
 	 */
-	private function gatherToolsForContext( string $context_type ): array {
+	private function gatherToolsForMode( string $mode ): array {
 		$available_tools = array();
 
-		$all_tools     = $this->tool_manager->get_all_tools();
-		$context_tools = $this->filterByContext( $all_tools, $context_type );
+		$all_tools  = $this->tool_manager->get_all_tools();
+		$mode_tools = $this->filterByMode( $all_tools, $mode );
 
-		foreach ( $context_tools as $tool_name => $tool_config ) {
+		foreach ( $mode_tools as $tool_name => $tool_config ) {
 			if ( ! is_array( $tool_config ) || empty( $tool_config ) ) {
 				continue;
 			}
@@ -602,22 +593,15 @@ class ToolPolicyResolver {
 	}
 
 	/**
-	 * Get available context presets.
+	 * Get available agent mode presets.
 	 *
-	 * @return array<string, string> Context name => description.
+	 * @return array<string, string> Mode slug => description.
 	 */
-	public static function getContexts(): array {
+	public static function getModes(): array {
 		return array(
-			self::CONTEXT_PIPELINE => 'Pipeline execution with handler tools from adjacent steps',
-			self::CONTEXT_CHAT     => 'Chat interaction with full management tools',
-			self::CONTEXT_SYSTEM   => 'System task execution with minimal toolset',
+			self::MODE_PIPELINE => 'Pipeline execution with handler tools from adjacent steps',
+			self::MODE_CHAT     => 'Chat interaction with full management tools',
+			self::MODE_SYSTEM   => 'System task execution with minimal toolset',
 		);
-	}
-
-	/**
-	 * @deprecated Use getContexts() instead.
-	 */
-	public static function getSurfaces(): array {
-		return self::getContexts();
 	}
 }

--- a/tests/Unit/AI/Memory/MemoryPolicyResolverTest.php
+++ b/tests/Unit/AI/Memory/MemoryPolicyResolverTest.php
@@ -32,22 +32,38 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 		// Seed a small, known set of registered files so assertions are
 		// stable across test runs. The real core registrations happen in
 		// bootstrap code we don't need here.
-		MemoryFileRegistry::register( 'SOUL.md', 10, array(
-			'layer'    => MemoryFileRegistry::LAYER_AGENT,
-			'contexts' => array( 'all' ),
-		) );
-		MemoryFileRegistry::register( 'MEMORY.md', 20, array(
-			'layer'    => MemoryFileRegistry::LAYER_AGENT,
-			'contexts' => array( 'all' ),
-		) );
-		MemoryFileRegistry::register( 'USER.md', 30, array(
-			'layer'    => MemoryFileRegistry::LAYER_USER,
-			'contexts' => array( 'chat', 'pipeline' ),
-		) );
-		MemoryFileRegistry::register( 'CHAT_ONLY.md', 40, array(
-			'layer'    => MemoryFileRegistry::LAYER_AGENT,
-			'contexts' => array( 'chat' ),
-		) );
+		MemoryFileRegistry::register(
+			'SOUL.md',
+			10,
+			array(
+				'layer'    => MemoryFileRegistry::LAYER_AGENT,
+				'contexts' => array( 'all' ),
+			)
+		);
+		MemoryFileRegistry::register(
+			'MEMORY.md',
+			20,
+			array(
+				'layer'    => MemoryFileRegistry::LAYER_AGENT,
+				'contexts' => array( 'all' ),
+			)
+		);
+		MemoryFileRegistry::register(
+			'USER.md',
+			30,
+			array(
+				'layer'    => MemoryFileRegistry::LAYER_USER,
+				'contexts' => array( 'chat', 'pipeline' ),
+			)
+		);
+		MemoryFileRegistry::register(
+			'CHAT_ONLY.md',
+			40,
+			array(
+				'layer'    => MemoryFileRegistry::LAYER_AGENT,
+				'contexts' => array( 'chat' ),
+			)
+		);
 
 		$this->resolver = new MemoryPolicyResolver();
 	}
@@ -64,9 +80,11 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	// ============================================
 
 	public function test_registered_chat_context_includes_all_and_chat_files(): void {
-		$files = $this->resolver->resolveRegistered( array(
-			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
-		) );
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode' => MemoryPolicyResolver::MODE_CHAT,
+			)
+		);
 
 		$this->assertArrayHasKey( 'SOUL.md', $files );
 		$this->assertArrayHasKey( 'MEMORY.md', $files );
@@ -75,9 +93,11 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_registered_pipeline_context_excludes_chat_only(): void {
-		$files = $this->resolver->resolveRegistered( array(
-			'context' => MemoryPolicyResolver::CONTEXT_PIPELINE,
-		) );
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode' => MemoryPolicyResolver::MODE_PIPELINE,
+			)
+		);
 
 		$this->assertArrayHasKey( 'SOUL.md', $files );
 		$this->assertArrayHasKey( 'MEMORY.md', $files );
@@ -86,9 +106,11 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_registered_preserves_metadata(): void {
-		$files = $this->resolver->resolveRegistered( array(
-			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
-		) );
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode' => MemoryPolicyResolver::MODE_CHAT,
+			)
+		);
 
 		$this->assertSame( MemoryFileRegistry::LAYER_AGENT, $files['SOUL.md']['layer'] );
 		$this->assertSame( MemoryFileRegistry::LAYER_USER, $files['USER.md']['layer'] );
@@ -99,20 +121,24 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	// ============================================
 
 	public function test_context_deny_removes_files(): void {
-		$files = $this->resolver->resolveRegistered( array(
-			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
-			'deny'    => array( 'MEMORY.md' ),
-		) );
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode' => MemoryPolicyResolver::MODE_CHAT,
+				'deny' => array( 'MEMORY.md' ),
+			)
+		);
 
 		$this->assertArrayNotHasKey( 'MEMORY.md', $files );
 		$this->assertArrayHasKey( 'SOUL.md', $files );
 	}
 
 	public function test_context_allow_only_narrows_to_subset(): void {
-		$files = $this->resolver->resolveRegistered( array(
-			'context'    => MemoryPolicyResolver::CONTEXT_CHAT,
-			'allow_only' => array( 'SOUL.md' ),
-		) );
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode'       => MemoryPolicyResolver::MODE_CHAT,
+				'allow_only' => array( 'SOUL.md' ),
+			)
+		);
 
 		$this->assertArrayHasKey( 'SOUL.md', $files );
 		$this->assertArrayNotHasKey( 'MEMORY.md', $files );
@@ -124,14 +150,18 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	// ============================================
 
 	public function test_no_agent_id_means_no_agent_filter(): void {
-		$without = $this->resolver->resolveRegistered( array(
-			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
-		) );
+		$without = $this->resolver->resolveRegistered(
+			array(
+				'mode' => MemoryPolicyResolver::MODE_CHAT,
+			)
+		);
 
-		$with_zero = $this->resolver->resolveRegistered( array(
-			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => 0,
-		) );
+		$with_zero = $this->resolver->resolveRegistered(
+			array(
+				'mode'     => MemoryPolicyResolver::MODE_CHAT,
+				'agent_id' => 0,
+			)
+		);
 
 		$this->assertSame( $without, $with_zero );
 	}
@@ -139,28 +169,36 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	public function test_agent_default_mode_is_noop(): void {
 		$agent_id = $this->createAgentWithPolicy( array( 'mode' => 'default' ) );
 
-		$without = $this->resolver->resolveRegistered( array(
-			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
-		) );
+		$without = $this->resolver->resolveRegistered(
+			array(
+				'mode' => MemoryPolicyResolver::MODE_CHAT,
+			)
+		);
 
-		$with = $this->resolver->resolveRegistered( array(
-			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$with = $this->resolver->resolveRegistered(
+			array(
+				'mode'     => MemoryPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertSame( $without, $with );
 	}
 
 	public function test_agent_deny_mode_removes_listed_files(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode' => 'deny',
-			'deny' => array( 'MEMORY.md', 'USER.md' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode' => 'deny',
+				'deny' => array( 'MEMORY.md', 'USER.md' ),
+			)
+		);
 
-		$files = $this->resolver->resolveRegistered( array(
-			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode'     => MemoryPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertArrayHasKey( 'SOUL.md', $files );
 		$this->assertArrayHasKey( 'CHAT_ONLY.md', $files );
@@ -169,15 +207,19 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_agent_allow_only_narrows_to_listed_files(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'       => 'allow_only',
-			'allow_only' => array( 'SOUL.md' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'       => 'allow_only',
+				'allow_only' => array( 'SOUL.md' ),
+			)
+		);
 
-		$files = $this->resolver->resolveRegistered( array(
-			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode'     => MemoryPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertArrayHasKey( 'SOUL.md', $files );
 		$this->assertArrayNotHasKey( 'MEMORY.md', $files );
@@ -185,47 +227,61 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_agent_allow_only_empty_returns_nothing(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'       => 'allow_only',
-			'allow_only' => array(),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'       => 'allow_only',
+				'allow_only' => array(),
+			)
+		);
 
-		$files = $this->resolver->resolveRegistered( array(
-			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode'     => MemoryPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertSame( array(), $files );
 	}
 
 	public function test_agent_deny_empty_list_is_noop(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode' => 'deny',
-			'deny' => array(),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode' => 'deny',
+				'deny' => array(),
+			)
+		);
 
-		$without = $this->resolver->resolveRegistered( array(
-			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
-		) );
+		$without = $this->resolver->resolveRegistered(
+			array(
+				'mode' => MemoryPolicyResolver::MODE_CHAT,
+			)
+		);
 
-		$with = $this->resolver->resolveRegistered( array(
-			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$with = $this->resolver->resolveRegistered(
+			array(
+				'mode'     => MemoryPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertSame( $without, $with );
 	}
 
 	public function test_agent_allow_only_ignores_unknown_files(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'       => 'allow_only',
-			'allow_only' => array( 'SOUL.md', 'DOES_NOT_EXIST.md' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'       => 'allow_only',
+				'allow_only' => array( 'SOUL.md', 'DOES_NOT_EXIST.md' ),
+			)
+		);
 
-		$files = $this->resolver->resolveRegistered( array(
-			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode'     => MemoryPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertArrayHasKey( 'SOUL.md', $files );
 		$this->assertArrayNotHasKey( 'DOES_NOT_EXIST.md', $files );
@@ -237,16 +293,20 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	// ============================================
 
 	public function test_explicit_deny_wins_over_agent_allow_only(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'       => 'allow_only',
-			'allow_only' => array( 'SOUL.md', 'MEMORY.md' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'       => 'allow_only',
+				'allow_only' => array( 'SOUL.md', 'MEMORY.md' ),
+			)
+		);
 
-		$files = $this->resolver->resolveRegistered( array(
-			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-			'deny'     => array( 'MEMORY.md' ),
-		) );
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode'     => MemoryPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+				'deny'     => array( 'MEMORY.md' ),
+			)
+		);
 
 		$this->assertArrayHasKey( 'SOUL.md', $files );
 		$this->assertArrayNotHasKey( 'MEMORY.md', $files );
@@ -256,15 +316,15 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	// datamachine_resolved_memory_files filter
 	// ============================================
 
-	public function test_resolved_filter_fires_with_context_and_files(): void {
+	public function test_resolved_filter_fires_with_mode_and_files(): void {
 		$captured = null;
 		add_filter(
 			'datamachine_resolved_memory_files',
-			function ( $files, $context_type, $context ) use ( &$captured ) {
+			function ( $files, $mode, $args ) use ( &$captured ) {
 				$captured = array(
-					'files'        => $files,
-					'context_type' => $context_type,
-					'context'      => $context,
+					'files' => $files,
+					'mode'  => $mode,
+					'args'  => $args,
 				);
 				return $files;
 			},
@@ -272,13 +332,15 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 			3
 		);
 
-		$this->resolver->resolveRegistered( array(
-			'context'  => MemoryPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => 0,
-		) );
+		$this->resolver->resolveRegistered(
+			array(
+				'mode'     => MemoryPolicyResolver::MODE_CHAT,
+				'agent_id' => 0,
+			)
+		);
 
 		$this->assertNotNull( $captured );
-		$this->assertSame( MemoryPolicyResolver::CONTEXT_CHAT, $captured['context_type'] );
+		$this->assertSame( MemoryPolicyResolver::MODE_CHAT, $captured['mode'] );
 		$this->assertArrayHasKey( 'SOUL.md', $captured['files'] );
 	}
 
@@ -291,9 +353,11 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 			}
 		);
 
-		$files = $this->resolver->resolveRegistered( array(
-			'context' => MemoryPolicyResolver::CONTEXT_CHAT,
-		) );
+		$files = $this->resolver->resolveRegistered(
+			array(
+				'mode' => MemoryPolicyResolver::MODE_CHAT,
+			)
+		);
 
 		$this->assertArrayNotHasKey( 'SOUL.md', $files );
 		$this->assertArrayHasKey( 'MEMORY.md', $files );
@@ -317,10 +381,12 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_filter_agent_deny_removes_files(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode' => 'deny',
-			'deny' => array( 'brand-voice.md' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode' => 'deny',
+				'deny' => array( 'brand-voice.md' ),
+			)
+		);
 
 		$out = $this->resolver->filter(
 			array( 'brand-voice.md', 'seo-checklist.md' ),
@@ -331,10 +397,12 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_filter_agent_allow_only_narrows_list(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'       => 'allow_only',
-			'allow_only' => array( 'seo-checklist.md' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'       => 'allow_only',
+				'allow_only' => array( 'seo-checklist.md' ),
+			)
+		);
 
 		$out = $this->resolver->filter(
 			array( 'brand-voice.md', 'seo-checklist.md', 'tone.md' ),
@@ -345,10 +413,12 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_filter_explicit_deny_applies_after_agent_policy(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode' => 'deny',
-			'deny' => array( 'brand-voice.md' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode' => 'deny',
+				'deny' => array( 'brand-voice.md' ),
+			)
+		);
 
 		$out = $this->resolver->filter(
 			array( 'brand-voice.md', 'seo-checklist.md', 'tone.md' ),
@@ -365,10 +435,10 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 		$captured = null;
 		add_filter(
 			'datamachine_resolved_scoped_memory_files',
-			function ( $filenames, $context ) use ( &$captured ) {
+			function ( $filenames, $args ) use ( &$captured ) {
 				$captured = array(
 					'filenames' => $filenames,
-					'context'   => $context,
+					'args'      => $args,
 				);
 				return $filenames;
 			},
@@ -383,7 +453,7 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 
 		$this->assertNotNull( $captured );
 		$this->assertSame( array( 'a.md' ), $captured['filenames'] );
-		$this->assertSame( 'pipeline', $captured['context']['scope'] );
+		$this->assertSame( 'pipeline', $captured['args']['scope'] );
 	}
 
 	// ============================================
@@ -412,18 +482,22 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_get_policy_returns_null_for_deny_with_empty_list(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode' => 'deny',
-			'deny' => array(),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode' => 'deny',
+				'deny' => array(),
+			)
+		);
 		$this->assertNull( $this->resolver->getAgentMemoryPolicy( $agent_id ) );
 	}
 
 	public function test_get_policy_returns_structure_for_valid_deny(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode' => 'deny',
-			'deny' => array( 'MEMORY.md' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode' => 'deny',
+				'deny' => array( 'MEMORY.md' ),
+			)
+		);
 
 		$policy = $this->resolver->getAgentMemoryPolicy( $agent_id );
 
@@ -434,10 +508,12 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_get_policy_returns_structure_for_valid_allow_only(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'       => 'allow_only',
-			'allow_only' => array( 'SOUL.md' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'       => 'allow_only',
+				'allow_only' => array( 'SOUL.md' ),
+			)
+		);
 
 		$policy = $this->resolver->getAgentMemoryPolicy( $agent_id );
 
@@ -448,15 +524,15 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	// ============================================
-	// getContexts()
+	// getModes()
 	// ============================================
 
-	public function test_get_contexts_returns_all_three_presets(): void {
-		$contexts = MemoryPolicyResolver::getContexts();
+	public function test_get_modes_returns_all_three_presets(): void {
+		$modes = MemoryPolicyResolver::getModes();
 
-		$this->assertArrayHasKey( MemoryPolicyResolver::CONTEXT_PIPELINE, $contexts );
-		$this->assertArrayHasKey( MemoryPolicyResolver::CONTEXT_CHAT, $contexts );
-		$this->assertArrayHasKey( MemoryPolicyResolver::CONTEXT_SYSTEM, $contexts );
+		$this->assertArrayHasKey( MemoryPolicyResolver::MODE_PIPELINE, $modes );
+		$this->assertArrayHasKey( MemoryPolicyResolver::MODE_CHAT, $modes );
+		$this->assertArrayHasKey( MemoryPolicyResolver::MODE_SYSTEM, $modes );
 	}
 
 	// ============================================

--- a/tests/Unit/AI/Tools/ChatToolsAvailabilityTest.php
+++ b/tests/Unit/AI/Tools/ChatToolsAvailabilityTest.php
@@ -28,7 +28,7 @@ class ChatToolsAvailabilityTest extends WP_UnitTestCase {
 
 	public function test_chat_tools_include_update_flow(): void {
 		$tools = $this->resolver->resolve( [
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
+			'mode'     => ToolPolicyResolver::MODE_CHAT,
 		] );
 
 		$this->assertIsArray( $tools );
@@ -40,7 +40,7 @@ class ChatToolsAvailabilityTest extends WP_UnitTestCase {
 
 	public function test_chat_tools_include_web_fetch(): void {
 		$tools = $this->resolver->resolve( [
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
+			'mode'     => ToolPolicyResolver::MODE_CHAT,
 		] );
 
 		$this->assertIsArray( $tools );

--- a/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
+++ b/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
@@ -62,7 +62,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 						);
 					},
 					'handler'           => 'widget_publish',
-					'contexts'          => array( 'pipeline' ),
+					'modes'             => array( 'pipeline' ),
 					'access_level'      => 'admin',
 				);
 				return $tools;
@@ -81,7 +81,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 		$this->assertSame( 'widget_publish', $resolved['widget_publish']['handler'] );
 		$this->assertSame(
 			array( 'pipeline' ),
-			$resolved['widget_publish']['contexts']
+			$resolved['widget_publish']['modes']
 		);
 		$this->assertSame( 'admin', $resolved['widget_publish']['access_level'] );
 		$this->assertSame( 'widget_publish', $resolved['widget_publish']['_observed']['slug'] );
@@ -96,7 +96,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 				$tools['__handler_tools_widget_publish'] = array(
 					'_handler_callable' => static fn() => array( 'widget_publish' => array( 'description' => 'x' ) ),
 					'handler'           => 'widget_publish',
-					'contexts'          => array( 'pipeline' ),
+					'modes'             => array( 'pipeline' ),
 				);
 				return $tools;
 			}
@@ -119,7 +119,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 				$tools['__handler_tools_widget'] = array(
 					'_handler_callable' => static fn() => null,
 					'handler'           => 'widget',
-					'contexts'          => array( 'pipeline' ),
+					'modes'             => array( 'pipeline' ),
 				);
 				return $tools;
 			}
@@ -162,7 +162,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 						);
 					},
 					'handler_types'     => array( 'fetch', 'event_import' ),
-					'contexts'          => array( 'pipeline' ),
+					'modes'             => array( 'pipeline' ),
 					'access_level'      => 'admin',
 				);
 				return $tools;
@@ -200,7 +200,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 				$tools['__handler_tools_skip_item_test'] = array(
 					'_handler_callable' => static fn() => array( 'skip_item_test' => array( 'description' => 'x' ) ),
 					'handler_types'     => array( 'fetch' ),
-					'contexts'          => array( 'pipeline' ),
+					'modes'             => array( 'pipeline' ),
 				);
 				return $tools;
 			}
@@ -231,7 +231,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 						return array( 'caching' => array( 'description' => 'x' ) );
 					},
 					'handler'           => 'caching',
-					'contexts'          => array( 'pipeline' ),
+					'modes'             => array( 'pipeline' ),
 				);
 				return $tools;
 			}
@@ -258,7 +258,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 						return array( 'no_cache' => array( 'description' => 'x' ) );
 					},
 					'handler'           => 'no_cache',
-					'contexts'          => array( 'pipeline' ),
+					'modes'             => array( 'pipeline' ),
 				);
 				return $tools;
 			}
@@ -280,12 +280,12 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 			function ( array $tools ): array {
 				$tools['static_global']          = array(
 					'description' => 'A static tool',
-					'contexts'    => array( 'chat' ),
+					'modes'       => array( 'chat' ),
 				);
 				$tools['__handler_tools_widget'] = array(
 					'_handler_callable' => static fn() => array( 'widget' => array() ),
 					'handler'           => 'widget',
-					'contexts'          => array( 'pipeline' ),
+					'modes'             => array( 'pipeline' ),
 				);
 				return $tools;
 			}
@@ -316,7 +316,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 						);
 					},
 					'handler'           => 'pubtest',
-					'contexts'          => array( 'pipeline' ),
+					'modes'             => array( 'pipeline' ),
 					'access_level'      => 'admin',
 				);
 				return $tools;
@@ -326,7 +326,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 		$resolver = new ToolPolicyResolver();
 		$tools    = $resolver->resolve(
 			array(
-				'context'          => ToolPolicyResolver::CONTEXT_PIPELINE,
+				'mode'             => ToolPolicyResolver::MODE_PIPELINE,
 				'next_step_config' => array(
 					'flow_step_id'    => 'fs_pipeline_test',
 					'handler_slugs'   => array( 'pubtest' ),
@@ -347,7 +347,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 				$tools['__handler_tools_unused'] = array(
 					'_handler_callable' => static fn() => array( 'unused' => array() ),
 					'handler'           => 'no_match',
-					'contexts'          => array( 'pipeline' ),
+					'modes'             => array( 'pipeline' ),
 				);
 				return $tools;
 			}
@@ -356,7 +356,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 		$resolver = new ToolPolicyResolver();
 		$tools    = $resolver->resolve(
 			array(
-				'context' => ToolPolicyResolver::CONTEXT_PIPELINE,
+				'mode' => ToolPolicyResolver::MODE_PIPELINE,
 			)
 		);
 

--- a/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
+++ b/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
@@ -1,0 +1,365 @@
+<?php
+/**
+ * Tests for handler tool resolution via the unified `datamachine_tools` registry.
+ *
+ * Covers the `_handler_callable` protocol that replaced the legacy
+ * `chubes_ai_tools` filter:
+ *
+ *  - Exact slug matching (`'handler' => 'wp_publish'`)
+ *  - Cross-cutting type matching (`'handler_types' => ['fetch', 'event_import']`)
+ *  - Per-scope caching
+ *  - Pipeline gather flow through ToolPolicyResolver
+ *
+ * @package DataMachine\Tests\Unit\AI\Tools
+ */
+
+namespace DataMachine\Tests\Unit\AI\Tools;
+
+use DataMachine\Engine\AI\Tools\ToolManager;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
+use WP_UnitTestCase;
+
+class HandlerToolResolutionTest extends WP_UnitTestCase {
+
+	private ToolManager $tool_manager;
+
+	public function set_up(): void {
+		parent::set_up();
+		datamachine_register_capabilities();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		ToolManager::clearCache();
+		$this->tool_manager = new ToolManager();
+	}
+
+	public function tear_down(): void {
+		ToolManager::clearCache();
+		parent::tear_down();
+	}
+
+	// ============================================
+	// EXACT SLUG MATCHING
+	// ============================================
+
+	public function test_resolves_handler_tool_with_exact_slug_match(): void {
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ): array {
+				$tools['__handler_tools_widget_publish'] = array(
+					'_handler_callable' => static function ( $slug, $config, $engine ) {
+						return array(
+							'widget_publish' => array(
+								'description' => 'Publish to widget',
+								'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+								'_observed'   => array(
+									'slug'   => $slug,
+									'config' => $config,
+									'engine' => $engine,
+								),
+							),
+						);
+					},
+					'handler'           => 'widget_publish',
+					'contexts'          => array( 'pipeline' ),
+					'access_level'      => 'admin',
+				);
+				return $tools;
+			}
+		);
+
+		$resolved = $this->tool_manager->resolveHandlerTools(
+			'widget_publish',
+			array( 'site_id' => 42 ),
+			array( 'job_id' => 99 ),
+			'flow_step_xyz'
+		);
+
+		$this->assertArrayHasKey( 'widget_publish', $resolved );
+		$this->assertSame( 'Publish to widget', $resolved['widget_publish']['description'] );
+		$this->assertSame( 'widget_publish', $resolved['widget_publish']['handler'] );
+		$this->assertSame(
+			array( 'pipeline' ),
+			$resolved['widget_publish']['contexts']
+		);
+		$this->assertSame( 'admin', $resolved['widget_publish']['access_level'] );
+		$this->assertSame( 'widget_publish', $resolved['widget_publish']['_observed']['slug'] );
+		$this->assertSame( array( 'site_id' => 42 ), $resolved['widget_publish']['_observed']['config'] );
+		$this->assertSame( array( 'job_id' => 99 ), $resolved['widget_publish']['_observed']['engine'] );
+	}
+
+	public function test_skips_handler_tools_with_non_matching_slug(): void {
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ): array {
+				$tools['__handler_tools_widget_publish'] = array(
+					'_handler_callable' => static fn() => array( 'widget_publish' => array( 'description' => 'x' ) ),
+					'handler'           => 'widget_publish',
+					'contexts'          => array( 'pipeline' ),
+				);
+				return $tools;
+			}
+		);
+
+		$resolved = $this->tool_manager->resolveHandlerTools(
+			'something_else',
+			array(),
+			array(),
+			'scope'
+		);
+
+		$this->assertSame( array(), $resolved );
+	}
+
+	public function test_callback_returning_non_array_is_silently_skipped(): void {
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ): array {
+				$tools['__handler_tools_widget'] = array(
+					'_handler_callable' => static fn() => null,
+					'handler'           => 'widget',
+					'contexts'          => array( 'pipeline' ),
+				);
+				return $tools;
+			}
+		);
+
+		$resolved = $this->tool_manager->resolveHandlerTools( 'widget', array(), array(), 'scope' );
+
+		$this->assertSame( array(), $resolved );
+	}
+
+	// ============================================
+	// HANDLER TYPE MATCHING (cross-cutting)
+	// ============================================
+
+	public function test_resolves_cross_cutting_tool_via_handler_types(): void {
+		// Register a handler so the type lookup succeeds.
+		add_filter(
+			'datamachine_handlers',
+			function ( array $handlers ): array {
+				$handlers['rss_feed'] = array(
+					'type'  => 'fetch',
+					'class' => 'StubRssHandler',
+					'label' => 'RSS',
+				);
+				return $handlers;
+			}
+		);
+
+		// Register a tool that applies to ANY fetch-type handler.
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ): array {
+				$tools['__handler_tools_skip_item_test'] = array(
+					'_handler_callable' => static function ( $slug ) {
+						return array(
+							'skip_item_test' => array(
+								'description'    => "Skip item from {$slug}",
+								'_resolved_slug' => $slug,
+							),
+						);
+					},
+					'handler_types'     => array( 'fetch', 'event_import' ),
+					'contexts'          => array( 'pipeline' ),
+					'access_level'      => 'admin',
+				);
+				return $tools;
+			}
+		);
+
+		$resolved = $this->tool_manager->resolveHandlerTools(
+			'rss_feed',
+			array(),
+			array(),
+			'scope'
+		);
+
+		$this->assertArrayHasKey( 'skip_item_test', $resolved );
+		$this->assertSame( 'Skip item from rss_feed', $resolved['skip_item_test']['description'] );
+		$this->assertSame( 'rss_feed', $resolved['skip_item_test']['handler'] );
+		$this->assertSame( 'rss_feed', $resolved['skip_item_test']['_resolved_slug'] );
+	}
+
+	public function test_handler_types_skips_non_matching_handler_type(): void {
+		add_filter(
+			'datamachine_handlers',
+			function ( array $handlers ): array {
+				$handlers['twitter'] = array(
+					'type'  => 'publish',
+					'class' => 'StubTwitter',
+				);
+				return $handlers;
+			}
+		);
+
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ): array {
+				$tools['__handler_tools_skip_item_test'] = array(
+					'_handler_callable' => static fn() => array( 'skip_item_test' => array( 'description' => 'x' ) ),
+					'handler_types'     => array( 'fetch' ),
+					'contexts'          => array( 'pipeline' ),
+				);
+				return $tools;
+			}
+		);
+
+		$resolved = $this->tool_manager->resolveHandlerTools(
+			'twitter',
+			array(),
+			array(),
+			'scope'
+		);
+
+		$this->assertArrayNotHasKey( 'skip_item_test', $resolved );
+	}
+
+	// ============================================
+	// PER-SCOPE CACHING
+	// ============================================
+
+	public function test_resolution_cached_per_scope(): void {
+		$invocations = 0;
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ) use ( &$invocations ): array {
+				$tools['__handler_tools_caching'] = array(
+					'_handler_callable' => function () use ( &$invocations ) {
+						$invocations++;
+						return array( 'caching' => array( 'description' => 'x' ) );
+					},
+					'handler'           => 'caching',
+					'contexts'          => array( 'pipeline' ),
+				);
+				return $tools;
+			}
+		);
+
+		$this->tool_manager->resolveHandlerTools( 'caching', array(), array(), 'scope_a' );
+		$this->tool_manager->resolveHandlerTools( 'caching', array(), array(), 'scope_a' );
+
+		$this->assertSame( 1, $invocations, 'Same scope should only invoke callback once.' );
+
+		$this->tool_manager->resolveHandlerTools( 'caching', array(), array(), 'scope_b' );
+
+		$this->assertSame( 2, $invocations, 'Different scope must re-invoke callback.' );
+	}
+
+	public function test_no_caching_when_scope_is_empty(): void {
+		$invocations = 0;
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ) use ( &$invocations ): array {
+				$tools['__handler_tools_no_cache'] = array(
+					'_handler_callable' => function () use ( &$invocations ) {
+						$invocations++;
+						return array( 'no_cache' => array( 'description' => 'x' ) );
+					},
+					'handler'           => 'no_cache',
+					'contexts'          => array( 'pipeline' ),
+				);
+				return $tools;
+			}
+		);
+
+		$this->tool_manager->resolveHandlerTools( 'no_cache', array(), array(), '' );
+		$this->tool_manager->resolveHandlerTools( 'no_cache', array(), array(), '' );
+
+		$this->assertSame( 2, $invocations, 'Empty scope must bypass cache.' );
+	}
+
+	// ============================================
+	// REGISTRY INTROSPECTION
+	// ============================================
+
+	public function test_get_handler_tool_entries_returns_only_handler_callable_entries(): void {
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ): array {
+				$tools['static_global']          = array(
+					'description' => 'A static tool',
+					'contexts'    => array( 'chat' ),
+				);
+				$tools['__handler_tools_widget'] = array(
+					'_handler_callable' => static fn() => array( 'widget' => array() ),
+					'handler'           => 'widget',
+					'contexts'          => array( 'pipeline' ),
+				);
+				return $tools;
+			}
+		);
+
+		$entries = $this->tool_manager->get_handler_tool_entries();
+
+		$this->assertArrayHasKey( '__handler_tools_widget', $entries );
+		$this->assertArrayNotHasKey( 'static_global', $entries );
+	}
+
+	// ============================================
+	// PIPELINE GATHER FLOW
+	// ============================================
+
+	public function test_pipeline_resolver_surfaces_handler_tools_for_adjacent_step(): void {
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ): array {
+				$tools['__handler_tools_pubtest'] = array(
+					'_handler_callable' => static function ( $slug, $config ) {
+						return array(
+							'pubtest_publish' => array(
+								'description' => 'Publish via pubtest',
+								'parameters'  => array(),
+								'config_seen' => $config,
+							),
+						);
+					},
+					'handler'           => 'pubtest',
+					'contexts'          => array( 'pipeline' ),
+					'access_level'      => 'admin',
+				);
+				return $tools;
+			}
+		);
+
+		$resolver = new ToolPolicyResolver();
+		$tools    = $resolver->resolve(
+			array(
+				'context'          => ToolPolicyResolver::CONTEXT_PIPELINE,
+				'next_step_config' => array(
+					'flow_step_id'    => 'fs_pipeline_test',
+					'handler_slugs'   => array( 'pubtest' ),
+					'handler_configs' => array( 'pubtest' => array( 'site' => 'example.com' ) ),
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 'pubtest_publish', $tools );
+		$this->assertSame( 'pubtest', $tools['pubtest_publish']['handler'] );
+		$this->assertSame( array( 'site' => 'example.com' ), $tools['pubtest_publish']['config_seen'] );
+	}
+
+	public function test_pipeline_resolver_omits_handler_wrappers_from_static_tools(): void {
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ): array {
+				$tools['__handler_tools_unused'] = array(
+					'_handler_callable' => static fn() => array( 'unused' => array() ),
+					'handler'           => 'no_match',
+					'contexts'          => array( 'pipeline' ),
+				);
+				return $tools;
+			}
+		);
+
+		$resolver = new ToolPolicyResolver();
+		$tools    = $resolver->resolve(
+			array(
+				'context' => ToolPolicyResolver::CONTEXT_PIPELINE,
+			)
+		);
+
+		$this->assertArrayNotHasKey( '__handler_tools_unused', $tools );
+	}
+}

--- a/tests/Unit/AI/Tools/PipelineToolsAvailabilityTest.php
+++ b/tests/Unit/AI/Tools/PipelineToolsAvailabilityTest.php
@@ -46,7 +46,7 @@ class PipelineToolsAvailabilityTest extends WP_UnitTestCase {
 		$this->assertTrue( $updated );
 
 		$tools_without_disabled = $this->resolver->resolve( [
-			'context'          => ToolPolicyResolver::CONTEXT_PIPELINE,
+			'mode'              => ToolPolicyResolver::MODE_PIPELINE,
 			'pipeline_step_id' => $pipeline_step_id,
 		] );
 		$this->assertIsArray( $tools_without_disabled );
@@ -59,7 +59,7 @@ class PipelineToolsAvailabilityTest extends WP_UnitTestCase {
 		$this->assertTrue( $updated_again );
 
 		$tools_with_disabled = $this->resolver->resolve( [
-			'context'          => ToolPolicyResolver::CONTEXT_PIPELINE,
+			'mode'              => ToolPolicyResolver::MODE_PIPELINE,
 			'pipeline_step_id' => $pipeline_step_id,
 		] );
 		$this->assertIsArray( $tools_with_disabled );
@@ -90,7 +90,7 @@ class PipelineToolsAvailabilityTest extends WP_UnitTestCase {
 		$this->assertTrue( $updated );
 
 		$tools = $this->resolver->resolve( [
-			'context'          => ToolPolicyResolver::CONTEXT_PIPELINE,
+			'mode'              => ToolPolicyResolver::MODE_PIPELINE,
 			'pipeline_step_id' => $pipeline_step_id,
 		] );
 		$this->assertIsArray( $tools );

--- a/tests/Unit/AI/Tools/ToolPolicyResolverTest.php
+++ b/tests/Unit/AI/Tools/ToolPolicyResolverTest.php
@@ -40,27 +40,33 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	// ============================================
 
 	public function test_chat_includes_global_tools(): void {
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
 		$this->assertIsArray( $tools );
 		$this->assertArrayHasKey( 'web_fetch', $tools );
 	}
 
 	public function test_chat_includes_chat_tools(): void {
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
 		$this->assertIsArray( $tools );
 		$this->assertArrayHasKey( 'update_flow', $tools );
 	}
 
- 	public function test_chat_tools_pass_availability_check(): void {
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+	public function test_chat_tools_pass_availability_check(): void {
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
 		foreach ( $tools as $tool_name => $tool_config ) {
 			$this->assertIsArray( $tool_config, "Tool '{$tool_name}' should have array config" );
@@ -76,28 +82,33 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		// filter. Only the use_tools cap is stripped here — chat remains.
 		add_filter( 'user_has_cap', array( $this, 'deny_use_tools_cap' ), 10, 4 );
 
-		add_filter( 'datamachine_tools', function ( $tools ) {
-			$tools['test_authenticated_tool'] = array(
-				'label'        => 'Test Authenticated Tool',
-				'description'  => 'Visible to authenticated users.',
-				'class'        => 'NonExistentClass',
-				'method'       => 'handle_tool_call',
-				'parameters'   => array(),
-				'contexts'     => array( 'chat' ),
-				'access_level' => 'authenticated',
-			);
+		add_filter(
+			'datamachine_tools',
+			function ( $tools ) {
+				$tools['test_authenticated_tool'] = array(
+					'label'        => 'Test Authenticated Tool',
+					'description'  => 'Visible to authenticated users.',
+					'class'        => 'NonExistentClass',
+					'method'       => 'handle_tool_call',
+					'parameters'   => array(),
+					'modes'        => array( 'chat' ),
+					'access_level' => 'authenticated',
+				);
 
-			return $tools;
-		} );
+				return $tools;
+			}
+		);
 
 		ToolManager::clearCache();
 
 		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $user_id );
 
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
 		$this->assertArrayHasKey( 'test_authenticated_tool', $tools );
 
@@ -111,28 +122,33 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		add_filter( 'user_has_cap', array( $this, 'deny_all_datamachine_caps' ), 10, 4 );
 		add_filter( 'datamachine_require_use_tools_for_chat_tools', '__return_true' );
 
-		add_filter( 'datamachine_tools', function ( $tools ) {
-			$tools['test_authenticated_tool'] = array(
-				'label'        => 'Test Authenticated Tool',
-				'description'  => 'Visible to authenticated users.',
-				'class'        => 'NonExistentClass',
-				'method'       => 'handle_tool_call',
-				'parameters'   => array(),
-				'contexts'     => array( 'chat' ),
-				'access_level' => 'authenticated',
-			);
+		add_filter(
+			'datamachine_tools',
+			function ( $tools ) {
+				$tools['test_authenticated_tool'] = array(
+					'label'        => 'Test Authenticated Tool',
+					'description'  => 'Visible to authenticated users.',
+					'class'        => 'NonExistentClass',
+					'method'       => 'handle_tool_call',
+					'parameters'   => array(),
+					'modes'        => array( 'chat' ),
+					'access_level' => 'authenticated',
+				);
 
-			return $tools;
-		} );
+				return $tools;
+			}
+		);
 
 		ToolManager::clearCache();
 
 		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $user_id );
 
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
 		$this->assertEmpty( $tools );
 
@@ -146,25 +162,30 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	public function test_chat_allows_public_tools_for_anonymous_users(): void {
 		wp_set_current_user( 0 );
 
-		add_filter( 'datamachine_tools', function ( $tools ) {
-			$tools['test_public_tool'] = array(
-				'label'        => 'Test Public Tool',
-				'description'  => 'Visible without login.',
-				'class'        => 'NonExistentClass',
-				'method'       => 'handle_tool_call',
-				'parameters'   => array(),
-				'contexts'     => array( 'chat' ),
-				'access_level' => 'public',
-			);
+		add_filter(
+			'datamachine_tools',
+			function ( $tools ) {
+				$tools['test_public_tool'] = array(
+					'label'        => 'Test Public Tool',
+					'description'  => 'Visible without login.',
+					'class'        => 'NonExistentClass',
+					'method'       => 'handle_tool_call',
+					'parameters'   => array(),
+					'modes'        => array( 'chat' ),
+					'access_level' => 'public',
+				);
 
-			return $tools;
-		} );
+				return $tools;
+			}
+		);
 
 		ToolManager::clearCache();
 
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
 		$this->assertArrayHasKey( 'test_public_tool', $tools );
 
@@ -175,24 +196,29 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	public function test_chat_keeps_untagged_tools_admin_only_for_anonymous_users(): void {
 		wp_set_current_user( 0 );
 
-		add_filter( 'datamachine_tools', function ( $tools ) {
-			$tools['test_untagged_tool'] = array(
-				'label'       => 'Test Untagged Tool',
-				'description' => 'No access metadata.',
-				'class'       => 'NonExistentClass',
-				'method'      => 'handle_tool_call',
-				'parameters'  => array(),
-				'contexts'    => array( 'chat' ),
-			);
+		add_filter(
+			'datamachine_tools',
+			function ( $tools ) {
+				$tools['test_untagged_tool'] = array(
+					'label'       => 'Test Untagged Tool',
+					'description' => 'No access metadata.',
+					'class'       => 'NonExistentClass',
+					'method'      => 'handle_tool_call',
+					'parameters'  => array(),
+					'modes'       => array( 'chat' ),
+				);
 
-			return $tools;
-		} );
+				return $tools;
+			}
+		);
 
 		ToolManager::clearCache();
 
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
 		$this->assertArrayNotHasKey( 'test_untagged_tool', $tools );
 
@@ -205,45 +231,56 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	// ============================================
 
 	public function test_pipeline_includes_global_tools(): void {
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_PIPELINE,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_PIPELINE,
+			)
+		);
 
 		$this->assertIsArray( $tools );
 		$this->assertArrayHasKey( 'web_fetch', $tools );
 	}
 
 	public function test_pipeline_excludes_chat_tools(): void {
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_PIPELINE,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_PIPELINE,
+			)
+		);
 
 		$this->assertArrayNotHasKey( 'update_flow', $tools );
 	}
 
 	public function test_pipeline_respects_step_disabled_tools(): void {
 		$pipelines   = new Pipelines();
-		$pipeline_id = $pipelines->create_pipeline( array(
-			'pipeline_name'   => 'Resolver Pipeline',
-			'pipeline_config' => array(),
-		) );
+		$pipeline_id = $pipelines->create_pipeline(
+			array(
+				'pipeline_name'   => 'Resolver Pipeline',
+				'pipeline_config' => array(),
+			)
+		);
 
 		$this->assertIsInt( $pipeline_id );
 		$pipeline_step_id = $pipeline_id . '_resolver-test-uuid';
 
-		$pipelines->update_pipeline( $pipeline_id, array(
-			'pipeline_config' => array(
-				$pipeline_step_id => array(
-					'step_type'      => 'fetch',
-					'disabled_tools' => array( 'web_fetch' ),
+		$pipelines->update_pipeline(
+			$pipeline_id,
+			array(
+				'pipeline_config' => array(
+					$pipeline_step_id => array(
+						'step_type'      => 'fetch',
+						'disabled_tools' => array( 'web_fetch' ),
+					),
 				),
-			),
-		) );
+			)
+		);
 
-		$tools = $this->resolver->resolve( array(
-			'context'          => ToolPolicyResolver::CONTEXT_PIPELINE,
-			'pipeline_step_id' => $pipeline_step_id,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'             => ToolPolicyResolver::MODE_PIPELINE,
+				'pipeline_step_id' => $pipeline_step_id,
+			)
+		);
 
 		$this->assertArrayNotHasKey( 'web_fetch', $tools );
 	}
@@ -253,9 +290,11 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	// ============================================
 
 	public function test_system_returns_only_system_context_tools(): void {
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_SYSTEM,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_SYSTEM,
+			)
+		);
 
 		$this->assertIsArray( $tools );
 		// No tools currently register with 'system' context.
@@ -263,23 +302,28 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_system_includes_system_context_tools(): void {
-		add_filter( 'datamachine_tools', function ( $tools ) {
-			$tools['test_system_tool'] = array(
-				'label'       => 'Test System Tool',
-				'description' => 'Only available to system tasks.',
-				'class'       => 'NonExistentClass',
-				'method'      => 'handle_tool_call',
-				'parameters'  => array(),
-				'contexts'    => array( 'system' ),
-			);
-			return $tools;
-		} );
+		add_filter(
+			'datamachine_tools',
+			function ( $tools ) {
+				$tools['test_system_tool'] = array(
+					'label'       => 'Test System Tool',
+					'description' => 'Only available to system tasks.',
+					'class'       => 'NonExistentClass',
+					'method'      => 'handle_tool_call',
+					'parameters'  => array(),
+					'modes'       => array( 'system' ),
+				);
+				return $tools;
+			}
+		);
 
 		ToolManager::clearCache();
 
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_SYSTEM,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_SYSTEM,
+			)
+		);
 
 		$this->assertArrayHasKey( 'test_system_tool', $tools );
 
@@ -292,20 +336,24 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	// ============================================
 
 	public function test_deny_list_removes_tools(): void {
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-			'deny'    => array( 'web_fetch' ),
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+				'deny' => array( 'web_fetch' ),
+			)
+		);
 
 		$this->assertArrayNotHasKey( 'web_fetch', $tools );
 	}
 
 	public function test_deny_list_overrides_allowlist(): void {
-		$tools = $this->resolver->resolve( array(
-			'context'    => ToolPolicyResolver::CONTEXT_CHAT,
-			'allow_only' => array( 'web_fetch' ),
-			'deny'       => array( 'web_fetch' ),
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'       => ToolPolicyResolver::MODE_CHAT,
+				'allow_only' => array( 'web_fetch' ),
+				'deny'       => array( 'web_fetch' ),
+			)
+		);
 
 		$this->assertArrayNotHasKey( 'web_fetch', $tools );
 	}
@@ -315,20 +363,24 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	// ============================================
 
 	public function test_allowlist_narrows_tools(): void {
-		$tools = $this->resolver->resolve( array(
-			'context'    => ToolPolicyResolver::CONTEXT_CHAT,
-			'allow_only' => array( 'web_fetch' ),
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'       => ToolPolicyResolver::MODE_CHAT,
+				'allow_only' => array( 'web_fetch' ),
+			)
+		);
 
 		$this->assertArrayHasKey( 'web_fetch', $tools );
 		$this->assertCount( 1, $tools );
 	}
 
 	public function test_allowlist_with_nonexistent_tool_returns_empty(): void {
-		$tools = $this->resolver->resolve( array(
-			'context'    => ToolPolicyResolver::CONTEXT_CHAT,
-			'allow_only' => array( 'completely_fake_tool_xyz' ),
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'       => ToolPolicyResolver::MODE_CHAT,
+				'allow_only' => array( 'completely_fake_tool_xyz' ),
+			)
+		);
 
 		$this->assertEmpty( $tools );
 	}
@@ -338,42 +390,56 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	// ============================================
 
 	public function test_resolved_tools_filter_can_modify_output(): void {
-		add_filter( 'datamachine_resolved_tools', function ( $tools, $context_type, $context ) {
-			$tools['injected_tool'] = array(
-				'label'       => 'Injected Tool',
-				'description' => 'Added via filter.',
-				'class'       => 'NonExistentClass',
-				'method'      => 'handle_tool_call',
-				'parameters'  => array(),
-			);
-			return $tools;
-		}, 10, 3 );
+		add_filter(
+			'datamachine_resolved_tools',
+			function ( $tools, $mode, $args ) {
+				$tools['injected_tool'] = array(
+					'label'       => 'Injected Tool',
+					'description' => 'Added via filter.',
+					'class'       => 'NonExistentClass',
+					'method'      => 'handle_tool_call',
+					'parameters'  => array(),
+				);
+				return $tools;
+			},
+			10,
+			3
+		);
 
-		$tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
 		$this->assertArrayHasKey( 'injected_tool', $tools );
 
 		remove_all_filters( 'datamachine_resolved_tools' );
 	}
 
-	public function test_resolved_tools_filter_receives_context_type(): void {
-		$captured_context_type = null;
-		$captured_context      = null;
+	public function test_resolved_tools_filter_receives_mode(): void {
+		$captured_mode = null;
+		$captured_args = null;
 
-		add_filter( 'datamachine_resolved_tools', function ( $tools, $context_type, $context ) use ( &$captured_context_type, &$captured_context ) {
-			$captured_context_type = $context_type;
-			$captured_context      = $context;
-			return $tools;
-		}, 10, 3 );
+		add_filter(
+			'datamachine_resolved_tools',
+			function ( $tools, $mode, $args ) use ( &$captured_mode, &$captured_args ) {
+				$captured_mode = $mode;
+				$captured_args = $args;
+				return $tools;
+			},
+			10,
+			3
+		);
 
-		$this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
-		$this->assertSame( ToolPolicyResolver::CONTEXT_CHAT, $captured_context_type );
-		$this->assertIsArray( $captured_context );
+		$this->assertSame( ToolPolicyResolver::MODE_CHAT, $captured_mode );
+		$this->assertIsArray( $captured_args );
 
 		remove_all_filters( 'datamachine_resolved_tools' );
 	}
@@ -394,9 +460,11 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		// are registered for this context, so the result is empty.
 		// This is correct: custom contexts only get tools that explicitly
 		// declare them, making the system extensible.
-		$tools = $this->resolver->resolve( array(
-			'context' => 'unknown_context_type',
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => 'unknown_context_type',
+			)
+		);
 
 		$this->assertIsArray( $tools );
 		$this->assertEmpty( $tools );
@@ -405,23 +473,28 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	public function test_custom_context_resolves_registered_tools(): void {
 		// Third parties can register tools with custom contexts and
 		// resolve them through the same path as built-in contexts.
-		add_filter( 'datamachine_tools', function ( $tools ) {
-			$tools['custom_automation_tool'] = array(
-				'label'       => 'Custom Automation Tool',
-				'description' => 'Only available in the automation context.',
-				'class'       => 'NonExistentClass',
-				'method'      => 'handle_tool_call',
-				'parameters'  => array(),
-				'contexts'    => array( 'automation' ),
-			);
-			return $tools;
-		} );
+		add_filter(
+			'datamachine_tools',
+			function ( $tools ) {
+				$tools['custom_automation_tool'] = array(
+					'label'       => 'Custom Automation Tool',
+					'description' => 'Only available in the automation context.',
+					'class'       => 'NonExistentClass',
+					'method'      => 'handle_tool_call',
+					'parameters'  => array(),
+					'modes'       => array( 'automation' ),
+				);
+				return $tools;
+			}
+		);
 
 		ToolManager::clearCache();
 
-		$tools = $this->resolver->resolve( array(
-			'context' => 'automation',
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode' => 'automation',
+			)
+		);
 
 		$this->assertArrayHasKey( 'custom_automation_tool', $tools );
 
@@ -432,38 +505,13 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 		ToolManager::clearCache();
 	}
 
-	public function test_getContexts_returns_all_three_presets(): void {
-		$contexts = ToolPolicyResolver::getContexts();
+	public function test_getModes_returns_all_three_presets(): void {
+		$modes = ToolPolicyResolver::getModes();
 
-		$this->assertArrayHasKey( ToolPolicyResolver::CONTEXT_PIPELINE, $contexts );
-		$this->assertArrayHasKey( ToolPolicyResolver::CONTEXT_CHAT, $contexts );
-		$this->assertArrayHasKey( ToolPolicyResolver::CONTEXT_SYSTEM, $contexts );
-		$this->assertCount( 3, $contexts );
-	}
-
-	// ============================================
-	// BACKWARD COMPATIBILITY
-	// ============================================
-
-	public function test_surface_key_still_works(): void {
-		// The deprecated 'surface' key should still resolve correctly.
-		$tools = $this->resolver->resolve( array(
-			'surface' => ToolPolicyResolver::SURFACE_CHAT,
-		) );
-
-		$this->assertIsArray( $tools );
-		$this->assertArrayHasKey( 'web_fetch', $tools );
-		$this->assertArrayHasKey( 'update_flow', $tools );
-	}
-
-	public function test_surface_constants_alias_context_constants(): void {
-		$this->assertSame( ToolPolicyResolver::CONTEXT_PIPELINE, ToolPolicyResolver::SURFACE_PIPELINE );
-		$this->assertSame( ToolPolicyResolver::CONTEXT_CHAT, ToolPolicyResolver::SURFACE_CHAT );
-		$this->assertSame( ToolPolicyResolver::CONTEXT_SYSTEM, ToolPolicyResolver::SURFACE_SYSTEM );
-	}
-
-	public function test_getSurfaces_delegates_to_getContexts(): void {
-		$this->assertSame( ToolPolicyResolver::getSurfaces(), ToolPolicyResolver::getContexts() );
+		$this->assertArrayHasKey( ToolPolicyResolver::MODE_PIPELINE, $modes );
+		$this->assertArrayHasKey( ToolPolicyResolver::MODE_CHAT, $modes );
+		$this->assertArrayHasKey( ToolPolicyResolver::MODE_SYSTEM, $modes );
+		$this->assertCount( 3, $modes );
 	}
 
 	// ============================================
@@ -472,18 +520,22 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 
 	public function test_deprecated_executor_delegates_to_resolver(): void {
 		$executor_tools = \DataMachine\Engine\AI\Tools\ToolExecutor::getAvailableTools( null, null, null, array() );
-		$resolver_tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_PIPELINE,
-		) );
+		$resolver_tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_PIPELINE,
+			)
+		);
 
 		$this->assertSame( $executor_tools, $resolver_tools );
 	}
 
 	public function test_deprecated_manager_delegates_to_resolver(): void {
 		$manager_tools  = ( new ToolManager() )->getAvailableToolsForChat();
-		$resolver_tools = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$resolver_tools = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
 		$this->assertSame( $manager_tools, $resolver_tools );
 	}
@@ -538,14 +590,18 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_no_agent_id_means_no_restrictions(): void {
-		$tools_without = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools_without = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
-		$tools_with_zero = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => 0,
-		) );
+		$tools_with_zero = $this->resolver->resolve(
+			array(
+				'mode'     => ToolPolicyResolver::MODE_CHAT,
+				'agent_id' => 0,
+			)
+		);
 
 		$this->assertSame( $tools_without, $tools_with_zero );
 	}
@@ -553,28 +609,36 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	public function test_agent_without_policy_no_restrictions(): void {
 		$agent_id = $this->createAgentWithPolicy( null );
 
-		$tools_no_agent = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools_no_agent = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
-		$tools_with_agent = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$tools_with_agent = $this->resolver->resolve(
+			array(
+				'mode'     => ToolPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertSame( $tools_no_agent, $tools_with_agent );
 	}
 
 	public function test_agent_deny_mode_removes_listed_tools(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'  => 'deny',
-			'tools' => array( 'web_fetch' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'  => 'deny',
+				'tools' => array( 'web_fetch' ),
+			)
+		);
 
-		$tools = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'     => ToolPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertArrayNotHasKey( 'web_fetch', $tools );
 		// Other tools should still be present.
@@ -582,91 +646,117 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_agent_allow_mode_keeps_only_listed_tools(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'  => 'allow',
-			'tools' => array( 'web_fetch' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'  => 'allow',
+				'tools' => array( 'web_fetch' ),
+			)
+		);
 
-		$tools = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'     => ToolPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertArrayHasKey( 'web_fetch', $tools );
 		$this->assertCount( 1, $tools );
 	}
 
 	public function test_agent_allow_mode_empty_tools_returns_empty(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'  => 'allow',
-			'tools' => array(),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'  => 'allow',
+				'tools' => array(),
+			)
+		);
 
-		$tools = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'     => ToolPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertEmpty( $tools );
 	}
 
 	public function test_agent_deny_mode_empty_tools_no_restrictions(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'  => 'deny',
-			'tools' => array(),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'  => 'deny',
+				'tools' => array(),
+			)
+		);
 
-		$tools_no_agent = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools_no_agent = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
-		$tools_with_agent = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$tools_with_agent = $this->resolver->resolve(
+			array(
+				'mode'     => ToolPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertSame( $tools_no_agent, $tools_with_agent );
 	}
 
 	public function test_nonexistent_agent_id_no_restrictions(): void {
-		$tools_no_agent = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools_no_agent = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
-		$tools_bad_id = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => 999999,
-		) );
+		$tools_bad_id = $this->resolver->resolve(
+			array(
+				'mode'     => ToolPolicyResolver::MODE_CHAT,
+				'agent_id' => 999999,
+			)
+		);
 
 		$this->assertSame( $tools_no_agent, $tools_bad_id );
 	}
 
 	public function test_explicit_deny_overrides_agent_allow_policy(): void {
 		// Agent allows only web_fetch, but explicit deny removes it.
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'  => 'allow',
-			'tools' => array( 'web_fetch' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'  => 'allow',
+				'tools' => array( 'web_fetch' ),
+			)
+		);
 
-		$tools = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-			'deny'     => array( 'web_fetch' ),
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'     => ToolPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+				'deny'     => array( 'web_fetch' ),
+			)
+		);
 
 		$this->assertEmpty( $tools );
 	}
 
 	public function test_agent_policy_applies_to_chat_context(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'  => 'deny',
-			'tools' => array( 'update_flow' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'  => 'deny',
+				'tools' => array( 'update_flow' ),
+			)
+		);
 
-		$tools = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'     => ToolPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertArrayNotHasKey( 'update_flow', $tools );
 		// Other chat tools should still be present.
@@ -674,60 +764,78 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_agent_policy_applies_to_pipeline_context(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'  => 'deny',
-			'tools' => array( 'web_fetch' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'  => 'deny',
+				'tools' => array( 'web_fetch' ),
+			)
+		);
 
-		$tools = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_PIPELINE,
-			'agent_id' => $agent_id,
-		) );
+		$tools = $this->resolver->resolve(
+			array(
+				'mode'     => ToolPolicyResolver::MODE_PIPELINE,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertArrayNotHasKey( 'web_fetch', $tools );
 	}
 
 	public function test_agent_invalid_policy_mode_ignored(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'  => 'invalid_mode',
-			'tools' => array( 'web_fetch' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'  => 'invalid_mode',
+				'tools' => array( 'web_fetch' ),
+			)
+		);
 
-		$tools_no_agent = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools_no_agent = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
-		$tools_with_agent = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$tools_with_agent = $this->resolver->resolve(
+			array(
+				'mode'     => ToolPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertSame( $tools_no_agent, $tools_with_agent );
 	}
 
 	public function test_agent_malformed_policy_ignored(): void {
 		// Missing 'tools' key.
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode' => 'deny',
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode' => 'deny',
+			)
+		);
 
-		$tools_no_agent = $this->resolver->resolve( array(
-			'context' => ToolPolicyResolver::CONTEXT_CHAT,
-		) );
+		$tools_no_agent = $this->resolver->resolve(
+			array(
+				'mode' => ToolPolicyResolver::MODE_CHAT,
+			)
+		);
 
-		$tools_with_agent = $this->resolver->resolve( array(
-			'context'  => ToolPolicyResolver::CONTEXT_CHAT,
-			'agent_id' => $agent_id,
-		) );
+		$tools_with_agent = $this->resolver->resolve(
+			array(
+				'mode'     => ToolPolicyResolver::MODE_CHAT,
+				'agent_id' => $agent_id,
+			)
+		);
 
 		$this->assertSame( $tools_no_agent, $tools_with_agent );
 	}
 
 	public function test_getAgentToolPolicy_returns_valid_policy(): void {
-		$agent_id = $this->createAgentWithPolicy( array(
-			'mode'  => 'deny',
-			'tools' => array( 'web_fetch', 'send_ping' ),
-		) );
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'mode'  => 'deny',
+				'tools' => array( 'web_fetch', 'send_ping' ),
+			)
+		);
 
 		$policy = $this->resolver->getAgentToolPolicy( $agent_id );
 
@@ -751,7 +859,10 @@ class ToolPolicyResolverTest extends WP_UnitTestCase {
 	}
 
 	public function test_applyAgentPolicy_null_returns_unchanged(): void {
-		$tools = array( 'tool_a' => array(), 'tool_b' => array() );
+		$tools = array(
+			'tool_a' => array(),
+			'tool_b' => array(),
+		);
 
 		$result = $this->resolver->applyAgentPolicy( $tools, null );
 

--- a/tests/Unit/AI/Tools/ToolResultFinderTest.php
+++ b/tests/Unit/AI/Tools/ToolResultFinderTest.php
@@ -21,7 +21,7 @@ class ToolResultFinderTest extends TestCase {
 				$logged[] = array(
 					'level'   => $level,
 					'message' => $message,
-					'context' => $context,
+					'mode'     => $context,
 				);
 			},
 			10,
@@ -46,7 +46,7 @@ class ToolResultFinderTest extends TestCase {
 				$logged[] = array(
 					'level'   => $level,
 					'message' => $message,
-					'context' => $context,
+					'mode'     => $context,
 				);
 			},
 			10,


### PR DESCRIPTION
## Summary

Two coordinated refactors landed together because they touch the same surface and should be audited as one:

1. **Consolidate handler tools into the unified registry** — eliminates the legacy `chubes_ai_tools` filter by extending `datamachine_tools` with a `_handler_callable` protocol that accepts runtime handler context.
2. **Rename `contexts` → `modes` throughout the tool + memory + directive registries** — aligns vocabulary with the `AgentMode` concept from #1129. Tools are scoped to **modes**, not contexts. The mental model "exclude memory in system mode" reads naturally in plain English; "exclude memory in system context" does not.

**Zero `chubes_` references anywhere in the codebase after this lands.** Hard cutover matching the #1129 philosophy — no shims, no deprecated aliases.

This is the prerequisite for the wp-ai-client hard cutover (#1027) so that PR becomes a pure LLM-layer swap with no tool-registration concerns mixed in.

---

## Part 1 — Handler tool consolidation

### Before
```
datamachine_tools    — STATIC registry. BaseTool subclasses. Already canonical.
chubes_ai_tools      — RUNTIME GENERATOR. Per-call with handler context.
```

### After
Single `datamachine_tools` registry with two resolution patterns:

```php
// Static tool entry
$tools['my_tool'] = [
    '_callable' => [$this, 'getToolDefinition'],
    'modes'     => ['chat', 'pipeline'],
    'ability'   => 'datamachine/my-ability',
];

// Handler tool entry (replaces chubes_ai_tools)
$tools['__handler_tools_wordpress_publish'] = [
    '_handler_callable' => function($handler_slug, $handler_config, $engine_data) {
        return ['wordpress_publish' => [/* shaped from runtime config */]];
    },
    'handler'      => 'wordpress_publish',           // exact slug match
    // OR
    'handler_types' => ['fetch', 'event_import'],    // cross-cutting (e.g. skip_item)
    'modes'        => ['pipeline'],
    'access_level' => 'admin',
];
```

### Changes
- `ToolManager::resolveHandlerTools()` + `get_handler_tool_entries()` — new
- `ToolPolicyResolver::gatherPipelineTools()` — reads unified registry
- `HandlerRegistrationTrait` — wires `aiToolCallback` into `datamachine_tools`
- `FetchHandler::init()` — registers `skip_item` with `handler_types` matching
- `PipelinesFilters.php` + `Api/Handlers.php` — read unified registry

---

## Part 2 — `contexts` → `modes` rename

### Tool registry
- `'contexts'` key on tool definitions → `'modes'`
- `ToolPolicyResolver::CONTEXT_*` → `MODE_*` (dropped `SURFACE_*` deprecated aliases)
- `filterByContext()` → `filterByMode()`
- `gatherByContext()` → `gatherByMode()`
- `gatherToolsForContext()` → `gatherToolsForMode()`
- `getContexts()` → `getModes()`
- `ToolManager::get_tool_contexts()` → `get_tool_modes()`
- `BaseTool::registerTool($contexts)` → `$modes`
- Resolve args key `'context'` → `'mode'`
- Dropped `'surface'` deprecated arg key
- Filter arg `'datamachine_resolved_tools'` now receives `$mode, $args` instead of `$context_type, $context`

### Memory registry
- `MemoryPolicyResolver::CONTEXT_*` → `MODE_*`
- `MemoryPolicyResolver::getContexts()` → `getModes()`
- `MemoryFileRegistry::get_for_context()` → `get_for_mode()`
- `MemoryFileRegistry::applies_to_context()` → `applies_to_mode()`
- `MemoryFileRegistry::CONTEXT_ALL` → `MODE_ALL`

### Directive registry
- `'contexts'` key on directive entries → `'modes'`
- `PromptBuilder::addDirective($contexts)` → `$modes`
- `PromptBuilder::build($context)` → `$mode`

### Consumers updated
- `AIStep` and `ChatOrchestrator` pass `'mode'` to `ToolPolicyResolver::resolve()`
- `ChatOrchestrator::executeConversationTurn` options key `'context'` → `'mode'`
- 8 directive self-registrations (Core/Client/AgentDaily/AgentMode memory/flow/pipeline/chat directives)
- 5 ability tool registrations (PostQuery, ReplacePostBlocks, GetPostBlocks, EditPostBlocks, InsertContent)
- `CoreMemoryFilesDirective` reads `$payload['agent_mode']`
- `AgentFileAbilities` uses `MemoryFileRegistry::MODE_ALL`

---

## Coordination required (extension repos)

Extension repos that register handler tools via `HandlerRegistrationTrait::registerHandler()` need matching PRs because the callback signature changed:

```php
// Before
function($tools, $handler_slug, $handler_config, $engine_data) {
    if ($handler_slug === 'twitter') {
        $tools['twitter_publish'] = [/* def */];
    }
    return $tools;
}

// After
function($handler_slug, $handler_config, $engine_data) {
    return ['twitter_publish' => [/* def */]];
}
```

Mechanical change — typically shrinks each handler by 3-5 LOC.

**Repos requiring updates:** `data-machine-events`, `data-machine-socials`, `data-machine-business`.

**Hard cutover** — merge core PR + extension PRs together.

---

## Intentionally deferred

Flagged in commit body:

- `Api/Providers.php` REST field still emits `'contexts'` — the React admin consumes `providersData.contexts` + uses `context_models` settings key. Coordinated frontend rename is a separate PR.
- `AIConversationLoop::run()` `$context` parameter kept as-is — it's part of the public `datamachine_conversation_runner` filter contract. Renaming breaks existing adapters.
- Chat sessions DB column named `context` — schema rename needs a `dbDelta` migration. Separate PR.

---

## Tests

New + updated:
- `tests/Unit/AI/Tools/HandlerToolResolutionTest.php` — 9 tests covering exact match, type match, caching, registry introspection, end-to-end pipeline gather
- `tests/Unit/AI/Tools/ToolPolicyResolverTest.php` — updated for `MODE_*` / `'mode'` / `getModes()`; dropped deprecated `SURFACE_*` tests
- `tests/Unit/AI/Memory/MemoryPolicyResolverTest.php` — updated for `MODE_*` / `'mode'` / `getModes()`
- `tests/Unit/AI/Tools/ChatToolsAvailabilityTest.php`, `PipelineToolsAvailabilityTest.php`, `ToolResultFinderTest.php` — swept

## Docs

Sweep across:
- `docs/core-system/handler-registration-trait.md`
- `docs/core-system/tool-execution.md`
- `docs/core-system/memory-policy.md`
- `docs/core-system/ai-directives.md`
- `docs/development/hooks/core-filters.md`
- `docs/ai-tools/tools-overview.md`
- `docs/ai-directives.md`
- `docs/handlers/publish/handlers-overview.md`
- `docs/architecture.md`
- `docs/overview.md`

Zero `chubes_ai_tools` or `CONTEXT_*` references in docs.

---

## Scope

| Component | LOC delta |
|---|---|
| Consolidation (commit 1) | +921/-224 |
| Rename (commit 2) | +1127/-908 |
| **Total** | **+2048/-1132** (net +916 across 40 files) |

Refs #1027.