### PR TITLE
feat(bundle): add upgrade planner pending actions

### DIFF
--- a/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * PendingAction handler registration for bundle upgrades.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+add_filter(
+	'datamachine_pending_action_handlers',
+	static function ( $handlers ) {
+		if ( ! is_array( $handlers ) ) {
+			$handlers = array();
+		}
+
+		$handlers[ AgentBundleUpgradePendingAction::KIND ] = array(
+			'apply'       => static function ( array $apply_input ) {
+				return AgentBundleUpgradePendingAction::apply( $apply_input );
+			},
+			'can_resolve' => static function () {
+				return current_user_can( 'manage_options' );
+			},
+		);
+
+		return $handlers;
+	}
+);

--- a/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
@@ -80,7 +80,10 @@ final class AgentBundleUpgradePendingAction {
 			}
 			$key = sanitize_key( (string) ( $artifact['artifact_type'] ?? '' ) ) . ':' . (string) ( $artifact['artifact_id'] ?? '' );
 			if ( ! isset( $approved[ $key ] ) ) {
-				$skipped[] = array( 'artifact_key' => $key, 'reason' => 'not_approved' );
+				$skipped[] = array(
+					'artifact_key' => $key,
+					'reason'       => 'not_approved',
+				);
 				continue;
 			}
 
