### PR TITLE
feat(ai): add loop event sink contract

### DIFF
--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -104,7 +104,7 @@ class AIConversationLoop {
 			return self::normalizeResultForRun( $result, $messages );
 		}
 
-		$loop = new self();
+		$loop   = new self();
 		$result = $loop->execute(
 			$messages,
 			$tools,
@@ -187,6 +187,8 @@ class AIConversationLoop {
 		$last_tool_calls        = array();
 		$tool_execution_results = array();
 		$last_request_metadata  = array();
+		$event_sink             = self::resolveEventSink( $payload );
+		$loop_payload           = self::payloadWithoutEventSink( $payload );
 
 		// Accumulate token usage across all turns.
 		$total_usage = array(
@@ -199,15 +201,15 @@ class AIConversationLoop {
 		// In pipeline mode, conversation should only complete when all handlers
 		// required by the adjacent step have fired, not just the first one.
 		$executed_handler_slugs = array();
-		$configured_handlers    = $payload['configured_handler_slugs'] ?? array();
+		$configured_handlers    = $loop_payload['configured_handler_slugs'] ?? array();
 		$configured_handlers    = is_array( $configured_handlers ) ? array_values( $configured_handlers ) : array();
 
 		// Build base log metadata from payload for consistent logging.
 		$base_log_context = array_filter(
 			array(
 				'mode'         => $mode,
-				'job_id'       => $payload['job_id'] ?? null,
-				'flow_step_id' => $payload['flow_step_id'] ?? null,
+				'job_id'       => $loop_payload['job_id'] ?? null,
+				'flow_step_id' => $loop_payload['flow_step_id'] ?? null,
 			),
 			fn( $v ) => null !== $v
 		);
@@ -216,16 +218,45 @@ class AIConversationLoop {
 			$turn_budget->increment();
 			$turn_count = $turn_budget->current();
 
+			self::emitLoopEvent(
+				$event_sink,
+				'turn_started',
+				array_merge(
+					$base_log_context,
+					array(
+						'turn_count'    => $turn_count,
+						'provider'      => $provider,
+						'model'         => $model,
+						'message_count' => count( $messages ),
+						'tool_count'    => count( $tools ),
+					)
+				)
+			);
+
 			// Build AI request using centralized RequestBuilder
-			$ai_response = RequestBuilder::build(
+			$ai_response           = RequestBuilder::build(
 				$messages,
 				$provider,
 				$model,
 				$tools,
 				$mode,
-				$payload
+				$loop_payload
 			);
 			$last_request_metadata = is_array( $ai_response['request_metadata'] ?? null ) ? $ai_response['request_metadata'] : array();
+			self::emitLoopEvent(
+				$event_sink,
+				'request_built',
+				array_merge(
+					$base_log_context,
+					array(
+						'turn_count'       => $turn_count,
+						'provider'         => $provider,
+						'model'            => $model,
+						'success'          => (bool) ( $ai_response['success'] ?? false ),
+						'request_metadata' => $last_request_metadata,
+					)
+				)
+			);
 
 			// Handle AI request failure
 			if ( ! $ai_response['success'] ) {
@@ -244,12 +275,12 @@ class AIConversationLoop {
 				);
 
 				$failure_result = array(
-					'messages'        => $messages,
-					'final_content'   => '',
-					'turn_count'      => $turn_count,
-					'completed'       => false,
-					'last_tool_calls' => array(),
-					'error'           => $ai_response['error'] ?? 'AI request failed',
+					'messages'         => $messages,
+					'final_content'    => '',
+					'turn_count'       => $turn_count,
+					'completed'        => false,
+					'last_tool_calls'  => array(),
+					'error'            => $ai_response['error'] ?? 'AI request failed',
 					'usage'            => $total_usage,
 					'request_metadata' => $last_request_metadata,
 				);
@@ -261,12 +292,25 @@ class AIConversationLoop {
 					$messages,
 					$provider,
 					$model,
-					$payload,
+					$loop_payload,
 					$failure_result
 				);
 				if ( '' !== $transcript_session_id ) {
 					$failure_result['transcript_session_id'] = $transcript_session_id;
 				}
+
+				self::emitLoopEvent(
+					$event_sink,
+					'failed',
+					array_merge(
+						$base_log_context,
+						array(
+							'turn_count' => $turn_count,
+							'provider'   => $ai_response['provider'] ?? $provider,
+							'error'      => $failure_result['error'],
+						)
+					)
+				);
 
 				return $failure_result;
 			}
@@ -293,7 +337,7 @@ class AIConversationLoop {
 				$messages[] = $ai_message;
 
 				// Fire hook for AI response events (used for system operations like title generation)
-				do_action( 'datamachine_ai_response_received', $mode, $messages, $payload );
+				do_action( 'datamachine_ai_response_received', $mode, $messages, $loop_payload );
 			}
 
 			// Process tool calls
@@ -330,6 +374,18 @@ class AIConversationLoop {
 								'turn'   => $turn_count,
 								'tool'   => $tool_name,
 								'params' => $tool_parameters,
+							)
+						)
+					);
+					self::emitLoopEvent(
+						$event_sink,
+						'tool_call',
+						array_merge(
+							$base_log_context,
+							array(
+								'turn_count' => $turn_count,
+								'tool_name'  => $tool_name,
+								'parameters' => $tool_parameters,
 							)
 						)
 					);
@@ -376,10 +432,10 @@ class AIConversationLoop {
 						$tool_name,
 						$tool_parameters,
 						$tools,
-						$payload,
+						$loop_payload,
 						$mode,
-						(int) ( $payload['agent_id'] ?? 0 ),
-						is_array( $payload['client_context'] ?? null ) ? $payload['client_context'] : array()
+						(int) ( $loop_payload['agent_id'] ?? 0 ),
+						is_array( $loop_payload['client_context'] ?? null ) ? $loop_payload['client_context'] : array()
 					);
 
 					do_action(
@@ -392,6 +448,19 @@ class AIConversationLoop {
 								'turn'    => $turn_count,
 								'tool'    => $tool_name,
 								'success' => $tool_result['success'] ?? false,
+							)
+						)
+					);
+					self::emitLoopEvent(
+						$event_sink,
+						'tool_result',
+						array_merge(
+							$base_log_context,
+							array(
+								'turn_count' => $turn_count,
+								'tool_name'  => $tool_name,
+								'success'    => (bool) ( $tool_result['success'] ?? false ),
+								'result'     => $tool_result,
 							)
 						)
 					);
@@ -547,14 +616,78 @@ class AIConversationLoop {
 			$messages,
 			$provider,
 			$model,
-			$payload,
+			$loop_payload,
 			$result
 		);
 		if ( '' !== $transcript_session_id ) {
 			$result['transcript_session_id'] = $transcript_session_id;
 		}
 
+		self::emitLoopEvent(
+			$event_sink,
+			'completed',
+			array_merge(
+				$base_log_context,
+				array(
+					'turn_count'        => $turn_count,
+					'completed'         => $is_completed,
+					'has_pending_tools' => ! empty( $last_tool_calls ) && ! $conversation_complete,
+					'usage'             => $total_usage,
+				)
+			)
+		);
+
 		return $result;
+	}
+
+	/**
+	 * Resolve the event sink carried by the loop payload.
+	 *
+	 * @param array $payload Loop payload.
+	 * @return LoopEventSinkInterface Event sink.
+	 */
+	private static function resolveEventSink( array $payload ): LoopEventSinkInterface {
+		$sink = $payload['event_sink'] ?? null;
+
+		if ( $sink instanceof LoopEventSinkInterface ) {
+			return $sink;
+		}
+
+		return new NullLoopEventSink();
+	}
+
+	/**
+	 * Remove observer-only payload values before dispatching requests or tools.
+	 *
+	 * @param array $payload Loop payload.
+	 * @return array Payload without the loop event sink object.
+	 */
+	private static function payloadWithoutEventSink( array $payload ): array {
+		unset( $payload['event_sink'] );
+		return $payload;
+	}
+
+	/**
+	 * Emit a loop event without letting observer failures change loop results.
+	 *
+	 * @param LoopEventSinkInterface $sink    Event sink.
+	 * @param string                 $event   Event name.
+	 * @param array                  $payload Event payload.
+	 */
+	private static function emitLoopEvent( LoopEventSinkInterface $sink, string $event, array $payload = array() ): void {
+		try {
+			$sink->emit( $event, $payload );
+		} catch ( \Throwable $e ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'AIConversationLoop: Event sink failed',
+				array(
+					'event' => $event,
+					'error' => $e->getMessage(),
+				)
+			);
+		}
 	}
 
 	/**
@@ -601,19 +734,19 @@ class AIConversationLoop {
 		$agent_id = (int) ( $payload['agent_id'] ?? 0 );
 
 		$metadata = array(
-			'source'        => 'pipeline_transcript',
-			'job_id'        => $payload['job_id'] ?? null,
-			'flow_step_id'  => $payload['flow_step_id'] ?? null,
-			'pipeline_id'   => $payload['pipeline_id'] ?? null,
-			'flow_id'       => $payload['flow_id'] ?? null,
-			'agent_id'      => $agent_id ?: null,
-			'owner_id'      => $user_id ?: null,
-			'provider'      => $provider,
-			'model'         => $model,
-			'turn_count'    => $result['turn_count'] ?? 0,
-			'completed'     => (bool) ( $result['completed'] ?? false ),
-			'error'         => $result['error'] ?? null,
-			'usage'         => $result['usage'] ?? array(),
+			'source'       => 'pipeline_transcript',
+			'job_id'       => $payload['job_id'] ?? null,
+			'flow_step_id' => $payload['flow_step_id'] ?? null,
+			'pipeline_id'  => $payload['pipeline_id'] ?? null,
+			'flow_id'      => $payload['flow_id'] ?? null,
+			'agent_id'     => $agent_id > 0 ? $agent_id : null,
+			'owner_id'     => $user_id > 0 ? $user_id : null,
+			'provider'     => $provider,
+			'model'        => $model,
+			'turn_count'   => $result['turn_count'] ?? 0,
+			'completed'    => (bool) ( $result['completed'] ?? false ),
+			'error'        => $result['error'] ?? null,
+			'usage'        => $result['usage'] ?? array(),
 		);
 
 		if ( ! empty( $result['request_metadata'] ) && is_array( $result['request_metadata'] ) ) {

--- a/inc/Engine/AI/LoopEventSinkInterface.php
+++ b/inc/Engine/AI/LoopEventSinkInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Transport-neutral AI loop event sink contract.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Receives structured AI loop lifecycle events.
+ */
+interface LoopEventSinkInterface {
+
+	/**
+	 * Emit a loop event.
+	 *
+	 * Event names are transport-neutral. Renderers can map them to logs, SSE,
+	 * WebSockets, CLI output, Discord updates, transcripts, or other consumers.
+	 *
+	 * @param string $event   Event name.
+	 * @param array  $payload Structured event payload.
+	 */
+	public function emit( string $event, array $payload = array() ): void;
+}

--- a/inc/Engine/AI/NullLoopEventSink.php
+++ b/inc/Engine/AI/NullLoopEventSink.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * No-op AI loop event sink.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Default sink used when a caller does not request event emission.
+ */
+class NullLoopEventSink implements LoopEventSinkInterface {
+
+	/**
+	 * Ignore emitted loop events.
+	 *
+	 * @param string $event   Event name.
+	 * @param array  $payload Structured event payload.
+	 */
+	public function emit( string $event, array $payload = array() ): void {
+		// Intentionally empty.
+	}
+}

--- a/tests/ai-loop-event-sink-smoke.php
+++ b/tests/ai-loop-event-sink-smoke.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Smoke tests for the transport-neutral AI loop event sink contract.
+ *
+ * Run with: php tests/ai-loop-event-sink-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$GLOBALS['datamachine_event_sink_test_filters'] = array();
+$GLOBALS['datamachine_event_sink_test_logs']    = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['datamachine_event_sink_test_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$callbacks = $GLOBALS['datamachine_event_sink_test_filters'][ $hook ] ?? array();
+		ksort( $callbacks );
+
+		foreach ( $callbacks as $priority_callbacks ) {
+			foreach ( $priority_callbacks as $entry ) {
+				$callback      = $entry[0];
+				$accepted_args = $entry[1];
+				$value         = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['datamachine_event_sink_test_logs'][] = array_merge( array( $hook ), $args );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $flags = 0 ) {
+		return json_encode( $data, $flags );
+	}
+}
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+use DataMachine\Engine\AI\AIConversationLoop;
+use DataMachine\Engine\AI\LoopEventSinkInterface;
+use DataMachine\Engine\AI\NullLoopEventSink;
+
+class LoopEventSinkSmokeCollector implements LoopEventSinkInterface {
+	public array $events = array();
+
+	public function emit( string $event, array $payload = array() ): void {
+		$this->events[] = array(
+			'event'   => $event,
+			'payload' => $payload,
+		);
+	}
+}
+
+class LoopEventSinkSmokeThrowingSink implements LoopEventSinkInterface {
+	public function emit( string $event, array $payload = array() ): void {
+		throw new RuntimeException( 'sink exploded on ' . $event );
+	}
+}
+
+class LoopEventSinkSmokeTool {
+	public static array $last_parameters = array();
+
+	public function execute( array $parameters, array $tool_def ): array {
+		self::$last_parameters = $parameters;
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'message' => 'handled ' . ( $parameters['name'] ?? 'unknown' ),
+			),
+		);
+	}
+}
+
+$failures = array();
+
+function assert_loop_event_sink( bool $condition, string $label ): void {
+	global $failures;
+
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	echo "FAIL: {$label}\n";
+	$failures[] = $label;
+}
+
+function reset_loop_event_sink_smoke(): void {
+	$GLOBALS['datamachine_event_sink_test_filters'] = array();
+	$GLOBALS['datamachine_event_sink_test_logs']    = array();
+}
+
+function loop_event_sink_event_names( LoopEventSinkSmokeCollector $sink ): array {
+	return array_map( fn( array $entry ): string => $entry['event'], $sink->events );
+}
+
+function loop_event_sink_tools(): array {
+	return array(
+		'smoke_tool' => array(
+			'name'        => 'smoke_tool',
+			'description' => 'Smoke tool',
+			'parameters'  => array(
+				'name' => array( 'type' => 'string' ),
+			),
+			'class'       => LoopEventSinkSmokeTool::class,
+			'method'      => 'execute',
+		),
+	);
+}
+
+function loop_event_sink_log_contains( string $message ): bool {
+	foreach ( $GLOBALS['datamachine_event_sink_test_logs'] as $entry ) {
+		if ( is_array( $entry ) && 'datamachine_log' === ( $entry[0] ?? '' ) && $message === ( $entry[2] ?? '' ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function loop_event_sink_failure_count(): int {
+	global $failures;
+	return count( $failures );
+}
+
+// 1. Null sink satisfies the contract and silently accepts events.
+$null_sink = new NullLoopEventSink();
+$null_sink->emit( 'completed', array( 'turn_count' => 1 ) );
+assert_loop_event_sink( in_array( LoopEventSinkInterface::class, class_implements( $null_sink ), true ), 'null sink implements the loop event sink interface' );
+
+// 2. A collecting sink receives generic loop events in execution order.
+reset_loop_event_sink_smoke();
+$dispatch_count = 0;
+$collector      = new LoopEventSinkSmokeCollector();
+
+add_filter(
+	'chubes_ai_request',
+	function ( ...$args ) use ( &$dispatch_count ) {
+		unset( $args );
+		++$dispatch_count;
+
+		if ( 1 === $dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'name'       => 'smoke_tool',
+							'parameters' => array( 'name' => 'Ada' ),
+						),
+					),
+					'usage'      => array( 'prompt_tokens' => 3, 'completion_tokens' => 2, 'total_tokens' => 5 ),
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'done',
+				'tool_calls' => array(),
+				'usage'      => array( 'prompt_tokens' => 4, 'completion_tokens' => 1, 'total_tokens' => 5 ),
+			),
+		);
+	},
+	10,
+	6
+);
+
+$result = ( new AIConversationLoop() )->execute(
+	array( array( 'role' => 'user', 'content' => 'run the tool' ) ),
+	loop_event_sink_tools(),
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	array(
+		'event_sink'   => $collector,
+		'job_id'       => 1479,
+		'flow_step_id' => 12,
+	),
+	3
+);
+
+assert_loop_event_sink( true === $result['completed'], 'evented loop preserves completed result shape' );
+assert_loop_event_sink( 'done' === $result['final_content'], 'evented loop preserves final content' );
+assert_loop_event_sink(
+	array( 'turn_started', 'request_built', 'tool_call', 'tool_result', 'turn_started', 'request_built', 'completed' ) === loop_event_sink_event_names( $collector ),
+	'collector receives core events in order'
+);
+assert_loop_event_sink( 'smoke_tool' === ( $collector->events[2]['payload']['tool_name'] ?? null ), 'tool_call payload includes the tool name' );
+assert_loop_event_sink( array( 'name' => 'Ada' ) === ( $collector->events[2]['payload']['parameters'] ?? null ), 'tool_call payload includes tool parameters' );
+assert_loop_event_sink( true === ( $collector->events[3]['payload']['success'] ?? null ), 'tool_result payload includes success status' );
+assert_loop_event_sink( isset( $collector->events[1]['payload']['request_metadata']['request_json_bytes'] ), 'request_built payload carries compact request metadata' );
+assert_loop_event_sink( 10 === ( $collector->events[6]['payload']['usage']['total_tokens'] ?? null ), 'completed payload carries accumulated token usage' );
+assert_loop_event_sink( ! array_key_exists( 'event_sink', LoopEventSinkSmokeTool::$last_parameters ), 'event sink object is not forwarded into tool parameters' );
+
+// 3. Failure events are emitted on AI request failure without changing the return array.
+reset_loop_event_sink_smoke();
+$failure_sink = new LoopEventSinkSmokeCollector();
+add_filter(
+	'chubes_ai_request',
+	fn( ...$args ) => array(
+		'success'  => false,
+		'error'    => 'provider offline',
+		'provider' => 'openai',
+	),
+	10,
+	6
+);
+
+$failure_result = ( new AIConversationLoop() )->execute(
+	array( array( 'role' => 'user', 'content' => 'fail' ) ),
+	array(),
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	array( 'event_sink' => $failure_sink ),
+	1
+);
+
+assert_loop_event_sink( false === $failure_result['completed'], 'failure path preserves completed=false result shape' );
+assert_loop_event_sink( 'provider offline' === ( $failure_result['error'] ?? null ), 'failure path preserves error message' );
+assert_loop_event_sink( array( 'turn_started', 'request_built', 'failed' ) === loop_event_sink_event_names( $failure_sink ), 'failure path emits failed after request_built' );
+assert_loop_event_sink( 'provider offline' === ( $failure_sink->events[2]['payload']['error'] ?? null ), 'failed payload includes the provider error' );
+
+// 4. Sink failures are logged and never change loop output.
+reset_loop_event_sink_smoke();
+add_filter(
+	'chubes_ai_request',
+	fn( ...$args ) => array(
+		'success' => true,
+		'data'    => array(
+			'content'    => 'still done',
+			'tool_calls' => array(),
+		),
+	),
+	10,
+	6
+);
+
+$throwing_result = ( new AIConversationLoop() )->execute(
+	array( array( 'role' => 'user', 'content' => 'no-op' ) ),
+	array(),
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	array( 'event_sink' => new LoopEventSinkSmokeThrowingSink() ),
+	1
+);
+
+assert_loop_event_sink( true === $throwing_result['completed'], 'throwing sink does not change loop completion' );
+assert_loop_event_sink( loop_event_sink_log_contains( 'AIConversationLoop: Event sink failed' ), 'throwing sink is logged as a warning' );
+
+echo "\n";
+$failure_count = loop_event_sink_failure_count();
+if ( 0 === $failure_count ) {
+	echo "All AI loop event sink smoke tests passed.\n";
+	exit( 0 );
+}
+
+echo sprintf( "%d failure(s):\n", $failure_count );
+foreach ( $failures as $failure ) {
+	echo "  - {$failure}\n";
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Adds a transport-neutral loop event sink contract for AI conversation lifecycle events.
- Threads an optional `$payload['event_sink']` through the built-in loop without changing final result arrays.
- Emits initial generic events for turn/request/tool/completion/failure paths.

## Event contract
- New `DataMachine\Engine\AI\LoopEventSinkInterface` exposes `emit( string $event, array $payload = array() ): void`.
- New `NullLoopEventSink` keeps the default path no-op when no sink is supplied.
- `AIConversationLoop` currently emits: `turn_started`, `request_built`, `tool_call`, `tool_result`, `completed`, and `failed`.
- The sink is observer-only: sink exceptions are logged and do not change loop results, and the sink object is removed before request/tool dispatch.

## Tests
- `php tests/ai-loop-event-sink-smoke.php`
- `php tests/ai-conversation-result-smoke.php`
- `php tests/ai-request-metadata-guardrails-smoke.php`
- `php -l inc/Engine/AI/AIConversationLoop.php && php -l inc/Engine/AI/LoopEventSinkInterface.php && php -l inc/Engine/AI/NullLoopEventSink.php && php -l tests/ai-loop-event-sink-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-loop-event-sink --changed-since origin/main --summary` reports PHPCS passing and no baseline drift, but exits non-zero because its ESLint phase reports `Unknown` against the PHP-only changed-file scope.

## Out of scope
- No SSE, WebSocket, CLI, REST, Discord, transcript, or A2A renderer implementation.
- No provider token streaming or assistant delta event contract yet.
- No job-wide event sink outside the AI conversation loop yet.

Closes #1479

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the event sink contract, wiring loop emissions, adding smoke coverage, and running verification. Chris reviewed direction and remains responsible for the change.
