### PR TITLE
fix(react): migrate queue UI from queue_enabled boolean to queue_mode enum

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -52,9 +52,15 @@ export default function FlowStepCard( {
 	const isAiStep = pipelineStep.step_type === 'ai';
 
 	const promptQueue = flowStepConfig.prompt_queue || [];
-	const queueEnabled = !! flowStepConfig.queue_enabled;
+	const rawQueueMode = flowStepConfig.queue_mode;
+	const queueMode = [ 'drain', 'loop', 'static' ].includes( rawQueueMode )
+		? rawQueueMode
+		: 'static';
 	const queueHasItems = promptQueue.length > 0;
-	const shouldShowQueue = queueEnabled || queueHasItems;
+	// Static is the no-op mode; only drain/loop actively mutate the queue
+	// per tick. Show the queue surface when the mode is active OR when items
+	// are staged (so the user can manage a dormant stockpile).
+	const shouldShowQueue = queueMode !== 'static' || queueHasItems;
 
 	const [ error, setError ] = useState( null );
 
@@ -188,7 +194,7 @@ export default function FlowStepCard( {
 							pipelineId={ pipelineId }
 							prompt={ currentPrompt }
 							promptQueue={ promptQueue }
-							queueEnabled={ queueEnabled }
+							queueMode={ queueMode }
 							placeholder={
 								isAiStep
 									? __( 'Enter user message for AI processing…', 'data-machine' )

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/QueueablePromptField.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/QueueablePromptField.jsx
@@ -26,7 +26,7 @@ import { AUTO_SAVE_DELAY } from '../../utils/constants';
  * @param {string}   props.flowStepId     - Flow step ID.
  * @param {string}   props.prompt         - Current prompt value (from handler_config or user_message).
  * @param {Array}    props.promptQueue    - Prompt queue array.
- * @param {boolean}  props.queueEnabled   - Whether queue is enabled.
+ * @param {string}   props.queueMode      - Queue access mode: "drain" | "loop" | "static".
  * @param {string}   props.placeholder    - Placeholder text.
  * @param {string}   props.label          - Field label override.
  * @param {Function} props.onSave         - Save callback for non-queue saves (receives prompt string).
@@ -40,7 +40,7 @@ export default function QueueablePromptField( {
 	pipelineId,
 	prompt = '',
 	promptQueue = [],
-	queueEnabled = false,
+	queueMode = 'static',
 	placeholder,
 	label,
 	onSave,
@@ -50,7 +50,11 @@ export default function QueueablePromptField( {
 	const queueCount = promptQueue.length;
 	const queueHasItems = queueCount > 0;
 	const firstQueuePrompt = queueHasItems ? promptQueue[ 0 ].prompt : '';
-	const shouldUseQueue = queueEnabled || queueHasItems;
+	// Drain/loop are the actively-mutating modes; static peeks without
+	// popping. The field routes saves through the queue whenever the
+	// mode is active OR items already exist (so editing the head of a
+	// dormant static stockpile still updates index 0).
+	const shouldUseQueue = queueMode !== 'static' || queueHasItems;
 
 	const [ localValue, setLocalValue ] = useState(
 		firstQueuePrompt || prompt || ''
@@ -204,12 +208,12 @@ export default function QueueablePromptField( {
 				);
 			}
 			return __(
-				'Queue enabled. Type a prompt to add it to the queue. Use Manage Queue for multiple prompts.',
+				'Queue active. Type a prompt to add it to the queue. Use Manage Queue for multiple prompts or to change mode.',
 				'data-machine'
 			);
 		}
 		return __(
-			'Type a prompt to save it directly. Enable the queue to pop prompts in order.',
+			'Type a prompt to save it directly. Switch the queue to drain or loop mode in Manage Queue to rotate prompts.',
 			'data-machine'
 		);
 	};

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/FlowQueueModal.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/FlowQueueModal.jsx
@@ -14,7 +14,7 @@ import {
 	Button,
 	TextareaControl,
 	Spinner,
-	CheckboxControl,
+	SelectControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 /**
@@ -25,8 +25,27 @@ import {
 	useAddToQueue,
 	useClearQueue,
 	useRemoveFromQueue,
-	useUpdateQueueSettings,
+	useUpdateQueueMode,
 } from '../../queries/queue';
+
+/**
+ * Queue mode options for the SelectControl. The value strings must match
+ * the server-side enum on /flows/{id}/queue/mode (drain | loop | static).
+ */
+const QUEUE_MODE_OPTIONS = [
+	{
+		value: 'static',
+		label: __( 'Static — peek head every run, do not pop', 'data-machine' ),
+	},
+	{
+		value: 'drain',
+		label: __( 'Drain — pop head per run, discard', 'data-machine' ),
+	},
+	{
+		value: 'loop',
+		label: __( 'Loop — pop head per run, append to tail', 'data-machine' ),
+	},
+];
 
 /**
  * Flow Queue Modal Component
@@ -47,39 +66,39 @@ export default function FlowQueueModal( {
 } ) {
 	const [ newPrompt, setNewPrompt ] = useState( '' );
 	const [ confirmClear, setConfirmClear ] = useState( false );
-	const [ queueEnabled, setQueueEnabled ] = useState( false );
+	const [ queueMode, setQueueMode ] = useState( 'static' );
 
 	// Query hooks
 	const { data, isLoading, error } = useFlowQueue( flowId, flowStepId );
 	const addMutation = useAddToQueue();
 	const clearMutation = useClearQueue();
 	const removeMutation = useRemoveFromQueue();
-	const updateSettingsMutation = useUpdateQueueSettings();
+	const updateModeMutation = useUpdateQueueMode();
 
 	const queue = data?.queue || [];
 	const isOperating =
 		addMutation.isPending ||
 		clearMutation.isPending ||
 		removeMutation.isPending ||
-		updateSettingsMutation.isPending;
+		updateModeMutation.isPending;
 
 	useEffect( () => {
-		if ( typeof data?.queueEnabled === 'boolean' ) {
-			setQueueEnabled( data.queueEnabled );
+		if ( typeof data?.queueMode === 'string' ) {
+			setQueueMode( data.queueMode );
 		}
-	}, [ data?.queueEnabled ] );
+	}, [ data?.queueMode ] );
 
-	const handleQueueEnabledChange = useCallback(
-		( enabled ) => {
-			setQueueEnabled( enabled );
-			updateSettingsMutation.mutate( {
+	const handleQueueModeChange = useCallback(
+		( mode ) => {
+			setQueueMode( mode );
+			updateModeMutation.mutate( {
 				flowId,
 				flowStepId,
 				pipelineId,
-				queueEnabled: enabled,
+				mode,
 			} );
 		},
-		[ flowId, flowStepId, pipelineId, updateSettingsMutation ]
+		[ flowId, flowStepId, pipelineId, updateModeMutation ]
 	);
 
 	/**
@@ -181,13 +200,14 @@ export default function FlowQueueModal( {
 
 				{ flowStepId && (
 					<div className="datamachine-modal-spacing--mb-20">
-						<CheckboxControl
-							label={ __( 'Queue enabled', 'data-machine' ) }
-							checked={ queueEnabled }
-							onChange={ handleQueueEnabledChange }
+						<SelectControl
+							label={ __( 'Queue mode', 'data-machine' ) }
+							value={ queueMode }
+							options={ QUEUE_MODE_OPTIONS }
+							onChange={ handleQueueModeChange }
 							disabled={ isOperating }
 							help={ __(
-								'When enabled, the queue pops the next prompt each run. When disabled, the first queued prompt is reused every run without popping.',
+								'Static reuses the head every run. Drain pops the head and discards it. Loop pops the head and appends it to the tail so the queue rotates indefinitely.',
 								'data-machine'
 							) }
 						/>
@@ -344,7 +364,7 @@ export default function FlowQueueModal( {
 							{ __( 'How it works:', 'data-machine' ) }
 						</strong>{ ' ' }
 						{ __(
-							'Prompts are processed in order (FIFO). When queue is enabled, the first prompt is removed each run. When disabled, the first prompt is reused each run without popping.',
+							'Prompts are processed in order (FIFO). The queue mode decides what happens to the head after each run: static peeks without mutating, drain pops and discards, loop pops and appends to the tail.',
 							'data-machine'
 						) }
 					</p>

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/queue.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/queue.js
@@ -17,9 +17,26 @@ import {
 	clearFlowQueue,
 	removeFromFlowQueue,
 	updateFlowQueueItem,
-	updateFlowQueueSettings,
+	updateFlowQueueMode,
 } from '../utils/api';
 import { normalizeId } from '../utils/ids';
+
+/**
+ * Valid queue access modes (must match the server-side enum on
+ * /flows/{id}/queue/mode and AIStep / FetchStep config).
+ */
+const QUEUE_MODES = [ 'drain', 'loop', 'static' ];
+
+/**
+ * Normalize a queue mode value, falling back to "static" for unknown
+ * or missing values. Mirrors the server-side default in AIStep and
+ * FetchStep when the key is absent on the flow_step_config.
+ *
+ * @param {*} value Raw value from the server or cache.
+ * @return {string} Normalized mode.
+ */
+const normalizeQueueMode = ( value ) =>
+	QUEUE_MODES.includes( value ) ? value : 'static';
 
 /**
  * Invalidate flows cache scoped to a specific pipeline when available.
@@ -62,7 +79,7 @@ export const useFlowQueue = ( flowId, flowStepId ) => {
 			return {
 				queue: response.data?.queue || [],
 				count: response.data?.count || 0,
-				queueEnabled: !! response.data?.queue_enabled,
+				queueMode: normalizeQueueMode( response.data?.queue_mode ),
 			};
 		},
 		enabled: !! cachedFlowId && !! cachedFlowStepId,
@@ -119,7 +136,6 @@ export const useClearQueue = () => {
 				cachedFlowId,
 				cachedFlowStepId,
 			] );
-			const queueEnabled = previousQueue?.queueEnabled;
 
 			// Optimistically clear the cache
 			queryClient.setQueryData(
@@ -127,10 +143,7 @@ export const useClearQueue = () => {
 				{
 					queue: [],
 					count: 0,
-					queueEnabled:
-						typeof queueEnabled === 'boolean'
-							? queueEnabled
-							: false,
+					queueMode: normalizeQueueMode( previousQueue?.queueMode ),
 				}
 			);
 
@@ -175,7 +188,9 @@ export const useRemoveFromQueue = () => {
 							( _, i ) => i !== index
 						),
 						count: Math.max( 0, previousQueue.count - 1 ),
-						queueEnabled: previousQueue.queueEnabled,
+						queueMode: normalizeQueueMode(
+							previousQueue.queueMode
+						),
 					}
 				);
 			}
@@ -256,7 +271,9 @@ export const useUpdateQueueItem = () => {
 					{
 						queue: newQueue,
 						count: newQueue.length,
-						queueEnabled: previousQueue.queueEnabled,
+						queueMode: normalizeQueueMode(
+							previousQueue.queueMode
+						),
 					}
 				);
 			}
@@ -291,17 +308,22 @@ export const useUpdateQueueItem = () => {
 };
 
 /**
- * Update queue settings for a flow step
+ * Update queue mode for a flow step
+ *
+ * Replaces the legacy `useUpdateQueueSettings` boolean toggle. Post-#1291
+ * the queue access pattern is a three-state enum (drain | loop | static)
+ * stored on `flow_step_config.queue_mode` and read by AIStep, FetchStep,
+ * and AgentPingTask via the same path.
  *
  * @return {Object} Mutation result
  */
-export const useUpdateQueueSettings = () => {
+export const useUpdateQueueMode = () => {
 	const queryClient = useQueryClient();
 
 	return useMutation( {
-		mutationFn: ( { flowId, flowStepId, queueEnabled } ) =>
-			updateFlowQueueSettings( flowId, flowStepId, queueEnabled ),
-		onMutate: async ( { flowId, flowStepId, queueEnabled } ) => {
+		mutationFn: ( { flowId, flowStepId, mode } ) =>
+			updateFlowQueueMode( flowId, flowStepId, mode ),
+		onMutate: async ( { flowId, flowStepId, mode } ) => {
 			const cachedFlowId = normalizeId( flowId );
 			const cachedFlowStepId = flowStepId ? String( flowStepId ) : null;
 
@@ -320,7 +342,7 @@ export const useUpdateQueueSettings = () => {
 					[ 'flowQueue', cachedFlowId, cachedFlowStepId ],
 					{
 						...previousQueue,
-						queueEnabled: !! queueEnabled,
+						queueMode: normalizeQueueMode( mode ),
 					}
 				);
 			}

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/utils/api.js
@@ -634,20 +634,16 @@ export const updateFlowQueueItem = async (
 };
 
 /**
- * Update queue settings for a flow step
+ * Update queue mode for a flow step
  *
- * @param {number}  flowId       - Flow ID
- * @param {string}  flowStepId   - Flow step ID
- * @param {boolean} queueEnabled - Whether queue pop is enabled
+ * @param {number} flowId     - Flow ID
+ * @param {string} flowStepId - Flow step ID
+ * @param {string} mode       - Queue access mode: "drain" | "loop" | "static"
  * @return {Promise<Object>} Result
  */
-export const updateFlowQueueSettings = async (
-	flowId,
-	flowStepId,
-	queueEnabled
-) => {
-	return await client.put( `/flows/${ flowId }/queue/settings`, {
+export const updateFlowQueueMode = async ( flowId, flowStepId, mode ) => {
+	return await client.put( `/flows/${ flowId }/queue/mode`, {
 		flow_step_id: flowStepId,
-		queue_enabled: queueEnabled,
+		mode,
 	} );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "datamachine",
-	"version": "0.79.1",
+	"version": "0.83.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "datamachine",
-			"version": "0.79.1",
+			"version": "0.83.0",
 			"dependencies": {
 				"@extrachill/chat": "^0.11.0",
 				"@tanstack/react-query": "^5.90.12",

--- a/tests/react-queue-mode-contract-smoke.php
+++ b/tests/react-queue-mode-contract-smoke.php
@@ -1,0 +1,363 @@
+<?php
+/**
+ * Pure-PHP smoke test for the React queue UI ↔ REST contract (#1300).
+ *
+ * Run with: php tests/react-queue-mode-contract-smoke.php
+ *
+ * #1296 (closed #1291) collapsed `queue_enabled` (boolean) into a
+ * `queue_mode` enum on every queueable step, and replaced the old
+ * `PUT /flows/{id}/queue/settings { queue_enabled }` endpoint with
+ * `PUT /flows/{id}/queue/mode { mode: "drain" | "loop" | "static" }`.
+ * The PR explicitly carved React out of scope (#1300).
+ *
+ * #1300 cleans up the React UI to read/write the new shape. Three
+ * regressions had to be eliminated:
+ *
+ *   1. `queue.js::useFlowQueue()` cast `response.data?.queue_enabled`
+ *      to a boolean. Post-#1296 the response field is `queue_mode`
+ *      (string); the boolean cast resolved to `false` for every step,
+ *      every time, silently degrading the UI.
+ *
+ *   2. `api.js::updateFlowQueueSettings()` POSTed to the dead
+ *      `/queue/settings` endpoint with `{ queue_enabled: bool }` body.
+ *      The endpoint no longer exists; the new endpoint is `/queue/mode`
+ *      with `{ mode }` body.
+ *
+ *   3. `FlowStepCard.jsx` read `flowStepConfig.queue_enabled` from a
+ *      flow_config blob that no longer carries that key. The card
+ *      rendered the queue surface as off forever.
+ *
+ * This smoke locks the contract by grepping the React source files
+ * for the exact strings and shape the server side expects. It does
+ * NOT load WordPress or evaluate JSX — it asserts on file contents.
+ * Drift between React and PHP is caught at this boundary.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failed = 0;
+$total  = 0;
+
+/**
+ * Assert helper.
+ *
+ * @param string $name      Test case name.
+ * @param bool   $condition Pass/fail.
+ */
+function assert_react_contract( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+	echo "  FAIL: {$name}\n";
+	++$failed;
+}
+
+/**
+ * Read a React source file relative to the worktree root.
+ *
+ * @param string $relative Path under `inc/Core/Admin/Pages/Pipelines/assets/react`.
+ * @return string File contents.
+ */
+function read_react_file( string $relative ): string {
+	$base = dirname( __DIR__ ) . '/inc/Core/Admin/Pages/Pipelines/assets/react';
+	$path = $base . '/' . ltrim( $relative, '/' );
+	if ( ! is_readable( $path ) ) {
+		fwrite( STDERR, "Missing React source: {$path}\n" );
+		exit( 2 );
+	}
+	return (string) file_get_contents( $path );
+}
+
+echo "=== React Queue Mode Contract Smoke (#1300) ===\n";
+
+// ---------------------------------------------------------------
+// SECTION 1: api.js — write-side endpoint shape.
+// ---------------------------------------------------------------
+
+echo "\n[api.js:1] updateFlowQueueMode export exists\n";
+$api = read_react_file( 'utils/api.js' );
+assert_react_contract(
+	'updateFlowQueueMode is exported',
+	false !== strpos( $api, 'export const updateFlowQueueMode' )
+);
+
+echo "\n[api.js:2] PUT URL is /queue/mode (not /queue/settings)\n";
+assert_react_contract(
+	'PUT URL targets /queue/mode',
+	false !== strpos( $api, '/flows/${ flowId }/queue/mode' )
+);
+assert_react_contract(
+	'legacy /queue/settings endpoint is gone',
+	false === strpos( $api, '/queue/settings' )
+);
+
+echo "\n[api.js:3] Request body uses `mode`, not `queue_enabled`\n";
+// The body literal must contain `mode,` (shorthand property) and NOT
+// `queue_enabled`. Match on a tight slice that includes the body
+// object so we don't false-positive against unrelated `mode` strings.
+preg_match( '/queue\/mode`,\s*\{([^}]+)\}/s', $api, $body_match );
+$body_block = $body_match[1] ?? '';
+assert_react_contract(
+	'request body contains `flow_step_id: flowStepId`',
+	false !== strpos( $body_block, 'flow_step_id: flowStepId' )
+);
+assert_react_contract(
+	'request body contains `mode` shorthand',
+	(bool) preg_match( '/\bmode,?\s/', $body_block )
+);
+assert_react_contract(
+	'request body does NOT contain queue_enabled',
+	false === strpos( $body_block, 'queue_enabled' )
+);
+
+echo "\n[api.js:4] Legacy updateFlowQueueSettings export is gone\n";
+assert_react_contract(
+	'updateFlowQueueSettings export removed',
+	false === strpos( $api, 'export const updateFlowQueueSettings' )
+);
+
+// ---------------------------------------------------------------
+// SECTION 2: queries/queue.js — read-side normalization + mode mutation.
+// ---------------------------------------------------------------
+
+echo "\n[queue.js:1] useFlowQueue reads queue_mode (not queue_enabled)\n";
+$queries = read_react_file( 'queries/queue.js' );
+assert_react_contract(
+	'queryFn reads response.data?.queue_mode',
+	false !== strpos( $queries, 'response.data?.queue_mode' )
+);
+assert_react_contract(
+	'queryFn does NOT read response.data?.queue_enabled',
+	false === strpos( $queries, 'response.data?.queue_enabled' )
+);
+
+echo "\n[queue.js:2] queueMode is normalized to enum (default static)\n";
+assert_react_contract(
+	'normalizeQueueMode helper exists',
+	false !== strpos( $queries, 'const normalizeQueueMode' )
+);
+assert_react_contract(
+	'QUEUE_MODES enum lists drain/loop/static',
+	(bool) preg_match(
+		"/QUEUE_MODES\s*=\s*\[\s*'drain',\s*'loop',\s*'static'\s*\]/",
+		$queries
+	)
+);
+assert_react_contract(
+	"normalize falls back to 'static' for unknown values",
+	false !== strpos( $queries, "? value : 'static'" )
+);
+
+echo "\n[queue.js:3] useUpdateQueueMode hook exists, posts {mode}\n";
+assert_react_contract(
+	'useUpdateQueueMode export exists',
+	false !== strpos( $queries, 'export const useUpdateQueueMode' )
+);
+assert_react_contract(
+	'useUpdateQueueMode mutationFn destructures `mode`',
+	(bool) preg_match(
+		'/mutationFn:\s*\(\s*\{\s*flowId,\s*flowStepId,\s*mode\s*\}\s*\)\s*=>\s*updateFlowQueueMode/',
+		$queries
+	)
+);
+
+echo "\n[queue.js:4] Legacy useUpdateQueueSettings export is gone\n";
+assert_react_contract(
+	'useUpdateQueueSettings export removed',
+	false === strpos( $queries, 'export const useUpdateQueueSettings' )
+);
+
+echo "\n[queue.js:5] queueEnabled identifier is gone from logic (only doc comment refs allowed)\n";
+// The doc comment on useUpdateQueueMode intentionally references the
+// legacy name for migration breadcrumbs. Allow exactly that one string;
+// reject any code-level use of queueEnabled / queue_enabled.
+$queue_enabled_hits   = substr_count( $queries, 'queueEnabled' );
+$queue_enabled_legacy = substr_count(
+	$queries,
+	'`useUpdateQueueSettings` boolean toggle'
+);
+assert_react_contract(
+	'queueEnabled identifier appears only in the migration doc comment',
+	0 === $queue_enabled_hits && 1 === $queue_enabled_legacy
+);
+assert_react_contract(
+	'queue_enabled snake_case identifier is gone',
+	false === strpos( $queries, 'queue_enabled' )
+);
+
+// ---------------------------------------------------------------
+// SECTION 3: FlowStepCard.jsx — read queue_mode off the flow_step_config blob.
+// ---------------------------------------------------------------
+
+echo "\n[FlowStepCard.jsx:1] Card reads flowStepConfig.queue_mode\n";
+$card = read_react_file( 'components/flows/FlowStepCard.jsx' );
+assert_react_contract(
+	'card reads flowStepConfig.queue_mode',
+	false !== strpos( $card, 'flowStepConfig.queue_mode' )
+);
+assert_react_contract(
+	'card does NOT read flowStepConfig.queue_enabled',
+	false === strpos( $card, 'flowStepConfig.queue_enabled' )
+);
+
+echo "\n[FlowStepCard.jsx:2] queueMode is normalized + queue surface gates on non-static\n";
+assert_react_contract(
+	'card normalizes via the drain/loop/static includes check',
+	(bool) preg_match(
+		"/\[\s*'drain',\s*'loop',\s*'static'\s*\]\.includes\(\s*rawQueueMode\s*\)/",
+		$card
+	)
+);
+assert_react_contract(
+	"card defaults missing/invalid queue_mode to 'static'",
+	false !== strpos( $card, ": 'static'" )
+);
+assert_react_contract(
+	"queue surface visible when mode !== 'static' OR queue has items",
+	false !== strpos( $card, "queueMode !== 'static' || queueHasItems" )
+);
+
+echo "\n[FlowStepCard.jsx:3] queueMode is passed down to QueueablePromptField\n";
+assert_react_contract(
+	'card passes queueMode prop',
+	false !== strpos( $card, 'queueMode={ queueMode }' )
+);
+assert_react_contract(
+	'card does NOT pass legacy queueEnabled prop',
+	false === strpos( $card, 'queueEnabled=' )
+);
+
+// ---------------------------------------------------------------
+// SECTION 4: QueueablePromptField.jsx — accepts queueMode prop.
+// ---------------------------------------------------------------
+
+echo "\n[QueueablePromptField.jsx:1] Component signature uses queueMode\n";
+$field = read_react_file( 'components/flows/QueueablePromptField.jsx' );
+assert_react_contract(
+	"queueMode prop has 'static' default",
+	(bool) preg_match( "/queueMode\s*=\s*'static'/", $field )
+);
+assert_react_contract(
+	'legacy queueEnabled prop is gone',
+	false === strpos( $field, 'queueEnabled' )
+);
+
+echo "\n[QueueablePromptField.jsx:2] shouldUseQueue gates on non-static OR items\n";
+assert_react_contract(
+	"shouldUseQueue includes queueMode !== 'static'",
+	false !== strpos( $field, "queueMode !== 'static' || queueHasItems" )
+);
+
+// ---------------------------------------------------------------
+// SECTION 5: FlowQueueModal.jsx — three-mode SelectControl wired to PUT /queue/mode.
+// ---------------------------------------------------------------
+
+echo "\n[FlowQueueModal.jsx:1] Modal imports useUpdateQueueMode, not useUpdateQueueSettings\n";
+$modal = read_react_file( 'components/modals/FlowQueueModal.jsx' );
+assert_react_contract(
+	'modal imports useUpdateQueueMode',
+	false !== strpos( $modal, 'useUpdateQueueMode' )
+);
+assert_react_contract(
+	'modal does NOT import useUpdateQueueSettings',
+	false === strpos( $modal, 'useUpdateQueueSettings' )
+);
+
+echo "\n[FlowQueueModal.jsx:2] Modal uses SelectControl with three modes\n";
+assert_react_contract(
+	'modal imports SelectControl',
+	(bool) preg_match( '/SelectControl,\s*\n/', $modal )
+);
+assert_react_contract(
+	'modal does NOT import CheckboxControl',
+	false === strpos( $modal, 'CheckboxControl' )
+);
+assert_react_contract(
+	"QUEUE_MODE_OPTIONS includes value: 'static'",
+	false !== strpos( $modal, "value: 'static'" )
+);
+assert_react_contract(
+	"QUEUE_MODE_OPTIONS includes value: 'drain'",
+	false !== strpos( $modal, "value: 'drain'" )
+);
+assert_react_contract(
+	"QUEUE_MODE_OPTIONS includes value: 'loop'",
+	false !== strpos( $modal, "value: 'loop'" )
+);
+
+echo "\n[FlowQueueModal.jsx:3] Modal mutation passes `mode` (not queueEnabled)\n";
+// Find the .mutate({ ... }) call inside handleQueueModeChange.
+preg_match(
+	'/updateModeMutation\.mutate\(\s*\{([^}]+)\}\s*\)/',
+	$modal,
+	$mutate_match
+);
+$mutate_block = $mutate_match[1] ?? '';
+assert_react_contract(
+	'mutate call contains `mode`',
+	(bool) preg_match( '/\bmode,/', $mutate_block )
+);
+assert_react_contract(
+	'mutate call does NOT contain queueEnabled',
+	false === strpos( $mutate_block, 'queueEnabled' )
+);
+
+echo "\n[FlowQueueModal.jsx:4] State and effect are queueMode-shaped\n";
+assert_react_contract(
+	"useState defaults to 'static'",
+	(bool) preg_match(
+		"/useState\(\s*'static'\s*\)/",
+		$modal
+	)
+);
+assert_react_contract(
+	'effect reads data?.queueMode',
+	false !== strpos( $modal, 'data?.queueMode' )
+);
+assert_react_contract(
+	"effect type-check is 'string', not 'boolean'",
+	false !== strpos( $modal, "typeof data?.queueMode === 'string'" )
+);
+
+// ---------------------------------------------------------------
+// SECTION 6: server contract — confirm the React shape matches the REST endpoint.
+// ---------------------------------------------------------------
+
+echo "\n[server-contract:1] FlowQueue.php REST surface still matches React\n";
+$rest = (string) file_get_contents(
+	dirname( __DIR__ ) . '/inc/Api/Flows/FlowQueue.php'
+);
+assert_react_contract(
+	'PUT /flows/{id}/queue/mode endpoint is registered',
+	false !== strpos( $rest, '/flows/(?P<flow_id>\d+)/queue/mode' )
+);
+assert_react_contract(
+	"REST `mode` arg has enum [drain, loop, static]",
+	(bool) preg_match(
+		"/'enum'\s*=>\s*array\(\s*'drain',\s*'loop',\s*'static'\s*\)/",
+		$rest
+	)
+);
+assert_react_contract(
+	"GET /queue response includes 'queue_mode' field",
+	false !== strpos( $rest, "'queue_mode'   => \$result['queue_mode']" )
+);
+assert_react_contract(
+	'legacy /queue/settings endpoint is gone server-side too',
+	false === strpos( $rest, '/queue/settings' )
+);
+
+echo "\n";
+if ( 0 === $failed ) {
+	echo "=== react-queue-mode-contract-smoke: ALL PASS ({$total}) ===\n";
+	exit( 0 );
+}
+echo "=== react-queue-mode-contract-smoke: {$failed} FAIL of {$total} ===\n";
+exit( 1 );


### PR DESCRIPTION
Closes #1300.

## Summary

PR #1296 (closing #1291) collapsed `queue_enabled` (bool) into a `queue_mode` enum on every queueable step and replaced the `PUT /flows/{id}/queue/settings { queue_enabled }` endpoint with `PUT /flows/{id}/queue/mode { mode }`. React was explicitly carved out of scope.

That carveout silently broke three React surfaces:

1. `useFlowQueue` cast `response.data?.queue_enabled` to a bool. Post-#1296 the response field is `queue_mode` (string); the boolean cast resolved to `false` for every step, every time. The queue toggle and queue-list count were stuck at zero.
2. `updateFlowQueueSettings` POSTed `{ queue_enabled }` to the dead `/queue/settings` endpoint. Every queue-toggle write 404'd.
3. `FlowStepCard.jsx` read `flowStepConfig.queue_enabled` from a flow_config blob that no longer carries that key. The card never showed the queue surface.

This PR replaces every `queue_enabled` / `queueEnabled` reference with the three-state `queue_mode` enum (drain | loop | static) end to end. **No shim, no boolean alias** — the legacy storage was already migrated server-side, React was the last consumer.

## Changes

### `utils/api.js`
- `updateFlowQueueSettings(flowId, flowStepId, queueEnabled)` → `updateFlowQueueMode(flowId, flowStepId, mode)`. URL is now `/queue/mode`; body is `{ flow_step_id, mode }` matching the REST endpoint registered in `inc/Api/Flows/FlowQueue.php`.

### `queries/queue.js`
- `useFlowQueue` returns `queueMode: string` (normalized to one of `drain | loop | static`, defaulting to `static`) instead of `queueEnabled: bool`.
- `useUpdateQueueSettings` → `useUpdateQueueMode`. Mutation destructures `mode` instead of `queueEnabled` and posts the new body shape via `updateFlowQueueMode`.
- All three optimistic-update paths (`useClearQueue`, `useRemoveFromQueue`, `useUpdateQueueItem`) preserve `queueMode` in their cache writes.
- `normalizeQueueMode` helper enforces the enum on every read so unknown / missing values can't crash the UI.

### `FlowQueueModal.jsx`
- `CheckboxControl` "Queue enabled" → `SelectControl` "Queue mode" with three options (static | drain | loop). Each label spells out the per-tick semantics so the mode is self-documenting.
- Default state is `'static'`; `useEffect` syncs against `data?.queueMode` when the query resolves.
- Info-box copy updated to describe what each mode does to the queue head per tick.

### `FlowStepCard.jsx`
- Reads `flowStepConfig.queue_mode` (normalized via the same `[drain, loop, static].includes` check as the other consumers).
- `shouldShowQueue = queueMode !== 'static' || queueHasItems` so the queue surface appears whenever the mode actively mutates OR when items are staged in static mode.
- Passes `queueMode` (not `queueEnabled`) to `QueueablePromptField`.

### `QueueablePromptField.jsx`
- Prop signature: `queueMode = 'static'` (was `queueEnabled = false`).
- `shouldUseQueue` gates on `queueMode !== 'static' || queueHasItems` matching the card-level check. Help text updated to mention the mode names instead of an enabled/disabled toggle.

## Tests

Added `tests/react-queue-mode-contract-smoke.php` — **43-assertion** pure-PHP smoke that greps the React source for the exact strings and shape the server-side REST endpoint expects. Locks the contract at the React ↔ REST boundary without requiring a JS test runner. Catches future drift in a single layer: if the JSX changes the request URL, body shape, or the response field it reads, the smoke fails.

All 5 prior queue smokes still pass:
- `queue-mode-collapse-smoke.php` (58)
- `queue-mode-callsites-smoke.php` (31)
- `queue-payload-split-smoke.php` (41)
- `queueable-trait-smoke.php` (all)
- `flow-update-set-user-message-smoke.php` (31)

## Live verify

End-to-end on `intelligence-chubes4` against the worktree:

```
$ studio wp datamachine flow get 2 --format=json | grep queue_mode
"queue_mode": "static"   (every step)
"queue_mode": "drain"    (the queueable fetch step)

$ studio wp datamachine flow queue list 2 --step=<id> --format=json
{
    "flow_id": 2,
    "flow_step_id": "...",
    "queue_mode": "drain",     ← React useFlowQueue reads this
    "prompt_queue": [],
    "config_patch_queue": []
}

$ studio wp datamachine flow queue mode 2 loop --step=<id>
Success: Queue mode set to loop.
   ↑ Same backend the React useUpdateQueueMode mutation now hits.

$ grep -o "queue/mode\|/queue/settings\|queue_enabled\|queue_mode" \
       inc/Core/Admin/assets/build/pipelines-react.js | sort | uniq -c
   1 queue/mode
   2 queue_mode
   ↑ Built bundle: zero references to the dead slot or endpoint.
```

## Out of scope

Phase 3 from #1300 (replacing the `UpdateFlowStepAbility::user_message` shim with a dedicated `datamachine/queue-replace` ability) is hygiene that doesn't gate this fix. Tracked in #1300 for a follow-up PR.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the React migration end-to-end (5 JSX/JS files + smoke test), live-verified the REST round-trip on intelligence-chubes4 (drain → loop → drain end-to-end), and reviewed the new contract surface against the existing queue-mode smokes. Chris reviewed the strategy (no shim, three-mode SelectControl, smoke at the React ↔ REST boundary) and the live-verify results.
