### PR TITLE
feat(actions): ActionPolicyResolver — tool invocation approval primitive

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -242,6 +242,11 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\Content\ReplacePostBlocksAbility();
 	new \DataMachine\Abilities\Content\InsertContentAbility();
 	new \DataMachine\Abilities\Content\ResolveDiffAbility();
+
+	// ActionPolicy + pending-action resolver (generic successor to ResolveDiffAbility).
+	new \DataMachine\Engine\AI\Actions\ResolvePendingActionAbility();
+	new \DataMachine\Engine\AI\Actions\ResolvePendingAction();
+
 	// GitHubAbilities moved to data-machine-code extension.
 	new \DataMachine\Abilities\Fetch\FetchFilesAbility();
 	new \DataMachine\Abilities\Email\EmailAbilities();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Data Machine will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **ActionPolicyResolver** (`inc/Engine/AI/Actions/ActionPolicyResolver.php`) — third sibling to `ToolPolicyResolver` and `MemoryPolicyResolver`. Decides whether a tool invocation executes directly, is staged for user approval (`preview`), or is refused (`forbidden`). Reads `agent_config.action_policy`. Resolution precedence: context-deny → per-agent tool → per-agent category → tool-declared default → mode preset → global default → `datamachine_tool_action_policy` filter.
+- **PendingActionStore** (generic successor to `PendingDiffStore`): kind-agnostic transient storage for tool invocations awaiting user resolution.
+- **PendingActionHelper** — convenience `stage()` method for tool handlers that need to produce a preview envelope. Fires `datamachine_pending_action_staged` action.
+- **ResolvePendingActionAbility** (`datamachine/resolve-pending-action`): generic resolver that dispatches by `kind` via the `datamachine_pending_action_handlers` filter. REST: `POST /datamachine/v1/actions/resolve`.
+- **`resolve_pending_action` chat tool** — thin BaseTool wrapper so the AI can close the loop on staged actions.
+- `datamachine-actions` ability category.
+
+### Changed
+- `ToolExecutor::executeTool()` now consults `ActionPolicyResolver` before invoking a tool handler. Forbidden invocations return an error; preview invocations stage via `PendingActionHelper` and return the standardized envelope instead of firing the handler. Tools without `action_policy` metadata resolve to `direct` — behavior is unchanged for all existing tools.
+- `ToolExecutor::executeTool()` accepts optional `$mode`, `$agent_id`, and `$client_context` parameters so the resolver has enough context. Old 4-arg callers continue to work (defaults: `mode=chat`, `agent_id=0`, `client_context=[]`).
+- `AIConversationLoop::execute()` forwards `$context`, `$payload['agent_id']`, and `$payload['client_context']` into `ToolExecutor::executeTool()`.
+
 ## [0.71.0] - 2026-04-21
 
 ### Added

