### PR TITLE
fix(analytics): restore variables consumed by fetchReport response

### DIFF
--- a/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
+++ b/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
@@ -399,6 +399,13 @@ class GoogleAnalyticsAbilities {
 	private static function fetchReport( array $input, string $action, string $access_token, string $property_id ): array {
 		$request_body = self::buildReportRequestBody( $input, $action );
 
+		// Pull values needed for response shaping back out of the request body
+		// so we don't have to recompute defaults / comparison logic in two places.
+		$compare     = ! empty( $input['compare'] );
+		$date_ranges = $request_body['dateRanges'];
+		$start_date  = $date_ranges[0]['startDate'];
+		$end_date    = $date_ranges[0]['endDate'];
+
 		$api_url = self::API_BASE . $property_id . ':runReport';
 
 		$result = HttpClient::post(


### PR DESCRIPTION
## Summary

Follow-up to #1440. Extracting `buildReportRequestBody()` left `fetchReport()` referencing 4 variables that no longer exist in its scope — `$compare`, `$date_ranges`, `$start_date`, `$end_date` — used when shaping the response payload (`date_range`, `compare_date_range`, comparison-row formatter selection).

## Symptom

Caught after deploying v0.87.1 to extrachill.com:

```
Warning: Undefined variable $compare in GoogleAnalyticsAbilities.php on line 441
Warning: Undefined variable $start_date in GoogleAnalyticsAbilities.php on line 449
Warning: Undefined variable $end_date in GoogleAnalyticsAbilities.php on line 450
Warning: Undefined variable $compare in GoogleAnalyticsAbilities.php on line 456
```

The actual data returned was correct (the page filter fix from #1440 works), but the `date_range` block came back as `{start_date: ?, end_date: ?}` and the comparison branch silently took the wrong path because `$compare` evaluated to null (falsy).

## Fix

Re-derive the values inside `fetchReport` from `$input` and the already-built `$request_body['dateRanges']` rather than recomputing the defaults / comparison-period logic. Keeps `buildReportRequestBody` as the single source of truth for date math and avoids duplicating the GA4 request shaping in two places.

## Verification

After merge + release:
```bash
wp datamachine analytics ga date_stats --page-filter=/the-history-of-extra-chill --hostname=extrachill.com
# No warnings, date_range populated, comparison branch correctly selected
```