### PR TITLE
feat(agent): route bundle directories through value objects

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -17,6 +17,9 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\AgentBundleLegacyAdapter;
+use DataMachine\Engine\Bundle\BundleValidationException;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -655,74 +658,12 @@ class AgentBundler {
 	 * @return bool True on success.
 	 */
 	public function to_directory( array $bundle, string $directory ): bool {
-		if ( ! wp_mkdir_p( $directory ) ) {
+		try {
+			AgentBundleLegacyAdapter::from_legacy_bundle( $bundle )->write( $directory );
+			return true;
+		} catch ( \Throwable $e ) {
 			return false;
 		}
-
-		// Write manifest.json (everything except file contents).
-		$manifest = $bundle;
-		unset( $manifest['files'] );
-		$manifest['pipelines'] = array_map( function ( $p ) {
-			unset( $p['memory_file_contents'] );
-			return $p;
-		}, $manifest['pipelines'] ?? array() );
-		$manifest['flows']     = array_map( function ( $f ) {
-			unset( $f['memory_file_contents'] );
-			return $f;
-		}, $manifest['flows'] ?? array() );
-		unset( $manifest['user_template'] );
-
-		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			$directory . '/manifest.json',
-			wp_json_encode( $manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES )
-		);
-
-		// Write agent identity files.
-		$agent_dir = $directory . '/agent';
-		wp_mkdir_p( $agent_dir );
-		foreach ( $bundle['files'] ?? array() as $filename => $content ) {
-			$path = $agent_dir . '/' . $filename;
-			$dir  = dirname( $path );
-			if ( ! is_dir( $dir ) ) {
-				wp_mkdir_p( $dir );
-			}
-			file_put_contents( $path, $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		}
-
-		// Write USER.md template.
-		if ( ! empty( $bundle['user_template'] ) ) {
-			file_put_contents( $directory . '/USER.md', $bundle['user_template'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		}
-
-		// Write pipeline memory files.
-		foreach ( $bundle['pipelines'] ?? array() as $i => $pipeline ) {
-			$pipeline_slug = sanitize_title( $pipeline['pipeline_name'] );
-			$pipeline_dir  = $directory . '/pipelines/' . $i . '-' . $pipeline_slug;
-			foreach ( $pipeline['memory_file_contents'] ?? array() as $filename => $content ) {
-				$path = $pipeline_dir . '/' . $filename;
-				$dir  = dirname( $path );
-				if ( ! is_dir( $dir ) ) {
-					wp_mkdir_p( $dir );
-				}
-				file_put_contents( $path, $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			}
-		}
-
-		// Write flow memory files.
-		foreach ( $bundle['flows'] ?? array() as $i => $flow ) {
-			$flow_slug = sanitize_title( $flow['flow_name'] );
-			$flow_dir  = $directory . '/flows/' . $i . '-' . $flow_slug;
-			foreach ( $flow['memory_file_contents'] ?? array() as $filename => $content ) {
-				$path = $flow_dir . '/' . $filename;
-				$dir  = dirname( $path );
-				if ( ! is_dir( $dir ) ) {
-					wp_mkdir_p( $dir );
-				}
-				file_put_contents( $path, $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			}
-		}
-
-		return true;
 	}
 
 	/**
@@ -732,6 +673,12 @@ class AgentBundler {
 	 * @return array|null Bundle data or null on failure.
 	 */
 	public function from_directory( string $directory ): ?array {
+		try {
+			return AgentBundleLegacyAdapter::to_legacy_bundle( AgentBundleDirectory::read( $directory ) );
+		} catch ( BundleValidationException $e ) {
+			// Fall through to the legacy monolithic manifest reader for old exports.
+		}
+
 		$manifest_path = $directory . '/manifest.json';
 		if ( ! file_exists( $manifest_path ) ) {
 			return null;

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -23,13 +23,16 @@ final class AgentBundleFlowFile {
 	private array $steps;
 
 	private const OPTIONAL_STEP_FIELDS = array(
+		'step_type',
 		'handler_slug',
 		'handler_slugs',
+		'handler_config',
 		'enabled_tools',
 		'disabled_tools',
 		'prompt_queue',
 		'config_patch_queue',
 		'queue_mode',
+		'enabled',
 	);
 
 	public function __construct( string $slug, string $name, string $pipeline_slug, string $schedule, array $max_items, array $steps ) {
@@ -103,8 +106,19 @@ final class AgentBundleFlowFile {
 	}
 
 	private static function normalize_optional_step_field( string $field, $value ) {
-		if ( 'handler_slug' === $field ) {
+		if ( in_array( $field, array( 'step_type', 'handler_slug' ), true ) ) {
 			return (string) $value;
+		}
+
+		if ( 'enabled' === $field ) {
+			return (bool) $value;
+		}
+
+		if ( 'handler_config' === $field ) {
+			if ( ! is_array( $value ) ) {
+				throw new BundleValidationException( 'flow file handler_config must be an object.' );
+			}
+			return $value;
 		}
 
 		if ( in_array( $field, array( 'handler_slugs', 'enabled_tools', 'disabled_tools' ), true ) ) {

--- a/inc/Engine/Bundle/AgentBundleLegacyAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleLegacyAdapter.php
@@ -1,0 +1,331 @@
+<?php
+/**
+ * Adapter between legacy agent bundle arrays and directory value objects.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Converts AgentBundler's legacy runtime-state bundle arrays to the reviewable
+ * schema_version 1 directory documents, and back again for the existing importer.
+ */
+final class AgentBundleLegacyAdapter {
+
+	/**
+	 * Convert a legacy AgentBundler bundle array into directory value objects.
+	 *
+	 * @param array $bundle Legacy bundle array.
+	 * @return AgentBundleDirectory
+	 */
+	public static function from_legacy_bundle( array $bundle ): AgentBundleDirectory {
+		$pipeline_slugs = self::pipeline_slugs( $bundle['pipelines'] ?? array() );
+		$flow_slugs     = self::flow_slugs( $bundle['flows'] ?? array() );
+
+		$manifest = new AgentBundleManifest(
+			(string) ( $bundle['exported_at'] ?? gmdate( 'c' ) ),
+			self::exported_by(),
+			array(
+				'slug'         => $bundle['agent']['agent_slug'] ?? 'agent',
+				'label'        => $bundle['agent']['agent_name'] ?? ( $bundle['agent']['agent_slug'] ?? 'Agent' ),
+				'description'  => (string) ( $bundle['agent']['description'] ?? '' ),
+				'agent_config' => is_array( $bundle['agent']['agent_config'] ?? null ) ? $bundle['agent']['agent_config'] : array(),
+			),
+			array(
+				'memory'       => self::memory_paths_from_legacy( $bundle, $pipeline_slugs, $flow_slugs ),
+				'pipelines'    => array_values( $pipeline_slugs ),
+				'flows'        => array_values( $flow_slugs ),
+				'handler_auth' => 'refs',
+			)
+		);
+
+		return new AgentBundleDirectory(
+			$manifest,
+			self::memory_files_from_legacy( $bundle, $pipeline_slugs, $flow_slugs ),
+			self::pipeline_files_from_legacy( $bundle['pipelines'] ?? array(), $pipeline_slugs ),
+			self::flow_files_from_legacy( $bundle['flows'] ?? array(), $bundle['pipelines'] ?? array(), $pipeline_slugs, $flow_slugs )
+		);
+	}
+
+	/**
+	 * Convert directory value objects back into the legacy bundle array shape.
+	 *
+	 * @param AgentBundleDirectory $directory Bundle directory value object.
+	 * @return array Legacy bundle array.
+	 */
+	public static function to_legacy_bundle( AgentBundleDirectory $directory ): array {
+		$manifest      = $directory->manifest()->to_array();
+		$memory_files  = $directory->memory_files();
+		$pipeline_ids  = array();
+		$pipeline_keys = array();
+		$pipelines     = array();
+
+		foreach ( $directory->pipelines() as $index => $pipeline_file ) {
+			$pipeline_id = $index + 1;
+			$pipeline    = $pipeline_file->to_array();
+			$slug        = $pipeline['slug'];
+
+			$pipeline_ids[ $slug ] = $pipeline_id;
+			$pipeline_config       = array();
+			foreach ( $pipeline['steps'] as $step ) {
+				$position         = (int) $step['step_position'];
+				$pipeline_step_id = $pipeline_id . '_bundle_step_' . $position;
+				$step_config      = $step['step_config'];
+				$step_config['pipeline_step_id'] = $pipeline_step_id;
+				$step_config['step_type']        = $step['step_type'];
+				$step_config['execution_order']  = $position;
+
+				$pipeline_config[ $pipeline_step_id ] = $step_config;
+				$pipeline_keys[ $slug ][ $position ]  = $pipeline_step_id;
+			}
+
+			$pipelines[] = array(
+				'original_id'           => $pipeline_id,
+				'pipeline_name'         => $pipeline['name'],
+				'pipeline_config'       => $pipeline_config,
+				'memory_file_contents'  => self::strip_memory_prefix( $memory_files, 'pipelines/' . $slug . '/' ),
+			);
+		}
+
+		$flows = array();
+		foreach ( $directory->flows() as $index => $flow_file ) {
+			$flow_id = $index + 1;
+			$flow    = $flow_file->to_array();
+			$slug    = $flow['slug'];
+			$pipeline_slug = $flow['pipeline_slug'];
+			$pipeline_id   = $pipeline_ids[ $pipeline_slug ] ?? 0;
+
+			$flow_config = array();
+			foreach ( $flow['steps'] as $step ) {
+				$position         = (int) $step['step_position'];
+				$pipeline_step_id = $pipeline_keys[ $pipeline_slug ][ $position ] ?? ( $pipeline_id . '_bundle_step_' . $position );
+				$flow_step_id     = $pipeline_step_id . '_' . $flow_id;
+				$flow_config[ $flow_step_id ] = self::flow_step_config_from_document_step( $step, $pipeline_id, $flow_id, $pipeline_step_id, $flow_step_id );
+			}
+
+			$flows[] = array(
+				'original_id'           => $flow_id,
+				'original_pipeline_id'  => $pipeline_id,
+				'flow_name'             => $flow['name'],
+				'flow_config'           => $flow_config,
+				'scheduling_config'     => array(
+					'enabled'   => false,
+					'interval'  => $flow['schedule'],
+					'max_items' => $flow['max_items'],
+				),
+				'memory_file_contents'  => self::strip_memory_prefix( $memory_files, 'flows/' . $slug . '/' ),
+			);
+		}
+
+		return array(
+			'bundle_version'     => 1,
+			'exported_at'        => $manifest['exported_at'],
+			'agent'              => array(
+				'agent_slug'   => $manifest['agent']['slug'],
+				'agent_name'   => $manifest['agent']['label'],
+				'agent_config' => $manifest['agent']['agent_config'],
+				'site_scope'   => 'site',
+			),
+			'files'              => self::strip_memory_prefix( $memory_files, 'agent/' ),
+			'user_template'      => $memory_files['USER.md'] ?? '',
+			'pipelines'          => $pipelines,
+			'flows'              => $flows,
+			'abilities_manifest' => array(),
+		);
+	}
+
+	/** @param array<int,array<string,mixed>> $pipelines */
+	private static function pipeline_slugs( array $pipelines ): array {
+		$used  = array();
+		$slugs = array();
+		foreach ( $pipelines as $index => $pipeline ) {
+			$slug = PortableSlug::dedupe( PortableSlug::normalize( (string) ( $pipeline['pipeline_name'] ?? 'pipeline' ), 'pipeline' ), $used );
+			$used[]          = $slug;
+			$slugs[ $index ] = $slug;
+		}
+		return $slugs;
+	}
+
+	/** @param array<int,array<string,mixed>> $flows */
+	private static function flow_slugs( array $flows ): array {
+		$used  = array();
+		$slugs = array();
+		foreach ( $flows as $index => $flow ) {
+			$slug = PortableSlug::dedupe( PortableSlug::normalize( (string) ( $flow['flow_name'] ?? 'flow' ), 'flow' ), $used );
+			$used[]          = $slug;
+			$slugs[ $index ] = $slug;
+		}
+		return $slugs;
+	}
+
+	private static function exported_by(): string {
+		if ( defined( 'DATAMACHINE_VERSION' ) ) {
+			return 'data-machine/' . DATAMACHINE_VERSION;
+		}
+		return 'data-machine/unknown';
+	}
+
+	private static function memory_paths_from_legacy( array $bundle, array $pipeline_slugs, array $flow_slugs ): array {
+		return array_keys( self::memory_files_from_legacy( $bundle, $pipeline_slugs, $flow_slugs ) );
+	}
+
+	private static function memory_files_from_legacy( array $bundle, array $pipeline_slugs, array $flow_slugs ): array {
+		$memory = array();
+		foreach ( $bundle['files'] ?? array() as $path => $contents ) {
+			$memory[ 'agent/' . ltrim( (string) $path, '/' ) ] = (string) $contents;
+		}
+		if ( '' !== (string) ( $bundle['user_template'] ?? '' ) ) {
+			$memory['USER.md'] = (string) $bundle['user_template'];
+		}
+		foreach ( $bundle['pipelines'] ?? array() as $index => $pipeline ) {
+			$slug = $pipeline_slugs[ $index ] ?? PortableSlug::normalize( (string) ( $pipeline['pipeline_name'] ?? 'pipeline' ), 'pipeline' );
+			foreach ( $pipeline['memory_file_contents'] ?? array() as $path => $contents ) {
+				$memory[ 'pipelines/' . $slug . '/' . ltrim( (string) $path, '/' ) ] = (string) $contents;
+			}
+		}
+		foreach ( $bundle['flows'] ?? array() as $index => $flow ) {
+			$slug = $flow_slugs[ $index ] ?? PortableSlug::normalize( (string) ( $flow['flow_name'] ?? 'flow' ), 'flow' );
+			foreach ( $flow['memory_file_contents'] ?? array() as $path => $contents ) {
+				$memory[ 'flows/' . $slug . '/' . ltrim( (string) $path, '/' ) ] = (string) $contents;
+			}
+		}
+		ksort( $memory, SORT_STRING );
+		return $memory;
+	}
+
+	private static function pipeline_files_from_legacy( array $pipelines, array $pipeline_slugs ): array {
+		$files = array();
+		foreach ( $pipelines as $index => $pipeline ) {
+			$files[] = new AgentBundlePipelineFile(
+				$pipeline_slugs[ $index ] ?? (string) ( $pipeline['pipeline_name'] ?? 'pipeline' ),
+				(string) ( $pipeline['pipeline_name'] ?? 'Pipeline' ),
+				self::pipeline_steps_from_config( $pipeline['pipeline_config'] ?? array() )
+			);
+		}
+		return $files;
+	}
+
+	private static function flow_files_from_legacy( array $flows, array $pipelines, array $pipeline_slugs, array $flow_slugs ): array {
+		$pipeline_slugs_by_id = array();
+		$pipeline_step_types_by_id = array();
+		foreach ( $pipelines as $index => $pipeline ) {
+			$original_id = (int) ( $pipeline['original_id'] ?? ( $index + 1 ) );
+			$pipeline_slugs_by_id[ $original_id ] = $pipeline_slugs[ $index ] ?? PortableSlug::normalize( (string) ( $pipeline['pipeline_name'] ?? 'pipeline' ), 'pipeline' );
+			foreach ( $pipeline['pipeline_config'] ?? array() as $pipeline_step_id => $pipeline_step ) {
+				if ( is_array( $pipeline_step ) ) {
+					$pipeline_step_types_by_id[ (string) $pipeline_step_id ] = (string) ( $pipeline_step['step_type'] ?? '' );
+				}
+			}
+		}
+
+		$files = array();
+		foreach ( $flows as $index => $flow ) {
+			$old_pipeline_id = (int) ( $flow['original_pipeline_id'] ?? 0 );
+			$pipeline_slug   = $pipeline_slugs_by_id[ $old_pipeline_id ] ?? reset( $pipeline_slugs ) ?: 'pipeline';
+			$scheduling      = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
+
+			$files[] = new AgentBundleFlowFile(
+				$flow_slugs[ $index ] ?? (string) ( $flow['flow_name'] ?? 'flow' ),
+				(string) ( $flow['flow_name'] ?? 'Flow' ),
+				$pipeline_slug,
+				(string) ( $scheduling['interval'] ?? 'manual' ),
+				is_array( $scheduling['max_items'] ?? null ) ? $scheduling['max_items'] : array(),
+				self::flow_steps_from_config( $flow['flow_config'] ?? array(), $pipeline_step_types_by_id )
+			);
+		}
+		return $files;
+	}
+
+	private static function pipeline_steps_from_config( array $pipeline_config ): array {
+		$steps = array();
+		foreach ( $pipeline_config as $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+			$position = (int) ( $step['execution_order'] ?? count( $steps ) );
+			$steps[]  = array(
+				'step_position' => $position,
+				'step_type'     => (string) ( $step['step_type'] ?? '' ),
+				'step_config'   => self::without_keys( $step, array( 'pipeline_step_id' ) ),
+			);
+		}
+		return $steps;
+	}
+
+	private static function flow_steps_from_config( array $flow_config, array $pipeline_step_types_by_id ): array {
+		$steps = array();
+		foreach ( $flow_config as $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+			$pipeline_step_id = (string) ( $step['pipeline_step_id'] ?? '' );
+			$document_step = array(
+				'step_position'   => (int) ( $step['execution_order'] ?? count( $steps ) ),
+				'handler_configs' => self::handler_configs_from_step( $step ),
+			);
+			if ( ! isset( $step['step_type'] ) && isset( $pipeline_step_types_by_id[ $pipeline_step_id ] ) ) {
+				$document_step['step_type'] = $pipeline_step_types_by_id[ $pipeline_step_id ];
+			}
+
+			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'handler_config', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'enabled' ) as $field ) {
+				if ( array_key_exists( $field, $step ) ) {
+					$document_step[ $field ] = $step[ $field ];
+				}
+			}
+
+			$steps[] = $document_step;
+		}
+		return $steps;
+	}
+
+	private static function flow_step_config_from_document_step( array $step, int $pipeline_id, int $flow_id, string $pipeline_step_id, string $flow_step_id ): array {
+		$config = array(
+			'flow_step_id'     => $flow_step_id,
+			'pipeline_step_id' => $pipeline_step_id,
+			'pipeline_id'      => $pipeline_id,
+			'flow_id'          => $flow_id,
+			'execution_order'  => (int) $step['step_position'],
+		);
+
+		foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'enabled' ) as $field ) {
+			if ( array_key_exists( $field, $step ) ) {
+				$config[ $field ] = $step[ $field ];
+			}
+		}
+
+		return $config;
+	}
+
+	private static function handler_configs_from_step( array $step ): array {
+		if ( is_array( $step['handler_configs'] ?? null ) ) {
+			return $step['handler_configs'];
+		}
+
+		if ( is_string( $step['handler_slug'] ?? null ) && is_array( $step['handler_config'] ?? null ) ) {
+			return array( $step['handler_slug'] => $step['handler_config'] );
+		}
+
+		return array();
+	}
+
+	private static function strip_memory_prefix( array $memory_files, string $prefix ): array {
+		$files = array();
+		foreach ( $memory_files as $path => $contents ) {
+			if ( str_starts_with( (string) $path, $prefix ) ) {
+				$files[ substr( (string) $path, strlen( $prefix ) ) ] = $contents;
+			}
+		}
+		ksort( $files, SORT_STRING );
+		return $files;
+	}
+
+	private static function without_keys( array $data, array $keys ): array {
+		foreach ( $keys as $key ) {
+			unset( $data[ $key ] );
+		}
+		return $data;
+	}
+}

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Pure-PHP smoke test for AgentBundler directory value-object adapter (#1501).
+ *
+ * Run with: php tests/agent-bundler-directory-adapter-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook = '' ) {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		// no-op
+	}
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\AgentBundleLegacyAdapter;
+
+$failures = array();
+$passes   = 0;
+
+function assert_adapter( string $label, bool $condition ): void {
+	global $failures, $passes;
+	if ( $condition ) {
+		++$passes;
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	$failures[] = $label;
+	echo "  FAIL: {$label}\n";
+}
+
+function assert_adapter_equals( string $label, $expected, $actual ): void {
+	assert_adapter( $label, $expected === $actual );
+}
+
+function rm_adapter_tree( string $path ): void {
+	if ( ! is_dir( $path ) ) {
+		return;
+	}
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+	foreach ( $iterator as $file ) {
+		$file->isDir() ? rmdir( $file->getPathname() ) : unlink( $file->getPathname() );
+	}
+	rmdir( $path );
+}
+
+echo "=== AgentBundler Directory Adapter Smoke (#1501) ===\n";
+
+$legacy_bundle = array(
+	'bundle_version' => 1,
+	'exported_at'    => '2026-04-28T12:00:00Z',
+	'agent'          => array(
+		'agent_slug'   => 'review-agent',
+		'agent_name'   => 'Review Agent',
+		'agent_config' => array( 'model' => 'gpt-5.5' ),
+		'site_scope'   => 'site',
+	),
+	'files'          => array(
+		'SOUL.md'   => "# Soul\n",
+		'MEMORY.md' => "# Memory\n",
+	),
+	'user_template'  => "# User\n",
+	'pipelines'      => array(
+		array(
+			'original_id'          => 88,
+			'pipeline_name'        => 'PR Review Pipeline',
+			'pipeline_config'      => array(
+				'88_fetch' => array(
+					'pipeline_step_id' => '88_fetch',
+					'step_type'        => 'fetch',
+					'execution_order'  => 0,
+					'label'            => 'Fetch context',
+				),
+				'88_ai'    => array(
+					'pipeline_step_id' => '88_ai',
+					'step_type'        => 'ai',
+					'execution_order'  => 1,
+					'label'            => 'Review',
+					'system_prompt'    => 'Review carefully.',
+					'disabled_tools'   => array( 'datamachine/delete-flow' ),
+				),
+			),
+			'memory_file_contents' => array( 'pipeline.md' => "# Pipeline\n" ),
+		),
+	),
+	'flows'          => array(
+		array(
+			'original_id'          => 144,
+			'original_pipeline_id' => 88,
+			'flow_name'            => 'PR Review Flow',
+			'flow_config'          => array(
+				'88_fetch_144' => array(
+					'flow_step_id'       => '88_fetch_144',
+					'pipeline_step_id'   => '88_fetch',
+					'pipeline_id'        => 88,
+					'flow_id'            => 144,
+					'execution_order'    => 0,
+					'handler_slug'       => 'mcp',
+					'handler_config'     => array( 'provider' => 'github', 'auth_ref' => 'github:default' ),
+					'config_patch_queue' => array( array( 'after' => '2026-04-01' ) ),
+					'queue_mode'         => 'drain',
+					'enabled'            => true,
+				),
+				'88_ai_144'    => array(
+					'flow_step_id'     => '88_ai_144',
+					'pipeline_step_id' => '88_ai',
+					'pipeline_id'      => 88,
+					'flow_id'          => 144,
+					'execution_order'  => 1,
+					'enabled_tools'    => array( 'datamachine/get-github-pull-review-context' ),
+					'disabled_tools'   => array( 'datamachine/delete-flow' ),
+					'prompt_queue'     => array( array( 'prompt' => 'Review PR #1', 'added_at' => '2026-04-28T12:00:00Z' ) ),
+					'queue_mode'       => 'loop',
+				),
+			),
+			'scheduling_config'    => array( 'enabled' => true, 'interval' => 'hourly', 'max_items' => array( 'mcp' => 5 ) ),
+			'memory_file_contents' => array( 'flow.md' => "# Flow\n", 'files/context.json' => "{}\n" ),
+		),
+	),
+);
+
+echo "\n[1] Legacy bundle converts to value-object directory documents\n";
+$directory = AgentBundleLegacyAdapter::from_legacy_bundle( $legacy_bundle );
+$manifest  = $directory->manifest()->to_array();
+$pipeline  = $directory->pipelines()[0]->to_array();
+$flow      = $directory->flows()[0]->to_array();
+
+assert_adapter_equals( 'manifest uses portable agent slug', 'review-agent', $manifest['agent']['slug'] );
+assert_adapter_equals( 'pipeline document named by portable slug', 'pr-review-pipeline', $pipeline['slug'] );
+assert_adapter_equals( 'flow references pipeline by slug', 'pr-review-pipeline', $flow['pipeline_slug'] );
+assert_adapter_equals( 'pipeline document strips runtime pipeline_step_id', false, array_key_exists( 'pipeline_step_id', $pipeline['steps'][0]['step_config'] ) );
+assert_adapter_equals( 'flow document preserves handler config', array( 'provider' => 'github', 'auth_ref' => 'github:default' ), $flow['steps'][0]['handler_config'] );
+assert_adapter_equals( 'flow document preserves step type', 'fetch', $flow['steps'][0]['step_type'] );
+assert_adapter_equals( 'flow document preserves config patch queue', array( array( 'after' => '2026-04-01' ) ), $flow['steps'][0]['config_patch_queue'] );
+assert_adapter_equals( 'flow document preserves AI enabled tools', array( 'datamachine/get-github-pull-review-context' ), $flow['steps'][1]['enabled_tools'] );
+assert_adapter_equals( 'flow document preserves AI disabled tools', array( 'datamachine/delete-flow' ), $flow['steps'][1]['disabled_tools'] );
+assert_adapter_equals( 'flow document preserves prompt queue', 'Review PR #1', $flow['steps'][1]['prompt_queue'][0]['prompt'] );
+assert_adapter_equals( 'flow document preserves queue mode', 'loop', $flow['steps'][1]['queue_mode'] );
+assert_adapter_equals( 'flow document preserves scheduling interval', 'hourly', $flow['schedule'] );
+assert_adapter_equals( 'memory path moves agent files under memory/agent', "# Soul\n", $directory->memory_files()['agent/SOUL.md'] ?? null );
+
+echo "\n[2] Directory write/read uses AgentBundleDirectory layout\n";
+$tmp = sys_get_temp_dir() . '/datamachine-agent-bundler-adapter-' . getmypid();
+rm_adapter_tree( $tmp );
+$directory->write( $tmp );
+
+assert_adapter( 'manifest.json written', is_file( $tmp . '/manifest.json' ) );
+assert_adapter( 'pipeline JSON written by portable slug', is_file( $tmp . '/pipelines/pr-review-pipeline.json' ) );
+assert_adapter( 'flow JSON written by portable slug', is_file( $tmp . '/flows/pr-review-flow.json' ) );
+assert_adapter( 'agent memory written under memory/agent', is_file( $tmp . '/memory/agent/SOUL.md' ) );
+
+$read_directory = AgentBundleDirectory::read( $tmp );
+$round_trip     = AgentBundleLegacyAdapter::to_legacy_bundle( $read_directory );
+$round_flow     = $round_trip['flows'][0];
+$round_steps    = array_values( $round_flow['flow_config'] );
+
+assert_adapter_equals( 'round-trip reconstructs one pipeline', 1, count( $round_trip['pipelines'] ) );
+assert_adapter_equals( 'round-trip reconstructs one flow', 1, count( $round_trip['flows'] ) );
+assert_adapter_equals( 'round-trip preserves pipeline memory', "# Pipeline\n", $round_trip['pipelines'][0]['memory_file_contents']['pipeline.md'] ?? null );
+assert_adapter_equals( 'round-trip preserves flow file memory', "{}\n", $round_trip['flows'][0]['memory_file_contents']['files/context.json'] ?? null );
+assert_adapter_equals( 'round-trip preserves handler config', array( 'auth_ref' => 'github:default', 'provider' => 'github' ), $round_steps[0]['handler_config'] );
+assert_adapter_equals( 'round-trip preserves step type', 'fetch', $round_steps[0]['step_type'] );
+assert_adapter_equals( 'round-trip preserves config patch queue', array( array( 'after' => '2026-04-01' ) ), $round_steps[0]['config_patch_queue'] );
+assert_adapter_equals( 'round-trip preserves enabled flag', true, $round_steps[0]['enabled'] );
+assert_adapter_equals( 'round-trip preserves enabled tools', array( 'datamachine/get-github-pull-review-context' ), $round_steps[1]['enabled_tools'] );
+assert_adapter_equals( 'round-trip preserves disabled tools', array( 'datamachine/delete-flow' ), $round_steps[1]['disabled_tools'] );
+assert_adapter_equals( 'round-trip preserves prompt queue', 'Review PR #1', $round_steps[1]['prompt_queue'][0]['prompt'] );
+assert_adapter_equals( 'round-trip preserves queue mode', 'loop', $round_steps[1]['queue_mode'] );
+assert_adapter_equals( 'round-trip preserves scheduling interval', 'hourly', $round_flow['scheduling_config']['interval'] );
+
+echo "\n[3] AgentBundler directory methods route through the adapter\n";
+$agent_bundler_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Agents/AgentBundler.php' ) ?: '';
+assert_adapter( 'to_directory writes AgentBundleLegacyAdapter output', false !== strpos( $agent_bundler_source, 'AgentBundleLegacyAdapter::from_legacy_bundle( $bundle )->write( $directory )' ) );
+assert_adapter( 'from_directory reads AgentBundleDirectory before legacy fallback', false !== strpos( $agent_bundler_source, 'AgentBundleLegacyAdapter::to_legacy_bundle( AgentBundleDirectory::read( $directory ) )' ) );
+
+rm_adapter_tree( $tmp );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAILED: " . count( $failures ) . " agent bundler directory adapter assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} agent bundler directory adapter assertions passed.\n";


### PR DESCRIPTION
## Summary
- Routes AgentBundler directory/ZIP exports through the bundle value-object directory format instead of maintaining a separate ad-hoc directory writer.
- Adds a focused legacy-array adapter so existing import/export callers keep their current bundle-array contract while directory exports become review-friendly JSON documents.

## Changes
- Added `AgentBundleLegacyAdapter` to convert legacy AgentBundler bundle arrays to/from `AgentBundleDirectory`, `AgentBundleManifest`, `AgentBundlePipelineFile`, and `AgentBundleFlowFile`.
- Switched `AgentBundler::to_directory()` to write via `AgentBundleDirectory` and `AgentBundler::from_directory()` to read the value-object format first, with fallback for older monolithic directory exports.
- Extended flow bundle documents to preserve portable step metadata needed by the current importer path: `step_type`, scalar `handler_config`, and `enabled`.
- Added a pure-PHP smoke covering handler config, config patch queue, prompt queue, enabled/disabled tools, queue mode, enabled state, scheduling, and memory-file round-trip through the adapter.

## Tests
- `php -l inc/Engine/Bundle/AgentBundleLegacyAdapter.php && php -l inc/Engine/Bundle/AgentBundleFlowFile.php && php -l inc/Core/Agents/AgentBundler.php && php -l tests/agent-bundler-directory-adapter-smoke.php`
- `php tests/agent-bundle-format-smoke.php && php tests/agent-bundler-directory-adapter-smoke.php`
- `git diff --check`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@refactor-agent-bundler-value-objects --changed-since origin/main`

Full `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@refactor-agent-bundler-value-objects` is still blocked by existing repo-wide phpstan noise unrelated to this diff.

Refs #1501. Remaining follow-up: compile workflow-shaped bundle documents into fresh runtime config during DB import instead of reconstructing the legacy array shape first.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the first AgentBundler/value-object unification slice under Chris's direction; Chris remains responsible for review and merge.