@@ -93,15 +96,24 @@ final class AgentBundleUpgradePendingAction {
 			 */
 			$result = apply_filters( 'datamachine_bundle_upgrade_apply_artifact', null, $artifact, $apply_input );
 			if ( is_wp_error( $result ) ) {
-				$failed[] = array( 'artifact_key' => $key, 'error' => $result->get_error_message() );
+				$failed[] = array(
+					'artifact_key' => $key,
+					'error'        => $result->get_error_message(),
+				);
 				continue;
 			}
 			if ( null === $result ) {
-				$failed[] = array( 'artifact_key' => $key, 'error' => 'No bundle artifact apply handler registered.' );
+				$failed[] = array(
+					'artifact_key' => $key,
+					'error'        => 'No bundle artifact apply handler registered.',
+				);
 				continue;
 			}
 
-			$applied[] = array( 'artifact_key' => $key, 'result' => $result );
+			$applied[] = array(
+				'artifact_key' => $key,
+				'result'       => $result,
+			);
 		}
 
 		return array(

--- a/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * PendingAction integration for agent bundle upgrades.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+use DataMachine\Engine\AI\Actions\PendingActionHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stages and applies approval-gated bundle artifact upgrades.
+ */
+final class AgentBundleUpgradePendingAction {
+
+	public const KIND = 'bundle_upgrade';
+
+	/**
+	 * Stage a bundle upgrade plan for human review.
+	 *
+	 * @param AgentBundleUpgradePlan $plan Upgrade plan.
+	 * @param array<string,mixed>    $args Staging args.
+	 * @return array PendingAction envelope.
+	 */
+	public static function stage( AgentBundleUpgradePlan $plan, array $args = array() ): array {
+		$plan_array       = $plan->to_array();
+		$target_artifacts = isset( $args['target_artifacts'] ) && is_array( $args['target_artifacts'] ) ? $args['target_artifacts'] : array();
+		$approved         = isset( $args['approved_artifacts'] ) && is_array( $args['approved_artifacts'] ) ? array_values( array_map( 'strval', $args['approved_artifacts'] ) ) : array();
+
+		return PendingActionHelper::stage(
+			array(
+				'kind'         => self::KIND,
+				'summary'      => (string) ( $args['summary'] ?? 'Review bundle upgrade artifacts.' ),
+				'apply_input'  => array(
+					'bundle'             => isset( $args['bundle'] ) && is_array( $args['bundle'] ) ? $args['bundle'] : array(),
+					'approved_artifacts' => $approved,
+					'target_artifacts'   => $target_artifacts,
+					'plan'               => $plan_array,
+				),
+				'preview_data' => array(
+					'bundle'         => isset( $args['bundle'] ) && is_array( $args['bundle'] ) ? $args['bundle'] : array(),
+					'counts'         => $plan_array['counts'],
+					'auto_apply'     => $plan_array['auto_apply'],
+					'needs_approval' => $plan_array['needs_approval'],
+					'warnings'       => $plan_array['warnings'],
+					'no_op'          => $plan_array['no_op'],
+				),
+				'agent_id'     => isset( $args['agent_id'] ) ? (int) $args['agent_id'] : 0,
+				'user_id'      => isset( $args['user_id'] ) ? (int) $args['user_id'] : 0,
+				'context'      => isset( $args['context'] ) && is_array( $args['context'] ) ? $args['context'] : array(),
+			)
+		);
+	}
+
+	/**
+	 * Apply only explicitly-approved artifact changes.
+	 *
+	 * Consumers provide the actual storage writer through the
+	 * `datamachine_bundle_upgrade_apply_artifact` filter.
+	 *
+	 * @param array<string,mixed> $apply_input Stored PendingAction apply input.
+	 * @return array<string,mixed>
+	 */
+	public static function apply( array $apply_input ): array {
+		$approved = isset( $apply_input['approved_artifacts'] ) && is_array( $apply_input['approved_artifacts'] )
+			? array_values( array_map( 'strval', $apply_input['approved_artifacts'] ) )
+			: array();
+		$approved = array_fill_keys( $approved, true );
+		$targets  = isset( $apply_input['target_artifacts'] ) && is_array( $apply_input['target_artifacts'] ) ? $apply_input['target_artifacts'] : array();
+		$applied  = array();
+		$skipped  = array();
+		$failed   = array();
+
+		foreach ( $targets as $artifact ) {
+			if ( ! is_array( $artifact ) ) {
+				continue;
+			}
+			$key = sanitize_key( (string) ( $artifact['artifact_type'] ?? '' ) ) . ':' . (string) ( $artifact['artifact_id'] ?? '' );
+			if ( ! isset( $approved[ $key ] ) ) {
+				$skipped[] = array( 'artifact_key' => $key, 'reason' => 'not_approved' );
+				continue;
+			}
+
+			/**
+			 * Apply one approved bundle upgrade artifact.
+			 *
+			 * @param mixed $result Null until a consumer applies the artifact.
+			 * @param array $artifact Target artifact payload.
+			 * @param array $apply_input Full PendingAction input.
+			 */
+			$result = apply_filters( 'datamachine_bundle_upgrade_apply_artifact', null, $artifact, $apply_input );
+			if ( is_wp_error( $result ) ) {
+				$failed[] = array( 'artifact_key' => $key, 'error' => $result->get_error_message() );
+				continue;
+			}
+			if ( null === $result ) {
+				$failed[] = array( 'artifact_key' => $key, 'error' => 'No bundle artifact apply handler registered.' );
+				continue;
+			}
+
+			$applied[] = array( 'artifact_key' => $key, 'result' => $result );
+		}
+
+		return array(
+			'success' => empty( $failed ),
+			'applied' => $applied,
+			'skipped' => $skipped,
+			'failed'  => $failed,
+		);
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleUpgradePlan.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlan.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Read-only agent bundle upgrade plan value object.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable machine-readable upgrade plan grouped by resolution bucket.
+ */
+final class AgentBundleUpgradePlan {
+
+	/** @var array<string,array<int,array<string,mixed>>> */
+	private array $buckets;
+	private array $metadata;
+
+	/**
+	 * @param array<string,array<int,array<string,mixed>>> $buckets Plan buckets.
+	 * @param array<string,mixed>                          $metadata Plan metadata.
+	 */
+	public function __construct( array $buckets, array $metadata = array() ) {
+		$this->buckets  = array(
+			'auto_apply'     => self::sort_entries( $buckets['auto_apply'] ?? array() ),
+			'needs_approval' => self::sort_entries( $buckets['needs_approval'] ?? array() ),
+			'warnings'       => self::sort_entries( $buckets['warnings'] ?? array() ),
+			'no_op'          => self::sort_entries( $buckets['no_op'] ?? array() ),
+		);
+		$this->metadata = $metadata;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function bucket( string $bucket ): array {
+		return $this->buckets[ $bucket ] ?? array();
+	}
+
+	public function has_pending_approval(): bool {
+		return ! empty( $this->buckets['needs_approval'] );
+	}
+
+	public function to_array(): array {
+		return array_merge( $this->metadata, $this->buckets, array( 'counts' => $this->counts() ) );
+	}
+
+	/** @return array<string,int> */
+	private function counts(): array {
+		return array(
+			'auto_apply'     => count( $this->buckets['auto_apply'] ),
+			'needs_approval' => count( $this->buckets['needs_approval'] ),
+			'warnings'       => count( $this->buckets['warnings'] ),
+			'no_op'          => count( $this->buckets['no_op'] ),
+		);
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $entries Entries to sort.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function sort_entries( array $entries ): array {
+		usort(
+			$entries,
+			static function ( array $a, array $b ): int {
+				return strcmp( (string) ( $a['artifact_key'] ?? '' ), (string) ( $b['artifact_key'] ?? '' ) );
+			}
+		);
+
+		return array_values( $entries );
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
@@ -54,8 +54,8 @@ final class AgentBundleUpgradePlanner {
 			}
 
 			if ( null === $installed_hash ) {
-				$bucket = null === $current_hash ? 'auto_apply' : 'needs_approval';
-				$reason = null === $current_hash ? 'new_artifact' : 'untracked_local_artifact';
+				$bucket               = null === $current_hash ? 'auto_apply' : 'needs_approval';
+				$reason               = null === $current_hash ? 'new_artifact' : 'untracked_local_artifact';
 				$buckets[ $bucket ][] = self::entry( $key, $target_artifact, null, $current_hash, $target_hash, $reason, $current_artifact );
 				continue;
 			}

--- a/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Read-only agent bundle upgrade planner.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Compares installed, current, and target artifact state without mutating storage.
+ */
+final class AgentBundleUpgradePlanner {
+
+	/**
+	 * Plan an upgrade from plain artifact arrays.
+	 *
+	 * Artifact arrays accept: artifact_type, artifact_id, source_path, payload, hash.
+	 * Installed artifacts may also be AgentBundleInstalledArtifact instances.
+	 *
+	 * @param array<int,array<string,mixed>|AgentBundleInstalledArtifact> $installed_artifacts Install-time tracking rows.
+	 * @param array<int,array<string,mixed>>                              $current_artifacts Current local artifact state.
+	 * @param array<int,array<string,mixed>>                              $target_artifacts Target bundle artifact state.
+	 * @param array<string,mixed>                                         $metadata Optional plan metadata.
+	 */
+	public static function plan( array $installed_artifacts, array $current_artifacts, array $target_artifacts, array $metadata = array() ): AgentBundleUpgradePlan {
+		$installed = self::index_installed_artifacts( $installed_artifacts );
+		$current   = self::index_artifacts( $current_artifacts );
+		$target    = self::index_artifacts( $target_artifacts );
+		$buckets   = array(
+			'auto_apply'     => array(),
+			'needs_approval' => array(),
+			'warnings'       => array(),
+			'no_op'          => array(),
+		);
+
+		foreach ( $target as $key => $target_artifact ) {
+			$current_artifact   = $current[ $key ] ?? null;
+			$installed_artifact = $installed[ $key ] ?? null;
+			$current_hash       = self::artifact_hash( $current_artifact );
+			$target_hash        = self::artifact_hash( $target_artifact );
+			$installed_hash     = isset( $installed_artifact['installed_hash'] ) ? (string) $installed_artifact['installed_hash'] : null;
+
+			if ( null !== $current_hash && hash_equals( $target_hash, $current_hash ) ) {
+				$buckets['no_op'][] = self::entry( $key, $target_artifact, $installed_hash, $current_hash, $target_hash, 'already_matches_target', $current_artifact );
+				continue;
+			}
+
+			if ( null === $current_hash && null !== $installed_hash ) {
+				$buckets['warnings'][] = self::entry( $key, $target_artifact, $installed_hash, null, $target_hash, 'missing_local_artifact', $current_artifact );
+				continue;
+			}
+
+			if ( null === $installed_hash ) {
+				$bucket = null === $current_hash ? 'auto_apply' : 'needs_approval';
+				$reason = null === $current_hash ? 'new_artifact' : 'untracked_local_artifact';
+				$buckets[ $bucket ][] = self::entry( $key, $target_artifact, null, $current_hash, $target_hash, $reason, $current_artifact );
+				continue;
+			}
+
+			if ( null !== $current_hash && hash_equals( $installed_hash, $current_hash ) ) {
+				$buckets['auto_apply'][] = self::entry( $key, $target_artifact, $installed_hash, $current_hash, $target_hash, 'local_unchanged_from_installed', $current_artifact );
+				continue;
+			}
+
+			$buckets['needs_approval'][] = self::entry( $key, $target_artifact, $installed_hash, $current_hash, $target_hash, 'local_modified', $current_artifact );
+		}
+
+		foreach ( $installed as $key => $installed_artifact ) {
+			if ( isset( $target[ $key ] ) ) {
+				continue;
+			}
+			$buckets['warnings'][] = array(
+				'artifact_key'  => $key,
+				'artifact_type' => $installed_artifact['artifact_type'],
+				'artifact_id'   => $installed_artifact['artifact_id'],
+				'source_path'   => $installed_artifact['source_path'],
+				'reason'        => 'orphaned_installed_artifact',
+				'summary'       => sprintf( '%s %s is not present in the target bundle.', $installed_artifact['artifact_type'], $installed_artifact['artifact_id'] ),
+			);
+		}
+
+		return new AgentBundleUpgradePlan( $buckets, $metadata );
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public static function artifacts_from_bundle( AgentBundleDirectory $bundle ): array {
+		$artifacts   = array();
+		$manifest    = $bundle->manifest();
+		$artifacts[] = array(
+			'artifact_type' => 'agent',
+			'artifact_id'   => $manifest->agent_slug(),
+			'source_path'   => BundleSchema::MANIFEST_FILE,
+			'payload'       => $manifest->to_array()['agent'],
+		);
+
+		foreach ( $bundle->memory_files() as $relative_path => $contents ) {
+			$artifacts[] = array(
+				'artifact_type' => 'memory',
+				'artifact_id'   => $relative_path,
+				'source_path'   => BundleSchema::MEMORY_DIR . '/' . $relative_path,
+				'payload'       => $contents,
+			);
+		}
+
+		foreach ( $bundle->pipelines() as $pipeline ) {
+			$artifacts[] = array(
+				'artifact_type' => 'pipeline',
+				'artifact_id'   => $pipeline->slug(),
+				'source_path'   => BundleSchema::PIPELINES_DIR . '/' . $pipeline->slug() . '.json',
+				'payload'       => $pipeline->to_array(),
+			);
+		}
+
+		foreach ( $bundle->flows() as $flow ) {
+			$artifacts[] = array(
+				'artifact_type' => 'flow',
+				'artifact_id'   => $flow->slug(),
+				'source_path'   => BundleSchema::FLOWS_DIR . '/' . $flow->slug() . '.json',
+				'payload'       => $flow->to_array(),
+			);
+		}
+
+		return $artifacts;
+	}
+
+	/** @param array<int,array<string,mixed>|AgentBundleInstalledArtifact> $artifacts */
+	private static function index_installed_artifacts( array $artifacts ): array {
+		$indexed = array();
+		foreach ( $artifacts as $artifact ) {
+			$row = $artifact instanceof AgentBundleInstalledArtifact ? $artifact->to_array() : $artifact;
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$key             = self::artifact_key( (string) ( $row['artifact_type'] ?? '' ), (string) ( $row['artifact_id'] ?? '' ) );
+			$indexed[ $key ] = $row;
+		}
+
+		ksort( $indexed, SORT_STRING );
+		return $indexed;
+	}
+
+	/** @param array<int,array<string,mixed>> $artifacts */
+	private static function index_artifacts( array $artifacts ): array {
+		$indexed = array();
+		foreach ( $artifacts as $artifact ) {
+			if ( ! is_array( $artifact ) ) {
+				continue;
+			}
+			$key             = self::artifact_key( (string) ( $artifact['artifact_type'] ?? '' ), (string) ( $artifact['artifact_id'] ?? '' ) );
+			$indexed[ $key ] = $artifact;
+		}
+
+		ksort( $indexed, SORT_STRING );
+		return $indexed;
+	}
+
+	private static function entry( string $key, array $target, ?string $installed_hash, ?string $current_hash, string $target_hash, string $reason, ?array $current ): array {
+		return array(
+			'artifact_key'   => $key,
+			'artifact_type'  => (string) $target['artifact_type'],
+			'artifact_id'    => (string) $target['artifact_id'],
+			'source_path'    => (string) ( $target['source_path'] ?? '' ),
+			'reason'         => $reason,
+			'installed_hash' => $installed_hash,
+			'current_hash'   => $current_hash,
+			'target_hash'    => $target_hash,
+			'summary'        => self::summary( $target, $reason ),
+			'diff'           => array(
+				'before' => self::redact( $current['payload'] ?? null ),
+				'after'  => self::redact( $target['payload'] ?? null ),
+			),
+		);
+	}
+
+	private static function artifact_key( string $type, string $id ): string {
+		return sanitize_key( $type ) . ':' . $id;
+	}
+
+	private static function artifact_hash( ?array $artifact ): ?string {
+		if ( null === $artifact ) {
+			return null;
+		}
+		if ( isset( $artifact['hash'] ) && '' !== trim( (string) $artifact['hash'] ) ) {
+			return (string) $artifact['hash'];
+		}
+		if ( ! array_key_exists( 'payload', $artifact ) || null === $artifact['payload'] ) {
+			return null;
+		}
+		return AgentBundleArtifactHasher::hash( $artifact['payload'] );
+	}
+
+	private static function summary( array $artifact, string $reason ): string {
+		return sprintf( '%s %s: %s', (string) $artifact['artifact_type'], (string) $artifact['artifact_id'], str_replace( '_', ' ', $reason ) );
+	}
+
+	private static function redact( mixed $value ): mixed {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$redacted = array();
+		foreach ( $value as $key => $child ) {
+			$key_string = (string) $key;
+			if ( preg_match( '/(secret|token|password|api[_-]?key|authorization|credential)/i', $key_string ) ) {
+				$redacted[ $key ] = '[redacted]';
+				continue;
+			}
+			$redacted[ $key ] = self::redact( $child );
+		}
+
+		return $redacted;
+	}
+}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -49,6 +49,7 @@ require_once __DIR__ . '/Api/StepTypes.php';
 require_once __DIR__ . '/Api/Handlers.php';
 require_once __DIR__ . '/Api/Tools.php';
 require_once __DIR__ . '/Api/Chat/ChatFilters.php';
+require_once __DIR__ . '/Engine/Bundle/AgentBundleUpgradeActionHandlers.php';
 require_once __DIR__ . '/Engine/AI/Directives/CoreMemoryFilesDirective.php';
 require_once __DIR__ . '/Engine/AI/Directives/AgentModeDirective.php';
 require_once __DIR__ . '/Engine/AI/Directives/CallerContextDirective.php';

--- a/tests/agent-bundle-upgrade-planner-smoke.php
+++ b/tests/agent-bundle-upgrade-planner-smoke.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Pure-PHP smoke test for bundle upgrade planning + PendingAction apply (#1532/#1533).
+ *
+ * Run with: php tests/agent-bundle-upgrade-planner-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+	define( 'HOUR_IN_SECONDS', 3600 );
+}
+
+$GLOBALS['__bundle_upgrade_filters']    = array();
+$GLOBALS['__bundle_upgrade_transients'] = array();
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $key ) );
+	}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ) {
+		return trim( wp_strip_all_tags( (string) $value ) );
+	}
+}
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text ) {
+		return strip_tags( (string) $text );
+	}
+}
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id() {
+		return 1;
+	}
+}
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( $capability ) {
+		return 'manage_options' === $capability;
+	}
+}
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook = '' ) {
+		return 0;
+	}
+}
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ) {
+		return false;
+	}
+}
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4() {
+		return '11111111-2222-4333-8444-555555555555';
+	}
+}
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( $key, $value, $expiration = 0 ) {
+		$GLOBALS['__bundle_upgrade_transients'][ $key ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( $key ) {
+		return $GLOBALS['__bundle_upgrade_transients'][ $key ] ?? false;
+	}
+}
+if ( ! function_exists( 'delete_transient' ) ) {
+	function delete_transient( $key ) {
+		unset( $GLOBALS['__bundle_upgrade_transients'][ $key ] );
+		return true;
+	}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['__bundle_upgrade_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+		ksort( $GLOBALS['__bundle_upgrade_filters'][ $hook ], SORT_NUMERIC );
+		return true;
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		return add_filter( $hook, $callback, $priority, $accepted_args );
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['__bundle_upgrade_filters'][ $hook ] ) ) {
+			return $value;
+		}
+		foreach ( $GLOBALS['__bundle_upgrade_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as $registration ) {
+				$value = call_user_func_array( $registration[0], array_slice( array_merge( array( $value ), $args ), 0, $registration[1] ) );
+			}
+		}
+		return $value;
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook, ...$args ) {
+		apply_filters( $hook, null, ...$args );
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error;
+	}
+}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $message;
+		public function __construct( string $code = '', string $message = '' ) {
+			$this->message = $message;
+		}
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleUpgradeActionHandlers.php';
+
+use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
+use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
+use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
+
+$failures = 0;
+$total    = 0;
+
+function assert_upgrade_plan( string $label, bool $condition ): void {
+	global $failures, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	echo "  FAIL: {$label}\n";
+	++$failures;
+}
+
+function assert_upgrade_plan_equals( string $label, $expected, $actual ): void {
+	assert_upgrade_plan( $label, $expected === $actual );
+}
+
+function upgrade_artifact( string $type, string $id, $payload, string $source_path = '' ): array {
+	return array(
+		'artifact_type' => $type,
+		'artifact_id'   => $id,
+		'source_path'   => $source_path ?: $type . 's/' . $id . '.json',
+		'payload'       => $payload,
+	);
+}
+
+function installed_row( array $artifact ): array {
+	return array(
+		'bundle_slug'    => 'woocommerce-brain',
+		'bundle_version' => '1.0.0',
+		'artifact_type'  => $artifact['artifact_type'],
+		'artifact_id'    => $artifact['artifact_id'],
+		'source_path'    => $artifact['source_path'],
+		'installed_hash' => AgentBundleArtifactHasher::hash( $artifact['payload'] ),
+		'current_hash'   => AgentBundleArtifactHasher::hash( $artifact['payload'] ),
+		'installed_at'   => '2026-04-28T00:00:00Z',
+		'updated_at'     => '2026-04-28T00:00:00Z',
+	);
+}
+
+echo "=== Agent Bundle Upgrade Planner Smoke (#1532/#1533) ===\n";
+
+$old_flow       = upgrade_artifact( 'flow', 'daily-loop', array( 'prompt' => 'old flow' ), 'flows/daily-loop.json' );
+$target_flow    = upgrade_artifact( 'flow', 'daily-loop', array( 'prompt' => 'new flow' ), 'flows/daily-loop.json' );
+$old_pipeline   = upgrade_artifact( 'pipeline', 'collector', array( 'steps' => array( 'fetch', 'ai' ) ), 'pipelines/collector.json' );
+$local_pipeline = upgrade_artifact( 'pipeline', 'collector', array( 'steps' => array( 'fetch', 'ai' ), 'note' => 'local edit' ), 'pipelines/collector.json' );
+$target_pipeline = upgrade_artifact(
+	'pipeline',
+	'collector',
+	array(
+		'steps'     => array( 'fetch', 'ai', 'publish' ),
+		'api_token' => 'secret-token-value',
+	),
+	'pipelines/collector.json'
+);
+$old_memory     = upgrade_artifact( 'memory', 'SOUL.md', "old\n", 'memory/SOUL.md' );
+$target_memory  = upgrade_artifact( 'memory', 'SOUL.md', "new\n", 'memory/SOUL.md' );
+$target_prompt  = upgrade_artifact( 'prompt', 'extract-facts', array( 'prompt' => 'same' ), 'prompts/extract-facts.json' );
+$orphaned       = upgrade_artifact( 'rubric', 'legacy', array( 'score' => 1 ), 'rubrics/legacy.json' );
+
+$target_artifacts = array( $target_flow, $target_pipeline, $target_memory, $target_prompt );
+$plan             = AgentBundleUpgradePlanner::plan(
+	array( installed_row( $old_flow ), installed_row( $old_pipeline ), installed_row( $old_memory ), installed_row( $orphaned ) ),
+	array( $old_flow, $local_pipeline, $target_prompt ),
+	$target_artifacts,
+	array( 'bundle_slug' => 'woocommerce-brain', 'target_version' => '1.1.0' )
+);
+$plan_array       = $plan->to_array();
+
+echo "\n[1] Planner buckets artifact changes deterministically\n";
+assert_upgrade_plan_equals( 'clean local artifact auto-applies', 'flow:daily-loop', $plan_array['auto_apply'][0]['artifact_key'] ?? null );
+assert_upgrade_plan_equals( 'modified local artifact needs approval', 'pipeline:collector', $plan_array['needs_approval'][0]['artifact_key'] ?? null );
+assert_upgrade_plan_equals( 'missing installed artifact warns', 'memory:SOUL.md', $plan_array['warnings'][0]['artifact_key'] ?? null );
+assert_upgrade_plan_equals( 'orphaned installed artifact warns', 'rubric:legacy', $plan_array['warnings'][1]['artifact_key'] ?? null );
+assert_upgrade_plan_equals( 'already-target artifact is no-op', 'prompt:extract-facts', $plan_array['no_op'][0]['artifact_key'] ?? null );
+assert_upgrade_plan_equals( 'counts expose machine-readable summary', array( 'auto_apply' => 1, 'needs_approval' => 1, 'warnings' => 2, 'no_op' => 1 ), $plan_array['counts'] );
+
+echo "\n[2] Preview diff is artifact-level and secret-safe\n";
+$approval = $plan_array['needs_approval'][0] ?? array();
+assert_upgrade_plan( 'approval entry includes before payload', isset( $approval['diff']['before']['note'] ) );
+assert_upgrade_plan_equals( 'secret-like target keys are redacted', '[redacted]', $approval['diff']['after']['api_token'] ?? null );
+assert_upgrade_plan( 'raw secret value is absent from preview', false === strpos( json_encode( $plan_array ), 'secret-token-value' ) );
+
+echo "\n[3] PendingAction stages bundle-upgrade previews\n";
+$staged = AgentBundleUpgradePendingAction::stage(
+	$plan,
+	array(
+		'summary'            => 'Upgrade WooCommerce brain bundle.',
+		'bundle'             => array( 'bundle_slug' => 'woocommerce-brain', 'target_version' => '1.1.0' ),
+		'target_artifacts'   => $target_artifacts,
+		'approved_artifacts' => array( 'pipeline:collector' ),
+	)
+);
+assert_upgrade_plan( 'pending action staged', true === ( $staged['staged'] ?? false ) );
+assert_upgrade_plan_equals( 'pending action kind is bundle_upgrade', 'bundle_upgrade', $staged['kind'] ?? null );
+assert_upgrade_plan_equals( 'preview carries approval count', 1, $staged['preview']['counts']['needs_approval'] ?? null );
+
+echo "\n[4] Resolve applies approved artifacts only\n";
+$applied_keys = array();
+add_filter(
+	'datamachine_bundle_upgrade_apply_artifact',
+	static function ( $result, array $artifact ) use ( &$applied_keys ) {
+		$key            = sanitize_key( (string) $artifact['artifact_type'] ) . ':' . (string) $artifact['artifact_id'];
+		$applied_keys[] = $key;
+		return array( 'applied' => $key );
+	},
+	10,
+	2
+);
+
+$resolved = ResolvePendingActionAbility::execute(
+	array(
+		'action_id' => $staged['action_id'],
+		'decision'  => 'accepted',
+	)
+);
+assert_upgrade_plan( 'resolve accepted succeeds', true === ( $resolved['success'] ?? false ) );
+assert_upgrade_plan_equals( 'only approved artifact writer ran', array( 'pipeline:collector' ), $applied_keys );
+assert_upgrade_plan_equals( 'apply result records one applied artifact', 1, count( $resolved['result']['applied'] ?? array() ) );
+assert_upgrade_plan_equals( 'unapproved target artifacts are skipped', 3, count( $resolved['result']['skipped'] ?? array() ) );
+
+echo "\nTotal assertions: {$total}\n";
+if ( 0 !== $failures ) {
+	echo "Failures: {$failures}\n";
+	exit( 1 );
+}
+
+echo "All assertions passed.\n";


