### PR TITLE
feat(ai): define message envelope contract

### DIFF
--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -225,7 +225,10 @@ An adapter is responsible for:
 Data Machine makes no assumptions about how the adapter produces that result.
 A consumer can delegate to any external runtime — its own `Agent` subclass, a
 remote RPC service, a different language — as long as the return shape is
-honored.
+honored. Returned messages may use the legacy `role/content/metadata` shape or
+the versioned [AI Message Envelope](./ai-message-envelope.md); Data Machine
+normalizes envelopes back to the persisted legacy shape before callers store or
+render the result.
 
 ### Minimal adapter example
 

--- a/docs/core-system/ai-message-envelope.md
+++ b/docs/core-system/ai-message-envelope.md
@@ -1,0 +1,113 @@
+# AI Message Envelope
+
+**File**: `/inc/Engine/AI/MessageEnvelope.php`
+
+Data Machine stores conversation messages as JSON-friendly arrays. The current
+persisted shape stays stable:
+
+```php
+[
+    'role'     => 'user|assistant|system|tool',
+    'content'  => 'Plain text or multimodal content blocks',
+    'metadata' => [ 'type' => 'text' ],
+]
+```
+
+The message envelope is the typed runtime contract that adapters should target.
+It makes tool calls, tool results, input-required states, final results, errors,
+deltas, and multimodal parts explicit without adopting any host-specific DTO.
+
+## Envelope Shape
+
+```php
+[
+    'schema'   => 'datamachine.ai.message',
+    'version'  => 1,
+    'type'     => 'text',
+    'role'     => 'assistant',
+    'content'  => 'Message text or provider-neutral content blocks',
+    'data'     => [],      // Type-specific JSON-serializable payload.
+    'metadata' => [],      // Extension metadata; must stay JSON-serializable.
+
+    // Optional fields preserved when present:
+    'id'         => 'stable-message-id',
+    'created_at' => '2026-04-28 12:00:00',
+    'updated_at' => '2026-04-28 12:00:00',
+]
+```
+
+Supported `type` values:
+
+- `text`
+- `tool_call`
+- `tool_result`
+- `input_required`
+- `approval_required`
+- `final_result`
+- `error`
+- `delta`
+- `multimodal_part`
+
+## Compatibility
+
+`MessageEnvelope::normalize()` accepts either the legacy
+`role/content/metadata` shape or the versioned envelope shape. The canonical
+storage path still writes legacy messages by calling
+`MessageEnvelope::to_legacy_message()` / `to_legacy_messages()`.
+
+This gives runtime adapters a stable typed target while preserving existing
+chat rows, pipeline transcripts, REST responses, and CLI transcript rendering.
+
+## Type Data
+
+Legacy tool-call messages:
+
+```php
+[
+    'role'     => 'assistant',
+    'content'  => 'AI ACTION (Turn 1): Executing Wiki Upsert',
+    'metadata' => [
+        'type'       => 'tool_call',
+        'tool_name'  => 'wiki_upsert',
+        'parameters' => [ 'title' => 'Example' ],
+        'turn'       => 1,
+    ],
+]
+```
+
+normalize to:
+
+```php
+[
+    'schema'  => 'datamachine.ai.message',
+    'version' => 1,
+    'type'    => 'tool_call',
+    'role'    => 'assistant',
+    'content' => 'AI ACTION (Turn 1): Executing Wiki Upsert',
+    'data'    => [
+        'tool_name'  => 'wiki_upsert',
+        'parameters' => [ 'title' => 'Example' ],
+        'turn'       => 1,
+    ],
+    'metadata' => [
+        'type'       => 'tool_call',
+        'tool_name'  => 'wiki_upsert',
+        'parameters' => [ 'title' => 'Example' ],
+        'turn'       => 1,
+    ],
+]
+```
+
+For new adapters, prefer putting type-specific fields in `data` and
+adapter-specific details in `metadata`. Data Machine will fold `data` back into
+`metadata` when returning the persisted legacy shape.
+
+## Adapter Guidance
+
+Runtime adapters using `datamachine_conversation_runner` may return messages in
+either shape. `AIConversationResult::normalize()` normalizes every message
+through `MessageEnvelope` and returns the current persisted shape to callers.
+
+Conversation store adapters should normalize host messages to this envelope at
+their boundary, then return `role/content/metadata` arrays to Data Machine's chat
+abilities and UI until the storage contract changes explicitly.

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -1303,7 +1303,10 @@ factory caches the store per request and applies the filter exactly once.
 
 **Message shape contract**
 
