### PR TITLE
fix(workflow): unify runtime step config resolution

### DIFF
--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -13,6 +13,7 @@ namespace DataMachine\Abilities\Job;
 
 use DataMachine\Abilities\StepTypeAbilities;
 use DataMachine\Core\Steps\WorkflowConfigFactory;
+use DataMachine\Engine\ExecutionPlan;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -169,8 +170,24 @@ class ExecuteWorkflowAbility {
 
 		$this->db_jobs->store_engine_data( $job_id, $engine_data );
 
-		// Find first step
-		$first_step_id = $this->getFirstStepId( $configs['flow_config'] );
+		try {
+			$first_step_id = ExecutionPlan::from_flow_config( $configs['flow_config'] )->first_step_id();
+		} catch ( \InvalidArgumentException $e ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Workflow execution failed - invalid execution plan',
+				array(
+					'job_id' => $job_id,
+					'error'  => $e->getMessage(),
+				)
+			);
+
+			return array(
+				'success' => false,
+				'error'   => $e->getMessage(),
+			);
+		}
 
 		if ( ! $first_step_id ) {
 			return array(
@@ -319,18 +336,4 @@ class ExecuteWorkflowAbility {
 		return array( 'valid' => true );
 	}
 
-	/**
-	 * Get first step ID from flow_config.
-	 *
-	 * @param array $flow_config Flow configuration.
-	 * @return string|null First step ID or null if not found.
-	 */
-	private function getFirstStepId( array $flow_config ): ?string {
-		foreach ( $flow_config as $step_id => $config ) {
-			if ( ( $config['execution_order'] ?? -1 ) === 0 ) {
-				return $step_id;
-			}
-		}
-		return null;
-	}
 }

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -16,6 +16,7 @@ use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Core\Steps\FlowStepConfigFactory;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -1013,16 +1014,12 @@ class PipelineStepAbilities {
 
 			$flow_step_id = apply_filters( 'datamachine_generate_flow_step_id', '', $pipeline_step_id, $flow_id );
 
-			$disabled_tools = $pipeline_config[ $pipeline_step_id ]['disabled_tools'] ?? array();
-
-			$flow_config[ $flow_step_id ] = array(
-				'flow_step_id'     => $flow_step_id,
-				'step_type'        => $step['step_type'] ?? '',
-				'pipeline_step_id' => $pipeline_step_id,
-				'pipeline_id'      => $pipeline_id,
-				'flow_id'          => $flow_id,
-				'execution_order'  => $step['execution_order'] ?? 0,
-				'disabled_tools'   => $disabled_tools,
+			$flow_config[ $flow_step_id ] = FlowStepConfigFactory::buildFromPipelineStep(
+				$step,
+				$pipeline_id,
+				$flow_id,
+				$flow_step_id,
+				$pipeline_config[ $pipeline_step_id ] ?? array()
 			);
 		}
 

--- a/tests/flow-step-config-factory-smoke.php
+++ b/tests/flow-step-config-factory-smoke.php
@@ -226,8 +226,9 @@ foreach ( $sync_cases as $name => $step ) {
 	);
 }
 
-$execute_workflow_src = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' ) ?: '';
-$flow_helpers_src     = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/FlowHelpers.php' ) ?: '';
+$execute_workflow_src  = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' ) ?: '';
+$flow_helpers_src      = file_get_contents( __DIR__ . '/../inc/Abilities/Flow/FlowHelpers.php' ) ?: '';
+$pipeline_step_src     = file_get_contents( __DIR__ . '/../inc/Abilities/PipelineStepAbilities.php' ) ?: '';
 
 assert_factory_equals(
 	true,
@@ -241,6 +242,38 @@ assert_factory_equals(
 	true,
 	false !== strpos( $flow_helpers_src, 'FlowStepConfigFactory::buildFromPipelineStep(' ),
 	'FlowHelpers routes synced flow rows through the factory scaffold',
+	$failures,
+	$passes
+);
+
+assert_factory_equals(
+	true,
+	false !== strpos( $pipeline_step_src, 'FlowStepConfigFactory::buildFromPipelineStep(' ),
+	'PipelineStepAbilities routes add-step flow sync through the factory scaffold',
+	$failures,
+	$passes
+);
+
+assert_factory_equals(
+	false,
+	false !== strpos( $pipeline_step_src, '$flow_config[ $flow_step_id ] = array(' ),
+	'PipelineStepAbilities no longer hand-builds synced flow config rows',
+	$failures,
+	$passes
+);
+
+assert_factory_equals(
+	true,
+	false !== strpos( $execute_workflow_src, 'ExecutionPlan::from_flow_config( $configs[\'flow_config\'] )->first_step_id()' ),
+	'ExecuteWorkflowAbility resolves ephemeral first step through ExecutionPlan',
+	$failures,
+	$passes
+);
+
+assert_factory_equals(
+	false,
+	false !== strpos( $execute_workflow_src, 'private function getFirstStepId' ),
+	'ExecuteWorkflowAbility no longer has a private first-step scanner',
 	$failures,
 	$passes
 );


### PR DESCRIPTION
## Summary
- Route saved-flow add-step sync through the canonical flow step config factory.
- Route ephemeral workflow first-step resolution through the shared execution plan contract.

## Changes
- Replaced `PipelineStepAbilities::syncStepsToFlow()`'s hand-built flow config row with `FlowStepConfigFactory::buildFromPipelineStep()`.
- Replaced `ExecuteWorkflowAbility`'s private first-step scanner with `ExecutionPlan::from_flow_config(...)->first_step_id()` and matching invalid-plan logging.
- Extended the factory smoke test with source assertions for both unification paths.

## Tests
- `php -l inc/Abilities/PipelineStepAbilities.php`
- `php -l inc/Abilities/Job/ExecuteWorkflowAbility.php`
- `php tests/flow-step-config-factory-smoke.php`
- `php tests/execute-workflow-initial-data-contract-smoke.php`
- `php tests/step-navigator-execution-order-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-workflow-runtime-unification --changed-since origin/main`

`homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-workflow-runtime-unification` was also run, but the broad repo lint still reports pre-existing PHPStan baseline noise unrelated to this patch.

Closes #1496
Closes #1499

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the workflow runtime cleanup under Chris's direction; Chris remains responsible for review and merge.
