### PR TITLE
fix(memory paths): report convention_path target, not the dead layer dir

### DIFF
--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -1282,10 +1282,20 @@ class MemoryCommand extends BaseCommand {
 			$layer     = $meta['layer'];
 			$directory = $layer_dirs[ $layer ] ?? $agent_dir;
 
+			// Use the registry's canonical resolver so files with `convention_path`
+			// (e.g. AGENTS.md → ABSPATH) report the path that compose actually
+			// writes to, not the layer dir that nothing touches anymore.
+			$abs_path = MemoryFileRegistry::resolve_filepath( $filename, $directory );
+			if ( null === $abs_path ) {
+				$abs_path = trailingslashit( $directory ) . $filename;
+			}
+
 			$core_files[] = array(
-				'file'      => $filename,
-				'layer'     => $layer,
-				'directory' => $directory,
+				'file'            => $filename,
+				'layer'           => $layer,
+				'directory'       => $directory,
+				'path'            => $abs_path,
+				'convention_path' => $meta['convention_path'] ?? '',
 			);
 		}
 
@@ -1303,15 +1313,16 @@ class MemoryCommand extends BaseCommand {
 			$relative_files = array();
 
 			foreach ( $core_files as $entry ) {
-				$abs_path = trailingslashit( $entry['directory'] ) . $entry['file'];
+				$abs_path = $entry['path'];
 				$rel_path = str_replace( $site_root . '/', '', $abs_path );
 				$exists   = file_exists( $abs_path );
 
 				$files[ $entry['file'] ] = array(
-					'layer'    => $entry['layer'],
-					'path'     => $abs_path,
-					'relative' => $rel_path,
-					'exists'   => $exists,
+					'layer'           => $entry['layer'],
+					'path'            => $abs_path,
+					'relative'        => $rel_path,
+					'exists'          => $exists,
+					'convention_path' => $entry['convention_path'],
 				);
 
 				if ( $exists ) {
@@ -1331,7 +1342,7 @@ class MemoryCommand extends BaseCommand {
 		} else {
 			$items = array();
 			foreach ( $core_files as $entry ) {
-				$abs_path = trailingslashit( $entry['directory'] ) . $entry['file'];
+				$abs_path = $entry['path'];
 				$rel_path = str_replace( $site_root . '/', '', $abs_path );
 
 				$items[] = array(


### PR DESCRIPTION
## Summary

- `wp datamachine memory paths` reports `{layer_dir}/{filename}` for every registered file. For files with a `convention_path` (e.g. AGENTS.md), that path is dead — compose writes only to `ABSPATH + convention_path`. Consumers reading the reported path see a stale or missing file.
- Route every entry through the registry's existing canonical resolver (`MemoryFileRegistry::resolve_filepath()`), the same call `ComposableFileGenerator` and write paths use.
- JSON output gains a `convention_path` field so consumers can detect overrides without re-reading the registry.

## Repro on a fresh install with AGENTS.md registered via DMC's section

```
$ wp datamachine memory paths --format=json | jq '.files["AGENTS.md"]'
{
  "layer": "shared",
  "path": "/wordpress/wp-content/uploads/datamachine-files/shared/AGENTS.md",
  "relative": "wp-content/uploads/datamachine-files/shared/AGENTS.md",
  "exists": true   # only "true" if a stale pre-v0.67.0 file is hanging around
}
```

`compose` actually writes to `/wordpress/AGENTS.md`. The reported path is whatever leftover exists at the layer dir, which on a fresh install would be `exists: false` and on an upgraded install is a stale snapshot from before v0.67.0.

## After

```
$ wp datamachine memory paths --format=json | jq '.files["AGENTS.md"]'
{
  "layer": "shared",
  "path": "/wordpress/AGENTS.md",
  "relative": "AGENTS.md",
  "exists": true,
  "convention_path": "AGENTS.md"
}
```

`paths` now agrees with where `compose` actually writes.

## Why this matters

- Setup scripts and config injectors rely on `paths --relative` to know where to inject memory files. They were getting the wrong location for AGENTS.md.
- Agents discovering memory files via `paths` were silently being pointed at stale or empty layer-dir copies.
- The `relative_files` array (the canonical `agents-md-files` list) was also wrong for any convention-path file.

## Implementation

`MemoryCommand::paths()`:
- Loop builds `path` for each entry using `MemoryFileRegistry::resolve_filepath()` (existing API, since v0.67.0).
- JSON branch and table branch both read `$entry['path']` instead of recomputing from `directory + filename`.
- JSON `files` entries gain a `convention_path` field; empty string for layer-only files. No breaking change to existing fields.
- The `layer` field stays — still useful metadata for grouping, still drives directory ownership for non-convention files.

Layer-only files (SITE.md, RULES.md, SOUL.md, USER.md, MEMORY.md, NETWORK.md) are unchanged because `resolve_filepath` falls back to `{layer_dir}/{filename}` when `convention_path` is empty.

## Validation

Ran live on `intelligence-chubes4`:

```
$ studio wp datamachine memory paths --format=table --relative
+------------+---------+------------------------------------+--------+
| file       | layer   | path                               | exists |
+------------+---------+------------------------------------+--------+
| AGENTS.md  | shared  | AGENTS.md                          | yes    |
| SITE.md    | shared  | wp-content/.../shared/SITE.md      | yes    |
| RULES.md   | shared  | wp-content/.../shared/RULES.md     | yes    |
| SOUL.md    | agent   | wp-content/.../agents/.../SOUL.md  | yes    |
| USER.md    | user    | wp-content/.../users/1/USER.md     | yes    |
| MEMORY.md  | agent   | wp-content/.../agents/.../MEMORY.md| yes    |
| NETWORK.md | network | wp-content/.../network/NETWORK.md  | no     |
+------------+---------+------------------------------------+--------+
```

`AGENTS.md` row now points at the convention path. The other rows are unchanged. `php -l` clean.

## Out of scope

- Stale layer-dir AGENTS.md files left over from pre-v0.67.0 installs are not deleted by this PR. That belongs in `compose` (separate PR).
- `convention_path` was a v0.66.0 addition; the layer/path mismatch has been a latent bug since v0.67.0 made the convention path write-only.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** noticed the path mismatch while reading composed AGENTS.md output mid-task, traced the reporting code in MemoryCommand vs the existing canonical resolver in MemoryFileRegistry, drafted the fix, ran live `paths` before/after on intelligence-chubes4 to verify.