### PR TITLE
feat(linkgraph): extractor/resolver filters + edge typing (#1143)

### DIFF
--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -30,13 +30,26 @@ class InternalLinkingAbilities {
 
 	/**
 	 * Transient key for the cached link graph.
+	 *
+	 * Bumped to v2 in 0.72.0 when edge_type was added to graph storage and
+	 * `datamachine_link_extractors` / `datamachine_link_resolvers` filters
+	 * were introduced. Existing installs rebuild the graph on first read.
 	 */
-	const GRAPH_TRANSIENT_KEY = 'datamachine_link_graph';
+	const GRAPH_TRANSIENT_KEY = 'datamachine_link_graph_v2';
 
 	/**
 	 * Cache TTL: 24 hours.
 	 */
 	const GRAPH_CACHE_TTL = DAY_IN_SECONDS;
+
+	/**
+	 * Built-in edge type for HTML anchor links.
+	 *
+	 * Consumers can register additional edge types (e.g. `wikilink`, `hashtag`,
+	 * `mention`) via the `datamachine_link_extractors` and
+	 * `datamachine_link_resolvers` filters.
+	 */
+	const EDGE_TYPE_HTML_ANCHOR = 'html_anchor';
 
 	private static bool $registered = false;
 
@@ -50,7 +63,49 @@ class InternalLinkingAbilities {
 		}
 
 		$this->registerAbilities();
+		$this->registerBuiltInLinkGraphParticipants();
 		self::$registered = true;
+	}
+
+	/**
+	 * Register DM's built-in HTML anchor extractor + resolver against the
+	 * link graph filters so core behavior is a participant, not a hardcoded
+	 * fallback.
+	 *
+	 * @since 0.72.0
+	 */
+	private function registerBuiltInLinkGraphParticipants(): void {
+		add_filter(
+			'datamachine_link_extractors',
+			function ( $extractors ) {
+				if ( ! is_array( $extractors ) ) {
+					$extractors = array();
+				}
+				if ( ! isset( $extractors[ self::EDGE_TYPE_HTML_ANCHOR ] ) ) {
+					$extractors[ self::EDGE_TYPE_HTML_ANCHOR ] = array(
+						'label'       => __( 'HTML anchor', 'data-machine' ),
+						'description' => __( 'Internal links via <a href> pointing to the site host.', 'data-machine' ),
+						'callback'    => array( self::class, 'extractHtmlAnchorEdges' ),
+					);
+				}
+				return $extractors;
+			}
+		);
+
+		add_filter(
+			'datamachine_link_resolvers',
+			function ( $resolvers ) {
+				if ( ! is_array( $resolvers ) ) {
+					$resolvers = array();
+				}
+				if ( ! isset( $resolvers[ self::EDGE_TYPE_HTML_ANCHOR ] ) ) {
+					$resolvers[ self::EDGE_TYPE_HTML_ANCHOR ] = array(
+						'callback' => array( self::class, 'resolveHtmlAnchor' ),
+					);
+				}
+				return $resolvers;
+			}
+		);
 	}
 
 	private function registerAbilities(): void {
@@ -167,6 +222,11 @@ class InternalLinkingAbilities {
 								'description' => 'Force rebuild even if cached graph exists.',
 								'default'     => false,
 							),
+							'types'     => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'Optional edge types to include in aggregates (e.g. ["html_anchor"]). Omit for all types.',
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -214,6 +274,11 @@ class InternalLinkingAbilities {
 								'description' => 'Maximum orphaned posts to return. Default: 50.',
 								'default'     => 50,
 							),
+							'types'     => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'Optional edge types to include (e.g. ["html_anchor"]). Omit for all types.',
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -253,6 +318,11 @@ class InternalLinkingAbilities {
 								'type'        => 'string',
 								'description' => 'Post type scope for the link graph. Default: post.',
 								'default'     => 'post',
+							),
+							'types'     => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'Optional edge types to include (e.g. ["html_anchor"]). Omit for all types.',
 							),
 						),
 					),
@@ -313,6 +383,11 @@ class InternalLinkingAbilities {
 								'description' => 'HTTP timeout per request in seconds. Default: 5.',
 								'default'     => 5,
 							),
+							'types'     => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'Optional edge types to include for internal-link checks (e.g. ["html_anchor"]). Omit for all types.',
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -362,6 +437,11 @@ class InternalLinkingAbilities {
 								'type'        => 'integer',
 								'description' => 'GSC lookback period in days. Default: 28.',
 								'default'     => 28,
+							),
+							'types'      => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => 'Optional edge types to include in link counts (e.g. ["html_anchor"]). Omit for all types.',
 							),
 						),
 					),
@@ -692,14 +772,16 @@ class InternalLinkingAbilities {
 		$category     = sanitize_text_field( $input['category'] ?? '' );
 		$specific_ids = array_map( 'absint', $input['post_ids'] ?? array() );
 		$force        = ! empty( $input['force'] );
+		$types        = self::normalizeTypesInput( $input['types'] ?? null );
 
 		// Check cache unless forced or scoped to specific posts/category.
 		$is_scoped = ! empty( $specific_ids ) || ! empty( $category );
 		if ( ! $force && ! $is_scoped ) {
 			$cached = get_transient( self::GRAPH_TRANSIENT_KEY );
 			if ( false !== $cached && is_array( $cached ) && ( $cached['post_type'] ?? '' ) === $post_type ) {
-				$cached['cached'] = true;
-				return $cached;
+				$graph            = self::applyTypesFilterToGraph( $cached, $types );
+				$graph['cached']  = true;
+				return $graph;
 			}
 		}
 
@@ -709,12 +791,57 @@ class InternalLinkingAbilities {
 			return $graph;
 		}
 
-		// Cache the full graph if this was an unscoped audit.
+		// Cache the full, unfiltered graph if this was an unscoped audit.
 		if ( ! $is_scoped ) {
 			set_transient( self::GRAPH_TRANSIENT_KEY, $graph, self::GRAPH_CACHE_TTL );
 		}
 
+		$graph           = self::applyTypesFilterToGraph( $graph, $types );
 		$graph['cached'] = false;
+		return $graph;
+	}
+
+	/**
+	 * Apply a `types` filter to a pre-built graph, re-computing aggregates
+	 * (outbound/orphaned/top_linked) from `_all_links` scoped to the given
+	 * edge types.
+	 *
+	 * @since 0.72.0
+	 *
+	 * @param array      $graph Full graph (returned by buildLinkGraph or from cache).
+	 * @param array|null $types Edge types to scope to. null/empty = all types unioned.
+	 * @return array Graph with aggregates recomputed and total_links updated.
+	 */
+	private static function applyTypesFilterToGraph( array $graph, ?array $types ): array {
+		if ( empty( $types ) ) {
+			return $graph;
+		}
+
+		$all_links   = $graph['_all_links'] ?? array();
+		$post_ids    = $graph['_post_ids'] ?? array();
+		$id_to_title = $graph['_id_to_title'] ?? array();
+		$id_to_url   = $graph['_id_to_url'] ?? array();
+
+		$types_set      = array_flip( array_map( 'strval', $types ) );
+		$filtered_links = array();
+		foreach ( $all_links as $edge ) {
+			$edge_type = (string) ( $edge['edge_type'] ?? '' );
+			if ( '' === $edge_type || isset( $types_set[ $edge_type ] ) ) {
+				$filtered_links[] = $edge;
+			}
+		}
+
+		$aggregates = self::computeGraphAggregates( $filtered_links, $post_ids, $id_to_title, $id_to_url, $types );
+
+		$graph['orphaned_posts'] = $aggregates['orphaned_posts'];
+		$graph['top_linked']     = $aggregates['top_linked'];
+		$graph['outbound']       = $aggregates['outbound'];
+		$graph['orphaned_count'] = $aggregates['orphaned_count'];
+		$graph['avg_outbound']   = $aggregates['avg_outbound'];
+		$graph['avg_inbound']    = $aggregates['avg_inbound'];
+		$graph['total_links']    = count( $filtered_links );
+		$graph['types']          = array_values( $types );
+
 		return $graph;
 	}
 
