### PR TITLE
docs: refresh stale Data Machine references

### DIFF
--- a/docs/api/endpoints/flows.md
+++ b/docs/api/endpoints/flows.md
@@ -525,30 +525,26 @@ Remove a specific queue item.
 - `flow_id` (integer, required): Flow ID
 - `index` (integer, required): Queue position
 
-### GET /flows/{flow_id}/queue/settings
+### PUT /flows/{flow_id}/queue/mode
 
-Get queue settings for a flow.
-
-**Permission**: `manage_options` capability required
-
-**Response**:
-```json
-{
-  "success": true,
-  "settings": {
-    "enabled": true,
-    "mode": "sequential"
-  }
-}
-```
-
-### PUT /flows/{flow_id}/queue/settings
-
-Update queue settings for a flow.
+Set the queue access mode for a flow step.
 
 **Permission**: `manage_options` capability required
 
 **Parameters**:
 - `flow_id` (integer, required): Flow ID
-- `enabled` (boolean, optional): Enable/disable queue
-- `mode` (string, optional): "sequential" or "random"
+- `flow_step_id` (string, required): Flow step ID
+- `mode` (string, required): One of `drain`, `loop`, or `static`
+
+**Response**:
+```json
+{
+  "success": true,
+  "data": {
+    "flow_id": 10,
+    "flow_step_id": "ai_2",
+    "queue_mode": "static"
+  },
+  "message": "Queue mode updated."
+}
+```

--- a/docs/architecture/pipeline-execution-axes.md
+++ b/docs/architecture/pipeline-execution-axes.md
@@ -15,19 +15,20 @@ Axes 1–3 expand fetch-side work. Axis 4 governs the AI step's completion bound
 
 ### 1. Queueable fetch — cross-tick scheduling
 
-`inc/Core/Steps/Fetch/FetchStep.php`, gated by the `queue_enabled` flag on `flow_step_config` and consuming via `inc/Core/Steps/QueueableTrait.php::popQueuedConfigPatch()`.
+`inc/Core/Steps/Fetch/FetchStep.php`, gated by the `queue_mode` enum on `flow_step_config` and consuming via `inc/Core/Steps/QueueableTrait.php::consumeFromConfigPatchQueue()`.
 
 Every tick of the flow:
 
-- If `queue_enabled` is false: use the static handler config as written. Standard fetch.
-- If `queue_enabled` is true: pop **one** JSON-encoded patch from the per-flow-step prompt queue. Deep-merge it into the static handler config via `QueueableTrait::mergeQueuedConfigPatch()`. Run the handler with the merged config.
-- If `queue_enabled` is true and the queue is empty: the fetch step is a no-op. The job completes with `JobStatus::COMPLETED_NO_ITEMS`. No fetch is attempted.
+- If `queue_mode` is `static`: peek the first config patch without mutating the queue. If the config-patch queue is empty, use the static handler config as written.
+- If `queue_mode` is `drain`: pop **one** decoded config patch from `config_patch_queue`, deep-merge it into the static handler config, and discard it after the tick.
+- If `queue_mode` is `loop`: pop **one** decoded config patch from `config_patch_queue`, deep-merge it into the static handler config, then append that patch to the tail so the queue rotates indefinitely.
+- If `queue_mode` is `drain` or `loop` and the queue is empty: the fetch step is a no-op. The job completes with `JobStatus::COMPLETED_NO_ITEMS`. No fetch is attempted.
 
 A "1" case is one queued patch consumed per tick. The "many" case is a queue of N patches drained over N ticks. The axis is **time** — different tick, different config.
 
-Typical use: windowed retroactive backfills (each patch is a date window like `{"after": "2015-05-01", "before": "2015-06-01"}`) and rotating-source forward-ingestion. The queue lets a single recurring flow chew through a backfill plan without an external orchestrator and goes idempotent — clean no-op ticks — once the queue drains.
+Typical use: windowed retroactive backfills (each patch is a date window like `{"after": "2015-05-01", "before": "2015-06-01"}`) and rotating-source forward-ingestion. Drain mode lets a single recurring flow chew through a backfill plan without an external orchestrator and goes idempotent — clean no-op ticks — once the queue drains. Loop mode cycles patches forever for rotating-source ingestion.
 
-The popped item is backed up to the parent job's engine data (`queued_prompt_backup`) so a failed tick can be retried without losing the input.
+The consumed item is backed up to the parent job's engine data so a failed tick can be retried without losing the input.
 
 ### 2. `max_items` — per-call source cap
 