-Stores MUST normalize messages on read to Data Machine message shape:
+Stores MUST normalize messages on read to Data Machine message shape. The
+versioned runtime envelope is documented in
+[`ai-message-envelope.md`](../../core-system/ai-message-envelope.md), but the
+chat/session storage contract remains this JSON-friendly legacy shape:
 
 ```php
 [
@@ -1317,8 +1320,9 @@ Stores MUST normalize messages on read to Data Machine message shape:
 ```
 
 The five Chat Session abilities and the DM chat UI consume this shape.
-Adapter stores (e.g. around `WPCOM\AI\Message` with `data` instead of
-`metadata`) are responsible for aliasing on the way out.
+Adapter stores that wrap another host runtime are responsible for translating
+host-specific message objects into Data Machine's envelope at the boundary and
+returning `role/content/metadata` arrays on the way out.
 
 **Swap boundary**
 

--- a/inc/Engine/AI/AIConversationResult.php
+++ b/inc/Engine/AI/AIConversationResult.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Validates and normalizes AIConversationLoop result arrays.
  */
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
 class AIConversationResult {
 
 	/**
@@ -37,6 +38,14 @@ class AIConversationResult {
 			if ( ! is_array( $message ) ) {
 				throw self::invalid( $path, 'must be an array' );
 			}
+
+			try {
+				$message = MessageEnvelope::to_legacy_message( $message );
+			} catch ( \InvalidArgumentException $e ) {
+				throw self::invalid( $path, $e->getMessage() );
+			}
+
+			$result['messages'][ $index ] = $message;
 
 			if ( array_key_exists( 'role', $message ) && ! is_string( $message['role'] ) ) {
 				throw self::invalid( $path . '.role', 'must be a string when present' );

--- a/inc/Engine/AI/MessageEnvelope.php
+++ b/inc/Engine/AI/MessageEnvelope.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * JSON-friendly AI message envelope contract.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Normalizes Data Machine AI messages into a stable typed envelope.
+ *
+ * The persisted chat/session shape remains `role/content/metadata`; this class
+ * gives adapters a versioned JSON object to target without coupling Data
+ * Machine core to any host-specific DTO.
+ */
+class MessageEnvelope {
+
+	public const SCHEMA  = 'datamachine.ai.message';
+	public const VERSION = 1;
+
+	public const TYPE_TEXT              = 'text';
+	public const TYPE_TOOL_CALL         = 'tool_call';
+	public const TYPE_TOOL_RESULT       = 'tool_result';
+	public const TYPE_INPUT_REQUIRED    = 'input_required';
+	public const TYPE_APPROVAL_REQUIRED = 'approval_required';
+	public const TYPE_FINAL_RESULT      = 'final_result';
+	public const TYPE_ERROR             = 'error';
+	public const TYPE_DELTA             = 'delta';
+	public const TYPE_MULTIMODAL_PART   = 'multimodal_part';
+
+	private const SUPPORTED_TYPES = array(
+		self::TYPE_TEXT,
+		self::TYPE_TOOL_CALL,
+		self::TYPE_TOOL_RESULT,
+		self::TYPE_INPUT_REQUIRED,
+		self::TYPE_APPROVAL_REQUIRED,
+		self::TYPE_FINAL_RESULT,
+		self::TYPE_ERROR,
+		self::TYPE_DELTA,
+		self::TYPE_MULTIMODAL_PART,
+	);
+
+	/**
+	 * Return the supported envelope type names.
+	 *
+	 * @return array<int, string>
+	 */
+	public static function supported_types(): array {
+		return self::SUPPORTED_TYPES;
+	}
+
+	/**
+	 * Normalize a legacy message or typed envelope to the canonical envelope.
+	 *
+	 * @param array $message Message array.
+	 * @return array Normalized envelope.
+	 * @throws \InvalidArgumentException When the message is invalid.
+	 */
+	public static function normalize( array $message ): array {
+		$envelope = self::is_envelope( $message )
+			? self::normalize_envelope( $message )
+			: self::from_legacy_message( $message );
+
+		if ( false === self::json_encode( $envelope ) ) {
+			throw new \InvalidArgumentException( 'invalid_ai_message_envelope: envelope must be JSON serializable' );
+		}
+
+		return $envelope;
+	}
+
+	/**
+	 * Normalize a list of messages to envelopes.
+	 *
+	 * @param array $messages Message arrays.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function normalize_many( array $messages ): array {
+		$normalized = array();
+		foreach ( $messages as $message ) {
+			if ( ! is_array( $message ) ) {
+				throw new \InvalidArgumentException( 'invalid_ai_message_envelope: message must be an array' );
+			}
+			$normalized[] = self::normalize( $message );
+		}
+		return $normalized;
+	}
+
+	/**
+	 * Convert an envelope back to the current persisted Data Machine shape.
+	 *
+	 * @param array $envelope Typed envelope or legacy message.
+	 * @return array Legacy message with role/content/metadata.
+	 */
+	public static function to_legacy_message( array $envelope ): array {
+		$source_is_envelope  = self::is_envelope( $envelope );
+		$source_had_metadata = array_key_exists( 'metadata', $envelope );
+		$source_metadata     = is_array( $envelope['metadata'] ?? null ) ? $envelope['metadata'] : array();
+		$envelope            = self::normalize( $envelope );
+
+		$metadata = $envelope['metadata'];
+		if ( $source_is_envelope || self::TYPE_TEXT !== $envelope['type'] || array_key_exists( 'type', $source_metadata ) ) {
+			$metadata['type'] = $envelope['type'];
+		}
+
+		foreach ( $envelope['data'] as $key => $value ) {
+			if ( ! array_key_exists( $key, $metadata ) ) {
+				$metadata[ $key ] = $value;
+			}
+		}
+
+		$message = array(
+			'role'    => $envelope['role'],
+			'content' => $envelope['content'],
+		);
+
+		if ( ! empty( $metadata ) || $source_is_envelope || $source_had_metadata ) {
+			$message['metadata'] = $metadata;
+		}
+
+		foreach ( array( 'id', 'created_at', 'updated_at' ) as $field ) {
+			if ( isset( $envelope[ $field ] ) && is_string( $envelope[ $field ] ) && '' !== $envelope[ $field ] ) {
+				$message[ $field ] = $envelope[ $field ];
+			}
+		}
+
+		return $message;
+	}
+
+	/**
+	 * Convert a message list back to the current persisted shape.
+	 *
+	 * @param array $messages Message arrays or envelopes.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function to_legacy_messages( array $messages ): array {
+		$legacy_messages = array();
+		foreach ( $messages as $message ) {
+			if ( ! is_array( $message ) ) {
+				throw new \InvalidArgumentException( 'invalid_ai_message_envelope: message must be an array' );
+			}
+			$legacy_messages[] = self::to_legacy_message( $message );
+		}
+		return $legacy_messages;
+	}
+
+	/**
+	 * Detect whether an array already uses the envelope shape.
+	 *
+	 * @param array $message Message array.
+	 * @return bool
+	 */
+	private static function is_envelope( array $message ): bool {
+		return isset( $message['version'], $message['type'] )
+			&& ( isset( $message['schema'] ) || array_key_exists( 'data', $message ) );
+	}
+
+	/**
+	 * Normalize an already-typed envelope.
+	 *
+	 * @param array $message Raw envelope.
+	 * @return array Canonical envelope.
+	 */
+	private static function normalize_envelope( array $message ): array {
+		if ( self::VERSION !== (int) $message['version'] ) {
+			throw new \InvalidArgumentException( 'invalid_ai_message_envelope: unsupported version' );
+		}
+
+		$type = self::normalize_type( $message['type'] ?? self::TYPE_TEXT );
+
+		return self::build_envelope(
+			$message['role'] ?? self::role_for_type( $type ),
+			$message['content'] ?? '',
+			$type,
+			is_array( $message['data'] ?? null ) ? $message['data'] : array(),
+			is_array( $message['metadata'] ?? null ) ? $message['metadata'] : array(),
+			$message
+		);
+	}
+
+	/**
+	 * Normalize the legacy role/content/metadata message shape.
+	 *
+	 * @param array $message Legacy message.
+	 * @return array Canonical envelope.
+	 */
+	private static function from_legacy_message( array $message ): array {
+		$metadata = is_array( $message['metadata'] ?? null ) ? $message['metadata'] : array();
+		$type     = self::infer_type( $message, $metadata );
+
+		return self::build_envelope(
+			$message['role'] ?? self::role_for_type( $type ),
+			$message['content'] ?? '',
+			$type,
+			self::data_from_legacy_metadata( $type, $metadata ),
+			$metadata,
+			$message
+		);
+	}
+
+	/**
+	 * Build a canonical envelope with common optional fields preserved.
+	 *
+	 * @param mixed  $role     Raw role.
+	 * @param mixed  $content  Raw content.
+	 * @param string $type     Envelope type.
+	 * @param array  $data     Type-specific payload.
+	 * @param array  $metadata Extension metadata.
+	 * @param array  $source   Source message.
+	 * @return array Canonical envelope.
+	 */
+	private static function build_envelope( $role, $content, string $type, array $data, array $metadata, array $source ): array {
+		if ( ! is_string( $role ) || '' === $role ) {
+			throw new \InvalidArgumentException( 'invalid_ai_message_envelope: role must be a non-empty string' );
+		}
+
+		if ( ! is_string( $content ) && ! is_array( $content ) ) {
+			throw new \InvalidArgumentException( 'invalid_ai_message_envelope: content must be a string or array' );
+		}
+
+		$envelope = array(
+			'schema'   => self::SCHEMA,
+			'version'  => self::VERSION,
+			'type'     => self::normalize_type( $type ),
+			'role'     => $role,
+			'content'  => $content,
+			'data'     => $data,
+			'metadata' => $metadata,
+		);
+
+		foreach ( array( 'id', 'created_at', 'updated_at' ) as $field ) {
+			if ( isset( $source[ $field ] ) && is_string( $source[ $field ] ) && '' !== $source[ $field ] ) {
+				$envelope[ $field ] = $source[ $field ];
+			}
+		}
+
+		return $envelope;
+	}
+
+	/**
+	 * Infer the typed envelope event from legacy message fields.
+	 *
+	 * @param array $message  Legacy message.
+	 * @param array $metadata Legacy metadata.
+	 * @return string Envelope type.
+	 */
+	private static function infer_type( array $message, array $metadata ): string {
+		if ( isset( $metadata['type'] ) && is_string( $metadata['type'] ) && in_array( $metadata['type'], self::SUPPORTED_TYPES, true ) ) {
+			return $metadata['type'];
+		}
+
+		if ( isset( $metadata['error'] ) ) {
+			return self::TYPE_ERROR;
+		}
+
+		if ( is_array( $message['content'] ?? null ) ) {
+			return self::TYPE_MULTIMODAL_PART;
+		}
+
+		return self::TYPE_TEXT;
+	}
+
+	/**
+	 * Pull common legacy metadata fields into type-specific envelope data.
+	 *
+	 * @param string $type     Envelope type.
+	 * @param array  $metadata Legacy metadata.
+	 * @return array Type-specific data.
+	 */
+	private static function data_from_legacy_metadata( string $type, array $metadata ): array {
+		$data = array();
+
+		if ( self::TYPE_TOOL_CALL === $type ) {
+			foreach ( array( 'tool_name', 'parameters', 'turn' ) as $key ) {
+				if ( array_key_exists( $key, $metadata ) ) {
+					$data[ $key ] = $metadata[ $key ];
+				}
+			}
+		}
+
+		if ( self::TYPE_TOOL_RESULT === $type ) {
+			foreach ( array( 'tool_name', 'success', 'turn', 'tool_data', 'media', 'error' ) as $key ) {
+				if ( array_key_exists( $key, $metadata ) ) {
+					$data[ $key ] = $metadata[ $key ];
+				}
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Normalize and validate a message type.
+	 *
+	 * @param mixed $type Raw type.
+	 * @return string Supported type.
+	 */
+	private static function normalize_type( $type ): string {
+		if ( ! is_string( $type ) || ! in_array( $type, self::SUPPORTED_TYPES, true ) ) {
+			throw new \InvalidArgumentException( 'invalid_ai_message_envelope: unsupported type' );
+		}
+		return $type;
+	}
+
+	/**
+	 * Encode data for serializability checks with a pure-PHP fallback for smokes.
+	 *
+	 * @param mixed $data Data to encode.
+	 * @return string|false Encoded JSON or false on failure.
+	 */
+	private static function json_encode( $data ) {
+		if ( function_exists( 'wp_json_encode' ) ) {
+			return wp_json_encode( $data );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Pure-PHP smoke tests run without WordPress loaded.
+		return json_encode( $data );
+	}
+
+	/**
+	 * Pick a default role for future typed envelopes that omit one.
+	 *
+	 * @param string $type Envelope type.
+	 * @return string Role.
+	 */
+	private static function role_for_type( string $type ): string {
+		if ( in_array( $type, array( self::TYPE_TOOL_RESULT, self::TYPE_INPUT_REQUIRED, self::TYPE_APPROVAL_REQUIRED ), true ) ) {
+			return 'tool';
+		}
+
+		return 'assistant';
+	}
+}

--- a/tests/ai-message-envelope-smoke.php
+++ b/tests/ai-message-envelope-smoke.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Smoke tests for the AI message envelope contract.
+ *
+ * Run with: php tests/ai-message-envelope-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+use DataMachine\Engine\AI\AIConversationResult;
+use DataMachine\Engine\AI\MessageEnvelope;
+
+function datamachine_message_envelope_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+function datamachine_message_envelope_count(): void {
+	$GLOBALS['datamachine_message_envelope_assertions'] = ( $GLOBALS['datamachine_message_envelope_assertions'] ?? 0 ) + 1;
+}
+
+$GLOBALS['datamachine_message_envelope_assertions'] = 0;
+
+$legacy_text = array(
+	'role'    => 'user',
+	'content' => 'Hello world.',
+);
+
+$text_envelope = MessageEnvelope::normalize( $legacy_text );
+datamachine_message_envelope_assert( MessageEnvelope::SCHEMA === $text_envelope['schema'], 'Legacy text normalizes to the Data Machine schema.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( MessageEnvelope::VERSION === $text_envelope['version'], 'Legacy text normalizes to the current envelope version.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( MessageEnvelope::TYPE_TEXT === $text_envelope['type'], 'Legacy text infers text type.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( $legacy_text === MessageEnvelope::to_legacy_message( $legacy_text ), 'Plain legacy text round-trips without adding metadata churn.' );
+datamachine_message_envelope_count();
+
+$legacy_tool_call = array(
+	'role'     => 'assistant',
+	'content'  => 'AI ACTION (Turn 2): Executing Wiki Upsert with parameters: title: Demo',
+	'metadata' => array(
+		'type'       => 'tool_call',
+		'tool_name'  => 'wiki_upsert',
+		'parameters' => array( 'title' => 'Demo' ),
+		'turn'       => 2,
+	),
+);
+
+$tool_call_envelope = MessageEnvelope::normalize( $legacy_tool_call );
+datamachine_message_envelope_assert( MessageEnvelope::TYPE_TOOL_CALL === $tool_call_envelope['type'], 'Legacy tool call keeps explicit tool_call type.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( 'wiki_upsert' === $tool_call_envelope['data']['tool_name'], 'Tool call tool_name is promoted to envelope data.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( array( 'title' => 'Demo' ) === $tool_call_envelope['data']['parameters'], 'Tool call parameters are promoted to envelope data.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( $legacy_tool_call === MessageEnvelope::to_legacy_message( $tool_call_envelope ), 'Tool call envelope converts back to legacy storage shape.' );
+datamachine_message_envelope_count();
+
+$legacy_tool_result = array(
+	'role'     => 'user',
+	'content'  => "TOOL RESPONSE (Turn 2): SUCCESS: Wiki Upsert completed successfully.\n\n{\"post_id\":123}",
+	'metadata' => array(
+		'type'      => 'tool_result',
+		'tool_name' => 'wiki_upsert',
+		'success'   => true,
+		'turn'      => 2,
+		'tool_data' => array( 'post_id' => 123 ),
+	),
+);
+
+$tool_result_envelope = MessageEnvelope::normalize( $legacy_tool_result );
+datamachine_message_envelope_assert( MessageEnvelope::TYPE_TOOL_RESULT === $tool_result_envelope['type'], 'Legacy tool result keeps explicit tool_result type.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( true === $tool_result_envelope['data']['success'], 'Tool result success is promoted to envelope data.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( array( 'post_id' => 123 ) === $tool_result_envelope['data']['tool_data'], 'Tool result data is promoted to envelope data.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( $legacy_tool_result === MessageEnvelope::to_legacy_message( $tool_result_envelope ), 'Tool result envelope converts back to legacy storage shape.' );
+datamachine_message_envelope_count();
+
+$typed_final_result = array(
+	'schema'   => MessageEnvelope::SCHEMA,
+	'version'  => MessageEnvelope::VERSION,
+	'type'     => MessageEnvelope::TYPE_FINAL_RESULT,
+	'role'     => 'assistant',
+	'content'  => 'Finished.',
+	'data'     => array( 'status' => 'complete' ),
+	'metadata' => array( 'provider_message_id' => 'msg_123' ),
+);
+
+$typed_legacy = MessageEnvelope::to_legacy_message( $typed_final_result );
+datamachine_message_envelope_assert( 'assistant' === $typed_legacy['role'], 'Future typed envelope keeps role in legacy output.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( 'Finished.' === $typed_legacy['content'], 'Future typed envelope keeps content in legacy output.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( MessageEnvelope::TYPE_FINAL_RESULT === $typed_legacy['metadata']['type'], 'Future typed envelope writes type into legacy metadata.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( 'complete' === $typed_legacy['metadata']['status'], 'Future typed envelope folds data into legacy metadata.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( 'msg_123' === $typed_legacy['metadata']['provider_message_id'], 'Future typed envelope preserves extension metadata.' );
+datamachine_message_envelope_count();
+
+$typed_delta = array(
+	'schema'  => MessageEnvelope::SCHEMA,
+	'version' => MessageEnvelope::VERSION,
+	'type'    => MessageEnvelope::TYPE_DELTA,
+	'content' => 'partial token',
+	'data'    => array( 'index' => 0 ),
+);
+
+$delta_envelope = MessageEnvelope::normalize( $typed_delta );
+datamachine_message_envelope_assert( 'assistant' === $delta_envelope['role'], 'Typed delta envelope gets assistant default role.' );
+datamachine_message_envelope_count();
+
+$multimodal_legacy = array(
+	'role'    => 'user',
+	'content' => array(
+		array( 'type' => 'text', 'text' => 'Describe this image.' ),
+		array( 'type' => 'image_url', 'image_url' => array( 'url' => 'https://example.com/image.jpg' ) ),
+	),
+);
+
+$multimodal_envelope = MessageEnvelope::normalize( $multimodal_legacy );
+datamachine_message_envelope_assert( MessageEnvelope::TYPE_MULTIMODAL_PART === $multimodal_envelope['type'], 'Array content infers multimodal_part type.' );
+datamachine_message_envelope_count();
+
+$result = AIConversationResult::normalize(
+	array(
+		'messages'               => array( $typed_final_result ),
+		'final_content'          => 'Finished.',
+		'turn_count'             => 1,
+		'completed'              => true,
+		'last_tool_calls'        => array(),
+		'tool_execution_results' => array(),
+		'usage'                  => array(),
+	)
+);
+
+datamachine_message_envelope_assert( MessageEnvelope::TYPE_FINAL_RESULT === $result['messages'][0]['metadata']['type'], 'AIConversationResult accepts typed envelopes and returns legacy messages.' );
+datamachine_message_envelope_count();
+
+try {
+	MessageEnvelope::normalize(
+		array(
+			'schema'  => MessageEnvelope::SCHEMA,
+			'version' => MessageEnvelope::VERSION,
+			'type'    => 'unknown_type',
+			'content' => 'bad',
+		)
+	);
+	throw new RuntimeException( 'Unsupported envelope type should throw.' );
+} catch ( InvalidArgumentException $e ) {
+	datamachine_message_envelope_assert( str_contains( $e->getMessage(), 'unsupported type' ), 'Unsupported envelope type fails loudly.' );
+	datamachine_message_envelope_count();
+}
+
+datamachine_message_envelope_assert( false !== json_encode( $typed_legacy ), 'Legacy output remains JSON serializable.' );
+datamachine_message_envelope_count();
+
+echo 'AI message envelope smoke passed (' . $GLOBALS['datamachine_message_envelope_assertions'] . " assertions).\n";


### PR DESCRIPTION
## Summary
- Adds a versioned, JSON-friendly AI message envelope helper for Data Machine messages.
- Lets runtime adapters return either current `role/content/metadata` messages or typed envelopes while preserving the existing stored message shape.
- Documents the stable adapter target in the core AI loop and filter docs.

## Message envelope
- Schema: `datamachine.ai.message`
- Version: `1`
- Supported types: `text`, `tool_call`, `tool_result`, `input_required`, `approval_required`, `final_result`, `error`, `delta`, `multimodal_part`
- Type-specific payload lives in `data`; adapter/private extension fields stay in `metadata`.

## Compatibility
- Existing chat rows and pipeline transcripts keep the current `role/content/metadata` shape.
- `AIConversationResult::normalize()` now normalizes messages through `MessageEnvelope` and converts them back to legacy storage shape before returning.
- No host-specific DTOs or `WPCOM\\AI` references are introduced.

## Tests
- `php tests/ai-message-envelope-smoke.php`
- `php tests/ai-conversation-result-smoke.php`
- `php -l inc/Engine/AI/MessageEnvelope.php`
- `php -l tests/ai-message-envelope-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@feat-message-envelope-spec --skip-lint --changed-since origin/main --json-summary`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-message-envelope-spec --changed-only --summary` *(PHPCS passed; command exits 1 because the runner still invokes ESLint on non-JS changed files, but baseline comparison reported no new lint items.)*

Closes #1484

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting the message envelope helper, compatibility normalization, docs, and smoke tests; Chris remains responsible for review and merge.