### PR TITLE
feat(ai): add per-agent directive policy

### DIFF
--- a/inc/Engine/AI/Directives/DirectivePolicyResolver.php
+++ b/inc/Engine/AI/Directives/DirectivePolicyResolver.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Directive Policy Resolver.
+ *
+ * Applies per-agent directive policy from agent_config.directive_policy to the
+ * registered directive stack. Policy entries match either the fully-qualified
+ * class name or the short class name (for example CoreMemoryFilesDirective).
+ *
+ * @package DataMachine\Engine\AI\Directives
+ */
+
+namespace DataMachine\Engine\AI\Directives;
+
+use DataMachine\Core\Database\Agents\Agents;
+
+defined( 'ABSPATH' ) || exit;
+
+class DirectivePolicyResolver {
+
+	/**
+	 * Resolve directives after applying optional per-agent policy.
+	 *
+	 * @param array $directives Registered directive configs.
+	 * @param array $args       Resolution args: mode, agent_id.
+	 * @return array{directives: array, suppressed: array}
+	 */
+	public function resolve( array $directives, array $args ): array {
+		$mode     = isset( $args['mode'] ) ? (string) $args['mode'] : '';
+		$agent_id = isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0;
+		$policy   = $agent_id > 0 ? $this->getAgentDirectivePolicy( $agent_id ) : null;
+
+		$result = $this->applyPolicy( $directives, $policy, $mode );
+
+		/**
+		 * Filter the directive stack after per-agent policy is applied.
+		 *
+		 * @param array $result     Array with directives and suppressed keys.
+		 * @param array $directives  Original registered directive configs.
+		 * @param array $args        Resolution args.
+		 */
+		return apply_filters( 'datamachine_resolved_directives', $result, $directives, $args );
+	}
+
+	/**
+	 * Read an agent's directive policy from agent_config.
+	 *
+	 * Supported shape:
+	 * {
+	 *   "directive_policy": {
+	 *     "mode": "deny"|"allow_only",
+	 *     "deny": ["CoreMemoryFilesDirective"],
+	 *     "allow_only": ["AgentModeDirective"],
+	 *     "modes": ["pipeline"]
+	 *   }
+	 * }
+	 *
+	 * The optional modes list scopes the policy to request modes. Without it,
+	 * the policy applies to every mode.
+	 *
+	 * @param int $agent_id Agent ID.
+	 * @return array|null Normalized policy, or null for no-op/invalid policy.
+	 */
+	public function getAgentDirectivePolicy( int $agent_id ): ?array {
+		if ( $agent_id <= 0 ) {
+			return null;
+		}
+
+		$agents_repo = new Agents();
+		$agent       = $agents_repo->get_agent( $agent_id );
+
+		if ( ! $agent ) {
+			return null;
+		}
+
+		$config = $agent['agent_config'] ?? array();
+
+		if ( empty( $config['directive_policy'] ) || ! is_array( $config['directive_policy'] ) ) {
+			return null;
+		}
+
+		return $this->normalizePolicy( $config['directive_policy'] );
+	}
+
+	/**
+	 * Apply a normalized directive policy.
+	 *
+	 * @param array      $directives Registered directive configs.
+	 * @param array|null $policy     Normalized policy.
+	 * @param string     $mode       Current agent mode.
+	 * @return array{directives: array, suppressed: array}
+	 */
+	public function applyPolicy( array $directives, ?array $policy, string $mode = '' ): array {
+		if ( null === $policy || ! $this->policyAppliesToMode( $policy, $mode ) ) {
+			return array(
+				'directives' => $directives,
+				'suppressed' => array(),
+			);
+		}
+
+		$filtered   = array();
+		$suppressed = array();
+		$mode_name  = $policy['mode'];
+		$deny       = array_flip( $policy['deny'] ?? array() );
+		$allow_only = array_flip( $policy['allow_only'] ?? array() );
+
+		foreach ( $directives as $directive ) {
+			$class = $directive['class'] ?? null;
+			if ( ! is_string( $class ) || '' === $class ) {
+				$filtered[] = $directive;
+				continue;
+			}
+
+			$identifiers = $this->getClassIdentifiers( $class );
+			$matches     = $this->matchesAny( $identifiers, 'deny' === $mode_name ? $deny : $allow_only );
+			$short_name  = $identifiers[ count( $identifiers ) - 1 ];
+
+			if ( 'deny' === $mode_name && $matches ) {
+				$suppressed[] = $short_name;
+				continue;
+			}
+
+			if ( 'allow_only' === $mode_name && ! $matches ) {
+				$suppressed[] = $short_name;
+				continue;
+			}
+
+			$filtered[] = $directive;
+		}
+
+		return array(
+			'directives' => $filtered,
+			'suppressed' => array_values( array_unique( $suppressed ) ),
+		);
+	}
+
+	/**
+	 * Normalize a raw directive policy.
+	 *
+	 * @param array $policy Raw policy.
+	 * @return array|null Normalized policy, or null for invalid/no-op policy.
+	 */
+	private function normalizePolicy( array $policy ): ?array {
+		$mode = $policy['mode'] ?? 'default';
+		if ( ! in_array( $mode, array( 'default', 'deny', 'allow_only' ), true ) ) {
+			return null;
+		}
+
+		if ( 'default' === $mode ) {
+			return null;
+		}
+
+		$deny       = isset( $policy['deny'] ) && is_array( $policy['deny'] )
+			? $this->normalizeClassList( $policy['deny'] )
+			: array();
+		$allow_only = isset( $policy['allow_only'] ) && is_array( $policy['allow_only'] )
+			? $this->normalizeClassList( $policy['allow_only'] )
+			: array();
+		$modes      = isset( $policy['modes'] ) && is_array( $policy['modes'] )
+			? $this->normalizeStringList( $policy['modes'] )
+			: array();
+
+		if ( 'deny' === $mode && empty( $deny ) ) {
+			return null;
+		}
+
+		return array(
+			'mode'       => $mode,
+			'deny'       => $deny,
+			'allow_only' => $allow_only,
+			'modes'      => $modes,
+		);
+	}
+
+	/**
+	 * Check whether a policy applies to the current mode.
+	 *
+	 * @param array  $policy Normalized policy.
+	 * @param string $mode   Current mode.
+	 * @return bool
+	 */
+	private function policyAppliesToMode( array $policy, string $mode ): bool {
+		$modes = $policy['modes'] ?? array();
+		return empty( $modes ) || in_array( $mode, $modes, true );
+	}
+
+	/**
+	 * Normalize class names from policy config.
+	 *
+	 * @param array $values Raw values.
+	 * @return string[]
+	 */
+	private function normalizeClassList( array $values ): array {
+		return $this->normalizeStringList( $values, true );
+	}
+
+	/**
+	 * Normalize strings.
+	 *
+	 * @param array $values Raw values.
+	 * @param bool  $class_names Whether values are class names.
+	 * @return string[]
+	 */
+	private function normalizeStringList( array $values, bool $class_names = false ): array {
+		$normalized = array();
+
+		foreach ( $values as $value ) {
+			if ( ! is_string( $value ) ) {
+				continue;
+			}
+			$value = trim( $value );
+			if ( '' === $value ) {
+				continue;
+			}
+			$normalized[] = $class_names ? ltrim( $value, '\\' ) : $value;
+		}
+
+		return array_values( array_unique( $normalized ) );
+	}
+
+	/**
+	 * Get the FQCN and short-name identifiers for a directive class.
+	 *
+	 * @param string $class Directive class.
+	 * @return string[] FQCN first, short class name second.
+	 */
+	private function getClassIdentifiers( string $class ): array {
+		$class = ltrim( $class, '\\' );
+		$pos   = strrpos( $class, '\\' );
+		$short = false === $pos ? $class : substr( $class, $pos + 1 );
+
+		return array_values( array_unique( array( $class, $short ) ) );
+	}
+
+	/**
+	 * Check class identifiers against a normalized policy set.
+	 *
+	 * @param string[] $identifiers Class identifiers.
+	 * @param array    $policy_set  Flipped policy list.
+	 * @return bool
+	 */
+	private function matchesAny( array $identifiers, array $policy_set ): bool {
+		foreach ( $identifiers as $identifier ) {
+			if ( isset( $policy_set[ $identifier ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/inc/Engine/AI/Directives/DirectivePolicyResolver.php
+++ b/inc/Engine/AI/Directives/DirectivePolicyResolver.php
@@ -223,12 +223,12 @@ class DirectivePolicyResolver {
 	 * @param string $class Directive class.
 	 * @return string[] FQCN first, short class name second.
 	 */
-	private function getClassIdentifiers( string $class ): array {
-		$class = ltrim( $class, '\\' );
-		$pos   = strrpos( $class, '\\' );
-		$short = false === $pos ? $class : substr( $class, $pos + 1 );
+	private function getClassIdentifiers( string $class_name ): array {
+		$class_name = ltrim( $class_name, '\\' );
+		$pos        = strrpos( $class_name, '\\' );
+		$short      = false === $pos ? $class_name : substr( $class_name, $pos + 1 );
 
-		return array_values( array_unique( array( $class, $short ) ) );
+		return array_values( array_unique( array( $class_name, $short ) ) );
 	}
 
 	/**

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -68,18 +68,18 @@ class RequestBuilder {
 			'AI request built',
 			array_filter(
 				array(
-					'mode'                => $mode,
-					'job_id'              => $payload['job_id'] ?? null,
-					'flow_step_id'        => $payload['flow_step_id'] ?? null,
-					'provider'            => $provider,
-					'model'               => $model,
-					'message_count'       => count( $request['messages'] ),
-					'tool_count'          => count( $structured_tools ),
-					'directives'          => $applied_directives,
+					'mode'                  => $mode,
+					'job_id'                => $payload['job_id'] ?? null,
+					'flow_step_id'          => $payload['flow_step_id'] ?? null,
+					'provider'              => $provider,
+					'model'                 => $model,
+					'message_count'         => count( $request['messages'] ),
+					'tool_count'            => count( $structured_tools ),
+					'directives'            => $applied_directives,
 					'suppressed_directives' => ! empty( $assembled['suppressed_directives'] ) ? $assembled['suppressed_directives'] : null,
-					'request_json_bytes'  => $request_metadata['request_json_bytes'] ?? null,
-					'messages_json_bytes' => $request_metadata['messages_json_bytes'] ?? null,
-					'tools_json_bytes'    => $request_metadata['tools_json_bytes'] ?? null,
+					'request_json_bytes'    => $request_metadata['request_json_bytes'] ?? null,
+					'messages_json_bytes'   => $request_metadata['messages_json_bytes'] ?? null,
+					'tools_json_bytes'      => $request_metadata['tools_json_bytes'] ?? null,
 				),
 				fn( $v ) => null !== $v
 			)
@@ -179,8 +179,8 @@ class RequestBuilder {
 				'agent_id' => $payload['agent_id'] ?? 0,
 			)
 		);
-		$directives       = $directive_policy['directives'];
-		$suppressed       = $directive_policy['suppressed'] ?? array();
+		$directives        = $directive_policy['directives'];
+		$suppressed        = $directive_policy['suppressed'] ?? array();
 		foreach ( $directives as $directive ) {
 			$promptBuilder->addDirective(
 				$directive['class'],
@@ -201,7 +201,7 @@ class RequestBuilder {
 			'structured_tools'    => $structured_tools,
 			'applied_directives'  => $applied_directives,
 			'directive_metadata'  => $directive_metadata,
-			'directive_breakdown' => $directive_breakdown,
+			'directive_breakdown'   => $directive_breakdown,
 			'suppressed_directives' => $suppressed,
 		);
 	}

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -12,6 +12,8 @@
 
 namespace DataMachine\Engine\AI;
 
+use DataMachine\Engine\AI\Directives\DirectivePolicyResolver;
+
 defined( 'ABSPATH' ) || exit;
 
 class RequestBuilder {
@@ -74,6 +76,7 @@ class RequestBuilder {
 					'message_count'       => count( $request['messages'] ),
 					'tool_count'          => count( $structured_tools ),
 					'directives'          => $applied_directives,
+					'suppressed_directives' => ! empty( $assembled['suppressed_directives'] ) ? $assembled['suppressed_directives'] : null,
 					'request_json_bytes'  => $request_metadata['request_json_bytes'] ?? null,
 					'messages_json_bytes' => $request_metadata['messages_json_bytes'] ?? null,
 					'tools_json_bytes'    => $request_metadata['tools_json_bytes'] ?? null,
@@ -168,7 +171,16 @@ class RequestBuilder {
 		$promptBuilder = new PromptBuilder();
 		$promptBuilder->setMessages( $messages )->setTools( $structured_tools );
 
-		$directives = apply_filters( 'datamachine_directives', array() );
+		$directives        = apply_filters( 'datamachine_directives', array() );
+		$directive_policy = ( new DirectivePolicyResolver() )->resolve(
+			$directives,
+			array(
+				'mode'     => $mode,
+				'agent_id' => $payload['agent_id'] ?? 0,
+			)
+		);
+		$directives       = $directive_policy['directives'];
+		$suppressed       = $directive_policy['suppressed'] ?? array();
 		foreach ( $directives as $directive ) {
 			$promptBuilder->addDirective(
 				$directive['class'],
@@ -190,6 +202,7 @@ class RequestBuilder {
 			'applied_directives'  => $applied_directives,
 			'directive_metadata'  => $directive_metadata,
 			'directive_breakdown' => $directive_breakdown,
+			'suppressed_directives' => $suppressed,
 		);
 	}
 

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -171,7 +171,7 @@ class RequestBuilder {
 		$promptBuilder = new PromptBuilder();
 		$promptBuilder->setMessages( $messages )->setTools( $structured_tools );
 
-		$directives        = apply_filters( 'datamachine_directives', array() );
+		$directives       = apply_filters( 'datamachine_directives', array() );
 		$directive_policy = ( new DirectivePolicyResolver() )->resolve(
 			$directives,
 			array(
@@ -179,8 +179,8 @@ class RequestBuilder {
 				'agent_id' => $payload['agent_id'] ?? 0,
 			)
 		);
-		$directives        = $directive_policy['directives'];
-		$suppressed        = $directive_policy['suppressed'] ?? array();
+		$directives = $directive_policy['directives'];
+		$suppressed = $directive_policy['suppressed'] ?? array();
 		foreach ( $directives as $directive ) {
 			$promptBuilder->addDirective(
 				$directive['class'],

--- a/tests/ai-request-inspector-smoke.php
+++ b/tests/ai-request-inspector-smoke.php
@@ -42,6 +42,7 @@ function wp_json_encode( $value, int $flags = 0 ) {
 }
 
 require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveInterface.php';
+require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectivePolicyResolver.php';
 require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveOutputValidator.php';
 require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveRenderer.php';
 require_once __DIR__ . '/../inc/Engine/AI/PromptBuilder.php';

--- a/tests/directive-policy-resolver-smoke.php
+++ b/tests/directive-policy-resolver-smoke.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Pure-PHP smoke test for DirectivePolicyResolver.
+ *
+ * Run with: php tests/directive-policy-resolver-smoke.php
+ *
+ * Covers the per-agent directive policy contract without booting WordPress.
+ * Policy entries match either short class names or fully-qualified class names.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\Database\Agents {
+	class Agents {
+		public function get_agent( int $agent_id ): ?array {
+			return $GLOBALS['__directive_policy_agents'][ $agent_id ] ?? null;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value ) {
+			return $value;
+		}
+	}
+
+	require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectivePolicyResolver.php';
+
+	use DataMachine\Engine\AI\Directives\DirectivePolicyResolver;
+
+	$assertions = 0;
+
+	function directive_policy_assert_same( $expected, $actual, string $message ): void {
+		global $assertions;
+		++$assertions;
+		if ( $expected !== $actual ) {
+			fwrite( STDERR, "FAIL: {$message}\nExpected: " . var_export( $expected, true ) . "\nActual: " . var_export( $actual, true ) . "\n" );
+			exit( 1 );
+		}
+	}
+
+	function directive_policy_directives(): array {
+		return array(
+			array(
+				'class'    => 'DataMachine\\Engine\\AI\\Directives\\CoreMemoryFilesDirective',
+				'priority' => 10,
+				'modes'    => array( 'all' ),
+			),
+			array(
+				'class'    => 'DataMachine\\Engine\\AI\\Directives\\AgentDailyMemoryDirective',
+				'priority' => 20,
+				'modes'    => array( 'all' ),
+			),
+			array(
+				'class'    => 'DataMachine\\Engine\\AI\\Directives\\AgentModeDirective',
+				'priority' => 30,
+				'modes'    => array( 'all' ),
+			),
+		);
+	}
+
+	function directive_policy_names( array $directives ): array {
+		return array_map(
+			function ( array $directive ): string {
+				$class = $directive['class'];
+				return substr( $class, strrpos( $class, '\\' ) + 1 );
+			},
+			$directives
+		);
+	}
+
+	$resolver   = new DirectivePolicyResolver();
+	$directives = directive_policy_directives();
+
+	// Default policy applies all directives as before.
+	$result = $resolver->resolve(
+		$directives,
+		array(
+			'mode'     => 'pipeline',
+			'agent_id' => 0,
+		)
+	);
+	directive_policy_assert_same( directive_policy_names( $directives ), directive_policy_names( $result['directives'] ), 'default policy keeps all directives' );
+	directive_policy_assert_same( array(), $result['suppressed'], 'default policy suppresses nothing' );
+
+	// Deny policy suppresses a short class name.
+	$GLOBALS['__directive_policy_agents'][1] = array(
+		'agent_config' => array(
+			'directive_policy' => array(
+				'mode' => 'deny',
+				'deny' => array( 'CoreMemoryFilesDirective' ),
+			),
+		),
+	);
+	$result = $resolver->resolve(
+		$directives,
+		array(
+			'mode'     => 'pipeline',
+			'agent_id' => 1,
+		)
+	);
+	directive_policy_assert_same( array( 'AgentDailyMemoryDirective', 'AgentModeDirective' ), directive_policy_names( $result['directives'] ), 'deny policy removes short class match' );
+	directive_policy_assert_same( array( 'CoreMemoryFilesDirective' ), $result['suppressed'], 'deny policy reports suppressed class' );
+
+	// allow_only policy accepts fully-qualified class names.
+	$GLOBALS['__directive_policy_agents'][2] = array(
+		'agent_config' => array(
+			'directive_policy' => array(
+				'mode'       => 'allow_only',
+				'allow_only' => array( 'DataMachine\\Engine\\AI\\Directives\\AgentModeDirective' ),
+			),
+		),
+	);
+	$result = $resolver->resolve(
+		$directives,
+		array(
+			'mode'     => 'pipeline',
+			'agent_id' => 2,
+		)
+	);
+	directive_policy_assert_same( array( 'AgentModeDirective' ), directive_policy_names( $result['directives'] ), 'allow_only policy keeps only FQCN match' );
+	directive_policy_assert_same( array( 'CoreMemoryFilesDirective', 'AgentDailyMemoryDirective' ), $result['suppressed'], 'allow_only policy reports suppressed classes' );
+
+	// Invalid policy is ignored safely.
+	$GLOBALS['__directive_policy_agents'][3] = array(
+		'agent_config' => array(
+			'directive_policy' => array(
+				'mode' => 'nonsense',
+				'deny' => array( 'CoreMemoryFilesDirective' ),
+			),
+		),
+	);
+	$result = $resolver->resolve(
+		$directives,
+		array(
+			'mode'     => 'pipeline',
+			'agent_id' => 3,
+		)
+	);
+	directive_policy_assert_same( directive_policy_names( $directives ), directive_policy_names( $result['directives'] ), 'invalid policy keeps all directives' );
+	directive_policy_assert_same( array(), $result['suppressed'], 'invalid policy suppresses nothing' );
+
+	// Optional modes scope makes policy mode-aware.
+	$GLOBALS['__directive_policy_agents'][4] = array(
+		'agent_config' => array(
+			'directive_policy' => array(
+				'mode'  => 'deny',
+				'deny'  => array( 'AgentDailyMemoryDirective' ),
+				'modes' => array( 'pipeline' ),
+			),
+		),
+	);
+	$result = $resolver->resolve(
+		$directives,
+		array(
+			'mode'     => 'chat',
+			'agent_id' => 4,
+		)
+	);
+	directive_policy_assert_same( directive_policy_names( $directives ), directive_policy_names( $result['directives'] ), 'mode-scoped policy does not affect other modes' );
+
+	$result = $resolver->resolve(
+		$directives,
+		array(
+			'mode'     => 'pipeline',
+			'agent_id' => 4,
+		)
+	);
+	directive_policy_assert_same( array( 'CoreMemoryFilesDirective', 'AgentModeDirective' ), directive_policy_names( $result['directives'] ), 'mode-scoped policy affects matching mode' );
+
+	fwrite( STDOUT, "DirectivePolicyResolver smoke passed ({$assertions} assertions).\n" );
+}


### PR DESCRIPTION
## Summary
- Adds a per-agent directive policy so narrow pipeline workers can suppress broad directive classes without changing global defaults.
- Supports deny and allow_only modes, optional request-mode scoping, and matching by short class name or fully-qualified class name.
- Logs suppressed directive names alongside applied directives for request inspection.

## Changes
- Adds DirectivePolicyResolver for agent_config.directive_policy resolution.
- Applies resolved directive policy in RequestBuilder before directives are registered with PromptBuilder.
- Adds a pure-PHP smoke test covering default behavior, deny, allow_only, invalid policy, mode scoping, and short/FQCN matching.

## Tests
- php tests/directive-policy-resolver-smoke.php
- php tests/ai-conversation-result-smoke.php
- php tests/ai-required-handlers-smoke.php
- php -l inc/Engine/AI/Directives/DirectivePolicyResolver.php
- php -l inc/Engine/AI/RequestBuilder.php
- php -l tests/directive-policy-resolver-smoke.php
- homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-directive-policy --changed-since origin/main
  - PHPCS passed and baseline drift did not increase.
  - Command still exits non-zero because the lint runner invokes ESLint on changed PHP files and reports PHP parse errors with no new baseline findings.

Closes #1426
Refs #1101

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the DirectivePolicy resolver, request-builder integration, tests, and validation steps; Chris remains responsible for review and merge.
