### PR TITLE
feat(bundle): update portable pipelines in place

### DIFF
--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -75,8 +75,25 @@ Memory artifacts can be tracked at section granularity. Section records extend t
 
 Self-memory writes are policy-constrained: the default target is the current acting agent, allowed section types are operational (`operating_note`, `source_quirk`, `run_lesson`, `task_note`), durable facts are rejected, and bundle-owned sections are staged through PendingActions instead of overwritten directly.
 
+## Pipeline And Flow Updates
+
+Bundle-installed pipelines and flows use stable `portable_slug` values as their runtime identity:
+
+- Pipelines resolve by `(agent_id, portable_slug)`.
+- Flows resolve by `(pipeline_id, portable_slug)`.
+- Re-importing the same bundle updates the existing clean rows instead of creating duplicates.
+- Local edits are detected by comparing the current artifact hash with the install-time hash recorded in the owning agent's `datamachine_bundle.artifacts` config.
+- Modified artifacts are reported as conflicts and are not overwritten by the import path.
+
+Schedule and queue policy is intentionally conservative:
+
+- New flows are installed paused/manual. The source schedule is retained as `_original_interval` for operators to opt in later.
+- Existing flow schedules are preserved during upgrades.
+- Queue slots (`prompt_queue`, `config_patch_queue`, `queue_mode`) seed new flows but are preserved on upgrades so runtime backlogs are not discarded.
+
 ## Follow-Ups
 
 - Add persistent DB storage for installed artifact records.
 - Wire importer/exporter paths for prompts, rubrics, tool policies, auth refs, and seed queues.
 - Use artifact statuses during bundle upgrade planning: auto-update `clean`, stage PendingActions for `modified`, surface `missing` and `orphaned` explicitly.
+- Add `wp datamachine agent-bundle list/status/diff/upgrade/apply` once the planner has a PendingAction-backed apply surface.

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -17,9 +17,12 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleLegacyAdapter;
 use DataMachine\Engine\Bundle\BundleValidationException;
