### PR TITLE
fix(import-export): honor step_config on pipeline import (#1133)

### DIFF
--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -121,6 +121,10 @@ class PipelineStepAbilities {
 								$types_list
 							),
 						),
+						'step_config' => array(
+							'type'        => 'object',
+							'description' => __( 'Optional step configuration to seed the new step (e.g. system_prompt, provider, model, label). Fresh pipeline_step_id, execution_order, and step_type are always generated/validated and will override values in step_config.', 'data-machine' ),
+						),
 					),
 				),
 				'output_schema'       => array(
@@ -389,17 +393,37 @@ class PipelineStepAbilities {
 		$current_steps        = $this->db_pipelines->get_pipeline_config( $pipeline_id );
 		$next_execution_order = count( $current_steps );
 
-		$new_step = array(
-			'step_type'        => $step_type,
-			'execution_order'  => $next_execution_order,
-			'pipeline_step_id' => $pipeline_id . '_' . wp_generate_uuid4(),
-			'label'            => $step_type_config['label'] ?? ucfirst( str_replace( '_', ' ', $step_type ) ),
+		// Seed from optional step_config (used by import to restore system_prompt, provider,
+		// model, label, etc.). Fresh pipeline_step_id / execution_order / step_type always
+		// override — the incoming pipeline_step_id is scoped to the exporting install and
+		// would collide here.
+		$seed_config = ( isset( $input['step_config'] ) && is_array( $input['step_config'] ) )
+			? $input['step_config']
+			: array();
+
+		$new_step = array_merge(
+			$seed_config,
+			array(
+				'step_type'        => $step_type,
+				'execution_order'  => $next_execution_order,
+				'pipeline_step_id' => $pipeline_id . '_' . wp_generate_uuid4(),
+			)
 		);
 
+		if ( ! isset( $new_step['label'] ) || '' === $new_step['label'] ) {
+			$new_step['label'] = $step_type_config['label'] ?? ucfirst( str_replace( '_', ' ', $step_type ) );
+		}
+
 		if ( 'ai' === $step_type ) {
-			$pipeline_defaults    = PluginSettings::getContextModel( 'pipeline' );
-			$new_step['provider'] = $pipeline_defaults['provider'];
-			$new_step['model']    = $pipeline_defaults['model'];
+			if ( empty( $new_step['provider'] ) || empty( $new_step['model'] ) ) {
+				$pipeline_defaults = PluginSettings::getContextModel( 'pipeline' );
+				if ( empty( $new_step['provider'] ) ) {
+					$new_step['provider'] = $pipeline_defaults['provider'];
+				}
+				if ( empty( $new_step['model'] ) ) {
+					$new_step['model'] = $pipeline_defaults['model'];
+				}
+			}
 		}
 
 		$pipeline_config = array();

--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -59,6 +59,18 @@ class ImportExport {
 			$step_position = $cols[2];
 			$step_type     = $cols[3];
 			$step_config   = json_decode( $cols[4], true );
+			if ( ! is_array( $step_config ) ) {
+				$step_config = array();
+			}
+			$flow_id_col = $cols[5] ?? '';
+
+			// Flow-specific rows (flow_id present) are emitted per-flow by the exporter and
+			// share the same step_type/step_config as their parent pipeline row. Flow + handler
+			// restoration is deferred to a follow-up (see issue #1133 step 2). Skip here to
+			// avoid adding duplicate steps when a pipeline has handler-bearing flows.
+			if ( '' !== (string) $flow_id_col ) {
+				continue;
+			}
 
 			if ( ! isset( $processed[ $pipeline_name ] ) ) {
 				$existing_id = $this->find_pipeline_by_name( $pipeline_name );
@@ -100,6 +112,7 @@ class ImportExport {
 						array(
 							'pipeline_id' => $processed[ $pipeline_name ],
 							'step_type'   => $step_type,
+							'step_config' => $step_config,
 						)
 					);
 				}

--- a/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
@@ -202,6 +202,96 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 		$this->assertEquals( 'upsert', $result['step_type'] );
 	}
 
+	public function test_add_pipeline_step_with_step_config_seeds_fields(): void {
+		$seed_config = array(
+			'system_prompt' => 'You are a careful summarizer.',
+			'label'         => 'Imported AI Step',
+			'provider'      => 'openai',
+			'model'         => 'gpt-5.4',
+			'custom_field'  => 'preserved',
+		);
+
+		$result = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'ai',
+				'step_config' => $seed_config,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$steps = $this->step_abilities->executeGetPipelineSteps(
+			array( 'pipeline_step_id' => $result['pipeline_step_id'] )
+		);
+
+		$this->assertTrue( $steps['success'] );
+		$this->assertCount( 1, $steps['steps'] );
+		$stored = $steps['steps'][0];
+
+		$this->assertSame( 'You are a careful summarizer.', $stored['system_prompt'] );
+		$this->assertSame( 'Imported AI Step', $stored['label'] );
+		$this->assertSame( 'openai', $stored['provider'] );
+		$this->assertSame( 'gpt-5.4', $stored['model'] );
+		$this->assertSame( 'preserved', $stored['custom_field'] );
+		$this->assertSame( 'ai', $stored['step_type'] );
+		$this->assertSame( $result['pipeline_step_id'], $stored['pipeline_step_id'] );
+		$this->assertEquals( 0, $stored['execution_order'] );
+	}
+
+	public function test_add_pipeline_step_with_step_config_overrides_identity_fields(): void {
+		$seed_config = array(
+			'pipeline_step_id' => 'legacy-id-from-another-install',
+			'execution_order'  => 99,
+			'step_type'        => 'publish',
+			'label'            => 'Kept Label',
+		);
+
+		$result = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'fetch',
+				'step_config' => $seed_config,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'fetch', $result['step_type'] );
+		$this->assertNotSame( 'legacy-id-from-another-install', $result['pipeline_step_id'] );
+		$this->assertStringStartsWith( $this->test_pipeline_id . '_', $result['pipeline_step_id'] );
+
+		$steps  = $this->step_abilities->executeGetPipelineSteps(
+			array( 'pipeline_step_id' => $result['pipeline_step_id'] )
+		);
+		$stored = $steps['steps'][0];
+
+		$this->assertSame( 'fetch', $stored['step_type'] );
+		$this->assertSame( 'Kept Label', $stored['label'] );
+		$this->assertEquals( 0, $stored['execution_order'] );
+		$this->assertNotSame( 'legacy-id-from-another-install', $stored['pipeline_step_id'] );
+	}
+
+	public function test_add_pipeline_step_ai_type_without_step_config_uses_defaults(): void {
+		$result = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'ai',
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$steps  = $this->step_abilities->executeGetPipelineSteps(
+			array( 'pipeline_step_id' => $result['pipeline_step_id'] )
+		);
+		$stored = $steps['steps'][0];
+
+		$this->assertArrayHasKey( 'provider', $stored );
+		$this->assertArrayHasKey( 'model', $stored );
+		$this->assertNotEmpty( $stored['provider'] );
+		$this->assertNotEmpty( $stored['model'] );
+	}
+
 	public function test_add_pipeline_step_invalid_type(): void {
 		$result = $this->step_abilities->executeAddPipelineStep(
 			array(

--- a/tests/Unit/Engine/ImportExportStepConfigTest.php
+++ b/tests/Unit/Engine/ImportExportStepConfigTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * ImportExport — step_config round-trip tests.
+ *
+ * Verifies that `datamachine/import-pipelines` honors the step_config column
+ * emitted by `datamachine/export-pipelines` (issue #1133 step 1). Flow and
+ * handler_config restoration is explicitly out of scope.
+ *
+ * @package DataMachine\Tests\Unit\Engine
+ */
+
+namespace DataMachine\Tests\Unit\Engine;
+
+use DataMachine\Abilities\PipelineAbilities;
+use DataMachine\Abilities\PipelineStepAbilities;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Engine\Actions\ImportExport;
+use WP_UnitTestCase;
+
+class ImportExportStepConfigTest extends WP_UnitTestCase {
+
+	private ImportExport $import_export;
+	private PipelineAbilities $pipeline_abilities;
+	private PipelineStepAbilities $step_abilities;
+	private Pipelines $db_pipelines;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$this->import_export      = new ImportExport();
+		$this->pipeline_abilities = new PipelineAbilities();
+		$this->step_abilities     = new PipelineStepAbilities();
+		$this->db_pipelines       = new Pipelines();
+	}
+
+	public function tear_down(): void {
+		parent::tear_down();
+	}
+
+	public function test_import_restores_step_config_from_export(): void {
+		// Build a source pipeline with a configured AI step.
+		$created            = $this->pipeline_abilities->executeCreatePipeline(
+			array( 'pipeline_name' => 'Round Trip Source' )
+		);
+		$source_pipeline_id = $created['pipeline_id'];
+
+		$add_result = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $source_pipeline_id,
+				'step_type'   => 'ai',
+			)
+		);
+		$source_step_id = $add_result['pipeline_step_id'];
+
+		// Overlay system_prompt + arbitrary custom field directly onto pipeline_config so the
+		// exporter serializes them. provider/model already live on the step from add-step.
+		$pipeline = $this->db_pipelines->get_pipeline( $source_pipeline_id );
+		$pipeline_config = $pipeline['pipeline_config'] ?? array();
+		$pipeline_config[ $source_step_id ]['system_prompt'] = 'You are a careful summarizer.';
+		$pipeline_config[ $source_step_id ]['label']         = 'My AI';
+		$pipeline_config[ $source_step_id ]['provider']      = 'openai';
+		$pipeline_config[ $source_step_id ]['model']         = 'gpt-5.4';
+		$pipeline_config[ $source_step_id ]['custom_field']  = 'passthrough';
+		$this->db_pipelines->update_pipeline(
+			$source_pipeline_id,
+			array( 'pipeline_config' => $pipeline_config )
+		);
+
+		// Export.
+		$csv = $this->import_export->handle_export( 'pipelines', array( $source_pipeline_id ) );
+		$this->assertIsString( $csv );
+		$this->assertNotEmpty( $csv );
+
+		// Rename the pipeline in the CSV so re-import creates a distinct pipeline instead of
+		// appending to the source (find_pipeline_by_name matches by name).
+		$csv_renamed = str_replace( 'Round Trip Source', 'Round Trip Target', $csv );
+
+		// Import.
+		$result = $this->import_export->handle_import( 'pipelines', $csv_renamed );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'imported', $result );
+		$this->assertCount( 1, $result['imported'] );
+
+		$imported_pipeline_id = $result['imported'][0];
+		$this->assertNotSame( $source_pipeline_id, $imported_pipeline_id );
+
+		// The imported pipeline should have exactly one step, with all step_config fields
+		// preserved and a freshly-generated pipeline_step_id.
+		$steps_result = $this->step_abilities->executeGetPipelineSteps(
+			array( 'pipeline_id' => $imported_pipeline_id )
+		);
+
+		$this->assertTrue( $steps_result['success'] );
+		$this->assertCount( 1, $steps_result['steps'] );
+
+		$imported_step = $steps_result['steps'][0];
+		$this->assertSame( 'ai', $imported_step['step_type'] );
+		$this->assertSame( 'You are a careful summarizer.', $imported_step['system_prompt'] );
+		$this->assertSame( 'My AI', $imported_step['label'] );
+		$this->assertSame( 'openai', $imported_step['provider'] );
+		$this->assertSame( 'gpt-5.4', $imported_step['model'] );
+		$this->assertSame( 'passthrough', $imported_step['custom_field'] );
+
+		// Fresh pipeline_step_id scoped to the new pipeline — NOT the source's id.
+		$this->assertNotSame( $source_step_id, $imported_step['pipeline_step_id'] );
+		$this->assertStringStartsWith( $imported_pipeline_id . '_', $imported_step['pipeline_step_id'] );
+	}
+
+	public function test_import_does_not_duplicate_steps_when_flow_rows_present(): void {
+		// Hand-craft a CSV that mirrors what the exporter emits for a pipeline with one step
+		// and one flow that has a handler configured. Today the flow-row branch of the CSV is
+		// deferred (step 2), but we still must not create duplicate steps from those rows.
+		$step_config_json = wp_json_encode(
+			array(
+				'step_type'        => 'fetch',
+				'execution_order'  => 0,
+				'pipeline_step_id' => '999_legacy-uuid',
+				'label'            => 'Fetch',
+			)
+		);
+		$settings_json    = wp_json_encode(
+			array(
+				'handler_slugs'   => array( 'rss' ),
+				'handler_configs' => array( 'rss' => array( 'feed_url' => 'https://example.com/feed' ) ),
+			)
+		);
+
+		$csv  = "pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,handler,settings\n";
+		$csv .= '999,"Flow Row Guard Test",0,fetch,' . $this->csv_field( $step_config_json ) . ',,,,' . "\n";
+		$csv .= '999,"Flow Row Guard Test",0,fetch,' . $this->csv_field( $step_config_json ) . ',42,"Default Flow",rss,' . $this->csv_field( $settings_json ) . "\n";
+
+		$result = $this->import_export->handle_import( 'pipelines', $csv );
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result['imported'] );
+
+		$steps_result = $this->step_abilities->executeGetPipelineSteps(
+			array( 'pipeline_id' => $result['imported'][0] )
+		);
+
+		$this->assertTrue( $steps_result['success'] );
+		$this->assertCount( 1, $steps_result['steps'], 'Flow rows must not trigger duplicate add-step calls.' );
+		$this->assertSame( 'Fetch', $steps_result['steps'][0]['label'] );
+	}
+
+	/**
+	 * Mirror the ImportExport::array_to_csv quoting rules for a single field.
+	 */
+	private function csv_field( string $value ): string {
+		if ( false !== strpos( $value, ',' ) || false !== strpos( $value, '"' ) || false !== strpos( $value, "\n" ) ) {
+			return '"' . str_replace( '"', '""', $value ) . '"';
+		}
+		return $value;
+	}
+}


### PR DESCRIPTION
## Summary

Fixes step 1 of #1133 — pipeline import is lossy, `step_config` is parsed out of the CSV and thrown away. Round-tripping a configured pipeline through `datamachine/export-pipelines` → `datamachine/import-pipelines` produced a skeleton with the right step count and types but zero configuration (no `system_prompt`, no `provider`/`model`, no `label`, no extension fields).

This PR restores **step-level** round-trip. Flow / handler restoration and the CSV → JSON migration remain follow-ups.

## Changes

**`inc/Abilities/PipelineStepAbilities.php`** — `datamachine/add-pipeline-step` gains an optional `step_config` input:

- When present, it seeds the new `pipeline_config` entry.
- Freshly-generated `pipeline_step_id`, re-derived `execution_order`, and the validated `step_type` always override the seed — the incoming `pipeline_step_id` is scoped to the exporting install's pipeline and would collide.
- No field allowlist. All other keys (system_prompt, provider, model, label, disabled_tools, plus anything an extension attaches) pass through unmodified; step-type owners decide shape.
- AI provider/model defaults and the label default only apply when `step_config` doesn't already supply them.

**`inc/Engine/Actions/ImportExport.php`** — `handle_import()`:

- Passes the decoded `step_config` through to `datamachine/add-pipeline-step`.
- Guards against non-array JSON decodes.
- Skips flow-specific rows (`flow_id != ''`) so pipelines with handler-bearing flows don't produce duplicate steps while flow restoration is still deferred. The exporter already writes one "pipeline structure" row per step plus one "flow + step" row per handler-bearing flow/step pair — today's code treats both as step-add candidates.

## Tests

- `PipelineStepAbilitiesTest` — `step_config` seeding (all fields round-trip), identity-field override (fresh `pipeline_step_id` wins over a legacy one supplied via `step_config`), and the AI default fallback when no `step_config` is passed.
- `ImportExportStepConfigTest` (new) — full export→import round-trip of `system_prompt` / `provider` / `model` / `label` / a custom extension field, plus a flow-row guard proving the handler-bearing flow rows don't trigger duplicate step creation.

## Out of scope

Explicitly deferred (issue #1133, step 2 / step 3):

- **Flow + handler restoration.** The flow-row branch of the CSV is skipped on import today. Recreating flows and writing `handler_slugs` / `handler_configs` keyed by freshly-generated `flow_step_id`s deserves its own design pass.
- **Secret scrubbing** for `handler_configs` (API keys, OAuth tokens). Orthogonal to the lossiness — whatever policy emerges applies equally to the current and post-fix import.
- **CSV → JSON format.** Not a blocker for the correctness fix.

Refs: #1133