### PR TITLE
feat(fetch): queueable fetch step — drive handler params from prompt queue (#1196)

### DIFF
--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -3,6 +3,7 @@
 namespace DataMachine\Core\Steps\Fetch;
 
 use DataMachine\Core\DataPacket;
+use DataMachine\Core\Steps\QueueableTrait;
 use DataMachine\Core\Steps\Step;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
 use DataMachine\Abilities\HandlerAbilities;
@@ -19,11 +20,25 @@ if ( ! defined( 'ABSPATH' ) ) {
  * PipelineBatchScheduler is active, multiple packets trigger fan-out
  * into child jobs.
  *
+ * Supports queue-driven dynamic params via QueueableTrait. When
+ * `queue_enabled` is true on the flow step config, the step pops one
+ * queued JSON-encoded patch per invocation and deep-merges it into the
+ * handler's static config before invoking the handler. This is how
+ * windowed retroactive backfills (a flow that processes a different
+ * date range each tick) and rotating-source forward-ingestion are
+ * expressed without an external orchestrator.
+ *
+ * Empty queue with queue_enabled=true is treated as a no-op tick: the
+ * job completes with COMPLETED_NO_ITEMS and no fetch is attempted. This
+ * matches the AI step's queue-empty behaviour and keeps recurring flows
+ * idempotent once their backfill queue drains.
+ *
  * @package DataMachine
  */
 class FetchStep extends Step {
 
 	use StepTypeRegistrationTrait;
+	use QueueableTrait;
 
 	/**
 	 * Initialize fetch step.
@@ -62,6 +77,45 @@ class FetchStep extends Step {
 		if ( ! isset( $this->flow_step_config['flow_id'] ) || empty( $this->flow_step_config['flow_id'] ) ) {
 			$this->log( 'error', 'Fetch Step: Missing flow_id in step config' );
 			return $this->dataPackets;
+		}
+
+		// Queue-driven params: when enabled, pop one queued patch and
+		// merge it into the static handler config. This is how a flow
+		// expresses "every tick, process the next windowed slice" with
+		// no external orchestrator.
+		$queue_enabled = (bool) ( $this->flow_step_config['queue_enabled'] ?? false );
+
+		if ( $queue_enabled ) {
+			$queue_result = $this->popQueuedConfigPatch( true );
+
+			if ( ! $queue_result['from_queue'] ) {
+				// Queue enabled but empty — clean no-op tick. Mark the
+				// job as completed-no-items so the engine treats this
+				// as success rather than a fetch failure.
+				$this->log(
+					'info',
+					'Fetch step skipped — queue enabled but empty',
+					array(
+						'flow_step_id' => $this->flow_step_id,
+					)
+				);
+
+				$this->engine->set( 'job_status', \DataMachine\Core\JobStatus::COMPLETED_NO_ITEMS );
+
+				return $this->dataPackets;
+			}
+
+			$handler_settings = $this->mergeQueuedConfigPatch( $handler_settings, $queue_result['patch'] );
+
+			$this->log(
+				'info',
+				'Fetch step merged queued config patch',
+				array(
+					'flow_step_id'  => $this->flow_step_id,
+					'patch_keys'    => array_keys( $queue_result['patch'] ),
+					'queued_at'     => $queue_result['added_at'],
+				)
+			);
 		}
 
 		$handler_settings['flow_step_id'] = $this->flow_step_config['flow_step_id'];

--- a/inc/Core/Steps/QueueableTrait.php
+++ b/inc/Core/Steps/QueueableTrait.php
@@ -5,6 +5,19 @@
  * Provides shared queue pop functionality that can be used by any step type
  * that needs to pull work items from the prompt queue.
  *
+ * Two consumption modes are exposed:
+ *
+ * - {@see popFromQueueIfEmpty()} — for steps that consume scalar prompts
+ *   (AI step's user_message). Returns the popped string verbatim.
+ *
+ * - {@see popQueuedConfigPatch()} — for steps that consume structured
+ *   config patches (Fetch step's handler params). Decodes the popped
+ *   prompt as JSON and returns it as an array suitable for deep-merging
+ *   into the step's existing handler configuration.
+ *
+ * Both share the same persistence (per-flow-step FIFO queue), the same
+ * `queue_enabled` toggle, and the same retry-on-failure backup semantics.
+ *
  * @package DataMachine\Core\Steps
  * @since 0.19.0
  */
@@ -48,11 +61,9 @@ trait QueueableTrait {
 			);
 		}
 
-		// Try to pop from queue
-		$job_context = $this->engine->getJobContext();
-		$flow_id     = $job_context['flow_id'] ?? null;
+		$queued = $this->popOnceFromFlowQueue();
 
-		if ( ! $flow_id ) {
+		if ( null === $queued ) {
 			return array(
 				'value'      => '',
 				'from_queue' => false,
@@ -60,46 +71,229 @@ trait QueueableTrait {
 			);
 		}
 
-		$queued_item = QueueAbility::popFromQueue( (int) $flow_id, $this->flow_step_id );
+		return array(
+			'value'      => $queued['prompt'],
+			'from_queue' => true,
+			'added_at'   => $queued['added_at'] ?? null,
+		);
+	}
 
-		if ( $queued_item && ! empty( $queued_item['prompt'] ) ) {
+	/**
+	 * Pop a structured config patch from the queue.
+	 *
+	 * Sibling of {@see popFromQueueIfEmpty()} for steps whose unit of work
+	 * is a structured config dict rather than a scalar prompt. The popped
+	 * prompt string is JSON-decoded and returned as an array.
+	 *
+	 * Typical use: fetch step pops a date-window dict
+	 * (e.g. `{"after":"2015-05-01","before":"2015-06-01"}` or
+	 * `{"params":{"after":"2015-05-01","before":"2015-06-01"}}`) and the
+	 * caller deep-merges it into the existing handler config to drive
+	 * windowed retroactive backfills.
+	 *
+	 * Empty queue and disabled queue both return `from_queue: false` with
+	 * an empty patch — callers can branch on that to either skip the tick
+	 * or fall through to the static handler config.
+	 *
+	 * @param bool $queue_enabled Whether queue pop is enabled for this step.
+	 * @return array{patch: array, from_queue: bool, added_at: string|null, raw_prompt: string} Result with the decoded patch and source info.
+	 */
+	protected function popQueuedConfigPatch( bool $queue_enabled = false ): array {
+		if ( ! $queue_enabled ) {
+			return array(
+				'patch'      => array(),
+				'from_queue' => false,
+				'added_at'   => null,
+				'raw_prompt' => '',
+			);
+		}
+
+		$queued = $this->popOnceFromFlowQueue();
+
+		if ( null === $queued ) {
+			return array(
+				'patch'      => array(),
+				'from_queue' => false,
+				'added_at'   => null,
+				'raw_prompt' => '',
+			);
+		}
+
+		$decoded = json_decode( $queued['prompt'], true );
+		$patch   = is_array( $decoded ) ? $decoded : array();
+
+		if ( ! is_array( $decoded ) ) {
 			do_action(
 				'datamachine_log',
-				'info',
-				'Using prompt from queue',
+				'warning',
+				'Queueable fetch: queued item is not a JSON object — treating as empty patch',
 				array(
-					'flow_id'   => $flow_id,
-					'step_type' => $this->step_type ?? 'unknown',
-					'added_at'  => $queued_item['added_at'] ?? '',
+					'flow_step_id' => $this->flow_step_id,
+					'raw_prompt'   => substr( $queued['prompt'], 0, 200 ),
 				)
-			);
-
-			// Store backup of the popped prompt in engine data for retry on failure.
-			if ( property_exists( $this, 'job_id' ) && ! empty( $this->job_id ) ) {
-				\datamachine_merge_engine_data(
-					$this->job_id,
-					array(
-						'queued_prompt_backup' => array(
-							'prompt'       => $queued_item['prompt'],
-							'flow_id'      => (int) $flow_id,
-							'flow_step_id' => $this->flow_step_id,
-							'added_at'     => $queued_item['added_at'] ?? null,
-						),
-					)
-				);
-			}
-
-			return array(
-				'value'      => $queued_item['prompt'],
-				'from_queue' => true,
-				'added_at'   => $queued_item['added_at'] ?? null,
 			);
 		}
 
 		return array(
-			'value'      => '',
-			'from_queue' => false,
-			'added_at'   => null,
+			'patch'      => $patch,
+			'from_queue' => true,
+			'added_at'   => $queued['added_at'] ?? null,
+			'raw_prompt' => $queued['prompt'],
 		);
+	}
+
+	/**
+	 * Pop one item from the flow queue and back it up to engine data.
+	 *
+	 * Internal helper shared by both pop variants. Returns null when the
+	 * flow_id is unavailable or the queue is empty.
+	 *
+	 * @return array{prompt: string, added_at: string|null}|null Popped item, or null if no item.
+	 */
+	private function popOnceFromFlowQueue(): ?array {
+		$job_context = $this->engine->getJobContext();
+		$flow_id     = $job_context['flow_id'] ?? null;
+
+		if ( ! $flow_id ) {
+			return null;
+		}
+
+		$queued_item = QueueAbility::popFromQueue( (int) $flow_id, $this->flow_step_id );
+
+		if ( ! $queued_item || empty( $queued_item['prompt'] ) ) {
+			return null;
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Using prompt from queue',
+			array(
+				'flow_id'   => $flow_id,
+				'step_type' => $this->step_type ?? 'unknown',
+				'added_at'  => $queued_item['added_at'] ?? '',
+			)
+		);
+
+		// Store backup of the popped prompt in engine data for retry on failure.
+		if ( property_exists( $this, 'job_id' ) && ! empty( $this->job_id ) ) {
+			\datamachine_merge_engine_data(
+				$this->job_id,
+				array(
+					'queued_prompt_backup' => array(
+						'prompt'       => $queued_item['prompt'],
+						'flow_id'      => (int) $flow_id,
+						'flow_step_id' => $this->flow_step_id,
+						'added_at'     => $queued_item['added_at'] ?? null,
+					),
+				)
+			);
+		}
+
+		return array(
+			'prompt'   => $queued_item['prompt'],
+			'added_at' => $queued_item['added_at'] ?? null,
+		);
+	}
+
+	/**
+	 * Deep-merge a config patch into existing handler settings.
+	 *
+	 * Handles two patterns:
+	 *
+	 * 1. Top-level keys in the patch overlay the same keys in $config
+	 *    (recursive merge for arrays, replacement for scalars).
+	 *
+	 * 2. JSON-string-encoded sub-fields (e.g. MCPFetchHandler's `params`
+	 *    field which serializes its tool params as a JSON string) are
+	 *    decoded, merged, and re-encoded as the same JSON string shape
+	 *    the handler expects to read.
+	 *
+	 * Empty patches return $config unchanged.
+	 *
+	 * @param array $config The current handler configuration.
+	 * @param array $patch  The decoded patch from the queue.
+	 * @return array Merged configuration.
+	 */
+	protected function mergeQueuedConfigPatch( array $config, array $patch ): array {
+		if ( empty( $patch ) ) {
+			return $config;
+		}
+
+		foreach ( $patch as $key => $value ) {
+			$existing = $config[ $key ] ?? null;
+
+			// JSON-encoded string field on the existing config — decode,
+			// merge, re-encode. Allows queued patches to drop into the
+			// MCP handler's `params` JSON string transparently.
+			if ( is_string( $existing ) && is_array( $value ) ) {
+				$decoded = json_decode( $existing, true );
+				if ( is_array( $decoded ) ) {
+					$config[ $key ] = wp_json_encode( $this->deepArrayMerge( $decoded, $value ) );
+					continue;
+				}
+			}
+
+			// Both arrays — recursive deep merge.
+			if ( is_array( $existing ) && is_array( $value ) ) {
+				// Numeric-keyed (list-shaped) arrays: concatenate to
+				// preserve list semantics rather than overwriting indices.
+				if ( $this->isList( $existing ) && $this->isList( $value ) ) {
+					$config[ $key ] = array_merge( $existing, $value );
+				} else {
+					$config[ $key ] = $this->deepArrayMerge( $existing, $value );
+				}
+				continue;
+			}
+
+			// Otherwise, queued value wins (including when it's the same
+			// scalar shape as the existing scalar, or when there's no
+			// existing key at all).
+			$config[ $key ] = $value;
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Recursive array deep-merge. Numeric-keyed (list-shaped) arrays are
+	 * concatenated; associative arrays merge by key.
+	 *
+	 * @param array $base    Base array.
+	 * @param array $overlay Overlay (wins on key collision unless both are arrays).
+	 * @return array Merged array.
+	 */
+	private function deepArrayMerge( array $base, array $overlay ): array {
+		foreach ( $overlay as $k => $v ) {
+			if ( is_array( $v ) && isset( $base[ $k ] ) && is_array( $base[ $k ] ) ) {
+				if ( $this->isList( $base[ $k ] ) && $this->isList( $v ) ) {
+					$base[ $k ] = array_merge( $base[ $k ], $v );
+				} else {
+					$base[ $k ] = $this->deepArrayMerge( $base[ $k ], $v );
+				}
+			} else {
+				$base[ $k ] = $v;
+			}
+		}
+		return $base;
+	}
+
+	/**
+	 * Whether an array is list-shaped (sequential 0..N-1 integer keys).
+	 *
+	 * Polyfill for PHP 8.1's array_is_list(); avoids assuming the
+	 * runtime supports it.
+	 *
+	 * @param array $arr Array to check.
+	 * @return bool True if list-shaped, false otherwise.
+	 */
+	private function isList( array $arr ): bool {
+		if ( function_exists( 'array_is_list' ) ) {
+			return array_is_list( $arr );
+		}
+		if ( array() === $arr ) {
+			return true;
+		}
+		return array_keys( $arr ) === range( 0, count( $arr ) - 1 );
 	}
 }

--- a/tests/queueable-trait-smoke.php
+++ b/tests/queueable-trait-smoke.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Pure-PHP smoke test for QueueableTrait::mergeQueuedConfigPatch().
+ *
+ * Run with: php tests/queueable-trait-smoke.php
+ *
+ * Covers the patch-merge logic that powers queueable fetch steps. The
+ * pop-from-queue paths depend on WordPress hooks + DB and are exercised
+ * via integration tests / live runs, not here.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $options = 0, int $depth = 512 ): string {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ): void {
+		// no-op for tests
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/QueueableTrait.php';
+
+use DataMachine\Core\Steps\QueueableTrait;
+
+/**
+ * Test harness that exposes the protected merge helper.
+ *
+ * The pop helpers depend on the WordPress action system and the
+ * QueueAbility static method, so they're exercised via Fetch step
+ * integration runs. This harness covers the pure-data merge logic
+ * which is the substantive new behavior in this PR.
+ */
+class QueueableTraitMergeHarness {
+	use QueueableTrait;
+
+	public function publicMerge( array $config, array $patch ): array {
+		return $this->mergeQueuedConfigPatch( $config, $patch );
+	}
+}
+
+function dm_assert( bool $cond, string $msg ): void {
+	if ( $cond ) {
+		echo "  [PASS] {$msg}\n";
+		return;
+	}
+	echo "  [FAIL] {$msg}\n";
+	exit( 1 );
+}
+
+$harness = new QueueableTraitMergeHarness();
+
+echo "=== queueable-trait-smoke ===\n";
+
+// -----------------------------------------------------------------
+echo "\n[1] empty patch is a no-op\n";
+$cfg = array(
+	'server'   => 'a8c',
+	'provider' => 'mgs',
+	'params'   => '{"query":"WooCommerce"}',
+);
+dm_assert(
+	$cfg === $harness->publicMerge( $cfg, array() ),
+	'config returned unchanged'
+);
+
+// -----------------------------------------------------------------
+echo "\n[2] patch into JSON-string field merges decoded contents\n";
+$cfg = array(
+	'server'   => 'a8c',
+	'provider' => 'mgs',
+	'tool'     => 'search',
+	'params'   => '{"query":"WooCommerce"}',
+);
+$patch = array(
+	'params' => array(
+		'after'  => '2017-03-01',
+		'before' => '2017-04-01',
+	),
+);
+$merged  = $harness->publicMerge( $cfg, $patch );
+$decoded = json_decode( $merged['params'], true );
+
+dm_assert( 'a8c' === $merged['server'], 'unrelated keys preserved' );
+dm_assert(
+	array(
+		'query'  => 'WooCommerce',
+		'after'  => '2017-03-01',
+		'before' => '2017-04-01',
+	) === $decoded,
+	'patch keys merged into decoded params, original keys preserved'
+);
+dm_assert( is_string( $merged['params'] ), 'params remains a JSON string after merge' );
+
+// -----------------------------------------------------------------
+echo "\n[3] queued patch wins on key collision\n";
+$cfg     = array( 'params' => '{"query":"WooCommerce","after":"2015-01-01"}' );
+$patch   = array( 'params' => array( 'after' => '2020-01-01' ) );
+$merged  = $harness->publicMerge( $cfg, $patch );
+$decoded = json_decode( $merged['params'], true );
+
+dm_assert( '2020-01-01' === $decoded['after'], 'queued value wins on collision' );
+dm_assert( 'WooCommerce' === $decoded['query'], 'non-conflicting key preserved' );
+
+// -----------------------------------------------------------------
+echo "\n[4] top-level scalar in patch overlays config\n";
+$cfg    = array(
+	'server'    => 'a8c',
+	'max_items' => 20,
+);
+$patch  = array( 'max_items' => 50 );
+$merged = $harness->publicMerge( $cfg, $patch );
+
+dm_assert( 50 === $merged['max_items'], 'scalar overlay applied' );
+dm_assert( 'a8c' === $merged['server'], 'unrelated scalar preserved' );
+
+// -----------------------------------------------------------------
+echo "\n[5] new key in patch added to config\n";
+$cfg    = array( 'server' => 'a8c' );
+$patch  = array( 'after' => '2017-03-01' );
+$merged = $harness->publicMerge( $cfg, $patch );
+
+dm_assert( '2017-03-01' === $merged['after'], 'new key added' );
+dm_assert( 'a8c' === $merged['server'], 'existing key preserved' );
+
+// -----------------------------------------------------------------
+echo "\n[6] assoc-array values deep-merge\n";
+$cfg = array(
+	'options' => array(
+		'timeout' => 30,
+		'retries' => 3,
+	),
+);
+$patch = array(
+	'options' => array(
+		'retries' => 5,
+		'verbose' => true,
+	),
+);
+$merged = $harness->publicMerge( $cfg, $patch );
+
+dm_assert(
+	array(
+		'timeout' => 30,
+		'retries' => 5,
+		'verbose' => true,
+	) === $merged['options'],
+	'recursive merge — timeout preserved, retries overwritten, verbose added'
+);
+
+// -----------------------------------------------------------------
+echo "\n[7] numeric arrays concatenate (preserve list semantics)\n";
+$cfg    = array( 'tags' => array( 'wc', 'release' ) );
+$patch  = array( 'tags' => array( '2026-04', 'fse-checkout' ) );
+$merged = $harness->publicMerge( $cfg, $patch );
+
+dm_assert(
+	array( 'wc', 'release', '2026-04', 'fse-checkout' ) === $merged['tags'],
+	'numeric array concatenated rather than replaced'
+);
+
+// -----------------------------------------------------------------
+echo "\n[8] malformed JSON string field overwritten by array patch\n";
+$cfg    = array( 'params' => 'not-json-at-all' );
+$patch  = array( 'params' => array( 'after' => '2017-03-01' ) );
+$merged = $harness->publicMerge( $cfg, $patch );
+
+dm_assert(
+	array( 'after' => '2017-03-01' ) === $merged['params'],
+	'array patch wins outright when string field is unparseable'
+);
+
+// -----------------------------------------------------------------
+echo "\n[9] string patch value replaces string field\n";
+$cfg    = array( 'tool' => 'search' );
+$patch  = array( 'tool' => 'fetch_posts' );
+$merged = $harness->publicMerge( $cfg, $patch );
+
+dm_assert( 'fetch_posts' === $merged['tool'], 'string-to-string replacement' );
+
+// -----------------------------------------------------------------
+echo "\n[10] WooCommerce backfill real-world shape end-to-end\n";
+$static_config = array(
+	'server'    => 'a8c',
+	'provider'  => 'mgs',
+	'tool'      => 'search',
+	'params'    => '{"query":"WooCommerce"}',
+	'max_items' => 20,
+);
+$queued_patch = array(
+	'params' => array(
+		'after'  => '2017-03-01',
+		'before' => '2017-04-01',
+		'limit'  => 100,
+	),
+);
+$merged = $harness->publicMerge( $static_config, $queued_patch );
+
+dm_assert( 'a8c' === $merged['server'], 'server preserved' );
+dm_assert( 'mgs' === $merged['provider'], 'provider preserved' );
+dm_assert( 'search' === $merged['tool'], 'tool preserved' );
+dm_assert( 20 === $merged['max_items'], 'max_items preserved' );
+dm_assert( is_string( $merged['params'] ), 'params remains JSON string for handler' );
+dm_assert(
+	array(
+		'query'  => 'WooCommerce',
+		'after'  => '2017-03-01',
+		'before' => '2017-04-01',
+		'limit'  => 100,
+	) === json_decode( $merged['params'], true ),
+	'all four expected params present (query + 3 from queue)'
+);
+
+// -----------------------------------------------------------------
+echo "\n[11] empty config + non-empty patch — patch becomes the config\n";
+$merged = $harness->publicMerge( array(), array( 'after' => '2015-01-01', 'before' => '2015-02-01' ) );
+
+dm_assert(
+	array(
+		'after'  => '2015-01-01',
+		'before' => '2015-02-01',
+	) === $merged,
+	'patch fully populated empty config'
+);
+
+// -----------------------------------------------------------------
+echo "\n[12] both empty\n";
+dm_assert(
+	array() === $harness->publicMerge( array(), array() ),
+	'empty + empty = empty'
+);
+
+echo "\n=== queueable-trait-smoke: ALL PASS ===\n";


### PR DESCRIPTION
## Summary

Extends \`QueueableTrait\` so \`FetchStep\` can pop one queued JSON-encoded config patch per invocation and deep-merge it into the handler's static config before invoking the handler. Mirrors the AI step's queue-pop pattern, with a config-merge semantic instead of a prompt-replace semantic.

Unlocks **press-go-and-walk-away retroactive backfills** against any windowed source (mgs, linear, github-a8c, slack search, etc.) using only existing primitives. Seed the queue with N date-window patches, schedule the flow recurring, each tick pops one window and fans out across its results.

Closes #1196.

## What changed

| | Before | After |
|---|---|---|
| Fetch step params | Static for the lifetime of the flow | Pop-and-merge from queue per tick when \`queue_enabled\` is true |
| Trait surface | One pop variant (scalar prompts) | Two pop variants — scalar (\`popFromQueueIfEmpty\`) for AI step; structured (\`popQueuedConfigPatch\`) for fetch step |
| Empty queue behaviour | (N/A on fetch) | Clean no-op tick — sets \`job_status\` to \`COMPLETED_NO_ITEMS\`, matches AI step's empty-queue semantic |
| Merge semantic | (N/A) | Top-level scalar overlay, recursive assoc-array merge, list-shaped array concatenation, AND transparent JSON-string-field decode → merge → re-encode |

The JSON-string-field handling is the bit that matters for real-world use: Intelligence's \`MCPFetchHandler\` stores tool params as a JSON-string-encoded value inside its handler config. The merge transparently decodes, deep-merges the queued patch in, and re-encodes — so a queue entry like \`{\"params\":{\"after\":\"2017-03-01\",\"before\":\"2017-04-01\"}}\` cleanly augments a static \`params: '{\"query\":\"WooCommerce\"}'\` config into \`params: '{\"query\":\"WooCommerce\",\"after\":\"2017-03-01\",\"before\":\"2017-04-01\"}'\`. No handler changes needed.

## In practice

\`\`\`bash
# Configure a flow once
studio wp datamachine flow update <id> --step=<fetch_step_id> \\
  --handler=mcp --handler-config='{\"mcp\":{...static template...}}' \\
  --queue-enabled

# Seed the queue (e.g. 132 monthly windows for a decade backfill)
for window in (monthly_iter 2015-05 2026-04); do
  studio wp datamachine flow queue add <id> --step=<fetch_step_id> \\
    --prompt='{\"params\":{\"after\":\"<start>\",\"before\":\"<end>\"}}'
done

# Schedule recurring and walk away
studio wp datamachine flow update <id> --scheduling=every_15_minutes
\`\`\`

Each tick pops one window patch, deep-merges it into the static handler config, invokes the handler, fans out the returned items to child jobs as today. After N ticks the queue drains and the flow no-ops on subsequent ticks.

## Tests

Pure-PHP smoke at \`tests/queueable-trait-smoke.php\` — 22 assertions across 12 cases:

\`\`\`
\$ php tests/queueable-trait-smoke.php
=== queueable-trait-smoke ===

[1] empty patch is a no-op
  [PASS] config returned unchanged
[2] patch into JSON-string field merges decoded contents
  [PASS] unrelated keys preserved
  [PASS] patch keys merged into decoded params, original keys preserved
  [PASS] params remains a JSON string after merge
[3] queued patch wins on key collision
  [PASS] queued value wins on collision
  [PASS] non-conflicting key preserved
[4] top-level scalar in patch overlays config
  [PASS] scalar overlay applied
  [PASS] unrelated scalar preserved
[5] new key in patch added to config
  [PASS] new key added
  [PASS] existing key preserved
[6] assoc-array values deep-merge
  [PASS] recursive merge — timeout preserved, retries overwritten, verbose added
[7] numeric arrays concatenate (preserve list semantics)
  [PASS] numeric array concatenated rather than replaced
[8] malformed JSON string field overwritten by array patch
  [PASS] array patch wins outright when string field is unparseable
[9] string patch value replaces string field
  [PASS] string-to-string replacement
[10] WooCommerce backfill real-world shape end-to-end
  [PASS] server preserved
  [PASS] provider preserved
  [PASS] tool preserved
  [PASS] max_items preserved
  [PASS] params remains JSON string for handler
  [PASS] all four expected params present (query + 3 from queue)
[11] empty config + non-empty patch — patch becomes the config
  [PASS] patch fully populated empty config
[12] both empty
  [PASS] empty + empty = empty

=== queueable-trait-smoke: ALL PASS ===
\`\`\`

The pop-from-queue paths themselves (action hooks, DB queue read/write) are exercised via the FetchStep integration path in real flow runs — queue infrastructure is already production-tested via AIStep. The substantive new logic in this PR is the merge, which is what the smoke focuses on.

## Backwards compatibility

- New fetch steps default to \`queue_enabled: false\` — zero behaviour change for existing flows
- Flow step config already gets \`queue_enabled: false\` + \`prompt_queue: []\` by default via \`FlowHelpers::syncFlowSteps()\`, so no migration is needed
- \`QueueAbility\` already keys queue operations on \`flow_step_id\` with no step-type restriction, so the existing \`flow queue add|list|pop|remove|update\` CLI surface works against fetch step IDs as-is
- AIStep's existing pop path is structurally unchanged — \`popFromQueueIfEmpty()\` was refactored to share the new \`popOnceFromFlowQueue()\` internal helper, but its return shape and behaviour are byte-equivalent

## Out of scope

- **Multi-source fan-in.** Single-source per flow with windowed iteration. For multi-source, run one flow per source.
- **Provider-side pagination loops.** If a single window's fetch hits a provider cap (e.g. mgs caps at 100 results), slice the window finer in queued patches.
- **Concurrent fetch.** One pop per tick. Concurrency comes from running multiple flows in parallel or from batch fan-out downstream.
- **Cross-flow queue sharing.** Each queue keyed on \`flow_step_id\`, single-consumer.

## Why now

Wiki-generation pipelines (Intelligence project — see [Automattic/intelligence#78](https://github.com/Automattic/intelligence/issues/78) and the architecture writeup at [Automattic/intelligence#78 (comment)](https://github.com/Automattic/intelligence/issues/78#issuecomment-4316480719)) need this primitive to retroactively populate a wiki from a decade of internal Automattic source material. Without it, every wiki has to either (a) live with a single mega-fetch, (b) be hand-orchestrated outside DM, or (c) spin up dozens of single-window flows.

This is also the missing piece for any \"crawl an archive\" pattern — old P2 backlogs, Linear migrations, GitHub history, etc. \`QueueableTrait\` on fetch is the primitive that makes all of those declarative.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Drafted the trait extension (\`popQueuedConfigPatch\` + \`mergeQueuedConfigPatch\` + \`popOnceFromFlowQueue\` + \`isList\` helpers), wired \`FetchStep\` to use it, and wrote the 22-assertion pure-PHP smoke. Chris reviewed the symmetry with AIStep's existing queue pattern, the empty-queue no-op semantic, and the JSON-string-field merge case driven by Intelligence's MCPFetchHandler \`params\` shape.