### PR TITLE
docs(content): document content-format substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Typed, permissioned functions registered via WordPress's Abilities API. Extensio
 | `datamachine/flow-execute` | Execute a flow programmatically |
 | ... | 40+ abilities across media, publishing, content, SEO, and infrastructure |
 
+### Content Formats
+
+Content and publish abilities accept `content_format` (`markdown`, `html`, or `blocks`) as the caller's source format. Data Machine stores content in the post type's canonical format from `datamachine_post_content_format`, converting through its bundled Block Format Bridge substrate.
+
 ### Multi-Agent
 
 Agents are scoped by user. Each agent gets its own:

--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -393,6 +393,13 @@ Chat-specific tools at `/inc/Api/Chat/Tools/`:
 
 Handler-specific tools registered into the unified `datamachine_tools` registry using HandlerRegistrationTrait in each handler class. Each entry carries a `_handler_callable` that is resolved at pipeline execution time with the adjacent step's runtime handler config.
 
+## Content Authoring Formats
+
+For normal prose, AI tools should write markdown and omit `content_format` unless
+a workflow explicitly asks for HTML or serialized blocks. Raw ability/API callers
+can still pass `content_format` explicitly; omitted raw `datamachine/upsert-post`
+calls keep the legacy block-markup default.
+
 ## Tool Management
 
 **ToolManager** (`/inc/Engine/AI/Tools/ToolManager.php`) centralizes tool discovery and validation:

--- a/docs/core-system/abilities-api.md
+++ b/docs/core-system/abilities-api.md
@@ -220,6 +220,11 @@ per post type by `datamachine_post_content_format`. Normal AI-authored prose
 should be markdown; only set `content_format` when the caller intentionally
 supplies HTML or serialized block markup.
 
+The block editing abilities are storage-format aware. They read the post type's
+canonical stored format through `DataMachine\Core\Content\ContentFormat`, convert
+to block markup for the edit operation, then convert the result back before
+writing.
+
 ### Media (7 abilities)
 
 | Ability | Description | Location |

--- a/docs/core-system/wordpress-components.md
+++ b/docs/core-system/wordpress-components.md
@@ -22,7 +22,7 @@ As of v0.2.7, WordPress-specific publishing operations are provided by WordPress
 
 **Key Features**:
 - Image attachment to WordPress posts as featured images
-- Source URL attribution with Gutenberg block generation
+- Source URL attribution in the caller's declared source format
 - Centralized WordPress publishing utilities
 
 **Static Methods**:
@@ -53,8 +53,8 @@ Apply source URL attribution to content based on configuration.
 **Process**:
 1. Check configuration (`link_handling` = 'append')
 2. Validate source URL
-3. Detect content type (Gutenberg blocks vs plain text)
-4. Generate appropriate attribution format
+3. Read the declared `content_format` from handler config (`html`, `markdown`, or `blocks`)
+4. Generate source attribution in the same source format
 5. Append to content
 
 **Returns**: Modified content with source attribution

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -600,6 +600,10 @@ wp datamachine links inject-category --category=news --links-per-post=3 --orphan
 
 Gutenberg block management. **Alias**: `block`. **Since**: 0.28.0
 
