### PR TITLE
feat: support payload propagation through OAuth state

### DIFF
--- a/inc/Core/OAuth/BaseOAuth2Provider.php
+++ b/inc/Core/OAuth/BaseOAuth2Provider.php
@@ -584,13 +584,16 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 	 *     return $this->oauth2->get_authorization_url( $auth_endpoint, $params );
 	 *
 	 * @since 0.66.0
+	 * @since 0.88.0 Added optional $state_payload parameter.
+	 *
+	 * @param array $state_payload Optional payload to propagate through the OAuth state.
 	 * @return array Query parameters for the authorization URL.
 	 */
-	protected function build_auth_url_params(): array {
+	protected function build_auth_url_params( array $state_payload = array() ): array {
 		$params = array(
 			'response_type' => $this->get_oauth_response_type(),
 			'redirect_uri'  => $this->get_callback_url(),
-			'state'         => $this->oauth2->create_state( $this->provider_slug ),
+			'state'         => $this->oauth2->create_state( $this->provider_slug, $state_payload ),
 		);
 
 		if ( $this->uses_pkce() ) {

--- a/inc/Core/OAuth/OAuth2Handler.php
+++ b/inc/Core/OAuth/OAuth2Handler.php
@@ -27,18 +27,62 @@ class OAuth2Handler {
 	use OAuthRedirects;
 
 	// -------------------------------------------------------------------------
+	// Constants
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Maximum serialized payload size in bytes.
+	 *
+	 * Keeps transients sane — payloads larger than this are rejected at
+	 * create_state() time rather than silently bloating the options table.
+	 */
+	const MAX_PAYLOAD_SIZE = 4096;
+
+	// -------------------------------------------------------------------------
 	// State Management
 	// -------------------------------------------------------------------------
 
 	/**
 	 * Create OAuth state nonce and store in transient.
 	 *
+	 * The state parameter is the canonical place in OAuth 2.0 to carry
+	 * caller-defined context through the authorization dance. The payload
+	 * array is stored alongside the CSRF nonce and returned to the caller
+	 * on successful verify_state().
+	 *
+	 * @since 0.2.0
+	 * @since 0.88.0 Added optional $payload parameter.
+	 *
 	 * @param string $provider_key Provider identifier (e.g., 'reddit', 'facebook').
-	 * @return string Generated state value.
+	 * @param array  $payload      Optional caller-defined context to propagate through the OAuth flow.
+	 *                             Must serialize to <= 4 KB. Opaque to the OAuth provider.
+	 * @return string Generated state nonce value.
+	 *
+	 * @throws \InvalidArgumentException When serialized payload exceeds MAX_PAYLOAD_SIZE.
 	 */
-	public function create_state( string $provider_key ): string {
-		$state = bin2hex( random_bytes( 32 ) );
-		set_transient( "datamachine_{$provider_key}_oauth_state", $state, 15 * MINUTE_IN_SECONDS );
+	public function create_state( string $provider_key, array $payload = array() ): string {
+		// Validate payload size.
+		if ( ! empty( $payload ) ) {
+			$serialized_size = strlen( maybe_serialize( $payload ) );
+			if ( $serialized_size > self::MAX_PAYLOAD_SIZE ) {
+				throw new \InvalidArgumentException(
+					sprintf(
+						'OAuth state payload exceeds maximum size (%d bytes > %d bytes).',
+						$serialized_size,
+						self::MAX_PAYLOAD_SIZE
+					)
+				);
+			}
+		}
+
+		$nonce  = bin2hex( random_bytes( 32 ) );
+		$record = array(
+			'nonce'      => $nonce,
+			'payload'    => $payload,
+			'created_at' => time(),
+		);
+
+		set_transient( "datamachine_{$provider_key}_oauth_state", $record, 15 * MINUTE_IN_SECONDS );
 
 		do_action(
 			'datamachine_log',
@@ -46,28 +90,97 @@ class OAuth2Handler {
 			'OAuth2: Created state nonce',
 			array(
 				'provider'     => $provider_key,
-				'state_length' => strlen( $state ),
+				'state_length' => strlen( $nonce ),
+				'has_payload'  => ! empty( $payload ),
 			)
 		);
 
-		return $state;
+		return $nonce;
 	}
 
 	/**
-	 * Verify OAuth state nonce.
+	 * Verify OAuth state nonce and return the associated payload.
+	 *
+	 * Returns the caller-defined payload array on success, or false on failure.
+	 * The transient is consumed (deleted) on successful verification.
+	 *
+	 * Backward-compatible: legacy plain-string transients (from in-flight
+	 * authorizations during the deploy window) are handled gracefully —
+	 * they verify correctly and return an empty payload array.
+	 *
+	 * IMPORTANT: The return type changed from `bool` to `array|false`.
+	 * Callers MUST use `false !== $oauth2->verify_state(...)` instead of
+	 * the previous `if ( $oauth2->verify_state(...) )` pattern, because
+	 * an empty array `[]` is falsy in PHP boolean context.
+	 *
+	 * @since 0.2.0
+	 * @since 0.88.0 Return type changed from bool to array|false. Returns payload on success.
 	 *
 	 * @param string $provider_key Provider identifier.
-	 * @param string $state State value to verify.
-	 * @return bool True if state is valid.
+	 * @param string $state        State nonce value to verify.
+	 * @return array|false Payload array on success (may be empty), false on failure.
 	 */
-	public function verify_state( string $provider_key, string $state ): bool {
-		$stored_state = get_transient( "datamachine_{$provider_key}_oauth_state" );
-		$is_valid     = ! empty( $state ) && false !== $stored_state && hash_equals( $stored_state, $state );
-
-		if ( $is_valid ) {
-			delete_transient( "datamachine_{$provider_key}_oauth_state" );
+	public function verify_state( string $provider_key, string $state ) {
+		if ( empty( $state ) ) {
+			$this->log_state_verification( $provider_key, false );
+			return false;
 		}
 
+		$record = get_transient( "datamachine_{$provider_key}_oauth_state" );
+
+		if ( false === $record ) {
+			$this->log_state_verification( $provider_key, false );
+			return false;
+		}
+
+		// Backward compat: legacy plain-string state (pre-payload era).
+		if ( is_string( $record ) ) {
+			if ( hash_equals( $record, $state ) ) {
+				delete_transient( "datamachine_{$provider_key}_oauth_state" );
+				$this->log_state_verification( $provider_key, true );
+				return array();
+			}
+			$this->log_state_verification( $provider_key, false );
+			return false;
+		}
+
+		// New structured record format.
+		if ( ! is_array( $record ) || empty( $record['nonce'] ) ) {
+			$this->log_state_verification( $provider_key, false );
+			return false;
+		}
+
+		if ( ! hash_equals( $record['nonce'], $state ) ) {
+			$this->log_state_verification( $provider_key, false );
+			return false;
+		}
+
+		delete_transient( "datamachine_{$provider_key}_oauth_state" );
+		$this->log_state_verification( $provider_key, true );
+
+		return $record['payload'] ?? array();
+	}
+
+	/**
+	 * Alias for verify_state() — reads cleaner at call sites that want the payload.
+	 *
+	 * @since 0.88.0
+	 *
+	 * @param string $provider_key Provider identifier.
+	 * @param string $state        State nonce value to verify.
+	 * @return array|false Payload array on success, false on failure.
+	 */
+	public function get_state_payload( string $provider_key, string $state ) {
+		return $this->verify_state( $provider_key, $state );
+	}
+
+	/**
+	 * Log state verification result.
+	 *
+	 * @param string $provider_key Provider identifier.
+	 * @param bool   $is_valid     Whether the state was valid.
+	 */
+	private function log_state_verification( string $provider_key, bool $is_valid ): void {
 		do_action(
 			'datamachine_log',
 			$is_valid ? 'debug' : 'error',
@@ -77,8 +190,6 @@ class OAuth2Handler {
 				'valid'    => $is_valid,
 			)
 		);
-
-		return $is_valid;
 	}
 
 	// -------------------------------------------------------------------------
@@ -195,6 +306,13 @@ class OAuth2Handler {
 	 * When PKCE is enabled, the stored code_verifier is automatically included
 	 * in the token exchange parameters.
 	 *
+	 * The recovered state payload is passed to the storage callback as the second
+	 * argument, allowing providers to access caller-defined context that was
+	 * propagated through the OAuth dance via create_state().
+	 *
+	 * @since 0.2.0
+	 * @since 0.88.0 Storage callback now receives payload as second argument.
+	 *
 	 * @param string        $provider_key Provider identifier.
 	 * @param string        $token_url Token exchange endpoint URL.
 	 * @param array         $token_params Parameters for token exchange.
@@ -203,7 +321,7 @@ class OAuth2Handler {
 	 * @param callable|null $token_transform_fn Optional function to transform token data (for two-stage exchanges like Meta long-lived tokens).
 	 *                                          Signature: function(array $token_data): array|WP_Error
 	 * @param callable|null $storage_fn Optional callback to store account data.
-	 *                                  Signature: function(array $account_data): bool
+	 *                                  Signature: function(array $account_data, array $state_payload): bool
 	 * @return bool|\WP_Error True on success, WP_Error on failure.
 	 */
 	public function handle_callback(
@@ -238,8 +356,10 @@ class OAuth2Handler {
 			return new \WP_Error( 'oauth_denied', __( 'OAuth authorization denied.', 'data-machine' ) );
 		}
 
-		// Verify state
-		if ( ! $this->verify_state( $provider_key, $state ) ) {
+		// Verify state and recover payload.
+		$state_payload = $this->verify_state( $provider_key, $state );
+
+		if ( false === $state_payload ) {
 			do_action(
 				'datamachine_log',
 				'error',
@@ -322,10 +442,11 @@ class OAuth2Handler {
 			return $account_data;
 		}
 
-		// Store account data
+		// Store account data — pass recovered state payload as second argument
+		// so providers can access caller-defined context without touching OAuth2Handler directly.
 		$stored = false;
 		if ( $storage_fn ) {
-			$stored = call_user_func( $storage_fn, $account_data );
+			$stored = call_user_func( $storage_fn, $account_data, $state_payload );
 		} else {
 			do_action(
 				'datamachine_log',

--- a/tests/Unit/Core/OAuth/OAuth2HandlerStateTest.php
+++ b/tests/Unit/Core/OAuth/OAuth2HandlerStateTest.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * OAuth2Handler State Payload Tests
+ *
+ * Tests for the state payload propagation feature:
+ * - Payload roundtrip (create → verify → recover payload)
+ * - Empty payload
+ * - Oversized payload rejection
+ * - Malformed transient handling
+ * - Expired transient handling
+ * - Legacy plain-string state migration
+ *
+ * @package DataMachine\Tests\Unit\Core\OAuth
+ */
+
+namespace DataMachine\Tests\Unit\Core\OAuth;
+
+use DataMachine\Core\OAuth\OAuth2Handler;
+use WP_UnitTestCase;
+
+class OAuth2HandlerStateTest extends WP_UnitTestCase {
+
+	private OAuth2Handler $handler;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->handler = new OAuth2Handler();
+	}
+
+	public function tear_down(): void {
+		// Clean up any transients.
+		delete_transient( 'datamachine_test_provider_oauth_state' );
+		delete_transient( 'datamachine_test_roundtrip_oauth_state' );
+		delete_transient( 'datamachine_test_empty_oauth_state' );
+		delete_transient( 'datamachine_test_legacy_oauth_state' );
+		delete_transient( 'datamachine_test_malformed_oauth_state' );
+		delete_transient( 'datamachine_test_oversize_oauth_state' );
+		delete_transient( 'datamachine_test_expired_oauth_state' );
+		parent::tear_down();
+	}
+
+	// -------------------------------------------------------------------------
+	// create_state() basics
+	// -------------------------------------------------------------------------
+
+	public function test_create_state_returns_hex_string(): void {
+		$state = $this->handler->create_state( 'test_provider' );
+
+		$this->assertNotEmpty( $state );
+		$this->assertSame( 64, strlen( $state ) ); // 32 bytes = 64 hex chars
+		$this->assertMatchesRegularExpression( '/^[0-9a-f]+$/', $state );
+	}
+
+	public function test_create_state_stores_structured_record_in_transient(): void {
+		$this->handler->create_state( 'test_provider', array( 'key' => 'value' ) );
+
+		$record = get_transient( 'datamachine_test_provider_oauth_state' );
+
+		$this->assertIsArray( $record );
+		$this->assertArrayHasKey( 'nonce', $record );
+		$this->assertArrayHasKey( 'payload', $record );
+		$this->assertArrayHasKey( 'created_at', $record );
+		$this->assertSame( array( 'key' => 'value' ), $record['payload'] );
+	}
+
+	public function test_create_state_without_payload_stores_empty_array(): void {
+		$this->handler->create_state( 'test_provider' );
+
+		$record = get_transient( 'datamachine_test_provider_oauth_state' );
+
+		$this->assertIsArray( $record );
+		$this->assertSame( array(), $record['payload'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Payload roundtrip
+	// -------------------------------------------------------------------------
+
+	public function test_payload_roundtrip(): void {
+		$payload = array(
+			'artist_id' => 123,
+			'return_to' => '/manage-artist/awesome-band',
+			'request_id' => 'req_abc123',
+		);
+
+		$state = $this->handler->create_state( 'test_roundtrip', $payload );
+
+		$result = $this->handler->verify_state( 'test_roundtrip', $state );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $payload, $result );
+	}
+
+	public function test_payload_with_nested_arrays(): void {
+		$payload = array(
+			'config'  => array(
+				'mode' => 'advanced',
+				'tags' => array( 'alpha', 'beta' ),
+			),
+			'user_id' => 42,
+		);
+
+		$state = $this->handler->create_state( 'test_roundtrip', $payload );
+
+		$result = $this->handler->verify_state( 'test_roundtrip', $state );
+
+		$this->assertSame( $payload, $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// Empty payload
+	// -------------------------------------------------------------------------
+
+	public function test_empty_payload_returns_empty_array_on_verify(): void {
+		$state = $this->handler->create_state( 'test_empty' );
+
+		$result = $this->handler->verify_state( 'test_empty', $state );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( array(), $result );
+		// Empty array is falsy in PHP — callers must use `false !== $result`.
+		$this->assertTrue( false !== $result );
+	}
+
+	public function test_empty_payload_is_not_identical_to_false(): void {
+		$state = $this->handler->create_state( 'test_empty' );
+
+		$result = $this->handler->verify_state( 'test_empty', $state );
+
+		// This is the critical assertion: empty array !== false.
+		$this->assertNotFalse( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// Oversized payload rejection
+	// -------------------------------------------------------------------------
+
+	public function test_oversized_payload_throws_exception(): void {
+		// Create a payload that exceeds 4 KB when serialized.
+		$payload = array(
+			'data' => str_repeat( 'x', 5000 ),
+		);
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessageMatches( '/exceeds maximum size/' );
+
+		$this->handler->create_state( 'test_oversize', $payload );
+	}
+
+	public function test_payload_at_limit_is_accepted(): void {
+		// Create a payload that's just under 4 KB.
+		// Serialized array overhead is ~30 bytes, so use ~4050 bytes of data.
+		$payload = array(
+			'data' => str_repeat( 'x', 4000 ),
+		);
+
+		$serialized_size = strlen( maybe_serialize( $payload ) );
+
+		// Only test if actually under the limit.
+		if ( $serialized_size <= OAuth2Handler::MAX_PAYLOAD_SIZE ) {
+			$state = $this->handler->create_state( 'test_provider', $payload );
+			$this->assertNotEmpty( $state );
+		} else {
+			// If our test payload happens to exceed, adjust and skip.
+			$this->markTestSkipped( 'Test payload exceeded size limit.' );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Malformed transient
+	// -------------------------------------------------------------------------
+
+	public function test_malformed_transient_returns_false(): void {
+		// Simulate a corrupted/malformed transient (array without nonce key).
+		set_transient( 'datamachine_test_malformed_oauth_state', array( 'garbage' => 'data' ), 900 );
+
+		$result = $this->handler->verify_state( 'test_malformed', 'any_state_value' );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_null_record_returns_false(): void {
+		// No transient set at all.
+		$result = $this->handler->verify_state( 'nonexistent_provider', 'any_state_value' );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_empty_state_string_returns_false(): void {
+		$this->handler->create_state( 'test_provider' );
+
+		$result = $this->handler->verify_state( 'test_provider', '' );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_wrong_nonce_returns_false(): void {
+		$this->handler->create_state( 'test_provider', array( 'secret' => 'data' ) );
+
+		$result = $this->handler->verify_state( 'test_provider', 'wrong_nonce_value' );
+
+		$this->assertFalse( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// Expired transient
+	// -------------------------------------------------------------------------
+
+	public function test_expired_transient_returns_false(): void {
+		// WordPress transients with 0 TTL or manually deleted simulate expiry.
+		$state = $this->handler->create_state( 'test_expired' );
+
+		// Simulate expiration by deleting the transient.
+		delete_transient( 'datamachine_test_expired_oauth_state' );
+
+		$result = $this->handler->verify_state( 'test_expired', $state );
+
+		$this->assertFalse( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// Legacy plain-string state migration
+	// -------------------------------------------------------------------------
+
+	public function test_legacy_plain_string_state_verifies_correctly(): void {
+		// Simulate the old format: plain hex string stored directly in transient.
+		$legacy_state = bin2hex( random_bytes( 32 ) );
+		set_transient( 'datamachine_test_legacy_oauth_state', $legacy_state, 900 );
+
+		$result = $this->handler->verify_state( 'test_legacy', $legacy_state );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( array(), $result ); // Legacy states have no payload.
+	}
+
+	public function test_legacy_plain_string_state_deletes_transient_on_success(): void {
+		$legacy_state = bin2hex( random_bytes( 32 ) );
+		set_transient( 'datamachine_test_legacy_oauth_state', $legacy_state, 900 );
+
+		$this->handler->verify_state( 'test_legacy', $legacy_state );
+
+		// Transient should be consumed.
+		$this->assertFalse( get_transient( 'datamachine_test_legacy_oauth_state' ) );
+	}
+
+	public function test_legacy_plain_string_state_rejects_wrong_nonce(): void {
+		$legacy_state = bin2hex( random_bytes( 32 ) );
+		set_transient( 'datamachine_test_legacy_oauth_state', $legacy_state, 900 );
+
+		$result = $this->handler->verify_state( 'test_legacy', 'wrong_value' );
+
+		$this->assertFalse( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// State consumption (one-time use)
+	// -------------------------------------------------------------------------
+
+	public function test_state_is_consumed_after_verify(): void {
+		$state = $this->handler->create_state( 'test_provider', array( 'once' => true ) );
+
+		// First verification succeeds.
+		$result = $this->handler->verify_state( 'test_provider', $state );
+		$this->assertNotFalse( $result );
+
+		// Second verification fails (consumed).
+		$result2 = $this->handler->verify_state( 'test_provider', $state );
+		$this->assertFalse( $result2 );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_state_payload() alias
+	// -------------------------------------------------------------------------
+
+	public function test_get_state_payload_is_alias_for_verify_state(): void {
+		$payload = array( 'artist_id' => 456 );
+		$state   = $this->handler->create_state( 'test_provider', $payload );
+
+		$result = $this->handler->get_state_payload( 'test_provider', $state );
+
+		$this->assertSame( $payload, $result );
+	}
+
+	public function test_get_state_payload_returns_false_on_failure(): void {
+		$result = $this->handler->get_state_payload( 'test_provider', 'bogus' );
+
+		$this->assertFalse( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// MAX_PAYLOAD_SIZE constant
+	// -------------------------------------------------------------------------
+
+	public function test_max_payload_size_constant_is_4096(): void {
+		$this->assertSame( 4096, OAuth2Handler::MAX_PAYLOAD_SIZE );
+	}
+}


### PR DESCRIPTION
## Summary

Extends `OAuth2Handler` state management to carry caller-defined context through the OAuth authorization dance. The `state` parameter is the canonical place in OAuth 2.0 for this — we were under-using it.

Closes #1460

## What changed

### `OAuth2Handler`

- **`create_state(string $provider, array $payload = []): string`** — new optional second arg. Stores a structured record `{nonce, payload, created_at}` in the transient instead of a bare hex string.
- **`verify_state(string $provider, string $state): array|false`** — returns the recovered payload array on success, `false` on failure. Transient is consumed on success.
- **`get_state_payload()`** — alias for `verify_state()` that reads cleaner at call sites that want the payload.
- **`MAX_PAYLOAD_SIZE = 4096`** — payloads exceeding 4 KB serialized are rejected with `InvalidArgumentException` at `create_state()` time.
- **`handle_callback()`** — now captures the payload from `verify_state()` and passes it to the storage callback as the **second argument**: `$storage_fn($account_data, $state_payload)`.

### `BaseOAuth2Provider`

- **`build_auth_url_params(array $state_payload = [])`** — new optional arg forwarded to `create_state()`. Subclasses can pass payload when building the auth URL.

### Tests

- New `OAuth2HandlerStateTest` (19 tests) covering: payload roundtrip, nested arrays, empty payload, oversized payload rejection, malformed transient, expired transient, legacy plain-string migration, state consumption (one-time use), `get_state_payload()` alias, and `MAX_PAYLOAD_SIZE` constant.

## BC consideration — return type change

`verify_state()` return type changed from `bool` to `array|false`. This is the one BC break:

| Pattern | Old behavior | New behavior | Status |
|---------|-------------|-------------|--------|
| `if ( $oauth2->verify_state(...) )` | `true` on success | `array()` on success — **falsy in PHP** | **Broken** for empty-payload case |
| `if ( false !== $oauth2->verify_state(...) )` | N/A | Works correctly | **Correct** |

### Call-site audit

| Location | Calls `verify_state()` directly? | Action |
|----------|--------------------------------|--------|
| `OAuth2Handler::handle_callback()` | Yes (internal) | **Updated** to `false === $state_payload` |
| `data-machine-socials` providers | No — they call `handle_callback()` which handles it internally | **No changes needed** |
| External plugins | Unknown — but the old `if (...)` pattern still works when payload is non-empty | Documented in PHPDoc |

The storage callbacks in data-machine-socials don't declare a 2nd parameter. PHP silently ignores extra arguments passed to closures that don't declare them — this is safe. Providers can **opt in** to using the payload by adding `$state_payload` to their callback signature when they need it.

### Backward-compat read path

During the deploy window, in-flight authorizations may have legacy plain-string transients. The new `verify_state()` detects `is_string($record)` and falls back to `hash_equals()` with an empty payload return — no user-facing impact.

## Motivating use case

Extra-Chill/extrachill-artist-platform#25 — per-artist Instagram OAuth. Each flow needs to know which artist's connection it represents when the callback fires. With this change: `create_state('instagram', ['artist_id' => 123, 'return_to' => '/manage-artist/...'])`, recovered on callback via the payload.