### PR TITLE
feat(publish): support WordPress content formats

### DIFF
--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -299,7 +299,7 @@ Available only when the adjacent step matches the handler slug or type, register
 - `bluesky_publish` - Post to Bluesky (300 char limit)  
 - `facebook_publish` - Post to Facebook (no limit)
 - `threads_publish` - Post to Threads (500 char limit)
-- `wordpress_publish` - Create WordPress posts
+- `wordpress_publish` - Create WordPress posts; accepts `content_format` (`markdown`, `html`, or `blocks`) and stores content in the post type's configured format
 - `google_sheets_publish` - Add data to Google Sheets
 
 **Update Tools**:

--- a/docs/handlers/publish/handlers-overview.md
+++ b/docs/handlers/publish/handlers-overview.md
@@ -9,7 +9,7 @@ Publish handlers distribute processed content to external platforms using AI too
 **WordPress** (`wordpress_publish`)
 - **Character Limit**: No limit
 - **Authentication**: None (local installation)
-- **Features**: Modular handler architecture with `WordPressPublishHelper`, `TaxonomyHandler`, `WordPressSettingsResolver`, configuration hierarchy, Gutenberg blocks
+- **Features**: Modular handler architecture with `WordPressPublishHelper`, `TaxonomyHandler`, `WordPressSettingsResolver`, configuration hierarchy, and storage-aware content format conversion
 - **API**: WordPress core functions
 
 ## Source URL Attribution
@@ -33,7 +33,7 @@ Publish handlers distribute processed content to external platforms using AI too
 
 | Platform | Separator | Character Count | Special Features |
 |----------|-----------|-----------------|------------------|
-| WordPress | Gutenberg blocks | No limit | Source attribution blocks |
+| WordPress | Source content format | No limit | Converts content to the post type's stored format before insertion |
 
 ### Engine Data Access Pattern
 

