### PR TITLE
feat(seo): datamachine_post_types_for_meta_description filter for batch discovery

### DIFF
--- a/inc/Abilities/SEO/MetaDescriptionAbilities.php
+++ b/inc/Abilities/SEO/MetaDescriptionAbilities.php
@@ -50,8 +50,7 @@ class MetaDescriptionAbilities {
 							),
 							'post_type' => array(
 								'type'        => 'string',
-								'description' => 'Post type to batch process (e.g. "post", "page")',
-								'default'     => 'post',
+								'description' => 'Post type to batch process (e.g. "post", "page"). When omitted in batch mode, discovery spans every post type registered via the datamachine_post_types_for_meta_description filter.',
 							),
 							'limit'     => array(
 								'type'        => 'integer',
@@ -134,7 +133,7 @@ class MetaDescriptionAbilities {
 	 */
 	public static function generateMetaDescriptions( array $input ): array {
 		$post_id   = absint( $input['post_id'] ?? 0 );
-		$post_type = sanitize_key( $input['post_type'] ?? 'post' );
+		$post_type = isset( $input['post_type'] ) ? sanitize_key( $input['post_type'] ) : '';
 		$limit     = absint( $input['limit'] ?? 50 );
 		$force     = ! empty( $input['force'] );
 
@@ -177,8 +176,13 @@ class MetaDescriptionAbilities {
 
 			$eligible = array( $post_id );
 		} else {
-			// Batch mode — find posts missing excerpts.
-			$eligible = self::findPostsMissingExcerpt( $post_type, $limit, $force );
+			// Batch mode — find posts missing excerpts. When no explicit
+			// post_type is provided, discover across every eligible post
+			// type registered via datamachine_post_types_for_meta_description.
+			$post_types = '' !== $post_type
+				? array( $post_type )
+				: self::getEligiblePostTypes();
+			$eligible   = self::findPostsMissingExcerpt( $post_types, $limit, $force );
 		}
 
 		if ( empty( $eligible ) ) {
@@ -275,40 +279,74 @@ class MetaDescriptionAbilities {
 	}
 
 	/**
+	 * Get post types eligible for meta description generation.
+	 *
+	 * Plugins register custom post types via the
+	 * 'datamachine_post_types_for_meta_description' filter so they
+	 * appear in batch discovery alongside the defaults.
+	 *
+	 * @return string[] Array of post type slugs.
+	 */
+	public static function getEligiblePostTypes(): array {
+		/**
+		 * Filter the post types eligible for meta description generation.
+		 *
+		 * @param string[] $post_types Default: ['post', 'page'].
+		 */
+		$post_types = apply_filters(
+			'datamachine_post_types_for_meta_description',
+			array( 'post', 'page' )
+		);
+
+		if ( ! is_array( $post_types ) ) {
+			return array( 'post', 'page' );
+		}
+
+		$post_types = array_values( array_unique( array_filter( array_map( 'sanitize_key', $post_types ) ) ) );
+
+		return ! empty( $post_types ) ? $post_types : array( 'post', 'page' );
+	}
+
+	/**
 	 * Find published posts missing a post_excerpt.
 	 *
-	 * @param string $post_type Post type to query.
-	 * @param int    $limit     Maximum results.
-	 * @param bool   $force     If true, return all posts regardless of excerpt.
+	 * Accepts either a single post type slug or an array of slugs so that
+	 * batch discovery can span every post type registered through
+	 * {@see self::getEligiblePostTypes()}.
+	 *
+	 * @param string|string[] $post_types Post type slug(s) to query.
+	 * @param int             $limit      Maximum results.
+	 * @param bool            $force      If true, return all posts regardless of excerpt.
 	 * @return int[] Post IDs.
 	 */
-	private static function findPostsMissingExcerpt( string $post_type, int $limit, bool $force ): array {
+	private static function findPostsMissingExcerpt( $post_types, int $limit, bool $force ): array {
 		global $wpdb;
 
-		if ( $force ) {
-			$results = $wpdb->get_col(
-				$wpdb->prepare(
-					"SELECT ID FROM {$wpdb->posts}
-					 WHERE post_type = %s AND post_status = 'publish'
-					 ORDER BY ID DESC LIMIT %d",
-					$post_type,
-					$limit
-				)
-			);
-		} else {
-			$results = $wpdb->get_col(
-				$wpdb->prepare(
-					"SELECT ID FROM {$wpdb->posts}
-					 WHERE post_type = %s
-					 AND post_status = 'publish'
-					 AND ( post_excerpt IS NULL OR post_excerpt = '' )
-					 ORDER BY ID DESC
-					 LIMIT %d",
-					$post_type,
-					$limit
-				)
-			);
+		$post_types = (array) $post_types;
+		$post_types = array_values( array_unique( array_filter( array_map( 'sanitize_key', $post_types ) ) ) );
+
+		if ( empty( $post_types ) ) {
+			return array();
 		}
+
+		$placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
+
+		if ( $force ) {
+			$sql  = "SELECT ID FROM {$wpdb->posts}
+				 WHERE post_type IN ({$placeholders}) AND post_status = 'publish'
+				 ORDER BY ID DESC LIMIT %d";
+			$args = array_merge( $post_types, array( $limit ) );
+		} else {
+			$sql  = "SELECT ID FROM {$wpdb->posts}
+				 WHERE post_type IN ({$placeholders})
+				 AND post_status = 'publish'
+				 AND ( post_excerpt IS NULL OR post_excerpt = '' )
+				 ORDER BY ID DESC
+				 LIMIT %d";
+			$args = array_merge( $post_types, array( $limit ) );
+		}
+
+		$results = $wpdb->get_col( $wpdb->prepare( $sql, $args ) );
 
 		return array_map( 'absint', $results ? $results : array() );
 	}

--- a/inc/Cli/Commands/MetaDescriptionCommand.php
+++ b/inc/Cli/Commands/MetaDescriptionCommand.php
@@ -116,10 +116,10 @@ class MetaDescriptionCommand extends BaseCommand {
 	 * : Single post ID to generate a description for.
 	 *
 	 * [--post_type=<type>]
-	 * : Post type to batch process (used when --post_id is not set).
-	 * ---
-	 * default: post
-	 * ---
+	 * : Post type to batch process (used when --post_id is not set). When
+	 * omitted, batch discovery spans every post type registered via the
+	 * `datamachine_post_types_for_meta_description` filter (defaults to
+	 * `post` and `page`).
 	 *
 	 * [--limit=<number>]
 	 * : Maximum posts to queue in batch mode.
@@ -161,19 +161,22 @@ class MetaDescriptionCommand extends BaseCommand {
 	 */
 	public function generate( array $args, array $assoc_args ): void {
 		$post_id   = isset( $assoc_args['post_id'] ) ? \absint( $assoc_args['post_id'] ) : 0;
-		$post_type = $assoc_args['post_type'] ?? 'post';
+		$post_type = isset( $assoc_args['post_type'] ) ? (string) $assoc_args['post_type'] : '';
 		$limit     = isset( $assoc_args['limit'] ) ? \absint( $assoc_args['limit'] ) : 50;
 		$force     = isset( $assoc_args['force'] );
 		$format    = $assoc_args['format'] ?? 'table';
 
-		$result = MetaDescriptionAbilities::generateMetaDescriptions(
-			array(
-				'post_id'   => $post_id,
-				'post_type' => $post_type,
-				'limit'     => $limit,
-				'force'     => $force,
-			)
+		$ability_input = array(
+			'post_id' => $post_id,
+			'limit'   => $limit,
+			'force'   => $force,
 		);
+
+		if ( '' !== $post_type ) {
+			$ability_input['post_type'] = $post_type;
+		}
+
+		$result = MetaDescriptionAbilities::generateMetaDescriptions( $ability_input );
 
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to queue meta description generation.' );

--- a/tests/meta-description-post-types-filter-smoke.php
+++ b/tests/meta-description-post-types-filter-smoke.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Pure-PHP smoke test for `datamachine_post_types_for_meta_description`.
+ *
+ * Run with: php tests/meta-description-post-types-filter-smoke.php
+ *
+ * Issue #1246: `MetaDescriptionAbilities::findPostsMissingExcerpt` and the
+ * surrounding batch discovery path were post-type-blind. This test exercises
+ * the new `getEligiblePostTypes()` helper and the
+ * `datamachine_post_types_for_meta_description` filter that lets plugins
+ * extend batch discovery to custom post types (e.g. Intelligence's `wiki`
+ * articles).
+ *
+ * The test stubs WordPress filter functions with a tiny in-memory registry
+ * so it can run under plain PHP with no WP bootstrap.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// Tiny filter registry — enough for getEligiblePostTypes().
+$GLOBALS['_dm_test_filters'] = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['_dm_test_filters'][ $hook ][ $priority ][] = $callback;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'remove_filter' ) ) {
+	function remove_filter( $hook, $callback, $priority = 10 ) {
+		if ( empty( $GLOBALS['_dm_test_filters'][ $hook ][ $priority ] ) ) {
+			return false;
+		}
+		foreach ( $GLOBALS['_dm_test_filters'][ $hook ][ $priority ] as $i => $registered ) {
+			if ( $registered === $callback ) {
+				unset( $GLOBALS['_dm_test_filters'][ $hook ][ $priority ][ $i ] );
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value ) {
+		if ( empty( $GLOBALS['_dm_test_filters'][ $hook ] ) ) {
+			return $value;
+		}
+		$args = func_get_args();
+		array_shift( $args ); // drop hook name
+		ksort( $GLOBALS['_dm_test_filters'][ $hook ] );
+		foreach ( $GLOBALS['_dm_test_filters'][ $hook ] as $priority => $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				$args[0] = call_user_func_array( $callback, $args );
+			}
+		}
+		return $args[0];
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $action = '' ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $action = '' ) {
+		return 1; // pretend wp_abilities_api_init already fired
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		// no-op
+	}
+}
+
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( ...$args ) {
+		// no-op
+	}
+}
+
+require_once __DIR__ . '/../inc/Abilities/PermissionHelper.php';
+require_once __DIR__ . '/../inc/Abilities/SEO/MetaDescriptionAbilities.php';
+
+use DataMachine\Abilities\SEO\MetaDescriptionAbilities;
+
+function dm_assert( bool $cond, string $msg ): void {
+	if ( $cond ) {
+		echo "  [PASS] {$msg}\n";
+		return;
+	}
+	echo "  [FAIL] {$msg}\n";
+	exit( 1 );
+}
+
+echo "getEligiblePostTypes — defaults\n";
+$default = MetaDescriptionAbilities::getEligiblePostTypes();
+dm_assert( is_array( $default ), 'returns an array' );
+dm_assert( in_array( 'post', $default, true ), 'includes "post" by default' );
+dm_assert( in_array( 'page', $default, true ), 'includes "page" by default' );
+dm_assert( 2 === count( $default ), 'returns exactly the two defaults' );
+
+echo "getEligiblePostTypes — filter appends a custom post type\n";
+$append_wiki = function ( array $types ): array {
+	$types[] = 'wiki';
+	return $types;
+};
+add_filter( 'datamachine_post_types_for_meta_description', $append_wiki );
+
+$with_wiki = MetaDescriptionAbilities::getEligiblePostTypes();
+dm_assert( in_array( 'wiki', $with_wiki, true ), 'includes "wiki" after filter' );
+dm_assert( in_array( 'post', $with_wiki, true ), 'still includes "post"' );
+dm_assert( in_array( 'page', $with_wiki, true ), 'still includes "page"' );
+dm_assert( 3 === count( $with_wiki ), 'returns three post types after filter' );
+
+echo "getEligiblePostTypes — removing the filter restores defaults\n";
+remove_filter( 'datamachine_post_types_for_meta_description', $append_wiki );
+$restored = MetaDescriptionAbilities::getEligiblePostTypes();
+dm_assert( ! in_array( 'wiki', $restored, true ), '"wiki" gone after remove_filter' );
+dm_assert( in_array( 'post', $restored, true ), '"post" still present' );
+dm_assert( in_array( 'page', $restored, true ), '"page" still present' );
+dm_assert( 2 === count( $restored ), 'returns exactly the two defaults again' );
+
+echo "getEligiblePostTypes — sanitization + dedupe\n";
+$noisy = function ( array $_types ): array {
+	// Caller returns junk: mixed case, dupes, empty strings, invalid chars.
+	return array( 'POST', 'post', '', 'wiki', 'wiki', 'bad type!' );
+};
+add_filter( 'datamachine_post_types_for_meta_description', $noisy );
+
+$cleaned = MetaDescriptionAbilities::getEligiblePostTypes();
+dm_assert( in_array( 'post', $cleaned, true ), 'lowercases "POST" to "post"' );
+dm_assert( in_array( 'wiki', $cleaned, true ), 'preserves "wiki"' );
+dm_assert( in_array( 'badtype', $cleaned, true ), 'sanitize_key strips invalid chars from "bad type!"' );
+dm_assert( 1 === count( array_filter( $cleaned, fn( $t ) => 'post' === $t ) ), 'dedupes "post"' );
+dm_assert( 1 === count( array_filter( $cleaned, fn( $t ) => 'wiki' === $t ) ), 'dedupes "wiki"' );
+dm_assert( ! in_array( '', $cleaned, true ), 'empty strings filtered out' );
+remove_filter( 'datamachine_post_types_for_meta_description', $noisy );
+
+echo "getEligiblePostTypes — non-array return falls back to defaults\n";
+$broken = function ( array $_types ) {
+	return 'not an array';
+};
+add_filter( 'datamachine_post_types_for_meta_description', $broken );
+$fallback = MetaDescriptionAbilities::getEligiblePostTypes();
+dm_assert( is_array( $fallback ), 'still returns an array when filter misbehaves' );
+dm_assert( array( 'post', 'page' ) === $fallback, 'falls back to default array exactly' );
+remove_filter( 'datamachine_post_types_for_meta_description', $broken );
+
+echo "getEligiblePostTypes — empty filter return falls back to defaults\n";
+$empty = function ( array $_types ): array {
+	return array();
+};
+add_filter( 'datamachine_post_types_for_meta_description', $empty );
+$still_default = MetaDescriptionAbilities::getEligiblePostTypes();
+dm_assert( array( 'post', 'page' ) === $still_default, 'empty filter return falls back to defaults' );
+remove_filter( 'datamachine_post_types_for_meta_description', $empty );
+
+echo "\n[OK] All meta-description post-types filter smoke tests passed.\n";


### PR DESCRIPTION
## Summary

- Adds the `datamachine_post_types_for_meta_description` filter (and a public `MetaDescriptionAbilities::getEligiblePostTypes()` helper) so plugins with custom CPTs can opt them into batch discovery without reimplementing the AI orchestration. Closes #1246.

## Changes

### `inc/Abilities/SEO/MetaDescriptionAbilities.php`
- New public static `getEligiblePostTypes()` that wraps `apply_filters( 'datamachine_post_types_for_meta_description', [ 'post', 'page' ] )` with sanitize_key / dedupe / non-array fallback.
- `generateMetaDescriptions()` no longer hard-defaults `post_type` to `'post'`. When the input omits `post_type`, batch mode now spans every eligible post type returned by `getEligiblePostTypes()`. Single-post execution and explicit `post_type` callers are unaffected.
- `findPostsMissingExcerpt()` accepts `string|string[]` so multi-type discovery stays a single `IN()` query. Single-type calls continue to work via the same arg.
- Input schema docstring on `datamachine/generate-meta-description` updated to describe the new omitted-post_type behavior.

### `inc/Cli/Commands/MetaDescriptionCommand.php`
- `wp datamachine meta-description generate --post_type=...` is now optional. When omitted, batch discovery spans every registered post type via the filter. When passed, behavior is unchanged.
- Removed the `default: post` line from the `--post_type` doc so the omitted path actually reaches the ability layer.

### `tests/meta-description-post-types-filter-smoke.php` (new)
- Pure-PHP smoke (matches `tests/exclude-keywords-smoke.php` convention).

## Tests

`php tests/meta-description-post-types-filter-smoke.php` — 22 assertions covering:
- Default returns `[ 'post', 'page' ]`.
- `add_filter` appending `'wiki'` is honored; `remove_filter` restores defaults.
- Filter values are run through `sanitize_key`, deduped, and empty strings dropped.
- Non-array filter return falls back to the default array exactly.
- Empty array filter return falls back to the default array.

Existing `tests/exclude-keywords-smoke.php` re-run to confirm shared-stub regressions did not slip in.

## Out of scope

- Per-post-type prompt overrides — `setPromptOverride( 'meta_description_generation', 'generate', $text )` is still global per task. A per-post-type override key (with voice/length tuning) needs its own design.
- The `meta_description_generation_batch` fan-out task that takes `post_types[]` and uses `TaskScheduler::scheduleBatch` — depends on the sibling fan-out trio (#1243 / #1244 / #1245) landing first, which is being addressed in a parallel PR.

Closes #1246.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the filter + helper, the multi-post-type query rewrite in `findPostsMissingExcerpt`, the CLI default change, and the smoke test. Chris reviewed the discovery callsite analysis (single discovery surface in `generateMetaDescriptions`; `MetaDescriptionTask` is per-post and unaffected) and validated the backwards-compatibility shape (explicit `post_type` callers unchanged; default surface remains `[ 'post', 'page' ]`).