### PR TITLE
fix(flow): drain due step actions after CLI runs

### DIFF
--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -84,6 +84,9 @@ class FlowsCommand extends BaseCommand {
 	 * [--timestamp=<unix>]
 	 * : Unix timestamp for delayed execution (future time required).
 	 *
+	 * [--no-drain]
+	 * : Skip the default CLI drain of due datamachine_execute_step actions after an immediate run.
+	 *
 	 * [--pipeline_id=<id>]
 	 * : Pipeline ID for flow creation (create subcommand).
 	 *
@@ -313,7 +316,7 @@ class FlowsCommand extends BaseCommand {
 		} elseif ( ! empty( $args ) && 'run' === $args[0] ) {
 			// Handle 'run' subcommand: `flows run 42`.
 			if ( ! isset( $args[1] ) ) {
-				WP_CLI::error( 'Usage: wp datamachine flows run <flow_id> [--count=N] [--timestamp=T]' );
+				WP_CLI::error( 'Usage: wp datamachine flows run <flow_id> [--count=N] [--timestamp=T] [--no-drain]' );
 				return;
 			}
 			$this->runFlow( (int) $args[1], $assoc_args );
@@ -868,6 +871,7 @@ class FlowsCommand extends BaseCommand {
 	private function runFlow( int $flow_id, array $assoc_args ): void {
 		$count     = isset( $assoc_args['count'] ) ? (int) $assoc_args['count'] : 1;
 		$timestamp = isset( $assoc_args['timestamp'] ) ? (int) $assoc_args['timestamp'] : null;
+		$drain     = ! isset( $assoc_args['no-drain'] );
 
 		// Validate count range (1-10).
 		if ( $count < 1 || $count > 10 ) {
@@ -937,6 +941,43 @@ class FlowsCommand extends BaseCommand {
 			WP_CLI::success( sprintf( 'Flow %d: %d/%d runs started.', $flow_id, count( $job_ids ), $count ) );
 			WP_CLI::log( sprintf( 'Job IDs: %s', implode( ', ', array_filter( $job_ids ) ) ) );
 		}
+
+		if ( $drain ) {
+			$this->drainDueStepActions();
+		}
+	}
+
+	/**
+	 * Drain due Data Machine step actions after manual CLI flow runs.
+	 *
+	 * Studio/local CLI runs can enqueue due step actions without any HTTP traffic
+	 * to tick Action Scheduler. Reuse Action Scheduler's CLI runner and scope the
+	 * drain to DM step actions so manual `flow run` advances the work it just queued.
+	 */
+	private function drainDueStepActions(): void {
+		if ( ! class_exists( '\WP_CLI' ) || ! method_exists( WP_CLI::class, 'runcommand' ) ) {
+			return;
+		}
+
+		$result = WP_CLI::runcommand(
+			'action-scheduler run --hooks=datamachine_execute_step --quiet',
+			array(
+				'exit_error' => false,
+				'return'     => 'all',
+			)
+		);
+
+		if ( 0 === (int) ( $result->return_code ?? 1 ) ) {
+			WP_CLI::log( 'Drained due Data Machine step actions.' );
+			return;
+		}
+
+		$message = trim( (string) ( $result->stderr ?? '' ) );
+		if ( '' === $message ) {
+			$message = 'Action Scheduler CLI drain failed.';
+		}
+
+		WP_CLI::warning( $message );
 	}
 
 	/**

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Pure-PHP smoke test for CLI flow-run Action Scheduler draining (#1374).
+ *
+ * Run with: php tests/flow-run-cli-drain-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$file = __DIR__ . '/../inc/Cli/Commands/Flows/FlowsCommand.php';
+$src  = file_get_contents( $file );
+
+$assertions = 0;
+
+function assert_true( bool $condition, string $message ): void {
+	global $assertions;
+	++$assertions;
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function assert_contains( string $needle, string $haystack, string $message ): void {
+	assert_true( false !== strpos( $haystack, $needle ), $message );
+}
+
+function assert_not_contains( string $needle, string $haystack, string $message ): void {
+	assert_true( false === strpos( $haystack, $needle ), $message );
+}
+
+assert_contains( '[--no-drain]', $src, 'flow run usage documents --no-drain escape hatch' );
+assert_contains( '$drain     = ! isset( $assoc_args[\'no-drain\'] );', $src, 'immediate runs drain by default' );
+assert_contains( 'if ( $drain ) {', $src, 'drain is gated by the CLI flag' );
+assert_contains( '$this->drainDueStepActions();', $src, 'immediate run calls the drain helper' );
+assert_contains( 'private function drainDueStepActions(): void', $src, 'drain helper exists' );
+assert_contains( 'WP_CLI::runcommand(', $src, 'drain helper reuses WP-CLI command runner' );
+assert_contains( 'action-scheduler run --hooks=datamachine_execute_step --quiet', $src, 'drain is scoped to due DM step actions' );
+assert_contains( "'exit_error' => false", $src, 'drain failure is surfaced as warning instead of fataling after job start' );
+assert_contains( "'return'     => 'all'", $src, 'drain captures Action Scheduler command result' );
+assert_contains( 'Drained due Data Machine step actions.', $src, 'successful drain is visible to CLI operator' );
+
+$run_flow_start = strpos( $src, 'private function runFlow' );
+$timestamp_path = strpos( $src, '// Delayed execution', $run_flow_start );
+$immediate_path = strpos( $src, '// Immediate execution', $run_flow_start );
+$drain_call     = strpos( $src, '$this->drainDueStepActions();', $run_flow_start );
+
+assert_true( false !== $run_flow_start, 'runFlow method found' );
+assert_true( false !== $timestamp_path, 'delayed scheduling path found' );
+assert_true( false !== $immediate_path, 'immediate execution path found' );
+assert_true( false !== $drain_call, 'drain call found in runFlow' );
+assert_true( $drain_call > $immediate_path, 'drain runs only after immediate execution starts jobs' );
+assert_true( $drain_call > $timestamp_path, 'timestamp scheduling returns before the drain call' );
+
+$helper_src = substr( $src, strpos( $src, 'private function drainDueStepActions(): void' ) );
+assert_not_contains( 'datamachine_run_flow_now', $helper_src, 'drain does not run scheduled flow-trigger actions' );
+
+echo "OK ({$assertions} assertions)\n";


### PR DESCRIPTION
## Summary
- Drain due `datamachine_execute_step` actions after immediate CLI `flow run` commands so Studio/local manual runs do not sit pending until an external Action Scheduler tick.
- Add `--no-drain` for operators who want the previous fire-and-forget CLI behavior.

## Changes
- `wp datamachine flows run <flow_id>` now calls Action Scheduler's own CLI runner scoped to `--hooks=datamachine_execute_step` after successful immediate runs.
- Delayed `--timestamp` scheduling remains schedule-only and returns before any drain path.
- Added a focused pure-PHP smoke that pins the CLI flag, drain scope, and timestamp-vs-immediate behavior.

## Tests
- `php -l inc/Cli/Commands/Flows/FlowsCommand.php`
- `php -l tests/flow-run-cli-drain-smoke.php`
- `php tests/flow-run-cli-drain-smoke.php`
- `php tests/execute-workflow-initial-data-contract-smoke.php`
- `homeboy audit data-machine --path . --changed-since origin/main`

`homeboy lint data-machine --path .` currently fails before findings with `/Users/chubes/.config/homeboy/extensions/wordpress/scripts/lint/lint-runner.sh: line 114: PLUGIN_PATH: unbound variable`, matching the known WordPress lint runner gap.

Closes #1374

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the CLI drain path, adding the smoke test, and running focused verification. Chris remains responsible for review and merge.