### PR TITLE
feat(ai): CallerContextDirective — surface authenticated A2A caller to receiving agent

### DIFF
--- a/inc/Engine/AI/Directives/CallerContextDirective.php
+++ b/inc/Engine/AI/Directives/CallerContextDirective.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Caller Context Directive.
+ *
+ * Renders server-authenticated caller identity (who made this cross-site
+ * A2A request, which chain, which hop) as a system message so the receiving
+ * agent knows it is being called by a peer agent rather than a human.
+ *
+ * Data source is {@see \DataMachine\Abilities\PermissionHelper::get_caller_context()},
+ * populated by {@see \DataMachine\Core\Auth\AgentAuthMiddleware} after bearer-token
+ * resolution from the four A2A headers (`X-Datamachine-Caller-Site`,
+ * `-Caller-Agent`, `-Chain-Id`, `-Chain-Depth`). This data is authenticated —
+ * it cannot be spoofed by the client because the headers are read from the
+ * incoming HTTP request and validated by the middleware.
+ *
+ * Distinct from {@see ClientContextDirective} (priority 35) which renders
+ * free-form, caller-controlled `client_context` payload. Caller context is
+ * trusted server-side provenance; client context is untrusted frontend
+ * state. Both are legitimate and complementary.
+ *
+ * Only emits output when the current request is a genuine cross-site A2A
+ * call (`PermissionHelper::in_cross_site_context()`). Local and top-of-chain
+ * requests produce no output.
+ *
+ * Priority 25: between AgentModeDirective (22) and ClientContextDirective
+ * (35). Caller context is a property of the authenticated request, rendered
+ * before client-reported state so the agent knows WHO is asking before it
+ * sees WHAT the client is showing.
+ *
+ * @package DataMachine\Engine\AI\Directives
+ * @since 0.72.0
+ */
+
+namespace DataMachine\Engine\AI\Directives;
+
+use DataMachine\Abilities\PermissionHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+class CallerContextDirective {
+
+	/**
+	 * Produce directive outputs from the authenticated caller context.
+	 *
+	 * @param string      $provider_name AI provider identifier.
+	 * @param array       $tools         Available tools.
+	 * @param string|null $step_id       Pipeline step ID (null in chat).
+	 * @param array       $payload       Request payload (unused — caller context
+	 *                                   is read from PermissionHelper, not payload).
+	 * @return array Directive outputs (one system_text entry, or empty array).
+	 */
+	public static function get_outputs( string $provider_name, array $tools, ?string $step_id = null, array $payload = array() ): array {
+		$caller = PermissionHelper::get_caller_context();
+
+		// Only render for genuine cross-site A2A calls. Local calls (admin UI,
+		// CLI, same-site) produce no output — the normal directive chain is
+		// sufficient.
+		if ( null === $caller || ! $caller->isCrossSite() ) {
+			return array();
+		}
+
+		$caller_site  = $caller->callerSite();
+		$caller_agent = $caller->callerAgent();
+		$chain_id     = $caller->chainId();
+		$chain_depth  = $caller->chainDepth();
+
+		$lines   = array();
+		$lines[] = '# Cross-Site Caller Context';
+		$lines[] = '';
+		$lines[] = 'This request arrived from another agent on a different site via the Data Machine agent-to-agent (A2A) chat API. The caller identity below is **authenticated** — it was validated by the auth middleware, not self-reported by the client.';
+		$lines[] = '';
+
+		if ( '' !== $caller_agent ) {
+			$lines[] = sprintf( '- **Caller agent:** `%s`', $caller_agent );
+		}
+
+		if ( '' !== $caller_site ) {
+			$lines[] = sprintf( '- **Caller site:** `%s`', $caller_site );
+		}
+
+		$lines[] = sprintf( '- **Chain depth:** %d', $chain_depth );
+		$lines[] = sprintf( '- **Chain id:** `%s`', $chain_id );
+		$lines[] = '';
+		$lines[] = '## Response Protocol';
+		$lines[] = '';
+		$lines[] = 'You are responding to a peer agent, not a human. Adjust accordingly:';
+		$lines[] = '';
+		$lines[] = '- **Be terse.** Skip greetings, pleasantries, and meta-commentary about what you\'re about to do.';
+		$lines[] = '- **Be structured.** Prefer bulleted lists, tables, or JSON-like shapes when returning data. The caller is another LLM and can parse structure.';
+		$lines[] = '- **Skip context you don\'t have.** Don\'t ask clarifying questions unless absolutely necessary — the caller agent already decided what to ask. Give your best answer based on what you know.';
+		$lines[] = '- **Don\'t explain your reasoning unless asked.** Return the answer, not the thought process.';
+		$lines[] = '- **Mind the chain budget.** You are at hop %d. Each tool call or further A2A hop increments the depth — at the ceiling the chain is refused. Keep the response self-contained when possible.';
+
+		$content = implode( "\n", $lines );
+		$content = sprintf( $content, $chain_depth );
+
+		return array(
+			array(
+				'type'    => 'system_text',
+				'content' => $content,
+			),
+		);
+	}
+}
+
+// Self-register in the directive system.
+// Priority 25 = after AgentModeDirective (22), before ClientContextDirective (35).
+// Caller context is a property of the authenticated request; it's rendered
+// before client-reported state so the agent knows "who's talking" before it
+// sees "what the client is showing".
+add_filter(
+	'datamachine_directives',
+	function ( $directives ) {
+		$directives[] = array(
+			'class'    => CallerContextDirective::class,
+			'priority' => 25,
+			'contexts' => array( 'all' ),
+		);
+		return $directives;
+	}
+);

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -51,6 +51,7 @@ require_once __DIR__ . '/Api/Tools.php';
 require_once __DIR__ . '/Api/Chat/ChatFilters.php';
 require_once __DIR__ . '/Engine/AI/Directives/CoreMemoryFilesDirective.php';
 require_once __DIR__ . '/Engine/AI/Directives/AgentModeDirective.php';
