### PR TITLE
cli: unify datamachine agent / agents — one noun, one class

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ users/{id}/
   USER.md                  — Information about the human
 ```
 
-Discovery: `wp datamachine agent paths --allow-root`
+Discovery: `wp datamachine memory paths --allow-root`
 
 ### Abilities API
 

--- a/docs/core-system/daily-memory-system.md
+++ b/docs/core-system/daily-memory-system.md
@@ -330,22 +330,22 @@ All endpoints require `manage_options` capability. The `PUT` endpoint accepts co
 
 ```bash
 # List all daily memory files
-wp datamachine agent daily list [--agent=<slug>] [--user=<id>] [--format=table|json]
+wp datamachine memory daily list [--agent=<slug>] [--user=<id>] [--format=table|json]
 
 # Read a daily file (defaults to today)
-wp datamachine agent daily read [YYYY-MM-DD] [--agent=<slug>]
+wp datamachine memory daily read [YYYY-MM-DD] [--agent=<slug>]
 
 # Write (replace) a daily file
-wp datamachine agent daily write [YYYY-MM-DD] <content> [--agent=<slug>]
+wp datamachine memory daily write [YYYY-MM-DD] <content> [--agent=<slug>]
 
 # Append to a daily file
-wp datamachine agent daily append [YYYY-MM-DD] <content> [--agent=<slug>]
+wp datamachine memory daily append [YYYY-MM-DD] <content> [--agent=<slug>]
 
 # Delete a daily file
-wp datamachine agent daily delete <YYYY-MM-DD> [--agent=<slug>]
+wp datamachine memory daily delete <YYYY-MM-DD> [--agent=<slug>]
 
 # Search across daily files
-wp datamachine agent daily search <query> [--from=YYYY-MM-DD] [--to=YYYY-MM-DD] [--agent=<slug>]
+wp datamachine memory daily search <query> [--from=YYYY-MM-DD] [--to=YYYY-MM-DD] [--agent=<slug>]
 ```
 
 All commands resolve agent scoping via `AgentResolver` (from `--agent` flag) with fallback to `--user`.

--- a/docs/core-system/ephemeral-workflows.md
+++ b/docs/core-system/ephemeral-workflows.md
@@ -18,7 +18,7 @@ When a direct execution workflow is triggered via the `/execute` REST endpoint, 
 - **AI Chatbot Execution**: When the Data Machine chat agent suggests a sequence of actions, it can trigger them immediately as a direct execution workflow.
 - **External Triggers**: Programmatically trigger a specific sequence of steps from an external script without cluttering the WordPress database with temporary pipelines.
 - **Testing**: Quickly test a new combination of handlers and prompts without going through the Pipeline Builder UI.
-- **CLI Tools**: Use the `wp datamachine agent` WP-CLI command to run the chat agent directly for debugging and validation.
+- **CLI Tools**: Use the `wp datamachine chat` WP-CLI command to run the chat agent directly for debugging and validation.
 
 ## Limitations
 

--- a/docs/core-system/wordpress-as-agent-memory.md
+++ b/docs/core-system/wordpress-as-agent-memory.md
@@ -56,7 +56,7 @@ The **CoreMemoryFilesDirective** loads all files from the **MemoryFileRegistry**
 - Editable through the WordPress admin Agent page
 - No serialization — plain markdown, human-readable, git-friendly
 - Core files created on activation with starter templates
-- Discover paths via `wp datamachine agent paths --allow-root`
+- Discover paths via `wp datamachine memory paths --allow-root`
 
 ### 2. Daily Memory — Temporal Knowledge
 
@@ -142,7 +142,7 @@ wp datamachine agents create --slug=my-agent --name="My Agent" --allow-root
 wp datamachine agents rename old-slug new-slug --allow-root
 
 # Discover file paths for an agent
-wp datamachine agent paths --agent=my-agent --allow-root
+wp datamachine memory paths --agent=my-agent --allow-root
 ```
 
 ## Core Memory Files
@@ -398,13 +398,13 @@ The canonical way to find agent memory file paths is via WP-CLI:
 
 ```bash
 # Discover all paths for the current agent
-wp datamachine agent paths --allow-root
+wp datamachine memory paths --allow-root
 
 # For a specific agent
-wp datamachine agent paths --agent=my-agent --allow-root
+wp datamachine memory paths --agent=my-agent --allow-root
 
 # Table format for readability
-wp datamachine agent paths --format=table --allow-root
+wp datamachine memory paths --format=table --allow-root
 ```
 
 Output structure:
