### PR TITLE
feat(ai): add runtime tool declaration validator

### DIFF
--- a/inc/Engine/AI/Tools/RuntimeToolDeclaration.php
+++ b/inc/Engine/AI/Tools/RuntimeToolDeclaration.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Runtime tool declaration validator.
+ *
+ * Runtime tools are declared by a client or transport for one agent run and
+ * are executed outside Data Machine. This class only validates the declaration
+ * shape; it intentionally does not register, expose, or execute those tools.
+ *
+ * @package DataMachine\Engine\AI\Tools
+ */
+
+namespace DataMachine\Engine\AI\Tools;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Validates scoped runtime tool declarations before policy integration.
+ */
+class RuntimeToolDeclaration {
+
+	public const SOURCE_CLIENT  = 'client';
+	public const EXECUTOR_CLIENT = 'client';
+	public const SCOPE_RUN      = 'run';
+
+	/**
+	 * Normalize a runtime tool declaration or throw a field-scoped error.
+	 *
+	 * @param array $declaration Raw runtime tool declaration.
+	 * @return array Normalized declaration.
+	 */
+	public static function normalize( array $declaration ): array {
+		$errors = self::validate( $declaration );
+		if ( ! empty( $errors ) ) {
+			throw new \InvalidArgumentException(
+				'invalid_runtime_tool_declaration: ' . implode( ', ', $errors )
+			);
+		}
+
+		$name   = (string) $declaration['name'];
+		$source = self::sourceFromName( $name );
+
+		return array(
+			'name'        => $name,
+			'source'      => $source,
+			'description' => trim( (string) $declaration['description'] ),
+			'parameters'  => $declaration['parameters'] ?? array(),
+			'executor'    => self::EXECUTOR_CLIENT,
+			'scope'       => self::SCOPE_RUN,
+		);
+	}
+
+	/**
+	 * Validate a runtime tool declaration without throwing.
+	 *
+	 * @param array $declaration Raw runtime tool declaration.
+	 * @return string[] Machine-readable invalid field names.
+	 */
+	public static function validate( array $declaration ): array {
+		$errors = array();
+
+		$name = $declaration['name'] ?? null;
+		if (
+			! is_string( $name )
+			|| '' === $name
+			|| ! preg_match( '/^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/', $name )
+		) {
+			$errors[] = 'name';
+		}
+
+		$source = is_string( $name ) ? self::sourceFromName( $name ) : '';
+		if ( self::SOURCE_CLIENT !== $source ) {
+			$errors[] = 'source';
+		}
+
+		if (
+			isset( $declaration['source'] )
+			&& $declaration['source'] !== $source
+		) {
+			$errors[] = 'source';
+		}
+
+		$description = $declaration['description'] ?? null;
+		if ( ! is_string( $description ) || '' === trim( $description ) ) {
+			$errors[] = 'description';
+		}
+
+		if (
+			isset( $declaration['parameters'] )
+			&& ! is_array( $declaration['parameters'] )
+		) {
+			$errors[] = 'parameters';
+		}
+
+		if ( ( $declaration['executor'] ?? null ) !== self::EXECUTOR_CLIENT ) {
+			$errors[] = 'executor';
+		}
+
+		if ( ( $declaration['scope'] ?? null ) !== self::SCOPE_RUN ) {
+			$errors[] = 'scope';
+		}
+
+		return array_values( array_unique( $errors ) );
+	}
+
+	/**
+	 * Build a namespaced runtime tool name.
+	 *
+	 * @param string $source Runtime tool source slug.
+	 * @param string $tool_slug Tool slug local to the source.
+	 * @return string Namespaced tool name.
+	 */
+	public static function namespacedName( string $source, string $tool_slug ): string {
+		return $source . '/' . $tool_slug;
+	}
+
+	/**
+	 * Extract the source prefix from a namespaced runtime tool name.
+	 *
+	 * @param string $name Runtime tool name.
+	 * @return string Source prefix, or empty string when unnamespaced.
+	 */
+	public static function sourceFromName( string $name ): string {
+		$parts = explode( '/', $name, 2 );
+		return count( $parts ) === 2 ? $parts[0] : '';
+	}
+}

