### PR TITLE
refactor(ai-step): split enabled_tools off handler_slugs (Phase 2b)

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -618,6 +618,9 @@ function datamachine_activate_for_site() {
 	// Strip dead `provider`/`model` keys from pipeline_config rows (data-machine#1180, idempotent).
 	datamachine_strip_pipeline_step_provider_model();
 
+	// Move AI step tools from handler_slugs to enabled_tools (#1205 Phase 2b, idempotent).
+	datamachine_migrate_ai_enabled_tools();
+
 	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
 	datamachine_drop_redundant_post_pipeline_meta();
 

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -315,30 +315,21 @@ class ExecuteWorkflowAbility {
 			$handler_config = $step['handler_config'] ?? array();
 			$step_type      = $step['type'];
 
-			// Resolve handler_slugs to mirror the on-disk shape established
-			// by inc/migrations/handler-keys.php (v0.60.0):
+			// Resolve handler_slugs. Single-purpose: it names the step's
+			// handler (always length 0..1). Three shapes match
+			// inc/migrations/handler-keys.php (v0.60.0):
 			//
 			//   1. Explicit handler_slug → [handler_slug] (fetch, publish,
 			//      upsert, …).
-			//   2. AI step with enabled_tools → enabled_tools (legacy field
-			//      overload; Phase 2b in #1205 will move this off
-			//      handler_slugs into a dedicated enabled_tools field).
-			//   3. Self-configuring step types (system_task, webhook_gate,
+			//   2. Self-configuring step types (system_task, webhook_gate,
 			//      agent_ping) with a non-empty handler_config → [step_type].
-			//      This is the synthetic-slug shape the migration uses for
-			//      handler-free steps; mirroring it here lets
-			//      FlowStepConfig::getPrimaryHandlerConfig() resolve via
-			//      handler_slugs[0] uniformly with no handler-free fallback
-			//      ladder. Step::getHandlerConfig() collapses to one line as
-			//      a result.
-			//   4. Otherwise → []. AI without enabled_tools, or
-			//      self-configuring step with no config, lands here — same as
-			//      the migration's "no config to key" branch.
+			//      Synthetic-slug shape lets FlowStepConfig::getPrimary
+			//      HandlerConfig() resolve uniformly via handler_slugs[0].
+			//   3. Otherwise → []. AI steps always land here: their tool
+			//      list lives in `enabled_tools`, not handler_slugs.
 			$handler_slugs = array();
 			if ( ! empty( $handler_slug ) ) {
 				$handler_slugs = array( $handler_slug );
-			} elseif ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
-				$handler_slugs = $step['enabled_tools'];
 			} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
 				$handler_slugs = array( $step_type );
 			}
@@ -353,6 +344,12 @@ class ExecuteWorkflowAbility {
 				$handler_configs[ $step_type ] = $handler_config;
 			}
 
+			// AI's tool list lives in its own field. handler_slugs is for
+			// handlers; enabled_tools is for AI tools. No overload.
+			$enabled_tools = ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
+				? array_values( $step['enabled_tools'] )
+				: array();
+
 			$flow_config[ $step_id ] = array(
 				'flow_step_id'     => $step_id,
 				'pipeline_step_id' => $pipeline_step_id,
@@ -360,6 +357,7 @@ class ExecuteWorkflowAbility {
 				'execution_order'  => $index,
 				'handler_slugs'    => $handler_slugs,
 				'handler_configs'  => $handler_configs,
+				'enabled_tools'    => $enabled_tools,
 				'user_message'     => $step['user_message'] ?? '',
 				'disabled_tools'   => $step['disabled_tools'] ?? array(),
 				'pipeline_id'      => 'direct',

--- a/inc/Core/Steps/FlowStepConfig.php
+++ b/inc/Core/Steps/FlowStepConfig.php
@@ -59,4 +59,30 @@ class FlowStepConfig {
 		}
 		return array();
 	}
+
+	/**
+	 * Get the AI step's enabled tools.
+	 *
+	 * Reads the dedicated `enabled_tools` field. The pre-Phase 2b shape
+	 * (AI tools stored under `handler_slugs`) is migrated on activation
+	 * by inc/migrations/ai-enabled-tools.php — there is no runtime
+	 * fallback to legacy data.
+	 *
+	 * @since 0.81.0
+	 *
+	 * @param array $step_config Flow step configuration array.
+	 * @return array Tool slugs the AI step has enabled. Empty for non-AI steps.
+	 */
+	public static function getEnabledTools( array $step_config ): array {
+		if ( 'ai' !== ( $step_config['step_type'] ?? '' ) ) {
+			return array();
+		}
+
+		$enabled = $step_config['enabled_tools'] ?? array();
+		if ( ! is_array( $enabled ) ) {
+			return array();
+		}
+
+		return array_values( $enabled );
+	}
 }

