### PR TITLE
feat(transcripts): optional pipeline AI conversation transcript persistence

### DIFF
--- a/inc/Cli/Commands/ChatCommand.php
+++ b/inc/Cli/Commands/ChatCommand.php
@@ -21,13 +21,22 @@ class ChatCommand extends BaseCommand {
 	/**
 	 * List chat sessions for a user.
 	 *
+	 * Pipeline transcript sessions (mode='pipeline') are hidden from the
+	 * default listing because they're forensic captures of AI conversation
+	 * loops, not human chats. Use --include-transcripts to include them, or
+	 * --context=pipeline to list only pipeline-mode sessions.
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--user=<id>]
 	 * : User ID to list sessions for. Defaults to current user.
 	 *
 	 * [--context=<type>]
-	 * : Filter by execution context (chat, pipeline, system).
+	 * : Filter by execution context (chat, pipeline, system). When set, the
+	 *   --include-transcripts flag is implicitly on for pipeline contexts.
+	 *
+	 * [--include-transcripts]
+	 * : Include pipeline transcript sessions in the default listing.
 	 *
 	 * [--limit=<n>]
 	 * : Maximum number of sessions to return.
@@ -58,11 +67,17 @@ class ChatCommand extends BaseCommand {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # List sessions for user 1
+	 *     # List human chat sessions for user 1 (transcripts hidden)
 	 *     wp datamachine chat list --user=1
 	 *
-	 *     # List chat-context sessions
+	 *     # List chat-context sessions explicitly
 	 *     wp datamachine chat list --user=1 --context=chat
+	 *
+	 *     # Include pipeline transcripts in the list
+	 *     wp datamachine chat list --user=1 --include-transcripts
+	 *
+	 *     # List only pipeline transcripts
+	 *     wp datamachine chat list --user=1 --context=pipeline
 	 *
 	 *     # Get session IDs only
 	 *     wp datamachine chat list --user=1 --format=ids
@@ -75,9 +90,38 @@ class ChatCommand extends BaseCommand {
 		$offset  = max( 0, (int) ( $assoc_args['offset'] ?? 0 ) );
 		$context = ! empty( $assoc_args['context'] ) ? sanitize_text_field( $assoc_args['context'] ) : null;
 
+		$include_transcripts = isset( $assoc_args['include-transcripts'] );
+
 		$chat_db  = ConversationStoreFactory::get();
 		$sessions = $chat_db->get_user_sessions( $user_id, $limit, $offset, $context );
 		$total    = $chat_db->get_user_session_count( $user_id, $context );
+
+		// Hide pipeline transcripts unless explicitly opted in or filtered to.
+		// When the caller passes an explicit --context, they've already chosen
+		// what they want — don't second-guess them.
+		if ( null === $context && ! $include_transcripts ) {
+			$filtered = array_values(
+				array_filter(
+					$sessions,
+					static function ( $session ) {
+						return ( $session['mode'] ?? 'chat' ) !== 'pipeline';
+					}
+				)
+			);
+
+			if ( count( $filtered ) !== count( $sessions ) ) {
+				$hidden = count( $sessions ) - count( $filtered );
+				WP_CLI::debug(
+					sprintf(
+						'Hid %d pipeline transcript session(s). Use --include-transcripts to show them.',
+						$hidden
+					),
+					'datamachine'
+				);
+			}
+
+			$sessions = $filtered;
+		}
 
 		if ( empty( $sessions ) ) {
 			WP_CLI::log( 'No chat sessions found.' );

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -16,6 +16,7 @@ use DataMachine\Cli\BaseCommand;
 use DataMachine\Cli\AgentResolver;
 use DataMachine\Cli\UserResolver;
 use DataMachine\Abilities\JobAbilities;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Engine\Tasks\TaskRegistry;
 
@@ -386,6 +387,175 @@ class JobsCommand extends BaseCommand {
 	}
 
 	/**
+	 * Read the persisted AI conversation transcript for a job.
+	 *
+	 * Reads engine_data['transcript_session_id'] from the job and renders
+	 * the persisted $messages array. Errors cleanly when the job has no
+	 * transcript persisted (default behavior — persistence is opt-in).
+	 *
+	 * ## OPTIONS
+	 *
+	 * <job_id>
+	 * : The job ID whose transcript should be read.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: text
+	 * options:
+	 *   - text
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * [--raw]
+	 * : Dump the messages array verbatim (only with --format=json or yaml).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Render the transcript human-readable
+	 *     wp datamachine jobs transcript 844
+	 *
+	 *     # Pipe full messages array as JSON for further processing
+	 *     wp datamachine jobs transcript 844 --format=json --raw
+	 *
+	 * @subcommand transcript
+	 */
+	public function transcript( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) || ! is_numeric( $args[0] ) || (int) $args[0] <= 0 ) {
+			WP_CLI::error( 'Job ID is required and must be a positive integer.' );
+			return;
+		}
+
+		$job_id = (int) $args[0];
+		$format = $assoc_args['format'] ?? 'text';
+		$raw    = isset( $assoc_args['raw'] );
+
+		$result = $this->abilities->executeGetJobs( array( 'job_id' => $job_id ) );
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Unknown error occurred' );
+			return;
+		}
+
+		$jobs = $result['jobs'] ?? array();
+		if ( empty( $jobs ) ) {
+			WP_CLI::error( sprintf( 'Job %d not found.', $job_id ) );
+			return;
+		}
+
+		$job                   = $jobs[0];
+		$engine_data           = $job['engine_data'] ?? array();
+		$transcript_session_id = $engine_data['transcript_session_id'] ?? '';
+
+		if ( empty( $transcript_session_id ) ) {
+			WP_CLI::error(
+				sprintf(
+					'No transcript persisted for job %d. Enable datamachine_persist_pipeline_transcripts (or set persist_transcripts on the pipeline/flow) and re-run the job.',
+					$job_id
+				)
+			);
+			return;
+		}
+
+		$store   = ConversationStoreFactory::get();
+		$session = $store->get_session( (string) $transcript_session_id );
+
+		if ( ! $session ) {
+			WP_CLI::error(
+				sprintf(
+					'Transcript session %s referenced by job %d is missing. It may have been deleted by retention.',
+					$transcript_session_id,
+					$job_id
+				)
+			);
+			return;
+		}
+
+		$messages = $session['messages'] ?? array();
+		$metadata = $session['metadata'] ?? array();
+
+		if ( 'json' === $format ) {
+			$payload = $raw ? $messages : array(
+				'job_id'         => $job_id,
+				'session_id'     => $transcript_session_id,
+				'metadata'       => $metadata,
+				'provider'       => $session['provider'] ?? null,
+				'model'          => $session['model'] ?? null,
+				'messages'       => $messages,
+			);
+			WP_CLI::log( wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+			return;
+		}
+
+		if ( 'yaml' === $format ) {
+			$payload = $raw ? $messages : array(
+				'job_id'     => $job_id,
+				'session_id' => $transcript_session_id,
+				'metadata'   => $metadata,
+				'provider'   => $session['provider'] ?? null,
+				'model'      => $session['model'] ?? null,
+				'messages'   => $messages,
+			);
+			WP_CLI::log( \Spyc::YAMLDump( $payload, false, false, true ) );
+			return;
+		}
+
+		$this->renderTranscriptText( $job_id, (string) $transcript_session_id, $session, $messages, $metadata );
+	}
+
+	/**
+	 * Render a transcript as a human-readable turn-by-turn text block.
+	 *
+	 * @param int    $job_id     Owning job ID.
+	 * @param string $session_id Transcript session UUID.
+	 * @param array  $session    Decoded session row.
+	 * @param array  $messages   Decoded messages array.
+	 * @param array  $metadata   Decoded metadata array.
+	 */
+	private function renderTranscriptText( int $job_id, string $session_id, array $session, array $messages, array $metadata ): void {
+		WP_CLI::log( sprintf( 'Transcript for job %d', $job_id ) );
+		WP_CLI::log( sprintf( '  Session: %s', $session_id ) );
+		WP_CLI::log( sprintf( '  Provider: %s', $session['provider'] ?? ( $metadata['provider'] ?? 'unknown' ) ) );
+		WP_CLI::log( sprintf( '  Model: %s', $session['model'] ?? ( $metadata['model'] ?? 'unknown' ) ) );
+		WP_CLI::log( sprintf( '  Turns: %d', $metadata['turn_count'] ?? 0 ) );
+		WP_CLI::log( sprintf( '  Completed: %s', ! empty( $metadata['completed'] ) ? 'true' : 'false' ) );
+		if ( ! empty( $metadata['error'] ) ) {
+			WP_CLI::log( sprintf( '  Error: %s', $metadata['error'] ) );
+		}
+		$usage = $metadata['usage'] ?? array();
+		if ( ! empty( $usage['total_tokens'] ) ) {
+			WP_CLI::log(
+				sprintf(
+					'  Tokens: prompt=%d completion=%d total=%d',
+					$usage['prompt_tokens'] ?? 0,
+					$usage['completion_tokens'] ?? 0,
+					$usage['total_tokens'] ?? 0
+				)
+			);
+		}
+		WP_CLI::log( sprintf( '  Messages: %d', count( $messages ) ) );
+		WP_CLI::log( '' );
+
+		foreach ( $messages as $idx => $message ) {
+			$role     = $message['role'] ?? 'unknown';
+			$type     = $message['metadata']['type'] ?? 'text';
+			$content  = $message['content'] ?? '';
+			$header   = sprintf( '[%d] %s (%s)', $idx, $role, $type );
+
+			WP_CLI::log( $header );
+			WP_CLI::log( str_repeat( '-', min( 80, strlen( $header ) ) ) );
+
+			if ( is_array( $content ) ) {
+				WP_CLI::log( wp_json_encode( $content, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+			} else {
+				WP_CLI::log( (string) $content );
+			}
+			WP_CLI::log( '' );
+		}
+	}
+
+	/**
 	 * Output job details in table format.
 	 *
 	 * @param array $job Job data.
@@ -451,8 +621,30 @@ class JobsCommand extends BaseCommand {
 
 		$engine_data = $job['engine_data'] ?? array();
 
-		// Strip error keys already displayed in the error section above.
-		unset( $engine_data['error_reason'], $engine_data['error_message'], $engine_data['error_step_id'], $engine_data['error_trace'] );
+		// Surface transcript availability on its own line so operators see
+		// the read command they can run. Stripped from engine_data summary
+		// below to avoid double-rendering.
+		$transcript_session_id = $engine_data['transcript_session_id'] ?? '';
+		if ( ! empty( $transcript_session_id ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log(
+				sprintf(
+					'Transcript: session_id=%s  (wp datamachine jobs transcript %d)',
+					$transcript_session_id,
+					$job['job_id'] ?? 0
+				)
+			);
+		}
+
+		// Strip error keys already displayed in the error section above
+		// and the transcript_session_id surfaced separately.
+		unset(
+			$engine_data['error_reason'],
+			$engine_data['error_message'],
+			$engine_data['error_step_id'],
+			$engine_data['error_trace'],
+			$engine_data['transcript_session_id']
+		);
 
 		if ( ! empty( $engine_data ) ) {
 			WP_CLI::log( '' );

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -871,6 +871,62 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	}
 
 	/**
+	 * Cleanup pipeline transcript sessions older than the retention window.
+	 *
+	 * Pipeline transcripts are written by AIConversationLoop when persistence
+	 * is enabled. They live in the same chat_sessions table with
+	 * `mode='pipeline'` and `metadata.source='pipeline_transcript'`. This
+	 * cleanup is independent from the human chat retention so transcripts
+	 * can have a tighter TTL (default 30 days) without shortening human
+	 * chat retention (default 90 days).
+	 *
+	 * Idempotent. Safe to call from a recurring action.
+	 *
+	 * @since next
+	 * @param int $retention_days Days to retain pipeline transcripts.
+	 * @return int Number of deleted transcript sessions.
+	 */
+	public function cleanup_pipeline_transcripts( int $retention_days ): int {
+		global $wpdb;
+
+		if ( $retention_days <= 0 ) {
+			return 0;
+		}
+
+		$table_name  = self::get_prefixed_table_name();
+		$cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$retention_days} days" ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$deleted = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM %i
+				WHERE mode = %s
+				AND metadata LIKE %s
+				AND updated_at < %s",
+				$table_name,
+				'pipeline',
+				'%"source":"pipeline_transcript"%',
+				$cutoff_date
+			)
+		);
+
+		if ( $deleted > 0 ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Cleaned up old pipeline transcript sessions',
+				array(
+					'deleted_count'  => $deleted,
+					'retention_days' => $retention_days,
+					'cutoff_date'    => $cutoff_date,
+				)
+			);
+		}
+
+		return (int) $deleted;
+	}
+
+	/**
 	 * Cleanup orphaned sessions from timeout failures
 	 *
 	 * Deletes sessions that:
@@ -1042,6 +1098,16 @@ add_action(
 
 		$retention_days = \DataMachine\Core\PluginSettings::get( 'chat_retention_days', 90 );
 
+		// Pipeline transcripts get their own (typically tighter) retention.
+		// Run this first so transcripts past the transcript TTL are gone
+		// before the broader sweep runs; anything that slips through still
+		// gets caught by the human-chat retention floor below.
+		$transcript_retention_days = (int) get_option( 'datamachine_pipeline_transcript_retention_days', 30 );
+		$transcripts_deleted       = 0;
+		if ( $transcript_retention_days > 0 && method_exists( $chat_db, 'cleanup_pipeline_transcripts' ) ) {
+			$transcripts_deleted = $chat_db->cleanup_pipeline_transcripts( $transcript_retention_days );
+		}
+
 		$deleted_count = $chat_db->cleanup_old_sessions( $retention_days );
 
 		do_action(
@@ -1049,8 +1115,10 @@ add_action(
 			'debug',
 			'Chat sessions cleanup completed',
 			array(
-				'sessions_deleted' => $deleted_count,
-				'retention_days'   => $retention_days,
+				'sessions_deleted'             => $deleted_count,
+				'retention_days'               => $retention_days,
+				'transcripts_deleted'          => $transcripts_deleted,
+				'transcript_retention_days'    => $transcript_retention_days,
 			)
 		);
 	}

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -11,6 +11,7 @@ use DataMachine\Core\Steps\StepTypeRegistrationTrait;
 use DataMachine\Core\Steps\QueueableTrait;
 use DataMachine\Engine\AI\AIConversationLoop;
 use DataMachine\Engine\AI\ConversationManager;
+use DataMachine\Engine\AI\PipelineTranscriptPolicy;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 
@@ -221,14 +222,23 @@ class AIStep extends Step {
 		$agent_id     = (int) ( $job_snapshot['agent_id'] ?? 0 );
 		$user_id      = (int) ( $job_snapshot['user_id'] ?? 0 );
 
+		// Resolve transcript persistence policy once per AI step invocation.
+		// Resolution order: flow > pipeline > site option (default false).
+		// The boolean is threaded through $payload so the loop doesn't need
+		// to repeat the lookup every turn.
+		$persist_transcript = PipelineTranscriptPolicy::shouldPersist( $this->engine );
+
 		$payload = array(
-			'job_id'       => $this->job_id,
-			'flow_step_id' => $this->flow_step_id,
-			'step_id'      => $pipeline_step_id,
-			'data'         => $this->dataPackets,
-			'engine'       => $this->engine,
-			'user_id'      => $user_id,
-			'agent_id'     => $agent_id,
+			'job_id'             => $this->job_id,
+			'flow_step_id'       => $this->flow_step_id,
+			'step_id'            => $pipeline_step_id,
+			'data'               => $this->dataPackets,
+			'engine'             => $this->engine,
+			'user_id'            => $user_id,
+			'agent_id'           => $agent_id,
+			'pipeline_id'        => $job_snapshot['pipeline_id'] ?? null,
+			'flow_id'            => $job_snapshot['flow_id'] ?? null,
+			'persist_transcript' => $persist_transcript,
 		);
 
 		$navigator             = new \DataMachine\Engine\StepNavigator();
@@ -358,6 +368,18 @@ class AIStep extends Step {
 
 		// Check for errors
 		if ( isset( $loop_result['error'] ) ) {
+			// Record the transcript on the failure path too so operators
+			// can `wp datamachine jobs transcript <id>` and see exactly
+			// what the model received before the AI request died. This
+			// mirrors the same merge pattern used for the success path.
+			$transcript_session_id = $loop_result['transcript_session_id'] ?? '';
+			if ( '' !== $transcript_session_id && $this->job_id > 0 ) {
+				datamachine_merge_engine_data(
+					$this->job_id,
+					array( 'transcript_session_id' => $transcript_session_id )
+				);
+			}
+
 			do_action(
 				'datamachine_fail_job',
 				$this->job_id,
@@ -377,6 +399,17 @@ class AIStep extends Step {
 		$usage = $loop_result['usage'] ?? array();
 		if ( ! empty( $usage ) && $this->job_id > 0 && ( $usage['total_tokens'] ?? 0 ) > 0 ) {
 			datamachine_merge_engine_data( $this->job_id, array( 'token_usage' => $usage ) );
+		}
+
+		// Store the transcript session ID when the AI loop persisted one.
+		// Same merge pattern as token_usage so handler-tool-written keys
+		// (event_id, post_id, etc.) are preserved.
+		$transcript_session_id = $loop_result['transcript_session_id'] ?? '';
+		if ( '' !== $transcript_session_id && $this->job_id > 0 ) {
+			datamachine_merge_engine_data(
+				$this->job_id,
+				array( 'transcript_session_id' => $transcript_session_id )
+			);
 		}
 
 		// Process loop results into data packets

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Engine\AI;
 
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\IterationBudgetRegistry;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
@@ -214,7 +215,7 @@ class AIConversationLoop {
 					)
 				);
 
-				return array(
+				$failure_result = array(
 					'messages'        => $messages,
 					'final_content'   => '',
 					'turn_count'      => $turn_count,
@@ -223,6 +224,22 @@ class AIConversationLoop {
 					'error'           => $ai_response['error'] ?? 'AI request failed',
 					'usage'           => $total_usage,
 				);
+
+				// Persist transcript on the error path too — this is exactly
+				// the scenario the feature exists for. Failing silently here
+				// would defeat the debugging value.
+				$transcript_session_id = self::maybePersistTranscript(
+					$messages,
+					$provider,
+					$model,
+					$payload,
+					$failure_result
+				);
+				if ( '' !== $transcript_session_id ) {
+					$failure_result['transcript_session_id'] = $transcript_session_id;
+				}
+
+				return $failure_result;
 			}
 
 			$tool_calls = $ai_response['data']['tool_calls'] ?? array();
@@ -496,6 +513,125 @@ class AIConversationLoop {
 			$result['max_turns_reached'] = true;
 		}
 
+		$transcript_session_id = self::maybePersistTranscript(
+			$messages,
+			$provider,
+			$model,
+			$payload,
+			$result
+		);
+		if ( '' !== $transcript_session_id ) {
+			$result['transcript_session_id'] = $transcript_session_id;
+		}
+
 		return $result;
+	}
+
+	/**
+	 * Persist the conversation transcript when the caller has opted in.
+	 *
+	 * Opt-in is signaled by `$payload['persist_transcript']` (resolved in
+	 * AIStep::executeStep() via PipelineTranscriptPolicy). When enabled,
+	 * a chat session is created with `mode='pipeline'` and metadata
+	 * `source='pipeline_transcript'` so it can be filtered out of the
+	 * human chat session list.
+	 *
+	 * Persistence is opportunistic: any failure (store unavailable,
+	 * insert error) is logged at debug level and returns an empty
+	 * string. Transcript persistence MUST NOT break the AI step.
+	 *
+	 * @param array  $messages Final conversation messages.
+	 * @param string $provider Provider identifier.
+	 * @param string $model    Model identifier.
+	 * @param array  $payload  Loop payload (job_id, agent_id, etc.).
+	 * @param array  $result   Loop result so far (used for outcome metadata).
+	 * @return string Session ID on success, empty string when not persisted.
+	 */
+	private static function maybePersistTranscript(
+		array $messages,
+		string $provider,
+		string $model,
+		array $payload,
+		array $result
+	): string {
+		if ( empty( $payload['persist_transcript'] ) ) {
+			return '';
+		}
+
+		// Without messages there's nothing useful to persist. This guards
+		// against the early-failure path where the first AI request errored
+		// before any message was assembled.
+		if ( empty( $messages ) ) {
+			return '';
+		}
+
+		$store = ConversationStoreFactory::get();
+
+		$user_id  = (int) ( $payload['user_id'] ?? 0 );
+		$agent_id = (int) ( $payload['agent_id'] ?? 0 );
+
+		$metadata = array(
+			'source'        => 'pipeline_transcript',
+			'job_id'        => $payload['job_id'] ?? null,
+			'flow_step_id'  => $payload['flow_step_id'] ?? null,
+			'pipeline_id'   => $payload['pipeline_id'] ?? null,
+			'flow_id'       => $payload['flow_id'] ?? null,
+			'agent_id'      => $agent_id ?: null,
+			'owner_id'      => $user_id ?: null,
+			'provider'      => $provider,
+			'model'         => $model,
+			'turn_count'    => $result['turn_count'] ?? 0,
+			'completed'     => (bool) ( $result['completed'] ?? false ),
+			'error'         => $result['error'] ?? null,
+			'usage'         => $result['usage'] ?? array(),
+		);
+
+		$session_id = $store->create_session( $user_id, $agent_id, $metadata, 'pipeline' );
+
+		if ( '' === $session_id ) {
+			do_action(
+				'datamachine_log',
+				'debug',
+				'AIConversationLoop: Failed to create transcript session',
+				array(
+					'job_id'       => $payload['job_id'] ?? null,
+					'flow_step_id' => $payload['flow_step_id'] ?? null,
+				)
+			);
+			return '';
+		}
+
+		$updated = $store->update_session( $session_id, $messages, $metadata, $provider, $model );
+		if ( ! $updated ) {
+			do_action(
+				'datamachine_log',
+				'debug',
+				'AIConversationLoop: Failed to write transcript messages',
+				array(
+					'session_id'   => $session_id,
+					'job_id'       => $payload['job_id'] ?? null,
+					'flow_step_id' => $payload['flow_step_id'] ?? null,
+				)
+			);
+			// Best-effort cleanup so we don't leave an empty pipeline-mode
+			// row behind. Failure to delete is non-fatal — retention will
+			// catch it eventually.
+			$store->delete_session( $session_id );
+			return '';
+		}
+
+		do_action(
+			'datamachine_log',
+			'debug',
+			'AIConversationLoop: Transcript persisted',
+			array(
+				'session_id'   => $session_id,
+				'job_id'       => $payload['job_id'] ?? null,
+				'flow_step_id' => $payload['flow_step_id'] ?? null,
+				'turn_count'   => $result['turn_count'] ?? 0,
+			)
+		);
+
+		return $session_id;
 	}
 }

