### PR TITLE
refactor(flow-step-config): collapse callsites onto FlowStepConfig helper

### DIFF
--- a/inc/Abilities/Handler/TestHandlerAbility.php
+++ b/inc/Abilities/Handler/TestHandlerAbility.php
@@ -15,6 +15,7 @@ namespace DataMachine\Abilities\Handler;
 use DataMachine\Abilities\HandlerAbilities;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -246,15 +247,13 @@ class TestHandlerAbility {
 				continue;
 			}
 
-			$handler_slugs = $step['handler_slugs'] ?? array();
+			$slug = FlowStepConfig::getEffectiveSlug( $step );
 
-			if ( empty( $handler_slugs ) ) {
+			if ( empty( $slug ) ) {
 				continue;
 			}
 
-			$slug            = $handler_slugs[0];
-			$handler_configs = $step['handler_configs'] ?? array();
-			$handler_config  = $handler_configs[ $slug ] ?? array();
+			$handler_config = FlowStepConfig::getPrimaryHandlerConfig( $step );
 
 			return array(
 				'success'      => true,

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -313,26 +313,44 @@ class ExecuteWorkflowAbility {
 			// Flow config (instance-specific)
 			$handler_slug   = $step['handler_slug'] ?? '';
 			$handler_config = $step['handler_config'] ?? array();
+			$step_type      = $step['type'];
 
-			// Resolve handler_slugs: explicit handler_slug for non-AI steps,
-			// or enabled_tools for AI steps (tells the AI which tools it must call).
+			// Resolve handler_slugs to mirror the on-disk shape established
+			// by inc/migrations/handler-keys.php (v0.60.0):
+			//
+			//   1. Explicit handler_slug → [handler_slug] (fetch, publish,
+			//      upsert, …).
+			//   2. AI step with enabled_tools → enabled_tools (legacy field
+			//      overload; Phase 2b in #1205 will move this off
+			//      handler_slugs into a dedicated enabled_tools field).
+			//   3. Self-configuring step types (system_task, webhook_gate,
+			//      agent_ping) with a non-empty handler_config → [step_type].
+			//      This is the synthetic-slug shape the migration uses for
+			//      handler-free steps; mirroring it here lets
+			//      FlowStepConfig::getPrimaryHandlerConfig() resolve via
+			//      handler_slugs[0] uniformly with no handler-free fallback
+			//      ladder. Step::getHandlerConfig() collapses to one line as
+			//      a result.
+			//   4. Otherwise → []. AI without enabled_tools, or
+			//      self-configuring step with no config, lands here — same as
+			//      the migration's "no config to key" branch.
 			$handler_slugs = array();
 			if ( ! empty( $handler_slug ) ) {
 				$handler_slugs = array( $handler_slug );
-			} elseif ( ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
+			} elseif ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
 				$handler_slugs = $step['enabled_tools'];
+			} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
+				$handler_slugs = array( $step_type );
 			}
 
-			// Preserve handler_config for handler-free step types (system_task,
-			// webhook_gate, ai with no handler) by keying it under the step
-			// type slug. Step::getHandlerConfig() falls back to this slot when
-			// no handler_slug is set, so SystemTaskStep can find its
-			// { task, params } config and the data is not silently dropped.
+			// Key handler_configs by the primary slug (handler_slugs[0]) so
+			// FlowStepConfig::getPrimaryHandlerConfig() finds the slot
+			// without branching on step type.
 			$handler_configs = array();
 			if ( ! empty( $handler_slug ) ) {
 				$handler_configs[ $handler_slug ] = $handler_config;
-			} elseif ( ! empty( $handler_config ) ) {
-				$handler_configs[ $step['type'] ] = $handler_config;
+			} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
+				$handler_configs[ $step_type ] = $handler_config;
 			}
 
 			$flow_config[ $step_id ] = array(

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -20,6 +20,7 @@ use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Cli\AgentResolver;
 use DataMachine\Cli\UserResolver;
+use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -1064,8 +1065,7 @@ class FlowsCommand extends BaseCommand {
 		$flow_config = $flow['flow_config'] ?? array();
 
 		foreach ( $flow_config as $step_data ) {
-			$primary_slug   = $step_data['handler_slugs'][0] ?? '';
-			$primary_config = ! empty( $primary_slug ) ? ( $step_data['handler_configs'][ $primary_slug ] ?? array() ) : array();
+			$primary_config = FlowStepConfig::getPrimaryHandlerConfig( $step_data );
 			if ( ! empty( $primary_config['prompt'] ) ) {
 				$prompt = $primary_config['prompt'];
 				return mb_strlen( $prompt ) > 50

--- a/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
@@ -98,7 +98,13 @@ class PipelineSystemPromptDirective implements \DataMachine\Engine\AI\Directives
 			return '';
 		}
 
-		// Sort steps by execution_order
+		// Sort steps by execution_order.
+		//
+		// Reads handler_slugs raw (not via FlowStepConfig::getEffectiveSlug)
+		// because the workflow visualization needs to render every handler
+		// in a multi-handler step (e.g. PUBLISH_A+PUBLISH_B → AI → UPSERT),
+		// not just the primary slug. This is one of the legitimate
+		// multi-element callsites alongside ToolPolicyResolver.
 		$sorted_steps = array();
 		foreach ( $flow_config as $flow_step_id => $step_config ) {
 			$execution_order = $step_config['execution_order'] ?? -1;

--- a/inc/Core/Steps/Step.php
+++ b/inc/Core/Steps/Step.php
@@ -212,7 +212,19 @@ abstract class Step {
 
 
 	/**
-	 * Get handler slug from flow step configuration.
+	 * Get the primary handler slug from flow step configuration.
+	 *
+	 * Returns the raw `handler_slugs[0]` value. For self-configuring step
+	 * types (system_task, webhook_gate, agent_ping), the migration in
+	 * inc/migrations/handler-keys.php and ExecuteWorkflowAbility::build
+	 * ConfigsFromWorkflow() store the step_type as the synthetic primary
+	 * slug, so this returns the step_type for those rows. Returns null
+	 * when no slug has been resolved (e.g. fetch step with no handler
+	 * configured) so the default validateStepConfiguration() can reject.
+	 *
+	 * Prefer FlowStepConfig::getEffectiveSlug() at non-Step callsites; it
+	 * is the canonical resolver and falls back to step_type when the
+	 * handler_slugs array is empty.
 	 *
 	 * @return string|null Handler slug or null if not set
 	 */
@@ -221,21 +233,19 @@ abstract class Step {
 	}
 
 	/**
-	 * Get handler configuration from flow step configuration.
+	 * Get the primary handler configuration from flow step configuration.
 	 *
-	 * Handler-bearing steps store config keyed by handler_slug.
-	 * Handler-free step types (system_task, webhook_gate, ai with no handler)
-	 * have their config keyed by step_type slug instead, since there is no
-	 * handler to key under. This accessor handles both shapes.
+	 * Reads handler_configs[handler_slugs[0]]. Handler-bearing steps key
+	 * by handler_slug; handler-free steps (system_task, webhook_gate,
+	 * agent_ping) key by step_type via the synthetic-slug shape applied
+	 * in inc/migrations/handler-keys.php and ExecuteWorkflowAbility::build
+	 * ConfigsFromWorkflow(). FlowStepConfig::getPrimaryHandlerConfig() is
+	 * the single source of truth for the lookup so callsites stay aligned.
 	 *
 	 * @return array Handler configuration array
 	 */
 	protected function getHandlerConfig(): array {
-		$slug = $this->getHandlerSlug();
-		if ( ! empty( $slug ) ) {
-			return $this->flow_step_config['handler_configs'][ $slug ] ?? array();
-		}
-		return $this->flow_step_config['handler_configs'][ $this->step_type ] ?? array();
+		return FlowStepConfig::getPrimaryHandlerConfig( $this->flow_step_config );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -292,6 +292,13 @@ class ToolPolicyResolver {
 		$engine_data      = $args['engine_data'] ?? array();
 
 		// Handler tools from adjacent steps (dynamic, resolved per-execution).
+		//
+		// Reads handler_slugs / handler_configs raw (not via FlowStepConfig
+		// helpers) because adjacent steps may declare multiple handler slugs
+		// (e.g. multi-handler publish: wordpress_publish + twitter_publish)
+		// and the AI must see tools for all of them, not just the primary.
+		// This is one of the legitimate multi-element callsites alongside
+		// PipelineSystemPromptDirective; see #1205 for the audit.
 		foreach ( array( $args['previous_step_config'] ?? null, $args['next_step_config'] ?? null ) as $step_config ) {
 			if ( ! $step_config ) {
 				continue;

--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -434,6 +434,13 @@ class ImportExport {
 					$flow_step_id = apply_filters( 'datamachine_generate_flow_step_id', '', $step['pipeline_step_id'], $flow['flow_id'] );
 					$flow_step    = $flow_config[ $flow_step_id ] ?? array();
 
+					// Read the primary slug raw rather than via FlowStepConfig::
+					// getEffectiveSlug() so handler-free steps (system_task,
+					// webhook_gate) don't synthesize a step_type fallback into
+					// the exported handler column when the row genuinely has
+					// no handler. The export emits a row only when the primary
+					// slug is present; FlowStepConfig's step_type fallback
+					// would defeat that gate.
 					$primary_handler = $flow_step['handler_slugs'][0] ?? '';
 
 					if ( ! empty( $primary_handler ) ) {

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -5,19 +5,20 @@
  * Run with: php tests/system-task-config-passthrough-smoke.php
  *
  * Covers the build-side + read-side fix that lets handler-free step
- * types (system_task, webhook_gate, ai with no handler) preserve their
+ * types (system_task, webhook_gate, agent_ping) preserve their
  * handler_config across the workflow → flow_config → step runtime
  * translation.
  *
- * Before this fix, ExecuteWorkflowAbility::buildConfigsFromWorkflow()
- * dropped handler_config to an empty array whenever handler_slug was
- * empty, and Step::getHandlerConfig() returned an empty array on the
- * read side for the same reason. system_task workflows passing
- * { task: 'daily_memory_generation', params: {} } got the config
- * silently dropped and failed with system_task_missing_task_type.
+ * Phase 1 fix (#1202): keyed handler-free configs by step_type and
+ * added a fallback in Step::getHandlerConfig() so SystemTaskStep could
+ * find its { task, params }.
  *
- * The fix keys handler-free configs by the step type slug on both
- * sides so they round-trip correctly.
+ * Phase 2a fix (#1205): collapsed onto FlowStepConfig::getPrimary
+ * HandlerConfig() by writing handler_slugs = [step_type] for handler-
+ * free steps with a non-empty handler_config (mirrors the v0.60.0
+ * migration in inc/migrations/handler-keys.php). This drops the read-
+ * side fallback ladder in Step::getHandlerConfig() — the helper now
+ * resolves uniformly via handler_slugs[0].
  *
  * @package DataMachine\Tests
  */
@@ -31,8 +32,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * for pure-PHP testing (the real method is private + lives in a class
  * with WordPress dependencies).
  *
- * Mirrors the post-fix shape so a regression in the real file shows up
- * as the fixture diverging from the harness.
+ * Mirrors the post-#1205 shape so a regression in the real file shows
+ * up as the fixture diverging from the harness.
  */
 function build_configs_from_workflow_for_test( array $workflow ): array {
 	$flow_config     = array();
@@ -44,25 +45,28 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 
 		$handler_slug   = $step['handler_slug'] ?? '';
 		$handler_config = $step['handler_config'] ?? array();
+		$step_type      = $step['type'];
 
 		$handler_slugs = array();
 		if ( ! empty( $handler_slug ) ) {
 			$handler_slugs = array( $handler_slug );
-		} elseif ( ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
+		} elseif ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
 			$handler_slugs = $step['enabled_tools'];
+		} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
+			$handler_slugs = array( $step_type );
 		}
 
 		$handler_configs = array();
 		if ( ! empty( $handler_slug ) ) {
 			$handler_configs[ $handler_slug ] = $handler_config;
-		} elseif ( ! empty( $handler_config ) ) {
-			$handler_configs[ $step['type'] ] = $handler_config;
+		} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
+			$handler_configs[ $step_type ] = $handler_config;
 		}
 
 		$flow_config[ $step_id ] = array(
 			'flow_step_id'     => $step_id,
 			'pipeline_step_id' => $pipeline_step_id,
-			'step_type'        => $step['type'],
+			'step_type'        => $step_type,
 			'execution_order'  => $index,
 			'handler_slugs'    => $handler_slugs,
 			'handler_configs'  => $handler_configs,
@@ -72,7 +76,7 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 			'flow_id'          => 'direct',
 		);
 
-		if ( 'ai' === $step['type'] ) {
+		if ( 'ai' === $step_type ) {
 			$pipeline_config[ $pipeline_step_id ] = array(
 				'system_prompt'  => $step['system_prompt'] ?? '',
 				'disabled_tools' => $step['disabled_tools'] ?? array(),
@@ -87,17 +91,33 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 }
 
 /**
- * Inline reimplementation of Step::getHandlerConfig() read-side.
+ * Inline reimplementation of FlowStepConfig::getPrimaryHandlerConfig().
  *
- * Mirrors the post-fix shape: when no handler_slug, fall back to
- * handler_configs keyed by step_type.
+ * Reads handler_configs[handler_slugs[0]] uniformly. The fallback ladder
+ * Step::getHandlerConfig() carried in #1202 is gone — the build side
+ * now writes handler_slugs = [step_type] for handler-free steps with a
+ * non-empty handler_config so this single lookup resolves both shapes.
  */
-function get_handler_config_for_test( array $flow_step_config, string $step_type ): array {
-	$slug = $flow_step_config['handler_slugs'][0] ?? null;
-	if ( ! empty( $slug ) ) {
-		return $flow_step_config['handler_configs'][ $slug ] ?? array();
+function get_primary_handler_config_for_test( array $flow_step_config ): array {
+	$slug = $flow_step_config['handler_slugs'][0] ?? '';
+	if ( ! empty( $slug ) && ! empty( $flow_step_config['handler_configs'][ $slug ] ) ) {
+		return $flow_step_config['handler_configs'][ $slug ];
 	}
-	return $flow_step_config['handler_configs'][ $step_type ] ?? array();
+	return array();
+}
+
+/**
+ * Inline reimplementation of FlowStepConfig::getEffectiveSlug().
+ */
+function get_effective_slug_for_test( array $flow_step_config, string $explicit_slug = '' ): string {
+	if ( ! empty( $explicit_slug ) ) {
+		return $explicit_slug;
+	}
+	$primary = $flow_step_config['handler_slugs'][0] ?? '';
+	if ( ! empty( $primary ) ) {
+		return $primary;
+	}
+	return $flow_step_config['step_type'] ?? '';
 }
 
 $failures = array();
@@ -116,8 +136,8 @@ function assert_equals( $expected, $actual, string $name, array &$failures, int 
 	echo "    actual:   " . var_export( $actual, true ) . "\n";
 }
 
-echo "system-task config passthrough smoke\n";
-echo "------------------------------------\n";
+echo "system-task config passthrough smoke (Phase 2a)\n";
+echo "-----------------------------------------------\n";
 
 // Test 1: system_task workflow round-trips handler_config under step type slug.
 echo "\n[1] system_task workflow round-trips { task, params }:\n";
@@ -135,12 +155,13 @@ $workflow = array(
 
 $built  = build_configs_from_workflow_for_test( $workflow );
 $step0  = $built['flow_config']['ephemeral_step_0'];
-$config = get_handler_config_for_test( $step0, 'system_task' );
+$config = get_primary_handler_config_for_test( $step0 );
 
 assert_equals( 'daily_memory_generation', $config['task'] ?? null, 'task survives passthrough', $failures, $passes );
 assert_equals( array(), $config['params'] ?? null, 'params survives passthrough', $failures, $passes );
-assert_equals( array(), $step0['handler_slugs'], 'handler_slugs is empty', $failures, $passes );
+assert_equals( array( 'system_task' ), $step0['handler_slugs'], 'handler_slugs synthesized from step_type', $failures, $passes );
 assert_equals( array( 'system_task' => array( 'task' => 'daily_memory_generation', 'params' => array() ) ), $step0['handler_configs'], 'handler_configs keyed by step type', $failures, $passes );
+assert_equals( 'system_task', get_effective_slug_for_test( $step0 ), 'getEffectiveSlug returns step_type', $failures, $passes );
 
 // Test 2: handler-bearing step still keys by handler_slug.
 echo "\n[2] fetch step (handler-bearing) keys handler_configs by handler_slug:\n";
@@ -159,14 +180,17 @@ $workflow = array(
 
 $built  = build_configs_from_workflow_for_test( $workflow );
 $step0  = $built['flow_config']['ephemeral_step_0'];
-$config = get_handler_config_for_test( $step0, 'fetch' );
+$config = get_primary_handler_config_for_test( $step0 );
 
 assert_equals( 'a8c', $config['server'] ?? null, 'server reachable via handler_slug', $failures, $passes );
 assert_equals( array( 'mcp' ), $step0['handler_slugs'], 'handler_slugs has mcp', $failures, $passes );
 assert_equals( array( 'mcp' => array( 'server' => 'a8c', 'provider' => 'mgs' ) ), $step0['handler_configs'], 'handler_configs keyed by handler_slug', $failures, $passes );
+assert_equals( 'mcp', get_effective_slug_for_test( $step0 ), 'getEffectiveSlug returns handler_slug', $failures, $passes );
 
-// Test 3: empty handler_config and no handler_slug → empty handler_configs.
-echo "\n[3] handler-free step with no config has empty handler_configs:\n";
+// Test 3: empty handler_config and no handler_slug → empty handler_configs and empty handler_slugs.
+// Mirrors inc/migrations/handler-keys.php: when there is nothing to key,
+// both arrays stay empty rather than synthesizing a slug-with-no-config row.
+echo "\n[3] handler-free step with no config has empty handler_configs and handler_slugs:\n";
 $workflow = array(
 	'steps' => array(
 		array(
@@ -178,15 +202,15 @@ $workflow = array(
 $built = build_configs_from_workflow_for_test( $workflow );
 $step0 = $built['flow_config']['ephemeral_step_0'];
 
+assert_equals( array(), $step0['handler_slugs'], 'no config → empty handler_slugs', $failures, $passes );
 assert_equals( array(), $step0['handler_configs'], 'no config → empty handler_configs', $failures, $passes );
-assert_equals( array(), get_handler_config_for_test( $step0, 'webhook_gate' ), 'getHandlerConfig returns empty', $failures, $passes );
+assert_equals( array(), get_primary_handler_config_for_test( $step0 ), 'getPrimaryHandlerConfig returns empty', $failures, $passes );
+assert_equals( 'webhook_gate', get_effective_slug_for_test( $step0 ), 'getEffectiveSlug falls back to step_type', $failures, $passes );
 
 // Test 4: ai step with enabled_tools (no handler_slug, no handler_config).
-// AI steps carry their step config via pipeline_config (system_prompt),
-// not handler_config — so handler_configs stays empty here.  The build
-// side still emits handler_slugs from enabled_tools so the AI step
-// knows which tools to expose.
-echo "\n[4] ai step with enabled_tools:\n";
+// Phase 2a preserves the legacy AI shape (enabled_tools as handler_slugs);
+// Phase 2b in #1205 will move enabled_tools to its own field.
+echo "\n[4] ai step with enabled_tools (legacy shape preserved for Phase 2a):\n";
 $workflow = array(
 	'steps' => array(
 		array(
@@ -204,10 +228,29 @@ assert_equals( array( 'intelligence/search', 'intelligence/wiki-upsert' ), $step
 assert_equals( array(), $step0['handler_configs'], 'ai step without handler_config → empty handler_configs', $failures, $passes );
 assert_equals( 'be helpful', $built['pipeline_config']['ephemeral_pipeline_0']['system_prompt'] ?? null, 'system_prompt lands in pipeline_config', $failures, $passes );
 
-// Test 5: regression — system_task workflow that bypassed validation
-// after #1200 still got handler_config dropped.  After this fix, the
-// task type is reachable end-to-end.
-echo "\n[5] regression: validate→build→getHandlerConfig pipeline:\n";
+// Test 5: ai step with no enabled_tools, no handler — must NOT synthesize step_type as a slug.
+// AI semantics treat handler_slugs as "enabled tools"; synthesizing 'ai' would pollute the AI
+// tool registry intersection in AIStep::resolve_pipeline_tools() and ToolPolicyResolver.
+echo "\n[5] ai step with no enabled_tools and no handler_config:\n";
+$workflow = array(
+	'steps' => array(
+		array(
+			'type'          => 'ai',
+			'system_prompt' => 'be helpful',
+		),
+	),
+);
+
+$built = build_configs_from_workflow_for_test( $workflow );
+$step0 = $built['flow_config']['ephemeral_step_0'];
+
+assert_equals( array(), $step0['handler_slugs'], 'ai with no tools does not synthesize step_type', $failures, $passes );
+assert_equals( array(), $step0['handler_configs'], 'ai with no config → empty handler_configs', $failures, $passes );
+
+// Test 6: regression — system_task workflow that bypassed validation
+// after #1200 still got handler_config dropped before #1202. After
+// Phase 2a, the task type is reachable end-to-end via the helper.
+echo "\n[6] regression: validate→build→getPrimaryHandlerConfig pipeline:\n";
 $workflow = array(
 	'steps' => array(
 		array(
@@ -222,12 +265,12 @@ $workflow = array(
 
 $built  = build_configs_from_workflow_for_test( $workflow );
 $step0  = $built['flow_config']['ephemeral_step_0'];
-$config = get_handler_config_for_test( $step0, 'system_task' );
+$config = get_primary_handler_config_for_test( $step0 );
 
 assert_equals( 'agent_ping', $config['task'] ?? null, 'task type reaches step runtime', $failures, $passes );
 assert_equals( array( 'agent_id' => 2 ), $config['params'] ?? null, 'task params reach step runtime', $failures, $passes );
 
-echo "\n------------------------------------\n";
+echo "\n-----------------------------------------------\n";
 $total = $passes + count( $failures );
 echo "{$passes} / {$total} passed\n";
 

--- a/tests/tool-policy-resolver-adjacency-smoke.php
+++ b/tests/tool-policy-resolver-adjacency-smoke.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Pure-PHP smoke test for ToolPolicyResolver adjacency with handler-free steps.
+ *
+ * Run with: php tests/tool-policy-resolver-adjacency-smoke.php
+ *
+ * After Phase 2a (#1205), ExecuteWorkflowAbility::buildConfigsFromWorkflow()
+ * writes handler_slugs = [step_type] for handler-free step types
+ * (system_task, webhook_gate, agent_ping) with a non-empty handler_config,
+ * mirroring inc/migrations/handler-keys.php (v0.60.0).
+ *
+ * ToolPolicyResolver::gatherPipelineTools() iterates handler_slugs from
+ * adjacent steps to surface their handler tools to the AI. The
+ * synthetic-slug shape means an adjacent system_task step will have
+ * handler_slugs = ['system_task'] — a slug that does NOT correspond to a
+ * registered handler tool. The resolver MUST handle that gracefully:
+ * when ToolManager::resolveHandlerTools('system_task', …) returns no
+ * tools, the resolver moves on without injecting a synthetic 'system_task'
+ * pseudo-tool into the AI's tool list.
+ *
+ * This regression guard verifies the iteration shape stays correct: the
+ * resolver visits each slug, asks the tool manager for tools, and only
+ * adds tools the manager actually returns. A handler-free synthetic slug
+ * yielding an empty result must not pollute the available_tools map.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/**
+ * Stub ToolManager that records the slugs the resolver asked for and
+ * returns canned tools per slug. A real handler slug
+ * ('wordpress_publish') gets back a real tool; a synthetic slug
+ * ('system_task') gets back an empty array, simulating what the unified
+ * datamachine_tools registry actually does for unknown handler slugs.
+ */
+class StubToolManager {
+	public array $resolveCalls = array();
+
+	public function resolveHandlerTools( string $slug, array $config, array $engine_data, string $cache_scope ): array {
+		$this->resolveCalls[] = $slug;
+
+		if ( 'wordpress_publish' === $slug ) {
+			return array(
+				'wordpress_publish_tool' => array(
+					'description'       => 'Publish a post',
+					'_handler_callable' => 'wordpress_publish::handler',
+				),
+			);
+		}
+
+		// All other slugs (including handler-free synthetic step_type
+		// slugs like 'system_task' or 'webhook_gate') return no tools.
+		return array();
+	}
+}
+
+/**
+ * Inline reimplementation of ToolPolicyResolver::gatherPipelineTools()
+ * adjacency loop. Mirrors inc/Engine/AI/Tools/ToolPolicyResolver.php
+ * post-#1205 (the documentation-only edit there did not change the
+ * iteration shape).
+ */
+function gather_pipeline_handler_tools_for_test( array $args, StubToolManager $tool_manager ): array {
+	$available_tools = array();
+
+	foreach ( array( $args['previous_step_config'] ?? null, $args['next_step_config'] ?? null ) as $step_config ) {
+		if ( ! $step_config ) {
+			continue;
+		}
+
+		$handler_slugs       = $step_config['handler_slugs'] ?? array();
+		$handler_configs_map = $step_config['handler_configs'] ?? array();
+		$cache_scope         = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
+
+		foreach ( $handler_slugs as $slug ) {
+			$handler_config = $handler_configs_map[ $slug ] ?? array();
+			$tools          = $tool_manager->resolveHandlerTools( $slug, $handler_config, array(), $cache_scope );
+
+			foreach ( $tools as $tool_name => $tool_config ) {
+				$available_tools[ $tool_name ] = $tool_config;
+			}
+		}
+	}
+
+	return $available_tools;
+}
+
+$failures = array();
+$passes   = 0;
+
+function assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		$passes++;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo "    expected: " . var_export( $expected, true ) . "\n";
+	echo "    actual:   " . var_export( $actual, true ) . "\n";
+}
+
+echo "ToolPolicyResolver adjacency smoke (Phase 2a)\n";
+echo "----------------------------------------------\n";
+
+// Test 1: AI step with a publish step (handler-bearing) before it.
+// Resolver should pick up wordpress_publish_tool from the adjacency.
+echo "\n[1] AI adjacent to handler-bearing publish step:\n";
+$tool_manager = new StubToolManager();
+$args         = array(
+	'previous_step_config' => array(
+		'flow_step_id'    => 'flow_pub_1',
+		'step_type'       => 'publish',
+		'handler_slugs'   => array( 'wordpress_publish' ),
+		'handler_configs' => array(
+			'wordpress_publish' => array( 'post_status' => 'draft' ),
+		),
+	),
+	'next_step_config'     => null,
+);
+$tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
+
+assert_equals( array( 'wordpress_publish' ), $tool_manager->resolveCalls, 'asked tool manager for wordpress_publish', $failures, $passes );
+assert_equals( true, isset( $tools['wordpress_publish_tool'] ), 'wordpress_publish_tool surfaced', $failures, $passes );
+
+// Test 2: AI step with a synthetic-slug system_task adjacency.
+// After #1205, system_task carries handler_slugs = ['system_task'].
+// Resolver must NOT inject a 'system_task' pseudo-tool — the tool
+// manager returns nothing for that slug, and the resolver respects
+// the empty result.
+echo "\n[2] AI adjacent to handler-free system_task step (synthetic slug):\n";
+$tool_manager = new StubToolManager();
+$args         = array(
+	'previous_step_config' => array(
+		'flow_step_id'    => 'flow_sys_1',
+		'step_type'       => 'system_task',
+		'handler_slugs'   => array( 'system_task' ),
+		'handler_configs' => array(
+			'system_task' => array( 'task' => 'daily_memory_generation', 'params' => array() ),
+		),
+	),
+	'next_step_config'     => null,
+);
+$tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
+
+assert_equals( array( 'system_task' ), $tool_manager->resolveCalls, 'resolver asked for synthetic system_task slug', $failures, $passes );
+assert_equals( array(), $tools, 'no tools surfaced for handler-free synthetic slug', $failures, $passes );
+
+// Test 3: Mixed adjacency — publish before, system_task after.
+// Only the real handler tool should land in available_tools.
+echo "\n[3] Mixed adjacency (publish before, system_task after):\n";
+$tool_manager = new StubToolManager();
+$args         = array(
+	'previous_step_config' => array(
+		'flow_step_id'    => 'flow_pub_1',
+		'step_type'       => 'publish',
+		'handler_slugs'   => array( 'wordpress_publish' ),
+		'handler_configs' => array(
+			'wordpress_publish' => array(),
+		),
+	),
+	'next_step_config'     => array(
+		'flow_step_id'    => 'flow_sys_2',
+		'step_type'       => 'system_task',
+		'handler_slugs'   => array( 'system_task' ),
+		'handler_configs' => array(
+			'system_task' => array( 'task' => 'agent_ping', 'params' => array() ),
+		),
+	),
+);
+$tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
+
+assert_equals( array( 'wordpress_publish', 'system_task' ), $tool_manager->resolveCalls, 'resolver visited both adjacent slugs', $failures, $passes );
+assert_equals( array( 'wordpress_publish_tool' ), array_keys( $tools ), 'only real handler tool landed in available_tools', $failures, $passes );
+
+// Test 4: Multi-handler publish adjacency — the legitimate multi-element callsite.
+// Resolver still iterates all slugs and surfaces every tool the manager returns.
+echo "\n[4] Multi-handler publish adjacency (the legitimate iteration case):\n";
+class MultiHandlerStub extends StubToolManager {
+	public function resolveHandlerTools( string $slug, array $config, array $engine_data, string $cache_scope ): array {
+		$this->resolveCalls[] = $slug;
+		if ( 'wordpress_publish' === $slug ) {
+			return array( 'wordpress_publish_tool' => array( 'description' => 'WP publish' ) );
+		}
+		if ( 'twitter_publish' === $slug ) {
+			return array( 'twitter_publish_tool' => array( 'description' => 'Twitter publish' ) );
+		}
+		return array();
+	}
+}
+$tool_manager = new MultiHandlerStub();
+$args         = array(
+	'previous_step_config' => array(
+		'flow_step_id'    => 'flow_pub_multi',
+		'step_type'       => 'publish',
+		'handler_slugs'   => array( 'wordpress_publish', 'twitter_publish' ),
+		'handler_configs' => array(
+			'wordpress_publish' => array(),
+			'twitter_publish'   => array(),
+		),
+	),
+	'next_step_config'     => null,
+);
+$tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
+
+assert_equals( array( 'wordpress_publish', 'twitter_publish' ), $tool_manager->resolveCalls, 'resolver visited every handler slug', $failures, $passes );
+assert_equals( array( 'wordpress_publish_tool', 'twitter_publish_tool' ), array_keys( $tools ), 'all handler tools surfaced', $failures, $passes );
+
+// Test 5: Empty handler_slugs (handler-bearing step with nothing configured).
+// Resolver short-circuits the inner foreach without calling the tool manager.
+echo "\n[5] Adjacent step with empty handler_slugs:\n";
+$tool_manager = new StubToolManager();
+$args         = array(
+	'previous_step_config' => array(
+		'flow_step_id'    => 'flow_empty',
+		'step_type'       => 'publish',
+		'handler_slugs'   => array(),
+		'handler_configs' => array(),
+	),
+	'next_step_config'     => null,
+);
+$tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
+
+assert_equals( array(), $tool_manager->resolveCalls, 'resolver did not call tool manager', $failures, $passes );
+assert_equals( array(), $tools, 'no tools surfaced', $failures, $passes );
+
+echo "\n----------------------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "Failures:\n";
+	foreach ( $failures as $name ) {
+		echo "  - {$name}\n";
+	}
+	exit( 1 );
+}
+
+echo "All checks passed.\n";
+exit( 0 );


### PR DESCRIPTION
## Summary

Phase 2a of #1205 — audits every read of `flow_step_config['handler_slugs'][0]` / `['handler_configs'][\$slug]` and migrates each callsite to the existing `FlowStepConfig::getEffectiveSlug()` / `getPrimaryHandlerConfig()` helpers, or documents why it legitimately needs the raw multi-element view.

The leverage point is mirroring the v0.60.0 migration's synthetic-slug shape (`inc/migrations/handler-keys.php`) on the build side, so the read side resolves uniformly without a handler-free fallback ladder. After this lands, `Step::getHandlerConfig()` is one line and the special case from #1202 is gone.

Stacks on #1204 (and transitively #1202 / #1200). Set the base to `fix-daily-memory-conservation` so the diff stays reviewable.

## What changes

### Build side: synthetic-slug shape

`ExecuteWorkflowAbility::buildConfigsFromWorkflow()` now writes the same shape the v0.60.0 migration uses:

| Step type | Before | After |
|---|---|---|
| Handler-bearing (\`fetch\`, \`publish\`, \`upsert\`) | \`handler_slugs = [handler_slug]\` | unchanged |
| AI with \`enabled_tools\` | \`handler_slugs = enabled_tools\` | unchanged (Phase 2b moves this to \`enabled_tools\` field) |
| AI without \`enabled_tools\` | \`handler_slugs = []\` | unchanged (does **not** synthesize \`ai\` — would pollute the AI tool registry intersection) |
| \`system_task\` / \`webhook_gate\` / \`agent_ping\` with \`handler_config\` | #1202 added \`handler_configs[step_type]\` fallback | now \`handler_slugs = [step_type]\` AND \`handler_configs[step_type]\`, mirroring the migration |
| Handler-free with no config | \`handler_slugs = []\`, \`handler_configs = []\` | unchanged |

### Read side

- \`Step::getHandlerConfig()\` collapses to:
  \`\`\`php
  return FlowStepConfig::getPrimaryHandlerConfig(\$this->flow_step_config);
  \`\`\`
  The handler-free fallback ladder added in #1202 is gone.

- \`TestHandlerAbility::findFetchHandlerInFlow()\` and \`FlowsCommand::extractPrompt()\` migrated to the helpers.

### Documented legitimate raw reads

- \`PipelineSystemPromptDirective\` and \`ToolPolicyResolver::gatherPipelineTools()\` — both iterate every \`handler_slug\` in adjacent steps because multi-handler publish steps must surface every handler tool / label, not just the primary. Comments now call out that these intentionally bypass the single-element helpers per the #1205 audit.

- \`ImportExport::handle_export()\` — falling back to \`step_type\` via \`getEffectiveSlug()\` would defeat the export-only-when-handler-set gate. Documented as a legitimate raw read.

## Tests

- \`tests/system-task-config-passthrough-smoke.php\` — updated to mirror the Phase 2a shape. **20 / 20 passes** covering:
  - \`system_task\` workflow round-trips \`{ task, params }\` via the synthetic slug.
  - \`fetch\` step continues to key by \`handler_slug\`.
  - Handler-free step with no config → empty \`handler_slugs\` / \`handler_configs\`.
  - AI step with \`enabled_tools\` (legacy shape preserved for Phase 2b).
  - AI step with **no** \`enabled_tools\` does NOT synthesize \`ai\` as a slug (regression guard for the AI registry intersection).
  - \`validate\` → \`build\` → \`getPrimaryHandlerConfig\` regression.

- \`tests/tool-policy-resolver-adjacency-smoke.php\` — **new**. **10 / 10 passes** verifying the synthetic-slug change does not break adjacent-step tool gathering:
  - Handler-bearing publish adjacency surfaces real tools.
  - Handler-free \`system_task\` adjacency (\`handler_slugs = ['system_task']\`) yields no tools and does not pollute \`available_tools\`.
  - Mixed adjacency (handler-bearing before, handler-free after) only surfaces real tools.
  - Multi-handler publish adjacency still iterates every slug — the legitimate multi-element case stays intact.
  - Empty \`handler_slugs\` short-circuits without touching the tool manager.

- \`tests/queueable-trait-smoke.php\` (#1196), \`tests/daily-memory-conservation-smoke.php\` (#1204), \`tests/batch-child-agent-id-smoke.php\` (#1198), \`tests/system-task-workflow-validation-smoke.php\` (#1200) all still pass.

## Live verify

\`intelligence-chubes4\`: deployed and ran \`wp datamachine system run daily_memory_generation\`. Job #94 completed end-to-end via the new shape:

\`\`\`
[INFO] Workflow executed via ability (direct mode)
[INFO] Task scheduled via workflow engine: daily_memory_generation (Job #94)
[INFO] Daily memory complete: 23 KB -> 20 KB (1 KB archived to daily/2026-04-25)
[INFO] Pipeline execution completed successfully
\`\`\`

The \`system_task\` workflow build → execute path is exercised end-to-end with the synthetic-slug shape; the conservation guard from #1204 also passed (combined 21 KB / 23 KB ≈ 0.91 > 0.85).

## Scope

Closes the Phase 2a items in #1205:
- [x] All non-test, non-migration reads of \`flow_step_config['handler_slugs']\` / \`['handler_configs']\` go through the helper or document the legitimate raw read.
- [x] \`Step::getHandlerConfig()\` is one line; the handler-free fallback added in #1202 is gone.
- [x] \`buildConfigsFromWorkflow\` writes \`handler_slugs = [step_type]\` for handler-free steps; the read-side special case is gone.
- [x] New smoke test guards \`ToolPolicyResolver\` against the synthetic-slug change.

Phase 2b (split AI's \`enabled_tools\` out of \`handler_slugs\` into its own field) ships separately.

Phase 2c (\`Step::getHandlerSlug()\` return contract) is folded into this PR via a docblock note explaining why the raw \`?string\` semantics stay (the validator's \`empty(\$handler)\` check would silently accept handler-bearing steps with no handler if we collapsed onto \`getEffectiveSlug()\`'s \`step_type\` fallback). The wrapper is now used in two places — \`Step::validateStepConfiguration()\` and \`FetchStep::executeStep()\` — both of which want raw handler-only semantics, not the resolver fallback. Leaving the surface intact for now; deletion can come once the validator default is removed (#1201 item: \`validateStepConfiguration\` default).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Audited \`handler_slugs\` / \`handler_configs\` callsites across the engine, drafted the FlowStepConfig migration plan, wrote the smoke test fixtures, and validated the end-to-end run on the deployed site. Chris reviewed the audit, gated the AI shape decision (do NOT synthesize \`ai\` as a slug — would pollute the AI tool registry intersection), and confirmed the build → run → log chain on \`intelligence-chubes4\`.
