### PR TITLE
feat(memory): add bundle-aware self-write policy

### DIFF
--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -61,6 +61,20 @@ Statuses:
 
 Hashing is deterministic: arrays are recursively sorted and JSON-encoded through `BundleSchema::encode_json()` before SHA-256 hashing. This makes formatting and associative key order irrelevant while preserving list order.
 
+### Memory Section Artifacts
+
+Memory artifacts can be tracked at section granularity. Section records extend the artifact identity with operational memory ownership fields:
+
+- `agent_id`
+- `section_id`
+- `section_heading`
+- `section_type`
+- `owner`: `bundle`, `user`, `runtime`, or `compaction`
+- `bundle_slug` and `bundle_version` for bundle-owned seed sections
+- `installed_hash`, `current_hash`, and `local_status`
+
+Self-memory writes are policy-constrained: the default target is the current acting agent, allowed section types are operational (`operating_note`, `source_quirk`, `run_lesson`, `task_note`), durable facts are rejected, and bundle-owned sections are staged through PendingActions instead of overwritten directly.
+
 ## Follow-Ups
 
 - Add persistent DB storage for installed artifact records.

--- a/inc/Abilities/AgentMemoryAbilities.php
+++ b/inc/Abilities/AgentMemoryAbilities.php
@@ -14,6 +14,8 @@ namespace DataMachine\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\FilesRepository\AgentMemory;
+use DataMachine\Engine\AI\Memory\MemorySectionPendingAction;
+use DataMachine\Engine\AI\Memory\SelfMemoryWritePolicy;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -27,6 +29,7 @@ class AgentMemoryAbilities {
 		}
 
 		$this->registerAbilities();
+		MemorySectionPendingAction::register();
 		self::$registered = true;
 	}
 
@@ -128,6 +131,73 @@ class AgentMemoryAbilities {
 					),
 					'execute_callback'    => array( self::class, 'updateMemory' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/write-self-memory',
+				array(
+					'label'               => 'Write Self Memory',
+					'description'         => 'Policy-constrained write to the current agent\'s operational memory. Cross-agent writes and durable facts are denied by default.',
+					'category'            => 'datamachine-memory',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'agent_id'           => array(
+								'type'        => array( 'integer', 'null' ),
+								'description' => 'Optional target agent. Defaults to the current acting agent; other agents require explicit delegation.',
+							),
+							'file'               => array(
+								'type'        => 'string',
+								'description' => 'Target memory file. Defaults to MEMORY.md.',
+								'default'     => 'MEMORY.md',
+							),
+							'section'            => array(
+								'type'        => 'string',
+								'description' => 'Section name to create or update.',
+							),
+							'section_type'       => array(
+								'type'        => 'string',
+								'description' => 'Operational section type, such as operating_note, source_quirk, run_lesson, or task_note.',
+								'default'     => 'operating_note',
+							),
+							'content'            => array(
+								'type'        => 'string',
+								'description' => 'Operational memory content to write.',
+							),
+							'mode'               => array(
+								'type'        => 'string',
+								'enum'        => array( 'set', 'append' ),
+								'description' => 'Write mode. Defaults to append.',
+								'default'     => 'append',
+							),
+							'reason'             => array(
+								'type'        => 'string',
+								'description' => 'Why this operational note should be recorded.',
+							),
+							'requires_approval'  => array(
+								'type'        => 'boolean',
+								'description' => 'Force PendingAction preview instead of direct write.',
+								'default'     => false,
+							),
+						),
+						'required'   => array( 'section', 'content' ),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'    => array( 'type' => 'boolean' ),
+							'message'    => array( 'type' => 'string' ),
+							'error'      => array( 'type' => 'string' ),
+							'error_code' => array( 'type' => 'string' ),
+							'staged'     => array( 'type' => 'boolean' ),
+							'action_id'  => array( 'type' => 'string' ),
+							'preview'    => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'writeSelfMemory' ),
+					'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -299,6 +369,16 @@ class AgentMemoryAbilities {
 		}
 
 		return $memory->set_section( $section, $content );
