### PR TITLE
feat(auth): add handler auth refs foundation

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -79,6 +79,7 @@ function datamachine_run_datamachine_plugin() {
 
 	// Load and instantiate all handlers - they self-register via constructors
 	datamachine_load_handlers();
+	\DataMachine\Engine\Bundle\AuthRefHandlerConfig::register();
 
 	// Initialize FetchHandler to register skip_item tool for all fetch-type handlers
 	\DataMachine\Core\Steps\Fetch\Handlers\FetchHandler::init();

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -100,6 +100,78 @@ abstract class BaseAuthProvider {
 	abstract public function is_authenticated(): bool;
 
 	/**
+	 * Get this provider's registered slug.
+	 *
+	 * @return string Provider slug.
+	 */
+	public function get_provider_slug(): string {
+		return $this->provider_slug;
+	}
+
+	/**
+	 * Convert an inline handler config to a portable auth_ref.
+	 *
+	 * Providers that recognize their own credential shape can override this and
+	 * return a provider:account handle. The default is intentionally no-op so
+	 * unknown handler configs pass through unchanged on export.
+	 *
+	 * @param array  $handler_config Handler config being exported.
+	 * @param string $handler_slug Handler slug that owns the config.
+	 * @param array  $context Export/import context.
+	 * @return string|null Portable auth_ref or null when not recognized.
+	 */
+	public function get_auth_ref_for_config( array $handler_config, string $handler_slug = '', array $context = array() ): ?string {
+		unset( $handler_config, $handler_slug, $context );
+		return null;
+	}
+
+	/**
+	 * Resolve an auth_ref account id to local handler config values.
+	 *
+	 * Providers that support portable refs should override this. The default
+	 * returns a clear unresolved error without exposing stored credentials.
+	 *
+	 * @param string $account Auth ref account/id segment.
+	 * @param string $handler_slug Handler slug requesting credentials.
+	 * @param array  $context Import/runtime context.
+	 * @return array|\WP_Error Local handler config fragment or failure.
+	 */
+	public function resolve_auth_ref( string $account, string $handler_slug = '', array $context = array() ): array|\WP_Error {
+		unset( $handler_slug, $context );
+		return new \WP_Error(
+			'auth_ref_unresolved',
+			sprintf(
+				/* translators: 1: provider slug, 2: auth ref account id. */
+				__( 'No local %1$s auth connection is configured for ref "%2$s".', 'data-machine' ),
+				$this->provider_slug,
+				$account
+			)
+		);
+	}
+
+	/**
+	 * Strip credential-shaped keys from a handler config before export.
+	 *
+	 * @param array $handler_config Handler config.
+	 * @return array Config without token/secret/password/key material.
+	 */
+	public function strip_auth_config_secrets( array $handler_config ): array {
+		$secret_fields = array_fill_keys( $this->get_encrypted_fields(), true );
+		$clean         = array();
+
+		foreach ( $handler_config as $key => $value ) {
+			$key = (string) $key;
+			if ( isset( $secret_fields[ $key ] ) || preg_match( '/(secret|token|password|credential|key)/i', $key ) ) {
+				continue;
+			}
+
+			$clean[ $key ] = is_array( $value ) ? $this->strip_auth_config_secrets( $value ) : $value;
+		}
+
+		return $clean;
+	}
+
+	/**
 	 * Check if provider is properly configured
 	 *
 	 * @return bool True if configured

--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -6,6 +6,7 @@ use DataMachine\Core\DataPacket;
 use DataMachine\Core\Steps\QueueableTrait;
 use DataMachine\Core\Steps\Step;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
+use DataMachine\Engine\Bundle\AuthRefHandlerConfig;
 use DataMachine\Abilities\HandlerAbilities;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -129,6 +130,24 @@ class FetchStep extends Step {
 		$handler_settings['flow_step_id'] = $this->flow_step_config['flow_step_id'];
 		$handler_settings['pipeline_id']  = $this->flow_step_config['pipeline_id'];
 		$handler_settings['flow_id']      = $this->flow_step_config['flow_id'];
+
+		$resolved_handler_settings = AuthRefHandlerConfig::resolve_runtime_config(
+			$handler_settings,
+			(string) $handler,
+			array(
+				'flow_step_id' => $this->flow_step_config['flow_step_id'],
+				'pipeline_id'  => $this->flow_step_config['pipeline_id'],
+				'flow_id'      => $this->flow_step_config['flow_id'],
+				'job_id'       => $this->job_id,
+			)
+		);
+
+		if ( is_wp_error( $resolved_handler_settings ) ) {
+			$this->log( 'error', 'Fetch auth_ref resolution failed: ' . $resolved_handler_settings->get_error_message() );
+			return $this->dataPackets;
+		}
+
+		$handler_settings = $resolved_handler_settings;
 
 		$packets = $this->execute_handler( $handler, $handler_settings, (string) $this->job_id );
 

--- a/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
@@ -83,6 +83,48 @@ class EmailAuth extends BaseAuthProvider {
 	}
 
 	/**
+	 * Convert inline IMAP credentials to the install-local default ref.
+	 *
+	 * @param array  $handler_config Handler config being exported.
+	 * @param string $handler_slug Handler slug.
+	 * @param array  $context Export context.
+	 * @return string|null Auth ref or null when config carries no IMAP credential shape.
+	 */
+	public function get_auth_ref_for_config( array $handler_config, string $handler_slug = '', array $context = array() ): ?string {
+		unset( $handler_slug, $context );
+
+		foreach ( array( 'imap_host', 'imap_user', 'imap_password' ) as $field ) {
+			if ( ! empty( $handler_config[ $field ] ) ) {
+				return 'email_imap:default';
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve the default IMAP auth ref to local credentials.
+	 *
+	 * @param string $account Auth ref account/id segment.
+	 * @param string $handler_slug Handler slug requesting credentials.
+	 * @param array  $context Import/runtime context.
+	 * @return array|\WP_Error Local IMAP config or failure.
+	 */
+	public function resolve_auth_ref( string $account, string $handler_slug = '', array $context = array() ): array|\WP_Error {
+		unset( $handler_slug, $context );
+
+		if ( 'default' !== $account ) {
+			return new \WP_Error( 'auth_ref_unresolved', __( 'Email auth only supports the default local connection.', 'data-machine' ) );
+		}
+
+		if ( ! $this->is_authenticated() ) {
+			return new \WP_Error( 'auth_ref_unresolved', __( 'Email IMAP credentials are not configured on this install.', 'data-machine' ) );
+		}
+
+		return $this->get_config();
+	}
+
+	/**
 	 * Get IMAP host.
 	 *
 	 * @return string IMAP hostname.

--- a/inc/Core/Steps/Publish/Handlers/PublishHandler.php
+++ b/inc/Core/Steps/Publish/Handlers/PublishHandler.php
@@ -17,6 +17,7 @@ namespace DataMachine\Core\Steps\Publish\Handlers;
 use DataMachine\Abilities\AuthAbilities;
 use DataMachine\Core\EngineData;
 use DataMachine\Core\Steps\Handlers\HttpRequestHelpers;
+use DataMachine\Engine\Bundle\AuthRefHandlerConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -68,7 +69,16 @@ abstract class PublishHandler {
 		$parameters['engine'] = $engine;
 
 		$handler_config = $tool_def['handler_config'] ?? array();
-		$result         = $this->executePublish( $parameters, $handler_config );
+		$handler_config = AuthRefHandlerConfig::resolve_runtime_config(
+			$handler_config,
+			(string) ( $tool_def['handler'] ?? $this->handler_type ),
+			array( 'job_id' => $job_id )
+		);
+		if ( is_wp_error( $handler_config ) ) {
+			return $this->errorResponse( 'Auth ref resolution failed: ' . $handler_config->get_error_message() );
+		}
+
+		$result = $this->executePublish( $parameters, $handler_config );
 
 		// Post origin tracking is applied centrally in ToolExecutor::executeTool()
 		// after every tool call — handler tools and ability tools share the same
@@ -342,5 +352,4 @@ abstract class PublishHandler {
 		$auth_abilities = new AuthAbilities();
 		return $auth_abilities->getProvider( $provider_key );
 	}
-
 }

--- a/inc/Core/Steps/Upsert/Handlers/UpsertHandler.php
+++ b/inc/Core/Steps/Upsert/Handlers/UpsertHandler.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Core\Steps\Upsert\Handlers;
 
 use DataMachine\Core\EngineData;
+use DataMachine\Engine\Bundle\AuthRefHandlerConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -80,7 +81,16 @@ abstract class UpsertHandler {
 		$parameters['engine'] = $engine;
 
 		$handler_config = $tool_def['handler_config'] ?? array();
-		$result         = $this->executeUpsert( $parameters, $handler_config );
+		$handler_config = AuthRefHandlerConfig::resolve_runtime_config(
+			$handler_config,
+			(string) ( $tool_def['handler'] ?? static::class ),
+			array( 'job_id' => $job_id )
+		);
+		if ( is_wp_error( $handler_config ) ) {
+			return $this->errorResponse( 'Auth ref resolution failed: ' . $handler_config->get_error_message() );
+		}
+
+		$result = $this->executeUpsert( $parameters, $handler_config );
 
 		// Post origin tracking is applied centrally in ToolExecutor::executeTool()
 		// after every tool call — handler tools and ability tools share the same

--- a/inc/Engine/Bundle/AuthRefHandlerConfig.php
+++ b/inc/Engine/Bundle/AuthRefHandlerConfig.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Handler config auth_ref export/import bridge.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+use DataMachine\Abilities\AuthAbilities;
+use DataMachine\Core\OAuth\BaseAuthProvider;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Bridges live handler configs to portable auth_ref handles.
+ */
+final class AuthRefHandlerConfig {
+
+	private static bool $registered = false;
+
+	/**
+	 * Register default filter callbacks.
+	 */
+	public static function register(): void {
+		if ( self::$registered ) {
+			return;
+		}
+
+		add_filter( 'datamachine_handler_config_to_auth_ref', array( self::class, 'handler_config_to_auth_ref' ), 10, 3 );
+		add_filter( 'datamachine_auth_ref_to_handler_config', array( self::class, 'auth_ref_to_handler_config' ), 10, 3 );
+
+		self::$registered = true;
+	}
+
+	/**
+	 * Rewrite inline credential config to auth_ref form for portable export.
+	 *
+	 * @param array|\WP_Error $handler_config Handler config or previous error.
+	 * @param string          $handler_slug Handler slug.
+	 * @param array           $context Export context.
+	 * @return array|\WP_Error Rewritten config or original value.
+	 */
+	public static function handler_config_to_auth_ref( array|\WP_Error $handler_config, string $handler_slug, array $context = array() ): array|\WP_Error {
+		if ( is_wp_error( $handler_config ) ) {
+			return $handler_config;
+		}
+
+		if ( isset( $handler_config['auth_ref'] ) ) {
+			return $handler_config;
+		}
+
+		$provider = self::provider_for_handler( $handler_slug );
+		if ( ! $provider ) {
+			return $handler_config;
+		}
+
+		$ref = $provider->get_auth_ref_for_config( $handler_config, $handler_slug, $context );
+		if ( null === $ref || '' === trim( $ref ) ) {
+			return $handler_config;
+		}
+
+		$parsed = self::parse_ref( $ref );
+		if ( is_wp_error( $parsed ) ) {
+			return $parsed;
+		}
+
+		$rewritten             = $provider->strip_auth_config_secrets( $handler_config );
+		$rewritten['auth_ref'] = $parsed->ref();
+
+		ksort( $rewritten, SORT_STRING );
+		return $rewritten;
+	}
+
+	/**
+	 * Resolve auth_ref form to local handler config for import/runtime.
+	 *
+	 * @param array|\WP_Error $handler_config Handler config or previous error.
+	 * @param string          $handler_slug Handler slug.
+	 * @param array           $context Import/runtime context.
+	 * @return array|\WP_Error Resolved config or failure.
+	 */
+	public static function auth_ref_to_handler_config( array|\WP_Error $handler_config, string $handler_slug, array $context = array() ): array|\WP_Error {
+		if ( is_wp_error( $handler_config ) ) {
+			return $handler_config;
+		}
+
+		$ref_string = $handler_config['auth_ref'] ?? null;
+		if ( ! is_string( $ref_string ) || '' === trim( $ref_string ) ) {
+			return $handler_config;
+		}
+
+		$ref = self::parse_ref( $ref_string );
+		if ( is_wp_error( $ref ) ) {
+			return $ref;
+		}
+
+		$provider = self::provider_for_ref( $ref, $handler_slug );
+		if ( is_wp_error( $provider ) ) {
+			return $provider;
+		}
+
+		$resolved = $provider->resolve_auth_ref( $ref->account(), $handler_slug, $context );
+		if ( is_wp_error( $resolved ) ) {
+			return self::redact_error( $resolved, $ref );
+		}
+
+		$static_config = $handler_config;
+		unset( $static_config['auth_ref'] );
+		$static_config = $provider->strip_auth_config_secrets( $static_config );
+
+		return array_merge( $resolved, $static_config );
+	}
+
+	/**
+	 * Resolve a handler config for runtime use.
+	 *
+	 * @param array  $handler_config Handler config.
+	 * @param string $handler_slug Handler slug.
+	 * @param array  $context Runtime context.
+	 * @return array|\WP_Error Resolved handler config or failure.
+	 */
+	public static function resolve_runtime_config( array $handler_config, string $handler_slug, array $context = array() ): array|\WP_Error {
+		$context['runtime'] = $context['runtime'] ?? true;
+		return apply_filters( 'datamachine_auth_ref_to_handler_config', $handler_config, $handler_slug, $context );
+	}
+
+	private static function provider_for_handler( string $handler_slug ): ?BaseAuthProvider {
+		$auth_abilities = new AuthAbilities();
+		$provider       = $auth_abilities->getProviderForHandler( $handler_slug );
+
+		return $provider instanceof BaseAuthProvider ? $provider : null;
+	}
+
+	private static function provider_for_ref( AuthRef $ref, string $handler_slug ): BaseAuthProvider|\WP_Error {
+		$auth_abilities   = new AuthAbilities();
+		$handler_provider = $auth_abilities->getProviderForHandler( $handler_slug );
+		$ref_provider     = $auth_abilities->getProvider( $ref->provider() );
+
+		if ( ! $ref_provider instanceof BaseAuthProvider ) {
+			return new \WP_Error(
+				'auth_ref_unresolved',
+				sprintf(
+					/* translators: 1: auth ref, 2: provider slug. */
+					__( 'Auth ref "%1$s" cannot be resolved because provider "%2$s" is not registered on this install.', 'data-machine' ),
+					$ref->ref(),
+					$ref->provider()
+				)
+			);
+		}
+
+		if ( $handler_provider instanceof BaseAuthProvider && $handler_provider->get_provider_slug() !== $ref_provider->get_provider_slug() ) {
+			return new \WP_Error(
+				'auth_ref_provider_mismatch',
+				sprintf(
+					/* translators: 1: auth ref, 2: handler slug. */
+					__( 'Auth ref "%1$s" does not match handler "%2$s".', 'data-machine' ),
+					$ref->ref(),
+					$handler_slug
+				)
+			);
+		}
+
+		return $ref_provider;
+	}
+
+	private static function parse_ref( string $ref ): AuthRef|\WP_Error {
+		try {
+			return AuthRef::from_string( $ref );
+		} catch ( BundleValidationException $e ) {
+			return new \WP_Error( 'auth_ref_invalid', $e->getMessage() );
+		}
+	}
+
+	private static function redact_error( \WP_Error $error, AuthRef $ref ): \WP_Error {
+		$error_code = $error->get_error_code();
+		if ( '' === $error_code ) {
+			$error_code = 'auth_ref_unresolved';
+		}
+
+		return new \WP_Error(
+			$error_code,
+			sprintf(
+				/* translators: %s: auth ref. */
+				__( 'Auth ref "%s" could not be resolved on this install.', 'data-machine' ),
+				$ref->ref()
+			)
+		);
+	}
+}

--- a/tests/auth-ref-handler-config-smoke.php
+++ b/tests/auth-ref-handler-config-smoke.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Smoke test for handler_config <-> auth_ref bridge.
+ *
+ * @package DataMachine\Tests
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+require_once __DIR__ . '/smoke-wp-stubs.php';
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+
+		public function __construct( string $code = '', string $message = '' ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		unset( $hook, $args );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value ): string {
+		return (string) json_encode( $value );
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = 'default' ): string {
+		unset( $domain );
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( string $text ): string {
+		return $text;
+	}
+}
+
+$GLOBALS['auth_ref_smoke_filters'] = array();
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['auth_ref_smoke_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['auth_ref_smoke_filters'][ $hook ] ) ) {
+			return $value;
+		}
+
+		ksort( $GLOBALS['auth_ref_smoke_filters'][ $hook ], SORT_NUMERIC );
+		foreach ( $GLOBALS['auth_ref_smoke_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as [ $callback, $accepted_args ] ) {
+				$value = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'get_site_option' ) ) {
+	function get_site_option( string $option, $default = false ) {
+		return $GLOBALS['auth_ref_smoke_options'][ $option ] ?? $default;
+	}
+}
+
+if ( ! function_exists( 'update_site_option' ) ) {
+	function update_site_option( string $option, $value ): bool {
+		$GLOBALS['auth_ref_smoke_options'][ $option ] = $value;
+		return true;
+	}
+}
+
+require_once __DIR__ . '/../inc/Engine/Bundle/BundleValidationException.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AuthRef.php';
+require_once __DIR__ . '/../inc/Core/OAuth/BaseAuthProvider.php';
+require_once __DIR__ . '/../inc/Abilities/HandlerAbilities.php';
+require_once __DIR__ . '/../inc/Abilities/AuthAbilities.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AuthRefHandlerConfig.php';
+require_once __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php';
+
+use DataMachine\Abilities\AuthAbilities;
+use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Core\Steps\Fetch\Handlers\Email\EmailAuth;
+use DataMachine\Engine\Bundle\AuthRefHandlerConfig;
+
+$passes = 0;
+$fails  = 0;
+
+$assert = static function ( string $label, bool $condition ) use ( &$passes, &$fails ): void {
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		++$passes;
+		return;
+	}
+
+	echo "FAIL: {$label}\n";
+	++$fails;
+};
+
+add_filter(
+	'datamachine_handlers',
+	static function ( array $handlers ): array {
+		$handlers['email'] = array(
+			'type'              => 'fetch',
+			'requires_auth'     => true,
+			'auth_provider_key' => 'email_imap',
+		);
+		return $handlers;
+	},
+	10,
+	2
+);
+
+add_filter(
+	'datamachine_auth_providers',
+	static function ( array $providers ): array {
+		$providers['email_imap'] = new EmailAuth();
+		return $providers;
+	},
+	10,
+	2
+);
+
+HandlerAbilities::clearCache();
+AuthAbilities::clearCache();
+AuthRefHandlerConfig::register();
+
+$GLOBALS['auth_ref_smoke_options']['datamachine_auth_data'] = array(
+	'email_imap' => array(
+		'config' => array(
+			'imap_host'       => 'imap.example.test',
+			'imap_port'       => 993,
+			'imap_encryption' => 'ssl',
+			'imap_user'       => 'reader@example.test',
+			'imap_password'   => 'super-secret-app-password',
+		),
+	),
+);
+
+echo "\n[1] Export rewrite strips secrets and inserts auth_ref\n";
+$rewritten = apply_filters(
+	'datamachine_handler_config_to_auth_ref',
+	array(
+		'imap_host'     => 'imap.example.test',
+		'imap_user'     => 'reader@example.test',
+		'imap_password' => 'super-secret-app-password',
+		'folder'        => 'INBOX',
+		'max_messages'  => 7,
+	),
+	'email',
+	array( 'flow_id' => 12 )
+);
+
+$assert( 'export returns array', is_array( $rewritten ) );
+$assert( 'export inserts canonical auth_ref', 'email_imap:default' === ( $rewritten['auth_ref'] ?? null ) );
+$assert( 'export preserves non-secret handler fields', 'INBOX' === ( $rewritten['folder'] ?? null ) && 7 === ( $rewritten['max_messages'] ?? null ) );
+$assert( 'export strips password', ! array_key_exists( 'imap_password', $rewritten ) );
+$assert( 'export strips host/user credential fields that include no secret words only when provider marks them by encrypted field absence', array_key_exists( 'imap_host', $rewritten ) );
+$assert( 'export output does not contain secret value', ! str_contains( wp_json_encode( $rewritten ), 'super-secret-app-password' ) );
+
+echo "\n[2] Import/runtime resolution restores local config while preserving static fields\n";
+$resolved = apply_filters(
+	'datamachine_auth_ref_to_handler_config',
+	array(
+		'auth_ref'     => 'email_imap:default',
+		'folder'       => 'Support',
+		'max_messages' => 3,
+	),
+	'email',
+	array( 'flow_id' => 12 )
+);
+
+$assert( 'resolve returns array', is_array( $resolved ) );
+$assert( 'resolve removes auth_ref marker', ! array_key_exists( 'auth_ref', $resolved ) );
+$assert( 'resolve restores local secret only at runtime/import boundary', 'super-secret-app-password' === ( $resolved['imap_password'] ?? null ) );
+$assert( 'resolve preserves handler static fields', 'Support' === ( $resolved['folder'] ?? null ) && 3 === ( $resolved['max_messages'] ?? null ) );
+
+echo "\n[3] Unresolved and mismatched refs fail clearly without secret leakage\n";
+$missing = apply_filters( 'datamachine_auth_ref_to_handler_config', array( 'auth_ref' => 'slack:default' ), 'email', array() );
+$assert( 'missing provider returns WP_Error', is_wp_error( $missing ) );
+$assert( 'missing provider error uses auth_ref code family', str_starts_with( $missing->get_error_code(), 'auth_ref_' ) );
+$assert( 'missing provider error names install-local ref', str_contains( $missing->get_error_message(), 'slack:default' ) );
+$assert( 'missing provider error does not leak local secret', ! str_contains( $missing->get_error_message(), 'super-secret-app-password' ) );
+
+$bad = apply_filters( 'datamachine_auth_ref_to_handler_config', array( 'auth_ref' => 'bad ref' ), 'email', array() );
+$assert( 'malformed ref returns WP_Error', is_wp_error( $bad ) && 'auth_ref_invalid' === $bad->get_error_code() );
+
+echo "\n[4] Runtime execution paths call the resolver\n";
+$root            = dirname( __DIR__ );
+$fetch_step      = (string) file_get_contents( $root . '/inc/Core/Steps/Fetch/FetchStep.php' );
+$publish_handler = (string) file_get_contents( $root . '/inc/Core/Steps/Publish/Handlers/PublishHandler.php' );
+$upsert_handler  = (string) file_get_contents( $root . '/inc/Core/Steps/Upsert/Handlers/UpsertHandler.php' );
+$bootstrap       = (string) file_get_contents( $root . '/data-machine.php' );
+
+$assert( 'fetch step resolves auth_ref before handler execution', str_contains( $fetch_step, 'AuthRefHandlerConfig::resolve_runtime_config' ) );
+$assert( 'publish handler resolves auth_ref before execution', str_contains( $publish_handler, 'AuthRefHandlerConfig::resolve_runtime_config' ) );
+$assert( 'upsert handler resolves auth_ref before execution', str_contains( $upsert_handler, 'AuthRefHandlerConfig::resolve_runtime_config' ) );
+$assert( 'plugin bootstrap registers auth_ref filters after handlers load', str_contains( $bootstrap, 'AuthRefHandlerConfig::register();' ) );
+
+echo "\n=== Results ===\n";
+echo "Passed: {$passes}\n";
+echo "Failed: {$fails}\n";
+
+if ( $fails > 0 ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Adds the foundational handler config ↔ auth_ref bridge for portable bundles and multi-environment flow configs.
- Resolves auth_ref-backed handler configs at execution time so exported bundles and tool declarations do not carry secret values.

## Changes
- Adds `datamachine_handler_config_to_auth_ref` and `datamachine_auth_ref_to_handler_config` default filter callbacks via `AuthRefHandlerConfig`.
- Extends `BaseAuthProvider` with no-op auth-ref conversion/resolution methods and a shared secret-stripping helper.
- Implements `email_imap:default` as the representative first-party provider mapping.
- Resolves auth refs in fetch, publish, and upsert execution paths, returning clear `WP_Error` failures on unresolved refs.
- Adds a pure-PHP smoke test covering export rewrite, import/runtime resolution, unresolved refs, and runtime hook-up points.

## Tests
- `php -l inc/Engine/Bundle/AuthRefHandlerConfig.php`
- `php tests/auth-ref-handler-config-smoke.php`
- `php tests/prompt-auth-template-artifacts-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@bundle-auth-refs --changed-since origin/main`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@bundle-auth-refs --changed-since origin/main` reports no new baseline findings; command still exits non-zero because the lint runner applies ESLint to PHP files and hits existing parse errors.
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@bundle-auth-refs` currently fails in the broader PHPUnit harness with existing registration/infrastructure failures unrelated to this branch; focused smokes above pass.

## Refs
- Refs #1538
- Refs #1307

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the auth-ref handler-config foundation, smoke coverage, and verification. Chris remains responsible for review and merge.