### PR TITLE
fix(ai): require only downstream handler blockers

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -253,14 +253,14 @@ class AIStep extends Step {
 		$next_flow_step_id = $navigator->get_next_flow_step_id( $this->flow_step_id, $payload );
 		$next_step_config  = $next_flow_step_id ? $this->engine->getFlowStepConfig( $next_flow_step_id ) : null;
 
-		// Collect handler slugs from adjacent steps for multi-handler tracking.
-		$all_handler_slugs = array();
+		// Collect required handler slugs from adjacent steps for completion tracking.
+		$required_handler_slugs = array();
 		foreach ( array( $previous_step_config, $next_step_config ) as $adj_step_config ) {
 			if ( ! $adj_step_config ) {
 				continue;
 			}
-			$handler_slugs     = FlowStepConfig::getConfiguredHandlerSlugs( $adj_step_config );
-			$all_handler_slugs = array_merge( $all_handler_slugs, $handler_slugs );
+			$handler_slugs          = FlowStepConfig::getRequiredHandlerSlugsForAi( $adj_step_config );
+			$required_handler_slugs = array_merge( $required_handler_slugs, $handler_slugs );
 		}
 
 		$engine_data = $this->engine->all();
@@ -285,17 +285,17 @@ class AIStep extends Step {
 			)
 		);
 
-		// Filter handler slugs to only those that are actual AI tools.
+		// Filter required handler slugs to only those that are actual AI tools.
 		// Previous-step handler slugs (e.g. 'universal_web_scraper') are
 		// pipeline-level fetch handlers, not AI-callable tools. Including
 		// them in configured_handlers causes the conversation loop to wait
 		// forever for a handler that can never fire, resulting in the AI
 		// calling the same handler tool on every turn until max_turns.
 		// See: https://github.com/Extra-Chill/data-machine/issues/1108
