### PR TITLE
fix(bundle): keep empty bundle list JSON parseable

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -217,8 +217,8 @@ class AgentBundleCommand extends BaseCommand {
 		);
 
 		if ( $plan->has_pending_approval() ) {
-			$agent      = $this->resolve_bundle_agent( $bundle, $slug );
-			$pending    = AgentBundleUpgradePendingAction::stage(
+			$agent                      = $this->resolve_bundle_agent( $bundle, $slug );
+			$pending                    = AgentBundleUpgradePendingAction::stage(
 				$plan,
 				array(
 					'bundle'           => $this->bundle_summary( $bundle, $slug ),
@@ -258,7 +258,7 @@ class AgentBundleCommand extends BaseCommand {
 			return;
 		}
 
-		$result = ResolvePendingActionAbility::execute(
+		$result               = ResolvePendingActionAbility::execute(
 			array(
 				'action_id' => $action_id,
 				'decision'  => 'accepted',
@@ -456,7 +456,7 @@ class AgentBundleCommand extends BaseCommand {
 
 		foreach ( $this->agents()->get_all() as $candidate ) {
 			$bundle = $candidate['agent_config']['datamachine_bundle'] ?? array();
-			if ( $slug === sanitize_title( (string) ( $bundle['bundle_slug'] ?? '' ) ) ) {
+			if ( sanitize_title( (string) ( $bundle['bundle_slug'] ?? '' ) ) === $slug ) {
 				return $candidate;
 			}
 		}
@@ -507,10 +507,10 @@ class AgentBundleCommand extends BaseCommand {
 		foreach ( array( 'auto_apply', 'needs_approval', 'warnings', 'no_op' ) as $bucket ) {
 			foreach ( $plan[ $bucket ] ?? array() as $entry ) {
 				$rows[] = array(
-					'bucket'        => $bucket,
-					'artifact_key'  => (string) ( $entry['artifact_key'] ?? '' ),
-					'reason'        => (string) ( $entry['reason'] ?? '' ),
-					'summary'       => (string) ( $entry['summary'] ?? '' ),
+					'bucket'       => $bucket,
+					'artifact_key' => (string) ( $entry['artifact_key'] ?? '' ),
+					'reason'       => (string) ( $entry['reason'] ?? '' ),
+					'summary'      => (string) ( $entry['summary'] ?? '' ),
 				);
 			}
 		}

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -94,6 +94,11 @@ class AgentBundleCommand extends BaseCommand {
 			);
 		}
 
+		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) && empty( $items ) ) {
+			WP_CLI::line( '[]' );
+			return;
+		}
+
 		$this->format_items( $items, array( 'agent_id', 'agent_slug', 'bundle_slug', 'bundle_version', 'artifacts' ), $assoc_args, 'agent_id' );
 	}
 


### PR DESCRIPTION
## Summary
- Return `[]` for `wp datamachine agent-bundle list --format=json` when no bundle-backed agents are installed.
- Preserve the human warning for empty table output.

## Tests
- `php -l inc/Cli/Commands/AgentBundleCommand.php`
- `php tests/agent-bundle-portable-update-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Caught the live JSON-output contract issue, made the small CLI fix, and ran focused verification. Chris remains responsible for review and merge.