### PR TITLE
fix(engine): mark step exceptions as failures

### DIFF
--- a/inc/Core/Steps/Step.php
+++ b/inc/Core/Steps/Step.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Core\Steps;
 
+use DataMachine\Core\DataPacket;
 use DataMachine\Core\EngineData;
 
 if ( ! defined('ABSPATH') ) {
@@ -255,11 +256,11 @@ abstract class Step {
 	}
 
 	/**
-	 * Handle exceptions with consistent logging and data packet return.
+	 * Handle exceptions with consistent logging and failure packet return.
 	 *
 	 * @param  \Exception $e       Exception instance
 	 * @param  string     $context Context where exception occurred
-	 * @return array Data packet array (unchanged on exception)
+	 * @return array Data packet array with an explicit failure packet
 	 */
 	protected function handleException( \Exception $e, string $context = 'execution' ): array {
 		$this->log(
@@ -271,7 +272,34 @@ abstract class Step {
 			)
 		);
 
-		return $this->dataPackets;
+		return $this->buildExceptionFailurePackets( $e, $context, 'step_exception' );
+	}
+
+	/**
+	 * Build a data packet that makes step exceptions explicit to the engine.
+	 *
+	 * @param \Exception $e Exception instance.
+	 * @param string     $context Exception context.
+	 * @param string     $failure_reason Machine-readable failure reason.
+	 * @return array Data packet array with the failure packet prepended.
+	 */
+	protected function buildExceptionFailurePackets( \Exception $e, string $context, string $failure_reason ): array {
+		$packet = new DataPacket(
+			array(
+				'body'              => $e->getMessage(),
+				'exception_context' => $context,
+				'exception_class'   => get_class( $e ),
+			),
+			array(
+				'step_type'      => $this->step_type,
+				'flow_step_id'   => $this->flow_step_id,
+				'success'        => false,
+				'failure_reason' => $failure_reason,
+			),
+			'step_error'
+		);
+
+		return $packet->addTo( $this->dataPackets );
 	}
 
 	/**

--- a/inc/Core/Steps/Upsert/UpsertStep.php
+++ b/inc/Core/Steps/Upsert/UpsertStep.php
@@ -155,7 +155,7 @@ class UpsertStep extends Step {
 	 *
 	 * @param \Exception $e Exception instance
 	 * @param string     $context Context where exception occurred
-	 * @return array Data packet array (unchanged on exception)
+	 * @return array Data packet array with an explicit failure packet
 	 */
 	protected function handleException( \Exception $e, string $context = 'execution' ): array {
 		do_action(
@@ -169,7 +169,7 @@ class UpsertStep extends Step {
 			)
 		);
 
-		return $this->dataPackets;
+		return $this->buildExceptionFailurePackets( $e, $context, 'upsert_step_exception' );
 	}
 
 	/**

--- a/tests/step-exception-failure-contract-smoke.php
+++ b/tests/step-exception-failure-contract-smoke.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Pure-PHP smoke test for explicit step exception failure packets.
+ *
+ * Run with: php tests/step-exception-failure-contract-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$datamachine_action_log = array();
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		global $datamachine_action_log;
+		$datamachine_action_log[] = array(
+			'hook' => $hook,
+			'args' => $args,
+		);
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		$key = strtolower( $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( 'datamachine_get_engine_data' ) ) {
+	function datamachine_get_engine_data( int $job_id ): array {
+		return array(
+			'flow_config' => array(
+				'throwing_step' => array(
+					'flow_step_id'     => 'throwing_step',
+					'flow_id'          => 9,
+					'pipeline_id'      => 3,
+					'pipeline_step_id' => 'pipeline_step_1',
+					'step_type'        => 'throwing',
+					'handler_slug'     => 'test_handler',
+				),
+			),
+			'job'         => array(
+				'job_id'      => $job_id,
+				'flow_id'     => 9,
+				'pipeline_id' => 3,
+			),
+		);
+	}
+}
+
+if ( ! function_exists( 'datamachine_get_file_context' ) ) {
+	function datamachine_get_file_context( $flow_id ): array {
+		return array();
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/DataPacket.php';
+require_once __DIR__ . '/../inc/Core/EngineData.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Core/Steps/Step.php';
+require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
+require_once __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php';
+
+use DataMachine\Abilities\Engine\ExecuteStepAbility;
+use DataMachine\Core\EngineData;
+use DataMachine\Core\Steps\Step;
+
+class DataMachine_Throwing_Test_Step extends Step {
+	public function __construct() {
+		parent::__construct( 'throwing' );
+	}
+
+	protected function executeStep(): array {
+		throw new RuntimeException( 'boom from fake step' );
+	}
+}
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+
+	++$failures;
+	echo "  [FAIL] {$label}\n";
+};
+
+echo "=== step-exception-failure-contract-smoke ===\n";
+
+$input_packets = array(
+	array(
+		'type'     => 'fetch',
+		'data'     => array( 'body' => 'original packet' ),
+		'metadata' => array( 'success' => true ),
+	),
+);
+
+$engine = new EngineData( datamachine_get_engine_data( 100 ), 100 );
+$step   = new DataMachine_Throwing_Test_Step();
+$result = $step->execute(
+	array(
+		'job_id'       => 100,
+		'flow_step_id' => 'throwing_step',
+		'data'         => $input_packets,
+		'engine'       => $engine,
+	)
+);
+
+echo "\n[1] throwing step returns explicit failure packet\n";
+$assert( 'exception adds a packet instead of returning only original input', 2 === count( $result ) );
+$assert( 'failure packet is first', 'step_error' === ( $result[0]['type'] ?? '' ) );
+$assert( 'failure packet is explicitly unsuccessful', false === ( $result[0]['metadata']['success'] ?? null ) );
+$assert( 'failure reason is machine-readable', 'step_exception' === ( $result[0]['metadata']['failure_reason'] ?? '' ) );
+$assert( 'exception message is preserved for logs', 'boom from fake step' === ( $result[0]['data']['body'] ?? '' ) );
+$assert( 'original non-empty input packet is still present after failure packet', 'original packet' === ( $result[1]['data']['body'] ?? '' ) );
+
+$ability_reflection = new ReflectionClass( ExecuteStepAbility::class );
+$ability            = $ability_reflection->newInstanceWithoutConstructor();
+
+$evaluate = $ability_reflection->getMethod( 'evaluateStepSuccess' );
+$step_success = $evaluate->invoke( $ability, $result, 100, 'throwing_step' );
+
+echo "\n[2] engine evaluates failure packet as step failure\n";
+$assert( 'failure packet overrides non-empty packet list', false === $step_success );
+
+$route = $ability_reflection->getMethod( 'routeAfterExecution' );
+$route_result = $route->invoke(
+	$ability,
+	100,
+	'throwing_step',
+	9,
+	datamachine_get_engine_data( 100 )['flow_config']['throwing_step'],
+	'throwing',
+	DataMachine_Throwing_Test_Step::class,
+	$result,
+	array( 'data' => $result ),
+	$step_success,
+	null
+);
+
+$scheduled_next = array_values( array_filter(
+	$datamachine_action_log,
+	fn( array $entry ): bool => 'datamachine_schedule_next_step' === $entry['hook']
+) );
+$failed_jobs    = array_values( array_filter(
+	$datamachine_action_log,
+	fn( array $entry ): bool => 'datamachine_fail_job' === $entry['hook']
+) );
+$last_failure   = end( $failed_jobs );
+$failure_reason = $last_failure['args'][2]['reason'] ?? '';
+
+echo "\n[3] failed step does not route as success\n";
+$assert( 'route outcome is failed', 'failed' === ( $route_result['outcome'] ?? '' ) );
+$assert( 'route reports step_success=false', false === ( $route_result['step_success'] ?? null ) );
+$assert( 'next step is not scheduled', empty( $scheduled_next ) );
+$assert( 'job failure action is emitted', ! empty( $failed_jobs ) );
+$assert( 'job failure reason comes from packet metadata', 'step_exception' === $failure_reason );
+
+echo "\n[4] UpsertStep override follows the explicit failure-packet contract\n";
+$upsert_source = file_get_contents( __DIR__ . '/../inc/Core/Steps/Upsert/UpsertStep.php' );
+$assert( 'UpsertStep does not return original packets from handleException', false === strpos( $upsert_source, 'return $this->dataPackets;' ) );
+$assert( 'UpsertStep uses shared exception failure packet builder', false !== strpos( $upsert_source, 'buildExceptionFailurePackets( $e, $context, \'upsert_step_exception\' )' ) );
+
+if ( $failures > 0 ) {
+	echo "\n=== step-exception-failure-contract-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";
+	exit( 1 );
+}
+
+echo "\n=== step-exception-failure-contract-smoke: ALL PASS ({$total} assertions) ===\n";


### PR DESCRIPTION
## Summary
- Make thrown step exceptions return explicit failure packets instead of the original input packet list.
- Ensure exception packets carry metadata.success=false and a machine-readable failure_reason so routing cannot treat non-empty input as success.

## Changes
- Step::handleException now prepends a step_error failure packet with the exception message and failure metadata.
- UpsertStep::handleException keeps its job-failure action and returns the same explicit failure-packet contract.
- Added a pure-PHP regression smoke covering a fake throwing step with non-empty input, route failure, and no next-step scheduling.

## Tests
- php tests/step-exception-failure-contract-smoke.php
- php -l inc/Core/Steps/Step.php
- php -l inc/Core/Steps/Upsert/UpsertStep.php
- php -l tests/step-exception-failure-contract-smoke.php
- php tests/step-navigator-execution-order-smoke.php
- php tests/jobs-command-undo-fanout-smoke.php
- php tests/execute-workflow-initial-data-contract-smoke.php
- php tests/jobs-get-children-smoke.php
- php tests/task-scheduler-batch-parent-link-smoke.php
- homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-step-exception-failures

Notes: homeboy lint currently exits in the WordPress extension runner with PLUGIN_PATH: unbound variable, matching the known runner gap tracked in Extra-Chill/homeboy-extensions#296. An ad-hoc alphabetical smoke loop also stops on an existing exclude-keywords-smoke.php missing FetchHttpGetTrait include; targeted smokes above pass.

Closes #1383

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the step exception failure-packet contract, adding regression coverage, and running validation commands. Chris remains responsible for review and merge.