### PR TITLE
test(lint): harden smoke source reads

### DIFF
--- a/tests/fetch-http-get-trait-smoke.php
+++ b/tests/fetch-http-get-trait-smoke.php
@@ -10,9 +10,9 @@
 $root = dirname( __DIR__ );
 
 $files = array(
-	'trait' => file_get_contents( $root . '/inc/Abilities/Fetch/FetchHttpGetTrait.php' ),
-	'rss'   => file_get_contents( $root . '/inc/Abilities/Fetch/FetchRssAbility.php' ),
-	'wpapi' => file_get_contents( $root . '/inc/Abilities/Fetch/FetchWordPressApiAbility.php' ),
+	'trait' => file_get_contents( $root . '/inc/Abilities/Fetch/FetchHttpGetTrait.php' ) ?: '',
+	'rss'   => file_get_contents( $root . '/inc/Abilities/Fetch/FetchRssAbility.php' ) ?: '',
+	'wpapi' => file_get_contents( $root . '/inc/Abilities/Fetch/FetchWordPressApiAbility.php' ) ?: '',
 );
 
 $failed = 0;
@@ -28,6 +28,11 @@ function assert_fetch_http_get_trait( string $name, bool $condition, string $det
 
 	++$failed;
 	echo "  [FAIL] {$name}" . ( $detail ? " - {$detail}" : '' ) . "\n";
+}
+
+function fetch_http_get_trait_failed_count(): int {
+	global $failed;
+	return $failed;
 }
 
 echo "=== fetch-http-get-trait-smoke ===\n";
@@ -65,7 +70,7 @@ assert_fetch_http_get_trait(
 		&& str_contains( $files['trait'], 'wp_remote_retrieve_body( $response )' )
 );
 
-if ( $failed > 0 ) {
+if ( fetch_http_get_trait_failed_count() > 0 ) {
 	echo "\nfetch-http-get-trait-smoke failed: {$failed}/{$total} assertions failed.\n";
 	exit( 1 );
 }

--- a/tests/fetch-test-cli-smoke.php
+++ b/tests/fetch-test-cli-smoke.php
@@ -14,9 +14,9 @@
 $root = dirname( __DIR__ );
 
 $files = array(
-	'bootstrap' => file_get_contents( $root . '/inc/Cli/Bootstrap.php' ),
-	'test'      => file_get_contents( $root . '/inc/Cli/Commands/TestCommand.php' ),
-	'handlers'  => file_get_contents( $root . '/inc/Cli/Commands/HandlersCommand.php' ),
+	'bootstrap' => file_get_contents( $root . '/inc/Cli/Bootstrap.php' ) ?: '',
+	'test'      => file_get_contents( $root . '/inc/Cli/Commands/TestCommand.php' ) ?: '',
+	'handlers'  => file_get_contents( $root . '/inc/Cli/Commands/HandlersCommand.php' ) ?: '',
 );
 
 $failed = 0;
@@ -32,6 +32,11 @@ function assert_fetch_cli( string $name, bool $condition, string $detail = '' ):
 
 	++$failed;
 	echo "  [FAIL] {$name}" . ( $detail ? " — {$detail}" : '' ) . "\n";
+}
+
+function fetch_cli_failed_count(): int {
+	global $failed;
+	return $failed;
 }
 
 echo "=== fetch-test-cli-smoke ===\n";
@@ -71,7 +76,7 @@ assert_fetch_cli(
 	str_contains( $files['handlers'], "? array( 'slug', 'label', 'step_type', 'settings_class' )" )
 );
 
-if ( $failed > 0 ) {
+if ( fetch_cli_failed_count() > 0 ) {
 	echo "\nfetch-test-cli-smoke failed: {$failed}/{$total} assertions failed.\n";
 	exit( 1 );
 }

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -8,7 +8,7 @@
  */
 
 $file = __DIR__ . '/../inc/Cli/Commands/Flows/FlowsCommand.php';
-$src  = file_get_contents( $file );
+$src  = file_get_contents( $file ) ?: '';
 
 $assertions = 0;
 
@@ -21,38 +21,44 @@ function assert_true( bool $condition, string $message ): void {
 	}
 }
 
