### PR TITLE
feat(fetch): map webhook payloads into data packets

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -381,6 +381,7 @@ function datamachine_load_handlers() {
 	new \DataMachine\Core\Steps\Fetch\Handlers\Rss\Rss();
 	new \DataMachine\Core\Steps\Fetch\Handlers\Email\Email();
 	new \DataMachine\Core\Steps\Fetch\Handlers\Files\Files();
+	new \DataMachine\Core\Steps\Fetch\Handlers\WebhookPayload\WebhookPayload();
 
 	// Upsert Handlers
 	new \DataMachine\Core\Steps\Upsert\Handlers\WordPress\WordPress();

--- a/inc/Core/Steps/Fetch/Handlers/WebhookPayload/WebhookPayload.php
+++ b/inc/Core/Steps/Fetch/Handlers/WebhookPayload/WebhookPayload.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Webhook payload fetch handler.
+ *
+ * Converts explicitly mapped webhook trigger payload fields into a DataPacket.
+ *
+ * @package DataMachine\Core\Steps\Fetch\Handlers\WebhookPayload
+ */
+
+namespace DataMachine\Core\Steps\Fetch\Handlers\WebhookPayload;
+
+use DataMachine\Core\ExecutionContext;
+use DataMachine\Core\Steps\Fetch\Handlers\FetchHandler;
+use DataMachine\Core\Steps\HandlerRegistrationTrait;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class WebhookPayload extends FetchHandler {
+
+	use HandlerRegistrationTrait;
+
+	public function __construct() {
+		parent::__construct( 'webhook_payload' );
+
+		self::registerHandler(
+			'webhook_payload',
+			'fetch',
+			self::class,
+			'Webhook Payload',
+			'Convert selected webhook payload fields into a DataPacket',
+			false,
+			null,
+			WebhookPayloadSettings::class,
+			null
+		);
+	}
+
+	/**
+	 * Build one packet item from the stored webhook trigger payload.
+	 *
+	 * @param array            $config  Handler configuration.
+	 * @param ExecutionContext $context Execution context.
+	 * @return array Handler result.
+	 */
+	protected function executeFetch( array $config, ExecutionContext $context ): array {
+		$trigger = $context->getEngine()->get( 'webhook_trigger', array() );
+		$payload = is_array( $trigger ) && is_array( $trigger['payload'] ?? null )
+			? $trigger['payload']
+			: array();
+
+		if ( empty( $payload ) ) {
+			$context->log( 'info', 'Webhook payload fetch skipped: no webhook payload found' );
+			return array();
+		}
+
+		try {
+			$item = self::mapPayloadToItem( $payload, $config );
+		} catch ( \UnexpectedValueException $e ) {
+			if ( ! empty( $config['ignore_missing_paths'] ) ) {
+				$context->log(
+					'info',
+					'Webhook payload fetch skipped: mapped payload field is missing',
+					array( 'reason' => $e->getMessage() )
+				);
+				return array();
+			}
+
+			throw $e;
+		}
+
+		return empty( $item ) ? array() : array( 'items' => array( $item ) );
+	}
+
+	/**
+	 * Map a webhook payload into one normalized fetch item.
+	 *
+	 * @param array $payload Webhook payload.
+	 * @param array $config  Mapping configuration.
+	 * @return array Normalized fetch item.
+	 */
+	public static function mapPayloadToItem( array $payload, array $config ): array {
+		$title_path   = trim( (string) ( $config['title_path'] ?? '' ) );
+		$content_path = trim( (string) ( $config['content_path'] ?? '' ) );
+
+		if ( '' === $title_path && '' === $content_path ) {
+			throw new \InvalidArgumentException( 'Webhook payload mapping requires title_path, content_path, or both.' );
+		}
+
+		$title   = '' === $title_path ? '' : self::stringifyValue( self::getRequiredPath( $payload, $title_path ) );
+		$content = '' === $content_path ? '' : self::stringifyValue( self::getRequiredPath( $payload, $content_path ) );
+
+		$metadata = array(
+			'source_type' => sanitize_key( (string) ( $config['source_type'] ?? 'webhook_payload' ) ),
+		);
+
+		foreach ( self::normalizeMetadataMapping( $config['metadata'] ?? array() ) as $key => $path ) {
+			$metadata[ $key ] = self::getRequiredPath( $payload, $path );
+		}
+
+		$template = trim( (string) ( $config['item_identifier_template'] ?? '' ) );
+		if ( '' !== $template ) {
+			$metadata['item_identifier'] = self::interpolateTemplate( $template, $payload );
+		}
+
+		return array(
+			'title'    => $title,
+			'content'  => $content,
+			'metadata' => $metadata,
+		);
+	}
+
+	/**
+	 * Extract a nested payload value using dot-path notation.
+	 *
+	 * @param array  $payload Payload array.
+	 * @param string $path    Dot path.
+	 * @return mixed Extracted value.
+	 */
+	public static function getPath( array $payload, string $path ) {
+		$path = trim( $path );
+		if ( '' === $path ) {
+			return null;
+		}
+
+		$value = $payload;
+		foreach ( explode( '.', $path ) as $segment ) {
+			if ( '' === $segment || ! is_array( $value ) || ! array_key_exists( $segment, $value ) ) {
+				return null;
+			}
+			$value = $value[ $segment ];
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Return a nested value or throw a clear missing-path exception.
+	 *
+	 * @param array  $payload Payload array.
+	 * @param string $path    Dot path.
+	 * @return mixed Extracted value.
+	 */
+	private static function getRequiredPath( array $payload, string $path ) {
+		$value = self::getPath( $payload, $path );
+		if ( null === $value ) {
+			throw new \UnexpectedValueException( sprintf( 'Missing webhook payload path "%s".', $path ) );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Interpolate `{path.to.value}` placeholders from the payload.
+	 *
+	 * @param string $template Identifier template.
+	 * @param array  $payload  Payload array.
+	 * @return string Interpolated value.
+	 */
+	private static function interpolateTemplate( string $template, array $payload ): string {
+		return (string) preg_replace_callback(
+			'/\{([^{}]+)\}/',
+			static function ( array $matches ) use ( $payload ): string {
+				return self::stringifyValue( self::getRequiredPath( $payload, trim( $matches[1] ) ) );
+			},
+			$template
+		);
+	}
+
+	/**
+	 * Normalize metadata mapping from an array or JSON object string.
+	 *
+	 * @param mixed $mapping Metadata mapping.
+	 * @return array<string,string> Normalized mapping.
+	 */
+	private static function normalizeMetadataMapping( $mapping ): array {
+		if ( is_string( $mapping ) ) {
+			$decoded = json_decode( $mapping, true );
+			$mapping = is_array( $decoded ) ? $decoded : array();
+		}
+
+		if ( ! is_array( $mapping ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $mapping as $key => $path ) {
+			$key  = sanitize_key( (string) $key );
+			$path = trim( (string) $path );
+			if ( '' !== $key && '' !== $path ) {
+				$normalized[ $key ] = $path;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Convert payload values into model-visible strings.
+	 *
+	 * @param mixed $value Payload value.
+	 * @return string String value.
+	 */
+	private static function stringifyValue( $value ): string {
+		if ( is_bool( $value ) ) {
+			return $value ? 'true' : 'false';
+		}
+
+		if ( is_scalar( $value ) ) {
+			return (string) $value;
+		}
+
+		$encoded = wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		return is_string( $encoded ) ? $encoded : '';
+	}
+
+	/**
+	 * Get the display label for the webhook payload handler.
+	 *
+	 * @return string Handler label.
+	 */
+	public static function get_label(): string {
+		return __( 'Webhook Payload', 'data-machine' );
+	}
+}

--- a/inc/Core/Steps/Fetch/Handlers/WebhookPayload/WebhookPayloadSettings.php
+++ b/inc/Core/Steps/Fetch/Handlers/WebhookPayload/WebhookPayloadSettings.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Webhook payload fetch handler settings.
+ *
+ * @package DataMachine\Core\Steps\Fetch\Handlers\WebhookPayload
+ */
+
+namespace DataMachine\Core\Steps\Fetch\Handlers\WebhookPayload;
+
+use DataMachine\Core\Steps\Fetch\Handlers\FetchHandlerSettings;
+
+defined( 'ABSPATH' ) || exit;
+
+class WebhookPayloadSettings extends FetchHandlerSettings {
+
+	/**
+	 * Get settings fields for Webhook Payload fetch handler.
+	 *
+	 * @return array Settings fields.
+	 */
+	public static function get_fields(): array {
+		return array_merge(
+			array(
+				'source_type'              => array(
+					'type'        => 'text',
+					'label'       => __( 'Source Type', 'data-machine' ),
+					'description' => __( 'Packet source_type metadata value, e.g. github_webhook.', 'data-machine' ),
+					'default'     => 'webhook_payload',
+				),
+				'title_path'               => array(
+					'type'        => 'text',
+					'label'       => __( 'Title Path', 'data-machine' ),
+					'description' => __( 'Dot path inside webhook payload for packet title, e.g. pull_request.title.', 'data-machine' ),
+				),
+				'content_path'             => array(
+					'type'        => 'text',
+					'label'       => __( 'Content Path', 'data-machine' ),
+					'description' => __( 'Dot path inside webhook payload for packet body, e.g. pull_request.body.', 'data-machine' ),
+				),
+				'metadata'                 => array(
+					'type'        => 'textarea',
+					'label'       => __( 'Metadata Mapping', 'data-machine' ),
+					'description' => __( 'JSON object mapping metadata keys to webhook payload dot paths.', 'data-machine' ),
+				),
+				'item_identifier_template' => array(
+					'type'        => 'text',
+					'label'       => __( 'Item Identifier Template', 'data-machine' ),
+					'description' => __( 'Template for processed-items dedupe, e.g. {repository.full_name}#{pull_request.number}@{pull_request.head.sha}.', 'data-machine' ),
+				),
+				'ignore_missing_paths'     => array(
+					'type'        => 'checkbox',
+					'label'       => __( 'Ignore Missing Paths', 'data-machine' ),
+					'description' => __( 'Skip the tick when a mapped path is missing. Leave off to fail loudly for bad config.', 'data-machine' ),
+				),
+			),
+			parent::get_common_fields()
+		);
+	}
+
+	/**
+	 * Sanitize webhook payload settings.
+	 *
+	 * @param array $raw_settings Raw settings input.
+	 * @return array Sanitized settings.
+	 */
+	public static function sanitize( array $raw_settings ): array {
+		$sanitized = parent::sanitize( $raw_settings );
+		$metadata  = $raw_settings['metadata'] ?? '';
+		$decoded   = is_array( $metadata ) ? $metadata : json_decode( (string) $metadata, true );
+
+		$sanitized['metadata'] = is_array( $decoded ) ? $decoded : array();
+
+		return $sanitized;
+	}
+}

--- a/tests/webhook-payload-fetch-handler-smoke.php
+++ b/tests/webhook-payload-fetch-handler-smoke.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Pure-PHP smoke test for webhook payload fetch handler mappings (#1411).
+ *
+ * Run with: php tests/webhook-payload-fetch-handler-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/smoke-wp-stubs.php';
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, $flags = 0, $depth = 512 ) {
+		return json_encode( $value, $flags, $depth );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook_name, $value, ...$args ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ) {
+		return trim( (string) $value );
+	}
+}
+
+if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+	function sanitize_textarea_field( $value ) {
+		return trim( (string) $value );
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
+		return $text;
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/Handlers/HttpRequestHelpers.php';
+require_once __DIR__ . '/../inc/Core/Steps/HandlerRegistrationTrait.php';
+require_once __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php';
+require_once __DIR__ . '/../inc/Core/Steps/Settings/SettingsHandler.php';
+require_once __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandlerSettings.php';
+require_once __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/WebhookPayload/WebhookPayload.php';
+require_once __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/WebhookPayload/WebhookPayloadSettings.php';
+
+use DataMachine\Core\Steps\Fetch\Handlers\WebhookPayload\WebhookPayload;
+use DataMachine\Core\Steps\Fetch\Handlers\WebhookPayload\WebhookPayloadSettings;
+
+$failed = 0;
+$total  = 0;
+
+function assert_webhook_payload_handler( string $name, bool $condition, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	++$failed;
+	echo "  [FAIL] {$name}" . ( $detail ? " - {$detail}" : '' ) . "\n";
+}
+
+echo "=== webhook-payload-fetch-handler-smoke ===\n";
+
+$payload = array(
+	'action'       => 'synchronize',
+	'repository'   => array(
+		'full_name' => 'Extra-Chill/data-machine',
+		'private'   => false,
+	),
+	'pull_request' => array(
+		'number' => 1411,
+		'title'  => 'Add webhook payload packet primitive',
+		'body'   => "Cook the webhook payload mapping primitive.\n\nNo headers should leak.",
+		'head'   => array(
+			'sha' => 'abc123def456',
+		),
+	),
+	'headers'      => array(
+		'x-hub-signature-256' => 'sha256=secret',
+	),
+	'secret_field' => 'do-not-leak',
+);
+
+$config = array(
+	'source_type'              => 'github_webhook',
+	'title_path'               => 'pull_request.title',
+	'content_path'             => 'pull_request.body',
+	'metadata'                 => array(
+		'repo'        => 'repository.full_name',
+		'pull_number' => 'pull_request.number',
+		'head_sha'    => 'pull_request.head.sha',
+		'action'      => 'action',
+	),
+	'item_identifier_template' => '{repository.full_name}#{pull_request.number}@{pull_request.head.sha}',
+);
+
+$item = WebhookPayload::mapPayloadToItem( $payload, $config );
+
+assert_webhook_payload_handler(
+	'GitHub-like payload title is mapped from nested title_path',
+	'Add webhook payload packet primitive' === $item['title']
+);
+
+assert_webhook_payload_handler(
+	'GitHub-like payload body is mapped from nested content_path',
+	str_contains( $item['content'], 'webhook payload mapping primitive' )
+);
+
+assert_webhook_payload_handler(
+	'nested metadata path extraction maps repository full_name',
+	'Extra-Chill/data-machine' === $item['metadata']['repo']
+);
+
+assert_webhook_payload_handler(
+	'nested metadata path extraction preserves scalar pull number',
+	1411 === $item['metadata']['pull_number']
+);
+
+assert_webhook_payload_handler(
+	'nested metadata path extraction maps head sha',
+	'abc123def456' === $item['metadata']['head_sha']
+);
+
+assert_webhook_payload_handler(
+	'item_identifier_template interpolates nested placeholders',
+	'Extra-Chill/data-machine#1411@abc123def456' === $item['metadata']['item_identifier']
+);
+
+assert_webhook_payload_handler(
+	'source_type is explicit and generic',
+	'github_webhook' === $item['metadata']['source_type']
+);
+
+assert_webhook_payload_handler(
+	'full payload is not copied into metadata',
+	! array_key_exists( 'payload', $item['metadata'] ) && ! array_key_exists( 'pull_request', $item['metadata'] )
+);
+
+assert_webhook_payload_handler(
+	'headers are not exposed unless explicitly mapped',
+	! array_key_exists( 'headers', $item['metadata'] ) && ! str_contains( wp_json_encode( $item ), 'x-hub-signature' )
+);
+
+assert_webhook_payload_handler(
+	'unmapped payload secrets are not exposed',
+	! str_contains( wp_json_encode( $item ), 'do-not-leak' )
+);
+
+assert_webhook_payload_handler(
+	'dot path helper extracts nested values',
+	'abc123def456' === WebhookPayload::getPath( $payload, 'pull_request.head.sha' )
+);
+
+assert_webhook_payload_handler(
+	'dot path helper returns null for missing paths',
+	null === WebhookPayload::getPath( $payload, 'pull_request.base.sha' )
+);
+
+$missing_path_failed = false;
+try {
+	WebhookPayload::mapPayloadToItem(
+		$payload,
+		array_merge( $config, array( 'content_path' => 'pull_request.missing_body' ) )
+	);
+} catch ( UnexpectedValueException $e ) {
+	$missing_path_failed = str_contains( $e->getMessage(), 'pull_request.missing_body' );
+}
+
+assert_webhook_payload_handler(
+	'missing required content path fails with clear path message',
+	$missing_path_failed
+);
+
+$bad_config_failed = false;
+try {
+	WebhookPayload::mapPayloadToItem( $payload, array( 'source_type' => 'github_webhook' ) );
+} catch ( InvalidArgumentException $e ) {
+	$bad_config_failed = str_contains( $e->getMessage(), 'requires title_path' );
+}
+
+assert_webhook_payload_handler(
+	'bad config without title_path or content_path fails clearly',
+	$bad_config_failed
+);
+
+$handler_source = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/WebhookPayload/WebhookPayload.php' );
+
+assert_webhook_payload_handler(
+	'handler reads only webhook_trigger.payload from engine data',
+	str_contains( $handler_source, "get( 'webhook_trigger'" )
+		&& str_contains( $handler_source, "['payload']" )
+		&& ! str_contains( $handler_source, "['headers']" )
+);
+
+assert_webhook_payload_handler(
+	'handler supports ignore_missing_paths skip mode for intentionally ignored events',
+	str_contains( $handler_source, "config['ignore_missing_paths']" )
+		&& str_contains( $handler_source, 'mapped payload field is missing' )
+);
+
+assert_webhook_payload_handler(
+	'settings sanitize JSON metadata mapping into an array',
+	array(
+		'repo' => 'repository.full_name',
+	) === WebhookPayloadSettings::sanitize(
+		array(
+			'source_type'              => 'github_webhook',
+			'title_path'               => 'pull_request.title',
+			'content_path'             => 'pull_request.body',
+			'metadata'                 => '{"repo":"repository.full_name"}',
+			'item_identifier_template' => '{repository.full_name}',
+		)
+	)['metadata']
+);
+
+assert_webhook_payload_handler(
+	'core handler loader instantiates webhook_payload fetch handler',
+	str_contains(
+		file_get_contents( __DIR__ . '/../data-machine.php' ),
+		'new \\DataMachine\\Core\\Steps\\Fetch\\Handlers\\WebhookPayload\\WebhookPayload()'
+	)
+);
+
+if ( $failed > 0 ) {
+	echo "\nwebhook-payload-fetch-handler-smoke failed: {$failed}/{$total} assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nwebhook-payload-fetch-handler-smoke passed: {$total} assertions.\n";


### PR DESCRIPTION
## Summary
- Adds a generic `webhook_payload` fetch handler that maps selected fields from `engine_data.webhook_trigger.payload` into a model-visible `DataPacket`.
- Keeps webhook payload exposure explicit through configured dot-path mappings and `item_identifier_template` for existing processed-items dedupe.

## Changes
- Registers a new `webhook_payload` fetch handler and settings surface.
- Supports nested dot-path extraction for title, content, metadata, and item identifier interpolation.
- Reads only `webhook_trigger.payload`; headers and full engine data are not copied by default.
- Adds `ignore_missing_paths` so intentionally ignored webhook shapes can skip cleanly while bad config fails with a clear missing-path message.

## Tests
- `php tests/webhook-payload-fetch-handler-smoke.php`
- `php -l inc/Core/Steps/Fetch/Handlers/WebhookPayload/WebhookPayload.php && php -l inc/Core/Steps/Fetch/Handlers/WebhookPayload/WebhookPayloadSettings.php && php -l tests/webhook-payload-fetch-handler-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@feat-webhook-payload-packet --changed-since origin/main`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-webhook-payload-packet` currently fails before findings with the known WordPress lint runner issue: `PLUGIN_PATH: unbound variable`.

Closes #1411

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted implementation and tests for the generic webhook payload mapping primitive; Chris remains responsible for review and merge.
