### PR TITLE
refactor(flow): centralize step config scaffolding

### DIFF
--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -20,6 +20,7 @@ use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Core\Steps\FlowStepConfigFactory;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -72,34 +73,32 @@ trait FlowHelpers {
 
 			$disabled_tools = $pipeline_config[ $pipeline_step_id ]['disabled_tools'] ?? array();
 
-			$step_type   = $step['step_type'] ?? '';
-			$step_config = array(
-				'flow_step_id'     => $flow_step_id,
-				'step_type'        => $step_type,
-				'pipeline_step_id' => $pipeline_step_id,
-				'pipeline_id'      => $pipeline_id,
-				'flow_id'          => $flow_id,
-				'execution_order'  => $step['execution_order'] ?? 0,
-				'disabled_tools'   => $disabled_tools,
-				'handler'          => null,
-				// queue_mode is the access pattern enum that drives both
-				// AI (prompt_queue) and Fetch (config_patch_queue)
-				// consumption (#1291). Default "static" preserves
-				// "first-entry-wins-every-tick" semantics for any
-				// freshly-scaffolded step.
-				'queue_mode'       => 'static',
-			);
+			$step_type            = $step['step_type'] ?? '';
+			$queue_field_defaults = ( 'fetch' === $step_type )
+				? array( 'config_patch_queue' => array() )
+				: array( 'prompt_queue' => array() );
 
-			// Fetch consumes from config_patch_queue (#1292); other
-			// step types that consume the queue use prompt_queue. Steps
-			// that have no queueable consumer don't need either field
-			// initialized — it's lazy-created by QueueAbility on first
-			// write.
-			if ( 'fetch' === $step_type ) {
-				$step_config['config_patch_queue'] = array();
-			} else {
-				$step_config['prompt_queue'] = array();
-			}
+			$step_config = FlowStepConfigFactory::build(
+				array_merge(
+					array(
+						'flow_step_id'     => $flow_step_id,
+						'step_type'        => $step_type,
+						'pipeline_step_id' => $pipeline_step_id,
+						'pipeline_id'      => $pipeline_id,
+						'flow_id'          => $flow_id,
+						'execution_order'  => $step['execution_order'] ?? 0,
+						'disabled_tools'   => $disabled_tools,
+						'handler'          => null,
+						// queue_mode is the access pattern enum that drives both
+						// AI (prompt_queue) and Fetch (config_patch_queue)
+						// consumption (#1291). Default "static" preserves
+						// "first-entry-wins-every-tick" semantics for any
+						// freshly-scaffolded step.
+						'queue_mode'       => 'static',
+					),
+					$queue_field_defaults
+				)
+			);
 
 			$flow_config[ $flow_step_id ] = $step_config;
 		}

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -12,7 +12,7 @@
 namespace DataMachine\Abilities\Job;
 
 use DataMachine\Abilities\StepTypeAbilities;
-use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Core\Steps\FlowStepConfigFactory;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -373,30 +373,22 @@ class ExecuteWorkflowAbility {
 				);
 			}
 
