### PR TITLE
feat(cli): add fetch handler dry-run alias

### DIFF
--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -40,6 +40,7 @@ WP_CLI::add_command( 'datamachine step-types', Commands\StepTypesCommand::class 
 WP_CLI::add_command( 'datamachine processed-items', Commands\ProcessedItemsCommand::class );
 WP_CLI::add_command( 'datamachine retention', Commands\RetentionCommand::class );
 WP_CLI::add_command( 'datamachine test', Commands\TestCommand::class );
+WP_CLI::add_command( 'datamachine fetch test', Commands\TestCommand::class );
 WP_CLI::add_command( 'datamachine external', Commands\ExternalCommand::class );
 
 // Aliases for AI agent compatibility (singular/plural variants).

--- a/inc/Cli/Commands/HandlersCommand.php
+++ b/inc/Cli/Commands/HandlersCommand.php
@@ -31,6 +31,9 @@ class HandlersCommand extends BaseCommand {
 	 * [--step-type=<step_type>]
 	 * : Filter by step type (fetch, publish, upsert, etc.).
 	 *
+	 * [--handler=<slug>]
+	 * : Filter to one handler slug and include its settings class.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -46,20 +49,30 @@ class HandlersCommand extends BaseCommand {
 	 *
 	 *     wp datamachine handlers list
 	 *     wp datamachine handlers list --step-type=fetch
+	 *     wp datamachine handlers list --handler=rss
 	 *     wp datamachine handlers list --format=json
 	 *
 	 * @subcommand list
 	 */
 	public function list_handlers( array $args, array $assoc_args ): void {
-		$step_type = $assoc_args['step-type'] ?? null;
-		$format    = $assoc_args['format'] ?? 'table';
+		$step_type    = $assoc_args['step-type'] ?? null;
+		$handler_slug = $assoc_args['handler'] ?? null;
+		$format       = $assoc_args['format'] ?? 'table';
 
 		$ability = new HandlerAbilities();
 		$result  = $ability->executeGetHandlers(
 			array(
-				'step_type' => $step_type,
+				'step_type'    => $step_type,
+				'handler_slug' => $handler_slug,
 			)
 		);
+
+		if ( $handler_slug ) {
+			$settings_class = $ability->getSettingsClass( $handler_slug );
+			if ( isset( $result['handlers'][ $handler_slug ] ) ) {
+				$result['handlers'][ $handler_slug ]['settings_class'] = $settings_class ? get_class( $settings_class ) : '';
+			}
+		}
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to get handlers.' );
@@ -84,11 +97,14 @@ class HandlersCommand extends BaseCommand {
 			$items[] = array(
 				'slug'      => $slug,
 				'label'     => $handler['label'] ?? '',
-				'step_type' => $handler['step_type'] ?? '',
+				'step_type'      => $handler['step_type'] ?? '',
+				'settings_class' => $handler['settings_class'] ?? '',
 			);
 		}
 
-		$fields = array( 'slug', 'label', 'step_type' );
+		$fields = $handler_slug
+			? array( 'slug', 'label', 'step_type', 'settings_class' )
+			: array( 'slug', 'label', 'step_type' );
 		$this->format_items( $items, $fields, $assoc_args, 'slug' );
 
 		WP_CLI::log( sprintf( 'Total: %d handler(s).', $result['count'] ) );

--- a/inc/Cli/Commands/TestCommand.php
+++ b/inc/Cli/Commands/TestCommand.php
@@ -31,6 +31,7 @@ defined( 'ABSPATH' ) || exit;
  *
  *     # Test a handler with config
  *     wp datamachine test ticketmaster --config='{"lat":32.7,"lng":-79.9,"radius":50}'
+ *     wp datamachine fetch test --handler=ticketmaster --config='{"lat":32.7,"lng":-79.9,"radius":50}'
  *
  *     # Test using an existing flow's config
  *     wp datamachine test --flow=42
@@ -49,6 +50,9 @@ class TestCommand extends BaseCommand {
 	 *
 	 * [<handler>]
 	 * : Handler slug to test.
+	 *
+	 * [--handler=<slug>]
+	 * : Handler slug to test. Useful for the `wp datamachine fetch test` alias.
 	 *
 	 * [--config=<json>]
 	 * : Handler config as JSON string.
@@ -84,6 +88,7 @@ class TestCommand extends BaseCommand {
 	 *     wp datamachine test --list
 	 *     wp datamachine test ticketmaster --describe
 	 *     wp datamachine test ticketmaster --config='{"lat":32.7,"lng":-79.9,"radius":50}'
+	 *     wp datamachine fetch test --handler=ticketmaster --config='{"lat":32.7,"lng":-79.9,"radius":50}'
 	 *     wp datamachine test rss --config='{"feed_url":"https://example.com/feed"}'
 	 *     wp datamachine test --flow=42
 	 *     wp datamachine test ticketmaster --config='...' --limit=3 --format=json
@@ -91,7 +96,7 @@ class TestCommand extends BaseCommand {
 	 * @when after_wp_load
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
-		$handler_slug = $args[0] ?? null;
+		$handler_slug = $assoc_args['handler'] ?? ( $args[0] ?? null );
 		$format       = $assoc_args['format'] ?? 'table';
 
 		// --list: show available handlers.

--- a/tests/fetch-test-cli-smoke.php
+++ b/tests/fetch-test-cli-smoke.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Pure-PHP smoke test for `wp datamachine fetch test` (#1156).
+ *
+ * Run with: php tests/fetch-test-cli-smoke.php
+ *
+ * The handler dry-run runner already exists as `wp datamachine test`.
+ * This smoke pins the CLI alias and companion handler discovery surface
+ * requested by #1156 without booting WordPress.
+ *
+ * @package DataMachine\Tests
+ */
+
+$root = dirname( __DIR__ );
+
+$files = array(
+	'bootstrap' => file_get_contents( $root . '/inc/Cli/Bootstrap.php' ),
+	'test'      => file_get_contents( $root . '/inc/Cli/Commands/TestCommand.php' ),
+	'handlers'  => file_get_contents( $root . '/inc/Cli/Commands/HandlersCommand.php' ),
+);
+
+$failed = 0;
+$total  = 0;
+
+function assert_fetch_cli( string $name, bool $condition, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	++$failed;
+	echo "  [FAIL] {$name}" . ( $detail ? " — {$detail}" : '' ) . "\n";
+}
+
+echo "=== fetch-test-cli-smoke ===\n";
+
+assert_fetch_cli(
+	'Bootstrap registers datamachine fetch test alias',
+	str_contains( $files['bootstrap'], "WP_CLI::add_command( 'datamachine fetch test', Commands\\TestCommand::class );" )
+);
+
+assert_fetch_cli(
+	'TestCommand accepts --handler before positional fallback',
+	str_contains( $files['test'], "\$handler_slug = \$assoc_args['handler'] ?? ( \$args[0] ?? null );" )
+);
+
+assert_fetch_cli(
+	'TestCommand documents fetch test alias example',
+	str_contains( $files['test'], 'wp datamachine fetch test --handler=ticketmaster' )
+);
+
+assert_fetch_cli(
+	'HandlersCommand documents --handler option',
+	str_contains( $files['handlers'], '[--handler=<slug>]' )
+);
+
+assert_fetch_cli(
+	'HandlersCommand passes handler_slug to HandlerAbilities',
+	str_contains( $files['handlers'], "'handler_slug' => \$handler_slug" )
+);
+
+assert_fetch_cli(
+	'HandlersCommand enriches single-handler output with settings_class',
+	str_contains( $files['handlers'], "['settings_class'] = \$settings_class ? get_class( \$settings_class ) : '';" )
+);
+
+assert_fetch_cli(
+	'HandlersCommand shows settings_class only for filtered handler table',
+	str_contains( $files['handlers'], "? array( 'slug', 'label', 'step_type', 'settings_class' )" )
+);
+
+if ( $failed > 0 ) {
+	echo "\nfetch-test-cli-smoke failed: {$failed}/{$total} assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nfetch-test-cli-smoke passed: {$total} assertions.\n";


### PR DESCRIPTION
## Summary
- Adds `wp datamachine fetch test --handler=<slug>` as a discoverable alias for the existing handler dry-run runner.
- Adds `wp datamachine handlers list --handler=<slug>` so authors can inspect one handler and its settings class.
- Covers the CLI surface with a pure-PHP smoke test.

## Tests
- `php tests/fetch-test-cli-smoke.php`
- `php -l inc/Cli/Bootstrap.php`
- `php -l inc/Cli/Commands/TestCommand.php`
- `php -l inc/Cli/Commands/HandlersCommand.php`
- `php -l tests/fetch-test-cli-smoke.php`

Closes #1156

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI alias, handler filter, and smoke coverage; Chris remains responsible for review and merge.