--- a/inc/migrations/ai-enabled-tools.php
+++ b/inc/migrations/ai-enabled-tools.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Data Machine — AI enabled_tools migration.
+ *
+ * One-shot conversion of legacy AI step rows. Pre-#1205 Phase 2b, AI
+ * step tool lists were stored under flow_step_config['handler_slugs'].
+ * After Phase 2b, handler_slugs is single-purpose (the step's handler)
+ * and AI tools live in flow_step_config['enabled_tools'].
+ *
+ * This migration moves AI rows over and clears handler_slugs so the
+ * field overload is gone for good. Idempotent: rows that already have
+ * `enabled_tools` populated are skipped.
+ *
+ * @package DataMachine
+ * @since 0.81.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Move AI step tools from handler_slugs to enabled_tools across every
+ * flow's flow_config JSON.
+ *
+ * Idempotent: skips rows where the AI step already has enabled_tools
+ * populated, or where handler_slugs is empty.
+ *
+ * @since 0.81.0
+ */
+function datamachine_migrate_ai_enabled_tools(): void {
+	$already_done = get_option( 'datamachine_ai_enabled_tools_migrated', false );
+	if ( $already_done ) {
+		return;
+	}
+
+	global $wpdb;
+	$table = $wpdb->prefix . 'datamachine_flows';
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix.
+	$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+	// phpcs:enable WordPress.DB.PreparedSQL
+	if ( ! $table_exists ) {
+		update_option( 'datamachine_ai_enabled_tools_migrated', true, true );
+		return;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix.
+	$rows = $wpdb->get_results( "SELECT flow_id, flow_config FROM {$table}", ARRAY_A );
+	// phpcs:enable WordPress.DB.PreparedSQL
+
+	if ( empty( $rows ) ) {
+		update_option( 'datamachine_ai_enabled_tools_migrated', true, true );
+		return;
+	}
+
+	$migrated = 0;
+	foreach ( $rows as $row ) {
+		$flow_config = json_decode( $row['flow_config'], true );
+		if ( ! is_array( $flow_config ) ) {
+			continue;
+		}
+
+		$changed = false;
+		foreach ( $flow_config as $step_id => &$step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+
+			if ( 'ai' !== ( $step['step_type'] ?? '' ) ) {
+				continue;
+			}
+
+			// Already migrated.
+			if ( ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
+				if ( ! empty( $step['handler_slugs'] ) ) {
+					$step['handler_slugs'] = array();
+					$changed               = true;
+				}
+				continue;
+			}
+
+			$legacy = $step['handler_slugs'] ?? array();
+			if ( empty( $legacy ) || ! is_array( $legacy ) ) {
+				// Nothing to migrate; ensure the field exists for shape consistency.
+				if ( ! isset( $step['enabled_tools'] ) ) {
+					$step['enabled_tools'] = array();
+					$changed               = true;
+				}
+				continue;
+			}
+
+			$step['enabled_tools'] = array_values( $legacy );
+			$step['handler_slugs'] = array();
+			$changed               = true;
+		}
+		unset( $step );
+
+		if ( $changed ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->update(
+				$table,
+				array( 'flow_config' => wp_json_encode( $flow_config ) ),
+				array( 'flow_id' => $row['flow_id'] ),
+				array( '%s' ),
+				array( '%d' )
+			);
+			++$migrated;
+		}
+	}
+
+	update_option( 'datamachine_ai_enabled_tools_migrated', true, true );
+
+	if ( $migrated > 0 ) {
+		do_action(
+			'datamachine_log',
+			'info',
+			'Migrated AI step tools from handler_slugs to enabled_tools',
+			array( 'flows_updated' => $migrated )
+		);
+	}
+}

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -23,3 +23,4 @@ require_once __DIR__ . '/flows.php';
 require_once __DIR__ . '/post-pipeline-meta.php';
 require_once __DIR__ . '/update-to-upsert.php';
 require_once __DIR__ . '/strip-pipeline-step-provider-model.php';
+require_once __DIR__ . '/ai-enabled-tools.php';

--- a/tests/ai-enabled-tools-smoke.php
+++ b/tests/ai-enabled-tools-smoke.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Pure-PHP smoke test for the AI enabled_tools split (#1205 Phase 2b).
+ *
+ * Run with: php tests/ai-enabled-tools-shim-smoke.php
+ *
+ * Phase 2b drops the field overload where flow_step_config['handler_slugs']
+ * carried both the step's handler (length 0..1) and the AI's tool list
+ * (length 0..N). After this:
+ *
+ *   - handler_slugs is single-purpose: [handler_slug] or [].
+ *   - AI tools live in flow_step_config['enabled_tools'].
+ *   - FlowStepConfig::getEnabledTools() reads the new field. No runtime
+ *     fallback to handler_slugs — legacy on-disk rows are migrated by
+ *     inc/migrations/ai-enabled-tools.php on activation.
+ *
+ * This file covers both:
+ *   1. The accessor (no shim, no fallback).
+ *   2. The migration that flips legacy rows in place.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/**
+ * Inline reimplementation of FlowStepConfig::getEnabledTools().
+ *
+ * Mirrors inc/Core/Steps/FlowStepConfig.php post-Phase 2b. Diverging
+ * here means the real file regressed.
+ */
+function get_enabled_tools_for_test( array $step_config ): array {
+	if ( 'ai' !== ( $step_config['step_type'] ?? '' ) ) {
+		return array();
+	}
+
+	$enabled = $step_config['enabled_tools'] ?? array();
+	if ( ! is_array( $enabled ) ) {
+		return array();
+	}
+
+	return array_values( $enabled );
+}
+
+/**
+ * Inline reimplementation of the per-flow_config migration step in
+ * datamachine_migrate_ai_enabled_tools(). Mirrors
+ * inc/migrations/ai-enabled-tools.php so a regression there shows up
+ * here as a fixture diverging.
+ */
+function migrate_ai_enabled_tools_for_test( array $flow_config ): array {
+	foreach ( $flow_config as $step_id => &$step ) {
+		if ( ! is_array( $step ) ) {
+			continue;
+		}
+
+		if ( 'ai' !== ( $step['step_type'] ?? '' ) ) {
+			continue;
+		}
+
+		if ( ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
+			if ( ! empty( $step['handler_slugs'] ) ) {
+				$step['handler_slugs'] = array();
+			}
+			continue;
+		}
+
+		$legacy = $step['handler_slugs'] ?? array();
+		if ( empty( $legacy ) || ! is_array( $legacy ) ) {
+			if ( ! isset( $step['enabled_tools'] ) ) {
+				$step['enabled_tools'] = array();
+			}
+			continue;
+		}
+
+		$step['enabled_tools'] = array_values( $legacy );
+		$step['handler_slugs'] = array();
+	}
+	unset( $step );
+
+	return $flow_config;
+}
+
+$failures = array();
+$passes   = 0;
+
+function assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		$passes++;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo "    expected: " . var_export( $expected, true ) . "\n";
+	echo "    actual:   " . var_export( $actual, true ) . "\n";
+}
+
+echo "AI enabled_tools split smoke (Phase 2b)\n";
+echo "---------------------------------------\n";
+
+// ----- FlowStepConfig::getEnabledTools() -----
+
+echo "\n[1] AI step with enabled_tools populated:\n";
+$config = array(
+	'flow_step_id'  => 'flow_ai_1',
+	'step_type'     => 'ai',
+	'handler_slugs' => array(),
+	'enabled_tools' => array( 'intelligence/search', 'intelligence/wiki-upsert' ),
+);
+assert_equals(
+	array( 'intelligence/search', 'intelligence/wiki-upsert' ),
+	get_enabled_tools_for_test( $config ),
+	'returns enabled_tools verbatim',
+	$failures,
+	$passes
+);
+
+echo "\n[2] AI step with no tools:\n";
+$config = array(
+	'flow_step_id' => 'flow_ai_empty',
+	'step_type'    => 'ai',
+);
+assert_equals( array(), get_enabled_tools_for_test( $config ), 'empty config → empty', $failures, $passes );
+
+echo "\n[3] AI step with handler_slugs populated but enabled_tools empty (post-migration impossible state):\n";
+// The accessor does NOT fall back. handler_slugs is for handlers; AI
+// has none. Anything stored there is dead data after the migration.
+$config = array(
+	'flow_step_id'  => 'flow_ai_legacy',
+	'step_type'     => 'ai',
+	'handler_slugs' => array( 'intelligence/search' ),
+);
+assert_equals( array(), get_enabled_tools_for_test( $config ), 'no fallback to handler_slugs', $failures, $passes );
+
+echo "\n[4] Non-AI step (publish) returns empty:\n";
+$config = array(
+	'step_type'     => 'publish',
+	'handler_slugs' => array( 'wordpress_publish' ),
+	'enabled_tools' => array( 'intelligence/search' ),
+);
+assert_equals( array(), get_enabled_tools_for_test( $config ), 'publish step has no AI tools', $failures, $passes );
+
+echo "\n[5] Step config without step_type:\n";
+$config = array(
+	'enabled_tools' => array( 'intelligence/search' ),
+);
+assert_equals( array(), get_enabled_tools_for_test( $config ), 'no step_type → empty', $failures, $passes );
+
+echo "\n[6] AI step with enabled_tools that is not an array:\n";
+$config = array(
+	'step_type'     => 'ai',
+	'enabled_tools' => 'not_an_array',
+);
+assert_equals( array(), get_enabled_tools_for_test( $config ), 'non-array enabled_tools → empty (no fatal)', $failures, $passes );
+
+// ----- inc/migrations/ai-enabled-tools.php -----
+
+echo "\n[7] Migration: legacy AI row flips handler_slugs → enabled_tools:\n";
+$flow_config = array(
+	'step_a' => array(
+		'step_type'     => 'ai',
+		'handler_slugs' => array( 'intelligence/search', 'intelligence/wiki-upsert' ),
+	),
+);
+$migrated = migrate_ai_enabled_tools_for_test( $flow_config );
+assert_equals( array( 'intelligence/search', 'intelligence/wiki-upsert' ), $migrated['step_a']['enabled_tools'], 'enabled_tools populated from handler_slugs', $failures, $passes );
+assert_equals( array(), $migrated['step_a']['handler_slugs'], 'handler_slugs cleared', $failures, $passes );
+
+echo "\n[8] Migration: AI row already on Phase 2b shape is left alone:\n";
+$flow_config = array(
+	'step_a' => array(
+		'step_type'     => 'ai',
+		'handler_slugs' => array(),
+		'enabled_tools' => array( 'intelligence/search' ),
+	),
+);
+$migrated = migrate_ai_enabled_tools_for_test( $flow_config );
+assert_equals( array( 'intelligence/search' ), $migrated['step_a']['enabled_tools'], 'enabled_tools preserved', $failures, $passes );
+assert_equals( array(), $migrated['step_a']['handler_slugs'], 'handler_slugs stays empty', $failures, $passes );
+
+echo "\n[9] Migration: dual-shape row (both populated) clears handler_slugs without overwriting enabled_tools:\n";
+// Defensive against partial-state rows. enabled_tools wins; handler_slugs is wiped.
+$flow_config = array(
+	'step_a' => array(
+		'step_type'     => 'ai',
+		'handler_slugs' => array( 'intelligence/legacy_search' ),
+		'enabled_tools' => array( 'intelligence/wiki-upsert' ),
+	),
+);
+$migrated = migrate_ai_enabled_tools_for_test( $flow_config );
+assert_equals( array( 'intelligence/wiki-upsert' ), $migrated['step_a']['enabled_tools'], 'enabled_tools wins on dual shape', $failures, $passes );
+assert_equals( array(), $migrated['step_a']['handler_slugs'], 'handler_slugs wiped on dual shape', $failures, $passes );
+
+echo "\n[10] Migration: AI row with no tools at all gets enabled_tools=[]:\n";
+$flow_config = array(
+	'step_a' => array(
+		'step_type' => 'ai',
+	),
+);
+$migrated = migrate_ai_enabled_tools_for_test( $flow_config );
+assert_equals( array(), $migrated['step_a']['enabled_tools'], 'enabled_tools field added empty', $failures, $passes );
+
+echo "\n[11] Migration: non-AI step left alone:\n";
+$flow_config = array(
+	'step_a' => array(
+		'step_type'     => 'publish',
+		'handler_slugs' => array( 'wordpress_publish' ),
+		'handler_configs' => array( 'wordpress_publish' => array( 'post_status' => 'draft' ) ),
+	),
+);
+$migrated = migrate_ai_enabled_tools_for_test( $flow_config );
+assert_equals( array( 'wordpress_publish' ), $migrated['step_a']['handler_slugs'], 'publish handler_slugs untouched', $failures, $passes );
+assert_equals( false, isset( $migrated['step_a']['enabled_tools'] ), 'no enabled_tools added to non-AI step', $failures, $passes );
+
+echo "\n[12] Migration: mixed flow with AI + publish + system_task:\n";
+$flow_config = array(
+	'step_a' => array(
+		'step_type'     => 'ai',
+		'handler_slugs' => array( 'intelligence/search' ),
+	),
+	'step_b' => array(
+		'step_type'       => 'publish',
+		'handler_slugs'   => array( 'wordpress_publish' ),
+		'handler_configs' => array( 'wordpress_publish' => array() ),
+	),
+	'step_c' => array(
+		'step_type'       => 'system_task',
+		'handler_slugs'   => array( 'system_task' ),
+		'handler_configs' => array( 'system_task' => array( 'task' => 'daily_memory_generation' ) ),
+	),
+);
+$migrated = migrate_ai_enabled_tools_for_test( $flow_config );
+assert_equals( array( 'intelligence/search' ), $migrated['step_a']['enabled_tools'], 'AI step migrated', $failures, $passes );
+assert_equals( array(), $migrated['step_a']['handler_slugs'], 'AI handler_slugs cleared', $failures, $passes );
+assert_equals( array( 'wordpress_publish' ), $migrated['step_b']['handler_slugs'], 'publish step untouched', $failures, $passes );
+assert_equals( array( 'system_task' ), $migrated['step_c']['handler_slugs'], 'system_task synthetic slug untouched', $failures, $passes );
+
+echo "\n---------------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "Failures:\n";
+	foreach ( $failures as $name ) {
+		echo "  - {$name}\n";
+	}
+	exit( 1 );
+}
+
+echo "All checks passed.\n";
+exit( 0 );

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -50,8 +50,6 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 		$handler_slugs = array();
 		if ( ! empty( $handler_slug ) ) {
 			$handler_slugs = array( $handler_slug );
-		} elseif ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) ) {
-			$handler_slugs = $step['enabled_tools'];
 		} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
 			$handler_slugs = array( $step_type );
 		}
