### PR TITLE
fix(plugin): remove redundant PHP version guard

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -707,22 +707,6 @@ require_once __DIR__ . '/inc/migrations/load.php';
 
 
 function datamachine_check_requirements() {
-	if ( version_compare( PHP_VERSION, '8.2', '<' ) ) {
-		add_action(
-			'admin_notices',
-			function () {
-				echo '<div class="notice notice-error"><p>';
-				printf(
-					esc_html( 'Data Machine requires PHP %2$s or higher. You are running PHP %1$s.' ),
-					esc_html( PHP_VERSION ),
-					'8.2'
-				);
-				echo '</p></div>';
-			}
-		);
-		return false;
-	}
-
 	global $wp_version;
 	$current_wp_version = $wp_version ?? '0.0.0';
 	if ( version_compare( $current_wp_version, '6.9', '<' ) ) {


### PR DESCRIPTION
## Summary
- Remove the PHP < 8.2 branch from `datamachine_check_requirements()` because the plugin header and Composer already require PHP 8.2+.
- Leaves the WordPress version and Composer autoload checks intact; those still provide user-facing install diagnostics.

## Tests
- `php -l data-machine.php`
- `homeboy audit data-machine --only upstream_workaround --ignore-baseline` timed out after 5 minutes with no output, so I did not use it as verification.

Closes #1287

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Triaged the audit issue, identified the one valid cleanup in the mixed finding set, made the targeted code change, and ran syntax verification. Chris remains responsible for review and merge.