### PR TITLE
feat(bundle): add agent bundle version drift metadata

### DIFF
--- a/inc/Engine/Bundle/AgentBundleDriftStatus.php
+++ b/inc/Engine/Bundle/AgentBundleDriftStatus.php
@@ -14,11 +14,11 @@ defined( 'ABSPATH' ) || exit;
  */
 final class AgentBundleDriftStatus {
 
-	public const CURRENT = 'current';
+	public const CURRENT       = 'current';
 	public const NOT_INSTALLED = 'not_installed';
-	public const WRONG_BUNDLE = 'wrong_bundle';
+	public const WRONG_BUNDLE  = 'wrong_bundle';
 	public const VERSION_DRIFT = 'version_drift';
-	public const SOURCE_DRIFT = 'source_drift';
+	public const SOURCE_DRIFT  = 'source_drift';
 
 	/**
 	 * Compare installed metadata to an available bundle manifest.

--- a/inc/Engine/Bundle/AgentBundleDriftStatus.php
+++ b/inc/Engine/Bundle/AgentBundleDriftStatus.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Agent bundle drift status helper.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Compares installed bundle metadata against an available manifest.
+ */
+final class AgentBundleDriftStatus {
+
+	public const CURRENT = 'current';
+	public const NOT_INSTALLED = 'not_installed';
+	public const WRONG_BUNDLE = 'wrong_bundle';
+	public const VERSION_DRIFT = 'version_drift';
+	public const SOURCE_DRIFT = 'source_drift';
+
+	/**
+	 * Compare installed metadata to an available bundle manifest.
+	 *
+	 * @param AgentBundleManifest $available Available bundle manifest.
+	 * @param array|null          $installed Installed metadata snapshot.
+	 * @return array{status:string,is_drifted:bool,available:array,installed:?array,differences:string[]}
+	 */
+	public static function compare( AgentBundleManifest $available, ?array $installed ): array {
+		$available_metadata = $available->version_metadata();
+		$installed_metadata = self::normalize_installed_metadata( $installed );
+
+		if ( null === $installed_metadata ) {
+			return self::result( self::NOT_INSTALLED, $available_metadata, null, array( 'bundle_slug' ) );
+		}
+
+		if ( $available_metadata['bundle_slug'] !== $installed_metadata['bundle_slug'] ) {
+			return self::result( self::WRONG_BUNDLE, $available_metadata, $installed_metadata, array( 'bundle_slug' ) );
+		}
+
+		if ( $available_metadata['bundle_version'] !== $installed_metadata['bundle_version'] ) {
+			return self::result( self::VERSION_DRIFT, $available_metadata, $installed_metadata, array( 'bundle_version' ) );
+		}
+
+		$source_differences = array();
+		foreach ( array( 'source_ref', 'source_revision' ) as $field ) {
+			if ( '' !== $available_metadata[ $field ] && '' !== $installed_metadata[ $field ] && $available_metadata[ $field ] !== $installed_metadata[ $field ] ) {
+				$source_differences[] = $field;
+			}
+		}
+
+		if ( ! empty( $source_differences ) ) {
+			return self::result( self::SOURCE_DRIFT, $available_metadata, $installed_metadata, $source_differences );
+		}
+
+		return self::result( self::CURRENT, $available_metadata, $installed_metadata, array() );
+	}
+
+	/**
+	 * Normalize installed metadata from agent_config or importer state.
+	 *
+	 * @param array|null $metadata Raw metadata.
+	 * @return array|null
+	 */
+	public static function normalize_installed_metadata( ?array $metadata ): ?array {
+		if ( empty( $metadata ) || ! is_array( $metadata ) ) {
+			return null;
+		}
+
+		$bundle_slug    = isset( $metadata['bundle_slug'] ) ? PortableSlug::normalize( (string) $metadata['bundle_slug'], 'bundle' ) : '';
+		$bundle_version = isset( $metadata['bundle_version'] ) ? trim( (string) $metadata['bundle_version'] ) : '';
+		if ( '' === $bundle_slug || '' === $bundle_version ) {
+			return null;
+		}
+
+		return array(
+			'bundle_slug'     => $bundle_slug,
+			'bundle_version'  => $bundle_version,
+			'source_ref'      => isset( $metadata['source_ref'] ) ? trim( (string) $metadata['source_ref'] ) : '',
+			'source_revision' => isset( $metadata['source_revision'] ) ? trim( (string) $metadata['source_revision'] ) : '',
+		);
+	}
+
+	private static function result( string $status, array $available, ?array $installed, array $differences ): array {
+		return array(
+			'status'      => $status,
+			'is_drifted'  => self::CURRENT !== $status,
+			'available'   => $available,
+			'installed'   => $installed,
+			'differences' => $differences,
+		);
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -16,14 +16,22 @@ final class AgentBundleManifest {
 
 	private string $exported_at;
 	private string $exported_by;
+	private string $bundle_slug;
+	private string $bundle_version;
+	private string $source_ref;
+	private string $source_revision;
 	private array $agent;
 	private array $included;
 
-	public function __construct( string $exported_at, string $exported_by, array $agent, array $included ) {
-		$this->exported_at = $exported_at;
-		$this->exported_by = $exported_by;
-		$this->agent       = self::validate_agent( $agent );
-		$this->included    = self::validate_included( $included );
+	public function __construct( string $exported_at, string $exported_by, string $bundle_slug, string $bundle_version, string $source_ref, string $source_revision, array $agent, array $included ) {
+		$this->exported_at     = $exported_at;
+		$this->exported_by     = $exported_by;
+		$this->bundle_slug     = PortableSlug::normalize( $bundle_slug, 'bundle' );
+		$this->bundle_version  = self::validate_version_string( $bundle_version, 'bundle_version' );
+		$this->source_ref      = self::validate_optional_string( $source_ref, 'source_ref' );
+		$this->source_revision = self::validate_optional_string( $source_revision, 'source_revision' );
+		$this->agent           = self::validate_agent( $agent );
+		$this->included        = self::validate_included( $included );
 	}
 
 	/**
@@ -35,7 +43,7 @@ final class AgentBundleManifest {
 	public static function from_array( array $data ): self {
 		BundleSchema::assert_supported_version( $data, 'manifest.json' );
 
-		foreach ( array( 'exported_at', 'exported_by', 'agent', 'included' ) as $field ) {
+		foreach ( array( 'exported_at', 'exported_by', 'bundle_slug', 'bundle_version', 'agent', 'included' ) as $field ) {
 			if ( ! array_key_exists( $field, $data ) ) {
 				throw new BundleValidationException( "manifest.json is missing required field {$field}." );
 			}
@@ -45,7 +53,16 @@ final class AgentBundleManifest {
 			throw new BundleValidationException( 'manifest.json agent and included fields must be objects.' );
 		}
 
-		return new self( (string) $data['exported_at'], (string) $data['exported_by'], $data['agent'], $data['included'] );
+		return new self(
+			(string) $data['exported_at'],
+			(string) $data['exported_by'],
+			(string) $data['bundle_slug'],
+			(string) $data['bundle_version'],
+			(string) ( $data['source_ref'] ?? '' ),
+			(string) ( $data['source_revision'] ?? '' ),
+			$data['agent'],
+			$data['included']
+		);
 	}
 
 	/**
@@ -55,16 +72,45 @@ final class AgentBundleManifest {
 	 */
 	public function to_array(): array {
 		return array(
-			'schema_version' => BundleSchema::VERSION,
-			'exported_at'    => $this->exported_at,
-			'exported_by'    => $this->exported_by,
-			'agent'          => $this->agent,
-			'included'       => $this->included,
+			'schema_version'   => BundleSchema::VERSION,
+			'bundle_slug'      => $this->bundle_slug,
+			'bundle_version'   => $this->bundle_version,
+			'source_ref'       => $this->source_ref,
+			'source_revision'  => $this->source_revision,
+			'exported_at'      => $this->exported_at,
+			'exported_by'      => $this->exported_by,
+			'agent'            => $this->agent,
+			'included'         => $this->included,
 		);
 	}
 
 	public function agent_slug(): string {
 		return (string) $this->agent['slug'];
+	}
+
+	public function bundle_slug(): string {
+		return $this->bundle_slug;
+	}
+
+	public function bundle_version(): string {
+		return $this->bundle_version;
+	}
+
+	public function source_ref(): string {
+		return $this->source_ref;
+	}
+
+	public function source_revision(): string {
+		return $this->source_revision;
+	}
+
+	public function version_metadata(): array {
+		return array(
+			'bundle_slug'     => $this->bundle_slug,
+			'bundle_version'  => $this->bundle_version,
+			'source_ref'      => $this->source_ref,
+			'source_revision' => $this->source_revision,
+		);
 	}
 
 	private static function validate_agent( array $agent ): array {
@@ -116,5 +162,27 @@ final class AgentBundleManifest {
 			'flows'        => $included['flows'],
 			'handler_auth' => $included['handler_auth'],
 		);
+	}
+
+	private static function validate_version_string( string $value, string $field ): string {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			throw new BundleValidationException( "manifest.json {$field} must be a non-empty string." );
+		}
+
+		if ( strlen( $value ) > 191 ) {
+			throw new BundleValidationException( "manifest.json {$field} must be 191 characters or fewer." );
+		}
+
+		return $value;
+	}
+
+	private static function validate_optional_string( string $value, string $field ): string {
+		$value = trim( $value );
+		if ( strlen( $value ) > 191 ) {
+			throw new BundleValidationException( "manifest.json {$field} must be 191 characters or fewer." );
+		}
+
+		return $value;
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -45,7 +45,7 @@ final class AgentBundleManifest {
 
 		foreach ( array( 'exported_at', 'exported_by', 'bundle_slug', 'bundle_version', 'agent', 'included' ) as $field ) {
 			if ( ! array_key_exists( $field, $data ) ) {
-				throw new BundleValidationException( "manifest.json is missing required field {$field}." );
+				throw new BundleValidationException( sprintf( 'manifest.json is missing required field %s.', esc_html( $field ) ) );
 			}
 		}
 
@@ -72,15 +72,15 @@ final class AgentBundleManifest {
 	 */
 	public function to_array(): array {
 		return array(
-			'schema_version'   => BundleSchema::VERSION,
-			'bundle_slug'      => $this->bundle_slug,
-			'bundle_version'   => $this->bundle_version,
-			'source_ref'       => $this->source_ref,
-			'source_revision'  => $this->source_revision,
-			'exported_at'      => $this->exported_at,
-			'exported_by'      => $this->exported_by,
-			'agent'            => $this->agent,
-			'included'         => $this->included,
+			'schema_version'  => BundleSchema::VERSION,
+			'bundle_slug'     => $this->bundle_slug,
+			'bundle_version'  => $this->bundle_version,
+			'source_ref'      => $this->source_ref,
+			'source_revision' => $this->source_revision,
+			'exported_at'     => $this->exported_at,
+			'exported_by'     => $this->exported_by,
+			'agent'           => $this->agent,
+			'included'        => $this->included,
 		);
 	}
 
@@ -116,7 +116,7 @@ final class AgentBundleManifest {
 	private static function validate_agent( array $agent ): array {
 		foreach ( array( 'slug', 'label', 'description', 'agent_config' ) as $field ) {
 			if ( ! array_key_exists( $field, $agent ) ) {
-				throw new BundleValidationException( "manifest.json agent is missing required field {$field}." );
+				throw new BundleValidationException( sprintf( 'manifest.json agent is missing required field %s.', esc_html( $field ) ) );
 			}
 		}
 
@@ -138,13 +138,13 @@ final class AgentBundleManifest {
 	private static function validate_included( array $included ): array {
 		foreach ( array( 'memory', 'pipelines', 'flows', 'handler_auth' ) as $field ) {
 			if ( ! array_key_exists( $field, $included ) ) {
-				throw new BundleValidationException( "manifest.json included is missing required field {$field}." );
+				throw new BundleValidationException( sprintf( 'manifest.json included is missing required field %s.', esc_html( $field ) ) );
 			}
 		}
 
 		foreach ( array( 'memory', 'pipelines', 'flows' ) as $field ) {
 			if ( ! is_array( $included[ $field ] ) || ! array_is_list( $included[ $field ] ) ) {
-				throw new BundleValidationException( "manifest.json included.{$field} must be a list." );
+				throw new BundleValidationException( sprintf( 'manifest.json included.%s must be a list.', esc_html( $field ) ) );
 			}
 			$included[ $field ] = array_values( array_map( 'strval', $included[ $field ] ) );
 			sort( $included[ $field ], SORT_STRING );
@@ -167,11 +167,11 @@ final class AgentBundleManifest {
 	private static function validate_version_string( string $value, string $field ): string {
 		$value = trim( $value );
 		if ( '' === $value ) {
-			throw new BundleValidationException( "manifest.json {$field} must be a non-empty string." );
+			throw new BundleValidationException( sprintf( 'manifest.json %s must be a non-empty string.', esc_html( $field ) ) );
 		}
 
 		if ( strlen( $value ) > 191 ) {
-			throw new BundleValidationException( "manifest.json {$field} must be 191 characters or fewer." );
+			throw new BundleValidationException( sprintf( 'manifest.json %s must be 191 characters or fewer.', esc_html( $field ) ) );
 		}
 
 		return $value;
@@ -180,7 +180,7 @@ final class AgentBundleManifest {
 	private static function validate_optional_string( string $value, string $field ): string {
 		$value = trim( $value );
 		if ( strlen( $value ) > 191 ) {
-			throw new BundleValidationException( "manifest.json {$field} must be 191 characters or fewer." );
+			throw new BundleValidationException( sprintf( 'manifest.json %s must be 191 characters or fewer.', esc_html( $field ) ) );
 		}
 
 		return $value;

--- a/tests/agent-bundle-format-smoke.php
+++ b/tests/agent-bundle-format-smoke.php
@@ -22,6 +22,12 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	}
 }
 
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
 if ( ! function_exists( 'did_action' ) ) {
 	function did_action( $hook = '' ) {
 		return 0;

--- a/tests/agent-bundle-format-smoke.php
+++ b/tests/agent-bundle-format-smoke.php
@@ -43,6 +43,7 @@ if ( ! function_exists( 'add_action' ) ) {
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\AgentBundleDriftStatus;
 use DataMachine\Engine\Bundle\AgentBundleFlowFile;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
@@ -91,16 +92,20 @@ assert_bundle_equals( 'dedupes sibling slugs with numeric suffix', 'daily-ingest
 echo "\n[2] Manifest schema validates and normalizes included lists\n";
 $manifest = AgentBundleManifest::from_array(
 	array(
-		'schema_version' => 1,
-		'exported_at'    => '2026-04-26T15:30:00Z',
-		'exported_by'    => 'data-machine/0.84.0-test',
-		'agent'          => array(
+		'schema_version'   => 1,
+		'bundle_slug'      => 'WooCommerce Knowledge Bundle',
+		'bundle_version'   => '1.2.3',
+		'source_ref'       => 'refs/heads/main',
+		'source_revision'  => 'abc1234',
+		'exported_at'      => '2026-04-26T15:30:00Z',
+		'exported_by'      => 'data-machine/0.84.0-test',
+		'agent'            => array(
 			'slug'         => 'WooCommerce Agent',
 			'label'        => 'WooCommerce Knowledge Keeper',
 			'description'  => 'Maintains the WooCommerce wiki.',
 			'agent_config' => array( 'model' => array( 'default' => 'gpt-5.5' ) ),
 		),
-		'included'       => array(
+		'included'         => array(
 			'memory'       => array( 'MEMORY.md', 'SOUL.md' ),
 			'pipelines'    => array( 'wc-weekly-lint', 'wc-daily-ingest' ),
 			'flows'        => array( 'wc-weekly-lint-flow', 'wc-daily-ingest-flow' ),
@@ -110,6 +115,9 @@ $manifest = AgentBundleManifest::from_array(
 );
 $manifest_array = $manifest->to_array();
 assert_bundle_equals( 'schema version pinned to v1', 1, $manifest_array['schema_version'] );
+assert_bundle_equals( 'bundle slug normalized once', 'woocommerce-knowledge-bundle', $manifest_array['bundle_slug'] );
+assert_bundle_equals( 'bundle version preserved', '1.2.3', $manifest_array['bundle_version'] );
+assert_bundle_equals( 'source revision preserved', 'abc1234', $manifest_array['source_revision'] );
 assert_bundle_equals( 'agent slug normalized once', 'woocommerce-agent', $manifest_array['agent']['slug'] );
 assert_bundle_equals( 'included pipelines sorted for deterministic JSON', array( 'wc-daily-ingest', 'wc-weekly-lint' ), $manifest_array['included']['pipelines'] );
 assert_bundle_equals( 'handler_auth refs accepted', 'refs', $manifest_array['included']['handler_auth'] );
@@ -269,11 +277,13 @@ $threw = false;
 try {
 	AgentBundleManifest::from_array(
 		array(
-			'schema_version' => 2,
-			'exported_at'    => '2026-04-26T15:30:00Z',
-			'exported_by'    => 'data-machine/next',
-			'agent'          => array(),
-			'included'       => array(),
+			'schema_version'  => 2,
+			'bundle_slug'     => 'next',
+			'bundle_version'  => 'next',
+			'exported_at'     => '2026-04-26T15:30:00Z',
+			'exported_by'     => 'data-machine/next',
+			'agent'           => array(),
+			'included'        => array(),
 		)
 	);
 } catch ( BundleValidationException $e ) {
@@ -281,7 +291,57 @@ try {
 }
 assert_bundle( 'v2 manifest refused with clear message', $threw );
 
-echo "\n[7] Source schema exposes stable portable slug columns\n";
+echo "\n[7] Bundle drift status compares installed metadata to available manifests\n";
+$current_status = AgentBundleDriftStatus::compare(
+	$manifest,
+	array(
+		'bundle_slug'     => 'WooCommerce Knowledge Bundle',
+		'bundle_version'  => '1.2.3',
+		'source_ref'      => 'refs/heads/main',
+		'source_revision' => 'abc1234',
+	)
+);
+assert_bundle_equals( 'matching metadata is current', AgentBundleDriftStatus::CURRENT, $current_status['status'] );
+assert_bundle_equals( 'current metadata is not drifted', false, $current_status['is_drifted'] );
+
+$missing_status = AgentBundleDriftStatus::compare( $manifest, null );
+assert_bundle_equals( 'missing metadata reports not installed', AgentBundleDriftStatus::NOT_INSTALLED, $missing_status['status'] );
+assert_bundle_equals( 'missing metadata is drifted', true, $missing_status['is_drifted'] );
+
+$wrong_bundle_status = AgentBundleDriftStatus::compare(
+	$manifest,
+	array(
+		'bundle_slug'    => 'Other Bundle',
+		'bundle_version' => '1.2.3',
+	)
+);
+assert_bundle_equals( 'different bundle slug reports wrong bundle', AgentBundleDriftStatus::WRONG_BUNDLE, $wrong_bundle_status['status'] );
+assert_bundle_equals( 'wrong bundle difference is bundle_slug', array( 'bundle_slug' ), $wrong_bundle_status['differences'] );
+
+$version_drift_status = AgentBundleDriftStatus::compare(
+	$manifest,
+	array(
+		'bundle_slug'    => 'WooCommerce Knowledge Bundle',
+		'bundle_version' => '1.2.2',
+	)
+);
+assert_bundle_equals( 'different version reports version drift', AgentBundleDriftStatus::VERSION_DRIFT, $version_drift_status['status'] );
+assert_bundle_equals( 'version drift difference is bundle_version', array( 'bundle_version' ), $version_drift_status['differences'] );
+
+$source_drift_status = AgentBundleDriftStatus::compare(
+	$manifest,
+	array(
+		'bundle_slug'     => 'WooCommerce Knowledge Bundle',
+		'bundle_version'  => '1.2.3',
+		'source_ref'      => 'refs/heads/main',
+		'source_revision' => 'def5678',
+	)
+);
+assert_bundle_equals( 'same version with different revision reports source drift', AgentBundleDriftStatus::SOURCE_DRIFT, $source_drift_status['status'] );
+assert_bundle_equals( 'source drift difference is source_revision', array( 'source_revision' ), $source_drift_status['differences'] );
+assert_bundle_equals( 'installed metadata normalized through portable slug', 'woocommerce-knowledge-bundle', $source_drift_status['installed']['bundle_slug'] );
+
+echo "\n[8] Source schema exposes stable portable slug columns\n";
 $pipelines_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Pipelines/Pipelines.php' );
 $flows_source     = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Flows/Flows.php' );
 assert_bundle( 'pipelines table has portable_slug column', str_contains( (string) $pipelines_source, 'portable_slug varchar(191) DEFAULT NULL' ) );


### PR DESCRIPTION
## Summary
- Adds bundle-level version/source metadata to portable agent manifests.
- Adds a pure `AgentBundleDriftStatus` helper for comparing installed bundle metadata against an available manifest.

## Changes
- Requires `bundle_slug` and `bundle_version` in `manifest.json`; accepts optional `source_ref` and `source_revision`.
- Exposes manifest version metadata through accessors and `version_metadata()`.
- Adds drift statuses for current, not-installed, wrong-bundle, version-drift, and source-drift states.
- Extends the existing agent bundle smoke to cover manifest metadata and drift comparisons.

## Tests
- `php tests/agent-bundle-format-smoke.php` — 48 assertions passed.
- `php -l inc/Engine/Bundle/AgentBundleManifest.php && php -l inc/Engine/Bundle/AgentBundleDriftStatus.php && php -l tests/agent-bundle-format-smoke.php` — passed.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agent-bundle-versioning --changed-since origin/main` — PHPCS passed and reported no baseline drift; local ESLint phase still exits non-zero because it attempts to parse changed PHP files as JavaScript.

Closes #1476

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the agent bundle versioning substrate, smoke tests, and PR description. Chris remains responsible for review and merge.