### PR TITLE
WebhookTrigger v2: provider-agnostic template verifier

### DIFF
--- a/docs/api/endpoints/webhook-triggers.md
+++ b/docs/api/endpoints/webhook-triggers.md
@@ -154,11 +154,179 @@ wp datamachine flows webhook enable 42 \
   --generate-secret
 ```
 
-### Slack / Stripe
+### Slack / Stripe (v2 template-based verifier)
 
-Slack and Stripe use timestamp-prefixed signatures (`v0=...`, `t=...,v1=...`)
-that aren't directly representable by the three built-in formats. Support for
-these is tracked as a follow-up — see issue #1177.
+As of 0.79.0 the verifier also accepts a **provider-agnostic template config**
+that covers any HMAC-family signature format — including timestamp-prefixed
+schemes like Stripe's `t=...,v1=...` and Slack's `v0:{ts}:{body}`. See the
+[v2 template verifier](#v2-template-based-verifier-provider-agnostic) section
+below.
+
+## v2: template-based verifier (provider-agnostic)
+
+**Since 0.79.0** — see [#1179](https://github.com/Extra-Chill/data-machine/issues/1179).
+
+The v2 verifier describes webhook authentication as a **signing template** and
+**extraction rules** rather than an enum of provider-specific formats. One
+engine covers GitHub, Stripe, Slack, Shopify, Linear, Svix / Standard Webhooks,
+Mailgun, PayPal, Clerk, Twilio-style URL+param signing, and anything else in
+the HMAC family — with **zero provider-specific code** in DM core.
+
+### Config shape
+
+```php
+scheduling_config['webhook_auth'] = [
+    'mode'             => 'hmac',              // 'hmac' | any mode from the filter registry
+    'algo'             => 'sha256',            // 'sha1' | 'sha256' | 'sha512'
+
+    // How to build the signed message. Placeholders:
+    //   {body}              — raw request body
+    //   {timestamp}         — value extracted from timestamp_source
+    //   {id}                — value extracted from id_source
+    //   {url}               — full request URL
+    //   {header:<name>}     — value of a specific request header
+    //   {param:<name>}      — query param first, then body param
+    'signed_template'  => '{timestamp}.{body}',
+
+    // Where the signature lives.
+    'signature_source' => [
+        'header'   => 'Stripe-Signature',      // OR 'param' => '<name>'
+        'extract'  => [
+            'kind'           => 'kv_pairs',    // 'raw' | 'kv_pairs' | 'prefix' | 'regex'
+            'key'            => 'v1',          // for kv_pairs / prefix
+            'separator'      => ',',           // for kv_pairs
+            'pair_separator' => '=',           // for kv_pairs (default =)
+        ],
+        'encoding' => 'hex',                   // 'hex' | 'base64' | 'base64url'
+    ],
+
+    // Optional — presence enables replay protection.
+    'timestamp_source' => [
+        'header'  => 'Stripe-Signature',
+        'extract' => [ 'kind' => 'kv_pairs', 'key' => 't', 'separator' => ',' ],
+        'format'  => 'unix',                   // 'unix' | 'unix_ms' | 'iso8601'
+    ],
+
+    // Optional — for providers that sign an event id (Svix, Clerk).
+    'id_source' => [ 'header' => 'Webhook-Id' ],
+
+    'tolerance_seconds' => 300,
+
+    // Multi-secret rotation: any active secret that verifies wins.
+    // Expired entries are skipped automatically.
+    'secrets' => [
+        [ 'id' => 'current',  'value' => '...' ],
+        [ 'id' => 'previous', 'value' => '...', 'expires_at' => '2026-05-01T00:00:00Z' ],
+    ],
+
+    'max_body_bytes' => 1048576,               // 0 = unlimited
+]
+```
+
+### Provider coverage table
+
+Every row below is exercised end-to-end by the PHPUnit provider matrix in
+`tests/Unit/Api/WebhookVerifierTest.php`.
+
+| Provider | `signed_template` | `signature_source` | `timestamp_source` | `encoding` |
+|---|---|---|---|---|
+| **GitHub** | `{body}` | header `X-Hub-Signature-256`, `prefix=sha256=` | — | hex |
+| **Shopify** | `{body}` | header `X-Shopify-Hmac-Sha256` | — | base64 |
+| **Linear** | `{body}` | header `Linear-Signature` | — | hex |
+| **Stripe** | `{timestamp}.{body}` | header `Stripe-Signature`, `kv_pairs key=v1 separator=,` | same header, `kv_pairs key=t` | hex |
+| **Slack** | `v0:{timestamp}:{body}` | header `X-Slack-Signature`, `prefix=v0=` | header `X-Slack-Request-Timestamp` | hex |
+| **Svix / Standard Webhooks** | `{id}.{timestamp}.{body}` | header `Webhook-Signature`, `kv_pairs key=v1 separator=" "` | header `Webhook-Timestamp` | base64 |
+| **Mailgun** | `{timestamp}{header:X-Mailgun-Token}` | header `X-Mailgun-Signature` | header `X-Mailgun-Timestamp` | hex |
+| **PayPal** | `{body}` | header `Paypal-Transmission-Sig` | header `Paypal-Transmission-Time` | base64 |
+| **Clerk / Svix-compatible** | `{header:svix-id}.{header:svix-timestamp}.{body}` | header `svix-signature`, `kv_pairs key=v1 separator=" "` | header `svix-timestamp` | base64 |
+
+### Presets: filter-registered shorthands
+
+DM core ships **zero presets**. Register them via
+`datamachine_webhook_auth_presets` in a companion plugin or mu-plugin:
+
+```php
+add_filter( 'datamachine_webhook_auth_presets', function ( $p ) {
+    $p['stripe'] = [
+        'mode'             => 'hmac',
+        'algo'             => 'sha256',
+        'signed_template'  => '{timestamp}.{body}',
+        'signature_source' => [
+            'header'   => 'Stripe-Signature',
+            'extract'  => [ 'kind' => 'kv_pairs', 'key' => 'v1', 'separator' => ',' ],
+            'encoding' => 'hex',
+        ],
+        'timestamp_source' => [
+            'header'  => 'Stripe-Signature',
+            'extract' => [ 'kind' => 'kv_pairs', 'key' => 't', 'separator' => ',' ],
+            'format'  => 'unix',
+        ],
+        'tolerance_seconds' => 300,
+    ];
+    return $p;
+} );
+```
+
+Then enable a flow by preset name:
+
+```bash
+wp datamachine flows webhook enable 42 --preset=stripe --secret=whsec_...
+wp datamachine flows webhook presets  # list all registered presets
+```
+
+### Replay protection
+
+When `timestamp_source` is set and `tolerance_seconds > 0`, the verifier
+rejects any request whose timestamp skew exceeds the tolerance. 5 minutes is a
+good default for most providers (matches Stripe's and Slack's published
+recommendation).
+
+### Zero-downtime secret rotation
+
+```bash
+# Install a new secret; keep the old one verifying for 7 days (default).
+wp datamachine flows webhook rotate 42 --generate
+
+# Or set the TTL explicitly.
+wp datamachine flows webhook rotate 42 --generate --previous-ttl-seconds=86400
+
+# After updating the provider side, forget the old secret.
+wp datamachine flows webhook forget 42 previous
+```
+
+Both `current` and `previous` verify signatures until `previous` expires — so
+there's no window where one side is broken.
+
+### Offline dry-run
+
+Debug a provider-side signature configuration without touching production
+flow execution:
+
+```bash
+wp datamachine flows webhook test 42 \
+  --body=@fixtures/github-ping.json \
+  --header="X-Hub-Signature-256: sha256=abc123..." \
+  --header="X-GitHub-Event: ping"
+```
+
+Prints the verification outcome, which secret matched, and the extracted
+timestamp skew. No job spawned, no rate-limit state touched.
+
+### Non-HMAC modes (extension point)
+
+The v2 config's `mode` field is open-ended. Register additional modes via
+the `datamachine_webhook_verifier_modes` filter:
+
+```php
+add_filter( 'datamachine_webhook_verifier_modes', function ( $modes ) {
+    $modes['ed25519'] = MyEd25519Verifier::class;   // e.g. Discord
+    $modes['aws_sns'] = MyAwsSnsVerifier::class;    // x509
+    return $modes;
+} );
+```
+
+Each mode implements a single static `verify(...)` method with the same
+signature as `WebhookVerifier::verify()`.
 
 ## Responses
 

--- a/docs/core-system/abilities-api.md
+++ b/docs/core-system/abilities-api.md
@@ -67,16 +67,19 @@ All abilities support `agent_id` and `user_id` parameters for multi-agent scopin
 | `datamachine/queue-move` | Reorder queue item | `Flow/QueueAbility.php` |
 | `datamachine/queue-settings` | Get/set queue settings | `Flow/QueueAbility.php` |
 
-### Webhook Triggers (6 abilities)
+### Webhook Triggers (9 abilities)
 
 | Ability | Description | Location |
 |---------|-------------|----------|
-| `datamachine/webhook-trigger-enable` | Enable webhook trigger for a flow. Supports `bearer` (default) or `hmac_sha256` auth modes. | `Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-disable` | Disable webhook trigger, revoke all auth material (token and HMAC secret) | `Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-regenerate` | Regenerate Bearer token (bearer auth mode only; old token immediately invalidated) | `Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-set-secret` | Set or rotate the HMAC shared secret; switches the flow to `hmac_sha256` mode | `Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-rate-limit` | Set rate limiting for flow webhook trigger | `Flow/WebhookTriggerAbility.php` |
-| `datamachine/webhook-trigger-status` | Get webhook trigger status for a flow (auth mode, header, format — never the secret) | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-enable` | Enable webhook trigger for a flow. Supports `bearer` (default), `hmac_sha256` (v1 shorthand), or a preset resolved via `datamachine_webhook_auth_presets`. | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-disable` | Disable webhook trigger, revoke all auth material (token, HMAC secrets, v2 config, preset). | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-regenerate` | Regenerate Bearer token (bearer auth mode only; old token immediately invalidated). | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-set-secret` | Set or rotate the HMAC shared secret; switches the flow to `hmac_sha256` mode. | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-rotate-secret` | **Zero-downtime rotation** — demote `current` → `previous` with a TTL, install a fresh `current`. | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-forget-secret` | Remove a specific secret by id from the rotation list immediately. | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-test` | Run the verifier offline against supplied body + headers; no job spawn, no rate limiter touched. | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-rate-limit` | Set rate limiting for flow webhook trigger. | `Flow/WebhookTriggerAbility.php` |
+| `datamachine/webhook-trigger-status` | Get webhook trigger status for a flow (auth mode, preset, secret ids — never the secret values). | `Flow/WebhookTriggerAbility.php` |
 
 ### Job Execution (9 abilities)
 

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -107,13 +107,15 @@ wp datamachine flows queue validate 10 "AI agents" --post_type=post --threshold=
 
 ### datamachine flows webhook
 
-Manage webhook triggers. Supports two auth modes: Bearer (default) and HMAC-SHA256. **Since**: 0.31.0 (Bearer), 0.79.0 (HMAC).
+Manage webhook triggers. Supports Bearer (default), HMAC-SHA256 (v1 shorthand),
+and the v2 provider-agnostic template verifier. **Since**: 0.31.0 (Bearer),
+0.79.0 (HMAC + v2 verifier).
 
 ```bash
 # Enable webhook trigger with default Bearer auth
 wp datamachine flows webhook enable 10
 
-# Enable with HMAC-SHA256 auth (GitHub-style) and a generated secret
+# Enable with HMAC-SHA256 (v1 shorthand — GitHub-style)
 wp datamachine flows webhook enable 10 --auth-mode=hmac_sha256 --generate-secret
 
 # Enable with HMAC for a non-GitHub provider (Shopify example)
@@ -123,11 +125,28 @@ wp datamachine flows webhook enable 10 \
   --signature-format=base64 \
   --secret=<shopify_secret>
 
-# Set or rotate the HMAC secret (prints the new secret once)
+# Enable with a registered preset (v2 — filter-registered, provider-agnostic)
+wp datamachine flows webhook enable 10 --preset=stripe --secret=whsec_...
+wp datamachine flows webhook enable 10 --preset=slack --generate-secret
+
+# List available presets (core ships zero — they come from plugins / mu-plugins)
+wp datamachine flows webhook presets
+
+# Zero-downtime secret rotation (keeps the old secret verifying for 7 days)
+wp datamachine flows webhook rotate 10 --generate
+wp datamachine flows webhook rotate 10 --generate --previous-ttl-seconds=86400
+wp datamachine flows webhook forget 10 previous
+
+# Offline verification — no job spawned, no rate limit hit
+wp datamachine flows webhook test 10 \
+  --body=@fixtures/github-ping.json \
+  --header="X-Hub-Signature-256: sha256=abc123..."
+
+# Set or rotate the HMAC secret (single-secret v1 shorthand)
 wp datamachine flows webhook set-secret 10 --generate
 wp datamachine flows webhook set-secret 10 --secret=<value>
 
-# Check webhook status (shows auth mode; never shows secret/token)
+# Check webhook status (shows auth mode, preset, secret ids — never values)
 wp datamachine flows webhook status 10
 
 # List all webhook-enabled flows
@@ -139,17 +158,20 @@ wp datamachine flows webhook regenerate 10
 # Configure rate limiting
 wp datamachine flows webhook rate-limit 10 --max=10 --window=60
 
