### PR TITLE
fix: prevent long auth tokens from breaking admin UI layout

### DIFF
--- a/inc/Core/Admin/Settings/assets/css/settings-page.css
+++ b/inc/Core/Admin/Settings/assets/css/settings-page.css
@@ -512,6 +512,7 @@
     border-radius: 4px;
     padding: 16px;
     background: #fff;
+    min-width: 0;
 }
 
 .datamachine-auth-card--connected {
@@ -573,6 +574,9 @@
     font-size: 13px;
     color: #50575e;
     margin-bottom: 8px;
+    word-break: break-all;
+    overflow-wrap: break-word;
+    max-width: 100%;
 }
 
 /* Card notice */


### PR DESCRIPTION
Adds word-break and overflow-wrap to .datamachine-auth-account so long access tokens wrap instead of stretching the card container. Also adds min-width: 0 to the card to prevent flex overflow issues.