### PR TITLE
fix(ai): validate conversation loop results

### DIFF
--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -101,11 +101,11 @@ class AIConversationLoop {
 		);
 
 		if ( is_array( $result ) ) {
-			return $result;
+			return self::normalizeResultForRun( $result, $messages );
 		}
 
 		$loop = new self();
-		return $loop->execute(
+		$result = $loop->execute(
 			$messages,
 			$tools,
 			$provider,
@@ -115,6 +115,32 @@ class AIConversationLoop {
 			$max_turns,
 			$single_turn
 		);
+
+		return self::normalizeResultForRun( $result, $messages );
+	}
+
+	/**
+	 * Normalize a loop result, returning a caller-consumable error on contract drift.
+	 *
+	 * @param array $result            Raw loop result.
+	 * @param array $fallback_messages Initial messages for validation failures.
+	 * @return array Normalized result or error result.
+	 */
+	private static function normalizeResultForRun( array $result, array $fallback_messages ): array {
+		try {
+			return AIConversationResult::normalize( $result );
+		} catch ( \InvalidArgumentException $e ) {
+			return array(
+				'messages'               => $fallback_messages,
+				'final_content'          => '',
+				'turn_count'             => 0,
+				'completed'              => false,
+				'last_tool_calls'        => array(),
+				'tool_execution_results' => array(),
+				'usage'                  => array(),
+				'error'                  => $e->getMessage(),
+			);
+		}
 	}
 
 	/**

--- a/inc/Engine/AI/AIConversationResult.php
+++ b/inc/Engine/AI/AIConversationResult.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * AI conversation result contract.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Validates and normalizes AIConversationLoop result arrays.
+ */
+class AIConversationResult {
+
+	/**
+	 * Validate and normalize a loop result.
+	 *
+	 * `tool_execution_results` is optional because a valid no-tool response has
+	 * no tool output; when omitted it normalizes to an empty list.
+	 *
+	 * @param array $result Raw loop result.
+	 * @return array Normalized loop result.
+	 * @throws \InvalidArgumentException When the result shape is invalid.
+	 */
+	public static function normalize( array $result ): array {
+		if ( ! array_key_exists( 'messages', $result ) || ! is_array( $result['messages'] ) ) {
+			throw self::invalid( 'messages', 'must be an array' );
+		}
+
+		foreach ( $result['messages'] as $index => $message ) {
+			$path = 'messages[' . $index . ']';
+
+			if ( ! is_array( $message ) ) {
+				throw self::invalid( $path, 'must be an array' );
+			}
+
+			if ( array_key_exists( 'role', $message ) && ! is_string( $message['role'] ) ) {
+				throw self::invalid( $path . '.role', 'must be a string when present' );
+			}
+
+			if (
+				'assistant' === ( $message['role'] ?? '' )
+				&& array_key_exists( 'content', $message )
+				&& ! is_string( $message['content'] )
+			) {
+				throw self::invalid( $path . '.content', 'must be a string for assistant messages' );
+			}
+		}
+
+		if ( ! array_key_exists( 'tool_execution_results', $result ) ) {
+			$result['tool_execution_results'] = array();
+		}
+
+		if ( ! is_array( $result['tool_execution_results'] ) ) {
+			throw self::invalid( 'tool_execution_results', 'must be an array' );
+		}
+
+		foreach ( $result['tool_execution_results'] as $index => $tool_result ) {
+			$path = 'tool_execution_results[' . $index . ']';
+
+			if ( ! is_array( $tool_result ) ) {
+				throw self::invalid( $path, 'must be an array' );
+			}
+
+			if ( ! array_key_exists( 'tool_name', $tool_result ) || ! is_string( $tool_result['tool_name'] ) || '' === $tool_result['tool_name'] ) {
+				throw self::invalid( $path . '.tool_name', 'must be a non-empty string' );
+			}
+
+			if ( ! array_key_exists( 'result', $tool_result ) || ! is_array( $tool_result['result'] ) ) {
+				throw self::invalid( $path . '.result', 'must be an array' );
+			}
+
+			if ( ! array_key_exists( 'parameters', $tool_result ) || ! is_array( $tool_result['parameters'] ) ) {
+				throw self::invalid( $path . '.parameters', 'must be an array' );
+			}
+
+			if ( ! array_key_exists( 'is_handler_tool', $tool_result ) || ! is_bool( $tool_result['is_handler_tool'] ) ) {
+				throw self::invalid( $path . '.is_handler_tool', 'must be a boolean' );
+			}
+
+			if ( ! array_key_exists( 'turn_count', $tool_result ) || ! is_int( $tool_result['turn_count'] ) ) {
+				throw self::invalid( $path . '.turn_count', 'must be an integer' );
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Build a machine-readable validation exception.
+	 *
+	 * @param string $path Field path.
+	 * @param string $reason Failure reason.
+	 * @return \InvalidArgumentException Validation exception.
+	 */
+	private static function invalid( string $path, string $reason ): \InvalidArgumentException {
+		return new \InvalidArgumentException( 'invalid_ai_conversation_result: ' . $path . ' ' . $reason );
+	}
+}

--- a/tests/ai-conversation-result-smoke.php
+++ b/tests/ai-conversation-result-smoke.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Smoke tests for AI conversation result validation.
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+use DataMachine\Engine\AI\AIConversationLoop;
+use DataMachine\Engine\AI\AIConversationResult;
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		global $datamachine_test_conversation_runner_result;
+
+		if ( 'datamachine_conversation_runner' === $hook ) {
+			return $datamachine_test_conversation_runner_result;
+		}
+
+		return $value;
+	}
+}
+
+function datamachine_ai_conversation_result_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+$assertions = 0;
+
+$valid_result = array(
+	'messages'               => array(
+		array( 'role' => 'assistant', 'content' => 'Done.' ),
+	),
+	'final_content'          => 'Done.',
+	'turn_count'             => 1,
+	'completed'              => true,
+	'last_tool_calls'        => array(),
+	'tool_execution_results' => array(
+		array(
+			'tool_name'       => 'upsert_event',
+			'result'          => array( 'success' => true, 'data' => array( 'post_id' => 123 ) ),
+			'parameters'      => array( 'title' => 'Test Event' ),
+			'is_handler_tool' => true,
+			'turn_count'      => 1,
+		),
+	),
+	'usage'                  => array( 'total_tokens' => 10 ),
+);
+
+$normalized = AIConversationResult::normalize( $valid_result );
+datamachine_ai_conversation_result_assert(
+	$valid_result === $normalized,
+	'Valid built-in-shaped result should pass unchanged.'
+);
+++$assertions;
+
+$without_tool_results = $valid_result;
+unset( $without_tool_results['tool_execution_results'] );
+$normalized_without_tools = AIConversationResult::normalize( $without_tool_results );
+datamachine_ai_conversation_result_assert(
+	array_key_exists( 'tool_execution_results', $normalized_without_tools ),
+	'Missing tool_execution_results should normalize to an explicit empty list.'
+);
+++$assertions;
+datamachine_ai_conversation_result_assert(
+	array() === $normalized_without_tools['tool_execution_results'],
+	'Normalized tool_execution_results should be empty.'
+);
+++$assertions;
+
+$malformed_tool_result = $valid_result;
+unset( $malformed_tool_result['tool_execution_results'][0]['parameters'] );
+
+try {
+	AIConversationResult::normalize( $malformed_tool_result );
+	throw new RuntimeException( 'Malformed tool result should throw.' );
+} catch ( InvalidArgumentException $e ) {
+	datamachine_ai_conversation_result_assert(
+		str_contains( $e->getMessage(), 'invalid_ai_conversation_result: tool_execution_results[0].parameters' ),
+		'Malformed tool result should include a machine-readable field path.'
+	);
+	++$assertions;
+}
+
+$missing_messages = $valid_result;
+unset( $missing_messages['messages'] );
+
+try {
+	AIConversationResult::normalize( $missing_messages );
+	throw new RuntimeException( 'Missing messages should throw.' );
+} catch ( InvalidArgumentException $e ) {
+	datamachine_ai_conversation_result_assert(
+		str_contains( $e->getMessage(), 'invalid_ai_conversation_result: messages' ),
+		'Missing messages should include a machine-readable field path.'
+	);
+	++$assertions;
+}
+
+$malformed_message = $valid_result;
+$malformed_message['messages'][0] = 'not a message array';
+
+try {
+	AIConversationResult::normalize( $malformed_message );
+	throw new RuntimeException( 'Malformed message should throw.' );
+} catch ( InvalidArgumentException $e ) {
+	datamachine_ai_conversation_result_assert(
+		str_contains( $e->getMessage(), 'invalid_ai_conversation_result: messages[0]' ),
+		'Malformed message should include a machine-readable field path.'
+	);
+	++$assertions;
+}
+
+$datamachine_test_conversation_runner_result = $malformed_tool_result;
+$runner_result = AIConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'Process this.' ) ),
+	array(),
+	'test-provider',
+	'test-model',
+	'pipeline',
+	array(),
+	1
+);
+
+datamachine_ai_conversation_result_assert(
+	isset( $runner_result['error'] ),
+	'Malformed runner output should return an explicit AI loop error.'
+);
+++$assertions;
+datamachine_ai_conversation_result_assert(
+	str_contains( $runner_result['error'], 'invalid_ai_conversation_result: tool_execution_results[0].parameters' ),
+	'Runner validation error should preserve the machine-readable field path.'
+);
+++$assertions;
+datamachine_ai_conversation_result_assert(
+	array() === $runner_result['tool_execution_results'],
+	'Runner validation failure should expose an empty tool result list.'
+);
+++$assertions;
+
+$datamachine_test_conversation_runner_result = $valid_result;
+$runner_valid_result = AIConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'Process this.' ) ),
+	array(),
+	'test-provider',
+	'test-model',
+	'pipeline',
+	array(),
+	1
+);
+
+datamachine_ai_conversation_result_assert(
+	! isset( $runner_valid_result['error'] ),
+	'Valid runner output should not become an error result.'
+);
+++$assertions;
+datamachine_ai_conversation_result_assert(
+	true === $runner_valid_result['tool_execution_results'][0]['is_handler_tool'],
+	'Valid handler-tool output should preserve handler-tool metadata.'
+);
+++$assertions;
+
+echo 'AI conversation result smoke passed (' . $assertions . " assertions).\n";


### PR DESCRIPTION
## Summary

- Validates and normalizes `AIConversationLoop` result arrays before pipeline packet conversion consumes them.
- Converts malformed external runner output into an explicit `invalid_ai_conversation_result` AI-loop error instead of silently producing empty or malformed packets.

## Changes

- Adds `AIConversationResult::normalize()` for the result contract consumed by `AIStep::processLoopResults()`.
- Normalizes missing `tool_execution_results` to an empty list for valid no-tool responses.
- Validates message entries and tool result fields including `tool_name`, `result`, `parameters`, `is_handler_tool`, and `turn_count`.
- Routes both filtered runner output and built-in loop output through the validator in `AIConversationLoop::run()`.

## Tests

- `php -l inc/Engine/AI/AIConversationResult.php`
- `php -l inc/Engine/AI/AIConversationLoop.php`
- `php -l tests/ai-conversation-result-smoke.php`
- `php tests/ai-conversation-result-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-ai-loop-result-validator`

`homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-ai-loop-result-validator` currently hits the known WordPress runner issue: `PLUGIN_PATH: unbound variable`.

Closes #1386

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the loop-result validator, wiring it into the AI loop boundary, and drafting the smoke coverage. Chris remains responsible for review and merge.
