### PR TITLE
docs: align user docs with current code structure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,11 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 - **Database Schema**: Tables that persist pipelines, flows, jobs, and processed items.
 - **Changelog**: Historical summary of notable releases and architectural changes.
 
+### Architecture Deep Dives
+- **Pipeline Execution Axes**: Queue, fan-out, and per-step iteration semantics ([architecture/pipeline-execution-axes.md](architecture/pipeline-execution-axes.md)).
+- **Policy Resolvers**: Why `ToolPolicyResolver`, `MemoryPolicyResolver`, `ActionPolicyResolver`, and `PipelineTranscriptPolicy` stay as four single-purpose classes ([architecture/policy-resolvers.md](architecture/policy-resolvers.md)).
+- **Iteration Budget**: Shared bounded-iteration primitive backing `conversation_turns` and `chain_depth` budgets ([architecture/iteration-budget.md](architecture/iteration-budget.md)).
+
 ### Engine & Services
 - **Universal Engine**: Shared AI infrastructure for pipeline and chat agents.
 - **AI Conversation Loop**: Turn-based conversation execution with directive orchestration.
@@ -57,6 +62,7 @@ Complete user documentation for Data Machine, the AI-first WordPress plugin that
 docs/
 ├── overview.md                        # System overview, data flow, and key concepts
 ├── architecture.md                    # Execution engine, architecture principles, and shared components
+├── architecture/                      # Architecture deep dives (axes, policies, primitives)
 ├── CHANGELOG.md                       # Semantic changelog for releases
 ├── core-system/                       # Engine, services, and core infrastructure pieces
 │   ├── abilities-api.md               # WordPress 6.9 Abilities API for flow queries, logging, and post filtering

--- a/docs/ai-tools/execute-workflow.md
+++ b/docs/ai-tools/execute-workflow.md
@@ -8,18 +8,17 @@ The ExecuteWorkflow tool enables AI agents to execute complete multi-step workfl
 
 ## Implementation
 
-**Location**: `/inc/Api/Chat/Tools/ExecuteWorkflowTool.php`
+**Tool wrapper**: `/inc/Api/Chat/Tools/ExecuteWorkflowTool.php` — registers the `execute_workflow` chat tool and binds it to the `datamachine/execute-workflow` ability via `BaseTool::registerTool()`.
 
-**Supporting Utilities**: `/inc/Api/Chat/Tools/HandlerDocumentation.php` - Shared utility for dynamic handler documentation generation from registered handlers
+**Backing ability**: `/inc/Abilities/Job/ExecuteWorkflowAbility.php` — owns the actual execution logic for ephemeral workflows.
 
-**Architecture**: Streamlined single-file implementation that delegates execution to the internal REST API Execute endpoint. Uses shared handler documentation utilities for dynamic description generation.
+**Architecture**: Ability-backed pattern. The chat tool is a thin handler that validates `steps`, looks up the ability via `wp_get_ability( 'datamachine/execute-workflow' )`, and forwards the workflow to it. Step type slugs are resolved at runtime from the `datamachine/get-step-types` ability so the description always reflects registered step types.
 
 **Key Responsibilities**:
 - Tool registration and definition
-- Request handling and parameter validation
-- REST API delegation to `/datamachine/v1/execute` endpoint
+- Parameter validation (`steps` required, `dry_run` optional)
+- Ability delegation via `wp_get_ability()`
 - Error handling and response formatting
-- Dynamic documentation generation from registered handlers
 
 ## Step Configuration
 
@@ -205,17 +204,19 @@ The ExecuteWorkflow tool provides comprehensive error handling:
 }
 ```
 
-## REST API Integration
+## Ability Integration
 
-The tool integrates with the internal Execute REST endpoint:
+The tool delegates to the `datamachine/execute-workflow` ability:
 
 ```php
-$request = new \WP_REST_Request('POST', '/datamachine/v1/execute');
-$request->set_body_params([
-    'steps' => $workflow_steps
-]);
-$response = rest_do_request($request);
+$ability = wp_get_ability( 'datamachine/execute-workflow' );
+$result  = $ability->execute( array(
+    'workflow' => array( 'steps' => $workflow_steps ),
+    'dry_run'  => $dry_run, // optional
+) );
 ```
+
+The same ability backs the `POST /datamachine/v1/execute` REST endpoint, so the tool path and the REST path produce identical results. See [Execute endpoint](../api/endpoints/execute.md) and [Abilities API](../core-system/abilities-api.md).
 
 ## Handler Discovery
 

--- a/docs/api/endpoints/files.md
+++ b/docs/api/endpoints/files.md
@@ -1,6 +1,6 @@
 # Files Endpoint
 
-**Implementation**: `inc/Api/Files.php`, `inc/Api/AgentFiles.php`
+**Implementation**: `inc/Api/FlowFiles.php`, `inc/Api/AgentFiles.php`
 
 **Base URL**: `/wp-json/datamachine/v1/files`
 
@@ -8,7 +8,7 @@
 
 The Files endpoint handles two distinct scopes:
 
-1. **Flow files** — File uploads for pipeline processing with flow-isolated storage, security validation, and automatic URL generation (`inc/Api/Files.php`)
+1. **Flow files** — File uploads for pipeline processing with flow-isolated storage, security validation, and automatic URL generation (`inc/Api/FlowFiles.php`)
 2. **Agent files** — Agent memory file management with 3-layer directory resolution for SOUL.md, MEMORY.md, USER.md, and daily memory journals (`inc/Api/AgentFiles.php`)
 
 ## Authentication
@@ -561,5 +561,5 @@ curl -X POST https://example.com/wp-json/datamachine/v1/files \
 ---
 
 **Base URL**: `/wp-json/datamachine/v1/files`
-**Implementation**: `inc/Api/Files.php` (flow files), `inc/Api/AgentFiles.php` (agent files)
+**Implementation**: `inc/Api/FlowFiles.php` (flow files), `inc/Api/AgentFiles.php` (agent files)
 **Max File Size**: WordPress `wp_max_upload_size()` setting

--- a/docs/architecture/iteration-budget.md
+++ b/docs/architecture/iteration-budget.md
@@ -1,0 +1,149 @@
+# Iteration Budget
+
+Generic primitive for bounded iteration with a configurable ceiling. Counts a named dimension (conversation turns, A2A chain depth, retry attempts) and exposes a uniform API for checking exceedance, formatting warnings, and surfacing response flags.
+
+**Source**: `inc/Engine/AI/IterationBudget.php`, `inc/Engine/AI/IterationBudgetRegistry.php`
+**Since**: v0.71.0
+
+## Why a primitive
+
+Before this primitive, every bounded loop in the codebase invented its own counter and its own "did we hit the limit" check — turn limits in the conversation loop, retry caps in async tasks, chain-depth limits in cross-site A2A. The result was inconsistent thresholds, copy-pasted clamping logic, and four different ways to surface "you ran out of budget" to the AI.
+
+`IterationBudget` is one value object covering all of them. Site config registers a named budget with a default, a site-setting override key, and clamp bounds; runtime code instantiates the budget for the current run and uses the same five methods on every consumer.
+
+## Two-stage lifecycle
+
+Budgets are **registered at boot** and **instantiated per run**.
+
+### Registration (boot time)
+
+Static, side-effect free, idempotent. Lives in `inc/bootstrap.php`:
+
+```php
+IterationBudgetRegistry::register( 'conversation_turns', array(
+    'default' => PluginSettings::DEFAULT_MAX_TURNS,
+    'min'     => 1,
+    'max'     => 50,
+    'setting' => 'max_turns',
+) );
+
+IterationBudgetRegistry::register( 'chain_depth', array(
+    'default' => 3,
+    'min'     => 1,
+    'max'     => 10,
+    'setting' => 'max_chain_depth',
+) );
+```
+
+Each registration declares:
+
+- `default` — Built-in fallback ceiling.
+- `min`, `max` — Hard clamp bounds. Resolved ceiling is always inside `[min, max]`.
+- `setting` — `PluginSettings` key that, when set, overrides `default`.
+
+Registrations are static. Calling `register()` twice with the same name overwrites — useful in tests, harmless in production.
+
+### Instantiation (per run)
+
+Each loop creates its own counter instance:
+
+```php
+$budget = IterationBudgetRegistry::create( 'conversation_turns', $startingCount = 0 );
+
+while ( ! $budget->exceeded() ) {
+    $budget->increment();
+    // ... do work ...
+}
+```
+
+`create()` reads the registered config, applies the ceiling-resolution chain, and returns a fresh `IterationBudget` value object.
+
+## Ceiling resolution
+
+Order, in `IterationBudgetRegistry::create()`:
+
+1. `$ceiling_override` argument — caller-supplied. Always wins. Used in tests and in execution paths that already received an override from a CallerContext header.
+2. `PluginSettings::get( config['setting'] )` — site-setting override.
+3. `config['default']` — registered default.
+
+Then clamped to `[config['min'], config['max']]`. The clamp is non-negotiable — even a misconfigured site setting can't push the ceiling out of safe bounds.
+
+## API surface
+
+`IterationBudget` exposes:
+
+| Method | Purpose |
+|--------|---------|
+| `increment()` | Bump the counter by one. Call at the top of each iteration. |
+| `current(): int` | Current counter value. |
+| `ceiling(): int` | Resolved ceiling for this run. |
+| `remaining(): int` | `ceiling - current`, never negative. |
+| `exceeded(): bool` | `current >= ceiling`. The loop's exit condition. |
+| `name(): string` | Budget name (e.g. `conversation_turns`). |
+| `toResponseFlag(): string` | Returns `"max_{name}_reached"` — the canonical flag for telling the AI / API consumer that this budget tripped. |
+
+`exceeded()` and `toResponseFlag()` are the integration points: every consumer surfaces budget exhaustion the same way.
+
+## Built-in budgets
+
+### conversation_turns
+
+Bounds how many turns a single AI conversation can run before the loop bails out.
+
+- **Default**: `PluginSettings::DEFAULT_MAX_TURNS`
+- **Site-setting key**: `max_turns`
+- **Clamp**: `[1, 50]`
+- **Consumer**: `AIConversationLoop`
+
+When exceeded, the loop returns with the response flag `max_conversation_turns_reached`, allowing the caller to detect "stopped because of turn limit" vs "stopped because the AI is done".
+
+### chain_depth
+
+Bounds how many cross-site agent hops a single A2A chain can contain before being refused. Prevents runaway recursion when agents on different sites can call each other's `/chat` endpoints.
+
+- **Default**: `3`
+- **Site-setting key**: `max_chain_depth`
+- **Clamp**: `[1, 10]`
+- **Consumer**: A2A middleware via `CallerContext`
+
+When exceeded, the request is refused with HTTP 429 and the error code `datamachine_chain_depth_exceeded`. The chain-depth header (`X-Datamachine-Chain-Depth`) is incremented by the receiving middleware before the budget check, so the budget reflects the count *after* this hop would land.
+
+## Adding a new budget
+
+1. Register at boot in `inc/bootstrap.php` (or in your extension's bootstrap):
+
+   ```php
+   IterationBudgetRegistry::register( 'my_budget', array(
+       'default' => 5,
+       'min'     => 1,
+       'max'     => 20,
+       'setting' => 'my_budget_max',
+   ) );
+   ```
+
+2. Instantiate per run wherever the loop lives:
+
+   ```php
+   $budget = IterationBudgetRegistry::create( 'my_budget' );
+   while ( $work_remaining && ! $budget->exceeded() ) {
+       $budget->increment();
+       // ...
+   }
+   if ( $budget->exceeded() ) {
+       $response['flags'][] = $budget->toResponseFlag();
+   }
+   ```
+
+3. Surface the response flag — `max_my_budget_reached` — wherever your loop returns control to its caller. Consumers (CLI, REST, agents) already know how to interpret `max_*_reached` flags because every bounded loop emits them the same way.
+
+## Why this isn't a Trait or base class
+
+Budgets don't share inheritance — they share *shape*. Different consumers count different things and integrate at different layers (an HTTP middleware, an AI loop, a retry helper). A trait or abstract class would force them to agree on lifecycle methods they don't actually share.
+
+`IterationBudget` is a single value-object class with a registry. Every consumer constructs its own, calls the same five methods, and emits the same response-flag convention. That is the contract. Inheritance would add nothing.
+
+## Related
+
+- [Policy Resolvers](policy-resolvers.md) — Same "single-purpose primitive over abstraction" principle applied to per-call decisioning.
+- [Pipeline Execution Axes](pipeline-execution-axes.md) — How `conversation_turns` and the pipeline's queue/fan-out axes compose.
+- `PluginSettings::DEFAULT_MAX_TURNS` — Default value source for `conversation_turns`.

--- a/docs/architecture/policy-resolvers.md
+++ b/docs/architecture/policy-resolvers.md
@@ -212,7 +212,7 @@ If two resolvers later turn out to share *both* the same return shape *and* the 
 inc/Engine/AI/Tools/ToolPolicyResolver.php
 inc/Engine/AI/Memory/MemoryPolicyResolver.php
 inc/Engine/AI/Actions/ActionPolicyResolver.php
-inc/Engine/AI/Transcripts/PipelineTranscriptPolicy.php
+inc/Engine/AI/PipelineTranscriptPolicy.php
 ```
 
 Each is a single file, single class, single responsibility. Class docblocks carry the precedence ladder. Class methods carry the per-step rationale. There is no shared parent, no shared interface, and no shared trait — only a shared shape that's documented here.