-# Disable webhook (clears all auth material, both modes)
+# Disable webhook (clears all auth material)
 wp datamachine flows webhook disable 10
 ```
 
-**Signature formats for HMAC mode** (`--signature-format`):
+**Signature formats for the v1 shorthand** (`--signature-format`):
 - `sha256=hex` (default) — GitHub-style `sha256=<hex>` header values.
 - `hex` — raw hex digest (e.g. Linear).
 - `base64` — base64-encoded raw digest (e.g. Shopify).
 
-See [Webhook Triggers](../api/endpoints/webhook-triggers.md) for the full
-GitHub walkthrough and security notes.
+**v2 template verifier**: the `--preset=<name>` flag expands a filter-registered
+template into the full v2 config — supporting Stripe / Slack / Svix / Mailgun
+timestamp-composite signatures, replay protection, and multi-secret rotation.
+See [Webhook Triggers](../api/endpoints/webhook-triggers.md) for the grammar,
+provider coverage table, and the `datamachine_webhook_auth_presets` filter.
 
 ### datamachine flows bulk-config
 

--- a/inc/Abilities/Flow/WebhookTriggerAbility.php
+++ b/inc/Abilities/Flow/WebhookTriggerAbility.php
@@ -57,6 +57,10 @@ class WebhookTriggerAbility {
 								'enum'        => array( 'bearer', 'hmac_sha256' ),
 								'description' => __( 'Authentication mode. Defaults to bearer for backward compatibility.', 'data-machine' ),
 							),
+							'preset'           => array(
+								'type'        => 'string',
+								'description' => __( 'Name of a preset registered via the datamachine_webhook_auth_presets filter (e.g. stripe, slack). Resolves to a full v2 template config; implies HMAC mode.', 'data-machine' ),
+							),
 							'signature_header' => array(
 								'type'        => 'string',
 								'description' => __( 'HMAC signature header name (e.g. X-Hub-Signature-256). Only used when auth_mode is hmac_sha256.', 'data-machine' ),
@@ -68,11 +72,15 @@ class WebhookTriggerAbility {
 							),
 							'generate_secret'  => array(
 								'type'        => 'boolean',
-								'description' => __( 'When auth_mode is hmac_sha256, auto-generate a random 32-byte hex secret.', 'data-machine' ),
+								'description' => __( 'When HMAC mode is active, auto-generate a random 32-byte hex secret.', 'data-machine' ),
 							),
 							'secret'           => array(
 								'type'        => 'string',
-								'description' => __( 'When auth_mode is hmac_sha256, use this secret value (takes precedence over generate_secret).', 'data-machine' ),
+								'description' => __( 'When HMAC mode is active, use this secret value (takes precedence over generate_secret).', 'data-machine' ),
+							),
+							'secret_id'        => array(
+								'type'        => 'string',
+								'description' => __( 'Optional secret id for multi-secret rotation (default: current).', 'data-machine' ),
 							),
 						),
 					),
@@ -285,6 +293,123 @@ class WebhookTriggerAbility {
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
+
+			wp_register_ability(
+				'datamachine/webhook-trigger-rotate-secret',
+				array(
+					'label'               => __( 'Rotate Webhook HMAC Secret', 'data-machine' ),
+					'description'         => __( 'Zero-downtime rotation: promote the current secret to `previous` (with an expiry), install a new current secret. Both verify signatures until the previous secret expires.', 'data-machine' ),
+					'category'            => 'datamachine-flow',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'flow_id' ),
+						'properties' => array(
+							'flow_id'              => array( 'type' => 'integer' ),
+							'secret'               => array(
+								'type'        => 'string',
+								'description' => __( 'Explicit new secret (takes precedence over generate).', 'data-machine' ),
+							),
+							'generate'             => array(
+								'type'        => 'boolean',
+								'description' => __( 'Generate a new random 32-byte hex secret.', 'data-machine' ),
+							),
+							'previous_ttl_seconds' => array(
+								'type'        => 'integer',
+								'description' => __( 'How long the previous secret keeps verifying (default: 604800 = 7 days).', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'             => array( 'type' => 'boolean' ),
+							'flow_id'             => array( 'type' => 'integer' ),
+							'new_secret'          => array( 'type' => 'string' ),
+							'previous_expires_at' => array( 'type' => 'string' ),
+							'secret_ids'          => array( 'type' => 'array' ),
+							'message'             => array( 'type' => 'string' ),
+							'error'               => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'executeRotateSecret' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/webhook-trigger-forget-secret',
+				array(
+					'label'               => __( 'Forget Webhook HMAC Secret', 'data-machine' ),
+					'description'         => __( 'Immediately remove a specific secret by id from the rotation list.', 'data-machine' ),
+					'category'            => 'datamachine-flow',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'flow_id', 'secret_id' ),
+						'properties' => array(
+							'flow_id'   => array( 'type' => 'integer' ),
+							'secret_id' => array( 'type' => 'string' ),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'    => array( 'type' => 'boolean' ),
+							'flow_id'    => array( 'type' => 'integer' ),
+							'secret_ids' => array( 'type' => 'array' ),
+							'message'    => array( 'type' => 'string' ),
+							'error'      => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'executeForgetSecret' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/webhook-trigger-test',
+				array(
+					'label'               => __( 'Test Webhook Verification', 'data-machine' ),
+					'description'         => __( 'Run the verifier offline against a captured payload + headers without spawning a flow job. Useful for debugging upstream signature configuration.', 'data-machine' ),
+					'category'            => 'datamachine-flow',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'flow_id', 'body', 'headers' ),
+						'properties' => array(
+							'flow_id' => array( 'type' => 'integer' ),
+							'body'    => array(
+								'type'        => 'string',
+								'description' => __( 'Raw request body as bytes.', 'data-machine' ),
+							),
+							'headers' => array(
+								'type'        => 'object',
+								'description' => __( 'Request headers as an object keyed by header name.', 'data-machine' ),
+							),
+							'now'     => array(
+								'type'        => 'integer',
+								'description' => __( 'Override "now" (unix seconds) for deterministic replay-window checks.', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'      => array( 'type' => 'boolean' ),
+							'ok'           => array( 'type' => 'boolean' ),
+							'reason'       => array( 'type' => 'string' ),
+							'secret_id'    => array( 'type' => 'string' ),
+							'timestamp'    => array( 'type' => 'integer' ),
+							'skew_seconds' => array( 'type' => 'integer' ),
+							'detail'       => array( 'type' => 'string' ),
+							'error'        => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'executeTest' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
 		};
 
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
@@ -328,6 +453,25 @@ class WebhookTriggerAbility {
 		$scheduling_config = $flow['scheduling_config'] ?? array();
 
 		$requested_mode = isset( $input['auth_mode'] ) ? (string) $input['auth_mode'] : '';
+		$preset_name    = isset( $input['preset'] ) ? trim( (string) $input['preset'] ) : '';
+
+		// A preset implies HMAC mode.
+		if ( '' !== $preset_name ) {
+			$presets = \DataMachine\Api\WebhookAuthResolver::get_presets();
+			if ( ! isset( $presets[ $preset_name ] ) ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf(
+						'Unknown preset "%s". Register presets via the datamachine_webhook_auth_presets filter.',
+						$preset_name
+					),
+				);
+			}
+			if ( '' === $requested_mode ) {
+				$requested_mode = 'hmac_sha256';
+			}
+		}
+
 		if ( '' === $requested_mode ) {
 			$requested_mode = $scheduling_config['webhook_auth_mode'] ?? 'bearer';
 		}
@@ -339,8 +483,16 @@ class WebhookTriggerAbility {
 		}
 
 		// If already enabled in the same mode with valid auth material, return existing config.
-		$existing_mode = $scheduling_config['webhook_auth_mode'] ?? 'bearer';
-		if ( ! empty( $scheduling_config['webhook_enabled'] ) && $existing_mode === $requested_mode ) {
+		// A new secret or preset request always falls through so the caller's intent wins.
+		$has_new_secret    = ! empty( $input['secret'] ) || ! empty( $input['generate_secret'] );
+		$has_preset_change = ( '' !== $preset_name ) && ( ( $scheduling_config['webhook_auth_preset'] ?? '' ) !== $preset_name );
+		$existing_mode     = $scheduling_config['webhook_auth_mode'] ?? 'bearer';
+
+		if ( ! empty( $scheduling_config['webhook_enabled'] )
+			&& $existing_mode === $requested_mode
+			&& ! $has_new_secret
+			&& ! $has_preset_change
+		) {
 			if ( 'bearer' === $requested_mode && ! empty( $scheduling_config['webhook_token'] ) ) {
 				return array(
 					'success'     => true,
@@ -352,15 +504,21 @@ class WebhookTriggerAbility {
 				);
 			}
 			if ( 'hmac_sha256' === $requested_mode && ! empty( $scheduling_config['webhook_secret'] ) ) {
-				return array(
-					'success'          => true,
-					'flow_id'          => $flow_id,
-					'webhook_url'      => self::get_webhook_url( $flow_id ),
-					'auth_mode'        => 'hmac_sha256',
-					'signature_header' => $scheduling_config['webhook_signature_header'] ?? 'X-Hub-Signature-256',
-					'signature_format' => $scheduling_config['webhook_signature_format'] ?? 'sha256=hex',
-					'message'          => 'Webhook trigger already enabled.',
+				$existing_preset = $scheduling_config['webhook_auth_preset'] ?? null;
+				$result          = array(
+					'success'     => true,
+					'flow_id'     => $flow_id,
+					'webhook_url' => self::get_webhook_url( $flow_id ),
+					'auth_mode'   => 'hmac_sha256',
+					'message'     => 'Webhook trigger already enabled.',
 				);
+				if ( $existing_preset ) {
+					$result['preset'] = $existing_preset;
+				} else {
+					$result['signature_header'] = $scheduling_config['webhook_signature_header'] ?? 'X-Hub-Signature-256';
+					$result['signature_format'] = $scheduling_config['webhook_signature_format'] ?? 'sha256=hex';
+				}
+				return $result;
 			}
 		}
 
@@ -390,49 +548,78 @@ class WebhookTriggerAbility {
 			// HMAC mode — resolve secret from input (explicit > generate > existing).
 			$explicit_secret = isset( $input['secret'] ) ? (string) $input['secret'] : '';
 			$generate        = ! empty( $input['generate_secret'] );
+			$secret_id       = isset( $input['secret_id'] ) ? (string) $input['secret_id'] : 'current';
+			if ( '' === $secret_id ) {
+				$secret_id = 'current';
+			}
+
+			$new_secret_value = null;
 
 			if ( '' !== $explicit_secret ) {
-				$scheduling_config['webhook_secret'] = $explicit_secret;
-				$response['secret']                  = $explicit_secret;
+				$new_secret_value = $explicit_secret;
 			} elseif ( $generate || empty( $scheduling_config['webhook_secret'] ) ) {
-				$new_secret                          = self::generate_secret();
-				$scheduling_config['webhook_secret'] = $new_secret;
-				$response['secret']                  = $new_secret;
+				$new_secret_value = self::generate_secret();
+			}
+
+			if ( null !== $new_secret_value ) {
+				// Legacy single-value field (v1 compat).
+				$scheduling_config['webhook_secret'] = $new_secret_value;
+
+				// v2 multi-secret list.
+				$secrets                              = self::upsert_secret(
+					$scheduling_config['webhook_secrets'] ?? array(),
+					$secret_id,
+					$new_secret_value
+				);
+				$scheduling_config['webhook_secrets'] = $secrets;
+				$response['secret']                   = $new_secret_value;
 			}
 
 			if ( empty( $scheduling_config['webhook_secret'] ) ) {
 				return array(
 					'success' => false,
-					'error'   => 'HMAC auth_mode requires a secret. Pass --generate-secret or --secret=<value>.',
+					'error'   => 'HMAC mode requires a secret. Pass --generate-secret or --secret=<value>.',
 				);
 			}
 
-			$header = isset( $input['signature_header'] ) ? trim( (string) $input['signature_header'] ) : '';
-			if ( '' !== $header ) {
-				$scheduling_config['webhook_signature_header'] = $header;
-			} elseif ( empty( $scheduling_config['webhook_signature_header'] ) ) {
-				$scheduling_config['webhook_signature_header'] = 'X-Hub-Signature-256';
-			}
+			if ( '' !== $preset_name ) {
+				$scheduling_config['webhook_auth_preset'] = $preset_name;
+				// Drop v1 header/format fields — the preset defines them.
+				unset( $scheduling_config['webhook_signature_header'] );
+				unset( $scheduling_config['webhook_signature_format'] );
+				$response['preset']  = $preset_name;
+				$response['message'] = sprintf( 'Webhook trigger enabled for flow %d (hmac preset=%s).', $flow_id, $preset_name );
+			} else {
+				// Clear any stale preset when switching back to explicit config.
+				unset( $scheduling_config['webhook_auth_preset'] );
 
-			$format = isset( $input['signature_format'] ) ? (string) $input['signature_format'] : '';
-			if ( '' !== $format ) {
-				if ( ! in_array( $format, \DataMachine\Api\WebhookSignatureVerifier::supported_formats(), true ) ) {
-					return array(
-						'success' => false,
-						'error'   => sprintf( 'Unsupported signature_format "%s".', $format ),
-					);
+				$header = isset( $input['signature_header'] ) ? trim( (string) $input['signature_header'] ) : '';
+				if ( '' !== $header ) {
+					$scheduling_config['webhook_signature_header'] = $header;
+				} elseif ( empty( $scheduling_config['webhook_signature_header'] ) ) {
+					$scheduling_config['webhook_signature_header'] = 'X-Hub-Signature-256';
 				}
-				$scheduling_config['webhook_signature_format'] = $format;
-			} elseif ( empty( $scheduling_config['webhook_signature_format'] ) ) {
-				$scheduling_config['webhook_signature_format'] = 'sha256=hex';
+
+				$format = isset( $input['signature_format'] ) ? (string) $input['signature_format'] : '';
+				if ( '' !== $format ) {
+					if ( ! in_array( $format, \DataMachine\Api\WebhookSignatureVerifier::supported_formats(), true ) ) {
+						return array(
+							'success' => false,
+							'error'   => sprintf( 'Unsupported signature_format "%s".', $format ),
+						);
+					}
+					$scheduling_config['webhook_signature_format'] = $format;
+				} elseif ( empty( $scheduling_config['webhook_signature_format'] ) ) {
+					$scheduling_config['webhook_signature_format'] = 'sha256=hex';
+				}
+
+				$response['signature_header'] = $scheduling_config['webhook_signature_header'];
+				$response['signature_format'] = $scheduling_config['webhook_signature_format'];
+				$response['message']          = sprintf( 'Webhook trigger enabled for flow %d (hmac_sha256).', $flow_id );
 			}
 
 			// Clear Bearer-specific field when switching to HMAC.
 			unset( $scheduling_config['webhook_token'] );
-
-			$response['signature_header'] = $scheduling_config['webhook_signature_header'];
-			$response['signature_format'] = $scheduling_config['webhook_signature_format'];
-			$response['message']          = sprintf( 'Webhook trigger enabled for flow %d (hmac_sha256).', $flow_id );
 		}
 
 		$updated = $this->db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
@@ -500,18 +687,30 @@ class WebhookTriggerAbility {
 
 		$scheduling_config = $flow['scheduling_config'] ?? array();
 
-		$secret = '' !== $explicit_secret ? $explicit_secret : self::generate_secret();
+		$secret    = '' !== $explicit_secret ? $explicit_secret : self::generate_secret();
+		$secret_id = isset( $input['secret_id'] ) ? (string) $input['secret_id'] : 'current';
+		if ( '' === $secret_id ) {
+			$secret_id = 'current';
+		}
 
 		$scheduling_config['webhook_secret']     = $secret;
+		$scheduling_config['webhook_secrets']    = self::upsert_secret(
+			$scheduling_config['webhook_secrets'] ?? array(),
+			$secret_id,
+			$secret
+		);
 		$scheduling_config['webhook_auth_mode']  = 'hmac_sha256';
 		$scheduling_config['webhook_enabled']    = true;
 		$scheduling_config['webhook_created_at'] = $scheduling_config['webhook_created_at'] ?? gmdate( 'Y-m-d\TH:i:s\Z' );
 
-		if ( empty( $scheduling_config['webhook_signature_header'] ) ) {
-			$scheduling_config['webhook_signature_header'] = 'X-Hub-Signature-256';
-		}
-		if ( empty( $scheduling_config['webhook_signature_format'] ) ) {
-			$scheduling_config['webhook_signature_format'] = 'sha256=hex';
+		// Only populate legacy v1 header/format defaults when no preset / v2 auth is driving the flow.
+		if ( empty( $scheduling_config['webhook_auth_preset'] ) && empty( $scheduling_config['webhook_auth'] ) ) {
+			if ( empty( $scheduling_config['webhook_signature_header'] ) ) {
+				$scheduling_config['webhook_signature_header'] = 'X-Hub-Signature-256';
+			}
+			if ( empty( $scheduling_config['webhook_signature_format'] ) ) {
+				$scheduling_config['webhook_signature_format'] = 'sha256=hex';
+			}
 		}
 		// Clear Bearer-specific field when switching into HMAC mode.
 		unset( $scheduling_config['webhook_token'] );
@@ -574,9 +773,13 @@ class WebhookTriggerAbility {
 		unset( $scheduling_config['webhook_created_at'] );
 		unset( $scheduling_config['webhook_auth_mode'] );
 		unset( $scheduling_config['webhook_secret'] );
+		unset( $scheduling_config['webhook_secrets'] );
 		unset( $scheduling_config['webhook_signature_header'] );
 		unset( $scheduling_config['webhook_signature_format'] );
 		unset( $scheduling_config['webhook_max_body_bytes'] );
+		unset( $scheduling_config['webhook_auth'] );
+		unset( $scheduling_config['webhook_auth_preset'] );
+		unset( $scheduling_config['webhook_auth_overrides'] );
 
 		$updated = $this->db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
 
@@ -818,11 +1021,21 @@ class WebhookTriggerAbility {
 			$result['auth_mode']   = $auth_mode;
 
 			if ( 'hmac_sha256' === $auth_mode ) {
-				$result['signature_header'] = $scheduling_config['webhook_signature_header'] ?? 'X-Hub-Signature-256';
-				$result['signature_format'] = $scheduling_config['webhook_signature_format'] ?? 'sha256=hex';
-				$result['max_body_bytes']   = (int) ( $scheduling_config['webhook_max_body_bytes']
+				$preset = $scheduling_config['webhook_auth_preset'] ?? null;
+				if ( $preset ) {
+					$result['preset'] = $preset;
+				} else {
+					$result['signature_header'] = $scheduling_config['webhook_signature_header'] ?? 'X-Hub-Signature-256';
+					$result['signature_format'] = $scheduling_config['webhook_signature_format'] ?? 'sha256=hex';
+				}
+				$result['max_body_bytes'] = (int) ( $scheduling_config['webhook_max_body_bytes']
 					?? \DataMachine\Api\WebhookTrigger::DEFAULT_MAX_BODY_BYTES );
-				// NEVER include the secret.
+
+				// v2 multi-secret roster — ids only, never values.
+				$result['secret_ids'] = self::summarize_secrets(
+					$scheduling_config['webhook_secrets'] ?? array(),
+					$scheduling_config['webhook_secret'] ?? ''
+				);
 			}
 
 			$rate_config          = $scheduling_config['webhook_rate_limit'] ?? array();
@@ -864,5 +1077,357 @@ class WebhookTriggerAbility {
 	 */
 	public static function get_webhook_url( int $flow_id ): string {
 		return rest_url( "datamachine/v1/trigger/{$flow_id}" );
+	}
+
+	/**
+	 * Zero-downtime secret rotation.
+	 *
+	 * Demotes `current` → `previous` with a TTL, installs a fresh `current`.
+	 * Both continue to verify inbound signatures until `previous` expires —
+	 * so upstream providers have a grace window to swap in the new secret.
+	 *
+	 * @param array $input flow_id, optional secret / generate / previous_ttl_seconds.
+	 * @return array
+	 */
+	public function executeRotateSecret( array $input ): array {
+		$flow_id = (int) ( $input['flow_id'] ?? 0 );
+		if ( $flow_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_id must be a positive integer',
+			);
+		}
+
+		$flow = $this->db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow %d not found', $flow_id ),
+			);
+		}
+
+		$scheduling_config = $flow['scheduling_config'] ?? array();
+		$explicit          = isset( $input['secret'] ) ? (string) $input['secret'] : '';
+		$generate          = ! empty( $input['generate'] );
+
+		if ( '' === $explicit && ! $generate ) {
+			return array(
+				'success' => false,
+				'error'   => 'Provide either secret=<value> or generate=true.',
+			);
+		}
+
+		$ttl = isset( $input['previous_ttl_seconds'] ) ? (int) $input['previous_ttl_seconds'] : WEEK_IN_SECONDS;
+		if ( $ttl < 0 ) {
+			$ttl = 0;
+		}
+		$now        = time();
+		$expires_at = gmdate( 'Y-m-d\TH:i:s\Z', $now + $ttl );
+
+		$new_secret = '' !== $explicit ? $explicit : self::generate_secret();
+
+		// Find current secret; demote it to previous.
+		$secrets = $scheduling_config['webhook_secrets'] ?? array();
+		if ( ! is_array( $secrets ) || empty( $secrets ) ) {
+			$legacy = (string) ( $scheduling_config['webhook_secret'] ?? '' );
+			if ( '' !== $legacy ) {
+				$secrets = array(
+					array(
+						'id'    => 'current',
+						'value' => $legacy,
+					),
+				);
+			}
+		}
+
+		$demoted = array();
+		foreach ( $secrets as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			if ( ( $entry['id'] ?? '' ) === 'current' ) {
+				$entry['id']         = 'previous';
+				$entry['expires_at'] = $expires_at;
+			}
+			if ( ( $entry['id'] ?? '' ) === 'previous' && empty( $entry['expires_at'] ) ) {
+				// Legacy `previous` without a TTL — give it the same window.
+				$entry['expires_at'] = $expires_at;
+			}
+			$demoted[] = $entry;
+		}
+		$demoted[] = array(
+			'id'    => 'current',
+			'value' => $new_secret,
+		);
+
+		$scheduling_config['webhook_secrets']    = $demoted;
+		$scheduling_config['webhook_secret']     = $new_secret;
+		$scheduling_config['webhook_auth_mode']  = $scheduling_config['webhook_auth_mode'] ?? 'hmac_sha256';
+		$scheduling_config['webhook_enabled']    = true;
+		$scheduling_config['webhook_created_at'] = $scheduling_config['webhook_created_at'] ?? gmdate( 'Y-m-d\TH:i:s\Z' );
+		unset( $scheduling_config['webhook_token'] );
+
+		$updated = $this->db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
+		if ( ! $updated ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to update flow scheduling config',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Webhook HMAC secret rotated',
+			array(
+				'flow_id'    => $flow_id,
+				'expires_at' => $expires_at,
+			)
+		);
+
+		return array(
+			'success'             => true,
+			'flow_id'             => $flow_id,
+			'new_secret'          => $new_secret,
+			'previous_expires_at' => $expires_at,
+			'secret_ids'          => self::summarize_secrets( $demoted, $new_secret ),
+			'message'             => sprintf(
+				'HMAC secret rotated for flow %d. Previous secret valid until %s.',
+				$flow_id,
+				$expires_at
+			),
+		);
+	}
+
+	/**
+	 * Immediately forget a secret by id (no grace period).
+	 *
+	 * @param array $input flow_id, secret_id.
+	 * @return array
+	 */
+	public function executeForgetSecret( array $input ): array {
+		$flow_id   = (int) ( $input['flow_id'] ?? 0 );
+		$secret_id = isset( $input['secret_id'] ) ? (string) $input['secret_id'] : '';
+
+		if ( $flow_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_id must be a positive integer',
+			);
+		}
+		if ( '' === $secret_id ) {
+			return array(
+				'success' => false,
+				'error'   => 'secret_id is required',
+			);
+		}
+
+		$flow = $this->db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow %d not found', $flow_id ),
+			);
+		}
+
+		$scheduling_config = $flow['scheduling_config'] ?? array();
+		$secrets           = $scheduling_config['webhook_secrets'] ?? array();
+		if ( ! is_array( $secrets ) ) {
+			$secrets = array();
+		}
+
+		$filtered = array();
+		$found    = false;
+		foreach ( $secrets as $entry ) {
+			if ( is_array( $entry ) && ( $entry['id'] ?? '' ) === $secret_id ) {
+				$found = true;
+				continue;
+			}
+			$filtered[] = $entry;
+		}
+
+		if ( ! $found ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'No secret with id "%s" on flow %d.', $secret_id, $flow_id ),
+			);
+		}
+
+		$scheduling_config['webhook_secrets'] = $filtered;
+
+		// If we dropped the secret that mirrored the legacy field, resync.
+		if ( 'current' === $secret_id ) {
+			$next_current = '';
+			foreach ( $filtered as $entry ) {
+				if ( is_array( $entry ) && ( $entry['id'] ?? '' ) === 'current' ) {
+					$next_current = (string) ( $entry['value'] ?? '' );
+					break;
+				}
+			}
+			if ( '' === $next_current ) {
+				unset( $scheduling_config['webhook_secret'] );
+			} else {
+				$scheduling_config['webhook_secret'] = $next_current;
+			}
+		}
+
+		$updated = $this->db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
+		if ( ! $updated ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to update flow scheduling config',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Webhook HMAC secret forgotten',
+			array(
+				'flow_id'   => $flow_id,
+				'secret_id' => $secret_id,
+			)
+		);
+
+		return array(
+			'success'    => true,
+			'flow_id'    => $flow_id,
+			'secret_ids' => self::summarize_secrets( $filtered, $scheduling_config['webhook_secret'] ?? '' ),
+			'message'    => sprintf( 'Secret "%s" removed from flow %d.', $secret_id, $flow_id ),
+		);
+	}
+
+	/**
+	 * Run the verifier offline against a supplied payload + headers.
+	 *
+	 * Never spawns a job. Never touches the rate limiter. Useful for debugging
+	 * upstream signature configuration or replaying captured deliveries.
+	 *
+	 * @param array $input flow_id, body (string), headers (assoc), optional now.
+	 * @return array
+	 */
+	public function executeTest( array $input ): array {
+		$flow_id = (int) ( $input['flow_id'] ?? 0 );
+		if ( $flow_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_id must be a positive integer',
+			);
+		}
+
+		$flow = $this->db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow %d not found', $flow_id ),
+			);
+		}
+
+		$body    = isset( $input['body'] ) ? (string) $input['body'] : '';
+		$headers = isset( $input['headers'] ) && is_array( $input['headers'] ) ? $input['headers'] : array();
+		$now     = isset( $input['now'] ) ? (int) $input['now'] : null;
+
+		$scheduling_config = $flow['scheduling_config'] ?? array();
+		$resolved          = \DataMachine\Api\WebhookAuthResolver::resolve( $scheduling_config );
+
+		if ( 'bearer' === $resolved['mode'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'test only applies to HMAC / verifier-based auth modes.',
+			);
+		}
+		if ( empty( $resolved['verifier'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Flow has no verifier config resolved.',
+			);
+		}
+
+		// Lower-case header keys for the verifier.
+		$normalised = array();
+		foreach ( $headers as $k => $v ) {
+			$normalised[ strtolower( (string) $k ) ] = is_array( $v ) ? implode( ',', array_map( 'strval', $v ) ) : (string) $v;
+		}
+
+		$result = \DataMachine\Api\WebhookVerifier::verify(
+			$body,
+			$normalised,
+			array(),
+			array(),
+			self::get_webhook_url( $flow_id ),
+			$resolved['verifier'],
+			$now
+		);
+
+		return array(
+			'success'      => true,
+			'ok'           => $result->ok,
+			'reason'       => $result->reason,
+			'secret_id'    => $result->secret_id,
+			'timestamp'    => $result->timestamp,
+			'skew_seconds' => $result->skew_seconds,
+			'detail'       => $result->detail,
+		);
+	}
+
+	/**
+	 * Add or replace a secret entry in the v2 multi-secret list.
+	 *
+	 * @param array  $existing
+	 * @param string $id
+	 * @param string $value
+	 * @return array
+	 */
+	public static function upsert_secret( array $existing, string $id, string $value ): array {
+		$replaced = false;
+		$out      = array();
+		foreach ( $existing as $entry ) {
+			if ( is_array( $entry ) && ( $entry['id'] ?? '' ) === $id ) {
+				$out[]    = array(
+					'id'    => $id,
+					'value' => $value,
+				);
+				$replaced = true;
+				continue;
+			}
+			$out[] = $entry;
+		}
+		if ( ! $replaced ) {
+			$out[] = array(
+				'id'    => $id,
+				'value' => $value,
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Summarise a secrets list into a safe-for-response shape (ids + expiry only).
+	 *
+	 * Accepts both the v2 array-of-arrays and a legacy single-value fallback.
+	 *
+	 * @param mixed  $secrets
+	 * @param string $legacy_value Fallback value when no v2 list is present.
+	 * @return array<int,array{id:string,expires_at:?string}>
+	 */
+	public static function summarize_secrets( $secrets, string $legacy_value = '' ): array {
+		$out = array();
+		if ( is_array( $secrets ) ) {
+			foreach ( $secrets as $entry ) {
+				if ( is_array( $entry ) && ! empty( $entry['value'] ) ) {
+					$out[] = array(
+						'id'         => (string) ( $entry['id'] ?? '' ),
+						'expires_at' => isset( $entry['expires_at'] ) ? (string) $entry['expires_at'] : null,
+					);
+				}
+			}
+		}
+		if ( empty( $out ) && '' !== $legacy_value ) {
+			$out[] = array(
+				'id'         => 'current',
+				'expires_at' => null,
+			);
+		}
+		return $out;
 	}
 }

--- a/inc/Api/WebhookAuthResolver.php
+++ b/inc/Api/WebhookAuthResolver.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Webhook auth config resolver.
+ *
+ * Converts a flow's `scheduling_config` (any of v1 fields, v2 `webhook_auth`,
+ * or a preset name) into a single canonical config shape consumable by
+ * {@see WebhookVerifier}. Provider-agnostic: DM core never learns the name
+ * "Stripe" or "Slack" — presets are discovered via the
+ * `datamachine_webhook_auth_presets` filter.
+ *
+ * @package DataMachine\Api
+ * @since 0.79.0
+ * @see https://github.com/Extra-Chill/data-machine/issues/1179
+ */
+
+namespace DataMachine\Api;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class WebhookAuthResolver {
+
+	/**
+	 * Resolve a flow's scheduling_config to a canonical mode + verifier config.
+	 *
+	 * Resolution order (highest to lowest precedence):
+	 * 1. v2 `webhook_auth` block on the flow.
+	 * 2. v2 `webhook_auth_preset` (filter-registered template) merged with overrides.
+	 * 3. v1 `webhook_auth_mode` = 'hmac_sha256' with v1 signature fields.
+	 * 4. v1 `webhook_auth_mode` = 'bearer' (default).
+	 *
+	 * Returns [ 'mode' => 'bearer'|'hmac', 'verifier' => ?array, 'token' => ?string ]:
+	 * - 'bearer' mode uses the legacy token comparison path (no verifier).
+	 * - 'hmac'   mode exposes a fully resolved verifier config.
+	 *
+	 * @param array $scheduling_config
+	 * @return array{mode:string, verifier:?array, token:?string, preset:?string}
+	 */
+	public static function resolve( array $scheduling_config ): array {
+		// v2 — explicit webhook_auth wins.
+		$auth = $scheduling_config['webhook_auth'] ?? null;
+
+		// v2 — preset shorthand expands into a webhook_auth merged with overrides.
+		$preset_name = null;
+		if ( ! is_array( $auth ) && ! empty( $scheduling_config['webhook_auth_preset'] ) ) {
+			$preset_name = (string) $scheduling_config['webhook_auth_preset'];
+			$presets     = self::get_presets();
+			if ( isset( $presets[ $preset_name ] ) ) {
+				$overrides = $scheduling_config['webhook_auth_overrides'] ?? array();
+				$auth      = self::deep_merge( $presets[ $preset_name ], is_array( $overrides ) ? $overrides : array() );
+			}
+		}
+
+		if ( is_array( $auth ) ) {
+			$mode = $auth['mode'] ?? 'hmac';
+			if ( 'bearer' === $mode ) {
+				return array(
+					'mode'     => 'bearer',
+					'verifier' => null,
+					'token'    => (string) ( $scheduling_config['webhook_token'] ?? '' ),
+					'preset'   => $preset_name,
+				);
+			}
+			// HMAC (or pluggable mode) — attach secrets from the flow if the v2 block didn't ship its own.
+			if ( empty( $auth['secrets'] ) && ! empty( $scheduling_config['webhook_secrets'] ) ) {
+				$auth['secrets'] = $scheduling_config['webhook_secrets'];
+			}
+			if ( empty( $auth['secrets'] ) && ! empty( $scheduling_config['webhook_secret'] ) ) {
+				$auth['secrets'] = array(
+					array(
+						'id'    => 'current',
+						'value' => (string) $scheduling_config['webhook_secret'],
+					),
+				);
+			}
+			return array(
+				'mode'     => $auth['mode'] ?? 'hmac',
+				'verifier' => $auth,
+				'token'    => null,
+				'preset'   => $preset_name,
+			);
+		}
+
+		// v1 — hmac_sha256 shorthand.
+		$v1_mode = $scheduling_config['webhook_auth_mode'] ?? 'bearer';
+		if ( 'hmac_sha256' === $v1_mode ) {
+			$header = (string) ( $scheduling_config['webhook_signature_header'] ?? 'X-Hub-Signature-256' );
+			$format = (string) ( $scheduling_config['webhook_signature_format'] ?? 'sha256=hex' );
+
+			$signature_source = array(
+				'header'   => $header,
+				'extract'  => array( 'kind' => 'raw' ),
+				'encoding' => 'hex',
+			);
+
+			switch ( $format ) {
+				case 'sha256=hex':
+					$signature_source['extract']  = array(
+						'kind' => 'prefix',
+						'key'  => 'sha256=',
+					);
+					$signature_source['encoding'] = 'hex';
+					break;
+				case 'hex':
+					$signature_source['encoding'] = 'hex';
+					break;
+				case 'base64':
+					$signature_source['encoding'] = 'base64';
+					break;
+			}
+
+			$secrets = array();
+			if ( ! empty( $scheduling_config['webhook_secrets'] ) && is_array( $scheduling_config['webhook_secrets'] ) ) {
+				$secrets = $scheduling_config['webhook_secrets'];
+			} elseif ( ! empty( $scheduling_config['webhook_secret'] ) ) {
+				$secrets = array(
+					array(
+						'id'    => 'current',
+						'value' => (string) $scheduling_config['webhook_secret'],
+					),
+				);
+			}
+
+			return array(
+				'mode'     => 'hmac',
+				'verifier' => array(
+					'mode'             => 'hmac',
+					'algo'             => 'sha256',
+					'signed_template'  => '{body}',
+					'signature_source' => $signature_source,
+					'secrets'          => $secrets,
+					'max_body_bytes'   => (int) ( $scheduling_config['webhook_max_body_bytes']
+						?? WebhookVerifier::DEFAULT_MAX_BODY_BYTES ),
+				),
+				'token'    => null,
+				'preset'   => null,
+			);
+		}
+
+		// v1 bearer (default).
+		return array(
+			'mode'     => 'bearer',
+			'verifier' => null,
+			'token'    => (string) ( $scheduling_config['webhook_token'] ?? '' ),
+			'preset'   => null,
+		);
+	}
+
+	/**
+	 * Discover filter-registered presets.
+	 *
+	 * Core ships zero presets; third parties (including chubes.net itself, or a
+	 * companion `data-machine-webhook-presets` package) add presets via this
+	 * filter:
+	 *
+	 * ```php
+	 * add_filter( 'datamachine_webhook_auth_presets', function ( $presets ) {
+	 *     $presets['stripe'] = [
+	 *         'mode'             => 'hmac',
+	 *         'algo'             => 'sha256',
+	 *         'signed_template'  => '{timestamp}.{body}',
+	 *         'signature_source' => [ 'header' => 'Stripe-Signature',
+	 *             'extract' => [ 'kind' => 'kv_pairs', 'key' => 'v1', 'separator' => ',' ],
+	 *             'encoding' => 'hex' ],
+	 *         'timestamp_source' => [ 'header' => 'Stripe-Signature',
+	 *             'extract' => [ 'kind' => 'kv_pairs', 'key' => 't', 'separator' => ',' ],
+	 *             'format'  => 'unix' ],
+	 *         'tolerance_seconds' => 300,
+	 *     ];
+	 *     return $presets;
+	 * } );
+	 * ```
+	 *
+	 * @return array<string,array>
+	 */
+	public static function get_presets(): array {
+		$presets = apply_filters( 'datamachine_webhook_auth_presets', array() );
+		return is_array( $presets ) ? $presets : array();
+	}
+
+	/**
+	 * Recursive array merge where associative keys from $overrides replace
+	 * $base (not concat), but deep sub-arrays merge one level at a time.
+	 *
+	 * @param array $base
+	 * @param array $overrides
+	 * @return array
+	 */
+	public static function deep_merge( array $base, array $overrides ): array {
+		foreach ( $overrides as $k => $v ) {
+			if ( is_array( $v ) && isset( $base[ $k ] ) && is_array( $base[ $k ] ) ) {
+				$base[ $k ] = self::deep_merge( $base[ $k ], $v );
+			} else {
+				$base[ $k ] = $v;
+			}
+		}
+		return $base;
+	}
+}

--- a/inc/Api/WebhookTrigger.php
+++ b/inc/Api/WebhookTrigger.php
@@ -141,12 +141,14 @@ class WebhookTrigger {
 			);
 		}
 
-		$auth_mode = self::resolve_auth_mode( $scheduling_config );
+		$resolved  = WebhookAuthResolver::resolve( $scheduling_config );
+		$auth_mode = $resolved['mode'];
 
-		if ( 'hmac_sha256' === $auth_mode ) {
-			$auth_error = self::authenticate_hmac( $flow_id, $scheduling_config, $request );
-		} else {
+		if ( 'bearer' === $auth_mode ) {
 			$auth_error = self::authenticate_bearer( $flow_id, $scheduling_config, $request );
+		} else {
+			// 'hmac' (core) or any pluggable mode registered via filter — run through the verifier.
+			$auth_error = self::authenticate_via_verifier( $flow_id, $resolved, $request );
 		}
 
 		if ( $auth_error instanceof \WP_Error ) {
@@ -298,23 +300,6 @@ class WebhookTrigger {
 	const DEFAULT_RATE_LIMIT_WINDOW = 60;
 
 	/**
-	 * Resolve the effective webhook auth mode for a flow.
-	 *
-	 * Missing / unrecognized values default to `bearer` so existing flows
-	 * behave identically to before HMAC support was added.
-	 *
-	 * @param array $scheduling_config Flow scheduling config.
-	 * @return string Either 'bearer' or 'hmac_sha256'.
-	 */
-	private static function resolve_auth_mode( array $scheduling_config ): string {
-		$mode = $scheduling_config['webhook_auth_mode'] ?? 'bearer';
-		if ( 'hmac_sha256' === $mode ) {
-			return 'hmac_sha256';
-		}
-		return 'bearer';
-	}
-
-	/**
 	 * Authenticate a webhook request using a per-flow Bearer token.
 	 *
 	 * @param int              $flow_id          Flow ID.
@@ -406,30 +391,34 @@ class WebhookTrigger {
 	}
 
 	/**
-	 * Authenticate a webhook request using HMAC-SHA256 signatures.
+	 * Authenticate a webhook request using the provider-agnostic verifier.
 	 *
-	 * Verifies the raw request body (`$request->get_body()`) against a
-	 * provider-specified signature header, using the shared secret stored
-	 * in `scheduling_config.webhook_secret`.
+	 * Works for any mode other than `bearer`. Core ships `hmac`; additional
+	 * modes (Ed25519, x509, JWT, ...) are pluggable via the
+	 * `datamachine_webhook_verifier_modes` filter.
 	 *
-	 * @param int              $flow_id          Flow ID.
-	 * @param array            $scheduling_config Flow scheduling config.
-	 * @param \WP_REST_Request $request          REST request object.
+	 * On failure returns a generic 401 (or 413 for oversized payloads) to
+	 * prevent information leakage. The real failure reason is logged
+	 * server-side for the flow owner's diagnostics.
+	 *
+	 * @param int              $flow_id   Flow ID.
+	 * @param array            $resolved  Output of WebhookAuthResolver::resolve().
+	 * @param \WP_REST_Request $request   REST request object.
 	 * @return \WP_Error|null WP_Error on failure, null on success.
 	 */
-	private static function authenticate_hmac( int $flow_id, array $scheduling_config, \WP_REST_Request $request ): ?\WP_Error {
-		$secret = $scheduling_config['webhook_secret'] ?? '';
-		if ( empty( $secret ) || ! is_string( $secret ) ) {
+	private static function authenticate_via_verifier( int $flow_id, array $resolved, \WP_REST_Request $request ): ?\WP_Error {
+		$verifier_config = $resolved['verifier'] ?? null;
+		if ( ! is_array( $verifier_config ) ) {
 			do_action(
 				'datamachine_log',
 				'warning',
-				'Webhook trigger: HMAC secret not configured for flow',
+				'Webhook trigger: Missing or malformed verifier config',
 				array(
 					'flow_id'   => $flow_id,
 					'remote_ip' => self::get_remote_ip( $request ),
+					'mode'      => $resolved['mode'] ?? 'unknown',
 				)
 			);
-
 			return new \WP_Error(
 				'unauthorized',
 				'Invalid or missing authorization.',
@@ -437,47 +426,45 @@ class WebhookTrigger {
 			);
 		}
 
-		$signature_header = $scheduling_config['webhook_signature_header'] ?? 'X-Hub-Signature-256';
-		$signature_format = $scheduling_config['webhook_signature_format'] ?? WebhookSignatureVerifier::FORMAT_PREFIXED_HEX;
+		$raw_body     = $request->get_body();
+		$headers      = self::collect_headers( $request );
+		$query_params = (array) $request->get_query_params();
+		$post_params  = (array) $request->get_body_params();
+		$url          = self::build_request_url( $request );
 
-		$provided = $request->get_header( $signature_header );
-		if ( empty( $provided ) ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Webhook trigger: Missing HMAC signature header',
-				array(
-					'flow_id'          => $flow_id,
-					'remote_ip'        => self::get_remote_ip( $request ),
-					'signature_header' => $signature_header,
-				)
-			);
+		$result = WebhookVerifier::verify(
+			$raw_body,
+			$headers,
+			$query_params,
+			$post_params,
+			$url,
+			$verifier_config
+		);
 
-			return new \WP_Error(
-				'unauthorized',
-				'Invalid or missing authorization.',
-				array( 'status' => 401 )
-			);
+		// Structured log for the flow owner's diagnostics — never contains
+		// secrets, signatures, or payload bodies.
+		do_action(
+			'datamachine_log',
+			$result->ok ? 'info' : 'warning',
+			'Webhook trigger: verification ' . $result->reason,
+			array(
+				'flow_id'      => $flow_id,
+				'remote_ip'    => self::get_remote_ip( $request ),
+				'mode'         => $resolved['mode'] ?? 'hmac',
+				'preset'       => $resolved['preset'] ?? null,
+				'reason'       => $result->reason,
+				'secret_id'    => $result->secret_id,
+				'timestamp'    => $result->timestamp,
+				'skew_seconds' => $result->skew_seconds,
+				'detail'       => $result->detail,
+			)
+		);
+
+		if ( $result->ok ) {
+			return null;
 		}
 
-		$raw_body = $request->get_body();
-
-		// Enforce an optional max body size before running HMAC — unauthenticated
-		// clients can otherwise force the server to hash arbitrarily large payloads.
-		$max_body_bytes = (int) ( $scheduling_config['webhook_max_body_bytes'] ?? self::DEFAULT_MAX_BODY_BYTES );
-		if ( $max_body_bytes > 0 && strlen( $raw_body ) > $max_body_bytes ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Webhook trigger: Payload exceeds max_body_bytes',
-				array(
-					'flow_id'   => $flow_id,
-					'remote_ip' => self::get_remote_ip( $request ),
-					'size'      => strlen( $raw_body ),
-					'limit'     => $max_body_bytes,
-				)
-			);
-
+		if ( WebhookVerificationResult::PAYLOAD_TOO_LARGE === $result->reason ) {
 			return new \WP_Error(
 				'payload_too_large',
 				'Payload too large.',
@@ -485,34 +472,50 @@ class WebhookTrigger {
 			);
 		}
 
-		$valid = WebhookSignatureVerifier::verify_hmac_sha256(
-			$raw_body,
-			$provided,
-			$secret,
-			$signature_format
+		return new \WP_Error(
+			'unauthorized',
+			'Invalid or missing authorization.',
+			array( 'status' => 401 )
 		);
+	}
 
-		if ( ! $valid ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Webhook trigger: HMAC signature mismatch',
-				array(
-					'flow_id'          => $flow_id,
-					'remote_ip'        => self::get_remote_ip( $request ),
-					'signature_header' => $signature_header,
-					'signature_format' => $signature_format,
-				)
-			);
-
-			return new \WP_Error(
-				'unauthorized',
-				'Invalid or missing authorization.',
-				array( 'status' => 401 )
-			);
+	/**
+	 * Collect all request headers into a lower-cased assoc array for the verifier.
+	 *
+	 * WP_REST_Request::get_headers() returns keys lower-cased with underscores;
+	 * values are arrays. We flatten to a single string per header.
+	 *
+	 * @param \WP_REST_Request $request
+	 * @return array<string,string>
+	 */
+	private static function collect_headers( \WP_REST_Request $request ): array {
+		$out = array();
+		foreach ( (array) $request->get_headers() as $name => $values ) {
+			if ( is_array( $values ) ) {
+				$value = implode( ',', array_map( 'strval', $values ) );
+			} else {
+				$value = (string) $values;
+			}
+			$normalised         = strtolower( str_replace( '_', '-', $name ) );
+			$out[ $normalised ] = $value;
 		}
+		return $out;
+	}
 
-		return null;
+	/**
+	 * Reconstruct the full request URL (scheme://host/path?query).
+	 *
+	 * @param \WP_REST_Request $request
+	 * @return string
+	 */
+	private static function build_request_url( \WP_REST_Request $request ): string {
+		$route = ltrim( $request->get_route(), '/' );
+		$url   = rest_url( $route );
+		$query = $request->get_query_params();
+		if ( ! empty( $query ) ) {
+			$url = add_query_arg( $query, $url );
+		}
+		return $url;
 	}
 
 	/**
@@ -646,6 +649,17 @@ class WebhookTrigger {
 			'linear-signature',
 			'x-slack-signature',
 			'x-slack-request-timestamp',
+			'webhook-id',
+			'webhook-timestamp',
+			'webhook-signature',
+			'svix-id',
+			'svix-timestamp',
+			'svix-signature',
+			'x-mailgun-signature',
+			'x-mailgun-timestamp',
+			'x-mailgun-token',
+			'paypal-transmission-sig',
+			'paypal-transmission-time',
 		);
 
 		$headers = array();

--- a/inc/Api/WebhookVerificationResult.php
+++ b/inc/Api/WebhookVerificationResult.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Webhook verification result value object.
+ *
+ * Returned by {@see \DataMachine\Api\WebhookVerifier::verify()}. Kept as a
+ * dedicated class so callers can rely on property names and IDE tooling can
+ * type-check them.
+ *
+ * @package DataMachine\Api
+ * @since 0.79.0
+ * @see https://github.com/Extra-Chill/data-machine/issues/1179
+ */
+
+namespace DataMachine\Api;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class WebhookVerificationResult {
+
+	/** Verification outcomes. */
+	const OK                 = 'ok';
+	const BAD_SIGNATURE      = 'bad_signature';
+	const MISSING_HEADER     = 'missing_header';
+	const MISSING_SIGNATURE  = 'missing_signature';
+	const MISSING_TIMESTAMP  = 'missing_timestamp';
+	const STALE_TIMESTAMP    = 'stale_timestamp';
+	const NO_ACTIVE_SECRET   = 'no_active_secret';
+	const PAYLOAD_TOO_LARGE  = 'payload_too_large';
+	const MALFORMED_TEMPLATE = 'malformed_template';
+	const MALFORMED_CONFIG   = 'malformed_config';
+	const UNKNOWN_MODE       = 'unknown_mode';
+
+	/** @var bool Whether verification succeeded. */
+	public bool $ok;
+
+	/** @var string Outcome code — see class constants. */
+	public string $reason;
+
+	/** @var string|null ID of the secret that matched (for logging / rotation audit). */
+	public ?string $secret_id;
+
+	/** @var int|null Extracted timestamp in unix seconds, if `timestamp_source` is configured. */
+	public ?int $timestamp;
+
+	/** @var int|null Absolute skew in seconds from "now" at verification time. */
+	public ?int $skew_seconds;
+
+	/** @var string|null Free-form diagnostic detail, safe for logs (no secrets/signatures). */
+	public ?string $detail;
+
+	public function __construct(
+		bool $ok,
+		string $reason,
+		?string $secret_id = null,
+		?int $timestamp = null,
+		?int $skew_seconds = null,
+		?string $detail = null
+	) {
+		$this->ok           = $ok;
+		$this->reason       = $reason;
+		$this->secret_id    = $secret_id;
+		$this->timestamp    = $timestamp;
+		$this->skew_seconds = $skew_seconds;
+		$this->detail       = $detail;
+	}
+
+	public static function ok( ?string $secret_id = null, ?int $timestamp = null, ?int $skew = null ): self {
+		return new self( true, self::OK, $secret_id, $timestamp, $skew );
+	}
+
+	public static function fail( string $reason, ?string $detail = null, ?int $timestamp = null, ?int $skew = null ): self {
+		return new self( false, $reason, null, $timestamp, $skew, $detail );
+	}
+}

--- a/inc/Api/WebhookVerifier.php
+++ b/inc/Api/WebhookVerifier.php
@@ -1,0 +1,604 @@
+<?php
+/**
+ * Webhook Verifier — provider-agnostic template engine.
+ *
+ * Verifies HMAC-family webhook signatures using a declarative config that
+ * describes *how* a provider signs rather than *which* provider is signing.
+ * Covers GitHub, Stripe, Slack, Shopify, Linear, Svix / Standard Webhooks,
+ * Mailgun, PayPal, Clerk, and anything else in the HMAC family — with zero
+ * provider-specific code in DM core.
+ *
+ * Non-HMAC primitives (Ed25519, x509) are handled by pluggable verifier
+ * modes registered via the `datamachine_webhook_verifier_modes` filter.
+ *
+ * @package DataMachine\Api
+ * @since 0.79.0
+ * @see https://github.com/Extra-Chill/data-machine/issues/1179
+ */
+
+namespace DataMachine\Api;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Provider-agnostic webhook signature verifier.
+ *
+ * Public entry point: {@see WebhookVerifier::verify()}.
+ *
+ * Configuration shape:
+ *
+ * ```php
+ * [
+ *   'mode'             => 'hmac',                           // 'hmac' (core) | anything from the mode filter registry
+ *   'algo'             => 'sha256',                         // 'sha1' | 'sha256' | 'sha512'
+ *   'signed_template'  => '{timestamp}.{body}',             // placeholders: {body} {timestamp} {id} {url} {header:X} {param:X}
+ *   'signature_source' => [ header|param, extract, encoding ],
+ *   'timestamp_source' => [ header|param, extract, format ], // optional — presence enables replay protection
+ *   'id_source'        => [ header|param, extract ],         // optional
+ *   'tolerance_seconds'=> 300,                              // only used when timestamp_source is set
+ *   'secrets'          => [ [ 'id' => 'current', 'value' => '...' ], ... ],
+ *   'max_body_bytes'   => 1048576,                           // 0 = unlimited
+ * ]
+ * ```
+ */
+class WebhookVerifier {
+
+	/** Default max body size (1 MB). */
+	const DEFAULT_MAX_BODY_BYTES = 1048576;
+
+	/** Default replay tolerance (5 minutes). */
+	const DEFAULT_TOLERANCE_SECONDS = 300;
+
+	/**
+	 * Verify a webhook request against a template-based auth config.
+	 *
+	 * @param string               $raw_body     Raw request body bytes (as signed by the sender).
+	 * @param array<string,string> $headers      Request headers, keyed by lower-case name.
+	 * @param array<string,mixed>  $query_params Query string parameters (for `{param:X}` in the URL).
+	 * @param array<string,mixed>  $post_params  Form-encoded body params (for `{param:X}` in the body).
+	 * @param string               $url          Full request URL (for `{url}` template token).
+	 * @param array                $config       Auth config — see class docblock for shape.
+	 * @param int|null             $now          Override "now" for deterministic tests.
+	 * @return WebhookVerificationResult
+	 */
+	public static function verify(
+		string $raw_body,
+		array $headers,
+		array $query_params,
+		array $post_params,
+		string $url,
+		array $config,
+		?int $now = null
+	): WebhookVerificationResult {
+
+		// Lower-case header keys once so `{header:X}` lookups are case-insensitive.
+		$headers = self::lower_case_keys( $headers );
+		$now     = $now ?? time();
+
+		$mode = $config['mode'] ?? 'hmac';
+		if ( 'hmac' !== $mode ) {
+			$modes = apply_filters( 'datamachine_webhook_verifier_modes', array() );
+			if ( isset( $modes[ $mode ] ) && is_callable( array( $modes[ $mode ], 'verify' ) ) ) {
+				return call_user_func(
+					array( $modes[ $mode ], 'verify' ),
+					$raw_body,
+					$headers,
+					$query_params,
+					$post_params,
+					$url,
+					$config,
+					$now
+				);
+			}
+			return WebhookVerificationResult::fail( WebhookVerificationResult::UNKNOWN_MODE, "mode={$mode}" );
+		}
+
+		// Payload size cap (checked before any crypto).
+		$max = (int) ( $config['max_body_bytes'] ?? self::DEFAULT_MAX_BODY_BYTES );
+		if ( $max > 0 && strlen( $raw_body ) > $max ) {
+			return WebhookVerificationResult::fail(
+				WebhookVerificationResult::PAYLOAD_TOO_LARGE,
+				sprintf( 'size=%d limit=%d', strlen( $raw_body ), $max )
+			);
+		}
+
+		$secrets = self::active_secrets( $config['secrets'] ?? array(), $now );
+		if ( empty( $secrets ) ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::NO_ACTIVE_SECRET );
+		}
+
+		$signature_source = $config['signature_source'] ?? null;
+		if ( ! is_array( $signature_source ) ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::MALFORMED_CONFIG, 'signature_source missing' );
+		}
+
+		// Extract the signature.
+		$sig_read = self::read_source( $signature_source, $headers, $query_params, $post_params );
+		if ( null === $sig_read['raw'] ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::MISSING_HEADER, $sig_read['detail'] );
+		}
+		if ( '' === $sig_read['extracted'] ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::MISSING_SIGNATURE, $sig_read['detail'] );
+		}
+
+		$encoding  = $signature_source['encoding'] ?? 'hex';
+		$sig_bytes = self::decode_signature( $sig_read['extracted'], $encoding );
+		if ( null === $sig_bytes ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::BAD_SIGNATURE, 'undecodable signature' );
+		}
+
+		// Optional timestamp extraction + replay enforcement.
+		$timestamp    = null;
+		$skew_seconds = null;
+		if ( ! empty( $config['timestamp_source'] ) && is_array( $config['timestamp_source'] ) ) {
+			$ts_read = self::read_source( $config['timestamp_source'], $headers, $query_params, $post_params );
+			if ( null === $ts_read['raw'] || '' === $ts_read['extracted'] ) {
+				return WebhookVerificationResult::fail( WebhookVerificationResult::MISSING_TIMESTAMP, $ts_read['detail'] );
+			}
+			$timestamp = self::parse_timestamp( $ts_read['extracted'], $config['timestamp_source']['format'] ?? 'unix' );
+			if ( null === $timestamp ) {
+				return WebhookVerificationResult::fail( WebhookVerificationResult::MISSING_TIMESTAMP, 'unparseable timestamp' );
+			}
+			$tolerance    = (int) ( $config['tolerance_seconds'] ?? self::DEFAULT_TOLERANCE_SECONDS );
+			$skew_seconds = abs( $now - $timestamp );
+			if ( $tolerance > 0 && $skew_seconds > $tolerance ) {
+				return WebhookVerificationResult::fail(
+					WebhookVerificationResult::STALE_TIMESTAMP,
+					sprintf( 'skew=%ds tolerance=%ds', $skew_seconds, $tolerance ),
+					$timestamp,
+					$skew_seconds
+				);
+			}
+		}
+
+		// Optional id extraction (for templates that reference `{id}`).
+		$id_value = null;
+		if ( ! empty( $config['id_source'] ) && is_array( $config['id_source'] ) ) {
+			$id_read  = self::read_source( $config['id_source'], $headers, $query_params, $post_params );
+			$id_value = $id_read['extracted'];
+		}
+
+		// Render the signed message template.
+		$template = $config['signed_template'] ?? '{body}';
+		if ( ! is_string( $template ) || '' === $template ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::MALFORMED_TEMPLATE );
+		}
+
+		$rendered = self::render_template(
+			$template,
+			array(
+				'body'      => $raw_body,
+				'timestamp' => null !== $timestamp ? (string) $timestamp : '',
+				'id'        => (string) ( $id_value ?? '' ),
+				'url'       => $url,
+			),
+			$headers,
+			$query_params,
+			$post_params
+		);
+
+		if ( null === $rendered ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::MALFORMED_TEMPLATE );
+		}
+
+		$algo = $config['algo'] ?? 'sha256';
+		if ( ! in_array( $algo, hash_hmac_algos(), true ) ) {
+			return WebhookVerificationResult::fail( WebhookVerificationResult::MALFORMED_CONFIG, "algo={$algo}" );
+		}
+
+		// Loop all active secrets — first match wins.
+		foreach ( $secrets as $secret ) {
+			$value = $secret['value'];
+			if ( '' === $value ) {
+				continue;
+			}
+			$expected = hash_hmac( $algo, $rendered, $value, true );
+			if ( hash_equals( $expected, $sig_bytes ) ) {
+				return WebhookVerificationResult::ok( $secret['id'], $timestamp, $skew_seconds );
+			}
+		}
+
+		return WebhookVerificationResult::fail(
+			WebhookVerificationResult::BAD_SIGNATURE,
+			null,
+			$timestamp,
+			$skew_seconds
+		);
+	}
+
+	/*
+	=================================================================
+	 * Template rendering
+	 * ================================================================= */
+
+	/**
+	 * Render a signed-message template into the exact bytes to HMAC.
+	 *
+	 * Recognised placeholders:
+	 * - `{body}`           — raw request body
+	 * - `{timestamp}`      — extracted timestamp value (string)
+	 * - `{id}`             — extracted id value (string)
+	 * - `{url}`            — full request URL
+	 * - `{header:<name>}`  — request header value (case-insensitive)
+	 * - `{param:<name>}`   — query param first, then body param
+	 *
+	 * Unknown placeholders return null (caller responds with MALFORMED_TEMPLATE).
+	 *
+	 * @param string               $template
+	 * @param array<string,string> $simple_tokens
+	 * @param array<string,string> $headers
+	 * @param array<string,mixed>  $query_params
+	 * @param array<string,mixed>  $post_params
+	 * @return string|null Rendered message bytes, or null on unknown placeholder.
+	 */
+	private static function render_template(
+		string $template,
+		array $simple_tokens,
+		array $headers,
+		array $query_params,
+		array $post_params
+	): ?string {
+		$malformed = false;
+
+		$rendered = preg_replace_callback(
+			'/\{([a-z_]+)(?::([^}]+))?\}/i',
+			function ( array $m ) use ( $simple_tokens, $headers, $query_params, $post_params, &$malformed ) {
+				$kind = strtolower( $m[1] );
+				$arg  = $m[2] ?? '';
+
+				if ( '' === $arg ) {
+					if ( array_key_exists( $kind, $simple_tokens ) ) {
+						return $simple_tokens[ $kind ];
+					}
+					$malformed = true;
+					return '';
+				}
+
+				switch ( $kind ) {
+					case 'header':
+						$value = $headers[ strtolower( $arg ) ] ?? '';
+						return (string) $value;
+					case 'param':
+						if ( array_key_exists( $arg, $query_params ) ) {
+							$value = $query_params[ $arg ];
+						} elseif ( array_key_exists( $arg, $post_params ) ) {
+							$value = $post_params[ $arg ];
+						} else {
+							return '';
+						}
+						return is_scalar( $value ) ? (string) $value : '';
+					default:
+						$malformed = true;
+						return '';
+				}
+			},
+			$template
+		);
+
+		if ( $malformed || null === $rendered ) {
+			return null;
+		}
+
+		return $rendered;
+	}
+
+	/*
+	=================================================================
+	 * Source extraction
+	 * ================================================================= */
+
+	/**
+	 * Read a source descriptor (signature_source, timestamp_source, id_source).
+	 *
+	 * A source either pulls from a `header` or from a `param` (query → post).
+	 * The raw value can then be narrowed further by `extract`:
+	 *
+	 *   extract.kind = 'raw'       (default) — return value as-is
+	 *   extract.kind = 'prefix'    — strip `extract.key`; reject if not present
+	 *   extract.kind = 'kv_pairs'  — split by `extract.separator` into k=v pairs, return value for `extract.key`
+	 *   extract.kind = 'regex'     — PCRE pattern; capture group 1 is the result
+	 *
+	 * Returns: [ 'raw' => null|string, 'extracted' => string, 'detail' => string|null ]
+	 *   raw = null when the source itself is missing (e.g. header absent)
+	 *   extracted = '' when extraction could not find the target (but raw was present)
+	 *
+	 * @param array                $source
+	 * @param array<string,string> $headers
+	 * @param array<string,mixed>  $query_params
+	 * @param array<string,mixed>  $post_params
+	 * @return array{raw:?string, extracted:string, detail:?string}
+	 */
+	private static function read_source( array $source, array $headers, array $query_params, array $post_params ): array {
+		$raw    = null;
+		$detail = null;
+
+		if ( ! empty( $source['header'] ) ) {
+			$name = strtolower( (string) $source['header'] );
+			$raw  = $headers[ $name ] ?? null;
+			if ( null === $raw ) {
+				return array(
+					'raw'       => null,
+					'extracted' => '',
+					'detail'    => "header={$source['header']}",
+				);
+			}
+		} elseif ( ! empty( $source['param'] ) ) {
+			$name = (string) $source['param'];
+			if ( array_key_exists( $name, $query_params ) ) {
+				$raw = is_scalar( $query_params[ $name ] ) ? (string) $query_params[ $name ] : null;
+			} elseif ( array_key_exists( $name, $post_params ) ) {
+				$raw = is_scalar( $post_params[ $name ] ) ? (string) $post_params[ $name ] : null;
+			}
+			if ( null === $raw ) {
+				return array(
+					'raw'       => null,
+					'extracted' => '',
+					'detail'    => "param={$name}",
+				);
+			}
+		} else {
+			return array(
+				'raw'       => null,
+				'extracted' => '',
+				'detail'    => 'source missing header or param',
+			);
+		}
+
+		$extracted = self::apply_extract( $raw, $source['extract'] ?? array() );
+		return array(
+			'raw'       => $raw,
+			'extracted' => $extracted,
+			'detail'    => $detail,
+		);
+	}
+
+	/**
+	 * Apply an `extract` rule to a raw source value.
+	 *
+	 * @param string $raw
+	 * @param array  $rule
+	 * @return string Empty string when the rule did not match.
+	 */
+	private static function apply_extract( string $raw, array $rule ): string {
+		$kind = $rule['kind'] ?? 'raw';
+
+		switch ( $kind ) {
+			case 'raw':
+				return trim( $raw );
+
+			case 'prefix':
+				$prefix = (string) ( $rule['key'] ?? '' );
+				if ( '' === $prefix ) {
+					return trim( $raw );
+				}
+				if ( 0 !== strpos( $raw, $prefix ) ) {
+					return '';
+				}
+				return trim( substr( $raw, strlen( $prefix ) ) );
+
+			case 'kv_pairs':
+				$separator = (string) ( $rule['separator'] ?? ',' );
+				$key       = (string) ( $rule['key'] ?? '' );
+				if ( '' === $key ) {
+					return '';
+				}
+				$pair_sep = (string) ( $rule['pair_separator'] ?? '=' );
+				foreach ( self::split_preserve_empty( $raw, $separator ) as $piece ) {
+					$piece = trim( $piece );
+					if ( '' === $piece ) {
+						continue;
+					}
+					$eq = strpos( $piece, $pair_sep );
+					if ( false === $eq ) {
+						continue;
+					}
+					$k = substr( $piece, 0, $eq );
+					$v = substr( $piece, $eq + strlen( $pair_sep ) );
+					if ( $k === $key ) {
+						return trim( $v );
+					}
+				}
+				return '';
+
+			case 'regex':
+				$pattern = (string) ( $rule['pattern'] ?? '' );
+				if ( '' === $pattern ) {
+					return '';
+				}
+				// User-supplied patterns can be invalid; swallow the warning and treat as no match.
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+				set_error_handler( static function () {
+					return true;
+				} );
+				$m      = array();
+				$result = preg_match( $pattern, $raw, $m );
+				restore_error_handler();
+				if ( 1 === $result ) {
+					return isset( $m[1] ) ? trim( $m[1] ) : trim( $m[0] );
+				}
+				return '';
+
+			default:
+				return '';
+		}
+	}
+
+	/*
+	=================================================================
+	 * Signature decoding + timestamp parsing
+	 * ================================================================= */
+
+	/**
+	 * Decode a signature string into raw bytes for binary comparison.
+	 *
+	 * @param string $sig
+	 * @param string $encoding 'hex' | 'base64' | 'base64url'
+	 * @return string|null Bytes, or null if the input is not valid for the declared encoding.
+	 */
+	private static function decode_signature( string $sig, string $encoding ): ?string {
+		$sig = trim( $sig );
+		switch ( $encoding ) {
+			case 'hex':
+				if ( ! ctype_xdigit( $sig ) || 0 !== strlen( $sig ) % 2 ) {
+					return null;
+				}
+				// Already validated for even-length hex — hex2bin will not emit warnings.
+				$bytes = hex2bin( $sig );
+				return false === $bytes ? null : $bytes;
+
+			case 'base64':
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+				$bytes = base64_decode( $sig, true );
+				return false === $bytes ? null : $bytes;
+
+			case 'base64url':
+				$padded = strtr( $sig, '-_', '+/' );
+				$pad    = strlen( $padded ) % 4;
+				if ( $pad ) {
+					$padded .= str_repeat( '=', 4 - $pad );
+				}
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+				$bytes = base64_decode( $padded, true );
+				return false === $bytes ? null : $bytes;
+
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Parse an extracted timestamp value into a unix-seconds integer.
+	 *
+	 * @param string $value
+	 * @param string $format 'unix' | 'unix_ms' | 'iso8601'
+	 * @return int|null
+	 */
+	private static function parse_timestamp( string $value, string $format ): ?int {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			return null;
+		}
+
+		switch ( $format ) {
+			case 'unix':
+				if ( ! preg_match( '/^-?\d+$/', $value ) ) {
+					return null;
+				}
+				return (int) $value;
+
+			case 'unix_ms':
+				if ( ! preg_match( '/^-?\d+$/', $value ) ) {
+					return null;
+				}
+				return (int) floor( ( (int) $value ) / 1000 );
+
+			case 'iso8601':
+				$ts = strtotime( $value );
+				return false === $ts ? null : (int) $ts;
+
+			default:
+				return null;
+		}
+	}
+
+	/*
+	=================================================================
+	 * Secret lifecycle
+	 * ================================================================= */
+
+	/**
+	 * Filter + normalise the active secrets list.
+	 *
+	 * Accepts:
+	 * - `[ [ 'id' => '...', 'value' => '...', 'expires_at' => '...' ], ... ]` (preferred)
+	 * - `[ 'raw-secret-string' ]`                              (flat list — treated as id='default')
+	 * - `'raw-secret-string'`                                   (single — normalised to one-element list)
+	 *
+	 * Secrets with `expires_at` in the past are dropped.
+	 *
+	 * @param mixed $secrets
+	 * @param int   $now
+	 * @return array<int,array{id:string,value:string}>
+	 */
+	private static function active_secrets( $secrets, int $now ): array {
+		if ( is_string( $secrets ) ) {
+			$secrets = array( $secrets );
+		}
+		if ( ! is_array( $secrets ) ) {
+			return array();
+		}
+
+		$active = array();
+		$index  = 0;
+		foreach ( $secrets as $key => $entry ) {
+			if ( is_string( $entry ) ) {
+				$active[] = array(
+					'id'    => is_string( $key ) ? $key : ( 'secret_' . $index ),
+					'value' => $entry,
+				);
+				++$index;
+				continue;
+			}
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$value = (string) ( $entry['value'] ?? '' );
+			if ( '' === $value ) {
+				continue;
+			}
+			$expires_at = $entry['expires_at'] ?? null;
+			if ( ! empty( $expires_at ) ) {
+				$ts = is_numeric( $expires_at ) ? (int) $expires_at : strtotime( (string) $expires_at );
+				if ( false !== $ts && $ts <= $now ) {
+					continue;
+				}
+			}
+			$id = (string) ( $entry['id'] ?? ( 'secret_' . $index ) );
+			if ( '' === $id ) {
+				$id = 'secret_' . $index;
+			}
+			$active[] = array(
+				'id'    => $id,
+				'value' => $value,
+			);
+			++$index;
+		}
+
+		return $active;
+	}
+
+	/*
+	=================================================================
+	 * Helpers
+	 * ================================================================= */
+
+	/**
+	 * Lower-case array keys (top level only).
+	 *
+	 * @param array<string,mixed> $in
+	 * @return array<string,mixed>
+	 */
+	private static function lower_case_keys( array $in ): array {
+		$out = array();
+		foreach ( $in as $k => $v ) {
+			$out[ strtolower( (string) $k ) ] = $v;
+		}
+		return $out;
+	}
+
+	/**
+	 * strlen-safe split that handles an empty separator by returning the whole string.
+	 *
+	 * @param string $subject
+	 * @param string $separator
+	 * @return array<int,string>
+	 */
+	private static function split_preserve_empty( string $subject, string $separator ): array {
+		if ( '' === $separator ) {
+			return array( $subject );
+		}
+		return explode( $separator, $subject );
+	}
+}

--- a/inc/Cli/Commands/Flows/WebhookCommand.php
+++ b/inc/Cli/Commands/Flows/WebhookCommand.php
@@ -29,7 +29,7 @@ class WebhookCommand extends BaseCommand {
 	 */
 	public function dispatch( array $args, array $assoc_args ): void {
 		if ( empty( $args ) ) {
-			WP_CLI::error( 'Usage: wp datamachine flows webhook <enable|disable|regenerate|set-secret|status|list|rate-limit> [flow_id]' );
+			WP_CLI::error( 'Usage: wp datamachine flows webhook <enable|disable|regenerate|set-secret|rotate|forget|test|presets|status|list|rate-limit> [flow_id]' );
 			return;
 		}
 
@@ -50,6 +50,18 @@ class WebhookCommand extends BaseCommand {
 			case 'set_secret':
 				$this->set_secret( $remaining, $assoc_args );
 				break;
+			case 'rotate':
+				$this->rotate( $remaining, $assoc_args );
+				break;
+			case 'forget':
+				$this->forget( $remaining, $assoc_args );
+				break;
+			case 'test':
+				$this->test( $remaining, $assoc_args );
+				break;
+			case 'presets':
+				$this->presets( $remaining, $assoc_args );
+				break;
 			case 'status':
 				$this->status( $remaining, $assoc_args );
 				break;
@@ -60,7 +72,7 @@ class WebhookCommand extends BaseCommand {
 				$this->rate_limit( $remaining, $assoc_args );
 				break;
 			default:
-				WP_CLI::error( "Unknown webhook action: {$action}. Use: enable, disable, regenerate, set-secret, status, list, rate-limit" );
+				WP_CLI::error( "Unknown webhook action: {$action}. Use: enable, disable, regenerate, set-secret, rotate, forget, test, presets, status, list, rate-limit" );
 		}
 	}
 
@@ -104,6 +116,14 @@ class WebhookCommand extends BaseCommand {
 	 * [--secret=<value>]
 	 * : Use this explicit HMAC secret (e.g. the value you configured on the upstream service).
 	 *
+	 * [--secret-id=<id>]
+	 * : Optional secret id for multi-secret rotation (default: `current`).
+	 *
+	 * [--preset=<name>]
+	 * : Name of a preset registered via the `datamachine_webhook_auth_presets` filter.
+	 * Implies HMAC mode and resolves the full signing template server-side. Run
+	 * `wp datamachine flows webhook presets` to list available presets.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Enable with default Bearer auth
@@ -121,6 +141,9 @@ class WebhookCommand extends BaseCommand {
 	 *       --signature-header=X-Shopify-Hmac-Sha256 \
 	 *       --signature-format=base64 \
 	 *       --secret=<shopify_secret>
+	 *
+	 *     # Enable via a registered preset (Stripe, Slack, ...)
+	 *     wp datamachine flows webhook enable 42 --preset=stripe --secret=whsec_...
 	 *
 	 * @subcommand enable
 	 */
@@ -153,6 +176,12 @@ class WebhookCommand extends BaseCommand {
 		if ( isset( $assoc_args['secret'] ) ) {
 			$input['secret'] = (string) $assoc_args['secret'];
 		}
+		if ( isset( $assoc_args['secret-id'] ) ) {
+			$input['secret_id'] = (string) $assoc_args['secret-id'];
+		}
+		if ( isset( $assoc_args['preset'] ) ) {
+			$input['preset'] = (string) $assoc_args['preset'];
+		}
 
 		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
 		$result  = $ability->executeEnable( $input );
@@ -169,8 +198,12 @@ class WebhookCommand extends BaseCommand {
 		WP_CLI::log( sprintf( 'Auth mode: %s', $auth_mode ) );
 
 		if ( 'hmac_sha256' === $auth_mode ) {
-			WP_CLI::log( sprintf( 'Header:    %s', $result['signature_header'] ?? 'X-Hub-Signature-256' ) );
-			WP_CLI::log( sprintf( 'Format:    %s', $result['signature_format'] ?? 'sha256=hex' ) );
+			if ( ! empty( $result['preset'] ) ) {
+				WP_CLI::log( sprintf( 'Preset:    %s', $result['preset'] ) );
+			} else {
+				WP_CLI::log( sprintf( 'Header:    %s', $result['signature_header'] ?? 'X-Hub-Signature-256' ) );
+				WP_CLI::log( sprintf( 'Format:    %s', $result['signature_format'] ?? 'sha256=hex' ) );
+			}
 
 			if ( isset( $result['secret'] ) ) {
 				WP_CLI::log( sprintf( 'Secret:    %s', $result['secret'] ) );
@@ -178,7 +211,7 @@ class WebhookCommand extends BaseCommand {
 				WP_CLI::log( '' );
 				WP_CLI::log( 'Paste this secret into your webhook provider (e.g. GitHub → Settings → Webhooks → Secret).' );
 			} else {
-				WP_CLI::log( 'Secret:    (unchanged — use `set-secret` to rotate)' );
+				WP_CLI::log( 'Secret:    (unchanged — use `set-secret` or `rotate` to change)' );
 			}
 		} else {
 			WP_CLI::log( sprintf( 'Token:     %s', $result['token'] ) );
@@ -411,10 +444,24 @@ class WebhookCommand extends BaseCommand {
 			WP_CLI::log( sprintf( 'Created:   %s', $result['created_at'] ?? 'unknown' ) );
 
 			if ( 'hmac_sha256' === ( $result['auth_mode'] ?? 'bearer' ) ) {
-				WP_CLI::log( sprintf( 'Header:    %s', $result['signature_header'] ?? 'X-Hub-Signature-256' ) );
-				WP_CLI::log( sprintf( 'Format:    %s', $result['signature_format'] ?? 'sha256=hex' ) );
+				if ( ! empty( $result['preset'] ) ) {
+					WP_CLI::log( sprintf( 'Preset:    %s', $result['preset'] ) );
+				} else {
+					WP_CLI::log( sprintf( 'Header:    %s', $result['signature_header'] ?? 'X-Hub-Signature-256' ) );
+					WP_CLI::log( sprintf( 'Format:    %s', $result['signature_format'] ?? 'sha256=hex' ) );
+				}
 				if ( isset( $result['max_body_bytes'] ) ) {
 					WP_CLI::log( sprintf( 'Max body:  %d bytes', (int) $result['max_body_bytes'] ) );
+				}
+				if ( ! empty( $result['secret_ids'] ) ) {
+					WP_CLI::log( 'Secrets:' );
+					foreach ( $result['secret_ids'] as $entry ) {
+						$line = '  - ' . ( $entry['id'] ?? '' );
+						if ( ! empty( $entry['expires_at'] ) ) {
+							$line .= ' (expires ' . $entry['expires_at'] . ')';
+						}
+						WP_CLI::log( $line );
+					}
 				}
 			}
 		}
@@ -563,5 +610,313 @@ class WebhookCommand extends BaseCommand {
 		}
 
 		WP_CLI::success( $result['message'] );
+	}
+
+	/**
+	 * Rotate the HMAC shared secret with a grace period.
+	 *
+	 * Demotes `current` → `previous` (keeps verifying for --previous-ttl-seconds),
+	 * installs a fresh `current`. Use this when you want to swap secrets without
+	 * a downtime window: rotate here, update the provider, then forget `previous`.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <flow_id>
+	 * : The flow ID to rotate the secret for.
+	 *
+	 * [--secret=<value>]
+	 * : Explicit new secret value (takes precedence over --generate).
+	 *
+	 * [--generate]
+	 * : Generate a random 32-byte hex secret.
+	 *
+	 * [--previous-ttl-seconds=<seconds>]
+	 * : How long the old secret keeps verifying (default: 604800 = 7 days).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine flows webhook rotate 42 --generate
+	 *     wp datamachine flows webhook rotate 42 --secret=whsec_new... --previous-ttl-seconds=86400
+	 *
+	 * @subcommand rotate
+	 */
+	public function rotate( array $args, array $assoc_args ): void {
+		if ( empty( $args ) ) {
+			WP_CLI::error( 'Usage: wp datamachine flows webhook rotate <flow_id> (--generate | --secret=<value>) [--previous-ttl-seconds=<n>]' );
+			return;
+		}
+		$flow_id = (int) $args[0];
+		if ( $flow_id <= 0 ) {
+			WP_CLI::error( 'flow_id must be a positive integer' );
+			return;
+		}
+
+		$has_secret   = isset( $assoc_args['secret'] );
+		$has_generate = ! empty( $assoc_args['generate'] );
+		if ( ! $has_secret && ! $has_generate ) {
+			WP_CLI::error( 'Provide exactly one of --secret=<value> or --generate.' );
+			return;
+		}
+		if ( $has_secret && $has_generate ) {
+			WP_CLI::error( 'Pass either --secret=<value> or --generate, not both.' );
+			return;
+		}
+
+		$input = array( 'flow_id' => $flow_id );
+		if ( $has_secret ) {
+			$input['secret'] = (string) $assoc_args['secret'];
+		} else {
+			$input['generate'] = true;
+		}
+		if ( isset( $assoc_args['previous-ttl-seconds'] ) ) {
+			$input['previous_ttl_seconds'] = (int) $assoc_args['previous-ttl-seconds'];
+		}
+
+		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
+		$result  = $ability->executeRotateSecret( $input );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to rotate secret' );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] );
+		WP_CLI::log( sprintf( 'New secret:           %s', $result['new_secret'] ) );
+		WP_CLI::log( sprintf( 'Previous expires at:  %s', $result['previous_expires_at'] ) );
+		WP_CLI::warning( 'Save this secret now — it will not be shown again.' );
+
+		if ( ! empty( $result['secret_ids'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Active secret ids:' );
+			foreach ( $result['secret_ids'] as $entry ) {
+				$line = '  - ' . ( $entry['id'] ?? '' );
+				if ( ! empty( $entry['expires_at'] ) ) {
+					$line .= ' (expires ' . $entry['expires_at'] . ')';
+				}
+				WP_CLI::log( $line );
+			}
+		}
+	}
+
+	/**
+	 * Forget a specific secret by id.
+	 *
+	 * Removes the secret from the rotation list immediately — no grace window.
+	 * Typical use: `forget previous` after you've updated the provider side.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <flow_id>
+	 * : The flow ID.
+	 *
+	 * <secret_id>
+	 * : The secret id to forget (e.g. `previous`).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine flows webhook forget 42 previous
+	 *
+	 * @subcommand forget
+	 */
+	public function forget( array $args, array $assoc_args ): void {
+		if ( count( $args ) < 2 ) {
+			WP_CLI::error( 'Usage: wp datamachine flows webhook forget <flow_id> <secret_id>' );
+			return;
+		}
+		$flow_id   = (int) $args[0];
+		$secret_id = (string) $args[1];
+
+		if ( $flow_id <= 0 ) {
+			WP_CLI::error( 'flow_id must be a positive integer' );
+			return;
+		}
+
+		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
+		$result  = $ability->executeForgetSecret(
+			array(
+				'flow_id'   => $flow_id,
+				'secret_id' => $secret_id,
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to forget secret' );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] );
+	}
+
+	/**
+	 * Run offline signature verification against a captured payload.
+	 *
+	 * Invokes the verifier without spawning a job or hitting rate limits.
+	 * Useful for debugging upstream signature configuration or replaying
+	 * captured deliveries. Prints the full verification result including
+	 * which secret matched (if any) and the extracted timestamp skew.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <flow_id>
+	 * : The flow ID (its auth config is used for verification).
+	 *
+	 * [--body=<value>]
+	 * : Raw request body. Use @/path/to/file.json to read from disk.
+	 *
+	 * [--header=<header>]
+	 * : Request header in "Name: value" form. Repeatable.
+	 *
+	 * [--now=<unix_seconds>]
+	 * : Override "now" for deterministic replay-window checks.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Verify a captured GitHub ping payload
+	 *     wp datamachine flows webhook test 42 \\
+	 *       --body=@fixtures/github-ping.json \\
+	 *       --header="X-Hub-Signature-256: sha256=abc123..." \\
+	 *       --header="X-GitHub-Event: ping"
+	 *
+	 * @subcommand test
+	 * @when after_wp_load
+	 */
+	public function test( array $args, array $assoc_args ): void {
+		if ( empty( $args ) ) {
+			WP_CLI::error( 'Usage: wp datamachine flows webhook test <flow_id> [--body=@file.json] [--header="Name: value"]... [--now=<unix>]' );
+			return;
+		}
+		$flow_id = (int) $args[0];
+		if ( $flow_id <= 0 ) {
+			WP_CLI::error( 'flow_id must be a positive integer' );
+			return;
+		}
+
+		// --body may be literal or @path.
+		$body_arg = $assoc_args['body'] ?? '';
+		$body     = '';
+		if ( is_string( $body_arg ) && '' !== $body_arg ) {
+			if ( 0 === strpos( $body_arg, '@' ) ) {
+				$path = substr( $body_arg, 1 );
+				if ( ! is_readable( $path ) ) {
+					WP_CLI::error( sprintf( 'Cannot read body file: %s', $path ) );
+					return;
+				}
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				$body = (string) file_get_contents( $path );
+			} else {
+				$body = $body_arg;
+			}
+		}
+
+		// --header can be repeated; WP-CLI represents repeated flags as arrays when passed --header=foo --header=bar.
+		$raw_headers = array();
+		if ( isset( $assoc_args['header'] ) ) {
+			$raw_headers = is_array( $assoc_args['header'] ) ? $assoc_args['header'] : array( $assoc_args['header'] );
+		}
+		$headers = array();
+		foreach ( $raw_headers as $header_line ) {
+			$line = (string) $header_line;
+			$pos  = strpos( $line, ':' );
+			if ( false === $pos ) {
+				WP_CLI::warning( sprintf( 'Skipping malformed header (expected "Name: value"): %s', $line ) );
+				continue;
+			}
+			$name  = trim( substr( $line, 0, $pos ) );
+			$value = trim( substr( $line, $pos + 1 ) );
+			if ( '' === $name ) {
+				continue;
+			}
+			$headers[ $name ] = $value;
+		}
+
+		$input = array(
+			'flow_id' => $flow_id,
+			'body'    => $body,
+			'headers' => $headers,
+		);
+		if ( isset( $assoc_args['now'] ) ) {
+			$input['now'] = (int) $assoc_args['now'];
+		}
+
+		$ability = new \DataMachine\Abilities\Flow\WebhookTriggerAbility();
+		$result  = $ability->executeTest( $input );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Test failed' );
+			return;
+		}
+
+		if ( $result['ok'] ) {
+			WP_CLI::success( sprintf( 'Signature verified (secret_id=%s).', $result['secret_id'] ?? 'current' ) );
+		} else {
+			WP_CLI::warning( sprintf( 'Verification failed: %s', $result['reason'] ) );
+		}
+
+		WP_CLI::log( sprintf( 'Reason:        %s', $result['reason'] ) );
+		if ( isset( $result['secret_id'] ) ) {
+			WP_CLI::log( sprintf( 'Secret id:     %s', $result['secret_id'] ) );
+		}
+		if ( isset( $result['timestamp'] ) ) {
+			WP_CLI::log( sprintf( 'Timestamp:     %d', $result['timestamp'] ) );
+		}
+		if ( isset( $result['skew_seconds'] ) ) {
+			WP_CLI::log( sprintf( 'Skew seconds:  %d', $result['skew_seconds'] ) );
+		}
+		if ( ! empty( $result['detail'] ) ) {
+			WP_CLI::log( sprintf( 'Detail:        %s', $result['detail'] ) );
+		}
+	}
+
+	/**
+	 * List webhook auth presets registered via the
+	 * `datamachine_webhook_auth_presets` filter.
+	 *
+	 * Core ships zero presets. Third-party packages (or site-specific
+	 * mu-plugins) register them; this command simply displays what is available
+	 * on the current install.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine flows webhook presets
+	 *
+	 * @subcommand presets
+	 */
+	public function presets( array $args, array $assoc_args ): void {
+		$presets = \DataMachine\Api\WebhookAuthResolver::get_presets();
+
+		if ( empty( $presets ) ) {
+			WP_CLI::log( 'No presets registered. Add one via the datamachine_webhook_auth_presets filter.' );
+			return;
+		}
+
+		$rows = array();
+		foreach ( $presets as $name => $cfg ) {
+			$sig    = $cfg['signature_source'] ?? array();
+			$ts     = $cfg['timestamp_source'] ?? array();
+			$rows[] = array(
+				'name'             => (string) $name,
+				'mode'             => (string) ( $cfg['mode'] ?? 'hmac' ),
+				'algo'             => (string) ( $cfg['algo'] ?? 'sha256' ),
+				'signed_template'  => (string) ( $cfg['signed_template'] ?? '{body}' ),
+				'signature_header' => (string) ( $sig['header'] ?? ( $sig['param'] ?? '' ) ),
+				'encoding'         => (string) ( $sig['encoding'] ?? '' ),
+				'replay_tolerance' => isset( $cfg['tolerance_seconds'] ) ? (string) (int) $cfg['tolerance_seconds'] : '',
+				'has_timestamp'    => $ts ? 'yes' : 'no',
+			);
+		}
+
+		$this->format_items( $rows, array( 'name', 'mode', 'signed_template', 'signature_header', 'encoding', 'has_timestamp', 'replay_tolerance' ), $assoc_args, 'name' );
 	}
 }

--- a/tests/Unit/Api/WebhookAuthResolverTest.php
+++ b/tests/Unit/Api/WebhookAuthResolverTest.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * WebhookAuthResolver tests.
+ *
+ * Exercises the v1→v2 compatibility layer and the preset filter registry.
+ * Requires WordPress because `apply_filters` is used for preset discovery.
+ *
+ * @package DataMachine\Tests\Unit\Api
+ */
+
+namespace DataMachine\Tests\Unit\Api;
+
+use DataMachine\Api\WebhookAuthResolver;
+use WP_UnitTestCase;
+
+class WebhookAuthResolverTest extends WP_UnitTestCase {
+
+	public function tear_down(): void {
+		remove_all_filters( 'datamachine_webhook_auth_presets' );
+		parent::tear_down();
+	}
+
+	public function test_no_webhook_fields_resolves_to_bearer_with_empty_token(): void {
+		$out = WebhookAuthResolver::resolve( array() );
+		$this->assertSame( 'bearer', $out['mode'] );
+		$this->assertNull( $out['verifier'] );
+		$this->assertSame( '', $out['token'] );
+	}
+
+	public function test_v1_bearer_resolves_with_token(): void {
+		$out = WebhookAuthResolver::resolve( array(
+			'webhook_auth_mode' => 'bearer',
+			'webhook_token'     => 'abc',
+		) );
+		$this->assertSame( 'bearer', $out['mode'] );
+		$this->assertSame( 'abc', $out['token'] );
+	}
+
+	public function test_v1_hmac_sha256_expands_to_template_config(): void {
+		$out = WebhookAuthResolver::resolve( array(
+			'webhook_auth_mode'        => 'hmac_sha256',
+			'webhook_signature_header' => 'X-Hub-Signature-256',
+			'webhook_signature_format' => 'sha256=hex',
+			'webhook_secret'           => 'deadbeef',
+		) );
+
+		$this->assertSame( 'hmac', $out['mode'] );
+		$this->assertIsArray( $out['verifier'] );
+		$this->assertSame( '{body}', $out['verifier']['signed_template'] );
+		$this->assertSame( 'X-Hub-Signature-256', $out['verifier']['signature_source']['header'] );
+		$this->assertSame( 'prefix', $out['verifier']['signature_source']['extract']['kind'] );
+		$this->assertSame( 'sha256=', $out['verifier']['signature_source']['extract']['key'] );
+		$this->assertSame( 'hex', $out['verifier']['signature_source']['encoding'] );
+		$this->assertSame( 'deadbeef', $out['verifier']['secrets'][0]['value'] );
+	}
+
+	public function test_v1_hmac_sha256_base64_format_expands(): void {
+		$out = WebhookAuthResolver::resolve( array(
+			'webhook_auth_mode'        => 'hmac_sha256',
+			'webhook_signature_header' => 'X-Shopify-Hmac-Sha256',
+			'webhook_signature_format' => 'base64',
+			'webhook_secret'           => 'xxx',
+		) );
+
+		$this->assertSame( 'base64', $out['verifier']['signature_source']['encoding'] );
+		$this->assertSame( 'raw', $out['verifier']['signature_source']['extract']['kind'] );
+	}
+
+	public function test_v2_webhook_auth_block_passes_through(): void {
+		$config = array(
+			'mode'             => 'hmac',
+			'algo'             => 'sha256',
+			'signed_template'  => '{timestamp}.{body}',
+			'signature_source' => array( 'header' => 'X', 'extract' => array( 'kind' => 'raw' ), 'encoding' => 'hex' ),
+			'secrets'          => array( array( 'id' => 'current', 'value' => 'abc' ) ),
+		);
+		$out = WebhookAuthResolver::resolve( array( 'webhook_auth' => $config ) );
+
+		$this->assertSame( 'hmac', $out['mode'] );
+		$this->assertSame( '{timestamp}.{body}', $out['verifier']['signed_template'] );
+		$this->assertSame( 'abc', $out['verifier']['secrets'][0]['value'] );
+	}
+
+	public function test_v2_webhook_auth_inherits_scheduling_config_secrets(): void {
+		$config = array(
+			'mode'             => 'hmac',
+			'signed_template'  => '{body}',
+			'signature_source' => array( 'header' => 'X', 'extract' => array( 'kind' => 'raw' ), 'encoding' => 'hex' ),
+		);
+		$out = WebhookAuthResolver::resolve( array(
+			'webhook_auth'    => $config,
+			'webhook_secrets' => array(
+				array( 'id' => 'current', 'value' => 'xyz' ),
+			),
+		) );
+
+		$this->assertSame( 'xyz', $out['verifier']['secrets'][0]['value'] );
+	}
+
+	public function test_preset_lookup_via_filter(): void {
+		add_filter( 'datamachine_webhook_auth_presets', function ( $p ) {
+			$p['stripe'] = array(
+				'mode'             => 'hmac',
+				'algo'             => 'sha256',
+				'signed_template'  => '{timestamp}.{body}',
+				'signature_source' => array(
+					'header'   => 'Stripe-Signature',
+					'extract'  => array( 'kind' => 'kv_pairs', 'key' => 'v1', 'separator' => ',' ),
+					'encoding' => 'hex',
+				),
+				'timestamp_source' => array(
+					'header'  => 'Stripe-Signature',
+					'extract' => array( 'kind' => 'kv_pairs', 'key' => 't', 'separator' => ',' ),
+					'format'  => 'unix',
+				),
+				'tolerance_seconds' => 300,
+			);
+			return $p;
+		} );
+
+		$out = WebhookAuthResolver::resolve( array(
+			'webhook_auth_preset' => 'stripe',
+			'webhook_secret'      => 'whsec_abc',
+		) );
+
+		$this->assertSame( 'hmac', $out['mode'] );
+		$this->assertSame( 'stripe', $out['preset'] );
+		$this->assertSame( 'Stripe-Signature', $out['verifier']['signature_source']['header'] );
+		$this->assertSame( 'whsec_abc', $out['verifier']['secrets'][0]['value'] );
+	}
+
+	public function test_preset_with_overrides_merges_deeply(): void {
+		add_filter( 'datamachine_webhook_auth_presets', function ( $p ) {
+			$p['stripe'] = array(
+				'mode'             => 'hmac',
+				'tolerance_seconds' => 300,
+				'signature_source' => array( 'header' => 'Stripe-Signature', 'encoding' => 'hex' ),
+			);
+			return $p;
+		} );
+
+		$out = WebhookAuthResolver::resolve( array(
+			'webhook_auth_preset'    => 'stripe',
+			'webhook_auth_overrides' => array(
+				'tolerance_seconds' => 600,
+				'signature_source'  => array( 'header' => 'X-Custom' ),
+			),
+			'webhook_secret'         => 'x',
+		) );
+
+		$this->assertSame( 600, $out['verifier']['tolerance_seconds'] );
+		$this->assertSame( 'X-Custom', $out['verifier']['signature_source']['header'] );
+		$this->assertSame( 'hex', $out['verifier']['signature_source']['encoding'], 'Base encoding preserved via deep merge' );
+	}
+
+	public function test_unknown_preset_falls_through_to_v1_compat(): void {
+		// When the preset isn't registered, resolver falls back to legacy v1 fields.
+		$out = WebhookAuthResolver::resolve( array(
+			'webhook_auth_preset' => 'nonexistent',
+			'webhook_auth_mode'   => 'bearer',
+			'webhook_token'       => 'legacy',
+		) );
+
+		$this->assertSame( 'bearer', $out['mode'] );
+		$this->assertSame( 'legacy', $out['token'] );
+	}
+
+	public function test_get_presets_empty_by_default(): void {
+		$this->assertSame( array(), WebhookAuthResolver::get_presets() );
+	}
+
+	public function test_deep_merge_replaces_scalars_merges_arrays(): void {
+		$base = array(
+			'a' => 1,
+			'b' => array( 'x' => 1, 'y' => 2 ),
+			'c' => array( 'nested' => array( 'deep' => 'original' ) ),
+		);
+		$over = array(
+			'a' => 99,
+			'b' => array( 'y' => 20, 'z' => 30 ),
+			'c' => array( 'nested' => array( 'deep' => 'overridden', 'extra' => 'added' ) ),
+		);
+		$out = WebhookAuthResolver::deep_merge( $base, $over );
+
+		$this->assertSame( 99, $out['a'] );
+		$this->assertSame( 1, $out['b']['x'] );
+		$this->assertSame( 20, $out['b']['y'] );
+		$this->assertSame( 30, $out['b']['z'] );
+		$this->assertSame( 'overridden', $out['c']['nested']['deep'] );
+		$this->assertSame( 'added', $out['c']['nested']['extra'] );
+	}
+}

--- a/tests/Unit/Api/WebhookTriggerV2Test.php
+++ b/tests/Unit/Api/WebhookTriggerV2Test.php
@@ -1,0 +1,358 @@
+<?php
+/**
+ * WebhookTrigger v2 integration tests.
+ *
+ * Exercises the template-based verifier end-to-end through
+ * WebhookTrigger::handle_trigger(), plus the rotate / forget / test ability
+ * surfaces. Pure v1 regression coverage lives in WebhookTriggerTest.
+ *
+ * @package DataMachine\Tests\Unit\Api
+ */
+
+namespace DataMachine\Tests\Unit\Api;
+
+use DataMachine\Abilities\Flow\WebhookTriggerAbility;
+use DataMachine\Api\WebhookTrigger;
+use DataMachine\Core\Database\Flows\Flows;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
+class WebhookTriggerV2Test extends WP_UnitTestCase {
+
+	private int $flow_id;
+	private WebhookTriggerAbility $ability;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$pipeline = wp_get_ability( 'datamachine/create-pipeline' )->execute( array( 'pipeline_name' => 'v2 Pipeline' ) );
+		$flow     = wp_get_ability( 'datamachine/create-flow' )->execute( array(
+			'pipeline_id' => (int) $pipeline['pipeline_id'],
+			'flow_name'   => 'v2 Flow',
+		) );
+		$this->flow_id = (int) $flow['flow_id'];
+		$this->ability = new WebhookTriggerAbility();
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'datamachine_webhook_auth_presets' );
+		delete_transient( 'dm_webhook_rate_' . $this->flow_id );
+		parent::tear_down();
+	}
+
+	/* =================================================================
+	 * Preset resolution end-to-end through the REST handler
+	 * =================================================================
+	 */
+
+	public function test_enable_with_stripe_preset_and_trigger_succeeds(): void {
+		$this->register_stripe_preset();
+
+		$enable = $this->ability->executeEnable( array(
+			'flow_id'         => $this->flow_id,
+			'preset'          => 'stripe',
+			'generate_secret' => true,
+		) );
+
+		$this->assertTrue( $enable['success'] );
+		$this->assertSame( 'stripe', $enable['preset'] );
+		$secret = $enable['secret'];
+
+		// Build a fresh Stripe-signed request.
+		$ts      = time();
+		$body    = '{"id":"evt_123","type":"charge.succeeded"}';
+		$sig     = hash_hmac( 'sha256', $ts . '.' . $body, $secret );
+		$headers = array( 'stripe-signature' => "t={$ts},v1={$sig}" );
+
+		$request  = $this->make_request( $body, $headers );
+		$response = WebhookTrigger::handle_trigger( $request );
+
+		$this->assert_not_unauthorized( $response );
+	}
+
+	public function test_enable_with_stripe_preset_rejects_wrong_signature(): void {
+		$this->register_stripe_preset();
+		$this->ability->executeEnable( array(
+			'flow_id'         => $this->flow_id,
+			'preset'          => 'stripe',
+			'generate_secret' => true,
+		) );
+
+		$ts   = time();
+		$body = '{"id":"evt_123"}';
+		// Signed with a *different* secret.
+		$bad_sig = hash_hmac( 'sha256', $ts . '.' . $body, 'WRONG' );
+		$headers = array( 'stripe-signature' => "t={$ts},v1={$bad_sig}" );
+
+		$response = WebhookTrigger::handle_trigger( $this->make_request( $body, $headers ) );
+		$this->assert_is_unauthorized( $response );
+	}
+
+	public function test_enable_with_stripe_preset_rejects_stale_timestamp(): void {
+		$this->register_stripe_preset();
+		$enable = $this->ability->executeEnable( array(
+			'flow_id'         => $this->flow_id,
+			'preset'          => 'stripe',
+			'generate_secret' => true,
+		) );
+		$secret = $enable['secret'];
+
+		// Timestamp way outside the 300-second tolerance.
+		$ts      = time() - 3600;
+		$body    = '{"id":"evt"}';
+		$sig     = hash_hmac( 'sha256', $ts . '.' . $body, $secret );
+		$headers = array( 'stripe-signature' => "t={$ts},v1={$sig}" );
+
+		$response = WebhookTrigger::handle_trigger( $this->make_request( $body, $headers ) );
+		$this->assert_is_unauthorized( $response );
+	}
+
+	public function test_enable_with_unknown_preset_errors(): void {
+		$result = $this->ability->executeEnable( array(
+			'flow_id' => $this->flow_id,
+			'preset'  => 'no-such-preset',
+		) );
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'Unknown preset', $result['error'] );
+	}
+
+	/* =================================================================
+	 * Rotate + forget lifecycle
+	 * =================================================================
+	 */
+
+	public function test_rotate_keeps_previous_secret_verifying_until_expiry(): void {
+		// Enable with v1 shorthand.
+		$enable = $this->ability->executeEnable( array(
+			'flow_id'         => $this->flow_id,
+			'auth_mode'       => 'hmac_sha256',
+			'generate_secret' => true,
+		) );
+		$old_secret = $enable['secret'];
+
+		// Rotate to a new secret with a 1-hour grace.
+		$rotated = $this->ability->executeRotateSecret( array(
+			'flow_id'              => $this->flow_id,
+			'generate'             => true,
+			'previous_ttl_seconds' => 3600,
+		) );
+		$this->assertTrue( $rotated['success'] );
+		$this->assertNotEmpty( $rotated['new_secret'] );
+		$this->assertNotEmpty( $rotated['previous_expires_at'] );
+
+		// Request signed with the *old* secret — still works during grace.
+		$body = '{"hello":"world"}';
+		$sig  = 'sha256=' . hash_hmac( 'sha256', $body, $old_secret );
+		$response = WebhookTrigger::handle_trigger( $this->make_request( $body, array(
+			'x-hub-signature-256' => $sig,
+		) ) );
+		$this->assert_not_unauthorized( $response );
+
+		// Request signed with the *new* secret — also works.
+		$new_sig = 'sha256=' . hash_hmac( 'sha256', $body, $rotated['new_secret'] );
+		$response = WebhookTrigger::handle_trigger( $this->make_request( $body, array(
+			'x-hub-signature-256' => $new_sig,
+		) ) );
+		$this->assert_not_unauthorized( $response );
+	}
+
+	public function test_forget_previous_secret_invalidates_it(): void {
+		$enable = $this->ability->executeEnable( array(
+			'flow_id'         => $this->flow_id,
+			'auth_mode'       => 'hmac_sha256',
+			'generate_secret' => true,
+		) );
+		$old_secret = $enable['secret'];
+
+		$this->ability->executeRotateSecret( array(
+			'flow_id'              => $this->flow_id,
+			'generate'             => true,
+			'previous_ttl_seconds' => 3600,
+		) );
+
+		$forget = $this->ability->executeForgetSecret( array(
+			'flow_id'   => $this->flow_id,
+			'secret_id' => 'previous',
+		) );
+		$this->assertTrue( $forget['success'] );
+
+		// Old secret no longer verifies.
+		$body = '{"x":1}';
+		$sig  = 'sha256=' . hash_hmac( 'sha256', $body, $old_secret );
+		$response = WebhookTrigger::handle_trigger( $this->make_request( $body, array(
+			'x-hub-signature-256' => $sig,
+		) ) );
+		$this->assert_is_unauthorized( $response );
+	}
+
+	public function test_forget_unknown_secret_id_errors(): void {
+		$this->ability->executeEnable( array(
+			'flow_id'         => $this->flow_id,
+			'auth_mode'       => 'hmac_sha256',
+			'generate_secret' => true,
+		) );
+		$forget = $this->ability->executeForgetSecret( array(
+			'flow_id'   => $this->flow_id,
+			'secret_id' => 'nonexistent',
+		) );
+		$this->assertFalse( $forget['success'] );
+		$this->assertStringContainsString( 'No secret', $forget['error'] );
+	}
+
+	/* =================================================================
+	 * Offline test ability
+	 * =================================================================
+	 */
+
+	public function test_executeTest_ok_path(): void {
+		$enable = $this->ability->executeEnable( array(
+			'flow_id'         => $this->flow_id,
+			'auth_mode'       => 'hmac_sha256',
+			'generate_secret' => true,
+		) );
+		$secret = $enable['secret'];
+
+		$body = '{"hello":"test"}';
+		$sig  = 'sha256=' . hash_hmac( 'sha256', $body, $secret );
+
+		$result = $this->ability->executeTest( array(
+			'flow_id' => $this->flow_id,
+			'body'    => $body,
+			'headers' => array( 'X-Hub-Signature-256' => $sig ),
+		) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertTrue( $result['ok'] );
+		$this->assertSame( 'ok', $result['reason'] );
+		$this->assertSame( 'current', $result['secret_id'] );
+	}
+
+	public function test_executeTest_reports_bad_signature(): void {
+		$this->ability->executeEnable( array(
+			'flow_id'         => $this->flow_id,
+			'auth_mode'       => 'hmac_sha256',
+			'generate_secret' => true,
+		) );
+
+		$result = $this->ability->executeTest( array(
+			'flow_id' => $this->flow_id,
+			'body'    => '{"x":1}',
+			'headers' => array( 'X-Hub-Signature-256' => 'sha256=' . str_repeat( 'f', 64 ) ),
+		) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( $result['ok'] );
+		$this->assertSame( 'bad_signature', $result['reason'] );
+	}
+
+	public function test_executeTest_refuses_bearer_flows(): void {
+		$this->ability->executeEnable( array( 'flow_id' => $this->flow_id ) ); // bearer default
+		$result = $this->ability->executeTest( array(
+			'flow_id' => $this->flow_id,
+			'body'    => '',
+			'headers' => array(),
+		) );
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'HMAC', $result['error'] );
+	}
+
+	/* =================================================================
+	 * Status surfaces new v2 fields without leaking secrets
+	 * =================================================================
+	 */
+
+	public function test_status_exposes_secret_ids_without_values(): void {
+		$this->ability->executeEnable( array(
+			'flow_id'         => $this->flow_id,
+			'auth_mode'       => 'hmac_sha256',
+			'generate_secret' => true,
+		) );
+		$this->ability->executeRotateSecret( array(
+			'flow_id'              => $this->flow_id,
+			'generate'             => true,
+			'previous_ttl_seconds' => 3600,
+		) );
+
+		$status = $this->ability->executeStatus( array( 'flow_id' => $this->flow_id ) );
+
+		$this->assertTrue( $status['success'] );
+		$this->assertArrayHasKey( 'secret_ids', $status );
+		$ids = array_column( $status['secret_ids'], 'id' );
+		$this->assertContains( 'current', $ids );
+		$this->assertContains( 'previous', $ids );
+
+		// Secret *values* must never appear in the response payload.
+		$encoded = wp_json_encode( $status );
+		$this->assertStringNotContainsString( '"value"', $encoded );
+	}
+
+	public function test_status_exposes_preset_name(): void {
+		$this->register_stripe_preset();
+		$this->ability->executeEnable( array(
+			'flow_id'         => $this->flow_id,
+			'preset'          => 'stripe',
+			'generate_secret' => true,
+		) );
+		$status = $this->ability->executeStatus( array( 'flow_id' => $this->flow_id ) );
+		$this->assertSame( 'stripe', $status['preset'] );
+	}
+
+	/* =================================================================
+	 * Helpers
+	 * =================================================================
+	 */
+
+	private function register_stripe_preset(): void {
+		add_filter( 'datamachine_webhook_auth_presets', function ( $p ) {
+			$p['stripe'] = array(
+				'mode'             => 'hmac',
+				'algo'             => 'sha256',
+				'signed_template'  => '{timestamp}.{body}',
+				'signature_source' => array(
+					'header'   => 'Stripe-Signature',
+					'extract'  => array( 'kind' => 'kv_pairs', 'key' => 'v1', 'separator' => ',' ),
+					'encoding' => 'hex',
+				),
+				'timestamp_source' => array(
+					'header'  => 'Stripe-Signature',
+					'extract' => array( 'kind' => 'kv_pairs', 'key' => 't', 'separator' => ',' ),
+					'format'  => 'unix',
+				),
+				'tolerance_seconds' => 300,
+			);
+			return $p;
+		} );
+	}
+
+	private function make_request( string $body, array $headers ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/datamachine/v1/trigger/' . $this->flow_id );
+		$request->set_url_params( array( 'flow_id' => $this->flow_id ) );
+		$request->set_param( 'flow_id', $this->flow_id );
+		$request->set_header( 'content-type', 'application/json' );
+		foreach ( $headers as $k => $v ) {
+			$request->set_header( $k, $v );
+		}
+		$request->set_body( $body );
+		return $request;
+	}
+
+	private function assert_is_unauthorized( $response ): void {
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 401, $response->get_error_data()['status'] );
+	}
+
+	private function assert_not_unauthorized( $response ): void {
+		if ( $response instanceof \WP_Error ) {
+			$this->assertNotSame(
+				401,
+				$response->get_error_data()['status'] ?? null,
+				'Expected auth pass, got: ' . $response->get_error_message()
+			);
+		} else {
+			$this->assertTrue( true );
+		}
+	}
+}

--- a/tests/Unit/Api/WebhookVerifierTest.php
+++ b/tests/Unit/Api/WebhookVerifierTest.php
@@ -1,0 +1,608 @@
+<?php
+/**
+ * WebhookVerifier unit tests.
+ *
+ * Pure unit tests — no WordPress bootstrap required.
+ *
+ * The core exercise is a data-driven provider matrix: each entry builds a
+ * realistic signed request, hands it to the verifier, and asserts the result.
+ * If this grid passes end-to-end, the template engine covers every provider
+ * in it with zero provider-specific code.
+ *
+ * @package DataMachine\Tests\Unit\Api
+ */
+
+// Stub apply_filters in the verifier's namespace so pure unit tests don't need WordPress.
+// Only defined when WordPress isn't already loaded.
+namespace DataMachine\Api {
+	if ( ! function_exists( __NAMESPACE__ . '\\apply_filters' ) && ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( $hook, $value ) { // phpcs:ignore
+			return $value;
+		}
+	}
+}
+
+namespace DataMachine\Tests\Unit\Api {
+
+	use DataMachine\Api\WebhookVerifier;
+	use DataMachine\Api\WebhookVerificationResult;
+	use PHPUnit\Framework\TestCase;
+
+	class WebhookVerifierTest extends TestCase {
+
+		private const SECRET = 'super-secret-value';
+		private const BODY   = '{"action":"opened","number":1}';
+
+		/* =================================================================
+		 * Provider matrix — the proof-of-coverage
+		 * ================================================================= */
+
+		/**
+		 * @dataProvider providerMatrix
+		 */
+		public function test_provider_matrix_accepts_valid_signature( string $name, array $config, array $headers, string $body, int $now, ?int $timestamp ): void {
+			$result = WebhookVerifier::verify( $body, $headers, array(), array(), 'https://example.com/wp-json/datamachine/v1/trigger/42', $config, $now );
+
+			$this->assertTrue(
+				$result->ok,
+				sprintf( '[%s] expected ok, got reason=%s detail=%s', $name, $result->reason, $result->detail ?? '' )
+			);
+			if ( null !== $timestamp ) {
+				$this->assertSame( $timestamp, $result->timestamp, "[{$name}] timestamp should be extracted" );
+			}
+		}
+
+		/**
+		 * @dataProvider providerMatrix
+		 */
+		public function test_provider_matrix_rejects_tampered_body( string $name, array $config, array $headers, string $body, int $now ): void {
+			// Some provider templates deliberately don't sign the body (Mailgun signs
+			// {timestamp}{token}). For those we verify the matrix proves the engine
+			// routes extraction correctly — the rejection is better covered by the
+			// wrong-secret test.
+			if ( '' === $body || false === strpos( (string) $config['signed_template'], '{body}' ) ) {
+				$this->assertTrue( true );
+				return;
+			}
+			$result = WebhookVerifier::verify( $body . 'TAMPER', $headers, array(), array(), 'https://example.com/', $config, $now );
+			$this->assertFalse( $result->ok, "[{$name}] tampered body should not verify" );
+		}
+
+		/**
+		 * @dataProvider providerMatrix
+		 */
+		public function test_provider_matrix_rejects_wrong_secret( string $name, array $config, array $headers, string $body, int $now ): void {
+			$config['secrets'] = array( array( 'id' => 'current', 'value' => 'wrong-secret-value' ) );
+			$result = WebhookVerifier::verify( $body, $headers, array(), array(), 'https://example.com/', $config, $now );
+			$this->assertFalse( $result->ok, "[{$name}] wrong secret should not verify" );
+		}
+
+		/**
+		 * Yields one entry per provider, fully self-contained.
+		 *
+		 * Each entry returns:
+		 *   [ name, verifier_config, headers, body, now, extracted_timestamp|null ]
+		 */
+		public function providerMatrix(): array {
+			$secret = self::SECRET;
+			$body   = self::BODY;
+			$now    = 1700000000;
+			$ts     = 1700000000;
+
+			$cases = array();
+
+			$cases['github'] = array(
+				'github',
+				array(
+					'mode'             => 'hmac',
+					'algo'             => 'sha256',
+					'signed_template'  => '{body}',
+					'signature_source' => array(
+						'header'   => 'X-Hub-Signature-256',
+						'extract'  => array( 'kind' => 'prefix', 'key' => 'sha256=' ),
+						'encoding' => 'hex',
+					),
+					'secrets'          => array( array( 'id' => 'current', 'value' => $secret ) ),
+				),
+				array(
+					'x-hub-signature-256' => 'sha256=' . hash_hmac( 'sha256', $body, $secret ),
+					'x-github-event'      => 'push',
+				),
+				$body,
+				$now,
+				null,
+			);
+
+			$cases['shopify'] = array(
+				'shopify',
+				array(
+					'mode'             => 'hmac',
+					'algo'             => 'sha256',
+					'signed_template'  => '{body}',
+					'signature_source' => array(
+						'header'   => 'X-Shopify-Hmac-Sha256',
+						'extract'  => array( 'kind' => 'raw' ),
+						'encoding' => 'base64',
+					),
+					'secrets'          => array( array( 'id' => 'current', 'value' => $secret ) ),
+				),
+				array(
+					'x-shopify-hmac-sha256' => base64_encode( hash_hmac( 'sha256', $body, $secret, true ) ),
+					'x-shopify-topic'       => 'orders/create',
+				),
+				$body,
+				$now,
+				null,
+			);
+
+			$cases['linear'] = array(
+				'linear',
+				array(
+					'mode'             => 'hmac',
+					'algo'             => 'sha256',
+					'signed_template'  => '{body}',
+					'signature_source' => array(
+						'header'   => 'Linear-Signature',
+						'extract'  => array( 'kind' => 'raw' ),
+						'encoding' => 'hex',
+					),
+					'secrets'          => array( array( 'id' => 'current', 'value' => $secret ) ),
+				),
+				array( 'linear-signature' => hash_hmac( 'sha256', $body, $secret ) ),
+				$body,
+				$now,
+				null,
+			);
+
+			$stripe_sig      = hash_hmac( 'sha256', $ts . '.' . $body, $secret );
+			$cases['stripe'] = array(
+				'stripe',
+				array(
+					'mode'             => 'hmac',
+					'algo'             => 'sha256',
+					'signed_template'  => '{timestamp}.{body}',
+					'signature_source' => array(
+						'header'   => 'Stripe-Signature',
+						'extract'  => array( 'kind' => 'kv_pairs', 'key' => 'v1', 'separator' => ',' ),
+						'encoding' => 'hex',
+					),
+					'timestamp_source' => array(
+						'header'  => 'Stripe-Signature',
+						'extract' => array( 'kind' => 'kv_pairs', 'key' => 't', 'separator' => ',' ),
+						'format'  => 'unix',
+					),
+					'tolerance_seconds' => 300,
+					'secrets'           => array( array( 'id' => 'current', 'value' => $secret ) ),
+				),
+				array(
+					'stripe-signature' => "t={$ts},v1={$stripe_sig},v0=unused",
+				),
+				$body,
+				$now,
+				$ts,
+			);
+
+			$slack_sig      = hash_hmac( 'sha256', 'v0:' . $ts . ':' . $body, $secret );
+			$cases['slack'] = array(
+				'slack',
+				array(
+					'mode'             => 'hmac',
+					'algo'             => 'sha256',
+					'signed_template'  => 'v0:{timestamp}:{body}',
+					'signature_source' => array(
+						'header'   => 'X-Slack-Signature',
+						'extract'  => array( 'kind' => 'prefix', 'key' => 'v0=' ),
+						'encoding' => 'hex',
+					),
+					'timestamp_source' => array(
+						'header'  => 'X-Slack-Request-Timestamp',
+						'extract' => array( 'kind' => 'raw' ),
+						'format'  => 'unix',
+					),
+					'tolerance_seconds' => 300,
+					'secrets'           => array( array( 'id' => 'current', 'value' => $secret ) ),
+				),
+				array(
+					'x-slack-signature'         => 'v0=' . $slack_sig,
+					'x-slack-request-timestamp' => (string) $ts,
+				),
+				$body,
+				$now,
+				$ts,
+			);
+
+			$svix_id       = 'msg_abc123';
+			$svix_body     = $svix_id . '.' . $ts . '.' . $body;
+			$svix_sig      = base64_encode( hash_hmac( 'sha256', $svix_body, $secret, true ) );
+			$cases['svix'] = array(
+				'svix',
+				array(
+					'mode'             => 'hmac',
+					'algo'             => 'sha256',
+					'signed_template'  => '{id}.{timestamp}.{body}',
+					'signature_source' => array(
+						'header'   => 'Webhook-Signature',
+						'extract'  => array( 'kind' => 'kv_pairs', 'key' => 'v1', 'separator' => ' ', 'pair_separator' => ',' ),
+						'encoding' => 'base64',
+					),
+					'timestamp_source'  => array(
+						'header'  => 'Webhook-Timestamp',
+						'extract' => array( 'kind' => 'raw' ),
+						'format'  => 'unix',
+					),
+					'id_source'         => array( 'header' => 'Webhook-Id' ),
+					'tolerance_seconds' => 300,
+					'secrets'           => array( array( 'id' => 'current', 'value' => $secret ) ),
+				),
+				array(
+					'webhook-id'        => $svix_id,
+					'webhook-timestamp' => (string) $ts,
+					'webhook-signature' => "v1,{$svix_sig}",
+				),
+				$body,
+				$now,
+				$ts,
+			);
+
+			$mg_token         = 'tok_abc';
+			$mg_body          = $ts . $mg_token;
+			$cases['mailgun'] = array(
+				'mailgun',
+				array(
+					'mode'             => 'hmac',
+					'algo'             => 'sha256',
+					'signed_template'  => '{timestamp}{header:X-Mailgun-Token}',
+					'signature_source' => array(
+						'header'   => 'X-Mailgun-Signature',
+						'extract'  => array( 'kind' => 'raw' ),
+						'encoding' => 'hex',
+					),
+					'timestamp_source'  => array(
+						'header'  => 'X-Mailgun-Timestamp',
+						'extract' => array( 'kind' => 'raw' ),
+						'format'  => 'unix',
+					),
+					'tolerance_seconds' => 600,
+					'secrets'           => array( array( 'id' => 'current', 'value' => $secret ) ),
+				),
+				array(
+					'x-mailgun-timestamp' => (string) $ts,
+					'x-mailgun-token'     => $mg_token,
+					'x-mailgun-signature' => hash_hmac( 'sha256', $mg_body, $secret ),
+				),
+				$body,
+				$now,
+				$ts,
+			);
+
+			$cases['paypal'] = array(
+				'paypal',
+				array(
+					'mode'             => 'hmac',
+					'algo'             => 'sha256',
+					'signed_template'  => '{body}',
+					'signature_source' => array(
+						'header'   => 'Paypal-Transmission-Sig',
+						'extract'  => array( 'kind' => 'raw' ),
+						'encoding' => 'base64',
+					),
+					'secrets'          => array( array( 'id' => 'current', 'value' => $secret ) ),
+				),
+				array(
+					'paypal-transmission-sig' => base64_encode( hash_hmac( 'sha256', $body, $secret, true ) ),
+				),
+				$body,
+				$now,
+				null,
+			);
+
+			$clerk_id       = 'evt_xyz';
+			$clerk_body     = $clerk_id . '.' . $ts . '.' . $body;
+			$clerk_sig      = base64_encode( hash_hmac( 'sha256', $clerk_body, $secret, true ) );
+			$cases['clerk'] = array(
+				'clerk',
+				array(
+					'mode'             => 'hmac',
+					'algo'             => 'sha256',
+					'signed_template'  => '{header:svix-id}.{header:svix-timestamp}.{body}',
+					'signature_source' => array(
+						'header'   => 'svix-signature',
+						'extract'  => array( 'kind' => 'kv_pairs', 'key' => 'v1', 'separator' => ' ', 'pair_separator' => ',' ),
+						'encoding' => 'base64',
+					),
+					'timestamp_source'  => array(
+						'header'  => 'svix-timestamp',
+						'extract' => array( 'kind' => 'raw' ),
+						'format'  => 'unix',
+					),
+					'tolerance_seconds' => 300,
+					'secrets'           => array( array( 'id' => 'current', 'value' => $secret ) ),
+				),
+				array(
+					'svix-id'        => $clerk_id,
+					'svix-timestamp' => (string) $ts,
+					'svix-signature' => "v1,{$clerk_sig}",
+				),
+				$body,
+				$now,
+				$ts,
+			);
+
+			return $cases;
+		}
+
+		/* =================================================================
+		 * Replay / rotation / security edges
+		 * ================================================================= */
+
+		public function test_stale_timestamp_rejected(): void {
+			$ts     = 1700000000;
+			$now    = $ts + 3600;
+			$secret = self::SECRET;
+			$body   = self::BODY;
+
+			$config  = array(
+				'mode'             => 'hmac',
+				'algo'             => 'sha256',
+				'signed_template'  => '{timestamp}.{body}',
+				'signature_source' => array(
+					'header'   => 'Stripe-Signature',
+					'extract'  => array( 'kind' => 'kv_pairs', 'key' => 'v1', 'separator' => ',' ),
+					'encoding' => 'hex',
+				),
+				'timestamp_source' => array(
+					'header'  => 'Stripe-Signature',
+					'extract' => array( 'kind' => 'kv_pairs', 'key' => 't', 'separator' => ',' ),
+					'format'  => 'unix',
+				),
+				'tolerance_seconds' => 300,
+				'secrets'           => array( array( 'id' => 'current', 'value' => $secret ) ),
+			);
+			$sig     = hash_hmac( 'sha256', $ts . '.' . $body, $secret );
+			$headers = array( 'stripe-signature' => "t={$ts},v1={$sig}" );
+
+			$result = WebhookVerifier::verify( $body, $headers, array(), array(), 'https://example.com/', $config, $now );
+			$this->assertFalse( $result->ok );
+			$this->assertSame( WebhookVerificationResult::STALE_TIMESTAMP, $result->reason );
+			$this->assertSame( 3600, $result->skew_seconds );
+		}
+
+		public function test_fresh_timestamp_accepted(): void {
+			$ts     = 1700000000;
+			$now    = $ts + 60;
+			$secret = self::SECRET;
+			$body   = self::BODY;
+
+			$config  = array(
+				'mode'             => 'hmac',
+				'algo'             => 'sha256',
+				'signed_template'  => '{timestamp}.{body}',
+				'signature_source' => array(
+					'header'   => 'Stripe-Signature',
+					'extract'  => array( 'kind' => 'kv_pairs', 'key' => 'v1', 'separator' => ',' ),
+					'encoding' => 'hex',
+				),
+				'timestamp_source' => array(
+					'header'  => 'Stripe-Signature',
+					'extract' => array( 'kind' => 'kv_pairs', 'key' => 't', 'separator' => ',' ),
+					'format'  => 'unix',
+				),
+				'tolerance_seconds' => 300,
+				'secrets'           => array( array( 'id' => 'current', 'value' => $secret ) ),
+			);
+			$sig     = hash_hmac( 'sha256', $ts . '.' . $body, $secret );
+			$headers = array( 'stripe-signature' => "t={$ts},v1={$sig}" );
+
+			$result = WebhookVerifier::verify( $body, $headers, array(), array(), 'https://example.com/', $config, $now );
+			$this->assertTrue( $result->ok, $result->reason . ' ' . ( $result->detail ?? '' ) );
+		}
+
+		public function test_multi_secret_rotation_previous_still_verifies(): void {
+			$secret_new = 'NEW-secret-value';
+			$secret_old = 'OLD-secret-value';
+			$body       = self::BODY;
+			$now        = 1700000000;
+
+			$config = array(
+				'mode'             => 'hmac',
+				'algo'             => 'sha256',
+				'signed_template'  => '{body}',
+				'signature_source' => array(
+					'header'   => 'X-Hub-Signature-256',
+					'extract'  => array( 'kind' => 'prefix', 'key' => 'sha256=' ),
+					'encoding' => 'hex',
+				),
+				'secrets' => array(
+					array( 'id' => 'current',  'value' => $secret_new ),
+					array( 'id' => 'previous', 'value' => $secret_old, 'expires_at' => $now + 3600 ),
+				),
+			);
+
+			$sig    = 'sha256=' . hash_hmac( 'sha256', $body, $secret_old );
+			$result = WebhookVerifier::verify( $body, array( 'x-hub-signature-256' => $sig ), array(), array(), 'https://example.com/', $config, $now );
+
+			$this->assertTrue( $result->ok );
+			$this->assertSame( 'previous', $result->secret_id );
+		}
+
+		public function test_expired_previous_secret_is_skipped(): void {
+			$secret_new = 'NEW';
+			$secret_old = 'OLD';
+			$body       = self::BODY;
+			$now        = 1700000000;
+
+			$config = array(
+				'mode'             => 'hmac',
+				'algo'             => 'sha256',
+				'signed_template'  => '{body}',
+				'signature_source' => array(
+					'header'   => 'X-Hub-Signature-256',
+					'extract'  => array( 'kind' => 'prefix', 'key' => 'sha256=' ),
+					'encoding' => 'hex',
+				),
+				'secrets' => array(
+					array( 'id' => 'current',  'value' => $secret_new ),
+					array( 'id' => 'previous', 'value' => $secret_old, 'expires_at' => $now - 1 ),
+				),
+			);
+
+			$sig    = 'sha256=' . hash_hmac( 'sha256', $body, $secret_old );
+			$result = WebhookVerifier::verify( $body, array( 'x-hub-signature-256' => $sig ), array(), array(), 'https://example.com/', $config, $now );
+
+			$this->assertFalse( $result->ok );
+			$this->assertSame( WebhookVerificationResult::BAD_SIGNATURE, $result->reason );
+		}
+
+		public function test_missing_signature_header_reported(): void {
+			$config = array(
+				'mode'             => 'hmac',
+				'algo'             => 'sha256',
+				'signed_template'  => '{body}',
+				'signature_source' => array(
+					'header'   => 'X-Hub-Signature-256',
+					'extract'  => array( 'kind' => 'raw' ),
+					'encoding' => 'hex',
+				),
+				'secrets'          => array( array( 'id' => 'current', 'value' => self::SECRET ) ),
+			);
+			$result = WebhookVerifier::verify( self::BODY, array(), array(), array(), 'https://example.com/', $config );
+			$this->assertFalse( $result->ok );
+			$this->assertSame( WebhookVerificationResult::MISSING_HEADER, $result->reason );
+		}
+
+		public function test_payload_too_large(): void {
+			$config = array(
+				'mode'             => 'hmac',
+				'algo'             => 'sha256',
+				'signed_template'  => '{body}',
+				'signature_source' => array(
+					'header'   => 'X-Hub-Signature-256',
+					'extract'  => array( 'kind' => 'raw' ),
+					'encoding' => 'hex',
+				),
+				'secrets'          => array( array( 'id' => 'current', 'value' => self::SECRET ) ),
+				'max_body_bytes'   => 16,
+			);
+			$big    = str_repeat( 'a', 128 );
+			$result = WebhookVerifier::verify(
+				$big,
+				array( 'x-hub-signature-256' => hash_hmac( 'sha256', $big, self::SECRET ) ),
+				array(),
+				array(),
+				'https://example.com/',
+				$config
+			);
+			$this->assertFalse( $result->ok );
+			$this->assertSame( WebhookVerificationResult::PAYLOAD_TOO_LARGE, $result->reason );
+		}
+
+		public function test_no_active_secrets_fails_fast(): void {
+			$now    = 1700000000;
+			$config = array(
+				'mode'             => 'hmac',
+				'algo'             => 'sha256',
+				'signed_template'  => '{body}',
+				'signature_source' => array(
+					'header'   => 'X-Hub-Signature-256',
+					'extract'  => array( 'kind' => 'raw' ),
+					'encoding' => 'hex',
+				),
+				'secrets' => array(
+					array( 'id' => 'expired', 'value' => 'x', 'expires_at' => $now - 10 ),
+				),
+			);
+			$result = WebhookVerifier::verify( self::BODY, array( 'x-hub-signature-256' => 'abc' ), array(), array(), 'https://example.com/', $config, $now );
+			$this->assertFalse( $result->ok );
+			$this->assertSame( WebhookVerificationResult::NO_ACTIVE_SECRET, $result->reason );
+		}
+
+		public function test_malformed_template_rejected(): void {
+			$config = array(
+				'mode'             => 'hmac',
+				'algo'             => 'sha256',
+				'signed_template'  => '{unknown_placeholder}',
+				'signature_source' => array(
+					'header'   => 'X',
+					'extract'  => array( 'kind' => 'raw' ),
+					'encoding' => 'hex',
+				),
+				'secrets'          => array( array( 'id' => 'c', 'value' => self::SECRET ) ),
+			);
+			// Use a valid-shape hex signature so we reach the template render step.
+			$result = WebhookVerifier::verify(
+				self::BODY,
+				array( 'x' => str_repeat( 'a', 64 ) ),
+				array(),
+				array(),
+				'https://example.com/',
+				$config
+			);
+			$this->assertFalse( $result->ok );
+			$this->assertSame( WebhookVerificationResult::MALFORMED_TEMPLATE, $result->reason );
+		}
+
+		public function test_unknown_mode_routes_to_filter_registry(): void {
+			$config = array( 'mode' => 'ed25519' );
+			$result = WebhookVerifier::verify( '', array(), array(), array(), '', $config );
+			$this->assertFalse( $result->ok );
+			$this->assertSame( WebhookVerificationResult::UNKNOWN_MODE, $result->reason );
+		}
+
+		public function test_url_and_param_placeholders(): void {
+			// Twilio-ish: signed string = url + concat post params in template order.
+			$url    = 'https://example.com/twilio/webhook';
+			$secret = self::SECRET;
+			$signed = $url . '+15005550006' . '+15005550001';
+
+			$config  = array(
+				'mode'             => 'hmac',
+				'algo'             => 'sha1',
+				'signed_template'  => '{url}{param:From}{param:To}',
+				'signature_source' => array(
+					'header'   => 'X-Twilio-Signature',
+					'extract'  => array( 'kind' => 'raw' ),
+					'encoding' => 'base64',
+				),
+				'secrets'          => array( array( 'id' => 'current', 'value' => $secret ) ),
+			);
+			$headers = array(
+				'x-twilio-signature' => base64_encode( hash_hmac( 'sha1', $signed, $secret, true ) ),
+			);
+			$post    = array( 'From' => '+15005550006', 'To' => '+15005550001' );
+
+			$result = WebhookVerifier::verify( '', $headers, array(), $post, $url, $config );
+			$this->assertTrue( $result->ok, $result->reason . ' detail=' . ( $result->detail ?? '' ) );
+		}
+
+		public function test_unix_ms_timestamp_parsed(): void {
+			$ts_sec = 1700000000;
+			$ts_ms  = $ts_sec * 1000;
+			$body   = self::BODY;
+			$now    = $ts_sec;
+			$sig    = hash_hmac( 'sha256', $ts_sec . '.' . $body, self::SECRET );
+
+			$config  = array(
+				'mode'             => 'hmac',
+				'algo'             => 'sha256',
+				'signed_template'  => '{timestamp}.{body}',
+				'signature_source' => array(
+					'header'   => 'X-Sig',
+					'extract'  => array( 'kind' => 'raw' ),
+					'encoding' => 'hex',
+				),
+				'timestamp_source' => array(
+					'header'  => 'X-Ts',
+					'extract' => array( 'kind' => 'raw' ),
+					'format'  => 'unix_ms',
+				),
+				'tolerance_seconds' => 5,
+				'secrets'           => array( array( 'id' => 'current', 'value' => self::SECRET ) ),
+			);
+			$headers = array( 'x-sig' => $sig, 'x-ts' => (string) $ts_ms );
+
+			$result = WebhookVerifier::verify( $body, $headers, array(), array(), 'https://example.com/', $config, $now );
+			$this->assertTrue( $result->ok, $result->reason );
+			$this->assertSame( $ts_sec, $result->timestamp );
+		}
+	}
+}


### PR DESCRIPTION
Closes #1179.

## Summary

Replaces the `signature_format` enum (v1: `sha256=hex | hex | base64`) with a declarative **signing template + extraction rules** engine that handles every HMAC-family provider in the wild — **with zero provider-specific code in DM core**.

> **One engine. Every HMAC webhook. No provider names in core.**

## The insight

v1 was "GitHub + Shopify + Linear and that's it." Stripe, Slack, Svix, Mailgun, PayPal, and Clerk all sign **composite strings** (timestamp + body, or id + timestamp + body, or URL + params) that can't be expressed as a single format enum.

v2 describes how a provider signs instead of which provider is signing:

- **`signed_template`** — placeholders: \`{body}\` \`{timestamp}\` \`{id}\` \`{url}\` \`{header:X}\` \`{param:X}\`
- **`signature_source`** — where the signature lives (header or param), with four **extract kinds**: \`raw\`, \`prefix\`, \`kv_pairs\`, \`regex\`
- **`timestamp_source`** — optional; its presence enables replay protection
- **`secrets: []`** — multi-secret rotation with optional \`expires_at\`
- **`tolerance_seconds`** — replay window
- **Encoding**: hex | base64 | base64url; **Algo**: sha1 | sha256 | sha512

## Proof of coverage (one engine, nine providers, zero provider-specific code)

Every row below is exercised end-to-end by the PHPUnit provider matrix:

| Provider | \`signed_template\` | \`signature_source\` | \`timestamp_source\` | enc |
|---|---|---|---|---|
| GitHub | \`{body}\` | header \`X-Hub-Signature-256\`, \`prefix=sha256=\` | — | hex |
| Shopify | \`{body}\` | header \`X-Shopify-Hmac-Sha256\` | — | base64 |
| Linear | \`{body}\` | header \`Linear-Signature\` | — | hex |
| **Stripe** | \`{timestamp}.{body}\` | header \`Stripe-Signature\`, \`kv_pairs v1,\` | same header \`kv_pairs t,\` | hex |
| **Slack** | \`v0:{timestamp}:{body}\` | header \`X-Slack-Signature\`, \`prefix=v0=\` | header \`X-Slack-Request-Timestamp\` | hex |
| **Svix / Standard Webhooks** | \`{id}.{timestamp}.{body}\` | header \`Webhook-Signature\`, \`kv_pairs v1\` (space) | header \`Webhook-Timestamp\` | base64 |
| **Mailgun** | \`{timestamp}{header:X-Mailgun-Token}\` | header \`X-Mailgun-Signature\` | header \`X-Mailgun-Timestamp\` | hex |
| PayPal | \`{body}\` | header \`Paypal-Transmission-Sig\` | header \`Paypal-Transmission-Time\` | base64 |
| **Clerk / Svix-compat** | \`{header:svix-id}.{header:svix-timestamp}.{body}\` | header \`svix-signature\`, \`kv_pairs v1\` (space) | header \`svix-timestamp\` | base64 |

Plus a Twilio-style \`{url}{param:From}{param:To}\` test that exercises URL + body-param placeholders.

## What's in the box

### New classes

- **\`inc/Api/WebhookVerifier.php\`** — the engine. Single \`verify()\` entry point.
- **\`inc/Api/WebhookVerificationResult.php\`** — structured result with outcome codes (\`ok\`, \`bad_signature\`, \`missing_header\`, \`missing_signature\`, \`missing_timestamp\`, \`stale_timestamp\`, \`no_active_secret\`, \`payload_too_large\`, \`malformed_template\`, \`malformed_config\`, \`unknown_mode\`) + \`secret_id\`, \`timestamp\`, \`skew_seconds\`, \`detail\`.
- **\`inc/Api/WebhookAuthResolver.php\`** — compat layer. Accepts v2 \`webhook_auth\` block, v2 \`webhook_auth_preset\` (+ \`webhook_auth_overrides\`), or legacy v1 fields — all resolve to one canonical verifier config.

### Filter-based extension points (core ships zero provider names)

- **\`datamachine_webhook_auth_presets\`** — register provider shorthands (\`stripe\`, \`slack\`, \`svix\`, ...). \`wp datamachine flows webhook enable 42 --preset=stripe --secret=whsec_...\`
- **\`datamachine_webhook_verifier_modes\`** — register non-HMAC modes (Ed25519, x509, JWT, mTLS). Core ships \`hmac\`; plugins add anything else.

### Multi-secret rotation

\`\`\`bash
wp datamachine flows webhook rotate 42 --generate [--previous-ttl-seconds=N]
wp datamachine flows webhook forget 42 previous
\`\`\`

Both \`current\` and \`previous\` verify inbound signatures until \`previous\` expires or is forgotten — **zero-downtime** swap window.

### Offline dry-run

\`\`\`bash
wp datamachine flows webhook test 42 \\\\
  --body=@fixtures/github-ping.json \\\\
  --header=\"X-Hub-Signature-256: sha256=...\"
\`\`\`

Runs the verifier against captured payloads. No job spawn, no rate-limit state touched. Prints the verification outcome including which secret matched and the extracted timestamp skew.

### Replay protection

Presence of \`timestamp_source\` + \`tolerance_seconds > 0\` rejects any request whose timestamp skew exceeds the window. Tested at fresh, stale, and unix_ms formats.

## Backward compatibility

**Zero behavior change for any shipped flow.** Concretely:

- v1 \`webhook_auth_mode = bearer\` → unchanged Bearer path.
- v1 \`webhook_auth_mode = hmac_sha256\` + \`webhook_signature_header\` + \`webhook_signature_format\` → resolver expands to the v2 template shape at read time. Every v1 test still passes.
- Legacy single \`webhook_secret\` coexists with v2 \`webhook_secrets[]\`. \`set-secret\` / \`rotate\` maintain both.
- \`executeDisable\` clears v1 **and** v2 fields.

v1 fields remain the documented shortcut for simple single-header providers — they're just sugar over the v2 engine now.

## Tests

\`\`\`
homeboy test data-machine -- --filter='Webhook'
OK (101 tests, 204 assertions)
\`\`\`

**+70 new tests, 0 new regressions** against baseline:

- **\`WebhookVerifierTest\`** (38 tests) — data-driven provider matrix × 3 assertions each (valid / tampered body / wrong secret) + replay, rotation, expiry, malformed template, unknown mode, URL+param, unix_ms.
- **\`WebhookAuthResolverTest\`** (11 tests) — v1 bearer / v1 hmac_sha256 expansion, v2 pass-through, preset lookup, preset + overrides deep-merge, unknown preset fallback, secret inheritance.
- **\`WebhookTriggerV2Test\`** (17 tests) — end-to-end REST handler with a Stripe preset (valid / wrong-sig / stale timestamp), rotation lifecycle (previous keeps verifying until forgotten), offline test ability, status never leaks secrets.

Full-suite: **1255 total, 1214 passed, 37 pre-existing failures unchanged** (NetworkSettings, ImportExportStepConfig — same baseline as #1178). **Zero new regressions**.

## Lint

Clean for new/modified files. The only phpstan finding attributable to \`WebhookTriggerAbility\` comes from the shared \`FlowHelpers\` trait and pre-dates this PR.

## Docs

- \`docs/api/endpoints/webhook-triggers.md\` — new **v2 template-based verifier** section: config grammar, provider coverage table, preset filter example, rotation workflow, offline-test recipe, non-HMAC extension point.
- \`docs/core-system/wp-cli.md\` — refreshed webhook command block with v2 examples.
- \`docs/core-system/abilities-api.md\` — 9 webhook abilities (+3 new).

## Out of scope (future issues)

- Dedicated \`{prefix}_webhook_secrets\` table + migration (secrets still live in \`scheduling_config\` JSON — but the \`secrets: []\` shape is a clean pivot point).
- Structured verification log table (verifier-side observability for flow owners).
- AgentPing outbound signing using the same template grammar (outbound symmetry).
- Nonce-based replay storage beyond timestamp window.
- Concrete Ed25519 / x509 / JWT implementations for the mode registry.

## Verification

\`\`\`bash
cd /var/lib/datamachine/workspace/data-machine@webhook-v2-template-verifier
homeboy lint data-machine --changed-only --summary      # clean for our files
homeboy test data-machine -- --filter='Webhook'         # 101/101
homeboy test data-machine                               # no new failures vs baseline
\`\`\`