+	}
+
+	/**
+	 * Policy-constrained write to the current agent's own operational memory.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result.
+	 */
+	public static function writeSelfMemory( array $input ): array {
+		return SelfMemoryWritePolicy::execute( $input );
 	}
 
 	/**

--- a/inc/Engine/AI/Memory/MemorySectionArtifact.php
+++ b/inc/Engine/AI/Memory/MemorySectionArtifact.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Memory section artifact metadata.
+ *
+ * @package DataMachine\Engine\AI\Memory
+ */
+
+namespace DataMachine\Engine\AI\Memory;
+
+use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\BundleValidationException;
+use DataMachine\Engine\Bundle\PortableSlug;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable section-level memory artifact row.
+ */
+final class MemorySectionArtifact {
+
+	public const OWNER_BUNDLE     = 'bundle';
+	public const OWNER_USER       = 'user';
+	public const OWNER_RUNTIME    = 'runtime';
+	public const OWNER_COMPACTION = 'compaction';
+
+	private const OWNERS = array(
+		self::OWNER_BUNDLE,
+		self::OWNER_USER,
+		self::OWNER_RUNTIME,
+		self::OWNER_COMPACTION,
+	);
+
+	private int $agent_id;
+	private string $bundle_slug;
+	private string $bundle_version;
+	private string $section_id;
+	private string $section_heading;
+	private string $section_type;
+	private string $owner;
+	private string $source_path;
+	private ?string $installed_hash;
+	private ?string $current_hash;
+	private string $local_status;
+	private string $installed_at;
+	private string $updated_at;
+
+	public function __construct( array $data ) {
+		$this->agent_id        = absint( $data['agent_id'] ?? 0 );
+		$this->bundle_slug     = self::optional_slug( $data['bundle_slug'] ?? '' );
+		$this->bundle_version  = self::optional_string( $data['bundle_version'] ?? '' );
+		$this->section_heading = self::non_empty_string( $data['section_heading'] ?? ( $data['section'] ?? '' ), 'section_heading' );
+		$this->section_id      = self::section_id( $data['section_id'] ?? $this->section_heading );
+		$this->section_type    = self::section_type( $data['section_type'] ?? 'operating_note' );
+		$this->owner           = self::owner( $data['owner'] ?? self::OWNER_RUNTIME );
+		$this->source_path     = self::source_path( $data['source_path'] ?? '' );
+		$this->installed_hash  = self::optional_hash( $data['installed_hash'] ?? null );
+		$this->current_hash    = self::optional_hash( $data['current_hash'] ?? null );
+		$this->local_status    = AgentBundleArtifactStatus::classify( $this->installed_hash, $this->current_hash );
+		$this->installed_at    = self::optional_string( $data['installed_at'] ?? '' );
+		$this->updated_at      = self::optional_string( $data['updated_at'] ?? '' );
+
+		if ( self::OWNER_BUNDLE === $this->owner && ( '' === $this->bundle_slug || '' === $this->bundle_version || null === $this->installed_hash ) ) {
+			throw new BundleValidationException( 'bundle-owned memory section artifacts require bundle_slug, bundle_version, and installed_hash.' );
+		}
+	}
+
+	public static function from_bundle_section( AgentBundleManifest $manifest, int $agent_id, string $section_heading, string $section_type, string $source_path, string $content, string $timestamp ): self {
+		$hash = AgentBundleArtifactHasher::hash( $content );
+
+		return new self(
+			array(
+				'agent_id'        => $agent_id,
+				'bundle_slug'     => $manifest->bundle_slug(),
+				'bundle_version'  => $manifest->bundle_version(),
+				'section_heading' => $section_heading,
+				'section_type'    => $section_type,
+				'owner'           => self::OWNER_BUNDLE,
+				'source_path'     => $source_path,
+				'installed_hash'  => $hash,
+				'current_hash'    => $hash,
+				'installed_at'    => $timestamp,
+				'updated_at'      => $timestamp,
+			)
+		);
+	}
+
+	public static function from_array( array $data ): self {
+		return new self( $data );
+	}
+
+	public function with_current_content( ?string $content, string $updated_at ): self {
+		$data                 = $this->to_array();
+		$data['current_hash'] = null === $content ? null : AgentBundleArtifactHasher::hash( $content );
+		$data['updated_at']   = $updated_at;
+		return new self( $data );
+	}
+
+	public function is_bundle_owned(): bool {
+		return self::OWNER_BUNDLE === $this->owner;
+	}
+
+	public function can_auto_update_from_bundle(): bool {
+		return $this->is_bundle_owned() && AgentBundleArtifactStatus::CLEAN === $this->local_status;
+	}
+
+	public function should_stage_bundle_update(): bool {
+		return $this->is_bundle_owned() && AgentBundleArtifactStatus::MODIFIED === $this->local_status;
+	}
+
+	public function local_status(): string {
+		return $this->local_status;
+	}
+
+	public function to_array(): array {
+		return array(
+			'agent_id'        => $this->agent_id,
+			'bundle_slug'     => $this->bundle_slug,
+			'bundle_version'  => $this->bundle_version,
+			'section_id'      => $this->section_id,
+			'section_heading' => $this->section_heading,
+			'section_type'    => $this->section_type,
+			'owner'           => $this->owner,
+			'source_path'     => $this->source_path,
+			'installed_hash'  => $this->installed_hash,
+			'current_hash'    => $this->current_hash,
+			'local_status'    => $this->local_status,
+			'installed_at'    => $this->installed_at,
+			'updated_at'      => $this->updated_at,
+		);
+	}
+
+	private static function section_id( string $value ): string {
+		$value = strtolower( self::non_empty_string( $value, 'section_id' ) );
+		$value = preg_replace( '/[^a-z0-9._\/-]+/', '-', $value ) ?? '';
+		$value = trim( $value, '-/' );
+
+		return self::non_empty_string( $value, 'section_id' );
+	}
+
+	private static function section_type( string $value ): string {
+		$value = sanitize_key( self::non_empty_string( $value, 'section_type' ) );
+		return self::non_empty_string( $value, 'section_type' );
+	}
+
+	private static function owner( string $owner ): string {
+		$owner = sanitize_key( self::non_empty_string( $owner, 'owner' ) );
+		if ( ! in_array( $owner, self::OWNERS, true ) ) {
+			throw new BundleValidationException( sprintf( 'memory section owner must be one of: %s.', implode( ', ', self::OWNERS ) ) );
+		}
+
+		return $owner;
+	}
+
+	private static function optional_slug( string $value ): string {
+		$value = trim( $value );
+		return '' === $value ? '' : PortableSlug::normalize( $value, 'bundle' );
+	}
+
+	private static function optional_string( string $value ): string {
+		return trim( $value );
+	}
+
+	private static function optional_hash( ?string $value ): ?string {
+		$value = null === $value ? '' : trim( $value );
+		return '' === $value ? null : $value;
+	}
+
+	private static function source_path( string $path ): string {
+		$path = str_replace( "\\", '/', trim( $path ) );
+		$path = ltrim( $path, '/' );
+		if ( str_contains( $path, '..' ) ) {
+			throw new BundleValidationException( 'memory section source_path must be bundle-local.' );
+		}
+
+		return $path;
+	}
+
+	private static function non_empty_string( string $value, string $field ): string {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			throw new BundleValidationException( sprintf( 'memory section %s must be a non-empty string.', esc_html( $field ) ) );
+		}
+
+		return $value;
+	}
+}

