### PR TITLE
refactor: finish contexts → modes rename (model-selection + REST + DB)

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -386,7 +386,7 @@ add_action(
 		if ( ! \DataMachine\Core\Database\Chat\Chat::table_exists() ) {
 			return;
 		}
-		\DataMachine\Core\Database\Chat\Chat::ensure_context_column();
+		\DataMachine\Core\Database\Chat\Chat::ensure_mode_column();
 		\DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();
 		\DataMachine\Core\Database\Chat\Chat::ensure_last_read_at_column();
 	},
@@ -565,7 +565,7 @@ function datamachine_activate_for_site() {
 	$db_identity_index->create_table();
 
 	\DataMachine\Core\Database\Chat\Chat::create_table();
-	\DataMachine\Core\Database\Chat\Chat::ensure_context_column();
+	\DataMachine\Core\Database\Chat\Chat::ensure_mode_column();
 	\DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();
 	\DataMachine\Core\Database\Chat\Chat::ensure_last_read_at_column();
 
@@ -653,7 +653,7 @@ function datamachine_resolve_or_create_agent_id( int $user_id ): int {
 
 	$agent_slug  = sanitize_title( (string) $user->user_login );
 	$agent_name  = (string) $user->display_name;
-	$agent_model = \DataMachine\Core\PluginSettings::getContextModel( 'chat' );
+	$agent_model = \DataMachine\Core\PluginSettings::getModelForMode( 'chat' );
 
 	return $agents_repo->create_if_missing(
 		$agent_slug,

--- a/inc/Abilities/Chat/CreateChatSessionAbility.php
+++ b/inc/Abilities/Chat/CreateChatSessionAbility.php
@@ -49,10 +49,10 @@ class CreateChatSessionAbility {
 								'type'        => 'integer',
 								'description' => __( 'First-class agent ID for this session.', 'data-machine' ),
 							),
-							'context'  => array(
+							'mode'     => array(
 								'type'        => 'string',
 								'default'     => 'chat',
-								'description' => __( 'Execution context (chat, pipeline, system).', 'data-machine' ),
+								'description' => __( 'Execution mode (chat, pipeline, system).', 'data-machine' ),
 							),
 							'source'   => array(
 								'type'        => 'string',
@@ -90,7 +90,7 @@ class CreateChatSessionAbility {
 	/**
 	 * Execute create-chat-session ability.
 	 *
-	 * @param array $input Input parameters with user_id, optional context, source, metadata.
+	 * @param array $input Input parameters with user_id, optional mode, source, metadata.
 	 * @return array Result with session_id on success.
 	 */
 	public function execute( array $input ): array {
@@ -103,7 +103,7 @@ class CreateChatSessionAbility {
 
 		$user_id  = (int) $input['user_id'];
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$context  = ! empty( $input['context'] ) ? sanitize_text_field( $input['context'] ) : 'chat';
+		$mode     = ! empty( $input['mode'] ) ? sanitize_text_field( $input['mode'] ) : 'chat';
 		$source   = ! empty( $input['source'] ) ? sanitize_text_field( $input['source'] ) : null;
 
 		if ( ! $this->can_access_user_sessions( $user_id ) ) {
@@ -127,7 +127,7 @@ class CreateChatSessionAbility {
 			$session_metadata = array_merge( $session_metadata, $input['metadata'] );
 		}
 
-		$session_id = $this->chat_db->create_session( $user_id, $agent_id, $session_metadata, $context );
+		$session_id = $this->chat_db->create_session( $user_id, $agent_id, $session_metadata, $mode );
 
 		if ( empty( $session_id ) ) {
 			return array(

--- a/inc/Abilities/Chat/ListChatSessionsAbility.php
+++ b/inc/Abilities/Chat/ListChatSessionsAbility.php
@@ -2,7 +2,7 @@
 /**
  * List Chat Sessions Ability
  *
-	 * Lists chat sessions for a given user with pagination and context filtering.
+	 * Lists chat sessions for a given user with pagination and mode filtering.
  *
  * @package DataMachine\Abilities\Chat
  * @since 0.31.0
@@ -35,7 +35,7 @@ class ListChatSessionsAbility {
 				'datamachine/list-chat-sessions',
 				array(
 					'label'               => __( 'List Chat Sessions', 'data-machine' ),
-					'description'         => __( 'List chat sessions for a user with pagination and context filtering.', 'data-machine' ),
+					'description'         => __( 'List chat sessions for a user with pagination and mode filtering.', 'data-machine' ),
 					'category'            => 'datamachine-chat',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -58,9 +58,9 @@ class ListChatSessionsAbility {
 								'default'     => 0,
 								'description' => __( 'Pagination offset.', 'data-machine' ),
 							),
-							'context'  => array(
+							'mode'     => array(
 								'type'        => array( 'string', 'null' ),
-								'description' => __( 'Context filter (chat, pipeline, system). Null returns all contexts.', 'data-machine' ),
+								'description' => __( 'Mode filter (chat, pipeline, system). Null returns all modes.', 'data-machine' ),
 							),
 						),
 						'required'   => array( 'user_id' ),
@@ -76,7 +76,7 @@ class ListChatSessionsAbility {
 							'total'    => array( 'type' => 'integer' ),
 							'limit'    => array( 'type' => 'integer' ),
 							'offset'   => array( 'type' => 'integer' ),
-							'context'  => array( 'type' => array( 'string', 'null' ) ),
+							'mode'     => array( 'type' => array( 'string', 'null' ) ),
 							'error'    => array( 'type' => 'string' ),
 						),
 					),
@@ -103,7 +103,8 @@ class ListChatSessionsAbility {
 	/**
 	 * Execute list-chat-sessions ability.
 	 *
-	 * @param array $input Input parameters with user_id, optional limit, offset, context.
+	 * @param array $input Input parameters with user_id, optional limit, offset, mode.
+	 *
 	 * @return array Result with sessions list and total count.
 	 */
 	public function execute( array $input ): array {
@@ -125,11 +126,11 @@ class ListChatSessionsAbility {
 
 		$limit    = min( 100, max( 1, (int) ( $input['limit'] ?? 20 ) ) );
 		$offset   = max( 0, (int) ( $input['offset'] ?? 0 ) );
-		$context  = ! empty( $input['context'] ) ? sanitize_text_field( $input['context'] ) : null;
+		$mode     = ! empty( $input['mode'] ) ? sanitize_text_field( $input['mode'] ) : null;
 		$agent_id = isset( $input['agent_id'] ) && is_numeric( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
 
-		$sessions = $this->chat_db->get_user_sessions( $user_id, $limit, $offset, $context, $agent_id );
-		$total    = $this->chat_db->get_user_session_count( $user_id, $context, $agent_id );
+		$sessions = $this->chat_db->get_user_sessions( $user_id, $limit, $offset, $mode, $agent_id );
+		$total    = $this->chat_db->get_user_session_count( $user_id, $mode, $agent_id );
 
 		return array(
 			'success'  => true,
@@ -137,7 +138,7 @@ class ListChatSessionsAbility {
 			'total'    => $total,
 			'limit'    => $limit,
 			'offset'   => $offset,
-			'context'  => $context,
+			'mode'     => $mode,
 		);
 	}
 }

--- a/inc/Abilities/Chat/SendMessageAbility.php
+++ b/inc/Abilities/Chat/SendMessageAbility.php
@@ -173,7 +173,7 @@ class SendMessageAbility {
 		$model    = $input['model'] ?? '';
 
 		if ( empty( $provider ) || empty( $model ) ) {
-			$agent_config = PluginSettings::resolveModelForAgentContext( $agent_id ?: null, 'chat' );
+			$agent_config = PluginSettings::resolveModelForAgentMode( $agent_id ?: null, 'chat' );
 			if ( empty( $provider ) ) {
 				$provider = $agent_config['provider'];
 			}

--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -417,7 +417,7 @@ class InternalLinkingAbilities {
 
 		$user_id         = get_current_user_id();
 		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
-		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 

--- a/inc/Abilities/Media/AltTextAbilities.php
+++ b/inc/Abilities/Media/AltTextAbilities.php
@@ -146,7 +146,7 @@ class AltTextAbilities {
 
 		$user_id         = get_current_user_id();
 		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
-		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 
@@ -362,7 +362,7 @@ class AltTextAbilities {
 
 		$user_id         = get_current_user_id();
 		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
-		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 

--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -282,7 +282,7 @@ class ImageGenerationAbilities {
 	public static function refine_prompt( string $raw_prompt, string $post_context = '', array $config = array() ): ?string {
 		$user_id         = get_current_user_id();
 		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
-		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 
@@ -386,7 +386,7 @@ class ImageGenerationAbilities {
 		// Must have a DM AI provider configured.
 		$user_id         = get_current_user_id();
 		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
-		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 
 		return ! empty( $system_defaults['provider'] ) && ! empty( $system_defaults['model'] );
 	}

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -152,7 +152,7 @@ class PipelineStepAbilities {
 			'datamachine/update-pipeline-step',
 			array(
 				'label'               => __( 'Update Pipeline Step', 'data-machine' ),
-				'description'         => __( 'Update pipeline step configuration (system prompt, disabled tools). Model/provider are configured via context_models setting.', 'data-machine' ),
+				'description'         => __( 'Update pipeline step configuration (system prompt, disabled tools). Model/provider are configured via mode_models setting.', 'data-machine' ),
 				'category'            => 'datamachine-pipeline',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -416,7 +416,7 @@ class PipelineStepAbilities {
 
 		if ( 'ai' === $step_type ) {
 			if ( empty( $new_step['provider'] ) || empty( $new_step['model'] ) ) {
-				$pipeline_defaults = PluginSettings::getContextModel( 'pipeline' );
+				$pipeline_defaults = PluginSettings::getModelForMode( 'pipeline' );
 				if ( empty( $new_step['provider'] ) ) {
 					$new_step['provider'] = $pipeline_defaults['provider'];
 				}
@@ -527,7 +527,7 @@ class PipelineStepAbilities {
 		$disabled_tools = $input['disabled_tools'] ?? null;
 
 		// provider/model are no longer configurable at the pipeline step level.
-		// Model resolution is handled exclusively by the context system (context_models setting).
+		// Model resolution is handled exclusively by the mode system (mode_models setting).
 
 		if ( null === $system_prompt && null === $disabled_tools ) {
 			return array(

--- a/inc/Abilities/SEO/MetaDescriptionAbilities.php
+++ b/inc/Abilities/SEO/MetaDescriptionAbilities.php
@@ -144,7 +144,7 @@ class MetaDescriptionAbilities {
 
 		$user_id         = get_current_user_id();
 		$agent_id        = function_exists( 'datamachine_resolve_or_create_agent_id' ) && $user_id > 0 ? datamachine_resolve_or_create_agent_id( $user_id ) : 0;
-		$system_defaults = PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		$system_defaults = PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 		$provider        = $system_defaults['provider'];
 		$model           = $system_defaults['model'];
 

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -108,13 +108,9 @@ class SettingsAbilities {
 						'daily_memory_enabled'           => array( 'type' => 'boolean' ),
 						'default_provider'               => array( 'type' => 'string' ),
 						'default_model'                  => array( 'type' => 'string' ),
-						'context_models'                 => array(
+						'mode_models'                    => array(
 							'type'        => 'object',
-							'description' => 'Per-context provider/model overrides keyed by context id',
-						),
-						'agent_models'                   => array(
-							'type'        => 'object',
-							'description' => 'Legacy alias for context_models',
+							'description' => 'Per-mode provider/model overrides keyed by mode id',
 						),
 						'max_turns'                      => array( 'type' => 'integer' ),
 						'disabled_tools'                 => array( 'type' => 'object' ),
@@ -131,7 +127,7 @@ class SettingsAbilities {
 						// GitHub settings moved to data-machine-code extension.
 						'network_settings'               => array(
 							'type'        => 'object',
-							'description' => 'Network-wide defaults (multisite). Keys: default_provider, default_model, context_models.',
+							'description' => 'Network-wide defaults (multisite). Keys: default_provider, default_model, mode_models.',
 						),
 					),
 				),
@@ -368,8 +364,7 @@ class SettingsAbilities {
 				'daily_memory_enabled'           => $settings['daily_memory_enabled'] ?? false,
 				'default_provider'               => $settings['default_provider'] ?? '',
 				'default_model'                  => $settings['default_model'] ?? '',
-				'context_models'                 => $settings['context_models'] ?? $settings['agent_models'] ?? array(),
-				'agent_models'                   => $settings['context_models'] ?? $settings['agent_models'] ?? array(),
+				'mode_models'                    => $settings['mode_models'] ?? array(),
 				'max_turns'                      => $settings['max_turns'] ?? $defaults['max_turns'],
 				'disabled_tools'                 => $settings['disabled_tools'] ?? array(),
 				'ai_provider_keys'               => $masked_keys,
@@ -379,8 +374,7 @@ class SettingsAbilities {
 			'network_settings' => array(
 				'default_provider' => $network_defaults['default_provider'] ?? '',
 				'default_model'    => $network_defaults['default_model'] ?? '',
-				'context_models'   => $network_defaults['context_models'] ?? $network_defaults['agent_models'] ?? array(),
-				'agent_models'     => $network_defaults['context_models'] ?? $network_defaults['agent_models'] ?? array(),
+				'mode_models'      => $network_defaults['mode_models'] ?? array(),
 			),
 			'global_tools'     => $tools_keyed,
 		);
@@ -455,28 +449,19 @@ class SettingsAbilities {
 			$handled_keys[]                = 'default_model';
 		}
 
-		$raw_context_models = null;
-		if ( isset( $input['context_models'] ) && is_array( $input['context_models'] ) ) {
-			$raw_context_models = $input['context_models'];
-		} elseif ( isset( $input['agent_models'] ) && is_array( $input['agent_models'] ) ) {
-			$raw_context_models = $input['agent_models'];
-		}
-
-		if ( is_array( $raw_context_models ) ) {
-			$valid_context_ids = array_column( PluginSettings::getAgentModes(), 'id' );
-			$context_models    = array();
-			foreach ( $raw_context_models as $context => $config ) {
-				if ( in_array( $context, $valid_context_ids, true ) && is_array( $config ) ) {
-					$context_models[ $context ] = array(
+		if ( isset( $input['mode_models'] ) && is_array( $input['mode_models'] ) ) {
+			$valid_mode_ids = array_column( PluginSettings::getAgentModes(), 'id' );
+			$mode_models    = array();
+			foreach ( $input['mode_models'] as $mode => $config ) {
+				if ( in_array( $mode, $valid_mode_ids, true ) && is_array( $config ) ) {
+					$mode_models[ $mode ] = array(
 						'provider' => sanitize_text_field( $config['provider'] ?? '' ),
 						'model'    => sanitize_text_field( $config['model'] ?? '' ),
 					);
 				}
 			}
-			$all_settings['context_models'] = $context_models;
-			$all_settings['agent_models']   = $context_models;
-			$handled_keys[]                 = 'context_models';
-			$handled_keys[]                 = 'agent_models';
+			$all_settings['mode_models'] = $mode_models;
+			$handled_keys[]              = 'mode_models';
 		}
 
 		if ( isset( $input['max_turns'] ) ) {
@@ -550,26 +535,18 @@ class SettingsAbilities {
 					$network_values['default_model'] = sanitize_text_field( $input['network_settings']['default_model'] );
 				}
 
-				$raw_network_context_models = null;
-				if ( isset( $input['network_settings']['context_models'] ) && is_array( $input['network_settings']['context_models'] ) ) {
-					$raw_network_context_models = $input['network_settings']['context_models'];
-				} elseif ( isset( $input['network_settings']['agent_models'] ) && is_array( $input['network_settings']['agent_models'] ) ) {
-					$raw_network_context_models = $input['network_settings']['agent_models'];
-				}
-
-				if ( is_array( $raw_network_context_models ) ) {
-					$valid_context_ids      = array_column( PluginSettings::getAgentModes(), 'id' );
-					$network_context_models = array();
-					foreach ( $raw_network_context_models as $context => $config ) {
-						if ( in_array( $context, $valid_context_ids, true ) && is_array( $config ) ) {
-							$network_context_models[ $context ] = array(
+				if ( isset( $input['network_settings']['mode_models'] ) && is_array( $input['network_settings']['mode_models'] ) ) {
+					$valid_mode_ids      = array_column( PluginSettings::getAgentModes(), 'id' );
+					$network_mode_models = array();
+					foreach ( $input['network_settings']['mode_models'] as $mode => $config ) {
+						if ( in_array( $mode, $valid_mode_ids, true ) && is_array( $config ) ) {
+							$network_mode_models[ $mode ] = array(
 								'provider' => sanitize_text_field( $config['provider'] ?? '' ),
 								'model'    => sanitize_text_field( $config['model'] ?? '' ),
 							);
 						}
 					}
-					$network_values['context_models'] = $network_context_models;
-					$network_values['agent_models']   = $network_context_models;
+					$network_values['mode_models'] = $network_mode_models;
 				}
 
 				if ( ! empty( $network_values ) ) {

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -498,7 +498,7 @@ class SystemAbilities {
 	}
 
 	private static function generateAITitle( string $first_user_message, ?string $first_assistant_response ): ?string {
-		$chat_defaults = PluginSettings::resolveModelForAgentContext( null, 'chat' );
+		$chat_defaults = PluginSettings::resolveModelForAgentMode( null, 'chat' );
 		$provider      = $chat_defaults['provider'];
 		$model         = $chat_defaults['model'];
 

--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -239,10 +239,10 @@ class Chat {
 						'description'       => __( 'Pagination offset', 'data-machine' ),
 						'sanitize_callback' => 'absint',
 					),
-					'context'  => array(
+					'mode'     => array(
 						'type'              => 'string',
 						'required'          => false,
-						'description'       => __( 'Context filter (chat, pipeline, system)', 'data-machine' ),
+						'description'       => __( 'Mode filter (chat, pipeline, system)', 'data-machine' ),
 						'sanitize_callback' => 'sanitize_text_field',
 						'validate_callback' => function ( $param ) {
 							return in_array( $param, array( 'chat', 'pipeline', 'system' ), true );
@@ -318,7 +318,7 @@ class Chat {
 		$prompt  = sanitize_textarea_field( wp_unslash( $request->get_param( 'prompt' ) ?? '' ) );
 		$context = $request->get_param( 'context' ) ?? array();
 
-		$agent_config = PluginSettings::resolveModelForAgentContext( $agent_id, 'chat' );
+		$agent_config = PluginSettings::resolveModelForAgentMode( $agent_id, 'chat' );
 		$provider     = $agent_config['provider'];
 		$model        = $agent_config['model'];
 
@@ -368,7 +368,7 @@ class Chat {
 				'agent_id' => PermissionHelper::resolve_scoped_agent_id( $request ),
 				'limit'    => (int) $request->get_param( 'limit' ),
 				'offset'   => (int) $request->get_param( 'offset' ),
-				'context'  => $request->get_param( 'context' ),
+				'mode'     => $request->get_param( 'mode' ),
 			)
 		);
 	}

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -107,7 +107,7 @@ class ChatOrchestrator {
 						'session_id'          => $session_id,
 						'user_id'             => $user_id,
 						'original_created_at' => $pending_session['created_at'],
-						'context'             => 'chat',
+						'mode'                => 'chat',
 					)
 				);
 			} else {
@@ -329,7 +329,7 @@ class ChatOrchestrator {
 		}
 
 		$messages             = $session['messages'] ?? array();
-		$chat_defaults        = PluginSettings::resolveModelForAgentContext( (int) ( $session['agent_id'] ?? 0 ), 'chat' );
+		$chat_defaults        = PluginSettings::resolveModelForAgentMode( (int) ( $session['agent_id'] ?? 0 ), 'chat' );
 		$provider             = $session['provider'] ?? $chat_defaults['provider'];
 		$model                = $session['model'] ?? $chat_defaults['model'];
 		$message_count_before = count( $messages );
@@ -510,7 +510,7 @@ class ChatOrchestrator {
 			array(
 				'session_id' => $session_id,
 				'turns'      => $result['turn_count'],
-				'context'    => 'chat',
+				'mode'       => 'chat',
 			)
 		);
 
@@ -552,7 +552,7 @@ class ChatOrchestrator {
 			$input = array(
 				'user_id'  => $user_id,
 				'agent_id' => $agent_id,
-				'context'  => 'chat',
+				'mode'     => 'chat',
 			);
 
 			if ( $source ) {

--- a/inc/Api/Chat/Tools/ConfigurePipelineStep.php
+++ b/inc/Api/Chat/Tools/ConfigurePipelineStep.php
@@ -33,7 +33,7 @@ class ConfigurePipelineStep extends BaseTool {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',
-			'description' => 'Configure pipeline-level AI step settings: system prompt and disabled tools. Model/provider are managed via the context_models site setting, not per-pipeline. For flow-level settings (handler, handler_config, user_message), use configure_flow_steps instead.',
+			'description' => 'Configure pipeline-level AI step settings: system prompt and disabled tools. Model/provider are managed via the mode_models site setting, not per-pipeline. For flow-level settings (handler, handler_config, user_message), use configure_flow_steps instead.',
 			'parameters'  => array(
 				'pipeline_step_id' => array(
 					'type'        => 'string',

--- a/inc/Api/Pipelines/PipelineSteps.php
+++ b/inc/Api/Pipelines/PipelineSteps.php
@@ -493,7 +493,7 @@ class PipelineSteps {
 
 		// Build step configuration data for AI steps.
 		// Note: provider/model are NOT configurable at the pipeline step level.
-		// Model resolution is handled by the context system (context_models setting).
+		// Model resolution is handled by the mode system (mode_models setting).
 		$step_config_data = array();
 		$api_key_saved    = false;
 

--- a/inc/Api/Providers.php
+++ b/inc/Api/Providers.php
@@ -86,17 +86,17 @@ class Providers {
 				'model'    => PluginSettings::get( 'default_model', '' ),
 			);
 
-			$contexts       = PluginSettings::getAgentModes();
-			$context_models = PluginSettings::get( 'context_models', PluginSettings::get( 'agent_models', array() ) );
+			$modes       = PluginSettings::getAgentModes();
+			$mode_models = PluginSettings::get( 'mode_models', array() );
 
 			return rest_ensure_response(
 				array(
 					'success' => true,
 					'data'    => array(
-						'providers'      => $providers,
-						'defaults'       => $defaults,
-						'contexts'       => $contexts,
-						'context_models' => $context_models,
+						'providers'   => $providers,
+						'defaults'    => $defaults,
+						'modes'       => $modes,
+						'mode_models' => $mode_models,
 					),
 				)
 			);

--- a/inc/Cli/Commands/ChatCommand.php
+++ b/inc/Cli/Commands/ChatCommand.php
@@ -91,13 +91,13 @@ class ChatCommand extends BaseCommand {
 			$display_items[] = array(
 				'session_id'    => $session['session_id'],
 				'title'         => $session['title'] ?? '(untitled)',
-				'context'       => $session['context'] ?? 'chat',
+				'mode'          => $session['mode'] ?? 'chat',
 				'message_count' => $metadata['message_count'] ?? 0,
 				'created_at'    => $metadata['started_at'] ?? $session['created_at'] ?? '-',
 			);
 		}
 
-		$fields = array( 'session_id', 'title', 'context', 'message_count', 'created_at' );
+		$fields = array( 'session_id', 'title', 'mode', 'message_count', 'created_at' );
 		$this->format_items( $display_items, $fields, $assoc_args, 'session_id' );
 
 		$format = $assoc_args['format'] ?? 'table';
@@ -171,7 +171,7 @@ class ChatCommand extends BaseCommand {
 		WP_CLI::log( WP_CLI::colorize( '%BSession Metadata:%n' ) );
 		WP_CLI::log( "  Session ID:   {$session['session_id']}" );
 		WP_CLI::log( '  Title:        ' . ( $session['title'] ?? '(untitled)' ) );
-		WP_CLI::log( '  Context:      ' . ( $session['context'] ?? 'chat' ) );
+		WP_CLI::log( '  Mode:         ' . ( $session['mode'] ?? 'chat' ) );
 		WP_CLI::log( "  User ID:      {$session['user_id']}" );
 		WP_CLI::log( '  Started:      ' . ( $metadata['started_at'] ?? '-' ) );
 		WP_CLI::log( '  Messages:     ' . count( $messages ) );

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentSettings.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentSettings.jsx
@@ -19,7 +19,7 @@ import { useProviders } from '@shared/queries/providers';
 const EMPTY_FORM = {
 	default_provider: '',
 	default_model: '',
-	context_models: {},
+	mode_models: {},
 	site_context_enabled: false,
 	max_turns: 0,
 };
@@ -88,10 +88,7 @@ const AgentSettings = () => {
 			form.reset( {
 				default_provider: data.settings.default_provider || '',
 				default_model: data.settings.default_model || '',
-				context_models:
-					data.settings.context_models ||
-					data.settings.agent_models ||
-					{},
+				mode_models: data.settings.mode_models || {},
 				site_context_enabled:
 					data.settings.site_context_enabled ?? false,
 				max_turns: data.settings.max_turns ?? maxTurnsDefault,
@@ -153,15 +150,15 @@ const AgentSettings = () => {
 							</div>
 							<p className="description">
 								The default provider and model used for all
-								contexts unless overridden below.
+								modes unless overridden below.
 							</p>
 						</td>
 					</tr>
 
-					{ ( providersData?.contexts || [] ).length > 0 && (
+					{ ( providersData?.modes || [] ).length > 0 && (
 						<tr>
 							<th scope="row">
-								Per-Context Model Overrides
+								Per-Mode Model Overrides
 							</th>
 							<td>
 								<p
@@ -171,20 +168,20 @@ const AgentSettings = () => {
 										marginBottom: '16px',
 									} }
 								>
-									The same agent runs in different contexts
+									The same agent runs in different modes
 									with different toolkits. Override the default
-									model for specific contexts — leave empty to
+									model for specific modes — leave empty to
 									use the default above.
 								</p>
-								{ ( providersData?.contexts || [] ).map(
-									( contextItem ) => {
-										const contextConfig =
-											form.data.context_models?.[
-												contextItem.id
+								{ ( providersData?.modes || [] ).map(
+									( modeItem ) => {
+										const modeConfig =
+											form.data.mode_models?.[
+												modeItem.id
 											] || {};
 										return (
 											<div
-												key={ contextItem.id }
+												key={ modeItem.id }
 												className="datamachine-agent-model-override"
 												style={ {
 													marginBottom: '20px',
@@ -198,7 +195,7 @@ const AgentSettings = () => {
 														margin: '0 0 4px',
 													} }
 												>
-													{ contextItem.label }
+													{ modeItem.label }
 												</h4>
 												<p
 													className="description"
@@ -207,27 +204,27 @@ const AgentSettings = () => {
 														marginBottom: '8px',
 													} }
 												>
-														{ contextItem.description }
+														{ modeItem.description }
 													</p>
 													<ProviderModelSelector
 														provider={
-															contextConfig.provider ||
+															modeConfig.provider ||
 															''
 														}
 														model={
-															contextConfig.model ||
+															modeConfig.model ||
 															''
 														}
 													onProviderChange={ (
 														provider
 													) => {
 															form.updateData( {
-																context_models: {
+																mode_models: {
 																	...form.data
-																		.context_models,
-																	[ contextItem.id ]:
+																		.mode_models,
+																	[ modeItem.id ]:
 																		{
-																			...contextConfig,
+																			...modeConfig,
 																			provider,
 																			model: '',
 																	},
@@ -239,12 +236,12 @@ const AgentSettings = () => {
 														model
 													) => {
 															form.updateData( {
-																context_models: {
+																mode_models: {
 																	...form.data
-																		.context_models,
-																	[ contextItem.id ]:
+																		.mode_models,
+																	[ modeItem.id ]:
 																		{
-																			...contextConfig,
+																			...modeConfig,
 																			model,
 																	},
 															},

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -55,7 +55,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			metadata LONGTEXT NULL,
 			provider VARCHAR(50) NULL,
 			model VARCHAR(100) NULL,
-			context VARCHAR(20) NOT NULL DEFAULT 'chat',
+			mode VARCHAR(20) NOT NULL DEFAULT 'chat',
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			last_read_at DATETIME NULL,
@@ -63,8 +63,8 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			PRIMARY KEY  (session_id),
 			KEY user_id (user_id),
 			KEY agent_id (agent_id),
-			KEY context (context),
-			KEY user_context (user_id, context),
+			KEY mode (mode),
+			KEY user_mode (user_id, mode),
 			KEY created_at (created_at),
 			KEY updated_at (updated_at),
 			KEY expires_at (expires_at)
@@ -100,47 +100,49 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	}
 
 	/**
-	 * Ensure context column exists and migrate legacy agent_type data.
+	 * Ensure the mode column exists, migrating from legacy `context` (or even
+	 * older `agent_type`) columns if present.
+	 *
+	 * Idempotent. Existing rows keep their values under the new `mode` name.
 	 *
 	 * @return void
 	 */
-	public static function ensure_context_column(): void {
+	public static function ensure_mode_column(): void {
 		global $wpdb;
 
 		$table_name = self::get_prefixed_table_name();
 
-		if ( ! self::column_exists( $table_name, 'context', $wpdb ) ) {
-			$legacy_agent_type = self::column_exists( $table_name, 'agent_type', $wpdb );
-
-			if ( $legacy_agent_type ) {
+		if ( ! self::column_exists( $table_name, 'mode', $wpdb ) ) {
+			if ( self::column_exists( $table_name, 'context', $wpdb ) ) {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
-				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i CHANGE COLUMN agent_type context VARCHAR(20) NOT NULL DEFAULT %s', $table_name, 'chat' ) );
+				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i CHANGE COLUMN context mode VARCHAR(20) NOT NULL DEFAULT %s', $table_name, 'chat' ) );
+			} elseif ( self::column_exists( $table_name, 'agent_type', $wpdb ) ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i CHANGE COLUMN agent_type mode VARCHAR(20) NOT NULL DEFAULT %s', $table_name, 'chat' ) );
 			} else {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
-				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN context VARCHAR(20) NOT NULL DEFAULT %s AFTER model', $table_name, 'chat' ) );
+				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN mode VARCHAR(20) NOT NULL DEFAULT %s AFTER model', $table_name, 'chat' ) );
 			}
 		}
 
-		// Idempotent index normalization: drop legacy, add new — only when needed.
+		// Idempotent index normalization: drop legacy indexes, add new — only when needed.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$indexes       = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i', $table_name ) );
 		$existing_keys = array_unique( array_column( $indexes, 'Key_name' ) );
 
-		if ( in_array( 'agent_type', $existing_keys, true ) ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP KEY agent_type', $table_name ) );
+		foreach ( array( 'agent_type', 'user_agent', 'context', 'user_context' ) as $legacy_key ) {
+			if ( in_array( $legacy_key, $existing_keys, true ) ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP KEY ' . $legacy_key, $table_name ) );
+			}
 		}
-		if ( in_array( 'user_agent', $existing_keys, true ) ) {
+		if ( ! in_array( 'mode', $existing_keys, true ) ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP KEY user_agent', $table_name ) );
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD KEY mode (mode)', $table_name ) );
 		}
-		if ( ! in_array( 'context', $existing_keys, true ) ) {
+		if ( ! in_array( 'user_mode', $existing_keys, true ) ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD KEY context (context)', $table_name ) );
-		}
-		if ( ! in_array( 'user_context', $existing_keys, true ) ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD KEY user_context (user_id, context)', $table_name ) );
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD KEY user_mode (user_id, mode)', $table_name ) );
 		}
 	}
 
@@ -211,14 +213,14 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 *
 	 * @param int    $user_id  WordPress user ID
 	 * @param array  $metadata Optional session metadata
-	 * @param string $context  Execution context (chat, pipeline, system)
+	 * @param string $mode  Execution mode (chat, pipeline, system)
 	 * @return string Session ID (UUID)
 	 */
 	public function create_session(
 		int $user_id,
 		int $agent_id = 0,
 		array $metadata = array(),
-		string $context = 'chat'
+		string $mode = 'chat'
 	): string {
 		global $wpdb;
 
@@ -236,7 +238,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				'metadata'   => wp_json_encode( $metadata ),
 				'provider'   => null,
 				'model'      => null,
-				'context'    => $context,
+				'mode' => $mode,
 				'expires_at' => null,
 			),
 			array( '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' )
@@ -250,7 +252,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				array(
 					'user_id' => $user_id,
 					'error'   => $wpdb->last_error,
-					'context' => $context,
+					'mode' => $mode,
 				)
 			);
 			return '';
@@ -264,7 +266,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				'session_id' => $session_id,
 				'user_id'    => $user_id,
 				'agent_id'   => $agent_id,
-				'context'    => $context,
+				'mode' => $mode,
 			)
 		);
 
@@ -357,7 +359,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				array(
 					'session_id' => $session_id,
 					'error'      => $wpdb->last_error,
-					'context'    => 'chat',
+					'mode' => 'chat',
 				)
 			);
 			return false;
@@ -392,7 +394,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				array(
 					'session_id' => $session_id,
 					'error'      => $wpdb->last_error,
-					'context'    => 'chat',
+					'mode' => 'chat',
 				)
 			);
 			return false;
@@ -404,7 +406,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			'Chat session deleted',
 			array(
 				'session_id' => $session_id,
-				'context'    => 'chat',
+				'mode' => 'chat',
 			)
 		);
 
@@ -437,7 +439,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				'Cleaned up expired chat sessions',
 				array(
 					'deleted_count' => $deleted,
-					'context'       => 'chat',
+					'mode' => 'chat',
 				)
 			);
 		}
@@ -451,7 +453,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * @param int         $user_id  WordPress user ID
 	 * @param int         $limit    Maximum sessions to return
 	 * @param int         $offset   Pagination offset
-	 * @param string|null $context  Optional context filter
+	 * @param string|null $mode  Optional mode filter
 	 * @param int|null    $agent_id Optional agent ID filter (null = no filter)
 	 * @return array Array of session data
 	 */
@@ -459,21 +461,21 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		int $user_id,
 		int $limit = 20,
 		int $offset = 0,
-		?string $context = null,
+		?string $mode = null,
 		?int $agent_id = null
 	): array {
 		global $wpdb;
 
 		$table_name = self::get_prefixed_table_name();
 
-		if ( null !== $agent_id && null !== $context && '' !== $context ) {
+		if ( null !== $agent_id && null !== $mode && '' !== $mode ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$sessions = $wpdb->get_results(
 				$wpdb->prepare(
-					'SELECT * FROM %i WHERE user_id = %d AND context = %s AND agent_id = %d ORDER BY updated_at DESC LIMIT %d OFFSET %d',
+					'SELECT * FROM %i WHERE user_id = %d AND mode = %s AND agent_id = %d ORDER BY updated_at DESC LIMIT %d OFFSET %d',
 					$table_name,
 					$user_id,
-					$context,
+					$mode,
 					$agent_id,
 					$limit,
 					$offset
@@ -493,14 +495,14 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				),
 				ARRAY_A
 			);
-		} elseif ( null !== $context && '' !== $context ) {
+		} elseif ( null !== $mode && '' !== $mode ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$sessions = $wpdb->get_results(
 				$wpdb->prepare(
-					'SELECT * FROM %i WHERE user_id = %d AND context = %s ORDER BY updated_at DESC LIMIT %d OFFSET %d',
+					'SELECT * FROM %i WHERE user_id = %d AND mode = %s ORDER BY updated_at DESC LIMIT %d OFFSET %d',
 					$table_name,
 					$user_id,
-					$context,
+					$mode,
 					$limit,
 					$offset
 				),
@@ -560,7 +562,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			$result[] = array(
 				'session_id'    => $session['session_id'],
 				'title'         => $session['title'] ?? null,
-				'context'       => $session['context'] ?? 'chat',
+				'mode' => $session['mode'] ?? 'chat',
 				'first_message' => mb_substr( $first_message, 0, 100 ),
 				'message_count' => count( $messages ),
 				'unread_count'  => $this->count_unread( $messages, $last_read_at ),
@@ -579,27 +581,27 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * Get total session count for a user
 	 *
 	 * @param int         $user_id  WordPress user ID
-	 * @param string|null $context  Optional context filter
+	 * @param string|null $mode  Optional mode filter
 	 * @param int|null    $agent_id Optional agent ID filter (null = no filter)
 	 * @return int Total session count
 	 */
 	public function get_user_session_count(
 		int $user_id,
-		?string $context = null,
+		?string $mode = null,
 		?int $agent_id = null
 	): int {
 		global $wpdb;
 
 		$table_name = self::get_prefixed_table_name();
 
-		if ( null !== $agent_id && null !== $context && '' !== $context ) {
+		if ( null !== $agent_id && null !== $mode && '' !== $mode ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$count = $wpdb->get_var(
 				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i WHERE user_id = %d AND context = %s AND agent_id = %d',
+					'SELECT COUNT(*) FROM %i WHERE user_id = %d AND mode = %s AND agent_id = %d',
 					$table_name,
 					$user_id,
-					$context,
+					$mode,
 					$agent_id
 				)
 			);
@@ -613,14 +615,14 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 					$agent_id
 				)
 			);
-		} elseif ( null !== $context && '' !== $context ) {
+		} elseif ( null !== $mode && '' !== $mode ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$count = $wpdb->get_var(
 				$wpdb->prepare(
-					'SELECT COUNT(*) FROM %i WHERE user_id = %d AND context = %s',
+					'SELECT COUNT(*) FROM %i WHERE user_id = %d AND mode = %s',
 					$table_name,
 					$user_id,
-					$context
+					$mode
 				)
 			);
 		} else {
@@ -644,7 +646,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * - Belongs to this user
 	 * - Was created within the threshold (default 10 minutes)
 	 * - Has 0 messages OR is actively processing (user message added but no AI response)
-	 * - Matches the specified agent type
+	 * - Matches the specified mode
 	 *
 	 * This prevents duplicate sessions when requests timeout at Cloudflare
 	 * but PHP continues executing. On retry, we reuse the pending session
@@ -653,14 +655,14 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * @since 0.9.8
 	 * @param int      $user_id WordPress user ID
 	 * @param int      $seconds Lookback window in seconds (default 600 = 10 minutes)
-	 * @param string   $context Context filter
+	 * @param string $mode Mode filter
 	 * @param int|null $token_id Optional token ID for login-scoped deduplication.
 	 * @return array|null Session data or null if none found
 	 */
 	public function get_recent_pending_session(
 		int $user_id,
 		int $seconds = 600,
-		string $context = 'chat',
+		string $mode = 'chat',
 		?int $token_id = null
 	): ?array {
 		global $wpdb;
@@ -670,7 +672,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 
 		$query  = "SELECT * FROM %i
 				WHERE user_id = %d
-				AND context = %s
+				AND mode = %s
 				AND created_at >= %s
 				AND (
 					(messages = '[]' OR messages = '' OR messages IS NULL)
@@ -679,7 +681,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		$params = array(
 			$table_name,
 			$user_id,
-			$context,
+			$mode,
 			$cutoff_time,
 			'%"status":"processing"%',
 		);
@@ -736,7 +738,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				array(
 					'session_id' => $session_id,
 					'error'      => $wpdb->last_error,
-					'context'    => 'chat',
+					'mode' => 'chat',
 				)
 			);
 			return false;
@@ -860,7 +862,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 					'deleted_count'  => $deleted,
 					'retention_days' => $retention_days,
 					'cutoff_date'    => $cutoff_date,
-					'context'        => 'chat',
+					'mode' => 'chat',
 				)
 			);
 		}
@@ -908,7 +910,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 					'deleted_count'   => $deleted,
 					'hours_threshold' => $hours,
 					'cutoff_time'     => $cutoff_time,
-					'context'         => 'chat',
+					'mode' => 'chat',
 				)
 			);
 		}
@@ -923,7 +925,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * without loading the full messages blob for every row.
 	 *
 	 * @param string $date Date string in `Y-m-d` format.
-	 * @return array<int, array{session_id: string, title: string|null, context: string, created_at: string}>
+	 * @return array<int, array{session_id: string, title: string|null, mode: string, created_at: string}>
 	 */
 	public function list_sessions_for_day( string $date ): array {
 		global $wpdb;
@@ -937,7 +939,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
-				'SELECT session_id, title, context, created_at
+				'SELECT session_id, title, mode, created_at
 				 FROM %i
 				 WHERE DATE(created_at) = %s
 				 ORDER BY created_at ASC',
@@ -956,7 +958,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			$result[] = array(
 				'session_id' => (string) $row['session_id'],
 				'title'      => isset( $row['title'] ) ? (string) $row['title'] : null,
-				'context'    => isset( $row['context'] ) ? (string) $row['context'] : 'chat',
+				'mode' => isset($row['mode']) ? (string) $row['mode'] : 'chat',
 				'created_at' => (string) $row['created_at'],
 			);
 		}

--- a/inc/Core/NetworkSettings.php
+++ b/inc/Core/NetworkSettings.php
@@ -31,8 +31,7 @@ class NetworkSettings {
 	const NETWORK_KEYS = array(
 		'default_provider',
 		'default_model',
-		'context_models',
-		'agent_models',
+		'mode_models',
 	);
 
 	private static ?array $cache = null;

--- a/inc/Core/PluginSettings.php
+++ b/inc/Core/PluginSettings.php
@@ -111,36 +111,36 @@ class PluginSettings {
 	}
 
 	/**
-	 * Get provider and model for a specific execution context.
+	 * Get provider and model for a specific execution mode.
 	 *
 	 * Resolution order:
-	 * 1. Per-site context-specific override from context_models setting (or legacy agent_models)
-	 * 2. Network context-specific override from network context_models (or legacy agent_models)
+	 * 1. Per-site mode-specific override from mode_models setting
+	 * 2. Network mode-specific override from network mode_models
 	 * 3. Per-site global default_provider / default_model
 	 * 4. Network global default_provider / default_model
 	 * 5. Empty strings
 	 *
-	 * @param string $context Execution context: 'chat', 'pipeline', 'system'.
+	 * @param string $mode Execution mode: 'chat', 'pipeline', 'system'.
 	 * @return array{ provider: string, model: string }
 	 */
-	public static function getContextModel( string $context ): array {
-		// Step 1: Check per-site context-specific override.
-		$site_context_models = self::get( 'context_models', self::get( 'agent_models', array() ) );
-		$site_context_config = $site_context_models[ $context ] ?? array();
+	public static function getModelForMode( string $mode ): array {
+		// Step 1: Check per-site mode-specific override.
+		$site_mode_models = self::get( 'mode_models', array() );
+		$site_mode_config = $site_mode_models[ $mode ] ?? array();
 
-		$provider = ! empty( $site_context_config['provider'] ) ? $site_context_config['provider'] : '';
-		$model    = ! empty( $site_context_config['model'] ) ? $site_context_config['model'] : '';
+		$provider = ! empty( $site_mode_config['provider'] ) ? $site_mode_config['provider'] : '';
+		$model    = ! empty( $site_mode_config['model'] ) ? $site_mode_config['model'] : '';
 
-		// Step 2: Fall back to network context-specific override.
+		// Step 2: Fall back to network mode-specific override.
 		if ( empty( $provider ) || empty( $model ) ) {
-			$network_context_models = NetworkSettings::get( 'context_models', NetworkSettings::get( 'agent_models', array() ) );
-			$network_context_config = $network_context_models[ $context ] ?? array();
+			$network_mode_models = NetworkSettings::get( 'mode_models', array() );
+			$network_mode_config = $network_mode_models[ $mode ] ?? array();
 
-			if ( empty( $provider ) && ! empty( $network_context_config['provider'] ) ) {
-				$provider = $network_context_config['provider'];
+			if ( empty( $provider ) && ! empty( $network_mode_config['provider'] ) ) {
+				$provider = $network_mode_config['provider'];
 			}
-			if ( empty( $model ) && ! empty( $network_context_config['model'] ) ) {
-				$model = $network_context_config['model'];
+			if ( empty( $model ) && ! empty( $network_mode_config['model'] ) ) {
+				$model = $network_mode_config['model'];
 			}
 		}
 
@@ -159,21 +159,21 @@ class PluginSettings {
 	}
 
 	/**
-	 * Resolve provider/model for an agent within an execution context.
+	 * Resolve provider/model for an agent within an execution mode.
 	 *
 	 * Resolution order:
-	 * 1. agent_config.context_models[context]
+	 * 1. agent_config.mode_models[mode]
 	 * 2. agent_config.default_provider/default_model
-	 * 3. site/network context-specific overrides
+	 * 3. site/network mode-specific overrides
 	 * 4. site/network global defaults
 	 *
 	 * @param int|null $agent_id Agent ID or null/0 for no agent-specific override.
-	 * @param string   $context  Execution context.
+	 * @param string   $mode     Execution mode.
 	 * @return array{ provider: string, model: string }
 	 */
-	public static function resolveModelForAgentContext( ?int $agent_id, string $context ): array {
+	public static function resolveModelForAgentMode( ?int $agent_id, string $mode ): array {
 		$agent_id  = (int) $agent_id;
-		$cache_key = $agent_id . ':' . $context;
+		$cache_key = $agent_id . ':' . $mode;
 
 		if ( isset( self::$agent_model_cache[ $cache_key ] ) ) {
 			return self::$agent_model_cache[ $cache_key ];
@@ -184,13 +184,11 @@ class PluginSettings {
 			$agent       = $agents_repo->get_agent( $agent_id );
 			$config      = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
 
-			$context_models = is_array( $config['context_models'] ?? null )
-				? $config['context_models']
-				: ( is_array( $config['agent_models'] ?? null ) ? $config['agent_models'] : array() );
-			$context_model  = is_array( $context_models[ $context ] ?? null ) ? $context_models[ $context ] : array();
+			$mode_models = is_array( $config['mode_models'] ?? null ) ? $config['mode_models'] : array();
+			$mode_config = is_array( $mode_models[ $mode ] ?? null ) ? $mode_models[ $mode ] : array();
 
-			$provider = sanitize_text_field( $context_model['provider'] ?? '' );
-			$model    = sanitize_text_field( $context_model['model'] ?? '' );
+			$provider = sanitize_text_field( $mode_config['provider'] ?? '' );
+			$model    = sanitize_text_field( $mode_config['model'] ?? '' );
 
 			if ( empty( $provider ) ) {
 				$provider = sanitize_text_field( $config['default_provider'] ?? '' );
@@ -210,7 +208,7 @@ class PluginSettings {
 			}
 		}
 
-		self::$agent_model_cache[ $cache_key ] = self::getContextModel( $context );
+		self::$agent_model_cache[ $cache_key ] = self::getModelForMode( $mode );
 
 		return self::$agent_model_cache[ $cache_key ];
 	}

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -75,10 +75,10 @@ class AIStep extends Step {
 		$job_snapshot         = $this->engine->get( 'job' );
 		$agent_id             = (int) ( $job_snapshot['agent_id'] ?? 0 );
 
-		// Model/provider resolved exclusively via context system (agent → site → network).
-		// Pipeline-level model/provider fields are ignored — context_models is the authority.
-		$context_model = PluginSettings::resolveModelForAgentContext( $agent_id, 'pipeline' );
-		$provider_name = $context_model['provider'];
+		// Model/provider resolved exclusively via mode system (agent → site → network).
+		// Pipeline-level model/provider fields are ignored — mode_models is the authority.
+		$mode_model = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
+		$provider_name = $mode_model['provider'];
 		if ( empty( $provider_name ) ) {
 			do_action(
 				'datamachine_fail_job',
@@ -87,8 +87,8 @@ class AIStep extends Step {
 				array(
 					'flow_step_id'     => $this->flow_step_id,
 					'pipeline_step_id' => $pipeline_step_id,
-					'error_message'    => 'AI step requires provider configuration. Set a default provider in Data Machine settings or configure context_models.',
-					'solution'         => 'Set default_provider in Data Machine settings or configure context_models for the pipeline context',
+					'error_message'    => 'AI step requires provider configuration. Set a default provider in Data Machine settings or configure mode_models.',
+					'solution'         => 'Set default_provider in Data Machine settings or configure mode_models for the pipeline mode',
 				)
 			);
 			return false;
@@ -292,10 +292,10 @@ class AIStep extends Step {
 			}
 		}
 
-		// Model/provider resolved exclusively via context system — pipeline config is ignored.
-		$context_model = PluginSettings::resolveModelForAgentContext( $agent_id, 'pipeline' );
-		$provider_name = $context_model['provider'];
-		$model_name    = $context_model['model'];
+		// Model/provider resolved exclusively via mode system — pipeline config is ignored.
+		$mode_model = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
+		$provider_name = $mode_model['provider'];
+		$model_name    = $mode_model['model'];
 
 		// Establish agent execution context before firing the conversation loop.
 		//

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -44,7 +44,7 @@ class AIConversationLoop {
 	 * @param array  $tools         Available tools for AI.
 	 * @param string $provider      AI provider identifier.
 	 * @param string $model         AI model identifier.
-	 * @param string $context       Execution context ('pipeline', 'chat', ...).
+	 * @param string $mode       Execution mode ('pipeline', 'chat', ...).
 	 * @param array  $payload       Step payload / loop context.
 	 * @param int    $max_turns     Maximum conversation turns.
 	 * @param bool   $single_turn   Execute exactly one turn and return.
@@ -55,7 +55,7 @@ class AIConversationLoop {
 		array $tools,
 		string $provider,
 		string $model,
-		string $context,
+		string $mode,
 		array $payload = array(),
 		int $max_turns = PluginSettings::DEFAULT_MAX_TURNS,
 		bool $single_turn = false
@@ -81,7 +81,7 @@ class AIConversationLoop {
 		 * @param array      $tools        Available tools for AI.
 		 * @param string     $provider     AI provider identifier.
 		 * @param string     $model        AI model identifier.
-		 * @param string     $context      Execution context.
+		 * @param string     $mode      Execution mode.
 		 * @param array      $payload      Step payload / loop context.
 		 * @param int        $max_turns    Maximum conversation turns.
 		 * @param bool       $single_turn  Single-turn mode flag.
@@ -93,7 +93,7 @@ class AIConversationLoop {
 			$tools,
 			$provider,
 			$model,
-			$context,
+			$mode,
 			$payload,
 			$max_turns,
 			$single_turn
@@ -109,7 +109,7 @@ class AIConversationLoop {
 			$tools,
 			$provider,
 			$model,
-			$context,
+			$mode,
 			$payload,
 			$max_turns,
 			$single_turn
@@ -123,7 +123,7 @@ class AIConversationLoop {
 	 * @param array  $tools          Available tools for AI
 	 * @param string $provider       AI provider (openai, anthropic, etc.)
 	 * @param string $model          AI model identifier
-	 * @param string $context        Execution context: 'pipeline' or 'chat'
+	 * @param string $mode        Execution mode: 'pipeline' or 'chat'
 	 * @param array  $payload        Step payload (job_id, flow_step_id, data, flow_step_config)
 	 * @param int    $max_turns      Maximum conversation turns (default 25)
 	 * @param bool   $single_turn    Execute exactly one turn and return (default false)
@@ -141,7 +141,7 @@ class AIConversationLoop {
 		array $tools,
 		string $provider,
 		string $model,
-		string $context,
+		string $mode,
 		array $payload = array(),
 		int $max_turns = PluginSettings::DEFAULT_MAX_TURNS,
 		bool $single_turn = false
@@ -174,10 +174,10 @@ class AIConversationLoop {
 		$flow_step_config       = $payload['flow_step_config'] ?? array();
 		$configured_handlers    = $flow_step_config['handler_slugs'] ?? array();
 
-		// Build base log context from payload for consistent logging
+		// Build base log metadata from payload for consistent logging.
 		$base_log_context = array_filter(
 			array(
-				'context'      => $context,
+				'mode'         => $mode,
 				'job_id'       => $payload['job_id'] ?? null,
 				'flow_step_id' => $payload['flow_step_id'] ?? null,
 			),
@@ -194,7 +194,7 @@ class AIConversationLoop {
 				$provider,
 				$model,
 				$tools,
-				$context,
+				$mode,
 				$payload
 			);
 
@@ -247,7 +247,7 @@ class AIConversationLoop {
 				$messages[] = $ai_message;
 
 				// Fire hook for AI response events (used for system operations like title generation)
-				do_action( 'datamachine_ai_response_received', $context, $messages, $payload );
+				do_action( 'datamachine_ai_response_received', $mode, $messages, $payload );
 			}
 
 			// Process tool calls
@@ -351,7 +351,7 @@ class AIConversationLoop {
 
 					// Track handler tool execution in pipeline mode.
 					// Only complete when ALL configured handlers have fired (multi-handler support).
-					if ( 'pipeline' === $context && $is_handler_tool && ( $tool_result['success'] ?? false ) ) {
+					if ( 'pipeline' === $mode && $is_handler_tool && ( $tool_result['success'] ?? false ) ) {
 						$handler_slug = $tool_def['handler'] ?? null;
 						if ( $handler_slug ) {
 							$executed_handler_slugs[] = $handler_slug;

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -2,7 +2,7 @@
 /**
  * AI Request Builder - Centralized AI request construction for all agents
  *
- * Single source of truth for building standardized AI requests across chat and pipeline contexts.
+ * Single source of truth for building standardized AI requests across chat and pipeline modes.
  * Ensures consistent request structure, tool formatting, and directive application to prevent
  * architectural drift between different AI agent types.
  *
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class RequestBuilder {
 
 	/**
-	 * Build standardized AI request for any context.
+	 * Build standardized AI request for any execution mode.
 	 *
 	 * Centralizes request construction logic to ensure chat and pipeline flows
 	 * build identical request structures. Handles tool restructuring, directive
@@ -27,7 +27,7 @@ class RequestBuilder {
 	 * @param string $provider    AI provider name (openai, anthropic, google, grok, openrouter)
 	 * @param string $model       Model identifier
 	 * @param array  $tools       Raw tools array from filters
-	 * @param string $context     Execution context: 'chat' or 'pipeline'
+	 * @param string $mode     Execution mode: 'chat' or 'pipeline'
 	 * @param array  $payload     Step payload (session_id, job_id, flow_step_id, data, etc)
 	 * @return array AI response from provider
 	 */
@@ -36,7 +36,7 @@ class RequestBuilder {
 		string $provider,
 		string $model,
 		array $tools,
-		string $context,
+		string $mode,
 		array $payload = array()
 	): array {
 
@@ -66,7 +66,7 @@ class RequestBuilder {
 		}
 
 		// Build the request with directives applied
-		$request            = $promptBuilder->build( $context, $provider, $payload );
+		$request            = $promptBuilder->build( $mode, $provider, $payload );
 		$applied_directives = $request['applied_directives'] ?? array();
 		unset( $request['applied_directives'] );
 		$request['model'] = $model;
@@ -77,7 +77,7 @@ class RequestBuilder {
 			'AI request built',
 			array_filter(
 				array(
-					'context'       => $context,
+					'mode'          => $mode,
 					'job_id'        => $payload['job_id'] ?? null,
 					'flow_step_id'  => $payload['flow_step_id'] ?? null,
 					'provider'      => $provider,
@@ -99,7 +99,7 @@ class RequestBuilder {
 			$structured_tools,
 			$payload['step_id'] ?? $payload['session_id'] ?? null,
 			array(
-				'context' => $context,
+				'mode'    => $mode,
 				'payload' => $payload,
 			)
 		);

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -506,8 +506,8 @@ class DailyMemoryTask extends SystemTask {
 		$lines = array();
 		foreach ( $sessions as $session ) {
 			$title   = ! empty( $session['title'] ) ? $session['title'] : 'Untitled session';
-			$context = $session['context'] ?? 'chat';
-			$lines[] = "- [{$context}] {$title}";
+			$mode    = $session['mode'] ?? 'chat';
+			$lines[] = "- [{$mode}] {$title}";
 		}
 
 		return implode( "\n", $lines );

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -260,7 +260,7 @@ abstract class SystemTask {
 	 */
 	protected function resolveSystemModel( array $params ): array {
 		$agent_id = (int) ( $params['agent_id'] ?? ( $params['context']['agent_id'] ?? 0 ) );
-		return PluginSettings::resolveModelForAgentContext( $agent_id, 'system' );
+		return PluginSettings::resolveModelForAgentMode( $agent_id, 'system' );
 	}
 
 	/**

--- a/inc/Engine/Agents/register-agents.php
+++ b/inc/Engine/Agents/register-agents.php
@@ -170,7 +170,7 @@ function datamachine_register_default_admin_agent(): void {
 	$default_config = array();
 	if ( class_exists( '\\DataMachine\\Core\\PluginSettings' ) ) {
 		$default_config['model'] = array(
-			'default' => \DataMachine\Core\PluginSettings::getContextModel( 'chat' ),
+			'default' => \DataMachine\Core\PluginSettings::getModelForMode( 'chat' ),
 		);
 	}
 

--- a/inc/migrations/layered-architecture.php
+++ b/inc/migrations/layered-architecture.php
@@ -86,7 +86,7 @@ function datamachine_migrate_to_layered_architecture(): void {
 			$user        = get_user_by( 'id', $user_id );
 			$agent_slug  = $user ? sanitize_title( $user->user_login ) : 'user-' . $user_id;
 			$agent_name  = $user ? $user->display_name : 'User ' . $user_id;
-			$agent_model = \DataMachine\Core\PluginSettings::getContextModel( 'chat' );
+			$agent_model = \DataMachine\Core\PluginSettings::getModelForMode( 'chat' );
 
 			$agent_id = $agents_repo->create_if_missing(
 				$agent_slug,
@@ -189,7 +189,7 @@ function datamachine_migrate_to_layered_architecture(): void {
 		$default_user    = get_user_by( 'id', $default_user_id );
 		$default_slug    = $default_user ? sanitize_title( $default_user->user_login ) : 'user-' . $default_user_id;
 		$default_name    = $default_user ? $default_user->display_name : 'User ' . $default_user_id;
-		$default_model   = \DataMachine\Core\PluginSettings::getContextModel( 'chat' );
+		$default_model   = \DataMachine\Core\PluginSettings::getModelForMode( 'chat' );
 
 		$agents_repo->create_if_missing(
 			$default_slug,

--- a/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
@@ -397,7 +397,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 		$pipeline_step_id = $add_result['pipeline_step_id'];
 
 		// Provider/model are no longer configurable at the pipeline step level.
-		// Model resolution is handled by the context system (context_models setting).
+		// Model resolution is handled by the context system (mode_models setting).
 		$result = $this->step_abilities->executeUpdatePipelineStep(
 			array(
 				'pipeline_step_id' => $pipeline_step_id,

--- a/tests/Unit/Core/NetworkSettingsTest.php
+++ b/tests/Unit/Core/NetworkSettingsTest.php
@@ -161,7 +161,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 		$this->assertSame( 12, PluginSettings::resolve( 'max_turns', 12 ) );
 	}
 
-	// --- getContextModel() cascade ---
+	// --- getModelForMode() cascade ---
 
 	public function test_get_agent_model_site_override_wins(): void {
 		update_option( 'datamachine_settings', array(
@@ -177,7 +177,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 			),
 		) );
 
-		$result = PluginSettings::getContextModel( 'chat' );
+		$result = PluginSettings::getModelForMode( 'chat' );
 
 		$this->assertSame( 'openai', $result['provider'] );
 		$this->assertSame( 'gpt-4o', $result['model'] );
@@ -193,7 +193,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 			),
 		) );
 
-		$result = PluginSettings::getContextModel( 'pipeline' );
+		$result = PluginSettings::getModelForMode( 'pipeline' );
 
 		$this->assertSame( 'openai', $result['provider'] );
 		$this->assertSame( 'gpt-4o-mini', $result['model'] );
@@ -208,7 +208,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 			'default_model'    => 'claude-sonnet-4-20250514',
 		) );
 
-		$result = PluginSettings::getContextModel( 'system' );
+		$result = PluginSettings::getModelForMode( 'system' );
 
 		$this->assertSame( 'anthropic', $result['provider'] );
 		$this->assertSame( 'claude-sonnet-4-20250514', $result['model'] );
@@ -218,7 +218,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 		update_option( 'datamachine_settings', array() );
 		PluginSettings::clearCache();
 
-		$result = PluginSettings::getContextModel( 'chat' );
+		$result = PluginSettings::getModelForMode( 'chat' );
 
 		$this->assertSame( '', $result['provider'] );
 		$this->assertSame( '', $result['model'] );
@@ -240,7 +240,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 			),
 		) );
 
-		$result = PluginSettings::getContextModel( 'chat' );
+		$result = PluginSettings::getModelForMode( 'chat' );
 
 		// Provider from site, model from network.
 		$this->assertSame( 'openai', $result['provider'] );


### PR DESCRIPTION
Closes #1138.

Completes the hard cutover started in #1129 / #1130. No BC shims, no legacy aliases — one vocabulary end-to-end.

## What moved

**PHP model-selection cluster**
- `PluginSettings::getContextModel()` → `getModelForMode()`
- `PluginSettings::resolveModelForAgentContext()` → `resolveModelForAgentMode()`
- `context_models` setting key → `mode_models` (settings option + `agent_config`)
- `NetworkSettings::NETWORK_KEYS` drops `context_models` / `agent_models`, adds `mode_models`

**REST surface**
- `/providers` response fields `contexts` → `modes`, `context_models` → `mode_models`
- `/chat/sessions` query param `context` → `mode`
- `datamachine/list-chat-sessions` ability input/output `context` → `mode`
- `datamachine/create-chat-session` ability input `context` → `mode`

**Chat sessions DB**
- column `context` → `mode`, keys `context` / `user_context` → `mode` / `user_mode`
- `ensure_context_column()` → `ensure_mode_column()` — migrates from legacy `context` (and even older `agent_type`) columns in place. Data preserved.
- `DailyMemoryTask` + `ChatCommand` CLI read `session['mode']`

**AI loop**
- `AIConversationLoop::run()` / `execute()` `$context` param → `$mode`
- `RequestBuilder::build()` `$context` param → `$mode`
- Log metadata fields `context` → `mode`

**Admin UI**
- `AgentSettings.jsx` consumes `providersData.modes` + `settings.mode_models`
- Strips `agent_models` / `context_models` BC reads

**Updated callers**
Abilities (Chat, Internal Linking, Media, Meta Description, Pipeline Steps, Settings, System), `AIStep`, `ChatOrchestrator`, `register-agents` bootstrap, activation migrations, and unit tests.

## Migration path for existing installs

- Settings / `agent_config`: on next save, `mode_models` is written. Before that, model-selection overrides fall through to the global defaults (no crash; just the per-mode overrides are unset). Acceptable for a hard cutover.
- Chat sessions DB: `ensure_mode_column()` fires on `plugins_loaded` priority 6 and renames the `context` column to `mode` via `ALTER TABLE ... CHANGE COLUMN`. Rows are preserved byte-for-byte.
- React admin: picks up new fields on next asset load; no manual step.

## Sanity checks

- `grep -rn "getContextModel|resolveModelForAgentContext|context_models|agent_models|ensure_context_column|providersData\.contexts" inc/ tests/ docs/` → 0 matches (ignoring the historical changelog entry).
- Extension audit across `data-machine-events`, `data-machine-socials`, `data-machine-code`, `data-machine-editor`, `data-machine-chat-bridge`, `data-machine-frontend-chat`, `extrachill-roadie`, `extrachill-ai-client`, `extrachill-api` → 0 consumers of the renamed symbols. The surface is self-contained within data-machine core.
- PHP syntax check on all modified files: clean.

## Acceptance (from #1138)

- [x] Zero references to `context` vocabulary in model-selection code paths
- [x] Zero references to `context` in tool/memory/directive vocabulary (was already true post-#1130, still true)
- [x] Setting key, REST field, and DB column all renamed with migration paths for existing installs

Refs #1129, #1130.