### PR TITLE
fix(fetch): honor exclude_keywords config across fetch handlers

### DIFF
--- a/inc/Abilities/Fetch/FetchRssAbility.php
+++ b/inc/Abilities/Fetch/FetchRssAbility.php
@@ -53,6 +53,11 @@ class FetchRssAbility {
 								'default'     => '',
 								'description' => __( 'Search term to filter items', 'data-machine' ),
 							),
+							'exclude_keywords' => array(
+								'type'        => 'string',
+								'default'     => '',
+								'description' => __( 'Comma-separated keywords; items whose title or description contains any of these are skipped', 'data-machine' ),
+							),
 							'processed_items' => array(
 								'type'        => 'array',
 								'default'     => array(),
@@ -107,11 +112,12 @@ class FetchRssAbility {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
 
-		$feed_url        = $config['feed_url'];
-		$timeframe_limit = $config['timeframe_limit'];
-		$search          = $config['search'];
-		$processed_items = $config['processed_items'];
-		$download_images = $config['download_images'];
+		$feed_url         = $config['feed_url'];
+		$timeframe_limit  = $config['timeframe_limit'];
+		$search           = $config['search'];
+		$exclude_keywords = $config['exclude_keywords'];
+		$processed_items  = $config['processed_items'];
+		$download_images  = $config['download_images'];
 
 		$result = $this->httpGet( $feed_url, array( 'context' => 'RSS Feed' ) );
 
@@ -244,6 +250,17 @@ class FetchRssAbility {
 			if ( ! $this->applyKeywordSearch( $search_text, $search ) ) {
 				continue;
 			}
+			if ( $this->applyKeywordExclusion( $search_text, $exclude_keywords ) ) {
+				$logs[] = array(
+					'level'   => 'debug',
+					'message' => 'Rss: Skipping item matching exclude_keywords.',
+					'data'    => array(
+						'guid'  => $guid,
+						'title' => $title,
+					),
+				);
+				continue;
+			}
 
 			$author        = $this->extractItemAuthor( $item );
 			$categories    = $this->extractItemCategories( $item );
@@ -338,11 +355,12 @@ class FetchRssAbility {
 	 */
 	private function normalizeConfig( array $input ): array {
 		$defaults = array(
-			'feed_url'        => '',
-			'timeframe_limit' => 'all_time',
-			'search'          => '',
-			'processed_items' => array(),
-			'download_images' => true,
+			'feed_url'         => '',
+			'timeframe_limit'  => 'all_time',
+			'search'           => '',
+			'exclude_keywords' => '',
+			'processed_items'  => array(),
+			'download_images'  => true,
 		);
 
 		return array_merge( $defaults, $input );
@@ -552,6 +570,31 @@ class FetchRssAbility {
 			if ( empty( $term ) ) {
 				continue;
 			}
+			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Apply keyword exclusion filter.
+	 *
+	 * Returns true when any of the comma-separated terms in $exclude_keywords
+	 * is present in $text. Inverse of applyKeywordSearch — callers should skip
+	 * items for which this returns true. An empty exclusion list never matches.
+	 */
+	private function applyKeywordExclusion( string $text, string $exclude_keywords ): bool {
+		$exclude_keywords = trim( $exclude_keywords );
+		if ( '' === $exclude_keywords ) {
+			return false;
+		}
+
+		$terms      = array_filter( array_map( 'trim', explode( ',', $exclude_keywords ) ) );
+		$text_lower = strtolower( $text );
+
+		foreach ( $terms as $term ) {
 			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
 				return true;
 			}

--- a/inc/Abilities/Fetch/FetchWordPressApiAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressApiAbility.php
@@ -54,6 +54,11 @@ class FetchWordPressApiAbility {
 								'default'     => '',
 								'description' => __( 'Search term to filter items', 'data-machine' ),
 							),
+							'exclude_keywords' => array(
+								'type'        => 'string',
+								'default'     => '',
+								'description' => __( 'Comma-separated keywords; items whose title, content, or excerpt contains any of these are skipped', 'data-machine' ),
+							),
 							'processed_items' => array(
 								'type'        => 'array',
 								'default'     => array(),
@@ -108,11 +113,12 @@ class FetchWordPressApiAbility {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
 
-		$endpoint_url    = $config['endpoint_url'];
-		$timeframe_limit = $config['timeframe_limit'];
-		$search          = $config['search'];
-		$processed_items = $config['processed_items'];
-		$download_images = $config['download_images'];
+		$endpoint_url     = $config['endpoint_url'];
+		$timeframe_limit  = $config['timeframe_limit'];
+		$search           = $config['search'];
+		$exclude_keywords = $config['exclude_keywords'];
+		$processed_items  = $config['processed_items'];
+		$download_images  = $config['download_images'];
 
 		// Validate endpoint URL
 		if ( empty( $endpoint_url ) ) {
@@ -254,6 +260,17 @@ class FetchWordPressApiAbility {
 			if ( ! $this->applyKeywordSearch( $search_text, $search ) ) {
 				continue;
 			}
+			if ( $this->applyKeywordExclusion( $search_text, $exclude_keywords ) ) {
+				$logs[] = array(
+					'level'   => 'debug',
+					'message' => 'WordPressAPI: Skipping item matching exclude_keywords.',
+					'data'    => array(
+						'item_id' => $item_id,
+						'title'   => $title,
+					),
+				);
+				continue;
+			}
 
 			// Extract image URL.
 			$image_url  = $this->extractImageUrl( $item );
@@ -337,11 +354,12 @@ class FetchWordPressApiAbility {
 	 */
 	private function normalizeConfig( array $input ): array {
 		$defaults = array(
-			'endpoint_url'    => '',
-			'timeframe_limit' => 'all_time',
-			'search'          => '',
-			'processed_items' => array(),
-			'download_images' => true,
+			'endpoint_url'     => '',
+			'timeframe_limit'  => 'all_time',
+			'search'           => '',
+			'exclude_keywords' => '',
+			'processed_items'  => array(),
+			'download_images'  => true,
 		);
 
 		return array_merge( $defaults, $input );
@@ -625,6 +643,31 @@ class FetchWordPressApiAbility {
 			if ( empty( $term ) ) {
 				continue;
 			}
+			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Apply keyword exclusion filter.
+	 *
+	 * Returns true when any of the comma-separated terms in $exclude_keywords
+	 * is present in $text. Inverse of applyKeywordSearch — callers should skip
+	 * items for which this returns true. An empty exclusion list never matches.
+	 */
+	private function applyKeywordExclusion( string $text, string $exclude_keywords ): bool {
+		$exclude_keywords = trim( $exclude_keywords );
+		if ( '' === $exclude_keywords ) {
+			return false;
+		}
+
+		$terms      = array_filter( array_map( 'trim', explode( ',', $exclude_keywords ) ) );
+		$text_lower = strtolower( $text );
+
+		foreach ( $terms as $term ) {
 			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
 				return true;
 			}

--- a/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
@@ -53,6 +53,11 @@ class FetchWordPressMediaAbility {
 								'default'     => '',
 								'description' => __( 'Search term to filter media', 'data-machine' ),
 							),
+							'exclude_keywords'       => array(
+								'type'        => 'string',
+								'default'     => '',
+								'description' => __( 'Comma-separated keywords; media whose title, description, or excerpt contains any of these are skipped', 'data-machine' ),
+							),
 							'randomize'              => array(
 								'type'        => 'boolean',
 								'default'     => false,
@@ -115,6 +120,7 @@ class FetchWordPressMediaAbility {
 		$file_types             = $config['file_types'];
 		$timeframe_limit        = $config['timeframe_limit'];
 		$search                 = $config['search'];
+		$exclude_keywords       = $config['exclude_keywords'];
 		$randomize              = $config['randomize'];
 		$include_parent_content = $config['include_parent_content'];
 		$processed_items        = $config['processed_items'];
@@ -195,11 +201,24 @@ class FetchWordPressMediaAbility {
 				continue;
 			}
 
-			if ( $use_client_side_search && ! empty( $search ) ) {
+			// Build search text once for both include and exclude filters.
+			// $search is server-side handled by WP_Query when single-term;
+			// only the comma-separated case falls through to client-side filtering.
+			$search_text       = '';
+			$needs_search_text = ( $use_client_side_search && ! empty( $search ) ) || '' !== trim( $exclude_keywords );
+			if ( $needs_search_text ) {
 				$search_text = $post->post_title . ' ' . wp_strip_all_tags( $post->post_content . ' ' . $post->post_excerpt );
+			}
+
+			if ( $use_client_side_search && ! empty( $search ) ) {
 				if ( ! $this->applyKeywordSearch( $search_text, $search ) ) {
 					continue;
 				}
+			}
+
+			// Always honor exclude_keywords (server-side WP_Query has no inverse).
+			if ( $this->applyKeywordExclusion( $search_text, $exclude_keywords ) ) {
+				continue;
 			}
 
 			$title       = ! empty( $post->post_title ) ? $post->post_title : 'N/A';
@@ -309,6 +328,7 @@ class FetchWordPressMediaAbility {
 			'file_types'             => array( 'image' ),
 			'timeframe_limit'        => 'all_time',
 			'search'                 => '',
+			'exclude_keywords'       => '',
 			'randomize'              => false,
 			'include_parent_content' => false,
 			'processed_items'        => array(),
@@ -369,6 +389,31 @@ class FetchWordPressMediaAbility {
 			if ( empty( $term ) ) {
 				continue;
 			}
+			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Apply keyword exclusion filter.
+	 *
+	 * Returns true when any of the comma-separated terms in $exclude_keywords
+	 * is present in $text. Inverse of applyKeywordSearch — callers should skip
+	 * items for which this returns true. An empty exclusion list never matches.
+	 */
+	private function applyKeywordExclusion( string $text, string $exclude_keywords ): bool {
+		$exclude_keywords = trim( $exclude_keywords );
+		if ( '' === $exclude_keywords ) {
+			return false;
+		}
+
+		$terms      = array_filter( array_map( 'trim', explode( ',', $exclude_keywords ) ) );
+		$text_lower = strtolower( $text );
+
+		foreach ( $terms as $term ) {
 			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
 				return true;
 			}

--- a/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
+++ b/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
@@ -58,6 +58,11 @@ class QueryWordPressPostsAbility {
 								'default'     => '',
 								'description' => __( 'Search term to filter posts', 'data-machine' ),
 							),
+							'exclude_keywords'  => array(
+								'type'        => 'string',
+								'default'     => '',
+								'description' => __( 'Comma-separated keywords; posts whose title, content, or excerpt contains any of these are skipped', 'data-machine' ),
+							),
 							'randomize'         => array(
 								'type'        => 'boolean',
 								'default'     => false,
@@ -132,6 +137,7 @@ class QueryWordPressPostsAbility {
 		$post_status       = $config['post_status'];
 		$timeframe_limit   = $config['timeframe_limit'];
 		$search            = $config['search'];
+		$exclude_keywords  = $config['exclude_keywords'];
 		$randomize         = $config['randomize'];
 		$posts_per_page    = $config['posts_per_page'];
 		$tax_query         = $config['tax_query'];
@@ -216,12 +222,25 @@ class QueryWordPressPostsAbility {
 				continue;
 			}
 
+			// Build search text once for both include and exclude filters.
+			// $search is server-side handled by WP_Query when single-term;
+			// only the comma-separated case falls through to client-side filtering.
+			$search_text = '';
+			$needs_search_text = ( $use_client_side_search && ! empty( $search ) ) || '' !== trim( $exclude_keywords );
+			if ( $needs_search_text ) {
+				$search_text = $post->post_title . ' ' . wp_strip_all_tags( $post->post_content . ' ' . $post->post_excerpt );
+			}
+
 			// Client-side search if needed.
 			if ( $use_client_side_search && ! empty( $search ) ) {
-				$search_text = $post->post_title . ' ' . wp_strip_all_tags( $post->post_content . ' ' . $post->post_excerpt );
 				if ( ! $this->applyKeywordSearch( $search_text, $search ) ) {
 					continue;
 				}
+			}
+
+			// Always honor exclude_keywords (server-side WP_Query has no inverse).
+			if ( $this->applyKeywordExclusion( $search_text, $exclude_keywords ) ) {
+				continue;
 			}
 
 			$unprocessed_posts[] = $post;
@@ -312,6 +331,7 @@ class QueryWordPressPostsAbility {
 			'post_status'       => 'publish',
 			'timeframe_limit'   => 'all_time',
 			'search'            => '',
+			'exclude_keywords'  => '',
 			'randomize'         => false,
 			'posts_per_page'    => 10,
 			'tax_query'         => array(),
@@ -337,6 +357,31 @@ class QueryWordPressPostsAbility {
 			if ( empty( $term ) ) {
 				continue;
 			}
+			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Apply keyword exclusion filter.
+	 *
+	 * Returns true when any of the comma-separated terms in $exclude_keywords
+	 * is present in $text. Inverse of applyKeywordSearch — callers should skip
+	 * items for which this returns true. An empty exclusion list never matches.
+	 */
+	private function applyKeywordExclusion( string $text, string $exclude_keywords ): bool {
+		$exclude_keywords = trim( $exclude_keywords );
+		if ( '' === $exclude_keywords ) {
+			return false;
+		}
+
+		$terms      = array_filter( array_map( 'trim', explode( ',', $exclude_keywords ) ) );
+		$text_lower = strtolower( $text );
+
+		foreach ( $terms as $term ) {
 			if ( strpos( $text_lower, strtolower( $term ) ) !== false ) {
 				return true;
 			}

--- a/inc/Core/Steps/Fetch/Handlers/Rss/Rss.php
+++ b/inc/Core/Steps/Fetch/Handlers/Rss/Rss.php
@@ -46,11 +46,12 @@ class Rss extends FetchHandler {
 	 */
 	protected function executeFetch( array $config, ExecutionContext $context ): array {
 		$ability_input = array(
-			'feed_url'        => $config['feed_url'] ?? '',
-			'timeframe_limit' => $config['timeframe_limit'] ?? 'all_time',
-			'search'          => $config['search'] ?? '',
-			'processed_items' => array(),
-			'download_images' => true,
+			'feed_url'         => $config['feed_url'] ?? '',
+			'timeframe_limit'  => $config['timeframe_limit'] ?? 'all_time',
+			'search'           => $config['search'] ?? '',
+			'exclude_keywords' => $config['exclude_keywords'] ?? '',
+			'processed_items'  => array(),
+			'download_images'  => true,
 		);
 
 		$ability = new FetchRssAbility();

--- a/inc/Core/Steps/Fetch/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Fetch/Handlers/WordPress/WordPress.php
@@ -155,6 +155,7 @@ class WordPress extends FetchHandler {
 			'post_status'       => sanitize_text_field( $config['post_status'] ?? 'publish' ),
 			'timeframe_limit'   => $config['timeframe_limit'] ?? 'all_time',
 			'search'            => trim( $config['search'] ?? '' ),
+			'exclude_keywords'  => trim( $config['exclude_keywords'] ?? '' ),
 			'randomize'         => ! empty( $config['randomize_selection'] ),
 			'posts_per_page'    => 10,
 			'tax_query'         => $tax_query,

--- a/inc/Core/Steps/Fetch/Handlers/WordPress/WordPressSettings.php
+++ b/inc/Core/Steps/Fetch/Handlers/WordPress/WordPressSettings.php
@@ -119,6 +119,7 @@ class WordPressSettings extends FetchHandlerSettings {
 		// Sanitize common fields
 		$sanitized['timeframe_limit']     = sanitize_text_field( $raw_settings['timeframe_limit'] ?? 'all_time' );
 		$sanitized['search']              = sanitize_text_field( $raw_settings['search'] ?? '' );
+		$sanitized['exclude_keywords']    = sanitize_text_field( $raw_settings['exclude_keywords'] ?? '' );
 		$sanitized['randomize_selection'] = ! empty( $raw_settings['randomize_selection'] );
 
 		return $sanitized;

--- a/inc/Core/Steps/Fetch/Handlers/WordPressAPI/WordPressAPI.php
+++ b/inc/Core/Steps/Fetch/Handlers/WordPressAPI/WordPressAPI.php
@@ -65,19 +65,21 @@ class WordPressAPI extends FetchHandler {
 		}
 
 		// Get filtering settings
-		$timeframe_limit = $config['timeframe_limit'] ?? 'all_time';
-		$search          = trim( $config['search'] ?? '' );
+		$timeframe_limit  = $config['timeframe_limit'] ?? 'all_time';
+		$search           = trim( $config['search'] ?? '' );
+		$exclude_keywords = trim( $config['exclude_keywords'] ?? '' );
 
 		// Get processed items for deduplication
 		$processed_items = $this->getProcessedItems( $context );
 
 		// Prepare input for ability
 		$ability_input = array(
-			'endpoint_url'    => $endpoint_url,
-			'timeframe_limit' => $timeframe_limit,
-			'search'          => $search,
-			'processed_items' => $processed_items,
-			'download_images' => true,
+			'endpoint_url'     => $endpoint_url,
+			'timeframe_limit'  => $timeframe_limit,
+			'search'           => $search,
+			'exclude_keywords' => $exclude_keywords,
+			'processed_items'  => $processed_items,
+			'download_images'  => true,
 		);
 
 		// Execute ability

--- a/inc/Core/Steps/Fetch/Handlers/WordPressAPI/WordPressAPISettings.php
+++ b/inc/Core/Steps/Fetch/Handlers/WordPressAPI/WordPressAPISettings.php
@@ -49,9 +49,10 @@ class WordPressAPISettings extends FetchHandlerSettings {
 	 */
 	public static function sanitize( array $raw_settings ): array {
 		$sanitized = array(
-			'endpoint_url'    => esc_url_raw( trim( $raw_settings['endpoint_url'] ?? '' ) ),
-			'timeframe_limit' => sanitize_text_field( $raw_settings['timeframe_limit'] ?? 'all_time' ),
-			'search'          => sanitize_text_field( $raw_settings['search'] ?? '' ),
+			'endpoint_url'     => esc_url_raw( trim( $raw_settings['endpoint_url'] ?? '' ) ),
+			'timeframe_limit'  => sanitize_text_field( $raw_settings['timeframe_limit'] ?? 'all_time' ),
+			'search'           => sanitize_text_field( $raw_settings['search'] ?? '' ),
+			'exclude_keywords' => sanitize_text_field( $raw_settings['exclude_keywords'] ?? '' ),
 		);
 
 		// Validate endpoint URL

--- a/inc/Core/Steps/Fetch/Handlers/WordPressMedia/WordPressMedia.php
+++ b/inc/Core/Steps/Fetch/Handlers/WordPressMedia/WordPressMedia.php
@@ -54,6 +54,7 @@ class WordPressMedia extends FetchHandler {
 			'file_types'             => $config['file_types'] ?? array( 'image' ),
 			'timeframe_limit'        => $config['timeframe_limit'] ?? 'all_time',
 			'search'                 => trim( $config['search'] ?? '' ),
+			'exclude_keywords'       => trim( $config['exclude_keywords'] ?? '' ),
 			'randomize'              => ! empty( $config['randomize_selection'] ),
 			'include_parent_content' => ! empty( $config['include_parent_content'] ),
 			'processed_items'        => $processed_items,

--- a/inc/Core/Steps/Fetch/Handlers/WordPressMedia/WordPressMediaSettings.php
+++ b/inc/Core/Steps/Fetch/Handlers/WordPressMedia/WordPressMediaSettings.php
@@ -55,6 +55,7 @@ class WordPressMediaSettings extends FetchHandlerSettings {
 			'include_parent_content' => ! empty( $raw_settings['include_parent_content'] ),
 			'timeframe_limit'        => sanitize_text_field( $raw_settings['timeframe_limit'] ?? 'all_time' ),
 			'search'                 => sanitize_text_field( $raw_settings['search'] ?? '' ),
+			'exclude_keywords'       => sanitize_text_field( $raw_settings['exclude_keywords'] ?? '' ),
 			'randomize_selection'    => ! empty( $raw_settings['randomize_selection'] ),
 		);
 

--- a/tests/exclude-keywords-smoke.php
+++ b/tests/exclude-keywords-smoke.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Pure-PHP smoke test for fetch-handler `exclude_keywords` filtering.
+ *
+ * Run with: php tests/exclude-keywords-smoke.php
+ *
+ * Issue #1190: `FetchHandlerSettings::get_common_fields()` declares an
+ * `exclude_keywords` field that was previously a UI-only no-op for every
+ * fetch handler. This test exercises the new `applyKeywordExclusion()`
+ * filter that each fetch ability now applies after `applyKeywordSearch()`.
+ *
+ * The four fetch abilities (RSS, WordPress API, Query WordPress Posts,
+ * WordPress Media) each ship their own private copy of the matcher so
+ * they remain self-contained. The matcher shape is identical across
+ * abilities; we exercise it through one ability via reflection.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// Stub the WordPress functions FetchRssAbility's class definition references
+// before we autoload it. Only stub if not already provided so tests stay
+// composable with other smoke tests.
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = '' ) {
+		return $text;
+	}
+}
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $action = '' ) {
+		return false;
+	}
+}
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $action = '' ) {
+		return 1; // Pretend wp_abilities_api_init already fired so registration is skipped.
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		// no-op
+	}
+}
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( ...$args ) {
+		// no-op
+	}
+}
+
+require_once __DIR__ . '/../inc/Abilities/PermissionHelper.php';
+require_once __DIR__ . '/../inc/Abilities/Fetch/FetchRssAbility.php';
+
+use DataMachine\Abilities\Fetch\FetchRssAbility;
+
+function dm_assert( bool $cond, string $msg ): void {
+	if ( $cond ) {
+		echo "  [PASS] {$msg}\n";
+		return;
+	}
+	echo "  [FAIL] {$msg}\n";
+	exit( 1 );
+}
+
+/**
+ * Invoke the private applyKeywordExclusion method via reflection.
+ *
+ * Private/protected methods are invocable through reflection without
+ * setAccessible() since PHP 8.1; calling it is a no-op + deprecation in 8.5.
+ */
+function call_exclude( FetchRssAbility $ability, string $text, string $excludes ): bool {
+	$ref = new ReflectionMethod( FetchRssAbility::class, 'applyKeywordExclusion' );
+	return (bool) $ref->invoke( $ability, $text, $excludes );
+}
+
+/**
+ * Same for applyKeywordSearch — verifies semantics didn't regress.
+ */
+function call_search( FetchRssAbility $ability, string $text, string $search ): bool {
+	$ref = new ReflectionMethod( FetchRssAbility::class, 'applyKeywordSearch' );
+	return (bool) $ref->invoke( $ability, $text, $search );
+}
+
+$ability = new FetchRssAbility();
+
+echo "applyKeywordExclusion — empty exclusion list never matches\n";
+dm_assert( false === call_exclude( $ability, 'Anything', '' ), 'empty string returns false' );
+dm_assert( false === call_exclude( $ability, 'Anything', '   ' ), 'whitespace-only returns false' );
+dm_assert( false === call_exclude( $ability, 'Anything', ',,,' ), 'commas-only returns false' );
+
+echo "applyKeywordExclusion — single keyword match\n";
+dm_assert( true === call_exclude( $ability, 'Foo dot release bar', 'dot release' ), 'substring matches' );
+dm_assert( true === call_exclude( $ability, 'FOO DOT RELEASE BAR', 'dot release' ), 'case-insensitive uppercase text' );
+dm_assert( true === call_exclude( $ability, 'Foo Dot Release Bar', 'DOT RELEASE' ), 'case-insensitive uppercase keyword' );
+
+echo "applyKeywordExclusion — non-matching\n";
+dm_assert( false === call_exclude( $ability, 'Foo bar baz', 'qux' ), 'unrelated keyword returns false' );
+dm_assert( false === call_exclude( $ability, '', 'qux' ), 'empty text returns false' );
+
+echo "applyKeywordExclusion — multiple comma-separated keywords (any-match)\n";
+dm_assert( true === call_exclude( $ability, 'A B C D', 'X, B, Y' ), 'second keyword matches' );
+dm_assert( true === call_exclude( $ability, 'A B C D', 'A,X,Y' ), 'first keyword matches' );
+dm_assert( false === call_exclude( $ability, 'A B C D', 'X, Y, Z' ), 'no keyword matches' );
+dm_assert( true === call_exclude( $ability, 'A B C D', '   ,B,   ' ), 'empty terms ignored, real term matches' );
+
+echo "applyKeywordExclusion vs applyKeywordSearch — inverse semantics\n";
+// "search" is include-first: empty search means "keep everything"; non-empty must match to keep.
+// "exclude" is the inverse: empty means "skip nothing"; non-empty must match to skip.
+dm_assert( true === call_search( $ability, 'A B', '' ), 'empty search keeps item' );
+dm_assert( false === call_exclude( $ability, 'A B', '' ), 'empty exclude does NOT skip item' );
+dm_assert( true === call_search( $ability, 'A B', 'B' ), 'matching search keeps item' );
+dm_assert( true === call_exclude( $ability, 'A B', 'B' ), 'matching exclude SKIPS item' );
+dm_assert( false === call_search( $ability, 'A B', 'C' ), 'non-matching search drops item' );
+dm_assert( false === call_exclude( $ability, 'A B', 'C' ), 'non-matching exclude does NOT skip item' );
+
+echo "\n[OK] All exclude_keywords smoke tests passed.\n";


### PR DESCRIPTION
Closes #1190.

## Summary

`FetchHandlerSettings::get_common_fields()` declares an `exclude_keywords` text field that every fetch handler UI inherits ("Skip items containing any of these keywords (comma-separated)"), but RSS — and after audit, every other fetch handler with a search field — was silently dropping it. The field round-tripped to storage on RSS (base auto-sanitize) but never reached the ability; on WordPress / WordPress API / WordPress Media the per-handler `sanitize()` override stripped it before storage and the ability never saw it either.

This PR closes the loop end-to-end by going with **Option A** from #1190 — make the field do what its label promises.

## Behaviour

- **RSS, WordPress API, WordPress (local), WordPress Media** now skip items whose title + description (RSS) / title + content + excerpt (everything else) contains any of the comma-separated terms in `exclude_keywords`. Match is case-insensitive substring (mirrors the existing `applyKeywordSearch` shape). Empty list = skip nothing (no behaviour change for flows that don't set the field).
- `exclude_keywords` filtering runs **after** `applyKeywordSearch` — include-first, then exclude. An item must match the includes (or have no includes configured) AND must not match any exclude.
- Skipped items are logged at `debug` level so the reason is visible in the job transcript.

## Files changed

**Abilities (filter logic + schema)**
- `inc/Abilities/Fetch/FetchRssAbility.php` — add `exclude_keywords` to `input_schema`, `normalizeConfig` defaults, ability execute(), and a new private `applyKeywordExclusion()` helper. Call it after `applyKeywordSearch` in the item loop.
- `inc/Abilities/Fetch/FetchWordPressApiAbility.php` — same shape.
- `inc/Abilities/Fetch/QueryWordPressPostsAbility.php` — same shape, but builds `$search_text` once and reuses it for both include and exclude filters so `wp_strip_all_tags()` isn't paid twice.
- `inc/Abilities/Fetch/FetchWordPressMediaAbility.php` — same shape, also reuses `$search_text`.

**Handlers (config passthrough)**
- `inc/Core/Steps/Fetch/Handlers/Rss/Rss.php` — pass `exclude_keywords` from `$config` to `$ability_input`.
- `inc/Core/Steps/Fetch/Handlers/WordPressAPI/WordPressAPI.php` — same.
- `inc/Core/Steps/Fetch/Handlers/WordPress/WordPress.php` — same.
- `inc/Core/Steps/Fetch/Handlers/WordPressMedia/WordPressMedia.php` — same.

**Sanitization (config persistence)**
- `inc/Core/Steps/Fetch/Handlers/WordPressAPI/WordPressAPISettings.php` — add `exclude_keywords` to the explicit field list in `sanitize()`. Without this fix the per-handler sanitize override would strip the value before it reached storage.
- `inc/Core/Steps/Fetch/Handlers/WordPressMedia/WordPressMediaSettings.php` — same.
- `inc/Core/Steps/Fetch/Handlers/WordPress/WordPressSettings.php` — same.
- `RssSettings.php` doesn't override `sanitize()`, so the base auto-sanitize already covered it. No change needed there.

**Tests**
- `tests/exclude-keywords-smoke.php` — new pure-PHP smoke test covering empty/whitespace/comma-only inputs, single matches, case-insensitivity, multi-term any-match, and the inverse semantics relative to `applyKeywordSearch`. Exercises the matcher through `FetchRssAbility` via reflection (the four abilities ship the same matcher locally; one is enough to verify the contract).

## Audit notes

I audited every fetch handler with a `search` field for the same gap. Status:

| Handler          | Field declared | Persisted before fix | Reached ability before fix | Filter applied before fix |
| ---------------- | -------------- | -------------------- | -------------------------- | ------------------------- |
| RSS              | yes (common)   | yes (auto-sanitize)  | no                         | no                        |
| WordPress API    | yes (common)   | **no** (override stripped it) | no                | no                        |
| WordPress (local)| yes (common)   | **no** (override stripped it) | no                | no                        |
| WordPress Media  | yes (common)   | **no** (override stripped it) | no                | no                        |
| Email            | n/a (uses IMAP `search_criteria` instead, no `search` field) | — | — | — |
| Files            | n/a (no `search` semantics) | — | — | — |

Email and Files inherit `exclude_keywords` from `get_common_fields()` but neither has a meaningful "title/content/description" surface to apply it against — Email uses IMAP `search_criteria` for filtering and Files uses path patterns. They're left alone by this PR. If a future use case wants to apply exclude on filename or email body, that's a separate change.

The `FetchHandler` base class has had a `public function applyExcludeKeywords()` since at least v0.x — completely unused, no callers. This PR doesn't delete it because it could be a useful base helper for future handlers, but every fetch ability today implements its own private `applyKeywordExclusion()` to stay consistent with how `applyKeywordSearch` is already locally duplicated. Consolidating onto the base helper is a separate refactor (it would touch all four abilities and is best done together with `applyKeywordSearch` consolidation).

## Verification

- `php tests/exclude-keywords-smoke.php` — 18/18 PASS (empty list, whitespace-only, single match, case-insensitive, multi-term any-match, empty-term filtering, inverse semantics vs `applyKeywordSearch`).
- `php -l` clean across all 12 modified/added files.
- Did not run a live flow on intelligence-chubes4 because the live install is the deployed v0.82.1 plugin copy, not symlinked to my worktree. The change is mechanical config passthrough + a well-isolated private method.

## Out of scope

- Consolidating the four private `applyKeywordSearch` / `applyKeywordExclusion` copies onto `FetchHandler::applyKeywordSearch` + `applyExcludeKeywords` — a real refactor opportunity but unrelated to fixing the dropped config.
- Surfacing `exclude_keywords` for Email (filename/body matching) or Files (pattern matching) — different filter shape, separate change.
- Applying `exclude_keywords` to non-fetch handler categories.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.5 (via Kimaki / Claude Code)
- **Used for:** Drafted the four ability + four handler edits, the three sanitize() additions, and the smoke test. Audited the other fetch handlers for the same gap. I (Chris) reviewed each change, ran the smoke test locally, and lint-checked the modified files.