### PR TITLE
feat(agent): add portable bundle schema

### DIFF
--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -26,12 +26,16 @@ class Flows extends BaseRepository {
             flow_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
             pipeline_id bigint(20) unsigned NOT NULL,
             user_id bigint(20) unsigned NOT NULL DEFAULT 0,
+            agent_id bigint(20) unsigned DEFAULT NULL,
             flow_name varchar(255) NOT NULL,
+            portable_slug varchar(191) DEFAULT NULL,
             flow_config longtext NOT NULL,
             scheduling_config longtext NOT NULL,
             PRIMARY KEY (flow_id),
             KEY pipeline_id (pipeline_id),
-            KEY user_id (user_id)
+            KEY user_id (user_id),
+            KEY agent_id (agent_id),
+            UNIQUE KEY pipeline_portable_slug (pipeline_id, portable_slug)
         ) $charset_collate;";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
@@ -121,6 +125,38 @@ class Flows extends BaseRepository {
 				array( 'table_name' => $this->table_name )
 			);
 		}
+
+		// Stable bundle filename/reference within a pipeline (#1303).
+		if ( ! self::column_exists( $this->table_name, 'portable_slug', $this->wpdb ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+			$result = $this->wpdb->query(
+				"ALTER TABLE {$this->table_name}
+				 ADD COLUMN portable_slug varchar(191) DEFAULT NULL AFTER flow_name,
+				 ADD UNIQUE KEY pipeline_portable_slug (pipeline_id, portable_slug)"
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+
+			if ( false === $result ) {
+				do_action(
+					'datamachine_log',
+					'error',
+					'Failed to add portable_slug column to flows table',
+					array(
+						'table_name' => $this->table_name,
+						'db_error'   => $this->wpdb->last_error,
+					)
+				);
+				return;
+			}
+
+			do_action(
+				'datamachine_log',
+				'info',
+				'Added portable_slug column to flows table for agent bundles',
+				array( 'table_name' => $this->table_name )
+			);
+		}
 	}
 
 	public function create_flow( array $flow_data ) {
@@ -167,6 +203,11 @@ class Flows extends BaseRepository {
 		if ( null !== $agent_id && $agent_id > 0 ) {
 			$insert_data['agent_id'] = $agent_id;
 			$insert_format[]         = '%d';
+		}
+
+		if ( isset( $flow_data['portable_slug'] ) && '' !== trim( (string) $flow_data['portable_slug'] ) ) {
+			$insert_data['portable_slug'] = sanitize_title( (string) $flow_data['portable_slug'] );
+			$insert_format[]              = '%s';
 		}
 
 		$result = $this->wpdb->insert(

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -57,6 +57,11 @@ class Pipelines extends BaseRepository {
 			$format[]         = '%d';
 		}
 
+		if ( isset( $pipeline_data['portable_slug'] ) && '' !== trim( (string) $pipeline_data['portable_slug'] ) ) {
+			$data['portable_slug'] = sanitize_title( (string) $pipeline_data['portable_slug'] );
+			$format[]              = '%s';
+		}
+
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$inserted = $this->wpdb->insert( $this->table_name, $data, $format );
 
@@ -661,6 +666,38 @@ class Pipelines extends BaseRepository {
 				array( 'table_name' => $this->table_name )
 			);
 		}
+
+		// Stable bundle filename/reference for portable agent exports (#1303).
+		if ( ! self::column_exists( $this->table_name, 'portable_slug', $this->wpdb ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+			$result = $this->wpdb->query(
+				"ALTER TABLE {$this->table_name}
+				 ADD COLUMN portable_slug varchar(191) DEFAULT NULL AFTER pipeline_name,
+				 ADD UNIQUE KEY agent_portable_slug (agent_id, portable_slug)"
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+
+			if ( false === $result ) {
+				do_action(
+					'datamachine_log',
+					'error',
+					'Failed to add portable_slug column to pipelines table',
+					array(
+						'table_name' => $this->table_name,
+						'db_error'   => $this->wpdb->last_error,
+					)
+				);
+				return;
+			}
+
+			do_action(
+				'datamachine_log',
+				'info',
+				'Added portable_slug column to pipelines table for agent bundles',
+				array( 'table_name' => $this->table_name )
+			);
+		}
 	}
 
 	public static function create_table() {
@@ -674,13 +711,17 @@ class Pipelines extends BaseRepository {
 		$sql = "CREATE TABLE $table_name (
 			pipeline_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 			user_id bigint(20) unsigned NOT NULL DEFAULT 0,
+			agent_id bigint(20) unsigned DEFAULT NULL,
 			pipeline_name varchar(255) NOT NULL,
+			portable_slug varchar(191) DEFAULT NULL,
 			pipeline_config longtext NULL,
 			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			PRIMARY KEY  (pipeline_id),
 			KEY user_id (user_id),
+			KEY agent_id (agent_id),
 			KEY pipeline_name (pipeline_name),
+			UNIQUE KEY agent_portable_slug (agent_id, portable_slug),
 			KEY created_at (created_at),
 			KEY updated_at (updated_at)
 		) $charset_collate;";

--- a/inc/Engine/Bundle/AgentBundleDirectory.php
+++ b/inc/Engine/Bundle/AgentBundleDirectory.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Agent bundle directory reader/writer.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Pure filesystem adapter for schema_version 1 agent bundle directories.
+ */
+final class AgentBundleDirectory {
+
+	private AgentBundleManifest $manifest;
+	/** @var array<string,string> */
+	private array $memory_files;
+	/** @var AgentBundlePipelineFile[] */
+	private array $pipelines;
+	/** @var AgentBundleFlowFile[] */
+	private array $flows;
+
+	/**
+	 * @param AgentBundleManifest       $manifest Bundle manifest.
+	 * @param array<string,string>      $memory_files Relative memory path => contents.
+	 * @param AgentBundlePipelineFile[] $pipelines Pipeline files.
+	 * @param AgentBundleFlowFile[]     $flows Flow files.
+	 */
+	public function __construct( AgentBundleManifest $manifest, array $memory_files, array $pipelines, array $flows ) {
+		$this->manifest     = $manifest;
+		$this->memory_files = self::normalize_memory_files( $memory_files );
+		$this->pipelines    = self::sort_documents_by_slug( $pipelines, AgentBundlePipelineFile::class );
+		$this->flows        = self::sort_documents_by_slug( $flows, AgentBundleFlowFile::class );
+	}
+
+	public static function read( string $directory ): self {
+		$directory = rtrim( $directory, '/\\' );
+		if ( ! is_dir( $directory ) ) {
+			throw new BundleValidationException( "Bundle directory does not exist: {$directory}" );
+		}
+
+		$manifest_path = $directory . '/' . BundleSchema::MANIFEST_FILE;
+		if ( ! is_file( $manifest_path ) ) {
+			throw new BundleValidationException( 'Bundle directory is missing manifest.json.' );
+		}
+
+		$manifest = AgentBundleManifest::from_array(
+			BundleSchema::decode_json( (string) file_get_contents( $manifest_path ), 'manifest.json' )
+		);
+
+		return new self(
+			$manifest,
+			self::read_memory_files( $directory . '/' . BundleSchema::MEMORY_DIR ),
+			self::read_documents( $directory . '/' . BundleSchema::PIPELINES_DIR, AgentBundlePipelineFile::class ),
+			self::read_documents( $directory . '/' . BundleSchema::FLOWS_DIR, AgentBundleFlowFile::class )
+		);
+	}
+
+	public function write( string $directory ): void {
+		$directory = rtrim( $directory, '/\\' );
+		self::ensure_directory( $directory );
+		self::ensure_directory( $directory . '/' . BundleSchema::MEMORY_DIR );
+		self::ensure_directory( $directory . '/' . BundleSchema::PIPELINES_DIR );
+		self::ensure_directory( $directory . '/' . BundleSchema::FLOWS_DIR );
+
+		file_put_contents( $directory . '/' . BundleSchema::MANIFEST_FILE, BundleSchema::encode_json( $this->manifest->to_array() ) );
+
+		foreach ( $this->memory_files as $relative_path => $contents ) {
+			$path = $directory . '/' . BundleSchema::MEMORY_DIR . '/' . $relative_path;
+			self::ensure_directory( dirname( $path ) );
+			file_put_contents( $path, $contents );
+		}
+
+		foreach ( $this->pipelines as $pipeline ) {
+			file_put_contents( $directory . '/' . BundleSchema::PIPELINES_DIR . '/' . $pipeline->slug() . '.json', BundleSchema::encode_json( $pipeline->to_array() ) );
+		}
+
+		foreach ( $this->flows as $flow ) {
+			file_put_contents( $directory . '/' . BundleSchema::FLOWS_DIR . '/' . $flow->slug() . '.json', BundleSchema::encode_json( $flow->to_array() ) );
+		}
+	}
+
+	public function manifest(): AgentBundleManifest {
+		return $this->manifest;
+	}
+
+	/** @return array<string,string> */
+	public function memory_files(): array {
+		return $this->memory_files;
+	}
+
+	/** @return AgentBundlePipelineFile[] */
+	public function pipelines(): array {
+		return $this->pipelines;
+	}
+
+	/** @return AgentBundleFlowFile[] */
+	public function flows(): array {
+		return $this->flows;
+	}
+
+	private static function ensure_directory( string $directory ): void {
+		if ( is_dir( $directory ) ) {
+			return;
+		}
+		if ( ! mkdir( $directory, 0775, true ) && ! is_dir( $directory ) ) {
+			throw new BundleValidationException( "Unable to create bundle directory: {$directory}" );
+		}
+	}
+
+	/** @return array<string,string> */
+	private static function normalize_memory_files( array $memory_files ): array {
+		$normalized = array();
+		foreach ( $memory_files as $relative_path => $contents ) {
+			$relative_path = str_replace( '\\', '/', (string) $relative_path );
+			$relative_path = ltrim( $relative_path, '/' );
+			if ( str_contains( $relative_path, '..' ) || '' === $relative_path ) {
+				throw new BundleValidationException( "Invalid memory file path: {$relative_path}" );
+			}
+			$normalized[ $relative_path ] = (string) $contents;
+		}
+		ksort( $normalized, SORT_STRING );
+		return $normalized;
+	}
+
+	/** @return array<string,string> */
+	private static function read_memory_files( string $directory ): array {
+		if ( ! is_dir( $directory ) ) {
+			return array();
+		}
+
+		$files    = array();
+		$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $directory, \FilesystemIterator::SKIP_DOTS ) );
+		foreach ( $iterator as $file ) {
+			if ( ! $file->isFile() ) {
+				continue;
+			}
+			$path             = $file->getPathname();
+			$relative         = str_replace( '\\', '/', substr( $path, strlen( $directory ) + 1 ) );
+			$files[ $relative ] = (string) file_get_contents( $path );
+		}
+		ksort( $files, SORT_STRING );
+		return $files;
+	}
+
+	/** @return array */
+	private static function read_documents( string $directory, string $class ): array {
+		if ( ! is_dir( $directory ) ) {
+			return array();
+		}
+
+		$documents = array();
+		$paths     = glob( $directory . '/*.json' ) ?: array();
+		sort( $paths, SORT_STRING );
+		foreach ( $paths as $path ) {
+			$documents[] = $class::from_array( BundleSchema::decode_json( (string) file_get_contents( $path ), basename( $path ) ) );
+		}
+
+		return self::sort_documents_by_slug( $documents, $class );
+	}
+
+	/** @return array */
+	private static function sort_documents_by_slug( array $documents, string $class ): array {
+		foreach ( $documents as $document ) {
+			if ( ! $document instanceof $class ) {
+				throw new BundleValidationException( "Expected {$class} document." );
+			}
+		}
+		usort( $documents, fn( $a, $b ) => strcmp( $a->slug(), $b->slug() ) );
+		return $documents;
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Agent bundle flow file value object.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable representation of flows/<slug>.json schema_version 1.
+ */
+final class AgentBundleFlowFile {
+
+	private string $slug;
+	private string $name;
+	private string $pipeline_slug;
+	private string $schedule;
+	private array $max_items;
+	private array $steps;
+
+	public function __construct( string $slug, string $name, string $pipeline_slug, string $schedule, array $max_items, array $steps ) {
+		$this->slug          = PortableSlug::normalize( $slug, 'flow' );
+		$this->name          = $name;
+		$this->pipeline_slug = PortableSlug::normalize( $pipeline_slug, 'pipeline' );
+		$this->schedule      = $schedule;
+		$this->max_items     = $max_items;
+		$this->steps         = self::validate_steps( $steps );
+	}
+
+	public static function from_array( array $data ): self {
+		BundleSchema::assert_supported_version( $data, 'flow file' );
+		foreach ( array( 'slug', 'name', 'pipeline_slug', 'schedule', 'max_items', 'steps' ) as $field ) {
+			if ( ! array_key_exists( $field, $data ) ) {
+				throw new BundleValidationException( "flow file is missing required field {$field}." );
+			}
+		}
+
+		if ( ! is_array( $data['max_items'] ) || ! is_array( $data['steps'] ) || ! array_is_list( $data['steps'] ) ) {
+			throw new BundleValidationException( 'flow file max_items must be an object and steps must be a list.' );
+		}
+
+		return new self( (string) $data['slug'], (string) $data['name'], (string) $data['pipeline_slug'], (string) $data['schedule'], $data['max_items'], $data['steps'] );
+	}
+
+	public function to_array(): array {
+		return array(
+			'schema_version' => BundleSchema::VERSION,
+			'slug'           => $this->slug,
+			'name'           => $this->name,
+			'pipeline_slug'  => $this->pipeline_slug,
+			'schedule'       => $this->schedule,
+			'max_items'      => $this->max_items,
+			'steps'          => $this->steps,
+		);
+	}
+
+	public function slug(): string {
+		return $this->slug;
+	}
+
+	private static function validate_steps( array $steps ): array {
+		$normalized = array();
+		foreach ( $steps as $step ) {
+			if ( ! is_array( $step ) ) {
+				throw new BundleValidationException( 'flow file steps must contain objects.' );
+			}
+			foreach ( array( 'step_position', 'handler_configs' ) as $field ) {
+				if ( ! array_key_exists( $field, $step ) ) {
+					throw new BundleValidationException( "flow file step is missing required field {$field}." );
+				}
+			}
+			if ( ! is_array( $step['handler_configs'] ) ) {
+				throw new BundleValidationException( 'flow file handler_configs must be an object.' );
+			}
+
+			$normalized_step = array(
+				'step_position'   => (int) $step['step_position'],
+				'handler_configs' => $step['handler_configs'],
+			);
+
+			if ( array_key_exists( 'handler_slug', $step ) ) {
+				$normalized_step['handler_slug'] = (string) $step['handler_slug'];
+			}
+			if ( array_key_exists( 'handler_slugs', $step ) ) {
+				if ( ! is_array( $step['handler_slugs'] ) || ! array_is_list( $step['handler_slugs'] ) ) {
+					throw new BundleValidationException( 'flow file handler_slugs must be a list.' );
+				}
+				$normalized_step['handler_slugs'] = array_values( array_map( 'strval', $step['handler_slugs'] ) );
+			}
+
+			$normalized[] = $normalized_step;
+		}
+
+		usort( $normalized, fn( $a, $b ) => $a['step_position'] <=> $b['step_position'] );
+
+		return $normalized;
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Agent bundle manifest value object.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable representation of manifest.json schema_version 1.
+ */
+final class AgentBundleManifest {
+
+	private string $exported_at;
+	private string $exported_by;
+	private array $agent;
+	private array $included;
+
+	public function __construct( string $exported_at, string $exported_by, array $agent, array $included ) {
+		$this->exported_at = $exported_at;
+		$this->exported_by = $exported_by;
+		$this->agent       = self::validate_agent( $agent );
+		$this->included    = self::validate_included( $included );
+	}
+
+	/**
+	 * Build from decoded manifest.json data.
+	 *
+	 * @param array $data Manifest data.
+	 * @return self
+	 */
+	public static function from_array( array $data ): self {
+		BundleSchema::assert_supported_version( $data, 'manifest.json' );
+
+		foreach ( array( 'exported_at', 'exported_by', 'agent', 'included' ) as $field ) {
+			if ( ! array_key_exists( $field, $data ) ) {
+				throw new BundleValidationException( "manifest.json is missing required field {$field}." );
+			}
+		}
+
+		if ( ! is_array( $data['agent'] ) || ! is_array( $data['included'] ) ) {
+			throw new BundleValidationException( 'manifest.json agent and included fields must be objects.' );
+		}
+
+		return new self( (string) $data['exported_at'], (string) $data['exported_by'], $data['agent'], $data['included'] );
+	}
+
+	/**
+	 * Convert to manifest.json data.
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		return array(
+			'schema_version' => BundleSchema::VERSION,
+			'exported_at'    => $this->exported_at,
+			'exported_by'    => $this->exported_by,
+			'agent'          => $this->agent,
+			'included'       => $this->included,
+		);
+	}
+
+	public function agent_slug(): string {
+		return (string) $this->agent['slug'];
+	}
+
+	private static function validate_agent( array $agent ): array {
+		foreach ( array( 'slug', 'label', 'description', 'agent_config' ) as $field ) {
+			if ( ! array_key_exists( $field, $agent ) ) {
+				throw new BundleValidationException( "manifest.json agent is missing required field {$field}." );
+			}
+		}
+
+		$agent['slug']        = PortableSlug::normalize( (string) $agent['slug'], 'agent' );
+		$agent['label']       = (string) $agent['label'];
+		$agent['description'] = (string) $agent['description'];
+		if ( ! is_array( $agent['agent_config'] ) ) {
+			throw new BundleValidationException( 'manifest.json agent.agent_config must be an object.' );
+		}
+
+		return array(
+			'slug'         => $agent['slug'],
+			'label'        => $agent['label'],
+			'description'  => $agent['description'],
+			'agent_config' => $agent['agent_config'],
+		);
+	}
+
+	private static function validate_included( array $included ): array {
+		foreach ( array( 'memory', 'pipelines', 'flows', 'handler_auth' ) as $field ) {
+			if ( ! array_key_exists( $field, $included ) ) {
+				throw new BundleValidationException( "manifest.json included is missing required field {$field}." );
+			}
+		}
+
+		foreach ( array( 'memory', 'pipelines', 'flows' ) as $field ) {
+			if ( ! is_array( $included[ $field ] ) || ! array_is_list( $included[ $field ] ) ) {
+				throw new BundleValidationException( "manifest.json included.{$field} must be a list." );
+			}
+			$included[ $field ] = array_values( array_map( 'strval', $included[ $field ] ) );
+			sort( $included[ $field ], SORT_STRING );
+		}
+
+		$handler_auth = (string) $included['handler_auth'];
+		if ( ! in_array( $handler_auth, array( 'refs', 'full', 'omit' ), true ) ) {
+			throw new BundleValidationException( 'manifest.json included.handler_auth must be one of refs, full, or omit.' );
+		}
+		$included['handler_auth'] = $handler_auth;
+
+		return array(
+			'memory'       => $included['memory'],
+			'pipelines'    => $included['pipelines'],
+			'flows'        => $included['flows'],
+			'handler_auth' => $included['handler_auth'],
+		);
+	}
+}

--- a/inc/Engine/Bundle/AgentBundlePipelineFile.php
+++ b/inc/Engine/Bundle/AgentBundlePipelineFile.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Agent bundle pipeline file value object.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable representation of pipelines/<slug>.json schema_version 1.
+ */
+final class AgentBundlePipelineFile {
+
+	private string $slug;
+	private string $name;
+	private array $steps;
+
+	public function __construct( string $slug, string $name, array $steps ) {
+		$this->slug  = PortableSlug::normalize( $slug, 'pipeline' );
+		$this->name  = $name;
+		$this->steps = self::validate_steps( $steps );
+	}
+
+	public static function from_array( array $data ): self {
+		BundleSchema::assert_supported_version( $data, 'pipeline file' );
+		foreach ( array( 'slug', 'name', 'steps' ) as $field ) {
+			if ( ! array_key_exists( $field, $data ) ) {
+				throw new BundleValidationException( "pipeline file is missing required field {$field}." );
+			}
+		}
+
+		if ( ! is_array( $data['steps'] ) || ! array_is_list( $data['steps'] ) ) {
+			throw new BundleValidationException( 'pipeline file steps must be a list.' );
+		}
+
+		return new self( (string) $data['slug'], (string) $data['name'], $data['steps'] );
+	}
+
+	public function to_array(): array {
+		return array(
+			'schema_version' => BundleSchema::VERSION,
+			'slug'           => $this->slug,
+			'name'           => $this->name,
+			'steps'          => $this->steps,
+		);
+	}
+
+	public function slug(): string {
+		return $this->slug;
+	}
+
+	private static function validate_steps( array $steps ): array {
+		$normalized = array();
+		foreach ( $steps as $step ) {
+			if ( ! is_array( $step ) ) {
+				throw new BundleValidationException( 'pipeline file steps must contain objects.' );
+			}
+			foreach ( array( 'step_position', 'step_type', 'step_config' ) as $field ) {
+				if ( ! array_key_exists( $field, $step ) ) {
+					throw new BundleValidationException( "pipeline file step is missing required field {$field}." );
+				}
+			}
+			if ( ! is_array( $step['step_config'] ) ) {
+				throw new BundleValidationException( 'pipeline file step_config must be an object.' );
+			}
+
+			$normalized[] = array(
+				'step_position' => (int) $step['step_position'],
+				'step_type'     => (string) $step['step_type'],
+				'step_config'   => $step['step_config'],
+			);
+		}
+
+		usort( $normalized, fn( $a, $b ) => $a['step_position'] <=> $b['step_position'] );
+
+		return $normalized;
+	}
+}

--- a/inc/Engine/Bundle/BundleSchema.php
+++ b/inc/Engine/Bundle/BundleSchema.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Agent bundle schema constants and deterministic JSON helpers.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared schema constants for portable agent bundles.
+ */
+final class BundleSchema {
+
+	public const VERSION = 1;
+
+	public const MANIFEST_FILE = 'manifest.json';
+
+	public const MEMORY_DIR = 'memory';
+
+	public const PIPELINES_DIR = 'pipelines';
+
+	public const FLOWS_DIR = 'flows';
+
+	/**
+	 * Encode bundle JSON in a stable, review-friendly shape.
+	 *
+	 * @param array $data JSON-serializable data.
+	 * @return string JSON document ending with a newline.
+	 */
+	public static function encode_json( array $data ): string {
+		$encoded = wp_json_encode( self::sort_recursive( $data ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		if ( ! is_string( $encoded ) ) {
+			throw new BundleValidationException( 'Unable to encode bundle JSON.' );
+		}
+
+		return $encoded . "\n";
+	}
+
+	/**
+	 * Decode a bundle JSON document into an array.
+	 *
+	 * @param string $json JSON document.
+	 * @param string $label Human-readable file label for errors.
+	 * @return array
+	 */
+	public static function decode_json( string $json, string $label ): array {
+		$data = json_decode( $json, true );
+		if ( ! is_array( $data ) ) {
+			throw new BundleValidationException( sprintf( '%s is not valid JSON.', $label ) );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Validate supported schema_version.
+	 *
+	 * @param array  $data Document data.
+	 * @param string $label Human-readable document label.
+	 */
+	public static function assert_supported_version( array $data, string $label ): void {
+		$version = (int) ( $data['schema_version'] ?? 0 );
+		if ( self::VERSION !== $version ) {
+			throw new BundleValidationException(
+				sprintf( '%s uses unsupported schema_version %d; this Data Machine build supports schema_version %d.', $label, $version, self::VERSION )
+			);
+		}
+	}
+
+	/**
+	 * Sort associative arrays recursively while preserving list order.
+	 *
+	 * @param mixed $value Value to normalize.
+	 * @return mixed
+	 */
+	private static function sort_recursive( mixed $value ): mixed {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		foreach ( $value as $key => $child ) {
+			$value[ $key ] = self::sort_recursive( $child );
+		}
+
+		if ( ! array_is_list( $value ) ) {
+			ksort( $value, SORT_STRING );
+		}
+
+		return $value;
+	}
+}

--- a/inc/Engine/Bundle/BundleValidationException.php
+++ b/inc/Engine/Bundle/BundleValidationException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Agent bundle validation exception.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Raised when a bundle document does not match the supported schema.
+ */
+class BundleValidationException extends \InvalidArgumentException {}

--- a/inc/Engine/Bundle/PortableSlug.php
+++ b/inc/Engine/Bundle/PortableSlug.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Portable slug helpers for agent bundle filenames and references.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes stable bundle slugs without touching persistence.
+ */
+final class PortableSlug {
+
+	/**
+	 * Normalize a candidate slug/name for bundle paths.
+	 *
+	 * @param string $candidate Candidate slug or display name.
+	 * @param string $fallback  Fallback when candidate is empty after normalization.
+	 * @return string
+	 */
+	public static function normalize( string $candidate, string $fallback = 'item' ): string {
+		$slug = strtolower( trim( $candidate ) );
+		$slug = preg_replace( '/[^a-z0-9]+/', '-', $slug );
+		$slug = trim( (string) $slug, '-' );
+
+		if ( '' === $slug ) {
+			$slug = $fallback;
+		}
+
+		return $slug;
+	}
+
+	/**
+	 * Deduplicate a slug against already-used sibling slugs.
+	 *
+	 * @param string $slug Existing normalized slug.
+	 * @param array  $used Used sibling slugs.
+	 * @return string
+	 */
+	public static function dedupe( string $slug, array $used ): string {
+		$used_lookup = array_fill_keys( array_map( 'strval', $used ), true );
+		if ( ! isset( $used_lookup[ $slug ] ) ) {
+			return $slug;
+		}
+
+		$base = $slug;
+		$i    = 2;
+		while ( isset( $used_lookup[ "{$base}-{$i}" ] ) ) {
+			++$i;
+		}
+
+		return "{$base}-{$i}";
+	}
+}

--- a/tests/agent-bundle-format-smoke.php
+++ b/tests/agent-bundle-format-smoke.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Pure-PHP smoke test for agent bundle format value objects (#1303).
+ *
+ * Run with: php tests/agent-bundle-format-smoke.php
+ *
+ * Phase 2a defines the on-disk bundle format only: manifest schema,
+ * pipeline/flow JSON documents, deterministic directory read/write, and
+ * stable portable slug columns. It must not depend on WordPress runtime state
+ * or perform importer/exporter DB writes; those belong to later phases.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\AgentBundleFlowFile;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
+use DataMachine\Engine\Bundle\BundleSchema;
+use DataMachine\Engine\Bundle\BundleValidationException;
+use DataMachine\Engine\Bundle\PortableSlug;
+
+$GLOBALS['__agent_bundle_failures'] = 0;
+$GLOBALS['__agent_bundle_total']    = 0;
+
+function assert_bundle( string $label, bool $condition ): void {
+	++$GLOBALS['__agent_bundle_total'];
+	if ( $condition ) {
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	echo "  FAIL: {$label}\n";
+	++$GLOBALS['__agent_bundle_failures'];
+}
+
+function assert_bundle_equals( string $label, $expected, $actual ): void {
+	assert_bundle( $label, $expected === $actual );
+}
+
+function rm_tree( string $path ): void {
+	if ( ! is_dir( $path ) ) {
+		return;
+	}
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+	foreach ( $iterator as $file ) {
+		$file->isDir() ? rmdir( $file->getPathname() ) : unlink( $file->getPathname() );
+	}
+	rmdir( $path );
+}
+
+echo "=== Agent Bundle Format Smoke (#1303) ===\n";
+
+echo "\n[1] Portable slug normalization is deterministic\n";
+assert_bundle_equals( 'normalizes names to kebab-case', 'woocommerce-daily-ingest', PortableSlug::normalize( 'WooCommerce Daily Ingest!' ) );
+assert_bundle_equals( 'falls back for empty candidates', 'pipeline', PortableSlug::normalize( '!!!', 'pipeline' ) );
+assert_bundle_equals( 'dedupes sibling slugs with numeric suffix', 'daily-ingest-3', PortableSlug::dedupe( 'daily-ingest', array( 'daily-ingest', 'daily-ingest-2' ) ) );
+
+echo "\n[2] Manifest schema validates and normalizes included lists\n";
+$manifest = AgentBundleManifest::from_array(
+	array(
+		'schema_version' => 1,
+		'exported_at'    => '2026-04-26T15:30:00Z',
+		'exported_by'    => 'data-machine/0.84.0-test',
+		'agent'          => array(
+			'slug'         => 'WooCommerce Agent',
+			'label'        => 'WooCommerce Knowledge Keeper',
+			'description'  => 'Maintains the WooCommerce wiki.',
+			'agent_config' => array( 'model' => array( 'default' => 'gpt-5.5' ) ),
+		),
+		'included'       => array(
+			'memory'       => array( 'MEMORY.md', 'SOUL.md' ),
+			'pipelines'    => array( 'wc-weekly-lint', 'wc-daily-ingest' ),
+			'flows'        => array( 'wc-weekly-lint-flow', 'wc-daily-ingest-flow' ),
+			'handler_auth' => 'refs',
+		),
+	)
+);
+$manifest_array = $manifest->to_array();
+assert_bundle_equals( 'schema version pinned to v1', 1, $manifest_array['schema_version'] );
+assert_bundle_equals( 'agent slug normalized once', 'woocommerce-agent', $manifest_array['agent']['slug'] );
+assert_bundle_equals( 'included pipelines sorted for deterministic JSON', array( 'wc-daily-ingest', 'wc-weekly-lint' ), $manifest_array['included']['pipelines'] );
+assert_bundle_equals( 'handler_auth refs accepted', 'refs', $manifest_array['included']['handler_auth'] );
+
+echo "\n[3] Pipeline and flow documents sort steps by position\n";
+$pipeline = AgentBundlePipelineFile::from_array(
+	array(
+		'schema_version' => 1,
+		'slug'           => 'WC Daily Ingest',
+		'name'           => 'WooCommerce daily ingest',
+		'steps'          => array(
+			array(
+				'step_position' => 1,
+				'step_type'     => 'ai',
+				'step_config'   => array( 'label' => 'Extract', 'system_prompt' => 'Extract facts.' ),
+			),
+			array(
+				'step_position' => 0,
+				'step_type'     => 'fetch',
+				'step_config'   => array( 'label' => 'Fetch' ),
+			),
+		),
+	)
+);
+$pipeline_array = $pipeline->to_array();
+assert_bundle_equals( 'pipeline slug normalized', 'wc-daily-ingest', $pipeline_array['slug'] );
+assert_bundle_equals( 'pipeline step 0 first after normalization', 'fetch', $pipeline_array['steps'][0]['step_type'] );
+
+$flow = AgentBundleFlowFile::from_array(
+	array(
+		'schema_version' => 1,
+		'slug'           => 'WC Daily Ingest Flow',
+		'name'           => 'WC Daily Ingest',
+		'pipeline_slug'  => 'WC Daily Ingest',
+		'schedule'       => 'daily',
+		'max_items'      => array( 'mcp' => 5 ),
+		'steps'          => array(
+			array(
+				'step_position'   => 1,
+				'handler_slug'    => 'wordpress_publish',
+				'handler_configs' => array( 'wordpress_publish' => array( 'post_type' => 'wiki' ) ),
+			),
+			array(
+				'step_position'   => 0,
+				'handler_slug'    => 'mcp',
+				'handler_configs' => array( 'mcp' => array( 'auth_ref' => 'wpcom:default', 'provider' => 'mgs' ) ),
+			),
+		),
+	)
+);
+$flow_array = $flow->to_array();
+assert_bundle_equals( 'flow references pipeline by slug, not source ID', 'wc-daily-ingest', $flow_array['pipeline_slug'] );
+assert_bundle_equals( 'flow step 0 first after normalization', 'mcp', $flow_array['steps'][0]['handler_slug'] );
+
+echo "\n[4] Directory write/read round-trips without DB access\n";
+$bundle = new AgentBundleDirectory(
+	$manifest,
+	array(
+		'MEMORY.md'       => "# Memory\n",
+		'SOUL.md'         => "# Soul\n",
+		'daily/2026-04-26.md' => "# Daily\n",
+	),
+	array( $pipeline ),
+	array( $flow )
+);
+$tmp = sys_get_temp_dir() . '/datamachine-agent-bundle-' . getmypid();
+rm_tree( $tmp );
+$bundle->write( $tmp );
+
+assert_bundle( 'manifest.json written', is_file( $tmp . '/manifest.json' ) );
+assert_bundle( 'memory/SOUL.md written as markdown file', is_file( $tmp . '/memory/SOUL.md' ) );
+assert_bundle( 'pipeline file named by portable slug', is_file( $tmp . '/pipelines/wc-daily-ingest.json' ) );
+assert_bundle( 'flow file named by portable slug', is_file( $tmp . '/flows/wc-daily-ingest-flow.json' ) );
+
+$read = AgentBundleDirectory::read( $tmp );
+assert_bundle_equals( 'read manifest preserves agent slug', 'woocommerce-agent', $read->manifest()->agent_slug() );
+assert_bundle_equals( 'read memory files preserve nested daily file', "# Daily\n", $read->memory_files()['daily/2026-04-26.md'] ?? null );
+assert_bundle_equals( 'one pipeline read', 1, count( $read->pipelines() ) );
+assert_bundle_equals( 'one flow read', 1, count( $read->flows() ) );
+assert_bundle_equals( 'round-trip manifest array stable', $manifest->to_array(), $read->manifest()->to_array() );
+
+echo "\n[5] JSON output is stable and review-friendly\n";
+$encoded_manifest = file_get_contents( $tmp . '/manifest.json' );
+assert_bundle( 'pretty JSON contains newlines', false !== strpos( (string) $encoded_manifest, "\n    \"agent\"" ) );
+assert_bundle( 'JSON ends with newline', str_ends_with( (string) $encoded_manifest, "\n" ) );
+assert_bundle( 'JSON object keys are deterministically sorted', strpos( (string) $encoded_manifest, '"agent"' ) < strpos( (string) $encoded_manifest, '"exported_at"' ) );
+
+echo "\n[6] Unsupported schema versions fail clearly\n";
+$threw = false;
+try {
+	AgentBundleManifest::from_array(
+		array(
+			'schema_version' => 2,
+			'exported_at'    => '2026-04-26T15:30:00Z',
+			'exported_by'    => 'data-machine/next',
+			'agent'          => array(),
+			'included'       => array(),
+		)
+	);
+} catch ( BundleValidationException $e ) {
+	$threw = str_contains( $e->getMessage(), 'unsupported schema_version 2' );
+}
+assert_bundle( 'v2 manifest refused with clear message', $threw );
+
+echo "\n[7] Source schema exposes stable portable slug columns\n";
+$pipelines_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Pipelines/Pipelines.php' );
+$flows_source     = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Flows/Flows.php' );
+assert_bundle( 'pipelines table has portable_slug column', str_contains( (string) $pipelines_source, 'portable_slug varchar(191) DEFAULT NULL' ) );
+assert_bundle( 'pipelines table has agent-scoped portable_slug uniqueness', str_contains( (string) $pipelines_source, 'UNIQUE KEY agent_portable_slug (agent_id, portable_slug)' ) );
+assert_bundle( 'flows table has portable_slug column', str_contains( (string) $flows_source, 'portable_slug varchar(191) DEFAULT NULL' ) );
+assert_bundle( 'flows table has pipeline-scoped portable_slug uniqueness', str_contains( (string) $flows_source, 'UNIQUE KEY pipeline_portable_slug (pipeline_id, portable_slug)' ) );
+
+rm_tree( $tmp );
+
+$total    = (int) $GLOBALS['__agent_bundle_total'];
+$failures = (int) $GLOBALS['__agent_bundle_failures'];
+echo "\nTotal assertions: {$total}\n";
+// @phpstan-ignore-next-line Smoke assertions mutate this counter through a global helper.
+if ( getenv( 'DATAMACHINE_AGENT_BUNDLE_SMOKE_FORCE_FAILURE' ) || 0 !== $failures ) {
+	echo "Failures: {$failures}\n";
+	exit( 1 );
+}
+
+echo "All assertions passed.\n";


### PR DESCRIPTION
## Summary

- Defines the Phase 2a portable agent bundle substrate: directory layout, manifest schema, pipeline/flow JSON value objects, deterministic JSON encoding, and pure filesystem read/write.
- Adds stable `portable_slug` schema support for pipelines and flows so later exporter/importer phases can reference files by persistent slugs instead of install-local IDs.

## Changes

- Adds `DataMachine\Engine\Bundle` value objects for `manifest.json`, `pipelines/<slug>.json`, and `flows/<slug>.json` with schema_version v1 validation and forward-version refusal.
- Adds `AgentBundleDirectory` for DB-free bundle directory read/write using `manifest.json`, `memory/`, `pipelines/`, and `flows/`.
- Adds `PortableSlug` helpers for deterministic slug normalization/deduping.
- Adds `portable_slug` columns and scoped unique keys to pipeline/flow table creation and migration paths.
- Adds a pure-PHP smoke test covering schema validation, deterministic ordering, directory round-trip, forward-version refusal, and schema-column presence.

## Tests

- `php tests/agent-bundle-format-smoke.php` ✅ 28 assertions
- `php -l` on changed PHP files ✅
- `homeboy test data-machine --path .` ✅
- `homeboy lint data-machine --path .` ⚠️ existing repo lint/PHPStan backlog remains (6255 findings, primarily WP unit-test stubs and existing smoke static-analysis issues)

Closes #1303
Refs #1137

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Phase 2a schema/value objects, smoke coverage, verification, and PR preparation for Chris to review.