--- a/inc/Abilities/AbilityCategories.php
+++ b/inc/Abilities/AbilityCategories.php
@@ -41,6 +41,7 @@ class AbilityCategories {
 	public const LOGGING    = 'datamachine-logging';
 	public const SYSTEM     = 'datamachine-system';
 	public const CHAT       = 'datamachine-chat';
+	public const ACTIONS    = 'datamachine-actions';
 
 	private static bool $registered = false;
 
@@ -128,6 +129,10 @@ class AbilityCategories {
 			self::CHAT       => array(
 				'label'       => __( 'Chat', 'data-machine' ),
 				'description' => __( 'Chat session management and messaging.', 'data-machine' ),
+			),
+			self::ACTIONS    => array(
+				'label'       => __( 'Actions', 'data-machine' ),
+				'description' => __( 'Pending action staging and resolution (user approval of tool invocations).', 'data-machine' ),
 			),
 		);
 

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -323,12 +323,17 @@ class AIConversationLoop {
 					);
 					$messages[]        = $tool_call_message;
 
-					// Execute the tool
+					// Execute the tool. Pass mode + agent_id + client_context
+					// so ActionPolicyResolver can apply per-agent and per-mode
+					// policy (preview/forbidden/direct) before the handler fires.
 					$tool_result = ToolExecutor::executeTool(
 						$tool_name,
 						$tool_parameters,
 						$tools,
-						$payload
+						$payload,
+						$context,
+						(int) ( $payload['agent_id'] ?? 0 ),
+						is_array( $payload['client_context'] ?? null ) ? $payload['client_context'] : array()
 					);
 
 					do_action(

--- a/inc/Engine/AI/Actions/ActionPolicyResolver.php
+++ b/inc/Engine/AI/Actions/ActionPolicyResolver.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * Action Policy Resolver
+ *
+ * Determines HOW a tool invocation is allowed to execute. Sibling to
+ * ToolPolicyResolver (which decides IF a tool is visible) and
+ * MemoryPolicyResolver (which decides WHICH memory files inject). Where
+ * ToolPolicy answers "can the agent see this tool?", ActionPolicy answers
+ * "having called it, does it execute directly, stage for user approval,
+ * or get refused?"
+ *
+ * Returned policy is one of:
+ *
+ *   - 'direct'    Execute immediately (default; no behavioral change).
+ *   - 'preview'   Stage the invocation via PendingActionStore and return
+ *                 a user-confirmation envelope instead of calling the
+ *                 underlying handler.
+ *   - 'forbidden' Refuse the invocation with an error.
+ *
+ * Resolution precedence (highest to lowest):
+ *
+ * 1. Explicit `deny` list in context (any listed tool → 'forbidden').
+ * 2. Per-agent `action_policy.tools[<tool_name>]` override.
+ * 3. Per-agent `action_policy.categories[<category>]` override.
+ * 4. Tool-declared default (`tool_def['action_policy']`) when present.
+ * 5. Mode preset (chat defaults publish-family to 'preview', pipeline
+ *    and system default to 'direct' since there is no user to confirm).
+ * 6. Global default: 'direct'.
+ * 7. `datamachine_tool_action_policy` filter (always runs last).
+ *
+ * @package DataMachine\Engine\AI\Actions
+ * @since   0.72.0
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+use DataMachine\Core\Database\Agents\Agents;
+
+defined( 'ABSPATH' ) || exit;
+
+class ActionPolicyResolver {
+
+	/**
+	 * Agent mode presets, aligned with ToolPolicyResolver and
+	 * MemoryPolicyResolver for consistency.
+	 */
+	public const MODE_PIPELINE = 'pipeline';
+	public const MODE_CHAT     = 'chat';
+	public const MODE_SYSTEM   = 'system';
+
+	/**
+	 * Valid policy values. Returned by resolveForTool().
+	 */
+	public const POLICY_DIRECT    = 'direct';
+	public const POLICY_PREVIEW   = 'preview';
+	public const POLICY_FORBIDDEN = 'forbidden';
+
+	/**
+	 * Resolve the action policy for a single tool invocation.
+	 *
+	 * @param array $context {
+	 *     Resolution context.
+	 *
+	 *     @type string     $tool_name      Required. The tool being invoked.
+	 *     @type string     $mode           Required. Agent mode (chat/pipeline/system).
+	 *     @type array      $tool_def       Optional. Tool definition (to read `action_policy` default).
+	 *     @type int|null   $agent_id       Optional. Acting agent ID for per-agent overrides.
+	 *     @type array      $client_context Optional. Client-supplied runtime context.
+	 *     @type string[]   $deny           Optional. Tools to forcibly forbid in this call.
+	 * }
+	 * @return string One of the POLICY_* constants.
+	 */
+	public function resolveForTool( array $context ): string {
+		$tool_name      = (string) ( $context['tool_name'] ?? '' );
+		$mode           = (string) ( $context['mode'] ?? self::MODE_CHAT );
+		$tool_def       = is_array( $context['tool_def'] ?? null ) ? $context['tool_def'] : array();
+		$agent_id       = isset( $context['agent_id'] ) ? (int) $context['agent_id'] : 0;
+		$deny           = is_array( $context['deny'] ?? null ) ? $context['deny'] : array();
+		$client_context = is_array( $context['client_context'] ?? null ) ? $context['client_context'] : array();
+
+		if ( '' === $tool_name ) {
+			return self::POLICY_DIRECT;
+		}
+
+		// 1. Explicit deny list always wins.
+		if ( in_array( $tool_name, $deny, true ) ) {
+			return $this->applyFilter( self::POLICY_FORBIDDEN, $tool_name, $mode, $context );
+		}
+
+		// 2 + 3. Per-agent overrides (tool-specific, then category).
+		if ( $agent_id > 0 ) {
+			$agent_policy = $this->getAgentActionPolicy( $agent_id );
+
+			if ( null !== $agent_policy ) {
+				$tool_override = $this->agentToolOverride( $agent_policy, $tool_name );
+				if ( null !== $tool_override ) {
+					return $this->applyFilter( $tool_override, $tool_name, $mode, $context );
+				}
+
+				$category_override = $this->agentCategoryOverride( $agent_policy, $tool_def );
+				if ( null !== $category_override ) {
+					return $this->applyFilter( $category_override, $tool_name, $mode, $context );
+				}
+			}
+		}
+
+		// 4. Tool-declared default.
+		$tool_default = $this->toolDeclaredDefault( $tool_def );
+		if ( null !== $tool_default ) {
+			// Mode can still upgrade a 'direct' default to 'preview' in chat
+			// if the tool opts in via action_policy_chat. Check step 5 first.
+			$mode_preset = $this->modePreset( $tool_def, $mode );
+			if ( null !== $mode_preset && self::POLICY_PREVIEW === $mode_preset && self::POLICY_DIRECT === $tool_default ) {
+				return $this->applyFilter( $mode_preset, $tool_name, $mode, $context );
+			}
+			return $this->applyFilter( $tool_default, $tool_name, $mode, $context );
+		}
+
+		// 5. Mode preset (only meaningful when the tool has opted in).
+		$mode_preset = $this->modePreset( $tool_def, $mode );
+		if ( null !== $mode_preset ) {
+			return $this->applyFilter( $mode_preset, $tool_name, $mode, $context );
+		}
+
+		// 6. Global default.
+		return $this->applyFilter( self::POLICY_DIRECT, $tool_name, $mode, $context );
+	}
+
+	/**
+	 * Read an agent's action_policy from agent_config.
+	 *
+	 * Returns null when the agent does not exist, has no policy, or the
+	 * policy is structurally invalid. Mirrors the null-for-no-op pattern
+	 * used by ToolPolicyResolver and MemoryPolicyResolver.
+	 *
+	 * Policy shape:
+	 *
+	 *   array(
+	 *       'tools'      => array( 'publish_instagram' => 'preview' ),
+	 *       'categories' => array( 'datamachine-socials' => 'preview' ),
+	 *   )
+	 *
+	 * @param int $agent_id Agent ID.
+	 * @return array|null { tools?: map, categories?: map } or null.
+	 */
+	public function getAgentActionPolicy( int $agent_id ): ?array {
+		if ( $agent_id <= 0 ) {
+			return null;
+		}
+
+		$agents_repo = new Agents();
+		$agent       = $agents_repo->get_agent( $agent_id );
+
+		if ( ! $agent ) {
+			return null;
+		}
+
+		$config = $agent['agent_config'] ?? array();
+		if ( empty( $config['action_policy'] ) || ! is_array( $config['action_policy'] ) ) {
+			return null;
+		}
+
+		$policy = $config['action_policy'];
+
+		$tools      = ( isset( $policy['tools'] ) && is_array( $policy['tools'] ) )
+			? array_filter( array_map( array( $this, 'normalizePolicyValue' ), $policy['tools'] ) )
+			: array();
+		$categories = ( isset( $policy['categories'] ) && is_array( $policy['categories'] ) )
+			? array_filter( array_map( array( $this, 'normalizePolicyValue' ), $policy['categories'] ) )
+			: array();
+
+		if ( empty( $tools ) && empty( $categories ) ) {
+			return null;
+		}
+
+		return array(
+			'tools'      => $tools,
+			'categories' => $categories,
+		);
+	}
+
+	/**
+	 * Look up a per-tool override in an agent policy.
+	 *
+	 * @param array  $policy    Normalized agent policy.
+	 * @param string $tool_name Tool being resolved.
+	 * @return string|null Policy value, or null if no override.
+	 */
+	private function agentToolOverride( array $policy, string $tool_name ): ?string {
+		$tools = $policy['tools'] ?? array();
+		return isset( $tools[ $tool_name ] ) ? $tools[ $tool_name ] : null;
+	}
+
+	/**
+	 * Look up a per-category override in an agent policy.
+	 *
+	 * Walks the tool's linked abilities (`ability` + `abilities`) and
+	 * returns the first matching override.
+	 *
+	 * @param array $policy   Normalized agent policy.
+	 * @param array $tool_def Tool definition.
+	 * @return string|null Policy value, or null if no override.
+	 */
+	private function agentCategoryOverride( array $policy, array $tool_def ): ?string {
+		$categories = $policy['categories'] ?? array();
+		if ( empty( $categories ) ) {
+			return null;
+		}
+
+		$registry = class_exists( 'WP_Abilities_Registry' ) ? \WP_Abilities_Registry::get_instance() : null;
+		if ( ! $registry ) {
+			return null;
+		}
+
+		$ability_slugs = array();
+		if ( ! empty( $tool_def['ability'] ) ) {
+			$ability_slugs[] = (string) $tool_def['ability'];
+		}
+		if ( ! empty( $tool_def['abilities'] ) && is_array( $tool_def['abilities'] ) ) {
+			foreach ( $tool_def['abilities'] as $slug ) {
+				$ability_slugs[] = (string) $slug;
+			}
+		}
+
+		foreach ( $ability_slugs as $slug ) {
+			$ability = $registry->get_registered( $slug );
+			if ( $ability ) {
+				$cat = $ability->get_category();
+				if ( isset( $categories[ $cat ] ) ) {
+					return $categories[ $cat ];
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Tool-declared default policy.
+	 *
+	 * Tools opt into ActionPolicy by declaring `action_policy` in their
+	 * definition (returned by BaseTool::getToolDefinition()). Unopted tools
+	 * return null and fall through to mode preset / global default.
+	 *
+	 * @param array $tool_def Tool definition.
+	 * @return string|null
+	 */
+	private function toolDeclaredDefault( array $tool_def ): ?string {
+		if ( empty( $tool_def['action_policy'] ) ) {
+			return null;
+		}
+		$value = $this->normalizePolicyValue( $tool_def['action_policy'] );
+		return '' === $value ? null : $value;
+	}
+
+	/**
+	 * Mode preset.
+	 *
+	 * Tools can declare mode-specific defaults via `action_policy_chat`,
+	 * `action_policy_pipeline`, `action_policy_system`. In chat mode this
+	 * lets a tool default to 'preview' conversationally while leaving
+	 * pipeline execution at 'direct' (no user to confirm).
+	 *
+	 * @param array  $tool_def Tool definition.
+	 * @param string $mode     Agent mode.
+	 * @return string|null
+	 */
+	private function modePreset( array $tool_def, string $mode ): ?string {
+		$key = 'action_policy_' . $mode;
+		if ( empty( $tool_def[ $key ] ) ) {
+			return null;
+		}
+		$value = $this->normalizePolicyValue( $tool_def[ $key ] );
+		return '' === $value ? null : $value;
+	}
+
+	/**
+	 * Normalize a user-supplied policy value.
+	 *
+	 * Returns one of the POLICY_* constants, or an empty string when the
+	 * value is not recognized (caller drops it).
+	 *
+	 * @param mixed $value Raw value from config or tool def.
+	 * @return string Normalized policy or ''.
+	 */
+	private function normalizePolicyValue( $value ): string {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+		$value = strtolower( trim( $value ) );
+		$allowed = array(
+			self::POLICY_DIRECT,
+			self::POLICY_PREVIEW,
+			self::POLICY_FORBIDDEN,
+		);
+		return in_array( $value, $allowed, true ) ? $value : '';
+	}
+
+	/**
+	 * Apply the datamachine_tool_action_policy filter and validate the result.
+	 *
+	 * @param string $policy    Policy computed by the resolver.
+	 * @param string $tool_name Tool being resolved.
+	 * @param string $mode      Agent mode.
+	 * @param array  $context   Full resolution context.
+	 * @return string Filtered policy (falls back to computed value if filter returns garbage).
+	 */
+	private function applyFilter( string $policy, string $tool_name, string $mode, array $context ): string {
+		/**
+		 * Filter the resolved action policy for a single tool invocation.
+		 *
+		 * Runs after all layered resolution. Allows plugins to force a
+		 * specific policy (e.g. network admin override, audit-mode wrapper)
+		 * without touching agent_config.
+		 *
+		 * @since 0.72.0
+		 *
+		 * @param string $policy    Computed policy (direct/preview/forbidden).
+		 * @param string $tool_name Tool name.
+		 * @param string $mode      Agent mode.
+		 * @param array  $context   Resolution context.
+		 */
+		$filtered = apply_filters( 'datamachine_tool_action_policy', $policy, $tool_name, $mode, $context );
+
+		$normalized = $this->normalizePolicyValue( $filtered );
+		return '' === $normalized ? $policy : $normalized;
+	}
+
+	/**
+	 * Available agent mode presets.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function getModes(): array {
+		return array(
+			self::MODE_CHAT     => 'Admin chat session (users present, preview-friendly)',
+			self::MODE_PIPELINE => 'Pipeline step execution (no user, direct-only)',
+			self::MODE_SYSTEM   => 'System task execution (no user, direct-only)',
+		);
+	}
+}

--- a/inc/Engine/AI/Actions/PendingActionHelper.php
+++ b/inc/Engine/AI/Actions/PendingActionHelper.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * PendingActionHelper — convenience wrapper for tool handlers that need to
+ * stage an invocation for user approval.
+ *
+ * Tools that opt into ActionPolicy should never hand-roll the store/envelope
+ * shape. Call PendingActionHelper::stage() from the 'preview' branch of the
+ * tool handler and return its result directly. The AI sees a standardized
+ * envelope that tells it to show the preview to the user and wait for
+ * confirmation.
+ *
+ * Envelope shape returned to the AI:
+ *
+ *   array(
+ *       'staged'         => true,
+ *       'action_id'      => 'act_abc123',
+ *       'kind'           => 'socials_publish_instagram',
+ *       'summary'        => 'Post to Instagram: "NEW EP 🎸"',
+ *       'preview'        => array( ... preview_data ... ),
+ *       'resolve_with'   => 'resolve_pending_action',
+ *       'resolve_params' => array( 'action_id' => 'act_abc123', 'decision' => 'accepted'|'rejected' ),
+ *       'instruction'    => 'Show the preview to the user and wait for confirmation. Do not auto-accept.',
+ *       'expires_at'     => <unix ts>,
+ *   )
+ *
+ * @package DataMachine\Engine\AI\Actions
+ * @since   0.72.0
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+defined( 'ABSPATH' ) || exit;
+
+class PendingActionHelper {
+
+	/**
+	 * Stage a tool invocation for user approval.
+	 *
+	 * @param array $args {
+	 *     Staging arguments.
+	 *
+	 *     @type string   $kind         Required. Handler dispatch key (e.g. 'socials_publish_instagram').
+	 *                                  Registered via the `datamachine_pending_action_handlers` filter.
+	 *     @type string   $summary      Required. Human-readable one-liner describing what will happen.
+	 *                                  Used by the AI to narrate the preview to the user.
+	 *     @type array    $apply_input  Required. Input that will replay through the kind's apply callback
+	 *                                  when the user accepts. Must be fully self-contained — it's re-sanitized
+	 *                                  and re-executed as if the tool were called fresh.
+	 *     @type array    $preview_data Optional. Renderable preview payload (copy, images, counts, etc.).
+	 *                                  Surfaced in the envelope so the AI can summarize to the user.
+	 *     @type int|null $agent_id     Optional. Acting agent ID (recorded for audit + can_resolve checks).
+	 *     @type int|null $user_id      Optional. Acting user ID (defaults to current user).
+	 *     @type array    $context      Optional. Free-form context (session_id, bridge_app, etc.).
+	 * }
+	 * @return array Envelope for the AI (see class docblock).
+	 */
+	public static function stage( array $args ): array {
+		$kind         = isset( $args['kind'] ) ? sanitize_key( $args['kind'] ) : '';
+		$summary      = isset( $args['summary'] ) ? (string) $args['summary'] : '';
+		$apply_input  = isset( $args['apply_input'] ) && is_array( $args['apply_input'] ) ? $args['apply_input'] : array();
+		$preview_data = isset( $args['preview_data'] ) && is_array( $args['preview_data'] ) ? $args['preview_data'] : array();
+		$agent_id     = isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0;
+		$user_id      = isset( $args['user_id'] ) ? (int) $args['user_id'] : get_current_user_id();
+		$context      = isset( $args['context'] ) && is_array( $args['context'] ) ? $args['context'] : array();
+
+		if ( '' === $kind ) {
+			return array(
+				'staged'      => false,
+				'error'       => 'PendingActionHelper::stage() requires a non-empty kind.',
+				'error_code'  => 'invalid_kind',
+			);
+		}
+
+		if ( empty( $apply_input ) ) {
+			return array(
+				'staged'     => false,
+				'error'      => 'PendingActionHelper::stage() requires apply_input.',
+				'error_code' => 'missing_apply_input',
+			);
+		}
+
+		$action_id = PendingActionStore::generate_id();
+
+		$payload = array(
+			'kind'         => $kind,
+			'summary'      => wp_strip_all_tags( $summary ),
+			'apply_input'  => $apply_input,
+			'preview_data' => $preview_data,
+			'agent_id'     => $agent_id,
+			'created_by'   => $user_id,
+			'context'      => $context,
+		);
+
+		$stored = PendingActionStore::store( $action_id, $payload );
+		if ( ! $stored ) {
+			return array(
+				'staged'     => false,
+				'error'      => 'Failed to persist pending action (transient write failed).',
+				'error_code' => 'store_failed',
+			);
+		}
+
+		/**
+		 * Fires when a pending action has been staged and is awaiting resolution.
+		 *
+		 * Hook this to notify users (email, chat ping, etc.), log audit trails,
+		 * or mirror the pending action into a visible queue.
+		 *
+		 * @since 0.72.0
+		 *
+		 * @param string $action_id Action identifier.
+		 * @param array  $payload   Full payload as stored.
+		 */
+		do_action( 'datamachine_pending_action_staged', $action_id, $payload );
+
+		return array(
+			'staged'         => true,
+			'action_id'      => $action_id,
+			'kind'           => $kind,
+			'summary'        => $payload['summary'],
+			'preview'        => $preview_data,
+			'resolve_with'   => 'resolve_pending_action',
+			'resolve_params' => array(
+				'action_id' => $action_id,
+				'decision'  => '<accepted|rejected>',
+			),
+			'instruction'    => 'Show this preview to the user and wait for their confirmation. Do not call resolve_pending_action until they explicitly approve or reject. If the user asks to modify, call the original tool again with updated parameters instead of resolving this action.',
+			'expires_at'     => time() + HOUR_IN_SECONDS,
+		);
+	}
+}

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * PendingActionStore — server-side storage for tool invocations awaiting user resolution.
+ *
+ * When a tool runs in preview mode (see ActionPolicyResolver), the pending
+ * invocation is stored here instead of being applied immediately. The
+ * datamachine/resolve-pending-action ability later retrieves the stored
+ * payload and either replays it (`accepted`) or discards it (`rejected`).
+ *
+ * This is the generic successor to PendingDiffStore. PendingDiffStore was
+ * scoped to post-content diffs (`edit_post_blocks`, `replace_post_blocks`,
+ * `insert_content`); PendingActionStore is kind-agnostic and supports any
+ * tool that opts into the preview/approve workflow (socials publishes,
+ * destructive ops, account mutations, etc.).
+ *
+ * Payload shape:
+ *
+ *   array(
+ *       'kind'          => 'socials_publish_instagram',  // handler dispatch key
+ *       'summary'       => 'Post to Instagram: "NEW EP 🎸"',
+ *       'preview_data'  => array( ... ),  // UI-oriented preview payload
+ *       'apply_input'   => array( ... ),  // replayable handler input
+ *       'created_by'    => 123,            // user_id (or 0 if anonymous)
+ *       'agent_id'      => 7,              // acting agent, if any
+ *       'context'       => array( ... ),   // free-form (session_id, bridge_app, etc.)
+ *   )
+ *
+ * Uses WordPress transients with a 1-hour TTL. Stale pending actions
+ * auto-expire if never resolved.
+ *
+ * @package DataMachine\Engine\AI\Actions
+ * @since   0.72.0
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+defined( 'ABSPATH' ) || exit;
+
+class PendingActionStore {
+
+	/**
+	 * Transient TTL in seconds (1 hour).
+	 */
+	private const TTL = HOUR_IN_SECONDS;
+
+	/**
+	 * Transient key prefix. Short to keep option_name under DB limits.
+	 */
+	private const PREFIX = 'dm_pa_';
+
+	/**
+	 * Store a pending action.
+	 *
+	 * The caller is responsible for building a well-formed payload. The
+	 * store stamps a created_at timestamp and the action_id before persisting.
+	 *
+	 * @param string $action_id Unique action identifier.
+	 * @param array  $payload   Pending action payload (see class docblock).
+	 * @return bool Whether the transient was written.
+	 */
+	public static function store( string $action_id, array $payload ): bool {
+		$payload['created_at'] = time();
+		$payload['action_id']  = $action_id;
+
+		return set_transient( self::PREFIX . $action_id, $payload, self::TTL );
+	}
+
+	/**
+	 * Retrieve a pending action payload.
+	 *
+	 * @param string $action_id Action identifier.
+	 * @return array|null The payload, or null if not found / expired.
+	 */
+	public static function get( string $action_id ): ?array {
+		$data = get_transient( self::PREFIX . $action_id );
+
+		if ( false === $data || ! is_array( $data ) ) {
+			return null;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Delete a pending action (called after resolution).
+	 *
+	 * @param string $action_id Action identifier.
+	 * @return bool Whether the transient was deleted.
+	 */
+	public static function delete( string $action_id ): bool {
+		return delete_transient( self::PREFIX . $action_id );
+	}
+
+	/**
+	 * Generate a unique action identifier.
+	 *
+	 * @return string A namespaced UUID.
+	 */
+	public static function generate_id(): string {
+		return 'act_' . wp_generate_uuid4();
+	}
+}

--- a/inc/Engine/AI/Actions/ResolvePendingAction.php
+++ b/inc/Engine/AI/Actions/ResolvePendingAction.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * ResolvePendingAction chat tool.
+ *
+ * Thin chat wrapper around datamachine/resolve-pending-action. Exposes the
+ * accept/reject decision to the AI so it can finalize user approval of a
+ * staged tool invocation.
+ *
+ * This tool is always 'direct' — resolving a pending action is itself the
+ * confirmation step and must not be staged for further approval (that would
+ * loop forever).
+ *
+ * @package DataMachine\Engine\AI\Actions
+ * @since   0.72.0
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+defined( 'ABSPATH' ) || exit;
+
+class ResolvePendingAction extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool(
+			'resolve_pending_action',
+			array( $this, 'getToolDefinition' ),
+			array( 'chat' ),
+			array( 'ability' => 'datamachine/resolve-pending-action' )
+		);
+	}
+
+	/**
+	 * Tool definition surfaced to the AI.
+	 *
+	 * @return array
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'         => self::class,
+			'method'        => 'handle_tool_call',
+			'description'   => 'Resolve a pending action (staged by a publish/write tool with action_policy=preview). Call with decision=accepted to apply, decision=rejected to discard. Only call this after the user has explicitly approved or rejected the preview. Do not guess the user\'s intent — if the user wants changes, call the original tool again with new parameters instead of accepting.',
+			'parameters'    => array(
+				'action_id' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'description' => 'The action_id returned by the preview envelope.',
+				),
+				'decision'  => array(
+					'type'        => 'string',
+					'required'    => true,
+					'enum'        => array( 'accepted', 'rejected' ),
+					'description' => 'accepted to apply the staged action, rejected to discard it.',
+				),
+			),
+			// Resolving is always direct — this IS the confirmation step.
+			'action_policy' => ActionPolicyResolver::POLICY_DIRECT,
+		);
+	}
+
+	/**
+	 * Handle chat tool call.
+	 *
+	 * @param array $parameters Tool parameters from AI agent.
+	 * @param array $tool_def   Tool definition context.
+	 * @return array Result for AI agent.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$action_id = isset( $parameters['action_id'] ) ? sanitize_text_field( $parameters['action_id'] ) : '';
+		$decision  = isset( $parameters['decision'] ) ? sanitize_text_field( $parameters['decision'] ) : '';
+
+		if ( '' === $action_id || '' === $decision ) {
+			return $this->buildErrorResponse( 'action_id and decision are required.', 'resolve_pending_action' );
+		}
+
+		$result = ResolvePendingActionAbility::execute(
+			array(
+				'action_id' => $action_id,
+				'decision'  => $decision,
+			)
+		);
+
+		return $result;
+	}
+}

--- a/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
+++ b/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
@@ -1,0 +1,352 @@
+<?php
+/**
+ * ResolvePendingActionAbility — accept or reject a pending tool invocation.
+ *
+ * When a tool runs under ActionPolicy::POLICY_PREVIEW, it stages an invocation
+ * via PendingActionHelper::stage() instead of executing directly. This ability
+ * is the generic resolver that replays (accept) or discards (reject) the
+ * stored payload, dispatching to the correct handler by `kind`.
+ *
+ * Handlers register themselves via the `datamachine_pending_action_handlers`
+ * filter:
+ *
+ *   add_filter( 'datamachine_pending_action_handlers', function ( $handlers ) {
+ *       $handlers['socials_publish_instagram'] = array(
+ *           'apply'       => array( InstagramPublishAbility::class, 'execute_publish' ),
+ *           'can_resolve' => array( __CLASS__, 'canResolveInstagram' ), // optional
+ *       );
+ *       return $handlers;
+ *   } );
+ *
+ * Each handler entry:
+ *
+ *   - apply       (callable, required): invoked with the stored apply_input
+ *                 array on 'accepted'. Return value is included in the
+ *                 response. Return a WP_Error or an array with `success=>false`
+ *                 to surface failure.
+ *   - can_resolve (callable, optional): invoked with ($payload, $decision, $user_id)
+ *                 before apply. Must return true. Return a WP_Error (or false)
+ *                 to deny. Defaults to "anyone with access to the ability".
+ *
+ * REST surface: POST /datamachine/v1/actions/resolve
+ * Ability slug: datamachine/resolve-pending-action
+ * Chat tool:    resolve_pending_action (registered separately by ResolvePendingAction BaseTool)
+ *
+ * @package DataMachine\Engine\AI\Actions
+ * @since   0.72.0
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+use DataMachine\Abilities\PermissionHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+class ResolvePendingActionAbility {
+
+	/**
+	 * Ensure the ability registers exactly once.
+	 *
+	 * @var bool
+	 */
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
+			return;
+		}
+
+		$this->register_ability();
+		$this->register_rest_route();
+		self::$registered = true;
+	}
+
+	/**
+	 * Register the WordPress ability.
+	 */
+	private function register_ability(): void {
+		$register = function () {
+			wp_register_ability(
+				'datamachine/resolve-pending-action',
+				array(
+					'label'               => __( 'Resolve Pending Action', 'data-machine' ),
+					'description'         => __( 'Accept or reject a pending tool invocation staged by ActionPolicy.', 'data-machine' ),
+					'category'            => 'datamachine-actions',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'action_id', 'decision' ),
+						'properties' => array(
+							'action_id' => array(
+								'type'        => 'string',
+								'description' => __( 'The pending action identifier.', 'data-machine' ),
+							),
+							'decision'  => array(
+								'type'        => 'string',
+								'enum'        => array( 'accepted', 'rejected' ),
+								'description' => __( 'Whether to apply or discard the pending action.', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'   => array( 'type' => 'boolean' ),
+							'decision'  => array( 'type' => 'string' ),
+							'action_id' => array( 'type' => 'string' ),
+							'kind'      => array( 'type' => 'string' ),
+							'result'    => array( 'type' => 'object' ),
+							'error'     => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'execute' ),
+					'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register );
+		}
+	}
+
+	/**
+	 * Register the REST route.
+	 */
+	private function register_rest_route(): void {
+		add_action(
+			'rest_api_init',
+			function () {
+				register_rest_route(
+					'datamachine/v1',
+					'/actions/resolve',
+					array(
+						'methods'             => 'POST',
+						'callback'            => array( self::class, 'handle_rest' ),
+						'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
+						'args'                => array(
+							'action_id' => array(
+								'required'          => true,
+								'type'              => 'string',
+								'sanitize_callback' => 'sanitize_text_field',
+							),
+							'decision'  => array(
+								'required'          => true,
+								'type'              => 'string',
+								'enum'              => array( 'accepted', 'rejected' ),
+								'sanitize_callback' => 'sanitize_text_field',
+							),
+						),
+					)
+				);
+			}
+		);
+	}
+
+	/**
+	 * REST handler — delegates to execute().
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response
+	 */
+	public static function handle_rest( \WP_REST_Request $request ): \WP_REST_Response {
+		$result = self::execute(
+			array(
+				'action_id' => $request->get_param( 'action_id' ),
+				'decision'  => $request->get_param( 'decision' ),
+			)
+		);
+
+		return new \WP_REST_Response( $result, ! empty( $result['success'] ) ? 200 : 400 );
+	}
+
+	/**
+	 * Execute: accept or reject a pending action.
+	 *
+	 * @param array $input { action_id, decision }.
+	 * @return array
+	 */
+	public static function execute( array $input ): array {
+		$action_id = isset( $input['action_id'] ) ? sanitize_text_field( $input['action_id'] ) : '';
+		$decision  = isset( $input['decision'] ) ? sanitize_text_field( $input['decision'] ) : '';
+
+		if ( '' === $action_id || '' === $decision ) {
+			return array(
+				'success' => false,
+				'error'   => 'action_id and decision are required.',
+			);
+		}
+
+		if ( ! in_array( $decision, array( 'accepted', 'rejected' ), true ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'decision must be "accepted" or "rejected".',
+			);
+		}
+
+		$payload = PendingActionStore::get( $action_id );
+		if ( null === $payload ) {
+			return array(
+				'success'   => false,
+				'error'     => 'Pending action not found or expired.',
+				'action_id' => $action_id,
+			);
+		}
+
+		$kind        = (string) ( $payload['kind'] ?? '' );
+		$user_id     = get_current_user_id();
+		$apply_input = isset( $payload['apply_input'] ) && is_array( $payload['apply_input'] ) ? $payload['apply_input'] : array();
+
+		if ( '' === $kind ) {
+			PendingActionStore::delete( $action_id );
+			return array(
+				'success'   => false,
+				'error'     => 'Stored pending action has no kind; cannot resolve.',
+				'action_id' => $action_id,
+			);
+		}
+
+		$handlers = self::getKindHandlers();
+		$handler  = $handlers[ $kind ] ?? null;
+
+		if ( ! is_array( $handler ) || empty( $handler['apply'] ) || ! is_callable( $handler['apply'] ) ) {
+			// No handler registered — can't apply, but reject is still safe.
+			if ( 'rejected' === $decision ) {
+				PendingActionStore::delete( $action_id );
+				self::fireResolvedAction( $decision, $action_id, $kind, $payload, null );
+				return array(
+					'success'   => true,
+					'decision'  => 'rejected',
+					'action_id' => $action_id,
+					'kind'      => $kind,
+				);
+			}
+
+			return array(
+				'success'   => false,
+				'error'     => sprintf( 'No handler registered for pending action kind "%s".', $kind ),
+				'action_id' => $action_id,
+				'kind'      => $kind,
+			);
+		}
+
+		// Optional permission hook per kind.
+		if ( ! empty( $handler['can_resolve'] ) && is_callable( $handler['can_resolve'] ) ) {
+			$allowed = call_user_func( $handler['can_resolve'], $payload, $decision, $user_id );
+			if ( is_wp_error( $allowed ) ) {
+				return array(
+					'success'   => false,
+					'error'     => $allowed->get_error_message(),
+					'action_id' => $action_id,
+					'kind'      => $kind,
+				);
+			}
+			if ( true !== $allowed ) {
+				return array(
+					'success'   => false,
+					'error'     => 'You do not have permission to resolve this pending action.',
+					'action_id' => $action_id,
+					'kind'      => $kind,
+				);
+			}
+		}
+
+		// Always clean up the stored payload after a decision is made.
+		PendingActionStore::delete( $action_id );
+
+		if ( 'rejected' === $decision ) {
+			self::fireResolvedAction( $decision, $action_id, $kind, $payload, null );
+			return array(
+				'success'   => true,
+				'decision'  => 'rejected',
+				'action_id' => $action_id,
+				'kind'      => $kind,
+			);
+		}
+
+		// Accepted: invoke the apply handler with the stored input.
+		$result = call_user_func( $handler['apply'], $apply_input, $payload );
+
+		self::fireResolvedAction( $decision, $action_id, $kind, $payload, $result );
+
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'   => false,
+				'decision'  => 'accepted',
+				'action_id' => $action_id,
+				'kind'      => $kind,
+				'error'     => $result->get_error_message(),
+			);
+		}
+
+		if ( is_array( $result ) && array_key_exists( 'success', $result ) && false === $result['success'] ) {
+			return array(
+				'success'   => false,
+				'decision'  => 'accepted',
+				'action_id' => $action_id,
+				'kind'      => $kind,
+				'result'    => $result,
+				'error'     => $result['error'] ?? 'Apply handler reported failure.',
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'decision'  => 'accepted',
+			'action_id' => $action_id,
+			'kind'      => $kind,
+			'result'    => is_array( $result ) ? $result : array( 'value' => $result ),
+		);
+	}
+
+	/**
+	 * Read the registered kind => handler map.
+	 *
+	 * @return array
+	 */
+	private static function getKindHandlers(): array {
+		/**
+		 * Filter the map of pending-action-kind => handler config.
+		 *
+		 * Handlers should return:
+		 *
+		 *   array(
+		 *       'apply'       => callable ( array $apply_input, array $payload ): mixed,
+		 *       'can_resolve' => callable ( array $payload, string $decision, int $user_id ): bool|WP_Error,
+		 *   )
+		 *
+		 * @since 0.72.0
+		 *
+		 * @param array<string, array{apply: callable, can_resolve?: callable}> $handlers Current map.
+		 */
+		$handlers = apply_filters( 'datamachine_pending_action_handlers', array() );
+		return is_array( $handlers ) ? $handlers : array();
+	}
+
+	/**
+	 * Fire the post-resolution action.
+	 *
+	 * @param string     $decision  accepted|rejected.
+	 * @param string     $action_id Action ID.
+	 * @param string     $kind      Kind.
+	 * @param array      $payload   Stored payload.
+	 * @param mixed|null $result    Apply result (for accepted) or null.
+	 * @return void
+	 */
+	private static function fireResolvedAction( string $decision, string $action_id, string $kind, array $payload, $result ): void {
+		/**
+		 * Fires after a pending action has been resolved.
+		 *
+		 * @since 0.72.0
+		 *
+		 * @param string     $decision  accepted|rejected.
+		 * @param string     $action_id Action ID.
+		 * @param string     $kind      Kind.
+		 * @param array      $payload   Stored payload (pre-deletion).
+		 * @param mixed|null $result    Apply result (for accepted) or null.
+		 */
+		do_action( 'datamachine_pending_action_resolved', $decision, $action_id, $kind, $payload, $result );
+	}
+}

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -12,6 +12,8 @@
 namespace DataMachine\Engine\AI\Tools;
 
 use DataMachine\Core\WordPress\PostTracking;
+use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
+use DataMachine\Engine\AI\Actions\PendingActionHelper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -48,13 +50,37 @@ class ToolExecutor {
 	 * Execute tool with parameter merging and comprehensive error handling.
 	 * Builds complete parameters by combining AI parameters with step payload.
 	 *
-	 * @param  string $tool_name       Tool name to execute
-	 * @param  array  $tool_parameters Parameters from AI
-	 * @param  array  $available_tools Available tools array
-	 * @param  array  $payload         Step payload (job_id, flow_step_id, data, flow_step_config)
-	 * @return array Tool execution result
+	 * Before invoking the tool handler, consults ActionPolicyResolver to
+	 * decide whether the invocation should execute directly, be staged for
+	 * user approval (preview), or be refused (forbidden). Tools opt into
+	 * preview/forbidden via metadata; unopted tools resolve to 'direct' and
+	 * behave identically to pre-ActionPolicy releases.
+	 *
+	 * The `$mode` / `$agent_id` / `$client_context` parameters were added in
+	 * 0.72.0 so the resolver has enough context to apply per-agent and
+	 * per-mode policy. Callers that pre-date the feature (pipeline code that
+	 * goes through `getAvailableTools()`) continue to work — mode defaults
+	 * to MODE_CHAT which matches the historical assumption, and missing
+	 * agent_id simply skips per-agent policy.
+	 *
+	 * @param  string $tool_name       Tool name to execute.
+	 * @param  array  $tool_parameters Parameters from AI.
+	 * @param  array  $available_tools Available tools array.
+	 * @param  array  $payload         Step payload (job_id, flow_step_id, data, flow_step_config).
+	 * @param  string $mode            Agent mode (chat/pipeline/system). Default: chat.
+	 * @param  int    $agent_id        Acting agent ID (0 = no per-agent policy).
+	 * @param  array  $client_context  Optional client-supplied context.
+	 * @return array Tool execution result.
 	 */
-	public static function executeTool( string $tool_name, array $tool_parameters, array $available_tools, array $payload ): array {
+	public static function executeTool(
+		string $tool_name,
+		array $tool_parameters,
+		array $available_tools,
+		array $payload,
+		string $mode = ActionPolicyResolver::MODE_CHAT,
+		int $agent_id = 0,
+		array $client_context = array()
+	): array {
 		$tool_def = $available_tools[ $tool_name ] ?? null;
 		if ( ! $tool_def ) {
 			return array(
@@ -115,6 +141,78 @@ class ToolExecutor {
 			);
 		}
 
+		// Resolve the action policy for this invocation. Tools without
+		// action_policy metadata resolve to 'direct' and behave exactly
+		// as before this feature landed.
+		$resolver = new ActionPolicyResolver();
+		$policy   = $resolver->resolveForTool(
+			array(
+				'tool_name'      => $tool_name,
+				'tool_def'       => $tool_def,
+				'mode'           => $mode,
+				'agent_id'       => $agent_id,
+				'client_context' => $client_context,
+			)
+		);
+
+		if ( ActionPolicyResolver::POLICY_FORBIDDEN === $policy ) {
+			return array(
+				'success'        => false,
+				'error'          => sprintf( 'Tool "%s" is not permitted in the current context (action_policy=forbidden).', $tool_name ),
+				'tool_name'      => $tool_name,
+				'action_policy'  => $policy,
+			);
+		}
+
+		if ( ActionPolicyResolver::POLICY_PREVIEW === $policy ) {
+			// Tool must declare how to build an action kind and summary.
+			// If it hasn't opted into the preview pipeline properly, fall
+			// back to 'direct' and log a warning — preview is a contract,
+			// not something we can synthesize for tools that don't cooperate.
+			if ( empty( $tool_def['action_kind'] ) ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					'ActionPolicy: tool resolved to preview but is missing action_kind metadata; falling back to direct.',
+					array(
+						'tool_name' => $tool_name,
+						'mode'      => $mode,
+						'agent_id'  => $agent_id,
+					)
+				);
+			} else {
+				$staged = PendingActionHelper::stage(
+					array(
+						'kind'         => (string) $tool_def['action_kind'],
+						'summary'      => self::buildActionSummary( $tool_name, $complete_parameters, $tool_def ),
+						'apply_input'  => $complete_parameters,
+						'preview_data' => self::buildActionPreviewData( $complete_parameters, $tool_def ),
+						'agent_id'     => $agent_id,
+						'context'      => array_filter(
+							array(
+								'mode'           => $mode,
+								'tool_name'      => $tool_name,
+								'job_id'         => $payload['job_id'] ?? null,
+								'session_id'     => $client_context['session_id'] ?? null,
+								'bridge_app'     => $client_context['bridge_app'] ?? null,
+							),
+							fn( $v ) => null !== $v && '' !== $v
+						),
+					)
+				);
+
+				return array_merge(
+					array(
+						'success'       => true,
+						'tool_name'     => $tool_name,
+						'action_policy' => $policy,
+					),
+					$staged
+				);
+			}
+		}
+
+		// Policy is 'direct' (or 'preview' fell back) — execute the tool normally.
 		$tool_handler = new $class_name();
 		$tool_result  = $tool_handler->$method( $complete_parameters, $tool_def );
 
@@ -135,6 +233,75 @@ class ToolExecutor {
 		}
 
 		return $tool_result;
+	}
+
+	/**
+	 * Build a one-line human summary for a staged invocation.
+	 *
+	 * Tools can customize via a `build_action_summary` callable in their
+	 * definition. Fallback: `"<Tool Name>: <first-required-param-value truncated>"`.
+	 *
+	 * @param string $tool_name   Tool name.
+	 * @param array  $parameters  Complete parameters (post parameter-merge).
+	 * @param array  $tool_def    Tool definition.
+	 * @return string
+	 */
+	private static function buildActionSummary( string $tool_name, array $parameters, array $tool_def ): string {
+		if ( ! empty( $tool_def['build_action_summary'] ) && is_callable( $tool_def['build_action_summary'] ) ) {
+			$custom = call_user_func( $tool_def['build_action_summary'], $parameters, $tool_def );
+			if ( is_string( $custom ) && '' !== trim( $custom ) ) {
+				return wp_strip_all_tags( trim( $custom ) );
+			}
+		}
+
+		$label = ucwords( str_replace( '_', ' ', $tool_name ) );
+
+		// First non-empty scalar param, truncated.
+		foreach ( $tool_def['parameters'] ?? array() as $param_name => $param_config ) {
+			if ( ! isset( $parameters[ $param_name ] ) ) {
+				continue;
+			}
+			$value = $parameters[ $param_name ];
+			if ( is_string( $value ) && '' !== trim( $value ) ) {
+				$snippet = wp_trim_words( wp_strip_all_tags( $value ), 12, '…' );
+				return $label . ': ' . $snippet;
+			}
+		}
+
+		return $label;
+	}
+
+	/**
+	 * Build a preview payload for a staged invocation.
+	 *
+	 * Tools can customize via a `build_action_preview` callable. Fallback:
+	 * pass the complete parameters through (minus anything under the tool's
+	 * `action_preview_redact` allowlist). This keeps the UI informative for
+	 * opted-in tools without requiring every tool to implement its own
+	 * preview renderer.
+	 *
+	 * @param array $parameters Complete parameters.
+	 * @param array $tool_def   Tool definition.
+	 * @return array
+	 */
+	private static function buildActionPreviewData( array $parameters, array $tool_def ): array {
+		if ( ! empty( $tool_def['build_action_preview'] ) && is_callable( $tool_def['build_action_preview'] ) ) {
+			$custom = call_user_func( $tool_def['build_action_preview'], $parameters, $tool_def );
+			if ( is_array( $custom ) ) {
+				return $custom;
+			}
+		}
+
+		$redact = array();
+		if ( ! empty( $tool_def['action_preview_redact'] ) && is_array( $tool_def['action_preview_redact'] ) ) {
+			$redact = array_flip( array_map( 'strval', $tool_def['action_preview_redact'] ) );
+		}
+
+		if ( empty( $redact ) ) {
+			return $parameters;
+		}
+
+		return array_diff_key( $parameters, $redact );
 	}
 
 	/**

--- a/tests/Unit/Engine/AI/Actions/ActionPolicyResolverTest.php
+++ b/tests/Unit/Engine/AI/Actions/ActionPolicyResolverTest.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * ActionPolicyResolver unit tests.
+ *
+ * Covers the 6-step resolution precedence:
+ *   1. Context-level deny wins over everything else.
+ *   2. Per-agent tool override beats per-agent category override.
+ *   3. Per-agent category override beats tool-declared default.
+ *   4. Tool-declared default beats mode preset.
+ *   5. Mode preset can upgrade a direct tool default to preview in chat.
+ *   6. Global default is 'direct'.
+ *   + External filter always runs last and can override anything.
+ *
+ * @package DataMachine\Tests\Unit\Engine\AI\Actions
+ */
+
+namespace DataMachine\Tests\Unit\Engine\AI\Actions;
+
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
+use WP_UnitTestCase;
+
+class ActionPolicyResolverTest extends WP_UnitTestCase {
+
+	private ActionPolicyResolver $resolver;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->resolver = new ActionPolicyResolver();
+	}
+
+	public function tear_down(): void {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agents" );
+		remove_all_filters( 'datamachine_tool_action_policy' );
+		parent::tear_down();
+	}
+
+	public function test_default_policy_is_direct(): void {
+		$policy = $this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'some_tool',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+			)
+		);
+
+		$this->assertSame( ActionPolicyResolver::POLICY_DIRECT, $policy );
+	}
+
+	public function test_tool_declared_default_overrides_global_default(): void {
+		$policy = $this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'publish_instagram',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+				'tool_def'  => array( 'action_policy' => 'preview' ),
+			)
+		);
+
+		$this->assertSame( ActionPolicyResolver::POLICY_PREVIEW, $policy );
+	}
+
+	public function test_mode_preset_upgrades_direct_tool_to_preview_in_chat(): void {
+		$policy = $this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'publish_tweet',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+				'tool_def'  => array(
+					'action_policy'      => 'direct',
+					'action_policy_chat' => 'preview',
+				),
+			)
+		);
+
+		$this->assertSame( ActionPolicyResolver::POLICY_PREVIEW, $policy );
+	}
+
+	public function test_mode_preset_does_not_affect_pipeline(): void {
+		$policy = $this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'publish_tweet',
+				'mode'      => ActionPolicyResolver::MODE_PIPELINE,
+				'tool_def'  => array(
+					'action_policy'      => 'direct',
+					'action_policy_chat' => 'preview',
+				),
+			)
+		);
+
+		$this->assertSame( ActionPolicyResolver::POLICY_DIRECT, $policy );
+	}
+
+	public function test_context_deny_always_wins(): void {
+		$policy = $this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'publish_instagram',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+				'tool_def'  => array( 'action_policy' => 'direct' ),
+				'deny'      => array( 'publish_instagram' ),
+			)
+		);
+
+		$this->assertSame( ActionPolicyResolver::POLICY_FORBIDDEN, $policy );
+	}
+
+	public function test_agent_tool_override_beats_tool_default(): void {
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'tools' => array( 'publish_instagram' => 'forbidden' ),
+			)
+		);
+
+		$policy = $this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'publish_instagram',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+				'tool_def'  => array( 'action_policy' => 'preview' ),
+				'agent_id'  => $agent_id,
+			)
+		);
+
+		$this->assertSame( ActionPolicyResolver::POLICY_FORBIDDEN, $policy );
+	}
+
+	public function test_agent_tool_override_can_downgrade_preview_to_direct(): void {
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'tools' => array( 'publish_instagram' => 'direct' ),
+			)
+		);
+
+		$policy = $this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'publish_instagram',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+				'tool_def'  => array( 'action_policy' => 'preview' ),
+				'agent_id'  => $agent_id,
+			)
+		);
+
+		$this->assertSame( ActionPolicyResolver::POLICY_DIRECT, $policy );
+	}
+
+	public function test_invalid_agent_policy_values_are_dropped(): void {
+		$agent_id = $this->createAgentWithPolicy(
+			array(
+				'tools' => array( 'publish_instagram' => 'bogus_value' ),
+			)
+		);
+
+		$policy = $this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'publish_instagram',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+				'tool_def'  => array( 'action_policy' => 'preview' ),
+				'agent_id'  => $agent_id,
+			)
+		);
+
+		// Bogus value dropped → falls through to tool-declared default.
+		$this->assertSame( ActionPolicyResolver::POLICY_PREVIEW, $policy );
+	}
+
+	public function test_filter_can_override_any_layer(): void {
+		add_filter(
+			'datamachine_tool_action_policy',
+			function ( $policy, $tool_name ) {
+				return 'publish_instagram' === $tool_name ? 'forbidden' : $policy;
+			},
+			10,
+			2
+		);
+
+		$policy = $this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'publish_instagram',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+				'tool_def'  => array( 'action_policy' => 'direct' ),
+			)
+		);
+
+		$this->assertSame( ActionPolicyResolver::POLICY_FORBIDDEN, $policy );
+	}
+
+	public function test_filter_garbage_return_is_ignored(): void {
+		add_filter(
+			'datamachine_tool_action_policy',
+			fn() => 'not_a_real_policy'
+		);
+
+		$policy = $this->resolver->resolveForTool(
+			array(
+				'tool_name' => 'some_tool',
+				'mode'      => ActionPolicyResolver::MODE_CHAT,
+				'tool_def'  => array( 'action_policy' => 'preview' ),
+			)
+		);
+
+		$this->assertSame( ActionPolicyResolver::POLICY_PREVIEW, $policy );
+	}
+
+	public function test_no_policy_returns_null_for_missing_agent(): void {
+		$this->assertNull( $this->resolver->getAgentActionPolicy( 99999 ) );
+	}
+
+	public function test_empty_agent_policy_returns_null(): void {
+		$agent_id = $this->createAgentWithPolicy( array() );
+		$this->assertNull( $this->resolver->getAgentActionPolicy( $agent_id ) );
+	}
+
+	/**
+	 * Seed an agent with a specific action_policy config.
+	 */
+	private function createAgentWithPolicy( array $action_policy ): int {
+		$repo     = new Agents();
+		$agent_id = $repo->create_if_missing( 'test-agent-' . wp_generate_uuid4(), 'Test Agent', get_current_user_id() );
+
+		if ( ! empty( $action_policy ) ) {
+			global $wpdb;
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->update(
+				$wpdb->base_prefix . 'datamachine_agents',
+				array(
+					'agent_config' => wp_json_encode( array( 'action_policy' => $action_policy ) ),
+				),
+				array( 'agent_id' => $agent_id )
+			);
+		}
+
+		return $agent_id;
+	}
+}


