### PR TITLE
fix(ai-step): include agent_id in directive payload

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -228,6 +228,7 @@ class AIStep extends Step {
 			'data'         => $this->dataPackets,
 			'engine'       => $this->engine,
 			'user_id'      => $user_id,
+			'agent_id'     => $agent_id,
 		);
 
 		$navigator             = new \DataMachine\Engine\StepNavigator();


### PR DESCRIPTION
## Summary

- One-line fix: pass `$agent_id` into the AIStep `$payload` alongside `$user_id`.
- Stops pipeline AI steps from leaking the wrong agent's `MEMORY.md` / `SOUL.md` / daily memory on installs with multiple agents owned by the same user.
- ChatOrchestrator already passed `agent_id` correctly, so this restores chat/pipeline parity.

## The bug

`AIStep::execute()` resolves `$agent_id` from the engine job snapshot at line 221 and uses it for `ToolPolicyResolver`, `resolveModelForAgentMode`, and `wp_set_current_user($owner_id)` + `PermissionHelper::set_agent_context()` — but never puts it into the `$payload` array that flows through `RequestBuilder::build()` → `PromptBuilder::build()` → directive stack:

```php
$payload = array(
    'job_id'       => $this->job_id,
    'flow_step_id' => $this->flow_step_id,
    'step_id'      => $pipeline_step_id,
    'data'         => $this->dataPackets,
    'engine'       => $this->engine,
    'user_id'      => $user_id,    // ← only user_id
    // 'agent_id'  => $agent_id,   // ← MISSING
);
```

Every directive that resolves agent identity reads `$payload['agent_id'] ?? 0`:

- `inc/Engine/AI/Directives/CoreMemoryFilesDirective.php:52`
- `inc/Engine/AI/Directives/AgentDailyMemoryDirective.php:64`
- `inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php:55`
- `inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php:59`

When that lookup returns 0, `MemoryFilesReader::read()` calls `DirectoryManager::resolve_agent_directory(['agent_id' => 0, 'user_id' => $user_id])`. With `agent_id=0` the resolver falls through to `get_agent_slug_for_user($user_id)`, which queries `Agents::get_by_owner_id($user_id)` — and that method returns the OLDEST agent owned by the user (`ORDER BY agent_id ASC LIMIT 1`). On any install where one user owns multiple agents, every pipeline AI step loads agent 1's memory regardless of which agent owns the job.

`AIConversationLoop::execute()` also reads `$payload['agent_id']` for tool dispatch (line 335), so tools fired inside the loop run with `agent_id=0` and the same wrong-agent fallback behavior — meaning per-agent tool policies, `set_agent_context()`-aware abilities, and pending-action attribution all silently mis-target.

## Why chat was unaffected

`Api/Chat/ChatOrchestrator.php:180` already passes `'agent_id' => $agent_id` into the loop options, so directives in chat mode see the right agent. The asymmetry made this regression invisible until a multi-agent pipeline backfill ran on a real install (Intelligence + a wiki-generator agent on the same site).

## Why it slipped past #1083

#1083 established the agent execution context for pipeline AI steps — `wp_set_current_user($owner_id)` + `PermissionHelper::set_agent_context($agent_id, $owner_id)` so abilities run as the right WP user with the right agent context. But the directive payload (which is read inside `RequestBuilder::build()` / `PromptBuilder` / each directive's `get_outputs()`) is a separate channel from the WP user context — the directives don't read `get_current_user_id()`, they read `$payload['agent_id']`. #1083 fixed the WP-side; this PR fixes the payload side.

## Test plan

Manual verification on a multi-agent install:

1. Two agents on same owner: agent A (id=1) and agent B (id=2), each with distinct `MEMORY.md` content under `wp-content/uploads/datamachine-files/agents/<slug>/`.
2. Run a pipeline whose flow's job carries `agent_id=2` (verify with `wp datamachine jobs show <job_id> --format=json`).
3. Before fix: `datamachine_log` shows `CoreMemoryFilesDirective` loading agent 1's memory file path.
4. After fix: same directive resolves agent 2's path. AI step's system prompt contains agent 2's MEMORY.md content.

No automated test added — directive payload contents aren't currently asserted by the suite. Adding one would require the directive smoke harness #1075 was carving out, which is still pending.

## Related

- #1083 — established agent execution context (this PR completes the propagation)
- #1198 — carry agent_id from parent to child jobs (this PR completes the propagation INTO the directive layer)
- #1110 — multi-agent DB primitives (made this regression observable)

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** root-cause investigation across `AIStep` → `RequestBuilder` → `PromptBuilder` → directive chain → `DirectoryManager::get_by_owner_id()`, drafting the one-line fix, and writing this PR description. Chris reviewed the trace, confirmed the symptom matches a real bug observed on intelligence-chubes4 during a WooCommerce wiki backfill, and is responsible for the change.