### PR TITLE
chore(tests): align orphaned unit test locations

### DIFF
--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -2,10 +2,10 @@
 /**
  * Tests for PipelineBatchScheduler.
  *
- * @package DataMachine\Tests\Unit\Engine
+ * @package DataMachine\Tests\Unit\Abilities\Engine
  */
 
-namespace DataMachine\Tests\Unit\Engine;
+namespace DataMachine\Tests\Unit\Abilities\Engine;
 
 use DataMachine\Abilities\Engine\PipelineBatchScheduler;
 use DataMachine\Core\Database\Jobs\Jobs;

--- a/tests/Unit/Core/FilesRepository/MediaValidatorTest.php
+++ b/tests/Unit/Core/FilesRepository/MediaValidatorTest.php
@@ -5,10 +5,10 @@
  * Verifies the shared validation logic works correctly through both
  * ImageValidator and VideoValidator subclasses.
  *
- * @package DataMachine\Tests\Unit\FilesRepository
+ * @package DataMachine\Tests\Unit\Core\FilesRepository
  */
 
-namespace DataMachine\Tests\Unit\FilesRepository;
+namespace DataMachine\Tests\Unit\Core\FilesRepository;
 
 use DataMachine\Core\FilesRepository\ImageValidator;
 use DataMachine\Core\FilesRepository\MediaValidator;

--- a/tests/Unit/Core/FilesRepository/VideoMetadataTest.php
+++ b/tests/Unit/Core/FilesRepository/VideoMetadataTest.php
@@ -2,10 +2,10 @@
 /**
  * Tests for VideoMetadata.
  *
- * @package DataMachine\Tests\Unit\FilesRepository
+ * @package DataMachine\Tests\Unit\Core\FilesRepository
  */
 
-namespace DataMachine\Tests\Unit\FilesRepository;
+namespace DataMachine\Tests\Unit\Core\FilesRepository;
 
 use DataMachine\Core\FilesRepository\VideoMetadata;
 use WP_UnitTestCase;

--- a/tests/Unit/Core/FilesRepository/VideoValidatorTest.php
+++ b/tests/Unit/Core/FilesRepository/VideoValidatorTest.php
@@ -2,10 +2,10 @@
 /**
  * Tests for VideoValidator.
  *
- * @package DataMachine\Tests\Unit\FilesRepository
+ * @package DataMachine\Tests\Unit\Core\FilesRepository
  */
 
-namespace DataMachine\Tests\Unit\FilesRepository;
+namespace DataMachine\Tests\Unit\Core\FilesRepository;
 
 use DataMachine\Core\FilesRepository\VideoValidator;
 use WP_UnitTestCase;

--- a/tests/Unit/Core/WordPress/PostTrackingTest.php
+++ b/tests/Unit/Core/WordPress/PostTrackingTest.php
@@ -5,10 +5,10 @@
  * Covers the post-tracking write path (PostTracking::store) and the
  * pipeline_id resolver / fallback introduced by #1091.
  *
- * @package DataMachine\Tests\Unit\WordPress
+ * @package DataMachine\Tests\Unit\Core\WordPress
  */
 
-namespace DataMachine\Tests\Unit\WordPress;
+namespace DataMachine\Tests\Unit\Core\WordPress;
 
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Jobs\Jobs;

--- a/tests/Unit/Core/WordPress/WordPressPublishHelperTest.php
+++ b/tests/Unit/Core/WordPress/WordPressPublishHelperTest.php
@@ -2,10 +2,10 @@
 /**
  * Tests for WordPressPublishHelper source attribution.
  *
- * @package DataMachine\Tests\Unit\WordPress
+ * @package DataMachine\Tests\Unit\Core\WordPress
  */
 
-namespace DataMachine\Tests\Unit\WordPress;
+namespace DataMachine\Tests\Unit\Core\WordPress;
 
 use DataMachine\Core\WordPress\WordPressPublishHelper;
 use WP_UnitTestCase;

--- a/tests/Unit/Engine/Filters/DataMachineFiltersTest.php
+++ b/tests/Unit/Engine/Filters/DataMachineFiltersTest.php
@@ -4,10 +4,10 @@
  *
  * Tests for utility filters in Engine/Filters/DataMachineFilters.php.
  *
- * @package DataMachine\Tests\Unit\Engine
+ * @package DataMachine\Tests\Unit\Engine\Filters
  */
 
-namespace DataMachine\Tests\Unit\Engine;
+namespace DataMachine\Tests\Unit\Engine\Filters;
 
 use WP_UnitTestCase;
 

--- a/tests/Unit/Engine/Tasks/TaskRegistryTest.php
+++ b/tests/Unit/Engine/Tasks/TaskRegistryTest.php
@@ -2,10 +2,10 @@
 /**
  * Tests for the TaskRegistry.
  *
- * @package DataMachine\Tests\Unit\Engine
+ * @package DataMachine\Tests\Unit\Engine\Tasks
  */
 
-namespace DataMachine\Tests\Unit\Engine;
+namespace DataMachine\Tests\Unit\Engine\Tasks;
 
 use DataMachine\Engine\Tasks\TaskRegistry;
 use WP_UnitTestCase;

--- a/tests/Unit/Engine/Tasks/TaskSchedulerTest.php
+++ b/tests/Unit/Engine/Tasks/TaskSchedulerTest.php
@@ -2,11 +2,11 @@
 /**
  * Tests for the TaskScheduler.
  *
- * @package DataMachine\Tests\Unit\Engine
+ * @package DataMachine\Tests\Unit\Engine\Tasks
  * @since 0.72.0 Updated: handleTask() removed, schedule() delegates to execute-workflow.
  */
 
-namespace DataMachine\Tests\Unit\Engine;
+namespace DataMachine\Tests\Unit\Engine\Tasks;
 
 use DataMachine\Engine\Tasks\TaskScheduler;
 use DataMachine\Engine\Tasks\TaskRegistry;


### PR DESCRIPTION
## Summary
- Move the valid orphaned-test file-location findings from #803 into paths that mirror the current source tree.
- Leave behavior-style method-name findings untouched because those remain Homeboy detector noise tracked upstream in Extra-Chill/homeboy#1743.

## Changes
- Move Engine filter/task tests under `tests/Unit/Engine/Filters` and `tests/Unit/Engine/Tasks`.
- Move PipelineBatchScheduler under `tests/Unit/Abilities/Engine`.
- Move FilesRepository and WordPress helper tests under `tests/Unit/Core`.
- Update only namespace and package tags to match the new locations.

## Tests
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@cleanup-test-file-locations --changed-since origin/main` (passes; selector found 0 impacted tests)
- `php -l` on all moved test files (passes)
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@cleanup-test-file-locations --changed-since origin/main` (passes)
- Direct moved-file Homeboy test run attempted but blocked by test-harness infrastructure: `/homeboy-extension/scripts/lib/playground-bootstrap.php` missing before PHPUnit took control.

Refs #803
Refs Extra-Chill/homeboy#1743

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** moving valid test files, updating paths, running validation, and drafting this PR; Chris remains responsible for review.