### PR TITLE
fix(agents): normalize missing status as active

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -513,11 +513,13 @@ class AgentAbilities {
 		}
 
 		// ---- Status filter -----------------------------------------------
+		$status_for_row = static fn( array $row ): string => (string) ( ( $row['status'] ?? '' ) ?: 'active' );
+
 		if ( 'any' !== $status ) {
 			$candidates = array_values(
 				array_filter(
 					$candidates,
-					static fn( $row ) => ( $row['status'] ?? '' ) === $status
+					static fn( $row ) => $status_for_row( $row ) === $status
 				)
 			);
 		}
@@ -547,8 +549,9 @@ class AgentAbilities {
 		foreach ( $candidates as $row ) {
 			$agent_id   = (int) $row['agent_id'];
 			$owner_id   = (int) $row['owner_id'];
-			$config     = is_array( $row['agent_config'] ?? null ) ? $row['agent_config'] : array();
+			$config      = is_array( $row['agent_config'] ?? null ) ? $row['agent_config'] : array();
 			$description = isset( $config['description'] ) ? (string) $config['description'] : '';
+			$row_status  = $status_for_row( $row );
 
 			$item = array(
 				'agent_id'    => $agent_id,
@@ -556,7 +559,7 @@ class AgentAbilities {
 				'agent_name'  => (string) $row['agent_name'],
 				'owner_id'    => $owner_id,
 				'site_scope'  => isset( $row['site_scope'] ) ? (int) $row['site_scope'] : null,
-				'status'      => (string) ( $row['status'] ?? '' ),
+				'status'      => $row_status,
 				'description' => $description,
 				'is_owner'    => $target_user_id > 0 && $owner_id === $target_user_id,
 			);

--- a/tests/Unit/Abilities/ListAgentsAbilityTest.php
+++ b/tests/Unit/Abilities/ListAgentsAbilityTest.php
@@ -108,26 +108,20 @@ class ListAgentsAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( array(), $result['agents'] );
 	}
 
-	public function test_default_scope_filters_by_status(): void {
+	public function test_default_scope_treats_missing_status_as_active(): void {
 		$active_id = $this->repo->create_if_missing( 'active-agent', 'Active', $this->owner_user );
-		$this->repo->update_agent(
-			$this->repo->create_if_missing( 'inactive-agent', 'Inactive', $this->owner_user ),
-			array( 'status' => 'inactive' )
-		);
 
 		wp_set_current_user( $this->owner_user );
 		$result = AgentAbilities::listAgents( array( 'status' => 'active' ) );
 
 		$this->assertCount( 1, $result['agents'] );
 		$this->assertSame( $active_id, $result['agents'][0]['agent_id'] );
+		$this->assertSame( 'active', $result['agents'][0]['status'] );
 	}
 
 	public function test_status_any_skips_status_filter(): void {
 		$this->repo->create_if_missing( 'active-agent', 'Active', $this->owner_user );
-		$this->repo->update_agent(
-			$this->repo->create_if_missing( 'inactive-agent', 'Inactive', $this->owner_user ),
-			array( 'status' => 'inactive' )
-		);
+		$this->repo->create_if_missing( 'another-agent', 'Another', $this->owner_user );
 
 		wp_set_current_user( $this->owner_user );
 		$result = AgentAbilities::listAgents( array( 'status' => 'any' ) );


### PR DESCRIPTION
## Summary
- Normalizes missing or empty agent status values to `active` in `AgentAbilities::listAgents()`.
- Keeps `wp datamachine agents list --status=active` working on fresh schemas where the removed `status` column is absent.
- Updates stale list-agent unit coverage so it no longer depends on mutating a removed status field.

## Why
Data Machine removed the agent `status` field as dead weight, but the CLI/ability still exposes a `status` output field and accepts a `--status` filter. Fresh installs therefore emitted `status: ""` and filtered out every agent for `--status=active`, while upgraded installs with a legacy column still emitted `active`. Downstream setup tools hit that fresh-vs-upgraded drift in Extra-Chill/wp-coding-agents#79.

## Tests
- `php -l inc/Abilities/AgentAbilities.php`
- `php -l tests/Unit/Abilities/ListAgentsAbilityTest.php`
- `git diff --check`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-agent-status-list-contract`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-agent-status-list-contract --changed-since origin/main`

Note: the current Homeboy WordPress test extension only ran its bootstrap sentinel test in this worktree; the changed unit file was syntax-checked but not executed by that runner.

Refs Extra-Chill/wp-coding-agents#79.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the downstream setup drift, drafting the minimal normalization fix, and running local verification. Chris remains responsible for review and merge.
