### PR TITLE
fix(ai): preserve handler tool metadata for upsert handoff

### DIFF
--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -274,12 +274,11 @@ class ToolManager {
 			}
 
 			// Handler callables follow two conventions:
-			// 1. Filter-style: ($tools, $handler_slug, $handler_config, $engine_data) — 4 params
-			// 2. Direct-style: ($handler_slug, $handler_config, $engine_data) — 3 params
-			// Detect by parameter count so both work correctly.
-			$callable         = $definition['_handler_callable'];
-			$callable_params  = $this->get_callable_param_count( $callable );
-			$uses_filter_convention = ( $callable_params >= 4 );
+			// 1. Filter-style: ($tools, $handler_slug, $handler_config[, $engine_data])
+			// 2. Direct-style: ($handler_slug, $handler_config, $engine_data)
+			// Detect by shape so 3-param filter callbacks are not mistaken for direct-style.
+			$callable = $definition['_handler_callable'];
+			$uses_filter_convention = $this->uses_filter_convention( $callable );
 
 			if ( $uses_filter_convention ) {
 				$tool_map = call_user_func(
@@ -633,23 +632,50 @@ class ToolManager {
 	}
 
 	/**
-	 * Get the number of parameters a callable accepts.
+	 * Determine whether a handler tool callback uses filter-style arguments.
 	 *
 	 * @param callable $callable Callable to inspect.
-	 * @return int Number of required+optional parameters, or 0 if unresolvable.
+	 * @return bool True for ($tools, $handler_slug, ...) callbacks.
 	 */
-	private function get_callable_param_count( $callable ): int {
+	private function uses_filter_convention( $callable ): bool {
 		try {
-			if ( is_array( $callable ) ) {
-				$ref = new \ReflectionMethod( $callable[0], $callable[1] );
-			} elseif ( $callable instanceof \Closure || is_string( $callable ) ) {
-				$ref = new \ReflectionFunction( $callable );
-			} else {
-				return 0;
+			$ref = $this->reflect_callable( $callable );
+			if ( null === $ref ) {
+				return false;
 			}
-			return $ref->getNumberOfParameters();
+
+			$params = $ref->getParameters();
+			if ( empty( $params ) ) {
+				return false;
+			}
+
+			if ( count( $params ) >= 4 ) {
+				return true;
+			}
+
+			$first_param_name = $params[0]->getName();
+			return in_array( $first_param_name, array( 'tools', 'all_tools' ), true );
 		} catch ( \ReflectionException $e ) {
-			return 0;
+			return false;
 		}
+	}
+
+	/**
+	 * Reflect a callable into a function-like reflection object.
+	 *
+	 * @param callable $callable Callable to inspect.
+	 * @return \ReflectionFunctionAbstract|null Reflection object, or null when unsupported.
+	 * @throws \ReflectionException When reflection fails.
+	 */
+	private function reflect_callable( $callable ): ?\ReflectionFunctionAbstract {
+		if ( is_array( $callable ) ) {
+			return new \ReflectionMethod( $callable[0], $callable[1] );
+		}
+
+		if ( $callable instanceof \Closure || is_string( $callable ) ) {
+			return new \ReflectionFunction( $callable );
+		}
+
+		return null;
 	}
 }

--- a/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
+++ b/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
@@ -89,6 +89,56 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'job_id' => 99 ), $resolved['widget_publish']['_observed']['engine'] );
 	}
 
