### PR TITLE
feat(ai): expose pipeline tool policy writes

### DIFF
--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -152,7 +152,7 @@ class PipelineStepAbilities {
 			'datamachine/update-pipeline-step',
 			array(
 				'label'               => __( 'Update Pipeline Step', 'data-machine' ),
-				'description'         => __( 'Update pipeline step configuration (system prompt, disabled tools). Model/provider are configured via mode_models setting.', 'data-machine' ),
+				'description'         => __( 'Update pipeline step configuration (system prompt and AI tool policy). Model/provider are configured via mode_models setting.', 'data-machine' ),
 				'category'            => 'datamachine-pipeline',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -169,6 +169,17 @@ class PipelineStepAbilities {
 						'disabled_tools'   => array(
 							'type'        => 'array',
 							'description' => __( 'Array of disabled tool IDs for this step', 'data-machine' ),
+							'items'       => array( 'type' => 'string' ),
+						),
+						'enabled_tools'    => array(
+							'type'        => 'array',
+							'description' => __( 'Array of enabled tool IDs for this step', 'data-machine' ),
+							'items'       => array( 'type' => 'string' ),
+						),
+						'tool_categories'  => array(
+							'type'        => 'array',
+							'description' => __( 'Array of ability categories allowed for this step', 'data-machine' ),
+							'items'       => array( 'type' => 'string' ),
 						),
 					),
 				),
@@ -523,16 +534,24 @@ class PipelineStepAbilities {
 			);
 		}
 
-		$system_prompt  = $input['system_prompt'] ?? null;
-		$disabled_tools = $input['disabled_tools'] ?? null;
+		$system_prompt = $input['system_prompt'] ?? null;
+		$policy_fields = array( 'enabled_tools', 'disabled_tools', 'tool_categories' );
 
 		// provider/model are no longer configurable at the pipeline step level.
 		// Model resolution is handled exclusively by the mode system (mode_models setting).
 
