### PR TITLE
feat(ai): inspect provider request shape

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -129,6 +129,7 @@ function datamachine_run_datamachine_plugin() {
 
 	// Load abilities
 	require_once __DIR__ . '/inc/Abilities/AuthAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/AI/InspectRequestAbility.php';
 	require_once __DIR__ . '/inc/Abilities/File/FileConstants.php';
 	require_once __DIR__ . '/inc/Abilities/File/AgentFileAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/File/FlowFileAbilities.php';
@@ -196,6 +197,7 @@ function datamachine_run_datamachine_plugin() {
 	// via ScaffoldAbilities::get_ability() → WP_Abilities_Registry::get_instance(),
 	// firing wp_abilities_api_init before the hooks were registered.
 	new \DataMachine\Abilities\AuthAbilities();
+	new \DataMachine\Abilities\AI\InspectRequestAbility();
 	new \DataMachine\Abilities\File\AgentFileAbilities();
 	new \DataMachine\Abilities\File\FlowFileAbilities();
 	new \DataMachine\Abilities\File\ScaffoldAbilities();

--- a/inc/Abilities/AI/InspectRequestAbility.php
+++ b/inc/Abilities/AI/InspectRequestAbility.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Inspect AI request ability.
+ *
+ * @package DataMachine\Abilities\AI
+ */
+
+namespace DataMachine\Abilities\AI;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Engine\AI\RequestInspector;
+
+defined( 'ABSPATH' ) || exit;
+
+class InspectRequestAbility {
+
+	public function __construct() {
+		$this->registerAbility();
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/inspect-ai-request',
+				array(
+					'label'               => __( 'Inspect AI Request', 'data-machine' ),
+					'description'         => __( 'Reconstruct the final provider request for a pipeline AI job without dispatching it.', 'data-machine' ),
+					'category'            => 'datamachine-jobs',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'job_id'       => array(
+								'type'        => 'integer',
+								'description' => __( 'Job ID to inspect.', 'data-machine' ),
+							),
+							'flow_step_id' => array(
+								'type'        => 'string',
+								'description' => __( 'Optional AI flow step ID. Required when the job snapshot has multiple AI steps.', 'data-machine' ),
+							),
+						),
+						'required'   => array( 'job_id' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can( 'view_logs' ) || PermissionHelper::can_manage();
+	}
+
+	public function execute( array $input ): array {
+		$job_id = (int) ( $input['job_id'] ?? 0 );
+		if ( $job_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'Missing or invalid job_id.',
+			);
+		}
+
+		$flow_step_id = isset( $input['flow_step_id'] ) && '' !== (string) $input['flow_step_id']
+			? (string) $input['flow_step_id']
+			: null;
+
+		return ( new RequestInspector() )->inspectPipelineJob( $job_id, $flow_step_id );
+	}
+}

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -21,6 +21,7 @@ WP_CLI::add_command( 'datamachine settings', Commands\SettingsCommand::class );
 WP_CLI::add_command( 'datamachine flows', Commands\Flows\FlowsCommand::class );
 WP_CLI::add_command( 'datamachine alt-text', Commands\AltTextCommand::class );
 WP_CLI::add_command( 'datamachine jobs', Commands\JobsCommand::class );
+WP_CLI::add_command( 'datamachine ai', Commands\AICommand::class );
 WP_CLI::add_command( 'datamachine pipelines', Commands\PipelinesCommand::class );
 WP_CLI::add_command( 'datamachine posts', Commands\PostsCommand::class );
 WP_CLI::add_command( 'datamachine logs', Commands\LogsCommand::class );

--- a/inc/Cli/Commands/AICommand.php
+++ b/inc/Cli/Commands/AICommand.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * WP-CLI AI debugging commands.
+ *
+ * @package DataMachine\Cli\Commands
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Engine\AI\RequestInspector;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+class AICommand extends BaseCommand {
+
+	/**
+	 * Inspect the final provider request for a pipeline AI job without dispatching it.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --job=<job_id>
+	 * : Job ID to inspect.
+	 *
+	 * [--step=<flow_step_id>]
+	 * : Flow step ID to inspect. Required when the job snapshot has multiple AI steps.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine ai inspect-request --job=123
+	 *     wp datamachine ai inspect-request --job=123 --step=flow_step_abc --format=json
+	 *
+	 * @subcommand inspect-request
+	 */
+	public function inspect_request( array $args, array $assoc_args ): void {
+		$job_id = isset( $assoc_args['job'] ) ? (int) $assoc_args['job'] : 0;
+		if ( $job_id <= 0 ) {
+			WP_CLI::error( 'Missing or invalid --job=<job_id>.' );
+			return;
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+		if ( ! in_array( $format, array( 'table', 'json' ), true ) ) {
+			WP_CLI::error( 'Invalid --format. Use table or json.' );
+			return;
+		}
+
+		$result = ( new RequestInspector() )->inspectPipelineJob(
+			$job_id,
+			isset( $assoc_args['step'] ) ? (string) $assoc_args['step'] : null
+		);
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Request inspection failed.' );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+			return;
+		}
+
+		$this->renderTableSummary( $result );
+	}
+
+	private function renderTableSummary( array $result ): void {
+		WP_CLI::log( sprintf( 'Job:        %d', (int) $result['job_id'] ) );
+		WP_CLI::log( sprintf( 'Flow step:  %s', $result['flow_step_id'] ) );
+		WP_CLI::log( sprintf( 'Provider:   %s', $result['provider'] ) );
+		WP_CLI::log( sprintf( 'Model:      %s', $result['model'] ) );
+		WP_CLI::log( sprintf( 'Mode:       %s', $result['mode'] ) );
+		WP_CLI::log( '' );
+
+		$summary = array(
+			array(
+				'metric' => 'message_count',
+				'value'  => (int) $result['message_count'],
+			),
+			array(
+				'metric' => 'total_request_json_bytes',
+				'value'  => (int) $result['total_request_json_bytes'],
+			),
+			array(
+				'metric' => 'messages_json_bytes',
+				'value'  => (int) $result['messages_json_bytes'],
+			),
+			array(
+				'metric' => 'tools_json_bytes',
+				'value'  => (int) $result['tools_json_bytes'],
+			),
+			array(
+				'metric' => 'conversation_user_message_bytes',
+				'value'  => (int) $result['conversation_user_message_bytes'],
+			),
+			array(
+				'metric' => 'conversation_packet_json_bytes',
+				'value'  => (int) $result['conversation_packet_json_bytes'],
+			),
+			array(
+				'metric' => 'tool_count',
+				'value'  => (int) $result['tool_count'],
+			),
+		);
+		\WP_CLI\Utils\format_items( 'table', $summary, array( 'metric', 'value' ) );
+
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Directives' );
+		$directives = array_map(
+			fn( $row ) => array(
+				'class'    => $row['class'] ?? '',
+				'priority' => $row['priority'] ?? 0,
+				'outputs'  => $row['output_count'] ?? 0,
+				'messages' => $row['rendered_message_count'] ?? 0,
+				'content'  => $row['content_bytes'] ?? 0,
+				'json'     => $row['json_bytes'] ?? 0,
+			),
+			$result['directives'] ?? array()
+		);
+		if ( ! empty( $directives ) ) {
+			\WP_CLI\Utils\format_items( 'table', $directives, array( 'class', 'priority', 'outputs', 'messages', 'content', 'json' ) );
+		} else {
+			WP_CLI::log( 'No directives rendered.' );
+		}
+
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Largest tools' );
+		$tools = $result['largest_tools'] ?? array();
+		if ( ! empty( $tools ) ) {
+			\WP_CLI\Utils\format_items( 'table', $tools, array( 'name', 'json_bytes' ) );
+		} else {
+			WP_CLI::log( 'No tools available.' );
+		}
+	}
+}

--- a/inc/Cli/Commands/AICommand.php
+++ b/inc/Cli/Commands/AICommand.php
@@ -8,7 +8,7 @@
 namespace DataMachine\Cli\Commands;
 
 use DataMachine\Cli\BaseCommand;
-use DataMachine\Engine\AI\RequestInspector;
+use DataMachine\Abilities\AI\InspectRequestAbility;
 use WP_CLI;
 
 defined( 'ABSPATH' ) || exit;
@@ -42,7 +42,7 @@ class AICommand extends BaseCommand {
 	 *
 	 * @subcommand inspect-request
 	 */
-	public function inspect_request( array $args, array $assoc_args ): void {
+	public function inspect_request( array $_args, array $assoc_args ): void {
 		$job_id = isset( $assoc_args['job'] ) ? (int) $assoc_args['job'] : 0;
 		if ( $job_id <= 0 ) {
 			WP_CLI::error( 'Missing or invalid --job=<job_id>.' );
@@ -55,9 +55,11 @@ class AICommand extends BaseCommand {
 			return;
 		}
 
-		$result = ( new RequestInspector() )->inspectPipelineJob(
-			$job_id,
-			isset( $assoc_args['step'] ) ? (string) $assoc_args['step'] : null
+		$result = ( new InspectRequestAbility() )->execute(
+			array(
+				'job_id'       => $job_id,
+				'flow_step_id' => isset( $assoc_args['step'] ) ? (string) $assoc_args['step'] : '',
+			)
 		);
 
 		if ( empty( $result['success'] ) ) {

--- a/inc/Engine/AI/PromptBuilder.php
+++ b/inc/Engine/AI/PromptBuilder.php
@@ -91,9 +91,28 @@ class PromptBuilder {
 	 * @param string $mode     Agent mode ('pipeline', 'chat', etc.)
 	 * @param string $provider AI provider name
 	 * @param array  $payload  Request payload
-	 * @return array Request array with 'messages', 'tools', and 'applied_directives' metadata
+	 * @return array Request array with messages, tools, and directive metadata
 	 */
 	public function build( string $mode, string $provider, array $payload = array() ): array {
+		$detailed = $this->buildDetailed( $mode, $provider, $payload );
+
+		return array(
+			'messages'           => $detailed['messages'],
+			'tools'              => $detailed['tools'],
+			'applied_directives' => $detailed['applied_directives'],
+			'directive_metadata' => $detailed['directive_metadata'],
+		);
+	}
+
+	/**
+	 * Build the final AI request and include directive-level inspection metadata.
+	 *
+	 * @param string $mode     Agent mode ('pipeline', 'chat', etc.).
+	 * @param string $provider AI provider name.
+	 * @param array  $payload  Request payload.
+	 * @return array Request array with messages, tools, applied_directives, directive_metadata, and directive_breakdown.
+	 */
+	public function buildDetailed( string $mode, string $provider, array $payload = array() ): array {
 		usort(
 			$this->directives,
 			function ( $a, $b ) {
@@ -107,10 +126,11 @@ class PromptBuilder {
 		}
 
 		$conversation_messages = $this->messages;
-		$directive_outputs      = array();
-		$applied_directives     = array();
-		$directive_metadata     = array();
-		$validation_context     = array_filter(
+		$directive_outputs     = array();
+		$applied_directives    = array();
+		$directive_metadata    = array();
+		$directive_breakdown   = array();
+		$validation_context    = array_filter(
 			array(
 				'job_id'       => $payload['job_id'] ?? null,
 				'flow_step_id' => $payload['flow_step_id'] ?? null,
@@ -121,6 +141,7 @@ class PromptBuilder {
 		foreach ( $this->directives as $directiveConfig ) {
 			$directive = $directiveConfig['directive'];
 			$modes     = $directiveConfig['modes'];
+			$priority  = (int) ( $directiveConfig['priority'] ?? 10 );
 
 			if ( ! in_array( 'all', $modes, true ) && ! in_array( $mode, $modes, true ) ) {
 				continue;
@@ -130,43 +151,48 @@ class PromptBuilder {
 			$directive_class = is_string( $directive ) ? $directive : get_class( $directive );
 			$directive_name  = substr( $directive_class, strrpos( $directive_class, '\\' ) + 1 );
 
+			$outputs = null;
+
 			if ( is_string( $directive ) && class_exists( $directive ) && is_subclass_of( $directive, DirectiveInterface::class ) ) {
 				$outputs = $directive::get_outputs( $provider, $this->tools, $stepId, $payload );
-				if ( is_array( $outputs ) && ! empty( $outputs ) ) {
-					$directive_outputs = array_merge( $directive_outputs, $outputs );
-				}
-				$applied_directives[] = $directive_name;
-				$directive_metadata[] = self::describeDirectiveOutputs(
-					$directive_name,
-					(int) $directiveConfig['priority'],
-					is_array( $outputs ) ? $outputs : array()
-				);
+			} elseif ( is_object( $directive ) && $directive instanceof DirectiveInterface ) {
+				$outputs = $directive->get_outputs( $provider, $this->tools, $stepId, $payload );
+			}
+
+			if ( null === $outputs ) {
 				continue;
 			}
 
-			if ( is_object( $directive ) && $directive instanceof DirectiveInterface ) {
-				$outputs = $directive->get_outputs( $provider, $this->tools, $stepId, $payload );
-				if ( is_array( $outputs ) && ! empty( $outputs ) ) {
-					$directive_outputs = array_merge( $directive_outputs, $outputs );
-				}
-				$applied_directives[] = $directive_name;
-				$directive_metadata[] = self::describeDirectiveOutputs(
-					$directive_name,
-					(int) $directiveConfig['priority'],
-					is_array( $outputs ) ? $outputs : array()
-				);
-				continue;
+			$outputs = is_array( $outputs ) ? $outputs : array();
+			if ( ! empty( $outputs ) ) {
+				$directive_outputs = array_merge( $directive_outputs, $outputs );
 			}
+
+			$validated_outputs   = DirectiveOutputValidator::validateOutputs( $outputs, $validation_context );
+			$rendered_messages    = DirectiveRenderer::renderMessages( $validated_outputs );
+			$applied_directives[] = $directive_name;
+			$directive_metadata[] = self::describeDirectiveOutputs( $directive_name, $priority, $outputs );
+			$directive_breakdown[] = array(
+				'class'                  => $directive_class,
+				'name'                   => $directive_name,
+				'priority'               => $priority,
+				'output_count'           => count( $outputs ),
+				'validated_output_count' => count( $validated_outputs ),
+				'rendered_message_count' => count( $rendered_messages ),
+				'content_bytes'          => self::sumMessageContentBytes( $rendered_messages ),
+				'json_bytes'             => self::jsonBytes( $rendered_messages ),
+			);
 		}
 
 		$validated_outputs  = DirectiveOutputValidator::validateOutputs( $directive_outputs, $validation_context );
 		$directive_messages = DirectiveRenderer::renderMessages( $validated_outputs );
 
 		return array(
-			'messages'           => array_merge( $directive_messages, $conversation_messages ),
-			'tools'              => $this->tools,
-			'applied_directives' => $applied_directives,
-			'directive_metadata' => $directive_metadata,
+			'messages'            => array_merge( $directive_messages, $conversation_messages ),
+			'tools'               => $this->tools,
+			'applied_directives'  => $applied_directives,
+			'directive_metadata'  => $directive_metadata,
+			'directive_breakdown' => $directive_breakdown,
 		);
 	}
 
@@ -254,5 +280,23 @@ class PromptBuilder {
 		}
 
 		return '';
+	}
+
+	private static function jsonBytes( array $value ): int {
+		$json = wp_json_encode( $value, JSON_UNESCAPED_UNICODE );
+		return is_string( $json ) ? strlen( $json ) : 0;
+	}
+
+	private static function sumMessageContentBytes( array $messages ): int {
+		$total = 0;
+		foreach ( $messages as $message ) {
+			$content = $message['content'] ?? '';
+			if ( is_string( $content ) ) {
+				$total += strlen( $content );
+			} elseif ( is_array( $content ) ) {
+				$total += self::jsonBytes( $content );
+			}
+		}
+		return $total;
 	}
 }

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -44,39 +44,11 @@ class RequestBuilder {
 		string $mode,
 		array $payload = array()
 	): array {
-
-		// 1. Initialize request with model and messages
-		$request = array(
-			'model'    => $model,
-			'messages' => $messages,
-		);
-
-		// 2. Restructure tools to standard format (ensures consistent tool structure for all providers)
-		$structured_tools = self::restructure_tools( $tools );
-
-		// 3. Apply directives via PromptBuilder
-		$promptBuilder = new PromptBuilder();
-		$promptBuilder->setMessages( $messages )->setTools( $structured_tools );
-
-		// Get registered directives
-		$directives = apply_filters( 'datamachine_directives', array() );
-
-		// Add each directive to the builder
-		foreach ( $directives as $directive ) {
-			$promptBuilder->addDirective(
-				$directive['class'],
-				$directive['priority'],
-				$directive['modes'] ?? array( 'all' )
-			);
-		}
-
-		// Build the request with directives applied
-		$request             = $promptBuilder->build( $mode, $provider, $payload );
-		$applied_directives  = $request['applied_directives'] ?? array();
-		$directive_metadata  = $request['directive_metadata'] ?? array();
-		unset( $request['applied_directives'] );
-		unset( $request['directive_metadata'] );
-		$request['model'] = $model;
+		$assembled           = self::assemble( $messages, $provider, $model, $tools, $mode, $payload );
+		$request             = $assembled['request'];
+		$structured_tools    = $assembled['structured_tools'];
+		$applied_directives  = $assembled['applied_directives'];
+		$directive_metadata  = $assembled['directive_metadata'];
 
 		$request_metadata = RequestMetadata::build(
 			$request,
@@ -170,6 +142,55 @@ class RequestBuilder {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Assemble a provider request without dispatching it.
+	 *
+	 * @param array  $messages Initial messages array with role/content.
+	 * @param string $provider AI provider name.
+	 * @param string $model    Model identifier.
+	 * @param array  $tools    Raw tools array from filters.
+	 * @param string $mode     Execution mode.
+	 * @param array  $payload  Step payload.
+	 * @return array Assembled request and inspection metadata.
+	 */
+	public static function assemble(
+		array $messages,
+		string $provider,
+		string $model,
+		array $tools,
+		string $mode,
+		array $payload = array()
+	): array {
+		$structured_tools = self::restructure_tools( $tools );
+
+		$promptBuilder = new PromptBuilder();
+		$promptBuilder->setMessages( $messages )->setTools( $structured_tools );
+
+		$directives = apply_filters( 'datamachine_directives', array() );
+		foreach ( $directives as $directive ) {
+			$promptBuilder->addDirective(
+				$directive['class'],
+				$directive['priority'],
+				$directive['modes'] ?? array( 'all' )
+			);
+		}
+
+		$request              = $promptBuilder->buildDetailed( $mode, $provider, $payload );
+		$applied_directives  = $request['applied_directives'] ?? array();
+		$directive_metadata  = $request['directive_metadata'] ?? array();
+		$directive_breakdown = $request['directive_breakdown'] ?? array();
+		unset( $request['applied_directives'], $request['directive_metadata'], $request['directive_breakdown'] );
+		$request['model']    = $model;
+
+		return array(
+			'request'             => $request,
+			'structured_tools'    => $structured_tools,
+			'applied_directives'  => $applied_directives,
+			'directive_metadata'  => $directive_metadata,
+			'directive_breakdown' => $directive_breakdown,
+		);
 	}
 
 	/**

--- a/inc/Engine/AI/RequestInspector.php
+++ b/inc/Engine/AI/RequestInspector.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * AI request inspector.
+ *
+ * Reconstructs the provider request for a pipeline AI step without dispatching it.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\EngineData;
+use DataMachine\Core\FilesRepository\FileRetrieval;
+use DataMachine\Core\PluginSettings;
+use DataMachine\Core\Steps\AI\AIStep;
+use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
+use DataMachine\Engine\StepNavigator;
+
+defined( 'ABSPATH' ) || exit;
+
+class RequestInspector {
+
+	/**
+	 * Inspect the final provider request for a pipeline AI job.
+	 *
+	 * @param int         $job_id       Job ID.
+	 * @param string|null $flow_step_id Optional flow step ID. Required when the flow has multiple AI steps.
+	 * @return array Inspection result.
+	 */
+	public function inspectPipelineJob( int $job_id, ?string $flow_step_id = null ): array {
+		$jobs = new Jobs();
+		$job  = $jobs->get_job( $job_id );
+
+		if ( ! $job ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Job %d not found.', $job_id ),
+			);
+		}
+
+		$engine_snapshot = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		if ( empty( $engine_snapshot ) ) {
+			$engine_snapshot = EngineData::retrieve( $job_id );
+		}
+
+		$engine_snapshot['job'] = array_merge(
+			is_array( $engine_snapshot['job'] ?? null ) ? $engine_snapshot['job'] : array(),
+			array(
+				'job_id'      => $job_id,
+				'flow_id'     => $job['flow_id'] ?? null,
+				'pipeline_id' => $job['pipeline_id'] ?? null,
+				'user_id'     => isset( $job['user_id'] ) ? (int) $job['user_id'] : 0,
+				'agent_id'    => isset( $job['agent_id'] ) ? (int) $job['agent_id'] : 0,
+			)
+		);
+
+		$engine       = new EngineData( $engine_snapshot, $job_id );
+		$flow_step_id = $flow_step_id ? $flow_step_id : $this->resolveAiFlowStepId( $engine->getFlowConfig() );
+		if ( '' === $flow_step_id ) {
+			return array(
+				'success' => false,
+				'error'   => 'No AI flow step found. Pass --step=<flow_step_id>.',
+			);
+		}
+
+		$flow_step_config = $engine->getFlowStepConfig( $flow_step_id );
+		if ( empty( $flow_step_config ) ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow step "%s" not found in job engine snapshot.', $flow_step_id ),
+			);
+		}
+		if ( 'ai' !== ( $flow_step_config['step_type'] ?? '' ) ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow step "%s" is not an AI step.', $flow_step_id ),
+			);
+		}
+
+		$pipeline_step_id = (string) ( $flow_step_config['pipeline_step_id'] ?? '' );
+		if ( '' === $pipeline_step_id ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Flow step "%s" is missing pipeline_step_id.', $flow_step_id ),
+			);
+		}
+
+		$data_packets = $this->retrieveDataPackets( $job_id, $engine );
+		$messages     = $this->buildInitialMessages( $data_packets, $engine, $flow_step_config );
+		$payload      = $this->buildPayload( $job_id, $flow_step_id, $pipeline_step_id, $data_packets, $engine, $job );
+
+		$previous_step_config = $this->getAdjacentStepConfig( $engine, $flow_step_id, $payload, 'previous' );
+		$next_step_config     = $this->getAdjacentStepConfig( $engine, $flow_step_id, $payload, 'next' );
+
+		$pipeline_step_config = $engine->getPipelineStepConfig( $pipeline_step_id );
+		$tool_categories      = $pipeline_step_config['tool_categories'] ?? $engine->get( 'pipeline_tool_categories' ) ?? array();
+		$agent_id             = (int) ( $payload['agent_id'] ?? 0 );
+
+		$resolver = new ToolPolicyResolver();
+		$tools    = $resolver->resolve(
+			array(
+				'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+				'agent_id'             => $agent_id,
+				'previous_step_config' => $previous_step_config,
+				'next_step_config'     => $next_step_config,
+				'pipeline_step_id'     => $pipeline_step_id,
+				'engine_data'          => $engine->all(),
+				'categories'           => $tool_categories,
+			)
+		);
+
+		$required_handler_slugs = array();
+		foreach ( array( $previous_step_config, $next_step_config ) as $adjacent_config ) {
+			if ( $adjacent_config ) {
+				$required_handler_slugs = array_merge( $required_handler_slugs, FlowStepConfig::getRequiredHandlerSlugsForAi( $adjacent_config ) );
+			}
+		}
+		if ( ! empty( $required_handler_slugs ) ) {
+			$handler_tool_slugs = array_values( array_intersect( array_unique( $required_handler_slugs ), array_keys( $tools ) ) );
+			if ( ! empty( $handler_tool_slugs ) ) {
+				$payload['configured_handler_slugs'] = $handler_tool_slugs;
+			}
+		}
+
+		$mode_model = PluginSettings::resolveModelForAgentMode( $agent_id, ToolPolicyResolver::MODE_PIPELINE );
+		$provider   = (string) ( $mode_model['provider'] ?? '' );
+		$model      = (string) ( $mode_model['model'] ?? '' );
+
+		$assembled = RequestBuilder::assemble(
+			$messages,
+			$provider,
+			$model,
+			$tools,
+			ToolPolicyResolver::MODE_PIPELINE,
+			$payload
+		);
+
+		return array_merge(
+			array(
+				'success'      => true,
+				'job_id'       => $job_id,
+				'flow_step_id' => $flow_step_id,
+				'step_id'      => $pipeline_step_id,
+				'provider'     => $provider,
+				'model'        => $model,
+				'mode'         => ToolPolicyResolver::MODE_PIPELINE,
+			),
+			$this->measure( $assembled, $data_packets, $messages )
+		);
+	}
+
+	private function resolveAiFlowStepId( array $flow_config ): string {
+		$ai_steps = array();
+		foreach ( $flow_config as $step_id => $step_config ) {
+			if ( is_array( $step_config ) && 'ai' === ( $step_config['step_type'] ?? '' ) ) {
+				$ai_steps[] = (string) $step_id;
+			}
+		}
+
+		return 1 === count( $ai_steps ) ? $ai_steps[0] : '';
+	}
+
+	private function retrieveDataPackets( int $job_id, EngineData $engine ): array {
+		$job_context = $engine->getJobContext();
+		$flow_id     = $job_context['flow_id'] ?? null;
+		if ( null === $flow_id || 'direct' === $flow_id || (int) $flow_id <= 0 ) {
+			return array();
+		}
+
+		$context = \datamachine_get_file_context( (int) $flow_id );
+		return ( new FileRetrieval() )->retrieve_data_by_job_id( $job_id, $context );
+	}
+
+	private function buildInitialMessages( array $data_packets, EngineData $engine, array $flow_step_config ): array {
+		$messages = array();
+
+		if ( ! empty( $data_packets ) ) {
+			$messages[] = array(
+				'role'    => 'user',
+				'content' => wp_json_encode( array( 'data_packets' => AIStep::sanitizeDataPacketsForAi( $data_packets ) ), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE ),
+			);
+		}
+
+		$file_path = $engine->get( 'image_file_path' );
+		if ( $file_path && file_exists( $file_path ) ) {
+			$file_info  = wp_check_filetype( $file_path );
+			$messages[] = array(
+				'role'    => 'user',
+				'content' => array(
+					array(
+						'type'      => 'file',
+						'file_path' => $file_path,
+						'mime_type' => $file_info['type'] ?? '',
+					),
+				),
+			);
+		}
+
+		$user_message = $this->peekPromptQueueValue( $flow_step_config );
+		if ( '' !== $user_message ) {
+			$messages[] = array(
+				'role'    => 'user',
+				'content' => $user_message,
+			);
+		}
+
+		return $messages;
+	}
+
+	private function peekPromptQueueValue( array $flow_step_config ): string {
+		$queue = $flow_step_config['prompt_queue'] ?? array();
+		if ( ! is_array( $queue ) || empty( $queue ) ) {
+			return '';
+		}
+
+		return trim( (string) ( $queue[0]['prompt'] ?? '' ) );
+	}
+
+	private function buildPayload(
+		int $job_id,
+		string $flow_step_id,
+		string $pipeline_step_id,
+		array $data_packets,
+		EngineData $engine,
+		array $job
+	): array {
+		$job_snapshot = $engine->getJobContext();
+		$user_id      = (int) ( $job_snapshot['user_id'] ?? ( $job['user_id'] ?? 0 ) );
+		$agent_id     = (int) ( $job_snapshot['agent_id'] ?? ( $job['agent_id'] ?? 0 ) );
+
+		return array(
+			'job_id'             => $job_id,
+			'flow_step_id'       => $flow_step_id,
+			'step_id'            => $pipeline_step_id,
+			'data'               => $data_packets,
+			'engine'             => $engine,
+			'user_id'            => $user_id,
+			'agent_id'           => $agent_id,
+			'pipeline_id'        => $job_snapshot['pipeline_id'] ?? ( $job['pipeline_id'] ?? null ),
+			'flow_id'            => $job_snapshot['flow_id'] ?? ( $job['flow_id'] ?? null ),
+			'persist_transcript' => false,
+		);
+	}
+
+	private function getAdjacentStepConfig( EngineData $engine, string $flow_step_id, array $payload, string $direction ): ?array {
+		$navigator   = new StepNavigator();
+		$adjacent_id = 'previous' === $direction
+			? $navigator->get_previous_flow_step_id( $flow_step_id, $payload )
+			: $navigator->get_next_flow_step_id( $flow_step_id, $payload );
+
+		return $adjacent_id ? $engine->getFlowStepConfig( $adjacent_id ) : null;
+	}
+
+	private function measure( array $assembled, array $data_packets, array $initial_messages ): array {
+		$request          = $assembled['request'];
+		$structured_tools = $assembled['structured_tools'];
+		$messages         = $request['messages'] ?? array();
+		$tools            = $request['tools'] ?? array();
+
+		return array(
+			'message_count'                   => count( $messages ),
+			'initial_message_count'           => count( $initial_messages ),
+			'total_request_json_bytes'        => self::jsonBytes( $request ),
+			'messages_json_bytes'             => self::jsonBytes( $messages ),
+			'tools_json_bytes'                => self::jsonBytes( $tools ),
+			'conversation_user_message_bytes' => self::sumUserMessageBytes( $initial_messages ),
+			'conversation_packet_json_bytes'  => self::jsonBytes( AIStep::sanitizeDataPacketsForAi( $data_packets ) ),
+			'directives'                      => $assembled['directive_breakdown'],
+			'tool_count'                      => count( $structured_tools ),
+			'largest_tools'                   => $this->largestTools( $structured_tools ),
+			'request'                         => $request,
+		);
+	}
+
+	private function largestTools( array $tools ): array {
+		$rows = array();
+		foreach ( $tools as $name => $tool ) {
+			$rows[] = array(
+				'name'       => (string) $name,
+				'json_bytes' => self::jsonBytes( $tool ),
+			);
+		}
+
+		usort( $rows, fn( $a, $b ) => $b['json_bytes'] <=> $a['json_bytes'] );
+		return array_slice( $rows, 0, 10 );
+	}
+
+	private static function jsonBytes( $value ): int {
+		$json = wp_json_encode( $value, JSON_UNESCAPED_UNICODE );
+		return is_string( $json ) ? strlen( $json ) : 0;
+	}
+
+	private static function sumUserMessageBytes( array $messages ): int {
+		$total = 0;
+		foreach ( $messages as $message ) {
+			if ( 'user' !== ( $message['role'] ?? '' ) ) {
+				continue;
+			}
+			$content = $message['content'] ?? '';
+			$total  += is_string( $content ) ? strlen( $content ) : self::jsonBytes( $content );
+		}
+		return $total;
+	}
+}

--- a/inc/Engine/AI/RequestInspector.php
+++ b/inc/Engine/AI/RequestInspector.php
@@ -15,6 +15,7 @@ use DataMachine\Core\FilesRepository\FileRetrieval;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\Steps\AI\AIStep;
 use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Abilities\Flow\QueueAbility;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 use DataMachine\Engine\StepNavigator;
 
@@ -210,7 +211,7 @@ class RequestInspector {
 	}
 
 	private function peekPromptQueueValue( array $flow_step_config ): string {
-		$queue = $flow_step_config['prompt_queue'] ?? array();
+		$queue = $flow_step_config[ QueueAbility::SLOT_PROMPT_QUEUE ] ?? array();
 		if ( ! is_array( $queue ) || empty( $queue ) ) {
 			return '';
 		}

--- a/tests/ai-request-inspector-smoke.php
+++ b/tests/ai-request-inspector-smoke.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Pure-PHP smoke test for AI request inspection (#1423).
+ *
+ * Run with: php tests/ai-request-inspector-smoke.php
+ *
+ * Covers the provider-request assembly seam used by the CLI inspector without
+ * booting WordPress or dispatching to a provider.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$test_filters = array();
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	global $test_filters;
+	$test_filters[ $hook ][ $priority ][] = $callback;
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	global $test_filters;
+	if ( empty( $test_filters[ $hook ] ) ) {
+		return $value;
+	}
+	ksort( $test_filters[ $hook ] );
+	foreach ( $test_filters[ $hook ] as $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			$value = $callback( $value, ...$args );
+		}
+	}
+	return $value;
+}
+
+function do_action( string $hook, ...$args ): void {}
+
+function wp_json_encode( $value, int $flags = 0 ) {
+	return json_encode( $value, $flags );
+}
+
+require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveInterface.php';
+require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveOutputValidator.php';
+require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveRenderer.php';
+require_once __DIR__ . '/../inc/Engine/AI/PromptBuilder.php';
+require_once __DIR__ . '/../inc/Engine/AI/RequestBuilder.php';
+
+class Test_Request_Inspector_Directive implements \DataMachine\Engine\AI\Directives\DirectiveInterface {
+	public static function get_outputs( string $provider_name, array $tools, ?string $step_id = null, array $payload = array() ): array {
+		return array(
+			array(
+				'type'    => 'system_text',
+				'content' => 'Inspect directive for job ' . ( $payload['job_id'] ?? 'none' ),
+			),
+		);
+	}
+}
+
+$failed = 0;
+$total  = 0;
+
+function assert_test( string $name, bool $cond, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $cond ) {
+		echo "  [PASS] $name\n";
+	} else {
+		echo "  [FAIL] $name" . ( $detail ? " — $detail" : '' ) . "\n";
+		++$failed;
+	}
+}
+
+echo "Case 1: RequestBuilder::assemble builds the request without provider dispatch\n";
+
+$dispatch_count = 0;
+add_filter(
+	'chubes_ai_request',
+	function ( $request ) use ( &$dispatch_count ) {
+		++$dispatch_count;
+		return array( 'success' => false, 'error' => 'should not dispatch' );
+	}
+);
+
+add_filter(
+	'datamachine_directives',
+	function ( array $directives ): array {
+		$directives[] = array(
+			'class'    => Test_Request_Inspector_Directive::class,
+			'priority' => 20,
+			'modes'    => array( 'pipeline' ),
+		);
+		return $directives;
+	}
+);
+
+$messages = array(
+	array(
+		'role'    => 'user',
+		'content' => 'Original user packet',
+	),
+);
+$tools = array(
+	'inspect_tool' => array(
+		'description' => 'Small fake tool',
+		'parameters'  => array(
+			'type'       => 'object',
+			'properties' => array(
+				'name' => array( 'type' => 'string' ),
+			),
+		),
+	),
+);
+
+$assembled = \DataMachine\Engine\AI\RequestBuilder::assemble(
+	$messages,
+	'openai',
+	'gpt-test',
+	$tools,
+	'pipeline',
+	array(
+		'job_id'       => 1423,
+		'flow_step_id' => 'ai_step_1',
+		'step_id'      => 'pipeline_ai_1',
+	)
+);
+
+assert_test( 'assemble did not call chubes_ai_request', 0 === $dispatch_count );
+assert_test( 'request model set', 'gpt-test' === ( $assembled['request']['model'] ?? '' ) );
+assert_test( 'directive prepended a system message', 'system' === ( $assembled['request']['messages'][0]['role'] ?? '' ) );
+assert_test( 'original user message preserved', 'Original user packet' === ( $assembled['request']['messages'][1]['content'] ?? '' ) );
+assert_test( 'tool restructured with explicit name', 'inspect_tool' === ( $assembled['structured_tools']['inspect_tool']['name'] ?? '' ) );
+
+echo "\nCase 2: directive breakdown and byte counts are deterministic\n";
+
+$breakdown = $assembled['directive_breakdown'][0] ?? array();
+assert_test( 'fake directive appears in breakdown', Test_Request_Inspector_Directive::class === ( $breakdown['class'] ?? '' ) );
+assert_test( 'directive priority recorded', 20 === ( $breakdown['priority'] ?? null ) );
+assert_test( 'directive rendered one message', 1 === ( $breakdown['rendered_message_count'] ?? null ) );
+assert_test( 'directive content byte count is exact', strlen( 'Inspect directive for job 1423' ) === ( $breakdown['content_bytes'] ?? null ) );
+
+$request_json_bytes = strlen( wp_json_encode( $assembled['request'], JSON_UNESCAPED_UNICODE ) );
+$messages_json_bytes = strlen( wp_json_encode( $assembled['request']['messages'], JSON_UNESCAPED_UNICODE ) );
+$tools_json_bytes = strlen( wp_json_encode( $assembled['request']['tools'], JSON_UNESCAPED_UNICODE ) );
+
+assert_test( 'request JSON byte count stable', 330 === $request_json_bytes, 'got ' . $request_json_bytes );
+assert_test( 'messages JSON byte count stable', 111 === $messages_json_bytes, 'got ' . $messages_json_bytes );
+assert_test( 'tools JSON byte count stable', 178 === $tools_json_bytes, 'got ' . $tools_json_bytes );
+
+echo "\nCase 3: CLI command surface is registered and documented\n";
+
+$bootstrap = file_get_contents( __DIR__ . '/../inc/Cli/Bootstrap.php' );
+$command   = file_get_contents( __DIR__ . '/../inc/Cli/Commands/AICommand.php' );
+
+assert_test( 'datamachine ai namespace registered', false !== strpos( $bootstrap, "datamachine ai" ) );
+assert_test( 'inspect-request subcommand declared', false !== strpos( $command, '@subcommand inspect-request' ) );
+assert_test( '--job option documented', false !== strpos( $command, '--job=<job_id>' ) );
+assert_test( '--step option documented', false !== strpos( $command, '--step=<flow_step_id>' ) );
+assert_test( 'json output path exists', false !== strpos( $command, "'json' === \$format" ) );
+assert_test( 'table output includes directive section', false !== strpos( $command, "Directives" ) );
+assert_test( 'table output includes largest tools section', false !== strpos( $command, "Largest tools" ) );
+
+echo "\n$total assertions, $failed failures\n";
+if ( $failed > 0 ) {
+	exit( 1 );
+}

--- a/tests/ai-request-inspector-smoke.php
+++ b/tests/ai-request-inspector-smoke.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $test_filters = array();
 
-function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+function add_filter( string $hook, callable $callback, int $priority = 10, int $_accepted_args = 1 ): void {
 	global $test_filters;
 	$test_filters[ $hook ][ $priority ][] = $callback;
 }
@@ -35,7 +35,7 @@ function apply_filters( string $hook, $value, ...$args ) {
 	return $value;
 }
 
-function do_action( string $hook, ...$args ): void {}
+function do_action( string $_hook, ...$args ): void {}
 
 function wp_json_encode( $value, int $flags = 0 ) {
 	return json_encode( $value, $flags );
@@ -48,7 +48,7 @@ require_once __DIR__ . '/../inc/Engine/AI/PromptBuilder.php';
 require_once __DIR__ . '/../inc/Engine/AI/RequestBuilder.php';
 
 class Test_Request_Inspector_Directive implements \DataMachine\Engine\AI\Directives\DirectiveInterface {
-	public static function get_outputs( string $provider_name, array $tools, ?string $step_id = null, array $payload = array() ): array {
+	public static function get_outputs( string $_provider_name, array $_tools, ?string $_step_id = null, array $payload = array() ): array {
 		return array(
 			array(
 				'type'    => 'system_text',
@@ -155,11 +155,19 @@ $command   = file_get_contents( __DIR__ . '/../inc/Cli/Commands/AICommand.php' )
 
 assert_test( 'datamachine ai namespace registered', false !== strpos( $bootstrap, "datamachine ai" ) );
 assert_test( 'inspect-request subcommand declared', false !== strpos( $command, '@subcommand inspect-request' ) );
+assert_test( 'CLI routes through inspect request ability', false !== strpos( $command, 'InspectRequestAbility' ) );
 assert_test( '--job option documented', false !== strpos( $command, '--job=<job_id>' ) );
 assert_test( '--step option documented', false !== strpos( $command, '--step=<flow_step_id>' ) );
 assert_test( 'json output path exists', false !== strpos( $command, "'json' === \$format" ) );
 assert_test( 'table output includes directive section', false !== strpos( $command, "Directives" ) );
 assert_test( 'table output includes largest tools section', false !== strpos( $command, "Largest tools" ) );
+
+$plugin = file_get_contents( __DIR__ . '/../data-machine.php' );
+$ability = file_get_contents( __DIR__ . '/../inc/Abilities/AI/InspectRequestAbility.php' );
+
+assert_test( 'inspect request ability loaded by plugin bootstrap', false !== strpos( $plugin, 'InspectRequestAbility.php' ) );
+assert_test( 'inspect request ability instantiated by plugin bootstrap', false !== strpos( $plugin, 'new \\DataMachine\\Abilities\\AI\\InspectRequestAbility()' ) );
+assert_test( 'ability registers datamachine/inspect-ai-request', false !== strpos( $ability, 'datamachine/inspect-ai-request' ) );
 
 echo "\n$total assertions, $failed failures\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- Adds a read-only `wp datamachine ai inspect-request` CLI surface for reconstructing a pipeline AI job's final provider request without dispatching to the provider.
- Exposes the same operation through the Abilities API as `datamachine/inspect-ai-request` so CLI is only one consumer of the debug surface.
- Extracts request assembly into `RequestBuilder::assemble()` so the inspector and live dispatch path share the same directive/tool request construction seam.

## Changes
- Registers `datamachine/inspect-ai-request` with `job_id` and optional `flow_step_id` inputs.
- Registers `datamachine ai inspect-request --job=<job_id> [--step=<flow_step_id>] [--format=table|json]` as a thin CLI wrapper around the ability.
- Adds directive-level inspection metadata from `PromptBuilder::buildDetailed()` including directive class, priority, output/message counts, content bytes, and JSON bytes.
- Adds `RequestInspector` to rebuild pipeline AI messages, resolve adjacent-step tools, measure request/message/tool/data-packet bytes, and report largest tool schemas.
- Leaves provider dispatch, job state, transcripts, queues, sessions, and flow config untouched.

## Tests
- `php tests/ai-request-inspector-smoke.php`
- `php tests/ai-required-handlers-smoke.php`
- `php tests/tool-policy-resolver-adjacency-smoke.php`
- `php tests/queue-mode-collapse-smoke.php`
- `php tests/transcript-policy-smoke.php`
- `php -l inc/Abilities/AI/InspectRequestAbility.php && php -l inc/Engine/AI/PromptBuilder.php && php -l inc/Engine/AI/RequestBuilder.php && php -l inc/Engine/AI/RequestInspector.php && php -l inc/Cli/Commands/AICommand.php && php -l inc/Cli/Bootstrap.php && php -l data-machine.php && php -l tests/ai-request-inspector-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@feat-ai-inspect-request --changed-since origin/main`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-ai-inspect-request --changed-only --errors-only --summary` currently fails before lint execution with `validation.invalid_json` / `duplicate field test at line 353 column 8` from Homeboy config parsing.

Closes #1423

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Abilities API surface, request assembly seam, CLI wrapper, and smoke tests; Chris remains responsible for review and validation.
