### PR TITLE
chore(deps): track @extrachill/chat on npm, bump to ^0.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
 	"name": "datamachine",
-	"version": "0.66.0",
+	"version": "0.79.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "datamachine",
-			"version": "0.66.0",
+			"version": "0.79.0",
 			"dependencies": {
-				"@extrachill/chat": "github:Extra-Chill/chat",
+				"@extrachill/chat": "^0.10.1",
 				"@tanstack/react-query": "^5.90.12",
 				"@tanstack/react-query-devtools": "^5.91.1",
 				"@wordpress/api-fetch": "^7.36.0",
@@ -2617,9 +2617,13 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.1.0",
-			"resolved": "git+ssh://git@github.com/Extra-Chill/chat.git#1e1315935f9cd346a24db31e8ea33be69cf3a15a",
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.10.1.tgz",
+			"integrity": "sha512-eQ9L7LQi+0WKBvNV5SONDyql14M/OL9necuAtq5NdCz2qd9JhIz5WeCqwmzz9JTzGj1FgvniusKjSOXi2RGuWQ==",
 			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"react-markdown": "^10.1.0"
+			},
 			"peerDependencies": {
 				"react": ">=18.0.0",
 				"react-dom": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"yauzl": "^3.2.1"
 	},
 	"dependencies": {
-		"@extrachill/chat": "github:Extra-Chill/chat",
+		"@extrachill/chat": "^0.10.1",
 		"@tanstack/react-query": "^5.90.12",
 		"@tanstack/react-query-devtools": "^5.91.1",
 		"@wordpress/api-fetch": "^7.36.0",


### PR DESCRIPTION
## Summary

- `@extrachill/chat` was pinned as `github:Extra-Chill/chat` with no branch or semver hint, so npm resolved it once to **v0.1.0** on first install and then held it there forever via the lockfile.
- Sibling repos (`data-machine-editor`, `data-machine-frontend-chat`) already consume `@extrachill/chat` from npm. This aligns `data-machine` with that pattern.
- The chat package is **35 commits ahead** of the pinned SHA (v0.1.0 → v0.10.1). `ChatSidebar.jsx` is already written against APIs that landed in v0.4.0+ — `basePath`/`fetchFn` config style, `metadata`, `onToolCalls`, `processingSessionId`, `copyChatAsMarkdown`, `sessionContext`.

## Symptom this fixes

Under the stale pin, those imports resolved against the original adapter contract from v0.1.0 (which required `adapter: ChatAdapter` and had no `metadata`/`onToolCalls`/etc.). `useChat` silently crashed inside its try/catch on mount, leaving the Pipelines admin chat sidebar unresponsive — user could type and hit send but nothing would happen.

## What changed

```diff
- "@extrachill/chat": "github:Extra-Chill/chat",
+ "@extrachill/chat": "^0.10.1",
```

Plus the lockfile re-resolution (from git-ssh to npm registry tarball) and a drive-by sync of the drifted root `version` field (was 0.66.0, now matches `package.json`'s 0.79.0).

**No source changes.** `ChatSidebar.jsx` is untouched — the code was already correct, waiting for the dep to catch up.

## Verification

- `npm run build` → webpack compiled successfully, 179 KiB `pipelines-react.js` bundle
- Deployed the built bundle to a local Studio install of data-machine v0.79.0; chat sidebar mounts cleanly against the new package

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Diagnosed the stale github: pin (identified the v0.1.0 → v0.10.1 API drift by comparing node_modules against upstream changelog), verified npm registry availability, drafted the dep-spec switch, ran `npm run build` for verification. Chris reviewed scope and picked the "inline audit across DM ecosystem" direction; companion PRs for `data-machine-editor` and `data-machine-frontend-chat` are opened in parallel.