### PR TITLE
Bump @extrachill/chat to npm ^0.10.1, drop source-alias hack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
 	"name": "datamachine",
-	"version": "0.66.0",
+	"version": "0.79.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "datamachine",
-			"version": "0.66.0",
+			"version": "0.79.0",
 			"dependencies": {
-				"@extrachill/chat": "github:Extra-Chill/chat",
+				"@extrachill/chat": "^0.10.1",
 				"@tanstack/react-query": "^5.90.12",
 				"@tanstack/react-query-devtools": "^5.91.1",
 				"@wordpress/api-fetch": "^7.36.0",
@@ -2617,9 +2617,13 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.1.0",
-			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#1e1315935f9cd346a24db31e8ea33be69cf3a15a",
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.10.1.tgz",
+			"integrity": "sha512-eQ9L7LQi+0WKBvNV5SONDyql14M/OL9necuAtq5NdCz2qd9JhIz5WeCqwmzz9JTzGj1FgvniusKjSOXi2RGuWQ==",
 			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"react-markdown": "^10.1.0"
+			},
 			"peerDependencies": {
 				"react": ">=18.0.0",
 				"react-dom": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"yauzl": "^3.2.1"
 	},
 	"dependencies": {
-		"@extrachill/chat": "github:Extra-Chill/chat",
+		"@extrachill/chat": "^0.10.1",
 		"@tanstack/react-query": "^5.90.12",
 		"@tanstack/react-query-devtools": "^5.91.1",
 		"@wordpress/api-fetch": "^7.36.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,11 +7,6 @@ const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
  */
 const path = require( 'path' );
 
-const chatPackageSrc = path.resolve(
-	__dirname,
-	'node_modules/@extrachill/chat/src',
-);
-
 module.exports = {
 	...defaultConfig,
 	entry: {
@@ -32,34 +27,6 @@ module.exports = {
 		alias: {
 			...( defaultConfig.resolve?.alias || {} ),
 			'@shared': path.resolve( __dirname, 'inc/Core/Admin/shared' ),
-			// Resolve @extrachill/chat to source (no dist/ in git-installed package)
-			'@extrachill/chat': chatPackageSrc + '/index.ts',
 		},
-		extensions: [
-			'.tsx', '.ts',
-			...( defaultConfig.resolve?.extensions || [ '.jsx', '.js', '.json' ] ),
-		],
-	},
-	module: {
-		...defaultConfig.module,
-		rules: [
-			// TypeScript support for @extrachill/chat source files
-			{
-				test: /\.tsx?$/,
-				include: [ chatPackageSrc ],
-				use: [
-					{
-						loader: require.resolve( 'babel-loader' ),
-						options: {
-							presets: [
-								require.resolve( '@babel/preset-typescript' ),
-								require.resolve( '@babel/preset-react' ),
-							],
-						},
-					},
-				],
-			},
-			...( defaultConfig.module?.rules || [] ),
-		],
 	},
 };


### PR DESCRIPTION
## Summary

DM has been pinned to a specific commit via `"@extrachill/chat": "github:Extra-Chill/chat"` in `package.json`. The resolved commit in `package-lock.json` was `1e131593` — the initial "planning stage" commit of the chat repo, tagged `@extrachill/chat@0.1.0`. That's **35 commits behind main** (current release: `0.10.1`).

To make the git-installed package importable despite the old commit not shipping a `dist/` folder, `webpack.config.js` aliased the bare specifier to `node_modules/@extrachill/chat/src/index.ts` and added a babel-loader rule for TypeScript compilation of those source files.

This was a workable hack when the chat package wasn't published to npm yet. The package has been shipping to npm since v0.6.0 with a proper pre-built `dist/` + declaration files.

## What was actually broken

Webpack compiled successfully because the alias resolved to whatever file happened to be at `node_modules/@extrachill/chat/src/index.ts` at install time — the stub 0.1.0 source. But `ChatSidebar.jsx` imports symbols that weren't exported from that stub:

- `copyChatAsMarkdown` (added in v0.6.0)
- `useLoadingMessages` (v0.7.0)
- `DiffCard`, `parseCanonicalDiffFromToolGroup` (v0.7.0)
- `AvailabilityGate` (exists in stub but with different shape)

So any runtime call into those missing exports would throw `undefined is not a function`.

## Fix

- `package.json`: `"github:Extra-Chill/chat"` → `"^0.10.1"` (matches what `data-machine-frontend-chat` uses).
- `webpack.config.js`: drop the `chatPackageSrc` alias, the TypeScript loader rule, and the extra `.tsx`/`.ts` resolve extensions. Webpack resolves `@extrachill/chat` from `node_modules` normally via the package's declared `main`/`exports`.

No code changes needed — `ChatSidebar.jsx` already imports the right symbols.

## Validation

- `npm install @extrachill/chat@^0.10.1` — resolves to `0.10.1` from the npm registry.
- `npm run build` — succeeds. `pipelines-react.js` grows from 172 KB → 183 KB (+11 KB) as the bundle now includes the APIs that previously were stubs or missing.
- Bundle inspection confirms `copyChatAsMarkdown`, `useLoadingMessages`, and `useChat`'s up-to-date body are all inlined (minified, but present).

`data-machine-frontend-chat` already consumes this package from npm at `^0.8.0`; both consumers now speak the same shape.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Diagnosed the version drift by reading `package-lock.json`, the npm registry metadata, and the installed package source, then drafted the `package.json` / `webpack.config.js` changes and verified with a full build. Chris flagged the audit target.