### PR TITLE
docs: fix stale documentation references

### DIFF
--- a/docs/admin-interface/pipeline-builder.md
+++ b/docs/admin-interface/pipeline-builder.md
@@ -149,8 +149,8 @@ For the authoritative list of endpoints used by the UI, refer to `inc/Core/Admin
 
 Handler-related server state is fetched through TanStack Query hooks under `inc/Core/Admin/Pages/Pipelines/assets/react/queries/` and shared utility helpers under `inc/Core/Admin/Pages/Pipelines/assets/react/utils/`:
 
-- `queries/handlers.js` - handler metadata queries
-- `utils/handlerSettings.js` - field normalization and settings helpers
+- `inc/Core/Admin/Pages/Pipelines/assets/react/queries/handlers.js` - handler metadata queries
+- `inc/Core/Admin/Pages/Pipelines/assets/react/utils/handlerSettings.js` - field normalization and settings helpers
 
 ### Service Layer Architecture
 

--- a/docs/core-system/import-export.md
+++ b/docs/core-system/import-export.md
@@ -87,4 +87,4 @@ Store pipeline configurations in external version control systems for change tra
 - **CSV Format**: Standard CSV with proper escaping for complex JSON configurations
 - **Execution Ordering**: Pipeline steps are sorted by `execution_order` during export
 - **Flow Isolation**: Each flow's handler configurations are preserved independently
-- **Database Integration**: Import/export is implemented by `DataMachine\Engine\Actions\ImportExport` and surfaced through `Pipeline/ImportExportAbility.php`; REST, CLI, and ability callers all route through that same action layer.
+- **Database Integration**: Import/export is implemented by `DataMachine\Engine\Actions\ImportExport` and surfaced through `inc/Abilities/Pipeline/ImportExportAbility.php`; REST, CLI, and ability callers all route through that same action layer.

--- a/docs/core-system/services-layer.md
+++ b/docs/core-system/services-layer.md
@@ -11,10 +11,10 @@ The migration from OOP service managers to WordPress Abilities API is **complete
 | Former Service | Replacement | Location |
 |----------------|-------------|----------|
 | `FlowManager` | Flow ability classes | `inc/Abilities/Flow/` |
-| `PipelineManager` | Pipeline ability classes | `inc/Abilities/Pipeline/` and `inc/Abilities/PipelineAbilities.php` |
+| `PipelineManager` | Pipeline ability classes | `inc/Abilities/Pipeline/` |
 | `PipelineStepManager` | `PipelineStepAbilities` | `inc/Abilities/PipelineStepAbilities.php` |
-| `FlowStepManager` | Flow step ability classes | `inc/Abilities/FlowStep/` and `inc/Abilities/FlowStepAbilities.php` |
-| `JobManager` | Job ability classes | `inc/Abilities/Job/` and `inc/Abilities/JobAbilities.php` |
+| `FlowStepManager` | Flow step ability classes | `inc/Abilities/FlowStep/` |
+| `JobManager` | Job ability classes | `inc/Abilities/Job/` |
 | `ProcessedItemsManager` | `ProcessedItemsAbilities` | `inc/Abilities/ProcessedItemsAbilities.php` |
 | `HandlerService` | `HandlerAbilities` | `inc/Abilities/HandlerAbilities.php` |
 | `StepTypeService` | `StepTypeAbilities` | `inc/Abilities/StepTypeAbilities.php` |

--- a/docs/development/hooks/core-actions.md
+++ b/docs/development/hooks/core-actions.md
@@ -2,14 +2,14 @@
 
 Comprehensive reference for all WordPress actions used by Data Machine for pipeline execution, data processing, and system operations.
 
-**Note**: Most core operations use classes in the `DataMachine\Abilities` namespace for direct method calls. These actions remain primarily for extensibility and backward compatibility.
+**Note**: Most core operations use ability classes under `inc/Abilities/` for direct method calls. These actions remain primarily for extensibility and backward compatibility.
 
 ## Abilities API Integration
 
 Direct ability calls are preferred over actions for system operations:
-- `PipelineAbilities` -> `create()`, `delete()`, `duplicate()`
-- `FlowAbilities` -> `create()`, `delete()`, `duplicate()`
-- `JobAbilities` -> `executeFailJob()`, `executeRetryJob()`
+- Pipeline abilities such as `datamachine/create-pipeline`, `datamachine/delete-pipeline`, and `datamachine/duplicate-pipeline`
+- Flow abilities such as `datamachine/create-flow`, `datamachine/delete-flow`, and `datamachine/duplicate-flow`
+- Job abilities such as `datamachine/fail-job` and `datamachine/retry-job`
 - `LogAbilities` -> `write_to_log()`, `read_logs()`, `clear_logs()`
 
 ## Pipeline Execution Actions

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -88,9 +88,9 @@ See [WordPress as Agent Memory](core-system/wordpress-as-agent-memory.md) for th
 
 ## Abilities API
 
-The Abilities API classes in the `DataMachine\Abilities` namespace provide direct method calls for core operations via the WordPress 6.9 Abilities API:
+The ability classes under `inc/Abilities/` provide direct method calls for core operations via the WordPress 6.9 Abilities API:
 
-- `FlowAbilities`, `PipelineAbilities`, `FlowStepAbilities`, and `PipelineStepAbilities` handle creation, duplication, synchronization, and ordering.
+- Flow, pipeline, and flow-step operations live in focused classes under `inc/Abilities/Flow/`, `inc/Abilities/Pipeline/`, and `inc/Abilities/FlowStep/`; `PipelineStepAbilities` handles pipeline-step ordering and synchronization.
 - Job abilities monitor execution outcomes, retries, manual failure, recovery, summaries, and deletion.
 - `ProcessedItemsAbilities` deduplicates content across executions by tracking previously processed identifiers.
 - `AgentAbilities` manages agent CRUD, renaming (with filesystem migration), and deletion.


### PR DESCRIPTION
## Summary
- Fix stale and broken documentation references to moved React helpers, import/export ability code, and split ability classes.

## Changes
- Updated pipeline builder and import/export docs to point at current source paths.
- Reworded service-layer and overview/core-actions ability references where aggregate classes no longer exist.

## Tests
- Confirmed referenced files/directories exist with shell path checks.
- Confirmed the stale reference patterns no longer appear in the touched docs.
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@cleanup-doc-references --changed-since origin/main`

Closes #1338
Closes #788

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updating stale documentation references and validation; Chris remains responsible for review.