### PR DESCRIPTION
## Summary

Third sibling to `ToolPolicyResolver` and `MemoryPolicyResolver`:

| Resolver | Answers |
|---|---|
| `ToolPolicyResolver` | Can the agent SEE this tool? (visibility) |
| `MemoryPolicyResolver` | Which memory files inject? (content) |
| **`ActionPolicyResolver`** (new) | **Given a tool WAS called, HOW does it execute? (direct / preview / forbidden)** |

Zero behavioral change for existing tools — tools opt in via `action_policy` metadata. Ships the primitive + generic store + resolver ability; opting `publish_instagram` (and the rest of data-machine-socials) in comes as a separate PR.

## Motivation

Multi-turn AI agents in chat mode can call publish/write tools (`publish_instagram`, `publish_tweet`, account mutations, destructive ops) without a user approval step. This is fine for pipelines where there is no user present, but unsafe in chat where the user expects to review before commit.

ActionPolicy makes approval a **property of the tool invocation**, configurable per-agent and per-mode. When a tool resolves to `preview`, `ToolExecutor` stages the call via `PendingActionStore` and returns a standardized envelope to the AI. The AI shows the preview to the user; the user confirms; the AI calls `resolve_pending_action` with `accepted` / `rejected`; the generic resolver replays the original input through the registered kind handler.

