### PR TITLE
fix(engine): make transition fan-out policy explicit

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -19,6 +19,7 @@ use DataMachine\Core\EngineData;
 use DataMachine\Core\FilesRepository\FileCleanup;
 use DataMachine\Core\FilesRepository\FileRetrieval;
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Engine\StepNavigator;
 
 defined( 'ABSPATH' ) || exit;
@@ -478,14 +479,35 @@ class ExecuteStepAbility {
 					);
 				}
 
-				// Filter packets before fan-out: only handler-complete packets
-				// carry data that downstream steps (UpsertStep) can use.
-				// Non-handler packets (tool_result, ai_response) would create
-				// child jobs guaranteed to fail with 'required_handler_tool_not_called'.
-				$fanout_packets = self::filterPacketsForFanOut( $dataPackets );
+				$engine                = $payload['engine'] ?? null;
+				$next_flow_step_config = $engine instanceof EngineData ? $engine->getFlowStepConfig( $next_flow_step_id ) : array();
+				$transition_route      = self::resolveTransitionRoute( $flow_step_config, $next_flow_step_config, $dataPackets );
+
+				if ( 'fail' === $transition_route['mode'] ) {
+					do_action(
+						'datamachine_fail_job',
+						$job_id,
+						'step_execution_failure',
+						array(
+							'flow_step_id'      => $flow_step_id,
+							'next_flow_step_id' => $next_flow_step_id,
+							'class'             => $step_class,
+							'reason'            => $transition_route['reason'],
+						)
+					);
+
+					return array(
+						'success'      => true,
+						'step_success' => false,
+						'outcome'      => 'failed',
+						'error'        => $transition_route['reason'],
+					);
+				}
+
+				$fanout_packets = $transition_route['packets'];
 
 				// After filtering, check if we're back to ≤1 packet — inline instead of fan-out.
