### PR TITLE
fix(deps): pin BFB release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=8.2",
 		"woocommerce/action-scheduler": "^3.9",
 		"chubes4/ai-http-client": "^2.0.13",
-		"chubes4/block-format-bridge": "dev-main"
+		"chubes4/block-format-bridge": "^0.4"
 	},
 	"require-dev": {
 		"php-stubs/wordpress-stubs": "^6.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "307b2dd9d37131ca17facd890981262c",
+    "content-hash": "cb8ee794e4793804034c976b0e7f08c0",
     "packages": [
         {
             "name": "chubes4/ai-http-client",
@@ -68,16 +68,16 @@
         },
         {
             "name": "chubes4/block-format-bridge",
-            "version": "dev-main",
+            "version": "v0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "23eae2f5283939ce0ac95d2bc287804f3702f829"
+                "reference": "e8b032bad4d2fe4e9ef06f008d52ed2d55d7d86d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/23eae2f5283939ce0ac95d2bc287804f3702f829",
-                "reference": "23eae2f5283939ce0ac95d2bc287804f3702f829",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/e8b032bad4d2fe4e9ef06f008d52ed2d55d7d86d",
+                "reference": "e8b032bad4d2fe4e9ef06f008d52ed2d55d7d86d",
                 "shasum": ""
             },
             "require": {
@@ -89,7 +89,6 @@
                 "chubes4/html-to-blocks-converter": "dev-main",
                 "humbug/php-scoper": "^0.18.19"
             },
-            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "files": [
@@ -113,10 +112,10 @@
             "description": "WordPress plugin orchestrating bidirectional content format conversion (HTML, Blocks, Markdown) via a unified adapter API.",
             "homepage": "https://github.com/chubes4/block-format-bridge",
             "support": {
-                "source": "https://github.com/chubes4/block-format-bridge/tree/main",
+                "source": "https://github.com/chubes4/block-format-bridge/tree/v0.4.0",
                 "issues": "https://github.com/chubes4/block-format-bridge/issues"
             },
-            "time": "2026-04-28T15:44:04+00:00"
+            "time": "2026-04-28T17:37:17+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -1559,9 +1558,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "chubes4/block-format-bridge": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## Summary
- Move the Block Format Bridge dependency from `dev-main` to the released `^0.4` line.
- Lock Data Machine to BFB `v0.4.0` so the bundled substrate reports the released BFB version and no longer tracks a moving branch.

## Tests
- `php tests/content-format-helper-smoke.php`
- `php tests/content-format-abilities-smoke.php`
- `php tests/wordpress-publish-content-format-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Refreshed the Composer constraint/lock to the released BFB substrate and ran focused validation. Chris remains responsible for review and merge.
