### PR TITLE
fix(analytics): apply page_filter to all GA4 actions

### DIFF
--- a/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
+++ b/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
@@ -252,15 +252,16 @@ class GoogleAnalyticsAbilities {
 	}
 
 	/**
-	 * Fetch a standard GA4 report.
+	 * Build the GA4 runReport request body from ability input.
 	 *
-	 * @param array  $input        Ability input.
-	 * @param string $action       Report action.
-	 * @param string $access_token OAuth2 access token.
-	 * @param string $property_id  GA4 property ID.
-	 * @return array
+	 * Public for unit testing — request body construction is the testable surface
+	 * for filter / sort / pagination behavior without needing an HTTP round-trip.
+	 *
+	 * @param array  $input  Ability input.
+	 * @param string $action Report action (must be a key in self::ACTION_REPORTS).
+	 * @return array Request body for the GA4 runReport endpoint.
 	 */
-	private static function fetchReport( array $input, string $action, string $access_token, string $property_id ): array {
+	public static function buildReportRequestBody( array $input, string $action ): array {
 		$report_config = self::ACTION_REPORTS[ $action ];
 
 		$start_date = ! empty( $input['start_date'] ) ? sanitize_text_field( $input['start_date'] ) : gmdate( 'Y-m-d', strtotime( '-28 days' ) );
@@ -310,26 +311,27 @@ class GoogleAnalyticsAbilities {
 		// Build dimension filters.
 		$filters = array();
 
-		// Page path filter (for actions with pagePath or landingPage dimension).
+		// Page path filter. GA4 supports pagePath/landingPage as filter dimensions
+		// even when they aren't part of the report's dimensions array, so the filter
+		// applies to every action — not just those that group by page.
 		if ( ! empty( $input['page_filter'] ) ) {
-			$path_dim = null;
-			if ( in_array( 'pagePath', $report_config['dimensions'], true ) ) {
-				$path_dim = 'pagePath';
-			} elseif ( in_array( 'landingPage', $report_config['dimensions'], true ) ) {
-				$path_dim = 'landingPage';
-			}
+			// Prefer landingPage when the report groups by it (so the filter matches
+			// the dimension being returned); otherwise filter by pagePath, which
+			// scopes any action (date_stats, traffic_sources, top_events, etc.) to
+			// hits/sessions that touched matching paths.
+			$path_dim = in_array( 'landingPage', $report_config['dimensions'], true )
+				? 'landingPage'
+				: 'pagePath';
 
-			if ( $path_dim ) {
-				$filters[] = array(
-					'filter' => array(
-						'fieldName'    => $path_dim,
-						'stringFilter' => array(
-							'matchType' => 'CONTAINS',
-							'value'     => sanitize_text_field( $input['page_filter'] ),
-						),
+			$filters[] = array(
+				'filter' => array(
+					'fieldName'    => $path_dim,
+					'stringFilter' => array(
+						'matchType' => 'CONTAINS',
+						'value'     => sanitize_text_field( $input['page_filter'] ),
 					),
-				);
-			}
+				),
+			);
 		}
 
 		// Hostname filter for multisite properties.
@@ -381,6 +383,21 @@ class GoogleAnalyticsAbilities {
 				);
 			}
 		}
+
+		return $request_body;
+	}
+
+	/**
+	 * Fetch a standard GA4 report.
+	 *
+	 * @param array  $input        Ability input.
+	 * @param string $action       Report action.
+	 * @param string $access_token OAuth2 access token.
+	 * @param string $property_id  GA4 property ID.
+	 * @return array
+	 */
+	private static function fetchReport( array $input, string $action, string $access_token, string $property_id ): array {
+		$request_body = self::buildReportRequestBody( $input, $action );
 
 		$api_url = self::API_BASE . $property_id . ':runReport';
 

--- a/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Unit tests for GoogleAnalyticsAbilities request body construction.
+ *
+ * Covers the bug where --page-filter (page_filter input) was silently dropped
+ * for any GA4 action whose dimensions did not include pagePath/landingPage —
+ * meaning date_stats, traffic_sources, top_events, user_demographics, and
+ * new_vs_returning all returned site-wide data even when the caller asked for
+ * a specific page. Fix is to always emit a pagePath CONTAINS dimensionFilter
+ * when page_filter is provided.
+ *
+ * @package DataMachine\Tests\Unit\Abilities\Analytics
+ */
+
+namespace DataMachine\Tests\Unit\Abilities\Analytics;
+
+use DataMachine\Abilities\Analytics\GoogleAnalyticsAbilities;
+use WP_UnitTestCase;
+
+class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * page_filter must produce a dimensionFilter for every action, including
+	 * actions whose dimensions don't include pagePath/landingPage.
+	 *
+	 * @dataProvider all_filterable_actions
+	 */
+	public function test_page_filter_applied_to_all_actions( string $action ): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '/the-history-of-extra-chill',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			$action
+		);
+
+		$this->assertArrayHasKey(
+			'dimensionFilter',
+			$body,
+			"Action '{$action}' must apply page_filter as a dimensionFilter"
+		);
+
+		$filter = $body['dimensionFilter']['filter'] ?? null;
+		$this->assertNotNull(
+			$filter,
+			"Action '{$action}' must produce a single (not nested) filter when only page_filter is set"
+		);
+		$this->assertSame( 'CONTAINS', $filter['stringFilter']['matchType'] );
+		$this->assertSame( '/the-history-of-extra-chill', $filter['stringFilter']['value'] );
+	}
+
+	/**
+	 * Actions that group by pagePath (page_stats, engagement) filter on pagePath.
+	 *
+	 * @dataProvider page_path_grouped_actions
+	 */
+	public function test_page_filter_uses_pagepath_when_grouped_by_pagepath( string $action ): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '/about/',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			$action
+		);
+
+		$this->assertSame( 'pagePath', $body['dimensionFilter']['filter']['fieldName'] );
+	}
+
+	/**
+	 * landing_pages action filters on landingPage so the filter matches the
+	 * dimension actually being returned in the response.
+	 */
+	public function test_page_filter_uses_landingpage_for_landing_pages_action(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '/about/',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			'landing_pages'
+		);
+
+		$this->assertSame( 'landingPage', $body['dimensionFilter']['filter']['fieldName'] );
+	}
+
+	/**
+	 * Actions without pagePath/landingPage in their dimensions still filter on
+	 * pagePath (the regression case). GA4 supports pagePath as a filter-only
+	 * dimension, so the request scopes to hits matching that path.
+	 *
+	 * @dataProvider non_page_grouped_actions
+	 */
+	public function test_page_filter_uses_pagepath_for_non_page_grouped_actions( string $action ): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '/about/',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			$action
+		);
+
+		$this->assertArrayHasKey(
+			'dimensionFilter',
+			$body,
+			"Regression: action '{$action}' previously dropped page_filter silently"
+		);
+		$this->assertSame( 'pagePath', $body['dimensionFilter']['filter']['fieldName'] );
+	}
+
+	/**
+	 * Without page_filter, no dimensionFilter is emitted at all.
+	 */
+	public function test_no_filter_when_page_filter_absent(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'start_date' => '2026-01-01',
+				'end_date'   => '2026-01-31',
+			),
+			'date_stats'
+		);
+
+		$this->assertArrayNotHasKey( 'dimensionFilter', $body );
+	}
+
+	/**
+	 * page_filter + hostname combine into an andGroup with both filters.
+	 */
+	public function test_page_filter_and_hostname_combine_into_and_group(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '/about/',
+				'hostname'    => 'extrachill.com',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			'date_stats'
+		);
+
+		$this->assertArrayHasKey( 'andGroup', $body['dimensionFilter'] );
+		$expressions = $body['dimensionFilter']['andGroup']['expressions'];
+		$this->assertCount( 2, $expressions );
+
+		$field_names = array_map(
+			static fn( $e ) => $e['filter']['fieldName'],
+			$expressions
+		);
+		$this->assertContains( 'pagePath', $field_names );
+		$this->assertContains( 'hostName', $field_names );
+	}
+
+	/**
+	 * Empty page_filter string should not produce a dimensionFilter (empty()
+	 * check semantics).
+	 */
+	public function test_empty_page_filter_does_not_emit_filter(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			'date_stats'
+		);
+
+		$this->assertArrayNotHasKey( 'dimensionFilter', $body );
+	}
+
+	public static function all_filterable_actions(): array {
+		return array(
+			'page_stats'        => array( 'page_stats' ),
+			'traffic_sources'   => array( 'traffic_sources' ),
+			'date_stats'        => array( 'date_stats' ),
+			'top_events'        => array( 'top_events' ),
+			'user_demographics' => array( 'user_demographics' ),
+			'landing_pages'     => array( 'landing_pages' ),
+			'engagement'        => array( 'engagement' ),
+			'new_vs_returning'  => array( 'new_vs_returning' ),
+		);
+	}
+
+	public static function page_path_grouped_actions(): array {
+		return array(
+			'page_stats' => array( 'page_stats' ),
+			'engagement' => array( 'engagement' ),
+		);
+	}
+
+	public static function non_page_grouped_actions(): array {
+		return array(
+			'date_stats'        => array( 'date_stats' ),
+			'traffic_sources'   => array( 'traffic_sources' ),
+			'top_events'        => array( 'top_events' ),
+			'user_demographics' => array( 'user_demographics' ),
+			'new_vs_returning'  => array( 'new_vs_returning' ),
+		);
+	}
+}