@@ -456,24 +456,24 @@ This makes WordPress the single source of truth for agent memory, regardless of 
 
 ### Reading Memory via WP-CLI
 
-Agents with shell access can use the `agent` command for structured access:
+Agents with shell access can use the `memory` command for structured access:
 
 ```bash
 # Discover file paths (canonical command for external consumers)
-wp datamachine agent paths --allow-root
+wp datamachine memory paths --allow-root
 
 # Read memory file
-wp datamachine agent files read SOUL.md --allow-root
-wp datamachine agent files read MEMORY.md --allow-root
+wp datamachine memory files read SOUL.md --allow-root
+wp datamachine memory files read MEMORY.md --allow-root
 
 # List agent directory contents
-wp datamachine agent files list --allow-root
+wp datamachine memory files list --allow-root
 
 # Read daily memory
-wp datamachine agent daily read 2026-03-15 --allow-root
+wp datamachine memory daily read 2026-03-15 --allow-root
 
 # Search daily memory
-wp datamachine agent daily search "deployment" --allow-root
+wp datamachine memory daily search "deployment" --allow-root
 ```
 
 ### The Key Principle
@@ -634,16 +634,16 @@ All daily memory abilities accept `user_id` and `agent_id` for multi-agent scopi
 
 ```bash
 # Canonical discovery command — returns all layer paths and file locations
-wp datamachine agent paths --allow-root
+wp datamachine memory paths --allow-root
 
 # Resolve for a specific agent
-wp datamachine agent paths --agent=my-agent --allow-root
+wp datamachine memory paths --agent=my-agent --allow-root
 
 # Table format
-wp datamachine agent paths --format=table --allow-root
+wp datamachine memory paths --format=table --allow-root
 
 # Relative paths (useful for AGENTS.md generators)
-wp datamachine agent paths --relative --allow-root
+wp datamachine memory paths --relative --allow-root
 ```
 
 ### Agent Management
@@ -657,11 +657,11 @@ wp datamachine agents rename old-slug new-slug --allow-root
 ### Agent File Commands
 
 ```bash
-wp datamachine agent paths --allow-root
-wp datamachine agent files list --allow-root
-wp datamachine agent files read <file> --allow-root
-wp datamachine agent files write <file> --content="..." --allow-root
-wp datamachine agent files edit <file> --old="..." --new="..." --allow-root
+wp datamachine memory paths --allow-root
+wp datamachine memory files list --allow-root
+wp datamachine memory files read <file> --allow-root
+wp datamachine memory files write <file> --content="..." --allow-root
+wp datamachine memory files edit <file> --old="..." --new="..." --allow-root
 ```
 
 > **Note:** For workspace/git operations, install the `data-machine-code` extension and use `wp datamachine-code workspace`.

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -187,11 +187,12 @@ wp datamachine jobs undo 42 --task-type=alt_text --force
 
 ### datamachine agents
 
-Manage agent identities. **Since**: 0.37.0
+Manage agent identities. **Aliases**: `agent`. **Since**: 0.37.0
 
 ```bash
 # List all agents
 wp datamachine agents list
+wp datamachine agent list  # alias
 
 # Show agent details (config, access grants, directory info)
 wp datamachine agents show my-agent
@@ -211,44 +212,44 @@ wp datamachine agents access revoke my-agent 2
 wp datamachine agents access list my-agent
 ```
 
-### datamachine agent
+### datamachine memory
 
