### PR TITLE
refactor(batch): declare completion strategy

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -84,7 +84,8 @@ class PipelineBatchScheduler {
 				'next_flow_step_id' => $next_flow_step_id,
 				'engine_snapshot'   => $engine_snapshot,
 			),
-			self::BATCH_CONTEXT
+			self::BATCH_CONTEXT,
+			BatchScheduler::COMPLETION_STRATEGY_CHILDREN_COMPLETE
 		);
 
 		// Surface next_flow_step_id at the top level for legacy consumers

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -42,6 +42,16 @@ defined( 'ABSPATH' ) || exit;
 class BatchScheduler {
 
 	/**
+	 * Parent completes after all child jobs complete.
+	 */
+	public const COMPLETION_STRATEGY_CHILDREN_COMPLETE = 'children_complete';
+
+	/**
+	 * Parent completes after all chunks have scheduled their work.
+	 */
+	public const COMPLETION_STRATEGY_CHUNKS_SCHEDULED = 'chunks_scheduled';
+
+	/**
 	 * Default chunk size when settings are unavailable.
 	 *
 	 * Used as a last-resort fallback only. The live value is read from
@@ -118,6 +128,7 @@ class BatchScheduler {
 	 *   batch_scheduled    => 0,
 	 *   batch_chunk_size   => 10,
 	 *   batch_context      => 'pipeline' | 'task' | ...,
+	 *   batch_completion_strategy => 'children_complete' | 'chunks_scheduled' | ...,
 	 *   started_at         => 'YYYY-MM-DD HH:MM:SS',
 	 *   batch_state        => array(
 	 *       offset       => 0,
@@ -131,6 +142,7 @@ class BatchScheduler {
 	 * @param array  $items         Raw work items. Shape is consumer-defined.
 	 * @param array  $extra         Arbitrary per-batch state cloned to chunks (engine_snapshot, task_type, ...).
 	 * @param string $context       Consumer context, used for chunk-size/delay filter dispatch.
+	 * @param string $completion_strategy Declared parent-completion strategy.
 	 * @return array{parent_job_id:int,total:int,chunk_size:int} Batch summary.
 	 */
 	public static function start(
@@ -138,7 +150,8 @@ class BatchScheduler {
 		string $hook,
 		array $items,
 		array $extra = array(),
-		string $context = ''
+		string $context = '',
+		string $completion_strategy = ''
 	): array {
 		$total      = count( $items );
 		$chunk_size = self::chunkSize( $context );
@@ -146,13 +159,14 @@ class BatchScheduler {
 		datamachine_merge_engine_data(
 			$parent_job_id,
 			array(
-				'batch'            => true,
-				'batch_total'      => $total,
-				'batch_scheduled'  => 0,
-				'batch_chunk_size' => $chunk_size,
-				'batch_context'    => $context,
-				'started_at'       => current_time( 'mysql' ),
-				'batch_state'      => array(
+				'batch'                     => true,
+				'batch_total'               => $total,
+				'batch_scheduled'           => 0,
+				'batch_chunk_size'          => $chunk_size,
+				'batch_context'             => $context,
+				'batch_completion_strategy' => $completion_strategy,
+				'started_at'                => current_time( 'mysql' ),
+				'batch_state'               => array(
 					'offset' => 0,
 					'total'  => $total,
 					'items'  => $items,

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -276,7 +276,8 @@ class TaskScheduler {
 				'batch_id'             => $batch_id,
 				'caller_parent_job_id' => $caller_parent_job_id,
 			),
-			self::BATCH_CONTEXT
+			self::BATCH_CONTEXT,
+			BatchScheduler::COMPLETION_STRATEGY_CHUNKS_SCHEDULED
 		);
 
 		// Surface task-specific identifiers alongside the BatchScheduler
@@ -551,17 +552,18 @@ class TaskScheduler {
 		$total = (int) ( $engine_data['batch_total'] ?? $engine_data['total'] ?? 0 );
 
 		return array(
-			'batch_job_id'    => $batchJobId,
-			'task_type'       => $engine_data['task_type'] ?? '',
-			'total_items'     => $total,
-			'offset'          => $engine_data['offset'] ?? $engine_data['batch_offset'] ?? 0,
-			'chunk_size'      => $engine_data['batch_chunk_size'] ?? BatchScheduler::DEFAULT_CHUNK_SIZE,
-			'tasks_scheduled' => $engine_data['tasks_scheduled'] ?? $engine_data['batch_scheduled'] ?? 0,
-			'status'          => $job['status'] ?? '',
-			'started_at'      => $engine_data['started_at'] ?? '',
-			'completed_at'    => $engine_data['completed_at'] ?? '',
-			'cancelled'       => ! empty( $engine_data['cancelled'] ),
-			'child_jobs'      => array(
+			'batch_job_id'        => $batchJobId,
+			'task_type'           => $engine_data['task_type'] ?? '',
+			'completion_strategy' => $engine_data['batch_completion_strategy'] ?? '',
+			'total_items'         => $total,
+			'offset'              => $engine_data['offset'] ?? $engine_data['batch_offset'] ?? 0,
+			'chunk_size'          => $engine_data['batch_chunk_size'] ?? BatchScheduler::DEFAULT_CHUNK_SIZE,
+			'tasks_scheduled'     => $engine_data['tasks_scheduled'] ?? $engine_data['batch_scheduled'] ?? 0,
+			'status'              => $job['status'] ?? '',
+			'started_at'          => $engine_data['started_at'] ?? '',
+			'completed_at'        => $engine_data['completed_at'] ?? '',
+			'cancelled'           => ! empty( $engine_data['cancelled'] ),
+			'child_jobs'          => array(
 				'total'      => (int) ( $child_stats['total'] ?? 0 ),
 				'completed'  => (int) ( $child_stats['completed'] ?? 0 ),
 				'failed'     => (int) ( $child_stats['failed'] ?? 0 ),

--- a/tests/batch-completion-strategy-smoke.php
+++ b/tests/batch-completion-strategy-smoke.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Pure-PHP smoke test for explicit batch completion strategy metadata.
+ *
+ * Run with: php tests/batch-completion-strategy-smoke.php
+ *
+ * Verifies issue #1347's metadata-only contract: pipeline fan-out and
+ * system-task fan-out declare how their parent batch completes, while the
+ * existing completion paths remain unchanged.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+function dm_strategy_assert( bool $cond, string $msg ): void {
+	if ( $cond ) {
+		echo "  [PASS] {$msg}\n";
+		return;
+	}
+	echo "  [FAIL] {$msg}\n";
+	exit( 1 );
+}
+
+function dm_strategy_read( string $relative_path ): string {
+	$path = dirname( __DIR__ ) . '/' . $relative_path;
+	$body = file_get_contents( $path );
+	if ( false === $body ) {
+		echo "  [FAIL] could not read {$relative_path}\n";
+		exit( 1 );
+	}
+	return $body;
+}
+
+/**
+ * Mirror of BatchScheduler::start()'s top-level metadata shape.
+ */
+function build_batch_metadata( int $total, int $chunk_size, string $context, string $completion_strategy ): array {
+	return array(
+		'batch'                     => true,
+		'batch_total'               => $total,
+		'batch_scheduled'           => 0,
+		'batch_chunk_size'          => $chunk_size,
+		'batch_context'             => $context,
+		'batch_completion_strategy' => $completion_strategy,
+	);
+}
+
+/**
+ * Mirror of TaskScheduler::getBatchStatus()'s exposed strategy field.
+ */
+function build_task_batch_status_strategy( array $engine_data ): string {
+	return $engine_data['batch_completion_strategy'] ?? '';
+}
+
+echo "=== batch-completion-strategy-smoke ===\n";
+
+$batch_scheduler   = dm_strategy_read( 'inc/Core/ActionScheduler/BatchScheduler.php' );
+$pipeline_batch    = dm_strategy_read( 'inc/Abilities/Engine/PipelineBatchScheduler.php' );
+$task_scheduler    = dm_strategy_read( 'inc/Engine/Tasks/TaskScheduler.php' );
+$children_strategy = 'children_complete';
+$chunks_strategy   = 'chunks_scheduled';
+
+// -----------------------------------------------------------------
+echo "\n[1] BatchScheduler declares and stores completion strategy metadata\n";
+dm_strategy_assert(
+	str_contains( $batch_scheduler, "COMPLETION_STRATEGY_CHILDREN_COMPLETE = '{$children_strategy}'" ),
+	'children_complete strategy constant exists'
+);
+dm_strategy_assert(
+	str_contains( $batch_scheduler, "COMPLETION_STRATEGY_CHUNKS_SCHEDULED = '{$chunks_strategy}'" ),
+	'chunks_scheduled strategy constant exists'
+);
+dm_strategy_assert(
+	str_contains( $batch_scheduler, "'batch_completion_strategy' => \$completion_strategy" ),
+	'BatchScheduler::start stores batch_completion_strategy in engine_data'
+);
+
+$metadata = build_batch_metadata( 25, 10, 'pipeline', $children_strategy );
+dm_strategy_assert( true === $metadata['batch'], 'metadata still marks the parent as a batch' );
+dm_strategy_assert( 25 === $metadata['batch_total'], 'metadata still stores batch_total' );
+dm_strategy_assert( 0 === $metadata['batch_scheduled'], 'metadata still initializes batch_scheduled to 0' );
+dm_strategy_assert( 10 === $metadata['batch_chunk_size'], 'metadata still stores batch_chunk_size' );
+dm_strategy_assert( 'pipeline' === $metadata['batch_context'], 'metadata still stores batch_context' );
+dm_strategy_assert( $children_strategy === $metadata['batch_completion_strategy'], 'metadata stores declared completion strategy' );
+
+// -----------------------------------------------------------------
+echo "\n[2] Pipeline fan-out declares children_complete\n";
+dm_strategy_assert(
+	str_contains( $pipeline_batch, 'BatchScheduler::COMPLETION_STRATEGY_CHILDREN_COMPLETE' ),
+	'PipelineBatchScheduler::fanOut passes children_complete to BatchScheduler::start'
+);
+dm_strategy_assert(
+	str_contains( $pipeline_batch, 'public static function onChildComplete' ),
+	'pipeline completion still lives in onChildComplete()'
+);
+dm_strategy_assert(
+	str_contains( $pipeline_batch, '$active > 0 || $total_children < $batch_total' ),
+	'pipeline parent still waits for children to finish and all children to be scheduled'
+);
+dm_strategy_assert(
+	str_contains( $pipeline_batch, '$jobs_db->complete_job( (int) $parent_job_id, $parent_status );' ),
+	'pipeline parent status is still completed from child aggregation'
+);
+
+// -----------------------------------------------------------------
+echo "\n[3] System-task fan-out declares chunks_scheduled\n";
+dm_strategy_assert(
+	str_contains( $task_scheduler, 'BatchScheduler::COMPLETION_STRATEGY_CHUNKS_SCHEDULED' ),
+	'TaskScheduler::scheduleBatch passes chunks_scheduled to BatchScheduler::start'
+);
+dm_strategy_assert(
+	str_contains( $task_scheduler, "if ( ! \$result['more'] )" ),
+	'task batch still completes on the final chunk path'
+);
+dm_strategy_assert(
+	str_contains( $task_scheduler, '$jobs_db->complete_job( $parent_job_id, JobStatus::COMPLETED );' ),
+	'task batch parent still completes after chunks are scheduled'
+);
+
+$metadata = build_batch_metadata( 25, 10, 'task', $chunks_strategy );
+dm_strategy_assert( 'task' === $metadata['batch_context'], 'task metadata still stores batch_context=task' );
+dm_strategy_assert( $chunks_strategy === $metadata['batch_completion_strategy'], 'task metadata stores chunks_scheduled strategy' );
+
+// -----------------------------------------------------------------
+echo "\n[4] Task batch status exposes strategy without changing behavior\n";
+dm_strategy_assert(
+	str_contains( $task_scheduler, "'completion_strategy' => \$engine_data['batch_completion_strategy'] ?? ''" ),
+	'getBatchStatus exposes completion_strategy from engine_data'
+);
+dm_strategy_assert( $chunks_strategy === build_task_batch_status_strategy( $metadata ), 'status helper resolves stored strategy' );
+dm_strategy_assert( '' === build_task_batch_status_strategy( array() ), 'missing legacy strategy resolves to empty string' );
+
+echo "\n=== batch-completion-strategy-smoke: ALL PASS ===\n";


### PR DESCRIPTION
## Summary
- Adds explicit batch completion strategy metadata so pipeline and system-task fan-out no longer rely only on `batch_context` to communicate parent completion semantics.
- Keeps existing completion behavior unchanged: pipeline parents still complete from child aggregation, while task batch parents still complete after the final chunk schedules work.

## Changes
- Adds `BatchScheduler::COMPLETION_STRATEGY_CHILDREN_COMPLETE` and `COMPLETION_STRATEGY_CHUNKS_SCHEDULED` constants.
- Stores `batch_completion_strategy` on batch parent `engine_data` from `BatchScheduler::start()`.
- Declares `children_complete` for `PipelineBatchScheduler` and `chunks_scheduled` for `TaskScheduler`.
- Exposes the strategy from `TaskScheduler::getBatchStatus()`.
- Adds a pure-PHP smoke test covering metadata shape, consumer declarations, and unchanged completion paths.

## Tests
- `php tests/batch-completion-strategy-smoke.php`
- `php tests/task-scheduler-batch-parent-link-smoke.php`
- `php tests/batch-child-agent-id-smoke.php`
- `php -l inc/Core/ActionScheduler/BatchScheduler.php`
- `php -l inc/Abilities/Engine/PipelineBatchScheduler.php`
- `php -l inc/Engine/Tasks/TaskScheduler.php`
- `php -l tests/batch-completion-strategy-smoke.php`
- `git diff --check`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@refactor-batch-completion-strategy --changed-since origin/main`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@refactor-batch-completion-strategy` currently exits before findings with the known WordPress runner `PLUGIN_PATH: unbound variable` issue (tracked upstream as Extra-Chill/homeboy-extensions#296).

Closes #1347

## Follow-ups
None.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the batch completion strategy metadata, tests, and PR description; Chris remains responsible for review and merge.