### PR TITLE
cleanup(pipelines): remove dead `useGlobalSettings()` hook

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/config.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/config.js
@@ -1,7 +1,7 @@
 /**
  * Configuration Queries
  *
- * TanStack Query hooks for configuration data (step types, global settings, tools).
+ * TanStack Query hooks for configuration data (step types, tools, scheduling intervals).
  * Provider queries have been moved to @shared/queries/providers.
  */
 
@@ -22,15 +22,6 @@ export const useStepTypes = () =>
 			return result.success ? result.data : {};
 		},
 		staleTime: Infinity, // Never refetch - step types don't change
-	} );
-
-export const useGlobalSettings = () =>
-	useQuery( {
-		queryKey: [ 'config', 'global-settings' ],
-		queryFn: async () => {
-			return window.datamachineConfig?.globalSettings || {};
-		},
-		staleTime: 10 * 60 * 1000, // 10 minutes
 	} );
 
 export const useSchedulingIntervals = () =>


### PR DESCRIPTION
Closes #1183.

## Summary

The `useGlobalSettings()` hook read `window.datamachineConfig?.globalSettings`, but no PHP code anywhere in the plugin emits that property. Grep across every `*.php` file for `datamachineConfig` or `globalSettings` returns zero matches. The hook therefore returned `{}` for every consumer, every call, forever.

It also had **zero consumers**: ripgrep across the React tree (excluding the build bundle and node_modules) finds only the declaration itself — nothing imports it. Pure dead export, no migration or rename path required.

## Changes

**`inc/Core/Admin/Pages/Pipelines/assets/react/queries/config.js`**
- Remove `useGlobalSettings` export.
- Update the file docblock: \"step types, global settings, tools\" → \"step types, tools, scheduling intervals\" (matches the hooks that actually live here).

## Verification

- `npm run build` → clean (only pre-existing `@extrachill/chat` `copyChatAsMarkdown` warning, unrelated).
- `grep -rn 'useGlobalSettings' --exclude-dir=build --exclude-dir=node_modules` before this PR: single match, the declaration in `config.js`. After: no matches.
- `grep -rn 'datamachineConfig\\|globalSettings' --include='*.php'`: no matches before or after — confirms the producer was never implemented.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Grep audit to confirm zero producer + zero consumer, then the trivial removal. Chris scoped the cleanup boundary.