-Agent memory operations. **Alias**: `memory`. **Since**: 0.30.0
+Agent memory-file operations. **Since**: 0.30.0
 
 ```bash
 # Read full memory
-wp datamachine agent read
+wp datamachine memory read
 
 # Read a specific section
-wp datamachine agent read "## State"
+wp datamachine memory read "## State"
 
 # List sections
-wp datamachine agent sections
+wp datamachine memory sections
 
 # Write to a section
-wp datamachine agent write "## State" "Active and running"
-wp datamachine agent write "## State" "New note" --mode=append
+wp datamachine memory write "## State" "Active and running"
+wp datamachine memory write "## State" "New note" --mode=append
 
 # Search memory
-wp datamachine agent search "deployment" --section="## State"
+wp datamachine memory search "deployment" --section="## State"
 
 # Daily memory operations
-wp datamachine agent daily list
-wp datamachine agent daily read 2026-03-15
-wp datamachine agent daily write 2026-03-15 "Session notes"
-wp datamachine agent daily append 2026-03-15 "More notes"
-wp datamachine agent daily delete 2026-03-15
-wp datamachine agent daily search "keyword" --from=2026-03-01 --to=2026-03-15
+wp datamachine memory daily list
+wp datamachine memory daily read 2026-03-15
+wp datamachine memory daily write 2026-03-15 "Session notes"
+wp datamachine memory daily append 2026-03-15 "More notes"
+wp datamachine memory daily delete 2026-03-15
+wp datamachine memory daily search "keyword" --from=2026-03-01 --to=2026-03-15
 
 # Agent file management
-wp datamachine agent files list
-wp datamachine agent files read SOUL.md
-echo "content" | wp datamachine agent files write CUSTOM.md
-wp datamachine agent files check --days=7
+wp datamachine memory files list
+wp datamachine memory files read SOUL.md
+echo "content" | wp datamachine memory files write CUSTOM.md
+wp datamachine memory files check --days=7
 
 # Show resolved file paths for all memory layers
-wp datamachine agent paths
-wp datamachine agent paths --agent=my-agent --format=json
+wp datamachine memory paths
+wp datamachine memory paths --agent=my-agent --format=json
 ```
 
 
@@ -650,7 +651,8 @@ Most commands have singular and plural forms:
 - `wp datamachine step-type` / `wp datamachine step-types`
 - `wp datamachine processed-item` / `wp datamachine processed-items`
 - `wp datamachine setting` / `wp datamachine settings`
-- `wp datamachine agent` / `wp datamachine memory` (backwards-compatible alias)
+- `wp datamachine agent` / `wp datamachine agents` (agent management)
+- `wp datamachine memory` (agent memory-file operations)
 
 ## Examples
 
@@ -687,6 +689,6 @@ fi
 
 ```bash
 # Read current memory, update a section, verify
-wp datamachine agent read
-wp datamachine agent write "## Status" "All systems operational"
-wp datamachine agent search "operational"
+wp datamachine memory read
+wp datamachine memory write "## Status" "All systems operational"
+wp datamachine memory search "operational"

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -79,7 +79,7 @@ Pipelines can selectively inject daily memory via the **DailyMemorySelectorDirec
 ### Memory Path Discovery
 
 ```bash
