### PR TITLE
fix(workflow): protect engine configs from initial data

### DIFF
--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -99,7 +99,7 @@ class ExecuteWorkflowAbility {
 	public function execute( array $input ): array {
 		$workflow     = $input['workflow'] ?? null;
 		$timestamp    = $input['timestamp'] ?? null;
-		$initial_data = $input['initial_data'] ?? null;
+		$initial_data = is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array();
 
 		// Validate workflow structure
 		$validation = $this->validateWorkflow( $workflow );
@@ -125,11 +125,9 @@ class ExecuteWorkflowAbility {
 			'label'       => 'Chat Workflow',
 		);
 
-		if ( is_array( $initial_data ) ) {
-			$initial_parent_job_id = (int) ( $initial_data['parent_job_id'] ?? 0 );
-			if ( $initial_parent_job_id > 0 ) {
-				$create_args['parent_job_id'] = $initial_parent_job_id;
-			}
+		$initial_parent_job_id = (int) ( $initial_data['parent_job_id'] ?? 0 );
+		if ( $initial_parent_job_id > 0 ) {
+			$create_args['parent_job_id'] = $initial_parent_job_id;
 		}
 
 		$job_id = $this->db_jobs->create_job( $create_args );
@@ -141,15 +139,10 @@ class ExecuteWorkflowAbility {
 			);
 		}
 
-		// Build engine data with configs and optional initial data
-		$engine_data = array(
-			'flow_config'     => $configs['flow_config'],
-			'pipeline_config' => $configs['pipeline_config'],
-		);
-
-		if ( ! empty( $initial_data ) && is_array( $initial_data ) ) {
-			$engine_data = array_merge( $engine_data, $initial_data );
-		}
+		// Build engine data with caller data underneath engine-owned configs.
+		$engine_data                    = $initial_data;
+		$engine_data['flow_config']     = $configs['flow_config'];
+		$engine_data['pipeline_config'] = $configs['pipeline_config'];
 
 		// Mirror RunFlowAbility's engine_data['job'] shape so downstream
 		// step types (AIStep, SystemTaskStep) can read job + agent

--- a/tests/execute-workflow-initial-data-contract-smoke.php
+++ b/tests/execute-workflow-initial-data-contract-smoke.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Pure-PHP smoke test for ExecuteWorkflowAbility initial_data contracts.
+ *
+ * Run with: php tests/execute-workflow-initial-data-contract-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/**
+ * Mirror of ExecuteWorkflowAbility::execute()'s create_args parent link.
+ */
+function build_execute_workflow_create_args_for_contract_test( array $initial_data ): array {
+	$args = array(
+		'pipeline_id' => 'direct',
+		'flow_id'     => 'direct',
+		'source'      => 'chat',
+		'label'       => 'Chat Workflow',
+	);
+
+	$initial_parent_job_id = (int) ( $initial_data['parent_job_id'] ?? 0 );
+	if ( $initial_parent_job_id > 0 ) {
+		$args['parent_job_id'] = $initial_parent_job_id;
+	}
+
+	return $args;
+}
+
+/**
+ * Mirror of ExecuteWorkflowAbility::execute()'s engine data assembly.
+ */
+function build_execute_workflow_engine_data_for_contract_test( int $job_id, array $configs, array $initial_data ): array {
+	$engine_data                    = $initial_data;
+	$engine_data['flow_config']     = $configs['flow_config'];
+	$engine_data['pipeline_config'] = $configs['pipeline_config'];
+
+	$caller_snapshot = is_array( $engine_data['job'] ?? null ) ? $engine_data['job'] : array();
+	$job_snapshot    = array_merge(
+		array( 'user_id' => (int) ( $initial_data['user_id'] ?? 0 ) ),
+		$caller_snapshot,
+		array( 'job_id' => $job_id )
+	);
+	if ( ! empty( $initial_data['agent_id'] ) && empty( $job_snapshot['agent_id'] ) ) {
+		$job_snapshot['agent_id'] = (int) $initial_data['agent_id'];
+	}
+	$engine_data['job'] = $job_snapshot;
+
+	return $engine_data;
+}
+
+function dm_assert_same( $expected, $actual, string $msg ): void {
+	if ( $expected === $actual ) {
+		echo "  [PASS] {$msg}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$msg}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	exit( 1 );
+}
+
+echo "=== execute-workflow-initial-data-contract-smoke ===\n";
+
+$generated_flow_config = array(
+	'ephemeral_step_0' => array(
+		'flow_step_id'     => 'ephemeral_step_0',
+		'pipeline_step_id' => 'ephemeral_pipeline_0',
+		'step_type'        => 'system_task',
+		'execution_order'  => 0,
+	),
+);
+
+$generated_pipeline_config = array(
+	'ephemeral_pipeline_0' => array(
+		'system_prompt' => 'generated system prompt',
+	),
+);
+
+$configs = array(
+	'flow_config'     => $generated_flow_config,
+	'pipeline_config' => $generated_pipeline_config,
+);
+
+echo "\n[1] engine-owned configs win over initial_data\n";
+$initial_data = array(
+	'flow_config'     => array( 'poisoned_flow' => array( 'execution_order' => 999 ) ),
+	'pipeline_config' => array( 'poisoned_pipeline' => array( 'system_prompt' => 'caller override' ) ),
+	'parent_job_id'   => 64,
+	'agent_id'        => 2,
+	'user_id'         => 1,
+	'job'             => array(
+		'user_id' => 1,
+	),
+	'task_type'       => 'wiki_maintain_article',
+);
+
+$engine_data = build_execute_workflow_engine_data_for_contract_test( 100, $configs, $initial_data );
+dm_assert_same( $generated_flow_config, $engine_data['flow_config'], 'generated flow_config is preserved' );
+dm_assert_same( false, isset( $engine_data['flow_config']['poisoned_flow'] ), 'caller flow_config is not retained' );
+dm_assert_same( $generated_pipeline_config, $engine_data['pipeline_config'], 'generated pipeline_config is preserved' );
+dm_assert_same( false, isset( $engine_data['pipeline_config']['poisoned_pipeline'] ), 'caller pipeline_config is not retained' );
+dm_assert_same( 'wiki_maintain_article', $engine_data['task_type'], 'non-reserved initial_data remains available' );
+
+echo "\n[2] parent_job_id still routes to create_job args\n";
+$create_args = build_execute_workflow_create_args_for_contract_test( $initial_data );
+dm_assert_same( 64, $create_args['parent_job_id'] ?? null, 'parent_job_id preserved for indexed job linkage' );
+
+echo "\n[3] flat identity fields still route into the job snapshot\n";
+dm_assert_same( 2, $engine_data['agent_id'], 'flat agent_id remains in engine_data' );
+dm_assert_same( 1, $engine_data['user_id'], 'flat user_id remains in engine_data' );
+dm_assert_same( 100, $engine_data['job']['job_id'], 'authoritative job_id wins in job snapshot' );
+dm_assert_same( 2, $engine_data['job']['agent_id'], 'flat agent_id fills missing job.agent_id' );
+dm_assert_same( 1, $engine_data['job']['user_id'], 'job.user_id preserved from caller snapshot' );
+
+echo "\n[4] caller job snapshot identity is preserved when provided\n";
+$initial_data_with_snapshot = array(
+	'agent_id' => 2,
+	'user_id'  => 1,
+	'job'      => array(
+		'agent_id' => 9,
+		'user_id'  => 8,
+		'job_id'   => 777,
+	),
+);
+$engine_data_with_snapshot = build_execute_workflow_engine_data_for_contract_test( 101, $configs, $initial_data_with_snapshot );
+dm_assert_same( 9, $engine_data_with_snapshot['job']['agent_id'], 'caller job.agent_id remains authoritative over flat agent_id' );
+dm_assert_same( 8, $engine_data_with_snapshot['job']['user_id'], 'caller job.user_id remains authoritative over flat user_id' );
+dm_assert_same( 101, $engine_data_with_snapshot['job']['job_id'], 'engine job_id remains authoritative over caller job.job_id' );
+
+echo "\n=== execute-workflow-initial-data-contract-smoke: ALL PASS ===\n";

--- a/tests/system-task-agent-context-smoke.php
+++ b/tests/system-task-agent-context-smoke.php
@@ -71,14 +71,9 @@ function build_task_scheduler_initial_data(
  * Mirror of ExecuteWorkflowAbility::execute() engine_data['job'] shape.
  */
 function build_engine_data_job_snapshot( int $job_id, array $initial_data ): array {
-	$engine_data = array(
-		'flow_config'     => array(),
-		'pipeline_config' => array(),
-	);
-
-	if ( ! empty( $initial_data ) && is_array( $initial_data ) ) {
-		$engine_data = array_merge( $engine_data, $initial_data );
-	}
+	$engine_data                    = $initial_data;
+	$engine_data['flow_config']     = array();
+	$engine_data['pipeline_config'] = array();
 
 	$job_snapshot = is_array( $engine_data['job'] ?? null ) ? $engine_data['job'] : array();
 	$job_snapshot = array_merge(


### PR DESCRIPTION
## Summary
- Protect ephemeral workflow engine-owned config keys from caller-provided `initial_data`.
- Keep TaskScheduler identity/linkage data flowing through `parent_job_id`, `agent_id`, `user_id`, and the caller job snapshot.

## Changes
- Normalize non-array `initial_data` to an empty array before engine assembly.
- Build engine data from caller data first, then write generated `flow_config` and `pipeline_config` so workflow config remains authoritative.
- Add a focused pure-PHP smoke covering reserved config keys and identity/linkage preservation.
- Update the existing system-task agent-context smoke mirror to match the corrected engine-data assembly order.

## Tests
- `php tests/execute-workflow-initial-data-contract-smoke.php`
- `php tests/system-task-agent-context-smoke.php`
- `php tests/task-scheduler-batch-parent-link-smoke.php`
- `php tests/system-task-config-passthrough-smoke.php`
- `php -l inc/Abilities/Job/ExecuteWorkflowAbility.php`
- `php -l tests/execute-workflow-initial-data-contract-smoke.php`
- `php -l tests/system-task-agent-context-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-workflow-initial-data-contract --changed-since origin/main`

`homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-workflow-initial-data-contract` hit the known WordPress extension runner issue `PLUGIN_PATH: unbound variable` before reporting findings; no lint findings were returned. Tracked upstream as Extra-Chill/homeboy-extensions#296.

Closes #1341

## Follow-ups
None.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the workflow contract fix, tests, and PR description; Chris remains responsible for review and merge.
