### PR TITLE
fix(migrations): run schema migrations on plugins_loaded, not just activation

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -585,54 +585,17 @@ function datamachine_activate_for_site() {
 		set_transient( 'datamachine_needs_scaffold', 1, HOUR_IN_SECONDS );
 	}
 
-	// Run layered architecture migration (idempotent).
-	datamachine_migrate_to_layered_architecture();
-
-	// Migrate flow_config handler keys from singular to plural (idempotent).
-	datamachine_migrate_handler_keys_to_plural();
-
-	// Backfill agent_id on pipelines, flows, and jobs from user_id→owner_id mapping (idempotent).
-	datamachine_backfill_agent_ids();
-
-	// Assign orphaned resources (agent_id IS NULL) to sole agent on single-agent installs (idempotent).
-	datamachine_assign_orphaned_resources_to_sole_agent();
-
-	// Migrate USER.md to network-scoped paths and create NETWORK.md on multisite (idempotent).
-	datamachine_migrate_user_md_to_network_scope();
-
-	// Migrate per-site agents to network-scoped tables (idempotent).
-	datamachine_migrate_agents_to_network_scope();
-
-	// Drop orphaned per-site agent tables left behind by the migration (idempotent).
-	datamachine_drop_orphaned_agent_tables();
-
-	// Migrate agent_ping step types to flow configs (idempotent).
-	datamachine_migrate_agent_ping_to_system_task();
-
-	// Migrate agent_ping step types to pipeline configs (idempotent).
-	datamachine_migrate_agent_ping_pipeline_to_system_task();
-
-	// Migrate `update` step type to `upsert` in pipeline/flow configs (idempotent).
-	datamachine_migrate_update_to_upsert_step_type();
-
-	// Strip dead `provider`/`model` keys from pipeline_config rows (data-machine#1180, idempotent).
-	datamachine_strip_pipeline_step_provider_model();
-
-	// Move AI step tools from handler_slugs to enabled_tools (#1205 Phase 2b, idempotent).
-	datamachine_migrate_ai_enabled_tools();
-
-	// Split prompt_queue / config_patch_queue payload polymorphism (#1292, idempotent).
-	datamachine_migrate_split_queue_payload();
-
-	// Collapse user_message into prompt_queue and replace queue_enabled with
-	// queue_mode enum (drain | loop | static) on every queueable step (#1291,
-	// idempotent).
-	datamachine_migrate_user_message_queue_mode();
-
-	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
-	datamachine_drop_redundant_post_pipeline_meta();
+	// Run the shared migration chain. Each migration is idempotent and
+	// option-gated; this same function fires from
+	// `datamachine_maybe_run_deferred_migrations()` at plugins_loaded:5
+	// when a deploy advances DATAMACHINE_VERSION past the persisted
+	// `datamachine_db_version` option (#1301).
+	datamachine_run_schema_migrations();
 
 	// Regenerate SITE.md with enriched content and clean up legacy SiteContext transient.
+	// Activation-only — SITE.md regeneration is heavy and shouldn't fire on
+	// every deploy (the version-gated runtime path is for schema-shape drift,
+	// not opportunistic content refresh).
 	datamachine_regenerate_site_md();
 	delete_transient( 'datamachine_site_context_data' );
 

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -26,3 +26,10 @@ require_once __DIR__ . '/strip-pipeline-step-provider-model.php';
 require_once __DIR__ . '/ai-enabled-tools.php';
 require_once __DIR__ . '/split-queue-payload.php';
 require_once __DIR__ . '/user-message-queue-mode.php';
