### PR TITLE
fix(directives): CallerContextDirective registers under `modes` key, not `contexts`

### DIFF
--- a/inc/Engine/AI/Directives/CallerContextDirective.php
+++ b/inc/Engine/AI/Directives/CallerContextDirective.php
@@ -114,7 +114,7 @@ add_filter(
 		$directives[] = array(
 			'class'    => CallerContextDirective::class,
 			'priority' => 25,
-			'contexts' => array( 'all' ),
+			'modes'    => array( 'all' ),
 		);
 		return $directives;
 	}

--- a/tests/Unit/AI/Directives/CallerContextDirectiveTest.php
+++ b/tests/Unit/AI/Directives/CallerContextDirectiveTest.php
@@ -140,6 +140,6 @@ class CallerContextDirectiveTest extends WP_UnitTestCase {
 
 		$this->assertNotNull( $found, 'CallerContextDirective must be registered via datamachine_directives filter.' );
 		$this->assertSame( 25, $found['priority'] );
-		$this->assertSame( array( 'all' ), $found['contexts'] );
+		$this->assertSame( array( 'all' ), $found['modes'] );
 	}
 }


### PR DESCRIPTION
## Summary

`CallerContextDirective` self-registers with `'contexts' => array( 'all' )` but `RequestBuilder` reads `$directive['modes'] ?? array( 'all' )`. The `contexts` key is silently ignored and the directive defaults to `all` modes — which happens to match the docblock, so the bug has produced the right behavior by accident.

## Why this isn't harmless

- The `contexts` → `modes` field rename was the whole point of #1130. Leaving one stray `contexts =>` key in the registry undermines the rename and signals to the next reader that both keys are valid.
- If the docblock or design intent ever narrows targeting to a subset (e.g. `['chat', 'pipeline']`), the registration will not actually take effect — the directive will keep firing for `system` mode too because `modes` is still missing and `RequestBuilder` falls back to `all`.
- The accompanying test asserted on the wrong key (`$found['contexts']`), so the unit test was reinforcing the bug instead of catching it.

## Changes

- `inc/Engine/AI/Directives/CallerContextDirective.php` — registration now uses `'modes' => array( 'all' )`.
- `tests/Unit/AI/Directives/CallerContextDirectiveTest.php` — updated assertion to read `$found['modes']`.

## Verification

```
homeboy test data-machine --path /var/lib/datamachine/workspace/data-machine@fix-caller-context-modes-key
# → status: passed
```

Targeted run on `--filter CallerContextDirectiveTest` also green.

## Context

Spotted while preparing the docs alignment PR (#1230). Behavior is unchanged because the fallback already produced `all`, but the registration shape now matches every other directive in the registry.