### PR TITLE
Add HMAC-SHA256 auth mode to WebhookTrigger

### DIFF
--- a/docs/api/endpoints/webhook-triggers.md
+++ b/docs/api/endpoints/webhook-triggers.md
@@ -1,0 +1,217 @@
+# Webhook Trigger Endpoint
+
+**Implementation**: `inc/Api/WebhookTrigger.php`, `inc/Api/WebhookSignatureVerifier.php`
+
+**Base URL**: `/wp-json/datamachine/v1/trigger/{flow_id}`
+
+**Since**: 0.30.0 (Bearer auth), 0.79.0 (HMAC-SHA256 auth)
+
+## Overview
+
+Public REST endpoint for triggering flows from external services — webhooks from
+GitHub, Stripe, Shopify, Slack, Linear, or any custom upstream. Complements the
+admin-only `/execute` endpoint and the mid-pipeline `WebhookGate` step.
+
+Authentication is per-flow and independent of WordPress capabilities. Each flow
+chooses between two auth modes:
+
+| Mode          | When to use                                            | Header                         |
+|---------------|--------------------------------------------------------|--------------------------------|
+| `bearer`      | Default. First-party callers you control.              | `Authorization: Bearer <token>` |
+| `hmac_sha256` | Third-party providers that sign the raw request body.  | Provider-specific (configurable) |
+
+Existing flows with no `webhook_auth_mode` value default to `bearer` — there is
+zero behavior change for anything shipped before 0.79.0.
+
+## Auth mode: `bearer`
+
+Generated with `wp datamachine flows webhook enable <flow_id>`. The flow gets a
+32-byte hex token. Callers present it in the `Authorization` header:
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/trigger/42 \
+  -H "Authorization: Bearer <64-char-hex-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"key": "value"}'
+```
+
+Token comparison is timing-safe via `hash_equals`. Token rotation is
+`wp datamachine flows webhook regenerate <flow_id>` — old tokens are
+invalidated immediately.
+
+## Auth mode: `hmac_sha256`
+
+Industry-standard webhook signature verification against the **raw request
+body**. Supported by GitHub, Stripe, Shopify, Slack, Linear, Mailgun, PayPal,
+SendGrid, Twilio, Plaid, and most major SaaS providers.
+
+### Flow
+
+1. Flow stores a shared `webhook_secret` (never exposed via status).
+2. Upstream signs the raw request body with that secret using HMAC-SHA256.
+3. Signature is sent in a provider-specific header.
+4. DM recomputes the signature with `hash_hmac('sha256', $raw_body, $secret)`
+   and compares via `hash_equals`.
+
+### Supported signature formats
+
+| `signature_format` | Encoding                          | Example provider      |
+|--------------------|-----------------------------------|-----------------------|
+| `sha256=hex`       | `sha256=` + lowercase hex (default) | GitHub                |
+| `hex`              | raw hex                           | Linear                |
+| `base64`           | base64-encoded raw digest         | Shopify               |
+
+### Payload size cap
+
+By default, HMAC flows reject bodies larger than 1 MB (`413 Payload Too Large`)
+before running HMAC, so unauthenticated clients cannot force the server to hash
+arbitrarily large payloads. Override with:
+
+```php
+scheduling_config['webhook_max_body_bytes'] = 2097152; // 2 MB
+```
+
+Set to `0` to disable the cap (not recommended).
+
+### What gets passed to the flow
+
+On successful authentication, the flow runs with this structure in
+`initial_data.webhook_trigger`:
+
+```json
+{
+  "payload":     { ... decoded JSON body ... },
+  "received_at": "2026-04-24T12:34:56Z",
+  "remote_ip":   "203.0.113.10",
+  "headers":     { "content-type": "...", "x-github-event": "...", ... },
+  "auth_mode":   "hmac_sha256"
+}
+```
+
+## GitHub webhook walkthrough (end-to-end)
+
+1. **Generate a secret and enable HMAC auth on the flow**:
+
+   ```bash
+   wp datamachine flows webhook enable 42 \
+     --auth-mode=hmac_sha256 \
+     --generate-secret
+   ```
+
+   Output:
+
+   ```
+   Success: Webhook trigger enabled for flow 42 (hmac_sha256).
+   URL:       https://example.com/wp-json/datamachine/v1/trigger/42
+   Auth mode: hmac_sha256
+   Header:    X-Hub-Signature-256
+   Format:    sha256=hex
+   Secret:    <64-char-hex>
+   Warning: Save this secret now — it will not be shown again.
+   ```
+
+2. **Copy the secret** into GitHub:
+   - Repo → Settings → Webhooks → Add webhook
+   - **Payload URL**: the `URL` printed above
+   - **Content type**: `application/json`
+   - **Secret**: paste the secret from step 1
+   - **Which events**: select the events you want (e.g. Pull requests)
+   - Save.
+
+3. **Test**: GitHub sends a ping event. The flow executes with the payload in
+   `initial_data.webhook_trigger.payload`.
+
+### Rotating the secret later
+
+```bash
+wp datamachine flows webhook set-secret 42 --generate
+```
+
+The old secret is invalidated immediately. Paste the new value into the
+provider UI.
+
+## Other providers
+
+The pattern is identical — only the default header and format differ.
+
+### Shopify (base64)
+
+```bash
+wp datamachine flows webhook enable 42 \
+  --auth-mode=hmac_sha256 \
+  --signature-header=X-Shopify-Hmac-Sha256 \
+  --signature-format=base64 \
+  --secret=<shopify_webhook_secret>
+```
+
+### Linear (hex)
+
+```bash
+wp datamachine flows webhook enable 42 \
+  --auth-mode=hmac_sha256 \
+  --signature-header=Linear-Signature \
+  --signature-format=hex \
+  --generate-secret
+```
+
+### Slack / Stripe
+
+Slack and Stripe use timestamp-prefixed signatures (`v0=...`, `t=...,v1=...`)
+that aren't directly representable by the three built-in formats. Support for
+these is tracked as a follow-up — see issue #1177.
+
+## Responses
+
+### 200 OK
+
+```json
+{
+  "success":   true,
+  "flow_id":   42,
+  "flow_name": "...",
+  "job_id":    123,
+  "message":   "Flow triggered successfully"
+}
+```
+
+### 401 Unauthorized
+
+Returned for **all** auth failures (missing/wrong Bearer token, missing/bad HMAC
+signature, flow not found, webhook not enabled) to prevent information leakage:
+
+```json
+{ "code": "unauthorized", "message": "Invalid or missing authorization.", "data": { "status": 401 } }
+```
+
+### 413 Payload Too Large
+
+Raw body exceeded `webhook_max_body_bytes` (HMAC mode only):
+
+```json
+{ "code": "payload_too_large", "message": "Payload too large.", "data": { "status": 413 } }
+```
+
+### 429 Too Many Requests
+
+Rate limit exceeded. See `wp datamachine flows webhook rate-limit`.
+
+## Security considerations
+
+- **Raw body is sacred.** HMAC verification uses `$request->get_body()` — the
+  exact bytes the sender signed. Any middleware that re-serializes JSON before
+  this endpoint will break verification.
+- **Constant-time comparison** via `hash_equals` in both auth modes.
+- **Generic 401 on failure** — the endpoint never distinguishes between
+  "no such flow", "wrong token", "bad signature", or "missing header".
+- **Secret storage** — the secret lives in the flow's `scheduling_config` JSON,
+  same column as `webhook_token`. Treat flow configs as secret-bearing.
+- **Replay protection** is out of scope for this endpoint. Providers like Slack
+  and Stripe include signed timestamps that could be validated with a replay
+  window — tracked as a follow-up.
+
+## Related
+
+- CLI: [`wp datamachine flows webhook`](../../core-system/wp-cli.md#datamachine-flows-webhook)
+- Abilities: `datamachine/webhook-trigger-enable`, `…-disable`, `…-regenerate`,
+  `…-set-secret`, `…-rate-limit`, `…-status`
+- Outbound counterpart: [Agent Ping tool](../../ai-tools/tools-overview.md)

--- a/docs/core-system/abilities-api.md
+++ b/docs/core-system/abilities-api.md
@@ -67,15 +67,16 @@ All abilities support `agent_id` and `user_id` parameters for multi-agent scopin
 | `datamachine/queue-move` | Reorder queue item | `Flow/QueueAbility.php` |
 | `datamachine/queue-settings` | Get/set queue settings | `Flow/QueueAbility.php` |
 
-### Webhook Triggers (5 abilities)
+### Webhook Triggers (6 abilities)
 
 | Ability | Description | Location |
 |---------|-------------|----------|
-| `datamachine/webhook-trigger-enable` | Enable webhook trigger for a flow and generate Bearer token | `Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-disable` | Disable webhook trigger, revoke token | `Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-regenerate` | Regenerate webhook token (old token immediately invalidated) | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-enable` | Enable webhook trigger for a flow. Supports `bearer` (default) or `hmac_sha256` auth modes. | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-disable` | Disable webhook trigger, revoke all auth material (token and HMAC secret) | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-regenerate` | Regenerate Bearer token (bearer auth mode only; old token immediately invalidated) | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-set-secret` | Set or rotate the HMAC shared secret; switches the flow to `hmac_sha256` mode | `Flow/WebhookTriggerAbility.php` |
 | `datamachine/webhook-trigger-rate-limit` | Set rate limiting for flow webhook trigger | `Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-status` | Get webhook trigger status for a flow | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-status` | Get webhook trigger status for a flow (auth mode, header, format — never the secret) | `Flow/WebhookTriggerAbility.php` |
 
 ### Job Execution (9 abilities)
 

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -107,27 +107,49 @@ wp datamachine flows queue validate 10 "AI agents" --post_type=post --threshold=
 
 ### datamachine flows webhook
 
-Manage webhook triggers. **Since**: 0.31.0
+Manage webhook triggers. Supports two auth modes: Bearer (default) and HMAC-SHA256. **Since**: 0.31.0 (Bearer), 0.79.0 (HMAC).
 
 ```bash
-# Enable webhook trigger (generates token and shows curl example)
+# Enable webhook trigger with default Bearer auth
 wp datamachine flows webhook enable 10
 
-# Check webhook status
+# Enable with HMAC-SHA256 auth (GitHub-style) and a generated secret
+wp datamachine flows webhook enable 10 --auth-mode=hmac_sha256 --generate-secret
+
+# Enable with HMAC for a non-GitHub provider (Shopify example)
+wp datamachine flows webhook enable 10 \
+  --auth-mode=hmac_sha256 \
+  --signature-header=X-Shopify-Hmac-Sha256 \
+  --signature-format=base64 \
+  --secret=<shopify_secret>
+
+# Set or rotate the HMAC secret (prints the new secret once)
+wp datamachine flows webhook set-secret 10 --generate
+wp datamachine flows webhook set-secret 10 --secret=<value>
+
+# Check webhook status (shows auth mode; never shows secret/token)
 wp datamachine flows webhook status 10
 
 # List all webhook-enabled flows
 wp datamachine flows webhook list
 
-# Regenerate token
+# Regenerate Bearer token (bearer mode only)
 wp datamachine flows webhook regenerate 10
 
 # Configure rate limiting
 wp datamachine flows webhook rate-limit 10 --max=10 --window=60
 
-# Disable webhook
+# Disable webhook (clears all auth material, both modes)
 wp datamachine flows webhook disable 10
 ```
