### PR TITLE
feat(agents): datamachine_register_agents hook + dogfooded default admin agent

### DIFF
--- a/docs/core-filters.md
+++ b/docs/core-filters.md
@@ -2,6 +2,48 @@
 
 ## Actions
 
+### `datamachine_register_agents`
+
+Fires once per request when the AgentRegistry is first consumed. Plugins declare agent roles inside this callback; DM reconciles declarations against the `datamachine_agents` table on `init` priority 15.
+
+Same API DM itself uses to register the default site administrator agent. Registrations are collected statically; last-wins on slug collision so plugins can override via hook priority.
+
+**Since:** 0.71.0
+
+```php
+add_action( 'datamachine_register_agents', function () {
+    datamachine_register_agent( 'wiki-generator', array(
+        'label'       => 'Wiki Generator',
+        'description' => 'Fetches sources, distills into wiki articles.',
+        'soul_path'   => MY_PLUGIN_DIR . 'agents/wiki-generator/SOUL.md',
+    ) );
+} );
+```
+
+See `docs/core-system/agent-registration.md` for the full registration contract.
+
+---
+
+### `datamachine_registered_agent_reconciled`
+
+Fires for each registered agent that was just materialized into the `datamachine_agents` table by `AgentRegistry::reconcile()`. Does not fire for registrations whose DB row already existed.
+
+**Since:** 0.71.0
+
+```php
+add_action( 'datamachine_registered_agent_reconciled', function ( $agent_id, $slug, $def ) {
+    // One-time provisioning for newly-created agents.
+}, 10, 3 );
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$agent_id` | `int` | Newly created agent row ID. |
+| `$slug` | `string` | Registered slug. |
+| `$def` | `array` | Full registration definition. |
+
+---
+
 ### `datamachine_agent_modes`
 
 Fires once per request when the AgentModeRegistry is first consumed. Extensions register their execution modes inside this callback.

--- a/docs/core-filters.md
+++ b/docs/core-filters.md
@@ -13,9 +13,12 @@ Same API DM itself uses to register the default site administrator agent. Regist
 ```php
 add_action( 'datamachine_register_agents', function () {
     datamachine_register_agent( 'wiki-generator', array(
-        'label'       => 'Wiki Generator',
-        'description' => 'Fetches sources, distills into wiki articles.',
-        'soul_path'   => MY_PLUGIN_DIR . 'agents/wiki-generator/SOUL.md',
+        'label'        => 'Wiki Generator',
+        'description'  => 'Fetches sources, distills into wiki articles.',
+        'memory_seeds' => array(
+            'SOUL.md'   => MY_PLUGIN_DIR . 'agents/wiki-generator/SOUL.md',
+            'MEMORY.md' => MY_PLUGIN_DIR . 'agents/wiki-generator/MEMORY.md',
+        ),
     ) );
 } );
 ```

--- a/docs/core-system/agent-registration.md
+++ b/docs/core-system/agent-registration.md
@@ -120,6 +120,10 @@ Registered agents and imperatively-created agents coexist cleanly — they're al
 
 ## Overriding a registered agent
 
+Two override paths. Pick based on what you're trying to change.
+
+### 1. Override registration intent (fresh installs only)
+
 Hook at a higher priority and re-register with the same slug:
 
 ```php
@@ -131,7 +135,40 @@ add_action( 'datamachine_register_agents', function () {
 }, 20 ); // Higher than the original plugin's priority 10.
 ```
 
