### PR TITLE
fix(cli): route flow update prompt through user_message; rename --set-prompt → --set-user-message

### DIFF
--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -99,8 +99,10 @@ class FlowsCommand extends BaseCommand {
 	 * [--scheduled-at=<datetime>]
 	 * : ISO-8601 datetime for one-time scheduling (e.g. "2026-03-20T15:00:00Z"). Implies --scheduling=one_time.
 	 *
-	 * [--set-prompt=<text>]
-	 * : Update the prompt for a handler step (requires handler step to exist).
+	 * [--set-user-message=<text>]
+	 * : Update the user_message for an AI step (per-flow task context appended
+	 *   after fetched data packets). For the pipeline-wide system prompt shared
+	 *   across all flows on the pipeline, use `pipeline update --set-system-prompt`.
 	 *
 	 * [--handler-config=<json>]
 	 * : JSON object of handler config key-value pairs to update (merged with existing config).
@@ -159,8 +161,8 @@ class FlowsCommand extends BaseCommand {
 	 *     # Update flow name
 	 *     wp datamachine flows update 141 --name="New Name"
 	 *
-	 *     # Update flow prompt
-	 *     wp datamachine flows update 42 --set-prompt="New prompt text"
+	 *     # Update flow user_message (per-flow task context for an AI step)
+	 *     wp datamachine flows update 42 --set-user-message="New user message"
 	 *
 	 *     # Add a handler to a flow step
 	 *     wp datamachine flows add-handler 42 --handler=rss
@@ -261,7 +263,7 @@ class FlowsCommand extends BaseCommand {
 		// Handle 'update' subcommand: `flows update 42 --name="New Name"`.
 		if ( ! empty( $args ) && 'update' === $args[0] ) {
 			if ( ! isset( $args[1] ) ) {
-				WP_CLI::error( 'Usage: wp datamachine flows update <flow_id> [--name=<name>] [--scheduling=<interval>] [--set-prompt=<text>] [--handler-config=<json>] [--step=<flow_step_id>]' );
+				WP_CLI::error( 'Usage: wp datamachine flows update <flow_id> [--name=<name>] [--scheduling=<interval>] [--set-user-message=<text>] [--handler-config=<json>] [--step=<flow_step_id>]' );
 				return;
 			}
 			$this->updateFlow( (int) $args[1], $assoc_args );
@@ -406,6 +408,14 @@ class FlowsCommand extends BaseCommand {
 	 * @param string $format Output format (table, json, csv, yaml).
 	 */
 	private function showFlowDetail( array $flow, string $format ): void {
+		// Always surface user_message on AI steps, even when unset, so the
+		// slot is visible to anyone inspecting the config. Otherwise the
+		// field disappears from the JSON output and the next reader can't
+		// tell whether it's empty or whether they're looking at the wrong
+		// key (which is exactly how the --set-prompt-writes-dead-key bug
+		// stayed invisible).
+		$flow = self::normalizeAiStepUserMessage( $flow );
+
 		// JSON/YAML: output the full flow data including flow_config.
 		if ( 'json' === $format ) {
 			WP_CLI::line( wp_json_encode( $flow, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
@@ -472,10 +482,15 @@ class FlowsCommand extends BaseCommand {
 
 			if ( empty( $slugs ) ) {
 				// Step with no handlers (e.g. AI step with only pipeline config).
-				$config_display = '';
+				$config_parts = array();
 
 				if ( $pipeline_prompt ) {
-					$config_display = 'prompt=' . $this->truncateValue( $pipeline_prompt, 60 );
+					$config_parts[] = 'system_prompt=' . $this->truncateValue( $pipeline_prompt, 60 );
+				}
+
+				if ( 'ai' === $step_type ) {
+					$user_message    = $step_data['user_message'] ?? '';
+					$config_parts[]  = 'user_message=' . ( '' === $user_message ? '(unset)' : $this->truncateValue( $user_message, 60 ) );
 				}
 
 				$rows[] = array(
@@ -483,7 +498,7 @@ class FlowsCommand extends BaseCommand {
 					'order'     => $order,
 					'step_type' => $step_type,
 					'handler'   => '—',
-					'config'    => $config_display ? $config_display : '(default)',
+					'config'    => empty( $config_parts ) ? '(default)' : implode( ', ', $config_parts ),
 				);
 				continue;
 			}
@@ -525,6 +540,38 @@ class FlowsCommand extends BaseCommand {
 			return mb_substr( $value, 0, $max - 3 ) . '...';
 		}
 		return $value;
+	}
+
+	/**
+	 * Ensure every AI step in a flow exposes the `user_message` slot.
+	 *
+	 * AIStep::execute() reads $flow_step_config['user_message'] at the
+	 * flow_step_config root (not under handler_configs). When the slot
+	 * is unset, omitting it from output makes the field invisible to
+	 * agents and humans inspecting flow configuration. Render an empty
+	 * string instead so the slot is always discoverable.
+	 *
+	 * @param array $flow Flow data with flow_config.
+	 * @return array Flow data with user_message normalized on AI steps.
+	 */
+	private static function normalizeAiStepUserMessage( array $flow ): array {
+		if ( empty( $flow['flow_config'] ) || ! is_array( $flow['flow_config'] ) ) {
+			return $flow;
+		}
+
+		foreach ( $flow['flow_config'] as $step_id => $step_data ) {
+			if ( ! is_array( $step_data ) ) {
+				continue;
+			}
+			if ( 'ai' !== ( $step_data['step_type'] ?? '' ) ) {
+				continue;
+			}
+			if ( ! array_key_exists( 'user_message', $step_data ) ) {
+				$flow['flow_config'][ $step_id ]['user_message'] = '';
+			}
+		}
+
+		return $flow;
 	}
 
 	/**
@@ -807,11 +854,20 @@ class FlowsCommand extends BaseCommand {
 			return;
 		}
 
+		// Clean break: the old --set-prompt flag silently wrote to a dead
+		// key (handler_configs.ai.prompt) that AIStep never reads. There is
+		// no working consumer to migrate. Hard-fail with a pointer to the
+		// correct flag rather than alias.
+		if ( isset( $assoc_args['set-prompt'] ) ) {
+			WP_CLI::error( '--set-prompt has been removed. Use --set-user-message=<text> for AI step per-flow context, or `pipeline update --set-system-prompt` for the shared pipeline system prompt.' );
+			return;
+		}
+
 		$name           = $assoc_args['name'] ?? null;
 		$scheduling     = $assoc_args['scheduling'] ?? null;
 		$scheduled_at   = $assoc_args['scheduled-at'] ?? null;
-		$prompt         = isset( $assoc_args['set-prompt'] )
-			? wp_kses_post( wp_unslash( $assoc_args['set-prompt'] ) )
+		$user_message   = isset( $assoc_args['set-user-message'] )
+			? wp_kses_post( wp_unslash( $assoc_args['set-user-message'] ) )
 			: null;
 		$handler_config = isset( $assoc_args['handler-config'] )
 			? json_decode( wp_unslash( $assoc_args['handler-config'] ), true )
@@ -828,13 +884,13 @@ class FlowsCommand extends BaseCommand {
 			return;
 		}
 
-		if ( null === $name && null === $scheduling && null === $prompt && null === $handler_config ) {
-			WP_CLI::error( 'Must provide --name, --scheduling, --set-prompt, --scheduled-at, or --handler-config to update' );
+		if ( null === $name && null === $scheduling && null === $user_message && null === $handler_config ) {
+			WP_CLI::error( 'Must provide --name, --scheduling, --set-user-message, --scheduled-at, or --handler-config to update' );
 			return;
 		}
 
 		// Validate step resolution BEFORE any writes (atomic: fail fast, change nothing).
-		$needs_step = null !== $prompt || null !== $handler_config;
+		$needs_step = null !== $user_message || null !== $handler_config;
 
 		if ( $needs_step && null === $step ) {
 			$resolved = $this->resolveHandlerStep( $flow_id );
@@ -880,13 +936,13 @@ class FlowsCommand extends BaseCommand {
 			}
 		}
 
-		// Phase 2: Step-level updates (prompt, handler config).
-		if ( null !== $prompt ) {
+		// Phase 2: Step-level updates (user_message, handler config).
+		if ( null !== $user_message ) {
 			$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
 			$step_result  = $step_ability->execute(
 				array(
-					'flow_step_id'   => $step,
-					'handler_config' => array( 'prompt' => $prompt ),
+					'flow_step_id' => $step,
+					'user_message' => $user_message,
 				)
 			);
 
@@ -895,11 +951,11 @@ class FlowsCommand extends BaseCommand {
 			}
 
 			if ( ! $step_result['success'] ) {
-				WP_CLI::error( $step_result['error'] ?? 'Failed to update prompt' );
+				WP_CLI::error( $step_result['error'] ?? 'Failed to update user_message' );
 				return;
 			}
 
-			WP_CLI::success( 'Prompt updated for step: ' . $step );
+			WP_CLI::success( 'User message updated for step: ' . $step );
 		}
 
 		if ( null !== $handler_config ) {

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -408,13 +408,13 @@ class FlowsCommand extends BaseCommand {
 	 * @param string $format Output format (table, json, csv, yaml).
 	 */
 	private function showFlowDetail( array $flow, string $format ): void {
-		// Always surface user_message on AI steps, even when unset, so the
-		// slot is visible to anyone inspecting the config. Otherwise the
-		// field disappears from the JSON output and the next reader can't
-		// tell whether it's empty or whether they're looking at the wrong
-		// key (which is exactly how the --set-prompt-writes-dead-key bug
-		// stayed invisible).
-		$flow = self::normalizeAiStepUserMessage( $flow );
+		// Always surface user_message, prompt_queue, and queue_enabled on
+		// AI steps, even when unset, so every slot AIStep reads at runtime
+		// is discoverable. Otherwise these fields disappear from the JSON
+		// output and the next reader can't tell whether they're empty or
+		// whether they're looking at the wrong key — which is exactly how
+		// the --set-prompt-writes-dead-key bug stayed invisible.
+		$flow = self::normalizeAiStepPromptSlots( $flow );
 
 		// JSON/YAML: output the full flow data including flow_config.
 		if ( 'json' === $format ) {
@@ -489,8 +489,25 @@ class FlowsCommand extends BaseCommand {
 				}
 
 				if ( 'ai' === $step_type ) {
-					$user_message    = $step_data['user_message'] ?? '';
-					$config_parts[]  = 'user_message=' . ( '' === $user_message ? '(unset)' : $this->truncateValue( $user_message, 60 ) );
+					// AI steps have THREE prompt-input slots that AIStep::execute()
+					// chains as a precedence: prompt_queue head → user_message →
+					// (none). Surface every slot that exists and mark which one
+					// AIStep would actually read at runtime, so the active prompt
+					// is never invisible.
+					$user_message = $step_data['user_message'] ?? '';
+					$config_parts[] = 'user_message=' . ( '' === $user_message ? '(unset)' : $this->truncateValue( $user_message, 60 ) );
+
+					$resolved = self::resolveAiStepActivePrompt( $step_data );
+
+					if ( $resolved['queue_depth'] > 0 || $resolved['queue_enabled'] ) {
+						$config_parts[] = sprintf(
+							'queue=%d item(s), queue_enabled=%s',
+							$resolved['queue_depth'],
+							$resolved['queue_enabled'] ? 'true' : 'false'
+						);
+					}
+
+					$config_parts[] = 'active_prompt=' . self::formatActivePromptLabel( $resolved );
 				}
 
 				$rows[] = array(
@@ -543,18 +560,30 @@ class FlowsCommand extends BaseCommand {
 	}
 
 	/**
-	 * Ensure every AI step in a flow exposes the `user_message` slot.
+	 * Ensure every AI step in a flow exposes its prompt-input slots.
 	 *
-	 * AIStep::execute() reads $flow_step_config['user_message'] at the
-	 * flow_step_config root (not under handler_configs). When the slot
-	 * is unset, omitting it from output makes the field invisible to
-	 * agents and humans inspecting flow configuration. Render an empty
-	 * string instead so the slot is always discoverable.
+	 * AIStep::execute() reads three slots at the flow_step_config root
+	 * (not under handler_configs):
+	 *
+	 *   - user_message: per-flow task framing (the slot --set-user-message
+	 *     writes to).
+	 *   - prompt_queue:  list of queued prompts (managed by `flow queue
+	 *     add/remove/clear` or by webhooks). When non-empty, AIStep
+	 *     reads the head of this queue in preference to user_message.
+	 *   - queue_enabled: when true, the queue head is popped per tick;
+	 *     when false, the head is statically peeked (first entry wins
+	 *     forever). Either way, queue head takes precedence over
+	 *     user_message.
+	 *
+	 * Omitting any of these from `flow get` output hides the precedence
+	 * chain — exactly the same blind-spot pattern as the original
+	 * --set-prompt dead-key bug. Render the slot keys with their
+	 * "unset" defaults so every input AIStep reads is discoverable.
 	 *
 	 * @param array $flow Flow data with flow_config.
-	 * @return array Flow data with user_message normalized on AI steps.
+	 * @return array Flow data with AI step prompt slots normalized.
 	 */
-	private static function normalizeAiStepUserMessage( array $flow ): array {
+	private static function normalizeAiStepPromptSlots( array $flow ): array {
 		if ( empty( $flow['flow_config'] ) || ! is_array( $flow['flow_config'] ) ) {
 			return $flow;
 		}
@@ -569,9 +598,118 @@ class FlowsCommand extends BaseCommand {
 			if ( ! array_key_exists( 'user_message', $step_data ) ) {
 				$flow['flow_config'][ $step_id ]['user_message'] = '';
 			}
+			if ( ! array_key_exists( 'prompt_queue', $step_data ) ) {
+				$flow['flow_config'][ $step_id ]['prompt_queue'] = array();
+			}
+			if ( ! array_key_exists( 'queue_enabled', $step_data ) ) {
+				$flow['flow_config'][ $step_id ]['queue_enabled'] = false;
+			}
 		}
 
 		return $flow;
+	}
+
+	/**
+	 * Resolve which prompt slot AIStep would actually read at runtime.
+	 *
+	 * Mirrors the precedence in inc/Core/Steps/AI/AIStep.php::execute()
+	 * lines 140-173:
+	 *
+	 *   - prompt_queue head wins when present (popped if queue_enabled,
+	 *     statically peeked otherwise).
+	 *   - user_message is the fallback when the queue head is empty.
+	 *   - both empty: AIStep runs with no flow-level user message
+	 *     (the pipeline system_prompt and any data packets still apply).
+	 *
+	 * @param array $step_data AI step data from flow_config.
+	 * @return array{slot:string, value:string, queue_depth:int, queue_enabled:bool}
+	 *               slot is one of: 'queue_head', 'user_message', 'none'.
+	 */
+	private static function resolveAiStepActivePrompt( array $step_data ): array {
+		$queue_enabled = (bool) ( $step_data['queue_enabled'] ?? false );
+		$prompt_queue  = $step_data['prompt_queue'] ?? array();
+		$queue_depth   = is_array( $prompt_queue ) ? count( $prompt_queue ) : 0;
+		$queue_head    = is_array( $prompt_queue ) ? trim( (string) ( $prompt_queue[0]['prompt'] ?? '' ) ) : '';
+		$user_message  = trim( (string) ( $step_data['user_message'] ?? '' ) );
+
+		if ( '' !== $queue_head ) {
+			return array(
+				'slot'          => 'queue_head',
+				'value'         => $queue_head,
+				'queue_depth'   => $queue_depth,
+				'queue_enabled' => $queue_enabled,
+			);
+		}
+
+		if ( '' !== $user_message ) {
+			return array(
+				'slot'          => 'user_message',
+				'value'         => $user_message,
+				'queue_depth'   => $queue_depth,
+				'queue_enabled' => $queue_enabled,
+			);
+		}
+
+		return array(
+			'slot'          => 'none',
+			'value'         => '',
+			'queue_depth'   => $queue_depth,
+			'queue_enabled' => $queue_enabled,
+		);
+	}
+
+	/**
+	 * Render a short label for the slot AIStep will read at runtime.
+	 *
+	 * Output examples:
+	 *   - "queue_head[1/3] (drains): \"Generate Q3 brief...\""
+	 *   - "queue_head[1/1] (static): \"Single override...\""
+	 *   - "user_message: \"Per-flow framing...\""
+	 *   - "(none)"
+	 *
+	 * The drains/static suffix on queue_head matches AIStep behavior:
+	 * with queue_enabled=true the head pops per tick (drains); with
+	 * queue_enabled=false the head is statically peeked (first entry
+	 * wins forever until the queue is mutated).
+	 *
+	 * @param array{slot:string, value:string, queue_depth:int, queue_enabled:bool} $resolved
+	 * @return string Formatted label suitable for table output.
+	 */
+	private static function formatActivePromptLabel( array $resolved ): string {
+		switch ( $resolved['slot'] ) {
+			case 'queue_head':
+				return sprintf(
+					'queue_head[1/%d] (%s): "%s"',
+					$resolved['queue_depth'],
+					$resolved['queue_enabled'] ? 'drains' : 'static',
+					self::truncateForLabel( $resolved['value'], 50 )
+				);
+
+			case 'user_message':
+				return sprintf( 'user_message: "%s"', self::truncateForLabel( $resolved['value'], 50 ) );
+
+			default:
+				return '(none)';
+		}
+	}
+
+	/**
+	 * Static helper for truncating values inside formatActivePromptLabel.
+	 *
+	 * Mirrors truncateValue() but is static so resolveAiStepActivePrompt's
+	 * companion formatter can stay static (callable from contexts without
+	 * a FlowsCommand instance, e.g. tests).
+	 *
+	 * @param string $value Value to truncate.
+	 * @param int    $max   Maximum characters.
+	 * @return string Truncated value.
+	 */
+	private static function truncateForLabel( string $value, int $max = 40 ): string {
+		$value = str_replace( array( "\n", "\r" ), ' ', $value );
+		if ( mb_strlen( $value ) > $max ) {
+			return mb_substr( $value, 0, $max - 3 ) . '...';
+		}
+		return $value;
 	}
 
 	/**

--- a/inc/Engine/AI/Directives/AgentModeDirective.php
+++ b/inc/Engine/AI/Directives/AgentModeDirective.php
@@ -45,7 +45,7 @@ PIPELINES define workflow structure: step types in sequence (e.g., event_import 
 
 FLOWS are configured pipeline instances. Each step needs a handler_slug and handler_config. When creating flows, match handler configurations from existing flows on the same pipeline.
 
-AI STEPS process data that handlers cannot automatically handle. Flow user_message is rarely needed; only for minimal source-specific overrides.
+AI STEPS process data that handlers cannot automatically handle. The pipeline system_prompt sets the agent's stable identity (shared across every flow). The flow user_message is appended as the final user-role message after fetched data packets — use it for per-flow task framing on top of the pipeline system_prompt. The two are additive, not alternative.
 
 ## Discovery
 

--- a/tests/flow-update-set-user-message-smoke.php
+++ b/tests/flow-update-set-user-message-smoke.php
@@ -63,12 +63,13 @@ function apply_update_flow_step_for_test( array $flow_step_config, array $input 
 }
 
 /**
- * Inline reimplementation of FlowsCommand::normalizeAiStepUserMessage().
- * AI steps must always expose the `user_message` slot, even when unset.
+ * Inline reimplementation of FlowsCommand::normalizeAiStepPromptSlots().
+ * AI steps must always expose every slot AIStep reads at runtime
+ * (`user_message`, `prompt_queue`, `queue_enabled`), even when unset.
  *
- * Mirrors inc/Cli/Commands/Flows/FlowsCommand.php::normalizeAiStepUserMessage.
+ * Mirrors inc/Cli/Commands/Flows/FlowsCommand.php::normalizeAiStepPromptSlots.
  */
-function normalize_ai_user_message_for_test( array $flow ): array {
+function normalize_ai_prompt_slots_for_test( array $flow ): array {
 	if ( empty( $flow['flow_config'] ) || ! is_array( $flow['flow_config'] ) ) {
 		return $flow;
 	}
@@ -83,9 +84,56 @@ function normalize_ai_user_message_for_test( array $flow ): array {
 		if ( ! array_key_exists( 'user_message', $step_data ) ) {
 			$flow['flow_config'][ $step_id ]['user_message'] = '';
 		}
+		if ( ! array_key_exists( 'prompt_queue', $step_data ) ) {
+			$flow['flow_config'][ $step_id ]['prompt_queue'] = array();
+		}
+		if ( ! array_key_exists( 'queue_enabled', $step_data ) ) {
+			$flow['flow_config'][ $step_id ]['queue_enabled'] = false;
+		}
 	}
 
 	return $flow;
+}
+
+/**
+ * Inline reimplementation of FlowsCommand::resolveAiStepActivePrompt().
+ * Resolves which slot AIStep::execute() reads at runtime.
+ *
+ * Mirrors inc/Core/Steps/AI/AIStep.php::execute() lines 140-173 and
+ * inc/Cli/Commands/Flows/FlowsCommand.php::resolveAiStepActivePrompt.
+ * Diverging here means one of those two files regressed.
+ */
+function resolve_ai_active_prompt_for_test( array $step_data ): array {
+	$queue_enabled = (bool) ( $step_data['queue_enabled'] ?? false );
+	$prompt_queue  = $step_data['prompt_queue'] ?? array();
+	$queue_depth   = is_array( $prompt_queue ) ? count( $prompt_queue ) : 0;
+	$queue_head    = is_array( $prompt_queue ) ? trim( (string) ( $prompt_queue[0]['prompt'] ?? '' ) ) : '';
+	$user_message  = trim( (string) ( $step_data['user_message'] ?? '' ) );
+
+	if ( '' !== $queue_head ) {
+		return array(
+			'slot'          => 'queue_head',
+			'value'         => $queue_head,
+			'queue_depth'   => $queue_depth,
+			'queue_enabled' => $queue_enabled,
+		);
+	}
+
+	if ( '' !== $user_message ) {
+		return array(
+			'slot'          => 'user_message',
+			'value'         => $user_message,
+			'queue_depth'   => $queue_depth,
+			'queue_enabled' => $queue_enabled,
+		);
+	}
+
+	return array(
+		'slot'          => 'none',
+		'value'         => '',
+		'queue_depth'   => $queue_depth,
+		'queue_enabled' => $queue_enabled,
+	);
 }
 
 $tests   = array();
@@ -195,10 +243,10 @@ assert_test(
 	'got: ' . var_export( $fetch_result['user_message'] ?? null, true )
 );
 
-// --- Case 4: normalizeAiStepUserMessage exposes the slot for `flow get`.
-echo "\nCase 4: flow get always renders user_message on AI steps\n";
+// --- Case 4: normalization exposes every prompt-input slot for `flow get`.
+echo "\nCase 4: flow get always renders user_message + prompt_queue + queue_enabled on AI steps\n";
 
-$flow_with_unset_user_message = array(
+$flow_with_unset_slots = array(
 	'flow_id'     => 1,
 	'flow_config' => array(
 		'pstep_ai_uuid_1' => array(
@@ -214,7 +262,7 @@ $flow_with_unset_user_message = array(
 	),
 );
 
-$normalized = normalize_ai_user_message_for_test( $flow_with_unset_user_message );
+$normalized = normalize_ai_prompt_slots_for_test( $flow_with_unset_slots );
 
 assert_test(
 	'AI step gets user_message="" when previously unset',
@@ -224,30 +272,58 @@ assert_test(
 );
 
 assert_test(
-	'non-AI step is NOT decorated with user_message',
-	! array_key_exists( 'user_message', $normalized['flow_config']['pstep_fetch_uuid_1'] ),
+	'AI step gets prompt_queue=[] when previously unset',
+	array_key_exists( 'prompt_queue', $normalized['flow_config']['pstep_ai_uuid_1'] )
+		&& array() === $normalized['flow_config']['pstep_ai_uuid_1']['prompt_queue'],
+	'got: ' . var_export( $normalized['flow_config']['pstep_ai_uuid_1']['prompt_queue'] ?? null, true )
+);
+
+assert_test(
+	'AI step gets queue_enabled=false when previously unset',
+	array_key_exists( 'queue_enabled', $normalized['flow_config']['pstep_ai_uuid_1'] )
+		&& false === $normalized['flow_config']['pstep_ai_uuid_1']['queue_enabled'],
+	'got: ' . var_export( $normalized['flow_config']['pstep_ai_uuid_1']['queue_enabled'] ?? null, true )
+);
+
+assert_test(
+	'non-AI step is NOT decorated with prompt slots',
+	! array_key_exists( 'user_message', $normalized['flow_config']['pstep_fetch_uuid_1'] )
+		&& ! array_key_exists( 'prompt_queue', $normalized['flow_config']['pstep_fetch_uuid_1'] )
+		&& ! array_key_exists( 'queue_enabled', $normalized['flow_config']['pstep_fetch_uuid_1'] ),
 	'got: ' . var_export( $normalized['flow_config']['pstep_fetch_uuid_1'], true )
 );
 
-// --- Case 5: existing user_message values are preserved by normalization.
-echo "\nCase 5: normalization preserves existing user_message values\n";
+// --- Case 5: existing values are preserved by normalization.
+echo "\nCase 5: normalization preserves existing values\n";
 
-$flow_with_set_user_message = array(
+$flow_with_set_values = array(
 	'flow_id'     => 2,
 	'flow_config' => array(
 		'pstep_ai_uuid_1' => array(
-			'step_type'    => 'ai',
-			'user_message' => 'Existing per-flow context.',
+			'step_type'     => 'ai',
+			'user_message'  => 'Existing per-flow context.',
+			'prompt_queue'  => array( array( 'prompt' => 'queued', 'added_at' => '2026-01-01T00:00:00Z' ) ),
+			'queue_enabled' => true,
 		),
 	),
 );
 
-$preserved = normalize_ai_user_message_for_test( $flow_with_set_user_message );
+$preserved = normalize_ai_prompt_slots_for_test( $flow_with_set_values );
 
 assert_test(
-	'existing user_message is preserved verbatim',
-	'Existing per-flow context.' === $preserved['flow_config']['pstep_ai_uuid_1']['user_message'],
-	'got: ' . var_export( $preserved['flow_config']['pstep_ai_uuid_1']['user_message'] ?? null, true )
+	'existing user_message preserved verbatim',
+	'Existing per-flow context.' === $preserved['flow_config']['pstep_ai_uuid_1']['user_message']
+);
+
+assert_test(
+	'existing prompt_queue preserved verbatim',
+	$preserved['flow_config']['pstep_ai_uuid_1']['prompt_queue']
+		=== array( array( 'prompt' => 'queued', 'added_at' => '2026-01-01T00:00:00Z' ) )
+);
+
+assert_test(
+	'existing queue_enabled preserved verbatim',
+	true === $preserved['flow_config']['pstep_ai_uuid_1']['queue_enabled']
 );
 
 // --- Case 6: empty/missing flow_config doesn't blow up normalization.
@@ -255,12 +331,12 @@ echo "\nCase 6: normalization is null-safe\n";
 
 assert_test(
 	'no flow_config returns flow unchanged',
-	normalize_ai_user_message_for_test( array( 'flow_id' => 3 ) ) === array( 'flow_id' => 3 )
+	normalize_ai_prompt_slots_for_test( array( 'flow_id' => 3 ) ) === array( 'flow_id' => 3 )
 );
 
 assert_test(
 	'non-array flow_config returns flow unchanged',
-	normalize_ai_user_message_for_test( array( 'flow_id' => 4, 'flow_config' => 'oops' ) )
+	normalize_ai_prompt_slots_for_test( array( 'flow_id' => 4, 'flow_config' => 'oops' ) )
 		=== array( 'flow_id' => 4, 'flow_config' => 'oops' )
 );
 
@@ -273,10 +349,148 @@ assert_test(
 				'pstep_ai_uuid_1' => array( 'step_type' => 'ai' ),
 			),
 		);
-		$out = normalize_ai_user_message_for_test( $flow );
+		$out = normalize_ai_prompt_slots_for_test( $flow );
 		return $out['flow_config']['memory_files'] === array( 'a.md' )
 			&& '' === $out['flow_config']['pstep_ai_uuid_1']['user_message'];
 	})()
+);
+
+// --- Case 7: resolver picks queue_head when prompt_queue has entries.
+echo "\nCase 7: resolveAiStepActivePrompt — queue head wins over user_message\n";
+
+$step_with_queue_and_message = array(
+	'step_type'     => 'ai',
+	'user_message'  => 'fallback per-flow context',
+	'prompt_queue'  => array(
+		array( 'prompt' => 'first queued', 'added_at' => '2026-01-01T00:00:00Z' ),
+		array( 'prompt' => 'second queued', 'added_at' => '2026-01-02T00:00:00Z' ),
+	),
+	'queue_enabled' => false,
+);
+
+$resolved = resolve_ai_active_prompt_for_test( $step_with_queue_and_message );
+
+assert_test(
+	'queue head takes precedence over user_message',
+	'queue_head' === $resolved['slot'] && 'first queued' === $resolved['value']
+);
+
+assert_test(
+	'queue depth reflects total entries (not just head)',
+	2 === $resolved['queue_depth']
+);
+
+assert_test(
+	'queue_enabled=false surfaced unchanged',
+	false === $resolved['queue_enabled']
+);
+
+// --- Case 8: queue_enabled=true with non-empty queue still picks queue_head.
+echo "\nCase 8: resolveAiStepActivePrompt — queue_enabled=true + non-empty\n";
+
+$step_drains_mode = array(
+	'step_type'     => 'ai',
+	'user_message'  => 'fallback',
+	'prompt_queue'  => array( array( 'prompt' => 'drains tick', 'added_at' => '2026-01-01T00:00:00Z' ) ),
+	'queue_enabled' => true,
+);
+
+$resolved = resolve_ai_active_prompt_for_test( $step_drains_mode );
+
+assert_test(
+	'drains-mode queue head still resolves to queue_head slot',
+	'queue_head' === $resolved['slot'] && 'drains tick' === $resolved['value']
+);
+
+assert_test(
+	'queue_enabled=true surfaced unchanged',
+	true === $resolved['queue_enabled']
+);
+
+// --- Case 9: empty queue falls back to user_message.
+echo "\nCase 9: resolveAiStepActivePrompt — empty queue falls back to user_message\n";
+
+$step_message_only = array(
+	'step_type'     => 'ai',
+	'user_message'  => 'per-flow framing',
+	'prompt_queue'  => array(),
+	'queue_enabled' => false,
+);
+
+$resolved = resolve_ai_active_prompt_for_test( $step_message_only );
+
+assert_test(
+	'empty queue → user_message slot',
+	'user_message' === $resolved['slot'] && 'per-flow framing' === $resolved['value']
+);
+
+assert_test(
+	'queue_depth=0 reported when queue is empty',
+	0 === $resolved['queue_depth']
+);
+
+// --- Case 10: queue head with empty string falls through to user_message.
+//     This matches AIStep::execute() behavior: empty $queued_prompt
+//     triggers the `if ( empty( $user_message ) )` fallback.
+echo "\nCase 10: resolveAiStepActivePrompt — empty-string queue head falls through\n";
+
+$step_empty_head = array(
+	'step_type'     => 'ai',
+	'user_message'  => 'message wins when head is empty string',
+	'prompt_queue'  => array( array( 'prompt' => '', 'added_at' => '2026-01-01T00:00:00Z' ) ),
+	'queue_enabled' => false,
+);
+
+$resolved = resolve_ai_active_prompt_for_test( $step_empty_head );
+
+assert_test(
+	'empty-string queue head falls through to user_message',
+	'user_message' === $resolved['slot']
+		&& 'message wins when head is empty string' === $resolved['value']
+);
+
+// --- Case 11: nothing set anywhere yields slot=none.
+echo "\nCase 11: resolveAiStepActivePrompt — nothing set yields slot=none\n";
+
+$step_empty = array(
+	'step_type'     => 'ai',
+	'user_message'  => '',
+	'prompt_queue'  => array(),
+	'queue_enabled' => false,
+);
+
+$resolved = resolve_ai_active_prompt_for_test( $step_empty );
+
+assert_test(
+	'all slots empty → slot=none',
+	'none' === $resolved['slot'] && '' === $resolved['value']
+);
+
+assert_test(
+	'all slots empty → queue_depth=0',
+	0 === $resolved['queue_depth']
+);
+
+// --- Case 12: malformed prompt_queue (non-array) is null-safe.
+echo "\nCase 12: resolveAiStepActivePrompt — null-safe on malformed data\n";
+
+$step_malformed = array(
+	'step_type'     => 'ai',
+	'user_message'  => 'still works',
+	'prompt_queue'  => 'not an array',
+	'queue_enabled' => false,
+);
+
+$resolved = resolve_ai_active_prompt_for_test( $step_malformed );
+
+assert_test(
+	'malformed prompt_queue → falls back to user_message',
+	'user_message' === $resolved['slot'] && 'still works' === $resolved['value']
+);
+
+assert_test(
+	'malformed prompt_queue → queue_depth=0',
+	0 === $resolved['queue_depth']
 );
 
 echo "\n--- Summary ---\n";

--- a/tests/flow-update-set-user-message-smoke.php
+++ b/tests/flow-update-set-user-message-smoke.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * Pure-PHP smoke test for the `flow update --set-user-message` fix (#1289).
+ *
+ * Run with: php tests/flow-update-set-user-message-smoke.php
+ *
+ * The bug: `wp datamachine flow update <id> --set-prompt="..."` silently
+ * wrote to handler_configs.ai.prompt, which AIStep::execute() never reads.
+ * AIStep reads $flow_step_config['user_message'] at the flow_step_config
+ * root, not under handler_configs. The CLI's `Success` message was a lie.
+ *
+ * The fix has three observable contracts this smoke covers:
+ *
+ *   1. The CLI rename: --set-prompt is removed (clean break, no alias),
+ *      --set-user-message is the new flag.
+ *   2. The CLI's write goes through UpdateFlowStepAbility's `user_message`
+ *      input parameter (which routes to updateUserMessage()), not via
+ *      `handler_config => array( 'prompt' => $prompt )`.
+ *   3. `flow get` always renders the `user_message` slot on AI steps,
+ *      even when unset, so the field is discoverable.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/**
+ * Inline reimplementation of UpdateFlowStepAbility::execute()'s
+ * write-routing logic (the relevant slice). When `user_message` is in
+ * the input, it's written to flow_step_config['user_message']. When
+ * `handler_config` is in the input, it's merged into
+ * flow_step_config['handler_configs'][$slug].
+ *
+ * Mirrors inc/Abilities/FlowStep/UpdateFlowStepAbility.php and
+ * inc/Abilities/FlowStep/FlowStepHelpers.php::updateUserMessage().
+ * Diverging here means the real files regressed.
+ */
+function apply_update_flow_step_for_test( array $flow_step_config, array $input ): array {
+	$user_message       = $input['user_message'] ?? null;
+	$handler_config     = $input['handler_config'] ?? array();
+	$has_message_update = null !== $user_message;
+	$has_handler_update = ! empty( $handler_config );
+
+	if ( $has_handler_update ) {
+		$slug = $input['handler_slug']
+			?? ( $flow_step_config['handler_slugs'][0] ?? ( $flow_step_config['step_type'] ?? '' ) );
+		if ( ! isset( $flow_step_config['handler_configs'][ $slug ] ) ) {
+			$flow_step_config['handler_configs'][ $slug ] = array();
+		}
+		$flow_step_config['handler_configs'][ $slug ] = array_merge(
+			$flow_step_config['handler_configs'][ $slug ],
+			$handler_config
+		);
+	}
+
+	if ( $has_message_update ) {
+		$flow_step_config['user_message'] = $user_message;
+	}
+
+	return $flow_step_config;
+}
+
+/**
+ * Inline reimplementation of FlowsCommand::normalizeAiStepUserMessage().
+ * AI steps must always expose the `user_message` slot, even when unset.
+ *
+ * Mirrors inc/Cli/Commands/Flows/FlowsCommand.php::normalizeAiStepUserMessage.
+ */
+function normalize_ai_user_message_for_test( array $flow ): array {
+	if ( empty( $flow['flow_config'] ) || ! is_array( $flow['flow_config'] ) ) {
+		return $flow;
+	}
+
+	foreach ( $flow['flow_config'] as $step_id => $step_data ) {
+		if ( ! is_array( $step_data ) ) {
+			continue;
+		}
+		if ( 'ai' !== ( $step_data['step_type'] ?? '' ) ) {
+			continue;
+		}
+		if ( ! array_key_exists( 'user_message', $step_data ) ) {
+			$flow['flow_config'][ $step_id ]['user_message'] = '';
+		}
+	}
+
+	return $flow;
+}
+
+$tests   = array();
+$failed  = 0;
+$total   = 0;
+
+function assert_test( string $name, bool $cond, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $cond ) {
+		echo "  [PASS] $name\n";
+	} else {
+		echo "  [FAIL] $name" . ( $detail ? " — $detail" : '' ) . "\n";
+		++$failed;
+	}
+}
+
+// --- Case 1: CLI maps --set-user-message to the user_message input.
+echo "Case 1: --set-user-message routes through user_message input\n";
+
+$flow_step_config = array(
+	'step_type'       => 'ai',
+	'handler_slugs'   => array(),
+	'handler_configs' => array(),
+);
+
+// Simulate FlowsCommand::updateFlow() building the ability input from
+// $assoc_args['set-user-message']. This is the exact shape the post-fix
+// CLI passes to UpdateFlowStepAbility::execute().
+$ability_input = array(
+	'flow_step_id' => 'pstep_1_uuid_1',
+	'user_message' => 'Per-flow task framing for the WC backfill.',
+);
+
+$result = apply_update_flow_step_for_test( $flow_step_config, $ability_input );
+
+assert_test(
+	'user_message lands at flow_step_config root',
+	( $result['user_message'] ?? null ) === 'Per-flow task framing for the WC backfill.',
+	'got: ' . var_export( $result['user_message'] ?? null, true )
+);
+
+assert_test(
+	'handler_configs.ai.prompt is NOT written (the dead key from the bug)',
+	! isset( $result['handler_configs']['ai']['prompt'] ),
+	'unexpected dead-key write: ' . var_export( $result['handler_configs'], true )
+);
+
+assert_test(
+	'handler_configs remains empty when only user_message is set',
+	$result['handler_configs'] === array(),
+	'got: ' . var_export( $result['handler_configs'], true )
+);
+
+// --- Case 2: The pre-fix shape would have written to the dead key.
+//     Demonstrate that the OLD CLI path (handler_config => prompt) is
+//     visibly broken: it does NOT populate user_message.
+echo "\nCase 2: old broken shape (handler_config => prompt) is observably wrong\n";
+
+$broken_input = array(
+	'flow_step_id'   => 'pstep_1_uuid_1',
+	'handler_config' => array( 'prompt' => 'TEST' ),
+);
+
+$broken_result = apply_update_flow_step_for_test( $flow_step_config, $broken_input );
+
+assert_test(
+	'old shape writes to handler_configs.ai.prompt (the dead key)',
+	( $broken_result['handler_configs']['ai']['prompt'] ?? null ) === 'TEST',
+	'pre-fix behavior should still be reproducible to prove the bug shape; got: '
+		. var_export( $broken_result['handler_configs'], true )
+);
+
+assert_test(
+	'old shape leaves user_message unset (the silent failure)',
+	! isset( $broken_result['user_message'] ),
+	'old broken shape should NOT touch user_message; got: '
+		. var_export( $broken_result['user_message'] ?? null, true )
+);
+
+// --- Case 3: Existing handler_config writes still work for non-AI steps.
+echo "\nCase 3: handler_config writes still work for handler steps\n";
+
+$fetch_step_config = array(
+	'step_type'       => 'fetch',
+	'handler_slugs'   => array( 'reddit' ),
+	'handler_configs' => array( 'reddit' => array( 'subreddit' => 'old' ) ),
+);
+
+$fetch_input = array(
+	'flow_step_id'   => 'pstep_2_uuid_1',
+	'handler_slug'   => 'reddit',
+	'handler_config' => array( 'subreddit' => 'WordPress' ),
+);
+
+$fetch_result = apply_update_flow_step_for_test( $fetch_step_config, $fetch_input );
+
+assert_test(
+	'handler_config merges into handler_configs[<slug>]',
+	( $fetch_result['handler_configs']['reddit']['subreddit'] ?? null ) === 'WordPress',
+	'got: ' . var_export( $fetch_result['handler_configs'], true )
+);
+
+assert_test(
+	'handler_config does NOT bleed into user_message',
+	! isset( $fetch_result['user_message'] ),
+	'got: ' . var_export( $fetch_result['user_message'] ?? null, true )
+);
+
+// --- Case 4: normalizeAiStepUserMessage exposes the slot for `flow get`.
+echo "\nCase 4: flow get always renders user_message on AI steps\n";
+
+$flow_with_unset_user_message = array(
+	'flow_id'     => 1,
+	'flow_config' => array(
+		'pstep_ai_uuid_1' => array(
+			'step_type'       => 'ai',
+			'handler_slugs'   => array(),
+			'handler_configs' => array(),
+		),
+		'pstep_fetch_uuid_1' => array(
+			'step_type'       => 'fetch',
+			'handler_slugs'   => array( 'reddit' ),
+			'handler_configs' => array( 'reddit' => array( 'subreddit' => 'WordPress' ) ),
+		),
+	),
+);
+
+$normalized = normalize_ai_user_message_for_test( $flow_with_unset_user_message );
+
+assert_test(
+	'AI step gets user_message="" when previously unset',
+	array_key_exists( 'user_message', $normalized['flow_config']['pstep_ai_uuid_1'] )
+		&& '' === $normalized['flow_config']['pstep_ai_uuid_1']['user_message'],
+	'got: ' . var_export( $normalized['flow_config']['pstep_ai_uuid_1'], true )
+);
+
+assert_test(
+	'non-AI step is NOT decorated with user_message',
+	! array_key_exists( 'user_message', $normalized['flow_config']['pstep_fetch_uuid_1'] ),
+	'got: ' . var_export( $normalized['flow_config']['pstep_fetch_uuid_1'], true )
+);
+
+// --- Case 5: existing user_message values are preserved by normalization.
+echo "\nCase 5: normalization preserves existing user_message values\n";
+
+$flow_with_set_user_message = array(
+	'flow_id'     => 2,
+	'flow_config' => array(
+		'pstep_ai_uuid_1' => array(
+			'step_type'    => 'ai',
+			'user_message' => 'Existing per-flow context.',
+		),
+	),
+);
+
+$preserved = normalize_ai_user_message_for_test( $flow_with_set_user_message );
+
+assert_test(
+	'existing user_message is preserved verbatim',
+	'Existing per-flow context.' === $preserved['flow_config']['pstep_ai_uuid_1']['user_message'],
+	'got: ' . var_export( $preserved['flow_config']['pstep_ai_uuid_1']['user_message'] ?? null, true )
+);
+
+// --- Case 6: empty/missing flow_config doesn't blow up normalization.
+echo "\nCase 6: normalization is null-safe\n";
+
+assert_test(
+	'no flow_config returns flow unchanged',
+	normalize_ai_user_message_for_test( array( 'flow_id' => 3 ) ) === array( 'flow_id' => 3 )
+);
+
+assert_test(
+	'non-array flow_config returns flow unchanged',
+	normalize_ai_user_message_for_test( array( 'flow_id' => 4, 'flow_config' => 'oops' ) )
+		=== array( 'flow_id' => 4, 'flow_config' => 'oops' )
+);
+
+assert_test(
+	'non-array step_data is skipped',
+	(function (): bool {
+		$flow = array(
+			'flow_config' => array(
+				'memory_files'    => array( 'a.md' ),
+				'pstep_ai_uuid_1' => array( 'step_type' => 'ai' ),
+			),
+		);
+		$out = normalize_ai_user_message_for_test( $flow );
+		return $out['flow_config']['memory_files'] === array( 'a.md' )
+			&& '' === $out['flow_config']['pstep_ai_uuid_1']['user_message'];
+	})()
+);
+
+echo "\n--- Summary ---\n";
+echo "Passed: " . ( $total - $failed ) . " / $total\n";
+
+if ( $failed > 0 ) {
+	echo "FAILED\n";
+	exit( 1 );
+}
+
+echo "OK\n";
+exit( 0 );


### PR DESCRIPTION
## Summary

`wp datamachine flow update <id> --set-prompt="..."` reported `Success` but the value never reached the AI step. The CLI was passing `handler_config => array( 'prompt' => \$prompt )` into `UpdateFlowStepAbility`, landing at `flow_step_config.handler_configs.ai.prompt` — a key `AIStep::execute()` never reads. AIStep reads `\$flow_step_config['user_message']` at the flow_step_config root (with `prompt_queue` taking precedence over it — see Precedence below). The CLI just never used the right slot.

Closes #1289.

## Bug fix

- **`FlowsCommand::updateFlow()`** now passes `[ 'flow_step_id' => \$step, 'user_message' => \$value ]` to `UpdateFlowStepAbility` instead of stuffing the value into `handler_config` under a bogus `prompt` key. This is the actual bug fix — the value now reaches a slot AIStep reads.
- **Flag rename, clean break, no alias.** `--set-prompt` is removed entirely. The old flag was silently broken, so there is no working consumer to migrate; hard-fail with a pointer to `--set-user-message` (and to `pipeline update --set-system-prompt` for the pipeline-wide case). New flag: `--set-user-message=<text>`.
- Updated doc block, EXAMPLES, the usage error string, and the success message (\"User message updated for step: …\") to reflect the new shape.

## Precedence (the part the issue body got slightly wrong)

AIStep::execute() (lines 140-173) reads three slots at the `flow_step_config` root and chains them:

| Slot | Source | Behavior |
|---|---|---|
| `prompt_queue[0].prompt` | `flow queue add` / webhooks / pipeline backfill | Wins when present. Popped per tick if `queue_enabled=true`; statically peeked (first entry wins forever) if `queue_enabled=false`. |
| `user_message` | `--set-user-message` | Fallback when the queue head is empty. |
| (none) | — | AIStep runs with no flow-level user message; pipeline `system_prompt` and any data packets still apply. |

So `--set-user-message` writes to the right slot, but the **active** slot at runtime depends on queue state. The original issue body called `prompt_queue` "unrelated" — it isn't; it's the higher-priority sibling slot. This PR makes that precedence visible in `flow get` so nobody else trips over it.

The broader architectural question of whether `user_message` and `prompt_queue` should be collapsed into a single storage slot (one role, one slot) is **out of scope for this PR** and will be filed as its own design issue.

## Discoverability extension

- **`flow get` always renders the prompt-input slots on AI steps.** New `FlowsCommand::normalizeAiStepPromptSlots()` ensures `user_message`, `prompt_queue`, and `queue_enabled` are always present in JSON/YAML output, even when unset. Hidden slots are how the original dead-key bug stayed invisible.
- **New `FlowsCommand::resolveAiStepActivePrompt()`** byte-mirrors AIStep's precedence and returns the slot AIStep would actually read at runtime.
- **Table output** now shows for AI steps:
  ```
  system_prompt=…, user_message=(unset), queue=2 item(s), queue_enabled=false,
  active_prompt=queue_head[1/2] (static): \"first queued…\"
  ```
  The `drains`/`static` suffix matches `queue_enabled` behavior. The `active_prompt` line names which slot AIStep will actually read — so a user can no longer set `user_message` and be surprised when the queue head wins.

## AgentModeDirective

- Replaced \"Flow user_message is rarely needed; only for minimal source-specific overrides\" with a description of the **additive** relationship between the pipeline `system_prompt` (stable agent identity, shared across flows) and the flow `user_message` (per-flow task framing appended after data packets). Nothing is being overridden — both apply on every run.

## Tests

- **`tests/flow-update-set-user-message-smoke.php`** — 29 assertions across 12 cases, all byte-mirrors of production code paths:
  - **Cases 1-3:** `--set-user-message` routes through the `user_message` parameter; the dead key is gone; the old broken shape is observably wrong; handler_config writes still work for handler steps.
  - **Cases 4-6:** `normalizeAiStepPromptSlots` exposes all three slots, preserves existing values, is null-safe.
  - **Cases 7-12:** `resolveAiStepActivePrompt` against every AIStep precedence branch — queue head wins, drains vs static, empty queue falls back, empty-string head falls through, all-empty yields `slot=none`, malformed `prompt_queue` is null-safe.
- All **19 existing smoke suites** still pass.

## Out of scope (deferred to follow-up issues)

- Collapsing `user_message` into the `prompt_queue` (one storage slot for the per-flow user-role message). The current two-slot model has historical depth and a React UI surface; the cleanup belongs in its own design issue with a migration plan. See **#1291** — `design: collapse user_message into prompt_queue`.
- The `prompt_queue` queueable variant in `AIStep::execute()` lines 142-169 is correctly handled today; this PR makes its precedence with `user_message` visible but does not change behavior.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Reading the CLI / AIStep / UpdateFlowStepAbility / QueueAbility paths, drafting the rename + write-routing fix, tracing the AIStep precedence chain after Chris pushed back on the original PR's \"unrelated\" framing of `prompt_queue`, extending `flow get` to surface the resolved active slot, and authoring the byte-mirror smoke test. Chris drove the framing decisions: clean break with no deprecation alias, surface the queue precedence in this PR, defer the storage-slot collapse to a separate design issue.