### PR TITLE
feat(content): bundle block format bridge substrate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
 	"require": {
 		"php": ">=8.2",
 		"woocommerce/action-scheduler": "^3.9",
-		"chubes4/ai-http-client": "^2.0.13"
+		"chubes4/ai-http-client": "^2.0.13",
+		"chubes4/block-format-bridge": "dev-main"
 	},
 	"require-dev": {
 		"php-stubs/wordpress-stubs": "^6.9",
@@ -38,5 +39,10 @@
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
-	}
+	},
+	"repositories": [{
+		"name": "block-format-bridge",
+		"type": "vcs",
+		"url": "https://github.com/chubes4/block-format-bridge"
+	}]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e3ec3b625f283a4b61c81a7fbbc909d",
+    "content-hash": "307b2dd9d37131ca17facd890981262c",
     "packages": [
         {
             "name": "chubes4/ai-http-client",
@@ -65,6 +65,770 @@
                 "source": "https://github.com/chubes4/ai-http-client"
             },
             "time": "2026-01-31T17:55:07+00:00"
+        },
+        {
+            "name": "chubes4/block-format-bridge",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/chubes4/block-format-bridge.git",
+                "reference": "59c87ed65c01dac25a9ff45d66ab1a61aa644009"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/59c87ed65c01dac25a9ff45d66ab1a61aa644009",
+                "reference": "59c87ed65c01dac25a9ff45d66ab1a61aa644009",
+                "shasum": ""
+            },
+            "require": {
+                "league/commonmark": "^2.5",
+                "league/html-to-markdown": "^5.1",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "chubes4/html-to-blocks-converter": "dev-main",
+                "humbug/php-scoper": "^0.18.19"
+            },
+            "default-branch": true,
+            "type": "wordpress-plugin",
+            "autoload": {
+                "files": [
+                    "library.php"
+                ]
+            },
+            "scripts": {
+                "build": [
+                    "./build.sh"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Huber",
+                    "homepage": "https://chubes.net"
+                }
+            ],
+            "description": "WordPress plugin orchestrating bidirectional content format conversion (HTML, Blocks, Markdown) via a unified adapter API.",
+            "homepage": "https://github.com/chubes4/block-format-bridge",
+            "support": {
+                "source": "https://github.com/chubes4/block-format-bridge/tree/main",
+                "issues": "https://github.com/chubes4/block-format-bridge/issues"
+            },
+            "time": "2026-04-28T00:25:05+00:00"
+        },
+        {
+            "name": "dflydev/dot-access-data",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
+                "reference": "a23a2bf4f31d3518f3ecb38660c95715dfead60f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/a23a2bf4f31d3518f3ecb38660c95715dfead60f",
+                "reference": "a23a2bf4f31d3518f3ecb38660c95715dfead60f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
+                "scrutinizer/ocular": "1.6.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dflydev\\DotAccessData\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                },
+                {
+                    "name": "Carlos Frutos",
+                    "email": "carlos@kiwing.it",
+                    "homepage": "https://github.com/cfrutos"
+                },
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com"
+                }
+            ],
+            "description": "Given a deep data structure, access data by dot notation.",
+            "homepage": "https://github.com/dflydev/dflydev-dot-access-data",
+            "keywords": [
+                "access",
+                "data",
+                "dot",
+                "notation"
+            ],
+            "support": {
+                "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
+            },
+            "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "league/commonmark",
+            "version": "2.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/commonmark.git",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "league/config": "^1.1.1",
+                "php": "^7.4 || ^8.0",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "require-dev": {
+                "cebe/markdown": "^1.0",
+                "commonmark/cmark": "0.31.1",
+                "commonmark/commonmark.js": "0.31.1",
+                "composer/package-versions-deprecated": "^1.8",
+                "embed/embed": "^4.4",
+                "erusev/parsedown": "^1.0",
+                "ext-json": "*",
+                "github/gfm": "0.29.0",
+                "michelf/php-markdown": "^1.4 || ^2.0",
+                "nyholm/psr7": "^1.5",
+                "phpstan/phpstan": "^1.8.2",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "scrutinizer/ocular": "^1.8.1",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
+                "unleashedtech/php-coding-standard": "^3.1.1",
+                "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
+            },
+            "suggest": {
+                "symfony/yaml": "v2.3+ required if using the Front Matter extension"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\CommonMark\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Highly-extensible PHP Markdown parser which fully supports the CommonMark spec and GitHub-Flavored Markdown (GFM)",
+            "homepage": "https://commonmark.thephpleague.com",
+            "keywords": [
+                "commonmark",
+                "flavored",
+                "gfm",
+                "github",
+                "github-flavored",
+                "markdown",
+                "md",
+                "parser"
+            ],
+            "support": {
+                "docs": "https://commonmark.thephpleague.com/",
+                "forum": "https://github.com/thephpleague/commonmark/discussions",
+                "issues": "https://github.com/thephpleague/commonmark/issues",
+                "rss": "https://github.com/thephpleague/commonmark/releases.atom",
+                "source": "https://github.com/thephpleague/commonmark"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/commonmark",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-19T13:16:38+00:00"
+        },
+        {
+            "name": "league/config",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/config.git",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/config/zipball/754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/dot-access-data": "^3.0.1",
+                "nette/schema": "^1.2",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.8.2",
+                "phpunit/phpunit": "^9.5.5",
+                "scrutinizer/ocular": "^1.8.1",
+                "unleashedtech/php-coding-standard": "^3.1",
+                "vimeo/psalm": "^4.7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Config\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Define configuration arrays with strict schemas and access values with dot notation",
+            "homepage": "https://config.thephpleague.com",
+            "keywords": [
+                "array",
+                "config",
+                "configuration",
+                "dot",
+                "dot-access",
+                "nested",
+                "schema"
+            ],
+            "support": {
+                "docs": "https://config.thephpleague.com/",
+                "issues": "https://github.com/thephpleague/config/issues",
+                "rss": "https://github.com/thephpleague/config/releases.atom",
+                "source": "https://github.com/thephpleague/config"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-11T20:36:23+00:00"
+        },
+        {
+            "name": "league/html-to-markdown",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/html-to-markdown.git",
+                "reference": "0b4066eede55c48f38bcee4fb8f0aa85654390fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/html-to-markdown/zipball/0b4066eede55c48f38bcee4fb8f0aa85654390fd",
+                "reference": "0b4066eede55c48f38bcee4fb8f0aa85654390fd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xml": "*",
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "mikehaertl/php-shellcommand": "^1.1.0",
+                "phpstan/phpstan": "^1.8.8",
+                "phpunit/phpunit": "^8.5 || ^9.2",
+                "scrutinizer/ocular": "^1.6",
+                "unleashedtech/php-coding-standard": "^2.7 || ^3.0",
+                "vimeo/psalm": "^4.22 || ^5.0"
+            },
+            "bin": [
+                "bin/html-to-markdown"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\HTMLToMarkdown\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Nick Cernis",
+                    "email": "nick@cern.is",
+                    "homepage": "http://modernnerd.net",
+                    "role": "Original Author"
+                }
+            ],
+            "description": "An HTML-to-markdown conversion helper for PHP",
+            "homepage": "https://github.com/thephpleague/html-to-markdown",
+            "keywords": [
+                "html",
+                "markdown"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/html-to-markdown/issues",
+                "source": "https://github.com/thephpleague/html-to-markdown/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/html-to-markdown",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-12T21:21:09+00:00"
+        },
+        {
+            "name": "nette/schema",
+            "version": "v1.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/schema.git",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^4.0",
+                "php": "8.1 - 8.5"
+            },
+            "require-dev": {
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
+                "tracy/tracy": "^2.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "📐 Nette Schema: validating data structures against a given Schema.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "config",
+                "nette"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/schema/issues",
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
+            },
+            "time": "2026-02-23T03:47:12+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v4.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "shasum": ""
+            },
+            "require": {
+                "php": "8.2 - 8.5"
+            },
+            "conflict": {
+                "nette/finder": "<3",
+                "nette/schema": "<1.2.2"
+            },
+            "require-dev": {
+                "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.5",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
+                "tracy/tracy": "^2.9"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠  Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/utils/issues",
+                "source": "https://github.com/nette/utils/tree/v4.1.3"
+            },
+            "time": "2026-02-13T03:05:33+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "woocommerce/action-scheduler",
@@ -795,12 +1559,14 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "chubes4/block-format-bridge": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/inc/Abilities/Content/EditPostBlocksAbility.php
+++ b/inc/Abilities/Content/EditPostBlocksAbility.php
@@ -13,6 +13,7 @@
 namespace DataMachine\Abilities\Content;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Engine\AI\Actions\PendingActionHelper;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 
