### PR TITLE
fix(bundle): validate portable flow policy queues

### DIFF
--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -91,6 +91,14 @@ Schedule and queue policy is intentionally conservative:
 - Existing flow schedules are preserved during upgrades.
 - Queue slots (`prompt_queue`, `config_patch_queue`, `queue_mode`) seed new flows but are preserved on upgrades so runtime backlogs are not discarded.
 
+Portable flow-step policy fields are explicit in `flows/<flow-slug>.json`:
+
+- `enabled_tools`: flow-scoped AI allow-list consumed by `ToolPolicyResolver`.
+- `disabled_tools`: flow-scoped AI deny-list composed with pipeline-level disabled tools.
+- `prompt_queue`: AI seed queue entries shaped as `{ "prompt": "...", "added_at": "..." }`.
+- `config_patch_queue`: fetch seed queue entries shaped as `{ "patch": { ... }, "added_at": "..." }`.
+- `queue_mode`: one of `drain`, `loop`, or `static`; shared by both queue slots on that flow step.
+
 ## CLI
 
 Bundle operations live under `wp datamachine agent-bundle`:

--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -131,12 +131,17 @@ class ImportExport {
 				$settings['handler_slug'] = $row['handler'];
 			}
 
-			$this->restore_flow_step_config(
-				$imported_flow_id,
-				$pipeline_step_id,
-				$row['step_type'],
-				$settings
-			);
+			try {
+				$this->restore_flow_step_config(
+					$imported_flow_id,
+					$pipeline_step_id,
+					$row['step_type'],
+					$settings
+				);
+			} catch ( \InvalidArgumentException $e ) {
+				do_action( 'datamachine_log', 'error', 'Import: malformed portable flow-step settings: ' . $e->getMessage() );
+				return false;
+			}
 		}
 
 		// Ensure every imported pipeline has at least one flow (fallback for exports with
