### PR TITLE
feat(processed-items): time-windowed revisit API + filter wire point

### DIFF
--- a/docs/api/endpoints/processed-items.md
+++ b/docs/api/endpoints/processed-items.md
@@ -395,13 +395,22 @@ curl -X DELETE https://example.com/wp-json/datamachine/v1/processed-items/1523 \
 
 ## Abilities API Integration
 
-Three registered abilities provide programmatic access to processed items operations. These are used by REST API endpoints, CLI commands, and Chat tools.
+Six registered abilities provide programmatic access to processed items operations. These are used by REST API endpoints, CLI commands, and Chat tools.
 
 | Ability | Description |
 |---------|-------------|
 | `datamachine/clear-processed-items` | Clear processed items by pipeline or flow scope |
 | `datamachine/check-processed-item` | Check if a specific item has been processed for a flow step |
 | `datamachine/has-processed-history` | Check if a flow step has any processing history |
+| `datamachine/processed-items-get-processed-at` | Get the last-processed Unix timestamp for a specific item (or null) |
+| `datamachine/processed-items-find-stale` | Given candidate identifiers, return those older than N days |
+| `datamachine/processed-items-find-never-processed` | Given candidate identifiers, return those with no row for this flow step + source type |
+
+### Revisit API (since 0.71.0)
+
+The three `processed-items-*` abilities expose the time-windowed read surface on the `processed_timestamp` column that has been populated on every row since the table existed. Together with the `datamachine_should_reprocess_item` filter (see [core-filters.md](../../development/hooks/core-filters.md)), they let consumers build maintenance-style pipelines ("review wiki post X if last reviewed > 7 days ago", "venue refresh on cadence", "rotating SEO audit") as thin wrappers on one DM primitive — no parallel tables, no post_meta, no new registration surface.
+
+See `ProcessedItems::get_processed_at()`, `has_been_processed_within()`, `find_stale()`, and `find_never_processed()` for the underlying methods.
 
 ### has-processed-history
 
@@ -455,7 +464,7 @@ The `SkipItemTool` is a handler tool available during the Fetch step that allows
 - `ExecutionContext::fromConfig($config, $job_id, $handler_type)` — Backward-compatible creation from handler config array
 
 **Key Methods for Processed Items**:
-- `isItemProcessed(string $item_id): bool` — Checks deduplication via `ProcessedItems::has_item_been_processed()`. Returns `false` in direct mode.
+- `isItemProcessed(string $item_id): bool` — Checks deduplication via `ProcessedItems::has_item_been_processed()` and applies the `datamachine_should_reprocess_item` filter so consumers can opt into revisit semantics (since 0.71.0). Returns `false` in direct and standalone modes.
 - `markItemProcessed(string $item_id): void` — Fires `datamachine_mark_item_processed` action. No-op in direct mode.
 - `storeEngineData(array $data): void` — Merges data into engine snapshot for the current job
 - `getEngine(): EngineData` — Lazily loads engine data for the current job

--- a/docs/core-system/abilities-api.md
+++ b/docs/core-system/abilities-api.md
@@ -355,13 +355,16 @@ Internal abilities for the pipeline execution engine.
 | `datamachine/get-step-types` | List available step types, or get single by slug | `StepTypeAbilities.php` |
 | `datamachine/validate-step-type` | Validate step type configuration | `StepTypeAbilities.php` |
 
-### Processed Items (3 abilities)
+### Processed Items (6 abilities)
 
 | Ability | Description | Location |
 |---------|-------------|----------|
 | `datamachine/clear-processed-items` | Clear processed items for flow (resets deduplication) | `ProcessedItemsAbilities.php` |
 | `datamachine/check-processed-item` | Check if item was processed | `ProcessedItemsAbilities.php` |
 | `datamachine/has-processed-history` | Check if flow has processed history | `ProcessedItemsAbilities.php` |
+| `datamachine/processed-items-get-processed-at` | Get last-processed Unix timestamp for an item (or null) | `ProcessedItemsAbilities.php` |
+| `datamachine/processed-items-find-stale` | Given candidates, return those older than N days | `ProcessedItemsAbilities.php` |
+| `datamachine/processed-items-find-never-processed` | Given candidates, return those never processed | `ProcessedItemsAbilities.php` |
 
 ### Agent Ping (1 ability)
 

