### PR TITLE
refactor(audit): share fetch HTTP helper

### DIFF
--- a/inc/Abilities/Fetch/FetchHttpGetTrait.php
+++ b/inc/Abilities/Fetch/FetchHttpGetTrait.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Shared HTTP GET helper for fetch abilities.
+ *
+ * @package DataMachine\Abilities\Fetch
+ */
+
+namespace DataMachine\Abilities\Fetch;
+
+defined( 'ABSPATH' ) || exit;
+
+trait FetchHttpGetTrait {
+
+	/**
+	 * Make HTTP GET request.
+	 */
+	private function httpGet( string $url, array $options ): array {
+		$args = array(
+			'timeout' => $options['timeout'] ?? 30,
+		);
+
+		$response = wp_remote_get( $url, $args );
+
+		if ( is_wp_error( $response ) ) {
+			return array(
+				'success' => false,
+				'error'   => $response->get_error_message(),
+			);
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = wp_remote_retrieve_body( $response );
+
+		return array(
+			'success'     => $status_code >= 200 && $status_code < 300,
+			'status_code' => $status_code,
+			'data'        => $body,
+		);
+	}
+}

--- a/inc/Abilities/Fetch/FetchRssAbility.php
+++ b/inc/Abilities/Fetch/FetchRssAbility.php
@@ -16,6 +16,8 @@ defined( 'ABSPATH' ) || exit;
 
 class FetchRssAbility {
 
+	use FetchHttpGetTrait;
+
 	private static bool $registered = false;
 
 	public function __construct() {
@@ -364,33 +366,6 @@ class FetchRssAbility {
 		);
 
 		return array_merge( $defaults, $input );
-	}
-
-	/**
-	 * Make HTTP GET request.
-	 */
-	private function httpGet( string $url, array $options ): array {
-		$args = array(
-			'timeout' => $options['timeout'] ?? 30,
-		);
-
-		$response = wp_remote_get( $url, $args );
-
-		if ( is_wp_error( $response ) ) {
-			return array(
-				'success' => false,
-				'error'   => $response->get_error_message(),
-			);
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = wp_remote_retrieve_body( $response );
-
-		return array(
-			'success'     => $status_code >= 200 && $status_code < 300,
-			'status_code' => $status_code,
-			'data'        => $body,
-		);
 	}
 
 	/**

--- a/inc/Abilities/Fetch/FetchWordPressApiAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressApiAbility.php
@@ -17,6 +17,8 @@ defined( 'ABSPATH' ) || exit;
 
 class FetchWordPressApiAbility {
 
+	use FetchHttpGetTrait;
+
 	private static bool $registered = false;
 
 	public function __construct() {
@@ -363,33 +365,6 @@ class FetchWordPressApiAbility {
 		);
 
 		return array_merge( $defaults, $input );
-	}
-
-	/**
-	 * Make HTTP GET request.
-	 */
-	private function httpGet( string $url, array $options ): array {
-		$args = array(
-			'timeout' => $options['timeout'] ?? 30,
-		);
-
-		$response = wp_remote_get( $url, $args );
-
-		if ( is_wp_error( $response ) ) {
-			return array(
-				'success' => false,
-				'error'   => $response->get_error_message(),
-			);
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$body        = wp_remote_retrieve_body( $response );
-
-		return array(
-			'success'     => $status_code >= 200 && $status_code < 300,
-			'status_code' => $status_code,
-			'data'        => $body,
-		);
 	}
 
 	/**

--- a/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
+++ b/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
@@ -10,6 +10,8 @@
 
 namespace DataMachine\Abilities\FlowStep;
 
+use DataMachine\Core\Steps\FlowStepConfig;
+
 defined( 'ABSPATH' ) || exit;
 
 class UpdateFlowStepAbility {
@@ -128,7 +130,7 @@ class UpdateFlowStepAbility {
 		$updated_fields = array();
 
 		if ( $has_handler_update ) {
-			$effective_slug = \DataMachine\Core\Steps\FlowStepConfig::getEffectiveSlug( $existing_step, $handler_slug ?? '' );
+			$effective_slug = FlowStepConfig::getEffectiveSlug( $existing_step, $handler_slug ?? '' );
 
 			if ( empty( $effective_slug ) ) {
 				return array(

--- a/tests/fetch-http-get-trait-smoke.php
+++ b/tests/fetch-http-get-trait-smoke.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Pure-PHP smoke test for shared fetch HTTP helper (#1322).
+ *
+ * Run with: php tests/fetch-http-get-trait-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root = dirname( __DIR__ );
+
+$files = array(
+	'trait' => file_get_contents( $root . '/inc/Abilities/Fetch/FetchHttpGetTrait.php' ),
+	'rss'   => file_get_contents( $root . '/inc/Abilities/Fetch/FetchRssAbility.php' ),
+	'wpapi' => file_get_contents( $root . '/inc/Abilities/Fetch/FetchWordPressApiAbility.php' ),
+);
+
+$failed = 0;
+$total  = 0;
+
+function assert_fetch_http_get_trait( string $name, bool $condition, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	++$failed;
+	echo "  [FAIL] {$name}" . ( $detail ? " - {$detail}" : '' ) . "\n";
+}
+
+echo "=== fetch-http-get-trait-smoke ===\n";
+
+assert_fetch_http_get_trait(
+	'FetchHttpGetTrait defines the shared HTTP helper',
+	str_contains( $files['trait'], 'trait FetchHttpGetTrait' )
+		&& substr_count( $files['trait'], 'function httpGet' ) === 1
+);
+
+assert_fetch_http_get_trait(
+	'RSS ability consumes shared helper trait',
+	str_contains( $files['rss'], 'use FetchHttpGetTrait;' )
+);
+
+assert_fetch_http_get_trait(
+	'WordPress API ability consumes shared helper trait',
+	str_contains( $files['wpapi'], 'use FetchHttpGetTrait;' )
+);
+
+assert_fetch_http_get_trait(
+	'RSS ability no longer defines a private duplicate httpGet method',
+	substr_count( $files['rss'], 'function httpGet' ) === 0
+);
+
+assert_fetch_http_get_trait(
+	'WordPress API ability no longer defines a private duplicate httpGet method',
+	substr_count( $files['wpapi'], 'function httpGet' ) === 0
+);
+
+assert_fetch_http_get_trait(
+	'Shared helper preserves WordPress HTTP API call',
+	str_contains( $files['trait'], 'wp_remote_get( $url, $args )' )
+		&& str_contains( $files['trait'], 'wp_remote_retrieve_response_code( $response )' )
+		&& str_contains( $files['trait'], 'wp_remote_retrieve_body( $response )' )
+);
+
+if ( $failed > 0 ) {
+	echo "\nfetch-http-get-trait-smoke failed: {$failed}/{$total} assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nfetch-http-get-trait-smoke passed: {$total} assertions.\n";


### PR DESCRIPTION
## Summary
- Resolves the real audit findings from the focused batch by importing `FlowStepConfig` directly and sharing the duplicated fetch HTTP GET helper.
- Leaves WP-CLI dispatch and retention signature false positives to Homeboy tracking rather than changing correct Data Machine code.

## Changes
- Added `FetchHttpGetTrait` and moved the duplicated `httpGet()` helper out of RSS and WordPress API fetch abilities.
- Updated `UpdateFlowStepAbility` to import and use `FlowStepConfig` consistently with sibling flow-step abilities.
- Added a pure-PHP smoke to pin the fetch helper sharing contract.

## Tests
- `php tests/fetch-http-get-trait-smoke.php`
- `php tests/fetch-test-cli-smoke.php`
- `php tests/retention-system-tasks-smoke.php`
- `php -l inc/Abilities/Fetch/FetchHttpGetTrait.php`
- `php -l inc/Abilities/Fetch/FetchRssAbility.php`
- `php -l inc/Abilities/Fetch/FetchWordPressApiAbility.php`
- `php -l inc/Abilities/FlowStep/UpdateFlowStepAbility.php`

## Closes
- Closes #1325
- Closes #1322

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Triage, implementation, and tests; Chris remains responsible.
