### PR TITLE
feat(bundle): persist installed artifact tracking

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -604,6 +604,8 @@ function datamachine_activate_for_site() {
 	$db_identity_index = new \DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex();
 	$db_identity_index->create_table();
 
+	\DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts::create_table();
+
 	\DataMachine\Core\Database\Chat\Chat::create_table();
 	\DataMachine\Core\Database\Chat\Chat::ensure_mode_column();
 	\DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();

--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -39,6 +39,7 @@ Only `manifest.json`, `pipelines/`, `flows/`, and `memory/` have import/export a
 
 Bundle installs track artifacts independently of their runtime table. The foundation record shape is:
 
+- `agent_id`
 - `bundle_slug`
 - `bundle_version`
 - `artifact_type`
@@ -46,7 +47,7 @@ Bundle installs track artifacts independently of their runtime table. The founda
 - `source_path`
 - `installed_hash`
 - `current_hash`
-- `status`
+- `local_status`
 - `installed_at`
 - `updated_at`
 
@@ -83,6 +84,7 @@ Bundle-installed pipelines and flows use stable `portable_slug` values as their 
 - Flows resolve by `(pipeline_id, portable_slug)`.
 - Re-importing the same bundle updates the existing clean rows instead of creating duplicates.
 - Local edits are detected by comparing the current artifact hash with the install-time hash recorded in the owning agent's `datamachine_bundle.artifacts` config.
+- Installed artifact tracking is persisted in the site-scoped `datamachine_bundle_artifacts` table, keyed by `(agent_id, bundle_slug, artifact_type, artifact_id)`, so bundle state is independent of runtime tables.
 - Modified artifacts are reported as conflicts and are not overwritten by the import path.
 
 Schedule and queue policy is intentionally conservative:
@@ -106,7 +108,6 @@ Every read/preview command supports `--format=json` for automation.
 
 ## Follow-Ups
 
-- Add persistent DB storage for installed artifact records.
 - Wire importer/exporter paths for prompts, rubrics, tool policies, auth refs, and seed queues.
 - Use artifact statuses during bundle upgrade planning: auto-update `clean`, stage PendingActions for `modified`, surface `missing` and `orphaned` explicitly.
 - Add registered bundle sources once bundles move beyond local paths.

--- a/inc/Core/Database/BundleArtifacts/InstalledBundleArtifacts.php
+++ b/inc/Core/Database/BundleArtifacts/InstalledBundleArtifacts.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Installed agent bundle artifact repository.
+ *
+ * @package DataMachine\Core\Database\BundleArtifacts
+ */
+
+namespace DataMachine\Core\Database\BundleArtifacts;
+
+use DataMachine\Core\Database\BaseRepository;
+use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
+use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Persists bundle-installed artifact hashes independently of runtime tables.
+ */
+final class InstalledBundleArtifacts extends BaseRepository {
+
+	public const TABLE_NAME = 'datamachine_bundle_artifacts';
+
+	/**
+	 * Create installed bundle artifact tracking table.
+	 *
+	 * Safe to call during activation or deploy-time migrations; dbDelta is idempotent.
+	 *
+	 * @return void
+	 */
+	public static function create_table(): void {
+		global $wpdb;
+
+		$table_name      = $wpdb->prefix . self::TABLE_NAME;
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE {$table_name} (
+			artifact_record_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+			agent_id BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+			bundle_slug VARCHAR(200) NOT NULL,
+			bundle_version VARCHAR(100) NOT NULL,
+			artifact_type VARCHAR(50) NOT NULL,
+			artifact_id VARCHAR(255) NOT NULL,
+			source_path VARCHAR(500) NOT NULL,
+			installed_hash CHAR(64) NULL DEFAULT NULL,
+			current_hash CHAR(64) NULL DEFAULT NULL,
+			local_status VARCHAR(20) NOT NULL DEFAULT 'clean',
+			installed_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			PRIMARY KEY (artifact_record_id),
+			UNIQUE KEY artifact_identity (agent_id, bundle_slug, artifact_type, artifact_id),
+			KEY bundle_slug (bundle_slug),
+			KEY artifact_type (artifact_type),
+			KEY local_status (local_status)
+		) {$charset_collate};";
+
+		if ( ! function_exists( 'dbDelta' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		}
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Persist or replace an installed artifact tracking row.
+	 *
+	 * @param AgentBundleInstalledArtifact $artifact Installed artifact value object.
+	 * @param int                          $agent_id Optional owning agent ID; 0 means global/unscoped.
+	 * @return bool
+	 */
+	public function upsert( AgentBundleInstalledArtifact $artifact, int $agent_id = 0 ): bool {
+		$artifact_row = $artifact->to_array();
+		$row          = array(
+			'agent_id'       => max( 0, $agent_id ),
+			'bundle_slug'    => $artifact_row['bundle_slug'],
+			'bundle_version' => $artifact_row['bundle_version'],
+			'artifact_type'  => $artifact_row['artifact_type'],
+			'artifact_id'    => $artifact_row['artifact_id'],
+			'source_path'    => $artifact_row['source_path'],
+			'installed_hash' => '' !== (string) $artifact_row['installed_hash'] ? $artifact_row['installed_hash'] : null,
+			'current_hash'   => '' !== (string) $artifact_row['current_hash'] ? $artifact_row['current_hash'] : null,
+			'local_status'   => $artifact_row['status'],
+			'installed_at'   => $artifact_row['installed_at'],
+			'updated_at'     => $artifact_row['updated_at'],
+		);
+		$record_id    = $this->existing_record_id( $row );
+		$format       = array( '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' );
+
+		if ( null !== $record_id ) {
+			$row        = array_merge( array( 'artifact_record_id' => $record_id ), $row );
+			$format     = array_merge( array( '%d' ), $format );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $this->wpdb->replace( $this->table_name, $row, $format );
+		if ( false === $result ) {
+			$this->log_db_error( 'upsert installed bundle artifact', $this->safe_log_context( $row ) );
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Record install-time state from a bundle artifact payload.
+	 *
+	 * @param AgentBundleManifest $manifest Manifest that owns the artifact.
+	 * @param string              $artifact_type Artifact type.
+	 * @param string              $artifact_id Stable artifact identifier.
+	 * @param string              $source_path Bundle-local source path/key.
+	 * @param mixed               $artifact_payload Install-time payload.
+	 * @param int                 $agent_id Optional owning agent ID; 0 means global/unscoped.
+	 * @param string|null         $timestamp Optional UTC timestamp; defaults to current time.
+	 * @return AgentBundleInstalledArtifact
+	 */
+	public function record_install( AgentBundleManifest $manifest, string $artifact_type, string $artifact_id, string $source_path, mixed $artifact_payload, int $agent_id = 0, ?string $timestamp = null ): AgentBundleInstalledArtifact {
+		$timestamp = null !== $timestamp ? $timestamp : gmdate( 'Y-m-d H:i:s' );
+		$artifact  = AgentBundleInstalledArtifact::from_installed_payload( $manifest, $artifact_type, $artifact_id, $source_path, $artifact_payload, $timestamp );
+		$this->upsert( $artifact, $agent_id );
+
+		return $artifact;
+	}
+
+	/**
+	 * Find one tracked artifact.
+	 */
+	public function get( string $bundle_slug, string $artifact_type, string $artifact_id, int $agent_id = 0 ): ?AgentBundleInstalledArtifact {
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$row = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				'SELECT * FROM %i WHERE agent_id = %d AND bundle_slug = %s AND artifact_type = %s AND artifact_id = %s LIMIT 1',
+				$this->table_name,
+				max( 0, $agent_id ),
+				$bundle_slug,
+				$artifact_type,
+				$artifact_id
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+
+		return $row ? $this->artifact_from_row( $row ) : null;
+	}
+
+	/**
+	 * List artifacts for one installed bundle.
+	 *
+	 * @return AgentBundleInstalledArtifact[]
+	 */
+	public function list_for_bundle( string $bundle_slug, int $agent_id = 0 ): array {
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				'SELECT * FROM %i WHERE agent_id = %d AND bundle_slug = %s ORDER BY artifact_type ASC, artifact_id ASC',
+				$this->table_name,
+				max( 0, $agent_id ),
+				$bundle_slug
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+
+		return array_map( array( $this, 'artifact_from_row' ), is_array( $rows ) ? $rows : array() );
+	}
+
+	/**
+	 * List artifacts for one agent across bundles.
+	 *
+	 * @return AgentBundleInstalledArtifact[]
+	 */
+	public function list_for_agent( int $agent_id ): array {
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				'SELECT * FROM %i WHERE agent_id = %d ORDER BY bundle_slug ASC, artifact_type ASC, artifact_id ASC',
+				$this->table_name,
+				max( 0, $agent_id )
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+
+		return array_map( array( $this, 'artifact_from_row' ), is_array( $rows ) ? $rows : array() );
+	}
+
+	/**
+	 * Refresh current hash/status for an existing tracked artifact.
+	 */
+	public function refresh_current_payload( string $bundle_slug, string $artifact_type, string $artifact_id, mixed $current_payload, int $agent_id = 0, ?string $timestamp = null ): ?AgentBundleInstalledArtifact {
+		$existing = $this->get( $bundle_slug, $artifact_type, $artifact_id, $agent_id );
+		if ( null === $existing ) {
+			return null;
+		}
+
+		$updated = $existing->with_current_payload( $current_payload, null !== $timestamp ? $timestamp : gmdate( 'Y-m-d H:i:s' ) );
+		$this->upsert( $updated, $agent_id );
+
+		return $updated;
+	}
+
+	/**
+	 * Build an orphaned artifact record for runtime state that lacks install metadata.
+	 */
+	public static function orphaned_artifact( string $bundle_slug, string $bundle_version, string $artifact_type, string $artifact_id, string $source_path, mixed $current_payload, string $timestamp ): AgentBundleInstalledArtifact {
+		return AgentBundleInstalledArtifact::from_array(
+			array(
+				'bundle_slug'    => $bundle_slug,
+				'bundle_version' => $bundle_version,
+				'artifact_type'  => $artifact_type,
+				'artifact_id'    => $artifact_id,
+				'source_path'    => $source_path,
+				'installed_hash' => '',
+				'current_hash'   => AgentBundleArtifactHasher::hash( $current_payload ),
+				'installed_at'   => $timestamp,
+				'updated_at'     => $timestamp,
+			)
+		);
+	}
+
+	/**
+	 * Delete a tracked artifact row.
+	 */
+	public function delete( string $bundle_slug, string $artifact_type, string $artifact_id, int $agent_id = 0 ): bool {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $this->wpdb->delete(
+			$this->table_name,
+			array(
+				'agent_id'       => max( 0, $agent_id ),
+				'bundle_slug'    => $bundle_slug,
+				'artifact_type'  => $artifact_type,
+				'artifact_id'    => $artifact_id,
+			),
+			array( '%d', '%s', '%s', '%s' )
+		);
+
+		return false !== $result;
+	}
+
+	private function artifact_from_row( array $row ): AgentBundleInstalledArtifact {
+		return AgentBundleInstalledArtifact::from_array(
+			array(
+				'bundle_slug'    => (string) $row['bundle_slug'],
+				'bundle_version' => (string) $row['bundle_version'],
+				'artifact_type'  => (string) $row['artifact_type'],
+				'artifact_id'    => (string) $row['artifact_id'],
+				'source_path'    => (string) $row['source_path'],
+				'installed_hash' => (string) $row['installed_hash'],
+				'current_hash'   => isset( $row['current_hash'] ) ? (string) $row['current_hash'] : null,
+				'installed_at'   => (string) $row['installed_at'],
+				'updated_at'     => (string) $row['updated_at'],
+			)
+		);
+	}
+
+	private function existing_record_id( array $row ): ?int {
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$value = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				'SELECT artifact_record_id FROM %i WHERE agent_id = %d AND bundle_slug = %s AND artifact_type = %s AND artifact_id = %s LIMIT 1',
+				$this->table_name,
+				(int) $row['agent_id'],
+				(string) $row['bundle_slug'],
+				(string) $row['artifact_type'],
+				(string) $row['artifact_id']
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+
+		return null === $value ? null : (int) $value;
+	}
+
+	private function safe_log_context( array $row ): array {
+		return array(
+			'agent_id'       => (int) $row['agent_id'],
+			'bundle_slug'    => (string) $row['bundle_slug'],
+			'artifact_type'  => (string) $row['artifact_type'],
+			'artifact_id'    => (string) $row['artifact_id'],
+			'local_status'   => AgentBundleArtifactStatus::classify( (string) $row['installed_hash'], isset( $row['current_hash'] ) ? (string) $row['current_hash'] : null ),
+		);
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
@@ -19,19 +19,19 @@ final class AgentBundleInstalledArtifact {
 	private string $artifact_type;
 	private string $artifact_id;
 	private string $source_path;
-	private string $installed_hash;
+	private ?string $installed_hash;
 	private ?string $current_hash;
 	private string $status;
 	private string $installed_at;
 	private string $updated_at;
 
-	public function __construct( string $bundle_slug, string $bundle_version, string $artifact_type, string $artifact_id, string $source_path, string $installed_hash, ?string $current_hash, string $installed_at, string $updated_at ) {
+	public function __construct( string $bundle_slug, string $bundle_version, string $artifact_type, string $artifact_id, string $source_path, ?string $installed_hash, ?string $current_hash, string $installed_at, string $updated_at ) {
 		$this->bundle_slug    = PortableSlug::normalize( $bundle_slug, 'bundle' );
 		$this->bundle_version = self::non_empty_string( $bundle_version, 'bundle_version' );
 		$this->artifact_type  = self::validate_artifact_type( $artifact_type );
 		$this->artifact_id    = self::non_empty_string( $artifact_id, 'artifact_id' );
 		$this->source_path    = self::normalize_source_path( $source_path );
-		$this->installed_hash = self::non_empty_string( $installed_hash, 'installed_hash' );
+		$this->installed_hash = self::optional_string( $installed_hash );
 		$this->current_hash   = self::optional_string( $current_hash );
 		$this->status         = AgentBundleArtifactStatus::classify( $this->installed_hash, $this->current_hash );
 		$this->installed_at   = self::non_empty_string( $installed_at, 'installed_at' );
@@ -57,7 +57,7 @@ final class AgentBundleInstalledArtifact {
 			(string) $data['artifact_type'],
 			(string) $data['artifact_id'],
 			(string) $data['source_path'],
-			(string) $data['installed_hash'],
+			isset( $data['installed_hash'] ) ? (string) $data['installed_hash'] : null,
 			isset( $data['current_hash'] ) ? (string) $data['current_hash'] : null,
 			(string) $data['installed_at'],
 			(string) $data['updated_at']
@@ -121,7 +121,7 @@ final class AgentBundleInstalledArtifact {
 	private static function validate_artifact_type( string $type ): string {
 		$type = self::non_empty_string( $type, 'artifact_type' );
 		if ( ! in_array( $type, BundleSchema::ARTIFACT_TYPES, true ) ) {
-			throw new BundleValidationException( sprintf( 'installed bundle artifact_type must be one of: %s.', implode( ', ', BundleSchema::ARTIFACT_TYPES ) ) );
+			throw new BundleValidationException( sprintf( 'installed bundle artifact_type must be one of: %s.', esc_html( implode( ', ', BundleSchema::ARTIFACT_TYPES ) ) ) );
 		}
 
 		return $type;
@@ -142,7 +142,7 @@ final class AgentBundleInstalledArtifact {
 	}
 
 	private static function normalize_source_path( string $path ): string {
-		$path = str_replace( "\\", '/', self::non_empty_string( $path, 'source_path' ) );
+		$path = str_replace( '\\', '/', self::non_empty_string( $path, 'source_path' ) );
 		$path = ltrim( $path, '/' );
 		if ( str_contains( $path, '..' ) ) {
 			throw new BundleValidationException( 'installed bundle artifact source_path must be bundle-local.' );

--- a/inc/migrations/bundle-artifacts.php
+++ b/inc/migrations/bundle-artifacts.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Data Machine — installed bundle artifact tracking table migration.
+ *
+ * @package DataMachine
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Ensure the installed bundle artifact tracking table exists on upgraded installs.
+ *
+ * Fresh installs create the table during activation. Deploy-in-place upgrades do
+ * not fire activation hooks, so the runtime migration chain also enters the same
+ * idempotent dbDelta path once per version gate.
+ *
+ * @return void
+ */
+function datamachine_migrate_bundle_artifacts_table(): void {
+	\DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts::create_table();
+}

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -29,6 +29,7 @@ require_once __DIR__ . '/split-queue-payload.php';
 require_once __DIR__ . '/user-message-queue-mode.php';
 require_once __DIR__ . '/webhook-auth-v2.php';
 require_once __DIR__ . '/agent-config-model-shape.php';
+require_once __DIR__ . '/bundle-artifacts.php';
 
 // Schema-migration runtime — defines `datamachine_run_schema_migrations()`
 // and `datamachine_maybe_run_deferred_migrations()`. Hooked at

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -125,6 +125,9 @@ function datamachine_run_schema_migrations(): void {
 
 	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
 	datamachine_drop_redundant_post_pipeline_meta();
+
+	// Ensure installed bundle artifact tracking table exists on upgraded installs (#1531).
+	datamachine_migrate_bundle_artifacts_table();
 }
 
 /**

--- a/tests/agent-bundle-artifact-store-smoke.php
+++ b/tests/agent-bundle-artifact-store-smoke.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Pure-PHP smoke test for installed bundle artifact persistence (#1531).
+ *
+ * Run with: php tests/agent-bundle-artifact-store-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook = '' ) {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( $hook = '' ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		// no-op.
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ) {
+		// no-op.
+	}
+}
+
+if ( ! function_exists( 'dbDelta' ) ) {
+	function dbDelta( $sql ) {
+		$GLOBALS['datamachine_bundle_artifact_store_dbdelta_sql'] = $sql;
+		return array();
+	}
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts;
+use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+
+final class BundleArtifactStoreFakeWpdb {
+	public string $prefix = 'wp_';
+	public string $last_error = '';
+	public array $rows = array();
+	private int $next_id = 1;
+
+	public function get_charset_collate(): string {
+		return 'DEFAULT CHARSET=utf8mb4';
+	}
+
+	public function prepare( string $query, ...$args ): array {
+		return array(
+			'query' => $query,
+			'args'  => $args,
+		);
+	}
+
+	public function replace( string $table, array $row, array $format ) {
+		$id = isset( $row['artifact_record_id'] ) ? (int) $row['artifact_record_id'] : 0;
+		if ( $id <= 0 ) {
+			$id = $this->next_id++;
+		}
+		$row['artifact_record_id'] = $id;
+		$this->rows[ $id ]         = $row;
+
+		return 1;
+	}
+
+	public function get_var( $prepared ) {
+		$args = $prepared['args'] ?? array();
+		if ( count( $args ) < 5 ) {
+			return null;
+		}
+
+		foreach ( $this->rows as $row ) {
+			if ( $this->matches_identity( $row, (int) $args[1], (string) $args[2], (string) $args[3], (string) $args[4] ) ) {
+				return $row['artifact_record_id'];
+			}
+		}
+
+		return null;
+	}
+
+	public function get_row( $prepared, $output = ARRAY_A ) {
+		$args = $prepared['args'] ?? array();
+		foreach ( $this->rows as $row ) {
+			if ( $this->matches_identity( $row, (int) $args[1], (string) $args[2], (string) $args[3], (string) $args[4] ) ) {
+				return $row;
+			}
+		}
+
+		return null;
+	}
+
+	public function get_results( $prepared, $output = ARRAY_A ): array {
+		$query = $prepared['query'] ?? '';
+		$args  = $prepared['args'] ?? array();
+		$rows  = array();
+
+		foreach ( $this->rows as $row ) {
+			if ( str_contains( $query, 'bundle_slug = %s' ) ) {
+				if ( (int) $row['agent_id'] !== (int) $args[1] || (string) $row['bundle_slug'] !== (string) $args[2] ) {
+					continue;
+				}
+			} elseif ( (int) $row['agent_id'] !== (int) $args[1] ) {
+				continue;
+			}
+
+			$rows[] = $row;
+		}
+
+		usort(
+			$rows,
+			static fn( array $a, array $b ): int => ( $a['bundle_slug'] <=> $b['bundle_slug'] ) ?: ( $a['artifact_type'] <=> $b['artifact_type'] ) ?: ( $a['artifact_id'] <=> $b['artifact_id'] )
+		);
+
+		return $rows;
+	}
+
+	public function delete( string $table, array $where, array $format ) {
+		foreach ( $this->rows as $id => $row ) {
+			if ( $this->matches_identity( $row, (int) $where['agent_id'], (string) $where['bundle_slug'], (string) $where['artifact_type'], (string) $where['artifact_id'] ) ) {
+				unset( $this->rows[ $id ] );
+				return 1;
+			}
+		}
+
+		return 0;
+	}
+
+	private function matches_identity( array $row, int $agent_id, string $bundle_slug, string $artifact_type, string $artifact_id ): bool {
+		return (int) $row['agent_id'] === $agent_id
+			&& (string) $row['bundle_slug'] === $bundle_slug
+			&& (string) $row['artifact_type'] === $artifact_type
+			&& (string) $row['artifact_id'] === $artifact_id;
+	}
+}
+
+$failures = 0;
+$total    = 0;
+
+function assert_bundle_artifact_store( string $label, bool $condition ): void {
+	global $failures, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	echo "  FAIL: {$label}\n";
+	++$failures;
+}
+
+function assert_bundle_artifact_store_equals( string $label, $expected, $actual ): void {
+	assert_bundle_artifact_store( $label, $expected === $actual );
+}
+
+echo "=== Agent Bundle Artifact Store Smoke (#1531) ===\n";
+
+$GLOBALS['wpdb'] = new BundleArtifactStoreFakeWpdb();
+
+$manifest = AgentBundleManifest::from_array(
+	array(
+		'schema_version' => 1,
+		'bundle_slug'    => 'WPCOM History',
+		'bundle_version' => '2026.04.28',
+		'exported_at'    => '2026-04-28T00:00:00Z',
+		'exported_by'    => 'data-machine/test',
+		'agent'          => array(
+			'slug'         => 'wpcom-agent',
+			'label'        => 'WPCOM Agent',
+			'description'  => 'Maintains WPCOM history.',
+			'agent_config' => array(),
+		),
+		'included'       => array(
+			'memory'       => array(),
+			'pipelines'    => array(),
+			'flows'        => array(),
+			'handler_auth' => 'refs',
+		),
+	)
+);
+
+$store = new InstalledBundleArtifacts();
+
+echo "\n[1] Table schema tracks bundle artifacts independently\n";
+InstalledBundleArtifacts::create_table();
+$sql = $GLOBALS['datamachine_bundle_artifact_store_dbdelta_sql'] ?? '';
+foreach ( array( 'datamachine_bundle_artifacts', 'agent_id', 'bundle_slug', 'bundle_version', 'artifact_type', 'artifact_id', 'source_path', 'installed_hash', 'current_hash', 'local_status', 'installed_at', 'updated_at' ) as $needle ) {
+	assert_bundle_artifact_store( "schema includes {$needle}", str_contains( $sql, $needle ) );
+}
+assert_bundle_artifact_store( 'schema has stable artifact identity key', str_contains( $sql, 'UNIQUE KEY artifact_identity (agent_id, bundle_slug, artifact_type, artifact_id)' ) );
+
+echo "\n[2] Install records store hashes, not payloads or secrets\n";
+$installed_payload = array(
+	'name'   => 'Historical digest',
+	'config' => array(
+		'query'     => 'WordPress.com launch',
+		'api_token' => 'super-secret-token',
+	),
+);
+$installed         = $store->record_install( $manifest, 'prompt', 'launch-history', 'prompts/launch-history.md', $installed_payload, 42, '2026-04-28 00:00:00' );
+$stored_row        = array_values( $GLOBALS['wpdb']->rows )[0];
+assert_bundle_artifact_store_equals( 'record install starts clean', AgentBundleArtifactStatus::CLEAN, $installed->to_array()['status'] );
+assert_bundle_artifact_store_equals( 'agent id scopes installed row', 42, $stored_row['agent_id'] );
+assert_bundle_artifact_store_equals( 'bundle slug normalized in stored row', 'wpcom-history', $stored_row['bundle_slug'] );
+assert_bundle_artifact_store_equals( 'installed hash persisted', AgentBundleArtifactHasher::hash( $installed_payload ), $stored_row['installed_hash'] );
+assert_bundle_artifact_store( 'raw payload is not stored', ! array_key_exists( 'payload', $stored_row ) );
+assert_bundle_artifact_store( 'secret value is not stored', ! str_contains( json_encode( $stored_row ) ?: '', 'super-secret-token' ) );
+
+echo "\n[3] Refreshing current payload distinguishes clean, modified, and missing\n";
+$clean = $store->refresh_current_payload( 'wpcom-history', 'prompt', 'launch-history', $installed_payload, 42, '2026-04-28 01:00:00' );
+assert_bundle_artifact_store_equals( 'same current payload remains clean', AgentBundleArtifactStatus::CLEAN, $clean?->to_array()['status'] ?? null );
+
+$modified_payload = array(
+	'name'   => 'Edited digest',
+	'config' => array( 'query' => 'WordPress.com edited launch' ),
+);
+$modified         = $store->refresh_current_payload( 'wpcom-history', 'prompt', 'launch-history', $modified_payload, 42, '2026-04-28 02:00:00' );
+assert_bundle_artifact_store_equals( 'changed current payload is modified', AgentBundleArtifactStatus::MODIFIED, $modified?->to_array()['status'] ?? null );
+assert_bundle_artifact_store_equals( 'stored local_status mirrors modified status', AgentBundleArtifactStatus::MODIFIED, array_values( $GLOBALS['wpdb']->rows )[0]['local_status'] );
+
+$missing = $store->refresh_current_payload( 'wpcom-history', 'prompt', 'launch-history', null, 42, '2026-04-28 03:00:00' );
+assert_bundle_artifact_store_equals( 'null current payload is missing', AgentBundleArtifactStatus::MISSING, $missing?->to_array()['status'] ?? null );
+assert_bundle_artifact_store_equals( 'missing row stores null current hash', null, array_values( $GLOBALS['wpdb']->rows )[0]['current_hash'] );
+
+echo "\n[4] Lookup/list/delete APIs preserve artifact identity\n";
+$store->record_install( $manifest, 'flow', 'launch-loop', 'flows/launch-loop.json', array( 'steps' => array( 'fetch', 'ai' ) ), 42, '2026-04-28 00:00:00' );
+$store->record_install( $manifest, 'pipeline', 'launch-pipeline', 'pipelines/launch-pipeline.json', array( 'steps' => array( 'fetch' ) ), 7, '2026-04-28 00:00:00' );
+assert_bundle_artifact_store_equals( 'get returns scoped artifact', 'prompt', $store->get( 'wpcom-history', 'prompt', 'launch-history', 42 )?->to_array()['artifact_type'] ?? null );
+assert_bundle_artifact_store_equals( 'wrong agent scope does not leak artifact', null, $store->get( 'wpcom-history', 'prompt', 'launch-history', 7 ) );
+assert_bundle_artifact_store_equals( 'list_for_bundle returns only scoped bundle rows', 2, count( $store->list_for_bundle( 'wpcom-history', 42 ) ) );
+assert_bundle_artifact_store_equals( 'list_for_agent returns only agent rows', 1, count( $store->list_for_agent( 7 ) ) );
+assert_bundle_artifact_store( 'delete succeeds', $store->delete( 'wpcom-history', 'flow', 'launch-loop', 42 ) );
+assert_bundle_artifact_store_equals( 'deleted artifact no longer resolves', null, $store->get( 'wpcom-history', 'flow', 'launch-loop', 42 ) );
+
+echo "\n[5] Orphan helper captures untracked runtime state without installed hash\n";
+$orphaned = InstalledBundleArtifacts::orphaned_artifact( 'wpcom-history', '2026.04.28', 'tool_policy', 'publisher-policy', 'tool-policies/publisher-policy.json', array( 'tools' => array( 'publish' ) ), '2026-04-28 04:00:00' )->to_array();
+assert_bundle_artifact_store_equals( 'orphaned helper classifies orphaned state', AgentBundleArtifactStatus::ORPHANED, $orphaned['status'] );
+assert_bundle_artifact_store_equals( 'orphaned helper has no installed hash', null, $orphaned['installed_hash'] );
+assert_bundle_artifact_store( 'orphaned helper hashes current payload', is_string( $orphaned['current_hash'] ) && 64 === strlen( $orphaned['current_hash'] ) );
+
+echo "\nTotal assertions: {$total}\n";
+// @phpstan-ignore-next-line Smoke assertion counter is mutated through helper calls at runtime.
+if ( 0 !== $failures ) {
+	echo "Failures: {$failures}\n";
+	exit( 1 );
+}
+
+echo "All assertions passed.\n";

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -127,6 +127,7 @@ $migration_chain = array(
 	'datamachine_migrate_webhook_auth_v2',
 	'datamachine_migrate_agent_config_model_shape',
 	'datamachine_drop_redundant_post_pipeline_meta',
+	'datamachine_migrate_bundle_artifacts_table',
 );
 
 foreach ( $migration_chain as $fn ) {


### PR DESCRIPTION
## Summary
- Add a site-scoped installed bundle artifact table/repository so bundle installs can track artifact hashes independently of runtime tables.
- Persist hash-only artifact state for clean/modified/missing/orphaned comparisons without storing artifact payloads or secrets.
- Wire the table into activation and the runtime migration chain so upgraded installs get the schema without reactivation.

## Changes
- Adds `InstalledBundleArtifacts` repository with install recording, scoped lookup/list/delete, current-payload refresh, and orphan helper APIs.
- Allows installed artifact value objects to represent orphaned runtime state with no install hash.
- Documents the persistent `datamachine_bundle_artifacts` table and updates migration smoke coverage.

## Tests
- `php tests/agent-bundle-artifact-store-smoke.php && php tests/agent-bundle-installed-artifact-smoke.php && php tests/agent-bundle-upgrade-planner-smoke.php && php tests/agent-bundle-format-smoke.php && php tests/migration-runtime-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@bundle-artifact-tracking --file inc/Core/Database/BundleArtifacts/InstalledBundleArtifacts.php --errors-only`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@bundle-artifact-tracking --file inc/Engine/Bundle/AgentBundleInstalledArtifact.php --errors-only`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@bundle-artifact-tracking --file inc/migrations/bundle-artifacts.php --errors-only`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@bundle-artifact-tracking --file tests/agent-bundle-artifact-store-smoke.php --errors-only`
- `git diff --check`

Note: `homeboy lint --changed-only --errors-only` has no new lint findings, but the command exits non-zero because the lint wrapper routes changed PHP/Markdown paths through ESLint and reports parser errors with an empty finding list. Focused Homeboy lint on the PHP files above passed.

Closes #1531.
Refs #1533.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the installed artifact repository, migration wiring, documentation update, and focused smoke tests; Chris remains responsible for review and merge.
