### PR TITLE
feat(media): BrandTokens primitive + cached_file output mode

### DIFF
--- a/inc/Abilities/Media/BrandTokens.php
+++ b/inc/Abilities/Media/BrandTokens.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Brand tokens primitive for image templates.
+ *
+ * Provides a single, filterable source of brand identity (colors, fonts,
+ * logo, label text) for GD-rendered templates. Themes hook
+ * `datamachine/image_template/brand_tokens` to supply site-specific
+ * branding; templates call BrandTokens::get() to read what to paint.
+ *
+ * The primitive is intentionally brand-agnostic — defaults are neutral.
+ * Downstream consumers (themes, plugins) layer brand on top via the filter.
+ *
+ * @package DataMachine\Abilities\Media
+ * @since 0.79.0
+ */
+
+namespace DataMachine\Abilities\Media;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class BrandTokens {
+
+	/**
+	 * Default brand tokens.
+	 *
+	 * Neutral values used when no theme/plugin supplies overrides.
+	 *
+	 * @var array
+	 */
+	private const DEFAULTS = array(
+		'colors' => array(
+			'background'      => '#ffffff',
+			'background_dark' => '#0f0f0f',
+			'surface'         => '#f1f5f9',
+			'accent'          => '#53940b',
+			'accent_hover'    => '#3d6b08',
+			'accent_2'        => '#36454f',
+			'accent_3'        => '#00c8e3',
+			'text_primary'    => '#000000',
+			'text_muted'      => '#6b7280',
+			'text_inverse'    => '#ffffff',
+			'header_bg'       => '#000000',
+			'border'          => '#dddddd',
+		),
+		'fonts'  => array(
+			// Absolute paths to .ttf files. GD cannot use .woff2 — themes
+			// must ship TTF/OTF for any font they want in rendered images.
+			'heading' => null,
+			'body'    => null,
+			'brand'   => null,
+			'mono'    => null,
+		),
+		'logo_path'  => null,
+		'brand_text' => '',
+		'site_label' => '',
+	);
+
+	/**
+	 * Get brand tokens for the current site/template.
+	 *
+	 * Themes and plugins filter these via
+	 * `datamachine/image_template/brand_tokens`. The filter receives the
+	 * template ID and an optional context (typically a WP_Post or array)
+	 * so callers can supply per-template or per-content overrides.
+	 *
+	 * @param string $template_id Template identifier (e.g. 'event_og_card').
+	 * @param mixed  $context     Optional context (WP_Post, array, etc.).
+	 * @return array Resolved brand token array (always has colors + fonts keys).
+	 */
+	public static function get( string $template_id = '', $context = null ): array {
+		$defaults = self::DEFAULTS;
+
+		/**
+		 * Filter brand tokens used by GD image templates.
+		 *
+		 * @param array  $tokens      Default tokens (colors, fonts, logo_path, brand_text, site_label).
+		 * @param string $template_id Template identifier requesting tokens.
+		 * @param mixed  $context     Optional context — typically a WP_Post or data array.
+		 */
+		// phpcs:ignore WordPress.NamingConventions.ValidHookName -- Intentional slash-separated hook namespace.
+		$tokens = apply_filters( 'datamachine/image_template/brand_tokens', $defaults, $template_id, $context );
+
+		// Ensure shape is stable even if a filter returns something unexpected.
+		$tokens['colors'] = array_merge( $defaults['colors'], (array) ( $tokens['colors'] ?? array() ) );
+		$tokens['fonts']  = array_merge( $defaults['fonts'], (array) ( $tokens['fonts'] ?? array() ) );
+
+		foreach ( array( 'logo_path', 'brand_text', 'site_label' ) as $key ) {
+			if ( ! array_key_exists( $key, $tokens ) ) {
+				$tokens[ $key ] = $defaults[ $key ];
+			}
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * Convenience accessor for a single color token.
+	 *
+	 * @param string $color_key    Key within the `colors` array.
+	 * @param string $template_id  Template identifier.
+	 * @param mixed  $context      Optional context.
+	 * @param string $fallback_hex Fallback hex string if the key is missing.
+	 * @return string Hex color.
+	 */
+	public static function color( string $color_key, string $template_id = '', $context = null, string $fallback_hex = '#000000' ): string {
+		$tokens = self::get( $template_id, $context );
+		return (string) ( $tokens['colors'][ $color_key ] ?? $fallback_hex );
+	}
+
+	/**
+	 * Convenience accessor for a single font path.
+	 *
+	 * Returns null when the theme has not supplied a font for the given
+	 * role. Templates should treat null as "fall back to system default".
+	 *
+	 * @param string $font_key    Key within the `fonts` array.
+	 * @param string $template_id Template identifier.
+	 * @param mixed  $context     Optional context.
+	 * @return string|null Absolute path to TTF file, or null if unset.
+	 */
+	public static function font( string $font_key, string $template_id = '', $context = null ): ?string {
+		$tokens = self::get( $template_id, $context );
+		$path   = $tokens['fonts'][ $font_key ] ?? null;
+		return is_string( $path ) && '' !== $path ? $path : null;
+	}
+}

--- a/inc/Abilities/Media/ImageTemplateAbilities.php
+++ b/inc/Abilities/Media/ImageTemplateAbilities.php
@@ -61,18 +61,41 @@ class ImageTemplateAbilities {
 								'type'        => 'object',
 								'description' => 'Storage context with pipeline_id and flow_id for repository storage',
 							),
+							'output'      => array(
+								'type'        => 'string',
+								'description' => 'Output destination: "files" returns file paths (default, requires context for repository or returns temp paths), "attachment" creates WordPress attachments and returns IDs/URLs.',
+								'enum'        => array( 'files', 'attachment' ),
+								'default'     => 'files',
+							),
+							'attachment'  => array(
+								'type'        => 'object',
+								'description' => 'Attachment options when output=attachment. Supports parent_post_id (attach to a post), title, alt_text.',
+								'properties'  => array(
+									'parent_post_id' => array( 'type' => 'integer' ),
+									'title'          => array( 'type' => 'string' ),
+									'alt_text'       => array( 'type' => 'string' ),
+								),
+							),
 						),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'     => array( 'type' => 'boolean' ),
-							'file_paths'  => array(
+							'success'        => array( 'type' => 'boolean' ),
+							'file_paths'     => array(
 								'type'  => 'array',
 								'items' => array( 'type' => 'string' ),
 							),
-							'template_id' => array( 'type' => 'string' ),
-							'message'     => array( 'type' => 'string' ),
+							'attachment_ids' => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'integer' ),
+							),
+							'attachment_urls' => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'string' ),
+							),
+							'template_id'    => array( 'type' => 'string' ),
+							'message'        => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'renderTemplate' ),
@@ -124,6 +147,8 @@ class ImageTemplateAbilities {
 		$preset      = $input['preset'] ?? '';
 		$format      = $input['format'] ?? 'png';
 		$context     = $input['context'] ?? array();
+		$output      = $input['output'] ?? 'files';
+		$attachment  = $input['attachment'] ?? array();
 
 		if ( empty( $template_id ) ) {
 			return array(
@@ -198,11 +223,134 @@ class ImageTemplateAbilities {
 			);
 		}
 
+		// Default output mode — return file paths as-is.
+		if ( 'attachment' !== $output ) {
+			return array(
+				'success'     => true,
+				'file_paths'  => $file_paths,
+				'template_id' => $template_id,
+				'message'     => sprintf( 'Generated %d image(s) using template "%s"', count( $file_paths ), $template_id ),
+			);
+		}
+
+		// Attachment output — convert each rendered file into a WP attachment.
+		$attachment_result = self::convertFilesToAttachments( $file_paths, $template_id, $attachment );
+
+		return array_merge(
+			array(
+				'success'     => ! empty( $attachment_result['attachment_ids'] ),
+				'template_id' => $template_id,
+			),
+			$attachment_result
+		);
+	}
+
+	/**
+	 * Convert rendered template files into WordPress attachments.
+	 *
+	 * Each file is sideloaded into the media library via wp_insert_attachment().
+	 * Original temp files are removed after sideload completes.
+	 *
+	 * @param string[] $file_paths       Rendered file paths from the template.
+	 * @param string   $template_id      Template identifier (used in fallback titles).
+	 * @param array    $attachment_opts  Attachment options (parent_post_id, title, alt_text).
+	 * @return array {
+	 *     @type string[] $file_paths      Original file paths (for parity with files mode).
+	 *     @type int[]    $attachment_ids  Created attachment post IDs.
+	 *     @type string[] $attachment_urls Public URLs for the created attachments.
+	 *     @type string   $message         Human-readable summary.
+	 * }
+	 */
+	private static function convertFilesToAttachments( array $file_paths, string $template_id, array $attachment_opts ): array {
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+
+		$parent_post_id = isset( $attachment_opts['parent_post_id'] ) ? (int) $attachment_opts['parent_post_id'] : 0;
+		$title          = isset( $attachment_opts['title'] ) ? (string) $attachment_opts['title'] : '';
+		$alt_text       = isset( $attachment_opts['alt_text'] ) ? (string) $attachment_opts['alt_text'] : '';
+
+		$upload_dir = wp_upload_dir();
+		if ( ! empty( $upload_dir['error'] ) ) {
+			return array(
+				'file_paths'      => $file_paths,
+				'attachment_ids'  => array(),
+				'attachment_urls' => array(),
+				'message'         => sprintf( 'Upload directory error: %s', $upload_dir['error'] ),
+			);
+		}
+
+		$attachment_ids  = array();
+		$attachment_urls = array();
+		$failures        = array();
+
+		foreach ( $file_paths as $index => $source_path ) {
+			if ( ! file_exists( $source_path ) ) {
+				$failures[] = basename( $source_path );
+				continue;
+			}
+
+			$basename     = basename( $source_path );
+			$safe_name    = wp_unique_filename( $upload_dir['path'], $basename );
+			$dest_path    = trailingslashit( $upload_dir['path'] ) . $safe_name;
+
+			if ( ! @copy( $source_path, $dest_path ) ) {
+				$failures[] = $basename;
+				continue;
+			}
+
+			// Best-effort cleanup of the source temp file.
+			wp_delete_file( $source_path );
+
+			$filetype = wp_check_filetype( $dest_path );
+
+			$attachment_title = $title;
+			if ( '' === $attachment_title ) {
+				$attachment_title = sprintf( '%s-%d', $template_id, $index + 1 );
+			}
+
+			$attachment_data = array(
+				'guid'           => trailingslashit( $upload_dir['url'] ) . $safe_name,
+				'post_mime_type' => $filetype['type'] ?: 'image/png',
+				'post_title'     => sanitize_text_field( $attachment_title ),
+				'post_content'   => '',
+				'post_status'    => 'inherit',
+			);
+
+			$attach_id = wp_insert_attachment( $attachment_data, $dest_path, $parent_post_id, true );
+
+			if ( is_wp_error( $attach_id ) || ! $attach_id ) {
+				wp_delete_file( $dest_path );
+				$failures[] = $basename;
+				continue;
+			}
+
+			$metadata = wp_generate_attachment_metadata( $attach_id, $dest_path );
+			wp_update_attachment_metadata( $attach_id, $metadata );
+
+			if ( '' !== $alt_text ) {
+				update_post_meta( $attach_id, '_wp_attachment_image_alt', sanitize_text_field( $alt_text ) );
+			}
+
+			$attachment_ids[]  = (int) $attach_id;
+			$attachment_urls[] = wp_get_attachment_url( (int) $attach_id );
+		}
+
+		$message = sprintf(
+			'Created %d attachment(s) from template "%s"',
+			count( $attachment_ids ),
+			$template_id
+		);
+
+		if ( ! empty( $failures ) ) {
+			$message .= sprintf( ' — %d failed (%s)', count( $failures ), implode( ', ', $failures ) );
+		}
+
 		return array(
-			'success'     => true,
-			'file_paths'  => $file_paths,
-			'template_id' => $template_id,
-			'message'     => sprintf( 'Generated %d image(s) using template "%s"', count( $file_paths ), $template_id ),
+			'file_paths'      => $file_paths,
+			'attachment_ids'  => $attachment_ids,
+			'attachment_urls' => $attachment_urls,
+			'message'         => $message,
 		);
 	}
 

--- a/inc/Abilities/Media/ImageTemplateAbilities.php
+++ b/inc/Abilities/Media/ImageTemplateAbilities.php
@@ -63,17 +63,22 @@ class ImageTemplateAbilities {
 							),
 							'output'      => array(
 								'type'        => 'string',
-								'description' => 'Output destination: "files" returns file paths (default, requires context for repository or returns temp paths), "attachment" creates WordPress attachments and returns IDs/URLs.',
-								'enum'        => array( 'files', 'attachment' ),
+								'description' => 'Output destination: "files" returns file paths (default, requires context for repository or returns temp paths), "cached_file" stores the rendered file under uploads/<bucket>/<key>.<ext> and returns a stable public URL — ideal for OG images and other long-lived public artifacts that should not pollute the media library.',
+								'enum'        => array( 'files', 'cached_file' ),
 								'default'     => 'files',
 							),
-							'attachment'  => array(
+							'cache'       => array(
 								'type'        => 'object',
-								'description' => 'Attachment options when output=attachment. Supports parent_post_id (attach to a post), title, alt_text.',
+								'description' => 'Cache options when output=cached_file. Required when output=cached_file.',
 								'properties'  => array(
-									'parent_post_id' => array( 'type' => 'integer' ),
-									'title'          => array( 'type' => 'string' ),
-									'alt_text'       => array( 'type' => 'string' ),
+									'bucket' => array(
+										'type'        => 'string',
+										'description' => 'Subdirectory under wp-content/uploads/ (slug-style; sanitized).',
+									),
+									'key'    => array(
+										'type'        => 'string',
+										'description' => 'Stable filename stem within the bucket (sanitized). Re-renders overwrite atomically.',
+									),
 								),
 							),
 						),
@@ -81,21 +86,21 @@ class ImageTemplateAbilities {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'        => array( 'type' => 'boolean' ),
-							'file_paths'     => array(
+							'success'      => array( 'type' => 'boolean' ),
+							'file_paths'   => array(
 								'type'  => 'array',
 								'items' => array( 'type' => 'string' ),
 							),
-							'attachment_ids' => array(
-								'type'  => 'array',
-								'items' => array( 'type' => 'integer' ),
-							),
-							'attachment_urls' => array(
+							'cached_paths' => array(
 								'type'  => 'array',
 								'items' => array( 'type' => 'string' ),
 							),
-							'template_id'    => array( 'type' => 'string' ),
-							'message'        => array( 'type' => 'string' ),
+							'cached_urls'  => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'string' ),
+							),
+							'template_id'  => array( 'type' => 'string' ),
+							'message'      => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'renderTemplate' ),
@@ -148,7 +153,7 @@ class ImageTemplateAbilities {
 		$format      = $input['format'] ?? 'png';
 		$context     = $input['context'] ?? array();
 		$output      = $input['output'] ?? 'files';
-		$attachment  = $input['attachment'] ?? array();
+		$cache_opts  = $input['cache'] ?? array();
 
 		if ( empty( $template_id ) ) {
 			return array(
@@ -224,7 +229,7 @@ class ImageTemplateAbilities {
 		}
 
 		// Default output mode — return file paths as-is.
-		if ( 'attachment' !== $output ) {
+		if ( 'cached_file' !== $output ) {
 			return array(
 				'success'     => true,
 				'file_paths'  => $file_paths,
@@ -233,56 +238,78 @@ class ImageTemplateAbilities {
 			);
 		}
 
-		// Attachment output — convert each rendered file into a WP attachment.
-		$attachment_result = self::convertFilesToAttachments( $file_paths, $template_id, $attachment );
+		// Cached file output — copy each rendered file under uploads/<bucket>/<key>.<ext>.
+		$cached_result = self::copyFilesToCachedLocation( $file_paths, $template_id, $cache_opts );
 
 		return array_merge(
 			array(
-				'success'     => ! empty( $attachment_result['attachment_ids'] ),
+				'success'     => ! empty( $cached_result['cached_urls'] ),
 				'template_id' => $template_id,
 			),
-			$attachment_result
+			$cached_result
 		);
 	}
 
 	/**
-	 * Convert rendered template files into WordPress attachments.
+	 * Copy rendered template files to a stable cached location under uploads/.
 	 *
-	 * Each file is sideloaded into the media library via wp_insert_attachment().
-	 * Original temp files are removed after sideload completes.
+	 * Files land at `wp-content/uploads/<bucket>/<key>[-<n>].<ext>`. Existing
+	 * files at the destination are overwritten, so re-rendering the same key
+	 * naturally invalidates and replaces. The bucket is intentionally outside
+	 * the YYYY/MM media library tree so cached artifacts do not pollute the
+	 * media browser, do not get resized, and do not interact with Imagify or
+	 * other media-pipeline plugins.
 	 *
-	 * @param string[] $file_paths       Rendered file paths from the template.
-	 * @param string   $template_id      Template identifier (used in fallback titles).
-	 * @param array    $attachment_opts  Attachment options (parent_post_id, title, alt_text).
+	 * Source temp files are removed after the copy to avoid leaking PHP tmp.
+	 *
+	 * @param string[] $file_paths   Rendered file paths from the template.
+	 * @param string   $template_id  Template identifier (for log/message context).
+	 * @param array    $cache_opts   { bucket, key } — both required.
 	 * @return array {
-	 *     @type string[] $file_paths      Original file paths (for parity with files mode).
-	 *     @type int[]    $attachment_ids  Created attachment post IDs.
-	 *     @type string[] $attachment_urls Public URLs for the created attachments.
-	 *     @type string   $message         Human-readable summary.
+	 *     @type string[] $file_paths   Original file paths (for parity with files mode).
+	 *     @type string[] $cached_paths Absolute filesystem paths of cached copies.
+	 *     @type string[] $cached_urls  Public URLs of cached copies.
+	 *     @type string   $message      Human-readable summary.
 	 * }
 	 */
-	private static function convertFilesToAttachments( array $file_paths, string $template_id, array $attachment_opts ): array {
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-		require_once ABSPATH . 'wp-admin/includes/image.php';
-		require_once ABSPATH . 'wp-admin/includes/media.php';
+	private static function copyFilesToCachedLocation( array $file_paths, string $template_id, array $cache_opts ): array {
+		$bucket = isset( $cache_opts['bucket'] ) ? sanitize_file_name( (string) $cache_opts['bucket'] ) : '';
+		$key    = isset( $cache_opts['key'] ) ? sanitize_file_name( (string) $cache_opts['key'] ) : '';
 
-		$parent_post_id = isset( $attachment_opts['parent_post_id'] ) ? (int) $attachment_opts['parent_post_id'] : 0;
-		$title          = isset( $attachment_opts['title'] ) ? (string) $attachment_opts['title'] : '';
-		$alt_text       = isset( $attachment_opts['alt_text'] ) ? (string) $attachment_opts['alt_text'] : '';
+		if ( '' === $bucket || '' === $key ) {
+			return array(
+				'file_paths'   => $file_paths,
+				'cached_paths' => array(),
+				'cached_urls'  => array(),
+				'message'      => 'cached_file output requires cache.bucket and cache.key',
+			);
+		}
 
 		$upload_dir = wp_upload_dir();
 		if ( ! empty( $upload_dir['error'] ) ) {
 			return array(
-				'file_paths'      => $file_paths,
-				'attachment_ids'  => array(),
-				'attachment_urls' => array(),
-				'message'         => sprintf( 'Upload directory error: %s', $upload_dir['error'] ),
+				'file_paths'   => $file_paths,
+				'cached_paths' => array(),
+				'cached_urls'  => array(),
+				'message'      => sprintf( 'Upload directory error: %s', $upload_dir['error'] ),
 			);
 		}
 
-		$attachment_ids  = array();
-		$attachment_urls = array();
-		$failures        = array();
+		$bucket_dir = trailingslashit( $upload_dir['basedir'] ) . $bucket;
+		$bucket_url = trailingslashit( $upload_dir['baseurl'] ) . $bucket;
+
+		if ( ! wp_mkdir_p( $bucket_dir ) ) {
+			return array(
+				'file_paths'   => $file_paths,
+				'cached_paths' => array(),
+				'cached_urls'  => array(),
+				'message'      => sprintf( 'Failed to create cache directory: %s', $bucket_dir ),
+			);
+		}
+
+		$cached_paths = array();
+		$cached_urls  = array();
+		$failures     = array();
 
 		foreach ( $file_paths as $index => $source_path ) {
 			if ( ! file_exists( $source_path ) ) {
@@ -290,55 +317,28 @@ class ImageTemplateAbilities {
 				continue;
 			}
 
-			$basename     = basename( $source_path );
-			$safe_name    = wp_unique_filename( $upload_dir['path'], $basename );
-			$dest_path    = trailingslashit( $upload_dir['path'] ) . $safe_name;
+			$ext       = strtolower( pathinfo( $source_path, PATHINFO_EXTENSION ) ) ?: 'png';
+			$suffix    = count( $file_paths ) > 1 ? '-' . ( $index + 1 ) : '';
+			$filename  = $key . $suffix . '.' . $ext;
+			$dest_path = trailingslashit( $bucket_dir ) . $filename;
+			$dest_url  = trailingslashit( $bucket_url ) . $filename;
 
 			if ( ! @copy( $source_path, $dest_path ) ) {
-				$failures[] = $basename;
+				$failures[] = basename( $source_path );
 				continue;
 			}
 
-			// Best-effort cleanup of the source temp file.
 			wp_delete_file( $source_path );
 
-			$filetype = wp_check_filetype( $dest_path );
-
-			$attachment_title = $title;
-			if ( '' === $attachment_title ) {
-				$attachment_title = sprintf( '%s-%d', $template_id, $index + 1 );
-			}
-
-			$attachment_data = array(
-				'guid'           => trailingslashit( $upload_dir['url'] ) . $safe_name,
-				'post_mime_type' => $filetype['type'] ?: 'image/png',
-				'post_title'     => sanitize_text_field( $attachment_title ),
-				'post_content'   => '',
-				'post_status'    => 'inherit',
-			);
-
-			$attach_id = wp_insert_attachment( $attachment_data, $dest_path, $parent_post_id, true );
-
-			if ( is_wp_error( $attach_id ) || ! $attach_id ) {
-				wp_delete_file( $dest_path );
-				$failures[] = $basename;
-				continue;
-			}
-
-			$metadata = wp_generate_attachment_metadata( $attach_id, $dest_path );
-			wp_update_attachment_metadata( $attach_id, $metadata );
-
-			if ( '' !== $alt_text ) {
-				update_post_meta( $attach_id, '_wp_attachment_image_alt', sanitize_text_field( $alt_text ) );
-			}
-
-			$attachment_ids[]  = (int) $attach_id;
-			$attachment_urls[] = wp_get_attachment_url( (int) $attach_id );
+			$cached_paths[] = $dest_path;
+			$cached_urls[]  = $dest_url;
 		}
 
 		$message = sprintf(
-			'Created %d attachment(s) from template "%s"',
-			count( $attachment_ids ),
+			'Cached %d image(s) under %s/%s for template "%s"',
+			count( $cached_paths ),
+			$bucket,
+			$key,
 			$template_id
 		);
 
@@ -347,10 +347,10 @@ class ImageTemplateAbilities {
 		}
 
 		return array(
-			'file_paths'      => $file_paths,
-			'attachment_ids'  => $attachment_ids,
-			'attachment_urls' => $attachment_urls,
-			'message'         => $message,
+			'file_paths'   => $file_paths,
+			'cached_paths' => $cached_paths,
+			'cached_urls'  => $cached_urls,
+			'message'      => $message,
 		);
 	}
 


### PR DESCRIPTION
## Summary

Two related additions to the GD image template system:

1. **BrandTokens primitive** — filterable source of brand identity (colors, fonts, logo, labels) for templates. Themes/plugins hook the filter once; every GD template network-wide paints with theme brand. Data Machine core stays brand-agnostic.

2. **cached_file output mode** for `datamachine/render-image-template` — renders files to a stable cache bucket under `wp-content/uploads/<bucket>/<key>.<ext>`. Returns the public URL. Designed for OG cards and other long-lived public artifacts that should NOT pollute the media library.

## BrandTokens

New class `DataMachine\Abilities\Media\BrandTokens` + filter `datamachine/image_template/brand_tokens`.

Templates call:

```php
$tokens = BrandTokens::get($template_id, $context);
// $tokens["colors"]["accent"]   => theme accent hex
// $tokens["fonts"]["heading"]   => absolute TTF path (or null)
// $tokens["brand_text"]          => brand name
// $tokens["site_label"]          => per-site label
```

Themes/plugins register brand once:

```php
add_filter("datamachine/image_template/brand_tokens", function($tokens) {
    $tokens["colors"]["accent"] = "#53940b";
    $tokens["fonts"]["heading"] = "/path/to/Heading.ttf";
    return $tokens;
}, 10, 3);
```

Neutral defaults ship in the primitive so templates still render without any registered tokens.

## cached_file output mode

Extends `datamachine/render-image-template` with:
- `output: "cached_file"` — copies rendered file to `uploads/<bucket>/<key>.<ext>`, returns `cached_paths` + `cached_urls`
- `cache: { bucket, key }` — both required for cached_file mode

Files land OUTSIDE the YYYY/MM media library tree so they:
- do not pollute the media browser
- are not auto-resized to thumbnail/medium/large variants
- do not interact with Imagify or other media-pipeline plugins

Re-renders with the same key overwrite atomically. Keys should be deterministic and include enough namespace for collision safety (e.g. `b<blog_id>-<post_type>-<post_id>`).

Backward compatible — default `output` remains `files`.

## Why these together

BrandTokens is the primitive that makes cached_file output actually look like something worth caching. Shipping them together lets consumer plugins adopt both in one move.

## Followup consumers

- [extrachill-multisite#9](https://github.com/Extra-Chill/extrachill-multisite/pull/9) — uses both via a SystemTask for per-post OG card generation across all EC sites
- [extrachill-seo#7](https://github.com/Extra-Chill/extrachill-seo/pull/7) — singular OG image filter (the entry point)
- [data-machine-events#210](https://github.com/Extra-Chill/data-machine-events/pull/210) — registers an event card GD template that consumes BrandTokens

## What changed in this PR

The earlier `output: attachment` mode was speculative — it created full WP attachments with all resized variants for every OG card. Reviewers (correctly) pointed out this would balloon disk usage to ~6GB for the events site alone with no real benefit (OG images are never displayed at thumbnail sizes). Replaced with the cleaner `cached_file` mode that gets ~30KB per card, no media library bloat.