## Architecture

```
AI calls publish_instagram
       │
       ▼
AIConversationLoop → ToolExecutor::executeTool(mode, agent_id, client_context)
       │
       ▼
ActionPolicyResolver::resolveForTool → 'direct' | 'preview' | 'forbidden'
       │
       ├─── direct    → call handler (unchanged behavior)
       ├─── forbidden → return error envelope
       └─── preview   → PendingActionHelper::stage
                           │
                           ▼
                        PendingActionStore (1hr transient)
                           │
                           ▼
                        return preview envelope to AI
                           │
                           ▼
                        (AI shows preview, user confirms)
                           │
                           ▼
                        AI calls resolve_pending_action(accepted|rejected)
                           │
                           ▼
                        ResolvePendingActionAbility
                           │
                           ▼
                        datamachine_pending_action_handlers[kind].apply(apply_input)
                           │
                           ▼
                        real publish happens
```

## Resolution precedence

1. **Context-level deny** (`deny` array in the invocation context) → `forbidden`
2. **Per-agent tool override** (`agent_config.action_policy.tools['publish_instagram']`)
3. **Per-agent category override** (`agent_config.action_policy.categories['datamachine-socials']`)
4. **Tool-declared default** (`tool_def['action_policy']`)
5. **Mode preset** (`tool_def['action_policy_chat']` etc.) — can upgrade `direct` → `preview` in chat
6. **Global default**: `direct`
7. **`datamachine_tool_action_policy` filter** — runs last, can override anything