-			$flow_step_config = array(
-				'flow_step_id'     => $step_id,
-				'pipeline_step_id' => $pipeline_step_id,
-				'step_type'        => $step['type'],
-				'execution_order'  => $index,
-				'enabled_tools'    => $enabled_tools,
-				'prompt_queue'     => $prompt_queue,
-				'queue_mode'       => 'static',
-				'disabled_tools'   => $step['disabled_tools'] ?? array(),
-				'pipeline_id'      => 'direct',
-				'flow_id'          => 'direct',
+			$flow_step_config = FlowStepConfigFactory::build(
+				array(
+					'flow_step_id'     => $step_id,
+					'pipeline_step_id' => $pipeline_step_id,
+					'step_type'        => $step_type,
+					'execution_order'  => $index,
+					'enabled_tools'    => $enabled_tools,
+					'prompt_queue'     => $prompt_queue,
+					'queue_mode'       => 'static',
+					'disabled_tools'   => $step['disabled_tools'] ?? array(),
+					'pipeline_id'      => 'direct',
+					'flow_id'          => 'direct',
+					'handler_slug'     => $handler_slug,
+					'handler_config'   => $handler_config,
+				)
 			);
-
-			if ( ! empty( $handler_slug ) ) {
-				if ( FlowStepConfig::isMultiHandler( $flow_step_config ) ) {
-					$flow_step_config['handler_slugs']   = array( $handler_slug );
-					$flow_step_config['handler_configs'] = array( $handler_slug => $handler_config );
-				} else {
-					$flow_step_config['handler_slug']   = $handler_slug;
-					$flow_step_config['handler_config'] = $handler_config;
-				}
-			} elseif ( ! FlowStepConfig::usesHandler( $flow_step_config ) && ! empty( $handler_config ) ) {
-				$flow_step_config['handler_config'] = $handler_config;
-			}
 
 			$flow_config[ $step_id ] = $flow_step_config;
 

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Flow step config factory.
+ *
+ * @package DataMachine\Core\Steps
+ */
+
+namespace DataMachine\Core\Steps;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds canonical flow step configuration rows from explicit inputs.
+ */
+class FlowStepConfigFactory {
+
+	/**
+	 * Build a canonical flow step configuration row.
+	 *
+	 * @param array $args Explicit config inputs.
+	 * @return array Flow step config row.
+	 */
+	public static function build( array $args ): array {
+		$step_config = array();
+		$copy_fields = array(
+			'flow_step_id'       => true,
+			'pipeline_step_id'   => true,
+			'step_type'          => true,
+			'execution_order'    => true,
+			'enabled_tools'      => true,
+			'disabled_tools'     => true,
+			'prompt_queue'       => true,
+			'config_patch_queue' => true,
+			'queue_mode'         => true,
+			'pipeline_id'        => true,
+			'flow_id'            => true,
+			'handler'            => true,
+		);
+
+		foreach ( $args as $field => $value ) {
+			if ( isset( $copy_fields[ $field ] ) ) {
+				$step_config[ $field ] = $value;
+			}
+		}
+
+		$handler_slug   = $args['handler_slug'] ?? '';
+		$handler_config = $args['handler_config'] ?? array();
+
+		if ( is_string( $handler_slug ) && '' !== $handler_slug ) {
+			if ( FlowStepConfig::isMultiHandler( $step_config ) ) {
+				$step_config['handler_slugs']   = array( $handler_slug );
+				$step_config['handler_configs'] = array( $handler_slug => $handler_config );
+			} else {
+				$step_config['handler_slug']   = $handler_slug;
+				$step_config['handler_config'] = $handler_config;
+			}
+		} elseif ( ! FlowStepConfig::usesHandler( $step_config ) && ! empty( $handler_config ) ) {
+			$step_config['handler_config'] = $handler_config;
+		}
+
+		return $step_config;
+	}
+}

--- a/tests/flow-step-config-factory-smoke.php
+++ b/tests/flow-step-config-factory-smoke.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Pure-PHP smoke test for FlowStepConfigFactory extraction.
+ *
+ * Run with: php tests/flow-step-config-factory-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_step_types' !== $hook ) {
+			return $value;
+		}
+
+		return array(
+			'ai'           => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'system_task'  => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'webhook_gate' => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'fetch'        => array( 'uses_handler' => true, 'multi_handler' => false ),
+			'publish'      => array( 'uses_handler' => true, 'multi_handler' => true ),
+			'upsert'       => array( 'uses_handler' => true, 'multi_handler' => true ),
+		);
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		// no-op for tests.
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
+
+use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Core\Steps\FlowStepConfigFactory;
+
+$failures = array();
+$passes   = 0;
+
+function assert_factory_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function legacy_workflow_step_config_for_test( array $step, int $index ): array {
+	$step_id          = "ephemeral_step_{$index}";
+	$pipeline_step_id = "ephemeral_pipeline_{$index}";
+	$handler_slug     = $step['handler_slug'] ?? '';
+	$handler_config   = $step['handler_config'] ?? array();
+	$step_type        = $step['type'];
+
+	$flow_step_config = array(
+		'flow_step_id'     => $step_id,
+		'pipeline_step_id' => $pipeline_step_id,
+		'step_type'        => $step_type,
+		'execution_order'  => $index,
+		'enabled_tools'    => ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
+			? array_values( $step['enabled_tools'] )
+			: array(),
+		'prompt_queue'     => $step['prompt_queue'] ?? array(),
+		'queue_mode'       => 'static',
+		'disabled_tools'   => $step['disabled_tools'] ?? array(),
+		'pipeline_id'      => 'direct',
+		'flow_id'          => 'direct',
+	);
+
+	if ( ! empty( $handler_slug ) ) {
+		if ( FlowStepConfig::isMultiHandler( $flow_step_config ) ) {
+			$flow_step_config['handler_slugs']   = array( $handler_slug );
+			$flow_step_config['handler_configs'] = array( $handler_slug => $handler_config );
+		} else {
+			$flow_step_config['handler_slug']   = $handler_slug;
+			$flow_step_config['handler_config'] = $handler_config;
+		}
+	} elseif ( ! FlowStepConfig::usesHandler( $flow_step_config ) && ! empty( $handler_config ) ) {
+		$flow_step_config['handler_config'] = $handler_config;
+	}
+
+	return $flow_step_config;
+}
+
+function factory_workflow_step_config_for_test( array $step, int $index ): array {
+	$step_type = $step['type'];
+
+	return FlowStepConfigFactory::build(
+		array(
+			'flow_step_id'     => "ephemeral_step_{$index}",
+			'pipeline_step_id' => "ephemeral_pipeline_{$index}",
+			'step_type'        => $step_type,
+			'execution_order'  => $index,
+			'enabled_tools'    => ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
+				? array_values( $step['enabled_tools'] )
+				: array(),
+			'prompt_queue'     => $step['prompt_queue'] ?? array(),
+			'queue_mode'       => 'static',
+			'disabled_tools'   => $step['disabled_tools'] ?? array(),
+			'pipeline_id'      => 'direct',
+			'flow_id'          => 'direct',
+			'handler_slug'     => $step['handler_slug'] ?? '',
+			'handler_config'   => $step['handler_config'] ?? array(),
+		)
+	);
+}
+
+function legacy_synced_step_config_for_test( array $step, int $flow_id, int $pipeline_id, array $disabled_tools ): array {
+	$step_type        = $step['step_type'] ?? '';
+	$pipeline_step_id = $step['pipeline_step_id'];
+	$flow_step_id     = $pipeline_step_id . '_' . $flow_id;
+
+	$step_config = array(
+		'flow_step_id'     => $flow_step_id,
+		'step_type'        => $step_type,
+		'pipeline_step_id' => $pipeline_step_id,
+		'pipeline_id'      => $pipeline_id,
+		'flow_id'          => $flow_id,
+		'execution_order'  => $step['execution_order'] ?? 0,
+		'disabled_tools'   => $disabled_tools,
+		'handler'          => null,
+		'queue_mode'       => 'static',
+	);
+
+	if ( 'fetch' === $step_type ) {
+		$step_config['config_patch_queue'] = array();
+	} else {
+		$step_config['prompt_queue'] = array();
+	}
+
+	return $step_config;
+}
+
+function factory_synced_step_config_for_test( array $step, int $flow_id, int $pipeline_id, array $disabled_tools ): array {
+	$step_type        = $step['step_type'] ?? '';
+	$pipeline_step_id = $step['pipeline_step_id'];
+	$queue_defaults   = ( 'fetch' === $step_type )
+		? array( 'config_patch_queue' => array() )
+		: array( 'prompt_queue' => array() );
+
+	return FlowStepConfigFactory::build(
+		array_merge(
+			array(
+				'flow_step_id'     => $pipeline_step_id . '_' . $flow_id,
+				'step_type'        => $step_type,
+				'pipeline_step_id' => $pipeline_step_id,
+				'pipeline_id'      => $pipeline_id,
+				'flow_id'          => $flow_id,
+				'execution_order'  => $step['execution_order'] ?? 0,
+				'disabled_tools'   => $disabled_tools,
+				'handler'          => null,
+				'queue_mode'       => 'static',
+			),
+			$queue_defaults
+		)
+	);
+}
+
+echo "FlowStepConfigFactory smoke (#1345)\n";
+echo "-----------------------------------\n";
+
+$workflow_cases = array(
+	'fetch keeps scalar handler shape'        => array(
+		'type'           => 'fetch',
+		'handler_slug'   => 'mcp',
+		'handler_config' => array( 'server' => 'a8c' ),
+		'disabled_tools' => array( 'local_search' ),
+	),
+	'publish keeps multi-handler shape'       => array(
+		'type'           => 'publish',
+		'handler_slug'   => 'wordpress_publish',
+		'handler_config' => array( 'post_type' => 'post' ),
+	),
+	'system_task keeps handler-free settings' => array(
+		'type'           => 'system_task',
+		'handler_config' => array( 'task' => 'daily_memory_generation' ),
+	),
+	'ai keeps enabled tools and prompt queue' => array(
+		'type'          => 'ai',
+		'enabled_tools' => array( 'local_search' ),
+		'prompt_queue'  => array(
+			array(
+				'prompt'   => 'Summarize',
+				'added_at' => '2026-04-27T00:00:00+00:00',
+			),
+		),
+	),
+);
+
+foreach ( $workflow_cases as $name => $step ) {
+	assert_factory_equals(
+		legacy_workflow_step_config_for_test( $step, 2 ),
+		factory_workflow_step_config_for_test( $step, 2 ),
+		"workflow scaffold: {$name}",
+		$failures,
+		$passes
+	);
+}
+
+$sync_cases = array(
+	'fetch gets config_patch_queue default' => array(
+		'pipeline_step_id' => 'fetch_1',
+		'step_type'        => 'fetch',
+		'execution_order'  => 0,
+	),
+	'ai gets prompt_queue default'          => array(
+		'pipeline_step_id' => 'ai_1',
+		'step_type'        => 'ai',
+		'execution_order'  => 1,
+	),
+	'publish gets prompt_queue default'     => array(
+		'pipeline_step_id' => 'publish_1',
+		'step_type'        => 'publish',
+		'execution_order'  => 2,
+	),
+);
+
+foreach ( $sync_cases as $name => $step ) {
+	assert_factory_equals(
+		legacy_synced_step_config_for_test( $step, 42, 7, array( 'tool_a' ) ),
+		factory_synced_step_config_for_test( $step, 42, 7, array( 'tool_a' ) ),
+		"flow sync scaffold: {$name}",
+		$failures,
+		$passes
+	);
+}
+
+echo "\n-----------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nAll assertions passed.\n";

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -35,8 +35,10 @@ if ( ! function_exists( 'do_action' ) ) {
 }
 
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
 
 use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Core\Steps\FlowStepConfigFactory;
 
 /**
  * Inline mirror of ExecuteWorkflowAbility::buildConfigsFromWorkflow().
@@ -52,32 +54,24 @@ function build_configs_from_workflow_for_test( array $workflow ): array {
 		$handler_config   = $step['handler_config'] ?? array();
 		$step_type        = $step['type'];
 
-		$flow_step_config = array(
-			'flow_step_id'     => $step_id,
-			'pipeline_step_id' => $pipeline_step_id,
-			'step_type'        => $step_type,
-			'execution_order'  => $index,
-			'enabled_tools'    => ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
-				? array_values( $step['enabled_tools'] )
-				: array(),
-			'prompt_queue'     => array(),
-			'queue_mode'       => 'static',
-			'disabled_tools'   => $step['disabled_tools'] ?? array(),
-			'pipeline_id'      => 'direct',
-			'flow_id'          => 'direct',
+		$flow_step_config = FlowStepConfigFactory::build(
+			array(
+				'flow_step_id'     => $step_id,
+				'pipeline_step_id' => $pipeline_step_id,
+				'step_type'        => $step_type,
+				'execution_order'  => $index,
+				'enabled_tools'    => ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
+					? array_values( $step['enabled_tools'] )
+					: array(),
+				'prompt_queue'     => array(),
+				'queue_mode'       => 'static',
+				'disabled_tools'   => $step['disabled_tools'] ?? array(),
+				'pipeline_id'      => 'direct',
+				'flow_id'          => 'direct',
+				'handler_slug'     => $handler_slug,
+				'handler_config'   => $handler_config,
+			)
 		);
-
-		if ( ! empty( $handler_slug ) ) {
-			if ( FlowStepConfig::isMultiHandler( $flow_step_config ) ) {
-				$flow_step_config['handler_slugs']   = array( $handler_slug );
-				$flow_step_config['handler_configs'] = array( $handler_slug => $handler_config );
-			} else {
-				$flow_step_config['handler_slug']   = $handler_slug;
-				$flow_step_config['handler_config'] = $handler_config;
-			}
-		} elseif ( ! FlowStepConfig::usesHandler( $flow_step_config ) && ! empty( $handler_config ) ) {
-			$flow_step_config['handler_config'] = $handler_config;
-		}
 
 		$flow_config[ $step_id ] = $flow_step_config;
 


### PR DESCRIPTION
## Summary
- Adds `FlowStepConfigFactory` as the first centralized compiler point for canonical flow-step rows.
- Moves the two lowest-risk scaffold writers onto the factory while preserving existing field shapes and order.

## Changes
- Replaces inline handler-cardinality construction in `ExecuteWorkflowAbility::buildConfigsFromWorkflow()` with `FlowStepConfigFactory::build()`.
- Replaces new-flow step scaffolding in `FlowHelpers::syncStepsToFlow()` with the same factory.
- Updates the existing handler-shape smoke to use the factory and adds a dedicated factory regression smoke that compares factory output against the pre-extraction writer shapes.

## Tests
- `php tests/flow-step-config-factory-smoke.php`
- `php tests/system-task-config-passthrough-smoke.php`
- `php tests/queue-mode-callsites-smoke.php`
- `php tests/handler-slug-scalar-migration-smoke.php`
- `php tests/system-task-workflow-validation-smoke.php`
- `php -l inc/Core/Steps/FlowStepConfigFactory.php && php -l inc/Abilities/Job/ExecuteWorkflowAbility.php && php -l inc/Abilities/Flow/FlowHelpers.php && php -l tests/flow-step-config-factory-smoke.php`
- `git diff --check`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@refactor-flow-step-config-compiler --changed-since origin/main`

`homeboy lint data-machine --path /Users/chubes/Developer/data-machine@refactor-flow-step-config-compiler` still hits the known WordPress lint-runner `PLUGIN_PATH: unbound variable` failure before producing findings (tracked upstream as Extra-Chill/homeboy-extensions#296).

Refs #1345

## Follow-ups
- Filed #1353 for moving the riskier copy/import/update overlay paths onto shared factory/helper primitives after this scaffold extraction lands.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the flow-step config compiler extraction, tests, and PR description; Chris remains responsible for review and merge.
