### PR TITLE
fix(tools): pass $tools array as first arg to handler callable

### DIFF
--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -331,7 +331,7 @@ class AIConversationLoop {
 						$tool_parameters,
 						$tools,
 						$payload,
-						$context,
+						$mode,
 						(int) ( $payload['agent_id'] ?? 0 ),
 						is_array( $payload['client_context'] ?? null ) ? $payload['client_context'] : array()
 					);

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -273,12 +273,30 @@ class ToolManager {
 				continue;
 			}
 
-			$tool_map = call_user_func(
-				$definition['_handler_callable'],
-				$handler_slug,
-				$handler_config,
-				$engine_data
-			);
+			// Handler callables follow two conventions:
+			// 1. Filter-style: ($tools, $handler_slug, $handler_config, $engine_data) — 4 params
+			// 2. Direct-style: ($handler_slug, $handler_config, $engine_data) — 3 params
+			// Detect by parameter count so both work correctly.
+			$callable         = $definition['_handler_callable'];
+			$callable_params  = $this->get_callable_param_count( $callable );
+			$uses_filter_convention = ( $callable_params >= 4 );
+
+			if ( $uses_filter_convention ) {
+				$tool_map = call_user_func(
+					$callable,
+					array(),           // $tools — filter callbacks expect this as first arg.
+					$handler_slug,
+					$handler_config,
+					$engine_data
+				);
+			} else {
+				$tool_map = call_user_func(
+					$callable,
+					$handler_slug,
+					$handler_config,
+					$engine_data
+				);
+			}
 
 			if ( ! is_array( $tool_map ) ) {
 				continue;
@@ -640,5 +658,26 @@ class ToolManager {
 				'mode' => ToolPolicyResolver::MODE_CHAT,
 			)
 		);
+	}
+
+	/**
+	 * Get the number of parameters a callable accepts.
+	 *
+	 * @param callable $callable Callable to inspect.
+	 * @return int Number of required+optional parameters, or 0 if unresolvable.
+	 */
+	private function get_callable_param_count( $callable ): int {
+		try {
+			if ( is_array( $callable ) ) {
+				$ref = new \ReflectionMethod( $callable[0], $callable[1] );
+			} elseif ( $callable instanceof \Closure || is_string( $callable ) ) {
+				$ref = new \ReflectionFunction( $callable );
+			} else {
+				return 0;
+			}
+			return $ref->getNumberOfParameters();
+		} catch ( \ReflectionException $e ) {
+			return 0;
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- `ToolManager::resolveHandlerTools()` calls handler tool callbacks with wrong argument order — missing `$tools` array
- This caused `upsert_event` to never resolve into `available_tools`, breaking ALL event pipeline flows since v0.70.2 (Apr 20)
- PR #1109 exposed this by filtering handler slugs against `available_tools` keys

Fixes the `required_handler_tool_not_called` regression. Zero event completions in 30h on events.extrachill.com.