### PR TITLE
refactor(flow): collapse handler config shapes

### DIFF
--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -19,6 +19,7 @@ use DataMachine\Core\Admin\FlowFormatter;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -321,8 +322,7 @@ trait FlowHelpers {
 				$flow_config = $flow['flow_config'] ?? array();
 
 				foreach ( $flow_config as $flow_step_id => $step_data ) {
-					// Data is normalized at the DB layer — handler_slugs is canonical.
-					$handler_slugs = $step_data['handler_slugs'] ?? array();
+					$handler_slugs = FlowStepConfig::getConfiguredHandlerSlugs( $step_data );
 					if ( in_array( $handler_slug, $handler_slugs, true ) ) {
 						return true;
 					}
@@ -439,12 +439,14 @@ trait FlowHelpers {
 			if ( isset( $source_steps_by_order[ $order ] ) ) {
 				$source_step = $source_steps_by_order[ $order ];
 
-				// Data is normalized at the DB layer — copy canonical plural fields.
-				if ( ! empty( $source_step['handler_slugs'] ) ) {
-					$new_step_config['handler_slugs'] = $source_step['handler_slugs'];
-				}
-				if ( ! empty( $source_step['handler_configs'] ) ) {
-					$new_step_config['handler_configs'] = $source_step['handler_configs'];
+				// Copy canonical handler fields verbatim. Single-handler steps use
+				// handler_slug/handler_config; multi-handler steps use
+				// handler_slugs/handler_configs; handler-free steps only carry
+				// handler_config when they have step-level settings.
+				foreach ( array( 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs' ) as $handler_field ) {
+					if ( array_key_exists( $handler_field, $source_step ) ) {
+						$new_step_config[ $handler_field ] = $source_step[ $handler_field ];
+					}
 				}
 
 				// Queue state copies verbatim (#1291 / #1292): AI steps
@@ -473,13 +475,27 @@ trait FlowHelpers {
 			$override = $this->resolveOverride( $overrides, $step_type, $order );
 			if ( $override ) {
 				if ( ! empty( $override['handler_slug'] ) ) {
-					$new_step_config['handler_slugs']   = array( $override['handler_slug'] );
-					$handler_config                     = $override['handler_config'] ?? array();
-					$new_step_config['handler_configs'] = array( $override['handler_slug'] => $handler_config );
-				} elseif ( ! empty( $override['handler_config'] ) && ! empty( $new_step_config['handler_slugs'] ) ) {
-					$primary_slug                                        = $new_step_config['handler_slugs'][0];
-					$existing_config                                     = $new_step_config['handler_configs'][ $primary_slug ] ?? array();
-					$new_step_config['handler_configs'][ $primary_slug ] = array_merge( $existing_config, $override['handler_config'] );
+					$handler_config = $override['handler_config'] ?? array();
+					if ( FlowStepConfig::isMultiHandler( $new_step_config ) ) {
+						$new_step_config['handler_slugs']   = array( $override['handler_slug'] );
+						$new_step_config['handler_configs'] = array( $override['handler_slug'] => $handler_config );
+						unset( $new_step_config['handler_slug'], $new_step_config['handler_config'] );
+					} else {
+						$new_step_config['handler_slug']   = $override['handler_slug'];
+						$new_step_config['handler_config'] = $handler_config;
+						unset( $new_step_config['handler_slugs'], $new_step_config['handler_configs'] );
+					}
+				} elseif ( ! empty( $override['handler_config'] ) ) {
+					if ( FlowStepConfig::isMultiHandler( $new_step_config ) ) {
+						$primary_slug = FlowStepConfig::getPrimaryHandlerSlug( $new_step_config );
+						if ( null !== $primary_slug ) {
+							$existing_config                                      = $new_step_config['handler_configs'][ $primary_slug ] ?? array();
+							$new_step_config['handler_configs'][ $primary_slug ] = array_merge( $existing_config, $override['handler_config'] );
+						}
+					} else {
+						$existing_config                   = FlowStepConfig::getPrimaryHandlerConfig( $new_step_config );
+						$new_step_config['handler_config'] = array_merge( $existing_config, $override['handler_config'] );
+					}
 				}
 				// Override user_message arrives as a workflow-spec input
 				// (matches the public contract used by `flow copy` and
@@ -560,13 +576,12 @@ trait FlowHelpers {
 				continue;
 			}
 
-			// Normalize plural forms to the singular keys that UpdateFlowStepAbility expects.
-			// CLI and admin UI naturally pass handler_slugs (array) and handler_configs (keyed object),
-			// but the ability expects handler_slug (string) and handler_config (object).
+			// Multi-handler configs use handler_slugs/handler_configs; single-handler
+			// and handler-free configs use handler_slug/handler_config.
 			$handler_slugs   = $config['handler_slugs'] ?? array();
 			$handler_configs = $config['handler_configs'] ?? array();
 
-			// If singular forms are provided, use those directly (backward compat with --handler-config path).
+			// Scalar forms go through UpdateFlowStepAbility.
 			$single_slug   = $config['handler_slug'] ?? '';
 			$single_config = $config['handler_config'] ?? array();
 
@@ -668,7 +683,7 @@ trait FlowHelpers {
 			}
 
 			// Skip if handler already configured.
-			if ( ! empty( $step_data['handler_slugs'] ) ) {
+			if ( ! empty( FlowStepConfig::getConfiguredHandlerSlugs( $step_data ) ) ) {
 				continue;
 			}
 

--- a/inc/Abilities/Flow/QueueAbility.php
+++ b/inc/Abilities/Flow/QueueAbility.php
@@ -34,6 +34,7 @@ namespace DataMachine\Abilities\Flow;
 
 use DataMachine\Core\Database\Flows\Flows as DB_Flows;
 use DataMachine\Abilities\DuplicateCheck\DuplicateCheckAbility;
+use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -1725,7 +1726,7 @@ class QueueAbility {
 			if ( ( $step_config['step_type'] ?? '' ) !== 'publish' ) {
 				continue;
 			}
-			$handler_configs = $step_config['handler_configs'] ?? array();
+			$handler_configs = FlowStepConfig::getHandlerConfigs( $step_config );
 			foreach ( $handler_configs as $handler_config ) {
 				if ( ! empty( $handler_config['post_type'] ) ) {
 					return sanitize_text_field( $handler_config['post_type'] );

--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Abilities\FlowStep;
 
+use DataMachine\Core\Steps\FlowStepConfig;
+
 defined( 'ABSPATH' ) || exit;
 
 class ConfigureFlowStepsAbility {
@@ -232,15 +234,15 @@ class ConfigureFlowStepsAbility {
 				}
 
 				if ( ! empty( $handler_slug ) ) {
-					if ( ! in_array( $handler_slug, $step_config['handler_slugs'] ?? array(), true ) ) {
+					if ( ! in_array( $handler_slug, FlowStepConfig::getConfiguredHandlerSlugs( $step_config ), true ) ) {
 						continue;
 					}
 				}
 
-				$existing_handler_slug   = \DataMachine\Core\Steps\FlowStepConfig::getEffectiveSlug( $step_config );
-				$existing_handler_config = \DataMachine\Core\Steps\FlowStepConfig::getPrimaryHandlerConfig( $step_config );
+				$existing_handler_slug   = FlowStepConfig::getEffectiveSlug( $step_config );
+				$existing_handler_config = FlowStepConfig::getPrimaryHandlerConfig( $step_config );
 
-				$effective_handler_slug = \DataMachine\Core\Steps\FlowStepConfig::getEffectiveSlug( $step_config, $target_handler_slug ?? '' );
+				$effective_handler_slug = FlowStepConfig::getEffectiveSlug( $step_config, $target_handler_slug ?? '' );
 
 				if ( empty( $effective_handler_slug ) ) {
 					$errors[] = array(
@@ -543,7 +545,7 @@ class ConfigureFlowStepsAbility {
 				$handler_config = $config['handler_config'] ?? array();
 				$user_message   = $config['user_message'] ?? null;
 
-				$effective_slug = \DataMachine\Core\Steps\FlowStepConfig::getEffectiveSlug( $flow_config[ $flow_step_id ], $handler_slug ?? '' );
+				$effective_slug = FlowStepConfig::getEffectiveSlug( $flow_config[ $flow_step_id ], $handler_slug ?? '' );
 
 				if ( ! empty( $handler_config ) && ! empty( $effective_slug ) ) {
 					$validation_result = $this->validateHandlerConfig( $effective_slug, $handler_config );
@@ -707,7 +709,7 @@ class ConfigureFlowStepsAbility {
 					}
 				}
 
-				if ( in_array( $handler_slug, $step_config['handler_slugs'] ?? array(), true ) ) {
+				if ( in_array( $handler_slug, FlowStepConfig::getConfiguredHandlerSlugs( $step_config ), true ) ) {
 					$matching_flows[] = array(
 						'flow'         => $flow,
 						'flow_step_id' => $flow_step_id,
@@ -758,10 +760,10 @@ class ConfigureFlowStepsAbility {
 			$flow_id      = (int) $flow['flow_id'];
 			$flow_name    = $flow['flow_name'] ?? __( 'Unnamed Flow', 'data-machine' );
 
-			$existing_handler_slug   = \DataMachine\Core\Steps\FlowStepConfig::getEffectiveSlug( $step_config );
-			$existing_handler_config = \DataMachine\Core\Steps\FlowStepConfig::getPrimaryHandlerConfig( $step_config );
+			$existing_handler_slug   = FlowStepConfig::getEffectiveSlug( $step_config );
+			$existing_handler_config = FlowStepConfig::getPrimaryHandlerConfig( $step_config );
 
-			$effective_handler_slug = \DataMachine\Core\Steps\FlowStepConfig::getEffectiveSlug( $step_config, $target_handler_slug ?? '' );
+			$effective_handler_slug = FlowStepConfig::getEffectiveSlug( $step_config, $target_handler_slug ?? '' );
 			$is_switching           = ! empty( $target_handler_slug ) && $target_handler_slug !== $existing_handler_slug;
 
 			if ( $is_switching && ! empty( $existing_handler_config ) ) {

--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -305,30 +305,26 @@ trait FlowStepHelpers {
 			);
 		}
 
-		$effective_slug = FlowStepConfig::getEffectiveSlug( $flow_config[ $flow_step_id ], $handler_slug );
+		$step = &$flow_config[ $flow_step_id ];
+
+		$uses_handler     = FlowStepConfig::usesHandler( $step );
+		$is_multi_handler = FlowStepConfig::isMultiHandler( $step );
+		$effective_slug   = $uses_handler
+			? FlowStepConfig::getEffectiveSlug( $step, $handler_slug )
+			: ( $step['step_type'] ?? '' );
 
 		if ( empty( $effective_slug ) ) {
 			do_action( 'datamachine_log', 'error', 'No handler slug or step_type available for flow step update', array( 'flow_step_id' => $flow_step_id ) );
+			unset( $step );
 			return false;
 		}
 
-		// Ensure handler_slugs array contains the effective slug.
-		$current_slugs = $flow_config[ $flow_step_id ]['handler_slugs'] ?? array();
-		if ( ! in_array( $effective_slug, $current_slugs, true ) ) {
-			$current_slugs = array( $effective_slug );
-		} elseif ( $current_slugs[0] !== $effective_slug ) {
-			// Move to first position (primary).
-			$current_slugs = array_diff( $current_slugs, array( $effective_slug ) );
-			array_unshift( $current_slugs, $effective_slug );
-		}
-		$flow_config[ $flow_step_id ]['handler_slugs'] = $current_slugs;
-
-		// Get existing config for this handler.
-		$existing_handler_config = $flow_config[ $flow_step_id ]['handler_configs'][ $effective_slug ] ?? array();
+		// Get existing config for this handler/settings slug.
+		$existing_handler_config = FlowStepConfig::getHandlerConfigForSlug( $step, $effective_slug );
 
 		// If switching handlers, strip legacy config fields that don't belong to the new handler.
-		$current_primary = $flow_config[ $flow_step_id ]['handler_slugs'][0] ?? '';
-		if ( $current_primary !== $effective_slug ) {
+		$current_primary = FlowStepConfig::getPrimaryHandlerSlug( $step ) ?? '';
+		if ( $uses_handler && $current_primary !== $effective_slug ) {
 			$valid_fields = array_keys( $this->handler_abilities->getConfigFields( $effective_slug ) );
 			if ( ! empty( $valid_fields ) ) {
 				$existing_handler_config = array_intersect_key( $existing_handler_config, array_flip( $valid_fields ) );
@@ -340,10 +336,34 @@ trait FlowStepHelpers {
 		// Sanitize incoming values via handler's settings class before merge.
 		$handler_settings = $this->sanitizeHandlerConfig( $effective_slug, $handler_settings );
 
-		// Merge and store in handler_configs.
 		$merged_config = array_merge( $existing_handler_config, $handler_settings );
-		$flow_config[ $flow_step_id ]['handler_configs'][ $effective_slug ] = $this->handler_abilities->applyDefaults( $effective_slug, $merged_config );
-		$flow_config[ $flow_step_id ]['enabled']                            = true;
+		$stored_config = $this->handler_abilities->applyDefaults( $effective_slug, $merged_config );
+
+		if ( ! $uses_handler ) {
+			$step['handler_config'] = $stored_config;
+			unset( $step['handler_slug'], $step['handler_slugs'], $step['handler_configs'] );
+		} elseif ( $is_multi_handler ) {
+			$current_slugs = FlowStepConfig::getHandlerSlugs( $step );
+			if ( ! in_array( $effective_slug, $current_slugs, true ) ) {
+				$current_slugs = array( $effective_slug );
+			} elseif ( $current_slugs[0] !== $effective_slug ) {
+				$current_slugs = array_values( array_diff( $current_slugs, array( $effective_slug ) ) );
+				array_unshift( $current_slugs, $effective_slug );
+			}
+
+			$handler_configs                    = is_array( $step['handler_configs'] ?? null ) ? $step['handler_configs'] : array();
+			$handler_configs[ $effective_slug ] = $stored_config;
+			$step['handler_slugs']              = $current_slugs;
+			$step['handler_configs']            = $handler_configs;
+			unset( $step['handler_slug'], $step['handler_config'] );
+		} else {
+			$step['handler_slug']   = $effective_slug;
+			$step['handler_config'] = $stored_config;
+			unset( $step['handler_slugs'], $step['handler_configs'] );
+		}
+
+		$step['enabled'] = true;
+		unset( $step );
 
 		$success = $this->db_flows->update_flow(
 			$flow_id,
@@ -404,7 +424,16 @@ trait FlowStepHelpers {
 
 		$step = &$flow_config[ $flow_step_id ];
 
-		$existing_slugs = $step['handler_slugs'] ?? array();
+		if ( ! FlowStepConfig::isMultiHandler( $step ) ) {
+			do_action( 'datamachine_log', 'error', 'Cannot add multiple handlers to single-handler step', array(
+				'flow_step_id' => $flow_step_id,
+				'step_type'    => $step['step_type'] ?? '',
+			) );
+			unset( $step );
+			return false;
+		}
+
+		$existing_slugs = FlowStepConfig::getHandlerSlugs( $step );
 
 		// Don't add duplicates.
 		if ( in_array( $handler_slug, $existing_slugs, true ) ) {
@@ -483,8 +512,12 @@ trait FlowStepHelpers {
 		}
 
 		$step = &$flow_config[ $flow_step_id ];
+		if ( ! FlowStepConfig::isMultiHandler( $step ) ) {
+			unset( $step );
+			return false;
+		}
 
-		$existing_slugs = $step['handler_slugs'] ?? array();
+		$existing_slugs = FlowStepConfig::getHandlerSlugs( $step );
 		$existing_slugs = array_values( array_filter( $existing_slugs, fn( $s ) => $s !== $handler_slug ) );
 
 		$step['handler_slugs'] = $existing_slugs;

--- a/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
+++ b/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Abilities\FlowStep;
 
+use DataMachine\Core\Steps\FlowStepConfig;
+
 defined( 'ABSPATH' ) || exit;
 
 class ValidateFlowStepsConfigAbility {
@@ -195,15 +197,15 @@ class ValidateFlowStepsConfigAbility {
 				}
 
 				if ( ! empty( $handler_slug ) ) {
-					if ( ! in_array( $handler_slug, $step_config['handler_slugs'] ?? array(), true ) ) {
+					if ( ! in_array( $handler_slug, FlowStepConfig::getConfiguredHandlerSlugs( $step_config ), true ) ) {
 						continue;
 					}
 				}
 
 				++$total_matching_steps;
 
-				$existing_handler_slug  = \DataMachine\Core\Steps\FlowStepConfig::getEffectiveSlug( $step_config );
-				$effective_handler_slug = \DataMachine\Core\Steps\FlowStepConfig::getEffectiveSlug( $step_config, $target_handler_slug ?? '' );
+				$existing_handler_slug  = FlowStepConfig::getEffectiveSlug( $step_config );
+				$effective_handler_slug = FlowStepConfig::getEffectiveSlug( $step_config, $target_handler_slug ?? '' );
 
 				if ( empty( $effective_handler_slug ) ) {
 					$validation_errors[] = array(

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Abilities\Job;
 
 use DataMachine\Abilities\StepTypeAbilities;
+use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -344,35 +345,6 @@ class ExecuteWorkflowAbility {
 			$handler_config = $step['handler_config'] ?? array();
 			$step_type      = $step['type'];
 
-			// Resolve handler_slugs. Single-purpose: it names the step's
-			// handler (always length 0..1). Three shapes match
-			// inc/migrations/handler-keys.php (v0.60.0):
-			//
-			//   1. Explicit handler_slug → [handler_slug] (fetch, publish,
-			//      upsert, …).
-			//   2. Self-configuring step types (system_task, webhook_gate,
-			//      agent_ping) with a non-empty handler_config → [step_type].
-			//      Synthetic-slug shape lets FlowStepConfig::getPrimary
-			//      HandlerConfig() resolve uniformly via handler_slugs[0].
-			//   3. Otherwise → []. AI steps always land here: their tool
-			//      list lives in `enabled_tools`, not handler_slugs.
-			$handler_slugs = array();
-			if ( ! empty( $handler_slug ) ) {
-				$handler_slugs = array( $handler_slug );
-			} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
-				$handler_slugs = array( $step_type );
-			}
-
-			// Key handler_configs by the primary slug (handler_slugs[0]) so
-			// FlowStepConfig::getPrimaryHandlerConfig() finds the slot
-			// without branching on step type.
-			$handler_configs = array();
-			if ( ! empty( $handler_slug ) ) {
-				$handler_configs[ $handler_slug ] = $handler_config;
-			} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
-				$handler_configs[ $step_type ] = $handler_config;
-			}
-
 			// AI's tool list lives in its own field. handler_slugs is for
 			// handlers; enabled_tools is for AI tools. No overload.
 			$enabled_tools = ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
@@ -401,13 +373,11 @@ class ExecuteWorkflowAbility {
 				);
 			}
 
-			$flow_config[ $step_id ] = array(
+			$flow_step_config = array(
 				'flow_step_id'     => $step_id,
 				'pipeline_step_id' => $pipeline_step_id,
 				'step_type'        => $step['type'],
 				'execution_order'  => $index,
-				'handler_slugs'    => $handler_slugs,
-				'handler_configs'  => $handler_configs,
 				'enabled_tools'    => $enabled_tools,
 				'prompt_queue'     => $prompt_queue,
 				'queue_mode'       => 'static',
@@ -415,6 +385,20 @@ class ExecuteWorkflowAbility {
 				'pipeline_id'      => 'direct',
 				'flow_id'          => 'direct',
 			);
+
+			if ( ! empty( $handler_slug ) ) {
+				if ( FlowStepConfig::isMultiHandler( $flow_step_config ) ) {
+					$flow_step_config['handler_slugs']   = array( $handler_slug );
+					$flow_step_config['handler_configs'] = array( $handler_slug => $handler_config );
+				} else {
+					$flow_step_config['handler_slug']   = $handler_slug;
+					$flow_step_config['handler_config'] = $handler_config;
+				}
+			} elseif ( ! FlowStepConfig::usesHandler( $flow_step_config ) && ! empty( $handler_config ) ) {
+				$flow_step_config['handler_config'] = $handler_config;
+			}
+
+			$flow_config[ $step_id ] = $flow_step_config;
 
 			// Pipeline config (AI settings only — model/provider resolved via context system, not stored here).
 			if ( 'ai' === $step['type'] ) {

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -516,10 +516,10 @@ class PipelineStepAbilities {
 		}
 
 		// Reject handler fields — handlers are flow-scoped, not pipeline-scoped.
-		if ( isset( $input['handler_slugs'] ) || isset( $input['handler_configs'] ) ) {
+		if ( isset( $input['handler_slug'] ) || isset( $input['handler_slugs'] ) || isset( $input['handler_config'] ) || isset( $input['handler_configs'] ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'handler_slugs and handler_configs are flow-scoped. Use datamachine/update-flow-step ability instead.',
+				'error'   => 'handler_slug(s) and handler_config(s) are flow-scoped. Use datamachine/update-flow-step ability instead.',
 			);
 		}
 

--- a/inc/Abilities/StepTypeAbilities.php
+++ b/inc/Abilities/StepTypeAbilities.php
@@ -257,6 +257,22 @@ class StepTypeAbilities {
 	}
 
 	/**
+	 * Check if a step type supports multiple handlers.
+	 *
+	 * @param string $slug Step type slug.
+	 * @return bool True if step type supports multiple handlers.
+	 */
+	public function supportsMultipleHandlers( string $slug ): bool {
+		$step_type = $this->getStepType( $slug );
+
+		if ( ! $step_type ) {
+			return false;
+		}
+
+		return $step_type['multi_handler'] ?? false;
+	}
+
+	/**
 	 * Validate a step type slug.
 	 *
 	 * @param string $slug Step type slug to validate.

--- a/inc/Api/Chat/ChatPipelinesDirective.php
+++ b/inc/Api/Chat/ChatPipelinesDirective.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Api\Chat;
 
+use DataMachine\Core\Steps\FlowStepConfig;
+
 defined( 'ABSPATH' ) || exit;
 
 class ChatPipelinesDirective implements \DataMachine\Engine\AI\Directives\DirectiveInterface {
@@ -103,8 +105,7 @@ class ChatPipelinesDirective implements \DataMachine\Engine\AI\Directives\Direct
 			$handlers    = array();
 
 			foreach ( $flow_config as $step_config ) {
-				// Data is normalized at the DB layer — handler_slugs is canonical.
-				foreach ( $step_config['handler_slugs'] ?? array() as $slug ) {
+				foreach ( FlowStepConfig::getConfiguredHandlerSlugs( $step_config ) as $slug ) {
 					if ( ! in_array( $slug, $handlers, true ) ) {
 						$handlers[] = $slug;
 					}

--- a/inc/Api/Flows/FlowSteps.php
+++ b/inc/Api/Flows/FlowSteps.php
@@ -368,13 +368,17 @@ class FlowSteps {
 
 			$step_config = array(
 				'step_type'        => $step_type,
-				'handler_slugs'    => $existing_step['handler_slugs'] ?? array(),
-				'handler_configs'  => $existing_step['handler_configs'] ?? array(),
 				'enabled'          => true,
 				'flow_id'          => $flow_id,
 				'pipeline_step_id' => $pipeline_step_id,
 				'flow_step_id'     => $flow_step_id,
 			);
+
+			foreach ( array( 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs' ) as $handler_field ) {
+				if ( array_key_exists( $handler_field, $existing_step ) ) {
+					$step_config[ $handler_field ] = $existing_step[ $handler_field ];
+				}
+			}
 
 			if ( isset( $existing_step['execution_order'] ) ) {
 				$step_config['execution_order'] = $existing_step['execution_order'];

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -480,15 +480,18 @@ class FlowsCommand extends BaseCommand {
 
 			$step_type = $step_data['step_type'] ?? '';
 			$order     = $step_data['execution_order'] ?? '';
-			$slugs     = $step_data['handler_slugs'] ?? array();
-			$configs   = $step_data['handler_configs'] ?? array();
+			$slugs     = FlowStepConfig::getConfiguredHandlerSlugs( $step_data );
+			$configs   = FlowStepConfig::getHandlerConfigs( $step_data );
 
 			// Show pipeline-level prompt if set.
 			$pipeline_prompt = $step_data['pipeline_config']['prompt'] ?? '';
 
 			if ( empty( $slugs ) ) {
-				// Step with no handlers (e.g. AI step with only pipeline config).
+				// Step with no handlers (e.g. AI or system_task).
 				$config_parts = array();
+				foreach ( FlowStepConfig::getPrimaryHandlerConfig( $step_data ) as $key => $value ) {
+					$config_parts[] = $key . '=' . $this->formatConfigValue( $value );
+				}
 
 				if ( $pipeline_prompt ) {
 					$config_parts[] = 'system_prompt=' . $this->truncateValue( $pipeline_prompt, 60 );
@@ -1158,8 +1161,7 @@ class FlowsCommand extends BaseCommand {
 		$handlers    = array();
 
 		foreach ( $flow_config as $step_data ) {
-			// Data is normalized at the DB layer — handler_slugs is canonical.
-			$handlers = array_merge( $handlers, $step_data['handler_slugs'] ?? array() );
+			$handlers = array_merge( $handlers, FlowStepConfig::getConfiguredHandlerSlugs( $step_data ) );
 		}
 
 		return implode( ', ', array_unique( $handlers ) );
@@ -1180,7 +1182,7 @@ class FlowsCommand extends BaseCommand {
 		$parts       = array();
 
 		foreach ( $flow_config as $step_data ) {
-			$handler_configs = $step_data['handler_configs'] ?? array();
+			$handler_configs = FlowStepConfig::getHandlerConfigs( $step_data );
 
 			foreach ( $handler_configs as $hconfig ) {
 				if ( ! is_array( $hconfig ) ) {
@@ -1304,7 +1306,7 @@ class FlowsCommand extends BaseCommand {
 				continue;
 			}
 
-			$handler_configs = $step_data['handler_configs'] ?? array();
+			$handler_configs = FlowStepConfig::getHandlerConfigs( $step_data );
 			if ( ! is_array( $handler_configs ) ) {
 				continue;
 			}
@@ -1446,8 +1448,8 @@ class FlowsCommand extends BaseCommand {
 
 			$step_type = $step['step_type'] ?? '';
 
-			$slugs   = $step['handler_slugs'] ?? array();
-			$configs = $step['handler_configs'] ?? array();
+			$slugs   = FlowStepConfig::getConfiguredHandlerSlugs( $step );
+			$configs = FlowStepConfig::getHandlerConfigs( $step );
 
 			if ( empty( $slugs ) && ! $step_id ) {
 				continue; // Skip steps with no handlers unless specifically requested.
@@ -1514,7 +1516,7 @@ class FlowsCommand extends BaseCommand {
 
 		$handler_steps = array();
 		foreach ( $flow_config as $step_id => $step_data ) {
-			if ( ! empty( $step_data['handler_slugs'] ) ) {
+			if ( ! empty( FlowStepConfig::getConfiguredHandlerSlugs( $step_data ) ) ) {
 				$handler_steps[] = $step_id;
 			}
 		}

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -15,6 +15,7 @@ use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Cli\AgentResolver;
 use DataMachine\Cli\UserResolver;
+use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -394,7 +395,7 @@ class PipelinesCommand extends BaseCommand {
 			}
 
 			foreach ( $config as $step ) {
-				$handler_configs = $step['handler_configs'] ?? array();
+				$handler_configs = is_array( $step ) ? FlowStepConfig::getHandlerConfigs( $step ) : array();
 
 				foreach ( $handler_configs as $hconfig ) {
 					// Coordinates (any handler that has a location field with lat,lon).

--- a/inc/Cli/Commands/StepTypesCommand.php
+++ b/inc/Cli/Commands/StepTypesCommand.php
@@ -70,13 +70,14 @@ class StepTypesCommand extends BaseCommand {
 		$items = array();
 		foreach ( $result['step_types'] as $slug => $step_type ) {
 			$items[] = array(
-				'slug'         => $slug,
-				'label'        => $step_type['label'] ?? '',
-				'uses_handler' => ! empty( $step_type['uses_handler'] ) ? 'yes' : 'no',
+				'slug'          => $slug,
+				'label'         => $step_type['label'] ?? '',
+				'uses_handler'  => ! empty( $step_type['uses_handler'] ) ? 'yes' : 'no',
+				'multi_handler' => ! empty( $step_type['multi_handler'] ) ? 'yes' : 'no',
 			);
 		}
 
-		$fields = array( 'slug', 'label', 'uses_handler' );
+		$fields = array( 'slug', 'label', 'uses_handler', 'multi_handler' );
 		$this->format_items( $items, $fields, $assoc_args, 'slug' );
 
 		WP_CLI::log( sprintf( 'Total: %d step type(s).', $result['count'] ) );

--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -66,13 +66,16 @@ class FlowFormatter {
 				$step_type
 			);
 
-			// Apply defaults to the primary handler config.
+			// Apply defaults to the primary config slot.
 			if ( ! empty( $effective_slug ) ) {
-				$primary_config                                  = $step_data['handler_configs'][ $effective_slug ] ?? array();
-				$step_data['handler_configs'][ $effective_slug ] = $handler_abilities->applyDefaults(
-					$effective_slug,
-					$primary_config
-				);
+				$primary_config = FlowStepConfig::getPrimaryHandlerConfig( $step_data );
+				$with_defaults  = $handler_abilities->applyDefaults( $effective_slug, $primary_config );
+
+				if ( FlowStepConfig::isMultiHandler( $step_data ) ) {
+					$step_data['handler_configs'][ $effective_slug ] = $with_defaults;
+				} else {
+					$step_data['handler_config'] = $with_defaults;
+				}
 			}
 
 			if ( ! empty( $step_data['settings_display'] ) && is_array( $step_data['settings_display'] ) ) {

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowCard.jsx
@@ -23,6 +23,7 @@ import {
 	useDuplicateFlow,
 	useRunFlow,
 } from '../../queries/flows';
+import { useStepTypes } from '../../queries/config';
 import { useUIStore } from '../../stores/uiStore';
 import useFlowReconciliation from '../../hooks/useFlowReconciliation';
 
@@ -49,6 +50,7 @@ function FlowCardContent( props ) {
 	const deleteFlowMutation = useDeleteFlow();
 	const duplicateFlowMutation = useDuplicateFlow();
 	const runFlowMutation = useRunFlow();
+	const { data: stepTypes = {} } = useStepTypes();
 	const { openModal } = useUIStore();
 	const { optimisticLastRunDisplay, reconcile } = useFlowReconciliation();
 
@@ -234,7 +236,11 @@ function FlowCardContent( props ) {
 				isSameId( s.pipeline_step_id, pipelineStepId )
 			);
 
-			const handlerSlugs = flowStepConfig.handler_slugs || [];
+			const stepType = pipelineStep?.step_type || flowStepConfig.step_type;
+			const isMultiHandlerStep = stepTypes[ stepType ]?.multi_handler === true;
+			const handlerSlugs = isMultiHandlerStep
+				? ( flowStepConfig.handler_slugs || [] )
+				: ( flowStepConfig.handler_slug ? [ flowStepConfig.handler_slug ] : [] );
 			const primarySlug = handlerSlugs[0] || '';
 
 			// Build data for handler modals
@@ -242,12 +248,12 @@ function FlowCardContent( props ) {
 				flowStepId,
 				handlerSlug: specificHandler || primarySlug,
 				handlerSlugs,
-				stepType: pipelineStep?.step_type || flowStepConfig.step_type,
+				stepType,
 				pipelineId: currentFlowData.pipeline_id,
 				flowId: currentFlowData.flow_id,
 				currentSettings: specificHandler
 					? ( flowStepConfig.handler_configs?.[ specificHandler ] || {} )
-					: ( flowStepConfig.handler_configs?.[ primarySlug ] || {} ),
+					: ( isMultiHandlerStep ? ( flowStepConfig.handler_configs?.[ primarySlug ] || {} ) : ( flowStepConfig.handler_config || {} ) ),
 				addMode,
 			};
 
@@ -262,7 +268,7 @@ function FlowCardContent( props ) {
 				openModal( MODAL_TYPES.HANDLER_SETTINGS, {
 					...data,
 					handlerSlug: specificHandler,
-					currentSettings: flowStepConfig.handler_configs?.[ specificHandler ] || {},
+					currentSettings: isMultiHandlerStep ? ( flowStepConfig.handler_configs?.[ specificHandler ] || {} ) : ( flowStepConfig.handler_config || {} ),
 				} );
 			} else {
 				// Default: open settings for primary handler.
@@ -274,6 +280,7 @@ function FlowCardContent( props ) {
 			currentFlowData.pipeline_id,
 			currentFlowData.flow_id,
 			pipelineConfig,
+			stepTypes,
 			openModal,
 		]
 	);

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowStepCard.jsx
@@ -50,6 +50,15 @@ export default function FlowStepCard( {
 	const stepTypeInfo = stepTypes[ pipelineStep.step_type ] || {};
 
 	const isAiStep = pipelineStep.step_type === 'ai';
+	const usesHandler = stepTypeInfo.uses_handler === true;
+	const isMultiHandlerStep = stepTypeInfo.multi_handler === true;
+	const handlerSlugs = isMultiHandlerStep
+		? ( flowStepConfig?.handler_slugs || [] )
+		: ( flowStepConfig?.handler_slug ? [ flowStepConfig.handler_slug ] : [] );
+	const primarySlug = handlerSlugs[0] || '';
+	const primaryConfig = isMultiHandlerStep
+		? ( primarySlug && flowStepConfig?.handler_configs?.[primarySlug] )
+		: ( flowStepConfig?.handler_config || {} );
 
 	const promptQueue = flowStepConfig.prompt_queue || [];
 	const rawQueueMode = flowStepConfig.queue_mode;
@@ -69,19 +78,13 @@ export default function FlowStepCard( {
 		if ( isAiStep ) {
 			return flowStepConfig.user_message || '';
 		}
-		const handlerSlugs = flowStepConfig?.handler_slugs || [];
-		const primarySlug = handlerSlugs[0];
-		const primaryConfig = primarySlug && flowStepConfig?.handler_configs?.[primarySlug];
 		// Support both top-level prompt (legacy) and nested params.prompt (system_task).
 		return primaryConfig?.prompt || primaryConfig?.params?.prompt || '';
-	}, [ isAiStep, flowStepConfig.user_message, flowStepConfig?.handler_slugs, flowStepConfig?.handler_configs ] );
+	}, [ isAiStep, flowStepConfig.user_message, primaryConfig ] );
 
 	// Determine if this step type shows a prompt field.
 	// AI steps always get it. Other steps get it if they have a prompt in handler_config
 	// or if queue is enabled/has items.
-	const handlerSlugs = flowStepConfig?.handler_slugs || [];
-	const primarySlug = handlerSlugs[0];
-	const primaryConfig = primarySlug && flowStepConfig?.handler_configs?.[primarySlug];
 	const hasPromptConfig = primaryConfig && (
 		primaryConfig.prompt !== undefined ||
 		primaryConfig.params?.prompt !== undefined
@@ -136,11 +139,7 @@ export default function FlowStepCard( {
 		[ flowStepId, isAiStep, primaryConfig ]
 	);
 
-	// Resolve handler info for settings display.
-	// Strict positive check — defaults to false while step types are loading
-	// so non-handler step types (AI, Agent Ping, Webhook Gate) never flash handler UI.
-	const usesHandler = stepTypeInfo.uses_handler === true;
-	const effectiveHandlerSlug = usesHandler ? ( flowStepConfig.handler_slugs?.[0] || '' ) : pipelineStep.step_type;
+	const effectiveHandlerSlug = usesHandler ? primarySlug : pipelineStep.step_type;
 
 	return (
 		<Card
@@ -177,7 +176,7 @@ export default function FlowStepCard( {
 					{ ! usesHandler && effectiveHandlerSlug && (
 					<InlineStepConfig
 						flowStepId={ flowStepId }
-						handlerConfig={ flowStepConfig?.handler_configs?.[ effectiveHandlerSlug ] || {} }
+						handlerConfig={ flowStepConfig?.handler_config || {} }
 						handlerSlug={ effectiveHandlerSlug }
 							excludeFields={ excludeFields }
 							onError={ setError }
@@ -210,16 +209,16 @@ export default function FlowStepCard( {
 					{ /* Handler Configuration (handler-based steps only) */ }
 					{ usesHandler && (
 					<FlowStepHandler
-						handlerSlug={ flowStepConfig.handler_slugs?.[0] || null }
-							handlerSlugs={ flowStepConfig.handler_slugs || null }
+						handlerSlug={ primarySlug || null }
+							handlerSlugs={ handlerSlugs.length ? handlerSlugs : null }
 							settingsDisplay={ flowStepConfig.settings_display || [] }
 							handlerSettingsDisplays={ flowStepConfig.handler_settings_displays || null }
 							onConfigure={ ( slug ) =>
 								onConfigure && onConfigure( flowStepId, slug )
 							}
-							onAddHandler={ () =>
+							onAddHandler={ isMultiHandlerStep ? () =>
 								onConfigure && onConfigure( flowStepId, null, true )
-							}
+							: undefined }
 							showConfigureButton
 							showBadge
 						/>

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineStepCard.jsx
@@ -47,7 +47,7 @@ export default function PipelineStepCard( {
 
 	// For system_task steps, show the task name badge (e.g. "Agent Ping").
 	const systemTaskName = isSystemTask
-		? ( stepConfig?.handler_configs?.system_task?.task || step.handler_configs?.system_task?.task || '' )
+		? ( stepConfig?.handler_config?.task || step.handler_config?.task || '' )
 		: '';
 
 	/**

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalManager.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/shared/ModalManager.jsx
@@ -99,7 +99,7 @@ export default function ModalManager() {
 
 				const stepConfig = result?.data?.step_config || {};
 				const handlerConfigs = stepConfig.handler_configs || {};
-				const currentSettings = handlerConfigs[selectedHandlerSlug] || {};
+				const currentSettings = stepConfig.handler_config || handlerConfigs[selectedHandlerSlug] || {};
 
 				openModal( MODAL_TYPES.HANDLER_SETTINGS, {
 					...modalData,

--- a/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/queries/flows.js
@@ -337,7 +337,7 @@ export const useAddFlowHandler = () => {
 		mutationFn: ( { flowStepId, handlerSlug, settings = {} } ) =>
 			addFlowHandler( flowStepId, handlerSlug, settings ),
 		onSuccess: ( response, variables ) => {
-			// Invalidate flows to pick up updated handler_slugs / handler_configs.
+			// Invalidate flows to pick up updated handler config shape.
 			if ( variables.pipelineId ) {
 				const cachedPipelineId = normalizeId( variables.pipelineId );
 				queryClient.invalidateQueries( {

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -7,6 +7,7 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\DataPacket;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\Steps\Step;
+use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
 use DataMachine\Core\Steps\QueueableTrait;
 use DataMachine\Engine\AI\AIConversationLoop;
@@ -258,7 +259,7 @@ class AIStep extends Step {
 			if ( ! $adj_step_config ) {
 				continue;
 			}
-			$handler_slugs     = $adj_step_config['handler_slugs'] ?? array();
+			$handler_slugs     = FlowStepConfig::getConfiguredHandlerSlugs( $adj_step_config );
 			$all_handler_slugs = array_merge( $all_handler_slugs, $handler_slugs );
 		}
 
@@ -300,9 +301,7 @@ class AIStep extends Step {
 			);
 
 			if ( ! empty( $ai_tool_handler_slugs ) ) {
-				$payload['flow_step_config'] = array(
-					'handler_slugs' => $ai_tool_handler_slugs,
-				);
+				$payload['configured_handler_slugs'] = $ai_tool_handler_slugs;
 			}
 		}
 

--- a/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
+++ b/inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php
@@ -20,6 +20,7 @@
 namespace DataMachine\Core\Steps\AI\Directives;
 
 use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -100,11 +101,10 @@ class PipelineSystemPromptDirective implements \DataMachine\Engine\AI\Directives
 
 		// Sort steps by execution_order.
 		//
-		// Reads handler_slugs raw (not via FlowStepConfig::getEffectiveSlug)
-		// because the workflow visualization needs to render every handler
-		// in a multi-handler step (e.g. PUBLISH_A+PUBLISH_B → AI → UPSERT),
-		// not just the primary slug. This is one of the legitimate
-		// multi-element callsites alongside ToolPolicyResolver.
+		// Reads every configured handler through FlowStepConfig's cardinality-
+		// agnostic helper because the visualization needs to render every
+		// handler in multi-handler steps, while still supporting scalar
+		// single-handler steps.
 		$sorted_steps = array();
 		foreach ( $flow_config as $flow_step_id => $step_config ) {
 			$execution_order = $step_config['execution_order'] ?? -1;
@@ -116,7 +116,7 @@ class PipelineSystemPromptDirective implements \DataMachine\Engine\AI\Directives
 				$sorted_steps[ $execution_order ] = array(
 					'pipeline_step_id' => $step_pipeline_step_id,
 					'step_type'        => $step_config['step_type'] ?? '',
-					'handler_slugs'    => $step_config['handler_slugs'] ?? array(),
+					'handler_slugs'    => FlowStepConfig::getConfiguredHandlerSlugs( $step_config ),
 				);
 			}
 		}

--- a/inc/Core/Steps/FlowStepConfig.php
+++ b/inc/Core/Steps/FlowStepConfig.php
@@ -15,17 +15,52 @@ defined( 'ABSPATH' ) || exit;
 class FlowStepConfig {
 
 	/**
+	 * Step-type capability fallback used before filters are registered.
+	 *
+	 * Runtime callers normally see step definitions from `datamachine_step_types`.
+	 * Migrations run earlier in bootstrap, so the core step-type contract lives
+	 * here too instead of depending on registration timing.
+	 *
+	 * @var array<string, array{uses_handler: bool, multi_handler: bool}>
+	 */
+	private const CORE_STEP_CAPABILITIES = array(
+		'ai'           => array(
+			'uses_handler'  => false,
+			'multi_handler' => false,
+		),
+		'system_task'  => array(
+			'uses_handler'  => false,
+			'multi_handler' => false,
+		),
+		'webhook_gate' => array(
+			'uses_handler'  => false,
+			'multi_handler' => false,
+		),
+		'fetch'        => array(
+			'uses_handler'  => true,
+			'multi_handler' => false,
+		),
+		'publish'      => array(
+			'uses_handler'  => true,
+			'multi_handler' => true,
+		),
+		'upsert'       => array(
+			'uses_handler'  => true,
+			'multi_handler' => true,
+		),
+	);
+
+	/**
 	 * Resolve the effective config slug for a flow step.
 	 *
-	 * Single source of truth for determining which slug to use when reading
-	 * or writing handler_configs. Works for both handler-based steps (fetch,
-	 * publish, upsert) and self-configuring steps (agent_ping, webhook_gate,
-	 * system_task) that use step_type as their config key.
+	 * This is the config-settings slug, not necessarily a handler slug. Handler
+	 * steps return their configured handler slug; handler-free steps return the
+	 * step_type because their settings classes are keyed by step type.
 	 *
 	 * Priority:
-	 * 1. Explicit slug (caller override, e.g. from API input)
-	 * 2. Primary slug from handler_slugs[0]
-	 * 3. step_type (self-configuring steps)
+	 * 1. Explicit slug (caller override, e.g. from API input).
+	 * 2. Primary configured handler slug.
+	 * 3. step_type for handler-free steps.
 	 *
 	 * @param array  $step_config   Step configuration array.
 	 * @param string $explicit_slug Optional caller-provided slug (highest priority).
@@ -36,14 +71,119 @@ class FlowStepConfig {
 			return $explicit_slug;
 		}
 
-		if ( ! empty( $step_config['handler_slugs'] ) && is_array( $step_config['handler_slugs'] ) ) {
-			$primary = $step_config['handler_slugs'][0] ?? '';
-			if ( ! empty( $primary ) ) {
-				return $primary;
-			}
+		$primary = self::getPrimaryHandlerSlug( $step_config );
+		if ( null !== $primary ) {
+			return $primary;
 		}
 
-		return $step_config['step_type'] ?? '';
+		return self::usesHandler( $step_config ) ? '' : ( $step_config['step_type'] ?? '' );
+	}
+
+	/**
+	 * Return whether this step type uses handlers.
+	 *
+	 * @param array $step_config Step configuration array.
+	 * @return bool True when the step selects a handler.
+	 */
+	public static function usesHandler( array $step_config ): bool {
+		return self::getCapabilities( $step_config )['uses_handler'];
+	}
+
+	/**
+	 * Return whether this step type supports multiple handlers.
+	 *
+	 * @param array $step_config Step configuration array.
+	 * @return bool True when the step stores handler_slugs as a list.
+	 */
+	public static function isMultiHandler( array $step_config ): bool {
+		$capabilities = self::getCapabilities( $step_config );
+		return $capabilities['uses_handler'] && $capabilities['multi_handler'];
+	}
+
+	/**
+	 * Get the scalar handler slug for single-handler step types.
+	 *
+	 * Calling this on a multi-handler step is a contract violation: callers
+	 * that need every handler must use getHandlerSlugs(). Handler-free steps
+	 * return null.
+	 *
+	 * @param array $step_config Step configuration array.
+	 * @return string|null Handler slug, or null when not configured/applicable.
+	 */
+	public static function getHandlerSlug( array $step_config ): ?string {
+		if ( ! self::usesHandler( $step_config ) ) {
+			return null;
+		}
+
+		if ( self::isMultiHandler( $step_config ) ) {
+			self::warnContractViolation( 'getHandlerSlug() called for a multi-handler step', $step_config );
+			return null;
+		}
+
+		$slug = $step_config['handler_slug'] ?? null;
+		if ( ! is_string( $slug ) || '' === $slug ) {
+			return null;
+		}
+
+		return $slug;
+	}
+
+	/**
+	 * Get handler slugs for multi-handler step types.
+	 *
+	 * Calling this on a single-handler step is a contract violation: callers
+	 * that need the single slug must use getHandlerSlug(). Handler-free steps
+	 * return an empty array.
+	 *
+	 * @param array $step_config Step configuration array.
+	 * @return array<int, string> Handler slugs.
+	 */
+	public static function getHandlerSlugs( array $step_config ): array {
+		if ( ! self::usesHandler( $step_config ) ) {
+			return array();
+		}
+
+		if ( ! self::isMultiHandler( $step_config ) ) {
+			self::warnContractViolation( 'getHandlerSlugs() called for a single-handler step', $step_config );
+			return array();
+		}
+
+		$slugs = $step_config['handler_slugs'] ?? array();
+		return self::sanitizeSlugList( is_array( $slugs ) ? $slugs : array() );
+	}
+
+	/**
+	 * Get every configured handler slug regardless of single vs multi shape.
+	 *
+	 * Use this for generic traversal/filtering callsites that are explicitly
+	 * agnostic to the step type's handler cardinality.
+	 *
+	 * @param array $step_config Step configuration array.
+	 * @return array<int, string> Handler slugs.
+	 */
+	public static function getConfiguredHandlerSlugs( array $step_config ): array {
+		if ( ! self::usesHandler( $step_config ) ) {
+			return array();
+		}
+
+		if ( self::isMultiHandler( $step_config ) ) {
+			$slugs = $step_config['handler_slugs'] ?? array();
+			return self::sanitizeSlugList( is_array( $slugs ) ? $slugs : array() );
+		}
+
+		$slug = $step_config['handler_slug'] ?? '';
+		return is_string( $slug ) && '' !== $slug ? array( $slug ) : array();
+	}
+
+	/**
+	 * Get the primary handler slug for handler steps.
+	 *
+	 * @param array $step_config Step configuration array.
+	 * @return string|null Primary handler slug.
+	 */
+	public static function getPrimaryHandlerSlug( array $step_config ): ?string {
+		$slugs = self::getConfiguredHandlerSlugs( $step_config );
+		return $slugs[0] ?? null;
 	}
 
 	/**
@@ -53,11 +193,126 @@ class FlowStepConfig {
 	 * @return array Primary handler configuration.
 	 */
 	public static function getPrimaryHandlerConfig( array $step_config ): array {
-		$slug = $step_config['handler_slugs'][0] ?? '';
-		if ( ! empty( $slug ) && ! empty( $step_config['handler_configs'][ $slug ] ) ) {
-			return $step_config['handler_configs'][ $slug ];
+		if ( self::isMultiHandler( $step_config ) ) {
+			$slug = self::getPrimaryHandlerSlug( $step_config );
+			if ( ! empty( $slug ) && ! empty( $step_config['handler_configs'][ $slug ] ) && is_array( $step_config['handler_configs'][ $slug ] ) ) {
+				return $step_config['handler_configs'][ $slug ];
+			}
+			return array();
 		}
-		return array();
+
+		$config = $step_config['handler_config'] ?? array();
+		return is_array( $config ) ? $config : array();
+	}
+
+	/**
+	 * Get a handler config by slug regardless of single vs multi shape.
+	 *
+	 * @param array  $step_config Step configuration array.
+	 * @param string $slug Handler or settings slug.
+	 * @return array Handler configuration.
+	 */
+	public static function getHandlerConfigForSlug( array $step_config, string $slug ): array {
+		if ( self::isMultiHandler( $step_config ) ) {
+			$config = $step_config['handler_configs'][ $slug ] ?? array();
+			return is_array( $config ) ? $config : array();
+		}
+
+		$effective_slug = self::getEffectiveSlug( $step_config );
+		if ( $slug !== $effective_slug ) {
+			return array();
+		}
+
+		return self::getPrimaryHandlerConfig( $step_config );
+	}
+
+	/**
+	 * Get handler configs as a slug-keyed map for generic display callsites.
+	 *
+	 * @param array $step_config Step configuration array.
+	 * @return array<string, array> Handler/settings configs keyed by slug.
+	 */
+	public static function getHandlerConfigs( array $step_config ): array {
+		if ( self::isMultiHandler( $step_config ) ) {
+			$configs = $step_config['handler_configs'] ?? array();
+			return is_array( $configs ) ? $configs : array();
+		}
+
+		$slug   = self::getEffectiveSlug( $step_config );
+		$config = self::getPrimaryHandlerConfig( $step_config );
+		if ( '' === $slug || empty( $config ) ) {
+			return array();
+		}
+
+		return array( $slug => $config );
+	}
+
+	/**
+	 * Normalize a step config to the canonical handler storage shape.
+	 *
+	 * @param array $step_config Step configuration array.
+	 * @return array Canonicalized step configuration.
+	 */
+	public static function normalizeHandlerShape( array $step_config ): array {
+		$uses_handler = self::usesHandler( $step_config );
+		$is_multi     = self::isMultiHandler( $step_config );
+		$step_type    = $step_config['step_type'] ?? '';
+
+		$legacy_slugs   = self::sanitizeSlugList( is_array( $step_config['handler_slugs'] ?? null ) ? $step_config['handler_slugs'] : array() );
+		$legacy_configs = is_array( $step_config['handler_configs'] ?? null ) ? $step_config['handler_configs'] : array();
+		$config_slugs   = self::sanitizeSlugList( array_keys( $legacy_configs ) );
+		$scalar_slug    = is_string( $step_config['handler_slug'] ?? null ) ? $step_config['handler_slug'] : '';
+		$scalar_config  = is_array( $step_config['handler_config'] ?? null ) ? $step_config['handler_config'] : array();
+
+		unset( $step_config['handler_slug'], $step_config['handler_slugs'], $step_config['handler_config'], $step_config['handler_configs'] );
+
+		if ( ! $uses_handler ) {
+			$config = $scalar_config;
+			if ( empty( $config ) && '' !== $step_type && isset( $legacy_configs[ $step_type ] ) && is_array( $legacy_configs[ $step_type ] ) ) {
+				$config = $legacy_configs[ $step_type ];
+			}
+			if ( ! empty( $config ) ) {
+				$step_config['handler_config'] = $config;
+			}
+			return $step_config;
+		}
+
+		if ( $is_multi ) {
+			$slugs = $legacy_slugs;
+			if ( empty( $slugs ) && '' !== $scalar_slug ) {
+				$slugs = array( $scalar_slug );
+			}
+			if ( empty( $slugs ) && ! empty( $config_slugs ) ) {
+				$slugs = $config_slugs;
+			}
+
+			$configs = $legacy_configs;
+			if ( empty( $configs ) && ! empty( $scalar_config ) && ! empty( $slugs ) ) {
+				$configs = array( $slugs[0] => $scalar_config );
+			}
+
+			if ( ! empty( $slugs ) ) {
+				$step_config['handler_slugs'] = $slugs;
+			}
+			if ( ! empty( $configs ) ) {
+				$step_config['handler_configs'] = $configs;
+			}
+			return $step_config;
+		}
+
+		$slug = '' !== $scalar_slug ? $scalar_slug : ( $legacy_slugs[0] ?? ( $config_slugs[0] ?? '' ) );
+		if ( '' !== $slug ) {
+			$step_config['handler_slug'] = $slug;
+		}
+
+		$config = $scalar_config;
+		if ( empty( $config ) && '' !== $slug && isset( $legacy_configs[ $slug ] ) && is_array( $legacy_configs[ $slug ] ) ) {
+			$config = $legacy_configs[ $slug ];
+		}
+		if ( ! empty( $config ) || '' !== $slug ) {
+			$step_config['handler_config'] = $config;
+		}
+		return $step_config;
 	}
 
 	/**
@@ -84,5 +339,70 @@ class FlowStepConfig {
 		}
 
 		return array_values( $enabled );
+	}
+
+	/**
+	 * Resolve capability flags for a step config.
+	 *
+	 * @param array $step_config Step configuration array.
+	 * @return array{uses_handler: bool, multi_handler: bool} Capability flags.
+	 */
+	private static function getCapabilities( array $step_config ): array {
+		$step_type = $step_config['step_type'] ?? '';
+		$defaults  = self::CORE_STEP_CAPABILITIES[ $step_type ] ?? array(
+			'uses_handler'  => true,
+			'multi_handler' => false,
+		);
+
+		$registered = function_exists( 'apply_filters' ) ? apply_filters( 'datamachine_step_types', array() ) : array();
+		if ( is_array( $registered ) && isset( $registered[ $step_type ] ) && is_array( $registered[ $step_type ] ) ) {
+			$definition = $registered[ $step_type ];
+			return array(
+				'uses_handler'  => (bool) ( $definition['uses_handler'] ?? $defaults['uses_handler'] ),
+				'multi_handler' => (bool) ( $definition['multi_handler'] ?? $defaults['multi_handler'] ),
+			);
+		}
+
+		return $defaults;
+	}
+
+	/**
+	 * Normalize and de-duplicate slug lists.
+	 *
+	 * @param array $slugs Raw slug values.
+	 * @return array<int, string> Clean slugs.
+	 */
+	private static function sanitizeSlugList( array $slugs ): array {
+		$clean = array();
+		foreach ( $slugs as $slug ) {
+			if ( ! is_string( $slug ) || '' === $slug ) {
+				continue;
+			}
+			if ( ! in_array( $slug, $clean, true ) ) {
+				$clean[] = $slug;
+			}
+		}
+		return $clean;
+	}
+
+	/**
+	 * Log a handler-shape contract violation.
+	 *
+	 * @param string $message Violation message.
+	 * @param array  $step_config Step configuration array.
+	 * @return void
+	 */
+	private static function warnContractViolation( string $message, array $step_config ): void {
+		if ( function_exists( 'do_action' ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'FlowStepConfig handler-shape contract violation',
+				array(
+					'message'   => $message,
+					'step_type' => $step_config['step_type'] ?? '',
+				)
+			);
+		}
 	}
 }

--- a/inc/Core/Steps/Publish/PublishStep.php
+++ b/inc/Core/Steps/Publish/PublishStep.php
@@ -34,6 +34,7 @@ class PublishStep extends Step {
 			class_name: self::class,
 			position: 30,
 			usesHandler: true,
+			multiHandler: true,
 			hasPipelineConfig: false
 		);
 	}

--- a/inc/Core/Steps/Settings/SettingsDisplayService.php
+++ b/inc/Core/Steps/Settings/SettingsDisplayService.php
@@ -75,28 +75,10 @@ class SettingsDisplayService {
 			return array();
 		}
 
-		// Data is normalized at the DB layer.
-		$handler_configs = $flow_step_config['handler_configs'] ?? array();
-		$handler_slugs   = $flow_step_config['handler_slugs'] ?? array();
-
-		// Fallback: build from primary handler when configs are empty.
-		if ( empty( $handler_configs ) ) {
-			$handler_slug     = FlowStepConfig::getEffectiveSlug( $flow_step_config );
-			$current_settings = FlowStepConfig::getPrimaryHandlerConfig( $flow_step_config );
-
-			if ( empty( $handler_slug ) ) {
-				return array();
-			}
-
-			$display = $this->getDisplayForHandler( $handler_slug, $current_settings );
-
-			return ! empty( $display ) ? array( $handler_slug => $display ) : array();
-		}
-
-		// Ensure handler_slugs is populated for ordering.
-		if ( empty( $handler_slugs ) ) {
-			$handler_slugs = array_keys( $handler_configs );
-		}
+		$handler_configs = FlowStepConfig::getHandlerConfigs( $flow_step_config );
+		$handler_slugs   = FlowStepConfig::usesHandler( $flow_step_config )
+			? FlowStepConfig::getConfiguredHandlerSlugs( $flow_step_config )
+			: array_keys( $handler_configs );
 
 		$result = array();
 		foreach ( $handler_slugs as $slug ) {

--- a/inc/Core/Steps/Step.php
+++ b/inc/Core/Steps/Step.php
@@ -214,33 +214,21 @@ abstract class Step {
 	/**
 	 * Get the primary handler slug from flow step configuration.
 	 *
-	 * Returns the raw `handler_slugs[0]` value. For self-configuring step
-	 * types (system_task, webhook_gate, agent_ping), the migration in
-	 * inc/migrations/handler-keys.php and ExecuteWorkflowAbility::build
-	 * ConfigsFromWorkflow() store the step_type as the synthetic primary
-	 * slug, so this returns the step_type for those rows. Returns null
-	 * when no slug has been resolved (e.g. fetch step with no handler
-	 * configured) so the default validateStepConfiguration() can reject.
-	 *
-	 * Prefer FlowStepConfig::getEffectiveSlug() at non-Step callsites; it
-	 * is the canonical resolver and falls back to step_type when the
-	 * handler_slugs array is empty.
+	 * Reads the canonical scalar `handler_slug` field. Multi-handler steps
+	 * should call getHandlerSlugs(); handler-free steps return null.
 	 *
 	 * @return string|null Handler slug or null if not set
 	 */
 	protected function getHandlerSlug(): ?string {
-		return $this->flow_step_config['handler_slugs'][0] ?? null;
+		return FlowStepConfig::getHandlerSlug( $this->flow_step_config );
 	}
 
 	/**
 	 * Get the primary handler configuration from flow step configuration.
 	 *
-	 * Reads handler_configs[handler_slugs[0]]. Handler-bearing steps key
-	 * by handler_slug; handler-free steps (system_task, webhook_gate,
-	 * agent_ping) key by step_type via the synthetic-slug shape applied
-	 * in inc/migrations/handler-keys.php and ExecuteWorkflowAbility::build
-	 * ConfigsFromWorkflow(). FlowStepConfig::getPrimaryHandlerConfig() is
-	 * the single source of truth for the lookup so callsites stay aligned.
+	 * Reads the canonical config slot: `handler_config` for handler-free and
+	 * single-handler steps, or `handler_configs[primary_slug]` for true
+	 * multi-handler steps.
 	 *
 	 * @return array Handler configuration array
 	 */
@@ -249,12 +237,12 @@ abstract class Step {
 	}
 
 	/**
-	 * Get handler slugs (supports both singular and plural config).
+	 * Get handler slugs for multi-handler steps.
 	 *
 	 * @return array Handler slug array
 	 */
 	protected function getHandlerSlugs(): array {
-		return $this->flow_step_config['handler_slugs'] ?? array();
+		return FlowStepConfig::getHandlerSlugs( $this->flow_step_config );
 	}
 
 	/**
@@ -263,7 +251,7 @@ abstract class Step {
 	 * @return array<string, array> Handler configs keyed by slug
 	 */
 	protected function getHandlerConfigs(): array {
-		return $this->flow_step_config['handler_configs'] ?? array();
+		return FlowStepConfig::getHandlerConfigs( $this->flow_step_config );
 	}
 
 	/**

--- a/inc/Core/Steps/StepTypeRegistrationTrait.php
+++ b/inc/Core/Steps/StepTypeRegistrationTrait.php
@@ -39,6 +39,7 @@ trait StepTypeRegistrationTrait {
 	 * @param string     $class_name Step class name
 	 * @param int        $position Position in step type list (lower = earlier)
 	 * @param bool       $usesHandler Whether step type uses handlers
+	 * @param bool       $multiHandler Whether step type supports multiple handlers
 	 * @param bool       $hasPipelineConfig Whether step has pipeline-level configuration
 	 * @param bool       $consumeAllPackets Whether step consumes all packets at once
 	 * @param array|null $stepSettings Optional UI settings for pipeline step configuration
@@ -50,6 +51,7 @@ trait StepTypeRegistrationTrait {
 		string $class_name,
 		int $position = 50,
 		bool $usesHandler = true,
+		bool $multiHandler = false,
 		bool $hasPipelineConfig = false,
 		bool $consumeAllPackets = false,
 		?array $stepSettings = null,
@@ -67,9 +69,10 @@ trait StepTypeRegistrationTrait {
 				$slug,
 				$label,
 				$description,
-			$class_name,
-			$position,
+				$class_name,
+				$position,
 				$usesHandler,
+				$multiHandler,
 				$hasPipelineConfig,
 				$consumeAllPackets,
 				$showSettingsDisplay
@@ -80,6 +83,7 @@ trait StepTypeRegistrationTrait {
 					'class'                 => $class_name,
 					'position'              => $position,
 					'uses_handler'          => $usesHandler,
+					'multi_handler'         => $multiHandler,
 					'has_pipeline_config'   => $hasPipelineConfig,
 					'consume_all_packets'   => $consumeAllPackets,
 					'show_settings_display' => $showSettingsDisplay,

--- a/inc/Core/Steps/Upsert/UpsertStep.php
+++ b/inc/Core/Steps/Upsert/UpsertStep.php
@@ -38,6 +38,7 @@ class UpsertStep extends Step {
 			class_name: self::class,
 			position: 40,
 			usesHandler: true,
+			multiHandler: true,
 			hasPipelineConfig: false
 		);
 	}

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -172,8 +172,8 @@ class AIConversationLoop {
 		// In pipeline mode, conversation should only complete when ALL configured
 		// handlers have fired, not just the first one.
 		$executed_handler_slugs = array();
-		$flow_step_config       = $payload['flow_step_config'] ?? array();
-		$configured_handlers    = $flow_step_config['handler_slugs'] ?? array();
+		$configured_handlers    = $payload['configured_handler_slugs'] ?? array();
+		$configured_handlers    = is_array( $configured_handlers ) ? array_values( $configured_handlers ) : array();
 
 		// Build base log metadata from payload for consistent logging.
 		$base_log_context = array_filter(

--- a/inc/Engine/AI/Directives/AgentModeDirective.php
+++ b/inc/Engine/AI/Directives/AgentModeDirective.php
@@ -43,7 +43,7 @@ HANDLERS are the core intelligence. Fetch handlers extract and structure source 
 
 PIPELINES define workflow structure: step types in sequence (e.g., event_import → ai → upsert). The pipeline system_prompt defines AI behavior shared by all flows.
 
-FLOWS are configured pipeline instances. Each step needs a handler_slug and handler_config. When creating flows, match handler configurations from existing flows on the same pipeline.
+FLOWS are configured pipeline instances. Handler-based single steps use handler_slug + handler_config; multi-handler steps use handler_slugs + handler_configs; handler-free steps only carry handler_config when they have settings. When creating flows, match handler configurations from existing flows on the same pipeline.
 
 AI STEPS process data that handlers cannot automatically handle. The pipeline system_prompt sets the agent's stable identity (shared across every flow). The flow's per-flow user message lives in the prompt_queue head — appended as the final user-role message after fetched data packets — use it for per-flow task framing on top of the pipeline system_prompt. The two are additive, not alternative. Set it via `flow update --set-user-message` (a 1-entry static queue) or `flow queue add` plus `flow queue mode <drain|loop|static>`.
 

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -24,6 +24,7 @@ namespace DataMachine\Engine\AI\Tools;
 
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -52,8 +53,8 @@ class ToolPolicyResolver {
 	 *
 	 *     @type string      $mode                  Required. One of the MODE_* constants (or a custom mode slug).
 	 *     @type int|null    $agent_id              Agent ID for per-agent tool policy filtering.
-	 *     @type array|null  $previous_step_config  Pipeline only: previous step config with handler_slugs.
-	 *     @type array|null  $next_step_config      Pipeline only: next step config with handler_slugs.
+	 *     @type array|null  $previous_step_config  Pipeline only: previous step config.
+	 *     @type array|null  $next_step_config      Pipeline only: next step config.
 	 *     @type string|null $pipeline_step_id      Pipeline only: current pipeline step ID for per-step filtering.
 	 *     @type array       $engine_data           Engine data snapshot for dynamic tool generation.
 	 *     @type array       $deny                  Tool names to explicitly deny (highest precedence).
@@ -293,23 +294,20 @@ class ToolPolicyResolver {
 
 		// Handler tools from adjacent steps (dynamic, resolved per-execution).
 		//
-		// Reads handler_slugs / handler_configs raw (not via FlowStepConfig
-		// helpers) because adjacent steps may declare multiple handler slugs
-		// (e.g. multi-handler publish: wordpress_publish + twitter_publish)
-		// and the AI must see tools for all of them, not just the primary.
-		// This is one of the legitimate multi-element callsites alongside
-		// PipelineSystemPromptDirective; see #1205 for the audit.
+		// Reads every configured handler through FlowStepConfig's cardinality-
+		// agnostic helper because adjacent steps can be single-handler (fetch)
+		// or true multi-handler (publish/upsert). The AI must see tools for
+		// every adjacent handler, not just the primary.
 		foreach ( array( $args['previous_step_config'] ?? null, $args['next_step_config'] ?? null ) as $step_config ) {
 			if ( ! $step_config ) {
 				continue;
 			}
 
-			$handler_slugs       = $step_config['handler_slugs'] ?? array();
-			$handler_configs_map = $step_config['handler_configs'] ?? array();
+			$handler_slugs       = FlowStepConfig::getConfiguredHandlerSlugs( $step_config );
 			$cache_scope         = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
 
 			foreach ( $handler_slugs as $slug ) {
-				$handler_config = $handler_configs_map[ $slug ] ?? array();
+				$handler_config = FlowStepConfig::getHandlerConfigForSlug( $step_config, $slug );
 				$tools          = $this->tool_manager->resolveHandlerTools(
 					$slug,
 					$handler_config,

--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Engine\Actions;
 
+use DataMachine\Core\Steps\FlowStepConfig;
+
 // Prevent direct access
 if ( ! defined( 'WPINC' ) ) {
 	die;
@@ -34,8 +36,8 @@ class ImportExport {
 	 *   Pass 1 — pipeline-structure rows (flow_id empty): create pipelines and add steps
 	 *            with their full step_config (#1133 step 1).
 	 *   Pass 2 — flow-step rows (flow_id present): ensure target flows exist, then write
-	 *            handler_slugs + handler_configs into each flow_config entry keyed by the
-	 *            freshly-generated flow_step_id (#1133 step 2).
+	 *            canonical handler fields into each flow_config entry keyed by the
+	 *            freshly-generated flow_step_id (#1133 step 2, #1293 shape cleanup).
 	 *
 	 * NOTE on secrets: handler_configs is restored verbatim. Any auth tokens / API keys in
 	 * the exported CSV will land in the imported flow's config. A scrub-or-reference policy
@@ -122,17 +124,16 @@ class ImportExport {
 				continue;
 			}
 
-			$handler_slugs   = $row['settings']['handler_slugs'] ?? array();
-			$handler_configs = $row['settings']['handler_configs'] ?? array();
-			if ( empty( $handler_slugs ) && '' !== $row['handler'] ) {
-				$handler_slugs = array( $row['handler'] );
+			$settings = $row['settings'];
+			if ( '' !== $row['handler'] && empty( $settings['handler_slug'] ) && empty( $settings['handler_slugs'] ) ) {
+				$settings['handler_slug'] = $row['handler'];
 			}
 
-			$this->restore_flow_step_handlers(
+			$this->restore_flow_step_config(
 				$imported_flow_id,
 				$pipeline_step_id,
-				$handler_slugs,
-				$handler_configs
+				$row['step_type'],
+				$settings
 			);
 		}
 
@@ -312,20 +313,20 @@ class ImportExport {
 	}
 
 	/**
-	 * Write handler_slugs and handler_configs into the flow_config entry for this step.
+	 * Write canonical handler config into the flow_config entry for this step.
 	 *
 	 * `create-flow` (and the step-sync pipeline) already populate the flow_config entry
 	 * keyed by flow_step_id with structural fields (step_type, pipeline_step_id, etc.).
 	 * This overlays the handler fields verbatim — no handler validation, no auth rewiring,
 	 * no secret scrubbing. Secret policy is a separate concern (see #1133).
 	 */
-	private function restore_flow_step_handlers(
+	private function restore_flow_step_config(
 		int $flow_id,
 		string $pipeline_step_id,
-		array $handler_slugs,
-		array $handler_configs
+		string $step_type,
+		array $settings
 	): bool {
-		if ( empty( $handler_slugs ) && empty( $handler_configs ) ) {
+		if ( empty( $settings ) ) {
 			return false;
 		}
 
@@ -348,17 +349,29 @@ class ImportExport {
 				'flow_step_id'     => $flow_step_id,
 				'pipeline_step_id' => $pipeline_step_id,
 				'flow_id'          => $flow_id,
+				'step_type'        => $step_type,
 			);
 		}
-
-		if ( ! empty( $handler_slugs ) ) {
-			$flow_config[ $flow_step_id ]['handler_slugs'] = array_values( $handler_slugs );
-			$flow_config[ $flow_step_id ]['handler']       = $handler_slugs[0] ?? null;
+		if ( empty( $flow_config[ $flow_step_id ]['step_type'] ) ) {
+			$flow_config[ $flow_step_id ]['step_type'] = $step_type;
 		}
 
-		if ( ! empty( $handler_configs ) ) {
-			$flow_config[ $flow_step_id ]['handler_configs'] = $handler_configs;
+
+		$step = FlowStepConfig::normalizeHandlerShape(
+			array_merge(
+				$flow_config[ $flow_step_id ],
+				$settings
+			)
+		);
+
+		$primary_handler = FlowStepConfig::getPrimaryHandlerSlug( $step );
+		if ( null !== $primary_handler ) {
+			$step['handler'] = $primary_handler;
+		} else {
+			unset( $step['handler'] );
 		}
+
+		$flow_config[ $flow_step_id ] = $step;
 
 		$flow_config[ $flow_step_id ]['enabled'] = true;
 
@@ -434,21 +447,26 @@ class ImportExport {
 					$flow_step_id = apply_filters( 'datamachine_generate_flow_step_id', '', $step['pipeline_step_id'], $flow['flow_id'] );
 					$flow_step    = $flow_config[ $flow_step_id ] ?? array();
 
-					// Read the primary slug raw rather than via FlowStepConfig::
-					// getEffectiveSlug() so handler-free steps (system_task,
-					// webhook_gate) don't synthesize a step_type fallback into
-					// the exported handler column when the row genuinely has
-					// no handler. The export emits a row only when the primary
-					// slug is present; FlowStepConfig's step_type fallback
-					// would defeat that gate.
-					$primary_handler = $flow_step['handler_slugs'][0] ?? '';
+					$settings        = array();
+					$primary_handler = FlowStepConfig::getPrimaryHandlerSlug( $flow_step ) ?? '';
 
-					if ( ! empty( $primary_handler ) ) {
+					if ( FlowStepConfig::isMultiHandler( $flow_step ) && ! empty( $primary_handler ) ) {
 						$settings = array(
-							'handler_slugs'   => $flow_step['handler_slugs'] ?? array(),
-							'handler_configs' => $flow_step['handler_configs'] ?? array(),
+							'handler_slugs'   => FlowStepConfig::getHandlerSlugs( $flow_step ),
+							'handler_configs' => FlowStepConfig::getHandlerConfigs( $flow_step ),
 						);
+					} elseif ( FlowStepConfig::usesHandler( $flow_step ) && ! empty( $primary_handler ) ) {
+						$settings = array(
+							'handler_slug'   => $primary_handler,
+							'handler_config' => FlowStepConfig::getPrimaryHandlerConfig( $flow_step ),
+						);
+					} elseif ( ! FlowStepConfig::usesHandler( $flow_step ) && ! empty( $flow_step['handler_config'] ) ) {
+						$settings = array(
+							'handler_config' => $flow_step['handler_config'],
+						);
+					}
 
+					if ( ! empty( $settings ) ) {
 						$csv_rows[] = array(
 							$pipeline_id,
 							$pipeline['pipeline_name'],

--- a/inc/migrations/agent-ping.php
+++ b/inc/migrations/agent-ping.php
@@ -83,9 +83,9 @@ function datamachine_migrate_agent_ping_to_system_task(): void {
 			);
 
 			// Convert step type and handler references.
-			$step['step_type']       = 'system_task';
-			$step['handler_slugs']   = array( 'system_task' );
-			$step['handler_configs'] = array( 'system_task' => $new_config );
+			$step['step_type']      = 'system_task';
+			$step['handler_config'] = $new_config;
+			unset( $step['handler_slug'], $step['handler_slugs'], $step['handler_configs'] );
 
 			// queue_enabled and prompt_queue stay at their existing positions
 			// in the step config — no changes needed, they're already there.
@@ -191,9 +191,9 @@ function datamachine_migrate_agent_ping_pipeline_to_system_task(): void {
 			);
 
 			// Convert step type and handler references.
-			$step['step_type']       = 'system_task';
-			$step['handler_slugs']   = array( 'system_task' );
-			$step['handler_configs'] = array( 'system_task' => $new_config );
+			$step['step_type']      = 'system_task';
+			$step['handler_config'] = $new_config;
+			unset( $step['handler_slug'], $step['handler_slugs'], $step['handler_configs'] );
 
 			$changed = true;
 		}

--- a/inc/migrations/handler-slug-scalar.php
+++ b/inc/migrations/handler-slug-scalar.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Data Machine — Handler slug scalar migration.
+ *
+ * Collapses handler storage to match step-type cardinality:
+ * handler-free steps carry no handler slug field, single-handler steps use
+ * handler_slug/handler_config, and multi-handler steps keep
+ * handler_slugs/handler_configs.
+ *
+ * @package DataMachine
+ * @since 0.85.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Migrate persisted step configs to the canonical handler shape.
+ *
+ * @return void
+ */
+function datamachine_migrate_handler_slug_scalar(): void {
+	if ( get_option( 'datamachine_handler_slug_scalar_migrated', false ) ) {
+		return;
+	}
+
+	global $wpdb;
+
+	$flows_updated     = datamachine_migrate_handler_slug_scalar_table( $wpdb->prefix . 'datamachine_flows', 'flow_id', 'flow_config' );
+	$pipelines_updated = datamachine_migrate_handler_slug_scalar_table( $wpdb->prefix . 'datamachine_pipelines', 'pipeline_id', 'pipeline_config' );
+
+	update_option( 'datamachine_handler_slug_scalar_migrated', true, true );
+
+	if ( $flows_updated > 0 || $pipelines_updated > 0 ) {
+		do_action(
+			'datamachine_log',
+			'info',
+			'Migrated handler slug storage to canonical scalar/list shape',
+			array(
+				'flows_updated'     => $flows_updated,
+				'pipelines_updated' => $pipelines_updated,
+			)
+		);
+	}
+}
+
+/**
+ * Migrate one config-bearing database table.
+ *
+ * @param string $table Table name.
+ * @param string $id_column Primary ID column.
+ * @param string $config_column JSON config column.
+ * @return int Rows updated.
+ */
+function datamachine_migrate_handler_slug_scalar_table( string $table, string $id_column, string $config_column ): int {
+	global $wpdb;
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix.
+	$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+	// phpcs:enable WordPress.DB.PreparedSQL
+	if ( ! $table_exists ) {
+		return 0;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table/column names are internal constants from this migration.
+	$rows = $wpdb->get_results( "SELECT {$id_column}, {$config_column} FROM {$table}", ARRAY_A );
+	// phpcs:enable WordPress.DB.PreparedSQL
+	if ( empty( $rows ) ) {
+		return 0;
+	}
+
+	$updated = 0;
+	foreach ( $rows as $row ) {
+		$config = json_decode( $row[ $config_column ], true );
+		if ( ! is_array( $config ) ) {
+			continue;
+		}
+
+		$changed = false;
+		foreach ( $config as $step_id => &$step ) {
+			if ( ! is_array( $step ) || 'memory_files' === $step_id ) {
+				continue;
+			}
+
+			$normalized = \DataMachine\Core\Steps\FlowStepConfig::normalizeHandlerShape( $step );
+			if ( $normalized !== $step ) {
+				$step    = $normalized;
+				$changed = true;
+			}
+		}
+		unset( $step );
+
+		if ( ! $changed ) {
+			continue;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->update(
+			$table,
+			array( $config_column => wp_json_encode( $config ) ),
+			array( $id_column => $row[ $id_column ] ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		++$updated;
+	}
+
+	return $updated;
+}

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -24,6 +24,7 @@ require_once __DIR__ . '/post-pipeline-meta.php';
 require_once __DIR__ . '/update-to-upsert.php';
 require_once __DIR__ . '/strip-pipeline-step-provider-model.php';
 require_once __DIR__ . '/ai-enabled-tools.php';
+require_once __DIR__ . '/handler-slug-scalar.php';
 require_once __DIR__ . '/split-queue-payload.php';
 require_once __DIR__ . '/user-message-queue-mode.php';
 

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -99,6 +99,9 @@ function datamachine_run_schema_migrations(): void {
 	// Move AI step tools from handler_slugs to enabled_tools (#1205 Phase 2b, idempotent).
 	datamachine_migrate_ai_enabled_tools();
 
+	// Collapse handler storage to match step-type cardinality (#1293, idempotent).
+	datamachine_migrate_handler_slug_scalar();
+
 	// Split prompt_queue / config_patch_queue payload polymorphism (#1292, idempotent).
 	datamachine_migrate_split_queue_payload();
 

--- a/tests/handler-slug-scalar-migration-smoke.php
+++ b/tests/handler-slug-scalar-migration-smoke.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Pure-PHP smoke test for handler slug scalar migration.
+ *
+ * Run with: php tests/handler-slug-scalar-migration-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+$options = array();
+
+function get_option( string $key, $default = false ) {
+	global $options;
+	return array_key_exists( $key, $options ) ? $options[ $key ] : $default;
+}
+
+function update_option( string $key, $value, bool $autoload = true ): bool {
+	global $options;
+	$GLOBALS['__handler_slug_scalar_migration_autoload'][ $key ] = $autoload;
+	$options[ $key ] = $value;
+	return true;
+}
+
+function wp_json_encode( $value ) {
+	return json_encode( $value );
+}
+
+function do_action( string $hook, ...$args ): void {
+	$GLOBALS['__handler_slug_scalar_migration_actions'][] = array( $hook, $args );
+}
+
+function apply_filters( string $hook, $value ) {
+	if ( 'datamachine_step_types' !== $hook ) {
+		return $value;
+	}
+
+	return array(
+		'ai'           => array( 'uses_handler' => false, 'multi_handler' => false ),
+		'system_task'  => array( 'uses_handler' => false, 'multi_handler' => false ),
+		'webhook_gate' => array( 'uses_handler' => false, 'multi_handler' => false ),
+		'fetch'        => array( 'uses_handler' => true, 'multi_handler' => false ),
+		'publish'      => array( 'uses_handler' => true, 'multi_handler' => true ),
+		'upsert'       => array( 'uses_handler' => true, 'multi_handler' => true ),
+	);
+}
+
+class HandlerSlugScalarMigrationWpdb {
+	public string $prefix = 'wp_';
+
+	/** @var array<string, array<int, array<string, mixed>>> */
+	public array $rows = array();
+
+	public function prepare( string $query, ...$args ): string {
+		return vsprintf( str_replace( '%s', "'%s'", $query ), $args );
+	}
+
+	public function get_var( string $query ) {
+		foreach ( array_keys( $this->rows ) as $table ) {
+			if ( str_contains( $query, $table ) ) {
+				return $table;
+			}
+		}
+		return null;
+	}
+
+	public function get_results( string $query, $output ) {
+		foreach ( $this->rows as $table => $rows ) {
+			if ( str_contains( $query, $table ) ) {
+				return $rows;
+			}
+		}
+		return array();
+	}
+
+	public function update( string $table, array $data, array $where, array $formats, array $where_formats ): bool {
+		$GLOBALS['__handler_slug_scalar_migration_update_formats'][] = array( $formats, $where_formats );
+		$id_column = array_key_first( $where );
+		if ( null === $id_column ) {
+			return false;
+		}
+		$id_value  = $where[ $id_column ];
+
+		foreach ( $this->rows[ $table ] as &$row ) {
+			if ( array_key_exists( $id_column, $row ) && (string) $row[ $id_column ] === (string) $id_value ) {
+				$row = array_merge( $row, $data );
+				return true;
+			}
+		}
+		unset( $row );
+
+		return false;
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/migrations/handler-slug-scalar.php';
+
+$failures = array();
+$passes   = 0;
+
+function assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+echo "handler slug scalar migration smoke\n";
+echo "-----------------------------------\n";
+
+$wpdb = new HandlerSlugScalarMigrationWpdb();
+$wpdb->rows['wp_datamachine_flows'] = array(
+	array(
+		'flow_id'     => 10,
+		'flow_config' => wp_json_encode(
+			array(
+				'fetch_10'  => array(
+					'step_type'       => 'fetch',
+					'handler_slugs'   => array( 'rss' ),
+					'handler_configs' => array( 'rss' => array( 'url' => 'https://example.com/feed.xml' ) ),
+				),
+				'system_10' => array(
+					'step_type'       => 'system_task',
+					'handler_slugs'   => array( 'system_task' ),
+					'handler_configs' => array( 'system_task' => array( 'task' => 'daily_memory_generation' ) ),
+				),
+				'publish_10' => array(
+					'step_type'       => 'publish',
+					'handler_slugs'   => array( 'wordpress_publish', 'email_publish' ),
+					'handler_configs' => array(
+						'wordpress_publish' => array( 'post_type' => 'post' ),
+						'email_publish'     => array( 'to' => 'ops@example.com' ),
+					),
+				),
+			)
+		),
+	),
+);
+$wpdb->rows['wp_datamachine_pipelines'] = array(
+	array(
+		'pipeline_id'     => 20,
+		'pipeline_config' => wp_json_encode(
+			array(
+				'system_pipeline' => array(
+					'step_type'       => 'system_task',
+					'handler_slugs'   => array( 'system_task' ),
+					'handler_configs' => array( 'system_task' => array( 'task' => 'agent_ping' ) ),
+				),
+			)
+		),
+	),
+);
+
+datamachine_migrate_handler_slug_scalar();
+
+$flow_config     = json_decode( $wpdb->rows['wp_datamachine_flows'][0]['flow_config'], true );
+$pipeline_config = json_decode( $wpdb->rows['wp_datamachine_pipelines'][0]['pipeline_config'], true );
+
+assert_equals( true, get_option( 'datamachine_handler_slug_scalar_migrated' ), 'migration gate set', $failures, $passes );
+assert_equals( 'rss', $flow_config['fetch_10']['handler_slug'] ?? null, 'fetch slug collapsed to scalar', $failures, $passes );
+assert_equals( array( 'url' => 'https://example.com/feed.xml' ), $flow_config['fetch_10']['handler_config'] ?? null, 'fetch config collapsed to scalar', $failures, $passes );
+assert_equals( false, array_key_exists( 'handler_slugs', $flow_config['fetch_10'] ), 'fetch plural slugs removed', $failures, $passes );
+assert_equals( array( 'task' => 'daily_memory_generation' ), $flow_config['system_10']['handler_config'] ?? null, 'system_task config collapsed', $failures, $passes );
+assert_equals( false, array_key_exists( 'handler_slugs', $flow_config['system_10'] ), 'system_task synthetic slugs removed', $failures, $passes );
+assert_equals( array( 'wordpress_publish', 'email_publish' ), $flow_config['publish_10']['handler_slugs'] ?? null, 'publish multi slugs preserved', $failures, $passes );
+assert_equals( array( 'task' => 'agent_ping' ), $pipeline_config['system_pipeline']['handler_config'] ?? null, 'pipeline system_task config collapsed', $failures, $passes );
+
+echo "\n-----------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nAll assertions passed.\n";

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -120,6 +120,7 @@ $migration_chain = array(
 	'datamachine_migrate_update_to_upsert_step_type',
 	'datamachine_strip_pipeline_step_provider_model',
 	'datamachine_migrate_ai_enabled_tools',
+	'datamachine_migrate_handler_slug_scalar',
 	'datamachine_migrate_split_queue_payload',
 	'datamachine_migrate_user_message_queue_mode',
 	'datamachine_drop_redundant_post_pipeline_meta',
@@ -199,6 +200,19 @@ assert_runtime(
 	false !== $handler_keys_pos
 		&& false !== $ai_tools_pos
 		&& $handler_keys_pos < $ai_tools_pos
+);
+$handler_scalar_pos = array_search(
+	'datamachine_migrate_handler_slug_scalar',
+	$GLOBALS['__test_migration_calls'],
+	true
+);
+assert_runtime(
+	'handler_slug_scalar runs after ai_enabled_tools and before split_queue_payload (#1293 dependency)',
+	false !== $handler_scalar_pos
+		&& false !== $ai_tools_pos
+		&& false !== $queue_split_pos
+		&& $ai_tools_pos < $handler_scalar_pos
+		&& $handler_scalar_pos < $queue_split_pos
 );
 
 // ---------------------------------------------------------------

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -1,24 +1,8 @@
 <?php
 /**
- * Pure-PHP smoke test for handler-free step config passthrough.
+ * Pure-PHP smoke test for canonical handler config shapes.
  *
  * Run with: php tests/system-task-config-passthrough-smoke.php
- *
- * Covers the build-side + read-side fix that lets handler-free step
- * types (system_task, webhook_gate, agent_ping) preserve their
- * handler_config across the workflow → flow_config → step runtime
- * translation.
- *
- * Phase 1 fix (#1202): keyed handler-free configs by step_type and
- * added a fallback in Step::getHandlerConfig() so SystemTaskStep could
- * find its { task, params }.
- *
- * Phase 2a fix (#1205): collapsed onto FlowStepConfig::getPrimary
- * HandlerConfig() by writing handler_slugs = [step_type] for handler-
- * free steps with a non-empty handler_config (mirrors the v0.60.0
- * migration in inc/migrations/handler-keys.php). This drops the read-
- * side fallback ladder in Step::getHandlerConfig() — the helper now
- * resolves uniformly via handler_slugs[0].
  *
  * @package DataMachine\Tests
  */
@@ -27,13 +11,35 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_step_types' !== $hook ) {
+			return $value;
+		}
+
+		return array(
+			'ai'           => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'system_task'  => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'webhook_gate' => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'fetch'        => array( 'uses_handler' => true, 'multi_handler' => false ),
+			'publish'      => array( 'uses_handler' => true, 'multi_handler' => true ),
+			'upsert'       => array( 'uses_handler' => true, 'multi_handler' => true ),
+		);
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['__system_task_config_passthrough_actions'][] = array( $hook, $args );
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+
+use DataMachine\Core\Steps\FlowStepConfig;
+
 /**
- * Inline reimplementation of ExecuteWorkflowAbility::buildConfigsFromWorkflow()
- * for pure-PHP testing (the real method is private + lives in a class
- * with WordPress dependencies).
- *
- * Mirrors the post-#1205 shape so a regression in the real file shows
- * up as the fixture diverging from the harness.
+ * Inline mirror of ExecuteWorkflowAbility::buildConfigsFromWorkflow().
  */
 function build_configs_from_workflow_for_test( array $workflow ): array {
 	$flow_config     = array();
@@ -42,42 +48,38 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 	foreach ( $workflow['steps'] as $index => $step ) {
 		$step_id          = "ephemeral_step_{$index}";
 		$pipeline_step_id = "ephemeral_pipeline_{$index}";
+		$handler_slug     = $step['handler_slug'] ?? '';
+		$handler_config   = $step['handler_config'] ?? array();
+		$step_type        = $step['type'];
 
-		$handler_slug   = $step['handler_slug'] ?? '';
-		$handler_config = $step['handler_config'] ?? array();
-		$step_type      = $step['type'];
-
-		$handler_slugs = array();
-		if ( ! empty( $handler_slug ) ) {
-			$handler_slugs = array( $handler_slug );
-		} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
-			$handler_slugs = array( $step_type );
-		}
-
-		$handler_configs = array();
-		if ( ! empty( $handler_slug ) ) {
-			$handler_configs[ $handler_slug ] = $handler_config;
-		} elseif ( 'ai' !== $step_type && ! empty( $handler_config ) ) {
-			$handler_configs[ $step_type ] = $handler_config;
-		}
-
-		$enabled_tools = ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
-			? array_values( $step['enabled_tools'] )
-			: array();
-
-		$flow_config[ $step_id ] = array(
+		$flow_step_config = array(
 			'flow_step_id'     => $step_id,
 			'pipeline_step_id' => $pipeline_step_id,
 			'step_type'        => $step_type,
 			'execution_order'  => $index,
-			'handler_slugs'    => $handler_slugs,
-			'handler_configs'  => $handler_configs,
-			'enabled_tools'    => $enabled_tools,
-			'user_message'     => $step['user_message'] ?? '',
+			'enabled_tools'    => ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
+				? array_values( $step['enabled_tools'] )
+				: array(),
+			'prompt_queue'     => array(),
+			'queue_mode'       => 'static',
 			'disabled_tools'   => $step['disabled_tools'] ?? array(),
 			'pipeline_id'      => 'direct',
 			'flow_id'          => 'direct',
 		);
+
+		if ( ! empty( $handler_slug ) ) {
+			if ( FlowStepConfig::isMultiHandler( $flow_step_config ) ) {
+				$flow_step_config['handler_slugs']   = array( $handler_slug );
+				$flow_step_config['handler_configs'] = array( $handler_slug => $handler_config );
+			} else {
+				$flow_step_config['handler_slug']   = $handler_slug;
+				$flow_step_config['handler_config'] = $handler_config;
+			}
+		} elseif ( ! FlowStepConfig::usesHandler( $flow_step_config ) && ! empty( $handler_config ) ) {
+			$flow_step_config['handler_config'] = $handler_config;
+		}
+
+		$flow_config[ $step_id ] = $flow_step_config;
 
 		if ( 'ai' === $step_type ) {
 			$pipeline_config[ $pipeline_step_id ] = array(
@@ -93,197 +95,177 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 	);
 }
 
-/**
- * Inline reimplementation of FlowStepConfig::getPrimaryHandlerConfig().
- *
- * Reads handler_configs[handler_slugs[0]] uniformly. The fallback ladder
- * Step::getHandlerConfig() carried in #1202 is gone — the build side
- * now writes handler_slugs = [step_type] for handler-free steps with a
- * non-empty handler_config so this single lookup resolves both shapes.
- */
-function get_primary_handler_config_for_test( array $flow_step_config ): array {
-	$slug = $flow_step_config['handler_slugs'][0] ?? '';
-	if ( ! empty( $slug ) && ! empty( $flow_step_config['handler_configs'][ $slug ] ) ) {
-		return $flow_step_config['handler_configs'][ $slug ];
-	}
-	return array();
-}
-
-/**
- * Inline reimplementation of FlowStepConfig::getEffectiveSlug().
- */
-function get_effective_slug_for_test( array $flow_step_config, string $explicit_slug = '' ): string {
-	if ( ! empty( $explicit_slug ) ) {
-		return $explicit_slug;
-	}
-	$primary = $flow_step_config['handler_slugs'][0] ?? '';
-	if ( ! empty( $primary ) ) {
-		return $primary;
-	}
-	return $flow_step_config['step_type'] ?? '';
-}
-
 $failures = array();
 $passes   = 0;
 
 function assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
 	if ( $expected === $actual ) {
-		$passes++;
+		++$passes;
 		echo "  ✓ {$name}\n";
 		return;
 	}
 
 	$failures[] = $name;
 	echo "  ✗ {$name}\n";
-	echo "    expected: " . var_export( $expected, true ) . "\n";
-	echo "    actual:   " . var_export( $actual, true ) . "\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }
 
-echo "system-task config passthrough smoke (Phase 2a + 2b)\n";
-echo "-----------------------------------------------------\n";
+function assert_absent( string $key, array $array, string $name, array &$failures, int &$passes ): void {
+	assert_equals( false, array_key_exists( $key, $array ), $name, $failures, $passes );
+}
 
-// Test 1: system_task workflow round-trips handler_config under step type slug.
-echo "\n[1] system_task workflow round-trips { task, params }:\n";
-$workflow = array(
-	'steps' => array(
-		array(
-			'type'           => 'system_task',
-			'handler_config' => array(
-				'task'   => 'daily_memory_generation',
-				'params' => array(),
+echo "handler config shape smoke (#1293)\n";
+echo "-----------------------------------\n";
+
+echo "\n[1] system_task stores handler_config without synthetic slugs:\n";
+$built = build_configs_from_workflow_for_test(
+	array(
+		'steps' => array(
+			array(
+				'type'           => 'system_task',
+				'handler_config' => array(
+					'task'   => 'daily_memory_generation',
+					'params' => array(),
+				),
 			),
 		),
-	),
+	)
 );
+$step0 = $built['flow_config']['ephemeral_step_0'];
+assert_equals( array( 'task' => 'daily_memory_generation', 'params' => array() ), FlowStepConfig::getPrimaryHandlerConfig( $step0 ), 'system_task config reachable', $failures, $passes );
+assert_equals( 'system_task', FlowStepConfig::getEffectiveSlug( $step0 ), 'system_task settings slug is step_type', $failures, $passes );
+assert_absent( 'handler_slug', $step0, 'system_task has no handler_slug', $failures, $passes );
+assert_absent( 'handler_slugs', $step0, 'system_task has no handler_slugs', $failures, $passes );
+assert_absent( 'handler_configs', $step0, 'system_task has no handler_configs', $failures, $passes );
 
-$built  = build_configs_from_workflow_for_test( $workflow );
-$step0  = $built['flow_config']['ephemeral_step_0'];
-$config = get_primary_handler_config_for_test( $step0 );
-
-assert_equals( 'daily_memory_generation', $config['task'] ?? null, 'task survives passthrough', $failures, $passes );
-assert_equals( array(), $config['params'] ?? null, 'params survives passthrough', $failures, $passes );
-assert_equals( array( 'system_task' ), $step0['handler_slugs'], 'handler_slugs synthesized from step_type', $failures, $passes );
-assert_equals( array( 'system_task' => array( 'task' => 'daily_memory_generation', 'params' => array() ) ), $step0['handler_configs'], 'handler_configs keyed by step type', $failures, $passes );
-assert_equals( 'system_task', get_effective_slug_for_test( $step0 ), 'getEffectiveSlug returns step_type', $failures, $passes );
-
-// Test 2: handler-bearing step still keys by handler_slug.
-echo "\n[2] fetch step (handler-bearing) keys handler_configs by handler_slug:\n";
-$workflow = array(
-	'steps' => array(
-		array(
-			'type'           => 'fetch',
-			'handler_slug'   => 'mcp',
-			'handler_config' => array(
-				'server'   => 'a8c',
-				'provider' => 'mgs',
+echo "\n[2] fetch stores scalar handler_slug + handler_config:\n";
+$built = build_configs_from_workflow_for_test(
+	array(
+		'steps' => array(
+			array(
+				'type'           => 'fetch',
+				'handler_slug'   => 'mcp',
+				'handler_config' => array( 'server' => 'a8c' ),
 			),
 		),
-	),
+	)
 );
-
-$built  = build_configs_from_workflow_for_test( $workflow );
-$step0  = $built['flow_config']['ephemeral_step_0'];
-$config = get_primary_handler_config_for_test( $step0 );
-
-assert_equals( 'a8c', $config['server'] ?? null, 'server reachable via handler_slug', $failures, $passes );
-assert_equals( array( 'mcp' ), $step0['handler_slugs'], 'handler_slugs has mcp', $failures, $passes );
-assert_equals( array( 'mcp' => array( 'server' => 'a8c', 'provider' => 'mgs' ) ), $step0['handler_configs'], 'handler_configs keyed by handler_slug', $failures, $passes );
-assert_equals( 'mcp', get_effective_slug_for_test( $step0 ), 'getEffectiveSlug returns handler_slug', $failures, $passes );
-
-// Test 3: empty handler_config and no handler_slug → empty handler_configs and empty handler_slugs.
-// Mirrors inc/migrations/handler-keys.php: when there is nothing to key,
-// both arrays stay empty rather than synthesizing a slug-with-no-config row.
-echo "\n[3] handler-free step with no config has empty handler_configs and handler_slugs:\n";
-$workflow = array(
-	'steps' => array(
-		array(
-			'type' => 'webhook_gate',
-		),
-	),
-);
-
-$built = build_configs_from_workflow_for_test( $workflow );
 $step0 = $built['flow_config']['ephemeral_step_0'];
+assert_equals( 'mcp', FlowStepConfig::getHandlerSlug( $step0 ), 'fetch handler slug is scalar', $failures, $passes );
+assert_equals( array( 'mcp' ), FlowStepConfig::getConfiguredHandlerSlugs( $step0 ), 'fetch generic slug list has one slug', $failures, $passes );
+assert_equals( array( 'server' => 'a8c' ), FlowStepConfig::getPrimaryHandlerConfig( $step0 ), 'fetch config reachable', $failures, $passes );
+assert_absent( 'handler_slugs', $step0, 'fetch has no handler_slugs', $failures, $passes );
+assert_absent( 'handler_configs', $step0, 'fetch has no handler_configs', $failures, $passes );
 
-assert_equals( array(), $step0['handler_slugs'], 'no config → empty handler_slugs', $failures, $passes );
-assert_equals( array(), $step0['handler_configs'], 'no config → empty handler_configs', $failures, $passes );
-assert_equals( array(), get_primary_handler_config_for_test( $step0 ), 'getPrimaryHandlerConfig returns empty', $failures, $passes );
-assert_equals( 'webhook_gate', get_effective_slug_for_test( $step0 ), 'getEffectiveSlug falls back to step_type', $failures, $passes );
-
-// Test 4: ai step with enabled_tools.
-// Phase 2b: tools now land in `enabled_tools` and `handler_slugs` stays empty
-// for AI steps. The field overload (enabled_tools as handler_slugs) is gone.
-echo "\n[4] ai step with enabled_tools (Phase 2b shape):\n";
-$workflow = array(
-	'steps' => array(
-		array(
-			'type'          => 'ai',
-			'system_prompt' => 'be helpful',
-			'enabled_tools' => array( 'intelligence/search', 'intelligence/wiki-upsert' ),
-		),
-	),
-);
-
-$built = build_configs_from_workflow_for_test( $workflow );
-$step0 = $built['flow_config']['ephemeral_step_0'];
-
-assert_equals( array( 'intelligence/search', 'intelligence/wiki-upsert' ), $step0['enabled_tools'], 'enabled_tools land in dedicated field', $failures, $passes );
-assert_equals( array(), $step0['handler_slugs'], 'ai handler_slugs stays empty (single-purpose now)', $failures, $passes );
-assert_equals( array(), $step0['handler_configs'], 'ai step without handler_config → empty handler_configs', $failures, $passes );
-assert_equals( 'be helpful', $built['pipeline_config']['ephemeral_pipeline_0']['system_prompt'] ?? null, 'system_prompt lands in pipeline_config', $failures, $passes );
-
-// Test 5: ai step with no enabled_tools, no handler — both arrays empty, including the new field.
-echo "\n[5] ai step with no enabled_tools and no handler_config:\n";
-$workflow = array(
-	'steps' => array(
-		array(
-			'type'          => 'ai',
-			'system_prompt' => 'be helpful',
-		),
-	),
-);
-
-$built = build_configs_from_workflow_for_test( $workflow );
-$step0 = $built['flow_config']['ephemeral_step_0'];
-
-assert_equals( array(), $step0['handler_slugs'], 'ai handler_slugs stays empty', $failures, $passes );
-assert_equals( array(), $step0['enabled_tools'], 'ai enabled_tools empty when none provided', $failures, $passes );
-assert_equals( array(), $step0['handler_configs'], 'ai with no config → empty handler_configs', $failures, $passes );
-
-// Test 6: regression — system_task workflow that bypassed validation
-// after #1200 still got handler_config dropped before #1202. After
-// Phase 2a, the task type is reachable end-to-end via the helper.
-echo "\n[6] regression: validate→build→getPrimaryHandlerConfig pipeline:\n";
-$workflow = array(
-	'steps' => array(
-		array(
-			'type'           => 'system_task',
-			'handler_config' => array(
-				'task'   => 'agent_ping',
-				'params' => array( 'agent_id' => 2 ),
+echo "\n[3] publish keeps multi-handler list shape:\n";
+$built = build_configs_from_workflow_for_test(
+	array(
+		'steps' => array(
+			array(
+				'type'           => 'publish',
+				'handler_slug'   => 'wordpress_publish',
+				'handler_config' => array( 'post_type' => 'post' ),
 			),
 		),
-	),
+	)
 );
+$step0 = $built['flow_config']['ephemeral_step_0'];
+assert_equals( array( 'wordpress_publish' ), FlowStepConfig::getHandlerSlugs( $step0 ), 'publish handler slugs stay plural', $failures, $passes );
+assert_equals( array( 'post_type' => 'post' ), FlowStepConfig::getPrimaryHandlerConfig( $step0 ), 'publish config reachable', $failures, $passes );
+assert_absent( 'handler_slug', $step0, 'publish has no scalar handler_slug', $failures, $passes );
+assert_absent( 'handler_config', $step0, 'publish has no scalar handler_config', $failures, $passes );
 
-$built  = build_configs_from_workflow_for_test( $workflow );
-$step0  = $built['flow_config']['ephemeral_step_0'];
-$config = get_primary_handler_config_for_test( $step0 );
+echo "\n[4] webhook_gate with no config has no handler fields:\n";
+$built = build_configs_from_workflow_for_test( array( 'steps' => array( array( 'type' => 'webhook_gate' ) ) ) );
+$step0 = $built['flow_config']['ephemeral_step_0'];
+assert_equals( array(), FlowStepConfig::getPrimaryHandlerConfig( $step0 ), 'webhook_gate config empty', $failures, $passes );
+assert_absent( 'handler_slug', $step0, 'webhook_gate has no handler_slug', $failures, $passes );
+assert_absent( 'handler_slugs', $step0, 'webhook_gate has no handler_slugs', $failures, $passes );
+assert_absent( 'handler_config', $step0, 'webhook_gate has no handler_config when empty', $failures, $passes );
 
-assert_equals( 'agent_ping', $config['task'] ?? null, 'task type reaches step runtime', $failures, $passes );
-assert_equals( array( 'agent_id' => 2 ), $config['params'] ?? null, 'task params reach step runtime', $failures, $passes );
+echo "\n[5] AI stores enabled_tools only:\n";
+$built = build_configs_from_workflow_for_test(
+	array(
+		'steps' => array(
+			array(
+				'type'          => 'ai',
+				'system_prompt' => 'be helpful',
+				'enabled_tools' => array( 'intelligence/search' ),
+			),
+		),
+	)
+);
+$step0 = $built['flow_config']['ephemeral_step_0'];
+assert_equals( array( 'intelligence/search' ), FlowStepConfig::getEnabledTools( $step0 ), 'AI enabled_tools readable', $failures, $passes );
+assert_absent( 'handler_slug', $step0, 'AI has no handler_slug', $failures, $passes );
+assert_absent( 'handler_slugs', $step0, 'AI has no handler_slugs', $failures, $passes );
+assert_equals( 'be helpful', $built['pipeline_config']['ephemeral_pipeline_0']['system_prompt'] ?? null, 'AI system_prompt lands in pipeline_config', $failures, $passes );
 
-echo "\n-----------------------------------------------------\n";
+echo "\n[6] normalize legacy rows to canonical storage:\n";
+$system_task = FlowStepConfig::normalizeHandlerShape(
+	array(
+		'step_type'       => 'system_task',
+		'handler_slugs'   => array( 'system_task' ),
+		'handler_configs' => array( 'system_task' => array( 'task' => 'agent_ping' ) ),
+	)
+);
+assert_equals( array( 'task' => 'agent_ping' ), $system_task['handler_config'] ?? array(), 'legacy synthetic system_task config collapses', $failures, $passes );
+assert_absent( 'handler_slugs', $system_task, 'legacy synthetic system_task slugs removed', $failures, $passes );
+
+$fetch = FlowStepConfig::normalizeHandlerShape(
+	array(
+		'step_type'       => 'fetch',
+		'handler_slugs'   => array( 'rss' ),
+		'handler_configs' => array( 'rss' => array( 'url' => 'https://example.com/feed.xml' ) ),
+	)
+);
+assert_equals( 'rss', $fetch['handler_slug'] ?? null, 'legacy fetch slug becomes scalar', $failures, $passes );
+assert_equals( array( 'url' => 'https://example.com/feed.xml' ), $fetch['handler_config'] ?? array(), 'legacy fetch config becomes scalar', $failures, $passes );
+assert_absent( 'handler_slugs', $fetch, 'legacy fetch plural slugs removed', $failures, $passes );
+
+$fetch_configs_only = FlowStepConfig::normalizeHandlerShape(
+	array(
+		'step_type'       => 'fetch',
+		'handler_configs' => array( 'rss' => array( 'url' => 'https://example.com/feed.xml' ) ),
+	)
+);
+assert_equals( 'rss', $fetch_configs_only['handler_slug'] ?? null, 'legacy fetch infers scalar slug from config key', $failures, $passes );
+assert_equals( array( 'url' => 'https://example.com/feed.xml' ), $fetch_configs_only['handler_config'] ?? array(), 'legacy fetch keeps config when slug list missing', $failures, $passes );
+
+$publish = FlowStepConfig::normalizeHandlerShape(
+	array(
+		'step_type'      => 'publish',
+		'handler_slug'   => 'wordpress_publish',
+		'handler_config' => array( 'post_type' => 'post' ),
+	)
+);
+assert_equals( array( 'wordpress_publish' ), $publish['handler_slugs'] ?? array(), 'legacy publish scalar slug becomes list', $failures, $passes );
+assert_equals( array( 'wordpress_publish' => array( 'post_type' => 'post' ) ), $publish['handler_configs'] ?? array(), 'legacy publish scalar config becomes map', $failures, $passes );
+assert_absent( 'handler_slug', $publish, 'legacy publish scalar slug removed', $failures, $passes );
+
+$publish_configs_only = FlowStepConfig::normalizeHandlerShape(
+	array(
+		'step_type'       => 'publish',
+		'handler_configs' => array(
+			'wordpress_publish' => array( 'post_type' => 'post' ),
+			'email_publish'     => array( 'to' => 'ops@example.com' ),
+		),
+	)
+);
+assert_equals( array( 'wordpress_publish', 'email_publish' ), $publish_configs_only['handler_slugs'] ?? array(), 'legacy publish infers slugs from config keys', $failures, $passes );
+assert_equals( array( 'to' => 'ops@example.com' ), $publish_configs_only['handler_configs']['email_publish'] ?? array(), 'legacy publish keeps all inferred configs', $failures, $passes );
+
+echo "\n-----------------------------------\n";
 $total = $passes + count( $failures );
 echo "{$passes} / {$total} passed\n";
 
 if ( ! empty( $failures ) ) {
-	echo "Failures:\n";
-	foreach ( $failures as $name ) {
-		echo "  - {$name}\n";
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
 	}
 	exit( 1 );
 }
 
-echo "All checks passed.\n";
-exit( 0 );
+echo "\nAll assertions passed.\n";

--- a/tests/tool-policy-resolver-adjacency-smoke.php
+++ b/tests/tool-policy-resolver-adjacency-smoke.php
@@ -4,24 +4,11 @@
  *
  * Run with: php tests/tool-policy-resolver-adjacency-smoke.php
  *
- * After Phase 2a (#1205), ExecuteWorkflowAbility::buildConfigsFromWorkflow()
- * writes handler_slugs = [step_type] for handler-free step types
- * (system_task, webhook_gate, agent_ping) with a non-empty handler_config,
- * mirroring inc/migrations/handler-keys.php (v0.60.0).
- *
- * ToolPolicyResolver::gatherPipelineTools() iterates handler_slugs from
- * adjacent steps to surface their handler tools to the AI. The
- * synthetic-slug shape means an adjacent system_task step will have
- * handler_slugs = ['system_task'] — a slug that does NOT correspond to a
- * registered handler tool. The resolver MUST handle that gracefully:
- * when ToolManager::resolveHandlerTools('system_task', …) returns no
- * tools, the resolver moves on without injecting a synthetic 'system_task'
- * pseudo-tool into the AI's tool list.
- *
- * This regression guard verifies the iteration shape stays correct: the
- * resolver visits each slug, asks the tool manager for tools, and only
- * adds tools the manager actually returns. A handler-free synthetic slug
- * yielding an empty result must not pollute the available_tools map.
+ * After #1293, handler-free steps (system_task, webhook_gate) no longer
+ * carry synthetic handler_slugs. ToolPolicyResolver::gatherPipelineTools()
+ * reads adjacent steps through FlowStepConfig::getConfiguredHandlerSlugs(),
+ * so handler-free adjacency should contribute zero handler tools while
+ * single-handler and multi-handler steps still expose their real handlers.
  *
  * @package DataMachine\Tests
  */
@@ -30,12 +17,37 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_step_types' !== $hook ) {
+			return $value;
+		}
+
+		return array(
+			'ai'           => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'system_task'  => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'webhook_gate' => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'fetch'        => array( 'uses_handler' => true, 'multi_handler' => false ),
+			'publish'      => array( 'uses_handler' => true, 'multi_handler' => true ),
+			'upsert'       => array( 'uses_handler' => true, 'multi_handler' => true ),
+		);
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['__tool_policy_resolver_actions'][] = array( $hook, $args );
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+
+use DataMachine\Core\Steps\FlowStepConfig;
+
 /**
  * Stub ToolManager that records the slugs the resolver asked for and
  * returns canned tools per slug. A real handler slug
- * ('wordpress_publish') gets back a real tool; a synthetic slug
- * ('system_task') gets back an empty array, simulating what the unified
- * datamachine_tools registry actually does for unknown handler slugs.
+ * ('wordpress_publish') gets back a real tool.
  */
 class StubToolManager {
 	public array $resolveCalls = array();
@@ -52,17 +64,14 @@ class StubToolManager {
 			);
 		}
 
-		// All other slugs (including handler-free synthetic step_type
-		// slugs like 'system_task' or 'webhook_gate') return no tools.
+		// All other slugs return no tools.
 		return array();
 	}
 }
 
 /**
  * Inline reimplementation of ToolPolicyResolver::gatherPipelineTools()
- * adjacency loop. Mirrors inc/Engine/AI/Tools/ToolPolicyResolver.php
- * post-#1205 (the documentation-only edit there did not change the
- * iteration shape).
+ * adjacency loop. Mirrors inc/Engine/AI/Tools/ToolPolicyResolver.php.
  */
 function gather_pipeline_handler_tools_for_test( array $args, StubToolManager $tool_manager ): array {
 	$available_tools = array();
@@ -72,12 +81,11 @@ function gather_pipeline_handler_tools_for_test( array $args, StubToolManager $t
 			continue;
 		}
 
-		$handler_slugs       = $step_config['handler_slugs'] ?? array();
-		$handler_configs_map = $step_config['handler_configs'] ?? array();
-		$cache_scope         = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
+		$handler_slugs = FlowStepConfig::getConfiguredHandlerSlugs( $step_config );
+		$cache_scope   = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
 
 		foreach ( $handler_slugs as $slug ) {
-			$handler_config = $handler_configs_map[ $slug ] ?? array();
+			$handler_config = FlowStepConfig::getHandlerConfigForSlug( $step_config, $slug );
 			$tools          = $tool_manager->resolveHandlerTools( $slug, $handler_config, array(), $cache_scope );
 
 			foreach ( $tools as $tool_name => $tool_config ) {
@@ -105,7 +113,7 @@ function assert_equals( $expected, $actual, string $name, array &$failures, int 
 	echo "    actual:   " . var_export( $actual, true ) . "\n";
 }
 
-echo "ToolPolicyResolver adjacency smoke (Phase 2a)\n";
+echo "ToolPolicyResolver adjacency smoke (#1293)\n";
 echo "----------------------------------------------\n";
 
 // Test 1: AI step with a publish step (handler-bearing) before it.
@@ -128,28 +136,22 @@ $tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
 assert_equals( array( 'wordpress_publish' ), $tool_manager->resolveCalls, 'asked tool manager for wordpress_publish', $failures, $passes );
 assert_equals( true, isset( $tools['wordpress_publish_tool'] ), 'wordpress_publish_tool surfaced', $failures, $passes );
 
-// Test 2: AI step with a synthetic-slug system_task adjacency.
-// After #1205, system_task carries handler_slugs = ['system_task'].
-// Resolver must NOT inject a 'system_task' pseudo-tool — the tool
-// manager returns nothing for that slug, and the resolver respects
-// the empty result.
-echo "\n[2] AI adjacent to handler-free system_task step (synthetic slug):\n";
+// Test 2: AI step with a handler-free system_task adjacency.
+// Resolver should not ask the tool manager for any handler slug.
+echo "\n[2] AI adjacent to handler-free system_task step:\n";
 $tool_manager = new StubToolManager();
 $args         = array(
 	'previous_step_config' => array(
 		'flow_step_id'    => 'flow_sys_1',
 		'step_type'       => 'system_task',
-		'handler_slugs'   => array( 'system_task' ),
-		'handler_configs' => array(
-			'system_task' => array( 'task' => 'daily_memory_generation', 'params' => array() ),
-		),
+		'handler_config'  => array( 'task' => 'daily_memory_generation', 'params' => array() ),
 	),
 	'next_step_config'     => null,
 );
 $tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
 
-assert_equals( array( 'system_task' ), $tool_manager->resolveCalls, 'resolver asked for synthetic system_task slug', $failures, $passes );
-assert_equals( array(), $tools, 'no tools surfaced for handler-free synthetic slug', $failures, $passes );
+assert_equals( array(), $tool_manager->resolveCalls, 'resolver ignored handler-free system_task', $failures, $passes );
+assert_equals( array(), $tools, 'no tools surfaced for handler-free step', $failures, $passes );
 
 // Test 3: Mixed adjacency — publish before, system_task after.
 // Only the real handler tool should land in available_tools.
@@ -167,15 +169,12 @@ $args         = array(
 	'next_step_config'     => array(
 		'flow_step_id'    => 'flow_sys_2',
 		'step_type'       => 'system_task',
-		'handler_slugs'   => array( 'system_task' ),
-		'handler_configs' => array(
-			'system_task' => array( 'task' => 'agent_ping', 'params' => array() ),
-		),
+		'handler_config'  => array( 'task' => 'agent_ping', 'params' => array() ),
 	),
 );
 $tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );
 
-assert_equals( array( 'wordpress_publish', 'system_task' ), $tool_manager->resolveCalls, 'resolver visited both adjacent slugs', $failures, $passes );
+assert_equals( array( 'wordpress_publish' ), $tool_manager->resolveCalls, 'resolver visited only real adjacent handlers', $failures, $passes );
 assert_equals( array( 'wordpress_publish_tool' ), array_keys( $tools ), 'only real handler tool landed in available_tools', $failures, $passes );
 
 // Test 4: Multi-handler publish adjacency — the legitimate multi-element callsite.


### PR DESCRIPTION
## Summary
- Collapse flow-step handler storage to match the step type contract: handler-free steps use `handler_config`, single-handler steps use `handler_slug`/`handler_config`, and publish/upsert keep `handler_slugs`/`handler_configs`.
- Add a version-gated migration to canonicalize persisted flow/pipeline configs and update import/export, tool policy, CLI/API, and React admin consumers to use `FlowStepConfig` helpers.
- Update smoke coverage for canonical handler shapes, migration ordering, scalar migration output, and handler-free adjacency behavior.

## Tests
- `php tests/*smoke.php`
- `for f in $(git show --name-only --format= HEAD -- '*.php'); do [ -n "$f" ] && php -l "$f" >/dev/null || exit 1; done`
- `npm run build`
- `homeboy test data-machine --path "$PWD"`

## Notes
- `homeboy lint data-machine --path "$PWD"` was also checked, but this repo currently reports broad pre-existing PHPStan/test-fixture noise unrelated to this branch, so it is not a useful pass/fail signal here.

Closes #1293.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, migration, smoke coverage, and validation commands under Chris's direction.
