### PR TITLE
feat(ai): execute ability-backed tools

### DIFF
--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -83,38 +83,6 @@ class ToolExecutor {
 			$tool_def
 		);
 
-		// Ensure tool definition has required 'class' key
-		if ( ! isset( $tool_def['class'] ) || empty( $tool_def['class'] ) ) {
-			return array(
-				'success'   => false,
-				'error'     => "Tool '{$tool_name}' is missing required 'class' definition. This may indicate the tool was not properly resolved from a callable.",
-				'tool_name' => $tool_name,
-			);
-		}
-
-		$class_name = $tool_def['class'];
-		if ( ! class_exists( $class_name ) ) {
-			return array(
-				'success'   => false,
-				'error'     => "Tool class '{$class_name}' not found",
-				'tool_name' => $tool_name,
-			);
-		}
-
-		$method = $tool_def['method'] ?? null;
-		if ( ! $method || ! method_exists( $class_name, $method ) ) {
-			return array(
-				'success'   => false,
-				'error'     => sprintf(
-					"Tool '%s' definition is missing required 'method' key or method '%s' does not exist on class '%s'.",
-					$tool_name,
-					$method ?? '(none)',
-					$class_name
-				),
-				'tool_name' => $tool_name,
-			);
-		}
-
 		// Resolve the action policy for this invocation. Tools without
 		// action_policy metadata resolve to 'direct' and behave exactly
 		// as before this feature landed.
@@ -187,8 +155,11 @@ class ToolExecutor {
 		}
 
 		// Policy is 'direct' (or 'preview' fell back) — execute the tool normally.
-		$tool_handler = new $class_name();
-		$tool_result  = $tool_handler->$method( $complete_parameters, $tool_def );
+		if ( self::isAbilityOnlyTool( $tool_def ) ) {
+			$tool_result = self::executeAbilityTool( $tool_name, $complete_parameters, $tool_def );
+		} else {
+			$tool_result = self::executeLegacyTool( $tool_name, $complete_parameters, $tool_def );
+		}
 
 		// Automatic post origin tracking — applies to every tool whose result
 		// contains an extractable post_id. This covers both handler tools
@@ -207,6 +178,139 @@ class ToolExecutor {
 		}
 
 		return $tool_result;
