### PR TITLE
fix(tools): restrict chat-only global tools

### DIFF
--- a/docs/core-system/base-tool.md
+++ b/docs/core-system/base-tool.md
@@ -6,14 +6,14 @@
 
 ## Overview
 
-The BaseTool class provides agent-agnostic tool registration patterns that dynamically create appropriate filters based on agent type. This enables unlimited agent specialization while maintaining consistent registration patterns across the entire AI tool ecosystem.
+The BaseTool class provides one registration path for tools in the unified `datamachine_tools` registry. Each tool declares the agent modes where it is visible, such as `chat` or `pipeline`.
 
 ## Key Features
 
 - **Unified Inheritance**: Single base class for all tools (global and chat)
-- **Agent-Agnostic Registration**: `registerTool()` method handles all agent types
-- **Dynamic Filter Creation**: Automatically creates `datamachine_{agentType}_tools` filters
-- **Extensible Architecture**: Supports current and future agent types (global, chat, frontend, etc.)
+- **Mode-Aware Registration**: `registerTool()` declares where each tool is visible
+- **Unified Registry**: Registers tools through the single `datamachine_tools` filter
+- **Extensible Architecture**: Supports current and future agent modes (chat, pipeline, system, etc.)
 - **Configuration Management**: Built-in support for tool configuration handlers
 - **Error Handling**: Standardized error response building with classification
 
@@ -21,27 +21,20 @@ The BaseTool class provides agent-agnostic tool registration patterns that dynam
 
 ### Tool Registration Methods
 
-#### `registerTool(string $agentType, string $toolName, array|callable $toolDefinition)`
+#### `registerTool(string $toolName, array|callable $toolDefinition, array $modes = [], array $meta = [])`
 
-Core registration method that dynamically creates the appropriate filter based on agent type.
+Core registration method that adds a tool to the unified registry with explicit mode visibility.
 
 **Parameters:**
-- `$agentType`: Agent type identifier (global, chat, frontend, etc.)
 - `$toolName`: Tool identifier
 - `$toolDefinition`: Tool definition array OR callable that returns it
+- `$modes`: Agent modes where this tool is visible, such as `['chat']` or `['chat', 'pipeline']`
+- `$meta`: Permission metadata, such as `ability`, `abilities`, or `access_level`
 
 **Example:**
 ```php
-$this->registerTool('chat', 'create_pipeline', [$this, 'getToolDefinition']);
+$this->registerTool('create_pipeline', [$this, 'getToolDefinition'], ['chat']);
 ```
-
-#### `registerGlobalTool(string $tool_name, array|callable $tool_definition)`
-
-Convenience method for registering tools available to all AI agents (pipeline + chat).
-
-#### `registerChatTool(string $tool_name, array|callable $tool_definition)`
-
-Convenience method for registering chat-specific tools.
 
 #### `registerConfigurationHandlers(string $tool_id)`
 
@@ -71,7 +64,7 @@ Build standardized error response with classification.
 
 ## Usage Patterns
 
-### Global Tool
+### Pipeline-Capable Tool
 
 ```php
 <?php
@@ -82,7 +75,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class GoogleSearch extends BaseTool {
 
     public function __construct() {
-        $this->registerGlobalTool('google_search', [$this, 'getToolDefinition']);
+        $this->registerTool('google_search', [$this, 'getToolDefinition'], ['chat', 'pipeline'], ['access_level' => 'admin']);
         $this->registerConfigurationHandlers('google_search');
     }
 
@@ -114,7 +107,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class CreatePipeline extends BaseTool {
 
     public function __construct() {
-        $this->registerChatTool('create_pipeline', [$this, 'getToolDefinition']);
+        $this->registerTool('create_pipeline', [$this, 'getToolDefinition'], ['chat'], ['access_level' => 'admin']);
     }
 
     public function getToolDefinition(): array {
@@ -152,9 +145,9 @@ class CreatePipeline extends BaseTool {
 
 - **Code Reduction**: Eliminates repetitive registration code across tool implementations
 - **Consistency**: Ensures uniform registration and error handling patterns across all AI tools
-- **Extensibility**: Supports unlimited agent types without code changes
+- **Extensibility**: Supports additional agent modes without code changes
 - **Maintainability**: Centralized registration and error handling logic in one base class
-- **Future-Proof**: Automatic support for new agent types through dynamic filter creation
+- **Future-Proof**: Tool definitions are mode-tagged before lazy definitions are resolved
 
 ## Integration with ToolManager
 
@@ -164,12 +157,8 @@ The BaseTool class integrates seamlessly with the ToolManager system:
 - **Configuration Validation**: `check_configuration()` methods are called during tool enablement checks
 - **Lazy Evaluation**: Tool definitions support callable format for deferred loading
 
-## Agent Type Support
+## Mode Support
 
-The class supports multiple agent types through dynamic filter creation:
+The class supports any mode string declared in the tool's `modes` array. Built-in modes are `chat`, `pipeline`, and `system`; third-party callers may resolve custom modes through `ToolPolicyResolver`.
 
-- **global**: `datamachine_global_tools` - Available to all agents
-- **chat**: `datamachine_chat_tools` - Chat agent specific
-- **pipeline**: `datamachine_pipeline_tools` - Pipeline agent specific
-- **frontend**: `datamachine_frontend_tools` - Frontend agent specific
-- **Custom**: Any agent type automatically gets `datamachine_{type}_tools` filter
+Only declare `pipeline` when the tool is useful inside automated pipeline AI steps. Chat affordances and tools that duplicate engine-level pipeline behavior should stay `chat`-only.

--- a/docs/development/hooks/engine-filters.md
+++ b/docs/development/hooks/engine-filters.md
@@ -105,7 +105,7 @@ $tools = apply_filters( 'datamachine_tools', array() );
             'description' => 'Search query',
         ],
     ],
-    'modes'            => ['chat', 'pipeline'], // which modes can see this tool
+    'modes'            => ['chat'],             // which modes can see this tool
     'requires_config'  => true,                 // checked via datamachine_tool_configured
     'category'         => 'search',             // optional grouping
 ]
@@ -132,6 +132,8 @@ add_filter( 'datamachine_tools', function ( $tools ) {
     return $tools;
 } );
 ```
