### PR TITLE
cleanup(pipelines): remove legacy provider/model fields from AI step config

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -615,6 +615,9 @@ function datamachine_activate_for_site() {
 	// Migrate `update` step type to `upsert` in pipeline/flow configs (idempotent).
 	datamachine_migrate_update_to_upsert_step_type();
 
+	// Strip dead `provider`/`model` keys from pipeline_config rows (data-machine#1180, idempotent).
+	datamachine_strip_pipeline_step_provider_model();
+
 	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
 	datamachine_drop_redundant_post_pipeline_meta();
 

--- a/inc/Api/Pipelines/PipelineSteps.php
+++ b/inc/Api/Pipelines/PipelineSteps.php
@@ -177,18 +177,11 @@ class PipelineSteps {
 				'sanitize_callback' => 'absint',
 				'description'       => __( 'Pipeline ID for context', 'data-machine' ),
 			),
-			'provider'         => array(
-				'required'          => false,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-				'description'       => __( 'AI provider slug', 'data-machine' ),
-			),
-			'model'            => array(
-				'required'          => false,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-				'description'       => __( 'AI model identifier', 'data-machine' ),
-			),
+			// Note: `provider` and `model` were previously accepted here but have
+			// never influenced execution — AIStep resolves model/provider exclusively
+			// from the mode system (PluginSettings::resolveModelForAgentMode()).
+			// They were removed to stop the REST schema from advertising dead fields.
+			// See: inc/Core/Steps/AI/AIStep.php
 			'ai_api_key'       => array(
 				'required'          => false,
 				'type'              => 'string',
@@ -492,8 +485,8 @@ class PipelineSteps {
 		$existing_config = $pipeline_config[ $pipeline_step_id ] ?? array();
 
 		// Build step configuration data for AI steps.
-		// Note: provider/model are NOT configurable at the pipeline step level.
-		// Model resolution is handled by the mode system (mode_models setting).
+		// Model/provider are resolved exclusively via the mode system
+		// (PluginSettings::resolveModelForAgentMode). They are not accepted here.
 		$step_config_data = array();
 		$api_key_saved    = false;
 
@@ -538,7 +531,7 @@ class PipelineSteps {
 			}
 		}
 
-		// Preserve provider-specific models by merging with existing config
+		// Preserve provider-specific models by merging with existing config.
 		if ( ! empty( $existing_config ) ) {
 			if ( isset( $existing_config['providers'] ) && isset( $step_config_data['providers'] ) ) {
 				$step_config_data['providers'] = array_merge(
@@ -548,6 +541,11 @@ class PipelineSteps {
 			} elseif ( isset( $existing_config['providers'] ) && ! isset( $step_config_data['providers'] ) ) {
 				$step_config_data['providers'] = $existing_config['providers'];
 			}
+
+			// Strip dead `provider` and `model` keys from any existing row on write.
+			// These were never read by AIStep (mode system is the authority) but older
+			// UI + REST versions persisted them. Remove so inspection matches execution.
+			unset( $existing_config['provider'], $existing_config['model'] );
 
 			$pipeline_config[ $pipeline_step_id ] = array_merge( $existing_config, $step_config_data );
 		} else {
@@ -570,8 +568,6 @@ class PipelineSteps {
 			);
 		}
 
-		$provider_for_log = $step_config_data['provider'] ?? ( $existing_config['provider'] ?? null );
-
 		return rest_ensure_response(
 			array(
 				'success' => true,
@@ -580,7 +576,6 @@ class PipelineSteps {
 					'debug_info'       => array(
 						'api_key_saved'     => $api_key_saved,
 						'step_config_saved' => true,
-						'provider'          => $provider_for_log,
 					),
 				),
 				'message' => __( 'AI step configuration saved successfully', 'data-machine' ),

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -30,7 +30,8 @@ import { useStepTypes } from '../../queries/config';
  * @param {string}   props.flowStepId     - Flow step ID.
  * @param {Object}   props.flowStepConfig - Flow step configuration.
  * @param {Object}   props.pipelineStep   - Pipeline step data.
- * @param {Object}   props.pipelineConfig - Pipeline AI configuration.
+ * @param {Object}   props.pipelineConfig - Pipeline AI configuration (currently unused; retained
+ *                                          for API stability while callers still pass it).
  * @param {Function} props.onConfigure    - Configure handler callback.
  * @param {Function} props.onQueueClick   - Queue button click handler (opens modal).
  * @return {JSX.Element} Flow step card.
@@ -49,9 +50,6 @@ export default function FlowStepCard( {
 	const stepTypeInfo = stepTypes[ pipelineStep.step_type ] || {};
 
 	const isAiStep = pipelineStep.step_type === 'ai';
-	const aiConfig = isAiStep
-		? pipelineConfig[ pipelineStep.pipeline_step_id ]
-		: null;
 
 	const promptQueue = flowStepConfig.prompt_queue || [];
 	const queueEnabled = !! flowStepConfig.queue_enabled;
@@ -161,22 +159,10 @@ export default function FlowStepCard( {
 						</strong>
 					</div>
 
-					{ /* AI Provider/Model Display */ }
-					{ isAiStep && aiConfig && (
-						<div className="datamachine-ai-config-display">
-							<div className="datamachine-ai-provider-info">
-								<strong>
-									{ __( 'AI Provider:', 'data-machine' ) }
-								</strong>{ ' ' }
-								{ aiConfig.provider || 'Not configured' }
-								{ ' | ' }
-								<strong>
-									{ __( 'Model:', 'data-machine' ) }
-								</strong>{ ' ' }
-								{ aiConfig.model || 'Not configured' }
-							</div>
-						</div>
-					) }
+					{ /* AI provider/model are not shown on the step card:
+					   they are resolved server-side via the mode system
+					   (PluginSettings::resolveModelForAgentMode), not from
+					   per-step config. See data-machine#1180. */ }
 
 					{ /* Inline Config Fields — flow step settings for non-handler step types only.
 					   Handler-based steps show their settings in the configuration modal,

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js
@@ -230,14 +230,11 @@ export const useAddPipelineStep = () => {
 						if ( ! isSameId( pipeline.pipeline_id, pipelineId ) ) {
 							return pipeline;
 						}
-						// Build config entry for AI steps
+						// Build config entry for AI steps.
+						// Note: provider/model are resolved via the mode system
+						// (PluginSettings::resolveModelForAgentMode on the server).
+						// They are not carried on the pipeline step config.
 						const configEntry = {};
-						if ( stepData.provider ) {
-							configEntry.provider = stepData.provider;
-						}
-						if ( stepData.model ) {
-							configEntry.model = stepData.model;
-						}
 						if ( stepData.disabled_tools ) {
 							configEntry.disabled_tools =
 								stepData.disabled_tools;

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -22,3 +22,4 @@ require_once __DIR__ . '/network-scope.php';
 require_once __DIR__ . '/flows.php';
 require_once __DIR__ . '/post-pipeline-meta.php';
 require_once __DIR__ . '/update-to-upsert.php';
+require_once __DIR__ . '/strip-pipeline-step-provider-model.php';

--- a/inc/migrations/strip-pipeline-step-provider-model.php
+++ b/inc/migrations/strip-pipeline-step-provider-model.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Data Machine — Strip dead `provider`/`model` keys from pipeline_config.
+ *
+ * Older REST + UI versions persisted `provider` and `model` on each AI step
+ * inside pipeline_config. AIStep never read them — model/provider are resolved
+ * exclusively through the mode system (PluginSettings::resolveModelForAgentMode).
+ *
+ * The surface (REST schema, React cache, FlowStepCard display) has been
+ * removed, but existing pipelines still carry the stale keys and will keep
+ * showing them in `GET /pipelines` responses and CLI inspections until
+ * scrubbed. This one-shot migration removes them so inspection matches
+ * execution.
+ *
+ * See: https://github.com/Extra-Chill/data-machine/issues/1180
+ *
+ * @package DataMachine
+ * @since 0.71.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Strip `provider` and `model` keys from every step entry in every
+ * pipeline_config row. Idempotent: guarded by the
+ * `datamachine_pipeline_step_provider_model_stripped` option.
+ *
+ * @since 0.71.0
+ */
+function datamachine_strip_pipeline_step_provider_model(): void {
+	if ( get_option( 'datamachine_pipeline_step_provider_model_stripped', false ) ) {
+		return;
+	}
+
+	global $wpdb;
+	$pipelines_table = $wpdb->prefix . 'datamachine_pipelines';
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL
+	$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $pipelines_table ) );
+	if ( ! $table_exists ) {
+		update_option( 'datamachine_pipeline_step_provider_model_stripped', true, true );
+		return;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL
+	$rows = $wpdb->get_results( "SELECT pipeline_id, pipeline_config FROM {$pipelines_table}", ARRAY_A );
+
+	$migrated = 0;
+
+	if ( ! empty( $rows ) ) {
+		foreach ( $rows as $row ) {
+			$config = json_decode( $row['pipeline_config'] ?? '', true );
+			if ( ! is_array( $config ) ) {
+				continue;
+			}
+
+			$changed = false;
+
+			foreach ( $config as $step_id => &$step ) {
+				if ( ! is_array( $step ) ) {
+					continue;
+				}
+				if ( array_key_exists( 'provider', $step ) || array_key_exists( 'model', $step ) ) {
+					unset( $step['provider'], $step['model'] );
+					$changed = true;
+				}
+			}
+			unset( $step );
+
+			if ( $changed ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->update(
+					$pipelines_table,
+					array( 'pipeline_config' => wp_json_encode( $config ) ),
+					array( 'pipeline_id' => $row['pipeline_id'] ),
+					array( '%s' ),
+					array( '%d' )
+				);
+				++$migrated;
+			}
+		}
+	}
+
+	update_option( 'datamachine_pipeline_step_provider_model_stripped', true, true );
+
+	if ( $migrated > 0 ) {
+		do_action(
+			'datamachine_log',
+			'info',
+			'Stripped dead `provider`/`model` keys from pipeline_config (see data-machine#1180)',
+			array(
+				'pipelines_updated' => $migrated,
+			)
+		);
+	}
+}


### PR DESCRIPTION
Closes #1180.

## Summary

AIStep resolves `model`/`provider` **exclusively via the mode system** (`PluginSettings::resolveModelForAgentMode` — agent → site → network → default). Per-step `provider`/`model` fields had no effect at execution time but were still accepted by the REST schema, persisted to `pipeline_config`, mirrored into the React Query cache, and rendered on `FlowStepCard` as \"AI Provider / Model\".

Result today: `GET /pipelines` and `wp datamachine pipeline get` both report whatever stale model/provider had been written to the step, while the actual execution uses the mode-model. **Inspection disagrees with execution.**

Reproduced on `intelligence-chubes4` on current `main`: pipeline step shows `provider: openai`, `model: gpt-5.4` in config; its flow actually runs through `DailyMemoryTask` → `SystemTask` → `system` mode → `gpt-5.4-mini`. Dead field lied.

This PR rips the dead surface out end-to-end and migrates existing rows so inspection starts telling the truth.

## Changes

**REST — `inc/Api/Pipelines/PipelineSteps.php`**
- Remove `provider` + `model` from `PipelineSteps::get_step_config_args` so the PATCH/PUT schema no longer advertises them.
- `unset( \$existing_config['provider'], \$existing_config['model'] )` on every write, so any step whose config is touched post-merge self-heals.
- Drop `provider_for_log` + the `debug_info.provider` echo from the upsert response (no downstream consumer).
- Update the two outdated \"Note:\" comments to reflect that the mode system is the authority.

**React — `Core/Admin/Pages/Pipelines/assets/react/queries/pipelines.js`**
- Stop copying `stepData.provider` / `stepData.model` into `pipeline_config[pipelineStepId]` inside `useAddPipelineStep.onSuccess`. Kept the `disabled_tools` copy (genuinely read).

**UI — `Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx`**
- Remove the \"AI Provider / Model\" display block. The card no longer claims to know what model executes — that's mode-resolved on the server and should be sourced from there if we want to surface it. Follow-up work is tracked in the issue discussion (requires a new REST field + localized config payload — out of scope here).
- Kept the `pipelineConfig` prop signature for API stability (5 callers pass it) and added a docblock note that it's currently unused.

**Migration — `inc/migrations/strip-pipeline-step-provider-model.php` (new)**
- `datamachine_strip_pipeline_step_provider_model()` walks every row in `{\$wpdb->prefix}datamachine_pipelines`, decodes `pipeline_config`, and strips `provider` + `model` from every step entry.
- Idempotent: guarded by the `datamachine_pipeline_step_provider_model_stripped` option.
- Wired into `datamachine_activate_for_site()` next to the existing `update-to-upsert` migration. Follows that file's template exactly.
- Logs via `datamachine_log` action when anything was actually stripped.

## Out of scope (noted for the record)

While scoping I noticed two adjacent oddities in `handle_upsert_step_config` that I did NOT touch, so the diff stays focused:

1. `\$effective_provider` is referenced on line 521 (`if ( \$has_api_key && ! empty( \$effective_provider ) )`) but never defined anywhere in the method. The whole `ai_api_key`-save branch is effectively dead until that's fixed.
2. `window.datamachineConfig?.globalSettings` is consumed in `queries/config.js` but no PHP code emits it, so `useGlobalSettings()` returns `{}` unconditionally. Unrelated dead plumbing.

Both are separate bugs; happy to file follow-ups if desired.

## Verification

- `php -l` clean on all four modified/added PHP files.
- `npm run build` compiles (only pre-existing `@extrachill/chat` export warning, unrelated).
- Activation path adds `datamachine_strip_pipeline_step_provider_model()` next to `datamachine_migrate_update_to_upsert_step_type()` in `datamachine_activate_for_site()`.
- After merge + deploy: `studio wp datamachine pipeline get <id>` on any existing pipeline should no longer show `provider` / `model` keys on AI steps.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Scoped the surface across AIStep read path, REST schema + write path, React cache, and FlowStepCard render. Wrote the migration following the existing `update-to-upsert` template. Chris verified the inspection/execution mismatch on his install (intelligence-chubes4) and framed the cleanup boundary.