### PR TITLE
docs: update stale architecture references

### DIFF
--- a/docs/admin-interface/pipeline-builder.md
+++ b/docs/admin-interface/pipeline-builder.md
@@ -143,45 +143,19 @@ For the authoritative list of endpoints used by the UI, refer to `inc/Core/Admin
 - Centralized state management
 - Consistent error handling patterns
 
-## Advanced Architecture Patterns (@since v0.2.5)
+## Advanced Architecture Patterns
 
-### Model-View Pattern
+### Handler API Helpers
 
-The Pipelines interface implements a model-view separation pattern for handler state management:
+Handler-related server state is fetched through TanStack Query hooks under `inc/Core/Admin/Pages/Pipelines/assets/react/queries/` and shared utility helpers under `inc/Core/Admin/Pages/Pipelines/assets/react/utils/`:
 
-**HandlerProvider** (`inc/Core/Admin/Pages/Pipelines/assets/react/context/HandlerProvider.jsx`):
-- React context providing handler state across components
-- Centralizes handler selection and configuration state
-- Reduces prop drilling for handler-related data
-
-**HandlerModel** (`inc/Core/Admin/Pages/Pipelines/assets/react/models/HandlerModel.js`):
-- Abstract model layer for handler data operations
-- Provides consistent interface for handler state management
-- Separates business logic from UI components
-
-**HandlerFactory** (`inc/Core/Admin/Pages/Pipelines/assets/react/models/HandlerFactory.js`):
-- Factory pattern for handler model instantiation
-- Creates appropriate handler models based on handler type
-- Centralizes handler model creation logic
-
-**Individual Handler Models** (`inc/Core/Admin/Pages/Pipelines/assets/react/models/handlers/`):
-- Type-specific handler models (e.g., TwitterHandlerModel, GoogleSheetsHandlerModel)
-- Encapsulate handler-specific behavior and validation
-- Provide handler-specific methods and computed properties
-
-### Service Layer Architecture
-
-**handlerService** (`inc/Core/Admin/Pages/Pipelines/assets/react/services/handlerService.js`):
-- Service abstraction for handler-related API operations
-- Separates API communication from component logic
-- Provides reusable handler operation methods
-- Centralizes error handling for handler operations
+- `queries/handlers.js` - handler metadata queries
+- `utils/handlerSettings.js` - field normalization and settings helpers
 
 **Benefits**:
-- Clear separation between API calls and UI logic
-- Testable service layer independent of components
-- Consistent error handling patterns
-- Easy to mock for testing
+- Clear separation between API calls, query state, and UI components
+- Consistent cache invalidation through TanStack Query
+- Reusable field-normalization helpers independent of modal rendering
 
 ### Modal Management System
 
@@ -212,40 +186,18 @@ The Pipelines interface implements a model-view separation pattern for handler s
 
 ```
 assets/react/
