### PR TITLE
cleanup(pipelines): remove dead `ai_api_key` surface from PipelineSteps REST

### DIFF
--- a/inc/Api/Pipelines/PipelineSteps.php
+++ b/inc/Api/Pipelines/PipelineSteps.php
@@ -182,12 +182,12 @@ class PipelineSteps {
 			// from the mode system (PluginSettings::resolveModelForAgentMode()).
 			// They were removed to stop the REST schema from advertising dead fields.
 			// See: inc/Core/Steps/AI/AIStep.php
-			'ai_api_key'       => array(
-				'required'          => false,
-				'type'              => 'string',
-				'sanitize_callback' => 'sanitize_text_field',
-				'description'       => __( 'AI API key', 'data-machine' ),
-			),
+			//
+			// Note: `ai_api_key` was previously accepted here but the save branch
+			// relied on an undefined `$effective_provider` and silently dropped every
+			// submitted key. API keys are managed exclusively through the canonical
+			// settings path (`SettingsAbilities` → `ai_provider_keys`), which exposes
+			// them via `wp datamachine auth` and the settings admin page.
 			'disabled_tools'   => array(
 				'required'    => false,
 				'type'        => 'array',
@@ -488,11 +488,9 @@ class PipelineSteps {
 		// Model/provider are resolved exclusively via the mode system
 		// (PluginSettings::resolveModelForAgentMode). They are not accepted here.
 		$step_config_data = array();
-		$api_key_saved    = false;
 
 		$has_system_prompt  = $request->has_param( 'system_prompt' );
 		$has_disabled_tools = $request->has_param( 'disabled_tools' );
-		$has_api_key        = $request->has_param( 'ai_api_key' );
 
 		if ( $has_system_prompt ) {
 			$step_config_data['system_prompt'] = sanitize_textarea_field( $request->get_param( 'system_prompt' ) );
@@ -509,26 +507,12 @@ class PipelineSteps {
 			$step_config_data['disabled_tools'] = $tools_manager->save_step_tool_selections( $pipeline_step_id, $sanitized_tool_ids );
 		}
 
-		if ( 'ai' === $step_type && empty( $step_config_data ) && ! $has_api_key ) {
+		if ( 'ai' === $step_type && empty( $step_config_data ) ) {
 			return new \WP_Error(
 				'no_config_values',
 				__( 'No configuration values were provided.', 'data-machine' ),
 				array( 'status' => 400 )
 			);
-		}
-
-		// Store API key if provided
-		if ( $has_api_key && ! empty( $effective_provider ) ) {
-			$ai_api_key = sanitize_text_field( $request->get_param( 'ai_api_key' ) );
-			try {
-				// Use AI HTTP Client library's filters directly to save API key
-				$all_keys                        = apply_filters( 'chubes_ai_provider_api_keys', null );
-				$all_keys[ $effective_provider ] = $ai_api_key;
-				apply_filters( 'chubes_ai_provider_api_keys', $all_keys );
-				$api_key_saved = true;
-			} catch ( \Exception $e ) {
-				unset( $e );
-			}
 		}
 
 		// Preserve provider-specific models by merging with existing config.
@@ -574,7 +558,6 @@ class PipelineSteps {
 				'data'    => array(
 					'pipeline_step_id' => $pipeline_step_id,
 					'debug_info'       => array(
-						'api_key_saved'     => $api_key_saved,
 						'step_config_saved' => true,
 					),
 				),


### PR DESCRIPTION
Closes #1182.

## Summary

The `ai_api_key` param on `PATCH /pipelines/{id}/steps/{step_id}/config` was silently broken: the save branch gated on an undefined `\$effective_provider` so every submitted key was dropped without surfacing an error. The endpoint returned `success: true` and `debug_info.api_key_saved: false` regardless of what the caller sent — indistinguishable from \"no key was provided\" from the outside.

API keys already have a canonical save path: `SettingsAbilities::update_settings()` handles `ai_provider_keys` via the same `chubes_ai_provider_api_keys` filter chain, and is exposed via `wp datamachine auth` plus the settings admin page. So this endpoint was an accidental second surface that never actually worked since the mode-system refactor retired per-step `provider`.

## Changes

**`inc/Api/Pipelines/PipelineSteps.php`**
- Remove `ai_api_key` from PATCH/PUT schema in `get_step_config_args` (lines 192-197).
- Remove the broken save branch in `handle_upsert_step_config` (the `\$has_api_key`, `\$api_key_saved`, `\$effective_provider`-gated block).
- Simplify the `'no_config_values'` guard — now just `empty( \$step_config_data )` since `ai_api_key` was the only non-config-data write.
- Drop `debug_info.api_key_saved` from the response envelope.

**No migration needed.** The branch never persisted anything (it was structurally unreachable), so there's no stale state to clean up. The `chubes_ai_provider_api_keys` filter chain is unaffected — callers using `SettingsAbilities` continue to work identically.

## Relationship to #1181

Adjacent cleanup in the same file. #1181 (legacy `provider`/`model` fields) touches lines 180-191 and 566-583; this PR touches lines 192-197 and 500-539. The two overlap on the schema block (both remove fields from `get_step_config_args`) and the response envelope (both simplify `debug_info`). Whichever lands first, the other is a trivial rebase — happy to do it either way.

## Verification

- `php -l inc/Api/Pipelines/PipelineSteps.php` → clean.
- Grepped `\$effective_provider` across the plugin — only occurrences were in this file, all in the dead branch.
- Grepped `\$has_api_key` / `\$api_key_saved` / `api_key_saved` — all gone after this PR.
- `chubes_ai_provider_api_keys` consumers verified via `grep -rn`: `SettingsAbilities` (canonical writer), `Providers.php`, `WpAiClientAdapter`, `DataMachineFilters` — none depend on anything this PR removes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Confirmed `SettingsAbilities::update_settings` is the canonical key-save path via grep across the plugin. Traced `chubes_ai_provider_api_keys` consumers to prove removal is safe. Chris scoped the cleanup boundary.