### PR TITLE
fix(agents): drop stale status field references (regression from #1112)

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -92,10 +92,6 @@ class AgentAbilities {
 								'type'        => 'integer',
 								'description' => 'Filter by site_scope. Matches the exact site OR network-wide (NULL) agents. Defaults to current blog.',
 							),
-							'status'       => array(
-								'type'        => 'string',
-								'description' => 'Filter by agent status. Defaults to "active". Pass "any" to skip status filtering.',
-							),
 							'include_role' => array(
 								'type'        => 'boolean',
 								'description' => 'When true, enriches each row with the resolved user\'s role on that agent.',
@@ -116,7 +112,6 @@ class AgentAbilities {
 										'agent_name'  => array( 'type' => 'string' ),
 										'owner_id'    => array( 'type' => 'integer' ),
 										'site_scope'  => array( 'type' => array( 'integer', 'null' ) ),
-										'status'      => array( 'type' => 'string' ),
 										'description' => array( 'type' => 'string' ),
 										'is_owner'    => array( 'type' => 'boolean' ),
 										'user_role'   => array( 'type' => array( 'string', 'null' ) ),
@@ -221,7 +216,7 @@ class AgentAbilities {
 				'datamachine/update-agent',
 				array(
 					'label'               => 'Update Agent',
-					'description'         => 'Update an agent\'s mutable fields (name, config, status)',
+					'description'         => 'Update an agent\'s mutable fields (name, config)',
 					'category'            => 'datamachine-agent',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -238,10 +233,6 @@ class AgentAbilities {
 							'agent_config' => array(
 								'type'        => 'object',
 								'description' => 'New agent configuration (replaces existing config).',
-							),
-							'status'       => array(
-								'type'        => 'string',
-								'description' => 'New status (active, inactive, archived).',
 							),
 						),
 					),
@@ -441,7 +432,6 @@ class AgentAbilities {
 		$scope        = isset( $input['scope'] ) ? (string) $input['scope'] : 'mine';
 		$requested_user_id = isset( $input['user_id'] ) ? (int) $input['user_id'] : 0;
 		$site_id      = isset( $input['site_id'] ) ? (int) $input['site_id'] : get_current_blog_id();
-		$status       = isset( $input['status'] ) ? (string) $input['status'] : 'active';
 		$include_role = ! empty( $input['include_role'] );
 
 		if ( ! in_array( $scope, array( 'mine', 'all' ), true ) ) {
@@ -512,16 +502,6 @@ class AgentAbilities {
 			);
 		}
 
-		// ---- Status filter -----------------------------------------------
-		if ( 'any' !== $status ) {
-			$candidates = array_values(
-				array_filter(
-					$candidates,
-					static fn( $row ) => ( $row['status'] ?? '' ) === $status
-				)
-			);
-		}
-
 		// ---- Final access gate (mine only) -------------------------------
 		//
 		// When listing the caller's OWN agents, defence-in-depth: run each
@@ -556,7 +536,6 @@ class AgentAbilities {
 				'agent_name'  => (string) $row['agent_name'],
 				'owner_id'    => $owner_id,
 				'site_scope'  => isset( $row['site_scope'] ) ? (int) $row['site_scope'] : null,
-				'status'      => (string) ( $row['status'] ?? '' ),
 				'description' => $description,
 				'is_owner'    => $target_user_id > 0 && $owner_id === $target_user_id,
 			);
@@ -777,7 +756,6 @@ class AgentAbilities {
 				'agent_config' => is_array( $agent['agent_config'] ?? null )
 					? $agent['agent_config']
 					: ( json_decode( $agent['agent_config'] ?? '{}', true ) ? json_decode( $agent['agent_config'] ?? '{}', true ) : array() ),
-				'status'       => (string) $agent['status'],
 				'created_at'   => $agent['created_at'] ?? '',
 				'updated_at'   => $agent['updated_at'] ?? '',
 				'agent_dir'    => $agent_dir,
@@ -790,7 +768,7 @@ class AgentAbilities {
 	/**
 	 * Update an agent's mutable fields.
 	 *
-	 * @param array $input { agent_id, agent_name?, agent_config?, status? }.
+	 * @param array $input { agent_id, agent_name?, agent_config? }.
 	 * @return array Result with updated agent data.
 	 */
 	public static function updateAgent( array $input ): array {
@@ -831,22 +809,10 @@ class AgentAbilities {
 			$update['agent_config'] = is_array( $input['agent_config'] ) ? $input['agent_config'] : array();
 		}
 
-		if ( isset( $input['status'] ) ) {
-			$valid_statuses = array( 'active', 'inactive', 'archived' );
-			$status         = sanitize_text_field( $input['status'] );
-			if ( ! in_array( $status, $valid_statuses, true ) ) {
-				return array(
-					'success' => false,
-					'error'   => sprintf( 'Invalid status "%s". Must be one of: %s', $status, implode( ', ', $valid_statuses ) ),
-				);
-			}
-			$update['status'] = $status;
-		}
-
 		if ( empty( $update ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'No fields to update. Provide agent_name, agent_config, or status.',
+				'error'   => 'No fields to update. Provide agent_name or agent_config.',
 			);
 		}
 

--- a/inc/Abilities/AgentTokenAbilities.php
+++ b/inc/Abilities/AgentTokenAbilities.php
@@ -192,13 +192,6 @@ class AgentTokenAbilities {
 			);
 		}
 
-		if ( 'active' !== ( $agent['status'] ?? '' ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Agent is not active', 'data-machine' ),
-			);
-		}
-
 		// Check access — caller must have admin access to the agent.
 		if ( ! PermissionHelper::can_access_agent( $agent_id, 'admin' ) ) {
 			return array(

--- a/inc/Api/Agents.php
+++ b/inc/Api/Agents.php
@@ -392,7 +392,6 @@ class Agents {
 		// Supported query params:
 		//   scope=mine|all      (default 'mine'; 'all' requires admin)
 		//   user_id=<int>       (admin-only; defaults to caller)
-		//   status=<string>     (default 'active'; 'any' to skip)
 		//   include_role=1      (optional; on for list UI by default below)
 
 		$input = array(
@@ -407,11 +406,6 @@ class Agents {
 		$user_id_param = $request->get_param( 'user_id' );
 		if ( null !== $user_id_param && '' !== $user_id_param ) {
 			$input['user_id'] = (int) $user_id_param;
-		}
-
-		$status_param = $request->get_param( 'status' );
-		if ( null !== $status_param && '' !== $status_param ) {
-			$input['status'] = sanitize_key( $status_param );
 		}
 
 		$include_role = $request->get_param( 'include_role' );
@@ -441,7 +435,6 @@ class Agents {
 				'agent_name' => (string) $agent['agent_name'],
 				'owner_id'   => (int) $agent['owner_id'],
 				'site_scope' => $agent['site_scope'] ?? null,
-				'status'     => (string) ( $agent['status'] ?? '' ),
 				'is_owner'   => (bool) ( $agent['is_owner'] ?? false ),
 			);
 

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -42,12 +42,6 @@ class AgentsCommand extends BaseCommand {
 	 * [--user_id=<id>]
 	 * : List accessible agents for a specific user (implies scope=mine).
 	 *
-	 * [--status=<status>]
-	 * : Filter by agent status. Use "any" to skip status filtering.
-	 * ---
-	 * default: any
-	 * ---
-	 *
 	 * [--include_role]
 	 * : Include the resolved user's role per agent in the output.
 	 *
@@ -78,9 +72,7 @@ class AgentsCommand extends BaseCommand {
 	 * @subcommand list
 	 */
 	public function list_agents( array $args, array $assoc_args ): void {
-		$input = array(
-			'status' => (string) \WP_CLI\Utils\get_flag_value( $assoc_args, 'status', 'any' ),
-		);
+		$input = array();
 
 		$user_id_flag = \WP_CLI\Utils\get_flag_value( $assoc_args, 'user_id', null );
 		if ( null !== $user_id_flag ) {
@@ -124,7 +116,6 @@ class AgentsCommand extends BaseCommand {
 				'owner_id'    => $owner_id,
 				'owner_login' => $user ? $user->user_login : '(deleted)',
 				'has_files'   => is_dir( $agent_dir ) ? 'Yes' : 'No',
-				'status'      => (string) ( $agent['status'] ?? '' ),
 			);
 
 			if ( $include_role ) {
@@ -135,7 +126,7 @@ class AgentsCommand extends BaseCommand {
 			$items[] = $row;
 		}
 
-		$fields = array( 'agent_id', 'agent_slug', 'agent_name', 'owner_id', 'owner_login', 'has_files', 'status' );
+		$fields = array( 'agent_id', 'agent_slug', 'agent_name', 'owner_id', 'owner_login', 'has_files' );
 		if ( $include_role ) {
 			$fields[] = 'user_role';
 		}
@@ -340,7 +331,6 @@ class AgentsCommand extends BaseCommand {
 		WP_CLI::log( sprintf( 'Slug:        %s', $agent['agent_slug'] ) );
 		WP_CLI::log( sprintf( 'Name:        %s', $agent['agent_name'] ) );
 		WP_CLI::log( sprintf( 'Owner:       %s (ID: %d)', $owner ? $owner->user_login : '(deleted)', $agent['owner_id'] ) );
-		WP_CLI::log( sprintf( 'Status:      %s', $agent['status'] ) );
 		WP_CLI::log( sprintf( 'Created:     %s', $agent['created_at'] ) );
 		WP_CLI::log( sprintf( 'Updated:     %s', $agent['updated_at'] ) );
 		WP_CLI::log( sprintf( 'Directory:   %s', $agent['agent_dir'] ) );

--- a/inc/Core/Admin/Pages/Agent/assets/react/components/AgentEditView.jsx
+++ b/inc/Core/Admin/Pages/Agent/assets/react/components/AgentEditView.jsx
@@ -33,15 +33,6 @@ import {
 } from '../queries/agents';
 
 /**
- * Status options for the dropdown.
- */
-const STATUS_OPTIONS = [
-	{ label: __( 'Active', 'data-machine' ), value: 'active' },
-	{ label: __( 'Inactive', 'data-machine' ), value: 'inactive' },
-	{ label: __( 'Archived', 'data-machine' ), value: 'archived' },
-];
-
-/**
  * Role options for access grants.
  */
 const ROLE_OPTIONS = [
@@ -245,14 +236,12 @@ const AgentEditView = ( { agentId, onBack } ) => {
 	const updateMutation = useUpdateAgent();
 
 	const [ name, setName ] = useState( '' );
-	const [ status, setStatus ] = useState( 'active' );
 	const [ saveMessage, setSaveMessage ] = useState( null );
 
 	// Sync form state when agent data loads.
 	useEffect( () => {
 		if ( agent ) {
 			setName( agent.agent_name || '' );
-			setStatus( agent.status || 'active' );
 		}
 	}, [ agent ] );
 
@@ -262,7 +251,6 @@ const AgentEditView = ( { agentId, onBack } ) => {
 		const result = await updateMutation.mutateAsync( {
 			agentId,
 			agent_name: name,
-			status,
 		} );
 
 		if ( result.success ) {
@@ -302,9 +290,7 @@ const AgentEditView = ( { agentId, onBack } ) => {
 		);
 	}
 
-	const isDirty =
-		name !== ( agent.agent_name || '' ) ||
-		status !== ( agent.status || 'active' );
+	const isDirty = name !== ( agent.agent_name || '' );
 
 	return (
 		<div className="datamachine-agent-edit-view">
@@ -348,13 +334,6 @@ const AgentEditView = ( { agentId, onBack } ) => {
 						label={ __( 'Display Name', 'data-machine' ) }
 						value={ name }
 						onChange={ setName }
-					/>
-
-					<SelectControl
-						label={ __( 'Status', 'data-machine' ) }
-						value={ status }
-						options={ STATUS_OPTIONS }
-						onChange={ setStatus }
 					/>
 
 					<div className="datamachine-agent-meta">

--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -306,7 +306,7 @@ class Agents extends BaseRepository {
 	 * @return bool True on success, false on DB failure or no valid fields.
 	 */
 	public function update_agent( int $agent_id, array $data ): bool {
-		$allowed = array( 'agent_name', 'agent_config', 'status' );
+		$allowed = array( 'agent_name', 'agent_config' );
 		$update  = array();
 		$formats = array();
 

--- a/tests/Unit/Abilities/AgentAbilitiesTest.php
+++ b/tests/Unit/Abilities/AgentAbilitiesTest.php
@@ -232,25 +232,6 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'New Name', $result['agent']['agent_name'] );
 	}
 
-	public function test_updateAgent_status(): void {
-		$created = AgentAbilities::createAgent(
-			array(
-				'agent_slug' => 'status-bot',
-				'owner_id'   => $this->admin_id,
-			)
-		);
-
-		$result = AgentAbilities::updateAgent(
-			array(
-				'agent_id' => $created['agent_id'],
-				'status'   => 'inactive',
-			)
-		);
-
-		$this->assertTrue( $result['success'] );
-		$this->assertSame( 'inactive', $result['agent']['status'] );
-	}
-
 	public function test_updateAgent_config(): void {
 		$created = AgentAbilities::createAgent(
 			array(
@@ -283,15 +264,15 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 
 		$result = AgentAbilities::updateAgent(
 			array(
-				'agent_id'   => $created['agent_id'],
-				'agent_name' => 'After',
-				'status'     => 'archived',
+				'agent_id'     => $created['agent_id'],
+				'agent_name'   => 'After',
+				'agent_config' => array( 'provider' => 'anthropic' ),
 			)
 		);
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( 'After', $result['agent']['agent_name'] );
-		$this->assertSame( 'archived', $result['agent']['status'] );
+		$this->assertSame( 'anthropic', $result['agent']['agent_config']['provider'] );
 	}
 
 	public function test_updateAgent_requires_agent_id(): void {
@@ -330,25 +311,6 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 
 		$this->assertFalse( $result['success'] );
 		$this->assertStringContainsString( 'empty', $result['error'] );
-	}
-
-	public function test_updateAgent_rejects_invalid_status(): void {
-		$created = AgentAbilities::createAgent(
-			array(
-				'agent_slug' => 'bad-status-bot',
-				'owner_id'   => $this->admin_id,
-			)
-		);
-
-		$result = AgentAbilities::updateAgent(
-			array(
-				'agent_id' => $created['agent_id'],
-				'status'   => 'deleted',
-			)
-		);
-
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'Invalid status', $result['error'] );
 	}
 
 	public function test_updateAgent_rejects_no_fields(): void {

--- a/tests/Unit/Abilities/ListAgentsAbilityTest.php
+++ b/tests/Unit/Abilities/ListAgentsAbilityTest.php
@@ -68,6 +68,23 @@ class ListAgentsAbilityTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['agents'][0]['is_owner'] );
 	}
 
+	/**
+	 * Regression: the agents table has no `status` column (#1080), so a
+	 * stale status='active' filter would silently exclude every row.
+	 * Default-arg listing must return owned rows without any status check.
+	 */
+	public function test_default_scope_returns_rows_without_status_column(): void {
+		$this->repo->create_if_missing( 'one', 'One', $this->owner_user );
+		$this->repo->create_if_missing( 'two', 'Two', $this->owner_user );
+
+		wp_set_current_user( $this->owner_user );
+		$result = AgentAbilities::listAgents( array() );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertCount( 2, $result['agents'] );
+		$this->assertArrayNotHasKey( 'status', $result['agents'][0] );
+	}
+
 	public function test_default_scope_returns_granted_agents_for_non_admin(): void {
 		$agent_id = $this->repo->create_if_missing( 'shared', 'Shared', $this->owner_user );
 		$this->access_repo->grant_access( $agent_id, $this->granted_user, 'operator' );
@@ -106,33 +123,6 @@ class ListAgentsAbilityTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( array(), $result['agents'] );
-	}
-
-	public function test_default_scope_filters_by_status(): void {
-		$active_id = $this->repo->create_if_missing( 'active-agent', 'Active', $this->owner_user );
-		$this->repo->update_agent(
-			$this->repo->create_if_missing( 'inactive-agent', 'Inactive', $this->owner_user ),
-			array( 'status' => 'inactive' )
-		);
-
-		wp_set_current_user( $this->owner_user );
-		$result = AgentAbilities::listAgents( array( 'status' => 'active' ) );
-
-		$this->assertCount( 1, $result['agents'] );
-		$this->assertSame( $active_id, $result['agents'][0]['agent_id'] );
-	}
-
-	public function test_status_any_skips_status_filter(): void {
-		$this->repo->create_if_missing( 'active-agent', 'Active', $this->owner_user );
-		$this->repo->update_agent(
-			$this->repo->create_if_missing( 'inactive-agent', 'Inactive', $this->owner_user ),
-			array( 'status' => 'inactive' )
-		);
-
-		wp_set_current_user( $this->owner_user );
-		$result = AgentAbilities::listAgents( array( 'status' => 'any' ) );
-
-		$this->assertCount( 2, $result['agents'] );
 	}
 
 	// ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Drop the stale `status` field from the agents code path. The column was removed in #1080 ("dead weight, no enforcement, token revocation is better"), but #1112 reintroduced a `status='active'` filter on `listAgents` and the related read/update/UI plumbing was never cleaned up either.

## Reproduction (before this PR)

On any clean v0.84.x install with one or more agents in `wp_datamachine_agents`:

```bash
wp eval '
wp_set_current_user(1);
$req = new WP_REST_Request("GET", "/datamachine/v1/agents");
print_r(rest_do_request($req)->get_data());
'
# => Array ( [success] => 1 [data] => Array ( ) )   ← admin sees no agents
```

The Agents admin React page shows zero agents on every install.

`SELECT status FROM wp_datamachine_agents` errors with **"no such column: status"** because `Agents::create_table()` never declared one — `listAgents` was filtering rows on a column that doesn't exist, dropping them all.

## Why drop instead of restore

#1080 already made the call: status was dead weight (every agent created active, nothing changes it, AgentAuthMiddleware enforcement was weaker than token revocation). Restoring the column would re-introduce the same dead weight. Drop is the consistent move.

## What's removed

- `inc/Abilities/AgentAbilities.php` — `status` filter, list/update schema entries, getAgent output, error string
- `inc/Core/Database/Agents/Agents.php` — `status` from `update_agent` allowlist
- `inc/Api/Agents.php` — `status` REST query param + response field
- `inc/Abilities/AgentTokenAbilities.php` — `'active' !== status` gate before token issuance (always failed because column was missing)
- `inc/Cli/Commands/AgentsCommand.php` — `--status` flag, list/detail output column
- `inc/Core/Admin/Pages/Agent/assets/react/components/AgentEditView.jsx` — `STATUS_OPTIONS`, status state, SelectControl, dirty check
- `tests/Unit/Abilities/{AgentAbilitiesTest,ListAgentsAbilityTest}.php` — drop status-only assertions; rewrite the multi-field update test against `agent_config` instead

Adds `test_default_scope_returns_rows_without_status_column` as an explicit regression guard.

## Test plan

- [ ] CI green (homeboy audit + lint + test)
- [ ] On a fresh install with seeded agents, `/datamachine/v1/agents` returns the rows
- [ ] Agents admin React page lists agents
- [ ] `wp datamachine agents list` shows agents with no `status` column
- [ ] Token issuance via the agent_token ability works regardless of agent age
- [ ] Editing an agent in the admin UI updates name/config (no status field shown)

## Refs

- #1080 — original removal of agent status field
- #1112 — refactor that reintroduced the filter without restoring the column
