### PR TITLE
feat(ai): add request metadata guardrails

### DIFF
--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -528,6 +528,18 @@ class JobsCommand extends BaseCommand {
 				)
 			);
 		}
+		$request_metadata = $metadata['request_metadata'] ?? array();
+		if ( is_array( $request_metadata ) && ! empty( $request_metadata ) ) {
+			WP_CLI::log(
+				sprintf(
+					'  Request: %s total, %s messages, %s tools, %d tools',
+					size_format( (int) ( $request_metadata['request_json_bytes'] ?? 0 ) ),
+					size_format( (int) ( $request_metadata['messages_json_bytes'] ?? 0 ) ),
+					size_format( (int) ( $request_metadata['tools_json_bytes'] ?? 0 ) ),
+					(int) ( $request_metadata['tools']['count'] ?? 0 )
+				)
+			);
+		}
 		WP_CLI::log( sprintf( '  Messages: %d', count( $messages ) ) );
 		WP_CLI::log( '' );
 

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -186,6 +186,7 @@ class AIConversationLoop {
 		$final_content          = '';
 		$last_tool_calls        = array();
 		$tool_execution_results = array();
+		$last_request_metadata  = array();
 
 		// Accumulate token usage across all turns.
 		$total_usage = array(
@@ -224,6 +225,7 @@ class AIConversationLoop {
 				$mode,
 				$payload
 			);
+			$last_request_metadata = is_array( $ai_response['request_metadata'] ?? null ) ? $ai_response['request_metadata'] : array();
 
 			// Handle AI request failure
 			if ( ! $ai_response['success'] ) {
@@ -248,7 +250,8 @@ class AIConversationLoop {
 					'completed'       => false,
 					'last_tool_calls' => array(),
 					'error'           => $ai_response['error'] ?? 'AI request failed',
-					'usage'           => $total_usage,
+					'usage'            => $total_usage,
+					'request_metadata' => $last_request_metadata,
 				);
 
 				// Persist transcript on the error path too — this is exactly
@@ -528,6 +531,7 @@ class AIConversationLoop {
 			'tool_execution_results' => $tool_execution_results,
 			'has_pending_tools'      => ! empty( $last_tool_calls ) && ! $conversation_complete,
 			'usage'                  => $total_usage,
+			'request_metadata'       => $last_request_metadata,
 		);
 
 		if ( $turn_budget->exceeded() && ! $conversation_complete ) {
@@ -611,6 +615,10 @@ class AIConversationLoop {
 			'error'         => $result['error'] ?? null,
 			'usage'         => $result['usage'] ?? array(),
 		);
+
+		if ( ! empty( $result['request_metadata'] ) && is_array( $result['request_metadata'] ) ) {
+			$metadata['request_metadata'] = $result['request_metadata'];
+		}
 
 		$session_id = $store->create_session( $user_id, $agent_id, $metadata, 'pipeline' );
 

--- a/inc/Engine/AI/PromptBuilder.php
+++ b/inc/Engine/AI/PromptBuilder.php
@@ -107,8 +107,16 @@ class PromptBuilder {
 		}
 
 		$conversation_messages = $this->messages;
-		$directive_outputs     = array();
-		$applied_directives    = array();
+		$directive_outputs      = array();
+		$applied_directives     = array();
+		$directive_metadata     = array();
+		$validation_context     = array_filter(
+			array(
+				'job_id'       => $payload['job_id'] ?? null,
+				'flow_step_id' => $payload['flow_step_id'] ?? null,
+			),
+			fn( $v ) => null !== $v
+		);
 
 		foreach ( $this->directives as $directiveConfig ) {
 			$directive = $directiveConfig['directive'];
@@ -128,6 +136,11 @@ class PromptBuilder {
 					$directive_outputs = array_merge( $directive_outputs, $outputs );
 				}
 				$applied_directives[] = $directive_name;
+				$directive_metadata[] = self::describeDirectiveOutputs(
+					$directive_name,
+					(int) $directiveConfig['priority'],
+					is_array( $outputs ) ? $outputs : array()
+				);
 				continue;
 			}
 
@@ -137,17 +150,15 @@ class PromptBuilder {
 					$directive_outputs = array_merge( $directive_outputs, $outputs );
 				}
 				$applied_directives[] = $directive_name;
+				$directive_metadata[] = self::describeDirectiveOutputs(
+					$directive_name,
+					(int) $directiveConfig['priority'],
+					is_array( $outputs ) ? $outputs : array()
+				);
 				continue;
 			}
 		}
 
-		$validation_context = array_filter(
-			array(
-				'job_id'       => $payload['job_id'] ?? null,
-				'flow_step_id' => $payload['flow_step_id'] ?? null,
-			),
-			fn( $v ) => null !== $v
-		);
 		$validated_outputs  = DirectiveOutputValidator::validateOutputs( $directive_outputs, $validation_context );
 		$directive_messages = DirectiveRenderer::renderMessages( $validated_outputs );
 
@@ -155,6 +166,93 @@ class PromptBuilder {
 			'messages'           => array_merge( $directive_messages, $conversation_messages ),
 			'tools'              => $this->tools,
 			'applied_directives' => $applied_directives,
+			'directive_metadata' => $directive_metadata,
 		);
+	}
+
+	/**
+	 * Describe a directive's output without storing full prompt text.
+	 *
+	 * @param string $name     Directive display name.
+	 * @param int    $priority Directive priority.
+	 * @param array  $outputs  Raw directive outputs.
+	 * @return array<string,mixed>
+	 */
+	private static function describeDirectiveOutputs( string $name, int $priority, array $outputs ): array {
+		$content_bytes = 0;
+		$memory_files  = array();
+
+		foreach ( $outputs as $output ) {
+			$content = '';
+			if ( is_array( $output ) && isset( $output['content'] ) && is_scalar( $output['content'] ) ) {
+				$content = (string) $output['content'];
+			} elseif ( is_array( $output ) && isset( $output['data'] ) ) {
+				$content = (string) wp_json_encode( $output['data'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+			}
+
+			$content_bytes += strlen( $content );
+			$memory_file    = self::extractMemoryFilename( $content );
+			if ( '' !== $memory_file ) {
+				$memory_files[] = array(
+					'filename' => $memory_file,
+					'bytes'    => strlen( $content ),
+					'injected' => true,
+				);
+			}
+		}
+
+		$json = wp_json_encode( $outputs, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+
+		return array(
+			'name'          => $name,
+			'priority'      => $priority,
+			'messages'      => self::countRenderableOutputs( $outputs ),
+			'outputs'       => count( $outputs ),
+			'content_bytes' => $content_bytes,
+			'json_bytes'    => strlen( (string) $json ),
+			'memory_files'  => $memory_files,
+		);
+	}
+
+	/**
+	 * Count outputs that can render into request messages without logging validation warnings.
+	 *
+	 * @param array $outputs Raw directive outputs.
+	 * @return int Renderable output count.
+	 */
+	private static function countRenderableOutputs( array $outputs ): int {
+		$count = 0;
+		foreach ( $outputs as $output ) {
+			if ( ! is_array( $output ) ) {
+				continue;
+			}
+
+			$type = $output['type'] ?? '';
+			if ( 'system_text' === $type && isset( $output['content'] ) && is_string( $output['content'] ) && '' !== trim( $output['content'] ) ) {
+				++$count;
+			}
+			if ( 'system_json' === $type && ! empty( $output['label'] ) && is_array( $output['data'] ?? null ) ) {
+				++$count;
+			}
+			if ( 'system_file' === $type && ! empty( $output['file_path'] ) && ! empty( $output['mime_type'] ) ) {
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Extract a memory filename from the standard MemoryFilesReader content prefix.
+	 *
+	 * @param string $content Directive content.
+	 * @return string Filename when present, otherwise empty string.
+	 */
+	private static function extractMemoryFilename( string $content ): string {
+		if ( preg_match( '/^## Memory File: ([^\n]+)/', $content, $matches ) ) {
+			return trim( $matches[1] );
+		}
+
+		return '';
 	}
 }

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -71,10 +71,22 @@ class RequestBuilder {
 		}
 
 		// Build the request with directives applied
-		$request            = $promptBuilder->build( $mode, $provider, $payload );
-		$applied_directives = $request['applied_directives'] ?? array();
+		$request             = $promptBuilder->build( $mode, $provider, $payload );
+		$applied_directives  = $request['applied_directives'] ?? array();
+		$directive_metadata  = $request['directive_metadata'] ?? array();
 		unset( $request['applied_directives'] );
+		unset( $request['directive_metadata'] );
 		$request['model'] = $model;
+
+		$request_metadata = RequestMetadata::build(
+			$request,
+			$structured_tools,
+			$directive_metadata,
+			$provider,
+			$model,
+			$mode
+		);
+		RequestMetadata::warn_if_oversized( $request_metadata, $payload );
 
 		do_action(
 			'datamachine_log',
@@ -82,14 +94,17 @@ class RequestBuilder {
 			'AI request built',
 			array_filter(
 				array(
-					'mode'          => $mode,
-					'job_id'        => $payload['job_id'] ?? null,
-					'flow_step_id'  => $payload['flow_step_id'] ?? null,
-					'provider'      => $provider,
-					'model'         => $model,
-					'message_count' => count( $request['messages'] ),
-					'tool_count'    => count( $structured_tools ),
-					'directives'    => $applied_directives,
+					'mode'                => $mode,
+					'job_id'              => $payload['job_id'] ?? null,
+					'flow_step_id'        => $payload['flow_step_id'] ?? null,
+					'provider'            => $provider,
+					'model'               => $model,
+					'message_count'       => count( $request['messages'] ),
+					'tool_count'          => count( $structured_tools ),
+					'directives'          => $applied_directives,
+					'request_json_bytes'  => $request_metadata['request_json_bytes'] ?? null,
+					'messages_json_bytes' => $request_metadata['messages_json_bytes'] ?? null,
+					'tools_json_bytes'    => $request_metadata['tools_json_bytes'] ?? null,
 				),
 				fn( $v ) => null !== $v
 			)
@@ -131,12 +146,13 @@ class RequestBuilder {
 					)
 				);
 
+				$wp_ai_response['request_metadata'] = $request_metadata;
 				return $wp_ai_response;
 			}
 		}
 
 		// Legacy path: ai-http-client via chubes_ai_request filter.
-		return apply_filters(
+		$response = apply_filters(
 			'chubes_ai_request',
 			$request,
 			$provider,
@@ -148,6 +164,12 @@ class RequestBuilder {
 				'payload' => $payload,
 			)
 		);
+
+		if ( is_array( $response ) ) {
+			$response['request_metadata'] = $request_metadata;
+		}
+
+		return $response;
 	}
 
 	/**

--- a/inc/Engine/AI/RequestMetadata.php
+++ b/inc/Engine/AI/RequestMetadata.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Compact AI request metadata builder.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+class RequestMetadata {
+
+	/**
+	 * Build compact request composition metadata.
+	 *
+	 * @param array  $request            Provider request array.
+	 * @param array  $structured_tools   Structured tool definitions.
+	 * @param array  $directive_metadata Directive output metadata from PromptBuilder.
+	 * @param string $provider           Provider slug.
+	 * @param string $model              Model name.
+	 * @param string $mode               Execution mode.
+	 * @return array<string,mixed>
+	 */
+	public static function build(
+		array $request,
+		array $structured_tools,
+		array $directive_metadata,
+		string $provider,
+		string $model,
+		string $mode
+	): array {
+		$messages_json = wp_json_encode( $request['messages'] ?? array(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+		$tools_json    = wp_json_encode( $structured_tools, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+		$request_json  = wp_json_encode( $request, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+
+		return array(
+			'provider'            => $provider,
+			'model'               => $model,
+			'mode'                => $mode,
+			'message_count'       => count( $request['messages'] ?? array() ),
+			'request_json_bytes'  => strlen( (string) $request_json ),
+			'messages_json_bytes' => strlen( (string) $messages_json ),
+			'tools_json_bytes'    => strlen( (string) $tools_json ),
+			'directives'          => $directive_metadata,
+			'memory_files'        => self::extract_memory_files( $directive_metadata ),
+			'tools'               => array(
+				'count'      => count( $structured_tools ),
+				'json_bytes' => strlen( (string) $tools_json ),
+				'largest'    => self::largest_tools( $structured_tools ),
+			),
+		);
+	}
+
+	/**
+	 * Emit a structured warning when request-size thresholds are crossed.
+	 *
+	 * @param array $metadata Request metadata.
+	 * @param array $payload  Loop payload for job/step context.
+	 * @return void
+	 */
+	public static function warn_if_oversized( array $metadata, array $payload ): void {
+		$thresholds = self::warning_thresholds();
+		$warnings   = array();
+
+		self::maybe_add_warning( $warnings, 'request_json_bytes', $metadata['request_json_bytes'] ?? 0, $thresholds['request_json_bytes'] );
+		self::maybe_add_warning( $warnings, 'messages_json_bytes', $metadata['messages_json_bytes'] ?? 0, $thresholds['messages_json_bytes'] );
+		self::maybe_add_warning( $warnings, 'tools_json_bytes', $metadata['tools_json_bytes'] ?? 0, $thresholds['tools_json_bytes'] );
+
+		$large_directives = array();
+		foreach ( $metadata['directives'] ?? array() as $directive ) {
+			if ( (int) ( $directive['json_bytes'] ?? 0 ) > $thresholds['directive_json_bytes'] ) {
+				$large_directives[] = $directive;
+			}
+		}
+		if ( ! empty( $large_directives ) ) {
+			$warnings['directives'] = array(
+				'threshold' => $thresholds['directive_json_bytes'],
+				'largest'   => array_slice( $large_directives, 0, 5 ),
+			);
+		}
+
+		$large_tools = array();
+		foreach ( $metadata['tools']['largest'] ?? array() as $tool ) {
+			if ( (int) ( $tool['json_bytes'] ?? 0 ) > $thresholds['tool_json_bytes'] ) {
+				$large_tools[] = $tool;
+			}
+		}
+		if ( ! empty( $large_tools ) ) {
+			$warnings['tools'] = array(
+				'threshold' => $thresholds['tool_json_bytes'],
+				'largest'   => array_slice( $large_tools, 0, 5 ),
+			);
+		}
+
+		if ( empty( $warnings ) ) {
+			return;
+		}
+
+		$largest_directives = $metadata['directives'] ?? array();
+		usort(
+			$largest_directives,
+			fn( $a, $b ) => ( $b['json_bytes'] ?? 0 ) <=> ( $a['json_bytes'] ?? 0 )
+		);
+
+		do_action(
+			'datamachine_log',
+			'warning',
+			'AI request size guardrail warning',
+			array_filter(
+				array(
+					'job_id'               => $payload['job_id'] ?? null,
+					'flow_step_id'         => $payload['flow_step_id'] ?? null,
+					'provider'             => $metadata['provider'] ?? null,
+					'model'                => $metadata['model'] ?? null,
+					'mode'                 => $metadata['mode'] ?? null,
+					'request_json_bytes'   => $metadata['request_json_bytes'] ?? null,
+					'messages_json_bytes' => $metadata['messages_json_bytes'] ?? null,
+					'tools_json_bytes'     => $metadata['tools_json_bytes'] ?? null,
+					'message_count'        => $metadata['message_count'] ?? null,
+					'tool_count'           => $metadata['tools']['count'] ?? null,
+					'largest_directives'   => array_slice( $largest_directives, 0, 5 ),
+					'largest_tools'        => array_slice( $metadata['tools']['largest'] ?? array(), 0, 5 ),
+					'largest_memory_files' => array_slice( $metadata['memory_files'] ?? array(), 0, 5 ),
+					'warnings'             => $warnings,
+				),
+				fn( $value ) => null !== $value
+			)
+		);
+	}
+
+	/**
+	 * Resolve filterable warning thresholds.
+	 *
+	 * Return 0 from a filter to disable that threshold.
+	 *
+	 * @return array<string,int>
+	 */
+	private static function warning_thresholds(): array {
+		return array(
+			'request_json_bytes'   => self::threshold( 'datamachine_ai_request_warning_bytes', 900000 ),
+			'messages_json_bytes'  => self::threshold( 'datamachine_ai_messages_warning_bytes', 750000 ),
+			'tools_json_bytes'     => self::threshold( 'datamachine_ai_tools_warning_bytes', 250000 ),
+			'directive_json_bytes' => self::threshold( 'datamachine_ai_directive_warning_bytes', 150000 ),
+			'tool_json_bytes'      => self::threshold( 'datamachine_ai_tool_warning_bytes', 100000 ),
+		);
+	}
+
+	private static function threshold( string $filter, int $default ): int {
+		$value = (int) apply_filters( $filter, $default );
+		return max( 0, $value );
+	}
+
+	/**
+	 * Add a scalar byte-threshold warning when exceeded.
+	 *
+	 * @param array  $warnings  Warning map mutated in place.
+	 * @param string $field     Metadata field name.
+	 * @param int    $value     Observed byte count.
+	 * @param int    $threshold Warning threshold, or 0 to disable.
+	 * @return void
+	 */
+	private static function maybe_add_warning( array &$warnings, string $field, int $value, int $threshold ): void {
+		if ( $threshold > 0 && $value > $threshold ) {
+			$warnings[ $field ] = array(
+				'value'     => $value,
+				'threshold' => $threshold,
+			);
+		}
+	}
+
+	/**
+	 * Return the largest tool schemas by encoded size.
+	 *
+	 * @param array $structured_tools Structured tool definitions.
+	 * @return array<int,array{name:string,json_bytes:int}>
+	 */
+	private static function largest_tools( array $structured_tools ): array {
+		$tools = array();
+		foreach ( $structured_tools as $name => $tool ) {
+			$json    = wp_json_encode( $tool, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+			$tools[] = array(
+				'name'       => (string) ( $tool['name'] ?? $name ),
+				'json_bytes' => strlen( (string) $json ),
+			);
+		}
+
+		usort( $tools, fn( $a, $b ) => ( $b['json_bytes'] ?? 0 ) <=> ( $a['json_bytes'] ?? 0 ) );
+		return array_slice( $tools, 0, 10 );
+	}
+
+	/**
+	 * Flatten memory-file metadata from directive records.
+	 *
+	 * @param array $directive_metadata Directive metadata records.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function extract_memory_files( array $directive_metadata ): array {
+		$files = array();
+		foreach ( $directive_metadata as $directive ) {
+			foreach ( $directive['memory_files'] ?? array() as $file ) {
+				$files[] = $file;
+			}
+		}
+
+		usort( $files, fn( $a, $b ) => ( $b['bytes'] ?? 0 ) <=> ( $a['bytes'] ?? 0 ) );
+		return $files;
+	}
+}

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Pure-PHP smoke test for AI request metadata and size guardrails.
+ *
+ * Run with: php tests/ai-request-metadata-guardrails-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+class WP_CLI_Command {}
+
+class WP_CLI {
+	public static array $logs = array();
+
+	public static function log( string $message ): void {
+		self::$logs[] = $message;
+	}
+
+	public static function warning( string $message ): void {
+		self::$logs[] = 'WARNING: ' . $message;
+	}
+
+	public static function error( string $message ): void {
+		throw new RuntimeException( $message );
+	}
+}
+
+$GLOBALS['datamachine_test_filters'] = array();
+$GLOBALS['datamachine_test_logs']    = array();
+
+function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['datamachine_test_filters'][ $tag ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function apply_filters( string $tag, $value, ...$args ) {
+	$callbacks = $GLOBALS['datamachine_test_filters'][ $tag ] ?? array();
+	ksort( $callbacks );
+	foreach ( $callbacks as $priority_callbacks ) {
+		foreach ( $priority_callbacks as $entry ) {
+			$callback      = $entry[0];
+			$accepted_args = $entry[1];
+			$value         = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+		}
+	}
+	return $value;
+}
+
+function do_action( string $tag, ...$args ): void {
+	if ( 'datamachine_log' === $tag ) {
+		$GLOBALS['datamachine_test_logs'][] = $args;
+	}
+}
+
+function wp_json_encode( $data, int $flags = 0 ) {
+	return json_encode( $data, $flags );
+}
+
+function size_format( $bytes ): string {
+	return $bytes . ' B';
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use DataMachine\Cli\Commands\JobsCommand;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
+use DataMachine\Core\Database\Chat\ConversationStoreInterface;
+use DataMachine\Engine\AI\AIConversationLoop;
+use DataMachine\Engine\AI\Directives\DirectiveInterface;
+use DataMachine\Engine\AI\RequestBuilder;
+
+class RequestMetadataSmokeDirective implements DirectiveInterface {
+	public static function get_outputs( string $provider_name, array $tools, ?string $step_id = null, array $payload = array() ): array {
+		return array(
+			array(
+				'type'    => 'system_text',
+				'content' => "## Memory File: RULES.md\n" . str_repeat( 'policy ', 25 ),
+			),
+		);
+	}
+}
+
+class RequestMetadataSmokeStore implements ConversationStoreInterface {
+	public array $sessions = array();
+	public array $updated  = array();
+
+	public function create_session( int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string {
+		$this->sessions['smoke-session'] = compact( 'user_id', 'agent_id', 'metadata', 'context' );
+		return 'smoke-session';
+	}
+
+	public function get_session( string $session_id ): ?array { return null; }
+	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '' ): bool {
+		$this->updated[ $session_id ] = compact( 'messages', 'metadata', 'provider', 'model' );
+		return true;
+	}
+	public function delete_session( string $session_id ): bool { return true; }
+	public function get_user_sessions( int $user_id, int $limit = 20, int $offset = 0, ?string $context = null, ?int $agent_id = null ): array { return array(); }
+	public function get_user_session_count( int $user_id, ?string $context = null, ?int $agent_id = null ): int { return 0; }
+	public function get_recent_pending_session( int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array { return null; }
+	public function update_title( string $session_id, string $title ): bool { return true; }
+	public function count_unread( array $messages, ?string $last_read_at ): int { return 0; }
+	public function mark_session_read( string $session_id, int $user_id ) { return gmdate( 'Y-m-d H:i:s' ); }
+	public function cleanup_expired_sessions(): int { return 0; }
+	public function cleanup_old_sessions( int $retention_days ): int { return 0; }
+	public function cleanup_orphaned_sessions( int $hours = 1 ): int { return 0; }
+	public function list_sessions_for_day( string $date ): array { return array(); }
+	public function get_storage_metrics(): ?array { return array( 'rows' => 0, 'size_mb' => '0.0' ); }
+}
+
+$failures = array();
+
+function assert_true( bool $condition, string $label ): void {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+	echo "FAIL: {$label}\n";
+	$failures[] = $label;
+}
+
+function reset_smoke_state(): void {
+	$GLOBALS['datamachine_test_filters'] = array();
+	$GLOBALS['datamachine_test_logs']    = array();
+	WP_CLI::$logs                        = array();
+}
+
+function build_smoke_request(): array {
+	add_filter(
+		'datamachine_directives',
+		function ( array $directives ): array {
+			$directives[] = array(
+				'class'    => RequestMetadataSmokeDirective::class,
+				'priority' => 20,
+				'modes'    => array( 'all' ),
+			);
+			return $directives;
+		}
+	);
+
+	add_filter(
+		'chubes_ai_request',
+		function ( array $request ) {
+			$GLOBALS['datamachine_test_dispatched_request'] = $request;
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => 'ok',
+					'tool_calls' => array(),
+				),
+			);
+		},
+		10,
+		6
+	);
+
+	return RequestBuilder::build(
+		array( array( 'role' => 'user', 'content' => 'hello' ) ),
+		'openai',
+		'gpt-smoke',
+		array(
+			'wiki_upsert' => array(
+				'description' => str_repeat( 'tool ', 20 ),
+				'parameters'  => array( 'type' => 'object', 'properties' => array( 'title' => array( 'type' => 'string' ) ) ),
+			),
+		),
+		'pipeline',
+		array( 'job_id' => 279, 'flow_step_id' => 12, 'persist_transcript' => true )
+	);
+}
+
+// 1. Tiny thresholds warn before dispatch, and compact metadata is attached to the response.
+reset_smoke_state();
+foreach ( array( 'datamachine_ai_request_warning_bytes', 'datamachine_ai_messages_warning_bytes', 'datamachine_ai_tools_warning_bytes', 'datamachine_ai_directive_warning_bytes', 'datamachine_ai_tool_warning_bytes' ) as $filter ) {
+	add_filter( $filter, fn() => 1 );
+}
+$response = build_smoke_request();
+assert_true( ! empty( $GLOBALS['datamachine_test_logs'] ), 'oversized request emits a pre-dispatch warning' );
+assert_true( isset( $response['request_metadata']['request_json_bytes'] ), 'response carries request metadata' );
+assert_true( 'RULES.md' === ( $response['request_metadata']['memory_files'][0]['filename'] ?? '' ), 'memory file metadata is compactly captured' );
+
+// 2. Large thresholds keep normal requests quiet.
+reset_smoke_state();
+foreach ( array( 'datamachine_ai_request_warning_bytes', 'datamachine_ai_messages_warning_bytes', 'datamachine_ai_tools_warning_bytes', 'datamachine_ai_directive_warning_bytes', 'datamachine_ai_tool_warning_bytes' ) as $filter ) {
+	add_filter( $filter, fn() => 999999999 );
+}
+build_smoke_request();
+$guardrail_warnings = array_filter(
+	$GLOBALS['datamachine_test_logs'],
+	fn( $entry ) => 'warning' === ( $entry[0] ?? '' ) && 'AI request size guardrail warning' === ( $entry[1] ?? '' )
+);
+assert_true( empty( $guardrail_warnings ), 'small request does not emit guardrail warning' );
+
+// 3. Simulated persisted pipeline transcript stores request_metadata in session metadata.
+$store    = new RequestMetadataSmokeStore();
+$property = new ReflectionProperty( ConversationStoreFactory::class, 'instance' );
+$property->setValue( null, $store );
+
+$method = new ReflectionMethod( AIConversationLoop::class, 'maybePersistTranscript' );
+$session_id = $method->invoke(
+	null,
+	array( array( 'role' => 'user', 'content' => 'hello' ) ),
+	'openai',
+	'gpt-smoke',
+	array( 'persist_transcript' => true, 'job_id' => 279, 'flow_step_id' => 12, 'user_id' => 1, 'agent_id' => 2 ),
+	array( 'turn_count' => 1, 'completed' => false, 'request_metadata' => $response['request_metadata'] )
+);
+assert_true( 'smoke-session' === $session_id, 'simulated pipeline transcript is persisted' );
+assert_true( isset( $store->updated['smoke-session']['metadata']['request_metadata'] ), 'transcript metadata includes request_metadata' );
+
+// 4. Legacy transcript metadata with no request_metadata still renders cleanly.
+$command = new JobsCommand();
+$render  = new ReflectionMethod( JobsCommand::class, 'renderTranscriptText' );
+$render->invoke(
+	$command,
+	279,
+	'legacy-session',
+	array( 'provider' => 'openai', 'model' => 'gpt-smoke' ),
+	array( array( 'role' => 'user', 'content' => 'legacy transcript' ) ),
+	array( 'turn_count' => 1, 'completed' => true )
+);
+assert_true( in_array( 'Transcript for job 279', WP_CLI::$logs, true ), 'legacy transcript renders without request metadata' );
+
+echo "\n";
+if ( empty( $failures ) ) {
+	echo "All AI request metadata guardrail smoke tests passed.\n";
+	exit( 0 );
+}
+
+echo sprintf( "%d failure(s):\n", count( $failures ) );
+foreach ( $failures as $failure ) {
+	echo "  - {$failure}\n";
+}
+exit( 1 );


### PR DESCRIPTION
## Summary

- Adds compact request composition metadata to AI provider dispatches so pipeline transcripts can explain request size and directive/tool makeup after provider-layer failures.
- Adds pre-dispatch request-size guardrail warnings with filterable thresholds, independent of transcript persistence.

## Changes

- Introduces `RequestMetadata` for request/message/tool byte counts, directive summaries, memory-file summaries, and largest tool schemas.
- Threads `request_metadata` from `RequestBuilder` through `AIConversationLoop` into persisted pipeline transcript session metadata.
- Shows a compact request-size summary in `wp datamachine jobs transcript` text output when metadata exists while preserving legacy transcript rendering.
- Adds filterable warning thresholds: `datamachine_ai_request_warning_bytes`, `datamachine_ai_messages_warning_bytes`, `datamachine_ai_tools_warning_bytes`, `datamachine_ai_directive_warning_bytes`, and `datamachine_ai_tool_warning_bytes`.

Closes #1424
Closes #1425

## Tests

- `php tests/ai-request-metadata-guardrails-smoke.php`
- `php tests/transcript-policy-smoke.php`
- `php -l inc/Engine/AI/RequestMetadata.php && php -l inc/Engine/AI/PromptBuilder.php && php -l inc/Engine/AI/RequestBuilder.php && php -l inc/Engine/AI/AIConversationLoop.php && php -l inc/Cli/Commands/JobsCommand.php && php -l tests/ai-request-metadata-guardrails-smoke.php`

Not run successfully:

- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@feat-ai-request-metadata-guardrails` failed before tests ran because the Playground harness could not load `/homeboy-extension/scripts/lib/playground-bootstrap.php`.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, smoke coverage, and PR description. Chris remains responsible for review and merge.