@@ -197,7 +198,16 @@ class EditPostBlocksAbility {
 			);
 		}
 
-		$blocks       = parse_blocks( $post->post_content );
+		$block_content = ContentFormat::storedToBlocks( (string) $post->post_content, (string) $post->post_type );
+		if ( is_wp_error( $block_content ) ) {
+			return array(
+				'success' => false,
+				'post_id' => $post_id,
+				'error'   => $block_content->get_error_message(),
+			);
+		}
+
+		$blocks       = parse_blocks( $block_content );
 		$total_blocks = count( $blocks );
 		$changes      = array();
 
@@ -275,7 +285,15 @@ class EditPostBlocksAbility {
 			);
 		}
 
-		$new_content = BlockSanitizer::sanitizeAndSerialize( $blocks );
+		$new_content    = BlockSanitizer::sanitizeAndSerialize( $blocks );
+		$stored_content = ContentFormat::blocksToStored( $new_content, (string) $post->post_type );
+		if ( is_wp_error( $stored_content ) ) {
+			return array(
+				'success' => false,
+				'post_id' => $post_id,
+				'error'   => $stored_content->get_error_message(),
+			);
+		}
 
 		// --- Preview mode: stage pending action, return preview envelope ---
 		if ( $preview ) {
@@ -342,7 +360,7 @@ class EditPostBlocksAbility {
 		$result = wp_update_post(
 			array(
 				'ID'           => $post_id,
-				'post_content' => $new_content,
+				'post_content' => $stored_content,
 			),
 			true
 		);

--- a/inc/Abilities/Content/GetPostBlocksAbility.php
+++ b/inc/Abilities/Content/GetPostBlocksAbility.php
@@ -13,6 +13,7 @@
 namespace DataMachine\Abilities\Content;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Content\ContentFormat;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -179,7 +180,15 @@ class GetPostBlocksAbility {
 			);
 		}
 
-		$blocks  = parse_blocks( $post->post_content );
+		$block_content = ContentFormat::storedToBlocks( (string) $post->post_content, (string) $post->post_type );
+		if ( is_wp_error( $block_content ) ) {
+			return array(
+				'success' => false,
+				'error'   => $block_content->get_error_message(),
+			);
+		}
+
+		$blocks  = parse_blocks( $block_content );
 		$results = array();
 
 		foreach ( $blocks as $index => $block ) {

--- a/inc/Abilities/Content/ReplacePostBlocksAbility.php
+++ b/inc/Abilities/Content/ReplacePostBlocksAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Abilities\Content;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Engine\AI\Actions\PendingActionHelper;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 
@@ -192,7 +193,16 @@ class ReplacePostBlocksAbility {
 			);
 		}
 
-		$blocks       = parse_blocks( $post->post_content );
+		$block_content = ContentFormat::storedToBlocks( (string) $post->post_content, (string) $post->post_type );
+		if ( is_wp_error( $block_content ) ) {
+			return array(
+				'success' => false,
+				'post_id' => $post_id,
+				'error'   => $block_content->get_error_message(),
+			);
+		}
+
+		$blocks       = parse_blocks( $block_content );
 		$total_blocks = count( $blocks );
 		$changes      = array();
 
@@ -259,7 +269,15 @@ class ReplacePostBlocksAbility {
 			);
 		}
 