-├── context/              # React context providers
-│   └── HandlerProvider.jsx
-├── models/               # Handler models & factory
-│   ├── HandlerModel.js
-│   ├── HandlerFactory.js
-│   └── handlers/         # Type-specific models
-├── services/             # API service layer
-│   └── handlerService.js
-├── hooks/                # Custom React hooks
-│   ├── useHandlerModel.js
-│   └── useFormState.js
-├── queries/              # TanStack Query definitions
-│   ├── flows.js
-│   └── handlers.js
-├── stores/               # Zustand stores
-│   └── modalStore.js
-└── components/           # React components
-    ├── modals/
-    ├── flows/
-    ├── pipelines/
-    └── shared/
+├── components/           # UI components and modals
+├── queries/              # TanStack Query hooks
+├── stores/               # Zustand UI state
+└── utils/                # API and field helpers
 ```
 
 ### Pattern Benefits
 
-**Model-View Separation**:
-- Business logic isolated from UI rendering
-- Easier testing of handler operations
-- Reusable handler logic across components
-
-**Service Layer**:
-- API calls abstracted from components
-- Consistent error handling patterns
-- Easy to switch API implementations
+**Query/UI Separation**:
+- Server state isolated in query hooks
+- UI state isolated in the Zustand store
+- Field normalization isolated in utility helpers
 
 **Centralized Modal Management**:
 - Single modal rendering location
@@ -260,7 +212,5 @@ assets/react/
 **Implemented Features:**
 React architecture provides modern features including:
 - Drag-and-drop step reordering (implemented)
-- Real-time collaboration (possible)
 - Advanced validation UI (easy to implement)
-- Undo/redo functionality (state-based)
 - Keyboard shortcuts (event-based)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,24 +189,19 @@ $image_url = $engine_data['image_url'] ?? null;
 - **Filter Consistency**: Maintains architectural pattern of filter-based service discovery
 - **Flexible Storage**: Steps access only what they need via filter call
 
-### Services Layer Architecture (@since v0.4.0)
-**Performance Revolution**: Complete replacement of filter-based action system with OOP service managers for 3x performance improvement through direct method calls. Most services have been migrated to the WordPress 6.9 Abilities API.
+### Abilities-First Architecture (@since v0.11.7)
+**Performance Revolution**: Complete replacement of the older filter-based action and service-manager layers with direct ability classes. REST endpoints, WP-CLI commands, and chat tools all delegate to WordPress Abilities API registrations under `inc/Abilities/`.
 
-**Remaining Services** (utilities for cross-cutting concerns):
-- **JobManager** - Job execution monitoring and management
-- **LogsManager** - Centralized log access and filtering
-- **Cache Invalidation** - Ability-level `clearCache()` methods for handlers, step types, tools, and settings
+**Ability domains** (business logic):
+- **Flow abilities** - Flow CRUD, duplication, pause/resume, scheduling, webhooks, and queue management
+- **Pipeline abilities** - Pipeline CRUD, import/export, and pipeline-step template management
+- **Flow step abilities** - Individual flow step configuration and handler management
+- **Job abilities** - Workflow execution, retry/fail/delete/recovery, flow health, and summaries
+- **Processed item abilities** - Deduplication tracking across workflows
+- **Agent abilities** - Agent CRUD, access grants, tokens, remote calls, memory, and daily memory
+- **File abilities** - Agent files, flow uploads, cleanup, and memory scaffolding
 
-**Abilities API** (business logic):
-- **FlowAbilities** - Flow CRUD operations, duplication
-- **PipelineAbilities** - Pipeline CRUD operations with complete/simple creation modes
-- **FlowStepAbilities** - Individual flow step configuration and handler management
-- **PipelineStepAbilities** - Pipeline step template management
-- **ProcessedItemsAbilities** - Deduplication tracking across workflows
-- **AgentAbilities** - Agent CRUD, rename (with filesystem migration), deletion
-- **AgentMemoryAbilities** - Section-based memory read, write, append, search
-- **DailyMemoryAbilities** - Daily memory file CRUD and search
-- **WorkspaceAbilities** - Git-aware workspace file operations
+**Coding workspace note**: Git-aware workspace and GitHub coding operations moved to the `data-machine-code` extension plugin. Data Machine core no longer registers `WorkspaceAbilities` or GitHub issue abilities.
 
 **Benefits**:
 - **3x Performance Improvement**: Direct method calls eliminate filter indirection
@@ -216,10 +211,10 @@ $image_url = $engine_data['image_url'] ?? null;
 - **Backward Compatibility**: Maintains WordPress hook integration
 
 ### Step Types
-- **Fetch**: Data retrieval with clean content processing (Files, RSS, Reddit, Google Sheets, WordPress Local, WordPress Media, WordPress API, Workspace)
+- **Fetch**: Data retrieval with clean content processing (core handlers include Files, RSS, Email, WordPress Local, WordPress Media, and WordPress API; extension plugins can register more)
 - **AI**: Content processing with multi-provider support (OpenAI, Anthropic, Google, Grok)
-- **Publish**: Content distribution with modular handler architecture (Twitter, Facebook, Threads, Bluesky, WordPress, Workspace)
-- **Update**: Content modification (WordPress posts/pages)
+- **Publish**: Content distribution with modular handler architecture (core handlers include WordPress and Email; extension plugins can register social destinations)
+- **Upsert**: Content modification (WordPress posts/pages)
 - **System Task**: Execute system tasks within pipeline flows
 - **Agent Ping**: Outbound webhook notifications to external agents
 - **Webhook Gate**: Wait for inbound webhook before proceeding
@@ -252,17 +247,16 @@ Directives implement `DirectiveInterface` and return arrays of typed outputs:
 
 **Base Classes**:
 - **BaseAuthProvider** (`/inc/Core/OAuth/BaseAuthProvider.php`): Abstract base for all authentication providers with unified option storage, callback URL generation, and authentication state checking
-- **BaseOAuth1Provider** (`/inc/Core/OAuth/BaseOAuth1Provider.php`): OAuth 1.0a providers (TwitterAuth) extending BaseAuthProvider
-- **BaseOAuth2Provider** (`/inc/Core/OAuth/BaseOAuth2Provider.php`): OAuth 2.0 providers (RedditAuth, FacebookAuth, ThreadsAuth, GoogleSheetsAuth) extending BaseAuthProvider
+- **BaseOAuth1Provider** (`/inc/Core/OAuth/BaseOAuth1Provider.php`): Base for extension-provided OAuth 1.0a providers
+- **BaseOAuth2Provider** (`/inc/Core/OAuth/BaseOAuth2Provider.php`): Base for core and extension OAuth 2.0 providers
 
 **OAuth Handlers**:
 - **OAuth1Handler** (`/inc/Core/OAuth/OAuth1Handler.php`): Three-legged OAuth 1.0a flow implementation
 - **OAuth2Handler** (`/inc/Core/OAuth/OAuth2Handler.php`): Authorization code flow implementation
 
 **Authentication Providers**:
-- **OAuth 1.0a**: TwitterAuth extends BaseOAuth1Provider
-- **OAuth 2.0**: RedditAuth, FacebookAuth, ThreadsAuth, GoogleSheetsAuth extend BaseOAuth2Provider
-- **Direct**: BlueskyAuth extends BaseAuthProvider (app password authentication)
+- Core ships base classes plus concrete providers next to the handlers that need them, such as Email auth.
+- Extension plugins register their own providers through `datamachine_auth_providers`.
 
 **OAuth2 Flow**:
 1. Create state nonce for CSRF protection
@@ -296,7 +290,7 @@ Data Machine v0.2.0 introduced a universal Engine layer (`/inc/Engine/AI/`) that
 **Tool Categories**:
 - Handler-specific tools for publish/update operations
 - Global tools for search and analysis (GoogleSearch, LocalSearch, WebFetch, WordPressPostReader)
-- Workspace-scoped tools (WorkspaceTools, WorkspaceScopedTools) for agent file operations (**moved to data-machine-code extension**)
+- Coding workspace tools live in the `data-machine-code` extension plugin
 - Agent memory tools (AgentMemory, AgentDailyMemory) for runtime memory access
 - Chat-only tools for workflow building (@since v0.4.3):
   - AddPipelineStep, ApiQuery, AuthenticateHandler, ConfigureFlowSteps, ConfigurePipelineStep, CopyFlow, CreateFlow, CreatePipeline, CreateTaxonomyTerm, ExecuteWorkflowTool, GetHandlerDefaults, ManageLogs, ReadLogs, RunFlow, SearchTaxonomyTerms, SetHandlerDefaults, UpdateFlow
@@ -358,11 +352,11 @@ For detailed documentation:
 - **`datamachine_timeframe_limit`**: Shared timeframe parsing with discovery/conversion modes
   - Discovery mode: Returns available timeframe options for UI dropdowns
   - Conversion mode: Returns Unix timestamp for specified timeframe
-  - Used by: RSS, Reddit, WordPress Local, WordPress Media, WordPress API
+  - Used by: RSS, WordPress Local, WordPress Media, WordPress API, and extension fetch handlers
 - **`datamachine_keyword_search_match`**: Universal keyword matching with OR logic
   - Case-insensitive Unicode-safe matching
   - Comma-separated keyword support
-  - Used by: RSS, Reddit, WordPress Local, WordPress Media, WordPress API
+  - Used by: RSS, WordPress Local, WordPress Media, WordPress API, and extension fetch handlers
 - **`datamachine_data_packet`**: Standardized data packet creation and structure
   - Ensures type and timestamp fields are present
   - Maintains chronological ordering via array_unshift()

--- a/docs/core-system/database-schema.md
+++ b/docs/core-system/database-schema.md
@@ -392,12 +392,12 @@ do_action('datamachine_update_job_status', $job_id, 'failed', 'Processing failed
 
 **Mark Item Processed**:
 ```php