+These commands are storage-format aware: Data Machine converts the post type's
+canonical stored format to blocks for the edit, then writes back in the canonical
+format selected by `datamachine_post_content_format`.
+
 ```bash
 # List blocks in a post
 wp datamachine blocks list 123

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -490,6 +490,12 @@ AI-facing tools should treat normal authored prose as markdown unless a workflow
 explicitly pins another source format. Storage-aware abilities then convert that
 source through Block Format Bridge into the post type's canonical stored shape.
 
+Block Format Bridge is bundled by Data Machine and is an internal substrate for
+these boundaries. Consumers should not require a standalone BFB plugin on a
+DM-powered site just to use Data Machine content abilities. Keep format repair,
+mixed-content detection, and malformed-input normalization in BFB (`bfb_normalize()`)
+rather than duplicating those checks in Data Machine call sites.
+
 ### `datamachine_post_content_format`
 
 **Purpose**: Choose the canonical `post_content` storage format for a post type.
@@ -507,6 +513,10 @@ or `blocks`). It is not the storage decision. For example, the `upsert_post`
 chat tool defaults omitted `content_format` to markdown so agents can author
 ordinary prose naturally; raw ability/API calls keep the legacy omitted-format
 default of block markup for compatibility.
+
+Publish handlers follow the same contract: `wordpress_publish` accepts
+`content_format`, appends source attribution in that source format, then stores
+the final content in the post type's canonical format.
 
 ### `datamachine_pending_action_staged`
 

--- a/docs/handlers/publish/handlers-overview.md
+++ b/docs/handlers/publish/handlers-overview.md
@@ -241,7 +241,8 @@ if ($http_code !== 200) {
 - `WordPressPublishHelper` for media attachment and source attribution
 - `TaxonomyHandler` with configuration-based processing (skip, AI-decided, pre-selected)
 - `WordPressSettingsResolver` for configuration hierarchy
-- Automatic Gutenberg block generation for source attribution
+- `content_format` support for markdown, HTML, or serialized block source content
+- Storage-format-aware conversion through the post type's canonical `post_content` format
 - Configuration hierarchy (system defaults override handler config)
 - Post status control (draft, publish, private)
 - Author assignment

--- a/docs/handlers/publish/wordpress-publish.md
+++ b/docs/handlers/publish/wordpress-publish.md
@@ -14,6 +14,22 @@ Creates posts in the local WordPress installation using a modular handler archit
 
 **Implementation**: Tool-first architecture via `handle_tool_call()` method for AI agents
 
+## Content Format Boundary
+
+`wordpress_publish` accepts source content in `content_format` (`markdown`,
+`html`, or `blocks`) and stores it in the target post type's canonical format:
+
+```
+content + content_format
+  -> source attribution in the same source format
+  -> DataMachine\Core\Content\ContentFormat::sourceToStored()
+  -> wp_insert_post() using the post type's canonical stored format
+```
+
+Omitted `content_format` defaults to `html` for raw ability/API compatibility.
+The stored format comes from `datamachine_post_content_format`, not from the
+caller.
+
 ### Handler Components
 
 **Main Handler** (`WordPress.php`):
@@ -196,6 +212,7 @@ The WordPress handler extends `PublishHandler` and implements the `executePublis
 
 ```php
 use DataMachine\Core\EngineData;
+use DataMachine\Core\Content\ContentFormat;
 use DataMachine\Core\WordPress\WordPressPublishHelper;
 use DataMachine\Core\WordPress\TaxonomyHandler;
 use DataMachine\Core\WordPress\WordPressSettingsResolver;
@@ -226,15 +243,22 @@ class WordPress extends PublishHandler {
             $handler_config
         );
 
-        // 4. Resolve configuration with system defaults
+        // 4. Convert source content to the post type's stored format
+        $stored_content = ContentFormat::sourceToStored(
+            $content,
+            $parameters['content_format'] ?? 'html',
+            $handler_config['post_type']
+        );
+
+        // 5. Resolve configuration with system defaults
         $resolver = new WordPressSettingsResolver();
         $post_status = $resolver->resolvePostStatus($handler_config);
         $post_author = $resolver->resolvePostAuthor($handler_config);
 
-        // 5. Create WordPress post
+        // 6. Create WordPress post
         $post_data = [
             'post_title' => sanitize_text_field($parameters['title']),
-            'post_content' => $content,
+            'post_content' => $stored_content,
             'post_status' => $post_status,
             'post_type' => $handler_config['post_type'],
             'post_author' => $post_author
@@ -242,14 +266,14 @@ class WordPress extends PublishHandler {
 
         $post_id = wp_insert_post($post_data);
 
-        // 6. Process taxonomies
+        // 7. Process taxonomies
         $taxonomy_results = $this->taxonomy_handler->processTaxonomies(
             $post_id, 
             $parameters, 
             $handler_config
         );
 
-        // 7. Attach featured image using helper
+        // 8. Attach featured image using helper
         $image_path = $engine->getImagePath();
         $attachment_id = WordPressPublishHelper::attachImageToPost(
             $post_id, 
@@ -257,7 +281,7 @@ class WordPress extends PublishHandler {
             $handler_config
         );
 
-        // 8. Return standardized success response
+        // 9. Return standardized success response
         return $this->successResponse([
             'post_id' => $post_id,
             'post_url' => get_permalink($post_id),
@@ -407,7 +431,7 @@ $handler_config = [
 
 **Efficient Media Handling**: Uses WordPress native functions for optimal media processing.
 
-**Clean Integration**: Gutenberg block generation maintains WordPress standards and performance.
+**Clean Integration**: Content format conversion happens once at the publishing boundary, preserving WordPress standards without forcing every post type to store serialized block markup.
 
 **Comprehensive Logging**: All components provide detailed debug logging for monitoring and troubleshooting.
 
@@ -438,7 +462,7 @@ $attachment_id = WordPressPublishHelper::attachImageToPost($post_id, $image_path
 
 #### applySourceAttribution()
 
-Appends source URL to content with Gutenberg blocks or plain text.
+Appends source URL to content in the declared source format (`html`, `markdown`, or `blocks`).
 
 ```php
 $content = WordPressPublishHelper::applySourceAttribution($content, $source_url, $config);


### PR DESCRIPTION
## Summary
- Document the content-format contract introduced by the Block Format Bridge substrate work.
- Clarify authoring/source format vs canonical stored `post_content` format across abilities, tools, hooks, CLI block edits, and WordPress publishing.
- Remove stale Gutenberg-only wording from WordPress publish/shared-component docs.

## Docs updated
- `README.md`
- `docs/core-system/abilities-api.md`
- `docs/development/hooks/core-filters.md`
- `docs/ai-tools/tools-overview.md`
- `docs/handlers/publish/wordpress-publish.md`
- `docs/core-system/wordpress-components.md`
- `docs/handlers/publish/handlers-overview.md`
- `docs/core-system/wp-cli.md`

## Tests
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the documentation updates and ran the docs-safe validation. Chris remains responsible for review and merge.