@@ -511,19 +516,90 @@ class ImportExport {
 		$normalized = array();
 
 		foreach ( array( 'enabled_tools', 'disabled_tools' ) as $field ) {
-			if ( isset( $source[ $field ] ) && is_array( $source[ $field ] ) ) {
-				$normalized[ $field ] = array_values( array_map( 'strval', $source[ $field ] ) );
+			if ( array_key_exists( $field, $source ) ) {
+				$normalized[ $field ] = $this->normalize_string_list_field( $field, $source[ $field ] );
 			}
 		}
 
-		foreach ( array( QueueAbility::SLOT_PROMPT_QUEUE, QueueAbility::SLOT_CONFIG_PATCH_QUEUE ) as $field ) {
-			if ( isset( $source[ $field ] ) && is_array( $source[ $field ] ) && array_is_list( $source[ $field ] ) ) {
-				$normalized[ $field ] = $source[ $field ];
-			}
+		if ( array_key_exists( QueueAbility::SLOT_PROMPT_QUEUE, $source ) ) {
+			$normalized[ QueueAbility::SLOT_PROMPT_QUEUE ] = $this->normalize_prompt_queue_field( $source[ QueueAbility::SLOT_PROMPT_QUEUE ] );
+		}
+
+		if ( array_key_exists( QueueAbility::SLOT_CONFIG_PATCH_QUEUE, $source ) ) {
+			$normalized[ QueueAbility::SLOT_CONFIG_PATCH_QUEUE ] = $this->normalize_config_patch_queue_field( $source[ QueueAbility::SLOT_CONFIG_PATCH_QUEUE ] );
 		}
 
 		if ( isset( $source['queue_mode'] ) && in_array( $source['queue_mode'], array( 'drain', 'loop', 'static' ), true ) ) {
 			$normalized['queue_mode'] = $source['queue_mode'];
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize a portable string-list setting.
+	 */
+	private function normalize_string_list_field( string $field, $value ): array {
+		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+			throw new \InvalidArgumentException( "{$field} must be a list of strings." );
+		}
+
+		$normalized = array();
+		foreach ( $value as $item ) {
+			if ( ! is_string( $item ) ) {
+				throw new \InvalidArgumentException( "{$field} must be a list of strings." );
+			}
+			$normalized[] = $item;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize AI prompt queue entries from portable settings.
+	 */
+	private function normalize_prompt_queue_field( $value ): array {
+		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+			throw new \InvalidArgumentException( 'prompt_queue must be a list of objects.' );
+		}
+
+		$normalized = array();
+		foreach ( $value as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				throw new \InvalidArgumentException( 'prompt_queue must be a list of objects.' );
+			}
+			if ( ! array_key_exists( QueueAbility::FIELD_PROMPT, $entry ) || ! is_string( $entry[ QueueAbility::FIELD_PROMPT ] ) ) {
+				throw new \InvalidArgumentException( 'prompt_queue entries must include a string prompt.' );
+			}
+			if ( array_key_exists( 'added_at', $entry ) && ! is_string( $entry['added_at'] ) ) {
+				throw new \InvalidArgumentException( 'prompt_queue added_at must be a string when present.' );
+			}
+			$normalized[] = $entry;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize fetch config-patch queue entries from portable settings.
+	 */
+	private function normalize_config_patch_queue_field( $value ): array {
+		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+			throw new \InvalidArgumentException( 'config_patch_queue must be a list of objects.' );
+		}
+
+		$normalized = array();
+		foreach ( $value as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				throw new \InvalidArgumentException( 'config_patch_queue must be a list of objects.' );
+			}
+			if ( ! array_key_exists( QueueAbility::FIELD_PATCH, $entry ) || ! is_array( $entry[ QueueAbility::FIELD_PATCH ] ) ) {
+				throw new \InvalidArgumentException( 'config_patch_queue entries must include an object patch.' );
+			}
+			if ( array_key_exists( 'added_at', $entry ) && ! is_string( $entry['added_at'] ) ) {
+				throw new \InvalidArgumentException( 'config_patch_queue added_at must be a string when present.' );
+			}
+			$normalized[] = $entry;
 		}
 
 		return $normalized;

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -122,22 +122,15 @@ final class AgentBundleFlowFile {
 		}
 
 		if ( in_array( $field, array( 'handler_slugs', 'enabled_tools', 'disabled_tools' ), true ) ) {
-			if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
-				throw new BundleValidationException( "flow file {$field} must be a list." );
-			}
-			return array_values( array_map( 'strval', $value ) );
+			return self::normalize_string_list( $field, $value );
 		}
 
-		if ( in_array( $field, array( 'prompt_queue', 'config_patch_queue' ), true ) ) {
-			if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
-				throw new BundleValidationException( "flow file {$field} must be a list of objects." );
-			}
-			foreach ( $value as $entry ) {
-				if ( ! is_array( $entry ) ) {
-					throw new BundleValidationException( "flow file {$field} must be a list of objects." );
-				}
-			}
-			return array_values( $value );
+		if ( 'prompt_queue' === $field ) {
+			return self::normalize_prompt_queue( $value );
+		}
+
+		if ( 'config_patch_queue' === $field ) {
+			return self::normalize_config_patch_queue( $value );
 		}
 
 		if ( 'queue_mode' === $field ) {
@@ -148,5 +141,74 @@ final class AgentBundleFlowFile {
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Normalize portable string-list fields.
+	 */
+	private static function normalize_string_list( string $field, $value ): array {
+		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+			throw new BundleValidationException( "flow file {$field} must be a list of strings." );
+		}
+
+		$normalized = array();
+		foreach ( $value as $item ) {
+			if ( ! is_string( $item ) ) {
+				throw new BundleValidationException( "flow file {$field} must be a list of strings." );
+			}
+			$normalized[] = $item;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize AI prompt queue seed entries.
+	 */
+	private static function normalize_prompt_queue( $value ): array {
+		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+			throw new BundleValidationException( 'flow file prompt_queue must be a list of objects.' );
+		}
+
+		$normalized = array();
+		foreach ( $value as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				throw new BundleValidationException( 'flow file prompt_queue must be a list of objects.' );
+			}
+			if ( ! array_key_exists( 'prompt', $entry ) || ! is_string( $entry['prompt'] ) ) {
+				throw new BundleValidationException( 'flow file prompt_queue entries must include a string prompt.' );
+			}
+			if ( array_key_exists( 'added_at', $entry ) && ! is_string( $entry['added_at'] ) ) {
+				throw new BundleValidationException( 'flow file prompt_queue added_at must be a string when present.' );
+			}
+			$normalized[] = $entry;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize fetch config-patch queue seed entries.
+	 */
+	private static function normalize_config_patch_queue( $value ): array {
+		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+			throw new BundleValidationException( 'flow file config_patch_queue must be a list of objects.' );
+		}
+
+		$normalized = array();
+		foreach ( $value as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				throw new BundleValidationException( 'flow file config_patch_queue must be a list of objects.' );
+			}
+			if ( ! array_key_exists( 'patch', $entry ) || ! is_array( $entry['patch'] ) ) {
+				throw new BundleValidationException( 'flow file config_patch_queue entries must include an object patch.' );
+			}
+			if ( array_key_exists( 'added_at', $entry ) && ! is_string( $entry['added_at'] ) ) {
+				throw new BundleValidationException( 'flow file config_patch_queue added_at must be a string when present.' );
+			}
+			$normalized[] = $entry;
+		}
+
+		return $normalized;
 	}
 }

--- a/tests/agent-bundle-format-smoke.php
+++ b/tests/agent-bundle-format-smoke.php
@@ -193,7 +193,12 @@ $flow = AgentBundleFlowFile::from_array(
 				'step_position'   => 0,
 				'handler_slug'    => 'mcp',
 				'handler_configs' => array( 'mcp' => array( 'auth_ref' => 'wpcom:default', 'provider' => 'mgs' ) ),
-				'config_patch_queue' => array( array( 'after' => '2026-04-01' ) ),
+				'config_patch_queue' => array(
+					array(
+						'patch'    => array( 'after' => '2026-04-01' ),
+						'added_at' => '2026-04-27T00:00:00Z',
+					),
+				),
 				'queue_mode'         => 'drain',
 			),
 		),
@@ -202,7 +207,7 @@ $flow = AgentBundleFlowFile::from_array(
 $flow_array = $flow->to_array();
 assert_bundle_equals( 'flow references pipeline by slug, not source ID', 'wc-daily-ingest', $flow_array['pipeline_slug'] );
 assert_bundle_equals( 'flow step 0 first after normalization', 'mcp', $flow_array['steps'][0]['handler_slug'] );
-assert_bundle_equals( 'flow step preserves fetch config patch queue', array( array( 'after' => '2026-04-01' ) ), $flow_array['steps'][0]['config_patch_queue'] );
+assert_bundle_equals( 'flow step preserves fetch config patch queue', array( 'after' => '2026-04-01' ), $flow_array['steps'][0]['config_patch_queue'][0]['patch'] );
 assert_bundle_equals( 'flow step preserves AI enabled tools', array( 'datamachine/get-github-pull-review-context' ), $flow_array['steps'][2]['enabled_tools'] );
 assert_bundle_equals( 'flow step preserves AI prompt queue', 'Review this PR.', $flow_array['steps'][2]['prompt_queue'][0]['prompt'] );
 assert_bundle_equals( 'flow step preserves AI queue mode', 'loop', $flow_array['steps'][2]['queue_mode'] );
@@ -254,6 +259,54 @@ try {
 	$threw = str_contains( $e->getMessage(), 'queue_mode must be one of drain, loop, static' );
 }
 assert_bundle( 'malformed queue_mode fails clearly', $threw );
+
+$threw = false;
+try {
+	AgentBundleFlowFile::from_array(
+		array(
+			'schema_version' => 1,
+			'slug'           => 'Bad Tools',
+			'name'           => 'Bad Tools',
+			'pipeline_slug'  => 'WC Daily Ingest',
+			'schedule'       => 'daily',
+			'max_items'      => array(),
+			'steps'          => array(
+				array(
+					'step_position'   => 0,
+					'handler_configs' => array(),
+					'enabled_tools'   => array( 'valid-tool', array( 'not' => 'a string' ) ),
+				),
+			),
+		)
+	);
+} catch ( BundleValidationException $e ) {
+	$threw = str_contains( $e->getMessage(), 'enabled_tools must be a list of strings' );
+}
+assert_bundle( 'malformed enabled_tools fails clearly', $threw );
+
+$threw = false;
+try {
+	AgentBundleFlowFile::from_array(
+		array(
+			'schema_version' => 1,
+			'slug'           => 'Bad Patch Queue',
+			'name'           => 'Bad Patch Queue',
+			'pipeline_slug'  => 'WC Daily Ingest',
+			'schedule'       => 'daily',
+			'max_items'      => array(),
+			'steps'          => array(
+				array(
+					'step_position'      => 0,
+					'handler_configs'    => array(),
+					'config_patch_queue' => array( array( 'after' => '2026-04-01' ) ),
+				),
+			),
+		)
+	);
+} catch ( BundleValidationException $e ) {
+	$threw = str_contains( $e->getMessage(), 'config_patch_queue entries must include an object patch' );
+}
+assert_bundle( 'malformed config_patch_queue fails clearly', $threw );
 
 echo "\n[4] Directory write/read round-trips without DB access\n";
 $bundle = new AgentBundleDirectory(

--- a/tests/agent-bundle-portable-update-smoke.php
+++ b/tests/agent-bundle-portable-update-smoke.php
@@ -136,7 +136,7 @@ $directory = new AgentBundleDirectory(
 					'handler_slug'        => 'mcp',
 					'handler_config'      => array( 'provider' => 'mgs' ),
 					'handler_configs'     => array( 'mcp' => array( 'provider' => 'mgs' ) ),
-					'config_patch_queue'  => array( array( 'query' => 'WooCommerce' ) ),
+					'config_patch_queue'  => array( array( 'patch' => array( 'query' => 'WooCommerce' ), 'added_at' => '2026-04-27T00:00:00Z' ) ),
 					'queue_mode'          => 'loop',
 				)
 			)
@@ -175,18 +175,18 @@ $incoming_flow_config = array(
 	'flow-step-1' => array(
 		'handler_slug'       => 'mcp',
 		'handler_config'     => array( 'provider' => 'mgs', 'query' => 'New seed' ),
-		'config_patch_queue' => array( array( 'query' => 'New seed' ) ),
+		'config_patch_queue' => array( array( 'patch' => array( 'query' => 'New seed' ), 'added_at' => '2026-04-27T00:00:00Z' ) ),
 		'queue_mode'         => 'drain',
 	),
 );
 $existing_flow_config = array(
 	'flow-step-1' => array(
-		'config_patch_queue' => array( array( 'query' => 'Local queue head' ) ),
+		'config_patch_queue' => array( array( 'patch' => array( 'query' => 'Local queue head' ), 'added_at' => '2026-04-27T00:00:00Z' ) ),
 		'queue_mode'         => 'static',
 	),
 );
 $preserved = call_bundle_private( $bundler, 'preserve_runtime_queue_fields', array( $incoming_flow_config, $existing_flow_config ) );
-assert_bundle_update_equals( 'upgrade preserves existing config_patch_queue', 'Local queue head', $preserved['flow-step-1']['config_patch_queue'][0]['query'] ?? null );
+assert_bundle_update_equals( 'upgrade preserves existing config_patch_queue', 'Local queue head', $preserved['flow-step-1']['config_patch_queue'][0]['patch']['query'] ?? null );
 assert_bundle_update_equals( 'upgrade preserves existing queue_mode', 'static', $preserved['flow-step-1']['queue_mode'] ?? null );
 
 $agent_bundler_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Agents/AgentBundler.php' ) ?: '';

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -125,7 +125,7 @@ $legacy_bundle = array(
 					'execution_order'    => 0,
 					'handler_slug'       => 'mcp',
 					'handler_config'     => array( 'provider' => 'github', 'auth_ref' => 'github:default' ),
-					'config_patch_queue' => array( array( 'after' => '2026-04-01' ) ),
+					'config_patch_queue' => array( array( 'patch' => array( 'after' => '2026-04-01' ), 'added_at' => '2026-04-27T00:00:00Z' ) ),
 					'queue_mode'         => 'drain',
 					'enabled'            => true,
 				),
@@ -159,7 +159,7 @@ assert_adapter_equals( 'flow references pipeline by slug', 'pr-review-pipeline',
 assert_adapter_equals( 'pipeline document strips runtime pipeline_step_id', false, array_key_exists( 'pipeline_step_id', $pipeline['steps'][0]['step_config'] ) );
 assert_adapter_equals( 'flow document preserves handler config', array( 'provider' => 'github', 'auth_ref' => 'github:default' ), $flow['steps'][0]['handler_config'] );
 assert_adapter_equals( 'flow document preserves step type', 'fetch', $flow['steps'][0]['step_type'] );
-assert_adapter_equals( 'flow document preserves config patch queue', array( array( 'after' => '2026-04-01' ) ), $flow['steps'][0]['config_patch_queue'] );
+assert_adapter_equals( 'flow document preserves config patch queue', array( 'after' => '2026-04-01' ), $flow['steps'][0]['config_patch_queue'][0]['patch'] ?? null );
 assert_adapter_equals( 'flow document preserves AI enabled tools', array( 'datamachine/get-github-pull-review-context' ), $flow['steps'][1]['enabled_tools'] );
 assert_adapter_equals( 'flow document preserves AI disabled tools', array( 'datamachine/delete-flow' ), $flow['steps'][1]['disabled_tools'] );
 assert_adapter_equals( 'flow document preserves prompt queue', 'Review PR #1', $flow['steps'][1]['prompt_queue'][0]['prompt'] );
@@ -188,7 +188,7 @@ assert_adapter_equals( 'round-trip preserves pipeline memory', "# Pipeline\n", $
 assert_adapter_equals( 'round-trip preserves flow file memory', "{}\n", $round_trip['flows'][0]['memory_file_contents']['files/context.json'] ?? null );
 assert_adapter_equals( 'round-trip preserves handler config', array( 'auth_ref' => 'github:default', 'provider' => 'github' ), $round_steps[0]['handler_config'] );
 assert_adapter_equals( 'round-trip preserves step type', 'fetch', $round_steps[0]['step_type'] );
-assert_adapter_equals( 'round-trip preserves config patch queue', array( array( 'after' => '2026-04-01' ) ), $round_steps[0]['config_patch_queue'] );
+assert_adapter_equals( 'round-trip preserves config patch queue', array( 'after' => '2026-04-01' ), $round_steps[0]['config_patch_queue'][0]['patch'] ?? null );
 assert_adapter_equals( 'round-trip preserves enabled flag', true, $round_steps[0]['enabled'] );
 assert_adapter_equals( 'round-trip preserves enabled tools', array( 'datamachine/get-github-pull-review-context' ), $round_steps[1]['enabled_tools'] );
 assert_adapter_equals( 'round-trip preserves disabled tools', array( 'datamachine/delete-flow' ), $round_steps[1]['disabled_tools'] );

--- a/tests/bulk-create-pipeline-workflow-smoke.php
+++ b/tests/bulk-create-pipeline-workflow-smoke.php
@@ -90,7 +90,7 @@ $workflow = array(
 			'label'              => 'Fetch Context',
 			'handler_slug'       => 'mcp',
 			'handler_config'     => array( 'provider' => 'github', 'query' => 'repo:Extra-Chill/data-machine' ),
-			'config_patch_queue' => array( array( 'query' => 'workflow spec' ) ),
+			'config_patch_queue' => array( array( 'patch' => array( 'query' => 'workflow spec' ), 'added_at' => '2026-04-27T00:00:00Z' ) ),
 			'queue_mode'         => 'drain',
 		),
 		array(
@@ -129,7 +129,7 @@ assert_bulk_workflow_equals( 2, count( $pipeline_config ), 'bulk workflow create
 assert_bulk_workflow_equals( 2, count( $flow_config ), 'bulk workflow creates persistent flow rows through shared factory', $failures, $passes );
 assert_bulk_workflow_equals( 'mcp', $flow_steps[0]['handler_slug'] ?? null, 'bulk workflow preserves handler slug', $failures, $passes );
 assert_bulk_workflow_equals( array( 'provider' => 'github', 'query' => 'repo:Extra-Chill/data-machine' ), $flow_steps[0]['handler_config'] ?? null, 'bulk workflow preserves handler config', $failures, $passes );
-assert_bulk_workflow_equals( array( array( 'query' => 'workflow spec' ) ), $flow_steps[0]['config_patch_queue'] ?? null, 'bulk workflow preserves config patch queue', $failures, $passes );
+assert_bulk_workflow_equals( array( 'query' => 'workflow spec' ), $flow_steps[0]['config_patch_queue'][0]['patch'] ?? null, 'bulk workflow preserves config patch queue', $failures, $passes );
 assert_bulk_workflow_equals( 'drain', $flow_steps[0]['queue_mode'] ?? null, 'bulk workflow preserves queue mode', $failures, $passes );
 assert_bulk_workflow_equals( array( 'datamachine/read-github-file' ), $flow_steps[1]['enabled_tools'] ?? null, 'bulk workflow preserves enabled tools', $failures, $passes );
 assert_bulk_workflow_equals( array( 'datamachine/delete-pipeline' ), $flow_steps[1]['disabled_tools'] ?? null, 'bulk workflow preserves disabled tools', $failures, $passes );

--- a/tests/import-export-portable-flow-settings-smoke.php
+++ b/tests/import-export-portable-flow-settings-smoke.php
@@ -12,6 +12,8 @@ namespace DataMachine\Abilities\Flow {
 		class QueueAbility {
 			const SLOT_PROMPT_QUEUE       = 'prompt_queue';
 			const SLOT_CONFIG_PATCH_QUEUE = 'config_patch_queue';
+			const FIELD_PROMPT            = 'prompt';
+			const FIELD_PATCH             = 'patch';
 		}
 	}
 }
@@ -106,14 +108,19 @@ $fetch_settings = call_import_export_private(
 		'step_type'          => 'fetch',
 		'handler_slug'       => 'webhook_payload',
 		'handler_config'     => array( 'payload_path' => 'pull_request' ),
-		'config_patch_queue' => array( array( 'after' => '2026-04-01' ) ),
+		'config_patch_queue' => array(
+			array(
+				'patch'    => array( 'after' => '2026-04-01' ),
+				'added_at' => '2026-04-27T00:00:00Z',
+			),
+		),
 		'queue_mode'         => 'drain',
 	)
 );
 
 assert_csv_equals( 'webhook_payload', $fetch_settings['handler_slug'] ?? null, 'fetch handler_slug still exports', $failures, $passes );
 assert_csv_equals( array( 'payload_path' => 'pull_request' ), $fetch_settings['handler_config'] ?? null, 'fetch handler_config still exports', $failures, $passes );
-assert_csv_equals( array( array( 'after' => '2026-04-01' ) ), $fetch_settings['config_patch_queue'] ?? null, 'fetch config_patch_queue exports as portable settings', $failures, $passes );
+assert_csv_equals( array( 'after' => '2026-04-01' ), $fetch_settings['config_patch_queue'][0]['patch'] ?? null, 'fetch config_patch_queue exports canonical patch entry', $failures, $passes );
 assert_csv_equals( 'drain', $fetch_settings['queue_mode'] ?? null, 'fetch queue_mode exports as portable settings', $failures, $passes );
 
 $normalized = call_import_export_private(
@@ -131,6 +138,44 @@ assert_csv_equals( array( 'datamachine/read-github-file' ), $normalized['enabled
 assert_csv_equals( array( array( 'prompt' => 'Pinned prompt.' ) ), $normalized['prompt_queue'] ?? null, 'import normalization keeps prompt_queue', $failures, $passes );
 assert_csv_equals( 'static', $normalized['queue_mode'] ?? null, 'import normalization keeps queue_mode', $failures, $passes );
 assert_csv_equals( false, array_key_exists( 'handler_slug', $normalized ), 'portable normalization does not duplicate handler fields', $failures, $passes );
+
+$normalized_patch = call_import_export_private(
+	$import_export,
+	'normalize_portable_flow_step_settings',
+	array(
+		'config_patch_queue' => array(
+			array(
+				'patch'    => array( 'before' => '2026-05-01' ),
+				'added_at' => '2026-04-27T00:00:00Z',
+			),
+		),
+	)
+);
+assert_csv_equals( array( 'before' => '2026-05-01' ), $normalized_patch['config_patch_queue'][0]['patch'] ?? null, 'import normalization keeps canonical config_patch_queue entries', $failures, $passes );
+
+$threw = false;
+try {
+	call_import_export_private(
+		$import_export,
+		'normalize_portable_flow_step_settings',
+		array( 'enabled_tools' => array( 'valid-tool', array( 'not' => 'a string' ) ) )
+	);
+} catch ( InvalidArgumentException $e ) {
+	$threw = str_contains( $e->getMessage(), 'enabled_tools must be a list of strings' );
+}
+assert_csv_equals( true, $threw, 'malformed enabled_tools fails clearly', $failures, $passes );
+
+$threw = false;
+try {
+	call_import_export_private(
+		$import_export,
+		'normalize_portable_flow_step_settings',
+		array( 'config_patch_queue' => array( array( 'after' => '2026-04-01' ) ) )
+	);
+} catch ( InvalidArgumentException $e ) {
+	$threw = str_contains( $e->getMessage(), 'config_patch_queue entries must include an object patch' );
+}
+assert_csv_equals( true, $threw, 'malformed config_patch_queue fails clearly', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " portable flow settings assertions failed.\n";

--- a/tests/workflow-persistent-install-smoke.php
+++ b/tests/workflow-persistent-install-smoke.php
@@ -87,7 +87,7 @@ $workflow = array(
 			'label'              => 'Webhook Payload',
 			'handler_slug'       => 'webhook_payload',
 			'handler_config'     => array( 'payload_path' => 'pull_request' ),
-			'config_patch_queue' => array( array( 'after' => '2026-04-01' ) ),
+			'config_patch_queue' => array( array( 'patch' => array( 'after' => '2026-04-01' ), 'added_at' => '2026-04-27T00:00:00Z' ) ),
 			'queue_mode'         => 'drain',
 		),
 		array(
@@ -146,7 +146,7 @@ assert_workflow_equals( 88, $flow_steps[0]['pipeline_id'] ?? null, 'flow stores 
 assert_workflow_equals( 144, $flow_steps[0]['flow_id'] ?? null, 'flow stores target flow id', $failures, $passes );
 assert_workflow_equals( 'webhook_payload', $flow_steps[0]['handler_slug'] ?? null, 'flow preserves fetch handler slug', $failures, $passes );
 assert_workflow_equals( array( 'payload_path' => 'pull_request' ), $flow_steps[0]['handler_config'] ?? null, 'flow preserves fetch handler config', $failures, $passes );
-assert_workflow_equals( array( array( 'after' => '2026-04-01' ) ), $flow_steps[0]['config_patch_queue'] ?? null, 'flow preserves fetch config patch queue', $failures, $passes );
+assert_workflow_equals( array( 'after' => '2026-04-01' ), $flow_steps[0]['config_patch_queue'][0]['patch'] ?? null, 'flow preserves fetch config patch queue', $failures, $passes );
 assert_workflow_equals( 'drain', $flow_steps[0]['queue_mode'] ?? null, 'flow preserves explicit fetch queue mode', $failures, $passes );
 assert_workflow_equals( array( 'datamachine/get-github-pull-review-context', 'datamachine/upsert-github-pull-review-comment' ), $flow_steps[1]['enabled_tools'] ?? null, 'flow preserves AI enabled tools', $failures, $passes );
 assert_workflow_equals( 'Summarize findings.', $flow_steps[1]['prompt_queue'][0]['prompt'] ?? null, 'AI user_message becomes prompt_queue head', $failures, $passes );


### PR DESCRIPTION
## Summary
- Makes flow-step bundle/CSV policy fields validate against the runtime queue/tool contracts instead of accepting handler-shaped or loosely coerced data.
- Documents the portable policy fields and keeps upgrade behavior conservative: seed queues are portable for new installs, existing runtime queues are preserved on upgrades.

## Changes
- Tightens `AgentBundleFlowFile` validation for `enabled_tools`, `disabled_tools`, `prompt_queue`, `config_patch_queue`, and `queue_mode`.
- Tightens CSV import/export normalization and fails imports with an actionable malformed portable settings error.
- Aligns tests and examples around canonical fetch queue entries shaped as `{ patch: { ... }, added_at: "..." }`.

## Tests
- `php -l inc/Engine/Bundle/AgentBundleFlowFile.php && php -l inc/Engine/Actions/ImportExport.php`
- `php tests/agent-bundle-format-smoke.php && php tests/import-export-portable-flow-settings-smoke.php && php tests/workflow-persistent-install-smoke.php && php tests/agent-bundler-directory-adapter-smoke.php && php tests/agent-bundle-portable-update-smoke.php && php tests/bulk-create-pipeline-workflow-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@bundle-policy-queues-roundtrip --changed-since origin/main`

Notes: `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@bundle-policy-queues-roundtrip` still reports the repo's existing full-suite PHPStan/PHPCS noise; no changed-since audit findings were introduced.

Closes #1449
Refs #1443

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the portable policy/queue validation slice, updating smoke coverage, and running focused verification. Chris remains responsible for review and merge.