### PR TITLE
feat(upsert-post): add post_author parameter for create path

### DIFF
--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -112,6 +112,10 @@ class UpsertPostAbility {
 								'type'        => 'string',
 								'description' => 'Post status for create path. Defaults to publish.',
 							),
+							'post_author'    => array(
+								'type'        => 'integer',
+								'description' => 'Post author user ID. Only applied on create; ignored on update.',
+							),
 							'post_excerpt'   => array(
 								'type'        => 'string',
 								'description' => 'Post excerpt.',
@@ -215,6 +219,10 @@ class UpsertPostAbility {
 					'type'        => 'string',
 					'description' => 'Slash-delimited parent path (e.g. "artist/link-pages").',
 				),
+				'post_author'  => array(
+					'type'        => 'integer',
+					'description' => 'Post author user ID (create only).',
+				),
 				'content_hash' => array(
 					'type'        => 'string',
 					'description' => 'Hash for idempotency check.',
@@ -254,6 +262,7 @@ class UpsertPostAbility {
 		$content_hash = $input['content_hash'] ?? '';
 		$raw_source   = $input['raw_source'] ?? '';
 		$post_status  = sanitize_key( $input['post_status'] ?? 'publish' );
+		$post_author  = absint( $input['post_author'] ?? 0 );
 		$post_excerpt = $input['post_excerpt'] ?? '';
 		$taxonomies   = $input['taxonomies'] ?? array();
 		$meta_input   = $input['meta_input'] ?? array();
@@ -345,6 +354,9 @@ class UpsertPostAbility {
 			$action          = 'updated';
 		} else {
 			$action = 'created';
+			if ( $post_author > 0 ) {
+				$post_data['post_author'] = $post_author;
+			}
 		}
 
 		// Merge caller-supplied meta_input.


### PR DESCRIPTION
## Summary

Adds `post_author` support to the `datamachine/upsert-post` ability.

## Why

The events extension (data-machine-events) delegates event creation to `datamachine/upsert-post` but needs to preserve the submitter attribution for user-submitted events. Without `post_author`, the extension would have to do a second `wp_update_post` call after every create, defeating the purpose of delegating to the generic primitive.

## Changes

- Input schema: added `post_author` (integer, optional)
- Chat tool params: added `post_author`
- Execute: reads `post_author`, applies only on create path (ignored on update, matching wp_insert_post semantics)

## Consumer

- Extra-Chill/data-machine-events#209