### PR TITLE
feat(queue): collapse user_message into prompt_queue with queue_mode enum

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -624,6 +624,11 @@ function datamachine_activate_for_site() {
 	// Split prompt_queue / config_patch_queue payload polymorphism (#1292, idempotent).
 	datamachine_migrate_split_queue_payload();
 
+	// Collapse user_message into prompt_queue and replace queue_enabled with
+	// queue_mode enum (drain | loop | static) on every queueable step (#1291,
+	// idempotent).
+	datamachine_migrate_user_message_queue_mode();
+
 	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
 	datamachine_drop_redundant_post_pipeline_meta();
 

--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -81,7 +81,12 @@ trait FlowHelpers {
 				'execution_order'  => $step['execution_order'] ?? 0,
 				'disabled_tools'   => $disabled_tools,
 				'handler'          => null,
-				'queue_enabled'    => false,
+				// queue_mode is the access pattern enum that drives both
+				// AI (prompt_queue) and Fetch (config_patch_queue)
+				// consumption (#1291). Default "static" preserves
+				// "first-entry-wins-every-tick" semantics for any
+				// freshly-scaffolded step.
+				'queue_mode'       => 'static',
 			);
 
 			// Fetch consumes from config_patch_queue (#1292); other

--- a/inc/Abilities/Flow/QueueAbility.php
+++ b/inc/Abilities/Flow/QueueAbility.php
@@ -7,22 +7,24 @@
  *
  *   - `prompt_queue`        — array<{prompt:string, added_at:string}>
  *                             Consumed by AI step (`AIStep::execute()`)
- *                             via {@see QueueableTrait::popFromQueueIfEmpty}.
+ *                             via {@see QueueableTrait::consumeFromPromptQueue}.
  *                             Each entry is a plain user-message string.
  *
  *   - `config_patch_queue`  — array<{patch:array, added_at:string}>
  *                             Consumed by Fetch step
  *                             (`FetchStep::executeStep()`) via
- *                             {@see QueueableTrait::popQueuedConfigPatch}.
+ *                             {@see QueueableTrait::consumeFromConfigPatchQueue}.
  *                             Each entry is a decoded object that gets
  *                             deep-merged into the handler's static
  *                             config before the fetch runs.
  *
- * Splitting these slots is #1292 — pre-split, both consumers shared a
- * single `prompt_queue` and ran string-vs-JSON detective work at read
- * time, with no validation at write time. Now each slot has one
- * payload shape, validated by JSON Schema directly, and writes that
- * target the wrong slot for a step type fail loudly.
+ * Both consumers share a single `queue_mode` enum on the step config
+ * — `drain` | `loop` | `static` — that picks the access pattern. See
+ * {@see QueueAbility::registerQueueMode()} for the contract.
+ *
+ * Splitting the slots was #1292; collapsing the legacy
+ * `user_message` slot into `prompt_queue` and replacing
+ * `queue_enabled` with the mode enum is #1291.
  *
  * @package DataMachine\Abilities\Flow
  * @since 0.16.0
@@ -81,7 +83,9 @@ class QueueAbility {
 			$this->registerQueueRemove();
 			$this->registerQueueUpdate();
 			$this->registerQueueMove();
-			$this->registerQueueSettings();
+
+			// Shared mode toggle for both prompt_queue and config_patch_queue.
+			$this->registerQueueMode();
 
 			// Config patch queue (Fetch consumer).
 			$this->registerConfigPatchAdd();
@@ -184,13 +188,13 @@ class QueueAbility {
 				'output_schema'       => array(
 					'type'       => 'object',
 					'properties' => array(
-						'success'       => array( 'type' => 'boolean' ),
-						'flow_id'       => array( 'type' => 'integer' ),
-						'flow_step_id'  => array( 'type' => 'string' ),
-						'queue'         => array( 'type' => 'array' ),
-						'count'         => array( 'type' => 'integer' ),
-						'queue_enabled' => array( 'type' => 'boolean' ),
-						'error'         => array( 'type' => 'string' ),
+						'success'      => array( 'type' => 'boolean' ),
+						'flow_id'      => array( 'type' => 'integer' ),
+						'flow_step_id' => array( 'type' => 'string' ),
+						'queue'        => array( 'type' => 'array' ),
+						'count'        => array( 'type' => 'integer' ),
+						'queue_mode'   => array( 'type' => 'string' ),
+						'error'        => array( 'type' => 'string' ),
 					),
 				),
 				'execute_callback'    => array( $this, 'executeQueueList' ),
@@ -392,45 +396,61 @@ class QueueAbility {
 	}
 
 	/**
-	 * Register queue settings ability.
+	 * Register queue-mode ability.
+	 *
+	 * Replaces the pre-#1291 `queue-settings` ability (which wrote a
+	 * `queue_enabled` boolean). The new enum names the access pattern
+	 * explicitly:
+	 *
+	 *   - drain  — pop the head per tick, discard. Empty queue → skip
+	 *              with COMPLETED_NO_ITEMS.
+	 *   - loop   — pop the head per tick, append to tail. The queue
+	 *              rotates indefinitely.
+	 *   - static — peek the head every tick without mutating the queue.
+	 *              Position 0 is active; positions 1..N stay staged.
+	 *
+	 * The mode applies to whichever slot the step type consumes (AI
+	 * steps consume `prompt_queue`, fetch steps consume
+	 * `config_patch_queue`) — there is no per-slot mode.
 	 */
-	private function registerQueueSettings(): void {
+	private function registerQueueMode(): void {
 		wp_register_ability(
-			'datamachine/queue-settings',
+			'datamachine/queue-mode',
 			array(
-				'label'               => __( 'Update Queue Settings', 'data-machine' ),
-				'description'         => __( 'Update queue settings for a flow step.', 'data-machine' ),
+				'label'               => __( 'Set Queue Mode', 'data-machine' ),
+				'description'         => __( 'Set the access mode (drain | loop | static) for a flow step\'s queue.', 'data-machine' ),
 				'category'            => 'datamachine-flow',
 				'input_schema'        => array(
 					'type'       => 'object',
-					'required'   => array( 'flow_id', 'flow_step_id', 'queue_enabled' ),
+					'required'   => array( 'flow_id', 'flow_step_id', 'mode' ),
 					'properties' => array(
-						'flow_id'       => array(
+						'flow_id'      => array(
 							'type'        => 'integer',
 							'description' => __( 'Flow ID', 'data-machine' ),
 						),
-						'flow_step_id'  => array(
+						'flow_step_id' => array(
 							'type'        => 'string',
 							'description' => __( 'Flow step ID', 'data-machine' ),
 						),
-						'queue_enabled' => array(
-							'type'        => 'boolean',
-							'description' => __( 'Whether queue pop is enabled for this step', 'data-machine' ),
+						'mode'         => array(
+							'type'        => 'string',
+							'enum'        => array( 'drain', 'loop', 'static' ),
+							'description' => __( 'Queue access mode: drain (pop+discard), loop (pop+append-to-tail), static (peek-only).', 'data-machine' ),
 						),
 					),
 				),
 				'output_schema'       => array(
 					'type'       => 'object',
 					'properties' => array(
-						'success'       => array( 'type' => 'boolean' ),
-						'flow_id'       => array( 'type' => 'integer' ),
-						'flow_step_id'  => array( 'type' => 'string' ),
-						'queue_enabled' => array( 'type' => 'boolean' ),
-						'message'       => array( 'type' => 'string' ),
-						'error'         => array( 'type' => 'string' ),
+						'success'      => array( 'type' => 'boolean' ),
+						'flow_id'      => array( 'type' => 'integer' ),
+						'flow_step_id' => array( 'type' => 'string' ),
+						'queue_mode'   => array( 'type' => 'string' ),
+						'message'      => array( 'type' => 'string' ),
+						'error'        => array( 'type' => 'string' ),
 					),
 				),
-				'execute_callback'    => array( $this, 'executeQueueSettings' ),
+				'execute_callback'    => array( $this, 'executeQueueMode' ),
 				'permission_callback' => array( $this, 'checkPermission' ),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
@@ -510,13 +530,13 @@ class QueueAbility {
 				'output_schema'       => array(
 					'type'       => 'object',
 					'properties' => array(
-						'success'       => array( 'type' => 'boolean' ),
-						'flow_id'       => array( 'type' => 'integer' ),
-						'flow_step_id'  => array( 'type' => 'string' ),
-						'queue'         => array( 'type' => 'array' ),
-						'count'         => array( 'type' => 'integer' ),
-						'queue_enabled' => array( 'type' => 'boolean' ),
-						'error'         => array( 'type' => 'string' ),
+						'success'      => array( 'type' => 'boolean' ),
+						'flow_id'      => array( 'type' => 'integer' ),
+						'flow_step_id' => array( 'type' => 'string' ),
+						'queue'        => array( 'type' => 'array' ),
+						'count'        => array( 'type' => 'integer' ),
+						'queue_mode'   => array( 'type' => 'string' ),
+						'error'        => array( 'type' => 'string' ),
 					),
 				),
 				'execute_callback'    => array( $this, 'executeConfigPatchList' ),
@@ -1015,32 +1035,37 @@ class QueueAbility {
 	}
 
 	/**
-	 * Update queue settings for a flow step.
+	 * Set the queue access mode for a flow step.
 	 *
-	 * @param array $input Input with flow_id, flow_step_id, and queue_enabled.
+	 * Replaces the pre-#1291 `executeQueueSettings()` (which wrote a
+	 * `queue_enabled` boolean). The mode is a single enum on the step
+	 * config; whichever slot the step consumes (`prompt_queue` or
+	 * `config_patch_queue`) reads it identically.
+	 *
+	 * @param array $input Input with flow_id, flow_step_id, and mode.
 	 * @return array Result.
 	 */
-	public function executeQueueSettings( array $input ): array {
-		$flow_id       = $input['flow_id'] ?? null;
-		$flow_step_id  = $input['flow_step_id'] ?? null;
-		$queue_enabled = $input['queue_enabled'] ?? null;
+	public function executeQueueMode( array $input ): array {
+		$flow_id      = $input['flow_id'] ?? null;
+		$flow_step_id = $input['flow_step_id'] ?? null;
+		$mode         = $input['mode'] ?? null;
 
 		$validation = $this->validateFlowStepIds( $flow_id, $flow_step_id );
 		if ( ! $validation['success'] ) {
 			return $validation;
 		}
 
-		if ( ! is_bool( $queue_enabled ) ) {
+		if ( ! is_string( $mode ) || ! in_array( $mode, array( 'drain', 'loop', 'static' ), true ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'queue_enabled is required and must be a boolean',
+				'error'   => 'mode must be one of: drain, loop, static',
 			);
 		}
 
 		$flow_id      = $validation['flow_id'];
 		$flow_step_id = $validation['flow_step_id'];
 
-		// queue_enabled is a step-level toggle that applies to whichever
+		// queue_mode is a step-level toggle that applies to whichever
 		// queue slot the step type consumes — no slot routing needed
 		// here. Use SLOT_PROMPT_QUEUE for the existence check; the
 		// step_config defaulting just ensures the row exists.
@@ -1049,8 +1074,8 @@ class QueueAbility {
 			return $flow_lookup;
 		}
 
-		$flow_config                                   = $flow_lookup['flow_config'];
-		$flow_config[ $flow_step_id ]['queue_enabled'] = $queue_enabled;
+		$flow_config                                = $flow_lookup['flow_config'];
+		$flow_config[ $flow_step_id ]['queue_mode'] = $mode;
 
 		$success = $this->db_flows->update_flow(
 			$flow_id,
@@ -1060,16 +1085,16 @@ class QueueAbility {
 		if ( ! $success ) {
 			return array(
 				'success' => false,
-				'error'   => 'Failed to update queue settings',
+				'error'   => 'Failed to update queue mode',
 			);
 		}
 
 		return array(
-			'success'       => true,
-			'flow_id'       => $flow_id,
-			'flow_step_id'  => $flow_step_id,
-			'queue_enabled' => $queue_enabled,
-			'message'       => 'Queue settings updated successfully',
+			'success'      => true,
+			'flow_id'      => $flow_id,
+			'flow_step_id' => $flow_step_id,
+			'queue_mode'   => $mode,
+			'message'      => sprintf( 'Queue mode set to %s.', $mode ),
 		);
 	}
 
@@ -1103,12 +1128,12 @@ class QueueAbility {
 		$queue       = $step_config[ $slot ];
 
 		return array(
-			'success'       => true,
-			'flow_id'       => $flow_id,
-			'flow_step_id'  => $flow_step_id,
-			'queue'         => $queue,
-			'count'         => count( $queue ),
-			'queue_enabled' => $step_config['queue_enabled'],
+			'success'      => true,
+			'flow_id'      => $flow_id,
+			'flow_step_id' => $flow_step_id,
+			'queue'        => $queue,
+			'count'        => count( $queue ),
+			'queue_mode'   => $step_config['queue_mode'],
 		);
 	}
 
@@ -1498,10 +1523,11 @@ class QueueAbility {
 	}
 
 	/**
-	 * Pop the first prompt from the queue (for engine use).
+	 * Pop the first prompt from the queue (drain semantics).
 	 *
-	 * Used by AIStep's queueable trait. For the fetch-step config-patch
-	 * queue, see {@see popConfigPatchFromQueue()}.
+	 * Used by AgentPingTask when its `queue_mode` is `drain`. AIStep's
+	 * mode-aware reader lives in QueueableTrait. For the fetch-step
+	 * config-patch queue, see {@see popConfigPatchFromQueue()}.
 	 *
 	 * @param int      $flow_id      Flow ID.
 	 * @param string   $flow_step_id Flow step ID.
@@ -1510,6 +1536,24 @@ class QueueAbility {
 	 */
 	public static function popFromQueue( int $flow_id, string $flow_step_id, ?DB_Flows $db_flows = null ): ?array {
 		return self::popFromQueueSlot( $flow_id, $flow_step_id, self::SLOT_PROMPT_QUEUE, $db_flows );
+	}
+
+	/**
+	 * Pop the first prompt from the queue and rotate it to the tail
+	 * (loop semantics).
+	 *
+	 * Sibling of {@see popFromQueue()} for the `loop` queue mode. The
+	 * returned entry is the one the caller should consume; the tail of
+	 * the queue gets the same entry appended so it cycles back around
+	 * after the rest of the queue drains.
+	 *
+	 * @param int      $flow_id      Flow ID.
+	 * @param string   $flow_step_id Flow step ID.
+	 * @param DB_Flows $db_flows     Database instance.
+	 * @return array|null The rotated queue item or null if empty.
+	 */
+	public static function loopFromQueue( int $flow_id, string $flow_step_id, ?DB_Flows $db_flows = null ): ?array {
+		return self::popFromQueueSlot( $flow_id, $flow_step_id, self::SLOT_PROMPT_QUEUE, $db_flows, true );
 	}
 
 	/**
@@ -1535,9 +1579,12 @@ class QueueAbility {
 	 * @param string   $flow_step_id Flow step ID.
 	 * @param string   $slot         Slot name.
 	 * @param DB_Flows $db_flows     Database instance.
+	 * @param bool     $loop         When true, append the popped entry to
+	 *                               the tail of the queue (loop semantics).
+	 *                               When false (default), discard (drain).
 	 * @return array|null The popped item or null if empty.
 	 */
-	private static function popFromQueueSlot( int $flow_id, string $flow_step_id, string $slot, ?DB_Flows $db_flows = null ): ?array {
+	private static function popFromQueueSlot( int $flow_id, string $flow_step_id, string $slot, ?DB_Flows $db_flows = null, bool $loop = false ): ?array {
 		if ( null === $db_flows ) {
 			$db_flows = new DB_Flows();
 		}
@@ -1561,6 +1608,10 @@ class QueueAbility {
 
 		$popped_item = array_shift( $queue );
 
+		if ( $loop ) {
+			$queue[] = $popped_item;
+		}
+
 		$flow_config[ $flow_step_id ][ $slot ] = $queue;
 
 		$db_flows->update_flow(
@@ -1571,7 +1622,7 @@ class QueueAbility {
 		do_action(
 			'datamachine_log',
 			'info',
-			'Item popped from queue',
+			$loop ? 'Item rotated in queue (loop)' : 'Item popped from queue (drain)',
 			array(
 				'flow_id'         => $flow_id,
 				'slot'            => $slot,
@@ -1614,10 +1665,11 @@ class QueueAbility {
 	/**
 	 * Load flow + normalize step config for queue operations.
 	 *
-	 * Defaults the named slot to an empty array and `queue_enabled` to
-	 * false when missing — same shape as the pre-split helper, but
-	 * targets a specific queue slot rather than the implicit
-	 * `prompt_queue`.
+	 * Defaults the named slot to an empty array and `queue_mode` to
+	 * "static" when missing — matches the migration's default for
+	 * absent toggles and preserves "first-entry-wins-every-tick"
+	 * behaviour for any pre-existing queue rows that haven't been
+	 * touched since the #1291 collapse.
 	 *
 	 * @param int    $flow_id      Flow ID (already validated).
 	 * @param string $flow_step_id Flow step ID (already validated).
@@ -1659,8 +1711,10 @@ class QueueAbility {
 		if ( ! isset( $step_config[ $slot ] ) || ! is_array( $step_config[ $slot ] ) ) {
 			$step_config[ $slot ] = array();
 		}
-		if ( ! isset( $step_config['queue_enabled'] ) || ! is_bool( $step_config['queue_enabled'] ) ) {
-			$step_config['queue_enabled'] = false;
+		if ( ! isset( $step_config['queue_mode'] )
+			|| ! in_array( $step_config['queue_mode'], array( 'drain', 'loop', 'static' ), true )
+		) {
+			$step_config['queue_mode'] = 'static';
 		}
 		$flow_config[ $flow_step_id ] = $step_config;
 

--- a/inc/Abilities/FlowAbilities.php
+++ b/inc/Abilities/FlowAbilities.php
@@ -240,6 +240,23 @@ class FlowAbilities {
 	}
 
 	/**
+	 * Execute queue-mode ability (#1291).
+	 *
+	 * Replaces the pre-#1291 `executeQueueSettings()` (which wrote a
+	 * `queue_enabled` boolean). Sets queue access mode to one of
+	 * drain | loop | static.
+	 *
+	 * @param array $input Input parameters (flow_id, flow_step_id, mode).
+	 * @return array Result with queue_mode set.
+	 */
+	public function executeQueueMode( array $input ): array {
+		if ( ! isset( $this->queue ) ) {
+			$this->queue = new QueueAbility();
+		}
+		return $this->queue->executeQueueMode( $input );
+	}
+
+	/**
 	 * Execute config-patch-add ability (Fetch consumer).
 	 *
 	 * @param array $input Input parameters (flow_id, flow_step_id, patch).

--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -499,7 +499,24 @@ trait FlowStepHelpers {
 	}
 
 	/**
-	 * Update user message for an AI flow step.
+	 * Update the per-flow user message for an AI step.
+	 *
+	 * Post-#1291 the dedicated `user_message` slot is gone. This helper
+	 * is the public-facing shim that lets existing callers (CLI's
+	 * `--set-user-message`, ConfigureFlowSteps, CreateFlow chat tools,
+	 * the React UI's save path) keep their input contract while we
+	 * route the write through the unified `prompt_queue` storage:
+	 *
+	 *   - Replace the entire prompt_queue with a single `{prompt, added_at}`
+	 *     entry containing the new user message.
+	 *   - Set queue_mode to "static" so the entry is peeked (not popped)
+	 *     every tick — this is the direct equivalent of the legacy
+	 *     "single user_message that runs every tick" semantic.
+	 *
+	 * Empty input (`""`) clears the queue entirely. The seeded entry's
+	 * shape mirrors `QueueAbility::executeQueueAdd`'s output so any
+	 * subsequent `flow queue list` rendering looks identical to a
+	 * manually-added prompt.
 	 *
 	 * @param string $flow_step_id Flow step ID (format: pipeline_step_id_flow_id).
 	 * @param string $user_message User message content.
@@ -542,7 +559,21 @@ trait FlowStepHelpers {
 			return false;
 		}
 
-		$flow_config[ $flow_step_id ]['user_message'] = wp_unslash( sanitize_textarea_field( $user_message ) );
+		$sanitized = wp_unslash( sanitize_textarea_field( $user_message ) );
+
+		// Empty input clears the queue entirely (matches the pre-#1291
+		// behaviour of unsetting user_message via empty string).
+		if ( '' === trim( $sanitized ) ) {
+			$flow_config[ $flow_step_id ]['prompt_queue'] = array();
+		} else {
+			$flow_config[ $flow_step_id ]['prompt_queue'] = array(
+				array(
+					'prompt'   => $sanitized,
+					'added_at' => gmdate( 'c' ),
+				),
+			);
+		}
+		$flow_config[ $flow_step_id ]['queue_mode'] = 'static';
 
 		$success = $this->db_flows->update_flow(
 			$flow_id,

--- a/inc/Api/Chat/Tools/ManageQueue.php
+++ b/inc/Api/Chat/Tools/ManageQueue.php
@@ -20,7 +20,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class ManageQueue extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'manage_queue', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/queue-add', 'datamachine/queue-list', 'datamachine/queue-clear', 'datamachine/queue-remove', 'datamachine/queue-update', 'datamachine/queue-move', 'datamachine/queue-settings' ) ) );
+		$this->registerTool( 'manage_queue', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/queue-add', 'datamachine/queue-list', 'datamachine/queue-clear', 'datamachine/queue-remove', 'datamachine/queue-update', 'datamachine/queue-move', 'datamachine/queue-mode' ) ) );
 	}
 
 	/**
@@ -35,45 +35,46 @@ class ManageQueue extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => $this->buildDescription(),
 			'parameters'  => array(
-				'action'        => array(
+				'action'       => array(
 					'type'        => 'string',
 					'required'    => true,
-					'description' => 'Action to perform: "add", "list", "clear", "remove", "update", "move", or "settings"',
+					'description' => 'Action to perform: "add", "list", "clear", "remove", "update", "move", or "mode"',
 				),
-				'flow_id'       => array(
+				'flow_id'      => array(
 					'type'        => 'integer',
 					'required'    => true,
 					'description' => 'Flow ID',
 				),
-				'flow_step_id'  => array(
+				'flow_step_id' => array(
 					'type'        => 'string',
 					'required'    => true,
 					'description' => 'Flow step ID',
 				),
-				'prompt'        => array(
+				'prompt'       => array(
 					'type'        => 'string',
 					'required'    => false,
 					'description' => 'Prompt text (for add and update actions)',
 				),
-				'index'         => array(
+				'index'        => array(
 					'type'        => 'integer',
 					'required'    => false,
 					'description' => 'Queue index, 0-based (for remove and update actions)',
 				),
-				'from_index'    => array(
+				'from_index'   => array(
 					'type'        => 'integer',
 					'required'    => false,
 					'description' => 'Source index for move action (0-based)',
 				),
-				'to_index'      => array(
+				'to_index'     => array(
 					'type'        => 'integer',
 					'required'    => false,
 					'description' => 'Destination index for move action (0-based)',
 				),
-				'queue_enabled' => array(
-					'type'        => 'boolean',
+				'mode'         => array(
+					'type'        => 'string',
 					'required'    => false,
-					'description' => 'Whether queue pop is enabled (for settings action)',
+					'enum'        => array( 'drain', 'loop', 'static' ),
+					'description' => 'Queue access mode for the "mode" action: drain (pop+discard), loop (pop+append-to-tail), static (peek-only).',
 				),
 			),
 		);
@@ -95,7 +96,7 @@ ACTIONS:
 - remove: Remove a prompt by index (requires index)
 - update: Update a prompt at a specific index (requires index and prompt)
 - move: Move a prompt from one position to another (requires from_index and to_index)
-- settings: Update queue settings (requires queue_enabled)
+- mode: Set the queue access mode (requires mode: drain | loop | static)
 
 All actions require flow_id and flow_step_id.';
 	}
@@ -112,19 +113,19 @@ All actions require flow_id and flow_step_id.';
 		$action = $parameters['action'] ?? '';
 
 		$ability_map = array(
-			'add'      => 'datamachine/queue-add',
-			'list'     => 'datamachine/queue-list',
-			'clear'    => 'datamachine/queue-clear',
-			'remove'   => 'datamachine/queue-remove',
-			'update'   => 'datamachine/queue-update',
-			'move'     => 'datamachine/queue-move',
-			'settings' => 'datamachine/queue-settings',
+			'add'    => 'datamachine/queue-add',
+			'list'   => 'datamachine/queue-list',
+			'clear'  => 'datamachine/queue-clear',
+			'remove' => 'datamachine/queue-remove',
+			'update' => 'datamachine/queue-update',
+			'move'   => 'datamachine/queue-move',
+			'mode'   => 'datamachine/queue-mode',
 		);
 
 		if ( ! isset( $ability_map[ $action ] ) ) {
 			return array(
 				'success'   => false,
-				'error'     => 'Invalid action. Use "add", "list", "clear", "remove", "update", "move", or "settings"',
+				'error'     => 'Invalid action. Use "add", "list", "clear", "remove", "update", "move", or "mode"',
 				'tool_name' => 'manage_queue',
 			);
 		}
@@ -187,8 +188,8 @@ All actions require flow_id and flow_step_id.';
 				$input['to_index']   = $parameters['to_index'] ?? null;
 				break;
 
-			case 'settings':
-				$input['queue_enabled'] = $parameters['queue_enabled'] ?? null;
+			case 'mode':
+				$input['mode'] = $parameters['mode'] ?? null;
 				break;
 		}
 

--- a/inc/Api/Flows/FlowQueue.php
+++ b/inc/Api/Flows/FlowQueue.php
@@ -178,28 +178,29 @@ class FlowQueue {
 
 		register_rest_route(
 			'datamachine/v1',
-			'/flows/(?P<flow_id>\d+)/queue/settings',
+			'/flows/(?P<flow_id>\d+)/queue/mode',
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
-				'callback'            => array( self::class, 'handle_update_queue_settings' ),
+				'callback'            => array( self::class, 'handle_update_queue_mode' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
-					'flow_id'       => array(
+					'flow_id'      => array(
 						'required'          => true,
 						'type'              => 'integer',
 						'sanitize_callback' => 'absint',
 						'description'       => __( 'Flow ID', 'data-machine' ),
 					),
-					'flow_step_id'  => array(
+					'flow_step_id' => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 						'description'       => __( 'Flow step ID', 'data-machine' ),
 					),
-					'queue_enabled' => array(
+					'mode'         => array(
 						'required'    => true,
-						'type'        => 'boolean',
-						'description' => __( 'Whether queue pop is enabled for this step', 'data-machine' ),
+						'type'        => 'string',
+						'enum'        => array( 'drain', 'loop', 'static' ),
+						'description' => __( 'Queue access mode: drain | loop | static.', 'data-machine' ),
 					),
 				),
 			)
@@ -267,11 +268,11 @@ class FlowQueue {
 			array(
 				'success' => true,
 				'data'    => array(
-					'flow_id'       => $result['flow_id'],
-					'flow_step_id'  => $result['flow_step_id'],
-					'queue'         => $result['queue'],
-					'count'         => $result['count'],
-					'queue_enabled' => $result['queue_enabled'],
+					'flow_id'      => $result['flow_id'],
+					'flow_step_id' => $result['flow_step_id'],
+					'queue'        => $result['queue'],
+					'count'        => $result['count'],
+					'queue_mode'   => $result['queue_mode'],
 				),
 			)
 		);
@@ -529,24 +530,24 @@ class FlowQueue {
 	}
 
 	/**
-	 * Handle queue settings update.
+	 * Handle queue mode update.
 	 *
-	 * PUT /flows/{id}/queue/settings
+	 * PUT /flows/{id}/queue/mode
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \WP_REST_Response|\WP_Error
 	 */
-	public static function handle_update_queue_settings( $request ) {
-		$ability = wp_get_ability( 'datamachine/queue-settings' );
+	public static function handle_update_queue_mode( $request ) {
+		$ability = wp_get_ability( 'datamachine/queue-mode' );
 		if ( ! $ability ) {
 			return new \WP_Error( 'ability_not_found', 'Ability not found', array( 'status' => 500 ) );
 		}
 
 		$result = $ability->execute(
 			array(
-				'flow_id'       => (int) $request->get_param( 'flow_id' ),
-				'flow_step_id'  => sanitize_text_field( $request->get_param( 'flow_step_id' ) ),
-				'queue_enabled' => (bool) $request->get_param( 'queue_enabled' ),
+				'flow_id'      => (int) $request->get_param( 'flow_id' ),
+				'flow_step_id' => sanitize_text_field( $request->get_param( 'flow_step_id' ) ),
+				'mode'         => sanitize_text_field( $request->get_param( 'mode' ) ),
 			)
 		);
 
@@ -561,8 +562,8 @@ class FlowQueue {
 			}
 
 			return new \WP_Error(
-				'queue_settings_failed',
-				$result['error'] ?? __( 'Failed to update queue settings.', 'data-machine' ),
+				'queue_mode_failed',
+				$result['error'] ?? __( 'Failed to update queue mode.', 'data-machine' ),
 				array( 'status' => $status )
 			);
 		}
@@ -571,11 +572,11 @@ class FlowQueue {
 			array(
 				'success' => true,
 				'data'    => array(
-					'flow_id'       => $result['flow_id'],
-					'flow_step_id'  => $result['flow_step_id'],
-					'queue_enabled' => $result['queue_enabled'],
+					'flow_id'      => $result['flow_id'],
+					'flow_step_id' => $result['flow_step_id'],
+					'queue_mode'   => $result['queue_mode'],
 				),
-				'message' => $result['message'] ?? __( 'Queue settings updated.', 'data-machine' ),
+				'message' => $result['message'] ?? __( 'Queue mode updated.', 'data-machine' ),
 			)
 		);
 	}

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -100,9 +100,10 @@ class FlowsCommand extends BaseCommand {
 	 * : ISO-8601 datetime for one-time scheduling (e.g. "2026-03-20T15:00:00Z"). Implies --scheduling=one_time.
 	 *
 	 * [--set-user-message=<text>]
-	 * : Update the user_message for an AI step (per-flow task context appended
-	 *   after fetched data packets). For the pipeline-wide system prompt shared
-	 *   across all flows on the pipeline, use `pipeline update --set-system-prompt`.
+	 * : Update the per-flow user message for an AI step. Stored as a 1-entry
+	 *   static prompt_queue (the queue head fires every tick). For the pipeline-
+	 *   wide system prompt shared across all flows, use `pipeline update
+	 *   --set-system-prompt`.
 	 *
 	 * [--handler-config=<json>]
 	 * : JSON object of handler config key-value pairs to update (merged with existing config).
@@ -165,7 +166,7 @@ class FlowsCommand extends BaseCommand {
 	 *     # Update flow name
 	 *     wp datamachine flows update 141 --name="New Name"
 	 *
-	 *     # Update flow user_message (per-flow task context for an AI step)
+	 *     # Update per-flow user message (stored as a 1-entry static prompt_queue)
 	 *     wp datamachine flows update 42 --set-user-message="New user message"
 	 *
 	 *     # Add a handler to a flow step
@@ -412,12 +413,13 @@ class FlowsCommand extends BaseCommand {
 	 * @param string $format Output format (table, json, csv, yaml).
 	 */
 	private function showFlowDetail( array $flow, string $format ): void {
-		// Always surface user_message, prompt_queue, and queue_enabled on
-		// AI steps, even when unset, so every slot AIStep reads at runtime
-		// is discoverable. Otherwise these fields disappear from the JSON
-		// output and the next reader can't tell whether they're empty or
-		// whether they're looking at the wrong key — which is exactly how
-		// the --set-prompt-writes-dead-key bug stayed invisible.
+		// Always surface prompt_queue / config_patch_queue + queue_mode
+		// on queueable steps, even when unset, so every slot AIStep /
+		// FetchStep reads at runtime is discoverable. Otherwise these
+		// fields disappear from JSON output and the next reader can't
+		// tell whether they're empty or looking at the wrong key — which
+		// is exactly how the --set-prompt-writes-dead-key bug stayed
+		// invisible.
 		$flow = self::normalizeAiStepPromptSlots( $flow );
 
 		// JSON/YAML: output the full flow data including flow_config.
@@ -493,23 +495,17 @@ class FlowsCommand extends BaseCommand {
 				}
 
 				if ( 'ai' === $step_type ) {
-					// AI steps have THREE prompt-input slots that AIStep::execute()
-					// chains as a precedence: prompt_queue head → user_message →
-					// (none). Surface every slot that exists and mark which one
-					// AIStep would actually read at runtime, so the active prompt
-					// is never invisible.
-					$user_message = $step_data['user_message'] ?? '';
-					$config_parts[] = 'user_message=' . ( '' === $user_message ? '(unset)' : $this->truncateValue( $user_message, 60 ) );
-
+					// AI steps consume the prompt_queue slot under one of
+					// three modes (drain | loop | static). Surface the
+					// queue depth, mode, and the active prompt label so
+					// the resolved per-flow user message is never invisible.
 					$resolved = self::resolveAiStepActivePrompt( $step_data );
 
-					if ( $resolved['queue_depth'] > 0 || $resolved['queue_enabled'] ) {
-						$config_parts[] = sprintf(
-							'queue=%d item(s), queue_enabled=%s',
-							$resolved['queue_depth'],
-							$resolved['queue_enabled'] ? 'true' : 'false'
-						);
-					}
+					$config_parts[] = sprintf(
+						'queue=%d item(s), queue_mode=%s',
+						$resolved['queue_depth'],
+						$resolved['queue_mode']
+					);
 
 					$config_parts[] = 'active_prompt=' . self::formatActivePromptLabel( $resolved );
 				}
@@ -532,17 +528,17 @@ class FlowsCommand extends BaseCommand {
 					$config_parts[] = $key . '=' . $this->formatConfigValue( $value );
 				}
 
-				// Fetch steps surface config_patch_queue depth + queue_enabled
-				// alongside their static handler config (#1292).
+				// Fetch steps surface config_patch_queue depth + queue_mode
+				// alongside their static handler config (#1291 / #1292).
 				if ( 'fetch' === $step_type ) {
-					$patch_queue   = $step_data['config_patch_queue'] ?? array();
-					$queue_depth   = is_array( $patch_queue ) ? count( $patch_queue ) : 0;
-					$queue_enabled = ! empty( $step_data['queue_enabled'] );
-					if ( $queue_depth > 0 || $queue_enabled ) {
+					$patch_queue = $step_data['config_patch_queue'] ?? array();
+					$queue_depth = is_array( $patch_queue ) ? count( $patch_queue ) : 0;
+					$queue_mode  = $step_data['queue_mode'] ?? 'static';
+					if ( $queue_depth > 0 || 'static' !== $queue_mode ) {
 						$config_parts[] = sprintf(
-							'config_patch_queue=%d item(s), queue_enabled=%s',
+							'config_patch_queue=%d item(s), queue_mode=%s',
 							$queue_depth,
-							$queue_enabled ? 'true' : 'false'
+							$queue_mode
 						);
 					}
 				}
@@ -579,28 +575,17 @@ class FlowsCommand extends BaseCommand {
 	}
 
 	/**
-	 * Ensure every AI step in a flow exposes its prompt-input slots.
+	 * Ensure every queueable step in a flow exposes its queue slots.
 	 *
-	 * AIStep::execute() reads three slots at the flow_step_config root
-	 * (not under handler_configs):
-	 *
-	 *   - user_message: per-flow task framing (the slot --set-user-message
-	 *     writes to).
-	 *   - prompt_queue:  list of queued prompts (managed by `flow queue
-	 *     add/remove/clear` or by webhooks). When non-empty, AIStep
-	 *     reads the head of this queue in preference to user_message.
-	 *   - queue_enabled: when true, the queue head is popped per tick;
-	 *     when false, the head is statically peeked (first entry wins
-	 *     forever). Either way, queue head takes precedence over
-	 *     user_message.
-	 *
-	 * Omitting any of these from `flow get` output hides the precedence
-	 * chain — exactly the same blind-spot pattern as the original
-	 * --set-prompt dead-key bug. Render the slot keys with their
-	 * "unset" defaults so every input AIStep reads is discoverable.
+	 * Post-#1291 collapse: AI and Fetch steps each consume one slot
+	 * (`prompt_queue` for AI, `config_patch_queue` for Fetch) and share
+	 * a single `queue_mode` enum. Default the slots to empty arrays and
+	 * `queue_mode` to "static" so the keys are visible on `flow get`
+	 * output even when never set, preserving the discoverability that
+	 * caught the --set-prompt dead-key bug originally.
 	 *
 	 * @param array $flow Flow data with flow_config.
-	 * @return array Flow data with AI step prompt slots normalized.
+	 * @return array Flow data with queue slots normalized.
 	 */
 	private static function normalizeAiStepPromptSlots( array $flow ): array {
 		if ( empty( $flow['flow_config'] ) || ! is_array( $flow['flow_config'] ) ) {
@@ -613,31 +598,22 @@ class FlowsCommand extends BaseCommand {
 			}
 			$step_type = $step_data['step_type'] ?? '';
 
-			// AI steps consume the prompt_queue slot. Surface
-			// user_message + prompt_queue + queue_enabled so every
-			// input AIStep reads is discoverable.
 			if ( 'ai' === $step_type ) {
-				if ( ! array_key_exists( 'user_message', $step_data ) ) {
-					$flow['flow_config'][ $step_id ]['user_message'] = '';
-				}
 				if ( ! array_key_exists( 'prompt_queue', $step_data ) ) {
 					$flow['flow_config'][ $step_id ]['prompt_queue'] = array();
 				}
-				if ( ! array_key_exists( 'queue_enabled', $step_data ) ) {
-					$flow['flow_config'][ $step_id ]['queue_enabled'] = false;
+				if ( ! array_key_exists( 'queue_mode', $step_data ) ) {
+					$flow['flow_config'][ $step_id ]['queue_mode'] = 'static';
 				}
 				continue;
 			}
 
-			// Fetch steps consume the config_patch_queue slot (#1292).
-			// Surface config_patch_queue + queue_enabled so the queue
-			// shape is discoverable on `flow get`.
 			if ( 'fetch' === $step_type ) {
 				if ( ! array_key_exists( 'config_patch_queue', $step_data ) ) {
 					$flow['flow_config'][ $step_id ]['config_patch_queue'] = array();
 				}
-				if ( ! array_key_exists( 'queue_enabled', $step_data ) ) {
-					$flow['flow_config'][ $step_id ]['queue_enabled'] = false;
+				if ( ! array_key_exists( 'queue_mode', $step_data ) ) {
+					$flow['flow_config'][ $step_id ]['queue_mode'] = 'static';
 				}
 			}
 		}
@@ -646,51 +622,36 @@ class FlowsCommand extends BaseCommand {
 	}
 
 	/**
-	 * Resolve which prompt slot AIStep would actually read at runtime.
+	 * Resolve the active prompt slot for an AI step at runtime.
 	 *
-	 * Mirrors the precedence in inc/Core/Steps/AI/AIStep.php::execute()
-	 * lines 140-173:
-	 *
-	 *   - prompt_queue head wins when present (popped if queue_enabled,
-	 *     statically peeked otherwise).
-	 *   - user_message is the fallback when the queue head is empty.
-	 *   - both empty: AIStep runs with no flow-level user message
-	 *     (the pipeline system_prompt and any data packets still apply).
+	 * Post-#1291 there is one slot — `prompt_queue` — and the access
+	 * mode picks how the head is consumed. Reading the active prompt
+	 * is just "look up queue_mode, peek the head".
 	 *
 	 * @param array $step_data AI step data from flow_config.
-	 * @return array{slot:string, value:string, queue_depth:int, queue_enabled:bool}
-	 *               slot is one of: 'queue_head', 'user_message', 'none'.
+	 * @return array{slot:string, value:string, queue_depth:int, queue_mode:string}
+	 *               slot is one of: 'queue_head', 'none'.
 	 */
 	private static function resolveAiStepActivePrompt( array $step_data ): array {
-		$queue_enabled = (bool) ( $step_data['queue_enabled'] ?? false );
-		$prompt_queue  = $step_data['prompt_queue'] ?? array();
-		$queue_depth   = is_array( $prompt_queue ) ? count( $prompt_queue ) : 0;
-		$queue_head    = is_array( $prompt_queue ) ? trim( (string) ( $prompt_queue[0]['prompt'] ?? '' ) ) : '';
-		$user_message  = trim( (string) ( $step_data['user_message'] ?? '' ) );
+		$queue_mode   = $step_data['queue_mode'] ?? 'static';
+		$prompt_queue = $step_data['prompt_queue'] ?? array();
+		$queue_depth  = is_array( $prompt_queue ) ? count( $prompt_queue ) : 0;
+		$queue_head   = is_array( $prompt_queue ) ? trim( (string) ( $prompt_queue[0]['prompt'] ?? '' ) ) : '';
 
 		if ( '' !== $queue_head ) {
 			return array(
-				'slot'          => 'queue_head',
-				'value'         => $queue_head,
-				'queue_depth'   => $queue_depth,
-				'queue_enabled' => $queue_enabled,
-			);
-		}
-
-		if ( '' !== $user_message ) {
-			return array(
-				'slot'          => 'user_message',
-				'value'         => $user_message,
-				'queue_depth'   => $queue_depth,
-				'queue_enabled' => $queue_enabled,
+				'slot'        => 'queue_head',
+				'value'       => $queue_head,
+				'queue_depth' => $queue_depth,
+				'queue_mode'  => $queue_mode,
 			);
 		}
 
 		return array(
-			'slot'          => 'none',
-			'value'         => '',
-			'queue_depth'   => $queue_depth,
-			'queue_enabled' => $queue_enabled,
+			'slot'        => 'none',
+			'value'       => '',
+			'queue_depth' => $queue_depth,
+			'queue_mode'  => $queue_mode,
 		);
 	}
 
@@ -698,17 +659,12 @@ class FlowsCommand extends BaseCommand {
 	 * Render a short label for the slot AIStep will read at runtime.
 	 *
 	 * Output examples:
-	 *   - "queue_head[1/3] (drains): \"Generate Q3 brief...\""
-	 *   - "queue_head[1/1] (static): \"Single override...\""
-	 *   - "user_message: \"Per-flow framing...\""
+	 *   - "queue_head[1/3] (drain): \"Generate Q3 brief...\""
+	 *   - "queue_head[1/1] (static): \"Single per-flow message...\""
+	 *   - "queue_head[1/5] (loop): \"Cycling source A...\""
 	 *   - "(none)"
 	 *
-	 * The drains/static suffix on queue_head matches AIStep behavior:
-	 * with queue_enabled=true the head pops per tick (drains); with
-	 * queue_enabled=false the head is statically peeked (first entry
-	 * wins forever until the queue is mutated).
-	 *
-	 * @param array{slot:string, value:string, queue_depth:int, queue_enabled:bool} $resolved
+	 * @param array{slot:string, value:string, queue_depth:int, queue_mode:string} $resolved
 	 * @return string Formatted label suitable for table output.
 	 */
 	private static function formatActivePromptLabel( array $resolved ): string {
@@ -717,12 +673,9 @@ class FlowsCommand extends BaseCommand {
 				return sprintf(
 					'queue_head[1/%d] (%s): "%s"',
 					$resolved['queue_depth'],
-					$resolved['queue_enabled'] ? 'drains' : 'static',
+					$resolved['queue_mode'],
 					self::truncateForLabel( $resolved['value'], 50 )
 				);
-
-			case 'user_message':
-				return sprintf( 'user_message: "%s"', self::truncateForLabel( $resolved['value'], 50 ) );
 
 			default:
 				return '(none)';

--- a/inc/Cli/Commands/Flows/QueueCommand.php
+++ b/inc/Cli/Commands/Flows/QueueCommand.php
@@ -3,7 +3,7 @@
  * WP-CLI Flows Queue Command
  *
  * Manages per-step queues attached to flow steps. Two queue slots are
- * supported (#1292):
+ * supported (#1292), both gated by a single `queue_mode` enum (#1291):
  *
  *   - prompt_queue       — string prompts, consumed by AI steps
  *   - config_patch_queue — object patches, consumed by fetch steps
@@ -15,9 +15,14 @@
  * fetch step, or `--patch=` against an AI step) errors loudly with a
  * pointer to the right flag.
  *
+ * The `mode` subcommand sets the access pattern (drain | loop | static)
+ * for whichever slot the step consumes — the same enum drives both
+ * AI and Fetch behaviour.
+ *
  * @package DataMachine\Cli\Commands\Flows
  * @since 0.31.0
  * @see https://github.com/Extra-Chill/data-machine/issues/345
+ * @see https://github.com/Extra-Chill/data-machine/issues/1291
  * @see https://github.com/Extra-Chill/data-machine/issues/1292
  */
 
@@ -41,7 +46,7 @@ class QueueCommand extends BaseCommand {
 	 */
 	public function dispatch( array $args, array $assoc_args ): void {
 		if ( empty( $args ) ) {
-			WP_CLI::error( 'Usage: wp datamachine flows queue <add|list|clear|remove|update|move|validate> <flow_id> [args...]' );
+			WP_CLI::error( 'Usage: wp datamachine flows queue <add|list|clear|remove|update|move|mode|validate> <flow_id> [args...]' );
 			return;
 		}
 
@@ -67,11 +72,14 @@ class QueueCommand extends BaseCommand {
 			case 'move':
 				$this->move( $remaining, $assoc_args );
 				break;
+			case 'mode':
+				$this->mode( $remaining, $assoc_args );
+				break;
 			case 'validate':
 				$this->validate( $remaining, $assoc_args );
 				break;
 			default:
-				WP_CLI::error( "Unknown queue action: {$action}. Use: add, list, clear, remove, update, move, validate" );
+				WP_CLI::error( "Unknown queue action: {$action}. Use: add, list, clear, remove, update, move, mode, validate" );
 		}
 	}
 
@@ -283,16 +291,16 @@ class QueueCommand extends BaseCommand {
 			return;
 		}
 
-		$prompt_queue  = $prompt_result['queue'] ?? array();
-		$patch_queue   = $patch_result['queue'] ?? array();
-		$queue_enabled = $prompt_result['queue_enabled'] ?? $patch_result['queue_enabled'] ?? false;
+		$prompt_queue = $prompt_result['queue'] ?? array();
+		$patch_queue  = $patch_result['queue'] ?? array();
+		$queue_mode   = $prompt_result['queue_mode'] ?? $patch_result['queue_mode'] ?? 'static';
 
 		if ( 'json' === $format ) {
 			WP_CLI::line( wp_json_encode(
 				array(
 					'flow_id'            => $flow_id,
 					'flow_step_id'       => $flow_step_id,
-					'queue_enabled'      => $queue_enabled,
+					'queue_mode'         => $queue_mode,
 					'prompt_queue'       => $prompt_queue,
 					'config_patch_queue' => $patch_queue,
 				),
@@ -302,7 +310,7 @@ class QueueCommand extends BaseCommand {
 		}
 
 		if ( empty( $prompt_queue ) && empty( $patch_queue ) ) {
-			WP_CLI::log( sprintf( 'Queue is empty. (queue_enabled: %s)', $queue_enabled ? 'yes' : 'no' ) );
+			WP_CLI::log( sprintf( 'Queue is empty. (queue_mode: %s)', $queue_mode ) );
 			return;
 		}
 
@@ -337,10 +345,10 @@ class QueueCommand extends BaseCommand {
 		}
 
 		WP_CLI::log( sprintf(
-			'Total: %d prompt(s), %d patch(es). (queue_enabled: %s)',
+			'Total: %d prompt(s), %d patch(es). (queue_mode: %s)',
 			count( $prompt_queue ),
 			count( $patch_queue ),
-			$queue_enabled ? 'yes' : 'no'
+			$queue_mode
 		) );
 	}
 
@@ -710,6 +718,89 @@ class QueueCommand extends BaseCommand {
 	}
 
 	/**
+	 * Set the queue access mode for a flow step.
+	 *
+	 * Replaces the pre-#1291 `flow queue settings --queue-enabled=...`
+	 * verb. Mode is one of:
+	 *
+	 *   - drain  — pop the head per tick, discard. Empty queue → skip
+	 *              with COMPLETED_NO_ITEMS.
+	 *   - loop   — pop the head per tick, append to tail. The queue
+	 *              cycles indefinitely.
+	 *   - static — peek the head every tick, do not mutate. Position 0
+	 *              is the active entry; positions 1..N stay staged.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <flow_id>
+	 * : The flow ID.
+	 *
+	 * <mode>
+	 * : One of: drain, loop, static.
+	 *
+	 * [--step=<flow_step_id>]
+	 * : Target a specific flow step. Auto-resolved if the flow has exactly one queueable step.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Make the AI step drain its prompt queue per tick
+	 *     wp datamachine flows queue mode 42 drain
+	 *
+	 *     # Cycle through queued patches forever
+	 *     wp datamachine flows queue mode 42 loop --step=fetch_42_abc
+	 *
+	 *     # Pin position 0 — runs every tick without mutating the queue
+	 *     wp datamachine flows queue mode 42 static
+	 *
+	 * @subcommand mode
+	 */
+	public function mode( array $args, array $assoc_args ): void {
+		if ( count( $args ) < 2 ) {
+			WP_CLI::error( 'Usage: wp datamachine flows queue mode <flow_id> <drain|loop|static>' );
+			return;
+		}
+
+		$flow_id      = (int) $args[0];
+		$mode         = strtolower( (string) $args[1] );
+		$flow_step_id = $assoc_args['step'] ?? null;
+
+		if ( $flow_id <= 0 ) {
+			WP_CLI::error( 'flow_id must be a positive integer' );
+			return;
+		}
+
+		if ( ! in_array( $mode, array( 'drain', 'loop', 'static' ), true ) ) {
+			WP_CLI::error( 'mode must be one of: drain, loop, static' );
+			return;
+		}
+
+		if ( empty( $flow_step_id ) ) {
+			$resolved = $this->resolveQueueableStep( $flow_id );
+			if ( $resolved['error'] ) {
+				WP_CLI::error( $resolved['error'] );
+				return;
+			}
+			$flow_step_id = $resolved['step_id'];
+		}
+
+		$ability = new \DataMachine\Abilities\FlowAbilities();
+		$result  = $ability->executeQueueMode(
+			array(
+				'flow_id'      => $flow_id,
+				'flow_step_id' => $flow_step_id,
+				'mode'         => $mode,
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to set queue mode' );
+			return;
+		}
+
+		WP_CLI::success( $result['message'] ?? sprintf( 'Queue mode set to %s.', $mode ) );
+	}
+
+	/**
 	 * Validate a topic against published posts and queue items for duplicates.
 	 *
 	 * ## OPTIONS
@@ -851,9 +942,17 @@ class QueueCommand extends BaseCommand {
 			);
 		}
 
+		// Post-#1291 a step is "queueable" by virtue of its step type
+		// (AI consumes prompt_queue, Fetch consumes config_patch_queue).
+		// Pre-#1291 the queueable signal was the `queue_enabled` flag,
+		// which conflated the access mode with the step's eligibility.
 		$queueable = array();
 		foreach ( $config as $step_id => $step_data ) {
-			if ( ! empty( $step_data['queue_enabled'] ) ) {
+			if ( ! is_array( $step_data ) ) {
+				continue;
+			}
+			$step_type = $step_data['step_type'] ?? '';
+			if ( 'ai' === $step_type || 'fetch' === $step_type ) {
 				$queueable[] = $step_id;
 			}
 		}

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -137,39 +137,42 @@ class AIStep extends Step {
 			return $this->dataPackets;
 		}
 
-		$configured_message = trim( $this->flow_step_config['user_message'] ?? '' );
-		$queue_enabled      = (bool) ( $this->flow_step_config['queue_enabled'] ?? false );
-		$prompt_queue       = $this->flow_step_config['prompt_queue'] ?? array();
-		$queued_prompt      = $prompt_queue[0]['prompt'] ?? '';
+		// AIStep reads a single prompt slot — `prompt_queue` — under one
+		// of three access modes (#1291). Pre-collapse this branched on
+		// `queue_enabled` plus a `user_message` fallback; post-collapse
+		// the mode picks the access pattern and the queue head is the
+		// only source of per-flow user-role content. Migration #1291
+		// rewrites legacy `user_message` into a 1-entry static queue so
+		// no runtime fallback shim is needed here.
+		$queue_mode   = $this->flow_step_config['queue_mode'] ?? 'static';
+		$queue_result = $this->consumeFromPromptQueue( $queue_mode );
+		$user_message = $queue_result['value'];
 
-		if ( $queue_enabled ) {
-			$queue_result = $this->popFromQueueIfEmpty( '', true );
-			$user_message = $queue_result['value'];
-
-			// Queue is enabled but empty — skip cleanly instead of failing.
-			if ( empty( $user_message ) && empty( $configured_message ) ) {
+		if ( '' === $user_message ) {
+			// Empty queue in drain or loop modes implies per-tick work
+			// that can't proceed — short-circuit cleanly so the engine
+			// completes with COMPLETED_NO_ITEMS rather than treating the
+			// missing prompt as a failure.
+			if ( in_array( $queue_mode, array( 'drain', 'loop' ), true ) ) {
 				do_action(
 					'datamachine_log',
 					'info',
-					'AI step skipped — queue enabled but empty, no configured message',
+					'AI step skipped — queue mode requires per-tick prompt but queue is empty',
 					array(
 						'job_id'       => $this->job_id,
 						'flow_step_id' => $this->flow_step_id,
+						'queue_mode'   => $queue_mode,
 					)
 				);
 
-				// Set status override so Engine completes with completed_no_items
-				// instead of treating empty data packets as a failure.
 				$this->engine->set( 'job_status', \DataMachine\Core\JobStatus::COMPLETED_NO_ITEMS );
 
 				return $this->dataPackets;
 			}
-		} else {
-			$user_message = $queued_prompt;
-		}
 
-		if ( empty( $user_message ) ) {
-			$user_message = $configured_message;
+			// Static mode + empty queue: no flow-level user message,
+			// but the pipeline system_prompt and any data packets still
+			// drive the conversation. Fall through with $user_message=''.
 		}
 
 		// Vision image from engine data (single source of truth)

--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -20,18 +20,25 @@ if ( ! defined( 'ABSPATH' ) ) {
  * PipelineBatchScheduler is active, multiple packets trigger fan-out
  * into child jobs.
  *
- * Supports queue-driven dynamic params via QueueableTrait. When
- * `queue_enabled` is true on the flow step config, the step pops one
- * queued JSON-encoded patch per invocation and deep-merges it into the
- * handler's static config before invoking the handler. This is how
- * windowed retroactive backfills (a flow that processes a different
- * date range each tick) and rotating-source forward-ingestion are
- * expressed without an external orchestrator.
+ * Supports queue-driven dynamic params via QueueableTrait. The
+ * `queue_mode` enum on the flow step config (#1291) picks the access
+ * pattern:
  *
- * Empty queue with queue_enabled=true is treated as a no-op tick: the
- * job completes with COMPLETED_NO_ITEMS and no fetch is attempted. This
- * matches the AI step's queue-empty behaviour and keeps recurring flows
- * idempotent once their backfill queue drains.
+ *   - drain  — pop one queued patch per tick, discard. Empty queue →
+ *              COMPLETED_NO_ITEMS. Drives windowed historical
+ *              backfills.
+ *   - loop   — pop one queued patch per tick, append same patch to
+ *              tail. Drives rotating-source forward-ingestion (e.g.
+ *              cycle through a list of fetch configs).
+ *   - static — peek the head, do not mutate. The position-0 patch
+ *              fires every tick; positions 1..N stay staged for
+ *              iterative flow development. Switch to drain or loop
+ *              once the patch is dialed in.
+ *
+ * Empty queue in drain/loop modes is treated as a no-op tick: the job
+ * completes with COMPLETED_NO_ITEMS and no fetch is attempted. Static
+ * mode falls through to the unmerged static handler config when the
+ * queue is empty (no patch == no overlay).
  *
  * @package DataMachine
  */
@@ -79,24 +86,23 @@ class FetchStep extends Step {
 			return $this->dataPackets;
 		}
 
-		// Queue-driven params: when enabled, pop one queued patch and
-		// merge it into the static handler config. This is how a flow
-		// expresses "every tick, process the next windowed slice" with
-		// no external orchestrator.
-		$queue_enabled = (bool) ( $this->flow_step_config['queue_enabled'] ?? false );
+		// Queue-driven params: read the configured mode and consume from
+		// the config_patch_queue accordingly. Drain pops, loop pops+
+		// appends, static peeks — see QueueableTrait for the contract.
+		$queue_mode   = $this->flow_step_config['queue_mode'] ?? 'static';
+		$queue_result = $this->consumeFromConfigPatchQueue( $queue_mode );
 
-		if ( $queue_enabled ) {
-			$queue_result = $this->popQueuedConfigPatch( true );
-
-			if ( ! $queue_result['from_queue'] ) {
-				// Queue enabled but empty — clean no-op tick. Mark the
-				// job as completed-no-items so the engine treats this
-				// as success rather than a fetch failure.
+		if ( ! $queue_result['from_queue'] ) {
+			// Empty queue in drain or loop modes implies per-tick work
+			// that can't proceed — short-circuit cleanly. Static mode
+			// falls through to the unmerged handler config below.
+			if ( in_array( $queue_mode, array( 'drain', 'loop' ), true ) ) {
 				$this->log(
 					'info',
-					'Fetch step skipped — queue enabled but empty',
+					'Fetch step skipped — queue mode requires per-tick patch but queue is empty',
 					array(
 						'flow_step_id' => $this->flow_step_id,
+						'queue_mode'   => $queue_mode,
 					)
 				);
 
@@ -104,7 +110,7 @@ class FetchStep extends Step {
 
 				return $this->dataPackets;
 			}
-
+		} else {
 			$handler_settings = $this->mergeQueuedConfigPatch( $handler_settings, $queue_result['patch'] );
 
 			$this->log(
@@ -112,6 +118,7 @@ class FetchStep extends Step {
 				'Fetch step merged queued config patch',
 				array(
 					'flow_step_id' => $this->flow_step_id,
+					'queue_mode'   => $queue_mode,
 					'patch_keys'   => array_keys( $queue_result['patch'] ),
 					'merged_keys'  => array_keys( $handler_settings ),
 					'queued_at'    => $queue_result['added_at'],

--- a/inc/Core/Steps/QueueableTrait.php
+++ b/inc/Core/Steps/QueueableTrait.php
@@ -2,24 +2,40 @@
 /**
  * Trait for steps that consume from a per-flow-step queue.
  *
- * Two consumption modes are exposed, each backed by its own storage
+ * Two consumption surfaces are exposed, each backed by its own storage
  * slot on the flow_step_config (see QueueAbility for the storage
  * contract):
  *
- * - {@see popFromQueueIfEmpty()} — for steps that consume scalar
- *   prompts (AI step's user_message). Reads from the
+ * - {@see consumeFromPromptQueue()} — for steps that consume scalar
+ *   prompts (AI step's per-flow user message). Reads from the
  *   `prompt_queue` slot. Each entry is `{ prompt: string, added_at }`.
  *
- * - {@see popQueuedConfigPatch()} — for steps that consume structured
- *   config patches (Fetch step's handler params). Reads from the
- *   `config_patch_queue` slot. Each entry is `{ patch: array,
- *   added_at }` — the patch is a decoded object stored verbatim, so
- *   no JSON-decode happens at read time.
+ * - {@see consumeFromConfigPatchQueue()} — for steps that consume
+ *   structured config patches (Fetch step's handler params). Reads
+ *   from the `config_patch_queue` slot. Each entry is
+ *   `{ patch: array, added_at }` — the patch is a decoded object
+ *   stored verbatim, so no JSON-decode happens at read time.
  *
- * Both share the same `queue_enabled` toggle on the step config and
- * the same retry-on-failure backup semantics. Splitting the storage
- * slots is #1292; pre-split, both consumers shared `prompt_queue` and
- * had to do string-vs-JSON detective work at read time.
+ * Both share a single `queue_mode` enum on the step config and the
+ * same retry-on-failure backup semantics. The mode is consumer-agnostic
+ * — `drain`, `loop`, and `static` all map to honest use cases on
+ * either consumer (see issue #1291 for the access-pattern table).
+ *
+ *   - drain  → pop the head, discard. Empty queue → null result with
+ *              `mutated: true` so the caller can branch on no-items.
+ *   - loop   → pop the head, append the same entry to the tail. Empty
+ *              queue → null result.
+ *   - static → peek the head, do not mutate. Empty queue → null result
+ *              with `mutated: false` so the caller can fall through to
+ *              its non-queue defaults.
+ *
+ * Pre-#1291 this trait took a `queue_enabled` boolean and exposed
+ * `popFromQueueIfEmpty()` / `popQueuedConfigPatch()`. Storage rewrites
+ * happened via QueueAbility::popFromQueueSlot() which always pop-and-
+ * discarded (no peek path, no rotate path). The boolean shadowed two
+ * unrelated decisions: "should the slot be consumed at all?" and "does
+ * the head get popped or peeked?". The mode enum names the access
+ * pattern explicitly and unblocks rotate-without-discard (loop).
  *
  * @package DataMachine\Core\Steps
  * @since 0.19.0
@@ -28,6 +44,7 @@
 namespace DataMachine\Core\Steps;
 
 use DataMachine\Abilities\Flow\QueueAbility;
+use DataMachine\Core\Database\Flows\Flows as DB_Flows;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -41,39 +58,45 @@ if ( ! defined( 'ABSPATH' ) ) {
  *       use QueueableTrait;
  *
  *       protected function executeStep(): array {
- *           $task = $this->popFromQueueIfEmpty( '', true );
- *           // Use $task...
+ *           $mode   = $this->flow_step_config['queue_mode'] ?? 'static';
+ *           $result = $this->consumeFromPromptQueue( $mode );
+ *           // Use $result['value'] / $result['from_queue'] / $result['mutated']...
  *       }
  *   }
  */
 trait QueueableTrait {
 
 	/**
-	 * Pop from the prompt queue if the provided value is empty and the
-	 * queue is enabled.
+	 * Consume from the prompt queue (AI consumer).
 	 *
-	 * Reads from the `prompt_queue` slot (AI consumer).
+	 * Reads from the `prompt_queue` slot. Mode-driven:
 	 *
-	 * @param string $current_value The current value (e.g., user_message or prompt).
-	 * @param bool   $queue_enabled Whether queue pop is enabled for this step.
-	 * @return array{value: string, from_queue: bool, added_at: string|null} Result with value and source info.
+	 *   - drain  → pop+discard
+	 *   - loop   → pop+append-to-tail
+	 *   - static → peek, no mutation
+	 *
+	 * Empty queue in any mode returns `value: ''`, `from_queue: false`.
+	 * For drain and loop, callers typically interpret an empty result
+	 * as "no work this tick" and short-circuit with COMPLETED_NO_ITEMS.
+	 * For static, callers fall through to whatever non-queue default
+	 * applies (e.g. system prompt + data packets only on AIStep).
+	 *
+	 * @param string $queue_mode One of "drain" | "loop" | "static".
+	 *                           Unknown values are treated as "static"
+	 *                           (peek without mutating) — same fail-safe
+	 *                           default the migration uses for absent
+	 *                           queue_mode keys.
+	 * @return array{value: string, from_queue: bool, added_at: string|null, mutated: bool}
 	 */
-	protected function popFromQueueIfEmpty( string $current_value, bool $queue_enabled = false ): array {
-		if ( ! $queue_enabled ) {
-			return array(
-				'value'      => $current_value,
-				'from_queue' => false,
-				'added_at'   => null,
-			);
-		}
-
-		$queued = $this->popOnceFromPromptQueue();
+	protected function consumeFromPromptQueue( string $queue_mode ): array {
+		$queued = $this->consumeOnceFromPromptQueue( $queue_mode );
 
 		if ( null === $queued ) {
 			return array(
 				'value'      => '',
 				'from_queue' => false,
 				'added_at'   => null,
+				'mutated'    => 'static' !== $queue_mode,
 			);
 		}
 
@@ -81,14 +104,15 @@ trait QueueableTrait {
 			'value'      => $queued['prompt'],
 			'from_queue' => true,
 			'added_at'   => $queued['added_at'] ?? null,
+			'mutated'    => 'static' !== $queue_mode,
 		);
 	}
 
 	/**
-	 * Pop a structured config patch from the fetch step queue.
+	 * Consume a structured config patch from the fetch step queue.
 	 *
-	 * Sibling of {@see popFromQueueIfEmpty()} for steps whose unit of
-	 * work is a structured config dict rather than a scalar prompt.
+	 * Sibling of {@see consumeFromPromptQueue()} for steps whose unit
+	 * of work is a structured config dict rather than a scalar prompt.
 	 * Reads from the `config_patch_queue` slot (Fetch consumer). The
 	 * `patch` field is stored as a decoded array verbatim, so no
 	 * JSON-decode happens here.
@@ -114,35 +138,22 @@ trait QueueableTrait {
 	 *
 	 *   {"feed_url":"https://example.com/feed.xml"}
 	 *
-	 * If the patch is shaped at the wrong nesting level the keys will
-	 * land on top-level config slots the handler never reads, and they
-	 * will be silently ignored downstream. The merge log line includes
-	 * both `patch_keys` and `merged_keys` to make this kind of
-	 * mis-shaping visible at debug time.
+	 * Empty queue in any mode returns `from_queue: false` with an empty
+	 * patch — callers can branch on that to either skip the tick or
+	 * fall through to the static handler config.
 	 *
-	 * Empty queue and disabled queue both return `from_queue: false` with
-	 * an empty patch — callers can branch on that to either skip the tick
-	 * or fall through to the static handler config.
-	 *
-	 * @param bool $queue_enabled Whether queue pop is enabled for this step.
-	 * @return array{patch: array, from_queue: bool, added_at: string|null} Result with the decoded patch and source info.
+	 * @param string $queue_mode One of "drain" | "loop" | "static".
+	 * @return array{patch: array, from_queue: bool, added_at: string|null, mutated: bool}
 	 */
-	protected function popQueuedConfigPatch( bool $queue_enabled = false ): array {
-		if ( ! $queue_enabled ) {
-			return array(
-				'patch'      => array(),
-				'from_queue' => false,
-				'added_at'   => null,
-			);
-		}
-
-		$queued = $this->popOnceFromConfigPatchQueue();
+	protected function consumeFromConfigPatchQueue( string $queue_mode ): array {
+		$queued = $this->consumeOnceFromConfigPatchQueue( $queue_mode );
 
 		if ( null === $queued ) {
 			return array(
 				'patch'      => array(),
 				'from_queue' => false,
 				'added_at'   => null,
+				'mutated'    => 'static' !== $queue_mode,
 			);
 		}
 
@@ -163,15 +174,18 @@ trait QueueableTrait {
 			'patch'      => $patch,
 			'from_queue' => true,
 			'added_at'   => $queued['added_at'] ?? null,
+			'mutated'    => 'static' !== $queue_mode,
 		);
 	}
 
 	/**
-	 * Pop one item from the AI prompt queue and back it up to engine data.
+	 * Consume one item from the AI prompt queue per the given mode and
+	 * back it up to engine data when the consumption mutates storage.
 	 *
-	 * @return array{prompt: string, added_at: string|null}|null Popped item, or null if no item.
+	 * @param string $queue_mode "drain" | "loop" | "static".
+	 * @return array{prompt: string, added_at: string|null}|null
 	 */
-	private function popOnceFromPromptQueue(): ?array {
+	private function consumeOnceFromPromptQueue( string $queue_mode ): ?array {
 		$job_context = $this->engine->getJobContext();
 		$flow_id     = $job_context['flow_id'] ?? null;
 
@@ -179,9 +193,14 @@ trait QueueableTrait {
 			return null;
 		}
 
-		$queued_item = QueueAbility::popFromQueue( (int) $flow_id, $this->flow_step_id );
+		$entry = self::consumeFromQueueSlot(
+			(int) $flow_id,
+			$this->flow_step_id,
+			QueueAbility::SLOT_PROMPT_QUEUE,
+			$queue_mode
+		);
 
-		if ( ! $queued_item || empty( $queued_item['prompt'] ) ) {
+		if ( ! $entry || empty( $entry['prompt'] ) ) {
 			return null;
 		}
 
@@ -190,41 +209,50 @@ trait QueueableTrait {
 			'info',
 			'Using prompt from queue',
 			array(
-				'flow_id'   => $flow_id,
-				'step_type' => $this->step_type ?? 'unknown',
-				'added_at'  => $queued_item['added_at'] ?? '',
+				'flow_id'    => $flow_id,
+				'step_type'  => $this->step_type ?? 'unknown',
+				'queue_mode' => $queue_mode,
+				'added_at'   => $entry['added_at'] ?? '',
 			)
 		);
 
-		// Store backup of the popped prompt in engine data for retry on failure.
-		// The `slot` field tells the retry path which queue to re-push to.
-		if ( property_exists( $this, 'job_id' ) && ! empty( $this->job_id ) ) {
+		// Store backup of the popped prompt in engine data for retry on
+		// failure. Static mode never mutates so no rollback is needed —
+		// re-running the static tick re-peeks the same entry naturally.
+		if ( 'static' !== $queue_mode
+			&& property_exists( $this, 'job_id' )
+			&& ! empty( $this->job_id )
+		) {
 			\datamachine_merge_engine_data(
 				$this->job_id,
 				array(
 					'queued_prompt_backup' => array(
 						'slot'         => QueueAbility::SLOT_PROMPT_QUEUE,
-						'prompt'       => $queued_item['prompt'],
+						'mode'         => $queue_mode,
+						'prompt'       => $entry['prompt'],
 						'flow_id'      => (int) $flow_id,
 						'flow_step_id' => $this->flow_step_id,
-						'added_at'     => $queued_item['added_at'] ?? null,
+						'added_at'     => $entry['added_at'] ?? null,
 					),
 				)
 			);
 		}
 
 		return array(
-			'prompt'   => $queued_item['prompt'],
-			'added_at' => $queued_item['added_at'] ?? null,
+			'prompt'   => $entry['prompt'],
+			'added_at' => $entry['added_at'] ?? null,
 		);
 	}
 
 	/**
-	 * Pop one item from the fetch config-patch queue and back it up to engine data.
+	 * Consume one item from the fetch config-patch queue per the given
+	 * mode and back it up to engine data when the consumption mutates
+	 * storage.
 	 *
-	 * @return array{patch: array, added_at: string|null}|null Popped item, or null if no item.
+	 * @param string $queue_mode "drain" | "loop" | "static".
+	 * @return array{patch: array, added_at: string|null}|null
 	 */
-	private function popOnceFromConfigPatchQueue(): ?array {
+	private function consumeOnceFromConfigPatchQueue( string $queue_mode ): ?array {
 		$job_context = $this->engine->getJobContext();
 		$flow_id     = $job_context['flow_id'] ?? null;
 
@@ -232,9 +260,14 @@ trait QueueableTrait {
 			return null;
 		}
 
-		$queued_item = QueueAbility::popConfigPatchFromQueue( (int) $flow_id, $this->flow_step_id );
+		$entry = self::consumeFromQueueSlot(
+			(int) $flow_id,
+			$this->flow_step_id,
+			QueueAbility::SLOT_CONFIG_PATCH_QUEUE,
+			$queue_mode
+		);
 
-		if ( ! $queued_item || ! isset( $queued_item['patch'] ) || ! is_array( $queued_item['patch'] ) ) {
+		if ( ! $entry || ! isset( $entry['patch'] ) || ! is_array( $entry['patch'] ) ) {
 			return null;
 		}
 
@@ -245,32 +278,112 @@ trait QueueableTrait {
 			array(
 				'flow_id'    => $flow_id,
 				'step_type'  => $this->step_type ?? 'unknown',
-				'patch_keys' => array_keys( $queued_item['patch'] ),
-				'added_at'   => $queued_item['added_at'] ?? '',
+				'queue_mode' => $queue_mode,
+				'patch_keys' => array_keys( $entry['patch'] ),
+				'added_at'   => $entry['added_at'] ?? '',
 			)
 		);
 
-		// Store backup for retry on failure. `slot` distinguishes which
-		// queue the backup belongs to.
-		if ( property_exists( $this, 'job_id' ) && ! empty( $this->job_id ) ) {
+		if ( 'static' !== $queue_mode
+			&& property_exists( $this, 'job_id' )
+			&& ! empty( $this->job_id )
+		) {
 			\datamachine_merge_engine_data(
 				$this->job_id,
 				array(
 					'queued_prompt_backup' => array(
 						'slot'         => QueueAbility::SLOT_CONFIG_PATCH_QUEUE,
-						'patch'        => $queued_item['patch'],
+						'mode'         => $queue_mode,
+						'patch'        => $entry['patch'],
 						'flow_id'      => (int) $flow_id,
 						'flow_step_id' => $this->flow_step_id,
-						'added_at'     => $queued_item['added_at'] ?? null,
+						'added_at'     => $entry['added_at'] ?? null,
 					),
 				)
 			);
 		}
 
 		return array(
-			'patch'    => $queued_item['patch'],
-			'added_at' => $queued_item['added_at'] ?? null,
+			'patch'    => $entry['patch'],
+			'added_at' => $entry['added_at'] ?? null,
 		);
+	}
+
+	/**
+	 * Consume one item from a named queue slot per the given mode.
+	 *
+	 * Centralizes the mode-aware read so prompt and config-patch
+	 * consumers share the same mutation/peek/rotate semantics. For
+	 * `drain` and `loop` the slot is rewritten in place; for `static`
+	 * no DB write happens.
+	 *
+	 * @param int      $flow_id      Flow ID.
+	 * @param string   $flow_step_id Flow step ID.
+	 * @param string   $slot         Queue slot name.
+	 * @param string   $queue_mode   "drain" | "loop" | "static".
+	 * @param DB_Flows $db_flows     Optional database instance.
+	 * @return array|null The consumed entry, or null if the queue was empty.
+	 */
+	private static function consumeFromQueueSlot(
+		int $flow_id,
+		string $flow_step_id,
+		string $slot,
+		string $queue_mode,
+		?DB_Flows $db_flows = null
+	): ?array {
+		if ( null === $db_flows ) {
+			$db_flows = new DB_Flows();
+		}
+
+		$flow = $db_flows->get_flow( $flow_id );
+		if ( ! $flow ) {
+			return null;
+		}
+
+		$flow_config = $flow['flow_config'] ?? array();
+		if ( ! isset( $flow_config[ $flow_step_id ] ) ) {
+			return null;
+		}
+
+		$step_config = $flow_config[ $flow_step_id ];
+		$queue       = $step_config[ $slot ] ?? array();
+
+		if ( empty( $queue ) ) {
+			return null;
+		}
+
+		// Static peek: read head, do not mutate storage.
+		if ( 'static' === $queue_mode ) {
+			return $queue[0];
+		}
+
+		// Drain or loop: pop the head, optionally rotate.
+		$entry = array_shift( $queue );
+
+		if ( 'loop' === $queue_mode ) {
+			$queue[] = $entry;
+		}
+
+		$flow_config[ $flow_step_id ][ $slot ] = $queue;
+
+		$db_flows->update_flow(
+			$flow_id,
+			array( 'flow_config' => $flow_config )
+		);
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Item consumed from queue',
+			array(
+				'flow_id'         => $flow_id,
+				'slot'            => $slot,
+				'queue_mode'      => $queue_mode,
+				'remaining_count' => count( $queue ),
+			)
+		);
+
+		return $entry;
 	}
 
 	/**

--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -234,8 +234,11 @@ class SystemTaskStep extends Step {
 			$child_engine_data['job_id']       = $this->job_id;
 			$child_engine_data['pipeline_id']  = $job_context['pipeline_id'] ?? null;
 
-			$fsc                                = $this->flow_step_config ?? array();
-			$child_engine_data['queue_enabled'] = ! empty( $fsc['queue_enabled'] );
+			$fsc                             = $this->flow_step_config ?? array();
+			$queue_mode                      = $fsc['queue_mode'] ?? 'static';
+			$child_engine_data['queue_mode'] = in_array( $queue_mode, array( 'drain', 'loop', 'static' ), true )
+				? $queue_mode
+				: 'static';
 		}
 		$jobs_db->store_engine_data( (int) $child_job_id, $child_engine_data );
 		$jobs_db->start_job( (int) $child_job_id, JobStatus::PROCESSING );

--- a/inc/Engine/AI/Directives/AgentModeDirective.php
+++ b/inc/Engine/AI/Directives/AgentModeDirective.php
@@ -45,7 +45,7 @@ PIPELINES define workflow structure: step types in sequence (e.g., event_import 
 
 FLOWS are configured pipeline instances. Each step needs a handler_slug and handler_config. When creating flows, match handler configurations from existing flows on the same pipeline.
 
-AI STEPS process data that handlers cannot automatically handle. The pipeline system_prompt sets the agent's stable identity (shared across every flow). The flow user_message is appended as the final user-role message after fetched data packets — use it for per-flow task framing on top of the pipeline system_prompt. The two are additive, not alternative.
+AI STEPS process data that handlers cannot automatically handle. The pipeline system_prompt sets the agent's stable identity (shared across every flow). The flow's per-flow user message lives in the prompt_queue head — appended as the final user-role message after fetched data packets — use it for per-flow task framing on top of the pipeline system_prompt. The two are additive, not alternative. Set it via `flow update --set-user-message` (a 1-entry static queue) or `flow queue add` plus `flow queue mode <drain|loop|static>`.
 
 ## Discovery
 

--- a/inc/Engine/AI/System/Tasks/AgentPingTask.php
+++ b/inc/Engine/AI/System/Tasks/AgentPingTask.php
@@ -60,14 +60,27 @@ class AgentPingTask extends SystemTask {
 			return;
 		}
 
-		// Pop from flow queue when running as a pipeline step.
-		$from_queue    = false;
-		$flow_id       = (int) ( $params['flow_id'] ?? 0 );
-		$flow_step_id  = $params['flow_step_id'] ?? '';
-		$queue_enabled = ! empty( $params['queue_enabled'] );
+		// Consume from flow queue when running as a pipeline step. The
+		// `queue_mode` enum (#1291) decides the access pattern:
+		//   - drain  → pop the head, discard
+		//   - loop   → pop the head, append to tail
+		//   - static → peek the head; do not mutate
+		// Static mode + non-empty `prompt` argument falls through to use
+		// the configured prompt directly. This preserves the pre-#1291
+		// behaviour where running an agent_ping task without a queue
+		// just sent the configured prompt every tick.
+		$from_queue   = false;
+		$flow_id      = (int) ( $params['flow_id'] ?? 0 );
+		$flow_step_id = $params['flow_step_id'] ?? '';
+		$queue_mode   = $params['queue_mode'] ?? 'static';
+		if ( ! in_array( $queue_mode, array( 'drain', 'loop', 'static' ), true ) ) {
+			$queue_mode = 'static';
+		}
 
-		if ( $queue_enabled && $flow_id > 0 && ! empty( $flow_step_id ) ) {
-			$queued_item = QueueAbility::popFromQueue( $flow_id, $flow_step_id );
+		if ( 'static' !== $queue_mode && $flow_id > 0 && ! empty( $flow_step_id ) ) {
+			$queued_item = ( 'loop' === $queue_mode )
+				? QueueAbility::loopFromQueue( $flow_id, $flow_step_id )
+				: QueueAbility::popFromQueue( $flow_id, $flow_step_id );
 
 			if ( $queued_item && ! empty( $queued_item['prompt'] ) ) {
 				$prompt     = $queued_item['prompt'];
@@ -81,19 +94,23 @@ class AgentPingTask extends SystemTask {
 						'job_id'       => $jobId,
 						'flow_id'      => $flow_id,
 						'flow_step_id' => $flow_step_id,
+						'queue_mode'   => $queue_mode,
 					)
 				);
 			} elseif ( empty( $prompt ) ) {
 				do_action(
 					'datamachine_log',
 					'info',
-					'Agent ping task skipped — queue enabled but empty, no configured prompt',
-					array( 'job_id' => $jobId )
+					'Agent ping task skipped — queue mode requires per-tick prompt but queue is empty, no configured fallback',
+					array(
+						'job_id'     => $jobId,
+						'queue_mode' => $queue_mode,
+					)
 				);
 
 				$this->completeJob( $jobId, array(
 					'skipped'      => true,
-					'reason'       => 'Queue enabled but empty, no configured prompt',
+					'reason'       => sprintf( 'Queue mode "%s" but queue empty, no configured prompt', $queue_mode ),
 					'completed_at' => current_time( 'mysql' ),
 				) );
 				return;

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -25,3 +25,4 @@ require_once __DIR__ . '/update-to-upsert.php';
 require_once __DIR__ . '/strip-pipeline-step-provider-model.php';
 require_once __DIR__ . '/ai-enabled-tools.php';
 require_once __DIR__ . '/split-queue-payload.php';
+require_once __DIR__ . '/user-message-queue-mode.php';

--- a/inc/migrations/user-message-queue-mode.php
+++ b/inc/migrations/user-message-queue-mode.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Data Machine — Collapse user_message into prompt_queue + queue_mode (#1291).
+ *
+ * Pre-#1291 AIStep had two physically-separate storage slots feeding
+ * the same per-flow user-role message:
+ *
+ *   - flow_step_config[step_id].user_message   (single string)
+ *   - flow_step_config[step_id].prompt_queue   (array of {prompt, added_at})
+ *
+ * paired with a `queue_enabled` boolean that picked between two access
+ * patterns (drain-on-pop when true, peek-without-pop when false).
+ *
+ * Post-#1291:
+ *
+ *   - prompt_queue       — array<{prompt, added_at}>      (AI consumer)
+ *   - config_patch_queue — array<{patch, added_at}>       (Fetch consumer, untouched here)
+ *   - queue_mode         — "drain" | "loop" | "static"    (replaces queue_enabled)
+ *
+ * The `user_message` field is deleted from AI steps. The
+ * `queue_enabled` boolean is deleted from every queueable step.
+ *
+ * Migration shape mirrors split-queue-payload.php (#1294) and
+ * ai-enabled-tools.php (#1216): one-shot, idempotent, gated on a
+ * single option, no runtime fallback shim. Per the no-shim rule.
+ *
+ * Boolean → mode resolution:
+ *   queue_enabled === true  → queue_mode = "drain"   (matches today's pop-per-tick)
+ *   queue_enabled === false → queue_mode = "static"  (matches today's peek-without-pop;
+ *                                                     the multi-entry-queue case is
+ *                                                     named explicitly as the manual
+ *                                                     stockpile / iterative-dev pattern)
+ *
+ * AI-step-only handling for `user_message`:
+ *   1. prompt_queue empty + user_message non-empty
+ *        → seed queue as [{prompt: user_message, added_at: now()}], queue_mode=static
+ *   2. prompt_queue non-empty + user_message non-empty
+ *        → keep queue as-is, queue_mode=static, drop user_message
+ *          (matches existing AIStep precedence: queue head wins; the fallback was
+ *          shadowed at runtime), log dropped value at info level for traceability
+ *   3. user_message empty
+ *        → just unset the dead key; nothing to seed
+ *
+ * `loop` mode is net-new on both consumers — no flow gets it from
+ * migration; opt-in via `flow queue mode loop`.
+ *
+ * Fetch steps have no `user_message` to migrate (the
+ * `config_patch_queue` slot is the only fetch-side storage post-#1294).
+ * The migration just resolves `queue_enabled` → `queue_mode` and drops
+ * the dead key.
+ *
+ * @package DataMachine
+ * @since 0.85.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Replace `user_message` + `queue_enabled` with the unified `queue_mode`
+ * enum on every flow step.
+ *
+ * Idempotent: gated on `datamachine_user_message_collapsed`.
+ *
+ * @since 0.85.0
+ */
+function datamachine_migrate_user_message_queue_mode(): void {
+	$already_done = get_option( 'datamachine_user_message_collapsed', false );
+	if ( $already_done ) {
+		return;
+	}
+
+	global $wpdb;
+	$table = $wpdb->prefix . 'datamachine_flows';
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix.
+	$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+	// phpcs:enable WordPress.DB.PreparedSQL
+	if ( ! $table_exists ) {
+		update_option( 'datamachine_user_message_collapsed', true, true );
+		return;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix.
+	$rows = $wpdb->get_results( "SELECT flow_id, flow_config FROM {$table}", ARRAY_A );
+	// phpcs:enable WordPress.DB.PreparedSQL
+
+	if ( empty( $rows ) ) {
+		update_option( 'datamachine_user_message_collapsed', true, true );
+		return;
+	}
+
+	$migrated_flows         = 0;
+	$user_messages_seeded   = 0;
+	$user_messages_dropped  = 0;
+	$queue_modes_resolved   = 0;
+
+	foreach ( $rows as $row ) {
+		$flow_config = json_decode( $row['flow_config'], true );
+		if ( ! is_array( $flow_config ) ) {
+			continue;
+		}
+
+		$changed = false;
+		foreach ( $flow_config as $step_id => &$step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+
+			$step_type = $step['step_type'] ?? '';
+
+			$has_queue_enabled = array_key_exists( 'queue_enabled', $step );
+			$has_user_message  = array_key_exists( 'user_message', $step );
+
+			// Skip steps that touch neither key — nothing to migrate.
+			if ( ! $has_queue_enabled && ! $has_user_message ) {
+				continue;
+			}
+
+			// Resolve queue_mode from queue_enabled (or default to static
+			// when only user_message was set without queue toggling).
+			$queue_enabled = $has_queue_enabled ? (bool) $step['queue_enabled'] : false;
+			$queue_mode    = $queue_enabled ? 'drain' : 'static';
+
+			$step['queue_mode'] = $queue_mode;
+			++$queue_modes_resolved;
+
+			// AI-step-only: collapse user_message into prompt_queue.
+			if ( 'ai' === $step_type && $has_user_message ) {
+				$user_message = is_string( $step['user_message'] ) ? trim( $step['user_message'] ) : '';
+				$queue        = isset( $step['prompt_queue'] ) && is_array( $step['prompt_queue'] )
+					? $step['prompt_queue']
+					: array();
+
+				if ( '' !== $user_message ) {
+					if ( empty( $queue ) ) {
+						// Seed 1-entry static queue with the legacy user_message.
+						$step['prompt_queue'] = array(
+							array(
+								'prompt'   => $user_message,
+								'added_at' => gmdate( 'c' ),
+							),
+						);
+						// Force static so the seeded entry doesn't drain on
+						// the next tick — preserves "runs every tick" semantics.
+						$step['queue_mode'] = 'static';
+						++$user_messages_seeded;
+					} else {
+						// Both populated: queue head was already winning at
+						// runtime (AIStep precedence). Drop user_message and
+						// log it for traceability.
+						do_action(
+							'datamachine_log',
+							'info',
+							'user_message → prompt_queue migration: dropped user_message that was already shadowed by non-empty prompt_queue head',
+							array(
+								'flow_id'        => $row['flow_id'],
+								'step_id'        => $step_id,
+								'queue_depth'    => count( $queue ),
+								'dropped_value'  => mb_substr( $user_message, 0, 200 ),
+							)
+						);
+						// Force static so the kept queue head doesn't suddenly
+						// start draining if queue_enabled was true previously
+						// — preserves observable behaviour ("first entry wins
+						// every tick" was the de-facto state once user_message
+						// was dropped on the floor).
+						$step['queue_mode'] = 'static';
+						++$user_messages_dropped;
+					}
+				}
+			}
+
+			// Always strip the dead keys (no runtime fallback shim).
+			unset( $step['user_message'] );
+			unset( $step['queue_enabled'] );
+
+			$changed = true;
+		}
+		unset( $step );
+
+		if ( $changed ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->update(
+				$table,
+				array( 'flow_config' => wp_json_encode( $flow_config ) ),
+				array( 'flow_id' => $row['flow_id'] ),
+				array( '%s' ),
+				array( '%d' )
+			);
+			++$migrated_flows;
+		}
+	}
+
+	update_option( 'datamachine_user_message_collapsed', true, true );
+
+	if ( $migrated_flows > 0 || $queue_modes_resolved > 0 ) {
+		do_action(
+			'datamachine_log',
+			'info',
+			'user_message → queue_mode collapse migration complete',
+			array(
+				'flows_updated'         => $migrated_flows,
+				'queue_modes_resolved'  => $queue_modes_resolved,
+				'user_messages_seeded'  => $user_messages_seeded,
+				'user_messages_dropped' => $user_messages_dropped,
+			)
+		);
+	}
+}

--- a/tests/flow-update-set-user-message-smoke.php
+++ b/tests/flow-update-set-user-message-smoke.php
@@ -1,23 +1,29 @@
 <?php
 /**
- * Pure-PHP smoke test for the `flow update --set-user-message` fix (#1289).
+ * Pure-PHP smoke test for `flow update --set-user-message` (#1289 + #1291).
  *
  * Run with: php tests/flow-update-set-user-message-smoke.php
  *
- * The bug: `wp datamachine flow update <id> --set-prompt="..."` silently
- * wrote to handler_configs.ai.prompt, which AIStep::execute() never reads.
- * AIStep reads $flow_step_config['user_message'] at the flow_step_config
- * root, not under handler_configs. The CLI's `Success` message was a lie.
+ * #1289 was the original bug: `wp datamachine flow update <id> --set-prompt`
+ * silently wrote to handler_configs.ai.prompt, which AIStep never reads.
+ * The fix renamed the flag to --set-user-message and routed the write
+ * through UpdateFlowStepAbility's `user_message` input.
  *
- * The fix has three observable contracts this smoke covers:
+ * #1291 collapsed `user_message` into `prompt_queue` and replaced the
+ * `queue_enabled` boolean with a `queue_mode` enum. The CLI flag stays
+ * the same; the underlying storage rewrites the queue rather than a
+ * dedicated user_message slot.
  *
- *   1. The CLI rename: --set-prompt is removed (clean break, no alias),
- *      --set-user-message is the new flag.
+ * Three observable contracts this smoke covers post-#1291:
+ *
+ *   1. The CLI rename (#1289): --set-prompt is removed (clean break,
+ *      no alias), --set-user-message is the canonical flag.
  *   2. The CLI's write goes through UpdateFlowStepAbility's `user_message`
- *      input parameter (which routes to updateUserMessage()), not via
- *      `handler_config => array( 'prompt' => $prompt )`.
- *   3. `flow get` always renders the `user_message` slot on AI steps,
- *      even when unset, so the field is discoverable.
+ *      input parameter, which routes to updateUserMessage() and writes
+ *      a 1-entry static prompt_queue (#1291). No `user_message` field
+ *      is stored anywhere.
+ *   3. `flow get` always renders prompt_queue + queue_mode on AI steps,
+ *      even when unset, so the active-prompt slot is discoverable.
  *
  * @package DataMachine\Tests
  */
@@ -29,9 +35,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Inline reimplementation of UpdateFlowStepAbility::execute()'s
  * write-routing logic (the relevant slice). When `user_message` is in
- * the input, it's written to flow_step_config['user_message']. When
- * `handler_config` is in the input, it's merged into
- * flow_step_config['handler_configs'][$slug].
+ * the input, FlowStepHelpers::updateUserMessage() rewrites
+ * flow_step_config['prompt_queue'] as a 1-entry list and sets
+ * queue_mode=static. When `handler_config` is in the input, it's
+ * merged into flow_step_config['handler_configs'][$slug].
  *
  * Mirrors inc/Abilities/FlowStep/UpdateFlowStepAbility.php and
  * inc/Abilities/FlowStep/FlowStepHelpers.php::updateUserMessage().
@@ -56,7 +63,23 @@ function apply_update_flow_step_for_test( array $flow_step_config, array $input 
 	}
 
 	if ( $has_message_update ) {
-		$flow_step_config['user_message'] = $user_message;
+		// updateUserMessage() post-#1291: rewrite prompt_queue as a
+		// 1-entry list (or empty when input is empty) and pin
+		// queue_mode to static. No user_message field is written.
+		$sanitized = trim( (string) $user_message );
+
+		if ( '' === $sanitized ) {
+			$flow_step_config['prompt_queue'] = array();
+		} else {
+			$flow_step_config['prompt_queue'] = array(
+				array(
+					'prompt'   => $sanitized,
+					'added_at' => '2026-04-26T00:00:00+00:00',
+				),
+			);
+		}
+		$flow_step_config['queue_mode'] = 'static';
+		unset( $flow_step_config['user_message'] );
 	}
 
 	return $flow_step_config;
@@ -64,8 +87,9 @@ function apply_update_flow_step_for_test( array $flow_step_config, array $input 
 
 /**
  * Inline reimplementation of FlowsCommand::normalizeAiStepPromptSlots().
- * AI steps must always expose every slot AIStep reads at runtime
- * (`user_message`, `prompt_queue`, `queue_enabled`), even when unset.
+ * Post-#1291 AI steps must expose prompt_queue + queue_mode (no
+ * user_message slot anymore). Fetch steps expose
+ * config_patch_queue + queue_mode.
  *
  * Mirrors inc/Cli/Commands/Flows/FlowsCommand.php::normalizeAiStepPromptSlots.
  */
@@ -78,17 +102,25 @@ function normalize_ai_prompt_slots_for_test( array $flow ): array {
 		if ( ! is_array( $step_data ) ) {
 			continue;
 		}
-		if ( 'ai' !== ( $step_data['step_type'] ?? '' ) ) {
+		$step_type = $step_data['step_type'] ?? '';
+
+		if ( 'ai' === $step_type ) {
+			if ( ! array_key_exists( 'prompt_queue', $step_data ) ) {
+				$flow['flow_config'][ $step_id ]['prompt_queue'] = array();
+			}
+			if ( ! array_key_exists( 'queue_mode', $step_data ) ) {
+				$flow['flow_config'][ $step_id ]['queue_mode'] = 'static';
+			}
 			continue;
 		}
-		if ( ! array_key_exists( 'user_message', $step_data ) ) {
-			$flow['flow_config'][ $step_id ]['user_message'] = '';
-		}
-		if ( ! array_key_exists( 'prompt_queue', $step_data ) ) {
-			$flow['flow_config'][ $step_id ]['prompt_queue'] = array();
-		}
-		if ( ! array_key_exists( 'queue_enabled', $step_data ) ) {
-			$flow['flow_config'][ $step_id ]['queue_enabled'] = false;
+
+		if ( 'fetch' === $step_type ) {
+			if ( ! array_key_exists( 'config_patch_queue', $step_data ) ) {
+				$flow['flow_config'][ $step_id ]['config_patch_queue'] = array();
+			}
+			if ( ! array_key_exists( 'queue_mode', $step_data ) ) {
+				$flow['flow_config'][ $step_id ]['queue_mode'] = 'static';
+			}
 		}
 	}
 
@@ -97,48 +129,35 @@ function normalize_ai_prompt_slots_for_test( array $flow ): array {
 
 /**
  * Inline reimplementation of FlowsCommand::resolveAiStepActivePrompt().
- * Resolves which slot AIStep::execute() reads at runtime.
+ * Post-#1291 there is one slot — prompt_queue — gated by queue_mode.
  *
- * Mirrors inc/Core/Steps/AI/AIStep.php::execute() lines 140-173 and
- * inc/Cli/Commands/Flows/FlowsCommand.php::resolveAiStepActivePrompt.
- * Diverging here means one of those two files regressed.
+ * Mirrors inc/Cli/Commands/Flows/FlowsCommand.php::resolveAiStepActivePrompt.
  */
 function resolve_ai_active_prompt_for_test( array $step_data ): array {
-	$queue_enabled = (bool) ( $step_data['queue_enabled'] ?? false );
-	$prompt_queue  = $step_data['prompt_queue'] ?? array();
-	$queue_depth   = is_array( $prompt_queue ) ? count( $prompt_queue ) : 0;
-	$queue_head    = is_array( $prompt_queue ) ? trim( (string) ( $prompt_queue[0]['prompt'] ?? '' ) ) : '';
-	$user_message  = trim( (string) ( $step_data['user_message'] ?? '' ) );
+	$queue_mode   = $step_data['queue_mode'] ?? 'static';
+	$prompt_queue = $step_data['prompt_queue'] ?? array();
+	$queue_depth  = is_array( $prompt_queue ) ? count( $prompt_queue ) : 0;
+	$queue_head   = is_array( $prompt_queue ) ? trim( (string) ( $prompt_queue[0]['prompt'] ?? '' ) ) : '';
 
 	if ( '' !== $queue_head ) {
 		return array(
-			'slot'          => 'queue_head',
-			'value'         => $queue_head,
-			'queue_depth'   => $queue_depth,
-			'queue_enabled' => $queue_enabled,
-		);
-	}
-
-	if ( '' !== $user_message ) {
-		return array(
-			'slot'          => 'user_message',
-			'value'         => $user_message,
-			'queue_depth'   => $queue_depth,
-			'queue_enabled' => $queue_enabled,
+			'slot'        => 'queue_head',
+			'value'       => $queue_head,
+			'queue_depth' => $queue_depth,
+			'queue_mode'  => $queue_mode,
 		);
 	}
 
 	return array(
-		'slot'          => 'none',
-		'value'         => '',
-		'queue_depth'   => $queue_depth,
-		'queue_enabled' => $queue_enabled,
+		'slot'        => 'none',
+		'value'       => '',
+		'queue_depth' => $queue_depth,
+		'queue_mode'  => $queue_mode,
 	);
 }
 
-$tests   = array();
-$failed  = 0;
-$total   = 0;
+$failed = 0;
+$total  = 0;
 
 function assert_test( string $name, bool $cond, string $detail = '' ): void {
 	global $failed, $total;
@@ -151,8 +170,8 @@ function assert_test( string $name, bool $cond, string $detail = '' ): void {
 	}
 }
 
-// --- Case 1: CLI maps --set-user-message to the user_message input.
-echo "Case 1: --set-user-message routes through user_message input\n";
+// --- Case 1: --set-user-message routes through user_message → prompt_queue.
+echo "Case 1: --set-user-message routes through user_message → 1-entry prompt_queue\n";
 
 $flow_step_config = array(
 	'step_type'       => 'ai',
@@ -160,9 +179,6 @@ $flow_step_config = array(
 	'handler_configs' => array(),
 );
 
-// Simulate FlowsCommand::updateFlow() building the ability input from
-// $assoc_args['set-user-message']. This is the exact shape the post-fix
-// CLI passes to UpdateFlowStepAbility::execute().
 $ability_input = array(
 	'flow_step_id' => 'pstep_1_uuid_1',
 	'user_message' => 'Per-flow task framing for the WC backfill.',
@@ -171,51 +187,37 @@ $ability_input = array(
 $result = apply_update_flow_step_for_test( $flow_step_config, $ability_input );
 
 assert_test(
-	'user_message lands at flow_step_config root',
-	( $result['user_message'] ?? null ) === 'Per-flow task framing for the WC backfill.',
-	'got: ' . var_export( $result['user_message'] ?? null, true )
+	'prompt_queue rewritten as 1-entry list',
+	1 === count( $result['prompt_queue'] ?? array() )
 );
 
 assert_test(
-	'handler_configs.ai.prompt is NOT written (the dead key from the bug)',
-	! isset( $result['handler_configs']['ai']['prompt'] ),
-	'unexpected dead-key write: ' . var_export( $result['handler_configs'], true )
+	'queue head matches input',
+	'Per-flow task framing for the WC backfill.' === ( $result['prompt_queue'][0]['prompt'] ?? null )
+);
+
+assert_test(
+	'queue_mode forced to static',
+	'static' === ( $result['queue_mode'] ?? null )
+);
+
+assert_test(
+	'NO user_message field written (collapsed)',
+	! array_key_exists( 'user_message', $result )
+);
+
+assert_test(
+	'handler_configs.ai.prompt is NOT written (the dead key from #1289)',
+	! isset( $result['handler_configs']['ai']['prompt'] )
 );
 
 assert_test(
 	'handler_configs remains empty when only user_message is set',
-	$result['handler_configs'] === array(),
-	'got: ' . var_export( $result['handler_configs'], true )
+	$result['handler_configs'] === array()
 );
 
-// --- Case 2: The pre-fix shape would have written to the dead key.
-//     Demonstrate that the OLD CLI path (handler_config => prompt) is
-//     visibly broken: it does NOT populate user_message.
-echo "\nCase 2: old broken shape (handler_config => prompt) is observably wrong\n";
-
-$broken_input = array(
-	'flow_step_id'   => 'pstep_1_uuid_1',
-	'handler_config' => array( 'prompt' => 'TEST' ),
-);
-
-$broken_result = apply_update_flow_step_for_test( $flow_step_config, $broken_input );
-
-assert_test(
-	'old shape writes to handler_configs.ai.prompt (the dead key)',
-	( $broken_result['handler_configs']['ai']['prompt'] ?? null ) === 'TEST',
-	'pre-fix behavior should still be reproducible to prove the bug shape; got: '
-		. var_export( $broken_result['handler_configs'], true )
-);
-
-assert_test(
-	'old shape leaves user_message unset (the silent failure)',
-	! isset( $broken_result['user_message'] ),
-	'old broken shape should NOT touch user_message; got: '
-		. var_export( $broken_result['user_message'] ?? null, true )
-);
-
-// --- Case 3: Existing handler_config writes still work for non-AI steps.
-echo "\nCase 3: handler_config writes still work for handler steps\n";
+// --- Case 2: handler_config writes still work for handler steps.
+echo "\nCase 2: handler_config writes still work for handler steps\n";
 
 $fetch_step_config = array(
 	'step_type'       => 'fetch',
@@ -233,23 +235,47 @@ $fetch_result = apply_update_flow_step_for_test( $fetch_step_config, $fetch_inpu
 
 assert_test(
 	'handler_config merges into handler_configs[<slug>]',
-	( $fetch_result['handler_configs']['reddit']['subreddit'] ?? null ) === 'WordPress',
-	'got: ' . var_export( $fetch_result['handler_configs'], true )
+	( $fetch_result['handler_configs']['reddit']['subreddit'] ?? null ) === 'WordPress'
 );
 
 assert_test(
-	'handler_config does NOT bleed into user_message',
-	! isset( $fetch_result['user_message'] ),
-	'got: ' . var_export( $fetch_result['user_message'] ?? null, true )
+	'handler_config does NOT bleed into prompt_queue',
+	! isset( $fetch_result['prompt_queue'] )
 );
 
-// --- Case 4: normalization exposes every prompt-input slot for `flow get`.
-echo "\nCase 4: flow get always renders user_message + prompt_queue + queue_enabled on AI steps\n";
+// --- Case 3: empty user_message clears the queue.
+echo "\nCase 3: empty user_message input clears the queue (legacy unset semantics)\n";
+
+$step_with_seeded_queue = array(
+	'step_type'    => 'ai',
+	'prompt_queue' => array(
+		array( 'prompt' => 'old prompt', 'added_at' => '2026-01-01T00:00:00Z' ),
+	),
+	'queue_mode'   => 'static',
+);
+
+$cleared = apply_update_flow_step_for_test( $step_with_seeded_queue, array(
+	'flow_step_id' => 'pstep_1_uuid_1',
+	'user_message' => '',
+) );
+
+assert_test(
+	'empty input clears prompt_queue',
+	array() === $cleared['prompt_queue']
+);
+
+assert_test(
+	'queue_mode still set to static after clear',
+	'static' === $cleared['queue_mode']
+);
+
+// --- Case 4: normalization exposes prompt_queue + queue_mode for `flow get`.
+echo "\nCase 4: flow get always renders prompt_queue + queue_mode on AI steps\n";
 
 $flow_with_unset_slots = array(
 	'flow_id'     => 1,
 	'flow_config' => array(
-		'pstep_ai_uuid_1' => array(
+		'pstep_ai_uuid_1'    => array(
 			'step_type'       => 'ai',
 			'handler_slugs'   => array(),
 			'handler_configs' => array(),
@@ -265,32 +291,24 @@ $flow_with_unset_slots = array(
 $normalized = normalize_ai_prompt_slots_for_test( $flow_with_unset_slots );
 
 assert_test(
-	'AI step gets user_message="" when previously unset',
-	array_key_exists( 'user_message', $normalized['flow_config']['pstep_ai_uuid_1'] )
-		&& '' === $normalized['flow_config']['pstep_ai_uuid_1']['user_message'],
-	'got: ' . var_export( $normalized['flow_config']['pstep_ai_uuid_1'], true )
-);
-
-assert_test(
 	'AI step gets prompt_queue=[] when previously unset',
-	array_key_exists( 'prompt_queue', $normalized['flow_config']['pstep_ai_uuid_1'] )
-		&& array() === $normalized['flow_config']['pstep_ai_uuid_1']['prompt_queue'],
-	'got: ' . var_export( $normalized['flow_config']['pstep_ai_uuid_1']['prompt_queue'] ?? null, true )
+	array() === $normalized['flow_config']['pstep_ai_uuid_1']['prompt_queue']
 );
 
 assert_test(
-	'AI step gets queue_enabled=false when previously unset',
-	array_key_exists( 'queue_enabled', $normalized['flow_config']['pstep_ai_uuid_1'] )
-		&& false === $normalized['flow_config']['pstep_ai_uuid_1']['queue_enabled'],
-	'got: ' . var_export( $normalized['flow_config']['pstep_ai_uuid_1']['queue_enabled'] ?? null, true )
+	'AI step gets queue_mode=static when previously unset',
+	'static' === $normalized['flow_config']['pstep_ai_uuid_1']['queue_mode']
 );
 
 assert_test(
-	'non-AI step is NOT decorated with prompt slots',
-	! array_key_exists( 'user_message', $normalized['flow_config']['pstep_fetch_uuid_1'] )
-		&& ! array_key_exists( 'prompt_queue', $normalized['flow_config']['pstep_fetch_uuid_1'] )
-		&& ! array_key_exists( 'queue_enabled', $normalized['flow_config']['pstep_fetch_uuid_1'] ),
-	'got: ' . var_export( $normalized['flow_config']['pstep_fetch_uuid_1'], true )
+	'AI step does NOT regrow user_message slot',
+	! array_key_exists( 'user_message', $normalized['flow_config']['pstep_ai_uuid_1'] )
+);
+
+assert_test(
+	'fetch step gets config_patch_queue=[] + queue_mode=static when previously unset',
+	array() === $normalized['flow_config']['pstep_fetch_uuid_1']['config_patch_queue']
+		&& 'static' === $normalized['flow_config']['pstep_fetch_uuid_1']['queue_mode']
 );
 
 // --- Case 5: existing values are preserved by normalization.
@@ -300,20 +318,14 @@ $flow_with_set_values = array(
 	'flow_id'     => 2,
 	'flow_config' => array(
 		'pstep_ai_uuid_1' => array(
-			'step_type'     => 'ai',
-			'user_message'  => 'Existing per-flow context.',
-			'prompt_queue'  => array( array( 'prompt' => 'queued', 'added_at' => '2026-01-01T00:00:00Z' ) ),
-			'queue_enabled' => true,
+			'step_type'    => 'ai',
+			'prompt_queue' => array( array( 'prompt' => 'queued', 'added_at' => '2026-01-01T00:00:00Z' ) ),
+			'queue_mode'   => 'drain',
 		),
 	),
 );
 
 $preserved = normalize_ai_prompt_slots_for_test( $flow_with_set_values );
-
-assert_test(
-	'existing user_message preserved verbatim',
-	'Existing per-flow context.' === $preserved['flow_config']['pstep_ai_uuid_1']['user_message']
-);
 
 assert_test(
 	'existing prompt_queue preserved verbatim',
@@ -322,8 +334,8 @@ assert_test(
 );
 
 assert_test(
-	'existing queue_enabled preserved verbatim',
-	true === $preserved['flow_config']['pstep_ai_uuid_1']['queue_enabled']
+	'existing queue_mode preserved verbatim',
+	'drain' === $preserved['flow_config']['pstep_ai_uuid_1']['queue_mode']
 );
 
 // --- Case 6: empty/missing flow_config doesn't blow up normalization.
@@ -351,27 +363,26 @@ assert_test(
 		);
 		$out = normalize_ai_prompt_slots_for_test( $flow );
 		return $out['flow_config']['memory_files'] === array( 'a.md' )
-			&& '' === $out['flow_config']['pstep_ai_uuid_1']['user_message'];
+			&& 'static' === $out['flow_config']['pstep_ai_uuid_1']['queue_mode'];
 	})()
 );
 
 // --- Case 7: resolver picks queue_head when prompt_queue has entries.
-echo "\nCase 7: resolveAiStepActivePrompt — queue head wins over user_message\n";
+echo "\nCase 7: resolveAiStepActivePrompt — queue head is the only source\n";
 
-$step_with_queue_and_message = array(
-	'step_type'     => 'ai',
-	'user_message'  => 'fallback per-flow context',
-	'prompt_queue'  => array(
+$step_with_queue = array(
+	'step_type'    => 'ai',
+	'prompt_queue' => array(
 		array( 'prompt' => 'first queued', 'added_at' => '2026-01-01T00:00:00Z' ),
 		array( 'prompt' => 'second queued', 'added_at' => '2026-01-02T00:00:00Z' ),
 	),
-	'queue_enabled' => false,
+	'queue_mode'   => 'static',
 );
 
-$resolved = resolve_ai_active_prompt_for_test( $step_with_queue_and_message );
+$resolved = resolve_ai_active_prompt_for_test( $step_with_queue );
 
 assert_test(
-	'queue head takes precedence over user_message',
+	'queue head resolves to queue_head slot',
 	'queue_head' === $resolved['slot'] && 'first queued' === $resolved['value']
 );
 
@@ -381,116 +392,107 @@ assert_test(
 );
 
 assert_test(
-	'queue_enabled=false surfaced unchanged',
-	false === $resolved['queue_enabled']
+	'queue_mode surfaced unchanged',
+	'static' === $resolved['queue_mode']
 );
 
-// --- Case 8: queue_enabled=true with non-empty queue still picks queue_head.
-echo "\nCase 8: resolveAiStepActivePrompt — queue_enabled=true + non-empty\n";
+// --- Case 8: drain mode + non-empty queue still resolves to queue_head.
+echo "\nCase 8: resolveAiStepActivePrompt — drain mode + non-empty queue\n";
 
 $step_drains_mode = array(
-	'step_type'     => 'ai',
-	'user_message'  => 'fallback',
-	'prompt_queue'  => array( array( 'prompt' => 'drains tick', 'added_at' => '2026-01-01T00:00:00Z' ) ),
-	'queue_enabled' => true,
+	'step_type'    => 'ai',
+	'prompt_queue' => array( array( 'prompt' => 'drain tick', 'added_at' => '2026-01-01T00:00:00Z' ) ),
+	'queue_mode'   => 'drain',
 );
 
 $resolved = resolve_ai_active_prompt_for_test( $step_drains_mode );
 
 assert_test(
-	'drains-mode queue head still resolves to queue_head slot',
-	'queue_head' === $resolved['slot'] && 'drains tick' === $resolved['value']
+	'drain-mode queue head resolves to queue_head slot',
+	'queue_head' === $resolved['slot'] && 'drain tick' === $resolved['value']
 );
 
 assert_test(
-	'queue_enabled=true surfaced unchanged',
-	true === $resolved['queue_enabled']
+	'queue_mode=drain surfaced unchanged',
+	'drain' === $resolved['queue_mode']
 );
 
-// --- Case 9: empty queue falls back to user_message.
-echo "\nCase 9: resolveAiStepActivePrompt — empty queue falls back to user_message\n";
-
-$step_message_only = array(
-	'step_type'     => 'ai',
-	'user_message'  => 'per-flow framing',
-	'prompt_queue'  => array(),
-	'queue_enabled' => false,
-);
-
-$resolved = resolve_ai_active_prompt_for_test( $step_message_only );
-
-assert_test(
-	'empty queue → user_message slot',
-	'user_message' === $resolved['slot'] && 'per-flow framing' === $resolved['value']
-);
-
-assert_test(
-	'queue_depth=0 reported when queue is empty',
-	0 === $resolved['queue_depth']
-);
-
-// --- Case 10: queue head with empty string falls through to user_message.
-//     This matches AIStep::execute() behavior: empty $queued_prompt
-//     triggers the `if ( empty( $user_message ) )` fallback.
-echo "\nCase 10: resolveAiStepActivePrompt — empty-string queue head falls through\n";
-
-$step_empty_head = array(
-	'step_type'     => 'ai',
-	'user_message'  => 'message wins when head is empty string',
-	'prompt_queue'  => array( array( 'prompt' => '', 'added_at' => '2026-01-01T00:00:00Z' ) ),
-	'queue_enabled' => false,
-);
-
-$resolved = resolve_ai_active_prompt_for_test( $step_empty_head );
-
-assert_test(
-	'empty-string queue head falls through to user_message',
-	'user_message' === $resolved['slot']
-		&& 'message wins when head is empty string' === $resolved['value']
-);
-
-// --- Case 11: nothing set anywhere yields slot=none.
-echo "\nCase 11: resolveAiStepActivePrompt — nothing set yields slot=none\n";
+// --- Case 9: empty queue yields slot=none.
+echo "\nCase 9: resolveAiStepActivePrompt — empty queue yields slot=none\n";
 
 $step_empty = array(
-	'step_type'     => 'ai',
-	'user_message'  => '',
-	'prompt_queue'  => array(),
-	'queue_enabled' => false,
+	'step_type'    => 'ai',
+	'prompt_queue' => array(),
+	'queue_mode'   => 'static',
 );
 
 $resolved = resolve_ai_active_prompt_for_test( $step_empty );
 
 assert_test(
-	'all slots empty → slot=none',
+	'empty queue → slot=none',
 	'none' === $resolved['slot'] && '' === $resolved['value']
 );
 
 assert_test(
-	'all slots empty → queue_depth=0',
+	'empty queue → queue_depth=0',
 	0 === $resolved['queue_depth']
 );
 
-// --- Case 12: malformed prompt_queue (non-array) is null-safe.
-echo "\nCase 12: resolveAiStepActivePrompt — null-safe on malformed data\n";
+// --- Case 10: queue head with empty string yields slot=none.
+echo "\nCase 10: resolveAiStepActivePrompt — empty-string queue head yields slot=none\n";
+
+$step_empty_head = array(
+	'step_type'    => 'ai',
+	'prompt_queue' => array( array( 'prompt' => '', 'added_at' => '2026-01-01T00:00:00Z' ) ),
+	'queue_mode'   => 'static',
+);
+
+$resolved = resolve_ai_active_prompt_for_test( $step_empty_head );
+
+assert_test(
+	'empty-string queue head → slot=none (no fallback to dead user_message)',
+	'none' === $resolved['slot']
+);
+
+// --- Case 11: malformed prompt_queue (non-array) is null-safe.
+echo "\nCase 11: resolveAiStepActivePrompt — null-safe on malformed data\n";
 
 $step_malformed = array(
-	'step_type'     => 'ai',
-	'user_message'  => 'still works',
-	'prompt_queue'  => 'not an array',
-	'queue_enabled' => false,
+	'step_type'    => 'ai',
+	'prompt_queue' => 'not an array',
+	'queue_mode'   => 'static',
 );
 
 $resolved = resolve_ai_active_prompt_for_test( $step_malformed );
 
 assert_test(
-	'malformed prompt_queue → falls back to user_message',
-	'user_message' === $resolved['slot'] && 'still works' === $resolved['value']
+	'malformed prompt_queue → slot=none',
+	'none' === $resolved['slot']
 );
 
 assert_test(
 	'malformed prompt_queue → queue_depth=0',
 	0 === $resolved['queue_depth']
+);
+
+// --- Case 12: missing queue_mode defaults to static (matches loadFlowAndStepConfig).
+echo "\nCase 12: resolveAiStepActivePrompt — missing queue_mode defaults to static\n";
+
+$step_no_mode = array(
+	'step_type'    => 'ai',
+	'prompt_queue' => array( array( 'prompt' => 'pinned', 'added_at' => '2026-01-01T00:00:00Z' ) ),
+);
+
+$resolved = resolve_ai_active_prompt_for_test( $step_no_mode );
+
+assert_test(
+	'missing queue_mode → static default',
+	'static' === $resolved['queue_mode']
+);
+
+assert_test(
+	'queue head still resolves',
+	'queue_head' === $resolved['slot'] && 'pinned' === $resolved['value']
 );
 
 echo "\n--- Summary ---\n";

--- a/tests/queue-mode-collapse-smoke.php
+++ b/tests/queue-mode-collapse-smoke.php
@@ -1,0 +1,551 @@
+<?php
+/**
+ * Pure-PHP smoke test for the user_message → queue_mode collapse (#1291).
+ *
+ * Run with: php tests/queue-mode-collapse-smoke.php
+ *
+ * Pre-#1291 AIStep had two storage slots feeding the same per-flow
+ * user-role message:
+ *
+ *   - flow_step_config[step_id].user_message   (single string)
+ *   - flow_step_config[step_id].prompt_queue   (array of {prompt, added_at})
+ *
+ * paired with a `queue_enabled` boolean. Post-#1291 the only AI prompt
+ * slot is `prompt_queue` and the access pattern is named explicitly via
+ * a `queue_mode` enum: drain | loop | static.
+ *
+ * The byte-mirror harness inlines the relevant slices of the real code
+ * so divergence between this file and production is caught by failing
+ * assertions.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'gmdate' ) ) {
+	// Defensive — gmdate is a PHP built-in but we need to be sure.
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $options = 0, int $depth = 512 ): string {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ): void {
+		// no-op for tests; logged migrations aren't observable here.
+	}
+}
+
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+	function sanitize_textarea_field( $value ) {
+		return trim( (string) $value );
+	}
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+	function wp_unslash( $value ) {
+		return is_string( $value ) ? stripslashes( $value ) : $value;
+	}
+}
+
+$failed = 0;
+$total  = 0;
+
+function assert_collapse( string $name, bool $cond, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $cond ) {
+		echo "  [PASS] $name\n";
+	} else {
+		echo "  [FAIL] $name" . ( $detail ? " — $detail" : '' ) . "\n";
+		++$failed;
+	}
+}
+
+/**
+ * Inline mirror of inc/migrations/user-message-queue-mode.php, walking
+ * one flow_config and applying the same transforms in-process so we can
+ * assert on every observable behaviour without booting WordPress.
+ *
+ * Mirrors `datamachine_migrate_user_message_queue_mode()` exactly. Any
+ * divergence here means production regressed.
+ *
+ * Returns [ migrated_flow_config, dropped_user_messages, seeded_user_messages ].
+ */
+function migrate_collapse_for_test( array $flow_config ): array {
+	$dropped = 0;
+	$seeded  = 0;
+
+	foreach ( $flow_config as $step_id => &$step ) {
+		if ( ! is_array( $step ) ) {
+			continue;
+		}
+
+		$step_type         = $step['step_type'] ?? '';
+		$has_queue_enabled = array_key_exists( 'queue_enabled', $step );
+		$has_user_message  = array_key_exists( 'user_message', $step );
+
+		if ( ! $has_queue_enabled && ! $has_user_message ) {
+			continue;
+		}
+
+		$queue_enabled = $has_queue_enabled ? (bool) $step['queue_enabled'] : false;
+		$queue_mode    = $queue_enabled ? 'drain' : 'static';
+
+		$step['queue_mode'] = $queue_mode;
+
+		if ( 'ai' === $step_type && $has_user_message ) {
+			$user_message = is_string( $step['user_message'] ) ? trim( $step['user_message'] ) : '';
+			$queue        = isset( $step['prompt_queue'] ) && is_array( $step['prompt_queue'] )
+				? $step['prompt_queue']
+				: array();
+
+			if ( '' !== $user_message ) {
+				if ( empty( $queue ) ) {
+					$step['prompt_queue'] = array(
+						array(
+							'prompt'   => $user_message,
+							'added_at' => '2026-04-26T00:00:00+00:00',
+						),
+					);
+					$step['queue_mode'] = 'static';
+					++$seeded;
+				} else {
+					// Both populated: kept queue, dropped user_message.
+					$step['queue_mode'] = 'static';
+					++$dropped;
+				}
+			}
+		}
+
+		unset( $step['user_message'] );
+		unset( $step['queue_enabled'] );
+	}
+	unset( $step );
+
+	return array( $flow_config, $dropped, $seeded );
+}
+
+/**
+ * Inline mirror of QueueableTrait::consumeFromQueueSlot logic for tests.
+ * Returns [updated_queue, consumed_entry_or_null, mutated_bool].
+ */
+function consume_for_test( array $queue, string $queue_mode ): array {
+	if ( empty( $queue ) ) {
+		return array( $queue, null, 'static' !== $queue_mode );
+	}
+
+	if ( 'static' === $queue_mode ) {
+		return array( $queue, $queue[0], false );
+	}
+
+	$entry = array_shift( $queue );
+
+	if ( 'loop' === $queue_mode ) {
+		$queue[] = $entry;
+	}
+
+	return array( $queue, $entry, true );
+}
+
+/**
+ * Inline mirror of FlowStepHelpers::updateUserMessage post-#1291. The
+ * helper is repurposed: the dedicated user_message slot is gone, the
+ * helper rewrites prompt_queue + queue_mode instead.
+ */
+function update_user_message_for_test( array $flow_step_config, string $user_message ): array {
+	$sanitized = trim( (string) $user_message );
+
+	if ( '' === $sanitized ) {
+		$flow_step_config['prompt_queue'] = array();
+	} else {
+		$flow_step_config['prompt_queue'] = array(
+			array(
+				'prompt'   => $sanitized,
+				'added_at' => '2026-04-26T00:00:00+00:00',
+			),
+		);
+	}
+	$flow_step_config['queue_mode'] = 'static';
+
+	// Critical: no user_message field stored anywhere.
+	unset( $flow_step_config['user_message'] );
+
+	return $flow_step_config;
+}
+
+/**
+ * Inline mirror of QueueAbility::executeQueueMode validation.
+ */
+function queue_mode_validate_for_test( $mode ): array {
+	if ( ! is_string( $mode ) || ! in_array( $mode, array( 'drain', 'loop', 'static' ), true ) ) {
+		return array(
+			'success' => false,
+			'error'   => 'mode must be one of: drain, loop, static',
+		);
+	}
+	return array(
+		'success'    => true,
+		'queue_mode' => $mode,
+	);
+}
+
+echo "=== queue-mode-collapse-smoke ===\n";
+
+// =====================================================================
+// Migration tests
+// =====================================================================
+
+echo "\n[migration:1] queue_enabled=true → queue_mode=drain on AI step\n";
+$flow_config = array(
+	'ai_step_42' => array(
+		'step_type'     => 'ai',
+		'user_message'  => '',
+		'queue_enabled' => true,
+		'prompt_queue'  => array(
+			array( 'prompt' => 'hello', 'added_at' => 'x' ),
+		),
+	),
+);
+[ $migrated, $dropped, $seeded ] = migrate_collapse_for_test( $flow_config );
+assert_collapse(
+	'queue_enabled=true resolved to drain',
+	'drain' === ( $migrated['ai_step_42']['queue_mode'] ?? '' ),
+	'mode=' . ( $migrated['ai_step_42']['queue_mode'] ?? 'NULL' )
+);
+assert_collapse(
+	'user_message stripped',
+	! array_key_exists( 'user_message', $migrated['ai_step_42'] )
+);
+assert_collapse(
+	'queue_enabled stripped',
+	! array_key_exists( 'queue_enabled', $migrated['ai_step_42'] )
+);
+assert_collapse(
+	'prompt_queue preserved as-is',
+	1 === count( $migrated['ai_step_42']['prompt_queue'] )
+		&& 'hello' === $migrated['ai_step_42']['prompt_queue'][0]['prompt']
+);
+assert_collapse( 'no user_message seeded for empty user_message', 0 === $seeded );
+assert_collapse( 'no user_message dropped (was empty)', 0 === $dropped );
+
+echo "\n[migration:2] queue_enabled=false + non-empty queue → queue_mode=static (named stockpile)\n";
+$flow_config = array(
+	'ai_step_42' => array(
+		'step_type'     => 'ai',
+		'user_message'  => '',
+		'queue_enabled' => false,
+		'prompt_queue'  => array(
+			array( 'prompt' => 'first', 'added_at' => 'a' ),
+			array( 'prompt' => 'second', 'added_at' => 'b' ),
+			array( 'prompt' => 'third', 'added_at' => 'c' ),
+		),
+	),
+);
+[ $migrated ] = migrate_collapse_for_test( $flow_config );
+assert_collapse(
+	'static mode preserves first-entry-wins-every-tick',
+	'static' === ( $migrated['ai_step_42']['queue_mode'] ?? '' )
+);
+assert_collapse(
+	'all 3 stockpile entries preserved',
+	3 === count( $migrated['ai_step_42']['prompt_queue'] )
+);
+
+echo "\n[migration:3] empty prompt_queue + non-empty user_message → 1-entry static queue\n";
+$flow_config = array(
+	'ai_step_42' => array(
+		'step_type'     => 'ai',
+		'user_message'  => 'My per-flow framing prompt',
+		'queue_enabled' => false,
+		'prompt_queue'  => array(),
+	),
+);
+[ $migrated, $dropped, $seeded ] = migrate_collapse_for_test( $flow_config );
+assert_collapse(
+	'user_message seeded into 1-entry queue',
+	1 === count( $migrated['ai_step_42']['prompt_queue'] )
+		&& 'My per-flow framing prompt' === $migrated['ai_step_42']['prompt_queue'][0]['prompt']
+);
+assert_collapse(
+	'mode forced to static',
+	'static' === $migrated['ai_step_42']['queue_mode']
+);
+assert_collapse( 'seeded counter incremented', 1 === $seeded );
+assert_collapse( 'dropped counter not touched', 0 === $dropped );
+assert_collapse(
+	'user_message field gone',
+	! array_key_exists( 'user_message', $migrated['ai_step_42'] )
+);
+
+echo "\n[migration:4] both prompt_queue and user_message non-empty → keep queue, drop user_message\n";
+$flow_config = array(
+	'ai_step_42' => array(
+		'step_type'     => 'ai',
+		'user_message'  => 'shadowed legacy message',
+		'queue_enabled' => true,
+		'prompt_queue'  => array(
+			array( 'prompt' => 'queued head wins', 'added_at' => 'x' ),
+		),
+	),
+);
+[ $migrated, $dropped, $seeded ] = migrate_collapse_for_test( $flow_config );
+assert_collapse(
+	'queue preserved as-is',
+	1 === count( $migrated['ai_step_42']['prompt_queue'] )
+		&& 'queued head wins' === $migrated['ai_step_42']['prompt_queue'][0]['prompt']
+);
+assert_collapse(
+	'mode forced to static (preserves observable behaviour)',
+	'static' === $migrated['ai_step_42']['queue_mode']
+);
+assert_collapse( 'dropped counter incremented', 1 === $dropped );
+assert_collapse( 'seeded counter not touched', 0 === $seeded );
+assert_collapse(
+	'user_message dropped',
+	! array_key_exists( 'user_message', $migrated['ai_step_42'] )
+);
+
+echo "\n[migration:5] FetchStep with queue_enabled=true → queue_mode=drain, no user_message handling\n";
+$flow_config = array(
+	'fetch_step_99' => array(
+		'step_type'          => 'fetch',
+		'queue_enabled'      => true,
+		'config_patch_queue' => array(
+			array( 'patch' => array( 'after' => '2017-01-01' ), 'added_at' => 'x' ),
+		),
+	),
+);
+[ $migrated ] = migrate_collapse_for_test( $flow_config );
+assert_collapse(
+	'fetch step gets drain mode',
+	'drain' === ( $migrated['fetch_step_99']['queue_mode'] ?? '' )
+);
+assert_collapse(
+	'fetch step queue_enabled stripped',
+	! array_key_exists( 'queue_enabled', $migrated['fetch_step_99'] )
+);
+assert_collapse(
+	'fetch step config_patch_queue preserved',
+	1 === count( $migrated['fetch_step_99']['config_patch_queue'] )
+);
+
+echo "\n[migration:6] idempotent — running migration twice = same result\n";
+$flow_config = array(
+	'ai_step_42' => array(
+		'step_type'     => 'ai',
+		'user_message'  => 'seed me',
+		'queue_enabled' => false,
+		'prompt_queue'  => array(),
+	),
+);
+[ $first ] = migrate_collapse_for_test( $flow_config );
+[ $second ] = migrate_collapse_for_test( $first );
+assert_collapse( 'second run is no-op (no queue_enabled to flip)', $first === $second );
+
+echo "\n[migration:7] non-queueable steps left untouched\n";
+$flow_config = array(
+	'publish_step_1' => array(
+		'step_type'      => 'publish',
+		'handler_slugs'  => array( 'wordpress' ),
+		'handler_configs' => array( 'wordpress' => array( 'post_type' => 'post' ) ),
+	),
+);
+[ $migrated ] = migrate_collapse_for_test( $flow_config );
+assert_collapse(
+	'publish step config unchanged',
+	$flow_config === $migrated
+);
+
+// =====================================================================
+// Mode-aware consumption tests
+// =====================================================================
+
+echo "\n[consume:1] drain mode pops queue head per tick\n";
+$queue = array(
+	array( 'prompt' => 'a', 'added_at' => '1' ),
+	array( 'prompt' => 'b', 'added_at' => '2' ),
+	array( 'prompt' => 'c', 'added_at' => '3' ),
+);
+[ $q1, $entry1, $mut1 ] = consume_for_test( $queue, 'drain' );
+assert_collapse( 'first drain consumes a', 'a' === $entry1['prompt'] );
+assert_collapse( 'first drain mutates', true === $mut1 );
+[ $q2, $entry2 ] = consume_for_test( $q1, 'drain' );
+assert_collapse( 'second drain consumes b', 'b' === $entry2['prompt'] );
+[ $q3, $entry3 ] = consume_for_test( $q2, 'drain' );
+assert_collapse( 'third drain consumes c', 'c' === $entry3['prompt'] );
+[ $q4, $entry4 ] = consume_for_test( $q3, 'drain' );
+assert_collapse( 'fourth drain returns null (empty)', null === $entry4 );
+
+echo "\n[consume:2] loop mode pops + appends — queue rotates back to original after N ticks\n";
+$queue   = array(
+	array( 'prompt' => 'a', 'added_at' => '1' ),
+	array( 'prompt' => 'b', 'added_at' => '2' ),
+	array( 'prompt' => 'c', 'added_at' => '3' ),
+);
+$current = $queue;
+$entries = array();
+for ( $i = 0; $i < 6; ++$i ) {
+	[ $current, $e ] = consume_for_test( $current, 'loop' );
+	$entries[]       = $e['prompt'];
+}
+assert_collapse(
+	'loop sequence cycles a,b,c,a,b,c after 6 ticks',
+	array( 'a', 'b', 'c', 'a', 'b', 'c' ) === $entries
+);
+assert_collapse(
+	'loop queue back to original shape after 3 ticks',
+	count( $current ) === count( $queue )
+);
+
+echo "\n[consume:3] static mode peeks — queue unchanged after tick\n";
+$queue   = array(
+	array( 'prompt' => 'pinned', 'added_at' => '1' ),
+	array( 'prompt' => 'staged_b', 'added_at' => '2' ),
+);
+[ $after, $entry, $mut ] = consume_for_test( $queue, 'static' );
+assert_collapse( 'static consumes head', 'pinned' === $entry['prompt'] );
+assert_collapse( 'static does not mutate', false === $mut );
+assert_collapse( 'static queue unchanged', $after === $queue );
+
+echo "\n[consume:4] static mode + multi-entry queue: position 0 fires every tick\n";
+$queue = array(
+	array( 'prompt' => 'iterating', 'added_at' => '1' ),
+	array( 'prompt' => 'staged_next', 'added_at' => '2' ),
+	array( 'prompt' => 'staged_after', 'added_at' => '3' ),
+);
+$picked = array();
+for ( $i = 0; $i < 4; ++$i ) {
+	[ $queue, $e ] = consume_for_test( $queue, 'static' );
+	$picked[]      = $e['prompt'];
+}
+assert_collapse(
+	'iterative-dev pattern: head fires forever',
+	array( 'iterating', 'iterating', 'iterating', 'iterating' ) === $picked
+);
+
+echo "\n[consume:5] empty queue + drain → null + mutated:true (signal no-items)\n";
+[ $q, $e, $mut ] = consume_for_test( array(), 'drain' );
+assert_collapse( 'empty drain returns null entry', null === $e );
+assert_collapse( 'empty drain signals mutation intent (caller should skip)', true === $mut );
+
+echo "\n[consume:6] empty queue + static → null + mutated:false (fallthrough)\n";
+[ $q, $e, $mut ] = consume_for_test( array(), 'static' );
+assert_collapse( 'empty static returns null entry', null === $e );
+assert_collapse( 'empty static signals no mutation (caller falls through)', false === $mut );
+
+// =====================================================================
+// updateUserMessage shim tests
+// =====================================================================
+
+echo "\n[shim:1] user_message=\"X\" writes 1-entry static queue\n";
+$step = array(
+	'step_type' => 'ai',
+);
+$updated = update_user_message_for_test( $step, 'My new message' );
+assert_collapse(
+	'prompt_queue is 1-entry list',
+	1 === count( $updated['prompt_queue'] )
+);
+assert_collapse(
+	'queue head matches input',
+	'My new message' === $updated['prompt_queue'][0]['prompt']
+);
+assert_collapse(
+	'queue mode is static',
+	'static' === $updated['queue_mode']
+);
+assert_collapse(
+	'no user_message field stored',
+	! array_key_exists( 'user_message', $updated )
+);
+
+echo "\n[shim:2] user_message=\"\" clears queue (legacy unset semantics)\n";
+$step = array(
+	'step_type'    => 'ai',
+	'prompt_queue' => array(
+		array( 'prompt' => 'old prompt', 'added_at' => 'x' ),
+	),
+);
+$updated = update_user_message_for_test( $step, '' );
+assert_collapse( 'queue emptied', array() === $updated['prompt_queue'] );
+assert_collapse( 'mode set to static', 'static' === $updated['queue_mode'] );
+
+echo "\n[shim:3] update overwrites existing queue\n";
+$step = array(
+	'step_type'    => 'ai',
+	'prompt_queue' => array(
+		array( 'prompt' => 'first', 'added_at' => 'a' ),
+		array( 'prompt' => 'second', 'added_at' => 'b' ),
+	),
+);
+$updated = update_user_message_for_test( $step, 'replacement' );
+assert_collapse(
+	'queue replaced with single entry',
+	1 === count( $updated['prompt_queue'] )
+		&& 'replacement' === $updated['prompt_queue'][0]['prompt']
+);
+
+// =====================================================================
+// QueueAbility::executeQueueMode validation tests
+// =====================================================================
+
+echo "\n[mode-validate:1] enum validation rejects unknown\n";
+$result = queue_mode_validate_for_test( 'invalid' );
+assert_collapse( 'unknown mode rejected', false === $result['success'] );
+
+echo "\n[mode-validate:2] each valid enum accepted\n";
+foreach ( array( 'drain', 'loop', 'static' ) as $mode ) {
+	$result = queue_mode_validate_for_test( $mode );
+	assert_collapse( "mode={$mode} accepted", true === $result['success'] );
+}
+
+echo "\n[mode-validate:3] non-string rejected\n";
+$result = queue_mode_validate_for_test( true );
+assert_collapse( 'boolean rejected', false === $result['success'] );
+
+// =====================================================================
+// AIStep collapsed precedence tests
+// =====================================================================
+
+echo "\n[aistep:1] empty queue + drain → COMPLETED_NO_ITEMS branch\n";
+// AIStep collapsed logic: $queue_mode picks consumption; empty queue +
+// (drain|loop) sets job_status=COMPLETED_NO_ITEMS.
+$queue_mode  = 'drain';
+$queue       = array();
+[ , $entry ] = consume_for_test( $queue, $queue_mode );
+$user_msg    = null !== $entry ? $entry['prompt'] : '';
+$should_skip = '' === $user_msg && in_array( $queue_mode, array( 'drain', 'loop' ), true );
+assert_collapse( 'empty drain triggers no-items skip branch', true === $should_skip );
+
+echo "\n[aistep:2] empty queue + static → fall through with empty user_message\n";
+$queue_mode  = 'static';
+$queue       = array();
+[ , $entry ] = consume_for_test( $queue, $queue_mode );
+$user_msg    = null !== $entry ? $entry['prompt'] : '';
+$should_skip = '' === $user_msg && in_array( $queue_mode, array( 'drain', 'loop' ), true );
+assert_collapse( 'empty static does not trigger skip', false === $should_skip );
+assert_collapse( 'static fallthrough yields empty user_message', '' === $user_msg );
+
+echo "\n[aistep:3] non-empty queue + drain → user_message comes from popped head\n";
+$queue       = array(
+	array( 'prompt' => 'tick-1 work', 'added_at' => 'x' ),
+	array( 'prompt' => 'tick-2 work', 'added_at' => 'y' ),
+);
+[ $after, $entry ] = consume_for_test( $queue, 'drain' );
+assert_collapse( 'drain returns first entry', 'tick-1 work' === $entry['prompt'] );
+assert_collapse( 'drain mutates queue (length 1 remaining)', 1 === count( $after ) );
+
+// =====================================================================
+
+echo "\n";
+if ( 0 === $failed ) {
+	echo "=== queue-mode-collapse-smoke: ALL PASS ({$total}) ===\n";
+	exit( 0 );
+}
+echo "=== queue-mode-collapse-smoke: {$failed} FAIL of {$total} ===\n";
+exit( 1 );


### PR DESCRIPTION
Closes #1291.

## Summary

AIStep had two physically-separate storage slots feeding the same per-flow user-role message — `user_message` (single string) and `prompt_queue` (list) — paired with a `queue_enabled` boolean that conflated step eligibility with access pattern. AIStep::execute() walked a 30-line precedence chain to resolve them.

This collapse names the access pattern explicitly via a `queue_mode` enum on every queueable step, deletes the `user_message` slot, and routes the legacy `--set-user-message` flag through the unified `prompt_queue` storage as a 1-entry static queue.

| Mode | Behaviour | AIStep use case | FetchStep use case |
|---|---|---|---|
| `drain` | Pop head per tick, discard. Empty → `COMPLETED_NO_ITEMS`. | Backfill prompts. | Windowed historical backfill. |
| `loop` | Pop head per tick, append to tail. Queue rotates indefinitely. | Cycle through N prompts forever. | Rotate fetch source configs. |
| `static` | Peek head every tick, do not mutate. Position 0 active; positions 1..N stay staged. | Single prompt OR manual stockpile. The `user_message` replacement. | Iterative flow development — pin position 0 while staging the next patches. |

Position 0 is always the active entry; the mode only decides what happens to position 0 *after* the tick. Same enum drives both `prompt_queue` (AI) and `config_patch_queue` (Fetch) — split by #1294, mode-unified here.

## Changes

### Storage shape

```
flow_step_config[step_id].prompt_queue:        [ {prompt, added_at}, ... ]   // AI consumer
flow_step_config[step_id].config_patch_queue:  [ {patch, added_at}, ... ]    // Fetch consumer (per #1294)
flow_step_config[step_id].queue_mode:          "drain" | "loop" | "static"   // NEW — replaces queue_enabled
```

The `user_message` field is **deleted** from AI steps. The `queue_enabled` boolean is **deleted** from every queueable step. No runtime fallback shim — per the no-shim rule.

### Code

- `QueueableTrait` rewired: `popFromQueueIfEmpty()` / `popQueuedConfigPatch()` → `consumeFromPromptQueue($mode)` / `consumeFromConfigPatchQueue($mode)`. Drain pops, loop pops+appends, static peeks. Engine-data backup only when the consumption mutates storage.
- `AIStep::execute()` — 30-line precedence chain → mode-driven `consumeFromPromptQueue($queue_mode)` + empty-queue short-circuit (drain/loop → `COMPLETED_NO_ITEMS`; static → fall through with empty user_message).
- `FetchStep::executeStep()` — same shape against `config_patch_queue`. Static + empty queue falls through to unmerged static handler config.
- `FlowStepHelpers::updateUserMessage()` repurposed: input is preserved, the helper now rewrites `prompt_queue` as a 1-entry static queue. No `user_message` field is stored anywhere.
- `QueueAbility::registerQueueSettings()` → `registerQueueMode()` (input enum: drain | loop | static). `executeQueueSettings()` → `executeQueueMode()`.
- `loadFlowAndStepConfig()` defaults `queue_mode` to `"static"` instead of `queue_enabled` to `false`.
- `AgentPingTask` now reads `queue_mode` and supports drain/loop via `QueueAbility::popFromQueue` (drain) and new `QueueAbility::loopFromQueue` (loop).
- `SystemTaskStep` propagates `queue_mode` to child engine_data instead of `queue_enabled`.
- `FlowHelpers::createDefaultFlowConfigForPipeline()` scaffolds `queue_mode: "static"` instead of `queue_enabled: false`.
- `AgentModeDirective` wording: "flow user_message" → "the queue head (the per-flow user message)".

### CLI

| Old | New |
|---|---|
| `flow queue settings --queue-enabled=true\|false` | `flow queue mode <drain\|loop\|static>` |
| `flow update --set-user-message="X"` | Same flag — routes through queue replace internally. |
| `flow queue list` output: `queue_enabled: yes/no` | `queue_mode: drain/loop/static` |
| `flow get` AI step: `user_message=...` line | Gone. `queue_mode=...` + `active_prompt=...` only. |

`flow update --set-prompt` was already removed in #1290 (clean break, no alias).

### REST API

- `PUT /flows/{id}/queue/settings` → `PUT /flows/{id}/queue/mode`
- Request body `queue_enabled: bool` → `mode: "drain" | "loop" | "static"`
- Response body `queue_enabled: bool` → `queue_mode: string`

### Chat tools

- `manage_queue` action `"settings"` → `"mode"`
- Parameter `queue_enabled` (bool) → `mode` (enum)

### React UI

**Out of scope.** The `UpdateFlowStepAbility::user_message` input parameter shim keeps the React save path working unchanged. Follow-up issue should route React through a dedicated `queue-replace` ability and remove the `user_message` parameter from the public ability input.

## Migration

`inc/migrations/user-message-queue-mode.php` — idempotent, gated on `datamachine_user_message_collapsed`. Mirrors the shape of `split-queue-payload.php` (#1294) and `ai-enabled-tools.php` (#1216).

For every flow_config in every flow, for every step:

1. **Resolve `queue_enabled` → `queue_mode`:**
   - `true` → `queue_mode = "drain"` (pop-per-tick preserved)
   - `false` (or unset) → `queue_mode = "static"` (peek-without-pop preserved; multi-entry case named explicitly as the manual stockpile pattern)
2. **AI-step-only handling for `user_message`:**
   - empty `prompt_queue` + non-empty `user_message` → seed `[{prompt: user_message, added_at: now()}]`, force `queue_mode = "static"`
   - both populated → keep queue, force `queue_mode = "static"`, drop `user_message`, log dropped value at info level for traceability (queue head was already winning at runtime)
   - empty `user_message` → just unset the dead key, nothing to seed
3. **Always:** `unset($step['user_message'])`, `unset($step['queue_enabled'])`.

`loop` mode is **net-new** on both consumers — no flow gets it from migration; opt-in via `flow queue mode <id> loop`.

Fetch steps have no `user_message` to migrate (per #1294 the only fetch slot is `config_patch_queue`). Migration just resolves the boolean and drops the dead key.

The migration is fully behaviour-preserving: every flow continues to produce the same per-tick output (role:user content for AI, merged config for Fetch).

## Tests

### `tests/queue-mode-collapse-smoke.php` (NEW)

55 assertions across:

- **Migration (7 cases):** boolean → mode resolution, user_message seeding, both-populated drop, fetch step handling, idempotency, non-queueable steps untouched.
- **Mode-aware consumption (6 cases):** drain pops sequentially, loop rotates queue back to original after N ticks, static peeks without mutation, multi-entry static = position 0 fires every tick (iterative-dev pattern), empty-queue branching for drain (mutated:true → caller skips) and static (mutated:false → fallthrough).
- **`updateUserMessage` shim (3 cases):** `user_message="X"` writes 1-entry static queue with no user_message field stored, empty input clears queue, existing queue overwritten.
- **`executeQueueMode` validation (3 cases):** enum rejects unknown, accepts each valid value, rejects non-string.
- **AIStep collapsed precedence (3 cases):** empty drain triggers no-items skip, empty static falls through, non-empty drain pops head and mutates queue.

### `tests/flow-update-set-user-message-smoke.php` (REWRITTEN)

31 assertions rewritten for the post-collapse shape: `--set-user-message` writes prompt_queue (not user_message slot), normalization defaults queue_mode=static, resolveAiStepActivePrompt is queue-only (no user_message fallback).

### Pre-existing smokes

All 19 other pure-PHP smokes still pass:
`ai-enabled-tools-smoke`, `batch-child-agent-id-smoke`, `daily-memory-conservation-smoke`, `exclude-keywords-smoke`, `jobs-command-undo-fanout-smoke`, `jobs-get-children-smoke`, `logger-agent-id-resolution-smoke`, `merge-term-meta-smoke`, `meta-description-post-types-filter-smoke`, `processed-items-flow-step-parse-smoke`, `queue-payload-split-smoke`, `queueable-trait-smoke`, `resolve-term-args-smoke`, `system-task-agent-context-smoke`, `system-task-config-passthrough-smoke`, `system-task-workflow-validation-smoke`, `task-scheduler-batch-parent-link-smoke`, `tool-policy-resolver-adjacency-smoke`, `transcript-policy-smoke`.

## Live-verify

Pointed `intelligence-chubes4`'s data-machine plugin symlink at the worktree, re-activated, ran the migration, then exercised every CLI surface:

- `studio wp option get datamachine_user_message_collapsed` → `1` (migration ran)
- `flow get 2` post-migration: MCP fetch step `queue_mode: "drain"` (was `queue_enabled: true`); AI step `queue_mode: "static"` (was `queue_enabled: false`); no `user_message` or `queue_enabled` fields anywhere in the JSON.
- `flow queue mode 2 loop --step=<fetch_id>` → `Success: Queue mode set to loop.` (verified via `flow get` JSON)
- `flow update 2 --set-user-message="X" --step=<ai_id>` → wrote a 1-entry `prompt_queue` with `queue_mode: "static"`, no `user_message` field stored
- `flow queue add 2 "Y" --step=<ai_id>` + `flow queue list 2` → 1 prompt, `queue_mode: static` in footer
- `flow queue mode 2 invalid` → `Error: mode must be one of: drain, loop, static`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the migration, QueueableTrait rewire, AIStep/FetchStep collapse, ability + CLI surface refactor, and smoke tests against the design Chris settled in #1291. Chris drove the three-mode design (drain | loop | static) and the symmetric application to both AI and Fetch consumers; the agent translated that to code, validated the storage shape via byte-mirror smokes, and live-verified the migration on intelligence-chubes4. The agent ran each pre-existing smoke after the change to confirm no regression.