### PR DESCRIPTION
## Summary

`GoogleAnalyticsAbilities::fetchReport()` silently dropped `--page-filter` (input key `page_filter`) on any GA4 action whose dimensions didn't include `pagePath` or `landingPage` — affecting `date_stats`, `traffic_sources`, `top_events`, `user_demographics`, and `new_vs_returning`. Callers got back full site-wide data even when they asked for a specific page, with **no warning**.

The CLI documents `--page-filter` as a top-level flag for all `wp datamachine analytics ga` actions, so this was a real WTF for anyone trying to scope traffic to a single page.

## Reproduction (pre-fix)

```bash
wp datamachine analytics ga date_stats \
    --page-filter=/the-history-of-extra-chill \
    --hostname=extrachill.com \
    --start-date=2024-01-01 --end-date=2024-01-31
```

Returned **site-wide** daily stats (top results: 11,565 page views/day) — completely unfiltered. Same for `traffic_sources`, `top_events`, `user_demographics`, `new_vs_returning`.

## Root cause

```php
// inc/Abilities/Analytics/GoogleAnalyticsAbilities.php (old)
if ( ! empty( $input['page_filter'] ) ) {
    $path_dim = null;
    if ( in_array( 'pagePath', $report_config['dimensions'], true ) ) {
        $path_dim = 'pagePath';
    } elseif ( in_array( 'landingPage', $report_config['dimensions'], true ) ) {
        $path_dim = 'landingPage';
    }

    if ( $path_dim ) {
        $filters[] = [ ... 'fieldName' => $path_dim ... ];
    }
    // ⚠ falls through silently if neither dim is present
}
```