+
+// Schema-migration runtime — defines `datamachine_run_schema_migrations()`
+// and `datamachine_maybe_run_deferred_migrations()`. Hooked at
+// plugins_loaded priority 5 so deploys that bump DATAMACHINE_VERSION past
+// the persisted `datamachine_db_version` option auto-migrate without
+// requiring an activation cycle (#1301).
+require_once __DIR__ . '/runtime.php';

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Data Machine — Schema migration runtime (#1301).
+ *
+ * Schema migrations were previously gated only on `register_activation_hook`
+ * via `datamachine_activate_for_site()`. The hook does not fire on plugin
+ * upgrade-in-place (`homeboy deploy`, `wp plugin update`, manual rsync, or
+ * any deploy path that doesn't toggle activation). Sites kept the old
+ * persisted shape and ran the new code against it, with no migration ever
+ * firing.
+ *
+ * The bug shape is invisible: each migration is gated on its own option
+ * (`datamachine_*_migrated`), so deferring is free for the activation path.
+ * The cost only shows up at runtime, where the new code reads the new
+ * shape and finds the old one. PR #1296 (queue_mode) and PR #1216
+ * (ai_enabled_tools) both bit on this during live-verify.
+ *
+ * The fix mirrors WordPress core's `db_version` pattern. A single option
+ * (`datamachine_db_version`) tracks the migrated version. Every request
+ * compares it against the `DATAMACHINE_VERSION` constant; on mismatch,
+ * the migration chain re-enters at `plugins_loaded` priority 5 (before
+ * the main plugin bootstrap at priority 20, so any migrated shape is in
+ * place before consumers run).
+ *
+ * Each migration is already idempotent and gated on its own option, so
+ * re-entry on every version bump is cheap: every gate short-circuits when
+ * nothing's needed. The version-bump just decides when to enter the chain
+ * at all.
+ *
+ * Table creation (`dbDelta` + per-table `create_table`) stays on activation.
+ * Tables don't drift the way persisted data does — `dbDelta` is idempotent
+ * but expensive, and a fresh install needs an activation hook to bootstrap
+ * the schema regardless. Schema-altering migrations (e.g. `ensure_*_column`
+ * helpers on `Chat`) already have their own `plugins_loaded` priority 6
+ * hook in `data-machine.php`.
+ *
+ * @package DataMachine
+ * @since 0.84.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Run the full schema-migration chain for the current site.
+ *
+ * Each migration is required to be idempotent and gated on its own
+ * `datamachine_*_migrated` option (or equivalent). This function is
+ * the shared entry point for both:
+ *
+ *   1. Activation (`datamachine_activate_for_site()`) — runs the chain
+ *      after table creation on initial install / explicit activation.
+ *   2. Deferred runtime (`datamachine_maybe_run_deferred_migrations()`)
+ *      — runs the chain on the first request after a deploy that
+ *      bumped `DATAMACHINE_VERSION` past the persisted
+ *      `datamachine_db_version` option.
+ *
+ * Order matters where one migration depends on another's resulting
+ * shape (e.g. `split_queue_payload` runs before `user_message_queue_mode`
+ * because the latter assumes the split is in place). Preserve this
+ * ordering when adding new migrations to the chain.
+ *
+ * @since 0.84.0
+ * @return void
+ */
+function datamachine_run_schema_migrations(): void {
+	// Layered architecture migration (idempotent).
+	datamachine_migrate_to_layered_architecture();
+
+	// Migrate flow_config handler keys from singular to plural (idempotent).
+	datamachine_migrate_handler_keys_to_plural();
+
+	// Backfill agent_id on pipelines, flows, and jobs from user_id→owner_id mapping (idempotent).
+	datamachine_backfill_agent_ids();
+
+	// Assign orphaned resources (agent_id IS NULL) to sole agent on single-agent installs (idempotent).
+	datamachine_assign_orphaned_resources_to_sole_agent();
+
+	// Migrate USER.md to network-scoped paths and create NETWORK.md on multisite (idempotent).
+	datamachine_migrate_user_md_to_network_scope();
+
+	// Migrate per-site agents to network-scoped tables (idempotent).
+	datamachine_migrate_agents_to_network_scope();
+
+	// Drop orphaned per-site agent tables left behind by the migration (idempotent).
+	datamachine_drop_orphaned_agent_tables();
+
+	// Migrate agent_ping step types to flow configs (idempotent).
+	datamachine_migrate_agent_ping_to_system_task();
+
+	// Migrate agent_ping step types to pipeline configs (idempotent).
+	datamachine_migrate_agent_ping_pipeline_to_system_task();
+
+	// Migrate `update` step type to `upsert` in pipeline/flow configs (idempotent).
+	datamachine_migrate_update_to_upsert_step_type();
+
+	// Strip dead `provider`/`model` keys from pipeline_config rows (data-machine#1180, idempotent).
+	datamachine_strip_pipeline_step_provider_model();
+
+	// Move AI step tools from handler_slugs to enabled_tools (#1205 Phase 2b, idempotent).
+	datamachine_migrate_ai_enabled_tools();
+
+	// Split prompt_queue / config_patch_queue payload polymorphism (#1292, idempotent).
+	datamachine_migrate_split_queue_payload();
+
+	// Collapse user_message into prompt_queue and replace queue_enabled with
+	// queue_mode enum (drain | loop | static) on every queueable step (#1291,
+	// idempotent).
+	datamachine_migrate_user_message_queue_mode();
+
+	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
+	datamachine_drop_redundant_post_pipeline_meta();
+}
+
+/**
+ * Maybe run schema migrations on plugins_loaded.
+ *
+ * Reads the persisted `datamachine_db_version` option and compares it to
+ * the `DATAMACHINE_VERSION` constant. On mismatch, runs the migration
+ * chain and bumps the option to the new version.
+ *
+ * Cheap-path early return: when the option matches the constant (the
+ * common case on every request for a stable install), this function does
+ * one option read and exits. The chain only re-enters when a deploy has
+ * advanced the constant past the option.
+ *
+ * Network considerations: on multisite, `datamachine_db_version` is stored
+ * per-site (autoloaded `wp_options`). The hook fires per-request which is
+ * naturally per-blog, so each subsite migrates independently on its own
+ * first post-deploy request. Sites with no traffic don't pay the cost
+ * until they're hit. Activation still uses `datamachine_for_each_site()`
+ * to migrate every site eagerly when the operator explicitly activates
+ * network-wide.
+ *
+ * Network-scoped agent tables don't need per-site migration — they live
+ * on `base_prefix` and are touched once at activation via
+ * `datamachine_create_network_agent_tables()`.
+ *
+ * @since 0.84.0
+ * @return void
+ */
+function datamachine_maybe_run_deferred_migrations(): void {
+	// Cheap path: option matches code. Most requests on a stable install.
+	$persisted = get_option( 'datamachine_db_version', '' );
+	if ( DATAMACHINE_VERSION === $persisted ) {
+		return;
+	}
+
+	// Mismatch — either fresh install whose activation just ran (option
+	// already bumped to current at the end of `datamachine_activate_for_site`),
+	// or a deploy bumped the constant past the persisted option. Run the
+	// chain (each migration's gate decides whether real work is needed),
+	// then bump the option.
+	datamachine_run_schema_migrations();
+	update_option( 'datamachine_db_version', DATAMACHINE_VERSION, true );
+}
+
+// Run deferred migrations early in plugins_loaded (priority 5) so that
+// `datamachine_run_datamachine_plugin` at priority 20 — and every consumer
+// after it — sees the migrated shape. Same hook fires for both activated
+// and upgraded installs; the option-gate inside the function avoids
+// double-running when activation already migrated this request.
+add_action( 'plugins_loaded', 'datamachine_maybe_run_deferred_migrations', 5 );

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -1,0 +1,356 @@
+<?php
+/**
+ * Pure-PHP smoke test for the schema-migration runtime (#1301).
+ *
+ * Run with: php tests/migration-runtime-smoke.php
+ *
+ * #1301 moved the schema-migration chain off `register_activation_hook`
+ * and onto a `plugins_loaded` hook gated by a `datamachine_db_version`
+ * option, mirroring WordPress core's `db_version` pattern. The bug: the
+ * activation hook does not fire on plugin upgrade-in-place
+ * (`homeboy deploy`, `wp plugin update`, manual rsync) so persisted DB
+ * shape silently lagged the running code after every deploy.
+ *
+ * The fix has three contracts that must hold:
+ *
+ *   1. `datamachine_run_schema_migrations()` is the shared entry point.
+ *      Both activation and the deferred runtime hook call it. Each
+ *      migration in the chain is invoked exactly once per call.
+ *
+ *   2. `datamachine_maybe_run_deferred_migrations()` short-circuits when
+ *      the persisted `datamachine_db_version` option matches the
+ *      DATAMACHINE_VERSION constant (the cheap path, fires every
+ *      request). When they differ, it runs the chain and bumps the
+ *      option.
+ *
+ *   3. The deferred runtime is hooked at `plugins_loaded` priority 5.
+ *      Earlier than `datamachine_run_datamachine_plugin` (priority 20)
+ *      so consumers see the migrated shape.
+ *
+ * This smoke validates all three by stubbing WordPress's option store
+ * and hook registry, then loading the production runtime file and
+ * exercising it. The production file is the real `inc/migrations/runtime.php`
+ * (no byte-mirror harness — the contracts are too thin to need one).
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// Mirror the production constant. The shared runtime reads this from
+// global scope; we set it before requiring the file.
+if ( ! defined( 'DATAMACHINE_VERSION' ) ) {
+	define( 'DATAMACHINE_VERSION', '0.84.0-test' );
+}
+
+$failed = 0;
+$total  = 0;
+
+/**
+ * Assert helper.
+ *
+ * @param string $name      Test case name.
+ * @param bool   $condition Pass/fail.
+ */
+function assert_runtime( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+	echo "  FAIL: {$name}\n";
+	++$failed;
+}
+
+// --- WordPress stubs -------------------------------------------------
+
+$GLOBALS['__test_options']         = array();
+$GLOBALS['__test_actions']         = array();
+$GLOBALS['__test_migration_calls'] = array();
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $name, $default = false ) {
+		return $GLOBALS['__test_options'][ $name ] ?? $default;
+	}
+}
+
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $name, $value, $autoload = null ) {
+		$GLOBALS['__test_options'][ $name ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['__test_actions'][] = array(
+			'hook'     => $hook,
+			'callback' => $callback,
+			'priority' => $priority,
+		);
+		return true;
+	}
+}
+
+// --- Stubbed migration registry -------------------------------------
+
+/**
+ * The runtime file calls a chain of `datamachine_migrate_*` functions.
+ * We stub each to record its invocation so the smoke can assert the
+ * chain ran end-to-end and didn't accidentally drop or duplicate a
+ * migration.
+ *
+ * The list MUST stay in sync with the real chain in
+ * `inc/migrations/runtime.php::datamachine_run_schema_migrations()`.
+ * Drift is the whole point this smoke exists to catch.
+ */
+$migration_chain = array(
+	'datamachine_migrate_to_layered_architecture',
+	'datamachine_migrate_handler_keys_to_plural',
+	'datamachine_backfill_agent_ids',
+	'datamachine_assign_orphaned_resources_to_sole_agent',
+	'datamachine_migrate_user_md_to_network_scope',
+	'datamachine_migrate_agents_to_network_scope',
+	'datamachine_drop_orphaned_agent_tables',
+	'datamachine_migrate_agent_ping_to_system_task',
+	'datamachine_migrate_agent_ping_pipeline_to_system_task',
+	'datamachine_migrate_update_to_upsert_step_type',
+	'datamachine_strip_pipeline_step_provider_model',
+	'datamachine_migrate_ai_enabled_tools',
+	'datamachine_migrate_split_queue_payload',
+	'datamachine_migrate_user_message_queue_mode',
+	'datamachine_drop_redundant_post_pipeline_meta',
+);
+
+foreach ( $migration_chain as $fn ) {
+	if ( function_exists( $fn ) ) {
+		continue;
+	}
+	$captured = $fn;
+	eval(
+		"function {$fn}() { \$GLOBALS['__test_migration_calls'][] = '{$captured}'; }"
+	);
+}
+
+// --- Load the production runtime under test --------------------------
+
+require_once dirname( __DIR__ ) . '/inc/migrations/runtime.php';
+
+echo "=== Migration Runtime Smoke (#1301) ===\n";
+
+// ---------------------------------------------------------------
+// SECTION 1: datamachine_run_schema_migrations() invokes the full chain.
+// ---------------------------------------------------------------
+
+echo "\n[chain:1] Shared entry point invokes every migration exactly once\n";
+$GLOBALS['__test_migration_calls'] = array();
+datamachine_run_schema_migrations();
+assert_runtime(
+	'all ' . count( $migration_chain ) . ' migrations were called',
+	count( $GLOBALS['__test_migration_calls'] ) === count( $migration_chain )
+);
+foreach ( $migration_chain as $expected ) {
+	assert_runtime(
+		"chain includes {$expected}",
+		in_array( $expected, $GLOBALS['__test_migration_calls'], true )
+	);
+}
+
+echo "\n[chain:2] No duplicate calls in a single chain run\n";
+$counts     = array_count_values( $GLOBALS['__test_migration_calls'] );
+$duplicates = array_filter( $counts, fn( $c ) => $c > 1 );
+assert_runtime(
+	'no migration called more than once',
+	0 === count( $duplicates )
+);
+
+echo "\n[chain:3] Chain order is preserved (queue split runs before queue mode)\n";
+$queue_split_pos = array_search(
+	'datamachine_migrate_split_queue_payload',
+	$GLOBALS['__test_migration_calls'],
+	true
+);
+$queue_mode_pos  = array_search(
+	'datamachine_migrate_user_message_queue_mode',
+	$GLOBALS['__test_migration_calls'],
+	true
+);
+assert_runtime(
+	'split_queue_payload runs before user_message_queue_mode',
+	false !== $queue_split_pos
+		&& false !== $queue_mode_pos
+		&& $queue_split_pos < $queue_mode_pos
+);
+$handler_keys_pos = array_search(
+	'datamachine_migrate_handler_keys_to_plural',
+	$GLOBALS['__test_migration_calls'],
+	true
+);
+$ai_tools_pos     = array_search(
+	'datamachine_migrate_ai_enabled_tools',
+	$GLOBALS['__test_migration_calls'],
+	true
+);
+assert_runtime(
+	'handler_keys_to_plural runs before ai_enabled_tools (#1216 dependency)',
+	false !== $handler_keys_pos
+		&& false !== $ai_tools_pos
+		&& $handler_keys_pos < $ai_tools_pos
+);
+
+// ---------------------------------------------------------------
+// SECTION 2: deferred runtime hook gates on db_version.
+// ---------------------------------------------------------------
+
+echo "\n[deferred:1] Cheap path: matching option short-circuits without running chain\n";
+$GLOBALS['__test_migration_calls']                       = array();
+$GLOBALS['__test_options']['datamachine_db_version']     = DATAMACHINE_VERSION;
+datamachine_maybe_run_deferred_migrations();
+assert_runtime(
+	'no migrations called when option matches constant',
+	0 === count( $GLOBALS['__test_migration_calls'] )
+);
+assert_runtime(
+	'option preserved at the matching value',
+	DATAMACHINE_VERSION === $GLOBALS['__test_options']['datamachine_db_version']
+);
+
+echo "\n[deferred:2] Stale option triggers chain + bumps option to current\n";
+$GLOBALS['__test_migration_calls']                       = array();
+$GLOBALS['__test_options']['datamachine_db_version']     = '0.79.0-stale';
+datamachine_maybe_run_deferred_migrations();
+assert_runtime(
+	'all migrations called when option lags constant',
+	count( $GLOBALS['__test_migration_calls'] ) === count( $migration_chain )
+);
+assert_runtime(
+	'option bumped to current DATAMACHINE_VERSION after chain',
+	DATAMACHINE_VERSION === $GLOBALS['__test_options']['datamachine_db_version']
+);
+
+echo "\n[deferred:3] Missing option (fresh install pre-activation) triggers chain\n";
+$GLOBALS['__test_migration_calls'] = array();
+unset( $GLOBALS['__test_options']['datamachine_db_version'] );
+datamachine_maybe_run_deferred_migrations();
+assert_runtime(
+	'missing option treated as mismatch — chain runs',
+	count( $GLOBALS['__test_migration_calls'] ) === count( $migration_chain )
+);
+assert_runtime(
+	'option created and set to current after chain',
+	DATAMACHINE_VERSION === $GLOBALS['__test_options']['datamachine_db_version']
+);
+
+echo "\n[deferred:4] Re-entry after bump is the cheap path again\n";
+$GLOBALS['__test_migration_calls'] = array();
+datamachine_maybe_run_deferred_migrations();
+assert_runtime(
+	'second call is a no-op now that option matches',
+	0 === count( $GLOBALS['__test_migration_calls'] )
+);
+
+echo "\n[deferred:5] Newer option than constant (downgrade path) is also cheap\n";
+// The contract is "match → no-op". Anything that mismatches re-enters,
+// including downgrade. That's safe because each migration is gated on its
+// own option; a downgraded constant doesn't undo persisted shape.
+$GLOBALS['__test_options']['datamachine_db_version'] = '99.99.0-future';
+$GLOBALS['__test_migration_calls']                   = array();
+datamachine_maybe_run_deferred_migrations();
+assert_runtime(
+	'downgrade triggers chain (idempotent gates make it safe)',
+	count( $GLOBALS['__test_migration_calls'] ) === count( $migration_chain )
+);
+assert_runtime(
+	'option bumped down to current constant after chain',
+	DATAMACHINE_VERSION === $GLOBALS['__test_options']['datamachine_db_version']
+);
+
+// ---------------------------------------------------------------
+// SECTION 3: hook registration shape.
+// ---------------------------------------------------------------
+
+echo "\n[hook:1] Deferred runtime is hooked at plugins_loaded priority 5\n";
+$matching_hook = null;
+foreach ( $GLOBALS['__test_actions'] as $registered ) {
+	if (
+		'plugins_loaded' === $registered['hook']
+		&& 'datamachine_maybe_run_deferred_migrations' === $registered['callback']
+	) {
+		$matching_hook = $registered;
+		break;
+	}
+}
+assert_runtime(
+	'plugins_loaded hook registered for datamachine_maybe_run_deferred_migrations',
+	null !== $matching_hook
+);
+assert_runtime(
+	'priority is 5 (before main bootstrap at 20)',
+	5 === ( $matching_hook['priority'] ?? null )
+);
+
+// ---------------------------------------------------------------
+// SECTION 4: activation path still calls the shared entry point.
+// ---------------------------------------------------------------
+
+echo "\n[activation:1] data-machine.php delegates to the shared runtime\n";
+// We can't load data-machine.php in this harness (it pulls in real WP),
+// but we can grep it. The contract: the activation function calls
+// `datamachine_run_schema_migrations()` instead of inlining the chain.
+$plugin_main = (string) file_get_contents(
+	dirname( __DIR__ ) . '/data-machine.php'
+);
+assert_runtime(
+	'activation calls shared datamachine_run_schema_migrations()',
+	false !== strpos(
+		$plugin_main,
+		'datamachine_run_schema_migrations();'
+	)
+);
+assert_runtime(
+	'activation no longer inlines datamachine_migrate_to_layered_architecture()',
+	0 === substr_count(
+		$plugin_main,
+		'datamachine_migrate_to_layered_architecture('
+	)
+);
+assert_runtime(
+	'activation no longer inlines datamachine_migrate_user_message_queue_mode()',
+	0 === substr_count(
+		$plugin_main,
+		'datamachine_migrate_user_message_queue_mode('
+	)
+);
+assert_runtime(
+	'activation still bumps datamachine_db_version after the chain',
+	false !== strpos(
+		$plugin_main,
+		"update_option( 'datamachine_db_version', DATAMACHINE_VERSION, true );"
+	)
+);
+
+// ---------------------------------------------------------------
+// SECTION 5: runtime file declares the chain in the documented order.
+// ---------------------------------------------------------------
+
+echo "\n[runtime-file:1] runtime.php chain matches the test fixture\n";
+$runtime_src = (string) file_get_contents(
+	dirname( __DIR__ ) . '/inc/migrations/runtime.php'
+);
+foreach ( $migration_chain as $expected ) {
+	assert_runtime(
+		"runtime.php declares {$expected}();",
+		false !== strpos( $runtime_src, $expected . '();' )
+	);
+}
+
+echo "\n";
+if ( 0 === $failed ) {
+	echo "=== migration-runtime-smoke: ALL PASS ({$total}) ===\n";
+	exit( 0 );
+}
+echo "=== migration-runtime-smoke: {$failed} FAIL of {$total} ===\n";
+exit( 1 );