+
+Use `pipeline` mode only when a static/global tool is useful inside an automated pipeline AI step. Chat affordances and tools that duplicate engine-level validation should stay `chat`-only; pipeline AI steps already receive step-scoped handler tools plus pipeline/flow memory directives.
 
 > The legacy `datamachine_global_tools` and `datamachine_chat_tools` filters were consolidated into `datamachine_tools` in v0.68.0 (PR #1130). The old per-mode filters no longer exist.
 

--- a/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
@@ -21,7 +21,7 @@ use DataMachine\Core\FilesRepository\DirectoryManager;
 class AgentDailyMemory extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'abilities' => array( 'datamachine/daily-memory-read', 'datamachine/daily-memory-write', 'datamachine/daily-memory-list', 'datamachine/search-daily-memory' ) ) );
+		$this->registerTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/daily-memory-read', 'datamachine/daily-memory-write', 'datamachine/daily-memory-list', 'datamachine/search-daily-memory' ) ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/AgentMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentMemory.php
@@ -21,7 +21,7 @@ use DataMachine\Core\FilesRepository\DirectoryManager;
 class AgentMemory extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'agent_memory', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'abilities' => array( 'datamachine/get-agent-memory', 'datamachine/update-agent-memory', 'datamachine/list-agent-memory-sections' ) ) );
+		$this->registerTool( 'agent_memory', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/get-agent-memory', 'datamachine/update-agent-memory', 'datamachine/list-agent-memory-sections' ) ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/QueueValidator.php
+++ b/inc/Engine/AI/Tools/Global/QueueValidator.php
@@ -23,7 +23,7 @@ use DataMachine\Engine\AI\Tools\BaseTool;
 class QueueValidator extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'queue_validator', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'access_level' => 'admin' ) );
+		$this->registerTool( 'queue_validator', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'access_level' => 'admin' ) );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/ToolServiceProvider.php
+++ b/inc/Engine/AI/Tools/ToolServiceProvider.php
@@ -14,7 +14,7 @@ namespace DataMachine\Engine\AI\Tools;
 
 defined( 'ABSPATH' ) || exit;
 
-// Tools available in chat and pipeline contexts.
+// Global tools. Each class declares the modes where its tool is visible.
 use DataMachine\Engine\AI\Tools\Global\AgentDailyMemory;
 use DataMachine\Engine\AI\Tools\Global\AgentMemory;
 use DataMachine\Engine\AI\Tools\Global\AmazonAffiliateLink;