-		$new_content = BlockSanitizer::sanitizeAndSerialize( $blocks );
+		$new_content    = BlockSanitizer::sanitizeAndSerialize( $blocks );
+		$stored_content = ContentFormat::blocksToStored( $new_content, (string) $post->post_type );
+		if ( is_wp_error( $stored_content ) ) {
+			return array(
+				'success' => false,
+				'post_id' => $post_id,
+				'error'   => $stored_content->get_error_message(),
+			);
+		}
 
 		// --- Preview mode: stage pending action, return preview envelope ---
 		if ( $preview ) {
@@ -332,7 +350,7 @@ class ReplacePostBlocksAbility {
 		$result = wp_update_post(
 			array(
 				'ID'           => $post_id,
-				'post_content' => $new_content,
+				'post_content' => $stored_content,
 			),
 			true
 		);

--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -25,6 +25,7 @@
 namespace DataMachine\Abilities\Content;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Core\WordPress\ResolvePostByPath;
 
 defined( 'ABSPATH' ) || exit;
@@ -73,7 +74,11 @@ class UpsertPostAbility {
 							),
 							'content'        => array(
 								'type'        => 'string',
-								'description' => 'Post content (HTML or blocks). Replaces existing content when updating.',
+								'description' => 'Post content. Replaces existing content when updating.',
+							),
+							'content_format' => array(
+								'type'        => 'string',
+								'description' => 'Format of content. Defaults to blocks. Use markdown/html when passing non-block source content.',
 							),
 							'post_id'        => array(
 								'type'        => 'integer',
@@ -195,31 +200,35 @@ class UpsertPostAbility {
 			'method'      => 'handleChatToolCall',
 			'description' => 'Idempotently create or update a WordPress post. Finds by identity (post_id, slug+parent, or custom meta), compares content hash, and returns created/updated/no_change. Use for pipeline-safe writes that avoid churn on re-runs.',
 			'parameters'  => array(
-				'post_type'    => array(
+				'post_type'      => array(
 					'type'        => 'string',
 					'description' => 'Post type slug.',
 				),
-				'title'        => array(
+				'title'          => array(
 					'type'        => 'string',
 					'description' => 'Post title.',
 				),
-				'content'      => array(
+				'content'        => array(
 					'type'        => 'string',
-					'description' => 'Post content (HTML or blocks).',
+					'description' => 'Post content.',
 				),
-				'slug'         => array(
+				'content_format' => array(
+					'type'        => 'string',
+					'description' => 'Format of content. Defaults to blocks.',
+				),
+				'slug'           => array(
 					'type'        => 'string',
 					'description' => 'Post slug for lookup.',
 				),
-				'parent_id'    => array(
+				'parent_id'      => array(
 					'type'        => 'integer',
 					'description' => 'Parent post ID.',
 				),
-				'parent_path'  => array(
+				'parent_path'    => array(
 					'type'        => 'string',
 					'description' => 'Slash-delimited parent path (e.g. "artist/link-pages").',
 				),
-				'post_author'  => array(
+				'post_author'    => array(
 					'type'        => 'integer',
 					'description' => 'Post author user ID (create only).',
 				),
@@ -236,6 +245,7 @@ class UpsertPostAbility {
 	 * Handle chat tool call.
 	 */
 	public static function handleChatToolCall( array $params, array $tool_def = array() ): array {
+		$tool_def;
 		$result = self::execute( $params );
 		return array(
 			'success'   => ! empty( $result['success'] ),
@@ -251,27 +261,36 @@ class UpsertPostAbility {
 	 * @return array Result with action: created|updated|no_change.
 	 */
 	public static function execute( array $input ): array {
-		$post_type    = sanitize_key( $input['post_type'] ?? '' );
-		$title        = trim( $input['title'] ?? '' );
-		$content      = $input['content'] ?? '';
-		$post_id      = absint( $input['post_id'] ?? 0 );
-		$slug         = sanitize_title( $input['slug'] ?? '' );
-		$parent_id    = absint( $input['parent_id'] ?? 0 );
-		$parent_path  = trim( $input['parent_path'] ?? '' );
-		$identity_meta = $input['identity_meta'] ?? array();
-		$content_hash = $input['content_hash'] ?? '';
-		$raw_source   = $input['raw_source'] ?? '';
-		$post_status  = sanitize_key( $input['post_status'] ?? 'publish' );
-		$post_author  = absint( $input['post_author'] ?? 0 );
-		$post_excerpt = $input['post_excerpt'] ?? '';
-		$taxonomies   = $input['taxonomies'] ?? array();
-		$meta_input   = $input['meta_input'] ?? array();
-		$create_stubs = ! empty( $input['create_stubs'] );
+		$post_type      = sanitize_key( $input['post_type'] ?? '' );
+		$title          = trim( $input['title'] ?? '' );
+		$content        = $input['content'] ?? '';
+		$content_format = sanitize_key( $input['content_format'] ?? 'blocks' );
+		$post_id        = absint( $input['post_id'] ?? 0 );
+		$slug           = sanitize_title( $input['slug'] ?? '' );
+		$parent_id      = absint( $input['parent_id'] ?? 0 );
+		$parent_path    = trim( $input['parent_path'] ?? '' );
+		$identity_meta  = $input['identity_meta'] ?? array();
+		$content_hash   = $input['content_hash'] ?? '';
+		$raw_source     = $input['raw_source'] ?? '';
+		$post_status    = sanitize_key( $input['post_status'] ?? 'publish' );
+		$post_author    = absint( $input['post_author'] ?? 0 );
+		$post_excerpt   = $input['post_excerpt'] ?? '';
+		$taxonomies     = $input['taxonomies'] ?? array();
+		$meta_input     = $input['meta_input'] ?? array();
+		$create_stubs   = ! empty( $input['create_stubs'] );
 
 		if ( '' === $post_type || '' === $title ) {
 			return array(
 				'success' => false,
 				'error'   => 'post_type and title are required.',
+			);
+		}
+
+		$stored_content = ContentFormat::sourceToStored( (string) $content, $content_format, $post_type );
+		if ( is_wp_error( $stored_content ) ) {
+			return array(
+				'success' => false,
+				'error'   => $stored_content->get_error_message(),
 			);
 		}
 
@@ -333,7 +352,7 @@ class UpsertPostAbility {
 		$post_data = array(
 			'post_type'    => $post_type,
 			'post_title'   => $title,
-			'post_content' => $content,
+			'post_content' => $stored_content,
 			'post_status'  => $post_status,
 		);
 

--- a/inc/Core/Content/ContentFormat.php
+++ b/inc/Core/Content/ContentFormat.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Content format conversion helpers for post content boundaries.
+ *
+ * @package DataMachine\Core\Content
+ */
+
+namespace DataMachine\Core\Content;
+
+defined( 'ABSPATH' ) || exit;
+
+class ContentFormat {
+
+
+	/**
+	 * Return the canonical storage format for a post type.
+	 *
+	 * @param  string $post_type Post type slug.
+	 * @return string Format slug.
+	 */
+	public static function storedFormat( string $post_type ): string {
+		$format = apply_filters( 'datamachine_post_content_format', 'blocks', $post_type );
+
+		return sanitize_key( is_string( $format ) && '' !== $format ? $format : 'blocks' );
+	}
+
+	/**
+	 * Convert content between two explicit formats.
+	 *
+	 * @param  string $content Source content.
+	 * @param  string $from    Source format slug.
+	 * @param  string $to      Target format slug.
+	 * @return string|\WP_Error Converted content or error.
+	 */
+	public static function convert( string $content, string $from, string $to ) {
+		$from = sanitize_key( $from );
+		$to   = sanitize_key( $to );
+
+		if ( $from === $to ) {
+			return $content;
+		}
+
+		if ( ! function_exists( 'bfb_convert' ) ) {
+			return new \WP_Error(
+				'datamachine_content_format_bfb_missing',
+				sprintf( 'Block Format Bridge is required to convert post content from %s to %s.', $from, $to )
+			);
+		}
+
+		$converted = bfb_convert( $content, $from, $to );
+
+		if ( is_wp_error( $converted ) ) {
+			return $converted;
+		}
+
+		if ( ! is_string( $converted ) ) {
+			return new \WP_Error(
+				'datamachine_content_format_invalid_result',
+				sprintf( 'Block Format Bridge returned a non-string result converting post content from %s to %s.', $from, $to )
+			);
+		}
+
+		return $converted;
+	}
+
+	/**
+	 * Convert stored post content to block markup for block-level tools.
+	 *
+	 * @param  string $content   Stored post content.
+	 * @param  string $post_type Post type slug.
+	 * @return string|\WP_Error Block markup or error.
+	 */
+	public static function storedToBlocks( string $content, string $post_type ) {
+		return self::convert( $content, self::storedFormat( $post_type ), 'blocks' );
+	}
+
+	/**
+	 * Convert block markup to the post type's stored format.
+	 *
+	 * @param  string $content   Block markup.
+	 * @param  string $post_type Post type slug.
+	 * @return string|\WP_Error Stored-format content or error.
+	 */
+	public static function blocksToStored( string $content, string $post_type ) {
+		return self::convert( $content, 'blocks', self::storedFormat( $post_type ) );
+	}
+
+	/**
+	 * Convert caller-provided content into the post type's stored format.
+	 *
+	 * @param  string $content       Source content.
+	 * @param  string $source_format Source format slug.
+	 * @param  string $post_type     Post type slug.
+	 * @return string|\WP_Error Stored-format content or error.
+	 */
+	public static function sourceToStored( string $content, string $source_format, string $post_type ) {
+		return self::convert( $content, $source_format, self::storedFormat( $post_type ) );
+	}
+}

--- a/tests/agent-bundle-format-smoke.php
+++ b/tests/agent-bundle-format-smoke.php
@@ -22,6 +22,24 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	}
 }
 
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook = '' ) {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		// no-op
+	}
+}
+
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
 use DataMachine\Engine\Bundle\AgentBundleDirectory;

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -57,6 +57,18 @@ function do_action( string $tag, ...$args ): void {
 	}
 }
 
+function did_action( string $hook = '' ): int {
+	return 0;
+}
+
+function doing_action( string $hook = '' ): bool {
+	return false;
+}
+
+function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	// no-op
+}
+
 function wp_json_encode( $data, int $flags = 0 ) {
 	return json_encode( $data, $flags );
 }

--- a/tests/bfb-substrate-bundle-smoke.php
+++ b/tests/bfb-substrate-bundle-smoke.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Pure-PHP smoke test for the bundled Block Format Bridge substrate (#1469).
+ *
+ * Run with: php tests/bfb-substrate-bundle-smoke.php
+ *
+ * This PR only makes the content-format substrate available to Data Machine.
+ * Ability-level `content_format` behavior belongs to #1470, so this smoke
+ * focuses on Composer/package loading boundaries instead of ability behavior.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failed = 0;
+$total  = 0;
+
+/**
+ * Assert helper.
+ *
+ * @param string $name      Test case name.
+ * @param bool   $condition Pass/fail.
+ */
+function assert_bfb_bundle( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+	echo "  FAIL: {$name}\n";
+	++$failed;
+}
+
+// --- Minimal WordPress stubs ----------------------------------------
+
+$GLOBALS['__bfb_bundle_actions'] = array();
+$GLOBALS['__bfb_bundle_filters'] = array();
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook = '' ) {
+		return 'plugins_loaded' === $hook ? 1 : 0;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['__bfb_bundle_actions'][] = compact( 'hook', 'callback', 'priority', 'accepted_args' );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['__bfb_bundle_filters'][] = compact( 'hook', 'callback', 'priority', 'accepted_args' );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'has_filter' ) ) {
+	function has_filter( $hook, $callback = false ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'has_action' ) ) {
+	function has_action( $hook, $callback = false ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook, ...$args ) {
+		return null;
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $path ) {
+		return rtrim( (string) $path, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+	function wp_unslash( $value ) {
+		return is_string( $value ) ? stripslashes( $value ) : $value;
+	}
+}
+
+if ( ! function_exists( 'wp_slash' ) ) {
+	function wp_slash( $value ) {
+		return is_string( $value ) ? addslashes( $value ) : $value;
+	}
+}
+
+if ( ! function_exists( 'parse_blocks' ) ) {
+	function parse_blocks( $content ) {
+		return array();
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	function serialize_blocks( $blocks ) {
+		return '';
+	}
+}
+
+if ( ! function_exists( 'get_post_types' ) ) {
+	function get_post_types( $args = array() ) {
+		return array();
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+// --- Composer/package assertions ------------------------------------
+
+$root          = dirname( __DIR__ );
+$composer_json = json_decode( file_get_contents( $root . '/composer.json' ), true );
+$composer_lock = json_decode( file_get_contents( $root . '/composer.lock' ), true );
+
+assert_bfb_bundle(
+	'composer-json-requires-bfb',
+	isset( $composer_json['require']['chubes4/block-format-bridge'] )
+);
+
+$locked_packages = array();
+foreach ( $composer_lock['packages'] ?? array() as $package ) {
+	$locked_packages[ $package['name'] ?? '' ] = $package;
+}
+
+assert_bfb_bundle(
+	'composer-lock-contains-bfb',
+	isset( $locked_packages['chubes4/block-format-bridge'] )
+);
+
+assert_bfb_bundle(
+	'composer-lock-does-not-contain-unscoped-h2bc',
+	! isset( $locked_packages['chubes4/html-to-blocks-converter'] )
+);
+
+$bfb_path = $root . '/vendor/chubes4/block-format-bridge';
+
+assert_bfb_bundle( 'bfb-library-installed', file_exists( $bfb_path . '/library.php' ) );
+assert_bfb_bundle( 'bfb-prefixed-autoload-installed', file_exists( $bfb_path . '/vendor_prefixed/autoload.php' ) );
+assert_bfb_bundle( 'unscoped-h2bc-vendor-dir-absent', ! is_dir( $root . '/vendor/chubes4/html-to-blocks-converter' ) );
+
+require $root . '/vendor/autoload.php';
+
+assert_bfb_bundle( 'bfb-convert-function-available', function_exists( 'bfb_convert' ) );
+assert_bfb_bundle( 'bfb-version-registry-loaded', class_exists( 'BFB_Versions', false ) );
+assert_bfb_bundle( 'bfb-adapter-registry-loaded', class_exists( 'BFB_Adapter_Registry', false ) );
+assert_bfb_bundle( 'scoped-h2bc-version-registry-loaded', class_exists( 'BlockFormatBridge\\Vendor\\HTML_To_Blocks_Versions', false ) );
+
+$h2bc_globals = array(
+	'HTML_To_Blocks_Versions',
+	'HTML_To_Blocks_HTML_Element',
+	'HTML_To_Blocks_Block_Factory',
+	'HTML_To_Blocks_Attribute_Parser',
+	'HTML_To_Blocks_Transform_Registry',
+);
+
+foreach ( $h2bc_globals as $class_name ) {
+	assert_bfb_bundle( "global-{$class_name}-not-created", ! class_exists( $class_name, false ) );
+}
+
+echo "\nBFB substrate bundle smoke: {$total} assertions, {$failed} failures.\n";
+
+if ( $failed > 0 ) {
+	exit( 1 );
+}

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -12,4 +12,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', '/tmp/' );
 }
 
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook = '' ) {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		// no-op
+	}
+}
+
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/content-format-abilities-smoke.php
+++ b/tests/content-format-abilities-smoke.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Pure-PHP smoke test for storage-format-aware content abilities.
+ *
+ * Run with: php tests/content-format-abilities-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\WordPress {
+	class ResolvePostByPath {
+
+		public static function build_path( $post ): string {
+			return $post->post_name ?? '';
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$failed = 0;
+	$total  = 0;
+
+	function assert_content_ability( string $name, bool $condition ): void {
+		global $failed, $total;
+		++$total;
+		if ( $condition ) {
+			echo "  PASS: {$name}\n";
+			return;
+		}
+		echo "  FAIL: {$name}\n";
+		++$failed;
+	}
+
+	class WP_Error {
+
+		private string $message;
+
+		public function __construct( string $code = '', string $message = '' ) {
+			unset( $code );
+			$this->message = $message;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+
+	$GLOBALS['__content_ability_filters']     = array();
+	$GLOBALS['__content_ability_posts']       = array(
+		7 => (object) array(
+			'ID'           => 7,
+			'post_type'    => 'wiki',
+			'post_title'   => 'Markdown Page',
+			'post_name'    => 'markdown-page',
+			'post_content' => "# Original\n\nHello world.",
+		),
+	);
+	$GLOBALS['__content_ability_next_id']     = 20;
+	$GLOBALS['__content_ability_conversions'] = array();
+
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['__content_ability_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+	}
+
+	function apply_filters( string $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['__content_ability_filters'][ $hook ] ) ) {
+			return $value;
+		}
+
+		ksort( $GLOBALS['__content_ability_filters'][ $hook ] );
+		foreach ( $GLOBALS['__content_ability_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as $registered_callback ) {
+				list( $callback, $accepted_args ) = $registered_callback;
+				$value                            = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+			}
+		}
+		return $value;
+	}
+
+	function sanitize_key( $key ): string {
+		return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $key ) );
+	}
+
+	function sanitize_title( $title ): string {
+		return strtolower( trim( preg_replace( '/[^a-zA-Z0-9]+/', '-', (string) $title ), '-' ) );
+	}
+
+	function sanitize_text_field( $value ): string {
+		return trim( (string) $value );
+	}
+
+	function absint( $value ): int {
+		return max( 0, (int) $value );
+	}
+
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+
+	function wp_kses_post( $content ): string {
+		return (string) $content;
+	}
+
+	function wp_unslash( $value ) {
+		return $value;
+	}
+
+	function __( $text, $domain = 'default' ) {
+		unset( $domain );
+		return $text;
+	}
+
+	function do_action( ...$args ): void {
+		$GLOBALS['__content_ability_actions'][] = $args;
+	}
+
+	function get_post( int $post_id ) {
+		return $GLOBALS['__content_ability_posts'][ $post_id ] ?? null;
+	}
+
+	function get_permalink( int $post_id ): string {
+		return "https://example.test/?p={$post_id}";
+	}
+
+	function get_post_meta( int $post_id, string $key, bool $single = false ) {
+		unset( $post_id, $key, $single );
+		return '';
+	}
+
+	function taxonomy_exists( string $taxonomy ): bool {
+		unset( $taxonomy );
+		return false;
+	}
+
+	function wp_update_post( array $post_data, bool $wp_error = false ) {
+		unset( $wp_error );
+		$id = (int) ( $post_data['ID'] ?? 0 );
+		if ( empty( $GLOBALS['__content_ability_posts'][ $id ] ) ) {
+			return new WP_Error( 'missing', 'Missing post.' );
+		}
+
+		foreach ( $post_data as $key => $value ) {
+			if ( 'ID' !== $key ) {
+				$GLOBALS['__content_ability_posts'][ $id ]->{$key} = $value;
+			}
+		}
+		return $id;
+	}
+
+	function wp_insert_post( array $post_data, bool $wp_error = false ) {
+		unset( $wp_error );
+		$id = (int) ( $post_data['ID'] ?? 0 );
+		if ( $id <= 0 ) {
+			$id = $GLOBALS['__content_ability_next_id']++;
+		}
+
+		$existing = $GLOBALS['__content_ability_posts'][ $id ] ?? (object) array( 'ID' => $id );
+		foreach ( $post_data as $key => $value ) {
+			if ( 'meta_input' !== $key ) {
+				$existing->{$key} = $value;
+			}
+		}
+		$existing->ID                              = $id;
+		$GLOBALS['__content_ability_posts'][ $id ] = $existing;
+		return $id;
+	}
+
+	function bfb_convert( string $content, string $from, string $to ) {
+		$GLOBALS['__content_ability_conversions'][] = array( $from, $to, $content );
+
+		if ( $from === $to ) {
+			return $content;
+		}
+
+		if ( 'markdown' === $from && 'blocks' === $to ) {
+			$lines = preg_split( '/\R+/', trim( $content ) );
+			if ( false === $lines ) {
+				return new WP_Error( 'parse_failed', 'Could not split markdown.' );
+			}
+
+			$blocks = array();
+			foreach ( $lines as $line ) {
+				if ( str_starts_with( $line, '# ' ) ) {
+					$text     = substr( $line, 2 );
+					$blocks[] = "<!-- wp:heading -->\n<h2>{$text}</h2>\n<!-- /wp:heading -->";
+				} else {
+					$blocks[] = "<!-- wp:paragraph -->\n<p>{$line}</p>\n<!-- /wp:paragraph -->";
+				}
+			}
+			return implode( "\n", $blocks );
+		}
+
+		if ( 'blocks' === $from && 'markdown' === $to ) {
+			$content = preg_replace( '/<!--\s*\/?wp:[^>]+-->\s*/', '', $content );
+			$content = preg_replace( '/<h[1-6][^>]*>(.*?)<\/h[1-6]>/', '# $1', $content );
+			$content = preg_replace( '/<p[^>]*>(.*?)<\/p>/', '$1', $content );
+			return trim( html_entity_decode( strip_tags( $content ) ) );
+		}
+
+		return new WP_Error( 'unsupported', "Unsupported {$from} to {$to}." );
+	}
+
+	function parse_blocks( string $content ): array {
+		$blocks = array();
+		if ( preg_match_all( '/<!-- wp:([^ ]+) -->\s*(.*?)\s*<!-- \/wp:\1 -->/s', $content, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				$block_name = str_contains( $match[1], '/' ) ? $match[1] : 'core/' . $match[1];
+				$blocks[]   = array(
+					'blockName'    => $block_name,
+					'innerHTML'    => $match[2],
+					'innerContent' => array( $match[2] ),
+					'innerBlocks'  => array(),
+				);
+			}
+			return $blocks;
+		}
+
+		return array(
+			array(
+				'blockName'    => null,
+				'innerHTML'    => $content,
+				'innerContent' => array( $content ),
+				'innerBlocks'  => array(),
+			),
+		);
+	}
+
+	function serialize_blocks( array $blocks ): string {
+		$serialized = array();
+		foreach ( $blocks as $block ) {
+			$name         = $block['blockName'] ?? 'core/freeform';
+			$html         = $block['innerHTML'] ?? '';
+			$serialized[] = "<!-- wp:{$name} -->\n{$html}\n<!-- /wp:{$name} -->";
+		}
+		return implode( "\n", $serialized );
+	}
+
+	add_filter(
+		'datamachine_post_content_format',
+		static function ( string $format, string $post_type ): string {
+			return 'wiki' === $post_type ? 'markdown' : $format;
+		},
+		10,
+		2
+	);
+
+	include_once dirname( __DIR__ ) . '/inc/Core/Content/ContentFormat.php';
+	include_once dirname( __DIR__ ) . '/inc/Abilities/Content/BlockSanitizer.php';
+	include_once dirname( __DIR__ ) . '/inc/Abilities/Content/GetPostBlocksAbility.php';
+	include_once dirname( __DIR__ ) . '/inc/Abilities/Content/EditPostBlocksAbility.php';
+	include_once dirname( __DIR__ ) . '/inc/Abilities/Content/UpsertPostAbility.php';
+
+	$get = DataMachine\Abilities\Content\GetPostBlocksAbility::execute( array( 'post_id' => 7 ) );
+	assert_content_ability( 'markdown-post-read-succeeds', true === $get['success'] );
+	assert_content_ability( 'markdown-post-read-converts-to-blocks', 'core/heading' === ( $get['blocks'][0]['block_name'] ?? '' ) );
+	$stored_after_read = get_post( 7 )->post_content ?? '';
+	assert_content_ability( 'markdown-post-read-does-not-mutate-storage', "# Original\n\nHello world." === $stored_after_read );
+
+	$edit = DataMachine\Abilities\Content\EditPostBlocksAbility::execute(
+		array(
+			'post_id' => 7,
+			'edits'   => array(
+				array(
+					'block_index' => 1,
+					'find'        => 'Hello world.',
+					'replace'     => 'Hello markdown.',
+				),
+			),
+		)
+	);
+	assert_content_ability( 'markdown-post-edit-succeeds', true === $edit['success'] );
+	$stored_after_edit = get_post( 7 )->post_content ?? '';
+	assert_content_ability( 'markdown-post-edit-saves-markdown', false === strpos( $stored_after_edit, '<!-- wp:' ) );
+	assert_content_ability( 'markdown-post-edit-has-replacement', false !== strpos( $stored_after_edit, 'Hello markdown.' ) );
+
+	$upsert   = DataMachine\Abilities\Content\UpsertPostAbility::execute(
+		array(
+			'post_type'      => 'wiki',
+			'title'          => 'New Markdown',
+			'content'        => "# Stored\n\nRaw markdown.",
+			'content_format' => 'markdown',
+		)
+	);
+	$new_id   = $upsert['post_id'] ?? 0;
+	$new_post = get_post( (int) $new_id );
+	assert_content_ability( 'upsert-markdown-source-succeeds', true === $upsert['success'] );
+	assert_content_ability( 'upsert-markdown-source-stays-markdown', "# Stored\n\nRaw markdown." === ( $new_post->post_content ?? '' ) );
+
+	echo "\nContentFormat abilities smoke: {$total} assertions, {$failed} failures.\n";
+
+	exit( min( 1, $failed ) );
+}

--- a/tests/content-format-helper-smoke.php
+++ b/tests/content-format-helper-smoke.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Pure-PHP smoke test for ContentFormat conversion policy.
+ *
+ * Run with: php tests/content-format-helper-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failed = 0;
+$total  = 0;
+
+function assert_content_format( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+	echo "  FAIL: {$name}\n";
+	++$failed;
+}
+
+$GLOBALS['__content_format_filters'] = array();
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['__content_format_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	if ( empty( $GLOBALS['__content_format_filters'][ $hook ] ) ) {
+		return $value;
+	}
+
+	ksort( $GLOBALS['__content_format_filters'][ $hook ] );
+	foreach ( $GLOBALS['__content_format_filters'][ $hook ] as $callbacks ) {
+		foreach ( $callbacks as $registered_callback ) {
+			list( $callback, $accepted_args ) = $registered_callback;
+			$value                            = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+		}
+	}
+	return $value;
+}
+
+function sanitize_key( $key ): string {
+	return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $key ) );
+}
+
+function is_wp_error( $thing ): bool {
+	return $thing instanceof WP_Error;
+}
+
+class WP_Error {
+
+	private string $message;
+
+	public function __construct( string $code = '', string $message = '' ) {
+		unset( $code );
+		$this->message = $message;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/Content/ContentFormat.php';
+
+use DataMachine\Core\Content\ContentFormat;
+
+assert_content_format( 'default-format-is-blocks', 'blocks' === ContentFormat::storedFormat( 'post' ) );
+
+add_filter(
+	'datamachine_post_content_format',
+	static function ( string $format, string $post_type ): string {
+		return 'wiki' === $post_type ? 'markdown' : $format;
+	},
+	10,
+	2
+);
+
+assert_content_format( 'filtered-format-is-markdown', 'markdown' === ContentFormat::storedFormat( 'wiki' ) );
+assert_content_format( 'same-format-is-no-op-without-bfb', 'Hello' === ContentFormat::convert( 'Hello', 'markdown', 'markdown' ) );
+
+$missing = ContentFormat::convert( '# Hello', 'markdown', 'blocks' );
+assert_content_format( 'missing-bfb-returns-wp-error', is_wp_error( $missing ) );
+$missing_message = is_wp_error( $missing ) ? $missing->get_error_message() : '';
+assert_content_format( 'missing-bfb-error-is-clear', false !== strpos( $missing_message, 'Block Format Bridge is required' ) );
+
+echo "\nContentFormat helper smoke: {$total} assertions, {$failed} failures.\n";
+
+exit( min( 1, $failed ) );


### PR DESCRIPTION
## Summary
- Bundle `chubes4/block-format-bridge` as Data Machine's content-format substrate via Composer.
- Add a focused pure-PHP smoke proving the BFB package, prefixed autoloader, and scoped h2bc path load safely from DM's Composer autoloader.
- Keep pure-PHP autoload smokes working by stubbing the minimal WordPress hook functions needed by Composer-loaded BFB.

## Tests
- `php tests/bfb-substrate-bundle-smoke.php`
- `php tests/ai-conversation-result-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/ai-request-metadata-guardrails-smoke.php`
- `php -l tests/bfb-substrate-bundle-smoke.php && php -l tests/bootstrap-unit.php && php -l tests/ai-request-metadata-guardrails-smoke.php && php -l tests/agent-bundle-format-smoke.php`
- `composer validate` (passes with the existing warning about the `version` field)
- `git diff --check`

## Out of scope
- No ability-level `content_format` parameters or write-path behavior changes; that belongs to #1470.
- No manual version bumps or changelog edits.

Closes #1469
Refs #1165

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the Composer dependency update, smoke coverage, focused verification, and PR description. Chris remains responsible for review and merge.



## Additional closures

Closes #1470 via the stacked storage-aware content-format PR.
Refs #1474 as the publish-handler follow-up.