-				if ( count( $fanout_packets ) <= 1 ) {
+				if ( 'inline' === $transition_route['mode'] || count( $fanout_packets ) <= 1 ) {
 					do_action(
 						'datamachine_schedule_next_step',
 						$job_id,
@@ -674,6 +696,45 @@ class ExecuteStepAbility {
 	}
 
 	/**
+	 * Resolve whether returned packets should continue inline, fan out, or fail.
+	 *
+	 * AI output headed into a handler-requiring step is a single logical
+	 * conversation result. Keep matching handler completions together so
+	 * PublishStep/UpsertStep can enforce their own multi-handler contracts.
+	 *
+	 * @param array $current_step_config Current flow step config.
+	 * @param array $next_step_config    Next flow step config.
+	 * @param array $dataPackets         Data packets returned from the current step.
+	 * @return array{mode: string, packets: array, reason?: string}
+	 */
+	public static function resolveTransitionRoute( array $current_step_config, array $next_step_config, array $dataPackets ): array {
+		$current_step_type = $current_step_config['step_type'] ?? '';
+		$next_step_type    = $next_step_config['step_type'] ?? '';
+
+		if ( 'ai' === $current_step_type && '' !== $next_step_type && FlowStepConfig::usesHandler( $next_step_config ) ) {
+			$handler_packets = self::getHandlerPacketsForFanOut( $dataPackets );
+
+			if ( empty( $handler_packets ) ) {
+				return array(
+					'mode'    => 'fail',
+					'packets' => array(),
+					'reason'  => 'handler_requiring_step_missing_handler_packets',
+				);
+			}
+
+			return array(
+				'mode'    => 'inline',
+				'packets' => $handler_packets,
+			);
+		}
+
+		return array(
+			'mode'    => 'fanout',
+			'packets' => self::filterPacketsForFanOut( $dataPackets ),
+		);
+	}
+
+	/**
 	 * Filter data packets to only those safe to fan out into child jobs.
 	 *
 	 * When the AI step produces multiple packets, the batch scheduler creates
@@ -705,6 +766,22 @@ class ExecuteStepAbility {
 	 * @return array Packets safe to fan out.
 	 */
 	public static function filterPacketsForFanOut( array $dataPackets ): array {
+		$handler_packets = self::getHandlerPacketsForFanOut( $dataPackets );
+
+		if ( empty( $handler_packets ) ) {
+			return $dataPackets;
+		}
+
+		return $handler_packets;
+	}
+
+	/**
+	 * Return de-duplicated ai_handler_complete packets.
+	 *
+	 * @param array $dataPackets Data packets returned from the step.
+	 * @return array Handler-complete packets only.
+	 */
+	private static function getHandlerPacketsForFanOut( array $dataPackets ): array {
 		$handler_packets = array_values(
 			array_filter(
 				$dataPackets,
@@ -715,7 +792,7 @@ class ExecuteStepAbility {
 		);
 
 		if ( empty( $handler_packets ) ) {
-			return $dataPackets;
+			return array();
 		}
 
 		// Deduplicate handler packets by tool_name. When the AI calls

--- a/tests/Unit/Abilities/Engine/ExecuteStepFanOutFilterTest.php
+++ b/tests/Unit/Abilities/Engine/ExecuteStepFanOutFilterTest.php
@@ -156,6 +156,67 @@ class ExecuteStepFanOutFilterTest extends WP_UnitTestCase {
 		$this->assertCount( 2, $filtered );
 	}
 
+	public function test_ai_to_handler_step_routes_only_handler_packets_inline(): void {
+		$route = ExecuteStepAbility::resolveTransitionRoute(
+			array( 'step_type' => 'ai' ),
+			array(
+				'step_type'     => 'publish',
+				'handler_slugs' => array( 'publish_post' ),
+			),
+			array(
+				$this->make_packet( 'ai_handler_complete', array( 'tool_name' => 'publish_post', 'handler_tool' => 'publish_post' ) ),
+				$this->make_packet( 'tool_result', array( 'tool_name' => 'search' ) ),
+			)
+		);
+
+		$this->assertSame( 'inline', $route['mode'] );
+		$this->assertCount( 1, $route['packets'] );
+		$this->assertSame( 'ai_handler_complete', $route['packets'][0]['type'] );
+		$this->assertSame( 'publish_post', $route['packets'][0]['metadata']['handler_tool'] );
+	}
+
+	/**
+	 * Multiple AI non-handler packets before publish/upsert should fail the
+	 * current transition explicitly instead of creating child jobs that cannot
+	 * satisfy the handler-requiring next step.
+	 */
+	public function test_ai_to_handler_step_without_handler_packets_fails_transition(): void {
+		$route = ExecuteStepAbility::resolveTransitionRoute(
+			array( 'step_type' => 'ai' ),
+			array(
+				'step_type'     => 'upsert',
+				'handler_slugs' => array( 'upsert_event' ),
+			),
+			array(
+				$this->make_packet( 'tool_result', array( 'tool_name' => 'search' ) ),
+				$this->make_packet( 'ai_response', array( 'source_type' => 'custom' ) ),
+			)
+		);
+
+		$this->assertSame( 'fail', $route['mode'] );
+		$this->assertSame( array(), $route['packets'] );
+		$this->assertSame( 'handler_requiring_step_missing_handler_packets', $route['reason'] );
+	}
+
+	public function test_ai_to_multi_handler_step_keeps_handler_packets_together(): void {
+		$route = ExecuteStepAbility::resolveTransitionRoute(
+			array( 'step_type' => 'ai' ),
+			array(
+				'step_type'     => 'publish',
+				'handler_slugs' => array( 'publish_post', 'publish_pin' ),
+			),
+			array(
+				$this->make_packet( 'ai_handler_complete', array( 'tool_name' => 'publish_post', 'handler_tool' => 'publish_post' ) ),
+				$this->make_packet( 'ai_handler_complete', array( 'tool_name' => 'publish_pin', 'handler_tool' => 'publish_pin' ) ),
+			)
+		);
+
+		$this->assertSame( 'inline', $route['mode'] );
+		$this->assertCount( 2, $route['packets'] );
+		$this->assertSame( 'publish_post', $route['packets'][0]['metadata']['handler_tool'] );
+		$this->assertSame( 'publish_pin', $route['packets'][1]['metadata']['handler_tool'] );
+	}
+
 	public function test_filter_handles_empty_array(): void {
 		$this->assertSame( array(), ExecuteStepAbility::filterPacketsForFanOut( array() ) );
 	}

--- a/tests/transition-fanout-policy-smoke.php
+++ b/tests/transition-fanout-policy-smoke.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Pure-PHP smoke test for ExecuteStepAbility transition fan-out policy.
+ *
+ * Run with: php tests/transition-fanout-policy-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+function apply_filters( string $hook, $value ) {
+	return $value;
+}
+
+function do_action( string $hook, ...$args ): void {}
+
+require_once __DIR__ . '/../inc/Core/DataPacket.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
+require_once __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php';
+
+use DataMachine\Abilities\Engine\ExecuteStepAbility;
+use DataMachine\Core\DataPacket;
+
+$failures = array();
+$passes   = 0;
+
+function transition_fanout_packet( string $type, array $metadata = array() ): array {
+	$packet = new DataPacket(
+		array(
+			'title' => 'Test',
+			'body'  => 'Test body',
+		),
+		$metadata,
+		$type
+	);
+
+	$result = $packet->addTo( array() );
+	return $result[0];
+}
+
+function transition_fanout_assert_same( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+$route = ExecuteStepAbility::resolveTransitionRoute(
+	array( 'step_type' => 'ai' ),
+	array(
+		'step_type'     => 'publish',
+		'handler_slugs' => array( 'publish_post' ),
+	),
+	array(
+		transition_fanout_packet( 'ai_handler_complete', array( 'tool_name' => 'publish_post', 'handler_tool' => 'publish_post' ) ),
+		transition_fanout_packet( 'tool_result', array( 'tool_name' => 'search' ) ),
+	)
+);
+
+transition_fanout_assert_same( 'inline', $route['mode'], 'ai to handler step continues inline', $failures, $passes );
+transition_fanout_assert_same( 1, count( $route['packets'] ), 'ai to handler step keeps only handler packet', $failures, $passes );
+transition_fanout_assert_same( 'publish_post', $route['packets'][0]['metadata']['handler_tool'], 'handler packet metadata preserved', $failures, $passes );
+
+$route = ExecuteStepAbility::resolveTransitionRoute(
+	array( 'step_type' => 'ai' ),
+	array(
+		'step_type'     => 'upsert',
+		'handler_slugs' => array( 'upsert_event' ),
+	),
+	array(
+		transition_fanout_packet( 'tool_result', array( 'tool_name' => 'search' ) ),
+		transition_fanout_packet( 'ai_response', array( 'source_type' => 'custom' ) ),
+	)
+);
+
+transition_fanout_assert_same( 'fail', $route['mode'], 'ai non-handler packets fail before handler step', $failures, $passes );
+transition_fanout_assert_same( 'handler_requiring_step_missing_handler_packets', $route['reason'], 'failure reason is explicit', $failures, $passes );
+
+$route = ExecuteStepAbility::resolveTransitionRoute(
+	array( 'step_type' => 'ai' ),
+	array(
+		'step_type'     => 'publish',
+		'handler_slugs' => array( 'publish_post', 'publish_pin' ),
+	),
+	array(
+		transition_fanout_packet( 'ai_handler_complete', array( 'tool_name' => 'publish_post', 'handler_tool' => 'publish_post' ) ),
+		transition_fanout_packet( 'ai_handler_complete', array( 'tool_name' => 'publish_pin', 'handler_tool' => 'publish_pin' ) ),
+	)
+);
+
+transition_fanout_assert_same( 'inline', $route['mode'], 'multi-handler completions stay in one job', $failures, $passes );
+transition_fanout_assert_same( 2, count( $route['packets'] ), 'multi-handler completions are both available to next step', $failures, $passes );
+
+$route = ExecuteStepAbility::resolveTransitionRoute(
+	array( 'step_type' => 'fetch' ),
+	array( 'step_type' => 'ai' ),
+	array(
+		transition_fanout_packet( 'fetch', array( 'item_identifier' => 'one' ) ),
+		transition_fanout_packet( 'fetch', array( 'item_identifier' => 'two' ) ),
+	)
+);
+
+transition_fanout_assert_same( 'fanout', $route['mode'], 'non-ai source-item transitions still fan out', $failures, $passes );
+transition_fanout_assert_same( 2, count( $route['packets'] ), 'source-item packet count preserved', $failures, $passes );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures: " . implode( ', ', $failures ) . "\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} transition fan-out policy assertions passed.\n";


### PR DESCRIPTION
## Summary
- Makes step-transition fan-out policy explicit for AI output headed into handler-requiring steps.
- Pins multi-handler publish/upsert semantics as one inline continuation with all matching handler completions available to the next step.

## Changes
- Adds `ExecuteStepAbility::resolveTransitionRoute()` to choose `inline`, `fanout`, or `fail` per current/next step transition.
- Routes `ai -> publish/upsert` inline with de-duplicated `ai_handler_complete` packets only.
- Fails `ai -> handler-requiring step` transitions when no handler-complete packets are present, preventing non-handler packets from creating doomed child jobs.
- Preserves generic source-item fan-out for non-AI transitions.

## Tests
- `php -l inc/Abilities/Engine/ExecuteStepAbility.php`
- `php -l tests/Unit/Abilities/Engine/ExecuteStepFanOutFilterTest.php`
- `php -l tests/transition-fanout-policy-smoke.php`
- `php tests/transition-fanout-policy-smoke.php`
- `homeboy test data-machine --path .`

Note: `homeboy lint data-machine --path .` is currently blocked by the known WordPress extension runner issue `PLUGIN_PATH: unbound variable` (Extra-Chill/homeboy-extensions#296).

Closes #1385

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the transition fan-out routing change, adding regression coverage, and running focused validation.