--- a/docs/core-system/database-schema.md
+++ b/docs/core-system/database-schema.md
@@ -125,7 +125,8 @@ CREATE TABLE wp_datamachine_processed_items (
     UNIQUE KEY `flow_source_item` (flow_step_id, source_type, item_identifier(191)),
     KEY `flow_step_id` (flow_step_id),
     KEY `source_type` (source_type),
-    KEY `job_id` (job_id)
+    KEY `job_id` (job_id),
+    KEY `flow_source_ts` (flow_step_id, source_type, processed_timestamp)
 );
 ```
 
@@ -136,6 +137,11 @@ CREATE TABLE wp_datamachine_processed_items (
 - `item_identifier` - Unique identifier within source type
 - `job_id` - Job that processed this item
 - `processed_timestamp` - Processing timestamp
+
+**Indexes**:
+- `flow_source_item` (UNIQUE) — point lookups + dedupe constraint.
+- `flow_step_id`, `source_type`, `job_id` — bulk deletes and filtered audits.
+- `flow_source_ts` (since 0.71.0) — covers time-windowed range scans used by `find_stale()` / `has_been_processed_within()`. `ProcessedItems::ensure_flow_source_ts_index()` backfills the index on existing installs since `dbDelta` does not reliably add indexes to populated tables.
 
 ### `wp_datamachine_chat_sessions`
 

--- a/docs/core-system/services-layer.md
+++ b/docs/core-system/services-layer.md
@@ -33,7 +33,7 @@ The migration from OOP service managers to WordPress Abilities API is **complete
 - **JobAbilities** - 6 abilities for workflow execution, job management, health monitoring, summary
 - **RecoverStuckJobsAbility** - 1 ability for stuck job recovery
 - **FileAbilities** - 5 abilities for file management and uploads
-- **ProcessedItemsAbilities** - 3 abilities for deduplication tracking
+- **ProcessedItemsAbilities** - 6 abilities for deduplication tracking and time-windowed revisit reads
 - **SettingsAbilities** - 7 abilities for plugin and handler settings
 - **AuthAbilities** - 3 abilities for OAuth authentication management
 - **LogAbilities** - 6 abilities for logging operations

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -516,6 +516,21 @@ wp datamachine processed-items check --flow-step=fetch_1_10 --source=rss --item=
 
 # Check if a flow step has processing history
 wp datamachine processed-items history --flow-step=fetch_1_10
+
+# Revisit semantics (since 0.71.0) — time-windowed reads on processed_timestamp
+# When was this item last processed?
+wp datamachine processed-items get-processed-at \
+  --flow-step-id=fetch_1_10 --source-type=wiki_post --item-identifier=42
+
+# Of these candidates, which are stale (older than N days)?
+wp datamachine processed-items find-stale \
+  --flow-step-id=fetch_1_10 --source-type=wiki_post \
+  --candidate-ids=1,2,3,4 --max-age-days=7
+
+# Of these candidates, which have never been processed?
+wp datamachine processed-items find-never-processed \
+  --flow-step-id=fetch_1_10 --source-type=wiki_post \
+  --candidate-ids=1,2,3,4
 ```
 
 ### datamachine links

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -743,6 +743,54 @@ $data = apply_filters('datamachine_data_packet', $data, $packet_data, $flow_step
 
 **Return**: Boolean processed status
 
+### `datamachine_should_reprocess_item`
+
+**Since**: v0.71.0
+
+**Purpose**: Opt into time-windowed revisit semantics for fetch-side deduplication without every handler growing its own `--revisit-days` flag.
+
+**Wire point**: `ExecutionContext::isItemProcessed()` — applied after the default seen/not-seen check runs. The filter is **not** invoked in `direct` or `standalone` execution modes, or when `flow_step_id` is empty.
+
+**Parameters**:
+- `$skip` (bool) — Current skip decision. `true` means "skip — already processed"; `false` means "process".
+- `$context` (array):
+  - `flow_step_id` (string)
+  - `source_type` (string)
+  - `item_identifier` (string)
+  - `job_id` (int) — 0 when unavailable.
+
+**Return**: Boolean. `true` to skip (default seen-before behavior). `false` to process anyway (revisit).
+
+**Default behavior (no filter)**: The filter never returns a different value than was passed in; existing deployments behave identically to pre-0.71 installs.
+
+**Example — reprocess stale wiki posts**:
+
+```php
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+
+add_filter( 'datamachine_should_reprocess_item', function ( $skip, $ctx ) {
+    if ( ! $skip ) {
+        return false;
+    }
+
+    if ( 'wiki_post' !== $ctx['source_type'] ) {
+        return $skip;
+    }
+
+    $fresh = ( new ProcessedItems() )->has_been_processed_within(
+        $ctx['flow_step_id'],
+        $ctx['source_type'],
+        $ctx['item_identifier'],
+        7
+    );
+
+    // skip=false means "process"; return true to keep skipping when still fresh.
+    return $fresh;
+}, 10, 2 );
+```
+
+**See also**: `ProcessedItems::get_processed_at()`, `ProcessedItems::has_been_processed_within()`, `ProcessedItems::find_stale()`, `ProcessedItems::find_never_processed()` — the time-windowed read API introduced in the same release.
+
 
 ## Duplicate Detection Filters
 

--- a/inc/Abilities/ProcessedItemsAbilities.php
+++ b/inc/Abilities/ProcessedItemsAbilities.php
@@ -44,6 +44,9 @@ class ProcessedItemsAbilities {
 			$this->registerClearProcessedItems();
 			$this->registerCheckProcessedItem();
 			$this->registerHasProcessedHistory();
+			$this->registerGetProcessedAt();
+			$this->registerFindStale();
+			$this->registerFindNeverProcessed();
 		};
 
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
@@ -166,6 +169,163 @@ class ProcessedItemsAbilities {
 					),
 				),
 				'execute_callback'    => array( $this, 'executeHasProcessedHistory' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Register datamachine/processed-items-get-processed-at ability.
+	 */
+	private function registerGetProcessedAt(): void {
+		wp_register_ability(
+			'datamachine/processed-items-get-processed-at',
+			array(
+				'label'               => __( 'Get Processed-At Timestamp', 'data-machine' ),
+				'description'         => __( 'Get the last-processed Unix timestamp for a specific item, or null if never processed.', 'data-machine' ),
+				'category'            => 'datamachine-agent',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'flow_step_id', 'source_type', 'item_identifier' ),
+					'properties' => array(
+						'flow_step_id'    => array(
+							'type'        => 'string',
+							'description' => __( 'Flow step ID in format "{pipeline_step_id}_{flow_id}"', 'data-machine' ),
+						),
+						'source_type'     => array(
+							'type'        => 'string',
+							'description' => __( 'Source type identifier (e.g., "rss", "wiki_post", "venue")', 'data-machine' ),
+						),
+						'item_identifier' => array(
+							'type'        => 'string',
+							'description' => __( 'Unique identifier for the item', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'processed_at' => array(
+							'type'        => array( 'integer', 'null' ),
+							'description' => __( 'Unix timestamp, or null when never processed', 'data-machine' ),
+						),
+						'error'        => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeGetProcessedAt' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Register datamachine/processed-items-find-stale ability.
+	 */
+	private function registerFindStale(): void {
+		wp_register_ability(
+			'datamachine/processed-items-find-stale',
+			array(
+				'label'               => __( 'Find Stale Processed Items', 'data-machine' ),
+				'description'         => __( 'Given candidate identifiers, return those whose processed_timestamp is older than the given window. Enables maintenance pipelines.', 'data-machine' ),
+				'category'            => 'datamachine-agent',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'flow_step_id', 'source_type', 'candidate_identifiers', 'max_age_days' ),
+					'properties' => array(
+						'flow_step_id'          => array(
+							'type'        => 'string',
+							'description' => __( 'Flow step ID in format "{pipeline_step_id}_{flow_id}"', 'data-machine' ),
+						),
+						'source_type'           => array(
+							'type'        => 'string',
+							'description' => __( 'Source type identifier', 'data-machine' ),
+						),
+						'candidate_identifiers' => array(
+							'type'        => 'array',
+							'items'       => array( 'type' => 'string' ),
+							'description' => __( 'Candidate item identifiers to evaluate', 'data-machine' ),
+						),
+						'max_age_days'          => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Staleness threshold in days', 'data-machine' ),
+						),
+						'limit'                 => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Maximum number of identifiers returned. Default 100.', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'   => array( 'type' => 'boolean' ),
+						'stale_ids' => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'count'     => array( 'type' => 'integer' ),
+						'error'     => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeFindStale' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Register datamachine/processed-items-find-never-processed ability.
+	 */
+	private function registerFindNeverProcessed(): void {
+		wp_register_ability(
+			'datamachine/processed-items-find-never-processed',
+			array(
+				'label'               => __( 'Find Never-Processed Items', 'data-machine' ),
+				'description'         => __( 'Given candidate identifiers, return those that have never been processed for this flow step + source type. Enables backfill on first run.', 'data-machine' ),
+				'category'            => 'datamachine-agent',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'flow_step_id', 'source_type', 'candidate_identifiers' ),
+					'properties' => array(
+						'flow_step_id'          => array(
+							'type'        => 'string',
+							'description' => __( 'Flow step ID in format "{pipeline_step_id}_{flow_id}"', 'data-machine' ),
+						),
+						'source_type'           => array(
+							'type'        => 'string',
+							'description' => __( 'Source type identifier', 'data-machine' ),
+						),
+						'candidate_identifiers' => array(
+							'type'        => 'array',
+							'items'       => array( 'type' => 'string' ),
+							'description' => __( 'Candidate item identifiers to evaluate', 'data-machine' ),
+						),
+						'limit'                 => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Maximum number of identifiers returned. Default 100.', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'         => array( 'type' => 'boolean' ),
+						'never_processed' => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'count'           => array( 'type' => 'integer' ),
+						'error'           => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeFindNeverProcessed' ),
 				'permission_callback' => array( $this, 'checkPermission' ),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
@@ -319,6 +479,165 @@ class ProcessedItemsAbilities {
 		return array(
 			'success'     => true,
 			'has_history' => $has_history,
+		);
+	}
+
+	/**
+	 * Execute processed-items-get-processed-at ability.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result with processed_at timestamp (or null).
+	 */
+	public function executeGetProcessedAt( array $input ): array {
+		$flow_step_id    = $input['flow_step_id'] ?? null;
+		$source_type     = $input['source_type'] ?? null;
+		$item_identifier = $input['item_identifier'] ?? null;
+
+		if ( empty( $flow_step_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_step_id is required',
+			);
+		}
+
+		if ( empty( $source_type ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'source_type is required',
+			);
+		}
+
+		if ( empty( $item_identifier ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'item_identifier is required',
+			);
+		}
+
+		$flow_step_id    = sanitize_text_field( $flow_step_id );
+		$source_type     = sanitize_text_field( $source_type );
+		$item_identifier = sanitize_text_field( $item_identifier );
+
+		$processed_at = $this->db_processed_items->get_processed_at(
+			$flow_step_id,
+			$source_type,
+			$item_identifier
+		);
+
+		return array(
+			'success'      => true,
+			'processed_at' => $processed_at,
+		);
+	}
+
+	/**
+	 * Execute processed-items-find-stale ability.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result with stale_ids array.
+	 */
+	public function executeFindStale( array $input ): array {
+		$flow_step_id = $input['flow_step_id'] ?? null;
+		$source_type  = $input['source_type'] ?? null;
+		$candidates   = $input['candidate_identifiers'] ?? null;
+		$max_age_days = $input['max_age_days'] ?? null;
+		$limit        = $input['limit'] ?? 100;
+
+		if ( empty( $flow_step_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_step_id is required',
+			);
+		}
+
+		if ( empty( $source_type ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'source_type is required',
+			);
+		}
+
+		if ( ! is_array( $candidates ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'candidate_identifiers must be an array',
+			);
+		}
+
+		if ( ! is_numeric( $max_age_days ) || (int) $max_age_days < 1 ) {
+			return array(
+				'success' => false,
+				'error'   => 'max_age_days must be an integer >= 1',
+			);
+		}
+
+		$flow_step_id = sanitize_text_field( $flow_step_id );
+		$source_type  = sanitize_text_field( $source_type );
+		$candidates   = array_values( array_map( 'strval', $candidates ) );
+
+		$stale_ids = $this->db_processed_items->find_stale(
+			$flow_step_id,
+			$source_type,
+			$candidates,
+			(int) $max_age_days,
+			max( 1, (int) $limit )
+		);
+
+		return array(
+			'success'   => true,
+			'stale_ids' => $stale_ids,
+			'count'     => count( $stale_ids ),
+		);
+	}
+
+	/**
+	 * Execute processed-items-find-never-processed ability.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result with never_processed array.
+	 */
+	public function executeFindNeverProcessed( array $input ): array {
+		$flow_step_id = $input['flow_step_id'] ?? null;
+		$source_type  = $input['source_type'] ?? null;
+		$candidates   = $input['candidate_identifiers'] ?? null;
+		$limit        = $input['limit'] ?? 100;
+
+		if ( empty( $flow_step_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_step_id is required',
+			);
+		}
+
+		if ( empty( $source_type ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'source_type is required',
+			);
+		}
+
+		if ( ! is_array( $candidates ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'candidate_identifiers must be an array',
+			);
+		}
+
+		$flow_step_id = sanitize_text_field( $flow_step_id );
+		$source_type  = sanitize_text_field( $source_type );
+		$candidates   = array_values( array_map( 'strval', $candidates ) );
+
+		$never = $this->db_processed_items->find_never_processed(
+			$flow_step_id,
+			$source_type,
+			$candidates,
+			max( 1, (int) $limit )
+		);
+
+		return array(
+			'success'         => true,
+			'never_processed' => $never,
+			'count'           => count( $never ),
 		);
 	}
 }

--- a/inc/Cli/Commands/ProcessedItemsCommand.php
+++ b/inc/Cli/Commands/ProcessedItemsCommand.php
@@ -483,4 +483,269 @@ class ProcessedItemsCommand extends BaseCommand {
 			WP_CLI::log( sprintf( 'Flow step %s has no processing history (first run or cleared).', $flow_step_id ) );
 		}
 	}
+
+	/**
+	 * Get the last-processed timestamp for a specific item.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --flow-step-id=<flow_step_id>
+	 * : Flow step ID in format "{pipeline_step_id}_{flow_id}".
+	 *
+	 * --source-type=<source_type>
+	 * : Source type (e.g., "rss", "wiki_post", "venue").
+	 *
+	 * --item-identifier=<item_identifier>
+	 * : Unique identifier for the item.
+	 *
+	 * [--format=<format>]
+	 * : Output format. Default: table.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine processed-items get-processed-at --flow-step-id=3_12 --source-type=rss --item-identifier=https://example.com/post-1
+	 *     wp datamachine processed-items get-processed-at --flow-step-id=3_12 --source-type=wiki_post --item-identifier=42 --format=json
+	 *
+	 * @subcommand get-processed-at
+	 */
+	public function get_processed_at( array $args, array $assoc_args ): void {
+		$flow_step_id    = $assoc_args['flow-step-id'] ?? '';
+		$source_type     = $assoc_args['source-type'] ?? '';
+		$item_identifier = $assoc_args['item-identifier'] ?? '';
+		$format          = $assoc_args['format'] ?? 'table';
+
+		if ( '' === $flow_step_id || '' === $source_type || '' === $item_identifier ) {
+			WP_CLI::error( '--flow-step-id, --source-type, and --item-identifier are all required.' );
+			return;
+		}
+
+		$ability = new ProcessedItemsAbilities();
+		$result  = $ability->executeGetProcessedAt(
+			array(
+				'flow_step_id'    => $flow_step_id,
+				'source_type'     => $source_type,
+				'item_identifier' => $item_identifier,
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to get processed-at timestamp.' );
+			return;
+		}
+
+		$processed_at = $result['processed_at'];
+
+		$rows = array(
+			array(
+				'flow_step_id'      => $flow_step_id,
+				'source_type'       => $source_type,
+				'item_identifier'   => $item_identifier,
+				'processed_at_unix' => null === $processed_at ? '—' : (string) $processed_at,
+				'processed_at_iso'  => null === $processed_at ? '—' : gmdate( 'Y-m-d\\TH:i:s\\Z', (int) $processed_at ),
+			),
+		);
+
+		WP_CLI\Utils\format_items( $format, $rows, array_keys( $rows[0] ) );
+	}
+
+	/**
+	 * Find candidate items that are stale (processed longer ago than the window).
+	 *
+	 * ## OPTIONS
+	 *
+	 * --flow-step-id=<flow_step_id>
+	 * : Flow step ID in format "{pipeline_step_id}_{flow_id}".
+	 *
+	 * --source-type=<source_type>
+	 * : Source type identifier.
+	 *
+	 * --candidate-ids=<csv>
+	 * : Comma-separated list of candidate item identifiers to check.
+	 *
+	 * --max-age-days=<days>
+	 * : Staleness threshold in days (integer >= 1).
+	 *
+	 * [--limit=<limit>]
+	 * : Maximum number of identifiers returned. Default 100.
+	 *
+	 * [--format=<format>]
+	 * : Output format. Default: table.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine processed-items find-stale --flow-step-id=3_12 --source-type=wiki_post \
+	 *         --candidate-ids=1,2,3,4 --max-age-days=7
+	 *
+	 * @subcommand find-stale
+	 */
+	public function find_stale( array $args, array $assoc_args ): void {
+		$flow_step_id = $assoc_args['flow-step-id'] ?? '';
+		$source_type  = $assoc_args['source-type'] ?? '';
+		$ids_csv      = $assoc_args['candidate-ids'] ?? '';
+		$max_age_days = $assoc_args['max-age-days'] ?? null;
+		$limit        = (int) ( $assoc_args['limit'] ?? 100 );
+		$format       = $assoc_args['format'] ?? 'table';
+
+		if ( '' === $flow_step_id || '' === $source_type || '' === $ids_csv ) {
+			WP_CLI::error( '--flow-step-id, --source-type, and --candidate-ids are all required.' );
+			return;
+		}
+
+		if ( null === $max_age_days || ! is_numeric( $max_age_days ) || (int) $max_age_days < 1 ) {
+			WP_CLI::error( '--max-age-days is required and must be an integer >= 1.' );
+			return;
+		}
+
+		$candidates = array_values(
+			array_filter(
+				array_map( 'trim', explode( ',', (string) $ids_csv ) ),
+				static function ( $v ) {
+					return '' !== $v;
+				}
+			)
+		);
+
+		if ( empty( $candidates ) ) {
+			WP_CLI::error( '--candidate-ids cannot be empty.' );
+			return;
+		}
+
+		$ability = new ProcessedItemsAbilities();
+		$result  = $ability->executeFindStale(
+			array(
+				'flow_step_id'          => $flow_step_id,
+				'source_type'           => $source_type,
+				'candidate_identifiers' => $candidates,
+				'max_age_days'          => (int) $max_age_days,
+				'limit'                 => $limit,
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to find stale items.' );
+			return;
+		}
+
+		$stale = $result['stale_ids'];
+
+		WP_CLI::log( sprintf( 'Stale: %d of %d candidate(s) older than %d day(s).', count( $stale ), count( $candidates ), (int) $max_age_days ) );
+
+		if ( empty( $stale ) ) {
+			return;
+		}
+
+		$rows = array();
+		foreach ( $stale as $id ) {
+			$rows[] = array( 'item_identifier' => $id );
+		}
+
+		WP_CLI\Utils\format_items( $format, $rows, array_keys( $rows[0] ) );
+	}
+
+	/**
+	 * Find candidate items that have never been processed.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --flow-step-id=<flow_step_id>
+	 * : Flow step ID in format "{pipeline_step_id}_{flow_id}".
+	 *
+	 * --source-type=<source_type>
+	 * : Source type identifier.
+	 *
+	 * --candidate-ids=<csv>
+	 * : Comma-separated list of candidate item identifiers to check.
+	 *
+	 * [--limit=<limit>]
+	 * : Maximum number of identifiers returned. Default 100.
+	 *
+	 * [--format=<format>]
+	 * : Output format. Default: table.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine processed-items find-never-processed --flow-step-id=3_12 --source-type=wiki_post \
+	 *         --candidate-ids=1,2,3,4
+	 *
+	 * @subcommand find-never-processed
+	 */
+	public function find_never_processed( array $args, array $assoc_args ): void {
+		$flow_step_id = $assoc_args['flow-step-id'] ?? '';
+		$source_type  = $assoc_args['source-type'] ?? '';
+		$ids_csv      = $assoc_args['candidate-ids'] ?? '';
+		$limit        = (int) ( $assoc_args['limit'] ?? 100 );
+		$format       = $assoc_args['format'] ?? 'table';
+
+		if ( '' === $flow_step_id || '' === $source_type || '' === $ids_csv ) {
+			WP_CLI::error( '--flow-step-id, --source-type, and --candidate-ids are all required.' );
+			return;
+		}
+
+		$candidates = array_values(
+			array_filter(
+				array_map( 'trim', explode( ',', (string) $ids_csv ) ),
+				static function ( $v ) {
+					return '' !== $v;
+				}
+			)
+		);
+
+		if ( empty( $candidates ) ) {
+			WP_CLI::error( '--candidate-ids cannot be empty.' );
+			return;
+		}
+
+		$ability = new ProcessedItemsAbilities();
+		$result  = $ability->executeFindNeverProcessed(
+			array(
+				'flow_step_id'          => $flow_step_id,
+				'source_type'           => $source_type,
+				'candidate_identifiers' => $candidates,
+				'limit'                 => $limit,
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to find never-processed items.' );
+			return;
+		}
+
+		$never = $result['never_processed'];
+
+		WP_CLI::log( sprintf( 'Never-processed: %d of %d candidate(s).', count( $never ), count( $candidates ) ) );
+
+		if ( empty( $never ) ) {
+			return;
+		}
+
+		$rows = array();
+		foreach ( $never as $id ) {
+			$rows[] = array( 'item_identifier' => $id );
+		}
+
+		WP_CLI\Utils\format_items( $format, $rows, array_keys( $rows[0] ) );
+	}
 }

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -55,6 +55,178 @@ class ProcessedItems extends BaseRepository {
 	}
 
 	/**
+	 * Get the last-processed timestamp for an item.
+	 *
+	 * Exposes the `processed_timestamp` column populated on every insert,
+	 * enabling time-windowed revisit semantics for consumers that want
+	 * "have I touched this recently?" instead of "have I ever seen it?".
+	 *
+	 * @since 0.71.0
+	 *
+	 * @param string $flow_step_id    Flow step ID (composite: pipeline_step_id_flow_id).
+	 * @param string $source_type     Source type (e.g. 'rss', 'wiki_post', 'venue').
+	 * @param string $item_identifier Unique identifier for the item.
+	 * @return int|null Unix timestamp, or null when the item has never been processed.
+	 */
+	public function get_processed_at( string $flow_step_id, string $source_type, string $item_identifier ): ?int {
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$value = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				'SELECT UNIX_TIMESTAMP(processed_timestamp) FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s',
+				$this->table_name,
+				$flow_step_id,
+				$source_type,
+				$item_identifier
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		if ( null === $value || '' === $value ) {
+			return null;
+		}
+
+		return (int) $value;
+	}
+
+	/**
+	 * Check whether an item has been processed within a given time window.
+	 *
+	 * Returns true only when the item exists in the table AND its
+	 * `processed_timestamp` is newer than (now - $max_age_days).
+	 *
+	 * @since 0.71.0
+	 *
+	 * @param string $flow_step_id    Flow step ID.
+	 * @param string $source_type     Source type.
+	 * @param string $item_identifier Unique identifier for the item.
+	 * @param int    $max_age_days    Window in days; must be >= 1.
+	 * @return bool True when item is present and fresh. False otherwise.
+	 */
+	public function has_been_processed_within( string $flow_step_id, string $source_type, string $item_identifier, int $max_age_days ): bool {
+		if ( $max_age_days < 1 ) {
+			return false;
+		}
+
+		$processed_at = $this->get_processed_at( $flow_step_id, $source_type, $item_identifier );
+
+		if ( null === $processed_at ) {
+			return false;
+		}
+
+		return $processed_at >= ( time() - ( $max_age_days * DAY_IN_SECONDS ) );
+	}
+
+	/**
+	 * Find candidate identifiers that exist in the table but are stale.
+	 *
+	 * Given a candidate list, returns the subset that:
+	 *   (a) has a row for (flow_step_id, source_type), AND
+	 *   (b) whose `processed_timestamp` is older than (now - $max_age_days).
+	 *
+	 * Enables maintenance pipelines: "which of these posts haven't I
+	 * reviewed in the last N days?"
+	 *
+	 * @since 0.71.0
+	 *
+	 * @param string   $flow_step_id          Flow step ID.
+	 * @param string   $source_type           Source type.
+	 * @param string[] $candidate_identifiers Candidate item identifiers to check.
+	 * @param int      $max_age_days          Staleness threshold in days; must be >= 1.
+	 * @param int      $limit                 Maximum number of identifiers returned. Default 100.
+	 * @return string[] Subset of $candidate_identifiers that are stale. Empty array on bad input.
+	 */
+	public function find_stale( string $flow_step_id, string $source_type, array $candidate_identifiers, int $max_age_days, int $limit = 100 ): array {
+		if ( empty( $candidate_identifiers ) || $max_age_days < 1 || $limit < 1 ) {
+			return array();
+		}
+
+		// Normalize to unique strings to keep the IN() list bounded.
+		$candidates = array_values( array_unique( array_map( 'strval', $candidate_identifiers ) ) );
+
+		$cutoff_datetime = gmdate( 'Y-m-d H:i:s', time() - ( $max_age_days * DAY_IN_SECONDS ) );
+
+		$placeholders = implode( ',', array_fill( 0, count( $candidates ), '%s' ) );
+
+		$sql = sprintf(
+			'SELECT item_identifier FROM %%i WHERE flow_step_id = %%s AND source_type = %%s AND processed_timestamp < %%s AND item_identifier IN (%s) ORDER BY processed_timestamp ASC LIMIT %%d',
+			$placeholders
+		);
+
+		$prepare_args = array_merge(
+			array( $this->table_name, $flow_step_id, $source_type, $cutoff_datetime ),
+			$candidates,
+			array( $limit )
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $this->wpdb->get_col( $this->wpdb->prepare( $sql, ...$prepare_args ) );
+
+		return array_map( 'strval', (array) $rows );
+	}
+
+	/**
+	 * Find candidate identifiers that have never been processed.
+	 *
+	 * Given a candidate list, returns the subset with no row in the table
+	 * for (flow_step_id, source_type). Enables backfill on the first run
+	 * of a maintenance pipeline over an existing corpus.
+	 *
+	 * @since 0.71.0
+	 *
+	 * @param string   $flow_step_id          Flow step ID.
+	 * @param string   $source_type           Source type.
+	 * @param string[] $candidate_identifiers Candidate item identifiers to check.
+	 * @param int      $limit                 Maximum number of identifiers returned. Default 100.
+	 * @return string[] Subset of $candidate_identifiers with no processed row. Empty array on bad input.
+	 */
+	public function find_never_processed( string $flow_step_id, string $source_type, array $candidate_identifiers, int $limit = 100 ): array {
+		if ( empty( $candidate_identifiers ) || $limit < 1 ) {
+			return array();
+		}
+
+		// Preserve input order while deduping.
+		$seen       = array();
+		$candidates = array();
+		foreach ( $candidate_identifiers as $candidate ) {
+			$candidate = (string) $candidate;
+			if ( isset( $seen[ $candidate ] ) ) {
+				continue;
+			}
+			$seen[ $candidate ] = true;
+			$candidates[]       = $candidate;
+		}
+
+		$placeholders = implode( ',', array_fill( 0, count( $candidates ), '%s' ) );
+
+		$sql = sprintf(
+			'SELECT item_identifier FROM %%i WHERE flow_step_id = %%s AND source_type = %%s AND item_identifier IN (%s)',
+			$placeholders
+		);
+
+		$prepare_args = array_merge(
+			array( $this->table_name, $flow_step_id, $source_type ),
+			$candidates
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$existing = $this->wpdb->get_col( $this->wpdb->prepare( $sql, ...$prepare_args ) );
+		$existing = array_flip( array_map( 'strval', (array) $existing ) );
+
+		$result = array();
+		foreach ( $candidates as $candidate ) {
+			if ( isset( $existing[ $candidate ] ) ) {
+				continue;
+			}
+			$result[] = $candidate;
+			if ( count( $result ) >= $limit ) {
+				break;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Adds a record indicating an item has been processed.
 	 *
 	 * @param string $flow_step_id   The ID of the flow step (composite: pipeline_step_id_flow_id).
@@ -321,7 +493,8 @@ class ProcessedItems extends BaseRepository {
             UNIQUE KEY `flow_source_item` (flow_step_id, source_type, item_identifier(191)),
             KEY `flow_step_id` (flow_step_id),
             KEY `source_type` (source_type),
-            KEY `job_id` (job_id)
+            KEY `job_id` (job_id),
+            KEY `flow_source_ts` (flow_step_id, source_type, processed_timestamp)
         ) $charset_collate;";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
@@ -329,6 +502,9 @@ class ProcessedItems extends BaseRepository {
 
 		// dbDelta may not add UNIQUE indexes to existing tables — ensure it exists.
 		self::ensure_unique_index( $this->table_name );
+
+		// dbDelta is also unreliable at adding regular indexes to existing tables.
+		self::ensure_flow_source_ts_index( $this->table_name );
 
 		// Log table creation
 		do_action(
@@ -401,6 +577,44 @@ class ProcessedItems extends BaseRepository {
 			'datamachine_log',
 			'info',
 			'Added UNIQUE index flow_source_item to processed_items table',
+			array( 'table_name' => $table_name )
+		);
+	}
+
+	/**
+	 * Ensure the composite (flow_step_id, source_type, processed_timestamp) index exists.
+	 *
+	 * Supports the time-windowed query methods added in 0.71.0 (`find_stale`,
+	 * `has_been_processed_within`). Range scans on `processed_timestamp`
+	 * scoped by flow_step_id + source_type benefit from a covering composite
+	 * index; the existing UNIQUE key on `item_identifier` does not help.
+	 *
+	 * @since 0.71.0
+	 *
+	 * @param string $table_name Full table name.
+	 */
+	private static function ensure_flow_source_ts_index( string $table_name ): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$index = $wpdb->get_row( "SHOW INDEX FROM {$table_name} WHERE Key_name = 'flow_source_ts'" );
+
+		if ( $index ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+		$wpdb->query(
+			"ALTER TABLE {$table_name}
+			 ADD KEY `flow_source_ts` (flow_step_id, source_type, processed_timestamp)"
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Added composite index flow_source_ts to processed_items table',
 			array( 'table_name' => $table_name )
 		);
 	}

--- a/inc/Core/ExecutionContext.php
+++ b/inc/Core/ExecutionContext.php
@@ -219,15 +219,59 @@ class ExecutionContext {
 	 *
 	 * In direct mode, always returns false (no deduplication).
 	 *
+	 * Applies the `datamachine_should_reprocess_item` filter so consumers
+	 * can opt into time-windowed revisit semantics without every handler
+	 * growing its own `--revisit-days` flag. The filter receives the
+	 * default boolean skip decision and a context array, and returns a
+	 * boolean: true to skip (default seen/not-seen behavior), false to
+	 * process again despite the item being present in the table.
+	 *
 	 * @param string $item_identifier Item identifier
-	 * @return bool True if already processed
+	 * @return bool True if already processed (and should be skipped).
 	 */
 	public function isItemProcessed( string $item_identifier ): bool {
 		if ( $this->isDirect() || $this->isStandalone() || ! $this->flow_step_id ) {
 			return false;
 		}
 		$db_processed_items = new ProcessedItems();
-		return $db_processed_items->has_item_been_processed( $this->flow_step_id, $this->handler_type, $item_identifier );
+		$skip               = $db_processed_items->has_item_been_processed(
+			$this->flow_step_id,
+			$this->handler_type,
+			$item_identifier
+		);
+
+		/**
+		 * Filters whether an item should be reprocessed despite existing in processed_items.
+		 *
+		 * Default behavior (no filter): honor the boolean seen/not-seen check.
+		 * Consumers can subscribe to reprocess stale items by returning false
+		 * when `$skip` is true and the stored `processed_timestamp` is older
+		 * than their revisit window.
+		 *
+		 * @since 0.71.0
+		 *
+		 * @param bool  $skip    Whether current logic says to skip (true = skip, false = process).
+		 * @param array $context {
+		 *     Context for the decision.
+		 *
+		 *     @type string $flow_step_id    Flow step ID.
+		 *     @type string $source_type     Handler source type.
+		 *     @type string $item_identifier Item identifier being checked.
+		 *     @type int    $job_id          Current job ID (0 if unavailable).
+		 * }
+		 */
+		$skip = (bool) apply_filters(
+			'datamachine_should_reprocess_item',
+			$skip,
+			array(
+				'flow_step_id'    => $this->flow_step_id,
+				'source_type'     => $this->handler_type,
+				'item_identifier' => $item_identifier,
+				'job_id'          => (int) $this->job_id,
+			)
+		);
+
+		return $skip;
 	}
 
 	/**

--- a/tests/Unit/Abilities/ProcessedItemsAbilitiesTest.php
+++ b/tests/Unit/Abilities/ProcessedItemsAbilitiesTest.php
@@ -271,4 +271,146 @@ class ProcessedItemsAbilitiesTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['success'] );
 		$this->assertArrayHasKey( 'is_processed', $result );
 	}
+
+	// -----------------------------------------------------------------
+	// processed-items-get-processed-at
+	// -----------------------------------------------------------------
+
+	public function test_get_processed_at_ability_registered(): void {
+		$ability = wp_get_ability( 'datamachine/processed-items-get-processed-at' );
+
+		$this->assertNotNull( $ability );
+		$this->assertSame( 'datamachine/processed-items-get-processed-at', $ability->get_name() );
+	}
+
+	public function test_get_processed_at_returns_null_for_unknown_item(): void {
+		$result = $this->abilities->executeGetProcessedAt(
+			array(
+				'flow_step_id'    => $this->test_flow_step_id,
+				'source_type'     => 'rss',
+				'item_identifier' => 'never-touched-guid',
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertArrayHasKey( 'processed_at', $result );
+		$this->assertNull( $result['processed_at'] );
+	}
+
+	public function test_get_processed_at_returns_timestamp_for_known_item(): void {
+		$this->db_processed_items->add_processed_item( $this->test_flow_step_id, 'rss', 'known-guid', 1 );
+
+		$result = $this->abilities->executeGetProcessedAt(
+			array(
+				'flow_step_id'    => $this->test_flow_step_id,
+				'source_type'     => 'rss',
+				'item_identifier' => 'known-guid',
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertIsInt( $result['processed_at'] );
+	}
+
+	public function test_get_processed_at_requires_fields(): void {
+		$result = $this->abilities->executeGetProcessedAt( array() );
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'flow_step_id', $result['error'] );
+	}
+
+	// -----------------------------------------------------------------
+	// processed-items-find-stale
+	// -----------------------------------------------------------------
+
+	public function test_find_stale_ability_registered(): void {
+		$ability = wp_get_ability( 'datamachine/processed-items-find-stale' );
+
+		$this->assertNotNull( $ability );
+		$this->assertSame( 'datamachine/processed-items-find-stale', $ability->get_name() );
+	}
+
+	public function test_find_stale_requires_candidate_array(): void {
+		$result = $this->abilities->executeFindStale(
+			array(
+				'flow_step_id'          => $this->test_flow_step_id,
+				'source_type'           => 'rss',
+				'candidate_identifiers' => 'not-an-array',
+				'max_age_days'          => 7,
+			)
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'candidate_identifiers', $result['error'] );
+	}
+
+	public function test_find_stale_requires_valid_max_age_days(): void {
+		$result = $this->abilities->executeFindStale(
+			array(
+				'flow_step_id'          => $this->test_flow_step_id,
+				'source_type'           => 'rss',
+				'candidate_identifiers' => array( 'a' ),
+				'max_age_days'          => 0,
+			)
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'max_age_days', $result['error'] );
+	}
+
+	public function test_find_stale_returns_empty_for_fresh_candidates(): void {
+		$this->db_processed_items->add_processed_item( $this->test_flow_step_id, 'rss', 'fresh-a', 1 );
+
+		$result = $this->abilities->executeFindStale(
+			array(
+				'flow_step_id'          => $this->test_flow_step_id,
+				'source_type'           => 'rss',
+				'candidate_identifiers' => array( 'fresh-a' ),
+				'max_age_days'          => 7,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array(), $result['stale_ids'] );
+		$this->assertSame( 0, $result['count'] );
+	}
+
+	// -----------------------------------------------------------------
+	// processed-items-find-never-processed
+	// -----------------------------------------------------------------
+
+	public function test_find_never_processed_ability_registered(): void {
+		$ability = wp_get_ability( 'datamachine/processed-items-find-never-processed' );
+
+		$this->assertNotNull( $ability );
+		$this->assertSame( 'datamachine/processed-items-find-never-processed', $ability->get_name() );
+	}
+
+	public function test_find_never_processed_requires_candidate_array(): void {
+		$result = $this->abilities->executeFindNeverProcessed(
+			array(
+				'flow_step_id'          => $this->test_flow_step_id,
+				'source_type'           => 'rss',
+				'candidate_identifiers' => 'not-an-array',
+			)
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'candidate_identifiers', $result['error'] );
+	}
+
+	public function test_find_never_processed_returns_unseen_subset(): void {
+		$this->db_processed_items->add_processed_item( $this->test_flow_step_id, 'rss', 'already-seen', 1 );
+
+		$result = $this->abilities->executeFindNeverProcessed(
+			array(
+				'flow_step_id'          => $this->test_flow_step_id,
+				'source_type'           => 'rss',
+				'candidate_identifiers' => array( 'already-seen', 'brand-new' ),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 'brand-new' ), $result['never_processed'] );
+		$this->assertSame( 1, $result['count'] );
+	}
 }

--- a/tests/Unit/Core/Database/ProcessedItemsTest.php
+++ b/tests/Unit/Core/Database/ProcessedItemsTest.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * ProcessedItems Revisit API Tests
+ *
+ * Covers the time-windowed query methods added in 0.71.0:
+ *   - get_processed_at
+ *   - has_been_processed_within
+ *   - find_stale
+ *   - find_never_processed
+ *
+ * Also verifies the composite (flow_step_id, source_type, processed_timestamp)
+ * index is created on activation.
+ *
+ * @package DataMachine\Tests\Unit\Core\Database
+ */
+
+namespace DataMachine\Tests\Unit\Core\Database;
+
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use WP_UnitTestCase;
+
+class ProcessedItemsTest extends WP_UnitTestCase {
+
+	private ProcessedItems $db;
+	private string $flow_step_id = '77_777';
+	private string $source_type  = 'wiki_post';
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->db = new ProcessedItems();
+
+		// Ensure isolation from other tests that might write to this table.
+		$this->db->delete_processed_items( array( 'flow_step_id' => $this->flow_step_id ) );
+	}
+
+	public function tear_down(): void {
+		$this->db->delete_processed_items( array( 'flow_step_id' => $this->flow_step_id ) );
+		parent::tear_down();
+	}
+
+	// -----------------------------------------------------------------
+	// get_processed_at
+	// -----------------------------------------------------------------
+
+	public function test_get_processed_at_returns_null_for_unknown_item(): void {
+		$this->assertNull(
+			$this->db->get_processed_at( $this->flow_step_id, $this->source_type, 'never-seen' )
+		);
+	}
+
+	public function test_get_processed_at_returns_unix_timestamp_for_known_item(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'seen-1', 123 );
+
+		$before = time() - 5;
+		$after  = time() + 5;
+
+		$ts = $this->db->get_processed_at( $this->flow_step_id, $this->source_type, 'seen-1' );
+
+		$this->assertIsInt( $ts );
+		$this->assertGreaterThanOrEqual( $before, $ts );
+		$this->assertLessThanOrEqual( $after, $ts );
+	}
+
+	// -----------------------------------------------------------------
+	// has_been_processed_within
+	// -----------------------------------------------------------------
+
+	public function test_has_been_processed_within_returns_false_when_never_processed(): void {
+		$this->assertFalse(
+			$this->db->has_been_processed_within( $this->flow_step_id, $this->source_type, 'never-seen', 7 )
+		);
+	}
+
+	public function test_has_been_processed_within_returns_true_for_fresh_row(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'fresh-id', 1 );
+
+		$this->assertTrue(
+			$this->db->has_been_processed_within( $this->flow_step_id, $this->source_type, 'fresh-id', 7 )
+		);
+	}
+
+	public function test_has_been_processed_within_returns_false_for_old_row(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'old-id', 1 );
+		$this->backdate_rows( array( 'old-id' ), 30 );
+
+		$this->assertFalse(
+			$this->db->has_been_processed_within( $this->flow_step_id, $this->source_type, 'old-id', 7 )
+		);
+	}
+
+	public function test_has_been_processed_within_rejects_zero_days(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'fresh-id-2', 1 );
+
+		$this->assertFalse(
+			$this->db->has_been_processed_within( $this->flow_step_id, $this->source_type, 'fresh-id-2', 0 )
+		);
+	}
+
+	// -----------------------------------------------------------------
+	// find_stale
+	// -----------------------------------------------------------------
+
+	public function test_find_stale_returns_empty_on_empty_candidate_list(): void {
+		$this->assertSame( array(), $this->db->find_stale( $this->flow_step_id, $this->source_type, array(), 7 ) );
+	}
+
+	public function test_find_stale_returns_empty_when_all_candidates_fresh(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'a', 1 );
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'b', 1 );
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'c', 1 );
+
+		$stale = $this->db->find_stale(
+			$this->flow_step_id,
+			$this->source_type,
+			array( 'a', 'b', 'c' ),
+			7
+		);
+
+		$this->assertSame( array(), $stale );
+	}
+
+	public function test_find_stale_returns_all_when_all_candidates_stale(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'a', 1 );
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'b', 1 );
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'c', 1 );
+		$this->backdate_rows( array( 'a', 'b', 'c' ), 30 );
+
+		$stale = $this->db->find_stale(
+			$this->flow_step_id,
+			$this->source_type,
+			array( 'a', 'b', 'c' ),
+			7
+		);
+
+		sort( $stale );
+		$this->assertSame( array( 'a', 'b', 'c' ), $stale );
+	}
+
+	public function test_find_stale_returns_only_stale_on_mixed_input(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'fresh-1', 1 );
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'stale-1', 1 );
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'stale-2', 1 );
+		$this->backdate_rows( array( 'stale-1', 'stale-2' ), 30 );
+
+		$stale = $this->db->find_stale(
+			$this->flow_step_id,
+			$this->source_type,
+			array( 'fresh-1', 'stale-1', 'stale-2', 'never-seen' ),
+			7
+		);
+
+		sort( $stale );
+		$this->assertSame( array( 'stale-1', 'stale-2' ), $stale );
+	}
+
+	public function test_find_stale_honors_limit(): void {
+		foreach ( range( 1, 5 ) as $i ) {
+			$this->db->add_processed_item( $this->flow_step_id, $this->source_type, "item-{$i}", 1 );
+		}
+		$this->backdate_rows( array( 'item-1', 'item-2', 'item-3', 'item-4', 'item-5' ), 30 );
+
+		$stale = $this->db->find_stale(
+			$this->flow_step_id,
+			$this->source_type,
+			array( 'item-1', 'item-2', 'item-3', 'item-4', 'item-5' ),
+			7,
+			2
+		);
+
+		$this->assertCount( 2, $stale );
+	}
+
+	public function test_find_stale_rejects_bad_max_age_days(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'x', 1 );
+
+		$this->assertSame( array(), $this->db->find_stale( $this->flow_step_id, $this->source_type, array( 'x' ), 0 ) );
+		$this->assertSame( array(), $this->db->find_stale( $this->flow_step_id, $this->source_type, array( 'x' ), -1 ) );
+	}
+
+	// -----------------------------------------------------------------
+	// find_never_processed
+	// -----------------------------------------------------------------
+
+	public function test_find_never_processed_returns_empty_on_empty_candidate_list(): void {
+		$this->assertSame(
+			array(),
+			$this->db->find_never_processed( $this->flow_step_id, $this->source_type, array() )
+		);
+	}
+
+	public function test_find_never_processed_returns_all_when_none_exist(): void {
+		$never = $this->db->find_never_processed(
+			$this->flow_step_id,
+			$this->source_type,
+			array( 'new-1', 'new-2', 'new-3' )
+		);
+
+		$this->assertSame( array( 'new-1', 'new-2', 'new-3' ), $never );
+	}
+
+	public function test_find_never_processed_returns_empty_when_all_exist(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'x', 1 );
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'y', 1 );
+
+		$never = $this->db->find_never_processed(
+			$this->flow_step_id,
+			$this->source_type,
+			array( 'x', 'y' )
+		);
+
+		$this->assertSame( array(), $never );
+	}
+
+	public function test_find_never_processed_returns_subset_on_mixed_input(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'known-1', 1 );
+		$this->db->add_processed_item( $this->flow_step_id, $this->source_type, 'known-2', 1 );
+
+		$never = $this->db->find_never_processed(
+			$this->flow_step_id,
+			$this->source_type,
+			array( 'known-1', 'new-1', 'known-2', 'new-2' )
+		);
+
+		$this->assertSame( array( 'new-1', 'new-2' ), $never );
+	}
+
+	public function test_find_never_processed_honors_limit(): void {
+		$never = $this->db->find_never_processed(
+			$this->flow_step_id,
+			$this->source_type,
+			array( 'a', 'b', 'c', 'd', 'e' ),
+			2
+		);
+
+		$this->assertCount( 2, $never );
+		$this->assertSame( array( 'a', 'b' ), $never );
+	}
+
+	public function test_find_never_processed_scopes_by_source_type(): void {
+		$this->db->add_processed_item( $this->flow_step_id, 'different_source', 'only-there', 1 );
+
+		$never = $this->db->find_never_processed(
+			$this->flow_step_id,
+			$this->source_type,
+			array( 'only-there' )
+		);
+
+		$this->assertSame( array( 'only-there' ), $never );
+	}
+
+	// -----------------------------------------------------------------
+	// Index / schema
+	// -----------------------------------------------------------------
+
+	public function test_composite_flow_source_ts_index_exists(): void {
+		global $wpdb;
+
+		$table = $this->db->get_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$rows = $wpdb->get_results( "SHOW INDEX FROM {$table} WHERE Key_name = 'flow_source_ts'" );
+
+		$this->assertNotEmpty( $rows, 'Composite index flow_source_ts should exist after table creation.' );
+	}
+
+	// -----------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------
+
+	/**
+	 * Backdate a specific set of rows so they look old enough to be stale.
+	 *
+	 * @param string[] $identifiers Item identifiers to backdate.
+	 * @param int      $days_ago    How many days back to set the timestamp.
+	 */
+	private function backdate_rows( array $identifiers, int $days_ago ): void {
+		global $wpdb;
+
+		$table    = $this->db->get_table_name();
+		$backdate = gmdate( 'Y-m-d H:i:s', time() - ( $days_ago * DAY_IN_SECONDS ) );
+
+		foreach ( $identifiers as $id ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query(
+				$wpdb->prepare(
+					'UPDATE %i SET processed_timestamp = %s WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s',
+					$table,
+					$backdate,
+					$this->flow_step_id,
+					$this->source_type,
+					$id
+				)
+			);
+		}
+	}
+}

