### PR TITLE
refactor(ai-step): split enabled_tools off handler_slugs (Phase 2b)

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -3,7 +3,7 @@
  * Plugin Name:     Data Machine
  * Plugin URI:      https://wordpress.org/plugins/data-machine/
  * Description:     AI-powered WordPress plugin for automated content workflows with visual pipeline builder and multi-provider AI integration.
- * Version:           0.80.2
+ * Version:           0.80.3
  * Requires at least: 6.9
  * Requires PHP:     8.2
  * Author:          Chris Huber, extrachill
@@ -21,7 +21,7 @@ if ( ! datamachine_check_requirements() ) {
 	return;
 }
 
-define( 'DATAMACHINE_VERSION', '0.80.2' );
+define( 'DATAMACHINE_VERSION', '0.80.3' );
 
 define( 'DATAMACHINE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DATAMACHINE_URL', plugin_dir_url( __FILE__ ) );

--- a/data-machine.php
+++ b/data-machine.php
@@ -3,7 +3,7 @@
  * Plugin Name:     Data Machine
  * Plugin URI:      https://wordpress.org/plugins/data-machine/
  * Description:     AI-powered WordPress plugin for automated content workflows with visual pipeline builder and multi-provider AI integration.
- * Version:           0.80.1
+ * Version:           0.80.2
  * Requires at least: 6.9
  * Requires PHP:     8.2
  * Author:          Chris Huber, extrachill
@@ -21,7 +21,7 @@ if ( ! datamachine_check_requirements() ) {
 	return;
 }
 
-define( 'DATAMACHINE_VERSION', '0.80.1' );
+define( 'DATAMACHINE_VERSION', '0.80.2' );
 
 define( 'DATAMACHINE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DATAMACHINE_URL', plugin_dir_url( __FILE__ ) );

