### PR TITLE
docs(memory): clarify daily memory storage seams

### DIFF
--- a/inc/Abilities/DailyMemoryAbilities.php
+++ b/inc/Abilities/DailyMemoryAbilities.php
@@ -5,11 +5,17 @@
  * WordPress 6.9 Abilities API primitives for daily memory operations.
  * Provides read/write/list/search/delete access to daily memory.
  *
- * Storage is resolved via the `datamachine_daily_memory_storage` filter.
- * The default implementation is DailyMemory (flat markdown files).
- * Plugins can return any object implementing DailyMemoryStorage to
- * completely replace the storage backend — Data Machine doesn't need
- * to know or care what's behind it.
+ * Ability-level storage is resolved via the
+ * `datamachine_daily_memory_storage` filter. The default implementation
+ * is DailyMemory, which persists through the unified
+ * `datamachine_memory_store` seam as agent-layer files under
+ * `daily/YYYY/MM/DD.md`.
+ *
+ * Precedence: a valid DailyMemoryStorage returned by
+ * `datamachine_daily_memory_storage` replaces the backend for these
+ * abilities. If that filter is absent or returns an invalid value,
+ * DailyMemory remains active and the active AgentMemoryStoreInterface
+ * selected by `datamachine_memory_store` handles persistence.
  *
  * @package DataMachine\Abilities
  * @since 0.32.0