-do_action('datamachine_mark_item_processed', $flow_step_id, 'rss', $item_id, $job_id);
+$context->markItemProcessed($item_id);
 ```
 
 **Check If Processed**:
 ```php
-$is_processed = apply_filters('datamachine_is_item_processed', false, $flow_step_id, 'rss', $item_id);
+$is_processed = $context->isItemProcessed($item_id);
 ```
 
 ### Chat Session Operations

--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -401,7 +401,7 @@ public function handle_callback(
 
 ## Provider Registration via Filters
 
-Concrete OAuth providers self-register via the `datamachine_auth_providers` filter (typically through `HandlerRegistrationTrait`). Core data-machine does not ship a `inc/Core/OAuth/Providers/` directory — every concrete provider lives next to its handler in either core or an extension plugin.
+Concrete OAuth providers self-register via the `datamachine_auth_providers` filter (typically through `HandlerRegistrationTrait`). Core data-machine does not ship a central providers directory; every concrete provider lives next to its handler in either core or an extension plugin.
 
 **In core data-machine:**
 

--- a/docs/development/hooks/core-actions.md
+++ b/docs/development/hooks/core-actions.md
@@ -150,53 +150,11 @@ do_action('datamachine_fail_job', $job_id, 'step_execution_failure', [
 3. Optionally cleans up job data files
 4. Stops pipeline execution
 
-## Configuration Actions
+## Configuration Hooks
 
-### `datamachine_update_system_prompt`
+Pipeline and flow-step configuration writes are ability-backed, not action-backed. Use `datamachine/update-pipeline-step`, `datamachine/update-flow-step`, or `datamachine/configure-flow-steps` through the Abilities API, REST API, WP-CLI, or chat tools.
 
-**Purpose**: Update pipeline-level system prompts
-
-**Parameters**:
-- `$pipeline_step_id` (string) - Pipeline step UUID
-- `$system_prompt` (string) - AI system prompt text
-
-**Usage**:
-```php
-do_action('datamachine_update_system_prompt', $pipeline_step_id, $system_prompt);
-```
-
-**Storage**: Stored in pipeline_config as reusable template
-
-### `datamachine_update_flow_user_message`
-
-**Purpose**: Update flow-level user messages
-
-**Parameters**:
-- `$flow_step_id` (string) - Flow step composite ID
-- `$user_message` (string) - AI user message text
-
-**Usage**:
-```php
-do_action('datamachine_update_flow_user_message', $flow_step_id, $user_message);
-```
-
-**Storage**: Stored in flow_config for instance-specific customization
-
-### `datamachine_save_tool_config`
-
-**Purpose**: Save tool configuration data
-
-**Parameters**:
-- `$tool_id` (string) - Tool identifier
-- `$config_data` (array) - Configuration data to save
-
-**Usage**:
-```php
-do_action('datamachine_save_tool_config', 'google_search', [
-    'api_key' => $api_key,
-    'search_engine_id' => $search_engine_id
-]);
-```
+Tool configuration uses the `datamachine_save_tool_config` **filter** from `BaseTool`; see [Core Filters](core-filters.md) for filter-oriented extension points.
 
 ## System Maintenance Actions
 
@@ -364,4 +322,3 @@ Input data is sanitized before processing:
 $pipeline_name = sanitize_text_field($data['pipeline_name'] ?? '');
 $config_json = wp_json_encode($config_data);
 ```