@@ -75,7 +76,7 @@ Non-handler tool calls (search, fetch, generic abilities) don't move the complet
 
 | Axis | Lives in | Trigger | "1" case | "many" case | Layer |
 |------|----------|---------|----------|-------------|-------|
-| **1. Queueable fetch** | `Core/Steps/Fetch/FetchStep.php` + `Core/Steps/QueueableTrait.php::popQueuedConfigPatch` | `flow_step_config['queue_enabled']` + a non-empty per-flow-step queue | Static handler config; or one queued patch popped per tick | Many ticks, each popping the next patch | Across ticks |
+| **1. Queueable fetch** | `Core/Steps/Fetch/FetchStep.php` + `Core/Steps/QueueableTrait.php::consumeFromConfigPatchQueue` | `flow_step_config['queue_mode']` + `config_patch_queue` | Static handler config; or one queued patch consumed per tick | Many ticks draining or looping queued patches | Across ticks |
 | **2. `max_items`** | `Core/Steps/Fetch/Handlers/FetchHandler.php::get_fetch_data` | `handler_config['max_items']`, applied after dedup | One DataPacket per fetch call | N DataPackets per fetch call | Inside one fetch call |
 | **3. Batch fan-out** | `Abilities/Engine/PipelineBatchScheduler.php::fanOut` + `Core/ActionScheduler/BatchScheduler.php` (called from `ExecuteStepAbility`) | Any step returning > 1 DataPacket after filtering | Inline continuation on the same job | N child jobs, scheduled in chunks of `chunk_size` every `chunk_delay` seconds (defaults: 10 / 30) | Across child jobs in one run |
 | **4. Multi-handler completion** | `Engine/AI/AIConversationLoop.php` (~line 359) | `flow_step_config['handler_slugs']` length on a pipeline-mode AI step | Loop completes after first successful handler tool | Loop runs until every configured handler has fired | Across turns of one conversation |
@@ -90,9 +91,10 @@ flow ticks (e.g. cron) ──┐
               ┌──────────────────────┐
               │  Fetch step          │
               │                      │
-              │  (1) queue_enabled?  │ ──► no  → use static config
-              │                      │ ──► yes → pop one patch, deep-merge
-              │                      │       (empty queue → COMPLETED_NO_ITEMS)
+              │  (1) queue_mode      │ ──► static → peek patch or use static config
+              │                      │ ──► drain  → pop one patch, deep-merge
+              │                      │ ──► loop   → pop one patch, requeue at tail
+              │                      │       (empty drain/loop → COMPLETED_NO_ITEMS)
               │                      │
               │  Handler runs        │
               │  → returns N raw     │
@@ -128,7 +130,7 @@ flow ticks (e.g. cron) ──┐
 
 ### Many ticks chewing through a queue
 
