### PR TITLE
chore(flow): remove legacy handler field residue

### DIFF
--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -88,7 +88,6 @@ trait FlowHelpers {
 						'flow_id'          => $flow_id,
 						'execution_order'  => $step['execution_order'] ?? 0,
 						'disabled_tools'   => $disabled_tools,
-						'handler'          => null,
 						// queue_mode is the access pattern enum that drives both
 						// AI (prompt_queue) and Fetch (config_patch_queue)
 						// consumption (#1291). Default "static" preserves

--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -301,7 +301,6 @@ trait FlowStepHelpers {
 				'pipeline_step_id' => $pipeline_step_id,
 				'pipeline_id'      => $flow['pipeline_id'],
 				'flow_id'          => $flow_id,
-				'handler'          => null,
 			);
 		}
 

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -965,7 +965,6 @@ class PipelineStepAbilities {
 				'flow_id'          => $flow_id,
 				'execution_order'  => $step['execution_order'] ?? 0,
 				'disabled_tools'   => $disabled_tools,
-				'handler'          => null,
 			);
 		}
 

--- a/inc/Core/Steps/FlowStepConfig.php
+++ b/inc/Core/Steps/FlowStepConfig.php
@@ -264,7 +264,7 @@ class FlowStepConfig {
 		$scalar_slug    = is_string( $step_config['handler_slug'] ?? null ) ? $step_config['handler_slug'] : '';
 		$scalar_config  = is_array( $step_config['handler_config'] ?? null ) ? $step_config['handler_config'] : array();
 
-		unset( $step_config['handler_slug'], $step_config['handler_slugs'], $step_config['handler_config'], $step_config['handler_configs'] );
+		unset( $step_config['handler'], $step_config['handler_slug'], $step_config['handler_slugs'], $step_config['handler_config'], $step_config['handler_configs'] );
 
 		if ( ! $uses_handler ) {
 			$config = $scalar_config;

--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -364,13 +364,6 @@ class ImportExport {
 			)
 		);
 
-		$primary_handler = FlowStepConfig::getPrimaryHandlerSlug( $step );
-		if ( null !== $primary_handler ) {
-			$step['handler'] = $primary_handler;
-		} else {
-			unset( $step['handler'] );
-		}
-
 		$flow_config[ $flow_step_id ] = $step;
 
 		$flow_config[ $flow_step_id ]['enabled'] = true;

--- a/tests/flow-step-legacy-handler-field-smoke.php
+++ b/tests/flow-step-legacy-handler-field-smoke.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Pure-PHP smoke test for removing legacy flow-step `handler` storage.
+ *
+ * Run with: php tests/flow-step-legacy-handler-field-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_step_types' !== $hook ) {
+			return $value;
+		}
+
+		return array(
+			'ai'           => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'system_task'  => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'webhook_gate' => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'fetch'        => array( 'uses_handler' => true, 'multi_handler' => false ),
+			'publish'      => array( 'uses_handler' => true, 'multi_handler' => true ),
+			'upsert'       => array( 'uses_handler' => true, 'multi_handler' => true ),
+		);
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['__flow_step_legacy_handler_field_actions'][] = array( $hook, $args );
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+
+use DataMachine\Core\Steps\FlowStepConfig;
+
+$failures = array();
+$passes   = 0;
+
+function assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function assert_absent( string $key, array $array, string $name, array &$failures, int &$passes ): void {
+	assert_equals( false, array_key_exists( $key, $array ), $name, $failures, $passes );
+}
+
+function assert_not_contains( string $needle, string $haystack, string $name, array &$failures, int &$passes ): void {
+	assert_equals( false, str_contains( $haystack, $needle ), $name, $failures, $passes );
+}
+
+echo "legacy handler field removal smoke (#1348)\n";
+echo "-------------------------------------------\n";
+
+echo "\n[1] new synced step seeds structural fields only:\n";
+$synced_step = array(
+	'flow_step_id'       => 'step_10',
+	'step_type'          => 'fetch',
+	'pipeline_step_id'   => 'step',
+	'pipeline_id'        => 1,
+	'flow_id'            => 10,
+	'execution_order'    => 0,
+	'disabled_tools'     => array(),
+	'config_patch_queue' => array(),
+	'queue_mode'         => 'static',
+);
+assert_absent( 'handler', $synced_step, 'synced step has no legacy handler field', $failures, $passes );
+
+echo "\n[2] configured single-handler step stores scalar canonical fields:\n";
+$single = FlowStepConfig::normalizeHandlerShape(
+	array_merge(
+		$synced_step,
+		array(
+			'handler'        => 'rss',
+			'handler_slug'   => 'rss',
+			'handler_config' => array( 'url' => 'https://example.com/feed.xml' ),
+		)
+	)
+);
+assert_equals( 'rss', $single['handler_slug'] ?? null, 'single-handler slug is canonical scalar', $failures, $passes );
+assert_equals( array( 'url' => 'https://example.com/feed.xml' ), $single['handler_config'] ?? array(), 'single-handler config is canonical scalar', $failures, $passes );
+assert_absent( 'handler', $single, 'single-handler step drops legacy handler field', $failures, $passes );
+assert_absent( 'handler_slugs', $single, 'single-handler step has no plural slugs', $failures, $passes );
+assert_absent( 'handler_configs', $single, 'single-handler step has no plural configs', $failures, $passes );
+
+echo "\n[3] configured multi-handler step stores plural canonical fields:\n";
+$multi = FlowStepConfig::normalizeHandlerShape(
+	array(
+		'flow_step_id'     => 'publish_10',
+		'step_type'        => 'publish',
+		'pipeline_step_id' => 'publish',
+		'pipeline_id'      => 1,
+		'flow_id'          => 10,
+		'handler'          => 'wordpress_publish',
+		'handler_slug'     => 'wordpress_publish',
+		'handler_config'   => array( 'post_type' => 'post' ),
+	)
+);
+assert_equals( array( 'wordpress_publish' ), $multi['handler_slugs'] ?? array(), 'multi-handler slug is canonical list', $failures, $passes );
+assert_equals( array( 'wordpress_publish' => array( 'post_type' => 'post' ) ), $multi['handler_configs'] ?? array(), 'multi-handler config is canonical map', $failures, $passes );
+assert_absent( 'handler', $multi, 'multi-handler step drops legacy handler field', $failures, $passes );
+assert_absent( 'handler_slug', $multi, 'multi-handler step has no scalar slug', $failures, $passes );
+assert_absent( 'handler_config', $multi, 'multi-handler step has no scalar config', $failures, $passes );
+
+echo "\n[4] restored step normalizes imported stale handler residue away:\n";
+$restored = FlowStepConfig::normalizeHandlerShape(
+	array(
+		'flow_step_id'     => 'restored_10',
+		'step_type'        => 'fetch',
+		'pipeline_step_id' => 'restored',
+		'flow_id'          => 10,
+		'handler'          => 'legacy_rss',
+		'handler_slugs'    => array( 'rss' ),
+		'handler_configs'  => array( 'rss' => array( 'url' => 'https://example.com/feed.xml' ) ),
+	)
+);
+assert_equals( 'rss', $restored['handler_slug'] ?? null, 'restored single-handler slug comes from canonical import settings', $failures, $passes );
+assert_absent( 'handler', $restored, 'restored step drops stale imported handler field', $failures, $passes );
+
+echo "\n[5] writer sources no longer seed or persist the legacy field:\n";
+$source_checks = array(
+	'inc/Abilities/Flow/FlowHelpers.php'         => array( "'handler'          => null" ),
+	'inc/Abilities/FlowStep/FlowStepHelpers.php' => array( "'handler'          => null" ),
+	'inc/Abilities/PipelineStepAbilities.php'    => array( "'handler'          => null" ),
+	'inc/Engine/Actions/ImportExport.php'        => array( "\$step['handler'] =" ),
+);
+foreach ( $source_checks as $relative_path => $needles ) {
+	$source = file_get_contents( __DIR__ . '/../' . $relative_path );
+	foreach ( $needles as $needle ) {
+		assert_not_contains( $needle, $source, "{$relative_path} does not contain {$needle}", $failures, $passes );
+	}
+}
+
+echo "\n-------------------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nAll assertions passed.\n";


