### PR TITLE
fix(compose): remove pre-v0.67.0 layer-dir copy when convention_path applies

### DIFF
--- a/inc/Engine/AI/ComposableFileGenerator.php
+++ b/inc/Engine/AI/ComposableFileGenerator.php
@@ -23,10 +23,15 @@ class ComposableFileGenerator {
 	/**
 	 * Regenerate a single composable file from its registered sections.
 	 *
-	 * Generates content via SectionRegistry, writes to the layer directory,
-	 * and optionally writes a convention copy at ABSPATH + convention_path.
+	 * Generates content via SectionRegistry. For files with a `convention_path`
+	 * the file is written ONLY at `ABSPATH + convention_path` (since v0.67.0);
+	 * any pre-v0.67.0 copy in the layer directory is removed so consumers don't
+	 * read a frozen snapshot. Files without a `convention_path` write to their
+	 * layer directory as before.
 	 *
 	 * @since 0.66.0
+	 * @since 0.67.0 Convention-path files write only to the convention path.
+	 * @since x.y.z  Removes pre-v0.67.0 layer-dir copies during regenerate.
 	 *
 	 * @param string $filename Composable filename (e.g. 'AGENTS.md').
 	 * @param array  $context  {
@@ -36,7 +41,7 @@ class ComposableFileGenerator {
 	 *     @type string $agent_slug Agent slug.
 	 *     @type int    $agent_id   Agent ID.
 	 * }
-	 * @return array{success: bool, message: string, filepath?: string}
+	 * @return array{success: bool, message: string, filepath?: string, stale_removed?: string}
 	 */
 	public static function regenerate( string $filename, array $context = array() ): array {
 		$meta = MemoryFileRegistry::get( $filename );
@@ -75,9 +80,23 @@ class ComposableFileGenerator {
 		// Resolve write target.
 		// Files with a convention_path write ONLY to that path (e.g. AGENTS.md → site root).
 		// Files without one write to their layer directory as before.
+		$stale_layer_path = '';
 		if ( ! empty( $meta['convention_path'] ) ) {
 			$filepath  = rtrim( ABSPATH, '/' ) . '/' . $meta['convention_path'];
 			$directory = dirname( $filepath );
+
+			// Pre-v0.67.0 versions wrote to the layer dir; the convention_path
+			// flag only controls writes now. If a stale layer-dir copy exists
+			// from before the migration, remove it so consumers reading the
+			// layer dir don't get pointed at a frozen snapshot. Resolving the
+			// directory must not fail the regenerate — cleanup is best-effort.
+			$layer_dir = ScaffoldAbilities::resolve_directory( $meta['layer'], $context );
+			if ( $layer_dir ) {
+				$candidate = trailingslashit( $layer_dir ) . $filename;
+				if ( $candidate !== $filepath && file_exists( $candidate ) ) {
+					$stale_layer_path = $candidate;
+				}
+			}
 		} else {
 			$directory = ScaffoldAbilities::resolve_directory( $meta['layer'], $context );
 
@@ -100,6 +119,17 @@ class ComposableFileGenerator {
 			);
 		}
 
+		// Best-effort cleanup of pre-v0.67.0 layer-dir copy. We only remove the
+		// file when it's at the dead layer-dir path, never the convention_path
+		// itself (those paths are guaranteed different by the check above).
+		$stale_removed = '';
+		if ( '' !== $stale_layer_path ) {
+			$fs = FilesystemHelper::get();
+			if ( $fs && $fs->delete( $stale_layer_path ) ) {
+				$stale_removed = $stale_layer_path;
+			}
+		}
+
 		/**
 		 * Fires after a composable file has been regenerated.
 		 *
@@ -113,11 +143,15 @@ class ComposableFileGenerator {
 		do_action( 'datamachine_composable_regenerated', $filename, $filepath, $context );
 
 		$message = sprintf( 'Regenerated %s at %s (%d sections).', $filename, $filepath, count( SectionRegistry::get_sections( $filename ) ) );
+		if ( '' !== $stale_removed ) {
+			$message .= sprintf( ' Removed stale layer-dir copy at %s.', $stale_removed );
+		}
 
 		return array(
-			'success'  => true,
-			'message'  => $message,
-			'filepath' => $filepath,
+			'success'       => true,
+			'message'       => $message,
+			'filepath'      => $filepath,
+			'stale_removed' => $stale_removed,
 		);
 	}
 


### PR DESCRIPTION
## Summary

- Pre-v0.67.0 versions of `ComposableFileGenerator` wrote convention-path files (like `AGENTS.md`) to BOTH the convention path AND the layer dir. Since v0.67.0, only the convention path is written.
- The leftover layer-dir copy from before the migration becomes a frozen snapshot — it never updates, but consumers who walk the layer directories still find and read it.
- Fix: during `regenerate()`, when a file has a `convention_path`, also resolve the layer-dir candidate and delete it if present. Best-effort, never blocks the regenerate.

## Repro

On any install upgraded through v0.67.0 with AGENTS.md or another convention-path file:

```
$ ls -la wp-content/uploads/datamachine-files/shared/AGENTS.md
-rw-rw-r--  1 chubes  staff  6357 Apr 15 22:37  ...AGENTS.md   ← frozen at upgrade time

$ wp datamachine memory compose AGENTS.md
Success: Regenerated AGENTS.md at /wordpress/AGENTS.md (5 sections).

$ diff /wordpress/AGENTS.md wp-content/.../shared/AGENTS.md
[diverged: only /wordpress/AGENTS.md got the regen, the layer-dir copy is months stale]
```

This was observed on `intelligence-chubes4` where the shared-layer AGENTS.md still carried the old `### Data Machine` heading and the `datamachine agent paths` verb a full release cycle after the section moved.

## After

```
$ echo 'test stale' > wp-content/uploads/datamachine-files/shared/AGENTS.md
$ wp datamachine memory compose AGENTS.md
Success: Regenerated AGENTS.md at /wordpress/AGENTS.md (5 sections).
         Removed stale layer-dir copy at /wordpress/wp-content/uploads/datamachine-files/shared/AGENTS.md.

$ ls wp-content/uploads/datamachine-files/shared/AGENTS.md
ls: ...: No such file or directory
```

After the next compose, the install converges on a clean state. Idempotent — once the stale copy is gone, subsequent regenerates report `stale_removed: ''` and silently no-op.

## Implementation

In `ComposableFileGenerator::regenerate()`:

1. After resolving `$filepath` from `convention_path`, also call `ScaffoldAbilities::resolve_directory()` to get the layer dir.
2. Build the layer-dir candidate path.
3. If the candidate path differs from the convention path AND the file exists at the candidate, mark it as stale.
4. After the convention-path write succeeds, delete the stale path via `FilesystemHelper::get()->delete()`.
5. If layer dir can't be resolved, or the delete fails, regenerate still succeeds — the cleanup is best-effort.

The `!== $filepath` guard is defense-in-depth; ABSPATH and the layer dir are guaranteed different but the check makes the intent explicit and protects against an unforeseen registry config where a misconfigured `convention_path` happens to land in the layer dir.

## Return value

The result array gains a `stale_removed` key:
- `''` (empty string) when nothing was cleaned (no stale file, or no convention_path).
- The deleted absolute path on success.

The success message also surfaces the cleanup:

```
Regenerated AGENTS.md at /wordpress/AGENTS.md (5 sections). Removed stale layer-dir copy at /wordpress/wp-content/uploads/datamachine-files/shared/AGENTS.md.
```

Existing consumers reading `success`, `message`, or `filepath` are unaffected.

## Validation

Live on `intelligence-chubes4`:

```
$ echo 'test stale' > wp-content/uploads/datamachine-files/shared/AGENTS.md
$ ls -la wp-content/uploads/datamachine-files/shared/AGENTS.md
-rw-r--r-- 1 chubes  staff   11 Apr 25 16:41 ...AGENTS.md
$ studio wp datamachine memory compose AGENTS.md
Success: Regenerated AGENTS.md at /wordpress/AGENTS.md (5 sections). Removed stale layer-dir copy at /wordpress/wp-content/uploads/datamachine-files/shared/AGENTS.md.
$ ls wp-content/uploads/datamachine-files/shared/AGENTS.md
[no such file]
```

`php -l` clean.

## Out of scope

- One-shot migration cleanup. This PR cleans on next compose, which is good enough — every install runs compose during normal operation. No DB migration step needed.
- The mirror bug in `wp datamachine memory paths` (reports the dead layer-dir path for convention-path files) is a separate concern and shipped in #1233.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** spotted the divergence between the project AGENTS.md and the shared-layer AGENTS.md while doing a separate change (DMC #63) and recomposing memory; traced the cause to the v0.67.0 migration; drafted the cleanup hook; live-tested on intelligence-chubes4.