--- a/data-machine.php
+++ b/data-machine.php
@@ -618,6 +618,9 @@ function datamachine_activate_for_site() {
 	// Strip dead `provider`/`model` keys from pipeline_config rows (data-machine#1180, idempotent).
 	datamachine_strip_pipeline_step_provider_model();
 
+	// Move AI step tools from handler_slugs to enabled_tools (#1205 Phase 2b, idempotent).
+	datamachine_migrate_ai_enabled_tools();
+
 	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
 	datamachine_drop_redundant_post_pipeline_meta();
 

--- a/inc/Abilities/Handler/TestHandlerAbility.php
+++ b/inc/Abilities/Handler/TestHandlerAbility.php
@@ -15,6 +15,7 @@ namespace DataMachine\Abilities\Handler;
 use DataMachine\Abilities\HandlerAbilities;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -246,15 +247,13 @@ class TestHandlerAbility {
 				continue;
 			}
 
-			$handler_slugs = $step['handler_slugs'] ?? array();
+			$slug = FlowStepConfig::getEffectiveSlug( $step );
 
-			if ( empty( $handler_slugs ) ) {
+			if ( empty( $slug ) ) {
 				continue;
 			}
 
-			$slug            = $handler_slugs[0];
-			$handler_configs = $step['handler_configs'] ?? array();
-			$handler_config  = $handler_configs[ $slug ] ?? array();
+			$handler_config = FlowStepConfig::getPrimaryHandlerConfig( $step );
 
 			return array(
 				'success'      => true,

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -323,13 +323,25 @@ class ExecuteWorkflowAbility {
 				$handler_slugs = $step['enabled_tools'];
 			}
 
+			// Preserve handler_config for handler-free step types (system_task,
+			// webhook_gate, ai with no handler) by keying it under the step
+			// type slug. Step::getHandlerConfig() falls back to this slot when
+			// no handler_slug is set, so SystemTaskStep can find its
+			// { task, params } config and the data is not silently dropped.
+			$handler_configs = array();
+			if ( ! empty( $handler_slug ) ) {
+				$handler_configs[ $handler_slug ] = $handler_config;
+			} elseif ( ! empty( $handler_config ) ) {
+				$handler_configs[ $step['type'] ] = $handler_config;
+			}
+
 			$flow_config[ $step_id ] = array(
 				'flow_step_id'     => $step_id,
 				'pipeline_step_id' => $pipeline_step_id,
 				'step_type'        => $step['type'],
 				'execution_order'  => $index,
 				'handler_slugs'    => $handler_slugs,
-				'handler_configs'  => ! empty( $handler_slug ) ? array( $handler_slug => $handler_config ) : array(),
+				'handler_configs'  => $handler_configs,
 				'user_message'     => $step['user_message'] ?? '',
 				'disabled_tools'   => $step['disabled_tools'] ?? array(),
 				'pipeline_id'      => 'direct',

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -315,30 +315,21 @@ class ExecuteWorkflowAbility {
 			$handler_config = $step['handler_config'] ?? array();
 			$step_type      = $step['type'];
 
-			// Resolve handler_slugs to mirror the on-disk shape established
-			// by inc/migrations/handler-keys.php (v0.60.0):
+			// Resolve handler_slugs. Single-purpose: it names the step's
+			// handler (always length 0..1). Three shapes match
+			// inc/migrations/handler-keys.php (v0.60.0):
 			//
 			//   1. Explicit handler_slug → [handler_slug] (fetch, publish,
 			//      upsert, …).
-			//   2. AI step with enabled_tools → enabled_tools (legacy field
-			//      overload; Phase 2b in #1205 will move this off
-			//      handler_slugs into a dedicated enabled_tools field).
-			//   3. Self-configuring step types (system_task, webhook_gate,
+			//   2. Self-configuring step types (system_task, webhook_gate,
 			//      agent_ping) with a non-empty handler_config → [step_type].
-			//      This is the synthetic-slug shape the migration uses for
-			//      handler-free steps; mirroring it here lets
-			//      FlowStepConfig::getPrimaryHandlerConfig() resolve via
-			//      handler_slugs[0] uniformly with no handler-free fallback
-			//      ladder. Step::getHandlerConfig() collapses to one line as
-			//      a result.
-			//   4. Otherwise → []. AI without enabled_tools, or
-			//      self-configuring step with no config, lands here — same as
-			//      the migration's "no config to key" branch.
+			//      Synthetic-slug shape lets FlowStepConfig::getPrimary
+			//      HandlerConfig() resolve uniformly via handler_slugs[0].
+			//   3. Otherwise → []. AI steps always land here: their tool
+			//      list lives in `enabled_tools`, not handler_slugs.
 			$handler_slugs = array();
 			if ( ! empty( $handler_slug ) ) {
 				$handler_slugs = array( $handler_slug );
-			} elseif ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
-				$handler_slugs = $step['enabled_tools'];
 			} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
 				$handler_slugs = array( $step_type );
 			}
@@ -353,6 +344,12 @@ class ExecuteWorkflowAbility {
 				$handler_configs[ $step_type ] = $handler_config;
 			}
 
+			// AI's tool list lives in its own field. handler_slugs is for
+			// handlers; enabled_tools is for AI tools. No overload.
+			$enabled_tools = ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
+				? array_values( $step['enabled_tools'] )
+				: array();
+
 			$flow_config[ $step_id ] = array(
 				'flow_step_id'     => $step_id,
 				'pipeline_step_id' => $pipeline_step_id,
@@ -360,6 +357,7 @@ class ExecuteWorkflowAbility {
 				'execution_order'  => $index,
 				'handler_slugs'    => $handler_slugs,
 				'handler_configs'  => $handler_configs,
+				'enabled_tools'    => $enabled_tools,
 				'user_message'     => $step['user_message'] ?? '',
 				'disabled_tools'   => $step['disabled_tools'] ?? array(),
 				'pipeline_id'      => 'direct',

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -313,26 +313,44 @@ class ExecuteWorkflowAbility {
 			// Flow config (instance-specific)
 			$handler_slug   = $step['handler_slug'] ?? '';
 			$handler_config = $step['handler_config'] ?? array();
+			$step_type      = $step['type'];
 
-			// Resolve handler_slugs: explicit handler_slug for non-AI steps,
-			// or enabled_tools for AI steps (tells the AI which tools it must call).
+			// Resolve handler_slugs to mirror the on-disk shape established
+			// by inc/migrations/handler-keys.php (v0.60.0):
+			//
+			//   1. Explicit handler_slug → [handler_slug] (fetch, publish,
+			//      upsert, …).
+			//   2. AI step with enabled_tools → enabled_tools (legacy field
+			//      overload; Phase 2b in #1205 will move this off
+			//      handler_slugs into a dedicated enabled_tools field).
+			//   3. Self-configuring step types (system_task, webhook_gate,
+			//      agent_ping) with a non-empty handler_config → [step_type].
+			//      This is the synthetic-slug shape the migration uses for
+			//      handler-free steps; mirroring it here lets
+			//      FlowStepConfig::getPrimaryHandlerConfig() resolve via
+			//      handler_slugs[0] uniformly with no handler-free fallback
+			//      ladder. Step::getHandlerConfig() collapses to one line as
+			//      a result.
+			//   4. Otherwise → []. AI without enabled_tools, or
+			//      self-configuring step with no config, lands here — same as
+			//      the migration's "no config to key" branch.
 			$handler_slugs = array();
 			if ( ! empty( $handler_slug ) ) {
 				$handler_slugs = array( $handler_slug );
-			} elseif ( ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
+			} elseif ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
 				$handler_slugs = $step['enabled_tools'];
+			} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
+				$handler_slugs = array( $step_type );
 			}
 
-			// Preserve handler_config for handler-free step types (system_task,
-			// webhook_gate, ai with no handler) by keying it under the step
-			// type slug. Step::getHandlerConfig() falls back to this slot when
-			// no handler_slug is set, so SystemTaskStep can find its
-			// { task, params } config and the data is not silently dropped.
+			// Key handler_configs by the primary slug (handler_slugs[0]) so
+			// FlowStepConfig::getPrimaryHandlerConfig() finds the slot
+			// without branching on step type.
 			$handler_configs = array();
 			if ( ! empty( $handler_slug ) ) {
 				$handler_configs[ $handler_slug ] = $handler_config;
-			} elseif ( ! empty( $handler_config ) ) {
-				$handler_configs[ $step['type'] ] = $handler_config;
+			} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
+				$handler_configs[ $step_type ] = $handler_config;
 			}
 
 			$flow_config[ $step_id ] = array(

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -20,6 +20,7 @@ use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Cli\AgentResolver;
 use DataMachine\Cli\UserResolver;
+use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -1064,8 +1065,7 @@ class FlowsCommand extends BaseCommand {
 		$flow_config = $flow['flow_config'] ?? array();
 
 		foreach ( $flow_config as $step_data ) {
-			$primary_slug   = $step_data['handler_slugs'][0] ?? '';
-			$primary_config = ! empty( $primary_slug ) ? ( $step_data['handler_configs'][ $primary_slug ] ?? array() ) : array();
+			$primary_config = FlowStepConfig::getPrimaryHandlerConfig( $step_data );
 			if ( ! empty( $primary_config['prompt'] ) ) {
 				$prompt = $primary_config['prompt'];
 				return mb_strlen( $prompt ) > 50

--- a/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
@@ -98,7 +98,13 @@ class PipelineSystemPromptDirective implements \DataMachine\Engine\AI\Directives
 			return '';
 		}
 
-		// Sort steps by execution_order
+		// Sort steps by execution_order.
+		//
+		// Reads handler_slugs raw (not via FlowStepConfig::getEffectiveSlug)
+		// because the workflow visualization needs to render every handler
+		// in a multi-handler step (e.g. PUBLISH_A+PUBLISH_B → AI → UPSERT),
+		// not just the primary slug. This is one of the legitimate
+		// multi-element callsites alongside ToolPolicyResolver.
 		$sorted_steps = array();
 		foreach ( $flow_config as $flow_step_id => $step_config ) {
 			$execution_order = $step_config['execution_order'] ?? -1;

--- a/inc/Core/Steps/FlowStepConfig.php
+++ b/inc/Core/Steps/FlowStepConfig.php
@@ -59,4 +59,30 @@ class FlowStepConfig {
 		}
 		return array();
 	}
+
+	/**
+	 * Get the AI step's enabled tools.
+	 *
+	 * Reads the dedicated `enabled_tools` field. The pre-Phase 2b shape
+	 * (AI tools stored under `handler_slugs`) is migrated on activation
+	 * by inc/migrations/ai-enabled-tools.php — there is no runtime
+	 * fallback to legacy data.
+	 *
+	 * @since 0.81.0
+	 *
+	 * @param array $step_config Flow step configuration array.
+	 * @return array Tool slugs the AI step has enabled. Empty for non-AI steps.
+	 */
+	public static function getEnabledTools( array $step_config ): array {
+		if ( 'ai' !== ( $step_config['step_type'] ?? '' ) ) {
+			return array();
+		}
+
+		$enabled = $step_config['enabled_tools'] ?? array();
+		if ( ! is_array( $enabled ) ) {
+			return array();
+		}
+
+		return array_values( $enabled );
+	}
 }

--- a/inc/Core/Steps/Step.php
+++ b/inc/Core/Steps/Step.php
@@ -223,11 +223,19 @@ abstract class Step {
 	/**
 	 * Get handler configuration from flow step configuration.
 	 *
+	 * Handler-bearing steps store config keyed by handler_slug.
+	 * Handler-free step types (system_task, webhook_gate, ai with no handler)
+	 * have their config keyed by step_type slug instead, since there is no
+	 * handler to key under. This accessor handles both shapes.
+	 *
 	 * @return array Handler configuration array
 	 */
 	protected function getHandlerConfig(): array {
 		$slug = $this->getHandlerSlug();
-		return ! empty( $slug ) ? ( $this->flow_step_config['handler_configs'][ $slug ] ?? array() ) : array();
+		if ( ! empty( $slug ) ) {
+			return $this->flow_step_config['handler_configs'][ $slug ] ?? array();
+		}
+		return $this->flow_step_config['handler_configs'][ $this->step_type ] ?? array();
 	}
 
 	/**

--- a/inc/Core/Steps/Step.php
+++ b/inc/Core/Steps/Step.php
@@ -212,7 +212,19 @@ abstract class Step {
 
 
 	/**
-	 * Get handler slug from flow step configuration.
+	 * Get the primary handler slug from flow step configuration.
+	 *
+	 * Returns the raw `handler_slugs[0]` value. For self-configuring step
+	 * types (system_task, webhook_gate, agent_ping), the migration in
+	 * inc/migrations/handler-keys.php and ExecuteWorkflowAbility::build
+	 * ConfigsFromWorkflow() store the step_type as the synthetic primary
+	 * slug, so this returns the step_type for those rows. Returns null
+	 * when no slug has been resolved (e.g. fetch step with no handler
+	 * configured) so the default validateStepConfiguration() can reject.
+	 *
+	 * Prefer FlowStepConfig::getEffectiveSlug() at non-Step callsites; it
+	 * is the canonical resolver and falls back to step_type when the
+	 * handler_slugs array is empty.
 	 *
 	 * @return string|null Handler slug or null if not set
 	 */
@@ -221,21 +233,19 @@ abstract class Step {
 	}
 
 	/**
-	 * Get handler configuration from flow step configuration.
+	 * Get the primary handler configuration from flow step configuration.
 	 *
-	 * Handler-bearing steps store config keyed by handler_slug.
-	 * Handler-free step types (system_task, webhook_gate, ai with no handler)
-	 * have their config keyed by step_type slug instead, since there is no
-	 * handler to key under. This accessor handles both shapes.
+	 * Reads handler_configs[handler_slugs[0]]. Handler-bearing steps key
+	 * by handler_slug; handler-free steps (system_task, webhook_gate,
+	 * agent_ping) key by step_type via the synthetic-slug shape applied
+	 * in inc/migrations/handler-keys.php and ExecuteWorkflowAbility::build
+	 * ConfigsFromWorkflow(). FlowStepConfig::getPrimaryHandlerConfig() is
+	 * the single source of truth for the lookup so callsites stay aligned.
 	 *
 	 * @return array Handler configuration array
 	 */
 	protected function getHandlerConfig(): array {
-		$slug = $this->getHandlerSlug();
-		if ( ! empty( $slug ) ) {
-			return $this->flow_step_config['handler_configs'][ $slug ] ?? array();
-		}
-		return $this->flow_step_config['handler_configs'][ $this->step_type ] ?? array();
+		return FlowStepConfig::getPrimaryHandlerConfig( $this->flow_step_config );
 	}
 
 	/**

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -162,8 +162,10 @@ class DailyMemoryTask extends SystemTask {
 		}
 
 		// Write the cleaned MEMORY.md.
-		$new_content = $parsed['persistent'];
-		$new_size    = strlen( $new_content );
+		$new_content   = $parsed['persistent'];
+		$new_size      = strlen( $new_content );
+		$archived_text = $parsed['archived'] ?? '';
+		$archived_size = strlen( $archived_text );
 
 		// Safety check: don't write if the new content is suspiciously small.
 		$target_size     = AgentMemory::MAX_FILE_SIZE;
@@ -195,19 +197,90 @@ class DailyMemoryTask extends SystemTask {
 			return;
 		}
 
+		// Conservation check: persistent + archived must approximately
+		// account for the original. The prompt explicitly says "NEVER
+		// discard information -- everything goes to either PERSISTENT or
+		// ARCHIVED", but a model that ignores that instruction can emit
+		// a short ARCHIVED section and silently lose content. Without
+		// this gate, the truncated MEMORY.md gets committed and the
+		// missing content is gone (the daily file ends up with the AI's
+		// _description_ of what it archived, not the content itself).
+		//
+		// Threshold defaults to 0.85 (combined size must be at least 85%
+		// of original) and is filterable for consumers that legitimately
+		// expect heavier compression. A value of 0 disables the check
+		// entirely (not recommended).
+		$combined_size = $new_size + $archived_size;
+
+		/**
+		 * Filter the conservation threshold for daily memory compaction.
+		 *
+		 * The persistent section plus the archived section must together
+		 * account for at least this fraction of the original MEMORY.md
+		 * size. Below the threshold the task fails rather than commit a
+		 * lossy split. Set to 0 to disable the check.
+		 *
+		 * @since 0.80.3
+		 *
+		 * @param float $threshold      Default 0.85.
+		 * @param array $context        date, original_size, new_size, archived_size, job_id.
+		 */
+		$conservation_threshold = (float) apply_filters(
+			'datamachine_daily_memory_conservation_threshold',
+			0.85,
+			array(
+				'date'          => $date,
+				'original_size' => $original_size,
+				'new_size'      => $new_size,
+				'archived_size' => $archived_size,
+				'job_id'        => $jobId,
+			)
+		);
+
+		if ( $conservation_threshold > 0 ) {
+			$min_combined = (int) ( $original_size * $conservation_threshold );
+			if ( $combined_size < $min_combined ) {
+				$discarded = $original_size - $combined_size;
+				do_action(
+					'datamachine_log',
+					'warning',
+					sprintf(
+						'Daily memory aborted -- conservation check failed: persistent (%s) + archived (%s) = %s, expected at least %s of %s original (~%s discarded). AI ignored the "NEVER discard information" rule.',
+						size_format( $new_size ),
+						size_format( $archived_size ),
+						size_format( $combined_size ),
+						size_format( $min_combined ),
+						size_format( $original_size ),
+						size_format( $discarded )
+					),
+					array(
+						'date'           => $date,
+						'original_size'  => $original_size,
+						'new_size'       => $new_size,
+						'archived_size'  => $archived_size,
+						'combined_size'  => $combined_size,
+						'min_combined'   => $min_combined,
+						'discarded_size' => $discarded,
+						'threshold'      => $conservation_threshold,
+					)
+				);
+				$this->failJob( $jobId, 'Conservation check failed -- AI emitted a lossy split. MEMORY.md unchanged.' );
+				return;
+			}
+		}
+
 		$write_result = $memory->replace_all( $new_content );
 		if ( empty( $write_result['success'] ) ) {
 			$this->failJob( $jobId, $write_result['message'] ?? 'Failed to persist cleaned memory.' );
 			return;
 		}
 
-		// Archive extracted content to the daily file.
-		$archived_size = 0;
-		$parts         = explode( '-', $date );
+		// Archive extracted content to the daily file. $archived_size
+		// is already computed above (was needed for the conservation
+		// check).
+		$parts = explode( '-', $date );
 
-		if ( ! empty( $parsed['archived'] ) ) {
-			$archived_size = strlen( $parsed['archived'] );
-
+		if ( $archived_size > 0 ) {
 			$archive_context = array(
 				'persistent'    => $parsed['persistent'],
 				'original_size' => $original_size,
@@ -220,16 +293,16 @@ class DailyMemoryTask extends SystemTask {
 			$handled = apply_filters(
 				'datamachine_daily_memory_pre_archive',
 				false,
-				$parsed['archived'],
+				$archived_text,
 				$date,
 				$archive_context
 			);
 
 			if ( ! $handled ) {
 				$archive_header = "\n### Archived from MEMORY.md\n\n";
-				$archive_text   = $archive_header . $parsed['archived'] . "\n";
+				$archive_body   = $archive_header . $archived_text . "\n";
 
-				$daily->append( $parts[0], $parts[1], $parts[2], $archive_text );
+				$daily->append( $parts[0], $parts[1], $parts[2], $archive_body );
 			}
 		}
 

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -292,6 +292,13 @@ class ToolPolicyResolver {
 		$engine_data      = $args['engine_data'] ?? array();
 
 		// Handler tools from adjacent steps (dynamic, resolved per-execution).
+		//
+		// Reads handler_slugs / handler_configs raw (not via FlowStepConfig
+		// helpers) because adjacent steps may declare multiple handler slugs
+		// (e.g. multi-handler publish: wordpress_publish + twitter_publish)
+		// and the AI must see tools for all of them, not just the primary.
+		// This is one of the legitimate multi-element callsites alongside
+		// PipelineSystemPromptDirective; see #1205 for the audit.
 		foreach ( array( $args['previous_step_config'] ?? null, $args['next_step_config'] ?? null ) as $step_config ) {
 			if ( ! $step_config ) {
 				continue;

--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -434,6 +434,13 @@ class ImportExport {
 					$flow_step_id = apply_filters( 'datamachine_generate_flow_step_id', '', $step['pipeline_step_id'], $flow['flow_id'] );
 					$flow_step    = $flow_config[ $flow_step_id ] ?? array();
 
+					// Read the primary slug raw rather than via FlowStepConfig::
+					// getEffectiveSlug() so handler-free steps (system_task,
+					// webhook_gate) don't synthesize a step_type fallback into
+					// the exported handler column when the row genuinely has
+					// no handler. The export emits a row only when the primary
+					// slug is present; FlowStepConfig's step_type fallback
+					// would defeat that gate.
 					$primary_handler = $flow_step['handler_slugs'][0] ?? '';
 
 					if ( ! empty( $primary_handler ) ) {

--- a/inc/migrations/ai-enabled-tools.php
+++ b/inc/migrations/ai-enabled-tools.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Data Machine — AI enabled_tools migration.
+ *
+ * One-shot conversion of legacy AI step rows. Pre-#1205 Phase 2b, AI
+ * step tool lists were stored under flow_step_config['handler_slugs'].
+ * After Phase 2b, handler_slugs is single-purpose (the step's handler)
+ * and AI tools live in flow_step_config['enabled_tools'].
+ *
+ * This migration moves AI rows over and clears handler_slugs so the
+ * field overload is gone for good. Idempotent: rows that already have
+ * `enabled_tools` populated are skipped.
+ *
+ * @package DataMachine
+ * @since 0.81.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Move AI step tools from handler_slugs to enabled_tools across every
+ * flow's flow_config JSON.
+ *
+ * Idempotent: skips rows where the AI step already has enabled_tools
+ * populated, or where handler_slugs is empty.
+ *
+ * @since 0.81.0
+ */
+function datamachine_migrate_ai_enabled_tools(): void {
+	$already_done = get_option( 'datamachine_ai_enabled_tools_migrated', false );
+	if ( $already_done ) {
+		return;
+	}
+
+	global $wpdb;
+	$table = $wpdb->prefix . 'datamachine_flows';
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix.
+	$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+	// phpcs:enable WordPress.DB.PreparedSQL
+	if ( ! $table_exists ) {
+		update_option( 'datamachine_ai_enabled_tools_migrated', true, true );
+		return;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix.
+	$rows = $wpdb->get_results( "SELECT flow_id, flow_config FROM {$table}", ARRAY_A );
+	// phpcs:enable WordPress.DB.PreparedSQL
+
+	if ( empty( $rows ) ) {
+		update_option( 'datamachine_ai_enabled_tools_migrated', true, true );
+		return;
+	}
+
+	$migrated = 0;
+	foreach ( $rows as $row ) {
+		$flow_config = json_decode( $row['flow_config'], true );
+		if ( ! is_array( $flow_config ) ) {
+			continue;
+		}
+
+		$changed = false;
+		foreach ( $flow_config as $step_id => &$step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+
+			if ( 'ai' !== ( $step['step_type'] ?? '' ) ) {
+				continue;
+			}
+
+			// Already migrated.
+			if ( ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
+				if ( ! empty( $step['handler_slugs'] ) ) {
+					$step['handler_slugs'] = array();
+					$changed               = true;
+				}
+				continue;
+			}
+
+			$legacy = $step['handler_slugs'] ?? array();
+			if ( empty( $legacy ) || ! is_array( $legacy ) ) {
+				// Nothing to migrate; ensure the field exists for shape consistency.
+				if ( ! isset( $step['enabled_tools'] ) ) {
+					$step['enabled_tools'] = array();
+					$changed               = true;
+				}
+				continue;
+			}
+
+			$step['enabled_tools'] = array_values( $legacy );
+			$step['handler_slugs'] = array();
+			$changed               = true;
+		}
+		unset( $step );
+
+		if ( $changed ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->update(
+				$table,
+				array( 'flow_config' => wp_json_encode( $flow_config ) ),
+				array( 'flow_id' => $row['flow_id'] ),
+				array( '%s' ),
+				array( '%d' )
+			);
+			++$migrated;
+		}
+	}
+
+	update_option( 'datamachine_ai_enabled_tools_migrated', true, true );
+
+	if ( $migrated > 0 ) {
+		do_action(
+			'datamachine_log',
+			'info',
+			'Migrated AI step tools from handler_slugs to enabled_tools',
+			array( 'flows_updated' => $migrated )
+		);
+	}
+}

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -23,3 +23,4 @@ require_once __DIR__ . '/flows.php';
 require_once __DIR__ . '/post-pipeline-meta.php';
 require_once __DIR__ . '/update-to-upsert.php';
 require_once __DIR__ . '/strip-pipeline-step-provider-model.php';
+require_once __DIR__ . '/ai-enabled-tools.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "datamachine",
-	"version": "0.80.2",
+	"version": "0.80.3",
 	"description": "AI-first WordPress plugin with Pipeline+Flow architecture",
 	"private": true,
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "datamachine",
-	"version": "0.80.1",
+	"version": "0.80.2",
 	"description": "AI-first WordPress plugin with Pipeline+Flow architecture",
 	"private": true,
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, automation, content, workflow, pipeline
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 0.80.2
+Stable tag: 0.80.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, automation, content, workflow, pipeline
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 0.80.1
+Stable tag: 0.80.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tests/ai-enabled-tools-smoke.php
+++ b/tests/ai-enabled-tools-smoke.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Pure-PHP smoke test for the AI enabled_tools split (#1205 Phase 2b).
+ *
+ * Run with: php tests/ai-enabled-tools-shim-smoke.php
+ *
+ * Phase 2b drops the field overload where flow_step_config['handler_slugs']
+ * carried both the step's handler (length 0..1) and the AI's tool list
+ * (length 0..N). After this:
+ *
+ *   - handler_slugs is single-purpose: [handler_slug] or [].
+ *   - AI tools live in flow_step_config['enabled_tools'].
+ *   - FlowStepConfig::getEnabledTools() reads the new field. No runtime
+ *     fallback to handler_slugs — legacy on-disk rows are migrated by
+ *     inc/migrations/ai-enabled-tools.php on activation.
+ *
+ * This file covers both:
+ *   1. The accessor (no shim, no fallback).
+ *   2. The migration that flips legacy rows in place.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/**
+ * Inline reimplementation of FlowStepConfig::getEnabledTools().
+ *
+ * Mirrors inc/Core/Steps/FlowStepConfig.php post-Phase 2b. Diverging
+ * here means the real file regressed.
+ */
+function get_enabled_tools_for_test( array $step_config ): array {
+	if ( 'ai' !== ( $step_config['step_type'] ?? '' ) ) {
+		return array();
+	}
+
+	$enabled = $step_config['enabled_tools'] ?? array();
+	if ( ! is_array( $enabled ) ) {
+		return array();
+	}
+
+	return array_values( $enabled );
+}
+
+/**
+ * Inline reimplementation of the per-flow_config migration step in
+ * datamachine_migrate_ai_enabled_tools(). Mirrors
+ * inc/migrations/ai-enabled-tools.php so a regression there shows up
+ * here as a fixture diverging.
+ */
+function migrate_ai_enabled_tools_for_test( array $flow_config ): array {
+	foreach ( $flow_config as $step_id => &$step ) {
+		if ( ! is_array( $step ) ) {
+			continue;
+		}
+
+		if ( 'ai' !== ( $step['step_type'] ?? '' ) ) {
+			continue;
+		}
+
+		if ( ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
+			if ( ! empty( $step['handler_slugs'] ) ) {
+				$step['handler_slugs'] = array();
+			}
+			continue;
+		}
+
+		$legacy = $step['handler_slugs'] ?? array();
+		if ( empty( $legacy ) || ! is_array( $legacy ) ) {
+			if ( ! isset( $step['enabled_tools'] ) ) {
+				$step['enabled_tools'] = array();
+			}
+			continue;
+		}
+
+		$step['enabled_tools'] = array_values( $legacy );
+		$step['handler_slugs'] = array();
+	}
+	unset( $step );
+
+	return $flow_config;
+}
+
+$failures = array();
+$passes   = 0;
+
+function assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		$passes++;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo "    expected: " . var_export( $expected, true ) . "\n";
+	echo "    actual:   " . var_export( $actual, true ) . "\n";
+}
+
+echo "AI enabled_tools split smoke (Phase 2b)\n";
+echo "---------------------------------------\n";
+
+// ----- FlowStepConfig::getEnabledTools() -----
+
+echo "\n[1] AI step with enabled_tools populated:\n";
+$config = array(
+	'flow_step_id'  => 'flow_ai_1',
+	'step_type'     => 'ai',
+	'handler_slugs' => array(),
+	'enabled_tools' => array( 'intelligence/search', 'intelligence/wiki-upsert' ),
+);
+assert_equals(
+	array( 'intelligence/search', 'intelligence/wiki-upsert' ),
+	get_enabled_tools_for_test( $config ),
+	'returns enabled_tools verbatim',
+	$failures,
+	$passes
+);
+
+echo "\n[2] AI step with no tools:\n";
+$config = array(
+	'flow_step_id' => 'flow_ai_empty',
+	'step_type'    => 'ai',
+);
+assert_equals( array(), get_enabled_tools_for_test( $config ), 'empty config → empty', $failures, $passes );
+
+echo "\n[3] AI step with handler_slugs populated but enabled_tools empty (post-migration impossible state):\n";
+// The accessor does NOT fall back. handler_slugs is for handlers; AI
+// has none. Anything stored there is dead data after the migration.
+$config = array(
+	'flow_step_id'  => 'flow_ai_legacy',
+	'step_type'     => 'ai',
+	'handler_slugs' => array( 'intelligence/search' ),
+);
+assert_equals( array(), get_enabled_tools_for_test( $config ), 'no fallback to handler_slugs', $failures, $passes );
+
+echo "\n[4] Non-AI step (publish) returns empty:\n";
+$config = array(
+	'step_type'     => 'publish',
+	'handler_slugs' => array( 'wordpress_publish' ),
+	'enabled_tools' => array( 'intelligence/search' ),
+);
+assert_equals( array(), get_enabled_tools_for_test( $config ), 'publish step has no AI tools', $failures, $passes );
+
+echo "\n[5] Step config without step_type:\n";
+$config = array(
+	'enabled_tools' => array( 'intelligence/search' ),
+);
+assert_equals( array(), get_enabled_tools_for_test( $config ), 'no step_type → empty', $failures, $passes );
+
+echo "\n[6] AI step with enabled_tools that is not an array:\n";
+$config = array(
+	'step_type'     => 'ai',
+	'enabled_tools' => 'not_an_array',
+);
+assert_equals( array(), get_enabled_tools_for_test( $config ), 'non-array enabled_tools → empty (no fatal)', $failures, $passes );
+
+// ----- inc/migrations/ai-enabled-tools.php -----
+
+echo "\n[7] Migration: legacy AI row flips handler_slugs → enabled_tools:\n";
+$flow_config = array(
+	'step_a' => array(
+		'step_type'     => 'ai',
+		'handler_slugs' => array( 'intelligence/search', 'intelligence/wiki-upsert' ),
+	),
+);
+$migrated = migrate_ai_enabled_tools_for_test( $flow_config );
+assert_equals( array( 'intelligence/search', 'intelligence/wiki-upsert' ), $migrated['step_a']['enabled_tools'], 'enabled_tools populated from handler_slugs', $failures, $passes );
+assert_equals( array(), $migrated['step_a']['handler_slugs'], 'handler_slugs cleared', $failures, $passes );
+
+echo "\n[8] Migration: AI row already on Phase 2b shape is left alone:\n";
+$flow_config = array(
+	'step_a' => array(
+		'step_type'     => 'ai',
+		'handler_slugs' => array(),
+		'enabled_tools' => array( 'intelligence/search' ),
+	),
+);
+$migrated = migrate_ai_enabled_tools_for_test( $flow_config );
+assert_equals( array( 'intelligence/search' ), $migrated['step_a']['enabled_tools'], 'enabled_tools preserved', $failures, $passes );
+assert_equals( array(), $migrated['step_a']['handler_slugs'], 'handler_slugs stays empty', $failures, $passes );
+
+echo "\n[9] Migration: dual-shape row (both populated) clears handler_slugs without overwriting enabled_tools:\n";
+// Defensive against partial-state rows. enabled_tools wins; handler_slugs is wiped.
+$flow_config = array(
+	'step_a' => array(
+		'step_type'     => 'ai',
+		'handler_slugs' => array( 'intelligence/legacy_search' ),
+		'enabled_tools' => array( 'intelligence/wiki-upsert' ),
+	),
+);
+$migrated = migrate_ai_enabled_tools_for_test( $flow_config );
+assert_equals( array( 'intelligence/wiki-upsert' ), $migrated['step_a']['enabled_tools'], 'enabled_tools wins on dual shape', $failures, $passes );
+assert_equals( array(), $migrated['step_a']['handler_slugs'], 'handler_slugs wiped on dual shape', $failures, $passes );
+
+echo "\n[10] Migration: AI row with no tools at all gets enabled_tools=[]:\n";
+$flow_config = array(
+	'step_a' => array(
+		'step_type' => 'ai',
+	),
+);
+$migrated = migrate_ai_enabled_tools_for_test( $flow_config );
+assert_equals( array(), $migrated['step_a']['enabled_tools'], 'enabled_tools field added empty', $failures, $passes );
+
+echo "\n[11] Migration: non-AI step left alone:\n";
+$flow_config = array(
+	'step_a' => array(
+		'step_type'     => 'publish',
+		'handler_slugs' => array( 'wordpress_publish' ),
+		'handler_configs' => array( 'wordpress_publish' => array( 'post_status' => 'draft' ) ),
+	),
+);
+$migrated = migrate_ai_enabled_tools_for_test( $flow_config );
+assert_equals( array( 'wordpress_publish' ), $migrated['step_a']['handler_slugs'], 'publish handler_slugs untouched', $failures, $passes );
+assert_equals( false, isset( $migrated['step_a']['enabled_tools'] ), 'no enabled_tools added to non-AI step', $failures, $passes );
+
+echo "\n[12] Migration: mixed flow with AI + publish + system_task:\n";
+$flow_config = array(
+	'step_a' => array(
+		'step_type'     => 'ai',
+		'handler_slugs' => array( 'intelligence/search' ),
+	),
+	'step_b' => array(
+		'step_type'       => 'publish',
+		'handler_slugs'   => array( 'wordpress_publish' ),
+		'handler_configs' => array( 'wordpress_publish' => array() ),
+	),
+	'step_c' => array(
+		'step_type'       => 'system_task',
+		'handler_slugs'   => array( 'system_task' ),
+		'handler_configs' => array( 'system_task' => array( 'task' => 'daily_memory_generation' ) ),
+	),
+);
+$migrated = migrate_ai_enabled_tools_for_test( $flow_config );
+assert_equals( array( 'intelligence/search' ), $migrated['step_a']['enabled_tools'], 'AI step migrated', $failures, $passes );
+assert_equals( array(), $migrated['step_a']['handler_slugs'], 'AI handler_slugs cleared', $failures, $passes );
+assert_equals( array( 'wordpress_publish' ), $migrated['step_b']['handler_slugs'], 'publish step untouched', $failures, $passes );
+assert_equals( array( 'system_task' ), $migrated['step_c']['handler_slugs'], 'system_task synthetic slug untouched', $failures, $passes );
+
+echo "\n---------------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "Failures:\n";
+	foreach ( $failures as $name ) {
+		echo "  - {$name}\n";
+	}
+	exit( 1 );
+}
+
+echo "All checks passed.\n";
+exit( 0 );

--- a/tests/daily-memory-conservation-smoke.php
+++ b/tests/daily-memory-conservation-smoke.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Pure-PHP smoke test for DailyMemoryTask conservation check.
+ *
+ * Run with: php tests/daily-memory-conservation-smoke.php
+ *
+ * Covers the conservation guardrail that blocks DailyMemoryTask from
+ * committing a lossy MEMORY.md split. Before this fix the task only
+ * validated that the persistent section was at least ~10% of the
+ * original; an AI that emitted 20KB persistent + 335B archived from a
+ * 55KB MEMORY.md silently lost ~35KB and the truncated file was
+ * written. After this fix the task verifies that
+ * persistent_size + archived_size ≈ original_size before writing.
+ *
+ * The check is filterable via
+ * `datamachine_daily_memory_conservation_threshold` (default 0.85).
+ *
+ * The guard logic is small and pure (size arithmetic), so this smoke
+ * mirrors the conservation block inline rather than booting the full
+ * task. A regression in the real file shows up when the harness'
+ * inline reimplementation diverges from the production one.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'size_format' ) ) {
+	function size_format( int $bytes ): string {
+		return $bytes . ' B';
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ): void {
+		// no-op for tests
+	}
+}
+
+/**
+ * Inline reimplementation of the conservation check body.
+ *
+ * Returns ['committed' => bool, 'reason' => string] so test
+ * assertions can verify both happy-path and reject-path behaviour.
+ */
+function evaluate_conservation(
+	int $original_size,
+	int $persistent_size,
+	int $archived_size,
+	float $threshold = 0.85
+): array {
+	if ( $threshold <= 0 ) {
+		return array(
+			'committed' => true,
+			'reason'    => 'threshold disabled',
+		);
+	}
+
+	$combined     = $persistent_size + $archived_size;
+	$min_combined = (int) ( $original_size * $threshold );
+
+	if ( $combined < $min_combined ) {
+		return array(
+			'committed' => false,
+			'reason'    => sprintf(
+				'conservation check failed: %d + %d = %d < %d',
+				$persistent_size,
+				$archived_size,
+				$combined,
+				$min_combined
+			),
+		);
+	}
+
+	return array(
+		'committed' => true,
+		'reason'    => 'conservation ok',
+	);
+}
+
+$failures = array();
+$passes   = 0;
+
+function assert_committed( bool $expected, array $result, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $result['committed'] ) {
+		$passes++;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo "    expected committed: " . ( $expected ? 'true' : 'false' ) . "\n";
+	echo "    actual:             " . ( $result['committed'] ? 'true' : 'false' ) . "\n";
+	echo "    reason: {$result['reason']}\n";
+}
+
+echo "daily memory conservation smoke\n";
+echo "-------------------------------\n";
+
+// Test 1: real-world reproducer from intelligence-chubes4 2026-04-25.
+// 55KB original, 20KB persistent, 335B archived. Should reject.
+echo "\n[1] reproducer from live failure (55KB → 20KB + 335B):\n";
+$result = evaluate_conservation( 55 * 1024, 20 * 1024, 335 );
+assert_committed( false, $result, 'live failure case is rejected', $failures, $passes );
+
+// Test 2: legitimate compaction with full archive (e.g. 60KB → 20KB persistent + 35KB archived).
+// Combined = 55KB ≈ 95% of 58KB original — passes 85% threshold.
+echo "\n[2] healthy compaction (58KB → 20KB persistent + 35KB archived):\n";
+$result = evaluate_conservation( 58 * 1024, 20 * 1024, 35 * 1024 );
+assert_committed( true, $result, 'healthy compaction commits', $failures, $passes );
+
+// Test 3: edge case — exactly at 85% threshold.
+echo "\n[3] exactly at 85% threshold:\n";
+$result = evaluate_conservation( 1000, 850, 0 );
+assert_committed( true, $result, '850/1000 with threshold 0.85 commits', $failures, $passes );
+
+// Test 4: just below threshold.
+echo "\n[4] just below 85% threshold:\n";
+$result = evaluate_conservation( 1000, 849, 0 );
+assert_committed( false, $result, '849/1000 with threshold 0.85 rejects', $failures, $passes );
+
+// Test 5: filter override to disable check.
+echo "\n[5] threshold = 0 disables the check (existing behaviour):\n";
+$result = evaluate_conservation( 55 * 1024, 20 * 1024, 335, 0.0 );
+assert_committed( true, $result, 'threshold 0 lets old behaviour through', $failures, $passes );
+
+// Test 6: filter override to a stricter threshold.
+echo "\n[6] strict threshold (0.95) tightens the gate:\n";
+$result = evaluate_conservation( 1000, 850, 100, 0.95 );
+assert_committed( true, $result, '950/1000 ≥ 95% commits', $failures, $passes );
+
+$result = evaluate_conservation( 1000, 850, 50, 0.95 );
+assert_committed( false, $result, '900/1000 < 95% rejects under strict threshold', $failures, $passes );
+
+// Test 7: zero archived (compaction with no archive). Persistent must
+// stand on its own at >= threshold of original.
+echo "\n[7] no archive section, persistent ≥ threshold:\n";
+$result = evaluate_conservation( 1000, 900, 0 );
+assert_committed( true, $result, '900/1000 commits without archive', $failures, $passes );
+
+$result = evaluate_conservation( 1000, 800, 0 );
+assert_committed( false, $result, '800/1000 rejects without archive', $failures, $passes );
+
+// Test 8: no compaction at all (idempotent or no-op case). Persistent
+// equals original, archive is empty. Must commit.
+echo "\n[8] no-op case (persistent == original, archive empty):\n";
+$result = evaluate_conservation( 5000, 5000, 0 );
+assert_committed( true, $result, 'no-op compaction commits', $failures, $passes );
+
+// Test 9: combined > original (AI duplicated content into both
+// sections). Should still commit — we only enforce the lower bound.
+// Filtering for double-write would belong elsewhere.
+echo "\n[9] combined > original (AI duplicated into both sections):\n";
+$result = evaluate_conservation( 1000, 800, 600 );
+assert_committed( true, $result, 'duplicate split commits (only lower bound enforced)', $failures, $passes );
+
+echo "\n-------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "Failures:\n";
+	foreach ( $failures as $name ) {
+		echo "  - {$name}\n";
+	}
+	exit( 1 );
+}
+
+echo "All checks passed.\n";
+exit( 0 );

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -50,8 +50,6 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 		$handler_slugs = array();
 		if ( ! empty( $handler_slug ) ) {
 			$handler_slugs = array( $handler_slug );
-		} elseif ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
-			$handler_slugs = $step['enabled_tools'];
 		} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
 			$handler_slugs = array( $step_type );
 		}
@@ -63,6 +61,10 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 			$handler_configs[ $step_type ] = $handler_config;
 		}
 
+		$enabled_tools = ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
+			? array_values( $step['enabled_tools'] )
+			: array();
+
 		$flow_config[ $step_id ] = array(
 			'flow_step_id'     => $step_id,
 			'pipeline_step_id' => $pipeline_step_id,
@@ -70,6 +72,7 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 			'execution_order'  => $index,
 			'handler_slugs'    => $handler_slugs,
 			'handler_configs'  => $handler_configs,
+			'enabled_tools'    => $enabled_tools,
 			'user_message'     => $step['user_message'] ?? '',
 			'disabled_tools'   => $step['disabled_tools'] ?? array(),
 			'pipeline_id'      => 'direct',
@@ -136,8 +139,8 @@ function assert_equals( $expected, $actual, string $name, array &$failures, int 
 	echo "    actual:   " . var_export( $actual, true ) . "\n";
 }
 
-echo "system-task config passthrough smoke (Phase 2a)\n";
-echo "-----------------------------------------------\n";
+echo "system-task config passthrough smoke (Phase 2a + 2b)\n";
+echo "-----------------------------------------------------\n";
 
 // Test 1: system_task workflow round-trips handler_config under step type slug.
 echo "\n[1] system_task workflow round-trips { task, params }:\n";
@@ -207,10 +210,10 @@ assert_equals( array(), $step0['handler_configs'], 'no config → empty handler_
 assert_equals( array(), get_primary_handler_config_for_test( $step0 ), 'getPrimaryHandlerConfig returns empty', $failures, $passes );
 assert_equals( 'webhook_gate', get_effective_slug_for_test( $step0 ), 'getEffectiveSlug falls back to step_type', $failures, $passes );
 
-// Test 4: ai step with enabled_tools (no handler_slug, no handler_config).
-// Phase 2a preserves the legacy AI shape (enabled_tools as handler_slugs);
-// Phase 2b in #1205 will move enabled_tools to its own field.
-echo "\n[4] ai step with enabled_tools (legacy shape preserved for Phase 2a):\n";
+// Test 4: ai step with enabled_tools.
+// Phase 2b: tools now land in `enabled_tools` and `handler_slugs` stays empty
+// for AI steps. The field overload (enabled_tools as handler_slugs) is gone.
+echo "\n[4] ai step with enabled_tools (Phase 2b shape):\n";
 $workflow = array(
 	'steps' => array(
 		array(
@@ -224,13 +227,12 @@ $workflow = array(
 $built = build_configs_from_workflow_for_test( $workflow );
 $step0 = $built['flow_config']['ephemeral_step_0'];
 
-assert_equals( array( 'intelligence/search', 'intelligence/wiki-upsert' ), $step0['handler_slugs'], 'enabled_tools become handler_slugs', $failures, $passes );
+assert_equals( array( 'intelligence/search', 'intelligence/wiki-upsert' ), $step0['enabled_tools'], 'enabled_tools land in dedicated field', $failures, $passes );
+assert_equals( array(), $step0['handler_slugs'], 'ai handler_slugs stays empty (single-purpose now)', $failures, $passes );
 assert_equals( array(), $step0['handler_configs'], 'ai step without handler_config → empty handler_configs', $failures, $passes );
 assert_equals( 'be helpful', $built['pipeline_config']['ephemeral_pipeline_0']['system_prompt'] ?? null, 'system_prompt lands in pipeline_config', $failures, $passes );
 
-// Test 5: ai step with no enabled_tools, no handler — must NOT synthesize step_type as a slug.
-// AI semantics treat handler_slugs as "enabled tools"; synthesizing 'ai' would pollute the AI
-// tool registry intersection in AIStep::resolve_pipeline_tools() and ToolPolicyResolver.
+// Test 5: ai step with no enabled_tools, no handler — both arrays empty, including the new field.
 echo "\n[5] ai step with no enabled_tools and no handler_config:\n";
 $workflow = array(
 	'steps' => array(
@@ -244,7 +246,8 @@ $workflow = array(
 $built = build_configs_from_workflow_for_test( $workflow );
 $step0 = $built['flow_config']['ephemeral_step_0'];
 
-assert_equals( array(), $step0['handler_slugs'], 'ai with no tools does not synthesize step_type', $failures, $passes );
+assert_equals( array(), $step0['handler_slugs'], 'ai handler_slugs stays empty', $failures, $passes );
+assert_equals( array(), $step0['enabled_tools'], 'ai enabled_tools empty when none provided', $failures, $passes );
 assert_equals( array(), $step0['handler_configs'], 'ai with no config → empty handler_configs', $failures, $passes );
 
 // Test 6: regression — system_task workflow that bypassed validation
@@ -270,7 +273,7 @@ $config = get_primary_handler_config_for_test( $step0 );
 assert_equals( 'agent_ping', $config['task'] ?? null, 'task type reaches step runtime', $failures, $passes );
 assert_equals( array( 'agent_id' => 2 ), $config['params'] ?? null, 'task params reach step runtime', $failures, $passes );
 
-echo "\n-----------------------------------------------\n";
+echo "\n-----------------------------------------------------\n";
 $total = $passes + count( $failures );
 echo "{$passes} / {$total} passed\n";
 

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Pure-PHP smoke test for handler-free step config passthrough.
+ *
+ * Run with: php tests/system-task-config-passthrough-smoke.php
+ *
+ * Covers the build-side + read-side fix that lets handler-free step
+ * types (system_task, webhook_gate, ai with no handler) preserve their
+ * handler_config across the workflow → flow_config → step runtime
+ * translation.
+ *
+ * Before this fix, ExecuteWorkflowAbility::buildConfigsFromWorkflow()
+ * dropped handler_config to an empty array whenever handler_slug was
+ * empty, and Step::getHandlerConfig() returned an empty array on the
+ * read side for the same reason. system_task workflows passing
+ * { task: 'daily_memory_generation', params: {} } got the config
+ * silently dropped and failed with system_task_missing_task_type.
+ *
+ * The fix keys handler-free configs by the step type slug on both
+ * sides so they round-trip correctly.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/**
+ * Inline reimplementation of ExecuteWorkflowAbility::buildConfigsFromWorkflow()
+ * for pure-PHP testing (the real method is private + lives in a class
+ * with WordPress dependencies).
+ *
+ * Mirrors the post-fix shape so a regression in the real file shows up
+ * as the fixture diverging from the harness.
+ */
+function build_configs_from_workflow_for_test( array $workflow ): array {
+	$flow_config     = array();
+	$pipeline_config = array();
+
+	foreach ( $workflow['steps'] as $index => $step ) {
+		$step_id          = "ephemeral_step_{$index}";
+		$pipeline_step_id = "ephemeral_pipeline_{$index}";
+
+		$handler_slug   = $step['handler_slug'] ?? '';
+		$handler_config = $step['handler_config'] ?? array();
+
+		$handler_slugs = array();
+		if ( ! empty( $handler_slug ) ) {
+			$handler_slugs = array( $handler_slug );
+		} elseif ( ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
+			$handler_slugs = $step['enabled_tools'];
+		}
+
+		$handler_configs = array();
+		if ( ! empty( $handler_slug ) ) {
+			$handler_configs[ $handler_slug ] = $handler_config;
+		} elseif ( ! empty( $handler_config ) ) {
+			$handler_configs[ $step['type'] ] = $handler_config;
+		}
+
+		$flow_config[ $step_id ] = array(
+			'flow_step_id'     => $step_id,
+			'pipeline_step_id' => $pipeline_step_id,
+			'step_type'        => $step['type'],
+			'execution_order'  => $index,
+			'handler_slugs'    => $handler_slugs,
+			'handler_configs'  => $handler_configs,
+			'user_message'     => $step['user_message'] ?? '',
+			'disabled_tools'   => $step['disabled_tools'] ?? array(),
+			'pipeline_id'      => 'direct',
+			'flow_id'          => 'direct',
+		);
+
+		if ( 'ai' === $step['type'] ) {
+			$pipeline_config[ $pipeline_step_id ] = array(
+				'system_prompt'  => $step['system_prompt'] ?? '',
+				'disabled_tools' => $step['disabled_tools'] ?? array(),
+			);
+		}
+	}
+
+	return array(
+		'flow_config'     => $flow_config,
+		'pipeline_config' => $pipeline_config,
+	);
+}
+
+/**
+ * Inline reimplementation of Step::getHandlerConfig() read-side.
+ *
+ * Mirrors the post-fix shape: when no handler_slug, fall back to
+ * handler_configs keyed by step_type.
+ */
+function get_handler_config_for_test( array $flow_step_config, string $step_type ): array {
+	$slug = $flow_step_config['handler_slugs'][0] ?? null;
+	if ( ! empty( $slug ) ) {
+		return $flow_step_config['handler_configs'][ $slug ] ?? array();
+	}
+	return $flow_step_config['handler_configs'][ $step_type ] ?? array();
+}
+
+$failures = array();
+$passes   = 0;
+
+function assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		$passes++;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo "    expected: " . var_export( $expected, true ) . "\n";
+	echo "    actual:   " . var_export( $actual, true ) . "\n";
+}
+
+echo "system-task config passthrough smoke\n";
+echo "------------------------------------\n";
+
+// Test 1: system_task workflow round-trips handler_config under step type slug.
+echo "\n[1] system_task workflow round-trips { task, params }:\n";
+$workflow = array(
+	'steps' => array(
+		array(
+			'type'           => 'system_task',
+			'handler_config' => array(
+				'task'   => 'daily_memory_generation',
+				'params' => array(),
+			),
+		),
+	),
+);
+
+$built  = build_configs_from_workflow_for_test( $workflow );
+$step0  = $built['flow_config']['ephemeral_step_0'];
+$config = get_handler_config_for_test( $step0, 'system_task' );
+
+assert_equals( 'daily_memory_generation', $config['task'] ?? null, 'task survives passthrough', $failures, $passes );
+assert_equals( array(), $config['params'] ?? null, 'params survives passthrough', $failures, $passes );
+assert_equals( array(), $step0['handler_slugs'], 'handler_slugs is empty', $failures, $passes );
+assert_equals( array( 'system_task' => array( 'task' => 'daily_memory_generation', 'params' => array() ) ), $step0['handler_configs'], 'handler_configs keyed by step type', $failures, $passes );
+
+// Test 2: handler-bearing step still keys by handler_slug.
+echo "\n[2] fetch step (handler-bearing) keys handler_configs by handler_slug:\n";
+$workflow = array(
+	'steps' => array(
+		array(
+			'type'           => 'fetch',
+			'handler_slug'   => 'mcp',
+			'handler_config' => array(
+				'server'   => 'a8c',
+				'provider' => 'mgs',
+			),
+		),
+	),
+);
+
+$built  = build_configs_from_workflow_for_test( $workflow );
+$step0  = $built['flow_config']['ephemeral_step_0'];
+$config = get_handler_config_for_test( $step0, 'fetch' );
+
+assert_equals( 'a8c', $config['server'] ?? null, 'server reachable via handler_slug', $failures, $passes );
+assert_equals( array( 'mcp' ), $step0['handler_slugs'], 'handler_slugs has mcp', $failures, $passes );
+assert_equals( array( 'mcp' => array( 'server' => 'a8c', 'provider' => 'mgs' ) ), $step0['handler_configs'], 'handler_configs keyed by handler_slug', $failures, $passes );
+
+// Test 3: empty handler_config and no handler_slug → empty handler_configs.
+echo "\n[3] handler-free step with no config has empty handler_configs:\n";
+$workflow = array(
+	'steps' => array(
+		array(
+			'type' => 'webhook_gate',
+		),
+	),
+);
+
+$built = build_configs_from_workflow_for_test( $workflow );
+$step0 = $built['flow_config']['ephemeral_step_0'];
+
+assert_equals( array(), $step0['handler_configs'], 'no config → empty handler_configs', $failures, $passes );
+assert_equals( array(), get_handler_config_for_test( $step0, 'webhook_gate' ), 'getHandlerConfig returns empty', $failures, $passes );
+
+// Test 4: ai step with enabled_tools (no handler_slug, no handler_config).
+// AI steps carry their step config via pipeline_config (system_prompt),
+// not handler_config — so handler_configs stays empty here.  The build
+// side still emits handler_slugs from enabled_tools so the AI step
+// knows which tools to expose.
+echo "\n[4] ai step with enabled_tools:\n";
+$workflow = array(
+	'steps' => array(
+		array(
+			'type'          => 'ai',
+			'system_prompt' => 'be helpful',
+			'enabled_tools' => array( 'intelligence/search', 'intelligence/wiki-upsert' ),
+		),
+	),
+);
+
+$built = build_configs_from_workflow_for_test( $workflow );
+$step0 = $built['flow_config']['ephemeral_step_0'];
+
+assert_equals( array( 'intelligence/search', 'intelligence/wiki-upsert' ), $step0['handler_slugs'], 'enabled_tools become handler_slugs', $failures, $passes );
+assert_equals( array(), $step0['handler_configs'], 'ai step without handler_config → empty handler_configs', $failures, $passes );
+assert_equals( 'be helpful', $built['pipeline_config']['ephemeral_pipeline_0']['system_prompt'] ?? null, 'system_prompt lands in pipeline_config', $failures, $passes );
+
+// Test 5: regression — system_task workflow that bypassed validation
+// after #1200 still got handler_config dropped.  After this fix, the
+// task type is reachable end-to-end.
+echo "\n[5] regression: validate→build→getHandlerConfig pipeline:\n";
+$workflow = array(
+	'steps' => array(
+		array(
+			'type'           => 'system_task',
+			'handler_config' => array(
+				'task'   => 'agent_ping',
+				'params' => array( 'agent_id' => 2 ),
+			),
+		),
+	),
+);
+
+$built  = build_configs_from_workflow_for_test( $workflow );
+$step0  = $built['flow_config']['ephemeral_step_0'];
+$config = get_handler_config_for_test( $step0, 'system_task' );
+
+assert_equals( 'agent_ping', $config['task'] ?? null, 'task type reaches step runtime', $failures, $passes );
+assert_equals( array( 'agent_id' => 2 ), $config['params'] ?? null, 'task params reach step runtime', $failures, $passes );
+
+echo "\n------------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "Failures:\n";
+	foreach ( $failures as $name ) {
+		echo "  - {$name}\n";
+	}
+	exit( 1 );
+}
+
+echo "All checks passed.\n";
+exit( 0 );

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -5,19 +5,20 @@
  * Run with: php tests/system-task-config-passthrough-smoke.php
  *
  * Covers the build-side + read-side fix that lets handler-free step
- * types (system_task, webhook_gate, ai with no handler) preserve their
+ * types (system_task, webhook_gate, agent_ping) preserve their
  * handler_config across the workflow → flow_config → step runtime
  * translation.
  *
- * Before this fix, ExecuteWorkflowAbility::buildConfigsFromWorkflow()
- * dropped handler_config to an empty array whenever handler_slug was
- * empty, and Step::getHandlerConfig() returned an empty array on the
- * read side for the same reason. system_task workflows passing
- * { task: 'daily_memory_generation', params: {} } got the config
- * silently dropped and failed with system_task_missing_task_type.
+ * Phase 1 fix (#1202): keyed handler-free configs by step_type and
+ * added a fallback in Step::getHandlerConfig() so SystemTaskStep could
+ * find its { task, params }.
  *
- * The fix keys handler-free configs by the step type slug on both
- * sides so they round-trip correctly.
+ * Phase 2a fix (#1205): collapsed onto FlowStepConfig::getPrimary
+ * HandlerConfig() by writing handler_slugs = [step_type] for handler-
+ * free steps with a non-empty handler_config (mirrors the v0.60.0
+ * migration in inc/migrations/handler-keys.php). This drops the read-
+ * side fallback ladder in Step::getHandlerConfig() — the helper now
+ * resolves uniformly via handler_slugs[0].
  *
  * @package DataMachine\Tests
  */
@@ -31,8 +32,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * for pure-PHP testing (the real method is private + lives in a class
  * with WordPress dependencies).
  *
- * Mirrors the post-fix shape so a regression in the real file shows up
- * as the fixture diverging from the harness.
+ * Mirrors the post-#1205 shape so a regression in the real file shows
+ * up as the fixture diverging from the harness.
  */
 function build_configs_from_workflow_for_test( array $workflow ): array {
 	$flow_config     = array();
@@ -44,25 +45,28 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 
 		$handler_slug   = $step['handler_slug'] ?? '';
 		$handler_config = $step['handler_config'] ?? array();
+		$step_type      = $step['type'];
 
 		$handler_slugs = array();
 		if ( ! empty( $handler_slug ) ) {
 			$handler_slugs = array( $handler_slug );
-		} elseif ( ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
+		} elseif ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
 			$handler_slugs = $step['enabled_tools'];
+		} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
+			$handler_slugs = array( $step_type );
 		}
 
 		$handler_configs = array();
 		if ( ! empty( $handler_slug ) ) {
 			$handler_configs[ $handler_slug ] = $handler_config;
-		} elseif ( ! empty( $handler_config ) ) {
-			$handler_configs[ $step['type'] ] = $handler_config;
+		} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
+			$handler_configs[ $step_type ] = $handler_config;
 		}
 
 		$flow_config[ $step_id ] = array(
 			'flow_step_id'     => $step_id,
 			'pipeline_step_id' => $pipeline_step_id,
-			'step_type'        => $step['type'],
+			'step_type'        => $step_type,
 			'execution_order'  => $index,
 			'handler_slugs'    => $handler_slugs,
 			'handler_configs'  => $handler_configs,
@@ -72,7 +76,7 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 			'flow_id'          => 'direct',
 		);
 
-		if ( 'ai' === $step['type'] ) {
+		if ( 'ai' === $step_type ) {
 			$pipeline_config[ $pipeline_step_id ] = array(
 				'system_prompt'  => $step['system_prompt'] ?? '',
 				'disabled_tools' => $step['disabled_tools'] ?? array(),
@@ -87,17 +91,33 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 }
 
 /**
- * Inline reimplementation of Step::getHandlerConfig() read-side.
+ * Inline reimplementation of FlowStepConfig::getPrimaryHandlerConfig().
  *
- * Mirrors the post-fix shape: when no handler_slug, fall back to
- * handler_configs keyed by step_type.
+ * Reads handler_configs[handler_slugs[0]] uniformly. The fallback ladder
+ * Step::getHandlerConfig() carried in #1202 is gone — the build side
+ * now writes handler_slugs = [step_type] for handler-free steps with a
+ * non-empty handler_config so this single lookup resolves both shapes.
  */
-function get_handler_config_for_test( array $flow_step_config, string $step_type ): array {
-	$slug = $flow_step_config['handler_slugs'][0] ?? null;
-	if ( ! empty( $slug ) ) {
-		return $flow_step_config['handler_configs'][ $slug ] ?? array();
+function get_primary_handler_config_for_test( array $flow_step_config ): array {
+	$slug = $flow_step_config['handler_slugs'][0] ?? '';
+	if ( ! empty( $slug ) && ! empty( $flow_step_config['handler_configs'][ $slug ] ) ) {
+		return $flow_step_config['handler_configs'][ $slug ];
 	}
-	return $flow_step_config['handler_configs'][ $step_type ] ?? array();
+	return array();
+}
+
+/**
+ * Inline reimplementation of FlowStepConfig::getEffectiveSlug().
+ */
+function get_effective_slug_for_test( array $flow_step_config, string $explicit_slug = '' ): string {
+	if ( ! empty( $explicit_slug ) ) {
+		return $explicit_slug;
+	}
+	$primary = $flow_step_config['handler_slugs'][0] ?? '';
+	if ( ! empty( $primary ) ) {
+		return $primary;
+	}
+	return $flow_step_config['step_type'] ?? '';
 }
 
 $failures = array();
@@ -116,8 +136,8 @@ function assert_equals( $expected, $actual, string $name, array &$failures, int 
 	echo "    actual:   " . var_export( $actual, true ) . "\n";
 }
 
-echo "system-task config passthrough smoke\n";
-echo "------------------------------------\n";
+echo "system-task config passthrough smoke (Phase 2a)\n";
+echo "-----------------------------------------------\n";
 
 // Test 1: system_task workflow round-trips handler_config under step type slug.
 echo "\n[1] system_task workflow round-trips { task, params }:\n";
@@ -135,12 +155,13 @@ $workflow = array(
 
 $built  = build_configs_from_workflow_for_test( $workflow );
 $step0  = $built['flow_config']['ephemeral_step_0'];
-$config = get_handler_config_for_test( $step0, 'system_task' );
+$config = get_primary_handler_config_for_test( $step0 );
 
 assert_equals( 'daily_memory_generation', $config['task'] ?? null, 'task survives passthrough', $failures, $passes );
 assert_equals( array(), $config['params'] ?? null, 'params survives passthrough', $failures, $passes );
-assert_equals( array(), $step0['handler_slugs'], 'handler_slugs is empty', $failures, $passes );
+assert_equals( array( 'system_task' ), $step0['handler_slugs'], 'handler_slugs synthesized from step_type', $failures, $passes );
 assert_equals( array( 'system_task' => array( 'task' => 'daily_memory_generation', 'params' => array() ) ), $step0['handler_configs'], 'handler_configs keyed by step type', $failures, $passes );
+assert_equals( 'system_task', get_effective_slug_for_test( $step0 ), 'getEffectiveSlug returns step_type', $failures, $passes );
 
 // Test 2: handler-bearing step still keys by handler_slug.
 echo "\n[2] fetch step (handler-bearing) keys handler_configs by handler_slug:\n";
@@ -159,14 +180,17 @@ $workflow = array(
 
 $built  = build_configs_from_workflow_for_test( $workflow );
 $step0  = $built['flow_config']['ephemeral_step_0'];
-$config = get_handler_config_for_test( $step0, 'fetch' );
+$config = get_primary_handler_config_for_test( $step0 );
 
 assert_equals( 'a8c', $config['server'] ?? null, 'server reachable via handler_slug', $failures, $passes );
 assert_equals( array( 'mcp' ), $step0['handler_slugs'], 'handler_slugs has mcp', $failures, $passes );
 assert_equals( array( 'mcp' => array( 'server' => 'a8c', 'provider' => 'mgs' ) ), $step0['handler_configs'], 'handler_configs keyed by handler_slug', $failures, $passes );
+assert_equals( 'mcp', get_effective_slug_for_test( $step0 ), 'getEffectiveSlug returns handler_slug', $failures, $passes );
 
-// Test 3: empty handler_config and no handler_slug → empty handler_configs.
-echo "\n[3] handler-free step with no config has empty handler_configs:\n";
+// Test 3: empty handler_config and no handler_slug → empty handler_configs and empty handler_slugs.
+// Mirrors inc/migrations/handler-keys.php: when there is nothing to key,
+// both arrays stay empty rather than synthesizing a slug-with-no-config row.
+echo "\n[3] handler-free step with no config has empty handler_configs and handler_slugs:\n";
 $workflow = array(
 	'steps' => array(
 		array(
@@ -178,15 +202,15 @@ $workflow = array(
 $built = build_configs_from_workflow_for_test( $workflow );
 $step0 = $built['flow_config']['ephemeral_step_0'];
 
+assert_equals( array(), $step0['handler_slugs'], 'no config → empty handler_slugs', $failures, $passes );
 assert_equals( array(), $step0['handler_configs'], 'no config → empty handler_configs', $failures, $passes );
-assert_equals( array(), get_handler_config_for_test( $step0, 'webhook_gate' ), 'getHandlerConfig returns empty', $failures, $passes );
+assert_equals( array(), get_primary_handler_config_for_test( $step0 ), 'getPrimaryHandlerConfig returns empty', $failures, $passes );
+assert_equals( 'webhook_gate', get_effective_slug_for_test( $step0 ), 'getEffectiveSlug falls back to step_type', $failures, $passes );
 
 // Test 4: ai step with enabled_tools (no handler_slug, no handler_config).
-// AI steps carry their step config via pipeline_config (system_prompt),
-// not handler_config — so handler_configs stays empty here.  The build
-// side still emits handler_slugs from enabled_tools so the AI step
-// knows which tools to expose.
-echo "\n[4] ai step with enabled_tools:\n";
+// Phase 2a preserves the legacy AI shape (enabled_tools as handler_slugs);
+// Phase 2b in #1205 will move enabled_tools to its own field.
+echo "\n[4] ai step with enabled_tools (legacy shape preserved for Phase 2a):\n";
 $workflow = array(
 	'steps' => array(
 		array(
@@ -204,10 +228,29 @@ assert_equals( array( 'intelligence/search', 'intelligence/wiki-upsert' ), $step
 assert_equals( array(), $step0['handler_configs'], 'ai step without handler_config → empty handler_configs', $failures, $passes );
 assert_equals( 'be helpful', $built['pipeline_config']['ephemeral_pipeline_0']['system_prompt'] ?? null, 'system_prompt lands in pipeline_config', $failures, $passes );
 
-// Test 5: regression — system_task workflow that bypassed validation
-// after #1200 still got handler_config dropped.  After this fix, the
-// task type is reachable end-to-end.
-echo "\n[5] regression: validate→build→getHandlerConfig pipeline:\n";
+// Test 5: ai step with no enabled_tools, no handler — must NOT synthesize step_type as a slug.
+// AI semantics treat handler_slugs as "enabled tools"; synthesizing 'ai' would pollute the AI
+// tool registry intersection in AIStep::resolve_pipeline_tools() and ToolPolicyResolver.
+echo "\n[5] ai step with no enabled_tools and no handler_config:\n";
+$workflow = array(
+	'steps' => array(
+		array(
+			'type'          => 'ai',
+			'system_prompt' => 'be helpful',
+		),
+	),
+);
+
+$built = build_configs_from_workflow_for_test( $workflow );
+$step0 = $built['flow_config']['ephemeral_step_0'];
+
+assert_equals( array(), $step0['handler_slugs'], 'ai with no tools does not synthesize step_type', $failures, $passes );
+assert_equals( array(), $step0['handler_configs'], 'ai with no config → empty handler_configs', $failures, $passes );
+
+// Test 6: regression — system_task workflow that bypassed validation
+// after #1200 still got handler_config dropped before #1202. After
+// Phase 2a, the task type is reachable end-to-end via the helper.
+echo "\n[6] regression: validate→build→getPrimaryHandlerConfig pipeline:\n";
 $workflow = array(
 	'steps' => array(
 		array(
@@ -222,12 +265,12 @@ $workflow = array(
 
 $built  = build_configs_from_workflow_for_test( $workflow );
 $step0  = $built['flow_config']['ephemeral_step_0'];
-$config = get_handler_config_for_test( $step0, 'system_task' );
+$config = get_primary_handler_config_for_test( $step0 );
 
 assert_equals( 'agent_ping', $config['task'] ?? null, 'task type reaches step runtime', $failures, $passes );
 assert_equals( array( 'agent_id' => 2 ), $config['params'] ?? null, 'task params reach step runtime', $failures, $passes );
 
-echo "\n------------------------------------\n";
+echo "\n-----------------------------------------------\n";
 $total = $passes + count( $failures );
 echo "{$passes} / {$total} passed\n";
 

--- a/tests/tool-policy-resolver-adjacency-smoke.php
+++ b/tests/tool-policy-resolver-adjacency-smoke.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Pure-PHP smoke test for ToolPolicyResolver adjacency with handler-free steps.
+ *
+ * Run with: php tests/tool-policy-resolver-adjacency-smoke.php
+ *
+ * After Phase 2a (#1205), ExecuteWorkflowAbility::buildConfigsFromWorkflow()
+ * writes handler_slugs = [step_type] for handler-free step types
+ * (system_task, webhook_gate, agent_ping) with a non-empty handler_config,
+ * mirroring inc/migrations/handler-keys.php (v0.60.0).
+ *
+ * ToolPolicyResolver::gatherPipelineTools() iterates handler_slugs from
+ * adjacent steps to surface their handler tools to the AI. The
+ * synthetic-slug shape means an adjacent system_task step will have
+ * handler_slugs = ['system_task'] — a slug that does NOT correspond to a
+ * registered handler tool. The resolver MUST handle that gracefully:
+ * when ToolManager::resolveHandlerTools('system_task', …) returns no
+ * tools, the resolver moves on without injecting a synthetic 'system_task'
+ * pseudo-tool into the AI's tool list.
+ *
+ * This regression guard verifies the iteration shape stays correct: the
+ * resolver visits each slug, asks the tool manager for tools, and only
+ * adds tools the manager actually returns. A handler-free synthetic slug
+ * yielding an empty result must not pollute the available_tools map.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/**
+ * Stub ToolManager that records the slugs the resolver asked for and
+ * returns canned tools per slug. A real handler slug
+ * ('wordpress_publish') gets back a real tool; a synthetic slug
+ * ('system_task') gets back an empty array, simulating what the unified
+ * datamachine_tools registry actually does for unknown handler slugs.
+ */
+class StubToolManager {
+	public array $resolveCalls = array();
+
+	public function resolveHandlerTools( string $slug, array $config, array $engine_data, string $cache_scope ): array {
+		$this->resolveCalls[] = $slug;
+
+		if ( 'wordpress_publish' === $slug ) {
+			return array(
+				'wordpress_publish_tool' => array(
+					'description'       => 'Publish a post',
+					'_handler_callable' => 'wordpress_publish::handler',
+				),
+			);
+		}
+
+		// All other slugs (including handler-free synthetic step_type
+		// slugs like 'system_task' or 'webhook_gate') return no tools.
+		return array();
+	}
+}
+
+/**
+ * Inline reimplementation of ToolPolicyResolver::gatherPipelineTools()
+ * adjacency loop. Mirrors inc/Engine/AI/Tools/ToolPolicyResolver.php
+ * post-#1205 (the documentation-only edit there did not change the
+ * iteration shape).
+ */
+function gather_pipeline_handler_tools_for_test( array $args, StubToolManager $tool_manager ): array {
+	$available_tools = array();
+
+	foreach ( array( $args['previous_step_config'] ?? null, $args['next_step_config'] ?? null ) as $step_config ) {
+		if ( ! $step_config ) {
+			continue;
+		}
+
+		$handler_slugs       = $step_config['handler_slugs'] ?? array();
+		$handler_configs_map = $step_config['handler_configs'] ?? array();
+		$cache_scope         = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
+
+		foreach ( $handler_slugs as $slug ) {
+			$handler_config = $handler_configs_map[ $slug ] ?? array();
+			$tools          = $tool_manager->resolveHandlerTools( $slug, $handler_config, array(), $cache_scope );
+
+			foreach ( $tools as $tool_name => $tool_config ) {
+				$available_tools[ $tool_name ] = $tool_config;
+			}
+		}
+	}
+
+	return $available_tools;
+}
+
+$failures = array();
+$passes   = 0;
+
+function assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		$passes++;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo "    expected: " . var_export( $expected, true ) . "\n";
+	echo "    actual:   " . var_export( $actual, true ) . "\n";
+}
+
+echo "ToolPolicyResolver adjacency smoke (Phase 2a)\n";
+echo "----------------------------------------------\n";
+
+// Test 1: AI step with a publish step (handler-bearing) before it.
+// Resolver should pick up wordpress_publish_tool from the adjacency.
+echo "\n[1] AI adjacent to handler-bearing publish step:\n";
+$tool_manager = new StubToolManager();
+$args         = array(
+	'previous_step_config' => array(
+		'flow_step_id'    => 'flow_pub_1',
+		'step_type'       => 'publish',
+		'handler_slugs'   => array( 'wordpress_publish' ),
+		'handler_configs' => array(
+			'wordpress_publish' => array( 'post_status' => 'draft' ),
+		),
+	),
+	'next_step_config'     => null,
+);
+$tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
+
+assert_equals( array( 'wordpress_publish' ), $tool_manager->resolveCalls, 'asked tool manager for wordpress_publish', $failures, $passes );
+assert_equals( true, isset( $tools['wordpress_publish_tool'] ), 'wordpress_publish_tool surfaced', $failures, $passes );
+
+// Test 2: AI step with a synthetic-slug system_task adjacency.
+// After #1205, system_task carries handler_slugs = ['system_task'].
+// Resolver must NOT inject a 'system_task' pseudo-tool — the tool
+// manager returns nothing for that slug, and the resolver respects
+// the empty result.
+echo "\n[2] AI adjacent to handler-free system_task step (synthetic slug):\n";
+$tool_manager = new StubToolManager();
+$args         = array(
+	'previous_step_config' => array(
+		'flow_step_id'    => 'flow_sys_1',
+		'step_type'       => 'system_task',
+		'handler_slugs'   => array( 'system_task' ),
+		'handler_configs' => array(
+			'system_task' => array( 'task' => 'daily_memory_generation', 'params' => array() ),
+		),
+	),
+	'next_step_config'     => null,
+);
+$tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
+
+assert_equals( array( 'system_task' ), $tool_manager->resolveCalls, 'resolver asked for synthetic system_task slug', $failures, $passes );
+assert_equals( array(), $tools, 'no tools surfaced for handler-free synthetic slug', $failures, $passes );
+
+// Test 3: Mixed adjacency — publish before, system_task after.
+// Only the real handler tool should land in available_tools.
+echo "\n[3] Mixed adjacency (publish before, system_task after):\n";
+$tool_manager = new StubToolManager();
+$args         = array(
+	'previous_step_config' => array(
+		'flow_step_id'    => 'flow_pub_1',
+		'step_type'       => 'publish',
+		'handler_slugs'   => array( 'wordpress_publish' ),
+		'handler_configs' => array(
+			'wordpress_publish' => array(),
+		),
+	),
+	'next_step_config'     => array(
+		'flow_step_id'    => 'flow_sys_2',
+		'step_type'       => 'system_task',
+		'handler_slugs'   => array( 'system_task' ),
+		'handler_configs' => array(
+			'system_task' => array( 'task' => 'agent_ping', 'params' => array() ),
+		),
+	),
+);
+$tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
+
+assert_equals( array( 'wordpress_publish', 'system_task' ), $tool_manager->resolveCalls, 'resolver visited both adjacent slugs', $failures, $passes );
+assert_equals( array( 'wordpress_publish_tool' ), array_keys( $tools ), 'only real handler tool landed in available_tools', $failures, $passes );
+
+// Test 4: Multi-handler publish adjacency — the legitimate multi-element callsite.
+// Resolver still iterates all slugs and surfaces every tool the manager returns.
+echo "\n[4] Multi-handler publish adjacency (the legitimate iteration case):\n";
+class MultiHandlerStub extends StubToolManager {
+	public function resolveHandlerTools( string $slug, array $config, array $engine_data, string $cache_scope ): array {
+		$this->resolveCalls[] = $slug;
+		if ( 'wordpress_publish' === $slug ) {
+			return array( 'wordpress_publish_tool' => array( 'description' => 'WP publish' ) );
+		}
+		if ( 'twitter_publish' === $slug ) {
+			return array( 'twitter_publish_tool' => array( 'description' => 'Twitter publish' ) );
+		}
+		return array();
+	}
+}
+$tool_manager = new MultiHandlerStub();
+$args         = array(
+	'previous_step_config' => array(
+		'flow_step_id'    => 'flow_pub_multi',
+		'step_type'       => 'publish',
+		'handler_slugs'   => array( 'wordpress_publish', 'twitter_publish' ),
+		'handler_configs' => array(
+			'wordpress_publish' => array(),
+			'twitter_publish'   => array(),
+		),
+	),
+	'next_step_config'     => null,
+);
+$tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
+
+assert_equals( array( 'wordpress_publish', 'twitter_publish' ), $tool_manager->resolveCalls, 'resolver visited every handler slug', $failures, $passes );
+assert_equals( array( 'wordpress_publish_tool', 'twitter_publish_tool' ), array_keys( $tools ), 'all handler tools surfaced', $failures, $passes );
+
+// Test 5: Empty handler_slugs (handler-bearing step with nothing configured).
+// Resolver short-circuits the inner foreach without calling the tool manager.
+echo "\n[5] Adjacent step with empty handler_slugs:\n";
+$tool_manager = new StubToolManager();
+$args         = array(
+	'previous_step_config' => array(
+		'flow_step_id'    => 'flow_empty',
+		'step_type'       => 'publish',
+		'handler_slugs'   => array(),
+		'handler_configs' => array(),
+	),
+	'next_step_config'     => null,
+);
+$tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
+
+assert_equals( array(), $tool_manager->resolveCalls, 'resolver did not call tool manager', $failures, $passes );
+assert_equals( array(), $tools, 'no tools surfaced', $failures, $passes );
+
+echo "\n----------------------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "Failures:\n";
+	foreach ( $failures as $name ) {
+		echo "  - {$name}\n";
+	}
+	exit( 1 );
+}
+
+echo "All checks passed.\n";
+exit( 0 );


### PR DESCRIPTION
## Summary

Phase 2b of #1205. Drops the AI-step field overload where `handler_slugs` carried both the step's handler (length 0..1 for handler-bearing steps) AND the AI's enabled tools (length 0..N for AI steps). After this `handler_slugs` is single-purpose: it names the step's handler.

Stacks on #1206 (Phase 2a). Set the base to \`refactor-flowstepconfig-callsites\` so the diff stays reviewable.

## What changes

\`ExecuteWorkflowAbility::buildConfigsFromWorkflow()\` now writes a dedicated \`enabled_tools\` field on \`flow_step_config\` for AI steps, instead of collapsing them onto \`handler_slugs\`:

| Step type | handler_slugs (before) | handler_slugs (after) | enabled_tools |
|---|---|---|---|
| \`fetch\` / \`publish\` / \`upsert\` | \`[handler_slug]\` | unchanged | (n/a) |
| \`ai\` | \`[tool, tool, ...]\` | \`[]\` | \`[tool, tool, ...]\` |
| \`system_task\` / \`webhook_gate\` | \`[step_type]\` (Phase 2a) | unchanged | (n/a) |

\`FlowStepConfig::getEnabledTools()\` is the read-side accessor for the AI step's tool list. **No runtime fallback to \`handler_slugs\`.** Legacy on-disk rows are migrated in place by the new migration on activation; the accessor is the only read path with no branches.

\`inc/migrations/ai-enabled-tools.php\` (new) does the one-shot conversion on activation. For every flow step where \`step_type === 'ai'\` has \`handler_slugs\` populated, it moves them to \`enabled_tools\` and clears \`handler_slugs\`. Idempotent (gated on the \`datamachine_ai_enabled_tools_migrated\` option). Mirrors the pattern of \`inc/migrations/handler-keys.php\` and the rest of the migrations directory.

## Why no shim

The whole point of #1205 is to delete cruft, not paper over it. A runtime fallback would route every AI step read past the legacy field forever and require future cleanup to remove the shim itself. A one-shot migration deletes the legacy data in place, leaving a single read path with no branches.

The earlier revision of this PR added a deprecation-logging shim; Chris rejected it during review for exactly this reason. This PR was rewritten to migrate the data instead.

## Latent bug fixed

Adjacency tracking in \`AIStep\` and \`ToolPolicyResolver\` continues to read adjacent \`handler_slugs\` as \"the adjacent step's handler tools\" — adjacent AI steps now correctly contribute zero handler tools (\`handler_slugs = []\`) which is the correct behaviour.

Today an adjacent AI step's enabled tools could land in \`AIConversationLoop\`'s \`configured_handlers\` tracker. \`intelligence/search\` would survive the \`available_tools\` intersection, but \`is_handler_tool\` would be false for it, so \`array_diff\` in the multi-handler completion check never empties — the loop would never complete via that path. After Phase 2b + the migration, adjacent AI steps contribute \`handler_slugs = []\` (the correct shape — AI doesn't have handlers).

## Tests

- \`tests/system-task-config-passthrough-smoke.php\` — updated for the Phase 2b shape. **22 / 22 passes** covering both phases together (Phase 2a synthetic-slug + Phase 2b enabled_tools split).

- \`tests/ai-enabled-tools-smoke.php\` — **new**. **19 / 19 passes** covering:
  - \`getEnabledTools()\` returns \`enabled_tools\` verbatim.
  - \`getEnabledTools()\` does NOT fall back to \`handler_slugs\`. Post-migration, AI rows have \`handler_slugs = []\`. If a stale row survives somehow, the accessor returns empty rather than silently picking up legacy data.
  - Defensive: non-array \`enabled_tools\` → empty (no fatal).
  - Migration: legacy AI row flips \`handler_slugs\` → \`enabled_tools\`.
  - Migration: row already on Phase 2b shape is left alone.
  - Migration: dual-shape row clears \`handler_slugs\` without overwriting \`enabled_tools\` (no-double-counting invariant).
  - Migration: AI row with no tools at all gets \`enabled_tools = []\`.
  - Migration: non-AI step left alone (publish \`handler_slugs\` untouched, no \`enabled_tools\` added).
  - Migration: mixed flow with AI + publish + system_task migrates only the AI row.

- \`tests/queueable-trait-smoke.php\` (#1196), \`tests/daily-memory-conservation-smoke.php\` (#1204), \`tests/batch-child-agent-id-smoke.php\` (#1198), \`tests/system-task-workflow-validation-smoke.php\` (#1200), \`tests/tool-policy-resolver-adjacency-smoke.php\` (#1206) all still pass.

## Live verify

\`intelligence-chubes4\`: deployed, ran the migration, then injected a synthetic legacy AI row into a flow on disk and re-ran the migration:

\`\`\`
before: {step_type: 'ai', handler_slugs: ['intelligence/search', 'intelligence/wiki-upsert']}
after:  {step_type: 'ai', handler_slugs: [], enabled_tools: ['intelligence/search', 'intelligence/wiki-upsert']}
\`\`\`

The flow_config was rolled back after the verify so the production rows are untouched. The site's existing flow rows had no legacy AI data to migrate, so the migration completed silently as designed.

## Scope

Closes the Phase 2b items in #1205:
- [x] AI step's enabled tools live in \`enabled_tools\`; \`handler_slugs\` is always 0..1 element.
- [x] On-disk migration converts legacy rows in place; no runtime shim.
- [x] New smoke test covers the accessor and the migration.

React/admin UI cleanup (Phase 3) remains out of scope and ships separately once the backend canonicalization is on disk in production.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the field-split plan and the migration; wrote the smoke fixtures. Chris reviewed the design, rejected the runtime shim (the point of #1205 is to delete cruft, not paper over it), and the PR was rewritten to migrate legacy data in place instead. Chris confirmed the migration end-to-end on \`intelligence-chubes4\` with a synthetic legacy row.