-wp datamachine agent paths --allow-root
+wp datamachine memory paths --allow-root
 ```
 
 This canonical CLI command returns the full directory structure and file locations for any agent — the recommended way for external consumers to discover memory file paths.

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -24,10 +24,10 @@ WP_CLI::add_command( 'datamachine jobs', Commands\JobsCommand::class );
 WP_CLI::add_command( 'datamachine pipelines', Commands\PipelinesCommand::class );
 WP_CLI::add_command( 'datamachine posts', Commands\PostsCommand::class );
 WP_CLI::add_command( 'datamachine logs', Commands\LogsCommand::class );
-WP_CLI::add_command( 'datamachine agent', Commands\MemoryCommand::class );
+WP_CLI::add_command( 'datamachine agent', Commands\AgentsCommand::class );
 WP_CLI::add_command( 'datamachine agents', Commands\AgentsCommand::class );
 
-// Backwards-compatible alias: `wp datamachine memory` → agent.
+// Canonical home for agent memory-file operations.
 WP_CLI::add_command( 'datamachine memory', Commands\MemoryCommand::class );
 WP_CLI::add_command( 'datamachine batch', Commands\BatchCommand::class );
 WP_CLI::add_command( 'datamachine image', Commands\ImageCommand::class );

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -64,22 +64,22 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # Read full MEMORY.md (default)
-	 *     wp datamachine agent read
+	 *     wp datamachine memory read
 	 *
 	 *     # Read a specific section from MEMORY.md
-	 *     wp datamachine agent read "Fleet"
+	 *     wp datamachine memory read "Fleet"
 	 *
 	 *     # Read full SOUL.md
-	 *     wp datamachine agent read SOUL.md
+	 *     wp datamachine memory read SOUL.md
 	 *
 	 *     # Read a section from SOUL.md
-	 *     wp datamachine agent read SOUL.md "Identity"
+	 *     wp datamachine memory read SOUL.md "Identity"
 	 *
 	 *     # Read USER.md for a specific agent
-	 *     wp datamachine agent read USER.md --agent=studio
+	 *     wp datamachine memory read USER.md --agent=studio
 	 *
 	 *     # Read for a specific user
-	 *     wp datamachine agent read --user=2
+	 *     wp datamachine memory read --user=2
 	 *
 	 * @subcommand read
 	 */
@@ -134,16 +134,16 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # List MEMORY.md sections (default)
-	 *     wp datamachine agent sections
+	 *     wp datamachine memory sections
 	 *
 	 *     # List SOUL.md sections
-	 *     wp datamachine agent sections --file=SOUL.md
+	 *     wp datamachine memory sections --file=SOUL.md
 	 *
 	 *     # List USER.md sections as JSON
-	 *     wp datamachine agent sections --file=USER.md --format=json
+	 *     wp datamachine memory sections --file=USER.md --format=json
 	 *
 	 *     # List sections for a specific agent
-	 *     wp datamachine agent sections --agent=studio
+	 *     wp datamachine memory sections --agent=studio
 	 *
 	 * @subcommand sections
 	 */
@@ -228,28 +228,28 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # Replace a section in MEMORY.md (default)
-	 *     wp datamachine agent write "State" "- Data Machine v0.30.0 installed"
+	 *     wp datamachine memory write "State" "- Data Machine v0.30.0 installed"
 	 *
 	 *     # Append to a section in MEMORY.md
-	 *     wp datamachine agent write "Lessons Learned" "- Always check file permissions" --mode=append
+	 *     wp datamachine memory write "Lessons Learned" "- Always check file permissions" --mode=append
 	 *
 	 *     # Write to a section in SOUL.md
-	 *     wp datamachine agent write SOUL.md "Identity" "I am chubes-bot"
+	 *     wp datamachine memory write SOUL.md "Identity" "I am chubes-bot"
 	 *
 	 *     # Append to a section in USER.md
-	 *     wp datamachine agent write USER.md "Goals" "- Ship the feature" --mode=append
+	 *     wp datamachine memory write USER.md "Goals" "- Ship the feature" --mode=append
 	 *
 	 *     # Write to a specific agent's file
-	 *     wp datamachine agent write SOUL.md "Voice" "Concise and direct" --agent=studio
+	 *     wp datamachine memory write SOUL.md "Voice" "Concise and direct" --agent=studio
 	 *
 	 *     # Load content from a file on disk
-	 *     wp datamachine agent write "Session Notes" --from-file=/tmp/notes.md --mode=append
+	 *     wp datamachine memory write "Session Notes" --from-file=/tmp/notes.md --mode=append
 	 *
 	 *     # Pipe content via stdin
-	 *     echo "- New lesson" | wp datamachine agent write "Lessons Learned" - --mode=append
+	 *     echo "- New lesson" | wp datamachine memory write "Lessons Learned" - --mode=append
 	 *
 	 *     # Heredoc via stdin
-	 *     wp datamachine agent write SOUL.md "Identity" - <<'EOF'
+	 *     wp datamachine memory write SOUL.md "Identity" - <<'EOF'
 	 *     Multi-line content with `backticks` and $vars
 	 *     EOF
 	 *
@@ -277,7 +277,7 @@ class MemoryCommand extends BaseCommand {
 			$file_section = $this->parseFileAndSection( $args );
 
 			if ( null === $file_section['section'] ) {
-				WP_CLI::error( 'Usage: wp datamachine agent write [<file.md>] <section> --from-file=<path> [--mode=set|append]' );
+				WP_CLI::error( 'Usage: wp datamachine memory write [<file.md>] <section> --from-file=<path> [--mode=set|append]' );
 				return;
 			}
 
@@ -311,7 +311,7 @@ class MemoryCommand extends BaseCommand {
 			$file_section = $this->parseFileAndSection( $args );
 
 			if ( null === $file_section['section'] ) {
-				WP_CLI::error( 'Usage: wp datamachine agent write [<file.md>] <section> - [--mode=set|append]' );
+				WP_CLI::error( 'Usage: wp datamachine memory write [<file.md>] <section> - [--mode=set|append]' );
 				return;
 			}
 
@@ -329,7 +329,7 @@ class MemoryCommand extends BaseCommand {
 			$parsed = $this->parseFileSectionContent( $args );
 
 			if ( null === $parsed ) {
-				WP_CLI::error( 'Usage: wp datamachine agent write [<file.md>] <section> <content> [--mode=set|append]' );
+				WP_CLI::error( 'Usage: wp datamachine memory write [<file.md>] <section> <content> [--mode=set|append]' );
 				return;
 			}
 
@@ -395,16 +395,16 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # Search MEMORY.md (default)
-	 *     wp datamachine agent search "homeboy"
+	 *     wp datamachine memory search "homeboy"
 	 *
 	 *     # Search SOUL.md
-	 *     wp datamachine agent search "identity" --file=SOUL.md
+	 *     wp datamachine memory search "identity" --file=SOUL.md
 	 *
 	 *     # Search within a section
-	 *     wp datamachine agent search "docker" --section="Lessons Learned"
+	 *     wp datamachine memory search "docker" --section="Lessons Learned"
 	 *
 	 *     # Search a specific agent's file
-	 *     wp datamachine agent search "socials" --file=USER.md --agent=studio
+	 *     wp datamachine memory search "socials" --file=USER.md --agent=studio
 	 *
 	 * @subcommand search
 	 */
@@ -474,34 +474,34 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # List all daily memory files
-	 *     wp datamachine agent daily list
+	 *     wp datamachine memory daily list
 	 *
 	 *     # Read today's daily memory
-	 *     wp datamachine agent daily read
+	 *     wp datamachine memory daily read
 	 *
 	 *     # Read a specific date
-	 *     wp datamachine agent daily read 2026-02-24
+	 *     wp datamachine memory daily read 2026-02-24
 	 *
 	 *     # Write to today's daily memory (replaces content)
-	 *     wp datamachine agent daily write "## Session notes"
+	 *     wp datamachine memory daily write "## Session notes"
 	 *
 	 *     # Append to a specific date
-	 *     wp datamachine agent daily append 2026-02-24 "- Additional discovery"
+	 *     wp datamachine memory daily append 2026-02-24 "- Additional discovery"
 	 *
 	 *     # Delete a daily file
-	 *     wp datamachine agent daily delete 2026-02-24
+	 *     wp datamachine memory daily delete 2026-02-24
 	 *
 	 *     # Search daily memory
-	 *     wp datamachine agent daily search "homeboy"
+	 *     wp datamachine memory daily search "homeboy"
 	 *
 	 *     # Search with date range
-	 *     wp datamachine agent daily search "deploy" --from=2026-02-01 --to=2026-02-28
+	 *     wp datamachine memory daily search "deploy" --from=2026-02-01 --to=2026-02-28
 	 *
 	 * @subcommand daily
 	 */
 	public function daily( array $args, array $assoc_args ): void {
 		if ( empty( $args ) ) {
-			WP_CLI::error( 'Usage: wp datamachine agent daily <list|read|write|append|delete> [date] [content]' );
+			WP_CLI::error( 'Usage: wp datamachine memory daily <list|read|write|append|delete> [date] [content]' );
 			return;
 		}
 
@@ -527,7 +527,7 @@ class MemoryCommand extends BaseCommand {
 			case 'delete':
 				$date = $args[1] ?? null;
 				if ( ! $date ) {
-					WP_CLI::error( 'Date is required for delete. Usage: wp datamachine agent daily delete 2026-02-24' );
+					WP_CLI::error( 'Date is required for delete. Usage: wp datamachine memory daily delete 2026-02-24' );
 					return;
 				}
 				$this->daily_delete( $daily, $date );
@@ -535,7 +535,7 @@ class MemoryCommand extends BaseCommand {
 			case 'search':
 				$search_query = $args[1] ?? null;
 				if ( ! $search_query ) {
-					WP_CLI::error( 'Search query is required. Usage: wp datamachine agent daily search "query" [--from=...] [--to=...]' );
+					WP_CLI::error( 'Search query is required. Usage: wp datamachine memory daily search "query" [--from=...] [--to=...]' );
 					return;
 				}
 				$this->daily_search( $daily, $search_query, $assoc_args );
@@ -606,7 +606,7 @@ class MemoryCommand extends BaseCommand {
 	private function daily_write( DailyMemory $daily, array $args ): void {
 		// write [date] <content> — date defaults to today.
 		if ( count( $args ) < 2 ) {
-			WP_CLI::error( 'Content is required. Usage: wp datamachine agent daily write [date] <content>' );
+			WP_CLI::error( 'Content is required. Usage: wp datamachine memory daily write [date] <content>' );
 			return;
 		}
 
@@ -641,7 +641,7 @@ class MemoryCommand extends BaseCommand {
 	private function daily_append( DailyMemory $daily, array $args ): void {
 		// append [date] <content> — date defaults to today.
 		if ( count( $args ) < 2 ) {
-			WP_CLI::error( 'Content is required. Usage: wp datamachine agent daily append [date] <content>' );
+			WP_CLI::error( 'Content is required. Usage: wp datamachine memory daily append [date] <content>' );
 			return;
 		}
 
@@ -753,25 +753,25 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # List all agent files with timestamps and sizes
-	 *     wp datamachine agent files list
+	 *     wp datamachine memory files list
 	 *
 	 *     # List files for a specific agent
-	 *     wp datamachine agent files list --agent=studio
+	 *     wp datamachine memory files list --agent=studio
 	 *
 	 *     # Check for stale files (not updated in 7 days)
-	 *     wp datamachine agent files check
+	 *     wp datamachine memory files check
 	 *
 	 *     # Check with custom threshold
-	 *     wp datamachine agent files check --days=14
+	 *     wp datamachine memory files check --days=14
 	 *
 	 *     # Check a specific agent's files
-	 *     wp datamachine agent files check --agent=studio
+	 *     wp datamachine memory files check --agent=studio
 	 *
 	 * @subcommand files
 	 */
 	public function files( array $args, array $assoc_args ): void {
 		if ( empty( $args ) ) {
-			WP_CLI::error( 'Usage: wp datamachine agent files <list|check>' );
+			WP_CLI::error( 'Usage: wp datamachine memory files <list|check>' );
 			return;
 		}
 
@@ -1045,16 +1045,16 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # Regenerate all composable files
-	 *     wp datamachine agent compose
+	 *     wp datamachine memory compose
 	 *
 	 *     # Regenerate a specific file
-	 *     wp datamachine agent compose AGENTS.md
+	 *     wp datamachine memory compose AGENTS.md
 	 *
 	 *     # List registered sections for a file
-	 *     wp datamachine agent compose --list AGENTS.md
+	 *     wp datamachine memory compose --list AGENTS.md
 	 *
 	 *     # List all sections across all composable files
-	 *     wp datamachine agent compose --list
+	 *     wp datamachine memory compose --list
 	 *
 	 * @subcommand compose
 	 */
@@ -1217,16 +1217,16 @@ class MemoryCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # Get all resolved paths as JSON (for setup scripts)
-	 *     wp datamachine agent paths --format=json
+	 *     wp datamachine memory paths --format=json
 	 *
 	 *     # Get paths for a specific agent (multi-agent)
-	 *     wp datamachine agent paths --agent=chubes-bot
+	 *     wp datamachine memory paths --agent=chubes-bot
 	 *
 	 *     # Get relative paths for config file injection
-	 *     wp datamachine agent paths --relative
+	 *     wp datamachine memory paths --relative
 	 *
 	 *     # Table view for debugging
-	 *     wp datamachine agent paths --format=table
+	 *     wp datamachine memory paths --format=table
 	 *
 	 * @subcommand paths
 	 */

--- a/inc/Engine/AI/ComposableFileInvalidation.php
+++ b/inc/Engine/AI/ComposableFileInvalidation.php
@@ -8,7 +8,7 @@
  * removes SectionRegistry entries. Plugins whose sections read live state
  * register their own state-change hooks via the
  * `datamachine_composable_invalidation_hooks` filter so files stay in sync
- * without manual `wp datamachine agent compose` runs.
+ * without manual `wp datamachine memory compose` runs.
  *
  * Regeneration is debounced to one run per 60 seconds so frequent-fire hooks
  * (e.g. save_post) are safe to register.


### PR DESCRIPTION
Closes #1172.

## Summary

Realigns `datamachine agent` / `datamachine agents` with the project's singular/plural aliasing convention. Every other DM noun (flow/flows, pipeline/pipelines, post/posts, handler/handlers, job/jobs, block/blocks, step-type/step-types, processed-item/processed-items, setting/settings, log/logs, link/links) routes both forms to the same class. `agent` was the lone outlier, routing to `MemoryCommand` instead of the `AgentsCommand` that `agents` routes to.

## Change

One-line swap in `inc/Cli/Bootstrap.php`:

```diff
-WP_CLI::add_command( 'datamachine agent', Commands\MemoryCommand::class );
+WP_CLI::add_command( 'datamachine agent', Commands\AgentsCommand::class );
 WP_CLI::add_command( 'datamachine agents', Commands\AgentsCommand::class );

