### PR TITLE
fix(content): default AI upserts to markdown authoring

### DIFF
--- a/docs/core-system/abilities-api.md
+++ b/docs/core-system/abilities-api.md
@@ -205,13 +205,20 @@ Workspace and GitHub coding abilities live in the `data-machine-code` extension 
 | `datamachine/query-posts` | Find posts created by Data Machine, filtered by handler/flow/pipeline | `inc/Abilities/PostQueryAbilities.php` |
 | `datamachine/list-posts` | List Data Machine posts with combinable filters | `inc/Abilities/PostQueryAbilities.php` |
 
-### Content / Block Editing (3 abilities)
+### Content / Block Editing (4 abilities)
 
 | Ability | Description | Location |
 |---------|-------------|----------|
+| `datamachine/upsert-post` | Create or update a post. AI/chat tool calls default to markdown authoring; raw ability/API callers that omit `content_format` keep the legacy block-markup default. | `inc/Abilities/Content/UpsertPostAbility.php` |
 | `datamachine/get-post-blocks` | Get Gutenberg blocks from a post | `inc/Abilities/Content/GetPostBlocksAbility.php` |
 | `datamachine/edit-post-blocks` | Update Gutenberg blocks in a post | `inc/Abilities/Content/EditPostBlocksAbility.php` |
 | `datamachine/replace-post-blocks` | Replace specific blocks in a post | `inc/Abilities/Content/ReplacePostBlocksAbility.php` |