-		if ( null === $system_prompt && null === $disabled_tools ) {
+		$has_policy_field = false;
+		foreach ( $policy_fields as $field ) {
+			if ( array_key_exists( $field, $input ) ) {
+				$has_policy_field = true;
+				break;
+			}
+		}
+
+		if ( null === $system_prompt && ! $has_policy_field ) {
 			return array(
 				'success' => false,
-				'error'   => 'At least one of system_prompt or disabled_tools is required',
+				'error'   => 'At least one of system_prompt, enabled_tools, disabled_tools, or tool_categories is required',
 			);
 		}
 
@@ -566,12 +585,26 @@ class PipelineStepAbilities {
 			$updated_fields[]                  = 'system_prompt';
 		}
 
-		if ( null !== $disabled_tools && is_array( $disabled_tools ) ) {
-			$sanitized_tool_ids = array_map( 'sanitize_text_field', $disabled_tools );
-			$tools_manager      = new \DataMachine\Engine\AI\Tools\ToolManager();
+		foreach ( $policy_fields as $field ) {
+			if ( ! array_key_exists( $field, $input ) ) {
+				continue;
+			}
 
-			$step_config_data['disabled_tools'] = $tools_manager->save_step_tool_selections( $pipeline_step_id, $sanitized_tool_ids );
-			$updated_fields[]                   = 'disabled_tools';
+			$sanitized_values = self::sanitizeStringListField( $input[ $field ], $field );
+			if ( is_wp_error( $sanitized_values ) ) {
+				return array(
+					'success' => false,
+					'error'   => $sanitized_values->get_error_message(),
+				);
+			}
+
+			if ( 'disabled_tools' === $field ) {
+				$tools_manager    = new \DataMachine\Engine\AI\Tools\ToolManager();
+				$sanitized_values = $tools_manager->save_step_tool_selections( $pipeline_step_id, $sanitized_values );
+			}
+
+			$step_config_data[ $field ] = $sanitized_values;
+			$updated_fields[]          = $field;
 		}
 
 		$pipeline_config[ $pipeline_step_id ] = array_merge( $existing_config, $step_config_data );
@@ -606,6 +639,36 @@ class PipelineStepAbilities {
 			'updated_fields'   => $updated_fields,
 			'message'          => 'Pipeline step configuration updated successfully. Fields updated: ' . implode( ', ', $updated_fields ),
 		);
+	}
+
+	/**
+	 * Sanitize an array-of-strings configuration field.
+	 *
+	 * @param mixed  $value Input value.
+	 * @param string $field Field name for error messages.
+	 * @return array|\WP_Error Sanitized string list or validation error.
+	 */
+	public static function sanitizeStringListField( mixed $value, string $field ): array|\WP_Error {
+		if ( ! is_array( $value ) ) {
+			return new \WP_Error(
+				'invalid_' . $field,
+				sprintf( '%s must be an array of strings', $field )
+			);
+		}
+
+		$sanitized = array();
+		foreach ( $value as $item ) {
+			if ( ! is_string( $item ) ) {
+				return new \WP_Error(
+					'invalid_' . $field,
+					sprintf( '%s must contain only strings', $field )
+				);
+			}
+
+			$sanitized[] = sanitize_text_field( wp_unslash( $item ) );
+		}
+
+		return array_values( $sanitized );
 	}
 
 	/**

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -171,11 +171,6 @@ class PipelineStepAbilities {
 							'description' => __( 'Array of disabled tool IDs for this step', 'data-machine' ),
 							'items'       => array( 'type' => 'string' ),
 						),
-						'enabled_tools'    => array(
-							'type'        => 'array',
-							'description' => __( 'Array of enabled tool IDs for this step', 'data-machine' ),
-							'items'       => array( 'type' => 'string' ),
-						),
 						'tool_categories'  => array(
 							'type'        => 'array',
 							'description' => __( 'Array of ability categories allowed for this step', 'data-machine' ),
@@ -535,7 +530,7 @@ class PipelineStepAbilities {
 		}
 
 		$system_prompt = $input['system_prompt'] ?? null;
-		$policy_fields = array( 'enabled_tools', 'disabled_tools', 'tool_categories' );
+		$policy_fields = array( 'disabled_tools', 'tool_categories' );
 
 		// provider/model are no longer configurable at the pipeline step level.
 		// Model resolution is handled exclusively by the mode system (mode_models setting).
@@ -551,7 +546,7 @@ class PipelineStepAbilities {
 		if ( null === $system_prompt && ! $has_policy_field ) {
 			return array(
 				'success' => false,
-				'error'   => 'At least one of system_prompt, enabled_tools, disabled_tools, or tool_categories is required',
+				'error'   => 'At least one of system_prompt, disabled_tools, or tool_categories is required',
 			);
 		}
 
@@ -604,7 +599,7 @@ class PipelineStepAbilities {
 			}
 
 			$step_config_data[ $field ] = $sanitized_values;
-			$updated_fields[]          = $field;
+			$updated_fields[]           = $field;
 		}
 
 		$pipeline_config[ $pipeline_step_id ] = array_merge( $existing_config, $step_config_data );
@@ -906,8 +901,8 @@ class PipelineStepAbilities {
 				);
 			}
 
-			$step                              = $steps_by_id[ $pipeline_step_id ];
-			$step['execution_order']           = $index;
+			$step                               = $steps_by_id[ $pipeline_step_id ];
+			$step['execution_order']            = $index;
 			$updated_steps[ $pipeline_step_id ] = $step;
 		}
 

--- a/inc/Api/Chat/Tools/ConfigurePipelineStep.php
+++ b/inc/Api/Chat/Tools/ConfigurePipelineStep.php
@@ -3,7 +3,7 @@
  * Configure Pipeline Step Tool
  *
  * Tool for configuring pipeline-level AI step settings including
- * system prompt, provider, model, and enabled tools.
+ * system prompt and tool policy fields.
  * Delegates to Abilities API for core logic.
  *
  * @package DataMachine\Api\Chat\Tools
@@ -33,7 +33,7 @@ class ConfigurePipelineStep extends BaseTool {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',
-			'description' => 'Configure pipeline-level AI step settings: system prompt and disabled tools. Model/provider are managed via the mode_models site setting, not per-pipeline. For flow-level settings (handler, handler_config, user_message), use configure_flow_steps instead.',
+			'description' => 'Configure pipeline-level AI step settings: system prompt and tool policy. Model/provider are managed via the mode_models site setting, not per-pipeline. For flow-level settings (handler, handler_config, user_message), use configure_flow_steps instead.',
 			'parameters'  => array(
 				'pipeline_step_id' => array(
 					'type'        => 'string',
@@ -45,10 +45,20 @@ class ConfigurePipelineStep extends BaseTool {
 					'required'    => false,
 					'description' => 'System prompt for the AI step - defines the AI persona and instructions',
 				),
+				'enabled_tools'    => array(
+					'type'        => 'array',
+					'required'    => false,
+					'description' => 'Array of tool slugs to allow for this AI step',
+				),
 				'disabled_tools'   => array(
 					'type'        => 'array',
 					'required'    => false,
 					'description' => 'Array of tool slugs to disable for this AI step',
+				),
+				'tool_categories'  => array(
+					'type'        => 'array',
+					'required'    => false,
+					'description' => 'Array of ability categories allowed for this AI step',
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/ConfigurePipelineStep.php
+++ b/inc/Api/Chat/Tools/ConfigurePipelineStep.php
@@ -45,11 +45,6 @@ class ConfigurePipelineStep extends BaseTool {
 					'required'    => false,
 					'description' => 'System prompt for the AI step - defines the AI persona and instructions',
 				),
-				'enabled_tools'    => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Array of tool slugs to allow for this AI step',
-				),
 				'disabled_tools'   => array(
 					'type'        => 'array',
 					'required'    => false,

--- a/inc/Api/Pipelines/PipelineSteps.php
+++ b/inc/Api/Pipelines/PipelineSteps.php
@@ -192,6 +192,19 @@ class PipelineSteps {
 				'required'    => false,
 				'type'        => 'array',
 				'description' => __( 'Array of disabled tool IDs', 'data-machine' ),
+				'items'       => array( 'type' => 'string' ),
+			),
+			'enabled_tools'    => array(
+				'required'    => false,
+				'type'        => 'array',
+				'description' => __( 'Array of enabled tool IDs', 'data-machine' ),
+				'items'       => array( 'type' => 'string' ),
+			),
+			'tool_categories'  => array(
+				'required'    => false,
+				'type'        => 'array',
+				'description' => __( 'Array of ability categories allowed for this step', 'data-machine' ),
+				'items'       => array( 'type' => 'string' ),
 			),
 			'system_prompt'    => array(
 				'required'          => false,
@@ -489,22 +502,33 @@ class PipelineSteps {
 		// (PluginSettings::resolveModelForAgentMode). They are not accepted here.
 		$step_config_data = array();
 
-		$has_system_prompt  = $request->has_param( 'system_prompt' );
-		$has_disabled_tools = $request->has_param( 'disabled_tools' );
+		$has_system_prompt = $request->has_param( 'system_prompt' );
+		$policy_fields     = array( 'enabled_tools', 'disabled_tools', 'tool_categories' );
 
 		if ( $has_system_prompt ) {
 			$step_config_data['system_prompt'] = sanitize_textarea_field( $request->get_param( 'system_prompt' ) );
 		}
 
-		if ( $has_disabled_tools ) {
-			$disabled_tools_raw = $request->get_param( 'disabled_tools' );
-			$sanitized_tool_ids = array();
-			if ( is_array( $disabled_tools_raw ) ) {
-				$sanitized_tool_ids = array_map( 'sanitize_text_field', $disabled_tools_raw );
+		foreach ( $policy_fields as $field ) {
+			if ( ! $request->has_param( $field ) ) {
+				continue;
 			}
 
-			$tools_manager                      = new \DataMachine\Engine\AI\Tools\ToolManager();
-			$step_config_data['disabled_tools'] = $tools_manager->save_step_tool_selections( $pipeline_step_id, $sanitized_tool_ids );
+			$sanitized_values = PipelineStepAbilities::sanitizeStringListField( $request->get_param( $field ), $field );
+			if ( is_wp_error( $sanitized_values ) ) {
+				return new \WP_Error(
+					$sanitized_values->get_error_code(),
+					$sanitized_values->get_error_message(),
+					array( 'status' => 400 )
+				);
+			}
+
+			if ( 'disabled_tools' === $field ) {
+				$tools_manager    = new \DataMachine\Engine\AI\Tools\ToolManager();
+				$sanitized_values = $tools_manager->save_step_tool_selections( $pipeline_step_id, $sanitized_values );
+			}
+
+			$step_config_data[ $field ] = $sanitized_values;
 		}
 
 		if ( 'ai' === $step_type && empty( $step_config_data ) ) {

--- a/inc/Api/Pipelines/PipelineSteps.php
+++ b/inc/Api/Pipelines/PipelineSteps.php
@@ -194,12 +194,6 @@ class PipelineSteps {
 				'description' => __( 'Array of disabled tool IDs', 'data-machine' ),
 				'items'       => array( 'type' => 'string' ),
 			),
-			'enabled_tools'    => array(
-				'required'    => false,
-				'type'        => 'array',
-				'description' => __( 'Array of enabled tool IDs', 'data-machine' ),
-				'items'       => array( 'type' => 'string' ),
-			),
 			'tool_categories'  => array(
 				'required'    => false,
 				'type'        => 'array',
@@ -503,7 +497,7 @@ class PipelineSteps {
 		$step_config_data = array();
 
 		$has_system_prompt = $request->has_param( 'system_prompt' );
-		$policy_fields     = array( 'enabled_tools', 'disabled_tools', 'tool_categories' );
+		$policy_fields     = array( 'disabled_tools', 'tool_categories' );
 
 		if ( $has_system_prompt ) {
 			$step_config_data['system_prompt'] = sanitize_textarea_field( $request->get_param( 'system_prompt' ) );

--- a/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
@@ -11,8 +11,10 @@ namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\Pipeline\CreatePipelineAbility;
 use DataMachine\Abilities\PipelineStepAbilities;
+use DataMachine\Api\Pipelines\PipelineSteps;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
+use WP_REST_Request;
 use WP_UnitTestCase;
 
 class PipelineStepAbilitiesTest extends WP_UnitTestCase {
@@ -389,6 +391,127 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'system_prompt', $result['message'] );
 	}
 
+	public function test_update_pipeline_step_accepts_tool_policy_fields(): void {
+		$this->register_test_pipeline_tools();
+
+		$add_result       = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'ai',
+			)
+		);
+		$pipeline_step_id = $add_result['pipeline_step_id'];
+
+		$result = $this->step_abilities->executeUpdatePipelineStep(
+			array(
+				'pipeline_step_id' => $pipeline_step_id,
+				'enabled_tools'    => array( 'test_pipeline_tool' ),
+				'disabled_tools'   => array( 'test_disabled_tool' ),
+				'tool_categories'  => array( 'datamachine-test' ),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 'enabled_tools', 'disabled_tools', 'tool_categories' ), $result['updated_fields'] );
+
+		$db_pipelines    = new Pipelines();
+		$pipeline_config = $db_pipelines->get_pipeline_config( $this->test_pipeline_id );
+
+		$this->assertSame( array( 'test_pipeline_tool' ), $pipeline_config[ $pipeline_step_id ]['enabled_tools'] );
+		$this->assertSame( array( 'test_disabled_tool' ), $pipeline_config[ $pipeline_step_id ]['disabled_tools'] );
+		$this->assertSame( array( 'datamachine-test' ), $pipeline_config[ $pipeline_step_id ]['tool_categories'] );
+	}
+
+	public function test_update_pipeline_step_rejects_malformed_tool_policy_fields(): void {
+		$add_result       = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'ai',
+			)
+		);
+		$pipeline_step_id = $add_result['pipeline_step_id'];
+
+		$non_array_result = $this->step_abilities->executeUpdatePipelineStep(
+			array(
+				'pipeline_step_id' => $pipeline_step_id,
+				'enabled_tools'    => 'test_pipeline_tool',
+			)
+		);
+		$this->assertFalse( $non_array_result['success'] );
+		$this->assertStringContainsString( 'enabled_tools must be an array of strings', $non_array_result['error'] );
+
+		$non_string_result = $this->step_abilities->executeUpdatePipelineStep(
+			array(
+				'pipeline_step_id' => $pipeline_step_id,
+				'tool_categories'  => array( 'datamachine-test', 123 ),
+			)
+		);
+		$this->assertFalse( $non_string_result['success'] );
+		$this->assertStringContainsString( 'tool_categories must contain only strings', $non_string_result['error'] );
+	}
+
+	public function test_rest_pipeline_step_config_schema_exposes_tool_policy_fields(): void {
+		$method = new \ReflectionMethod( PipelineSteps::class, 'get_step_config_args' );
+		$method->setAccessible( true );
+
+		$args = $method->invoke( null, true );
+
+		foreach ( array( 'enabled_tools', 'disabled_tools', 'tool_categories' ) as $field ) {
+			$this->assertArrayHasKey( $field, $args );
+			$this->assertSame( 'array', $args[ $field ]['type'] );
+			$this->assertSame( array( 'type' => 'string' ), $args[ $field ]['items'] );
+		}
+	}
+
+	public function test_rest_pipeline_step_config_persists_tool_policy_fields(): void {
+		$this->register_test_pipeline_tools();
+
+		$add_result       = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'ai',
+			)
+		);
+		$pipeline_step_id = $add_result['pipeline_step_id'];
+
+		$request = new WP_REST_Request( 'PATCH', '/datamachine/v1/pipelines/steps/' . $pipeline_step_id . '/config' );
+		$request->set_param( 'pipeline_step_id', $pipeline_step_id );
+		$request->set_param( 'enabled_tools', array( 'test_pipeline_tool' ) );
+		$request->set_param( 'disabled_tools', array( 'test_disabled_tool' ) );
+		$request->set_param( 'tool_categories', array( 'datamachine-test' ) );
+
+		$response = PipelineSteps::handle_upsert_step_config( $request );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $response );
+
+		$db_pipelines    = new Pipelines();
+		$pipeline_config = $db_pipelines->get_pipeline_config( $this->test_pipeline_id );
+
+		$this->assertSame( array( 'test_pipeline_tool' ), $pipeline_config[ $pipeline_step_id ]['enabled_tools'] );
+		$this->assertSame( array( 'test_disabled_tool' ), $pipeline_config[ $pipeline_step_id ]['disabled_tools'] );
+		$this->assertSame( array( 'datamachine-test' ), $pipeline_config[ $pipeline_step_id ]['tool_categories'] );
+	}
+
+	public function test_rest_pipeline_step_config_rejects_malformed_tool_policy_fields(): void {
+		$add_result       = $this->step_abilities->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $this->test_pipeline_id,
+				'step_type'   => 'ai',
+			)
+		);
+		$pipeline_step_id = $add_result['pipeline_step_id'];
+
+		$request = new WP_REST_Request( 'PATCH', '/datamachine/v1/pipelines/steps/' . $pipeline_step_id . '/config' );
+		$request->set_param( 'pipeline_step_id', $pipeline_step_id );
+		$request->set_param( 'disabled_tools', array( 'test_disabled_tool', 123 ) );
+
+		$response = PipelineSteps::handle_upsert_step_config( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'invalid_disabled_tools', $response->get_error_code() );
+		$this->assertStringContainsString( 'disabled_tools must contain only strings', $response->get_error_message() );
+	}
+
 	public function test_update_pipeline_step_rejects_provider_and_model(): void {
 		$add_result       = $this->step_abilities->executeAddPipelineStep(
 			array(
@@ -409,7 +532,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 		);
 
 		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'system_prompt or disabled_tools', $result['error'] );
+		$this->assertStringContainsString( 'system_prompt, enabled_tools, disabled_tools, or tool_categories', $result['error'] );
 	}
 
 	public function test_update_pipeline_step_no_fields(): void {
@@ -848,5 +971,24 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 		// Verify processed items are cleaned up
 		$this->assertFalse($processed_items_db->has_item_been_processed($flow_step_id, 'rss', 'test-item-1'));
 		$this->assertFalse($processed_items_db->has_item_been_processed($flow_step_id, 'rss', 'test-item-2'));
+	}
+
+	private function register_test_pipeline_tools(): void {
+		add_filter(
+			'datamachine_tools',
+			static function ( array $tools ): array {
+				$tools['test_pipeline_tool'] = array(
+					'name'        => 'test_pipeline_tool',
+					'description' => 'Test pipeline tool',
+					'modes'       => array( 'pipeline' ),
+				);
+				$tools['test_disabled_tool'] = array(
+					'name'        => 'test_disabled_tool',
+					'description' => 'Test disabled tool',
+					'modes'       => array( 'pipeline' ),
+				);
+				return $tools;
+			}
+		);
 	}
 }

--- a/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
@@ -405,19 +405,17 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 		$result = $this->step_abilities->executeUpdatePipelineStep(
 			array(
 				'pipeline_step_id' => $pipeline_step_id,
-				'enabled_tools'    => array( 'test_pipeline_tool' ),
 				'disabled_tools'   => array( 'test_disabled_tool' ),
 				'tool_categories'  => array( 'datamachine-test' ),
 			)
 		);
 
 		$this->assertTrue( $result['success'] );
-		$this->assertSame( array( 'enabled_tools', 'disabled_tools', 'tool_categories' ), $result['updated_fields'] );
+		$this->assertSame( array( 'disabled_tools', 'tool_categories' ), $result['updated_fields'] );
 
 		$db_pipelines    = new Pipelines();
 		$pipeline_config = $db_pipelines->get_pipeline_config( $this->test_pipeline_id );
 
-		$this->assertSame( array( 'test_pipeline_tool' ), $pipeline_config[ $pipeline_step_id ]['enabled_tools'] );
 		$this->assertSame( array( 'test_disabled_tool' ), $pipeline_config[ $pipeline_step_id ]['disabled_tools'] );
 		$this->assertSame( array( 'datamachine-test' ), $pipeline_config[ $pipeline_step_id ]['tool_categories'] );
 	}
@@ -434,11 +432,11 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 		$non_array_result = $this->step_abilities->executeUpdatePipelineStep(
 			array(
 				'pipeline_step_id' => $pipeline_step_id,
-				'enabled_tools'    => 'test_pipeline_tool',
+				'disabled_tools'   => 'test_disabled_tool',
 			)
 		);
 		$this->assertFalse( $non_array_result['success'] );
-		$this->assertStringContainsString( 'enabled_tools must be an array of strings', $non_array_result['error'] );
+		$this->assertStringContainsString( 'disabled_tools must be an array of strings', $non_array_result['error'] );
 
 		$non_string_result = $this->step_abilities->executeUpdatePipelineStep(
 			array(
@@ -455,11 +453,12 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 
 		$args = $method->invoke( null, true );
 
-		foreach ( array( 'enabled_tools', 'disabled_tools', 'tool_categories' ) as $field ) {
+		foreach ( array( 'disabled_tools', 'tool_categories' ) as $field ) {
 			$this->assertArrayHasKey( $field, $args );
 			$this->assertSame( 'array', $args[ $field ]['type'] );
 			$this->assertSame( array( 'type' => 'string' ), $args[ $field ]['items'] );
 		}
+		$this->assertArrayNotHasKey( 'enabled_tools', $args );
 	}
 
 	public function test_rest_pipeline_step_config_persists_tool_policy_fields(): void {
@@ -475,7 +474,6 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 
 		$request = new WP_REST_Request( 'PATCH', '/datamachine/v1/pipelines/steps/' . $pipeline_step_id . '/config' );
 		$request->set_param( 'pipeline_step_id', $pipeline_step_id );
-		$request->set_param( 'enabled_tools', array( 'test_pipeline_tool' ) );
 		$request->set_param( 'disabled_tools', array( 'test_disabled_tool' ) );
 		$request->set_param( 'tool_categories', array( 'datamachine-test' ) );
 
@@ -486,7 +484,6 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 		$db_pipelines    = new Pipelines();
 		$pipeline_config = $db_pipelines->get_pipeline_config( $this->test_pipeline_id );
 
-		$this->assertSame( array( 'test_pipeline_tool' ), $pipeline_config[ $pipeline_step_id ]['enabled_tools'] );
 		$this->assertSame( array( 'test_disabled_tool' ), $pipeline_config[ $pipeline_step_id ]['disabled_tools'] );
 		$this->assertSame( array( 'datamachine-test' ), $pipeline_config[ $pipeline_step_id ]['tool_categories'] );
 	}
@@ -531,7 +528,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 		);
 
 		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'system_prompt, enabled_tools, disabled_tools, or tool_categories', $result['error'] );
+		$this->assertStringContainsString( 'system_prompt, disabled_tools, or tool_categories', $result['error'] );
 	}
 
 	public function test_update_pipeline_step_no_fields(): void {

--- a/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
@@ -452,7 +452,6 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 
 	public function test_rest_pipeline_step_config_schema_exposes_tool_policy_fields(): void {
 		$method = new \ReflectionMethod( PipelineSteps::class, 'get_step_config_args' );
-		$method->setAccessible( true );
 
 		$args = $method->invoke( null, true );
 
@@ -990,5 +989,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 				return $tools;
 			}
 		);
+
+		\DataMachine\Engine\AI\Tools\ToolManager::clearCache();
 	}
 }


### PR DESCRIPTION
## Summary
- Expose the pipeline AI tool-policy fields that runtime already understands across the server write surfaces.
- Keep the canonical field names instead of introducing a new nested policy shape.

## Changes
- `datamachine/update-pipeline-step` now accepts `disabled_tools` and `tool_categories` as array-of-string policy fields.
- Pipeline step REST config writes expose and persist the same fields.
- `configure_pipeline_step` chat tool advertises the same policy fields.
- Shared validation rejects non-arrays and non-string entries with field-specific errors.
- Keeps `enabled_tools` out of the pipeline-step write surface because runtime allowlists are flow-scoped today.

## Tests
- `php -l inc/Abilities/PipelineStepAbilities.php`
- `php -l inc/Api/Pipelines/PipelineSteps.php`
- `php -l inc/Api/Chat/Tools/ConfigurePipelineStep.php`
- `php -l tests/Unit/Abilities/PipelineStepAbilitiesTest.php`
- `git diff --check`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-tool-policy-writes --changed-since origin/main` — PHPCS passed; Homeboy still exits non-zero because the ESLint leg parses PHP files, but baseline comparison reports no new lint findings.
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-tool-policy-writes -- --filter PipelineStepAbilitiesTest` — still runs the broader repo test suite and fails on existing unrelated harness/unit failures.

Closes #1448
Refs #1443

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the server-side tool-policy write surfaces, aligning the write contract with runtime tool policy ownership, adding focused PHPUnit coverage, and preparing the PR for Chris to review.
