### PR TITLE
chore(tests): drop redundant WP_Ability class_exists guards in LogAbilitiesTest (refs #1210)

### DIFF
--- a/tests/Unit/Abilities/LogAbilitiesTest.php
+++ b/tests/Unit/Abilities/LogAbilitiesTest.php
@@ -43,11 +43,6 @@ class LogAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function testWrite_toLog_withValidData_returnsSuccess(): void {
-		if (!class_exists('WP_Ability')) {
-			$this->markTestSkipped('WP_Ability class not available');
-			return;
-		}
-
 		$ability = wp_get_ability('datamachine/write-to-log');
 		$result = $ability->execute([
 			'level' => 'debug',
@@ -62,11 +57,6 @@ class LogAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function testWrite_toLog_withoutPermissions_returnsPermissionDenied(): void {
-		if (!class_exists('WP_Ability')) {
-			$this->markTestSkipped('WP_Ability class not available');
-			return;
-		}
-
 		wp_set_current_user(0);
 		add_filter( 'datamachine_cli_bypass_permissions', '__return_false' );
 
@@ -81,11 +71,6 @@ class LogAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function testWrite_toLog_withInvalidLevel_returnsError(): void {
-		if (!class_exists('WP_Ability')) {
-			$this->markTestSkipped('WP_Ability class not available');
-			return;
-		}
-
 		$ability = wp_get_ability('datamachine/write-to-log');
 		$result = $ability->execute([
 			'level' => 'invalid_level',
@@ -97,11 +82,6 @@ class LogAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function testWrite_toLog_withContext_storesContext(): void {
-		if (!class_exists('WP_Ability')) {
-			$this->markTestSkipped('WP_Ability class not available');
-			return;
-		}
-
 		$ability = wp_get_ability('datamachine/write-to-log');
 		$result = $ability->execute([
 			'level' => 'info',
@@ -115,11 +95,6 @@ class LogAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function testWrite_toLog_withoutContext_succeeds(): void {
-		if (!class_exists('WP_Ability')) {
-			$this->markTestSkipped('WP_Ability class not available');
-			return;
-		}
-
 		$ability = wp_get_ability('datamachine/write-to-log');
 		$result = $ability->execute([
 			'level' => 'info',
@@ -130,11 +105,6 @@ class LogAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function testClearLogs_withValidAgentType_returnsSuccess(): void {
-		if (!class_exists('WP_Ability')) {
-			$this->markTestSkipped('WP_Ability class not available');
-			return;
-		}
-
 		$ability = wp_get_ability('datamachine/clear-logs');
 		$result = $ability->execute([]);
 
@@ -143,11 +113,6 @@ class LogAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function testClearLogs_withAll_clearsAllAgentTypes(): void {
-		if (!class_exists('WP_Ability')) {
-			$this->markTestSkipped('WP_Ability class not available');
-			return;
-		}
-
 		$ability = wp_get_ability('datamachine/clear-logs');
 		$result = $ability->execute([]);
 
@@ -156,11 +121,6 @@ class LogAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function testClearLogs_withoutPermissions_returnsPermissionDenied(): void {
-		if (!class_exists('WP_Ability')) {
-			$this->markTestSkipped('WP_Ability class not available');
-			return;
-		}
-
 		wp_set_current_user(0);
 		add_filter( 'datamachine_cli_bypass_permissions', '__return_false' );
 
@@ -179,11 +139,6 @@ class LogAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function testReadDebugLog_returnsSuccess(): void {
-		if (!class_exists('WP_Ability')) {
-			$this->markTestSkipped('WP_Ability class not available');
-			return;
-		}
-
 		$ability = wp_get_ability('datamachine/read-debug-log');
 		$result = $ability->execute([]);
 


### PR DESCRIPTION
## Summary

Drop 9 redundant \`class_exists( 'WP_Ability' )\` guards in \`tests/Unit/Abilities/LogAbilitiesTest.php\`. Partial cleanup of #1210 (\`dead_guard\` audit findings).

Each test method opened with:

\`\`\`php
if ( ! class_exists( 'WP_Ability' ) ) {
    \$this->markTestSkipped( 'WP_Ability class not available' );
    return;
}
\`\`\`

The plugin requires WP 6.9+ where \`WP_Ability\` ships in core, and the WP test bootstrap loads core before tests run. The skip path is unreachable in any environment that can run the test file at all. The guards add 4 lines of noise per test method and contribute zero protection.

## Why this is a partial cleanup

#1210 reports 37 \`dead_guard\` findings. Reading 8 representative ones, **only ~10–15 are actually dead in the production runtime**. The rest are load-bearing in non-production contexts:

- \`data-machine.php:40\` — \`! class_exists( 'ActionScheduler' )\` guards a vendor require; removing breaks installs where another plugin (WooCommerce, etc.) ships AS first → double-load fatal
- \`uninstall.php:113\` — runs at uninstall, when sibling plugins may already be deactivated
- \`inc/migrations/flows.php:19\` — runs at plugin activation, before AS is guaranteed loaded
- \`inc/Core/Auth/CallerContext.php:202\` — explicit testability fallback for environments where WordPress isn't loaded
- \`tests/Unit/Abilities/JobAbilitiesTest.php:14\` — stub definition (\`if ( ! function_exists(...) ) { function ... }\`), not a usage guard
- \`tests/queueable-trait-smoke.php:18\` — same stub-definition pattern

The \`LogAbilitiesTest\` guards are different: they were defensive \`markTestSkipped\` calls inside test methods, not stub definitions. WP_Ability is reliably available in the WordPress test bootstrap, so the skip is unreachable. Safe to remove.

## What this PR does NOT touch

The other 28 findings in #1210 fall into the categories above. Removing them blanket-style would break tests, break uninstall, and cause double-load fatals on WooCommerce sites. Each one needs case-by-case context analysis the audit rule should be doing — filed as homeboy#1552.

## Verification

- ✅ \`homeboy test data-machine\` — passes
- ✅ All pure-PHP smokes pass
- ✅ PHP lint clean
- 1 file changed, 45 deletions

## Related

- Refs #1210 (\`dead_guard\` audit) — partial cleanup
- homeboy#1552 — \`dead_guard\` rule context-blindness, blocks the rest of the cleanup

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.5 (via Kimaki / Claude Code)
- **Used for:** Triaged the 37 \`dead_guard\` findings, identified which are truly dead vs load-bearing, applied the safe subset (9 guards in LogAbilitiesTest), ran the test suite to verify. Drafted homeboy#1552 to capture the rule's context-blindness so the rest of the findings can be revisited after the rule sharpens.