### PR TITLE
fix(import-export): preserve portable AI flow state

### DIFF
--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Engine\Actions;
 
+use DataMachine\Abilities\Flow\QueueAbility;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\FlowStepConfigFactory;
 
@@ -359,8 +360,8 @@ class ImportExport {
 			$flow_config[ $flow_step_id ]['step_type'] = $step_type;
 		}
 
-
 		$step = FlowStepConfigFactory::withHandlerFields( $flow_config[ $flow_step_id ], $settings );
+		$step = array_merge( $step, $this->normalize_portable_flow_step_settings( $settings ) );
 
 		$flow_config[ $flow_step_id ] = $step;
 
@@ -438,24 +439,8 @@ class ImportExport {
 					$flow_step_id = apply_filters( 'datamachine_generate_flow_step_id', '', $step['pipeline_step_id'], $flow['flow_id'] );
 					$flow_step    = $flow_config[ $flow_step_id ] ?? array();
 
-					$settings        = array();
+					$settings        = $this->export_flow_step_settings( $flow_step );
 					$primary_handler = FlowStepConfig::getPrimaryHandlerSlug( $flow_step ) ?? '';
-
-					if ( FlowStepConfig::isMultiHandler( $flow_step ) && ! empty( $primary_handler ) ) {
-						$settings = array(
-							'handler_slugs'   => FlowStepConfig::getHandlerSlugs( $flow_step ),
-							'handler_configs' => FlowStepConfig::getHandlerConfigs( $flow_step ),
-						);
-					} elseif ( FlowStepConfig::usesHandler( $flow_step ) && ! empty( $primary_handler ) ) {
-						$settings = array(
-							'handler_slug'   => $primary_handler,
-							'handler_config' => FlowStepConfig::getPrimaryHandlerConfig( $flow_step ),
-						);
-					} elseif ( ! FlowStepConfig::usesHandler( $flow_step ) && ! empty( $flow_step['handler_config'] ) ) {
-						$settings = array(
-							'handler_config' => $flow_step['handler_config'],
-						);
-					}
 
 					if ( ! empty( $settings ) ) {
 						$csv_rows[] = array(
@@ -487,6 +472,61 @@ class ImportExport {
 
 		do_action( 'datamachine_log', 'debug', 'Pipeline export completed', array( 'count' => count( $ids ) ) );
 		return $csv;
+	}
+
+	/**
+	 * Build portable flow-step settings for CSV export.
+	 *
+	 * Handler selection/config remains in its canonical handler fields. Queue and
+	 * AI tool-policy state is stored beside those fields because it is flow-scoped
+	 * runtime state, not pipeline structure.
+	 */
+	private function export_flow_step_settings( array $flow_step ): array {
+		$settings        = array();
+		$primary_handler = FlowStepConfig::getPrimaryHandlerSlug( $flow_step ) ?? '';
+
+		if ( FlowStepConfig::isMultiHandler( $flow_step ) && ! empty( $primary_handler ) ) {
+			$settings = array(
+				'handler_slugs'   => FlowStepConfig::getHandlerSlugs( $flow_step ),
+				'handler_configs' => FlowStepConfig::getHandlerConfigs( $flow_step ),
+			);
+		} elseif ( FlowStepConfig::usesHandler( $flow_step ) && ! empty( $primary_handler ) ) {
+			$settings = array(
+				'handler_slug'   => $primary_handler,
+				'handler_config' => FlowStepConfig::getPrimaryHandlerConfig( $flow_step ),
+			);
+		} elseif ( ! FlowStepConfig::usesHandler( $flow_step ) && ! empty( $flow_step['handler_config'] ) ) {
+			$settings = array(
+				'handler_config' => $flow_step['handler_config'],
+			);
+		}
+
+		return array_merge( $settings, $this->normalize_portable_flow_step_settings( $flow_step ) );
+	}
+
+	/**
+	 * Normalize portable flow-step fields for import/export.
+	 */
+	private function normalize_portable_flow_step_settings( array $source ): array {
+		$normalized = array();
+
+		foreach ( array( 'enabled_tools', 'disabled_tools' ) as $field ) {
+			if ( isset( $source[ $field ] ) && is_array( $source[ $field ] ) ) {
+				$normalized[ $field ] = array_values( array_map( 'strval', $source[ $field ] ) );
+			}
+		}
+
+		foreach ( array( QueueAbility::SLOT_PROMPT_QUEUE, QueueAbility::SLOT_CONFIG_PATCH_QUEUE ) as $field ) {
+			if ( isset( $source[ $field ] ) && is_array( $source[ $field ] ) && array_is_list( $source[ $field ] ) ) {
+				$normalized[ $field ] = $source[ $field ];
+			}
+		}
+
+		if ( isset( $source['queue_mode'] ) && in_array( $source['queue_mode'], array( 'drain', 'loop', 'static' ), true ) ) {
+			$normalized['queue_mode'] = $source['queue_mode'];
+		}
+
+		return $normalized;
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -22,6 +22,16 @@ final class AgentBundleFlowFile {
 	private array $max_items;
 	private array $steps;
 
+	private const OPTIONAL_STEP_FIELDS = array(
+		'handler_slug',
+		'handler_slugs',
+		'enabled_tools',
+		'disabled_tools',
+		'prompt_queue',
+		'config_patch_queue',
+		'queue_mode',
+	);
+
 	public function __construct( string $slug, string $name, string $pipeline_slug, string $schedule, array $max_items, array $steps ) {
 		$this->slug          = PortableSlug::normalize( $slug, 'flow' );
 		$this->name          = $name;
@@ -78,14 +88,10 @@ final class AgentBundleFlowFile {
 				'handler_configs' => $step['handler_configs'],
 			);
 
-			if ( array_key_exists( 'handler_slug', $step ) ) {
-				$normalized_step['handler_slug'] = (string) $step['handler_slug'];
-			}
-			if ( array_key_exists( 'handler_slugs', $step ) ) {
-				if ( ! is_array( $step['handler_slugs'] ) || ! array_is_list( $step['handler_slugs'] ) ) {
-					throw new BundleValidationException( 'flow file handler_slugs must be a list.' );
+			foreach ( self::OPTIONAL_STEP_FIELDS as $field ) {
+				if ( array_key_exists( $field, $step ) ) {
+					$normalized_step[ $field ] = self::normalize_optional_step_field( $field, $step[ $field ] );
 				}
-				$normalized_step['handler_slugs'] = array_values( array_map( 'strval', $step['handler_slugs'] ) );
 			}
 
 			$normalized[] = $normalized_step;
@@ -94,5 +100,39 @@ final class AgentBundleFlowFile {
 		usort( $normalized, fn( $a, $b ) => $a['step_position'] <=> $b['step_position'] );
 
 		return $normalized;
+	}
+
+	private static function normalize_optional_step_field( string $field, $value ) {
+		if ( 'handler_slug' === $field ) {
+			return (string) $value;
+		}
+
+		if ( in_array( $field, array( 'handler_slugs', 'enabled_tools', 'disabled_tools' ), true ) ) {
+			if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+				throw new BundleValidationException( "flow file {$field} must be a list." );
+			}
+			return array_values( array_map( 'strval', $value ) );
+		}
+
+		if ( in_array( $field, array( 'prompt_queue', 'config_patch_queue' ), true ) ) {
+			if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+				throw new BundleValidationException( "flow file {$field} must be a list of objects." );
+			}
+			foreach ( $value as $entry ) {
+				if ( ! is_array( $entry ) ) {
+					throw new BundleValidationException( "flow file {$field} must be a list of objects." );
+				}
+			}
+			return array_values( $value );
+		}
+
+		if ( 'queue_mode' === $field ) {
+			if ( ! in_array( $value, array( 'drain', 'loop', 'static' ), true ) ) {
+				throw new BundleValidationException( 'flow file queue_mode must be one of drain, loop, static.' );
+			}
+			return $value;
+		}
+
+		return $value;
 	}
 }

--- a/tests/agent-bundle-format-smoke.php
+++ b/tests/agent-bundle-format-smoke.php
@@ -130,14 +130,29 @@ $flow = AgentBundleFlowFile::from_array(
 		'max_items'      => array( 'mcp' => 5 ),
 		'steps'          => array(
 			array(
+				'step_position'   => 2,
+				'handler_configs' => array(),
+				'enabled_tools'   => array( 'datamachine/get-github-pull-review-context' ),
+				'prompt_queue'    => array(
+					array(
+						'prompt'   => 'Review this PR.',
+						'added_at' => '2026-04-27T00:00:00Z',
+					),
+				),
+				'queue_mode'      => 'loop',
+			),
+			array(
 				'step_position'   => 1,
 				'handler_slug'    => 'wordpress_publish',
 				'handler_configs' => array( 'wordpress_publish' => array( 'post_type' => 'wiki' ) ),
+				'disabled_tools'  => array( 'datamachine/delete-flow' ),
 			),
 			array(
 				'step_position'   => 0,
 				'handler_slug'    => 'mcp',
 				'handler_configs' => array( 'mcp' => array( 'auth_ref' => 'wpcom:default', 'provider' => 'mgs' ) ),
+				'config_patch_queue' => array( array( 'after' => '2026-04-01' ) ),
+				'queue_mode'         => 'drain',
 			),
 		),
 	)
@@ -145,6 +160,58 @@ $flow = AgentBundleFlowFile::from_array(
 $flow_array = $flow->to_array();
 assert_bundle_equals( 'flow references pipeline by slug, not source ID', 'wc-daily-ingest', $flow_array['pipeline_slug'] );
 assert_bundle_equals( 'flow step 0 first after normalization', 'mcp', $flow_array['steps'][0]['handler_slug'] );
+assert_bundle_equals( 'flow step preserves fetch config patch queue', array( array( 'after' => '2026-04-01' ) ), $flow_array['steps'][0]['config_patch_queue'] );
+assert_bundle_equals( 'flow step preserves AI enabled tools', array( 'datamachine/get-github-pull-review-context' ), $flow_array['steps'][2]['enabled_tools'] );
+assert_bundle_equals( 'flow step preserves AI prompt queue', 'Review this PR.', $flow_array['steps'][2]['prompt_queue'][0]['prompt'] );
+assert_bundle_equals( 'flow step preserves AI queue mode', 'loop', $flow_array['steps'][2]['queue_mode'] );
+
+$threw = false;
+try {
+	AgentBundleFlowFile::from_array(
+		array(
+			'schema_version' => 1,
+			'slug'           => 'Bad Flow',
+			'name'           => 'Bad Flow',
+			'pipeline_slug'  => 'WC Daily Ingest',
+			'schedule'       => 'daily',
+			'max_items'      => array(),
+			'steps'          => array(
+				array(
+					'step_position'   => 0,
+					'handler_configs' => array(),
+					'prompt_queue'    => array( 'not-an-object' ),
+				),
+			),
+		)
+	);
+} catch ( BundleValidationException $e ) {
+	$threw = str_contains( $e->getMessage(), 'prompt_queue must be a list of objects' );
+}
+assert_bundle( 'malformed prompt_queue fails clearly', $threw );
+
+$threw = false;
+try {
+	AgentBundleFlowFile::from_array(
+		array(
+			'schema_version' => 1,
+			'slug'           => 'Bad Queue Mode',
+			'name'           => 'Bad Queue Mode',
+			'pipeline_slug'  => 'WC Daily Ingest',
+			'schedule'       => 'daily',
+			'max_items'      => array(),
+			'steps'          => array(
+				array(
+					'step_position'   => 0,
+					'handler_configs' => array(),
+					'queue_mode'      => 'random',
+				),
+			),
+		)
+	);
+} catch ( BundleValidationException $e ) {
+	$threw = str_contains( $e->getMessage(), 'queue_mode must be one of drain, loop, static' );
+}
+assert_bundle( 'malformed queue_mode fails clearly', $threw );
 
 echo "\n[4] Directory write/read round-trips without DB access\n";
 $bundle = new AgentBundleDirectory(

--- a/tests/import-export-portable-flow-settings-smoke.php
+++ b/tests/import-export-portable-flow-settings-smoke.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Pure-PHP smoke test for portable flow-step settings in CSV import/export.
+ *
+ * Run with: php tests/import-export-portable-flow-settings-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities\Flow {
+	if ( ! class_exists( QueueAbility::class, false ) ) {
+		class QueueAbility {
+			const SLOT_PROMPT_QUEUE       = 'prompt_queue';
+			const SLOT_CONFIG_PATCH_QUEUE = 'config_patch_queue';
+		}
+	}
+}
+
+namespace {
+
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', __DIR__ );
+}
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		if ( 'datamachine_step_types' === $hook ) {
+			return array(
+				'ai'      => array( 'uses_handler' => false, 'multi_handler' => false ),
+				'fetch'   => array( 'uses_handler' => true, 'multi_handler' => false ),
+				'publish' => array( 'uses_handler' => true, 'multi_handler' => true ),
+				'upsert'  => array( 'uses_handler' => true, 'multi_handler' => true ),
+			);
+		}
+
+		return $value;
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
+require_once __DIR__ . '/../inc/Engine/Actions/ImportExport.php';
+
+use DataMachine\Engine\Actions\ImportExport;
+
+$failures = array();
+$passes   = 0;
+
+function assert_csv_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function call_import_export_private( ImportExport $import_export, string $method, array $arg ): array {
+	$reflection = new ReflectionMethod( ImportExport::class, $method );
+	$result = $reflection->invoke( $import_export, $arg );
+	return is_array( $result ) ? $result : array();
+}
+
+echo "import-export-portable-flow-settings-smoke\n";
+
+$import_export = new ImportExport();
+
+$ai_settings = call_import_export_private(
+	$import_export,
+	'export_flow_step_settings',
+	array(
+		'step_type'     => 'ai',
+		'enabled_tools' => array( 'datamachine/get-github-pull-review-context', 'datamachine/upsert-github-pull-review-comment' ),
+		'prompt_queue'  => array(
+			array(
+				'prompt'   => 'Review this PR.',
+				'added_at' => '2026-04-27T00:00:00Z',
+			),
+		),
+		'queue_mode'    => 'loop',
+	)
+);
+
+assert_csv_equals(
+	array( 'datamachine/get-github-pull-review-context', 'datamachine/upsert-github-pull-review-comment' ),
+	$ai_settings['enabled_tools'] ?? null,
+	'AI enabled_tools export as portable settings',
+	$failures,
+	$passes
+);
+assert_csv_equals( 'Review this PR.', $ai_settings['prompt_queue'][0]['prompt'] ?? null, 'AI prompt_queue exports as portable settings', $failures, $passes );
+assert_csv_equals( 'loop', $ai_settings['queue_mode'] ?? null, 'AI queue_mode exports as portable settings', $failures, $passes );
+assert_csv_equals( false, array_key_exists( 'handler_slug', $ai_settings ), 'AI settings stay handler-free', $failures, $passes );
+
+$fetch_settings = call_import_export_private(
+	$import_export,
+	'export_flow_step_settings',
+	array(
+		'step_type'          => 'fetch',
+		'handler_slug'       => 'webhook_payload',
+		'handler_config'     => array( 'payload_path' => 'pull_request' ),
+		'config_patch_queue' => array( array( 'after' => '2026-04-01' ) ),
+		'queue_mode'         => 'drain',
+	)
+);
+
+assert_csv_equals( 'webhook_payload', $fetch_settings['handler_slug'] ?? null, 'fetch handler_slug still exports', $failures, $passes );
+assert_csv_equals( array( 'payload_path' => 'pull_request' ), $fetch_settings['handler_config'] ?? null, 'fetch handler_config still exports', $failures, $passes );
+assert_csv_equals( array( array( 'after' => '2026-04-01' ) ), $fetch_settings['config_patch_queue'] ?? null, 'fetch config_patch_queue exports as portable settings', $failures, $passes );
+assert_csv_equals( 'drain', $fetch_settings['queue_mode'] ?? null, 'fetch queue_mode exports as portable settings', $failures, $passes );
+
+$normalized = call_import_export_private(
+	$import_export,
+	'normalize_portable_flow_step_settings',
+	array(
+		'enabled_tools' => array( 'datamachine/read-github-file' ),
+		'queue_mode'    => 'static',
+		'prompt_queue'  => array( array( 'prompt' => 'Pinned prompt.' ) ),
+		'handler_slug'  => 'ignored_here',
+	)
+);
+
+assert_csv_equals( array( 'datamachine/read-github-file' ), $normalized['enabled_tools'] ?? null, 'import normalization keeps enabled_tools', $failures, $passes );
+assert_csv_equals( array( array( 'prompt' => 'Pinned prompt.' ) ), $normalized['prompt_queue'] ?? null, 'import normalization keeps prompt_queue', $failures, $passes );
+assert_csv_equals( 'static', $normalized['queue_mode'] ?? null, 'import normalization keeps queue_mode', $failures, $passes );
+assert_csv_equals( false, array_key_exists( 'handler_slug', $normalized ), 'portable normalization does not duplicate handler fields', $failures, $passes );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " portable flow settings assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} portable flow settings assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Preserve flow-scoped AI tool policy and queue state in CSV export/import settings rows.
- Extend agent bundle flow files to explicitly validate and round-trip portable queue/tool-policy fields.

## Changes
- Adds portable flow-step settings export/import for `enabled_tools`, `disabled_tools`, `prompt_queue`, `config_patch_queue`, and `queue_mode`.
- Keeps handler config export behavior intact while adding flow-scoped runtime state beside handler fields.
- Extends `AgentBundleFlowFile` optional step fields with list/enum validation for queue and tool-policy fields.
- Adds focused smoke coverage for CSV portable settings and expands bundle format coverage for AI/fetch queue state.

## Tests
- `php -l inc/Engine/Actions/ImportExport.php`
- `php -l inc/Engine/Bundle/AgentBundleFlowFile.php`
- `php tests/import-export-portable-flow-settings-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/workflow-persistent-install-smoke.php`
- `git diff --check`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-ai-policy-roundtrip --changed-since origin/main` (passed, but reported 0 files scanned)
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-ai-policy-roundtrip` (failed on existing repo-wide phpstan findings unrelated to this branch; focused smokes above pass)

Refs #1449
Refs #1443

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the import/export and bundle flow schema, implementing the portable flow-step state preservation, and adding focused smoke coverage. Chris remains responsible for review and testing.