@@ -63,6 +61,10 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 			$handler_configs[ $step_type ] = $handler_config;
 		}
 
+		$enabled_tools = ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
+			? array_values( $step['enabled_tools'] )
+			: array();
+
 		$flow_config[ $step_id ] = array(
 			'flow_step_id'     => $step_id,
 			'pipeline_step_id' => $pipeline_step_id,
@@ -70,6 +72,7 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 			'execution_order'  => $index,
 			'handler_slugs'    => $handler_slugs,
 			'handler_configs'  => $handler_configs,
+			'enabled_tools'    => $enabled_tools,
 			'user_message'     => $step['user_message'] ?? '',
 			'disabled_tools'   => $step['disabled_tools'] ?? array(),
 			'pipeline_id'      => 'direct',
@@ -136,8 +139,8 @@ function assert_equals( $expected, $actual, string $name, array &$failures, int 
 	echo "    actual:   " . var_export( $actual, true ) . "\n";
 }
 
-echo "system-task config passthrough smoke (Phase 2a)\n";
-echo "-----------------------------------------------\n";
+echo "system-task config passthrough smoke (Phase 2a + 2b)\n";
+echo "-----------------------------------------------------\n";
 
 // Test 1: system_task workflow round-trips handler_config under step type slug.
 echo "\n[1] system_task workflow round-trips { task, params }:\n";
@@ -207,10 +210,10 @@ assert_equals( array(), $step0['handler_configs'], 'no config → empty handler_
 assert_equals( array(), get_primary_handler_config_for_test( $step0 ), 'getPrimaryHandlerConfig returns empty', $failures, $passes );
 assert_equals( 'webhook_gate', get_effective_slug_for_test( $step0 ), 'getEffectiveSlug falls back to step_type', $failures, $passes );
 
-// Test 4: ai step with enabled_tools (no handler_slug, no handler_config).
-// Phase 2a preserves the legacy AI shape (enabled_tools as handler_slugs);
-// Phase 2b in #1205 will move enabled_tools to its own field.
-echo "\n[4] ai step with enabled_tools (legacy shape preserved for Phase 2a):\n";
+// Test 4: ai step with enabled_tools.
+// Phase 2b: tools now land in `enabled_tools` and `handler_slugs` stays empty
+// for AI steps. The field overload (enabled_tools as handler_slugs) is gone.
+echo "\n[4] ai step with enabled_tools (Phase 2b shape):\n";
 $workflow = array(
 	'steps' => array(
 		array(
@@ -224,13 +227,12 @@ $workflow = array(
 $built = build_configs_from_workflow_for_test( $workflow );
 $step0 = $built['flow_config']['ephemeral_step_0'];
 
-assert_equals( array( 'intelligence/search', 'intelligence/wiki-upsert' ), $step0['handler_slugs'], 'enabled_tools become handler_slugs', $failures, $passes );
+assert_equals( array( 'intelligence/search', 'intelligence/wiki-upsert' ), $step0['enabled_tools'], 'enabled_tools land in dedicated field', $failures, $passes );
+assert_equals( array(), $step0['handler_slugs'], 'ai handler_slugs stays empty (single-purpose now)', $failures, $passes );
 assert_equals( array(), $step0['handler_configs'], 'ai step without handler_config → empty handler_configs', $failures, $passes );
 assert_equals( 'be helpful', $built['pipeline_config']['ephemeral_pipeline_0']['system_prompt'] ?? null, 'system_prompt lands in pipeline_config', $failures, $passes );
 
-// Test 5: ai step with no enabled_tools, no handler — must NOT synthesize step_type as a slug.
-// AI semantics treat handler_slugs as "enabled tools"; synthesizing 'ai' would pollute the AI
-// tool registry intersection in AIStep::resolve_pipeline_tools() and ToolPolicyResolver.
+// Test 5: ai step with no enabled_tools, no handler — both arrays empty, including the new field.
 echo "\n[5] ai step with no enabled_tools and no handler_config:\n";
 $workflow = array(
 	'steps' => array(
@@ -244,7 +246,8 @@ $workflow = array(
 $built = build_configs_from_workflow_for_test( $workflow );
 $step0 = $built['flow_config']['ephemeral_step_0'];
 
-assert_equals( array(), $step0['handler_slugs'], 'ai with no tools does not synthesize step_type', $failures, $passes );
+assert_equals( array(), $step0['handler_slugs'], 'ai handler_slugs stays empty', $failures, $passes );
+assert_equals( array(), $step0['enabled_tools'], 'ai enabled_tools empty when none provided', $failures, $passes );
 assert_equals( array(), $step0['handler_configs'], 'ai with no config → empty handler_configs', $failures, $passes );
 
 // Test 6: regression — system_task workflow that bypassed validation
@@ -270,7 +273,7 @@ $config = get_primary_handler_config_for_test( $step0 );
 assert_equals( 'agent_ping', $config['task'] ?? null, 'task type reaches step runtime', $failures, $passes );
 assert_equals( array( 'agent_id' => 2 ), $config['params'] ?? null, 'task params reach step runtime', $failures, $passes );
 
-echo "\n-----------------------------------------------\n";
+echo "\n-----------------------------------------------------\n";
 $total = $passes + count( $failures );
 echo "{$passes} / {$total} passed\n";
 


### PR DESCRIPTION
## Summary

Phase 2b of #1205. Drops the AI-step field overload where `handler_slugs` carried both the step's handler (length 0..1 for handler-bearing steps) AND the AI's enabled tools (length 0..N for AI steps). After this `handler_slugs` is single-purpose: it names the step's handler.

Stacks on #1206 (Phase 2a). Set the base to \`refactor-flowstepconfig-callsites\` so the diff stays reviewable.

## What changes

\`ExecuteWorkflowAbility::buildConfigsFromWorkflow()\` now writes a dedicated \`enabled_tools\` field on \`flow_step_config\` for AI steps, instead of collapsing them onto \`handler_slugs\`:

| Step type | handler_slugs (before) | handler_slugs (after) | enabled_tools |
|---|---|---|---|
| \`fetch\` / \`publish\` / \`upsert\` | \`[handler_slug]\` | unchanged | (n/a) |
| \`ai\` | \`[tool, tool, ...]\` | \`[]\` | \`[tool, tool, ...]\` |
| \`system_task\` / \`webhook_gate\` | \`[step_type]\` (Phase 2a) | unchanged | (n/a) |

\`FlowStepConfig::getEnabledTools()\` is the read-side accessor for the AI step's tool list. **No runtime fallback to \`handler_slugs\`.** Legacy on-disk rows are migrated in place by the new migration on activation; the accessor is the only read path with no branches.

\`inc/migrations/ai-enabled-tools.php\` (new) does the one-shot conversion on activation. For every flow step where \`step_type === 'ai'\` has \`handler_slugs\` populated, it moves them to \`enabled_tools\` and clears \`handler_slugs\`. Idempotent (gated on the \`datamachine_ai_enabled_tools_migrated\` option). Mirrors the pattern of \`inc/migrations/handler-keys.php\` and the rest of the migrations directory.

## Why no shim

The whole point of #1205 is to delete cruft, not paper over it. A runtime fallback would route every AI step read past the legacy field forever and require future cleanup to remove the shim itself. A one-shot migration deletes the legacy data in place, leaving a single read path with no branches.

The earlier revision of this PR added a deprecation-logging shim; Chris rejected it during review for exactly this reason. This PR was rewritten to migrate the data instead.

## Latent bug fixed

Adjacency tracking in \`AIStep\` and \`ToolPolicyResolver\` continues to read adjacent \`handler_slugs\` as \"the adjacent step's handler tools\" — adjacent AI steps now correctly contribute zero handler tools (\`handler_slugs = []\`) which is the correct behaviour.

Today an adjacent AI step's enabled tools could land in \`AIConversationLoop\`'s \`configured_handlers\` tracker. \`intelligence/search\` would survive the \`available_tools\` intersection, but \`is_handler_tool\` would be false for it, so \`array_diff\` in the multi-handler completion check never empties — the loop would never complete via that path. After Phase 2b + the migration, adjacent AI steps contribute \`handler_slugs = []\` (the correct shape — AI doesn't have handlers).

## Tests

- \`tests/system-task-config-passthrough-smoke.php\` — updated for the Phase 2b shape. **22 / 22 passes** covering both phases together (Phase 2a synthetic-slug + Phase 2b enabled_tools split).

- \`tests/ai-enabled-tools-smoke.php\` — **new**. **19 / 19 passes** covering:
  - \`getEnabledTools()\` returns \`enabled_tools\` verbatim.
  - \`getEnabledTools()\` does NOT fall back to \`handler_slugs\`. Post-migration, AI rows have \`handler_slugs = []\`. If a stale row survives somehow, the accessor returns empty rather than silently picking up legacy data.
  - Defensive: non-array \`enabled_tools\` → empty (no fatal).
  - Migration: legacy AI row flips \`handler_slugs\` → \`enabled_tools\`.
  - Migration: row already on Phase 2b shape is left alone.
  - Migration: dual-shape row clears \`handler_slugs\` without overwriting \`enabled_tools\` (no-double-counting invariant).
  - Migration: AI row with no tools at all gets \`enabled_tools = []\`.
  - Migration: non-AI step left alone (publish \`handler_slugs\` untouched, no \`enabled_tools\` added).
  - Migration: mixed flow with AI + publish + system_task migrates only the AI row.

- \`tests/queueable-trait-smoke.php\` (#1196), \`tests/daily-memory-conservation-smoke.php\` (#1204), \`tests/batch-child-agent-id-smoke.php\` (#1198), \`tests/system-task-workflow-validation-smoke.php\` (#1200), \`tests/tool-policy-resolver-adjacency-smoke.php\` (#1206) all still pass.

## Live verify

\`intelligence-chubes4\`: deployed, ran the migration, then injected a synthetic legacy AI row into a flow on disk and re-ran the migration:

\`\`\`
before: {step_type: 'ai', handler_slugs: ['intelligence/search', 'intelligence/wiki-upsert']}
after:  {step_type: 'ai', handler_slugs: [], enabled_tools: ['intelligence/search', 'intelligence/wiki-upsert']}
\`\`\`

The flow_config was rolled back after the verify so the production rows are untouched. The site's existing flow rows had no legacy AI data to migrate, so the migration completed silently as designed.

## Scope

Closes the Phase 2b items in #1205:
- [x] AI step's enabled tools live in \`enabled_tools\`; \`handler_slugs\` is always 0..1 element.
- [x] On-disk migration converts legacy rows in place; no runtime shim.
- [x] New smoke test covers the accessor and the migration.

React/admin UI cleanup (Phase 3) remains out of scope and ships separately once the backend canonicalization is on disk in production.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the field-split plan and the migration; wrote the smoke fixtures. Chris reviewed the design, rejected the runtime shim (the point of #1205 is to delete cruft, not paper over it), and the PR was rewritten to migrate legacy data in place instead. Chris confirmed the migration end-to-end on \`intelligence-chubes4\` with a synthetic legacy row.
