### PR TITLE
fix(fetch): document queueable patch shape contract + log merged_keys

### DIFF
--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -111,9 +111,10 @@ class FetchStep extends Step {
 				'info',
 				'Fetch step merged queued config patch',
 				array(
-					'flow_step_id'  => $this->flow_step_id,
-					'patch_keys'    => array_keys( $queue_result['patch'] ),
-					'queued_at'     => $queue_result['added_at'],
+					'flow_step_id' => $this->flow_step_id,
+					'patch_keys'   => array_keys( $queue_result['patch'] ),
+					'merged_keys'  => array_keys( $handler_settings ),
+					'queued_at'    => $queue_result['added_at'],
 				)
 			);
 		}

--- a/inc/Core/Steps/QueueableTrait.php
+++ b/inc/Core/Steps/QueueableTrait.php
@@ -85,11 +85,32 @@ trait QueueableTrait {
 	 * is a structured config dict rather than a scalar prompt. The popped
 	 * prompt string is JSON-decoded and returned as an array.
 	 *
-	 * Typical use: fetch step pops a date-window dict
-	 * (e.g. `{"after":"2015-05-01","before":"2015-06-01"}` or
-	 * `{"params":{"after":"2015-05-01","before":"2015-06-01"}}`) and the
-	 * caller deep-merges it into the existing handler config to drive
-	 * windowed retroactive backfills.
+	 * Typical use: fetch step pops a config patch and the caller
+	 * deep-merges it into the existing handler config to drive windowed
+	 * retroactive backfills, rotating sources, or any other per-tick
+	 * config rotation.
+	 *
+	 * **Patch shape must mirror the handler's static config shape.** The
+	 * merge is opaque (it knows nothing about handler-specific layout),
+	 * so a key in the patch lands at the same nesting depth in the
+	 * handler config. For example, the MCP fetch handler stores its tool
+	 * parameters as a JSON-encoded string under the `params` key, so a
+	 * date-window patch for an MCP flow must nest the date keys inside
+	 * `params`:
+	 *
+	 *   {"params":{"after":"2015-05-01","before":"2015-06-01"}}
+	 *
+	 * For a handler whose params live at the top level (e.g. RSS, which
+	 * reads `$config['feed_url']` directly), a top-level patch shape is
+	 * correct:
+	 *
+	 *   {"feed_url":"https://example.com/feed.xml"}
+	 *
+	 * If the patch is shaped at the wrong nesting level the keys will
+	 * land on top-level config slots the handler never reads, and they
+	 * will be silently ignored downstream. The merge log line includes
+	 * both `patch_keys` and `merged_keys` to make this kind of
+	 * mis-shaping visible at debug time.
 	 *
 	 * Empty queue and disabled queue both return `from_queue: false` with
 	 * an empty patch — callers can branch on that to either skip the tick

--- a/tests/queueable-trait-smoke.php
+++ b/tests/queueable-trait-smoke.php
@@ -238,4 +238,43 @@ dm_assert(
 	'empty + empty = empty'
 );
 
+// -----------------------------------------------------------------
+echo "\n[13] flat-shaped patch lands top-level — contract check (issue #1235)\n";
+// When a user incorrectly shapes the patch flat instead of nesting under
+// `params`, the keys land at top level alongside the JSON-encoded
+// `params` field. The handler ignores them because it only reads
+// `$config['params']`. This test locks the documented contract: the
+// merge is opaque, and a misshapen patch produces an observable shape
+// (top-level keys present, JSON params unchanged) rather than silent
+// success or silent failure.
+$static_config = array(
+	'server'   => 'a8c',
+	'provider' => 'mgs',
+	'tool'     => 'search',
+	'params'   => '{"query":"WooCommerce"}',
+);
+$wrong_shape = array(
+	'query'  => 'WooCommerce',
+	'after'  => '2026-04-01',
+	'before' => '2026-04-25',
+);
+$merged = $harness->publicMerge( $static_config, $wrong_shape );
+
+dm_assert(
+	'{"query":"WooCommerce"}' === $merged['params'],
+	'JSON-encoded params untouched when patch keys do not match the params key'
+);
+dm_assert( 'WooCommerce' === $merged['query'], 'flat patch key landed at top level (where handler will not read it)' );
+dm_assert( '2026-04-01' === $merged['after'], 'flat after lands at top level' );
+dm_assert( '2026-04-25' === $merged['before'], 'flat before lands at top level' );
+// merged_keys log: comparing patch_keys ["query","after","before"] to
+// merged_keys ["server","provider","tool","params","query","after","before"]
+// surfaces the mis-shaping — the keys are present but alongside `params`
+// rather than inside it.
+$expected_merged_keys = array( 'server', 'provider', 'tool', 'params', 'query', 'after', 'before' );
+dm_assert(
+	$expected_merged_keys === array_keys( $merged ),
+	'merged_keys log surfaces the mis-shaping: patch keys sit alongside params, not inside it'
+);
+
 echo "\n=== queueable-trait-smoke: ALL PASS ===\n";


### PR DESCRIPTION
## Summary

Closes #1235.

The QueueableTrait merge is opaque — patch keys land at the same nesting depth in the handler config. For handlers that pack tool params into a JSON-encoded sub-field (e.g. `MCPFetchHandler`'s `params`), the patch must wrap the keys under that field name.

A flat patch like `{"query":"WC","after":"X","before":"Y"}` lands the keys at top level alongside `params`, where the handler never reads them — and they're silently dropped from the actual MCP call. That is the exact failure mode in #1235.

The trait already supports the correct nested shape (smoke test `[10]` has exercised it since the queueable feature shipped). The bug surfaced in #1235 was a mis-shaped patch silently doing nothing, with no observable signal in logs.

## Diagnosis

Walking the data flow:

1. `FetchStep::executeStep()` calls `popQueuedConfigPatch()` then `mergeQueuedConfigPatch( $handler_settings, $patch )`.
2. `mergeQueuedConfigPatch()` does a deep merge — it has no whitelist, no allowlist, no shape knowledge. Top-level patch keys land at top-level config slots.
3. `MCPFetchHandler::resolveParams()` reads `$config['params']` only (a JSON-encoded string), so any top-level keys outside `params` are invisible to it.

Live-verified on intelligence-chubes4 with both shapes:

```
# wrong (flat) shape — the issue's reproducer
patch_keys:  ["query","after","before"]
merged_keys: ["server","provider","tool","params","max_items","query","after","before"]
                                                              ^^^^^ sit alongside params, not inside it

# correct (nested) shape
patch_keys:  ["params"]
merged_keys: ["server","provider","tool","params","max_items"]
                                          ^^^^^^ params merged in place
```

The merge is doing exactly what it's documented to do. The handler is doing exactly what it's documented to do. The contract is just under-specified.

## Changes

- **`inc/Core/Steps/QueueableTrait.php`** — rewrite `popQueuedConfigPatch()` docblock. Spell out the shape contract with two worked examples (MCP nested under `params`, RSS flat). Call out the silent-drop failure mode and point at the new `merged_keys` log breadcrumb.
- **`inc/Core/Steps/Fetch/FetchStep.php`** — add `merged_keys` to the `Fetch step merged queued config patch` log entry. Comparing `patch_keys` to `merged_keys` makes mis-shaping visible without a debugger.
- **`tests/queueable-trait-smoke.php`** — add test `[13]` locking the contract: a flat-shaped patch into a config with a JSON-encoded `params` field leaves `params` untouched and the patch keys land at top level. This is the exact shape the issue reproducer hits, now pinned.

## No-shim posture

Considered (and rejected) adding handler-specific normalization in QueueableTrait or MCPFetchHandler that would silently fold flat keys into `params`. That's the allowlist pattern in disguise — it papers over the contract instead of making it observable. The trait should stay opaque; the contract is "patch shape mirrors handler config shape".

The runtime fix for users hitting this is to wrap their patch:

```diff
- {"query":"WC","after":"X","before":"Y"}
+ {"params":{"query":"WC","after":"X","before":"Y"}}
```

This is what smoke test `[10]` ("WooCommerce backfill real-world shape end-to-end") already documents as the canonical shape and what the wiki article was implicitly referencing.

## Verification

- `php tests/queueable-trait-smoke.php` — 13/13 pass (including new `[13]`).
- All other smoke tests pass (`ai-enabled-tools`, `batch-child-agent-id`, `daily-memory-conservation`, `merge-term-meta`, `resolve-term-args`, `system-task-config-passthrough`, `system-task-workflow-validation`, `tool-policy-resolver-adjacency`, `transcript-policy`).
- Live-verified on intelligence-chubes4 (jobs 121 + 122) — `merged_keys` log surfaces the mis-shaping for the wrong patch and confirms in-place merge for the correct one.

## Out of scope

- The MCP handler's static-config shape (params as JSON-encoded string) is a separate design choice; not touched here. A follow-up could surface the canonical queue-patch shape in `MCPFetchSettings` field help text. Filed mentally; not blocking #1235.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.5 (via Kimaki / Claude Code)
- **Used for:** Drafted the diagnosis, doc rewrite, log-key addition, and smoke test from the live reproducer; verified end-to-end on intelligence-chubes4 against both patch shapes. Chris reviewed the no-shim posture decision before commit.