### PR TITLE
fix(flow): normalize reordered step execution order

### DIFF
--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -249,7 +249,7 @@ class PipelineStepAbilities {
 						),
 						'step_order'  => array(
 							'type'        => 'array',
-							'description' => __( 'Array of step order objects: [{pipeline_step_id: "...", execution_order: 0}, ...]', 'data-machine' ),
+							'description' => __( 'Array of step order objects. Input array order determines final contiguous execution_order values.', 'data-machine' ),
 						),
 					),
 				),
@@ -687,6 +687,7 @@ class PipelineStepAbilities {
 			$step['execution_order']                    = $index;
 			$updated_steps[ $step['pipeline_step_id'] ] = $step;
 		}
+		$updated_orders = $this->buildExecutionOrderMap( $updated_steps );
 
 		$success = $this->db_pipelines->update_pipeline(
 			$pipeline_id,
@@ -709,6 +710,10 @@ class PipelineStepAbilities {
 			$updated_flow_config = array();
 			foreach ( $flow_config as $flow_step_id => $flow_step ) {
 				if ( isset( $flow_step['pipeline_step_id'] ) && $flow_step['pipeline_step_id'] !== $pipeline_step_id ) {
+					$flow_pipeline_step_id = $flow_step['pipeline_step_id'];
+					if ( isset( $updated_orders[ $flow_pipeline_step_id ] ) ) {
+						$flow_step['execution_order'] = $updated_orders[ $flow_pipeline_step_id ];
+					}
 					$updated_flow_config[ $flow_step_id ] = $flow_step;
 				}
 			}
@@ -803,22 +808,31 @@ class PipelineStepAbilities {
 			);
 		}
 
-		$updated_steps = array();
-		foreach ( $step_order as $item ) {
-			$pipeline_step_id = sanitize_text_field( $item['pipeline_step_id'] );
-			$execution_order  = (int) $item['execution_order'];
-
-			$step_found = false;
-			foreach ( $pipeline_steps as $step ) {
-				if ( $step['pipeline_step_id'] === $pipeline_step_id ) {
-					$step['execution_order'] = $execution_order;
-					$updated_steps[]         = $step;
-					$step_found              = true;
-					break;
-				}
+		$steps_by_id = array();
+		foreach ( $pipeline_steps as $step ) {
+			if ( ! empty( $step['pipeline_step_id'] ) ) {
+				$steps_by_id[ $step['pipeline_step_id'] ] = $step;
 			}
+		}
 
-			if ( ! $step_found ) {
+		$updated_steps = array();
+		$seen_steps    = array();
+		foreach ( $step_order as $index => $item ) {
+			$pipeline_step_id = sanitize_text_field( $item['pipeline_step_id'] );
+
+			if ( isset( $seen_steps[ $pipeline_step_id ] ) ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf(
+						/* translators: %s: pipeline step ID */
+						__( 'Step %s appears more than once in reorder input', 'data-machine' ),
+						$pipeline_step_id
+					),
+				);
+			}
+			$seen_steps[ $pipeline_step_id ] = true;
+
+			if ( ! isset( $steps_by_id[ $pipeline_step_id ] ) ) {
 				return array(
 					'success' => false,
 					'error'   => sprintf(
@@ -828,6 +842,10 @@ class PipelineStepAbilities {
 					),
 				);
 			}
+
+			$step                              = $steps_by_id[ $pipeline_step_id ];
+			$step['execution_order']           = $index;
+			$updated_steps[ $pipeline_step_id ] = $step;
 		}
 
 		if ( count( $updated_steps ) !== count( $pipeline_steps ) ) {
@@ -851,7 +869,8 @@ class PipelineStepAbilities {
 			);
 		}
 
-		$flows = $this->db_flows->get_flows_for_pipeline( $pipeline_id );
+		$updated_orders = $this->buildExecutionOrderMap( $updated_steps );
+		$flows          = $this->db_flows->get_flows_for_pipeline( $pipeline_id );
 		foreach ( $flows as $flow ) {
 			$flow_id     = $flow['flow_id'];
 			$flow_config = $flow['flow_config'] ?? array();
@@ -862,11 +881,8 @@ class PipelineStepAbilities {
 				}
 				$pipeline_step_id = $flow_step['pipeline_step_id'];
 
-				foreach ( $updated_steps as $updated_step ) {
-					if ( $updated_step['pipeline_step_id'] === $pipeline_step_id ) {
-						$flow_step['execution_order'] = $updated_step['execution_order'];
-						break;
-					}
+				if ( isset( $updated_orders[ $pipeline_step_id ] ) ) {
+					$flow_step['execution_order'] = $updated_orders[ $pipeline_step_id ];
 				}
 			}
 			unset( $flow_step );
@@ -895,6 +911,22 @@ class PipelineStepAbilities {
 			'step_count'  => count( $updated_steps ),
 			'message'     => 'Pipeline steps reordered successfully.',
 		);
+	}
+
+	/**
+	 * Build pipeline step ID to execution order map.
+	 *
+	 * @param array $steps Pipeline steps keyed by pipeline_step_id.
+	 * @return array<string,int>
+	 */
+	private function buildExecutionOrderMap( array $steps ): array {
+		$orders = array();
+		foreach ( $steps as $step ) {
+			if ( ! empty( $step['pipeline_step_id'] ) && isset( $step['execution_order'] ) ) {
+				$orders[ $step['pipeline_step_id'] ] = (int) $step['execution_order'];
+			}
+		}
+		return $orders;
 	}
 
 	/**

--- a/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
@@ -11,6 +11,8 @@ namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\Pipeline\CreatePipelineAbility;
 use DataMachine\Abilities\PipelineStepAbilities;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Pipelines\Pipelines;
 use WP_UnitTestCase;
 
 class PipelineStepAbilitiesTest extends WP_UnitTestCase {
@@ -536,6 +538,162 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 		$this->assertEquals( $this->test_pipeline_id, $result['pipeline_id'] );
 		$this->assertEquals( 2, $result['step_count'] );
 		$this->assertStringContainsString( 'reordered', $result['message'] );
+	}
+
+	public function test_reorder_pipeline_steps_normalizes_gapped_orders_and_syncs_flows(): void {
+		$step1 = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'fetch',
+			)
+		);
+
+		$step2 = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'ai',
+			)
+		);
+
+		$step3 = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'publish',
+			)
+		);
+
+		$flow_result = wp_get_ability( 'datamachine/create-flow' )->execute(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'flow_name'   => 'Flow for gapped reorder sync',
+			)
+		);
+		$this->assertTrue( $flow_result['success'] );
+
+		$result = $this->step_abilities->executeReorderPipelineSteps(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_order'  => array(
+					array(
+						'pipeline_step_id' => $step3['pipeline_step_id'],
+						'execution_order'  => 0,
+					),
+					array(
+						'pipeline_step_id' => $step1['pipeline_step_id'],
+						'execution_order'  => 10,
+					),
+					array(
+						'pipeline_step_id' => $step2['pipeline_step_id'],
+						'execution_order'  => 20,
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$db_pipelines    = new Pipelines();
+		$pipeline_config = $db_pipelines->get_pipeline_config( $this->test_pipeline_id );
+
+		$this->assertSame( array( $step3['pipeline_step_id'], $step1['pipeline_step_id'], $step2['pipeline_step_id'] ), array_keys( $pipeline_config ) );
+		$this->assertSame( 0, $pipeline_config[ $step3['pipeline_step_id'] ]['execution_order'] );
+		$this->assertSame( 1, $pipeline_config[ $step1['pipeline_step_id'] ]['execution_order'] );
+		$this->assertSame( 2, $pipeline_config[ $step2['pipeline_step_id'] ]['execution_order'] );
+
+		$db_flows    = new Flows();
+		$flow        = $db_flows->get_flow( $flow_result['flow_id'] );
+		$flow_config = $flow['flow_config'];
+
+		$this->assertSame( 0, $flow_config[ $step3['pipeline_step_id'] . '_' . $flow_result['flow_id'] ]['execution_order'] );
+		$this->assertSame( 1, $flow_config[ $step1['pipeline_step_id'] . '_' . $flow_result['flow_id'] ]['execution_order'] );
+		$this->assertSame( 2, $flow_config[ $step2['pipeline_step_id'] . '_' . $flow_result['flow_id'] ]['execution_order'] );
+	}
+
+	public function test_reorder_pipeline_steps_normalizes_duplicate_orders_by_input_order(): void {
+		$step1 = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'fetch',
+			)
+		);
+
+		$step2 = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'ai',
+			)
+		);
+
+		$step3 = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'publish',
+			)
+		);
+
+		$result = $this->step_abilities->executeReorderPipelineSteps(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_order'  => array(
+					array(
+						'pipeline_step_id' => $step2['pipeline_step_id'],
+						'execution_order'  => 0,
+					),
+					array(
+						'pipeline_step_id' => $step3['pipeline_step_id'],
+						'execution_order'  => 0,
+					),
+					array(
+						'pipeline_step_id' => $step1['pipeline_step_id'],
+						'execution_order'  => 1,
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$db_pipelines    = new Pipelines();
+		$pipeline_config = $db_pipelines->get_pipeline_config( $this->test_pipeline_id );
+
+		$this->assertSame( 0, $pipeline_config[ $step2['pipeline_step_id'] ]['execution_order'] );
+		$this->assertSame( 1, $pipeline_config[ $step3['pipeline_step_id'] ]['execution_order'] );
+		$this->assertSame( 2, $pipeline_config[ $step1['pipeline_step_id'] ]['execution_order'] );
+	}
+
+	public function test_reorder_pipeline_steps_rejects_duplicate_step_ids(): void {
+		$step1 = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'fetch',
+			)
+		);
+
+		$this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'ai',
+			)
+		);
+
+		$result = $this->step_abilities->executeReorderPipelineSteps(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_order'  => array(
+					array(
+						'pipeline_step_id' => $step1['pipeline_step_id'],
+						'execution_order'  => 0,
+					),
+					array(
+						'pipeline_step_id' => $step1['pipeline_step_id'],
+						'execution_order'  => 1,
+					),
+				),
+			)
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'appears more than once', $result['error'] );
 	}
 
 	public function test_reorder_pipeline_steps_invalid_format(): void {

--- a/tests/step-navigator-execution-order-smoke.php
+++ b/tests/step-navigator-execution-order-smoke.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Pure-PHP smoke test for StepNavigator's contiguous execution_order contract.
+ *
+ * Run with: php tests/step-navigator-execution-order-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core {
+	class EngineData {
+		public static array $snapshots = array();
+
+		public static function retrieve( int $job_id ): array {
+			return self::$snapshots[ $job_id ] ?? array();
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+	if ( ! defined( 'WPINC' ) ) {
+		define( 'WPINC', 'wp-includes' );
+	}
+
+	require_once __DIR__ . '/../inc/Engine/Filters/EngineData.php';
+	require_once __DIR__ . '/../inc/Engine/StepNavigator.php';
+
+	$failed = 0;
+	$total  = 0;
+
+	function assert_step_navigator_order( string $name, bool $condition, string $detail = '' ): void {
+		global $failed, $total;
+		++$total;
+		if ( $condition ) {
+			echo "  [PASS] {$name}\n";
+			return;
+		}
+
+		echo "  [FAIL] {$name}" . ( $detail ? " - {$detail}" : '' ) . "\n";
+		++$failed;
+	}
+
+	echo "=== step-navigator-execution-order-smoke ===\n";
+
+	\DataMachine\Core\EngineData::$snapshots[123] = array(
+		'flow_config' => array(
+			'fetch_step'   => array(
+				'flow_step_id'    => 'fetch_step',
+				'execution_order' => 0,
+			),
+			'ai_step'      => array(
+				'flow_step_id'    => 'ai_step',
+				'execution_order' => 1,
+			),
+			'publish_step' => array(
+				'flow_step_id'    => 'publish_step',
+				'execution_order' => 2,
+			),
+		),
+	);
+
+	$navigator = new \DataMachine\Engine\StepNavigator();
+	$context   = array( 'job_id' => 123 );
+
+	assert_step_navigator_order(
+		'fetch advances to ai when orders are contiguous',
+		'ai_step' === $navigator->get_next_flow_step_id( 'fetch_step', $context )
+	);
+	assert_step_navigator_order(
+		'ai advances to publish when orders are contiguous',
+		'publish_step' === $navigator->get_next_flow_step_id( 'ai_step', $context )
+	);
+	assert_step_navigator_order(
+		'publish has no next step',
+		null === $navigator->get_next_flow_step_id( 'publish_step', $context )
+	);
+	assert_step_navigator_order(
+		'publish moves back to ai when orders are contiguous',
+		'ai_step' === $navigator->get_previous_flow_step_id( 'publish_step', $context )
+	);
+	assert_step_navigator_order(
+		'ai moves back to fetch when orders are contiguous',
+		'fetch_step' === $navigator->get_previous_flow_step_id( 'ai_step', $context )
+	);
+	assert_step_navigator_order(
+		'fetch has no previous step',
+		null === $navigator->get_previous_flow_step_id( 'fetch_step', $context )
+	);
+
+	if ( $failed > 0 ) {
+		echo "\n{$failed}/{$total} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$total} assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Normalizes pipeline step reorder writes to contiguous `0..N-1` execution orders based on input array position.
- Keeps synchronized flow configs aligned with the normalized pipeline order so runtime navigation cannot stop on `0, 10, 20` gaps.
- Rejects duplicate `pipeline_step_id` entries in reorder input, while duplicate numeric `execution_order` values are normalized by input order.

## Changes
- Updates `datamachine/reorder-pipeline-steps` docs to make input array order the contract.
- Persists reordered pipeline configs keyed by `pipeline_step_id` with normalized `execution_order` values.
- Reuses the normalized order map when syncing reorder and delete effects into flow configs.
- Adds unit coverage for gapped orders, duplicate numeric orders, duplicate step IDs, and flow-config synchronization.
- Adds a pure-PHP StepNavigator smoke test that pins contiguous-order navigation.

## Tests
- `php tests/step-navigator-execution-order-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-execution-order-contract --changed-since origin/main`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-execution-order-contract`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-execution-order-contract --changed-since origin/main` started, reported `10 finding(s) in changed files — no baseline to compare against, treating as pre-existing`, then hung before completion; not rerun further.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-execution-order-contract` hit the known WordPress lint runner issue: `PLUGIN_PATH: unbound variable`.
- `php -l inc/Abilities/PipelineStepAbilities.php`
- `php -l tests/Unit/Abilities/PipelineStepAbilitiesTest.php`
- `php -l tests/step-navigator-execution-order-smoke.php`

Closes #1343

## Follow-ups
None.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the execution-order contract fix, tests, and PR description; Chris remains responsible for review and merge.
