### PR TITLE
refactor(queue): consolidate three consumers onto shared consumeFromQueueSlot

### DIFF
--- a/inc/Abilities/Flow/QueueAbility.php
+++ b/inc/Abilities/Flow/QueueAbility.php
@@ -1523,68 +1523,43 @@ class QueueAbility {
 	}
 
 	/**
-	 * Pop the first prompt from the queue (drain semantics).
+	 * Consume one item from a named queue slot per the given mode.
 	 *
-	 * Used by AgentPingTask when its `queue_mode` is `drain`. AIStep's
-	 * mode-aware reader lives in QueueableTrait. For the fetch-step
-	 * config-patch queue, see {@see popConfigPatchFromQueue()}.
+	 * Single source of truth for the drain / loop / static access
+	 * pattern (#1291) regardless of which consumer is reading. Used by
+	 * `QueueableTrait` (Step-side consumers AIStep + FetchStep) and
+	 * `AgentPingTask` (SystemTask consumer) — both share the same
+	 * mutation, peek, rotation, and logging semantics.
 	 *
-	 * @param int      $flow_id      Flow ID.
-	 * @param string   $flow_step_id Flow step ID.
-	 * @param DB_Flows $db_flows     Database instance (avoids creating new instance each call).
-	 * @return array|null The popped queue item or null if empty.
+	 *   - drain  → pop the head, discard. DB write.
+	 *   - loop   → pop the head, append to the tail. DB write.
+	 *   - static → peek the head, no mutation. No DB write.
+	 *
+	 * Pre-#1299 this lived as `private static` on `QueueableTrait` with
+	 * three sibling helpers on `QueueAbility` (`popFromQueue`,
+	 * `loopFromQueue`, `popConfigPatchFromQueue`) that AgentPingTask
+	 * called instead — those reimplemented the same logic minus the
+	 * static-mode branch. The static helpers are gone; AgentPingTask
+	 * goes through this method now.
+	 *
+	 * @param int           $flow_id      Flow ID.
+	 * @param string        $flow_step_id Flow step ID.
+	 * @param string        $slot         Queue slot name (one of the
+	 *                                    SLOT_* constants on this class).
+	 * @param string        $queue_mode   "drain" | "loop" | "static".
+	 *                                    Unknown values are treated as
+	 *                                    "static" (peek without mutating).
+	 * @param DB_Flows|null $db_flows     Optional database instance.
+	 * @return array|null The consumed entry, or null if the queue was empty.
+	 * @since 0.84.0
 	 */
