### PR TITLE
refactor(chat): split conversation store contracts

### DIFF
--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -21,10 +21,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Chat Database Manager
  *
- * Implements {@see ConversationStoreInterface} so the conversation
- * storage backend can be swapped via the `datamachine_conversation_store`
- * filter. Resolve via {@see ConversationStoreFactory::get()} rather than
- * instantiating this class directly.
+ * Implements the aggregate {@see ConversationStoreInterface} by satisfying
+ * the narrower transcript, index, read-state, retention, and reporting
+ * contracts. Resolve via {@see ConversationStoreFactory::get()} rather
+ * than instantiating this class directly.
  */
 class Chat extends BaseRepository implements ConversationStoreInterface {
 

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -21,10 +21,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Chat Database Manager
  *
- * Implements the aggregate {@see ConversationStoreInterface} by satisfying
- * the narrower transcript, index, read-state, retention, and reporting
- * contracts. Resolve via {@see ConversationStoreFactory::get()} rather
- * than instantiating this class directly.
+ * Implements {@see ConversationStoreInterface} so the conversation
+ * storage backend can be swapped via the `datamachine_conversation_store`
+ * filter. Resolve via {@see ConversationStoreFactory::get()} rather than
+ * instantiating this class directly.
  */
 class Chat extends BaseRepository implements ConversationStoreInterface {
 

--- a/inc/Core/Database/Chat/ConversationReadStateInterface.php
+++ b/inc/Core/Database/Chat/ConversationReadStateInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Conversation read-state contract.
+ *
+ * Covers unread-count derivation and marking a session as read. Stores
+ * that do not own read state can avoid this contract and still implement
+ * transcript/index interfaces.
+ *
+ * @package DataMachine\Core\Database\Chat
+ * @since   next
+ */
+
+namespace DataMachine\Core\Database\Chat;
+
+defined( 'ABSPATH' ) || exit;
+
+interface ConversationReadStateInterface {
+
+	/**
+	 * Count unread assistant messages in a decoded messages array.
+	 *
+	 * Pure derivation from a messages array. Default impl is stateless and
+	 * has no backend I/O. Included here so consumers can share unread
+	 * semantics regardless of backend.
+	 *
+	 * @param array       $messages     Decoded messages array.
+	 * @param string|null $last_read_at MySQL datetime of last read, or null.
+	 * @return int
+	 */
+	public function count_unread( array $messages, ?string $last_read_at ): int;
+
+	/**
+	 * Mark a session as read (updates last_read_at).
+	 *
+	 * @param string $session_id Session UUID.
+	 * @param int    $user_id    User ID for ownership scope.
+	 * @return string|false New last_read_at MySQL datetime, or false on failure.
+	 */
+	public function mark_session_read( string $session_id, int $user_id );
+}

--- a/inc/Core/Database/Chat/ConversationReportingInterface.php
+++ b/inc/Core/Database/Chat/ConversationReportingInterface.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Conversation reporting contract.
+ *
+ * Covers non-mutating summary/metrics reads used by daily memory and
+ * retention status reporting. Backends that cannot report storage metrics
+ * may return null from get_storage_metrics().
+ *
+ * @package DataMachine\Core\Database\Chat
+ * @since   next
+ */
+
+namespace DataMachine\Core\Database\Chat;
+
+defined( 'ABSPATH' ) || exit;
+
+interface ConversationReportingInterface {
+
+	/**
+	 * List lightweight session summaries created on the given date.
+	 *
+	 * Returns rows with `{session_id, title, context/mode, created_at}`.
+	 * Used by the Daily Memory Task to summarize a day's chat activity
+	 * without loading the full messages array.
+	 *
+	 * Implementations determine their own date comparison semantics. The
+	 * default MySQL store uses `DATE(created_at) = $date` on the stored
+	 * timestamp.
+	 *
+	 * @param string $date Date string in `Y-m-d` format.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function list_sessions_for_day( string $date ): array;
+
+	/**
+	 * Report storage metrics for the retention CLI.
+	 *
+	 * Returns `['rows' => int, 'size_mb' => string]` for the default
+	 * MySQL store. Stores that cannot report byte size return
+	 * `size_mb => '0.0'`. Stores that cannot report rows either return
+	 * `null` to opt out of the metrics table.
+	 *
+	 * @return array{rows: int, size_mb: string}|null
+	 */
+	public function get_storage_metrics(): ?array;
+}

--- a/inc/Core/Database/Chat/ConversationRetentionInterface.php
+++ b/inc/Core/Database/Chat/ConversationRetentionInterface.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Conversation retention contract.
+ *
+ * Covers destructive cleanup operations for chat-session retention. This
+ * contract is intentionally separate from transcript CRUD so external
+ * backends can expose cleanup only when they own retention policy.
+ *
+ * @package DataMachine\Core\Database\Chat
+ * @since   next
+ */
+
+namespace DataMachine\Core\Database\Chat;
+
+defined( 'ABSPATH' ) || exit;
+
+interface ConversationRetentionInterface {
+
+	/**
+	 * Delete sessions whose `expires_at` has passed.
+	 *
+	 * @return int Number of sessions deleted.
+	 */
+	public function cleanup_expired_sessions(): int;
+
+	/**
+	 * Delete sessions older than the retention window.
+	 *
+	 * @param int $retention_days Days to retain sessions (by updated_at).
+	 * @return int Number of sessions deleted.
+	 */
+	public function cleanup_old_sessions( int $retention_days ): int;
+
+	/**
+	 * Delete sessions that were created but never received a message.
+	 *
+	 * Orphaned sessions are the fallout from request timeouts that left
+	 * empty rows behind. This cleanup keeps the switcher tidy.
+	 *
+	 * @param int $hours Age threshold in hours (default 1).
+	 * @return int Number of sessions deleted.
+	 */
+	public function cleanup_orphaned_sessions( int $hours = 1 ): int;
+}

--- a/inc/Core/Database/Chat/ConversationSessionIndexInterface.php
+++ b/inc/Core/Database/Chat/ConversationSessionIndexInterface.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Conversation session index contract.
+ *
+ * Covers the paginated session switcher/index surface. Backends that can
+ * list sessions separately from transcript storage can implement this
+ * contract independently.
+ *
+ * @package DataMachine\Core\Database\Chat
+ * @since   next
+ */
+
+namespace DataMachine\Core\Database\Chat;
+
+defined( 'ABSPATH' ) || exit;
+
+interface ConversationSessionIndexInterface {
+
+	/**
+	 * List sessions for a user with pagination and optional filtering.
+	 *
+	 * Returned entries are summary rows intended for the session switcher
+	 * (session_id, title, context/mode, first_message, message_count,
+	 * unread_count, agent_id, agent_slug, agent_name, created_at,
+	 * updated_at). Implementations MUST include agent metadata so the
+	 * switcher UI can render without an N+1 lookup.
+	 *
+	 * @param int         $user_id  WordPress user ID.
+	 * @param int         $limit    Max rows to return (1-100).
+	 * @param int         $offset   Pagination offset.
+	 * @param string|null $context  Optional context filter.
+	 * @param int|null    $agent_id Optional agent filter (null = all agents).
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function get_user_sessions( int $user_id, int $limit = 20, int $offset = 0, ?string $context = null, ?int $agent_id = null ): array;
+
+	/**
+	 * Total session count for a user, honoring optional filters.
+	 *
+	 * @param int         $user_id  WordPress user ID.
+	 * @param string|null $context  Optional context filter.
+	 * @param int|null    $agent_id Optional agent filter (null = all agents).
+	 * @return int
+	 */
+	public function get_user_session_count( int $user_id, ?string $context = null, ?int $agent_id = null ): int;
+}

--- a/inc/Core/Database/Chat/ConversationStoreFactory.php
+++ b/inc/Core/Database/Chat/ConversationStoreFactory.php
@@ -50,28 +50,29 @@ class ConversationStoreFactory {
 		/**
 		 * Filter: swap the chat conversation persistence backend.
 		 *
-		 * Return a {@see ConversationStoreInterface} instance to short-circuit
+		 * Return a {@see ConversationStoreInterface} aggregate to short-circuit
 		 * the default MySQL-table store. Return the default (or anything not
-		 * implementing the interface) to use the built-in {@see Chat} store.
+		 * implementing the aggregate) to use the built-in {@see Chat} store.
 		 *
 		 * The MySQL default preserves byte-for-byte the behavior Data Machine
 		 * had before this seam was introduced — self-hosted users see no
-		 * change. Managed-host consumers (e.g. Intelligence on WordPress.com)
-		 * can register an AI Framework-backed implementation conditionally:
+		 * change. Consumers can register an external-backend implementation
+		 * conditionally:
 		 *
 		 *     add_filter( 'datamachine_conversation_store', function ( $store ) {
-		 *         if ( $store instanceof My_AIFramework_Conversation_Store ) {
+		 *         if ( $store instanceof My_External_Conversation_Store ) {
 		 *             return $store; // already swapped
 		 *         }
-		 *         if ( ! function_exists( 'my_host_is_wpcom' ) || ! my_host_is_wpcom() ) {
-		 *             return $store; // self-hosted — keep MySQL default
+		 *         if ( ! function_exists( 'my_should_use_external_backend' ) || ! my_should_use_external_backend() ) {
+		 *             return $store; // keep MySQL default
 		 *         }
-		 *         return new My_AIFramework_Conversation_Store();
+		 *         return new My_External_Conversation_Store();
 		 *     }, 10, 1 );
 		 *
 		 * The store MUST normalize messages on read to Data Machine message
-		 * shape — see docs/development/hooks/core-filters.md for the full
-		 * contract.
+		 * shape. Implementations that only need a slice of the store surface can
+		 * target the narrower contracts, but this filter still expects the full
+		 * aggregate for behavior compatibility.
 		 *
 		 * @since next
 		 *

--- a/inc/Core/Database/Chat/ConversationStoreInterface.php
+++ b/inc/Core/Database/Chat/ConversationStoreInterface.php
@@ -1,18 +1,18 @@
 <?php
 /**
- * Conversation Store Interface
+ * Aggregate conversation store contract.
  *
  * Single seam between chat session operations and the underlying
  * persistence backend. Default implementation ({@see Chat}) preserves
  * today's MySQL-table behavior. Consumers can swap in an alternate
- * store via the `datamachine_conversation_store` filter (e.g. an
- * AI Framework Conversation_Storage shim on managed hosts like
- * WordPress.com).
+ * aggregate store via the `datamachine_conversation_store` filter.
  *
- * The five Chat Session abilities (list / get / create / delete /
- * mark-read) and the Chat Orchestrator all route session I/O through
- * this seam. The DM chat UI and REST surface are unaffected — they
- * consume the ability contracts, not the store directly.
+ * The narrower contracts this interface composes are the reusable seams
+ * for future adapters that only own part of the conversation surface:
+ * transcript/session CRUD, session indexes, read state, retention cleanup,
+ * and reporting/metrics. Existing callers still request the aggregate via
+ * {@see ConversationStoreFactory::get()}, so this split is a contract
+ * clarification with no behavior change.
  *
  * Implementations are responsible for:
  * - normalizing messages on read to Data Machine message shape
@@ -34,183 +34,10 @@ namespace DataMachine\Core\Database\Chat;
 
 defined( 'ABSPATH' ) || exit;
 
-interface ConversationStoreInterface {
-
-	/**
-	 * Create a new chat session and return its ID.
-	 *
-	 * @param int    $user_id  WordPress user ID owning the session.
-	 * @param int    $agent_id Agent ID (0 = legacy agent-less session).
-	 * @param array  $metadata Arbitrary session metadata (JSON-serializable).
-	 * @param string $context  Execution context ('chat', 'pipeline', 'system').
-	 * @return string Session ID (UUIDv4), or empty string on failure.
-	 */
-	public function create_session( int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string;
-
-	/**
-	 * Retrieve a session by ID.
-	 *
-	 * Returns the session as an associative array with keys:
-	 * session_id, user_id, agent_id, title, messages (decoded array),
-	 * metadata (decoded array), provider, model, context, created_at,
-	 * updated_at, last_read_at, expires_at.
-	 *
-	 * @param string $session_id Session UUID.
-	 * @return array|null Session data or null if not found.
-	 */
-	public function get_session( string $session_id ): ?array;
-
-	/**
-	 * Replace a session's messages + metadata.
-	 *
-	 * @param string $session_id Session UUID.
-	 * @param array  $messages   Complete messages array (not a delta).
-	 * @param array  $metadata   Updated metadata.
-	 * @param string $provider   Optional AI provider identifier.
-	 * @param string $model      Optional AI model identifier.
-	 * @return bool True on success.
-	 */
-	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '' ): bool;
-
-	/**
-	 * Delete a session by ID. Idempotent.
-	 *
-	 * @param string $session_id Session UUID.
-	 * @return bool True on success.
-	 */
-	public function delete_session( string $session_id ): bool;
-
-	/**
-	 * List sessions for a user with pagination and optional filtering.
-	 *
-	 * Returned entries are summary rows intended for the session switcher
-	 * (session_id, title, context, first_message, message_count,
-	 * unread_count, agent_id, agent_slug, agent_name, created_at,
-	 * updated_at). Implementations MUST include agent metadata so the
-	 * switcher UI can render without an N+1 lookup.
-	 *
-	 * @param int         $user_id  WordPress user ID.
-	 * @param int         $limit    Max rows to return (1-100).
-	 * @param int         $offset   Pagination offset.
-	 * @param string|null $context  Optional context filter.
-	 * @param int|null    $agent_id Optional agent filter (null = all agents).
-	 * @return array<int, array<string, mixed>>
-	 */
-	public function get_user_sessions( int $user_id, int $limit = 20, int $offset = 0, ?string $context = null, ?int $agent_id = null ): array;
-
-	/**
-	 * Total session count for a user, honoring optional filters.
-	 *
-	 * @param int         $user_id  WordPress user ID.
-	 * @param string|null $context  Optional context filter.
-	 * @param int|null    $agent_id Optional agent filter (null = all agents).
-	 * @return int
-	 */
-	public function get_user_session_count( int $user_id, ?string $context = null, ?int $agent_id = null ): int;
-
-	/**
-	 * Find a recent pending session for deduplication after request timeouts.
-	 *
-	 * Returns the most recent session that belongs to $user_id, was created
-	 * within $seconds, and is either empty or actively processing. Used by
-	 * the orchestrator to avoid duplicate sessions when a Cloudflare timeout
-	 * triggers a client retry while PHP keeps executing.
-	 *
-	 * @param int      $user_id  WordPress user ID.
-	 * @param int      $seconds  Lookback window (default 600 = 10 minutes).
-	 * @param string   $context  Context filter.
-	 * @param int|null $token_id Optional token ID for login-scoped dedup.
-	 * @return array|null Session data or null if none.
-	 */
-	public function get_recent_pending_session( int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array;
-
-	/**
-	 * Set a session's display title.
-	 *
-	 * @param string $session_id Session UUID.
-	 * @param string $title      New title.
-	 * @return bool True on success.
-	 */
-	public function update_title( string $session_id, string $title ): bool;
-
-	/**
-	 * Count unread assistant messages in a decoded messages array.
-	 *
-	 * Pure derivation from a messages array — default impl is stateless
-	 * and has no backend I/O. Included on the interface so consumers get
-	 * the same unread semantics regardless of backend.
-	 *
-	 * @param array       $messages     Decoded messages array.
-	 * @param string|null $last_read_at MySQL datetime of last read, or null.
-	 * @return int
-	 */
-	public function count_unread( array $messages, ?string $last_read_at ): int;
-
-	/**
-	 * Mark a session as read (updates last_read_at).
-	 *
-	 * @param string $session_id Session UUID.
-	 * @param int    $user_id    User ID for ownership scope.
-	 * @return string|false New last_read_at MySQL datetime, or false on failure.
-	 */
-	public function mark_session_read( string $session_id, int $user_id );
-
-	/**
-	 * Delete sessions whose `expires_at` has passed.
-	 *
-	 * @return int Number of sessions deleted.
-	 */
-	public function cleanup_expired_sessions(): int;
-
-	/**
-	 * Delete sessions older than the retention window.
-	 *
-	 * @param int $retention_days Days to retain sessions (by updated_at).
-	 * @return int Number of sessions deleted.
-	 */
-	public function cleanup_old_sessions( int $retention_days ): int;
-
-	/**
-	 * Delete sessions that were created but never received a message.
-	 *
-	 * Orphaned sessions are the fallout from request timeouts that left
-	 * empty rows behind. This cleanup keeps the switcher tidy.
-	 *
-	 * @param int $hours Age threshold in hours (default 1).
-	 * @return int Number of sessions deleted.
-	 */
-	public function cleanup_orphaned_sessions( int $hours = 1 ): int;
-
-	/**
-	 * List lightweight session summaries created on the given date.
-	 *
-	 * Returns rows with `{session_id, title, context, created_at}`.
-	 * Used by the Daily Memory Task to summarize a day's chat activity
-	 * without loading the full messages array.
-	 *
-	 * Implementations determine their own date comparison semantics.
-	 * The default MySQL store uses `DATE(created_at) = $date` on the
-	 * stored timestamp (MySQL-server timezone, which in a WordPress
-	 * install is typically UTC for Data Machine DATETIME columns).
-	 *
-	 * @param string $date Date string in `Y-m-d` format.
-	 * @return array<int, array{session_id: string, title: string|null, context: string, created_at: string}>
-	 */
-	public function list_sessions_for_day( string $date ): array;
-
-	/**
-	 * Report storage metrics for the retention CLI.
-	 *
-	 * Returns `['rows' => int, 'size_mb' => string]` for the default
-	 * MySQL store. Stores that cannot report byte size (e.g. an external
-	 * API-backed store) return `size_mb => '0.0'`. Stores that cannot
-	 * report rows either return `null` to opt out of the metrics table.
-	 *
-	 * The CLI displays the "Chat sessions" row only when this method
-	 * returns a non-null value, so the metrics table stays meaningful
-	 * regardless of backend.
-	 *
-	 * @return array{rows: int, size_mb: string}|null
-	 */
-	public function get_storage_metrics(): ?array;
+interface ConversationStoreInterface extends
+	ConversationTranscriptStoreInterface,
+	ConversationSessionIndexInterface,
+	ConversationReadStateInterface,
+	ConversationRetentionInterface,
+	ConversationReportingInterface {
 }

--- a/inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php
+++ b/inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Conversation transcript store contract.
+ *
+ * Covers session row creation, transcript reads/writes, title updates,
+ * and retry deduplication. Backends that only need to persist complete
+ * conversation transcripts can implement this contract without taking on
+ * list, read-state, retention, or metrics responsibilities.
+ *
+ * @package DataMachine\Core\Database\Chat
+ * @since   next
+ */
+
+namespace DataMachine\Core\Database\Chat;
+
+defined( 'ABSPATH' ) || exit;
+
+interface ConversationTranscriptStoreInterface {
+
+	/**
+	 * Create a new chat session and return its ID.
+	 *
+	 * @param int    $user_id  WordPress user ID owning the session.
+	 * @param int    $agent_id Agent ID (0 = legacy agent-less session).
+	 * @param array  $metadata Arbitrary session metadata (JSON-serializable).
+	 * @param string $context  Execution context ('chat', 'pipeline', 'system').
+	 * @return string Session ID (UUIDv4), or empty string on failure.
+	 */
+	public function create_session( int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string;
+
+	/**
+	 * Retrieve a session by ID.
+	 *
+	 * Returns the session as an associative array with keys:
+	 * session_id, user_id, agent_id, title, messages (decoded array),
+	 * metadata (decoded array), provider, model, context/mode, created_at,
+	 * updated_at, last_read_at, expires_at.
+	 *
+	 * @param string $session_id Session UUID.
+	 * @return array|null Session data or null if not found.
+	 */
+	public function get_session( string $session_id ): ?array;
+
+	/**
+	 * Replace a session's messages + metadata.
+	 *
+	 * @param string $session_id Session UUID.
+	 * @param array  $messages   Complete messages array (not a delta).
+	 * @param array  $metadata   Updated metadata.
+	 * @param string $provider   Optional AI provider identifier.
+	 * @param string $model      Optional AI model identifier.
+	 * @return bool True on success.
+	 */
+	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '' ): bool;
+
+	/**
+	 * Delete a session by ID. Idempotent.
+	 *
+	 * @param string $session_id Session UUID.
+	 * @return bool True on success.
+	 */
+	public function delete_session( string $session_id ): bool;
+
+	/**
+	 * Find a recent pending session for deduplication after request timeouts.
+	 *
+	 * Returns the most recent session that belongs to $user_id, was created
+	 * within $seconds, and is either empty or actively processing. Used by
+	 * the orchestrator to avoid duplicate sessions when a timeout triggers a
+	 * client retry while PHP keeps executing.
+	 *
+	 * @param int      $user_id  WordPress user ID.
+	 * @param int      $seconds  Lookback window (default 600 = 10 minutes).
+	 * @param string   $context  Context filter.
+	 * @param int|null $token_id Optional token ID for login-scoped dedup.
+	 * @return array|null Session data or null if none.
+	 */
+	public function get_recent_pending_session( int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array;
+
+	/**
+	 * Set a session's display title.
+	 *
+	 * @param string $session_id Session UUID.
+	 * @param string $title      New title.
+	 * @return bool True on success.
+	 */
+	public function update_title( string $session_id, string $title ): bool;
+}

--- a/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
+++ b/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
@@ -16,8 +16,13 @@ namespace DataMachine\Tests\Unit\Core\Database\Chat;
 
 use DataMachine\Abilities\Chat\ListChatSessionsAbility;
 use DataMachine\Core\Database\Chat\Chat;
+use DataMachine\Core\Database\Chat\ConversationReadStateInterface;
+use DataMachine\Core\Database\Chat\ConversationReportingInterface;
+use DataMachine\Core\Database\Chat\ConversationRetentionInterface;
+use DataMachine\Core\Database\Chat\ConversationSessionIndexInterface;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Chat\ConversationStoreInterface;
+use DataMachine\Core\Database\Chat\ConversationTranscriptStoreInterface;
 use WP_UnitTestCase;
 
 class ConversationStoreFactoryTest extends WP_UnitTestCase {
@@ -41,7 +46,29 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$store = ConversationStoreFactory::get();
 
 		$this->assertInstanceOf( ConversationStoreInterface::class, $store );
+		$this->assertInstanceOf( ConversationTranscriptStoreInterface::class, $store );
+		$this->assertInstanceOf( ConversationSessionIndexInterface::class, $store );
+		$this->assertInstanceOf( ConversationReadStateInterface::class, $store );
+		$this->assertInstanceOf( ConversationRetentionInterface::class, $store );
+		$this->assertInstanceOf( ConversationReportingInterface::class, $store );
 		$this->assertInstanceOf( Chat::class, $store );
+	}
+
+	public function test_conversation_store_interface_is_composed_from_narrow_contracts(): void {
+		$reflection = new \ReflectionClass( ConversationStoreInterface::class );
+		$expected   = array(
+			ConversationTranscriptStoreInterface::class,
+			ConversationSessionIndexInterface::class,
+			ConversationReadStateInterface::class,
+			ConversationRetentionInterface::class,
+			ConversationReportingInterface::class,
+		);
+		$actual     = array_values( $reflection->getInterfaceNames() );
+
+		sort( $expected );
+		sort( $actual );
+
+		$this->assertSame( $expected, $actual );
 	}
 
 	public function test_filter_swaps_the_store(): void {
@@ -57,6 +84,11 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$resolved = ConversationStoreFactory::get();
 
 		$this->assertSame( $memory_store, $resolved );
+		$this->assertInstanceOf( ConversationTranscriptStoreInterface::class, $resolved );
+		$this->assertInstanceOf( ConversationSessionIndexInterface::class, $resolved );
+		$this->assertInstanceOf( ConversationReadStateInterface::class, $resolved );
+		$this->assertInstanceOf( ConversationRetentionInterface::class, $resolved );
+		$this->assertInstanceOf( ConversationReportingInterface::class, $resolved );
 		$this->assertNotInstanceOf( Chat::class, $resolved );
 	}
 

--- a/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
+++ b/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
@@ -2,8 +2,8 @@
 /**
  * In-memory ConversationStoreInterface implementation for tests.
  *
- * Reference adapter demonstrating how a third-party store slots into the
- * `datamachine_conversation_store` filter without depending on `$wpdb`.
+ * Reference aggregate adapter demonstrating how a third-party store slots
+ * into the `datamachine_conversation_store` filter without depending on `$wpdb`.
  * Stays in lockstep with {@see \DataMachine\Core\Database\Chat\Chat}'s
  * observable shape so the chat abilities work identically against it.
  *

--- a/tests/conversation-store-contracts-smoke.php
+++ b/tests/conversation-store-contracts-smoke.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Smoke tests for the split conversation store contracts.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 86400 );
+}
+
+function did_action( string $hook = '' ): int {
+	return 0;
+}
+
+function doing_action( string $hook = '' ): bool {
+	return false;
+}
+
+function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	// no-op
+}
+
+function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	// no-op
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use DataMachine\Core\Database\Chat\Chat;
+use DataMachine\Core\Database\Chat\ConversationReadStateInterface;
+use DataMachine\Core\Database\Chat\ConversationReportingInterface;
+use DataMachine\Core\Database\Chat\ConversationRetentionInterface;
+use DataMachine\Core\Database\Chat\ConversationSessionIndexInterface;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
+use DataMachine\Core\Database\Chat\ConversationStoreInterface;
+use DataMachine\Core\Database\Chat\ConversationTranscriptStoreInterface;
+use DataMachine\Tests\Unit\Core\Database\Chat\InMemoryConversationStore;
+
+$failures = array();
+
+function assert_true( bool $condition, string $label ): void {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+	echo "FAIL: {$label}\n";
+	$failures[] = $label;
+}
+
+$narrow_contracts = array(
+	ConversationTranscriptStoreInterface::class,
+	ConversationSessionIndexInterface::class,
+	ConversationReadStateInterface::class,
+	ConversationRetentionInterface::class,
+	ConversationReportingInterface::class,
+);
+
+$aggregate = new ReflectionClass( ConversationStoreInterface::class );
+foreach ( $narrow_contracts as $contract ) {
+	assert_true( $aggregate->implementsInterface( $contract ), "aggregate composes {$contract}" );
+}
+
+foreach ( $narrow_contracts as $contract ) {
+	assert_true( is_subclass_of( Chat::class, $contract ), "Chat implements {$contract}" );
+	assert_true( is_subclass_of( InMemoryConversationStore::class, $contract ), "InMemoryConversationStore implements {$contract}" );
+}
+
+assert_true( is_subclass_of( Chat::class, ConversationStoreInterface::class ), 'Chat remains a ConversationStoreInterface aggregate' );
+assert_true( is_subclass_of( InMemoryConversationStore::class, ConversationStoreInterface::class ), 'test adapter remains a ConversationStoreInterface aggregate' );
+
+$factory_get = new ReflectionMethod( ConversationStoreFactory::class, 'get' );
+assert_true( ConversationStoreInterface::class === (string) $factory_get->getReturnType(), 'factory still returns the aggregate contract' );
+
+echo "\n";
+if ( empty( $failures ) ) {
+	echo "All conversation store contract smoke tests passed.\n";
+	exit( 0 );
+}
+
+echo sprintf( "%d failure(s):\n", count( $failures ) );
+foreach ( $failures as $failure ) {
+	echo "  - {$failure}\n";
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Splits the broad conversation store interface into focused contracts for transcript CRUD, session indexes, read state, retention, and reporting.
- Keeps `ConversationStoreInterface` as the aggregate returned by `ConversationStoreFactory::get()` so current callers and filters remain behavior-compatible.
- Adds focused smoke coverage and extends factory tests to prove default and swapped stores satisfy the aggregate plus narrow contracts.

## Contract split
- Added `ConversationTranscriptStoreInterface` for session/transcript CRUD, title updates, and retry deduplication.
- Added `ConversationSessionIndexInterface` for list/count switcher surfaces.
- Added `ConversationReadStateInterface` for unread derivation and read markers.
- Added `ConversationRetentionInterface` for cleanup operations.
- Added `ConversationReportingInterface` for daily summaries and storage metrics.

## Behavior compatibility
- `ConversationStoreInterface` now extends the five narrower contracts instead of declaring every method inline.
- `ConversationStoreFactory::get()` still returns `ConversationStoreInterface` and still rejects non-aggregate filter returns.
- `Chat` continues to satisfy the aggregate through its existing methods; no callsites were rewritten.
- Factory documentation now uses generic external-backend wording rather than host-specific examples.

## Tests
- `php tests/conversation-store-contracts-smoke.php`
- `php tests/ai-request-metadata-guardrails-smoke.php`
- `php -l` on changed production/test files
- `git diff --check`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@refactor-conversation-store-contracts --changed-since origin/main` currently has PHPCS clean and no baseline drift, but the JS lint phase still tries to parse changed PHP files and exits with `Parsing error: Unexpected token`.
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@refactor-conversation-store-contracts --changed-since origin/main` currently hits existing PHPUnit/bootstrap noise around ability registration and unrelated tests; the focused pure-PHP smokes above pass.

Closes #1482

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the contract split, focused test updates, smoke coverage, and verification summary; Chris remains responsible for review and merge.