### PR TITLE
feat(bundle): add agent bundle artifact foundations

### DIFF
--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -1,0 +1,68 @@
+# Agent Bundles
+
+Agent bundles are portable, versioned packages for an agent's runtime behavior. They describe what to install without embedding local database IDs or secrets.
+
+## Directory Layout
+
+```text
+<bundle>/
+├── manifest.json
+├── memory/
+├── pipelines/<pipeline-slug>.json
+├── flows/<flow-slug>.json
+├── prompts/<prompt-slug>.md
+├── rubrics/<rubric-slug>.md
+├── tool-policies/<policy-slug>.json
+└── seed-queues/<queue-slug>.json
+```
+
+Only `manifest.json`, `pipelines/`, `flows/`, and `memory/` have import/export adapters today. The remaining directories are reserved schema surface for prompts, rubrics, tool policies, auth references, and seed queue artifacts.
+
+## Manifest Schema
+
+`manifest.json` uses `schema_version: 1` and requires:
+
+- `bundle_slug`: stable bundle identity.
+- `bundle_version`: explicit bundle version for upgrade planning.
+- `source_ref` and `source_revision`: optional source coordinates.
+- `exported_at` and `exported_by`: export metadata.
+- `agent`: `slug`, `label`, `description`, and `agent_config` defaults.
+- `included`: lists of `memory`, `pipelines`, `flows`, `prompts`, `rubrics`, `tool_policies`, `auth_refs`, and `seed_queues`, plus `handler_auth` mode.
+
+`handler_auth` is one of:
+
+- `refs`: include `auth_ref` handles only.
+- `full`: reserved for encrypted credential exports.
+- `omit`: omit handler auth material.
+
+## Artifact Tracking
+
+Bundle installs track artifacts independently of their runtime table. The foundation record shape is:
+
+- `bundle_slug`
+- `bundle_version`
+- `artifact_type`
+- `artifact_id`
+- `source_path`
+- `installed_hash`
+- `current_hash`
+- `status`
+- `installed_at`
+- `updated_at`
+
+`artifact_type` is one of `agent`, `memory`, `pipeline`, `flow`, `prompt`, `rubric`, `tool_policy`, `auth_ref`, `seed_queue`, or `schedule`.
+
+Statuses:
+
+- `clean`: current hash equals the installed hash.
+- `modified`: current hash differs from the installed hash.
+- `missing`: an installed artifact no longer exists in runtime state.
+- `orphaned`: runtime state exists without an installed bundle record.
+
+Hashing is deterministic: arrays are recursively sorted and JSON-encoded through `BundleSchema::encode_json()` before SHA-256 hashing. This makes formatting and associative key order irrelevant while preserving list order.
+
+## Follow-Ups
+
+- Add persistent DB storage for installed artifact records.
+- Wire importer/exporter paths for prompts, rubrics, tool policies, auth refs, and seed queues.
+- Use artifact statuses during bundle upgrade planning: auto-update `clean`, stage PendingActions for `modified`, surface `missing` and `orphaned` explicitly.

