### PR TITLE
fix(ai): preserve required handler tools

### DIFF
--- a/docs/architecture/policy-resolvers.md
+++ b/docs/architecture/policy-resolvers.md
@@ -111,7 +111,9 @@ The ladders look similar because they are similar. They are not identical, and t
 
 Resolvers that gate by category (`ToolPolicyResolver`, `ActionPolicyResolver`) walk a tool's `ability` and `abilities` keys, look up each slug in `WP_Abilities_Registry::get_instance()`, and read `get_category()` on the ability. A tool's category is whatever its linked ability declares — there is no separate "tool category" registry.
 
-Tools without a linked ability are excluded when category filtering is active (they cannot be categorized) unless explicitly allow-listed. Handler tools (those with a `handler` key but no `ability` key) bypass category filtering — they are dynamically scoped by the pipeline engine to adjacent step handlers.
+Tools without a linked ability are excluded when category filtering is active (they cannot be categorized) unless explicitly allow-listed. Handler tools (those with a `handler` key but no `ability` key) are the exception: in pipeline mode they are required flow plumbing resolved from adjacent steps, so they bypass agent `tool_policy`, context category filtering, and context `allow_only` filtering. The flow shape decides whether they exist; optional/global tool policy only narrows research and utility tools.
+
+If a publish/upsert handler is required by the adjacent flow shape but no AI-callable handler tool is available, the AI step fails before the model call. Runtime and request inspection both use `FlowStepConfig::getMissingRequiredHandlerSlugsForAi()` so the inspector reports the same failure state the runtime would hit.
 
 ### 5. Mode-aware (`pipeline` / `chat` / `system`)
 
@@ -153,6 +155,7 @@ Each resolver invented something the others don't have. None of those inventions
 - An ability-permission gate (`filterByAbilityPermissions()`) that runs only in `chat` mode.
 - An `access_level` fallback (`public` / `authenticated` / `author` / `editor` / `admin`) for tools without a linked ability.
 - A category-aware `applyAgentPolicy()` that supports `tools[]` and `categories[]` composing in either deny or allow mode.
+- A pipeline handler-tool exception: adjacent handler tools are preserved through agent allow/deny policy and context allow/category filters because they are required flow plumbing, not optional global tools.
 
 `MemoryPolicyResolver` has:
 

