### PR TITLE
refactor(webhook): migrate legacy auth config once

### DIFF
--- a/inc/Abilities/Flow/WebhookTriggerAbility.php
+++ b/inc/Abilities/Flow/WebhookTriggerAbility.php
@@ -395,10 +395,7 @@ class WebhookTriggerAbility {
 			);
 		}
 
-		// Run the one-time legacy migration before doing anything else so we
-		// read/write the canonical shape only.
-		$migration         = \DataMachine\Api\WebhookAuthResolver::migrate_legacy( $flow['scheduling_config'] ?? array() );
-		$scheduling_config = $migration['config'];
+		$scheduling_config = $flow['scheduling_config'] ?? array();
 
 		$preset_name = isset( $input['preset'] ) ? trim( (string) $input['preset'] ) : '';
 		$template_in = isset( $input['template'] ) && is_array( $input['template'] ) ? $input['template'] : null;
@@ -606,8 +603,7 @@ class WebhookTriggerAbility {
 			);
 		}
 
-		$migration         = \DataMachine\Api\WebhookAuthResolver::migrate_legacy( $flow['scheduling_config'] ?? array() );
-		$scheduling_config = $migration['config'];
+		$scheduling_config = $flow['scheduling_config'] ?? array();
 
 		if ( empty( $scheduling_config['webhook_auth'] ) ) {
 			return array(
@@ -697,12 +693,7 @@ class WebhookTriggerAbility {
 			$scheduling_config['webhook_created_at'],
 			$scheduling_config['webhook_auth_mode'],
 			$scheduling_config['webhook_auth'],
-			$scheduling_config['webhook_secrets'],
-			// Legacy v1 fields — safe to clear even post-migration.
-			$scheduling_config['webhook_secret'],
-			$scheduling_config['webhook_signature_header'],
-			$scheduling_config['webhook_signature_format'],
-			$scheduling_config['webhook_max_body_bytes']
+			$scheduling_config['webhook_secrets']
 		);
 
 		$updated = $this->db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
@@ -932,12 +923,7 @@ class WebhookTriggerAbility {
 			);
 		}
 
-		// Apply the one-time migration silently so status reports the canonical shape.
-		$migration         = \DataMachine\Api\WebhookAuthResolver::migrate_legacy( $flow['scheduling_config'] ?? array() );
-		$scheduling_config = $migration['config'];
-		if ( $migration['migrated'] ) {
-			$this->db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
-		}
+		$scheduling_config = $flow['scheduling_config'] ?? array();
 
 		$enabled = ! empty( $scheduling_config['webhook_enabled'] );
 		$result  = array(
@@ -1027,8 +1013,7 @@ class WebhookTriggerAbility {
 			);
 		}
 
-		$migration         = \DataMachine\Api\WebhookAuthResolver::migrate_legacy( $flow['scheduling_config'] ?? array() );
-		$scheduling_config = $migration['config'];
+		$scheduling_config = $flow['scheduling_config'] ?? array();
 
 		if ( empty( $scheduling_config['webhook_auth'] ) ) {
 			return array(
@@ -1148,8 +1133,7 @@ class WebhookTriggerAbility {
 			);
 		}
 
-		$migration         = \DataMachine\Api\WebhookAuthResolver::migrate_legacy( $flow['scheduling_config'] ?? array() );
-		$scheduling_config = $migration['config'];
+		$scheduling_config = $flow['scheduling_config'] ?? array();
 
 		$secrets = $scheduling_config['webhook_secrets'] ?? array();
 		if ( ! is_array( $secrets ) ) {

--- a/inc/Api/WebhookAuthResolver.php
+++ b/inc/Api/WebhookAuthResolver.php
@@ -10,8 +10,8 @@
  *   scheduling_config[ 'webhook_secrets' ]   = [ [...], ... ]
  *
  * Legacy v1 flows (`webhook_auth_mode = hmac_sha256` + `webhook_signature_*`
- * + singular `webhook_secret`) are migrated **once** on first read via the
- * `migrate_legacy()` helper, after which the legacy fields are deleted.
+ * + singular `webhook_secret`) are normalized by the schema migration chain
+ * before runtime webhook code reads them.
  *
  * No provider names live in this file.
  *
@@ -64,120 +64,6 @@ class WebhookAuthResolver {
 			'mode'     => $verifier['mode'] ?? $mode,
 			'verifier' => $verifier,
 			'token'    => null,
-		);
-	}
-
-	/**
-	 * One-time migration of legacy v1 HMAC fields into the canonical v2 shape.
-	 *
-	 * Called by callers that own the flow row (ability + trigger handler).
-	 * Returns a potentially-mutated scheduling_config. If any legacy fields
-	 * were found, the caller should persist the result and the legacy fields
-	 * are never seen again.
-	 *
-	 * Returns [ 'config' => <new>, 'migrated' => <bool> ].
-	 *
-	 * @param array $scheduling_config
-	 * @return array{config:array,migrated:bool}
-	 */
-	public static function migrate_legacy( array $scheduling_config ): array {
-		$legacy_mode       = $scheduling_config['webhook_auth_mode'] ?? null;
-		$has_legacy_fields = isset( $scheduling_config['webhook_signature_header'] )
-			|| isset( $scheduling_config['webhook_signature_format'] )
-			|| isset( $scheduling_config['webhook_secret'] );
-
-		// Only migrate when the flow is on the legacy v1 shorthand.
-		if ( 'hmac_sha256' !== $legacy_mode && ! $has_legacy_fields ) {
-			return array(
-				'config'   => $scheduling_config,
-				'migrated' => false,
-			);
-		}
-		if ( 'hmac_sha256' !== $legacy_mode ) {
-			// Orphaned legacy fields without the legacy mode — just drop them.
-			unset(
-				$scheduling_config['webhook_signature_header'],
-				$scheduling_config['webhook_signature_format'],
-				$scheduling_config['webhook_secret']
-			);
-			return array(
-				'config'   => $scheduling_config,
-				'migrated' => true,
-			);
-		}
-
-		$scheduling_config['webhook_auth_mode'] = 'hmac';
-
-		// Only synthesise a template if one wasn't already there.
-		if ( empty( $scheduling_config['webhook_auth'] ) ) {
-			$scheduling_config['webhook_auth'] = self::v1_template(
-				(string) ( $scheduling_config['webhook_signature_header'] ?? 'X-Hub-Signature-256' ),
-				(string) ( $scheduling_config['webhook_signature_format'] ?? 'sha256=hex' )
-			);
-		}
-
-		// Promote legacy single secret into the secrets roster.
-		if ( empty( $scheduling_config['webhook_secrets'] ) && ! empty( $scheduling_config['webhook_secret'] ) ) {
-			$scheduling_config['webhook_secrets'] = array(
-				array(
-					'id'    => 'current',
-					'value' => (string) $scheduling_config['webhook_secret'],
-				),
-			);
-		}
-
-		// Drop every legacy field — they will never be read again.
-		unset(
-			$scheduling_config['webhook_signature_header'],
-			$scheduling_config['webhook_signature_format'],
-			$scheduling_config['webhook_secret']
-		);
-
-		return array(
-			'config'   => $scheduling_config,
-			'migrated' => true,
-		);
-	}
-
-	/**
-	 * Build a template config from the three legacy v1 fields.
-	 *
-	 * This is the ONLY place in DM core that knows about the
-	 * `{sha256=hex | hex | base64}` v1 format enum. It exists solely to
-	 * migrate pre-existing flows. No other code path reads these values.
-	 *
-	 * @internal
-	 */
-	private static function v1_template( string $header, string $format ): array {
-		$signature_source = array(
-			'header'   => $header,
-			'extract'  => array( 'kind' => 'raw' ),
-			'encoding' => 'hex',
-		);
-
-		switch ( $format ) {
-			case 'sha256=hex':
-				$signature_source['extract']  = array(
-					'kind' => 'prefix',
-					'key'  => 'sha256=',
-				);
-				$signature_source['encoding'] = 'hex';
-				break;
-			case 'base64':
-				$signature_source['encoding'] = 'base64';
-				break;
-			case 'hex':
-			default:
-				$signature_source['encoding'] = 'hex';
-				break;
-		}
-
-		return array(
-			'mode'             => 'hmac',
-			'algo'             => 'sha256',
-			'signed_template'  => '{body}',
-			'signature_source' => $signature_source,
-			'max_body_bytes'   => WebhookVerifier::DEFAULT_MAX_BODY_BYTES,
 		);
 	}
 

--- a/inc/Api/WebhookTrigger.php
+++ b/inc/Api/WebhookTrigger.php
@@ -117,14 +117,6 @@ class WebhookTrigger {
 
 		$scheduling_config = $flow['scheduling_config'] ?? array();
 
-		// Silently upgrade legacy v1 HMAC fields into the canonical v2 shape.
-		// This happens once per flow, the first time any v1 flow is hit.
-		$migration = WebhookAuthResolver::migrate_legacy( $scheduling_config );
-		if ( $migration['migrated'] ) {
-			$scheduling_config = $migration['config'];
-			$db_flows->update_flow( $flow_id, array( 'scheduling_config' => $scheduling_config ) );
-		}
-
 		if ( empty( $scheduling_config['webhook_enabled'] ) ) {
 			do_action(
 				'datamachine_log',

--- a/inc/Cli/Commands/Flows/WebhookCommand.php
+++ b/inc/Cli/Commands/Flows/WebhookCommand.php
@@ -532,13 +532,10 @@ class WebhookCommand extends BaseCommand {
 
 		$webhook_flows = array();
 		foreach ( $flows as $flow ) {
-			$raw_config = $flow['scheduling_config'] ?? array();
-			if ( empty( $raw_config['webhook_enabled'] ) ) {
+			$config = $flow['scheduling_config'] ?? array();
+			if ( empty( $config['webhook_enabled'] ) ) {
 				continue;
 			}
-			// Normalise auth_mode label for list display (v1 → v2 on the fly).
-			$migration       = \DataMachine\Api\WebhookAuthResolver::migrate_legacy( $raw_config );
-			$config          = $migration['config'];
 			$webhook_flows[] = array(
 				'flow_id'     => $flow['flow_id'],
 				'flow_name'   => $flow['flow_name'],

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -27,6 +27,7 @@ require_once __DIR__ . '/ai-enabled-tools.php';
 require_once __DIR__ . '/handler-slug-scalar.php';
 require_once __DIR__ . '/split-queue-payload.php';
 require_once __DIR__ . '/user-message-queue-mode.php';
+require_once __DIR__ . '/webhook-auth-v2.php';
 
 // Schema-migration runtime — defines `datamachine_run_schema_migrations()`
 // and `datamachine_maybe_run_deferred_migrations()`. Hooked at

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -110,6 +110,10 @@ function datamachine_run_schema_migrations(): void {
 	// idempotent).
 	datamachine_migrate_user_message_queue_mode();
 
+	// Normalize webhook auth scheduling configs to canonical v2 shape (#1333,
+	// idempotent).
+	datamachine_migrate_webhook_auth_v2();
+
 	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
 	datamachine_drop_redundant_post_pipeline_meta();
 }

--- a/inc/migrations/webhook-auth-v2.php
+++ b/inc/migrations/webhook-auth-v2.php
@@ -103,11 +103,7 @@ function datamachine_normalize_webhook_auth_v2_config( array $scheduling_config 
 	}
 
 	if ( 'hmac_sha256' !== $legacy_mode ) {
-		unset(
-			$scheduling_config['webhook_signature_header'],
-			$scheduling_config['webhook_signature_format'],
-			$scheduling_config['webhook_secret']
-		);
+		$scheduling_config = datamachine_webhook_auth_remove_v1_fields( $scheduling_config );
 
 		return array(
 			'config'  => $scheduling_config,
@@ -133,16 +129,28 @@ function datamachine_normalize_webhook_auth_v2_config( array $scheduling_config 
 		);
 	}
 
+	$scheduling_config = datamachine_webhook_auth_remove_v1_fields( $scheduling_config );
+
+	return array(
+		'config'  => $scheduling_config,
+		'changed' => true,
+	);
+}
+
+/**
+ * Remove legacy v1 webhook auth fields from a scheduling config.
+ *
+ * @param array $scheduling_config Scheduling config.
+ * @return array
+ */
+function datamachine_webhook_auth_remove_v1_fields( array $scheduling_config ): array {
 	unset(
 		$scheduling_config['webhook_signature_header'],
 		$scheduling_config['webhook_signature_format'],
 		$scheduling_config['webhook_secret']
 	);
 
-	return array(
-		'config'  => $scheduling_config,
-		'changed' => true,
-	);
+	return $scheduling_config;
 }
 
 /**

--- a/inc/migrations/webhook-auth-v2.php
+++ b/inc/migrations/webhook-auth-v2.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Data Machine — Webhook auth v2 migration (#1333).
+ *
+ * Pre-#1333 webhook auth still allowed legacy v1 scheduling config rows at
+ * runtime: `webhook_auth_mode = hmac_sha256`, `webhook_signature_*`, and a
+ * singular `webhook_secret`. Runtime webhook consumers normalized those rows
+ * repeatedly before they could trust the config shape.
+ *
+ * This migration normalizes persisted flow scheduling configs once. After it
+ * runs, webhook runtime code reads only the canonical v2 shape:
+ *
+ *   - webhook_auth_mode = bearer|hmac
+ *   - webhook_auth      = verifier template config
+ *   - webhook_secrets   = array of secret roster entries
+ *
+ * @package DataMachine
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalize persisted webhook auth scheduling configs to the canonical v2 shape.
+ *
+ * Idempotent: gated on `datamachine_webhook_auth_v2_migrated`.
+ *
+ * @return void
+ */
+function datamachine_migrate_webhook_auth_v2(): void {
+	if ( get_option( 'datamachine_webhook_auth_v2_migrated', false ) ) {
+		return;
+	}
+
+	global $wpdb;
+	$table = $wpdb->prefix . 'datamachine_flows';
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix.
+	$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+	// phpcs:enable WordPress.DB.PreparedSQL
+	if ( ! $table_exists ) {
+		update_option( 'datamachine_webhook_auth_v2_migrated', true, true );
+		return;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	// phpcs:disable WordPress.DB.PreparedSQL -- Table/column names are internal constants from this migration.
+	$rows = $wpdb->get_results( "SELECT flow_id, scheduling_config FROM {$table}", ARRAY_A );
+	// phpcs:enable WordPress.DB.PreparedSQL
+
+	$updated = 0;
+	foreach ( $rows as $row ) {
+		$scheduling_config = json_decode( $row['scheduling_config'] ?? '', true );
+		if ( ! is_array( $scheduling_config ) ) {
+			continue;
+		}
+
+		$normalized = datamachine_normalize_webhook_auth_v2_config( $scheduling_config );
+		if ( ! $normalized['changed'] ) {
+			continue;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->update(
+			$table,
+			array( 'scheduling_config' => wp_json_encode( $normalized['config'] ) ),
+			array( 'flow_id' => $row['flow_id'] ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		++$updated;
+	}
+
+	update_option( 'datamachine_webhook_auth_v2_migrated', true, true );
+
+	if ( $updated > 0 ) {
+		do_action(
+			'datamachine_log',
+			'info',
+			'Migrated webhook auth scheduling configs to canonical v2 shape',
+			array( 'flows_updated' => $updated )
+		);
+	}
+}
+
+/**
+ * Normalize one scheduling config.
+ *
+ * @param array $scheduling_config Scheduling config.
+ * @return array{config:array,changed:bool}
+ */
+function datamachine_normalize_webhook_auth_v2_config( array $scheduling_config ): array {
+	$legacy_mode       = $scheduling_config['webhook_auth_mode'] ?? null;
+	$has_legacy_fields = isset( $scheduling_config['webhook_signature_header'] )
+		|| isset( $scheduling_config['webhook_signature_format'] )
+		|| isset( $scheduling_config['webhook_secret'] );
+
+	if ( 'hmac_sha256' !== $legacy_mode && ! $has_legacy_fields ) {
+		return array(
+			'config'  => $scheduling_config,
+			'changed' => false,
+		);
+	}
+
+	if ( 'hmac_sha256' !== $legacy_mode ) {
+		unset(
+			$scheduling_config['webhook_signature_header'],
+			$scheduling_config['webhook_signature_format'],
+			$scheduling_config['webhook_secret']
+		);
+
+		return array(
+			'config'  => $scheduling_config,
+			'changed' => true,
+		);
+	}
+
+	$scheduling_config['webhook_auth_mode'] = 'hmac';
+
+	if ( empty( $scheduling_config['webhook_auth'] ) ) {
+		$scheduling_config['webhook_auth'] = datamachine_webhook_auth_v1_template(
+			(string) ( $scheduling_config['webhook_signature_header'] ?? 'X-Hub-Signature-256' ),
+			(string) ( $scheduling_config['webhook_signature_format'] ?? 'sha256=hex' )
+		);
+	}
+
+	if ( empty( $scheduling_config['webhook_secrets'] ) && ! empty( $scheduling_config['webhook_secret'] ) ) {
+		$scheduling_config['webhook_secrets'] = array(
+			array(
+				'id'    => 'current',
+				'value' => (string) $scheduling_config['webhook_secret'],
+			),
+		);
+	}
+
+	unset(
+		$scheduling_config['webhook_signature_header'],
+		$scheduling_config['webhook_signature_format'],
+		$scheduling_config['webhook_secret']
+	);
+
+	return array(
+		'config'  => $scheduling_config,
+		'changed' => true,
+	);
+}
+
+/**
+ * Build the canonical v2 verifier template equivalent for legacy v1 fields.
+ *
+ * @param string $header Signature header name.
+ * @param string $format Legacy signature format enum.
+ * @return array
+ */
+function datamachine_webhook_auth_v1_template( string $header, string $format ): array {
+	$signature_source = array(
+		'header'   => $header,
+		'extract'  => array( 'kind' => 'raw' ),
+		'encoding' => 'hex',
+	);
+
+	switch ( $format ) {
+		case 'sha256=hex':
+			$signature_source['extract']  = array(
+				'kind' => 'prefix',
+				'key'  => 'sha256=',
+			);
+			$signature_source['encoding'] = 'hex';
+			break;
+		case 'base64':
+			$signature_source['encoding'] = 'base64';
+			break;
+		case 'hex':
+		default:
+			$signature_source['encoding'] = 'hex';
+			break;
+	}
+
+	return array(
+		'mode'             => 'hmac',
+		'algo'             => 'sha256',
+		'signed_template'  => '{body}',
+		'signature_source' => $signature_source,
+		'max_body_bytes'   => \DataMachine\Api\WebhookVerifier::DEFAULT_MAX_BODY_BYTES,
+	);
+}

--- a/tests/Unit/Api/WebhookAuthResolverTest.php
+++ b/tests/Unit/Api/WebhookAuthResolverTest.php
@@ -2,7 +2,7 @@
 /**
  * WebhookAuthResolver tests.
  *
- * Covers the silent legacy-migration path and the preset filter registry.
+ * Covers canonical auth resolution and the preset filter registry.
  * Requires WordPress because `apply_filters` is used for preset discovery.
  *
  * @package DataMachine\Tests\Unit\Api
@@ -65,89 +65,6 @@ class WebhookAuthResolverTest extends WP_UnitTestCase {
 		) );
 		$this->assertSame( 'hmac', $out['mode'] );
 		$this->assertNull( $out['verifier'] );
-	}
-
-	/* -------- migrate_legacy() -------- */
-
-	public function test_migrate_noop_for_bearer_flow(): void {
-		$in  = array(
-			'webhook_enabled'   => true,
-			'webhook_auth_mode' => 'bearer',
-			'webhook_token'     => 'tok',
-		);
-		$out = WebhookAuthResolver::migrate_legacy( $in );
-		$this->assertFalse( $out['migrated'] );
-		$this->assertSame( $in, $out['config'] );
-	}
-
-	public function test_migrate_noop_for_canonical_hmac_flow(): void {
-		$in  = array(
-			'webhook_enabled'   => true,
-			'webhook_auth_mode' => 'hmac',
-			'webhook_auth'      => array( 'mode' => 'hmac' ),
-			'webhook_secrets'   => array(),
-		);
-		$out = WebhookAuthResolver::migrate_legacy( $in );
-		$this->assertFalse( $out['migrated'] );
-	}
-
-	public function test_migrate_v1_hmac_sha256_flow_to_v2(): void {
-		$in  = array(
-			'webhook_enabled'          => true,
-			'webhook_auth_mode'        => 'hmac_sha256',
-			'webhook_signature_header' => 'X-Hub-Signature-256',
-			'webhook_signature_format' => 'sha256=hex',
-			'webhook_secret'           => 'legacy-secret',
-		);
-		$out = WebhookAuthResolver::migrate_legacy( $in );
-
-		$this->assertTrue( $out['migrated'] );
-		$config = $out['config'];
-
-		$this->assertSame( 'hmac', $config['webhook_auth_mode'] );
-		$this->assertArrayNotHasKey( 'webhook_signature_header', $config );
-		$this->assertArrayNotHasKey( 'webhook_signature_format', $config );
-		$this->assertArrayNotHasKey( 'webhook_secret', $config );
-
-		$this->assertArrayHasKey( 'webhook_auth', $config );
-		$this->assertSame( '{body}', $config['webhook_auth']['signed_template'] );
-		$this->assertSame( 'X-Hub-Signature-256', $config['webhook_auth']['signature_source']['header'] );
-		$this->assertSame( 'prefix', $config['webhook_auth']['signature_source']['extract']['kind'] );
-		$this->assertSame( 'sha256=', $config['webhook_auth']['signature_source']['extract']['key'] );
-		$this->assertSame( 'hex', $config['webhook_auth']['signature_source']['encoding'] );
-
-		$this->assertArrayHasKey( 'webhook_secrets', $config );
-		$this->assertSame( 'current', $config['webhook_secrets'][0]['id'] );
-		$this->assertSame( 'legacy-secret', $config['webhook_secrets'][0]['value'] );
-	}
-
-	public function test_migrate_v1_base64_format(): void {
-		$in  = array(
-			'webhook_enabled'          => true,
-			'webhook_auth_mode'        => 'hmac_sha256',
-			'webhook_signature_header' => 'X-Shopify-Hmac-Sha256',
-			'webhook_signature_format' => 'base64',
-			'webhook_secret'           => 'x',
-		);
-		$out = WebhookAuthResolver::migrate_legacy( $in );
-		$this->assertTrue( $out['migrated'] );
-		$this->assertSame( 'base64', $out['config']['webhook_auth']['signature_source']['encoding'] );
-		$this->assertSame( 'raw', $out['config']['webhook_auth']['signature_source']['extract']['kind'] );
-	}
-
-	public function test_migrate_drops_orphan_legacy_fields(): void {
-		// Fields left over from a partial migration but no legacy mode set.
-		$in  = array(
-			'webhook_enabled'          => true,
-			'webhook_auth_mode'        => 'hmac',
-			'webhook_auth'             => array( 'mode' => 'hmac' ),
-			'webhook_signature_header' => 'stale',
-			'webhook_secret'           => 'stale',
-		);
-		$out = WebhookAuthResolver::migrate_legacy( $in );
-		$this->assertTrue( $out['migrated'] );
-		$this->assertArrayNotHasKey( 'webhook_signature_header', $out['config'] );
-		$this->assertArrayNotHasKey( 'webhook_secret', $out['config'] );
 	}
 
 	/* -------- presets -------- */

--- a/tests/Unit/Api/WebhookTriggerTest.php
+++ b/tests/Unit/Api/WebhookTriggerTest.php
@@ -294,43 +294,6 @@ class WebhookTriggerTest extends WP_UnitTestCase {
 	}
 
 	/* =================================================================
-	 * Silent v1 → v2 migration
-	 * =================================================================
-	 */
-
-	public function test_v1_legacy_flow_migrates_silently_and_still_authenticates(): void {
-		// Set a flow to the legacy v1 shape directly in the DB, bypassing the ability.
-		$db     = new Flows();
-		$secret = 'legacy-secret-value';
-		$config = array(
-			'webhook_enabled'          => true,
-			'webhook_auth_mode'        => 'hmac_sha256',
-			'webhook_signature_header' => 'X-Hub-Signature-256',
-			'webhook_signature_format' => 'sha256=hex',
-			'webhook_secret'           => $secret,
-		);
-		$db->update_flow( $this->flow_id, array( 'scheduling_config' => $config ) );
-
-		// First request — should succeed.
-		$body = '{"legacy":true}';
-		$sig  = 'sha256=' . hash_hmac( 'sha256', $body, $secret );
-		$res  = WebhookTrigger::handle_trigger( $this->make_request( $body, array( 'x-hub-signature-256' => $sig ) ) );
-		$this->assert_not_unauthorized( $res );
-
-		// Config must now be in canonical v2 shape — legacy fields gone, v2 fields present.
-		$new = $this->get_scheduling_config();
-		$this->assertSame( 'hmac', $new['webhook_auth_mode'] );
-		$this->assertArrayHasKey( 'webhook_auth', $new );
-		$this->assertArrayNotHasKey( 'webhook_signature_header', $new );
-		$this->assertArrayNotHasKey( 'webhook_signature_format', $new );
-		$this->assertArrayNotHasKey( 'webhook_secret', $new );
-
-		$this->assertArrayHasKey( 'webhook_secrets', $new );
-		$this->assertSame( 'current', $new['webhook_secrets'][0]['id'] );
-		$this->assertSame( $secret, $new['webhook_secrets'][0]['value'] );
-	}
-
-	/* =================================================================
 	 * Safe headers — pattern-based deny-list, no provider names
 	 * =================================================================
 	 */

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -123,6 +123,7 @@ $migration_chain = array(
 	'datamachine_migrate_handler_slug_scalar',
 	'datamachine_migrate_split_queue_payload',
 	'datamachine_migrate_user_message_queue_mode',
+	'datamachine_migrate_webhook_auth_v2',
 	'datamachine_drop_redundant_post_pipeline_meta',
 );
 

--- a/tests/webhook-auth-v2-migration-smoke.php
+++ b/tests/webhook-auth-v2-migration-smoke.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Pure-PHP smoke test for webhook auth v2 migration (#1333).
+ *
+ * Run with: php tests/webhook-auth-v2-migration-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+$options = array();
+
+function get_option( string $key, $default = false ) {
+	global $options;
+	return array_key_exists( $key, $options ) ? $options[ $key ] : $default;
+}
+
+function update_option( string $key, $value, bool $autoload = true ): bool {
+	global $options;
+	$GLOBALS['__webhook_auth_v2_migration_autoload'][ $key ] = $autoload;
+	$options[ $key ] = $value;
+	return true;
+}
+
+function wp_json_encode( $value ) {
+	return json_encode( $value );
+}
+
+function do_action( string $hook, ...$args ): void {
+	$GLOBALS['__webhook_auth_v2_migration_actions'][] = array( $hook, $args );
+}
+
+class WebhookAuthV2MigrationWpdb {
+	public string $prefix = 'wp_';
+
+	/** @var array<string, array<int, array<string, mixed>>> */
+	public array $rows = array();
+
+	public function prepare( string $query, ...$args ): string {
+		return vsprintf( str_replace( '%s', "'%s'", $query ), $args );
+	}
+
+	public function get_var( string $query ) {
+		foreach ( array_keys( $this->rows ) as $table ) {
+			if ( str_contains( $query, $table ) ) {
+				return $table;
+			}
+		}
+		return null;
+	}
+
+	public function get_results( string $query, $output ) {
+		foreach ( $this->rows as $table => $rows ) {
+			if ( str_contains( $query, $table ) ) {
+				return $rows;
+			}
+		}
+		return array();
+	}
+
+	public function update( string $table, array $data, array $where, array $formats, array $where_formats ): bool {
+		$GLOBALS['__webhook_auth_v2_migration_update_formats'][] = array( $formats, $where_formats );
+		$id_column = array_key_first( $where );
+		if ( null === $id_column ) {
+			return false;
+		}
+		$id_value = $where[ $id_column ];
+
+		foreach ( $this->rows[ $table ] as &$row ) {
+			if ( array_key_exists( $id_column, $row ) && (string) $row[ $id_column ] === (string) $id_value ) {
+				$row = array_merge( $row, $data );
+				return true;
+			}
+		}
+		unset( $row );
+
+		return false;
+	}
+}
+
+require_once __DIR__ . '/../inc/Api/WebhookVerificationResult.php';
+require_once __DIR__ . '/../inc/Api/WebhookVerifier.php';
+require_once __DIR__ . '/../inc/migrations/webhook-auth-v2.php';
+
+$failures = array();
+$passes   = 0;
+
+function assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+echo "webhook auth v2 migration smoke\n";
+echo "--------------------------------\n";
+
+$wpdb = new WebhookAuthV2MigrationWpdb();
+$wpdb->rows['wp_datamachine_flows'] = array(
+	array(
+		'flow_id'           => 10,
+		'scheduling_config' => wp_json_encode(
+			array(
+				'webhook_enabled'          => true,
+				'webhook_auth_mode'        => 'hmac_sha256',
+				'webhook_signature_header' => 'X-Hub-Signature-256',
+				'webhook_signature_format' => 'sha256=hex',
+				'webhook_secret'           => 'legacy-secret',
+			)
+		),
+	),
+	array(
+		'flow_id'           => 11,
+		'scheduling_config' => wp_json_encode(
+			array(
+				'webhook_enabled'          => true,
+				'webhook_auth_mode'        => 'hmac',
+				'webhook_auth'             => array( 'mode' => 'hmac' ),
+				'webhook_secrets'          => array( array( 'id' => 'current', 'value' => 'canonical' ) ),
+				'webhook_signature_header' => 'stale',
+				'webhook_secret'           => 'stale',
+			)
+		),
+	),
+	array(
+		'flow_id'           => 12,
+		'scheduling_config' => wp_json_encode(
+			array(
+				'webhook_enabled'   => true,
+				'webhook_auth_mode' => 'hmac',
+				'webhook_auth'      => array(
+					'mode'             => 'hmac',
+					'signed_template'  => '{body}',
+					'signature_source' => array(
+						'header'   => 'X-Sig',
+						'extract'  => array( 'kind' => 'raw' ),
+						'encoding' => 'base64',
+					),
+				),
+				'webhook_secrets'   => array( array( 'id' => 'current', 'value' => 'canon' ) ),
+			)
+		),
+	),
+	array(
+		'flow_id'           => 13,
+		'scheduling_config' => wp_json_encode( array() ),
+	),
+	array(
+		'flow_id'           => 14,
+		'scheduling_config' => '{not-json',
+	),
+);
+
+datamachine_migrate_webhook_auth_v2();
+
+$legacy   = json_decode( $wpdb->rows['wp_datamachine_flows'][0]['scheduling_config'], true );
+$orphaned = json_decode( $wpdb->rows['wp_datamachine_flows'][1]['scheduling_config'], true );
+$canon    = json_decode( $wpdb->rows['wp_datamachine_flows'][2]['scheduling_config'], true );
+$empty    = json_decode( $wpdb->rows['wp_datamachine_flows'][3]['scheduling_config'], true );
+
+assert_equals( true, get_option( 'datamachine_webhook_auth_v2_migrated' ), 'migration gate set', $failures, $passes );
+assert_equals( 'hmac', $legacy['webhook_auth_mode'] ?? null, 'legacy hmac_sha256 row converted to hmac', $failures, $passes );
+assert_equals( '{body}', $legacy['webhook_auth']['signed_template'] ?? null, 'legacy row gets v2 signed template', $failures, $passes );
+assert_equals( 'X-Hub-Signature-256', $legacy['webhook_auth']['signature_source']['header'] ?? null, 'legacy header preserved', $failures, $passes );
+assert_equals( 'prefix', $legacy['webhook_auth']['signature_source']['extract']['kind'] ?? null, 'legacy sha256 prefix extraction preserved', $failures, $passes );
+assert_equals( 'sha256=', $legacy['webhook_auth']['signature_source']['extract']['key'] ?? null, 'legacy sha256 prefix key preserved', $failures, $passes );
+assert_equals( 'hex', $legacy['webhook_auth']['signature_source']['encoding'] ?? null, 'legacy encoding preserved', $failures, $passes );
+assert_equals( 'current', $legacy['webhook_secrets'][0]['id'] ?? null, 'legacy singular secret promoted to roster id', $failures, $passes );
+assert_equals( 'legacy-secret', $legacy['webhook_secrets'][0]['value'] ?? null, 'legacy singular secret promoted to roster value', $failures, $passes );
+assert_equals( false, array_key_exists( 'webhook_signature_header', $legacy ), 'legacy header removed', $failures, $passes );
+assert_equals( false, array_key_exists( 'webhook_signature_format', $legacy ), 'legacy format removed', $failures, $passes );
+assert_equals( false, array_key_exists( 'webhook_secret', $legacy ), 'legacy secret removed', $failures, $passes );
+
+assert_equals( 'hmac', $orphaned['webhook_auth_mode'] ?? null, 'orphaned row keeps canonical mode', $failures, $passes );
+assert_equals( 'canonical', $orphaned['webhook_secrets'][0]['value'] ?? null, 'orphaned row preserves canonical roster', $failures, $passes );
+assert_equals( false, array_key_exists( 'webhook_signature_header', $orphaned ), 'orphaned header removed', $failures, $passes );
+assert_equals( false, array_key_exists( 'webhook_secret', $orphaned ), 'orphaned secret removed', $failures, $passes );
+assert_equals( 'base64', $canon['webhook_auth']['signature_source']['encoding'] ?? null, 'already-canonical row unchanged', $failures, $passes );
+assert_equals( array(), $empty, 'empty scheduling config unchanged', $failures, $passes );
+assert_equals( 2, count( $GLOBALS['__webhook_auth_v2_migration_update_formats'] ?? array() ), 'only changed rows persisted', $failures, $passes );
+
+datamachine_migrate_webhook_auth_v2();
+assert_equals( 2, count( $GLOBALS['__webhook_auth_v2_migration_update_formats'] ?? array() ), 'second run is gated and does not persist rows again', $failures, $passes );
+
+echo "\n--------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nAll assertions passed.\n";

--- a/tests/webhook-auth-v2-migration-smoke.php
+++ b/tests/webhook-auth-v2-migration-smoke.php
@@ -55,7 +55,7 @@ class WebhookAuthV2MigrationWpdb {
 		return null;
 	}
 
-	public function get_results( string $query, $output ) {
+	public function get_results( string $query, $_output ) {
 		foreach ( $this->rows as $table => $rows ) {
 			if ( str_contains( $query, $table ) ) {
 				return $rows;


### PR DESCRIPTION
## Summary

Move legacy webhook auth v1 normalization out of webhook runtime paths and into the schema migration chain.

## Changes

- Added an idempotent `datamachine_migrate_webhook_auth_v2()` migration for persisted flow scheduling configs.
- Removed `WebhookAuthResolver::migrate_legacy()` and runtime normalization from trigger, ability, and CLI webhook paths.
- Moved legacy v1 behavior coverage into a pure migration smoke and updated runtime tests to assume canonical config.

## Tests

- `php -l inc/migrations/webhook-auth-v2.php`
- `php -l inc/migrations/load.php`
- `php -l inc/migrations/runtime.php`
- `php -l inc/Api/WebhookAuthResolver.php`
- `php -l inc/Abilities/Flow/WebhookTriggerAbility.php`
- `php -l inc/Api/WebhookTrigger.php`
- `php -l inc/Cli/Commands/Flows/WebhookCommand.php`
- `php -l tests/webhook-auth-v2-migration-smoke.php`
- `php tests/webhook-auth-v2-migration-smoke.php`
- `php tests/migration-runtime-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@refactor-webhook-auth-v2-migration --changed-since origin/main`

`homeboy test data-machine --path /Users/chubes/Developer/data-machine@refactor-webhook-auth-v2-migration` did not run tests because the Playground harness failed before runner startup: `/homeboy-extension/scripts/lib/playground-bootstrap.php` was missing.

Closes #1333

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Writing the migration, removing runtime v1 normalization, tests, and validation. Chris remains responsible for review.