### PR TITLE
feat(pipeline): support workflow specs in bulk create

### DIFF
--- a/inc/Abilities/Pipeline/CreatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/CreatePipelineAbility.php
@@ -58,11 +58,11 @@ class CreatePipelineAbility {
 							),
 							'pipelines'     => array(
 								'type'        => 'array',
-								'description' => __( 'Bulk mode: create multiple pipelines. Each item: {name, steps?, flow_name?, scheduling_config?}', 'data-machine' ),
+								'description' => __( 'Bulk mode: create multiple pipelines. Each item: {name, workflow?, steps?, flow_name?, scheduling_config?}', 'data-machine' ),
 							),
 							'template'      => array(
 								'type'        => 'object',
-								'description' => __( 'Shared config for bulk mode applied to all pipelines: {steps, scheduling_config}', 'data-machine' ),
+								'description' => __( 'Shared config for bulk mode applied to all pipelines: {workflow, steps, scheduling_config}', 'data-machine' ),
 							),
 							'validate_only' => array(
 								'type'        => 'boolean',
@@ -152,7 +152,7 @@ class CreatePipelineAbility {
 		$workflow    = isset( $input['workflow'] ) && is_array( $input['workflow'] ) ? $input['workflow'] : array();
 		$flow_config = $input['flow_config'] ?? array();
 
-		$has_steps = ! empty( $steps ) && is_array( $steps );
+		$has_steps    = ! empty( $steps ) && is_array( $steps );
 		$has_workflow = ! empty( $workflow );
 
 		if ( $has_workflow ) {
@@ -321,9 +321,23 @@ class CreatePipelineAbility {
 		$template      = $input['template'] ?? array();
 		$validate_only = ! empty( $input['validate_only'] );
 
-		// Pre-validation: check handler slugs in template
-		$template_steps = $template['steps'] ?? array();
-		if ( ! empty( $template_steps ) ) {
+		// Pre-validation: check handler slugs in template.
+		$template_workflow = isset( $template['workflow'] ) && is_array( $template['workflow'] ) ? $template['workflow'] : array();
+		$template_steps    = $template['steps'] ?? array();
+		if ( ! empty( $template_workflow ) ) {
+			$validation = $this->validateWorkflow( $template_workflow );
+			if ( true !== $validation ) {
+				return array(
+					'success' => false,
+					'error'   => 'Template workflow validation failed: ' . $validation,
+				);
+			}
+
+			$handler_validation = $this->validateHandlerSlugs( $template_workflow['steps'] );
+			if ( true !== $handler_validation ) {
+				return $handler_validation;
+			}
+		} elseif ( ! empty( $template_steps ) ) {
 			$validation = $this->validateSteps( $template_steps );
 			if ( true !== $validation ) {
 				return array(
@@ -351,7 +365,29 @@ class CreatePipelineAbility {
 				continue;
 			}
 
-			// Validate per-pipeline steps if provided
+			$per_pipeline_workflow = isset( $pipeline_config['workflow'] ) && is_array( $pipeline_config['workflow'] ) ? $pipeline_config['workflow'] : array();
+
+			// Per-pipeline workflow wins over per-pipeline steps.
+			if ( ! empty( $per_pipeline_workflow ) ) {
+				$workflow_validation = $this->validateWorkflow( $per_pipeline_workflow );
+				if ( true !== $workflow_validation ) {
+					$validation_errors[] = array(
+						'index'       => $index,
+						'name'        => $name,
+						'error'       => 'Workflow validation failed: ' . $workflow_validation,
+						'remediation' => 'Fix the workflow configuration for this pipeline',
+					);
+					continue;
+				}
+
+				$handler_validation = $this->validateHandlerSlugs( $per_pipeline_workflow['steps'] );
+				if ( true !== $handler_validation ) {
+					$validation_errors[] = $this->handlerValidationError( $index, $name, $handler_validation );
+				}
+				continue;
+			}
+
+			// Validate per-pipeline steps if provided.
 			$per_pipeline_steps = $pipeline_config['steps'] ?? array();
 			if ( ! empty( $per_pipeline_steps ) ) {
 				$steps_validation = $this->validateSteps( $per_pipeline_steps );
@@ -367,12 +403,7 @@ class CreatePipelineAbility {
 
 				$handler_validation = $this->validateHandlerSlugs( $per_pipeline_steps );
 				if ( true !== $handler_validation ) {
-					$validation_errors[] = array(
-						'index'       => $index,
-						'name'        => $name,
-						'error'       => $handler_validation['error'],
-						'remediation' => 'Use valid handler slugs from the list_handlers tool',
-					);
+					$validation_errors[] = $this->handlerValidationError( $index, $name, $handler_validation );
 				}
 			}
 		}
@@ -389,12 +420,15 @@ class CreatePipelineAbility {
 		if ( $validate_only ) {
 			$preview = array();
 			foreach ( $pipelines as $index => $pipeline_config ) {
-				$name  = $pipeline_config['name'];
-				$steps = ! empty( $pipeline_config['steps'] ) ? $pipeline_config['steps'] : $template_steps;
+				$name     = $pipeline_config['name'];
+				$resolved = $this->resolveBulkPipelineSpec( $pipeline_config, $template_workflow, $template_steps );
+				$workflow = $resolved['workflow'];
+				$steps    = $resolved['steps'];
 
 				$preview_item = array(
-					'name'  => $name,
-					'steps' => count( $steps ),
+					'name'          => $name,
+					'steps'         => ! empty( $workflow ) ? count( $workflow['steps'] ?? array() ) : count( $steps ),
+					'creation_mode' => ! empty( $workflow ) ? 'workflow' : ( ! empty( $steps ) ? 'batch' : 'simple' ),
 				);
 
 				$has_flow = isset( $pipeline_config['flow_name'] ) || isset( $pipeline_config['scheduling_config'] ) || isset( $template['scheduling_config'] );
@@ -425,13 +459,20 @@ class CreatePipelineAbility {
 		$agent_id = isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
 
 		foreach ( $pipelines as $index => $pipeline_config ) {
-			$name  = $pipeline_config['name'];
-			$steps = ! empty( $pipeline_config['steps'] ) ? $pipeline_config['steps'] : $template_steps;
+			$name     = $pipeline_config['name'];
+			$resolved = $this->resolveBulkPipelineSpec( $pipeline_config, $template_workflow, $template_steps );
+			$workflow = $resolved['workflow'];
+			$steps    = $resolved['steps'];
 
 			$single_input = array(
 				'pipeline_name' => $name,
-				'steps'         => $steps,
 			);
+
+			if ( ! empty( $workflow ) ) {
+				$single_input['workflow'] = $workflow;
+			} else {
+				$single_input['steps'] = $steps;
+			}
 
 			if ( null !== $agent_id && $agent_id > 0 ) {
 				$single_input['agent_id'] = $agent_id;
@@ -506,6 +547,53 @@ class CreatePipelineAbility {
 			'partial'       => $partial,
 			'message'       => $message,
 			'creation_mode' => 'bulk',
+		);
+	}
+
+	/**
+	 * Resolve the effective step source for a bulk pipeline entry.
+	 *
+	 * @param array $pipeline_config Pipeline entry config.
+	 * @param array $template_workflow Shared workflow template.
+	 * @param array $template_steps Shared legacy steps template.
+	 * @return array{workflow: array, steps: array}
+	 */
+	private function resolveBulkPipelineSpec( array $pipeline_config, array $template_workflow, array $template_steps ): array {
+		$workflow = isset( $pipeline_config['workflow'] ) && is_array( $pipeline_config['workflow'] ) && ! empty( $pipeline_config['workflow'] )
+			? $pipeline_config['workflow']
+			: array();
+		$steps    = array();
+
+		if ( empty( $workflow ) ) {
+			if ( ! empty( $pipeline_config['steps'] ) ) {
+				$steps = $pipeline_config['steps'];
+			} elseif ( ! empty( $template_workflow ) ) {
+				$workflow = $template_workflow;
+			} else {
+				$steps = $template_steps;
+			}
+		}
+
+		return array(
+			'workflow' => $workflow,
+			'steps'    => $steps,
+		);
+	}
+
+	/**
+	 * Build a bulk validation error for invalid handler slugs.
+	 *
+	 * @param int   $index Pipeline entry index.
+	 * @param string $name Pipeline name.
+	 * @param array $handler_validation Handler validation result.
+	 * @return array<string,mixed> Validation error item.
+	 */
+	private function handlerValidationError( int $index, string $name, array $handler_validation ): array {
+		return array(
+			'index'       => $index,
+			'name'        => $name,
+			'error'       => $handler_validation['error'],
+			'remediation' => 'Use valid handler slugs from the list_handlers tool',
 		);
 	}
 }

--- a/tests/bulk-create-pipeline-workflow-smoke.php
+++ b/tests/bulk-create-pipeline-workflow-smoke.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Pure-PHP smoke test for bulk create-pipeline workflow spec resolution.
+ *
+ * Run with: php tests/bulk-create-pipeline-workflow-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities\Flow {
+	if ( ! class_exists( QueueAbility::class, false ) ) {
+		class QueueAbility {
+			const SLOT_PROMPT_QUEUE       = 'prompt_queue';
+			const SLOT_CONFIG_PATCH_QUEUE = 'config_patch_queue';
+		}
+	}
+}
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		if ( 'datamachine_step_types' === $hook ) {
+			return array(
+				'ai'      => array( 'uses_handler' => false, 'multi_handler' => false ),
+				'fetch'   => array( 'uses_handler' => true, 'multi_handler' => false ),
+				'publish' => array( 'uses_handler' => true, 'multi_handler' => true ),
+			);
+		}
+
+		if ( 'datamachine_generate_flow_step_id' === $hook ) {
+			return $args[0] . '_' . $args[1];
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4(): string {
+		static $i = 0;
+		++$i;
+		return 'bulk-uuid-' . $i;
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
+require_once __DIR__ . '/../inc/Core/Steps/WorkflowConfigFactory.php';
+require_once __DIR__ . '/../inc/Abilities/Pipeline/PipelineHelpers.php';
+require_once __DIR__ . '/../inc/Abilities/Pipeline/CreatePipelineAbility.php';
+
+use DataMachine\Abilities\Pipeline\CreatePipelineAbility;
+use DataMachine\Core\Steps\WorkflowConfigFactory;
+
+$failures = array();
+$passes   = 0;
+
+function assert_bulk_workflow_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function resolve_bulk_pipeline_spec_for_test( array $pipeline_config, array $template_workflow, array $template_steps ): array {
+	$reflection = new \ReflectionClass( CreatePipelineAbility::class );
+	$ability    = $reflection->newInstanceWithoutConstructor();
+	$method     = $reflection->getMethod( 'resolveBulkPipelineSpec' );
+
+	return $method->invoke( $ability, $pipeline_config, $template_workflow, $template_steps );
+}
+
+echo "bulk-create-pipeline-workflow-smoke\n";
+
+$workflow = array(
+	'steps' => array(
+		array(
+			'type'               => 'fetch',
+			'label'              => 'Fetch Context',
+			'handler_slug'       => 'mcp',
+			'handler_config'     => array( 'provider' => 'github', 'query' => 'repo:Extra-Chill/data-machine' ),
+			'config_patch_queue' => array( array( 'query' => 'workflow spec' ) ),
+			'queue_mode'         => 'drain',
+		),
+		array(
+			'type'           => 'ai',
+			'label'          => 'Summarize Context',
+			'system_prompt'  => 'Summarize the fetched context.',
+			'user_message'   => 'Use the latest queue item.',
+			'enabled_tools'  => array( 'datamachine/read-github-file' ),
+			'disabled_tools' => array( 'datamachine/delete-pipeline' ),
+		),
+	),
+);
+
+$legacy_steps = array(
+	array( 'step_type' => 'fetch', 'label' => 'Legacy Fetch' ),
+);
+
+$resolved = resolve_bulk_pipeline_spec_for_test(
+	array(
+		'name'     => 'Workflow Wins',
+		'workflow' => $workflow,
+		'steps'    => array( array( 'step_type' => 'ai', 'label' => 'Ignored Legacy AI' ) ),
+	),
+	array(),
+	array()
+);
+
+assert_bulk_workflow_equals( $workflow, $resolved['workflow'], 'per-pipeline workflow wins over per-pipeline steps', $failures, $passes );
+assert_bulk_workflow_equals( array(), $resolved['steps'], 'per-pipeline workflow suppresses legacy steps', $failures, $passes );
+
+$pipeline_config = WorkflowConfigFactory::buildPersistentPipelineConfig( $resolved['workflow'], 501 );
+$flow_config     = WorkflowConfigFactory::buildPersistentFlowConfig( $resolved['workflow'], 501, 601, $pipeline_config );
+$flow_steps      = array_values( $flow_config );
+
+assert_bulk_workflow_equals( 2, count( $pipeline_config ), 'bulk workflow creates persistent pipeline rows', $failures, $passes );
+assert_bulk_workflow_equals( 2, count( $flow_config ), 'bulk workflow creates persistent flow rows through shared factory', $failures, $passes );
+assert_bulk_workflow_equals( 'mcp', $flow_steps[0]['handler_slug'] ?? null, 'bulk workflow preserves handler slug', $failures, $passes );
+assert_bulk_workflow_equals( array( 'provider' => 'github', 'query' => 'repo:Extra-Chill/data-machine' ), $flow_steps[0]['handler_config'] ?? null, 'bulk workflow preserves handler config', $failures, $passes );
+assert_bulk_workflow_equals( array( array( 'query' => 'workflow spec' ) ), $flow_steps[0]['config_patch_queue'] ?? null, 'bulk workflow preserves config patch queue', $failures, $passes );
+assert_bulk_workflow_equals( 'drain', $flow_steps[0]['queue_mode'] ?? null, 'bulk workflow preserves queue mode', $failures, $passes );
+assert_bulk_workflow_equals( array( 'datamachine/read-github-file' ), $flow_steps[1]['enabled_tools'] ?? null, 'bulk workflow preserves enabled tools', $failures, $passes );
+assert_bulk_workflow_equals( array( 'datamachine/delete-pipeline' ), $flow_steps[1]['disabled_tools'] ?? null, 'bulk workflow preserves disabled tools', $failures, $passes );
+assert_bulk_workflow_equals( 'Use the latest queue item.', $flow_steps[1]['prompt_queue'][0]['prompt'] ?? null, 'bulk workflow converts AI user_message to prompt queue head', $failures, $passes );
+
+$template_workflow = array(
+	'steps' => array(
+		array(
+			'type'          => 'publish',
+			'label'         => 'Template Publish',
+			'handler_slug'  => 'wordpress',
+			'handler_config' => array( 'post_type' => 'wiki' ),
+		),
+	),
+);
+
+foreach ( array( 'Template A', 'Template B' ) as $name ) {
+	$resolved = resolve_bulk_pipeline_spec_for_test(
+		array( 'name' => $name ),
+		$template_workflow,
+		$legacy_steps
+	);
+
+	assert_bulk_workflow_equals( $template_workflow, $resolved['workflow'], "template workflow applies to {$name}", $failures, $passes );
+	assert_bulk_workflow_equals( array(), $resolved['steps'], "template workflow wins over template steps for {$name}", $failures, $passes );
+}
+
+$resolved = resolve_bulk_pipeline_spec_for_test(
+	array(
+		'name'  => 'Legacy Override',
+		'steps' => $legacy_steps,
+	),
+	$template_workflow,
+	array( array( 'step_type' => 'ai', 'label' => 'Ignored Template AI' ) )
+);
+
+assert_bulk_workflow_equals( array(), $resolved['workflow'], 'per-pipeline legacy steps still override template workflow', $failures, $passes );
+assert_bulk_workflow_equals( $legacy_steps, $resolved['steps'], 'existing legacy bulk steps behavior remains available', $failures, $passes );
+
+$source = file_get_contents( __DIR__ . '/../inc/Abilities/Pipeline/CreatePipelineAbility.php' ) ?: '';
+assert_bulk_workflow_equals( true, false !== strpos( $source, '$single_input[\'workflow\'] = $workflow;' ), 'bulk execution forwards resolved workflow to single-mode creator', $failures, $passes );
+assert_bulk_workflow_equals( true, false !== strpos( $source, '$single_input[\'steps\'] = $steps;' ), 'bulk execution still forwards legacy steps to single-mode creator', $failures, $passes );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " bulk workflow assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} bulk workflow assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Allows bulk create-pipeline entries and templates to provide portable workflow specs, not only legacy steps arrays.
- Preserves legacy bulk steps behavior while giving per-pipeline workflows precedence over steps.
- Adds smoke coverage for per-entry workflow, template workflow, legacy override, and execution forwarding behavior.

Closes #1500

## Tests
- php tests/bulk-create-pipeline-workflow-smoke.php
- php tests/workflow-persistent-install-smoke.php
- homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-bulk-workflow-specs --changed-since origin/main

## Notes
- Changed-since PHPCS passes and Homeboy reports no lint baseline delta.
- The lint command still exits nonzero because the current runner feeds PHP files to ESLint; no new lint findings remain.
- Changed-since audit is not used as a gate here because it reports changed-file findings as pre-existing/no-baseline and hangs on this repo.

## AI assistance
- AI assistance: Yes
- Tool(s): OpenCode (GPT-5.5)
- Used for: Drafting the implementation and smoke tests; Chris reviewed direction and test results.