### PR TITLE
refactor(audit): share duplicate helper implementations

### DIFF
--- a/inc/Abilities/File/AgentFileAbilities.php
+++ b/inc/Abilities/File/AgentFileAbilities.php
@@ -313,7 +313,7 @@ class AgentFileAbilities {
 				'editable'    => MemoryFileRegistry::is_editable( $filename ),
 				'modes'       => $registry_meta['modes'] ?? array( MemoryFileRegistry::MODE_ALL ),
 				'registered'  => true,
-				'label'       => $registry_meta['label'] ?? self::filename_to_label( $filename ),
+				'label'       => $registry_meta['label'] ?? MemoryFileRegistry::filename_to_label( $filename ),
 				'description' => $registry_meta['description'] ?? '',
 			);
 			$seen[ $filename ] = true;
@@ -345,7 +345,7 @@ class AgentFileAbilities {
 					'editable'    => MemoryFileRegistry::is_editable( $entry->filename ),
 					'modes'       => $registry_meta['modes'] ?? array( MemoryFileRegistry::MODE_ALL ),
 					'registered'  => null !== $registry_meta,
-					'label'       => $registry_meta['label'] ?? self::filename_to_label( $entry->filename ),
+					'label'       => $registry_meta['label'] ?? MemoryFileRegistry::filename_to_label( $entry->filename ),
 					'description' => $registry_meta['description'] ?? '',
 				);
 				$seen[ $entry->filename ] = true;
@@ -686,14 +686,4 @@ class AgentFileAbilities {
 		return $sanitized;
 	}
 
-	/**
-	 * Derive a human-readable label from a filename.
-	 *
-	 * @param string $filename The filename.
-	 * @return string Label.
-	 */
-	private static function filename_to_label( string $filename ): string {
-		$name = pathinfo( $filename, PATHINFO_FILENAME );
-		return ucwords( str_replace( array( '-', '_' ), ' ', $name ) );
-	}
 }