--- a/inc/Engine/Bundle/AgentBundleArtifactHasher.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactHasher.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Deterministic hash helper for installed agent bundle artifacts.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Produces stable hashes for bundle artifact state comparisons.
+ */
+final class AgentBundleArtifactHasher {
+
+	/**
+	 * Hash a structured artifact payload.
+	 *
+	 * @param mixed $artifact Artifact payload.
+	 * @return string SHA-256 hash.
+	 */
+	public static function hash( mixed $artifact ): string {
+		if ( is_string( $artifact ) ) {
+			$normalized = $artifact;
+		} elseif ( is_array( $artifact ) ) {
+			$normalized = BundleSchema::encode_json( $artifact );
+		} else {
+			$encoded = wp_json_encode( $artifact, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+			if ( ! is_string( $encoded ) ) {
+				throw new BundleValidationException( 'Unable to encode bundle artifact for hashing.' );
+			}
+			$normalized = $encoded;
+		}
+
+		return hash( 'sha256', $normalized );
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleArtifactStatus.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactStatus.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Installed bundle artifact status classifier.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Classifies local artifact state against installed bundle metadata.
+ */
+final class AgentBundleArtifactStatus {
+
+	public const CLEAN    = 'clean';
+	public const MODIFIED = 'modified';
+	public const MISSING  = 'missing';
+	public const ORPHANED = 'orphaned';
+
+	/**
+	 * Classify an artifact by installed and current hash presence.
+	 *
+	 * @param string|null $installed_hash Hash recorded when the bundle installed the artifact.
+	 * @param string|null $current_hash Current runtime artifact hash, or null when missing.
+	 * @return string One of clean, modified, missing, orphaned.
+	 */
+	public static function classify( ?string $installed_hash, ?string $current_hash ): string {
+		$installed_hash = self::normalize_hash( $installed_hash );
+		$current_hash   = self::normalize_hash( $current_hash );
+
+		if ( null === $installed_hash && null !== $current_hash ) {
+			return self::ORPHANED;
+		}
+
+		if ( null === $installed_hash || null === $current_hash ) {
+			return self::MISSING;
+		}
+
+		return hash_equals( $installed_hash, $current_hash ) ? self::CLEAN : self::MODIFIED;
+	}
+
+	private static function normalize_hash( ?string $hash ): ?string {
+		$hash = null === $hash ? '' : trim( $hash );
+		return '' === $hash ? null : $hash;
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Installed agent bundle artifact tracking value object.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable record shape for a bundle-installed runtime artifact.
+ */
+final class AgentBundleInstalledArtifact {
+
+	private string $bundle_slug;
+	private string $bundle_version;
+	private string $artifact_type;
+	private string $artifact_id;
+	private string $source_path;
+	private string $installed_hash;
+	private ?string $current_hash;
+	private string $status;
+	private string $installed_at;
+	private string $updated_at;
+
+	public function __construct( string $bundle_slug, string $bundle_version, string $artifact_type, string $artifact_id, string $source_path, string $installed_hash, ?string $current_hash, string $installed_at, string $updated_at ) {
+		$this->bundle_slug    = PortableSlug::normalize( $bundle_slug, 'bundle' );
+		$this->bundle_version = self::non_empty_string( $bundle_version, 'bundle_version' );
+		$this->artifact_type  = self::validate_artifact_type( $artifact_type );
+		$this->artifact_id    = self::non_empty_string( $artifact_id, 'artifact_id' );
+		$this->source_path    = self::normalize_source_path( $source_path );
+		$this->installed_hash = self::non_empty_string( $installed_hash, 'installed_hash' );
+		$this->current_hash   = self::optional_string( $current_hash );
+		$this->status         = AgentBundleArtifactStatus::classify( $this->installed_hash, $this->current_hash );
+		$this->installed_at   = self::non_empty_string( $installed_at, 'installed_at' );
+		$this->updated_at     = self::non_empty_string( $updated_at, 'updated_at' );
+	}
+
+	/**
+	 * Build from a stored artifact row shape.
+	 *
+	 * @param array $data Artifact row data.
+	 * @return self
+	 */
+	public static function from_array( array $data ): self {
+		foreach ( array( 'bundle_slug', 'bundle_version', 'artifact_type', 'artifact_id', 'source_path', 'installed_hash', 'installed_at', 'updated_at' ) as $field ) {
+			if ( ! array_key_exists( $field, $data ) ) {
+				throw new BundleValidationException( sprintf( 'installed bundle artifact is missing required field %s.', esc_html( $field ) ) );
+			}
+		}
+
+		return new self(
+			(string) $data['bundle_slug'],
+			(string) $data['bundle_version'],
+			(string) $data['artifact_type'],
+			(string) $data['artifact_id'],
+			(string) $data['source_path'],
+			(string) $data['installed_hash'],
+			isset( $data['current_hash'] ) ? (string) $data['current_hash'] : null,
+			(string) $data['installed_at'],
+			(string) $data['updated_at']
+		);
+	}
+
+	/**
+	 * Build an installed record from the artifact's install-time payload.
+	 *
+	 * @param AgentBundleManifest $manifest Manifest that owns the artifact.
+	 * @param string              $artifact_type Artifact type.
+	 * @param string              $artifact_id Stable artifact identifier.
+	 * @param string              $source_path Bundle-local source path/key.
+	 * @param mixed               $artifact_payload Artifact payload to hash.
+	 * @param string              $timestamp Install/update timestamp.
+	 * @return self
+	 */
+	public static function from_installed_payload( AgentBundleManifest $manifest, string $artifact_type, string $artifact_id, string $source_path, mixed $artifact_payload, string $timestamp ): self {
+		$hash = AgentBundleArtifactHasher::hash( $artifact_payload );
+		return new self( $manifest->bundle_slug(), $manifest->bundle_version(), $artifact_type, $artifact_id, $source_path, $hash, $hash, $timestamp, $timestamp );
+	}
+
+	/**
+	 * Return a copy with refreshed current artifact hash/status.
+	 *
+	 * @param mixed|null $current_payload Current artifact payload, or null when missing.
+	 * @param string     $updated_at Updated timestamp.
+	 * @return self
+	 */
+	public function with_current_payload( mixed $current_payload, string $updated_at ): self {
+		$current_hash = null === $current_payload ? null : AgentBundleArtifactHasher::hash( $current_payload );
+
+		return new self(
+			$this->bundle_slug,
+			$this->bundle_version,
+			$this->artifact_type,
+			$this->artifact_id,
+			$this->source_path,
+			$this->installed_hash,
+			$current_hash,
+			$this->installed_at,
+			$updated_at
+		);
+	}
+
+	public function to_array(): array {
+		return array(
+			'bundle_slug'    => $this->bundle_slug,
+			'bundle_version' => $this->bundle_version,
+			'artifact_type'  => $this->artifact_type,
+			'artifact_id'    => $this->artifact_id,
+			'source_path'    => $this->source_path,
+			'installed_hash' => $this->installed_hash,
+			'current_hash'   => $this->current_hash,
+			'status'         => $this->status,
+			'installed_at'   => $this->installed_at,
+			'updated_at'     => $this->updated_at,
+		);
+	}
+
+	private static function validate_artifact_type( string $type ): string {
+		$type = self::non_empty_string( $type, 'artifact_type' );
+		if ( ! in_array( $type, BundleSchema::ARTIFACT_TYPES, true ) ) {
+			throw new BundleValidationException( sprintf( 'installed bundle artifact_type must be one of: %s.', implode( ', ', BundleSchema::ARTIFACT_TYPES ) ) );
+		}
+
+		return $type;
+	}
+
+	private static function non_empty_string( string $value, string $field ): string {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			throw new BundleValidationException( sprintf( 'installed bundle artifact %s must be a non-empty string.', esc_html( $field ) ) );
+		}
+
+		return $value;
+	}
+
+	private static function optional_string( ?string $value ): ?string {
+		$value = null === $value ? '' : trim( $value );
+		return '' === $value ? null : $value;
+	}
+
+	private static function normalize_source_path( string $path ): string {
+		$path = str_replace( "\\", '/', self::non_empty_string( $path, 'source_path' ) );
+		$path = ltrim( $path, '/' );
+		if ( str_contains( $path, '..' ) ) {
+			throw new BundleValidationException( 'installed bundle artifact source_path must be bundle-local.' );
+		}
+
+		return $path;
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleLegacyAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleLegacyAdapter.php
@@ -28,6 +28,10 @@ final class AgentBundleLegacyAdapter {
 		$manifest = new AgentBundleManifest(
 			(string) ( $bundle['exported_at'] ?? gmdate( 'c' ) ),
 			self::exported_by(),
+			(string) ( $bundle['bundle_slug'] ?? ( $bundle['agent']['agent_slug'] ?? 'agent-bundle' ) ),
+			(string) ( $bundle['bundle_version'] ?? '1' ),
+			(string) ( $bundle['source_ref'] ?? '' ),
+			(string) ( $bundle['source_revision'] ?? '' ),
 			array(
 				'slug'         => $bundle['agent']['agent_slug'] ?? 'agent',
 				'label'        => $bundle['agent']['agent_name'] ?? ( $bundle['agent']['agent_slug'] ?? 'Agent' ),

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -142,7 +142,11 @@ final class AgentBundleManifest {
 			}
 		}
 
-		foreach ( array( 'memory', 'pipelines', 'flows' ) as $field ) {
+		foreach ( array( 'prompts', 'rubrics', 'tool_policies', 'auth_refs', 'seed_queues' ) as $field ) {
+			$included[ $field ] = $included[ $field ] ?? array();
+		}
+
+		foreach ( array( 'memory', 'pipelines', 'flows', 'prompts', 'rubrics', 'tool_policies', 'auth_refs', 'seed_queues' ) as $field ) {
 			if ( ! is_array( $included[ $field ] ) || ! array_is_list( $included[ $field ] ) ) {
 				throw new BundleValidationException( sprintf( 'manifest.json included.%s must be a list.', esc_html( $field ) ) );
 			}
@@ -157,10 +161,15 @@ final class AgentBundleManifest {
 		$included['handler_auth'] = $handler_auth;
 
 		return array(
-			'memory'       => $included['memory'],
-			'pipelines'    => $included['pipelines'],
-			'flows'        => $included['flows'],
-			'handler_auth' => $included['handler_auth'],
+			'memory'        => $included['memory'],
+			'pipelines'     => $included['pipelines'],
+			'flows'         => $included['flows'],
+			'prompts'       => $included['prompts'],
+			'rubrics'       => $included['rubrics'],
+			'tool_policies' => $included['tool_policies'],
+			'auth_refs'     => $included['auth_refs'],
+			'seed_queues'   => $included['seed_queues'],
+			'handler_auth'  => $included['handler_auth'],
 		);
 	}
 

--- a/inc/Engine/Bundle/BundleSchema.php
+++ b/inc/Engine/Bundle/BundleSchema.php
@@ -24,6 +24,27 @@ final class BundleSchema {
 
 	public const FLOWS_DIR = 'flows';
 
+	public const PROMPTS_DIR = 'prompts';
+
+	public const RUBRICS_DIR = 'rubrics';
+
+	public const TOOL_POLICIES_DIR = 'tool-policies';
+
+	public const SEED_QUEUES_DIR = 'seed-queues';
+
+	public const ARTIFACT_TYPES = array(
+		'agent',
+		'memory',
+		'pipeline',
+		'flow',
+		'prompt',
+		'rubric',
+		'tool_policy',
+		'auth_ref',
+		'seed_queue',
+		'schedule',
+	);
+
 	/**
 	 * Encode bundle JSON in a stable, review-friendly shape.
 	 *

--- a/tests/agent-bundle-format-smoke.php
+++ b/tests/agent-bundle-format-smoke.php
@@ -112,10 +112,15 @@ $manifest = AgentBundleManifest::from_array(
 			'agent_config' => array( 'model' => array( 'default' => 'gpt-5.5' ) ),
 		),
 		'included'         => array(
-			'memory'       => array( 'MEMORY.md', 'SOUL.md' ),
-			'pipelines'    => array( 'wc-weekly-lint', 'wc-daily-ingest' ),
-			'flows'        => array( 'wc-weekly-lint-flow', 'wc-daily-ingest-flow' ),
-			'handler_auth' => 'refs',
+			'memory'        => array( 'MEMORY.md', 'SOUL.md' ),
+			'pipelines'     => array( 'wc-weekly-lint', 'wc-daily-ingest' ),
+			'flows'         => array( 'wc-weekly-lint-flow', 'wc-daily-ingest-flow' ),
+			'prompts'       => array( 'extract-facts' ),
+			'rubrics'       => array( 'wiki-quality' ),
+			'tool_policies' => array( 'read-only-context' ),
+			'auth_refs'     => array( 'github:default', 'wpcom:default' ),
+			'seed_queues'   => array( 'mgs-topic-loop' ),
+			'handler_auth'  => 'refs',
 		),
 	)
 );
@@ -127,6 +132,11 @@ assert_bundle_equals( 'source revision preserved', 'abc1234', $manifest_array['s
 assert_bundle_equals( 'agent slug normalized once', 'woocommerce-agent', $manifest_array['agent']['slug'] );
 assert_bundle_equals( 'included pipelines sorted for deterministic JSON', array( 'wc-daily-ingest', 'wc-weekly-lint' ), $manifest_array['included']['pipelines'] );
 assert_bundle_equals( 'handler_auth refs accepted', 'refs', $manifest_array['included']['handler_auth'] );
+assert_bundle_equals( 'manifest can describe prompt artifacts', array( 'extract-facts' ), $manifest_array['included']['prompts'] );
+assert_bundle_equals( 'manifest can describe rubric artifacts', array( 'wiki-quality' ), $manifest_array['included']['rubrics'] );
+assert_bundle_equals( 'manifest can describe tool policy artifacts', array( 'read-only-context' ), $manifest_array['included']['tool_policies'] );
+assert_bundle_equals( 'manifest can describe auth refs without secrets', array( 'github:default', 'wpcom:default' ), $manifest_array['included']['auth_refs'] );
+assert_bundle_equals( 'manifest can describe seed queue artifacts', array( 'mgs-topic-loop' ), $manifest_array['included']['seed_queues'] );
 
 echo "\n[3] Pipeline and flow documents sort steps by position\n";
 $pipeline = AgentBundlePipelineFile::from_array(
@@ -354,6 +364,13 @@ assert_bundle( 'pipelines table has portable_slug column', str_contains( (string
 assert_bundle( 'pipelines table has agent-scoped portable_slug uniqueness', str_contains( (string) $pipelines_source, 'UNIQUE KEY agent_portable_slug (agent_id, portable_slug)' ) );
 assert_bundle( 'flows table has portable_slug column', str_contains( (string) $flows_source, 'portable_slug varchar(191) DEFAULT NULL' ) );
 assert_bundle( 'flows table has pipeline-scoped portable_slug uniqueness', str_contains( (string) $flows_source, 'UNIQUE KEY pipeline_portable_slug (pipeline_id, portable_slug)' ) );
+
+echo "\n[9] Bundle docs describe reserved artifact directories\n";
+$bundle_docs = file_get_contents( dirname( __DIR__ ) . '/docs/core-system/agent-bundles.md' ) ?: '';
+assert_bundle( 'docs include prompts directory', str_contains( $bundle_docs, 'prompts/<prompt-slug>.md' ) );
+assert_bundle( 'docs include rubrics directory', str_contains( $bundle_docs, 'rubrics/<rubric-slug>.md' ) );
+assert_bundle( 'docs include tool policies directory', str_contains( $bundle_docs, 'tool-policies/<policy-slug>.json' ) );
+assert_bundle( 'docs include seed queues directory', str_contains( $bundle_docs, 'seed-queues/<queue-slug>.json' ) );
 
 rm_tree( $tmp );
 

--- a/tests/agent-bundle-installed-artifact-smoke.php
+++ b/tests/agent-bundle-installed-artifact-smoke.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Pure-PHP smoke test for installed agent bundle artifact tracking (#1531).
+ *
+ * Run with: php tests/agent-bundle-installed-artifact-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook = '' ) {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		// no-op
+	}
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
+use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\BundleValidationException;
+
+$failures = 0;
+$total    = 0;
+
+function assert_installed_artifact( string $label, bool $condition ): void {
+	global $failures, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	echo "  FAIL: {$label}\n";
+	++$failures;
+}
+
+function assert_installed_artifact_equals( string $label, $expected, $actual ): void {
+	assert_installed_artifact( $label, $expected === $actual );
+}
+
+echo "=== Agent Bundle Installed Artifact Smoke (#1531) ===\n";
+
+$manifest = AgentBundleManifest::from_array(
+	array(
+		'schema_version'  => 1,
+		'bundle_slug'     => 'WooCommerce Brain',
+		'bundle_version'  => '2026.04.28',
+		'exported_at'     => '2026-04-28T00:00:00Z',
+		'exported_by'     => 'data-machine/test',
+		'agent'           => array(
+			'slug'         => 'wc-agent',
+			'label'        => 'WooCommerce Agent',
+			'description'  => 'Maintains WooCommerce knowledge.',
+			'agent_config' => array(),
+		),
+		'included'        => array(
+			'memory'       => array(),
+			'pipelines'    => array(),
+			'flows'        => array(),
+			'handler_auth' => 'refs',
+		),
+	)
+);
+
+echo "\n[1] Artifact hashes are deterministic\n";
+$payload_a = array(
+	'name'   => 'Daily ingest',
+	'config' => array(
+		'b'     => 2,
+		'a'     => 1,
+		'steps' => array( 'fetch', 'ai' ),
+	),
+);
+$payload_b = array(
+	'config' => array(
+		'steps' => array( 'fetch', 'ai' ),
+		'a'     => 1,
+		'b'     => 2,
+	),
+	'name'   => 'Daily ingest',
+);
+$payload_c = array(
+	'name'   => 'Daily ingest',
+	'config' => array(
+		'a'     => 1,
+		'b'     => 2,
+		'steps' => array( 'ai', 'fetch' ),
+	),
+);
+$hash_a    = AgentBundleArtifactHasher::hash( $payload_a );
+assert_installed_artifact_equals( 'associative key order does not change hash', $hash_a, AgentBundleArtifactHasher::hash( $payload_b ) );
+assert_installed_artifact( 'list order does change hash', $hash_a !== AgentBundleArtifactHasher::hash( $payload_c ) );
+assert_installed_artifact_equals( 'string payload hashes directly', hash( 'sha256', "Prompt\n" ), AgentBundleArtifactHasher::hash( "Prompt\n" ) );
+
+echo "\n[2] Installed record stores bundle/artifact identity and current status\n";
+$installed = AgentBundleInstalledArtifact::from_installed_payload(
+	$manifest,
+	'pipeline',
+	'daily-ingest',
+	'pipelines/daily-ingest.json',
+	$payload_a,
+	'2026-04-28T00:00:00Z'
+);
+$installed_array = $installed->to_array();
+assert_installed_artifact_equals( 'bundle slug normalized', 'woocommerce-brain', $installed_array['bundle_slug'] );
+assert_installed_artifact_equals( 'bundle version preserved', '2026.04.28', $installed_array['bundle_version'] );
+assert_installed_artifact_equals( 'artifact type preserved', 'pipeline', $installed_array['artifact_type'] );
+assert_installed_artifact_equals( 'artifact id preserved', 'daily-ingest', $installed_array['artifact_id'] );
+assert_installed_artifact_equals( 'source path preserved', 'pipelines/daily-ingest.json', $installed_array['source_path'] );
+assert_installed_artifact_equals( 'installed hash stored', $hash_a, $installed_array['installed_hash'] );
+assert_installed_artifact_equals( 'current hash initialized from installed payload', $hash_a, $installed_array['current_hash'] );
+assert_installed_artifact_equals( 'fresh install is clean', AgentBundleArtifactStatus::CLEAN, $installed_array['status'] );
+
+echo "\n[3] Clean, modified, missing, and orphaned states classify distinctly\n";
+$clean = $installed->with_current_payload( $payload_b, '2026-04-28T01:00:00Z' )->to_array();
+assert_installed_artifact_equals( 'same structured payload is clean', AgentBundleArtifactStatus::CLEAN, $clean['status'] );
+
+$modified = $installed->with_current_payload( array( 'name' => 'Edited ingest' ), '2026-04-28T01:00:00Z' )->to_array();
+assert_installed_artifact_equals( 'changed runtime payload is modified', AgentBundleArtifactStatus::MODIFIED, $modified['status'] );
+assert_installed_artifact( 'modified payload updates current hash', $modified['current_hash'] !== $modified['installed_hash'] );
+
+$missing = $installed->with_current_payload( null, '2026-04-28T01:00:00Z' )->to_array();
+assert_installed_artifact_equals( 'missing runtime payload is missing', AgentBundleArtifactStatus::MISSING, $missing['status'] );
+assert_installed_artifact_equals( 'missing runtime payload has null current hash', null, $missing['current_hash'] );
+
+assert_installed_artifact_equals( 'untracked runtime payload is orphaned', AgentBundleArtifactStatus::ORPHANED, AgentBundleArtifactStatus::classify( null, $hash_a ) );
+assert_installed_artifact_equals( 'empty current hash is treated as missing', AgentBundleArtifactStatus::MISSING, AgentBundleArtifactStatus::classify( $hash_a, '' ) );
+
+echo "\n[4] Stored records round-trip and validate narrowly\n";
+$round_trip = AgentBundleInstalledArtifact::from_array( $modified )->to_array();
+assert_installed_artifact_equals( 'round-trip recomputes modified status', AgentBundleArtifactStatus::MODIFIED, $round_trip['status'] );
+assert_installed_artifact_equals( 'round-trip preserves updated timestamp', '2026-04-28T01:00:00Z', $round_trip['updated_at'] );
+
+$threw = false;
+try {
+	AgentBundleInstalledArtifact::from_array( array_merge( $installed_array, array( 'artifact_type' => 'secret' ) ) );
+} catch ( BundleValidationException $e ) {
+	$threw = str_contains( $e->getMessage(), 'artifact_type must be one of' );
+}
+assert_installed_artifact( 'unsupported artifact type fails clearly', $threw );
+
+$threw = false;
+try {
+	AgentBundleInstalledArtifact::from_array( array_merge( $installed_array, array( 'source_path' => '../secret.txt' ) ) );
+} catch ( BundleValidationException $e ) {
+	$threw = str_contains( $e->getMessage(), 'source_path must be bundle-local' );
+}
+assert_installed_artifact( 'source path traversal fails clearly', $threw );
+
+echo "\n[5] Documentation names the storage fields and statuses\n";
+$docs = file_get_contents( dirname( __DIR__ ) . '/docs/core-system/agent-bundles.md' ) ?: '';
+foreach ( array( 'bundle_slug', 'bundle_version', 'artifact_type', 'artifact_id', 'installed_hash', 'current_hash', 'status' ) as $field ) {
+	assert_installed_artifact( "docs include {$field}", str_contains( $docs, $field ) );
+}
+foreach ( array( 'clean', 'modified', 'missing', 'orphaned' ) as $status ) {
+	assert_installed_artifact( "docs include {$status} status", str_contains( $docs, "`{$status}`" ) );
+}
+
+echo "\nTotal assertions: {$total}\n";
+if ( 0 !== $failures ) {
+	echo "Failures: {$failures}\n";
+	exit( 1 );
+}
+
+echo "All assertions passed.\n";


### PR DESCRIPTION
## Summary
- Extends the agent bundle manifest foundation so bundles can declare prompts, rubrics, tool policies, auth refs, and seed queues without embedding secrets.
- Adds deterministic installed-artifact hashing/status value objects for future safe bundle upgrades.

## Changes
- Added bundle schema constants and docs for reserved artifact directories and installed-artifact tracking fields.
- Added `AgentBundleArtifactHasher`, `AgentBundleArtifactStatus`, and `AgentBundleInstalledArtifact` for stable hashes and clean/modified/missing/orphaned classification.
- Updated manifest validation/smoke coverage for the expanded artifact surface.
- Fixed the legacy bundle adapter to pass explicit bundle identity/version fields into the current manifest constructor.

## Tests
- `php tests/agent-bundle-format-smoke.php`
- `php tests/agent-bundle-installed-artifact-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php -l inc/Engine/Bundle/AgentBundleArtifactHasher.php`
- `php -l inc/Engine/Bundle/AgentBundleArtifactStatus.php`
- `php -l inc/Engine/Bundle/AgentBundleInstalledArtifact.php`
- `php -l inc/Engine/Bundle/AgentBundleManifest.php`

## Follow-ups
- Add persistent DB storage for installed bundle artifact records.
- Wire importer/exporter paths for prompts, rubrics, tool policies, auth refs, and seed queues.
- Use artifact statuses during bundle upgrade planning so clean artifacts can auto-update while modified artifacts are staged for review.

Closes #1530.
Refs #1531.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the bundle foundation value objects, docs, and smoke tests; Chris remains responsible for review and merge.
