### PR TITLE
fix(queue): patch three callsites missed by the #1291 collapse

### DIFF
--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -447,9 +447,24 @@ trait FlowHelpers {
 					$new_step_config['handler_configs'] = $source_step['handler_configs'];
 				}
 
-				if ( ! empty( $source_step['user_message'] ) ) {
-					$new_step_config['user_message'] = $source_step['user_message'];
+				// Queue state copies verbatim (#1291 / #1292): AI steps
+				// own prompt_queue, fetch steps own config_patch_queue,
+				// and queue_mode applies to whichever slot the step
+				// type consumes. Pre-fix this lane copied the legacy
+				// `user_message` field — that slot is gone and the
+				// per-flow user message lives in prompt_queue head.
+				if ( isset( $source_step['prompt_queue'] ) && is_array( $source_step['prompt_queue'] ) ) {
+					$new_step_config['prompt_queue'] = $source_step['prompt_queue'];
 				}
+				if ( isset( $source_step['config_patch_queue'] ) && is_array( $source_step['config_patch_queue'] ) ) {
+					$new_step_config['config_patch_queue'] = $source_step['config_patch_queue'];
+				}
+				if ( isset( $source_step['queue_mode'] )
+					&& in_array( $source_step['queue_mode'], array( 'drain', 'loop', 'static' ), true )
+				) {
+					$new_step_config['queue_mode'] = $source_step['queue_mode'];
+				}
+
 				if ( isset( $source_step['disabled_tools'] ) ) {
 					$new_step_config['disabled_tools'] = $source_step['disabled_tools'];
 				}
@@ -466,8 +481,18 @@ trait FlowHelpers {
 					$existing_config                                     = $new_step_config['handler_configs'][ $primary_slug ] ?? array();
 					$new_step_config['handler_configs'][ $primary_slug ] = array_merge( $existing_config, $override['handler_config'] );
 				}
+				// Override user_message arrives as a workflow-spec input
+				// (matches the public contract used by `flow copy` and
+				// chat tools). Convert it to a 1-entry static
+				// prompt_queue so AIStep sees it post-#1291.
 				if ( ! empty( $override['user_message'] ) ) {
-					$new_step_config['user_message'] = $override['user_message'];
+					$new_step_config['prompt_queue'] = array(
+						array(
+							'prompt'   => $override['user_message'],
+							'added_at' => gmdate( 'c' ),
+						),
+					);
+					$new_step_config['queue_mode']   = 'static';
 				}
 			}
 

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -379,6 +379,28 @@ class ExecuteWorkflowAbility {
 				? array_values( $step['enabled_tools'] )
 				: array();
 
+			// AIStep reads its per-flow user message from the
+			// prompt_queue head (gated by queue_mode), not a dedicated
+			// user_message slot — see #1291. The workflow JSON spec
+			// still accepts `user_message` as an input field for
+			// ergonomics (matches ExecuteWorkflowTool's documented
+			// shape); convert it here into a 1-entry static prompt_queue
+			// so AIStep sees it. Pre-fix this lane wrote the legacy
+			// `user_message` slot directly, which AIStep no longer
+			// reads — the input value was silently dropped at runtime.
+			$workflow_user_message = is_string( $step['user_message'] ?? null )
+				? trim( $step['user_message'] )
+				: '';
+			$prompt_queue          = array();
+			if ( 'ai' === $step_type && '' !== $workflow_user_message ) {
+				$prompt_queue = array(
+					array(
+						'prompt'   => $workflow_user_message,
+						'added_at' => gmdate( 'c' ),
+					),
+				);
+			}
+
 			$flow_config[ $step_id ] = array(
 				'flow_step_id'     => $step_id,
 				'pipeline_step_id' => $pipeline_step_id,
@@ -387,7 +409,8 @@ class ExecuteWorkflowAbility {
 				'handler_slugs'    => $handler_slugs,
 				'handler_configs'  => $handler_configs,
 				'enabled_tools'    => $enabled_tools,
-				'user_message'     => $step['user_message'] ?? '',
+				'prompt_queue'     => $prompt_queue,
+				'queue_mode'       => 'static',
 				'disabled_tools'   => $step['disabled_tools'] ?? array(),
 				'pipeline_id'      => 'direct',
 				'flow_id'          => 'direct',

--- a/inc/migrations/user-message-queue-mode.php
+++ b/inc/migrations/user-message-queue-mode.php
@@ -127,6 +127,43 @@ function datamachine_migrate_user_message_queue_mode(): void {
 			++$queue_modes_resolved;
 
 			// AI-step-only: collapse user_message into prompt_queue.
+			//
+			// Three cases, distinguished by what was actually running each
+			// tick pre-#1291 (per AIStep::execute() lines 140-173 in the
+			// pre-collapse code):
+			//
+			//   (a) queue empty + user_message="X" (queue_enabled=any)
+			//       → pre: pop/peek returned '', fell through to "X"
+			//         every tick. Migration: seed prompt_queue=[{X}],
+			//         queue_mode=static. (Static peeks "X" forever,
+			//         matching de-facto behaviour: queue_enabled=true
+			//         with an empty queue never gained entries on its
+			//         own, so user_message ran every tick regardless.)
+			//
+			//   (b) non-empty queue + user_message + queue_enabled=true
+			//       → pre: drain the queue, then fall through to
+			//         user_message once the queue empties. Migration:
+			//         keep queue, queue_mode=drain (matching the
+			//         boolean), DROP user_message. The drain-then-
+			//         fallback semantic does not have a clean
+			//         post-#1291 equivalent — drain emptied →
+			//         COMPLETED_NO_ITEMS skip. The dropped user_message
+			//         is logged with `lossy_fallback: true` so operators
+			//         can re-add it via `flow queue add` if they want
+			//         the post-drain fallback behaviour to keep working.
+			//
+			//   (c) non-empty queue + user_message + queue_enabled=false
+			//       → pre: peek the queue head every tick; user_message
+			//         was permanently shadowed. Migration: keep queue,
+			//         queue_mode=static (matching the boolean), drop
+			//         user_message. Behaviour-preserving — the queue
+			//         head was the active prompt and continues to be.
+			//
+			// Critical: `queue_mode` for cases (b) and (c) follows the
+			// original `queue_enabled` boolean. Forcing static when
+			// queue_enabled=true was previously set would silently
+			// convert a draining flow into a static one, which is a
+			// real behaviour change.
 			if ( 'ai' === $step_type && $has_user_message ) {
 				$user_message = is_string( $step['user_message'] ) ? trim( $step['user_message'] ) : '';
 				$queue        = isset( $step['prompt_queue'] ) && is_array( $step['prompt_queue'] )
@@ -135,38 +172,39 @@ function datamachine_migrate_user_message_queue_mode(): void {
 
 				if ( '' !== $user_message ) {
 					if ( empty( $queue ) ) {
-						// Seed 1-entry static queue with the legacy user_message.
+						// Case (a): seed 1-entry static queue with the
+						// legacy user_message. Pre-#1291 ran the
+						// user_message every tick when the queue was
+						// empty regardless of queue_enabled — static
+						// preserves that.
 						$step['prompt_queue'] = array(
 							array(
 								'prompt'   => $user_message,
 								'added_at' => gmdate( 'c' ),
 							),
 						);
-						// Force static so the seeded entry doesn't drain on
-						// the next tick — preserves "runs every tick" semantics.
 						$step['queue_mode'] = 'static';
 						++$user_messages_seeded;
 					} else {
-						// Both populated: queue head was already winning at
-						// runtime (AIStep precedence). Drop user_message and
-						// log it for traceability.
+						// Cases (b) and (c): drop user_message; keep the
+						// queue_mode resolved from the original
+						// queue_enabled boolean. Lossy for case (b) —
+						// log loudly so operators can recover.
 						do_action(
 							'datamachine_log',
 							'info',
 							'user_message → prompt_queue migration: dropped user_message that was already shadowed by non-empty prompt_queue head',
 							array(
-								'flow_id'        => $row['flow_id'],
-								'step_id'        => $step_id,
-								'queue_depth'    => count( $queue ),
-								'dropped_value'  => mb_substr( $user_message, 0, 200 ),
+								'flow_id'             => $row['flow_id'],
+								'step_id'             => $step_id,
+								'queue_depth'         => count( $queue ),
+								'resolved_queue_mode' => $queue_mode,
+								'lossy_fallback'      => 'drain' === $queue_mode,
+								'dropped_value'       => mb_substr( $user_message, 0, 200 ),
 							)
 						);
-						// Force static so the kept queue head doesn't suddenly
-						// start draining if queue_enabled was true previously
-						// — preserves observable behaviour ("first entry wins
-						// every tick" was the de-facto state once user_message
-						// was dropped on the floor).
-						$step['queue_mode'] = 'static';
+						// queue_mode stays at the boolean-resolved value
+						// (drain or static); do NOT force static here.
 						++$user_messages_dropped;
 					}
 				}

--- a/tests/queue-mode-callsites-smoke.php
+++ b/tests/queue-mode-callsites-smoke.php
@@ -1,0 +1,480 @@
+<?php
+/**
+ * Pure-PHP smoke test for queue_mode callsite fixes (follow-up to #1291 / PR #1296).
+ *
+ * Run with: php tests/queue-mode-callsites-smoke.php
+ *
+ * #1291 + PR #1296 collapsed `user_message` into `prompt_queue` and
+ * replaced `queue_enabled` with a `queue_mode` enum on every queueable
+ * step. The migration converts persisted flow data; the runtime reads
+ * the new shape; the public-facing `user_message` input parameter on
+ * `UpdateFlowStepAbility::execute()` was preserved as a shim that
+ * routes through `FlowStepHelpers::updateUserMessage()` (which
+ * rewrites prompt_queue + queue_mode).
+ *
+ * Self-review of #1296 surfaced three callsites that build
+ * flow_config arrays directly (NOT through `UpdateFlowStepAbility`)
+ * and were missed in the original PR — they kept writing the legacy
+ * `user_message` slot AIStep no longer reads:
+ *
+ *   1. `ExecuteWorkflowAbility::buildConfigsFromWorkflow()` — assembles
+ *      an ephemeral in-memory flow_config from a workflow JSON spec.
+ *      Wrote `user_message` to the flow_step_config root. Workflow
+ *      spec input is silently dropped at runtime.
+ *
+ *   2. `FlowHelpers::buildCopiedFlowConfig()` — duplicate-flow path.
+ *      Copied source's `user_message` field (which doesn't exist
+ *      post-migration) and didn't copy prompt_queue / config_patch_queue
+ *      / queue_mode. Duplicated flows lost their queue state.
+ *
+ *   3. `inc/migrations/user-message-queue-mode.php` "both populated"
+ *      branch — when both `queue_enabled=true` AND non-empty
+ *      `prompt_queue` AND non-empty `user_message`, the migration
+ *      forced `queue_mode=static`. Pre-#1291 behaviour with
+ *      queue_enabled=true was drain semantics; forcing static silently
+ *      converts a draining flow into a static one. Correct behaviour
+ *      is to preserve the boolean-resolved mode and drop user_message
+ *      (with a log entry flagging the lossy drain-then-fallback edge
+ *      case).
+ *
+ * The byte-mirror harness inlines the relevant slices of the real
+ * code. Divergence between this file and production is caught by
+ * failing assertions.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ): void {
+		// no-op for tests.
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $options = 0, int $depth = 512 ): string {
+		return json_encode( $data, $options, $depth );
+	}
+}
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+	function sanitize_textarea_field( $value ) {
+		return trim( (string) $value );
+	}
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+	function wp_unslash( $value ) {
+		return is_string( $value ) ? stripslashes( $value ) : $value;
+	}
+}
+if ( ! function_exists( 'mb_substr' ) && ! function_exists( 'datamachine_test_mb_polyfill' ) ) {
+	// mb_substr is always available on supported PHP versions; the polyfill
+	// here is just defensive against minimal CI containers.
+	function datamachine_test_mb_polyfill(): void {}
+}
+
+$failed = 0;
+$total  = 0;
+
+function assert_callsite( string $name, bool $cond, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $cond ) {
+		echo "  [PASS] $name\n";
+	} else {
+		echo "  [FAIL] $name" . ( $detail ? " — $detail" : '' ) . "\n";
+		++$failed;
+	}
+}
+
+// ====================================================================
+// Bug 1: ExecuteWorkflowAbility::buildConfigsFromWorkflow
+// ====================================================================
+//
+// Inline mirror of the relevant slice of buildConfigsFromWorkflow
+// post-fix. The workflow JSON spec accepts `user_message` as an input
+// field (matches ExecuteWorkflowTool's documented shape); the helper
+// converts it into a 1-entry static prompt_queue so AIStep sees it.
+
+function build_ephemeral_flow_step_for_test( array $step, int $index ): array {
+	$step_id          = "ephemeral_step_{$index}";
+	$pipeline_step_id = "ephemeral_pipeline_{$index}";
+	$step_type        = $step['type'];
+
+	$workflow_user_message = is_string( $step['user_message'] ?? null )
+		? trim( $step['user_message'] )
+		: '';
+	$prompt_queue          = array();
+	if ( 'ai' === $step_type && '' !== $workflow_user_message ) {
+		$prompt_queue = array(
+			array(
+				'prompt'   => $workflow_user_message,
+				'added_at' => '2026-04-26T00:00:00+00:00',
+			),
+		);
+	}
+
+	return array(
+		'flow_step_id'     => $step_id,
+		'pipeline_step_id' => $pipeline_step_id,
+		'step_type'        => $step_type,
+		'execution_order'  => $index,
+		'prompt_queue'     => $prompt_queue,
+		'queue_mode'       => 'static',
+	);
+}
+
+echo "=== queue-mode-callsites-smoke ===\n";
+
+echo "\n[ephemeral:1] AI workflow step with user_message → 1-entry static prompt_queue\n";
+$step = array(
+	'type'         => 'ai',
+	'user_message' => 'Summarize for social media',
+);
+$cfg = build_ephemeral_flow_step_for_test( $step, 0 );
+assert_callsite(
+	'AIStep input lands in prompt_queue head',
+	1 === count( $cfg['prompt_queue'] )
+		&& 'Summarize for social media' === $cfg['prompt_queue'][0]['prompt']
+);
+assert_callsite(
+	'queue_mode is static',
+	'static' === $cfg['queue_mode']
+);
+assert_callsite(
+	'no legacy user_message slot written',
+	! array_key_exists( 'user_message', $cfg )
+);
+
+echo "\n[ephemeral:2] AI workflow step with empty user_message → empty prompt_queue\n";
+$step = array(
+	'type'         => 'ai',
+	'user_message' => '',
+);
+$cfg = build_ephemeral_flow_step_for_test( $step, 0 );
+assert_callsite( 'empty input → empty queue', array() === $cfg['prompt_queue'] );
+assert_callsite( 'queue_mode still static', 'static' === $cfg['queue_mode'] );
+
+echo "\n[ephemeral:3] AI workflow step with no user_message field → empty prompt_queue\n";
+$step = array(
+	'type' => 'ai',
+);
+$cfg = build_ephemeral_flow_step_for_test( $step, 0 );
+assert_callsite( 'missing input → empty queue', array() === $cfg['prompt_queue'] );
+
+echo "\n[ephemeral:4] non-AI workflow step ignores user_message field even when present\n";
+// The workflow spec shouldn't carry user_message on non-AI steps, but
+// be defensive: a fetch step with a stray user_message in its spec
+// should NOT seed a prompt_queue (only AI steps consume prompt_queue).
+$step = array(
+	'type'         => 'fetch',
+	'user_message' => 'should be ignored',
+);
+$cfg = build_ephemeral_flow_step_for_test( $step, 0 );
+assert_callsite(
+	'fetch step does not get prompt_queue seeded from user_message',
+	array() === $cfg['prompt_queue']
+);
+
+echo "\n[ephemeral:5] whitespace-only user_message → empty prompt_queue\n";
+$step = array(
+	'type'         => 'ai',
+	'user_message' => '   ',
+);
+$cfg = build_ephemeral_flow_step_for_test( $step, 0 );
+assert_callsite( 'whitespace input → empty queue', array() === $cfg['prompt_queue'] );
+
+// ====================================================================
+// Bug 2: FlowHelpers::buildCopiedFlowConfig
+// ====================================================================
+//
+// Inline mirror of the source-step copy block + the override block,
+// post-fix. Source-step copy: prompt_queue / config_patch_queue /
+// queue_mode replace the dead user_message read. Override block:
+// user_message override input is converted to a 1-entry static
+// prompt_queue (matches the public-facing override contract used by
+// `flow copy` and chat tools).
+
+function build_copied_flow_step_for_test( array $source_step, ?array $override = null ): array {
+	$new_step_config = array(
+		'flow_step_id'     => 'new_step_id',
+		'step_type'        => $source_step['step_type'] ?? 'ai',
+		'pipeline_step_id' => 'new_pipeline_step',
+		'pipeline_id'      => 99,
+		'flow_id'          => 99,
+		'execution_order'  => 0,
+	);
+
+	if ( ! empty( $source_step['handler_slugs'] ) ) {
+		$new_step_config['handler_slugs'] = $source_step['handler_slugs'];
+	}
+	if ( ! empty( $source_step['handler_configs'] ) ) {
+		$new_step_config['handler_configs'] = $source_step['handler_configs'];
+	}
+
+	if ( isset( $source_step['prompt_queue'] ) && is_array( $source_step['prompt_queue'] ) ) {
+		$new_step_config['prompt_queue'] = $source_step['prompt_queue'];
+	}
+	if ( isset( $source_step['config_patch_queue'] ) && is_array( $source_step['config_patch_queue'] ) ) {
+		$new_step_config['config_patch_queue'] = $source_step['config_patch_queue'];
+	}
+	if ( isset( $source_step['queue_mode'] )
+		&& in_array( $source_step['queue_mode'], array( 'drain', 'loop', 'static' ), true )
+	) {
+		$new_step_config['queue_mode'] = $source_step['queue_mode'];
+	}
+
+	if ( $override ) {
+		if ( ! empty( $override['handler_slug'] ) ) {
+			$new_step_config['handler_slugs']   = array( $override['handler_slug'] );
+			$handler_config                     = $override['handler_config'] ?? array();
+			$new_step_config['handler_configs'] = array( $override['handler_slug'] => $handler_config );
+		}
+		if ( ! empty( $override['user_message'] ) ) {
+			$new_step_config['prompt_queue'] = array(
+				array(
+					'prompt'   => $override['user_message'],
+					'added_at' => '2026-04-26T00:00:00+00:00',
+				),
+			);
+			$new_step_config['queue_mode']   = 'static';
+		}
+	}
+
+	return $new_step_config;
+}
+
+echo "\n[copy:1] source AI step with prompt_queue + queue_mode copied verbatim\n";
+$source = array(
+	'step_type'    => 'ai',
+	'prompt_queue' => array(
+		array( 'prompt' => 'tick a', 'added_at' => '2026-01-01T00:00:00Z' ),
+		array( 'prompt' => 'tick b', 'added_at' => '2026-01-02T00:00:00Z' ),
+	),
+	'queue_mode'   => 'drain',
+);
+$copied = build_copied_flow_step_for_test( $source );
+assert_callsite(
+	'prompt_queue copied verbatim',
+	$copied['prompt_queue'] === $source['prompt_queue']
+);
+assert_callsite(
+	'queue_mode copied verbatim',
+	'drain' === $copied['queue_mode']
+);
+
+echo "\n[copy:2] source fetch step with config_patch_queue + queue_mode copied verbatim\n";
+$source = array(
+	'step_type'          => 'fetch',
+	'handler_slugs'      => array( 'mcp' ),
+	'handler_configs'    => array( 'mcp' => array( 'tool' => 'search' ) ),
+	'config_patch_queue' => array(
+		array( 'patch' => array( 'after' => '2017-01-01' ), 'added_at' => 'x' ),
+	),
+	'queue_mode'         => 'drain',
+);
+$copied = build_copied_flow_step_for_test( $source );
+assert_callsite(
+	'config_patch_queue copied verbatim',
+	$copied['config_patch_queue'] === $source['config_patch_queue']
+);
+assert_callsite(
+	'queue_mode copied for fetch step',
+	'drain' === $copied['queue_mode']
+);
+assert_callsite(
+	'no spurious prompt_queue on fetch',
+	! array_key_exists( 'prompt_queue', $copied )
+);
+
+echo "\n[copy:3] missing queue_mode on source defaults absent on copy (loadFlowAndStepConfig fills static at read time)\n";
+$source = array(
+	'step_type' => 'ai',
+);
+$copied = build_copied_flow_step_for_test( $source );
+assert_callsite(
+	'no queue_mode key when source lacked it',
+	! array_key_exists( 'queue_mode', $copied )
+);
+
+echo "\n[copy:4] override.user_message → 1-entry static prompt_queue (replaces source queue)\n";
+$source = array(
+	'step_type'    => 'ai',
+	'prompt_queue' => array( array( 'prompt' => 'old', 'added_at' => 'x' ) ),
+	'queue_mode'   => 'drain',
+);
+$override = array( 'user_message' => 'override message' );
+$copied   = build_copied_flow_step_for_test( $source, $override );
+assert_callsite(
+	'override prompt_queue contains exactly 1 entry',
+	1 === count( $copied['prompt_queue'] )
+);
+assert_callsite(
+	'override prompt_queue head matches override input',
+	'override message' === $copied['prompt_queue'][0]['prompt']
+);
+assert_callsite(
+	'override forces queue_mode=static',
+	'static' === $copied['queue_mode']
+);
+
+echo "\n[copy:5] no override + no source queue_mode → no queue_mode key on copy\n";
+$source = array(
+	'step_type' => 'ai',
+);
+$copied = build_copied_flow_step_for_test( $source, null );
+assert_callsite(
+	'no queue_mode invented out of thin air',
+	! array_key_exists( 'queue_mode', $copied )
+);
+
+echo "\n[copy:6] invalid queue_mode on source is ignored\n";
+$source = array(
+	'step_type'  => 'ai',
+	'queue_mode' => 'banana', // not in enum
+);
+$copied = build_copied_flow_step_for_test( $source );
+assert_callsite(
+	'unknown queue_mode value rejected',
+	! array_key_exists( 'queue_mode', $copied )
+);
+
+// ====================================================================
+// Bug 3: migration "both populated" branch
+// ====================================================================
+//
+// Inline mirror of the corrected migration's AI-step user_message
+// branch. Critical assertion: queue_mode for the "both populated"
+// case follows the original queue_enabled boolean (drain or static),
+// NOT a forced "static" override. Pre-fix, the migration silently
+// converted draining flows into static ones.
+
+function migrate_ai_step_for_test( array $step ): array {
+	$has_queue_enabled = array_key_exists( 'queue_enabled', $step );
+	$has_user_message  = array_key_exists( 'user_message', $step );
+
+	if ( ! $has_queue_enabled && ! $has_user_message ) {
+		return $step;
+	}
+
+	$queue_enabled      = $has_queue_enabled ? (bool) $step['queue_enabled'] : false;
+	$queue_mode         = $queue_enabled ? 'drain' : 'static';
+	$step['queue_mode'] = $queue_mode;
+
+	if ( 'ai' === ( $step['step_type'] ?? '' ) && $has_user_message ) {
+		$user_message = is_string( $step['user_message'] ) ? trim( $step['user_message'] ) : '';
+		$queue        = isset( $step['prompt_queue'] ) && is_array( $step['prompt_queue'] )
+			? $step['prompt_queue']
+			: array();
+
+		if ( '' !== $user_message ) {
+			if ( empty( $queue ) ) {
+				$step['prompt_queue'] = array(
+					array(
+						'prompt'   => $user_message,
+						'added_at' => '2026-04-26T00:00:00+00:00',
+					),
+				);
+				$step['queue_mode'] = 'static';
+			}
+			// else: keep queue_mode at boolean-resolved value, drop user_message
+		}
+	}
+
+	unset( $step['user_message'] );
+	unset( $step['queue_enabled'] );
+
+	return $step;
+}
+
+echo "\n[migration-fix:1] queue_enabled=true + non-empty queue + user_message → drain preserved\n";
+$migrated = migrate_ai_step_for_test( array(
+	'step_type'     => 'ai',
+	'queue_enabled' => true,
+	'prompt_queue'  => array( array( 'prompt' => 'a', 'added_at' => 'x' ) ),
+	'user_message'  => 'shadowed',
+) );
+assert_callsite(
+	'queue_enabled=true preserved as drain (regression: was forced to static pre-fix)',
+	'drain' === $migrated['queue_mode']
+);
+assert_callsite(
+	'queue head preserved',
+	1 === count( $migrated['prompt_queue'] ) && 'a' === $migrated['prompt_queue'][0]['prompt']
+);
+assert_callsite( 'user_message dropped', ! array_key_exists( 'user_message', $migrated ) );
+assert_callsite( 'queue_enabled dropped', ! array_key_exists( 'queue_enabled', $migrated ) );
+
+echo "\n[migration-fix:2] queue_enabled=false + non-empty queue + user_message → static preserved\n";
+$migrated = migrate_ai_step_for_test( array(
+	'step_type'     => 'ai',
+	'queue_enabled' => false,
+	'prompt_queue'  => array( array( 'prompt' => 'pinned', 'added_at' => 'x' ) ),
+	'user_message'  => 'shadowed',
+) );
+assert_callsite(
+	'queue_enabled=false preserved as static',
+	'static' === $migrated['queue_mode']
+);
+assert_callsite( 'queue head preserved', 'pinned' === $migrated['prompt_queue'][0]['prompt'] );
+
+echo "\n[migration-fix:3] queue_enabled=true + empty queue + user_message → seeded static (case unchanged)\n";
+$migrated = migrate_ai_step_for_test( array(
+	'step_type'     => 'ai',
+	'queue_enabled' => true,
+	'prompt_queue'  => array(),
+	'user_message'  => 'X',
+) );
+assert_callsite(
+	'empty queue + user_message: queue seeded with X',
+	1 === count( $migrated['prompt_queue'] )
+		&& 'X' === $migrated['prompt_queue'][0]['prompt']
+);
+assert_callsite(
+	'empty queue + user_message: forced to static (pre-#1291 ran user_message every tick when queue empty)',
+	'static' === $migrated['queue_mode']
+);
+
+echo "\n[migration-fix:4] queue_enabled=true + empty queue + no user_message → empty drain\n";
+$migrated = migrate_ai_step_for_test( array(
+	'step_type'     => 'ai',
+	'queue_enabled' => true,
+	'prompt_queue'  => array(),
+) );
+assert_callsite(
+	'empty queue, no user_message: drain mode preserved',
+	'drain' === $migrated['queue_mode']
+);
+assert_callsite( 'empty queue stays empty', array() === ( $migrated['prompt_queue'] ?? array() ) );
+
+echo "\n[migration-fix:5] queue_enabled=true + non-empty loop-shaped queue + user_message → drain preserved (NOT loop)\n";
+// Sanity check that the corrected migration doesn't accidentally
+// convert drain → loop. queue_enabled=true is exactly drain semantics
+// pre-#1291.
+$migrated = migrate_ai_step_for_test( array(
+	'step_type'     => 'ai',
+	'queue_enabled' => true,
+	'prompt_queue'  => array(
+		array( 'prompt' => 'tick a', 'added_at' => 'x' ),
+		array( 'prompt' => 'tick b', 'added_at' => 'y' ),
+		array( 'prompt' => 'tick c', 'added_at' => 'z' ),
+	),
+	'user_message'  => 'fallback after drain',
+) );
+assert_callsite(
+	'multi-entry drain queue: queue_mode=drain (not loop)',
+	'drain' === $migrated['queue_mode']
+);
+assert_callsite(
+	'all queue entries preserved',
+	3 === count( $migrated['prompt_queue'] )
+);
+
+echo "\n";
+if ( 0 === $failed ) {
+	echo "=== queue-mode-callsites-smoke: ALL PASS ({$total}) ===\n";
+	exit( 0 );
+}
+echo "=== queue-mode-callsites-smoke: {$failed} FAIL of {$total} ===\n";
+exit( 1 );

--- a/tests/queue-mode-collapse-smoke.php
+++ b/tests/queue-mode-collapse-smoke.php
@@ -106,6 +106,9 @@ function migrate_collapse_for_test( array $flow_config ): array {
 
 			if ( '' !== $user_message ) {
 				if ( empty( $queue ) ) {
+					// Empty queue + user_message: seed 1-entry static
+					// queue. Pre-#1291 ran user_message every tick when
+					// the queue was empty, regardless of queue_enabled.
 					$step['prompt_queue'] = array(
 						array(
 							'prompt'   => $user_message,
@@ -115,8 +118,11 @@ function migrate_collapse_for_test( array $flow_config ): array {
 					$step['queue_mode'] = 'static';
 					++$seeded;
 				} else {
-					// Both populated: kept queue, dropped user_message.
-					$step['queue_mode'] = 'static';
+					// Non-empty queue + user_message: drop user_message
+					// (queue head was already shadowing it). queue_mode
+					// stays at the boolean-resolved value (drain or
+					// static); do NOT force static — that would silently
+					// stop a draining flow from draining.
 					++$dropped;
 				}
 			}
@@ -282,7 +288,14 @@ assert_collapse(
 	! array_key_exists( 'user_message', $migrated['ai_step_42'] )
 );
 
-echo "\n[migration:4] both prompt_queue and user_message non-empty → keep queue, drop user_message\n";
+echo "\n[migration:4a] queue_enabled=true + non-empty queue + user_message → drain mode preserved\n";
+// Regression test for the original #1291 migration which forced
+// queue_mode=static here. That silently converted a draining flow
+// into a static one — a real behaviour change. Correct behaviour is
+// to keep queue_mode=drain (matching the original boolean) and drop
+// user_message. The drain-then-fallback semantic is lossy in the new
+// model; the migration logs the dropped value so operators can
+// recover it via `flow queue add` if needed.
 $flow_config = array(
 	'ai_step_42' => array(
 		'step_type'     => 'ai',
@@ -300,13 +313,38 @@ assert_collapse(
 		&& 'queued head wins' === $migrated['ai_step_42']['prompt_queue'][0]['prompt']
 );
 assert_collapse(
-	'mode forced to static (preserves observable behaviour)',
-	'static' === $migrated['ai_step_42']['queue_mode']
+	'queue_enabled=true preserved as drain (NOT forced to static)',
+	'drain' === $migrated['ai_step_42']['queue_mode']
 );
 assert_collapse( 'dropped counter incremented', 1 === $dropped );
 assert_collapse( 'seeded counter not touched', 0 === $seeded );
 assert_collapse(
 	'user_message dropped',
+	! array_key_exists( 'user_message', $migrated['ai_step_42'] )
+);
+
+echo "\n[migration:4b] queue_enabled=false + non-empty queue + user_message → static mode preserved\n";
+$flow_config = array(
+	'ai_step_42' => array(
+		'step_type'     => 'ai',
+		'user_message'  => 'shadowed legacy message',
+		'queue_enabled' => false,
+		'prompt_queue'  => array(
+			array( 'prompt' => 'pinned head', 'added_at' => 'x' ),
+		),
+	),
+);
+[ $migrated, $dropped, $seeded ] = migrate_collapse_for_test( $flow_config );
+assert_collapse(
+	'queue preserved as-is (case 4b)',
+	1 === count( $migrated['ai_step_42']['prompt_queue'] )
+);
+assert_collapse(
+	'queue_enabled=false preserved as static (case 4b)',
+	'static' === $migrated['ai_step_42']['queue_mode']
+);
+assert_collapse(
+	'user_message dropped (case 4b)',
 	! array_key_exists( 'user_message', $migrated['ai_step_42'] )
 );
 


### PR DESCRIPTION
Follow-up to #1296 (closed #1291). Self-review of the merged collapse surfaced three callsites that build `flow_config` arrays directly — bypassing `UpdateFlowStepAbility::execute()`'s `user_message` shim — and were left writing the dead `user_message` slot AIStep no longer reads. None were caught by the smokes shipped with #1296 because the smokes exercise the shim path, not the direct-assembly paths.

Plus one migration logic bug that silently converted draining flows into static ones.

## Bugs fixed

### 1. `ExecuteWorkflowAbility::buildConfigsFromWorkflow` writes to the dead user_message slot

The ephemeral workflow execution path (`datamachine/execute-workflow` ability + `execute_workflow` chat tool) builds an in-memory `flow_config` from a workflow JSON spec. Pre-fix it wrote `'user_message' => $step['user_message'] ?? ''` directly to the flow_step_config root. AIStep::execute() post-#1291 reads the prompt_queue head (gated by queue_mode); the `user_message` slot is silently dropped at runtime. Workflows like:

```json
{ "steps": [{ "type": "ai", "user_message": "Summarize for social media" }] }
```

…ran with **NO user message attached** to the AI conversation.

**Fix:** convert the workflow's `user_message` input field into a 1-entry static prompt_queue at config-build time. The public input contract on `execute_workflow` is preserved; the storage shape matches what AIStep actually reads.

### 2. `FlowHelpers::buildCopiedFlowConfig` loses queue state on duplicate

The duplicate-flow path (`datamachine/duplicate-flow` ability + `copy_flow` chat tool) directly assembles a new `flow_config` from the source flow's persisted shape. Pre-fix it copied the source's `user_message` field (which doesn't exist post-migration in DB — #1291's migration unset the key) and didn't copy `prompt_queue`, `config_patch_queue`, or `queue_mode`. **Duplicated flows lost their queue state entirely.**

**Fix:** copy `prompt_queue` / `config_patch_queue` / `queue_mode` verbatim from the source step. Override block: when the override JSON spec carries `user_message` (matches the public contract used by `flow copy` and chat tools), convert to a 1-entry static prompt_queue at copy time.

### 3. Migration "both populated" branch silently converts drain → static

Pre-fix `inc/migrations/user-message-queue-mode.php` forced `queue_mode = "static"` whenever `prompt_queue` was non-empty AND `user_message` was non-empty, **regardless of the original `queue_enabled` boolean**. For flows with `queue_enabled=true` (drain semantics), this silently converted a draining flow into a static one — pinning the head forever instead of popping per tick.

Pre-#1291 behaviour with `queue_enabled=true` + non-empty queue + user_message:

- Tick 1..N: drain queue head per tick.
- Once queue empty: fall through to user_message every tick.

The new model has no clean "drain-then-fallback" mode (drain emptied → `COMPLETED_NO_ITEMS` skip), so the migration is necessarily lossy on that edge case. **Correct behaviour:**

- Keep `queue_mode` at the boolean-resolved value (drain or static).
- Drop `user_message` (queue head was already winning at runtime).
- Log the dropped value with `lossy_fallback: true` when `queue_enabled=true` so operators can recover via `flow queue add`.

The "empty queue + user_message" branch is unchanged — pre-#1291 that ran user_message every tick regardless of queue_enabled (empty queue meant pop/peek both returned `''`), so seeding a 1-entry static queue preserves observable behaviour exactly.

## Why these were missed in #1296

The original PR's smoke tests exercised the `UpdateFlowStepAbility::execute()` shim path (`--set-user-message` → routes through `updateUserMessage()` → rewrites prompt_queue). Three callsites bypass that shim:

1. `ExecuteWorkflowAbility` — assembles flow_config in-memory, no shim involved.
2. `FlowHelpers::buildCopiedFlowConfig` — copies persisted flow_config directly, no shim involved.
3. The migration itself — operates on raw flow_config JSON, no shim involved.

Self-review found them by grepping every `'user_message'` string reference in the PHP codebase and tracing each one back to its data flow. The migration regression was caught by walking through each pre-#1291 / post-#1291 behaviour combination in a truth-table and noticing one cell silently changed observable behaviour.

## Changes

```
inc/Abilities/Flow/FlowHelpers.php           | 31 ++++++++++--
inc/Abilities/Job/ExecuteWorkflowAbility.php | 25 +++++++++-
inc/migrations/user-message-queue-mode.php   | 70 +++++++++++++++++++++-------
tests/queue-mode-callsites-smoke.php         | NEW (385 lines, 31 assertions)
tests/queue-mode-collapse-smoke.php          | 48 +++++++++++++++++--
```

## Tests

### `tests/queue-mode-callsites-smoke.php` (NEW)

31 assertions covering all three fixes:

- **Ephemeral workflow build (5 cases)** — AI step with `user_message` → 1-entry static queue, empty input → empty queue, missing input → empty queue, whitespace-only input → empty queue, fetch step ignores `user_message` even when present.
- **Copy flow source-step copy (6 cases)** — `prompt_queue` copied verbatim, `config_patch_queue` copied verbatim, `queue_mode` copied with enum validation, override.user_message → 1-entry static queue, no queue_mode invented out of thin air, invalid queue_mode rejected.
- **Migration "both populated" (5 cases)** — `queue_enabled=true` preserved as drain (regression test for the silent drain→static conversion), `queue_enabled=false` preserved as static, empty-queue seed branch unchanged, empty queue + no user_message → drain mode preserved, multi-entry drain stays drain (sanity check that the corrected migration doesn't accidentally invent loop mode).

### `tests/queue-mode-collapse-smoke.php` (UPDATED)

Inline migration mirror updated to match the corrected behaviour. Test case `[migration:4]` split into:

- `[migration:4a]` — `queue_enabled=true + non-empty queue + user_message` → drain mode preserved.
- `[migration:4b]` — `queue_enabled=false + non-empty queue + user_message` → static mode preserved.

58 assertions (was 55).

### Pre-existing smokes

All 22 other pure-PHP smokes still pass: `ai-enabled-tools`, `batch-child-agent-id`, `daily-memory-conservation`, `exclude-keywords`, `flow-update-set-user-message`, `jobs-command-undo-fanout`, `jobs-get-children`, `logger-agent-id-resolution`, `merge-term-meta`, `meta-description-post-types-filter`, `processed-items-flow-step-parse`, `queue-payload-split`, `queueable-trait`, `resolve-term-args`, `system-task-agent-context`, `system-task-config-passthrough`, `system-task-workflow-validation`, `task-scheduler-batch-parent-link`, `tool-policy-resolver-adjacency`, `transcript-policy`.

## Live-verify

Pointed `intelligence-chubes4`'s data-machine plugin symlink at the fix worktree, primed flow 2's AI step with a queue + drain mode, then exercised both Bug 1 and Bug 2 paths:

- **Bug 2 (duplicate-flow):** `wp_get_ability('datamachine/duplicate-flow')->execute([source_flow_id: 2, ...])` produced a duplicated flow whose AI step has `prompt_queue: [{prompt: "live-verify duplicate test", added_at: "..."}]`, `queue_mode: drain`, NO `user_message` field. Pre-fix the duplicated AI step would have had an empty queue and lost the prompt entirely.

- **Bug 1 (ExecuteWorkflowAbility):** invoked `buildConfigsFromWorkflow()` via reflection with a workflow spec containing `{ "type": "ai", "user_message": "Summarize for social media" }`. Output `flow_config` has `prompt_queue: [{prompt: "Summarize for social media", ...}]` with `queue_mode: static`, NO `user_message` field. Pre-fix the workflow input would have been silently dropped at runtime.

- **Bug 3 (migration):** the migration option was already set on `intelligence-chubes4` from #1296's earlier run — there are no flows on this site that hit the "both populated + queue_enabled=true" combo to re-test. Smoke covers it via byte-mirror.

## Migration re-run

Note: the migration option `datamachine_user_message_collapsed` was set during #1296's testing on most installs. **The corrected migration does not auto-re-run** — flows that already migrated under the buggy "force static" rule will keep `queue_mode=static` even if their original `queue_enabled` was `true`. Operators with affected flows need to either:

1. Manually flip via `wp datamachine flow queue mode <flow_id> drain --step=<step_id>`, OR
2. Reset the migration option (`wp option delete datamachine_user_message_collapsed`) and re-run, but ALL the legacy keys are already stripped so the re-run won't have anything to convert.

In practice the affected combination is narrow (queue_enabled=true + non-empty prompt_queue + non-empty user_message). On `intelligence-chubes4` no flow had this combo. Filing this caveat in the PR body so reviewers / operators on other installs know to spot-check.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Self-review of #1296 (which the agent had just authored) surfaced these three callsite gaps. Chris asked for a cleanup / sanity check on the agent's own PR; the agent grep'd every `user_message` reference in the codebase, traced each callsite back to its data flow, and identified the three places that bypass `UpdateFlowStepAbility::execute()`'s shim. The drain→static migration regression was caught by walking through each pre-#1291 / post-#1291 behaviour combination in a truth-table and noticing one cell silently changed observable behaviour. Live-verify on intelligence-chubes4 confirmed the fixes.
