### PR TITLE
fix(cli): processed-items audit honors --pipeline filter and works on SQLite

### DIFF
--- a/inc/Cli/Commands/ProcessedItemsCommand.php
+++ b/inc/Cli/Commands/ProcessedItemsCommand.php
@@ -65,7 +65,7 @@ class ProcessedItemsCommand extends BaseCommand {
 		global $wpdb;
 
 		$handler_filter  = $assoc_args['handler'] ?? null;
-		$pipeline_filter = $assoc_args['pipeline'] ?? null;
+		$pipeline_filter = isset( $assoc_args['pipeline'] ) ? (int) $assoc_args['pipeline'] : null;
 		$min_waste       = (int) ( $assoc_args['min-waste'] ?? 10 );
 		$format          = $assoc_args['format'] ?? 'table';
 
@@ -73,12 +73,21 @@ class ProcessedItemsCommand extends BaseCommand {
 		$table = $db->get_table_name();
 
 		// Get processed items grouped by flow_step_id and source_type.
+		// Pipeline + flow IDs are parsed from flow_step_id in PHP (deterministic prefix
+		// {pipeline_id}_{uuid}_{flow_id}); avoiding SQL string functions like
+		// SUBSTRING_INDEX keeps this portable across MySQL and the SQLite drop-in.
 		$where_clauses = array();
 		$prepare_args  = array( $table );
 
 		if ( $handler_filter ) {
 			$where_clauses[] = 'source_type = %s';
 			$prepare_args[]  = $handler_filter;
+		}
+
+		if ( null !== $pipeline_filter ) {
+			// flow_step_id always begins with the pipeline_id followed by an underscore.
+			$where_clauses[] = 'flow_step_id LIKE %s';
+			$prepare_args[]  = $wpdb->esc_like( (string) $pipeline_filter ) . '_%';
 		}
 
 		$where_sql = ! empty( $where_clauses ) ? 'WHERE ' . implode( ' AND ', $where_clauses ) : '';
@@ -91,8 +100,7 @@ class ProcessedItemsCommand extends BaseCommand {
 					source_type,
 					COUNT(*) as processed_count,
 					MIN(processed_timestamp) as first_processed,
-					MAX(processed_timestamp) as last_processed,
-					CAST(SUBSTRING_INDEX(flow_step_id, '_', -1) AS UNSIGNED) as flow_id
+					MAX(processed_timestamp) as last_processed
 				FROM %i
 				{$where_sql}
 				GROUP BY flow_step_id, source_type
@@ -107,19 +115,22 @@ class ProcessedItemsCommand extends BaseCommand {
 			return;
 		}
 
-		// Enrich with flow names and filter by pipeline.
+		// Enrich with flow names; pipeline_id and flow_id come from the flow_step_id prefix.
 		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
 		$rows     = array();
 
 		foreach ( $results as $row ) {
-			$flow_id = (int) $row['flow_id'];
-			$flow    = $db_flows->get_flow( $flow_id );
-
-			if ( ! $flow ) {
+			$ids = $this->parse_flow_step_id( (string) $row['flow_step_id'] );
+			if ( null === $ids ) {
+				// Malformed flow_step_id — skip rather than misattribute.
 				continue;
 			}
 
-			if ( $pipeline_filter && (int) $flow['pipeline_id'] !== (int) $pipeline_filter ) {
+			$pipeline_id = $ids['pipeline_id'];
+			$flow_id     = $ids['flow_id'];
+
+			// Defensive: skip rows that slipped past the LIKE filter (shouldn't happen).
+			if ( null !== $pipeline_filter && $pipeline_id !== $pipeline_filter ) {
 				continue;
 			}
 
@@ -130,10 +141,13 @@ class ProcessedItemsCommand extends BaseCommand {
 				continue;
 			}
 
+			$flow      = $db_flows->get_flow( $flow_id );
+			$flow_name = is_array( $flow ) ? ( $flow['flow_name'] ?? '(deleted)' ) : '(deleted)';
+
 			$rows[] = array(
 				'flow_id'     => $flow_id,
-				'flow_name'   => $flow['flow_name'] ?? '?',
-				'pipeline_id' => $flow['pipeline_id'] ?? '?',
+				'flow_name'   => $flow_name,
+				'pipeline_id' => $pipeline_id,
 				'handler'     => $row['source_type'],
 				'processed'   => $processed,
 				'first_seen'  => $row['first_processed'],
@@ -152,6 +166,40 @@ class ProcessedItemsCommand extends BaseCommand {
 		WP_CLI::log( '' );
 
 		WP_CLI\Utils\format_items( $format, $rows, array_keys( $rows[0] ) );
+	}
+
+	/**
+	 * Parse pipeline_id and flow_id from a flow_step_id.
+	 *
+	 * Format: {pipeline_id}_{uuid}_{flow_id}, where pipeline_id and flow_id are
+	 * positive integers and uuid is a v4 UUID (contains dashes, no underscores).
+	 *
+	 * @param string $flow_step_id Composite flow step ID.
+	 * @return array{pipeline_id:int,flow_id:int}|null Null when the input is malformed.
+	 */
+	private function parse_flow_step_id( string $flow_step_id ): ?array {
+		if ( '' === $flow_step_id ) {
+			return null;
+		}
+
+		$first_underscore = strpos( $flow_step_id, '_' );
+		$last_underscore  = strrpos( $flow_step_id, '_' );
+
+		if ( false === $first_underscore || false === $last_underscore || $first_underscore === $last_underscore ) {
+			return null;
+		}
+
+		$pipeline_part = substr( $flow_step_id, 0, $first_underscore );
+		$flow_part     = substr( $flow_step_id, $last_underscore + 1 );
+
+		if ( ! ctype_digit( $pipeline_part ) || ! ctype_digit( $flow_part ) ) {
+			return null;
+		}
+
+		return array(
+			'pipeline_id' => (int) $pipeline_part,
+			'flow_id'     => (int) $flow_part,
+		);
 	}
 
 	/**

--- a/tests/processed-items-flow-step-parse-smoke.php
+++ b/tests/processed-items-flow-step-parse-smoke.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Pure-PHP smoke test for ProcessedItemsCommand::parse_flow_step_id().
+ *
+ * Run with: php tests/processed-items-flow-step-parse-smoke.php
+ *
+ * Covers the deterministic prefix/suffix parser that powers
+ * `wp datamachine processed-items audit --pipeline=N`. The full audit
+ * query is exercised against MySQL/SQLite via live runs; this harness
+ * just locks down the parser shape so SUBSTRING_INDEX never sneaks back.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// Stub the WP-CLI base class hierarchy enough to load ProcessedItemsCommand.
+if ( ! class_exists( 'WP_CLI' ) ) {
+	class WP_CLI {
+		public static function log( $msg ) {}
+		public static function error( $msg ) {}
+		public static function success( $msg ) {}
+		public static function confirm( $msg ) {}
+	}
+}
+
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+	class WP_CLI_Command {}
+}
+
+// Stub plugin classes that ProcessedItemsCommand references at file load time.
+if ( ! class_exists( 'DataMachine\\Cli\\BaseCommand' ) ) {
+	eval( 'namespace DataMachine\\Cli; class BaseCommand extends \\WP_CLI_Command {}' );
+}
+
+if ( ! class_exists( 'DataMachine\\Abilities\\ProcessedItemsAbilities' ) ) {
+	eval( 'namespace DataMachine\\Abilities; class ProcessedItemsAbilities {}' );
+}
+
+if ( ! class_exists( 'DataMachine\\Core\\Database\\ProcessedItems\\ProcessedItems' ) ) {
+	eval( 'namespace DataMachine\\Core\\Database\\ProcessedItems; class ProcessedItems { public function get_table_name(): string { return "wp_datamachine_processed_items"; } }' );
+}
+
+require_once __DIR__ . '/../inc/Cli/Commands/ProcessedItemsCommand.php';
+
+use DataMachine\Cli\Commands\ProcessedItemsCommand;
+
+function dm_assert( bool $cond, string $msg ): void {
+	if ( $cond ) {
+		echo "  [PASS] {$msg}\n";
+		return;
+	}
+	echo "  [FAIL] {$msg}\n";
+	exit( 1 );
+}
+
+$method = new ReflectionMethod( ProcessedItemsCommand::class, 'parse_flow_step_id' );
+if ( PHP_VERSION_ID < 80100 ) {
+	$method->setAccessible( true );
+}
+$cmd = new ProcessedItemsCommand();
+
+$parse = static function ( string $input ) use ( $method, $cmd ) {
+	return $method->invoke( $cmd, $input );
+};
+
+echo "Test 1: canonical {pipeline_id}_{uuid}_{flow_id} shape\n";
+$result = $parse( '2_0978b49e-a5a1-46e6-ae3a-0bf62ccea60d_2' );
+dm_assert( is_array( $result ), 'returns an array for canonical input' );
+dm_assert( 2 === $result['pipeline_id'], 'pipeline_id parsed from prefix' );
+dm_assert( 2 === $result['flow_id'], 'flow_id parsed from suffix' );
+
+echo "Test 2: multi-digit pipeline + flow ids\n";
+$result = $parse( '42_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee_137' );
+dm_assert( 42 === $result['pipeline_id'], 'multi-digit pipeline_id' );
+dm_assert( 137 === $result['flow_id'], 'multi-digit flow_id' );
+
+echo "Test 3: pipeline_id and flow_id can match without aliasing the uuid\n";
+$result = $parse( '7_xxxx-yyyy-zzzz_7' );
+dm_assert( 7 === $result['pipeline_id'], 'leading 7' );
+dm_assert( 7 === $result['flow_id'], 'trailing 7 — different segment' );
+
+echo "Test 4: malformed inputs return null\n";
+dm_assert( null === $parse( '' ), 'empty string' );
+dm_assert( null === $parse( '2' ), 'no underscore' );
+dm_assert( null === $parse( '2_uuid' ), 'single underscore (no flow_id segment)' );
+dm_assert( null === $parse( 'abc_uuid_2' ), 'non-numeric pipeline_id' );
+dm_assert( null === $parse( '2_uuid_abc' ), 'non-numeric flow_id' );
+dm_assert( null === $parse( '_uuid_2' ), 'empty pipeline_id segment' );
+dm_assert( null === $parse( '2_uuid_' ), 'empty flow_id segment' );
+
+echo "\nAll smoke checks passed.\n";


### PR DESCRIPTION
## Summary

Closes #1191. `wp datamachine processed-items audit --pipeline=N` returned `'No processed items found.'` even when the `wp_datamachine_processed_items` table was populated for that pipeline.

## Root cause (different from the issue's hypothesis)

The issue guessed at a broken JOIN. The actual bug is a stack of two:

1. **`SUBSTRING_INDEX` is MySQL-only.** The audit query used `CAST(SUBSTRING_INDEX(flow_step_id, '_', -1) AS UNSIGNED) as flow_id` to extract `flow_id` for an in-PHP `Flows::get_flow()` lookup. SQLite (via the sqlite-database-integration drop-in used by Studio + intelligence-chubes4) returns `SQLSTATE[HY000]: General error: 1 no such function: SUBSTRING_INDEX` and the entire `$results` array is empty. The "No processed items found." log line fires before any pipeline filtering ever runs.
2. **`--pipeline` was never applied at the SQL layer.** Even on real MySQL where `SUBSTRING_INDEX` works, scoping happened in a PHP loop that called `Flows::get_flow($flow_id)` per row and compared `pipeline_id`. The same bug surface (no SQL-side `--pipeline` filter, JOIN-ish PHP work per row) existed behind a different failure mode.

Both `pipeline_id` and `flow_id` are deterministic prefix/suffix segments of `flow_step_id` (`{pipeline_id}_{uuid}_{flow_id}`, where the uuid contains dashes but no underscores). Parsing them in PHP — and pushing `--pipeline` into SQL as a portable `flow_step_id LIKE 'N\_%'` clause — fixes both axes at once.

## Changes

- `inc/Cli/Commands/ProcessedItemsCommand.php`
  - Drop `SUBSTRING_INDEX` from the audit query.
  - Add private `parse_flow_step_id()` helper that returns `{pipeline_id, flow_id}` or `null` for malformed input.
  - Push `--pipeline=N` into SQL as `flow_step_id LIKE %s` (`esc_like` + `_%` suffix), so filtering happens before `GROUP BY`.
  - Make `Flows::get_flow()` enrichment-only: missing flows render as `'(deleted)'` instead of silently dropping rows. Auditing is exactly when you want to see the dedup state for flows that no longer exist.
- `tests/processed-items-flow-step-parse-smoke.php`
  - Pure-PHP smoke test (no PHPUnit dependency) covering canonical input, multi-digit IDs, the `7_..._7` aliasing case, and 7 malformed-input branches.

## Behaviour

| Filter | Before | After |
|--------|--------|-------|
| `--pipeline=2` (rows exist) | `No processed items found.` | Returns matching rows |
| `--pipeline=999` (no rows) | `No processed items found.` | `No processed items found.` (unchanged) |
| `--handler=rss` | Returned 0 rows on SQLite | Returns matching rows |
| `--pipeline=2 --handler=rss` | Returned 0 rows on SQLite | Returns intersection |
| no filter | Returned 0 rows on SQLite | Returns all groups |

## Tests

- New: `tests/processed-items-flow-step-parse-smoke.php` — 14/14 passing.
- Live-verified on intelligence-chubes4 (SQLite via markdown-database-integration drop-in) with synthetic rows for pipelines 2 and 42 plus a non-existent flow id; all five scenarios in the table above behave correctly.

## Out of scope

- The `clear_with_filters()` and `cleanup_orphans()` paths use `flow_step_id LIKE '%_$flow_id'` which is portable and works today; they're not touched here.
- Per-handler `'unknown'` status concern from the issue: appears to have been a side-effect of the same SQLite query failure (zero rows out → can't enumerate handlers). Now fixed via the same change; no separate fix needed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.5 (via Kimaki / Claude Code)
- **Used for:** Drafted the bug analysis, the parse helper, the SQL refactor, and the smoke test. Chris reviewed and live-verified the five behaviour-table scenarios on intelligence-chubes4 against the symlinked worktree before merge.