--- a/inc/Engine/AI/Tools/RuntimeToolDeclaration.php
+++ b/inc/Engine/AI/Tools/RuntimeToolDeclaration.php
@@ -16,11 +16,12 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Validates scoped runtime tool declarations before policy integration.
  */
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
 class RuntimeToolDeclaration {
 
-	public const SOURCE_CLIENT  = 'client';
+	public const SOURCE_CLIENT   = 'client';
 	public const EXECUTOR_CLIENT = 'client';
-	public const SCOPE_RUN      = 'run';
+	public const SCOPE_RUN       = 'run';
 
 	/**
 	 * Normalize a runtime tool declaration or throw a field-scoped error.
@@ -31,8 +32,13 @@ class RuntimeToolDeclaration {
 	public static function normalize( array $declaration ): array {
 		$errors = self::validate( $declaration );
 		if ( ! empty( $errors ) ) {
+			$message = sprintf(
+				'invalid_runtime_tool_declaration: %s',
+				implode( ', ', self::sanitizeErrorKeys( $errors ) )
+			);
+
 			throw new \InvalidArgumentException(
-				'invalid_runtime_tool_declaration: ' . implode( ', ', $errors )
+				$message
 			);
 		}
 
@@ -122,5 +128,21 @@ class RuntimeToolDeclaration {
 	public static function sourceFromName( string $name ): string {
 		$parts = explode( '/', $name, 2 );
 		return count( $parts ) === 2 ? $parts[0] : '';
+	}
+
+	/**
+	 * Sanitize validator field names without requiring WordPress functions.
+	 *
+	 * @param string[] $errors Raw validator field names.
+	 * @return string[] Sanitized field names.
+	 */
+	private static function sanitizeErrorKeys( array $errors ): array {
+		return array_map(
+			static function ( string $error ): string {
+				$sanitized = preg_replace( '/[^a-z0-9_-]/', '', strtolower( $error ) );
+				return is_string( $sanitized ) ? $sanitized : '';
+			},
+			$errors
+		);
 	}
 }