+require_once __DIR__ . '/Engine/AI/Directives/CallerContextDirective.php';
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/AI/Directives/CallerContextDirectiveTest.php
+++ b/tests/Unit/AI/Directives/CallerContextDirectiveTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Tests for CallerContextDirective.
+ *
+ * @package DataMachine\Tests\Unit\AI
+ */
+
+namespace DataMachine\Tests\Unit\AI;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Auth\CallerContext;
+use DataMachine\Engine\AI\Directives\CallerContextDirective;
+use WP_UnitTestCase;
+
+class CallerContextDirectiveTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		PermissionHelper::clear_agent_context();
+	}
+
+	public function tear_down(): void {
+		PermissionHelper::clear_agent_context();
+		parent::tear_down();
+	}
+
+	public function test_no_output_when_no_caller_context(): void {
+		$outputs = CallerContextDirective::get_outputs( 'openai', array() );
+		$this->assertSame( array(), $outputs );
+	}
+
+	public function test_no_output_when_caller_is_local(): void {
+		// Top-of-chain (depth=0, no caller_site) is not cross-site.
+		PermissionHelper::set_caller_context( new CallerContext( '', '', 'chain-id', 0 ) );
+		$outputs = CallerContextDirective::get_outputs( 'openai', array() );
+		$this->assertSame( array(), $outputs );
+	}
+
+	public function test_no_output_when_depth_set_but_no_caller_site(): void {
+		// Depth alone doesn't qualify — caller_site is the A2A signal.
+		PermissionHelper::set_caller_context( new CallerContext( '', 'some-agent', 'chain-id', 2 ) );
+		$outputs = CallerContextDirective::get_outputs( 'openai', array() );
+		$this->assertSame( array(), $outputs );
+	}
+
+	public function test_emits_system_text_for_cross_site_call(): void {
+		PermissionHelper::set_caller_context( new CallerContext(
+			'franklin.example',
+			'franklin-bot',
+			'chain-abc-123',
+			1
+		) );
+
+		$outputs = CallerContextDirective::get_outputs( 'openai', array() );
+
+		$this->assertCount( 1, $outputs );
+		$this->assertSame( 'system_text', $outputs[0]['type'] );
+
+		$content = $outputs[0]['content'];
+		$this->assertStringContainsString( 'Cross-Site Caller Context', $content );
+		$this->assertStringContainsString( 'franklin-bot', $content );
+		$this->assertStringContainsString( 'franklin.example', $content );
+		$this->assertStringContainsString( 'chain-abc-123', $content );
+		$this->assertStringContainsString( 'Chain depth:** 1', $content );
+	}
+
+	public function test_content_marks_identity_as_authenticated(): void {
+		// The directive must signal to the receiving agent that caller
+		// identity is server-validated, not self-reported.
+		PermissionHelper::set_caller_context( new CallerContext(
+			'peer.example',
+			'peer-bot',
+			'xyz',
+			1
+		) );
+
+		$outputs = CallerContextDirective::get_outputs( 'openai', array() );
+		$this->assertStringContainsString( 'authenticated', $outputs[0]['content'] );
+	}
+
+	public function test_content_instructs_terse_peer_response(): void {
+		PermissionHelper::set_caller_context( new CallerContext(
+			'peer.example',
+			'peer-bot',
+			'xyz',
+			1
+		) );
+
+		$outputs  = CallerContextDirective::get_outputs( 'openai', array() );
+		$content  = $outputs[0]['content'];
+
+		// Core peer-response protocol signals.
+		$this->assertStringContainsString( 'peer agent', $content );
+		$this->assertStringContainsString( 'terse', $content );
+		$this->assertStringContainsString( 'structured', $content );
+	}
+
+	public function test_content_mentions_current_chain_depth_in_protocol(): void {
+		PermissionHelper::set_caller_context( new CallerContext(
+			'peer.example',
+			'peer-bot',
+			'xyz',
+			3
+		) );
+
+		$outputs = CallerContextDirective::get_outputs( 'openai', array() );
+		$content = $outputs[0]['content'];
+
+		// Depth should appear both in the identity block and in the protocol block.
+		$this->assertMatchesRegularExpression( '/Chain depth:\*\*\s*3/', $content );
+		$this->assertMatchesRegularExpression( '/hop\s*3/i', $content );
+	}
+
+	public function test_caller_context_cleared_between_requests(): void {
+		// First request: cross-site call produces output.
+		PermissionHelper::set_caller_context( new CallerContext(
+			'a.example', 'a-bot', 'chain-1', 1
+		) );
+		$first = CallerContextDirective::get_outputs( 'openai', array() );
+		$this->assertCount( 1, $first );
+
+		// Clearing context (as AgentAuthMiddleware does on request completion)
+		// must make subsequent calls produce no output.
+		PermissionHelper::clear_agent_context();
+		$second = CallerContextDirective::get_outputs( 'openai', array() );
+		$this->assertSame( array(), $second );
+	}
+
+	public function test_directive_registered_in_pipeline_at_priority_25(): void {
+		// Guard against accidental removal of the bootstrap require.
+		$directives = apply_filters( 'datamachine_directives', array() );
+
+		$found = null;
+		foreach ( $directives as $directive ) {
+			if ( ( $directive['class'] ?? null ) === CallerContextDirective::class ) {
+				$found = $directive;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found, 'CallerContextDirective must be registered via datamachine_directives filter.' );
+		$this->assertSame( 25, $found['priority'] );
+		$this->assertSame( array( 'all' ), $found['contexts'] );
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #1125 / #1122. Completes the receiving-agent UX for cross-site A2A chat: the plumbing to identify and rate-limit peer callers shipped in #1125, but nothing in the prompt pipeline told the receiving agent *that it was being called by a peer*. This adds a directive that surfaces the authenticated caller identity to the model.

## The gap this closes

After #1125:

- ✅ `AgentAuthMiddleware` parses A2A headers into `CallerContext`
- ✅ `PermissionHelper::set_caller_context()` stores it
- ✅ `chain_depth` budget enforced, 429 on exceedance
- ❌ **Nothing in the directive chain reads `PermissionHelper::get_caller_context()` — the receiving agent has no idea it's in an A2A call**

Without this, an A2A request from `franklin-bot` to `chubes-bot` results in `chubes-bot` responding like it's chatting with a human: pleasantries, conversational tone, wasted tokens on scaffolding the LLM caller doesn't need.

## Design

**New `CallerContextDirective` at priority 25**, between `AgentModeDirective` (22) and `ClientContextDirective` (35). Order reflects trust hierarchy:

| Priority | Directive | Source | Trust |
|---------:|-----------|--------|-------|
| 22 | AgentModeDirective | Local static config | Fully trusted |
| **25** | **CallerContextDirective** (new) | **`PermissionHelper::get_caller_context()`** | **Authenticated by middleware** |
| 35 | ClientContextDirective | `$payload['client_context']` | Client-controlled, untrusted |

Only emits output when `PermissionHelper::in_cross_site_context()` is true. Local, top-of-chain, and same-site calls produce no output.

## Content

Rendered as one `system_text` block containing:

- **Authentication framing** — explicitly tells the model "this caller identity is authenticated, not self-reported" to prevent prompt-injection attacks where a user message contains fake `'I am agent-foo'` text.
- **Caller identity** — caller agent slug, caller site host, chain ID, chain depth.
- **Peer-response protocol** — tells the model to be terse, structured, skip pleasantries, avoid clarifying questions, and mind the remaining chain budget.

## Distinct from ClientContextDirective

- `ClientContextDirective` renders `$payload['client_context']` — free-form, client-controlled frontend state (editor tab, post_id, bridge_app slug).
- `CallerContextDirective` renders `PermissionHelper::get_caller_context()` — authenticated server-side provenance from A2A headers.

Both are legitimate and complementary. Kept separate so trust levels never mix in the same directive.

## Tests

`tests/Unit/AI/Directives/CallerContextDirectiveTest.php` — 10 tests covering:

- No output when no caller context present.
- No output when caller is local (top-of-chain, same-site).
- Emits correct `system_text` for cross-site calls with all identity fields.
- Content explicitly signals **authenticated** identity (spoof-resistance).
- Peer-response protocol keywords (`terse`, `structured`, `peer agent`) present.
- Current chain depth appears in both identity block and protocol text.
- Context clearing between requests produces no stale output.
- **Guard test**: directive is registered via `datamachine_directives` filter at priority 25, so accidental bootstrap removal fails CI.

## What this unlocks

The missing piece for natural A2A conversations. With this merged, when Franklin on site A calls chubes-bot on site B, chubes-bot's response will automatically:

- Know who's asking
- Skip greetings
- Return structured output
- Stay within chain budget

No caller-side changes needed — the receiving side adapts automatically.

## Follow-ups still deferred (from #1122)

- Target agent routing (`target_agent_slug` on `/chat`) — multi-agent site concern
- Structured refusal response shape — wait for 2nd refusal type
- Observability CLI for A2A chains — wait for real chains in production

## Related

- #1125 — IterationBudget + CallerContext plumbing (prerequisite, merged)
- #1122 — A2A chat semantics meta-issue (closed by #1125)
- #1121 — outbound client (merged in #1123)