--- a/docs/core-system/tool-execution.md
+++ b/docs/core-system/tool-execution.md
@@ -96,6 +96,18 @@ add_filter('datamachine_tools', function($tools) {
 against the adjacent pipeline step's `handler_slug` (or `handler_types` for
 cross-cutting tools like `skip_item`).
 
+Adjacent handler tools are **flow plumbing**, not optional global tools. In
+pipeline mode they bypass agent `tool_policy`, context `tool_categories`, and
+context `allow_only` filtering because the adjacent flow shape requires them for
+publish/upsert completion. Static/global pipeline tools still pass those policy
+layers normally.
+
+If a required adjacent publish/upsert handler has no AI-callable handler tool,
+the AI step fails before the model call with `required_handler_tool_unavailable`.
+The request inspector uses the same missing-handler check, so `wp datamachine ai
+inspect-request` reports the same unavailable-handler state without dispatching
+to a provider.
+
 #### 2. Global Tools (All Agents)
 
 Tools registered via `datamachine_global_tools` filter, available to all AI agents:

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -79,7 +79,7 @@ class AIStep extends Step {
 
 		// Model/provider resolved exclusively via mode system (agent → site → network).
 		// Pipeline-level model/provider fields are ignored — mode_models is the authority.
-		$mode_model = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
+		$mode_model    = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
 		$provider_name = $mode_model['provider'];
 		if ( empty( $provider_name ) ) {
 			do_action(
@@ -290,8 +290,8 @@ class AIStep extends Step {
 					$this->job_id,
 					'required_handler_tool_unavailable',
 					array(
-						'flow_step_id'                  => $this->flow_step_id,
-						'pipeline_step_id'              => $pipeline_step_id,
+						'flow_step_id'                   => $this->flow_step_id,
+						'pipeline_step_id'               => $pipeline_step_id,
 						'required_handler_slugs'         => $required_handler_slugs,
 						'missing_required_handler_slugs' => $missing_handler_slugs,
 						'available_handler_tool_slugs'   => FlowStepConfig::getAvailableRequiredHandlerSlugsForAi( $required_handler_slugs, $available_tools ),
@@ -310,7 +310,7 @@ class AIStep extends Step {
 		}
 
 		// Model/provider resolved exclusively via mode system — pipeline config is ignored.
-		$mode_model = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
+		$mode_model    = PluginSettings::resolveModelForAgentMode( $agent_id, 'pipeline' );
 		$provider_name = $mode_model['provider'];
 		$model_name    = $mode_model['model'];
 

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -254,14 +254,7 @@ class AIStep extends Step {
 		$next_step_config  = $next_flow_step_id ? $this->engine->getFlowStepConfig( $next_flow_step_id ) : null;
 
 		// Collect required handler slugs from adjacent steps for completion tracking.
-		$required_handler_slugs = array();
-		foreach ( array( $previous_step_config, $next_step_config ) as $adj_step_config ) {
-			if ( ! $adj_step_config ) {
-				continue;
-			}
-			$handler_slugs          = FlowStepConfig::getRequiredHandlerSlugsForAi( $adj_step_config );
-			$required_handler_slugs = array_merge( $required_handler_slugs, $handler_slugs );
-		}
+		$required_handler_slugs = FlowStepConfig::getAdjacentRequiredHandlerSlugsForAi( $previous_step_config, $next_step_config );
 
 		$engine_data = $this->engine->all();
 
@@ -285,20 +278,31 @@ class AIStep extends Step {
 			)
 		);
 
-		// Filter required handler slugs to only those that are actual AI tools.
-		// Previous-step handler slugs (e.g. 'universal_web_scraper') are
-		// pipeline-level fetch handlers, not AI-callable tools. Including
-		// them in configured_handlers causes the conversation loop to wait
-		// forever for a handler that can never fire, resulting in the AI
-		// calling the same handler tool on every turn until max_turns.
-		// See: https://github.com/Extra-Chill/data-machine/issues/1108
+		// Required adjacent handler tools are flow plumbing, not optional research
+		// tools. If a publish/upsert handler required by the flow shape cannot be
+		// exposed to the model, fail before the model call instead of silently
+		// narrowing completion tracking to the visible subset.
 		if ( ! empty( $required_handler_slugs ) ) {
-			$ai_tool_handler_slugs = array_values(
-				array_intersect(
-					array_unique( $required_handler_slugs ),
-					array_keys( $available_tools )
-				)
-			);
+			$missing_handler_slugs = FlowStepConfig::getMissingRequiredHandlerSlugsForAi( $required_handler_slugs, $available_tools );
+			if ( ! empty( $missing_handler_slugs ) ) {
+				do_action(
+					'datamachine_fail_job',
+					$this->job_id,
+					'required_handler_tool_unavailable',
+					array(
+						'flow_step_id'                  => $this->flow_step_id,
+						'pipeline_step_id'              => $pipeline_step_id,
+						'required_handler_slugs'         => $required_handler_slugs,
+						'missing_required_handler_slugs' => $missing_handler_slugs,
+						'available_handler_tool_slugs'   => FlowStepConfig::getAvailableRequiredHandlerSlugsForAi( $required_handler_slugs, $available_tools ),
+						'error_message'                  => 'AI step requires adjacent handler tools that are not available to the model.',
+					)
+				);
+
+				return array();
+			}
+
+			$ai_tool_handler_slugs = FlowStepConfig::getAvailableRequiredHandlerSlugsForAi( $required_handler_slugs, $available_tools );
 
 			if ( ! empty( $ai_tool_handler_slugs ) ) {
 				$payload['configured_handler_slugs'] = $ai_tool_handler_slugs;

--- a/inc/Core/Steps/FlowStepConfig.php
+++ b/inc/Core/Steps/FlowStepConfig.php
@@ -220,6 +220,79 @@ class FlowStepConfig {
 	}
 
 	/**
+	 * Resolve required handler slugs from the steps adjacent to an AI step.
+	 *
+	 * @param array|null $previous_step_config Previous adjacent flow step config.
+	 * @param array|null $next_step_config     Next adjacent flow step config.
+	 * @return array<int, string> Unique required handler slugs.
+	 */
+	public static function getAdjacentRequiredHandlerSlugsForAi( ?array $previous_step_config, ?array $next_step_config ): array {
+		$required_handler_slugs = array();
+
+		foreach ( array( $previous_step_config, $next_step_config ) as $adjacent_step_config ) {
+			if ( ! $adjacent_step_config ) {
+				continue;
+			}
+
+			$required_handler_slugs = array_merge(
+				$required_handler_slugs,
+				self::getRequiredHandlerSlugsForAi( $adjacent_step_config )
+			);
+		}
+
+		return array_values( array_unique( self::sanitizeSlugList( $required_handler_slugs ) ) );
+	}
+
+	/**
+	 * Return required handler slugs that are available as AI-callable tools.
+	 *
+	 * Completion tracking is keyed by handler slug, not by tool name: a handler
+	 * tool may expose a model-facing name that differs from the handler slug while
+	 * still carrying `handler => <slug>` metadata for the runtime.
+	 *
+	 * @param array<int, string> $required_handler_slugs Required handler slugs.
+	 * @param array             $available_tools         Resolved tools keyed by tool name.
+	 * @return array<int, string> Required handler slugs present in the tool set.
+	 */
+	public static function getAvailableRequiredHandlerSlugsForAi( array $required_handler_slugs, array $available_tools ): array {
+		$required_handler_slugs = array_values( array_unique( self::sanitizeSlugList( $required_handler_slugs ) ) );
+		if ( empty( $required_handler_slugs ) ) {
+			return array();
+		}
+
+		$available_handler_slugs = array();
+		foreach ( $available_tools as $tool_config ) {
+			if ( ! is_array( $tool_config ) ) {
+				continue;
+			}
+
+			$handler_slug = $tool_config['handler'] ?? '';
+			if ( is_string( $handler_slug ) && '' !== $handler_slug ) {
+				$available_handler_slugs[] = $handler_slug;
+			}
+		}
+
+		return array_values( array_intersect( $required_handler_slugs, array_unique( $available_handler_slugs ) ) );
+	}
+
+	/**
+	 * Return required handler slugs that are not available as AI-callable tools.
+	 *
+	 * @param array<int, string> $required_handler_slugs Required handler slugs.
+	 * @param array             $available_tools         Resolved tools keyed by tool name.
+	 * @return array<int, string> Missing required handler slugs.
+	 */
+	public static function getMissingRequiredHandlerSlugsForAi( array $required_handler_slugs, array $available_tools ): array {
+		$required_handler_slugs = array_values( array_unique( self::sanitizeSlugList( $required_handler_slugs ) ) );
+		if ( empty( $required_handler_slugs ) ) {
+			return array();
+		}
+
+		$available_required = self::getAvailableRequiredHandlerSlugsForAi( $required_handler_slugs, $available_tools );
+		return array_values( array_diff( $required_handler_slugs, $available_required ) );
+	}
+
+	/**
 	 * Get the primary handler config from a step config.
 	 *
 	 * @param array $step_config Step configuration array.

--- a/inc/Engine/AI/RequestInspector.php
+++ b/inc/Engine/AI/RequestInspector.php
@@ -112,14 +112,23 @@ class RequestInspector {
 			)
 		);
 
-		$required_handler_slugs = array();
-		foreach ( array( $previous_step_config, $next_step_config ) as $adjacent_config ) {
-			if ( $adjacent_config ) {
-				$required_handler_slugs = array_merge( $required_handler_slugs, FlowStepConfig::getRequiredHandlerSlugsForAi( $adjacent_config ) );
-			}
-		}
+		$required_handler_slugs = FlowStepConfig::getAdjacentRequiredHandlerSlugsForAi( $previous_step_config, $next_step_config );
 		if ( ! empty( $required_handler_slugs ) ) {
-			$handler_tool_slugs = array_values( array_intersect( array_unique( $required_handler_slugs ), array_keys( $tools ) ) );
+			$missing_handler_slugs = FlowStepConfig::getMissingRequiredHandlerSlugsForAi( $required_handler_slugs, $tools );
+			if ( ! empty( $missing_handler_slugs ) ) {
+				return array(
+					'success'                       => false,
+					'error'                         => 'AI step requires adjacent handler tools that are not available to the model.',
+					'job_id'                        => $job_id,
+					'flow_step_id'                  => $flow_step_id,
+					'step_id'                       => $pipeline_step_id,
+					'required_handler_slugs'         => $required_handler_slugs,
+					'missing_required_handler_slugs' => $missing_handler_slugs,
+					'available_handler_tool_slugs'   => FlowStepConfig::getAvailableRequiredHandlerSlugsForAi( $required_handler_slugs, $tools ),
+				);
+			}
+
+			$handler_tool_slugs = FlowStepConfig::getAvailableRequiredHandlerSlugsForAi( $required_handler_slugs, $tools );
 			if ( ! empty( $handler_tool_slugs ) ) {
 				$payload['configured_handler_slugs'] = $handler_tool_slugs;
 			}

--- a/inc/Engine/AI/RequestInspector.php
+++ b/inc/Engine/AI/RequestInspector.php
@@ -117,11 +117,11 @@ class RequestInspector {
 			$missing_handler_slugs = FlowStepConfig::getMissingRequiredHandlerSlugsForAi( $required_handler_slugs, $tools );
 			if ( ! empty( $missing_handler_slugs ) ) {
 				return array(
-					'success'                       => false,
-					'error'                         => 'AI step requires adjacent handler tools that are not available to the model.',
-					'job_id'                        => $job_id,
-					'flow_step_id'                  => $flow_step_id,
-					'step_id'                       => $pipeline_step_id,
+					'success'                        => false,
+					'error'                          => 'AI step requires adjacent handler tools that are not available to the model.',
+					'job_id'                         => $job_id,
+					'flow_step_id'                   => $flow_step_id,
+					'step_id'                        => $pipeline_step_id,
 					'required_handler_slugs'         => $required_handler_slugs,
 					'missing_required_handler_slugs' => $missing_handler_slugs,
 					'available_handler_tool_slugs'   => FlowStepConfig::getAvailableRequiredHandlerSlugsForAi( $required_handler_slugs, $tools ),

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -305,8 +305,8 @@ class ToolPolicyResolver {
 				continue;
 			}
 
-			$handler_slugs       = FlowStepConfig::getConfiguredHandlerSlugs( $step_config );
-			$cache_scope         = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
+			$handler_slugs = FlowStepConfig::getConfiguredHandlerSlugs( $step_config );
+			$cache_scope   = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
 
 			foreach ( $handler_slugs as $slug ) {
 				$handler_config = FlowStepConfig::getHandlerConfigForSlug( $step_config, $slug );

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -114,6 +114,8 @@ class ToolPolicyResolver {
 		}
 
 		// 3. Apply per-agent tool policy (from agent_config).
+		// Pipeline handler tools are required flow plumbing derived from adjacent
+		// steps, so per-agent allow/deny policy only filters optional tools.
 		if ( $agent_id > 0 ) {
 			$agent_policy = $this->getAgentToolPolicy( $agent_id );
 			$tools        = $this->applyAgentPolicy( $tools, $agent_policy );
@@ -126,10 +128,10 @@ class ToolPolicyResolver {
 			$tools = $this->filterByAbilityCategories( $tools, $categories );
 		}
 
-		// 5. Apply allowlist if specified (narrows to explicit subset).
+		// 5. Apply allowlist if specified (narrows optional tools to explicit subset).
 		$allow_only = $args['allow_only'] ?? array();
 		if ( ! empty( $allow_only ) ) {
-			$tools = array_intersect_key( $tools, array_flip( $allow_only ) );
+			$tools = $this->filterByAllowOnlyPreservingHandlerTools( $tools, $allow_only );
 		}
 
 		// 6. Apply deny list (always wins).
@@ -422,7 +424,7 @@ class ToolPolicyResolver {
 
 			// Handler tools bypass category filtering — they're already scoped
 			// by the pipeline engine to adjacent step handlers.
-			if ( isset( $tool['handler'] ) && ! isset( $tool['ability'] ) && ! isset( $tool['abilities'] ) ) {
+			if ( self::isPipelineHandlerTool( $tool ) ) {
 				$filtered[ $name ] = $tool;
 				continue;
 			}
@@ -547,18 +549,20 @@ class ToolPolicyResolver {
 		$mode              = $policy['mode'];
 		$tool_names        = $policy['tools'] ?? array();
 		$policy_categories = $policy['categories'] ?? array();
+		$handler_tools     = $this->getPipelineHandlerTools( $tools );
+		$optional_tools    = array_diff_key( $tools, $handler_tools );
 
-		// No tool names and no categories = no restrictions (deny) or no tools (allow).
+		// No tool names and no categories = no restrictions (deny) or no optional tools (allow).
 		if ( empty( $tool_names ) && empty( $policy_categories ) ) {
-			return 'allow' === $mode ? array() : $tools;
+			return 'allow' === $mode ? $handler_tools : $tools;
 		}
 
 		// Simple case: no categories, just tool names (original behavior).
 		if ( empty( $policy_categories ) ) {
 			if ( 'deny' === $mode ) {
-				return array_diff_key( $tools, array_flip( $tool_names ) );
+				return $handler_tools + array_diff_key( $optional_tools, array_flip( $tool_names ) );
 			}
-			return array_intersect_key( $tools, array_flip( $tool_names ) );
+			return $handler_tools + array_intersect_key( $optional_tools, array_flip( $tool_names ) );
 		}
 
 		// Category-aware filtering: check both tool names and categories.
@@ -567,7 +571,7 @@ class ToolPolicyResolver {
 		$categories_flip = array_flip( $policy_categories );
 		$filtered        = array();
 
-		foreach ( $tools as $name => $tool ) {
+		foreach ( $optional_tools as $name => $tool ) {
 			$matches_tool = isset( $tool_names_flip[ $name ] );
 			$matches_cat  = false;
 
@@ -599,7 +603,48 @@ class ToolPolicyResolver {
 			}
 		}
 
-		return $filtered;
+		return $handler_tools + $filtered;
+	}
+
+	/**
+	 * Return whether a tool is a pipeline handler tool resolved from adjacency.
+	 *
+	 * Handler tools are flow plumbing: they are controlled by the adjacent flow
+	 * shape and carry handler metadata for completion tracking. Optional/global
+	 * tool policy should not remove them.
+	 *
+	 * @param array $tool Tool definition.
+	 * @return bool Whether this is an adjacent handler tool.
+	 */
+	private static function isPipelineHandlerTool( array $tool ): bool {
+		return isset( $tool['handler'] ) && ! isset( $tool['ability'] ) && ! isset( $tool['abilities'] );
+	}
+
+	/**
+	 * Extract adjacent pipeline handler tools from a resolved tool set.
+	 *
+	 * @param array $tools Tool definitions keyed by tool name.
+	 * @return array Handler tools keyed by tool name.
+	 */
+	private function getPipelineHandlerTools( array $tools ): array {
+		return array_filter(
+			$tools,
+			static fn( $tool ) => is_array( $tool ) && self::isPipelineHandlerTool( $tool )
+		);
+	}
+
+	/**
+	 * Apply an allow-only list while preserving adjacent handler tools.
+	 *
+	 * @param array $tools      Tool definitions keyed by tool name.
+	 * @param array $allow_only Optional/global tool names to allow.
+	 * @return array Filtered tools.
+	 */
+	private function filterByAllowOnlyPreservingHandlerTools( array $tools, array $allow_only ): array {
+		$handler_tools  = $this->getPipelineHandlerTools( $tools );
+		$optional_tools = array_diff_key( $tools, $handler_tools );
+
+		return $handler_tools + array_intersect_key( $optional_tools, array_flip( $allow_only ) );
 	}
 
 	/**

--- a/tests/adjacent-handler-tool-policy-smoke.php
+++ b/tests/adjacent-handler-tool-policy-smoke.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Pure-PHP smoke test for adjacent handler tool policy semantics (#1444).
+ *
+ * Run with: php tests/adjacent-handler-tool-policy-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Engine\AI\Tools {
+	if ( ! class_exists( ToolManager::class ) ) {
+		class ToolManager {}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	function do_action( string $_hook, ...$_args ): void {}
+
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_step_types' !== $hook ) {
+			return $value;
+		}
+
+		return array(
+			'ai'           => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'system_task'  => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'webhook_gate' => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'fetch'        => array( 'uses_handler' => true, 'multi_handler' => false ),
+			'publish'      => array( 'uses_handler' => true, 'multi_handler' => true ),
+			'upsert'       => array( 'uses_handler' => true, 'multi_handler' => true ),
+		);
+	}
+
+	require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+	require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
+
+	$failures = array();
+	$passes   = 0;
+
+	function assert_same_policy( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+		if ( $expected === $actual ) {
+			++$passes;
+			echo "  ✓ {$name}\n";
+			return;
+		}
+
+		$failures[] = $name;
+		echo "  ✗ {$name}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	}
+
+	echo "Adjacent handler tool policy smoke (#1444)\n";
+	echo "-------------------------------------------\n";
+
+	$resolver = new \DataMachine\Engine\AI\Tools\ToolPolicyResolver( new \DataMachine\Engine\AI\Tools\ToolManager() );
+	$tools    = array(
+		'publish_to_wordpress' => array(
+			'handler'     => 'wordpress_publish',
+			'description' => 'Publish through adjacent WordPress handler',
+		),
+		'web_fetch'            => array(
+			'ability'     => 'datamachine/web-fetch',
+			'description' => 'Optional research tool',
+		),
+	);
+
+	echo "\n[1] Agent tool_policy cannot remove adjacent handler tools:\n";
+	$filtered = $resolver->applyAgentPolicy(
+		$tools,
+		array(
+			'mode'  => 'deny',
+			'tools' => array( 'publish_to_wordpress', 'web_fetch' ),
+		)
+	);
+	assert_same_policy( true, isset( $filtered['publish_to_wordpress'] ), 'deny policy preserves handler tool', $failures, $passes );
+	assert_same_policy( false, isset( $filtered['web_fetch'] ), 'deny policy still removes optional tool', $failures, $passes );
+
+	$filtered = $resolver->applyAgentPolicy(
+		$tools,
+		array(
+			'mode'  => 'allow',
+			'tools' => array(),
+		)
+	);
+	assert_same_policy( array( 'publish_to_wordpress' ), array_keys( $filtered ), 'empty allow policy keeps only handler plumbing', $failures, $passes );
+
+	echo "\n[2] Context allow_only cannot remove adjacent handler tools:\n";
+	$method   = new ReflectionMethod( \DataMachine\Engine\AI\Tools\ToolPolicyResolver::class, 'filterByAllowOnlyPreservingHandlerTools' );
+	$filtered = $method->invoke( $resolver, $tools, array( 'web_fetch' ) );
+	assert_same_policy( true, isset( $filtered['publish_to_wordpress'] ), 'allow_only preserves handler tool', $failures, $passes );
+	assert_same_policy( true, isset( $filtered['web_fetch'] ), 'allow_only keeps explicitly allowed optional tool', $failures, $passes );
+
+	echo "\n[3] Required handler availability is checked by handler metadata:\n";
+	$publish_step = array(
+		'step_type'     => 'publish',
+		'handler_slugs' => array( 'wordpress_publish' ),
+	);
+	$required     = \DataMachine\Core\Steps\FlowStepConfig::getAdjacentRequiredHandlerSlugsForAi( null, $publish_step );
+	assert_same_policy( array( 'wordpress_publish' ), $required, 'publish step declares required handler slug', $failures, $passes );
+	assert_same_policy( array( 'wordpress_publish' ), \DataMachine\Core\Steps\FlowStepConfig::getAvailableRequiredHandlerSlugsForAi( $required, $tools ), 'tool name may differ when handler metadata matches', $failures, $passes );
+	assert_same_policy( array(), \DataMachine\Core\Steps\FlowStepConfig::getMissingRequiredHandlerSlugsForAi( $required, $tools ), 'available handler metadata reports no missing slug', $failures, $passes );
+	assert_same_policy( array( 'wordpress_publish' ), \DataMachine\Core\Steps\FlowStepConfig::getMissingRequiredHandlerSlugsForAi( $required, array() ), 'missing required handler reports diagnostic slug', $failures, $passes );
+
+	echo "\n[4] Runtime and inspector use the same failure helper:\n";
+	$ai_step_source   = (string) file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' );
+	$inspector_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/RequestInspector.php' );
+	assert_same_policy( true, false !== strpos( $ai_step_source, 'getMissingRequiredHandlerSlugsForAi' ), 'AIStep checks missing required handler tools before model call', $failures, $passes );
+	assert_same_policy( true, false !== strpos( $inspector_source, 'getMissingRequiredHandlerSlugsForAi' ), 'RequestInspector checks the same missing handler state', $failures, $passes );
+	assert_same_policy( false, false !== strpos( $ai_step_source, 'array_keys( $available_tools )' ), 'AIStep no longer silently narrows by visible tool names', $failures, $passes );
+
+	echo "\n-------------------------------------------\n";
+	$total = $passes + count( $failures );
+	echo "{$passes} / {$total} passed\n";
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFailures:\n";
+		foreach ( $failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\nAll assertions passed.\n";
+}

--- a/tests/ai-required-handlers-smoke.php
+++ b/tests/ai-required-handlers-smoke.php
@@ -58,27 +58,6 @@ function assert_not_contains( string $needle, string $haystack, string $name, ar
 	assert_equals( false, str_contains( $haystack, $needle ), $name, $failures, $passes );
 }
 
-function resolve_required_ai_handler_tools_for_test( ?array $previous_step_config, ?array $next_step_config, array $available_tools ): array {
-	$required_handler_slugs = array();
-	foreach ( array( $previous_step_config, $next_step_config ) as $adjacent_step_config ) {
-		if ( ! $adjacent_step_config ) {
-			continue;
-		}
-
-		$required_handler_slugs = array_merge(
-			$required_handler_slugs,
-			FlowStepConfig::getRequiredHandlerSlugsForAi( $adjacent_step_config )
-		);
-	}
-
-	return array_values(
-		array_intersect(
-			array_unique( $required_handler_slugs ),
-			array_keys( $available_tools )
-		)
-	);
-}
-
 echo "AI required handlers smoke\n";
 echo "--------------------------\n";
 
@@ -132,22 +111,58 @@ assert_equals(
 );
 
 $available_tools = array(
-	'wordpress_update' => array( 'handler' => 'wordpress_update' ),
-	'notion_update'    => array( 'handler' => 'notion_update' ),
+	'wordpress_update_tool' => array( 'handler' => 'wordpress_update' ),
+	'notion_update_tool'    => array( 'handler' => 'notion_update' ),
+);
+$required_handler_slugs = FlowStepConfig::getAdjacentRequiredHandlerSlugsForAi( null, $upsert_step );
+assert_equals(
+	array( 'notion_update' ),
+	$required_handler_slugs,
+	'adjacent helper resolves required upsert handler slug',
+	$failures,
+	$passes
 );
 assert_equals(
 	array( 'notion_update' ),
-	resolve_required_ai_handler_tools_for_test( null, $upsert_step, $available_tools ),
-	'AIStep-style payload tracks only required upsert handler tools',
+	FlowStepConfig::getAvailableRequiredHandlerSlugsForAi( $required_handler_slugs, $available_tools ),
+	'AIStep-style payload tracks required handler slugs via tool metadata, not tool names',
+	$failures,
+	$passes
+);
+assert_equals(
+	array(),
+	FlowStepConfig::getMissingRequiredHandlerSlugsForAi( $required_handler_slugs, $available_tools ),
+	'available required handler tools report no missing slugs',
+	$failures,
+	$passes
+);
+assert_equals(
+	array( 'notion_update' ),
+	FlowStepConfig::getMissingRequiredHandlerSlugsForAi( $required_handler_slugs, array() ),
+	'missing required handler tools are reported instead of silently dropped',
 	$failures,
 	$passes
 );
 
-$ai_step_source = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' );
+$ai_step_source = (string) file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' );
 assert_contains(
-	'FlowStepConfig::getRequiredHandlerSlugsForAi( $adj_step_config )',
+	'FlowStepConfig::getAdjacentRequiredHandlerSlugsForAi( $previous_step_config, $next_step_config )',
 	$ai_step_source,
-	'AIStep resolves adjacent required handlers through FlowStepConfig',
+	'AIStep resolves adjacent required handlers through shared FlowStepConfig helper',
+	$failures,
+	$passes
+);
+assert_contains(
+	'FlowStepConfig::getMissingRequiredHandlerSlugsForAi( $required_handler_slugs, $available_tools )',
+	$ai_step_source,
+	'AIStep fails before model call when required handler tools are unavailable',
+	$failures,
+	$passes
+);
+assert_not_contains(
+	'array_keys( $available_tools )',
+	$ai_step_source,
+	'AIStep no longer intersects required handlers against post-policy tool names',
 	$failures,
 	$passes
 );


### PR DESCRIPTION
## Summary
- Defines adjacent handler tools as required pipeline flow plumbing, not optional global/research tools.
- Fails AI request assembly before the model call when a required adjacent handler tool cannot be exposed.

## Changes
- Preserves adjacent handler tools through agent `tool_policy`, context `tool_categories`, and context `allow_only` filtering.
- Adds shared `FlowStepConfig` helpers for required adjacent handler discovery, availability, and missing-handler diagnostics.
- Updates `AIStep` and `RequestInspector` to use the same required-handler availability check.
- Documents the handler-tool policy contract in policy resolver and tool execution docs.
- Adds smoke coverage for policy preservation, metadata-based handler availability, and runtime/inspector consistency.

## Tests
- `php -l inc/Core/Steps/FlowStepConfig.php && php -l inc/Core/Steps/AI/AIStep.php && php -l inc/Engine/AI/RequestInspector.php && php -l inc/Engine/AI/Tools/ToolPolicyResolver.php && php -l tests/adjacent-handler-tool-policy-smoke.php`
- `php tests/adjacent-handler-tool-policy-smoke.php`
- `php tests/ai-required-handlers-smoke.php`
- `php tests/tool-policy-resolver-adjacency-smoke.php`
- `php tests/ai-request-inspector-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-handler-tool-policy-contract --changed-since origin/main` — PHPCS passed and baseline drift did not increase; command still exits non-zero because the lint runner invokes ESLint against non-JS changed files.

Closes #1444

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the handler-tool policy contract, smoke coverage, docs, and verification steps for Chris to review.
