### PR TITLE
fix(homeboy): declare remote_path for deploy resolver

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -12,6 +12,7 @@
     }
   },
   "changelog_target": "docs/CHANGELOG.md",
+  "remote_path": "wp-content/plugins/data-machine",
   "extensions": {
     "wordpress": {
       "php": "8.2",


### PR DESCRIPTION
## Summary

`homeboy deploy data-machine` failed with `Invalid argument 'path': Path cannot be empty` because `homeboy.json` was missing the `remote_path` field. The resolver returned `null` for the deploy destination even though the plugin already exists at `/var/www/.../wp-content/plugins/data-machine` on production.

Every sibling component declares `remote_path` in its own `homeboy.json` (`data-machine-code`, `data-machine-socials`, `data-machine-events`, etc.) — data-machine never had it. This is why earlier deploys worked via manual rsync but `homeboy deploy` now refuses.

## Diff

```diff
   "changelog_target": "docs/CHANGELOG.md",
+  "remote_path": "wp-content/plugins/data-machine",
   "extensions": {
```

## Verification

After merge + release:
```bash
homeboy deploy data-machine --check
# remote_path now resolves to /var/www/extrachill.com/wp-content/plugins/data-machine
```

Discovered while trying to deploy v0.87.0 (PR #1440) to production.