@@ -41,8 +47,10 @@ class DailyMemoryAbilities {
 	/**
 	 * Resolve the daily memory storage backend for a given context.
 	 *
-	 * Returns the default filesystem-backed DailyMemory unless a plugin
-	 * provides an alternative via the `datamachine_daily_memory_storage` filter.
+	 * Returns the default DailyMemory unless a plugin provides an
+	 * alternative via the `datamachine_daily_memory_storage` filter.
+	 * DailyMemory itself writes through `datamachine_memory_store`; the
+	 * daily-specific filter is only for replacing the whole ability backend.
 	 *
 	 * @since 0.47.0
 	 *
@@ -57,8 +65,13 @@ class DailyMemoryAbilities {
 		 * Filters the daily memory storage backend.
 		 *
 		 * Return any object implementing DailyMemoryStorage to completely
-		 * replace the flat-file storage. All daily memory operations (read,
-		 * write, append, list, search, delete) will use the returned backend.
+		 * replace the default DailyMemory backend for these abilities. All
+		 * daily memory ability operations (read, write, append, list, search,
+		 * delete) will use the returned backend.
+		 *
+		 * This filter is narrower than `datamachine_memory_store`: it bypasses
+		 * the default DailyMemory implementation rather than swapping the
+		 * underlying whole-memory persistence store.
 		 *
 		 * @since 0.47.0
 		 *

--- a/inc/Core/FilesRepository/AgentMemoryStoreFactory.php
+++ b/inc/Core/FilesRepository/AgentMemoryStoreFactory.php
@@ -6,9 +6,14 @@
  * via the `datamachine_memory_store` filter, falling back to the
  * built-in {@see DiskAgentMemoryStore}.
  *
- * Single resolution point so every consumer (AgentMemory, AgentFileAbilities,
- * CoreMemoryFilesDirective) gets the same swap mechanism without duplicating
- * the filter call.
+ * Single resolution point so every consumer (AgentMemory, DailyMemory,
+ * AgentFileAbilities, CoreMemoryFilesDirective) gets the same swap mechanism
+ * without duplicating the filter call.
+ *
+ * A guideline-backed store can register here when a site provides
+ * `wp_guideline` (for example via Gutenberg or a plugin), but Data Machine
+ * does not require that post type. The built-in disk store remains the
+ * default and any implementation of AgentMemoryStoreInterface is valid.
  *
  * @package DataMachine\Core\FilesRepository
  * @since   next

--- a/inc/Core/FilesRepository/DailyMemoryStorage.php
+++ b/inc/Core/FilesRepository/DailyMemoryStorage.php
@@ -2,10 +2,17 @@
 /**
  * Daily Memory Storage Interface
  *
- * Contract for daily memory storage backends. The default implementation
- * is DailyMemory (flat markdown files). Plugins can provide alternative
- * implementations (WordPress pages, external services, etc.) by filtering
- * `datamachine_daily_memory_storage` in DailyMemoryAbilities.
+ * Contract for daily memory storage backends used by the Daily Memory
+ * abilities. The default implementation is {@see DailyMemory}, which
+ * delegates persistence to the active {@see AgentMemoryStoreInterface}
+ * resolved through `datamachine_memory_store`.
+ *
+ * `datamachine_daily_memory_storage` is a narrower escape hatch for
+ * replacing the ability-level daily memory backend entirely. When that
+ * filter returns a DailyMemoryStorage implementation, it takes precedence
+ * for Daily Memory abilities. Otherwise DailyMemory remains active and
+ * daily files are stored through the unified memory-store seam as
+ * `daily/YYYY/MM/DD.md` in the agent layer.
  *
  * @package DataMachine\Core\FilesRepository
  * @since 0.47.0

--- a/tests/daily-memory-store-seam-smoke.php
+++ b/tests/daily-memory-store-seam-smoke.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Pure-PHP smoke test for DailyMemory's unified memory-store seam.
+ *
+ * Verifies that the default DailyMemory implementation addresses daily
+ * entries as agent-layer files under daily/YYYY/MM/DD.md through the active
+ * AgentMemoryStoreInterface. The older datamachine_daily_memory_storage seam
+ * is ability-level only and is intentionally not needed for this default path.
+ */
+
+define( 'ABSPATH', __DIR__ . '/../' );
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['datamachine_daily_memory_store_seam_filters'][ $hook ][ $priority ][] = array(
+			'callback'      => $callback,
+			'accepted_args' => $accepted_args,
+		);
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$filters = $GLOBALS['datamachine_daily_memory_store_seam_filters'][ $hook ] ?? array();
+		ksort( $filters );
+
+		foreach ( $filters as $callbacks ) {
+			foreach ( $callbacks as $filter ) {
+				$value = $filter['callback']( ...array_slice( array_merge( array( $value ), $args ), 0, $filter['accepted_args'] ) );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {}
+}
+
+if ( ! function_exists( 'size_format' ) ) {
+	function size_format( int $bytes ): string {
+		return $bytes . ' B';
+	}
+}
+
+require_once __DIR__ . '/../inc/Engine/AI/MemoryFileRegistry.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/DirectoryManager.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryScope.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryReadResult.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryWriteResult.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryListEntry.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryStoreInterface.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/DiskAgentMemoryStore.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryStoreFactory.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemory.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/DailyMemoryStorage.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/DailyMemory.php';
+
+use DataMachine\Core\FilesRepository\AgentMemoryListEntry;
+use DataMachine\Core\FilesRepository\AgentMemoryReadResult;
+use DataMachine\Core\FilesRepository\AgentMemoryScope;
+use DataMachine\Core\FilesRepository\AgentMemoryStoreInterface;
+use DataMachine\Core\FilesRepository\AgentMemoryWriteResult;
+use DataMachine\Core\FilesRepository\DailyMemory;
+use DataMachine\Engine\AI\MemoryFileRegistry;
+
+class DailyMemorySeamFakeStore implements AgentMemoryStoreInterface {
+	/** @var array<string, string> */
+	public array $files = array();
+
+	/** @var string[] */
+	public array $operations = array();
+
+	/** @var AgentMemoryScope[] */
+	public array $scopes = array();
+
+	/** @var string[] */
+	public array $list_prefixes = array();
+
+	public function read( AgentMemoryScope $scope ): AgentMemoryReadResult {
+		$this->record( 'read', $scope );
+
+		if ( ! array_key_exists( $scope->key(), $this->files ) ) {
+			return AgentMemoryReadResult::not_found();
+		}
+
+		$content = $this->files[ $scope->key() ];
+		return new AgentMemoryReadResult( true, $content, sha1( $content ), strlen( $content ), 123 );
+	}
+
+	public function write( AgentMemoryScope $scope, string $content, ?string $if_match = null ): AgentMemoryWriteResult {
+		$this->record( 'write', $scope );
+		$this->files[ $scope->key() ] = $content;
+
+		return AgentMemoryWriteResult::ok( sha1( $content ), strlen( $content ) );
+	}
+
+	public function exists( AgentMemoryScope $scope ): bool {
+		$this->record( 'exists', $scope );
+		return array_key_exists( $scope->key(), $this->files );
+	}
+
+	public function delete( AgentMemoryScope $scope ): AgentMemoryWriteResult {
+		$this->record( 'delete', $scope );
+		unset( $this->files[ $scope->key() ] );
+
+		return AgentMemoryWriteResult::ok( '', 0 );
+	}
+
+	public function list_layer( AgentMemoryScope $scope_query ): array {
+		$this->record( 'list_layer', $scope_query );
+		return array();
+	}
+
+	public function list_subtree( AgentMemoryScope $scope_query, string $prefix ): array {
+		$this->record( 'list_subtree', $scope_query );
+		$this->list_prefixes[] = $prefix;
+
+		$entries = array();
+		foreach ( $this->files as $key => $content ) {
+			[ $layer, $user_id, $agent_id, $filename ] = explode( ':', $key, 4 );
+			if ( $layer !== $scope_query->layer || (int) $user_id !== $scope_query->user_id || (int) $agent_id !== $scope_query->agent_id ) {
+				continue;
+			}
+			if ( 0 !== strpos( $filename, $prefix . '/' ) ) {
+				continue;
+			}
+
+			$entries[] = new AgentMemoryListEntry( $filename, $layer, strlen( $content ), 123 );
+		}
+
+		return $entries;
+	}
+
+	private function record( string $operation, AgentMemoryScope $scope ): void {
+		$this->operations[] = $operation;
+		$this->scopes[]     = $scope;
+	}
+}
+
+function datamachine_daily_memory_store_seam_assert( bool $condition, string $message ): void {
+	static $assertions = 0;
+	++$assertions;
+
+	if ( ! $condition ) {
+		fwrite( STDERR, "Assertion failed: {$message}\n" );
+		exit( 1 );
+	}
+
+	echo "ok {$assertions} - {$message}\n";
+}
+
+$store = new DailyMemorySeamFakeStore();
+add_filter(
+	'datamachine_memory_store',
+	function ( $default, AgentMemoryScope $scope ) use ( $store ) {
+		return $store;
+	},
+	10,
+	2
+);
+
+$daily = new DailyMemory( 123, 456 );
+
+$append = $daily->append( '2026', '04', '28', 'First note.' );
+datamachine_daily_memory_store_seam_assert( true === $append['success'], 'append succeeds through the fake memory store' );
+
+$read = $daily->read( '2026', '04', '28' );
+datamachine_daily_memory_store_seam_assert( true === $read['success'], 'read succeeds through the fake memory store' );
+datamachine_daily_memory_store_seam_assert( false !== strpos( $read['content'], 'First note.' ), 'read returns content written by append' );
+
+$daily->write( '2026', '04', '29', 'Second note.' );
+
+$list = $daily->list_all();
+datamachine_daily_memory_store_seam_assert( true === $list['success'], 'list_all succeeds through the fake memory store' );
+datamachine_daily_memory_store_seam_assert( array( '28', '29' ) === $list['months']['2026/04'], 'list_all groups daily store filenames by month' );
+
+$filenames = array_map(
+	static fn( AgentMemoryScope $scope ): string => $scope->filename,
+	$store->scopes
+);
+
+datamachine_daily_memory_store_seam_assert( in_array( 'daily/2026/04/28.md', $filenames, true ), 'append/read use daily/YYYY/MM/DD.md filename for first date' );
+datamachine_daily_memory_store_seam_assert( in_array( 'daily/2026/04/29.md', $filenames, true ), 'write uses daily/YYYY/MM/DD.md filename for second date' );
+datamachine_daily_memory_store_seam_assert( in_array( 'list_subtree', $store->operations, true ), 'list_all calls list_subtree on the active memory store' );
+datamachine_daily_memory_store_seam_assert( array( 'daily' ) === $store->list_prefixes, 'list_all enumerates the daily subtree prefix' );
+
+foreach ( $store->scopes as $scope ) {
+	datamachine_daily_memory_store_seam_assert( MemoryFileRegistry::LAYER_AGENT === $scope->layer, 'daily memory scope uses the agent layer' );
+	datamachine_daily_memory_store_seam_assert( 123 === $scope->user_id, 'daily memory scope preserves effective user id' );
+	datamachine_daily_memory_store_seam_assert( 456 === $scope->agent_id, 'daily memory scope preserves agent id' );
+}
+
+echo "Daily memory store seam smoke passed.\n";


### PR DESCRIPTION
## Summary
- Clarifies that `datamachine_memory_store` is the primary whole-memory persistence seam used by the default `DailyMemory` implementation.
- Documents `datamachine_daily_memory_storage` as the narrower ability-level escape hatch that takes precedence only when it returns a `DailyMemoryStorage` backend.
- Adds a pure-PHP smoke proving default daily memory operations address `daily/YYYY/MM/DD.md` through the active `AgentMemoryStoreInterface`.

## Clarified seam precedence
- `datamachine_daily_memory_storage` wins for Daily Memory abilities when it returns a valid `DailyMemoryStorage` implementation.
- Otherwise, `DailyMemory` remains active and all persistence routes through `datamachine_memory_store` in the agent layer.
- `DailyMemoryTask` continues using the default `DailyMemory` path, so daily compaction keeps working with the disk store and any generic `AgentMemoryStoreInterface` implementation.

## Guardrail
- `wp_guideline` is optional and not assumed to exist in WordPress core.
- Guideline-backed memory stores may register through `datamachine_memory_store` when a site provides that post type, but Data Machine still defaults to disk and accepts any `AgentMemoryStoreInterface` implementation.

## Tests
- `php -l inc/Core/FilesRepository/DailyMemoryStorage.php`
- `php -l inc/Abilities/DailyMemoryAbilities.php`
- `php -l inc/Core/FilesRepository/AgentMemoryStoreFactory.php`
- `php -l tests/daily-memory-store-seam-smoke.php`
- `php tests/daily-memory-store-seam-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@clarify-daily-memory-seams --changed-since origin/main` (PHPCS passed; Homeboy runner still incorrectly sends PHP files to ESLint and exits 1 with parsing errors, no baseline drift)

Closes #1518

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the contract/docblock clarifications, smoke test, validation commands, and PR description for Chris to review.