## Tool opt-in surface

Tools opt into ActionPolicy purely through metadata in their definition:

```php
'action_policy'          => 'preview',                       // default for all modes
'action_policy_chat'     => 'preview',                       // mode-specific override
'action_kind'            => 'socials_publish_instagram',     // handler dispatch key
'build_action_summary'   => callable,                        // optional: custom one-liner
'build_action_preview'   => callable,                        // optional: custom preview payload
'action_preview_redact'  => ['secret_param'],                // optional: redact from preview
```

Handlers register apply callbacks:

```php
add_filter('datamachine_pending_action_handlers', function($handlers) {
    $handlers['socials_publish_instagram'] = [
        'apply'       => [InstagramPublishAbility::class, 'execute_publish'],
        'can_resolve' => [self::class, 'check_can_publish'],  // optional
    ];
    return $handlers;
});
```

## Why NOT BasePolicy

Tempted to extract a shared abstract class since three resolvers now exist with the same 5-step pattern. I chose not to because:

1. **Rule of three applies after shipping, not after designing.** The genuine shared surface (`agent_config` read, mode/precedence validation, external-filter convention) will become obvious after ActionPolicy lives in production for a release. Extracting now risks baking in premature constraints.
2. **The three resolvers have different output semantics:** ToolPolicy returns a tool map (filter), MemoryPolicy returns a file map (filter), ActionPolicy returns a per-tool decision string (transform). A forced common base class would have to be abstract enough that each subclass writes most of its own logic anyway.
3. **What IS shared** — `AgentPolicyReader::read($agent_id, $key)`, `normalizePolicyValue()` — is small enough to extract as a helper in a follow-up PR rather than a hierarchy.