-A backfill flow with `queue_enabled = true`, a queue seeded with twelve monthly date windows, and a fetch handler configured to return up to `max_items = 50` items per call:
+A backfill flow with `queue_mode = drain`, a `config_patch_queue` seeded with twelve monthly date windows, and a fetch handler configured to return up to `max_items = 50` items per call:
 
 ```
 tick 0   pop {after:"2015-01-01", before:"2015-02-01"}
@@ -174,16 +176,17 @@ Note: `chunk_size` is the **producer-side** knob (how DM creates child jobs). Th
 
 ### Queueable fetch vs. queueable AI — same primitive, two consumption shapes
 
-Both share `QueueableTrait` and the same `popOnceFromFlowQueue()` pop / backup mechanics. They differ only in how the popped string is interpreted.
+Both share `QueueableTrait` and the same queue-mode mechanics. They differ in which storage slot they consume and how that slot's payload is interpreted.
 
-| | Queueable AI (`popFromQueueIfEmpty`) | Queueable fetch (`popQueuedConfigPatch`) |
+| | Queueable AI (`consumeFromPromptQueue`) | Queueable fetch (`consumeFromConfigPatchQueue`) |
 |---|---|---|
-| Used by | AI step's `user_message` | Fetch step's handler config |
-| Popped value treated as | Scalar prompt string, returned verbatim | JSON object, decoded into a config patch |
-| What the consumer does with it | Sets it as the AI step's user message | Deep-merges it into the static handler config (with JSON-encoded sub-fields handled transparently — see `mergeQueuedConfigPatch`) |
-| Empty-queue behaviour | Returns empty value with `from_queue = false` — caller decides | `FetchStep` treats it as a clean no-op tick (`COMPLETED_NO_ITEMS`) |
+| Used by | AI step's per-flow user message | Fetch step's handler config |
+| Storage slot | `prompt_queue` | `config_patch_queue` |
+| Queued value treated as | Scalar prompt string, returned verbatim | Decoded config patch object |
+| What the consumer does with it | Appends it as the AI step's user-role message | Deep-merges it into the static handler config |
+| Empty-queue behaviour | `drain` / `loop` skip with `COMPLETED_NO_ITEMS`; `static` falls back to no per-flow user message | `drain` / `loop` skip with `COMPLETED_NO_ITEMS`; `static` falls back to the static handler config |
 
-The persistence layer (`QueueAbility`), the per-flow-step FIFO ordering, the `queue_enabled` toggle, and the retry-on-failure backup into engine data are identical. The difference is "config dict" vs "scalar string" and what happens when the queue runs dry. This is intentional shared infrastructure, not duplicated machinery.
+The persistence layer (`QueueAbility`), the per-flow-step FIFO ordering, the `queue_mode` enum, and the retry-on-failure backup into engine data are shared. The payload slots stay separate so AI prompts and fetch config patches cannot be mixed accidentally.
 
 ## What to reach for when
 

--- a/docs/core-system/abilities-api.md
+++ b/docs/core-system/abilities-api.md
@@ -6,7 +6,7 @@ WordPress 6.9 Abilities API provides standardized capability discovery and execu
 
 The Abilities API in `inc/Abilities/` provides a unified interface for Data Machine operations. Each ability implements `execute_callback` with `permission_callback` for consistent access control across REST API, CLI commands, and Chat tools.
 
-**Total registered abilities**: 167
+**Total registered abilities**: 193
 
 ## Multi-Agent Scoping
 
@@ -23,8 +23,8 @@ All abilities support `agent_id` and `user_id` parameters for multi-agent scopin
 | `datamachine/update-pipeline` | Update pipeline properties | `Pipeline/UpdatePipelineAbility.php` |
 | `datamachine/delete-pipeline` | Delete pipeline and associated flows | `Pipeline/DeletePipelineAbility.php` |
 | `datamachine/duplicate-pipeline` | Duplicate pipeline with flows | `Pipeline/DuplicatePipelineAbility.php` |
-| `datamachine/import-pipelines` | Import pipelines from JSON | `Pipeline/ImportExportAbility.php` |
-| `datamachine/export-pipelines` | Export pipelines to JSON | `Pipeline/ImportExportAbility.php` |
+| `datamachine/import-pipelines` | Import pipelines from CSV | `Pipeline/ImportExportAbility.php` |
+| `datamachine/export-pipelines` | Export pipelines to CSV | `Pipeline/ImportExportAbility.php` |
 
 ### Pipeline Steps (5 abilities)
 
@@ -55,7 +55,7 @@ All abilities support `agent_id` and `user_id` parameters for multi-agent scopin
 | `datamachine/configure-flow-steps` | Bulk configure flow steps | `FlowStep/ConfigureFlowStepsAbility.php` |
 | `datamachine/validate-flow-steps-config` | Validate flow steps configuration | `FlowStep/ValidateFlowStepsConfigAbility.php` |
 
-### Queue Management (7 abilities)
+### Queue Management (13 abilities)
 
 | Ability | Description | Location |
 |---------|-------------|----------|
@@ -65,7 +65,13 @@ All abilities support `agent_id` and `user_id` parameters for multi-agent scopin
 | `datamachine/queue-remove` | Remove item from queue | `Flow/QueueAbility.php` |
 | `datamachine/queue-update` | Update queue item | `Flow/QueueAbility.php` |
 | `datamachine/queue-move` | Reorder queue item | `Flow/QueueAbility.php` |
-| `datamachine/queue-settings` | Get/set queue settings | `Flow/QueueAbility.php` |
+| `datamachine/queue-mode` | Set queue access mode (`drain`, `loop`, or `static`) | `Flow/QueueAbility.php` |
+| `datamachine/config-patch-add` | Add a fetch config patch to a flow step queue | `Flow/QueueAbility.php` |
+| `datamachine/config-patch-list` | List fetch config patches | `Flow/QueueAbility.php` |
+| `datamachine/config-patch-clear` | Clear fetch config patches | `Flow/QueueAbility.php` |
+| `datamachine/config-patch-remove` | Remove a fetch config patch by index | `Flow/QueueAbility.php` |
+| `datamachine/config-patch-update` | Update a fetch config patch by index | `Flow/QueueAbility.php` |
+| `datamachine/config-patch-move` | Reorder a fetch config patch | `Flow/QueueAbility.php` |
 
 ### Webhook Triggers (8 abilities)
 
@@ -419,23 +425,21 @@ PermissionHelper::resolve_scoped_user_id($params);
 
 ### Delegation Pattern
 
-REST API endpoints, CLI commands, and Chat tools delegate to abilities for business logic. Abilities are the canonical, public-facing primitive; service classes are considered an internal implementation detail and are being phased out as abilities become fully self-contained.
+REST API endpoints, CLI commands, and Chat tools delegate to abilities for business logic. Abilities are the canonical, public-facing primitive; implementation classes below an ability are internal details.
 
 ```
