### PR TITLE
feat(PostTracking): add agent-direction resolution helpers (#1155)

### DIFF
--- a/inc/Core/WordPress/PostTracking.php
+++ b/inc/Core/WordPress/PostTracking.php
@@ -144,6 +144,58 @@ class PostTracking {
 	}
 
 	/**
+	 * Resolve the agent ID for a DM-produced post.
+	 *
+	 * Reads _datamachine_post_flow_id from post meta and resolves the
+	 * agent ID via the flows table. datamachine_flows.agent_id is set at
+	 * flow creation (see Flows::create_flow) and is not mutated by
+	 * update_flow, so the resolution is stable.
+	 *
+	 * @param int $post_id WordPress post ID.
+	 * @return int Agent ID, or 0 if the post was not produced by DM,
+	 *             the flow row has since been deleted, or the flow has
+	 *             no agent_id set.
+	 */
+	public static function getAgentIdForPost( int $post_id ): int {
+		if ( $post_id <= 0 ) {
+			return 0;
+		}
+
+		$flow_id = (int) get_post_meta( $post_id, self::FLOW_ID_META_KEY, true );
+		if ( $flow_id <= 0 ) {
+			return 0;
+		}
+
+		$flow = ( new Flows() )->get_flow( $flow_id );
+		if ( ! $flow || empty( $flow['agent_id'] ) ) {
+			return 0;
+		}
+
+		return (int) $flow['agent_id'];
+	}
+
+	/**
+	 * Collect the flow IDs that belong to a given agent.
+	 *
+	 * Used to translate "posts produced by agent N" queries into
+	 * meta_query clauses on _datamachine_post_flow_id, since agent_id
+	 * is not stored on posts. datamachine_flows.agent_id is set at flow
+	 * creation and is not mutated by update_flow.
+	 *
+	 * @param int $agent_id Agent ID.
+	 * @return int[] Flow IDs belonging to the agent. Empty array if none.
+	 */
+	public static function getFlowIdsForAgent( int $agent_id ): array {
+		if ( $agent_id <= 0 ) {
+			return array();
+		}
+
+		$flows = ( new Flows() )->get_all_flows( null, $agent_id );
+
+		return array_map( static fn ( array $flow ): int => (int) $flow['flow_id'], $flows );
+	}
+
+	/**
 	 * Extract post_id from a handler result array.
 	 *
 	 * Checks both top-level and nested data.post_id locations,

--- a/tests/Unit/WordPress/PostTrackingTest.php
+++ b/tests/Unit/WordPress/PostTrackingTest.php
@@ -108,17 +108,86 @@ class PostTrackingTest extends WP_UnitTestCase {
 		$this->assertSame( 0, PostTracking::extractPostId( array( 'data' => array( 'post_id' => 0 ) ) ) );
 	}
 
-	private function create_flow( int $pipeline_id, string $flow_name = 'Test Flow' ): int {
-		$flows_db = new Flows();
-		$flow_id  = $flows_db->create_flow(
-			array(
-				'pipeline_id'       => $pipeline_id,
-				'user_id'           => get_current_user_id(),
-				'flow_name'         => $flow_name,
-				'flow_config'       => array(),
-				'scheduling_config' => array(),
-			)
+	public function test_get_agent_id_for_post_resolves_via_flow_row(): void {
+		$pipeline_id = 444;
+		$agent_id    = 42;
+		$flow_id     = $this->create_flow( $pipeline_id, 'Agent Flow', $agent_id );
+
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, PostTracking::FLOW_ID_META_KEY, $flow_id );
+
+		$this->assertSame( $agent_id, PostTracking::getAgentIdForPost( $post_id ) );
+	}
+
+	public function test_get_agent_id_for_post_returns_zero_when_flow_row_missing(): void {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, PostTracking::FLOW_ID_META_KEY, 987654321 );
+
+		$this->assertSame( 0, PostTracking::getAgentIdForPost( $post_id ) );
+	}
+
+	public function test_get_agent_id_for_post_returns_zero_when_flow_has_no_agent(): void {
+		$pipeline_id = 555;
+		$flow_id     = $this->create_flow( $pipeline_id );
+
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, PostTracking::FLOW_ID_META_KEY, $flow_id );
+
+		$this->assertSame( 0, PostTracking::getAgentIdForPost( $post_id ) );
+	}
+
+	public function test_get_agent_id_for_post_returns_zero_for_untracked_post(): void {
+		$post_id = self::factory()->post->create();
+		$this->assertSame( 0, PostTracking::getAgentIdForPost( $post_id ) );
+	}
+
+	public function test_get_agent_id_for_post_returns_zero_for_invalid_post_id(): void {
+		$this->assertSame( 0, PostTracking::getAgentIdForPost( 0 ) );
+		$this->assertSame( 0, PostTracking::getAgentIdForPost( -5 ) );
+	}
+
+	public function test_get_flow_ids_for_agent_returns_flow_ids(): void {
+		$a = $this->create_flow( 100, 'Agent 7 Flow A', 7 );
+		$b = $this->create_flow( 200, 'Agent 7 Flow B', 7 );
+		// Flows belonging to a different agent, or no agent, must not appear.
+		$this->create_flow( 100, 'Agent 8 Flow', 8 );
+		$this->create_flow( 100, 'Unassigned Flow' );
+
+		$result = PostTracking::getFlowIdsForAgent( 7 );
+
+		$this->assertContains( $a, $result );
+		$this->assertContains( $b, $result );
+		$this->assertCount( 2, $result );
+	}
+
+	public function test_get_flow_ids_for_agent_empty_when_no_flows(): void {
+		$this->assertSame( array(), PostTracking::getFlowIdsForAgent( 999999 ) );
+	}
+
+	public function test_get_flow_ids_for_agent_empty_for_invalid_agent_id(): void {
+		// Create a flow with no agent_id to confirm the guard short-circuits
+		// rather than matching NULL/0 rows.
+		$this->create_flow( 100, 'Unassigned Flow' );
+
+		$this->assertSame( array(), PostTracking::getFlowIdsForAgent( 0 ) );
+		$this->assertSame( array(), PostTracking::getFlowIdsForAgent( -1 ) );
+	}
+
+	private function create_flow( int $pipeline_id, string $flow_name = 'Test Flow', ?int $agent_id = null ): int {
+		$flow_data = array(
+			'pipeline_id'       => $pipeline_id,
+			'user_id'           => get_current_user_id(),
+			'flow_name'         => $flow_name,
+			'flow_config'       => array(),
+			'scheduling_config' => array(),
 		);
+
+		if ( null !== $agent_id ) {
+			$flow_data['agent_id'] = $agent_id;
+		}
+
+		$flows_db = new Flows();
+		$flow_id  = $flows_db->create_flow( $flow_data );
 		$this->assertIsInt( $flow_id );
 		$this->assertGreaterThan( 0, $flow_id );
 		return (int) $flow_id;


### PR DESCRIPTION
## Summary
- Adds `PostTracking::getAgentIdForPost( int $post_id ): int` — forward resolution (post → agent_id) via `_datamachine_post_flow_id` + `datamachine_flows.agent_id`.
- Adds `PostTracking::getFlowIdsForAgent( int $agent_id ): int[]` — reverse resolution for `meta_query IN` clauses; delegates to `Flows::get_all_flows( null, $agent_id )`.
- Structurally identical to the existing `getPipelineIdForPost` / `getFlowIdsForPipeline` pair. No schema change, no new meta key, no migration.

Closes #1155.

## Why
`agent_id` is a first-class column on `datamachine_flows` (added in #735) and `Flows::get_all_flows( null, $agent_id )` already filters by it, but the post-side loop was only closed for pipelines. Intelligence (and anything else that needs "show me all posts produced by agent X") had to reach into the flows table directly. These helpers close the agent-direction loop at the same layer the pipeline-direction helpers live.

## Behavior
- `getAgentIdForPost()` returns `0` for `post_id <= 0`, untracked posts, deleted flow rows, or flows whose `agent_id` is NULL/0.
- `getFlowIdsForAgent()` returns `[]` for `agent_id <= 0` or agents with no flows. The guard short-circuits before the DB call so NULL/0 `agent_id` rows can never match.
- PHPDoc on both helpers explicitly notes that `flows.agent_id` is immutable after flow creation (per `Flows::create_flow` / `Flows::update_flow` contract).

## Test plan
- [x] 8 unit tests added in `tests/Unit/WordPress/PostTrackingTest.php` mirroring the existing `getPipelineIdForPost` / `getFlowIdsForPipeline` coverage:
  - `getAgentIdForPost`: happy path, missing flow row, flow without agent_id, untracked post, invalid post_id.
  - `getFlowIdsForAgent`: happy path across multiple pipelines, empty agent, invalid agent_id guard (also verifies the guard short-circuits rather than matching NULL rows).
- [x] `create_flow()` test factory extended with an optional `?int $agent_id = null` param; existing callsites unchanged.
- [ ] CI to confirm — local PHPUnit skipped (test env has no MySQL).
- [x] `php -l` clean on both edited files.