### PR TITLE
feat: encrypt OAuth tokens at rest in BaseAuthProvider

### DIFF
--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -9,6 +9,14 @@
  * are shared across all subsites on a multisite network. On single-site installs,
  * these behave identically to get_option()/update_option().
  *
+ * Sensitive fields (tokens, secrets) are encrypted at rest using AES-256-CBC with
+ * a key derived from wp_salt('auth'). Encrypted values use an envelope format:
+ *
+ *     dm:enc:v1:{base64(iv)}:{base64(ciphertext)}
+ *
+ * Plaintext values without the envelope prefix are read as-is for backward
+ * compatibility. Values get encrypted opportunistically on next save.
+ *
  * @package DataMachine
  * @subpackage Core\OAuth
  * @since 0.2.6
@@ -21,6 +29,40 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 abstract class BaseAuthProvider {
+
+	/**
+	 * Encryption envelope prefix.
+	 *
+	 * @since 0.88.0
+	 */
+	const ENCRYPTION_PREFIX = 'dm:enc:v1:';
+
+	/**
+	 * Cipher algorithm for at-rest encryption.
+	 *
+	 * @since 0.88.0
+	 */
+	const CIPHER_ALGO = 'aes-256-cbc';
+
+	/**
+	 * Fields that should be encrypted when stored.
+	 *
+	 * Providers can extend this list via the `datamachine_auth_encrypted_fields` filter.
+	 *
+	 * @since 0.88.0
+	 * @var array<string>
+	 */
+	const ENCRYPTED_FIELDS = array(
+		'access_token',
+		'refresh_token',
+		'oauth_token',
+		'oauth_token_secret',
+		'app_secret',
+		'client_secret',
+		'consumer_secret',
+		'api_secret',
+		'webhook_secret',
+	);
 
 	/**
 	 * @var string Provider slug (e.g., 'twitter', 'facebook')
@@ -87,25 +129,35 @@ abstract class BaseAuthProvider {
 	/**
 	 * Get OAuth account data directly from options.
 	 *
+	 * Automatically decrypts any encrypted fields. Plaintext legacy values
+	 * pass through unchanged.
+	 *
 	 * @return array Account data or empty array
 	 */
 	public function get_account(): array {
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
-		return $all_auth_data[ $this->provider_slug ]['account'] ?? array();
+		$account       = $all_auth_data[ $this->provider_slug ]['account'] ?? array();
+		return $this->decrypt_fields( $account );
 	}
 
 	/**
 	 * Get OAuth configuration keys directly from options.
 	 *
+	 * Automatically decrypts any encrypted fields. Plaintext legacy values
+	 * pass through unchanged.
+	 *
 	 * @return array Configuration data or empty array
 	 */
 	public function get_config(): array {
 		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
-		return $all_auth_data[ $this->provider_slug ]['config'] ?? array();
+		$config        = $all_auth_data[ $this->provider_slug ]['config'] ?? array();
+		return $this->decrypt_fields( $config );
 	}
 
 	/**
 	 * Store OAuth account data directly in options.
+	 *
+	 * Sensitive fields are automatically encrypted before storage.
 	 *
 	 * @param array $data Account data to store
 	 * @return bool True on success
@@ -115,12 +167,14 @@ abstract class BaseAuthProvider {
 		if ( ! isset( $all_auth_data[ $this->provider_slug ] ) ) {
 			$all_auth_data[ $this->provider_slug ] = array();
 		}
-		$all_auth_data[ $this->provider_slug ]['account'] = $data;
+		$all_auth_data[ $this->provider_slug ]['account'] = $this->encrypt_fields( $data );
 		return update_site_option( 'datamachine_auth_data', $all_auth_data );
 	}
 
 	/**
 	 * Store OAuth configuration keys directly in options.
+	 *
+	 * Sensitive fields are automatically encrypted before storage.
 	 *
 	 * @param array $data Configuration data to store
 	 * @return bool True on success
@@ -130,7 +184,7 @@ abstract class BaseAuthProvider {
 		if ( ! isset( $all_auth_data[ $this->provider_slug ] ) ) {
 			$all_auth_data[ $this->provider_slug ] = array();
 		}
-		$all_auth_data[ $this->provider_slug ]['config'] = $data;
+		$all_auth_data[ $this->provider_slug ]['config'] = $this->encrypt_fields( $data );
 		return update_site_option( 'datamachine_auth_data', $all_auth_data );
 	}
 
@@ -170,5 +224,215 @@ abstract class BaseAuthProvider {
 	 */
 	public function get_account_details(): ?array {
 		return $this->get_account();
+	}
+
+	// -------------------------------------------------------------------------
+	// Encryption
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Get the list of field names that should be encrypted at rest.
+	 *
+	 * Combines the built-in ENCRYPTED_FIELDS constant with any additions
+	 * from the `datamachine_auth_encrypted_fields` filter.
+	 *
+	 * @since 0.88.0
+	 * @return array<string> Field names to encrypt.
+	 */
+	protected function get_encrypted_fields(): array {
+		$fields = self::ENCRYPTED_FIELDS;
+
+		/**
+		 * Filters the list of auth data fields that are encrypted at rest.
+		 *
+		 * Providers can add custom field names that contain sensitive data
+		 * (e.g. non-standard token field names used by specific OAuth1 flows).
+		 *
+		 * @since 0.88.0
+		 *
+		 * @param array  $fields        Default list of field names.
+		 * @param string $provider_slug The provider this applies to.
+		 */
+		if ( function_exists( 'apply_filters' ) ) {
+			$fields = apply_filters( 'datamachine_auth_encrypted_fields', $fields, $this->provider_slug );
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Encrypt sensitive fields in a data array before storage.
+	 *
+	 * Only encrypts fields listed in get_encrypted_fields() that have
+	 * non-empty string values and are not already encrypted.
+	 *
+	 * @since 0.88.0
+	 * @param array $data Raw data array.
+	 * @return array Data with sensitive fields encrypted.
+	 */
+	protected function encrypt_fields( array $data ): array {
+		foreach ( $this->get_encrypted_fields() as $field ) {
+			if ( isset( $data[ $field ] ) && is_string( $data[ $field ] ) && '' !== $data[ $field ] ) {
+				// Don't double-encrypt values that already carry the envelope.
+				if ( str_starts_with( $data[ $field ], self::ENCRYPTION_PREFIX ) ) {
+					continue;
+				}
+				$encrypted = $this->encrypt_value( $data[ $field ] );
+				if ( null !== $encrypted ) {
+					$data[ $field ] = $encrypted;
+				}
+			}
+		}
+		return $data;
+	}
+
+	/**
+	 * Decrypt sensitive fields in a data array after retrieval.
+	 *
+	 * Only attempts decryption on fields that carry the encryption envelope
+	 * prefix. Plaintext values are returned unchanged for backward compatibility.
+	 *
+	 * @since 0.88.0
+	 * @param array $data Stored data array (may contain encrypted or plaintext values).
+	 * @return array Data with sensitive fields decrypted.
+	 */
+	protected function decrypt_fields( array $data ): array {
+		foreach ( $this->get_encrypted_fields() as $field ) {
+			if ( isset( $data[ $field ] ) && is_string( $data[ $field ] ) ) {
+				if ( str_starts_with( $data[ $field ], self::ENCRYPTION_PREFIX ) ) {
+					$decrypted = $this->decrypt_value( $data[ $field ] );
+					if ( null !== $decrypted ) {
+						$data[ $field ] = $decrypted;
+					}
+					// On decryption failure, leave the encrypted blob as-is
+					// so it doesn't silently become an empty string.
+				}
+				// else: plaintext legacy value — pass through unchanged.
+			}
+		}
+		return $data;
+	}
+
+	/**
+	 * Encrypt a single value using AES-256-CBC.
+	 *
+	 * Returns the encrypted value in envelope format:
+	 *     dm:enc:v1:{base64(iv)}:{base64(ciphertext)}
+	 *
+	 * @since 0.88.0
+	 * @param string $plaintext The value to encrypt.
+	 * @return string|null Encrypted envelope string, or null on failure.
+	 */
+	private function encrypt_value( string $plaintext ): ?string {
+		$key = $this->derive_encryption_key();
+		if ( null === $key ) {
+			return null;
+		}
+
+		$iv_length = openssl_cipher_iv_length( self::CIPHER_ALGO );
+		$iv        = openssl_random_pseudo_bytes( $iv_length );
+
+		$ciphertext = openssl_encrypt( $plaintext, self::CIPHER_ALGO, $key, OPENSSL_RAW_DATA, $iv );
+
+		if ( false === $ciphertext ) {
+			$this->log_encryption_error( 'Encryption failed' );
+			return null;
+		}
+
+		return self::ENCRYPTION_PREFIX . base64_encode( $iv ) . ':' . base64_encode( $ciphertext );
+	}
+
+	/**
+	 * Decrypt a single value from the encryption envelope format.
+	 *
+	 * Expects input in format: dm:enc:v1:{base64(iv)}:{base64(ciphertext)}
+	 *
+	 * @since 0.88.0
+	 * @param string $envelope The encrypted envelope string.
+	 * @return string|null Decrypted plaintext, or null on failure.
+	 */
+	private function decrypt_value( string $envelope ): ?string {
+		$key = $this->derive_encryption_key();
+		if ( null === $key ) {
+			return null;
+		}
+
+		// Strip prefix and split into iv:ciphertext.
+		$payload = substr( $envelope, strlen( self::ENCRYPTION_PREFIX ) );
+		$parts   = explode( ':', $payload, 2 );
+
+		if ( 2 !== count( $parts ) ) {
+			$this->log_encryption_error( 'Malformed encryption envelope: missing separator' );
+			return null;
+		}
+
+		$iv         = base64_decode( $parts[0], true );
+		$ciphertext = base64_decode( $parts[1], true );
+
+		if ( false === $iv || false === $ciphertext ) {
+			$this->log_encryption_error( 'Malformed encryption envelope: invalid base64' );
+			return null;
+		}
+
+		$expected_iv_length = openssl_cipher_iv_length( self::CIPHER_ALGO );
+		if ( strlen( $iv ) !== $expected_iv_length ) {
+			$this->log_encryption_error( 'Malformed encryption envelope: invalid IV length' );
+			return null;
+		}
+
+		$plaintext = openssl_decrypt( $ciphertext, self::CIPHER_ALGO, $key, OPENSSL_RAW_DATA, $iv );
+
+		if ( false === $plaintext ) {
+			$this->log_encryption_error( 'Decryption failed (wrong key or corrupted data)' );
+			return null;
+		}
+
+		return $plaintext;
+	}
+
+	/**
+	 * Derive the encryption key from WordPress auth salts.
+	 *
+	 * Uses hash('sha256', wp_salt('auth') . 'datamachine-oauth') to produce
+	 * a 32-byte key suitable for AES-256. The 'datamachine-oauth' suffix
+	 * ensures key isolation from other WordPress subsystems.
+	 *
+	 * @since 0.88.0
+	 * @return string|null 32-byte binary key, or null if derivation fails.
+	 */
+	private function derive_encryption_key(): ?string {
+		if ( ! function_exists( 'wp_salt' ) ) {
+			return null;
+		}
+
+		$salt = wp_salt( 'auth' );
+
+		// Warn if WordPress is using default salts (insecure but functional).
+		if ( 'put your unique phrase here' === $salt ) {
+			$this->log_encryption_error(
+				'wp_salt(\'auth\') returns the WordPress default. '
+				. 'Set unique AUTH_KEY and AUTH_SALT in wp-config.php for proper security.'
+			);
+		}
+
+		// Return raw binary (32 bytes) for use as AES-256 key.
+		return hash( 'sha256', $salt . 'datamachine-oauth', true );
+	}
+
+	/**
+	 * Log an encryption-related error via the datamachine_log action.
+	 *
+	 * @since 0.88.0
+	 * @param string $message Error message.
+	 */
+	private function log_encryption_error( string $message ): void {
+		if ( function_exists( 'do_action' ) ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'OAuth Encryption: ' . $message,
+				array( 'provider' => $this->provider_slug )
+			);
+		}
 	}
 }

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -9,10 +9,10 @@
  * are shared across all subsites on a multisite network. On single-site installs,
  * these behave identically to get_option()/update_option().
  *
- * Sensitive fields (tokens, secrets) are encrypted at rest using AES-256-CBC with
+ * Sensitive fields (tokens, secrets) are encrypted at rest using AES-256-GCM with
  * a key derived from wp_salt('auth'). Encrypted values use an envelope format:
  *
- *     dm:enc:v1:{base64(iv)}:{base64(ciphertext)}
+ *     dm:enc:v1:{base64(iv)}:{base64(tag)}:{base64(ciphertext)}
  *
  * Plaintext values without the envelope prefix are read as-is for backward
  * compatibility. Values get encrypted opportunistically on next save.
@@ -42,7 +42,14 @@ abstract class BaseAuthProvider {
 	 *
 	 * @since 0.88.0
 	 */
-	const CIPHER_ALGO = 'aes-256-cbc';
+	const CIPHER_ALGO = 'aes-256-gcm';
+
+	/**
+	 * Authentication tag length for AES-GCM.
+	 *
+	 * @since 0.88.0
+	 */
+	const AUTH_TAG_LENGTH = 16;
 
 	/**
 	 * Fields that should be encrypted when stored.
@@ -314,10 +321,10 @@ abstract class BaseAuthProvider {
 	}
 
 	/**
-	 * Encrypt a single value using AES-256-CBC.
+	 * Encrypt a single value using AES-256-GCM.
 	 *
 	 * Returns the encrypted value in envelope format:
-	 *     dm:enc:v1:{base64(iv)}:{base64(ciphertext)}
+	 *     dm:enc:v1:{base64(iv)}:{base64(tag)}:{base64(ciphertext)}
 	 *
 	 * @since 0.88.0
 	 * @param string $plaintext The value to encrypt.
@@ -332,20 +339,22 @@ abstract class BaseAuthProvider {
 		$iv_length = openssl_cipher_iv_length( self::CIPHER_ALGO );
 		$iv        = openssl_random_pseudo_bytes( $iv_length );
 
-		$ciphertext = openssl_encrypt( $plaintext, self::CIPHER_ALGO, $key, OPENSSL_RAW_DATA, $iv );
+		$tag        = '';
+		$ciphertext = openssl_encrypt( $plaintext, self::CIPHER_ALGO, $key, OPENSSL_RAW_DATA, $iv, $tag, '', self::AUTH_TAG_LENGTH );
 
-		if ( false === $ciphertext ) {
+		if ( false === $ciphertext || '' === $tag ) {
 			$this->log_encryption_error( 'Encryption failed' );
 			return null;
 		}
 
-		return self::ENCRYPTION_PREFIX . base64_encode( $iv ) . ':' . base64_encode( $ciphertext );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encoding binary crypto envelope fields, not obfuscation.
+		return self::ENCRYPTION_PREFIX . base64_encode( $iv ) . ':' . base64_encode( $tag ) . ':' . base64_encode( $ciphertext );
 	}
 
 	/**
 	 * Decrypt a single value from the encryption envelope format.
 	 *
-	 * Expects input in format: dm:enc:v1:{base64(iv)}:{base64(ciphertext)}
+	 * Expects input in format: dm:enc:v1:{base64(iv)}:{base64(tag)}:{base64(ciphertext)}
 	 *
 	 * @since 0.88.0
 	 * @param string $envelope The encrypted envelope string.
@@ -357,19 +366,23 @@ abstract class BaseAuthProvider {
 			return null;
 		}
 
-		// Strip prefix and split into iv:ciphertext.
+		// Strip prefix and split into iv:tag:ciphertext.
 		$payload = substr( $envelope, strlen( self::ENCRYPTION_PREFIX ) );
-		$parts   = explode( ':', $payload, 2 );
+		$parts   = explode( ':', $payload, 3 );
 
-		if ( 2 !== count( $parts ) ) {
+		if ( 3 !== count( $parts ) ) {
 			$this->log_encryption_error( 'Malformed encryption envelope: missing separator' );
 			return null;
 		}
 
-		$iv         = base64_decode( $parts[0], true );
-		$ciphertext = base64_decode( $parts[1], true );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding binary crypto envelope fields, not obfuscation.
+		$iv = base64_decode( $parts[0], true );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding binary crypto envelope fields, not obfuscation.
+		$tag = base64_decode( $parts[1], true );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding binary crypto envelope fields, not obfuscation.
+		$ciphertext = base64_decode( $parts[2], true );
 
-		if ( false === $iv || false === $ciphertext ) {
+		if ( false === $iv || false === $tag || false === $ciphertext ) {
 			$this->log_encryption_error( 'Malformed encryption envelope: invalid base64' );
 			return null;
 		}
@@ -380,7 +393,12 @@ abstract class BaseAuthProvider {
 			return null;
 		}
 
-		$plaintext = openssl_decrypt( $ciphertext, self::CIPHER_ALGO, $key, OPENSSL_RAW_DATA, $iv );
+		if ( strlen( $tag ) !== self::AUTH_TAG_LENGTH ) {
+			$this->log_encryption_error( 'Malformed encryption envelope: invalid authentication tag length' );
+			return null;
+		}
+
+		$plaintext = openssl_decrypt( $ciphertext, self::CIPHER_ALGO, $key, OPENSSL_RAW_DATA, $iv, $tag );
 
 		if ( false === $plaintext ) {
 			$this->log_encryption_error( 'Decryption failed (wrong key or corrupted data)' );
@@ -394,7 +412,7 @@ abstract class BaseAuthProvider {
 	 * Derive the encryption key from WordPress auth salts.
 	 *
 	 * Uses hash('sha256', wp_salt('auth') . 'datamachine-oauth') to produce
-	 * a 32-byte key suitable for AES-256. The 'datamachine-oauth' suffix
+	 * a 32-byte key suitable for AES-256-GCM. The 'datamachine-oauth' suffix
 	 * ensures key isolation from other WordPress subsystems.
 	 *
 	 * @since 0.88.0

--- a/tests/Unit/Core/OAuth/BaseAuthProviderEncryptionTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderEncryptionTest.php
@@ -289,20 +289,21 @@ class BaseAuthProviderEncryptionTest extends TestCase {
 
 	public function test_malformed_envelope_invalid_base64_returns_original(): void {
 		$data = array(
-			'access_token' => 'dm:enc:v1:!!!invalid!!!:!!!invalid!!!',
+			'access_token' => 'dm:enc:v1:!!!invalid!!!:!!!invalid!!!:!!!invalid!!!',
 		);
 
 		$decrypted = $this->provider->test_decrypt_fields( $data );
 
 		// Should return the encrypted blob as-is on failure.
-		$this->assertSame( 'dm:enc:v1:!!!invalid!!!:!!!invalid!!!', $decrypted['access_token'] );
+		$this->assertSame( 'dm:enc:v1:!!!invalid!!!:!!!invalid!!!:!!!invalid!!!', $decrypted['access_token'] );
 	}
 
 	public function test_malformed_envelope_wrong_iv_length_returns_original(): void {
-		// Valid base64 but IV is too short (should be 16 bytes for AES-256-CBC).
+		// Valid base64 but IV is too short (should be 12 bytes for AES-256-GCM).
 		$short_iv   = base64_encode( 'short' );
+		$tag        = base64_encode( str_repeat( 't', BaseAuthProvider::AUTH_TAG_LENGTH ) );
 		$ciphertext = base64_encode( 'fakeciphertext' );
-		$envelope   = "dm:enc:v1:{$short_iv}:{$ciphertext}";
+		$envelope   = "dm:enc:v1:{$short_iv}:{$tag}:{$ciphertext}";
 
 		$data      = array( 'access_token' => $envelope );
 		$decrypted = $this->provider->test_decrypt_fields( $data );
@@ -317,7 +318,7 @@ class BaseAuthProviderEncryptionTest extends TestCase {
 
 		// Corrupt the ciphertext portion.
 		$parts    = explode( ':', $encrypted['access_token'] );
-		$parts[4] = base64_encode( 'corrupted-garbage-data' );
+		$parts[5] = base64_encode( 'corrupted-garbage-data' );
 		$corrupted_envelope = implode( ':', $parts );
 
 		$corrupted_data = array( 'access_token' => $corrupted_envelope );
@@ -345,17 +346,31 @@ class BaseAuthProviderEncryptionTest extends TestCase {
 		$this->assertSame( 'shared-token', $decrypted['access_token'] );
 	}
 
-	public function test_different_salts_cannot_decrypt_each_others_data(): void {
-		// Encrypt with salt A.
-		self::$current_salt = 'salt-alpha';
+	public function test_modified_auth_tag_cannot_decrypt_data(): void {
 		$data      = array( 'access_token' => 'secret-value' );
 		$encrypted = $this->provider->test_encrypt_fields( $data );
 
+		$parts    = explode( ':', $encrypted['access_token'] );
+		$parts[4] = base64_encode( str_repeat( 'x', BaseAuthProvider::AUTH_TAG_LENGTH ) );
+		$modified = implode( ':', $parts );
+
+		$decrypted = $this->provider->test_decrypt_fields( array( 'access_token' => $modified ) );
+
+		// Authenticated encryption must reject tampered envelopes.
+		$this->assertSame( $modified, $decrypted['access_token'] );
+	}
+
+	public function test_different_salts_cannot_decrypt_each_others_data(): void {
+		// Encrypt with salt A.
+		self::$current_salt = 'salt-alpha';
+		$data               = array( 'access_token' => 'secret-value' );
+		$encrypted          = $this->provider->test_encrypt_fields( $data );
+
 		// Attempt decrypt with salt B.
 		self::$current_salt = 'salt-beta';
-		$decrypted = $this->provider->test_decrypt_fields( $encrypted );
+		$decrypted          = $this->provider->test_decrypt_fields( $encrypted );
 
-		// Should fail to decrypt — returns the encrypted blob.
+		// Should fail to decrypt and return the encrypted blob.
 		$this->assertSame( $encrypted['access_token'], $decrypted['access_token'] );
 	}
 
@@ -391,26 +406,31 @@ class BaseAuthProviderEncryptionTest extends TestCase {
 
 		$envelope = $encrypted['access_token'];
 
-		// Should match: dm:enc:v1:{base64}:{base64}
+		// Should match: dm:enc:v1:{base64}:{base64}:{base64}
 		$this->assertMatchesRegularExpression(
-			'/^dm:enc:v1:[A-Za-z0-9+\/=]+:[A-Za-z0-9+\/=]+$/',
+			'/^dm:enc:v1:[A-Za-z0-9+\/=]+:[A-Za-z0-9+\/=]+:[A-Za-z0-9+\/=]+$/',
 			$envelope
 		);
 
 		// Split and validate parts.
 		$parts = explode( ':', $envelope );
-		$this->assertCount( 5, $parts );
+		$this->assertCount( 6, $parts );
 		$this->assertSame( 'dm', $parts[0] );
 		$this->assertSame( 'enc', $parts[1] );
 		$this->assertSame( 'v1', $parts[2] );
 
-		// IV should decode to 16 bytes (AES-256-CBC IV length).
+		// IV should decode to the AES-256-GCM IV length.
 		$iv = base64_decode( $parts[3], true );
 		$this->assertNotFalse( $iv );
-		$this->assertSame( 16, strlen( $iv ) );
+		$this->assertSame( openssl_cipher_iv_length( BaseAuthProvider::CIPHER_ALGO ), strlen( $iv ) );
+
+		// Authentication tag should decode to the configured length.
+		$tag = base64_decode( $parts[4], true );
+		$this->assertNotFalse( $tag );
+		$this->assertSame( BaseAuthProvider::AUTH_TAG_LENGTH, strlen( $tag ) );
 
 		// Ciphertext should be valid base64.
-		$this->assertNotFalse( base64_decode( $parts[4], true ) );
+		$this->assertNotFalse( base64_decode( $parts[5], true ) );
 	}
 
 	// -------------------------------------------------------------------------
@@ -422,9 +442,13 @@ class BaseAuthProviderEncryptionTest extends TestCase {
 	}
 
 	public function test_cipher_algo_constant(): void {
-		$this->assertSame( 'aes-256-cbc', BaseAuthProvider::CIPHER_ALGO );
+		$this->assertSame( 'aes-256-gcm', BaseAuthProvider::CIPHER_ALGO );
 		// Verify the algorithm is available on this system.
-		$this->assertContains( 'aes-256-cbc', openssl_get_cipher_methods() );
+		$this->assertContains( 'aes-256-gcm', openssl_get_cipher_methods() );
+	}
+
+	public function test_auth_tag_length_constant(): void {
+		$this->assertSame( 16, BaseAuthProvider::AUTH_TAG_LENGTH );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/Unit/Core/OAuth/BaseAuthProviderEncryptionTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderEncryptionTest.php
@@ -1,0 +1,463 @@
+<?php
+/**
+ * BaseAuthProvider Encryption Tests
+ *
+ * Pure unit tests for the at-rest encryption layer.
+ * No WordPress dependency — tests run with the bootstrap-unit.php stub.
+ *
+ * @package DataMachine\Tests\Unit\Core\OAuth
+ */
+
+namespace DataMachine\Tests\Unit\Core\OAuth;
+
+use PHPUnit\Framework\TestCase;
+use DataMachine\Core\OAuth\BaseAuthProvider;
+
+/**
+ * Concrete test double that exposes protected encryption methods.
+ *
+ * Also stubs wp_salt() and do_action() for the pure-unit context.
+ */
+class EncryptionTestProvider extends BaseAuthProvider {
+
+	/**
+	 * Fixed salt for deterministic key derivation in tests.
+	 */
+	private string $test_salt = 'test-auth-salt-value-for-unit-tests';
+
+	public function get_config_fields(): array {
+		return array();
+	}
+
+	public function is_authenticated(): bool {
+		return false;
+	}
+
+	/**
+	 * Expose encrypt_fields for testing.
+	 */
+	public function test_encrypt_fields( array $data ): array {
+		return $this->encrypt_fields( $data );
+	}
+
+	/**
+	 * Expose decrypt_fields for testing.
+	 */
+	public function test_decrypt_fields( array $data ): array {
+		return $this->decrypt_fields( $data );
+	}
+
+	/**
+	 * Expose get_encrypted_fields for testing.
+	 */
+	public function test_get_encrypted_fields(): array {
+		return $this->get_encrypted_fields();
+	}
+
+	/**
+	 * Set a custom salt for testing key derivation.
+	 */
+	public function set_test_salt( string $salt ): void {
+		$this->test_salt = $salt;
+	}
+
+	/**
+	 * Get the test salt (used by the wp_salt stub).
+	 */
+	public function get_test_salt(): string {
+		return $this->test_salt;
+	}
+}
+
+/**
+ * Tests for BaseAuthProvider encryption layer.
+ */
+class BaseAuthProviderEncryptionTest extends TestCase {
+
+	private EncryptionTestProvider $provider;
+
+	/**
+	 * Track the salt that wp_salt() should return.
+	 */
+	private static string $current_salt = 'test-auth-salt-value-for-unit-tests';
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		// Load global-namespace stubs for wp_salt(), do_action(), apply_filters().
+		require_once __DIR__ . '/encryption-test-stubs.php';
+	}
+
+	public static function getSalt(): string {
+		return self::$current_salt;
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		self::$current_salt = 'test-auth-salt-value-for-unit-tests';
+		$this->provider     = new EncryptionTestProvider( 'test_provider' );
+	}
+
+	// -------------------------------------------------------------------------
+	// Encrypted fields list
+	// -------------------------------------------------------------------------
+
+	public function test_encrypted_fields_contains_expected_defaults(): void {
+		$fields = $this->provider->test_get_encrypted_fields();
+
+		$this->assertContains( 'access_token', $fields );
+		$this->assertContains( 'refresh_token', $fields );
+		$this->assertContains( 'client_secret', $fields );
+		$this->assertContains( 'oauth_token', $fields );
+		$this->assertContains( 'oauth_token_secret', $fields );
+		$this->assertContains( 'app_secret', $fields );
+		$this->assertContains( 'consumer_secret', $fields );
+		$this->assertContains( 'api_secret', $fields );
+		$this->assertContains( 'webhook_secret', $fields );
+	}
+
+	// -------------------------------------------------------------------------
+	// Encrypt → Decrypt roundtrip
+	// -------------------------------------------------------------------------
+
+	public function test_encrypt_decrypt_roundtrip_access_token(): void {
+		$data = array(
+			'access_token' => 'my-secret-token-12345',
+			'username'     => 'testuser',
+		);
+
+		$encrypted = $this->provider->test_encrypt_fields( $data );
+
+		// access_token should be encrypted (starts with envelope prefix).
+		$this->assertStringStartsWith( 'dm:enc:v1:', $encrypted['access_token'] );
+		// username is NOT an encrypted field — should remain plaintext.
+		$this->assertSame( 'testuser', $encrypted['username'] );
+
+		// Decrypt should restore the original value.
+		$decrypted = $this->provider->test_decrypt_fields( $encrypted );
+		$this->assertSame( 'my-secret-token-12345', $decrypted['access_token'] );
+		$this->assertSame( 'testuser', $decrypted['username'] );
+	}
+
+	public function test_encrypt_decrypt_roundtrip_multiple_fields(): void {
+		$data = array(
+			'access_token'  => 'access-tok-abc',
+			'refresh_token' => 'refresh-tok-xyz',
+			'client_secret' => 'client-secret-123',
+			'user_id'       => '12345',
+			'username'      => 'myuser',
+		);
+
+		$encrypted = $this->provider->test_encrypt_fields( $data );
+
+		// All sensitive fields encrypted.
+		$this->assertStringStartsWith( 'dm:enc:v1:', $encrypted['access_token'] );
+		$this->assertStringStartsWith( 'dm:enc:v1:', $encrypted['refresh_token'] );
+		$this->assertStringStartsWith( 'dm:enc:v1:', $encrypted['client_secret'] );
+
+		// Non-sensitive fields untouched.
+		$this->assertSame( '12345', $encrypted['user_id'] );
+		$this->assertSame( 'myuser', $encrypted['username'] );
+
+		// Full roundtrip.
+		$decrypted = $this->provider->test_decrypt_fields( $encrypted );
+		$this->assertSame( $data, $decrypted );
+	}
+
+	public function test_encrypt_decrypt_roundtrip_with_special_characters(): void {
+		$token = 'tok/abc+def==123&foo=bar<script>"\'\\';
+
+		$data      = array( 'access_token' => $token );
+		$encrypted = $this->provider->test_encrypt_fields( $data );
+		$decrypted = $this->provider->test_decrypt_fields( $encrypted );
+
+		$this->assertSame( $token, $decrypted['access_token'] );
+	}
+
+	public function test_encrypt_decrypt_roundtrip_with_long_token(): void {
+		// Simulate a JWT-like token (2000+ chars).
+		$token = str_repeat( 'abcdefghijklmnop', 200 );
+
+		$data      = array( 'access_token' => $token );
+		$encrypted = $this->provider->test_encrypt_fields( $data );
+		$decrypted = $this->provider->test_decrypt_fields( $encrypted );
+
+		$this->assertSame( $token, $decrypted['access_token'] );
+	}
+
+	public function test_encrypt_decrypt_roundtrip_with_unicode(): void {
+		$token = 'tok_' . "\xF0\x9F\x94\x91" . '_key_emoji';
+
+		$data      = array( 'access_token' => $token );
+		$encrypted = $this->provider->test_encrypt_fields( $data );
+		$decrypted = $this->provider->test_decrypt_fields( $encrypted );
+
+		$this->assertSame( $token, $decrypted['access_token'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Plaintext passthrough (backward compatibility)
+	// -------------------------------------------------------------------------
+
+	public function test_plaintext_values_pass_through_on_decrypt(): void {
+		// Simulate legacy data stored before encryption was added.
+		$data = array(
+			'access_token' => 'plaintext-legacy-token',
+			'username'     => 'olduser',
+		);
+
+		$decrypted = $this->provider->test_decrypt_fields( $data );
+
+		// Should return data unchanged.
+		$this->assertSame( 'plaintext-legacy-token', $decrypted['access_token'] );
+		$this->assertSame( 'olduser', $decrypted['username'] );
+	}
+
+	public function test_empty_string_not_encrypted(): void {
+		$data = array(
+			'access_token' => '',
+			'username'     => 'user',
+		);
+
+		$encrypted = $this->provider->test_encrypt_fields( $data );
+
+		// Empty strings should not be encrypted.
+		$this->assertSame( '', $encrypted['access_token'] );
+	}
+
+	public function test_null_value_not_encrypted(): void {
+		$data = array(
+			'access_token' => null,
+			'username'     => 'user',
+		);
+
+		$encrypted = $this->provider->test_encrypt_fields( $data );
+
+		// Null values should pass through (not a string).
+		$this->assertNull( $encrypted['access_token'] );
+	}
+
+	public function test_non_string_values_not_encrypted(): void {
+		$data = array(
+			'access_token' => 12345,
+			'refresh_token' => true,
+		);
+
+		$encrypted = $this->provider->test_encrypt_fields( $data );
+
+		// Non-string values should not be touched.
+		$this->assertSame( 12345, $encrypted['access_token'] );
+		$this->assertSame( true, $encrypted['refresh_token'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Double-encryption prevention
+	// -------------------------------------------------------------------------
+
+	public function test_already_encrypted_values_not_double_encrypted(): void {
+		$data = array(
+			'access_token' => 'original-token',
+		);
+
+		// Encrypt once.
+		$encrypted_once = $this->provider->test_encrypt_fields( $data );
+		$this->assertStringStartsWith( 'dm:enc:v1:', $encrypted_once['access_token'] );
+
+		// Encrypt again — should not double-encrypt.
+		$encrypted_twice = $this->provider->test_encrypt_fields( $encrypted_once );
+		$this->assertSame( $encrypted_once['access_token'], $encrypted_twice['access_token'] );
+
+		// Should still decrypt to original.
+		$decrypted = $this->provider->test_decrypt_fields( $encrypted_twice );
+		$this->assertSame( 'original-token', $decrypted['access_token'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Malformed envelope handling
+	// -------------------------------------------------------------------------
+
+	public function test_malformed_envelope_missing_separator_returns_null(): void {
+		$data = array(
+			'access_token' => 'dm:enc:v1:missingsecondsegment',
+		);
+
+		$decrypted = $this->provider->test_decrypt_fields( $data );
+
+		// On failure, the encrypted blob should be returned as-is.
+		$this->assertSame( 'dm:enc:v1:missingsecondsegment', $decrypted['access_token'] );
+	}
+
+	public function test_malformed_envelope_invalid_base64_returns_original(): void {
+		$data = array(
+			'access_token' => 'dm:enc:v1:!!!invalid!!!:!!!invalid!!!',
+		);
+
+		$decrypted = $this->provider->test_decrypt_fields( $data );
+
+		// Should return the encrypted blob as-is on failure.
+		$this->assertSame( 'dm:enc:v1:!!!invalid!!!:!!!invalid!!!', $decrypted['access_token'] );
+	}
+
+	public function test_malformed_envelope_wrong_iv_length_returns_original(): void {
+		// Valid base64 but IV is too short (should be 16 bytes for AES-256-CBC).
+		$short_iv   = base64_encode( 'short' );
+		$ciphertext = base64_encode( 'fakeciphertext' );
+		$envelope   = "dm:enc:v1:{$short_iv}:{$ciphertext}";
+
+		$data      = array( 'access_token' => $envelope );
+		$decrypted = $this->provider->test_decrypt_fields( $data );
+
+		$this->assertSame( $envelope, $decrypted['access_token'] );
+	}
+
+	public function test_corrupted_ciphertext_returns_original(): void {
+		$data = array( 'access_token' => 'valid-token' );
+
+		$encrypted = $this->provider->test_encrypt_fields( $data );
+
+		// Corrupt the ciphertext portion.
+		$parts    = explode( ':', $encrypted['access_token'] );
+		$parts[4] = base64_encode( 'corrupted-garbage-data' );
+		$corrupted_envelope = implode( ':', $parts );
+
+		$corrupted_data = array( 'access_token' => $corrupted_envelope );
+		$decrypted      = $this->provider->test_decrypt_fields( $corrupted_data );
+
+		// Should return corrupted blob as-is (not silently empty).
+		$this->assertSame( $corrupted_envelope, $decrypted['access_token'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Key derivation determinism
+	// -------------------------------------------------------------------------
+
+	public function test_same_salt_produces_same_encrypted_result_after_decrypt(): void {
+		// Encrypt with one provider instance.
+		$provider_a = new EncryptionTestProvider( 'provider_a' );
+		$data       = array( 'access_token' => 'shared-token' );
+
+		$encrypted = $provider_a->test_encrypt_fields( $data );
+
+		// Decrypt with another provider instance using the same salt.
+		$provider_b = new EncryptionTestProvider( 'provider_b' );
+		$decrypted  = $provider_b->test_decrypt_fields( $encrypted );
+
+		$this->assertSame( 'shared-token', $decrypted['access_token'] );
+	}
+
+	public function test_different_salts_cannot_decrypt_each_others_data(): void {
+		// Encrypt with salt A.
+		self::$current_salt = 'salt-alpha';
+		$data      = array( 'access_token' => 'secret-value' );
+		$encrypted = $this->provider->test_encrypt_fields( $data );
+
+		// Attempt decrypt with salt B.
+		self::$current_salt = 'salt-beta';
+		$decrypted = $this->provider->test_decrypt_fields( $encrypted );
+
+		// Should fail to decrypt — returns the encrypted blob.
+		$this->assertSame( $encrypted['access_token'], $decrypted['access_token'] );
+	}
+
+	public function test_key_derivation_is_deterministic(): void {
+		// Same salt should produce consistent encrypt/decrypt across calls.
+		self::$current_salt = 'deterministic-salt-xyz';
+
+		$data = array( 'access_token' => 'test-token-123' );
+
+		// First encrypt/decrypt cycle.
+		$encrypted_1 = $this->provider->test_encrypt_fields( $data );
+		$decrypted_1 = $this->provider->test_decrypt_fields( $encrypted_1 );
+
+		// Second encrypt/decrypt cycle.
+		$encrypted_2 = $this->provider->test_encrypt_fields( $data );
+		$decrypted_2 = $this->provider->test_decrypt_fields( $encrypted_2 );
+
+		// Both should decrypt to the same value.
+		$this->assertSame( 'test-token-123', $decrypted_1['access_token'] );
+		$this->assertSame( 'test-token-123', $decrypted_2['access_token'] );
+
+		// But the encrypted values should differ (unique IV each time).
+		$this->assertNotSame( $encrypted_1['access_token'], $encrypted_2['access_token'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Envelope format verification
+	// -------------------------------------------------------------------------
+
+	public function test_encrypted_envelope_format(): void {
+		$data      = array( 'access_token' => 'format-test-token' );
+		$encrypted = $this->provider->test_encrypt_fields( $data );
+
+		$envelope = $encrypted['access_token'];
+
+		// Should match: dm:enc:v1:{base64}:{base64}
+		$this->assertMatchesRegularExpression(
+			'/^dm:enc:v1:[A-Za-z0-9+\/=]+:[A-Za-z0-9+\/=]+$/',
+			$envelope
+		);
+
+		// Split and validate parts.
+		$parts = explode( ':', $envelope );
+		$this->assertCount( 5, $parts );
+		$this->assertSame( 'dm', $parts[0] );
+		$this->assertSame( 'enc', $parts[1] );
+		$this->assertSame( 'v1', $parts[2] );
+
+		// IV should decode to 16 bytes (AES-256-CBC IV length).
+		$iv = base64_decode( $parts[3], true );
+		$this->assertNotFalse( $iv );
+		$this->assertSame( 16, strlen( $iv ) );
+
+		// Ciphertext should be valid base64.
+		$this->assertNotFalse( base64_decode( $parts[4], true ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Constants
+	// -------------------------------------------------------------------------
+
+	public function test_encryption_prefix_constant(): void {
+		$this->assertSame( 'dm:enc:v1:', BaseAuthProvider::ENCRYPTION_PREFIX );
+	}
+
+	public function test_cipher_algo_constant(): void {
+		$this->assertSame( 'aes-256-cbc', BaseAuthProvider::CIPHER_ALGO );
+		// Verify the algorithm is available on this system.
+		$this->assertContains( 'aes-256-cbc', openssl_get_cipher_methods() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Edge cases
+	// -------------------------------------------------------------------------
+
+	public function test_data_with_no_encrypted_fields_passes_through(): void {
+		$data = array(
+			'username' => 'testuser',
+			'user_id'  => '123',
+			'scope'    => 'read write',
+		);
+
+		$encrypted = $this->provider->test_encrypt_fields( $data );
+		$this->assertSame( $data, $encrypted );
+
+		$decrypted = $this->provider->test_decrypt_fields( $data );
+		$this->assertSame( $data, $decrypted );
+	}
+
+	public function test_empty_array_passes_through(): void {
+		$this->assertSame( array(), $this->provider->test_encrypt_fields( array() ) );
+		$this->assertSame( array(), $this->provider->test_decrypt_fields( array() ) );
+	}
+
+	public function test_field_with_prefix_like_text_not_treated_as_encrypted(): void {
+		// A field named 'description' that happens to start with "dm:enc:" but
+		// is not in the encrypted fields list should NOT be decrypted.
+		$data = array(
+			'description' => 'dm:enc:v1:some:thing',
+		);
+
+		$decrypted = $this->provider->test_decrypt_fields( $data );
+		$this->assertSame( 'dm:enc:v1:some:thing', $decrypted['description'] );
+	}
+}

--- a/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
@@ -159,7 +159,8 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'test_provider', $raw );
 		$this->assertArrayHasKey( 'account', $raw['test_provider'] );
-		$this->assertSame( 'tok_123', $raw['test_provider']['account']['access_token'] );
+		// Sensitive fields are encrypted at rest — raw stored value carries the envelope prefix.
+		$this->assertStringStartsWith( 'dm:enc:v1:', $raw['test_provider']['account']['access_token'] );
 	}
 
 	public function test_get_account_details_returns_account(): void {

--- a/tests/Unit/Core/OAuth/encryption-test-stubs.php
+++ b/tests/Unit/Core/OAuth/encryption-test-stubs.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Global function stubs for BaseAuthProviderEncryptionTest.
+ *
+ * Defines wp_salt(), do_action(), and apply_filters() in the global namespace
+ * so that BaseAuthProvider's encrypt/decrypt methods work in pure-unit tests.
+ *
+ * Must be loaded AFTER bootstrap-unit.php and BEFORE the test class.
+ *
+ * @package DataMachine\Tests\Unit\Core\OAuth
+ */
+
+if ( ! function_exists( 'wp_salt' ) ) {
+	/**
+	 * Stub wp_salt() that delegates to a static method for test control.
+	 */
+	function wp_salt( string $scheme = 'auth' ): string {
+		return DataMachine\Tests\Unit\Core\OAuth\BaseAuthProviderEncryptionTest::getSalt();
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ): void {
+		// no-op
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		return $value;
+	}
+}


### PR DESCRIPTION
## Summary

Adds transparent AES-256-CBC encryption for sensitive OAuth fields stored in `datamachine_auth_data`. Closes #1459.

- **Encrypt on save:** `save_account()` / `save_config()` automatically encrypt fields listed in `ENCRYPTED_FIELDS`
- **Decrypt on read:** `get_account()` / `get_config()` automatically decrypt values with the `dm:enc:v1:` envelope prefix
- **Backward compatible:** Plaintext values without the envelope pass through unchanged — no manual migration or reauth needed
- **Opportunistic re-encryption:** Values get encrypted on next save (e.g. token refresh, config update)

## Implementation

### Encryption envelope format
```
dm:enc:v1:{base64(iv)}:{base64(ciphertext)}
```
- Versioned prefix supports future algorithm migration
- Per-record 16-byte IV via `openssl_random_pseudo_bytes`
- Algorithm: `AES-256-CBC`

### Key derivation
```php
hash('sha256', wp_salt('auth') . 'datamachine-oauth', true)
```
Uses existing WordPress auth salts with a purpose suffix for key isolation. No new `wp-config.php` constants required.

### Encrypted fields
```php
const ENCRYPTED_FIELDS = [
    'access_token', 'refresh_token', 'oauth_token', 'oauth_token_secret',
    'app_secret', 'client_secret', 'consumer_secret', 'api_secret', 'webhook_secret',
];
```
Extensible via `datamachine_auth_encrypted_fields` filter.

## Migration story

**No manual reauth needed.** Existing plaintext values are returned as-is on read. They get encrypted the next time the provider saves (token refresh, OAuth reauth, config update). This is eventual consistency with zero user disruption.

## Tests

- **24 unit tests** in `BaseAuthProviderEncryptionTest.php` covering:
  - Encrypt → decrypt roundtrip (single field, multiple fields, special chars, unicode, long tokens)
  - Plaintext passthrough (backward compatibility)
  - Double-encryption prevention
  - Malformed envelope handling (missing separator, invalid base64, wrong IV length, corrupted ciphertext)
  - Key derivation determinism (same salt = same key, different salts can't cross-decrypt)
  - Envelope format verification
  - Edge cases (empty arrays, non-string values, non-sensitive fields)
- **Smoke tested** against extrachill.com production auth data (Reddit, Twitter, Facebook, Instagram, Bluesky) — all providers pass plaintext passthrough and encrypt→decrypt roundtrip

## Files changed

| File | Change |
|------|--------|
| `inc/Core/OAuth/BaseAuthProvider.php` | Added `ENCRYPTED_FIELDS`, `ENCRYPTION_PREFIX`, `CIPHER_ALGO` constants; `encrypt_fields()`, `decrypt_fields()`, `encrypt_value()`, `decrypt_value()`, `derive_encryption_key()`, `get_encrypted_fields()`, `log_encryption_error()` methods; wired into `save_account()`, `save_config()`, `get_account()`, `get_config()` |
| `tests/Unit/Core/OAuth/BaseAuthProviderEncryptionTest.php` | 24 new pure unit tests |
| `tests/Unit/Core/OAuth/encryption-test-stubs.php` | Global-namespace stubs for `wp_salt`, `do_action`, `apply_filters` |
| `tests/Unit/Core/OAuth/BaseAuthProviderTest.php` | Updated `test_data_stored_via_site_option` to verify encrypted-at-rest (envelope prefix instead of plaintext) |