### PR TITLE
fix: align retention windows to prevent orphaned processed_items (#1222)

### DIFF
--- a/inc/Cli/Commands/ProcessedItemsCommand.php
+++ b/inc/Cli/Commands/ProcessedItemsCommand.php
@@ -381,6 +381,105 @@ class ProcessedItemsCommand extends BaseCommand {
 	}
 
 	/**
+	 * Remove orphaned processed items whose jobs no longer exist.
+	 *
+	 * When completed-job retention purges old jobs, their processed_items
+	 * records can persist longer (different retention window). These orphans
+	 * block re-ingestion because dedup says "already processed" but the
+	 * evidence (the job) is gone. This command cleans them up.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--flow=<flow_id>]
+	 * : Only clean orphans for this flow ID.
+	 *
+	 * [--dry-run]
+	 * : Show what would be deleted without actually deleting.
+	 *
+	 * [--yes]
+	 * : Skip confirmation prompt.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine processed-items cleanup-orphans --dry-run
+	 *     wp datamachine processed-items cleanup-orphans --yes
+	 *     wp datamachine processed-items cleanup-orphans --flow=9 --yes
+	 *
+	 * @subcommand cleanup-orphans
+	 */
+	public function cleanup_orphans( array $args, array $assoc_args ): void {
+		global $wpdb;
+
+		$flow_id      = $assoc_args['flow'] ?? null;
+		$dry_run      = isset( $assoc_args['dry-run'] );
+		$skip_confirm = isset( $assoc_args['yes'] );
+
+		$db    = new ProcessedItems();
+		$table = $db->get_table_name();
+		$jobs  = $wpdb->prefix . 'datamachine_jobs';
+
+		$where_extra = '';
+		$values      = array( $table, $jobs );
+
+		if ( $flow_id ) {
+			$where_extra = ' AND pi.flow_step_id LIKE %s';
+			$values[]    = '%_' . (int) $flow_id;
+		}
+
+		// Count orphans.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM %i pi LEFT JOIN %i j ON pi.job_id = j.job_id WHERE j.job_id IS NULL{$where_extra}",
+				...$values
+			)
+		);
+
+		if ( 0 === $count ) {
+			WP_CLI::success( 'No orphaned processed items found.' );
+			return;
+		}
+
+		$scope = $flow_id ? sprintf( 'flow %d', (int) $flow_id ) : 'all flows';
+
+		if ( $dry_run ) {
+			WP_CLI::log( sprintf( 'DRY RUN: Would delete %s orphaned processed items for %s.', number_format( $count ), $scope ) );
+			return;
+		}
+
+		if ( ! $skip_confirm ) {
+			WP_CLI::confirm(
+				sprintf( 'Delete %s orphaned processed items for %s? This unblocks re-ingestion of those items.', number_format( $count ), $scope )
+			);
+		}
+
+		// Delete orphans.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$deleted = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE pi FROM %i pi LEFT JOIN %i j ON pi.job_id = j.job_id WHERE j.job_id IS NULL{$where_extra}",
+				...$values
+			)
+		);
+
+		if ( false === $deleted ) {
+			WP_CLI::error( 'Database error during deletion: ' . $wpdb->last_error );
+			return;
+		}
+
+		WP_CLI::success( sprintf( 'Deleted %s orphaned processed items for %s.', number_format( $deleted ), $scope ) );
+	}
+
+	/**
 	 * Check if a specific item has been processed.
 	 *
 	 * ## OPTIONS

--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -133,7 +133,7 @@ class RetentionCommand extends BaseCommand {
 		$results = array();
 
 		// 1. Completed jobs.
-		$completed_days = (int) apply_filters( 'datamachine_completed_jobs_max_age_days', 14 );
+		$completed_days = (int) apply_filters( 'datamachine_completed_jobs_max_age_days', 30 );
 		$db_jobs        = new \DataMachine\Core\Database\Jobs\Jobs();
 		$count          = $db_jobs->count_old_jobs( 'completed', $completed_days );
 		$results[]      = array(
@@ -228,7 +228,7 @@ class RetentionCommand extends BaseCommand {
 	private function get_retention_policies(): array {
 		return array(
 			'Completed jobs'  => array(
-				'retention' => apply_filters( 'datamachine_completed_jobs_max_age_days', 14 ) . ' days',
+				'retention' => apply_filters( 'datamachine_completed_jobs_max_age_days', 30 ) . ' days',
 				'filter'    => 'datamachine_completed_jobs_max_age_days',
 			),
 			'Failed jobs'     => array(

--- a/inc/Core/ActionScheduler/CompletedJobsCleanup.php
+++ b/inc/Core/ActionScheduler/CompletedJobsCleanup.php
@@ -31,12 +31,12 @@ add_action(
 		 *
 		 * @since 0.40.0
 		 *
-		 * @param int $max_age_days Maximum age in days. Default 14.
+		 * @param int $max_age_days Maximum age in days. Default 30.
 		 */
-		$max_age_days = (int) apply_filters( 'datamachine_completed_jobs_max_age_days', 14 );
+		$max_age_days = (int) apply_filters( 'datamachine_completed_jobs_max_age_days', 30 );
 
 		if ( $max_age_days < 1 ) {
-			$max_age_days = 14;
+			$max_age_days = 30;
 		}
 
 		$deleted = $db_jobs->delete_old_jobs( 'completed', $max_age_days );

--- a/inc/Core/Database/Jobs/JobsOperations.php
+++ b/inc/Core/Database/Jobs/JobsOperations.php
@@ -479,6 +479,7 @@ class JobsOperations extends BaseRepository {
 		'completed' => array(
 			'completed',
 			'completed_no_items',
+			'agent_skipped',
 		),
 		'failed'    => array(
 			'failed',


### PR DESCRIPTION
## Summary

Fixes the dominant cause of the 36% silent data loss on event ingestion pipelines ([#1222](https://github.com/Extra-Chill/data-machine/issues/1222)).

**Root cause:** Completed jobs were purged after 14 days but `processed_items` records persisted for 30 days. During the 16-day gap, dedup said "already processed, skip" for items whose job evidence was gone — permanently blocking re-ingestion.

**Evidence from production (events.extrachill.com):**
- Charleston Pour House: 18 of 50 API events genuinely missing (36% drop rate)
- 112 orphaned `processed_items` records for that single venue
- ~17,000 orphaned records network-wide across all flows
- Orphan rates of 13-49% across top 20 flow steps by volume

## Changes

1. **Align retention defaults** — Completed jobs retention raised from 14 → 30 days (matches `processed_items` window). Records can no longer be orphaned by the retention asymmetry.

2. **Include `agent_skipped` in cleanup** — Added to `STATUS_VARIANTS['completed']` so AI-rejected jobs get cleaned up instead of persisting forever. Previously `agent_skipped` jobs were missed by both the completed and failed retention sweeps.

3. **`cleanup-orphans` CLI command** — New `wp datamachine processed-items cleanup-orphans` subcommand for recovering from existing orphaned records. Supports `--flow=<id>`, `--dry-run`, and `--yes` flags.

## Recovery

After deploying, run:
```
wp datamachine processed-items cleanup-orphans --yes --url=events.extrachill.com
```
This deletes all orphaned `processed_items` whose jobs no longer exist, unblocking re-ingestion on the next scheduled flow run.

## Related

- Closes #1222 (processed_items lifecycle bug — architectural)
- Related: Extra-Chill/data-machine-events#219 (date-only hash — separate fix)