### PR TITLE
ci: split Homeboy action checks

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -19,8 +19,12 @@ permissions:
 
 jobs:
   homeboy:
-    name: Homeboy
+    name: Homeboy (${{ matrix.command }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        command: [audit, lint, test]
     services:
       mysql:
         image: mysql:8.0
@@ -48,8 +52,10 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: Extra-Chill/homeboy-action@v2
+      - name: Run Homeboy ${{ matrix.command }}
+        uses: Extra-Chill/homeboy-action@v2
         with:
-          commands: audit
+          commands: ${{ matrix.command }}
+          expected-commands: audit,lint,test
           app-token: ${{ steps.app-token.outputs.token || '' }}
           autofix: 'false'


### PR DESCRIPTION
## Summary
- Split the Homeboy workflow into separate `audit`, `lint`, and `test` matrix checks.
- Pass `expected-commands: audit,lint,test` on each invocation so Homeboy Action can reconcile split command results without sibling jobs fighting over comments/issues.

## Why
The current workflow runs Homeboy as one opaque action step. When one command hangs or runs long, the whole check is hard to diagnose and the other command signals are hidden. Homeboy Action now supports split invocations; this updates Data Machine to that shape.

## Tests
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/homeboy.yml"); puts "YAML OK"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workflow-only CI update and PR description; Chris identified the stale Homeboy Action usage pattern.
