### PR TITLE
feat(content): support storage-aware post formats

### DIFF
--- a/inc/Abilities/Content/EditPostBlocksAbility.php
+++ b/inc/Abilities/Content/EditPostBlocksAbility.php
@@ -13,6 +13,7 @@
 namespace DataMachine\Abilities\Content;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Engine\AI\Actions\PendingActionHelper;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 
@@ -197,7 +198,16 @@ class EditPostBlocksAbility {
 			);
 		}
 
-		$blocks       = parse_blocks( $post->post_content );
+		$block_content = ContentFormat::storedToBlocks( (string) $post->post_content, (string) $post->post_type );
+		if ( is_wp_error( $block_content ) ) {
+			return array(
+				'success' => false,
+				'post_id' => $post_id,
+				'error'   => $block_content->get_error_message(),
+			);
+		}
+
+		$blocks       = parse_blocks( $block_content );
 		$total_blocks = count( $blocks );
 		$changes      = array();
 
@@ -275,7 +285,15 @@ class EditPostBlocksAbility {
 			);
 		}
 
-		$new_content = BlockSanitizer::sanitizeAndSerialize( $blocks );
+		$new_content    = BlockSanitizer::sanitizeAndSerialize( $blocks );
+		$stored_content = ContentFormat::blocksToStored( $new_content, (string) $post->post_type );
+		if ( is_wp_error( $stored_content ) ) {
+			return array(
+				'success' => false,
+				'post_id' => $post_id,
+				'error'   => $stored_content->get_error_message(),
+			);
+		}
 
 		// --- Preview mode: stage pending action, return preview envelope ---
 		if ( $preview ) {
@@ -342,7 +360,7 @@ class EditPostBlocksAbility {
 		$result = wp_update_post(
 			array(
 				'ID'           => $post_id,
-				'post_content' => $new_content,
+				'post_content' => $stored_content,
 			),
 			true
 		);

--- a/inc/Abilities/Content/GetPostBlocksAbility.php
+++ b/inc/Abilities/Content/GetPostBlocksAbility.php
@@ -13,6 +13,7 @@
 namespace DataMachine\Abilities\Content;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Content\ContentFormat;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -179,7 +180,15 @@ class GetPostBlocksAbility {
 			);
 		}
 
-		$blocks  = parse_blocks( $post->post_content );
+		$block_content = ContentFormat::storedToBlocks( (string) $post->post_content, (string) $post->post_type );
+		if ( is_wp_error( $block_content ) ) {
+			return array(
+				'success' => false,
+				'error'   => $block_content->get_error_message(),
+			);
+		}
+
+		$blocks  = parse_blocks( $block_content );
 		$results = array();
 
 		foreach ( $blocks as $index => $block ) {

--- a/inc/Abilities/Content/ReplacePostBlocksAbility.php
+++ b/inc/Abilities/Content/ReplacePostBlocksAbility.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Abilities\Content;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Engine\AI\Actions\PendingActionHelper;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 
@@ -192,7 +193,16 @@ class ReplacePostBlocksAbility {
 			);
 		}
 
-		$blocks       = parse_blocks( $post->post_content );
+		$block_content = ContentFormat::storedToBlocks( (string) $post->post_content, (string) $post->post_type );
+		if ( is_wp_error( $block_content ) ) {
+			return array(
+				'success' => false,
+				'post_id' => $post_id,
+				'error'   => $block_content->get_error_message(),
+			);
+		}
+
+		$blocks       = parse_blocks( $block_content );
 		$total_blocks = count( $blocks );
 		$changes      = array();
 
@@ -259,7 +269,15 @@ class ReplacePostBlocksAbility {
 			);
 		}
 