### PR DESCRIPTION
Closes #1301.

## Summary

Schema migrations were gated only on `register_activation_hook` via `datamachine_activate_for_site()`. The hook does not fire on plugin upgrade-in-place — `homeboy deploy`, `wp plugin update`, manual rsync, or any deploy path that doesn't toggle activation. Sites kept the old persisted shape and ran the new code against it; no migration ever fired.

The bug shape is invisible: every migration is gated on its own `datamachine_*_migrated` option, so deferring is free for the activation path. The cost only surfaces at runtime, where the new code reads the new shape and finds the old one. PR #1296 (queue_mode) and PR #1216 (ai_enabled_tools) both bit on this during live-verify — the agent only noticed because the per-migration option remained unset.

This PR mirrors **WordPress core's `db_version` pattern**. A single option (`datamachine_db_version`) tracks the migrated version. Every request compares it against `DATAMACHINE_VERSION`; on mismatch, the migration chain re-enters at `plugins_loaded` priority 5 (before the main plugin bootstrap at 20, so any migrated shape is in place before consumers run). Each migration's own gate decides whether real work is needed, so re-entry is cheap on every release that bumps the constant without changing schema.

## Changes

### `inc/migrations/runtime.php` (new)

- `datamachine_run_schema_migrations()` — shared entry point for the full chain (13 migration calls, ordered, every one already idempotent + option-gated).
- `datamachine_maybe_run_deferred_migrations()` — `plugins_loaded:5` hook. Cheap path: matching option short-circuits with a single option read. Mismatch path: runs the chain, bumps the option. Network multisite naturally migrates each subsite on its own first post-deploy request via per-blog `wp_options` scope.

