### PR TITLE
fix(ai): pass handler config to resolved tools

### DIFF
--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -315,6 +315,9 @@ class ToolManager {
 				if ( ! isset( $tool_def['handler'] ) ) {
 					$tool_def['handler'] = $handler_slug;
 				}
+				if ( ! isset( $tool_def['handler_config'] ) ) {
+					$tool_def['handler_config'] = $handler_config;
+				}
 
 				// Apply registry-level meta unless the resolved tool
 				// explicitly overrides.

--- a/tests/upsert-handler-result-handoff-smoke.php
+++ b/tests/upsert-handler-result-handoff-smoke.php
@@ -133,6 +133,8 @@ $available_tools = $resolver->resolve(
 assert_handoff_equals( true, isset( $available_tools['wiki_upsert'] ), 'handler-scoped wiki_upsert tool resolved', $failures, $passes );
 assert_handoff_equals( 'wiki_upsert', $available_tools['wiki_upsert']['handler'] ?? null, 'handler slug metadata survives name collision', $failures, $passes );
 assert_handoff_equals( 'Handler-scoped wiki upsert tool', $available_tools['wiki_upsert']['description'] ?? null, 'handler definition wins over global tool', $failures, $passes );
+assert_handoff_equals( array( 'fixed_parent_path' => 'woocommerce' ), $available_tools['wiki_upsert']['handler_config'] ?? null, 'handler config propagates to resolved tool definition', $failures, $passes );
+assert_handoff_equals( array( 'fixed_parent_path' => 'woocommerce' ), $available_tools['wiki_upsert']['config_seen'] ?? null, 'handler callback still receives the same config', $failures, $passes );
 
 $method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
 


### PR DESCRIPTION
## Summary
- Pass the current flow-step handler_config onto resolved handler tool definitions when the tool does not provide its own override.
- Extend the wiki_upsert handler-result smoke to prove fixed_parent_path-style config survives tool resolution.

## Tests
- php tests/upsert-handler-result-handoff-smoke.php
- php -l inc/Engine/AI/Tools/ToolManager.php && php -l tests/upsert-handler-result-handoff-smoke.php
- php tests/tool-policy-resolver-adjacency-smoke.php
- homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-handler-tool-config --changed-since origin/main
- homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-handler-tool-config (fails on pre-existing phpstan findings across unrelated tests)

Closes #1468

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the handler-tool config fix and smoke coverage. Chris/Franklin reviewed the framing and live repro.