-		$new_content = BlockSanitizer::sanitizeAndSerialize( $blocks );
+		$new_content    = BlockSanitizer::sanitizeAndSerialize( $blocks );
+		$stored_content = ContentFormat::blocksToStored( $new_content, (string) $post->post_type );
+		if ( is_wp_error( $stored_content ) ) {
+			return array(
+				'success' => false,
+				'post_id' => $post_id,
+				'error'   => $stored_content->get_error_message(),
+			);
+		}
 
 		// --- Preview mode: stage pending action, return preview envelope ---
 		if ( $preview ) {
@@ -332,7 +350,7 @@ class ReplacePostBlocksAbility {
 		$result = wp_update_post(
 			array(
 				'ID'           => $post_id,
-				'post_content' => $new_content,
+				'post_content' => $stored_content,
 			),
 			true
 		);

--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -25,6 +25,7 @@
 namespace DataMachine\Abilities\Content;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Core\WordPress\ResolvePostByPath;
 
 defined( 'ABSPATH' ) || exit;
@@ -73,7 +74,11 @@ class UpsertPostAbility {
 							),
 							'content'        => array(
 								'type'        => 'string',
-								'description' => 'Post content (HTML or blocks). Replaces existing content when updating.',
+								'description' => 'Post content. Replaces existing content when updating.',
+							),
+							'content_format' => array(
+								'type'        => 'string',
+								'description' => 'Format of content. Defaults to blocks. Use markdown/html when passing non-block source content.',
 							),
 							'post_id'        => array(
 								'type'        => 'integer',
@@ -195,31 +200,35 @@ class UpsertPostAbility {
 			'method'      => 'handleChatToolCall',
 			'description' => 'Idempotently create or update a WordPress post. Finds by identity (post_id, slug+parent, or custom meta), compares content hash, and returns created/updated/no_change. Use for pipeline-safe writes that avoid churn on re-runs.',
 			'parameters'  => array(
-				'post_type'    => array(
+				'post_type'      => array(
 					'type'        => 'string',
 					'description' => 'Post type slug.',
 				),
-				'title'        => array(
+				'title'          => array(
 					'type'        => 'string',
 					'description' => 'Post title.',
 				),
-				'content'      => array(
+				'content'        => array(
 					'type'        => 'string',
-					'description' => 'Post content (HTML or blocks).',
+					'description' => 'Post content.',
 				),
-				'slug'         => array(
+				'content_format' => array(
+					'type'        => 'string',
+					'description' => 'Format of content. Defaults to blocks.',
+				),
+				'slug'           => array(
 					'type'        => 'string',
 					'description' => 'Post slug for lookup.',
 				),
-				'parent_id'    => array(
+				'parent_id'      => array(
 					'type'        => 'integer',
 					'description' => 'Parent post ID.',
 				),
-				'parent_path'  => array(
+				'parent_path'    => array(
 					'type'        => 'string',
 					'description' => 'Slash-delimited parent path (e.g. "artist/link-pages").',
 				),
-				'post_author'  => array(
+				'post_author'    => array(
 					'type'        => 'integer',
 					'description' => 'Post author user ID (create only).',
 				),
@@ -236,6 +245,7 @@ class UpsertPostAbility {
 	 * Handle chat tool call.
 	 */
 	public static function handleChatToolCall( array $params, array $tool_def = array() ): array {
+		$tool_def;
 		$result = self::execute( $params );
 		return array(
 			'success'   => ! empty( $result['success'] ),
@@ -251,27 +261,36 @@ class UpsertPostAbility {
 	 * @return array Result with action: created|updated|no_change.
 	 */
 	public static function execute( array $input ): array {
-		$post_type    = sanitize_key( $input['post_type'] ?? '' );
-		$title        = trim( $input['title'] ?? '' );
-		$content      = $input['content'] ?? '';
-		$post_id      = absint( $input['post_id'] ?? 0 );
-		$slug         = sanitize_title( $input['slug'] ?? '' );
-		$parent_id    = absint( $input['parent_id'] ?? 0 );
-		$parent_path  = trim( $input['parent_path'] ?? '' );
-		$identity_meta = $input['identity_meta'] ?? array();
-		$content_hash = $input['content_hash'] ?? '';
-		$raw_source   = $input['raw_source'] ?? '';
-		$post_status  = sanitize_key( $input['post_status'] ?? 'publish' );
-		$post_author  = absint( $input['post_author'] ?? 0 );
-		$post_excerpt = $input['post_excerpt'] ?? '';
-		$taxonomies   = $input['taxonomies'] ?? array();
-		$meta_input   = $input['meta_input'] ?? array();
-		$create_stubs = ! empty( $input['create_stubs'] );
+		$post_type      = sanitize_key( $input['post_type'] ?? '' );
+		$title          = trim( $input['title'] ?? '' );
+		$content        = $input['content'] ?? '';
+		$content_format = sanitize_key( $input['content_format'] ?? 'blocks' );
+		$post_id        = absint( $input['post_id'] ?? 0 );
+		$slug           = sanitize_title( $input['slug'] ?? '' );
+		$parent_id      = absint( $input['parent_id'] ?? 0 );
+		$parent_path    = trim( $input['parent_path'] ?? '' );
+		$identity_meta  = $input['identity_meta'] ?? array();
+		$content_hash   = $input['content_hash'] ?? '';
+		$raw_source     = $input['raw_source'] ?? '';
+		$post_status    = sanitize_key( $input['post_status'] ?? 'publish' );
+		$post_author    = absint( $input['post_author'] ?? 0 );
+		$post_excerpt   = $input['post_excerpt'] ?? '';
+		$taxonomies     = $input['taxonomies'] ?? array();
+		$meta_input     = $input['meta_input'] ?? array();
+		$create_stubs   = ! empty( $input['create_stubs'] );
 
 		if ( '' === $post_type || '' === $title ) {
 			return array(
 				'success' => false,
 				'error'   => 'post_type and title are required.',
+			);
+		}
+
+		$stored_content = ContentFormat::sourceToStored( (string) $content, $content_format, $post_type );
+		if ( is_wp_error( $stored_content ) ) {
+			return array(
+				'success' => false,
+				'error'   => $stored_content->get_error_message(),
 			);
 		}
 
@@ -333,7 +352,7 @@ class UpsertPostAbility {
 		$post_data = array(
 			'post_type'    => $post_type,
 			'post_title'   => $title,
-			'post_content' => $content,
+			'post_content' => $stored_content,
 			'post_status'  => $post_status,
 		);
 

--- a/inc/Core/Content/ContentFormat.php
+++ b/inc/Core/Content/ContentFormat.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Content format conversion helpers for post content boundaries.
+ *
+ * @package DataMachine\Core\Content
+ */
+
+namespace DataMachine\Core\Content;
+
+defined( 'ABSPATH' ) || exit;
+
+class ContentFormat {
+
+
+	/**
+	 * Return the canonical storage format for a post type.
+	 *
+	 * @param  string $post_type Post type slug.
+	 * @return string Format slug.
+	 */
+	public static function storedFormat( string $post_type ): string {
+		$format = apply_filters( 'datamachine_post_content_format', 'blocks', $post_type );
+
+		return sanitize_key( is_string( $format ) && '' !== $format ? $format : 'blocks' );
+	}
+
+	/**
+	 * Convert content between two explicit formats.
+	 *
+	 * @param  string $content Source content.
+	 * @param  string $from    Source format slug.
+	 * @param  string $to      Target format slug.
+	 * @return string|\WP_Error Converted content or error.
+	 */
+	public static function convert( string $content, string $from, string $to ) {
+		$from = sanitize_key( $from );
+		$to   = sanitize_key( $to );
+
+		if ( $from === $to ) {
+			return $content;
+		}
+
+		if ( ! function_exists( 'bfb_convert' ) ) {
+			return new \WP_Error(
+				'datamachine_content_format_bfb_missing',
+				sprintf( 'Block Format Bridge is required to convert post content from %s to %s.', $from, $to )
+			);
+		}
+
+		$converted = bfb_convert( $content, $from, $to );
+
+		if ( is_wp_error( $converted ) ) {
+			return $converted;
+		}
+
+		if ( ! is_string( $converted ) ) {
+			return new \WP_Error(
+				'datamachine_content_format_invalid_result',
+				sprintf( 'Block Format Bridge returned a non-string result converting post content from %s to %s.', $from, $to )
+			);
+		}
+
+		return $converted;
+	}
+
+	/**
+	 * Convert stored post content to block markup for block-level tools.
+	 *
+	 * @param  string $content   Stored post content.
+	 * @param  string $post_type Post type slug.
+	 * @return string|\WP_Error Block markup or error.
+	 */
+	public static function storedToBlocks( string $content, string $post_type ) {
+		return self::convert( $content, self::storedFormat( $post_type ), 'blocks' );
+	}
+
+	/**
+	 * Convert block markup to the post type's stored format.
+	 *
+	 * @param  string $content   Block markup.
+	 * @param  string $post_type Post type slug.
+	 * @return string|\WP_Error Stored-format content or error.
+	 */
+	public static function blocksToStored( string $content, string $post_type ) {
+		return self::convert( $content, 'blocks', self::storedFormat( $post_type ) );
+	}
+
+	/**
+	 * Convert caller-provided content into the post type's stored format.
+	 *
+	 * @param  string $content       Source content.
+	 * @param  string $source_format Source format slug.
+	 * @param  string $post_type     Post type slug.
+	 * @return string|\WP_Error Stored-format content or error.
+	 */
+	public static function sourceToStored( string $content, string $source_format, string $post_type ) {
+		return self::convert( $content, $source_format, self::storedFormat( $post_type ) );
+	}
+}

--- a/tests/content-format-abilities-smoke.php
+++ b/tests/content-format-abilities-smoke.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Pure-PHP smoke test for storage-format-aware content abilities.
+ *
+ * Run with: php tests/content-format-abilities-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\WordPress {
+	class ResolvePostByPath {
+
+		public static function build_path( $post ): string {
+			return $post->post_name ?? '';
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$failed = 0;
+	$total  = 0;
+
+	function assert_content_ability( string $name, bool $condition ): void {
+		global $failed, $total;
+		++$total;
+		if ( $condition ) {
+			echo "  PASS: {$name}\n";
+			return;
+		}
+		echo "  FAIL: {$name}\n";
+		++$failed;
+	}
+
+	class WP_Error {
+
+		private string $message;
+
+		public function __construct( string $code = '', string $message = '' ) {
+			unset( $code );
+			$this->message = $message;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+
+	$GLOBALS['__content_ability_filters']     = array();
+	$GLOBALS['__content_ability_posts']       = array(
+		7 => (object) array(
+			'ID'           => 7,
+			'post_type'    => 'wiki',
+			'post_title'   => 'Markdown Page',
+			'post_name'    => 'markdown-page',
+			'post_content' => "# Original\n\nHello world.",
+		),
+	);
+	$GLOBALS['__content_ability_next_id']     = 20;
+	$GLOBALS['__content_ability_conversions'] = array();
+
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['__content_ability_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+	}
+
+	function apply_filters( string $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['__content_ability_filters'][ $hook ] ) ) {
+			return $value;
+		}
+
+		ksort( $GLOBALS['__content_ability_filters'][ $hook ] );
+		foreach ( $GLOBALS['__content_ability_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as $registered_callback ) {
+				list( $callback, $accepted_args ) = $registered_callback;
+				$value                            = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+			}
+		}
+		return $value;
+	}
+
+	function sanitize_key( $key ): string {
+		return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $key ) );
+	}
+
+	function sanitize_title( $title ): string {
+		return strtolower( trim( preg_replace( '/[^a-zA-Z0-9]+/', '-', (string) $title ), '-' ) );
+	}
+
+	function sanitize_text_field( $value ): string {
+		return trim( (string) $value );
+	}
+
+	function absint( $value ): int {
+		return max( 0, (int) $value );
+	}
+
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+
+	function wp_kses_post( $content ): string {
+		return (string) $content;
+	}
+
+	function wp_unslash( $value ) {
+		return $value;
+	}
+
+	function __( $text, $domain = 'default' ) {
+		unset( $domain );
+		return $text;
+	}
+
+	function do_action( ...$args ): void {
+		$GLOBALS['__content_ability_actions'][] = $args;
+	}
+
+	function get_post( int $post_id ) {
+		return $GLOBALS['__content_ability_posts'][ $post_id ] ?? null;
+	}
+
+	function get_permalink( int $post_id ): string {
+		return "https://example.test/?p={$post_id}";
+	}
+
+	function get_post_meta( int $post_id, string $key, bool $single = false ) {
+		unset( $post_id, $key, $single );
+		return '';
+	}
+
+	function taxonomy_exists( string $taxonomy ): bool {
+		unset( $taxonomy );
+		return false;
+	}
+
+	function wp_update_post( array $post_data, bool $wp_error = false ) {
+		unset( $wp_error );
+		$id = (int) ( $post_data['ID'] ?? 0 );
+		if ( empty( $GLOBALS['__content_ability_posts'][ $id ] ) ) {
+			return new WP_Error( 'missing', 'Missing post.' );
+		}
+
+		foreach ( $post_data as $key => $value ) {
+			if ( 'ID' !== $key ) {
+				$GLOBALS['__content_ability_posts'][ $id ]->{$key} = $value;
+			}
+		}
+		return $id;
+	}
+
+	function wp_insert_post( array $post_data, bool $wp_error = false ) {
+		unset( $wp_error );
+		$id = (int) ( $post_data['ID'] ?? 0 );
+		if ( $id <= 0 ) {
+			$id = $GLOBALS['__content_ability_next_id']++;
+		}
+
+		$existing = $GLOBALS['__content_ability_posts'][ $id ] ?? (object) array( 'ID' => $id );
+		foreach ( $post_data as $key => $value ) {
+			if ( 'meta_input' !== $key ) {
+				$existing->{$key} = $value;
+			}
+		}
+		$existing->ID                              = $id;
+		$GLOBALS['__content_ability_posts'][ $id ] = $existing;
+		return $id;
+	}
+
+	function bfb_convert( string $content, string $from, string $to ) {
+		$GLOBALS['__content_ability_conversions'][] = array( $from, $to, $content );
+
+		if ( $from === $to ) {
+			return $content;
+		}
+
+		if ( 'markdown' === $from && 'blocks' === $to ) {
+			$lines = preg_split( '/\R+/', trim( $content ) );
+			if ( false === $lines ) {
+				return new WP_Error( 'parse_failed', 'Could not split markdown.' );
+			}
+
+			$blocks = array();
+			foreach ( $lines as $line ) {
+				if ( str_starts_with( $line, '# ' ) ) {
+					$text     = substr( $line, 2 );
+					$blocks[] = "<!-- wp:heading -->\n<h2>{$text}</h2>\n<!-- /wp:heading -->";
+				} else {
+					$blocks[] = "<!-- wp:paragraph -->\n<p>{$line}</p>\n<!-- /wp:paragraph -->";
+				}
+			}
+			return implode( "\n", $blocks );
+		}
+
+		if ( 'blocks' === $from && 'markdown' === $to ) {
+			$content = preg_replace( '/<!--\s*\/?wp:[^>]+-->\s*/', '', $content );
+			$content = preg_replace( '/<h[1-6][^>]*>(.*?)<\/h[1-6]>/', '# $1', $content );
+			$content = preg_replace( '/<p[^>]*>(.*?)<\/p>/', '$1', $content );
+			return trim( html_entity_decode( strip_tags( $content ) ) );
+		}
+
+		return new WP_Error( 'unsupported', "Unsupported {$from} to {$to}." );
+	}
+
+	function parse_blocks( string $content ): array {
+		$blocks = array();
+		if ( preg_match_all( '/<!-- wp:([^ ]+) -->\s*(.*?)\s*<!-- \/wp:\1 -->/s', $content, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				$block_name = str_contains( $match[1], '/' ) ? $match[1] : 'core/' . $match[1];
+				$blocks[]   = array(
+					'blockName'    => $block_name,
+					'innerHTML'    => $match[2],
+					'innerContent' => array( $match[2] ),
+					'innerBlocks'  => array(),
+				);
+			}
+			return $blocks;
+		}
+
+		return array(
+			array(
+				'blockName'    => null,
+				'innerHTML'    => $content,
+				'innerContent' => array( $content ),
+				'innerBlocks'  => array(),
+			),
+		);
+	}
+
+	function serialize_blocks( array $blocks ): string {
+		$serialized = array();
+		foreach ( $blocks as $block ) {
+			$name         = $block['blockName'] ?? 'core/freeform';
+			$html         = $block['innerHTML'] ?? '';
+			$serialized[] = "<!-- wp:{$name} -->\n{$html}\n<!-- /wp:{$name} -->";
+		}
+		return implode( "\n", $serialized );
+	}
+
+	add_filter(
+		'datamachine_post_content_format',
+		static function ( string $format, string $post_type ): string {
+			return 'wiki' === $post_type ? 'markdown' : $format;
+		},
+		10,
+		2
+	);
+
+	include_once dirname( __DIR__ ) . '/inc/Core/Content/ContentFormat.php';
+	include_once dirname( __DIR__ ) . '/inc/Abilities/Content/BlockSanitizer.php';
+	include_once dirname( __DIR__ ) . '/inc/Abilities/Content/GetPostBlocksAbility.php';
+	include_once dirname( __DIR__ ) . '/inc/Abilities/Content/EditPostBlocksAbility.php';
+	include_once dirname( __DIR__ ) . '/inc/Abilities/Content/UpsertPostAbility.php';
+
+	$get = DataMachine\Abilities\Content\GetPostBlocksAbility::execute( array( 'post_id' => 7 ) );
+	assert_content_ability( 'markdown-post-read-succeeds', true === $get['success'] );
+	assert_content_ability( 'markdown-post-read-converts-to-blocks', 'core/heading' === ( $get['blocks'][0]['block_name'] ?? '' ) );
+	$stored_after_read = get_post( 7 )->post_content ?? '';
+	assert_content_ability( 'markdown-post-read-does-not-mutate-storage', "# Original\n\nHello world." === $stored_after_read );
+
+	$edit = DataMachine\Abilities\Content\EditPostBlocksAbility::execute(
+		array(
+			'post_id' => 7,
+			'edits'   => array(
+				array(
+					'block_index' => 1,
+					'find'        => 'Hello world.',
+					'replace'     => 'Hello markdown.',
+				),
+			),
+		)
+	);
+	assert_content_ability( 'markdown-post-edit-succeeds', true === $edit['success'] );
+	$stored_after_edit = get_post( 7 )->post_content ?? '';
+	assert_content_ability( 'markdown-post-edit-saves-markdown', false === strpos( $stored_after_edit, '<!-- wp:' ) );
+	assert_content_ability( 'markdown-post-edit-has-replacement', false !== strpos( $stored_after_edit, 'Hello markdown.' ) );
+
+	$upsert   = DataMachine\Abilities\Content\UpsertPostAbility::execute(
+		array(
+			'post_type'      => 'wiki',
+			'title'          => 'New Markdown',
+			'content'        => "# Stored\n\nRaw markdown.",
+			'content_format' => 'markdown',
+		)
+	);
+	$new_id   = $upsert['post_id'] ?? 0;
+	$new_post = get_post( (int) $new_id );
+	assert_content_ability( 'upsert-markdown-source-succeeds', true === $upsert['success'] );
+	assert_content_ability( 'upsert-markdown-source-stays-markdown', "# Stored\n\nRaw markdown." === ( $new_post->post_content ?? '' ) );
+
+	echo "\nContentFormat abilities smoke: {$total} assertions, {$failed} failures.\n";
+
+	exit( min( 1, $failed ) );
+}

--- a/tests/content-format-helper-smoke.php
+++ b/tests/content-format-helper-smoke.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Pure-PHP smoke test for ContentFormat conversion policy.
+ *
+ * Run with: php tests/content-format-helper-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failed = 0;
+$total  = 0;
+
+function assert_content_format( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+	echo "  FAIL: {$name}\n";
+	++$failed;
+}
+
+$GLOBALS['__content_format_filters'] = array();
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['__content_format_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	if ( empty( $GLOBALS['__content_format_filters'][ $hook ] ) ) {
+		return $value;
+	}
+
+	ksort( $GLOBALS['__content_format_filters'][ $hook ] );
+	foreach ( $GLOBALS['__content_format_filters'][ $hook ] as $callbacks ) {
+		foreach ( $callbacks as $registered_callback ) {
+			list( $callback, $accepted_args ) = $registered_callback;
+			$value                            = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+		}
+	}
+	return $value;
+}
+
+function sanitize_key( $key ): string {
+	return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $key ) );
+}
+
+function is_wp_error( $thing ): bool {
+	return $thing instanceof WP_Error;
+}
+
+class WP_Error {
+
+	private string $message;
+
+	public function __construct( string $code = '', string $message = '' ) {
+		unset( $code );
+		$this->message = $message;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/Content/ContentFormat.php';
+
+use DataMachine\Core\Content\ContentFormat;
+
+assert_content_format( 'default-format-is-blocks', 'blocks' === ContentFormat::storedFormat( 'post' ) );
+
+add_filter(
+	'datamachine_post_content_format',
+	static function ( string $format, string $post_type ): string {
+		return 'wiki' === $post_type ? 'markdown' : $format;
+	},
+	10,
+	2
+);
+
+assert_content_format( 'filtered-format-is-markdown', 'markdown' === ContentFormat::storedFormat( 'wiki' ) );
+assert_content_format( 'same-format-is-no-op-without-bfb', 'Hello' === ContentFormat::convert( 'Hello', 'markdown', 'markdown' ) );
+
+$missing = ContentFormat::convert( '# Hello', 'markdown', 'blocks' );
+assert_content_format( 'missing-bfb-returns-wp-error', is_wp_error( $missing ) );
+$missing_message = is_wp_error( $missing ) ? $missing->get_error_message() : '';
+assert_content_format( 'missing-bfb-error-is-clear', false !== strpos( $missing_message, 'Block Format Bridge is required' ) );
+
+echo "\nContentFormat helper smoke: {$total} assertions, {$failed} failures.\n";
+
+exit( min( 1, $failed ) );


### PR DESCRIPTION
## Summary
- Adds a `ContentFormat` helper that centralizes stored post-content format detection and BFB-backed conversions.
- Makes generic content/block abilities storage-format aware at their boundaries while keeping internal block editing block-based.

## Changes
- Adds `datamachine_post_content_format`, defaulting to `blocks`, so storage layers can declare canonical `post_content` formats such as `markdown`.
- Converts stored content to blocks for `get-post-blocks`, `edit-post-blocks`, and `replace-post-blocks`, then converts block edits back to the stored format before saving.
- Adds `content_format` to `upsert-post` so callers can provide markdown/html/block source content explicitly.
- Leaves publish handlers and `wordpress_publish` out of scope for this PR.

## Tests
- `php tests/content-format-helper-smoke.php`
- `php tests/content-format-abilities-smoke.php`
- `tests/bfb-substrate-smoke.php` not present
- `git diff --check`
- Also ran: `php tests/bfb-substrate-bundle-smoke.php`
- Also ran: `composer validate` (passes with existing warning about the `version` field)

## Closes #1470

## Follow-up
- #1474 tracks storage-format awareness for `wordpress_publish` / publish-handler surfaces.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the content-format helper, updating generic content abilities, and drafting focused smoke coverage. Chris reviewed and directed scope.