@@ -731,6 +858,7 @@ class InternalLinkingAbilities {
 	public static function getOrphanedPosts( array $input = array() ): array {
 		$post_type  = sanitize_text_field( $input['post_type'] ?? 'post' );
 		$limit      = absint( $input['limit'] ?? 50 );
+		$types      = self::normalizeTypesInput( $input['types'] ?? null );
 		$from_cache = true;
 
 		$graph = get_transient( self::GRAPH_TRANSIENT_KEY );
@@ -743,6 +871,8 @@ class InternalLinkingAbilities {
 			set_transient( self::GRAPH_TRANSIENT_KEY, $graph, self::GRAPH_CACHE_TTL );
 			$from_cache = false;
 		}
+
+		$graph = self::applyTypesFilterToGraph( $graph, $types );
 
 		$orphaned = $graph['orphaned_posts'] ?? array();
 		if ( $limit > 0 && count( $orphaned ) > $limit ) {
@@ -773,6 +903,7 @@ class InternalLinkingAbilities {
 	public static function getBacklinks( array $input = array() ): array {
 		$post_id    = absint( $input['post_id'] ?? 0 );
 		$post_type  = sanitize_text_field( $input['post_type'] ?? 'post' );
+		$types      = self::normalizeTypesInput( $input['types'] ?? null );
 		$from_cache = true;
 
 		if ( 0 === $post_id ) {
@@ -795,17 +926,25 @@ class InternalLinkingAbilities {
 
 		$all_links   = $graph['_all_links'] ?? array();
 		$id_to_title = $graph['_id_to_title'] ?? array();
+		$types_set   = null === $types ? null : array_flip( array_map( 'strval', $types ) );
 
 		// Filter links where target_id matches, group by source_id.
 		$sources = array();
 		foreach ( $all_links as $link ) {
-			if ( ( $link['target_id'] ?? null ) === $post_id ) {
-				$source_id = $link['source_id'];
-				if ( ! isset( $sources[ $source_id ] ) ) {
-					$sources[ $source_id ] = 0;
-				}
-				++$sources[ $source_id ];
+			if ( ( $link['target_id'] ?? null ) !== $post_id ) {
+				continue;
 			}
+			if ( null !== $types_set ) {
+				$edge_type = (string) ( $link['edge_type'] ?? '' );
+				if ( '' === $edge_type || ! isset( $types_set[ $edge_type ] ) ) {
+					continue;
+				}
+			}
+			$source_id = $link['source_id'];
+			if ( ! isset( $sources[ $source_id ] ) ) {
+				$sources[ $source_id ] = 0;
+			}
+			++$sources[ $source_id ];
 		}
 
 		// Build the response array with titles and permalinks.
@@ -849,6 +988,7 @@ class InternalLinkingAbilities {
 		$limit      = absint( $input['limit'] ?? 200 );
 		$timeout    = absint( $input['timeout'] ?? 5 );
 		$scope      = sanitize_text_field( $input['scope'] ?? 'internal' );
+		$types      = self::normalizeTypesInput( $input['types'] ?? null );
 		$from_cache = true;
 
 		if ( ! in_array( $scope, array( 'internal', 'external', 'all' ), true ) ) {
@@ -868,6 +1008,7 @@ class InternalLinkingAbilities {
 		// Build URL → source mapping based on scope.
 		$url_sources = array(); // url => array of {source_id, anchor_text}.
 		$id_to_title = $graph['_id_to_title'] ?? array();
+		$types_set   = null === $types ? null : array_flip( array_map( 'strval', $types ) );
 
 		if ( 'internal' === $scope || 'all' === $scope ) {
 			$all_links = $graph['_all_links'] ?? array();
@@ -875,6 +1016,12 @@ class InternalLinkingAbilities {
 				$url = $link['target_url'] ?? '';
 				if ( empty( $url ) ) {
 					continue;
+				}
+				if ( null !== $types_set ) {
+					$edge_type = (string) ( $link['edge_type'] ?? '' );
+					if ( '' === $edge_type || ! isset( $types_set[ $edge_type ] ) ) {
+						continue;
+					}
 				}
 				if ( ! isset( $url_sources[ $url ] ) ) {
 					$url_sources[ $url ] = array();
@@ -1042,6 +1189,7 @@ class InternalLinkingAbilities {
 		$category   = sanitize_text_field( $input['category'] ?? '' );
 		$min_clicks = absint( $input['min_clicks'] ?? 5 );
 		$days       = absint( $input['days'] ?? 28 );
+		$types      = self::normalizeTypesInput( $input['types'] ?? null );
 
 		// 1. Load the link graph from transient (run audit if not cached).
 		$graph = get_transient( self::GRAPH_TRANSIENT_KEY );
@@ -1059,26 +1207,35 @@ class InternalLinkingAbilities {
 		// Build inbound/outbound counts from the link graph's _all_links data.
 		$inbound_counts  = array();
 		$outbound_counts = array();
+		$types_set       = null === $types ? null : array_flip( array_map( 'strval', $types ) );
 
-		// Initialize from orphaned_posts (0 inbound).
-		foreach ( $graph['orphaned_posts'] ?? array() as $orphan ) {
-			$pid = $orphan['post_id'] ?? 0;
-			if ( $pid > 0 ) {
-				$inbound_counts[ $pid ] = 0;
+		// Initialize from orphaned_posts (0 inbound) — only reliable for unfiltered reads.
+		if ( null === $types_set ) {
+			foreach ( $graph['orphaned_posts'] ?? array() as $orphan ) {
+				$pid = $orphan['post_id'] ?? 0;
+				if ( $pid > 0 ) {
+					$inbound_counts[ $pid ] = 0;
+				}
+			}
+
+			foreach ( $graph['top_linked'] ?? array() as $top ) {
+				$pid = $top['post_id'] ?? 0;
+				if ( $pid > 0 ) {
+					$inbound_counts[ $pid ] = (int) ( $top['inbound'] ?? 0 );
+				}
 			}
 		}
 
-		// Initialize from top_linked (has inbound count).
-		foreach ( $graph['top_linked'] ?? array() as $top ) {
-			$pid = $top['post_id'] ?? 0;
-			if ( $pid > 0 ) {
-				$inbound_counts[ $pid ] = (int) ( $top['inbound'] ?? 0 );
-			}
-		}
-
-		// Rebuild full counts from _all_links for accuracy.
+		// Rebuild full counts from _all_links for accuracy / types filtering.
 		$all_links = $graph['_all_links'] ?? array();
 		foreach ( $all_links as $link ) {
+			if ( null !== $types_set ) {
+				$edge_type = (string) ( $link['edge_type'] ?? '' );
+				if ( '' === $edge_type || ! isset( $types_set[ $edge_type ] ) ) {
+					continue;
+				}
+			}
+
 			$source_id = $link['source_id'] ?? 0;
 			$target_id = $link['target_id'] ?? null;
 
@@ -1244,12 +1401,211 @@ class InternalLinkingAbilities {
 	}
 
 	/**
+	 * Get the registered link edge extractors.
+	 *
+	 * Applies the `datamachine_link_extractors` filter. Consumers register
+	 * extractors as a keyed map: `[ edge_type => [ 'label', 'description',
+	 * 'callback' ] ]` where callback receives `(string $content, array
+	 * $context)` and returns an array of edges with `target_hint`,
+	 * `edge_type`, and optional `display` / `location`.
+	 *
+	 * @since 0.72.0
+	 *
+	 * @return array<string, array{label?: string, description?: string, callback: callable}>
+	 */
+	public static function getExtractors(): array {
+		$extractors = apply_filters( 'datamachine_link_extractors', array() );
+		return is_array( $extractors ) ? $extractors : array();
+	}
+
+	/**
+	 * Get the registered link target resolvers, keyed by edge_type.
+	 *
+	 * Applies the `datamachine_link_resolvers` filter. Consumers register
+	 * resolvers as `[ edge_type => [ 'callback' ] ]` where callback
+	 * receives `(string $target_hint, array $context)` and returns an
+	 * `int` post ID or `null`.
+	 *
+	 * @since 0.72.0
+	 *
+	 * @return array<string, array{callback: callable}>
+	 */
+	public static function getResolvers(): array {
+		$resolvers = apply_filters( 'datamachine_link_resolvers', array() );
+		return is_array( $resolvers ) ? $resolvers : array();
+	}
+
+	/**
+	 * Dispatch all registered extractors against a single post's content.
+	 *
+	 * @since 0.72.0
+	 *
+	 * @param string $content Post content.
+	 * @param array  $context Context passed to each extractor (post_id, post_type, home_host, ...).
+	 * @return array List of edges; each edge carries at minimum `target_hint` and `edge_type`.
+	 */
+	public static function dispatchExtractors( string $content, array $context ): array {
+		$edges = array();
+		foreach ( self::getExtractors() as $edge_type => $extractor ) {
+			$callback = $extractor['callback'] ?? null;
+			if ( ! is_callable( $callback ) ) {
+				continue;
+			}
+			$result = call_user_func( $callback, $content, $context );
+			if ( ! is_array( $result ) ) {
+				continue;
+			}
+			foreach ( $result as $edge ) {
+				if ( ! is_array( $edge ) || empty( $edge['target_hint'] ) ) {
+					continue;
+				}
+				// Stamp edge_type from registration key when extractor omits or conflicts.
+				$edge['edge_type'] = isset( $edge['edge_type'] ) && is_string( $edge['edge_type'] ) && '' !== $edge['edge_type']
+					? $edge['edge_type']
+					: (string) $edge_type;
+				$edges[]           = $edge;
+			}
+		}
+		return $edges;
+	}
+
+	/**
+	 * Resolve a single edge's `target_hint` to a post ID using the registered
+	 * resolver for its `edge_type`.
+	 *
+	 * @since 0.72.0
+	 *
+	 * @param string $target_hint Target hint produced by an extractor.
+	 * @param string $edge_type   Edge type (resolver lookup key).
+	 * @param array  $context     Context passed to the resolver.
+	 * @return int|null Post ID or null if unresolvable.
+	 */
+	public static function dispatchResolver( string $target_hint, string $edge_type, array $context ): ?int {
+		$resolvers = self::getResolvers();
+		$entry     = $resolvers[ $edge_type ] ?? null;
+		if ( null === $entry ) {
+			return null;
+		}
+		$callback = $entry['callback'] ?? null;
+		if ( ! is_callable( $callback ) ) {
+			return null;
+		}
+		$result = call_user_func( $callback, $target_hint, $context );
+		if ( is_int( $result ) && $result > 0 ) {
+			return $result;
+		}
+		return null;
+	}
+
+	/**
+	 * Built-in extractor for HTML anchor edges.
+	 *
+	 * Parses `<a href>` tags in post content and emits edges pointing to the
+	 * site's own host. Replaces the legacy `extractInternalLinks()` helper as
+	 * a first-class participant in the extractor filter.
+	 *
+	 * @since 0.72.0
+	 *
+	 * @param string $content Post content.
+	 * @param array  $context Context; reads `home_host` for host comparison.
+	 * @return array List of edges with target_hint = normalized URL.
+	 */
+	public static function extractHtmlAnchorEdges( string $content, array $context ): array {
+		$home_host = $context['home_host'] ?? wp_parse_url( home_url(), PHP_URL_HOST );
+		$edges     = array();
+
+		if ( empty( $content ) || ! is_string( $home_host ) || '' === $home_host ) {
+			return $edges;
+		}
+
+		if ( ! preg_match_all( '/<a\s[^>]*href=["\']([^"\'#]+)["\'][^>]*>/i', $content, $matches ) ) {
+			return $edges;
+		}
+
+		$seen = array();
+
+		foreach ( $matches[1] as $url ) {
+			// Skip non-http URLs.
+			if ( preg_match( '/^(mailto:|tel:|javascript:|data:)/i', $url ) ) {
+				continue;
+			}
+
+			// Handle relative URLs.
+			if ( 0 === strpos( $url, '/' ) && 0 !== strpos( $url, '//' ) ) {
+				$url = home_url( $url );
+			}
+
+			$parsed = wp_parse_url( $url );
+			$host   = $parsed['host'] ?? '';
+
+			if ( empty( $host ) || strcasecmp( $host, $home_host ) !== 0 ) {
+				continue;
+			}
+
+			$clean_url = ( $parsed['scheme'] ?? 'http' ) . '://' . $parsed['host'];
+			if ( ! empty( $parsed['path'] ) ) {
+				$clean_url .= $parsed['path'];
+			}
+
+			if ( isset( $seen[ $clean_url ] ) ) {
+				continue;
+			}
+			$seen[ $clean_url ] = true;
+
+			$edges[] = array(
+				'target_hint' => $clean_url,
+				'edge_type'   => self::EDGE_TYPE_HTML_ANCHOR,
+				'location'    => 'body',
+			);
+		}
+
+		return $edges;
+	}
+
+	/**
+	 * Built-in resolver for `html_anchor` edges.
+	 *
+	 * Resolves a URL `target_hint` to a post ID by consulting a provided
+	 * URL→ID lookup first, then falling back to `url_to_postid()`.
+	 *
+	 * @since 0.72.0
+	 *
+	 * @param string $target_hint URL produced by the html_anchor extractor.
+	 * @param array  $context     Context; reads `url_to_id` lookup map.
+	 * @return int|null Post ID or null.
+	 */
+	public static function resolveHtmlAnchor( string $target_hint, array $context ): ?int {
+		$url       = $target_hint;
+		$url_to_id = $context['url_to_id'] ?? array();
+
+		if ( is_array( $url_to_id ) ) {
+			$normalized = untrailingslashit( $url );
+			if ( isset( $url_to_id[ $normalized ] ) ) {
+				return (int) $url_to_id[ $normalized ];
+			}
+			$trailing = trailingslashit( $url );
+			if ( isset( $url_to_id[ $trailing ] ) ) {
+				return (int) $url_to_id[ $trailing ];
+			}
+		}
+
+		$fallback = url_to_postid( $url );
+		if ( $fallback > 0 ) {
+			return (int) $fallback;
+		}
+		return null;
+	}
+
+	/**
 	 * Build the internal link graph by scanning post content.
 	 *
 	 * Shared logic used by audit, get-orphaned-posts, and check-broken-links.
 	 * Returns the full graph data structure suitable for caching.
 	 *
 	 * @since 0.32.0
+	 * @since 0.72.0 Graph edges carry `edge_type`; extractors and resolvers
+	 *               are pluggable via `datamachine_link_extractors` and
+	 *               `datamachine_link_resolvers` filters.
 	 *
 	 * @param string $post_type    Post type to scan.
 	 * @param string $category     Category slug to filter by.
@@ -1313,17 +1669,21 @@ class InternalLinkingAbilities {
 
 		if ( empty( $posts ) ) {
 			return array(
-				'success'        => true,
-				'post_type'      => $post_type,
-				'total_scanned'  => 0,
-				'total_links'    => 0,
-				'orphaned_count' => 0,
-				'avg_outbound'   => 0,
-				'avg_inbound'    => 0,
-				'orphaned_posts' => array(),
-				'top_linked'     => array(),
-				'_all_links'     => array(),
-				'_id_to_title'   => array(),
+				'success'             => true,
+				'post_type'           => $post_type,
+				'total_scanned'       => 0,
+				'total_links'         => 0,
+				'orphaned_count'      => 0,
+				'avg_outbound'        => 0,
+				'avg_inbound'         => 0,
+				'orphaned_posts'      => array(),
+				'top_linked'          => array(),
+				'outbound'            => array(),
+				'_all_links'          => array(),
+				'_all_external_links' => array(),
+				'_id_to_title'        => array(),
+				'_id_to_url'          => array(),
+				'_post_ids'           => array(),
 			);
 		}
 
@@ -1331,6 +1691,7 @@ class InternalLinkingAbilities {
 		$url_to_id   = array();
 		$id_to_url   = array();
 		$id_to_title = array();
+		$post_ids    = array();
 
 		foreach ( $posts as $post ) {
 			$permalink = get_permalink( $post->ID );
@@ -1340,19 +1701,12 @@ class InternalLinkingAbilities {
 				$id_to_url[ $post->ID ]                       = $permalink;
 			}
 			$id_to_title[ $post->ID ] = $post->post_title;
+			$post_ids[]               = (int) $post->ID;
 		}
 
-		// Scan each post's content for internal links.
-		$outbound    = array(); // post_id => array of target post_ids.
-		$inbound     = array(); // post_id => count of inbound links.
-		$all_links   = array(); // all discovered internal link entries.
+		// Scan each post's content using the registered extractors + resolvers.
+		$all_links   = array(); // all discovered internal edge entries (with edge_type).
 		$total_links = 0;
-
-		// Initialize inbound counts.
-		foreach ( $posts as $post ) {
-			$inbound[ $post->ID ]  = 0;
-			$outbound[ $post->ID ] = array();
-		}
 
 		$all_external_links = array();
 
@@ -1362,45 +1716,54 @@ class InternalLinkingAbilities {
 				continue;
 			}
 
-			// Internal links.
-			$links = self::extractInternalLinks( $content, $home_host );
+			$extract_context = array(
+				'post_id'   => (int) $post->ID,
+				'post_type' => $post_type,
+				'home_host' => $home_host,
+				'home_url'  => $home_url,
+			);
 
-			foreach ( $links as $link_url ) {
-				++$total_links;
-				$normalized = untrailingslashit( $link_url );
+			$edges = self::dispatchExtractors( $content, $extract_context );
 
-				// Resolve to a post ID if possible.
-				$target_id = $url_to_id[ $normalized ] ?? $url_to_id[ trailingslashit( $link_url ) ] ?? null;
-
-				if ( null === $target_id ) {
-					// Try url_to_postid as fallback for non-standard URLs.
-					$target_id = url_to_postid( $link_url );
-					if ( 0 === $target_id ) {
-						$target_id = null;
-					}
+			foreach ( $edges as $edge ) {
+				$target_hint = $edge['target_hint'] ?? '';
+				$edge_type   = $edge['edge_type'] ?? '';
+				if ( '' === $target_hint || '' === $edge_type ) {
+					continue;
 				}
 
-				if ( null !== $target_id && $target_id !== $post->ID ) {
-					$outbound[ $post->ID ][] = $target_id;
+				++$total_links;
 
-					if ( isset( $inbound[ $target_id ] ) ) {
-						++$inbound[ $target_id ];
-					}
+				$resolve_context = $extract_context;
+				if ( self::EDGE_TYPE_HTML_ANCHOR === $edge_type ) {
+					$resolve_context['url_to_id'] = $url_to_id;
+				}
+				$resolve_context['edge']    = $edge;
+				$resolve_context['post_ids'] = $post_ids;
+
+				$target_id = self::dispatchResolver( $target_hint, $edge_type, $resolve_context );
+
+				// Don't self-loop.
+				if ( null !== $target_id && $target_id === (int) $post->ID ) {
+					$target_id = null;
 				}
 
 				$all_links[] = array(
-					'source_id'  => $post->ID,
-					'target_url' => $link_url,
+					'source_id'  => (int) $post->ID,
+					'target_url' => $target_hint,
 					'target_id'  => $target_id,
+					'edge_type'  => $edge_type,
 					'resolved'   => null !== $target_id,
+					'display'    => $edge['display'] ?? '',
+					'location'   => $edge['location'] ?? '',
 				);
 			}
 
-			// External links.
+			// External links — html_anchor-specific auxiliary data for broken-link checks.
 			$external = self::extractExternalLinks( $content, $home_host );
 			foreach ( $external as $ext_link ) {
 				$all_external_links[] = array(
-					'source_id'   => $post->ID,
+					'source_id'   => (int) $post->ID,
 					'target_url'  => $ext_link['url'],
 					'anchor_text' => $ext_link['anchor_text'],
 					'domain'      => $ext_link['domain'],
@@ -1408,107 +1771,196 @@ class InternalLinkingAbilities {
 			}
 		}
 
-		// Identify orphaned posts (zero inbound links from other scanned posts).
-		$orphaned = array();
-		foreach ( $inbound as $post_id => $count ) {
-			if ( 0 === $count ) {
-				$orphaned[] = array(
-					'post_id'   => $post_id,
-					'title'     => $id_to_title[ $post_id ] ?? '',
-					'permalink' => $id_to_url[ $post_id ] ?? '',
-					'outbound'  => count( $outbound[ $post_id ] ?? array() ),
-				);
-			}
-		}
-
-		// Top linked posts (most inbound).
-		arsort( $inbound );
-		$top_linked = array();
-		$top_count  = 0;
-		foreach ( $inbound as $post_id => $count ) {
-			if ( 0 === $count || $top_count >= 20 ) {
-				break;
-			}
-			$top_linked[] = array(
-				'post_id'   => $post_id,
-				'title'     => $id_to_title[ $post_id ] ?? '',
-				'permalink' => $id_to_url[ $post_id ] ?? '',
-				'inbound'   => $count,
-				'outbound'  => count( $outbound[ $post_id ] ?? array() ),
-			);
-			++$top_count;
-		}
-
-		$total_scanned  = count( $posts );
-		$outbound_total = array_sum( array_map( 'count', $outbound ) );
-		$inbound_total  = array_sum( $inbound );
+		// Derive the default all-types-unioned aggregates.
+		$aggregates = self::computeGraphAggregates( $all_links, $post_ids, $id_to_title, $id_to_url, null );
 
 		return array(
 			'success'             => true,
 			'post_type'           => $post_type,
-			'total_scanned'       => $total_scanned,
+			'total_scanned'       => count( $posts ),
 			'total_links'         => $total_links,
-			'orphaned_count'      => count( $orphaned ),
-			'avg_outbound'        => $total_scanned > 0 ? round( $outbound_total / $total_scanned, 2 ) : 0,
-			'avg_inbound'         => $total_scanned > 0 ? round( $inbound_total / $total_scanned, 2 ) : 0,
-			'orphaned_posts'      => $orphaned,
-			'top_linked'          => $top_linked,
-			// Internal data for broken link checker (not exposed in REST).
+			'orphaned_count'      => $aggregates['orphaned_count'],
+			'avg_outbound'        => $aggregates['avg_outbound'],
+			'avg_inbound'         => $aggregates['avg_inbound'],
+			'orphaned_posts'      => $aggregates['orphaned_posts'],
+			'top_linked'          => $aggregates['top_linked'],
+			'outbound'            => $aggregates['outbound'],
+			// Internal data kept for typed queries and broken-link checker (not exposed in REST).
 			'_all_links'          => $all_links,
 			'_all_external_links' => $all_external_links,
 			'_id_to_title'        => $id_to_title,
+			'_id_to_url'          => $id_to_url,
+			'_post_ids'           => $post_ids,
 		);
 	}
 
 	/**
-	 * Extract internal link URLs from HTML content.
+	 * Compute graph aggregates (outbound map, inbound counts, orphans, top-linked)
+	 * from a raw edge list, optionally filtered by edge_type.
 	 *
-	 * Uses regex to find all <a href="..."> tags where the href points to
-	 * the same host as the site. Ignores anchors, mailto, tel, and external links.
+	 * @since 0.72.0
 	 *
-	 * @since 0.32.0
-	 *
-	 * @param string $html      HTML content to parse.
-	 * @param string $home_host Site hostname for comparison.
-	 * @return array Array of internal link URLs.
+	 * @param array      $all_links   Raw `_all_links` entries with `edge_type`.
+	 * @param array      $post_ids    Post IDs included in the scan scope.
+	 * @param array      $id_to_title post_id => title lookup.
+	 * @param array      $id_to_url   post_id => permalink lookup.
+	 * @param array|null $types       Edge types to include. null / empty = all types.
+	 * @return array{
+	 *     outbound: array<int, array<int, array{count: int, types: array<string, int>}>>,
+	 *     orphaned_posts: array<int, array{post_id: int, title: string, permalink: string, outbound: int}>,
+	 *     top_linked: array<int, array{post_id: int, title: string, permalink: string, inbound: int, outbound: int}>,
+	 *     orphaned_count: int,
+	 *     avg_outbound: float,
+	 *     avg_inbound: float
+	 * }
 	 */
-	private static function extractInternalLinks( string $html, string $home_host ): array {
-		$links = array();
-
-		// Match all href attributes in anchor tags.
-		if ( ! preg_match_all( '/<a\s[^>]*href=["\']([^"\'#]+)["\'][^>]*>/i', $html, $matches ) ) {
-			return $links;
+	private static function computeGraphAggregates(
+		array $all_links,
+		array $post_ids,
+		array $id_to_title,
+		array $id_to_url,
+		?array $types
+	): array {
+		$types_set = null;
+		if ( is_array( $types ) && ! empty( $types ) ) {
+			$types_set = array_flip( array_map( 'strval', $types ) );
 		}
 
-		foreach ( $matches[1] as $url ) {
-			// Skip non-http URLs.
-			if ( preg_match( '/^(mailto:|tel:|javascript:|data:)/i', $url ) ) {
+		$outbound        = array();
+		$outbound_counts = array();
+		$inbound         = array();
+
+		foreach ( $post_ids as $pid ) {
+			$pid             = (int) $pid;
+			$inbound[ $pid ] = 0;
+		}
+
+		foreach ( $all_links as $edge ) {
+			$source_id = (int) ( $edge['source_id'] ?? 0 );
+			$target_id = $edge['target_id'] ?? null;
+			$edge_type = (string) ( $edge['edge_type'] ?? '' );
+
+			if ( $source_id <= 0 ) {
+				continue;
+			}
+			if ( null !== $types_set && '' !== $edge_type && ! isset( $types_set[ $edge_type ] ) ) {
+				continue;
+			}
+			if ( null === $target_id ) {
+				continue;
+			}
+			$target_id = (int) $target_id;
+			if ( $target_id <= 0 || $target_id === $source_id ) {
 				continue;
 			}
 
-			// Handle relative URLs.
-			if ( 0 === strpos( $url, '/' ) && 0 !== strpos( $url, '//' ) ) {
-				$url = home_url( $url );
+			if ( ! isset( $outbound[ $source_id ] ) ) {
+				$outbound[ $source_id ] = array();
+			}
+			if ( ! isset( $outbound[ $source_id ][ $target_id ] ) ) {
+				$outbound[ $source_id ][ $target_id ] = array(
+					'count' => 0,
+					'types' => array(),
+				);
+			}
+			++$outbound[ $source_id ][ $target_id ]['count'];
+			if ( '' !== $edge_type ) {
+				if ( ! isset( $outbound[ $source_id ][ $target_id ]['types'][ $edge_type ] ) ) {
+					$outbound[ $source_id ][ $target_id ]['types'][ $edge_type ] = 0;
+				}
+				++$outbound[ $source_id ][ $target_id ]['types'][ $edge_type ];
 			}
 
-			// Parse and check host.
-			$parsed = wp_parse_url( $url );
-			$host   = $parsed['host'] ?? '';
-
-			if ( empty( $host ) || strcasecmp( $host, $home_host ) !== 0 ) {
-				continue;
+			if ( ! isset( $outbound_counts[ $source_id ] ) ) {
+				$outbound_counts[ $source_id ] = 0;
 			}
+			++$outbound_counts[ $source_id ];
 
-			// Strip query string and fragment for normalization.
-			$clean_url = $parsed['scheme'] . '://' . $parsed['host'];
-			if ( ! empty( $parsed['path'] ) ) {
-				$clean_url .= $parsed['path'];
+			if ( isset( $inbound[ $target_id ] ) ) {
+				++$inbound[ $target_id ];
 			}
-
-			$links[] = $clean_url;
 		}
 
-		return array_unique( $links );
+		// Orphans: posts in scope with zero inbound links.
+		$orphaned = array();
+		foreach ( $inbound as $post_id => $count ) {
+			if ( 0 === $count ) {
+				$orphaned[] = array(
+					'post_id'   => (int) $post_id,
+					'title'     => $id_to_title[ $post_id ] ?? '',
+					'permalink' => $id_to_url[ $post_id ] ?? '',
+					'outbound'  => $outbound_counts[ $post_id ] ?? 0,
+				);
+			}
+		}
+
+		// Top linked: descending inbound, cap 20.
+		$inbound_sorted = $inbound;
+		arsort( $inbound_sorted );
+		$top_linked = array();
+		$top_count  = 0;
+		foreach ( $inbound_sorted as $post_id => $count ) {
+			if ( 0 === $count || $top_count >= 20 ) {
+				break;
+			}
+			$top_linked[] = array(
+				'post_id'   => (int) $post_id,
+				'title'     => $id_to_title[ $post_id ] ?? '',
+				'permalink' => $id_to_url[ $post_id ] ?? '',
+				'inbound'   => (int) $count,
+				'outbound'  => $outbound_counts[ $post_id ] ?? 0,
+			);
+			++$top_count;
+		}
+
+		$total_scanned  = count( $post_ids );
+		$outbound_total = array_sum( $outbound_counts );
+		$inbound_total  = array_sum( $inbound );
+
+		return array(
+			'outbound'       => $outbound,
+			'orphaned_posts' => $orphaned,
+			'top_linked'     => $top_linked,
+			'orphaned_count' => count( $orphaned ),
+			'avg_outbound'   => $total_scanned > 0 ? round( $outbound_total / $total_scanned, 2 ) : 0,
+			'avg_inbound'    => $total_scanned > 0 ? round( $inbound_total / $total_scanned, 2 ) : 0,
+		);
+	}
+
+	/**
+	 * Sanitize a `types` input parameter into a normalized array of edge_type
+	 * strings. Accepts arrays, comma-separated strings, or empty/null values.
+	 *
+	 * @since 0.72.0
+	 *
+	 * @param mixed $raw Raw input.
+	 * @return array|null Non-empty array of edge types, or null for "all types".
+	 */
+	private static function normalizeTypesInput( $raw ): ?array {
+		if ( empty( $raw ) ) {
+			return null;
+		}
+		if ( is_string( $raw ) ) {
+			$raw = array_map( 'trim', explode( ',', $raw ) );
+		}
+		if ( ! is_array( $raw ) ) {
+			return null;
+		}
+		$normalized = array();
+		foreach ( $raw as $type ) {
+			if ( ! is_scalar( $type ) ) {
+				continue;
+			}
+			$type = sanitize_key( (string) $type );
+			if ( '' === $type ) {
+				continue;
+			}
+			$normalized[ $type ] = true;
+		}
+		if ( empty( $normalized ) ) {
+			return null;
+		}
+		return array_keys( $normalized );
 	}
 
 	/**

--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -72,6 +72,11 @@ class InternalLinkingAbilities {
 	 * link graph filters so core behavior is a participant, not a hardcoded
 	 * fallback.
 	 *
+	 * Intentionally uses anonymous closures so these registrations cannot
+	 * be removed by consumers via `remove_filter`. The built-in edge type
+	 * is a guarantee of the core primitive, not a default that third-party
+	 * code should be able to silently drop.
+	 *
 	 * @since 0.72.0
 	 */
 	private function registerBuiltInLinkGraphParticipants(): void {
@@ -826,7 +831,10 @@ class InternalLinkingAbilities {
 		$filtered_links = array();
 		foreach ( $all_links as $edge ) {
 			$edge_type = (string) ( $edge['edge_type'] ?? '' );
-			if ( '' === $edge_type || isset( $types_set[ $edge_type ] ) ) {
+			// Drop edges lacking a type when a filter is active — dispatchExtractors
+			// stamps edge_type from the registration key, so missing types only
+			// appear for malformed data and shouldn't leak into scoped results.
+			if ( '' !== $edge_type && isset( $types_set[ $edge_type ] ) ) {
 				$filtered_links[] = $edge;
 			}
 		}
@@ -1843,7 +1851,11 @@ class InternalLinkingAbilities {
 			if ( $source_id <= 0 ) {
 				continue;
 			}
-			if ( null !== $types_set && '' !== $edge_type && ! isset( $types_set[ $edge_type ] ) ) {
+			// Drop edges lacking a type when a filter is active — same rationale
+			// as applyTypesFilterToGraph(): dispatch stamps edge_type from the
+			// registration key, so missing types only appear for malformed data
+			// and shouldn't leak into scoped aggregates.
+			if ( null !== $types_set && ( '' === $edge_type || ! isset( $types_set[ $edge_type ] ) ) ) {
 				continue;
 			}
 			if ( null === $target_id ) {

--- a/inc/Api/InternalLinks.php
+++ b/inc/Api/InternalLinks.php
@@ -144,6 +144,19 @@ class InternalLinks {
 			$input = array();
 		}
 
+		// Normalize `types` for GET where arrays arrive as comma-separated strings
+		// (e.g. ?types=html_anchor,wikilink) and keep arrays intact for JSON bodies.
+		if ( array_key_exists( 'types', $input ) ) {
+			$types = $input['types'];
+			if ( is_string( $types ) ) {
+				$types = array_filter( array_map( 'trim', explode( ',', $types ) ) );
+			}
+			if ( ! is_array( $types ) ) {
+				$types = array();
+			}
+			$input['types'] = array_values( $types );
+		}
+
 		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {

--- a/inc/Cli/Commands/LinksCommand.php
+++ b/inc/Cli/Commands/LinksCommand.php
@@ -29,6 +29,29 @@ defined( 'ABSPATH' ) || exit;
 class LinksCommand extends BaseCommand {
 
 	/**
+	 * Parse a `--types=` associative arg into a normalized array.
+	 *
+	 * Accepts comma-separated values (e.g. `--types=html_anchor,wikilink`).
+	 * Returns an empty array when the flag is omitted or empty.
+	 *
+	 * @since 0.72.0
+	 *
+	 * @param array $assoc_args CLI associative args.
+	 * @return array
+	 */
+	private static function parseTypesArg( array $assoc_args ): array {
+		$raw = $assoc_args['types'] ?? '';
+		if ( is_array( $raw ) ) {
+			return array_values( array_filter( array_map( 'strval', $raw ) ) );
+		}
+		$raw = (string) $raw;
+		if ( '' === trim( $raw ) ) {
+			return array();
+		}
+		return array_values( array_filter( array_map( 'trim', explode( ',', $raw ) ) ) );
+	}
+
+	/**
 	 * Queue internal cross-linking for posts.
 	 *
 	 * ## OPTIONS
@@ -272,6 +295,9 @@ class LinksCommand extends BaseCommand {
 	 * [--force]
 	 * : Force rebuild even if cached graph exists.
 	 *
+	 * [--types=<types>]
+	 * : Comma-separated list of edge types to include (e.g. html_anchor,wikilink). Omit for all types.
+	 *
 	 * [--show=<section>]
 	 * : Which section to display: summary, orphans, top, all.
 	 * ---
@@ -327,6 +353,8 @@ class LinksCommand extends BaseCommand {
 			$post_ids = array_map( 'absint', explode( ',', $assoc_args['post_id'] ) );
 		}
 
+		$types = self::parseTypesArg( $assoc_args );
+
 		WP_CLI::log( 'Scanning post content for internal links...' );
 
 		$result = InternalLinkingAbilities::auditInternalLinks(
@@ -335,6 +363,7 @@ class LinksCommand extends BaseCommand {
 				'category'  => $category,
 				'post_ids'  => $post_ids,
 				'force'     => $force,
+				'types'     => $types,
 			)
 		);
 
@@ -460,6 +489,9 @@ class LinksCommand extends BaseCommand {
 	 * default: 50
 	 * ---
 	 *
+	 * [--types=<types>]
+	 * : Comma-separated list of edge types to include (e.g. html_anchor,wikilink). Omit for all types.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -495,6 +527,7 @@ class LinksCommand extends BaseCommand {
 			array(
 				'post_type' => $post_type,
 				'limit'     => $limit,
+				'types'     => self::parseTypesArg( $assoc_args ),
 			)
 		);
 
@@ -549,6 +582,9 @@ class LinksCommand extends BaseCommand {
 	 * default: post
 	 * ---
 	 *
+	 * [--types=<types>]
+	 * : Comma-separated list of edge types to include (e.g. html_anchor,wikilink). Omit for all types.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -589,6 +625,7 @@ class LinksCommand extends BaseCommand {
 			array(
 				'post_id'   => $post_id,
 				'post_type' => $post_type,
+				'types'     => self::parseTypesArg( $assoc_args ),
 			)
 		);
 
@@ -654,6 +691,9 @@ class LinksCommand extends BaseCommand {
 	 * default: 28
 	 * ---
 	 *
+	 * [--types=<types>]
+	 * : Comma-separated list of edge types to include in link counts (e.g. html_anchor,wikilink). Omit for all types.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -698,6 +738,7 @@ class LinksCommand extends BaseCommand {
 				'category'   => $category,
 				'min_clicks' => $min_clicks,
 				'days'       => $days,
+				'types'      => self::parseTypesArg( $assoc_args ),
 			)
 		);
 
@@ -776,6 +817,9 @@ class LinksCommand extends BaseCommand {
 	 * default: 5
 	 * ---
 	 *
+	 * [--types=<types>]
+	 * : Comma-separated list of edge types to include for internal-link checks (e.g. html_anchor,wikilink). Omit for all types.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -828,6 +872,7 @@ class LinksCommand extends BaseCommand {
 				'scope'     => $scope,
 				'limit'     => $limit,
 				'timeout'   => $timeout,
+				'types'     => self::parseTypesArg( $assoc_args ),
 			)
 		);
 

--- a/inc/Engine/AI/Tools/Global/InternalLinkAudit.php
+++ b/inc/Engine/AI/Tools/Global/InternalLinkAudit.php
@@ -131,6 +131,12 @@ class InternalLinkAudit extends BaseTool {
 					'required'    => false,
 					'description' => 'Maximum results to return. For orphans: max posts (default 50). For broken: max URLs to check (default 200).',
 				),
+				'types'     => array(
+					'type'        => 'array',
+					'required'    => false,
+					'description' => 'Optional edge types to include (e.g. ["html_anchor"], ["wikilink"]). Omit for all registered types.',
+					'items'       => array( 'type' => 'string' ),
+				),
 			),
 		);
 	}

--- a/tests/Unit/Abilities/InternalLinkingAbilitiesTest.php
+++ b/tests/Unit/Abilities/InternalLinkingAbilitiesTest.php
@@ -1,0 +1,415 @@
+<?php
+/**
+ * InternalLinkingAbilities Tests
+ *
+ * Covers the link-graph extensibility primitives introduced in 0.72.0:
+ * - `datamachine_link_extractors` filter registration + dispatch.
+ * - `datamachine_link_resolvers` filter registration + dispatch.
+ * - Typed queries (`types` parameter on audit/backlinks/orphans).
+ * - Backward compatibility (no external extractors = current behavior).
+ * - Edge typing in graph storage (`outbound[source][target]` shape).
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\InternalLinkingAbilities;
+use WP_UnitTestCase;
+
+defined( 'ABSPATH' ) || exit;
+
+class InternalLinkingAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Post IDs created during a single test, keyed for convenient access.
+	 *
+	 * @var array<string, int>
+	 */
+	private array $posts = array();
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		// Ensure a stale cache doesn't leak across tests.
+		delete_transient( InternalLinkingAbilities::GRAPH_TRANSIENT_KEY );
+	}
+
+	public function tear_down(): void {
+		delete_transient( InternalLinkingAbilities::GRAPH_TRANSIENT_KEY );
+		$this->posts = array();
+		parent::tear_down();
+	}
+
+	/**
+	 * Create three interlinked posts: A links to B, B links to C, C has no outbound.
+	 * Returns [post_a_id, post_b_id, post_c_id].
+	 */
+	private function create_html_anchor_corpus(): array {
+		$post_a = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_title'  => 'Post A',
+				'post_name'   => 'post-a',
+			)
+		);
+		$post_b = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_title'  => 'Post B',
+				'post_name'   => 'post-b',
+			)
+		);
+		$post_c = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_title'  => 'Post C',
+				'post_name'   => 'post-c',
+			)
+		);
+
+		$permalink_b = get_permalink( $post_b );
+		$permalink_c = get_permalink( $post_c );
+
+		wp_update_post(
+			array(
+				'ID'           => $post_a,
+				'post_content' => '<p>See <a href="' . esc_url( $permalink_b ) . '">Post B</a> for details.</p>',
+			)
+		);
+		wp_update_post(
+			array(
+				'ID'           => $post_b,
+				'post_content' => '<p>Continue reading <a href="' . esc_url( $permalink_c ) . '">Post C</a>.</p>',
+			)
+		);
+		// Post C is an orphan from the html_anchor perspective of this corpus
+		// only if nothing links to it; here B does. C itself has no outbound.
+		wp_update_post(
+			array(
+				'ID'           => $post_c,
+				'post_content' => '<p>No outbound links here.</p>',
+			)
+		);
+
+		$this->posts = array(
+			'a' => $post_a,
+			'b' => $post_b,
+			'c' => $post_c,
+		);
+
+		return array( $post_a, $post_b, $post_c );
+	}
+
+	public function test_audit_internal_links_ability_registered(): void {
+		$ability = wp_get_ability( 'datamachine/audit-internal-links' );
+		$this->assertNotNull( $ability );
+		$this->assertSame( 'datamachine/audit-internal-links', $ability->get_name() );
+	}
+
+	public function test_html_anchor_extractor_registered_against_filter(): void {
+		$extractors = InternalLinkingAbilities::getExtractors();
+		$this->assertArrayHasKey( 'html_anchor', $extractors );
+		$this->assertArrayHasKey( 'callback', $extractors['html_anchor'] );
+		$this->assertIsCallable( $extractors['html_anchor']['callback'] );
+	}
+
+	public function test_html_anchor_resolver_registered_against_filter(): void {
+		$resolvers = InternalLinkingAbilities::getResolvers();
+		$this->assertArrayHasKey( 'html_anchor', $resolvers );
+		$this->assertArrayHasKey( 'callback', $resolvers['html_anchor'] );
+		$this->assertIsCallable( $resolvers['html_anchor']['callback'] );
+	}
+
+	public function test_default_audit_behavior_matches_pre_filter(): void {
+		$this->create_html_anchor_corpus();
+
+		$result = InternalLinkingAbilities::auditInternalLinks( array( 'force' => true ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 3, $result['total_scanned'] );
+		// A→B and B→C = 2 resolved outbound edges in this corpus.
+		$this->assertGreaterThanOrEqual( 2, $result['total_links'] );
+
+		// Every edge in the graph should be typed as html_anchor.
+		$this->assertArrayHasKey( '_all_links', $result );
+		foreach ( $result['_all_links'] as $edge ) {
+			$this->assertArrayHasKey( 'edge_type', $edge );
+			$this->assertSame( 'html_anchor', $edge['edge_type'] );
+		}
+	}
+
+	public function test_graph_outbound_uses_new_shape_with_count_and_types(): void {
+		list( $post_a, $post_b, $post_c ) = $this->create_html_anchor_corpus();
+
+		$result = InternalLinkingAbilities::auditInternalLinks( array( 'force' => true ) );
+
+		$this->assertArrayHasKey( 'outbound', $result );
+		$outbound = $result['outbound'];
+
+		// A → B edge.
+		$this->assertArrayHasKey( $post_a, $outbound );
+		$this->assertArrayHasKey( $post_b, $outbound[ $post_a ] );
+		$this->assertArrayHasKey( 'count', $outbound[ $post_a ][ $post_b ] );
+		$this->assertArrayHasKey( 'types', $outbound[ $post_a ][ $post_b ] );
+		$this->assertSame( 1, $outbound[ $post_a ][ $post_b ]['count'] );
+		$this->assertArrayHasKey( 'html_anchor', $outbound[ $post_a ][ $post_b ]['types'] );
+		$this->assertSame( 1, $outbound[ $post_a ][ $post_b ]['types']['html_anchor'] );
+
+		// B → C edge.
+		$this->assertArrayHasKey( $post_b, $outbound );
+		$this->assertArrayHasKey( $post_c, $outbound[ $post_b ] );
+		$this->assertSame( 1, $outbound[ $post_b ][ $post_c ]['count'] );
+	}
+
+	public function test_extractor_filter_dispatch_surfaces_custom_edges(): void {
+		list( $post_a, $post_b, $post_c ) = $this->create_html_anchor_corpus();
+
+		// Register a test-only extractor that emits a synthetic edge from post A → post C.
+		$extractor = static function ( $content, $context ) use ( $post_a, $post_c ) {
+			if ( (int) ( $context['post_id'] ?? 0 ) !== $post_a ) {
+				return array();
+			}
+			return array(
+				array(
+					'target_hint' => 'post-c',
+					'edge_type'   => 'test_type',
+					'display'     => 'Post C',
+					'location'    => 'body',
+				),
+			);
+		};
+		$register_extractor = static function ( $extractors ) use ( $extractor ) {
+			$extractors['test_type'] = array(
+				'label'       => 'Test type',
+				'description' => 'Synthetic edge type used in PHPUnit.',
+				'callback'    => $extractor,
+			);
+			return $extractors;
+		};
+		add_filter( 'datamachine_link_extractors', $register_extractor );
+
+		// Register a test-only resolver that maps the slug → post ID.
+		$resolver = static function ( $target_hint ) use ( $post_c ) {
+			if ( 'post-c' === $target_hint ) {
+				return $post_c;
+			}
+			return null;
+		};
+		$register_resolver = static function ( $resolvers ) use ( $resolver ) {
+			$resolvers['test_type'] = array( 'callback' => $resolver );
+			return $resolvers;
+		};
+		add_filter( 'datamachine_link_resolvers', $register_resolver );
+
+		try {
+			$result = InternalLinkingAbilities::auditInternalLinks( array( 'force' => true ) );
+
+			$this->assertTrue( $result['success'] );
+
+			// Find the synthetic edge in _all_links and assert type + resolution.
+			$found = false;
+			foreach ( $result['_all_links'] as $edge ) {
+				if ( 'test_type' === ( $edge['edge_type'] ?? '' ) ) {
+					$found = true;
+					$this->assertSame( $post_a, $edge['source_id'] );
+					$this->assertSame( $post_c, $edge['target_id'] );
+					$this->assertTrue( $edge['resolved'] );
+					$this->assertSame( 'Post C', $edge['display'] );
+					$this->assertSame( 'body', $edge['location'] );
+					break;
+				}
+			}
+			$this->assertTrue( $found, 'Expected a synthetic test_type edge in the graph.' );
+
+			// Outbound structure should reflect both html_anchor and test_type counts for A → C.
+			$outbound_a_c = $result['outbound'][ $post_a ][ $post_c ] ?? null;
+			$this->assertIsArray( $outbound_a_c );
+			$this->assertArrayHasKey( 'test_type', $outbound_a_c['types'] );
+			$this->assertSame( 1, $outbound_a_c['types']['test_type'] );
+		} finally {
+			remove_filter( 'datamachine_link_extractors', $register_extractor );
+			remove_filter( 'datamachine_link_resolvers', $register_resolver );
+		}
+	}
+
+	public function test_resolver_filter_maps_target_hint_to_post_id(): void {
+		list( , , $post_c ) = $this->create_html_anchor_corpus();
+
+		$resolver_called_with = array();
+		$resolver             = static function ( $target_hint, $context ) use ( $post_c, &$resolver_called_with ) {
+			$resolver_called_with[] = $target_hint;
+			return 'post-c' === $target_hint ? $post_c : null;
+		};
+		$register_resolver = static function ( $resolvers ) use ( $resolver ) {
+			$resolvers['test_type'] = array( 'callback' => $resolver );
+			return $resolvers;
+		};
+		add_filter( 'datamachine_link_resolvers', $register_resolver );
+
+		try {
+			$resolved = InternalLinkingAbilities::dispatchResolver( 'post-c', 'test_type', array( 'post_id' => 1 ) );
+			$this->assertSame( $post_c, $resolved );
+
+			$unresolved = InternalLinkingAbilities::dispatchResolver( 'does-not-exist', 'test_type', array() );
+			$this->assertNull( $unresolved );
+
+			// Unknown edge_type returns null (no resolver registered).
+			$unknown = InternalLinkingAbilities::dispatchResolver( 'whatever', 'unknown_type', array() );
+			$this->assertNull( $unknown );
+
+			$this->assertSame( array( 'post-c', 'does-not-exist' ), $resolver_called_with );
+		} finally {
+			remove_filter( 'datamachine_link_resolvers', $register_resolver );
+		}
+	}
+
+	public function test_backlinks_types_filter_scopes_to_single_edge_type(): void {
+		list( $post_a, $post_b, $post_c ) = $this->create_html_anchor_corpus();
+
+		// Register a synthetic extractor + resolver pointing A → C with edge_type test_type.
+		$extractor = static function ( $content, $context ) use ( $post_a ) {
+			if ( (int) ( $context['post_id'] ?? 0 ) !== $post_a ) {
+				return array();
+			}
+			return array(
+				array(
+					'target_hint' => 'post-c',
+					'edge_type'   => 'test_type',
+				),
+			);
+		};
+		$resolver = static function ( $target_hint ) use ( $post_c ) {
+			return 'post-c' === $target_hint ? $post_c : null;
+		};
+		$reg_extractor = static function ( $extractors ) use ( $extractor ) {
+			$extractors['test_type'] = array( 'callback' => $extractor );
+			return $extractors;
+		};
+		$reg_resolver = static function ( $resolvers ) use ( $resolver ) {
+			$resolvers['test_type'] = array( 'callback' => $resolver );
+			return $resolvers;
+		};
+		add_filter( 'datamachine_link_extractors', $reg_extractor );
+		add_filter( 'datamachine_link_resolvers', $reg_resolver );
+
+		try {
+			// Prime the cache by running a full audit.
+			InternalLinkingAbilities::auditInternalLinks( array( 'force' => true ) );
+
+			// Without types filter: C has two inbound (B via html_anchor, A via test_type).
+			$all_types = InternalLinkingAbilities::getBacklinks( array( 'post_id' => $post_c ) );
+			$this->assertTrue( $all_types['success'] );
+			$source_ids_all = array_map( static fn( $bl ) => $bl['source_id'], $all_types['backlinks'] );
+			sort( $source_ids_all );
+			$expected_all = array( $post_a, $post_b );
+			sort( $expected_all );
+			$this->assertSame( $expected_all, $source_ids_all );
+
+			// Scoped to test_type only: just A.
+			$scoped = InternalLinkingAbilities::getBacklinks(
+				array(
+					'post_id' => $post_c,
+					'types'   => array( 'test_type' ),
+				)
+			);
+			$this->assertTrue( $scoped['success'] );
+			$this->assertSame( 1, $scoped['backlink_count'] );
+			$this->assertSame( $post_a, $scoped['backlinks'][0]['source_id'] );
+
+			// Scoped to html_anchor only: just B.
+			$scoped_html = InternalLinkingAbilities::getBacklinks(
+				array(
+					'post_id' => $post_c,
+					'types'   => array( 'html_anchor' ),
+				)
+			);
+			$this->assertTrue( $scoped_html['success'] );
+			$this->assertSame( 1, $scoped_html['backlink_count'] );
+			$this->assertSame( $post_b, $scoped_html['backlinks'][0]['source_id'] );
+		} finally {
+			remove_filter( 'datamachine_link_extractors', $reg_extractor );
+			remove_filter( 'datamachine_link_resolvers', $reg_resolver );
+		}
+	}
+
+	public function test_audit_types_filter_recomputes_aggregates(): void {
+		list( $post_a, $post_b, $post_c ) = $this->create_html_anchor_corpus();
+
+		// Register a test_type extractor that links A → C.
+		$reg_extractor = static function ( $extractors ) use ( $post_a ) {
+			$extractors['test_type'] = array(
+				'callback' => static function ( $content, $context ) use ( $post_a ) {
+					if ( (int) ( $context['post_id'] ?? 0 ) !== $post_a ) {
+						return array();
+					}
+					return array( array( 'target_hint' => 'post-c', 'edge_type' => 'test_type' ) );
+				},
+			);
+			return $extractors;
+		};
+		$reg_resolver = static function ( $resolvers ) use ( $post_c ) {
+			$resolvers['test_type'] = array(
+				'callback' => static function ( $target_hint ) use ( $post_c ) {
+					return 'post-c' === $target_hint ? $post_c : null;
+				},
+			);
+			return $resolvers;
+		};
+		add_filter( 'datamachine_link_extractors', $reg_extractor );
+		add_filter( 'datamachine_link_resolvers', $reg_resolver );
+
+		try {
+			// All-types audit: total_links = html_anchor (2) + test_type (1) = 3.
+			$full = InternalLinkingAbilities::auditInternalLinks( array( 'force' => true ) );
+			$this->assertGreaterThanOrEqual( 3, $full['total_links'] );
+
+			// Scoped to test_type only: total_links in the returned view drops to 1.
+			$scoped = InternalLinkingAbilities::auditInternalLinks( array( 'types' => array( 'test_type' ) ) );
+			$this->assertSame( 1, $scoped['total_links'] );
+
+			// The scoped outbound map should only contain A → C (not B → C from html_anchor).
+			$this->assertArrayHasKey( $post_a, $scoped['outbound'] );
+			$this->assertArrayHasKey( $post_c, $scoped['outbound'][ $post_a ] );
+			$this->assertArrayNotHasKey( $post_b, $scoped['outbound'] );
+		} finally {
+			remove_filter( 'datamachine_link_extractors', $reg_extractor );
+			remove_filter( 'datamachine_link_resolvers', $reg_resolver );
+		}
+	}
+
+	public function test_cache_key_bumped_to_v2(): void {
+		// Ensures existing installs rebuild cleanly on upgrade.
+		$this->assertSame( 'datamachine_link_graph_v2', InternalLinkingAbilities::GRAPH_TRANSIENT_KEY );
+	}
+
+	public function test_extractor_stamps_edge_type_from_registration_key(): void {
+		// Extractor that returns edges WITHOUT an edge_type — dispatch should stamp the key.
+		$reg = static function ( $extractors ) {
+			$extractors['stamped_type'] = array(
+				'callback' => static function () {
+					return array( array( 'target_hint' => 'whatever' ) );
+				},
+			);
+			return $extractors;
+		};
+		add_filter( 'datamachine_link_extractors', $reg );
+
+		try {
+			$edges = InternalLinkingAbilities::dispatchExtractors( '<p>ignored</p>', array( 'post_id' => 1, 'post_type' => 'post' ) );
+			$found = false;
+			foreach ( $edges as $edge ) {
+				if ( 'whatever' === ( $edge['target_hint'] ?? '' ) ) {
+					$this->assertSame( 'stamped_type', $edge['edge_type'] );
+					$found = true;
+				}
+			}
+			$this->assertTrue( $found );
+		} finally {
+			remove_filter( 'datamachine_link_extractors', $reg );
+		}
+	}
+}

--- a/tests/Unit/Abilities/InternalLinkingAbilitiesTest.php
+++ b/tests/Unit/Abilities/InternalLinkingAbilitiesTest.php
@@ -131,8 +131,8 @@ class InternalLinkingAbilitiesTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( 3, $result['total_scanned'] );
-		// A→B and B→C = 2 resolved outbound edges in this corpus.
-		$this->assertGreaterThanOrEqual( 2, $result['total_links'] );
+		// A→B and B→C = exactly 2 resolved outbound edges in this corpus.
+		$this->assertSame( 2, $result['total_links'] );
 
 		// Every edge in the graph should be typed as html_anchor.
 		$this->assertArrayHasKey( '_all_links', $result );
@@ -363,9 +363,9 @@ class InternalLinkingAbilitiesTest extends WP_UnitTestCase {
 		add_filter( 'datamachine_link_resolvers', $reg_resolver );
 
 		try {
-			// All-types audit: total_links = html_anchor (2) + test_type (1) = 3.
+			// All-types audit: total_links = html_anchor (2) + test_type (1) = exactly 3.
 			$full = InternalLinkingAbilities::auditInternalLinks( array( 'force' => true ) );
-			$this->assertGreaterThanOrEqual( 3, $full['total_links'] );
+			$this->assertSame( 3, $full['total_links'] );
 
 			// Scoped to test_type only: total_links in the returned view drops to 1.
 			$scoped = InternalLinkingAbilities::auditInternalLinks( array( 'types' => array( 'test_type' ) ) );


### PR DESCRIPTION
## Summary

Makes `DataMachine\Abilities\InternalLinkingAbilities` extensible via two filters plus edge typing in graph storage, so consumers with different link conventions (Obsidian-style `[[wikilinks]]`, hashtags, mentions, custom brackets) can participate in the link graph without forking it.

Fixes Extra-Chill/data-machine#1143.

## The three changes

### 1. `datamachine_link_extractors` filter

Keyed map of `edge_type => [ label, description, callback ]`. Callbacks receive `(string $content, array $context)` and return edges with `target_hint`, `edge_type`, optional `display`, and `location`. Context carries `post_id`, `post_type`, `home_host`, etc., so extractors can be scope-aware.

DM's built-in `html_anchor` extractor is registered against this filter during plugin boot — the built-in behavior is a participant, not a hardcoded fallback.

### 2. `datamachine_link_resolvers` filter

Keyed map of `edge_type => [ callback ]`. Callbacks receive `(string $target_hint, array $context)` and return `?int` (post ID or null). DM's `html_anchor` resolver (URL→home-host → `url_to_postid()`) registers against this filter.

### 3. Edge typing in graph storage

Every edge in `_all_links` now carries `edge_type`. The graph exposes a new `outbound` field matching the issue spec:

```php
'outbound' => [
    source_id => [
        target_id => [ 'count' => N, 'types' => [ type => N ] ],
    ],
]
```

Query abilities (`audit`, `getBacklinks`, `getOrphanedPosts`, `getLinkOpportunities`, `checkBrokenLinks`) accept an optional `types` parameter. When set, aggregates are recomputed from the raw edge list scoped to the requested types. No param = all types unioned (backward compatible).

`GRAPH_TRANSIENT_KEY` bumped to `datamachine_link_graph_v2`; existing installs rebuild the graph on first read.

## Files touched

- `inc/Abilities/InternalLinkingAbilities.php` — new filter dispatch + `extractHtmlAnchorEdges()` / `resolveHtmlAnchor()` / `dispatchExtractors()` / `dispatchResolver()` / `computeGraphAggregates()` / `applyTypesFilterToGraph()` / `normalizeTypesInput()`; `types` threaded through query methods; cache key bumped.
- `inc/Api/InternalLinks.php` — REST endpoints normalize `types` (arrays for POST, comma-separated for GET).
- `inc/Cli/Commands/LinksCommand.php` — `--types=` flag on `audit`, `orphans`, `backlinks`, `opportunities`, `broken` subcommands, with shared `parseTypesArg()` helper.
- `inc/Engine/AI/Tools/Global/InternalLinkAudit.php` — adds `types` as an array tool parameter.
- `tests/Unit/Abilities/InternalLinkingAbilitiesTest.php` — new PHPUnit coverage (see below).

## Acceptance criteria (from #1143)

- [x] `datamachine_link_extractors` filter documented; DM's `html_anchor` extractor registered against it.
- [x] `datamachine_link_resolvers` filter documented; DM's `html_anchor` resolver registered against it.
- [x] Each graph edge carries `edge_type`.
- [x] `getBacklinks`, `auditInternalLinks`, `getOrphanedPosts`, `getLinkOpportunities`, `checkBrokenLinks` accept optional `types` parameter.
- [x] Zero external extractors/resolvers registered → behavior matches today (existing queries return all-types unioned; built-in `html_anchor` is the only participant).
- [x] A test-only extractor + resolver registration produces expected edges in the audit output with the right `edge_type` (see `test_extractor_filter_dispatch_surfaces_custom_edges`).
- [x] Cache version bumped (`datamachine_link_graph_v2`); existing installs rebuild on first read without error.
- [x] REST + CLI + AI tool surfaces accept `types` pass-through.
- [x] New PHPUnit tests for filter registration, dispatch, and typed queries.

## Test execution status

- All modified files pass `php -l`.
- PHPUnit tests are **written but not executed locally**. `homeboy test data-machine` failed on this machine with a `db_connect_fail` (the WP test DB wasn't reachable in this environment) — that's an environment issue unrelated to the changes in this PR.
- **Recommend reviewer runs `homeboy test data-machine` in an env where the test DB is configured** before merging. The relevant new test class is `DataMachine\Tests\Unit\Abilities\InternalLinkingAbilitiesTest` — you can filter with `homeboy test data-machine -- --filter=InternalLinkingAbilitiesTest`.

## Downstream

Unblocks Automattic/intelligence#128 / #129 — Intelligence's wikilink graph can now be built as ~300 lines of registration glue on top of this primitive, replacing the 666-line parallel `Intelligence_Wiki_Linkgraph`. That follow-up is out of scope for this PR.