### PR TITLE
feat(ai): compose tools from source providers

### DIFF
--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -38,9 +38,11 @@ class ToolPolicyResolver {
 	public const MODE_SYSTEM   = 'system';
 
 	private ToolManager $tool_manager;
+	private ToolSourceRegistry $tool_source_registry;
 
 	public function __construct( ?ToolManager $tool_manager = null ) {
-		$this->tool_manager = $tool_manager ?? new ToolManager();
+		$this->tool_manager         = $tool_manager ?? new ToolManager();
+		$this->tool_source_registry = new ToolSourceRegistry( $this->tool_manager );
 	}
 
 	/**
@@ -303,138 +305,7 @@ class ToolPolicyResolver {
 	 * @return array Tools array.
 	 */
 	private function gatherByMode( string $mode, array $args ): array {
-		// Pipeline has special handling for adjacent step handler tools.
-		if ( self::MODE_PIPELINE === $mode ) {
-			return $this->gatherPipelineTools( $args );
-		}
-
-		// All other modes (chat, system, and any custom modes) use the
-		// generic gatherer — filter tools by their declared modes.
-		return $this->gatherToolsForMode( $mode );
-	}
-
-	/**
-	 * Filter resolved tools by agent mode.
-	 *
-	 * @param array  $tools Resolved tools array.
-	 * @param string $mode  Mode slug to filter by (e.g. 'chat', 'pipeline').
-	 * @return array Filtered tools.
-	 */
-	private function filterByMode( array $tools, string $mode ): array {
-		return array_filter(
-			$tools,
-			function ( $tool ) use ( $mode ) {
-				$modes = $tool['modes'] ?? array();
-				return in_array( $mode, $modes, true );
-			}
-		);
-	}
-
-	/**
-	 * Pipeline mode: mode-filtered tools + handler tools from adjacent steps.
-	 *
-	 * Handler tools are resolved from the unified `datamachine_tools` registry
-	 * via {@see ToolManager::resolveHandlerTools()}. Each adjacent step contributes
-	 * the handler tools owned by its handler_slug (exact match) plus any
-	 * cross-cutting tools registered against its handler type (e.g. `skip_item`
-	 * for fetch-type handlers).
-	 */
-	private function gatherPipelineTools( array $args ): array {
-		$available_tools = array();
-		$engine_data     = $args['engine_data'] ?? array();
-
-		// Handler tools from adjacent steps (dynamic, resolved per-execution).
-		//
-		// Reads every configured handler through FlowStepConfig's cardinality-
-		// agnostic helper because adjacent steps can be single-handler (fetch)
-		// or true multi-handler (publish/upsert). The AI must see tools for
-		// every adjacent handler, not just the primary.
-		foreach ( array( $args['previous_step_config'] ?? null, $args['next_step_config'] ?? null ) as $step_config ) {
-			if ( ! $step_config ) {
-				continue;
-			}
-
-			$handler_slugs = FlowStepConfig::getConfiguredHandlerSlugs( $step_config );
-			$cache_scope   = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
-
-			foreach ( $handler_slugs as $slug ) {
-				$handler_config = FlowStepConfig::getHandlerConfigForSlug( $step_config, $slug );
-				$tools          = $this->tool_manager->resolveHandlerTools(
-					$slug,
-					$handler_config,
-					$engine_data,
-					$cache_scope
-				);
-
-				foreach ( $tools as $tool_name => $tool_config ) {
-					$available_tools[ $tool_name ] = $tool_config;
-				}
-			}
-		}
-
-		// Static registry tools filtered for 'pipeline' mode.
-		$all_tools      = $this->tool_manager->get_all_tools();
-		$pipeline_tools = $this->filterByMode( $all_tools, self::MODE_PIPELINE );
-
-		foreach ( $pipeline_tools as $tool_name => $tool_config ) {
-			if ( ! is_array( $tool_config ) ) {
-				continue;
-			}
-			// Skip handler tool registry wrappers — those are resolved above.
-			if ( isset( $tool_config['_handler_callable'] ) ) {
-				continue;
-			}
-			// Handler-scoped tools carry flow-specific config and completion
-			// metadata. If a global pipeline tool uses the same name, keep the
-			// adjacent handler definition so downstream steps can detect that the
-			// required handler tool actually ran.
-			if ( isset( $available_tools[ $tool_name ] ) ) {
-				continue;
-			}
-			if ( $this->tool_manager->is_tool_available( $tool_name, null ) ) {
-				$available_tools[ $tool_name ] = $tool_config;
-			}
-		}
-
-		return $available_tools;
-	}
-
-	/**
-	 * Gather tools for any mode slug.
-	 *
-	 * Filters the tool registry by declared modes, then applies availability
-	 * and enablement checks. Works with built-in modes (chat, system) and
-	 * any custom mode — third parties can register tools with custom mode
-	 * slugs and resolve them through the same path.
-	 *
-	 * @param string $mode Mode slug to filter by (e.g. 'chat', 'system', 'automation').
-	 * @return array Available tools for this mode.
-	 */
-	private function gatherToolsForMode( string $mode ): array {
-		$available_tools = array();
-
-		$all_tools  = $this->tool_manager->get_all_tools();
-		$mode_tools = $this->filterByMode( $all_tools, $mode );
-
-		foreach ( $mode_tools as $tool_name => $tool_config ) {
-			if ( ! is_array( $tool_config ) || empty( $tool_config ) ) {
-				continue;
-			}
-
-			// Tools with requires_config go through availability checks.
-			// Tools without it are always available unless globally disabled.
-			if ( ! empty( $tool_config['requires_config'] ) ) {
-				if ( ! $this->tool_manager->is_tool_available( $tool_name, null ) ) {
-					continue;
-				}
-			} elseif ( ! $this->tool_manager->is_globally_enabled( $tool_name ) ) {
-				continue;
-			}
-
-			$available_tools[ $tool_name ] = $tool_config;
-		}
-
-		return $available_tools;
+		return $this->tool_source_registry->gather( $mode, $args );
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/ToolSourceRegistry.php
+++ b/inc/Engine/AI/Tools/ToolSourceRegistry.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Tool source registry.
+ *
+ * Composes tool definitions from named sources before policy filtering.
+ *
+ * @package DataMachine\Engine\AI\Tools
+ */
+
+namespace DataMachine\Engine\AI\Tools;
+
+use DataMachine\Core\Steps\FlowStepConfig;
+
+defined( 'ABSPATH' ) || exit;
+
+class ToolSourceRegistry {
+
+	public const SOURCE_STATIC_REGISTRY   = 'static_registry';
+	public const SOURCE_ADJACENT_HANDLERS = 'adjacent_handlers';
+
+	private ToolManager $tool_manager;
+
+	public function __construct( ToolManager $tool_manager ) {
+		$this->tool_manager = $tool_manager;
+	}
+
+	/**
+	 * Gather tools from the sources configured for a mode.
+	 *
+	 * @param string $mode Agent mode slug.
+	 * @param array  $args Full resolution arguments.
+	 * @return array Tools keyed by tool name.
+	 */
+	public function gather( string $mode, array $args ): array {
+		$tools   = array();
+		$sources = $this->getRegisteredSources( $mode, $args );
+
+		foreach ( $this->getSourcesForMode( $mode, $args ) as $source_slug ) {
+			$source_tools = $this->gatherFromSource( $source_slug, $mode, $args, $sources );
+
+			foreach ( $source_tools as $tool_name => $tool_config ) {
+				if ( isset( $tools[ $tool_name ] ) ) {
+					continue;
+				}
+
+				$tools[ $tool_name ] = $tool_config;
+			}
+		}
+
+		return $tools;
+	}
+
+	/**
+	 * Return registered tool sources.
+	 *
+	 * @param string $mode Agent mode slug.
+	 * @param array  $args Full resolution arguments.
+	 * @return array<string, callable> Source callbacks keyed by source slug.
+	 */
+	private function getRegisteredSources( string $mode, array $args ): array {
+		$sources = apply_filters(
+			'datamachine_tool_sources',
+			array(
+				self::SOURCE_STATIC_REGISTRY   => array( $this, 'gatherStaticRegistryTools' ),
+				self::SOURCE_ADJACENT_HANDLERS => array( $this, 'gatherAdjacentHandlerTools' ),
+			),
+			$mode,
+			$args,
+			$this->tool_manager
+		);
+
+		return is_array( $sources ) ? $sources : array();
+	}
+
+	/**
+	 * Return source slugs for a mode.
+	 *
+	 * @param string $mode Agent mode slug.
+	 * @param array  $args Full resolution arguments.
+	 * @return array<int, string> Source slugs in precedence order.
+	 */
+	private function getSourcesForMode( string $mode, array $args ): array {
+		$sources = ToolPolicyResolver::MODE_PIPELINE === $mode
+			? array( self::SOURCE_ADJACENT_HANDLERS, self::SOURCE_STATIC_REGISTRY )
+			: array( self::SOURCE_STATIC_REGISTRY );
+
+		$sources = apply_filters( 'datamachine_tool_sources_for_mode', $sources, $mode, $args );
+
+		if ( ! is_array( $sources ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				$sources,
+				static fn( $source ) => is_string( $source ) && '' !== $source
+			)
+		);
+	}
+
+	/**
+	 * Gather tools from one source.
+	 *
+	 * @param string $source_slug Source slug.
+	 * @param string $mode        Agent mode slug.
+	 * @param array  $args        Full resolution arguments.
+	 * @param array  $sources     Registered source callbacks keyed by source slug.
+	 * @return array Tools keyed by tool name.
+	 */
+	private function gatherFromSource( string $source_slug, string $mode, array $args, array $sources ): array {
+		$source = $sources[ $source_slug ] ?? null;
+		if ( ! is_callable( $source ) ) {
+			return array();
+		}
+
+		$tools = call_user_func( $source, $mode, $args, $this->tool_manager );
+
+		return is_array( $tools ) ? $tools : array();
+	}
+
+	/**
+	 * Gather mode-filtered tools from the static registry.
+	 *
+	 * @param string $mode Agent mode slug.
+	 * @return array Tools keyed by tool name.
+	 */
+	public function gatherStaticRegistryTools( string $mode ): array {
+		$available_tools = array();
+		$all_tools       = $this->tool_manager->get_all_tools();
+		$mode_tools      = $this->filterByMode( $all_tools, $mode );
+
+		foreach ( $mode_tools as $tool_name => $tool_config ) {
+			if ( ! is_array( $tool_config ) || empty( $tool_config ) ) {
+				continue;
+			}
+
+			if ( ToolPolicyResolver::MODE_PIPELINE === $mode ) {
+				if ( isset( $tool_config['_handler_callable'] ) ) {
+					continue;
+				}
+
+				if ( $this->tool_manager->is_tool_available( $tool_name, null ) ) {
+					$available_tools[ $tool_name ] = $tool_config;
+				}
+
+				continue;
+			}
+
+			// Tools with requires_config go through availability checks.
+			// Tools without it are always available unless globally disabled.
+			if ( ! empty( $tool_config['requires_config'] ) ) {
+				if ( ! $this->tool_manager->is_tool_available( $tool_name, null ) ) {
+					continue;
+				}
+			} elseif ( ! $this->tool_manager->is_globally_enabled( $tool_name ) ) {
+				continue;
+			}
+
+			$available_tools[ $tool_name ] = $tool_config;
+		}
+
+		return $available_tools;
+	}
+
+	/**
+	 * Gather handler tools from adjacent pipeline steps.
+	 *
+	 * @param string $mode Agent mode slug.
+	 * @param array  $args Full resolution arguments.
+	 * @return array Tools keyed by tool name.
+	 */
+	public function gatherAdjacentHandlerTools( string $mode, array $args ): array {
+		if ( ToolPolicyResolver::MODE_PIPELINE !== $mode ) {
+			return array();
+		}
+
+		$available_tools = array();
+		$engine_data     = $args['engine_data'] ?? array();
+
+		foreach ( array( $args['previous_step_config'] ?? null, $args['next_step_config'] ?? null ) as $step_config ) {
+			if ( ! $step_config ) {
+				continue;
+			}
+
+			$handler_slugs = FlowStepConfig::getConfiguredHandlerSlugs( $step_config );
+			$cache_scope   = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
+
+			foreach ( $handler_slugs as $slug ) {
+				$handler_config = FlowStepConfig::getHandlerConfigForSlug( $step_config, $slug );
+				$tools          = $this->tool_manager->resolveHandlerTools(
+					$slug,
+					$handler_config,
+					$engine_data,
+					$cache_scope
+				);
+
+				foreach ( $tools as $tool_name => $tool_config ) {
+					$available_tools[ $tool_name ] = $tool_config;
+				}
+			}
+		}
+
+		return $available_tools;
+	}
+
+	/**
+	 * Filter resolved tools by agent mode.
+	 *
+	 * @param array  $tools Resolved tools array.
+	 * @param string $mode  Mode slug to filter by.
+	 * @return array Filtered tools.
+	 */
+	private function filterByMode( array $tools, string $mode ): array {
+		return array_filter(
+			$tools,
+			static function ( $tool ) use ( $mode ) {
+				$modes = $tool['modes'] ?? array();
+				return in_array( $mode, $modes, true );
+			}
+		);
+	}
+}

--- a/tests/adjacent-handler-tool-policy-smoke.php
+++ b/tests/adjacent-handler-tool-policy-smoke.php
@@ -36,6 +36,7 @@ namespace {
 	}
 
 	require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+	require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 	require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 
 	$failures = array();

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -61,6 +61,7 @@ require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
 require_once __DIR__ . '/../inc/Core/Steps/WorkflowConfigFactory.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 
 use DataMachine\Core\Steps\WorkflowConfigFactory;

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Pure-PHP smoke test for tool source provider composition (#1481).
+ *
+ * Run with: php tests/tool-source-registry-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$__filters = array();
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['__filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function remove_all_filters_for_source_smoke(): void {
+	$GLOBALS['__filters'] = array();
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	if ( 'datamachine_step_types' === $hook && empty( $GLOBALS['__filters'][ $hook ] ) ) {
+		return array(
+			'ai'      => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'fetch'   => array( 'uses_handler' => true, 'multi_handler' => false ),
+			'publish' => array( 'uses_handler' => true, 'multi_handler' => true ),
+			'upsert'  => array( 'uses_handler' => true, 'multi_handler' => true ),
+		);
+	}
+
+	if ( empty( $GLOBALS['__filters'][ $hook ] ) ) {
+		return $value;
+	}
+
+	ksort( $GLOBALS['__filters'][ $hook ] );
+	foreach ( $GLOBALS['__filters'][ $hook ] as $callbacks ) {
+		foreach ( $callbacks as $entry ) {
+			$callback      = $entry[0];
+			$accepted_args = $entry[1];
+			$call_args     = array_slice( array_merge( array( $value ), $args ), 0, $accepted_args );
+			$value         = $callback( ...$call_args );
+		}
+	}
+
+	return $value;
+}
+
+function do_action( string $hook, ...$args ): void {}
+
+function did_action( string $hook ): int {
+	return 1;
+}
+
+function current_action(): string {
+	return '';
+}
+
+function get_option( string $key, $default = false ) {
+	return $default;
+}
+
+class WP_Abilities_Registry {
+	public static function get_instance(): self {
+		return new self();
+	}
+
+	public function get_registered( string $slug ) {
+		return null;
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/PluginSettings.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
+
+use DataMachine\Engine\AI\Tools\ToolManager;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
+
+class SourcePolicyToolManager extends ToolManager {
+	/** @var array<int, string> */
+	public array $handler_calls = array();
+
+	public function get_all_tools(): array {
+		return array(
+			'collision_tool'       => array( 'modes' => array( 'pipeline' ), 'origin' => 'static' ),
+			'static_pipeline_tool' => array( 'modes' => array( 'pipeline' ), 'origin' => 'static' ),
+			'chat_static_tool'     => array( 'modes' => array( 'chat' ), 'origin' => 'static', 'access_level' => 'public' ),
+			'system_static_tool'   => array( 'modes' => array( 'system' ), 'origin' => 'static' ),
+			'custom_static_tool'   => array( 'modes' => array( 'custom_mode' ), 'origin' => 'static' ),
+			'handler_wrapper'      => array( 'modes' => array( 'pipeline' ), '_handler_callable' => 'noop' ),
+			'disabled_static_tool' => array( 'modes' => array( 'chat' ), 'origin' => 'static', 'access_level' => 'public' ),
+		);
+	}
+
+	public function is_tool_available( string $tool_id, ?string $context_id = null ): bool {
+		return 'disabled_static_tool' !== $tool_id;
+	}
+
+	public function is_globally_enabled( string $tool_id ): bool {
+		return 'disabled_static_tool' !== $tool_id;
+	}
+
+	public function resolveHandlerTools( string $handler_slug, array $handler_config, array $engine_data, string $cache_scope = '' ): array {
+		$this->handler_calls[] = $handler_slug . ':' . (string) ( $handler_config['marker'] ?? '' ) . ':' . $cache_scope;
+
+		if ( 'publish_to_wordpress' === $handler_slug ) {
+			return array(
+				'collision_tool'  => array( 'handler' => $handler_slug, 'origin' => 'adjacent' ),
+				'adjacent_publish' => array( 'handler' => $handler_slug, 'origin' => 'adjacent' ),
+			);
+		}
+
+		if ( 'ticketmaster_fetch' === $handler_slug ) {
+			return array(
+				'adjacent_fetch' => array( 'handler' => $handler_slug, 'origin' => 'adjacent' ),
+			);
+		}
+
+		return array();
+	}
+}
+
+$failures = array();
+$passes   = 0;
+
+function assert_source_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function resolve_source_tools( string $mode, SourcePolicyToolManager $manager, array $extra = array() ): array {
+	$resolver = new ToolPolicyResolver( $manager );
+
+	return $resolver->resolve(
+		array_merge(
+			array(
+				'mode'                 => $mode,
+				'agent_id'             => 0,
+				'previous_step_config' => null,
+				'next_step_config'     => null,
+				'engine_data'          => array(),
+				'categories'           => array(),
+			),
+			$extra
+		)
+	);
+}
+
+echo "tool-source-registry-smoke\n";
+
+echo "\n[1] pipeline composes adjacent handlers before static registry:\n";
+$manager = new SourcePolicyToolManager();
+$tools   = resolve_source_tools(
+	ToolPolicyResolver::MODE_PIPELINE,
+	$manager,
+	array(
+		'previous_step_config' => array(
+			'flow_step_id'   => 'fetch_step',
+			'step_type'      => 'fetch',
+			'handler_slug'   => 'ticketmaster_fetch',
+			'handler_config' => array( 'marker' => 'previous' ),
+		),
+		'next_step_config'     => array(
+			'flow_step_id'     => 'publish_step',
+			'step_type'        => 'publish',
+			'handler_slugs'    => array( 'publish_to_wordpress' ),
+			'handler_configs'  => array( 'publish_to_wordpress' => array( 'marker' => 'next' ) ),
+			'enabled_handlers' => array( 'publish_to_wordpress' ),
+		),
+	)
+);
+assert_source_equals( array( 'adjacent_fetch', 'collision_tool', 'adjacent_publish', 'static_pipeline_tool' ), array_keys( $tools ), 'pipeline source order is deterministic', $failures, $passes );
+assert_source_equals( 'adjacent', $tools['collision_tool']['origin'] ?? '', 'adjacent handler tool wins static name collision', $failures, $passes );
+assert_source_equals( false, isset( $tools['handler_wrapper'] ), 'pipeline static source skips handler wrappers', $failures, $passes );
+assert_source_equals( array( 'ticketmaster_fetch:previous:fetch_step', 'publish_to_wordpress:next:publish_step' ), $manager->handler_calls, 'adjacent handler source receives configs and cache scopes', $failures, $passes );
+
+echo "\n[2] non-pipeline modes use static registry only:\n";
+$manager = new SourcePolicyToolManager();
+assert_source_equals( array( 'chat_static_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_CHAT, $manager ) ), 'chat mode gets static chat tools only', $failures, $passes );
+assert_source_equals( array(), $manager->handler_calls, 'chat mode does not query adjacent handlers', $failures, $passes );
+assert_source_equals( array( 'system_static_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_SYSTEM, new SourcePolicyToolManager() ) ), 'system mode gets static system tools only', $failures, $passes );
+assert_source_equals( array( 'custom_static_tool' ), array_keys( resolve_source_tools( 'custom_mode', new SourcePolicyToolManager() ) ), 'custom mode gets static custom-mode tools only', $failures, $passes );
+
+echo "\n[3] filters can add a source without disturbing default order:\n";
+remove_all_filters_for_source_smoke();
+add_filter(
+	'datamachine_tool_sources',
+	static function ( array $sources ): array {
+		$sources['extra_source'] = static function (): array {
+			return array(
+				'extra_tool' => array( 'origin' => 'extra', 'access_level' => 'public' ),
+			);
+		};
+		return $sources;
+	},
+	10,
+	4
+);
+add_filter(
+	'datamachine_tool_sources_for_mode',
+	static function ( array $sources, string $mode ): array {
+		if ( ToolPolicyResolver::MODE_CHAT === $mode ) {
+			$sources[] = 'extra_source';
+		}
+		return $sources;
+	},
+	10,
+	3
+);
+$tools = resolve_source_tools( ToolPolicyResolver::MODE_CHAT, new SourcePolicyToolManager() );
+assert_source_equals( array( 'chat_static_tool', 'extra_tool' ), array_keys( $tools ), 'filter appends extra source after static source', $failures, $passes );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " tool source assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} tool source assertions passed.\n";

--- a/tests/upsert-handler-result-handoff-smoke.php
+++ b/tests/upsert-handler-result-handoff-smoke.php
@@ -59,6 +59,7 @@ require_once __DIR__ . '/../inc/Core/Steps/QueueableTrait.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Engine/AI/ConversationManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolResultFinder.php';
 require_once __DIR__ . '/../inc/Core/Steps/AI/AIStep.php';


### PR DESCRIPTION
## Summary
- Extracts tool gathering from `ToolPolicyResolver` into a composable `ToolSourceRegistry`.
- Preserves current pipeline behavior by composing adjacent handler tools before static registry tools.
- Keeps chat, system, and custom modes on static registry tools only by default.

## Changes
- Adds built-in `static_registry` and `adjacent_handlers` tool sources.
- Adds filters for registered sources and mode-to-source selection.
- Adds smoke coverage for provider order, static-only non-pipeline modes, adjacent/static name collisions, and filter-added sources.

## Tests
- `php -l inc/Engine/AI/Tools/ToolSourceRegistry.php`
- `php -l inc/Engine/AI/Tools/ToolPolicyResolver.php`
- `php tests/tool-source-registry-smoke.php`
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `php tests/adjacent-handler-tool-policy-smoke.php`
- `php tests/upsert-handler-result-handoff-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@feat-tool-source-providers --skip-lint --changed-since origin/main --json-summary`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-tool-source-providers --changed-only --summary` reports no baseline drift, but the wrapper still exits non-zero from the existing ESLint Unknown findings on the PHP-only changed-file scope.

Closes #1481

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Extracted Data Machine tool gathering into composable source providers and added smoke coverage; Chris to review and test before merge.