So: ship the sibling, run it, extract later.

## Files

**New:**
- `inc/Engine/AI/Actions/ActionPolicyResolver.php`
- `inc/Engine/AI/Actions/PendingActionStore.php`
- `inc/Engine/AI/Actions/PendingActionHelper.php`
- `inc/Engine/AI/Actions/ResolvePendingActionAbility.php`
- `inc/Engine/AI/Actions/ResolvePendingAction.php`
- `tests/Unit/Engine/AI/Actions/ActionPolicyResolverTest.php` (11 tests)

**Modified:**
- `inc/Engine/AI/Tools/ToolExecutor.php` — consults resolver before invoking handler; stages previews; forwards 3 new params (backward compatible via defaults)
- `inc/Engine/AI/AIConversationLoop.php` — forwards `mode`/`agent_id`/`client_context` to ToolExecutor
- `inc/Abilities/AbilityCategories.php` — adds `datamachine-actions` category
- `data-machine.php` — boots `ResolvePendingActionAbility` + `ResolvePendingAction`

## Tests

`ActionPolicyResolverTest` covers the 6-step precedence:
- Default is `direct`
- Tool-declared default overrides global default
- Mode preset upgrades `direct` → `preview` in chat only
- Mode preset ignored outside chat
- Context deny always wins
- Agent tool override beats tool default
- Agent override can downgrade preview → direct
- Invalid agent policy values are dropped
- Filter can override any layer
- Filter garbage return is ignored
- Missing agent → null policy