GA4 supports `pagePath` as a **filter-only** dimension even when it's not part of the report's `dimensions` array. The fix is to always emit a `pagePath CONTAINS` dimensionFilter when `page_filter` is provided.

## Fix

- Always apply a `pagePath CONTAINS` dimensionFilter when `page_filter` is set.
- `landing_pages` keeps filtering by `landingPage` (so the filter matches the dimension being returned in results).
- Extract the request-body construction into a public static `buildReportRequestBody()` so it's directly unit-testable without HTTP / JWT / OAuth round-trips.

## Verification

Manual smoke-test against the patched code (running the extracted method against all 8 actions):

```
=== AFTER FIX ===
  OK    page_stats:        pagePath CONTAINS /the-history-of-extra-chill
  OK    date_stats:        pagePath CONTAINS /the-history-of-extra-chill
  OK    traffic_sources:   pagePath CONTAINS /the-history-of-extra-chill
  OK    top_events:        pagePath CONTAINS /the-history-of-extra-chill
  OK    user_demographics: pagePath CONTAINS /the-history-of-extra-chill
  OK    landing_pages:     landingPage CONTAINS /the-history-of-extra-chill
  OK    engagement:        pagePath CONTAINS /the-history-of-extra-chill
  OK    new_vs_returning:  pagePath CONTAINS /the-history-of-extra-chill

No page_filter:        no dimensionFilter emitted (clean)
page_filter + hostname: andGroup with 2 expressions (pagePath + hostName)
```

## Tests

`tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php` covers:

- All 8 actions emit a `dimensionFilter` when `page_filter` is set (regression test for the silent-drop bug).
- `page_stats` and `engagement` filter on `pagePath` (matches their grouping).
- `landing_pages` filters on `landingPage` (matches its grouping).
- 5 actions that don't group by page (`date_stats`, `traffic_sources`, `top_events`, `user_demographics`, `new_vs_returning`) filter on `pagePath` — the previously-broken cases.
- Empty / absent `page_filter` produces no `dimensionFilter`.
- `page_filter` + `hostname` combine into an `andGroup`.

## Discovery context

Found while answering "how much traffic does this page get?" on extrachill.com via `wp datamachine analytics ga date_stats --page-filter=...`. Daily numbers came back at site-wide volumes — page filter was silently ignored.