--- a/inc/Core/OAuth/OAuth1Handler.php
+++ b/inc/Core/OAuth/OAuth1Handler.php
@@ -20,6 +20,8 @@ if ( ! defined( 'WPINC' ) ) {
 
 class OAuth1Handler {
 
+	use OAuthRedirects;
+
 	const TEMP_TOKEN_SECRET_PREFIX = 'datamachine_oauth1_temp_secret_';
 
 	/**
@@ -358,44 +360,4 @@ class OAuth1Handler {
 		delete_transient( $transient_key );
 	}
 
-	/**
-	 * Redirect to admin with error message.
-	 *
-	 * @param string $provider_key Provider identifier.
-	 * @param string $error_code Error code.
-	 * @return void
-	 */
-	private function redirect_with_error( string $provider_key, string $error_code ): void {
-		wp_safe_redirect(
-			add_query_arg(
-				array(
-					'page'       => 'datamachine-settings',
-					'auth_error' => $error_code,
-					'provider'   => $provider_key,
-				),
-				admin_url( 'admin.php' )
-			)
-		);
-		exit;
-	}
-
-	/**
-	 * Redirect to admin with success message.
-	 *
-	 * @param string $provider_key Provider identifier.
-	 * @return void
-	 */
-	private function redirect_with_success( string $provider_key ): void {
-		wp_safe_redirect(
-			add_query_arg(
-				array(
-					'page'         => 'datamachine-settings',
-					'auth_success' => '1',
-					'provider'     => $provider_key,
-				),
-				admin_url( 'admin.php' )
-			)
-		);
-		exit;
-	}
 }

--- a/inc/Core/OAuth/OAuth2Handler.php
+++ b/inc/Core/OAuth/OAuth2Handler.php
@@ -24,6 +24,8 @@ if ( ! defined( 'WPINC' ) ) {
 
 class OAuth2Handler {
 
+	use OAuthRedirects;
+
 	// -------------------------------------------------------------------------
 	// State Management
 	// -------------------------------------------------------------------------
@@ -653,48 +655,4 @@ class OAuth2Handler {
 		return $token_data;
 	}
 
-	// -------------------------------------------------------------------------
-	// Redirects
-	// -------------------------------------------------------------------------
-
-	/**
-	 * Redirect to admin with error message.
-	 *
-	 * @param string $provider_key Provider identifier.
-	 * @param string $error_code Error code.
-	 * @return void
-	 */
-	private function redirect_with_error( string $provider_key, string $error_code ): void {
-		wp_safe_redirect(
-			add_query_arg(
-				array(
-					'page'       => 'datamachine-settings',
-					'auth_error' => $error_code,
-					'provider'   => $provider_key,
-				),
-				admin_url( 'admin.php' )
-			)
-		);
-		exit;
-	}
-
-	/**
-	 * Redirect to admin with success message.
-	 *
-	 * @param string $provider_key Provider identifier.
-	 * @return void
-	 */
-	private function redirect_with_success( string $provider_key ): void {
-		wp_safe_redirect(
-			add_query_arg(
-				array(
-					'page'         => 'datamachine-settings',
-					'auth_success' => '1',
-					'provider'     => $provider_key,
-				),
-				admin_url( 'admin.php' )
-			)
-		);
-		exit;
-	}
 }

--- a/inc/Core/OAuth/OAuthRedirects.php
+++ b/inc/Core/OAuth/OAuthRedirects.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * OAuth redirect helpers.
+ *
+ * Shared by OAuth1 and OAuth2 callback handlers.
+ *
+ * @package DataMachine\Core\OAuth
+ */
+
+namespace DataMachine\Core\OAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+trait OAuthRedirects {
+
+	/**
+	 * Redirect to admin with error message.
+	 *
+	 * @param string $provider_key Provider identifier.
+	 * @param string $error_code Error code.
+	 * @return void
+	 */
+	private function redirect_with_error( string $provider_key, string $error_code ): void {
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'       => 'datamachine-settings',
+					'auth_error' => $error_code,
+					'provider'   => $provider_key,
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Redirect to admin with success message.
+	 *
+	 * @param string $provider_key Provider identifier.
+	 * @return void
+	 */
+	private function redirect_with_success( string $provider_key ): void {
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'         => 'datamachine-settings',
+					'auth_success' => '1',
+					'provider'     => $provider_key,
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+}

--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -21,14 +21,16 @@ use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Core\DataPacket;
 use DataMachine\Core\ExecutionContext;
 use DataMachine\Core\FilesRepository\FileStorage;
-use DataMachine\Core\HttpClient;
 use DataMachine\Core\Steps\Fetch\Tools\SkipItemTool;
+use DataMachine\Core\Steps\Handlers\HttpRequestHelpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 abstract class FetchHandler {
+
+	use HttpRequestHelpers;
 
 	/**
 	 * Handler type identifier (e.g., 'rss', 'reddit', 'files')
@@ -359,59 +361,6 @@ abstract class FetchHandler {
 	protected function getAuthProvider( string $provider_key ): ?object {
 		$auth_abilities = new AuthAbilities();
 		return $auth_abilities->getProvider( $provider_key );
-	}
-
-	/**
-	 * Perform HTTP request with standardized handling
-	 *
-	 * @param string $method  HTTP method (GET, POST, PUT, DELETE, PATCH)
-	 * @param string $url     Request URL
-	 * @param array  $options Request options:
-	 *                        - headers: array - Additional headers to merge
-	 *                        - body: string|array - Request body (for POST/PUT/PATCH)
-	 *                        - timeout: int - Request timeout (default 120)
-	 *                        - browser_mode: bool - Use browser-like headers (default false)
-	 *                        - context: string - Context for logging (defaults to handler_type)
-	 * @return array{success: bool, data?: string, status_code?: int, headers?: array, response?: array, error?: string}
-	 */
-	protected function httpRequest( string $method, string $url, array $options = array() ): array {
-		if ( ! isset( $options['context'] ) ) {
-			$options['context'] = ucfirst( $this->handler_type );
-		}
-		return HttpClient::request( $method, $url, $options );
-	}
-
-	/**
-	 * Perform HTTP GET request
-	 *
-	 * @param string $url     Request URL
-	 * @param array  $options Request options
-	 * @return array Response array
-	 */
-	protected function httpGet( string $url, array $options = array() ): array {
-		return $this->httpRequest( 'GET', $url, $options );
-	}
-
-	/**
-	 * Perform HTTP POST request
-	 *
-	 * @param string $url     Request URL
-	 * @param array  $options Request options
-	 * @return array Response array
-	 */
-	protected function httpPost( string $url, array $options = array() ): array {
-		return $this->httpRequest( 'POST', $url, $options );
-	}
-
-	/**
-	 * Perform HTTP DELETE request
-	 *
-	 * @param string $url     Request URL
-	 * @param array  $options Request options
-	 * @return array Response array
-	 */
-	protected function httpDelete( string $url, array $options = array() ): array {
-		return $this->httpRequest( 'DELETE', $url, $options );
 	}
 
 	/**

--- a/inc/Core/Steps/Handlers/HttpRequestHelpers.php
+++ b/inc/Core/Steps/Handlers/HttpRequestHelpers.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Shared handler HTTP request helpers.
+ *
+ * Fetch and publish handlers both expose the same protected convenience
+ * methods for subclasses. Keeping them in one trait prevents the two base
+ * classes from drifting apart.
+ *
+ * @package DataMachine\Core\Steps\Handlers
+ */
+
+namespace DataMachine\Core\Steps\Handlers;
+
+use DataMachine\Core\HttpClient;
+
+defined( 'ABSPATH' ) || exit;
+
+trait HttpRequestHelpers {
+
+	/**
+	 * Perform HTTP request with standardized handling.
+	 *
+	 * @param string $method  HTTP method (GET, POST, PUT, DELETE, PATCH).
+	 * @param string $url     Request URL.
+	 * @param array  $options Request options.
+	 * @return array{success: bool, data?: string, status_code?: int, headers?: array, response?: array, error?: string}
+	 */
+	protected function httpRequest( string $method, string $url, array $options = array() ): array {
+		if ( ! isset( $options['context'] ) ) {
+			$options['context'] = ucfirst( $this->handler_type );
+		}
+		return HttpClient::request( $method, $url, $options );
+	}
+
+	/**
+	 * Perform HTTP GET request.
+	 *
+	 * @param string $url     Request URL.
+	 * @param array  $options Request options.
+	 * @return array Response array.
+	 */
+	protected function httpGet( string $url, array $options = array() ): array {
+		return $this->httpRequest( 'GET', $url, $options );
+	}
+
+	/**
+	 * Perform HTTP POST request.
+	 *
+	 * @param string $url     Request URL.
+	 * @param array  $options Request options.
+	 * @return array Response array.
+	 */
+	protected function httpPost( string $url, array $options = array() ): array {
+		return $this->httpRequest( 'POST', $url, $options );
+	}
+
+	/**
+	 * Perform HTTP DELETE request.
+	 *
+	 * @param string $url     Request URL.
+	 * @param array  $options Request options.
+	 * @return array Response array.
+	 */
+	protected function httpDelete( string $url, array $options = array() ): array {
+		return $this->httpRequest( 'DELETE', $url, $options );
+	}
+}

--- a/inc/Core/Steps/Publish/Handlers/PublishHandler.php
+++ b/inc/Core/Steps/Publish/Handlers/PublishHandler.php
@@ -16,11 +16,13 @@ namespace DataMachine\Core\Steps\Publish\Handlers;
 
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Core\EngineData;
-use DataMachine\Core\HttpClient;
+use DataMachine\Core\Steps\Handlers\HttpRequestHelpers;
 
 defined( 'ABSPATH' ) || exit;
 
 abstract class PublishHandler {
+
+	use HttpRequestHelpers;
 
 	/** @var string Handler type for logging and responses */
 	protected string $handler_type;
@@ -341,56 +343,4 @@ abstract class PublishHandler {
 		return $auth_abilities->getProvider( $provider_key );
 	}
 
-	/**
-	 * Perform HTTP request with standardized handling
-	 *
-	 * @param string $method  HTTP method (GET, POST, PUT, DELETE, PATCH)
-	 * @param string $url     Request URL
-	 * @param array  $options Request options:
-	 *                        - headers: array - Additional headers to merge
-	 *                        - body: string|array - Request body (for POST/PUT/PATCH)
-	 *                        - timeout: int - Request timeout (default 120)
-	 *                        - browser_mode: bool - Use browser-like headers (default false)
-	 *                        - context: string - Context for logging (defaults to handler_type)
-	 * @return array{success: bool, data?: string, status_code?: int, headers?: array, response?: array, error?: string}
-	 */
-	protected function httpRequest( string $method, string $url, array $options = array() ): array {
-		if ( ! isset( $options['context'] ) ) {
-			$options['context'] = ucfirst( $this->handler_type );
-		}
-		return HttpClient::request( $method, $url, $options );
-	}
-
-	/**
-	 * Perform HTTP GET request
-	 *
-	 * @param string $url     Request URL
-	 * @param array  $options Request options
-	 * @return array Response array
-	 */
-	protected function httpGet( string $url, array $options = array() ): array {
-		return $this->httpRequest( 'GET', $url, $options );
-	}
-
-	/**
-	 * Perform HTTP POST request
-	 *
-	 * @param string $url     Request URL
-	 * @param array  $options Request options
-	 * @return array Response array
-	 */
-	protected function httpPost( string $url, array $options = array() ): array {
-		return $this->httpRequest( 'POST', $url, $options );
-	}
-
-	/**
-	 * Perform HTTP DELETE request
-	 *
-	 * @param string $url     Request URL
-	 * @param array  $options Request options
-	 * @return array Response array
-	 */
-	protected function httpDelete( string $url, array $options = array() ): array {
-		return $this->httpRequest( 'DELETE', $url, $options );
-	}
 }

--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -498,7 +498,7 @@ class MemoryFileRegistry {
 	 * @param string $filename The filename.
 	 * @return string Label.
 	 */
-	private static function filename_to_label( string $filename ): string {
+	public static function filename_to_label( string $filename ): string {
 		$name = pathinfo( $filename, PATHINFO_FILENAME );
 		return ucwords( str_replace( array( '-', '_' ), ' ', $name ) );
 	}

--- a/tests/duplicate-function-cleanup-smoke.php
+++ b/tests/duplicate-function-cleanup-smoke.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Pure-PHP smoke test for duplicate-function cleanup (#674).
+ *
+ * Run with: php tests/duplicate-function-cleanup-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failed = 0;
+$total  = 0;
+
+function assert_duplicate_cleanup( string $name, bool $condition, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] $name\n";
+		return;
+	}
+
+	echo "  [FAIL] $name" . ( $detail ? " - $detail" : '' ) . "\n";
+	++$failed;
+}
+
+function source_file( string $relative_path ): string {
+	$path = dirname( __DIR__ ) . '/' . ltrim( $relative_path, '/' );
+	$contents = file_get_contents( $path );
+	if ( ! is_string( $contents ) ) {
+		throw new RuntimeException( "Unable to read source file: {$relative_path}" );
+	}
+	return $contents;
+}
+
+function finish_duplicate_cleanup_smoke(): void {
+	global $failed, $total;
+
+	if ( $failed > 0 ) {
+		echo "\nFAIL: {$failed}/{$total} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nPASS: {$total} assertions passed.\n";
+}
+
+echo "=== duplicate-function-cleanup-smoke ===\n";
+
+$agent_files     = source_file( 'inc/Abilities/File/AgentFileAbilities.php' );
+$registry        = source_file( 'inc/Engine/AI/MemoryFileRegistry.php' );
+$oauth1          = source_file( 'inc/Core/OAuth/OAuth1Handler.php' );
+$oauth2          = source_file( 'inc/Core/OAuth/OAuth2Handler.php' );
+$oauth_redirects = source_file( 'inc/Core/OAuth/OAuthRedirects.php' );
+$fetch_handler   = source_file( 'inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );
+$publish_handler = source_file( 'inc/Core/Steps/Publish/Handlers/PublishHandler.php' );
+$http_helpers    = source_file( 'inc/Core/Steps/Handlers/HttpRequestHelpers.php' );
+
+assert_duplicate_cleanup(
+	'Agent file abilities delegates filename labels to MemoryFileRegistry',
+	str_contains( $agent_files, 'MemoryFileRegistry::filename_to_label(' )
+);
+assert_duplicate_cleanup(
+	'Agent file abilities no longer defines filename_to_label',
+	! str_contains( $agent_files, 'function filename_to_label' )
+);
+assert_duplicate_cleanup(
+	'MemoryFileRegistry exposes filename_to_label once',
+	substr_count( $registry, 'function filename_to_label' ) === 1 && str_contains( $registry, 'public static function filename_to_label' )
+);
+
+assert_duplicate_cleanup( 'OAuth1 uses shared redirect trait', str_contains( $oauth1, 'use OAuthRedirects;' ) );
+assert_duplicate_cleanup( 'OAuth2 uses shared redirect trait', str_contains( $oauth2, 'use OAuthRedirects;' ) );
+assert_duplicate_cleanup(
+	'OAuth handlers do not define redirect helpers locally',
+	! str_contains( $oauth1, 'function redirect_with_error' )
+		&& ! str_contains( $oauth1, 'function redirect_with_success' )
+		&& ! str_contains( $oauth2, 'function redirect_with_error' )
+		&& ! str_contains( $oauth2, 'function redirect_with_success' )
+);
+assert_duplicate_cleanup( 'OAuthRedirects trait owns error redirect', substr_count( $oauth_redirects, 'function redirect_with_error' ) === 1 );
+assert_duplicate_cleanup( 'OAuthRedirects trait owns success redirect', substr_count( $oauth_redirects, 'function redirect_with_success' ) === 1 );
+
+assert_duplicate_cleanup( 'FetchHandler uses shared HTTP helper trait', str_contains( $fetch_handler, 'use HttpRequestHelpers;' ) );
+assert_duplicate_cleanup( 'PublishHandler uses shared HTTP helper trait', str_contains( $publish_handler, 'use HttpRequestHelpers;' ) );
+foreach ( array( 'httpRequest', 'httpPost', 'httpDelete' ) as $method ) {
+	assert_duplicate_cleanup(
+		"Fetch/Publish handlers do not define {$method} locally",
+		! str_contains( $fetch_handler, "function {$method}" )
+			&& ! str_contains( $publish_handler, "function {$method}" )
+	);
+}
+assert_duplicate_cleanup( 'HTTP helper trait owns httpRequest once', substr_count( $http_helpers, 'function httpRequest' ) === 1 );
+assert_duplicate_cleanup( 'HTTP helper trait owns httpPost once', substr_count( $http_helpers, 'function httpPost' ) === 1 );
+assert_duplicate_cleanup( 'HTTP helper trait owns httpDelete once', substr_count( $http_helpers, 'function httpDelete' ) === 1 );
+
+finish_duplicate_cleanup_smoke();

--- a/tests/exclude-keywords-smoke.php
+++ b/tests/exclude-keywords-smoke.php
@@ -21,6 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+require_once __DIR__ . '/smoke-wp-stubs.php';
+
 // Stub the WordPress functions FetchRssAbility's class definition references
 // before we autoload it. Only stub if not already provided so tests stay
 // composable with other smoke tests.
@@ -29,27 +31,6 @@ if ( ! function_exists( '__' ) ) {
 		return $text;
 	}
 }
-if ( ! function_exists( 'doing_action' ) ) {
-	function doing_action( $action = '' ) {
-		return false;
-	}
-}
-if ( ! function_exists( 'did_action' ) ) {
-	function did_action( $action = '' ) {
-		return 1; // Pretend wp_abilities_api_init already fired so registration is skipped.
-	}
-}
-if ( ! function_exists( 'add_action' ) ) {
-	function add_action( ...$args ) {
-		// no-op
-	}
-}
-if ( ! function_exists( 'wp_register_ability' ) ) {
-	function wp_register_ability( ...$args ) {
-		// no-op
-	}
-}
-
 require_once __DIR__ . '/../inc/Abilities/PermissionHelper.php';
 require_once __DIR__ . '/../inc/Abilities/Fetch/FetchRssAbility.php';
 

--- a/tests/logger-agent-id-resolution-smoke.php
+++ b/tests/logger-agent-id-resolution-smoke.php
@@ -53,7 +53,7 @@ class PermissionHelper {
 	}
 
 	public static function in_agent_context(): bool {
-		return null !== self::$acting_agent_id;
+		return null !== self::get_acting_agent_id();
 	}
 
 	public static function get_acting_agent_id(): ?int {

--- a/tests/meta-description-post-types-filter-smoke.php
+++ b/tests/meta-description-post-types-filter-smoke.php
@@ -21,6 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+require_once __DIR__ . '/smoke-wp-stubs.php';
+
 // Tiny filter registry — enough for getEligiblePostTypes().
 $GLOBALS['_dm_test_filters'] = array();
 
@@ -67,30 +69,6 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	function sanitize_key( $key ) {
 		$key = strtolower( (string) $key );
 		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
-	}
-}
-
-if ( ! function_exists( 'doing_action' ) ) {
-	function doing_action( $action = '' ) {
-		return false;
-	}
-}
-
-if ( ! function_exists( 'did_action' ) ) {
-	function did_action( $action = '' ) {
-		return 1; // pretend wp_abilities_api_init already fired
-	}
-}
-
-if ( ! function_exists( 'add_action' ) ) {
-	function add_action( ...$args ) {
-		// no-op
-	}
-}
-
-if ( ! function_exists( 'wp_register_ability' ) ) {
-	function wp_register_ability( ...$args ) {
-		// no-op
 	}
 }
 

--- a/tests/queue-mode-callsites-smoke.php
+++ b/tests/queue-mode-callsites-smoke.php
@@ -48,6 +48,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+require_once __DIR__ . '/smoke-wp-stubs.php';
+
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( ...$args ): void {
 		// no-op for tests.
@@ -61,11 +63,6 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 if ( ! function_exists( 'sanitize_textarea_field' ) ) {
 	function sanitize_textarea_field( $value ) {
 		return trim( (string) $value );
-	}
-}
-if ( ! function_exists( 'wp_unslash' ) ) {
-	function wp_unslash( $value ) {
-		return is_string( $value ) ? stripslashes( $value ) : $value;
 	}
 }
 if ( ! function_exists( 'mb_substr' ) && ! function_exists( 'datamachine_test_mb_polyfill' ) ) {

--- a/tests/queue-mode-collapse-smoke.php
+++ b/tests/queue-mode-collapse-smoke.php
@@ -25,6 +25,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+require_once __DIR__ . '/smoke-wp-stubs.php';
+
 if ( ! function_exists( 'gmdate' ) ) {
 	// Defensive — gmdate is a PHP built-in but we need to be sure.
 }
@@ -46,12 +48,6 @@ if ( ! function_exists( 'sanitize_textarea_field' ) ) {
 		return trim( (string) $value );
 	}
 }
-if ( ! function_exists( 'wp_unslash' ) ) {
-	function wp_unslash( $value ) {
-		return is_string( $value ) ? stripslashes( $value ) : $value;
-	}
-}
-
 $failed = 0;
 $total  = 0;
 

--- a/tests/smoke-wp-stubs.php
+++ b/tests/smoke-wp-stubs.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Shared WordPress function stubs for pure-PHP smoke tests.
+ *
+ * Include this file from tests that need tiny WP API stand-ins but do not
+ * bootstrap WordPress.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $action = '' ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $action = '' ) {
+		return 1; // Pretend wp_abilities_api_init already fired.
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		// no-op
+	}
+}
+
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( ...$args ) {
+		// no-op
+	}
+}
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+	function wp_unslash( $value ) {
+		return is_string( $value ) ? stripslashes( $value ) : $value;
+	}
+}


### PR DESCRIPTION
## Summary
- Collapse duplicate filename label derivation onto `MemoryFileRegistry::filename_to_label()`.
- Extract shared OAuth redirect helpers and fetch/publish HTTP request helpers into reusable traits.
- Move repeated pure-PHP smoke-test WordPress stubs into a shared test stub file.

Closes #674.

## Tests
- `php tests/duplicate-function-cleanup-smoke.php`
- `php tests/exclude-keywords-smoke.php`
- `php tests/meta-description-post-types-filter-smoke.php`
- `php tests/queue-mode-callsites-smoke.php`
- `php tests/queue-mode-collapse-smoke.php`
- `php tests/logger-agent-id-resolution-smoke.php`
- `php -l` on all changed PHP files
- `git diff --check`
- `homeboy test data-machine --path . --skip-lint`

## Notes
- `homeboy lint data-machine --path . --changed-only --errors-only` still reports the existing repository PHPStan baseline noise. The new duplicate cleanup smoke file was adjusted so it does not add its own PHPStan findings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafting the helper extraction, smoke coverage, and validation workflow.
