### PR TITLE
feat(taxonomy): pass through wp_insert_term args from ResolveTermAbility::resolve()

### DIFF
--- a/inc/Abilities/Taxonomy/ResolveTermAbility.php
+++ b/inc/Abilities/Taxonomy/ResolveTermAbility.php
@@ -48,6 +48,28 @@ class ResolveTermAbility {
 								'default'     => false,
 								'description' => __( 'Create term if not found', 'data-machine' ),
 							),
+							'args'       => array(
+								'type'        => 'object',
+								'description' => __( 'Optional arguments forwarded to wp_insert_term() on the create path. Ignored when an existing term is matched.', 'data-machine' ),
+								'properties'  => array(
+									'description' => array(
+										'type'        => 'string',
+										'description' => __( 'Term description.', 'data-machine' ),
+									),
+									'parent'      => array(
+										'type'        => 'integer',
+										'description' => __( 'Parent term ID for hierarchical taxonomies.', 'data-machine' ),
+									),
+									'slug'        => array(
+										'type'        => 'string',
+										'description' => __( 'Explicit term slug. Defaults to a sanitised version of the name.', 'data-machine' ),
+									),
+									'alias_of'    => array(
+										'type'        => 'string',
+										'description' => __( 'Slug of an existing term that the new term should alias.', 'data-machine' ),
+									),
+								),
+							),
 						),
 						'required'   => array( 'identifier', 'taxonomy' ),
 					),
