### PR TITLE
feat(core): define resumable run state vocabulary

### DIFF
--- a/inc/Core/RunState.php
+++ b/inc/Core/RunState.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Generic resumable run-state vocabulary.
+ *
+ * This is transport- and storage-neutral. It names the lifecycle states that
+ * future resumable agent/workflow runs can persist without coupling core to a
+ * specific runtime, protocol, or job-table schema.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+class RunState {
+
+	public const PENDING              = 'pending';
+	public const RUNNING              = 'running';
+	public const WAITING_FOR_TOOL     = 'waiting_for_tool';
+	public const WAITING_FOR_INPUT    = 'waiting_for_input';
+	public const WAITING_FOR_APPROVAL = 'waiting_for_approval';
+	public const WAITING_FOR_CALLBACK = 'waiting_for_callback';
+	public const COMPLETED            = 'completed';
+	public const FAILED               = 'failed';
+	public const CANCELLED            = 'cancelled';
+
+	public const ALL_STATES = array(
+		self::PENDING,
+		self::RUNNING,
+		self::WAITING_FOR_TOOL,
+		self::WAITING_FOR_INPUT,
+		self::WAITING_FOR_APPROVAL,
+		self::WAITING_FOR_CALLBACK,
+		self::COMPLETED,
+		self::FAILED,
+		self::CANCELLED,
+	);
+
+	public const WAITING_STATES = array(
+		self::WAITING_FOR_TOOL,
+		self::WAITING_FOR_INPUT,
+		self::WAITING_FOR_APPROVAL,
+		self::WAITING_FOR_CALLBACK,
+	);
+
+	public const TERMINAL_STATES = array(
+		self::COMPLETED,
+		self::FAILED,
+		self::CANCELLED,
+	);
+
+	public static function is_valid( string $state ): bool {
+		return in_array( $state, self::ALL_STATES, true );
+	}
+
+	public static function is_waiting( string $state ): bool {
+		return in_array( $state, self::WAITING_STATES, true );
+	}
+
+	public static function is_terminal( string $state ): bool {
+		return in_array( $state, self::TERMINAL_STATES, true );
+	}
+}

--- a/tests/run-state-smoke.php
+++ b/tests/run-state-smoke.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Pure-PHP smoke test for DataMachine\Core\RunState.
+ *
+ * Run with: php tests/run-state-smoke.php
+ *
+ * Pins the generic resumable run-state vocabulary before the storage/event
+ * migration lands. This deliberately does not assert any job-table behavior;
+ * JobStatus::WAITING remains the existing webhook-gate job status until the
+ * real run-state system is built.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/Core/RunState.php';
+
+use DataMachine\Core\RunState;
+
+function dm_assert( bool $cond, string $msg ): void {
+	if ( $cond ) {
+		echo "  [PASS] {$msg}\n";
+		return;
+	}
+	echo "  [FAIL] {$msg}\n";
+	exit( 1 );
+}
+
+echo "=== run-state-smoke ===\n";
+
+echo "\n[1] vocabulary matches issue #1483\n";
+$expected_states = array(
+	'pending',
+	'running',
+	'waiting_for_tool',
+	'waiting_for_input',
+	'waiting_for_approval',
+	'waiting_for_callback',
+	'completed',
+	'failed',
+	'cancelled',
+);
+
+dm_assert( $expected_states === RunState::ALL_STATES, 'all states are ordered and complete' );
+dm_assert( count( $expected_states ) === count( array_unique( RunState::ALL_STATES ) ), 'states are unique' );
+
+echo "\n[2] validity is exact, not prefix-based\n";
+foreach ( $expected_states as $state ) {
+	dm_assert( RunState::is_valid( $state ), "{$state} is valid" );
+}
+dm_assert( ! RunState::is_valid( 'waiting' ), 'generic waiting is intentionally not a run state' );
+dm_assert( ! RunState::is_valid( 'waiting_for_human' ), 'unregistered future wait reason is invalid until named' );
+
+echo "\n[3] waiting states are explicit pause reasons\n";
+$expected_waiting = array(
+	'waiting_for_tool',
+	'waiting_for_input',
+	'waiting_for_approval',
+	'waiting_for_callback',
+);
+dm_assert( $expected_waiting === RunState::WAITING_STATES, 'waiting states are explicit reason states' );
+foreach ( $expected_waiting as $state ) {
+	dm_assert( RunState::is_waiting( $state ), "{$state} is waiting" );
+}
+dm_assert( ! RunState::is_waiting( RunState::PENDING ), 'pending is not waiting' );
+dm_assert( ! RunState::is_waiting( RunState::RUNNING ), 'running is not waiting' );
+dm_assert( ! RunState::is_waiting( RunState::COMPLETED ), 'completed is not waiting' );
+
+echo "\n[4] terminal states are distinct from resumable states\n";
+$expected_terminal = array( 'completed', 'failed', 'cancelled' );
+dm_assert( $expected_terminal === RunState::TERMINAL_STATES, 'terminal states are complete' );
+foreach ( $expected_terminal as $state ) {
+	dm_assert( RunState::is_terminal( $state ), "{$state} is terminal" );
+}
+dm_assert( ! RunState::is_terminal( RunState::WAITING_FOR_CALLBACK ), 'waiting_for_callback remains resumable' );
+dm_assert( ! RunState::is_terminal( RunState::RUNNING ), 'running is not terminal' );
+
+echo "\n=== run-state-smoke: ALL PASS ===\n";


### PR DESCRIPTION
## Summary
- Defines a transport-neutral `DataMachine\Core\RunState` vocabulary for future resumable agent/workflow runs.
- Pins explicit waiting reasons separately from terminal states so future work does not overload `JobStatus::WAITING`.
- Adds a pure smoke test with no schema, job-table, pending-action, or runtime behavior changes.

## Why
Issue #1483 needs a shared state vocabulary, but the durable storage shape should wait for the event sink (#1479) and `agent_call` follow-up adapter work from #1478. This PR only names the states and predicates future PRs can consume once those seams land.

## Tests
- `php tests/run-state-smoke.php`
- `php -l inc/Core/RunState.php`
- `php -l tests/run-state-smoke.php`

Closes #1483? No — this is only a preparatory vocabulary PR for #1483.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Scouted resumable run-state dependencies and implemented a tiny preparatory change; Chris to review before merge.
