### PR TITLE
refactor(ai): rename context → mode in model-selection cluster (Phase 1 of #1138)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Data Machine ships its own multi-turn conversation loop and uses it by default. 
 ```php
 add_filter(
     'datamachine_conversation_runner',
-    function ( $result, $messages, $tools, $provider, $model, $context, $payload, $max_turns, $single_turn ) {
+    function ( $result, $messages, $tools, $provider, $model, $mode, $payload, $max_turns, $single_turn ) {
         // Return an array matching AIConversationLoop::execute()'s shape to
         // replace the built-in loop, or null to let Data Machine run it.
         return my_runtime_run( ... );

--- a/data-machine.php
+++ b/data-machine.php
@@ -653,7 +653,7 @@ function datamachine_resolve_or_create_agent_id( int $user_id ): int {
 
 	$agent_slug  = sanitize_title( (string) $user->user_login );
 	$agent_name  = (string) $user->display_name;
-	$agent_model = \DataMachine\Core\PluginSettings::getContextModel( 'chat' );
+	$agent_model = \DataMachine\Core\PluginSettings::getModelForMode( 'chat' );
 
 	return $agents_repo->create_if_missing(
 		$agent_slug,

--- a/docs/core-filters.md
+++ b/docs/core-filters.md
@@ -94,8 +94,6 @@ Central registry for execution modes. Extensions register modes; the settings UI
 | `get_for_settings(): array` | Get modes formatted for the admin UI. |
 | `reset(): void` | Clear all registrations (testing only). |
 
-**Deprecated:** `ContextRegistry` is a class alias for `AgentModeRegistry`.
-
 ---
 
 ### `AgentModeDirective`

--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -122,7 +122,7 @@ $result = AIConversationLoop::run(
     $tools,           // Available tools for AI
     $provider,        // AI provider (openai, anthropic, etc.)
     $model,           // AI model identifier
-    $context,         // 'pipeline' or 'chat'
+    $mode,            // Execution mode: 'pipeline' or 'chat'
     $payload,         // Agent-specific payload data
     $max_turns,       // Maximum conversation turns (default: 25)
     $single_turn      // Execute exactly one turn (default: false)
@@ -200,12 +200,17 @@ apply_filters(
     $tools,
     $provider,
     $model,
-    $context,
+    $mode,
     $payload,
     $max_turns,
     $single_turn
 );
 ```
+
+> The 5th positional argument was previously documented as `$context`; it was renamed to
+> `$mode` in v0.68.0 for vocabulary alignment with the AgentMode concept (see
+> [#1138](https://github.com/Extra-Chill/data-machine/issues/1138)). The filter is positional,
+> so existing adapters continue to receive the same value by position without any changes.
 
 Return an array matching `AIConversationLoop::execute()`'s documented return
 shape to replace the built-in loop. Return `null` (the default) to let Data
@@ -232,9 +237,9 @@ honored.
 ```php
 add_filter(
     'datamachine_conversation_runner',
-    function ( $result, $messages, $tools, $provider, $model, $context, $payload, $max_turns, $single_turn ) {
-        // Only take over for a specific context.
-        if ( 'chat' !== $context ) {
+    function ( $result, $messages, $tools, $provider, $model, $mode, $payload, $max_turns, $single_turn ) {
+        // Only take over for a specific execution mode.
+        if ( 'chat' !== $mode ) {
             return $result;
         }
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -1117,7 +1117,7 @@ $final_response = \DataMachine\Engine\AI\AIConversationLoop::run(
     array $tools,
     string $provider,
     string $model,
-    string $context,         // 'pipeline', 'chat', etc.
+    string $mode,            // Execution mode: 'pipeline', 'chat', 'system', etc.
     array $payload = [],
     int $max_turns = 25,
     bool $single_turn = false
@@ -1135,9 +1135,14 @@ apply_filters(
     'datamachine_conversation_runner',
     null,           // Return non-null array to short-circuit
     $messages, $tools, $provider, $model,
-    $context, $payload, $max_turns, $single_turn
+    $mode, $payload, $max_turns, $single_turn
 );
 ```
+
+> The 5th positional argument was previously documented as `$context`; it was renamed
+> to `$mode` in v0.68.0 for vocabulary alignment with the AgentMode concept (see
+> [#1138](https://github.com/Extra-Chill/data-machine/issues/1138)). The filter signature
+> is positional, so existing adapters are unaffected.
 
 Return an array matching `execute()`'s documented return shape to replace the
 built-in loop. Return `null` (the default) to let Data Machine run the

--- a/inc/Abilities/Chat/SendMessageAbility.php
+++ b/inc/Abilities/Chat/SendMessageAbility.php
@@ -173,7 +173,7 @@ class SendMessageAbility {
 		$model    = $input['model'] ?? '';
 
 		if ( empty( $provider ) || empty( $model ) ) {
-			$agent_config = PluginSettings::resolveModelForAgentContext( $agent_id ?: null, 'chat' );
+			$agent_config = PluginSettings::resolveModelForAgentMode( $agent_id ?: null, 'chat' );
 			if ( empty( $provider ) ) {
 				$provider = $agent_config['provider'];
 			}

--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -417,7 +417,7 @@ class InternalLinkingAbilities {
 
 		$user_id         = get_current_user_id();
 		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
-		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 

--- a/inc/Abilities/Media/AltTextAbilities.php
+++ b/inc/Abilities/Media/AltTextAbilities.php
@@ -146,7 +146,7 @@ class AltTextAbilities {
 
 		$user_id         = get_current_user_id();
 		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
-		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 
@@ -362,7 +362,7 @@ class AltTextAbilities {
 
 		$user_id         = get_current_user_id();
 		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
-		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 

--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -282,7 +282,7 @@ class ImageGenerationAbilities {
 	public static function refine_prompt( string $raw_prompt, string $post_context = '', array $config = array() ): ?string {
 		$user_id         = get_current_user_id();
 		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
-		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 
@@ -386,7 +386,7 @@ class ImageGenerationAbilities {
 		// Must have a DM AI provider configured.
 		$user_id         = get_current_user_id();
 		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
-		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 
 		return ! empty( $system_defaults['provider'] ) && ! empty( $system_defaults['model'] );
 	}

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -416,7 +416,7 @@ class PipelineStepAbilities {
 
 		if ( 'ai' === $step_type ) {
 			if ( empty( $new_step['provider'] ) || empty( $new_step['model'] ) ) {
-				$pipeline_defaults = PluginSettings::getContextModel( 'pipeline' );
+				$pipeline_defaults = PluginSettings::getModelForMode( 'pipeline' );
 				if ( empty( $new_step['provider'] ) ) {
 					$new_step['provider'] = $pipeline_defaults['provider'];
 				}

--- a/inc/Abilities/SEO/MetaDescriptionAbilities.php
+++ b/inc/Abilities/SEO/MetaDescriptionAbilities.php
@@ -144,7 +144,7 @@ class MetaDescriptionAbilities {
 
 		$user_id         = get_current_user_id();
 		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
-		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -498,7 +498,7 @@ class SystemAbilities {
 	}
 
 	private static function generateAITitle( string $first_user_message, ?string $first_assistant_response ): ?string {
-		$chat_defaults = PluginSettings::resolveModelForAgentContext( null, 'chat' );
+		$chat_defaults = PluginSettings::resolveModelForAgentMode( null, 'chat' );
 		$provider      = $chat_defaults['provider'];
 		$model         = $chat_defaults['model'];
 

--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -318,7 +318,7 @@ class Chat {
 		$prompt  = sanitize_textarea_field( wp_unslash( $request->get_param( 'prompt' ) ?? '' ) );
 		$context = $request->get_param( 'context' ) ?? array();
 
-		$agent_config = PluginSettings::resolveModelForAgentContext( $agent_id, 'chat' );
+		$agent_config = PluginSettings::resolveModelForAgentMode( $agent_id, 'chat' );
 		$provider     = $agent_config['provider'];
 		$model        = $agent_config['model'];
 

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -329,7 +329,7 @@ class ChatOrchestrator {
 		}
 
 		$messages             = $session['messages'] ?? array();
-		$chat_defaults        = PluginSettings::resolveModelForAgentContext( (int) ( $session['agent_id'] ?? 0 ), 'chat' );
+		$chat_defaults        = PluginSettings::resolveModelForAgentMode( (int) ( $session['agent_id'] ?? 0 ), 'chat' );
 		$provider             = $session['provider'] ?? $chat_defaults['provider'];
 		$model                = $session['model'] ?? $chat_defaults['model'];
 		$message_count_before = count( $messages );

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -111,36 +111,41 @@ class PluginSettings {
 	}
 
 	/**
-	 * Get provider and model for a specific execution context.
+	 * Get provider and model for a specific execution mode.
 	 *
 	 * Resolution order:
-	 * 1. Per-site context-specific override from context_models setting (or legacy agent_models)
-	 * 2. Network context-specific override from network context_models (or legacy agent_models)
+	 * 1. Per-site mode-specific override from context_models setting (or legacy agent_models)
+	 * 2. Network mode-specific override from network context_models (or legacy agent_models)
 	 * 3. Per-site global default_provider / default_model
 	 * 4. Network global default_provider / default_model
 	 * 5. Empty strings
 	 *
-	 * @param string $context Execution context: 'chat', 'pipeline', 'system'.
+	 * Note: the underlying setting key is still `context_models` — that rename is
+	 * scheduled for Phase 2 of #1138 (needs migration + React admin coordination).
+	 *
+	 * @since 0.68.0 Renamed from getContextModel().
+	 *
+	 * @param string $mode Execution mode: 'chat', 'pipeline', 'system'.
 	 * @return array{ provider: string, model: string }
 	 */
-	public static function getContextModel( string $context ): array {
-		// Step 1: Check per-site context-specific override.
-		$site_context_models = self::get( 'context_models', self::get( 'agent_models', array() ) );
-		$site_context_config = $site_context_models[ $context ] ?? array();
+	public static function getModelForMode( string $mode ): array {
+		// Step 1: Check per-site mode-specific override.
+		$site_mode_models = self::get( 'context_models', self::get( 'agent_models', array() ) );
+		$site_mode_config = $site_mode_models[ $mode ] ?? array();
 
-		$provider = ! empty( $site_context_config['provider'] ) ? $site_context_config['provider'] : '';
-		$model    = ! empty( $site_context_config['model'] ) ? $site_context_config['model'] : '';
+		$provider = ! empty( $site_mode_config['provider'] ) ? $site_mode_config['provider'] : '';
+		$model    = ! empty( $site_mode_config['model'] ) ? $site_mode_config['model'] : '';
 
-		// Step 2: Fall back to network context-specific override.
+		// Step 2: Fall back to network mode-specific override.
 		if ( empty( $provider ) || empty( $model ) ) {
-			$network_context_models = NetworkSettings::get( 'context_models', NetworkSettings::get( 'agent_models', array() ) );
-			$network_context_config = $network_context_models[ $context ] ?? array();
+			$network_mode_models = NetworkSettings::get( 'context_models', NetworkSettings::get( 'agent_models', array() ) );
+			$network_mode_config = $network_mode_models[ $mode ] ?? array();
 
-			if ( empty( $provider ) && ! empty( $network_context_config['provider'] ) ) {
-				$provider = $network_context_config['provider'];
+			if ( empty( $provider ) && ! empty( $network_mode_config['provider'] ) ) {
+				$provider = $network_mode_config['provider'];
 			}
-			if ( empty( $model ) && ! empty( $network_context_config['model'] ) ) {
-				$model = $network_context_config['model'];
+			if ( empty( $model ) && ! empty( $network_mode_config['model'] ) ) {
+				$model = $network_mode_config['model'];
 			}
 		}
 
@@ -159,21 +164,26 @@ class PluginSettings {
 	}
 
 	/**
-	 * Resolve provider/model for an agent within an execution context.
+	 * Resolve provider/model for an agent within an execution mode.
 	 *
 	 * Resolution order:
-	 * 1. agent_config.context_models[context]
+	 * 1. agent_config.context_models[mode]
 	 * 2. agent_config.default_provider/default_model
-	 * 3. site/network context-specific overrides
+	 * 3. site/network mode-specific overrides
 	 * 4. site/network global defaults
 	 *
+	 * Note: the underlying agent_config key is still `context_models` — that rename
+	 * is scheduled for Phase 2 of #1138 (needs migration + React admin coordination).
+	 *
+	 * @since 0.68.0 Renamed from resolveModelForAgentContext().
+	 *
 	 * @param int|null $agent_id Agent ID or null/0 for no agent-specific override.
-	 * @param string   $context  Execution context.
+	 * @param string   $mode     Execution mode.
 	 * @return array{ provider: string, model: string }
 	 */
-	public static function resolveModelForAgentContext( ?int $agent_id, string $context ): array {
+	public static function resolveModelForAgentMode( ?int $agent_id, string $mode ): array {
 		$agent_id  = (int) $agent_id;
-		$cache_key = $agent_id . ':' . $context;
+		$cache_key = $agent_id . ':' . $mode;
 
 		if ( isset( self::$agent_model_cache[ $cache_key ] ) ) {
 			return self::$agent_model_cache[ $cache_key ];
@@ -184,13 +194,13 @@ class PluginSettings {
 			$agent       = $agents_repo->get_agent( $agent_id );
 			$config      = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
 
-			$context_models = is_array( $config['context_models'] ?? null )
+			$mode_models = is_array( $config['context_models'] ?? null )
 				? $config['context_models']
 				: ( is_array( $config['agent_models'] ?? null ) ? $config['agent_models'] : array() );
-			$context_model  = is_array( $context_models[ $context ] ?? null ) ? $context_models[ $context ] : array();
+			$mode_model  = is_array( $mode_models[ $mode ] ?? null ) ? $mode_models[ $mode ] : array();
 
-			$provider = sanitize_text_field( $context_model['provider'] ?? '' );
-			$model    = sanitize_text_field( $context_model['model'] ?? '' );
+			$provider = sanitize_text_field( $mode_model['provider'] ?? '' );
+			$model    = sanitize_text_field( $mode_model['model'] ?? '' );
 
 			if ( empty( $provider ) ) {
 				$provider = sanitize_text_field( $config['default_provider'] ?? '' );
@@ -210,7 +220,7 @@ class PluginSettings {
 			}
 		}
 
-		self::$agent_model_cache[ $cache_key ] = self::getContextModel( $context );
+		self::$agent_model_cache[ $cache_key ] = self::getModelForMode( $mode );
 
 		return self::$agent_model_cache[ $cache_key ];
 	}

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -75,10 +75,10 @@ class AIStep extends Step {
 		$job_snapshot         = $this->engine->get( 'job' );
 		$agent_id             = (int) ( $job_snapshot['agent_id'] ?? 0 );
 
-		// Model/provider resolved exclusively via context system (agent → site → network).
+		// Model/provider resolved exclusively via mode system (agent → site → network).
 		// Pipeline-level model/provider fields are ignored — context_models is the authority.
-		$context_model = PluginSettings::resolveModelForAgentContext( $agent_id, 'pipeline' );
-		$provider_name = $context_model['provider'];
+		$mode_model    = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
+		$provider_name = $mode_model['provider'];
 		if ( empty( $provider_name ) ) {
 			do_action(
 				'datamachine_fail_job',
@@ -88,7 +88,7 @@ class AIStep extends Step {
 					'flow_step_id'     => $this->flow_step_id,
 					'pipeline_step_id' => $pipeline_step_id,
 					'error_message'    => 'AI step requires provider configuration. Set a default provider in Data Machine settings or configure context_models.',
-					'solution'         => 'Set default_provider in Data Machine settings or configure context_models for the pipeline context',
+					'solution'         => 'Set default_provider in Data Machine settings or configure context_models for the pipeline mode',
 				)
 			);
 			return false;
@@ -292,10 +292,10 @@ class AIStep extends Step {
 			}
 		}
 
-		// Model/provider resolved exclusively via context system — pipeline config is ignored.
-		$context_model = PluginSettings::resolveModelForAgentContext( $agent_id, 'pipeline' );
-		$provider_name = $context_model['provider'];
-		$model_name    = $context_model['model'];
+		// Model/provider resolved exclusively via mode system — pipeline config is ignored.
+		$mode_model    = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
+		$provider_name = $mode_model['provider'];
+		$model_name    = $mode_model['model'];
 
 		// Establish agent execution context before firing the conversation loop.
 		//

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -40,12 +40,18 @@ class AIConversationLoop {
 	 * Adapters MUST return an array matching {@see self::execute()}'s
 	 * documented return shape.
 	 *
+	 * Note: the 5th positional argument was previously named `$context`. The
+	 * filter signature is positional — external adapters receive the value by
+	 * position and are unaffected by the PHP parameter name change.
+	 *
+	 * @since 0.68.0 Renamed `$context` parameter to `$mode`.
+	 *
 	 * @param array  $messages      Initial conversation messages.
 	 * @param array  $tools         Available tools for AI.
 	 * @param string $provider      AI provider identifier.
 	 * @param string $model         AI model identifier.
-	 * @param string $context       Execution context ('pipeline', 'chat', ...).
-	 * @param array  $payload       Step payload / loop context.
+	 * @param string $mode          Execution mode ('pipeline', 'chat', ...).
+	 * @param array  $payload       Step payload / loop mode data.
 	 * @param int    $max_turns     Maximum conversation turns.
 	 * @param bool   $single_turn   Execute exactly one turn and return.
 	 * @return array Result array matching self::execute() shape.
@@ -55,7 +61,7 @@ class AIConversationLoop {
 		array $tools,
 		string $provider,
 		string $model,
-		string $context,
+		string $mode,
 		array $payload = array(),
 		int $max_turns = PluginSettings::DEFAULT_MAX_TURNS,
 		bool $single_turn = false
@@ -73,6 +79,11 @@ class AIConversationLoop {
 		 * executing tools, managing turns, and producing the expected
 		 * result shape.
 		 *
+		 * The 5th positional argument (`$mode`) was previously documented as
+		 * `$context`; the value semantics are unchanged (e.g. 'pipeline',
+		 * 'chat', 'system'). Since the filter is positional, existing
+		 * adapters continue to work without modification.
+		 *
 		 * @since next
 		 *
 		 * @param array|null $result       Null to run the built-in loop, or an
@@ -81,8 +92,8 @@ class AIConversationLoop {
 		 * @param array      $tools        Available tools for AI.
 		 * @param string     $provider     AI provider identifier.
 		 * @param string     $model        AI model identifier.
-		 * @param string     $context      Execution context.
-		 * @param array      $payload      Step payload / loop context.
+		 * @param string     $mode         Execution mode.
+		 * @param array      $payload      Step payload / loop mode data.
 		 * @param int        $max_turns    Maximum conversation turns.
 		 * @param bool       $single_turn  Single-turn mode flag.
 		 */
@@ -93,7 +104,7 @@ class AIConversationLoop {
 			$tools,
 			$provider,
 			$model,
-			$context,
+			$mode,
 			$payload,
 			$max_turns,
 			$single_turn
@@ -109,7 +120,7 @@ class AIConversationLoop {
 			$tools,
 			$provider,
 			$model,
-			$context,
+			$mode,
 			$payload,
 			$max_turns,
 			$single_turn
@@ -119,11 +130,13 @@ class AIConversationLoop {
 	/**
 	 * Execute conversation loop
 	 *
+	 * @since 0.68.0 Renamed `$context` parameter to `$mode`.
+	 *
 	 * @param array  $messages      Initial conversation messages
 	 * @param array  $tools          Available tools for AI
 	 * @param string $provider       AI provider (openai, anthropic, etc.)
 	 * @param string $model          AI model identifier
-	 * @param string $context        Execution context: 'pipeline' or 'chat'
+	 * @param string $mode           Execution mode: 'pipeline' or 'chat'
 	 * @param array  $payload        Step payload (job_id, flow_step_id, data, flow_step_config)
 	 * @param int    $max_turns      Maximum conversation turns (default 25)
 	 * @param bool   $single_turn    Execute exactly one turn and return (default false)
@@ -141,7 +154,7 @@ class AIConversationLoop {
 		array $tools,
 		string $provider,
 		string $model,
-		string $context,
+		string $mode,
 		array $payload = array(),
 		int $max_turns = PluginSettings::DEFAULT_MAX_TURNS,
 		bool $single_turn = false
@@ -177,7 +190,7 @@ class AIConversationLoop {
 		// Build base log context from payload for consistent logging
 		$base_log_context = array_filter(
 			array(
-				'context'      => $context,
+				'mode'         => $mode,
 				'job_id'       => $payload['job_id'] ?? null,
 				'flow_step_id' => $payload['flow_step_id'] ?? null,
 			),
@@ -194,7 +207,7 @@ class AIConversationLoop {
 				$provider,
 				$model,
 				$tools,
-				$context,
+				$mode,
 				$payload
 			);
 
@@ -247,7 +260,7 @@ class AIConversationLoop {
 				$messages[] = $ai_message;
 
 				// Fire hook for AI response events (used for system operations like title generation)
-				do_action( 'datamachine_ai_response_received', $context, $messages, $payload );
+				do_action( 'datamachine_ai_response_received', $mode, $messages, $payload );
 			}
 
 			// Process tool calls
@@ -351,7 +364,7 @@ class AIConversationLoop {
 
 					// Track handler tool execution in pipeline mode.
 					// Only complete when ALL configured handlers have fired (multi-handler support).
-					if ( 'pipeline' === $context && $is_handler_tool && ( $tool_result['success'] ?? false ) ) {
+					if ( 'pipeline' === $mode && $is_handler_tool && ( $tool_result['success'] ?? false ) ) {
 						$handler_slug = $tool_def['handler'] ?? null;
 						if ( $handler_slug ) {
 							$executed_handler_slugs[] = $handler_slug;

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -2,7 +2,7 @@
 /**
  * AI Request Builder - Centralized AI request construction for all agents
  *
- * Single source of truth for building standardized AI requests across chat and pipeline contexts.
+ * Single source of truth for building standardized AI requests across chat and pipeline modes.
  * Ensures consistent request structure, tool formatting, and directive application to prevent
  * architectural drift between different AI agent types.
  *
@@ -17,18 +17,22 @@ defined( 'ABSPATH' ) || exit;
 class RequestBuilder {
 
 	/**
-	 * Build standardized AI request for any context.
+	 * Build standardized AI request for any execution mode.
 	 *
 	 * Centralizes request construction logic to ensure chat and pipeline flows
 	 * build identical request structures. Handles tool restructuring, directive
 	 * application via PromptBuilder, and consistent chubes_ai_request filter invocation.
 	 *
-	 * @param array  $messages    Initial messages array with role/content
-	 * @param string $provider    AI provider name (openai, anthropic, google, grok, openrouter)
-	 * @param string $model       Model identifier
-	 * @param array  $tools       Raw tools array from filters
-	 * @param string $context     Execution context: 'chat' or 'pipeline'
-	 * @param array  $payload     Step payload (session_id, job_id, flow_step_id, data, etc)
+	 * @since 0.68.0 Renamed `$context` parameter to `$mode`. The external
+	 *               `chubes_ai_request` filter still receives a `context` key
+	 *               in its 6th argument (Phase 2 rename).
+	 *
+	 * @param array  $messages Initial messages array with role/content
+	 * @param string $provider AI provider name (openai, anthropic, google, grok, openrouter)
+	 * @param string $model    Model identifier
+	 * @param array  $tools    Raw tools array from filters
+	 * @param string $mode     Execution mode: 'chat' or 'pipeline'
+	 * @param array  $payload  Step payload (session_id, job_id, flow_step_id, data, etc)
 	 * @return array AI response from provider
 	 */
 	public static function build(
@@ -36,7 +40,7 @@ class RequestBuilder {
 		string $provider,
 		string $model,
 		array $tools,
-		string $context,
+		string $mode,
 		array $payload = array()
 	): array {
 
@@ -66,7 +70,7 @@ class RequestBuilder {
 		}
 
 		// Build the request with directives applied
-		$request            = $promptBuilder->build( $context, $provider, $payload );
+		$request            = $promptBuilder->build( $mode, $provider, $payload );
 		$applied_directives = $request['applied_directives'] ?? array();
 		unset( $request['applied_directives'] );
 		$request['model'] = $model;
@@ -77,7 +81,7 @@ class RequestBuilder {
 			'AI request built',
 			array_filter(
 				array(
-					'context'       => $context,
+					'mode'          => $mode,
 					'job_id'        => $payload['job_id'] ?? null,
 					'flow_step_id'  => $payload['flow_step_id'] ?? null,
 					'provider'      => $provider,
@@ -90,7 +94,9 @@ class RequestBuilder {
 			)
 		);
 
-		// 4. Send to ai-http-client via chubes_ai_request filter
+		// 4. Send to ai-http-client via chubes_ai_request filter.
+		//    The `context` key here is the external filter contract and is
+		//    scheduled for Phase 2 of #1138 (coordinated ai-http-client rename).
 		return apply_filters(
 			'chubes_ai_request',
 			$request,
@@ -99,7 +105,7 @@ class RequestBuilder {
 			$structured_tools,
 			$payload['step_id'] ?? $payload['session_id'] ?? null,
 			array(
-				'context' => $context,
+				'context' => $mode,
 				'payload' => $payload,
 			)
 		);

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -260,7 +260,7 @@ abstract class SystemTask {
 	 */
 	protected function resolveSystemModel( array $params ): array {
 		$agent_id = (int) ( $params['agent_id'] ?? ( $params['context']['agent_id'] ?? 0 ) );
-		return PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		return PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 	}
 
 	/**

--- a/inc/migrations/layered-architecture.php
+++ b/inc/migrations/layered-architecture.php
@@ -86,7 +86,7 @@ function datamachine_migrate_to_layered_architecture(): void {
 			$user        = get_user_by( 'id', $user_id );
 			$agent_slug  = $user ? sanitize_title( $user->user_login ) : 'user-' . $user_id;
 			$agent_name  = $user ? $user->display_name : 'User ' . $user_id;
-			$agent_model = \DataMachine\Core\PluginSettings::getContextModel( 'chat' );
+			$agent_model = \DataMachine\Core\PluginSettings::getModelForMode( 'chat' );
 
 			$agent_id = $agents_repo->create_if_missing(
 				$agent_slug,
@@ -189,7 +189,7 @@ function datamachine_migrate_to_layered_architecture(): void {
 		$default_user    = get_user_by( 'id', $default_user_id );
 		$default_slug    = $default_user ? sanitize_title( $default_user->user_login ) : 'user-' . $default_user_id;
 		$default_name    = $default_user ? $default_user->display_name : 'User ' . $default_user_id;
-		$default_model   = \DataMachine\Core\PluginSettings::getContextModel( 'chat' );
+		$default_model   = \DataMachine\Core\PluginSettings::getModelForMode( 'chat' );
 
 		$agents_repo->create_if_missing(
 			$default_slug,

--- a/tests/Unit/Core/NetworkSettingsTest.php
+++ b/tests/Unit/Core/NetworkSettingsTest.php
@@ -161,7 +161,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 		$this->assertSame( 12, PluginSettings::resolve( 'max_turns', 12 ) );
 	}
 
-	// --- getContextModel() cascade ---
+	// --- getModelForMode() cascade ---
 
 	public function test_get_agent_model_site_override_wins(): void {
 		update_option( 'datamachine_settings', array(
@@ -177,7 +177,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 			),
 		) );
 
-		$result = PluginSettings::getContextModel( 'chat' );
+		$result = PluginSettings::getModelForMode( 'chat' );
 
 		$this->assertSame( 'openai', $result['provider'] );
 		$this->assertSame( 'gpt-4o', $result['model'] );
@@ -193,7 +193,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 			),
 		) );
 
-		$result = PluginSettings::getContextModel( 'pipeline' );
+		$result = PluginSettings::getModelForMode( 'pipeline' );
 
 		$this->assertSame( 'openai', $result['provider'] );
 		$this->assertSame( 'gpt-4o-mini', $result['model'] );
@@ -208,7 +208,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 			'default_model'    => 'claude-sonnet-4-20250514',
 		) );
 
-		$result = PluginSettings::getContextModel( 'system' );
+		$result = PluginSettings::getModelForMode( 'system' );
 
 		$this->assertSame( 'anthropic', $result['provider'] );
 		$this->assertSame( 'claude-sonnet-4-20250514', $result['model'] );
@@ -218,7 +218,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 		update_option( 'datamachine_settings', array() );
 		PluginSettings::clearCache();
 
-		$result = PluginSettings::getContextModel( 'chat' );
+		$result = PluginSettings::getModelForMode( 'chat' );
 
 		$this->assertSame( '', $result['provider'] );
 		$this->assertSame( '', $result['model'] );
@@ -240,7 +240,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 			),
 		) );
 
-		$result = PluginSettings::getContextModel( 'chat' );
+		$result = PluginSettings::getModelForMode( 'chat' );
 
 		// Provider from site, model from network.
 		$this->assertSame( 'openai', $result['provider'] );


### PR DESCRIPTION
## Summary

**Phase 1** of finishing the `contexts` → `modes` vocabulary rename tracked in #1138. Scope is **server-internal and safe to hard-cutover**, matching the style of #1130 (no shims).

The user-visible `context_models` setting key, `Api/Providers.php` REST field, chat sessions DB column, and extension repo alignment are all explicitly deferred to Phase 2/3 per #1138.

## Renamed symbols

| From | To |
|---|---|
| `PluginSettings::getContextModel()` | `PluginSettings::getModelForMode()` |
| `PluginSettings::resolveModelForAgentContext()` | `PluginSettings::resolveModelForAgentMode()` |
| `AIConversationLoop::run()` `$context` param | `$mode` |
| `AIConversationLoop::execute()` `$context` param | `$mode` |
| `RequestBuilder::build()` `$context` param | `$mode` |
| `AIStep` local `$context_model` → `$mode_model` | (vocabulary hygiene) |
| `AIConversationLoop` + `RequestBuilder` log field `'context'` → `'mode'` | (vocabulary hygiene) |

Callers for the two `PluginSettings` renames, updated across:

- `data-machine.php`
- `inc/migrations/layered-architecture.php`
- `inc/Core/Steps/AI/AIStep.php`
- `inc/Engine/AI/System/Tasks/SystemTask.php`
- `inc/Api/Chat/Chat.php`
- `inc/Api/Chat/ChatOrchestrator.php`
- `inc/Abilities/SystemAbilities.php`
- `inc/Abilities/PipelineStepAbilities.php`
- `inc/Abilities/InternalLinkingAbilities.php`
- `inc/Abilities/SEO/MetaDescriptionAbilities.php`
- `inc/Abilities/Media/ImageGenerationAbilities.php`
- `inc/Abilities/Media/AltTextAbilities.php`
- `inc/Abilities/Chat/SendMessageAbility.php`
- `tests/Unit/Core/NetworkSettingsTest.php`

Docs + README code snippets (`README.md`, `docs/core-system/ai-conversation-loop.md`, `docs/development/hooks/core-filters.md`) updated to use `$mode`.

## Decisions surfaced for review

### `datamachine_conversation_runner` public filter contract — renamed without a shim

The 5th positional argument was previously `$context`. #1130 deferred this as a "public runner filter contract". The filter signature is **9 positional args** — external adapters receive values by position and are **unaffected by the PHP parameter name change**. No deprecation shim is needed; this matches #1130's hard-cutover style.

Doc blocks + README snippets updated to reflect `$mode`. A callout is included in each place that explains the rename and confirms adapters continue to work unchanged.

### `chubes_ai_request` external filter — NOT renamed

`RequestBuilder` still passes a `context` key in the 6th argument of `chubes_ai_request`. That is an **external contract** consumed by the ai-http-client provider pack and should be renamed in coordination with that package. Deferred to Phase 2.

### `ContextRegistry` — already renamed in #1129 (not #1130)

The original #1138 task description lists `inc/Engine/AI/ContextRegistry.php` as unfinished, but that class was already renamed to `AgentModeRegistry` back in #1129, before #1130 even landed. Zero live code references remain. A stale "class alias" line in `docs/core-filters.md` was removed as part of this PR.

## Out of scope (Phase 2/3)

- `context_models` setting key + `agent_config.context_models[$mode]` — needs migration + React admin coordination
- `Api/Providers.php` REST `contexts` field — needs React admin rename
- Chat sessions DB `context` column — needs dbDelta migration
- `chubes_ai_request` filter's `context` key — ai-http-client coordinated rename
- Extension repo audit (`data-machine-events`, `data-machine-socials`, `data-machine-business`, `data-machine-code`) — Phase 3

## Tests

- `homeboy test data-machine` produces the **same error counts as main** (53 argument.type, 29 parameter.notFound, etc.); none of them reference the renamed symbols.
- Local PHPUnit does not run (DB connection issue is reproducible on `main` — pre-existing environment issue, not related to this PR).
- `tests/Unit/Core/NetworkSettingsTest.php` cascade tests updated to call the renamed methods.

## Refs

- Closes Phase 1 of #1138
- Follows style of #1130
- Builds on #1129 (original `ContextRegistry` → `AgentModeRegistry` rename)