-// Backwards-compatible alias: `wp datamachine memory` → agent.
+// Canonical home for agent memory-file operations.
 WP_CLI::add_command( 'datamachine memory', Commands\MemoryCommand::class );
```

Post-fix command map:

| Command | Routes to |
|---|---|
| `wp datamachine agent <verb>` | `AgentsCommand` (new — aliased to plural) |
| `wp datamachine agents <verb>` | `AgentsCommand` (unchanged) |
| `wp datamachine memory <verb>` | `MemoryCommand` (unchanged — canonical home for memory ops) |

Users can now reflexively type `wp datamachine agent list`, `agent show`, `agent create` — matching the muscle memory from every other noun — and get the expected dispatch instead of `Error: 'list' is not a registered subcommand of 'datamachine agent'`.

## Breaking change

The singular memory-verb forms are gone:

```
wp datamachine agent read      → use wp datamachine memory read
wp datamachine agent write     → use wp datamachine memory write
wp datamachine agent search    → use wp datamachine memory search
wp datamachine agent paths     → use wp datamachine memory paths
wp datamachine agent sections  → use wp datamachine memory sections
wp datamachine agent compose   → use wp datamachine memory compose
wp datamachine agent daily ... → use wp datamachine memory daily ...
wp datamachine agent files ... → use wp datamachine memory files ...
```

Low blast radius per #1172's analysis: `wp datamachine memory <verb>` has been a registered alias for `MemoryCommand` since day one, so every caller has a stable replacement; the `agent` singular was never intuitive for memory ops (natural English is \"agent's memory\", not \"agent read\"); and external callers are small in number today.

## Docs swept

- `README.md` — discovery command updated
- `docs/overview.md` — discovery command updated
- `docs/core-system/wp-cli.md` — `agent` section renamed to `memory`, alias list updated, workflow example migrated
- `docs/core-system/wordpress-as-agent-memory.md` — all path-discovery and memory-access snippets migrated (17 refs)
- `docs/core-system/daily-memory-system.md` — daily-memory CLI section migrated (6 refs)
- `docs/core-system/ephemeral-workflows.md` — stale reference fixed (`agent` → `chat`)
- `inc/Cli/Commands/MemoryCommand.php` — all 52 docblock examples + `WP_CLI::error()` usage strings migrated
- `inc/Engine/AI/ComposableFileInvalidation.php` — comment updated

`docs/CHANGELOG.md` left untouched per repo convention (homeboy generates it at release time from git commits).

## Acceptance criteria

- [x] `wp datamachine agent list|create|show|delete|rename|access|config|export|import|token|cleanup-legacy-context-files` route to `AgentsCommand` (aliased to plural)
- [x] `wp datamachine agents ...` continues to work unchanged
- [x] `wp datamachine memory ...` continues to work unchanged and is the canonical home for memory-file ops
- [x] README + doc references to `wp datamachine agent <memory-verb>` updated to `wp datamachine memory <verb>`
- [x] CHANGELOG left alone (generated from commit messages)

Commit message covers the breaking rename + points to the replacement; that becomes the user-facing changelog entry on release.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** drafted the Bootstrap.php swap, swept doc references from `wp datamachine agent <memory-verb>` to `wp datamachine memory <verb>`, updated MemoryCommand docblocks/error strings. Chris filed the planning issue (#1172) and greenlit the hard-swap path; I executed the mechanical changes against that plan.