+	}
+
+	/**
+	 * Whether a tool should execute directly through a linked WordPress Ability.
+	 *
+	 * Legacy class/method definitions stay authoritative during the migration.
+	 * This branch only handles the new ability-native shape for a single linked
+	 * ability; composed multi-ability tools remain on their existing adapters.
+	 *
+	 * @param array $tool_def Tool definition.
+	 * @return bool
+	 */
+	private static function isAbilityOnlyTool( array $tool_def ): bool {
+		return ! empty( $tool_def['ability'] )
+			&& empty( $tool_def['class'] )
+			&& empty( $tool_def['method'] );
+	}
+
+	/**
+	 * Execute a tool through its linked WordPress Ability.
+	 *
+	 * @param string $tool_name  Tool name.
+	 * @param array  $parameters Complete tool parameters.
+	 * @param array  $tool_def   Tool definition.
+	 * @return array Tool execution result.
+	 */
+	private static function executeAbilityTool( string $tool_name, array $parameters, array $tool_def ): array {
+		$ability_slug = (string) $tool_def['ability'];
+		if ( ! class_exists( '\\WP_Abilities_Registry' ) ) {
+			return array(
+				'success'   => false,
+				'error'     => sprintf( "Tool '%s' references ability '%s', but the WordPress Abilities API is not available.", $tool_name, $ability_slug ),
+				'tool_name' => $tool_name,
+				'ability'   => $ability_slug,
+			);
+		}
+
+		$registry     = \WP_Abilities_Registry::get_instance();
+		$ability      = $registry ? $registry->get_registered( $ability_slug ) : null;
+
+		if ( ! $ability ) {
+			return array(
+				'success'   => false,
+				'error'     => sprintf( "Tool '%s' references missing ability '%s'.", $tool_name, $ability_slug ),
+				'tool_name' => $tool_name,
+				'ability'   => $ability_slug,
+			);
+		}
+
+		$permission = $ability->check_permissions( $parameters );
+		if ( is_wp_error( $permission ) ) {
+			return array(
+				'success'   => false,
+				'error'     => $permission->get_error_message(),
+				'tool_name' => $tool_name,
+				'ability'   => $ability_slug,
+			);
+		}
+
+		if ( true !== $permission ) {
+			return array(
+				'success'   => false,
+				'error'     => sprintf( "Tool '%s' is not permitted by ability '%s'.", $tool_name, $ability_slug ),
+				'tool_name' => $tool_name,
+				'ability'   => $ability_slug,
+			);
+		}
+
+		$result = $ability->execute( $parameters );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'   => false,
+				'error'     => $result->get_error_message(),
+				'tool_name' => $tool_name,
+				'ability'   => $ability_slug,
+			);
+		}
+
+		if ( is_array( $result ) ) {
+			return $result;
+		}
+
+		return array(
+			'success'   => true,
+			'tool_name' => $tool_name,
+			'ability'   => $ability_slug,
+			'result'    => $result,
+		);
+	}
+
+	/**
+	 * Execute a legacy class/method tool definition.
+	 *
+	 * @param string $tool_name  Tool name.
+	 * @param array  $parameters Complete tool parameters.
+	 * @param array  $tool_def   Tool definition.
+	 * @return array Tool execution result.
+	 */
+	private static function executeLegacyTool( string $tool_name, array $parameters, array $tool_def ): array {
+		// Ensure tool definition has required 'class' key.
+		if ( ! isset( $tool_def['class'] ) || empty( $tool_def['class'] ) ) {
+			return array(
+				'success'   => false,
+				'error'     => "Tool '{$tool_name}' is missing required 'class' definition. This may indicate the tool was not properly resolved from a callable.",
+				'tool_name' => $tool_name,
+			);
+		}
+
+		$class_name = $tool_def['class'];
+		if ( ! class_exists( $class_name ) ) {
+			return array(
+				'success'   => false,
+				'error'     => "Tool class '{$class_name}' not found",
+				'tool_name' => $tool_name,
+			);
+		}
+
+		$method = $tool_def['method'] ?? null;
+		if ( ! $method || ! method_exists( $class_name, $method ) ) {
+			return array(
+				'success'   => false,
+				'error'     => sprintf(
+					"Tool '%s' definition is missing required 'method' key or method '%s' does not exist on class '%s'.",
+					$tool_name,
+					$method ?? '(none)',
+					$class_name
+				),
+				'tool_name' => $tool_name,
+			);
+		}
+
+		$tool_handler = new $class_name();
+		return $tool_handler->$method( $parameters, $tool_def );
 	}
 
 	/**

--- a/tests/tool-executor-ability-native-smoke.php
+++ b/tests/tool-executor-ability-native-smoke.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Pure-PHP smoke test for Ability-native AI tool execution (#1480).
+ *
+ * Run with: php tests/tool-executor-ability-native-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			private string $message;
+
+			public function __construct( string $code = '', string $message = '' ) {
+				$this->message = $message;
+			}
+
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( ...$args ) {
+		}
+	}
+
+	class Ability_Native_Smoke_Ability {
+		/** @var callable */
+		private $permission_callback;
+
+		/** @var callable */
+		private $execute_callback;
+
+		public int $execute_count = 0;
+
+		public function __construct( callable $permission_callback, callable $execute_callback ) {
+			$this->permission_callback = $permission_callback;
+			$this->execute_callback    = $execute_callback;
+		}
+
+		public function check_permissions( $input = null ) {
+			return call_user_func( $this->permission_callback, $input );
+		}
+
+		public function execute( $input = null ) {
+			++$this->execute_count;
+			return call_user_func( $this->execute_callback, $input );
+		}
+	}
+
+	class WP_Abilities_Registry {
+		private static ?self $instance = null;
+
+		/** @var array<string, Ability_Native_Smoke_Ability> */
+		private array $abilities = array();
+
+		public static function get_instance(): self {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
+		}
+
+		public static function reset(): void {
+			self::$instance = new self();
+		}
+
+		public function register_for_smoke( string $slug, Ability_Native_Smoke_Ability $ability ): void {
+			$this->abilities[ $slug ] = $ability;
+		}
+
+		public function get_registered( string $slug ): ?Ability_Native_Smoke_Ability {
+			return $this->abilities[ $slug ] ?? null;
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI\Actions {
+	class ActionPolicyResolver {
+		public const MODE_CHAT        = 'chat';
+		public const POLICY_DIRECT    = 'direct';
+		public const POLICY_PREVIEW   = 'preview';
+		public const POLICY_FORBIDDEN = 'forbidden';
+
+		public function resolveForTool( array $args ): string {
+			return $args['tool_def']['action_policy'] ?? self::POLICY_DIRECT;
+		}
+	}
+}
+
+namespace DataMachine\Core\WordPress {
+	class PostTracking {
+		public static array $stored = array();
+
+		public static function extractPostId( array $tool_result ): int {
+			return (int) ( $tool_result['post_id'] ?? 0 );
+		}
+
+		public static function store( int $post_id, array $tool_def, int $job_id ): void {
+			self::$stored[] = compact( 'post_id', 'tool_def', 'job_id' );
+		}
+	}
+}
+
+namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
+	use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
+	use DataMachine\Engine\AI\Tools\ToolExecutor;
+
+	require_once dirname( __DIR__ ) . '/inc/Engine/AI/Tools/ToolParameters.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/AI/Tools/ToolExecutor.php';
+
+	$failed = 0;
+	$total  = 0;
+
+	function assert_smoke( string $name, bool $condition ): void {
+		global $failed, $total;
+		++$total;
+		if ( $condition ) {
+			echo "  PASS: {$name}\n";
+			return;
+		}
+
+		echo "  FAIL: {$name}\n";
+		++$failed;
+	}
+
+	class LegacyTool {
+		public static int $calls = 0;
+
+		public function execute( array $parameters, array $tool_def ): array {
+			++self::$calls;
+			return array(
+				'success'   => true,
+				'legacy'    => true,
+				'tool_name' => $tool_def['name'] ?? 'legacy_tool',
+				'received'  => $parameters,
+			);
+		}
+	}
+
+	function execute_tool( string $tool_name, array $tool_parameters, array $tool_def, array $payload = array() ): array {
+		return ToolExecutor::executeTool(
+			$tool_name,
+			$tool_parameters,
+			array( $tool_name => $tool_def ),
+			array_merge(
+				array(
+					'job_id' => 42,
+					'data'   => array(),
+				),
+				$payload
+			),
+			ActionPolicyResolver::MODE_CHAT
+		);
+	}
+
+	echo "=== ToolExecutor Ability-Native Smoke (#1480) ===\n";
+
+	\WP_Abilities_Registry::reset();
+	$registry = \WP_Abilities_Registry::get_instance();
+	$ability  = new \Ability_Native_Smoke_Ability(
+		fn( $input ) => isset( $input['message'] ),
+		fn( $input ) => array(
+			'success'  => true,
+			'ability'  => true,
+			'received' => $input,
+			'post_id'  => 123,
+		)
+	);
+	$registry->register_for_smoke( 'datamachine/smoke-ability', $ability );
+
+	echo "\n[ability:1] Ability-only tool executes through WP_Ability::execute()\n";
+	$result = execute_tool(
+		'ability_only_tool',
+		array( 'message' => 'hello' ),
+		array(
+			'ability'     => 'datamachine/smoke-ability',
+			'description' => 'Ability-only smoke tool',
+			'parameters'  => array(
+				'message' => array(
+					'type'     => 'string',
+					'required' => true,
+				),
+			),
+		)
+	);
+	assert_smoke( 'ability-only result succeeds', true === ( $result['success'] ?? false ) );
+	assert_smoke( 'ability execute callback ran exactly once', 1 === $ability->execute_count );
+	assert_smoke( 'AI parameter reached ability input', 'hello' === ( $result['received']['message'] ?? null ) );
+	assert_smoke( 'payload parameter reached ability input', 42 === ( $result['received']['job_id'] ?? null ) );
+	assert_smoke( 'successful ability result still participates in post tracking', 1 === count( \DataMachine\Core\WordPress\PostTracking::$stored ) );
+
+	echo "\n[legacy:1] Legacy class/method tool still executes\n";
+	LegacyTool::$calls = 0;
+	$result            = execute_tool(
+		'legacy_tool',
+		array( 'message' => 'legacy' ),
+		array(
+			'name'    => 'legacy_tool',
+			'class'   => LegacyTool::class,
+			'method'  => 'execute',
+			'ability' => 'datamachine/missing-legacy-ability',
+		)
+	);
+	assert_smoke( 'legacy result succeeds', true === ( $result['success'] ?? false ) );
+	assert_smoke( 'class/method metadata wins over linked ability during migration', true === ( $result['legacy'] ?? false ) );
+
+	echo "\n[ability:2] Missing ability returns a clear failure\n";
+	$result = execute_tool(
+		'missing_ability_tool',
+		array(),
+		array(
+			'ability' => 'datamachine/not-registered',
+		)
+	);
+	assert_smoke( 'missing ability fails', false === ( $result['success'] ?? true ) );
+	assert_smoke( 'missing ability error names the ability slug', false !== strpos( $result['error'] ?? '', 'datamachine/not-registered' ) );
+
+	echo "\n[ability:3] Permission-denied ability does not execute\n";
+	$denied = new \Ability_Native_Smoke_Ability(
+		fn( $input ) => false,
+		fn( $input ) => array( 'success' => true )
+	);
+	$registry->register_for_smoke( 'datamachine/denied-ability', $denied );
+	$result = execute_tool(
+		'denied_ability_tool',
+		array(),
+		array(
+			'ability' => 'datamachine/denied-ability',
+		)
+	);
+	assert_smoke( 'permission-denied ability fails', false === ( $result['success'] ?? true ) );
+	assert_smoke( 'permission-denied ability execute callback did not run', 0 === $denied->execute_count );
+	assert_smoke( 'permission-denied error names the ability slug', false !== strpos( $result['error'] ?? '', 'datamachine/denied-ability' ) );
+
+	echo "\nAssertions: " . ( $total - $failed ) . " passed, {$failed} failed, {$total} total\n";
+	if ( $failed > 0 ) {
+		exit( 1 );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds an Ability-native execution branch for AI tools that declare a single `ability` and do not declare legacy `class` / `method` metadata.
- Keeps legacy class/method tools as the fallback path during migration.

## Changes
- Refactors `ToolExecutor::executeTool()` so direct execution routes to either `WP_Ability::execute()` for ability-only tools or the existing class/method adapter.
- Returns clear failures for missing Abilities API, missing registered ability, WP_Error results, and permission denial.
- Adds pure-PHP smoke coverage for ability-only execution, legacy fallback, missing ability, and permission-denied behavior.

## Tests
- `php tests/tool-executor-ability-native-smoke.php`
- `php tests/ai-conversation-result-smoke.php`
- `php -l inc/Engine/AI/Tools/ToolExecutor.php && php -l tests/tool-executor-ability-native-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-ability-native-tool-execution --changed-since origin/main`

Note: full `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-ability-native-tool-execution` still reports the repository's existing broad PHPStan backlog; the changed-since lint pass is clean.

Closes #1480

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the Ability-native AI tool execution path and smoke coverage; Chris to review and test before merge.