### PR TITLE
fix(engine): protect child engine context from packet metadata

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -304,6 +304,7 @@ class PipelineBatchScheduler {
 		// item's data overwriting all previous items).
 		$item_engine_data = $single_packet['metadata']['_engine_data'] ?? array();
 		if ( ! empty( $item_engine_data ) && is_array( $item_engine_data ) ) {
+			$item_engine_data = $this->removeReservedEngineDataKeys( $item_engine_data, $parent_job_id );
 			$child_engine = array_merge( $child_engine, $item_engine_data );
 		}
 
@@ -337,6 +338,65 @@ class PipelineBatchScheduler {
 		);
 
 		return $child_job_id;
+	}
+
+	/**
+	 * Remove packet-provided keys that belong to the canonical engine snapshot.
+	 *
+	 * Packet metadata may provide per-item context, but it must not overwrite
+	 * job/flow/pipeline/batch state cloned from the parent execution.
+	 *
+	 * @param array $engine_data   Packet-provided engine data.
+	 * @param int   $parent_job_id Parent job ID for logging context.
+	 * @return array Sanitized per-item engine data.
+	 */
+	private function removeReservedEngineDataKeys( array $engine_data, int $parent_job_id ): array {
+		$reserved = array();
+
+		foreach ( array_keys( $engine_data ) as $key ) {
+			if ( $this->isReservedEngineDataKey( (string) $key ) ) {
+				$reserved[] = (string) $key;
+				unset( $engine_data[ $key ] );
+			}
+		}
+
+		if ( $reserved ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Pipeline batch: dropped packet engine_data keys reserved for child job context',
+				array(
+					'parent_job_id' => $parent_job_id,
+					'keys'          => $reserved,
+				)
+			);
+		}
+
+		return $engine_data;
+	}
+
+	/**
+	 * Check whether a packet-provided engine_data key is reserved.
+	 *
+	 * @param string $key Engine data key.
+	 * @return bool
+	 */
+	private function isReservedEngineDataKey( string $key ): bool {
+		if ( str_starts_with( $key, 'batch' ) ) {
+			return true;
+		}
+
+		return in_array(
+			$key,
+			array(
+				'job',
+				'flow',
+				'pipeline',
+				'flow_config',
+				'pipeline_config',
+			),
+			true
+		);
 	}
 
 	/**

--- a/tests/Unit/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Engine/PipelineBatchSchedulerTest.php
@@ -436,6 +436,49 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$this->assertEquals( 'Hotel Vegas', $child_b_engine['venue_context']['name'] );
 	}
 
+	public function test_packet_engine_data_cannot_clobber_reserved_child_context(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+
+		$engine['job']['agent_id'] = 123;
+		$engine['job']['user_id']  = 456;
+		$engine['flow_config']     = array( 'original' => 'flow-config' );
+		$engine['pipeline_config'] = array( 'original' => 'pipeline-config' );
+
+		$packet = $this->make_data_packet( 'Reserved Context Attempt' );
+		$packet['metadata']['_engine_data'] = array(
+			'job'             => array( 'agent_id' => 999 ),
+			'flow_config'     => array(),
+			'pipeline_config' => array(),
+			'batch_total'     => 999,
+			'item_identifier' => 'safe-id',
+			'venue'           => 'Safe Venue',
+		);
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_abc_123', array( $packet ), $engine );
+		$scheduler->processChunk( $parent_id );
+
+		global $wpdb;
+		$table    = $wpdb->prefix . 'datamachine_jobs';
+		$children = $wpdb->get_results(
+			$wpdb->prepare( "SELECT job_id FROM {$table} WHERE parent_job_id = %d", $parent_id ),
+			ARRAY_A
+		);
+
+		$this->assertCount( 1, $children );
+
+		$child_engine = datamachine_get_engine_data( (int) $children[0]['job_id'] );
+
+		$this->assertEquals( 123, $child_engine['job']['agent_id'] );
+		$this->assertEquals( 456, $child_engine['job']['user_id'] );
+		$this->assertEquals( array( 'original' => 'flow-config' ), $child_engine['flow_config'] );
+		$this->assertEquals( array( 'original' => 'pipeline-config' ), $child_engine['pipeline_config'] );
+		$this->assertArrayNotHasKey( 'batch_total', $child_engine );
+		$this->assertEquals( 'safe-id', $child_engine['item_identifier'] );
+		$this->assertEquals( 'Safe Venue', $child_engine['venue'] );
+	}
+
 	public function test_child_jobs_work_without_engine_data_key(): void {
 		$parent_id = $this->create_parent_job();
 		$engine    = $this->make_engine_snapshot( $parent_id );


### PR DESCRIPTION
## Summary
- Prevent packet-provided `_engine_data` from overwriting canonical child job engine context during pipeline fan-out.
- Keep safe per-item engine data flowing at the existing top level so downstream steps retain their current contract.

## Changes
- Filters packet `_engine_data` before merging it into the child engine snapshot.
- Drops and logs reserved keys: `job`, `flow`, `pipeline`, `flow_config`, `pipeline_config`, and any `batch*` key.
- Adds regression coverage for a packet attempting to override `job.agent_id`, config snapshots, and batch state while preserving safe item data.

## Tests
- `php -l inc/Abilities/Engine/PipelineBatchScheduler.php`
- `php -l tests/Unit/Engine/PipelineBatchSchedulerTest.php`
- `git diff --check`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-engine-data-reserved-keys --changed-since origin/main`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-engine-data-reserved-keys`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-engine-data-reserved-keys -- --filter PipelineBatchSchedulerTest`

Note: `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-engine-data-reserved-keys` currently fails in the WordPress extension runner before findings with `PLUGIN_PATH: unbound variable` (tracked separately in Extra-Chill/homeboy-extensions#296).

Closes #1382

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the reserved-key guard, adding regression coverage, and running validation under Chris's review workflow.