--- a/tests/runtime-tool-declaration-smoke.php
+++ b/tests/runtime-tool-declaration-smoke.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Pure-PHP smoke tests for runtime tool declaration validation.
+ *
+ * Run with: php tests/runtime-tool-declaration-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+use DataMachine\Engine\AI\Tools\RuntimeToolDeclaration;
+
+function datamachine_runtime_tool_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+$assertions = 0;
+
+$valid = array(
+	'name'        => 'client/select_block',
+	'description' => 'Select a block in the active editor.',
+	'parameters'  => array(
+		'type'       => 'object',
+		'properties' => array(
+			'client_id' => array( 'type' => 'string' ),
+		),
+	),
+	'executor'    => 'client',
+	'scope'       => 'run',
+);
+
+$normalized = RuntimeToolDeclaration::normalize( $valid );
+datamachine_runtime_tool_assert(
+	'client' === $normalized['source'],
+	'Valid client source should be derived from namespaced name.'
+);
+++$assertions;
+datamachine_runtime_tool_assert(
+	'run' === $normalized['scope'],
+	'Valid runtime tool should preserve run scope.'
+);
+++$assertions;
+datamachine_runtime_tool_assert(
+	'client' === $normalized['executor'],
+	'Valid runtime tool should preserve client executor.'
+);
+++$assertions;
+datamachine_runtime_tool_assert(
+	$valid['parameters'] === $normalized['parameters'],
+	'Valid runtime tool should preserve parameter schema.'
+);
+++$assertions;
+
+$with_source = $valid;
+$with_source['source'] = 'client';
+datamachine_runtime_tool_assert(
+	array() === RuntimeToolDeclaration::validate( $with_source ),
+	'Explicit matching source should pass validation.'
+);
+++$assertions;
+
+$forbidden_server_source = $valid;
+$forbidden_server_source['name'] = 'server/select_block';
+datamachine_runtime_tool_assert(
+	array( 'source' ) === RuntimeToolDeclaration::validate( $forbidden_server_source ),
+	'Unknown runtime tool source should be forbidden by default.'
+);
+++$assertions;
+
+$forbidden_transport_source = $valid;
+$forbidden_transport_source['name'] = 'mcp/select_block';
+datamachine_runtime_tool_assert(
+	array( 'source' ) === RuntimeToolDeclaration::validate( $forbidden_transport_source ),
+	'Transport-specific runtime tool source should be forbidden by default.'
+);
+++$assertions;
+
+$mismatched_source = $valid;
+$mismatched_source['source'] = 'browser';
+datamachine_runtime_tool_assert(
+	array( 'source' ) === RuntimeToolDeclaration::validate( $mismatched_source ),
+	'Explicit source must match the name prefix.'
+);
+++$assertions;
+
+$missing_executor = $valid;
+unset( $missing_executor['executor'] );
+datamachine_runtime_tool_assert(
+	array( 'executor' ) === RuntimeToolDeclaration::validate( $missing_executor ),
+	'Runtime tool executor is required and must be client.'
+);
+++$assertions;
+
+$server_executor = $valid;
+$server_executor['executor'] = 'server';
+datamachine_runtime_tool_assert(
+	array( 'executor' ) === RuntimeToolDeclaration::validate( $server_executor ),
+	'Server executor is forbidden until Ability-native execution lands.'
+);
+++$assertions;
+
+$job_scope = $valid;
+$job_scope['scope'] = 'job';
+datamachine_runtime_tool_assert(
+	array( 'scope' ) === RuntimeToolDeclaration::validate( $job_scope ),
+	'Only run-scoped declarations are accepted.'
+);
+++$assertions;
+
+$bad_parameters = $valid;
+$bad_parameters['parameters'] = 'not a schema';
+datamachine_runtime_tool_assert(
+	array( 'parameters' ) === RuntimeToolDeclaration::validate( $bad_parameters ),
+	'Parameters must be an array schema.'
+);
+++$assertions;
+
+$bad_name = $valid;
+$bad_name['name'] = 'select_block';
+datamachine_runtime_tool_assert(
+	array( 'name', 'source' ) === RuntimeToolDeclaration::validate( $bad_name ),
+	'Runtime tool names must be source/tool namespaced.'
+);
+++$assertions;
+
+try {
+	RuntimeToolDeclaration::normalize( $server_executor );
+	throw new RuntimeException( 'normalize() should reject forbidden executors.' );
+} catch ( InvalidArgumentException $e ) {
+	datamachine_runtime_tool_assert(
+		str_contains( $e->getMessage(), 'invalid_runtime_tool_declaration: executor' ),
+		'normalize() should throw a machine-readable executor error.'
+	);
+	++$assertions;
+}
+
+datamachine_runtime_tool_assert(
+	'client/select_block' === RuntimeToolDeclaration::namespacedName( 'client', 'select_block' ),
+	'namespacedName() should build source/tool names.'
+);
+++$assertions;
+
+echo 'Runtime tool declaration smoke passed (' . $assertions . " assertions).\n";


### PR DESCRIPTION
## Summary
- Adds a standalone `RuntimeToolDeclaration` validator/value object for future run-scoped client-declared tools.
- Documents safe defaults now: only `client/*` source names, `executor=client`, and `scope=run` validate; server/MCP/unknown sources remain forbidden until the provider/run-state work lands.
- Adds a pure-PHP smoke test for valid normalization, namespacing, and forbidden-by-default cases.

## Tests
- `php tests/runtime-tool-declaration-smoke.php`
- `homeboy lint data-machine --path "/Users/chubes/Developer/data-machine@prep-client-runtime-tools" --changed-since origin/main` — PHPCS passed; command still exits non-zero because Homeboy ESLint attempts to parse changed PHP files, but reports `No change from baseline` and no lint drift.

## Notes
- No integration with `ToolPolicyResolver`, `AIConversationLoop`, `RequestBuilder`, or `ToolExecutor`.
- Runtime execution remains blocked on #1480, #1481, and #1483.

Refs #1485.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Scouted scoped client-declared runtime tools and implemented a tiny preparatory validator; Chris to review before merge.
