### PR TITLE
chore(deps): bump @extrachill/chat ^0.10.1 -> ^0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
 	"name": "datamachine",
-	"version": "0.79.0",
+	"version": "0.79.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "datamachine",
-			"version": "0.79.0",
+			"version": "0.79.1",
 			"dependencies": {
-				"@extrachill/chat": "^0.10.1",
+				"@extrachill/chat": "^0.11.0",
 				"@tanstack/react-query": "^5.90.12",
 				"@tanstack/react-query-devtools": "^5.91.1",
 				"@wordpress/api-fetch": "^7.36.0",
@@ -2617,9 +2617,9 @@
 			}
 		},
 		"node_modules/@extrachill/chat": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.10.1.tgz",
-			"integrity": "sha512-eQ9L7LQi+0WKBvNV5SONDyql14M/OL9necuAtq5NdCz2qd9JhIz5WeCqwmzz9JTzGj1FgvniusKjSOXi2RGuWQ==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@extrachill/chat/-/chat-0.11.0.tgz",
+			"integrity": "sha512-wOskWB9SucQKGWmMfC98Fvyeg7cIBmYoeZtrh06RBKZTtSJP0JL5TYnANYsyf578jOX7y9KzLt3i/LCHbu9Cjg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react-markdown": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"yauzl": "^3.2.1"
 	},
 	"dependencies": {
-		"@extrachill/chat": "^0.10.1",
+		"@extrachill/chat": "^0.11.0",
 		"@tanstack/react-query": "^5.90.12",
 		"@tanstack/react-query-devtools": "^5.91.1",
 		"@wordpress/api-fetch": "^7.36.0",


### PR DESCRIPTION
## Summary

v0.11.0 of `@extrachill/chat` ships three additive changes that the DM ecosystem needs:

- **[chat #21](https://github.com/Extra-Chill/chat/pull/21)** — adds `actionId` as the canonical field on `CanonicalDiffData` (alongside a deprecated `diffId` alias). Aligns with DM's unified pending-action primitive (PR #1171).
- **[chat #22](https://github.com/Extra-Chill/chat/pull/22)** — forwards `onToolCalls` and `sessionContext` from `<Chat>` to `useChat`. Unblocks the admin ChatSidebar migration to the composed component (follow-up PR).
- **[chat #23](https://github.com/Extra-Chill/chat/pull/23)** — `parseCanonicalDiff` now recognizes `container.preview` and `container.preview_data` nesting (DM's `PendingActionHelper::stage()` envelope shape). Retires the duplicate parser that lived in data-machine-editor.

## Behaviour

No code changes needed — DM admin already imports the right symbols and all three chat PRs are strictly additive.

## Validation

- `npm install @extrachill/chat@^0.11.0` — resolves to 0.11.0 from npm.
- `npm run build` — succeeds, no warnings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Cross-repo audit of the chat package consumers, cut chat v0.11.0 and rolled the bump across all three consumers (this PR, data-machine-frontend-chat, data-machine-editor). Chris cut the npm publish.