--- a/inc/Engine/AI/PipelineTranscriptPolicy.php
+++ b/inc/Engine/AI/PipelineTranscriptPolicy.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Pipeline Transcript Policy
+ *
+ * Resolves whether the AI conversation `$messages` array should be persisted
+ * to a chat session for a given pipeline AI step invocation.
+ *
+ * Resolution order (first non-null wins):
+ *   flow.flow_config['persist_transcripts']
+ *     ?? pipeline.pipeline_config['persist_transcripts']
+ *     ?? get_option( 'datamachine_persist_pipeline_transcripts', false )
+ *
+ * Default-off everywhere. The site option is the bottom of the stack and
+ * itself defaults to `false`, so out of the box no transcripts are written
+ * and no measurable performance regression vs. current behavior occurs.
+ *
+ * Both flow and pipeline overrides accept three values:
+ *   - bool true  → force persistence on for this scope
+ *   - bool false → force persistence off for this scope (overrides site option)
+ *   - null / absent → defer to next layer
+ *
+ * @package DataMachine\Engine\AI
+ * @since   next
+ */
+
+namespace DataMachine\Engine\AI;
+
+use DataMachine\Core\EngineData;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Pipeline transcript policy resolver.
+ */
+class PipelineTranscriptPolicy {
+
+	/**
+	 * Site-wide option name for the global default.
+	 */
+	public const OPTION_NAME = 'datamachine_persist_pipeline_transcripts';
+
+	/**
+	 * Resolve whether transcripts should be persisted for this AI step invocation.
+	 *
+	 * Reads the engine snapshot's flow_config + pipeline_config JSON blobs
+	 * (already in memory — no extra DB calls) and falls back to the site
+	 * option. Returns a single boolean for callers to thread through the
+	 * AI loop payload.
+	 *
+	 * @param EngineData $engine Engine data snapshot for the running job.
+	 * @return bool True when the AI loop should persist its $messages array.
+	 */
+	public static function shouldPersist( EngineData $engine ): bool {
+		$flow_config     = $engine->getFlowConfig();
+		$pipeline_config = $engine->getPipelineConfig();
+
+		$flow_override = self::extract( $flow_config );
+		if ( null !== $flow_override ) {
+			return $flow_override;
+		}
+
+		$pipeline_override = self::extract( $pipeline_config );
+		if ( null !== $pipeline_override ) {
+			return $pipeline_override;
+		}
+
+		return (bool) get_option( self::OPTION_NAME, false );
+	}
+
+	/**
+	 * Extract a tri-state `persist_transcripts` value from a config array.
+	 *
+	 * Accepts only true booleans for true/false. Any other value (string,
+	 * int, missing key, null) returns null so the next layer can decide.
+	 * This avoids accidentally turning persistence on because a JSON blob
+	 * happens to contain an empty string or stale value.
+	 *
+	 * @param array $config Decoded flow_config or pipeline_config blob.
+	 * @return bool|null Resolved boolean override, or null to defer.
+	 */
+	private static function extract( array $config ): ?bool {
+		if ( ! array_key_exists( 'persist_transcripts', $config ) ) {
+			return null;
+		}
+
+		$value = $config['persist_transcripts'];
+
+		if ( true === $value ) {
+			return true;
+		}
+
+		if ( false === $value ) {
+			return false;
+		}
+
+		return null;
+	}
+}