### PR DESCRIPTION
## Summary
- Adds a read-only bundle upgrade planner that buckets artifact changes into `auto_apply`, `needs_approval`, `warnings`, and `no_op`.
- Adds a `bundle_upgrade` PendingAction handler that stages artifact-level previews and applies only explicitly approved artifacts.

## Changes
- Introduces `AgentBundleUpgradePlanner` and `AgentBundleUpgradePlan` for deterministic artifact-level plan output from installed/current/target artifact arrays.
- Redacts secret-like keys from preview diffs so planner/PendingAction output can be shown safely.
- Registers `bundle_upgrade` on `datamachine_pending_action_handlers`; actual artifact writes are delegated to `datamachine_bundle_upgrade_apply_artifact` so storage-specific consumers can own mutation.

## Tests
- `php tests/agent-bundle-upgrade-planner-smoke.php`
- `php tests/agent-bundle-installed-artifact-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-bundle-upgrade-pendingactions --changed-since origin/main` reports no new baseline findings; the command still exits non-zero because the Homeboy lint runner also tries to parse changed PHP files with ESLint and hits the existing PHP/ESLint routing issue.

## Follow-ups
- Wire the planner to persisted bundle install metadata and real bundle import/upgrade commands.
- Add UI/CLI affordances for accepting/rejecting individual bundle artifacts.
- Add previous-snapshot metadata once artifact storage writers exist.

Closes #1532.
Refs #1533.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the planner/PendingAction scaffolding and smoke coverage; Chris remains responsible for review and merge.