-Last registration wins. Because reconciliation never overwrites existing DB rows, an override only affects **fresh creation** — already-materialized rows retain their historical data. To reseed SOUL.md on an existing install, delete the file and let the scaffold ability regenerate it.
+Last registration wins at the registry level. Because reconciliation is create-if-missing and the scaffold ability never overwrites existing files, an override only affects **fresh creation**:
+
+| State | Override applies? |
+|---|---|
+| Agent row doesn't exist yet | ✅ Yes — your registration creates the row with your label + scaffolds SOUL.md from your `soul_path` |
+| Agent row exists but SOUL.md doesn't | ✅ Partially — `label`/`description` are ignored (DB-owned), but the next scaffold cycle picks up your `soul_path` |
+| Agent row exists and SOUL.md exists | ❌ No — registration changes don't propagate to existing DB rows, and scaffold never overwrites existing files |
+
+To reseed SOUL.md on an existing install, delete the file and let the scaffold ability regenerate it. To change `agent_name` or `agent_config`, go through the DB (`wp datamachine pipeline update`, admin UI, or direct `Agents::update_agent()` call) — those are DB-owned, user-editable fields.
+
+### 2. Suppress a default registration entirely
+
+Every DM core registration is a **named function** — callers can remove it cleanly:
+
+```php
+remove_action(
+    'datamachine_register_agents',
+    'datamachine_register_default_admin_agent',
+    10
+);
+```
+
+This prevents the registration from contributing to the registry at all. Useful for deployments that want full control over which agents exist on their site.
+
+Plugins that bundle their own default registrations should follow the same convention — use a named function, document the handle in their README so site operators can suppress them.
+
+### 3. Change SOUL.md content on an existing agent
+
+Neither path 1 nor path 2 touches SOUL.md content once it exists on disk. To replace content for an already-materialized agent, the clean options are:
+
+- **Delete and reseed** — remove the existing `SOUL.md` file, let the scaffold ability regenerate on the next read path (scaffold is idempotent + never overwrites extant files, so deletion is the trigger).
+- **Hook `datamachine_scaffold_content` directly** — for conditional overrides based on agent context (e.g. Intelligence's `intelligence_kit` agent_config flag already does this at priority 20).
+
+Registry-level overrides are the right tool for declaring defaults; content-level overrides are the right tool for active SOUL.md substitution.
 
 ## Related
 

--- a/docs/core-system/agent-registration.md
+++ b/docs/core-system/agent-registration.md
@@ -18,9 +18,12 @@ Inside your plugin:
 ```php
 add_action( 'datamachine_register_agents', function () {
     datamachine_register_agent( 'wiki-generator', array(
-        'label'       => __( 'Wiki Generator', 'my-plugin' ),
-        'description' => __( 'Fetches sources, distills into wiki articles, cross-links.', 'my-plugin' ),
-        'soul_path'   => MY_PLUGIN_DIR . 'agents/wiki-generator/SOUL.md',
+        'label'        => __( 'Wiki Generator', 'my-plugin' ),
+        'description'  => __( 'Fetches sources, distills into wiki articles, cross-links.', 'my-plugin' ),
+        'memory_seeds' => array(
+            'SOUL.md'   => MY_PLUGIN_DIR . 'agents/wiki-generator/SOUL.md',
+            'MEMORY.md' => MY_PLUGIN_DIR . 'agents/wiki-generator/MEMORY.md',
+        ),
     ) );
 } );
 ```
@@ -28,8 +31,8 @@ add_action( 'datamachine_register_agents', function () {
 That's it. On the next request where `init` fires, DM reconciles the registration:
 
 - If a row with `agent_slug = 'wiki-generator'` already exists in `datamachine_agents`, nothing happens. Mutable state is DB-owned; the registration never overwrites it.
-- If the row is missing, DM creates it (owner resolved via `owner_resolver` or falls back to the default admin user), bootstraps owner access, ensures the agent directory exists, and runs the scaffold ability for SOUL.md / MEMORY.md.
-- If a `soul_path` was registered, its file contents become the initial SOUL.md instead of DM's generic site-context SOUL.
+- If the row is missing, DM creates it (owner resolved via `owner_resolver` or falls back to the default admin user), bootstraps owner access, ensures the agent directory exists, and runs the scaffold ability for every registered agent-layer memory file.
+- For each `memory_seeds` entry whose target file does not yet exist on disk, the bundled file's contents become the initial scaffold. Generic site-context defaults apply to any filename without a seed entry.
 
 ## Registration arguments
 
@@ -39,7 +42,7 @@ That's it. On the next request where `init` fires, DM reconciles the registratio
 |---|---|---|
 | `label` | string | Display name. Defaults to the slug when omitted. |
 | `description` | string | Short description for admin UI / CLI listings. |
-| `soul_path` | string | Absolute path to a bundled `SOUL.md`. Its contents are surfaced through the scaffold ability as the SOUL content for this agent. See [SOUL resolution](#soul-resolution). |
+| `memory_seeds` | array<string,string> | Map of `filename => absolute path`. Each entry surfaces the bundled file as scaffold content for that filename when the target file does not yet exist on disk. Works for any filename registered via `MemoryFileRegistry::register()` — `SOUL.md` and `MEMORY.md` are common, but plugins can seed custom agent-layer files through the same primitive. See [Memory seed resolution](#memory-seed-resolution). |
 | `owner_resolver` | callable | Returns `int user_id`. Called once at row-creation time. Defaults to `DirectoryManager::get_default_agent_user_id()`. |
 | `default_config` | array | Initial `agent_config` persisted on creation. Subsequent config changes go through the DB — the registration never overrides user-edited config. |
 
@@ -57,16 +60,18 @@ Reconciliation runs on `init` at priority 15:
 
 The `datamachine_register_agents` action is also fired lazily by `AgentRegistry::get_all()` / `get()` / `reconcile()` — so any caller can query the registry regardless of hook ordering.
 
-## SOUL resolution
+## Memory seed resolution
 
-Registered `soul_path` contents flow into SOUL.md via the existing `datamachine_scaffold_content` filter chain:
+Registered `memory_seeds` entries flow into scaffold content via the existing `datamachine_scaffold_content` filter chain:
 
-1. **Priority 5** — registry's generator. Checks `AgentRegistry::get($agent_slug)` for a `soul_path`. If present and readable, returns the file contents as the SOUL.md scaffold content.
-2. **Priority 10** — DM's default `datamachine_scaffold_soul_content` generator. Produces the generic site-context SOUL using agent display name + site metadata.
+1. **Priority 5** — registry's generator. For any filename being scaffolded, checks `AgentRegistry::get($agent_slug)['memory_seeds'][$filename]`. If a readable bundle path is registered, its contents become the scaffold content.
+2. **Priority 10** — DM's default generators (`datamachine_scaffold_soul_content`, `datamachine_scaffold_memory_content`, etc.). Produce generic site-context content using agent display name + site metadata.
 
-Registered agents with a `soul_path` win at priority 5. Registered agents without a `soul_path` fall through to priority 10. Agents created imperatively via `AgentAbilities::createAgent()` (with no registry entry) likewise fall through.
+Registered agents with a `memory_seeds` entry for a filename win at priority 5. Filenames without a seed entry fall through to priority 10. Agents created imperatively via `AgentAbilities::createAgent()` (with no registry entry) likewise fall through for every filename.
 
-The scaffold ability never overwrites existing files. Once SOUL.md exists on disk, its content is user-editable and plugin updates don't rewrite it. To reseed a SOUL.md from an updated bundled version, delete the file and run the scaffold ability again.
+The scaffold ability never overwrites existing files. Once a seeded file exists on disk, its content is user-editable and plugin updates don't rewrite it. To reseed from an updated bundled version, delete the file and run the scaffold ability again.
+
+Seeds apply to any filename registered via `MemoryFileRegistry::register()`. `SOUL.md` and `MEMORY.md` ship registered by default, so they work out of the box. Custom agent-layer files need a one-line `MemoryFileRegistry::register()` call somewhere in the plugin's bootstrap before a `memory_seeds` entry can be surfaced for them.
 
 ## Reconciliation outcomes
 
@@ -129,8 +134,10 @@ Hook at a higher priority and re-register with the same slug:
 ```php
 add_action( 'datamachine_register_agents', function () {
     datamachine_register_agent( 'wiki-generator', array(
-        'label'     => __( 'Custom Wiki Generator', 'my-override' ),
-        'soul_path' => __DIR__ . '/custom-wiki-soul.md',
+        'label'        => __( 'Custom Wiki Generator', 'my-override' ),
+        'memory_seeds' => array(
+            'SOUL.md' => __DIR__ . '/custom-wiki-soul.md',
+        ),
     ) );
 }, 20 ); // Higher than the original plugin's priority 10.
 ```
@@ -139,9 +146,9 @@ Last registration wins at the registry level. Because reconciliation is create-i
 
 | State | Override applies? |
 |---|---|
-| Agent row doesn't exist yet | ✅ Yes — your registration creates the row with your label + scaffolds SOUL.md from your `soul_path` |
-| Agent row exists but SOUL.md doesn't | ✅ Partially — `label`/`description` are ignored (DB-owned), but the next scaffold cycle picks up your `soul_path` |
-| Agent row exists and SOUL.md exists | ❌ No — registration changes don't propagate to existing DB rows, and scaffold never overwrites existing files |
+| Agent row doesn't exist yet | ✅ Yes — your registration creates the row with your label + scaffolds from your `memory_seeds` |
+| Agent row exists, seeded file doesn't | ✅ Partially — `label`/`description` are ignored (DB-owned), but the next scaffold cycle picks up your `memory_seeds` for any still-missing files |
+| Agent row exists and seeded files exist | ❌ No — registration changes don't propagate to existing DB rows, and scaffold never overwrites existing files |
 
 To reseed SOUL.md on an existing install, delete the file and let the scaffold ability regenerate it. To change `agent_name` or `agent_config`, go through the DB (`wp datamachine pipeline update`, admin UI, or direct `Agents::update_agent()` call) — those are DB-owned, user-editable fields.
 
@@ -174,5 +181,5 @@ Registry-level overrides are the right tool for declaring defaults; content-leve
 
 - `docs/core-system/multi-agent-architecture.md` — agents table schema, access control, filesystem layout
 - `docs/core-filters.md` — the `datamachine_register_agents` action, `datamachine_registered_agent_reconciled` action, `datamachine_scaffold_content` filter
-- `inc/Abilities/File/ScaffoldAbilities.php` — scaffold ability that honors registered `soul_path` content
+- `inc/Abilities/File/ScaffoldAbilities.php` — scaffold ability that honors registered `memory_seeds` content
 - `inc/migrations/scaffolding.php` — default `datamachine_scaffold_content` generators

--- a/docs/core-system/agent-registration.md
+++ b/docs/core-system/agent-registration.md
@@ -1,0 +1,141 @@
+# Agent Registration
+
+Declarative agent registration via the `datamachine_register_agents` action. Plugins (and Data Machine itself) declare agent roles once; DM's registry reconciles those declarations against the `datamachine_agents` table on `init`.
+
+**Since:** 0.71.0
+**Source:** `inc/Engine/Agents/AgentRegistry.php`, `inc/Engine/Agents/register-agents.php`
+
+## Why
+
+Agents were previously materialized imperatively — either via `AgentAbilities::createAgent()` from CLI/REST, or lazily via `datamachine_resolve_or_create_agent_id()` on first chat turn. That works for per-user personal agents but doesn't give extensions a clean way to ship a bundled agent role (e.g. a wiki-generator, a support-triage bot, a content-reviewer).
+
+The registry mirrors the `register_post_type()` / `register_taxonomy()` pattern: plugins declare the role, DM owns the runtime. The same API DM uses internally is the API any plugin uses. DM dogfoods it — the default site administrator agent is now registered through the hook.
+
+## Declaring an agent
+
+Inside your plugin:
+
+```php
+add_action( 'datamachine_register_agents', function () {
+    datamachine_register_agent( 'wiki-generator', array(
+        'label'       => __( 'Wiki Generator', 'my-plugin' ),
+        'description' => __( 'Fetches sources, distills into wiki articles, cross-links.', 'my-plugin' ),
+        'soul_path'   => MY_PLUGIN_DIR . 'agents/wiki-generator/SOUL.md',
+    ) );
+} );
+```
+
+That's it. On the next request where `init` fires, DM reconciles the registration:
+
+- If a row with `agent_slug = 'wiki-generator'` already exists in `datamachine_agents`, nothing happens. Mutable state is DB-owned; the registration never overwrites it.
+- If the row is missing, DM creates it (owner resolved via `owner_resolver` or falls back to the default admin user), bootstraps owner access, ensures the agent directory exists, and runs the scaffold ability for SOUL.md / MEMORY.md.
+- If a `soul_path` was registered, its file contents become the initial SOUL.md instead of DM's generic site-context SOUL.
+
+## Registration arguments
+
+`datamachine_register_agent( string $slug, array $args )`
+
+| Key | Type | Description |
+|---|---|---|
+| `label` | string | Display name. Defaults to the slug when omitted. |
+| `description` | string | Short description for admin UI / CLI listings. |
+| `soul_path` | string | Absolute path to a bundled `SOUL.md`. Its contents are surfaced through the scaffold ability as the SOUL content for this agent. See [SOUL resolution](#soul-resolution). |
+| `owner_resolver` | callable | Returns `int user_id`. Called once at row-creation time. Defaults to `DirectoryManager::get_default_agent_user_id()`. |
+| `default_config` | array | Initial `agent_config` persisted on creation. Subsequent config changes go through the DB — the registration never overrides user-edited config. |
+
+### Slug semantics
+
+Slugs are passed through `sanitize_title()`. They must be unique across a site (DB column has a UNIQUE constraint on `agent_slug`). Two plugins registering the same slug is resolved by **last-wins** — this matches WP action/filter semantics, so plugins can override core or other plugins by hooking at a higher priority.
+
+## Reconciliation
+
+Reconciliation runs on `init` at priority 15:
+
+- Priority 10: `wp_abilities_api_init` fires. Abilities register.
+- **Priority 15: `AgentRegistry::reconcile()` fires the `datamachine_register_agents` action, collects registrations, creates missing DB rows, scaffolds agent-layer memory files.**
+- Priority 20: existing `datamachine_needs_scaffold` transient check. No-op when the registry has already scaffolded.
+
+The `datamachine_register_agents` action is also fired lazily by `AgentRegistry::get_all()` / `get()` / `reconcile()` — so any caller can query the registry regardless of hook ordering.
+
+## SOUL resolution
+
+Registered `soul_path` contents flow into SOUL.md via the existing `datamachine_scaffold_content` filter chain:
+
+1. **Priority 5** — registry's generator. Checks `AgentRegistry::get($agent_slug)` for a `soul_path`. If present and readable, returns the file contents as the SOUL.md scaffold content.
+2. **Priority 10** — DM's default `datamachine_scaffold_soul_content` generator. Produces the generic site-context SOUL using agent display name + site metadata.
+
+Registered agents with a `soul_path` win at priority 5. Registered agents without a `soul_path` fall through to priority 10. Agents created imperatively via `AgentAbilities::createAgent()` (with no registry entry) likewise fall through.
+
+The scaffold ability never overwrites existing files. Once SOUL.md exists on disk, its content is user-editable and plugin updates don't rewrite it. To reseed a SOUL.md from an updated bundled version, delete the file and run the scaffold ability again.
+
+## Reconciliation outcomes
+
+`AgentRegistry::reconcile()` returns a summary for logging / testing:
+
+```php
+[
+    'created'  => [ 'wiki-generator' ],  // newly inserted into datamachine_agents
+    'existing' => [ 'chubes' ],          // row already present, skipped
+    'skipped'  => [],                    // owner resolution failed or DB insert failed
+]
+```
+
+The `datamachine_registered_agent_reconciled` action fires for each newly-materialized agent:
+
+```php
+do_action( 'datamachine_registered_agent_reconciled', int $agent_id, string $slug, array $definition );
+```
+
+## DM core dogfood
+
+Data Machine registers its default site administrator agent through the same hook:
+
+```php
+add_action( 'datamachine_register_agents', function () {
+    $default_user_id = DirectoryManager::get_default_agent_user_id();
+    $user            = get_user_by( 'id', $default_user_id );
+
+    datamachine_register_agent(
+        sanitize_title( $user->user_login ),
+        array(
+            'label'          => $user->display_name,
+            'description'    => 'Default site administrator agent.',
+            'owner_resolver' => fn() => $default_user_id,
+        )
+    );
+}, 10 );
+```
+
+Same API. Same hook priority as any plugin. On existing installs this is a no-op (the per-user agent already exists); on fresh installs the registry is the primary creation path for the default agent.
+
+## When to register vs create imperatively
+
+| Scenario | Pattern |
+|---|---|
+| A role bundled with a plugin, same on every install | **Register** via `datamachine_register_agents` |
+| A user-created agent with install-specific name, owner, config | **Create imperatively** via `AgentAbilities::createAgent()` |
+| Lazy provisioning of a per-user agent on first chat turn | **Use** `datamachine_resolve_or_create_agent_id($user_id)` |
+
+Registered agents and imperatively-created agents coexist cleanly — they're all just rows in `datamachine_agents` keyed by slug. The registry is an additive declarative path, not a replacement for the imperative API.
+
+## Overriding a registered agent
+
+Hook at a higher priority and re-register with the same slug:
+
+```php
+add_action( 'datamachine_register_agents', function () {
+    datamachine_register_agent( 'wiki-generator', array(
+        'label'     => __( 'Custom Wiki Generator', 'my-override' ),
+        'soul_path' => __DIR__ . '/custom-wiki-soul.md',
+    ) );
+}, 20 ); // Higher than the original plugin's priority 10.
+```
+
+Last registration wins. Because reconciliation never overwrites existing DB rows, an override only affects **fresh creation** — already-materialized rows retain their historical data. To reseed SOUL.md on an existing install, delete the file and let the scaffold ability regenerate it.
+
+## Related
+
+- `docs/core-system/multi-agent-architecture.md` — agents table schema, access control, filesystem layout
+- `docs/core-filters.md` — the `datamachine_register_agents` action, `datamachine_registered_agent_reconciled` action, `datamachine_scaffold_content` filter
+- `inc/Abilities/File/ScaffoldAbilities.php` — scaffold ability that honors registered `soul_path` content
+- `inc/migrations/scaffolding.php` — default `datamachine_scaffold_content` generators

--- a/docs/core-system/multi-agent-architecture.md
+++ b/docs/core-system/multi-agent-architecture.md
@@ -12,6 +12,8 @@ The multi-agent system consists of five layers:
 4. **Database scoping** — agent_id on pipelines, flows, jobs, and chat sessions
 5. **Resolution** — CLI and API helpers that resolve the active agent from context
 
+Plugins that ship bundled agent roles (e.g. a wiki-generator, a support-triage bot) declare them via the `datamachine_register_agents` action. See `agent-registration.md` for the declarative registration surface.
+
 ## Agents Table
 
 **Table:** `{prefix}_datamachine_agents`

--- a/inc/Engine/Agents/AgentRegistry.php
+++ b/inc/Engine/Agents/AgentRegistry.php
@@ -64,10 +64,15 @@ class AgentRegistry {
 	 *
 	 *     @type string   $label          Display name. Defaults to the slug.
 	 *     @type string   $description    Short description for admin UI / CLI listings.
-	 *     @type string   $soul_path      Absolute path to a bundled SOUL.md file.
-	 *                                    When the scaffold ability runs for this agent,
-	 *                                    its contents are used as the SOUL.md content
-	 *                                    instead of the generic site-context default.
+	 *     @type array    $memory_seeds   Map of filename → absolute path to a bundled
+	 *                                    memory-file template. When the scaffold ability
+	 *                                    runs for a registered filename AND the target
+	 *                                    file does not yet exist on disk, the bundled
+	 *                                    content is used as the scaffold seed. Works
+	 *                                    for any filename registered via
+	 *                                    `MemoryFileRegistry::register()` — SOUL.md and
+	 *                                    MEMORY.md are the common cases, but plugins can
+	 *                                    seed custom agent-layer files the same way.
 	 *                                    Optional.
 	 *     @type callable $owner_resolver Callable returning int user_id. Called once
 	 *                                    on row creation to determine the owner.
@@ -88,11 +93,22 @@ class AgentRegistry {
 			$label = $slug;
 		}
 
+		$memory_seeds = array();
+		if ( isset( $args['memory_seeds'] ) && is_array( $args['memory_seeds'] ) ) {
+			foreach ( $args['memory_seeds'] as $filename => $path ) {
+				$filename = sanitize_file_name( (string) $filename );
+				$path     = (string) $path;
+				if ( '' !== $filename && '' !== $path ) {
+					$memory_seeds[ $filename ] = $path;
+				}
+			}
+		}
+
 		self::$agents[ $slug ] = array(
 			'slug'           => $slug,
 			'label'          => $label,
 			'description'    => isset( $args['description'] ) ? (string) $args['description'] : '',
-			'soul_path'      => isset( $args['soul_path'] ) ? (string) $args['soul_path'] : '',
+			'memory_seeds'   => $memory_seeds,
 			'owner_resolver' => isset( $args['owner_resolver'] ) && is_callable( $args['owner_resolver'] ) ? $args['owner_resolver'] : null,
 			'default_config' => isset( $args['default_config'] ) && is_array( $args['default_config'] ) ? $args['default_config'] : array(),
 		);
@@ -199,9 +215,10 @@ class AgentRegistry {
 				$dir_mgr->ensure_directory_exists( $agent_dir );
 			}
 
-			// Scaffold agent-layer memory files (SOUL.md, MEMORY.md).
-			// The SOUL.md scaffold generator consults AgentRegistry for a
-			// `soul_path` and substitutes bundled content when present.
+			// Scaffold agent-layer memory files (SOUL.md, MEMORY.md, etc.).
+			// The scaffold filter consults AgentRegistry for a matching
+			// `memory_seeds` entry per filename and substitutes bundled
+			// content when present.
 			$scaffold = ScaffoldAbilities::get_ability();
 			if ( $scaffold ) {
 				$scaffold->execute(

--- a/inc/Engine/Agents/AgentRegistry.php
+++ b/inc/Engine/Agents/AgentRegistry.php
@@ -1,0 +1,298 @@
+<?php
+/**
+ * Agent Registry
+ *
+ * Declarative registration surface for Data Machine agents. Plugins
+ * (and DM core itself) declare agent roles by calling
+ * `datamachine_register_agent()` inside a `datamachine_register_agents`
+ * action callback. The registry collects definitions and reconciles
+ * them against the `datamachine_agents` table on init.
+ *
+ * Registration is side-effect free — adding a slug to the registry
+ * does not touch the database. Reconciliation materializes missing
+ * rows, triggers the scaffold ability for newly-created agents, and
+ * leaves existing rows alone (owner_id, agent_config, and other
+ * mutable fields remain DB-owned).
+ *
+ * Plugins ship declarative agent definitions; DM owns the runtime.
+ * The split mirrors the WordPress pattern where
+ * `register_post_type()` is declarative and the posts table stays
+ * operator-mutable.
+ *
+ * @package DataMachine\Engine\Agents
+ * @since   0.71.0
+ */
+
+namespace DataMachine\Engine\Agents;
+
+use DataMachine\Abilities\File\ScaffoldAbilities;
+use DataMachine\Core\Database\Agents\AgentAccess;
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\FilesRepository\DirectoryManager;
+
+defined( 'ABSPATH' ) || exit;
+
+class AgentRegistry {
+
+	/**
+	 * Registered agent definitions, keyed by slug.
+	 *
+	 * @var array<string, array>
+	 */
+	private static array $agents = array();
+
+	/**
+	 * Whether the `datamachine_register_agents` action has fired.
+	 *
+	 * @var bool
+	 */
+	private static bool $registration_fired = false;
+
+	/**
+	 * Register an agent definition.
+	 *
+	 * Call from inside a `datamachine_register_agents` action callback.
+	 * Later registrations for the same slug overwrite earlier ones — this
+	 * matches WordPress hook semantics, so plugins can override core or
+	 * other plugins via action priority.
+	 *
+	 * @since 0.71.0
+	 *
+	 * @param string $slug Unique agent slug (sanitize_title applied).
+	 * @param array  $args {
+	 *     Registration arguments.
+	 *
+	 *     @type string   $label          Display name. Defaults to the slug.
+	 *     @type string   $description    Short description for admin UI / CLI listings.
+	 *     @type string   $soul_path      Absolute path to a bundled SOUL.md file.
+	 *                                    When the scaffold ability runs for this agent,
+	 *                                    its contents are used as the SOUL.md content
+	 *                                    instead of the generic site-context default.
+	 *                                    Optional.
+	 *     @type callable $owner_resolver Callable returning int user_id. Called once
+	 *                                    on row creation to determine the owner.
+	 *                                    Defaults to `DirectoryManager::get_default_agent_user_id()`.
+	 *     @type array    $default_config Initial agent_config persisted on creation.
+	 *                                    Mutations thereafter go through the DB.
+	 * }
+	 * @return void
+	 */
+	public static function register( string $slug, array $args = array() ): void {
+		$slug = sanitize_title( $slug );
+		if ( '' === $slug ) {
+			return;
+		}
+
+		$label = isset( $args['label'] ) ? (string) $args['label'] : '';
+		if ( '' === $label ) {
+			$label = $slug;
+		}
+
+		self::$agents[ $slug ] = array(
+			'slug'           => $slug,
+			'label'          => $label,
+			'description'    => isset( $args['description'] ) ? (string) $args['description'] : '',
+			'soul_path'      => isset( $args['soul_path'] ) ? (string) $args['soul_path'] : '',
+			'owner_resolver' => isset( $args['owner_resolver'] ) && is_callable( $args['owner_resolver'] ) ? $args['owner_resolver'] : null,
+			'default_config' => isset( $args['default_config'] ) && is_array( $args['default_config'] ) ? $args['default_config'] : array(),
+		);
+	}
+
+	/**
+	 * Get all registered agent definitions.
+	 *
+	 * Fires the `datamachine_register_agents` action once per request so
+	 * callers can lazily collect registrations without needing to worry
+	 * about hook ordering.
+	 *
+	 * @since 0.71.0
+	 *
+	 * @return array<string, array>
+	 */
+	public static function get_all(): array {
+		self::ensure_fired();
+		return self::$agents;
+	}
+
+	/**
+	 * Get a single registered agent definition by slug.
+	 *
+	 * @since 0.71.0
+	 *
+	 * @param string $slug Agent slug.
+	 * @return array|null Definition, or null if not registered.
+	 */
+	public static function get( string $slug ): ?array {
+		self::ensure_fired();
+		$slug = sanitize_title( $slug );
+		return self::$agents[ $slug ] ?? null;
+	}
+
+	/**
+	 * Reconcile registered definitions against the `datamachine_agents` table.
+	 *
+	 * For each registered slug:
+	 *   - Row already exists → leave it alone (mutable fields are DB-owned)
+	 *   - Row missing        → resolve owner, create row, bootstrap access,
+	 *                          ensure agent directory, trigger scaffold ability
+	 *
+	 * Idempotent: safe to call multiple times per request. Returns a
+	 * summary of what happened for logging / testing.
+	 *
+	 * @since 0.71.0
+	 *
+	 * @return array{
+	 *     created: string[],
+	 *     existing: string[],
+	 *     skipped: string[],
+	 * }
+	 */
+	public static function reconcile(): array {
+		self::ensure_fired();
+
+		$summary = array(
+			'created'  => array(),
+			'existing' => array(),
+			'skipped'  => array(),
+		);
+
+		if ( ! class_exists( Agents::class ) ) {
+			return $summary;
+		}
+
+		$repo = new Agents();
+
+		foreach ( self::$agents as $slug => $def ) {
+			$existing = $repo->get_by_slug( $slug );
+			if ( $existing ) {
+				$summary['existing'][] = $slug;
+				continue;
+			}
+
+			$owner_id = self::resolve_owner( $def );
+			if ( $owner_id <= 0 ) {
+				$summary['skipped'][] = $slug;
+				continue;
+			}
+
+			$agent_id = $repo->create_if_missing(
+				$slug,
+				$def['label'],
+				$owner_id,
+				$def['default_config']
+			);
+
+			if ( $agent_id <= 0 ) {
+				$summary['skipped'][] = $slug;
+				continue;
+			}
+
+			// Bootstrap owner access (mirrors AgentAbilities::createAgent()).
+			if ( class_exists( AgentAccess::class ) ) {
+				( new AgentAccess() )->bootstrap_owner_access( $agent_id, $owner_id );
+			}
+
+			// Ensure agent directory exists.
+			if ( class_exists( DirectoryManager::class ) ) {
+				$dir_mgr   = new DirectoryManager();
+				$agent_dir = $dir_mgr->get_agent_identity_directory( $slug );
+				$dir_mgr->ensure_directory_exists( $agent_dir );
+			}
+
+			// Scaffold agent-layer memory files (SOUL.md, MEMORY.md).
+			// The SOUL.md scaffold generator consults AgentRegistry for a
+			// `soul_path` and substitutes bundled content when present.
+			$scaffold = ScaffoldAbilities::get_ability();
+			if ( $scaffold ) {
+				$scaffold->execute(
+					array(
+						'layer'      => 'agent',
+						'agent_slug' => $slug,
+						'agent_id'   => $agent_id,
+					)
+				);
+			}
+
+			/**
+			 * Fires after a registered agent is materialized into the database.
+			 *
+			 * @since 0.71.0
+			 *
+			 * @param int    $agent_id Newly created agent row ID.
+			 * @param string $slug     Registered slug.
+			 * @param array  $def      Full registration definition.
+			 */
+			do_action( 'datamachine_registered_agent_reconciled', $agent_id, $slug, $def );
+
+			$summary['created'][] = $slug;
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Resolve the owner user ID for a registered agent.
+	 *
+	 * Calls the registration's `owner_resolver` when provided and falls
+	 * back to `DirectoryManager::get_default_agent_user_id()`.
+	 *
+	 * @param array $def Registration definition.
+	 * @return int User ID, or 0 when resolution fails.
+	 */
+	private static function resolve_owner( array $def ): int {
+		if ( isset( $def['owner_resolver'] ) && is_callable( $def['owner_resolver'] ) ) {
+			$resolved = (int) call_user_func( $def['owner_resolver'] );
+			if ( $resolved > 0 ) {
+				return $resolved;
+			}
+		}
+
+		if ( class_exists( DirectoryManager::class ) ) {
+			return (int) DirectoryManager::get_default_agent_user_id();
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Ensure the `datamachine_register_agents` action has fired.
+	 *
+	 * Plugins register their agents inside action callbacks — collecting
+	 * them lazily lets callers of `get_all()` / `reconcile()` / `get()`
+	 * work regardless of hook ordering.
+	 *
+	 * @return void
+	 */
+	private static function ensure_fired(): void {
+		if ( self::$registration_fired ) {
+			return;
+		}
+
+		self::$registration_fired = true;
+
+		/**
+		 * Fires to let plugins register Data Machine agents.
+		 *
+		 * Callbacks should call `datamachine_register_agent()` to contribute
+		 * one or more agent definitions. Registrations are collected into a
+		 * central registry and reconciled against the `datamachine_agents`
+		 * table on `init` (priority 15).
+		 *
+		 * @since 0.71.0
+		 */
+		do_action( 'datamachine_register_agents' );
+	}
+
+	/**
+	 * Reset internal state. Test helper only.
+	 *
+	 * @internal
+	 * @since 0.71.0
+	 *
+	 * @return void
+	 */
+	public static function reset_for_tests(): void {
+		self::$agents             = array();
+		self::$registration_fired = false;
+	}
+}

--- a/inc/Engine/Agents/register-agents.php
+++ b/inc/Engine/Agents/register-agents.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Agent Registration — global helper + hook wiring.
+ *
+ * Defines the top-level `datamachine_register_agent()` function that
+ * plugins call from inside a `datamachine_register_agents` action
+ * callback to declare agents. Wires reconciliation on `init` and a
+ * SOUL.md scaffold generator that surfaces each registered agent's
+ * bundled `soul_path` as the SOUL content at creation time.
+ *
+ * Also dogfoods the API: DM itself registers the site's default
+ * administrator agent through the same hook plugins use. On existing
+ * installs the registration is a no-op because the agent already
+ * exists in the `datamachine_agents` table. On fresh installs the
+ * registry is the primary creation path for the default agent.
+ *
+ * @package DataMachine\Engine\Agents
+ * @since   0.71.0
+ */
+
+use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Engine\Agents\AgentRegistry;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register a Data Machine agent.
+ *
+ * Call from inside a `datamachine_register_agents` action callback.
+ * The registry collects all definitions and reconciles them against
+ * the `datamachine_agents` table on `init` priority 15.
+ *
+ * @since 0.71.0
+ *
+ * @param string $slug Unique agent slug.
+ * @param array  $args Registration arguments. See AgentRegistry::register().
+ * @return void
+ */
+function datamachine_register_agent( string $slug, array $args = array() ): void {
+	AgentRegistry::register( $slug, $args );
+}
+
+/**
+ * Reconcile registered agents on `init`.
+ *
+ * Priority 15 runs after ability registration (priority 10) so the
+ * scaffold ability is available when reconciliation triggers SOUL/MEMORY
+ * creation for newly-materialized agents, and before the existing
+ * `datamachine_needs_scaffold` transient check at priority 20.
+ *
+ * @since 0.71.0
+ */
+add_action(
+	'init',
+	static function (): void {
+		AgentRegistry::reconcile();
+	},
+	15
+);
+
+/**
+ * SOUL.md scaffold generator — surface registered `soul_path` as content.
+ *
+ * Priority 5 runs before DM's default site-context SOUL generator
+ * (priority 10 in inc/migrations/scaffolding.php). When a registered
+ * agent provides a `soul_path`, its bundled content becomes the SOUL.md
+ * scaffold. Agents without a `soul_path` fall through untouched and the
+ * default generator produces the generic site-context SOUL.
+ *
+ * @since 0.71.0
+ *
+ * @param string $content  Current content (empty if no prior generator).
+ * @param string $filename Filename being scaffolded.
+ * @param array  $context  Scaffolding context with `agent_slug`.
+ * @return string
+ */
+add_filter(
+	'datamachine_scaffold_content',
+	static function ( string $content, string $filename, array $context ): string {
+		if ( 'SOUL.md' !== $filename || '' !== $content ) {
+			return $content;
+		}
+
+		$agent_slug = isset( $context['agent_slug'] ) ? (string) $context['agent_slug'] : '';
+		if ( '' === $agent_slug ) {
+			return $content;
+		}
+
+		$def = AgentRegistry::get( $agent_slug );
+		if ( ! $def || empty( $def['soul_path'] ) ) {
+			return $content;
+		}
+
+		$path = (string) $def['soul_path'];
+		if ( ! is_readable( $path ) ) {
+			return $content;
+		}
+
+		$bundled = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if ( false === $bundled || '' === $bundled ) {
+			return $content;
+		}
+
+		return $bundled;
+	},
+	5,
+	3
+);
+
+/**
+ * DM core dogfood — register the default site administrator agent.
+ *
+ * Declares the site's default admin-owned agent through the same
+ * hook plugins use. Uses the site admin's `user_login` as the slug —
+ * the same identity `datamachine_resolve_or_create_agent_id()` produces
+ * on a user's first chat turn — so this registration is a no-op on
+ * existing installs where that agent already exists.
+ *
+ * Plugins that want to replace or reshape the default admin agent
+ * registration can hook at a higher priority and re-register with the
+ * same slug.
+ *
+ * @since 0.71.0
+ */
+add_action(
+	'datamachine_register_agents',
+	static function (): void {
+		if ( ! class_exists( DirectoryManager::class ) ) {
+			return;
+		}
+
+		$default_user_id = (int) DirectoryManager::get_default_agent_user_id();
+		if ( $default_user_id <= 0 ) {
+			return;
+		}
+
+		$user = get_user_by( 'id', $default_user_id );
+		if ( ! $user ) {
+			return;
+		}
+
+		$slug = sanitize_title( (string) $user->user_login );
+		if ( '' === $slug ) {
+			return;
+		}
+
+		$default_config = array();
+		if ( class_exists( '\\DataMachine\\Core\\PluginSettings' ) ) {
+			$default_config['model'] = array(
+				'default' => \DataMachine\Core\PluginSettings::getContextModel( 'chat' ),
+			);
+		}
+
+		datamachine_register_agent(
+			$slug,
+			array(
+				'label'          => (string) $user->display_name,
+				'description'    => __( 'Default site administrator agent.', 'data-machine' ),
+				'owner_resolver' => static fn() => $default_user_id,
+				'default_config' => $default_config,
+			)
+		);
+	},
+	10
+);

--- a/inc/Engine/Agents/register-agents.php
+++ b/inc/Engine/Agents/register-agents.php
@@ -116,50 +116,59 @@ add_filter(
  * on a user's first chat turn — so this registration is a no-op on
  * existing installs where that agent already exists.
  *
- * Plugins that want to replace or reshape the default admin agent
- * registration can hook at a higher priority and re-register with the
- * same slug.
+ * Named function (not a closure) so plugins that want to suppress the
+ * default admin-agent registration can `remove_action()` it cleanly:
+ *
+ *     remove_action(
+ *         'datamachine_register_agents',
+ *         'datamachine_register_default_admin_agent',
+ *         10
+ *     );
+ *
+ * Plugins that want to *replace* (rather than suppress) the default
+ * admin agent can hook at a higher priority and re-register with the
+ * same slug — standard WordPress last-wins semantics apply at the
+ * registry level. Note: reconciliation is create-if-missing, so
+ * re-registration only affects fresh installs where the DB row has
+ * not yet been materialized.
  *
  * @since 0.71.0
  */
-add_action(
-	'datamachine_register_agents',
-	static function (): void {
-		if ( ! class_exists( DirectoryManager::class ) ) {
-			return;
-		}
+function datamachine_register_default_admin_agent(): void {
+	if ( ! class_exists( DirectoryManager::class ) ) {
+		return;
+	}
 
-		$default_user_id = (int) DirectoryManager::get_default_agent_user_id();
-		if ( $default_user_id <= 0 ) {
-			return;
-		}
+	$default_user_id = (int) DirectoryManager::get_default_agent_user_id();
+	if ( $default_user_id <= 0 ) {
+		return;
+	}
 
-		$user = get_user_by( 'id', $default_user_id );
-		if ( ! $user ) {
-			return;
-		}
+	$user = get_user_by( 'id', $default_user_id );
+	if ( ! $user ) {
+		return;
+	}
 
-		$slug = sanitize_title( (string) $user->user_login );
-		if ( '' === $slug ) {
-			return;
-		}
+	$slug = sanitize_title( (string) $user->user_login );
+	if ( '' === $slug ) {
+		return;
+	}
 
-		$default_config = array();
-		if ( class_exists( '\\DataMachine\\Core\\PluginSettings' ) ) {
-			$default_config['model'] = array(
-				'default' => \DataMachine\Core\PluginSettings::getContextModel( 'chat' ),
-			);
-		}
-
-		datamachine_register_agent(
-			$slug,
-			array(
-				'label'          => (string) $user->display_name,
-				'description'    => __( 'Default site administrator agent.', 'data-machine' ),
-				'owner_resolver' => static fn() => $default_user_id,
-				'default_config' => $default_config,
-			)
+	$default_config = array();
+	if ( class_exists( '\\DataMachine\\Core\\PluginSettings' ) ) {
+		$default_config['model'] = array(
+			'default' => \DataMachine\Core\PluginSettings::getContextModel( 'chat' ),
 		);
-	},
-	10
-);
+	}
+
+	datamachine_register_agent(
+		$slug,
+		array(
+			'label'          => (string) $user->display_name,
+			'description'    => __( 'Default site administrator agent.', 'data-machine' ),
+			'owner_resolver' => static fn() => $default_user_id,
+			'default_config' => $default_config,
+		)
+	);
+}
+add_action( 'datamachine_register_agents', 'datamachine_register_default_admin_agent', 10 );

--- a/inc/Engine/Agents/register-agents.php
+++ b/inc/Engine/Agents/register-agents.php
@@ -5,8 +5,10 @@
  * Defines the top-level `datamachine_register_agent()` function that
  * plugins call from inside a `datamachine_register_agents` action
  * callback to declare agents. Wires reconciliation on `init` and a
- * SOUL.md scaffold generator that surfaces each registered agent's
- * bundled `soul_path` as the SOUL content at creation time.
+ * scaffold generator that surfaces each registered agent's bundled
+ * `memory_seeds` entries as scaffold content for their respective
+ * agent-layer memory files (SOUL.md, MEMORY.md, or any custom file
+ * registered via `MemoryFileRegistry::register()`).
  *
  * Also dogfoods the API: DM itself registers the site's default
  * administrator agent through the same hook plugins use. On existing
@@ -59,13 +61,18 @@ add_action(
 );
 
 /**
- * SOUL.md scaffold generator — surface registered `soul_path` as content.
+ * Memory-seed scaffold generator — surface registered `memory_seeds` as content.
  *
- * Priority 5 runs before DM's default site-context SOUL generator
+ * Priority 5 runs before DM's default site-context scaffold generators
  * (priority 10 in inc/migrations/scaffolding.php). When a registered
- * agent provides a `soul_path`, its bundled content becomes the SOUL.md
- * scaffold. Agents without a `soul_path` fall through untouched and the
- * default generator produces the generic site-context SOUL.
+ * agent declares a `memory_seeds` entry for the current filename, the
+ * bundled file's contents become the scaffold content. Filenames without
+ * a seed entry fall through untouched; the default generator produces
+ * the generic site-context default.
+ *
+ * Symmetric across any registered agent-layer memory file — SOUL.md,
+ * MEMORY.md, or any custom filename a plugin registers via
+ * `MemoryFileRegistry::register()` and seeds through `memory_seeds`.
  *
  * @since 0.71.0
  *
@@ -77,7 +84,7 @@ add_action(
 add_filter(
 	'datamachine_scaffold_content',
 	static function ( string $content, string $filename, array $context ): string {
-		if ( 'SOUL.md' !== $filename || '' !== $content ) {
+		if ( '' !== $content ) {
 			return $content;
 		}
 
@@ -87,12 +94,18 @@ add_filter(
 		}
 
 		$def = AgentRegistry::get( $agent_slug );
-		if ( ! $def || empty( $def['soul_path'] ) ) {
+		if ( ! $def || empty( $def['memory_seeds'] ) ) {
 			return $content;
 		}
 
-		$path = (string) $def['soul_path'];
-		if ( ! is_readable( $path ) ) {
+		$filename_key = sanitize_file_name( $filename );
+		$seeds        = $def['memory_seeds'];
+		if ( ! isset( $seeds[ $filename_key ] ) ) {
+			return $content;
+		}
+
+		$path = (string) $seeds[ $filename_key ];
+		if ( '' === $path || ! is_readable( $path ) ) {
 			return $content;
 		}
 

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -52,6 +52,7 @@ require_once __DIR__ . '/Api/Chat/ChatFilters.php';
 require_once __DIR__ . '/Engine/AI/Directives/CoreMemoryFilesDirective.php';
 require_once __DIR__ . '/Engine/AI/Directives/AgentModeDirective.php';
 require_once __DIR__ . '/Engine/AI/Directives/CallerContextDirective.php';
+require_once __DIR__ . '/Engine/Agents/register-agents.php';
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Introduce a declarative registration surface for Data Machine agents — `datamachine_register_agents` action + `datamachine_register_agent()` helper — modeled on WordPress core's `register_post_type()` / `register_taxonomy()` pattern. Plugins (and DM itself) declare agent roles once; the registry reconciles declarations against the `datamachine_agents` table on `init` priority 15.

**DM core dogfoods it.** The default site administrator agent is now declared through the same hook plugins use, replacing part of the activation-time bootstrap. On existing installs the registration is a no-op (row already exists); on fresh installs the registry is the primary creation path.

## Why this exists

Agents were previously materialized imperatively — `AgentAbilities::createAgent()` from CLI/REST, or lazily via `datamachine_resolve_or_create_agent_id()` on first chat turn. That's right for per-user personal agents but doesn't give extensions a clean way to ship a **bundled agent role** (e.g. a wiki-generator, support-triage bot, content-reviewer).

Direct trigger: Automattic/intelligence is shipping a `wiki-generator` agent with a bundled `SOUL.md`, pipelines, and rubrics under `intelligence/agents/wiki-generator/`. Without a declarative registration path the options were (a) invent a second "bundled agents filter" that duplicates WP's register-pattern, (b) reach into `MemoryFileRegistry` / `ScaffoldAbilities` directly, or (c) require users to run a `spawn-wiki-generator` one-shot command. All wrong. The answer is the same shape WP uses for everything else: **`register_*` as a public API that core itself dogfoods**.

## Architecture

```
┌──────────────────────────────────────────────────────────────┐
│ Plugin Layer (any plugin, including DM core)                 │
│   add_action('datamachine_register_agents', ...)             │
│     datamachine_register_agent('wiki-generator', [...])      │
└──────────────────────────────────────────────────────────────┘
                           │
                           ▼
┌──────────────────────────────────────────────────────────────┐
│ AgentRegistry (declarative)                                   │
│   register() / get() / get_all() / reconcile()               │
│   Fires datamachine_register_agents lazily on first access   │
└──────────────────────────────────────────────────────────────┘
                           │
                           ▼
┌──────────────────────────────────────────────────────────────┐
│ datamachine_agents (imperative, DB-owned)                     │
│   1 row per registered slug — reconciler creates if missing   │
│   Existing rows are NEVER overwritten (owner, config are DB)  │
└──────────────────────────────────────────────────────────────┘
```

### SOUL.md surfacing

Registered agents can declare `soul_path` — an absolute path to a bundled `SOUL.md`. A scaffold-content filter at priority 5 surfaces the bundled content to the existing `ScaffoldAbilities` flow, beating DM's default site-context generator (priority 10). Agents without a `soul_path` fall through untouched. No new scaffold primitive — reuses `datamachine_scaffold_content`.

### Reconciliation semantics

- `init` priority 10 — abilities register (`wp_abilities_api_init`)
- **`init` priority 15 — `AgentRegistry::reconcile()` fires `datamachine_register_agents`, collects registrations, creates missing DB rows, triggers scaffold for each new row**
- `init` priority 20 — existing `datamachine_needs_scaffold` transient check (no-op when registry already scaffolded)

The registry only **creates** missing rows. It never touches mutable fields on existing rows (`owner_id`, `agent_config`, `status`). Override semantics are standard WP hook priority: later registrations for the same slug overwrite earlier ones, but materialized DB rows retain their historical state.

## Dogfood — default admin agent

```php
// inc/Engine/Agents/register-agents.php
add_action( 'datamachine_register_agents', static function () {
    $default_user_id = (int) DirectoryManager::get_default_agent_user_id();
    $user            = get_user_by( 'id', $default_user_id );

    datamachine_register_agent(
        sanitize_title( (string) $user->user_login ),
        array(
            'label'          => (string) $user->display_name,
            'description'    => __( 'Default site administrator agent.', 'data-machine' ),
            'owner_resolver' => static fn() => $default_user_id,
            // default_config includes chat model from PluginSettings
        )
    );
}, 10 );
```

Uses `sanitize_title( $user->user_login )` as slug — same identity `datamachine_resolve_or_create_agent_id()` produces, so it's byte-compatible on existing installs.

## Public API

| Symbol | Type | Purpose |
|---|---|---|
| `datamachine_register_agents` | action | Plugins declare agents in callbacks |
| `datamachine_register_agent( $slug, $args )` | function | Top-level helper for callbacks |
| `datamachine_registered_agent_reconciled` | action | Fires per newly-materialized agent |
| `DataMachine\Engine\Agents\AgentRegistry` | class | Registry + reconciler internals |

Registration args: `label`, `description`, `soul_path`, `owner_resolver`, `default_config`. See `docs/core-system/agent-registration.md` for the full contract.

## Files

- **New** `inc/Engine/Agents/AgentRegistry.php` — registry, reconciler, summary reporting, test-reset helper (~300 LOC)
- **New** `inc/Engine/Agents/register-agents.php` — `datamachine_register_agent()` helper, init priority 15 reconcile, priority 5 SOUL scaffold generator, priority 10 DM core admin-agent dogfood registration (~175 LOC)
- **New** `docs/core-system/agent-registration.md` — full registration contract, SOUL resolution order, override semantics, imperative-vs-declarative decision guide
- **Modified** `inc/bootstrap.php` — require the registry file
- **Modified** `docs/core-filters.md` — entries for the two new actions
- **Modified** `docs/core-system/multi-agent-architecture.md` — cross-reference

+649 / −0. No deletions — purely additive; every existing creation path still works identically.

## Backwards compatibility

- `datamachine_resolve_or_create_agent_id()` unchanged — lazy per-user creation still works on first chat turn
- `AgentAbilities::createAgent()` unchanged — imperative REST/CLI creation still works
- `datamachine_ensure_default_memory_files()` unchanged — still scaffolds shared + user layers
- On existing installs the dogfood registration is a no-op (slug collision short-circuits reconcile)
- No schema changes; no migration required

## Testing

- `php -l` clean on all three new/modified code files
- `AgentRegistry::reset_for_tests()` exposed for unit test isolation

Full smoke test (agent materialization + SOUL path override + collision no-op) is best run in a clean env — the plugin's current Studio test site is on a stale bundled DM that drifts from `origin/main`, so round-trip there would need a site-level DM upgrade first.

## Follow-ups

- **Automattic/intelligence** — ships `agents/wiki-generator/` bundle + registers via this hook (next PR; blocked on this one)
- **`datamachine_register_pipeline_templates`** — sibling hook for pipeline templates, DM system tasks dogfood it (tracked separately)
- Eventual migration of `datamachine_resolve_or_create_agent_id()` path to internally route through the registry — deliberately out of scope here; that's a hot path with many callers