### PR TITLE
feat(bundle): add portable bundle upgrade CLI

### DIFF
--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -91,9 +91,22 @@ Schedule and queue policy is intentionally conservative:
 - Existing flow schedules are preserved during upgrades.
 - Queue slots (`prompt_queue`, `config_patch_queue`, `queue_mode`) seed new flows but are preserved on upgrades so runtime backlogs are not discarded.
 
+## CLI
+
+Bundle operations live under `wp datamachine agent-bundle`:
+
+- `install <path>` imports a local bundle path (`.zip`, `.json`, or directory).
+- `list` reports installed bundle-backed agents.
+- `status <slug>` reports installed version and tracked artifact state by agent slug or bundle slug.
+- `diff <path>` builds a read-only upgrade plan.
+- `upgrade <path>` applies clean updates and stages locally modified artifacts as PendingActions.
+- `apply <pending_action_id>` accepts a staged bundle PendingAction.
+
+Every read/preview command supports `--format=json` for automation.
+
 ## Follow-Ups
 
 - Add persistent DB storage for installed artifact records.
 - Wire importer/exporter paths for prompts, rubrics, tool policies, auth refs, and seed queues.
 - Use artifact statuses during bundle upgrade planning: auto-update `clean`, stage PendingActions for `modified`, surface `missing` and `orphaned` explicitly.
-- Add `wp datamachine agent-bundle list/status/diff/upgrade/apply` once the planner has a PendingAction-backed apply surface.
+- Add registered bundle sources once bundles move beyond local paths.

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -27,6 +27,7 @@ WP_CLI::add_command( 'datamachine posts', Commands\PostsCommand::class );
 WP_CLI::add_command( 'datamachine logs', Commands\LogsCommand::class );
 WP_CLI::add_command( 'datamachine agent', Commands\AgentsCommand::class );
 WP_CLI::add_command( 'datamachine agents', Commands\AgentsCommand::class );
