### PR TITLE
fix(engine): centralize execution order planning

### DIFF
--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -14,6 +14,8 @@
 
 namespace DataMachine\Abilities\Engine;
 
+use DataMachine\Engine\ExecutionPlan;
+
 defined( 'ABSPATH' ) || exit;
 
 class RunFlowAbility {
@@ -222,12 +224,24 @@ class RunFlowAbility {
 
 		datamachine_set_engine_data( $job_id, $engine_snapshot );
 
-		$first_flow_step_id = null;
-		foreach ( $flow_config as $flow_step_id => $config ) {
-			if ( ( $config['execution_order'] ?? -1 ) === 0 ) {
-				$first_flow_step_id = $flow_step_id;
-				break;
-			}
+		try {
+			$first_flow_step_id = ExecutionPlan::from_flow_config( $flow_config )->first_step_id();
+		} catch ( \InvalidArgumentException $e ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Flow execution failed - invalid execution plan',
+				array(
+					'job_id'      => $job_id,
+					'pipeline_id' => $pipeline_id,
+					'flow_id'     => $flow_id,
+					'error'       => $e->getMessage(),
+				)
+			);
+			return array(
+				'success' => false,
+				'error'   => $e->getMessage(),
+			);
 		}
 
 		if ( ! $first_flow_step_id ) {

--- a/inc/Engine/ExecutionPlan.php
+++ b/inc/Engine/ExecutionPlan.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Flow execution order planning.
+ *
+ * @package DataMachine\Engine
+ */
+
+namespace DataMachine\Engine;
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Normalized positional plan for a flow's execution order.
+ */
+class ExecutionPlan {
+
+	/**
+	 * Flow step IDs sorted by execution_order.
+	 *
+	 * @var string[]
+	 */
+	private array $step_ids;
+
+	/**
+	 * @param string[] $step_ids Flow step IDs sorted by execution_order.
+	 */
+	private function __construct( array $step_ids ) {
+		$this->step_ids = array_values( $step_ids );
+	}
+
+	/**
+	 * Build a normalized execution plan from a flow config.
+	 *
+	 * @param array $flow_config Flow step config keyed by flow step ID.
+	 * @return self
+	 * @throws \InvalidArgumentException When execution_order is missing, invalid, or duplicated.
+	 */
+	public static function from_flow_config( array $flow_config ): self {
+		$steps_by_order = array();
+
+		foreach ( $flow_config as $step_id => $step_config ) {
+			if ( ! is_array( $step_config ) || ! array_key_exists( 'execution_order', $step_config ) ) {
+				throw new \InvalidArgumentException( sprintf( 'Flow step "%s" is missing execution_order.', (string) $step_id ) );
+			}
+
+			$order = self::normalize_order( $step_config['execution_order'], (string) $step_id );
+			if ( array_key_exists( $order, $steps_by_order ) ) {
+				throw new \InvalidArgumentException(
+					sprintf(
+						'Duplicate execution_order %d for flow steps "%s" and "%s".',
+						$order,
+						$steps_by_order[ $order ],
+						(string) $step_id
+					)
+				);
+			}
+
+			$steps_by_order[ $order ] = (string) $step_id;
+		}
+
+		ksort( $steps_by_order, SORT_NUMERIC );
+
+		return new self( array_values( $steps_by_order ) );
+	}
+
+	/**
+	 * Get the first flow step ID in the plan.
+	 */
+	public function first_step_id(): ?string {
+		return $this->step_ids[0] ?? null;
+	}
+
+	/**
+	 * Get the next flow step ID after the current step.
+	 *
+	 * @param string $flow_step_id Current flow step ID.
+	 */
+	public function next_step_id( string $flow_step_id ): ?string {
+		$position = array_search( $flow_step_id, $this->step_ids, true );
+		if ( false === $position ) {
+			return null;
+		}
+
+		return $this->step_ids[ $position + 1 ] ?? null;
+	}
+
+	/**
+	 * Get the previous flow step ID before the current step.
+	 *
+	 * @param string $flow_step_id Current flow step ID.
+	 */
+	public function previous_step_id( string $flow_step_id ): ?string {
+		$position = array_search( $flow_step_id, $this->step_ids, true );
+		if ( false === $position || 0 === $position ) {
+			return null;
+		}
+
+		return $this->step_ids[ $position - 1 ] ?? null;
+	}
+
+	/**
+	 * Normalize an execution order value to an integer.
+	 *
+	 * @param mixed  $raw_order Raw execution_order value.
+	 * @param string $step_id   Flow step ID for error messages.
+	 */
+	private static function normalize_order( mixed $raw_order, string $step_id ): int {
+		if ( is_int( $raw_order ) ) {
+			return $raw_order;
+		}
+
+		if ( is_string( $raw_order ) && preg_match( '/^-?\d+$/', $raw_order ) ) {
+			return (int) $raw_order;
+		}
+
+		throw new \InvalidArgumentException( sprintf( 'Flow step "%s" has invalid execution_order.', $step_id ) );
+	}
+}

--- a/inc/Engine/StepNavigator.php
+++ b/inc/Engine/StepNavigator.php
@@ -30,6 +30,28 @@ class StepNavigator {
 	}
 
 	/**
+	 * Build the execution plan for navigation, logging invalid plans once.
+	 */
+	private function getExecutionPlan( array $flow_config, int $job_id, string $flow_step_id ): ?ExecutionPlan {
+		try {
+			return ExecutionPlan::from_flow_config( $flow_config );
+		} catch ( \InvalidArgumentException $e ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Step navigation failed - invalid execution plan',
+				array(
+					'job_id'       => $job_id,
+					'flow_step_id' => $flow_step_id,
+					'error'        => $e->getMessage(),
+				)
+			);
+		}
+
+		return null;
+	}
+
+	/**
 	 * Get next flow step ID based on execution order
 	 *
 	 * Uses centralized engine data for execution context.
@@ -46,21 +68,12 @@ class StepNavigator {
 
 		$flow_config = $this->getFlowConfig( $job_id );
 
-		$current_step = $flow_config[ $flow_step_id ] ?? null;
-		if ( ! $current_step ) {
+		if ( ! isset( $flow_config[ $flow_step_id ] ) ) {
 			return null;
 		}
 
-		$current_order = $current_step['execution_order'] ?? -1;
-		$next_order    = $current_order + 1;
-
-		foreach ( $flow_config as $step_id => $step ) {
-			if ( ( $step['execution_order'] ?? -1 ) === $next_order ) {
-				return $step_id;
-			}
-		}
-
-		return null;
+		$plan = $this->getExecutionPlan( $flow_config, $job_id, $flow_step_id );
+		return $plan ? $plan->next_step_id( $flow_step_id ) : null;
 	}
 
 	/**
@@ -80,20 +93,11 @@ class StepNavigator {
 
 		$flow_config = $this->getFlowConfig( $job_id );
 
-		$current_step = $flow_config[ $flow_step_id ] ?? null;
-		if ( ! $current_step ) {
+		if ( ! isset( $flow_config[ $flow_step_id ] ) ) {
 			return null;
 		}
 
-		$current_order = $current_step['execution_order'] ?? -1;
-		$prev_order    = $current_order - 1;
-
-		foreach ( $flow_config as $step_id => $step ) {
-			if ( ( $step['execution_order'] ?? -1 ) === $prev_order ) {
-				return $step_id;
-			}
-		}
-
-		return null;
+		$plan = $this->getExecutionPlan( $flow_config, $job_id, $flow_step_id );
+		return $plan ? $plan->previous_step_id( $flow_step_id ) : null;
 	}
 }

--- a/tests/step-navigator-execution-order-smoke.php
+++ b/tests/step-navigator-execution-order-smoke.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Pure-PHP smoke test for StepNavigator's contiguous execution_order contract.
+ * Pure-PHP smoke test for shared execution-order planning.
  *
  * Run with: php tests/step-navigator-execution-order-smoke.php
  *
@@ -24,8 +24,17 @@ namespace {
 	if ( ! defined( 'WPINC' ) ) {
 		define( 'WPINC', 'wp-includes' );
 	}
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( string $hook, ...$args ): void {
+			$GLOBALS['datamachine_step_navigator_actions'][] = array(
+				'hook' => $hook,
+				'args' => $args,
+			);
+		}
+	}
 
 	require_once __DIR__ . '/../inc/Engine/Filters/EngineData.php';
+	require_once __DIR__ . '/../inc/Engine/ExecutionPlan.php';
 	require_once __DIR__ . '/../inc/Engine/StepNavigator.php';
 
 	$failed = 0;
@@ -45,25 +54,62 @@ namespace {
 
 	echo "=== step-navigator-execution-order-smoke ===\n";
 
-	\DataMachine\Core\EngineData::$snapshots[123] = array(
-		'flow_config' => array(
-			'fetch_step'   => array(
-				'flow_step_id'    => 'fetch_step',
-				'execution_order' => 0,
-			),
-			'ai_step'      => array(
-				'flow_step_id'    => 'ai_step',
-				'execution_order' => 1,
-			),
-			'publish_step' => array(
-				'flow_step_id'    => 'publish_step',
-				'execution_order' => 2,
-			),
+	function set_step_navigator_flow_config( int $job_id, array $flow_config ): void {
+		\DataMachine\Core\EngineData::$snapshots[ $job_id ] = array(
+			'flow_config' => $flow_config,
+		);
+	}
+
+	function step_navigator_flow_config( array $orders ): array {
+		$flow_config = array();
+		foreach ( $orders as $step_id => $order ) {
+			$flow_config[ $step_id ] = array(
+				'flow_step_id'    => $step_id,
+				'execution_order' => $order,
+			);
+		}
+
+		return $flow_config;
+	}
+
+	function latest_step_navigator_log_context(): array {
+		$actions = $GLOBALS['datamachine_step_navigator_actions'] ?? array();
+		$latest  = end( $actions );
+		$args    = is_array( $latest ) ? ( $latest['args'] ?? array() ) : array();
+
+		return is_array( $args[2] ?? null ) ? $args[2] : array();
+	}
+
+	set_step_navigator_flow_config( 123, array(
+		'fetch_step'   => array(
+			'flow_step_id'    => 'fetch_step',
+			'execution_order' => 0,
 		),
-	);
+		'ai_step'      => array(
+			'flow_step_id'    => 'ai_step',
+			'execution_order' => 1,
+		),
+		'publish_step' => array(
+			'flow_step_id'    => 'publish_step',
+			'execution_order' => 2,
+		),
+	) );
 
 	$navigator = new \DataMachine\Engine\StepNavigator();
 	$context   = array( 'job_id' => 123 );
+
+	assert_step_navigator_order(
+		'execution plan first step reads sorted order instead of strict zero scan',
+		'fetch_step' === \DataMachine\Engine\ExecutionPlan::from_flow_config(
+			step_navigator_flow_config(
+				array(
+					'publish_step' => 20,
+					'fetch_step'   => 10,
+					'ai_step'      => 15,
+				)
+			)
+		)->first_step_id()
+	);
 
 	assert_step_navigator_order(
 		'fetch advances to ai when orders are contiguous',
@@ -88,6 +134,58 @@ namespace {
 	assert_step_navigator_order(
 		'fetch has no previous step',
 		null === $navigator->get_previous_flow_step_id( 'fetch_step', $context )
+	);
+
+	set_step_navigator_flow_config( 124, step_navigator_flow_config(
+		array(
+			'fetch_step'   => 0,
+			'ai_step'      => 10,
+			'publish_step' => 20,
+		)
+	) );
+	$gapped_context = array( 'job_id' => 124 );
+	assert_step_navigator_order(
+		'gapped orders advance by sorted position',
+		'ai_step' === $navigator->get_next_flow_step_id( 'fetch_step', $gapped_context )
+	);
+	assert_step_navigator_order(
+		'gapped orders move back by sorted position',
+		'ai_step' === $navigator->get_previous_flow_step_id( 'publish_step', $gapped_context )
+	);
+
+	set_step_navigator_flow_config( 125, step_navigator_flow_config(
+		array(
+			'fetch_step'   => '0',
+			'ai_step'      => '10',
+			'publish_step' => '20',
+		)
+	) );
+	$string_context = array( 'job_id' => 125 );
+	assert_step_navigator_order(
+		'numeric-string orders are normalized for next navigation',
+		'ai_step' === $navigator->get_next_flow_step_id( 'fetch_step', $string_context )
+	);
+	assert_step_navigator_order(
+		'numeric-string orders are normalized for previous navigation',
+		'ai_step' === $navigator->get_previous_flow_step_id( 'publish_step', $string_context )
+	);
+
+	$GLOBALS['datamachine_step_navigator_actions'] = array();
+	set_step_navigator_flow_config( 126, step_navigator_flow_config(
+		array(
+			'fetch_step'   => 0,
+			'ai_step'      => '0',
+			'publish_step' => 20,
+		)
+	) );
+	$duplicate_context = array( 'job_id' => 126 );
+	assert_step_navigator_order(
+		'duplicate execution orders stop next navigation',
+		null === $navigator->get_next_flow_step_id( 'fetch_step', $duplicate_context )
+	);
+	assert_step_navigator_order(
+		'duplicate execution orders log an explicit error',
+		str_contains( latest_step_navigator_log_context()['error'] ?? '', 'Duplicate execution_order 0' )
 	);
 
 	if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary

Centralizes flow execution-order planning so first-step detection and step navigation share the same normalized ordering rules.

## Changes

- Added `DataMachine\Engine\ExecutionPlan` to normalize integer and numeric-string `execution_order` values, sort steps numerically, and reject duplicate orders explicitly.
- Updated `RunFlowAbility` to find the first step from the sorted plan instead of strict `execution_order === 0` scans.
- Updated `StepNavigator` to navigate next/previous by sorted position instead of `current_order +/- 1`.
- Expanded the execution-order smoke coverage for contiguous, gapped, numeric-string, and duplicate-order cases.

## Tests

- `php -l inc/Engine/ExecutionPlan.php && php -l inc/Engine/StepNavigator.php && php -l inc/Abilities/Engine/RunFlowAbility.php && php -l tests/step-navigator-execution-order-smoke.php`
- `php tests/step-navigator-execution-order-smoke.php`
- `php tests/execute-workflow-initial-data-contract-smoke.php`
- `php tests/flow-run-cli-drain-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@refactor-execution-order-plan --changed-since origin/main`

Closes #1384

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the execution-plan helper, tests, and validation; Chris remains responsible for review.