## What ships vs what's next

**This PR:** primitive + integration + tests. Every existing tool still resolves to `direct`.

**Follow-up PRs:**
- `data-machine-socials`: `publish_instagram` opts in (`action_policy_chat = 'preview'`, registers `socials_publish_instagram` kind handler). Then the rest of the socials chat tools.
- `data-machine` core: migrate `ResolveDiffAbility` to dispatch through `datamachine_pending_action_handlers` under kinds `content_edit_blocks` / `content_replace_blocks` / `content_insert`. Keep `ResolveDiffAbility` as a BC forwarder for the editor frontend.
- Much later: extract `AgentPolicyReader` shared helper consumed by all three resolvers.

## Backward compatibility

- Every existing tool resolves to `direct` → zero runtime change
- `ToolExecutor::executeTool()` new params are optional with sensible defaults
- No existing endpoint or filter is modified
- `PendingDiffStore` and `ResolveDiffAbility` remain intact; the generic primitive is additive, not a replacement (yet)

## Rollout

1. Merge this PR
2. `homeboy release data-machine` (minor bump → v0.72.0)
3. `homeboy deploy data-machine`
4. `data-machine-socials` opt-in PR ships `publish_instagram` preview behavior
5. Validate with Gardner / Beeper end-to-end: image → caption preview → user approves → post lands