### PR TITLE
fix(fetch): document queueable patch shape contract + log merged_keys

### DIFF
--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -111,9 +111,10 @@ class FetchStep extends Step {
 				'info',
 				'Fetch step merged queued config patch',
 				array(
-					'flow_step_id'  => $this->flow_step_id,
-					'patch_keys'    => array_keys( $queue_result['patch'] ),
-					'queued_at'     => $queue_result['added_at'],
+					'flow_step_id' => $this->flow_step_id,
+					'patch_keys'   => array_keys( $queue_result['patch'] ),
+					'merged_keys'  => array_keys( $handler_settings ),
+					'queued_at'    => $queue_result['added_at'],
 				)
 			);
 		}

--- a/inc/Core/Steps/QueueableTrait.php
+++ b/inc/Core/Steps/QueueableTrait.php
@@ -85,11 +85,32 @@ trait QueueableTrait {
 	 * is a structured config dict rather than a scalar prompt. The popped
 	 * prompt string is JSON-decoded and returned as an array.
 	 *
-	 * Typical use: fetch step pops a date-window dict
-	 * (e.g. `{"after":"2015-05-01","before":"2015-06-01"}` or
-	 * `{"params":{"after":"2015-05-01","before":"2015-06-01"}}`) and the
-	 * caller deep-merges it into the existing handler config to drive
-	 * windowed retroactive backfills.
+	 * Typical use: fetch step pops a config patch and the caller
+	 * deep-merges it into the existing handler config to drive windowed
+	 * retroactive backfills, rotating sources, or any other per-tick
+	 * config rotation.
+	 *
+	 * **Patch shape must mirror the handler's static config shape.** The
+	 * merge is opaque (it knows nothing about handler-specific layout),
+	 * so a key in the patch lands at the same nesting depth in the
+	 * handler config. For example, the MCP fetch handler stores its tool
+	 * parameters as a JSON-encoded string under the `params` key, so a
+	 * date-window patch for an MCP flow must nest the date keys inside
+	 * `params`:
+	 *
+	 *   {"params":{"after":"2015-05-01","before":"2015-06-01"}}
+	 *
+	 * For a handler whose params live at the top level (e.g. RSS, which
+	 * reads `$config['feed_url']` directly), a top-level patch shape is
+	 * correct:
+	 *
+	 *   {"feed_url":"https://example.com/feed.xml"}
+	 *
+	 * If the patch is shaped at the wrong nesting level the keys will
+	 * land on top-level config slots the handler never reads, and they
+	 * will be silently ignored downstream. The merge log line includes
+	 * both `patch_keys` and `merged_keys` to make this kind of
+	 * mis-shaping visible at debug time.
 	 *
 	 * Empty queue and disabled queue both return `from_queue: false` with
 	 * an empty patch — callers can branch on that to either skip the tick

--- a/tests/queueable-trait-smoke.php
+++ b/tests/queueable-trait-smoke.php
@@ -238,4 +238,43 @@ dm_assert(
 	'empty + empty = empty'
 );
 
+// -----------------------------------------------------------------
+echo "\n[13] flat-shaped patch lands top-level — contract check (issue #1235)\n";
+// When a user incorrectly shapes the patch flat instead of nesting under
+// `params`, the keys land at top level alongside the JSON-encoded
+// `params` field. The handler ignores them because it only reads
+// `$config['params']`. This test locks the documented contract: the
+// merge is opaque, and a misshapen patch produces an observable shape
+// (top-level keys present, JSON params unchanged) rather than silent
+// success or silent failure.
+$static_config = array(
+	'server'   => 'a8c',
+	'provider' => 'mgs',
+	'tool'     => 'search',
+	'params'   => '{"query":"WooCommerce"}',
+);
+$wrong_shape = array(
+	'query'  => 'WooCommerce',
+	'after'  => '2026-04-01',
+	'before' => '2026-04-25',
+);
+$merged = $harness->publicMerge( $static_config, $wrong_shape );
+
+dm_assert(
+	'{"query":"WooCommerce"}' === $merged['params'],
+	'JSON-encoded params untouched when patch keys do not match the params key'
+);
+dm_assert( 'WooCommerce' === $merged['query'], 'flat patch key landed at top level (where handler will not read it)' );
+dm_assert( '2026-04-01' === $merged['after'], 'flat after lands at top level' );
+dm_assert( '2026-04-25' === $merged['before'], 'flat before lands at top level' );
+// merged_keys log: comparing patch_keys ["query","after","before"] to
+// merged_keys ["server","provider","tool","params","query","after","before"]
+// surfaces the mis-shaping — the keys are present but alongside `params`
+// rather than inside it.
+$expected_merged_keys = array( 'server', 'provider', 'tool', 'params', 'query', 'after', 'before' );
+dm_assert(
+	$expected_merged_keys === array_keys( $merged ),
+	'merged_keys log surfaces the mis-shaping: patch keys sit alongside params, not inside it'
+);
+
 echo "\n=== queueable-trait-smoke: ALL PASS ===\n";


### PR DESCRIPTION
Closes #1235.

## Summary

- Rewrite `popQueuedConfigPatch()` docblock to spell out the shape contract with two worked examples (MCP nested under `params`, RSS flat). Calls out the silent-drop failure mode and points at the new `merged_keys` log breadcrumb.
- Add `merged_keys` to the `Fetch step merged queued config patch` log entry. Comparing `patch_keys` to `merged_keys` makes mis-shaping visible: a flat MCP-shaped patch shows up as top-level keys sitting alongside `params` instead of inside it.
- Add smoke test [13] locking the contract: a flat-shaped patch into a config with a JSON-encoded `params` field leaves `params` untouched and the patch keys land at top level. This is the exact shape the issue reproducer hits.

**No behavior change. Docs + observability only.**

## Diagnosis (alternative interpretation in #1235 turned out to be right)

The issue's reproducer:

```bash
studio wp datamachine flow queue add 2 \
  '{"query":"WooCommerce","after":"2026-04-01","before":"2026-04-25"}'
```

Logged `patch_keys: ["query","after","before"]` but the next line showed `params: {"query":"WooCommerce"}`.

The hypothesis was that `QueueableTrait` whitelist-filters keys. It does not — the trait is a fully opaque deep-merge. Tracing the data flow:

1. `FetchStep::executeStep()` calls `popQueuedConfigPatch()` → `mergeQueuedConfigPatch($handler_settings, $patch)`.
2. The trait merges the patch top-level into `$handler_settings` top-level. The patch had `query`, `after`, `before` as **flat top-level keys**.
3. `MCPFetchHandler` reads tool params via `$config['params']` (a JSON-encoded string) → `resolveParams()` decodes it. The handler does NOT scan the rest of the config for additional top-level params.
4. So flat patch keys land alongside `params`, get silently ignored by the handler, and the original JSON-encoded `{"query":"WooCommerce"}` is what reaches the MCP tool call.

The trait's smoke test [10] (added when the queueable feature shipped) already exercises the **correct** nested shape and confirms it works:

```php
$queued_patch = array(
    'params' => array(
        'after'  => '2017-03-01',
        'before' => '2017-04-01',
    ),
);
```

So the trait + handler are correct — the bug is the docblock previously suggesting the flat shape was supported, and the absence of any log signal making the silent drop visible.

## Fix shape

**No-shim**: did not add an MCP-specific allowlist or auto-promote unknown top-level keys into JSON-encoded sub-fields. The trait must remain opaque (it serves AI step too, which uses a totally different payload shape). Fixing the docs and adding observability is the right move.

User-facing remediation (no code change needed, just patch shape):

```diff
- {"query":"WC","after":"2026-04-01","before":"2026-04-25"}
+ {"params":{"query":"WC","after":"2026-04-01","before":"2026-04-25"}}
```

After this PR, a user hitting the same mistake will see:

```
Fetch step merged queued config patch
  patch_keys: ["query","after","before"]
  merged_keys: ["server","provider","tool","params","query","after","before"]
```

The presence of `query`, `after`, `before` at top level **alongside** `params` is the giveaway: those keys should have been nested inside `params`. The wiki doc for the WooCommerce backfill pattern needs the same correction (followup, downstream).

## Tests

- `tests/queueable-trait-smoke.php` — 13 cases (was 12), 1455 assertions. New case [13] locks the contract for the exact shape from #1235.

```
$ php tests/queueable-trait-smoke.php
=== queueable-trait-smoke ===
... [snip] ...
[13] flat-shaped patch lands top-level — contract check (issue #1235)
  [PASS] JSON-encoded params untouched when patch keys do not match the params key
  [PASS] flat patch key landed at top level (where handler will not read it)
  [PASS] flat after lands at top level
  [PASS] flat before lands at top level
  [PASS] merged_keys log surfaces the mis-shaping: patch keys sit alongside params, not inside it

=== queueable-trait-smoke: ALL PASS ===
```

## Out of scope

- Live verify on intelligence-chubes4 — the live site's `data-machine` symlink currently points at a different worktree, and the changes are docs + log-field-only. The smoke test exhaustively covers the merge logic. Live signal will land naturally once this is deployed and a user hits the issue reproducer (they'll see the new `merged_keys` field).
- Wiki update for the WooCommerce backfill pattern (uses the wrong shape in its example) — separate doc-fix in the intelligence repo.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.5 (via Kimaki / Claude Code)
- **Used for:** Traced the data flow from `FetchStep::executeStep` through `mergeQueuedConfigPatch` to `MCPFetchHandler::resolveParams` to identify the root cause as docs + observability (not a deep-merge bug). Reviewed pre-existing in-progress edits on this branch (docblock rewrite + `merged_keys` log addition) and confirmed they match the right fix shape under the no-shim rule. Authored smoke test [13] to lock the contract. All assertions in the test were run against the actual code locally and pass; the diagnosis cross-checked the existing 12 smoke tests (which already covered the nested-correct shape via case [10]).