### `data-machine.php`

- `datamachine_activate_for_site()` now delegates to the shared `datamachine_run_schema_migrations()` instead of inlining the chain (-43 / +5 net). Activation still bumps `datamachine_db_version` to current at the end.
- Table creation (`dbDelta` + `Chat::ensure_*_column` runtime hooks) **stays on activation**. Tables don't drift the way persisted data does, and a fresh install needs an activation hook to bootstrap the schema regardless.

### `inc/migrations/load.php`

- Requires the new `runtime.php` so the deferred hook registers when any DM file is autoloaded.

## Tests

Added `tests/migration-runtime-smoke.php` — **49-assertion** pure-PHP smoke that stubs WordPress's option store + hook registry, loads the production runtime file, and exercises every contract:

- Shared entry point invokes every migration **exactly once**, in the documented order (queue_split before queue_mode, handler_keys before ai_enabled_tools — both real cross-migration dependencies).
- **Cheap path**: matching option short-circuits without entering the chain.
- **Stale option** triggers chain + bumps option to current.
- **Missing option** (fresh-install pre-activation race) triggers chain.
- Re-entry after bump is the cheap path again.
- **Downgrade path** (newer persisted than constant) safely re-enters because per-migration gates make it idempotent.
- `plugins_loaded` priority is 5.
- `data-machine.php` calls the shared function (no inlined migrations remain in the activation function).
- Runtime file's chain matches the test fixture (the smoke is the trip-wire if a new migration is added in only one of the two files).

