### PR TITLE
fix(workflow): centralize workflow spec validation

### DIFF
--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -11,8 +11,8 @@
 
 namespace DataMachine\Abilities\Job;
 
-use DataMachine\Abilities\StepTypeAbilities;
 use DataMachine\Core\Steps\WorkflowConfigFactory;
+use DataMachine\Core\Steps\WorkflowSpecValidator;
 use DataMachine\Engine\ExecutionPlan;
 
 defined( 'ABSPATH' ) || exit;
@@ -103,7 +103,7 @@ class ExecuteWorkflowAbility {
 		$initial_data = is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array();
 
 		// Validate workflow structure
-		$validation = $this->validateWorkflow( $workflow );
+		$validation = WorkflowSpecValidator::validate( $workflow );
 		if ( ! $validation['valid'] ) {
 			return array(
 				'success' => false,
@@ -284,56 +284,4 @@ class ExecuteWorkflowAbility {
 			'message'        => 'Ephemeral workflow scheduled for one-time execution at ' . wp_date( 'M j, Y g:i A', $timestamp ),
 		);
 	}
-
-	/**
-	 * Validate workflow structure.
-	 *
-	 * @param array|null $workflow Workflow to validate.
-	 * @return array Validation result with 'valid' boolean and optional 'error' string.
-	 */
-	private function validateWorkflow( $workflow ): array {
-		if ( ! isset( $workflow['steps'] ) || ! is_array( $workflow['steps'] ) ) {
-			return array(
-				'valid' => false,
-				'error' => 'Workflow must contain steps array',
-			);
-		}
-
-		if ( empty( $workflow['steps'] ) ) {
-			return array(
-				'valid' => false,
-				'error' => 'Workflow must have at least one step',
-			);
-		}
-
-		$step_type_abilities = new StepTypeAbilities();
-		$valid_types         = array_keys( $step_type_abilities->getAllStepTypes() );
-
-		foreach ( $workflow['steps'] as $index => $step ) {
-			if ( ! isset( $step['type'] ) ) {
-				return array(
-					'valid' => false,
-					'error' => "Step {$index} missing type",
-				);
-			}
-
-			if ( ! in_array( $step['type'], $valid_types, true ) ) {
-				return array(
-					'valid' => false,
-					'error' => "Step {$index} has invalid type: {$step['type']}. Valid types: " . implode( ', ', $valid_types ),
-				);
-			}
-		}
-
-		// Step types own their config requirements — handler_slug
-		// presence, handler_config shape, and any other per-type
-		// invariants are validated by each step's own executeStep() at
-		// runtime, not here. The workflow validator only enforces
-		// structural invariants (the workflow has steps; each step has
-		// a registered type) and leaves per-type validation to the
-		// step types themselves.
-
-		return array( 'valid' => true );
-	}
-
 }

--- a/inc/Abilities/Pipeline/PipelineHelpers.php
+++ b/inc/Abilities/Pipeline/PipelineHelpers.php
@@ -18,6 +18,7 @@ use DataMachine\Abilities\StepTypeAbilities;
 use DataMachine\Core\Admin\DateFormatter;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\Steps\WorkflowSpecValidator;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -66,7 +67,7 @@ trait PipelineHelpers {
 		// Batch flow data to avoid N+1 queries across the list.
 		$pipeline_ids = array_map( fn( $p ) => (int) $p['pipeline_id'], $pipelines );
 
-		$flow_counts = array();
+		$flow_counts       = array();
 		$flows_by_pipeline = array();
 
 		if ( ! empty( $pipeline_ids ) ) {
@@ -210,33 +211,9 @@ trait PipelineHelpers {
 	 * @return bool|string True if valid, error message if not.
 	 */
 	protected function validateWorkflow( array $workflow ): bool|string {
-		if ( ! isset( $workflow['steps'] ) || ! is_array( $workflow['steps'] ) ) {
-			return 'Workflow must contain steps array';
-		}
+		$validation = WorkflowSpecValidator::validate( $workflow );
 
-		if ( empty( $workflow['steps'] ) ) {
-			return 'Workflow must have at least one step';
-		}
-
-		$step_type_abilities = new StepTypeAbilities();
-		$valid_types         = array_keys( $step_type_abilities->getAllStepTypes() );
-
-		foreach ( $workflow['steps'] as $index => $step ) {
-			if ( ! is_array( $step ) ) {
-				return "Workflow step at index {$index} must be an object";
-			}
-
-			$step_type = $step['type'] ?? null;
-			if ( empty( $step_type ) || ! is_string( $step_type ) ) {
-				return "Workflow step at index {$index} is missing required type";
-			}
-
-			if ( ! in_array( $step_type, $valid_types, true ) ) {
-				return "Workflow step at index {$index} has invalid type '{$step_type}'. Must be one of: " . implode( ', ', $valid_types );
-			}
-		}
-
-		return true;
+		return $validation['valid'] ? true : $validation['error'];
 	}
 
 	/**

--- a/inc/Core/Steps/WorkflowConfigFactory.php
+++ b/inc/Core/Steps/WorkflowConfigFactory.php
@@ -28,14 +28,8 @@ class WorkflowConfigFactory {
 			$step_id          = "ephemeral_step_{$index}";
 			$pipeline_step_id = "ephemeral_pipeline_{$index}";
 
-			$flow_config[ $step_id ] = FlowStepConfigFactory::buildFromWorkflowStep( $step, $index );
-
-			if ( 'ai' === ( $step['type'] ?? '' ) ) {
-				$pipeline_config[ $pipeline_step_id ] = array(
-					'system_prompt'  => $step['system_prompt'] ?? '',
-					'disabled_tools' => $step['disabled_tools'] ?? array(),
-				);
-			}
+			$flow_config[ $step_id ]              = FlowStepConfigFactory::buildFromWorkflowStep( $step, $index );
+			$pipeline_config[ $pipeline_step_id ] = self::pipelineStepFromWorkflowStep( $step, $pipeline_step_id, $index );
 		}
 
 		return array(
@@ -55,7 +49,7 @@ class WorkflowConfigFactory {
 		$pipeline_config = array();
 
 		foreach ( $workflow['steps'] as $index => $step ) {
-			$pipeline_step_id                    = $pipeline_id . '_' . wp_generate_uuid4();
+			$pipeline_step_id                     = $pipeline_id . '_' . wp_generate_uuid4();
 			$pipeline_config[ $pipeline_step_id ] = self::pipelineStepFromWorkflowStep( $step, $pipeline_step_id, $index );
 		}
 

--- a/inc/Core/Steps/WorkflowSpecValidator.php
+++ b/inc/Core/Steps/WorkflowSpecValidator.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Workflow spec validator.
+ *
+ * @package DataMachine\Core\Steps
+ */
+
+namespace DataMachine\Core\Steps;
+
+use DataMachine\Abilities\StepTypeAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Validates the structural workflow JSON contract shared by workflow consumers.
+ */
+class WorkflowSpecValidator {
+
+	/**
+	 * Validate a workflow spec.
+	 *
+	 * This validates only structural invariants. Step types still own their
+	 * handler/config requirements at runtime.
+	 *
+	 * @param mixed $workflow Workflow spec to validate.
+	 * @return array{valid: bool, error?: string}
+	 */
+	public static function validate( $workflow ): array {
+		if ( ! is_array( $workflow ) || ! isset( $workflow['steps'] ) || ! is_array( $workflow['steps'] ) ) {
+			return array(
+				'valid' => false,
+				'error' => 'Workflow must contain steps array',
+			);
+		}
+
+		if ( ! array_is_list( $workflow['steps'] ) ) {
+			return array(
+				'valid' => false,
+				'error' => 'Workflow steps must be a list',
+			);
+		}
+
+		if ( empty( $workflow['steps'] ) ) {
+			return array(
+				'valid' => false,
+				'error' => 'Workflow must have at least one step',
+			);
+		}
+
+		$step_type_abilities = new StepTypeAbilities();
+		$valid_types         = array_keys( $step_type_abilities->getAllStepTypes() );
+
+		foreach ( $workflow['steps'] as $index => $step ) {
+			if ( ! is_array( $step ) ) {
+				return array(
+					'valid' => false,
+					'error' => "Workflow step at index {$index} must be an object",
+				);
+			}
+
+			$step_type = $step['type'] ?? null;
+			if ( ! is_string( $step_type ) || '' === trim( $step_type ) ) {
+				return array(
+					'valid' => false,
+					'error' => "Step {$index} missing type",
+				);
+			}
+
+			if ( ! in_array( $step_type, $valid_types, true ) ) {
+				return array(
+					'valid' => false,
+					'error' => "Step {$index} has invalid type: {$step_type}. Valid types: " . implode( ', ', $valid_types ),
+				);
+			}
+		}
+
+		return array( 'valid' => true );
+	}
+}

--- a/tests/workflow-persistent-install-smoke.php
+++ b/tests/workflow-persistent-install-smoke.php
@@ -57,6 +57,7 @@ if ( ! function_exists( 'wp_generate_uuid4' ) ) {
 
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
+require_once __DIR__ . '/../inc/Core/Steps/WorkflowSpecValidator.php';
 require_once __DIR__ . '/../inc/Core/Steps/WorkflowConfigFactory.php';
 
 use DataMachine\Core\Steps\WorkflowConfigFactory;
@@ -111,6 +112,17 @@ $workflow = array(
 		),
 	),
 );
+
+$ephemeral_config = WorkflowConfigFactory::buildEphemeralConfigs( $workflow );
+$ephemeral_steps  = array_values( $ephemeral_config['pipeline_config'] );
+
+assert_workflow_equals( 3, count( $ephemeral_config['pipeline_config'] ), 'ephemeral pipeline contains every workflow step', $failures, $passes );
+assert_workflow_equals( array( 'fetch', 'ai', 'ai' ), array_column( $ephemeral_steps, 'step_type' ), 'ephemeral pipeline preserves workflow step order', $failures, $passes );
+assert_workflow_equals( array( 0, 1, 2 ), array_column( $ephemeral_steps, 'execution_order' ), 'ephemeral pipeline stores contiguous execution order', $failures, $passes );
+assert_workflow_equals( 'Webhook Payload', $ephemeral_steps[0]['label'] ?? null, 'ephemeral pipeline preserves fetch label', $failures, $passes );
+assert_workflow_equals( 'Review Pull Request', $ephemeral_steps[1]['label'] ?? null, 'ephemeral pipeline preserves AI label', $failures, $passes );
+assert_workflow_equals( 'Review the PR.', $ephemeral_steps[1]['system_prompt'] ?? null, 'ephemeral pipeline preserves AI system prompt', $failures, $passes );
+assert_workflow_equals( array( 'datamachine/delete-flow' ), $ephemeral_steps[1]['disabled_tools'] ?? null, 'ephemeral pipeline preserves AI disabled tools', $failures, $passes );
 
 $pipeline_config = WorkflowConfigFactory::buildPersistentPipelineConfig( $workflow, 88 );
 $pipeline_steps  = array_values( $pipeline_config );

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Pure-PHP smoke test for workflow spec validation and ephemeral config shape.
+ *
+ * Run with: php tests/workflow-spec-contract-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities\Flow {
+	if ( ! class_exists( QueueAbility::class, false ) ) {
+		class QueueAbility {
+			const SLOT_PROMPT_QUEUE       = 'prompt_queue';
+			const SLOT_CONFIG_PATCH_QUEUE = 'config_patch_queue';
+		}
+	}
+}
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = 'default' ): string {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( string $hook ): bool {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( string $hook ): int {
+		return 1;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		// no-op for tests.
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_step_types' !== $hook ) {
+			return $value;
+		}
+
+		return array(
+			'ai'           => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'fetch'        => array( 'uses_handler' => true, 'multi_handler' => false ),
+			'publish'      => array( 'uses_handler' => true, 'multi_handler' => true ),
+			'system_task'  => array( 'uses_handler' => false, 'multi_handler' => false ),
+			'webhook_gate' => array( 'uses_handler' => false, 'multi_handler' => false ),
+		);
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		// no-op for tests.
+	}
+}
+
+require_once __DIR__ . '/../inc/Abilities/StepTypeAbilities.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
+require_once __DIR__ . '/../inc/Core/Steps/WorkflowSpecValidator.php';
+require_once __DIR__ . '/../inc/Core/Steps/WorkflowConfigFactory.php';
+require_once __DIR__ . '/../inc/Abilities/Pipeline/PipelineHelpers.php';
+
+use DataMachine\Abilities\Pipeline\PipelineHelpers;
+use DataMachine\Core\Steps\WorkflowConfigFactory;
+use DataMachine\Core\Steps\WorkflowSpecValidator;
+
+class WorkflowSpecPipelineHarness {
+	use PipelineHelpers;
+
+	public function validateForTest( array $workflow ): bool|string {
+		return $this->validateWorkflow( $workflow );
+	}
+}
+
+function workflow_execute_edge_for_test( $workflow ): array {
+	$validation = WorkflowSpecValidator::validate( $workflow );
+	if ( ! $validation['valid'] ) {
+		return array(
+			'success' => false,
+			'error'   => $validation['error'] ?? 'Workflow validation failed',
+		);
+	}
+
+	return array( 'success' => true );
+}
+
+$failures = array();
+$passes   = 0;
+
+function assert_workflow_spec_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+echo "workflow-spec-contract-smoke\n";
+
+$pipeline_harness = new WorkflowSpecPipelineHarness();
+$invalid_cases    = array(
+	'missing steps'     => array(),
+	'empty steps'       => array( 'steps' => array() ),
+	'associative steps' => array( 'steps' => array( 'first' => array( 'type' => 'fetch' ) ) ),
+	'scalar step'       => array( 'steps' => array( 'fetch' ) ),
+	'missing type'      => array( 'steps' => array( array( 'handler_slug' => 'rss' ) ) ),
+	'non-string type'   => array( 'steps' => array( array( 'type' => 123 ) ) ),
+	'unknown type'      => array( 'steps' => array( array( 'type' => 'time_travel' ) ) ),
+);
+
+foreach ( $invalid_cases as $case => $workflow ) {
+	$execute_result = workflow_execute_edge_for_test( $workflow );
+	$pipeline_error = $pipeline_harness->validateForTest( $workflow );
+
+	assert_workflow_spec_equals( false, $execute_result['success'], "execute-workflow rejects {$case}", $failures, $passes );
+	assert_workflow_spec_equals( $execute_result['error'], $pipeline_error, "create-pipeline shares {$case} validation error", $failures, $passes );
+}
+
+$valid_workflow = array(
+	'steps' => array(
+		array( 'type' => 'fetch' ),
+		array( 'type' => 'ai' ),
+		array( 'type' => 'system_task', 'handler_config' => array( 'task' => 'daily_memory_generation' ) ),
+	),
+);
+
+assert_workflow_spec_equals( array( 'valid' => true ), WorkflowSpecValidator::validate( $valid_workflow ), 'shared validator accepts valid structural workflow', $failures, $passes );
+assert_workflow_spec_equals( true, $pipeline_harness->validateForTest( $valid_workflow ), 'create-pipeline adapter accepts valid workflow', $failures, $passes );
+assert_workflow_spec_equals( array( 'success' => true ), workflow_execute_edge_for_test( $valid_workflow ), 'execute-workflow adapter accepts valid workflow', $failures, $passes );
+
+$configs         = WorkflowConfigFactory::buildEphemeralConfigs(
+	array(
+		'steps' => array(
+			array(
+				'type'           => 'fetch',
+				'label'          => 'Fetch Source',
+				'handler_slug'   => 'mcp',
+				'handler_config' => array( 'server' => 'a8c' ),
+			),
+			array(
+				'type'           => 'ai',
+				'label'          => 'Summarize',
+				'system_prompt'  => 'Be concise.',
+				'disabled_tools' => array( 'danger_tool' ),
+			),
+			array(
+				'type'           => 'system_task',
+				'label'          => 'Cleanup',
+				'handler_config' => array( 'task' => 'retention_logs' ),
+			),
+		),
+	)
+);
+$pipeline_config = $configs['pipeline_config'];
+$pipeline_steps  = array_values( $pipeline_config );
+
+assert_workflow_spec_equals( array( 'ephemeral_pipeline_0', 'ephemeral_pipeline_1', 'ephemeral_pipeline_2' ), array_keys( $pipeline_config ), 'ephemeral pipeline_config has one row per workflow step', $failures, $passes );
+assert_workflow_spec_equals( array( 'fetch', 'ai', 'system_task' ), array_column( $pipeline_steps, 'step_type' ), 'ephemeral pipeline_config preserves step types', $failures, $passes );
+assert_workflow_spec_equals( array( 0, 1, 2 ), array_column( $pipeline_steps, 'execution_order' ), 'ephemeral pipeline_config preserves execution order', $failures, $passes );
+assert_workflow_spec_equals( 'Fetch Source', $pipeline_steps[0]['label'] ?? null, 'ephemeral pipeline_config preserves fetch label', $failures, $passes );
+assert_workflow_spec_equals( 'Be concise.', $pipeline_steps[1]['system_prompt'] ?? null, 'ephemeral pipeline_config preserves AI system prompt', $failures, $passes );
+assert_workflow_spec_equals( array( 'danger_tool' ), $pipeline_steps[1]['disabled_tools'] ?? null, 'ephemeral pipeline_config preserves AI disabled tools', $failures, $passes );
+assert_workflow_spec_equals( 'Cleanup', $pipeline_steps[2]['label'] ?? null, 'ephemeral pipeline_config preserves system_task label', $failures, $passes );
+assert_workflow_spec_equals( false, array_key_exists( 'system_prompt', $pipeline_steps[2] ), 'non-AI ephemeral pipeline rows do not gain AI metadata', $failures, $passes );
+
+$execute_source  = file_get_contents( __DIR__ . '/../inc/Abilities/Job/ExecuteWorkflowAbility.php' ) ?: '';
+$pipeline_source = file_get_contents( __DIR__ . '/../inc/Abilities/Pipeline/PipelineHelpers.php' ) ?: '';
+
+assert_workflow_spec_equals( 1, substr_count( $execute_source, 'WorkflowSpecValidator::validate' ), 'execute-workflow calls shared validator once', $failures, $passes );
+assert_workflow_spec_equals( 1, substr_count( $pipeline_source, 'WorkflowSpecValidator::validate' ), 'create-pipeline helper calls shared validator once', $failures, $passes );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " workflow spec assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} workflow spec assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Centralizes workflow JSON validation behind WorkflowSpecValidator so execute-workflow and create-pipeline share the same structural contract.
- Makes ephemeral workflow pipeline_config symmetric with persisted workflow compilation for all step types.
- Adds smoke coverage for shared validation and ephemeral/persistent workflow config parity.

Closes #1497
Closes #1498

## Tests
- php tests/workflow-spec-contract-smoke.php
- php tests/workflow-persistent-install-smoke.php
- php tests/flow-step-config-factory-smoke.php
- php tests/system-task-config-passthrough-smoke.php
- php tests/pipeline-tool-policy-snapshot-smoke.php
- php tests/system-task-workflow-validation-smoke.php
- homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-workflow-spec-contract --changed-since origin/main

## Notes
- Changed-since PHPCS passes and Homeboy reports no lint baseline delta.
- The lint command still exits nonzero because the current runner feeds PHP files to ESLint; no new lint findings remain.
- Changed-since audit prints 140 changed-file findings as pre-existing/no-baseline and hangs, so it was not used as a gate for this PR.

## AI assistance
- AI assistance: Yes
- Tool(s): OpenCode (GPT-5.5)
- Used for: Drafting the implementation and smoke tests; Chris reviewed direction and test results.