+
+**Signature formats for HMAC mode** (`--signature-format`):
+- `sha256=hex` (default) — GitHub-style `sha256=<hex>` header values.
+- `hex` — raw hex digest (e.g. Linear).
+- `base64` — base64-encoded raw digest (e.g. Shopify).
+
+See [Webhook Triggers](../api/endpoints/webhook-triggers.md) for the full
+GitHub walkthrough and security notes.
 
 ### datamachine flows bulk-config
 

--- a/inc/Abilities/Flow/WebhookTriggerAbility.php
+++ b/inc/Abilities/Flow/WebhookTriggerAbility.php
@@ -42,30 +42,97 @@ class WebhookTriggerAbility {
 				'datamachine/webhook-trigger-enable',
 				array(
 					'label'               => __( 'Enable Webhook Trigger', 'data-machine' ),
-					'description'         => __( 'Enable webhook trigger for a flow and generate a Bearer token. External services can POST to the trigger URL to start flow executions.', 'data-machine' ),
+					'description'         => __( 'Enable webhook trigger for a flow. Supports Bearer token (default) or HMAC-SHA256 authentication. External services can POST to the trigger URL to start flow executions.', 'data-machine' ),
 					'category'            => 'datamachine-flow',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'flow_id' ),
 						'properties' => array(
-							'flow_id' => array(
+							'flow_id'          => array(
 								'type'        => 'integer',
 								'description' => __( 'Flow ID to enable webhook trigger for', 'data-machine' ),
+							),
+							'auth_mode'        => array(
+								'type'        => 'string',
+								'enum'        => array( 'bearer', 'hmac_sha256' ),
+								'description' => __( 'Authentication mode. Defaults to bearer for backward compatibility.', 'data-machine' ),
+							),
+							'signature_header' => array(
+								'type'        => 'string',
+								'description' => __( 'HMAC signature header name (e.g. X-Hub-Signature-256). Only used when auth_mode is hmac_sha256.', 'data-machine' ),
+							),
+							'signature_format' => array(
+								'type'        => 'string',
+								'enum'        => array( 'sha256=hex', 'hex', 'base64' ),
+								'description' => __( 'HMAC signature encoding. Only used when auth_mode is hmac_sha256.', 'data-machine' ),
+							),
+							'generate_secret'  => array(
+								'type'        => 'boolean',
+								'description' => __( 'When auth_mode is hmac_sha256, auto-generate a random 32-byte hex secret.', 'data-machine' ),
+							),
+							'secret'           => array(
+								'type'        => 'string',
+								'description' => __( 'When auth_mode is hmac_sha256, use this secret value (takes precedence over generate_secret).', 'data-machine' ),
 							),
 						),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'     => array( 'type' => 'boolean' ),
-							'flow_id'     => array( 'type' => 'integer' ),
-							'webhook_url' => array( 'type' => 'string' ),
-							'token'       => array( 'type' => 'string' ),
-							'message'     => array( 'type' => 'string' ),
-							'error'       => array( 'type' => 'string' ),
+							'success'          => array( 'type' => 'boolean' ),
+							'flow_id'          => array( 'type' => 'integer' ),
+							'webhook_url'      => array( 'type' => 'string' ),
+							'auth_mode'        => array( 'type' => 'string' ),
+							'token'            => array( 'type' => 'string' ),
+							'secret'           => array( 'type' => 'string' ),
+							'signature_header' => array( 'type' => 'string' ),
+							'signature_format' => array( 'type' => 'string' ),
+							'message'          => array( 'type' => 'string' ),
+							'error'            => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( $this, 'executeEnable' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/webhook-trigger-set-secret',
+				array(
+					'label'               => __( 'Set Webhook HMAC Secret', 'data-machine' ),
+					'description'         => __( 'Set or rotate the HMAC shared secret for a flow webhook. The secret is returned once and never retrievable via status.', 'data-machine' ),
+					'category'            => 'datamachine-flow',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'flow_id' ),
+						'properties' => array(
+							'flow_id'  => array(
+								'type'        => 'integer',
+								'description' => __( 'Flow ID to set the HMAC secret for', 'data-machine' ),
+							),
+							'secret'   => array(
+								'type'        => 'string',
+								'description' => __( 'Secret value provided by the upstream service (e.g. GitHub webhook secret).', 'data-machine' ),
+							),
+							'generate' => array(
+								'type'        => 'boolean',
+								'description' => __( 'Generate a random 32-byte hex secret and display it once.', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'   => array( 'type' => 'boolean' ),
+							'flow_id'   => array( 'type' => 'integer' ),
+							'secret'    => array( 'type' => 'string' ),
+							'auth_mode' => array( 'type' => 'string' ),
+							'message'   => array( 'type' => 'string' ),
+							'error'     => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'executeSetSecret' ),
 					'permission_callback' => array( $this, 'checkPermission' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
@@ -200,13 +267,17 @@ class WebhookTriggerAbility {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'         => array( 'type' => 'boolean' ),
-							'flow_id'         => array( 'type' => 'integer' ),
-							'flow_name'       => array( 'type' => 'string' ),
-							'webhook_enabled' => array( 'type' => 'boolean' ),
-							'webhook_url'     => array( 'type' => 'string' ),
-							'created_at'      => array( 'type' => 'string' ),
-							'error'           => array( 'type' => 'string' ),
+							'success'          => array( 'type' => 'boolean' ),
+							'flow_id'          => array( 'type' => 'integer' ),
+							'flow_name'        => array( 'type' => 'string' ),
+							'webhook_enabled'  => array( 'type' => 'boolean' ),
+							'webhook_url'      => array( 'type' => 'string' ),
+							'created_at'       => array( 'type' => 'string' ),
+							'auth_mode'        => array( 'type' => 'string' ),
+							'signature_header' => array( 'type' => 'string' ),
+							'signature_format' => array( 'type' => 'string' ),
+							'max_body_bytes'   => array( 'type' => 'integer' ),
+							'error'            => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( $this, 'executeStatus' ),
@@ -226,11 +297,15 @@ class WebhookTriggerAbility {
 	/**
 	 * Enable webhook trigger for a flow.
 	 *
-	 * Generates a new token and stores it in scheduling_config.
-	 * If already enabled, returns the existing token and URL.
+	 * Supports two auth modes:
+	 * - `bearer` (default): generates a 32-byte hex token.
+	 * - `hmac_sha256`:       stores a shared secret plus signature header/format.
 	 *
-	 * @param array $input Input with flow_id.
-	 * @return array Result with token and webhook URL.
+	 * If already enabled in the same mode, returns the existing config.
+	 * Switching modes requires disabling and re-enabling.
+	 *
+	 * @param array $input Input with flow_id and optional auth_mode / header / format / secret.
+	 * @return array Result with token or secret and webhook URL.
 	 */
 	public function executeEnable( array $input ): array {
 		$flow_id = (int) ( $input['flow_id'] ?? 0 );
@@ -252,23 +327,113 @@ class WebhookTriggerAbility {
 
 		$scheduling_config = $flow['scheduling_config'] ?? array();
 
-		// If already enabled with a valid token, return existing.
-		if ( ! empty( $scheduling_config['webhook_enabled'] ) && ! empty( $scheduling_config['webhook_token'] ) ) {
+		$requested_mode = isset( $input['auth_mode'] ) ? (string) $input['auth_mode'] : '';
+		if ( '' === $requested_mode ) {
+			$requested_mode = $scheduling_config['webhook_auth_mode'] ?? 'bearer';
+		}
+		if ( ! in_array( $requested_mode, array( 'bearer', 'hmac_sha256' ), true ) ) {
 			return array(
-				'success'     => true,
-				'flow_id'     => $flow_id,
-				'webhook_url' => self::get_webhook_url( $flow_id ),
-				'token'       => $scheduling_config['webhook_token'],
-				'message'     => 'Webhook trigger already enabled.',
+				'success' => false,
+				'error'   => sprintf( 'Unknown auth_mode "%s". Expected bearer or hmac_sha256.', $requested_mode ),
 			);
 		}
 
-		// Generate new token.
-		$token = self::generate_token();
+		// If already enabled in the same mode with valid auth material, return existing config.
+		$existing_mode = $scheduling_config['webhook_auth_mode'] ?? 'bearer';
+		if ( ! empty( $scheduling_config['webhook_enabled'] ) && $existing_mode === $requested_mode ) {
+			if ( 'bearer' === $requested_mode && ! empty( $scheduling_config['webhook_token'] ) ) {
+				return array(
+					'success'     => true,
+					'flow_id'     => $flow_id,
+					'webhook_url' => self::get_webhook_url( $flow_id ),
+					'auth_mode'   => 'bearer',
+					'token'       => $scheduling_config['webhook_token'],
+					'message'     => 'Webhook trigger already enabled.',
+				);
+			}
+			if ( 'hmac_sha256' === $requested_mode && ! empty( $scheduling_config['webhook_secret'] ) ) {
+				return array(
+					'success'          => true,
+					'flow_id'          => $flow_id,
+					'webhook_url'      => self::get_webhook_url( $flow_id ),
+					'auth_mode'        => 'hmac_sha256',
+					'signature_header' => $scheduling_config['webhook_signature_header'] ?? 'X-Hub-Signature-256',
+					'signature_format' => $scheduling_config['webhook_signature_format'] ?? 'sha256=hex',
+					'message'          => 'Webhook trigger already enabled.',
+				);
+			}
+		}
 
 		$scheduling_config['webhook_enabled']    = true;
-		$scheduling_config['webhook_token']      = $token;
-		$scheduling_config['webhook_created_at'] = gmdate( 'Y-m-d\TH:i:s\Z' );
+		$scheduling_config['webhook_auth_mode']  = $requested_mode;
+		$scheduling_config['webhook_created_at'] = $scheduling_config['webhook_created_at'] ?? gmdate( 'Y-m-d\TH:i:s\Z' );
+
+		$response = array(
+			'success'     => true,
+			'flow_id'     => $flow_id,
+			'webhook_url' => self::get_webhook_url( $flow_id ),
+			'auth_mode'   => $requested_mode,
+		);
+
+		if ( 'bearer' === $requested_mode ) {
+			if ( empty( $scheduling_config['webhook_token'] ) ) {
+				$scheduling_config['webhook_token'] = self::generate_token();
+			}
+			// Clear HMAC-specific fields when switching to bearer.
+			unset( $scheduling_config['webhook_secret'] );
+			unset( $scheduling_config['webhook_signature_header'] );
+			unset( $scheduling_config['webhook_signature_format'] );
+
+			$response['token']   = $scheduling_config['webhook_token'];
+			$response['message'] = sprintf( 'Webhook trigger enabled for flow %d (bearer).', $flow_id );
+		} else {
+			// HMAC mode — resolve secret from input (explicit > generate > existing).
+			$explicit_secret = isset( $input['secret'] ) ? (string) $input['secret'] : '';
+			$generate        = ! empty( $input['generate_secret'] );
+
+			if ( '' !== $explicit_secret ) {
+				$scheduling_config['webhook_secret'] = $explicit_secret;
+				$response['secret']                  = $explicit_secret;
+			} elseif ( $generate || empty( $scheduling_config['webhook_secret'] ) ) {
+				$new_secret                          = self::generate_secret();
+				$scheduling_config['webhook_secret'] = $new_secret;
+				$response['secret']                  = $new_secret;
+			}
+
+			if ( empty( $scheduling_config['webhook_secret'] ) ) {
+				return array(
+					'success' => false,
+					'error'   => 'HMAC auth_mode requires a secret. Pass --generate-secret or --secret=<value>.',
+				);
+			}
+
+			$header = isset( $input['signature_header'] ) ? trim( (string) $input['signature_header'] ) : '';
+			if ( '' !== $header ) {
+				$scheduling_config['webhook_signature_header'] = $header;
+			} elseif ( empty( $scheduling_config['webhook_signature_header'] ) ) {
+				$scheduling_config['webhook_signature_header'] = 'X-Hub-Signature-256';
+			}
+
+			$format = isset( $input['signature_format'] ) ? (string) $input['signature_format'] : '';
+			if ( '' !== $format ) {
+				if ( ! in_array( $format, \DataMachine\Api\WebhookSignatureVerifier::supported_formats(), true ) ) {
+					return array(
+						'success' => false,
+						'error'   => sprintf( 'Unsupported signature_format "%s".', $format ),
+					);
+				}
+				$scheduling_config['webhook_signature_format'] = $format;
+			} elseif ( empty( $scheduling_config['webhook_signature_format'] ) ) {
+				$scheduling_config['webhook_signature_format'] = 'sha256=hex';
+			}
+
+			// Clear Bearer-specific field when switching to HMAC.
+			unset( $scheduling_config['webhook_token'] );
+
+			$response['signature_header'] = $scheduling_config['webhook_signature_header'];
+			$response['signature_format'] = $scheduling_config['webhook_signature_format'];
+			$response['message']          = sprintf( 'Webhook trigger enabled for flow %d (hmac_sha256).', $flow_id );
+		}
 
 		$updated = $this->db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
 
@@ -283,15 +448,96 @@ class WebhookTriggerAbility {
 			'datamachine_log',
 			'info',
 			'Webhook trigger enabled for flow',
+			array(
+				'flow_id'   => $flow_id,
+				'auth_mode' => $requested_mode,
+			)
+		);
+
+		return $response;
+	}
+
+	/**
+	 * Set or rotate the HMAC shared secret for a flow.
+	 *
+	 * Accepts either an explicit `secret` value or `generate=true` to produce
+	 * a random 32-byte hex secret. The secret is returned once in the result
+	 * and never exposed via `executeStatus`.
+	 *
+	 * Also flips `webhook_auth_mode` to `hmac_sha256` if not already set, so
+	 * this command can be used as a one-liner for new HMAC flows.
+	 *
+	 * @param array $input Input with flow_id and either secret or generate=true.
+	 * @return array Result with the new secret on success.
+	 */
+	public function executeSetSecret( array $input ): array {
+		$flow_id = (int) ( $input['flow_id'] ?? 0 );
+
+		if ( $flow_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_id must be a positive integer',
+			);
+		}
+
+		$explicit_secret = isset( $input['secret'] ) ? (string) $input['secret'] : '';
+		$generate        = ! empty( $input['generate'] );
+
+		if ( '' === $explicit_secret && ! $generate ) {
+			return array(
+				'success' => false,
+				'error'   => 'Provide either secret=<value> or generate=true.',
+			);
+		}
+
+		$flow = $this->db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow %d not found', $flow_id ),
+			);
+		}
+
+		$scheduling_config = $flow['scheduling_config'] ?? array();
+
+		$secret = '' !== $explicit_secret ? $explicit_secret : self::generate_secret();
+
+		$scheduling_config['webhook_secret']     = $secret;
+		$scheduling_config['webhook_auth_mode']  = 'hmac_sha256';
+		$scheduling_config['webhook_enabled']    = true;
+		$scheduling_config['webhook_created_at'] = $scheduling_config['webhook_created_at'] ?? gmdate( 'Y-m-d\TH:i:s\Z' );
+
+		if ( empty( $scheduling_config['webhook_signature_header'] ) ) {
+			$scheduling_config['webhook_signature_header'] = 'X-Hub-Signature-256';
+		}
+		if ( empty( $scheduling_config['webhook_signature_format'] ) ) {
+			$scheduling_config['webhook_signature_format'] = 'sha256=hex';
+		}
+		// Clear Bearer-specific field when switching into HMAC mode.
+		unset( $scheduling_config['webhook_token'] );
+
+		$updated = $this->db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
+
+		if ( ! $updated ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to update flow scheduling config',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Webhook HMAC secret updated for flow',
 			array( 'flow_id' => $flow_id )
 		);
 
 		return array(
-			'success'     => true,
-			'flow_id'     => $flow_id,
-			'webhook_url' => self::get_webhook_url( $flow_id ),
-			'token'       => $token,
-			'message'     => sprintf( 'Webhook trigger enabled for flow %d.', $flow_id ),
+			'success'   => true,
+			'flow_id'   => $flow_id,
+			'secret'    => $secret,
+			'auth_mode' => 'hmac_sha256',
+			'message'   => sprintf( 'HMAC secret updated for flow %d. Old secret is invalidated.', $flow_id ),
 		);
 	}
 
@@ -326,6 +572,11 @@ class WebhookTriggerAbility {
 		unset( $scheduling_config['webhook_enabled'] );
 		unset( $scheduling_config['webhook_token'] );
 		unset( $scheduling_config['webhook_created_at'] );
+		unset( $scheduling_config['webhook_auth_mode'] );
+		unset( $scheduling_config['webhook_secret'] );
+		unset( $scheduling_config['webhook_signature_header'] );
+		unset( $scheduling_config['webhook_signature_format'] );
+		unset( $scheduling_config['webhook_max_body_bytes'] );
 
 		$updated = $this->db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
 
@@ -382,6 +633,14 @@ class WebhookTriggerAbility {
 			return array(
 				'success' => false,
 				'error'   => sprintf( 'Webhook trigger is not enabled for flow %d. Enable it first.', $flow_id ),
+			);
+		}
+
+		$auth_mode = $scheduling_config['webhook_auth_mode'] ?? 'bearer';
+		if ( 'bearer' !== $auth_mode ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'regenerate only applies to bearer auth_mode (flow %d is %s). Use set-secret for HMAC flows.', $flow_id, $auth_mode ),
 			);
 		}
 
@@ -553,8 +812,18 @@ class WebhookTriggerAbility {
 		);
 
 		if ( $enabled ) {
+			$auth_mode             = $scheduling_config['webhook_auth_mode'] ?? 'bearer';
 			$result['webhook_url'] = self::get_webhook_url( $flow_id );
 			$result['created_at']  = $scheduling_config['webhook_created_at'] ?? '';
+			$result['auth_mode']   = $auth_mode;
+
+			if ( 'hmac_sha256' === $auth_mode ) {
+				$result['signature_header'] = $scheduling_config['webhook_signature_header'] ?? 'X-Hub-Signature-256';
+				$result['signature_format'] = $scheduling_config['webhook_signature_format'] ?? 'sha256=hex';
+				$result['max_body_bytes']   = (int) ( $scheduling_config['webhook_max_body_bytes']
+					?? \DataMachine\Api\WebhookTrigger::DEFAULT_MAX_BODY_BYTES );
+				// NEVER include the secret.
+			}
 
 			$rate_config          = $scheduling_config['webhook_rate_limit'] ?? array();
 			$result['rate_limit'] = array(
@@ -572,6 +841,18 @@ class WebhookTriggerAbility {
 	 * @return string 64-character hex token.
 	 */
 	public static function generate_token(): string {
+		return bin2hex( random_bytes( 32 ) );
+	}
+
+	/**
+	 * Generate a cryptographically secure HMAC shared secret.
+	 *
+	 * Returned as a 64-character hex string so it can be safely pasted into
+	 * provider webhook configuration UIs (GitHub, Shopify, etc.).
+	 *
+	 * @return string 64-character hex secret.
+	 */
+	public static function generate_secret(): string {
 		return bin2hex( random_bytes( 32 ) );
 	}
 

--- a/inc/Api/WebhookSignatureVerifier.php
+++ b/inc/Api/WebhookSignatureVerifier.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Webhook Signature Verifier
+ *
+ * Shared HMAC-SHA256 signature verification helper for inbound webhooks.
+ * Kept deliberately small and static so future providers (Slack, Stripe)
+ * can plug in additional verification helpers without duplicating HMAC logic.
+ *
+ * @package DataMachine\Api
+ * @since 0.79.0
+ * @see https://github.com/Extra-Chill/data-machine/issues/1177
+ */
+
+namespace DataMachine\Api;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Static helper for verifying webhook signatures.
+ *
+ * Single responsibility: verify an HMAC-SHA256 signature against a raw
+ * request body using a shared secret. All comparisons are timing-safe
+ * via hash_equals().
+ */
+class WebhookSignatureVerifier {
+
+	/**
+	 * Supported signature formats.
+	 */
+	const FORMAT_PREFIXED_HEX = 'sha256=hex';
+	const FORMAT_HEX          = 'hex';
+	const FORMAT_BASE64       = 'base64';
+
+	/**
+	 * Verify an HMAC-SHA256 signature against a raw body.
+	 *
+	 * Formats:
+	 * - `sha256=hex` (default) — GitHub-style `sha256=<hex>` header value.
+	 * - `hex`                  — raw hex digest (e.g. Linear).
+	 * - `base64`               — base64-encoded raw digest (e.g. Shopify).
+	 *
+	 * Returns false for any malformed input instead of throwing, so callers
+	 * can treat all auth failures uniformly (generic 401).
+	 *
+	 * @param string $raw_body            Raw request body bytes (as signed by the sender).
+	 * @param string $provided_signature  Signature value from the request header.
+	 * @param string $secret              Shared HMAC secret.
+	 * @param string $format              Signature format: 'sha256=hex' | 'hex' | 'base64'.
+	 * @return bool True if the signature is valid, false otherwise.
+	 */
+	public static function verify_hmac_sha256(
+		string $raw_body,
+		string $provided_signature,
+		string $secret,
+		string $format = self::FORMAT_PREFIXED_HEX
+	): bool {
+		// Empty secret is a misconfiguration — never authenticate.
+		if ( '' === $secret ) {
+			return false;
+		}
+
+		if ( '' === $provided_signature ) {
+			return false;
+		}
+
+		$provided = trim( $provided_signature );
+
+		switch ( $format ) {
+			case self::FORMAT_PREFIXED_HEX:
+				if ( 0 !== strpos( $provided, 'sha256=' ) ) {
+					return false;
+				}
+				$provided = substr( $provided, 7 );
+				$expected = hash_hmac( 'sha256', $raw_body, $secret, false );
+				// Both are lowercase hex — enforce that to keep comparisons consistent.
+				if ( ! ctype_xdigit( $provided ) ) {
+					return false;
+				}
+				return hash_equals( $expected, strtolower( $provided ) );
+
+			case self::FORMAT_HEX:
+				if ( ! ctype_xdigit( $provided ) ) {
+					return false;
+				}
+				$expected = hash_hmac( 'sha256', $raw_body, $secret, false );
+				return hash_equals( $expected, strtolower( $provided ) );
+
+			case self::FORMAT_BASE64:
+				// Required for HMAC signature decoding (Shopify, others). Not user input obfuscation.
+				$decoded = base64_decode( $provided, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+				if ( false === $decoded ) {
+					return false;
+				}
+				$expected = hash_hmac( 'sha256', $raw_body, $secret, true );
+				return hash_equals( $expected, $decoded );
+
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * List of supported signature format identifiers.
+	 *
+	 * @return string[]
+	 */
+	public static function supported_formats(): array {
+		return array(
+			self::FORMAT_PREFIXED_HEX,
+			self::FORMAT_HEX,
+			self::FORMAT_BASE64,
+		);
+	}
+}

--- a/inc/Api/WebhookTrigger.php
+++ b/inc/Api/WebhookTrigger.php
@@ -66,13 +66,27 @@ class WebhookTrigger {
 	}
 
 	/**
+	 * Default maximum raw body size (1 MB).
+	 *
+	 * @var int
+	 */
+	const DEFAULT_MAX_BODY_BYTES = 1048576;
+
+	/**
 	 * Handle inbound webhook trigger.
 	 *
-	 * Authentication flow:
+	 * Authentication flow (Bearer, default):
 	 * 1. Extract Bearer token from Authorization header
 	 * 2. Load flow by ID
 	 * 3. Verify webhook_enabled in scheduling_config
 	 * 4. Constant-time token comparison via hash_equals()
+	 * 5. Delegate to execute-workflow ability
+	 *
+	 * Authentication flow (HMAC-SHA256, opt-in via `webhook_auth_mode`):
+	 * 1. Load flow by ID
+	 * 2. Verify webhook_enabled and a non-empty secret in scheduling_config
+	 * 3. Enforce optional max body size (413 on overflow)
+	 * 4. Verify signature header via WebhookSignatureVerifier::verify_hmac_sha256()
 	 * 5. Delegate to execute-workflow ability
 	 *
 	 * Returns generic 401 for all auth failures to prevent information leakage.
@@ -83,48 +97,7 @@ class WebhookTrigger {
 	public static function handle_trigger( \WP_REST_Request $request ) {
 		$flow_id = (int) $request->get_param( 'flow_id' );
 
-		// Extract Bearer token from Authorization header.
-		$auth_header = $request->get_header( 'authorization' );
-		$token       = self::extract_bearer_token( $auth_header );
-
-		if ( ! $token ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Webhook trigger: Missing or malformed Authorization header',
-				array(
-					'flow_id'   => $flow_id,
-					'remote_ip' => self::get_remote_ip( $request ),
-				)
-			);
-
-			return new \WP_Error(
-				'unauthorized',
-				'Invalid or missing authorization.',
-				array( 'status' => 401 )
-			);
-		}
-
-		// Validate token format before database lookup.
-		if ( ! preg_match( '/^[a-f0-9]{64}$/', $token ) ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Webhook trigger: Invalid token format',
-				array(
-					'flow_id'   => $flow_id,
-					'remote_ip' => self::get_remote_ip( $request ),
-				)
-			);
-
-			return new \WP_Error(
-				'unauthorized',
-				'Invalid or missing authorization.',
-				array( 'status' => 401 )
-			);
-		}
-
-		// Load flow and validate webhook configuration.
+		// Load flow first so auth-mode branching can read scheduling_config.
 		$db_flows = new Flows();
 		$flow     = $db_flows->get_flow( $flow_id );
 
@@ -149,9 +122,8 @@ class WebhookTrigger {
 
 		$scheduling_config = $flow['scheduling_config'] ?? array();
 		$webhook_enabled   = ! empty( $scheduling_config['webhook_enabled'] );
-		$stored_token      = $scheduling_config['webhook_token'] ?? '';
 
-		if ( ! $webhook_enabled || empty( $stored_token ) ) {
+		if ( ! $webhook_enabled ) {
 			do_action(
 				'datamachine_log',
 				'warning',
@@ -169,23 +141,16 @@ class WebhookTrigger {
 			);
 		}
 
-		// Constant-time token comparison to prevent timing attacks.
-		if ( ! hash_equals( $stored_token, $token ) ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Webhook trigger: Token mismatch',
-				array(
-					'flow_id'   => $flow_id,
-					'remote_ip' => self::get_remote_ip( $request ),
-				)
-			);
+		$auth_mode = self::resolve_auth_mode( $scheduling_config );
 
-			return new \WP_Error(
-				'unauthorized',
-				'Invalid or missing authorization.',
-				array( 'status' => 401 )
-			);
+		if ( 'hmac_sha256' === $auth_mode ) {
+			$auth_error = self::authenticate_hmac( $flow_id, $scheduling_config, $request );
+		} else {
+			$auth_error = self::authenticate_bearer( $flow_id, $scheduling_config, $request );
+		}
+
+		if ( $auth_error instanceof \WP_Error ) {
+			return $auth_error;
 		}
 
 		// Check rate limit before executing.
@@ -221,6 +186,17 @@ class WebhookTrigger {
 			$webhook_body = $request->get_body_params();
 		}
 		if ( empty( $webhook_body ) ) {
+			// Fall back to decoding the raw body — HMAC flows often arrive with
+			// non-standard content types that skip WP's automatic parsing.
+			$raw = $request->get_body();
+			if ( ! empty( $raw ) ) {
+				$decoded = json_decode( $raw, true );
+				if ( is_array( $decoded ) ) {
+					$webhook_body = $decoded;
+				}
+			}
+		}
+		if ( empty( $webhook_body ) ) {
 			$webhook_body = array();
 		}
 
@@ -233,6 +209,7 @@ class WebhookTrigger {
 					'received_at' => gmdate( 'Y-m-d\TH:i:s\Z' ),
 					'remote_ip'   => self::get_remote_ip( $request ),
 					'headers'     => self::get_safe_headers( $request ),
+					'auth_mode'   => $auth_mode,
 				),
 			),
 		);
@@ -319,6 +296,224 @@ class WebhookTrigger {
 	 * @var int
 	 */
 	const DEFAULT_RATE_LIMIT_WINDOW = 60;
+
+	/**
+	 * Resolve the effective webhook auth mode for a flow.
+	 *
+	 * Missing / unrecognized values default to `bearer` so existing flows
+	 * behave identically to before HMAC support was added.
+	 *
+	 * @param array $scheduling_config Flow scheduling config.
+	 * @return string Either 'bearer' or 'hmac_sha256'.
+	 */
+	private static function resolve_auth_mode( array $scheduling_config ): string {
+		$mode = $scheduling_config['webhook_auth_mode'] ?? 'bearer';
+		if ( 'hmac_sha256' === $mode ) {
+			return 'hmac_sha256';
+		}
+		return 'bearer';
+	}
+
+	/**
+	 * Authenticate a webhook request using a per-flow Bearer token.
+	 *
+	 * @param int              $flow_id          Flow ID.
+	 * @param array            $scheduling_config Flow scheduling config.
+	 * @param \WP_REST_Request $request          REST request object.
+	 * @return \WP_Error|null WP_Error on failure, null on success.
+	 */
+	private static function authenticate_bearer( int $flow_id, array $scheduling_config, \WP_REST_Request $request ): ?\WP_Error {
+		$auth_header = $request->get_header( 'authorization' );
+		$token       = self::extract_bearer_token( $auth_header );
+
+		if ( ! $token ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: Missing or malformed Authorization header',
+				array(
+					'flow_id'   => $flow_id,
+					'remote_ip' => self::get_remote_ip( $request ),
+				)
+			);
+
+			return new \WP_Error(
+				'unauthorized',
+				'Invalid or missing authorization.',
+				array( 'status' => 401 )
+			);
+		}
+
+		// Validate token format before database lookup.
+		if ( ! preg_match( '/^[a-f0-9]{64}$/', $token ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: Invalid token format',
+				array(
+					'flow_id'   => $flow_id,
+					'remote_ip' => self::get_remote_ip( $request ),
+				)
+			);
+
+			return new \WP_Error(
+				'unauthorized',
+				'Invalid or missing authorization.',
+				array( 'status' => 401 )
+			);
+		}
+
+		$stored_token = $scheduling_config['webhook_token'] ?? '';
+
+		if ( empty( $stored_token ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: Bearer token not configured for flow',
+				array(
+					'flow_id'   => $flow_id,
+					'remote_ip' => self::get_remote_ip( $request ),
+				)
+			);
+
+			return new \WP_Error(
+				'unauthorized',
+				'Invalid or missing authorization.',
+				array( 'status' => 401 )
+			);
+		}
+
+		// Constant-time token comparison to prevent timing attacks.
+		if ( ! hash_equals( $stored_token, $token ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: Token mismatch',
+				array(
+					'flow_id'   => $flow_id,
+					'remote_ip' => self::get_remote_ip( $request ),
+				)
+			);
+
+			return new \WP_Error(
+				'unauthorized',
+				'Invalid or missing authorization.',
+				array( 'status' => 401 )
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Authenticate a webhook request using HMAC-SHA256 signatures.
+	 *
+	 * Verifies the raw request body (`$request->get_body()`) against a
+	 * provider-specified signature header, using the shared secret stored
+	 * in `scheduling_config.webhook_secret`.
+	 *
+	 * @param int              $flow_id          Flow ID.
+	 * @param array            $scheduling_config Flow scheduling config.
+	 * @param \WP_REST_Request $request          REST request object.
+	 * @return \WP_Error|null WP_Error on failure, null on success.
+	 */
+	private static function authenticate_hmac( int $flow_id, array $scheduling_config, \WP_REST_Request $request ): ?\WP_Error {
+		$secret = $scheduling_config['webhook_secret'] ?? '';
+		if ( empty( $secret ) || ! is_string( $secret ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: HMAC secret not configured for flow',
+				array(
+					'flow_id'   => $flow_id,
+					'remote_ip' => self::get_remote_ip( $request ),
+				)
+			);
+
+			return new \WP_Error(
+				'unauthorized',
+				'Invalid or missing authorization.',
+				array( 'status' => 401 )
+			);
+		}
+
+		$signature_header = $scheduling_config['webhook_signature_header'] ?? 'X-Hub-Signature-256';
+		$signature_format = $scheduling_config['webhook_signature_format'] ?? WebhookSignatureVerifier::FORMAT_PREFIXED_HEX;
+
+		$provided = $request->get_header( $signature_header );
+		if ( empty( $provided ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: Missing HMAC signature header',
+				array(
+					'flow_id'          => $flow_id,
+					'remote_ip'        => self::get_remote_ip( $request ),
+					'signature_header' => $signature_header,
+				)
+			);
+
+			return new \WP_Error(
+				'unauthorized',
+				'Invalid or missing authorization.',
+				array( 'status' => 401 )
+			);
+		}
+
+		$raw_body = $request->get_body();
+
+		// Enforce an optional max body size before running HMAC — unauthenticated
+		// clients can otherwise force the server to hash arbitrarily large payloads.
+		$max_body_bytes = (int) ( $scheduling_config['webhook_max_body_bytes'] ?? self::DEFAULT_MAX_BODY_BYTES );
+		if ( $max_body_bytes > 0 && strlen( $raw_body ) > $max_body_bytes ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: Payload exceeds max_body_bytes',
+				array(
+					'flow_id'   => $flow_id,
+					'remote_ip' => self::get_remote_ip( $request ),
+					'size'      => strlen( $raw_body ),
+					'limit'     => $max_body_bytes,
+				)
+			);
+
+			return new \WP_Error(
+				'payload_too_large',
+				'Payload too large.',
+				array( 'status' => 413 )
+			);
+		}
+
+		$valid = WebhookSignatureVerifier::verify_hmac_sha256(
+			$raw_body,
+			$provided,
+			$secret,
+			$signature_format
+		);
+
+		if ( ! $valid ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Webhook trigger: HMAC signature mismatch',
+				array(
+					'flow_id'          => $flow_id,
+					'remote_ip'        => self::get_remote_ip( $request ),
+					'signature_header' => $signature_header,
+					'signature_format' => $signature_format,
+				)
+			);
+
+			return new \WP_Error(
+				'unauthorized',
+				'Invalid or missing authorization.',
+				array( 'status' => 401 )
+			);
+		}
+
+		return null;
+	}
 
 	/**
 	 * Check rate limit for a webhook trigger request.
@@ -445,6 +640,12 @@ class WebhookTrigger {
 			'x-hub-signature-256',
 			'x-webhook-id',
 			'x-request-id',
+			'x-shopify-topic',
+			'x-shopify-hmac-sha256',
+			'stripe-signature',
+			'linear-signature',
+			'x-slack-signature',
+			'x-slack-request-timestamp',
 		);
 
 		$headers = array();

--- a/inc/Cli/Commands/Flows/WebhookCommand.php
+++ b/inc/Cli/Commands/Flows/WebhookCommand.php
@@ -29,7 +29,7 @@ class WebhookCommand extends BaseCommand {
 	 */
 	public function dispatch( array $args, array $assoc_args ): void {
 		if ( empty( $args ) ) {
-			WP_CLI::error( 'Usage: wp datamachine flows webhook <enable|disable|regenerate|status|list|rate-limit> [flow_id]' );
+			WP_CLI::error( 'Usage: wp datamachine flows webhook <enable|disable|regenerate|set-secret|status|list|rate-limit> [flow_id]' );
 			return;
 		}
 
@@ -46,6 +46,10 @@ class WebhookCommand extends BaseCommand {
 			case 'regenerate':
 				$this->regenerate( $remaining, $assoc_args );
 				break;
+			case 'set-secret':
+			case 'set_secret':
+				$this->set_secret( $remaining, $assoc_args );
+				break;
 			case 'status':
 				$this->status( $remaining, $assoc_args );
 				break;
@@ -56,31 +60,73 @@ class WebhookCommand extends BaseCommand {
 				$this->rate_limit( $remaining, $assoc_args );
 				break;
 			default:
-				WP_CLI::error( "Unknown webhook action: {$action}. Use: enable, disable, regenerate, status, list, rate-limit" );
+				WP_CLI::error( "Unknown webhook action: {$action}. Use: enable, disable, regenerate, set-secret, status, list, rate-limit" );
 		}
 	}
 
 	/**
 	 * Enable webhook trigger for a flow.
 	 *
-	 * Generates a per-flow Bearer token and displays the webhook URL
-	 * with a curl example for testing.
+	 * Supports two authentication modes:
+	 * - `bearer` (default): per-flow Bearer token.
+	 * - `hmac_sha256`:      HMAC-SHA256 signature verification against the raw body.
 	 *
 	 * ## OPTIONS
 	 *
 	 * <flow_id>
 	 * : The flow ID to enable webhook trigger for.
 	 *
+	 * [--auth-mode=<mode>]
+	 * : Authentication mode.
+	 * ---
+	 * default: bearer
+	 * options:
+	 *   - bearer
+	 *   - hmac_sha256
+	 * ---
+	 *
+	 * [--signature-header=<header>]
+	 * : HMAC signature header name (e.g. X-Hub-Signature-256, Stripe-Signature, X-Shopify-Hmac-Sha256). Only used when --auth-mode=hmac_sha256.
+	 *
+	 * [--signature-format=<format>]
+	 * : HMAC signature encoding. Only used when --auth-mode=hmac_sha256.
+	 * ---
+	 * default: sha256=hex
+	 * options:
+	 *   - sha256=hex
+	 *   - hex
+	 *   - base64
+	 * ---
+	 *
+	 * [--generate-secret]
+	 * : Generate a random 32-byte hex secret for HMAC mode.
+	 *
+	 * [--secret=<value>]
+	 * : Use this explicit HMAC secret (e.g. the value you configured on the upstream service).
+	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Enable webhook trigger
+	 *     # Enable with default Bearer auth
 	 *     wp datamachine flows webhook enable 42
+	 *
+	 *     # Enable with HMAC-SHA256 auth and a generated secret (GitHub-style)
+	 *     wp datamachine flows webhook enable 42 --auth-mode=hmac_sha256 --generate-secret
+	 *
+	 *     # Enable with HMAC-SHA256 auth and an explicit secret
+	 *     wp datamachine flows webhook enable 42 --auth-mode=hmac_sha256 --secret=abc123...
+	 *
+	 *     # Enable with HMAC-SHA256 auth for Shopify (base64 header)
+	 *     wp datamachine flows webhook enable 42 \
+	 *       --auth-mode=hmac_sha256 \
+	 *       --signature-header=X-Shopify-Hmac-Sha256 \
+	 *       --signature-format=base64 \
+	 *       --secret=<shopify_secret>
 	 *
 	 * @subcommand enable
 	 */
 	public function enable( array $args, array $assoc_args ): void {
 		if ( empty( $args ) ) {
-			WP_CLI::error( 'Usage: wp datamachine flows webhook enable <flow_id>' );
+			WP_CLI::error( 'Usage: wp datamachine flows webhook enable <flow_id> [--auth-mode=<mode>] [--signature-header=<header>] [--signature-format=<format>] [--generate-secret] [--secret=<value>]' );
 			return;
 		}
 
@@ -90,23 +136,132 @@ class WebhookCommand extends BaseCommand {
 			return;
 		}
 
+		$input = array( 'flow_id' => $flow_id );
+
+		if ( isset( $assoc_args['auth-mode'] ) ) {
+			$input['auth_mode'] = (string) $assoc_args['auth-mode'];
+		}
+		if ( isset( $assoc_args['signature-header'] ) ) {
+			$input['signature_header'] = (string) $assoc_args['signature-header'];
+		}
+		if ( isset( $assoc_args['signature-format'] ) ) {
+			$input['signature_format'] = (string) $assoc_args['signature-format'];
+		}
+		if ( ! empty( $assoc_args['generate-secret'] ) ) {
+			$input['generate_secret'] = true;
+		}
+		if ( isset( $assoc_args['secret'] ) ) {
+			$input['secret'] = (string) $assoc_args['secret'];
+		}
+
 		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
-		$result  = $ability->executeEnable( array( 'flow_id' => $flow_id ) );
+		$result  = $ability->executeEnable( $input );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to enable webhook trigger' );
 			return;
 		}
 
+		$auth_mode = $result['auth_mode'] ?? 'bearer';
+
 		WP_CLI::success( $result['message'] );
-		WP_CLI::log( sprintf( 'URL:   %s', $result['webhook_url'] ) );
-		WP_CLI::log( sprintf( 'Token: %s', $result['token'] ) );
-		WP_CLI::log( '' );
-		WP_CLI::log( 'Usage:' );
-		WP_CLI::log( sprintf( '  curl -X POST %s \\', $result['webhook_url'] ) );
-		WP_CLI::log( sprintf( '    -H "Authorization: Bearer %s" \\', $result['token'] ) );
-		WP_CLI::log( '    -H "Content-Type: application/json" \\' );
-		WP_CLI::log( '    -d \'{"key": "value"}\'' );
+		WP_CLI::log( sprintf( 'URL:       %s', $result['webhook_url'] ) );
+		WP_CLI::log( sprintf( 'Auth mode: %s', $auth_mode ) );
+
+		if ( 'hmac_sha256' === $auth_mode ) {
+			WP_CLI::log( sprintf( 'Header:    %s', $result['signature_header'] ?? 'X-Hub-Signature-256' ) );
+			WP_CLI::log( sprintf( 'Format:    %s', $result['signature_format'] ?? 'sha256=hex' ) );
+
+			if ( isset( $result['secret'] ) ) {
+				WP_CLI::log( sprintf( 'Secret:    %s', $result['secret'] ) );
+				WP_CLI::warning( 'Save this secret now — it will not be shown again.' );
+				WP_CLI::log( '' );
+				WP_CLI::log( 'Paste this secret into your webhook provider (e.g. GitHub → Settings → Webhooks → Secret).' );
+			} else {
+				WP_CLI::log( 'Secret:    (unchanged — use `set-secret` to rotate)' );
+			}
+		} else {
+			WP_CLI::log( sprintf( 'Token:     %s', $result['token'] ) );
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Usage:' );
+			WP_CLI::log( sprintf( '  curl -X POST %s \\', $result['webhook_url'] ) );
+			WP_CLI::log( sprintf( '    -H "Authorization: Bearer %s" \\', $result['token'] ) );
+			WP_CLI::log( '    -H "Content-Type: application/json" \\' );
+			WP_CLI::log( '    -d \'{"key": "value"}\'' );
+		}
+	}
+
+	/**
+	 * Set or rotate the HMAC shared secret for a flow.
+	 *
+	 * Switches the flow to hmac_sha256 auth mode if it isn't already.
+	 * Provide exactly one of --secret or --generate.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <flow_id>
+	 * : The flow ID to set the secret for.
+	 *
+	 * [--secret=<value>]
+	 * : Explicit secret value (typically copied from the upstream provider UI).
+	 *
+	 * [--generate]
+	 * : Generate a random 32-byte hex secret and print it once.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Paste a secret from GitHub
+	 *     wp datamachine flows webhook set-secret 42 --secret=<value>
+	 *
+	 *     # Generate a fresh secret (you will paste it into the provider)
+	 *     wp datamachine flows webhook set-secret 42 --generate
+	 *
+	 * @subcommand set-secret
+	 */
+	public function set_secret( array $args, array $assoc_args ): void {
+		if ( empty( $args ) ) {
+			WP_CLI::error( 'Usage: wp datamachine flows webhook set-secret <flow_id> (--secret=<value> | --generate)' );
+			return;
+		}
+
+		$flow_id = (int) $args[0];
+		if ( $flow_id <= 0 ) {
+			WP_CLI::error( 'flow_id must be a positive integer' );
+			return;
+		}
+
+		$has_secret   = isset( $assoc_args['secret'] );
+		$has_generate = ! empty( $assoc_args['generate'] );
+
+		if ( ! $has_secret && ! $has_generate ) {
+			WP_CLI::error( 'Provide exactly one of --secret=<value> or --generate.' );
+			return;
+		}
+		if ( $has_secret && $has_generate ) {
+			WP_CLI::error( 'Pass either --secret=<value> or --generate, not both.' );
+			return;
+		}
+
+		$input = array( 'flow_id' => $flow_id );
+		if ( $has_secret ) {
+			$input['secret'] = (string) $assoc_args['secret'];
+		} else {
+			$input['generate'] = true;
+		}
+
+		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
+		$result  = $ability->executeSetSecret( $input );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to set webhook secret' );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] );
+		WP_CLI::log( sprintf( 'Flow:      %d', $flow_id ) );
+		WP_CLI::log( sprintf( 'Auth mode: %s', $result['auth_mode'] ?? 'hmac_sha256' ) );
+		WP_CLI::log( sprintf( 'Secret:    %s', $result['secret'] ) );
+		WP_CLI::warning( 'Save this secret now — it will not be shown again.' );
 	}
 
 	/**
@@ -247,12 +402,21 @@ class WebhookCommand extends BaseCommand {
 			return;
 		}
 
-		WP_CLI::log( sprintf( 'Flow:    %d — %s', $result['flow_id'], $result['flow_name'] ) );
-		WP_CLI::log( sprintf( 'Webhook: %s', $result['webhook_enabled'] ? 'enabled' : 'disabled' ) );
+		WP_CLI::log( sprintf( 'Flow:      %d — %s', $result['flow_id'], $result['flow_name'] ) );
+		WP_CLI::log( sprintf( 'Webhook:   %s', $result['webhook_enabled'] ? 'enabled' : 'disabled' ) );
 
 		if ( $result['webhook_enabled'] ) {
-			WP_CLI::log( sprintf( 'URL:     %s', $result['webhook_url'] ) );
-			WP_CLI::log( sprintf( 'Created: %s', $result['created_at'] ?? 'unknown' ) );
+			WP_CLI::log( sprintf( 'URL:       %s', $result['webhook_url'] ) );
+			WP_CLI::log( sprintf( 'Auth mode: %s', $result['auth_mode'] ?? 'bearer' ) );
+			WP_CLI::log( sprintf( 'Created:   %s', $result['created_at'] ?? 'unknown' ) );
+
+			if ( 'hmac_sha256' === ( $result['auth_mode'] ?? 'bearer' ) ) {
+				WP_CLI::log( sprintf( 'Header:    %s', $result['signature_header'] ?? 'X-Hub-Signature-256' ) );
+				WP_CLI::log( sprintf( 'Format:    %s', $result['signature_format'] ?? 'sha256=hex' ) );
+				if ( isset( $result['max_body_bytes'] ) ) {
+					WP_CLI::log( sprintf( 'Max body:  %d bytes', (int) $result['max_body_bytes'] ) );
+				}
+			}
 		}
 	}
 
@@ -296,6 +460,7 @@ class WebhookCommand extends BaseCommand {
 				$webhook_flows[] = array(
 					'flow_id'     => $flow['flow_id'],
 					'flow_name'   => $flow['flow_name'],
+					'auth_mode'   => $config['webhook_auth_mode'] ?? 'bearer',
 					'webhook_url' => \DataMachine\Abilities\Flow\WebhookTriggerAbility::get_webhook_url( (int) $flow['flow_id'] ),
 					'created_at'  => $config['webhook_created_at'] ?? '',
 				);
@@ -307,7 +472,7 @@ class WebhookCommand extends BaseCommand {
 			return;
 		}
 
-		$this->format_items( $webhook_flows, array( 'flow_id', 'flow_name', 'webhook_url', 'created_at' ), $assoc_args, 'flow_id' );
+		$this->format_items( $webhook_flows, array( 'flow_id', 'flow_name', 'auth_mode', 'webhook_url', 'created_at' ), $assoc_args, 'flow_id' );
 		WP_CLI::log( sprintf( 'Total: %d flow(s) with webhook triggers enabled.', count( $webhook_flows ) ) );
 	}
 

--- a/tests/Unit/Api/WebhookSignatureVerifierTest.php
+++ b/tests/Unit/Api/WebhookSignatureVerifierTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * WebhookSignatureVerifier tests.
+ *
+ * Pure unit tests — no WordPress bootstrap required. The verifier is a
+ * static helper that only depends on hash_hmac / hash_equals / base64_decode.
+ *
+ * @package DataMachine\Tests\Unit\Api
+ */
+
+namespace DataMachine\Tests\Unit\Api;
+
+use DataMachine\Api\WebhookSignatureVerifier;
+use PHPUnit\Framework\TestCase;
+
+class WebhookSignatureVerifierTest extends TestCase {
+
+	private const SECRET = 'super-secret-value';
+	private const BODY   = '{"action":"opened","number":1}';
+
+	public function test_valid_prefixed_hex_signature_is_accepted(): void {
+		$sig = 'sha256=' . hash_hmac( 'sha256', self::BODY, self::SECRET );
+
+		$this->assertTrue(
+			WebhookSignatureVerifier::verify_hmac_sha256( self::BODY, $sig, self::SECRET, 'sha256=hex' )
+		);
+	}
+
+	public function test_valid_hex_signature_is_accepted(): void {
+		$sig = hash_hmac( 'sha256', self::BODY, self::SECRET );
+
+		$this->assertTrue(
+			WebhookSignatureVerifier::verify_hmac_sha256( self::BODY, $sig, self::SECRET, 'hex' )
+		);
+	}
+
+	public function test_valid_base64_signature_is_accepted(): void {
+		$sig = base64_encode( hash_hmac( 'sha256', self::BODY, self::SECRET, true ) );
+
+		$this->assertTrue(
+			WebhookSignatureVerifier::verify_hmac_sha256( self::BODY, $sig, self::SECRET, 'base64' )
+		);
+	}
+
+	public function test_uppercase_hex_is_accepted(): void {
+		$sig = 'sha256=' . strtoupper( hash_hmac( 'sha256', self::BODY, self::SECRET ) );
+
+		$this->assertTrue(
+			WebhookSignatureVerifier::verify_hmac_sha256( self::BODY, $sig, self::SECRET, 'sha256=hex' )
+		);
+	}
+
+	public function test_invalid_signature_is_rejected(): void {
+		$this->assertFalse(
+			WebhookSignatureVerifier::verify_hmac_sha256(
+				self::BODY,
+				'sha256=' . str_repeat( 'a', 64 ),
+				self::SECRET,
+				'sha256=hex'
+			)
+		);
+	}
+
+	public function test_wrong_secret_is_rejected(): void {
+		$sig = 'sha256=' . hash_hmac( 'sha256', self::BODY, self::SECRET );
+
+		$this->assertFalse(
+			WebhookSignatureVerifier::verify_hmac_sha256( self::BODY, $sig, 'different-secret', 'sha256=hex' )
+		);
+	}
+
+	public function test_missing_sha256_prefix_is_rejected_for_prefixed_format(): void {
+		$sig = hash_hmac( 'sha256', self::BODY, self::SECRET );
+
+		$this->assertFalse(
+			WebhookSignatureVerifier::verify_hmac_sha256( self::BODY, $sig, self::SECRET, 'sha256=hex' )
+		);
+	}
+
+	public function test_format_mismatch_is_rejected(): void {
+		// Base64 signature but declare hex format.
+		$sig = base64_encode( hash_hmac( 'sha256', self::BODY, self::SECRET, true ) );
+
+		$this->assertFalse(
+			WebhookSignatureVerifier::verify_hmac_sha256( self::BODY, $sig, self::SECRET, 'hex' )
+		);
+	}
+
+	public function test_empty_secret_always_rejects(): void {
+		$sig = hash_hmac( 'sha256', self::BODY, '' );
+
+		$this->assertFalse(
+			WebhookSignatureVerifier::verify_hmac_sha256( self::BODY, $sig, '', 'hex' )
+		);
+	}
+
+	public function test_empty_signature_is_rejected(): void {
+		$this->assertFalse(
+			WebhookSignatureVerifier::verify_hmac_sha256( self::BODY, '', self::SECRET, 'sha256=hex' )
+		);
+	}
+
+	public function test_empty_body_is_handled(): void {
+		$sig = 'sha256=' . hash_hmac( 'sha256', '', self::SECRET );
+
+		$this->assertTrue(
+			WebhookSignatureVerifier::verify_hmac_sha256( '', $sig, self::SECRET, 'sha256=hex' )
+		);
+	}
+
+	public function test_body_tampering_is_rejected(): void {
+		$sig      = 'sha256=' . hash_hmac( 'sha256', self::BODY, self::SECRET );
+		$tampered = self::BODY . '{"extra":"data"}';
+
+		$this->assertFalse(
+			WebhookSignatureVerifier::verify_hmac_sha256( $tampered, $sig, self::SECRET, 'sha256=hex' )
+		);
+	}
+
+	public function test_unknown_format_is_rejected(): void {
+		$sig = hash_hmac( 'sha256', self::BODY, self::SECRET );
+
+		$this->assertFalse(
+			WebhookSignatureVerifier::verify_hmac_sha256( self::BODY, $sig, self::SECRET, 'ed25519' )
+		);
+	}
+
+	public function test_supported_formats_exposes_all_formats(): void {
+		$formats = WebhookSignatureVerifier::supported_formats();
+
+		$this->assertContains( 'sha256=hex', $formats );
+		$this->assertContains( 'hex', $formats );
+		$this->assertContains( 'base64', $formats );
+	}
+
+	public function test_uses_hash_equals_for_timing_safety(): void {
+		// Static inspection: the implementation must delegate to hash_equals.
+		// Reading the source is the most reliable check for a static helper.
+		$source = file_get_contents( __DIR__ . '/../../../inc/Api/WebhookSignatureVerifier.php' );
+		$this->assertStringContainsString( 'hash_equals(', $source );
+	}
+}

--- a/tests/Unit/Api/WebhookTriggerTest.php
+++ b/tests/Unit/Api/WebhookTriggerTest.php
@@ -1,0 +1,385 @@
+<?php
+/**
+ * WebhookTrigger + WebhookTriggerAbility tests.
+ *
+ * Covers both the Bearer regression path and the new HMAC-SHA256 auth mode,
+ * exercised end-to-end through `WebhookTrigger::handle_trigger()`.
+ *
+ * @package DataMachine\Tests\Unit\Api
+ */
+
+namespace DataMachine\Tests\Unit\Api;
+
+use DataMachine\Abilities\Flow\WebhookTriggerAbility;
+use DataMachine\Api\WebhookTrigger;
+use DataMachine\Core\Database\Flows\Flows;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
+class WebhookTriggerTest extends WP_UnitTestCase {
+
+	private int $pipeline_id;
+	private int $flow_id;
+	private WebhookTriggerAbility $webhook_ability;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$pipeline = wp_get_ability( 'datamachine/create-pipeline' )
+			->execute( array( 'pipeline_name' => 'WebhookTrigger test pipeline' ) );
+		$this->pipeline_id = (int) $pipeline['pipeline_id'];
+
+		$flow = wp_get_ability( 'datamachine/create-flow' )
+			->execute( array( 'pipeline_id' => $this->pipeline_id, 'flow_name' => 'WebhookTrigger test flow' ) );
+		$this->flow_id = (int) $flow['flow_id'];
+
+		$this->webhook_ability = new WebhookTriggerAbility();
+	}
+
+	public function tear_down(): void {
+		delete_transient( 'dm_webhook_rate_' . $this->flow_id );
+		parent::tear_down();
+	}
+
+	/* -----------------------------------------------------------------
+	 * Ability-level behavior
+	 * -----------------------------------------------------------------
+	 */
+
+	public function test_enable_defaults_to_bearer_mode(): void {
+		$result = $this->webhook_ability->executeEnable( array( 'flow_id' => $this->flow_id ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'bearer', $result['auth_mode'] );
+		$this->assertNotEmpty( $result['token'] );
+		$this->assertArrayNotHasKey( 'secret', $result );
+	}
+
+	public function test_enable_with_hmac_generates_secret(): void {
+		$result = $this->webhook_ability->executeEnable(
+			array(
+				'flow_id'         => $this->flow_id,
+				'auth_mode'       => 'hmac_sha256',
+				'generate_secret' => true,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'hmac_sha256', $result['auth_mode'] );
+		$this->assertNotEmpty( $result['secret'] );
+		$this->assertSame( 'X-Hub-Signature-256', $result['signature_header'] );
+		$this->assertSame( 'sha256=hex', $result['signature_format'] );
+	}
+
+	public function test_enable_with_hmac_accepts_explicit_secret_and_custom_header(): void {
+		$result = $this->webhook_ability->executeEnable(
+			array(
+				'flow_id'          => $this->flow_id,
+				'auth_mode'        => 'hmac_sha256',
+				'secret'           => 'explicit-shopify-secret',
+				'signature_header' => 'X-Shopify-Hmac-Sha256',
+				'signature_format' => 'base64',
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'explicit-shopify-secret', $result['secret'] );
+		$this->assertSame( 'X-Shopify-Hmac-Sha256', $result['signature_header'] );
+		$this->assertSame( 'base64', $result['signature_format'] );
+	}
+
+	public function test_status_never_returns_secret(): void {
+		$this->webhook_ability->executeEnable(
+			array(
+				'flow_id'         => $this->flow_id,
+				'auth_mode'       => 'hmac_sha256',
+				'generate_secret' => true,
+			)
+		);
+
+		$status = $this->webhook_ability->executeStatus( array( 'flow_id' => $this->flow_id ) );
+
+		$this->assertTrue( $status['success'] );
+		$this->assertTrue( $status['webhook_enabled'] );
+		$this->assertSame( 'hmac_sha256', $status['auth_mode'] );
+		$this->assertSame( 'X-Hub-Signature-256', $status['signature_header'] );
+		$this->assertSame( 'sha256=hex', $status['signature_format'] );
+		$this->assertArrayNotHasKey( 'secret', $status );
+		$this->assertArrayNotHasKey( 'webhook_secret', $status );
+	}
+
+	public function test_set_secret_rotates_and_switches_to_hmac(): void {
+		$this->webhook_ability->executeEnable( array( 'flow_id' => $this->flow_id ) ); // bearer
+
+		$result = $this->webhook_ability->executeSetSecret(
+			array(
+				'flow_id'  => $this->flow_id,
+				'generate' => true,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'hmac_sha256', $result['auth_mode'] );
+		$this->assertNotEmpty( $result['secret'] );
+
+		$status = $this->webhook_ability->executeStatus( array( 'flow_id' => $this->flow_id ) );
+		$this->assertSame( 'hmac_sha256', $status['auth_mode'] );
+	}
+
+	public function test_set_secret_requires_input(): void {
+		$result = $this->webhook_ability->executeSetSecret( array( 'flow_id' => $this->flow_id ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'secret', $result['error'] );
+	}
+
+	public function test_regenerate_rejects_hmac_mode(): void {
+		$this->webhook_ability->executeEnable(
+			array(
+				'flow_id'         => $this->flow_id,
+				'auth_mode'       => 'hmac_sha256',
+				'generate_secret' => true,
+			)
+		);
+
+		$result = $this->webhook_ability->executeRegenerate( array( 'flow_id' => $this->flow_id ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'bearer', $result['error'] );
+	}
+
+	public function test_disable_clears_hmac_fields(): void {
+		$this->webhook_ability->executeEnable(
+			array(
+				'flow_id'         => $this->flow_id,
+				'auth_mode'       => 'hmac_sha256',
+				'generate_secret' => true,
+			)
+		);
+
+		$this->webhook_ability->executeDisable( array( 'flow_id' => $this->flow_id ) );
+
+		$config = $this->get_scheduling_config();
+		$this->assertArrayNotHasKey( 'webhook_secret', $config );
+		$this->assertArrayNotHasKey( 'webhook_auth_mode', $config );
+		$this->assertArrayNotHasKey( 'webhook_signature_header', $config );
+	}
+
+	/* -----------------------------------------------------------------
+	 * handle_trigger() — Bearer regression path
+	 * -----------------------------------------------------------------
+	 */
+
+	public function test_bearer_flow_still_works(): void {
+		$result = $this->webhook_ability->executeEnable( array( 'flow_id' => $this->flow_id ) );
+		$token  = $result['token'];
+
+		$request = $this->make_request( array(), array( 'Authorization' => 'Bearer ' . $token ) );
+		$response = WebhookTrigger::handle_trigger( $request );
+
+		$this->assert_not_unauthorized( $response );
+	}
+
+	public function test_bearer_missing_token_returns_401(): void {
+		$this->webhook_ability->executeEnable( array( 'flow_id' => $this->flow_id ) );
+
+		$request  = $this->make_request();
+		$response = WebhookTrigger::handle_trigger( $request );
+
+		$this->assert_is_unauthorized( $response );
+	}
+
+	public function test_bearer_wrong_token_returns_401(): void {
+		$this->webhook_ability->executeEnable( array( 'flow_id' => $this->flow_id ) );
+
+		$request = $this->make_request(
+			array(),
+			array( 'Authorization' => 'Bearer ' . str_repeat( 'a', 64 ) )
+		);
+		$response = WebhookTrigger::handle_trigger( $request );
+
+		$this->assert_is_unauthorized( $response );
+	}
+
+	/* -----------------------------------------------------------------
+	 * handle_trigger() — HMAC-SHA256 path
+	 * -----------------------------------------------------------------
+	 */
+
+	public function test_hmac_valid_signature_passes(): void {
+		$enable = $this->webhook_ability->executeEnable(
+			array(
+				'flow_id'         => $this->flow_id,
+				'auth_mode'       => 'hmac_sha256',
+				'generate_secret' => true,
+			)
+		);
+		$secret = $enable['secret'];
+		$body   = '{"action":"opened","number":1}';
+		$sig    = 'sha256=' . hash_hmac( 'sha256', $body, $secret );
+
+		$request  = $this->make_request_raw( $body, array( 'X-Hub-Signature-256' => $sig ) );
+		$response = WebhookTrigger::handle_trigger( $request );
+
+		$this->assert_not_unauthorized( $response );
+	}
+
+	public function test_hmac_invalid_signature_returns_401(): void {
+		$this->webhook_ability->executeEnable(
+			array(
+				'flow_id'         => $this->flow_id,
+				'auth_mode'       => 'hmac_sha256',
+				'generate_secret' => true,
+			)
+		);
+
+		$body = '{"action":"opened"}';
+		$bad  = 'sha256=' . str_repeat( '0', 64 );
+
+		$request  = $this->make_request_raw( $body, array( 'X-Hub-Signature-256' => $bad ) );
+		$response = WebhookTrigger::handle_trigger( $request );
+
+		$this->assert_is_unauthorized( $response );
+	}
+
+	public function test_hmac_missing_signature_header_returns_401(): void {
+		$this->webhook_ability->executeEnable(
+			array(
+				'flow_id'         => $this->flow_id,
+				'auth_mode'       => 'hmac_sha256',
+				'generate_secret' => true,
+			)
+		);
+
+		$request  = $this->make_request_raw( '{"x":1}' );
+		$response = WebhookTrigger::handle_trigger( $request );
+
+		$this->assert_is_unauthorized( $response );
+	}
+
+	public function test_hmac_oversized_body_returns_413(): void {
+		$enable = $this->webhook_ability->executeEnable(
+			array(
+				'flow_id'         => $this->flow_id,
+				'auth_mode'       => 'hmac_sha256',
+				'generate_secret' => true,
+			)
+		);
+		$secret = $enable['secret'];
+
+		// Lower the max to something tiny.
+		$config                            = $this->get_scheduling_config();
+		$config['webhook_max_body_bytes']  = 16;
+		$this->update_scheduling_config( $config );
+
+		$body = str_repeat( 'a', 128 );
+		$sig  = 'sha256=' . hash_hmac( 'sha256', $body, $secret );
+
+		$request  = $this->make_request_raw( $body, array( 'X-Hub-Signature-256' => $sig ) );
+		$response = WebhookTrigger::handle_trigger( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'payload_too_large', $response->get_error_code() );
+		$this->assertSame( 413, $response->get_error_data()['status'] );
+	}
+
+	public function test_hmac_wrong_body_signature_rejected(): void {
+		$enable = $this->webhook_ability->executeEnable(
+			array(
+				'flow_id'         => $this->flow_id,
+				'auth_mode'       => 'hmac_sha256',
+				'generate_secret' => true,
+			)
+		);
+		$secret = $enable['secret'];
+
+		$signed_body = '{"a":1}';
+		$sent_body   = '{"a":2}'; // tampered
+		$sig         = 'sha256=' . hash_hmac( 'sha256', $signed_body, $secret );
+
+		$request  = $this->make_request_raw( $sent_body, array( 'X-Hub-Signature-256' => $sig ) );
+		$response = WebhookTrigger::handle_trigger( $request );
+
+		$this->assert_is_unauthorized( $response );
+	}
+
+	public function test_missing_auth_mode_defaults_to_bearer(): void {
+		// Manually enable webhook without setting webhook_auth_mode — mimics flows
+		// created before HMAC support landed.
+		$db     = new Flows();
+		$config = array(
+			'webhook_enabled'    => true,
+			'webhook_token'      => WebhookTriggerAbility::generate_token(),
+			'webhook_created_at' => gmdate( 'Y-m-d\TH:i:s\Z' ),
+		);
+		$db->update_flow( $this->flow_id, array( 'scheduling_config' => $config ) );
+
+		$request  = $this->make_request( array(), array( 'Authorization' => 'Bearer ' . $config['webhook_token'] ) );
+		$response = WebhookTrigger::handle_trigger( $request );
+
+		$this->assert_not_unauthorized( $response );
+	}
+
+	/* -----------------------------------------------------------------
+	 * Helpers
+	 * -----------------------------------------------------------------
+	 */
+
+	private function make_request( array $body = array(), array $headers = array() ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/datamachine/v1/trigger/' . $this->flow_id );
+		$request->set_url_params( array( 'flow_id' => $this->flow_id ) );
+		$request->set_param( 'flow_id', $this->flow_id );
+		$request->set_header( 'content-type', 'application/json' );
+		foreach ( $headers as $key => $value ) {
+			$request->set_header( $key, $value );
+		}
+		if ( ! empty( $body ) ) {
+			$json = wp_json_encode( $body );
+			$request->set_body( $json );
+		}
+		return $request;
+	}
+
+	private function make_request_raw( string $body, array $headers = array() ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/datamachine/v1/trigger/' . $this->flow_id );
+		$request->set_url_params( array( 'flow_id' => $this->flow_id ) );
+		$request->set_param( 'flow_id', $this->flow_id );
+		$request->set_header( 'content-type', 'application/json' );
+		foreach ( $headers as $key => $value ) {
+			$request->set_header( $key, $value );
+		}
+		$request->set_body( $body );
+		return $request;
+	}
+
+	private function get_scheduling_config(): array {
+		$db   = new Flows();
+		$flow = $db->get_flow( $this->flow_id );
+		return $flow['scheduling_config'] ?? array();
+	}
+
+	private function update_scheduling_config( array $config ): void {
+		$db = new Flows();
+		$db->update_flow( $this->flow_id, array( 'scheduling_config' => $config ) );
+	}
+
+	private function assert_is_unauthorized( $response ): void {
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 401, $response->get_error_data()['status'] );
+	}
+
+	private function assert_not_unauthorized( $response ): void {
+		if ( $response instanceof \WP_Error ) {
+			$this->assertNotSame(
+				401,
+				$response->get_error_data()['status'] ?? null,
+				'Expected request to authenticate, got: ' . $response->get_error_message()
+			);
+		} else {
+			$this->assertTrue( true ); // successful response
+		}
+	}
+}


### PR DESCRIPTION
Closes #1177.

## Summary

Adds an optional **HMAC-SHA256** auth mode to `inc/Api/WebhookTrigger.php` alongside the existing Bearer-token flow. HMAC is the industry-standard webhook auth protocol used by GitHub, Stripe, Shopify, Slack, Linear, Mailgun, Twilio, Plaid, SendGrid, and PayPal. Wiring it in natively means DM can accept these webhooks directly — no mu-plugin bridge, no relay service.

- **Bearer stays the default.** Missing / unknown `webhook_auth_mode` is treated as `bearer`, so every shipped flow is byte-for-byte unchanged.
- **HMAC is purely additive** — no changes to the engine, job queue, `datamachine_run_flow_now`, rate limiting, or the downstream `initial_data.webhook_trigger` payload shape.

## What's in the box

### New

- `inc/Api/WebhookSignatureVerifier.php` — static helper with timing-safe `verify_hmac_sha256()` supporting three formats: `sha256=hex` (GitHub), `hex` (Linear), `base64` (Shopify).
- `datamachine/webhook-trigger-set-secret` ability + `wp datamachine flows webhook set-secret` CLI subcommand.
- `docs/api/endpoints/webhook-triggers.md` — full GitHub walkthrough, Shopify/Linear examples, security notes.

### Changed

- `WebhookTrigger::handle_trigger()` branches on `scheduling_config.webhook_auth_mode`:
  - `bearer` → existing code path (unchanged).
  - `hmac_sha256` → read raw body via `$request->get_body()`, enforce `webhook_max_body_bytes` cap (default 1 MB → 413), verify signature via `WebhookSignatureVerifier`.
- `WebhookTriggerAbility`:
  - `executeEnable` accepts `auth_mode`, `signature_header`, `signature_format`, `generate_secret`, `secret`.
  - `executeSetSecret` generates or rotates the HMAC secret and flips the flow into `hmac_sha256` mode.
  - `executeStatus` returns `auth_mode` and HMAC header/format — **never the secret**.
  - `executeDisable` clears all HMAC-related fields.
  - `executeRegenerate` now refuses to run on HMAC flows (directs the caller to `set-secret`).
- `WebhookCommand` CLI:
  - `enable` gains `--auth-mode`, `--signature-header`, `--signature-format`, `--generate-secret`, `--secret` flags.
  - New `set-secret` subcommand (`--secret=<value>` or `--generate`).
  - `status` and `list` display the auth mode.
- Added common provider signature headers to the safe-headers logging list.

## Acceptance criteria

- [x] Flows can be enabled with `--auth-mode=hmac_sha256` via CLI
- [x] Signature verification accepts valid HMAC and rejects invalid HMAC
- [x] Missing signature header returns 401 when `auth_mode = hmac_sha256`
- [x] Existing Bearer flows are unaffected (regression test `test_bearer_flow_still_works` + `test_missing_auth_mode_defaults_to_bearer`)
- [x] `status` shows auth mode + HMAC header/format, never the secret
- [x] `max_body_bytes` cap (default 1 MB) returns 413 on overflow for HMAC flows
- [x] Docs include a copy-pasteable GitHub webhook setup
- [x] All tests green, lint clean for new/modified files

## Tests

- **`tests/Unit/Api/WebhookSignatureVerifierTest.php`** — 15 pure unit tests: valid / invalid per format, empty secret, empty body, empty signature, wrong secret, tampered body, missing `sha256=` prefix, format mismatch, uppercase hex, unknown format, `hash_equals` usage.
- **`tests/Unit/Api/WebhookTriggerTest.php`** — 17 `WP_UnitTestCase` tests: Bearer regression (3 cases), HMAC valid/invalid/missing/oversized/tampered (5 cases), ability-level behavior (enable modes, set-secret, regenerate refusal, disable clearing), and `missing_auth_mode_defaults_to_bearer`.

All 32 new tests green:

```
homeboy test data-machine -- --filter='Webhook'
OK (40 tests, 82 assertions)
```

Full-suite run is clean relative to baseline — only the 37 pre-existing failures from `NetworkSettingsTest`, `ImportExportStepConfigTest`, etc. remain. No new regressions introduced.

Lint of modified / new files is clean; the only phpstan finding attributable to `WebhookTriggerAbility` comes from the shared `FlowHelpers` trait and pre-dates this PR (it affects every class that uses the trait).

## Out of scope (per #1177)

- Ed25519 (Discord) — different primitive, separate follow-up.
- Slack / Stripe timestamp-prefixed signatures (`v0=...`, `t=...,v1=...`) — can extend `webhook_signature_format` later.
- Replay protection / timestamp windows.
- Moving secrets out of `scheduling_config` into a dedicated credentials table.

## Verification

```bash
cd /var/lib/datamachine/workspace/data-machine@webhook-trigger-step
homeboy lint data-machine --changed-only --summary   # clean for our files
homeboy test data-machine -- --filter='Webhook'      # 40/40 pass
homeboy test data-machine                            # no new failures vs. baseline
```