### PR TITLE
feat(ai): make message envelopes canonical

### DIFF
--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -83,6 +83,7 @@ if (empty($tool_calls)) {
 ### State Management
 
 The loop maintains conversation state across turns, tracking:
+
 - Total message count
 - Current turn number
 - Final AI content response
@@ -227,8 +228,9 @@ A consumer can delegate to any external runtime — its own `Agent` subclass, a
 remote RPC service, a different language — as long as the return shape is
 honored. Returned messages may use the legacy `role/content/metadata` shape or
 the versioned [AI Message Envelope](./ai-message-envelope.md); Data Machine
-normalizes envelopes back to the persisted legacy shape before callers store or
-render the result.
+normalizes every returned message to the canonical envelope before callers store
+or render the result. Provider-specific `role/content/metadata` arrays are now a
+projection at the provider boundary, not the runtime/storage contract.
 
 ### Minimal adapter example
 
@@ -387,6 +389,7 @@ do_action('datamachine_log', 'warning', 'AIConversationLoop: Max turns reached',
 The conversation loop provides comprehensive logging at each stage:
 
 ### Loop Start
+
 ```php
 do_action('datamachine_log', 'debug', 'AIConversationLoop: Starting conversation loop', [
     'agent_type' => $agent_type,
@@ -399,6 +402,7 @@ do_action('datamachine_log', 'debug', 'AIConversationLoop: Starting conversation
 ```
 
 ### Turn Start
+
 ```php
 do_action('datamachine_log', 'debug', 'AIConversationLoop: Turn started', [
     'agent_type' => $agent_type,
@@ -408,6 +412,7 @@ do_action('datamachine_log', 'debug', 'AIConversationLoop: Turn started', [
 ```
 
 ### AI Response
+
 ```php
 do_action('datamachine_log', 'debug', 'AIConversationLoop: AI returned content', [
     'agent_type' => $agent_type,
@@ -418,6 +423,7 @@ do_action('datamachine_log', 'debug', 'AIConversationLoop: AI returned content',
 ```
 
 ### Tool Execution
+
 ```php
 do_action('datamachine_log', 'debug', 'AIConversationLoop: Processing tool calls', [
     'agent_type' => $agent_type,
@@ -428,6 +434,7 @@ do_action('datamachine_log', 'debug', 'AIConversationLoop: Processing tool calls
 ```
 
 ### Conversation Complete
+
 ```php
 do_action('datamachine_log', 'debug', 'AIConversationLoop: Conversation complete', [
     'agent_type' => $agent_type,

--- a/docs/core-system/ai-message-envelope.md
+++ b/docs/core-system/ai-message-envelope.md
@@ -2,20 +2,11 @@
 
 **File**: `/inc/Engine/AI/MessageEnvelope.php`
 
-Data Machine stores conversation messages as JSON-friendly arrays. The current
-persisted shape stays stable:
-
-```php
-[
-    'role'     => 'user|assistant|system|tool',
-    'content'  => 'Plain text or multimodal content blocks',
-    'metadata' => [ 'type' => 'text' ],
-]
-```
-
-The message envelope is the typed runtime contract that adapters should target.
-It makes tool calls, tool results, input-required states, final results, errors,
-deltas, and multimodal parts explicit without adopting any host-specific DTO.
+Data Machine's canonical internal AI message shape is a JSON-friendly typed
+envelope. Runtime code, chat storage, and transcript storage should store and
+return envelopes. Provider-specific `role/content/metadata` arrays are a
+projection used at the current `ai-http-client` boundary, not the internal
+contract.
 
 ## Envelope Shape
 
@@ -26,7 +17,7 @@ deltas, and multimodal parts explicit without adopting any host-specific DTO.
     'type'     => 'text',
     'role'     => 'assistant',
     'content'  => 'Message text or provider-neutral content blocks',
-    'data'     => [],      // Type-specific JSON-serializable payload.
+    'payload'  => [],      // Type-specific JSON-serializable payload.
     'metadata' => [],      // Extension metadata; must stay JSON-serializable.
 
     // Optional fields preserved when present:
@@ -48,17 +39,24 @@ Supported `type` values:
 - `delta`
 - `multimodal_part`
 
+Use `payload` for type-specific fields that Data Machine understands, such as
+tool names, tool parameters, turn numbers, and tool result data. Use `metadata`
+for extension/provider details that should be preserved but are not part of the
+type contract.
+
 ## Compatibility
 
-`MessageEnvelope::normalize()` accepts either the legacy
-`role/content/metadata` shape or the versioned envelope shape. The canonical
-storage path still writes legacy messages by calling
-`MessageEnvelope::to_legacy_message()` / `to_legacy_messages()`.
+`MessageEnvelope::normalize()` accepts existing `role/content/metadata` rows and
+versioned envelopes. It also accepts the short-lived `data` envelope key from the
+initial envelope draft as a read-time compatibility input and rewrites it to
+`payload`.
 
-This gives runtime adapters a stable typed target while preserving existing
-chat rows, pipeline transcripts, REST responses, and CLI transcript rendering.
+New writes should store canonical envelopes. Current provider requests use
+`MessageEnvelope::to_provider_message()` / `to_provider_messages()` to project
+envelopes into the `role/content/metadata` shape expected by `ai-http-client`.
+That projection folds the envelope `type` and `payload` into provider metadata.
 
-## Type Data
+## Type Payload
 
 Legacy tool-call messages:
 
@@ -84,7 +82,7 @@ normalize to:
     'type'    => 'tool_call',
     'role'    => 'assistant',
     'content' => 'AI ACTION (Turn 1): Executing Wiki Upsert',
-    'data'    => [
+    'payload' => [
         'tool_name'  => 'wiki_upsert',
         'parameters' => [ 'title' => 'Example' ],
         'turn'       => 1,
@@ -98,16 +96,19 @@ normalize to:
 ]
 ```
 
-For new adapters, prefer putting type-specific fields in `data` and
-adapter-specific details in `metadata`. Data Machine will fold `data` back into
-`metadata` when returning the persisted legacy shape.
+For new adapters, prefer putting type-specific fields in `payload` and
+adapter-specific details in `metadata`. Data Machine projects `payload` back into
+provider metadata only when calling a provider boundary that still expects that
+shape.
 
 ## Adapter Guidance
 
 Runtime adapters using `datamachine_conversation_runner` may return messages in
-either shape. `AIConversationResult::normalize()` normalizes every message
-through `MessageEnvelope` and returns the current persisted shape to callers.
+either legacy or envelope shape. `AIConversationResult::normalize()` normalizes
+every returned message to the canonical envelope before callers store or render
+the result.
 
 Conversation store adapters should normalize host messages to this envelope at
-their boundary, then return `role/content/metadata` arrays to Data Machine's chat
-abilities and UI until the storage contract changes explicitly.
+their boundary and return envelopes to Data Machine's chat abilities and UI.
+Adapters that wrap a host-specific DTO should keep that DTO at the host boundary,
+not inside Data Machine storage.

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -9,11 +9,13 @@ Comprehensive reference for all WordPress filters used by Data Machine for servi
 **Purpose**: Register fetch, publish, and upsert handlers
 
 **Parameters**:
+
 - `$handlers` (array) - Current handlers array
 
 **Return**: Array of handler definitions
 
 **Handler Structure**:
+
 ```php
 $handlers['handler_slug'] = [
     'type' => 'fetch|publish|upsert',
@@ -25,6 +27,7 @@ $handlers['handler_slug'] = [
 ```
 
 **Usage Example**:
+
 ```php
 add_filter('datamachine_handlers', function($handlers) {
     $handlers['twitter'] = [
@@ -39,6 +42,7 @@ add_filter('datamachine_handlers', function($handlers) {
 ```
 
 **Handler Metadata**:
+
 - `requires_auth` (boolean): Optional metadata flag for performance optimization
 - Eliminates auth provider instantiation during handler settings modal load
 - Auth-enabled handlers: Twitter, Bluesky, Facebook, Threads, Google Sheets (publish & fetch), Reddit (fetch)
@@ -48,11 +52,13 @@ add_filter('datamachine_handlers', function($handlers) {
 **Purpose**: Register step types for pipeline execution
 
 **Parameters**:
+
 - `$steps` (array) - Current steps array
 
 **Return**: Array of step definitions
 
 **Step Structure**:
+
 ```php
 $steps['step_type'] = [
     'name' => __('Step Display Name', 'data-machine'),
@@ -66,6 +72,7 @@ $steps['step_type'] = [
 **Purpose**: Service discovery for OAuth 1.0a handler
 
 **Parameters**:
+
 - `$handler` (OAuth1Handler|null) - Current handler instance
 
 **Return**: OAuth1Handler instance
@@ -73,6 +80,7 @@ $steps['step_type'] = [
 **Location**: `/inc/Core/OAuth/OAuth1Handler.php`
 
 **Usage Example**:
+
 ```php
 $oauth1 = apply_filters('datamachine_get_oauth1_handler', null);
 $request_token = $oauth1->get_request_token($url, $key, $secret, $callback, 'twitter');
@@ -81,6 +89,7 @@ $result = $oauth1->handle_callback('twitter', $access_url, $key, $secret, $accou
 ```
 
 **Methods**:
+
 - `get_request_token()` - Obtain OAuth request token (step 1)
 - `get_authorization_url()` - Build authorization URL (step 2)
 - `handle_callback()` - Complete OAuth flow (step 3)
@@ -92,6 +101,7 @@ $result = $oauth1->handle_callback('twitter', $access_url, $key, $secret, $accou
 **Purpose**: Service discovery for OAuth 2.0 handler
 
 **Parameters**:
+
 - `$handler` (OAuth2Handler|null) - Current handler instance
 
 **Return**: OAuth2Handler instance
@@ -99,6 +109,7 @@ $result = $oauth1->handle_callback('twitter', $access_url, $key, $secret, $accou
 **Location**: `/inc/Core/OAuth/OAuth2Handler.php`
 
 **Usage Example**:
+
 ```php
 $oauth2 = apply_filters('datamachine_get_oauth2_handler', null);
 $state = $oauth2->create_state('provider_key');
@@ -107,6 +118,7 @@ $result = $oauth2->handle_callback($provider_key, $token_url, $token_params, $ac
 ```
 
 **Methods**:
+
 - `create_state()` - Generate OAuth state nonce
 - `verify_state()` - Verify OAuth state nonce
 - `get_authorization_url()` - Build authorization URL
@@ -123,15 +135,19 @@ Modern handler registration uses **HandlerRegistrationTrait** which automaticall
 The HandlerRegistrationTrait (`/inc/Core/Steps/HandlerRegistrationTrait.php`) automatically registers handlers with the following filters:
 
 #### datamachine_handlers
+
 Handler metadata registration (always registered)
 
 #### datamachine_auth_providers
+
 Authentication provider registration (conditional on `requires_auth=true`)
 
 #### datamachine_handler_settings
+
 Settings class registration (always registered if settings_class provided)
 
 #### datamachine_tools (handler tools)
+
 AI tool registration via callback (conditional on tools_callback provided). The
 trait wires the callback into the unified `datamachine_tools` registry as a
 deferred `_handler_callable` entry resolved at pipeline execution time.
@@ -168,6 +184,7 @@ datamachine_register_my_handler_filters();
 ### Example Implementation
 
 **Publish Handler with OAuth**:
+
 ```php
 use DataMachine\Core\Steps\HandlerRegistrationTrait;
 
@@ -195,6 +212,7 @@ class TwitterFilters {
 ```
 
 **Fetch Handler without Auth**:
+
 ```php
 use DataMachine\Core\Steps\HandlerRegistrationTrait;
 
@@ -235,6 +253,7 @@ runtime-generated tools. Consumed by `ToolPolicyResolver` when gathering the
 available tool set for a pipeline or chat context.
 
 **Parameters**:
+
 - `$tools` (array) - Current tools registry (keyed by tool name or internal wrapper key)
 
 **Return**: Modified tools array
@@ -288,6 +307,7 @@ add_filter('datamachine_tools', function($tools) {
 ```
 
 Matching modes:
+
 - `'handler' => 'slug'` — entry applies only when the adjacent step's handler
   slug equals `'slug'`.
 - `'handler_types' => ['fetch', 'event_import']` — entry applies to any
@@ -333,6 +353,7 @@ the resolved definition follows the same shape:
 **Purpose**: Process AI requests with provider routing and modular directive system message injection
 
 **Parameters**:
+
 - `$request` (array) - AI request data
 - `$provider` (string) - AI provider slug
 - `$streaming_callback` (mixed) - Streaming callback function
@@ -349,6 +370,7 @@ All AI requests now use `RequestBuilder::build()` which integrates with `PromptB
 1. **Unified Directives** (`datamachine_directives` filter) - Centralized directive registration with priority and agent targeting
 
 **Request Structure**:
+
 ```php
 $ai_response = RequestBuilder::build(
     $messages,      // Messages array with role/content
@@ -363,17 +385,21 @@ $ai_response = RequestBuilder::build(
 **Current Directive Implementations**:
 
 **Global Directives** (all agents):
+
 - `GlobalSystemPromptDirective` - Background guidance for all AI agents
 - `SiteContextDirective` - WordPress environment information (optional)
 
 **Pipeline Agent Directives**:
+
 - `PipelineCoreDirective` - Foundational agent identity with tool instructions (priority 10)
 - `PipelineSystemPromptDirective` - User-defined system prompts (priority 20)
 
 **Chat Agent Directives**:
+
 - `ChatAgentDirective` - Chat agent identity and capabilities
 
 **Unified Directive Registration**:
+
 ```php
 // Register directives with priority and agent targeting
 add_filter('datamachine_directives', function($directives) {
@@ -400,6 +426,7 @@ add_filter('datamachine_directives', function($directives) {
 **Purpose**: Customize or replace the AI prompt used for generating session titles.
 
 **Parameters**:
+
 - `$default_prompt` (string) - The default prompt for title generation
 - `$context` (array) - Conversation context with the following keys:
   - `first_user_message` (string) - The first message from the user
@@ -411,6 +438,7 @@ add_filter('datamachine_directives', function($directives) {
 **Location**: `/inc/Abilities/SystemAbilities.php`
 
 **Usage Example**:
+
 ```php
 // Generate code names instead of descriptive titles
 add_filter('datamachine_session_title_prompt', function($prompt, $context) {
@@ -436,6 +464,7 @@ add_filter('datamachine_session_title_prompt', function($prompt, $context) {
 ```
 
 **Use Cases**:
+
 - Generate code names instead of descriptive titles
 - Add custom instructions to title generation
 - Create privacy-safe titles that don't expose chat content
@@ -535,12 +564,14 @@ declarations, and mode presets.
 **Abilities Integration**: Handled by `datamachine/create-pipeline` ability.
 
 **Parameters**:
+
 - `$pipeline_id` (null) - Placeholder for return value
 - `$data` (array) - Pipeline creation data
 
 **Return**: Integer pipeline ID or false
 
 **Data Structure**:
+
 ```php
 $data = [
     'pipeline_name' => 'Pipeline Name',
@@ -549,6 +580,7 @@ $data = [
 ```
 
 **Usage**:
+
 ```php
 // Abilities API
 $ability = wp_get_ability( 'datamachine/create-pipeline' );
@@ -565,12 +597,14 @@ $pipeline_id = apply_filters('datamachine_create_pipeline', null, $data);
 **Abilities Integration**: Handled by `datamachine/create-flow` ability.
 
 **Parameters**:
+
 - `$flow_id` (null) - Placeholder for return value
 - `$data` (array) - Flow creation data
 
 **Return**: Integer flow ID or false
 
 **Usage**:
+
 ```php
 // Abilities API
 $ability = wp_get_ability( 'datamachine/create-flow' );
@@ -585,6 +619,7 @@ $flow_id = apply_filters('datamachine_create_flow', null, $data);
 **Purpose**: Retrieve pipeline data
 
 **Parameters**:
+
 - `$pipelines` (array) - Empty array for return data
 - `$pipeline_id` (int|null) - Specific pipeline ID or null for all
 
@@ -595,6 +630,7 @@ $flow_id = apply_filters('datamachine_create_flow', null, $data);
 **Purpose**: Get flow configuration
 
 **Parameters**:
+
 - `$config` (array) - Empty array for return data
 - `$flow_id` (int) - Flow ID
 
@@ -605,6 +641,7 @@ $flow_id = apply_filters('datamachine_create_flow', null, $data);
 **Purpose**: Get specific flow step configuration
 
 **Parameters**:
+
 - `$config` (array) - Empty array for return data
 - `$flow_step_id` (string) - Composite flow step ID
 
@@ -617,11 +654,13 @@ $flow_id = apply_filters('datamachine_create_flow', null, $data);
 **Purpose**: Register OAuth authentication providers
 
 **Parameters**:
+
 - `$providers` (array) - Current auth providers
 
 **Return**: Array of authentication provider instances
 
 **Structure**:
+
 ```php
 $providers['provider_slug'] = new AuthProviderClass();
 ```
@@ -631,6 +670,7 @@ $providers['provider_slug'] = new AuthProviderClass();
 **Purpose**: Get stored OAuth account data
 
 **Parameters**:
+
 - `$account` (array) - Empty array for return data
 - `$handler` (string) - Handler slug
 
@@ -641,6 +681,7 @@ $providers['provider_slug'] = new AuthProviderClass();
 **Purpose**: Generate OAuth authorization URL
 
 **Parameters**:
+
 - `$url` (string) - Empty string for return data
 - `$provider` (string) - Provider slug
 
@@ -653,6 +694,7 @@ $providers['provider_slug'] = new AuthProviderClass();
 **Purpose**: Check if tool is properly configured
 
 **Parameters**:
+
 - `$configured` (bool) - Default configuration status
 - `$tool_id` (string) - Tool identifier
 
@@ -663,6 +705,7 @@ $providers['provider_slug'] = new AuthProviderClass();
 **Purpose**: Retrieve tool configuration data
 
 **Parameters**:
+
 - `$config` (array) - Empty array for return data
 - `$tool_id` (string) - Tool identifier
 
@@ -673,6 +716,7 @@ $providers['provider_slug'] = new AuthProviderClass();
 **Purpose**: Register handler settings classes
 
 **Parameters**:
+
 - `$settings` (array) - Current settings array
 
 **Return**: Array of settings class instances
@@ -684,12 +728,14 @@ $providers['provider_slug'] = new AuthProviderClass();
 **Purpose**: Centralized engine data access filter for retrieving stored engine parameters
 
 **Parameters**:
+
 - `$engine_data` (array) - Default empty array for return data
 - `$job_id` (int) - Job ID to retrieve engine data for
 
 **Return**: Array containing engine data (source_url, image_url, etc.)
 
 **Engine Data Structure**:
+
 ```php
 $engine_data = [
     'source_url' => $source_url,    // For link attribution and content updates
@@ -699,6 +745,7 @@ $engine_data = [
 ```
 
 **Core Implementation (EngineData.php)**:
+
 ```php
 add_filter('datamachine_engine_data', function($engine_data, $job_id) {
     if (empty($job_id)) {
@@ -714,6 +761,7 @@ add_filter('datamachine_engine_data', function($engine_data, $job_id) {
 ```
 
 **Usage by Steps**:
+
 ```php
 // Steps access engine data as needed
 $engine_data = apply_filters('datamachine_engine_data', [], $job_id);
@@ -722,6 +770,7 @@ $image_url = $engine_data['image_url'] ?? null;
 ```
 
 **Engine Data Storage (by Fetch Handlers)**:
+
 ```php
 // Fetch handlers store engine parameters in database via centralized filter (array storage)
 if ($job_id) {
@@ -733,6 +782,7 @@ if ($job_id) {
 ```
 
 **Benefits**:
+
 - ✅ **Centralized Access**: Single filter for all engine data retrieval
 - ✅ **Filter-Based Discovery**: Uses established database service discovery pattern
 - ✅ **Clean Separation**: Engine data separate from AI data packets
@@ -745,12 +795,14 @@ if ($job_id) {
 **Purpose**: Shared timeframe parsing across fetch handlers with discovery and conversion modes
 
 **Parameters**:
+
 - `$default` (mixed) - Default value (null or timestamp)
 - `$timeframe_limit` (string|null) - Timeframe specification
 
 **Return**: Array of options (discovery mode) or timestamp (conversion mode) or null
 
 **Discovery Mode** (when `$timeframe_limit` is null):
+
 ```php
 $timeframe_options = apply_filters('datamachine_timeframe_limit', null, null);
 // Returns:
@@ -764,6 +816,7 @@ $timeframe_options = apply_filters('datamachine_timeframe_limit', null, null);
 ```
 
 **Conversion Mode** (when `$timeframe_limit` is a string):
+
 ```php
 $cutoff_timestamp = apply_filters('datamachine_timeframe_limit', null, '24_hours');
 // Returns: Unix timestamp for 24 hours ago or null for 'all_time'
@@ -774,6 +827,7 @@ $cutoff_timestamp = apply_filters('datamachine_timeframe_limit', null, '24_hours
 **Purpose**: Universal keyword matching with OR logic for all fetch handlers
 
 **Parameters**:
+
 - `$default` (bool) - Default match result
 - `$content` (string) - Content to search in
 - `$search_term` (string) - Comma-separated keywords
@@ -781,12 +835,14 @@ $cutoff_timestamp = apply_filters('datamachine_timeframe_limit', null, '24_hours
 **Return**: Boolean indicating if any keyword matches
 
 **Usage**:
+
 ```php
 $matches = apply_filters('datamachine_keyword_search_match', true, $content, 'wordpress,ai,automation');
 // Returns true if content contains 'wordpress' OR 'ai' OR 'automation'
 ```
 
 **Features**:
+
 - **OR Logic**: Any keyword match passes the filter
 - **Case Insensitive**: Uses `mb_stripos()` for Unicode-safe matching
 - **Comma Separated**: Supports multiple keywords separated by commas
@@ -797,6 +853,7 @@ $matches = apply_filters('datamachine_keyword_search_match', true, $content, 'wo
 **Purpose**: Centralized data packet creation with standardized structure
 
 **Parameters**:
+
 - `$data` (array) - Current data packet array
 - `$packet_data` (array) - Packet data to add
 - `$flow_step_id` (string) - Flow step identifier
@@ -805,11 +862,13 @@ $matches = apply_filters('datamachine_keyword_search_match', true, $content, 'wo
 **Return**: Array with new packet added to front
 
 **Usage**:
+
 ```php
 $data = apply_filters('datamachine_data_packet', $data, $packet_data, $flow_step_id, $step_type);
 ```
 
 **Features**:
+
 - **Standardized Structure**: Ensures type and timestamp fields are present
 - **Preserves All Fields**: Merges packet_data while adding missing structure
 - **Front Addition**: Uses `array_unshift()` to add new packets to the beginning
@@ -825,6 +884,7 @@ $data = apply_filters('datamachine_data_packet', $data, $packet_data, $flow_step
 **Wire point**: `ExecutionContext::isItemProcessed()` — applied after the default seen/not-seen check runs. The filter is **not** invoked in `direct` or `standalone` execution modes, or when `flow_step_id` is empty.
 
 **Parameters**:
+
 - `$skip` (bool) — Current skip decision. `true` means "skip — already processed"; `false` means "process".
 - `$context` (array):
   - `flow_step_id` (string)
@@ -864,7 +924,6 @@ add_filter( 'datamachine_should_reprocess_item', function ( $skip, $ctx ) {
 
 **See also**: `ProcessedItems::get_processed_at()`, `ProcessedItems::has_been_processed_within()`, `ProcessedItems::find_stale()`, `ProcessedItems::find_never_processed()` — the time-windowed read API introduced in the same release.
 
-
 ## Duplicate Detection Filters
 
 ### `datamachine_duplicate_strategies`
@@ -874,12 +933,14 @@ add_filter( 'datamachine_should_reprocess_item', function ( $skip, $ctx ) {
 **Purpose**: Register domain-specific duplicate detection strategies for the `datamachine/check-duplicate` ability. Extensions use this to add post-type-specific matching logic (e.g., event identity via venue + date + ticket URL) that runs before core's generic title/source-URL strategies.
 
 **Parameters**:
+
 - `$strategies` (array) - Array of strategy definitions (see structure below)
 - `$post_type` (string) - The post type being checked
 
 **Return**: Array of strategy definitions
 
 **Strategy Definition Structure**:
+
 ```php
 [
     'id'        => 'event_identity_index',      // string, required. Stable id, surfaced as `strategy` in the ability result.
@@ -890,6 +951,7 @@ add_filter( 'datamachine_should_reprocess_item', function ( $skip, $ctx ) {
 ```
 
 **Cascade Order**:
+
 1. Extension strategies registered on this filter (sorted by `priority`, lowest first).
 2. Core `published_post_source_url` match (exact source URL via `PostIdentityIndex`).
 3. Core `published_post` title match (similarity engine).
@@ -997,6 +1059,7 @@ There is no requirement to use `PostIdentityIndex` — the filter accepts any ca
 This filter, the strategy definition shape, the callback signature, and the return array shape are considered a public API as of 0.39.0. They will not change in a backward-incompatible way without a deprecation cycle.
 
 **See Also**:
+
 - Source: `inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php::getStrategies()`
 - Canonical consumer: the event duplicate strategy in the `data-machine-events` extension plugin
 - Ability docs: [datamachine/check-duplicate](../../ai-tools/) in ai-tools reference
@@ -1008,6 +1071,7 @@ This filter, the strategy definition shape, the callback signature, and the retu
 **Purpose**: Access files repository service
 
 **Parameters**:
+
 - `$repositories` (array) - Empty array for repository services
 
 **Return**: Array with 'files' key containing repository instance
@@ -1021,11 +1085,13 @@ This filter, the strategy definition shape, the callback signature, and the retu
 **Purpose**: Unified directive registration with priority-based ordering and agent type targeting
 
 **Parameters**:
+
 - `$directives` (array) - Array of directive configurations
 
 **Return**: Modified directives array
 
 **Directive Configuration Structure**:
+
 ```php
 [
     'class' => DirectiveClass::class,   // Directive class name
@@ -1035,6 +1101,7 @@ This filter, the strategy definition shape, the callback signature, and the retu
 ```
 
 **Usage Example**:
+
 ```php
 add_filter('datamachine_directives', function($directives) {
     // Global directive (all agents)
@@ -1056,6 +1123,7 @@ add_filter('datamachine_directives', function($directives) {
 ```
 
 **Priority Guidelines**:
+
 - **10-19**: Core agent identity and foundational instructions
 - **20-29**: Global system prompts and universal behavior
 - **30-39**: Agent-specific system prompts and context
@@ -1070,6 +1138,7 @@ add_filter('datamachine_directives', function($directives) {
 **Purpose**: Modify global AI system directives applied across all AI interactions (pipeline + chat)
 
 **Migration Example**:
+
 ```php
 // LEGACY (pre-v0.2.5)
 add_filter('datamachine_global_directives', function($directives) {
@@ -1099,6 +1168,7 @@ add_filter('datamachine_directives', function($directives) {
 **Purpose**: Modify AI system directives for specific agent types (pipeline or chat)
 
 **Parameters**:
+
 - `$request` (array) - Current AI request being built
 - `$agent_type` (string) - Agent type ('pipeline' or 'chat')
 - `$provider` (string) - AI provider (openai, anthropic, etc.)
@@ -1108,6 +1178,7 @@ add_filter('datamachine_directives', function($directives) {
 **Return**: Modified request array
 
 **Migration Example**:
+
 ```php
 // LEGACY (pre-v0.2.5)
 add_filter('datamachine_agent_directives', function($request, $agent_type, $provider, $tools, $context) {
@@ -1138,6 +1209,7 @@ add_filter('datamachine_directives', function($directives) {
 **Purpose**: Find next step in flow execution sequence
 
 **Parameters**:
+
 - `$next_id` (null) - Placeholder for return value
 - `$current_flow_step_id` (string) - Current step ID
 
@@ -1157,12 +1229,15 @@ Data Machine's Universal Engine provides shared AI infrastructure serving both P
 **Core Methods**:
 
 #### `buildParameters()`
+
 ```php
 \DataMachine\Engine\AI\ToolParameters::buildParameters(array $data, ?string $job_id, ?string $flow_step_id): array
 ```
+
 Builds flat parameter structure for standard AI tools with content extraction and job context.
 
 **Returns**:
+
 ```php
 [
     'content_string' => 'Clean content text',
@@ -1173,12 +1248,15 @@ Builds flat parameter structure for standard AI tools with content extraction an
 ```
 
 #### `buildForHandlerTool()`
+
 ```php
 \DataMachine\Engine\AI\ToolParameters::buildForHandlerTool(array $data, array $tool_def, ?string $job_id, ?string $flow_step_id): array
 ```
+
 Builds parameters for handler-specific tools with engine data merging (source_url, image_url).
 
 **Returns**:
+
 ```php
 [
     // Standard parameters
@@ -1199,6 +1277,7 @@ Builds parameters for handler-specific tools with engine data merging (source_ur
 ```
 
 **Key Features**:
+
 - Content/title extraction from data packets
 - Flat parameter structure for AI simplicity
 - Tool metadata integration
@@ -1229,6 +1308,7 @@ $tools = $resolver->resolve( array(
 ```
 
 **Discovery Process**:
+
 1. Handler Tools - Retrieved via `datamachine_tools` filter (runtime-resolved `_handler_callable` entries)
 2. Global Tools - Retrieved via `datamachine_global_tools` filter
 3. Chat Tools - Retrieved via `datamachine_chat_tools` filter (chat only)
@@ -1274,6 +1354,7 @@ conversation. See [ai-conversation-loop.md](../../core-system/ai-conversation-lo
 for the full adapter contract.
 
 **Features**:
+
 - Automatic tool execution during conversation turns
 - Conversation completion detection
 - Turn-based state management with chronological ordering
@@ -1328,26 +1409,31 @@ factory caches the store per request and applies the filter exactly once.
 
 **Message shape contract**
 
-Stores MUST normalize messages on read to Data Machine message shape. The
-versioned runtime envelope is documented in
-[`ai-message-envelope.md`](../../core-system/ai-message-envelope.md), but the
-chat/session storage contract remains this JSON-friendly legacy shape:
+Stores MUST normalize messages on read to Data Machine's canonical AI message
+envelope, documented in
+[`ai-message-envelope.md`](../../core-system/ai-message-envelope.md). The
+chat/session storage contract is this JSON-friendly envelope shape:
 
 ```php
 [
-    'id'         => string,                 // Stable message identifier
-    'role'       => 'user'|'assistant'|'system'|'tool',
-    'content'    => string|array,
-    'metadata'   => array,                  // Tool calls, tokens, provider-specific fields
-    'created_at' => string,                 // MySQL DATETIME (UTC)
-    'updated_at' => string,                 // MySQL DATETIME (UTC)
+	'schema'     => 'datamachine.ai.message',
+	'version'    => 1,
+	'type'       => 'text'|'tool_call'|'tool_result'|...,
+	'role'       => 'user'|'assistant'|'system'|'tool',
+	'content'    => string|array,
+	'payload'    => array,                  // Type-specific fields.
+	'metadata'   => array,                  // Extension/provider details.
+	'id'         => string,                 // Optional stable message identifier.
+	'created_at' => string,                 // Optional MySQL DATETIME (UTC).
+	'updated_at' => string,                 // Optional MySQL DATETIME (UTC).
 ]
 ```
 
 The five Chat Session abilities and the DM chat UI consume this shape.
 Adapter stores that wrap another host runtime are responsible for translating
 host-specific message objects into Data Machine's envelope at the boundary and
-returning `role/content/metadata` arrays on the way out.
+returning envelopes on the way out. Provider-specific `role/content/metadata`
+arrays are projection shapes at provider boundaries, not the store contract.
 
 **Swap boundary**
 
@@ -1408,6 +1494,7 @@ add_filter( 'datamachine_memory_store', function ( $store, $scope ) {
 ```
 
 **Contract**:
+
 - `read( $scope )` → `AgentMemoryReadResult { exists, content, hash, bytes, updated_at }`
 - `write( $scope, $content, $if_match = null )` → `AgentMemoryWriteResult`
   (implementations supporting concurrency MUST honor `$if_match` and return
@@ -1442,6 +1529,7 @@ Outside plugins and extensions should follow the same pattern: instantiate `Agen
 **Purpose**: Message formatting utilities for AI requests.
 
 **Key Features**:
+
 - Message formatting for AI providers
 - Tool call recording and tracking
 - Conversation message normalization
@@ -1454,6 +1542,7 @@ Outside plugins and extensions should follow the same pattern: instantiate `Agen
 **Core Method**:
 
 #### `build()`
+
 ```php
 $response = \DataMachine\Engine\AI\RequestBuilder::build(
     array $messages,
@@ -1466,6 +1555,7 @@ $response = \DataMachine\Engine\AI\RequestBuilder::build(
 ```
 
 **Features**:
+
 - Directive application system (global, agent-specific, pipeline, chat)
 - Tool restructuring for AI provider compatibility
 - Integration with ai-http-client library

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -14,6 +14,7 @@ namespace DataMachine\Abilities;
 use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Engine\AI\RequestBuilder;
+use DataMachine\Engine\AI\MessageEnvelope;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\Tasks\TaskScheduler;
@@ -546,8 +547,10 @@ class SystemAbilities {
 		$first_assistant_response = null;
 
 		foreach ( $messages as $msg ) {
+			$msg     = MessageEnvelope::normalize( $msg );
 			$role    = $msg['role'] ?? '';
 			$content = $msg['content'] ?? '';
+			$content = is_string( $content ) ? $content : wp_json_encode( $content, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
 
 			if ( 'user' === $role && null === $first_user_message && ! empty($content) ) {
 				$first_user_message = $content;

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -23,6 +23,7 @@ use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Abilities\Job\RetryJobAbility;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Engine\AI\MessageEnvelope;
 use DataMachine\Engine\Tasks\TaskRegistry;
 
 defined( 'ABSPATH' ) || exit;
@@ -471,12 +472,12 @@ class JobsCommand extends BaseCommand {
 
 		if ( 'json' === $format ) {
 			$payload = $raw ? $messages : array(
-				'job_id'         => $job_id,
-				'session_id'     => $transcript_session_id,
-				'metadata'       => $metadata,
-				'provider'       => $session['provider'] ?? null,
-				'model'          => $session['model'] ?? null,
-				'messages'       => $messages,
+				'job_id'     => $job_id,
+				'session_id' => $transcript_session_id,
+				'metadata'   => $metadata,
+				'provider'   => $session['provider'] ?? null,
+				'model'      => $session['model'] ?? null,
+				'messages'   => $messages,
 			);
 			WP_CLI::log( wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
 			return;
@@ -544,10 +545,11 @@ class JobsCommand extends BaseCommand {
 		WP_CLI::log( '' );
 
 		foreach ( $messages as $idx => $message ) {
-			$role     = $message['role'] ?? 'unknown';
-			$type     = $message['metadata']['type'] ?? 'text';
-			$content  = $message['content'] ?? '';
-			$header   = sprintf( '[%d] %s (%s)', $idx, $role, $type );
+			$message = MessageEnvelope::normalize( $message );
+			$role    = $message['role'] ?? 'unknown';
+			$type    = $message['type'] ?? MessageEnvelope::TYPE_TEXT;
+			$content = $message['content'] ?? '';
+			$header  = sprintf( '[%d] %s (%s)', $idx, $role, $type );
 
 			WP_CLI::log( $header );
 			WP_CLI::log( str_repeat( '-', min( 80, strlen( $header ) ) ) );
@@ -1252,8 +1254,8 @@ class JobsCommand extends BaseCommand {
 				$preview_effects = $engine_data['effects'] ?? array();
 				if ( empty( $preview_effects ) ) {
 					foreach ( $jobs_db->get_children( (int) $jid ) as $child ) {
-						$child_data    = is_array( $child['engine_data'] ?? null ) ? $child['engine_data'] : array();
-						$child_effects = $child_data['effects'] ?? array();
+						$child_data      = is_array( $child['engine_data'] ?? null ) ? $child['engine_data'] : array();
+						$child_effects   = $child_data['effects'] ?? array();
 						$preview_effects = array_merge( $preview_effects, $child_effects );
 					}
 				}

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -13,6 +13,7 @@ namespace DataMachine\Core\Database\Chat;
 
 use DataMachine\Core\Admin\DateFormatter;
 use DataMachine\Core\Database\BaseRepository;
+use DataMachine\Engine\AI\MessageEnvelope;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -244,7 +245,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				'metadata'   => wp_json_encode( $metadata ),
 				'provider'   => null,
 				'model'      => null,
-				'mode' => $mode,
+				'mode'       => $mode,
 				'expires_at' => null,
 			),
 			array( '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' )
@@ -258,7 +259,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				array(
 					'user_id' => $user_id,
 					'error'   => $wpdb->last_error,
-					'mode' => $mode,
+					'mode'    => $mode,
 				)
 			);
 			return '';
@@ -272,7 +273,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				'session_id' => $session_id,
 				'user_id'    => $user_id,
 				'agent_id'   => $agent_id,
-				'mode' => $mode,
+				'mode'       => $mode,
 			)
 		);
 
@@ -304,7 +305,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			return null;
 		}
 
-		$session['messages'] = json_decode( $session['messages'], true ) ?? array();
+		$session['messages'] = self::normalize_messages( json_decode( $session['messages'], true ) ?? array() );
 		$session['metadata'] = json_decode( $session['metadata'], true ) ?? array();
 
 		return $session;
@@ -331,8 +332,24 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 
 		$table_name = self::get_prefixed_table_name();
 
+		try {
+			$normalized_messages = MessageEnvelope::normalize_many( $messages );
+		} catch ( \InvalidArgumentException $e ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Failed to normalize chat session messages for update',
+				array(
+					'session_id' => $session_id,
+					'error'      => $e->getMessage(),
+					'mode'       => 'chat',
+				)
+			);
+			return false;
+		}
+
 		$update_data = array(
-			'messages' => wp_json_encode( $messages ),
+			'messages' => wp_json_encode( $normalized_messages ),
 			'metadata' => wp_json_encode( $metadata ),
 		);
 
@@ -365,7 +382,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				array(
 					'session_id' => $session_id,
 					'error'      => $wpdb->last_error,
-					'mode' => 'chat',
+					'mode'       => 'chat',
 				)
 			);
 			return false;
@@ -400,7 +417,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				array(
 					'session_id' => $session_id,
 					'error'      => $wpdb->last_error,
-					'mode' => 'chat',
+					'mode'       => 'chat',
 				)
 			);
 			return false;
@@ -412,7 +429,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			'Chat session deleted',
 			array(
 				'session_id' => $session_id,
-				'mode' => 'chat',
+				'mode'       => 'chat',
 			)
 		);
 
@@ -445,7 +462,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				'Cleaned up expired chat sessions',
 				array(
 					'deleted_count' => $deleted,
-					'mode' => 'chat',
+					'mode'          => 'chat',
 				)
 			);
 		}
@@ -552,11 +569,11 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 
 		$result = array();
 		foreach ( $sessions as $session ) {
-			$messages      = json_decode( $session['messages'] ?? '[]', true ) ?? array();
+			$messages      = self::normalize_messages( json_decode( $session['messages'] ?? '[]', true ) ?? array() );
 			$first_message = '';
 			foreach ( $messages as $msg ) {
 				if ( ( $msg['role'] ?? '' ) === 'user' ) {
-					$first_message = $msg['content'] ?? '';
+					$first_message = self::message_content_text( $msg );
 					break;
 				}
 			}
@@ -568,7 +585,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			$result[] = array(
 				'session_id'    => $session['session_id'],
 				'title'         => $session['title'] ?? null,
-				'mode' => $session['mode'] ?? 'chat',
+				'mode'          => $session['mode'] ?? 'chat',
 				'first_message' => mb_substr( $first_message, 0, 100 ),
 				'message_count' => count( $messages ),
 				'unread_count'  => $this->count_unread( $messages, $last_read_at ),
@@ -700,16 +717,18 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		$query .= ' ORDER BY created_at DESC LIMIT 1';
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		$session = $wpdb->get_row(
 			$wpdb->prepare( $query, $params ),
 			ARRAY_A
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL
 
 		if ( ! $session ) {
 			return null;
 		}
 
-		$session['messages'] = json_decode( $session['messages'], true ) ?? array();
+		$session['messages'] = self::normalize_messages( json_decode( $session['messages'], true ) ?? array() );
 		$session['metadata'] = json_decode( $session['metadata'], true ) ?? array();
 
 		return $session;
@@ -744,7 +763,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				array(
 					'session_id' => $session_id,
 					'error'      => $wpdb->last_error,
-					'mode' => 'chat',
+					'mode'       => 'chat',
 				)
 			);
 			return false;
@@ -770,13 +789,14 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		$count = 0;
 
 		foreach ( $messages as $msg ) {
+			$msg = MessageEnvelope::normalize( $msg );
 			if ( ( $msg['role'] ?? '' ) !== 'assistant' ) {
 				continue;
 			}
 
 			// Skip tool call/result messages — only count visible assistant responses.
-			$type = $msg['metadata']['type'] ?? 'text';
-			if ( 'tool_call' === $type || 'tool_result' === $type ) {
+			$type = $msg['type'] ?? MessageEnvelope::TYPE_TEXT;
+			if ( MessageEnvelope::TYPE_TOOL_CALL === $type || MessageEnvelope::TYPE_TOOL_RESULT === $type ) {
 				continue;
 			}
 
@@ -792,6 +812,41 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		}
 
 		return $count;
+	}
+
+	/**
+	 * Normalize a decoded message list to the canonical Data Machine envelope.
+	 *
+	 * @param array $messages Decoded messages.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function normalize_messages( array $messages ): array {
+		try {
+			return MessageEnvelope::normalize_many( $messages );
+		} catch ( \InvalidArgumentException $e ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Chat: Failed to normalize stored messages',
+				array( 'error' => $e->getMessage() )
+			);
+			return array();
+		}
+	}
+
+	/**
+	 * Render envelope content to a summary-safe string.
+	 *
+	 * @param array $message Message envelope.
+	 * @return string Summary text.
+	 */
+	private static function message_content_text( array $message ): string {
+		$content = $message['content'] ?? '';
+		if ( is_string( $content ) ) {
+			return $content;
+		}
+
+		return (string) wp_json_encode( $content, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
 	}
 
 	/**
@@ -868,7 +923,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 					'deleted_count'  => $deleted,
 					'retention_days' => $retention_days,
 					'cutoff_date'    => $cutoff_date,
-					'mode' => 'chat',
+					'mode'           => 'chat',
 				)
 			);
 		}
@@ -905,10 +960,10 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$deleted = $wpdb->query(
 			$wpdb->prepare(
-				"DELETE FROM %i
+				'DELETE FROM %i
 				WHERE mode = %s
 				AND metadata LIKE %s
-				AND updated_at < %s",
+				AND updated_at < %s',
 				$table_name,
 				'pipeline',
 				'%"source":"pipeline_transcript"%',
@@ -972,7 +1027,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 					'deleted_count'   => $deleted,
 					'hours_threshold' => $hours,
 					'cutoff_time'     => $cutoff_time,
-					'mode' => 'chat',
+					'mode'            => 'chat',
 				)
 			);
 		}
@@ -1020,7 +1075,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			$result[] = array(
 				'session_id' => (string) $row['session_id'],
 				'title'      => isset( $row['title'] ) ? (string) $row['title'] : null,
-				'mode' => isset($row['mode']) ? (string) $row['mode'] : 'chat',
+				'mode'       => isset($row['mode']) ? (string) $row['mode'] : 'chat',
 				'created_at' => (string) $row['created_at'],
 			);
 		}

--- a/inc/Core/Database/Chat/ConversationStoreInterface.php
+++ b/inc/Core/Database/Chat/ConversationStoreInterface.php
@@ -15,7 +15,7 @@
  * clarification with no behavior change.
  *
  * Implementations are responsible for:
- * - normalizing messages on read to Data Machine message shape
+ * - normalizing messages on read to Data Machine's canonical AI message envelope
  *   (see docs/development/hooks/core-filters.md#message-shape-contract);
  * - preserving per-session identity via UUIDv4 session IDs;
  * - honoring the `(user_id, agent_id, context)` triple when listing.

--- a/inc/Engine/AI/AIConversationResult.php
+++ b/inc/Engine/AI/AIConversationResult.php
@@ -40,7 +40,7 @@ class AIConversationResult {
 			}
 
 			try {
-				$message = MessageEnvelope::to_legacy_message( $message );
+				$message = MessageEnvelope::normalize( $message );
 			} catch ( \InvalidArgumentException $e ) {
 				throw self::invalid( $path, $e->getMessage() );
 			}
@@ -49,14 +49,6 @@ class AIConversationResult {
 
 			if ( array_key_exists( 'role', $message ) && ! is_string( $message['role'] ) ) {
 				throw self::invalid( $path . '.role', 'must be a string when present' );
-			}
-
-			if (
-				'assistant' === ( $message['role'] ?? '' )
-				&& array_key_exists( 'content', $message )
-				&& ! is_string( $message['content'] )
-			) {
-				throw self::invalid( $path . '.content', 'must be a string for assistant messages' );
 			}
 		}
 

--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
 class ConversationManager {
 
 	/**
-	 * Build standardized conversation message structure.
+	 * Build standardized conversation message envelope.
 	 *
 	 * Content can be a plain string (text-only messages) or an array of content
 	 * blocks for multi-modal messages (text + images). When an array is provided,
@@ -36,14 +36,10 @@ class ConversationManager {
 	 * @param string       $role     Role identifier (user, assistant, system).
 	 * @param string|array $content  Message content — string for text, array for multi-modal content blocks.
 	 * @param array        $metadata Optional metadata for the message (e.g., type, tool_data, attachments).
-	 * @return array Message array with role, content, and metadata.
+	 * @return array Message envelope.
 	 */
 	public static function buildConversationMessage( string $role, $content, array $metadata = array() ): array {
-		return array(
-			'role'     => $role,
-			'content'  => $content,
-			'metadata' => array_merge( array( 'timestamp' => gmdate( 'c' ) ), $metadata ),
-		);
+		return MessageEnvelope::text( $role, $content, array_merge( array( 'timestamp' => gmdate( 'c' ) ), $metadata ) );
 	}
 
 	/**
@@ -129,14 +125,13 @@ class ConversationManager {
 			$message .= ' with parameters: ' . implode( ', ', $params_str );
 		}
 
-		$metadata = array(
-			'type'       => 'tool_call',
-			'tool_name'  => $tool_name,
-			'parameters' => $tool_parameters,
-			'turn'       => $turn_count,
+		return MessageEnvelope::toolCall(
+			$message,
+			$tool_name,
+			$tool_parameters,
+			$turn_count,
+			array( 'timestamp' => gmdate( 'c' ) )
 		);
-
-		return self::buildConversationMessage( 'assistant', $message, $metadata );
 	}
 
 	/**
@@ -158,15 +153,13 @@ class ConversationManager {
 			$content = $human_message;
 		}
 
-		$metadata = array(
-			'type'      => 'tool_result',
-			'tool_name' => $tool_name,
-			'success'   => $tool_result['success'] ?? false,
-			'turn'      => $turn_count,
+		$payload = array(
+			'success' => $tool_result['success'] ?? false,
+			'turn'    => $turn_count,
 		);
 
 		if ( ! empty( $tool_result['data'] ) ) {
-			$metadata['tool_data'] = $tool_result['data'];
+			$payload['tool_data'] = $tool_result['data'];
 
 			// Still append to content for AI context, but frontend can use metadata to hide it
 			if ( ! $is_handler_tool ) {
@@ -178,14 +171,14 @@ class ConversationManager {
 		// Tools can include a 'media' array in their result to signal renderable
 		// media (images, videos) that the frontend should display inline.
 		if ( ! empty( $tool_result['media'] ) ) {
-			$metadata['media'] = $tool_result['media'];
+			$payload['media'] = $tool_result['media'];
 		}
 
 		if ( isset( $tool_result['error'] ) ) {
-			$metadata['error'] = $tool_result['error'];
+			$payload['error'] = $tool_result['error'];
 		}
 
-		return self::buildConversationMessage( 'user', $content, $metadata );
+		return MessageEnvelope::toolResult( $content, $tool_name, $payload, array( 'timestamp' => gmdate( 'c' ) ) );
 	}
 
 	/**
@@ -305,18 +298,18 @@ class ConversationManager {
 
 		// Scan ALL previous tool_call messages, not just the most recent one.
 		for ( $i = count( $conversation_messages ) - 1; $i >= 0; $i-- ) {
-			$message = $conversation_messages[ $i ];
+			$message = MessageEnvelope::normalize( $conversation_messages[ $i ] );
 
 			if ( 'assistant' !== $message['role'] ) {
 				continue;
 			}
 
-			if ( ( $message['metadata']['type'] ?? null ) !== 'tool_call' ) {
+			if ( MessageEnvelope::TYPE_TOOL_CALL !== $message['type'] ) {
 				continue;
 			}
 
-			$prev_tool_name  = $message['metadata']['tool_name'] ?? null;
-			$prev_parameters = $message['metadata']['parameters'] ?? null;
+			$prev_tool_name  = $message['payload']['tool_name'] ?? null;
+			$prev_parameters = $message['payload']['parameters'] ?? null;
 
 			if ( ! is_string( $prev_tool_name ) || ! is_array( $prev_parameters ) ) {
 				continue;
@@ -346,9 +339,11 @@ class ConversationManager {
 	 * @return array|null Tool call details or null if not a tool call message
 	 */
 	public static function extractToolCallFromMessage( array $message ): ?array {
-		if ( ( $message['metadata']['type'] ?? null ) === 'tool_call' ) {
-			$tool_name  = $message['metadata']['tool_name'] ?? null;
-			$parameters = $message['metadata']['parameters'] ?? null;
+		$envelope = MessageEnvelope::normalize( $message );
+
+		if ( MessageEnvelope::TYPE_TOOL_CALL === $envelope['type'] ) {
+			$tool_name  = $envelope['payload']['tool_name'] ?? null;
+			$parameters = $envelope['payload']['parameters'] ?? null;
 
 			if ( is_string( $tool_name ) && is_array( $parameters ) ) {
 				return array(
@@ -358,11 +353,11 @@ class ConversationManager {
 			}
 		}
 
-		if ( 'assistant' !== $message['role'] || ! isset( $message['content'] ) ) {
+		if ( 'assistant' !== $envelope['role'] || ! isset( $envelope['content'] ) ) {
 			return null;
 		}
 
-		$content = $message['content'];
+		$content = $envelope['content'];
 
 		if ( ! preg_match( '/AI ACTION \(Turn \d+\): Executing (.+?)(?: with parameters: (.+))?$/', $content, $matches ) ) {
 			return null;

--- a/inc/Engine/AI/MessageEnvelope.php
+++ b/inc/Engine/AI/MessageEnvelope.php
@@ -12,11 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Normalizes Data Machine AI messages into a stable typed envelope.
- *
- * The persisted chat/session shape remains `role/content/metadata`; this class
- * gives adapters a versioned JSON object to target without coupling Data
- * Machine core to any host-specific DTO.
+ * Normalizes Data Machine AI messages into the canonical typed envelope.
  */
 class MessageEnvelope {
 
@@ -55,18 +51,70 @@ class MessageEnvelope {
 	}
 
 	/**
+	 * Build a canonical text envelope.
+	 *
+	 * @param string       $role     Message role.
+	 * @param string|array $content  Message content.
+	 * @param array        $metadata Extension metadata.
+	 * @return array<string, mixed>
+	 */
+	public static function text( string $role, $content, array $metadata = array() ): array {
+		return self::buildEnvelope( $role, $content, self::inferContentType( $content, $metadata ), array(), $metadata, array() );
+	}
+
+	/**
+	 * Build a canonical tool-call envelope.
+	 *
+	 * @param string $content    Human-readable tool-call content.
+	 * @param string $tool_name  Tool identifier.
+	 * @param array  $parameters Tool parameters.
+	 * @param int    $turn       Conversation turn.
+	 * @param array  $metadata   Extension metadata.
+	 * @return array<string, mixed>
+	 */
+	public static function toolCall( string $content, string $tool_name, array $parameters, int $turn, array $metadata = array() ): array {
+		return self::buildEnvelope(
+			'assistant',
+			$content,
+			self::TYPE_TOOL_CALL,
+			array(
+				'tool_name'  => $tool_name,
+				'parameters' => $parameters,
+				'turn'       => $turn,
+			),
+			$metadata,
+			array()
+		);
+	}
+
+	/**
+	 * Build a canonical tool-result envelope.
+	 *
+	 * @param string $content  Human-readable tool-result content.
+	 * @param string $tool_name Tool identifier.
+	 * @param array  $payload  Type-specific result payload.
+	 * @param array  $metadata Extension metadata.
+	 * @return array<string, mixed>
+	 */
+	public static function toolResult( string $content, string $tool_name, array $payload, array $metadata = array() ): array {
+		$payload['tool_name'] = $tool_name;
+
+		return self::buildEnvelope( 'user', $content, self::TYPE_TOOL_RESULT, $payload, $metadata, array() );
+	}
+
+	/**
 	 * Normalize a legacy message or typed envelope to the canonical envelope.
 	 *
 	 * @param array $message Message array.
-	 * @return array Normalized envelope.
+	 * @return array<string, mixed> Normalized envelope.
 	 * @throws \InvalidArgumentException When the message is invalid.
 	 */
 	public static function normalize( array $message ): array {
-		$envelope = self::is_envelope( $message )
-			? self::normalize_envelope( $message )
-			: self::from_legacy_message( $message );
+		$envelope = self::isEnvelope( $message )
+			? self::normalizeEnvelope( $message )
+			: self::fromLegacyMessage( $message );
 
-		if ( false === self::json_encode( $envelope ) ) {
+		if ( false === self::jsonEncode( $envelope ) ) {
 			throw new \InvalidArgumentException( 'invalid_ai_message_envelope: envelope must be JSON serializable' );
 		}
 
@@ -91,61 +139,62 @@ class MessageEnvelope {
 	}
 
 	/**
-	 * Convert an envelope back to the current persisted Data Machine shape.
+	 * Project an envelope to the current ai-http-client request message shape.
 	 *
-	 * @param array $envelope Typed envelope or legacy message.
-	 * @return array Legacy message with role/content/metadata.
+	 * @param array $message Typed envelope or legacy message.
+	 * @return array<string, mixed> Provider-facing message.
 	 */
-	public static function to_legacy_message( array $envelope ): array {
-		$source_is_envelope  = self::is_envelope( $envelope );
-		$source_had_metadata = array_key_exists( 'metadata', $envelope );
-		$source_metadata     = is_array( $envelope['metadata'] ?? null ) ? $envelope['metadata'] : array();
-		$envelope            = self::normalize( $envelope );
-
+	public static function to_provider_message( array $message ): array {
+		$envelope = self::normalize( $message );
 		$metadata = $envelope['metadata'];
-		if ( $source_is_envelope || self::TYPE_TEXT !== $envelope['type'] || array_key_exists( 'type', $source_metadata ) ) {
+
+		if ( self::TYPE_TEXT !== $envelope['type'] || ! empty( $envelope['payload'] ) || ! empty( $metadata ) ) {
 			$metadata['type'] = $envelope['type'];
 		}
-
-		foreach ( $envelope['data'] as $key => $value ) {
+		foreach ( $envelope['payload'] as $key => $value ) {
 			if ( ! array_key_exists( $key, $metadata ) ) {
 				$metadata[ $key ] = $value;
 			}
 		}
 
-		$message = array(
+		$provider_message = array(
 			'role'    => $envelope['role'],
 			'content' => $envelope['content'],
 		);
 
-		if ( ! empty( $metadata ) || $source_is_envelope || $source_had_metadata ) {
-			$message['metadata'] = $metadata;
+		if ( ! empty( $metadata ) ) {
+			$provider_message['metadata'] = $metadata;
 		}
 
-		foreach ( array( 'id', 'created_at', 'updated_at' ) as $field ) {
-			if ( isset( $envelope[ $field ] ) && is_string( $envelope[ $field ] ) && '' !== $envelope[ $field ] ) {
-				$message[ $field ] = $envelope[ $field ];
-			}
-		}
-
-		return $message;
+		return $provider_message;
 	}
 
 	/**
-	 * Convert a message list back to the current persisted shape.
+	 * Project envelopes to the current ai-http-client request message shape.
 	 *
-	 * @param array $messages Message arrays or envelopes.
-	 * @return array<int, array<string, mixed>>
+	 * @param array $messages Typed envelopes or legacy messages.
+	 * @return array<int, array<string, mixed>> Provider-facing messages.
 	 */
-	public static function to_legacy_messages( array $messages ): array {
-		$legacy_messages = array();
+	public static function to_provider_messages( array $messages ): array {
+		$provider_messages = array();
 		foreach ( $messages as $message ) {
 			if ( ! is_array( $message ) ) {
 				throw new \InvalidArgumentException( 'invalid_ai_message_envelope: message must be an array' );
 			}
-			$legacy_messages[] = self::to_legacy_message( $message );
+			$provider_messages[] = self::to_provider_message( $message );
 		}
-		return $legacy_messages;
+		return $provider_messages;
+	}
+
+	/**
+	 * Extract the canonical type from a message.
+	 *
+	 * @param array $message Typed envelope or legacy message.
+	 * @return string Message type.
+	 */
+	public static function type( array $message ): string {
+		$envelope = self::normalize( $message );
+		return $envelope['type'];
 	}
 
 	/**
@@ -154,29 +203,34 @@ class MessageEnvelope {
 	 * @param array $message Message array.
 	 * @return bool
 	 */
-	private static function is_envelope( array $message ): bool {
+	private static function isEnvelope( array $message ): bool {
 		return isset( $message['version'], $message['type'] )
-			&& ( isset( $message['schema'] ) || array_key_exists( 'data', $message ) );
+			&& ( isset( $message['schema'] ) || array_key_exists( 'payload', $message ) || array_key_exists( 'data', $message ) );
 	}
 
 	/**
 	 * Normalize an already-typed envelope.
 	 *
 	 * @param array $message Raw envelope.
-	 * @return array Canonical envelope.
+	 * @return array<string, mixed> Canonical envelope.
 	 */
-	private static function normalize_envelope( array $message ): array {
+	private static function normalizeEnvelope( array $message ): array {
 		if ( self::VERSION !== (int) $message['version'] ) {
 			throw new \InvalidArgumentException( 'invalid_ai_message_envelope: unsupported version' );
 		}
 
-		$type = self::normalize_type( $message['type'] ?? self::TYPE_TEXT );
+		$type    = self::normalizeType( $message['type'] ?? self::TYPE_TEXT );
+		$payload = is_array( $message['payload'] ?? null ) ? $message['payload'] : array();
 
-		return self::build_envelope(
-			$message['role'] ?? self::role_for_type( $type ),
+		if ( empty( $payload ) && is_array( $message['data'] ?? null ) ) {
+			$payload = $message['data'];
+		}
+
+		return self::buildEnvelope(
+			$message['role'] ?? self::roleForType( $type ),
 			$message['content'] ?? '',
 			$type,
-			is_array( $message['data'] ?? null ) ? $message['data'] : array(),
+			$payload,
 			is_array( $message['metadata'] ?? null ) ? $message['metadata'] : array(),
 			$message
 		);
@@ -186,17 +240,17 @@ class MessageEnvelope {
 	 * Normalize the legacy role/content/metadata message shape.
 	 *
 	 * @param array $message Legacy message.
-	 * @return array Canonical envelope.
+	 * @return array<string, mixed> Canonical envelope.
 	 */
-	private static function from_legacy_message( array $message ): array {
+	private static function fromLegacyMessage( array $message ): array {
 		$metadata = is_array( $message['metadata'] ?? null ) ? $message['metadata'] : array();
-		$type     = self::infer_type( $message, $metadata );
+		$type     = self::inferType( $message, $metadata );
 
-		return self::build_envelope(
-			$message['role'] ?? self::role_for_type( $type ),
+		return self::buildEnvelope(
+			$message['role'] ?? self::roleForType( $type ),
 			$message['content'] ?? '',
 			$type,
-			self::data_from_legacy_metadata( $type, $metadata ),
+			self::payloadFromLegacyMetadata( $type, $metadata ),
 			$metadata,
 			$message
 		);
@@ -208,12 +262,12 @@ class MessageEnvelope {
 	 * @param mixed  $role     Raw role.
 	 * @param mixed  $content  Raw content.
 	 * @param string $type     Envelope type.
-	 * @param array  $data     Type-specific payload.
+	 * @param array  $payload  Type-specific payload.
 	 * @param array  $metadata Extension metadata.
 	 * @param array  $source   Source message.
-	 * @return array Canonical envelope.
+	 * @return array<string, mixed> Canonical envelope.
 	 */
-	private static function build_envelope( $role, $content, string $type, array $data, array $metadata, array $source ): array {
+	private static function buildEnvelope( $role, $content, string $type, array $payload, array $metadata, array $source ): array {
 		if ( ! is_string( $role ) || '' === $role ) {
 			throw new \InvalidArgumentException( 'invalid_ai_message_envelope: role must be a non-empty string' );
 		}
@@ -225,10 +279,10 @@ class MessageEnvelope {
 		$envelope = array(
 			'schema'   => self::SCHEMA,
 			'version'  => self::VERSION,
-			'type'     => self::normalize_type( $type ),
+			'type'     => self::normalizeType( $type ),
 			'role'     => $role,
 			'content'  => $content,
-			'data'     => $data,
+			'payload'  => $payload,
 			'metadata' => $metadata,
 		);
 
@@ -248,36 +302,48 @@ class MessageEnvelope {
 	 * @param array $metadata Legacy metadata.
 	 * @return string Envelope type.
 	 */
-	private static function infer_type( array $message, array $metadata ): string {
-		if ( isset( $metadata['type'] ) && is_string( $metadata['type'] ) && in_array( $metadata['type'], self::SUPPORTED_TYPES, true ) ) {
-			return $metadata['type'];
+	private static function inferType( array $message, array $metadata ): string {
+		$metadata_type = is_string( $metadata['type'] ?? null ) ? $metadata['type'] : '';
+		if ( in_array( $metadata_type, self::SUPPORTED_TYPES, true ) ) {
+			return $metadata_type;
+		}
+
+		if ( 'multimodal' === $metadata_type || is_array( $message['content'] ?? null ) ) {
+			return self::TYPE_MULTIMODAL_PART;
 		}
 
 		if ( isset( $metadata['error'] ) ) {
 			return self::TYPE_ERROR;
 		}
 
-		if ( is_array( $message['content'] ?? null ) ) {
-			return self::TYPE_MULTIMODAL_PART;
-		}
-
 		return self::TYPE_TEXT;
 	}
 
 	/**
-	 * Pull common legacy metadata fields into type-specific envelope data.
+	 * Infer the type for newly built messages.
+	 *
+	 * @param mixed $content  Message content.
+	 * @param array $metadata Message metadata.
+	 * @return string Envelope type.
+	 */
+	private static function inferContentType( $content, array $metadata ): string {
+		return self::inferType( array( 'content' => $content ), $metadata );
+	}
+
+	/**
+	 * Pull common legacy metadata fields into type-specific envelope payload.
 	 *
 	 * @param string $type     Envelope type.
 	 * @param array  $metadata Legacy metadata.
-	 * @return array Type-specific data.
+	 * @return array<string, mixed> Type-specific payload.
 	 */
-	private static function data_from_legacy_metadata( string $type, array $metadata ): array {
-		$data = array();
+	private static function payloadFromLegacyMetadata( string $type, array $metadata ): array {
+		$payload = array();
 
 		if ( self::TYPE_TOOL_CALL === $type ) {
 			foreach ( array( 'tool_name', 'parameters', 'turn' ) as $key ) {
 				if ( array_key_exists( $key, $metadata ) ) {
-					$data[ $key ] = $metadata[ $key ];
+					$payload[ $key ] = $metadata[ $key ];
 				}
 			}
 		}
@@ -285,12 +351,12 @@ class MessageEnvelope {
 		if ( self::TYPE_TOOL_RESULT === $type ) {
 			foreach ( array( 'tool_name', 'success', 'turn', 'tool_data', 'media', 'error' ) as $key ) {
 				if ( array_key_exists( $key, $metadata ) ) {
-					$data[ $key ] = $metadata[ $key ];
+					$payload[ $key ] = $metadata[ $key ];
 				}
 			}
 		}
 
-		return $data;
+		return $payload;
 	}
 
 	/**
@@ -299,7 +365,7 @@ class MessageEnvelope {
 	 * @param mixed $type Raw type.
 	 * @return string Supported type.
 	 */
-	private static function normalize_type( $type ): string {
+	private static function normalizeType( $type ): string {
 		if ( ! is_string( $type ) || ! in_array( $type, self::SUPPORTED_TYPES, true ) ) {
 			throw new \InvalidArgumentException( 'invalid_ai_message_envelope: unsupported type' );
 		}
@@ -312,7 +378,7 @@ class MessageEnvelope {
 	 * @param mixed $data Data to encode.
 	 * @return string|false Encoded JSON or false on failure.
 	 */
-	private static function json_encode( $data ) {
+	private static function jsonEncode( $data ) {
 		if ( function_exists( 'wp_json_encode' ) ) {
 			return wp_json_encode( $data );
 		}
@@ -327,7 +393,7 @@ class MessageEnvelope {
 	 * @param string $type Envelope type.
 	 * @return string Role.
 	 */
-	private static function role_for_type( string $type ): string {
+	private static function roleForType( string $type ): string {
 		if ( in_array( $type, array( self::TYPE_TOOL_RESULT, self::TYPE_INPUT_REQUIRED, self::TYPE_APPROVAL_REQUIRED ), true ) ) {
 			return 'tool';
 		}

--- a/inc/Engine/AI/PromptBuilder.php
+++ b/inc/Engine/AI/PromptBuilder.php
@@ -168,10 +168,10 @@ class PromptBuilder {
 				$directive_outputs = array_merge( $directive_outputs, $outputs );
 			}
 
-			$validated_outputs   = DirectiveOutputValidator::validateOutputs( $outputs, $validation_context );
-			$rendered_messages    = DirectiveRenderer::renderMessages( $validated_outputs );
-			$applied_directives[] = $directive_name;
-			$directive_metadata[] = self::describeDirectiveOutputs( $directive_name, $priority, $outputs );
+			$validated_outputs     = DirectiveOutputValidator::validateOutputs( $outputs, $validation_context );
+			$rendered_messages     = DirectiveRenderer::renderMessages( $validated_outputs );
+			$applied_directives[]  = $directive_name;
+			$directive_metadata[]  = self::describeDirectiveOutputs( $directive_name, $priority, $outputs );
 			$directive_breakdown[] = array(
 				'class'                  => $directive_class,
 				'name'                   => $directive_name,
@@ -188,7 +188,7 @@ class PromptBuilder {
 		$directive_messages = DirectiveRenderer::renderMessages( $validated_outputs );
 
 		return array(
-			'messages'            => array_merge( $directive_messages, $conversation_messages ),
+			'messages'            => MessageEnvelope::normalize_many( array_merge( $directive_messages, $conversation_messages ) ),
 			'tools'               => $this->tools,
 			'applied_directives'  => $applied_directives,
 			'directive_metadata'  => $directive_metadata,

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -46,14 +46,16 @@ class RequestBuilder {
 		string $mode,
 		array $payload = array()
 	): array {
-		$assembled           = self::assemble( $messages, $provider, $model, $tools, $mode, $payload );
-		$request             = $assembled['request'];
-		$structured_tools    = $assembled['structured_tools'];
-		$applied_directives  = $assembled['applied_directives'];
-		$directive_metadata  = $assembled['directive_metadata'];
+		$assembled                    = self::assemble( $messages, $provider, $model, $tools, $mode, $payload );
+		$request                      = $assembled['request'];
+		$provider_request             = $request;
+		$provider_request['messages'] = MessageEnvelope::to_provider_messages( $request['messages'] ?? array() );
+		$structured_tools             = $assembled['structured_tools'];
+		$applied_directives           = $assembled['applied_directives'];
+		$directive_metadata           = $assembled['directive_metadata'];
 
 		$request_metadata = RequestMetadata::build(
-			$request,
+			$provider_request,
 			$structured_tools,
 			$directive_metadata,
 			$provider,
@@ -73,7 +75,7 @@ class RequestBuilder {
 					'flow_step_id'          => $payload['flow_step_id'] ?? null,
 					'provider'              => $provider,
 					'model'                 => $model,
-					'message_count'         => count( $request['messages'] ),
+					'message_count'         => count( $provider_request['messages'] ),
 					'tool_count'            => count( $structured_tools ),
 					'directives'            => $applied_directives,
 					'suppressed_directives' => ! empty( $assembled['suppressed_directives'] ) ? $assembled['suppressed_directives'] : null,
@@ -98,7 +100,7 @@ class RequestBuilder {
 		// surface. Once WordPress 7.0 is the minimum supported version, those layers
 		// will be migrated and ai-http-client will be removed entirely.
 		if ( WpAiClientAdapter::isAvailable( $provider ) ) {
-			$wp_ai_response = WpAiClientAdapter::dispatch( $request, $provider, $structured_tools );
+			$wp_ai_response = WpAiClientAdapter::dispatch( $provider_request, $provider, $structured_tools );
 
 			// dispatch() returns null when the bridge cannot translate the request
 			// (e.g. multi-modal content) so we transparently fall through to the
@@ -129,7 +131,7 @@ class RequestBuilder {
 		// Legacy path: ai-http-client via chubes_ai_request filter.
 		$response = apply_filters(
 			'chubes_ai_request',
-			$request,
+			$provider_request,
 			$provider,
 			null, // streaming_callback
 			$structured_tools,
@@ -179,8 +181,8 @@ class RequestBuilder {
 				'agent_id' => $payload['agent_id'] ?? 0,
 			)
 		);
-		$directives = $directive_policy['directives'];
-		$suppressed = $directive_policy['suppressed'] ?? array();
+		$directives       = $directive_policy['directives'];
+		$suppressed       = $directive_policy['suppressed'] ?? array();
 		foreach ( $directives as $directive ) {
 			$promptBuilder->addDirective(
 				$directive['class'],
@@ -189,18 +191,19 @@ class RequestBuilder {
 			);
 		}
 
-		$request              = $promptBuilder->buildDetailed( $mode, $provider, $payload );
+		$request             = $promptBuilder->buildDetailed( $mode, $provider, $payload );
+		$request['messages'] = MessageEnvelope::normalize_many( $request['messages'] ?? array() );
 		$applied_directives  = $request['applied_directives'] ?? array();
 		$directive_metadata  = $request['directive_metadata'] ?? array();
 		$directive_breakdown = $request['directive_breakdown'] ?? array();
 		unset( $request['applied_directives'], $request['directive_metadata'], $request['directive_breakdown'] );
-		$request['model']    = $model;
+		$request['model'] = $model;
 
 		return array(
-			'request'             => $request,
-			'structured_tools'    => $structured_tools,
-			'applied_directives'  => $applied_directives,
-			'directive_metadata'  => $directive_metadata,
+			'request'               => $request,
+			'structured_tools'      => $structured_tools,
+			'applied_directives'    => $applied_directives,
+			'directive_metadata'    => $directive_metadata,
 			'directive_breakdown'   => $directive_breakdown,
 			'suppressed_directives' => $suppressed,
 		);

--- a/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
+++ b/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
@@ -13,6 +13,7 @@
 namespace DataMachine\Tests\Unit\Core\Database\Chat;
 
 use DataMachine\Core\Database\Chat\ConversationStoreInterface;
+use DataMachine\Engine\AI\MessageEnvelope;
 
 class InMemoryConversationStore implements ConversationStoreInterface {
 
@@ -173,11 +174,12 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 	public function count_unread( array $messages, ?string $last_read_at ): int {
 		$count = 0;
 		foreach ( $messages as $msg ) {
+			$msg = MessageEnvelope::normalize( $msg );
 			if ( ( $msg['role'] ?? '' ) !== 'assistant' ) {
 				continue;
 			}
-			$type = $msg['metadata']['type'] ?? 'text';
-			if ( 'tool_call' === $type || 'tool_result' === $type ) {
+			$type = $msg['type'] ?? MessageEnvelope::TYPE_TEXT;
+			if ( MessageEnvelope::TYPE_TOOL_CALL === $type || MessageEnvelope::TYPE_TOOL_RESULT === $type ) {
 				continue;
 			}
 			if ( null === $last_read_at ) {

--- a/tests/ai-conversation-result-smoke.php
+++ b/tests/ai-conversation-result-smoke.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/bootstrap-unit.php';
 
 use DataMachine\Engine\AI\AIConversationLoop;
 use DataMachine\Engine\AI\AIConversationResult;
+use DataMachine\Engine\AI\MessageEnvelope;
 
 if ( ! function_exists( 'apply_filters' ) ) {
 	function apply_filters( string $hook, $value ) {
@@ -52,8 +53,13 @@ $valid_result = array(
 
 $normalized = AIConversationResult::normalize( $valid_result );
 datamachine_ai_conversation_result_assert(
-	$valid_result === $normalized,
-	'Valid built-in-shaped result should pass unchanged.'
+	MessageEnvelope::TYPE_TEXT === $normalized['messages'][0]['type'],
+	'Valid built-in-shaped result should normalize messages to canonical envelopes.'
+);
+++$assertions;
+datamachine_ai_conversation_result_assert(
+	'Done.' === $normalized['messages'][0]['content'],
+	'Canonical envelope preserves message content.'
 );
 ++$assertions;
 

--- a/tests/ai-message-envelope-smoke.php
+++ b/tests/ai-message-envelope-smoke.php
@@ -10,6 +10,7 @@
 require_once __DIR__ . '/bootstrap-unit.php';
 
 use DataMachine\Engine\AI\AIConversationResult;
+use DataMachine\Engine\AI\ConversationManager;
 use DataMachine\Engine\AI\MessageEnvelope;
 
 function datamachine_message_envelope_assert( bool $condition, string $message ): void {
@@ -36,7 +37,9 @@ datamachine_message_envelope_assert( MessageEnvelope::VERSION === $text_envelope
 datamachine_message_envelope_count();
 datamachine_message_envelope_assert( MessageEnvelope::TYPE_TEXT === $text_envelope['type'], 'Legacy text infers text type.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( $legacy_text === MessageEnvelope::to_legacy_message( $legacy_text ), 'Plain legacy text round-trips without adding metadata churn.' );
+datamachine_message_envelope_assert( array() === $text_envelope['payload'], 'Plain legacy text normalizes with an empty payload.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( $legacy_text === MessageEnvelope::to_provider_message( $legacy_text ), 'Plain legacy text projects without provider metadata churn.' );
 datamachine_message_envelope_count();
 
 $legacy_tool_call = array(
@@ -53,11 +56,17 @@ $legacy_tool_call = array(
 $tool_call_envelope = MessageEnvelope::normalize( $legacy_tool_call );
 datamachine_message_envelope_assert( MessageEnvelope::TYPE_TOOL_CALL === $tool_call_envelope['type'], 'Legacy tool call keeps explicit tool_call type.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( 'wiki_upsert' === $tool_call_envelope['data']['tool_name'], 'Tool call tool_name is promoted to envelope data.' );
+datamachine_message_envelope_assert( 'wiki_upsert' === $tool_call_envelope['payload']['tool_name'], 'Tool call tool_name is promoted to envelope payload.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( array( 'title' => 'Demo' ) === $tool_call_envelope['data']['parameters'], 'Tool call parameters are promoted to envelope data.' );
+datamachine_message_envelope_assert( array( 'title' => 'Demo' ) === $tool_call_envelope['payload']['parameters'], 'Tool call parameters are promoted to envelope payload.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( $legacy_tool_call === MessageEnvelope::to_legacy_message( $tool_call_envelope ), 'Tool call envelope converts back to legacy storage shape.' );
+datamachine_message_envelope_assert( $legacy_tool_call === MessageEnvelope::to_provider_message( $tool_call_envelope ), 'Tool call envelope projects back to provider message shape.' );
+datamachine_message_envelope_count();
+
+$built_tool_call = ConversationManager::formatToolCallMessage( 'wiki_upsert', array( 'title' => 'Demo' ), 3 );
+datamachine_message_envelope_assert( MessageEnvelope::TYPE_TOOL_CALL === $built_tool_call['type'], 'ConversationManager emits tool_call envelopes.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( 'wiki_upsert' === $built_tool_call['payload']['tool_name'], 'ConversationManager stores tool call details in payload.' );
 datamachine_message_envelope_count();
 
 $legacy_tool_result = array(
@@ -75,11 +84,11 @@ $legacy_tool_result = array(
 $tool_result_envelope = MessageEnvelope::normalize( $legacy_tool_result );
 datamachine_message_envelope_assert( MessageEnvelope::TYPE_TOOL_RESULT === $tool_result_envelope['type'], 'Legacy tool result keeps explicit tool_result type.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( true === $tool_result_envelope['data']['success'], 'Tool result success is promoted to envelope data.' );
+datamachine_message_envelope_assert( true === $tool_result_envelope['payload']['success'], 'Tool result success is promoted to envelope payload.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( array( 'post_id' => 123 ) === $tool_result_envelope['data']['tool_data'], 'Tool result data is promoted to envelope data.' );
+datamachine_message_envelope_assert( array( 'post_id' => 123 ) === $tool_result_envelope['payload']['tool_data'], 'Tool result data is promoted to envelope payload.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( $legacy_tool_result === MessageEnvelope::to_legacy_message( $tool_result_envelope ), 'Tool result envelope converts back to legacy storage shape.' );
+datamachine_message_envelope_assert( $legacy_tool_result === MessageEnvelope::to_provider_message( $tool_result_envelope ), 'Tool result envelope projects back to provider message shape.' );
 datamachine_message_envelope_count();
 
 $typed_final_result = array(
@@ -88,20 +97,26 @@ $typed_final_result = array(
 	'type'     => MessageEnvelope::TYPE_FINAL_RESULT,
 	'role'     => 'assistant',
 	'content'  => 'Finished.',
-	'data'     => array( 'status' => 'complete' ),
+	'payload'  => array( 'status' => 'complete' ),
 	'metadata' => array( 'provider_message_id' => 'msg_123' ),
 );
 
-$typed_legacy = MessageEnvelope::to_legacy_message( $typed_final_result );
-datamachine_message_envelope_assert( 'assistant' === $typed_legacy['role'], 'Future typed envelope keeps role in legacy output.' );
+$typed_envelope = MessageEnvelope::normalize( $typed_final_result );
+datamachine_message_envelope_assert( 'assistant' === $typed_envelope['role'], 'Future typed envelope keeps role in canonical output.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( 'Finished.' === $typed_legacy['content'], 'Future typed envelope keeps content in legacy output.' );
+datamachine_message_envelope_assert( 'Finished.' === $typed_envelope['content'], 'Future typed envelope keeps content in canonical output.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( MessageEnvelope::TYPE_FINAL_RESULT === $typed_legacy['metadata']['type'], 'Future typed envelope writes type into legacy metadata.' );
+datamachine_message_envelope_assert( MessageEnvelope::TYPE_FINAL_RESULT === $typed_envelope['type'], 'Future typed envelope keeps type as a top-level field.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( 'complete' === $typed_legacy['metadata']['status'], 'Future typed envelope folds data into legacy metadata.' );
+datamachine_message_envelope_assert( 'complete' === $typed_envelope['payload']['status'], 'Future typed envelope keeps type-specific data in payload.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( 'msg_123' === $typed_legacy['metadata']['provider_message_id'], 'Future typed envelope preserves extension metadata.' );
+datamachine_message_envelope_assert( 'msg_123' === $typed_envelope['metadata']['provider_message_id'], 'Future typed envelope preserves extension metadata.' );
+datamachine_message_envelope_count();
+
+$typed_provider = MessageEnvelope::to_provider_message( $typed_envelope );
+datamachine_message_envelope_assert( MessageEnvelope::TYPE_FINAL_RESULT === $typed_provider['metadata']['type'], 'Provider projection folds type into metadata.' );
+datamachine_message_envelope_count();
+datamachine_message_envelope_assert( 'complete' === $typed_provider['metadata']['status'], 'Provider projection folds payload into metadata.' );
 datamachine_message_envelope_count();
 
 $typed_delta = array(
@@ -109,11 +124,18 @@ $typed_delta = array(
 	'version' => MessageEnvelope::VERSION,
 	'type'    => MessageEnvelope::TYPE_DELTA,
 	'content' => 'partial token',
-	'data'    => array( 'index' => 0 ),
+	'payload' => array( 'index' => 0 ),
 );
 
 $delta_envelope = MessageEnvelope::normalize( $typed_delta );
 datamachine_message_envelope_assert( 'assistant' === $delta_envelope['role'], 'Typed delta envelope gets assistant default role.' );
+datamachine_message_envelope_count();
+
+$old_data_envelope = $typed_delta;
+$old_data_envelope['data'] = $old_data_envelope['payload'];
+unset( $old_data_envelope['payload'] );
+$old_data_normalized = MessageEnvelope::normalize( $old_data_envelope );
+datamachine_message_envelope_assert( array( 'index' => 0 ) === $old_data_normalized['payload'], 'Old data envelope key is accepted as a read-time compatibility input.' );
 datamachine_message_envelope_count();
 
 $multimodal_legacy = array(
@@ -140,7 +162,7 @@ $result = AIConversationResult::normalize(
 	)
 );
 
-datamachine_message_envelope_assert( MessageEnvelope::TYPE_FINAL_RESULT === $result['messages'][0]['metadata']['type'], 'AIConversationResult accepts typed envelopes and returns legacy messages.' );
+datamachine_message_envelope_assert( MessageEnvelope::TYPE_FINAL_RESULT === $result['messages'][0]['type'], 'AIConversationResult accepts typed envelopes and returns canonical envelopes.' );
 datamachine_message_envelope_count();
 
 try {
@@ -158,7 +180,7 @@ try {
 	datamachine_message_envelope_count();
 }
 
-datamachine_message_envelope_assert( false !== json_encode( $typed_legacy ), 'Legacy output remains JSON serializable.' );
+datamachine_message_envelope_assert( false !== json_encode( $typed_envelope ), 'Canonical envelope remains JSON serializable.' );
 datamachine_message_envelope_count();
 
 echo 'AI message envelope smoke passed (' . $GLOBALS['datamachine_message_envelope_assertions'] . " assertions).\n";

--- a/tests/ai-request-inspector-smoke.php
+++ b/tests/ai-request-inspector-smoke.php
@@ -45,6 +45,7 @@ require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveInterface.php';
 require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectivePolicyResolver.php';
 require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveOutputValidator.php';
 require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveRenderer.php';
+require_once __DIR__ . '/../inc/Engine/AI/MessageEnvelope.php';
 require_once __DIR__ . '/../inc/Engine/AI/PromptBuilder.php';
 require_once __DIR__ . '/../inc/Engine/AI/RequestBuilder.php';
 
@@ -145,8 +146,8 @@ $request_json_bytes = strlen( wp_json_encode( $assembled['request'], JSON_UNESCA
 $messages_json_bytes = strlen( wp_json_encode( $assembled['request']['messages'], JSON_UNESCAPED_UNICODE ) );
 $tools_json_bytes = strlen( wp_json_encode( $assembled['request']['tools'], JSON_UNESCAPED_UNICODE ) );
 
-assert_test( 'request JSON byte count stable', 330 === $request_json_bytes, 'got ' . $request_json_bytes );
-assert_test( 'messages JSON byte count stable', 111 === $messages_json_bytes, 'got ' . $messages_json_bytes );
+assert_test( 'request JSON byte count stable', 504 === $request_json_bytes, 'got ' . $request_json_bytes );
+assert_test( 'messages JSON byte count stable', 285 === $messages_json_bytes, 'got ' . $messages_json_bytes );
 assert_test( 'tools JSON byte count stable', 178 === $tools_json_bytes, 'got ' . $tools_json_bytes );
 
 echo "\nCase 3: CLI command surface is registered and documented\n";
@@ -163,7 +164,7 @@ assert_test( 'json output path exists', false !== strpos( $command, "'json' === 
 assert_test( 'table output includes directive section', false !== strpos( $command, "Directives" ) );
 assert_test( 'table output includes largest tools section', false !== strpos( $command, "Largest tools" ) );
 
-$plugin = file_get_contents( __DIR__ . '/../data-machine.php' );
+$plugin  = file_get_contents( __DIR__ . '/../data-machine.php' );
 $ability = file_get_contents( __DIR__ . '/../inc/Abilities/AI/InspectRequestAbility.php' );
 
 assert_test( 'inspect request ability loaded by plugin bootstrap', false !== strpos( $plugin, 'InspectRequestAbility.php' ) );


### PR DESCRIPTION
## Summary
- Makes `MessageEnvelope` the canonical internal message shape for AI runtime, chat storage, and transcripts.
- Renames the typed envelope payload field from `data` to `payload`, with read-time compatibility for existing draft envelopes.
- Projects canonical envelopes to provider `role/content/metadata` messages only at request dispatch boundaries.

## Changes
- `ConversationManager`, `PromptBuilder`, `AIConversationResult`, and chat storage now emit/normalize canonical envelopes.
- `RequestBuilder` keeps canonical request assembly for inspection while dispatching provider-shaped projections.
- Chat/session docs and runtime adapter docs now describe the envelope as the storage/runtime contract.

## Tests
- `php tests/ai-message-envelope-smoke.php`
- `php tests/ai-conversation-result-smoke.php`
- `php tests/ai-request-inspector-smoke.php`
- `php tests/ai-request-metadata-guardrails-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@feat-canonical-message-envelope --skip-lint --changed-since origin/main`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-canonical-message-envelope --changed-only --summary` *(PHPCS passed; Homeboy still exits non-zero from existing ESLint-on-non-JS changed-scope noise, with no baseline drift.)*

Closes #1514.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the canonical envelope migration, updated tests/docs, and ran focused validation. Chris remains responsible for review and merge.