### PR TITLE
refactor(flow): centralize step config scaffolds

### DIFF
--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -72,32 +72,12 @@ trait FlowHelpers {
 
 			$flow_step_id = apply_filters( 'datamachine_generate_flow_step_id', '', $pipeline_step_id, $flow_id );
 
-			$disabled_tools = $pipeline_config[ $pipeline_step_id ]['disabled_tools'] ?? array();
-
-			$step_type            = $step['step_type'] ?? '';
-			$queue_field_defaults = ( 'fetch' === $step_type )
-				? array( 'config_patch_queue' => array() )
-				: array( 'prompt_queue' => array() );
-
-			$step_config = FlowStepConfigFactory::build(
-				array_merge(
-					array(
-						'flow_step_id'     => $flow_step_id,
-						'step_type'        => $step_type,
-						'pipeline_step_id' => $pipeline_step_id,
-						'pipeline_id'      => $pipeline_id,
-						'flow_id'          => $flow_id,
-						'execution_order'  => $step['execution_order'] ?? 0,
-						'disabled_tools'   => $disabled_tools,
-						// queue_mode is the access pattern enum that drives both
-						// AI (prompt_queue) and Fetch (config_patch_queue)
-						// consumption (#1291). Default "static" preserves
-						// "first-entry-wins-every-tick" semantics for any
-						// freshly-scaffolded step.
-						'queue_mode'       => 'static',
-					),
-					$queue_field_defaults
-				)
+			$step_config = FlowStepConfigFactory::buildFromPipelineStep(
+				$step,
+				$pipeline_id,
+				$flow_id,
+				$flow_step_id,
+				$pipeline_config[ $pipeline_step_id ] ?? array()
 			);
 
 			$flow_config[ $flow_step_id ] = $step_config;

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -333,55 +333,8 @@ class ExecuteWorkflowAbility {
 			$step_id          = "ephemeral_step_{$index}";
 			$pipeline_step_id = "ephemeral_pipeline_{$index}";
 
-			// Flow config (instance-specific)
-			$handler_slug   = $step['handler_slug'] ?? '';
-			$handler_config = $step['handler_config'] ?? array();
-			$step_type      = $step['type'];
-
-			// AI's tool list lives in its own field. handler_slugs is for
-			// handlers; enabled_tools is for AI tools. No overload.
-			$enabled_tools = ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
-				? array_values( $step['enabled_tools'] )
-				: array();
-
-			// AIStep reads its per-flow user message from the
-			// prompt_queue head (gated by queue_mode), not a dedicated
-			// user_message slot — see #1291. The workflow JSON spec
-			// still accepts `user_message` as an input field for
-			// ergonomics (matches ExecuteWorkflowTool's documented
-			// shape); convert it here into a 1-entry static prompt_queue
-			// so AIStep sees it. Pre-fix this lane wrote the legacy
-			// `user_message` slot directly, which AIStep no longer
-			// reads — the input value was silently dropped at runtime.
-			$workflow_user_message = is_string( $step['user_message'] ?? null )
-				? trim( $step['user_message'] )
-				: '';
-			$prompt_queue          = array();
-			if ( 'ai' === $step_type && '' !== $workflow_user_message ) {
-				$prompt_queue = array(
-					array(
-						'prompt'   => $workflow_user_message,
-						'added_at' => gmdate( 'c' ),
-					),
-				);
-			}
-
-			$flow_step_config = FlowStepConfigFactory::build(
-				array(
-					'flow_step_id'     => $step_id,
-					'pipeline_step_id' => $pipeline_step_id,
-					'step_type'        => $step_type,
-					'execution_order'  => $index,
-					'enabled_tools'    => $enabled_tools,
-					'prompt_queue'     => $prompt_queue,
-					'queue_mode'       => 'static',
-					'disabled_tools'   => $step['disabled_tools'] ?? array(),
-					'pipeline_id'      => 'direct',
-					'flow_id'          => 'direct',
-					'handler_slug'     => $handler_slug,
-					'handler_config'   => $handler_config,
-				)
-			);
+			$step_type        = $step['type'];
+			$flow_step_config = FlowStepConfigFactory::buildFromWorkflowStep( $step, $index );
 
 			$flow_config[ $step_id ] = $flow_step_config;
 

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -7,6 +7,8 @@
 
 namespace DataMachine\Core\Steps;
 
+use DataMachine\Abilities\Flow\QueueAbility;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -99,8 +101,8 @@ class FlowStepConfigFactory {
 			'execution_order'    => true,
 			'enabled_tools'      => true,
 			'disabled_tools'     => true,
-			'prompt_queue'       => true,
-			'config_patch_queue' => true,
+			QueueAbility::SLOT_PROMPT_QUEUE       => true,
+			QueueAbility::SLOT_CONFIG_PATCH_QUEUE => true,
 			'queue_mode'         => true,
 			'pipeline_id'        => true,
 			'flow_id'            => true,
@@ -141,9 +143,9 @@ class FlowStepConfigFactory {
 		$defaults = array( 'queue_mode' => 'static' );
 
 		if ( 'fetch' === $step_type ) {
-			$defaults['config_patch_queue'] = array();
+			$defaults[ QueueAbility::SLOT_CONFIG_PATCH_QUEUE ] = array();
 		} else {
-			$defaults['prompt_queue'] = array();
+			$defaults[ QueueAbility::SLOT_PROMPT_QUEUE ] = array();
 		}
 
 		return $defaults;
@@ -161,11 +163,11 @@ class FlowStepConfigFactory {
 			: '';
 
 		if ( 'ai' !== ( $step['type'] ?? '' ) || '' === $workflow_user_message ) {
-			return array( 'prompt_queue' => array() );
+			return array( QueueAbility::SLOT_PROMPT_QUEUE => array() );
 		}
 
 		return array(
-			'prompt_queue' => array(
+			QueueAbility::SLOT_PROMPT_QUEUE => array(
 				array(
 					'prompt'   => $workflow_user_message,
 					'added_at' => gmdate( 'c' ),

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -15,6 +15,76 @@ defined( 'ABSPATH' ) || exit;
 class FlowStepConfigFactory {
 
 	/**
+	 * Build a canonical flow step config row from an ephemeral workflow step.
+	 *
+	 * @param array $step  Workflow step input.
+	 * @param int   $index Zero-based workflow step index.
+	 * @return array Flow step config row.
+	 */
+	public static function buildFromWorkflowStep( array $step, int $index ): array {
+		$step_type = $step['type'];
+
+		return self::build(
+			array_merge(
+				array(
+					'flow_step_id'     => "ephemeral_step_{$index}",
+					'pipeline_step_id' => "ephemeral_pipeline_{$index}",
+					'step_type'        => $step_type,
+					'execution_order'  => $index,
+					'enabled_tools'    => ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
+						? array_values( $step['enabled_tools'] )
+						: array(),
+				),
+				self::promptQueueFromWorkflowStep( $step ),
+				array(
+					'queue_mode'       => 'static',
+					'disabled_tools'   => $step['disabled_tools'] ?? array(),
+					'pipeline_id'      => 'direct',
+					'flow_id'          => 'direct',
+					'handler_slug'     => $step['handler_slug'] ?? '',
+					'handler_config'   => $step['handler_config'] ?? array(),
+				)
+			)
+		);
+	}
+
+	/**
+	 * Build a canonical flow step config row from a pipeline step for a flow.
+	 *
+	 * @param array      $step                 Pipeline step row.
+	 * @param int|string $pipeline_id          Pipeline ID.
+	 * @param int|string $flow_id              Flow ID.
+	 * @param string     $flow_step_id         Generated flow step ID.
+	 * @param array      $pipeline_step_config Pipeline step config keyed by pipeline step ID.
+	 * @return array Flow step config row.
+	 */
+	public static function buildFromPipelineStep(
+		array $step,
+		$pipeline_id,
+		$flow_id,
+		string $flow_step_id,
+		array $pipeline_step_config = array()
+	): array {
+		$step_type        = $step['step_type'] ?? '';
+		$pipeline_step_id = $step['pipeline_step_id'] ?? '';
+
+		return self::build(
+			array_merge(
+				array(
+					'flow_step_id'     => $flow_step_id,
+					'step_type'        => $step_type,
+					'pipeline_step_id' => $pipeline_step_id,
+					'pipeline_id'      => $pipeline_id,
+					'flow_id'          => $flow_id,
+					'execution_order'  => $step['execution_order'] ?? 0,
+					'disabled_tools'   => $pipeline_step_config['disabled_tools'] ?? array(),
+				),
+				self::queueDefaultsForStepType( $step_type )
+			)
+		);
+	}
+
+	/**
 	 * Build a canonical flow step configuration row.
 	 *
 	 * @param array $args Explicit config inputs.
@@ -59,5 +129,48 @@ class FlowStepConfigFactory {
 		}
 
 		return $step_config;
+	}
+
+	/**
+	 * Return queue defaults for a step type.
+	 *
+	 * @param string $step_type Step type slug.
+	 * @return array Queue fields.
+	 */
+	private static function queueDefaultsForStepType( string $step_type ): array {
+		$defaults = array( 'queue_mode' => 'static' );
+
+		if ( 'fetch' === $step_type ) {
+			$defaults['config_patch_queue'] = array();
+		} else {
+			$defaults['prompt_queue'] = array();
+		}
+
+		return $defaults;
+	}
+
+	/**
+	 * Convert workflow user_message input into AIStep's prompt queue slot.
+	 *
+	 * @param array $step Workflow step input.
+	 * @return array Prompt queue override or empty array.
+	 */
+	private static function promptQueueFromWorkflowStep( array $step ): array {
+		$workflow_user_message = is_string( $step['user_message'] ?? null )
+			? trim( $step['user_message'] )
+			: '';
+
+		if ( 'ai' !== ( $step['type'] ?? '' ) || '' === $workflow_user_message ) {
+			return array( 'prompt_queue' => array() );
+		}
+
+		return array(
+			'prompt_queue' => array(
+				array(
+					'prompt'   => $workflow_user_message,
+					'added_at' => gmdate( 'c' ),
+				),
+			),
+		);
 	}
 }

--- a/tests/flow-step-config-factory-smoke.php
+++ b/tests/flow-step-config-factory-smoke.php
@@ -62,6 +62,19 @@ function legacy_workflow_step_config_for_test( array $step, int $index ): array 
 	$handler_slug     = $step['handler_slug'] ?? '';
 	$handler_config   = $step['handler_config'] ?? array();
 	$step_type        = $step['type'];
+	$prompt_queue     = array();
+
+	$workflow_user_message = is_string( $step['user_message'] ?? null )
+		? trim( $step['user_message'] )
+		: '';
+	if ( 'ai' === $step_type && '' !== $workflow_user_message ) {
+		$prompt_queue = array(
+			array(
+				'prompt'   => $workflow_user_message,
+				'added_at' => '__dynamic__',
+			),
+		);
+	}
 
 	$flow_step_config = array(
 		'flow_step_id'     => $step_id,
@@ -71,7 +84,7 @@ function legacy_workflow_step_config_for_test( array $step, int $index ): array 
 		'enabled_tools'    => ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
 			? array_values( $step['enabled_tools'] )
 			: array(),
-		'prompt_queue'     => $step['prompt_queue'] ?? array(),
+		'prompt_queue'     => $prompt_queue,
 		'queue_mode'       => 'static',
 		'disabled_tools'   => $step['disabled_tools'] ?? array(),
 		'pipeline_id'      => 'direct',
@@ -94,26 +107,11 @@ function legacy_workflow_step_config_for_test( array $step, int $index ): array 
 }
 
 function factory_workflow_step_config_for_test( array $step, int $index ): array {
-	$step_type = $step['type'];
-
-	return FlowStepConfigFactory::build(
-		array(
-			'flow_step_id'     => "ephemeral_step_{$index}",
-			'pipeline_step_id' => "ephemeral_pipeline_{$index}",
-			'step_type'        => $step_type,
-			'execution_order'  => $index,
-			'enabled_tools'    => ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
-				? array_values( $step['enabled_tools'] )
-				: array(),
-			'prompt_queue'     => $step['prompt_queue'] ?? array(),
-			'queue_mode'       => 'static',
-			'disabled_tools'   => $step['disabled_tools'] ?? array(),
-			'pipeline_id'      => 'direct',
-			'flow_id'          => 'direct',
-			'handler_slug'     => $step['handler_slug'] ?? '',
-			'handler_config'   => $step['handler_config'] ?? array(),
-		)
-	);
+	$config = FlowStepConfigFactory::buildFromWorkflowStep( $step, $index );
+	if ( isset( $config['prompt_queue'][0]['added_at'] ) ) {
+		$config['prompt_queue'][0]['added_at'] = '__dynamic__';
+	}
+	return $config;
 }
 
 function legacy_synced_step_config_for_test( array $step, int $flow_id, int $pipeline_id, array $disabled_tools ): array {
@@ -129,7 +127,6 @@ function legacy_synced_step_config_for_test( array $step, int $flow_id, int $pip
 		'flow_id'          => $flow_id,
 		'execution_order'  => $step['execution_order'] ?? 0,
 		'disabled_tools'   => $disabled_tools,
-		'handler'          => null,
 		'queue_mode'       => 'static',
 	);
 
@@ -143,27 +140,14 @@ function legacy_synced_step_config_for_test( array $step, int $flow_id, int $pip
 }
 
 function factory_synced_step_config_for_test( array $step, int $flow_id, int $pipeline_id, array $disabled_tools ): array {
-	$step_type        = $step['step_type'] ?? '';
 	$pipeline_step_id = $step['pipeline_step_id'];
-	$queue_defaults   = ( 'fetch' === $step_type )
-		? array( 'config_patch_queue' => array() )
-		: array( 'prompt_queue' => array() );
 
-	return FlowStepConfigFactory::build(
-		array_merge(
-			array(
-				'flow_step_id'     => $pipeline_step_id . '_' . $flow_id,
-				'step_type'        => $step_type,
-				'pipeline_step_id' => $pipeline_step_id,
-				'pipeline_id'      => $pipeline_id,
-				'flow_id'          => $flow_id,
-				'execution_order'  => $step['execution_order'] ?? 0,
-				'disabled_tools'   => $disabled_tools,
-				'handler'          => null,
-				'queue_mode'       => 'static',
-			),
-			$queue_defaults
-		)
+	return FlowStepConfigFactory::buildFromPipelineStep(
+		$step,
+		$pipeline_id,
+		$flow_id,
+		$pipeline_step_id . '_' . $flow_id,
+		array( 'disabled_tools' => $disabled_tools )
 	);
 }
 
@@ -186,15 +170,10 @@ $workflow_cases = array(
 		'type'           => 'system_task',
 		'handler_config' => array( 'task' => 'daily_memory_generation' ),
 	),
-	'ai keeps enabled tools and prompt queue' => array(
+	'ai converts user message to prompt queue' => array(
 		'type'          => 'ai',
 		'enabled_tools' => array( 'local_search' ),
-		'prompt_queue'  => array(
-			array(
-				'prompt'   => 'Summarize',
-				'added_at' => '2026-04-27T00:00:00+00:00',
-			),
-		),
+		'user_message'  => ' Summarize ',
 	),
 );
 
@@ -235,6 +214,25 @@ foreach ( $sync_cases as $name => $step ) {
 		$passes
 	);
 }
+
+$execute_workflow_src = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' ) ?: '';
+$flow_helpers_src     = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/FlowHelpers.php' ) ?: '';
+
+assert_factory_equals(
+	true,
+	false !== strpos( $execute_workflow_src, 'FlowStepConfigFactory::buildFromWorkflowStep( $step, $index )' ),
+	'ExecuteWorkflowAbility routes workflow rows through the factory scaffold',
+	$failures,
+	$passes
+);
+
+assert_factory_equals(
+	true,
+	false !== strpos( $flow_helpers_src, 'FlowStepConfigFactory::buildFromPipelineStep(' ),
+	'FlowHelpers routes synced flow rows through the factory scaffold',
+	$failures,
+	$passes
+);
 
 echo "\n-----------------------------------\n";
 $total = $passes + count( $failures );

--- a/tests/flow-step-config-factory-smoke.php
+++ b/tests/flow-step-config-factory-smoke.php
@@ -7,6 +7,17 @@
  * @package DataMachine\Tests
  */
 
+namespace DataMachine\Abilities\Flow {
+	if ( ! class_exists( QueueAbility::class, false ) ) {
+		class QueueAbility {
+			const SLOT_PROMPT_QUEUE       = 'prompt_queue';
+			const SLOT_CONFIG_PATCH_QUEUE = 'config_patch_queue';
+		}
+	}
+}
+
+namespace {
+
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
@@ -247,3 +258,4 @@ if ( ! empty( $failures ) ) {
 }
 
 echo "\nAll assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Centralizes the two lowest-risk flow step scaffold writers on `FlowStepConfigFactory` so workflow execution and flow creation share one row-construction path.
- Keeps copy/import/update overlay paths untouched for the follow-up in #1353.

## Changes
- Added `FlowStepConfigFactory::buildFromWorkflowStep()` for ephemeral workflow rows, including AI `enabled_tools`, static prompt queue conversion from `user_message`, handler shape selection, and direct-mode IDs.
- Added `FlowStepConfigFactory::buildFromPipelineStep()` for persistent flow sync rows, including flow/pipeline IDs, execution order, disabled tools, and queue defaults.
- Updated `ExecuteWorkflowAbility::buildConfigsFromWorkflow()` and `FlowHelpers::syncStepsToFlow()` to call the shared factory scaffold methods.
- Extended `tests/flow-step-config-factory-smoke.php` to prove the extracted paths preserve existing workflow and flow-sync shapes and route through the factory.

## Tests
- `php -l inc/Core/Steps/FlowStepConfigFactory.php`
- `php -l inc/Abilities/Job/ExecuteWorkflowAbility.php`
- `php -l inc/Abilities/Flow/FlowHelpers.php`
- `php -l tests/flow-step-config-factory-smoke.php`
- `php tests/flow-step-config-factory-smoke.php`
- `php tests/handler-slug-scalar-migration-smoke.php`
- `php tests/queue-mode-collapse-smoke.php`
- `php tests/system-task-config-passthrough-smoke.php`
- `php tests/execute-workflow-initial-data-contract-smoke.php`
- `php tests/systemtask-passthrough-smoke.php`
- `php tests/queue-payload-split-smoke.php`
- `php tests/flow-step-legacy-handler-field-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@refactor-flow-step-config-factory --changed-since origin/main`

Attempted but blocked by local test harness infrastructure:
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@refactor-flow-step-config-factory --filter ImportExportStepConfigTest`
- Failed before tests ran because the Playground runner could not load `/homeboy-extension/scripts/lib/playground-bootstrap.php`.

Closes #1345

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** extracting the shared config factory scaffold methods, updating tests, and validation; Chris remains responsible for review.
