### PR TITLE
feat(queue): split prompt_queue payload polymorphism into two slots (#1292)

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -621,6 +621,9 @@ function datamachine_activate_for_site() {
 	// Move AI step tools from handler_slugs to enabled_tools (#1205 Phase 2b, idempotent).
 	datamachine_migrate_ai_enabled_tools();
 
+	// Split prompt_queue / config_patch_queue payload polymorphism (#1292, idempotent).
+	datamachine_migrate_split_queue_payload();
+
 	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
 	datamachine_drop_redundant_post_pipeline_meta();
 

--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -71,18 +71,31 @@ trait FlowHelpers {
 
 			$disabled_tools = $pipeline_config[ $pipeline_step_id ]['disabled_tools'] ?? array();
 
-			$flow_config[ $flow_step_id ] = array(
+			$step_type   = $step['step_type'] ?? '';
+			$step_config = array(
 				'flow_step_id'     => $flow_step_id,
-				'step_type'        => $step['step_type'] ?? '',
+				'step_type'        => $step_type,
 				'pipeline_step_id' => $pipeline_step_id,
 				'pipeline_id'      => $pipeline_id,
 				'flow_id'          => $flow_id,
 				'execution_order'  => $step['execution_order'] ?? 0,
 				'disabled_tools'   => $disabled_tools,
 				'handler'          => null,
-				'prompt_queue'     => array(),
 				'queue_enabled'    => false,
 			);
+
+			// Fetch consumes from config_patch_queue (#1292); other
+			// step types that consume the queue use prompt_queue. Steps
+			// that have no queueable consumer don't need either field
+			// initialized — it's lazy-created by QueueAbility on first
+			// write.
+			if ( 'fetch' === $step_type ) {
+				$step_config['config_patch_queue'] = array();
+			} else {
+				$step_config['prompt_queue'] = array();
+			}
+
+			$flow_config[ $flow_step_id ] = $step_config;
 		}
 
 		$success = $this->db_flows->update_flow(

--- a/inc/Abilities/Flow/QueueAbility.php
+++ b/inc/Abilities/Flow/QueueAbility.php
@@ -2,8 +2,27 @@
 /**
  * Queue Ability
  *
- * Manages prompt queues for flows. Prompts are stored in flow_config
- * and processed sequentially by AI steps.
+ * Manages per-step queues attached to flow steps. Two parallel queues
+ * are supported, each with its own payload shape:
+ *
+ *   - `prompt_queue`        — array<{prompt:string, added_at:string}>
+ *                             Consumed by AI step (`AIStep::execute()`)
+ *                             via {@see QueueableTrait::popFromQueueIfEmpty}.
+ *                             Each entry is a plain user-message string.
+ *
+ *   - `config_patch_queue`  — array<{patch:array, added_at:string}>
+ *                             Consumed by Fetch step
+ *                             (`FetchStep::executeStep()`) via
+ *                             {@see QueueableTrait::popQueuedConfigPatch}.
+ *                             Each entry is a decoded object that gets
+ *                             deep-merged into the handler's static
+ *                             config before the fetch runs.
+ *
+ * Splitting these slots is #1292 — pre-split, both consumers shared a
+ * single `prompt_queue` and ran string-vs-JSON detective work at read
+ * time, with no validation at write time. Now each slot has one
+ * payload shape, validated by JSON Schema directly, and writes that
+ * target the wrong slot for a step type fail loudly.
  *
  * @package DataMachine\Abilities\Flow
  * @since 0.16.0
@@ -20,6 +39,30 @@ class QueueAbility {
 
 	use FlowHelpers;
 
+	/**
+	 * Slot name for AI prompt queues. Used as both the storage key
+	 * and the per-entry payload field name (so each entry is
+	 * `{ prompt: string, added_at: string }`).
+	 */
+	const SLOT_PROMPT_QUEUE = 'prompt_queue';
+
+	/**
+	 * Slot name for fetch-step config-patch queues. Each entry is
+	 * `{ patch: array, added_at: string }` — `patch` is a decoded
+	 * object stored verbatim (no JSON-encoding-as-string).
+	 */
+	const SLOT_CONFIG_PATCH_QUEUE = 'config_patch_queue';
+
+	/**
+	 * Per-entry payload field name for prompt queues.
+	 */
+	const FIELD_PROMPT = 'prompt';
+
+	/**
+	 * Per-entry payload field name for config-patch queues.
+	 */
+	const FIELD_PATCH = 'patch';
+
 	public function __construct() {
 		$this->initDatabases();
 
@@ -31,6 +74,7 @@ class QueueAbility {
 	 */
 	private function registerAbilities(): void {
 		$register_callback = function () {
+			// Prompt queue (AI consumer).
 			$this->registerQueueAdd();
 			$this->registerQueueList();
 			$this->registerQueueClear();
@@ -38,6 +82,14 @@ class QueueAbility {
 			$this->registerQueueUpdate();
 			$this->registerQueueMove();
 			$this->registerQueueSettings();
+
+			// Config patch queue (Fetch consumer).
+			$this->registerConfigPatchAdd();
+			$this->registerConfigPatchList();
+			$this->registerConfigPatchClear();
+			$this->registerConfigPatchRemove();
+			$this->registerConfigPatchUpdate();
+			$this->registerConfigPatchMove();
 		};
 
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
@@ -55,7 +107,7 @@ class QueueAbility {
 			'datamachine/queue-add',
 			array(
 				'label'               => __( 'Add to Queue', 'data-machine' ),
-				'description'         => __( 'Add a prompt to the flow queue.', 'data-machine' ),
+				'description'         => __( 'Add a prompt to the AI step prompt queue.', 'data-machine' ),
 				'category'            => 'datamachine-flow',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -113,7 +165,7 @@ class QueueAbility {
 			'datamachine/queue-list',
 			array(
 				'label'               => __( 'List Queue', 'data-machine' ),
-				'description'         => __( 'List all prompts in the flow queue.', 'data-machine' ),
+				'description'         => __( 'List all prompts in the AI step prompt queue.', 'data-machine' ),
 				'category'            => 'datamachine-flow',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -156,7 +208,7 @@ class QueueAbility {
 			'datamachine/queue-clear',
 			array(
 				'label'               => __( 'Clear Queue', 'data-machine' ),
-				'description'         => __( 'Clear all prompts from the flow queue.', 'data-machine' ),
+				'description'         => __( 'Clear all prompts from the AI step prompt queue.', 'data-machine' ),
 				'category'            => 'datamachine-flow',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -386,9 +438,289 @@ class QueueAbility {
 	}
 
 	/**
-	 * Add a prompt to the flow queue.
+	 * Register config-patch-add ability (Fetch consumer).
+	 */
+	private function registerConfigPatchAdd(): void {
+		wp_register_ability(
+			'datamachine/config-patch-add',
+			array(
+				'label'               => __( 'Add Config Patch to Queue', 'data-machine' ),
+				'description'         => __( 'Add a config patch to the fetch step queue. The patch is deep-merged into the handler config when the step runs.', 'data-machine' ),
+				'category'            => 'datamachine-flow',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'flow_id', 'flow_step_id', 'patch' ),
+					'properties' => array(
+						'flow_id'      => array(
+							'type'        => 'integer',
+							'description' => __( 'Flow ID', 'data-machine' ),
+						),
+						'flow_step_id' => array(
+							'type'        => 'string',
+							'description' => __( 'Flow step ID (must be a fetch step)', 'data-machine' ),
+						),
+						'patch'        => array(
+							'type'        => 'object',
+							'description' => __( 'Config patch object — deep-merged into the handler config at fetch time. Shape must mirror the handler\'s static config nesting.', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'flow_id'      => array( 'type' => 'integer' ),
+						'flow_step_id' => array( 'type' => 'string' ),
+						'queue_length' => array( 'type' => 'integer' ),
+						'message'      => array( 'type' => 'string' ),
+						'error'        => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeConfigPatchAdd' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Register config-patch-list ability.
+	 */
+	private function registerConfigPatchList(): void {
+		wp_register_ability(
+			'datamachine/config-patch-list',
+			array(
+				'label'               => __( 'List Config Patch Queue', 'data-machine' ),
+				'description'         => __( 'List all queued config patches for a fetch step.', 'data-machine' ),
+				'category'            => 'datamachine-flow',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'flow_id', 'flow_step_id' ),
+					'properties' => array(
+						'flow_id'      => array(
+							'type'        => 'integer',
+							'description' => __( 'Flow ID', 'data-machine' ),
+						),
+						'flow_step_id' => array(
+							'type'        => 'string',
+							'description' => __( 'Flow step ID', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'flow_id'       => array( 'type' => 'integer' ),
+						'flow_step_id'  => array( 'type' => 'string' ),
+						'queue'         => array( 'type' => 'array' ),
+						'count'         => array( 'type' => 'integer' ),
+						'queue_enabled' => array( 'type' => 'boolean' ),
+						'error'         => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeConfigPatchList' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Register config-patch-clear ability.
+	 */
+	private function registerConfigPatchClear(): void {
+		wp_register_ability(
+			'datamachine/config-patch-clear',
+			array(
+				'label'               => __( 'Clear Config Patch Queue', 'data-machine' ),
+				'description'         => __( 'Clear all queued config patches for a fetch step.', 'data-machine' ),
+				'category'            => 'datamachine-flow',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'flow_id', 'flow_step_id' ),
+					'properties' => array(
+						'flow_id'      => array(
+							'type'        => 'integer',
+							'description' => __( 'Flow ID', 'data-machine' ),
+						),
+						'flow_step_id' => array(
+							'type'        => 'string',
+							'description' => __( 'Flow step ID', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'flow_id'       => array( 'type' => 'integer' ),
+						'flow_step_id'  => array( 'type' => 'string' ),
+						'cleared_count' => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
+						'error'         => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeConfigPatchClear' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Register config-patch-remove ability.
+	 */
+	private function registerConfigPatchRemove(): void {
+		wp_register_ability(
+			'datamachine/config-patch-remove',
+			array(
+				'label'               => __( 'Remove Config Patch from Queue', 'data-machine' ),
+				'description'         => __( 'Remove a queued config patch by index.', 'data-machine' ),
+				'category'            => 'datamachine-flow',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'flow_id', 'flow_step_id', 'index' ),
+					'properties' => array(
+						'flow_id'      => array(
+							'type'        => 'integer',
+							'description' => __( 'Flow ID', 'data-machine' ),
+						),
+						'flow_step_id' => array(
+							'type'        => 'string',
+							'description' => __( 'Flow step ID', 'data-machine' ),
+						),
+						'index'        => array(
+							'type'        => 'integer',
+							'description' => __( 'Queue index to remove (0-based)', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'flow_id'       => array( 'type' => 'integer' ),
+						'removed_patch' => array( 'type' => 'object' ),
+						'queue_length'  => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
+						'error'         => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeConfigPatchRemove' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Register config-patch-update ability.
+	 */
+	private function registerConfigPatchUpdate(): void {
+		wp_register_ability(
+			'datamachine/config-patch-update',
+			array(
+				'label'               => __( 'Update Config Patch in Queue', 'data-machine' ),
+				'description'         => __( 'Replace a queued config patch at a specific index.', 'data-machine' ),
+				'category'            => 'datamachine-flow',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'flow_id', 'flow_step_id', 'index', 'patch' ),
+					'properties' => array(
+						'flow_id'      => array(
+							'type'        => 'integer',
+							'description' => __( 'Flow ID', 'data-machine' ),
+						),
+						'flow_step_id' => array(
+							'type'        => 'string',
+							'description' => __( 'Flow step ID', 'data-machine' ),
+						),
+						'index'        => array(
+							'type'        => 'integer',
+							'description' => __( 'Queue index to update (0-based)', 'data-machine' ),
+						),
+						'patch'        => array(
+							'type'        => 'object',
+							'description' => __( 'Replacement config patch object', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'flow_id'      => array( 'type' => 'integer' ),
+						'flow_step_id' => array( 'type' => 'string' ),
+						'index'        => array( 'type' => 'integer' ),
+						'queue_length' => array( 'type' => 'integer' ),
+						'message'      => array( 'type' => 'string' ),
+						'error'        => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeConfigPatchUpdate' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Register config-patch-move ability.
+	 */
+	private function registerConfigPatchMove(): void {
+		wp_register_ability(
+			'datamachine/config-patch-move',
+			array(
+				'label'               => __( 'Move Config Patch in Queue', 'data-machine' ),
+				'description'         => __( 'Reorder a queued config patch from one index to another.', 'data-machine' ),
+				'category'            => 'datamachine-flow',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'flow_id', 'flow_step_id', 'from_index', 'to_index' ),
+					'properties' => array(
+						'flow_id'      => array(
+							'type'        => 'integer',
+							'description' => __( 'Flow ID', 'data-machine' ),
+						),
+						'flow_step_id' => array(
+							'type'        => 'string',
+							'description' => __( 'Flow step ID', 'data-machine' ),
+						),
+						'from_index'   => array(
+							'type'        => 'integer',
+							'description' => __( 'Current index of item to move (0-based)', 'data-machine' ),
+						),
+						'to_index'     => array(
+							'type'        => 'integer',
+							'description' => __( 'Target index to move item to (0-based)', 'data-machine' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'flow_id'      => array( 'type' => 'integer' ),
+						'flow_step_id' => array( 'type' => 'string' ),
+						'from_index'   => array( 'type' => 'integer' ),
+						'to_index'     => array( 'type' => 'integer' ),
+						'queue_length' => array( 'type' => 'integer' ),
+						'message'      => array( 'type' => 'string' ),
+						'error'        => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'executeConfigPatchMove' ),
+				'permission_callback' => array( $this, 'checkPermission' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	/**
+	 * Add a prompt to the AI step prompt queue.
 	 *
-	 * @param array $input Input with flow_id and prompt.
+	 * @param array $input Input with flow_id, flow_step_id, prompt.
 	 * @return array Result.
 	 */
 	public function executeQueueAdd( array $input ): array {
@@ -396,18 +728,9 @@ class QueueAbility {
 		$flow_step_id = $input['flow_step_id'] ?? null;
 		$prompt       = $input['prompt'] ?? null;
 
-		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_id is required and must be a positive integer',
-			);
-		}
-
-		if ( empty( $flow_step_id ) || ! is_string( $flow_step_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id is required and must be a string',
-			);
+		$validation = $this->validateFlowStepIds( $flow_id, $flow_step_id );
+		if ( ! $validation['success'] ) {
+			return $validation;
 		}
 
 		if ( empty( $prompt ) || ! is_string( $prompt ) ) {
@@ -417,26 +740,18 @@ class QueueAbility {
 			);
 		}
 
-		$flow_id      = (int) $flow_id;
-		$flow_step_id = sanitize_text_field( $flow_step_id );
+		$flow_id      = $validation['flow_id'];
+		$flow_step_id = $validation['flow_step_id'];
 		$prompt       = sanitize_textarea_field( wp_unslash( $prompt ) );
 
-		$flow = $this->db_flows->get_flow( $flow_id );
-		if ( ! $flow ) {
-			return array(
-				'success' => false,
-				'error'   => 'Flow not found',
-			);
+		$flow_lookup = $this->loadFlowAndStepConfig( $flow_id, $flow_step_id, self::SLOT_PROMPT_QUEUE );
+		if ( ! $flow_lookup['success'] ) {
+			return $flow_lookup;
 		}
 
-		$validation = $this->getStepConfigForQueue( $flow, $flow_step_id );
-		if ( ! $validation['success'] ) {
-			return $validation;
-		}
-
-		$flow_config  = $validation['flow_config'];
-		$step_config  = $validation['step_config'];
-		$prompt_queue = $step_config['prompt_queue'];
+		$flow_config = $flow_lookup['flow_config'];
+		$step_config = $flow_lookup['step_config'];
+		$queue       = $step_config[ self::SLOT_PROMPT_QUEUE ];
 
 		// Duplicate validation (unless explicitly skipped).
 		$skip_validation = ! empty( $input['skip_validation'] );
@@ -470,12 +785,12 @@ class QueueAbility {
 			}
 		}
 
-		$prompt_queue[] = array(
-			'prompt'   => $prompt,
-			'added_at' => gmdate( 'c' ),
+		$queue[] = array(
+			self::FIELD_PROMPT => $prompt,
+			'added_at'         => gmdate( 'c' ),
 		);
 
-		$flow_config[ $flow_step_id ]['prompt_queue'] = $prompt_queue;
+		$flow_config[ $flow_step_id ][ self::SLOT_PROMPT_QUEUE ] = $queue;
 
 		$success = $this->db_flows->update_flow(
 			$flow_id,
@@ -495,7 +810,7 @@ class QueueAbility {
 			'Prompt added to queue',
 			array(
 				'flow_id'      => $flow_id,
-				'queue_length' => count( $prompt_queue ),
+				'queue_length' => count( $queue ),
 			)
 		);
 
@@ -503,239 +818,39 @@ class QueueAbility {
 			'success'      => true,
 			'flow_id'      => $flow_id,
 			'flow_step_id' => $flow_step_id,
-			'queue_length' => count( $prompt_queue ),
-			'message'      => sprintf( 'Prompt added to queue. Queue now has %d item(s).', count( $prompt_queue ) ),
+			'queue_length' => count( $queue ),
+			'message'      => sprintf( 'Prompt added to queue. Queue now has %d item(s).', count( $queue ) ),
 		);
 	}
 
 	/**
-	 * List all prompts in the flow queue.
+	 * List all prompts in the AI step prompt queue.
 	 *
-	 * @param array $input Input with flow_id.
-	 * @return array Result with queue items.
+	 * @param array $input Input with flow_id, flow_step_id.
+	 * @return array Result.
 	 */
 	public function executeQueueList( array $input ): array {
-		$flow_id      = $input['flow_id'] ?? null;
-		$flow_step_id = $input['flow_step_id'] ?? null;
-
-		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_id is required and must be a positive integer',
-			);
-		}
-
-		if ( empty( $flow_step_id ) || ! is_string( $flow_step_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id is required and must be a string',
-			);
-		}
-
-		$flow_id      = (int) $flow_id;
-		$flow_step_id = sanitize_text_field( $flow_step_id );
-
-		$flow = $this->db_flows->get_flow( $flow_id );
-		if ( ! $flow ) {
-			return array(
-				'success' => false,
-				'error'   => 'Flow not found',
-			);
-		}
-
-		$validation = $this->getStepConfigForQueue( $flow, $flow_step_id );
-		if ( ! $validation['success'] ) {
-			return $validation;
-		}
-
-		$step_config  = $validation['step_config'];
-		$prompt_queue = $step_config['prompt_queue'];
-
-		return array(
-			'success'       => true,
-			'flow_id'       => $flow_id,
-			'flow_step_id'  => $flow_step_id,
-			'queue'         => $prompt_queue,
-			'count'         => count( $prompt_queue ),
-			'queue_enabled' => $step_config['queue_enabled'],
-		);
+		return $this->listQueueSlot( $input, self::SLOT_PROMPT_QUEUE );
 	}
 
 	/**
-	 * Clear all prompts from the flow queue.
+	 * Clear all prompts from the AI step prompt queue.
 	 *
-	 * @param array $input Input with flow_id.
+	 * @param array $input Input with flow_id, flow_step_id.
 	 * @return array Result.
 	 */
 	public function executeQueueClear( array $input ): array {
-		$flow_id      = $input['flow_id'] ?? null;
-		$flow_step_id = $input['flow_step_id'] ?? null;
-
-		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_id is required and must be a positive integer',
-			);
-		}
-
-		if ( empty( $flow_step_id ) || ! is_string( $flow_step_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id is required and must be a string',
-			);
-		}
-
-		$flow_id      = (int) $flow_id;
-		$flow_step_id = sanitize_text_field( $flow_step_id );
-
-		$flow = $this->db_flows->get_flow( $flow_id );
-		if ( ! $flow ) {
-			return array(
-				'success' => false,
-				'error'   => 'Flow not found',
-			);
-		}
-
-		$validation = $this->getStepConfigForQueue( $flow, $flow_step_id );
-		if ( ! $validation['success'] ) {
-			return $validation;
-		}
-
-		$flow_config   = $validation['flow_config'];
-		$step_config   = $validation['step_config'];
-		$cleared_count = count( $step_config['prompt_queue'] );
-
-		$flow_config[ $flow_step_id ]['prompt_queue'] = array();
-
-		$success = $this->db_flows->update_flow(
-			$flow_id,
-			array( 'flow_config' => $flow_config )
-		);
-
-		if ( ! $success ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to clear queue',
-			);
-		}
-
-		do_action(
-			'datamachine_log',
-			'info',
-			'Queue cleared',
-			array(
-				'flow_id'       => $flow_id,
-				'cleared_count' => $cleared_count,
-			)
-		);
-
-		return array(
-			'success'       => true,
-			'flow_id'       => $flow_id,
-			'flow_step_id'  => $flow_step_id,
-			'cleared_count' => $cleared_count,
-			'message'       => sprintf( 'Cleared %d prompt(s) from queue.', $cleared_count ),
-		);
+		return $this->clearQueueSlot( $input, self::SLOT_PROMPT_QUEUE );
 	}
 
 	/**
 	 * Remove a specific prompt from the queue by index.
 	 *
-	 * @param array $input Input with flow_id and index.
+	 * @param array $input Input with flow_id, flow_step_id, index.
 	 * @return array Result.
 	 */
 	public function executeQueueRemove( array $input ): array {
-		$flow_id      = $input['flow_id'] ?? null;
-		$flow_step_id = $input['flow_step_id'] ?? null;
-		$index        = $input['index'] ?? null;
-
-		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_id is required and must be a positive integer',
-			);
-		}
-
-		if ( empty( $flow_step_id ) || ! is_string( $flow_step_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id is required and must be a string',
-			);
-		}
-
-		if ( ! is_numeric( $index ) || (int) $index < 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'index is required and must be a non-negative integer',
-			);
-		}
-
-		$flow_id      = (int) $flow_id;
-		$flow_step_id = sanitize_text_field( $flow_step_id );
-		$index        = (int) $index;
-
-		$flow = $this->db_flows->get_flow( $flow_id );
-		if ( ! $flow ) {
-			return array(
-				'success' => false,
-				'error'   => 'Flow not found',
-			);
-		}
-
-		$validation = $this->getStepConfigForQueue( $flow, $flow_step_id );
-		if ( ! $validation['success'] ) {
-			return $validation;
-		}
-
-		$flow_config  = $validation['flow_config'];
-		$step_config  = $validation['step_config'];
-		$prompt_queue = $step_config['prompt_queue'];
-
-		if ( $index >= count( $prompt_queue ) ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Index %d is out of range. Queue has %d item(s).', $index, count( $prompt_queue ) ),
-			);
-		}
-
-		$removed_item   = $prompt_queue[ $index ];
-		$removed_prompt = $removed_item['prompt'] ?? '';
-
-		array_splice( $prompt_queue, $index, 1 );
-
-		$flow_config[ $flow_step_id ]['prompt_queue'] = $prompt_queue;
-
-		$success = $this->db_flows->update_flow(
-			$flow_id,
-			array( 'flow_config' => $flow_config )
-		);
-
-		if ( ! $success ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to remove prompt from queue',
-			);
-		}
-
-		do_action(
-			'datamachine_log',
-			'info',
-			'Prompt removed from queue',
-			array(
-				'flow_id'      => $flow_id,
-				'index'        => $index,
-				'queue_length' => count( $prompt_queue ),
-			)
-		);
-
-		return array(
-			'success'        => true,
-			'flow_id'        => $flow_id,
-			'flow_step_id'   => $flow_step_id,
-			'removed_prompt' => $removed_prompt,
-			'queue_length'   => count( $prompt_queue ),
-			'message'        => sprintf( 'Removed prompt at index %d. Queue now has %d item(s).', $index, count( $prompt_queue ) ),
-		);
+		return $this->removeQueueSlot( $input, self::SLOT_PROMPT_QUEUE, self::FIELD_PROMPT );
 	}
 
 	/**
@@ -743,222 +858,80 @@ class QueueAbility {
 	 *
 	 * If the index is 0 and the queue is empty, creates a new item.
 	 *
-	 * @param array $input Input with flow_id, index, and prompt.
+	 * @param array $input Input with flow_id, flow_step_id, index, prompt.
 	 * @return array Result.
 	 */
 	public function executeQueueUpdate( array $input ): array {
-		$flow_id      = $input['flow_id'] ?? null;
-		$flow_step_id = $input['flow_step_id'] ?? null;
-		$index        = $input['index'] ?? null;
-		$prompt       = $input['prompt'] ?? null;
-
-		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_id is required and must be a positive integer',
-			);
-		}
-
-		if ( empty( $flow_step_id ) || ! is_string( $flow_step_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id is required and must be a string',
-			);
-		}
-
-		if ( ! is_numeric( $index ) || (int) $index < 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'index is required and must be a non-negative integer',
-			);
-		}
-
-		if ( ! is_string( $prompt ) ) {
+		$value = $input['prompt'] ?? null;
+		if ( ! is_string( $value ) ) {
 			return array(
 				'success' => false,
 				'error'   => 'prompt is required and must be a string',
 			);
 		}
+		$value = sanitize_textarea_field( wp_unslash( $value ) );
 
-		$flow_id      = (int) $flow_id;
-		$flow_step_id = sanitize_text_field( $flow_step_id );
-		$index        = (int) $index;
-		$prompt       = sanitize_textarea_field( wp_unslash( $prompt ) );
-
-		$flow = $this->db_flows->get_flow( $flow_id );
-		if ( ! $flow ) {
-			return array(
-				'success' => false,
-				'error'   => 'Flow not found',
-			);
-		}
-
-		$validation = $this->getStepConfigForQueue( $flow, $flow_step_id );
-		if ( ! $validation['success'] ) {
-			return $validation;
-		}
-
-		$flow_config  = $validation['flow_config'];
-		$step_config  = $validation['step_config'];
-		$prompt_queue = $step_config['prompt_queue'];
-
-		// Special case: if index is 0 and queue is empty, create a new item
-		if ( 0 === $index && empty( $prompt_queue ) ) {
-			// If prompt is empty, don't create anything
-			if ( '' === $prompt ) {
-				return array(
-					'success'      => true,
-					'flow_id'      => $flow_id,
-					'index'        => $index,
-					'queue_length' => 0,
-					'message'      => 'No changes made (empty prompt, empty queue).',
-				);
-			}
-
-			$prompt_queue[] = array(
-				'prompt'   => $prompt,
-				'added_at' => gmdate( 'c' ),
-			);
-		} elseif ( $index >= count( $prompt_queue ) ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Index %d is out of range. Queue has %d item(s).', $index, count( $prompt_queue ) ),
-			);
-		} else {
-			// Update existing item, preserving added_at
-			$prompt_queue[ $index ]['prompt'] = $prompt;
-		}
-
-		$flow_config[ $flow_step_id ]['prompt_queue'] = $prompt_queue;
-
-		$success = $this->db_flows->update_flow(
-			$flow_id,
-			array( 'flow_config' => $flow_config )
-		);
-
-		if ( ! $success ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to update queue',
-			);
-		}
-
-		do_action(
-			'datamachine_log',
-			'info',
-			'Queue item updated',
-			array(
-				'flow_id'      => $flow_id,
-				'index'        => $index,
-				'queue_length' => count( $prompt_queue ),
-			)
-		);
-
-		return array(
-			'success'      => true,
-			'flow_id'      => $flow_id,
-			'flow_step_id' => $flow_step_id,
-			'index'        => $index,
-			'queue_length' => count( $prompt_queue ),
-			'message'      => sprintf( 'Updated prompt at index %d. Queue has %d item(s).', $index, count( $prompt_queue ) ),
-		);
+		return $this->updateQueueSlot( $input, self::SLOT_PROMPT_QUEUE, self::FIELD_PROMPT, $value );
 	}
 
 	/**
 	 * Move a prompt from one position to another in the queue.
 	 *
-	 * @param array $input Input with flow_id, flow_step_id, from_index, and to_index.
+	 * @param array $input Input with flow_id, flow_step_id, from_index, to_index.
 	 * @return array Result.
 	 */
 	public function executeQueueMove( array $input ): array {
+		return $this->moveQueueSlot( $input, self::SLOT_PROMPT_QUEUE );
+	}
+
+	/**
+	 * Add a config patch to the fetch step config-patch queue.
+	 *
+	 * @param array $input Input with flow_id, flow_step_id, patch.
+	 * @return array Result.
+	 */
+	public function executeConfigPatchAdd( array $input ): array {
 		$flow_id      = $input['flow_id'] ?? null;
 		$flow_step_id = $input['flow_step_id'] ?? null;
-		$from_index   = $input['from_index'] ?? null;
-		$to_index     = $input['to_index'] ?? null;
+		$patch        = $input['patch'] ?? null;
 
-		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_id is required and must be a positive integer',
-			);
-		}
-
-		if ( empty( $flow_step_id ) || ! is_string( $flow_step_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id is required and must be a string',
-			);
-		}
-
-		if ( ! is_numeric( $from_index ) || (int) $from_index < 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'from_index is required and must be a non-negative integer',
-			);
-		}
-
-		if ( ! is_numeric( $to_index ) || (int) $to_index < 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'to_index is required and must be a non-negative integer',
-			);
-		}
-
-		$flow_id      = (int) $flow_id;
-		$flow_step_id = sanitize_text_field( $flow_step_id );
-		$from_index   = (int) $from_index;
-		$to_index     = (int) $to_index;
-
-		if ( $from_index === $to_index ) {
-			return array(
-				'success'      => true,
-				'flow_id'      => $flow_id,
-				'flow_step_id' => $flow_step_id,
-				'from_index'   => $from_index,
-				'to_index'     => $to_index,
-				'queue_length' => 0,
-				'message'      => 'No move needed (same position).',
-			);
-		}
-
-		$flow = $this->db_flows->get_flow( $flow_id );
-		if ( ! $flow ) {
-			return array(
-				'success' => false,
-				'error'   => 'Flow not found',
-			);
-		}
-
-		$validation = $this->getStepConfigForQueue( $flow, $flow_step_id );
+		$validation = $this->validateFlowStepIds( $flow_id, $flow_step_id );
 		if ( ! $validation['success'] ) {
 			return $validation;
 		}
 
-		$flow_config  = $validation['flow_config'];
-		$step_config  = $validation['step_config'];
-		$prompt_queue = $step_config['prompt_queue'];
-		$queue_length = count( $prompt_queue );
-
-		if ( $from_index >= $queue_length ) {
+		if ( ! is_array( $patch ) ) {
 			return array(
 				'success' => false,
-				'error'   => sprintf( 'from_index %d is out of range. Queue has %d item(s).', $from_index, $queue_length ),
+				'error'   => 'patch is required and must be an object',
 			);
 		}
 
-		if ( $to_index >= $queue_length ) {
+		if ( empty( $patch ) ) {
 			return array(
 				'success' => false,
-				'error'   => sprintf( 'to_index %d is out of range. Queue has %d item(s).', $to_index, $queue_length ),
+				'error'   => 'patch must be a non-empty object',
 			);
 		}
 
-		// Extract the item and reinsert at new position
-		$item = $prompt_queue[ $from_index ];
-		array_splice( $prompt_queue, $from_index, 1 );
-		array_splice( $prompt_queue, $to_index, 0, array( $item ) );
+		$flow_id      = $validation['flow_id'];
+		$flow_step_id = $validation['flow_step_id'];
 
-		$flow_config[ $flow_step_id ]['prompt_queue'] = $prompt_queue;
+		$flow_lookup = $this->loadFlowAndStepConfig( $flow_id, $flow_step_id, self::SLOT_CONFIG_PATCH_QUEUE );
+		if ( ! $flow_lookup['success'] ) {
+			return $flow_lookup;
+		}
+
+		$flow_config = $flow_lookup['flow_config'];
+		$step_config = $flow_lookup['step_config'];
+		$queue       = $step_config[ self::SLOT_CONFIG_PATCH_QUEUE ];
+
+		$queue[] = array(
+			self::FIELD_PATCH => $patch,
+			'added_at'        => gmdate( 'c' ),
+		);
+
+		$flow_config[ $flow_step_id ][ self::SLOT_CONFIG_PATCH_QUEUE ] = $queue;
 
 		$success = $this->db_flows->update_flow(
 			$flow_id,
@@ -968,20 +941,18 @@ class QueueAbility {
 		if ( ! $success ) {
 			return array(
 				'success' => false,
-				'error'   => 'Failed to move queue item',
+				'error'   => 'Failed to update flow config patch queue',
 			);
 		}
 
 		do_action(
 			'datamachine_log',
 			'info',
-			'Queue item moved',
+			'Config patch added to queue',
 			array(
 				'flow_id'      => $flow_id,
-				'flow_step_id' => $flow_step_id,
-				'from_index'   => $from_index,
-				'to_index'     => $to_index,
-				'queue_length' => $queue_length,
+				'queue_length' => count( $queue ),
+				'patch_keys'   => array_keys( $patch ),
 			)
 		);
 
@@ -989,11 +960,58 @@ class QueueAbility {
 			'success'      => true,
 			'flow_id'      => $flow_id,
 			'flow_step_id' => $flow_step_id,
-			'from_index'   => $from_index,
-			'to_index'     => $to_index,
-			'queue_length' => $queue_length,
-			'message'      => sprintf( 'Moved item from index %d to %d.', $from_index, $to_index ),
+			'queue_length' => count( $queue ),
+			'message'      => sprintf( 'Config patch added to queue. Queue now has %d item(s).', count( $queue ) ),
 		);
+	}
+
+	/**
+	 * List all config patches in the fetch queue.
+	 */
+	public function executeConfigPatchList( array $input ): array {
+		return $this->listQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE );
+	}
+
+	/**
+	 * Clear all config patches from the fetch queue.
+	 */
+	public function executeConfigPatchClear( array $input ): array {
+		return $this->clearQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE );
+	}
+
+	/**
+	 * Remove a specific config patch from the queue by index.
+	 */
+	public function executeConfigPatchRemove( array $input ): array {
+		return $this->removeQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE, self::FIELD_PATCH );
+	}
+
+	/**
+	 * Update a config patch at a specific index in the queue.
+	 */
+	public function executeConfigPatchUpdate( array $input ): array {
+		$value = $input['patch'] ?? null;
+		if ( ! is_array( $value ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'patch is required and must be an object',
+			);
+		}
+		if ( empty( $value ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'patch must be a non-empty object',
+			);
+		}
+
+		return $this->updateQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE, self::FIELD_PATCH, $value );
+	}
+
+	/**
+	 * Move a config patch from one position to another in the queue.
+	 */
+	public function executeConfigPatchMove( array $input ): array {
+		return $this->moveQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE );
 	}
 
 	/**
@@ -1007,18 +1025,9 @@ class QueueAbility {
 		$flow_step_id  = $input['flow_step_id'] ?? null;
 		$queue_enabled = $input['queue_enabled'] ?? null;
 
-		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_id is required and must be a positive integer',
-			);
-		}
-
-		if ( empty( $flow_step_id ) || ! is_string( $flow_step_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id is required and must be a string',
-			);
+		$validation = $this->validateFlowStepIds( $flow_id, $flow_step_id );
+		if ( ! $validation['success'] ) {
+			return $validation;
 		}
 
 		if ( ! is_bool( $queue_enabled ) ) {
@@ -1028,23 +1037,19 @@ class QueueAbility {
 			);
 		}
 
-		$flow_id      = (int) $flow_id;
-		$flow_step_id = sanitize_text_field( $flow_step_id );
+		$flow_id      = $validation['flow_id'];
+		$flow_step_id = $validation['flow_step_id'];
 
-		$flow = $this->db_flows->get_flow( $flow_id );
-		if ( ! $flow ) {
-			return array(
-				'success' => false,
-				'error'   => 'Flow not found',
-			);
+		// queue_enabled is a step-level toggle that applies to whichever
+		// queue slot the step type consumes — no slot routing needed
+		// here. Use SLOT_PROMPT_QUEUE for the existence check; the
+		// step_config defaulting just ensures the row exists.
+		$flow_lookup = $this->loadFlowAndStepConfig( $flow_id, $flow_step_id, self::SLOT_PROMPT_QUEUE );
+		if ( ! $flow_lookup['success'] ) {
+			return $flow_lookup;
 		}
 
-		$validation = $this->getStepConfigForQueue( $flow, $flow_step_id );
-		if ( ! $validation['success'] ) {
-			return $validation;
-		}
-
-		$flow_config                                   = $validation['flow_config'];
+		$flow_config                                   = $flow_lookup['flow_config'];
 		$flow_config[ $flow_step_id ]['queue_enabled'] = $queue_enabled;
 
 		$success = $this->db_flows->update_flow(
@@ -1069,13 +1074,470 @@ class QueueAbility {
 	}
 
 	/**
+	 * List items in a specific queue slot.
+	 *
+	 * Shared executor for `queue-list` and `config-patch-list`.
+	 *
+	 * @param array  $input Input with flow_id, flow_step_id.
+	 * @param string $slot  One of self::SLOT_PROMPT_QUEUE | self::SLOT_CONFIG_PATCH_QUEUE.
+	 * @return array Result with queue items.
+	 */
+	private function listQueueSlot( array $input, string $slot ): array {
+		$flow_id      = $input['flow_id'] ?? null;
+		$flow_step_id = $input['flow_step_id'] ?? null;
+
+		$validation = $this->validateFlowStepIds( $flow_id, $flow_step_id );
+		if ( ! $validation['success'] ) {
+			return $validation;
+		}
+
+		$flow_id      = $validation['flow_id'];
+		$flow_step_id = $validation['flow_step_id'];
+
+		$flow_lookup = $this->loadFlowAndStepConfig( $flow_id, $flow_step_id, $slot );
+		if ( ! $flow_lookup['success'] ) {
+			return $flow_lookup;
+		}
+
+		$step_config = $flow_lookup['step_config'];
+		$queue       = $step_config[ $slot ];
+
+		return array(
+			'success'       => true,
+			'flow_id'       => $flow_id,
+			'flow_step_id'  => $flow_step_id,
+			'queue'         => $queue,
+			'count'         => count( $queue ),
+			'queue_enabled' => $step_config['queue_enabled'],
+		);
+	}
+
+	/**
+	 * Clear all items from a specific queue slot.
+	 *
+	 * @param array  $input Input.
+	 * @param string $slot  Slot name.
+	 * @return array Result.
+	 */
+	private function clearQueueSlot( array $input, string $slot ): array {
+		$flow_id      = $input['flow_id'] ?? null;
+		$flow_step_id = $input['flow_step_id'] ?? null;
+
+		$validation = $this->validateFlowStepIds( $flow_id, $flow_step_id );
+		if ( ! $validation['success'] ) {
+			return $validation;
+		}
+
+		$flow_id      = $validation['flow_id'];
+		$flow_step_id = $validation['flow_step_id'];
+
+		$flow_lookup = $this->loadFlowAndStepConfig( $flow_id, $flow_step_id, $slot );
+		if ( ! $flow_lookup['success'] ) {
+			return $flow_lookup;
+		}
+
+		$flow_config   = $flow_lookup['flow_config'];
+		$step_config   = $flow_lookup['step_config'];
+		$cleared_count = count( $step_config[ $slot ] );
+
+		$flow_config[ $flow_step_id ][ $slot ] = array();
+
+		$success = $this->db_flows->update_flow(
+			$flow_id,
+			array( 'flow_config' => $flow_config )
+		);
+
+		if ( ! $success ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to clear queue',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Queue cleared',
+			array(
+				'flow_id'       => $flow_id,
+				'slot'          => $slot,
+				'cleared_count' => $cleared_count,
+			)
+		);
+
+		return array(
+			'success'       => true,
+			'flow_id'       => $flow_id,
+			'flow_step_id'  => $flow_step_id,
+			'cleared_count' => $cleared_count,
+			'message'       => sprintf( 'Cleared %d item(s) from queue.', $cleared_count ),
+		);
+	}
+
+	/**
+	 * Remove a specific item from a queue slot.
+	 *
+	 * Returns both `removed_prompt` (legacy field, set when slot is the
+	 * prompt queue) and `removed_patch` (set when slot is the config
+	 * patch queue) so existing prompt-queue callers see no shape change.
+	 *
+	 * @param array  $input       Input with flow_id, flow_step_id, index.
+	 * @param string $slot        Slot name.
+	 * @param string $field_name  Per-entry payload field (`prompt` or `patch`).
+	 * @return array Result.
+	 */
+	private function removeQueueSlot( array $input, string $slot, string $field_name ): array {
+		$flow_id      = $input['flow_id'] ?? null;
+		$flow_step_id = $input['flow_step_id'] ?? null;
+		$index        = $input['index'] ?? null;
+
+		$validation = $this->validateFlowStepIds( $flow_id, $flow_step_id );
+		if ( ! $validation['success'] ) {
+			return $validation;
+		}
+
+		if ( ! is_numeric( $index ) || (int) $index < 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'index is required and must be a non-negative integer',
+			);
+		}
+
+		$flow_id      = $validation['flow_id'];
+		$flow_step_id = $validation['flow_step_id'];
+		$index        = (int) $index;
+
+		$flow_lookup = $this->loadFlowAndStepConfig( $flow_id, $flow_step_id, $slot );
+		if ( ! $flow_lookup['success'] ) {
+			return $flow_lookup;
+		}
+
+		$flow_config = $flow_lookup['flow_config'];
+		$step_config = $flow_lookup['step_config'];
+		$queue       = $step_config[ $slot ];
+
+		if ( $index >= count( $queue ) ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Index %d is out of range. Queue has %d item(s).', $index, count( $queue ) ),
+			);
+		}
+
+		$removed_item    = $queue[ $index ];
+		$removed_payload = $removed_item[ $field_name ] ?? '';
+
+		array_splice( $queue, $index, 1 );
+
+		$flow_config[ $flow_step_id ][ $slot ] = $queue;
+
+		$success = $this->db_flows->update_flow(
+			$flow_id,
+			array( 'flow_config' => $flow_config )
+		);
+
+		if ( ! $success ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to remove item from queue',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Item removed from queue',
+			array(
+				'flow_id'      => $flow_id,
+				'slot'         => $slot,
+				'index'        => $index,
+				'queue_length' => count( $queue ),
+			)
+		);
+
+		$result = array(
+			'success'      => true,
+			'flow_id'      => $flow_id,
+			'flow_step_id' => $flow_step_id,
+			'queue_length' => count( $queue ),
+			'message'      => sprintf( 'Removed item at index %d. Queue now has %d item(s).', $index, count( $queue ) ),
+		);
+
+		// Surface payload under the slot-appropriate key.
+		if ( self::FIELD_PATCH === $field_name ) {
+			$result['removed_patch'] = is_array( $removed_payload ) ? $removed_payload : array();
+		} else {
+			$result['removed_prompt'] = is_string( $removed_payload ) ? $removed_payload : '';
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Update an item at a specific index in a queue slot.
+	 *
+	 * If the index is 0 and the queue is empty, creates a new item.
+	 *
+	 * @param array  $input      Input with flow_id, flow_step_id, index.
+	 * @param string $slot       Slot name.
+	 * @param string $field_name Per-entry payload field.
+	 * @param mixed  $value      New payload value (already validated/sanitized by caller).
+	 * @return array Result.
+	 */
+	private function updateQueueSlot( array $input, string $slot, string $field_name, $value ): array {
+		$flow_id      = $input['flow_id'] ?? null;
+		$flow_step_id = $input['flow_step_id'] ?? null;
+		$index        = $input['index'] ?? null;
+
+		$validation = $this->validateFlowStepIds( $flow_id, $flow_step_id );
+		if ( ! $validation['success'] ) {
+			return $validation;
+		}
+
+		if ( ! is_numeric( $index ) || (int) $index < 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'index is required and must be a non-negative integer',
+			);
+		}
+
+		$flow_id      = $validation['flow_id'];
+		$flow_step_id = $validation['flow_step_id'];
+		$index        = (int) $index;
+
+		$flow_lookup = $this->loadFlowAndStepConfig( $flow_id, $flow_step_id, $slot );
+		if ( ! $flow_lookup['success'] ) {
+			return $flow_lookup;
+		}
+
+		$flow_config = $flow_lookup['flow_config'];
+		$step_config = $flow_lookup['step_config'];
+		$queue       = $step_config[ $slot ];
+
+		// Special case: if index is 0 and queue is empty, create a new item.
+		if ( 0 === $index && empty( $queue ) ) {
+			// If value is the empty version of its type, don't create anything.
+			$is_empty = self::FIELD_PATCH === $field_name
+				? ( ! is_array( $value ) || empty( $value ) )
+				: '' === $value;
+
+			if ( $is_empty ) {
+				return array(
+					'success'      => true,
+					'flow_id'      => $flow_id,
+					'index'        => $index,
+					'queue_length' => 0,
+					'message'      => 'No changes made (empty value, empty queue).',
+				);
+			}
+
+			$queue[] = array(
+				$field_name => $value,
+				'added_at'  => gmdate( 'c' ),
+			);
+		} elseif ( $index >= count( $queue ) ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Index %d is out of range. Queue has %d item(s).', $index, count( $queue ) ),
+			);
+		} else {
+			// Update existing item, preserving added_at.
+			$queue[ $index ][ $field_name ] = $value;
+		}
+
+		$flow_config[ $flow_step_id ][ $slot ] = $queue;
+
+		$success = $this->db_flows->update_flow(
+			$flow_id,
+			array( 'flow_config' => $flow_config )
+		);
+
+		if ( ! $success ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to update queue',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Queue item updated',
+			array(
+				'flow_id'      => $flow_id,
+				'slot'         => $slot,
+				'index'        => $index,
+				'queue_length' => count( $queue ),
+			)
+		);
+
+		return array(
+			'success'      => true,
+			'flow_id'      => $flow_id,
+			'flow_step_id' => $flow_step_id,
+			'index'        => $index,
+			'queue_length' => count( $queue ),
+			'message'      => sprintf( 'Updated item at index %d. Queue has %d item(s).', $index, count( $queue ) ),
+		);
+	}
+
+	/**
+	 * Move an item from one position to another in a queue slot.
+	 *
+	 * @param array  $input Input with flow_id, flow_step_id, from_index, to_index.
+	 * @param string $slot  Slot name.
+	 * @return array Result.
+	 */
+	private function moveQueueSlot( array $input, string $slot ): array {
+		$flow_id      = $input['flow_id'] ?? null;
+		$flow_step_id = $input['flow_step_id'] ?? null;
+		$from_index   = $input['from_index'] ?? null;
+		$to_index     = $input['to_index'] ?? null;
+
+		$validation = $this->validateFlowStepIds( $flow_id, $flow_step_id );
+		if ( ! $validation['success'] ) {
+			return $validation;
+		}
+
+		if ( ! is_numeric( $from_index ) || (int) $from_index < 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'from_index is required and must be a non-negative integer',
+			);
+		}
+
+		if ( ! is_numeric( $to_index ) || (int) $to_index < 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'to_index is required and must be a non-negative integer',
+			);
+		}
+
+		$flow_id      = $validation['flow_id'];
+		$flow_step_id = $validation['flow_step_id'];
+		$from_index   = (int) $from_index;
+		$to_index     = (int) $to_index;
+
+		if ( $from_index === $to_index ) {
+			return array(
+				'success'      => true,
+				'flow_id'      => $flow_id,
+				'flow_step_id' => $flow_step_id,
+				'from_index'   => $from_index,
+				'to_index'     => $to_index,
+				'queue_length' => 0,
+				'message'      => 'No move needed (same position).',
+			);
+		}
+
+		$flow_lookup = $this->loadFlowAndStepConfig( $flow_id, $flow_step_id, $slot );
+		if ( ! $flow_lookup['success'] ) {
+			return $flow_lookup;
+		}
+
+		$flow_config  = $flow_lookup['flow_config'];
+		$step_config  = $flow_lookup['step_config'];
+		$queue        = $step_config[ $slot ];
+		$queue_length = count( $queue );
+
+		if ( $from_index >= $queue_length ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'from_index %d is out of range. Queue has %d item(s).', $from_index, $queue_length ),
+			);
+		}
+
+		if ( $to_index >= $queue_length ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'to_index %d is out of range. Queue has %d item(s).', $to_index, $queue_length ),
+			);
+		}
+
+		// Extract the item and reinsert at new position.
+		$item = $queue[ $from_index ];
+		array_splice( $queue, $from_index, 1 );
+		array_splice( $queue, $to_index, 0, array( $item ) );
+
+		$flow_config[ $flow_step_id ][ $slot ] = $queue;
+
+		$success = $this->db_flows->update_flow(
+			$flow_id,
+			array( 'flow_config' => $flow_config )
+		);
+
+		if ( ! $success ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to move queue item',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Queue item moved',
+			array(
+				'flow_id'      => $flow_id,
+				'flow_step_id' => $flow_step_id,
+				'slot'         => $slot,
+				'from_index'   => $from_index,
+				'to_index'     => $to_index,
+				'queue_length' => $queue_length,
+			)
+		);
+
+		return array(
+			'success'      => true,
+			'flow_id'      => $flow_id,
+			'flow_step_id' => $flow_step_id,
+			'from_index'   => $from_index,
+			'to_index'     => $to_index,
+			'queue_length' => $queue_length,
+			'message'      => sprintf( 'Moved item from index %d to %d.', $from_index, $to_index ),
+		);
+	}
+
+	/**
 	 * Pop the first prompt from the queue (for engine use).
 	 *
-	 * @param int      $flow_id  Flow ID.
-	 * @param DB_Flows $db_flows Database instance (avoids creating new instance each call).
+	 * Used by AIStep's queueable trait. For the fetch-step config-patch
+	 * queue, see {@see popConfigPatchFromQueue()}.
+	 *
+	 * @param int      $flow_id      Flow ID.
+	 * @param string   $flow_step_id Flow step ID.
+	 * @param DB_Flows $db_flows     Database instance (avoids creating new instance each call).
 	 * @return array|null The popped queue item or null if empty.
 	 */
 	public static function popFromQueue( int $flow_id, string $flow_step_id, ?DB_Flows $db_flows = null ): ?array {
+		return self::popFromQueueSlot( $flow_id, $flow_step_id, self::SLOT_PROMPT_QUEUE, $db_flows );
+	}
+
+	/**
+	 * Pop the first config patch from the fetch step config-patch queue.
+	 *
+	 * Sibling of {@see popFromQueue()} for FetchStep's QueueableTrait
+	 * consumer. Returns the entry verbatim (no JSON-decode — the patch
+	 * is stored as a decoded array).
+	 *
+	 * @param int      $flow_id      Flow ID.
+	 * @param string   $flow_step_id Flow step ID.
+	 * @param DB_Flows $db_flows     Database instance.
+	 * @return array|null The popped queue item (`{ patch, added_at }`) or null if empty.
+	 */
+	public static function popConfigPatchFromQueue( int $flow_id, string $flow_step_id, ?DB_Flows $db_flows = null ): ?array {
+		return self::popFromQueueSlot( $flow_id, $flow_step_id, self::SLOT_CONFIG_PATCH_QUEUE, $db_flows );
+	}
+
+	/**
+	 * Pop the first item from a named queue slot.
+	 *
+	 * @param int      $flow_id      Flow ID.
+	 * @param string   $flow_step_id Flow step ID.
+	 * @param string   $slot         Slot name.
+	 * @param DB_Flows $db_flows     Database instance.
+	 * @return array|null The popped item or null if empty.
+	 */
+	private static function popFromQueueSlot( int $flow_id, string $flow_step_id, string $slot, ?DB_Flows $db_flows = null ): ?array {
 		if ( null === $db_flows ) {
 			$db_flows = new DB_Flows();
 		}
@@ -1090,16 +1552,16 @@ class QueueAbility {
 			return null;
 		}
 
-		$step_config  = $flow_config[ $flow_step_id ];
-		$prompt_queue = $step_config['prompt_queue'] ?? array();
+		$step_config = $flow_config[ $flow_step_id ];
+		$queue       = $step_config[ $slot ] ?? array();
 
-		if ( empty( $prompt_queue ) ) {
+		if ( empty( $queue ) ) {
 			return null;
 		}
 
-		$popped_item = array_shift( $prompt_queue );
+		$popped_item = array_shift( $queue );
 
-		$flow_config[ $flow_step_id ]['prompt_queue'] = $prompt_queue;
+		$flow_config[ $flow_step_id ][ $slot ] = $queue;
 
 		$db_flows->update_flow(
 			$flow_id,
@@ -1109,14 +1571,104 @@ class QueueAbility {
 		do_action(
 			'datamachine_log',
 			'info',
-			'Prompt popped from queue',
+			'Item popped from queue',
 			array(
 				'flow_id'         => $flow_id,
-				'remaining_count' => count( $prompt_queue ),
+				'slot'            => $slot,
+				'remaining_count' => count( $queue ),
 			)
 		);
 
 		return $popped_item;
+	}
+
+	/**
+	 * Validate flow_id and flow_step_id input fields.
+	 *
+	 * @param mixed $flow_id      Raw flow_id input.
+	 * @param mixed $flow_step_id Raw flow_step_id input.
+	 * @return array{success: bool, error?: string, flow_id?: int, flow_step_id?: string}
+	 */
+	private function validateFlowStepIds( $flow_id, $flow_step_id ): array {
+		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_id is required and must be a positive integer',
+			);
+		}
+
+		if ( empty( $flow_step_id ) || ! is_string( $flow_step_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_step_id is required and must be a string',
+			);
+		}
+
+		return array(
+			'success'      => true,
+			'flow_id'      => (int) $flow_id,
+			'flow_step_id' => sanitize_text_field( $flow_step_id ),
+		);
+	}
+
+	/**
+	 * Load flow + normalize step config for queue operations.
+	 *
+	 * Defaults the named slot to an empty array and `queue_enabled` to
+	 * false when missing — same shape as the pre-split helper, but
+	 * targets a specific queue slot rather than the implicit
+	 * `prompt_queue`.
+	 *
+	 * @param int    $flow_id      Flow ID (already validated).
+	 * @param string $flow_step_id Flow step ID (already validated).
+	 * @param string $slot         Queue slot to default.
+	 * @return array{success: bool, error?: string, flow_config?: array, step_config?: array}
+	 */
+	private function loadFlowAndStepConfig( int $flow_id, string $flow_step_id, string $slot ): array {
+		$flow = $this->db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return array(
+				'success' => false,
+				'error'   => 'Flow not found',
+			);
+		}
+
+		$parts = apply_filters( 'datamachine_split_flow_step_id', null, $flow_step_id );
+		if ( ! $parts || empty( $parts['flow_id'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Invalid flow_step_id format',
+			);
+		}
+		if ( (int) $parts['flow_id'] !== $flow_id ) {
+			return array(
+				'success' => false,
+				'error'   => 'flow_step_id does not belong to this flow',
+			);
+		}
+
+		$flow_config = $flow['flow_config'] ?? array();
+		if ( ! isset( $flow_config[ $flow_step_id ] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Flow step not found in flow config',
+			);
+		}
+
+		$step_config = $flow_config[ $flow_step_id ];
+		if ( ! isset( $step_config[ $slot ] ) || ! is_array( $step_config[ $slot ] ) ) {
+			$step_config[ $slot ] = array();
+		}
+		if ( ! isset( $step_config['queue_enabled'] ) || ! is_bool( $step_config['queue_enabled'] ) ) {
+			$step_config['queue_enabled'] = false;
+		}
+		$flow_config[ $flow_step_id ] = $step_config;
+
+		return array(
+			'success'     => true,
+			'flow_config' => $flow_config,
+			'step_config' => $step_config,
+		);
 	}
 
 	/**
@@ -1145,52 +1697,5 @@ class QueueAbility {
 			}
 		}
 		return 'post';
-	}
-
-	/**
-	 * Normalize flow step queue config for queue operations.
-	 *
-	 * @param array  $flow Flow record.
-	 * @param string $flow_step_id Flow step ID.
-	 * @return array Result with flow_config and step_config or error.
-	 */
-	private function getStepConfigForQueue( array $flow, string $flow_step_id ): array {
-		$flow_id = (int) ( $flow['flow_id'] ?? 0 );
-		$parts   = apply_filters( 'datamachine_split_flow_step_id', null, $flow_step_id );
-		if ( ! $parts || empty( $parts['flow_id'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Invalid flow_step_id format',
-			);
-		}
-		if ( (int) $parts['flow_id'] !== $flow_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id does not belong to this flow',
-			);
-		}
-
-		$flow_config = $flow['flow_config'] ?? array();
-		if ( ! isset( $flow_config[ $flow_step_id ] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Flow step not found in flow config',
-			);
-		}
-
-		$step_config = $flow_config[ $flow_step_id ];
-		if ( ! isset( $step_config['prompt_queue'] ) || ! is_array( $step_config['prompt_queue'] ) ) {
-			$step_config['prompt_queue'] = array();
-		}
-		if ( ! isset( $step_config['queue_enabled'] ) || ! is_bool( $step_config['queue_enabled'] ) ) {
-			$step_config['queue_enabled'] = false;
-		}
-		$flow_config[ $flow_step_id ] = $step_config;
-
-		return array(
-			'success'     => true,
-			'flow_config' => $flow_config,
-			'step_config' => $step_config,
-		);
 	}
 }

--- a/inc/Abilities/FlowAbilities.php
+++ b/inc/Abilities/FlowAbilities.php
@@ -238,4 +238,67 @@ class FlowAbilities {
 		}
 		return $this->queue->executeQueueMove( $input );
 	}
+
+	/**
+	 * Execute config-patch-add ability (Fetch consumer).
+	 *
+	 * @param array $input Input parameters (flow_id, flow_step_id, patch).
+	 * @return array Result.
+	 */
+	public function executeConfigPatchAdd( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
+		return $this->queue->executeConfigPatchAdd( $input );
+	}
+
+	/**
+	 * Execute config-patch-list ability.
+	 */
+	public function executeConfigPatchList( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
+		return $this->queue->executeConfigPatchList( $input );
+	}
+
+	/**
+	 * Execute config-patch-clear ability.
+	 */
+	public function executeConfigPatchClear( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
+		return $this->queue->executeConfigPatchClear( $input );
+	}
+
+	/**
+	 * Execute config-patch-remove ability.
+	 */
+	public function executeConfigPatchRemove( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
+		return $this->queue->executeConfigPatchRemove( $input );
+	}
+
+	/**
+	 * Execute config-patch-update ability.
+	 */
+	public function executeConfigPatchUpdate( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
+		return $this->queue->executeConfigPatchUpdate( $input );
+	}
+
+	/**
+	 * Execute config-patch-move ability.
+	 */
+	public function executeConfigPatchMove( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
+		return $this->queue->executeConfigPatchMove( $input );
+	}
 }

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -239,23 +239,43 @@ class RecoverStuckJobsAbility {
 
 					do_action( 'datamachine_job_complete', $job_id, 'failed' );
 
-					// Check for queued_prompt_backup and requeue if found
-					if ( isset( $engine_data['queued_prompt_backup']['prompt'] ) && isset( $engine_data['queued_prompt_backup']['flow_step_id'] ) ) {
+					// Check for queued_prompt_backup and requeue if found.
+					// Slot-aware: AI backups go back to prompt_queue,
+					// fetch backups go back to config_patch_queue.
+					$backup = $engine_data['queued_prompt_backup'] ?? array();
+					if ( ! empty( $backup ) && isset( $backup['flow_step_id'] ) ) {
+						$slot = $backup['slot'] ?? \DataMachine\Abilities\Flow\QueueAbility::SLOT_PROMPT_QUEUE;
 						$flow = $this->db_flows->get_flow( $job_flow_id );
 						if ( $flow && isset( $flow['flow_config'] ) ) {
 							$flow_config = $flow['flow_config'];
-							$step_id     = $engine_data['queued_prompt_backup']['flow_step_id'];
-							$prompt      = $engine_data['queued_prompt_backup']['prompt'];
+							$step_id     = $backup['flow_step_id'];
 
-							if ( isset( $flow_config[ $step_id ] ) && isset( $flow_config[ $step_id ]['prompt_queue'] ) ) {
-								$flow_config[ $step_id ]['prompt_queue'][] = array(
-									'prompt'   => $prompt,
-									'added_at' => gmdate( 'c' ),
-								);
+							if ( isset( $flow_config[ $step_id ] ) ) {
+								$entry = null;
 
-								$update_result = $this->db_flows->update_flow( $job_flow_id, array( 'flow_config' => $flow_config ) );
-								if ( $update_result ) {
-									++$requeued;
+								if ( \DataMachine\Abilities\Flow\QueueAbility::SLOT_CONFIG_PATCH_QUEUE === $slot && isset( $backup['patch'] ) && is_array( $backup['patch'] ) ) {
+									$entry = array(
+										'patch'    => $backup['patch'],
+										'added_at' => gmdate( 'c' ),
+									);
+								} elseif ( isset( $backup['prompt'] ) ) {
+									$entry = array(
+										'prompt'   => $backup['prompt'],
+										'added_at' => gmdate( 'c' ),
+									);
+									$slot  = \DataMachine\Abilities\Flow\QueueAbility::SLOT_PROMPT_QUEUE;
+								}
+
+								if ( null !== $entry ) {
+									if ( ! isset( $flow_config[ $step_id ][ $slot ] ) || ! is_array( $flow_config[ $step_id ][ $slot ] ) ) {
+										$flow_config[ $step_id ][ $slot ] = array();
+									}
+									$flow_config[ $step_id ][ $slot ][] = $entry;
+
+									$update_result = $this->db_flows->update_flow( $job_flow_id, array( 'flow_config' => $flow_config ) );
+									if ( $update_result ) {
+										++$requeued;
+									}
 								}
 							}
 						}

--- a/inc/Abilities/Job/RetryJobAbility.php
+++ b/inc/Abilities/Job/RetryJobAbility.php
@@ -119,28 +119,51 @@ class RetryJobAbility {
 
 		do_action( 'datamachine_job_complete', $job_id, 'failed' );
 
-		// Check for queued_prompt_backup and requeue if found.
+		// Check for queued_prompt_backup and requeue if found. The
+		// `slot` field on the backup tells us which queue it came from
+		// (prompt_queue for AI, config_patch_queue for Fetch). Pre-#1292
+		// backups have no `slot` field; treat them as prompt_queue for
+		// backward compat — those jobs predate the split.
 		$prompt_requeued = false;
 		$job_flow_id     = (int) ( $job['flow_id'] ?? 0 );
+		$backup          = $engine_data['queued_prompt_backup'] ?? array();
 
-		if ( isset( $engine_data['queued_prompt_backup']['prompt'] ) && isset( $engine_data['queued_prompt_backup']['flow_step_id'] ) ) {
+		if ( ! empty( $backup ) && isset( $backup['flow_step_id'] ) ) {
+			$slot = $backup['slot'] ?? \DataMachine\Abilities\Flow\QueueAbility::SLOT_PROMPT_QUEUE;
+
 			$flow = $this->db_flows->get_flow( $job_flow_id );
 
 			if ( $flow && isset( $flow['flow_config'] ) ) {
 				$flow_config = $flow['flow_config'];
-				$step_id     = $engine_data['queued_prompt_backup']['flow_step_id'];
-				$prompt      = $engine_data['queued_prompt_backup']['prompt'];
+				$step_id     = $backup['flow_step_id'];
 
-				if ( isset( $flow_config[ $step_id ] ) && isset( $flow_config[ $step_id ]['prompt_queue'] ) ) {
-					$flow_config[ $step_id ]['prompt_queue'][] = array(
-						'prompt'   => $prompt,
-						'added_at' => gmdate( 'c' ),
-					);
+				if ( isset( $flow_config[ $step_id ] ) ) {
+					$entry = null;
 
-					$update_result = $this->db_flows->update_flow( $job_flow_id, array( 'flow_config' => $flow_config ) );
+					if ( \DataMachine\Abilities\Flow\QueueAbility::SLOT_CONFIG_PATCH_QUEUE === $slot && isset( $backup['patch'] ) && is_array( $backup['patch'] ) ) {
+						$entry = array(
+							'patch'    => $backup['patch'],
+							'added_at' => gmdate( 'c' ),
+						);
+					} elseif ( isset( $backup['prompt'] ) ) {
+						$entry = array(
+							'prompt'   => $backup['prompt'],
+							'added_at' => gmdate( 'c' ),
+						);
+						$slot  = \DataMachine\Abilities\Flow\QueueAbility::SLOT_PROMPT_QUEUE;
+					}
 
-					if ( $update_result ) {
-						$prompt_requeued = true;
+					if ( null !== $entry ) {
+						if ( ! isset( $flow_config[ $step_id ][ $slot ] ) || ! is_array( $flow_config[ $step_id ][ $slot ] ) ) {
+							$flow_config[ $step_id ][ $slot ] = array();
+						}
+						$flow_config[ $step_id ][ $slot ][] = $entry;
+
+						$update_result = $this->db_flows->update_flow( $job_flow_id, array( 'flow_config' => $flow_config ) );
+
+						if ( $update_result ) {
+							$prompt_requeued = true;
+						}
 					}
 				}
 			}

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -111,6 +111,10 @@ class FlowsCommand extends BaseCommand {
 	 * [--step=<flow_step_id>]
 	 * : Target a specific flow step for prompt update or handler config update (auto-resolved if flow has exactly one handler step).
 	 *
+	 * [--patch=<json>]
+	 * : JSON-encoded config patch object for fetch step queue operations (queue add/update subcommands).
+	 *   The patch is deep-merged into the handler config when the fetch step runs.
+	 *
 	 * [--add=<filename>]
 	 * : Attach a memory file to a flow (memory-files subcommand).
 	 *
@@ -528,6 +532,21 @@ class FlowsCommand extends BaseCommand {
 					$config_parts[] = $key . '=' . $this->formatConfigValue( $value );
 				}
 
+				// Fetch steps surface config_patch_queue depth + queue_enabled
+				// alongside their static handler config (#1292).
+				if ( 'fetch' === $step_type ) {
+					$patch_queue   = $step_data['config_patch_queue'] ?? array();
+					$queue_depth   = is_array( $patch_queue ) ? count( $patch_queue ) : 0;
+					$queue_enabled = ! empty( $step_data['queue_enabled'] );
+					if ( $queue_depth > 0 || $queue_enabled ) {
+						$config_parts[] = sprintf(
+							'config_patch_queue=%d item(s), queue_enabled=%s',
+							$queue_depth,
+							$queue_enabled ? 'true' : 'false'
+						);
+					}
+				}
+
 				$rows[] = array(
 					'step_id'   => $step_id,
 					'order'     => $order,
@@ -592,17 +611,34 @@ class FlowsCommand extends BaseCommand {
 			if ( ! is_array( $step_data ) ) {
 				continue;
 			}
-			if ( 'ai' !== ( $step_data['step_type'] ?? '' ) ) {
+			$step_type = $step_data['step_type'] ?? '';
+
+			// AI steps consume the prompt_queue slot. Surface
+			// user_message + prompt_queue + queue_enabled so every
+			// input AIStep reads is discoverable.
+			if ( 'ai' === $step_type ) {
+				if ( ! array_key_exists( 'user_message', $step_data ) ) {
+					$flow['flow_config'][ $step_id ]['user_message'] = '';
+				}
+				if ( ! array_key_exists( 'prompt_queue', $step_data ) ) {
+					$flow['flow_config'][ $step_id ]['prompt_queue'] = array();
+				}
+				if ( ! array_key_exists( 'queue_enabled', $step_data ) ) {
+					$flow['flow_config'][ $step_id ]['queue_enabled'] = false;
+				}
 				continue;
 			}
-			if ( ! array_key_exists( 'user_message', $step_data ) ) {
-				$flow['flow_config'][ $step_id ]['user_message'] = '';
-			}
-			if ( ! array_key_exists( 'prompt_queue', $step_data ) ) {
-				$flow['flow_config'][ $step_id ]['prompt_queue'] = array();
-			}
-			if ( ! array_key_exists( 'queue_enabled', $step_data ) ) {
-				$flow['flow_config'][ $step_id ]['queue_enabled'] = false;
+
+			// Fetch steps consume the config_patch_queue slot (#1292).
+			// Surface config_patch_queue + queue_enabled so the queue
+			// shape is discoverable on `flow get`.
+			if ( 'fetch' === $step_type ) {
+				if ( ! array_key_exists( 'config_patch_queue', $step_data ) ) {
+					$flow['flow_config'][ $step_id ]['config_patch_queue'] = array();
+				}
+				if ( ! array_key_exists( 'queue_enabled', $step_data ) ) {
+					$flow['flow_config'][ $step_id ]['queue_enabled'] = false;
+				}
 			}
 		}
 

--- a/inc/Cli/Commands/Flows/QueueCommand.php
+++ b/inc/Cli/Commands/Flows/QueueCommand.php
@@ -2,18 +2,30 @@
 /**
  * WP-CLI Flows Queue Command
  *
- * Manages the prompt queue for flow steps.
- * Extracted from FlowsCommand to follow the focused command pattern.
+ * Manages per-step queues attached to flow steps. Two queue slots are
+ * supported (#1292):
+ *
+ *   - prompt_queue       — string prompts, consumed by AI steps
+ *   - config_patch_queue — object patches, consumed by fetch steps
+ *
+ * The CLI is consumer-aware: it inspects the target flow step's
+ * `step_type` and routes to the slot that step consumes. Fetch steps
+ * accept patches via `--patch=<json>`; AI steps accept prompts as a
+ * positional argument. Mixing the two (a string prompt against a
+ * fetch step, or `--patch=` against an AI step) errors loudly with a
+ * pointer to the right flag.
  *
  * @package DataMachine\Cli\Commands\Flows
  * @since 0.31.0
  * @see https://github.com/Extra-Chill/data-machine/issues/345
+ * @see https://github.com/Extra-Chill/data-machine/issues/1292
  */
 
 namespace DataMachine\Cli\Commands\Flows;
 
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
+use DataMachine\Abilities\Flow\QueueAbility;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -64,41 +76,60 @@ class QueueCommand extends BaseCommand {
 	}
 
 	/**
-	 * Add a prompt to the flow queue.
+	 * Add a prompt or config patch to a flow step's queue.
+	 *
+	 * Routes by target step type:
+	 *  - AI step    → writes to prompt_queue (string prompt argument)
+	 *  - Fetch step → writes to config_patch_queue (--patch=<json>)
 	 *
 	 * ## OPTIONS
 	 *
 	 * <flow_id>
 	 * : The flow ID.
 	 *
-	 * <prompt>
-	 * : The prompt text to enqueue.
+	 * [<prompt>]
+	 * : Prompt text to enqueue (for AI steps). Conflicts with --patch.
+	 *
+	 * [--patch=<json>]
+	 * : JSON-encoded config patch object to enqueue (for fetch steps).
+	 * : The patch is deep-merged into the handler config when the step runs.
 	 *
 	 * [--step=<flow_step_id>]
 	 * : Target a specific flow step. Auto-resolved if the flow has exactly one queueable step.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Add a prompt to the queue
+	 *     # Add a prompt to an AI step queue
 	 *     wp datamachine flows queue add 42 "Generate a blog post about AI"
 	 *
-	 *     # Add with explicit step
-	 *     wp datamachine flows queue add 42 --step=flow-42-step-abc "Write about cats"
+	 *     # Add a config patch to a fetch step queue
+	 *     wp datamachine flows queue add 42 --patch='{"params":{"after":"2015-05-01"}}'
 	 *
 	 * @subcommand add
 	 */
 	public function add( array $args, array $assoc_args ): void {
-		if ( count( $args ) < 2 ) {
-			WP_CLI::error( 'Usage: wp datamachine flows queue add <flow_id> "prompt text"' );
+		if ( count( $args ) < 1 ) {
+			WP_CLI::error( 'Usage: wp datamachine flows queue add <flow_id> "prompt text"  or  wp datamachine flows queue add <flow_id> --patch=\'{...}\'' );
 			return;
 		}
 
 		$flow_id      = (int) $args[0];
 		$flow_step_id = $assoc_args['step'] ?? null;
-		$prompt       = $args[1];
+		$patch_json   = $assoc_args['patch'] ?? null;
+		$prompt       = $args[1] ?? null;
 
 		if ( $flow_id <= 0 ) {
 			WP_CLI::error( 'flow_id must be a positive integer' );
+			return;
+		}
+
+		if ( null !== $patch_json && null !== $prompt ) {
+			WP_CLI::error( 'Cannot use both a positional prompt and --patch. Pick one based on the target step type.' );
+			return;
+		}
+
+		if ( null === $patch_json && null === $prompt ) {
+			WP_CLI::error( 'Provide either a positional prompt (AI step) or --patch=<json> (fetch step).' );
 			return;
 		}
 
@@ -111,30 +142,72 @@ class QueueCommand extends BaseCommand {
 			$flow_step_id = $resolved['step_id'];
 		}
 
-		if ( empty( trim( $prompt ) ) ) {
-			WP_CLI::error( 'prompt cannot be empty' );
+		$step_type = $this->getStepType( $flow_id, $flow_step_id );
+		if ( null === $step_type ) {
+			WP_CLI::error( sprintf( 'Flow step %s not found in flow %d.', $flow_step_id, $flow_id ) );
 			return;
 		}
 
 		$ability = new \DataMachine\Abilities\FlowAbilities();
-		$result  = $ability->executeQueueAdd(
-			array(
-				'flow_id'      => $flow_id,
-				'flow_step_id' => $flow_step_id,
-				'prompt'       => $prompt,
-			)
-		);
+
+		if ( null !== $patch_json ) {
+			if ( 'fetch' !== $step_type ) {
+				WP_CLI::error( sprintf(
+					'--patch is only valid for fetch steps; this step is "%s". For AI steps, pass a positional prompt instead.',
+					$step_type
+				) );
+				return;
+			}
+
+			$patch = json_decode( $patch_json, true );
+			if ( ! is_array( $patch ) ) {
+				WP_CLI::error( 'Invalid --patch: not a JSON object.' );
+				return;
+			}
+
+			$result = $ability->executeConfigPatchAdd(
+				array(
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+					'patch'        => $patch,
+				)
+			);
+		} else {
+			if ( 'fetch' === $step_type ) {
+				WP_CLI::error( 'Fetch steps consume config patches, not string prompts. Use --patch=\'{...}\' instead.' );
+				return;
+			}
+
+			if ( empty( trim( (string) $prompt ) ) ) {
+				WP_CLI::error( 'prompt cannot be empty' );
+				return;
+			}
+
+			$result = $ability->executeQueueAdd(
+				array(
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+					'prompt'       => $prompt,
+				)
+			);
+		}
 
 		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] ?? 'Failed to add prompt to queue' );
+			WP_CLI::error( $result['error'] ?? 'Failed to add item to queue' );
 			return;
 		}
 
-		WP_CLI::success( $result['message'] ?? 'Prompt added to queue.' );
+		WP_CLI::success( $result['message'] ?? 'Item added to queue.' );
 	}
 
 	/**
-	 * List all prompts in the flow queue.
+	 * List queued items for a flow step.
+	 *
+	 * Renders both prompt_queue (AI) and config_patch_queue (fetch)
+	 * when the step has either populated. Per-step routing decides
+	 * which slot to query, but `flow queue list` is allowed to show
+	 * either — convenient for inspecting flows without remembering the
+	 * step type.
 	 *
 	 * ## OPTIONS
 	 *
@@ -157,10 +230,10 @@ class QueueCommand extends BaseCommand {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # List queued prompts
+	 *     # List queued items
 	 *     wp datamachine flows queue list 42
 	 *
-	 *     # List queued prompts as JSON
+	 *     # List as JSON
 	 *     wp datamachine flows queue list 42 --format=json
 	 *
 	 * @subcommand list
@@ -190,51 +263,92 @@ class QueueCommand extends BaseCommand {
 		}
 
 		$ability = new \DataMachine\Abilities\FlowAbilities();
-		$result  = $ability->executeQueueList(
+
+		$prompt_result = $ability->executeQueueList(
 			array(
 				'flow_id'      => $flow_id,
 				'flow_step_id' => $flow_step_id,
 			)
 		);
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] ?? 'Failed to list queue' );
+		$patch_result = $ability->executeConfigPatchList(
+			array(
+				'flow_id'      => $flow_id,
+				'flow_step_id' => $flow_step_id,
+			)
+		);
+
+		if ( ! $prompt_result['success'] && ! $patch_result['success'] ) {
+			WP_CLI::error( $prompt_result['error'] ?? $patch_result['error'] ?? 'Failed to list queue' );
 			return;
 		}
 
-		$queue         = $result['queue'] ?? array();
-		$queue_enabled = $result['queue_enabled'] ?? false;
+		$prompt_queue  = $prompt_result['queue'] ?? array();
+		$patch_queue   = $patch_result['queue'] ?? array();
+		$queue_enabled = $prompt_result['queue_enabled'] ?? $patch_result['queue_enabled'] ?? false;
 
-		if ( empty( $queue ) ) {
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode(
+				array(
+					'flow_id'            => $flow_id,
+					'flow_step_id'       => $flow_step_id,
+					'queue_enabled'      => $queue_enabled,
+					'prompt_queue'       => $prompt_queue,
+					'config_patch_queue' => $patch_queue,
+				),
+				JSON_PRETTY_PRINT
+			) );
+			return;
+		}
+
+		if ( empty( $prompt_queue ) && empty( $patch_queue ) ) {
 			WP_CLI::log( sprintf( 'Queue is empty. (queue_enabled: %s)', $queue_enabled ? 'yes' : 'no' ) );
 			return;
 		}
 
-		if ( 'json' === $format ) {
-			WP_CLI::line( wp_json_encode( $queue, JSON_PRETTY_PRINT ) );
-			return;
+		if ( ! empty( $prompt_queue ) ) {
+			WP_CLI::log( '== AI prompts (prompt_queue) ==' );
+			$items = array();
+			foreach ( $prompt_queue as $index => $item ) {
+				$prompt_preview = mb_strlen( $item['prompt'] ?? '' ) > 60
+					? mb_substr( $item['prompt'], 0, 57 ) . '...'
+					: ( $item['prompt'] ?? '' );
+
+				$items[] = array(
+					'index'    => $index,
+					'prompt'   => $prompt_preview,
+					'added_at' => $item['added_at'] ?? '',
+				);
+			}
+			$this->format_items( $items, array( 'index', 'prompt', 'added_at' ), $assoc_args, 'index' );
 		}
 
-		// Transform for table display.
-		$items = array();
-		foreach ( $queue as $index => $item ) {
-			$prompt_preview = mb_strlen( $item['prompt'] ) > 60
-				? mb_substr( $item['prompt'], 0, 57 ) . '...'
-				: $item['prompt'];
-
-			$items[] = array(
-				'index'    => $index,
-				'prompt'   => $prompt_preview,
-				'added_at' => $item['added_at'] ?? '',
-			);
+		if ( ! empty( $patch_queue ) ) {
+			WP_CLI::log( '== Config patches (config_patch_queue) ==' );
+			foreach ( $patch_queue as $index => $item ) {
+				$patch     = $item['patch'] ?? array();
+				$added_at  = $item['added_at'] ?? '';
+				$patch_str = is_array( $patch ) ? wp_json_encode( $patch, JSON_PRETTY_PRINT ) : (string) $patch;
+				WP_CLI::log( sprintf( '[%d]  added_at: %s', $index, $added_at ) );
+				foreach ( explode( "\n", $patch_str ) as $line ) {
+					WP_CLI::log( '      ' . $line );
+				}
+			}
 		}
 
-		$this->format_items( $items, array( 'index', 'prompt', 'added_at' ), $assoc_args, 'index' );
-		WP_CLI::log( sprintf( 'Total: %d prompt(s) in queue. (queue_enabled: %s)', count( $queue ), $queue_enabled ? 'yes' : 'no' ) );
+		WP_CLI::log( sprintf(
+			'Total: %d prompt(s), %d patch(es). (queue_enabled: %s)',
+			count( $prompt_queue ),
+			count( $patch_queue ),
+			$queue_enabled ? 'yes' : 'no'
+		) );
 	}
 
 	/**
-	 * Clear all prompts from the flow queue.
+	 * Clear all queued items for a flow step.
+	 *
+	 * Routes by step type. Fetch steps clear `config_patch_queue`;
+	 * other step types clear `prompt_queue`.
 	 *
 	 * ## OPTIONS
 	 *
@@ -246,7 +360,7 @@ class QueueCommand extends BaseCommand {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Clear all prompts from queue
+	 *     # Clear all queued items
 	 *     wp datamachine flows queue clear 42
 	 *
 	 * @subcommand clear
@@ -274,13 +388,24 @@ class QueueCommand extends BaseCommand {
 			$flow_step_id = $resolved['step_id'];
 		}
 
-		$ability = new \DataMachine\Abilities\FlowAbilities();
-		$result  = $ability->executeQueueClear(
-			array(
-				'flow_id'      => $flow_id,
-				'flow_step_id' => $flow_step_id,
-			)
-		);
+		$step_type = $this->getStepType( $flow_id, $flow_step_id );
+		$ability   = new \DataMachine\Abilities\FlowAbilities();
+
+		if ( 'fetch' === $step_type ) {
+			$result = $ability->executeConfigPatchClear(
+				array(
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+				)
+			);
+		} else {
+			$result = $ability->executeQueueClear(
+				array(
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+				)
+			);
+		}
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to clear queue' );
@@ -291,7 +416,9 @@ class QueueCommand extends BaseCommand {
 	}
 
 	/**
-	 * Remove a specific prompt from the queue by index.
+	 * Remove a queued item by index.
+	 *
+	 * Routes by step type.
 	 *
 	 * ## OPTIONS
 	 *
@@ -299,18 +426,15 @@ class QueueCommand extends BaseCommand {
 	 * : The flow ID.
 	 *
 	 * <index>
-	 * : Zero-based index of the prompt to remove.
+	 * : Zero-based index of the item to remove.
 	 *
 	 * [--step=<flow_step_id>]
 	 * : Target a specific flow step. Auto-resolved if the flow has exactly one queueable step.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Remove the first prompt
+	 *     # Remove the first item
 	 *     wp datamachine flows queue remove 42 0
-	 *
-	 *     # Remove from specific step
-	 *     wp datamachine flows queue remove 42 3 --step=flow-42-step-abc
 	 *
 	 * @subcommand remove
 	 */
@@ -343,31 +467,48 @@ class QueueCommand extends BaseCommand {
 			return;
 		}
 
-		$ability = new \DataMachine\Abilities\FlowAbilities();
-		$result  = $ability->executeQueueRemove(
-			array(
-				'flow_id'      => $flow_id,
-				'flow_step_id' => $flow_step_id,
-				'index'        => $index,
-			)
-		);
+		$step_type = $this->getStepType( $flow_id, $flow_step_id );
+		$ability   = new \DataMachine\Abilities\FlowAbilities();
+
+		if ( 'fetch' === $step_type ) {
+			$result = $ability->executeConfigPatchRemove(
+				array(
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+					'index'        => $index,
+				)
+			);
+		} else {
+			$result = $ability->executeQueueRemove(
+				array(
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+					'index'        => $index,
+				)
+			);
+		}
 
 		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] ?? 'Failed to remove prompt from queue' );
+			WP_CLI::error( $result['error'] ?? 'Failed to remove item from queue' );
 			return;
 		}
 
-		WP_CLI::success( $result['message'] ?? 'Prompt removed from queue.' );
+		WP_CLI::success( $result['message'] ?? 'Item removed from queue.' );
 		if ( ! empty( $result['removed_prompt'] ) ) {
 			$preview = mb_strlen( $result['removed_prompt'] ) > 80
 				? mb_substr( $result['removed_prompt'], 0, 77 ) . '...'
 				: $result['removed_prompt'];
 			WP_CLI::log( sprintf( 'Removed: %s', $preview ) );
+		} elseif ( ! empty( $result['removed_patch'] ) && is_array( $result['removed_patch'] ) ) {
+			WP_CLI::log( 'Removed patch: ' . wp_json_encode( $result['removed_patch'] ) );
 		}
 	}
 
 	/**
-	 * Update a prompt at a specific index in the queue.
+	 * Update a queued item at a specific index.
+	 *
+	 * Routes by step type. AI steps accept a positional prompt; fetch
+	 * steps accept --patch=<json>.
 	 *
 	 * ## OPTIONS
 	 *
@@ -375,34 +516,51 @@ class QueueCommand extends BaseCommand {
 	 * : The flow ID.
 	 *
 	 * <index>
-	 * : Zero-based index of the prompt to update.
+	 * : Zero-based index of the item to update.
 	 *
-	 * <prompt>
-	 * : The replacement prompt text.
+	 * [<prompt>]
+	 * : Replacement prompt text (for AI steps).
+	 *
+	 * [--patch=<json>]
+	 * : JSON-encoded replacement patch (for fetch steps).
 	 *
 	 * [--step=<flow_step_id>]
 	 * : Target a specific flow step. Auto-resolved if the flow has exactly one queueable step.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Update the first prompt
+	 *     # Update an AI prompt at index 0
 	 *     wp datamachine flows queue update 42 0 "Updated prompt text"
+	 *
+	 *     # Update a fetch patch
+	 *     wp datamachine flows queue update 42 0 --patch='{"params":{"after":"2016-01-01"}}'
 	 *
 	 * @subcommand update
 	 */
 	public function update( array $args, array $assoc_args ): void {
-		if ( count( $args ) < 3 ) {
-			WP_CLI::error( 'Usage: wp datamachine flows queue update <flow_id> <index> "new prompt text"' );
+		if ( count( $args ) < 2 ) {
+			WP_CLI::error( 'Usage: wp datamachine flows queue update <flow_id> <index> "new prompt text"  or  --patch=\'{...}\'' );
 			return;
 		}
 
 		$flow_id      = (int) $args[0];
 		$flow_step_id = $assoc_args['step'] ?? null;
 		$index        = (int) $args[1];
-		$prompt       = $args[2];
+		$patch_json   = $assoc_args['patch'] ?? null;
+		$prompt       = $args[2] ?? null;
 
 		if ( $flow_id <= 0 ) {
 			WP_CLI::error( 'flow_id must be a positive integer' );
+			return;
+		}
+
+		if ( null !== $patch_json && null !== $prompt ) {
+			WP_CLI::error( 'Cannot use both a positional prompt and --patch.' );
+			return;
+		}
+
+		if ( null === $patch_json && null === $prompt ) {
+			WP_CLI::error( 'Provide either a positional prompt or --patch=<json>.' );
 			return;
 		}
 
@@ -420,26 +578,54 @@ class QueueCommand extends BaseCommand {
 			return;
 		}
 
-		$ability = new \DataMachine\Abilities\FlowAbilities();
-		$result  = $ability->executeQueueUpdate(
-			array(
-				'flow_id'      => $flow_id,
-				'flow_step_id' => $flow_step_id,
-				'index'        => $index,
-				'prompt'       => $prompt,
-			)
-		);
+		$step_type = $this->getStepType( $flow_id, $flow_step_id );
+		$ability   = new \DataMachine\Abilities\FlowAbilities();
+
+		if ( null !== $patch_json ) {
+			if ( 'fetch' !== $step_type ) {
+				WP_CLI::error( sprintf( '--patch is only valid for fetch steps; this step is "%s".', $step_type ) );
+				return;
+			}
+			$patch = json_decode( $patch_json, true );
+			if ( ! is_array( $patch ) ) {
+				WP_CLI::error( 'Invalid --patch: not a JSON object.' );
+				return;
+			}
+			$result = $ability->executeConfigPatchUpdate(
+				array(
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+					'index'        => $index,
+					'patch'        => $patch,
+				)
+			);
+		} else {
+			if ( 'fetch' === $step_type ) {
+				WP_CLI::error( 'Fetch steps consume config patches, not string prompts. Use --patch=\'{...}\' instead.' );
+				return;
+			}
+			$result = $ability->executeQueueUpdate(
+				array(
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+					'index'        => $index,
+					'prompt'       => $prompt,
+				)
+			);
+		}
 
 		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] ?? 'Failed to update prompt in queue' );
+			WP_CLI::error( $result['error'] ?? 'Failed to update queue item' );
 			return;
 		}
 
-		WP_CLI::success( $result['message'] ?? 'Prompt updated in queue.' );
+		WP_CLI::success( $result['message'] ?? 'Queue item updated.' );
 	}
 
 	/**
-	 * Move a prompt from one position to another in the queue.
+	 * Move an item from one position to another in the queue.
+	 *
+	 * Routes by step type.
 	 *
 	 * ## OPTIONS
 	 *
@@ -447,7 +633,7 @@ class QueueCommand extends BaseCommand {
 	 * : The flow ID.
 	 *
 	 * <from_index>
-	 * : Current zero-based index of the prompt.
+	 * : Current zero-based index of the item.
 	 *
 	 * <to_index>
 	 * : Desired zero-based index.
@@ -457,7 +643,7 @@ class QueueCommand extends BaseCommand {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Move prompt from position 2 to front of queue
+	 *     # Move item from position 2 to front of queue
 	 *     wp datamachine flows queue move 42 2 0
 	 *
 	 * @subcommand move
@@ -492,15 +678,28 @@ class QueueCommand extends BaseCommand {
 			return;
 		}
 
-		$ability = new \DataMachine\Abilities\FlowAbilities();
-		$result  = $ability->executeQueueMove(
-			array(
-				'flow_id'      => $flow_id,
-				'flow_step_id' => $flow_step_id,
-				'from_index'   => $from_index,
-				'to_index'     => $to_index,
-			)
-		);
+		$step_type = $this->getStepType( $flow_id, $flow_step_id );
+		$ability   = new \DataMachine\Abilities\FlowAbilities();
+
+		if ( 'fetch' === $step_type ) {
+			$result = $ability->executeConfigPatchMove(
+				array(
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+					'from_index'   => $from_index,
+					'to_index'     => $to_index,
+				)
+			);
+		} else {
+			$result = $ability->executeQueueMove(
+				array(
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+					'from_index'   => $from_index,
+					'to_index'     => $to_index,
+				)
+			);
+		}
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to move item in queue' );
@@ -677,5 +876,39 @@ class QueueCommand extends BaseCommand {
 			'step_id' => $queueable[0],
 			'error'   => null,
 		);
+	}
+
+	/**
+	 * Look up the step_type of a specific flow step.
+	 *
+	 * Used to route consumer-aware operations (AI vs Fetch) to the
+	 * correct queue slot.
+	 *
+	 * @param int    $flow_id      Flow ID.
+	 * @param string $flow_step_id Flow step ID.
+	 * @return string|null Step type, or null if not found.
+	 */
+	private function getStepType( int $flow_id, string $flow_step_id ): ?string {
+		global $wpdb;
+
+		$flow = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT flow_config FROM {$wpdb->prefix}datamachine_flows WHERE flow_id = %d",
+				$flow_id
+			),
+			ARRAY_A
+		);
+
+		if ( ! $flow ) {
+			return null;
+		}
+
+		$config = json_decode( $flow['flow_config'], true );
+		if ( ! is_array( $config ) || ! isset( $config[ $flow_step_id ] ) ) {
+			return null;
+		}
+
+		$step_type = $config[ $flow_step_id ]['step_type'] ?? '';
+		return is_string( $step_type ) && '' !== $step_type ? $step_type : null;
 	}
 }

--- a/inc/Core/Steps/QueueableTrait.php
+++ b/inc/Core/Steps/QueueableTrait.php
@@ -1,22 +1,25 @@
 <?php
 /**
- * Trait for steps that can consume prompts/tasks from the flow queue.
+ * Trait for steps that consume from a per-flow-step queue.
  *
- * Provides shared queue pop functionality that can be used by any step type
- * that needs to pull work items from the prompt queue.
+ * Two consumption modes are exposed, each backed by its own storage
+ * slot on the flow_step_config (see QueueAbility for the storage
+ * contract):
  *
- * Two consumption modes are exposed:
- *
- * - {@see popFromQueueIfEmpty()} — for steps that consume scalar prompts
- *   (AI step's user_message). Returns the popped string verbatim.
+ * - {@see popFromQueueIfEmpty()} — for steps that consume scalar
+ *   prompts (AI step's user_message). Reads from the
+ *   `prompt_queue` slot. Each entry is `{ prompt: string, added_at }`.
  *
  * - {@see popQueuedConfigPatch()} — for steps that consume structured
- *   config patches (Fetch step's handler params). Decodes the popped
- *   prompt as JSON and returns it as an array suitable for deep-merging
- *   into the step's existing handler configuration.
+ *   config patches (Fetch step's handler params). Reads from the
+ *   `config_patch_queue` slot. Each entry is `{ patch: array,
+ *   added_at }` — the patch is a decoded object stored verbatim, so
+ *   no JSON-decode happens at read time.
  *
- * Both share the same persistence (per-flow-step FIFO queue), the same
- * `queue_enabled` toggle, and the same retry-on-failure backup semantics.
+ * Both share the same `queue_enabled` toggle on the step config and
+ * the same retry-on-failure backup semantics. Splitting the storage
+ * slots is #1292; pre-split, both consumers shared `prompt_queue` and
+ * had to do string-vs-JSON detective work at read time.
  *
  * @package DataMachine\Core\Steps
  * @since 0.19.0
@@ -31,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Queueable trait for steps that consume from prompt queue.
+ * Queueable trait for steps that consume from a per-step queue.
  *
  * Usage:
  *   class MyStep extends Step {
@@ -46,7 +49,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 trait QueueableTrait {
 
 	/**
-	 * Pop from queue if the provided value is empty and queue is enabled.
+	 * Pop from the prompt queue if the provided value is empty and the
+	 * queue is enabled.
+	 *
+	 * Reads from the `prompt_queue` slot (AI consumer).
 	 *
 	 * @param string $current_value The current value (e.g., user_message or prompt).
 	 * @param bool   $queue_enabled Whether queue pop is enabled for this step.
@@ -61,7 +67,7 @@ trait QueueableTrait {
 			);
 		}
 
-		$queued = $this->popOnceFromFlowQueue();
+		$queued = $this->popOnceFromPromptQueue();
 
 		if ( null === $queued ) {
 			return array(
@@ -79,11 +85,13 @@ trait QueueableTrait {
 	}
 
 	/**
-	 * Pop a structured config patch from the queue.
+	 * Pop a structured config patch from the fetch step queue.
 	 *
-	 * Sibling of {@see popFromQueueIfEmpty()} for steps whose unit of work
-	 * is a structured config dict rather than a scalar prompt. The popped
-	 * prompt string is JSON-decoded and returned as an array.
+	 * Sibling of {@see popFromQueueIfEmpty()} for steps whose unit of
+	 * work is a structured config dict rather than a scalar prompt.
+	 * Reads from the `config_patch_queue` slot (Fetch consumer). The
+	 * `patch` field is stored as a decoded array verbatim, so no
+	 * JSON-decode happens here.
 	 *
 	 * Typical use: fetch step pops a config patch and the caller
 	 * deep-merges it into the existing handler config to drive windowed
@@ -117,7 +125,7 @@ trait QueueableTrait {
 	 * or fall through to the static handler config.
 	 *
 	 * @param bool $queue_enabled Whether queue pop is enabled for this step.
-	 * @return array{patch: array, from_queue: bool, added_at: string|null, raw_prompt: string} Result with the decoded patch and source info.
+	 * @return array{patch: array, from_queue: bool, added_at: string|null} Result with the decoded patch and source info.
 	 */
 	protected function popQueuedConfigPatch( bool $queue_enabled = false ): array {
 		if ( ! $queue_enabled ) {
@@ -125,32 +133,28 @@ trait QueueableTrait {
 				'patch'      => array(),
 				'from_queue' => false,
 				'added_at'   => null,
-				'raw_prompt' => '',
 			);
 		}
 
-		$queued = $this->popOnceFromFlowQueue();
+		$queued = $this->popOnceFromConfigPatchQueue();
 
 		if ( null === $queued ) {
 			return array(
 				'patch'      => array(),
 				'from_queue' => false,
 				'added_at'   => null,
-				'raw_prompt' => '',
 			);
 		}
 
-		$decoded = json_decode( $queued['prompt'], true );
-		$patch   = is_array( $decoded ) ? $decoded : array();
+		$patch = isset( $queued['patch'] ) && is_array( $queued['patch'] ) ? $queued['patch'] : array();
 
-		if ( ! is_array( $decoded ) ) {
+		if ( empty( $patch ) ) {
 			do_action(
 				'datamachine_log',
 				'warning',
-				'Queueable fetch: queued item is not a JSON object — treating as empty patch',
+				'Queueable fetch: queued config patch is empty or malformed — treating as no-op tick',
 				array(
 					'flow_step_id' => $this->flow_step_id,
-					'raw_prompt'   => substr( $queued['prompt'], 0, 200 ),
 				)
 			);
 		}
@@ -159,19 +163,15 @@ trait QueueableTrait {
 			'patch'      => $patch,
 			'from_queue' => true,
 			'added_at'   => $queued['added_at'] ?? null,
-			'raw_prompt' => $queued['prompt'],
 		);
 	}
 
 	/**
-	 * Pop one item from the flow queue and back it up to engine data.
-	 *
-	 * Internal helper shared by both pop variants. Returns null when the
-	 * flow_id is unavailable or the queue is empty.
+	 * Pop one item from the AI prompt queue and back it up to engine data.
 	 *
 	 * @return array{prompt: string, added_at: string|null}|null Popped item, or null if no item.
 	 */
-	private function popOnceFromFlowQueue(): ?array {
+	private function popOnceFromPromptQueue(): ?array {
 		$job_context = $this->engine->getJobContext();
 		$flow_id     = $job_context['flow_id'] ?? null;
 
@@ -197,11 +197,13 @@ trait QueueableTrait {
 		);
 
 		// Store backup of the popped prompt in engine data for retry on failure.
+		// The `slot` field tells the retry path which queue to re-push to.
 		if ( property_exists( $this, 'job_id' ) && ! empty( $this->job_id ) ) {
 			\datamachine_merge_engine_data(
 				$this->job_id,
 				array(
 					'queued_prompt_backup' => array(
+						'slot'         => QueueAbility::SLOT_PROMPT_QUEUE,
 						'prompt'       => $queued_item['prompt'],
 						'flow_id'      => (int) $flow_id,
 						'flow_step_id' => $this->flow_step_id,
@@ -213,6 +215,60 @@ trait QueueableTrait {
 
 		return array(
 			'prompt'   => $queued_item['prompt'],
+			'added_at' => $queued_item['added_at'] ?? null,
+		);
+	}
+
+	/**
+	 * Pop one item from the fetch config-patch queue and back it up to engine data.
+	 *
+	 * @return array{patch: array, added_at: string|null}|null Popped item, or null if no item.
+	 */
+	private function popOnceFromConfigPatchQueue(): ?array {
+		$job_context = $this->engine->getJobContext();
+		$flow_id     = $job_context['flow_id'] ?? null;
+
+		if ( ! $flow_id ) {
+			return null;
+		}
+
+		$queued_item = QueueAbility::popConfigPatchFromQueue( (int) $flow_id, $this->flow_step_id );
+
+		if ( ! $queued_item || ! isset( $queued_item['patch'] ) || ! is_array( $queued_item['patch'] ) ) {
+			return null;
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Using config patch from queue',
+			array(
+				'flow_id'    => $flow_id,
+				'step_type'  => $this->step_type ?? 'unknown',
+				'patch_keys' => array_keys( $queued_item['patch'] ),
+				'added_at'   => $queued_item['added_at'] ?? '',
+			)
+		);
+
+		// Store backup for retry on failure. `slot` distinguishes which
+		// queue the backup belongs to.
+		if ( property_exists( $this, 'job_id' ) && ! empty( $this->job_id ) ) {
+			\datamachine_merge_engine_data(
+				$this->job_id,
+				array(
+					'queued_prompt_backup' => array(
+						'slot'         => QueueAbility::SLOT_CONFIG_PATCH_QUEUE,
+						'patch'        => $queued_item['patch'],
+						'flow_id'      => (int) $flow_id,
+						'flow_step_id' => $this->flow_step_id,
+						'added_at'     => $queued_item['added_at'] ?? null,
+					),
+				)
+			);
+		}
+
+		return array(
+			'patch'    => $queued_item['patch'],
 			'added_at' => $queued_item['added_at'] ?? null,
 		);
 	}

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -24,3 +24,4 @@ require_once __DIR__ . '/post-pipeline-meta.php';
 require_once __DIR__ . '/update-to-upsert.php';
 require_once __DIR__ . '/strip-pipeline-step-provider-model.php';
 require_once __DIR__ . '/ai-enabled-tools.php';
+require_once __DIR__ . '/split-queue-payload.php';

--- a/inc/migrations/split-queue-payload.php
+++ b/inc/migrations/split-queue-payload.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Data Machine — Split queue payload migration (#1292).
+ *
+ * Pre-#1292, both AIStep and FetchStep consumed from the same
+ * `prompt_queue` storage slot, but with different payload semantics:
+ * AI expected plain string prompts; Fetch expected JSON-encoded
+ * config-patch objects in the `prompt` field. The schema lied at
+ * write time, validation was implicit via the consumer step type,
+ * and tooling could not tell the two payload shapes apart.
+ *
+ * After #1292, the slot is split:
+ *
+ *   - prompt_queue        — array<{prompt:string, added_at}>      (AI only)
+ *   - config_patch_queue  — array<{patch:array, added_at}>        (Fetch only)
+ *
+ * This migration walks every flow_config and, for each fetch step,
+ * decodes the JSON-encoded `prompt` field of every prompt_queue entry
+ * back into an object and moves it to a new `config_patch_queue`
+ * entry under the `patch` field. The fetch step's `prompt_queue` is
+ * then unset (not just emptied — fetch steps no longer have a
+ * prompt_queue at all under the post-split shape).
+ *
+ * Idempotent. Gated on the `datamachine_queue_payload_split_migrated`
+ * option. Misshaped entries (a `prompt` string that does not
+ * JSON-decode to an object) are logged at level=warning with the
+ * flow_id, step_id and a short preview, then skipped — they would
+ * have silently no-op'd at runtime under the pre-split code anyway,
+ * so dropping them on the floor is the same observable behaviour.
+ *
+ * AI-step prompt_queue entries are left untouched. Other step types
+ * (publish/upsert/system_task/etc.) are also untouched — they have no
+ * queueable consumer and any prompt_queue rows on them are stale.
+ *
+ * @package DataMachine
+ * @since 0.84.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Move fetch-step queue entries from `prompt_queue` (with JSON-encoded
+ * `prompt` strings) to a new `config_patch_queue` slot (with decoded
+ * `patch` arrays).
+ *
+ * Idempotent: gated on `datamachine_queue_payload_split_migrated`.
+ *
+ * @since 0.84.0
+ */
+function datamachine_migrate_split_queue_payload(): void {
+	$already_done = get_option( 'datamachine_queue_payload_split_migrated', false );
+	if ( $already_done ) {
+		return;
+	}
+
+	global $wpdb;
+	$table = $wpdb->prefix . 'datamachine_flows';
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix.
+	$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+	// phpcs:enable WordPress.DB.PreparedSQL
+	if ( ! $table_exists ) {
+		update_option( 'datamachine_queue_payload_split_migrated', true, true );
+		return;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix.
+	$rows = $wpdb->get_results( "SELECT flow_id, flow_config FROM {$table}", ARRAY_A );
+	// phpcs:enable WordPress.DB.PreparedSQL
+
+	if ( empty( $rows ) ) {
+		update_option( 'datamachine_queue_payload_split_migrated', true, true );
+		return;
+	}
+
+	$migrated_flows   = 0;
+	$migrated_entries = 0;
+	$skipped_entries  = 0;
+
+	foreach ( $rows as $row ) {
+		$flow_config = json_decode( $row['flow_config'], true );
+		if ( ! is_array( $flow_config ) ) {
+			continue;
+		}
+
+		$changed = false;
+		foreach ( $flow_config as $step_id => &$step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+
+			if ( 'fetch' !== ( $step['step_type'] ?? '' ) ) {
+				continue;
+			}
+
+			$legacy_queue = $step['prompt_queue'] ?? null;
+			if ( ! is_array( $legacy_queue ) || empty( $legacy_queue ) ) {
+				// Nothing to migrate; ensure the prompt_queue field is
+				// gone so fetch steps have a uniform shape post-split.
+				if ( array_key_exists( 'prompt_queue', $step ) ) {
+					unset( $step['prompt_queue'] );
+					$changed = true;
+				}
+				continue;
+			}
+
+			$existing_patch_queue = $step['config_patch_queue'] ?? array();
+			if ( ! is_array( $existing_patch_queue ) ) {
+				$existing_patch_queue = array();
+			}
+
+			$migrated_for_step = array();
+			foreach ( $legacy_queue as $idx => $entry ) {
+				if ( ! is_array( $entry ) || ! isset( $entry['prompt'] ) ) {
+					++$skipped_entries;
+					do_action(
+						'datamachine_log',
+						'warning',
+						'Split queue payload migration: skipped malformed prompt_queue entry on fetch step',
+						array(
+							'flow_id' => $row['flow_id'],
+							'step_id' => $step_id,
+							'index'   => $idx,
+							'preview' => is_string( $entry ) ? substr( $entry, 0, 80 ) : gettype( $entry ),
+						)
+					);
+					continue;
+				}
+
+				$decoded = json_decode( (string) $entry['prompt'], true );
+				if ( ! is_array( $decoded ) || empty( $decoded ) ) {
+					++$skipped_entries;
+					do_action(
+						'datamachine_log',
+						'warning',
+						'Split queue payload migration: prompt_queue entry on fetch step is not a JSON object — skipped',
+						array(
+							'flow_id' => $row['flow_id'],
+							'step_id' => $step_id,
+							'index'   => $idx,
+							'preview' => substr( (string) $entry['prompt'], 0, 80 ),
+						)
+					);
+					continue;
+				}
+
+				$migrated_for_step[] = array(
+					'patch'    => $decoded,
+					'added_at' => $entry['added_at'] ?? gmdate( 'c' ),
+				);
+				++$migrated_entries;
+			}
+
+			$step['config_patch_queue'] = array_merge( $existing_patch_queue, $migrated_for_step );
+			unset( $step['prompt_queue'] );
+			$changed = true;
+		}
+		unset( $step );
+
+		if ( $changed ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->update(
+				$table,
+				array( 'flow_config' => wp_json_encode( $flow_config ) ),
+				array( 'flow_id' => $row['flow_id'] ),
+				array( '%s' ),
+				array( '%d' )
+			);
+			++$migrated_flows;
+		}
+	}
+
+	update_option( 'datamachine_queue_payload_split_migrated', true, true );
+
+	if ( $migrated_flows > 0 || $skipped_entries > 0 ) {
+		do_action(
+			'datamachine_log',
+			'info',
+			'Split queue payload migration complete',
+			array(
+				'flows_updated'    => $migrated_flows,
+				'entries_migrated' => $migrated_entries,
+				'entries_skipped'  => $skipped_entries,
+			)
+		);
+	}
+}

--- a/tests/queue-payload-split-smoke.php
+++ b/tests/queue-payload-split-smoke.php
@@ -1,0 +1,564 @@
+<?php
+/**
+ * Pure-PHP smoke test for the queue payload split (#1292).
+ *
+ * Run with: php tests/queue-payload-split-smoke.php
+ *
+ * Pre-#1292, both AIStep and FetchStep consumed from the same
+ * `prompt_queue` slot — AI as plain strings, Fetch as JSON-encoded
+ * objects under the same `prompt` field. The schema lied at write
+ * time and validation was implicit via the consumer step type.
+ *
+ * Post-#1292:
+ *   - prompt_queue:        AI only, payload field `prompt` (string)
+ *   - config_patch_queue:  Fetch only, payload field `patch` (object)
+ *
+ * The byte-mirror harness inlines the relevant slices of the real
+ * code so any divergence between this file and production is caught
+ * by failing assertions.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failed = 0;
+$total  = 0;
+
+function assert_split( string $name, bool $cond, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $cond ) {
+		echo "  [PASS] $name\n";
+	} else {
+		echo "  [FAIL] $name" . ( $detail ? " — $detail" : '' ) . "\n";
+		++$failed;
+	}
+}
+
+/**
+ * Inline mirror of QueueableTrait::popQueuedConfigPatch — reads from
+ * `config_patch_queue`, expects `patch` field as a decoded array.
+ *
+ * Mirrors inc/Core/Steps/QueueableTrait.php::popQueuedConfigPatch().
+ */
+function pop_config_patch_for_test( array $step_config, bool $queue_enabled ): array {
+	if ( ! $queue_enabled ) {
+		return array(
+			'patch'      => array(),
+			'from_queue' => false,
+			'added_at'   => null,
+		);
+	}
+
+	$queue = $step_config['config_patch_queue'] ?? array();
+	if ( empty( $queue ) ) {
+		return array(
+			'patch'      => array(),
+			'from_queue' => false,
+			'added_at'   => null,
+		);
+	}
+
+	$entry = array_shift( $queue );
+	$patch = isset( $entry['patch'] ) && is_array( $entry['patch'] ) ? $entry['patch'] : array();
+
+	return array(
+		'patch'      => $patch,
+		'from_queue' => true,
+		'added_at'   => $entry['added_at'] ?? null,
+	);
+}
+
+/**
+ * Inline mirror of AIStep's prompt_queue read path — reads `prompt`
+ * field as a string from `prompt_queue`.
+ *
+ * Mirrors inc/Core/Steps/AI/AIStep.php::execute() lines 140-173.
+ */
+function pop_prompt_for_test( array $step_config, bool $queue_enabled ): array {
+	$queue        = $step_config['prompt_queue'] ?? array();
+	$queued_head  = $queue[0]['prompt'] ?? '';
+
+	if ( $queue_enabled ) {
+		// drain mode: pop the head.
+		$entry = array_shift( $queue );
+		return array(
+			'value'      => $entry['prompt'] ?? '',
+			'from_queue' => null !== $entry,
+			'added_at'   => $entry['added_at'] ?? null,
+		);
+	}
+
+	// Static peek mode.
+	return array(
+		'value'      => $queued_head,
+		'from_queue' => false,
+		'added_at'   => null,
+	);
+}
+
+/**
+ * Inline mirror of inc/migrations/split-queue-payload.php::datamachine_migrate_split_queue_payload.
+ *
+ * Walks one flow_config and migrates fetch-step prompt_queue entries
+ * (with JSON-encoded prompt fields) into config_patch_queue entries
+ * (with decoded patch fields). AI step queues are left untouched.
+ *
+ * Returns [ migrated_flow_config, entries_migrated, entries_skipped ].
+ */
+function migrate_flow_config_for_test( array $flow_config ): array {
+	$entries_migrated = 0;
+	$entries_skipped  = 0;
+
+	foreach ( $flow_config as $step_id => &$step ) {
+		if ( ! is_array( $step ) ) {
+			continue;
+		}
+		if ( 'fetch' !== ( $step['step_type'] ?? '' ) ) {
+			continue;
+		}
+
+		$legacy_queue = $step['prompt_queue'] ?? null;
+		if ( ! is_array( $legacy_queue ) || empty( $legacy_queue ) ) {
+			if ( array_key_exists( 'prompt_queue', $step ) ) {
+				unset( $step['prompt_queue'] );
+			}
+			continue;
+		}
+
+		$existing_patch_queue = $step['config_patch_queue'] ?? array();
+		if ( ! is_array( $existing_patch_queue ) ) {
+			$existing_patch_queue = array();
+		}
+
+		$migrated_for_step = array();
+		foreach ( $legacy_queue as $entry ) {
+			if ( ! is_array( $entry ) || ! isset( $entry['prompt'] ) ) {
+				++$entries_skipped;
+				continue;
+			}
+			$decoded = json_decode( (string) $entry['prompt'], true );
+			if ( ! is_array( $decoded ) || empty( $decoded ) ) {
+				++$entries_skipped;
+				continue;
+			}
+			$migrated_for_step[] = array(
+				'patch'    => $decoded,
+				'added_at' => $entry['added_at'] ?? '2026-04-26T00:00:00+00:00',
+			);
+			++$entries_migrated;
+		}
+
+		$step['config_patch_queue'] = array_merge( $existing_patch_queue, $migrated_for_step );
+		unset( $step['prompt_queue'] );
+	}
+	unset( $step );
+
+	return array( $flow_config, $entries_migrated, $entries_skipped );
+}
+
+/**
+ * Inline mirror of QueueAbility::executeConfigPatchAdd validation.
+ * Returns whether the input is accepted, plus an error string when not.
+ *
+ * Mirrors inc/Abilities/Flow/QueueAbility.php::executeConfigPatchAdd.
+ */
+function validate_config_patch_add_for_test( $patch ): array {
+	if ( ! is_array( $patch ) ) {
+		return array( 'success' => false, 'error' => 'patch is required and must be an object' );
+	}
+	if ( empty( $patch ) ) {
+		return array( 'success' => false, 'error' => 'patch must be a non-empty object' );
+	}
+	return array( 'success' => true );
+}
+
+/**
+ * Inline mirror of CLI consumer-aware routing: given step_type and
+ * input shape, decide whether the operation is allowed and which
+ * slot it targets.
+ *
+ * Mirrors inc/Cli/Commands/Flows/QueueCommand.php::add().
+ */
+function cli_route_for_test( string $step_type, $patch_json, $prompt ): array {
+	if ( null !== $patch_json && null !== $prompt ) {
+		return array( 'allowed' => false, 'error' => 'cannot use both' );
+	}
+	if ( null === $patch_json && null === $prompt ) {
+		return array( 'allowed' => false, 'error' => 'provide one' );
+	}
+
+	if ( null !== $patch_json ) {
+		if ( 'fetch' !== $step_type ) {
+			return array( 'allowed' => false, 'error' => '--patch only valid for fetch' );
+		}
+		return array( 'allowed' => true, 'slot' => 'config_patch_queue' );
+	}
+
+	// Prompt path.
+	if ( 'fetch' === $step_type ) {
+		return array( 'allowed' => false, 'error' => 'fetch consumes patches, not prompts' );
+	}
+	return array( 'allowed' => true, 'slot' => 'prompt_queue' );
+}
+
+// --- Case 1: AIStep reads prompt_queue post-split (drain mode).
+echo "Case 1: AIStep prompt_queue drain mode\n";
+
+$ai_step_drain = array(
+	'step_type'     => 'ai',
+	'queue_enabled' => true,
+	'prompt_queue'  => array(
+		array( 'prompt' => 'First task', 'added_at' => '2026-04-26T01:00:00+00:00' ),
+		array( 'prompt' => 'Second task', 'added_at' => '2026-04-26T02:00:00+00:00' ),
+	),
+);
+
+$result = pop_prompt_for_test( $ai_step_drain, true );
+
+assert_split(
+	'AI drain pops the first prompt as a string',
+	'First task' === $result['value'],
+	'got: ' . var_export( $result['value'], true )
+);
+assert_split(
+	'AI drain reports from_queue=true',
+	true === $result['from_queue']
+);
+assert_split(
+	'AI drain returns added_at',
+	'2026-04-26T01:00:00+00:00' === $result['added_at']
+);
+
+// --- Case 2: AIStep reads prompt_queue post-split (peek mode, queue_enabled=false).
+echo "\nCase 2: AIStep prompt_queue peek mode\n";
+
+$ai_step_peek = array(
+	'step_type'     => 'ai',
+	'queue_enabled' => false,
+	'prompt_queue'  => array(
+		array( 'prompt' => 'Static peek', 'added_at' => '2026-04-26T01:00:00+00:00' ),
+	),
+);
+
+$result = pop_prompt_for_test( $ai_step_peek, false );
+
+assert_split(
+	'AI peek returns head value',
+	'Static peek' === $result['value']
+);
+assert_split(
+	'AI peek does NOT report from_queue=true',
+	false === $result['from_queue']
+);
+
+// --- Case 3: FetchStep reads config_patch_queue (post-split).
+echo "\nCase 3: FetchStep config_patch_queue read\n";
+
+$fetch_step = array(
+	'step_type'          => 'fetch',
+	'queue_enabled'      => true,
+	'config_patch_queue' => array(
+		array(
+			'patch'    => array( 'params' => array( 'after' => '2015-05-01', 'before' => '2015-06-01' ) ),
+			'added_at' => '2026-04-26T01:00:00+00:00',
+		),
+		array(
+			'patch'    => array( 'params' => array( 'after' => '2015-06-01' ) ),
+			'added_at' => '2026-04-26T02:00:00+00:00',
+		),
+	),
+);
+
+$result = pop_config_patch_for_test( $fetch_step, true );
+
+assert_split(
+	'FetchStep pops patch as a decoded array',
+	is_array( $result['patch'] ) && isset( $result['patch']['params'] )
+);
+assert_split(
+	'FetchStep patch contains expected keys',
+	'2015-05-01' === ( $result['patch']['params']['after'] ?? null )
+);
+assert_split(
+	'FetchStep patch is NOT a JSON-encoded string',
+	is_array( $result['patch'] ) && ! is_string( $result['patch'] ),
+	'patch type: ' . gettype( $result['patch'] )
+);
+assert_split(
+	'FetchStep reports from_queue=true',
+	true === $result['from_queue']
+);
+
+// --- Case 4: FetchStep with no queued patch returns empty.
+echo "\nCase 4: FetchStep with empty config_patch_queue\n";
+
+$fetch_empty = array(
+	'step_type'          => 'fetch',
+	'queue_enabled'      => true,
+	'config_patch_queue' => array(),
+);
+
+$result = pop_config_patch_for_test( $fetch_empty, true );
+
+assert_split(
+	'Empty queue returns empty patch',
+	array() === $result['patch']
+);
+assert_split(
+	'Empty queue reports from_queue=false',
+	false === $result['from_queue']
+);
+
+// --- Case 5: FetchStep with queue_enabled=false skips pop.
+echo "\nCase 5: FetchStep with queue_enabled=false\n";
+
+$result = pop_config_patch_for_test( $fetch_step, false );
+assert_split(
+	'queue_enabled=false returns empty patch',
+	array() === $result['patch'] && false === $result['from_queue']
+);
+
+// --- Case 6: Migration moves fetch-step JSON-encoded prompts to config_patch_queue.
+echo "\nCase 6: Migration — fetch step JSON prompts → config_patch_queue\n";
+
+$pre_migration = array(
+	'pstep_fetch_uuid_1' => array(
+		'step_type'    => 'fetch',
+		'prompt_queue' => array(
+			array(
+				'prompt'   => '{"params":{"after":"2015-05-01","before":"2015-06-01"}}',
+				'added_at' => '2026-04-26T01:00:00+00:00',
+			),
+			array(
+				'prompt'   => '{"params":{"after":"2015-06-01","before":"2015-07-01"}}',
+				'added_at' => '2026-04-26T02:00:00+00:00',
+			),
+		),
+	),
+	'pstep_ai_uuid_1'    => array(
+		'step_type'    => 'ai',
+		'prompt_queue' => array(
+			array( 'prompt' => 'AI task one', 'added_at' => '2026-04-26T03:00:00+00:00' ),
+		),
+	),
+);
+
+list( $migrated, $count_migrated, $count_skipped ) = migrate_flow_config_for_test( $pre_migration );
+
+assert_split(
+	'Migration creates config_patch_queue on fetch step',
+	isset( $migrated['pstep_fetch_uuid_1']['config_patch_queue'] )
+);
+assert_split(
+	'Migration removes prompt_queue from fetch step',
+	! isset( $migrated['pstep_fetch_uuid_1']['prompt_queue'] )
+);
+assert_split(
+	'Migration moves all 2 fetch entries',
+	2 === count( $migrated['pstep_fetch_uuid_1']['config_patch_queue'] ?? array() )
+);
+assert_split(
+	'Migrated patch is a decoded object',
+	isset( $migrated['pstep_fetch_uuid_1']['config_patch_queue'][0]['patch']['params']['after'] )
+		&& '2015-05-01' === $migrated['pstep_fetch_uuid_1']['config_patch_queue'][0]['patch']['params']['after']
+);
+assert_split(
+	'Migration preserves added_at on each entry',
+	'2026-04-26T01:00:00+00:00' === ( $migrated['pstep_fetch_uuid_1']['config_patch_queue'][0]['added_at'] ?? null )
+);
+assert_split(
+	'Migration leaves AI step prompt_queue untouched',
+	isset( $migrated['pstep_ai_uuid_1']['prompt_queue'] )
+		&& 1 === count( $migrated['pstep_ai_uuid_1']['prompt_queue'] )
+		&& 'AI task one' === $migrated['pstep_ai_uuid_1']['prompt_queue'][0]['prompt']
+);
+assert_split(
+	'Migration does NOT create config_patch_queue on AI step',
+	! isset( $migrated['pstep_ai_uuid_1']['config_patch_queue'] )
+);
+assert_split( 'Migration count: 2 entries migrated', 2 === $count_migrated );
+assert_split( 'Migration count: 0 entries skipped', 0 === $count_skipped );
+
+// --- Case 7: Migration skips misshaped fetch entries (non-JSON prompts).
+echo "\nCase 7: Migration — misshaped fetch entries are skipped, not crashed on\n";
+
+$misshaped = array(
+	'pstep_fetch_uuid_1' => array(
+		'step_type'    => 'fetch',
+		'prompt_queue' => array(
+			array( 'prompt' => 'this is not JSON', 'added_at' => '2026-04-26T01:00:00+00:00' ),
+			array( 'prompt' => '{"valid":true}', 'added_at' => '2026-04-26T02:00:00+00:00' ),
+			array( 'prompt' => '', 'added_at' => '2026-04-26T03:00:00+00:00' ),
+			array( 'prompt' => '"just a string"', 'added_at' => '2026-04-26T04:00:00+00:00' ),
+		),
+	),
+);
+
+list( $migrated, $count_migrated, $count_skipped ) = migrate_flow_config_for_test( $misshaped );
+
+assert_split(
+	'Misshaped: only the valid JSON object entry is migrated',
+	1 === count( $migrated['pstep_fetch_uuid_1']['config_patch_queue'] ?? array() )
+);
+assert_split(
+	'Misshaped: surviving entry decoded correctly',
+	true === ( $migrated['pstep_fetch_uuid_1']['config_patch_queue'][0]['patch']['valid'] ?? null )
+);
+assert_split(
+	'Misshaped: 3 entries skipped (non-JSON, empty, JSON-but-not-object)',
+	3 === $count_skipped
+);
+assert_split(
+	'Misshaped: 1 entry migrated',
+	1 === $count_migrated
+);
+assert_split(
+	'Misshaped: prompt_queue still removed from fetch step',
+	! isset( $migrated['pstep_fetch_uuid_1']['prompt_queue'] )
+);
+
+// --- Case 8: Migration is idempotent.
+echo "\nCase 8: Migration idempotency\n";
+
+$first_pass_input = array(
+	'pstep_fetch_uuid_1' => array(
+		'step_type'    => 'fetch',
+		'prompt_queue' => array(
+			array( 'prompt' => '{"x":1}', 'added_at' => '2026-04-26T01:00:00+00:00' ),
+		),
+	),
+);
+
+list( $after_first, , ) = migrate_flow_config_for_test( $first_pass_input );
+list( $after_second, $second_count, $second_skipped ) = migrate_flow_config_for_test( $after_first );
+
+assert_split(
+	'Idempotency: second pass migrates 0 entries',
+	0 === $second_count
+);
+assert_split(
+	'Idempotency: second pass skips 0 entries',
+	0 === $second_skipped
+);
+assert_split(
+	'Idempotency: shape unchanged after second pass',
+	$after_first === $after_second,
+	'first: ' . wp_json_encode_test( $after_first ) . ' second: ' . wp_json_encode_test( $after_second )
+);
+
+function wp_json_encode_test( $v ) {
+	return json_encode( $v );
+}
+
+// --- Case 9: Validation — config-patch-add rejects non-object input.
+echo "\nCase 9: config-patch-add validation\n";
+
+$result = validate_config_patch_add_for_test( 'a plain string' );
+assert_split(
+	'Strings rejected on config-patch-add',
+	false === $result['success']
+		&& false !== strpos( $result['error'], 'object' )
+);
+
+$result = validate_config_patch_add_for_test( null );
+assert_split(
+	'Null rejected on config-patch-add',
+	false === $result['success']
+);
+
+$result = validate_config_patch_add_for_test( array() );
+assert_split(
+	'Empty arrays rejected on config-patch-add',
+	false === $result['success']
+		&& false !== strpos( $result['error'], 'non-empty' )
+);
+
+$result = validate_config_patch_add_for_test( array( 'params' => array( 'x' => 1 ) ) );
+assert_split(
+	'Valid object accepted on config-patch-add',
+	true === $result['success']
+);
+
+// --- Case 10: CLI routing — fetch step blocks string prompt.
+echo "\nCase 10: CLI consumer-aware routing\n";
+
+$result = cli_route_for_test( 'fetch', null, 'a prompt' );
+assert_split(
+	'fetch + positional prompt → blocked',
+	false === $result['allowed']
+		&& false !== strpos( $result['error'], 'fetch' )
+);
+
+$result = cli_route_for_test( 'fetch', '{"x":1}', null );
+assert_split(
+	'fetch + --patch → routes to config_patch_queue',
+	true === $result['allowed']
+		&& 'config_patch_queue' === ( $result['slot'] ?? null )
+);
+
+$result = cli_route_for_test( 'ai', '{"x":1}', null );
+assert_split(
+	'ai + --patch → blocked',
+	false === $result['allowed']
+		&& false !== strpos( $result['error'], 'fetch' )
+);
+
+$result = cli_route_for_test( 'ai', null, 'a prompt' );
+assert_split(
+	'ai + positional prompt → routes to prompt_queue',
+	true === $result['allowed']
+		&& 'prompt_queue' === ( $result['slot'] ?? null )
+);
+
+$result = cli_route_for_test( 'ai', '{"x":1}', 'a prompt' );
+assert_split(
+	'both flags supplied → blocked with helpful error',
+	false === $result['allowed']
+		&& false !== strpos( $result['error'], 'cannot use both' )
+);
+
+$result = cli_route_for_test( 'ai', null, null );
+assert_split(
+	'neither flag supplied → blocked',
+	false === $result['allowed']
+);
+
+// --- Case 11: Storage shape contract — slot keys are distinct.
+echo "\nCase 11: Storage shape contract\n";
+
+$config = array(
+	'step_type'          => 'fetch',
+	'prompt_queue'       => array(),
+	'config_patch_queue' => array(
+		array( 'patch' => array( 'a' => 1 ), 'added_at' => '2026-04-26T01:00:00+00:00' ),
+	),
+);
+
+assert_split(
+	'prompt_queue and config_patch_queue are independent storage slots',
+	array_key_exists( 'prompt_queue', $config )
+		&& array_key_exists( 'config_patch_queue', $config )
+		&& count( $config['prompt_queue'] ) !== count( $config['config_patch_queue'] )
+);
+
+assert_split(
+	'config_patch_queue entries use `patch` field, not `prompt`',
+	isset( $config['config_patch_queue'][0]['patch'] )
+		&& ! isset( $config['config_patch_queue'][0]['prompt'] )
+);
+
+// --- Final report.
+echo "\n";
+echo "===========================================\n";
+echo sprintf( "Smoke test: %d / %d passed\n", $total - $failed, $total );
+echo "===========================================\n";
+
+if ( $failed > 0 ) {
+	exit( 1 );
+}
+
+exit( 0 );


### PR DESCRIPTION
## Summary

Splits the `prompt_queue` payload polymorphism into two storage slots, one per consumer. Path B from #1292.

Pre-split, both `AIStep` and `FetchStep` consumed from the same `prompt_queue` slot. AI expected plain strings; Fetch expected JSON-encoded objects in the same `prompt` field. Schema lied at write time, validation was implicit via the consumer step type, and tooling could not tell the two payload shapes apart. Each new consumer would have stretched the same field further.

After this PR every queue slot holds one payload shape, validated by JSON Schema directly:

| Slot | Consumer | Payload field | Shape |
|---|---|---|---|
| `prompt_queue` | AI step | `prompt` | string |
| `config_patch_queue` | Fetch step | `patch` | object |

`patch` is stored as a decoded array verbatim — no JSON-encoded-string indirection. The inner `json_decode` in `popQueuedConfigPatch` is gone.

## Changes

### Storage + abilities
- `QueueAbility` gains six parallel abilities for the new slot: `config-patch-add | -list | -clear | -remove | -update | -move`. The seven existing prompt-queue executors share private slot-parameterised helpers (`listQueueSlot`, `clearQueueSlot`, `removeQueueSlot`, `updateQueueSlot`, `moveQueueSlot`, `loadFlowAndStepConfig`) — no copy-paste of the 300+ LOC of executor scaffolding.
- New static helper `QueueAbility::popConfigPatchFromQueue()` mirrors `popFromQueue()` for the new slot. Both delegate to a private `popFromQueueSlot($flow_id, $step_id, $slot, $db)` helper.
- `datamachine/config-patch-add` schema declares `patch: { type: object }` and validates non-empty at execute time.
- `FlowHelpers::syncStepsToFlow` initialises `config_patch_queue` on fetch steps, `prompt_queue` on others — each step type only carries the slot its consumer reads.

### QueueableTrait
- `popQueuedConfigPatch()` now reads `config_patch_queue` and returns the stored object verbatim. The "queued item is not a JSON object" warning path is gone (write-time validation prevents it).
- `popFromQueueIfEmpty()` continues reading `prompt_queue` (unchanged behaviour for AI step).
- Internal `popOnceFromFlowQueue` split into `popOnceFromPromptQueue` and `popOnceFromConfigPatchQueue`.

### Retry / recover
- `RetryJobAbility` and `RecoverStuckJobsAbility` are slot-aware: the `queued_prompt_backup` engine_data field now carries a `slot` value (`prompt_queue` or `config_patch_queue`) so AI backups push strings back into the prompt queue and fetch backups push patches back into the config-patch queue. Backups created before this PR (no `slot` field) are treated as `prompt_queue` for backward compat.

### CLI
- `flow queue add` is consumer-aware. Inspects target step's `step_type`, routes:
  - AI step → positional prompt → `prompt_queue`
  - Fetch step → `--patch=<json>` → `config_patch_queue`
  - Mixed (string against fetch, `--patch` against AI, both, neither) errors loudly.
- `flow queue list` renders both queues when populated. Section headers ("AI prompts" / "Config patches") + pretty-printed JSON tree per patch entry instead of 60-char string truncation.
- `flow queue clear/remove/update/move` route by step type to the correct slot.
- `flow get` table now surfaces `config_patch_queue=N item(s), queue_enabled=...` on fetch steps, mirroring how `prompt_queue` is surfaced on AI steps. `normalizeAiStepPromptSlots` extended to expose `config_patch_queue` + `queue_enabled` on fetch steps even when unset, so the field is discoverable.
- `--patch=<json>` declared in `FlowsCommand`'s WP-CLI annotation so the dispatcher accepts it.

### Migration
- `inc/migrations/split-queue-payload.php` mirrors the shape of `inc/migrations/ai-enabled-tools.php`. Idempotent, gated on `datamachine_queue_payload_split_migrated`. For each flow_config and each fetch step:
  - JSON-decode every `prompt_queue[*].prompt` field. Decode-to-object → push to `config_patch_queue[*].patch` with `added_at` preserved.
  - Decode failure → log at `warning` with `flow_id`, `step_id`, `index`, 80-char preview. Skip the entry. (These would have silently no-op'd at runtime under the pre-split code.)
  - After processing, unset `prompt_queue` on the fetch step. Fetch steps no longer have a `prompt_queue` at all under the post-split shape.
- AI step prompt queues are left untouched. Other step types are also untouched.
- No runtime fallback shim — per the no-shim rule.

## Tests

`tests/queue-payload-split-smoke.php` — 41 assertions across 11 cases following the byte-mirror harness convention from `tests/flow-update-set-user-message-smoke.php`. Inlines the relevant slices of QueueableTrait, the migration, the validation, and the CLI routing so divergence between the smoke and production fails the test.

Cases:
1. AIStep prompt_queue drain mode
2. AIStep prompt_queue peek mode (queue_enabled=false)
3. FetchStep config_patch_queue read returns decoded array
4. FetchStep with empty queue
5. FetchStep with queue_enabled=false
6. Migration: fetch JSON-encoded prompts → config_patch_queue with decoded objects, AI prompt_queue untouched
7. Migration: 3 misshaped fetch entries skipped, 1 valid migrated, no crash
8. Migration idempotency — second pass is a true no-op
9. config-patch-add validation rejects strings, null, empty arrays; accepts non-empty objects
10. CLI consumer-aware routing — six positive / negative cases
11. Storage shape contract — slots are independent, patch field is `patch` not `prompt`

All 19 pre-existing pure-PHP smokes still pass.

## Migration

Live-verified on `intelligence-chubes4`:

1. **Seeded** flow 2's fetch step with 3 legacy entries (2 valid JSON-encoded patches, 1 misshaped non-JSON string).
2. **Ran migration** via `datamachine_migrate_split_queue_payload()` directly. Result: `prompt_queue` removed from fetch step, `config_patch_queue` populated with 2 decoded objects, 1 misshaped entry logged at warning + skipped, migration option persisted as `'1'`.
3. **Idempotency**: second migration pass added 0 entries, skipped 0 entries, shape unchanged.
4. **CLI routing**:
   - `flow queue add 2 --patch='{...}' --step=<fetch>` → patch added to `config_patch_queue`.
   - `flow queue add 2 "string" --step=<fetch>` → blocked with "Fetch steps consume config patches, not string prompts. Use `--patch='{...}'` instead."
   - `flow queue add 2 --patch='{...}' --step=<ai>` → blocked with "`--patch` is only valid for fetch steps; this step is `ai`."
5. **End-to-end pop**: queued one date-window patch onto flow 2, ran `flow run 2` + AS tick. Logs show `Fetch step merged queued config patch` with `patch_keys: ["params"]`, `merged_keys: ["server","provider","tool","params","max_items"]` — patch was popped from the new slot, merged into the handler config, fetch ran with the merged params, queue drained post-tick.

## Order of operations

This unblocks #1291 (collapse `user_message` into the now-AI-only `prompt_queue` with a `queue_mode` enum). #1293 (handler_slugs scalar) is orthogonal and independent.

Closes #1292

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the slot-split refactor of `QueueAbility` (six parallel abilities sharing private slot-parameterised executors), the trait split, the slot-aware retry/recover paths, the migration, the consumer-aware CLI, and the pure-PHP smoke. Chris reviewed, ran the migration + queueable flow live on `intelligence-chubes4` to confirm end-to-end behaviour, and signed off on the no-shim approach.