+WP_CLI::add_command( 'datamachine agent-bundle', Commands\AgentBundleCommand::class );
 
 // Canonical home for agent memory-file operations.
 WP_CLI::add_command( 'datamachine memory', Commands\MemoryCommand::class );

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -1,0 +1,554 @@
+<?php
+/**
+ * Agent bundle WP-CLI command.
+ *
+ * @package DataMachine\Cli\Commands
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Core\Agents\AgentBundler;
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
+use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
+use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
+use DataMachine\Engine\Bundle\PortableSlug;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Install, inspect, and upgrade portable agent bundles.
+ */
+class AgentBundleCommand extends BaseCommand {
+
+	/**
+	 * Install a bundle from a local file or directory.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <path>
+	 * : Bundle path (.zip, .json, or directory).
+	 *
+	 * [--slug=<slug>]
+	 * : Override target agent slug.
+	 *
+	 * [--owner=<user>]
+	 * : Owner WordPress user ID, login, or email.
+	 *
+	 * [--dry-run]
+	 * : Preview the install without writing.
+	 *
+	 * [--yes]
+	 * : Skip confirmation.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function install( array $args, array $assoc_args ): void {
+		$this->run_install( $args, $assoc_args );
+	}
+
+	/**
+	 * List installed agent bundles.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - count
+	 * ---
+	 * @subcommand list
+	 */
+	public function list_( array $args, array $assoc_args ): void {
+		unset( $args );
+
+		$items = array();
+		foreach ( $this->agents()->get_all() as $agent ) {
+			$bundle = $agent['agent_config']['datamachine_bundle'] ?? array();
+			if ( empty( $bundle['bundle_slug'] ) ) {
+				continue;
+			}
+
+			$items[] = array(
+				'agent_id'       => (int) $agent['agent_id'],
+				'agent_slug'     => (string) $agent['agent_slug'],
+				'bundle_slug'    => (string) $bundle['bundle_slug'],
+				'bundle_version' => (string) ( $bundle['bundle_version'] ?? '' ),
+				'artifacts'      => count( is_array( $bundle['artifacts'] ?? null ) ? $bundle['artifacts'] : array() ),
+			);
+		}
+
+		$this->format_items( $items, array( 'agent_id', 'agent_slug', 'bundle_slug', 'bundle_version', 'artifacts' ), $assoc_args, 'agent_id' );
+	}
+
+	/**
+	 * Show installed bundle status for an agent or bundle slug.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug>
+	 * : Agent slug or bundle slug.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function status( array $args, array $assoc_args ): void {
+		$agent = $this->resolve_installed_agent( (string) ( $args[0] ?? '' ) );
+		if ( ! $agent ) {
+			WP_CLI::error( 'Installed bundle not found.' );
+			return;
+		}
+
+		$status = $this->installed_status( $agent );
+		$this->output( $status, $assoc_args, array( 'agent_id', 'agent_slug', 'bundle_slug', 'bundle_version', 'artifact_count' ) );
+	}
+
+	/**
+	 * Show an upgrade diff for a bundle path.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <path>
+	 * : Bundle path (.zip, .json, or directory).
+	 *
+	 * [--slug=<slug>]
+	 * : Override target agent slug.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function diff( array $args, array $assoc_args ): void {
+		$bundle = $this->load_bundle_arg( $args );
+		$plan   = $this->plan_for_bundle( $bundle, (string) ( $assoc_args['slug'] ?? '' ) )->to_array();
+		$this->output_plan( $plan, $assoc_args );
+	}
+
+	/**
+	 * Upgrade an installed bundle.
+	 *
+	 * Clean artifacts are applied through the importer. Approval-required changes
+	 * are staged as PendingActions.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <path>
+	 * : Bundle path (.zip, .json, or directory).
+	 *
+	 * [--slug=<slug>]
+	 * : Override target agent slug.
+	 *
+	 * [--owner=<user>]
+	 * : Owner WordPress user ID, login, or email.
+	 *
+	 * [--dry-run]
+	 * : Preview the upgrade without writing.
+	 *
+	 * [--yes]
+	 * : Skip confirmation.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function upgrade( array $args, array $assoc_args ): void {
+		$bundle  = $this->load_bundle_arg( $args );
+		$slug    = (string) ( $assoc_args['slug'] ?? '' );
+		$plan    = $this->plan_for_bundle( $bundle, $slug );
+		$dry_run = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+
+		if ( $dry_run ) {
+			$this->output_plan( $plan->to_array(), $assoc_args );
+			return;
+		}
+
+		if ( ! isset( $assoc_args['yes'] ) ) {
+			WP_CLI::confirm( 'Apply clean bundle artifact updates now?' );
+		}
+
+		$owner_id = isset( $assoc_args['owner'] ) ? $this->resolve_user_id( $assoc_args['owner'] ) : 0;
+		$result   = $this->bundler()->import( $bundle, '' !== $slug ? $slug : null, $owner_id, false );
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( (string) ( $result['error'] ?? 'Bundle upgrade failed.' ) );
+			return;
+		}
+
+		$response = array(
+			'success' => true,
+			'import'  => $result,
+			'plan'    => $plan->to_array(),
+		);
+
+		if ( $plan->has_pending_approval() ) {
+			$agent      = $this->resolve_bundle_agent( $bundle, $slug );
+			$pending    = AgentBundleUpgradePendingAction::stage(
+				$plan,
+				array(
+					'bundle'           => $this->bundle_summary( $bundle, $slug ),
+					'target_artifacts' => $this->bundle_artifacts( $bundle ),
+					'summary'          => 'Review locally modified bundle artifacts before applying.',
+					'agent_id'         => $agent ? (int) $agent['agent_id'] : 0,
+					'user_id'          => get_current_user_id(),
+				)
+			);
+			$response['pending_action'] = $pending;
+		}
+
+		$this->output( $response, $assoc_args, array( 'success' ) );
+	}
+
+	/**
+	 * Resolve a staged bundle PendingAction.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <pending_action_id>
+	 * : PendingAction ID to accept.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function apply( array $args, array $assoc_args ): void {
+		$action_id = sanitize_text_field( (string) ( $args[0] ?? '' ) );
+		if ( '' === $action_id ) {
+			WP_CLI::error( 'Pending action ID is required.' );
+			return;
+		}
+
+		$result = ResolvePendingActionAbility::execute(
+			array(
+				'action_id' => $action_id,
+				'decision'  => 'accepted',
+			)
+		);
+		$assoc_args['format'] = $assoc_args['format'] ?? 'json';
+		$this->output( $result, $assoc_args, array( 'success', 'action_id', 'kind' ) );
+	}
+
+	private function run_install( array $args, array $assoc_args ): void {
+		$bundle  = $this->load_bundle_arg( $args );
+		$slug    = isset( $assoc_args['slug'] ) ? sanitize_title( (string) $assoc_args['slug'] ) : null;
+		$owner   = isset( $assoc_args['owner'] ) ? $this->resolve_user_id( $assoc_args['owner'] ) : 0;
+		$dry_run = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+
+		if ( ! $dry_run && ! isset( $assoc_args['yes'] ) ) {
+			WP_CLI::confirm( sprintf( 'Install agent bundle "%s"?', $this->bundle_summary( $bundle, (string) $slug )['target_slug'] ) );
+		}
+
+		$result = $this->bundler()->import( $bundle, $slug, $owner, $dry_run );
+		$this->output( $result, $assoc_args, array( 'success', 'message' ) );
+	}
+
+	private function load_bundle_arg( array $args ): array {
+		$path = (string) ( $args[0] ?? '' );
+		if ( '' === $path || ! file_exists( $path ) ) {
+			WP_CLI::error( 'Bundle path not found.' );
+		}
+
+		$bundle = null;
+		if ( is_dir( $path ) ) {
+			$bundle = $this->bundler()->from_directory( $path );
+		} elseif ( preg_match( '/\.zip$/i', $path ) ) {
+			$bundle = $this->bundler()->from_zip( $path );
+		} elseif ( preg_match( '/\.json$/i', $path ) ) {
+			$bundle = $this->bundler()->from_json( (string) file_get_contents( $path ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		}
+
+		if ( ! is_array( $bundle ) ) {
+			WP_CLI::error( 'Failed to parse bundle. Use .zip, .json, or a bundle directory.' );
+		}
+
+		return $bundle;
+	}
+
+	private function plan_for_bundle( array $bundle, string $slug = '' ): \DataMachine\Engine\Bundle\AgentBundleUpgradePlan {
+		$agent = $this->resolve_bundle_agent( $bundle, $slug );
+		if ( ! $agent ) {
+			return AgentBundleUpgradePlanner::plan(
+				array(),
+				array(),
+				$this->bundle_artifacts( $bundle ),
+				$this->bundle_summary( $bundle, $slug )
+			);
+		}
+
+		$bundle_state = is_array( $agent['agent_config']['datamachine_bundle'] ?? null ) ? $agent['agent_config']['datamachine_bundle'] : array();
+		$installed    = array_values( is_array( $bundle_state['artifacts'] ?? null ) ? $bundle_state['artifacts'] : array() );
+
+		return AgentBundleUpgradePlanner::plan(
+			$installed,
+			$this->current_artifacts( $agent, $installed ),
+			$this->bundle_artifacts( $bundle ),
+			$this->bundle_summary( $bundle, $slug )
+		);
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function bundle_artifacts( array $bundle ): array {
+		$artifacts = array();
+		foreach ( $bundle['pipelines'] ?? array() as $pipeline ) {
+			if ( ! is_array( $pipeline ) ) {
+				continue;
+			}
+			$slug        = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
+			$artifacts[] = array(
+				'artifact_type' => 'pipeline',
+				'artifact_id'   => $slug,
+				'source_path'   => 'pipelines/' . $slug . '.json',
+				'payload'       => $this->pipeline_payload( $pipeline, $slug ),
+			);
+		}
+
+		foreach ( $bundle['flows'] ?? array() as $flow ) {
+			if ( ! is_array( $flow ) ) {
+				continue;
+			}
+			$slug        = PortableSlug::normalize( (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ), 'flow' );
+			$artifacts[] = array(
+				'artifact_type' => 'flow',
+				'artifact_id'   => $slug,
+				'source_path'   => 'flows/' . $slug . '.json',
+				'payload'       => $this->flow_payload( $flow, $slug ),
+			);
+		}
+
+		return $artifacts;
+	}
+
+	/** @param array<int,array<string,mixed>> $installed */
+	private function current_artifacts( array $agent, array $installed ): array {
+		$agent_id  = (int) $agent['agent_id'];
+		$artifacts = array();
+		$pipelines = $this->pipelines()->get_all_pipelines( null, $agent_id );
+		$flows     = $this->flows()->get_all_flows( null, $agent_id );
+
+		$pipeline_by_slug = array();
+		foreach ( $pipelines as $pipeline ) {
+			$slug = (string) ( $pipeline['portable_slug'] ?? '' );
+			if ( '' !== $slug ) {
+				$pipeline_by_slug[ $slug ] = $pipeline;
+			}
+		}
+
+		$flow_by_slug = array();
+		foreach ( $flows as $flow ) {
+			$slug = (string) ( $flow['portable_slug'] ?? '' );
+			if ( '' !== $slug ) {
+				$flow_by_slug[ $slug ] = $flow;
+			}
+		}
+
+		foreach ( $installed as $record ) {
+			$type = (string) ( $record['artifact_type'] ?? '' );
+			$id   = (string) ( $record['artifact_id'] ?? '' );
+			if ( 'pipeline' === $type && isset( $pipeline_by_slug[ $id ] ) ) {
+				$artifacts[] = array(
+					'artifact_type' => 'pipeline',
+					'artifact_id'   => $id,
+					'source_path'   => (string) ( $record['source_path'] ?? '' ),
+					'payload'       => $this->pipeline_payload( $pipeline_by_slug[ $id ], $id ),
+				);
+			}
+			if ( 'flow' === $type && isset( $flow_by_slug[ $id ] ) ) {
+				$artifacts[] = array(
+					'artifact_type' => 'flow',
+					'artifact_id'   => $id,
+					'source_path'   => (string) ( $record['source_path'] ?? '' ),
+					'payload'       => $this->flow_payload( $flow_by_slug[ $id ], $id ),
+				);
+			}
+		}
+
+		return $artifacts;
+	}
+
+	private function pipeline_payload( array $pipeline, string $portable_slug ): array {
+		return array(
+			'portable_slug'   => $portable_slug,
+			'pipeline_name'   => (string) ( $pipeline['pipeline_name'] ?? '' ),
+			'pipeline_config' => is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
+		);
+	}
+
+	private function flow_payload( array $flow, string $portable_slug ): array {
+		return array(
+			'portable_slug'     => $portable_slug,
+			'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
+			'flow_config'       => $this->flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
+			'scheduling_policy' => 'create_paused_upgrade_preserve_existing',
+			'queue_policy'      => 'create_seed_upgrade_preserve_existing',
+		);
+	}
+
+	private function flow_config_without_runtime_queues( array $flow_config ): array {
+		foreach ( $flow_config as &$step ) {
+			if ( is_array( $step ) ) {
+				unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'] );
+			}
+		}
+		unset( $step );
+
+		return $flow_config;
+	}
+
+	private function resolve_bundle_agent( array $bundle, string $slug = '' ): ?array {
+		$target = '' !== $slug ? sanitize_title( $slug ) : sanitize_title( (string) ( $bundle['agent']['agent_slug'] ?? '' ) );
+		if ( '' === $target ) {
+			return null;
+		}
+
+		return $this->agents()->get_by_slug( $target );
+	}
+
+	private function resolve_installed_agent( string $slug ): ?array {
+		$slug = sanitize_title( $slug );
+		if ( '' === $slug ) {
+			return null;
+		}
+
+		$agent = $this->agents()->get_by_slug( $slug );
+		if ( $agent && ! empty( $agent['agent_config']['datamachine_bundle']['bundle_slug'] ) ) {
+			return $agent;
+		}
+
+		foreach ( $this->agents()->get_all() as $candidate ) {
+			$bundle = $candidate['agent_config']['datamachine_bundle'] ?? array();
+			if ( $slug === sanitize_title( (string) ( $bundle['bundle_slug'] ?? '' ) ) ) {
+				return $candidate;
+			}
+		}
+
+		return null;
+	}
+
+	private function installed_status( array $agent ): array {
+		$bundle    = $agent['agent_config']['datamachine_bundle'] ?? array();
+		$artifacts = is_array( $bundle['artifacts'] ?? null ) ? $bundle['artifacts'] : array();
+
+		return array(
+			'agent_id'        => (int) $agent['agent_id'],
+			'agent_slug'      => (string) $agent['agent_slug'],
+			'bundle_slug'     => (string) ( $bundle['bundle_slug'] ?? '' ),
+			'bundle_version'  => (string) ( $bundle['bundle_version'] ?? '' ),
+			'source_ref'      => (string) ( $bundle['source_ref'] ?? '' ),
+			'source_revision' => (string) ( $bundle['source_revision'] ?? '' ),
+			'artifact_count'  => count( $artifacts ),
+			'artifacts'       => array_values( $artifacts ),
+		);
+	}
+
+	private function bundle_summary( array $bundle, string $slug = '' ): array {
+		$agent = is_array( $bundle['agent'] ?? null ) ? $bundle['agent'] : array();
+		return array(
+			'bundle_slug'    => (string) ( $bundle['bundle_slug'] ?? sanitize_title( (string) ( $agent['agent_slug'] ?? 'agent-bundle' ) ) ),
+			'bundle_version' => (string) ( $bundle['bundle_version'] ?? '' ),
+			'target_slug'    => '' !== $slug ? sanitize_title( $slug ) : sanitize_title( (string) ( $agent['agent_slug'] ?? '' ) ),
+			'pipelines'      => count( $bundle['pipelines'] ?? array() ),
+			'flows'          => count( $bundle['flows'] ?? array() ),
+		);
+	}
+
+	private function output_plan( array $plan, array $assoc_args ): void {
+		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
+			WP_CLI::line( wp_json_encode( $plan, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$counts = $plan['counts'] ?? array();
+		WP_CLI::log( sprintf( 'Auto-apply:     %d', (int) ( $counts['auto_apply'] ?? 0 ) ) );
+		WP_CLI::log( sprintf( 'Needs approval: %d', (int) ( $counts['needs_approval'] ?? 0 ) ) );
+		WP_CLI::log( sprintf( 'Warnings:       %d', (int) ( $counts['warnings'] ?? 0 ) ) );
+		WP_CLI::log( sprintf( 'No-op:          %d', (int) ( $counts['no_op'] ?? 0 ) ) );
+
+		$rows = array();
+		foreach ( array( 'auto_apply', 'needs_approval', 'warnings', 'no_op' ) as $bucket ) {
+			foreach ( $plan[ $bucket ] ?? array() as $entry ) {
+				$rows[] = array(
+					'bucket'        => $bucket,
+					'artifact_key'  => (string) ( $entry['artifact_key'] ?? '' ),
+					'reason'        => (string) ( $entry['reason'] ?? '' ),
+					'summary'       => (string) ( $entry['summary'] ?? '' ),
+				);
+			}
+		}
+
+		if ( $rows ) {
+			$this->format_items( $rows, array( 'bucket', 'artifact_key', 'reason', 'summary' ), array( 'format' => 'table' ) );
+		}
+	}
+
+	private function output( array $value, array $assoc_args, array $table_fields ): void {
+		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
+			WP_CLI::line( wp_json_encode( $value, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$this->format_items( array( $value ), $table_fields, array( 'format' => 'table' ) );
+	}
+
+	private function resolve_user_id( $value ): int {
+		if ( is_numeric( $value ) ) {
+			return (int) $value;
+		}
+		$user = is_email( $value ) ? get_user_by( 'email', $value ) : get_user_by( 'login', $value );
+		if ( ! $user ) {
+			WP_CLI::error( sprintf( 'User "%s" not found.', (string) $value ) );
+		}
+
+		return (int) $user->ID;
+	}
+
+	private function bundler(): AgentBundler {
+		return new AgentBundler();
+	}
+
+	private function agents(): Agents {
+		return new Agents();
+	}
+
+	private function pipelines(): Pipelines {
+		return new Pipelines();
+	}
+
+	private function flows(): Flows {
+		return new Flows();
+	}
+}

--- a/tests/agent-bundle-portable-update-smoke.php
+++ b/tests/agent-bundle-portable-update-smoke.php
@@ -192,12 +192,22 @@ assert_bundle_update_equals( 'upgrade preserves existing queue_mode', 'static', 
 $agent_bundler_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Agents/AgentBundler.php' ) ?: '';
 $pipelines_source     = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Pipelines/Pipelines.php' ) ?: '';
 $flows_source         = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Flows/Flows.php' ) ?: '';
+$bootstrap_source     = file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Bootstrap.php' ) ?: '';
+$bundle_cli_source    = file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/AgentBundleCommand.php' ) ?: '';
 assert_bundle_update( 'importer resolves existing pipelines by portable slug', str_contains( $agent_bundler_source, 'get_by_portable_slug( $agent_id, $portable_slug )' ) );
 assert_bundle_update( 'importer updates existing pipelines instead of duplicating', str_contains( $agent_bundler_source, 'update_pipeline(' ) );
 assert_bundle_update( 'importer resolves existing flows by portable slug', str_contains( $agent_bundler_source, 'get_by_portable_slug( (int) $new_pipeline_id, $portable_slug )' ) );
 assert_bundle_update( 'importer updates existing flows instead of duplicating', str_contains( $agent_bundler_source, 'update_flow(' ) );
 assert_bundle_update( 'pipelines repository exposes portable slug lookup', str_contains( $pipelines_source, 'function get_by_portable_slug' ) );
 assert_bundle_update( 'flows repository exposes portable slug lookup', str_contains( $flows_source, 'function get_by_portable_slug' ) );
+assert_bundle_update( 'agent-bundle CLI command is registered', str_contains( $bootstrap_source, "WP_CLI::add_command( 'datamachine agent-bundle', Commands\\AgentBundleCommand::class );" ) );
+assert_bundle_update( 'agent-bundle CLI exposes install command', str_contains( $bundle_cli_source, 'function install(' ) );
+assert_bundle_update( 'agent-bundle CLI exposes list command', str_contains( $bundle_cli_source, 'function list_(' ) );
+assert_bundle_update( 'agent-bundle CLI exposes status command', str_contains( $bundle_cli_source, 'function status(' ) );
+assert_bundle_update( 'agent-bundle CLI exposes diff command', str_contains( $bundle_cli_source, 'function diff(' ) );
+assert_bundle_update( 'agent-bundle CLI exposes upgrade command', str_contains( $bundle_cli_source, 'function upgrade(' ) );
+assert_bundle_update( 'agent-bundle CLI stages PendingActions for approval-required upgrades', str_contains( $bundle_cli_source, 'AgentBundleUpgradePendingAction::stage' ) );
+assert_bundle_update( 'agent-bundle CLI resolves staged apply actions', str_contains( $bundle_cli_source, 'ResolvePendingActionAbility::execute' ) );
 
 if ( ! empty( $failures ) ) {
 	echo "\nFAILED: " . count( $failures ) . " portable update assertions failed.\n";


### PR DESCRIPTION
## Summary
- Add stable `portable_slug` import/update semantics for bundle pipelines and flows.
- Preserve schedules and runtime queues during bundle upgrades while detecting locally modified artifacts.
- Add `wp datamachine agent-bundle` commands for install/list/status/diff/upgrade/apply with JSON output support.

## Tests
- `php -l inc/Cli/Commands/AgentBundleCommand.php && php -l inc/Cli/Bootstrap.php && php -l inc/Core/Agents/AgentBundler.php && php -l inc/Core/Database/Flows/Flows.php && php -l inc/Core/Database/Pipelines/Pipelines.php && php -l inc/Engine/Bundle/AgentBundleLegacyAdapter.php`
- `php tests/agent-bundle-portable-update-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@feat-bundle-pipeline-update-cli --changed-since origin/main`

## Notes
- Full `homeboy test` currently fails in the shared harness with broad ability-registration/test-infrastructure failures unrelated to this branch.
- Changed-scope `homeboy lint` hits the existing Homeboy ESLint scoping issue where PHP/Markdown files are passed to ESLint; PHPCS passed and Homeboy reported no baseline drift.

Closes #1534.
Closes #1539.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the portable bundle update semantics, CLI surface, smoke coverage, and verification. Chris remains responsible for review and merge.