--- a/inc/Engine/AI/Memory/MemorySectionPendingAction.php
+++ b/inc/Engine/AI/Memory/MemorySectionPendingAction.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * PendingAction integration for memory section changes.
+ *
+ * @package DataMachine\Engine\AI\Memory
+ */
+
+namespace DataMachine\Engine\AI\Memory;
+
+use DataMachine\Core\FilesRepository\AgentMemory;
+use DataMachine\Engine\AI\Actions\PendingActionHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stages and applies memory section updates through the generic resolver.
+ */
+final class MemorySectionPendingAction {
+
+	public const KIND = 'memory_section_update';
+
+	public static function register(): void {
+		add_filter(
+			'datamachine_pending_action_handlers',
+			static function ( array $handlers ): array {
+				$handlers[ self::KIND ] = array(
+					'apply' => array( self::class, 'apply' ),
+				);
+				return $handlers;
+			}
+		);
+	}
+
+	public static function stage( array $args ): array {
+		$agent_id = absint( $args['agent_id'] ?? 0 );
+		$user_id  = absint( $args['user_id'] ?? 0 );
+		$file     = (string) ( $args['file'] ?? 'MEMORY.md' );
+		$section  = (string) ( $args['section'] ?? '' );
+		$content  = (string) ( $args['content'] ?? '' );
+		$mode     = self::mode( (string) ( $args['mode'] ?? 'append' ) );
+		$reason   = (string) ( $args['reason'] ?? '' );
+
+		$memory  = new AgentMemory( $user_id, $agent_id, $file );
+		$current = $memory->get_section( $section );
+		$current_content = ! empty( $current['success'] ) ? (string) $current['content'] : '';
+		$proposed        = 'append' === $mode && '' !== $current_content
+			? rtrim( $current_content ) . "\n" . $content
+			: $content;
+
+		return PendingActionHelper::stage(
+			array(
+				'kind'         => self::KIND,
+				'summary'      => sprintf( 'Update %s section "%s" for agent %d.', $file, $section, $agent_id ),
+				'agent_id'     => $agent_id,
+				'user_id'      => $user_id,
+				'apply_input'  => array(
+					'agent_id'     => $agent_id,
+					'user_id'      => $user_id,
+					'file'         => $file,
+					'section'      => $section,
+					'section_type' => (string) ( $args['section_type'] ?? '' ),
+					'content'      => $content,
+					'mode'         => $mode,
+					'reason'       => $reason,
+				),
+				'preview_data' => array(
+					'target_agent'     => $agent_id,
+					'file'             => $file,
+					'section'          => $section,
+					'section_type'     => (string) ( $args['section_type'] ?? '' ),
+					'source'           => (string) ( $args['source'] ?? 'runtime_agent' ),
+					'reason'           => $reason,
+					'current_content'  => self::redact( $current_content ),
+					'proposed_content' => self::redact( $proposed ),
+					'diff'             => self::redacted_diff( $current_content, $proposed ),
+				),
+			)
+		);
+	}
+
+	public static function apply( array $input ): array {
+		$memory  = new AgentMemory( absint( $input['user_id'] ?? 0 ), absint( $input['agent_id'] ?? 0 ), (string) ( $input['file'] ?? 'MEMORY.md' ) );
+		$section = (string) ( $input['section'] ?? '' );
+		$content = (string) ( $input['content'] ?? '' );
+		$mode    = self::mode( (string) ( $input['mode'] ?? 'append' ) );
+
+		if ( '' === trim( $section ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'section is required.',
+			);
+		}
+
+		$result = 'set' === $mode ? $memory->set_section( $section, $content ) : $memory->append_to_section( $section, $content );
+
+		return array(
+			'success' => ! empty( $result['success'] ),
+			'message' => $result['message'] ?? '',
+			'file'    => (string) ( $input['file'] ?? 'MEMORY.md' ),
+			'section' => $section,
+		);
+	}
+
+	private static function mode( string $mode ): string {
+		return 'set' === $mode ? 'set' : 'append';
+	}
+
+	private static function redacted_diff( string $current, string $proposed ): string {
+		$current_lines  = explode( "\n", self::redact( $current ) );
+		$proposed_lines = explode( "\n", self::redact( $proposed ) );
+		$lines          = array();
+
+		foreach ( $current_lines as $line ) {
+			if ( '' !== $line ) {
+				$lines[] = '- ' . $line;
+			}
+		}
+		foreach ( $proposed_lines as $line ) {
+			if ( '' !== $line ) {
+				$lines[] = '+ ' . $line;
+			}
+		}
+
+		return implode( "\n", array_slice( $lines, 0, 80 ) );
+	}
+
+	private static function redact( string $content ): string {
+		$redacted = preg_replace( '/\b(api[_-]?key|token|secret|password)\b\s*[:=]\s*\S+/i', '$1: [redacted]', $content );
+		$redacted = preg_replace( '/Bearer\s+[A-Za-z0-9._~+\/-]+=*/i', 'Bearer [redacted]', $redacted ?? $content );
+
+		return $redacted ?? $content;
+	}
+}