All 6 prior smokes still pass:
- queue-mode-collapse-smoke (58)
- queue-mode-callsites-smoke (31)
- queue-payload-split-smoke (41)
- queueable-trait-smoke
- flow-update-set-user-message-smoke (31)
- jobs-get-children-smoke

## Live verify

End-to-end on `intelligence-chubes4`:

1. Pointed live site at the worktree; bumped `DATAMACHINE_VERSION` constant to `0.83.99-live-verify` (simulating a deploy past the persisted `0.83.0` option).
2. `studio wp option update datamachine_db_version "0.79.0-stale"` — force a stale value.
3. `studio wp option get datamachine_db_version` — the call boots WP, plugins_loaded:5 fires, hook detects stale option, runs the chain, bumps option to `0.83.99-live-verify`. Returned value is post-bump.
4. Subsequent `option get` calls take the cheap path (single option read, no chain entry).
5. `wp-content/debug.log` shows **zero migration errors** across every chain entry.

The fix that the wiki article called out as a workaround (`plugin deactivate && plugin activate` after a deploy) is no longer necessary — a single normal request now triggers the migrations end-to-end.

## Out of scope

- **Table creation timing** — stays on activation. `dbDelta` is expensive to run on every request, and the schema-altering helpers (`Chat::ensure_*_column`) already have their own `plugins_loaded:6` hook for in-place schema additions.
- **homeboy deploy reactivation** — no longer needed; the deferred hook covers it. Documenting the change in homeboy is outside the scope of this PR.
- **SITE.md regeneration** — kept on activation only. The version-gated runtime path is for schema-shape drift, not opportunistic content refresh that happens to live in the activation function today.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Designed the deferred-runtime + db_version-gate shape, extracted the shared `datamachine_run_schema_migrations()` function, wrote the 49-assertion smoke harness, and live-verified the end-to-end migration auto-fire on intelligence-chubes4 with a stale-option simulation. Chris reviewed the strategy (mirror core's db_version pattern, keep table creation on activation, no shim).
