### PR TITLE
fix(flow): reject ambiguous step type targets

### DIFF
--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -64,7 +64,7 @@ class CreateFlowAbility {
 							),
 							'step_configs'       => array(
 								'type'        => 'object',
-								'description' => __( 'Step configurations keyed by step_type (single mode)', 'data-machine' ),
+								'description' => __( 'Step configurations keyed by step_type (single mode). If a flow has duplicate step types, include flow_step_id, pipeline_step_id, or execution_order in the config.', 'data-machine' ),
 							),
 							'flows'              => array(
 								'type'        => 'array',

--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -21,6 +21,7 @@ use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\FlowStepConfigFactory;
+use DataMachine\Core\Steps\FlowStepTargetResolver;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -555,25 +556,19 @@ trait FlowHelpers {
 		$flow        = $this->db_flows->get_flow( $flow_id );
 		$flow_config = $flow['flow_config'] ?? array();
 
-		$step_type_to_flow_step = array();
-		foreach ( $flow_config as $flow_step_id => $step_data ) {
-			$step_type = $step_data['step_type'] ?? '';
-			if ( ! empty( $step_type ) ) {
-				$step_type_to_flow_step[ $step_type ] = $flow_step_id;
-			}
-		}
-
 		$update_flow_step_ability = new UpdateFlowStepAbility();
 
-		foreach ( $step_configs as $step_type => $config ) {
-			$flow_step_id = $step_type_to_flow_step[ $step_type ] ?? null;
-			if ( ! $flow_step_id ) {
-				$errors[] = array(
-					'step_type' => $step_type,
-					'error'     => "No step of type '{$step_type}' found in flow",
-				);
+		foreach ( $step_configs as $step_key => $config ) {
+			$config = is_array( $config ) ? $config : array();
+
+			$target = FlowStepTargetResolver::resolve( $flow_config, (string) $step_key, $config );
+			if ( empty( $target['success'] ) ) {
+				$errors[] = $target['error'];
 				continue;
 			}
+
+			$flow_step_id = $target['flow_step_id'];
+			$step_type    = $target['step_type'] ?? (string) $step_key;
 
 			// Multi-handler configs use handler_slugs/handler_configs; single-handler
 			// and handler-free configs use handler_slug/handler_config.

--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Abilities\FlowStep;
 
 use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Core\Steps\FlowStepTargetResolver;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -78,11 +79,11 @@ class ConfigureFlowStepsAbility {
 							),
 							'updates'             => array(
 								'type'        => 'array',
-								'description' => __( 'Cross-pipeline mode: configure multiple flows with different settings. Each item: {flow_id, step_configs (keyed by step_type)}', 'data-machine' ),
+								'description' => __( 'Cross-pipeline mode: configure multiple flows with different settings. Each item: {flow_id, step_configs}. Step configs may be keyed by step_type when unique, or include flow_step_id, pipeline_step_id, or execution_order when duplicate step types exist.', 'data-machine' ),
 							),
 							'shared_config'       => array(
 								'type'        => 'object',
-								'description' => __( 'Shared step config for updates mode applied before per-flow overrides (keyed by step_type)', 'data-machine' ),
+								'description' => __( 'Shared step config for updates mode applied before per-flow overrides. Keys may use unique step_type shorthand; duplicate step types require explicit targeting in the config.', 'data-machine' ),
 							),
 							'validate_only'       => array(
 								'type'        => 'boolean',
@@ -517,29 +518,20 @@ class ConfigureFlowStepsAbility {
 			// Merge shared config with per-flow config (per-flow takes precedence)
 			$merged_step_configs = array_merge( $shared_config, $step_configs );
 
-			// Build step_type to flow_step_id mapping
-			$step_type_to_flow_step = array();
-			foreach ( $flow_config as $flow_step_id => $step_data ) {
-				$step_type = $step_data['step_type'] ?? '';
-				if ( ! empty( $step_type ) ) {
-					$step_type_to_flow_step[ $step_type ] = $flow_step_id;
-				}
-			}
-
 			$flow_updated    = false;
 			$flow_step_count = 0;
 
-			foreach ( $merged_step_configs as $step_type => $config ) {
-				$flow_step_id = $step_type_to_flow_step[ $step_type ] ?? null;
+			foreach ( $merged_step_configs as $step_key => $config ) {
+				$config = is_array( $config ) ? $config : array();
 
-				if ( ! $flow_step_id ) {
-					$errors[] = array(
-						'flow_id'   => $flow_id,
-						'step_type' => $step_type,
-						'error'     => "No step of type '{$step_type}' found in flow",
-					);
+				$target = FlowStepTargetResolver::resolve( $flow_config, (string) $step_key, $config );
+				if ( empty( $target['success'] ) ) {
+					$errors[] = array_merge( array( 'flow_id' => $flow_id ), $target['error'] );
 					continue;
 				}
+
+				$flow_step_id = $target['flow_step_id'];
+				$step_type    = $target['step_type'] ?? (string) $step_key;
 
 				$handler_slug   = $config['handler_slug'] ?? null;
 				$handler_config = $config['handler_config'] ?? array();

--- a/inc/Core/Steps/FlowStepTargetResolver.php
+++ b/inc/Core/Steps/FlowStepTargetResolver.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Flow step target resolver.
+ *
+ * @package DataMachine\Core\Steps
+ */
+
+namespace DataMachine\Core\Steps;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves a flow-step config target from explicit identifiers or step_type shorthand.
+ */
+class FlowStepTargetResolver {
+
+	/**
+	 * Resolve a config entry to one flow step.
+	 *
+	 * @param array  $flow_config Flow config keyed by flow_step_id.
+	 * @param string $config_key Step config key, historically the step_type shorthand.
+	 * @param array  $config Step config payload.
+	 * @return array{success: bool, flow_step_id?: string, step_type?: string, error?: array}
+	 */
+	public static function resolve( array $flow_config, string $config_key, array $config ): array {
+		$explicit_fields = array( 'flow_step_id', 'pipeline_step_id', 'execution_order' );
+
+		foreach ( $explicit_fields as $field ) {
+			if ( array_key_exists( $field, $config ) && null !== $config[ $field ] && '' !== $config[ $field ] ) {
+				return self::resolveExplicitField( $flow_config, $field, $config[ $field ], $config_key );
+			}
+		}
+
+		$step_type = self::resolveStepType( $config_key, $config );
+		$matches   = self::findMatches( $flow_config, 'step_type', $step_type );
+
+		if ( 1 === count( $matches ) ) {
+			return array(
+				'success'      => true,
+				'flow_step_id' => $matches[0]['flow_step_id'],
+				'step_type'    => $matches[0]['step_type'] ?? $step_type,
+			);
+		}
+
+		if ( count( $matches ) > 1 ) {
+			return array(
+				'success' => false,
+				'error'   => self::ambiguityError( 'step_type', $step_type, $matches ),
+			);
+		}
+
+		return array(
+			'success' => false,
+			'error'   => array(
+				'step_type' => $step_type,
+				'error'     => "No step of type '{$step_type}' found in flow",
+			),
+		);
+	}
+
+	/**
+	 * Resolve a config entry using an explicit target field.
+	 *
+	 * @param array  $flow_config Flow config keyed by flow_step_id.
+	 * @param string $field Explicit target field.
+	 * @param mixed  $value Explicit target value.
+	 * @param string $config_key Original config key.
+	 * @return array{success: bool, flow_step_id?: string, step_type?: string, error?: array}
+	 */
+	private static function resolveExplicitField( array $flow_config, string $field, $value, string $config_key ): array {
+		$matches = self::findMatches( $flow_config, $field, $value );
+
+		if ( 1 === count( $matches ) ) {
+			return array(
+				'success'      => true,
+				'flow_step_id' => $matches[0]['flow_step_id'],
+				'step_type'    => $matches[0]['step_type'] ?? $config_key,
+			);
+		}
+
+		if ( count( $matches ) > 1 ) {
+			return array(
+				'success' => false,
+				'error'   => self::ambiguityError( $field, $value, $matches ),
+			);
+		}
+
+		return array(
+			'success' => false,
+			'error'   => array(
+				$field   => $value,
+				'error'  => "No step found for {$field} '{$value}'",
+			),
+		);
+	}
+
+	/**
+	 * Find matching flow steps by field.
+	 *
+	 * @param array  $flow_config Flow config keyed by flow_step_id.
+	 * @param string $field Field to match.
+	 * @param mixed  $value Value to match.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function findMatches( array $flow_config, string $field, $value ): array {
+		$matches = array();
+
+		foreach ( $flow_config as $flow_step_id => $step_data ) {
+			$actual = 'flow_step_id' === $field ? $flow_step_id : ( $step_data[ $field ] ?? null );
+			if ( 'execution_order' === $field ) {
+				$is_match = is_numeric( $actual ) && is_numeric( $value ) && (int) $actual === (int) $value;
+			} else {
+				$is_match = (string) $actual === (string) $value;
+			}
+
+			if ( ! $is_match ) {
+				continue;
+			}
+
+			$matches[] = self::candidate( (string) $flow_step_id, $step_data );
+		}
+
+		usort(
+			$matches,
+			static function ( array $a, array $b ): int {
+				return ( (int) ( $a['execution_order'] ?? 0 ) ) <=> ( (int) ( $b['execution_order'] ?? 0 ) );
+			}
+		);
+
+		return $matches;
+	}
+
+	/**
+	 * Build an ambiguity error payload.
+	 *
+	 * @param string $field Ambiguous target field.
+	 * @param mixed  $value Ambiguous target value.
+	 * @param array  $matches Matching candidates.
+	 * @return array<string, mixed>
+	 */
+	private static function ambiguityError( string $field, $value, array $matches ): array {
+		return array(
+			'error_type' => 'ambiguous_step_target',
+			$field       => $value,
+			'error'      => "Multiple flow steps match {$field} '{$value}'. Use flow_step_id, pipeline_step_id, or execution_order to target one step explicitly.",
+			'candidates' => array_map(
+				static function ( array $candidate ): array {
+					return array(
+						'flow_step_id'     => $candidate['flow_step_id'],
+						'pipeline_step_id' => $candidate['pipeline_step_id'] ?? null,
+						'execution_order'  => $candidate['execution_order'] ?? null,
+					);
+				},
+				$matches
+			),
+		);
+	}
+
+	/**
+	 * Build a candidate payload.
+	 *
+	 * @param string $flow_step_id Flow step ID.
+	 * @param array  $step_data Step config.
+	 * @return array<string, mixed>
+	 */
+	private static function candidate( string $flow_step_id, array $step_data ): array {
+		return array(
+			'flow_step_id'     => $flow_step_id,
+			'pipeline_step_id' => $step_data['pipeline_step_id'] ?? null,
+			'execution_order'  => $step_data['execution_order'] ?? null,
+			'step_type'        => $step_data['step_type'] ?? null,
+		);
+	}
+
+	/**
+	 * Resolve the step_type shorthand for a config entry.
+	 *
+	 * @param string $config_key Config array key.
+	 * @param array  $config Config payload.
+	 * @return string
+	 */
+	private static function resolveStepType( string $config_key, array $config ): string {
+		if ( ! empty( $config['step_type'] ) && is_string( $config['step_type'] ) ) {
+			return $config['step_type'];
+		}
+
+		return $config_key;
+	}
+}

--- a/tests/flow-step-target-resolver-smoke.php
+++ b/tests/flow-step-target-resolver-smoke.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Pure-PHP smoke test for flow step target resolution (#1346).
+ *
+ * Run with: php tests/flow-step-target-resolver-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepTargetResolver.php';
+
+use DataMachine\Core\Steps\FlowStepTargetResolver;
+
+$failed = 0;
+$total  = 0;
+
+function assert_test( string $name, bool $cond, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $cond ) {
+		echo "  [PASS] $name\n";
+	} else {
+		echo "  [FAIL] $name" . ( $detail ? " — $detail" : '' ) . "\n";
+		++$failed;
+	}
+}
+
+$single_ai_flow = array(
+	'fetch_42' => array(
+		'flow_step_id'     => 'fetch_42',
+		'pipeline_step_id' => 'fetch',
+		'step_type'        => 'fetch',
+		'execution_order'  => 0,
+	),
+	'ai_42'    => array(
+		'flow_step_id'     => 'ai_42',
+		'pipeline_step_id' => 'ai',
+		'step_type'        => 'ai',
+		'execution_order'  => 1,
+	),
+);
+
+echo "Case 1: single matching step_type keeps shorthand\n";
+$single = FlowStepTargetResolver::resolve( $single_ai_flow, 'ai', array( 'user_message' => 'Summarize this.' ) );
+assert_test( 'single step_type shorthand succeeds', true === ( $single['success'] ?? false ) );
+assert_test( 'single step_type resolves the AI flow_step_id', 'ai_42' === ( $single['flow_step_id'] ?? null ) );
+assert_test( 'single step_type carries resolved step_type', 'ai' === ( $single['step_type'] ?? null ) );
+
+$duplicate_ai_flow = array(
+	'fetch_77'   => array(
+		'flow_step_id'     => 'fetch_77',
+		'pipeline_step_id' => 'fetch',
+		'step_type'        => 'fetch',
+		'execution_order'  => 0,
+	),
+	'ai_intro_77' => array(
+		'flow_step_id'     => 'ai_intro_77',
+		'pipeline_step_id' => 'ai_intro',
+		'step_type'        => 'ai',
+		'execution_order'  => 1,
+	),
+	'ai_outro_77' => array(
+		'flow_step_id'     => 'ai_outro_77',
+		'pipeline_step_id' => 'ai_outro',
+		'step_type'        => 'ai',
+		'execution_order'  => 2,
+	),
+);
+
+echo "\nCase 2: duplicate matching step_type rejects shorthand with candidates\n";
+$ambiguous = FlowStepTargetResolver::resolve( $duplicate_ai_flow, 'ai', array( 'user_message' => 'Summarize this.' ) );
+assert_test( 'duplicate step_type shorthand fails', false === ( $ambiguous['success'] ?? true ) );
+assert_test( 'duplicate step_type returns ambiguity error type', 'ambiguous_step_target' === ( $ambiguous['error']['error_type'] ?? null ) );
+assert_test( 'duplicate step_type lists both candidates', 2 === count( $ambiguous['error']['candidates'] ?? array() ) );
+assert_test( 'first candidate exposes flow_step_id', 'ai_intro_77' === ( $ambiguous['error']['candidates'][0]['flow_step_id'] ?? null ) );
+assert_test( 'first candidate exposes pipeline_step_id', 'ai_intro' === ( $ambiguous['error']['candidates'][0]['pipeline_step_id'] ?? null ) );
+assert_test( 'first candidate exposes execution_order', 1 === ( $ambiguous['error']['candidates'][0]['execution_order'] ?? null ) );
+assert_test( 'second candidate exposes flow_step_id', 'ai_outro_77' === ( $ambiguous['error']['candidates'][1]['flow_step_id'] ?? null ) );
+
+echo "\nCase 3: explicit flow_step_id targeting works with duplicate step types\n";
+$by_flow_step = FlowStepTargetResolver::resolve(
+	$duplicate_ai_flow,
+	'ai',
+	array(
+		'flow_step_id' => 'ai_outro_77',
+		'user_message' => 'Write the outro.',
+	)
+);
+assert_test( 'flow_step_id targeting succeeds', true === ( $by_flow_step['success'] ?? false ) );
+assert_test( 'flow_step_id targets the requested duplicate', 'ai_outro_77' === ( $by_flow_step['flow_step_id'] ?? null ) );
+
+echo "\nCase 4: explicit pipeline_step_id targeting works with duplicate step types\n";
+$by_pipeline_step = FlowStepTargetResolver::resolve(
+	$duplicate_ai_flow,
+	'ai',
+	array(
+		'pipeline_step_id' => 'ai_intro',
+		'user_message'     => 'Write the intro.',
+	)
+);
+assert_test( 'pipeline_step_id targeting succeeds', true === ( $by_pipeline_step['success'] ?? false ) );
+assert_test( 'pipeline_step_id targets the requested duplicate', 'ai_intro_77' === ( $by_pipeline_step['flow_step_id'] ?? null ) );
+
+echo "\nCase 5: explicit execution_order targeting works with duplicate step types\n";
+$by_order = FlowStepTargetResolver::resolve(
+	$duplicate_ai_flow,
+	'ai',
+	array(
+		'execution_order' => 2,
+		'user_message'    => 'Write the outro.',
+	)
+);
+assert_test( 'execution_order targeting succeeds', true === ( $by_order['success'] ?? false ) );
+assert_test( 'execution_order targets the requested duplicate', 'ai_outro_77' === ( $by_order['flow_step_id'] ?? null ) );
+
+echo "\nCase 6: production call sites use the shared resolver instead of last-write-wins maps\n";
+$flow_helpers      = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/FlowHelpers.php' );
+$configure_ability = file_get_contents( __DIR__ . '/../inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php' );
+
+assert_test( 'FlowHelpers imports FlowStepTargetResolver', false !== strpos( $flow_helpers, 'FlowStepTargetResolver' ) );
+assert_test( 'ConfigureFlowStepsAbility imports FlowStepTargetResolver', false !== strpos( $configure_ability, 'FlowStepTargetResolver' ) );
+assert_test( 'FlowHelpers no longer builds step_type_to_flow_step map', false === strpos( $flow_helpers, '$step_type_to_flow_step' ) );
+assert_test( 'ConfigureFlowStepsAbility no longer builds step_type_to_flow_step map', false === strpos( $configure_ability, '$step_type_to_flow_step' ) );
+
+echo "\nAssertions: $total\n";
+if ( $failed > 0 ) {
+	echo "Failures: $failed\n";
+	exit( 1 );
+}
+
+echo "All flow-step target resolver smoke tests passed.\n";


### PR DESCRIPTION
## Summary
- Reject `step_type` shorthand when a flow contains multiple matching steps instead of silently picking the last one.
- Preserve `step_type` shorthand when it resolves to exactly one step.
- Allow explicit targeting with `flow_step_id`, `pipeline_step_id`, or `execution_order` in step config payloads.

## Changes
- Adds `FlowStepTargetResolver` as the shared target resolver for flow-step config APIs.
- Updates create-flow step config application and cross-pipeline configure-flow-steps to use the resolver.
- Returns structured ambiguity errors with candidate `flow_step_id`, `pipeline_step_id`, and `execution_order` values.
- Updates ability descriptions to document explicit targeting for duplicate step types.
- Adds a pure-PHP smoke test covering unique shorthand, duplicate ambiguity, and explicit targeting.

## Tests
- `php -l inc/Core/Steps/FlowStepTargetResolver.php && php -l inc/Abilities/Flow/FlowHelpers.php && php -l inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php && php -l inc/Abilities/Flow/CreateFlowAbility.php && php -l tests/flow-step-target-resolver-smoke.php`
- `php tests/flow-step-target-resolver-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-ambiguous-step-type-targeting --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-ambiguous-step-type-targeting --changed-since origin/main` passed before the final rebase; post-rebase retries timed out after printing the existing no-baseline changed-file findings.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-ambiguous-step-type-targeting` hit the known WordPress extension runner issue: `PLUGIN_PATH: unbound variable`.

Closes #1346

## Follow-ups
None.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the ambiguous step-type targeting fix, tests, and PR description; Chris remains responsible for review and merge.