+	public function test_resolves_three_param_filter_style_handler_callable_before_static_tool(): void {
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ): array {
+				$tools['wiki_upsert'] = array(
+					'description' => 'Global wiki upsert tool',
+					'modes'       => array( 'pipeline' ),
+				);
+
+				$tools['__handler_tools_wiki_upsert'] = array(
+					'_handler_callable' => static function ( $tools, $handler_slug, $handler_config ) {
+						if ( 'wiki_upsert' !== $handler_slug ) {
+							return $tools;
+						}
+
+						$tools['wiki_upsert'] = array(
+							'description' => 'Handler-scoped wiki upsert tool',
+							'parameters'  => array(),
+							'config_seen' => $handler_config,
+						);
+
+						return $tools;
+					},
+					'handler'           => 'wiki_upsert',
+					'modes'             => array( 'pipeline' ),
+					'access_level'      => 'admin',
+				);
+
+				return $tools;
+			}
+		);
+
+		$resolver = new ToolPolicyResolver();
+		$tools    = $resolver->resolve(
+			array(
+				'mode'             => ToolPolicyResolver::MODE_PIPELINE,
+				'next_step_config' => array(
+					'flow_step_id'    => 'fs_wiki_upsert',
+					'handler_slugs'   => array( 'wiki_upsert' ),
+					'handler_configs' => array( 'wiki_upsert' => array( 'fixed_parent_path' => 'woocommerce' ) ),
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 'wiki_upsert', $tools );
+		$this->assertSame( 'wiki_upsert', $tools['wiki_upsert']['handler'] );
+		$this->assertSame( 'Handler-scoped wiki upsert tool', $tools['wiki_upsert']['description'] );
+		$this->assertSame( array( 'fixed_parent_path' => 'woocommerce' ), $tools['wiki_upsert']['config_seen'] );
+	}
+
 	public function test_skips_handler_tools_with_non_matching_slug(): void {
 		add_filter(
 			'datamachine_tools',

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Tests\Unit\Core\Steps\AI;
 
 use DataMachine\Core\Steps\AI\AIStep;
+use DataMachine\Engine\AI\Tools\ToolResultFinder;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -182,6 +183,55 @@ class AIStepTest extends TestCase {
 		);
 
 		$this->assertSame( 'ticketmaster', $result[0]['metadata']['source_type'] );
+	}
+
+	public function test_successful_handler_tool_result_is_findable_by_downstream_handler_slug(): void {
+		$method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
+		$method->setAccessible( true );
+
+		$loop_result = array(
+			'messages'               => array(
+				array( 'role' => 'assistant', 'content' => 'I updated the wiki article.' ),
+			),
+			'tool_execution_results' => array(
+				array(
+					'tool_name'       => 'wiki_upsert',
+					'result'          => array(
+						'success' => true,
+						'action'  => 'updated',
+						'article' => array( 'id' => 538, 'title' => 'WooCommerce Ownership Manager' ),
+					),
+					'parameters'      => array( 'title' => 'WooCommerce Ownership Manager' ),
+					'is_handler_tool' => true,
+					'turn_count'      => 2,
+				),
+			),
+		);
+
+		$result = $method->invoke(
+			null,
+			$loop_result,
+			array(
+				array(
+					'type'     => 'fetch',
+					'metadata' => array( 'source_type' => 'mcp' ),
+				),
+			),
+			array( 'flow_step_id' => 'ai_step' ),
+			array(
+				'wiki_upsert' => array(
+					'handler'        => 'wiki_upsert',
+					'handler_config' => array( 'fixed_parent_path' => 'woocommerce' ),
+				),
+			)
+		);
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'ai_handler_complete', $result[0]['type'] );
+		$this->assertSame( 'wiki_upsert', $result[0]['metadata']['handler_tool'] );
+
+		$found = ToolResultFinder::findHandlerResult( $result, 'wiki_upsert', 'upsert_step', false );
+		$this->assertSame( $result[0], $found );
 	}
 
 	/**

--- a/tests/upsert-handler-result-handoff-smoke.php
+++ b/tests/upsert-handler-result-handoff-smoke.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Pure-PHP smoke test for AI handler-result handoff to upsert validation.
+ *
+ * Run with: php tests/upsert-handler-result-handoff-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$__filters = array();
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['__filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	if ( empty( $GLOBALS['__filters'][ $hook ] ) ) {
+		return $value;
+	}
+
+	ksort( $GLOBALS['__filters'][ $hook ] );
+	foreach ( $GLOBALS['__filters'][ $hook ] as $callbacks ) {
+		foreach ( $callbacks as $entry ) {
+			$callback      = $entry[0];
+			$accepted_args = $entry[1];
+			$call_args     = array_slice( array_merge( array( $value ), $args ), 0, $accepted_args );
+			$value         = $callback( ...$call_args );
+		}
+	}
+
+	return $value;
+}
+
+function do_action( string $hook, ...$args ): void {
+	$GLOBALS['__actions'][] = array( $hook, $args );
+}
+
+function did_action( string $hook ): int {
+	return 'init' === $hook ? 1 : 0;
+}
+
+function current_action(): string {
+	return '';
+}
+
+function get_option( string $key, $default = false ) {
+	return $default;
+}
+
+require_once __DIR__ . '/../inc/Core/DataPacket.php';
+require_once __DIR__ . '/../inc/Core/PluginSettings.php';
+require_once __DIR__ . '/../inc/Core/Steps/Step.php';
+require_once __DIR__ . '/../inc/Core/Steps/StepTypeRegistrationTrait.php';
+require_once __DIR__ . '/../inc/Core/Steps/QueueableTrait.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Engine/AI/ConversationManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolResultFinder.php';
+require_once __DIR__ . '/../inc/Core/Steps/AI/AIStep.php';
+
+use DataMachine\Core\Steps\AI\AIStep;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
+use DataMachine\Engine\AI\Tools\ToolResultFinder;
+
+$passes   = 0;
+$failures = array();
+
+function assert_handoff_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+echo "Upsert handler result handoff smoke (#1375)\n";
+echo "------------------------------------------\n\n";
+
+add_filter(
+	'datamachine_tools',
+	static function ( array $tools ): array {
+		$tools['wiki_upsert'] = array(
+			'description' => 'Global wiki upsert tool',
+			'modes'       => array( 'pipeline' ),
+		);
+
+		$tools['__handler_tools_wiki_upsert'] = array(
+			'_handler_callable' => static function ( $tools, $handler_slug, $handler_config ) {
+				if ( 'wiki_upsert' !== $handler_slug ) {
+					return $tools;
+				}
+
+				$tools['wiki_upsert'] = array(
+					'description' => 'Handler-scoped wiki upsert tool',
+					'parameters'  => array(),
+					'config_seen' => $handler_config,
+				);
+
+				return $tools;
+			},
+			'handler'           => 'wiki_upsert',
+			'modes'             => array( 'pipeline' ),
+			'access_level'      => 'admin',
+		);
+
+		return $tools;
+	}
+);
+
+$resolver        = new ToolPolicyResolver();
+$available_tools = $resolver->resolve(
+	array(
+		'mode'             => ToolPolicyResolver::MODE_PIPELINE,
+		'next_step_config' => array(
+			'flow_step_id'    => 'upsert_step',
+			'step_type'       => 'upsert',
+			'handler_slugs'   => array( 'wiki_upsert' ),
+			'handler_configs' => array( 'wiki_upsert' => array( 'fixed_parent_path' => 'woocommerce' ) ),
+		),
+	)
+);
+
+assert_handoff_equals( true, isset( $available_tools['wiki_upsert'] ), 'handler-scoped wiki_upsert tool resolved', $failures, $passes );
+assert_handoff_equals( 'wiki_upsert', $available_tools['wiki_upsert']['handler'] ?? null, 'handler slug metadata survives name collision', $failures, $passes );
+assert_handoff_equals( 'Handler-scoped wiki upsert tool', $available_tools['wiki_upsert']['description'] ?? null, 'handler definition wins over global tool', $failures, $passes );
+
+$method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
+
+$packets = $method->invoke(
+	null,
+	array(
+		'messages'               => array(
+			array( 'role' => 'assistant', 'content' => 'Updated the article.' ),
+		),
+		'tool_execution_results' => array(
+			array(
+				'tool_name'       => 'wiki_upsert',
+				'result'          => array(
+					'success' => true,
+					'action'  => 'updated',
+					'article' => array( 'id' => 538, 'title' => 'WooCommerce Ownership Manager' ),
+				),
+				'parameters'      => array( 'title' => 'WooCommerce Ownership Manager' ),
+				'is_handler_tool' => true,
+				'turn_count'      => 2,
+			),
+		),
+	),
+	array(
+		array(
+			'type'     => 'fetch',
+			'metadata' => array( 'source_type' => 'mcp' ),
+		),
+	),
+	array( 'flow_step_id' => 'ai_step' ),
+	$available_tools
+);
+
+assert_handoff_equals( 1, count( $packets ), 'AI step emitted one downstream packet', $failures, $passes );
+assert_handoff_equals( 'ai_handler_complete', $packets[0]['type'] ?? null, 'AI step emitted handler-complete packet', $failures, $passes );
+assert_handoff_equals( 'wiki_upsert', $packets[0]['metadata']['handler_tool'] ?? null, 'packet carries required handler slug', $failures, $passes );
+
+$found = ToolResultFinder::findHandlerResult( $packets, 'wiki_upsert', 'upsert_step', false );
+assert_handoff_equals( $packets[0], $found, 'ToolResultFinder finds packet by required handler slug', $failures, $passes );
+
+echo "\n------------------------------------------\n";
+echo "{$passes} / " . ( $passes + count( $failures ) ) . " passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "Failures:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "All checks passed.\n";


### PR DESCRIPTION
## Summary
- Fix handler tool resolution so 3-parameter filter-style handler callbacks are invoked with the correct argument order.
- Preserve handler-scoped metadata when an adjacent handler tool has the same public name as a global pipeline tool, allowing downstream upsert validation to match the successful AI tool result.

## Changes
- Detect filter-style callbacks by callable shape instead of assuming every 3-parameter callback is direct-style.
- Add regression coverage for the `wiki_upsert` live shape: handler-scoped tool wins the static-name collision, `AIStep` emits `ai_handler_complete`, and `ToolResultFinder` finds it by handler slug.

## Tests
- `php tests/upsert-handler-result-handoff-smoke.php`
- `php tests/tool-policy-resolver-adjacency-smoke.php`
- `php -l inc/Engine/AI/Tools/ToolManager.php`
- `php -l tests/upsert-handler-result-handoff-smoke.php`
- `php -l tests/Unit/AI/Tools/HandlerToolResolutionTest.php`
- `php -l tests/Unit/Core/Steps/AI/AIStepTest.php`
- `homeboy test data-machine --path "/Users/chubes/Developer/data-machine@fix-upsert-handler-result-handoff" --filter test_resolves_three_param_filter_style_handler_callable_before_static_tool`
- `homeboy test data-machine --path "/Users/chubes/Developer/data-machine@fix-upsert-handler-result-handoff" --filter test_successful_handler_tool_result_is_findable_by_downstream_handler_slug`

Note: `homeboy lint data-machine --path "/Users/chubes/Developer/data-machine@fix-upsert-handler-result-handoff"` currently exits before findings with the known WordPress extension runner issue: `PLUGIN_PATH: unbound variable`.

Closes #1375

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Root-cause tracing from the live failure, implementing the handler callback detection fix, and drafting regression coverage. Chris remains responsible for review and merge.
