### PR TITLE
feat(bundle): add prompt artifact auth ref contracts

### DIFF
--- a/inc/Engine/AI/System/SystemTaskPromptRegistry.php
+++ b/inc/Engine/AI/System/SystemTaskPromptRegistry.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * AI system task prompt artifact registry.
+ *
+ * @package DataMachine\Engine\AI\System
+ */
+
+namespace DataMachine\Engine\AI\System;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Engine\Bundle\PromptArtifact;
+
+/**
+ * Resolves versioned prompt artifacts for AI-backed system tasks.
+ */
+final class SystemTaskPromptRegistry {
+
+	/**
+	 * Build the stable artifact ID for a system task prompt.
+	 */
+	public static function artifact_id( string $task_type, string $prompt_key ): string {
+		return 'system-task:' . sanitize_key( $task_type ) . ':' . sanitize_key( $prompt_key );
+	}
+
+	/**
+	 * Build the default artifact for an existing SystemTask prompt definition.
+	 *
+	 * @param  string $task_type  Task slug.
+	 * @param  string $prompt_key Prompt key.
+	 * @param  array  $definition Existing getPromptDefinitions() row.
+	 * @return PromptArtifact|null
+	 */
+	public static function artifact_from_definition( string $task_type, string $prompt_key, array $definition ): ?PromptArtifact {
+		if ( empty( $definition['default'] ) || ! is_string( $definition['default'] ) ) {
+			return null;
+		}
+
+		$artifact_id = (string) ( $definition['artifact_id'] ?? self::artifact_id( $task_type, $prompt_key ) );
+		$version     = (string) ( $definition['version'] ?? 'builtin' );
+		$source_path = (string) ( $definition['source_path'] ?? 'system-tasks/' . sanitize_key( $task_type ) . '/' . sanitize_key( $prompt_key ) . '.md' );
+		$metadata    = array(
+			'task_type'  => $task_type,
+			'prompt_key' => $prompt_key,
+			'label'      => (string) ( $definition['label'] ?? '' ),
+			'variables'  => $definition['variables'] ?? array(),
+		);
+
+		return new PromptArtifact( $artifact_id, PromptArtifact::TYPE_PROMPT, $version, $source_path, $definition['default'], (string) ( $definition['changelog'] ?? '' ), $metadata );
+	}
+
+	/**
+	 * Resolve an effective task prompt through the artifact seam.
+	 *
+	 * @param  string              $task_type  Task slug.
+	 * @param  string              $prompt_key Prompt key.
+	 * @param  PromptArtifact|null $artifact   Default prompt artifact.
+	 * @param  string|null         $override   Local override, if any.
+	 * @return array{content:string, artifact_id:string, content_hash:string, source:string, version:string, artifact:?PromptArtifact}
+	 */
+	public static function resolve_effective_prompt( string $task_type, string $prompt_key, ?PromptArtifact $artifact, ?string $override = null ): array {
+		$override = null === $override ? null : (string) $override;
+		$content  = null !== $override && '' !== $override ? $override : ( $artifact ? $artifact->content() : '' );
+		$source   = null !== $override && '' !== $override ? 'override' : 'artifact';
+
+		$resolved = array(
+			'content'      => $content,
+			'artifact_id'  => $artifact ? $artifact->artifact_id() : self::artifact_id( $task_type, $prompt_key ),
+			'content_hash' => hash( 'sha256', $content ),
+			'source'       => $source,
+			'version'      => $artifact ? $artifact->version() : '',
+			'artifact'     => $artifact,
+		);
+
+		/**
+		 * Filter effective AI system task prompt resolution.
+		 *
+		 * Consumers can return a different content/source envelope to wire in
+		 * site-owned prompt stores without overriding SystemTask classes.
+		 *
+		 * @param array               $resolved Effective prompt envelope.
+		 * @param string              $task_type Task slug.
+		 * @param string              $prompt_key Prompt key.
+		 * @param PromptArtifact|null $artifact Default prompt artifact.
+		 * @param string|null         $override Local override content.
+		 */
+		$resolved = apply_filters( 'datamachine_system_task_effective_prompt', $resolved, $task_type, $prompt_key, $artifact, $override );
+
+		return array(
+			'content'      => isset( $resolved['content'] ) ? (string) $resolved['content'] : $content,
+			'artifact_id'  => isset( $resolved['artifact_id'] ) ? (string) $resolved['artifact_id'] : ( $artifact ? $artifact->artifact_id() : self::artifact_id( $task_type, $prompt_key ) ),
+			'content_hash' => isset( $resolved['content_hash'] ) ? (string) $resolved['content_hash'] : hash( 'sha256', isset( $resolved['content'] ) ? (string) $resolved['content'] : $content ),
+			'source'       => isset( $resolved['source'] ) ? (string) $resolved['source'] : $source,
+			'version'      => isset( $resolved['version'] ) ? (string) $resolved['version'] : ( $artifact ? $artifact->version() : '' ),
+			'artifact'     => $resolved['artifact'] ?? $artifact,
+		);
+	}
+}

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -44,6 +44,7 @@ defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\System\SystemTaskPromptRegistry;
 
 abstract class SystemTask {
 
@@ -292,12 +293,10 @@ abstract class SystemTask {
 
 		$overrides = self::getAllPromptOverrides();
 		$task_type = $this->getTaskType();
+		$artifact  = SystemTaskPromptRegistry::artifact_from_definition( $task_type, $prompt_key, $definitions[ $prompt_key ] );
+		$override  = $overrides[ $task_type ][ $prompt_key ] ?? null;
 
-		if ( isset( $overrides[ $task_type ][ $prompt_key ] ) && '' !== $overrides[ $task_type ][ $prompt_key ] ) {
-			return $overrides[ $task_type ][ $prompt_key ];
-		}
-
-		return $definitions[ $prompt_key ]['default'];
+		return SystemTaskPromptRegistry::resolve_effective_prompt( $task_type, $prompt_key, $artifact, is_string( $override ) ? $override : null )['content'];
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentTemplateMetadata.php
+++ b/inc/Engine/Bundle/AgentTemplateMetadata.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Agent template source/version metadata value object.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Tracks which template/bundle installed a local agent and owned artifacts.
+ */
+final class AgentTemplateMetadata {
+
+	private string $template_slug;
+	private string $template_version;
+	private string $bundle_slug;
+	private string $bundle_version;
+	private string $source_ref;
+	private string $source_revision;
+	private array $installed_hashes;
+
+	public function __construct( string $template_slug, string $template_version, string $bundle_slug, string $bundle_version, string $source_ref = '', string $source_revision = '', array $installed_hashes = array() ) {
+		$this->template_slug    = PortableSlug::normalize( $template_slug, 'template' );
+		$this->template_version = self::non_empty_string( $template_version, 'template_version' );
+		$this->bundle_slug      = PortableSlug::normalize( $bundle_slug, 'bundle' );
+		$this->bundle_version   = self::non_empty_string( $bundle_version, 'bundle_version' );
+		$this->source_ref       = self::optional_string( $source_ref );
+		$this->source_revision  = self::optional_string( $source_revision );
+		$this->installed_hashes = self::normalize_hashes( $installed_hashes );
+	}
+
+	public static function from_array( array $data ): self {
+		foreach ( array( 'template_slug', 'template_version', 'bundle_slug', 'bundle_version' ) as $field ) {
+			if ( ! array_key_exists( $field, $data ) ) {
+				throw new BundleValidationException( sprintf( 'agent template metadata is missing required field %s.', esc_html( $field ) ) );
+			}
+		}
+
+		if ( isset( $data['installed_hashes'] ) && ! is_array( $data['installed_hashes'] ) ) {
+			throw new BundleValidationException( 'agent template metadata installed_hashes must be an object.' );
+		}
+
+		return new self(
+			(string) $data['template_slug'],
+			(string) $data['template_version'],
+			(string) $data['bundle_slug'],
+			(string) $data['bundle_version'],
+			(string) ( $data['source_ref'] ?? '' ),
+			(string) ( $data['source_revision'] ?? '' ),
+			$data['installed_hashes'] ?? array()
+		);
+	}
+
+	public static function from_manifest( AgentBundleManifest $manifest, string $template_slug = '', string $template_version = '', array $installed_hashes = array() ): self {
+		$manifest_data = $manifest->to_array();
+		$agent_slug    = (string) ( $manifest_data['agent']['slug'] ?? 'template' );
+
+		return new self(
+			'' !== trim( $template_slug ) ? $template_slug : $agent_slug,
+			'' !== trim( $template_version ) ? $template_version : $manifest->bundle_version(),
+			$manifest->bundle_slug(),
+			$manifest->bundle_version(),
+			$manifest->source_ref(),
+			$manifest->source_revision(),
+			$installed_hashes
+		);
+	}
+
+	public function to_array(): array {
+		return array(
+			'template_slug'    => $this->template_slug,
+			'template_version' => $this->template_version,
+			'bundle_slug'      => $this->bundle_slug,
+			'bundle_version'   => $this->bundle_version,
+			'source_ref'       => $this->source_ref,
+			'source_revision'  => $this->source_revision,
+			'installed_hashes' => $this->installed_hashes,
+		);
+	}
+
+	public function version_metadata(): array {
+		return $this->to_array();
+	}
+
+	private static function non_empty_string( string $value, string $field ): string {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			throw new BundleValidationException( sprintf( 'agent template metadata %s must be a non-empty string.', esc_html( $field ) ) );
+		}
+
+		return $value;
+	}
+
+	private static function optional_string( string $value ): string {
+		$value = trim( $value );
+		if ( strlen( $value ) > 191 ) {
+			throw new BundleValidationException( 'agent template metadata source fields must be 191 characters or fewer.' );
+		}
+
+		return $value;
+	}
+
+	private static function normalize_hashes( array $hashes ): array {
+		$normalized = array();
+		foreach ( $hashes as $artifact_id => $hash ) {
+			$artifact_id = trim( (string) $artifact_id );
+			$hash        = trim( (string) $hash );
+			if ( '' === $artifact_id || '' === $hash ) {
+				throw new BundleValidationException( 'agent template installed_hashes must map non-empty artifact IDs to hashes.' );
+			}
+			$normalized[ $artifact_id ] = $hash;
+		}
+
+		ksort( $normalized, SORT_STRING );
+		return $normalized;
+	}
+}

--- a/inc/Engine/Bundle/AuthRef.php
+++ b/inc/Engine/Bundle/AuthRef.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Portable auth reference value object.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Symbolic credential handle used by portable bundles.
+ */
+final class AuthRef {
+
+	private string $provider;
+	private string $account;
+	private array $metadata;
+
+	public function __construct( string $provider, string $account, array $metadata = array() ) {
+		$this->provider = self::validate_segment( $provider, 'provider' );
+		$this->account  = self::validate_segment( $account, 'account' );
+		$this->metadata = self::sanitize_metadata( $metadata );
+	}
+
+	public static function from_string( string $ref, array $metadata = array() ): self {
+		$parts = explode( ':', trim( $ref ), 2 );
+		if ( 2 !== count( $parts ) ) {
+			throw new BundleValidationException( 'auth_ref must use provider:account format.' );
+		}
+
+		return new self( $parts[0], $parts[1], $metadata );
+	}
+
+	public static function from_array( array $data ): self {
+		if ( isset( $data['ref'] ) ) {
+			return self::from_string( (string) $data['ref'], is_array( $data['metadata'] ?? null ) ? $data['metadata'] : array() );
+		}
+
+		foreach ( array( 'provider', 'account' ) as $field ) {
+			if ( ! array_key_exists( $field, $data ) ) {
+				throw new BundleValidationException( sprintf( 'auth_ref is missing required field %s.', esc_html( $field ) ) );
+			}
+		}
+
+		return new self( (string) $data['provider'], (string) $data['account'], is_array( $data['metadata'] ?? null ) ? $data['metadata'] : array() );
+	}
+
+	public function ref(): string {
+		return $this->provider . ':' . $this->account;
+	}
+
+	public function provider(): string {
+		return $this->provider;
+	}
+
+	public function account(): string {
+		return $this->account;
+	}
+
+	public function metadata(): array {
+		return $this->metadata;
+	}
+
+	public function to_array(): array {
+		return array(
+			'ref'      => $this->ref(),
+			'provider' => $this->provider,
+			'account'  => $this->account,
+			'metadata' => $this->metadata,
+		);
+	}
+
+	private static function validate_segment( string $value, string $field ): string {
+		$value = trim( strtolower( $value ) );
+		if ( '' === $value || ! preg_match( '/^[a-z0-9][a-z0-9._-]*$/', $value ) ) {
+			throw new BundleValidationException( sprintf( 'auth_ref %s must be lowercase letters, numbers, dots, underscores, or dashes.', esc_html( $field ) ) );
+		}
+
+		return $value;
+	}
+
+	private static function sanitize_metadata( array $metadata ): array {
+		$clean = array();
+		foreach ( $metadata as $key => $value ) {
+			$key = (string) $key;
+			if ( preg_match( '/(secret|token|password|credential|key)/i', $key ) ) {
+				continue;
+			}
+			$clean[ $key ] = is_scalar( $value ) || null === $value ? $value : (string) wp_json_encode( $value );
+		}
+
+		ksort( $clean, SORT_STRING );
+		return $clean;
+	}
+}

--- a/inc/Engine/Bundle/AuthRefResolver.php
+++ b/inc/Engine/Bundle/AuthRefResolver.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Auth ref resolver filter seam.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves symbolic auth refs without exporting raw credentials.
+ */
+final class AuthRefResolver {
+
+	/**
+	 * Build a standard unresolved envelope.
+	 */
+	public static function unresolved( AuthRef $ref, string $warning = '' ): array {
+		return array(
+			'resolved' => false,
+			'ref'      => $ref->ref(),
+			'provider' => $ref->provider(),
+			'account'  => $ref->account(),
+			'warning'  => '' !== $warning ? $warning : 'No local auth resolver handled this auth ref.',
+		);
+	}
+
+	/**
+	 * Resolve an auth ref through registered resolver objects and filters.
+	 *
+	 * @param  AuthRef|string $ref     Auth ref object or provider:account string.
+	 * @param  array          $context Import/export context.
+	 * @return array{resolved:bool, ref:string, provider:string, account:string, config?:array, warning?:string}
+	 */
+	public static function resolve( AuthRef|string $ref, array $context = array() ): array {
+		$auth_ref = is_string( $ref ) ? AuthRef::from_string( $ref ) : $ref;
+		$result   = self::unresolved( $auth_ref );
+
+		/**
+		 * Register auth ref resolver objects.
+		 *
+		 * Resolver objects must implement AuthRefResolverInterface and must not
+		 * return raw secret values.
+		 *
+		 * @param array $resolvers Resolver objects.
+		 */
+		$resolvers = apply_filters( 'datamachine_auth_ref_resolvers', array(), $context );
+		foreach ( $resolvers as $resolver ) {
+			if ( ! $resolver instanceof AuthRefResolverInterface ) {
+				continue;
+			}
+
+			$candidate = self::sanitize_resolution( $resolver->resolve( $auth_ref, $context ), $auth_ref );
+			if ( ! empty( $candidate['resolved'] ) ) {
+				$result = $candidate;
+				break;
+			}
+			if ( ! empty( $candidate['warning'] ) ) {
+				$result = $candidate;
+			}
+		}
+
+		/**
+		 * Filter final auth ref resolution.
+		 *
+		 * @param array   $result  Resolution envelope.
+		 * @param AuthRef $auth_ref Auth ref value object.
+		 * @param array   $context Import/export context.
+		 */
+		return self::sanitize_resolution( apply_filters( 'datamachine_resolve_auth_ref', $result, $auth_ref, $context ), $auth_ref );
+	}
+
+	private static function sanitize_resolution( array $result, AuthRef $ref ): array {
+		$sanitized = array(
+			'resolved' => ! empty( $result['resolved'] ),
+			'ref'      => $ref->ref(),
+			'provider' => $ref->provider(),
+			'account'  => $ref->account(),
+		);
+
+		if ( isset( $result['config'] ) && is_array( $result['config'] ) ) {
+			$sanitized['config'] = self::strip_secret_keys( $result['config'] );
+		}
+		if ( isset( $result['warning'] ) && '' !== trim( (string) $result['warning'] ) ) {
+			$sanitized['warning'] = trim( (string) $result['warning'] );
+		}
+
+		return $sanitized;
+	}
+
+	private static function strip_secret_keys( array $config ): array {
+		$clean = array();
+		foreach ( $config as $key => $value ) {
+			$key = (string) $key;
+			if ( preg_match( '/(secret|token|password|credential|key)/i', $key ) ) {
+				continue;
+			}
+			$clean[ $key ] = is_array( $value ) ? self::strip_secret_keys( $value ) : $value;
+		}
+
+		return $clean;
+	}
+}

--- a/inc/Engine/Bundle/AuthRefResolverInterface.php
+++ b/inc/Engine/Bundle/AuthRefResolverInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Auth ref resolver interface.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+interface AuthRefResolverInterface {
+
+
+	/**
+	 * Resolve an auth ref to local non-secret auth metadata/config handles.
+	 *
+	 * Implementations must not return raw secret values.
+	 *
+	 * @param  AuthRef $ref     Symbolic auth reference.
+	 * @param  array   $context Import/export context.
+	 * @return array{resolved:bool, ref:string, provider:string, account:string, config?:array, warning?:string}
+	 */
+	public function resolve( AuthRef $ref, array $context = array() ): array;
+}

--- a/inc/Engine/Bundle/BundleSchema.php
+++ b/inc/Engine/Bundle/BundleSchema.php
@@ -30,6 +30,8 @@ final class BundleSchema {
 
 	public const TOOL_POLICIES_DIR = 'tool-policies';
 
+	public const AUTH_REFS_DIR = 'auth-refs';
+
 	public const SEED_QUEUES_DIR = 'seed-queues';
 
 	public const ARTIFACT_TYPES = array(

--- a/inc/Engine/Bundle/PromptArtifact.php
+++ b/inc/Engine/Bundle/PromptArtifact.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Versioned prompt/rubric artifact value object.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable representation of a deployable prompt or rubric artifact.
+ */
+final class PromptArtifact {
+
+	public const TYPE_PROMPT = 'prompt';
+	public const TYPE_RUBRIC = 'rubric';
+
+	private string $artifact_id;
+	private string $artifact_type;
+	private string $version;
+	private string $source_path;
+	private string $content;
+	private string $content_hash;
+	private string $changelog;
+	private array $metadata;
+
+	public function __construct( string $artifact_id, string $artifact_type, string $version, string $source_path, string $content, string $changelog = '', array $metadata = array() ) {
+		$this->artifact_id   = self::validate_artifact_id( $artifact_id );
+		$this->artifact_type = self::validate_artifact_type( $artifact_type );
+		$this->version       = self::non_empty_string( $version, 'version' );
+		$this->source_path   = self::normalize_source_path( $source_path );
+		$this->content       = $content;
+		$this->content_hash  = AgentBundleArtifactHasher::hash( $content );
+		$this->changelog     = trim( $changelog );
+		$this->metadata      = self::normalize_metadata( $metadata );
+	}
+
+	/**
+	 * Build from a prompt/rubric artifact document.
+	 *
+	 * @param  array $data Artifact document data.
+	 * @return self
+	 */
+	public static function from_array( array $data ): self {
+		foreach ( array( 'artifact_id', 'artifact_type', 'version', 'source_path', 'content' ) as $field ) {
+			if ( ! array_key_exists( $field, $data ) ) {
+				throw new BundleValidationException( sprintf( 'prompt artifact is missing required field %s.', esc_html( $field ) ) );
+			}
+		}
+
+		if ( isset( $data['metadata'] ) && ! is_array( $data['metadata'] ) ) {
+			throw new BundleValidationException( 'prompt artifact metadata must be an object.' );
+		}
+
+		return new self(
+			(string) $data['artifact_id'],
+			(string) $data['artifact_type'],
+			(string) $data['version'],
+			(string) $data['source_path'],
+			(string) $data['content'],
+			(string) ( $data['changelog'] ?? '' ),
+			$data['metadata'] ?? array()
+		);
+	}
+
+	public function to_array(): array {
+		return array(
+			'artifact_id'   => $this->artifact_id,
+			'artifact_type' => $this->artifact_type,
+			'version'       => $this->version,
+			'source_path'   => $this->source_path,
+			'content_hash'  => $this->content_hash,
+			'content'       => $this->content,
+			'changelog'     => $this->changelog,
+			'metadata'      => $this->metadata,
+		);
+	}
+
+	public function artifact_id(): string {
+		return $this->artifact_id;
+	}
+
+	public function artifact_type(): string {
+		return $this->artifact_type;
+	}
+
+	public function version(): string {
+		return $this->version;
+	}
+
+	public function source_path(): string {
+		return $this->source_path;
+	}
+
+	public function content(): string {
+		return $this->content;
+	}
+
+	public function content_hash(): string {
+		return $this->content_hash;
+	}
+
+	public function version_metadata(): array {
+		return array(
+			'artifact_id'   => $this->artifact_id,
+			'artifact_type' => $this->artifact_type,
+			'version'       => $this->version,
+			'source_path'   => $this->source_path,
+			'content_hash'  => $this->content_hash,
+			'changelog'     => $this->changelog,
+			'metadata'      => $this->metadata,
+		);
+	}
+
+	private static function validate_artifact_id( string $artifact_id ): string {
+		$artifact_id = trim( $artifact_id );
+		if ( '' === $artifact_id || ! preg_match( '/^[a-z0-9][a-z0-9._:\/_-]*$/', $artifact_id ) ) {
+			throw new BundleValidationException( 'prompt artifact_id must be a stable lowercase identifier.' );
+		}
+
+		return $artifact_id;
+	}
+
+	private static function validate_artifact_type( string $artifact_type ): string {
+		$artifact_type = self::non_empty_string( $artifact_type, 'artifact_type' );
+		if ( ! in_array( $artifact_type, array( self::TYPE_PROMPT, self::TYPE_RUBRIC ), true ) ) {
+			throw new BundleValidationException( 'prompt artifact_type must be prompt or rubric.' );
+		}
+
+		return $artifact_type;
+	}
+
+	private static function non_empty_string( string $value, string $field ): string {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			throw new BundleValidationException( sprintf( 'prompt artifact %s must be a non-empty string.', esc_html( $field ) ) );
+		}
+
+		return $value;
+	}
+
+	private static function normalize_source_path( string $path ): string {
+		$path = str_replace( '\\', '/', self::non_empty_string( $path, 'source_path' ) );
+		$path = ltrim( $path, '/' );
+		if ( str_contains( $path, '..' ) ) {
+			throw new BundleValidationException( 'prompt artifact source_path must be bundle-local.' );
+		}
+
+		return $path;
+	}
+
+	private static function normalize_metadata( array $metadata ): array {
+		foreach ( $metadata as $key => $value ) {
+			if ( ! is_string( $key ) ) {
+				throw new BundleValidationException( 'prompt artifact metadata keys must be strings.' );
+			}
+		}
+
+		ksort( $metadata, SORT_STRING );
+		return $metadata;
+	}
+}

--- a/tests/prompt-auth-template-artifacts-smoke.php
+++ b/tests/prompt-auth-template-artifacts-smoke.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * Smoke tests for prompt artifacts, system-task prompt resolution, template metadata, and auth refs.
+ *
+ * Run with: php tests/prompt-auth-template-artifacts-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+require_once __DIR__ . '/smoke-wp-stubs.php';
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+$GLOBALS['__prompt_smoke_filters'] = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['__prompt_smoke_filters'][ $hook ][] = $callback;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		foreach ( $GLOBALS['__prompt_smoke_filters'][ $hook ] ?? array() as $callback ) {
+			$value = $callback( $value, ...$args );
+		}
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook, ...$args ) {
+		return null;
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $value ) {
+		return rtrim( (string) $value, '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'plugin_dir_url' ) ) {
+	function plugin_dir_url( $file ) {
+		return 'http://example.test/plugin/';
+	}
+}
+
+$GLOBALS['__prompt_smoke_options'] = array();
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $key, $default = false ) {
+		return $GLOBALS['__prompt_smoke_options'][ $key ] ?? $default;
+	}
+}
+
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $key, $value ) {
+		$GLOBALS['__prompt_smoke_options'][ $key ] = $value;
+		return true;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use DataMachine\Engine\AI\System\SystemTaskPromptRegistry;
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\AgentTemplateMetadata;
+use DataMachine\Engine\Bundle\AuthRef;
+use DataMachine\Engine\Bundle\AuthRefResolver;
+use DataMachine\Engine\Bundle\AuthRefResolverInterface;
+use DataMachine\Engine\Bundle\BundleSchema;
+use DataMachine\Engine\Bundle\BundleValidationException;
+use DataMachine\Engine\Bundle\PromptArtifact;
+
+$failures = 0;
+$passes   = 0;
+
+function prompt_artifact_assert( string $label, bool $condition ): void {
+	global $failures, $passes;
+	if ( $condition ) {
+		++$passes;
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	++$failures;
+	echo "  FAIL: {$label}\n";
+}
+
+function prompt_artifact_assert_equals( string $label, $expected, $actual ): void {
+	prompt_artifact_assert( $label, $expected === $actual );
+}
+
+final class FixturePromptTask extends SystemTask {
+
+	public function executeTask( int $jobId, array $params ): void {
+	}
+	public function getTaskType(): string {
+		return 'fixture_generation';
+	}
+	public function getPromptDefinitions(): array {
+		return array(
+			'generate' => array(
+				'label'       => 'Fixture prompt',
+				'description' => 'Prompt used by fixture task.',
+				'default'     => 'Write about {{topic}}.',
+				'variables'   => array( 'topic' => 'Topic name' ),
+				'version'     => '2026.04.28',
+				'changelog'   => 'Initial artifact contract.',
+			),
+		);
+	}
+	public function exposeResolvePrompt( string $key ): string {
+		return $this->resolvePrompt( $key );
+	}
+}
+
+final class FixtureAuthRefResolver implements AuthRefResolverInterface {
+
+	public function resolve( AuthRef $ref, array $context = array() ): array {
+		if ( 'github:automattic' !== $ref->ref() ) {
+			return AuthRefResolver::unresolved( $ref, 'Fixture resolver skipped ref.' );
+		}
+
+		return array(
+			'resolved' => true,
+			'config'   => array(
+				'account_id'   => 42,
+				'access_token' => 'should-not-export',
+				'app_secret'   => 'should-not-export',
+			),
+		);
+	}
+}
+
+echo "=== Prompt/Auth/Template Artifact Contracts Smoke ===\n";
+
+echo "\n[1] Prompt/rubric artifacts expose stable IDs, versions, and hashes\n";
+$artifact       = new PromptArtifact(
+	'system-task:daily_memory_generation:daily_memory',
+	PromptArtifact::TYPE_PROMPT,
+	'2026.04.28',
+	'system-tasks/daily-memory.md',
+	"Preserve all memory.\n",
+	'Adds conservation wording.',
+	array( 'task_type' => 'daily_memory_generation' )
+);
+$artifact_array = $artifact->to_array();
+prompt_artifact_assert_equals( 'artifact ID is preserved', 'system-task:daily_memory_generation:daily_memory', $artifact_array['artifact_id'] );
+prompt_artifact_assert_equals( 'artifact version is preserved', '2026.04.28', $artifact_array['version'] );
+prompt_artifact_assert_equals( 'content hash is SHA-256 of raw content', hash( 'sha256', "Preserve all memory.\n" ), $artifact_array['content_hash'] );
+prompt_artifact_assert_equals( 'version metadata includes content hash', $artifact_array['content_hash'], $artifact->version_metadata()['content_hash'] );
+
+$rubric = PromptArtifact::from_array(
+	array(
+		'artifact_id'   => 'rubric:wiki_quality',
+		'artifact_type' => 'rubric',
+		'version'       => '1.0.0',
+		'source_path'   => 'rubrics/wiki-quality.md',
+		'content'       => 'Score factual density.',
+	)
+);
+prompt_artifact_assert_equals( 'rubric artifact type round-trips', 'rubric', $rubric->to_array()['artifact_type'] );
+
+$threw = false;
+try {
+	PromptArtifact::from_array(
+		array(
+			'artifact_id'   => 'Bad ID',
+			'artifact_type' => 'prompt',
+			'version'       => '1.0.0',
+			'source_path'   => 'prompts/bad.md',
+			'content'       => 'bad',
+		)
+	);
+} catch ( BundleValidationException $e ) {
+	$threw = str_contains( $e->getMessage(), 'stable lowercase identifier' );
+}
+prompt_artifact_assert( 'invalid artifact IDs fail clearly', $threw );
+
+echo "\n[2] System task prompt registry preserves current behaviour and adds filter seam\n";
+$task     = new FixturePromptTask();
+$resolved = $task->exposeResolvePrompt( 'generate' );
+prompt_artifact_assert_equals( 'default prompt resolves through artifact registry', 'Write about {{topic}}.', $resolved );
+
+SystemTask::setPromptOverride( 'fixture_generation', 'generate', 'Override {{topic}}.' );
+prompt_artifact_assert_equals( 'local override still wins', 'Override {{topic}}.', $task->exposeResolvePrompt( 'generate' ) );
+SystemTask::setPromptOverride( 'fixture_generation', 'generate', '' );
+
+add_filter(
+	'datamachine_system_task_effective_prompt',
+	static function ( array $resolved, string $task_type, string $prompt_key ): array {
+		if ( 'fixture_generation' === $task_type && 'generate' === $prompt_key ) {
+			$resolved['content'] = 'Filtered artifact prompt.';
+			$resolved['source']  = 'filter';
+		}
+		return $resolved;
+	},
+	10,
+	5
+);
+prompt_artifact_assert_equals( 'filter can replace effective prompt deterministically', 'Filtered artifact prompt.', $task->exposeResolvePrompt( 'generate' ) );
+
+$definition_artifact = SystemTaskPromptRegistry::artifact_from_definition( 'fixture_generation', 'generate', $task->getPromptDefinitions()['generate'] );
+prompt_artifact_assert( 'definition produces a prompt artifact', $definition_artifact instanceof PromptArtifact );
+prompt_artifact_assert_equals( 'default artifact ID is stable', 'system-task:fixture_generation:generate', $definition_artifact->artifact_id() );
+prompt_artifact_assert_equals( 'definition version propagates to artifact', '2026.04.28', $definition_artifact->version() );
+
+echo "\n[3] Agent template source/version metadata round-trips\n";
+$manifest       = AgentBundleManifest::from_array(
+	array(
+		'schema_version'  => 1,
+		'bundle_slug'     => 'portable-knowledge-agent',
+		'bundle_version'  => '2.3.4',
+		'source_ref'      => 'refs/tags/v2.3.4',
+		'source_revision' => 'abc123',
+		'exported_at'     => '2026-04-28T00:00:00Z',
+		'exported_by'     => 'data-machine/test',
+		'agent'           => array(
+			'slug'         => 'knowledge-agent',
+			'label'        => 'Knowledge Agent',
+			'description'  => 'Maintains a domain wiki.',
+			'agent_config' => array(),
+		),
+		'included'        => array(
+			'memory'       => array(),
+			'pipelines'    => array(),
+			'flows'        => array(),
+			'handler_auth' => 'refs',
+		),
+	)
+);
+$template       = AgentTemplateMetadata::from_manifest(
+	$manifest,
+	'domain-wiki-template',
+	'5.6.7',
+	array(
+		'instructions' => hash( 'sha256', 'instructions' ),
+		'tool_policy'  => hash( 'sha256', 'tool policy' ),
+	)
+);
+$template_array = $template->to_array();
+prompt_artifact_assert_equals( 'template slug preserved', 'domain-wiki-template', $template_array['template_slug'] );
+prompt_artifact_assert_equals( 'template version preserved', '5.6.7', $template_array['template_version'] );
+prompt_artifact_assert_equals( 'bundle source revision preserved', 'abc123', $template_array['source_revision'] );
+prompt_artifact_assert_equals( 'installed hashes sorted by artifact ID', array( 'instructions', 'tool_policy' ), array_keys( $template_array['installed_hashes'] ) );
+prompt_artifact_assert_equals( 'template metadata round-trips', $template_array, AgentTemplateMetadata::from_array( $template_array )->to_array() );
+
+echo "\n[4] Auth refs validate, resolve, and strip secrets\n";
+$auth_ref = AuthRef::from_string(
+	'github:automattic',
+	array(
+		'label'        => 'Automattic GitHub',
+		'access_token' => 'nope',
+	)
+);
+prompt_artifact_assert_equals( 'auth ref string preserves provider/account', 'github:automattic', $auth_ref->ref() );
+prompt_artifact_assert_equals( 'bundle schema reserves auth refs directory', 'auth-refs', BundleSchema::AUTH_REFS_DIR );
+prompt_artifact_assert( 'auth ref metadata strips token-like keys', ! array_key_exists( 'access_token', $auth_ref->metadata() ) );
+
+$threw = false;
+try {
+	AuthRef::from_string( 'bad ref' );
+} catch ( BundleValidationException $e ) {
+	$threw = str_contains( $e->getMessage(), 'provider:account' );
+}
+prompt_artifact_assert( 'malformed auth refs fail clearly', $threw );
+
+add_filter(
+	'datamachine_auth_ref_resolvers',
+	static function ( array $resolvers ): array {
+		$resolvers[] = new FixtureAuthRefResolver();
+		return $resolvers;
+	},
+	10,
+	2
+);
+$resolution = AuthRefResolver::resolve( $auth_ref );
+prompt_artifact_assert( 'registered resolver can resolve auth ref', true === $resolution['resolved'] );
+prompt_artifact_assert_equals( 'resolver preserves ref identity', 'github:automattic', $resolution['ref'] );
+prompt_artifact_assert_equals( 'non-secret config survives resolution', 42, $resolution['config']['account_id'] ?? null );
+prompt_artifact_assert( 'secret config keys are stripped from resolution', ! array_key_exists( 'access_token', $resolution['config'] ?? array() ) && ! array_key_exists( 'app_secret', $resolution['config'] ?? array() ) );
+
+$unresolved = AuthRefResolver::resolve( 'slack:a8c' );
+prompt_artifact_assert( 'unresolved refs return warning envelope, not failure', false === $unresolved['resolved'] && ! empty( $unresolved['warning'] ) );
+
+echo "\n=== Results ===\n";
+echo "Passed: {$passes}\n";
+echo "Failed: {$failures}\n";
+
+if ( $failures > 0 ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Adds value-object contracts for versioned prompt/rubric artifacts, agent template source/version metadata, and portable auth refs.
- Routes system task prompt resolution through a prompt artifact registry while preserving existing local override behavior.
- Adds an auth-ref resolver/filter seam that returns non-secret resolution envelopes and strips token/secret-like keys.

## Changes
- Added `PromptArtifact` with stable IDs, SHA-256 content hashes, version metadata, changelog text, and bundle-local source paths.
- Added `SystemTaskPromptRegistry` and wired `SystemTask::resolvePrompt()` through it via `datamachine_system_task_effective_prompt`.
- Added `AgentTemplateMetadata` for template/bundle source and installed artifact hash round-trips.
- Added `AuthRef`, `AuthRefResolverInterface`, and `AuthRefResolver` with `datamachine_auth_ref_resolvers` and `datamachine_resolve_auth_ref` seams.
- Reserved `BundleSchema::AUTH_REFS_DIR` for future bundle file layout.

## Tests
- `php tests/prompt-auth-template-artifacts-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/system-task-config-passthrough-smoke.php`
- `git diff --check`

## Follow-ups
- Implement bundle install/upgrade persistence for prompt/rubric artifacts, including clean auto-update vs PendingAction staging for modified local prompts.
- Add CLI/UI prompt diffs and upgrade planner output once the installed/current artifact store writes these new metadata shapes.
- Wire concrete auth providers into `AuthRefResolverInterface` for export rewrite/import resolve.
- Persist `AgentTemplateMetadata` on installed agents and expose template upgrade availability.

## Closes/Refs
- Refs #1535
- Refs #1536
- Refs #1537
- Refs #1538

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing the artifact contract value objects, system-task prompt seam, auth-ref resolver skeleton, and smoke tests. Chris remains responsible for review and merge.