-

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -791,18 +791,6 @@ $data = apply_filters('datamachine_data_packet', $data, $packet_data, $flow_step
 
 ## Data Processing Filters
 
-### `datamachine_is_item_processed`
-
-**Purpose**: Check if item was already processed
-
-**Parameters**:
-- `$processed` (bool) - Default processed status
-- `$flow_step_id` (string) - Flow step identifier
-- `$source_type` (string) - Handler source type
-- `$item_id` (mixed) - Item identifier
-
-**Return**: Boolean processed status
-
 ### `datamachine_should_reprocess_item`
 
 **Since**: v0.71.0

--- a/docs/handlers/fetch/handlers-overview.md
+++ b/docs/handlers/fetch/handlers-overview.md
@@ -130,20 +130,23 @@ $image_url = $engine_data['image_url'] ?? null;
 
 ### Processed Items Tracking
 
-All fetch handlers use the processed items system:
+Fetch handlers use the processed items system through `ExecutionContext` and `FetchHandler::filterProcessed()`:
 
 ```php
-// Check if already processed
-$is_processed = apply_filters('datamachine_is_item_processed', false, $flow_step_id, $source_type, $item_id);
-
-if (!$is_processed) {
-    // Mark as processed
-    do_action('datamachine_mark_item_processed', $flow_step_id, $source_type, $item_id, $job_id);
-    
-    // Process item
-    return [$data_packet];
+if (!$context->isItemProcessed($item_identifier)) {
+    return [
+        'items' => [[
+            'title' => $title,
+            'content' => $content,
+            'metadata' => [
+                'item_identifier' => $item_identifier,
+            ],
+        ]],
+    ];
 }
 ```
+
+Fetch handlers identify candidate items; completed items are marked processed after the full pipeline finishes successfully so downstream failures do not permanently drop content.
 
 **Scope**: Per-flow-step deduplication (same item can be processed by different flows)
 **Persistence**: Stored in `wp_datamachine_processed_items` table
@@ -153,12 +156,12 @@ if (!$is_processed) {
 
 - `wordpress_local` - Local WordPress posts
 - `wordpress_media` - Local media files  
+- `email` - IMAP email messages
 - `files` - File processing
 - `rss` - RSS feed items
-- `reddit` - Reddit posts
-- `google_sheets` - Spreadsheet data
 - `wordpress_api` - External WordPress API content
-- `universal_web_scraper` - Universal web scraper items
+
+Extension plugins can register additional fetch handlers and source type identifiers.
 
 ## Configuration Patterns
 
@@ -290,13 +293,16 @@ $result = $wordpress_handler->get_fetch_data(
 
 ```php
 foreach ($potential_items as $item) {
-    $is_processed = apply_filters('datamachine_is_item_processed', false, 
-        $flow_step_id, 'my_source', $item['id']);
-    
-    if (!$is_processed) {
-        do_action('datamachine_mark_item_processed', $flow_step_id, 
-            'my_source', $item['id'], $job_id);
-        return [$this->create_data_packet($item)];
+    if (!$context->isItemProcessed((string) $item['id'])) {
+        return [
+            [
+                'title' => $item['title'],
+                'content' => $item['content'],
+                'metadata' => [
+                    'item_identifier' => (string) $item['id'],
+                ],
+            ],
+        ];
     }
 }
 return ['processed_items' => []]; // No unprocessed items
@@ -307,38 +313,42 @@ return ['processed_items' => []]; // No unprocessed items
 ### Custom Fetch Handler
 
 ```php
-class CustomFetchHandler {
-    public function get_fetch_data(int $pipeline_id, array $handler_config, ?string $job_id = null): array {
+use DataMachine\Core\ExecutionContext;
+use DataMachine\Core\Steps\Fetch\Handlers\FetchHandler;
+
+class CustomFetchHandler extends FetchHandler {
+    protected function executeFetch(array $config, ExecutionContext $context): array {
         // Extract configuration
-        $config = $handler_config['custom_source'] ?? [];
-        $flow_step_id = $handler_config['flow_step_id'] ?? null;
+        $source_config = $config['custom_source'] ?? [];
 
         // Fetch data from source
-        $items = $this->fetch_from_source($config);
+        $items = $this->fetch_from_source($source_config);
 
         // Process first unprocessed item
         foreach ($items as $item) {
-            if ($flow_step_id) {
-                $is_processed = apply_filters('datamachine_is_item_processed', false,
-                    $flow_step_id, 'custom_source', $item['id']);
-
-                if ($is_processed) continue;
-
-                do_action('datamachine_mark_item_processed', $flow_step_id,
-                    'custom_source', $item['id'], $job_id);
+            if ($context->isItemProcessed((string) $item['id'])) {
+                continue;
             }
 
             // Store engine data via centralized filter (array storage)
-            if ($job_id) {
-                apply_filters('datamachine_engine_data', null, $job_id, [
-                    'source_url' => $item['url'],
-                    'image_url' => $item['image'] ?? ''
-                ]);
-            }
+            $context->storeEngineData([
+                'source_url' => $item['url'],
+                'image_url' => $item['image'] ?? ''
+            ]);
 
-            return ['processed_items' => [$this->create_data_packet($item)]];
+            return [
+                'items' => [
+                    [
+                        'title' => $item['title'],
+                        'content' => $item['content'],
+                        'metadata' => [
+                            'item_identifier' => (string) $item['id'],
+                        ],
+                    ],
+                ],
+            ];
         }
 
-        return ['processed_items' => []];
+        return ['items' => []];
     }
 }

--- a/docs/handlers/fetch/wordpress-local.md
+++ b/docs/handlers/fetch/wordpress-local.md
@@ -126,7 +126,7 @@ return [
 Uses processed items tracking to prevent duplicate processing:
 
 ```php
-$is_processed = apply_filters('datamachine_is_item_processed', false, $flow_step_id, 'wordpress_local', $post_id);
+$is_processed = $context->isItemProcessed((string) $post_id);
 ```
 
 **Tracking**: Each processed post is marked by flow step and post ID

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -91,13 +91,12 @@ See [WordPress as Agent Memory](core-system/wordpress-as-agent-memory.md) for th
 The Abilities API (DataMachine\Abilities) provides direct method calls for core operations via the WordPress 6.9 Abilities API:
 
 - `FlowAbilities`, `PipelineAbilities`, `FlowStepAbilities`, and `PipelineStepAbilities` handle creation, duplication, synchronization, and ordering.
-- `JobAbilities` monitors execution outcomes and updates statuses.
+- Job abilities monitor execution outcomes, retries, manual failure, recovery, summaries, and deletion.
 - `ProcessedItemsAbilities` deduplicates content across executions by tracking previously processed identifiers.
 - `AgentAbilities` manages agent CRUD, renaming (with filesystem migration), and deletion.
 - `AgentMemoryAbilities` provides section-based read, write, append, and search operations on memory files.
 - `DailyMemoryAbilities` manages daily memory files — read, write, list, search, and delete by date.
-**Remaining Services** (utilities for cross-cutting concerns):
-- `LogsManager` aggregates log entries in the `wp_datamachine_logs` table for filtering in the admin UI.
+- `LogAbilities` and the `LogRepository` aggregate log entries in the `wp_datamachine_logs` table for filtering in the admin UI.
 - Cache invalidation is handled by ability-level `clearCache()` methods to ensure dynamic handler and step type registrations are immediately reflected across the system.
 
 Abilities are the single source of truth for REST endpoints, CLI commands, and Chat tools, ensuring validation and sanitization before persisting data or enqueuing jobs.
@@ -151,7 +150,7 @@ wp datamachine jobs undo <job_id> --dry-run --allow-root
 
 ## Authentication & Security
 
-- **Authentication providers** extend BaseAuthProvider, BaseOAuth1Provider, or BaseOAuth2Provider under `/inc/Core/OAuth/`, covering Twitter, Reddit, Facebook, Threads, Google Sheets, and Bluesky (app passwords).
+- **Authentication providers** extend BaseAuthProvider, BaseOAuth1Provider, or BaseOAuth2Provider under `/inc/Core/OAuth/`; concrete providers live next to their handlers in core or extension plugins.
 - **OAuth handlers** (`OAuth1Handler`, `OAuth2Handler`) standardize callback handling, nonce validation, and credential storage.
 - **Capability checks** (`manage_options`) and WordPress nonces guard REST endpoints; inputs run through `sanitize_*` helpers before hitting services.
 - **Multi-agent permissions**: `PermissionHelper` handles agent-level access checks via `resolve_scoped_agent_id()`, `can_access_agent()`, and `owns_agent_resource()`.
@@ -163,7 +162,7 @@ wp datamachine jobs undo <job_id> --dry-run --allow-root
 - **Flow schedules** support manual runs, one-time execution, and recurring intervals (from 5 minutes to weekly). See [Scheduling Intervals](api/endpoints/intervals.md) for available options.
 - **System task scheduling**: DailyMemoryTask and other system tasks run on cron schedules via Action Scheduler.
 - **Batch execution**: Jobs support parent-child relationships via `parent_job_id` for processing multiple items in coordinated batches.
-- **JobManager** updates statuses, emits extensibility actions (`datamachine_update_job_status`), and links jobs to logs and processed items for auditing.
+- Job abilities and repositories update statuses, emit extensibility actions (`datamachine_update_job_status`), and link jobs to logs and processed items for auditing.
 
 ## Admin Interface
 
@@ -178,7 +177,7 @@ wp datamachine jobs undo <job_id> --dry-run --allow-root
 ## Key Capabilities
 
 - **Multi-agent support** with isolated identity, memory, and resources per agent on a single WordPress installation.
-- **Multi-platform publishing** via dedicated fetch/publish/upsert handlers for files, RSS, Reddit, Google Sheets, WordPress, Twitter, Threads, Bluesky, Facebook, and Google Sheets output.
+- **Multi-platform publishing** via core fetch/publish/upsert handlers for files, RSS, email, and WordPress, plus extension-provided handlers for social, business, and event destinations.
 - **Daily memory system** for automatic temporal knowledge management with AI-driven pruning.
 - **System tasks** for background AI operations (image generation, alt text, internal linking, meta descriptions) with undo support.
 - **Extension points** through filters such as `datamachine_handlers`, `datamachine_tools`, `datamachine_step_types`, `datamachine_auth_providers`, and `datamachine_engine_data`.


### PR DESCRIPTION
## Summary
- Refresh architecture and overview docs for the current abilities-first shape.
- Replace stale React handler model/service docs with the current query/helper layout.
- Update processed-item examples to use `ExecutionContext` and remove docs for a deleted `datamachine_is_item_processed` filter.

## Tests
- `php -r '<doc path reference scan>'`
- `php -r '<relative markdown link scan>'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing stale documentation references, applying the documentation edits, and running validation checks. Chris remains responsible for review and merge.