--- a/docs/core-system/ai-directives.md
+++ b/docs/core-system/ai-directives.md
@@ -1,6 +1,6 @@
 # AI Directives System
 
-Data Machine uses a hierarchical directive system to provide contextual information to AI agents during conversation and workflow execution. Directives are injected into AI requests in priority order, ensuring consistent behavior and context across all interactions.
+Data Machine uses a hierarchical directive system to inject contextual information into AI requests. Directives self-register via the `datamachine_directives` filter, are sorted by priority, filtered by mode, validated, and rendered into system messages before the conversation messages.
 
 ## Directive Architecture
 
@@ -15,7 +15,7 @@ public static function get_outputs(
 ): array;
 ```
 
-Each directive self-registers via the `datamachine_directives` WordPress filter, appending an array with `class`, `priority`, and `contexts` keys.
+Each directive self-registers via the `datamachine_directives` filter, appending an array with `class`, `priority`, and `modes` keys.
 
 ### Output Types
 
@@ -23,148 +23,97 @@ Directive outputs are validated by `DirectiveOutputValidator`:
 
 - **`system_text`** — requires `content` (string). Rendered as `{role: 'system', content: ...}`.
 - **`system_json`** — requires `label` (string) and `data` (array). Rendered as `{role: 'system', content: "LABEL:\n\n{json}"}`.
-- **`system_file`** — requires `file_path` and `mime_type`. Rendered as file attachment in system message.
+- **`system_file`** — requires `file_path` and `mime_type`. Rendered as a file attachment in the system message.
+
+### Modes
+
+Each registered directive declares which agent **modes** it applies to via the `modes` array. The current built-in modes are `chat`, `pipeline`, and `system`. The literal string `all` matches every mode.
+
+> Historical note: prior to v0.71.0 this field was named `contexts`. The internal terminology was renamed during the AgentMode refactor (#1130). RequestBuilder reads `$directive['modes']`; older `'contexts' =>` registrations are silently treated as `all` because they don't match the canonical key.
 
 ### Priority System
 
-Directives are applied in ascending priority order (lowest number = highest priority):
+Directives are applied in ascending priority order (lowest number = highest priority).
 
-| Priority | Directive | Contexts | Purpose |
-|----------|-----------|----------|---------|
-| **10** | `PipelineCoreDirective` | pipeline | Pipeline agent identity and operational principles |
-| **15** | `ChatAgentDirective` | chat | Chat agent identity and behavioral instructions |
-| **20** | `SystemAgentDirective` | system | System agent identity and capabilities |
-| **20** | `CoreMemoryFilesDirective` | **all** | SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md, custom files |
-| **35** | `AgentDailyMemoryDirective` | chat, pipeline | Recent daily archives for agents that opt in via `agent_config.daily_memory` |
-| **40** | `PipelineMemoryFilesDirective` | pipeline | Per-pipeline selectable memory files |
-| **45** | `ChatPipelinesDirective` | chat | Pipeline/flow/handler inventory for discovery |
-| **45** | `FlowMemoryFilesDirective` | pipeline | Per-flow selectable memory files (additive) |
-| **50** | `PipelineSystemPromptDirective` | pipeline | User-configured task instructions + workflow visualization |
-| **80** | `SiteContextDirective` | **all** | WordPress site metadata (post types, taxonomies, etc.) |
+| Priority | Directive | Modes | Source | Purpose |
+|----------|-----------|-------|--------|---------|
+| **20** | `CoreMemoryFilesDirective` | all | `inc/Engine/AI/Directives/CoreMemoryFilesDirective.php` | SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md, custom registered files |
+| **22** | `AgentModeDirective` | all | `inc/Engine/AI/Directives/AgentModeDirective.php` | Mode-specific guidance (chat / pipeline / system) injected as runtime directive |
+| **25** | `CallerContextDirective` | all (cross-site only) | `inc/Engine/AI/Directives/CallerContextDirective.php` | Authenticated A2A caller identity (peer agent slug, host, chain depth) |
+| **35** | `AgentDailyMemoryDirective` | chat, pipeline | `inc/Engine/AI/Directives/AgentDailyMemoryDirective.php` | Recent daily archives for agents that opt in via `agent_config.daily_memory` |
+| **35** | `ClientContextDirective` | all | `inc/Engine/AI/Directives/ClientContextDirective.php` | Free-form client-reported context (current screen, post being edited, etc.) |
+| **40** | `PipelineMemoryFilesDirective` | pipeline | `inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php` | Per-pipeline selectable memory files |
+| **45** | `ChatPipelinesDirective` | chat | `inc/Api/Chat/ChatPipelinesDirective.php` | Pipeline / flow / handler inventory for discovery |
+| **45** | `FlowMemoryFilesDirective` | pipeline | `inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php` | Per-flow selectable memory files (additive to pipeline memory) |
+| **50** | `PipelineSystemPromptDirective` | pipeline | `inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php` | User-configured task instructions + workflow visualization |
 
-**Note**: Tools are injected by `RequestBuilder` via `PromptBuilder::setTools()`, not as a directive class.
+> Note: Tools are injected by `RequestBuilder` via `PromptBuilder::setTools()`, not as a directive class. The earlier `GlobalSystemPromptDirective`, `SiteContextDirective`, `PipelineCoreDirective`, `ChatAgentDirective`, and `SystemAgentDirective` classes were removed during the AgentMode refactor — their guidance now lives inline in `AgentModeDirective` and in agent memory files (SITE.md, SOUL.md, MEMORY.md).
 
 ## Individual Directives
 
-### PipelineCoreDirective (Priority 10)
-
-**Location**: `inc/Core/Steps/AI/Directives/PipelineCoreDirective.php`
-**Contexts**: Pipeline only
-**Purpose**: Establishes foundational agent identity for pipeline AI agents
-
-Provides the static core directive covering:
-- **Core Role** — Identifies the AI as a "content processing agent in the Data Machine WordPress plugin pipeline system"
-- **Operational Principles** — Execute tasks systematically, use tools strategically, maintain pipeline consistency
-- **Workflow Approach** — Analyze before acting; handler tools produce final results
-- **Data Packet Structure** — Describes guaranteed JSON packet fields (`type`, `timestamp`)
-
-### ChatAgentDirective (Priority 15)
-
-**Location**: `inc/Api/Chat/ChatAgentDirective.php`
-**Contexts**: Chat only
-**Since**: 0.2.0
-**Purpose**: Defines chat agent identity and capabilities
-
-Provides comprehensive behavioral instructions for the chat interface:
-- **Architecture** — Explains Handlers, Pipelines, Flows, and AI Steps concepts
-- **Discovery** — Use `api_query` for detailed config; query existing flows before creating new ones
-- **Configuration** — Only use documented handler_config fields; act first instead of asking
-- **Scheduling** — Intervals only (daily, hourly), never specific times
-- **Site Context** — Post types, taxonomy metadata, term management tools
-- **Error Recovery** — Taxonomy of error types (`not_found`, `validation`, `permission`, `system`)
-
-### SystemAgentDirective (Priority 20)
-
-**Location**: `inc/Api/System/SystemAgentDirective.php`
-**Contexts**: System only
-**Since**: 0.13.7
-**Purpose**: Defines system agent identity for internal operations
-
-Covers:
-- **Session Title Generation** — Rules for concise chat session titles (3-6 words, under 100 chars)
-- **GitHub Issue Creation** — Instructions for clear titles, detailed bodies, labels, routing
-- **Dynamic Repository Listing** — If `GitHubAbilities` exists, dynamically lists available repos at runtime
-- **System Operations** — Execute with precision, log appropriately, handle errors gracefully
-
 ### CoreMemoryFilesDirective (Priority 20)
 
-**Location**: `inc/Engine/AI/Directives/CoreMemoryFilesDirective.php`
-**Contexts**: All
+**Source**: `inc/Engine/AI/Directives/CoreMemoryFilesDirective.php`
+**Modes**: All
 **Since**: 0.30.0
-**Purpose**: Injects core memory files from the agent registry
 
 Reads core memory files from three directory layers and injects them as system messages:
 
-**Site Layer** (shared):
+**Site layer** (shared):
 - `SITE.md` — Site identity and configuration
 - `RULES.md` — Global rules and constraints
 
-**Agent Layer** (per-agent):
+**Agent layer** (per-agent):
 - `SOUL.md` — Agent personality and behavioral guidelines
 - `MEMORY.md` — Agent long-term memory
 
-**User Layer** (per-user):
+**User layer** (per-user):
 - `USER.md` — User-specific preferences and context
 
 **Custom registered files** — Any additional files registered via `MemoryFileRegistry` are also loaded from the agent directory.
 
 **Features**:
-- Self-healing: calls `DirectoryManager::ensure_agent_files()` before reading
-- Three-layer directory resolution via `DirectoryManager`
-- File size warning: logs warning if any file exceeds `AgentMemory::MAX_FILE_SIZE` (8KB)
-- Empty files are silently skipped
+- Self-healing: calls `DirectoryManager::ensure_agent_files()` before reading.
+- Three-layer directory resolution via `DirectoryManager`.
+- File size warning logged when any file exceeds `AgentMemory::MAX_FILE_SIZE` (8KB).
+- Empty files are silently skipped.
 
 **Configuration**: Edit files via the Agent admin page file browser or REST API (`PUT /datamachine/v1/files/agent/{filename}`).
 
-### PipelineMemoryFilesDirective (Priority 40)
+### AgentModeDirective (Priority 22)
 
-**Location**: `inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php`
-**Contexts**: Pipeline only
-**Purpose**: Injects per-pipeline selected agent memory files
+**Source**: `inc/Engine/AI/Directives/AgentModeDirective.php`
+**Modes**: All
+**Since**: 0.68.0 (replaced per-agent context files in #1129/#1130)
 
-Reads the pipeline's `memory_files` configuration (an array of filenames) and injects each file's content from the agent directory as a system message prefixed with `## Memory File: {filename}`.
+Injects execution-mode guidance (chat, pipeline, system) as a runtime directive rather than per-agent disk files. Mode guidance is platform knowledge, not agent-specific state — shipping it as a directive removes per-agent disk clutter and enables hook-based composition.
 
