### PR TITLE
refactor(flow): centralize flow step config overlays

### DIFF
--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -406,27 +406,21 @@ trait FlowHelpers {
 			$step_type               = $target_step['step_type'];
 			$new_flow_step_id        = $target_pipeline_step_id . '_' . $new_flow_id;
 
-			$new_step_config = array(
-				'flow_step_id'     => $new_flow_step_id,
-				'step_type'        => $step_type,
-				'pipeline_step_id' => $target_pipeline_step_id,
-				'pipeline_id'      => $target_pipeline_id,
-				'flow_id'          => $new_flow_id,
-				'execution_order'  => $order,
+			$new_step_config = FlowStepConfigFactory::build(
+				array(
+					'flow_step_id'     => $new_flow_step_id,
+					'step_type'        => $step_type,
+					'pipeline_step_id' => $target_pipeline_step_id,
+					'pipeline_id'      => $target_pipeline_id,
+					'flow_id'          => $new_flow_id,
+					'execution_order'  => $order,
+				)
 			);
 
 			if ( isset( $source_steps_by_order[ $order ] ) ) {
 				$source_step = $source_steps_by_order[ $order ];
 
-				// Copy canonical handler fields verbatim. Single-handler steps use
-				// handler_slug/handler_config; multi-handler steps use
-				// handler_slugs/handler_configs; handler-free steps only carry
-				// handler_config when they have step-level settings.
-				foreach ( array( 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs' ) as $handler_field ) {
-					if ( array_key_exists( $handler_field, $source_step ) ) {
-						$new_step_config[ $handler_field ] = $source_step[ $handler_field ];
-					}
-				}
+				$new_step_config = FlowStepConfigFactory::withHandlerFields( $new_step_config, $source_step );
 
 				// Queue state copies verbatim (#1291 / #1292): AI steps
 				// own prompt_queue, fetch steps own config_patch_queue,
@@ -434,17 +428,7 @@ trait FlowHelpers {
 				// type consumes. Pre-fix this lane copied the legacy
 				// `user_message` field — that slot is gone and the
 				// per-flow user message lives in prompt_queue head.
-				if ( isset( $source_step['prompt_queue'] ) && is_array( $source_step['prompt_queue'] ) ) {
-					$new_step_config['prompt_queue'] = $source_step['prompt_queue'];
-				}
-				if ( isset( $source_step['config_patch_queue'] ) && is_array( $source_step['config_patch_queue'] ) ) {
-					$new_step_config['config_patch_queue'] = $source_step['config_patch_queue'];
-				}
-				if ( isset( $source_step['queue_mode'] )
-					&& in_array( $source_step['queue_mode'], array( 'drain', 'loop', 'static' ), true )
-				) {
-					$new_step_config['queue_mode'] = $source_step['queue_mode'];
-				}
+				$new_step_config = FlowStepConfigFactory::withQueueState( $new_step_config, $source_step );
 
 				if ( isset( $source_step['disabled_tools'] ) ) {
 					$new_step_config['disabled_tools'] = $source_step['disabled_tools'];
@@ -455,39 +439,16 @@ trait FlowHelpers {
 			if ( $override ) {
 				if ( ! empty( $override['handler_slug'] ) ) {
 					$handler_config = $override['handler_config'] ?? array();
-					if ( FlowStepConfig::isMultiHandler( $new_step_config ) ) {
-						$new_step_config['handler_slugs']   = array( $override['handler_slug'] );
-						$new_step_config['handler_configs'] = array( $override['handler_slug'] => $handler_config );
-						unset( $new_step_config['handler_slug'], $new_step_config['handler_config'] );
-					} else {
-						$new_step_config['handler_slug']   = $override['handler_slug'];
-						$new_step_config['handler_config'] = $handler_config;
-						unset( $new_step_config['handler_slugs'], $new_step_config['handler_configs'] );
-					}
+					$new_step_config = FlowStepConfigFactory::withHandlerConfig( $new_step_config, $override['handler_slug'], $handler_config );
 				} elseif ( ! empty( $override['handler_config'] ) ) {
-					if ( FlowStepConfig::isMultiHandler( $new_step_config ) ) {
-						$primary_slug = FlowStepConfig::getPrimaryHandlerSlug( $new_step_config );
-						if ( null !== $primary_slug ) {
-							$existing_config                                      = $new_step_config['handler_configs'][ $primary_slug ] ?? array();
-							$new_step_config['handler_configs'][ $primary_slug ] = array_merge( $existing_config, $override['handler_config'] );
-						}
-					} else {
-						$existing_config                   = FlowStepConfig::getPrimaryHandlerConfig( $new_step_config );
-						$new_step_config['handler_config'] = array_merge( $existing_config, $override['handler_config'] );
-					}
+					$new_step_config = FlowStepConfigFactory::withHandlerConfig( $new_step_config, '', $override['handler_config'], true );
 				}
 				// Override user_message arrives as a workflow-spec input
 				// (matches the public contract used by `flow copy` and
 				// chat tools). Convert it to a 1-entry static
 				// prompt_queue so AIStep sees it post-#1291.
 				if ( ! empty( $override['user_message'] ) ) {
-					$new_step_config['prompt_queue'] = array(
-						array(
-							'prompt'   => $override['user_message'],
-							'added_at' => gmdate( 'c' ),
-						),
-					);
-					$new_step_config['queue_mode']   = 'static';
+					$new_step_config = FlowStepConfigFactory::withUserMessage( $new_step_config, $override['user_message'] );
 				}
 			}
 
@@ -549,14 +510,15 @@ trait FlowHelpers {
 			$flow_step_id = $target['flow_step_id'];
 			$step_type    = $target['step_type'] ?? (string) $step_key;
 
-			// Multi-handler configs use handler_slugs/handler_configs; single-handler
-			// and handler-free configs use handler_slug/handler_config.
-			$handler_slugs   = $config['handler_slugs'] ?? array();
-			$handler_configs = $config['handler_configs'] ?? array();
+			$normalized_handler_config = FlowStepConfigFactory::withHandlerFields(
+				array( 'step_type' => $step_type ),
+				$config
+			);
 
-			// Scalar forms go through UpdateFlowStepAbility.
-			$single_slug   = $config['handler_slug'] ?? '';
-			$single_config = $config['handler_config'] ?? array();
+			$handler_slugs   = $config['handler_slugs'] ?? array();
+			$handler_configs = FlowStepConfig::getHandlerConfigs( $normalized_handler_config );
+			$single_slug     = $config['handler_slug'] ?? '';
+			$single_config   = $config['handler_config'] ?? array();
 
 			// When handler_slugs is provided, add each handler with its config from handler_configs.
 			if ( ! empty( $handler_slugs ) ) {

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -175,4 +175,125 @@ class FlowStepConfigFactory {
 			),
 		);
 	}
+
+	/**
+	 * Overlay canonical handler fields onto a step config.
+	 *
+	 * @param array $step_config Step configuration array.
+	 * @param array $handler_fields Source fields containing handler shape data.
+	 * @return array Step config with canonical handler shape.
+	 */
+	public static function withHandlerFields( array $step_config, array $handler_fields ): array {
+		$overlay = array();
+		foreach ( array( 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs' ) as $field ) {
+			if ( array_key_exists( $field, $handler_fields ) ) {
+				$overlay[ $field ] = $handler_fields[ $field ];
+			}
+		}
+
+		if ( empty( $overlay ) ) {
+			return $step_config;
+		}
+
+		return FlowStepConfig::normalizeHandlerShape( array_merge( $step_config, $overlay ) );
+	}
+
+	/**
+	 * Set or merge the primary handler/settings config for a step.
+	 *
+	 * @param array  $step_config Step configuration array.
+	 * @param string $handler_slug Explicit handler slug. Empty preserves the current effective slug.
+	 * @param array  $handler_config Handler/settings config to store.
+	 * @param bool   $merge Whether to merge into the existing primary config.
+	 * @return array Step config with canonical handler shape.
+	 */
+	public static function withHandlerConfig( array $step_config, string $handler_slug = '', array $handler_config = array(), bool $merge = false ): array {
+		$uses_handler   = FlowStepConfig::usesHandler( $step_config );
+		$is_multi       = FlowStepConfig::isMultiHandler( $step_config );
+		$effective_slug = FlowStepConfig::getEffectiveSlug( $step_config, $handler_slug );
+
+		if ( ! $uses_handler ) {
+			$existing_config = $merge ? FlowStepConfig::getPrimaryHandlerConfig( $step_config ) : array();
+			return self::withHandlerFields(
+				$step_config,
+				array( 'handler_config' => array_merge( $existing_config, $handler_config ) )
+			);
+		}
+
+		if ( '' === $effective_slug ) {
+			return $step_config;
+		}
+
+		$existing_config = $merge ? FlowStepConfig::getHandlerConfigForSlug( $step_config, $effective_slug ) : array();
+		$stored_config   = array_merge( $existing_config, $handler_config );
+
+		if ( $is_multi ) {
+			$slugs = '' !== $handler_slug ? array( $effective_slug ) : FlowStepConfig::getHandlerSlugs( $step_config );
+			if ( empty( $slugs ) ) {
+				$slugs = array( $effective_slug );
+			}
+
+			$configs                    = '' !== $handler_slug ? array() : FlowStepConfig::getHandlerConfigs( $step_config );
+			$configs[ $effective_slug ] = $stored_config;
+
+			return self::withHandlerFields(
+				$step_config,
+				array(
+					'handler_slugs'   => $slugs,
+					'handler_configs' => $configs,
+				)
+			);
+		}
+
+		return self::withHandlerFields(
+			$step_config,
+			array(
+				'handler_slug'   => $effective_slug,
+				'handler_config' => $stored_config,
+			)
+		);
+	}
+
+	/**
+	 * Copy queue state fields from a source step config.
+	 *
+	 * @param array $step_config Step configuration array.
+	 * @param array $source_step Source step configuration array.
+	 * @return array Step config with copied queue state.
+	 */
+	public static function withQueueState( array $step_config, array $source_step ): array {
+		if ( isset( $source_step[ QueueAbility::SLOT_PROMPT_QUEUE ] ) && is_array( $source_step[ QueueAbility::SLOT_PROMPT_QUEUE ] ) ) {
+			$step_config[ QueueAbility::SLOT_PROMPT_QUEUE ] = $source_step[ QueueAbility::SLOT_PROMPT_QUEUE ];
+		}
+		if ( isset( $source_step[ QueueAbility::SLOT_CONFIG_PATCH_QUEUE ] ) && is_array( $source_step[ QueueAbility::SLOT_CONFIG_PATCH_QUEUE ] ) ) {
+			$step_config[ QueueAbility::SLOT_CONFIG_PATCH_QUEUE ] = $source_step[ QueueAbility::SLOT_CONFIG_PATCH_QUEUE ];
+		}
+		if ( isset( $source_step['queue_mode'] )
+			&& in_array( $source_step['queue_mode'], array( 'drain', 'loop', 'static' ), true )
+		) {
+			$step_config['queue_mode'] = $source_step['queue_mode'];
+		}
+
+		return $step_config;
+	}
+
+	/**
+	 * Store a public user_message input as a one-entry static prompt queue.
+	 *
+	 * @param array       $step_config Step configuration array.
+	 * @param string      $user_message User message text.
+	 * @param string|null $added_at Optional timestamp for tests/importers.
+	 * @return array Step config with prompt queue state.
+	 */
+	public static function withUserMessage( array $step_config, string $user_message, ?string $added_at = null ): array {
+		$step_config[ QueueAbility::SLOT_PROMPT_QUEUE ] = array(
+			array(
+				'prompt'   => $user_message,
+				'added_at' => $added_at ?? gmdate( 'c' ),
+			),
+		);
+		$step_config['queue_mode']   = 'static';
+
+		return $step_config;
+	}
 }

--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Engine\Actions;
 
 use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Core\Steps\FlowStepConfigFactory;
 
 // Prevent direct access
 if ( ! defined( 'WPINC' ) ) {
@@ -345,11 +346,13 @@ class ImportExport {
 		if ( ! isset( $flow_config[ $flow_step_id ] ) ) {
 			// Defensive seed — should have been created by create-flow's step sync, but
 			// fall back to a minimal entry so the handler restore still lands.
-			$flow_config[ $flow_step_id ] = array(
-				'flow_step_id'     => $flow_step_id,
-				'pipeline_step_id' => $pipeline_step_id,
-				'flow_id'          => $flow_id,
-				'step_type'        => $step_type,
+			$flow_config[ $flow_step_id ] = FlowStepConfigFactory::build(
+				array(
+					'flow_step_id'     => $flow_step_id,
+					'pipeline_step_id' => $pipeline_step_id,
+					'flow_id'          => $flow_id,
+					'step_type'        => $step_type,
+				)
 			);
 		}
 		if ( empty( $flow_config[ $flow_step_id ]['step_type'] ) ) {
@@ -357,12 +360,7 @@ class ImportExport {
 		}
 
 
-		$step = FlowStepConfig::normalizeHandlerShape(
-			array_merge(
-				$flow_config[ $flow_step_id ],
-				$settings
-			)
-		);
+		$step = FlowStepConfigFactory::withHandlerFields( $flow_config[ $flow_step_id ], $settings );
 
 		$flow_config[ $flow_step_id ] = $step;
 

--- a/tests/flow-step-config-overlays-smoke.php
+++ b/tests/flow-step-config-overlays-smoke.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Pure-PHP smoke test for flow-step config overlay helpers (#1353).
+ *
+ * Run with: php tests/flow-step-config-overlays-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities\Flow {
+	if ( ! class_exists( QueueAbility::class, false ) ) {
+		class QueueAbility {
+			const SLOT_PROMPT_QUEUE       = 'prompt_queue';
+			const SLOT_CONFIG_PATCH_QUEUE = 'config_patch_queue';
+		}
+	}
+}
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_step_types' !== $hook ) {
+			return $value;
+		}
+
+		return array(
+			'ai'           => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'system_task'  => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'webhook_gate' => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'fetch'        => array( 'uses_handler' => true, 'multi_handler' => false ),
+			'publish'      => array( 'uses_handler' => true, 'multi_handler' => true ),
+			'upsert'       => array( 'uses_handler' => true, 'multi_handler' => true ),
+		);
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		// no-op for tests.
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
+
+use DataMachine\Core\Steps\FlowStepConfigFactory;
+
+$failed = 0;
+$total  = 0;
+
+function assert_overlay( string $name, bool $condition, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	++$failed;
+	echo "  [FAIL] {$name}" . ( '' !== $detail ? " - {$detail}" : '' ) . "\n";
+}
+
+function assert_overlay_same( string $name, $expected, $actual ): void {
+	assert_overlay(
+		$name,
+		$expected === $actual,
+		'expected ' . var_export( $expected, true ) . ', got ' . var_export( $actual, true )
+	);
+}
+
+echo "=== flow-step-config-overlays-smoke ===\n";
+
+$copy_base = FlowStepConfigFactory::build(
+	array(
+		'flow_step_id'     => 'publish_step_99',
+		'step_type'        => 'publish',
+		'pipeline_step_id' => 'publish_step',
+		'pipeline_id'      => 7,
+		'flow_id'          => 99,
+		'execution_order'  => 2,
+	)
+);
+$copy_source = array(
+	'handler_slugs'   => array( 'wordpress', 'pinterest' ),
+	'handler_configs' => array(
+		'wordpress' => array( 'post_type' => 'post' ),
+		'pinterest' => array( 'board' => 'events' ),
+	),
+	'prompt_queue'    => array(
+		array( 'prompt' => 'Publish copy', 'added_at' => '2026-04-27T00:00:00Z' ),
+	),
+	'queue_mode'      => 'loop',
+);
+$copied = FlowStepConfigFactory::withQueueState(
+	FlowStepConfigFactory::withHandlerFields( $copy_base, $copy_source ),
+	$copy_source
+);
+
+assert_overlay_same( 'copy path keeps multi-handler slugs', $copy_source['handler_slugs'], $copied['handler_slugs'] );
+assert_overlay_same( 'copy path keeps multi-handler configs', $copy_source['handler_configs'], $copied['handler_configs'] );
+assert_overlay_same( 'copy path keeps prompt queue', $copy_source['prompt_queue'], $copied['prompt_queue'] );
+assert_overlay_same( 'copy path keeps queue mode', 'loop', $copied['queue_mode'] );
+
+$overridden = FlowStepConfigFactory::withHandlerConfig(
+	$copied,
+	'wordpress_xmlrpc',
+	array( 'post_type' => 'page' )
+);
+assert_overlay_same( 'copy override replaces multi-handler list', array( 'wordpress_xmlrpc' ), $overridden['handler_slugs'] );
+assert_overlay_same(
+	'copy override stores config under replacement handler',
+	array( 'wordpress_xmlrpc' => array( 'post_type' => 'page' ) ),
+	$overridden['handler_configs']
+);
+
+$message_override = FlowStepConfigFactory::withUserMessage( $copied, 'Override prompt', '2026-04-27T01:00:00Z' );
+assert_overlay_same(
+	'copy user_message override becomes one-entry prompt queue',
+	array( array( 'prompt' => 'Override prompt', 'added_at' => '2026-04-27T01:00:00Z' ) ),
+	$message_override['prompt_queue']
+);
+assert_overlay_same( 'copy user_message override forces static queue mode', 'static', $message_override['queue_mode'] );
+
+$import_base = FlowStepConfigFactory::build(
+	array(
+		'flow_step_id'     => 'fetch_step_42',
+		'pipeline_step_id' => 'fetch_step',
+		'flow_id'          => 42,
+		'step_type'        => 'fetch',
+	)
+);
+$import_restored = FlowStepConfigFactory::withHandlerFields(
+	$import_base,
+	array(
+		'handler_slug'   => 'mcp',
+		'handler_config' => array( 'server' => 'a8c', 'provider' => 'slack' ),
+	)
+);
+
+assert_overlay_same(
+	'import restore path preserves field order and scalar handler shape',
+	array(
+		'flow_step_id'     => 'fetch_step_42',
+		'pipeline_step_id' => 'fetch_step',
+		'flow_id'          => 42,
+		'step_type'        => 'fetch',
+		'handler_slug'     => 'mcp',
+		'handler_config'   => array( 'server' => 'a8c', 'provider' => 'slack' ),
+	),
+	$import_restored
+);
+
+$import_handler_free = FlowStepConfigFactory::withHandlerFields(
+	FlowStepConfigFactory::build(
+		array(
+			'flow_step_id'     => 'system_task_42',
+			'pipeline_step_id' => 'system_task',
+			'flow_id'          => 42,
+			'step_type'        => 'system_task',
+		)
+	),
+	array( 'handler_config' => array( 'task' => 'daily_memory_generation' ) )
+);
+assert_overlay_same(
+	'import restore path preserves handler-free settings config',
+	array( 'task' => 'daily_memory_generation' ),
+	$import_handler_free['handler_config']
+);
+
+$flow_helpers_source = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/FlowHelpers.php' );
+$import_export_source = file_get_contents( __DIR__ . '/../inc/Engine/Actions/ImportExport.php' );
+
+assert_overlay( 'copy path calls withHandlerFields', false !== strpos( $flow_helpers_source, 'FlowStepConfigFactory::withHandlerFields( $new_step_config, $source_step )' ) );
+assert_overlay( 'copy path calls withQueueState', false !== strpos( $flow_helpers_source, 'FlowStepConfigFactory::withQueueState( $new_step_config, $source_step )' ) );
+assert_overlay( 'import restore path calls withHandlerFields', false !== strpos( $import_export_source, 'FlowStepConfigFactory::withHandlerFields( $flow_config[ $flow_step_id ], $settings )' ) );
+assert_overlay( 'import restore path no longer hand-normalizes array_merge', false === strpos( $import_export_source, 'FlowStepConfig::normalizeHandlerShape(\n\t\t\tarray_merge' ) );
+
+echo "\n";
+if ( 0 === $failed ) {
+	echo "=== flow-step-config-overlays-smoke: ALL PASS ({$total}) ===\n";
+	exit( 0 );
+}
+
+echo "=== flow-step-config-overlays-smoke: {$failed} FAIL of {$total} ===\n";
+exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Moves copy/import flow-step config overlays onto explicit `FlowStepConfigFactory` helper primitives.
- Keeps overlay behavior narrow: handler field normalization, primary handler config mutation, queue-state copy, and `user_message` to static prompt queue conversion.

## Changes
- Added `withHandlerFields()`, `withHandlerConfig()`, `withQueueState()`, and `withUserMessage()` to `FlowStepConfigFactory`.
- Updated `buildCopiedFlowConfig()`, `restore_flow_step_config()`, and `applyStepConfigsToFlow()` to use shared helper primitives for handler/queue overlay placement.
- Added `tests/flow-step-config-overlays-smoke.php` covering copy and import restore overlay behavior.

## Tests
- `php -l inc/Core/Steps/FlowStepConfigFactory.php && php -l inc/Abilities/Flow/FlowHelpers.php && php -l inc/Engine/Actions/ImportExport.php && php -l tests/flow-step-config-overlays-smoke.php`
- `php tests/flow-step-config-factory-smoke.php && php tests/queue-mode-callsites-smoke.php && php tests/queue-mode-collapse-smoke.php && php tests/handler-slug-scalar-migration-smoke.php && php tests/flow-step-legacy-handler-field-smoke.php && php tests/flow-step-config-overlays-smoke.php`
- `php tests/system-task-config-passthrough-smoke.php && php tests/task-scheduler-batch-parent-link-smoke.php && php tests/jobs-command-undo-fanout-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@refactor-flow-step-config-overlays --changed-since origin/main`

Focused import/export PHPUnit note: `homeboy test data-machine --path /Users/chubes/Developer/data-machine@refactor-flow-step-config-overlays --filter ImportExportStepConfigTest` failed before running tests because the Playground runner could not load `/homeboy-extension/scripts/lib/playground-bootstrap.php`.

Closes #1353

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Extracting overlay helpers, tests, and validation; Chris remains responsible for review.