-REST API Endpoint → Ability → (Service layer used during migration) → Database
-CLI Command → Ability → (Service layer used during migration) → Database
-Chat Tool → Ability → (Service layer used during migration) → Database
+REST API Endpoint → Ability → Database / WordPress API
+CLI Command → Ability → Database / WordPress API
+Chat Tool → Ability → Database / WordPress API
 ```
-
-Note: many ability implementations are already self-contained and do not call service managers. Where services remain, they are transitional and will be migrated into abilities per the migration plan.
 
 ### Facade Pattern
 
-Several top-level ability classes serve as facades that instantiate sub-ability classes from subdirectories:
+Several top-level ability classes serve as facades that instantiate sub-ability classes from subdirectories; other domains are registered directly from their subdirectory classes:
 
 - `ChatAbilities.php` → `Chat/CreateChatSessionAbility.php`, etc.
 - `EngineAbilities.php` → `Engine/RunFlowAbility.php`, etc.
-- `FlowAbilities.php` → `Flow/QueueAbility.php`, `Flow/WebhookTriggerAbility.php`, etc.
+- Flow abilities are registered from `Flow/CreateFlowAbility.php`, `Flow/QueueAbility.php`, `Flow/WebhookTriggerAbility.php`, etc.
 
 ### Ability Registration
 

--- a/docs/core-system/import-export.md
+++ b/docs/core-system/import-export.md
@@ -87,4 +87,4 @@ Store pipeline configurations in external version control systems for change tra
 - **CSV Format**: Standard CSV with proper escaping for complex JSON configurations
 - **Execution Ordering**: Pipeline steps are sorted by `execution_order` during export
 - **Flow Isolation**: Each flow's handler configurations are preserved independently
-- **Database Integration**: Direct integration with PipelineManager and PipelineStepManager services
+- **Database Integration**: Import/export is implemented by `DataMachine\Engine\Actions\ImportExport` and surfaced through `Pipeline/ImportExportAbility.php`; REST, CLI, and ability callers all route through that same action layer.

--- a/docs/core-system/services-layer.md
+++ b/docs/core-system/services-layer.md
@@ -10,11 +10,11 @@ The migration from OOP service managers to WordPress Abilities API is **complete
 
 | Former Service | Replacement | Location |
 |----------------|-------------|----------|
-| `FlowManager` | `FlowAbilities` | `inc/Abilities/FlowAbilities.php` |
-| `PipelineManager` | `PipelineAbilities` | `inc/Abilities/PipelineAbilities.php` |
+| `FlowManager` | Flow ability classes | `inc/Abilities/Flow/` |
+| `PipelineManager` | Pipeline ability classes | `inc/Abilities/Pipeline/` and `inc/Abilities/PipelineAbilities.php` |
 | `PipelineStepManager` | `PipelineStepAbilities` | `inc/Abilities/PipelineStepAbilities.php` |
-| `FlowStepManager` | `FlowStepAbilities` | `inc/Abilities/FlowStepAbilities.php` |
-| `JobManager` | `JobAbilities` | `inc/Abilities/JobAbilities.php` |
+| `FlowStepManager` | Flow step ability classes | `inc/Abilities/FlowStep/` and `inc/Abilities/FlowStepAbilities.php` |
+| `JobManager` | Job ability classes | `inc/Abilities/Job/` and `inc/Abilities/JobAbilities.php` |
 | `ProcessedItemsManager` | `ProcessedItemsAbilities` | `inc/Abilities/ProcessedItemsAbilities.php` |
 | `HandlerService` | `HandlerAbilities` | `inc/Abilities/HandlerAbilities.php` |
 | `StepTypeService` | `StepTypeAbilities` | `inc/Abilities/StepTypeAbilities.php` |
@@ -24,28 +24,14 @@ The migration from OOP service managers to WordPress Abilities API is **complete
 
 ## Abilities Overview
 
-22 ability classes provide 79 registered abilities covering all Data Machine operations:
+Ability classes under `inc/Abilities/` register the operations Data Machine exposes to REST, WP-CLI, and chat tools. The current registry includes 193 `wp_register_ability()` callsites across domains including:
 
-- **PipelineAbilities** - 7 abilities for pipeline CRUD, import/export
-- **PipelineStepAbilities** - 5 abilities for pipeline step management
-- **FlowAbilities** - 5 abilities for flow CRUD and duplication
-- **FlowStepAbilities** - 4 abilities for flow step configuration and validation
-- **JobAbilities** - 6 abilities for workflow execution, job management, health monitoring, summary
-- **RecoverStuckJobsAbility** - 1 ability for stuck job recovery
-- **FileAbilities** - 5 abilities for file management and uploads
-- **ProcessedItemsAbilities** - 6 abilities for deduplication tracking and time-windowed revisit reads
-- **SettingsAbilities** - 7 abilities for plugin and handler settings
-- **AuthAbilities** - 3 abilities for OAuth authentication management
-- **LogAbilities** - 6 abilities for logging operations
-- **HandlerAbilities** - 5 abilities for handler discovery and configuration
-- **StepTypeAbilities** - 2 abilities for step type discovery and validation
-- **PostQueryAbilities** - 1 ability for querying Data Machine-created posts
-- **LocalSearchAbilities** - 1 ability for WordPress site search
-- **SystemAbilities** - 2 abilities for session titles and health checks
-- **TaxonomyAbilities** - 5 abilities for taxonomy term CRUD and resolution
-- **QueueAbility** - 8 abilities for flow queue management
-- **AltTextAbilities** - 2 abilities for media alt text generation and diagnostics
-- **SendPingAbility** - 1 ability for agent ping notifications
+- Pipeline and pipeline-step CRUD, duplication, import, and export
+- Flow CRUD, scheduling, duplication, pause/resume, webhook triggers, and per-step configuration
+- Prompt queues, fetch config-patch queues, and queue mode management
+- Job execution, retry/fail/delete/recovery, flow health, and summaries
+- Agent identity, access, tokens, remote calls, memory, and ping notifications
+- File, scaffold, chat, email, media, SEO, taxonomy, settings, auth, logs, and analytics operations
 
 ## Architecture Principles
 

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -59,7 +59,7 @@ wp datamachine flows run 10 --count=5 --timestamp="2026-01-01 00:00:00"
 # Update flow properties
 wp datamachine flows update 10 --name="New Name"
 wp datamachine flows update 10 --scheduling=daily
-wp datamachine flows update 10 --set-prompt --step=ai_2
+wp datamachine flows update 10 --set-user-message="Summarize this week's source data" --step=ai_2
 wp datamachine flows update 10 --handler-config='{"key":"val"}' --step=fetch_1
 
 # Delete a flow
@@ -84,8 +84,15 @@ Manage flow queues. **Since**: 0.31.0
 # Add a prompt to the queue
 wp datamachine flows queue add 10 "Write about AI agents"
 
+# Add a fetch config patch to the queue
+wp datamachine flows queue add 10 --patch='{"params":{"after":"2026-01-01"}}' --step=fetch_1
+
 # List queue contents
 wp datamachine flows queue list 10
+
+# Set queue access mode: drain, loop, or static
+wp datamachine flows queue mode 10 drain --step=ai_2
+wp datamachine flows queue mode 10 loop --step=fetch_1
 
 # Update a queue item
 wp datamachine flows queue update 10 0 "Updated prompt"


### PR DESCRIPTION
## Summary
- Updates stale queue documentation from queue_enabled / queue-settings to queue_mode plus prompt/config-patch queues.
- Refreshes WP-CLI, REST, abilities, service-layer, and import/export docs to match current code paths.

## Tests
- git diff --check
- Verified documented ability registration count matches source: 193
- Grepped docs for stale queue terms; remaining set-prompt matches are historical CHANGELOG entries only
- homeboy audit data-machine --path /Users/chubes/Developer/data-machine@docs-audit-staleness attempted, but timed out after 10 minutes

## AI assistance
- AI assistance: Yes
- Tool(s): OpenCode (GPT-5.5)
- Used for: Auditing documentation against current source, drafting the docs patch, and running validation. Chris remains responsible for review and merge.