--- a/inc/Engine/AI/Memory/SelfMemoryWritePolicy.php
+++ b/inc/Engine/AI/Memory/SelfMemoryWritePolicy.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Policy gate for self-scoped operational memory writes.
+ *
+ * @package DataMachine\Engine\AI\Memory
+ */
+
+namespace DataMachine\Engine\AI\Memory;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\FilesRepository\AgentMemory;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Constrains agents to writing their own operational memory sections.
+ */
+final class SelfMemoryWritePolicy {
+
+	private const DEFAULT_ALLOWED_SECTION_TYPES = array(
+		'operating_note',
+		'source_quirk',
+		'run_lesson',
+		'task_note',
+	);
+
+	private const DURABLE_FACT_TYPES = array(
+		'fact',
+		'domain_fact',
+		'wiki_fact',
+		'knowledge',
+	);
+
+	public static function execute( array $input ): array {
+		$current_agent_id = PermissionHelper::get_acting_agent_id();
+		if ( null === $current_agent_id ) {
+			return self::deny( 'Self-memory writes require an active agent context.', 'missing_agent_context' );
+		}
+
+		$target_agent_id = absint( $input['agent_id'] ?? $current_agent_id );
+		if ( $target_agent_id !== $current_agent_id && ! self::delegated_cross_agent_write_allowed( $current_agent_id, $target_agent_id, $input ) ) {
+			return self::deny( 'Self-memory writes cannot target another agent without explicit delegation.', 'cross_agent_denied' );
+		}
+
+		$section_type = sanitize_key( (string) ( $input['section_type'] ?? 'operating_note' ) );
+		if ( in_array( $section_type, self::DURABLE_FACT_TYPES, true ) ) {
+			return self::deny( 'Durable domain facts belong in wiki/graph tools, not operational memory.', 'durable_fact_denied' );
+		}
+
+		$allowed = apply_filters( 'datamachine_self_memory_allowed_section_types', self::DEFAULT_ALLOWED_SECTION_TYPES, $current_agent_id, $input );
+		$allowed = is_array( $allowed ) ? array_map( 'sanitize_key', $allowed ) : self::DEFAULT_ALLOWED_SECTION_TYPES;
+		if ( ! in_array( $section_type, $allowed, true ) ) {
+			return self::deny( sprintf( 'Section type "%s" is not allowed for self-memory writes.', $section_type ), 'section_type_denied' );
+		}
+
+		$file    = (string) ( $input['file'] ?? 'MEMORY.md' );
+		$section = trim( (string) ( $input['section'] ?? '' ) );
+		$content = (string) ( $input['content'] ?? '' );
+		$mode    = 'set' === ( $input['mode'] ?? 'append' ) ? 'set' : 'append';
+
+		if ( '' === $section || '' === trim( $content ) ) {
+			return self::deny( 'section and content are required.', 'missing_required_input' );
+		}
+
+		$artifact = self::memory_section_artifact( $target_agent_id, $file, $section, $section_type, $input );
+		if ( $artifact && $artifact->is_bundle_owned() ) {
+			return MemorySectionPendingAction::stage( self::stage_args( $input, $target_agent_id, $file, $section, $section_type, $content, $mode, 'bundle_upgrade' ) );
+		}
+
+		$sensitive_types = apply_filters( 'datamachine_self_memory_sensitive_section_types', array(), $current_agent_id, $input );
+		$sensitive_types = is_array( $sensitive_types ) ? array_map( 'sanitize_key', $sensitive_types ) : array();
+		if ( ! empty( $input['requires_approval'] ) || in_array( $section_type, $sensitive_types, true ) ) {
+			return MemorySectionPendingAction::stage( self::stage_args( $input, $target_agent_id, $file, $section, $section_type, $content, $mode, 'runtime_agent' ) );
+		}
+
+		$memory = new AgentMemory( PermissionHelper::acting_user_id(), $target_agent_id, $file );
+		$result = 'set' === $mode ? $memory->set_section( $section, $content ) : $memory->append_to_section( $section, $content );
+
+		return array_merge(
+			$result,
+			array(
+				'agent_id'     => $target_agent_id,
+				'file'         => $file,
+				'section'      => $section,
+				'section_type' => $section_type,
+				'owner'        => MemorySectionArtifact::OWNER_RUNTIME,
+			)
+		);
+	}
+
+	private static function memory_section_artifact( int $agent_id, string $file, string $section, string $section_type, array $input ): ?MemorySectionArtifact {
+		$artifact = apply_filters(
+			'datamachine_memory_section_artifact',
+			null,
+			array(
+				'agent_id'     => $agent_id,
+				'file'         => $file,
+				'section'      => $section,
+				'section_type' => $section_type,
+				'input'        => $input,
+			)
+		);
+
+		if ( $artifact instanceof MemorySectionArtifact ) {
+			return $artifact;
+		}
+
+		return is_array( $artifact ) ? MemorySectionArtifact::from_array( $artifact ) : null;
+	}
+
+	private static function delegated_cross_agent_write_allowed( int $current_agent_id, int $target_agent_id, array $input ): bool {
+		return true === apply_filters( 'datamachine_self_memory_allow_cross_agent_write', false, $current_agent_id, $target_agent_id, $input );
+	}
+
+	private static function stage_args( array $input, int $agent_id, string $file, string $section, string $section_type, string $content, string $mode, string $source ): array {
+		return array(
+			'agent_id'     => $agent_id,
+			'user_id'      => PermissionHelper::acting_user_id(),
+			'file'         => $file,
+			'section'      => $section,
+			'section_type' => $section_type,
+			'content'      => $content,
+			'mode'         => $mode,
+			'reason'       => (string) ( $input['reason'] ?? '' ),
+			'source'       => $source,
+		);
+	}
+
+	private static function deny( string $message, string $code ): array {
+		return array(
+			'success'    => false,
+			'error'      => $message,
+			'error_code' => $code,
+		);
+	}
+}

