### PR TITLE
fix(ai): enforce snapshot pipeline tool policy

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -79,7 +79,7 @@ class AIStep extends Step {
 
 		// Model/provider resolved exclusively via mode system (agent → site → network).
 		// Pipeline-level model/provider fields are ignored — mode_models is the authority.
-		$mode_model = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
+		$mode_model    = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
 		$provider_name = $mode_model['provider'];
 		if ( empty( $provider_name ) ) {
 			do_action(
@@ -274,14 +274,17 @@ class AIStep extends Step {
 
 		$resolver        = new ToolPolicyResolver();
 		$available_tools = $resolver->resolve(
-			array(
-				'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
-				'agent_id'             => $agent_id,
-				'previous_step_config' => $previous_step_config,
-				'next_step_config'     => $next_step_config,
-				'pipeline_step_id'     => $pipeline_step_id,
-				'engine_data'          => $engine_data,
-				'categories'           => $tool_categories,
+			array_merge(
+				array(
+					'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+					'agent_id'             => $agent_id,
+					'previous_step_config' => $previous_step_config,
+					'next_step_config'     => $next_step_config,
+					'pipeline_step_id'     => $pipeline_step_id,
+					'engine_data'          => $engine_data,
+					'categories'           => $tool_categories,
+				),
+				ToolPolicyResolver::getPipelinePolicyArgs( $this->flow_step_config, $pipeline_step_config )
 			)
 		);
 
@@ -306,7 +309,7 @@ class AIStep extends Step {
 		}
 
 		// Model/provider resolved exclusively via mode system — pipeline config is ignored.
-		$mode_model = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
+		$mode_model    = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
 		$provider_name = $mode_model['provider'];
 		$model_name    = $mode_model['model'];
 

--- a/inc/Engine/AI/RequestInspector.php
+++ b/inc/Engine/AI/RequestInspector.php
@@ -101,14 +101,17 @@ class RequestInspector {
 
 		$resolver = new ToolPolicyResolver();
 		$tools    = $resolver->resolve(
-			array(
-				'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
-				'agent_id'             => $agent_id,
-				'previous_step_config' => $previous_step_config,
-				'next_step_config'     => $next_step_config,
-				'pipeline_step_id'     => $pipeline_step_id,
-				'engine_data'          => $engine->all(),
-				'categories'           => $tool_categories,
+			array_merge(
+				array(
+					'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+					'agent_id'             => $agent_id,
+					'previous_step_config' => $previous_step_config,
+					'next_step_config'     => $next_step_config,
+					'pipeline_step_id'     => $pipeline_step_id,
+					'engine_data'          => $engine->all(),
+					'categories'           => $tool_categories,
+				),
+				ToolPolicyResolver::getPipelinePolicyArgs( $flow_step_config, $pipeline_step_config )
 			)
 		);
 

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -144,6 +144,56 @@ class ToolPolicyResolver {
 	}
 
 	/**
+	 * Build snapshot-derived pipeline policy arguments.
+	 *
+	 * Pipeline execution must honor the flow/pipeline config captured in the
+	 * current engine snapshot. Do not re-read persisted pipeline rows here:
+	 * direct workflows use synthetic IDs, and historical jobs must inspect the
+	 * policy that existed when they ran.
+	 *
+	 * @param array $flow_step_config     Current flow step config snapshot.
+	 * @param array $pipeline_step_config Current pipeline step config snapshot.
+	 * @return array Resolver args containing allow_only/deny when configured.
+	 */
+	public static function getPipelinePolicyArgs( array $flow_step_config, array $pipeline_step_config ): array {
+		$args          = array();
+		$enabled_tools = FlowStepConfig::getEnabledTools( $flow_step_config );
+
+		if ( ! empty( $enabled_tools ) ) {
+			$args['allow_only'] = self::sanitizeToolList( $enabled_tools );
+		}
+
+		$deny = array_merge(
+			self::sanitizeToolList( is_array( $pipeline_step_config['disabled_tools'] ?? null ) ? $pipeline_step_config['disabled_tools'] : array() ),
+			self::sanitizeToolList( is_array( $flow_step_config['disabled_tools'] ?? null ) ? $flow_step_config['disabled_tools'] : array() )
+		);
+
+		if ( ! empty( $deny ) ) {
+			$args['deny'] = array_values( array_unique( $deny ) );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Sanitize a list of tool slugs.
+	 *
+	 * @param array $tools Raw tool names.
+	 * @return array<int, string> Clean tool names.
+	 */
+	private static function sanitizeToolList( array $tools ): array {
+		$clean = array();
+		foreach ( $tools as $tool ) {
+			if ( ! is_string( $tool ) || '' === $tool ) {
+				continue;
+			}
+			$clean[] = $tool;
+		}
+
+		return array_values( array_unique( $clean ) );
+	}
+
+	/**
 	 * Filter tools by their linked ability permissions.
 	 *
 	 * For each tool that declares an `ability` or `abilities` key, checks
@@ -288,9 +338,8 @@ class ToolPolicyResolver {
 	 * for fetch-type handlers).
 	 */
 	private function gatherPipelineTools( array $args ): array {
-		$available_tools  = array();
-		$pipeline_step_id = $args['pipeline_step_id'] ?? null;
-		$engine_data      = $args['engine_data'] ?? array();
+		$available_tools = array();
+		$engine_data     = $args['engine_data'] ?? array();
 
 		// Handler tools from adjacent steps (dynamic, resolved per-execution).
 		//
@@ -303,8 +352,8 @@ class ToolPolicyResolver {
 				continue;
 			}
 
-			$handler_slugs       = FlowStepConfig::getConfiguredHandlerSlugs( $step_config );
-			$cache_scope         = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
+			$handler_slugs = FlowStepConfig::getConfiguredHandlerSlugs( $step_config );
+			$cache_scope   = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
 
 			foreach ( $handler_slugs as $slug ) {
 				$handler_config = FlowStepConfig::getHandlerConfigForSlug( $step_config, $slug );
@@ -340,7 +389,7 @@ class ToolPolicyResolver {
 			if ( isset( $available_tools[ $tool_name ] ) ) {
 				continue;
 			}
-			if ( $this->tool_manager->is_tool_available( $tool_name, $pipeline_step_id ) ) {
+			if ( $this->tool_manager->is_tool_available( $tool_name, null ) ) {
 				$available_tools[ $tool_name ] = $tool_config;
 			}
 		}

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Pure-PHP smoke test for snapshot-based pipeline tool policy (#1445).
+ *
+ * Run with: php tests/pipeline-tool-policy-snapshot-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities\Flow {
+	if ( ! class_exists( QueueAbility::class, false ) ) {
+		class QueueAbility {
+			const SLOT_PROMPT_QUEUE       = 'prompt_queue';
+			const SLOT_CONFIG_PATCH_QUEUE = 'config_patch_queue';
+		}
+	}
+}
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		if ( 'datamachine_step_types' === $hook ) {
+			return array(
+				'ai'      => array( 'uses_handler' => false, 'multi_handler' => false ),
+				'fetch'   => array( 'uses_handler' => true, 'multi_handler' => false ),
+				'publish' => array( 'uses_handler' => true, 'multi_handler' => true ),
+				'upsert'  => array( 'uses_handler' => true, 'multi_handler' => true ),
+			);
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		// no-op for tests.
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( string $hook ): int {
+		return 1;
+	}
+}
+
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4(): string {
+		static $i = 0;
+		++$i;
+		return 'uuid-' . $i;
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
+require_once __DIR__ . '/../inc/Core/Steps/WorkflowConfigFactory.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
+
+use DataMachine\Core\Steps\WorkflowConfigFactory;
+use DataMachine\Engine\AI\Tools\ToolManager;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
+
+class SnapshotPolicyToolManager extends ToolManager {
+	/** @var array<int, string|null> */
+	public array $availability_contexts = array();
+
+	public function get_all_tools(): array {
+		return array(
+			'alpha_tool'  => array( 'modes' => array( 'pipeline' ) ),
+			'beta_tool'   => array( 'modes' => array( 'pipeline' ) ),
+			'danger_tool' => array( 'modes' => array( 'pipeline' ) ),
+			'chat_only'   => array( 'modes' => array( 'chat' ) ),
+		);
+	}
+
+	public function is_tool_available( string $tool_id, ?string $context_id = null ): bool {
+		$this->availability_contexts[] = $context_id;
+		return null === $context_id;
+	}
+
+	public function resolveHandlerTools( string $handler_slug, array $handler_config, array $engine_data, string $cache_scope = '' ): array {
+		return array();
+	}
+}
+
+$failures = array();
+$passes   = 0;
+
+function assert_policy_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function resolve_policy_tools_for_test( array $flow_step_config, array $pipeline_step_config, SnapshotPolicyToolManager $manager ): array {
+	$resolver = new ToolPolicyResolver( $manager );
+
+	return $resolver->resolve(
+		array_merge(
+			array(
+				'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
+				'agent_id'             => 0,
+				'previous_step_config' => null,
+				'next_step_config'     => null,
+				'pipeline_step_id'     => (string) ( $flow_step_config['pipeline_step_id'] ?? '' ),
+				'engine_data'          => array(),
+				'categories'           => array(),
+			),
+			ToolPolicyResolver::getPipelinePolicyArgs( $flow_step_config, $pipeline_step_config )
+		)
+	);
+}
+
+echo "pipeline-tool-policy-snapshot-smoke\n";
+
+echo "\n[1] non-empty enabled_tools narrows pipeline tools:\n";
+$manager = new SnapshotPolicyToolManager();
+$tools   = resolve_policy_tools_for_test(
+	array(
+		'step_type'        => 'ai',
+		'pipeline_step_id' => 'ephemeral_pipeline_0',
+		'enabled_tools'    => array( 'alpha_tool' ),
+	),
+	array(),
+	$manager
+);
+assert_policy_equals( array( 'alpha_tool' ), array_keys( $tools ), 'allowlist keeps only enabled tool', $failures, $passes );
+assert_policy_equals( array( null, null, null ), $manager->availability_contexts, 'pipeline availability does not pass context IDs', $failures, $passes );
+
+echo "\n[2] ephemeral workflow disabled_tools deny from snapshot:\n";
+$ephemeral = WorkflowConfigFactory::buildEphemeralConfigs(
+	array(
+		'steps' => array(
+			array(
+				'type'           => 'ai',
+				'enabled_tools'  => array(),
+				'disabled_tools' => array( 'danger_tool' ),
+			),
+		),
+	)
+);
+$flow_step_config     = $ephemeral['flow_config']['ephemeral_step_0'];
+$pipeline_step_config = $ephemeral['pipeline_config']['ephemeral_pipeline_0'];
+$manager              = new SnapshotPolicyToolManager();
+$tools                = resolve_policy_tools_for_test( $flow_step_config, $pipeline_step_config, $manager );
+assert_policy_equals( array( 'alpha_tool', 'beta_tool' ), array_keys( $tools ), 'ephemeral disabled_tools removes denied tool without DB row', $failures, $passes );
+assert_policy_equals( array( null, null, null ), $manager->availability_contexts, 'ephemeral policy never re-reads by synthetic pipeline step ID', $failures, $passes );
+
+echo "\n[3] persistent workflow disabled_tools still apply from snapshot:\n";
+$workflow = array(
+	'steps' => array(
+		array(
+			'type'           => 'ai',
+			'enabled_tools'  => array(),
+			'disabled_tools' => array( 'beta_tool' ),
+		),
+	),
+);
+$pipeline_config      = WorkflowConfigFactory::buildPersistentPipelineConfig( $workflow, 44 );
+$flow_config          = WorkflowConfigFactory::buildPersistentFlowConfig( $workflow, 44, 55, $pipeline_config );
+$pipeline_step_id     = array_key_first( $pipeline_config );
+$flow_step_id         = array_key_first( $flow_config );
+$manager              = new SnapshotPolicyToolManager();
+$tools                = resolve_policy_tools_for_test( $flow_config[ $flow_step_id ], $pipeline_config[ $pipeline_step_id ], $manager );
+assert_policy_equals( array( 'alpha_tool', 'danger_tool' ), array_keys( $tools ), 'persistent disabled_tools removes denied tool', $failures, $passes );
+assert_policy_equals( array( null, null, null ), $manager->availability_contexts, 'persistent policy does not re-read persisted step config', $failures, $passes );
+
+echo "\n[4] RequestInspector and AIStep share policy input helper:\n";
+$ai_step_source   = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' ) ?: '';
+$inspector_source = file_get_contents( __DIR__ . '/../inc/Engine/AI/RequestInspector.php' ) ?: '';
+assert_policy_equals( 1, substr_count( $ai_step_source, 'ToolPolicyResolver::getPipelinePolicyArgs' ), 'AIStep uses shared policy helper once', $failures, $passes );
+assert_policy_equals( 1, substr_count( $inspector_source, 'ToolPolicyResolver::getPipelinePolicyArgs' ), 'RequestInspector uses shared policy helper once', $failures, $passes );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " pipeline policy assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} pipeline policy assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Enforces AI `enabled_tools` as a non-empty pipeline allowlist.
- Resolves pipeline tool denies from the current engine snapshot instead of persisted pipeline-step DB reads.
- Keeps request inspection aligned with runtime AI tool policy.

## Changes
- Adds `ToolPolicyResolver::getPipelinePolicyArgs()` to derive `allow_only` and `deny` from the current flow/pipeline step snapshots.
- Threads the shared policy args through both `AIStep` and `RequestInspector`.
- Stops pipeline tool gathering from passing `pipeline_step_id` into `ToolManager::is_tool_available()`, avoiding stale DB re-reads during runtime resolution.
- Adds a pure-PHP smoke covering allowlist narrowing, ephemeral snapshot denies, persistent snapshot denies, and inspector/runtime helper parity.

## Tests
- `php -l inc/Engine/AI/Tools/ToolPolicyResolver.php && php -l inc/Core/Steps/AI/AIStep.php && php -l inc/Engine/AI/RequestInspector.php && php -l tests/pipeline-tool-policy-snapshot-smoke.php`
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `php tests/workflow-persistent-install-smoke.php`
- `php tests/system-task-config-passthrough-smoke.php`
- `git diff --check`
- `homeboy audit data-machine --path "/Users/chubes/Developer/data-machine@fix-pipeline-tool-policy-snapshot" --changed-since origin/main`

`homeboy lint data-machine --path "/Users/chubes/Developer/data-machine@fix-pipeline-tool-policy-snapshot"` still fails on the repository's existing broad PHPStan smoke-test findings (6,585 findings), unrelated to this change.

Closes #1445

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the snapshot-based policy change, adding smoke coverage, and running focused verification. Chris remains responsible for review and merge.
