### PR TITLE
feat(pipeline): install persistent workflows from scaffolds

### DIFF
--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -12,7 +12,7 @@
 namespace DataMachine\Abilities\Job;
 
 use DataMachine\Abilities\StepTypeAbilities;
-use DataMachine\Core\Steps\FlowStepConfigFactory;
+use DataMachine\Core\Steps\WorkflowConfigFactory;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -111,7 +111,7 @@ class ExecuteWorkflowAbility {
 		}
 
 		// Build configs from workflow
-		$configs = $this->buildConfigsFromWorkflow( $workflow );
+		$configs = WorkflowConfigFactory::buildEphemeralConfigs( $workflow );
 
 		// Create job record for direct execution. Honor parent_job_id
 		// from initial_data so callers (e.g. TaskScheduler scheduling
@@ -317,40 +317,6 @@ class ExecuteWorkflowAbility {
 		// step types themselves.
 
 		return array( 'valid' => true );
-	}
-
-	/**
-	 * Build flow_config and pipeline_config from workflow structure.
-	 *
-	 * @param array $workflow Workflow with steps.
-	 * @return array Array with 'flow_config' and 'pipeline_config' keys.
-	 */
-	private function buildConfigsFromWorkflow( array $workflow ): array {
-		$flow_config     = array();
-		$pipeline_config = array();
-
-		foreach ( $workflow['steps'] as $index => $step ) {
-			$step_id          = "ephemeral_step_{$index}";
-			$pipeline_step_id = "ephemeral_pipeline_{$index}";
-
-			$step_type        = $step['type'];
-			$flow_step_config = FlowStepConfigFactory::buildFromWorkflowStep( $step, $index );
-
-			$flow_config[ $step_id ] = $flow_step_config;
-
-			// Pipeline config (AI settings only — model/provider resolved via context system, not stored here).
-			if ( 'ai' === $step['type'] ) {
-				$pipeline_config[ $pipeline_step_id ] = array(
-					'system_prompt'  => $step['system_prompt'] ?? '',
-					'disabled_tools' => $step['disabled_tools'] ?? array(),
-				);
-			}
-		}
-
-		return array(
-			'flow_config'     => $flow_config,
-			'pipeline_config' => $pipeline_config,
-		);
 	}
 
 	/**

--- a/inc/Abilities/Pipeline/CreatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/CreatePipelineAbility.php
@@ -11,6 +11,7 @@
 namespace DataMachine\Abilities\Pipeline;
 
 use DataMachine\Abilities\StepTypeAbilities;
+use DataMachine\Core\Steps\WorkflowConfigFactory;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -46,6 +47,10 @@ class CreatePipelineAbility {
 							'steps'         => array(
 								'type'        => 'array',
 								'description' => __( 'Optional steps configuration (each with step_type, optional label)', 'data-machine' ),
+							),
+							'workflow'      => array(
+								'type'        => 'object',
+								'description' => __( 'Optional persistent workflow scaffold using the same steps shape as datamachine/execute-workflow. When provided, Data Machine creates matching pipeline steps and a flow whose step configs preserve handler config, enabled tools, queue state, user_message prompt queue, disabled tools, labels, and execution order.', 'data-machine' ),
 							),
 							'flow_config'   => array(
 								'type'        => 'object',
@@ -144,11 +149,21 @@ class CreatePipelineAbility {
 
 		$agent_id    = isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
 		$steps       = $input['steps'] ?? array();
+		$workflow    = isset( $input['workflow'] ) && is_array( $input['workflow'] ) ? $input['workflow'] : array();
 		$flow_config = $input['flow_config'] ?? array();
 
 		$has_steps = ! empty( $steps ) && is_array( $steps );
+		$has_workflow = ! empty( $workflow );
 
-		if ( $has_steps ) {
+		if ( $has_workflow ) {
+			$validation = $this->validateWorkflow( $workflow );
+			if ( true !== $validation ) {
+				return array(
+					'success' => false,
+					'error'   => $validation,
+				);
+			}
+		} elseif ( $has_steps ) {
 			$validation = $this->validateSteps( $steps );
 			if ( true !== $validation ) {
 				return array(
@@ -180,7 +195,17 @@ class CreatePipelineAbility {
 		$pipeline_config = array();
 		$steps_created   = 0;
 
-		if ( $has_steps ) {
+		if ( $has_workflow ) {
+			$pipeline_config = WorkflowConfigFactory::buildPersistentPipelineConfig( $workflow, $pipeline_id );
+			$steps_created   = count( $pipeline_config );
+
+			if ( ! empty( $pipeline_config ) ) {
+				$this->db_pipelines->update_pipeline(
+					$pipeline_id,
+					array( 'pipeline_config' => $pipeline_config )
+				);
+			}
+		} elseif ( $has_steps ) {
 			$step_type_abilities = new StepTypeAbilities();
 
 			foreach ( $steps as $index => $step_data ) {
@@ -219,7 +244,7 @@ class CreatePipelineAbility {
 		$flow_name     = null;
 		$flow_step_ids = array();
 
-		if ( ! empty( $flow_config ) ) {
+		if ( ! empty( $flow_config ) || $has_workflow ) {
 			$flow_name         = $flow_config['flow_name'] ?? $pipeline_name;
 			$scheduling_config = $flow_config['scheduling_config'] ?? array( 'interval' => 'manual' );
 
@@ -240,6 +265,20 @@ class CreatePipelineAbility {
 
 			if ( ! $flow_result || ! $flow_result['success'] ) {
 				do_action( 'datamachine_log', 'error', "Failed to create flow for pipeline {$pipeline_id}" );
+			}
+
+			if ( $flow_result && $flow_result['success'] && $has_workflow ) {
+				$persistent_flow_config = WorkflowConfigFactory::buildPersistentFlowConfig(
+					$workflow,
+					$pipeline_id,
+					(int) $flow_result['flow_id'],
+					$pipeline_config
+				);
+				$this->db_flows->update_flow(
+					(int) $flow_result['flow_id'],
+					array( 'flow_config' => $persistent_flow_config )
+				);
+				$flow_result['flow_data']['flow_config'] = $persistent_flow_config;
 			}
 
 			if ( $flow_result && $flow_result['success'] && ! empty( $flow_result['flow_data']['flow_config'] ) ) {
@@ -267,7 +306,7 @@ class CreatePipelineAbility {
 			'flow_name'     => $flow_name,
 			'steps_created' => $steps_created,
 			'flow_step_ids' => $flow_step_ids,
-			'creation_mode' => $has_steps ? 'batch' : 'simple',
+			'creation_mode' => $has_workflow ? 'workflow' : ( $has_steps ? 'batch' : 'simple' ),
 		);
 	}
 

--- a/inc/Abilities/Pipeline/PipelineHelpers.php
+++ b/inc/Abilities/Pipeline/PipelineHelpers.php
@@ -204,6 +204,42 @@ trait PipelineHelpers {
 	}
 
 	/**
+	 * Validate workflow steps array.
+	 *
+	 * @param array $workflow Workflow with steps.
+	 * @return bool|string True if valid, error message if not.
+	 */
+	protected function validateWorkflow( array $workflow ): bool|string {
+		if ( ! isset( $workflow['steps'] ) || ! is_array( $workflow['steps'] ) ) {
+			return 'Workflow must contain steps array';
+		}
+
+		if ( empty( $workflow['steps'] ) ) {
+			return 'Workflow must have at least one step';
+		}
+
+		$step_type_abilities = new StepTypeAbilities();
+		$valid_types         = array_keys( $step_type_abilities->getAllStepTypes() );
+
+		foreach ( $workflow['steps'] as $index => $step ) {
+			if ( ! is_array( $step ) ) {
+				return "Workflow step at index {$index} must be an object";
+			}
+
+			$step_type = $step['type'] ?? null;
+			if ( empty( $step_type ) || ! is_string( $step_type ) ) {
+				return "Workflow step at index {$index} is missing required type";
+			}
+
+			if ( ! in_array( $step_type, $valid_types, true ) ) {
+				return "Workflow step at index {$index} has invalid type '{$step_type}'. Must be one of: " . implode( ', ', $valid_types );
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * Validate handler slugs in steps array.
 	 *
 	 * @param array $steps Steps to validate.

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -25,8 +25,7 @@ class FlowStepConfigFactory {
 	 */
 	public static function buildFromWorkflowStep( array $step, int $index ): array {
 		$step_type = $step['type'];
-
-		return self::build(
+		$config    = self::build(
 			array_merge(
 				array(
 					'flow_step_id'     => "ephemeral_step_{$index}",
@@ -48,6 +47,17 @@ class FlowStepConfigFactory {
 				)
 			)
 		);
+
+		$config = self::withQueueState( $config, $step );
+
+		$workflow_user_message = is_string( $step['user_message'] ?? null )
+			? trim( $step['user_message'] )
+			: '';
+		if ( 'ai' === $step_type && '' !== $workflow_user_message ) {
+			$config = self::withUserMessage( $config, $workflow_user_message );
+		}
+
+		return $config;
 	}
 
 	/**

--- a/inc/Core/Steps/WorkflowConfigFactory.php
+++ b/inc/Core/Steps/WorkflowConfigFactory.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Workflow config factory.
+ *
+ * @package DataMachine\Core\Steps
+ */
+
+namespace DataMachine\Core\Steps;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds pipeline and flow config rows from workflow step definitions.
+ */
+class WorkflowConfigFactory {
+
+	/**
+	 * Build direct-execution configs from a workflow.
+	 *
+	 * @param array $workflow Workflow with steps.
+	 * @return array{flow_config: array, pipeline_config: array}
+	 */
+	public static function buildEphemeralConfigs( array $workflow ): array {
+		$flow_config     = array();
+		$pipeline_config = array();
+
+		foreach ( $workflow['steps'] as $index => $step ) {
+			$step_id          = "ephemeral_step_{$index}";
+			$pipeline_step_id = "ephemeral_pipeline_{$index}";
+
+			$flow_config[ $step_id ] = FlowStepConfigFactory::buildFromWorkflowStep( $step, $index );
+
+			if ( 'ai' === ( $step['type'] ?? '' ) ) {
+				$pipeline_config[ $pipeline_step_id ] = array(
+					'system_prompt'  => $step['system_prompt'] ?? '',
+					'disabled_tools' => $step['disabled_tools'] ?? array(),
+				);
+			}
+		}
+
+		return array(
+			'flow_config'     => $flow_config,
+			'pipeline_config' => $pipeline_config,
+		);
+	}
+
+	/**
+	 * Build persistent pipeline config from a workflow.
+	 *
+	 * @param array      $workflow Workflow with steps.
+	 * @param int|string $pipeline_id Pipeline ID.
+	 * @return array<string,array<string,mixed>> Pipeline config keyed by generated pipeline step ID.
+	 */
+	public static function buildPersistentPipelineConfig( array $workflow, $pipeline_id ): array {
+		$pipeline_config = array();
+
+		foreach ( $workflow['steps'] as $index => $step ) {
+			$pipeline_step_id                    = $pipeline_id . '_' . wp_generate_uuid4();
+			$pipeline_config[ $pipeline_step_id ] = self::pipelineStepFromWorkflowStep( $step, $pipeline_step_id, $index );
+		}
+
+		return $pipeline_config;
+	}
+
+	/**
+	 * Build persistent flow config from workflow steps and their pipeline rows.
+	 *
+	 * @param array      $workflow Workflow with steps.
+	 * @param int|string $pipeline_id Pipeline ID.
+	 * @param int|string $flow_id Flow ID.
+	 * @param array      $pipeline_config Pipeline config keyed by pipeline step ID.
+	 * @return array<string,array<string,mixed>> Flow config keyed by generated flow step ID.
+	 */
+	public static function buildPersistentFlowConfig( array $workflow, $pipeline_id, $flow_id, array $pipeline_config ): array {
+		$pipeline_steps_by_order = array();
+		foreach ( $pipeline_config as $pipeline_step_id => $pipeline_step ) {
+			$order                             = (int) ( $pipeline_step['execution_order'] ?? 0 );
+			$pipeline_steps_by_order[ $order ] = array_merge(
+				$pipeline_step,
+				array( 'pipeline_step_id' => $pipeline_step_id )
+			);
+		}
+
+		$flow_config = array();
+		foreach ( $workflow['steps'] as $index => $step ) {
+			$pipeline_step = $pipeline_steps_by_order[ $index ] ?? null;
+			if ( ! $pipeline_step ) {
+				continue;
+			}
+
+			$pipeline_step_id = $pipeline_step['pipeline_step_id'];
+			$flow_step_id     = apply_filters( 'datamachine_generate_flow_step_id', '', $pipeline_step_id, $flow_id );
+			if ( empty( $flow_step_id ) ) {
+				$flow_step_id = $pipeline_step_id . '_' . $flow_id;
+			}
+
+			$flow_step = FlowStepConfigFactory::buildFromPipelineStep(
+				$pipeline_step,
+				$pipeline_id,
+				$flow_id,
+				$flow_step_id,
+				$pipeline_step
+			);
+
+			$workflow_step_config = FlowStepConfigFactory::buildFromWorkflowStep( $step, $index );
+			$flow_step            = FlowStepConfigFactory::withHandlerFields( $flow_step, $workflow_step_config );
+			$flow_step            = FlowStepConfigFactory::withQueueState( $flow_step, $workflow_step_config );
+
+			if ( isset( $workflow_step_config['enabled_tools'] ) ) {
+				$flow_step['enabled_tools'] = $workflow_step_config['enabled_tools'];
+			}
+			if ( isset( $workflow_step_config['disabled_tools'] ) ) {
+				$flow_step['disabled_tools'] = $workflow_step_config['disabled_tools'];
+			}
+
+			$flow_config[ $flow_step_id ] = $flow_step;
+		}
+
+		return $flow_config;
+	}
+
+	/**
+	 * Build a pipeline step row from a workflow step.
+	 *
+	 * @param array  $step Workflow step.
+	 * @param string $pipeline_step_id Pipeline step ID.
+	 * @param int    $index Execution order.
+	 * @return array<string,mixed> Pipeline step config.
+	 */
+	private static function pipelineStepFromWorkflowStep( array $step, string $pipeline_step_id, int $index ): array {
+		$step_type = (string) ( $step['type'] ?? '' );
+		$label     = isset( $step['label'] ) && is_string( $step['label'] ) && '' !== trim( $step['label'] )
+			? $step['label']
+			: ucfirst( str_replace( '_', ' ', $step_type ) );
+
+		$pipeline_step = array(
+			'pipeline_step_id' => $pipeline_step_id,
+			'step_type'        => $step_type,
+			'execution_order'  => $index,
+			'label'            => $label,
+		);
+
+		if ( 'ai' === $step_type ) {
+			$pipeline_step['system_prompt']  = $step['system_prompt'] ?? '';
+			$pipeline_step['disabled_tools'] = is_array( $step['disabled_tools'] ?? null ) ? array_values( $step['disabled_tools'] ) : array();
+		}
+
+		return $pipeline_step;
+	}
+}

--- a/tests/flow-step-config-factory-smoke.php
+++ b/tests/flow-step-config-factory-smoke.php
@@ -231,8 +231,8 @@ $flow_helpers_src     = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/Flo
 
 assert_factory_equals(
 	true,
-	false !== strpos( $execute_workflow_src, 'FlowStepConfigFactory::buildFromWorkflowStep( $step, $index )' ),
-	'ExecuteWorkflowAbility routes workflow rows through the factory scaffold',
+	false !== strpos( $execute_workflow_src, 'WorkflowConfigFactory::buildEphemeralConfigs( $workflow )' ),
+	'ExecuteWorkflowAbility routes workflow rows through the shared workflow factory',
 	$failures,
 	$passes
 );

--- a/tests/queue-mode-callsites-smoke.php
+++ b/tests/queue-mode-callsites-smoke.php
@@ -17,7 +17,7 @@
  * and were missed in the original PR — they kept writing the legacy
  * `user_message` slot AIStep no longer reads:
  *
- *   1. `ExecuteWorkflowAbility::buildConfigsFromWorkflow()` — assembles
+ *   1. `WorkflowConfigFactory::buildEphemeralConfigs()` — assembles
  *      an ephemeral in-memory flow_config from a workflow JSON spec.
  *      Wrote `user_message` to the flow_step_config root. Workflow
  *      spec input is silently dropped at runtime.
@@ -86,10 +86,10 @@ function assert_callsite( string $name, bool $cond, string $detail = '' ): void 
 }
 
 // ====================================================================
-// Bug 1: ExecuteWorkflowAbility::buildConfigsFromWorkflow
+// Bug 1: WorkflowConfigFactory::buildEphemeralConfigs
 // ====================================================================
 //
-// Inline mirror of the relevant slice of buildConfigsFromWorkflow
+// Inline mirror of the relevant slice of buildEphemeralConfigs
 // post-fix. The workflow JSON spec accepts `user_message` as an input
 // field (matches ExecuteWorkflowTool's documented shape); the helper
 // converts it into a 1-entry static prompt_queue so AIStep sees it.

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -11,6 +11,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+if ( ! class_exists( 'DM_System_Task_Config_Passthrough_QueueAbility_Stub', false ) ) {
+	class DM_System_Task_Config_Passthrough_QueueAbility_Stub {
+		const SLOT_PROMPT_QUEUE       = 'prompt_queue';
+		const SLOT_CONFIG_PATCH_QUEUE = 'config_patch_queue';
+	}
+}
+if ( ! class_exists( '\DataMachine\Abilities\Flow\QueueAbility', false ) ) {
+	class_alias( 'DM_System_Task_Config_Passthrough_QueueAbility_Stub', '\DataMachine\Abilities\Flow\QueueAbility' );
+}
+
 if ( ! function_exists( 'apply_filters' ) ) {
 	function apply_filters( string $hook, $value ) {
 		if ( 'datamachine_step_types' !== $hook ) {
@@ -36,57 +46,17 @@ if ( ! function_exists( 'do_action' ) ) {
 
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
+require_once __DIR__ . '/../inc/Core/Steps/WorkflowConfigFactory.php';
 
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\FlowStepConfigFactory;
+use DataMachine\Core\Steps\WorkflowConfigFactory;
 
 /**
- * Inline mirror of ExecuteWorkflowAbility::buildConfigsFromWorkflow().
+ * Inline mirror of ExecuteWorkflowAbility's workflow config builder call.
  */
 function build_configs_from_workflow_for_test( array $workflow ): array {
-	$flow_config     = array();
-	$pipeline_config = array();
-
-	foreach ( $workflow['steps'] as $index => $step ) {
-		$step_id          = "ephemeral_step_{$index}";
-		$pipeline_step_id = "ephemeral_pipeline_{$index}";
-		$handler_slug     = $step['handler_slug'] ?? '';
-		$handler_config   = $step['handler_config'] ?? array();
-		$step_type        = $step['type'];
-
-		$flow_step_config = FlowStepConfigFactory::build(
-			array(
-				'flow_step_id'     => $step_id,
-				'pipeline_step_id' => $pipeline_step_id,
-				'step_type'        => $step_type,
-				'execution_order'  => $index,
-				'enabled_tools'    => ( 'ai' === $step_type && ! empty( $step['enabled_tools'] ) && is_array( $step['enabled_tools'] ) )
-					? array_values( $step['enabled_tools'] )
-					: array(),
-				'prompt_queue'     => array(),
-				'queue_mode'       => 'static',
-				'disabled_tools'   => $step['disabled_tools'] ?? array(),
-				'pipeline_id'      => 'direct',
-				'flow_id'          => 'direct',
-				'handler_slug'     => $handler_slug,
-				'handler_config'   => $handler_config,
-			)
-		);
-
-		$flow_config[ $step_id ] = $flow_step_config;
-
-		if ( 'ai' === $step_type ) {
-			$pipeline_config[ $pipeline_step_id ] = array(
-				'system_prompt'  => $step['system_prompt'] ?? '',
-				'disabled_tools' => $step['disabled_tools'] ?? array(),
-			);
-		}
-	}
-
-	return array(
-		'flow_config'     => $flow_config,
-		'pipeline_config' => $pipeline_config,
-	);
+	return WorkflowConfigFactory::buildEphemeralConfigs( $workflow );
 }
 
 $failures = array();

--- a/tests/workflow-persistent-install-smoke.php
+++ b/tests/workflow-persistent-install-smoke.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Pure-PHP smoke test for workflow scaffold -> persistent pipeline/flow mapping.
+ *
+ * Run with: php tests/workflow-persistent-install-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities\Flow {
+	if ( ! class_exists( QueueAbility::class, false ) ) {
+		class QueueAbility {
+			const SLOT_PROMPT_QUEUE       = 'prompt_queue';
+			const SLOT_CONFIG_PATCH_QUEUE = 'config_patch_queue';
+		}
+	}
+}
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		if ( 'datamachine_step_types' === $hook ) {
+			return array(
+				'ai'      => array( 'uses_handler' => false, 'multi_handler' => false ),
+				'fetch'   => array( 'uses_handler' => true, 'multi_handler' => false ),
+				'publish' => array( 'uses_handler' => true, 'multi_handler' => true ),
+				'upsert'  => array( 'uses_handler' => true, 'multi_handler' => true ),
+			);
+		}
+
+		if ( 'datamachine_generate_flow_step_id' === $hook ) {
+			return $args[0] . '_' . $args[1];
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		// no-op for tests.
+	}
+}
+
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4(): string {
+		static $i = 0;
+		++$i;
+		return 'uuid-' . $i;
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
+require_once __DIR__ . '/../inc/Core/Steps/WorkflowConfigFactory.php';
+
+use DataMachine\Core\Steps\WorkflowConfigFactory;
+
+$failures = array();
+$passes   = 0;
+
+function assert_workflow_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+echo "workflow-persistent-install-smoke\n";
+
+$workflow = array(
+	'steps' => array(
+		array(
+			'type'               => 'fetch',
+			'label'              => 'Webhook Payload',
+			'handler_slug'       => 'webhook_payload',
+			'handler_config'     => array( 'payload_path' => 'pull_request' ),
+			'config_patch_queue' => array( array( 'after' => '2026-04-01' ) ),
+			'queue_mode'         => 'drain',
+		),
+		array(
+			'type'           => 'ai',
+			'label'          => 'Review Pull Request',
+			'system_prompt'  => 'Review the PR.',
+			'user_message'   => 'Summarize findings.',
+			'enabled_tools'  => array( 'datamachine/get-github-pull-review-context', 'datamachine/upsert-github-pull-review-comment' ),
+			'disabled_tools' => array( 'datamachine/delete-flow' ),
+		),
+		array(
+			'type'          => 'ai',
+			'label'         => 'Rotating Prompt',
+			'prompt_queue'  => array(
+				array(
+					'prompt'   => 'Prompt A',
+					'added_at' => '2026-04-27T00:00:00Z',
+				),
+			),
+			'queue_mode'    => 'loop',
+			'enabled_tools' => array( 'datamachine/read-github-file' ),
+		),
+	),
+);
+
+$pipeline_config = WorkflowConfigFactory::buildPersistentPipelineConfig( $workflow, 88 );
+$pipeline_steps  = array_values( $pipeline_config );
+
+assert_workflow_equals( 3, count( $pipeline_config ), 'persistent pipeline contains every workflow step', $failures, $passes );
+assert_workflow_equals( array( 'fetch', 'ai', 'ai' ), array_column( $pipeline_steps, 'step_type' ), 'pipeline preserves workflow step order', $failures, $passes );
+assert_workflow_equals( array( 0, 1, 2 ), array_column( $pipeline_steps, 'execution_order' ), 'pipeline stores contiguous execution order', $failures, $passes );
+assert_workflow_equals( 'Webhook Payload', $pipeline_steps[0]['label'] ?? null, 'pipeline preserves fetch label', $failures, $passes );
+assert_workflow_equals( 'Review Pull Request', $pipeline_steps[1]['label'] ?? null, 'pipeline preserves AI label', $failures, $passes );
+assert_workflow_equals( 'Review the PR.', $pipeline_steps[1]['system_prompt'] ?? null, 'pipeline preserves AI system prompt', $failures, $passes );
+assert_workflow_equals( array( 'datamachine/delete-flow' ), $pipeline_steps[1]['disabled_tools'] ?? null, 'pipeline preserves AI disabled tools', $failures, $passes );
+assert_workflow_equals( false, array_key_exists( 'handler_slug', $pipeline_steps[0] ), 'pipeline rows stay handler-free', $failures, $passes );
+
+$flow_config = WorkflowConfigFactory::buildPersistentFlowConfig( $workflow, 88, 144, $pipeline_config );
+$flow_steps  = array_values( $flow_config );
+
+assert_workflow_equals( 3, count( $flow_config ), 'persistent flow contains every workflow step', $failures, $passes );
+assert_workflow_equals( array( 'fetch', 'ai', 'ai' ), array_column( $flow_steps, 'step_type' ), 'flow preserves workflow step order', $failures, $passes );
+assert_workflow_equals( '88_uuid-1_144', $flow_steps[0]['flow_step_id'] ?? null, 'flow step id maps pipeline step id to flow id', $failures, $passes );
+assert_workflow_equals( 88, $flow_steps[0]['pipeline_id'] ?? null, 'flow stores target pipeline id', $failures, $passes );
+assert_workflow_equals( 144, $flow_steps[0]['flow_id'] ?? null, 'flow stores target flow id', $failures, $passes );
+assert_workflow_equals( 'webhook_payload', $flow_steps[0]['handler_slug'] ?? null, 'flow preserves fetch handler slug', $failures, $passes );
+assert_workflow_equals( array( 'payload_path' => 'pull_request' ), $flow_steps[0]['handler_config'] ?? null, 'flow preserves fetch handler config', $failures, $passes );
+assert_workflow_equals( array( array( 'after' => '2026-04-01' ) ), $flow_steps[0]['config_patch_queue'] ?? null, 'flow preserves fetch config patch queue', $failures, $passes );
+assert_workflow_equals( 'drain', $flow_steps[0]['queue_mode'] ?? null, 'flow preserves explicit fetch queue mode', $failures, $passes );
+assert_workflow_equals( array( 'datamachine/get-github-pull-review-context', 'datamachine/upsert-github-pull-review-comment' ), $flow_steps[1]['enabled_tools'] ?? null, 'flow preserves AI enabled tools', $failures, $passes );
+assert_workflow_equals( 'Summarize findings.', $flow_steps[1]['prompt_queue'][0]['prompt'] ?? null, 'AI user_message becomes prompt_queue head', $failures, $passes );
+assert_workflow_equals( 'static', $flow_steps[1]['queue_mode'] ?? null, 'AI user_message stores static queue mode', $failures, $passes );
+assert_workflow_equals( array( 'datamachine/delete-flow' ), $flow_steps[1]['disabled_tools'] ?? null, 'flow preserves AI disabled tools', $failures, $passes );
+assert_workflow_equals( array( array( 'prompt' => 'Prompt A', 'added_at' => '2026-04-27T00:00:00Z' ) ), $flow_steps[2]['prompt_queue'] ?? null, 'flow preserves explicit prompt queue', $failures, $passes );
+assert_workflow_equals( 'loop', $flow_steps[2]['queue_mode'] ?? null, 'flow preserves explicit AI queue mode', $failures, $passes );
+
+$execute_workflow_source = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' ) ?: '';
+$create_pipeline_source  = file_get_contents( __DIR__ . '/../inc/Abilities/Pipeline/CreatePipelineAbility.php' ) ?: '';
+
+assert_workflow_equals( true, false !== strpos( $execute_workflow_source, 'WorkflowConfigFactory::buildEphemeralConfigs( $workflow )' ), 'execute-workflow uses shared workflow config factory', $failures, $passes );
+assert_workflow_equals( true, false !== strpos( $create_pipeline_source, 'WorkflowConfigFactory::buildPersistentPipelineConfig( $workflow, $pipeline_id )' ), 'create-pipeline builds persistent pipeline from workflow', $failures, $passes );
+assert_workflow_equals( true, false !== strpos( $create_pipeline_source, 'WorkflowConfigFactory::buildPersistentFlowConfig(' ), 'create-pipeline builds persistent flow from workflow', $failures, $passes );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " workflow persistent install assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} workflow persistent install assertions passed.\n";
+}


### PR DESCRIPTION
## Summary

- Adds a shared workflow config factory so ephemeral workflow execution and persistent pipeline/flow creation use the same workflow step mapping.
- Extends `datamachine/create-pipeline` with a generic `workflow` input that installs a pipeline plus flow from scaffolded workflow steps without extensions writing Data Machine internals.

## Changes

- New `WorkflowConfigFactory` builds ephemeral configs, persistent pipeline configs, and persistent flow configs from workflow `steps`.
- `CreatePipelineAbility` now accepts `workflow` and creates a flow by default when a workflow scaffold is supplied.
- Workflow mapping preserves handler slug/config, AI enabled tools, `user_message` as a static `prompt_queue`, explicit queue state, disabled tools, labels, and execution order.
- `ExecuteWorkflowAbility` now routes through the shared factory instead of a private workflow mapper.

## Tests

- `php -l inc/Core/Steps/WorkflowConfigFactory.php && php -l inc/Core/Steps/FlowStepConfigFactory.php && php -l inc/Abilities/Job/ExecuteWorkflowAbility.php && php -l inc/Abilities/Pipeline/CreatePipelineAbility.php && php -l inc/Abilities/Pipeline/PipelineHelpers.php`
- `php tests/workflow-persistent-install-smoke.php`
- `php tests/flow-step-config-factory-smoke.php`
- `php tests/flow-step-config-overlays-smoke.php`
- `php tests/queue-mode-callsites-smoke.php`
- `php tests/system-task-config-passthrough-smoke.php`
- `git diff --check`

Refs #1437

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the shared workflow mapping primitive, focused smoke coverage, and PR preparation. Chris provided the issue direction and constraints.