--- a/tests/memory-bundle-policy-smoke.php
+++ b/tests/memory-bundle-policy-smoke.php
@@ -1,0 +1,397 @@
+<?php
+/**
+ * Pure-PHP smoke tests for memory bundle artifact policy (#1543-#1545).
+ *
+ * Run with: php tests/memory-bundle-policy-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+	define( 'HOUR_IN_SECONDS', 3600 );
+}
+
+$GLOBALS['datamachine_memory_policy_filters']    = array();
+$GLOBALS['datamachine_memory_policy_actions']    = array();
+$GLOBALS['datamachine_memory_policy_transients'] = array();
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ): string {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $key ) ?? '' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ): string {
+		return trim( wp_strip_all_tags( (string) $value ) );
+	}
+}
+
+if ( ! function_exists( 'sanitize_file_name' ) ) {
+	function sanitize_file_name( string $filename ): string {
+		return preg_replace( '/[^a-zA-Z0-9._\/-]/', '', $filename ) ?? '';
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $value ): string {
+		return strip_tags( (string) $value );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ): string {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return 7;
+	}
+}
+
+if ( ! function_exists( 'get_users' ) ) {
+	function get_users( array $_args ): array {
+		unset( $_args );
+		return array( 7 );
+	}
+}
+
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in(): bool {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $_capability ): bool {
+		unset( $_capability );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'user_can' ) ) {
+	function user_can( int $_user_id, string $_capability ): bool {
+		unset( $_user_id, $_capability );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'size_format' ) ) {
+	function size_format( int $bytes ): string {
+		return $bytes . ' B';
+	}
+}
+
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4(): string {
+		static $i = 0;
+		++$i;
+		return sprintf( '00000000-0000-4000-8000-%012d', $i );
+	}
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( string $key, $value, int $_expiration ): bool {
+		unset( $_expiration );
+		$GLOBALS['datamachine_memory_policy_transients'][ $key ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( string $key ) {
+		return $GLOBALS['datamachine_memory_policy_transients'][ $key ] ?? false;
+	}
+}
+
+if ( ! function_exists( 'delete_transient' ) ) {
+	function delete_transient( string $key ): bool {
+		unset( $GLOBALS['datamachine_memory_policy_transients'][ $key ] );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['datamachine_memory_policy_filters'][ $hook ][ $priority ][] = array(
+			'callback'      => $callback,
+			'accepted_args' => $accepted_args,
+		);
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		add_filter( $hook, $callback, $priority, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$filters = $GLOBALS['datamachine_memory_policy_filters'][ $hook ] ?? array();
+		ksort( $filters );
+		foreach ( $filters as $callbacks ) {
+			foreach ( $callbacks as $filter ) {
+				$value = $filter['callback']( ...array_slice( array_merge( array( $value ), $args ), 0, $filter['accepted_args'] ) );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['datamachine_memory_policy_actions'][] = array(
+			'hook' => $hook,
+			'args' => $args,
+		);
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( string $_hook = '' ): bool {
+		unset( $_hook );
+		return false;
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( string $_hook = '' ): int {
+		unset( $_hook );
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $_thing ): bool {
+		unset( $_thing );
+		return false;
+	}
+}
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\FilesRepository\AgentMemoryListEntry;
+use DataMachine\Core\FilesRepository\AgentMemoryReadResult;
+use DataMachine\Core\FilesRepository\AgentMemoryScope;
+use DataMachine\Core\FilesRepository\AgentMemoryStoreInterface;
+use DataMachine\Core\FilesRepository\AgentMemoryWriteResult;
+use DataMachine\Engine\AI\Actions\PendingActionStore;
+use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
+use DataMachine\Engine\AI\Memory\MemorySectionArtifact;
+use DataMachine\Engine\AI\Memory\MemorySectionPendingAction;
+use DataMachine\Engine\AI\Memory\SelfMemoryWritePolicy;
+use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+
+class MemoryPolicyFakeStore implements AgentMemoryStoreInterface {
+
+	/** @var array<string, string> */
+	public array $files = array();
+
+	public function read( AgentMemoryScope $scope ): AgentMemoryReadResult {
+		if ( ! array_key_exists( $scope->key(), $this->files ) ) {
+			return AgentMemoryReadResult::not_found();
+		}
+
+		$content = $this->files[ $scope->key() ];
+		return new AgentMemoryReadResult( true, $content, sha1( $content ), strlen( $content ), 123 );
+	}
+
+	public function write( AgentMemoryScope $scope, string $content, ?string $_if_match = null ): AgentMemoryWriteResult {
+		unset( $_if_match );
+		$this->files[ $scope->key() ] = $content;
+		return AgentMemoryWriteResult::ok( sha1( $content ), strlen( $content ) );
+	}
+
+	public function exists( AgentMemoryScope $scope ): bool {
+		return array_key_exists( $scope->key(), $this->files );
+	}
+
+	public function delete( AgentMemoryScope $scope ): AgentMemoryWriteResult {
+		unset( $this->files[ $scope->key() ] );
+		return AgentMemoryWriteResult::ok( '', 0 );
+	}
+
+	public function list_layer( AgentMemoryScope $_scope_query ): array {
+		unset( $_scope_query );
+		return array();
+	}
+
+	public function list_subtree( AgentMemoryScope $_scope_query, string $_prefix ): array {
+		unset( $_scope_query, $_prefix );
+		return array();
+	}
+}
+
+function memory_policy_assert( bool $condition, string $message ): void {
+	static $assertions = 0;
+	++$assertions;
+	if ( ! $condition ) {
+		fwrite( STDERR, "Assertion failed: {$message}\n" );
+		exit( 1 );
+	}
+	echo "ok {$assertions} - {$message}\n";
+}
+
+$store = new MemoryPolicyFakeStore();
+add_filter(
+	'datamachine_memory_store',
+	static function ( $_default, AgentMemoryScope $_scope ) use ( $store ) {
+		unset( $_default, $_scope );
+		return $store;
+	},
+	10,
+	2
+);
+MemorySectionPendingAction::register();
+PermissionHelper::set_agent_context( 42, 7 );
+
+$scope_key                  = 'agent:7:42:MEMORY.md';
+$store->files[ $scope_key ] = "# MEMORY.md\n\n## Source quirks\nExisting note.\n";
+
+echo "\n[1] Memory sections are bundle artifacts with ownership/status metadata\n";
+$manifest = AgentBundleManifest::from_array(
+	array(
+		'schema_version' => 1,
+		'bundle_slug'    => 'WooCommerce Brain',
+		'bundle_version' => '2026.04.28',
+		'exported_at'    => '2026-04-28T00:00:00Z',
+		'exported_by'    => 'test',
+		'agent'          => array(
+			'slug'         => 'wc-agent',
+			'label'        => 'WooCommerce Agent',
+			'description'  => 'Maintains WooCommerce knowledge.',
+			'agent_config' => array(),
+		),
+		'included'       => array(
+			'memory'       => array( 'source-quirks' ),
+			'pipelines'    => array(),
+			'flows'        => array(),
+			'handler_auth' => 'refs',
+		),
+	)
+);
+$artifact = MemorySectionArtifact::from_bundle_section( $manifest, 42, 'Source quirks', 'source_quirk', 'memory/source-quirks.md', "Existing note.\n", '2026-04-28T00:00:00Z' );
+$row      = $artifact->to_array();
+memory_policy_assert( 'bundle' === $row['owner'], 'bundle owner is tracked' );
+memory_policy_assert( 42 === $row['agent_id'], 'agent identity is tracked' );
+memory_policy_assert( 'source-quirks' === $row['section_id'], 'section id is normalized' );
+memory_policy_assert( AgentBundleArtifactStatus::CLEAN === $row['local_status'], 'fresh bundle section is clean' );
+memory_policy_assert( true === $artifact->can_auto_update_from_bundle(), 'clean bundle section can auto-update from bundle' );
+memory_policy_assert( AgentBundleArtifactStatus::MODIFIED === $artifact->with_current_content( "Local edit.\n", '2026-04-28T01:00:00Z' )->local_status(), 'edited bundle section is modified' );
+memory_policy_assert( true === $artifact->with_current_content( "Local edit.\n", '2026-04-28T01:00:00Z' )->should_stage_bundle_update(), 'modified bundle section should stage bundle update' );
+memory_policy_assert( AgentBundleArtifactStatus::MISSING === $artifact->with_current_content( null, '2026-04-28T01:00:00Z' )->local_status(), 'missing bundle section is missing' );
+
+echo "\n[2] Self-memory writes are scoped to current agent and operational section types\n";
+$write = SelfMemoryWritePolicy::execute(
+	array(
+		'section'      => 'Run lessons',
+		'section_type' => 'run_lesson',
+		'content'      => 'MGS source needed narrower query terms.',
+		'reason'       => 'Observed noisy result set.',
+	)
+);
+memory_policy_assert( true === $write['success'], 'allowed self-memory write succeeds' );
+memory_policy_assert( str_contains( $store->files[ $scope_key ], 'MGS source needed narrower query terms.' ), 'allowed self-memory write reaches active memory store' );
+
+$cross_agent = SelfMemoryWritePolicy::execute(
+	array(
+		'agent_id'     => 99,
+		'section'      => 'Run lessons',
+		'section_type' => 'run_lesson',
+		'content'      => 'Should not write.',
+	)
+);
+memory_policy_assert( false === $cross_agent['success'] && 'cross_agent_denied' === $cross_agent['error_code'], 'cross-agent write is denied by default' );
+
+$durable_fact = SelfMemoryWritePolicy::execute(
+	array(
+		'section'      => 'Facts',
+		'section_type' => 'domain_fact',
+		'content'      => 'WooCommerce was founded in 2008.',
+	)
+);
+memory_policy_assert( false === $durable_fact['success'] && 'durable_fact_denied' === $durable_fact['error_code'], 'durable fact writes are rejected' );
+
+echo "\n[3] Bundle-owned section overwrites are staged with redacted PendingAction preview\n";
+add_filter(
+	'datamachine_memory_section_artifact',
+	static function ( $_artifact, array $context ) use ( $artifact ) {
+		unset( $_artifact );
+		return 'Source quirks' === $context['section'] ? $artifact : null;
+	},
+	10,
+	2
+);
+
+$staged = SelfMemoryWritePolicy::execute(
+	array(
+		'section'      => 'Source quirks',
+		'section_type' => 'source_quirk',
+		'content'      => 'token=super-secret-value should not appear in preview.',
+		'mode'         => 'set',
+		'reason'       => 'Bundle seed needs local approval before overwrite.',
+	)
+);
+memory_policy_assert( true === $staged['staged'], 'bundle-owned overwrite is staged instead of applied' );
+memory_policy_assert( ! str_contains( $store->files[ $scope_key ], 'super-secret-value' ), 'staged overwrite does not mutate memory immediately' );
+memory_policy_assert( str_contains( $staged['preview']['diff'], '[redacted]' ), 'preview diff redacts secret-like values' );
+memory_policy_assert( ! str_contains( $staged['preview']['diff'], 'super-secret-value' ), 'preview diff does not expose secret-like value' );
+
+$payload = PendingActionStore::get( $staged['action_id'] );
+memory_policy_assert( is_array( $payload ) && MemorySectionPendingAction::KIND === $payload['kind'], 'pending action stores memory section kind' );
+
+echo "\n[4] PendingAction accept applies only the approved section; reject leaves memory untouched\n";
+$accepted = ResolvePendingActionAbility::execute(
+	array(
+		'action_id' => $staged['action_id'],
+		'decision'  => 'accepted',
+	)
+);
+memory_policy_assert( true === $accepted['success'], 'accepted memory PendingAction resolves successfully' );
+memory_policy_assert( str_contains( $store->files[ $scope_key ], 'super-secret-value' ), 'accepted memory PendingAction applies raw content to the target section' );
+memory_policy_assert( null === PendingActionStore::get( $staged['action_id'] ), 'accepted PendingAction is deleted after resolution' );
+
+$before_reject = $store->files[ $scope_key ];
+$rejectable    = SelfMemoryWritePolicy::execute(
+	array(
+		'section'      => 'Source quirks',
+		'section_type' => 'source_quirk',
+		'content'      => 'Rejected content.',
+		'mode'         => 'set',
+	)
+);
+$rejected = ResolvePendingActionAbility::execute(
+	array(
+		'action_id' => $rejectable['action_id'],
+		'decision'  => 'rejected',
+	)
+);
+memory_policy_assert( true === $rejected['success'], 'rejected memory PendingAction resolves successfully' );
+memory_policy_assert( sha1( $before_reject ) === sha1( $store->files[ $scope_key ] ), 'rejected memory PendingAction leaves memory untouched' );
+memory_policy_assert( ! str_contains( $store->files[ $scope_key ], 'Rejected content.' ), 'rejected memory PendingAction does not apply proposed content' );
+
+PermissionHelper::clear_agent_context();
+
+echo "Memory bundle policy smoke passed.\n";


