### PR TITLE
refactor(bundle): share bundle slug accessor

### DIFF
--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -13,6 +13,7 @@ defined( 'ABSPATH' ) || exit;
  * Immutable representation of flows/<slug>.json schema_version 1.
  */
 final class AgentBundleFlowFile {
+	use AgentBundleSlugTrait;
 
 	private string $slug;
 	private string $name;
@@ -55,10 +56,6 @@ final class AgentBundleFlowFile {
 			'max_items'      => $this->max_items,
 			'steps'          => $this->steps,
 		);
-	}
-
-	public function slug(): string {
-		return $this->slug;
 	}
 
 	private static function validate_steps( array $steps ): array {

--- a/inc/Engine/Bundle/AgentBundlePipelineFile.php
+++ b/inc/Engine/Bundle/AgentBundlePipelineFile.php
@@ -13,6 +13,7 @@ defined( 'ABSPATH' ) || exit;
  * Immutable representation of pipelines/<slug>.json schema_version 1.
  */
 final class AgentBundlePipelineFile {
+	use AgentBundleSlugTrait;
 
 	private string $slug;
 	private string $name;
@@ -46,10 +47,6 @@ final class AgentBundlePipelineFile {
 			'name'           => $this->name,
 			'steps'          => $this->steps,
 		);
-	}
-
-	public function slug(): string {
-		return $this->slug;
 	}
 
 	private static function validate_steps( array $steps ): array {

--- a/inc/Engine/Bundle/AgentBundleSlugTrait.php
+++ b/inc/Engine/Bundle/AgentBundleSlugTrait.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Agent bundle slug accessor helper.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared slug accessor for bundle documents named by portable slug.
+ */
+trait AgentBundleSlugTrait {
+
+	public function slug(): string {
+		return $this->slug;
+	}
+}


### PR DESCRIPTION
## Summary
- Move the shared bundle document `slug()` accessor into a tiny bundle-local trait.
- Keep flow and pipeline bundle file behavior unchanged while removing the duplicate helper body.

## Tests
- `php -l inc/Engine/Bundle/AgentBundleSlugTrait.php && php -l inc/Engine/Bundle/AgentBundleFlowFile.php && php -l inc/Engine/Bundle/AgentBundlePipelineFile.php`
- `php tests/agent-bundle-format-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@cleanup-bundle-slug-duplicate-2 --changed-since origin/main`

Closes #1337

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the small refactor, ran focused validation, and prepared the PR. Chris remains responsible for review and merge.