-function assert_contains( string $needle, string $haystack, string $message ): void {
+function assert_drain_contains( string $needle, string $haystack, string $message ): void {
 	assert_true( false !== strpos( $haystack, $needle ), $message );
 }
 
-function assert_not_contains( string $needle, string $haystack, string $message ): void {
+function assert_drain_not_contains( string $needle, string $haystack, string $message ): void {
 	assert_true( false === strpos( $haystack, $needle ), $message );
 }
 
-assert_contains( '[--no-drain]', $src, 'flow run usage documents --no-drain escape hatch' );
-assert_contains( '$drain     = ! isset( $assoc_args[\'no-drain\'] );', $src, 'immediate runs drain by default' );
-assert_contains( 'if ( $drain ) {', $src, 'drain is gated by the CLI flag' );
-assert_contains( '$this->drainDueStepActions();', $src, 'immediate run calls the drain helper' );
-assert_contains( 'private function drainDueStepActions(): void', $src, 'drain helper exists' );
-assert_contains( 'WP_CLI::runcommand(', $src, 'drain helper reuses WP-CLI command runner' );
-assert_contains( 'action-scheduler run --hooks=datamachine_execute_step --quiet', $src, 'drain is scoped to due DM step actions' );
-assert_contains( "'exit_error' => false", $src, 'drain failure is surfaced as warning instead of fataling after job start' );
-assert_contains( "'return'     => 'all'", $src, 'drain captures Action Scheduler command result' );
-assert_contains( 'Drained due Data Machine step actions.', $src, 'successful drain is visible to CLI operator' );
+assert_drain_contains( '[--no-drain]', $src, 'flow run usage documents --no-drain escape hatch' );
+assert_drain_contains( '$drain     = ! isset( $assoc_args[\'no-drain\'] );', $src, 'immediate runs drain by default' );
+assert_drain_contains( 'if ( $drain ) {', $src, 'drain is gated by the CLI flag' );
+assert_drain_contains( '$this->drainDueStepActions();', $src, 'immediate run calls the drain helper' );
+assert_drain_contains( 'private function drainDueStepActions(): void', $src, 'drain helper exists' );
+assert_drain_contains( 'WP_CLI::runcommand(', $src, 'drain helper reuses WP-CLI command runner' );
+assert_drain_contains( 'action-scheduler run --hooks=datamachine_execute_step --quiet', $src, 'drain is scoped to due DM step actions' );
+assert_drain_contains( "'exit_error' => false", $src, 'drain failure is surfaced as warning instead of fataling after job start' );
+assert_drain_contains( "'return'     => 'all'", $src, 'drain captures Action Scheduler command result' );
+assert_drain_contains( 'Drained due Data Machine step actions.', $src, 'successful drain is visible to CLI operator' );
 
 $run_flow_start = strpos( $src, 'private function runFlow' );
-$timestamp_path = strpos( $src, '// Delayed execution', $run_flow_start );
-$immediate_path = strpos( $src, '// Immediate execution', $run_flow_start );
-$drain_call     = strpos( $src, '$this->drainDueStepActions();', $run_flow_start );
-
 assert_true( false !== $run_flow_start, 'runFlow method found' );
+
+$run_flow_offset = false === $run_flow_start ? 0 : $run_flow_start;
+$timestamp_path  = strpos( $src, '// Delayed execution', $run_flow_offset );
+$immediate_path  = strpos( $src, '// Immediate execution', $run_flow_offset );
+$drain_call      = strpos( $src, '$this->drainDueStepActions();', $run_flow_offset );
+
 assert_true( false !== $timestamp_path, 'delayed scheduling path found' );
 assert_true( false !== $immediate_path, 'immediate execution path found' );
 assert_true( false !== $drain_call, 'drain call found in runFlow' );
 assert_true( $drain_call > $immediate_path, 'drain runs only after immediate execution starts jobs' );
 assert_true( $drain_call > $timestamp_path, 'timestamp scheduling returns before the drain call' );
 
-$helper_src = substr( $src, strpos( $src, 'private function drainDueStepActions(): void' ) );
-assert_not_contains( 'datamachine_run_flow_now', $helper_src, 'drain does not run scheduled flow-trigger actions' );
+$helper_start = strpos( $src, 'private function drainDueStepActions(): void' );
+assert_true( false !== $helper_start, 'drain helper start found' );
+
+$helper_offset = false === $helper_start ? 0 : $helper_start;
+$helper_src    = substr( $src, $helper_offset );
+assert_drain_not_contains( 'datamachine_run_flow_now', $helper_src, 'drain does not run scheduled flow-trigger actions' );
 
 echo "OK ({$assertions} assertions)\n";

--- a/tests/retention-system-tasks-smoke.php
+++ b/tests/retention-system-tasks-smoke.php
@@ -15,12 +15,12 @@
 $root = dirname( __DIR__ );
 
 $sources = array(
-	'bootstrap' => file_get_contents( $root . '/inc/bootstrap.php' ),
-	'provider'  => file_get_contents( $root . '/inc/Engine/AI/System/SystemAgentServiceProvider.php' ),
-	'command'   => file_get_contents( $root . '/inc/Cli/Commands/RetentionCommand.php' ),
-	'files'     => file_get_contents( $root . '/inc/Core/FilesRepository/FileCleanup.php' ),
-	'chat'      => file_get_contents( $root . '/inc/Core/Database/Chat/Chat.php' ),
-	'cleanup'   => file_get_contents( $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php' ),
+	'bootstrap' => file_get_contents( $root . '/inc/bootstrap.php' ) ?: '',
+	'provider'  => file_get_contents( $root . '/inc/Engine/AI/System/SystemAgentServiceProvider.php' ) ?: '',
+	'command'   => file_get_contents( $root . '/inc/Cli/Commands/RetentionCommand.php' ) ?: '',
+	'files'     => file_get_contents( $root . '/inc/Core/FilesRepository/FileCleanup.php' ) ?: '',
+	'chat'      => file_get_contents( $root . '/inc/Core/Database/Chat/Chat.php' ) ?: '',
+	'cleanup'   => file_get_contents( $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php' ) ?: '',
 );
 
 $failed = 0;
@@ -36,6 +36,11 @@ function assert_retention( string $name, bool $condition, string $detail = '' ):
 
 	++$failed;
 	echo "  [FAIL] {$name}" . ( $detail ? " — {$detail}" : '' ) . "\n";
+}
+
+function retention_failed_count(): int {
+	global $failed;
+	return $failed;
 }
 
 echo "=== retention-system-tasks-smoke ===\n";
@@ -67,7 +72,7 @@ $task_classes = array(
 
 foreach ( $task_classes as $task_class ) {
 	$path = $root . '/inc/Engine/AI/System/Tasks/Retention/' . $task_class . '.php';
-	$task_source = file_exists( $path ) ? file_get_contents( $path ) : '';
+	$task_source = file_exists( $path ) ? file_get_contents( $path ) ?: '' : '';
 	assert_retention( "task class file exists: {$task_class}", file_exists( $path ) );
 	assert_retention( "provider imports {$task_class}", str_contains( $sources['provider'], $task_class . ';' ) );
 	assert_retention( "provider registers {$task_class}", str_contains( $sources['provider'], '= ' . $task_class . '::class;' ) );
@@ -125,7 +130,7 @@ assert_retention(
 		&& str_contains( $sources['cleanup'], '++$count;' )
 );
 
-if ( $failed > 0 ) {
+if ( retention_failed_count() > 0 ) {
 	echo "\nretention-system-tasks-smoke failed: {$failed}/{$total} assertions failed.\n";
 	exit( 1 );
 }


### PR DESCRIPTION
## Summary
- Targeted lint burn-down for pure-PHP smoke tests that read source files with `file_get_contents()` and then pass the result to string helpers.
- Keeps the change scoped to test harness hardening; no production behavior changes.

## Changes
- Normalized source-file reads in four smoke tests to fall back to an empty string when `file_get_contents()` returns `false`.
- Gave the CLI drain smoke local assertion helper names so PHPStan does not resolve a different global helper signature.
- Added small failed-count accessors where PHPStan could not see assertion helper side effects on global counters.

## Tests
- `php -l tests/retention-system-tasks-smoke.php && php -l tests/fetch-http-get-trait-smoke.php && php -l tests/fetch-test-cli-smoke.php && php -l tests/flow-run-cli-drain-smoke.php`
- `php tests/retention-system-tasks-smoke.php`
- `php tests/fetch-http-get-trait-smoke.php`
- `php tests/fetch-test-cli-smoke.php`
- `php tests/flow-run-cli-drain-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@cleanup-lint-findings` — still fails on the repository baseline, but reported findings dropped from 6,580 to 567.
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@cleanup-lint-findings --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the narrow lint cleanup, ran local verification, and prepared the PR description. Chris remains responsible for reviewing and testing the change.