### PR DESCRIPTION
## Summary
- Adds section-level memory artifact metadata for bundle-owned, user, runtime, and compaction-owned sections.
- Adds a self-scoped memory write ability that only permits operational memory updates for the current agent by default.
- Stages bundle-owned or approval-required memory section writes through the existing PendingAction resolver.

## Changes
- New `MemorySectionArtifact` value object tracks agent, section, owner/source, bundle version, hashes, and local status.
- New `datamachine/write-self-memory` ability routes writes through `SelfMemoryWritePolicy`.
- New `memory_section_update` PendingAction handler previews/apply/rejects approved memory section changes.
- Documents memory section artifact fields in the agent bundle docs.

## Tests
- `php tests/memory-bundle-policy-smoke.php`
- `php tests/agent-bundle-installed-artifact-smoke.php`
- `php tests/agent-memory-events-smoke.php`
- `php -l inc/Engine/AI/Memory/MemorySectionArtifact.php`
- `php -l inc/Engine/AI/Memory/MemorySectionPendingAction.php`
- `php -l inc/Engine/AI/Memory/SelfMemoryWritePolicy.php`
- `php -l inc/Abilities/AgentMemoryAbilities.php`
- `php -l tests/memory-bundle-policy-smoke.php`

Full `homeboy lint data-machine --path .` still reports the existing broad PHPStan baseline, and full `homeboy test data-machine --path .` still hits the existing harness/infrastructure failures. Focused smokes for this change pass.

## Follow-ups
- Persist memory section artifact rows in the bundle installer/importer path.
- Wire bundle upgrade planning to auto-apply clean section upgrades and stage modified section upgrades.
- Add UI rendering for memory PendingAction previews once the admin approval surface is ready.

## Closes / Refs
- Closes #1543
- Closes #1544
- Closes #1545

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the memory artifact/policy layer, smoke tests, and PR preparation; Chris remains responsible for review and merge.