### PR TITLE
feat(taxonomy): add MergeTermMetaAbility as the post-resolution meta-write primitive

### DIFF
--- a/inc/Abilities/Taxonomy/MergeTermMetaAbility.php
+++ b/inc/Abilities/Taxonomy/MergeTermMetaAbility.php
@@ -1,0 +1,273 @@
+<?php
+/**
+ * Merge Term Meta Ability
+ *
+ * Post-resolution primitive for writing taxonomy term meta with two strategies:
+ *
+ *   - 'fill_empty' (default): only writes meta keys whose existing stored value
+ *     is empty. Used on the existing-term path of find-or-create flows so that
+ *     incoming data enriches the term without clobbering operator edits.
+ *   - 'overwrite':              writes every supplied meta key unconditionally.
+ *     Used on the freshly-created-term path where there is nothing to preserve.
+ *
+ * Pairs with ResolveTermAbility. Together they collapse the find-or-create-with-meta
+ * pattern that has shown up across DM and DM-events taxonomies (Promoter, Venue, ...).
+ *
+ * @package DataMachine\Abilities\Taxonomy
+ */
+
+namespace DataMachine\Abilities\Taxonomy;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\WordPress\TaxonomyHandler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class MergeTermMetaAbility {
+
+	public const STRATEGY_FILL_EMPTY = 'fill_empty';
+	public const STRATEGY_OVERWRITE  = 'overwrite';
+
+	public function __construct() {
+		$this->registerAbility();
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/merge-term-meta',
+				array(
+					'label'               => __( 'Merge Term Meta', 'data-machine' ),
+					'description'         => __( 'Write taxonomy term meta with fill-empty or overwrite semantics. Pairs with resolve-term as the post-resolution write step in find-or-create flows.', 'data-machine' ),
+					'category'            => 'datamachine-taxonomy',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'term_id'     => array(
+								'type'        => 'integer',
+								'description' => __( 'Target term ID.', 'data-machine' ),
+							),
+							'taxonomy'    => array(
+								'type'        => 'string',
+								'description' => __( 'Taxonomy slug. Used for validation and logs.', 'data-machine' ),
+							),
+							'data'        => array(
+								'type'        => 'object',
+								'description' => __( 'Incoming values keyed by data_key. Empty values are skipped.', 'data-machine' ),
+							),
+							'field_map'   => array(
+								'type'        => 'object',
+								'description' => __( 'Map of data_key => meta_key. Only listed keys are considered; everything else in data is ignored.', 'data-machine' ),
+							),
+							'strategy'    => array(
+								'type'        => 'string',
+								'enum'        => array( self::STRATEGY_FILL_EMPTY, self::STRATEGY_OVERWRITE ),
+								'default'     => self::STRATEGY_FILL_EMPTY,
+								'description' => __( 'fill_empty: only write keys whose stored value is empty. overwrite: write every supplied key unconditionally.', 'data-machine' ),
+							),
+							'description' => array(
+								'type'        => 'string',
+								'description' => __( 'Optional term description. Written to the term row, not term_meta. Honours the same strategy.', 'data-machine' ),
+							),
+						),
+						'required'   => array( 'term_id', 'taxonomy', 'data', 'field_map' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'             => array( 'type' => 'boolean' ),
+							'term_id'             => array( 'type' => 'integer' ),
+							'taxonomy'            => array( 'type' => 'string' ),
+							'updated'             => array( 'type' => 'array' ),
+							'skipped'             => array( 'type' => 'array' ),
+							'description_updated' => array( 'type' => 'boolean' ),
+							'error'               => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Execute the merge.
+	 *
+	 * @param array $input Input shape — see input_schema above.
+	 * @return array Output shape — see output_schema above.
+	 */
+	public function execute( array $input ): array {
+		$term_id     = (int) ( $input['term_id'] ?? 0 );
+		$taxonomy    = trim( (string) ( $input['taxonomy'] ?? '' ) );
+		$data        = is_array( $input['data'] ?? null ) ? $input['data'] : array();
+		$field_map   = is_array( $input['field_map'] ?? null ) ? $input['field_map'] : array();
+		$strategy    = (string) ( $input['strategy'] ?? self::STRATEGY_FILL_EMPTY );
+		$description = array_key_exists( 'description', $input ) ? (string) $input['description'] : null;
+
+		if ( $term_id <= 0 ) {
+			return $this->error_response( 'term_id is required' );
+		}
+
+		if ( '' === $taxonomy ) {
+			return $this->error_response( 'taxonomy is required' );
+		}
+
+		if ( ! taxonomy_exists( $taxonomy ) ) {
+			return $this->error_response( "Taxonomy '{$taxonomy}' does not exist" );
+		}
+
+		if ( TaxonomyHandler::shouldSkipTaxonomy( $taxonomy ) ) {
+			return $this->error_response( "Cannot write meta for system taxonomy '{$taxonomy}'" );
+		}
+
+		if ( empty( $field_map ) ) {
+			return $this->error_response( 'field_map is required and cannot be empty' );
+		}
+
+		if ( ! in_array( $strategy, array( self::STRATEGY_FILL_EMPTY, self::STRATEGY_OVERWRITE ), true ) ) {
+			return $this->error_response( "Unknown strategy '{$strategy}'" );
+		}
+
+		$term = get_term( $term_id, $taxonomy );
+		if ( ! $term || is_wp_error( $term ) ) {
+			return $this->error_response( "Term {$term_id} not found in taxonomy '{$taxonomy}'" );
+		}
+
+		$updated = array();
+		$skipped = array();
+
+		foreach ( $field_map as $data_key => $meta_key ) {
+			$data_key = (string) $data_key;
+			$meta_key = (string) $meta_key;
+
+			if ( '' === $data_key || '' === $meta_key ) {
+				continue;
+			}
+
+			if ( ! array_key_exists( $data_key, $data ) ) {
+				$skipped[] = $data_key;
+				continue;
+			}
+
+			$incoming = $data[ $data_key ];
+
+			// Treat null and empty-string as "not provided". This mirrors the
+			// behaviour of the legacy update_*_meta / smart_merge_*_meta helpers
+			// the consumers used to roll themselves.
+			if ( null === $incoming || '' === $incoming || ( is_array( $incoming ) && empty( $incoming ) ) ) {
+				$skipped[] = $data_key;
+				continue;
+			}
+
+			if ( self::STRATEGY_FILL_EMPTY === $strategy ) {
+				$existing = get_term_meta( $term_id, $meta_key, true );
+				if ( '' !== $existing && null !== $existing && array() !== $existing ) {
+					$skipped[] = $data_key;
+					continue;
+				}
+			}
+
+			update_term_meta( $term_id, $meta_key, sanitize_text_field( (string) $incoming ) );
+			$updated[] = $data_key;
+		}
+
+		$description_updated = false;
+		if ( null !== $description && '' !== $description ) {
+			$should_write = true;
+			if ( self::STRATEGY_FILL_EMPTY === $strategy ) {
+				$should_write = ( '' === (string) $term->description );
+			}
+
+			if ( $should_write ) {
+				$result = wp_update_term(
+					$term_id,
+					$taxonomy,
+					array(
+						'description' => sanitize_textarea_field( $description ),
+					)
+				);
+
+				if ( is_wp_error( $result ) ) {
+					return $this->error_response( $result->get_error_message() );
+				}
+
+				$description_updated = true;
+			}
+		}
+
+		return array(
+			'success'             => true,
+			'term_id'             => $term_id,
+			'taxonomy'            => $taxonomy,
+			'updated'             => array_values( array_unique( $updated ) ),
+			'skipped'             => array_values( array_unique( $skipped ) ),
+			'description_updated' => $description_updated,
+		);
+	}
+
+	/**
+	 * Build error response.
+	 *
+	 * @param string $message Error message.
+	 * @return array
+	 */
+	private function error_response( string $message ): array {
+		return array(
+			'success' => false,
+			'error'   => $message,
+		);
+	}
+
+	/**
+	 * Check permission for this ability.
+	 *
+	 * @return bool
+	 */
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	/**
+	 * Static helper for internal use without going through the abilities API.
+	 *
+	 * @param int    $term_id     Target term ID.
+	 * @param string $taxonomy    Taxonomy slug.
+	 * @param array  $data        Incoming data keyed by data_key.
+	 * @param array  $field_map   Map of data_key => meta_key. Determines what is considered.
+	 * @param string $strategy    'fill_empty' (default) or 'overwrite'.
+	 * @param string|null $description Optional term description. Honours the strategy.
+	 * @return array Result with success/updated/skipped/description_updated/error.
+	 */
+	public static function merge(
+		int $term_id,
+		string $taxonomy,
+		array $data,
+		array $field_map,
+		string $strategy = self::STRATEGY_FILL_EMPTY,
+		?string $description = null
+	): array {
+		$input = array(
+			'term_id'   => $term_id,
+			'taxonomy'  => $taxonomy,
+			'data'      => $data,
+			'field_map' => $field_map,
+			'strategy'  => $strategy,
+		);
+
+		if ( null !== $description ) {
+			$input['description'] = $description;
+		}
+
+		return ( new self() )->execute( $input );
+	}
+}

--- a/inc/Abilities/TaxonomyAbilities.php
+++ b/inc/Abilities/TaxonomyAbilities.php
@@ -18,6 +18,7 @@ use DataMachine\Abilities\Taxonomy\CreateTaxonomyTermAbility;
 use DataMachine\Abilities\Taxonomy\UpdateTaxonomyTermAbility;
 use DataMachine\Abilities\Taxonomy\DeleteTaxonomyTermAbility;
 use DataMachine\Abilities\Taxonomy\ResolveTermAbility;
+use DataMachine\Abilities\Taxonomy\MergeTermMetaAbility;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -30,6 +31,7 @@ class TaxonomyAbilities {
 	private UpdateTaxonomyTermAbility $update_taxonomy_term;
 	private DeleteTaxonomyTermAbility $delete_taxonomy_term;
 	private ResolveTermAbility $resolve_term;
+	private MergeTermMetaAbility $merge_term_meta;
 
 	public function __construct() {
 		if ( self::$registered ) {
@@ -37,6 +39,7 @@ class TaxonomyAbilities {
 		}
 
 		$this->resolve_term         = new ResolveTermAbility();
+		$this->merge_term_meta      = new MergeTermMetaAbility();
 		$this->get_taxonomy_terms   = new GetTaxonomyTermsAbility();
 		$this->create_taxonomy_term = new CreateTaxonomyTermAbility();
 		$this->update_taxonomy_term = new UpdateTaxonomyTermAbility();

--- a/tests/merge-term-meta-smoke.php
+++ b/tests/merge-term-meta-smoke.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Pure-PHP smoke test for MergeTermMetaAbility (#1164 follow-up).
+ *
+ * Run with: php tests/merge-term-meta-smoke.php
+ *
+ * Exercises the per-key decision logic in execute() — given a (data, field_map,
+ * strategy, existing_meta) tuple, decide for each data_key:
+ *
+ *   - skip: missing from data, empty value, or strategy=fill_empty + already populated
+ *   - update: write the sanitised value via update_term_meta
+ *
+ * The production code in inc/Abilities/Taxonomy/MergeTermMetaAbility.php
+ * embeds the decision inside execute(); this test reimplements just the
+ * decision so we can verify the logic without booting WordPress.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+const STRATEGY_FILL_EMPTY = 'fill_empty';
+const STRATEGY_OVERWRITE  = 'overwrite';
+
+/**
+ * Inline re-implementation of the per-key decision in
+ * MergeTermMetaAbility::execute(). Returns ['updated' => string[],
+ * 'skipped' => string[]].
+ */
+function dm_test_merge_decide( array $data, array $field_map, string $strategy, array $existing_meta ): array {
+	$updated = array();
+	$skipped = array();
+
+	foreach ( $field_map as $data_key => $meta_key ) {
+		$data_key = (string) $data_key;
+		$meta_key = (string) $meta_key;
+
+		if ( '' === $data_key || '' === $meta_key ) {
+			continue;
+		}
+
+		if ( ! array_key_exists( $data_key, $data ) ) {
+			$skipped[] = $data_key;
+			continue;
+		}
+
+		$incoming = $data[ $data_key ];
+		if ( null === $incoming || '' === $incoming || ( is_array( $incoming ) && empty( $incoming ) ) ) {
+			$skipped[] = $data_key;
+			continue;
+		}
+
+		if ( STRATEGY_FILL_EMPTY === $strategy ) {
+			$existing = $existing_meta[ $meta_key ] ?? '';
+			if ( '' !== $existing && null !== $existing && array() !== $existing ) {
+				$skipped[] = $data_key;
+				continue;
+			}
+		}
+
+		$updated[] = $data_key;
+	}
+
+	return array(
+		'updated' => array_values( array_unique( $updated ) ),
+		'skipped' => array_values( array_unique( $skipped ) ),
+	);
+}
+
+$failures = array();
+
+$promoter_field_map = array(
+	'url'  => '_promoter_url',
+	'type' => '_promoter_type',
+);
+
+$venue_field_map = array(
+	'address'     => '_venue_address',
+	'city'        => '_venue_city',
+	'state'       => '_venue_state',
+	'coordinates' => '_venue_coordinates',
+);
+
+// Case 1: fill_empty, all existing meta empty, all data present → all updated.
+$out = dm_test_merge_decide(
+	array( 'url' => 'https://example.com', 'type' => 'Organization' ),
+	$promoter_field_map,
+	STRATEGY_FILL_EMPTY,
+	array()
+);
+if ( $out['updated'] !== array( 'url', 'type' ) ) {
+	$failures[] = 'fill_empty + empty meta should update all: ' . var_export( $out, true );
+}
+
+// Case 2: fill_empty, url already populated → url skipped, type updated.
+$out = dm_test_merge_decide(
+	array( 'url' => 'https://NEW.com', 'type' => 'Person' ),
+	$promoter_field_map,
+	STRATEGY_FILL_EMPTY,
+	array( '_promoter_url' => 'https://existing.com' )
+);
+if ( $out['updated'] !== array( 'type' ) || ! in_array( 'url', $out['skipped'], true ) ) {
+	$failures[] = 'fill_empty should skip populated keys: ' . var_export( $out, true );
+}
+
+// Case 3: overwrite, url already populated → url still updated.
+$out = dm_test_merge_decide(
+	array( 'url' => 'https://NEW.com', 'type' => 'Person' ),
+	$promoter_field_map,
+	STRATEGY_OVERWRITE,
+	array( '_promoter_url' => 'https://existing.com' )
+);
+if ( $out['updated'] !== array( 'url', 'type' ) ) {
+	$failures[] = 'overwrite should write populated keys: ' . var_export( $out, true );
+}
+
+// Case 4: data has no value for a mapped key → skipped.
+$out = dm_test_merge_decide(
+	array( 'url' => 'https://example.com' ),
+	$promoter_field_map,
+	STRATEGY_FILL_EMPTY,
+	array()
+);
+if ( $out['updated'] !== array( 'url' ) || $out['skipped'] !== array( 'type' ) ) {
+	$failures[] = 'missing data key should be skipped: ' . var_export( $out, true );
+}
+
+// Case 5: empty-string incoming → skipped even with overwrite.
+$out = dm_test_merge_decide(
+	array( 'url' => '', 'type' => 'Organization' ),
+	$promoter_field_map,
+	STRATEGY_OVERWRITE,
+	array( '_promoter_url' => 'https://existing.com' )
+);
+if ( in_array( 'url', $out['updated'], true ) ) {
+	$failures[] = 'empty-string incoming should never update: ' . var_export( $out, true );
+}
+if ( ! in_array( 'url', $out['skipped'], true ) ) {
+	$failures[] = 'empty-string incoming should be in skipped: ' . var_export( $out, true );
+}
+
+// Case 6: keys not in field_map are silently ignored.
+$out = dm_test_merge_decide(
+	array( 'url' => 'https://example.com', 'evil' => 'pwn' ),
+	$promoter_field_map,
+	STRATEGY_FILL_EMPTY,
+	array()
+);
+if ( in_array( 'evil', $out['updated'], true ) || in_array( 'evil', $out['skipped'], true ) ) {
+	$failures[] = 'unmapped data keys should not appear in result: ' . var_export( $out, true );
+}
+
+// Case 7: Venue partial update — only coordinates incoming on a venue with
+// every address field already populated. fill_empty leaves address alone,
+// writes coordinates.
+$out = dm_test_merge_decide(
+	array( 'coordinates' => '32.78,-79.93' ),
+	$venue_field_map,
+	STRATEGY_FILL_EMPTY,
+	array(
+		'_venue_address' => '123 Main St',
+		'_venue_city'    => 'Charleston',
+		'_venue_state'   => 'SC',
+	)
+);
+if ( $out['updated'] !== array( 'coordinates' ) ) {
+	$failures[] = 'venue partial update should only write coordinates: ' . var_export( $out, true );
+}
+
+// Case 8: Venue create-time write (overwrite) populates everything.
+$out = dm_test_merge_decide(
+	array(
+		'address'     => '123 Main St',
+		'city'        => 'Charleston',
+		'state'       => 'SC',
+		'coordinates' => '32.78,-79.93',
+	),
+	$venue_field_map,
+	STRATEGY_OVERWRITE,
+	array()
+);
+if ( count( $out['updated'] ) !== 4 ) {
+	$failures[] = 'venue create-time overwrite should write all four: ' . var_export( $out, true );
+}
+
+if ( ! empty( $failures ) ) {
+	echo "FAIL\n";
+	foreach ( $failures as $f ) {
+		echo "  - $f\n";
+	}
+	exit( 1 );
+}
+
+echo "PASS merge-term-meta smoke (8/8 cases)\n";
+exit( 0 );


### PR DESCRIPTION
## Summary

Stacked on #1217. **Marked draft until #1217 merges**, then will rebase onto `main` and convert to ready-for-review.

`ResolveTermAbility::resolve()` answers "give me a term." The other half of every find-or-create flow is "now reconcile its meta." That second half has been hand-rolled at least twice across the DM ecosystem (Promoter and Venue in `data-machine-events`). Both copies implement the same shape — only the field map and the side effects differ.

This PR lifts that primitive into DM core as `MergeTermMetaAbility` and a matching `merge()` static helper.

## Surface

```php
// Abilities API
'datamachine/merge-term-meta'

// Static helper for internal use
MergeTermMetaAbility::merge(
    int     \$term_id,
    string  \$taxonomy,
    array   \$data,         // incoming values keyed by data_key
    array   \$field_map,    // map of data_key => meta_key
    string  \$strategy   = 'fill_empty',
    ?string \$description = null
);
```

## Strategies

- **`fill_empty`** (default) — only write keys whose stored meta value is currently empty. Used on the existing-term hit path so incoming data enriches a term without clobbering operator edits. This is the "smart merge" behaviour both Promoter and Venue ship today.
- **`overwrite`** — write every supplied key unconditionally. Used on the freshly-created-term path where there is nothing to preserve.

## Output shape

```php
[
  'success'             => bool,
  'term_id'             => int,
  'taxonomy'            => string,
  'updated'             => string[], // data_keys that were written
  'skipped'             => string[], // data_keys that were not (no value, or fill_empty + populated)
  'description_updated' => bool,
  'error'               => string,   // only on failure
]
```

`updated[]` / `skipped[]` are the **data_keys**, not meta_keys, so callers can drive post-write side effects without reading meta back. Venue's geocoder will use this — "if `'address'` is in `updated`, requeue geocoding."

## Validation surface

- `taxonomy_exists()` + `TaxonomyHandler::shouldSkipTaxonomy()` guards (matches the rest of the taxonomy abilities).
- `get_term()` guard before any writes — won't write meta to a term that doesn't exist or got trashed mid-flight.
- `field_map` gates which `data_keys` are even considered. Anything outside the map is silently ignored, so untrusted callers cannot reach `update_term_meta()` with arbitrary keys.
- Both `description` writes and meta writes go through the WP-core sanitisers (`sanitize_textarea_field` / `sanitize_text_field`).

## Tests

`tests/merge-term-meta-smoke.php` is a pure-PHP smoke test (matches `ai-enabled-tools-smoke.php`, `daily-memory-conservation-smoke.php`, etc.). Eight cases:

1. fill_empty + empty meta → all keys written
2. fill_empty + populated key → that key skipped
3. overwrite + populated key → still written
4. data missing a mapped key → key skipped
5. empty-string incoming → never written even with overwrite
6. unmapped data keys → silently ignored
7. Venue partial update — only coordinates incoming, leaves address alone
8. Venue create-time overwrite — populates everything

Run: `php tests/merge-term-meta-smoke.php` → `PASS merge-term-meta smoke (8/8 cases)`.

## What's next (separate PRs, not in this stack)

- **Extra-Chill/data-machine-events#217** — already open as draft. Will be updated to compose `ResolveTermAbility::resolve()` + `MergeTermMetaAbility::merge()` once both DM PRs land. The Promoter collapse drops ~30 more lines.
- **Venue collapse (new events PR, TBD)** — Venue's match cascade is domain-specific (address-based, "The"-toggle, normalised-name) and stays put. Only the meta-write half (`smart_merge_venue_meta` + `update_venue_meta`) collapses onto this primitive. Side effects (`maybe_geocode_venue`, `maybe_derive_timezone`) move into the consumer where they belong.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Designed the API around the two existing consumers, drafted the ability + static helper + smoke test, wrote this PR description. Chris reviewed the design call (extracting the meta-write half rather than a pluggable-matcher framework) and the diff.