### PR TITLE
feat(admin): show AI tool policy summary

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineStepCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineStepCard.jsx
@@ -19,6 +19,54 @@ import { updateSystemPrompt } from '../../utils/api';
 import { useStepTypes } from '../../queries/config';
 
 /**
+ * Normalize a tool policy field into displayable labels.
+ *
+ * @param {Array|string|Object} value Tool policy field value.
+ * @return {Array<string>} Display labels.
+ */
+const normalizeToolPolicyList = ( value ) => {
+	if ( Array.isArray( value ) ) {
+		return value.filter( Boolean ).map( String );
+	}
+
+	if ( typeof value === 'string' && value ) {
+		return [ value ];
+	}
+
+	if ( value && typeof value === 'object' ) {
+		return Object.entries( value )
+			.filter( ( [ , enabled ] ) => Boolean( enabled ) )
+			.map( ( [ key ] ) => key );
+	}
+
+	return [];
+};
+
+/**
+ * Render a read-only tool policy row.
+ *
+ * @param {string}        label  Policy label.
+ * @param {Array<string>} values Policy values.
+ * @return {React.ReactElement|null} Policy row.
+ */
+const renderToolPolicyRow = ( label, values ) => {
+	if ( ! values.length ) {
+		return null;
+	}
+
+	return (
+		<div className="datamachine-ai-tool-policy-row">
+			<strong>{ label }</strong>
+			<div className="datamachine-ai-tool-policy-values">
+				{ values.map( ( value ) => (
+					<code key={ value }>{ value }</code>
+				) ) }
+			</div>
+		</div>
+	);
+};
+
+/**
  * Pipeline Step Card Component
  *
  * @param {Object}   props                - Component props
@@ -40,6 +88,12 @@ export default function PipelineStepCard( {
 	const isSystemTask = step.step_type === 'system_task';
 
 	const stepConfig = pipelineConfig[ step.pipeline_step_id ] || null;
+	const enabledTools = normalizeToolPolicyList( stepConfig?.enabled_tools );
+	const disabledTools = normalizeToolPolicyList( stepConfig?.disabled_tools );
+	const toolCategories = normalizeToolPolicyList( stepConfig?.tool_categories );
+	const hasToolPolicy = Boolean(
+		enabledTools.length || disabledTools.length || toolCategories.length
+	);
 
 	// Resolve display label: step type registry, then legacy fallback for agent_ping.
 	const displayLabel = stepTypes[ step.step_type ]?.label
@@ -138,6 +192,31 @@ export default function PipelineStepCard( {
 							) }
 							rows={ 6 }
 						/>
+						{ hasToolPolicy && (
+							<div className="datamachine-ai-tool-policy-summary">
+								<h4>
+									{ __( 'Tool Policy', 'data-machine' ) }
+								</h4>
+								<p>
+									{ __(
+										'Read-only summary of the pipeline AI step policy. Handler tools required by adjacent steps are resolved separately at runtime.',
+										'data-machine'
+									) }
+								</p>
+								{ renderToolPolicyRow(
+									__( 'Allowlist', 'data-machine' ),
+									enabledTools
+								) }
+								{ renderToolPolicyRow(
+									__( 'Denylist', 'data-machine' ),
+									disabledTools
+								) }
+								{ renderToolPolicyRow(
+									__( 'Categories', 'data-machine' ),
+									toolCategories
+								) }
+							</div>
+						) }
 					</div>
 				) }
 

--- a/tests/react-pipeline-tool-policy-contract-smoke.php
+++ b/tests/react-pipeline-tool-policy-contract-smoke.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Pure-PHP smoke test for the React pipeline AI tool policy summary (#1450).
+ *
+ * Run with: php tests/react-pipeline-tool-policy-contract-smoke.php
+ *
+ * #1448 has not landed yet, so the admin UI must not invent editable
+ * writes for tool policy fields. This smoke locks the first acceptable
+ * slice: PipelineStepCard.jsx renders a read-only summary for the
+ * canonical runtime fields already present on stepConfig.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failed = 0;
+$total  = 0;
+
+/**
+ * Assert helper.
+ *
+ * @param string $name      Test case name.
+ * @param bool   $condition Pass/fail.
+ */
+function assert_pipeline_tool_policy_contract( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+	echo "  FAIL: {$name}\n";
+	++$failed;
+}
+
+/**
+ * Read a React source file relative to the pipelines React root.
+ *
+ * @param string $relative Path under `inc/Core/Admin/Pages/Pipelines/assets/react`.
+ * @return string File contents.
+ */
+function read_pipeline_react_file( string $relative ): string {
+	$base = dirname( __DIR__ ) . '/inc/Core/Admin/Pages/Pipelines/assets/react';
+	$path = $base . '/' . ltrim( $relative, '/' );
+	if ( ! is_readable( $path ) ) {
+		fwrite( STDERR, "Missing React source: {$path}\n" );
+		exit( 2 );
+	}
+	return (string) file_get_contents( $path );
+}
+
+echo "=== React Pipeline Tool Policy Contract Smoke (#1450) ===\n";
+
+$card = read_pipeline_react_file( 'components/pipelines/PipelineStepCard.jsx' );
+$api  = read_pipeline_react_file( 'utils/api.js' );
+
+echo "\n[PipelineStepCard.jsx:1] Canonical policy fields are read from stepConfig\n";
+assert_pipeline_tool_policy_contract(
+	'reads stepConfig.enabled_tools',
+	false !== strpos( $card, 'stepConfig?.enabled_tools' )
+);
+assert_pipeline_tool_policy_contract(
+	'reads stepConfig.disabled_tools',
+	false !== strpos( $card, 'stepConfig?.disabled_tools' )
+);
+assert_pipeline_tool_policy_contract(
+	'reads stepConfig.tool_categories',
+	false !== strpos( $card, 'stepConfig?.tool_categories' )
+);
+
+echo "\n[PipelineStepCard.jsx:2] Summary labels match runtime policy vocabulary\n";
+assert_pipeline_tool_policy_contract(
+	'allowlist label exists',
+	false !== strpos( $card, "__( 'Allowlist', 'data-machine' )" )
+);
+assert_pipeline_tool_policy_contract(
+	'denylist label exists',
+	false !== strpos( $card, "__( 'Denylist', 'data-machine' )" )
+);
+assert_pipeline_tool_policy_contract(
+	'categories label exists',
+	false !== strpos( $card, "__( 'Categories', 'data-machine' )" )
+);
+
+echo "\n[PipelineStepCard.jsx:3] UI is explicitly read-only and handler tools stay separate\n";
+assert_pipeline_tool_policy_contract(
+	'read-only summary copy exists',
+	false !== strpos( $card, 'Read-only summary of the pipeline AI step policy' )
+);
+assert_pipeline_tool_policy_contract(
+	'handler tools are described as resolved separately',
+	false !== strpos( $card, 'Handler tools required by adjacent steps are resolved separately at runtime' )
+);
+assert_pipeline_tool_policy_contract(
+	'policy summary class exists',
+	false !== strpos( $card, 'datamachine-ai-tool-policy-summary' )
+);
+
+echo "\n[PipelineStepCard.jsx:4] No edit controls or mutation helpers claim policy write support\n";
+assert_pipeline_tool_policy_contract(
+	'no updateToolPolicy helper in component',
+	false === strpos( $card, 'updateToolPolicy' )
+);
+assert_pipeline_tool_policy_contract(
+	'no ToolPolicyField edit component in component',
+	false === strpos( $card, 'ToolPolicyField' )
+);
+assert_pipeline_tool_policy_contract(
+	'policy fields are not added to updateSystemPrompt payload',
+	false === strpos( $api, 'enabled_tools:' )
+		&& false === strpos( $api, 'disabled_tools:' )
+		&& false === strpos( $api, 'tool_categories:' )
+);
+
+echo "\n[PipelineStepCard.jsx:5] Display helper accepts existing array/string/object shapes\n";
+assert_pipeline_tool_policy_contract(
+	'normalizeToolPolicyList helper exists',
+	false !== strpos( $card, 'const normalizeToolPolicyList' )
+);
+assert_pipeline_tool_policy_contract(
+	'array values are filtered and stringified',
+	false !== strpos( $card, 'value.filter( Boolean ).map( String )' )
+);
+assert_pipeline_tool_policy_contract(
+	'object values render truthy keys',
+	false !== strpos( $card, 'Object.entries( value )' )
+		&& false !== strpos( $card, '.filter( ( [ , enabled ] ) => Boolean( enabled ) )' )
+);
+
+echo "\n=== Summary ===\n";
+if ( $failed > 0 ) {
+	echo "FAILED: {$failed}/{$total} assertions failed\n";
+	exit( 1 );
+}
+
+echo "PASSED: {$total} assertions\n";


### PR DESCRIPTION
## Summary
- Adds a truthful, read-only admin summary for pipeline AI step tool policy while the write-side API remains open in #1448.

## Changes
- Shows `enabled_tools`, `disabled_tools`, and `tool_categories` from the existing pipeline step config on AI steps.
- Labels the runtime fields as allowlist, denylist, and categories.
- Calls out that handler tools required by adjacent steps are resolved separately at runtime.
- Adds a PHP source-contract smoke that pins the React boundary and prevents accidental claims of edit support.

## Tests
- `php tests/react-pipeline-tool-policy-contract-smoke.php`
- `php -l tests/react-pipeline-tool-policy-contract-smoke.php`
- React build not run: `npm` is not available in this non-interactive shell.

Refs #1450
Refs #1443

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the read-only React policy summary, adding the source-contract smoke, and running focused verification.