--- a/docs/handlers/publish/wordpress-publish.md
+++ b/docs/handlers/publish/wordpress-publish.md
@@ -152,7 +152,7 @@ $parameters = [
 
 **Implementation**: `WordPressPublishHelper::applySourceAttribution()` static method
 
-**Purpose**: Appends source URLs to content with automatic Gutenberg block generation or plain text formatting.
+**Purpose**: Appends source URLs in the declared source content format, then lets the content-format boundary convert once to the post type's stored format.
 
 **Engine Data Source**: `source_url` retrieved from fetch handlers via `datamachine_engine_data` filter
 
@@ -170,22 +170,8 @@ $content = WordPressPublishHelper::applySourceAttribution($content, $source_url,
 **Source Processing**:
 - URL validation with `filter_var($url, FILTER_VALIDATE_URL)`
 - URL sanitization with `esc_url()`
-- Automatic content type detection with `has_blocks()`
-- Gutenberg block generation for block content
-- Plain text formatting for classic content
-
-**Block Generation** (for Gutenberg content):
-```php
-// Generated Gutenberg blocks
-"<!-- wp:separator --><hr class=\"wp-block-separator has-alpha-channel-opacity\"/><!-- /wp:separator -->
-
-<!-- wp:paragraph --><p>Source: <a href=\"{sanitized_url}\">{sanitized_url}</a></p><!-- /wp:paragraph -->"
-```
-
-**Plain Text Format** (for classic content):
-```php
-"\n\nSource: {sanitized_url}"
-```
+- Format-aware attribution for `html`, `markdown`, and `blocks`
+- Single conversion through `DataMachine\Core\Content\ContentFormat` before `wp_insert_post()`
 
 **Usage Example**:
 ```php
@@ -298,9 +284,10 @@ All configuration parameters must be provided in handler config:
 
 **Required**:
 - `title`: Post title (sanitized with `sanitize_text_field`)
-- `content`: Post content (sanitized with `wp_kses_post`)
+- `content`: Post content in the declared `content_format`
 
 **Optional**:
+- `content_format`: Source format for `content` (`html`, `markdown`, or `blocks`; defaults to `html` for compatibility). Data Machine converts this to the post type's stored format before insertion.
 - `image_url`: Featured image URL (processed by `WordPressPublishHelper`)
 - `source_url`: Source attribution URL (processed by `WordPressPublishHelper`)
 - `category`: Category assignment for `TaxonomyHandler`
@@ -406,7 +393,7 @@ $handler_config = [
 
 ## Security Features
 
-**Input Sanitization**: All components use WordPress security functions (`sanitize_text_field`, `wp_kses_post`, `esc_url`).
+**Input Sanitization**: Titles and URLs use WordPress security functions (`sanitize_text_field`, `esc_url`). HTML/block-backed post content is filtered after conversion; markdown-backed post types keep their markdown storage shape.
 
 **Permission Respect**: Honors WordPress user capabilities and post type permissions.
 

--- a/inc/Abilities/Publish/PublishWordPressAbility.php
+++ b/inc/Abilities/Publish/PublishWordPressAbility.php
@@ -11,7 +11,9 @@
 namespace DataMachine\Abilities\Publish;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Core\WordPress\PostTracking;
+use DataMachine\Core\WordPress\WordPressPublishHelper;
 use DataMachine\Core\WordPress\WordPressSettingsResolver;
 
 defined( 'ABSPATH' ) || exit;
@@ -47,7 +49,13 @@ class PublishWordPressAbility {
 							),
 							'content'                => array(
 								'type'        => 'string',
-								'description' => __( 'Post content in HTML format', 'data-machine' ),
+								'description' => __( 'Post content in the format declared by content_format', 'data-machine' ),
+							),
+							'content_format'         => array(
+								'type'        => 'string',
+								'enum'        => array( 'html', 'markdown', 'blocks' ),
+								'default'     => 'html',
+								'description' => __( 'Format of the supplied content before storage conversion', 'data-machine' ),
 							),
 							'post_type'              => array(
 								'type'        => 'string',
@@ -143,6 +151,8 @@ class PublishWordPressAbility {
 
 		$title                  = $config['title'];
 		$content                = $config['content'];
+		$content_format         = sanitize_key( $config['content_format'] );
+		$content_format         = '' !== $content_format ? $content_format : 'html';
 		$post_type              = $config['post_type'];
 		$post_status            = $config['post_status'];
 		$post_author            = $config['post_author'];
@@ -181,7 +191,6 @@ class PublishWordPressAbility {
 		}
 
 		$content = wp_unslash( $content );
-		$content = wp_filter_post_kses( $content );
 
 		if ( empty( trim( wp_strip_all_tags( $content ) ) ) ) {
 			$logs[] = array(
@@ -200,7 +209,37 @@ class PublishWordPressAbility {
 		}
 
 		if ( $add_source_attribution && ! empty( $source_url ) ) {
-			$content = $this->applySourceAttribution( $content, $source_url );
+			$content = WordPressPublishHelper::applySourceAttribution(
+				$content,
+				$source_url,
+				array(
+					'link_handling'  => 'append',
+					'content_format' => $content_format,
+				)
+			);
+		}
+
+		$stored_content = ContentFormat::sourceToStored( $content, $content_format, $post_type );
+		if ( is_wp_error( $stored_content ) ) {
+			$logs[] = array(
+				'level'   => 'error',
+				'message' => 'WordPress: Content format conversion failed',
+				'data'    => array(
+					'content_format' => $content_format,
+					'stored_format'  => ContentFormat::storedFormat( $post_type ),
+					'error'          => $stored_content->get_error_message(),
+				),
+			);
+			return array(
+				'success' => false,
+				'error'   => $stored_content->get_error_message(),
+				'logs'    => $logs,
+			);
+		}
+
+		$content = $stored_content;
+		if ( in_array( ContentFormat::storedFormat( $post_type ), array( 'html', 'blocks' ), true ) ) {
+			$content = wp_filter_post_kses( $content );
 		}
 
 		$post_data = array(
@@ -226,6 +265,8 @@ class PublishWordPressAbility {
 				'post_author'    => $post_data['post_author'],
 				'post_status'    => $post_data['post_status'],
 				'post_type'      => $post_data['post_type'],
+				'content_format' => $content_format,
+				'stored_format'  => ContentFormat::storedFormat( $post_type ),
 				'title_length'   => strlen( $post_data['post_title'] ),
 				'content_length' => strlen( $post_data['post_content'] ),
 			),
@@ -365,30 +406,13 @@ class PublishWordPressAbility {
 			'taxonomies'             => array(),
 			'featured_image_path'    => '',
 			'source_url'             => '',
+			'content_format'         => 'html',
 			'add_source_attribution' => true,
 			'post_parent'            => 0,
 			'job_id'                 => null,
 		);
 
 		return array_merge( $defaults, $input );
-	}
-
-	/**
-	 * Apply source attribution to content.
-	 */
-	private function applySourceAttribution( string $content, string $source_url ): string {
-		if ( empty( $source_url ) ) {
-			return $content;
-		}
-
-		$attribution = sprintf(
-			'<p class="datamachine-source-attribution">%s <a href="%s" target="_blank" rel="noopener noreferrer">%s</a></p>',
-			__( 'Source:', 'data-machine' ),
-			esc_url( $source_url ),
-			esc_html( $source_url )
-		);
-
-		return $content . "\n\n" . $attribution;
 	}
 
 	/**

--- a/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
+++ b/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php
@@ -45,15 +45,22 @@ class WordPress extends PublishHandler {
 				if ( 'wordpress_publish' === $handler_slug ) {
 					// Base parameters (always present)
 					$base_parameters = array(
-						'title'   => array(
+						'title'          => array(
 							'type'        => 'string',
 							'required'    => true,
 							'description' => 'The title of the WordPress post or page',
 						),
-						'content' => array(
+						'content'        => array(
 							'type'        => 'string',
 							'required'    => true,
-							'description' => 'The main content of the post in HTML format. Do not include source URL attribution or images - these are handled automatically by the system.',
+							'description' => 'The main content of the post in the requested content_format. Markdown is preferred for AI-authored prose unless the workflow asks for HTML or blocks. Do not include source URL attribution or images - these are handled automatically by the system.',
+						),
+						'content_format' => array(
+							'type'        => 'string',
+							'required'    => false,
+							'enum'        => array( 'html', 'markdown', 'blocks' ),
+							'default'     => 'html',
+							'description' => 'Format of the supplied content before Data Machine converts it to the post type storage format.',
 						),
 					);
 
@@ -179,6 +186,7 @@ class WordPress extends PublishHandler {
 		$ability_input = array(
 			'title'                  => $parameters['title'] ?? '',
 			'content'                => $parameters['content'] ?? '',
+			'content_format'         => $parameters['content_format'] ?? 'html',
 			'post_type'              => $handler_config['post_type'] ?? '',
 			'post_status'            => WordPressSettingsResolver::getPostStatus( $handler_config ),
 			'post_author'            => WordPressSettingsResolver::getPostAuthor( $handler_config ),

--- a/inc/Core/WordPress/WordPressPublishHelper.php
+++ b/inc/Core/WordPress/WordPressPublishHelper.php
@@ -108,7 +108,7 @@ class WordPressPublishHelper {
 	 *
 	 * @param string      $content The content to modify.
 	 * @param string|null $source_url Source URL to append.
-	 * @param array       $config Handler configuration (checks 'link_handling').
+	 * @param array       $config Handler configuration (checks 'link_handling' and 'content_format').
 	 * @return string Modified content.
 	 */
 	public static function applySourceAttribution( string $content, ?string $source_url, array $config ): string {
@@ -121,10 +121,16 @@ class WordPressPublishHelper {
 		}
 
 		$sanitized_url = esc_url( $source_url );
-		$has_blocks    = self::contentHasBlocks( $content );
+		$content_format = isset( $config['content_format'] )
+			? sanitize_key( $config['content_format'] )
+			: ( self::contentHasBlocks( $content ) ? 'blocks' : 'html' );
+		$content_format = '' !== $content_format ? $content_format : 'html';
 
-		// Match attribution format to existing content to avoid mixed HTML/block markup.
-		if ( $has_blocks ) {
+		if ( 'markdown' === $content_format ) {
+			return $content . "\n\n**Source:** [{$sanitized_url}]({$sanitized_url})";
+		}
+
+		if ( 'blocks' === $content_format ) {
 			return $content . "\n\n<!-- wp:paragraph -->\n<p><strong>Source:</strong> <a href=\"{$sanitized_url}\">{$sanitized_url}</a></p>\n<!-- /wp:paragraph -->";
 		}
 
@@ -132,7 +138,7 @@ class WordPressPublishHelper {
 	}
 
 	/**
-	 * Determine whether the content already contains Gutenberg block markup.
+	 * Determine whether legacy callers passed block markup without an explicit format.
 	 */
 	private static function contentHasBlocks( string $content ): bool {
 		return strpos( $content, '<!-- wp:' ) !== false;

--- a/tests/wordpress-publish-content-format-smoke.php
+++ b/tests/wordpress-publish-content-format-smoke.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Pure-PHP smoke test for WordPress publish content-format handling.
+ *
+ * Run with: php tests/wordpress-publish-content-format-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core {
+    class PluginSettings {
+
+        public static function get( string $key, array $default = array() ): array {
+            unset( $key );
+            return $default;
+        }
+    }
+}
+
+namespace {
+    if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/' );
+    }
+
+    $failed = 0;
+    $total  = 0;
+
+    function assert_publish_format( string $name, bool $condition ): void {
+        global $failed, $total;
+        ++$total;
+        if ( $condition ) {
+            echo "  PASS: {$name}\n";
+            return;
+        }
+        echo "  FAIL: {$name}\n";
+        ++$failed;
+    }
+
+    class WP_Error {
+
+        private string $message;
+
+        public function __construct( string $code = '', string $message = '' ) {
+            unset( $code );
+            $this->message = $message;
+        }
+
+        public function get_error_message(): string {
+            return $this->message;
+        }
+    }
+
+    $GLOBALS['__publish_format_filters']     = array();
+    $GLOBALS['__publish_format_posts']       = array();
+    $GLOBALS['__publish_format_meta']        = array();
+    $GLOBALS['__publish_format_next_id']     = 100;
+    $GLOBALS['__publish_format_conversions'] = array();
+
+    function doing_action( string $hook ): bool {
+        unset( $hook );
+        return false;
+    }
+
+    function did_action( string $hook ): int {
+        unset( $hook );
+        return 1;
+    }
+
+    function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+        $GLOBALS['__publish_format_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+    }
+
+    function apply_filters( string $hook, $value, ...$args ) {
+        if ( empty( $GLOBALS['__publish_format_filters'][ $hook ] ) ) {
+            return $value;
+        }
+
+        ksort( $GLOBALS['__publish_format_filters'][ $hook ] );
+        foreach ( $GLOBALS['__publish_format_filters'][ $hook ] as $callbacks ) {
+            foreach ( $callbacks as $registered_callback ) {
+                list( $callback, $accepted_args ) = $registered_callback;
+                $value                            = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+            }
+        }
+        return $value;
+    }
+
+    function sanitize_key( $key ): string {
+        return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $key ) );
+    }
+
+    function sanitize_text_field( $value ): string {
+        return trim( (string) $value );
+    }
+
+    function wp_unslash( $value ) {
+        return $value;
+    }
+
+    function wp_strip_all_tags( $value ): string {
+        return strip_tags( (string) $value );
+    }
+
+    function wp_filter_post_kses( $content ): string {
+        return (string) $content;
+    }
+
+    function esc_url( $url ): string {
+        return filter_var( (string) $url, FILTER_SANITIZE_URL );
+    }
+
+    function esc_url_raw( $url ): string {
+        return esc_url( $url );
+    }
+
+    function esc_html( $text ): string {
+        return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+    }
+
+    function __( $text, $domain = 'default' ) {
+        unset( $domain );
+        return $text;
+    }
+
+    function is_wp_error( $thing ): bool {
+        return $thing instanceof WP_Error;
+    }
+
+    function get_current_user_id(): int {
+        return 0;
+    }
+
+    function get_users( array $args = array() ): array {
+        unset( $args );
+        return array( 1 );
+    }
+
+    function wp_insert_post( array $post_data, bool $wp_error = false ) {
+        unset( $wp_error );
+        $id = $GLOBALS['__publish_format_next_id']++;
+
+        $post_data['ID']                          = $id;
+        $GLOBALS['__publish_format_posts'][ $id ] = (object) $post_data;
+
+        return $id;
+    }
+
+    function get_permalink( int $post_id ): string {
+        return "https://example.test/?p={$post_id}";
+    }
+
+    function update_post_meta( int $post_id, string $key, $value ): void {
+        $GLOBALS['__publish_format_meta'][ $post_id ][ $key ] = $value;
+    }
+
+    function bfb_convert( string $content, string $from, string $to ) {
+        $GLOBALS['__publish_format_conversions'][] = array( $from, $to, $content );
+
+        if ( $from === $to ) {
+            return $content;
+        }
+
+        if ( 'html' === $from && 'blocks' === $to ) {
+            return "<!-- wp:paragraph -->\n{$content}\n<!-- /wp:paragraph -->";
+        }
+
+        if ( 'markdown' === $from && 'blocks' === $to ) {
+            $html = preg_replace( '/^# (.+)$/m', '<h1>$1</h1>', $content );
+            $html = preg_replace( '/\*\*([^*]+)\*\* \[([^\]]+)\]\(([^)]+)\)/', '<strong>$1</strong> <a href="$3">$2</a>', $html );
+            return "<!-- wp:paragraph -->\n{$html}\n<!-- /wp:paragraph -->";
+        }
+
+        return new WP_Error( 'unsupported', "Unsupported {$from} to {$to}." );
+    }
+
+    add_filter(
+        'datamachine_post_content_format',
+        static function ( string $format, string $post_type ): string {
+            return 'wiki' === $post_type ? 'markdown' : $format;
+        },
+        10,
+        2
+    );
+
+    require_once dirname( __DIR__ ) . '/inc/Core/Content/ContentFormat.php';
+    require_once dirname( __DIR__ ) . '/inc/Core/WordPress/PostTracking.php';
+    require_once dirname( __DIR__ ) . '/inc/Core/WordPress/WordPressSettingsResolver.php';
+    require_once dirname( __DIR__ ) . '/inc/Core/WordPress/WordPressPublishHelper.php';
+    require_once dirname( __DIR__ ) . '/inc/Abilities/Publish/PublishWordPressAbility.php';
+
+    $ability = new \DataMachine\Abilities\Publish\PublishWordPressAbility();
+
+    $html_result = $ability->execute(
+        array(
+            'title'      => 'HTML post',
+            'content'    => '<p>Hello HTML.</p>',
+            'post_type'  => 'post',
+            'source_url' => 'https://example.test/source',
+        )
+    );
+    $html_post   = $GLOBALS['__publish_format_posts'][ $html_result['post_id'] ?? 0 ] ?? null;
+    assert_publish_format( 'default-html-publish-succeeds', true === ( $html_result['success'] ?? false ) );
+    assert_publish_format( 'default-html-converts-to-block-storage', false !== strpos( $html_post->post_content ?? '', '<!-- wp:paragraph -->' ) );
+    assert_publish_format( 'default-html-attribution-converted-with-content', false !== strpos( $html_post->post_content ?? '', '<strong>Source:</strong>' ) );
+
+    $markdown_result = $ability->execute(
+        array(
+            'title'          => 'Markdown post',
+            'content'        => "# Markdown\n\nBody.",
+            'content_format' => 'markdown',
+            'post_type'      => 'post',
+            'source_url'     => 'https://example.test/markdown',
+        )
+    );
+    $markdown_post   = $GLOBALS['__publish_format_posts'][ $markdown_result['post_id'] ?? 0 ] ?? null;
+    assert_publish_format( 'markdown-source-publish-succeeds', true === ( $markdown_result['success'] ?? false ) );
+    assert_publish_format( 'markdown-source-converts-to-block-storage', false !== strpos( $markdown_post->post_content ?? '', '<!-- wp:paragraph -->' ) );
+    assert_publish_format( 'markdown-source-attribution-starts-as-markdown', false !== strpos( $GLOBALS['__publish_format_conversions'][1][2] ?? '', '**Source:** [https://example.test/markdown](https://example.test/markdown)' ) );
+
+    $wiki_result = $ability->execute(
+        array(
+            'title'          => 'Markdown wiki',
+            'content'        => "# Wiki\n\nStored as markdown.",
+            'content_format' => 'markdown',
+            'post_type'      => 'wiki',
+            'source_url'     => 'https://example.test/wiki',
+        )
+    );
+    $wiki_post   = $GLOBALS['__publish_format_posts'][ $wiki_result['post_id'] ?? 0 ] ?? null;
+    assert_publish_format( 'markdown-backed-post-type-publish-succeeds', true === ( $wiki_result['success'] ?? false ) );
+    assert_publish_format( 'markdown-backed-post-type-stores-markdown', false === strpos( $wiki_post->post_content ?? '', '<!-- wp:' ) );
+    assert_publish_format( 'markdown-backed-attribution-stays-markdown', false !== strpos( $wiki_post->post_content ?? '', '**Source:** [https://example.test/wiki](https://example.test/wiki)' ) );
+
+    $ability_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/Publish/PublishWordPressAbility.php' );
+    $handler_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php' );
+    assert_publish_format( 'ability-schema-exposes-content-format', false !== strpos( $ability_source, "'content_format'" ) );
+    assert_publish_format( 'handler-tool-schema-exposes-content-format', false !== strpos( $handler_source, "'content_format'" ) );
+    assert_publish_format( 'handler-tool-no-longer-demands-html-only', false === strpos( $handler_source, 'content in HTML format' ) );
+
+    echo "\nWordPress publish content-format smoke: {$total} assertions, {$failed} failures.\n";
+
+    exit( min( 1, $failed ) );
+}


### PR DESCRIPTION
## Summary
- Adds `content_format` to `datamachine/publish-wordpress` and the adjacent `wordpress_publish` handler tool.
- Routes WordPress publish content through `DataMachine\Core\Content\ContentFormat` before insertion so storage-aware post types keep their configured stored format.
- Updates source attribution and docs/tool guidance so WordPress publish is no longer HTML-only.

## Behaviour
- Existing callers continue to default to `content_format=html` for compatibility.
- AI/tool callers can pass `content_format=markdown`, `html`, or `blocks`.
- Source attribution is appended in the caller's source format, then converted once into the post type's stored format.
- Post types filtered through `datamachine_post_content_format` to `markdown` store markdown in `post_content`.

## Tests
- `php -l inc/Abilities/Publish/PublishWordPressAbility.php`
- `php -l inc/Core/WordPress/WordPressPublishHelper.php`
- `php -l inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php`
- `php -l tests/wordpress-publish-content-format-smoke.php`
- `php tests/wordpress-publish-content-format-smoke.php`
- `php tests/content-format-helper-smoke.php`
- `php tests/content-format-abilities-smoke.php`
- `git diff --check origin/main...HEAD`

Closes #1474

## Follow-ups
- #1487 for broader AI markdown authoring defaults.
- BFB #44/#45 for malformed/mixed validation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the WordPress publish content-format boundary, updating publish tool/docs guidance, and drafting focused smoke coverage. Chris remains responsible for review and testing.
