### PR TITLE
feat(pipeline): support workflow specs in bulk create

### DIFF
--- a/inc/Abilities/Pipeline/CreatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/CreatePipelineAbility.php
@@ -420,21 +420,18 @@ class CreatePipelineAbility {
 		if ( $validate_only ) {
 			$preview = array();
 			foreach ( $pipelines as $index => $pipeline_config ) {
-				$name     = $pipeline_config['name'];
-				$resolved = $this->resolveBulkPipelineSpec( $pipeline_config, $template_workflow, $template_steps );
-				$workflow = $resolved['workflow'];
-				$steps    = $resolved['steps'];
+				$entry = $this->resolveBulkPipelineEntry( $pipeline_config, $template_workflow, $template_steps );
 
 				$preview_item = array(
-					'name'          => $name,
-					'steps'         => ! empty( $workflow ) ? count( $workflow['steps'] ?? array() ) : count( $steps ),
-					'creation_mode' => ! empty( $workflow ) ? 'workflow' : ( ! empty( $steps ) ? 'batch' : 'simple' ),
+					'name'          => $entry['name'],
+					'steps'         => ! empty( $entry['workflow'] ) ? count( $entry['workflow']['steps'] ?? array() ) : count( $entry['steps'] ),
+					'creation_mode' => ! empty( $entry['workflow'] ) ? 'workflow' : ( ! empty( $entry['steps'] ) ? 'batch' : 'simple' ),
 				);
 
 				$has_flow = isset( $pipeline_config['flow_name'] ) || isset( $pipeline_config['scheduling_config'] ) || isset( $template['scheduling_config'] );
 				if ( $has_flow ) {
 					$scheduling_config          = $pipeline_config['scheduling_config'] ?? ( $template['scheduling_config'] ?? array( 'interval' => 'manual' ) );
-					$preview_item['flow_name']  = $pipeline_config['flow_name'] ?? $name;
+					$preview_item['flow_name']  = $pipeline_config['flow_name'] ?? $entry['name'];
 					$preview_item['scheduling'] = $scheduling_config['interval'] ?? 'manual';
 				}
 
@@ -459,19 +456,16 @@ class CreatePipelineAbility {
 		$agent_id = isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
 
 		foreach ( $pipelines as $index => $pipeline_config ) {
-			$name     = $pipeline_config['name'];
-			$resolved = $this->resolveBulkPipelineSpec( $pipeline_config, $template_workflow, $template_steps );
-			$workflow = $resolved['workflow'];
-			$steps    = $resolved['steps'];
+			$entry = $this->resolveBulkPipelineEntry( $pipeline_config, $template_workflow, $template_steps );
 
 			$single_input = array(
-				'pipeline_name' => $name,
+				'pipeline_name' => $entry['name'],
 			);
 
-			if ( ! empty( $workflow ) ) {
-				$single_input['workflow'] = $workflow;
+			if ( ! empty( $entry['workflow'] ) ) {
+				$single_input['workflow'] = $entry['workflow'];
 			} else {
-				$single_input['steps'] = $steps;
+				$single_input['steps'] = $entry['steps'];
 			}
 
 			if ( null !== $agent_id && $agent_id > 0 ) {
@@ -482,7 +476,7 @@ class CreatePipelineAbility {
 			$has_flow_config = isset( $pipeline_config['flow_name'] ) || isset( $pipeline_config['scheduling_config'] ) || isset( $template['scheduling_config'] );
 			if ( $has_flow_config ) {
 				$single_input['flow_config'] = array(
-					'flow_name'         => $pipeline_config['flow_name'] ?? $name,
+					'flow_name'         => $pipeline_config['flow_name'] ?? $entry['name'],
 					'scheduling_config' => $pipeline_config['scheduling_config'] ?? ( $template['scheduling_config'] ?? array( 'interval' => 'manual' ) ),
 				);
 			}
@@ -503,7 +497,7 @@ class CreatePipelineAbility {
 				++$failed_count;
 				$errors[] = array(
 					'index'       => $index,
-					'name'        => $name,
+					'name'        => $entry['name'],
 					'error'       => $single_result['error'],
 					'remediation' => 'Check the error message and fix the pipeline configuration',
 				);
@@ -577,6 +571,21 @@ class CreatePipelineAbility {
 		return array(
 			'workflow' => $workflow,
 			'steps'    => $steps,
+		);
+	}
+
+	/**
+	 * Resolve a bulk pipeline entry name and effective step source.
+	 *
+	 * @param array $pipeline_config Pipeline entry config.
+	 * @param array $template_workflow Shared workflow template.
+	 * @param array $template_steps Shared legacy steps template.
+	 * @return array{name: string, workflow: array, steps: array}
+	 */
+	private function resolveBulkPipelineEntry( array $pipeline_config, array $template_workflow, array $template_steps ): array {
+		return array_merge(
+			array( 'name' => $pipeline_config['name'] ),
+			$this->resolveBulkPipelineSpec( $pipeline_config, $template_workflow, $template_steps )
 		);
 	}
 

--- a/tests/bulk-create-pipeline-workflow-smoke.php
+++ b/tests/bulk-create-pipeline-workflow-smoke.php
@@ -170,8 +170,8 @@ assert_bulk_workflow_equals( array(), $resolved['workflow'], 'per-pipeline legac
 assert_bulk_workflow_equals( $legacy_steps, $resolved['steps'], 'existing legacy bulk steps behavior remains available', $failures, $passes );
 
 $source = file_get_contents( __DIR__ . '/../inc/Abilities/Pipeline/CreatePipelineAbility.php' ) ?: '';
-assert_bulk_workflow_equals( true, false !== strpos( $source, '$single_input[\'workflow\'] = $workflow;' ), 'bulk execution forwards resolved workflow to single-mode creator', $failures, $passes );
-assert_bulk_workflow_equals( true, false !== strpos( $source, '$single_input[\'steps\'] = $steps;' ), 'bulk execution still forwards legacy steps to single-mode creator', $failures, $passes );
+assert_bulk_workflow_equals( true, false !== strpos( $source, '$single_input[\'workflow\'] = $entry[\'workflow\'];' ), 'bulk execution forwards resolved workflow to single-mode creator', $failures, $passes );
+assert_bulk_workflow_equals( true, false !== strpos( $source, '$single_input[\'steps\'] = $entry[\'steps\'];' ), 'bulk execution still forwards legacy steps to single-mode creator', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " bulk workflow assertions failed.\n";


### PR DESCRIPTION
## Summary

- Allows bulk pipeline workflow-spec installs to share the resolved bulk entry path for validation preview and creation.
- Keeps the bulk workflow smoke aligned with the resolved entry contract after the workflow-spec support landed on `main` during this cook.

## Changes

- Adds a small `resolveBulkPipelineEntry()` helper so validate-only preview and execution consume the same resolved name/workflow/steps payload.
- Updates the bulk workflow smoke assertions to pin forwarding the resolved workflow/steps through the single-mode create path.

## Tests

- `php tests/bulk-create-pipeline-workflow-smoke.php`
- `php tests/workflow-persistent-install-smoke.php`
- `php -l inc/Abilities/Pipeline/CreatePipelineAbility.php && php -l tests/bulk-create-pipeline-workflow-smoke.php && git diff --check`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@feat-bulk-workflow-specs --changed-since origin/main` passed. It still reports existing heuristic warnings for missing unit-test file and constant-backed slug literals, but no blocking failures.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-bulk-workflow-specs` still fails on the repo-wide lint backlog; the touched production file had no lint findings after the formatting fix.

Closes #1500

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented bulk workflow-spec support under Chris's direction; Chris remains responsible for review and merge.