-	public static function popFromQueue( int $flow_id, string $flow_step_id, ?DB_Flows $db_flows = null ): ?array {
-		return self::popFromQueueSlot( $flow_id, $flow_step_id, self::SLOT_PROMPT_QUEUE, $db_flows );
-	}
-
-	/**
-	 * Pop the first prompt from the queue and rotate it to the tail
-	 * (loop semantics).
-	 *
-	 * Sibling of {@see popFromQueue()} for the `loop` queue mode. The
-	 * returned entry is the one the caller should consume; the tail of
-	 * the queue gets the same entry appended so it cycles back around
-	 * after the rest of the queue drains.
-	 *
-	 * @param int      $flow_id      Flow ID.
-	 * @param string   $flow_step_id Flow step ID.
-	 * @param DB_Flows $db_flows     Database instance.
-	 * @return array|null The rotated queue item or null if empty.
-	 */
-	public static function loopFromQueue( int $flow_id, string $flow_step_id, ?DB_Flows $db_flows = null ): ?array {
-		return self::popFromQueueSlot( $flow_id, $flow_step_id, self::SLOT_PROMPT_QUEUE, $db_flows, true );
-	}
-
-	/**
-	 * Pop the first config patch from the fetch step config-patch queue.
-	 *
-	 * Sibling of {@see popFromQueue()} for FetchStep's QueueableTrait
-	 * consumer. Returns the entry verbatim (no JSON-decode — the patch
-	 * is stored as a decoded array).
-	 *
-	 * @param int      $flow_id      Flow ID.
-	 * @param string   $flow_step_id Flow step ID.
-	 * @param DB_Flows $db_flows     Database instance.
-	 * @return array|null The popped queue item (`{ patch, added_at }`) or null if empty.
-	 */
-	public static function popConfigPatchFromQueue( int $flow_id, string $flow_step_id, ?DB_Flows $db_flows = null ): ?array {
-		return self::popFromQueueSlot( $flow_id, $flow_step_id, self::SLOT_CONFIG_PATCH_QUEUE, $db_flows );
-	}
-
-	/**
-	 * Pop the first item from a named queue slot.
-	 *
-	 * @param int      $flow_id      Flow ID.
-	 * @param string   $flow_step_id Flow step ID.
-	 * @param string   $slot         Slot name.
-	 * @param DB_Flows $db_flows     Database instance.
-	 * @param bool     $loop         When true, append the popped entry to
-	 *                               the tail of the queue (loop semantics).
-	 *                               When false (default), discard (drain).
-	 * @return array|null The popped item or null if empty.
-	 */
-	private static function popFromQueueSlot( int $flow_id, string $flow_step_id, string $slot, ?DB_Flows $db_flows = null, bool $loop = false ): ?array {
+	public static function consumeFromQueueSlot(
+		int $flow_id,
+		string $flow_step_id,
+		string $slot,
+		string $queue_mode,
+		?DB_Flows $db_flows = null
+	): ?array {
 		if ( null === $db_flows ) {
 			$db_flows = new DB_Flows();
 		}
@@ -1606,10 +1581,16 @@ class QueueAbility {
 			return null;
 		}
 
-		$popped_item = array_shift( $queue );
+		// Static peek: read head, do not mutate storage.
+		if ( 'static' === $queue_mode ) {
+			return $queue[0];
+		}
 
-		if ( $loop ) {
-			$queue[] = $popped_item;
+		// Drain or loop: pop the head, optionally rotate.
+		$entry = array_shift( $queue );
+
+		if ( 'loop' === $queue_mode ) {
+			$queue[] = $entry;
 		}
 
 		$flow_config[ $flow_step_id ][ $slot ] = $queue;
@@ -1622,15 +1603,16 @@ class QueueAbility {
 		do_action(
 			'datamachine_log',
 			'info',
-			$loop ? 'Item rotated in queue (loop)' : 'Item popped from queue (drain)',
+			'Item consumed from queue',
 			array(
 				'flow_id'         => $flow_id,
 				'slot'            => $slot,
+				'queue_mode'      => $queue_mode,
 				'remaining_count' => count( $queue ),
 			)
 		);
 
-		return $popped_item;
+		return $entry;
 	}
 
 	/**

--- a/inc/Core/Steps/QueueableTrait.php
+++ b/inc/Core/Steps/QueueableTrait.php
@@ -44,7 +44,6 @@
 namespace DataMachine\Core\Steps;
 
 use DataMachine\Abilities\Flow\QueueAbility;
-use DataMachine\Core\Database\Flows\Flows as DB_Flows;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -193,7 +192,7 @@ trait QueueableTrait {
 			return null;
 		}
 
-		$entry = self::consumeFromQueueSlot(
+		$entry = QueueAbility::consumeFromQueueSlot(
 			(int) $flow_id,
 			$this->flow_step_id,
 			QueueAbility::SLOT_PROMPT_QUEUE,
@@ -260,7 +259,7 @@ trait QueueableTrait {
 			return null;
 		}
 
-		$entry = self::consumeFromQueueSlot(
+		$entry = QueueAbility::consumeFromQueueSlot(
 			(int) $flow_id,
 			$this->flow_step_id,
 			QueueAbility::SLOT_CONFIG_PATCH_QUEUE,
@@ -309,82 +308,12 @@ trait QueueableTrait {
 		);
 	}
 
-	/**
-	 * Consume one item from a named queue slot per the given mode.
-	 *
-	 * Centralizes the mode-aware read so prompt and config-patch
-	 * consumers share the same mutation/peek/rotate semantics. For
-	 * `drain` and `loop` the slot is rewritten in place; for `static`
-	 * no DB write happens.
-	 *
-	 * @param int      $flow_id      Flow ID.
-	 * @param string   $flow_step_id Flow step ID.
-	 * @param string   $slot         Queue slot name.
-	 * @param string   $queue_mode   "drain" | "loop" | "static".
-	 * @param DB_Flows $db_flows     Optional database instance.
-	 * @return array|null The consumed entry, or null if the queue was empty.
-	 */
-	private static function consumeFromQueueSlot(
-		int $flow_id,
-		string $flow_step_id,
-		string $slot,
-		string $queue_mode,
-		?DB_Flows $db_flows = null
-	): ?array {
-		if ( null === $db_flows ) {
-			$db_flows = new DB_Flows();
-		}
-
-		$flow = $db_flows->get_flow( $flow_id );
-		if ( ! $flow ) {
-			return null;
-		}
-
-		$flow_config = $flow['flow_config'] ?? array();
-		if ( ! isset( $flow_config[ $flow_step_id ] ) ) {
-			return null;
-		}
-
-		$step_config = $flow_config[ $flow_step_id ];
-		$queue       = $step_config[ $slot ] ?? array();
-
-		if ( empty( $queue ) ) {
-			return null;
-		}
-
-		// Static peek: read head, do not mutate storage.
-		if ( 'static' === $queue_mode ) {
-			return $queue[0];
-		}
-
-		// Drain or loop: pop the head, optionally rotate.
-		$entry = array_shift( $queue );
-
-		if ( 'loop' === $queue_mode ) {
-			$queue[] = $entry;
-		}
-
-		$flow_config[ $flow_step_id ][ $slot ] = $queue;
-
-		$db_flows->update_flow(
-			$flow_id,
-			array( 'flow_config' => $flow_config )
-		);
-
-		do_action(
-			'datamachine_log',
-			'info',
-			'Item consumed from queue',
-			array(
-				'flow_id'         => $flow_id,
-				'slot'            => $slot,
-				'queue_mode'      => $queue_mode,
-				'remaining_count' => count( $queue ),
-			)
-		);
-
-		return $entry;
-	}
+	// Note: the consumer-agnostic mode-aware reader lives on
+	// `QueueAbility::consumeFromQueueSlot()` (#1299). The trait
+	// delegates to it from `consumeOnceFromPromptQueue()` /
+	// `consumeOnceFromConfigPatchQueue()` above; AgentPingTask calls
+	// it directly. Single source of truth for drain / loop / static
+	// semantics regardless of which consumer is reading.
 
 	/**
 	 * Deep-merge a config patch into existing handler settings.

--- a/inc/Engine/AI/System/Tasks/AgentPingTask.php
+++ b/inc/Engine/AI/System/Tasks/AgentPingTask.php
@@ -62,13 +62,17 @@ class AgentPingTask extends SystemTask {
 
 		// Consume from flow queue when running as a pipeline step. The
 		// `queue_mode` enum (#1291) decides the access pattern:
-		//   - drain  → pop the head, discard
-		//   - loop   → pop the head, append to tail
-		//   - static → peek the head; do not mutate
+		//   - drain  → pop the head, discard. DB write.
+		//   - loop   → pop the head, append to tail. DB write.
+		//   - static → peek the head; do not mutate. No DB write.
 		// Static mode + non-empty `prompt` argument falls through to use
 		// the configured prompt directly. This preserves the pre-#1291
 		// behaviour where running an agent_ping task without a queue
 		// just sent the configured prompt every tick.
+		//
+		// #1299: shares `QueueAbility::consumeFromQueueSlot()` with
+		// `QueueableTrait` (AIStep / FetchStep). Single source of truth
+		// for the drain / loop / static semantics.
 		$from_queue   = false;
 		$flow_id      = (int) ( $params['flow_id'] ?? 0 );
 		$flow_step_id = $params['flow_step_id'] ?? '';
@@ -78,14 +82,40 @@ class AgentPingTask extends SystemTask {
 		}
 
 		if ( 'static' !== $queue_mode && $flow_id > 0 && ! empty( $flow_step_id ) ) {
-			$queued_item = ( 'loop' === $queue_mode )
-				? QueueAbility::loopFromQueue( $flow_id, $flow_step_id )
-				: QueueAbility::popFromQueue( $flow_id, $flow_step_id );
+			$queued_item = QueueAbility::consumeFromQueueSlot(
+				$flow_id,
+				$flow_step_id,
+				QueueAbility::SLOT_PROMPT_QUEUE,
+				$queue_mode
+			);
 
 			if ( $queued_item && ! empty( $queued_item['prompt'] ) ) {
 				$prompt     = $queued_item['prompt'];
 				$from_queue = true;
 
+				// Back up the popped prompt to engine_data for retry on
+				// failure. Mirrors `QueueableTrait::consumeOnceFromPromptQueue()`'s
+				// `queued_prompt_backup` write so a SendPingAbility
+				// failure after the pop doesn't lose the prompt. Static
+				// mode never mutates so no rollback is needed.
+				\datamachine_merge_engine_data(
+					$jobId,
+					array(
+						'queued_prompt_backup' => array(
+							'slot'         => QueueAbility::SLOT_PROMPT_QUEUE,
+							'mode'         => $queue_mode,
+							'prompt'       => $queued_item['prompt'],
+							'flow_id'      => $flow_id,
+							'flow_step_id' => $flow_step_id,
+							'added_at'     => $queued_item['added_at'] ?? null,
+						),
+					)
+				);
+
+				// `consumeFromQueueSlot` already logged the slot-level
+				// pop/rotate event with the unified shape. This second
+				// log line is the consumer-side announcement so an
+				// operator searching by "agent_ping" still finds it.
 				do_action(
 					'datamachine_log',
 					'info',

--- a/tests/queue-consumption-consolidation-smoke.php
+++ b/tests/queue-consumption-consolidation-smoke.php
@@ -1,0 +1,424 @@
+<?php
+/**
+ * Pure-PHP smoke test for the queue consumption consolidation (#1299).
+ *
+ * Run with: php tests/queue-consumption-consolidation-smoke.php
+ *
+ * Pre-#1299 the codebase had three queue consumers but only two shared
+ * a code path:
+ *
+ *   - AIStep              uses `QueueableTrait::consumeFromPromptQueue()`
+ *   - FetchStep           uses `QueueableTrait::consumeFromConfigPatchQueue()`
+ *   - AgentPingTask       called `QueueAbility::popFromQueue() / ::loopFromQueue()`
+ *                         directly — reimplementing pop logic minus the
+ *                         static-peek branch.
+ *
+ * The trait's `private static consumeFromQueueSlot()` and QueueAbility's
+ * `private static popFromQueueSlot()` were near-duplicates (drain/loop
+ * differed only in whether the popped entry was appended to the tail).
+ * The duplication meant queue-mode shape changes had to land in two
+ * places; AgentPingTask got a different log shape than the trait
+ * consumers; AgentPingTask had no `queued_prompt_backup` write, so a
+ * SendPingAbility failure after the pop silently lost the prompt.
+ *
+ * #1299 promotes the consumer-agnostic core to
+ * `QueueAbility::consumeFromQueueSlot()` (public static), deletes the
+ * three orphan helpers (`popFromQueue`, `loopFromQueue`,
+ * `popConfigPatchFromQueue` — the last had ZERO callers), and migrates
+ * AgentPingTask to call the new method directly. Single source of truth
+ * for the drain / loop / static semantics regardless of consumer.
+ *
+ * This smoke validates:
+ *
+ *   1. `QueueAbility::consumeFromQueueSlot` exists with the documented
+ *      signature.
+ *   2. Trait's wrapper methods delegate to the new public method.
+ *   3. AgentPingTask calls `consumeFromQueueSlot` directly (no
+ *      `popFromQueue` / `loopFromQueue` references remain).
+ *   4. The deleted helpers are truly gone from QueueAbility source.
+ *   5. AgentPingTask now writes `queued_prompt_backup` for retry parity
+ *      with the trait consumers.
+ *   6. `consumeFromQueueSlot` semantic correctness via in-memory
+ *      simulation: drain pops+writes, loop pops+rotates+writes, static
+ *      peeks no-op.
+ *   7. Unified log shape: `Item consumed from queue` with `slot` +
+ *      `queue_mode` + `remaining_count`.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failed = 0;
+$total  = 0;
+
+/**
+ * Assert helper.
+ *
+ * @param string $name      Test case name.
+ * @param bool   $condition Pass/fail.
+ */
+function assert_consolidation( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+	echo "  FAIL: {$name}\n";
+	++$failed;
+}
+
+$root_dir = dirname( __DIR__ );
+
+echo "=== Queue Consumption Consolidation Smoke (#1299) ===\n";
+
+// ---------------------------------------------------------------
+// SECTION 1: QueueAbility::consumeFromQueueSlot exists.
+// ---------------------------------------------------------------
+
+echo "\n[ability:1] QueueAbility::consumeFromQueueSlot is the new shared entry point\n";
+$qa_src = (string) file_get_contents( $root_dir . '/inc/Abilities/Flow/QueueAbility.php' );
+assert_consolidation(
+	'consumeFromQueueSlot is declared public static',
+	(bool) preg_match(
+		'/public static function consumeFromQueueSlot\(\s*int \$flow_id,\s*string \$flow_step_id,\s*string \$slot,\s*string \$queue_mode/s',
+		$qa_src
+	)
+);
+assert_consolidation(
+	'consumeFromQueueSlot accepts an optional DB_Flows instance for testing',
+	false !== strpos( $qa_src, '?DB_Flows $db_flows = null' )
+);
+
+// ---------------------------------------------------------------
+// SECTION 2: Trait delegates to the new method.
+// ---------------------------------------------------------------
+
+echo "\n[trait:1] QueueableTrait calls QueueAbility::consumeFromQueueSlot()\n";
+$trait_src = (string) file_get_contents( $root_dir . '/inc/Core/Steps/QueueableTrait.php' );
+$delegate_call_count = preg_match_all(
+	'/^\s*\$entry\s*=\s*QueueAbility::consumeFromQueueSlot\(/m',
+	$trait_src
+);
+assert_consolidation(
+	'trait delegates from both consumeOnce* methods (2 real callsites)',
+	2 === $delegate_call_count
+);
+
+echo "\n[trait:2] Trait no longer declares its own consumeFromQueueSlot\n";
+assert_consolidation(
+	'no `private static function consumeFromQueueSlot` declaration in the trait',
+	false === strpos( $trait_src, 'private static function consumeFromQueueSlot' )
+);
+assert_consolidation(
+	'no `self::consumeFromQueueSlot` calls (delegate goes through QueueAbility)',
+	false === strpos( $trait_src, 'self::consumeFromQueueSlot' )
+);
+
+echo "\n[trait:3] Trait dropped the now-unused DB_Flows import\n";
+assert_consolidation(
+	'use statement for `DB_Flows` is gone (no direct DB access in trait)',
+	false === strpos( $trait_src, 'use DataMachine\\Core\\Database\\Flows\\Flows as DB_Flows' )
+);
+
+// ---------------------------------------------------------------
+// SECTION 3: AgentPingTask calls the new method directly.
+// ---------------------------------------------------------------
+
+echo "\n[agent_ping:1] AgentPingTask calls QueueAbility::consumeFromQueueSlot()\n";
+$ping_src = (string) file_get_contents(
+	$root_dir . '/inc/Engine/AI/System/Tasks/AgentPingTask.php'
+);
+assert_consolidation(
+	'AgentPingTask calls QueueAbility::consumeFromQueueSlot()',
+	false !== strpos( $ping_src, 'QueueAbility::consumeFromQueueSlot(' )
+);
+assert_consolidation(
+	'call passes QueueAbility::SLOT_PROMPT_QUEUE constant',
+	false !== strpos( $ping_src, 'QueueAbility::SLOT_PROMPT_QUEUE' )
+);
+assert_consolidation(
+	'call threads queue_mode through (no separate loop/drain branch)',
+	(bool) preg_match(
+		'/consumeFromQueueSlot\([^)]*\$queue_mode\s*\)/s',
+		$ping_src
+	)
+);
+
+echo "\n[agent_ping:2] No references to the deleted helpers in AgentPingTask\n";
+assert_consolidation(
+	'AgentPingTask does NOT reference QueueAbility::popFromQueue',
+	false === strpos( $ping_src, 'QueueAbility::popFromQueue' )
+);
+assert_consolidation(
+	'AgentPingTask does NOT reference QueueAbility::loopFromQueue',
+	false === strpos( $ping_src, 'QueueAbility::loopFromQueue' )
+);
+
+// ---------------------------------------------------------------
+// SECTION 4: Deleted helpers are gone from QueueAbility source.
+// ---------------------------------------------------------------
+
+echo "\n[deletion:1] popFromQueue / loopFromQueue / popConfigPatchFromQueue / popFromQueueSlot are removed\n";
+foreach ( array(
+	'function popFromQueue(',
+	'function loopFromQueue(',
+	'function popConfigPatchFromQueue(',
+	'function popFromQueueSlot(',
+) as $needle ) {
+	assert_consolidation(
+		"`{$needle}` is gone from QueueAbility",
+		false === strpos( $qa_src, $needle )
+	);
+}
+
+echo "\n[deletion:2] No PHP file in the codebase calls the deleted helpers\n";
+$callers = array();
+$rii     = new \RecursiveIteratorIterator(
+	new \RecursiveDirectoryIterator( $root_dir, \FilesystemIterator::SKIP_DOTS )
+);
+$self_path = realpath( __FILE__ );
+foreach ( $rii as $file ) {
+	if ( $file->isDir() ) {
+		continue;
+	}
+	if ( 'php' !== strtolower( $file->getExtension() ) ) {
+		continue;
+	}
+	$path = $file->getPathname();
+	if (
+		false !== strpos( $path, '/vendor/' )
+		|| false !== strpos( $path, '/node_modules/' )
+		|| realpath( $path ) === $self_path
+	) {
+		// Skip vendor, node_modules, and this smoke file itself
+		// (the smoke contains the regex pattern as a string literal,
+		// which would self-match without this guard).
+		continue;
+	}
+	$contents = (string) file_get_contents( $path );
+	// Look for invocations only — historical docblock mentions are
+	// allowed (the QueueAbility + QueueableTrait docblocks document
+	// the migration on purpose).
+	if (
+		preg_match( '/\bQueueAbility::popFromQueue\s*\(/', $contents )
+		|| preg_match( '/\bQueueAbility::loopFromQueue\s*\(/', $contents )
+		|| preg_match( '/\bQueueAbility::popConfigPatchFromQueue\s*\(/', $contents )
+	) {
+		$callers[] = ltrim( str_replace( $root_dir, '', $path ), '/' );
+	}
+}
+assert_consolidation(
+	'no live call sites for any deleted helper',
+	array() === $callers
+);
+
+// ---------------------------------------------------------------
+// SECTION 5: AgentPingTask writes queued_prompt_backup for retry parity.
+// ---------------------------------------------------------------
+
+echo "\n[parity:1] AgentPingTask writes queued_prompt_backup after a mutating consume\n";
+assert_consolidation(
+	'datamachine_merge_engine_data() called from AgentPingTask',
+	false !== strpos( $ping_src, '\\datamachine_merge_engine_data(' )
+);
+assert_consolidation(
+	'queued_prompt_backup payload includes slot, mode, prompt, flow_id, flow_step_id',
+	false !== strpos( $ping_src, "'queued_prompt_backup'" )
+		&& false !== strpos( $ping_src, "'slot'         => QueueAbility::SLOT_PROMPT_QUEUE" )
+		&& false !== strpos( $ping_src, "'mode'         => \$queue_mode" )
+		&& false !== strpos( $ping_src, "'prompt'       => \$queued_item['prompt']" )
+);
+
+// ---------------------------------------------------------------
+// SECTION 6: In-memory consumeFromQueueSlot semantic correctness.
+// ---------------------------------------------------------------
+
+/**
+ * Pure-PHP simulator of `QueueAbility::consumeFromQueueSlot()` that
+ * mirrors the production logic. If the production behaviour drifts,
+ * the byte-mirror smoke catches it; if THIS function drifts from the
+ * behaviour, the assertions below fail. The simulator stands in for
+ * the real DB-backed flow_config storage.
+ *
+ * @param array  $flow_config    The full flow_config array (mutated).
+ * @param string $flow_step_id   Step ID.
+ * @param string $slot           Queue slot name.
+ * @param string $queue_mode     "drain" | "loop" | "static".
+ * @return array{ entry: ?array, mutated: bool, remaining_count: int }
+ */
+function simulate_consume_from_queue_slot(
+	array &$flow_config,
+	string $flow_step_id,
+	string $slot,
+	string $queue_mode
+): array {
+	if ( ! isset( $flow_config[ $flow_step_id ] ) ) {
+		return array( 'entry' => null, 'mutated' => false, 'remaining_count' => 0 );
+	}
+
+	$step_config = $flow_config[ $flow_step_id ];
+	$queue       = $step_config[ $slot ] ?? array();
+
+	if ( empty( $queue ) ) {
+		return array( 'entry' => null, 'mutated' => false, 'remaining_count' => 0 );
+	}
+
+	if ( 'static' === $queue_mode ) {
+		return array(
+			'entry'           => $queue[0],
+			'mutated'         => false,
+			'remaining_count' => count( $queue ),
+		);
+	}
+
+	$entry = array_shift( $queue );
+
+	if ( 'loop' === $queue_mode ) {
+		$queue[] = $entry;
+	}
+
+	$flow_config[ $flow_step_id ][ $slot ] = $queue;
+
+	return array(
+		'entry'           => $entry,
+		'mutated'         => true,
+		'remaining_count' => count( $queue ),
+	);
+}
+
+echo "\n[semantics:1] static mode peeks the head, no mutation\n";
+$fc = array(
+	'step1' => array(
+		'prompt_queue' => array(
+			array( 'prompt' => 'first',  'added_at' => 't0' ),
+			array( 'prompt' => 'second', 'added_at' => 't1' ),
+		),
+	),
+);
+$result = simulate_consume_from_queue_slot( $fc, 'step1', 'prompt_queue', 'static' );
+assert_consolidation(
+	'static returns the head entry',
+	'first' === ( $result['entry']['prompt'] ?? null )
+);
+assert_consolidation(
+	'static did NOT mutate storage',
+	false === $result['mutated']
+		&& 2 === count( $fc['step1']['prompt_queue'] )
+		&& 'first' === $fc['step1']['prompt_queue'][0]['prompt']
+);
+
+echo "\n[semantics:2] drain mode pops the head, head is gone after\n";
+$fc = array(
+	'step1' => array(
+		'prompt_queue' => array(
+			array( 'prompt' => 'first',  'added_at' => 't0' ),
+			array( 'prompt' => 'second', 'added_at' => 't1' ),
+		),
+	),
+);
+$result = simulate_consume_from_queue_slot( $fc, 'step1', 'prompt_queue', 'drain' );
+assert_consolidation(
+	'drain returns the head entry',
+	'first' === ( $result['entry']['prompt'] ?? null )
+);
+assert_consolidation(
+	'drain mutated storage and dropped the head',
+	true === $result['mutated']
+		&& 1 === count( $fc['step1']['prompt_queue'] )
+		&& 'second' === $fc['step1']['prompt_queue'][0]['prompt']
+);
+assert_consolidation(
+	'drain reports remaining_count = 1 after popping from a 2-entry queue',
+	1 === $result['remaining_count']
+);
+
+echo "\n[semantics:3] loop mode pops the head and appends it to the tail\n";
+$fc = array(
+	'step1' => array(
+		'prompt_queue' => array(
+			array( 'prompt' => 'first',  'added_at' => 't0' ),
+			array( 'prompt' => 'second', 'added_at' => 't1' ),
+		),
+	),
+);
+$result = simulate_consume_from_queue_slot( $fc, 'step1', 'prompt_queue', 'loop' );
+assert_consolidation(
+	'loop returns the head entry',
+	'first' === ( $result['entry']['prompt'] ?? null )
+);
+assert_consolidation(
+	'loop rotated the head to the tail',
+	true === $result['mutated']
+		&& 2 === count( $fc['step1']['prompt_queue'] )
+		&& 'second' === $fc['step1']['prompt_queue'][0]['prompt']
+		&& 'first' === $fc['step1']['prompt_queue'][1]['prompt']
+);
+
+echo "\n[semantics:4] empty queue returns null entry regardless of mode\n";
+foreach ( array( 'static', 'drain', 'loop' ) as $mode ) {
+	$fc = array( 'step1' => array( 'prompt_queue' => array() ) );
+	$result = simulate_consume_from_queue_slot( $fc, 'step1', 'prompt_queue', $mode );
+	assert_consolidation(
+		"empty queue + mode={$mode} returns null entry",
+		null === $result['entry']
+	);
+}
+
+echo "\n[semantics:5] missing flow_step_id returns null without error\n";
+$fc = array();
+$result = simulate_consume_from_queue_slot( $fc, 'step1', 'prompt_queue', 'drain' );
+assert_consolidation(
+	'missing step degrades to null entry, no exception',
+	null === $result['entry']
+);
+
+echo "\n[semantics:6] config_patch_queue slot uses the same logic as prompt_queue\n";
+$fc = array(
+	'step1' => array(
+		'config_patch_queue' => array(
+			array( 'patch' => array( 'after' => '2017-03' ), 'added_at' => 't0' ),
+		),
+	),
+);
+$result = simulate_consume_from_queue_slot( $fc, 'step1', 'config_patch_queue', 'drain' );
+assert_consolidation(
+	'config_patch_queue drain returns the patch entry',
+	array( 'after' => '2017-03' ) === ( $result['entry']['patch'] ?? null )
+);
+assert_consolidation(
+	'config_patch_queue drain emptied the slot',
+	0 === count( $fc['step1']['config_patch_queue'] )
+);
+
+// ---------------------------------------------------------------
+// SECTION 7: Unified log shape.
+// ---------------------------------------------------------------
+
+echo "\n[logging:1] consumeFromQueueSlot logs `Item consumed from queue` with unified shape\n";
+assert_consolidation(
+	'production source logs `Item consumed from queue`',
+	false !== strpos( $qa_src, "'Item consumed from queue'" )
+);
+foreach ( array(
+	"'flow_id'",
+	"'slot'",
+	"'queue_mode'",
+	"'remaining_count'",
+) as $field ) {
+	assert_consolidation(
+		"log payload includes {$field}",
+		false !== strpos( $qa_src, $field )
+	);
+}
+
+echo "\n";
+if ( 0 === $failed ) {
+	echo "=== queue-consumption-consolidation-smoke: ALL PASS ({$total}) ===\n";
+	exit( 0 );
+}
+echo "=== queue-consumption-consolidation-smoke: {$failed} FAIL of {$total} ===\n";
+exit( 1 );


### PR DESCRIPTION
Closes #1299.

## Summary

Pre-#1299 the codebase had three queue consumers but only two shared a code path:

- **AIStep** used `QueueableTrait::consumeFromPromptQueue()`
- **FetchStep** used `QueueableTrait::consumeFromConfigPatchQueue()`
- **AgentPingTask** called `QueueAbility::popFromQueue()` / `::loopFromQueue()` directly, reimplementing pop logic minus the static-peek branch.

The trait's `private static consumeFromQueueSlot()` and QueueAbility's `private static popFromQueueSlot()` were near-duplicates — drain/loop differed only in whether the popped entry was appended to the tail. The duplication meant queue-mode shape changes had to land in two places (the trigger for #1299 was migrating `queue_enabled → queue_mode` and having to add `loopFromQueue` specifically for AgentPingTask). The log message shape diverged. **AgentPingTask had no `queued_prompt_backup` write**, so a SendPingAbility failure after the pop silently lost the prompt — a real reliability gap.

This PR promotes the consumer-agnostic core to a single public static method and drops the duplicates.

## Changes

### `inc/Abilities/Flow/QueueAbility.php`

- New `public static consumeFromQueueSlot( $flow_id, $flow_step_id, $slot, $queue_mode, ?$db_flows )` is the **single source of truth** for the drain / loop / static access pattern (#1291). Identical body to the trait's old private static helper (which moved here).
- Deleted `popFromQueue`, `loopFromQueue`, `popConfigPatchFromQueue`, and the underlying private `popFromQueueSlot` helper. The first two had AgentPingTask as their only callers; **`popConfigPatchFromQueue` had ZERO callers** and was already dead per the deprecation policy.

### `inc/Core/Steps/QueueableTrait.php`

- `consumeOnceFromPromptQueue()` and `consumeOnceFromConfigPatchQueue()` delegate to `QueueAbility::consumeFromQueueSlot()` instead of the local private static helper.
- Local `consumeFromQueueSlot()` private static method deleted (75 lines, fully superseded).
- Drops the now-unused `use ...Flows as DB_Flows` import (the trait no longer touches the DB directly).

### `inc/Engine/AI/System/Tasks/AgentPingTask.php`

- Single `QueueAbility::consumeFromQueueSlot()` call replaces the drain-vs-loop ternary that called the now-deleted helpers.
- **Now writes `queued_prompt_backup` to engine_data** after a mutating consume (drain or loop) — mirrors the trait's reliability semantic. Pre-#1299, a SendPingAbility failure after the pop silently lost the prompt; post-#1299 the pop is recoverable from engine_data on retry.
- Static mode skips the backup (no mutation = no rollback needed).

## Tests

Added `tests/queue-consumption-consolidation-smoke.php` — **36-assertion** pure-PHP smoke that:

- Verifies the new `QueueAbility::consumeFromQueueSlot()` signature.
- Confirms QueueableTrait delegates from both consumeOnce* methods (2 real call sites, not counting the docblock breadcrumb).
- Confirms AgentPingTask calls the new method directly with no references to the deleted helpers remaining.
- Source-greps the deleted functions and asserts they're gone AND that no PHP file in the codebase calls them (excluding the smoke itself, which contains the regex pattern as a string literal).
- Confirms AgentPingTask now writes `queued_prompt_backup` for retry parity.
- Simulates the consumeFromQueueSlot logic in pure PHP to lock the drain / loop / static / empty / missing semantics — six scenarios covering both `prompt_queue` and `config_patch_queue` slots.
- Asserts the unified `Item consumed from queue` log line shape.

All 7 prior smokes still pass:
- queue-mode-collapse-smoke (58)
- queue-mode-callsites-smoke (31)
- queue-payload-split-smoke (41)
- queueable-trait-smoke
- flow-update-set-user-message-smoke (31)
- jobs-get-children-smoke
- system-task-agent-context-smoke (41)

## Live verify

End-to-end on `intelligence-chubes4` with the live site repointed at the worktree:

1. `studio wp datamachine flow queue add 2 --step=<id> --patch='{...}'` stages a config patch.
2. `studio wp datamachine flow run 2` schedules the flow.
3. `studio wp action-scheduler run --hooks=datamachine_execute_step` ticks AS, FetchStep fires.
4. DM logs show the new unified shape end-to-end:

```
INFO: Config patch added to queue
INFO: Flow execution started successfully
INFO: Pipeline batch: all 5 items scheduled
INFO: Item consumed from queue        ← new shared log line
INFO: Using config patch from queue   ← consumer-side announcement
INFO: Fetch step merged queued config patch
INFO: MCP: Fetching from a8c/mgs/search
```

5. Patch is gone from the queue post-tick (drain semantic).
6. Zero fatals or queue-related errors in `debug.log`.
7. Site restored to deployed copy.

The patched-window fetch actually executed (item 7 above), which proves the trait → QueueAbility delegation works under real Action Scheduler load, not just unit-test isolation.

## Out of scope

- A typed `QueueConsumerContext` value object would be the cleaner end state for the trait → AgentPingTask boundary (option 1 from #1299). The current public-static method takes scalar arguments which is fine for two consumers but starts to wear if a fourth consumer needs more context. File a follow-up if/when a fourth consumer surfaces.
- The `queued_prompt_backup` engine_data write is not yet wired to a retry-on-failure path — it's stored so a future retry can restore the prompt to the queue if the post-pop work failed. Wiring the retry consumer is a separate PR; this one just closes the parity gap so AgentPingTask's data isn't silently lost.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Mapped the three consumers and the four duplicate helper functions, designed the public-static promotion (option 2 from #1299), wrote the migration end-to-end (QueueAbility + QueueableTrait + AgentPingTask), authored the 36-assertion smoke harness, and live-verified the production-shape end-to-end on intelligence-chubes4 (CLI add → AS tick → FetchStep drain → unified log shape). Chris reviewed the strategy (lighter-touch static method promotion over a typed value object, drop the dead `popConfigPatchFromQueue` helper outright per the no-shim policy, add backup-on-mutation parity to AgentPingTask).