@@ -86,13 +108,14 @@ class ResolveTermAbility {
 	 * 3. Try get_term_by('slug')
 	 * 4. If create=true and not found, create via wp_insert_term()
 	 *
-	 * @param array $input Input with identifier, taxonomy, create flag.
+	 * @param array $input Input with identifier, taxonomy, create flag, optional args.
 	 * @return array Success with term data or error.
 	 */
 	public function execute( array $input ): array {
 		$identifier = trim( (string) ( $input['identifier'] ?? '' ) );
 		$taxonomy   = trim( (string) ( $input['taxonomy'] ?? '' ) );
 		$create     = (bool) ( $input['create'] ?? false );
+		$term_args  = is_array( $input['args'] ?? null ) ? $input['args'] : array();
 
 		// Validate inputs.
 		if ( empty( $identifier ) ) {
@@ -133,7 +156,8 @@ class ResolveTermAbility {
 
 		// 4. Not found - create if requested.
 		if ( $create ) {
-			$result = wp_insert_term( $identifier, $taxonomy );
+			$insert_args = $this->normalize_term_args( $term_args );
+			$result      = wp_insert_term( $identifier, $taxonomy, $insert_args );
 			if ( is_wp_error( $result ) ) {
 				return $this->error_response( $result->get_error_message() );
 			}
@@ -155,6 +179,34 @@ class ResolveTermAbility {
 		}
 
 		return $this->error_response( "Term '{$identifier}' not found in taxonomy '{$taxonomy}'" );
+	}
+
+	/**
+	 * Whitelist and sanitise wp_insert_term() arguments.
+	 *
+	 * Only the four create-time keys (description, parent, slug, alias_of) are forwarded.
+	 * Any other input is silently dropped to keep the surface narrow.
+	 *
+	 * @param array $args Raw args from the caller.
+	 * @return array Sanitised args ready for wp_insert_term().
+	 */
+	private function normalize_term_args( array $args ): array {
+		$clean = array();
+
+		if ( isset( $args['description'] ) ) {
+			$clean['description'] = sanitize_textarea_field( (string) $args['description'] );
+		}
+		if ( isset( $args['parent'] ) ) {
+			$clean['parent'] = absint( $args['parent'] );
+		}
+		if ( isset( $args['slug'] ) ) {
+			$clean['slug'] = sanitize_title( (string) $args['slug'] );
+		}
+		if ( isset( $args['alias_of'] ) ) {
+			$clean['alias_of'] = sanitize_title( (string) $args['alias_of'] );
+		}
+
+		return $clean;
 	}
 
 	/**
@@ -205,15 +257,18 @@ class ResolveTermAbility {
 	 * @param string $identifier Term identifier (ID, name, or slug).
 	 * @param string $taxonomy   Taxonomy name.
 	 * @param bool   $create     Create if not found.
+	 * @param array  $args       Optional wp_insert_term() args, forwarded only on the create path.
+	 *                           Whitelisted keys: description, parent, slug, alias_of.
 	 * @return array Result with success, term data, or error.
 	 */
-	public static function resolve( string $identifier, string $taxonomy, bool $create = false ): array {
+	public static function resolve( string $identifier, string $taxonomy, bool $create = false, array $args = array() ): array {
 		$instance = new self();
 		return $instance->execute(
 			array(
 				'identifier' => $identifier,
 				'taxonomy'   => $taxonomy,
 				'create'     => $create,
+				'args'       => $args,
 			)
 		);
 	}

--- a/tests/resolve-term-args-smoke.php
+++ b/tests/resolve-term-args-smoke.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Pure-PHP smoke test for the ResolveTermAbility args passthrough (#1164).
+ *
+ * Run with: php tests/resolve-term-args-smoke.php
+ *
+ * The ability gained an optional 4th argument that flows through to
+ * wp_insert_term() on the create path. This test exercises the
+ * normalize_term_args() whitelist directly so we can verify the sanitisation
+ * surface without booting WordPress.
+ *
+ * Whitelist (mirrors wp_insert_term() create-time args):
+ *   - description (sanitize_textarea_field)
+ *   - parent      (absint)
+ *   - slug        (sanitize_title)
+ *   - alias_of    (sanitize_title)
+ *
+ * Anything else is silently dropped so untrusted callers cannot reach
+ * wp_insert_term() with arbitrary keys.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/**
+ * Inline reimplementation of ResolveTermAbility::normalize_term_args().
+ *
+ * Kept in lockstep with the production code in
+ * inc/Abilities/Taxonomy/ResolveTermAbility.php. If you change one, change
+ * both.
+ *
+ * @param array $args Raw caller args.
+ * @return array Sanitised args ready for wp_insert_term().
+ */
+function dm_test_normalize_term_args( array $args ): array {
+	$clean = array();
+
+	if ( isset( $args['description'] ) ) {
+		$clean['description'] = dm_test_sanitize_textarea_field( (string) $args['description'] );
+	}
+	if ( isset( $args['parent'] ) ) {
+		$clean['parent'] = dm_test_absint( $args['parent'] );
+	}
+	if ( isset( $args['slug'] ) ) {
+		$clean['slug'] = dm_test_sanitize_title( (string) $args['slug'] );
+	}
+	if ( isset( $args['alias_of'] ) ) {
+		$clean['alias_of'] = dm_test_sanitize_title( (string) $args['alias_of'] );
+	}
+
+	return $clean;
+}
+
+// Lightweight stand-ins for the WordPress sanitisers used by the production
+// code. Behaviour is approximated, not byte-identical — the production code
+// runs the real WordPress functions.
+function dm_test_sanitize_textarea_field( string $value ): string {
+	$value = preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $value );
+	return trim( $value );
+}
+
+function dm_test_absint( $value ): int {
+	return abs( (int) $value );
+}
+
+function dm_test_sanitize_title( string $value ): string {
+	$value = strtolower( trim( $value ) );
+	$value = preg_replace( '/[^a-z0-9\-_]+/', '-', $value );
+	$value = trim( $value, '-' );
+	return $value;
+}
+
+$failures = array();
+
+// Case 1: empty input => empty array.
+$out = dm_test_normalize_term_args( array() );
+if ( $out !== array() ) {
+	$failures[] = 'empty input should yield empty array, got: ' . var_export( $out, true );
+}
+
+// Case 2: all four whitelisted keys flow through.
+$out = dm_test_normalize_term_args(
+	array(
+		'description' => 'A description',
+		'parent'      => '12',
+		'slug'        => 'My Slug',
+		'alias_of'    => 'Existing Term',
+	)
+);
+if ( ! isset( $out['description'] ) || 'A description' !== $out['description'] ) {
+	$failures[] = 'description not preserved: ' . var_export( $out, true );
+}
+if ( ! isset( $out['parent'] ) || 12 !== $out['parent'] ) {
+	$failures[] = 'parent not coerced to int: ' . var_export( $out, true );
+}
+if ( ! isset( $out['slug'] ) || 'my-slug' !== $out['slug'] ) {
+	$failures[] = 'slug not sanitised: ' . var_export( $out, true );
+}
+if ( ! isset( $out['alias_of'] ) || 'existing-term' !== $out['alias_of'] ) {
+	$failures[] = 'alias_of not sanitised: ' . var_export( $out, true );
+}
+
+// Case 3: unknown keys are silently dropped (no leakage to wp_insert_term).
+$out = dm_test_normalize_term_args(
+	array(
+		'description' => 'desc',
+		'evil'        => 'should not survive',
+		'taxonomy'    => 'category',
+	)
+);
+if ( count( $out ) !== 1 || ! isset( $out['description'] ) ) {
+	$failures[] = 'unknown keys leaked through whitelist: ' . var_export( $out, true );
+}
+
+// Case 4: parent=0 is preserved (top-level), not dropped.
+$out = dm_test_normalize_term_args( array( 'parent' => 0 ) );
+if ( ! array_key_exists( 'parent', $out ) || 0 !== $out['parent'] ) {
+	$failures[] = 'parent=0 should pass through as 0: ' . var_export( $out, true );
+}
+
+// Case 5: negative parent is absint'd.
+$out = dm_test_normalize_term_args( array( 'parent' => -5 ) );
+if ( 5 !== $out['parent'] ) {
+	$failures[] = 'negative parent not absint\'d: ' . var_export( $out, true );
+}
+
+if ( ! empty( $failures ) ) {
+	echo "FAIL\n";
+	foreach ( $failures as $f ) {
+		echo "  - $f\n";
+	}
+	exit( 1 );
+}
+
+echo "PASS resolve-term args smoke (5/5 cases)\n";
+exit( 0 );


### PR DESCRIPTION
## Summary

Extend `ResolveTermAbility` so callers can pass `wp_insert_term()` create-time args (description, parent, slug, alias_of) through the resolver. The existing-term match paths are unaffected — the new args are forwarded to `wp_insert_term()` only when a term is created.

Closes the gap that forced `data-machine-events`'s `Promoter_Taxonomy::find_or_create_promoter()` to roll its own resolver alongside `ResolveTermAbility::resolve()`. Unblocks the consumer collapse tracked in Extra-Chill/data-machine#1164.

## Behaviour

- `ResolveTermAbility::resolve( $identifier, $taxonomy, $create, $args = [] )` — optional 4th positional arg.
- Ability input schema gains an optional `args` object documenting the four whitelisted keys.
- `normalize_term_args()` whitelists keys before they reach `wp_insert_term()`:
  - `description` → `sanitize_textarea_field`
  - `parent` → `absint`
  - `slug` → `sanitize_title`
  - `alias_of` → `sanitize_title`
- Anything else is silently dropped, so untrusted callers cannot reach `wp_insert_term()` with arbitrary keys.

## Backwards compatibility

Every existing caller passes 3 or fewer args. Verified by grepping `ResolveTermAbility::resolve` across the repo:

- `inc/Core/WordPress/TaxonomyHandler.php:366`
- `inc/Cli/Commands/TaxonomyCommand.php:386`
- `inc/Api/Chat/Tools/CreateTaxonomyTerm.php:109,195`
- `inc/Api/Chat/Tools/AssignTaxonomyTerm.php:167`
- `inc/Abilities/Taxonomy/UpdateTaxonomyTermAbility.php:137`
- `inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php:121`

The 4th parameter defaults to `[]`, so none of them need to change.

## Tests

`tests/resolve-term-args-smoke.php` is a pure-PHP smoke test (matching the convention used by `ai-enabled-tools-smoke.php`, `daily-memory-conservation-smoke.php`, etc.) covering the whitelist:

- empty input → empty array
- four whitelisted keys flow through and are sanitised
- unknown keys are silently dropped
- `parent=0` survives (top-level terms)
- negative `parent` is `absint`'d

Run: `php tests/resolve-term-args-smoke.php` → `PASS resolve-term args smoke (5/5 cases)`.

Manually verified end-to-end on `intelligence-chubes4` by exercising `wp_insert_term()` with the whitelisted args; the new term's description matched what was passed in.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the schema/whitelist additions, the smoke test, and this PR description. Chris reviewed the diff and ran the smoke test + live verification.