+use DataMachine\Engine\Bundle\PortableSlug;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -77,9 +80,11 @@ class AgentBundler {
 
 		// 1. Agent identity.
 		$bundle = array(
-			'bundle_version' => self::BUNDLE_VERSION,
-			'exported_at'    => gmdate( 'c' ),
-			'agent'          => array(
+			'bundle_version'        => self::BUNDLE_VERSION,
+			'bundle_schema_version' => self::BUNDLE_VERSION,
+			'bundle_slug'           => sanitize_title( $agent['agent_slug'] ),
+			'exported_at'           => gmdate( 'c' ),
+			'agent'                 => array(
 				'agent_slug'   => $agent['agent_slug'],
 				'agent_name'   => $agent['agent_name'],
 				'agent_config' => $agent['agent_config'] ?? array(),
@@ -100,8 +105,12 @@ class AgentBundler {
 
 		foreach ( $pipelines as $pipeline ) {
 			$pipeline_id   = (int) $pipeline['pipeline_id'];
+			$portable_slug = ! empty( $pipeline['portable_slug'] )
+				? $pipeline['portable_slug']
+				: PortableSlug::normalize( (string) $pipeline['pipeline_name'], 'pipeline' );
 			$pipeline_data = array(
 				'original_id'     => $pipeline_id,
+				'portable_slug'   => $portable_slug,
 				'pipeline_name'   => $pipeline['pipeline_name'],
 				'pipeline_config' => $pipeline['pipeline_config'] ?? array(),
 			);
@@ -118,9 +127,13 @@ class AgentBundler {
 
 		foreach ( $flows as $flow ) {
 			$flow_id   = (int) $flow['flow_id'];
+			$portable_slug = ! empty( $flow['portable_slug'] )
+				? $flow['portable_slug']
+				: PortableSlug::normalize( (string) $flow['flow_name'], 'flow' );
 			$flow_data = array(
 				'original_id'          => $flow_id,
 				'original_pipeline_id' => (int) $flow['pipeline_id'],
+				'portable_slug'        => $portable_slug,
 				'flow_name'            => $flow['flow_name'],
 				'flow_config'          => $flow['flow_config'] ?? array(),
 				'scheduling_config'    => $this->sanitize_scheduling_config( $flow['scheduling_config'] ?? array() ),
@@ -163,16 +176,38 @@ class AgentBundler {
 			);
 		}
 
-		$agent_data = $bundle['agent'];
-		$slug       = $new_slug ? sanitize_title( $new_slug ) : sanitize_title( $agent_data['agent_slug'] );
+		$agent_data             = $bundle['agent'];
+		$slug                   = $new_slug
+			? sanitize_title( $new_slug )
+			: sanitize_title( $agent_data['agent_slug'] );
+		$bundle_slug            = PortableSlug::normalize( (string) ( $bundle['bundle_slug'] ?? $slug ), 'bundle' );
+		$bundle_version         = trim( (string) ( $bundle['bundle_version'] ?? self::BUNDLE_VERSION ) );
+		$bundle_source_ref      = trim( (string) ( $bundle['source_ref'] ?? '' ) );
+		$bundle_source_revision = trim( (string) ( $bundle['source_revision'] ?? '' ) );
+		$bundle_metadata        = array(
+			'bundle_slug'     => $bundle_slug,
+			'bundle_version'  => $bundle_version,
+			'source_ref'      => $bundle_source_ref,
+			'source_revision' => $bundle_source_revision,
+		);
+		$is_portable_bundle = ! empty( $bundle['bundle_slug'] ) || $this->bundle_has_portable_artifacts( $bundle );
 
 		// Check for slug collision.
 		$existing = $this->agents_repo->get_by_slug( $slug );
-		if ( $existing ) {
+		if ( $existing && ( $new_slug || ! $is_portable_bundle ) ) {
 			return array(
 				'success' => false,
 				'error'   => sprintf( 'Agent slug "%s" already exists. Use --slug=<new-slug> to rename on import.', $slug ),
 			);
+		}
+		if ( $existing ) {
+			$installed_bundle = $existing['agent_config']['datamachine_bundle'] ?? array();
+			if ( ! empty( $installed_bundle['bundle_slug'] ) && $installed_bundle['bundle_slug'] !== $bundle_slug ) {
+				return array(
+					'success' => false,
+					'error'   => sprintf( 'Agent slug "%s" is installed from bundle "%s", not "%s".', $slug, $installed_bundle['bundle_slug'], $bundle_slug ),
+				);
+			}
 		}
 
 		// Resolve owner.
@@ -194,10 +229,13 @@ class AgentBundler {
 			'agent_slug'        => $slug,
 			'agent_name'        => $agent_data['agent_name'],
 			'owner_id'          => $owner_id,
+			'bundle_slug'       => $bundle_slug,
+			'bundle_version'    => $bundle_version,
 			'files'             => count( $bundle['files'] ?? array() ),
 			'pipelines'         => count( $bundle['pipelines'] ?? array() ),
 			'flows'             => count( $bundle['flows'] ?? array() ),
 			'has_user_template' => ! empty( $bundle['user_template'] ),
+			'upgrade'           => (bool) $existing,
 		);
 
 		if ( $dry_run ) {
@@ -214,14 +252,38 @@ class AgentBundler {
 
 		// --- Actual import ---
 
-		// 1. Create agent record.
-		$config   = $agent_data['agent_config'] ?? array();
-		$agent_id = $this->agents_repo->create_if_missing(
-			$slug,
-			$agent_data['agent_name'] ?? $slug,
-			$owner_id,
-			is_array( $config ) ? $config : array()
+		// 1. Create or update the agent record.
+		$incoming_config = $agent_data['agent_config'] ?? array();
+		$incoming_config = is_array( $incoming_config ) ? $incoming_config : array();
+		$config          = is_array( $existing['agent_config'] ?? null )
+			? array_merge( $existing['agent_config'], $incoming_config )
+			: $incoming_config;
+		$existing_bundle_state = is_array( $existing['agent_config']['datamachine_bundle'] ?? null )
+			? $existing['agent_config']['datamachine_bundle']
+			: array();
+		$config['datamachine_bundle'] = array_merge(
+			$existing_bundle_state,
+			$bundle_metadata,
+			array( 'artifacts' => $existing_bundle_state['artifacts'] ?? array() )
 		);
+
+		if ( $existing ) {
+			$agent_id = (int) $existing['agent_id'];
+			$this->agents_repo->update_agent(
+				$agent_id,
+				array(
+					'agent_name'   => $agent_data['agent_name'] ?? $slug,
+					'agent_config' => $config,
+				)
+			);
+		} else {
+			$agent_id = $this->agents_repo->create_if_missing(
+				$slug,
+				$agent_data['agent_name'] ?? $slug,
+				$owner_id,
+				$config
+			);
+		}
 
 		if ( ! $agent_id ) {
 			return array(
@@ -238,19 +300,66 @@ class AgentBundler {
 			$this->write_user_template( $owner_id, $bundle['user_template'] );
 		}
 
+		$artifact_records = $config['datamachine_bundle']['artifacts'] ?? array();
+		$conflicts        = array();
+
 		// 4. Import pipelines — build old→new ID map.
 		$pipeline_id_map = array(); // old_id => new_id.
 		foreach ( $bundle['pipelines'] ?? array() as $pipeline_data ) {
-			$old_id          = (int) ( $pipeline_data['original_id'] ?? 0 );
-			$new_pipeline_id = $this->pipelines_repo->create_pipeline( array(
-				'pipeline_name'   => $pipeline_data['pipeline_name'],
-				'pipeline_config' => $pipeline_data['pipeline_config'] ?? array(),
-				'agent_id'        => $agent_id,
-				'user_id'         => $owner_id,
-			) );
+			$old_id            = (int) ( $pipeline_data['original_id'] ?? 0 );
+			$portable_slug     = PortableSlug::normalize(
+				(string) ( $pipeline_data['portable_slug'] ?? ( $pipeline_data['pipeline_name'] ?? 'pipeline' ) ),
+				'pipeline'
+			);
+			$artifact_key      = 'pipeline:' . $portable_slug;
+			$payload           = $this->pipeline_artifact_payload( $pipeline_data, $portable_slug );
+			$existing_pipeline = $this->pipelines_repo->get_by_portable_slug( $agent_id, $portable_slug );
+
+			if (
+				$existing_pipeline
+				&& $this->artifact_has_local_modifications(
+					$artifact_records[ $artifact_key ] ?? null,
+					$this->pipeline_artifact_payload( $existing_pipeline, $portable_slug )
+				)
+			) {
+				$conflicts[] = array(
+					'artifact_type' => 'pipeline',
+					'artifact_id'   => $portable_slug,
+					'reason'        => 'local_modified',
+				);
+				$pipeline_id_map[ $old_id ] = (int) $existing_pipeline['pipeline_id'];
+				continue;
+			}
+
+			if ( $existing_pipeline ) {
+				$new_pipeline_id = (int) $existing_pipeline['pipeline_id'];
+				$this->pipelines_repo->update_pipeline(
+					$new_pipeline_id,
+					array(
+						'pipeline_name'   => $pipeline_data['pipeline_name'],
+						'pipeline_config' => $pipeline_data['pipeline_config'] ?? array(),
+						'portable_slug'   => $portable_slug,
+					)
+				);
+			} else {
+				$new_pipeline_id = $this->pipelines_repo->create_pipeline( array(
+					'pipeline_name'   => $pipeline_data['pipeline_name'],
+					'pipeline_config' => $pipeline_data['pipeline_config'] ?? array(),
+					'portable_slug'   => $portable_slug,
+					'agent_id'        => $agent_id,
+					'user_id'         => $owner_id,
+				) );
+			}
 
 			if ( $new_pipeline_id ) {
 				$pipeline_id_map[ $old_id ] = (int) $new_pipeline_id;
+				$artifact_records[ $artifact_key ] = $this->bundle_artifact_record(
+					$bundle_metadata,
+					'pipeline',
+					$portable_slug,
+					'pipelines/' . $portable_slug . '.json',
+					$payload
+				);
 
 				// Write pipeline memory files to disk.
 				$this->write_pipeline_memory_files(
@@ -260,7 +369,7 @@ class AgentBundler {
 			}
 		}
 
-		// 5. Import flows — remap pipeline IDs, import paused.
+		// 5. Import flows: create paused, preserve local schedules/queues on update.
 		$flow_count = 0;
 		foreach ( $bundle['flows'] ?? array() as $flow_data ) {
 			$old_pipeline_id = (int) ( $flow_data['original_pipeline_id'] ?? 0 );
@@ -270,7 +379,13 @@ class AgentBundler {
 				continue; // Skip orphan flows.
 			}
 
-			// Force paused/manual scheduling on import.
+			$portable_slug = PortableSlug::normalize(
+				(string) ( $flow_data['portable_slug'] ?? ( $flow_data['flow_name'] ?? 'flow' ) ),
+				'flow'
+			);
+			$artifact_key  = 'flow:' . $portable_slug;
+
+			// Force paused/manual scheduling on create.
 			$scheduling            = $flow_data['scheduling_config'] ?? array();
 			$scheduling['enabled'] = false;
 			if ( ! isset( $scheduling['interval'] ) || 'manual' !== $scheduling['interval'] ) {
@@ -281,19 +396,58 @@ class AgentBundler {
 			$flow_config = $flow_data['flow_config'] ?? array();
 
 			// Remap pipeline step IDs inside flow_config.
-			$flow_config = $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, $new_pipeline_id );
+			$flow_config         = $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, $new_pipeline_id );
+			$existing_flow       = $this->flows_repo->get_by_portable_slug( (int) $new_pipeline_id, $portable_slug );
+			$flow_payload_source = array_merge( $flow_data, array( 'flow_config' => $flow_config ) );
+			$payload             = $this->flow_artifact_payload( $flow_payload_source, $portable_slug );
 
-			$new_flow_id = $this->flows_repo->create_flow( array(
-				'pipeline_id'       => $new_pipeline_id,
-				'flow_name'         => $flow_data['flow_name'],
-				'flow_config'       => $flow_config,
-				'scheduling_config' => $scheduling,
-				'agent_id'          => $agent_id,
-				'user_id'           => $owner_id,
-			) );
+			if (
+				$existing_flow
+				&& $this->artifact_has_local_modifications(
+					$artifact_records[ $artifact_key ] ?? null,
+					$this->flow_artifact_payload( $existing_flow, $portable_slug )
+				)
+			) {
+				$conflicts[] = array(
+					'artifact_type' => 'flow',
+					'artifact_id'   => $portable_slug,
+					'reason'        => 'local_modified',
+				);
+				continue;
+			}
+
+			if ( $existing_flow ) {
+				$new_flow_id = (int) $existing_flow['flow_id'];
+				$flow_config = $this->preserve_runtime_queue_fields( $flow_config, $existing_flow['flow_config'] ?? array() );
+				$this->flows_repo->update_flow(
+					$new_flow_id,
+					array(
+						'flow_name'     => $flow_data['flow_name'],
+						'flow_config'   => $flow_config,
+						'portable_slug' => $portable_slug,
+					)
+				);
+			} else {
+				$new_flow_id = $this->flows_repo->create_flow( array(
+					'pipeline_id'       => $new_pipeline_id,
+					'flow_name'         => $flow_data['flow_name'],
+					'flow_config'       => $flow_config,
+					'scheduling_config' => $scheduling,
+					'portable_slug'     => $portable_slug,
+					'agent_id'          => $agent_id,
+					'user_id'           => $owner_id,
+				) );
+			}
 
 			if ( $new_flow_id ) {
 				++$flow_count;
+				$artifact_records[ $artifact_key ] = $this->bundle_artifact_record(
+					$bundle_metadata,
+					'flow',
+					$portable_slug,
+					'flows/' . $portable_slug . '.json',
+					$payload
+				);
 
 				// Write flow memory files to disk.
 				$this->write_flow_memory_files(
@@ -307,6 +461,10 @@ class AgentBundler {
 		$summary['agent_id']           = $agent_id;
 		$summary['pipelines_imported'] = count( $pipeline_id_map );
 		$summary['flows_imported']     = $flow_count;
+		$summary['conflicts']          = $conflicts;
+
+		$config['datamachine_bundle']['artifacts'] = $artifact_records;
+		$this->agents_repo->update_agent( $agent_id, array( 'agent_config' => $config ) );
 
 		return array(
 			'success' => true,
@@ -319,6 +477,95 @@ class AgentBundler {
 			),
 			'summary' => $summary,
 		);
+	}
+
+	private function bundle_has_portable_artifacts( array $bundle ): bool {
+		foreach ( $bundle['pipelines'] ?? array() as $pipeline ) {
+			if ( ! empty( $pipeline['portable_slug'] ) ) {
+				return true;
+			}
+		}
+		foreach ( $bundle['flows'] ?? array() as $flow ) {
+			if ( ! empty( $flow['portable_slug'] ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function pipeline_artifact_payload( array $pipeline, string $portable_slug ): array {
+		return array(
+			'portable_slug'   => $portable_slug,
+			'pipeline_name'   => (string) ( $pipeline['pipeline_name'] ?? '' ),
+			'pipeline_config' => is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
+		);
+	}
+
+	private function flow_artifact_payload( array $flow, string $portable_slug ): array {
+		return array(
+			'portable_slug'      => $portable_slug,
+			'flow_name'          => (string) ( $flow['flow_name'] ?? '' ),
+			'flow_config'        => $this->flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
+			'scheduling_policy'  => 'create_paused_upgrade_preserve_existing',
+			'queue_policy'       => 'create_seed_upgrade_preserve_existing',
+		);
+	}
+
+	private function artifact_has_local_modifications( ?array $record, array $current_payload ): bool {
+		if ( empty( $record['installed_hash'] ) ) {
+			return false;
+		}
+
+		return AgentBundleArtifactStatus::MODIFIED === AgentBundleArtifactStatus::classify(
+			(string) $record['installed_hash'],
+			AgentBundleArtifactHasher::hash( $current_payload )
+		);
+	}
+
+	private function bundle_artifact_record( array $bundle_metadata, string $type, string $id, string $source_path, array $payload ): array {
+		$hash = AgentBundleArtifactHasher::hash( $payload );
+		$now  = gmdate( 'c' );
+
+		return array(
+			'bundle_slug'    => $bundle_metadata['bundle_slug'],
+			'bundle_version' => $bundle_metadata['bundle_version'],
+			'artifact_type'  => $type,
+			'artifact_id'    => $id,
+			'source_path'    => $source_path,
+			'installed_hash' => $hash,
+			'current_hash'   => $hash,
+			'status'         => AgentBundleArtifactStatus::CLEAN,
+			'installed_at'   => $now,
+			'updated_at'     => $now,
+		);
+	}
+
+	private function preserve_runtime_queue_fields( array $incoming_flow_config, array $existing_flow_config ): array {
+		foreach ( $incoming_flow_config as $flow_step_id => &$step ) {
+			if ( ! is_array( $step ) || ! is_array( $existing_flow_config[ $flow_step_id ] ?? null ) ) {
+				continue;
+			}
+			foreach ( array( 'prompt_queue', 'config_patch_queue', 'queue_mode' ) as $field ) {
+				if ( array_key_exists( $field, $existing_flow_config[ $flow_step_id ] ) ) {
+					$step[ $field ] = $existing_flow_config[ $flow_step_id ][ $field ];
+				}
+			}
+		}
+		unset( $step );
+
+		return $incoming_flow_config;
+	}
+
+	private function flow_config_without_runtime_queues( array $flow_config ): array {
+		foreach ( $flow_config as &$step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+			unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'] );
+		}
+		unset( $step );
+
+		return $flow_config;
 	}
 
 	/**

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -126,11 +126,11 @@ class AgentBundler {
 		$bundle['flows'] = array();
 
 		foreach ( $flows as $flow ) {
-			$flow_id   = (int) $flow['flow_id'];
+			$flow_id       = (int) $flow['flow_id'];
 			$portable_slug = ! empty( $flow['portable_slug'] )
 				? $flow['portable_slug']
 				: PortableSlug::normalize( (string) $flow['flow_name'], 'flow' );
-			$flow_data = array(
+			$flow_data     = array(
 				'original_id'          => $flow_id,
 				'original_pipeline_id' => (int) $flow['pipeline_id'],
 				'portable_slug'        => $portable_slug,
@@ -190,7 +190,7 @@ class AgentBundler {
 			'source_ref'      => $bundle_source_ref,
 			'source_revision' => $bundle_source_revision,
 		);
-		$is_portable_bundle = ! empty( $bundle['bundle_slug'] ) || $this->bundle_has_portable_artifacts( $bundle );
+		$is_portable_bundle     = ! empty( $bundle['bundle_slug'] ) || $this->bundle_has_portable_artifacts( $bundle );
 
 		// Check for slug collision.
 		$existing = $this->agents_repo->get_by_slug( $slug );
@@ -254,13 +254,17 @@ class AgentBundler {
 
 		// 1. Create or update the agent record.
 		$incoming_config = $agent_data['agent_config'] ?? array();
+
 		$incoming_config = is_array( $incoming_config ) ? $incoming_config : array();
-		$config          = is_array( $existing['agent_config'] ?? null )
+
+		$config = is_array( $existing['agent_config'] ?? null )
 			? array_merge( $existing['agent_config'], $incoming_config )
 			: $incoming_config;
+
 		$existing_bundle_state = is_array( $existing['agent_config']['datamachine_bundle'] ?? null )
 			? $existing['agent_config']['datamachine_bundle']
 			: array();
+
 		$config['datamachine_bundle'] = array_merge(
 			$existing_bundle_state,
 			$bundle_metadata,
@@ -322,7 +326,7 @@ class AgentBundler {
 					$this->pipeline_artifact_payload( $existing_pipeline, $portable_slug )
 				)
 			) {
-				$conflicts[] = array(
+				$conflicts[]                = array(
 					'artifact_type' => 'pipeline',
 					'artifact_id'   => $portable_slug,
 					'reason'        => 'local_modified',
@@ -352,7 +356,7 @@ class AgentBundler {
 			}
 
 			if ( $new_pipeline_id ) {
-				$pipeline_id_map[ $old_id ] = (int) $new_pipeline_id;
+				$pipeline_id_map[ $old_id ]        = (int) $new_pipeline_id;
 				$artifact_records[ $artifact_key ] = $this->bundle_artifact_record(
 					$bundle_metadata,
 					'pipeline',
@@ -503,11 +507,11 @@ class AgentBundler {
 
 	private function flow_artifact_payload( array $flow, string $portable_slug ): array {
 		return array(
-			'portable_slug'      => $portable_slug,
-			'flow_name'          => (string) ( $flow['flow_name'] ?? '' ),
-			'flow_config'        => $this->flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
-			'scheduling_policy'  => 'create_paused_upgrade_preserve_existing',
-			'queue_policy'       => 'create_seed_upgrade_preserve_existing',
+			'portable_slug'     => $portable_slug,
+			'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
+			'flow_config'       => $this->flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
+			'scheduling_policy' => 'create_paused_upgrade_preserve_existing',
+			'queue_policy'      => 'create_seed_upgrade_preserve_existing',
 		);
 	}
 
@@ -590,9 +594,6 @@ class AgentBundler {
 				$files[ $filename ] = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			}
 		}
-
-
-
 		return $files;
 	}
 
@@ -923,6 +924,7 @@ class AgentBundler {
 		try {
 			return AgentBundleLegacyAdapter::to_legacy_bundle( AgentBundleDirectory::read( $directory ) );
 		} catch ( BundleValidationException $e ) {
+			unset( $e );
 			// Fall through to the legacy monolithic manifest reader for old exports.
 		}
 

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -308,7 +308,7 @@ class Flows extends BaseRepository {
 	 * @return string|null Raw JSON string, or null when the flow is missing.
 	 */
 	public function get_flow_config_json( int $flow_id ): ?string {
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 		$value = $this->wpdb->get_var(
 			$this->wpdb->prepare(
 				'SELECT flow_config FROM %i WHERE flow_id = %d',
@@ -316,6 +316,7 @@ class Flows extends BaseRepository {
 				$flow_id
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		return null === $value ? null : (string) $value;
 	}
@@ -334,8 +335,7 @@ class Flows extends BaseRepository {
 	public function compare_and_swap_flow_config( int $flow_id, string $expected_config_json, array $new_flow_config ): bool {
 		$new_config_json = wp_json_encode( $new_flow_config );
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$result = $this->wpdb->query(
 			$this->wpdb->prepare(
 				'UPDATE %i SET flow_config = %s WHERE flow_id = %d AND flow_config = %s',
@@ -345,7 +345,7 @@ class Flows extends BaseRepository {
 				$expected_config_json
 			)
 		);
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( false === $result ) {
 			do_action(

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -271,6 +271,37 @@ class Flows extends BaseRepository {
 	}
 
 	/**
+	 * Get a flow by stable bundle portable slug within a pipeline.
+	 */
+	public function get_by_portable_slug( int $pipeline_id, string $portable_slug ): ?array {
+		$portable_slug = sanitize_title( $portable_slug );
+		if ( $pipeline_id <= 0 || '' === $portable_slug ) {
+			return null;
+		}
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$flow = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				'SELECT * FROM %i WHERE pipeline_id = %d AND portable_slug = %s LIMIT 1',
+				$this->table_name,
+				$pipeline_id,
+				$portable_slug
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( ! $flow ) {
+			return null;
+		}
+
+		$flow['flow_config']       = json_decode( $flow['flow_config'], true ) ?? array();
+		$flow['scheduling_config'] = json_decode( $flow['scheduling_config'], true ) ?? array();
+
+		return $flow;
+	}
+
+	/**
 	 * Get the raw flow_config JSON blob for compare-and-swap updates.
 	 *
 	 * @param int $flow_id Flow ID.
@@ -728,6 +759,14 @@ class Flows extends BaseRepository {
 		if ( isset( $flow_data['scheduling_config'] ) ) {
 			$update_data['scheduling_config'] = wp_json_encode( $flow_data['scheduling_config'] );
 			$update_formats[]                 = '%s';
+		}
+
+		if ( isset( $flow_data['portable_slug'] ) ) {
+			$portable_slug = sanitize_title( (string) $flow_data['portable_slug'] );
+			if ( '' !== $portable_slug ) {
+				$update_data['portable_slug'] = $portable_slug;
+				$update_formats[]             = '%s';
+			}
 		}
 
 		if ( empty( $update_data ) ) {

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -115,6 +115,38 @@ class Pipelines extends BaseRepository {
 	}
 
 	/**
+	 * Get a pipeline by stable bundle portable slug for an agent.
+	 */
+	public function get_by_portable_slug( int $agent_id, string $portable_slug ): ?array {
+		$portable_slug = sanitize_title( $portable_slug );
+		if ( $agent_id <= 0 || '' === $portable_slug ) {
+			return null;
+		}
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$pipeline = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				'SELECT * FROM %i WHERE agent_id = %d AND portable_slug = %s LIMIT 1',
+				$this->table_name,
+				$agent_id,
+				$portable_slug
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( ! $pipeline ) {
+			return null;
+		}
+
+		if ( ! empty( $pipeline['pipeline_config'] ) ) {
+			$pipeline['pipeline_config'] = json_decode( $pipeline['pipeline_config'], true ) ?? array();
+		}
+
+		return $pipeline;
+	}
+
+	/**
 	 * Get all pipelines from the database.
 	 *
 	 * When $per_page is a positive integer, results are paginated at the SQL layer.
@@ -242,6 +274,14 @@ class Pipelines extends BaseRepository {
 		if ( isset( $pipeline_data['pipeline_config'] ) ) {
 			$update_data['pipeline_config'] = wp_json_encode( $pipeline_data['pipeline_config'] );
 			$format[]                       = '%s';
+		}
+
+		if ( isset( $pipeline_data['portable_slug'] ) ) {
+			$portable_slug = sanitize_title( (string) $pipeline_data['portable_slug'] );
+			if ( '' !== $portable_slug ) {
+				$update_data['portable_slug'] = $portable_slug;
+				$format[]                     = '%s';
+			}
 		}
 
 		// Always update the updated_at timestamp

--- a/inc/Engine/Bundle/AgentBundleLegacyAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleLegacyAdapter.php
@@ -88,6 +88,7 @@ final class AgentBundleLegacyAdapter {
 
 			$pipelines[] = array(
 				'original_id'           => $pipeline_id,
+				'portable_slug'         => $slug,
 				'pipeline_name'         => $pipeline['name'],
 				'pipeline_config'       => $pipeline_config,
 				'memory_file_contents'  => self::strip_memory_prefix( $memory_files, 'pipelines/' . $slug . '/' ),
@@ -113,6 +114,7 @@ final class AgentBundleLegacyAdapter {
 			$flows[] = array(
 				'original_id'           => $flow_id,
 				'original_pipeline_id'  => $pipeline_id,
+				'portable_slug'         => $slug,
 				'flow_name'             => $flow['name'],
 				'flow_config'           => $flow_config,
 				'scheduling_config'     => array(
@@ -125,9 +127,13 @@ final class AgentBundleLegacyAdapter {
 		}
 
 		return array(
-			'bundle_version'     => 1,
-			'exported_at'        => $manifest['exported_at'],
-			'agent'              => array(
+			'bundle_version'        => $manifest['bundle_version'],
+			'bundle_slug'           => $manifest['bundle_slug'],
+			'source_ref'            => $manifest['source_ref'] ?? '',
+			'source_revision'       => $manifest['source_revision'] ?? '',
+			'bundle_schema_version' => BundleSchema::VERSION,
+			'exported_at'           => $manifest['exported_at'],
+			'agent'                 => array(
 				'agent_slug'   => $manifest['agent']['slug'],
 				'agent_name'   => $manifest['agent']['label'],
 				'agent_config' => $manifest['agent']['agent_config'],
@@ -146,7 +152,13 @@ final class AgentBundleLegacyAdapter {
 		$used  = array();
 		$slugs = array();
 		foreach ( $pipelines as $index => $pipeline ) {
-			$slug = PortableSlug::dedupe( PortableSlug::normalize( (string) ( $pipeline['pipeline_name'] ?? 'pipeline' ), 'pipeline' ), $used );
+			$slug = PortableSlug::dedupe(
+				PortableSlug::normalize(
+					(string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ),
+					'pipeline'
+				),
+				$used
+			);
 			$used[]          = $slug;
 			$slugs[ $index ] = $slug;
 		}
@@ -158,7 +170,13 @@ final class AgentBundleLegacyAdapter {
 		$used  = array();
 		$slugs = array();
 		foreach ( $flows as $index => $flow ) {
-			$slug = PortableSlug::dedupe( PortableSlug::normalize( (string) ( $flow['flow_name'] ?? 'flow' ), 'flow' ), $used );
+			$slug = PortableSlug::dedupe(
+				PortableSlug::normalize(
+					(string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ),
+					'flow'
+				),
+				$used
+			);
 			$used[]          = $slug;
 			$slugs[ $index ] = $slug;
 		}

--- a/inc/Engine/Bundle/AgentBundleLegacyAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleLegacyAdapter.php
@@ -75,9 +75,9 @@ final class AgentBundleLegacyAdapter {
 			$pipeline_ids[ $slug ] = $pipeline_id;
 			$pipeline_config       = array();
 			foreach ( $pipeline['steps'] as $step ) {
-				$position         = (int) $step['step_position'];
-				$pipeline_step_id = $pipeline_id . '_bundle_step_' . $position;
-				$step_config      = $step['step_config'];
+				$position                        = (int) $step['step_position'];
+				$pipeline_step_id                = $pipeline_id . '_bundle_step_' . $position;
+				$step_config                     = $step['step_config'];
 				$step_config['pipeline_step_id'] = $pipeline_step_id;
 				$step_config['step_type']        = $step['step_type'];
 				$step_config['execution_order']  = $position;
@@ -87,42 +87,42 @@ final class AgentBundleLegacyAdapter {
 			}
 
 			$pipelines[] = array(
-				'original_id'           => $pipeline_id,
-				'portable_slug'         => $slug,
-				'pipeline_name'         => $pipeline['name'],
-				'pipeline_config'       => $pipeline_config,
-				'memory_file_contents'  => self::strip_memory_prefix( $memory_files, 'pipelines/' . $slug . '/' ),
+				'original_id'          => $pipeline_id,
+				'portable_slug'        => $slug,
+				'pipeline_name'        => $pipeline['name'],
+				'pipeline_config'      => $pipeline_config,
+				'memory_file_contents' => self::strip_memory_prefix( $memory_files, 'pipelines/' . $slug . '/' ),
 			);
 		}
 
 		$flows = array();
 		foreach ( $directory->flows() as $index => $flow_file ) {
-			$flow_id = $index + 1;
-			$flow    = $flow_file->to_array();
-			$slug    = $flow['slug'];
+			$flow_id       = $index + 1;
+			$flow          = $flow_file->to_array();
+			$slug          = $flow['slug'];
 			$pipeline_slug = $flow['pipeline_slug'];
 			$pipeline_id   = $pipeline_ids[ $pipeline_slug ] ?? 0;
 
 			$flow_config = array();
 			foreach ( $flow['steps'] as $step ) {
-				$position         = (int) $step['step_position'];
-				$pipeline_step_id = $pipeline_keys[ $pipeline_slug ][ $position ] ?? ( $pipeline_id . '_bundle_step_' . $position );
-				$flow_step_id     = $pipeline_step_id . '_' . $flow_id;
+				$position                     = (int) $step['step_position'];
+				$pipeline_step_id             = $pipeline_keys[ $pipeline_slug ][ $position ] ?? ( $pipeline_id . '_bundle_step_' . $position );
+				$flow_step_id                 = $pipeline_step_id . '_' . $flow_id;
 				$flow_config[ $flow_step_id ] = self::flow_step_config_from_document_step( $step, $pipeline_id, $flow_id, $pipeline_step_id, $flow_step_id );
 			}
 
 			$flows[] = array(
-				'original_id'           => $flow_id,
-				'original_pipeline_id'  => $pipeline_id,
-				'portable_slug'         => $slug,
-				'flow_name'             => $flow['name'],
-				'flow_config'           => $flow_config,
-				'scheduling_config'     => array(
+				'original_id'          => $flow_id,
+				'original_pipeline_id' => $pipeline_id,
+				'portable_slug'        => $slug,
+				'flow_name'            => $flow['name'],
+				'flow_config'          => $flow_config,
+				'scheduling_config'    => array(
 					'enabled'   => false,
 					'interval'  => $flow['schedule'],
 					'max_items' => $flow['max_items'],
 				),
-				'memory_file_contents'  => self::strip_memory_prefix( $memory_files, 'flows/' . $slug . '/' ),
+				'memory_file_contents' => self::strip_memory_prefix( $memory_files, 'flows/' . $slug . '/' ),
 			);
 		}
 
@@ -139,11 +139,11 @@ final class AgentBundleLegacyAdapter {
 				'agent_config' => $manifest['agent']['agent_config'],
 				'site_scope'   => 'site',
 			),
-			'files'              => self::strip_memory_prefix( $memory_files, 'agent/' ),
-			'user_template'      => $memory_files['USER.md'] ?? '',
-			'pipelines'          => $pipelines,
-			'flows'              => $flows,
-			'abilities_manifest' => array(),
+			'files'                 => self::strip_memory_prefix( $memory_files, 'agent/' ),
+			'user_template'         => $memory_files['USER.md'] ?? '',
+			'pipelines'             => $pipelines,
+			'flows'                 => $flows,
+			'abilities_manifest'    => array(),
 		);
 	}
 
@@ -152,7 +152,7 @@ final class AgentBundleLegacyAdapter {
 		$used  = array();
 		$slugs = array();
 		foreach ( $pipelines as $index => $pipeline ) {
-			$slug = PortableSlug::dedupe(
+			$slug            = PortableSlug::dedupe(
 				PortableSlug::normalize(
 					(string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ),
 					'pipeline'
@@ -170,7 +170,7 @@ final class AgentBundleLegacyAdapter {
 		$used  = array();
 		$slugs = array();
 		foreach ( $flows as $index => $flow ) {
-			$slug = PortableSlug::dedupe(
+			$slug            = PortableSlug::dedupe(
 				PortableSlug::normalize(
 					(string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ),
 					'flow'
@@ -231,10 +231,11 @@ final class AgentBundleLegacyAdapter {
 	}
 
 	private static function flow_files_from_legacy( array $flows, array $pipelines, array $pipeline_slugs, array $flow_slugs ): array {
-		$pipeline_slugs_by_id = array();
+		$pipeline_slugs_by_id      = array();
 		$pipeline_step_types_by_id = array();
 		foreach ( $pipelines as $index => $pipeline ) {
 			$original_id = (int) ( $pipeline['original_id'] ?? ( $index + 1 ) );
+
 			$pipeline_slugs_by_id[ $original_id ] = $pipeline_slugs[ $index ] ?? PortableSlug::normalize( (string) ( $pipeline['pipeline_name'] ?? 'pipeline' ), 'pipeline' );
 			foreach ( $pipeline['pipeline_config'] ?? array() as $pipeline_step_id => $pipeline_step ) {
 				if ( is_array( $pipeline_step ) ) {
@@ -245,9 +246,10 @@ final class AgentBundleLegacyAdapter {
 
 		$files = array();
 		foreach ( $flows as $index => $flow ) {
-			$old_pipeline_id = (int) ( $flow['original_pipeline_id'] ?? 0 );
-			$pipeline_slug   = $pipeline_slugs_by_id[ $old_pipeline_id ] ?? reset( $pipeline_slugs ) ?: 'pipeline';
-			$scheduling      = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
+			$old_pipeline_id       = (int) ( $flow['original_pipeline_id'] ?? 0 );
+			$default_pipeline_slug = reset( $pipeline_slugs );
+			$pipeline_slug         = $pipeline_slugs_by_id[ $old_pipeline_id ] ?? ( $default_pipeline_slug ? $default_pipeline_slug : 'pipeline' );
+			$scheduling            = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
 
 			$files[] = new AgentBundleFlowFile(
 				$flow_slugs[ $index ] ?? (string) ( $flow['flow_name'] ?? 'flow' ),
@@ -284,7 +286,7 @@ final class AgentBundleLegacyAdapter {
 				continue;
 			}
 			$pipeline_step_id = (string) ( $step['pipeline_step_id'] ?? '' );
-			$document_step = array(
+			$document_step    = array(
 				'step_position'   => (int) ( $step['execution_order'] ?? count( $steps ) ),
 				'handler_configs' => self::handler_configs_from_step( $step ),
 			);

--- a/tests/agent-bundle-portable-update-smoke.php
+++ b/tests/agent-bundle-portable-update-smoke.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Pure-PHP smoke test for portable bundle update semantics (#1534/#1539).
+ *
+ * Run with: php tests/agent-bundle-portable-update-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		$title = strtolower( (string) $title );
+		$title = preg_replace( '/[^a-z0-9]+/', '-', $title );
+		return trim( (string) $title, '-' );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook = '' ) {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		// no-op
+	}
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use DataMachine\Core\Agents\AgentBundler;
+use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
+use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\AgentBundleLegacyAdapter;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
+use DataMachine\Engine\Bundle\AgentBundleFlowFile;
+
+$failures = array();
+$passes   = 0;
+
+function assert_bundle_update( string $label, bool $condition ): void {
+	global $failures, $passes;
+	if ( $condition ) {
+		++$passes;
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	$failures[] = $label;
+	echo "  FAIL: {$label}\n";
+}
+
+function assert_bundle_update_equals( string $label, $expected, $actual ): void {
+	assert_bundle_update( $label, $expected === $actual );
+}
+
+function call_bundle_private( AgentBundler $bundler, string $method, array $args = array() ) {
+	$reflection = new ReflectionMethod( AgentBundler::class, $method );
+	return $reflection->invokeArgs( $bundler, $args );
+}
+
+echo "=== Agent Bundle Portable Update Smoke (#1534/#1539) ===\n";
+
+$manifest = AgentBundleManifest::from_array(
+	array(
+		'schema_version'  => 1,
+		'bundle_slug'     => 'Woo Brain',
+		'bundle_version'  => '2026.04.28',
+		'exported_at'     => '2026-04-28T00:00:00Z',
+		'exported_by'     => 'data-machine/test',
+		'agent'           => array(
+			'slug'         => 'woo-agent',
+			'label'        => 'Woo Agent',
+			'description'  => 'Maintains WooCommerce knowledge.',
+			'agent_config' => array(),
+		),
+		'included'        => array(
+			'memory'       => array(),
+			'pipelines'    => array( 'daily-ingest' ),
+			'flows'        => array( 'daily-ingest-flow' ),
+			'handler_auth' => 'refs',
+		),
+	)
+);
+
+$directory = new AgentBundleDirectory(
+	$manifest,
+	array(),
+	array(
+		new AgentBundlePipelineFile(
+			'Daily Ingest',
+			'Daily ingest',
+			array(
+				array(
+					'step_position' => 0,
+					'step_type'     => 'fetch',
+					'step_config'   => array( 'label' => 'Fetch' ),
+				),
+			)
+		),
+	),
+	array(
+		new AgentBundleFlowFile(
+			'Daily Ingest Flow',
+			'Daily ingest flow',
+			'Daily Ingest',
+			'daily',
+			array( 'mcp' => 5 ),
+			array(
+				array(
+					'step_position'       => 0,
+					'handler_slug'        => 'mcp',
+					'handler_config'      => array( 'provider' => 'mgs' ),
+					'handler_configs'     => array( 'mcp' => array( 'provider' => 'mgs' ) ),
+					'config_patch_queue'  => array( array( 'query' => 'WooCommerce' ) ),
+					'queue_mode'          => 'loop',
+				)
+			)
+		),
+	)
+);
+
+$legacy_bundle = AgentBundleLegacyAdapter::to_legacy_bundle( $directory );
+assert_bundle_update_equals( 'directory adapter preserves bundle slug for updater', 'woo-brain', $legacy_bundle['bundle_slug'] ?? null );
+assert_bundle_update_equals( 'directory adapter preserves semantic bundle version', '2026.04.28', $legacy_bundle['bundle_version'] ?? null );
+assert_bundle_update_equals( 'pipeline carries portable slug into legacy importer', 'daily-ingest', $legacy_bundle['pipelines'][0]['portable_slug'] ?? null );
+assert_bundle_update_equals( 'flow carries portable slug into legacy importer', 'daily-ingest-flow', $legacy_bundle['flows'][0]['portable_slug'] ?? null );
+
+$bundler_reflection = new ReflectionClass( AgentBundler::class );
+$bundler            = $bundler_reflection->newInstanceWithoutConstructor();
+
+$pipeline_payload = call_bundle_private(
+	$bundler,
+	'pipeline_artifact_payload',
+	array(
+		array(
+			'pipeline_name'   => 'Daily ingest',
+			'pipeline_config' => array( 'step-1' => array( 'step_type' => 'fetch' ) ),
+		),
+		'daily-ingest',
+	)
+);
+$installed_hash = AgentBundleArtifactHasher::hash( $pipeline_payload );
+$record         = array( 'installed_hash' => $installed_hash );
+
+assert_bundle_update( 'clean artifact is safe to update in place', ! call_bundle_private( $bundler, 'artifact_has_local_modifications', array( $record, $pipeline_payload ) ) );
+assert_bundle_update( 'changed artifact is detected as local modification', call_bundle_private( $bundler, 'artifact_has_local_modifications', array( $record, array_merge( $pipeline_payload, array( 'pipeline_name' => 'Locally edited' ) ) ) ) );
+assert_bundle_update_equals( 'artifact classifier labels changed payload modified', AgentBundleArtifactStatus::MODIFIED, AgentBundleArtifactStatus::classify( $installed_hash, AgentBundleArtifactHasher::hash( array_merge( $pipeline_payload, array( 'pipeline_name' => 'Locally edited' ) ) ) ) );
+
+$incoming_flow_config = array(
+	'flow-step-1' => array(
+		'handler_slug'       => 'mcp',
+		'handler_config'     => array( 'provider' => 'mgs', 'query' => 'New seed' ),
+		'config_patch_queue' => array( array( 'query' => 'New seed' ) ),
+		'queue_mode'         => 'drain',
+	),
+);
+$existing_flow_config = array(
+	'flow-step-1' => array(
+		'config_patch_queue' => array( array( 'query' => 'Local queue head' ) ),
+		'queue_mode'         => 'static',
+	),
+);
+$preserved = call_bundle_private( $bundler, 'preserve_runtime_queue_fields', array( $incoming_flow_config, $existing_flow_config ) );
+assert_bundle_update_equals( 'upgrade preserves existing config_patch_queue', 'Local queue head', $preserved['flow-step-1']['config_patch_queue'][0]['query'] ?? null );
+assert_bundle_update_equals( 'upgrade preserves existing queue_mode', 'static', $preserved['flow-step-1']['queue_mode'] ?? null );
+
+$agent_bundler_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Agents/AgentBundler.php' ) ?: '';
+$pipelines_source     = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Pipelines/Pipelines.php' ) ?: '';
+$flows_source         = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Flows/Flows.php' ) ?: '';
+assert_bundle_update( 'importer resolves existing pipelines by portable slug', str_contains( $agent_bundler_source, 'get_by_portable_slug( $agent_id, $portable_slug )' ) );
+assert_bundle_update( 'importer updates existing pipelines instead of duplicating', str_contains( $agent_bundler_source, 'update_pipeline(' ) );
+assert_bundle_update( 'importer resolves existing flows by portable slug', str_contains( $agent_bundler_source, 'get_by_portable_slug( (int) $new_pipeline_id, $portable_slug )' ) );
+assert_bundle_update( 'importer updates existing flows instead of duplicating', str_contains( $agent_bundler_source, 'update_flow(' ) );
+assert_bundle_update( 'pipelines repository exposes portable slug lookup', str_contains( $pipelines_source, 'function get_by_portable_slug' ) );
+assert_bundle_update( 'flows repository exposes portable slug lookup', str_contains( $flows_source, 'function get_by_portable_slug' ) );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAILED: " . count( $failures ) . " portable update assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} portable update assertions passed.\n";


### PR DESCRIPTION
## Summary
- Adds portable-slug lookup/update paths for bundle-installed pipelines and flows so re-importing the same bundle updates clean runtime rows instead of duplicating them.
- Tracks installed bundle artifacts in the owning agent config with deterministic hashes, conflict detection, and conservative queue/schedule preservation semantics.
- Documents the update policy and adds a focused smoke test for portable bundle re-import behavior.

## Changes
- Resolve pipelines by `(agent_id, portable_slug)` and flows by `(pipeline_id, portable_slug)` during bundle import.
- Preserve runtime queue state and existing schedules on upgrade, while installing new flows paused/manual with the source schedule retained as `_original_interval`.
- Preserve bundle metadata and portable slugs through the legacy directory adapter.
- Record clean installed pipeline/flow artifacts under `agent_config.datamachine_bundle.artifacts` and report locally modified artifacts as import conflicts.

## Tests
- `php tests/agent-bundle-portable-update-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php tests/agent-bundle-installed-artifact-smoke.php`
- `php tests/import-export-portable-flow-settings-smoke.php`
- `php -l inc/Core/Agents/AgentBundler.php && php -l inc/Core/Database/Pipelines/Pipelines.php && php -l inc/Core/Database/Flows/Flows.php && php -l inc/Engine/Bundle/AgentBundleLegacyAdapter.php && php -l tests/agent-bundle-portable-update-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@feat-bundle-pipeline-update-cli --changed-since origin/main`

## Tooling notes
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-bundle-pipeline-update-cli --changed-since origin/main` reports `PHPCS linting passed` and `No change from baseline`, then exits non-zero because scoped ESLint is handed changed PHP/Markdown files and tries to parse them. Tracked upstream in Extra-Chill/homeboy-extensions#325.
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@feat-bundle-pipeline-update-cli --changed-since origin/main` still hits the existing broad WP test-harness/registration failure mode: 1209 tests selected, 197 errors, 174 failures. Focused bundle smokes above pass.

## Follow-ups
- Add the `wp datamachine agent-bundle list/status/diff/upgrade/apply` CLI surface once upgrade planning has a PendingAction-backed apply path.
- Move installed artifact records from agent config into persistent DB storage when the planner needs richer querying.

Closes #1534.
Refs #1539.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing the portable bundle update semantics, smoke coverage, docs, and PR text. Chris remains responsible for review and merge decisions.