### PR TITLE
fix(import-export): restore flows + handler_configs on pipeline import (#1133 step 2)

### DIFF
--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -28,7 +28,18 @@ class ImportExport {
 	}
 
 	/**
-	 * Handle datamachine_import action
+	 * Handle datamachine_import action.
+	 *
+	 * Two-pass CSV import:
+	 *   Pass 1 — pipeline-structure rows (flow_id empty): create pipelines and add steps
+	 *            with their full step_config (#1133 step 1).
+	 *   Pass 2 — flow-step rows (flow_id present): ensure target flows exist, then write
+	 *            handler_slugs + handler_configs into each flow_config entry keyed by the
+	 *            freshly-generated flow_step_id (#1133 step 2).
+	 *
+	 * NOTE on secrets: handler_configs is restored verbatim. Any auth tokens / API keys in
+	 * the exported CSV will land in the imported flow's config. A scrub-or-reference policy
+	 * is orthogonal to the lossiness fix and is tracked separately.
 	 */
 	public function handle_import( $type, $data ) {
 		if ( ! current_user_can( 'manage_options' ) ) {
@@ -41,81 +52,95 @@ class ImportExport {
 			return false;
 		}
 
-		$rows               = str_getcsv( $data, "\n" );
+		$parsed_rows = $this->parse_csv_rows( $data );
+
 		$imported_pipelines = array();
-		$processed          = array();
+		// pipeline_name => imported pipeline_id.
+		$pipeline_ids_by_name = array();
+		// [pipeline_name][(int) step_position] => imported pipeline_step_id.
+		$step_id_map = array();
+		// [pipeline_name][source_flow_id] => imported flow_id.
+		$flow_id_map = array();
 
-		foreach ( $rows as $index => $row ) {
-			if ( 0 === $index ) {
+		// Pass 1: pipelines + steps.
+		foreach ( $parsed_rows as $row ) {
+			if ( '' !== $row['flow_id'] ) {
 				continue;
 			}
 
-			$cols = str_getcsv( $row );
-			if ( count( $cols ) < 5 ) {
+			$pipeline_name = $row['pipeline_name'];
+
+			if ( ! isset( $pipeline_ids_by_name[ $pipeline_name ] ) ) {
+				$pipeline_id = $this->ensure_pipeline( $pipeline_name );
+				if ( ! $pipeline_id ) {
+					continue;
+				}
+				$pipeline_ids_by_name[ $pipeline_name ] = $pipeline_id;
+				$imported_pipelines[]                   = $pipeline_id;
+			}
+
+			if ( ! $row['step_type'] ) {
 				continue;
 			}
 
-			$pipeline_name = $cols[1];
-			$step_position = $cols[2];
-			$step_type     = $cols[3];
-			$step_config   = json_decode( $cols[4], true );
-			if ( ! is_array( $step_config ) ) {
-				$step_config = array();
+			$pipeline_step_id = $this->add_step_to_pipeline(
+				$pipeline_ids_by_name[ $pipeline_name ],
+				$row['step_type'],
+				$row['step_config']
+			);
+			if ( $pipeline_step_id ) {
+				$step_id_map[ $pipeline_name ][ $row['step_position'] ] = $pipeline_step_id;
 			}
-			$flow_id_col = $cols[5] ?? '';
+		}
 
-			// Flow-specific rows (flow_id present) are emitted per-flow by the exporter and
-			// share the same step_type/step_config as their parent pipeline row. Flow + handler
-			// restoration is deferred to a follow-up (see issue #1133 step 2). Skip here to
-			// avoid adding duplicate steps when a pipeline has handler-bearing flows.
-			if ( '' !== (string) $flow_id_col ) {
+		// Pass 2: flows + handler configs.
+		foreach ( $parsed_rows as $row ) {
+			if ( '' === $row['flow_id'] ) {
 				continue;
 			}
 
-			if ( ! isset( $processed[ $pipeline_name ] ) ) {
-				$existing_id = $this->find_pipeline_by_name( $pipeline_name );
-
-				if ( ! $existing_id ) {
-					$ability = wp_get_ability( 'datamachine/create-pipeline' );
-
-					if ( ! $ability ) {
-						do_action( 'datamachine_log', 'error', 'Import: create-pipeline ability not available' );
-						continue;
-					}
-
-					$result = $ability->execute(
-						array(
-							'pipeline_name' => $pipeline_name,
-							'flow_config'   => array( 'flow_name' => 'Default Flow' ),
-						)
-					);
-
-					if ( is_wp_error( $result ) ) {
-						do_action( 'datamachine_log', 'error', 'Import: create-pipeline failed: ' . $result->get_error_message() );
-						continue;
-					}
-
-					$existing_id = $result['success'] ? ( $result['pipeline_id'] ?? false ) : false;
-				}
-
-				if ( $existing_id ) {
-					$processed[ $pipeline_name ] = $existing_id;
-					$imported_pipelines[]        = $existing_id;
-				}
+			$pipeline_name = $row['pipeline_name'];
+			if ( ! isset( $pipeline_ids_by_name[ $pipeline_name ] ) ) {
+				continue;
 			}
 
-			if ( isset( $processed[ $pipeline_name ] ) && $step_type ) {
-				$add_step_ability = wp_get_ability( 'datamachine/add-pipeline-step' );
+			$imported_pipeline_id = $pipeline_ids_by_name[ $pipeline_name ];
+			$source_flow_id       = $row['flow_id'];
+			$flow_name            = '' !== $row['flow_name'] ? $row['flow_name'] : 'Flow';
 
-				if ( $add_step_ability ) {
-					$add_step_ability->execute(
-						array(
-							'pipeline_id' => $processed[ $pipeline_name ],
-							'step_type'   => $step_type,
-							'step_config' => $step_config,
-						)
-					);
+			if ( ! isset( $flow_id_map[ $pipeline_name ][ $source_flow_id ] ) ) {
+				$new_flow_id = $this->ensure_flow( $imported_pipeline_id, $flow_name );
+				if ( ! $new_flow_id ) {
+					continue;
 				}
+				$flow_id_map[ $pipeline_name ][ $source_flow_id ] = $new_flow_id;
+			}
+
+			$imported_flow_id = $flow_id_map[ $pipeline_name ][ $source_flow_id ];
+			$pipeline_step_id = $step_id_map[ $pipeline_name ][ $row['step_position'] ] ?? null;
+			if ( ! $pipeline_step_id ) {
+				continue;
+			}
+
+			$handler_slugs   = $row['settings']['handler_slugs'] ?? array();
+			$handler_configs = $row['settings']['handler_configs'] ?? array();
+			if ( empty( $handler_slugs ) && '' !== $row['handler'] ) {
+				$handler_slugs = array( $row['handler'] );
+			}
+
+			$this->restore_flow_step_handlers(
+				$imported_flow_id,
+				$pipeline_step_id,
+				$handler_slugs,
+				$handler_configs
+			);
+		}
+
+		// Ensure every imported pipeline has at least one flow (fallback for exports with
+		// no flow rows — e.g. a pipeline containing only AI steps with no handlers).
+		foreach ( $pipeline_ids_by_name as $pipeline_name => $imported_pipeline_id ) {
+			if ( ! isset( $flow_id_map[ $pipeline_name ] ) ) {
+				$this->ensure_flow( $imported_pipeline_id, 'Default Flow' );
 			}
 		}
 
@@ -129,6 +154,218 @@ class ImportExport {
 
 		do_action( 'datamachine_log', 'debug', 'Pipeline import completed', array( 'count' => count( $result['imported'] ) ) );
 		return $result;
+	}
+
+	/**
+	 * Parse the import CSV into a normalized row list.
+	 *
+	 * @param string $data Raw CSV content.
+	 * @return array<int, array{
+	 *     pipeline_name:string, step_position:int, step_type:string, step_config:array,
+	 *     flow_id:string, flow_name:string, handler:string, settings:array
+	 * }>
+	 */
+	private function parse_csv_rows( string $data ): array {
+		$rows   = str_getcsv( $data, "\n" );
+		$parsed = array();
+
+		foreach ( $rows as $index => $row ) {
+			if ( 0 === $index ) {
+				continue;
+			}
+
+			$cols = str_getcsv( $row );
+			if ( count( $cols ) < 5 ) {
+				continue;
+			}
+
+			$step_config = json_decode( $cols[4], true );
+			if ( ! is_array( $step_config ) ) {
+				$step_config = array();
+			}
+
+			$settings_raw = $cols[8] ?? '';
+			$settings     = json_decode( $settings_raw, true );
+			if ( ! is_array( $settings ) ) {
+				$settings = array();
+			}
+
+			$parsed[] = array(
+				'pipeline_name' => (string) $cols[1],
+				'step_position' => (int) $cols[2],
+				'step_type'     => (string) $cols[3],
+				'step_config'   => $step_config,
+				'flow_id'       => (string) ( $cols[5] ?? '' ),
+				'flow_name'     => (string) ( $cols[6] ?? '' ),
+				'handler'       => (string) ( $cols[7] ?? '' ),
+				'settings'      => $settings,
+			);
+		}
+
+		return $parsed;
+	}
+
+	/**
+	 * Ensure a pipeline with the given name exists; return its id.
+	 *
+	 * Reuses any existing pipeline with a matching name. When a new pipeline is created we
+	 * deliberately skip auto-flow-creation (no flow_config) — flows are created in pass 2
+	 * from the CSV, with a final "Default Flow" fallback for exports that carry no flow rows.
+	 */
+	private function ensure_pipeline( string $pipeline_name ): ?int {
+		$existing_id = $this->find_pipeline_by_name( $pipeline_name );
+		if ( $existing_id ) {
+			return (int) $existing_id;
+		}
+
+		$ability = wp_get_ability( 'datamachine/create-pipeline' );
+		if ( ! $ability ) {
+			do_action( 'datamachine_log', 'error', 'Import: create-pipeline ability not available' );
+			return null;
+		}
+
+		$result = $ability->execute(
+			array(
+				'pipeline_name' => $pipeline_name,
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			do_action( 'datamachine_log', 'error', 'Import: create-pipeline failed: ' . $result->get_error_message() );
+			return null;
+		}
+
+		if ( empty( $result['success'] ) || empty( $result['pipeline_id'] ) ) {
+			return null;
+		}
+
+		return (int) $result['pipeline_id'];
+	}
+
+	/**
+	 * Add a step to a pipeline with its full step_config; return the new pipeline_step_id.
+	 */
+	private function add_step_to_pipeline( int $pipeline_id, string $step_type, array $step_config ): ?string {
+		$ability = wp_get_ability( 'datamachine/add-pipeline-step' );
+		if ( ! $ability ) {
+			return null;
+		}
+
+		$result = $ability->execute(
+			array(
+				'pipeline_id' => $pipeline_id,
+				'step_type'   => $step_type,
+				'step_config' => $step_config,
+			)
+		);
+
+		if ( is_wp_error( $result ) || empty( $result['success'] ) || empty( $result['pipeline_step_id'] ) ) {
+			return null;
+		}
+
+		return (string) $result['pipeline_step_id'];
+	}
+
+	/**
+	 * Ensure a flow matching the given name exists on the pipeline; return its id.
+	 *
+	 * Reuses an existing flow by exact name match (case-sensitive) so repeated imports of
+	 * the same export don't spawn duplicate flows. Otherwise creates a new flow.
+	 */
+	private function ensure_flow( int $pipeline_id, string $flow_name ): ?int {
+		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
+
+		$existing = $db_flows->get_flows_for_pipeline( $pipeline_id );
+		foreach ( $existing as $flow ) {
+			if ( isset( $flow['flow_name'] ) && $flow['flow_name'] === $flow_name ) {
+				return (int) $flow['flow_id'];
+			}
+		}
+
+		$create_flow = wp_get_ability( 'datamachine/create-flow' );
+		if ( ! $create_flow ) {
+			do_action( 'datamachine_log', 'error', 'Import: create-flow ability not available' );
+			return null;
+		}
+
+		$result = $create_flow->execute(
+			array(
+				'pipeline_id' => $pipeline_id,
+				'flow_name'   => $flow_name,
+			)
+		);
+
+		if ( is_wp_error( $result ) || empty( $result['success'] ) || empty( $result['flow_id'] ) ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Import: failed to create flow',
+				array(
+					'pipeline_id' => $pipeline_id,
+					'flow_name'   => $flow_name,
+				)
+			);
+			return null;
+		}
+
+		return (int) $result['flow_id'];
+	}
+
+	/**
+	 * Write handler_slugs and handler_configs into the flow_config entry for this step.
+	 *
+	 * `create-flow` (and the step-sync pipeline) already populate the flow_config entry
+	 * keyed by flow_step_id with structural fields (step_type, pipeline_step_id, etc.).
+	 * This overlays the handler fields verbatim — no handler validation, no auth rewiring,
+	 * no secret scrubbing. Secret policy is a separate concern (see #1133).
+	 */
+	private function restore_flow_step_handlers(
+		int $flow_id,
+		string $pipeline_step_id,
+		array $handler_slugs,
+		array $handler_configs
+	): bool {
+		if ( empty( $handler_slugs ) && empty( $handler_configs ) ) {
+			return false;
+		}
+
+		$flow_step_id = apply_filters( 'datamachine_generate_flow_step_id', '', $pipeline_step_id, $flow_id );
+		if ( empty( $flow_step_id ) ) {
+			return false;
+		}
+
+		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
+		$flow     = $db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return false;
+		}
+
+		$flow_config = $flow['flow_config'] ?? array();
+		if ( ! isset( $flow_config[ $flow_step_id ] ) ) {
+			// Defensive seed — should have been created by create-flow's step sync, but
+			// fall back to a minimal entry so the handler restore still lands.
+			$flow_config[ $flow_step_id ] = array(
+				'flow_step_id'     => $flow_step_id,
+				'pipeline_step_id' => $pipeline_step_id,
+				'flow_id'          => $flow_id,
+			);
+		}
+
+		if ( ! empty( $handler_slugs ) ) {
+			$flow_config[ $flow_step_id ]['handler_slugs'] = array_values( $handler_slugs );
+			$flow_config[ $flow_step_id ]['handler']       = $handler_slugs[0] ?? null;
+		}
+
+		if ( ! empty( $handler_configs ) ) {
+			$flow_config[ $flow_step_id ]['handler_configs'] = $handler_configs;
+		}
+
+		$flow_config[ $flow_step_id ]['enabled'] = true;
+
+		return (bool) $db_flows->update_flow(
+			$flow_id,
+			array( 'flow_config' => $flow_config )
+		);
 	}
 
 	/**

--- a/tests/Unit/Engine/ImportExportStepConfigTest.php
+++ b/tests/Unit/Engine/ImportExportStepConfigTest.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * ImportExport — step_config round-trip tests.
+ * ImportExport — pipeline round-trip tests.
  *
- * Verifies that `datamachine/import-pipelines` honors the step_config column
- * emitted by `datamachine/export-pipelines` (issue #1133 step 1). Flow and
- * handler_config restoration is explicitly out of scope.
+ * Covers the two lossy-import fixes from issue #1133:
+ *   - Step 1: step_config restoration (system_prompt, provider, model, label, extensions).
+ *   - Step 2: flow + handler_slugs / handler_configs restoration.
  *
  * @package DataMachine\Tests\Unit\Engine
  */
@@ -13,6 +13,7 @@ namespace DataMachine\Tests\Unit\Engine;
 
 use DataMachine\Abilities\PipelineAbilities;
 use DataMachine\Abilities\PipelineStepAbilities;
+use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Engine\Actions\ImportExport;
 use WP_UnitTestCase;
@@ -23,6 +24,7 @@ class ImportExportStepConfigTest extends WP_UnitTestCase {
 	private PipelineAbilities $pipeline_abilities;
 	private PipelineStepAbilities $step_abilities;
 	private Pipelines $db_pipelines;
+	private Flows $db_flows;
 
 	public function set_up(): void {
 		parent::set_up();
@@ -34,6 +36,7 @@ class ImportExportStepConfigTest extends WP_UnitTestCase {
 		$this->pipeline_abilities = new PipelineAbilities();
 		$this->step_abilities     = new PipelineStepAbilities();
 		$this->db_pipelines       = new Pipelines();
+		$this->db_flows           = new Flows();
 	}
 
 	public function tear_down(): void {
@@ -111,8 +114,8 @@ class ImportExportStepConfigTest extends WP_UnitTestCase {
 
 	public function test_import_does_not_duplicate_steps_when_flow_rows_present(): void {
 		// Hand-craft a CSV that mirrors what the exporter emits for a pipeline with one step
-		// and one flow that has a handler configured. Today the flow-row branch of the CSV is
-		// deferred (step 2), but we still must not create duplicate steps from those rows.
+		// and one flow that has a handler configured. Flow rows share step_type/step_config
+		// with their parent pipeline row and must NOT trigger duplicate add-step calls.
 		$step_config_json = wp_json_encode(
 			array(
 				'step_type'        => 'fetch',
@@ -143,6 +146,124 @@ class ImportExportStepConfigTest extends WP_UnitTestCase {
 		$this->assertTrue( $steps_result['success'] );
 		$this->assertCount( 1, $steps_result['steps'], 'Flow rows must not trigger duplicate add-step calls.' );
 		$this->assertSame( 'Fetch', $steps_result['steps'][0]['label'] );
+	}
+
+	public function test_import_restores_flow_and_handler_config_from_export(): void {
+		// Build a source pipeline with a fetch step and a flow configured with an RSS handler.
+		$created            = $this->pipeline_abilities->executeCreatePipeline(
+			array(
+				'pipeline_name' => 'Flow Round Trip Source',
+				'flow_config'   => array( 'flow_name' => 'Morning Flow' ),
+			)
+		);
+		$source_pipeline_id = $created['pipeline_id'];
+		$source_flow_id     = $created['flow_id'] ?? null;
+		$this->assertNotNull( $source_flow_id );
+
+		$add_result     = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $source_pipeline_id,
+				'step_type'   => 'fetch',
+			)
+		);
+		$source_step_id = $add_result['pipeline_step_id'];
+
+		// Directly seed the flow_config with handler_slugs + handler_configs for this step.
+		$source_flow      = $this->db_flows->get_flow( (int) $source_flow_id );
+		$flow_config      = $source_flow['flow_config'] ?? array();
+		$source_flow_step = apply_filters( 'datamachine_generate_flow_step_id', '', $source_step_id, (int) $source_flow_id );
+		$flow_config[ $source_flow_step ]['handler_slugs']   = array( 'rss' );
+		$flow_config[ $source_flow_step ]['handler_configs'] = array(
+			'rss' => array(
+				'feed_url' => 'https://example.com/feed',
+				'max_items' => 25,
+			),
+		);
+		$flow_config[ $source_flow_step ]['enabled'] = true;
+		$this->db_flows->update_flow( (int) $source_flow_id, array( 'flow_config' => $flow_config ) );
+
+		// Export.
+		$csv = $this->import_export->handle_export( 'pipelines', array( $source_pipeline_id ) );
+		$this->assertIsString( $csv );
+		$this->assertStringContainsString( 'Morning Flow', $csv );
+		$this->assertStringContainsString( 'rss', $csv );
+
+		// Rename to force a distinct target pipeline.
+		$csv_renamed = str_replace( 'Flow Round Trip Source', 'Flow Round Trip Target', $csv );
+
+		$result = $this->import_export->handle_import( 'pipelines', $csv_renamed );
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result['imported'] );
+
+		$imported_pipeline_id = (int) $result['imported'][0];
+		$this->assertNotSame( $source_pipeline_id, $imported_pipeline_id );
+
+		// The imported pipeline should have exactly one flow, and it should be named after
+		// the exported flow (not the legacy "Default Flow" fallback).
+		$imported_flows = $this->db_flows->get_flows_for_pipeline( $imported_pipeline_id );
+		$this->assertCount( 1, $imported_flows, 'Import should not leave an orphan Default Flow.' );
+		$imported_flow = $imported_flows[0];
+		$this->assertSame( 'Morning Flow', $imported_flow['flow_name'] );
+
+		// Imported step id.
+		$steps_result     = $this->step_abilities->executeGetPipelineSteps(
+			array( 'pipeline_id' => $imported_pipeline_id )
+		);
+		$imported_step_id = $steps_result['steps'][0]['pipeline_step_id'];
+
+		// Compute the target flow_step_id and verify handler_slugs + handler_configs round-trip.
+		$imported_flow_step_id = apply_filters(
+			'datamachine_generate_flow_step_id',
+			'',
+			$imported_step_id,
+			(int) $imported_flow['flow_id']
+		);
+		$this->assertNotEmpty( $imported_flow_step_id );
+		$this->assertNotSame( $source_flow_step, $imported_flow_step_id );
+
+		$imported_flow_config = $imported_flow['flow_config'] ?? array();
+		$this->assertArrayHasKey( $imported_flow_step_id, $imported_flow_config );
+		$imported_step = $imported_flow_config[ $imported_flow_step_id ];
+
+		$this->assertSame( array( 'rss' ), $imported_step['handler_slugs'] );
+		$this->assertSame(
+			array(
+				'feed_url'  => 'https://example.com/feed',
+				'max_items' => 25,
+			),
+			$imported_step['handler_configs']['rss']
+		);
+		$this->assertTrue( $imported_step['enabled'] );
+	}
+
+	public function test_import_without_flow_rows_creates_default_flow_fallback(): void {
+		// Pipeline with only an AI step and no handler-bearing flow — export emits no flow
+		// rows, so import should still leave the pipeline with at least one flow.
+		$created            = $this->pipeline_abilities->executeCreatePipeline(
+			array( 'pipeline_name' => 'Empty Flow Source' )
+		);
+		$source_pipeline_id = $created['pipeline_id'];
+		$this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $source_pipeline_id,
+				'step_type'   => 'ai',
+			)
+		);
+
+		// Delete any auto-created flows on the source so the export has no flow rows.
+		foreach ( $this->db_flows->get_flows_for_pipeline( $source_pipeline_id ) as $flow ) {
+			$this->db_flows->delete_flow( (int) $flow['flow_id'] );
+		}
+
+		$csv         = $this->import_export->handle_export( 'pipelines', array( $source_pipeline_id ) );
+		$csv_renamed = str_replace( 'Empty Flow Source', 'Empty Flow Target', $csv );
+
+		$result = $this->import_export->handle_import( 'pipelines', $csv_renamed );
+		$this->assertCount( 1, $result['imported'] );
+
+		$imported_flows = $this->db_flows->get_flows_for_pipeline( (int) $result['imported'][0] );
+		$this->assertCount( 1, $imported_flows, 'Exports with no flow rows should still produce one default flow on import.' );
+		$this->assertSame( 'Default Flow', $imported_flows[0]['flow_name'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes **step 2** of #1133 — the flow-row branch of the export CSV is now actually processed on import. Before this, `flow_id` / `flow_name` / `handler` / `settings` columns were parsed and skipped, so imported pipelines had correct steps but no handler-bearing flows. All RSS URLs, publish targets, handler configs, and flow names were dropped on round-trip.

Stacked on top of #1135 (step 1, step_config restoration). Retarget to \`main\` once #1135 merges.

## Changes

**`inc/Engine/Actions/ImportExport.php`** — \`handle_import\` becomes a two-pass parse:

- **Pass 1** — pipeline-structure rows (\`flow_id\` empty): create pipelines, add steps with their full \`step_config\` (as in step 1). Track \`(pipeline_name, step_position) → imported pipeline_step_id\`.
- **Pass 2** — flow-step rows (\`flow_id\` present): ensure the target flow exists on the imported pipeline (match by name first, create via \`datamachine/create-flow\` otherwise). Track \`(pipeline_name, source_flow_id) → imported flow_id\`. Compute the imported \`flow_step_id\` via the existing \`datamachine_generate_flow_step_id\` filter (single source of truth, matching the export side). Overlay \`handler_slugs\` + \`handler_configs\` onto the \`flow_config\` entry that \`create-flow\`'s step-sync already populated.
- \`create-pipeline\` no longer auto-creates a \`Default Flow\` on import — pass 2 owns flow creation, which avoids orphan \`Default Flow\` rows when the export carries custom-named flows. A final fallback still creates one \`Default Flow\` for any imported pipeline that got no flow rows (pipelines with only AI steps that carry no handlers), preserving that common shape.
- Extracted helpers: \`parse_csv_rows\`, \`ensure_pipeline\`, \`add_step_to_pipeline\`, \`ensure_flow\`, \`restore_flow_step_handlers\`.

## Tests

- \`test_import_restores_flow_and_handler_config_from_export\` — full round-trip: build a pipeline with a fetch step + a custom-named \`Morning Flow\` with an RSS handler config (\`feed_url\`, \`max_items\`), export, re-import under a new pipeline name, assert the imported flow is named \`Morning Flow\` (no orphan Default Flow), handler_slugs match, handler_configs are restored verbatim, and the freshly-generated \`flow_step_id\` is distinct from the source's.
- \`test_import_without_flow_rows_creates_default_flow_fallback\` — exports a pipeline whose flows have been deleted, verifies the import fallback still yields exactly one \`Default Flow\`.
- Existing step-1 tests still pass (step_config restoration, flow-row dedupe guard).

## Out of scope

- **Secrets policy.** \`handler_configs\` is restored verbatim — auth tokens / API keys in exported CSV land on the target install. Tracked as the \"open question: secrets\" section in #1133. Candidates: scrub on export, reference-by-handle into the target install's auth registry, or explicit \`--include-secrets\` opt-in. Orthogonal to the lossiness fix.
- **Re-import duplicate guard.** Re-importing the same CSV into the same install still appends duplicate steps (pre-existing — \`find_pipeline_by_name\` reuses the pipeline but \`add-pipeline-step\` runs per row). Can be addressed with an idempotency check keyed on \`(pipeline_name, step_position)\`, but that's a separate concern.
- **CSV → JSON format.** Step 3 from #1133, still not a blocker.

Refs: #1133