-**Features**:
-- Files sourced from the agent's memory directory (`wp-content/uploads/datamachine-files/agents/{agent_slug}/`)
-- Missing files logged as warnings but don't fail the request
-- Empty files are silently skipped
-- Supports multi-agent partitioning via `user_id` and `agent_id` from payload
-- Uses shared `MemoryFilesReader` helper
+**Built-in modes**:
+- `chat` — Live chat session in the admin UI. Includes Data Machine architecture overview, configuration rules, scheduling rules, and execution protocol.
+- `pipeline` — Automated pipeline step execution. Includes data packet structure and analysis-before-action principles.
+- `system` — Background system task execution. Includes session title generation rules and "return only what's asked" behavior.
 
-**Configuration**: Select memory files per-pipeline via the "Agent Memory Files" section in the pipeline settings UI. SOUL.md is excluded from the picker (it's always injected separately at Priority 20).
+**Extension hook**: `datamachine_agent_mode_{slug}` — extensions can append or modify mode-specific guidance for a given mode (e.g. the editor plugin appends diff workflow instructions when the `editor` mode is active).
 
-### ChatPipelinesDirective (Priority 45)
+**Payload key**: Reads `agent_mode` from the request payload.
 
-**Location**: `inc/Api/Chat/ChatPipelinesDirective.php`
-**Contexts**: Chat only
-**Purpose**: Injects pipeline inventory and flow summaries
+### CallerContextDirective (Priority 25)
 
-Provides a lightweight JSON inventory of all pipelines, their steps, and flow summaries (active handlers), labeled as `"DATAMACHINE PIPELINES INVENTORY"`.
+**Source**: `inc/Engine/AI/Directives/CallerContextDirective.php`
+**Modes**: All — but only emits output during cross-site A2A calls
+**Since**: 0.72.0
 
-**Context Awareness**:
-When `selected_pipeline_id` is provided (e.g., from the Integrated Chat Sidebar), the agent prioritizes context for that specific pipeline.
+Renders authenticated agent-to-agent caller identity from the four cross-site headers (`X-Datamachine-Caller-Site`, `-Caller-Agent`, `-Chain-Id`, `-Chain-Depth`). The data is server-validated — it cannot be spoofed by the client because the headers are read from the incoming HTTP request and validated by middleware.
 
-### FlowMemoryFilesDirective (Priority 45)
-
-**Location**: `inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php`
-**Contexts**: Pipeline only
-**Purpose**: Injects per-flow selected memory files (additive to pipeline memory files)
-
-Reads the flow's `memory_files` configuration and injects each file's content. Different flows on the same pipeline can reference different memory files.
-
-**Features**:
-- Additive to pipeline memory files (Priority 40), not a replacement
-- Uses shared `MemoryFilesReader` helper
-- Supports multi-agent partitioning
+When `PermissionHelper::in_cross_site_context()` returns false (local request, top of chain), the directive emits nothing. Distinct from `ClientContextDirective`: caller context is trusted server-side provenance; client context is untrusted frontend state.
 
 ### AgentDailyMemoryDirective (Priority 35)
 
-**Location**: `inc/Engine/AI/Directives/AgentDailyMemoryDirective.php`
-**Contexts**: Chat, Pipeline
+**Source**: `inc/Engine/AI/Directives/AgentDailyMemoryDirective.php`
+**Modes**: chat, pipeline
 **Since**: 0.71.0
-**Purpose**: Injects recent daily archive files for agents that explicitly opt in
 
-Replaces the former `DailyMemorySelectorDirective` + per-flow `flow_config.daily_memory` config.
+Injects recent daily archive files for agents that explicitly opt in. Replaces the former `DailyMemorySelectorDirective` + per-flow `flow_config.daily_memory` config.
 
 **Opt-in shape (per agent, in `agent_config`):**
 
@@ -177,194 +126,166 @@ Replaces the former `DailyMemorySelectorDirective` + per-flow `flow_config.daily
 }
 ```
 
-When disabled or absent the directive emits nothing — a stateless pipeline agent (alt-text generator, wiki builder, etc.) gets zero daily memory noise in its context. When enabled, the directive walks the **real files on disk** (`agents/{slug}/daily/YYYY/MM/DD.md`) from newest to oldest, injecting each as its own `system_text` block labelled `"## Daily Memory: YYYY-MM-DD"`.
+When disabled or absent the directive emits nothing — a stateless pipeline agent (alt-text generator, wiki builder) gets zero daily memory noise in its context. When enabled, the directive walks the real files on disk (`agents/{slug}/daily/YYYY/MM/DD.md`) from newest to oldest, injecting each as its own `system_text` block labelled `"## Daily Memory: YYYY-MM-DD"`.
 
 **Features**:
-- Opt-in per agent — default off for every agent
-- `recent_days` default 3, hard ceiling 14 (`MAX_RECENT_DAYS`)
-- Size-bounded by `AgentMemory::MAX_FILE_SIZE` (8 KB); older days dropped first when the budget would be exceeded
-- One real file = one `system_text` block so the AI can distinguish dates rather than reasoning over a stitched-together blob
-- Precise historical lookups still available via the `agent_daily_memory` tool
+- Opt-in per agent — default off for every agent.
+- `recent_days` default 3, hard ceiling 14 (`MAX_RECENT_DAYS`).
+- Size-bounded by `AgentMemory::MAX_FILE_SIZE` (8 KB); older days dropped first when the budget would be exceeded.
+- One real file = one `system_text` block so the AI can distinguish dates rather than reasoning over a stitched-together blob.
+- Precise historical lookups still available via the `agent_daily_memory` tool.
+
+### ClientContextDirective (Priority 35)
+
+**Source**: `inc/Engine/AI/Directives/ClientContextDirective.php`
+
+Renders free-form context reported by the calling client. Examples:
+
+- `{ "tab": "compose", "post_id": 123, "post_title": "My Draft" }` — Gutenberg sidebar
+- `{ "screen": "socials", "platform": "instagram" }` — Socials admin page
+- `{ "page": "forum", "topic_id": 42 }` — community page
+
+The payload is **untrusted** — it represents what the frontend says it is showing. Pair it with `CallerContextDirective` (priority 25) when authoritative provenance matters.
+
+### PipelineMemoryFilesDirective (Priority 40)
+
+**Source**: `inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php`
+**Modes**: Pipeline only
+
+Reads the pipeline's `memory_files` configuration (an array of filenames) and injects each file's content from the agent directory as a system message prefixed with `## Memory File: {filename}`.
+
+**Features**:
+- Files sourced from the agent's memory directory (`wp-content/uploads/datamachine-files/agents/{agent_slug}/`).
+- Missing files logged as warnings but don't fail the request.
+- Empty files are silently skipped.
+- Supports multi-agent partitioning via `user_id` and `agent_id` from payload.
+- Uses the shared `MemoryFilesReader` helper.
+
+**Configuration**: Select memory files per-pipeline via the "Agent Memory Files" section in the pipeline settings UI. SOUL.md is excluded from the picker — it's always injected by `CoreMemoryFilesDirective` (Priority 20).
+
+### ChatPipelinesDirective (Priority 45)
+
+**Source**: `inc/Api/Chat/ChatPipelinesDirective.php`
+**Modes**: Chat only
+
+Provides a lightweight JSON inventory of all pipelines, their steps, and flow summaries (active handlers), labeled `"DATAMACHINE PIPELINES INVENTORY"`.
+
+**Context awareness**: When `selected_pipeline_id` is provided (e.g. from the Integrated Chat Sidebar), the agent prioritizes context for that specific pipeline.
+
+### FlowMemoryFilesDirective (Priority 45)
+
+**Source**: `inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php`
+**Modes**: Pipeline only
+
+Reads the flow's `memory_files` configuration and injects each file's content. Different flows on the same pipeline can reference different memory files.
+
+**Features**:
+- Additive to pipeline memory files (Priority 40), not a replacement.
+- Uses the shared `MemoryFilesReader` helper.
+- Supports multi-agent partitioning.
 
 ### PipelineSystemPromptDirective (Priority 50)
 
-**Location**: `inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php`
-**Contexts**: Pipeline only
-**Purpose**: Injects user-configured pipeline system prompt with workflow visualization
+**Source**: `inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php`
+**Modes**: Pipeline only
 
 Two parts:
 
-1. **Workflow Visualization** — Compact string showing step sequence with "YOU ARE HERE" marker:
+1. **Workflow visualization** — Compact string showing step sequence with "YOU ARE HERE" marker:
    ```
    WORKFLOW: REDDIT FETCH -> AI (YOU ARE HERE) -> WORDPRESS PUBLISH
    ```
 
-2. **Pipeline Goals** — The `system_prompt` text from the pipeline step configuration, prefixed with `"PIPELINE GOALS:\n"`.
+2. **Pipeline goals** — The `system_prompt` text from the pipeline step configuration, prefixed with `"PIPELINE GOALS:\n"`.
 
 **Features**:
-- Returns empty if no system_prompt is configured
-- Provides spatial awareness (where in the pipeline the AI currently sits)
-- Multi-handler steps shown as `"LABEL1+LABEL2 STEPTYPE"`
-
-### SiteContextDirective (Priority 80)
-
-**Location**: `inc/Engine/AI/Directives/SiteContextDirective.php`
-**Contexts**: All agents
-**Purpose**: Provides comprehensive WordPress site metadata
-
-Injects structured JSON data about the WordPress site including post types, taxonomies, terms, and site configuration, labeled as `"WORDPRESS SITE CONTEXT"`. This is the final directive in the hierarchy.
-
-**Features**:
-- Cached site metadata for performance
-- Automatic cache invalidation on content changes
-- Toggleable via `site_context_enabled` setting
-- Directive class swappable via `datamachine_site_context_directive` filter
-- Extensible through `datamachine_site_context` filter
-
-## Site Context Data Structure
-
-The site context directive provides the following structured data:
-
-```json
-{
-  "site": {
-    "name": "Site Title",
-    "tagline": "Site Description",
-    "url": "https://example.com",
-    "admin_url": "https://example.com/wp-admin",
-    "language": "en_US",
-    "timezone": "America/New_York"
-  },
-  "post_types": {
-    "post": {
-      "label": "Posts",
-      "singular_label": "Post",
-      "count": 150,
-      "hierarchical": false
-    }
-  },
-  "taxonomies": {
-    "category": {
-      "label": "Categories",
-      "singular_label": "Category",
-      "terms": {
-        "news": 45,
-        "updates": 23
-      },
-      "hierarchical": true,
-      "post_types": ["post"]
-    }
-  }
-}
-```
+- Returns empty if no `system_prompt` is configured.
+- Provides spatial awareness (where in the pipeline the AI currently sits).
+- Multi-handler steps shown as `"LABEL1+LABEL2 STEPTYPE"`.
 
 ## Directive Injection Process
 
 ### Request Flow
 
-1. **Request Building**: `RequestBuilder` initiates AI request construction
-2. **Directive Collection**: Gathers all registered directives via `apply_filters('datamachine_directives', [])`
-3. **Priority Sorting**: `PromptBuilder` sorts directives by priority (ascending)
-4. **Context Filtering**: Only directives matching current context are applied (`'all'` matches everything)
-5. **Output Generation**: Each directive's `get_outputs()` is called
-6. **Validation**: `DirectiveOutputValidator` ensures outputs follow expected schema
-7. **Rendering**: `DirectiveRenderer` converts validated outputs to system messages
-8. **Final Request**: System messages prepended before conversation messages
+1. **Request Building**: `RequestBuilder` initiates AI request construction.
+2. **Directive Collection**: Gathers all registered directives via `apply_filters('datamachine_directives', [])`.
+3. **Priority Sorting**: `PromptBuilder` sorts directives by priority (ascending).
+4. **Mode Filtering**: Only directives matching the current `mode` are applied (`'all'` matches everything).
+5. **Output Generation**: Each directive's `get_outputs()` is called.
+6. **Validation**: `DirectiveOutputValidator` ensures outputs follow expected schema.
+7. **Rendering**: `DirectiveRenderer` converts validated outputs into `{role: 'system', content: ...}` messages.
+8. **Final Request**: System messages are prepended before conversation messages.
 
-### Message Ordering
+### Mode-Specific Stacks
 
-Directives maintain consistent message ordering by using `array_push()` to append system messages. This ensures:
-- Core directives appear first
-- Context accumulates predictably
-- Site context appears last
+**Chat agents** receive (in order):
 
-## Context-Specific Directive Stacks
+1. P20 — CoreMemoryFilesDirective
+2. P22 — AgentModeDirective (chat guidance)
+3. P25 — CallerContextDirective (cross-site only)
+4. P35 — AgentDailyMemoryDirective (opt-in per agent)
+5. P35 — ClientContextDirective
+6. P45 — ChatPipelinesDirective
+7. (Tools are injected separately by RequestBuilder)
 
-### Pipeline Agents
+**Pipeline agents** receive (in order):
 
-Receive directives in order:
-1. P10 — PipelineCoreDirective (identity)
-2. P20 — CoreMemoryFilesDirective (SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md, custom)
-3. P35 — AgentDailyMemoryDirective (daily archives, opt-in per agent)
-4. P40 — PipelineMemoryFilesDirective (pipeline-selected memory files)
-5. P45 — FlowMemoryFilesDirective (flow-selected memory files)
-6. P50 — PipelineSystemPromptDirective (task instructions + workflow viz)
-7. P80 — SiteContextDirective (WordPress metadata)
+1. P20 — CoreMemoryFilesDirective
+2. P22 — AgentModeDirective (pipeline guidance)
+3. P25 — CallerContextDirective (cross-site only)
+4. P35 — AgentDailyMemoryDirective (opt-in per agent)
+5. P35 — ClientContextDirective
+6. P40 — PipelineMemoryFilesDirective
+7. P45 — FlowMemoryFilesDirective
+8. P50 — PipelineSystemPromptDirective
 
-### Chat Agents
+**System agents** receive (in order):
 
-Receive directives in order:
-1. P15 — ChatAgentDirective (identity)
-2. P20 — CoreMemoryFilesDirective (SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md, custom)
-3. P35 — AgentDailyMemoryDirective (daily archives, opt-in per agent)
-4. P45 — ChatPipelinesDirective (pipeline inventory)
-5. P80 — SiteContextDirective (WordPress metadata)
+1. P20 — CoreMemoryFilesDirective
+2. P22 — AgentModeDirective (system guidance)
+3. P25 — CallerContextDirective (cross-site only)
+4. P35 — ClientContextDirective
 
-### System Agents
-
-Receive directives in order:
-1. P20 — SystemAgentDirective (identity)
-2. P20 — CoreMemoryFilesDirective (SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md, custom)
-3. P80 — SiteContextDirective (WordPress metadata)
-
-### Universal Directives
-
-CoreMemoryFilesDirective (P20) and SiteContextDirective (P80) apply to all agent types, ensuring consistent behavior across the system.
+System agents do not receive `AgentDailyMemoryDirective` (its registered modes are `chat` and `pipeline` only) and do not receive any pipeline-only memory directives.
 
 ## Configuration & Extensibility
 
 ### Plugin Settings Integration
 
-Several directives integrate with plugin settings:
-
-- **Agent Memory Files**: File-based in agent memory directory (migrated from `global_system_prompt`)
-- **Pipeline Memory Files**: Per-pipeline `memory_files` array in pipeline config
-- **Flow Memory Files**: Per-flow `memory_files` array in flow config
-- **Daily Memory**: Per-agent `agent_config.daily_memory = { enabled: bool, recent_days: int }`. Default disabled. When enabled, the `AgentDailyMemoryDirective` injects the last N days of real daily files as individual `system_text` blocks at priority 35.
-- **Site Context**: `site_context_enabled` toggle
+- **Agent memory files**: File-based in agent memory directory (migrated from `global_system_prompt`).
+- **Pipeline memory files**: Per-pipeline `memory_files` array in pipeline config.
+- **Flow memory files**: Per-flow `memory_files` array in flow config.
+- **Daily memory**: Per-agent `agent_config.daily_memory = { enabled: bool, recent_days: int }`. Default disabled.
 
 ### Filter Hooks
 
-**`datamachine_directives`**: Register new directives
-```php
-$directives[] = [
-    'class' => 'My\Directive\Class',
-    'priority' => 25,
-    'modes'    => ['chat', 'pipeline', 'all']
-];
-```
+**`datamachine_directives`** — Register a new directive:
 
-**`datamachine_site_context`**: Extend site context data
 ```php
-add_filter('datamachine_site_context', function($context) {
-    $context['custom_data'] = get_my_custom_data();
-    return $context;
+add_filter('datamachine_directives', function($directives) {
+    $directives[] = [
+        'class'    => MyDirective::class,
+        'priority' => 25,
+        'modes'    => ['chat', 'pipeline'], // or ['all']
+    ];
+    return $directives;
 });
 ```
 
-**`datamachine_site_context_directive`**: Override site context directive class
+**`datamachine_agent_mode_{slug}`** — Append or modify mode-specific guidance:
+
 ```php
-add_filter('datamachine_site_context_directive', function($class) {
-    return 'My\Custom\SiteContextDirective::class';
-});
+add_filter('datamachine_agent_mode_chat', function($content, $payload) {
+    return $content . "\n\n# Plugin extension\n\nExtra rules for this site.";
+}, 10, 2);
 ```
 
 ## Performance Considerations
 
 ### Caching Strategy
 
-- **Site Context**: Cached with automatic invalidation on content changes
-- **Memory Files**: Read from filesystem on each request (no caching)
-- **Pipeline Inventory**: Queried from database on each chat request
-
-### Cache Invalidation Triggers
-
-Site context cache clears automatically when:
-- Posts are created, updated, or deleted
-- Terms are created, edited, or deleted
-- Users are registered or deleted
-- Theme is switched
-- Site options (name, description, URL) change
+- **Memory files**: Read from filesystem on each request (no caching).
+- **Pipeline inventory**: Queried from database on each chat request.
 
 ## Support Infrastructure
 
@@ -382,18 +303,17 @@ Site context cache clears automatically when:
 
 ### Logging Integration
 
-All directives integrate with the Data Machine logging system:
+Directives integrate with the Data Machine logging system:
 
 ```php
-do_action('datamachine_log', 'debug', 'Directive: Context files injected', [
+do_action('datamachine_log', 'debug', 'Directive: Memory files injected', [
     'pipeline_id' => $pipeline_id,
-    'file_count' => count($files)
+    'file_count'  => count($files),
 ]);
 ```
 
 ### Error Handling
 
-Directives include comprehensive error handling:
-- Empty content detection and logging
-- Graceful degradation when optional features fail
-- File size warnings for oversized memory files
+- Empty content detection and logging.
+- Graceful degradation when optional features fail.
+- File size warnings for oversized memory files.

--- a/docs/core-system/files-repository.md
+++ b/docs/core-system/files-repository.md
@@ -7,8 +7,13 @@ The FilesRepository is a modular component system for file operations in the Dat
 ## Architecture
 
 **Location**: `/inc/Core/FilesRepository/`
-**Components**: 6 specialized classes
 **Since**: 0.2.1
+
+The repository covers two responsibility groups:
+
+- **Flow file primitives** — `DirectoryManager`, `FileStorage`, `FileRetrieval`, `FileCleanup`, `RemoteFileDownloader`, `FilesystemHelper`
+- **Validation primitives** — `ImageValidator`, `MediaValidator`, `VideoValidator`, `VideoMetadata`
+- **Agent memory primitives** — `AgentMemory`, `AgentMemoryStoreInterface`, `AgentMemoryStoreFactory`, `DiskAgentMemoryStore`, `AgentMemoryScope`, `AgentMemoryReadResult`, `AgentMemoryWriteResult`, `AgentMemoryListEntry`, `DailyMemory`, `DailyMemoryStorage`
 
 ## Components
 
@@ -153,7 +158,7 @@ $file_data = $file_retrieval->retrieve_data_by_job_id($job_id, [
 
 Components work together for complete file handling:
 
-> Note: When mapping flow_step_id -> flow_id, the REST API uses `datamachine_get_flow_id_from_step` filter (see datamachine/inc/Api/Files.php:168). Implement this filter when connecting flow-step-aware file operations from extensions.
+> Note: When mapping flow_step_id -> flow_id, the REST API uses `datamachine_get_flow_id_from_step` filter (see datamachine/inc/Api/FlowFiles.php). Implement this filter when connecting flow-step-aware file operations from extensions.
 
 ```php
 use DataMachine\Core\FilesRepository\RemoteFileDownloader;

--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -81,7 +81,8 @@ abstract public function handle_oauth_callback();
 ```
 
 **Providers Using BaseOAuth1Provider**:
-- TwitterAuth (OAuth 1.0a for tweet publishing)
+
+Core data-machine does not ship any concrete OAuth1 providers. Extensions register their own — for example, `data-machine-socials` ships `TwitterAuth` for tweet publishing.
 
 **Example Implementation**:
 
@@ -174,10 +175,11 @@ public function refresh_token(): bool; // Token refresh implementation
 ```
 
 **Providers Using BaseOAuth2Provider**:
-- RedditAuth (subreddit fetching)
-- FacebookAuth (Graph API publishing)
-- ThreadsAuth (Meta Threads integration)
-- GoogleSheetsAuth (spreadsheet operations, moved to `/inc/Core/OAuth/Providers/` in v0.2.6)
+
+Core data-machine ships only `EmailAuth` (`inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php`). Concrete OAuth2 social/event providers live in extension plugins:
+
+- `data-machine-socials` — `RedditAuth`, `FacebookAuth`, `ThreadsAuth`, etc.
+- `data-machine-events` — `DiceFmAuth`, `TicketmasterAuth`, etc.
 
 **Example Implementation**:
 
@@ -262,10 +264,10 @@ class RedditAuth extends BaseOAuth2Provider {
 ### Bluesky Authentication (BaseAuthProvider Direct Extension)
 
 **Provider**: BlueskyAuth
-**Location**: `/inc/Core/Steps/Publish/Handlers/Bluesky/BlueskyAuth.php`
+**Location**: `data-machine-socials/inc/Handlers/Bluesky/BlueskyAuth.php` (extension plugin)
 **Since**: v0.1.0 (updated to extend BaseAuthProvider in v0.2.6)
 
-Bluesky authentication uses app password authentication and extends BaseAuthProvider directly.
+Bluesky authentication uses app password authentication and extends BaseAuthProvider directly. The implementation lives in the `data-machine-socials` extension plugin; the example below shows the pattern any extension can follow.
 
 **Implementation Pattern**:
 
@@ -397,37 +399,30 @@ public function handle_callback(
 - 15-minute expiration for request tokens
 - Automatic cleanup after exchange
 
-## OAuth Providers Directory
+## Provider Registration via Filters
 
-**Location**: `/inc/Core/OAuth/Providers/`
-**Since**: v0.2.5
+Concrete OAuth providers self-register via the `datamachine_auth_providers` filter (typically through `HandlerRegistrationTrait`). Core data-machine does not ship a `inc/Core/OAuth/Providers/` directory — every concrete provider lives next to its handler in either core or an extension plugin.
 
-Centralized directory for shared OAuth provider implementations used by multiple handlers.
+**In core data-machine:**
 
-### GoogleSheetsAuth
+- `EmailAuth` — `inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php`
 
-**Location**: `/inc/Core/OAuth/Providers/GoogleSheetsAuth.php`
-**Since**: v0.2.0 (moved to Providers/ in v0.2.5, updated to extend BaseOAuth2Provider in v0.2.6)
+**In extension plugins:**
 
-OAuth2 provider for Google Sheets API access shared by both fetch and publish handlers.
+- `data-machine-socials` — Bluesky, Twitter, Reddit, Facebook, Threads, etc.
+- `data-machine-events` — Dice.fm, Ticketmaster, etc.
 
-**Key Features**:
-- OAuth2 authentication with offline access
-- Automatic token refresh 5 minutes before expiry
-- Service access method returning valid access token
-- Spreadsheet-specific scopes
+**Reusable provider pattern**:
 
-**Usage Pattern**:
+When multiple handlers in the same plugin need the same OAuth2 provider (e.g. a fetch and publish handler against the same API), implement the auth provider once and inject it into both handlers. The shared instance lives next to its handlers (e.g. `<plugin>/inc/Handlers/<Service>/<Service>Auth.php`).
 
 ```php
-use DataMachine\Core\OAuth\Providers\GoogleSheetsAuth;
-
-class GoogleSheetsFetch extends FetchHandler {
+class MyServiceFetch extends FetchHandler {
 
     private $auth;
 
     public function __construct() {
-        $this->auth = new GoogleSheetsAuth();
+        $this->auth = new MyServiceAuth();
     }
 
     public function fetch($flow_step_config, $job_id) {
@@ -641,5 +636,5 @@ class RedditAuth extends BaseOAuth2Provider {
 
 ---
 
-**Implementation**: `/inc/Core/OAuth/` directory with BaseAuthProvider, BaseOAuth1Provider, and BaseOAuth2Provider base classes, OAuth1Handler and OAuth2Handler services, and Providers/ directory (GoogleSheetsAuth)
+**Implementation**: `/inc/Core/OAuth/` directory ships `BaseAuthProvider`, `BaseOAuth1Provider`, and `BaseOAuth2Provider` base classes plus the `OAuth1Handler` and `OAuth2Handler` services. Concrete providers ship in core (`EmailAuth`) and in extension plugins (`data-machine-socials`, `data-machine-events`).
 **Architecture**: Inheritance-based provider system with centralized storage and validation

--- a/docs/core-system/system-tasks.md
+++ b/docs/core-system/system-tasks.md
@@ -1,6 +1,6 @@
 # System Tasks
 
-System tasks are background operations that run outside the normal pipeline execution cycle. They handle AI-powered content operations (alt text, meta descriptions, internal linking), media processing (image generation, optimization), and agent maintenance (daily memory, GitHub issues). All system tasks share a common base class with standardized job management, effect tracking, and undo support.
+System tasks are background operations that run outside the normal pipeline execution cycle. They handle AI-powered content operations (alt text, meta descriptions, internal linking), media processing (image generation, optimization), and agent housekeeping (daily memory synthesis, agent ping). All system tasks share a common base class with standardized job management, effect tracking, and undo support.
 
 ## Overview
 
@@ -12,6 +12,8 @@ The system tasks framework consists of:
 4. **TaskScheduler** — schedules and dispatches tasks via Action Scheduler
 5. **SystemTaskStep** — pipeline step type that bridges system tasks into pipeline workflows
 6. **Seven built-in tasks** — each implementing a specific AI or system operation
+
+> Note: `GitHubIssueTask` was extracted to the `data-machine-code` extension plugin (see PR #926). It is no longer part of core data-machine.
 
 ## SystemTask Base Class
 
@@ -187,10 +189,10 @@ Hooks the `datamachine_tasks` filter to register the seven built-in task types:
 
 | Task Key | Class |
 |----------|-------|
+| `agent_ping` | `AgentPingTask` |
 | `image_generation` | `ImageGenerationTask` |
 | `image_optimization` | `ImageOptimizationTask` |
 | `alt_text_generation` | `AltTextTask` |
-| `github_create_issue` | `GitHubIssueTask` |
 | `internal_linking` | `InternalLinkingTask` |
 | `daily_memory_generation` | `DailyMemoryTask` |
 | `meta_description_generation` | `MetaDescriptionTask` |
@@ -361,20 +363,21 @@ Compresses oversized images and generates WebP variants using WordPress's native
 | Manual run | No |
 | Prompts | None (not an AI task) |
 
-### GitHubIssueTask
+### AgentPingTask
 
-**Type:** `github_create_issue`
-**Source:** `inc/Engine/AI/System/Tasks/GitHubIssueTask.php`
+**Type:** `agent_ping`
+**Source:** `inc/Engine/AI/System/Tasks/AgentPingTask.php`
+**Since:** v0.60.0
 **Undo:** No
 
-The simplest task — creates GitHub issues by delegating entirely to `GitHubAbilities::createIssue()`. Validates the result and completes or fails the job. No prompt building, no normalization.
+Sends pipeline context to external webhook endpoints (Discord, Slack, custom HTTP collectors). Delegates HTTP transport to `SendPingAbility` (`inc/Abilities/AgentPing/SendPingAbility.php`). When dispatched as a pipeline step via `SystemTaskStep`, supports queue popping so a single ping configuration can be reused across queued runs.
 
 | Property | Value |
 |----------|-------|
 | Setting | None (always available) |
-| Trigger | AI tool call |
-| Manual run | No |
-| Prompts | None |
+| Trigger | On-demand via CLI, REST, or pipeline step |
+| Manual run | Yes |
+| Prompts | None (not an AI task) |
 
 ## Task Registration
 
@@ -426,6 +429,6 @@ The class must extend `SystemTask` and implement `execute()` and `getTaskType()`
 | `inc/Engine/AI/System/Tasks/AltTextTask.php` | AI-powered image alt text generation |
 | `inc/Engine/AI/System/Tasks/ImageGenerationTask.php` | Async image generation via Replicate API |
 | `inc/Engine/AI/System/Tasks/ImageOptimizationTask.php` | Image compression and WebP generation |
-| `inc/Engine/AI/System/Tasks/GitHubIssueTask.php` | GitHub issue creation |
+| `inc/Engine/AI/System/Tasks/AgentPingTask.php` | Send pipeline context to external webhook endpoints |
 | `inc/Core/Steps/SystemTask/SystemTaskStep.php` | Pipeline step type bridging system tasks |
 | `inc/Core/Steps/SystemTask/SystemTaskSettings.php` | Admin UI settings for the SystemTask step |

--- a/docs/development/hooks/engine-filters.md
+++ b/docs/development/hooks/engine-filters.md
@@ -1,533 +1,206 @@
 # Universal Engine Filters
 
-**Since**: 0.2.0
+Reference for the WordPress filters used by the Universal Engine to register directives, tools, and authentication providers, and to validate tool configuration.
 
-Comprehensive reference for filter hooks used by the Universal Engine to apply directives, register tools, and control tool enablement across Pipeline AI and Chat API agents.
-
-## Overview
-
-The Universal Engine uses WordPress filters for extensible integration, allowing custom directives, tools, and agent behaviors without modifying core code. All filters follow consistent patterns with clear parameter structures.
+> Modes vs contexts: prior to v0.71.0 the directive-targeting field was named `contexts`. It was renamed to `modes` during the AgentMode refactor (#1130). Both `RequestBuilder` and `PromptBuilder` now read `modes`. Old `contexts =>` registrations are silently ignored and treated as `all`.
 
 ## Directive System
 
-Directives inject system messages, tool definitions, and contextual information into AI requests. Since v0.2.5, directives use a unified registration system with priority-based ordering and agent targeting.
+Directives inject system messages and contextual information into AI requests. They self-register via a single unified filter with priority-based ordering and mode targeting.
 
 ### datamachine_directives
 
-Centralized filter for directive registration with priority and agent type targeting.
+Centralized filter for directive registration.
 
-**Hook Usage**:
+**Hook usage**:
+
 ```php
-apply_filters('datamachine_directives', $directives);
+$directives = apply_filters( 'datamachine_directives', array() );
 ```
 
-**Parameters**:
-- `$directives` (array) - Array of directive configurations
+**Return shape**: array of directive configurations.
 
-**Return**: Modified `$directives` array
+**Directive configuration**:
 
-**Directive Configuration**:
 ```php
-$directive_config = [
-    'class' => DirectiveClass::class,        // Directive class name
-    'priority' => 20,                        // Priority (lower = applied first)
-    'agent_types' => ['all']                 // 'all', 'pipeline', 'chat', or array
+$directive = [
+    'class'    => DirectiveClass::class, // implements DirectiveInterface
+    'priority' => 25,                    // lower = applied first
+    'modes'    => ['all'],               // 'all', or array of modes (chat, pipeline, system)
 ];
 ```
 
-**Implementation Example**:
-```php
-add_filter('datamachine_directives', function($directives) {
-    $directives[] = [
-        'class' => MyDirective::class,
-        'priority' => 25,
-        'agent_types' => ['all']
-    ];
+**Implementation example**:
 
+```php
+add_filter( 'datamachine_directives', function ( $directives ) {
     $directives[] = [
-        'class' => PipelineDirective::class,
+        'class'    => MyCustomDirective::class,
         'priority' => 30,
-        'agent_types' => ['pipeline']
-    ];
-
-    return $directives;
-});
-```
-
-**Registered Directives**:
-
-#### GlobalSystemPromptDirective (Priority 20)
-**File**: `/inc/Engine/AI/Directives/GlobalSystemPromptDirective.php`
-**Purpose**: Injects user-defined global system prompt from settings
-**Configuration**: Settings → AI Configuration → Global System Prompt
-**Agent Types**: `['all']`
-
-#### SiteContextDirective (Priority 50)
-**File**: `/inc/Engine/AI/Directives/SiteContextDirective.php`
-**Purpose**: Injects WordPress site context (site name, URL, description, post types, taxonomies)
-**Configuration**: Settings → AI Configuration → Include Site Context in AI Requests (enabled by default)
-**Agent Types**: `['all']`
-
-#### PipelineCoreDirective (Priority 10)
-**File**: `/inc/Core/Steps/AI/Directives/PipelineCoreDirective.php`
-**Purpose**: Foundational pipeline agent identity with tool instructions
-**Agent Types**: `['pipeline']`
-
-#### PipelineSystemPromptDirective (Priority 30)
-**File**: `/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php`
-**Purpose**: User-defined pipeline system prompts
-**Agent Types**: `['pipeline']`
-
-#### ChatAgentDirective (Priority 10)
-**File**: `/inc/Api/Chat/ChatAgentDirective.php`
-**Purpose**: Chat agent identity and capabilities
-**Agent Types**: `['chat']`
-
-**Hook Usage (LEGACY — use datamachine_directives instead)**:
-```php
-// Legacy usage — not used in core since v0.2.5. Use datamachine_directives with agent_types instead.
-apply_filters(
-    'datamachine_agent_directives',
-    $request,
-    $agent_type,
-    $provider,
-    $tools,
-    $context
-);
-```
-
-**Recommended (current)**:
-```php
-add_filter('datamachine_directives', function($directives) {
-    $directives[] = [
-        'class' => MyChatDirective::class,
-        'priority' => 15,
-        'agent_types' => ['chat']
+        'modes'    => ['chat', 'pipeline'],
     ];
     return $directives;
-});
+} );
+```
+
+**Built-in directives** are listed in [AI Directives System](../../core-system/ai-directives.md) with current priority and mode assignments. The earlier `GlobalSystemPromptDirective`, `SiteContextDirective`, `PipelineCoreDirective`, `ChatAgentDirective`, and `SystemAgentDirective` classes were removed during the AgentMode refactor — their guidance now lives inline in `AgentModeDirective` and in agent memory files (SITE.md, SOUL.md, MEMORY.md).
+
+### datamachine_agent_mode_{slug}
+
+Per-mode guidance composition hook fired by `AgentModeDirective` (priority 22).
+
+**Hook usage** (one filter per mode slug):
+
+```php
+$content = apply_filters( "datamachine_agent_mode_{$mode}", $default_content, $payload );
 ```
 
 **Parameters**:
-- `$request` (array) - AI request array (model, messages)
-- `$agent_type` (string) - Agent type ('pipeline' or 'chat')
-- `$provider` (string) - AI provider name
-- `$tools` (array) - Structured tools array
-- `$context` (array) - Agent-specific context (step_id/payload for pipeline, session_id for chat)
 
-**Return**: Modified `$request` array
+- `$default_content` (string) — Built-in guidance for that mode (or empty for unregistered modes).
+- `$payload` (array) — Full request payload (`agent_id`, `user_id`, `agent_mode`, etc.).
 
-**Pipeline Implementation Example**:
+**Return**: Modified guidance text. Returning an empty string suppresses the directive.
+
+**Built-in modes**: `chat`, `pipeline`, `system`. Extensions can register additional modes (e.g. the editor plugin registers `editor` to inject diff-workflow instructions).
+
+**Implementation example**:
+
 ```php
-add_filter('datamachine_agent_directives', function($request, $agent_type, $provider, $tools, $context) {
-    if ($agent_type === 'pipeline') {
-        // Apply pipeline-specific directives
-        $request = PipelineCoreDirective::inject(
-            $request,
-            $provider,
-            $tools,
-            $context['step_id'] ?? null,
-            $context['payload'] ?? []
-        );
+add_filter( 'datamachine_agent_mode_chat', function ( $content, $payload ) {
+    if ( empty( $payload['agent_id'] ) ) {
+        return $content;
     }
-    return $request;
-}, 10, 5);
+    return $content . "\n\n## Site-specific\n\nAlways prefer existing taxonomies before creating new ones.";
+}, 10, 2 );
 ```
 
-**Chat Implementation Example**:
-```php
-add_filter('datamachine_agent_directives', function($request, $agent_type, $provider, $tools, $context) {
-    if ($agent_type === 'chat') {
-        // Apply chat-specific directives
-        $request = ChatAgentDirective::inject($request, $provider, $tools, $context);
-    }
-    return $request;
-}, 10, 5);
-```
+## Tool System
 
-**Registered Directives**:
+Tools are registered via a single unified filter. Per-mode tool partitioning is handled inside `ToolManager`, not by separate registration filters.
 
-#### Pipeline Directives
+### datamachine_tools
 
-**PipelineCoreDirective**
-**File**: `/inc/Core/Steps/AI/Directives/PipelineCoreDirective.php`
-**Purpose**: Foundational pipeline agent identity and operational principles
-**Content**: Agent role, workflow approach, data packet structure
+Single registry for all AI tools. Used by `ToolManager::getRawToolsForMode()` to assemble the available tool set for a given execution mode.
+
+**Hook usage**:
 
 ```php
-add_filter('datamachine_agent_directives', function($request, $agent_type, $provider, $tools, $context) {
-    if ($agent_type === 'pipeline') {
-        $request = PipelineCoreDirective::inject(
-            $request,
-            $provider,
-            $tools,
-            $context['step_id'] ?? null,
-            $context['payload'] ?? []
-        );
-    }
-    return $request;
-}, 10, 5);
+$tools = apply_filters( 'datamachine_tools', array() );
 ```
 
-**PipelineSystemPromptDirective**
-**File**: `/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php`
-**Purpose**: User-defined pipeline-level system prompt from pipeline configuration
-**Configuration**: Pipeline Builder → System Prompt (template level)
+**Return shape**: associative array keyed by tool ID.
 
-```php
-add_filter('datamachine_agent_directives', function($request, $agent_type, $provider, $tools, $context) {
-    if ($agent_type === 'pipeline') {
-        $request = PipelineSystemPromptDirective::inject(
-            $request,
-            $provider,
-            $tools,
-            $context['step_id'] ?? null,
-            $context['payload'] ?? []
-        );
-    }
-    return $request;
-}, 20, 5);
-```
+**Tool definition**:
 
-#### Chat Directives
-
-**ChatAgentDirective**
-**File**: `/inc/Api/Chat/ChatAgentDirective.php`
-**Purpose**: Chat agent identity, capabilities, and available REST API endpoints
-**Content**: Agent role, workflow building capabilities, API documentation
-
-```php
-add_filter('datamachine_agent_directives', function($request, $agent_type, $provider, $tools, $context) {
-    if ($agent_type === 'chat') {
-        $request = ChatAgentDirective::inject($request, $provider, $tools, $context);
-    }
-    return $request;
-}, 10, 5);
-```
-
-
-
-## Tool Filters
-
-Control tool registration, enablement, and configuration validation.
-
-### datamachine_tool_enabled
-
-Universal tool enablement control. Determines which tools are available to AI agents.
-
-**Note**: Direct filter usage for tool availability is replaced by **ToolManager** (@since v0.2.1). The ToolManager provides centralized methods (`is_tool_available()`, `is_tool_configured()`) that internally use these filters but add additional validation layers. Components should use ToolManager methods rather than calling filters directly.
-
-See Tool Manager for the modern tool management approach.
-
-**Hook Usage**:
-```php
-apply_filters(
-    'datamachine_tool_enabled',
-    $enabled,
-    $tool_name,
-    $tool_config,
-    $context_id
-);
-```
-
-**Parameters**:
-- `$enabled` (bool) - Current enablement status
-- `$tool_name` (string) - Tool identifier
-- `$tool_config` (array) - Tool configuration array
-- `$context_id` (string|null) - Pipeline step ID or null for chat
-
-**Return**: (bool) Whether tool is enabled
-
-**Pipeline Implementation** (step-specific enablement):
-```php
-add_filter('datamachine_tool_enabled', function($enabled, $tool_name, $tool_config, $pipeline_step_id) {
-    if ($pipeline_step_id) {
-        // Pipeline agent: check step-specific enablement
-        $step_config = apply_filters('datamachine_get_flow_step_config', [], $pipeline_step_id);
-        $enabled_tools = $step_config['enabled_tools'] ?? [];
-        return in_array($tool_name, $enabled_tools);
-    }
-    return $enabled;
-}, 10, 4);
-```
-
-**Chat Implementation** (global enablement):
-```php
-add_filter('datamachine_tool_enabled', function($enabled, $tool_name, $tool_config, $context_id) {
-    if ($context_id === null) {
-        // Chat agent: use global tool enablement
-        $tool_configured = apply_filters('datamachine_tool_configured', false, $tool_name);
-        $requires_config = !empty($tool_config['requires_config']);
-        return !$requires_config || $tool_configured;
-    }
-    return $enabled;
-}, 5, 4); // Priority 5 so pipeline (priority 10) can override
-```
-
-### datamachine_tool_configured
-
-Validates tool configuration. Used to check if tools requiring external services (API keys, credentials) are properly configured.
-
-**Hook Usage**:
-```php
-apply_filters(
-    'datamachine_tool_configured',
-    $configured,
-    $tool_name
-);
-```
-
-**Parameters**:
-- `$configured` (bool) - Current configuration status
-- `$tool_name` (string) - Tool identifier
-
-**Return**: (bool) Whether tool is configured
-
-**Implementation Example**:
-```php
-add_filter('datamachine_tool_configured', function($configured, $tool_name) {
-    if ($tool_name === 'google_search') {
-        $settings = datamachine_get_data_machine_settings();
-        $api_key = $settings['google_search_api_key'] ?? '';
-        $search_engine_id = $settings['google_search_engine_id'] ?? '';
-        return !empty($api_key) && !empty($search_engine_id);
-    }
-    return $configured;
-}, 10, 2);
-```
-
-**Tools Requiring Configuration**:
-- `google_search` - API key + Custom Search Engine ID
-- OAuth-based handler tools (validated via separate OAuth filters)
-
-### datamachine_global_tools
-
-Registers tools available to all AI agents (pipeline + chat).
-
-**Hook Usage**:
-```php
-apply_filters('datamachine_global_tools', $tools);
-```
-
-**Parameters**:
-- `$tools` (array) - Current global tools array
-
-**Return**: Modified `$tools` array
-
-**Implementation Example**:
-```php
-add_filter('datamachine_global_tools', function($tools) {
-    $tools['google_search'] = [
-        'class' => 'DataMachine\\Engine\\AI\\Tools\\GoogleSearch',
-        'method' => 'handle_tool_call',
-        'description' => 'Search the web using Google Custom Search',
-        'parameters' => [
-            'query' => [
-                'type' => 'string',
-                'required' => true,
-                'description' => 'Search query'
-            ],
-            'num_results' => [
-                'type' => 'integer',
-                'required' => false,
-                'description' => 'Number of results (1-10, default 5)'
-            ]
-        ],
-        'requires_config' => true
-    ];
-    return $tools;
-});
-```
-
-**Registered Global Tools**:
-- `google_search` - Web search via Google Custom Search API
-- `local_search` - WordPress content search
-- `web_fetch` - Retrieve web page content
-- `wordpress_post_reader` - Read specific WordPress post by URL
-
-**Tool Structure**:
 ```php
 [
-    'class' => 'Namespace\\ClassName',     // Tool handler class
-    'method' => 'handle_tool_call',        // Handler method
-    'description' => 'Tool description',   // Visible to AI
-    'parameters' => [                      // Tool parameters
-        'param_name' => [
-            'type' => 'string|integer|boolean|array',
-            'required' => true|false,
-            'description' => 'Parameter description'
-        ]
+    'class'            => 'My\\Plugin\\Tools\\MyTool',
+    'method'           => 'handle_tool_call',
+    'description'      => 'Clear, AI-readable description.',
+    'parameters'       => [
+        'query' => [
+            'type'        => 'string',
+            'required'    => true,
+            'description' => 'Search query',
+        ],
     ],
-    'requires_config' => true|false        // Whether tool needs configuration
+    'modes'            => ['chat', 'pipeline'], // which modes can see this tool
+    'requires_config'  => true,                 // checked via datamachine_tool_configured
+    'category'         => 'search',             // optional grouping
 ]
 ```
 
-### datamachine_chat_tools
+**Implementation example**:
 
-Registers tools available exclusively to chat agents.
-
-**Hook Usage**:
 ```php
-apply_filters('datamachine_chat_tools', $tools);
+add_filter( 'datamachine_tools', function ( $tools ) {
+    $tools['my_search'] = [
+        'class'           => 'My\\Plugin\\Tools\\MySearch',
+        'method'          => 'handle_tool_call',
+        'description'     => 'Search the My Plugin index.',
+        'parameters'      => [
+            'query' => [
+                'type'        => 'string',
+                'required'    => true,
+                'description' => 'Search terms',
+            ],
+        ],
+        'modes'           => ['chat'],
+        'requires_config' => false,
+    ];
+    return $tools;
+} );
+```
+
+> The legacy `datamachine_global_tools` and `datamachine_chat_tools` filters were consolidated into `datamachine_tools` in v0.68.0 (PR #1130). The old per-mode filters no longer exist.
+
+### datamachine_tool_configured
+
+Validates that tools requiring external services (API keys, OAuth credentials) are properly configured.
+
+**Hook usage**:
+
+```php
+$configured = apply_filters( 'datamachine_tool_configured', false, $tool_id );
 ```
 
 **Parameters**:
-- `$tools` (array) - Current chat tools array
 
-**Return**: Modified `$tools` array
+- `$configured` (bool) — Current configuration status.
+- `$tool_id` (string) — Tool identifier.
 
-**Implementation Example**:
+**Return**: bool — Whether the tool is configured.
+
+**Implementation example**:
+
 ```php
-add_filter('datamachine_chat_tools', function($tools) {
-    $tools['create_pipeline'] = [
-        'class' => 'DataMachine\\Api\\Chat\\Tools\\CreatePipeline',
-        'method' => 'handle_tool_call',
-        'description' => 'Create a new pipeline with optional steps',
-        'parameters' => [
-            'name' => [
-                'type' => 'string',
-                'required' => true,
-                'description' => 'Pipeline name'
-            ],
-            'steps' => [
-                'type' => 'array',
-                'required' => false,
-                'description' => 'Optional initial steps'
-            ]
-        ]
-    ];
-    return $tools;
-});
+add_filter( 'datamachine_tool_configured', function ( $configured, $tool_id ) {
+    if ( $tool_id === 'my_search' ) {
+        $settings = get_option( 'my_plugin_settings', array() );
+        return ! empty( $settings['api_key'] ) && strlen( $settings['api_key'] ) >= 20;
+    }
+    return $configured;
+}, 10, 2 );
 ```
 
-**Registered Chat Tools** (@since v0.4.3 specialized tools):
-- `execute_workflow` - Execute complete multi-step workflows
-- `add_pipeline_step` - Add steps to existing pipelines
-- `api_query` - REST API query for discovery
-- `configure_flow_step` - Configure flow step handlers and AI messages
-- `configure_pipeline_step` - Configure pipeline AI settings
-- `create_flow` - Create flow instances from pipelines
-- `create_pipeline` - Create pipelines with optional steps
-- `run_flow` - Execute or schedule flows
-- `update_flow` - Update flow properties
+> Tool *availability* (whether the AI sees the tool in this request) is now resolved by `ToolManager::is_tool_available()`, not by a public filter. The `datamachine_tool_enabled` filter from earlier versions has been removed in favour of `ToolManager`'s direct logic, which combines configuration state, mode membership, and per-step `enabled_tools` settings.
 
-## Directive Application Order
+## Handler Registration
 
-Directives are applied in priority-based order by PromptBuilder (@since v0.2.5):
+Handlers (fetch / publish / upsert) are registered via the `HandlerRegistrationTrait` (`inc/Core/Steps/HandlerRegistrationTrait.php`), which wires multiple filters in one call. The full pattern is documented in [Core Filters](core-filters.md). The trait registers:
 
-```
-Unified Directive System (datamachine_directives filter):
-├── Priority 10-19: Core agent identity
-│   ├── PipelineCoreDirective (Priority 10, pipeline only)
-│   └── ChatAgentDirective (Priority 10, chat only)
-│
-├── Priority 20-29: Global system prompts
-│   ├── GlobalSystemPromptDirective (Priority 20, all agents)
-│   └── GlobalToolsDirective (Priority 25, all agents)
-│
-├── Priority 30-39: Agent-specific prompts
-│   └── PipelineSystemPromptDirective (Priority 30, pipeline only)
-│
-└── Priority 50+: Site context
-    └── SiteContextDirective (Priority 50, all agents)
-```
-
-**Migration Note**: Prior to v0.2.5, directives used separate `datamachine_global_directives` and `datamachine_agent_directives` filters. These are now deprecated in favor of the unified `datamachine_directives` filter with priority-based ordering and agent type targeting.
+| Filter | Purpose |
+|--------|---------|
+| `datamachine_handlers` | Handler metadata lookup keyed by step type |
+| `datamachine_auth_providers` | Auth provider lookup (when `requires_auth=true`) |
+| `datamachine_handler_settings` | Settings class lookup keyed by handler slug |
+| `datamachine_tools` | Handler tool registration via `_handler_callable` deferred entries |
 
 ## Best Practices
 
 ### Directive Registration
 
-**Use Appropriate Filter Priority**:
-```php
-// Earlier priority (10-30) for foundational directives
-add_filter('datamachine_global_directives', function($request, ...) {
-    // Critical system directive
-    return $request;
-}, 15, 5);
+- Use **priority 10–29** for foundational identity / mode guidance.
+- Use **priority 30–49** for contextual information (memory files, inventory).
+- Use **priority 50+** for late-stage configuration (workflow visualization, pipeline goals).
+- Always declare `modes` explicitly. Default to `['all']` only when the directive truly applies everywhere.
 
-// Later priority (40-50) for contextual information
-add_filter('datamachine_global_directives', function($request, ...) {
-    // Site context, tool definitions
-    return $request;
-}, 40, 5);
-```
+### Tool Registration
 
-**Always Return Modified Request**:
-```php
-add_filter('datamachine_global_directives', function($request, $provider, $tools, $step_id, $payload) {
-    $request['messages'][] = [
-        'role' => 'system',
-        'content' => 'Directive content'
-    ];
+- Provide a complete `parameters` schema — the AI relies on it for argument structure.
+- Set `requires_config => true` only when the tool genuinely needs configuration. Tools that always work (e.g. `web_fetch`) should leave it `false` so they don't get filtered out.
+- Declare `modes` so the tool only appears where it's useful (e.g. workflow-management tools should be `chat`-only, not exposed to pipeline AI steps).
 
-    return $request; // Critical: always return
-}, 10, 5);
-```
+### Configuration Validation
 
-**Check Agent Type for Agent Directives**:
-```php
-add_filter('datamachine_agent_directives', function($request, $agent_type, $provider, $tools, $context) {
-    if ($agent_type === 'pipeline') {
-        // Pipeline-specific logic
-    } elseif ($agent_type === 'chat') {
-        // Chat-specific logic
-    }
-    return $request;
-}, 10, 5);
-```
-
-### Tool Filters
-
-**Provide Complete Tool Definitions**:
-```php
-add_filter('datamachine_global_tools', function($tools) {
-    $tools['my_tool'] = [
-        'class' => 'MyNamespace\\MyTool',
-        'method' => 'handle_tool_call',
-        'description' => 'Clear, concise description for AI',
-        'parameters' => [
-            'required_param' => [
-                'type' => 'string',
-                'required' => true,
-                'description' => 'Parameter description'
-            ]
-        ],
-        'requires_config' => false
-    ];
-    return $tools;
-});
-```
-
-**Validate Configuration Properly**:
-```php
-add_filter('datamachine_tool_configured', function($configured, $tool_name) {
-    if ($tool_name === 'my_tool') {
-        $settings = datamachine_get_data_machine_settings();
-        $api_key = $settings['my_tool_api_key'] ?? '';
-        return !empty($api_key) && strlen($api_key) >= 20; // Validate length
-    }
-    return $configured;
-}, 10, 2);
-```
-
-**Respect Context ID in Tool Enablement**:
-```php
-add_filter('datamachine_tool_enabled', function($enabled, $tool_name, $tool_config, $context_id) {
-    // context_id = pipeline_step_id for pipeline, null for chat
-    if ($context_id === null) {
-        // Chat agent logic
-    } else {
-        // Pipeline agent logic
-    }
-    return $enabled;
-}, 10, 4);
-```
+- Validate the actual usability of credentials, not just their presence (e.g. minimum length, expected prefix).
+- Keep validation cheap — `datamachine_tool_configured` is called repeatedly during tool listing.
+- Do not perform live API calls inside the filter; cache results elsewhere if you need to verify connectivity.
 
 ## Related Documentation
 
-- Universal Engine Architecture - Overall engine structure
-- RequestBuilder Pattern - Directive application system
-- Tool Execution Architecture - Tool discovery and execution
-- Tool Manager - Centralized tool management (@since v0.2.1)
-- AI Conversation Loop - Multi-turn conversation execution
+- [AI Directives System](../../core-system/ai-directives.md) — Built-in directive list, priorities, modes
+- [Tool Manager](../../core-system/tool-manager.md) — Tool availability resolution
+- [Tool Execution](../../core-system/tool-execution.md) — Tool dispatch and result handling
+- [Core Filters](core-filters.md) — Handler registration filters and OAuth service discovery


### PR DESCRIPTION
## Summary

Sweep pass over `docs/` to bring user-facing documentation back in sync with the post-AgentMode-refactor codebase. Net result: **+492 / -740** lines (cleanup, not bloat).

## Why

`homeboy docs audit` is documented in homeboy's CLI docs but isn't wired up in 0.88.3, so I ran a manual audit instead — extracting `inc/.../*.php` references from every doc and verifying them against the filesystem on the current `main` of data-machine.

The audit found 9 docs referencing files that have been moved, renamed, or deleted. The biggest cluster was the AgentMode refactor (#1129 / #1130), which removed `GlobalSystemPromptDirective`, `SiteContextDirective`, `PipelineCoreDirective`, `ChatAgentDirective`, and `SystemAgentDirective` — all five still appeared verbatim in our directive docs. The legacy `datamachine_global_tools`, `datamachine_chat_tools`, `datamachine_agent_directives`, and `datamachine_tool_enabled` filters were similarly still being documented even though they no longer exist in core.

## Broken-reference fixes

- **`api/endpoints/files.md`**, **`core-system/files-repository.md`**: `Files.php` → `FlowFiles.php`.
- **`core-system/system-tasks.md`**: drop `GitHubIssueTask` (extracted to `data-machine-code` in #926); document `AgentPingTask` in its place. Update intro to drop "GitHub issues" mention.
- **`core-system/oauth-handlers.md`**: reframe as **core ships base classes + EmailAuth**; concrete providers (Bluesky, Twitter, Reddit, Facebook, Threads, Dice.fm, Ticketmaster) live in extension plugins. The `inc/Core/OAuth/Providers/` directory no longer exists.
- **`ai-tools/execute-workflow.md`**: tool now delegates to `datamachine/execute-workflow` ability via `wp_get_ability()`, not to the `/datamachine/v1/execute` REST endpoint. Drop dead `HandlerDocumentation.php` reference.
- **`architecture/policy-resolvers.md`**: `PipelineTranscriptPolicy.php` is in `inc/Engine/AI/`, not `inc/Engine/AI/Transcripts/`.

## Architecture rewrites

### `core-system/ai-directives.md`

Full replace of the directive registry. Current canonical list:

| P | Directive | Modes |
|---|-----------|-------|
| 20 | `CoreMemoryFilesDirective` | all |
| 22 | `AgentModeDirective` | all |
| 25 | `CallerContextDirective` | all (cross-site only) |
| 35 | `AgentDailyMemoryDirective` | chat, pipeline |
| 35 | `ClientContextDirective` | all |
| 40 | `PipelineMemoryFilesDirective` | pipeline |
| 45 | `ChatPipelinesDirective` | chat |
| 45 | `FlowMemoryFilesDirective` | pipeline |
| 50 | `PipelineSystemPromptDirective` | pipeline |

Documents the `contexts` → `modes` field rename and the per-mode stack (`chat` / `pipeline` / `system`).

### `development/hooks/engine-filters.md`

Collapses the legacy multi-filter directive/tool surface into the current single-filter API:

- `datamachine_directives` (replaces `datamachine_global_directives` and `datamachine_agent_directives`).
- `datamachine_tools` (replaces `datamachine_global_tools` and `datamachine_chat_tools`).
- `datamachine_tool_configured` (still public).
- `datamachine_agent_mode_{slug}` (new — composition hook fired by `AgentModeDirective`).
- Tool *availability* now resolves through `ToolManager::is_tool_available()`, no longer through a public `datamachine_tool_enabled` filter.

## New coverage

- **`architecture/iteration-budget.md`**: documents the `IterationBudget` primitive (#1117), the `IterationBudgetRegistry` registration pattern, and the two built-in budgets (`conversation_turns`, `chain_depth`). Closes a notable gap — this primitive is the shared basis for both turn limits in `AIConversationLoop` and chain-depth limits in cross-site A2A, but had no architecture-level doc.

- **`README.md`**: adds an Architecture Deep Dives section linking `pipeline-execution-axes`, `policy-resolvers`, and the new `iteration-budget` doc. Adds `architecture/` to the directory tree.

## Verification

After this PR, all `inc/<Path>.php` and `inc/<Dir>` references in core data-machine docs resolve to live files. Two false-positive matches remain in my verifier output — both correctly point to **extension-plugin** paths (`data-machine-socials/inc/Handlers/Bluesky/...`, `data-machine-events/inc/Core/DuplicateDetection/...`) that the regex stripped of their plugin prefix.

## Out of scope

- `docs/CHANGELOG.md` is treated as immutable history and was not touched.
- Code is not modified in this PR (alignment workflow rule). One drive-by note for follow-up: `CallerContextDirective` registers itself with a `'contexts' =>` key instead of `'modes' =>`. `RequestBuilder` reads `modes`, so the `contexts` key is silently ignored and the directive defaults to all modes — which is what the docblock describes anyway, so the bug is harmless. Worth a small fix in a separate PR.