### PR DESCRIPTION
## Summary
- Stops persisting the legacy flow-step `handler` field now that handler selection lives in canonical `FlowStepConfig` shapes.
- Keeps export display compatibility by deriving handler values from canonical fields instead of storing duplicate state in `flow_config`.

## Changes
- Removed `handler => null` seeds from flow sync paths.
- Removed import restore persistence of `$step['handler']`.
- Updated `FlowStepConfig::normalizeHandlerShape()` to discard stale incoming `handler` residue while normalizing canonical fields.
- Added a pure-PHP smoke covering new, configured, and restored step shapes with no redundant `handler` field.

## Tests
- `php -l inc/Abilities/Flow/FlowHelpers.php && php -l inc/Abilities/FlowStep/FlowStepHelpers.php && php -l inc/Engine/Actions/ImportExport.php && php -l inc/Core/Steps/FlowStepConfig.php`
- `php -l inc/Abilities/PipelineStepAbilities.php && php -l tests/flow-step-legacy-handler-field-smoke.php`
- `php tests/flow-step-legacy-handler-field-smoke.php` — 17/17 passed
- `php tests/system-task-config-passthrough-smoke.php` — 34/34 passed
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@chore-remove-flow-step-handler-field --changed-since origin/main` passed before rebase; after rebase it reported pre-existing findings in changed files and timed out, so I did not keep looping.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@chore-remove-flow-step-handler-field` hit the known WordPress runner bug: `PLUGIN_PATH: unbound variable`.

Closes #1348

## Follow-ups
None.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the legacy handler-field cleanup, tests, and PR description; Chris remains responsible for review and merge.