@@ -70,9 +70,8 @@ class ToolServiceProvider {
 	/**
 	 * Register all tools.
 	 *
-	 * Tools with contexts ['chat', 'pipeline'] are registered
-	 * first because chat-only tools may depend on handlers and step types
-	 * that they provide.
+		 * Global tools are registered first because chat-only tools may depend
+		 * on handlers and step types that they provide.
 	 */
 	public static function register(): void {
 		self::registerTools();
@@ -82,7 +81,7 @@ class ToolServiceProvider {
 	 * Register all tools with their context declarations.
 	 */
 	private static function registerTools(): void {
-		// Tools available in chat and pipeline contexts.
+		// Global tools. Each class declares its own mode visibility.
 		new AgentDailyMemory();
 		new AgentMemory();
 		new AmazonAffiliateLink();

--- a/tests/global-tool-pipeline-modes-smoke.php
+++ b/tests/global-tool-pipeline-modes-smoke.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Pure-PHP smoke test for global tool pipeline-mode visibility (#1442).
+ *
+ * Run with: php tests/global-tool-pipeline-modes-smoke.php
+ *
+ * Static/global tools that declare `pipeline` are auto-injected into every
+ * pipeline AI step. This smoke pins the audit boundary: source/search/content
+ * helpers can remain pipeline-visible, while chat affordances and duplicate
+ * validation tools stay chat-only.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$test_filters_for_pipeline_modes = array();
+
+function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	global $test_filters_for_pipeline_modes;
+	$test_filters_for_pipeline_modes[ $tag ][ $priority ][] = $callback;
+}
+
+function apply_filters( string $tag, $value ) {
+	global $test_filters_for_pipeline_modes;
+	if ( empty( $test_filters_for_pipeline_modes[ $tag ] ) ) {
+		return $value;
+	}
+
+	ksort( $test_filters_for_pipeline_modes[ $tag ] );
+	foreach ( $test_filters_for_pipeline_modes[ $tag ] as $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			$value = $callback( $value );
+		}
+	}
+
+	return $value;
+}
+
+require_once __DIR__ . '/../inc/Engine/AI/Tools/BaseTool.php';
+
+$failures = array();
+$passes   = 0;
+
+function assert_true_for_pipeline_modes( bool $condition, string $name, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		$passes++;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+}
+
+function file_contains_for_pipeline_modes( string $relative_path, string $needle ): bool {
+	$contents = file_get_contents( __DIR__ . '/../' . $relative_path );
+	return false !== $contents && false !== strpos( $contents, $needle );
+}
+
+function load_global_tool_for_pipeline_modes( string $relative_path, string $class_name ): void {
+	require_once __DIR__ . '/../' . $relative_path;
+	new $class_name();
+}
+
+function resolve_tools_for_pipeline_modes( string $mode ): array {
+	$tools = apply_filters( 'datamachine_tools', array() );
+
+	return array_filter(
+		$tools,
+		function ( $tool ) use ( $mode ) {
+			return is_array( $tool ) && in_array( $mode, $tool['modes'] ?? array(), true );
+		}
+	);
+}
+
+echo "Global tool pipeline-mode smoke (#1442)\n";
+echo "---------------------------------------\n";
+
+$chat_only = array(
+	'queue_validator'    => array( 'inc/Engine/AI/Tools/Global/QueueValidator.php', 'DataMachine\Engine\AI\Tools\Global\QueueValidator' ),
+	'agent_memory'       => array( 'inc/Engine/AI/Tools/Global/AgentMemory.php', 'DataMachine\Engine\AI\Tools\Global\AgentMemory' ),
+	'agent_daily_memory' => array( 'inc/Engine/AI/Tools/Global/AgentDailyMemory.php', 'DataMachine\Engine\AI\Tools\Global\AgentDailyMemory' ),
+);
+
+foreach ( $chat_only as $tool => [ $path, $class_name ] ) {
+	load_global_tool_for_pipeline_modes( $path, $class_name );
+
+	$chat_tools     = resolve_tools_for_pipeline_modes( 'chat' );
+	$pipeline_tools = resolve_tools_for_pipeline_modes( 'pipeline' );
+
+	assert_true_for_pipeline_modes(
+		isset( $chat_tools[ $tool ] ),
+		"{$tool} resolves in chat mode",
+		$failures,
+		$passes
+	);
+	assert_true_for_pipeline_modes(
+		! isset( $pipeline_tools[ $tool ] ),
+		"{$tool} does not resolve in pipeline mode",
+		$failures,
+		$passes
+	);
+}
+
+$pipeline_tools = array(
+	'web_fetch'             => array( 'inc/Engine/AI/Tools/Global/WebFetch.php', 'DataMachine\Engine\AI\Tools\Global\WebFetch' ),
+	'wordpress_post_reader' => array( 'inc/Engine/AI/Tools/Global/WordPressPostReader.php', 'DataMachine\Engine\AI\Tools\Global\WordPressPostReader' ),
+	'image_generation'      => array( 'inc/Engine/AI/Tools/Global/ImageGeneration.php', 'DataMachine\Engine\AI\Tools\Global\ImageGeneration' ),
+	'google_search'         => array( 'inc/Engine/AI/Tools/Global/GoogleSearch.php', 'DataMachine\Engine\AI\Tools\Global\GoogleSearch' ),
+	'google_analytics'      => array( 'inc/Engine/AI/Tools/Global/GoogleAnalytics.php', 'DataMachine\Engine\AI\Tools\Global\GoogleAnalytics' ),
+	'google_search_console' => array( 'inc/Engine/AI/Tools/Global/GoogleSearchConsole.php', 'DataMachine\Engine\AI\Tools\Global\GoogleSearchConsole' ),
+	'bing_webmaster'        => array( 'inc/Engine/AI/Tools/Global/BingWebmaster.php', 'DataMachine\Engine\AI\Tools\Global\BingWebmaster' ),
+	'pagespeed'             => array( 'inc/Engine/AI/Tools/Global/PageSpeed.php', 'DataMachine\Engine\AI\Tools\Global\PageSpeed' ),
+	'local_search'          => array( 'inc/Engine/AI/Tools/Global/LocalSearch.php', 'DataMachine\Engine\AI\Tools\Global\LocalSearch' ),
+	'internal_link_audit'   => array( 'inc/Engine/AI/Tools/Global/InternalLinkAudit.php', 'DataMachine\Engine\AI\Tools\Global\InternalLinkAudit' ),
+	'amazon_affiliate_link' => array( 'inc/Engine/AI/Tools/Global/AmazonAffiliateLink.php', 'DataMachine\Engine\AI\Tools\Global\AmazonAffiliateLink' ),
+);
+
+foreach ( $pipeline_tools as $tool => [ $path, $class_name ] ) {
+	load_global_tool_for_pipeline_modes( $path, $class_name );
+}
+
+$resolved_pipeline_tools = resolve_tools_for_pipeline_modes( 'pipeline' );
+foreach ( $pipeline_tools as $tool => $unused ) {
+	assert_true_for_pipeline_modes(
+		isset( $resolved_pipeline_tools[ $tool ] ),
+		"{$tool} remains pipeline-visible",
+		$failures,
+		$passes
+	);
+}
+
+assert_true_for_pipeline_modes(
+	file_contains_for_pipeline_modes( 'inc/Core/Steps/AI/Directives/PipelineMemoryFilesDirective.php', "'modes'    => array( 'pipeline' )" ),
+	'pipeline memory directive remains pipeline-scoped context injection',
+	$failures,
+	$passes
+);
+assert_true_for_pipeline_modes(
+	file_contains_for_pipeline_modes( 'inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php', "'modes'    => array( 'pipeline' )" ),
+	'flow memory directive remains pipeline-scoped context injection',
+	$failures,
+	$passes
+);
+assert_true_for_pipeline_modes(
+	file_contains_for_pipeline_modes( 'inc/Engine/AI/Directives/AgentDailyMemoryDirective.php', "'modes'    => array( 'chat', 'pipeline' )" ),
+	'daily memory directive remains opt-in pipeline context injection',
+	$failures,
+	$passes
+);
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAILURES:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\n{$passes} assertions passed.\n";


### PR DESCRIPTION
## Summary

- Removes pipeline-mode visibility from global tools that are chat affordances or duplicate pipeline-engine behavior.
- Keeps source/search/content enrichment tools pipeline-visible and documents the static/global tool contract.

## Changes

- Makes `queue_validator`, `agent_memory`, and `agent_daily_memory` chat-only.
- Leaves pipeline context injection in the pipeline/flow/daily memory directives instead of exposing memory write/read tools to every pipeline AI step.
- Adds a pure-PHP smoke test that exercises the `datamachine_tools` registration path and verifies audited tools resolve in chat mode but not pipeline mode.
- Refreshes tool-registration docs around explicit mode visibility.

## Tests

- `php -l inc/Engine/AI/Tools/Global/QueueValidator.php`
- `php -l inc/Engine/AI/Tools/Global/AgentMemory.php`
- `php -l inc/Engine/AI/Tools/Global/AgentDailyMemory.php`
- `php -l inc/Engine/AI/Tools/ToolServiceProvider.php`
- `php -l tests/global-tool-pipeline-modes-smoke.php`
- `php tests/global-tool-pipeline-modes-smoke.php` — 20 assertions passed
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@audit-global-pipeline-tools --changed-since origin/main`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@audit-global-pipeline-tools --changed-only --summary` — PHPCS passed and no baseline drift; command still exits non-zero because the ESLint leg reports baseline-equivalent `Unknown` findings for PHP/Markdown files.

Closes #1442

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited global tool mode declarations, implemented the scoped mode changes, added smoke coverage, updated docs, and ran verification. Chris remains responsible for review and merge.
