### PR TITLE
fix(agents): align agent_config writer with resolver schema

### DIFF
--- a/inc/Engine/Agents/register-agents.php
+++ b/inc/Engine/Agents/register-agents.php
@@ -169,9 +169,16 @@ function datamachine_register_default_admin_agent(): void {
 
 	$default_config = array();
 	if ( class_exists( '\\DataMachine\\Core\\PluginSettings' ) ) {
-		$default_config['model'] = array(
-			'default' => \DataMachine\Core\PluginSettings::getModelForMode( 'chat' ),
-		);
+		$resolved = \DataMachine\Core\PluginSettings::getModelForMode( 'chat' );
+		$provider = isset( $resolved['provider'] ) ? (string) $resolved['provider'] : '';
+		$model    = isset( $resolved['model'] ) ? (string) $resolved['model'] : '';
+
+		if ( '' !== $provider ) {
+			$default_config['default_provider'] = $provider;
+		}
+		if ( '' !== $model ) {
+			$default_config['default_model'] = $model;
+		}
 	}
 
 	datamachine_register_agent(

--- a/inc/migrations/agent-config-model-shape.php
+++ b/inc/migrations/agent-config-model-shape.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Data Machine — Migrate stale `agent_config.model.default.*` shape to
+ * `agent_config.default_provider` / `agent_config.default_model`.
+ *
+ * `inc/Engine/Agents/register-agents.php` previously persisted newly
+ * registered agents with `agent_config = { model: { default: { provider,
+ * model } } }`. The reader (`PluginSettings::resolveModelForAgentMode()`)
+ * has read `agent_config.mode_models[mode]` plus top-level
+ * `agent_config.default_provider` / `agent_config.default_model` since
+ * the contexts → modes rename in #1138, and never spoke the
+ * `model.default.*` dialect at all.
+ *
+ * Effect on existing installs: every agent created through
+ * `datamachine_register_agent()` (including DM's own default
+ * administrator agent and every plugin-registered agent — roadie,
+ * events-bot, game-master, etc.) carries a config shape the resolver
+ * cannot read. `SendMessageAbility` then trips its
+ * `provider_required` / `model_required` guards on the first chat send
+ * with no explicit provider/model, surfacing as the user-facing
+ * "AI provider is required" error.
+ *
+ * The writer is fixed in the same change. This migration cleans up the
+ * persisted rows so existing installs recover without manual SQL.
+ *
+ * Idempotent: gated on `datamachine_agent_config_model_shape_migrated`.
+ *
+ * @package DataMachine
+ * @since 0.88.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Migrate stale `agent_config.model.default.{provider,model}` rows to
+ * top-level `default_provider` / `default_model` keys.
+ *
+ * - Preserves every other key in `agent_config` (tool_policy,
+ *   directive_policy, memory_policy, daily_memory, allowed_redirect_uris, …).
+ * - Drops the legacy `model` key after migration.
+ * - Skips empty provider/model values so rows fall through to the site
+ *   and network defaults instead of being pinned to empty strings.
+ * - Network-scoped: agents live on `base_prefix`, so we only need the
+ *   one network-scoped table regardless of subsite count.
+ *
+ * @since 0.88.0
+ * @return void
+ */
+function datamachine_migrate_agent_config_model_shape(): void {
+	if ( get_option( 'datamachine_agent_config_model_shape_migrated', false ) ) {
+		return;
+	}
+
+	global $wpdb;
+	$agents_table = $wpdb->base_prefix . 'datamachine_agents';
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL
+	$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $agents_table ) );
+	if ( ! $table_exists ) {
+		update_option( 'datamachine_agent_config_model_shape_migrated', true, true );
+		return;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL
+	$rows = $wpdb->get_results( "SELECT agent_id, agent_config FROM {$agents_table}", ARRAY_A );
+
+	$migrated = 0;
+
+	if ( ! empty( $rows ) ) {
+		foreach ( $rows as $row ) {
+			$config = json_decode( $row['agent_config'] ?? '', true );
+			if ( ! is_array( $config ) ) {
+				continue;
+			}
+
+			if ( ! isset( $config['model'] ) || ! is_array( $config['model'] ) ) {
+				continue;
+			}
+
+			$legacy   = isset( $config['model']['default'] ) && is_array( $config['model']['default'] )
+				? $config['model']['default']
+				: array();
+			$provider = isset( $legacy['provider'] ) ? trim( (string) $legacy['provider'] ) : '';
+			$model    = isset( $legacy['model'] ) ? trim( (string) $legacy['model'] ) : '';
+
+			unset( $config['model'] );
+
+			if ( '' !== $provider && ! isset( $config['default_provider'] ) ) {
+				$config['default_provider'] = $provider;
+			}
+			if ( '' !== $model && ! isset( $config['default_model'] ) ) {
+				$config['default_model'] = $model;
+			}
+
+			// Empty array → empty object on the JSON side, so the column
+			// stays `{}` rather than `[]` and matches every other code
+			// path that writes agent_config.
+			$encoded = empty( $config )
+				? '{}'
+				: wp_json_encode( $config );
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->update(
+				$agents_table,
+				array( 'agent_config' => $encoded ),
+				array( 'agent_id' => (int) $row['agent_id'] ),
+				array( '%s' ),
+				array( '%d' )
+			);
+
+			++$migrated;
+		}
+	}
+
+	update_option( 'datamachine_agent_config_model_shape_migrated', true, true );
+
+	if ( $migrated > 0 ) {
+		do_action(
+			'datamachine_log',
+			'info',
+			'Migrated stale agent_config.model.default.* shape to default_provider/default_model.',
+			array(
+				'agents_updated' => $migrated,
+			)
+		);
+	}
+}

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/handler-slug-scalar.php';
 require_once __DIR__ . '/split-queue-payload.php';
 require_once __DIR__ . '/user-message-queue-mode.php';
 require_once __DIR__ . '/webhook-auth-v2.php';
+require_once __DIR__ . '/agent-config-model-shape.php';
 
 // Schema-migration runtime — defines `datamachine_run_schema_migrations()`
 // and `datamachine_maybe_run_deferred_migrations()`. Hooked at

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -114,6 +114,12 @@ function datamachine_run_schema_migrations(): void {
 	// idempotent).
 	datamachine_migrate_webhook_auth_v2();
 
+	// Migrate stale agent_config.model.default.{provider,model} shape to
+	// top-level default_provider/default_model so the resolver can read it.
+	// Pairs with the writer fix in inc/Engine/Agents/register-agents.php.
+	// Idempotent.
+	datamachine_migrate_agent_config_model_shape();
+
 	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
 	datamachine_drop_redundant_post_pipeline_meta();
 }

--- a/tests/agent-config-model-shape-migration-smoke.php
+++ b/tests/agent-config-model-shape-migration-smoke.php
@@ -1,0 +1,355 @@
+<?php
+/**
+ * Pure-PHP smoke test for the agent_config model.default.* migration.
+ *
+ * Run with: php tests/agent-config-model-shape-migration-smoke.php
+ *
+ * The migration flattens the legacy
+ *   agent_config = { "model": { "default": { "provider", "model" } } }
+ * shape persisted by the pre-fix `register-agents.php` writer to the
+ * shape `PluginSettings::resolveModelForAgentMode()` actually reads:
+ *   agent_config = { "default_provider", "default_model" }
+ *
+ * Contracts under test:
+ *
+ *  1. Legacy `model.default.{provider,model}` is flattened to top-level
+ *     `default_provider` / `default_model`.
+ *  2. Sibling keys (`tool_policy`, `directive_policy`, arbitrary plugin
+ *     keys) are preserved verbatim.
+ *  3. Empty legacy values are dropped — rows fall through to site/network
+ *     defaults instead of being pinned to empty strings.
+ *  4. Rows without a legacy `model` key are left alone.
+ *  5. Empty `agent_config` is encoded as `{}`, not `[]`.
+ *  6. Idempotent: gated on `datamachine_agent_config_model_shape_migrated`.
+ *  7. Missing table is a no-op (gate still set so we don't loop).
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+$options = array();
+
+function get_option( string $key, $default = false ) {
+	global $options;
+	return array_key_exists( $key, $options ) ? $options[ $key ] : $default;
+}
+
+function update_option( string $key, $value, bool $autoload = true ): bool {
+	global $options;
+	$options[ $key ] = $value;
+	return true;
+}
+
+function wp_json_encode( $value ) {
+	return json_encode( $value );
+}
+
+function do_action( string $hook, ...$args ): void {
+	$GLOBALS['__agent_config_migration_actions'][] = array( $hook, $args );
+}
+
+class AgentConfigModelShapeWpdb {
+	public string $base_prefix = 'wp_';
+
+	/** @var array<string, array<int, array<string, mixed>>> */
+	public array $rows = array();
+
+	/** Toggle to simulate "table does not exist". */
+	public bool $table_present = true;
+
+	public function prepare( string $query, ...$args ): string {
+		return vsprintf( str_replace( '%s', "'%s'", $query ), $args );
+	}
+
+	public function get_var( string $query ) {
+		if ( ! $this->table_present ) {
+			return null;
+		}
+		foreach ( array_keys( $this->rows ) as $table ) {
+			if ( str_contains( $query, $table ) ) {
+				return $table;
+			}
+		}
+		return null;
+	}
+
+	public function get_results( string $query, $output ) {
+		foreach ( $this->rows as $table => $rows ) {
+			if ( str_contains( $query, $table ) ) {
+				return $rows;
+			}
+		}
+		return array();
+	}
+
+	public function update( string $table, array $data, array $where, array $formats, array $where_formats ): bool {
+		$id_column = array_key_first( $where );
+		if ( null === $id_column ) {
+			return false;
+		}
+		$id_value = $where[ $id_column ];
+
+		foreach ( $this->rows[ $table ] as &$row ) {
+			if ( array_key_exists( $id_column, $row ) && (string) $row[ $id_column ] === (string) $id_value ) {
+				$row = array_merge( $row, $data );
+				return true;
+			}
+		}
+		unset( $row );
+
+		return false;
+	}
+}
+
+require_once __DIR__ . '/../inc/migrations/agent-config-model-shape.php';
+
+$failures = array();
+$passes   = 0;
+
+function assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS: {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  FAIL: {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+echo "agent-config-model-shape migration smoke\n";
+echo "----------------------------------------\n";
+
+// ---------------------------------------------------------------------
+// Section 1: end-to-end on a representative spread of agent_config rows.
+// ---------------------------------------------------------------------
+
+echo "\n[shape:1] Flatten legacy and preserve siblings\n";
+
+$wpdb         = new AgentConfigModelShapeWpdb();
+$rows         = array(
+	// Legacy with provider+model and tool_policy.
+	array(
+		'agent_id'     => 1,
+		'agent_config' => wp_json_encode(
+			array(
+				'model'       => array(
+					'default' => array(
+						'provider' => 'openai',
+						'model'    => 'gpt-5-mini',
+					),
+				),
+				'tool_policy' => array(
+					'mode'  => 'deny',
+					'tools' => array( 'progress_story' ),
+				),
+				'extra_key'   => 'preserve_me',
+			)
+		),
+	),
+	// Legacy with empty provider/model — should leave both fields off
+	// so site/network defaults apply.
+	array(
+		'agent_id'     => 2,
+		'agent_config' => wp_json_encode(
+			array(
+				'model' => array(
+					'default' => array(
+						'provider' => '',
+						'model'    => '',
+					),
+				),
+			)
+		),
+	),
+	// Already current shape — nothing to flatten, no `model` key.
+	array(
+		'agent_id'     => 3,
+		'agent_config' => wp_json_encode(
+			array(
+				'default_provider' => 'openai',
+				'default_model'    => 'gpt-5.4-nano',
+			)
+		),
+	),
+	// No legacy and no current — should not be touched.
+	array(
+		'agent_id'     => 4,
+		'agent_config' => wp_json_encode(
+			array(
+				'allowed_redirect_uris' => array( 'example.com' ),
+			)
+		),
+	),
+);
+$wpdb->rows['wp_datamachine_agents'] = $rows;
+
+datamachine_migrate_agent_config_model_shape();
+
+$by_id = array();
+foreach ( $wpdb->rows['wp_datamachine_agents'] as $row ) {
+	$by_id[ $row['agent_id'] ] = json_decode( $row['agent_config'], true );
+}
+
+assert_equals(
+	array(
+		'tool_policy'      => array(
+			'mode'  => 'deny',
+			'tools' => array( 'progress_story' ),
+		),
+		'extra_key'        => 'preserve_me',
+		'default_provider' => 'openai',
+		'default_model'    => 'gpt-5-mini',
+	),
+	$by_id[1],
+	'agent 1 — legacy flattened, tool_policy + extra keys preserved',
+	$failures,
+	$passes
+);
+
+assert_equals(
+	false,
+	isset( $by_id[2]['default_provider'] ) || isset( $by_id[2]['default_model'] ) || isset( $by_id[2]['model'] ),
+	'agent 2 — empty legacy values dropped, no pinned empty strings',
+	$failures,
+	$passes
+);
+
+assert_equals(
+	array(
+		'default_provider' => 'openai',
+		'default_model'    => 'gpt-5.4-nano',
+	),
+	$by_id[3],
+	'agent 3 — already-current shape preserved verbatim (gpt-5.4-nano stays)',
+	$failures,
+	$passes
+);
+
+assert_equals(
+	array(
+		'allowed_redirect_uris' => array( 'example.com' ),
+	),
+	$by_id[4],
+	'agent 4 — rows without legacy model key are left alone',
+	$failures,
+	$passes
+);
+
+assert_equals(
+	true,
+	get_option( 'datamachine_agent_config_model_shape_migrated' ),
+	'gate option set after first run',
+	$failures,
+	$passes
+);
+
+// ---------------------------------------------------------------------
+// Section 2: empty agent_config encodes as `{}`, not `[]`.
+// ---------------------------------------------------------------------
+
+echo "\n[shape:2] Empty resulting config encodes as object, not array\n";
+
+global $options;
+$options = array();
+$wpdb_b  = new AgentConfigModelShapeWpdb();
+$wpdb_b->rows['wp_datamachine_agents'] = array(
+	array(
+		'agent_id'     => 5,
+		'agent_config' => wp_json_encode(
+			array(
+				'model' => array(
+					'default' => array(
+						'provider' => '',
+						'model'    => '',
+					),
+				),
+			)
+		),
+	),
+);
+
+global $wpdb;
+$wpdb = $wpdb_b;
+datamachine_migrate_agent_config_model_shape();
+
+assert_equals(
+	'{}',
+	$wpdb_b->rows['wp_datamachine_agents'][0]['agent_config'],
+	'fully drained config writes `{}` not `[]`',
+	$failures,
+	$passes
+);
+
+// ---------------------------------------------------------------------
+// Section 3: idempotent — second call is a no-op.
+// ---------------------------------------------------------------------
+
+echo "\n[shape:3] Second invocation short-circuits\n";
+
+$wpdb_c = new AgentConfigModelShapeWpdb();
+$wpdb_c->rows['wp_datamachine_agents'] = array(
+	array(
+		'agent_id'     => 6,
+		'agent_config' => wp_json_encode(
+			array(
+				'model' => array( 'default' => array( 'provider' => 'openai', 'model' => 'gpt-5-mini' ) ),
+			)
+		),
+	),
+);
+$wpdb = $wpdb_c;
+// Gate from section 2 above is still set; this call must be a no-op.
+datamachine_migrate_agent_config_model_shape();
+
+$post = json_decode( $wpdb_c->rows['wp_datamachine_agents'][0]['agent_config'], true );
+assert_equals(
+	true,
+	isset( $post['model']['default'] ),
+	'gated re-entry leaves stale shape untouched (idempotent)',
+	$failures,
+	$passes
+);
+
+// ---------------------------------------------------------------------
+// Section 4: missing table is a no-op but still sets the gate.
+// ---------------------------------------------------------------------
+
+echo "\n[shape:4] Missing agents table sets gate without erroring\n";
+
+$options                = array();
+$wpdb_d                 = new AgentConfigModelShapeWpdb();
+$wpdb_d->table_present  = false;
+$wpdb_d->rows['wp_datamachine_agents'] = array();
+$wpdb                   = $wpdb_d;
+datamachine_migrate_agent_config_model_shape();
+
+assert_equals(
+	true,
+	get_option( 'datamachine_agent_config_model_shape_migrated' ),
+	'gate set even when table is missing',
+	$failures,
+	$passes
+);
+
+echo "\n----------------------------------------\n";
+$total = $passes + count( $failures );
+echo "{$passes} / {$total} passed\n";
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nAll assertions passed.\n";

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -124,6 +124,7 @@ $migration_chain = array(
 	'datamachine_migrate_split_queue_payload',
 	'datamachine_migrate_user_message_queue_mode',
 	'datamachine_migrate_webhook_auth_v2',
+	'datamachine_migrate_agent_config_model_shape',
 	'datamachine_drop_redundant_post_pipeline_meta',
 );
 


### PR DESCRIPTION
## Summary

`datamachine_register_default_admin_agent()` (and every plugin that uses
`datamachine_register_agent()` with a `default_config`) persists newly
registered agents with the **legacy shape**:

```jsonc
{ "model": { "default": { "provider": "openai", "model": "gpt-5-mini" } } }
```

`PluginSettings::resolveModelForAgentMode()` has read
`mode_models[mode]` plus top-level `default_provider` / `default_model`
since the `contexts → modes` rename in #1138, and never spoke the
`model.default.*` dialect at all.

Effect on existing installs: every agent created through the
registration helper — including DM's own default admin agent and every
plugin-registered agent (`roadie`, `events-bot`, `game-master`, etc.) —
carries a config shape the resolver cannot read. `SendMessageAbility`
then trips its `provider_required` / `model_required` guards on the
first chat send with no explicit provider/model, surfacing as the
user-facing **"AI provider is required"** error.

Discovered live on extrachill.com when the floating chat for `roadie`
hard-failed with that exact message. Inspection showed all 10 agents on
the network carrying the legacy shape, including 6 plugin-created
self-service agents whose config was effectively `{ model: { default:
{ provider: "", model: "" } } }`.

## Changes

- **`inc/Engine/Agents/register-agents.php`** — write
  `default_provider` / `default_model` directly instead of
  `model.default.{provider,model}`. Empty values are dropped so rows
  fall through to site/network defaults rather than being pinned to
  empty strings.
- **`inc/migrations/agent-config-model-shape.php`** *(new)* — idempotent
  one-shot migration that flattens persisted
  `agent_config.model.default.*` rows to the new shape, preserving
  every other key (`tool_policy`, `directive_policy`, `memory_policy`,
  `daily_memory`, plugin-specific keys like `allowed_redirect_uris`,
  etc.). Gated on `datamachine_agent_config_model_shape_migrated`.
- **`inc/migrations/load.php`** — require the new migration file.
- **`inc/migrations/runtime.php`** — wire it into
  `datamachine_run_schema_migrations()` so deploys past
  `DATAMACHINE_VERSION` pick it up automatically (matches the pattern
  established in #1301).

## Verification

Functional test on a planted dirty row (extrachill.com):

```
before: {"model":{"default":{"provider":"openai","model":"gpt-test-mini"}},
         "tool_policy":{"mode":"allow","tools":["foo"]},
         "extra_key":"preserve_me"}

after:  {"tool_policy":{"mode":"allow","tools":["foo"]},
         "extra_key":"preserve_me",
         "default_provider":"openai",
         "default_model":"gpt-test-mini"}
```

- ✅ legacy `model.default.*` flattened
- ✅ `tool_policy` preserved
- ✅ arbitrary sibling keys preserved
- ✅ idempotent gate set on first run
- ✅ empty `agent_config` rows left alone (fall through to defaults)
- ✅ on a manually-cleaned install, second run is a no-op (cheap)

End-to-end on extrachill.com: `roadie` chat send via
`datamachine/send-message` now resolves provider/model correctly and
returns a session id + tool_calls payload instead of the
`provider_required` `WP_Error`.

## Notes

- Network-scoped table — agents live on `base_prefix`, so a single
  pass migrates every multisite at once.
- This is a writer/reader contract bug, not a feature change. No
  user-visible behavior changes for installs that never had the bug.