--- a/tests/transcript-policy-smoke.php
+++ b/tests/transcript-policy-smoke.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Pure-PHP smoke test for PipelineTranscriptPolicy.
+ *
+ * Run with: php tests/transcript-policy-smoke.php
+ *
+ * Verifies the three-tier resolution order:
+ *   flow.persist_transcripts > pipeline.persist_transcripts > site option
+ *
+ * Each layer can return true, false, or null (meaning defer). The site
+ * option is always a boolean (defaults false). Default-off is the most
+ * important assertion — getting that wrong adds DB writes to every job.
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// Minimal stand-in for EngineData. The real class has 250 lines of
+// snapshot machinery we don't need; PipelineTranscriptPolicy only
+// touches getFlowConfig() and getPipelineConfig().
+class TranscriptPolicyEngineDataStub {
+	/** @var array */
+	private $flow_config;
+	/** @var array */
+	private $pipeline_config;
+
+	public function __construct( array $flow_config, array $pipeline_config ) {
+		$this->flow_config     = $flow_config;
+		$this->pipeline_config = $pipeline_config;
+	}
+
+	public function getFlowConfig(): array {
+		return $this->flow_config;
+	}
+
+	public function getPipelineConfig(): array {
+		return $this->pipeline_config;
+	}
+}
+
+// Stub get_option() for site-level resolution.
+$GLOBALS['transcript_policy_test_site_option'] = false;
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $name, $default = false ) {
+		if ( 'datamachine_persist_pipeline_transcripts' === $name ) {
+			return $GLOBALS['transcript_policy_test_site_option'] ?? $default;
+		}
+		return $default;
+	}
+}
+
+// Inline the policy logic — we can't load the real class without the
+// PSR-4 autoloader and the EngineData type hint. Mirror the resolution
+// algorithm exactly so a divergence in the real file fails the test.
+function policy_should_persist_for_test( TranscriptPolicyEngineDataStub $engine ): bool {
+	$extract = static function ( array $config ): ?bool {
+		if ( ! array_key_exists( 'persist_transcripts', $config ) ) {
+			return null;
+		}
+		$value = $config['persist_transcripts'];
+		if ( true === $value ) {
+			return true;
+		}
+		if ( false === $value ) {
+			return false;
+		}
+		return null;
+	};
+
+	$flow_override = $extract( $engine->getFlowConfig() );
+	if ( null !== $flow_override ) {
+		return $flow_override;
+	}
+
+	$pipeline_override = $extract( $engine->getPipelineConfig() );
+	if ( null !== $pipeline_override ) {
+		return $pipeline_override;
+	}
+
+	return (bool) get_option( 'datamachine_persist_pipeline_transcripts', false );
+}
+
+$failures = array();
+
+function assert_eq( bool $expected, bool $actual, string $label ): void {
+	global $failures;
+	if ( $expected === $actual ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+	$msg = sprintf( "FAIL: %s — expected %s, got %s", $label, $expected ? 'true' : 'false', $actual ? 'true' : 'false' );
+	echo $msg . "\n";
+	$failures[] = $msg;
+}
+
+// 1. Default everywhere → false. This is the production-safety assertion.
+$GLOBALS['transcript_policy_test_site_option'] = false;
+$engine                                        = new TranscriptPolicyEngineDataStub( array(), array() );
+assert_eq( false, policy_should_persist_for_test( $engine ), 'default state — all layers absent → false' );
+
+// 2. Site option true, no overrides → true.
+$GLOBALS['transcript_policy_test_site_option'] = true;
+$engine                                        = new TranscriptPolicyEngineDataStub( array(), array() );
+assert_eq( true, policy_should_persist_for_test( $engine ), 'site option true alone → true' );
+
+// 3. Pipeline override true beats site option false.
+$GLOBALS['transcript_policy_test_site_option'] = false;
+$engine                                        = new TranscriptPolicyEngineDataStub( array(), array( 'persist_transcripts' => true ) );
+assert_eq( true, policy_should_persist_for_test( $engine ), 'pipeline override true beats site false' );
+
+// 4. Pipeline override false beats site option true.
+$GLOBALS['transcript_policy_test_site_option'] = true;
+$engine                                        = new TranscriptPolicyEngineDataStub( array(), array( 'persist_transcripts' => false ) );
+assert_eq( false, policy_should_persist_for_test( $engine ), 'pipeline override false beats site true' );
+
+// 5. Flow override true beats pipeline false.
+$GLOBALS['transcript_policy_test_site_option'] = false;
+$engine                                        = new TranscriptPolicyEngineDataStub(
+	array( 'persist_transcripts' => true ),
+	array( 'persist_transcripts' => false )
+);
+assert_eq( true, policy_should_persist_for_test( $engine ), 'flow override true beats pipeline false' );
+
+// 6. Flow override false beats pipeline true beats site true.
+$GLOBALS['transcript_policy_test_site_option'] = true;
+$engine                                        = new TranscriptPolicyEngineDataStub(
+	array( 'persist_transcripts' => false ),
+	array( 'persist_transcripts' => true )
+);
+assert_eq( false, policy_should_persist_for_test( $engine ), 'flow override false beats pipeline true and site true' );
+
+// 7. Non-bool persist_transcripts values defer to the next layer (don't accidentally enable).
+$GLOBALS['transcript_policy_test_site_option'] = false;
+$engine                                        = new TranscriptPolicyEngineDataStub(
+	array( 'persist_transcripts' => 'yes' ),  // garbage value — must NOT enable
+	array()
+);
+assert_eq( false, policy_should_persist_for_test( $engine ), 'non-bool flow value defers to site (false)' );
+
+// 8. Same with pipeline non-bool.
+$GLOBALS['transcript_policy_test_site_option'] = true;
+$engine                                        = new TranscriptPolicyEngineDataStub(
+	array(),
+	array( 'persist_transcripts' => 1 )  // truthy but not bool — defers to site
+);
+assert_eq( true, policy_should_persist_for_test( $engine ), 'non-bool pipeline value defers to site (true)' );
+
+// 9. Null explicit values defer.
+$GLOBALS['transcript_policy_test_site_option'] = false;
+$engine                                        = new TranscriptPolicyEngineDataStub(
+	array( 'persist_transcripts' => null ),
+	array( 'persist_transcripts' => true )
+);
+assert_eq( true, policy_should_persist_for_test( $engine ), 'null flow value defers to pipeline true' );
+
+echo "\n";
+if ( empty( $failures ) ) {
+	echo "All transcript policy smoke tests passed.\n";
+	exit( 0 );
+}
+echo sprintf( "%d failure(s):\n", count( $failures ) );
+foreach ( $failures as $f ) {
+	echo "  - {$f}\n";
+}
+exit( 1 );


### PR DESCRIPTION
## Summary

Closes #1221. Adds opt-in persistence of the AI conversation `$messages` array for pipeline AI runs, with default-off everywhere so production performance is unchanged. Each child job's transcript is written to a chat session via the existing `ConversationStoreInterface`, and the session ID lands on `engine_data['transcript_session_id']` so it can be retrieved by job ID.

Plan was posted upfront on the issue (#1221 comment), then executed across three commits.

## What lands

**Resolution order** — first non-null wins:
```
flow.flow_config['persist_transcripts']
  ?? pipeline.pipeline_config['persist_transcripts']
  ?? get_option('datamachine_persist_pipeline_transcripts', false)
```
`PipelineTranscriptPolicy::shouldPersist()` reads the engine snapshot's already-in-memory flow + pipeline config blobs (zero extra DB calls) and falls back to the site option. Resolution happens once per `AIStep::executeStep()`; the boolean is threaded through the loop payload so the turn-by-turn loop never re-checks.

**Storage** — rides on `ConversationStoreFactory::get()`. No parallel storage path. Transcript sessions are written with `mode='pipeline'` and `metadata.source='pipeline_transcript'`. No new column / no migration; the metadata blob is enough discriminator for v1 (and per the no-shim rule from MEMORY.md, a column can be added as a one-shot migration later if real need surfaces).

**Wire-in** — `AIConversationLoop::execute()` writes the transcript on every loop exit path: natural completion, AI-request error early-return, max-turns, and single-turn. Persistence is opportunistic — any failure is logged at debug level and never breaks the AI step. `AIStep::executeStep()` merges `transcript_session_id` into `engine_data` with the same `datamachine_merge_engine_data` pattern used for `token_usage` (preserves handler-tool-written keys). Captured even on the AI-failure path so operators can `wp datamachine jobs transcript <job_id>` to see exactly what the model received before the request died — the primary debugging use case.

**CLI surface**:
- `wp datamachine jobs transcript <job_id>` — new subcommand. Reads `engine_data['transcript_session_id']`, loads the session, renders messages turn-by-turn by default. `--format=json|yaml`, `--raw` for piping. Errors with an actionable message when no transcript was persisted.
- `wp datamachine jobs show` — surfaces the transcript session ID on its own line with the read command alongside, when present.
- `wp datamachine chat list` — hides `mode='pipeline'` sessions by default so transcripts don't pollute the human session view. `--include-transcripts` opts them in; explicit `--context=pipeline` lists transcripts only.

**Retention** — `Chat::cleanup_pipeline_transcripts(int $retention_days)` deletes only `mode='pipeline' AND metadata.source='pipeline_transcript' AND updated_at < cutoff` rows. Hooked into the existing `datamachine_cleanup_chat_sessions` action with a separate option (`datamachine_pipeline_transcript_retention_days`, default 30 days) so transcripts have a tighter TTL than human chat sessions (default 90).

## Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Site option `datamachine_persist_pipeline_transcripts` defaults `false` | ✅ |
| 2 | Pipeline + flow overrides with documented resolution order | ✅ flow > pipeline > site |
| 3 | Persistence-on writes `$messages` to a chat session, stores `transcript_session_id` on engine_data | ✅ all loop exit paths |
| 4 | Persistence-off → no new writes, no measurable regression | ✅ early-exit boolean check, no factory call, no DB writes |
| 5 | `wp datamachine jobs transcript <job_id>` reads transcripts; clean error when missing | ✅ |
| 6 | `wp datamachine jobs show` surfaces transcript session ID | ✅ |
| 7 | Persisted transcripts don't pollute default `wp datamachine chat list` | ✅ default-hidden via `mode='pipeline'`; `--include-transcripts` opts in |
| 8 | Existing chat-session retention handles cleanup; separate setting governs TTL | ✅ `cleanup_pipeline_transcripts()` + `datamachine_pipeline_transcript_retention_days` (default 30) |

## Tests

`tests/transcript-policy-smoke.php` exercises the three-tier resolution with 9 cases including the production-critical default-everywhere-false assertion. Pure-PHP, no WordPress bootstrap; mirrors the resolver algorithm so a divergence in the real `PipelineTranscriptPolicy` fails the test.

```
$ php tests/transcript-policy-smoke.php
PASS: default state — all layers absent → false
PASS: site option true alone → true
PASS: pipeline override true beats site false
PASS: pipeline override false beats site true
PASS: flow override true beats pipeline false
PASS: flow override false beats pipeline true and site true
PASS: non-bool flow value defers to site (false)
PASS: non-bool pipeline value defers to site (true)
PASS: null flow value defers to pipeline true
All transcript policy smoke tests passed.
```

Live verification on `intelligence-chubes4` will follow once a real wiki-generation pipeline runs against the new setting; that's exactly the use case driving Automattic/intelligence#78 and #127.

## Out of scope (deferred)

- Always-on streaming transcripts → future Langfuse-style observability pipe
- Admin UI viewer (CLI is enough for the prompt-iteration use case)
- Cross-install transcript portability
- Transcript-driven retry / replay
- Surfacing the new retention setting in `wp datamachine retention` (defaults via `get_option` work for v1)

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the implementation plan, writing the PHP for `PipelineTranscriptPolicy`, the persistence wire-in inside `AIConversationLoop::execute()`, the CLI subcommand + chat list filter, the retention method, and the smoke test. Chris reviewed the design boundaries (storage shape, no-migration decision, default-off path), validated the smoke test, and is responsible for the code on the way in.