### PR TITLE
feat(agent): add import-agent ability

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -194,7 +194,7 @@ class AgentAbilities {
 							),
 							'on_conflict' => array(
 								'type'        => 'string',
-								'enum'        => array( 'error', 'replace', 'skip' ),
+								'enum'        => array( 'error', 'skip' ),
 								'description' => 'How to handle an existing target agent slug.',
 							),
 							'owner_id'    => array(
@@ -482,10 +482,10 @@ class AgentAbilities {
 	 */
 	public static function listAgents( array $input ): array {
 		// ---- Parameter resolution ----------------------------------------
-		$scope        = isset( $input['scope'] ) ? (string) $input['scope'] : 'mine';
+		$scope             = isset( $input['scope'] ) ? (string) $input['scope'] : 'mine';
 		$requested_user_id = isset( $input['user_id'] ) ? (int) $input['user_id'] : 0;
-		$site_id      = isset( $input['site_id'] ) ? (int) $input['site_id'] : get_current_blog_id();
-		$include_role = ! empty( $input['include_role'] );
+		$site_id           = isset( $input['site_id'] ) ? (int) $input['site_id'] : get_current_blog_id();
+		$include_role      = ! empty( $input['include_role'] );
 
 		if ( ! in_array( $scope, array( 'mine', 'all' ), true ) ) {
 			return array(
@@ -578,9 +578,9 @@ class AgentAbilities {
 		$agents = array();
 
 		foreach ( $candidates as $row ) {
-			$agent_id   = (int) $row['agent_id'];
-			$owner_id   = (int) $row['owner_id'];
-			$config     = is_array( $row['agent_config'] ?? null ) ? $row['agent_config'] : array();
+			$agent_id    = (int) $row['agent_id'];
+			$owner_id    = (int) $row['owner_id'];
+			$config      = is_array( $row['agent_config'] ?? null ) ? $row['agent_config'] : array();
 			$description = isset( $config['description'] ) ? (string) $config['description'] : '';
 
 			$item = array(
@@ -629,10 +629,10 @@ class AgentAbilities {
 		}
 
 		$on_conflict = (string) ( $input['on_conflict'] ?? 'error' );
-		if ( ! in_array( $on_conflict, array( 'error', 'replace', 'skip' ), true ) ) {
+		if ( ! in_array( $on_conflict, array( 'error', 'skip' ), true ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'on_conflict must be one of: error, replace, skip.',
+				'error'   => 'on_conflict must be one of: error, skip.',
 			);
 		}
 
@@ -653,13 +653,18 @@ class AgentAbilities {
 			);
 		}
 
-		$slug     = isset( $input['slug'] ) && '' !== trim( (string) $input['slug'] )
-			? sanitize_title( (string) $input['slug'] )
-			: sanitize_title( (string) ( $bundle['agent']['agent_slug'] ?? '' ) );
+		$slug = sanitize_title( (string) ( $bundle['agent']['agent_slug'] ?? '' ) );
+		if ( isset( $input['slug'] ) && '' !== trim( (string) $input['slug'] ) ) {
+			$slug = sanitize_title( (string) $input['slug'] );
+		}
 		if ( isset( $input['slug'] ) && '' !== $slug ) {
 			$bundle['agent']['agent_slug'] = $slug;
 		}
 		$existing = $slug ? ( new Agents() )->get_by_slug( $slug ) : null;
+
+		$auth_resolution = self::resolve_import_auth_refs( $bundle );
+		$bundle          = $auth_resolution['bundle'];
+		$auth_warnings   = $auth_resolution['warnings'];
 
 		if ( $existing && 'skip' === $on_conflict ) {
 			return array(
@@ -667,7 +672,7 @@ class AgentAbilities {
 				'skipped'       => true,
 				'agent_id'      => (int) $existing['agent_id'],
 				'agent_slug'    => $slug,
-				'auth_warnings' => self::collect_import_auth_warnings( $bundle ),
+				'auth_warnings' => $auth_warnings,
 				'message'       => sprintf( 'Agent "%s" already exists; import skipped.', $slug ),
 			);
 		}
@@ -677,12 +682,11 @@ class AgentAbilities {
 				'success'    => false,
 				'agent_id'   => (int) $existing['agent_id'],
 				'agent_slug' => $slug,
-				'error'      => sprintf( 'Agent slug "%s" already exists. Use on_conflict=replace to update it or on_conflict=skip to no-op.', $slug ),
+				'error'      => sprintf( 'Agent slug "%s" already exists. Use on_conflict=skip to no-op, or import with a new slug.', $slug ),
 			);
 		}
 
-		$auth_warnings = self::collect_import_auth_warnings( $bundle );
-		$result        = $bundler->import( $bundle, null, $owner_id, ! empty( $input['dry_run'] ) );
+		$result = $bundler->import( $bundle, null, $owner_id, ! empty( $input['dry_run'] ) );
 		if ( empty( $result['success'] ) ) {
 			$result['auth_warnings'] = $auth_warnings;
 			return $result;
@@ -734,28 +738,42 @@ class AgentAbilities {
 	}
 
 	/**
-	 * Resolve auth_ref markers far enough to surface missing target credentials.
+	 * Resolve auth_ref markers into local handler configs before import.
 	 *
 	 * @param array $bundle Legacy bundle array.
-	 * @return array<int,array<string,string>>
+	 * @return array{bundle: array, warnings: array<int,array<string,string>>}
 	 */
-	private static function collect_import_auth_warnings( array $bundle ): array {
+	private static function resolve_import_auth_refs( array $bundle ): array {
 		$warnings = array();
-		foreach ( $bundle['flows'] ?? array() as $flow ) {
+		if ( ! is_array( $bundle['flows'] ?? null ) ) {
+			return array(
+				'bundle'   => $bundle,
+				'warnings' => $warnings,
+			);
+		}
+
+		foreach ( $bundle['flows'] as $flow_index => &$flow ) {
 			if ( ! is_array( $flow ) ) {
 				continue;
 			}
-			foreach ( $flow['flow_config'] ?? array() as $flow_step_id => $step ) {
+			$disable_flow = false;
+			if ( ! is_array( $flow['flow_config'] ?? null ) ) {
+				continue;
+			}
+
+			foreach ( $flow['flow_config'] as $flow_step_id => &$step ) {
 				if ( ! is_array( $step ) || ! is_array( $step['handler_configs'] ?? null ) ) {
 					continue;
 				}
-				foreach ( $step['handler_configs'] as $handler_slug => $handler_config ) {
+				foreach ( $step['handler_configs'] as $handler_slug => &$handler_config ) {
 					if ( ! is_array( $handler_config ) || empty( $handler_config['auth_ref'] ) ) {
 						continue;
 					}
 
 					$resolved = apply_filters( 'datamachine_auth_ref_to_handler_config', $handler_config, (string) $handler_slug, array( 'import' => true ) );
 					if ( is_wp_error( $resolved ) ) {
+						$disable_flow = true;
+
 						$warnings[] = array(
 							'flow'         => (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? '' ) ),
 							'flow_step_id' => (string) $flow_step_id,
@@ -764,12 +782,31 @@ class AgentAbilities {
 							'code'         => $resolved->get_error_code(),
 							'message'      => $resolved->get_error_message(),
 						);
+						continue;
+					}
+
+					if ( is_array( $resolved ) ) {
+						$handler_config = $resolved;
 					}
 				}
+				unset( $handler_config );
+			}
+			unset( $step );
+
+			if ( $disable_flow ) {
+				$scheduling_config                    = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
+				$scheduling_config['enabled']         = false;
+				$scheduling_config['interval']        = 'manual';
+				$scheduling_config['disabled_reason'] = 'unresolved_auth_ref';
+				$flow['scheduling_config']            = $scheduling_config;
 			}
 		}
+		unset( $flow );
 
-		return $warnings;
+		return array(
+			'bundle'   => $bundle,
+			'warnings' => $warnings,
+		);
 	}
 
 	/**
@@ -1207,12 +1244,12 @@ class AgentAbilities {
 				$files    = new \RecursiveIteratorIterator( $iterator, \RecursiveIteratorIterator::CHILD_FIRST );
 				foreach ( $files as $file ) {
 					if ( $file->isDir() ) {
-						rmdir( $file->getRealPath() );
+						rmdir( $file->getRealPath() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- DirectoryManager owns agent filesystem paths.
 					} else {
-						wp_delete_file( $file->getRealPath( ) );
+						wp_delete_file( $file->getRealPath() );
 					}
 				}
-				rmdir( $agent_dir );
+				rmdir( $agent_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- DirectoryManager owns agent filesystem paths.
 				$files_deleted = true;
 			}
 		}

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -677,7 +677,7 @@ class AgentAbilities {
 			);
 		}
 
-		if ( $existing && 'error' === $on_conflict ) {
+		if ( $existing ) {
 			return array(
 				'success'    => false,
 				'agent_id'   => (int) $existing['agent_id'],

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Agents\AgentAccess;
 use DataMachine\Core\FilesRepository\DirectoryManager;
@@ -169,6 +170,58 @@ class AgentAbilities {
 					),
 					'execute_callback'    => array( self::class, 'createAgent' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage() || PermissionHelper::can( 'create_own_agent' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/import-agent',
+				array(
+					'label'               => 'Import Agent',
+					'description'         => 'Materialize a portable agent bundle from a local bundle directory, JSON file, or ZIP archive.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'source' ),
+						'properties' => array(
+							'source'      => array(
+								'type'        => 'string',
+								'description' => 'Local bundle source path. Supports bundle directories, .json files, and .zip archives.',
+							),
+							'slug'        => array(
+								'type'        => 'string',
+								'description' => 'Optional target agent slug override.',
+							),
+							'on_conflict' => array(
+								'type'        => 'string',
+								'enum'        => array( 'error', 'replace', 'skip' ),
+								'description' => 'How to handle an existing target agent slug.',
+							),
+							'owner_id'    => array(
+								'type'        => 'integer',
+								'description' => 'WordPress user ID that should own the imported agent.',
+							),
+							'dry_run'     => array(
+								'type'        => 'boolean',
+								'description' => 'Validate and summarize without writing.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'       => array( 'type' => 'boolean' ),
+							'skipped'       => array( 'type' => 'boolean' ),
+							'agent_id'      => array( 'type' => 'integer' ),
+							'agent_slug'    => array( 'type' => 'string' ),
+							'imported'      => array( 'type' => 'object' ),
+							'auth_warnings' => array( 'type' => 'array' ),
+							'summary'       => array( 'type' => 'object' ),
+							'error'         => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'importAgent' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -558,6 +611,165 @@ class AgentAbilities {
 			'success' => true,
 			'agents'  => $agents,
 		);
+	}
+
+	/**
+	 * Import an agent bundle through the generic ability surface.
+	 *
+	 * @param array $input Import parameters.
+	 * @return array<string,mixed>
+	 */
+	public static function importAgent( array $input ): array {
+		$source = trim( (string) ( $input['source'] ?? '' ) );
+		if ( '' === $source || ! file_exists( $source ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bundle source not found.',
+			);
+		}
+
+		$on_conflict = (string) ( $input['on_conflict'] ?? 'error' );
+		if ( ! in_array( $on_conflict, array( 'error', 'replace', 'skip' ), true ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'on_conflict must be one of: error, replace, skip.',
+			);
+		}
+
+		$owner_id = self::resolve_import_owner_id( isset( $input['owner_id'] ) ? (int) $input['owner_id'] : 0 );
+		if ( $owner_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'Unable to resolve import owner. Pass owner_id, authenticate as a user, or set datamachine_default_owner_id.',
+			);
+		}
+
+		$bundler = new AgentBundler();
+		$bundle  = self::load_import_bundle( $bundler, $source );
+		if ( ! is_array( $bundle ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to parse bundle. Use a bundle directory, .json file, or .zip archive.',
+			);
+		}
+
+		$slug     = isset( $input['slug'] ) && '' !== trim( (string) $input['slug'] )
+			? sanitize_title( (string) $input['slug'] )
+			: sanitize_title( (string) ( $bundle['agent']['agent_slug'] ?? '' ) );
+		if ( isset( $input['slug'] ) && '' !== $slug ) {
+			$bundle['agent']['agent_slug'] = $slug;
+		}
+		$existing = $slug ? ( new Agents() )->get_by_slug( $slug ) : null;
+
+		if ( $existing && 'skip' === $on_conflict ) {
+			return array(
+				'success'       => true,
+				'skipped'       => true,
+				'agent_id'      => (int) $existing['agent_id'],
+				'agent_slug'    => $slug,
+				'auth_warnings' => self::collect_import_auth_warnings( $bundle ),
+				'message'       => sprintf( 'Agent "%s" already exists; import skipped.', $slug ),
+			);
+		}
+
+		if ( $existing && 'error' === $on_conflict ) {
+			return array(
+				'success'    => false,
+				'agent_id'   => (int) $existing['agent_id'],
+				'agent_slug' => $slug,
+				'error'      => sprintf( 'Agent slug "%s" already exists. Use on_conflict=replace to update it or on_conflict=skip to no-op.', $slug ),
+			);
+		}
+
+		$auth_warnings = self::collect_import_auth_warnings( $bundle );
+		$result        = $bundler->import( $bundle, null, $owner_id, ! empty( $input['dry_run'] ) );
+		if ( empty( $result['success'] ) ) {
+			$result['auth_warnings'] = $auth_warnings;
+			return $result;
+		}
+
+		$summary  = is_array( $result['summary'] ?? null ) ? $result['summary'] : array();
+		$imported = array(
+			'pipelines' => (int) ( $summary['pipelines_imported'] ?? 0 ),
+			'flows'     => (int) ( $summary['flows_imported'] ?? 0 ),
+			'files'     => (int) ( $summary['files'] ?? 0 ),
+		);
+
+		$result['agent_id']      = (int) ( $summary['agent_id'] ?? 0 );
+		$result['agent_slug']    = (string) ( $summary['agent_slug'] ?? $slug );
+		$result['imported']      = $imported;
+		$result['auth_warnings'] = $auth_warnings;
+
+		return $result;
+	}
+
+	private static function load_import_bundle( AgentBundler $bundler, string $source ): ?array {
+		if ( is_dir( $source ) ) {
+			return $bundler->from_directory( $source );
+		}
+
+		if ( preg_match( '/\.zip$/i', $source ) ) {
+			return $bundler->from_zip( $source );
+		}
+
+		if ( preg_match( '/\.json$/i', $source ) ) {
+			return $bundler->from_json( (string) file_get_contents( $source ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		}
+
+		return null;
+	}
+
+	private static function resolve_import_owner_id( int $explicit_owner_id ): int {
+		if ( $explicit_owner_id > 0 ) {
+			return $explicit_owner_id;
+		}
+
+		$current_user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+		if ( $current_user_id > 0 ) {
+			return $current_user_id;
+		}
+
+		$default_owner_id = function_exists( 'get_option' ) ? (int) get_option( 'datamachine_default_owner_id', 0 ) : 0;
+		return $default_owner_id > 0 ? $default_owner_id : 0;
+	}
+
+	/**
+	 * Resolve auth_ref markers far enough to surface missing target credentials.
+	 *
+	 * @param array $bundle Legacy bundle array.
+	 * @return array<int,array<string,string>>
+	 */
+	private static function collect_import_auth_warnings( array $bundle ): array {
+		$warnings = array();
+		foreach ( $bundle['flows'] ?? array() as $flow ) {
+			if ( ! is_array( $flow ) ) {
+				continue;
+			}
+			foreach ( $flow['flow_config'] ?? array() as $flow_step_id => $step ) {
+				if ( ! is_array( $step ) || ! is_array( $step['handler_configs'] ?? null ) ) {
+					continue;
+				}
+				foreach ( $step['handler_configs'] as $handler_slug => $handler_config ) {
+					if ( ! is_array( $handler_config ) || empty( $handler_config['auth_ref'] ) ) {
+						continue;
+					}
+
+					$resolved = apply_filters( 'datamachine_auth_ref_to_handler_config', $handler_config, (string) $handler_slug, array( 'import' => true ) );
+					if ( is_wp_error( $resolved ) ) {
+						$warnings[] = array(
+							'flow'         => (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? '' ) ),
+							'flow_step_id' => (string) $flow_step_id,
+							'handler_slug' => (string) $handler_slug,
+							'auth_ref'     => (string) $handler_config['auth_ref'],
+							'code'         => $resolved->get_error_code(),
+							'message'      => $resolved->get_error_message(),
+						);
+					}
+				}
+			}
+		}
+
+		return $warnings;
 	}
 
 	/**

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -747,7 +747,7 @@ class AgentsCommand extends BaseCommand {
 			$items[] = array(
 				'token_id'  => $token['token_id'],
 				'prefix'    => $token['token_prefix'] . '...',
-				'label'     => $token['label'] ?: '(none)',
+				'label'     => ! empty( $token['label'] ) ? $token['label'] : '(none)',
 				'last_used' => $token['last_used_at'] ?? 'never',
 				'expires'   => $token['expires_at'] ?? 'never',
 				'status'    => $expired ? 'expired' : 'active',
@@ -1071,7 +1071,6 @@ class AgentsCommand extends BaseCommand {
 	 * default: error
 	 * options:
 	 *   - error
-	 *   - replace
 	 *   - skip
 	 * ---
 	 *

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -245,7 +245,13 @@ class AgentsCommand extends BaseCommand {
 
 		$config = array();
 		if ( isset( $assoc_args['config'] ) ) {
-			$config = json_decode( wp_unslash( $assoc_args['config'] ), true );
+			$config_json = wp_unslash( $assoc_args['config'] );
+			if ( ! is_string( $config_json ) ) {
+				WP_CLI::error( 'Invalid JSON in --config.' );
+				return;
+			}
+
+			$config = json_decode( $config_json, true );
 			if ( null === $config ) {
 				WP_CLI::error( 'Invalid JSON in --config.' );
 				return;
@@ -269,7 +275,7 @@ class AgentsCommand extends BaseCommand {
 		WP_CLI::success( $result['message'] );
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 		} else {
 			WP_CLI::log( sprintf( 'Agent ID:  %d', $result['agent_id'] ) );
 			WP_CLI::log( sprintf( 'Slug:      %s', $result['agent_slug'] ) );
@@ -321,7 +327,7 @@ class AgentsCommand extends BaseCommand {
 		$agent = $result['agent'];
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( wp_json_encode( $agent, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			WP_CLI::line( (string) wp_json_encode( $agent, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 			return;
 		}
 
@@ -340,7 +346,7 @@ class AgentsCommand extends BaseCommand {
 		if ( ! empty( $agent['agent_config'] ) ) {
 			WP_CLI::log( '' );
 			WP_CLI::log( 'Config:' );
-			WP_CLI::log( wp_json_encode( $agent['agent_config'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			WP_CLI::log( (string) wp_json_encode( $agent['agent_config'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 		}
 
 		// Access grants.
@@ -733,7 +739,7 @@ class AgentsCommand extends BaseCommand {
 		$format = $assoc_args['format'] ?? 'table';
 
 		if ( 'json' === $format ) {
-			WP_CLI::log( wp_json_encode( $tokens, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			WP_CLI::log( (string) wp_json_encode( $tokens, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 			return;
 		}
 
@@ -865,7 +871,7 @@ class AgentsCommand extends BaseCommand {
 			}
 
 			if ( 'json' === $format ) {
-				WP_CLI::log( wp_json_encode( $config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+				WP_CLI::log( (string) wp_json_encode( $config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 			} else {
 				$items = array();
 				foreach ( $config as $key => $value ) {
@@ -1000,11 +1006,11 @@ class AgentsCommand extends BaseCommand {
 		$result  = $bundler->export( $slug );
 
 		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] );
+			WP_CLI::error( (string) ( $result['error'] ?? 'Failed to export agent.' ) );
 			return;
 		}
 
-		$bundle = $result['bundle'];
+		$bundle = is_array( $result['bundle'] ?? null ) ? $result['bundle'] : array();
 
 		// Log what's being exported.
 		WP_CLI::log( sprintf( '  Agent:     %s (%s)', $bundle['agent']['agent_name'], $bundle['agent']['agent_slug'] ) );
@@ -1017,7 +1023,7 @@ class AgentsCommand extends BaseCommand {
 				$output = $output ?? $slug . '-bundle.json';
 				$json   = $bundler->to_json( $bundle );
 				file_put_contents( $output, $json ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-				WP_CLI::success( sprintf( 'Bundle exported to %s (%s)', $output, size_format( filesize( $output ) ) ) );
+				WP_CLI::success( sprintf( 'Bundle exported to %s (%s)', $output, size_format( (int) filesize( $output ) ) ) );
 				break;
 
 			case 'dir':
@@ -1042,7 +1048,7 @@ class AgentsCommand extends BaseCommand {
 					WP_CLI::error( 'Failed to create ZIP archive.' );
 					return;
 				}
-				WP_CLI::success( sprintf( 'Bundle exported to %s (%s)', $output, size_format( filesize( $output ) ) ) );
+				WP_CLI::success( sprintf( 'Bundle exported to %s (%s)', $output, size_format( (int) filesize( $output ) ) ) );
 				break;
 		}
 	}
@@ -1150,7 +1156,7 @@ class AgentsCommand extends BaseCommand {
 		}
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT ) );
 			return;
 		}
 
@@ -1297,6 +1303,7 @@ class AgentsCommand extends BaseCommand {
 			$user = get_user_by( 'id', (int) $value );
 			if ( ! $user ) {
 				WP_CLI::error( sprintf( 'User ID %d not found.', (int) $value ) );
+				return 0;
 			}
 			return $user->ID;
 		}
@@ -1305,6 +1312,7 @@ class AgentsCommand extends BaseCommand {
 			$user = get_user_by( 'email', $value );
 			if ( ! $user ) {
 				WP_CLI::error( sprintf( 'User with email "%s" not found.', $value ) );
+				return 0;
 			}
 			return $user->ID;
 		}
@@ -1312,6 +1320,7 @@ class AgentsCommand extends BaseCommand {
 		$user = get_user_by( 'login', $value );
 		if ( ! $user ) {
 			WP_CLI::error( sprintf( 'User with login "%s" not found.', $value ) );
+			return 0;
 		}
 		return $user->ID;
 	}

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -1065,6 +1065,16 @@ class AgentsCommand extends BaseCommand {
 	 * [--owner=<user>]
 	 * : Owner WordPress user ID, login, or email. Defaults to current user.
 	 *
+	 * [--on-conflict=<policy>]
+	 * : How to handle an existing target agent slug.
+	 * ---
+	 * default: error
+	 * options:
+	 *   - error
+	 *   - replace
+	 *   - skip
+	 * ---
+	 *
 	 * [--dry-run]
 	 * : Validate the bundle and show what would be imported without making changes.
 	 *
@@ -1094,6 +1104,7 @@ class AgentsCommand extends BaseCommand {
 		$path     = $args[0] ?? '';
 		$new_slug = $assoc_args['slug'] ?? null;
 		$dry_run  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$format   = (string) ( $assoc_args['format'] ?? 'table' );
 
 		if ( empty( $path ) ) {
 			WP_CLI::error( 'Bundle path is required.' );
@@ -1105,64 +1116,67 @@ class AgentsCommand extends BaseCommand {
 			return;
 		}
 
-		$bundler = new AgentBundler();
-
-		// Parse the bundle based on path type.
-		if ( is_dir( $path ) ) {
-			$bundle = $bundler->from_directory( $path );
-		} elseif ( preg_match( '/\.zip$/i', $path ) ) {
-			$bundle = $bundler->from_zip( $path );
-		} elseif ( preg_match( '/\.json$/i', $path ) ) {
-			$json   = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			$bundle = $bundler->from_json( $json );
-		} else {
-			WP_CLI::error( 'Unsupported bundle format. Use .zip, .json, or a directory path.' );
-			return;
-		}
-
-		if ( ! $bundle ) {
-			WP_CLI::error( 'Failed to parse bundle. Ensure the file is a valid agent bundle.' );
-			return;
-		}
-
-		// Display bundle info.
-		$agent_data  = $bundle['agent'] ?? array();
-		$target_slug = $new_slug ? sanitize_title( $new_slug ) : sanitize_title( $agent_data['agent_slug'] ?? 'unknown' );
-
-		WP_CLI::log( 'Bundle contents:' );
-		WP_CLI::log( sprintf( '  Agent:     %s (%s)', $agent_data['agent_name'] ?? '(unnamed)', $agent_data['agent_slug'] ?? '(no slug)' ) );
-		WP_CLI::log( sprintf( '  Target:    %s', $target_slug ) );
-		WP_CLI::log( sprintf( '  Files:     %d identity file(s)', count( $bundle['files'] ?? array() ) ) );
-		WP_CLI::log( sprintf( '  Pipelines: %d', count( $bundle['pipelines'] ?? array() ) ) );
-		WP_CLI::log( sprintf( '  Flows:     %d', count( $bundle['flows'] ?? array() ) ) );
-		WP_CLI::log( sprintf( '  Exported:  %s', $bundle['exported_at'] ?? 'unknown' ) );
-
 		// Resolve owner.
 		$owner_id = 0;
 		if ( isset( $assoc_args['owner'] ) ) {
 			$owner_id = $this->resolveUserId( $assoc_args['owner'] );
 		}
 
-		if ( $dry_run ) {
+		if ( $dry_run && 'json' !== $format ) {
 			WP_CLI::log( '' );
 			WP_CLI::log( WP_CLI::colorize( '%YDry run mode — validating bundle...%n' ) );
 		} elseif ( ! isset( $assoc_args['yes'] ) ) {
-			WP_CLI::confirm( sprintf( 'Import agent "%s"?', $target_slug ) );
+			WP_CLI::confirm( 'Import agent bundle?' );
 		}
 
-		$result = $bundler->import( $bundle, $new_slug, $owner_id, $dry_run );
+		$ability = wp_get_ability( 'datamachine/import-agent' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'datamachine/import-agent ability is not registered.' );
+			return;
+		}
+
+		$result = $ability->execute(
+			array(
+				'source'      => $path,
+				'slug'        => $new_slug,
+				'owner_id'    => $owner_id,
+				'on_conflict' => (string) ( $assoc_args['on-conflict'] ?? 'error' ),
+				'dry_run'     => $dry_run,
+			)
+		);
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] );
 			return;
 		}
 
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		foreach ( $result['auth_warnings'] ?? array() as $warning ) {
+			WP_CLI::warning(
+				sprintf(
+					'%s: %s',
+					(string) ( $warning['auth_ref'] ?? 'auth_ref' ),
+					(string) ( $warning['message'] ?? 'unresolved auth reference' )
+				)
+			);
+		}
+
+		if ( ! empty( $result['skipped'] ) ) {
+			WP_CLI::success( (string) ( $result['message'] ?? 'Import skipped.' ) );
+			return;
+		}
+
 		if ( $dry_run ) {
 			$summary = $result['summary'] ?? array();
+			$slug    = (string) ( $summary['agent_slug'] ?? 'unknown' );
 
 			WP_CLI::log( '' );
 			WP_CLI::log( 'Import preview:' );
-			WP_CLI::log( sprintf( '  Agent slug:  %s', $summary['agent_slug'] ?? $target_slug ) );
+			WP_CLI::log( sprintf( '  Agent slug:  %s', $slug ) );
 			WP_CLI::log( sprintf( '  Agent name:  %s', $summary['agent_name'] ?? '(unnamed)' ) );
 			WP_CLI::log( sprintf( '  Owner ID:    %d', $summary['owner_id'] ?? 0 ) );
 			WP_CLI::log( sprintf( '  Files:       %d', $summary['files'] ?? 0 ) );

--- a/tests/import-agent-ability-smoke.php
+++ b/tests/import-agent-ability-smoke.php
@@ -52,56 +52,62 @@ namespace {
 	function is_wp_error( mixed $thing ): bool {
 		return $thing instanceof WP_Error;
 	}
-}
 
-namespace DataMachine\Core\Agents {
-	class AgentBundler {
-		public static array $last_import = array();
+	eval(
+		<<<'PHP'
+		namespace DataMachine\Core\Agents;
 
-		public function from_directory( string $source ): ?array {
-			return null;
+		class AgentBundler {
+			public static array $last_import = array();
+
+			public function from_directory( string $source ): ?array {
+				return null;
+			}
+
+			public function from_zip( string $source ): ?array {
+				return null;
+			}
+
+			public function from_json( string $json ): ?array {
+				$bundle = json_decode( $json, true );
+				return is_array( $bundle ) ? $bundle : null;
+			}
+
+			public function import( array $bundle, ?string $new_slug = null, int $owner_id = 0, bool $dry_run = false ): array {
+				self::$last_import = compact( 'bundle', 'new_slug', 'owner_id', 'dry_run' );
+
+				return array(
+					'success' => true,
+					'summary' => array(
+						'agent_id'           => 123,
+						'agent_slug'         => (string) ( $bundle['agent']['agent_slug'] ?? '' ),
+						'pipelines_imported' => count( $bundle['pipelines'] ?? array() ),
+						'flows_imported'     => count( $bundle['flows'] ?? array() ),
+						'files'              => count( $bundle['files'] ?? array() ),
+					),
+				);
+			}
+		}
+		PHP
+	);
+
+	eval(
+		<<<'PHP'
+		namespace DataMachine\Core\Database\Agents;
+
+		class Agents {
+			public static array $by_slug = array();
+
+			public function get_by_slug( string $slug ): ?array {
+				return self::$by_slug[ $slug ] ?? null;
+			}
 		}
 
-		public function from_zip( string $source ): ?array {
-			return null;
-		}
+		class AgentAccess {}
+		PHP
+	);
 
-		public function from_json( string $json ): ?array {
-			$bundle = json_decode( $json, true );
-			return is_array( $bundle ) ? $bundle : null;
-		}
-
-		public function import( array $bundle, ?string $new_slug = null, int $owner_id = 0, bool $dry_run = false ): array {
-			self::$last_import = compact( 'bundle', 'new_slug', 'owner_id', 'dry_run' );
-
-			return array(
-				'success' => true,
-				'summary' => array(
-					'agent_id'           => 123,
-					'agent_slug'         => (string) ( $bundle['agent']['agent_slug'] ?? '' ),
-					'pipelines_imported' => count( $bundle['pipelines'] ?? array() ),
-					'flows_imported'     => count( $bundle['flows'] ?? array() ),
-					'files'              => count( $bundle['files'] ?? array() ),
-				),
-			);
-		}
-	}
-}
-
-namespace DataMachine\Core\Database\Agents {
-	class Agents {
-		public static array $by_slug = array();
-
-		public function get_by_slug( string $slug ): ?array {
-			return self::$by_slug[ $slug ] ?? null;
-		}
-	}
-
-	class AgentAccess {}
-}
-
-namespace DataMachine\Core\FilesRepository {
-	class DirectoryManager {}
+	eval( 'namespace DataMachine\\Core\\FilesRepository; class DirectoryManager {}' );
 }
 
 namespace DataMachine\Abilities {

--- a/tests/import-agent-ability-smoke.php
+++ b/tests/import-agent-ability-smoke.php
@@ -166,7 +166,9 @@ namespace {
 	};
 
 	$reset = function (): void {
+		// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 		AgentBundler::$last_import                   = array();
+		// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 		Agents::$by_slug                             = array();
 		$GLOBALS['datamachine_test_current_user_id'] = 42;
 		$GLOBALS['datamachine_test_auth_resolver']   = null;
@@ -176,6 +178,7 @@ namespace {
 
 	echo "\n[1] Conflict modes\n";
 	$reset();
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 	Agents::$by_slug['portable-agent'] = array( 'agent_id' => 77 );
 	$bundle_path                       = $write_bundle( $base_bundle() );
 	$result                            = AgentAbilities::importAgent(
@@ -185,6 +188,7 @@ namespace {
 		)
 	);
 	$assert( 'conflict error fails', false === $result['success'] );
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 	$assert( 'conflict error happens before import writes', array() === AgentBundler::$last_import );
 
 	$result = AgentAbilities::importAgent(
@@ -195,6 +199,7 @@ namespace {
 	);
 	$assert( 'conflict skip succeeds', true === $result['success'] );
 	$assert( 'conflict skip marks skipped', true === $result['skipped'] );
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 	$assert( 'conflict skip does not import', array() === AgentBundler::$last_import );
 
 	$result = AgentAbilities::importAgent(
@@ -217,9 +222,13 @@ namespace {
 		)
 	);
 	$assert( 'accepted import succeeds', true === $result['success'] );
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 	$assert( 'accepted import reaches bundler import', ! empty( AgentBundler::$last_import ) );
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 	$assert( 'slug override rewrites bundle before import', 'renamed-agent' === AgentBundler::$last_import['bundle']['agent']['agent_slug'] );
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 	$assert( 'owner_id passes through to bundler import', 99 === AgentBundler::$last_import['owner_id'] );
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 	$assert( 'ability lets bundler use rewritten bundle slug, not new_slug', null === AgentBundler::$last_import['new_slug'] );
 
 	echo "\n[3] Auth ref resolution\n";
@@ -243,6 +252,7 @@ namespace {
 	);
 	$bundle_path                                      = $write_bundle( $bundle );
 	$result                                           = AgentAbilities::importAgent( array( 'source' => $bundle_path ) );
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 	$imported_bundle                                  = AgentBundler::$last_import['bundle'];
 	$resolved_config                                  = $imported_bundle['flows'][0]['flow_config']['step-one']['handler_configs']['resolvable'];
 	$unresolved_config                                = $imported_bundle['flows'][0]['flow_config']['step-two']['handler_configs']['missing'];

--- a/tests/import-agent-ability-smoke.php
+++ b/tests/import-agent-ability-smoke.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Smoke test for the generic import-agent ability slice (#1306).
+ *
+ * Run with: php tests/import-agent-ability-smoke.php
+ */
+
+$root = dirname( __DIR__ );
+
+$agent_abilities = file_get_contents( $root . '/inc/Abilities/AgentAbilities.php' ) ?: '';
+$agents_command  = file_get_contents( $root . '/inc/Cli/Commands/AgentsCommand.php' ) ?: '';
+
+$assertions = 0;
+
+$assert = function ( string $label, bool $condition ) use ( &$assertions ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$label}\n" );
+		exit( 1 );
+	}
+	echo "ok - {$label}\n";
+};
+
+echo "=== Import Agent Ability Smoke (#1306) ===\n";
+
+echo "\n[1] Ability surface\n";
+$assert( 'registers datamachine/import-agent ability', str_contains( $agent_abilities, "'datamachine/import-agent'" ) );
+$assert( 'ability requires source input', str_contains( $agent_abilities, "'required'   => array( 'source' )" ) );
+$assert( 'ability exposes on_conflict enum', str_contains( $agent_abilities, "'on_conflict'" ) && str_contains( $agent_abilities, "array( 'error', 'replace', 'skip' )" ) );
+$assert( 'ability exposes owner_id input', str_contains( $agent_abilities, "'owner_id'" ) );
+$assert( 'ability output includes imported summary', str_contains( $agent_abilities, "'imported'" ) );
+$assert( 'ability output includes auth warnings', str_contains( $agent_abilities, "'auth_warnings'" ) );
+$assert( 'ability execute callback points at importAgent', str_contains( $agent_abilities, "'execute_callback'    => array( self::class, 'importAgent' )" ) );
+
+echo "\n[2] Import behavior contract\n";
+$assert( 'source loader supports directories', str_contains( $agent_abilities, 'return $bundler->from_directory( $source );' ) );
+$assert( 'source loader supports zip archives', str_contains( $agent_abilities, 'return $bundler->from_zip( $source );' ) );
+$assert( 'source loader supports json bundles', str_contains( $agent_abilities, 'return $bundler->from_json' ) );
+$assert( 'owner resolution checks current user', str_contains( $agent_abilities, 'get_current_user_id()' ) );
+$assert( 'owner resolution checks default owner option', str_contains( $agent_abilities, "get_option( 'datamachine_default_owner_id'" ) );
+$assert( 'owner resolution rejects unresolved owner instead of falling through to admin', str_contains( $agent_abilities, 'Unable to resolve import owner' ) );
+$assert( 'conflict error fails before importer writes', str_contains( $agent_abilities, "'error' === $" . 'on_conflict' ) && str_contains( $agent_abilities, 'already exists. Use on_conflict=replace' ) );
+$assert( 'conflict skip returns skipped success', str_contains( $agent_abilities, "'skipped'       => true" ) );
+$assert( 'slug override rewrites bundle slug before import', str_contains( $agent_abilities, "$" . "bundle['agent']['agent_slug'] = $" . 'slug;' ) );
+
+echo "\n[3] Auth-ref warning contract\n";
+$assert( 'auth refs are routed through resolver filter', str_contains( $agent_abilities, "apply_filters( 'datamachine_auth_ref_to_handler_config'" ) );
+$assert( 'unresolved auth refs are collected as warnings', str_contains( $agent_abilities, 'collect_import_auth_warnings' ) && str_contains( $agent_abilities, 'is_wp_error( $resolved )' ) );
+$assert( 'auth warning records handler slug', str_contains( $agent_abilities, "'handler_slug' => (string) $" . 'handler_slug' ) );
+$assert( 'auth warning records auth ref', str_contains( $agent_abilities, "'auth_ref'     => (string) $" . "handler_config['auth_ref']" ) );
+
+echo "\n[4] CLI wrapper\n";
+$assert( 'agent import command documents on-conflict', str_contains( $agents_command, '[--on-conflict=<policy>]' ) );
+$assert( 'agent import command resolves ability from registry', str_contains( $agents_command, "wp_get_ability( 'datamachine/import-agent' )" ) );
+$assert( 'agent import command executes ability with source', str_contains( $agents_command, "'source'      => $" . 'path' ) );
+$assert( 'agent import command passes owner_id', str_contains( $agents_command, "'owner_id'    => $" . 'owner_id' ) );
+$assert( 'agent import command passes on_conflict', str_contains( $agents_command, "'on_conflict' => (string) ( $" . "assoc_args['on-conflict']" ) );
+$assert( 'agent import command supports JSON output from ability result', str_contains( $agents_command, "'json' === $" . 'format' ) && str_contains( $agents_command, 'wp_json_encode( $result, JSON_PRETTY_PRINT )' ) );
+
+echo "\nAssertions: {$assertions}\n";
+echo "PASS\n";

--- a/tests/import-agent-ability-smoke.php
+++ b/tests/import-agent-ability-smoke.php
@@ -1,61 +1,264 @@
 <?php
 /**
- * Smoke test for the generic import-agent ability slice (#1306).
+ * Behavior smoke test for the generic import-agent ability slice (#1306).
  *
  * Run with: php tests/import-agent-ability-smoke.php
  */
 
-$root = dirname( __DIR__ );
+namespace {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 
-$agent_abilities = file_get_contents( $root . '/inc/Abilities/AgentAbilities.php' ) ?: '';
-$agents_command  = file_get_contents( $root . '/inc/Cli/Commands/AgentsCommand.php' ) ?: '';
+	class WP_Error {
+		private string $code;
+		private string $message;
 
-$assertions = 0;
+		public function __construct( string $code, string $message ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
 
-$assert = function ( string $label, bool $condition ) use ( &$assertions ): void {
-	++$assertions;
-	if ( ! $condition ) {
-		fwrite( STDERR, "FAIL: {$label}\n" );
-		exit( 1 );
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
 	}
-	echo "ok - {$label}\n";
-};
 
-echo "=== Import Agent Ability Smoke (#1306) ===\n";
+	function sanitize_title( string $title ): string {
+		$title = strtolower( trim( $title ) );
+		$title = preg_replace( '/[^a-z0-9]+/', '-', $title ) ?? '';
+		return trim( $title, '-' );
+	}
 
-echo "\n[1] Ability surface\n";
-$assert( 'registers datamachine/import-agent ability', str_contains( $agent_abilities, "'datamachine/import-agent'" ) );
-$assert( 'ability requires source input', str_contains( $agent_abilities, "'required'   => array( 'source' )" ) );
-$assert( 'ability exposes on_conflict enum', str_contains( $agent_abilities, "'on_conflict'" ) && str_contains( $agent_abilities, "array( 'error', 'replace', 'skip' )" ) );
-$assert( 'ability exposes owner_id input', str_contains( $agent_abilities, "'owner_id'" ) );
-$assert( 'ability output includes imported summary', str_contains( $agent_abilities, "'imported'" ) );
-$assert( 'ability output includes auth warnings', str_contains( $agent_abilities, "'auth_warnings'" ) );
-$assert( 'ability execute callback points at importAgent', str_contains( $agent_abilities, "'execute_callback'    => array( self::class, 'importAgent' )" ) );
+	function get_current_user_id(): int {
+		return (int) ( $GLOBALS['datamachine_test_current_user_id'] ?? 0 );
+	}
 
-echo "\n[2] Import behavior contract\n";
-$assert( 'source loader supports directories', str_contains( $agent_abilities, 'return $bundler->from_directory( $source );' ) );
-$assert( 'source loader supports zip archives', str_contains( $agent_abilities, 'return $bundler->from_zip( $source );' ) );
-$assert( 'source loader supports json bundles', str_contains( $agent_abilities, 'return $bundler->from_json' ) );
-$assert( 'owner resolution checks current user', str_contains( $agent_abilities, 'get_current_user_id()' ) );
-$assert( 'owner resolution checks default owner option', str_contains( $agent_abilities, "get_option( 'datamachine_default_owner_id'" ) );
-$assert( 'owner resolution rejects unresolved owner instead of falling through to admin', str_contains( $agent_abilities, 'Unable to resolve import owner' ) );
-$assert( 'conflict error fails before importer writes', str_contains( $agent_abilities, "'error' === $" . 'on_conflict' ) && str_contains( $agent_abilities, 'already exists. Use on_conflict=replace' ) );
-$assert( 'conflict skip returns skipped success', str_contains( $agent_abilities, "'skipped'       => true" ) );
-$assert( 'slug override rewrites bundle slug before import', str_contains( $agent_abilities, "$" . "bundle['agent']['agent_slug'] = $" . 'slug;' ) );
+	function get_option( string $name, mixed $default = false ): mixed {
+		return $GLOBALS['datamachine_test_options'][ $name ] ?? $default;
+	}
 
-echo "\n[3] Auth-ref warning contract\n";
-$assert( 'auth refs are routed through resolver filter', str_contains( $agent_abilities, "apply_filters( 'datamachine_auth_ref_to_handler_config'" ) );
-$assert( 'unresolved auth refs are collected as warnings', str_contains( $agent_abilities, 'collect_import_auth_warnings' ) && str_contains( $agent_abilities, 'is_wp_error( $resolved )' ) );
-$assert( 'auth warning records handler slug', str_contains( $agent_abilities, "'handler_slug' => (string) $" . 'handler_slug' ) );
-$assert( 'auth warning records auth ref', str_contains( $agent_abilities, "'auth_ref'     => (string) $" . "handler_config['auth_ref']" ) );
+	function apply_filters( string $hook_name, mixed $value, mixed ...$args ): mixed {
+		if ( 'datamachine_auth_ref_to_handler_config' !== $hook_name ) {
+			return $value;
+		}
 
-echo "\n[4] CLI wrapper\n";
-$assert( 'agent import command documents on-conflict', str_contains( $agents_command, '[--on-conflict=<policy>]' ) );
-$assert( 'agent import command resolves ability from registry', str_contains( $agents_command, "wp_get_ability( 'datamachine/import-agent' )" ) );
-$assert( 'agent import command executes ability with source', str_contains( $agents_command, "'source'      => $" . 'path' ) );
-$assert( 'agent import command passes owner_id', str_contains( $agents_command, "'owner_id'    => $" . 'owner_id' ) );
-$assert( 'agent import command passes on_conflict', str_contains( $agents_command, "'on_conflict' => (string) ( $" . "assoc_args['on-conflict']" ) );
-$assert( 'agent import command supports JSON output from ability result', str_contains( $agents_command, "'json' === $" . 'format' ) && str_contains( $agents_command, 'wp_json_encode( $result, JSON_PRETTY_PRINT )' ) );
+		$resolver = $GLOBALS['datamachine_test_auth_resolver'] ?? null;
+		return is_callable( $resolver ) ? $resolver( $value, ...$args ) : $value;
+	}
 
-echo "\nAssertions: {$assertions}\n";
-echo "PASS\n";
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+namespace DataMachine\Core\Agents {
+	class AgentBundler {
+		public static array $last_import = array();
+
+		public function from_directory( string $source ): ?array {
+			return null;
+		}
+
+		public function from_zip( string $source ): ?array {
+			return null;
+		}
+
+		public function from_json( string $json ): ?array {
+			$bundle = json_decode( $json, true );
+			return is_array( $bundle ) ? $bundle : null;
+		}
+
+		public function import( array $bundle, ?string $new_slug = null, int $owner_id = 0, bool $dry_run = false ): array {
+			self::$last_import = compact( 'bundle', 'new_slug', 'owner_id', 'dry_run' );
+
+			return array(
+				'success' => true,
+				'summary' => array(
+					'agent_id'           => 123,
+					'agent_slug'         => (string) ( $bundle['agent']['agent_slug'] ?? '' ),
+					'pipelines_imported' => count( $bundle['pipelines'] ?? array() ),
+					'flows_imported'     => count( $bundle['flows'] ?? array() ),
+					'files'              => count( $bundle['files'] ?? array() ),
+				),
+			);
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Agents {
+	class Agents {
+		public static array $by_slug = array();
+
+		public function get_by_slug( string $slug ): ?array {
+			return self::$by_slug[ $slug ] ?? null;
+		}
+	}
+
+	class AgentAccess {}
+}
+
+namespace DataMachine\Core\FilesRepository {
+	class DirectoryManager {}
+}
+
+namespace DataMachine\Abilities {
+	require_once dirname( __DIR__ ) . '/inc/Abilities/AgentAbilities.php';
+}
+
+namespace {
+	use DataMachine\Abilities\AgentAbilities;
+	use DataMachine\Core\Agents\AgentBundler;
+	use DataMachine\Core\Database\Agents\Agents;
+
+	$assertions = 0;
+
+	$assert = function ( string $label, bool $condition ) use ( &$assertions ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			fwrite( STDERR, "FAIL: {$label}\n" );
+			exit( 1 );
+		}
+		echo "ok - {$label}\n";
+	};
+
+	$write_bundle = function ( array $bundle ): string {
+		$path = tempnam( sys_get_temp_dir(), 'datamachine-import-agent-' );
+		if ( false === $path ) {
+			fwrite( STDERR, "FAIL: unable to create temp bundle\n" );
+			exit( 1 );
+		}
+		$json_path = $path . '.json';
+		rename( $path, $json_path );
+		file_put_contents( $json_path, json_encode( $bundle ) );
+		return $json_path;
+	};
+
+	$base_bundle = function ( string $slug = 'portable-agent' ): array {
+		return array(
+			'bundle_version' => '1',
+			'agent'          => array(
+				'agent_slug' => $slug,
+				'agent_name' => 'Portable Agent',
+			),
+			'pipelines'      => array( array( 'pipeline_name' => 'Pipeline' ) ),
+			'flows'          => array(
+				array(
+					'portable_slug'     => 'flow-one',
+					'flow_name'         => 'Flow One',
+					'scheduling_config' => array(
+						'enabled'  => true,
+						'interval' => 'hourly',
+					),
+					'flow_config'       => array(
+						'step-one' => array(
+							'handler_configs' => array(
+								'resolvable' => array( 'auth_ref' => 'provider:local' ),
+							),
+						),
+					),
+				),
+			),
+			'files'          => array(),
+		);
+	};
+
+	$reset = function (): void {
+		AgentBundler::$last_import                   = array();
+		Agents::$by_slug                             = array();
+		$GLOBALS['datamachine_test_current_user_id'] = 42;
+		$GLOBALS['datamachine_test_auth_resolver']   = null;
+	};
+
+	echo "=== Import Agent Ability Behavior Smoke (#1306) ===\n";
+
+	echo "\n[1] Conflict modes\n";
+	$reset();
+	Agents::$by_slug['portable-agent'] = array( 'agent_id' => 77 );
+	$bundle_path                       = $write_bundle( $base_bundle() );
+	$result                            = AgentAbilities::importAgent(
+		array(
+			'source'      => $bundle_path,
+			'on_conflict' => 'error',
+		)
+	);
+	$assert( 'conflict error fails', false === $result['success'] );
+	$assert( 'conflict error happens before import writes', array() === AgentBundler::$last_import );
+
+	$result = AgentAbilities::importAgent(
+		array(
+			'source'      => $bundle_path,
+			'on_conflict' => 'skip',
+		)
+	);
+	$assert( 'conflict skip succeeds', true === $result['success'] );
+	$assert( 'conflict skip marks skipped', true === $result['skipped'] );
+	$assert( 'conflict skip does not import', array() === AgentBundler::$last_import );
+
+	$result = AgentAbilities::importAgent(
+		array(
+			'source'      => $bundle_path,
+			'on_conflict' => 'replace',
+		)
+	);
+	$assert( 'unsupported replace policy is rejected', false === $result['success'] );
+	$assert( 'replace policy is no longer claimed', str_contains( $result['error'], 'error, skip' ) );
+
+	echo "\n[2] Accepted import path\n";
+	$reset();
+	$bundle_path = $write_bundle( $base_bundle() );
+	$result      = AgentAbilities::importAgent(
+		array(
+			'source'   => $bundle_path,
+			'slug'     => 'Renamed Agent',
+			'owner_id' => 99,
+		)
+	);
+	$assert( 'accepted import succeeds', true === $result['success'] );
+	$assert( 'accepted import reaches bundler import', ! empty( AgentBundler::$last_import ) );
+	$assert( 'slug override rewrites bundle before import', 'renamed-agent' === AgentBundler::$last_import['bundle']['agent']['agent_slug'] );
+	$assert( 'owner_id passes through to bundler import', 99 === AgentBundler::$last_import['owner_id'] );
+	$assert( 'ability lets bundler use rewritten bundle slug, not new_slug', null === AgentBundler::$last_import['new_slug'] );
+
+	echo "\n[3] Auth ref resolution\n";
+	$reset();
+	$GLOBALS['datamachine_test_auth_resolver'] = function ( array $handler_config, string $handler_slug ): array|WP_Error {
+		if ( 'resolvable' === $handler_slug ) {
+			return array(
+				'account_id' => 'local-account',
+				'token_id'   => 'local-token',
+			);
+		}
+
+		return new WP_Error( 'missing_auth_ref', 'Credential is not connected locally.' );
+	};
+
+	$bundle                                           = $base_bundle();
+	$bundle['flows'][0]['flow_config']['step-two']    = array(
+		'handler_configs' => array(
+			'missing' => array( 'auth_ref' => 'provider:missing' ),
+		),
+	);
+	$bundle_path                                      = $write_bundle( $bundle );
+	$result                                           = AgentAbilities::importAgent( array( 'source' => $bundle_path ) );
+	$imported_bundle                                  = AgentBundler::$last_import['bundle'];
+	$resolved_config                                  = $imported_bundle['flows'][0]['flow_config']['step-one']['handler_configs']['resolvable'];
+	$unresolved_config                                = $imported_bundle['flows'][0]['flow_config']['step-two']['handler_configs']['missing'];
+	$disabled_scheduling                              = $imported_bundle['flows'][0]['scheduling_config'];
+
+	$assert( 'auth ref resolver import succeeds with warning', true === $result['success'] );
+	$assert( 'resolved auth_ref rewrites handler config', 'local-account' === $resolved_config['account_id'] );
+	$assert( 'resolved auth_ref is removed from handler config', ! isset( $resolved_config['auth_ref'] ) );
+	$assert( 'unresolved auth_ref remains visible', 'provider:missing' === $unresolved_config['auth_ref'] );
+	$assert( 'unresolved auth_ref returns one warning', 1 === count( $result['auth_warnings'] ) );
+	$assert( 'warning names handler slug', 'missing' === $result['auth_warnings'][0]['handler_slug'] );
+	$assert( 'warning carries resolver error code', 'missing_auth_ref' === $result['auth_warnings'][0]['code'] );
+	$assert( 'flow with unresolved auth_ref is disabled', false === $disabled_scheduling['enabled'] );
+	$assert( 'disabled flow is forced manual', 'manual' === $disabled_scheduling['interval'] );
+	$assert( 'disabled flow records reason', 'unresolved_auth_ref' === $disabled_scheduling['disabled_reason'] );
+
+	echo "\nAssertions: {$assertions}\n";
+	echo "PASS\n";
+}


### PR DESCRIPTION
## Summary
- Adds the generic `datamachine/import-agent` ability for materializing portable agent bundles through the Abilities API.
- Routes `wp datamachine agent import` through the new ability while preserving the existing AgentBundler import substrate.
- Rebases the branch onto the current bundle substrate, including materialized artifact directories and plugin-defined `extensions/` artifacts.

## Changes
- Registers `datamachine/import-agent` with source, slug, owner, conflict-policy, and dry-run inputs.
- Adds owner resolution through explicit owner, current user, then `datamachine_default_owner_id` with a clear failure when unresolved.
- Supports conflict handling for `error` and `skip`. Full replacement semantics are intentionally left out of this slice rather than claimed without implementation.
- Resolves `auth_ref` markers through the existing `datamachine_auth_ref_to_handler_config` resolver before import, rewrites resolved handler configs to local config, preserves unresolved refs as warnings, and disables affected flow schedules.
- Updates the CLI import wrapper to call the ability and support `--on-conflict` plus JSON output.
- Keeps import compatibility on top of the current value-object bundle reader/writer and extension-artifact substrate.

## Tests
- `php -l inc/Abilities/AgentAbilities.php && php -l inc/Cli/Commands/AgentsCommand.php && php -l tests/import-agent-ability-smoke.php`
- `php tests/import-agent-ability-smoke.php`
- `php tests/agent-bundle-format-smoke.php && php tests/agent-bundle-extension-artifacts-smoke.php && php tests/agent-bundle-installed-artifact-smoke.php && php tests/agent-bundler-directory-adapter-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@bundle-import-agent --changed-since origin/main --summary`
- `homeboy audit --path /Users/chubes/Developer/data-machine@bundle-import-agent --changed-since origin/main data-machine --json-summary`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@bundle-import-agent --file tests/import-agent-ability-smoke.php --summary`

Known CI noise:
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@bundle-import-agent --changed-since origin/main --summary` still selects a broad WordPress PHPUnit set and fails 14 unrelated tests in memory/tool policy/internal linking/bulk config/auth-provider areas. The focused import-agent host smoke passes.

Closes #1306.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the ability/CLI slice, aligned auth-ref import behavior and conflict policy with review feedback, rebased the branch onto the current bundle substrate, fixed changed-scope lint drift, and validated focused smoke coverage; Chris remains responsible for review and merge.