-		if ( ! empty( $all_handler_slugs ) ) {
+		if ( ! empty( $required_handler_slugs ) ) {
 			$ai_tool_handler_slugs = array_values(
 				array_intersect(
-					array_unique( $all_handler_slugs ),
+					array_unique( $required_handler_slugs ),
 					array_keys( $available_tools )
 				)
 			);

--- a/inc/Core/Steps/FlowStepConfig.php
+++ b/inc/Core/Steps/FlowStepConfig.php
@@ -187,6 +187,39 @@ class FlowStepConfig {
 	}
 
 	/**
+	 * Resolve handler slugs that must execute before an adjacent AI step completes.
+	 *
+	 * Publish requires every configured handler because it processes all matching
+	 * handler results. Upsert may require only a configured subset; when no
+	 * explicit subset is set, it requires the primary handler only.
+	 *
+	 * @param array $step_config Step configuration array.
+	 * @return array<int, string> Required handler slugs for AI completion.
+	 */
+	public static function getRequiredHandlerSlugsForAi( array $step_config ): array {
+		$step_type = $step_config['step_type'] ?? '';
+
+		if ( 'publish' === $step_type ) {
+			return self::getConfiguredHandlerSlugs( $step_config );
+		}
+
+		if ( 'upsert' !== $step_type ) {
+			return array();
+		}
+
+		$required = $step_config['required_handler_slugs'] ?? array();
+		if ( is_array( $required ) ) {
+			$required = self::sanitizeSlugList( $required );
+			if ( ! empty( $required ) ) {
+				return $required;
+			}
+		}
+
+		$primary = self::getPrimaryHandlerSlug( $step_config );
+		return null === $primary ? array() : array( $primary );
+	}
+
+	/**
 	 * Get the primary handler config from a step config.
 	 *
 	 * @param array $step_config Step configuration array.

--- a/inc/Core/Steps/Upsert/UpsertStep.php
+++ b/inc/Core/Steps/Upsert/UpsertStep.php
@@ -13,6 +13,7 @@
 namespace DataMachine\Core\Steps\Upsert;
 
 use DataMachine\Core\DataPacket;
+use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\Step;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
 use DataMachine\Engine\AI\Tools\ToolResultFinder;
@@ -50,7 +51,7 @@ class UpsertStep extends Step {
 	 */
 	protected function executeStep(): array {
 		$configured_handler_slugs = $this->getHandlerSlugs();
-		$required_handler_slugs   = $this->getRequiredHandlerSlugs( $configured_handler_slugs );
+		$required_handler_slugs   = $this->getRequiredHandlerSlugs();
 		$tool_results_by_slug     = $this->findSuccessfulHandlerResultsBySlug( $required_handler_slugs );
 
 		$missing_required_handlers = array_values( array_diff( $required_handler_slugs, array_keys( $tool_results_by_slug ) ) );
@@ -237,21 +238,10 @@ class UpsertStep extends Step {
 	/**
 	 * Resolve required handler slugs for this upsert step.
 	 *
-	 * @param array $configured_handler_slugs Configured handler slugs.
 	 * @return array
 	 */
-	private function getRequiredHandlerSlugs( array $configured_handler_slugs ): array {
-		$required = $this->getRawRequiredHandlerSlugs();
-
-		if ( ! empty( $required ) ) {
-			return $required;
-		}
-
-		if ( empty( $configured_handler_slugs ) ) {
-			return array();
-		}
-
-		return array( $configured_handler_slugs[0] );
+	private function getRequiredHandlerSlugs(): array {
+		return FlowStepConfig::getRequiredHandlerSlugsForAi( $this->flow_step_config );
 	}
 
 	/**

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -169,8 +169,8 @@ class AIConversationLoop {
 		);
 
 		// Track which handler tools have been executed for multi-handler support.
-		// In pipeline mode, conversation should only complete when ALL configured
-		// handlers have fired, not just the first one.
+		// In pipeline mode, conversation should only complete when all handlers
+		// required by the adjacent step have fired, not just the first one.
 		$executed_handler_slugs = array();
 		$configured_handlers    = $payload['configured_handler_slugs'] ?? array();
 		$configured_handlers    = is_array( $configured_handlers ) ? array_values( $configured_handlers ) : array();

--- a/tests/ai-required-handlers-smoke.php
+++ b/tests/ai-required-handlers-smoke.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Pure-PHP smoke test for AI required handler completion semantics.
+ *
+ * Run with: php tests/ai-required-handlers-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+function do_action( string $hook, ...$args ): void {
+	$GLOBALS['__ai_required_handlers_actions'][] = array( $hook, $args );
+}
+
+function apply_filters( string $hook, $value ) {
+	if ( 'datamachine_step_types' !== $hook ) {
+		return $value;
+	}
+
+	return array(
+		'ai'           => array( 'uses_handler' => false, 'multi_handler' => false ),
+		'system_task'  => array( 'uses_handler' => false, 'multi_handler' => false ),
+		'webhook_gate' => array( 'uses_handler' => false, 'multi_handler' => false ),
+		'fetch'        => array( 'uses_handler' => true, 'multi_handler' => false ),
+		'publish'      => array( 'uses_handler' => true, 'multi_handler' => true ),
+		'upsert'       => array( 'uses_handler' => true, 'multi_handler' => true ),
+	);
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+
+use DataMachine\Core\Steps\FlowStepConfig;
+
+$failures = array();
+$passes   = 0;
+
+function assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function assert_contains( string $needle, string $haystack, string $name, array &$failures, int &$passes ): void {
+	assert_equals( true, str_contains( $haystack, $needle ), $name, $failures, $passes );
+}
+
+function assert_not_contains( string $needle, string $haystack, string $name, array &$failures, int &$passes ): void {
+	assert_equals( false, str_contains( $haystack, $needle ), $name, $failures, $passes );
+}
+
+function resolve_required_ai_handler_tools_for_test( ?array $previous_step_config, ?array $next_step_config, array $available_tools ): array {
+	$required_handler_slugs = array();
+	foreach ( array( $previous_step_config, $next_step_config ) as $adjacent_step_config ) {
+		if ( ! $adjacent_step_config ) {
+			continue;
+		}
+
+		$required_handler_slugs = array_merge(
+			$required_handler_slugs,
+			FlowStepConfig::getRequiredHandlerSlugsForAi( $adjacent_step_config )
+		);
+	}
+
+	return array_values(
+		array_intersect(
+			array_unique( $required_handler_slugs ),
+			array_keys( $available_tools )
+		)
+	);
+}
+
+echo "AI required handlers smoke\n";
+echo "--------------------------\n";
+
+$publish_step = array(
+	'step_type'     => 'publish',
+	'handler_slugs' => array( 'wordpress_publish', 'email_publish' ),
+);
+assert_equals(
+	array( 'wordpress_publish', 'email_publish' ),
+	FlowStepConfig::getRequiredHandlerSlugsForAi( $publish_step ),
+	'publish requires all configured handlers',
+	$failures,
+	$passes
+);
+
+$upsert_step = array(
+	'step_type'              => 'upsert',
+	'handler_slugs'          => array( 'wordpress_update', 'notion_update' ),
+	'required_handler_slugs' => array( 'notion_update' ),
+);
+assert_equals(
+	array( 'notion_update' ),
+	FlowStepConfig::getRequiredHandlerSlugsForAi( $upsert_step ),
+	'upsert explicit required_handler_slugs wins',
+	$failures,
+	$passes
+);
+
+$upsert_step_without_required = array(
+	'step_type'     => 'upsert',
+	'handler_slugs' => array( 'wordpress_update', 'notion_update' ),
+);
+assert_equals(
+	array( 'wordpress_update' ),
+	FlowStepConfig::getRequiredHandlerSlugsForAi( $upsert_step_without_required ),
+	'upsert without required_handler_slugs requires first configured handler',
+	$failures,
+	$passes
+);
+
+$fetch_step = array(
+	'step_type'    => 'fetch',
+	'handler_slug' => 'rss_fetch',
+);
+assert_equals(
+	array(),
+	FlowStepConfig::getRequiredHandlerSlugsForAi( $fetch_step ),
+	'handler-free-for-AI completion step returns empty required list',
+	$failures,
+	$passes
+);
+
+$available_tools = array(
+	'wordpress_update' => array( 'handler' => 'wordpress_update' ),
+	'notion_update'    => array( 'handler' => 'notion_update' ),
+);
+assert_equals(
+	array( 'notion_update' ),
+	resolve_required_ai_handler_tools_for_test( null, $upsert_step, $available_tools ),
+	'AIStep-style payload tracks only required upsert handler tools',
+	$failures,
+	$passes
+);
+
+$ai_step_source = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' );
+assert_contains(
+	'FlowStepConfig::getRequiredHandlerSlugsForAi( $adj_step_config )',
+	$ai_step_source,
+	'AIStep resolves adjacent required handlers through FlowStepConfig',
+	$failures,
+	$passes
+);
+assert_not_contains(
+	'FlowStepConfig::getConfiguredHandlerSlugs( $adj_step_config )',
+	$ai_step_source,
+	'AIStep no longer passes every adjacent configured handler to the AI loop',
+	$failures,
+	$passes
+);
+
+echo "\n--------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nAll assertions passed.\n";


### PR DESCRIPTION
## Summary
- Align AI conversation completion with the handler tools downstream steps actually require.
- Prevent multi-handler upsert steps from waiting on optional handler tools before the AI loop can finish.

## Changes
- Added `FlowStepConfig::getRequiredHandlerSlugsForAi()` as the shared contract for AI completion requirements.
- Updated `AIStep` to collect required adjacent handler slugs instead of every configured adjacent handler.
- Reused the new helper in `UpsertStep` so execution and AI completion resolve the same required handler list.
- Clarified `AIConversationLoop` comments around required adjacent handlers.
- Added a pure-PHP smoke test covering publish, upsert, handler-free steps, and the AIStep payload contract.

## Tests
- `php -l inc/Core/Steps/FlowStepConfig.php`
- `php -l inc/Core/Steps/AI/AIStep.php`
- `php -l inc/Core/Steps/Upsert/UpsertStep.php`
- `php -l inc/Engine/AI/AIConversationLoop.php`
- `php -l tests/ai-required-handlers-smoke.php`
- `php tests/ai-required-handlers-smoke.php`
- `php tests/handler-slug-scalar-migration-smoke.php`
- `homeboy audit data-machine --path . --changed-since origin/main`

`homeboy lint data-machine --path .` hit the known WordPress extension runner bug before producing findings: `PLUGIN_PATH: unbound variable` (tracked separately as Extra-Chill/homeboy-extensions#296).

Closes #1387

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the required-handler completion contract, adding smoke coverage, and drafting the PR description for human review.