--- a/tests/Unit/Core/ExecutionContextReprocessFilterTest.php
+++ b/tests/Unit/Core/ExecutionContextReprocessFilterTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * ExecutionContext `datamachine_should_reprocess_item` Filter Tests
+ *
+ * Coverage for the revisit-window wire point added in 0.71.0:
+ *   - default behavior (no filter) unchanged
+ *   - filter can force a processed item back into the pipeline
+ *   - filter context payload carries the expected keys
+ *   - direct / standalone modes bypass the check entirely
+ *
+ * @package DataMachine\Tests\Unit\Core
+ */
+
+namespace DataMachine\Tests\Unit\Core;
+
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\ExecutionContext;
+use WP_UnitTestCase;
+
+class ExecutionContextReprocessFilterTest extends WP_UnitTestCase {
+
+	private ProcessedItems $db;
+	private int $pipeline_id = 999;
+	private int $flow_id     = 88888;
+	private string $flow_step_id;
+	private string $handler_type = 'wiki_post';
+	private string $item_identifier = 'post-42';
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->db           = new ProcessedItems();
+		$this->flow_step_id = '1_' . $this->flow_id;
+		$this->db->delete_processed_items( array( 'flow_step_id' => $this->flow_step_id ) );
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'datamachine_should_reprocess_item' );
+		$this->db->delete_processed_items( array( 'flow_step_id' => $this->flow_step_id ) );
+		parent::tear_down();
+	}
+
+	public function test_default_behavior_unchanged_when_item_not_processed(): void {
+		$ctx = ExecutionContext::fromFlow(
+			$this->pipeline_id,
+			$this->flow_id,
+			$this->flow_step_id,
+			null,
+			$this->handler_type
+		);
+
+		$this->assertFalse( $ctx->isItemProcessed( $this->item_identifier ) );
+	}
+
+	public function test_default_behavior_unchanged_when_item_processed(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->handler_type, $this->item_identifier, 1 );
+
+		$ctx = ExecutionContext::fromFlow(
+			$this->pipeline_id,
+			$this->flow_id,
+			$this->flow_step_id,
+			null,
+			$this->handler_type
+		);
+
+		$this->assertTrue( $ctx->isItemProcessed( $this->item_identifier ) );
+	}
+
+	public function test_filter_can_force_reprocessing_of_seen_item(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->handler_type, $this->item_identifier, 1 );
+
+		add_filter(
+			'datamachine_should_reprocess_item',
+			static function ( $skip, $context ) {
+				// Force reprocess regardless of history.
+				return false;
+			},
+			10,
+			2
+		);
+
+		$ctx = ExecutionContext::fromFlow(
+			$this->pipeline_id,
+			$this->flow_id,
+			$this->flow_step_id,
+			null,
+			$this->handler_type
+		);
+
+		$this->assertFalse(
+			$ctx->isItemProcessed( $this->item_identifier ),
+			'Filter returning false should mark item as not-skipped (i.e. process again).'
+		);
+	}
+
+	public function test_filter_context_payload_carries_expected_keys(): void {
+		$this->db->add_processed_item( $this->flow_step_id, $this->handler_type, $this->item_identifier, 1 );
+
+		$captured = null;
+
+		add_filter(
+			'datamachine_should_reprocess_item',
+			function ( $skip, $context ) use ( &$captured ) {
+				$captured = $context;
+				return $skip;
+			},
+			10,
+			2
+		);
+
+		$ctx = ExecutionContext::fromFlow(
+			$this->pipeline_id,
+			$this->flow_id,
+			$this->flow_step_id,
+			'7',
+			$this->handler_type
+		);
+
+		$ctx->isItemProcessed( $this->item_identifier );
+
+		$this->assertIsArray( $captured );
+		$this->assertSame( $this->flow_step_id, $captured['flow_step_id'] );
+		$this->assertSame( $this->handler_type, $captured['source_type'] );
+		$this->assertSame( $this->item_identifier, $captured['item_identifier'] );
+		$this->assertSame( 7, $captured['job_id'] );
+	}
+
+	public function test_filter_not_invoked_in_direct_mode(): void {
+		$invoked = false;
+
+		add_filter(
+			'datamachine_should_reprocess_item',
+			function ( $skip, $context ) use ( &$invoked ) {
+				$invoked = true;
+				return $skip;
+			},
+			10,
+			2
+		);
+
+		$ctx = ExecutionContext::direct( $this->handler_type );
+		$this->assertFalse( $ctx->isItemProcessed( $this->item_identifier ) );
+		$this->assertFalse( $invoked, 'Filter should not fire in direct mode.' );
+	}
+
+	public function test_filter_not_invoked_in_standalone_mode(): void {
+		$invoked = false;
+
+		add_filter(
+			'datamachine_should_reprocess_item',
+			function ( $skip, $context ) use ( &$invoked ) {
+				$invoked = true;
+				return $skip;
+			},
+			10,
+			2
+		);
+
+		$ctx = ExecutionContext::standalone( null, $this->handler_type );
+		$this->assertFalse( $ctx->isItemProcessed( $this->item_identifier ) );
+		$this->assertFalse( $invoked, 'Filter should not fire in standalone mode.' );
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1152.

Promotes `processed_items` from a boolean seen/not-seen ledger to a full dedupe primitive that supports **revisit windows**, **stale-item discovery**, and **never-processed backfill** — so maintenance-style pipelines (wiki-review cadence, SEO re-audit, venue refresh, outdated-info detection, etc.) can ship as thin consumers of one DM primitive instead of inventing parallel state stores.

Deliberately minimal. **No new table. No post_meta. No artifact-state registry.** The triple `(flow_step_id, source_type, item_identifier)` is already agnostic to what the item is — every consumer picks its own `source_type` string.

## API additions

`ProcessedItems` gains four additive read methods exposing the `processed_timestamp` column that has been populated on every row since the table existed:

```php
public function get_processed_at(string $flow_step_id, string $source_type, string $item_identifier): ?int;
public function has_been_processed_within(string $flow_step_id, string $source_type, string $item_identifier, int $max_age_days): bool;
public function find_stale(string $flow_step_id, string $source_type, array $candidate_identifiers, int $max_age_days, int $limit = 100): array;
public function find_never_processed(string $flow_step_id, string $source_type, array $candidate_identifiers, int $limit = 100): array;
```

All guard empty candidate lists and bad windows. `find_stale` / `find_never_processed` honor a `$limit` param and normalize candidates (dedupe + cast to string).

## Filter wire point

`ExecutionContext::isItemProcessed()` now applies the `datamachine_should_reprocess_item` filter. Default behavior unchanged — a site with no registered callback behaves identically to today. Not invoked in `direct` / `standalone` modes.

```php
add_filter('datamachine_should_reprocess_item', function ($skip, $ctx) {
    if (!$skip || $ctx['source_type'] !== 'wiki_post') return $skip;
    return (new ProcessedItems())->has_been_processed_within(
        $ctx['flow_step_id'], $ctx['source_type'], $ctx['item_identifier'], 7
    );
}, 10, 2);
```

`$ctx` payload: `flow_step_id`, `source_type`, `item_identifier`, `job_id`.

## Schema

Adds composite `KEY flow_source_ts (flow_step_id, source_type, processed_timestamp)` in `create_table()` + `ensure_flow_source_ts_index()` helper that backfills the index on existing installs (dbDelta is unreliable at adding indexes to populated tables — same pattern as `ensure_unique_index`).

Fully backward compatible. No column changes.

## Abilities + CLI

Three new abilities (same `datamachine-agent` category, same permission callback as existing ones):

- `datamachine/processed-items-get-processed-at`
- `datamachine/processed-items-find-stale`
- `datamachine/processed-items-find-never-processed`

Three new CLI subcommands on `wp datamachine processed-items`:

- `get-processed-at --flow-step-id --source-type --item-identifier`
- `find-stale --flow-step-id --source-type --candidate-ids --max-age-days [--limit]`
- `find-never-processed --flow-step-id --source-type --candidate-ids [--limit]`

## Tests

- **New** `tests/Unit/Core/Database/ProcessedItemsTest.php` — four new methods across empty / all-stale / all-fresh / mixed candidate cases, plus composite-index schema check.
- **New** `tests/Unit/Core/ExecutionContextReprocessFilterTest.php` — filter default behavior, force-reprocess, context payload shape, direct/standalone bypass.
- **Extended** `tests/Unit/Abilities/ProcessedItemsAbilitiesTest.php` — registration + execute coverage for the three new abilities.

## Docs

- `docs/core-system/abilities-api.md` — 3 → 6 abilities.
- `docs/core-system/wp-cli.md` — three new subcommands.
- `docs/development/hooks/core-filters.md` — `datamachine_should_reprocess_item` (with wiki-post example).
- `docs/core-system/database-schema.md` — new index + backfill note.
- `docs/core-system/services-layer.md` — ability count bump.
- `docs/api/endpoints/processed-items.md` — revisit-API section cross-referencing the new methods and filter.

## Out of scope (per issue)

- `item_hash` column for diff-based re-ingest — defer until a real consumer demands it.
- Cross-flow dedupe — each `flow_step_id`'s processed items stay independent.
- Any "artifact state" abstraction beyond the existing triple — the `(flow_step_id, source_type, item_identifier)` shape is sufficient for every named use case.

## Acceptance criteria checklist

- [x] `get_processed_at`, `has_been_processed_within`, `find_stale`, `find_never_processed` added with inline PHPDoc.
- [x] `datamachine_should_reprocess_item` filter applied in `ExecutionContext::isItemProcessed()`.
- [x] Composite index added via `dbDelta()` + ensure-helper for existing installs.
- [x] Three new abilities registered with REST + CLI + MCP surfaces via the standard ability pattern.
- [x] Three new CLI subcommands on `wp datamachine processed-items`.
- [x] New tests cover the four new query methods (empty candidate list, all stale, all fresh, mix), filter wire, and new abilities. Existing tests unchanged.
- [x] Documentation updated in `docs/` for the new methods, abilities, CLI commands, schema index, and filter.
- [x] No post_meta touched. No new table. No breaking change to existing API.