### PR TITLE
cleanup(fetch): remove events-domain examples from skip_item tool description

### DIFF
--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -480,7 +480,7 @@ abstract class FetchHandler {
 			'parameters'     => array(
 				'reason' => array(
 					'type'        => 'string',
-					'description' => 'Concise skip reason, 2-5 words max. Examples: "not a music event", "comedy show", "wrong location", "duplicate event", "past event". Do NOT write sentences — just the category.',
+					'description' => 'Concise 2-5 word categorical skip reason, following the vocabulary defined in the pipeline system prompt or RULES.md. Do NOT write sentences — just the category.',
 					'required'    => true,
 				),
 			),


### PR DESCRIPTION
Closes #1187.

## Summary

`FetchHandler::getSkipItemToolDefinition()` hardcoded events-domain examples into the `reason` parameter description of the `skip_item` tool:

> \"Examples: 'not a music event', 'comedy show', 'wrong location', 'duplicate event', 'past event'\"

Every fetch step in every pipeline — RSS, WordPress, MCP, anything — shipped these domain-specific examples to the model. A WooCommerce release pipeline with a 4000-word WC-specific system prompt (zero mention of events, temporality, or skip vocabulary) fetched a recent WC 10.5.3 release post and ended in `agent_skipped - past event`. Token usage: 18,984 prompt / 19 completion — the agent read the full item, saw the skip tool's events-domain examples, and pattern-matched to the closest temporal-sounding one. Structurally correct agent behavior; core was handing it the wrong vocabulary.

Skip criteria are a config-level concern. The pipeline's system prompt and RULES.md define what \"skip-worthy\" means for a given domain — core's tool definition should describe *what the tool does*, not *when to use it*. The tool-level `description` already correctly points at RULES.md; the `reason` parameter description just needed to stop contradicting it.

## Changes

**`inc/Core/Steps/Fetch/Handlers/FetchHandler.php`** (single line):

```diff
-  'description' => 'Concise skip reason, 2-5 words max. Examples: \"not a music event\", \"comedy show\", \"wrong location\", \"duplicate event\", \"past event\". Do NOT write sentences — just the category.',
+  'description' => 'Concise 2-5 word categorical skip reason, following the vocabulary defined in the pipeline system prompt or RULES.md. Do NOT write sentences — just the category.',
```

**No filter, no extensibility surface, no migration.** Extensions with domain-specific vocabulary (`data-machine-events` etc.) should teach their pipelines the right skip categories via their own system prompts, not via DM core tool definitions. Config is a prompt concern, not a code concern.

## Verification

- `php -l inc/Core/Steps/Fetch/Handlers/FetchHandler.php` → clean.
- Confirmed no other hardcoded events-domain examples leak into core tool definitions via `grep -rn 'not a music event\\|comedy show\\|past event'` — after this PR, matches are limited to historical commit logs and this file's pre-change docblock (which is also removed).

## Impact on existing pipelines

- Pipelines with well-written system prompts (including data-machine-events pipelines that already teach their agents the event-domain vocabulary) see no behavior change beyond a small reduction in prompt-token overhead.
- Pipelines whose system prompt doesn't define skip vocabulary may see the agent produce different (likely more generic / pipeline-appropriate) skip reasons when it decides to skip. This is the intended behavior: agents should draw vocabulary from the pipeline's prompt, not from hardcoded core strings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Traced \"past event\" from a real job's status back through `SkipItemTool` to the tool-definition description. Chris spotted the data-machine-events vocabulary leakage and scoped the fix (pure strip, no filter — config concern belongs in prompts, not code).