+
+`content_format` is the caller's authoring/source format (`markdown`, `html`, or
+`blocks`). It is distinct from the stored `post_content` format, which is chosen
+per post type by `datamachine_post_content_format`. Normal AI-authored prose
+should be markdown; only set `content_format` when the caller intentionally
+supplies HTML or serialized block markup.
 
 ### Media (7 abilities)
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -483,6 +483,31 @@ add_filter( 'datamachine_pending_action_handlers', function ( $handlers ) {
 value (which is wrapped into the resolver response) or a `WP_Error` to
 surface failure.
 
+## Content Format Filters
+
+Data Machine separates **authoring/source format** from **stored format**.
+AI-facing tools should treat normal authored prose as markdown unless a workflow
+explicitly pins another source format. Storage-aware abilities then convert that
+source through Block Format Bridge into the post type's canonical stored shape.
+
+### `datamachine_post_content_format`
+
+**Purpose**: Choose the canonical `post_content` storage format for a post type.
+Core defaults to `blocks`, while storage-layer plugins can return formats such as
+`markdown` for post types they own.
+
+```php
+add_filter( 'datamachine_post_content_format', function ( string $format, string $post_type ): string {
+    return 'wiki' === $post_type ? 'markdown' : $format;
+}, 10, 2 );
+```
+
+`content_format` on abilities is the caller's source format (`markdown`, `html`,
+or `blocks`). It is not the storage decision. For example, the `upsert_post`
+chat tool defaults omitted `content_format` to markdown so agents can author
+ordinary prose naturally; raw ability/API calls keep the legacy omitted-format
+default of block markup for compatibility.
+
 ### `datamachine_pending_action_staged`
 
 **Purpose**: Fires when a tool invocation has been staged and is awaiting

--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -74,11 +74,12 @@ class UpsertPostAbility {
 							),
 							'content'        => array(
 								'type'        => 'string',
-								'description' => 'Post content. Replaces existing content when updating.',
+								'description' => 'Post content. Replaces existing content when updating. Raw ability callers that omit content_format are treated as providing block markup for backwards compatibility.',
 							),
 							'content_format' => array(
 								'type'        => 'string',
-								'description' => 'Format of content. Defaults to blocks. Use markdown/html when passing non-block source content.',
+								'enum'        => array( 'blocks', 'html', 'markdown' ),
+								'description' => 'Authoring/source format of content, not the stored post_content format. Raw ability/API calls default to blocks for compatibility. Pass markdown or html when supplying those source formats; the post type stored format is decided by datamachine_post_content_format.',
 							),
 							'post_id'        => array(
 								'type'        => 'integer',
@@ -198,7 +199,7 @@ class UpsertPostAbility {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handleChatToolCall',
-			'description' => 'Idempotently create or update a WordPress post. Finds by identity (post_id, slug+parent, or custom meta), compares content hash, and returns created/updated/no_change. Use for pipeline-safe writes that avoid churn on re-runs.',
+			'description' => 'Idempotently create or update a WordPress post. For normal authored prose, write content as markdown and omit content_format; Data Machine converts that authoring format to the post type stored format. Only set content_format when you are intentionally providing html or serialized block markup.',
 			'parameters'  => array(
 				'post_type'      => array(
 					'type'        => 'string',
@@ -210,11 +211,12 @@ class UpsertPostAbility {
 				),
 				'content'        => array(
 					'type'        => 'string',
-					'description' => 'Post content.',
+					'description' => 'Post content to author. Use markdown for normal prose unless content_format explicitly says otherwise.',
 				),
 				'content_format' => array(
 					'type'        => 'string',
-					'description' => 'Format of content. Defaults to blocks.',
+					'enum'        => array( 'markdown', 'html', 'blocks' ),
+					'description' => 'Optional authoring/source format for content. Omit for normal prose; AI tool calls default to markdown. Set to html or blocks only when content is already in that format. This is distinct from the stored format chosen by the post type.',
 				),
 				'slug'           => array(
 					'type'        => 'string',
@@ -246,6 +248,10 @@ class UpsertPostAbility {
 	 */
 	public static function handleChatToolCall( array $params, array $tool_def = array() ): array {
 		$tool_def;
+		if ( empty( $params['content_format'] ) ) {
+			$params['content_format'] = 'markdown';
+		}
+
 		$result = self::execute( $params );
 		return array(
 			'success'   => ! empty( $result['success'] ),

--- a/tests/content-format-abilities-smoke.php
+++ b/tests/content-format-abilities-smoke.php
@@ -194,6 +194,21 @@ namespace {
 			return implode( "\n", $blocks );
 		}
 
+		if ( 'html' === $from && 'blocks' === $to ) {
+			$blocks = array();
+			if ( preg_match_all( '/<h[1-6][^>]*>(.*?)<\/h[1-6]>|<p[^>]*>(.*?)<\/p>/s', $content, $matches, PREG_SET_ORDER ) ) {
+				foreach ( $matches as $match ) {
+					if ( '' !== ( $match[1] ?? '' ) ) {
+						$blocks[] = "<!-- wp:heading -->\n<h2>{$match[1]}</h2>\n<!-- /wp:heading -->";
+					} else {
+						$blocks[] = "<!-- wp:paragraph -->\n<p>{$match[2]}</p>\n<!-- /wp:paragraph -->";
+					}
+				}
+				return implode( "\n", $blocks );
+			}
+			return "<!-- wp:html -->\n{$content}\n<!-- /wp:html -->";
+		}
+
 		if ( 'blocks' === $from && 'markdown' === $to ) {
 			$content = preg_replace( '/<!--\s*\/?wp:[^>]+-->\s*/', '', $content );
 			$content = preg_replace( '/<h[1-6][^>]*>(.*?)<\/h[1-6]>/', '# $1', $content );
@@ -289,6 +304,63 @@ namespace {
 	$new_post = get_post( (int) $new_id );
 	assert_content_ability( 'upsert-markdown-source-succeeds', true === $upsert['success'] );
 	assert_content_ability( 'upsert-markdown-source-stays-markdown', "# Stored\n\nRaw markdown." === ( $new_post->post_content ?? '' ) );
+
+	$chat_upsert   = DataMachine\Abilities\Content\UpsertPostAbility::handleChatToolCall(
+		array(
+			'post_type' => 'post',
+			'title'     => 'AI Markdown Default',
+			'content'   => "# AI Heading\n\nAI paragraph.",
+		)
+	);
+	$chat_id       = $chat_upsert['data']['post_id'] ?? 0;
+	$chat_post     = get_post( (int) $chat_id );
+	$chat_content  = $chat_post->post_content ?? '';
+	$last_convert  = end( $GLOBALS['__content_ability_conversions'] );
+	assert_content_ability( 'chat-upsert-default-succeeds', true === $chat_upsert['success'] );
+	assert_content_ability( 'chat-upsert-defaults-authoring-format-to-markdown', array( 'markdown', 'blocks', "# AI Heading\n\nAI paragraph." ) === $last_convert );
+	assert_content_ability( 'chat-upsert-markdown-default-stores-blocks-for-block-backed-post-type', false !== strpos( $chat_content, '<!-- wp:heading -->' ) );
+	assert_content_ability( 'chat-upsert-markdown-default-has-paragraph', false !== strpos( $chat_content, 'AI paragraph.' ) );
+
+	$raw_blocks = "<!-- wp:paragraph -->\n<p>Programmatic block content.</p>\n<!-- /wp:paragraph -->";
+	$raw_upsert = DataMachine\Abilities\Content\UpsertPostAbility::execute(
+		array(
+			'post_type' => 'post',
+			'title'     => 'Raw Blocks Default',
+			'content'   => $raw_blocks,
+		)
+	);
+	$raw_post   = get_post( (int) ( $raw_upsert['post_id'] ?? 0 ) );
+	assert_content_ability( 'raw-upsert-omitted-format-preserves-compat-block-default', $raw_blocks === ( $raw_post->post_content ?? '' ) );
+
+	$html_upsert = DataMachine\Abilities\Content\UpsertPostAbility::execute(
+		array(
+			'post_type'      => 'post',
+			'title'          => 'Explicit HTML',
+			'content'        => '<h2>HTML Heading</h2><p>HTML paragraph.</p>',
+			'content_format' => 'html',
+		)
+	);
+	$html_post   = get_post( (int) ( $html_upsert['post_id'] ?? 0 ) );
+	assert_content_ability( 'explicit-html-format-succeeds', true === $html_upsert['success'] );
+	assert_content_ability( 'explicit-html-format-converts-to-blocks', false !== strpos( $html_post->post_content ?? '', '<!-- wp:heading -->' ) );
+
+	$explicit_blocks_to_markdown = DataMachine\Abilities\Content\UpsertPostAbility::execute(
+		array(
+			'post_type'      => 'wiki',
+			'title'          => 'Explicit Blocks To Markdown',
+			'content'        => "<!-- wp:heading -->\n<h2>Blocks Heading</h2>\n<!-- /wp:heading -->",
+			'content_format' => 'blocks',
+		)
+	);
+	$blocks_to_markdown_post     = get_post( (int) ( $explicit_blocks_to_markdown['post_id'] ?? 0 ) );
+	assert_content_ability( 'explicit-blocks-format-succeeds', true === $explicit_blocks_to_markdown['success'] );
+	assert_content_ability( 'explicit-blocks-format-converts-to-markdown-storage', '# Blocks Heading' === ( $blocks_to_markdown_post->post_content ?? '' ) );
+
+	$tool = DataMachine\Abilities\Content\UpsertPostAbility::getChatTool();
+	assert_content_ability( 'chat-tool-content-format-is-optional', ! in_array( 'content_format', $tool['required'] ?? array(), true ) );
+	assert_content_ability( 'chat-tool-description-prefers-markdown-authoring', false !== strpos( $tool['description'], 'write content as markdown' ) );
+	assert_content_ability( 'chat-tool-content-format-description-defaults-markdown', false !== strpos( $tool['parameters']['content_format']['description'] ?? '', 'default to markdown' ) );
+	assert_content_ability( 'chat-tool-guidance-does-not-default-to-blocks', false === strpos( $tool['parameters']['content_format']['description'] ?? '', 'Defaults to blocks' ) );
 
 	echo "\nContentFormat abilities smoke: {$total} assertions, {$failed} failures.\n";
 


### PR DESCRIPTION
## Summary
- Make the AI-facing `upsert_post` tool default omitted `content_format` to markdown authoring.
- Preserve the raw `datamachine/upsert-post` ability/API omitted-format default as block markup for compatibility.
- Document authoring/source format separately from stored `post_content` format.

## Behaviour
- Normal AI-authored prose can be sent as `content` only; the chat tool treats it as markdown and converts through BFB into the post type's stored format.
- Explicit `content_format=blocks|html|markdown` callers still route through the storage-aware conversion path.
- Raw ability/API callers that omit `content_format` keep the legacy block-markup assumption.

## Tests
- `php tests/content-format-abilities-smoke.php`
- `php tests/content-format-helper-smoke.php`
- `php -l inc/Abilities/Content/UpsertPostAbility.php && php -l tests/content-format-abilities-smoke.php`
- `git diff --check`

Closes #1487.

## Follow-ups
- #1474 tracks applying the same contract to `wordpress_publish`.
- chubes4/block-format-bridge#44 and chubes4/block-format-bridge#45 track malformed/mixed input normalization.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing and testing the AI-facing markdown authoring default while preserving raw ability compatibility.
