### PR TITLE
feat(bundle): add export-agent ability

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -16,6 +16,8 @@ use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Agents\AgentAccess;
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\BundleValidationException;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -34,6 +36,55 @@ class AgentAbilities {
 
 	private function registerAbilities(): void {
 		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/export-agent',
+				array(
+					'label'               => 'Export Agent',
+					'description'         => 'Export an agent as a portable bundle directory or ZIP archive.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'agent_id' ),
+						'properties' => array(
+							'agent_id'    => array(
+								'type'        => 'integer',
+								'description' => 'Agent ID to export.',
+							),
+							'profile'     => array(
+								'type'        => 'string',
+								'enum'        => array( 'share', 'backup', 'fork' ),
+								'description' => 'Export profile. Defaults to share.',
+							),
+							'destination' => array(
+								'type'        => 'string',
+								'description' => 'Destination directory or ZIP file path. Defaults to <agent-slug>-bundle.',
+							),
+							'format'      => array(
+								'type'        => 'string',
+								'enum'        => array( 'directory', 'zip' ),
+								'description' => 'Output format. Defaults to directory.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'    => array( 'type' => 'boolean' ),
+							'path'       => array( 'type' => 'string' ),
+							'format'     => array( 'type' => 'string' ),
+							'profile'    => array( 'type' => 'string' ),
+							'manifest'   => array( 'type' => 'object' ),
+							'agent_id'   => array( 'type' => 'integer' ),
+							'agent_slug' => array( 'type' => 'string' ),
+							'error'      => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'exportAgent' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
 			wp_register_ability(
 				'datamachine/rename-agent',
 				array(
@@ -1184,6 +1235,141 @@ class AgentAbilities {
 			'files_updated' => $files_updated,
 			'files_skipped' => $files_skipped,
 		);
+	}
+
+	/**
+	 * Export an agent to a portable bundle directory or ZIP file.
+	 *
+	 * @param array $input Export input.
+	 * @return array Result.
+	 */
+	public static function exportAgent( array $input ): array {
+		$agent_id = (int) ( $input['agent_id'] ?? 0 );
+		if ( $agent_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'agent_id is required.',
+			);
+		}
+
+		$agents_repo = new Agents();
+		$agent       = $agents_repo->get_agent( $agent_id );
+		if ( ! $agent ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Agent ID %d not found.', $agent_id ),
+			);
+		}
+
+		$format = (string) ( $input['format'] ?? 'directory' );
+		if ( 'dir' === $format ) {
+			$format = 'directory';
+		}
+		if ( ! in_array( $format, array( 'directory', 'zip' ), true ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'format must be directory or zip.',
+			);
+		}
+
+		$profile = (string) ( $input['profile'] ?? 'share' );
+		if ( ! in_array( $profile, array( 'share', 'backup', 'fork' ), true ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'profile must be share, backup, or fork.',
+			);
+		}
+
+		$agent_slug   = (string) $agent['agent_slug'];
+		$destination  = trim( (string) ( $input['destination'] ?? '' ) );
+		$destination  = '' !== $destination ? $destination : $agent_slug . '-bundle' . ( 'zip' === $format ? '.zip' : '' );
+		$bundler      = new AgentBundler();
+		$export       = $bundler->export_directory_object( $agent_slug, array( 'profile' => $profile ) );
+		$directory    = $export['directory'] ?? null;
+		$manifest     = $directory instanceof AgentBundleDirectory ? $directory->manifest()->to_array() : array();
+		$written_path = $destination;
+
+		if ( empty( $export['success'] ) || ! $directory instanceof AgentBundleDirectory ) {
+			return array(
+				'success' => false,
+				'error'   => (string) ( $export['error'] ?? 'Failed to build export bundle.' ),
+			);
+		}
+
+		try {
+			if ( 'directory' === $format ) {
+				$directory->write( $destination );
+			} else {
+				$written_path = self::writeBundleZip( $directory, $destination, $agent_slug );
+			}
+		} catch ( \Throwable $e ) {
+			return array(
+				'success' => false,
+				'error'   => $e->getMessage(),
+			);
+		}
+
+		return array(
+			'success'    => true,
+			'agent_id'   => $agent_id,
+			'agent_slug' => $agent_slug,
+			'profile'    => $profile,
+			'format'     => $format,
+			'path'       => $written_path,
+			'manifest'   => $manifest,
+		);
+	}
+
+	private static function writeBundleZip( AgentBundleDirectory $directory, string $zip_path, string $agent_slug ): string {
+		if ( ! class_exists( '\ZipArchive' ) ) {
+			throw new BundleValidationException( 'ZipArchive is not available.' );
+		}
+
+		$temp_dir   = sys_get_temp_dir() . '/datamachine-agent-export-' . uniqid( '', true );
+		$bundle_dir = $temp_dir . '/' . sanitize_title( $agent_slug );
+		wp_mkdir_p( $bundle_dir );
+		$directory->write( $bundle_dir );
+
+		$zip = new \ZipArchive();
+		if ( true !== $zip->open( $zip_path, \ZipArchive::CREATE | \ZipArchive::OVERWRITE ) ) {
+			self::removeDirectory( $temp_dir );
+			throw new BundleValidationException( sprintf( 'Unable to create ZIP archive: %s', esc_html( $zip_path ) ) );
+		}
+
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $bundle_dir, \RecursiveDirectoryIterator::SKIP_DOTS ),
+			\RecursiveIteratorIterator::SELF_FIRST
+		);
+		foreach ( $iterator as $item ) {
+			$relative_path = sanitize_title( $agent_slug ) . '/' . substr( $item->getPathname(), strlen( $bundle_dir ) + 1 );
+			if ( $item->isDir() ) {
+				$zip->addEmptyDir( $relative_path );
+			} else {
+				$zip->addFile( $item->getPathname(), $relative_path );
+			}
+		}
+		$zip->close();
+		self::removeDirectory( $temp_dir );
+
+		return $zip_path;
+	}
+
+	private static function removeDirectory( string $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $dir, \RecursiveDirectoryIterator::SKIP_DOTS ),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ( $iterator as $item ) {
+			if ( $item->isDir() ) {
+				rmdir( $item->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+			} else {
+				wp_delete_file( $item->getPathname() );
+			}
+		}
+		rmdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
 	}
 
 	/**

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -957,100 +957,91 @@ class AgentsCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <slug>
-	 * : Agent slug to export.
+	 * <agent>
+	 * : Agent ID or slug to export.
+	 *
+	 * [--profile=<profile>]
+	 * : Export profile.
+	 * ---
+	 * default: share
+	 * options:
+	 *   - share
+	 *   - backup
+	 *   - fork
+	 * ---
 	 *
 	 * [--format=<format>]
 	 * : Bundle format.
 	 * ---
-	 * default: zip
+	 * default: directory
 	 * options:
 	 *   - zip
-	 *   - json
-	 *   - dir
+	 *   - directory
 	 * ---
 	 *
-	 * [--output=<path>]
-	 * : Output path. For zip/json, a file path. For dir, a directory path.
+	 * [--destination=<path>]
+	 * : Output path. For zip, a file path. For directory, a directory path.
 	 *   Defaults to current directory with auto-generated filename.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Export as ZIP (default)
-	 *     wp datamachine agents export mattic-agent
+	 *     # Export as directory (default)
+	 *     wp datamachine agents export 42
 	 *
-	 *     # Export as JSON
-	 *     wp datamachine agents export mattic-agent --format=json
+	 *     # Export as ZIP
+	 *     wp datamachine agents export mattic-agent --format=zip --destination=/tmp/mattic-agent.zip
 	 *
-	 *     # Export as directory
-	 *     wp datamachine agents export mattic-agent --format=dir --output=/tmp/mattic-bundle
-	 *
-	 *     # Export to specific file
-	 *     wp datamachine agents export mattic-agent --output=/tmp/mattic-agent.zip
+	 *     # Export backup profile as directory
+	 *     wp datamachine agents export mattic-agent --profile=backup --destination=/tmp/mattic-bundle
 	 *
 	 * @subcommand export
 	 */
 	public function export( array $args, array $assoc_args ): void {
-		$slug   = sanitize_title( $args[0] ?? '' );
-		$format = $assoc_args['format'] ?? 'zip';
-		$output = $assoc_args['output'] ?? null;
+		$identifier  = (string) ( $args[0] ?? '' );
+		$format      = (string) ( $assoc_args['format'] ?? 'directory' );
+		$destination = (string) ( $assoc_args['destination'] ?? ( $assoc_args['output'] ?? '' ) );
+		$profile     = (string) ( $assoc_args['profile'] ?? 'share' );
 
-		if ( empty( $slug ) ) {
-			WP_CLI::error( 'Agent slug is required.' );
+		if ( '' === trim( $identifier ) ) {
+			WP_CLI::error( 'Agent ID or slug is required.' );
 			return;
 		}
 
-		WP_CLI::log( sprintf( 'Exporting agent "%s"...', $slug ) );
+		$agents_repo = new \DataMachine\Core\Database\Agents\Agents();
+		$agent       = is_numeric( $identifier )
+			? $agents_repo->get_agent( (int) $identifier )
+			: $agents_repo->get_by_slug( sanitize_title( $identifier ) );
 
-		$bundler = new AgentBundler();
-		$result  = $bundler->export( $slug );
+		if ( ! $agent ) {
+			WP_CLI::error( sprintf( 'Agent "%s" not found.', $identifier ) );
+			return;
+		}
 
-		if ( ! $result['success'] ) {
+		$input = array(
+			'agent_id' => (int) $agent['agent_id'],
+			'profile'  => $profile,
+			'format'   => $format,
+		);
+		if ( '' !== trim( $destination ) ) {
+			$input['destination'] = $destination;
+		}
+
+		WP_CLI::log( sprintf( 'Exporting agent "%s"...', $agent['agent_slug'] ) );
+		$result = AgentAbilities::exportAgent( $input );
+		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( (string) ( $result['error'] ?? 'Failed to export agent.' ) );
 			return;
 		}
 
-		$bundle = is_array( $result['bundle'] ?? null ) ? $result['bundle'] : array();
-
-		// Log what's being exported.
-		WP_CLI::log( sprintf( '  Agent:     %s (%s)', $bundle['agent']['agent_name'], $bundle['agent']['agent_slug'] ) );
-		WP_CLI::log( sprintf( '  Files:     %d identity file(s)', count( $bundle['files'] ?? array() ) ) );
-		WP_CLI::log( sprintf( '  Pipelines: %d', count( $bundle['pipelines'] ?? array() ) ) );
-		WP_CLI::log( sprintf( '  Flows:     %d', count( $bundle['flows'] ?? array() ) ) );
-
-		switch ( $format ) {
-			case 'json':
-				$output = $output ?? $slug . '-bundle.json';
-				$json   = $bundler->to_json( $bundle );
-				file_put_contents( $output, $json ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-				WP_CLI::success( sprintf( 'Bundle exported to %s (%s)', $output, size_format( (int) filesize( $output ) ) ) );
-				break;
-
-			case 'dir':
-				$output = $output ?? $slug . '-bundle';
-				if ( is_dir( $output ) ) {
-					WP_CLI::error( sprintf( 'Directory "%s" already exists. Remove it first or use --output=<path>.', $output ) );
-					return;
-				}
-				$wrote = $bundler->to_directory( $bundle, $output );
-				if ( ! $wrote ) {
-					WP_CLI::error( 'Failed to write bundle directory.' );
-					return;
-				}
-				WP_CLI::success( sprintf( 'Bundle exported to directory: %s', $output ) );
-				break;
-
-			case 'zip':
-			default:
-				$output = $output ?? $slug . '-bundle.zip';
-				$wrote  = $bundler->to_zip( $bundle, $output );
-				if ( ! $wrote ) {
-					WP_CLI::error( 'Failed to create ZIP archive.' );
-					return;
-				}
-				WP_CLI::success( sprintf( 'Bundle exported to %s (%s)', $output, size_format( (int) filesize( $output ) ) ) );
-				break;
-		}
+		$manifest = is_array( $result['manifest'] ?? null ) ? $result['manifest'] : array();
+		$included = is_array( $manifest['included'] ?? null ) ? $manifest['included'] : array();
+		WP_CLI::log( sprintf( '  Agent:     %s (%s)', $manifest['agent']['label'] ?? $agent['agent_name'], $agent['agent_slug'] ) );
+		WP_CLI::log( sprintf( '  Profile:   %s', $result['profile'] ) );
+		WP_CLI::log( sprintf( '  Format:    %s', $result['format'] ) );
+		WP_CLI::log( sprintf( '  Memory:    %d file(s)', count( $included['memory'] ?? array() ) ) );
+		WP_CLI::log( sprintf( '  Pipelines: %d', count( $included['pipelines'] ?? array() ) ) );
+		WP_CLI::log( sprintf( '  Flows:     %d', count( $included['flows'] ?? array() ) ) );
+		WP_CLI::success( sprintf( 'Bundle exported to %s', $result['path'] ) );
 	}
 
 	/**

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -1111,7 +1111,6 @@ class AgentsCommand extends BaseCommand {
 			WP_CLI::error( sprintf( 'Path not found: %s', $path ) );
 			return;
 		}
-
 		// Resolve owner.
 		$owner_id = 0;
 		if ( isset( $assoc_args['owner'] ) ) {
@@ -1142,7 +1141,7 @@ class AgentsCommand extends BaseCommand {
 		);
 
 		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] );
+			WP_CLI::error( $result['error'] ?? 'Failed to import agent bundle.' );
 			return;
 		}
 
@@ -1198,7 +1197,7 @@ class AgentsCommand extends BaseCommand {
 		WP_CLI::log( sprintf( '  Pipelines:   %d imported', $summary['pipelines_imported'] ?? 0 ) );
 		WP_CLI::log( sprintf( '  Flows:       %d imported (paused)', $summary['flows_imported'] ?? 0 ) );
 
-		WP_CLI::success( $result['message'] );
+		WP_CLI::success( $result['message'] ?? 'Agent bundle imported.' );
 	}
 
 	/**

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -101,7 +101,7 @@ class AgentBundler {
 	 * @param string $slug Agent slug.
 	 * @return array{success: bool, directory?: AgentBundleDirectory, agent?: array, error?: string}
 	 */
-	public function export_directory_object( string $slug ): array {
+	public function export_directory_object( string $slug, array $context = array() ): array {
 		$agent = $this->agents_repo->get_by_slug( sanitize_title( $slug ) );
 
 		if ( ! $agent ) {
@@ -111,7 +111,9 @@ class AgentBundler {
 			);
 		}
 
-		$agent_id = (int) $agent['agent_id'];
+		$agent_id        = (int) $agent['agent_id'];
+		$export_manifest = self::resolve_export_manifest( $agent_id, $context );
+		$handler_auth    = (string) $export_manifest['handler_auth'];
 
 		$pipelines                 = $this->pipelines_repo->get_all_pipelines( null, $agent_id );
 		$flows                     = $this->flows_repo->get_all_flows( null, $agent_id );
@@ -125,65 +127,87 @@ class AgentBundler {
 		$used_flow_slugs           = array();
 
 		foreach ( $this->collect_agent_files( $agent['agent_slug'] ) as $path => $contents ) {
+			if ( 'SOUL.md' === $path && empty( $export_manifest['soul'] ) ) {
+				continue;
+			}
+			if ( 'MEMORY.md' === $path && empty( $export_manifest['memory'] ) ) {
+				continue;
+			}
 			$memory_files[ 'agent/' . ltrim( (string) $path, '/' ) ] = $contents;
 		}
 
 		$owner_id      = (int) $agent['owner_id'];
 		$user_template = $this->collect_user_template( $owner_id );
-		if ( '' !== $user_template ) {
+		if ( ! empty( $export_manifest['user'] ) && '' !== $user_template ) {
 			$memory_files['USER.md'] = $user_template;
 		}
 
-		foreach ( $pipelines as $pipeline ) {
-			$pipeline_id                          = (int) $pipeline['pipeline_id'];
-			$portable_slug                        = ! empty( $pipeline['portable_slug'] )
-				? PortableSlug::normalize( (string) $pipeline['portable_slug'], 'pipeline' )
-				: PortableSlug::normalize( (string) $pipeline['pipeline_name'], 'pipeline' );
-			$portable_slug                        = PortableSlug::dedupe( $portable_slug, $used_pipeline_slugs );
-			$used_pipeline_slugs[]                = $portable_slug;
-			$pipeline_config                      = is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array();
-			$pipeline_slugs_by_id[ $pipeline_id ] = $portable_slug;
+		if ( ! empty( $export_manifest['pipelines'] ) ) {
+			foreach ( $pipelines as $pipeline ) {
+				$pipeline_id                          = (int) $pipeline['pipeline_id'];
+				$portable_slug                        = ! empty( $pipeline['portable_slug'] )
+					? PortableSlug::normalize( (string) $pipeline['portable_slug'], 'pipeline' )
+					: PortableSlug::normalize( (string) $pipeline['pipeline_name'], 'pipeline' );
+				$portable_slug                        = PortableSlug::dedupe( $portable_slug, $used_pipeline_slugs );
+				$used_pipeline_slugs[]                = $portable_slug;
+				$pipeline_config                      = is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array();
+				$pipeline_slugs_by_id[ $pipeline_id ] = $portable_slug;
 
-			foreach ( $pipeline_config as $pipeline_step_id => $pipeline_step ) {
-				if ( is_array( $pipeline_step ) ) {
-					$pipeline_step_types_by_id[ (string) $pipeline_step_id ] = (string) ( $pipeline_step['step_type'] ?? '' );
+				foreach ( $pipeline_config as $pipeline_step_id => $pipeline_step ) {
+					if ( is_array( $pipeline_step ) ) {
+						$pipeline_step_types_by_id[ (string) $pipeline_step_id ] = (string) ( $pipeline_step['step_type'] ?? '' );
+					}
 				}
-			}
 
-			$pipeline_documents[] = new AgentBundlePipelineFile(
-				$portable_slug,
-				(string) $pipeline['pipeline_name'],
-				self::pipeline_document_steps_from_config( $pipeline_config )
-			);
+				$pipeline_documents[] = new AgentBundlePipelineFile(
+					$portable_slug,
+					(string) $pipeline['pipeline_name'],
+					self::pipeline_document_steps_from_config( $pipeline_config )
+				);
 
-			foreach ( $this->collect_pipeline_memory_files( $pipeline_id ) as $path => $contents ) {
-				$memory_files[ 'pipelines/' . $portable_slug . '/' . ltrim( (string) $path, '/' ) ] = $contents;
+				if ( ! empty( $export_manifest['memory'] ) ) {
+					foreach ( $this->collect_pipeline_memory_files( $pipeline_id ) as $path => $contents ) {
+						$memory_files[ 'pipelines/' . $portable_slug . '/' . ltrim( (string) $path, '/' ) ] = $contents;
+					}
+				}
 			}
 		}
 
-		foreach ( $flows as $flow ) {
-			$flow_id           = (int) $flow['flow_id'];
-			$pipeline_id       = (int) $flow['pipeline_id'];
-			$portable_slug     = ! empty( $flow['portable_slug'] )
-				? PortableSlug::normalize( (string) $flow['portable_slug'], 'flow' )
-				: PortableSlug::normalize( (string) $flow['flow_name'], 'flow' );
-			$portable_slug     = PortableSlug::dedupe( $portable_slug, $used_flow_slugs );
-			$used_flow_slugs[] = $portable_slug;
-			$scheduling        = $this->sanitize_scheduling_config( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() );
-			$flow_documents[]  = new AgentBundleFlowFile(
-				$portable_slug,
-				(string) $flow['flow_name'],
-				$pipeline_slugs_by_id[ $pipeline_id ] ?? 'pipeline',
-				(string) ( $scheduling['interval'] ?? 'manual' ),
-				is_array( $scheduling['max_items'] ?? null ) ? $scheduling['max_items'] : array(),
-				self::flow_document_steps_from_config(
-					is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array(),
-					$pipeline_step_types_by_id
-				)
-			);
+		if ( ! empty( $export_manifest['flows'] ) ) {
+			foreach ( $flows as $flow ) {
+				$flow_id           = (int) $flow['flow_id'];
+				$pipeline_id       = (int) $flow['pipeline_id'];
+				$portable_slug     = ! empty( $flow['portable_slug'] )
+					? PortableSlug::normalize( (string) $flow['portable_slug'], 'flow' )
+					: PortableSlug::normalize( (string) $flow['flow_name'], 'flow' );
+				$portable_slug     = PortableSlug::dedupe( $portable_slug, $used_flow_slugs );
+				$used_flow_slugs[] = $portable_slug;
+				$scheduling        = $this->sanitize_scheduling_config( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() );
+				$flow_documents[]  = new AgentBundleFlowFile(
+					$portable_slug,
+					(string) $flow['flow_name'],
+					$pipeline_slugs_by_id[ $pipeline_id ] ?? 'pipeline',
+					(string) ( $scheduling['interval'] ?? 'manual' ),
+					is_array( $scheduling['max_items'] ?? null ) ? $scheduling['max_items'] : array(),
+					self::flow_document_steps_from_config(
+						is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array(),
+						$pipeline_step_types_by_id,
+						$handler_auth,
+						array_merge(
+							$context,
+							array(
+								'agent_id' => $agent_id,
+								'flow_id'  => $flow_id,
+							)
+						)
+					)
+				);
 
-			foreach ( $this->collect_flow_memory_files( $pipeline_id, $flow_id ) as $path => $contents ) {
-				$memory_files[ 'flows/' . $portable_slug . '/' . ltrim( (string) $path, '/' ) ] = $contents;
+				if ( ! empty( $export_manifest['memory'] ) ) {
+					foreach ( $this->collect_flow_memory_files( $pipeline_id, $flow_id ) as $path => $contents ) {
+						$memory_files[ 'flows/' . $portable_slug . '/' . ltrim( (string) $path, '/' ) ] = $contents;
+					}
+				}
 			}
 		}
 
@@ -208,7 +232,7 @@ class AgentBundler {
 				'pipelines'    => $pipeline_slugs,
 				'flows'        => $flow_slugs,
 				'extensions'   => array_values( array_filter( $extension_paths ) ),
-				'handler_auth' => 'refs',
+				'handler_auth' => $handler_auth,
 			)
 		);
 
@@ -250,7 +274,7 @@ class AgentBundler {
 	 * @param array $pipeline_step_types_by_id Pipeline step ID to step type map.
 	 * @return array<int,array<string,mixed>>
 	 */
-	private static function flow_document_steps_from_config( array $flow_config, array $pipeline_step_types_by_id ): array {
+	private static function flow_document_steps_from_config( array $flow_config, array $pipeline_step_types_by_id, string $handler_auth = 'refs', array $context = array() ): array {
 		$steps = array();
 		foreach ( $flow_config as $step ) {
 			if ( ! is_array( $step ) ) {
@@ -260,7 +284,7 @@ class AgentBundler {
 			$pipeline_step_id = (string) ( $step['pipeline_step_id'] ?? '' );
 			$document_step    = array(
 				'step_position'   => (int) ( $step['execution_order'] ?? count( $steps ) ),
-				'handler_configs' => self::handler_configs_from_flow_step( $step ),
+				'handler_configs' => self::handler_configs_from_flow_step( $step, $handler_auth, $context ),
 			);
 
 			if ( ! isset( $step['step_type'] ) && isset( $pipeline_step_types_by_id[ $pipeline_step_id ] ) ) {
@@ -284,16 +308,109 @@ class AgentBundler {
 	 * @param array $step Runtime flow step row.
 	 * @return array<string,array<string,mixed>>
 	 */
-	private static function handler_configs_from_flow_step( array $step ): array {
+	private static function handler_configs_from_flow_step( array $step, string $handler_auth = 'refs', array $context = array() ): array {
+		if ( 'omit' === $handler_auth ) {
+			return array();
+		}
+
 		if ( is_array( $step['handler_configs'] ?? null ) ) {
-			return $step['handler_configs'];
+			$configs = $step['handler_configs'];
+		} elseif ( is_string( $step['handler_slug'] ?? null ) && is_array( $step['handler_config'] ?? null ) ) {
+			$configs = array( $step['handler_slug'] => $step['handler_config'] );
+		} else {
+			return array();
 		}
 
-		if ( is_string( $step['handler_slug'] ?? null ) && is_array( $step['handler_config'] ?? null ) ) {
-			return array( $step['handler_slug'] => $step['handler_config'] );
+		if ( 'refs' !== $handler_auth ) {
+			return $configs;
 		}
 
-		return array();
+		$rewritten = array();
+		foreach ( $configs as $handler_slug => $handler_config ) {
+			if ( ! is_array( $handler_config ) ) {
+				continue;
+			}
+			$config = apply_filters( 'datamachine_handler_config_to_auth_ref', $handler_config, (string) $handler_slug, $context );
+			if ( is_wp_error( $config ) || ! is_array( $config ) ) {
+				$config = array();
+			}
+			$rewritten[ (string) $handler_slug ] = self::strip_secret_like_values( $config );
+		}
+
+		ksort( $rewritten, SORT_STRING );
+		return $rewritten;
+	}
+
+	private static function resolve_export_manifest( int $agent_id, array $context ): array {
+		$profile = (string) ( $context['profile'] ?? 'share' );
+		$default = array(
+			'soul'         => true,
+			'memory'       => false,
+			'user'         => false,
+			'daily_memory' => false,
+			'agent_config' => true,
+			'pipelines'    => true,
+			'flows'        => true,
+			'handler_auth' => 'refs',
+		);
+
+		$profiles = array(
+			'share'  => array(
+				'memory'       => false,
+				'user'         => false,
+				'daily_memory' => false,
+				'handler_auth' => 'refs',
+			),
+			'backup' => array(
+				'memory'       => true,
+				'user'         => true,
+				'daily_memory' => true,
+				'handler_auth' => 'full',
+			),
+			'fork'   => array(
+				'memory'       => false,
+				'user'         => false,
+				'daily_memory' => false,
+				'handler_auth' => 'omit',
+			),
+		);
+
+		if ( isset( $profiles[ $profile ] ) ) {
+			$default = array_merge( $default, $profiles[ $profile ] );
+		}
+
+		$context['profile'] = '' !== $profile ? $profile : null;
+		$manifest           = apply_filters( 'datamachine_agent_export_manifest', $default, $agent_id, $context );
+		if ( ! is_array( $manifest ) ) {
+			$manifest = $default;
+		}
+
+		$manifest = array_merge( $default, $manifest );
+		if ( ! in_array( $manifest['handler_auth'], array( 'refs', 'full', 'omit' ), true ) ) {
+			$manifest['handler_auth'] = 'refs';
+		}
+
+		foreach ( array( 'soul', 'memory', 'user', 'daily_memory', 'agent_config', 'pipelines', 'flows' ) as $flag ) {
+			$manifest[ $flag ] = ! empty( $manifest[ $flag ] );
+		}
+
+		return $manifest;
+	}
+
+	private static function strip_secret_like_values( array $value ): array {
+		$secret_keys = array( 'access_token', 'refresh_token', 'token', 'secret', 'client_secret', 'password', 'api_key', 'apikey', 'key' );
+		foreach ( $value as $key => $child ) {
+			$key_string = strtolower( (string) $key );
+			if ( in_array( $key_string, $secret_keys, true ) || str_contains( $key_string, 'secret' ) || str_contains( $key_string, 'token' ) || str_contains( $key_string, 'password' ) ) {
+				unset( $value[ $key ] );
+				continue;
+			}
+			if ( is_array( $child ) ) {
+				$value[ $key ] = self::strip_secret_like_values( $child );
+			}
+		}
+		ksort( $value, SORT_STRING );
+		return $value;
 	}
 
 	/**

--- a/tests/export-agent-ability-smoke.php
+++ b/tests/export-agent-ability-smoke.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Smoke test for datamachine/export-agent ability slice (#1305).
+ *
+ * Run with: php tests/export-agent-ability-smoke.php
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		$title = strtolower( (string) $title );
+		$title = preg_replace( '/[^a-z0-9]+/', '-', $title );
+		return trim( (string) $title, '-' );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, $flags = 0 ) {
+		return json_encode( $value, $flags );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $value ) {
+		return (string) $value;
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	$GLOBALS['export_agent_smoke_filters'] = array();
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['export_agent_smoke_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+	}
+	function apply_filters( $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['export_agent_smoke_filters'][ $hook ] ) ) {
+			return $value;
+		}
+		ksort( $GLOBALS['export_agent_smoke_filters'][ $hook ], SORT_NUMERIC );
+		foreach ( $GLOBALS['export_agent_smoke_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as $callback_entry ) {
+				$callback      = $callback_entry[0];
+				$accepted_args = $callback_entry[1];
+				$value = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+			}
+		}
+		return $value;
+	}
+}
+
+class WP_Error {
+}
+
+require_once __DIR__ . '/../inc/Engine/Bundle/BundleValidationException.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/PortableSlug.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/BundleSchema.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleSlugTrait.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleManifest.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundlePipelineFile.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleFlowFile.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleDirectory.php';
+require_once __DIR__ . '/../inc/Core/Agents/AgentBundler.php';
+
+use DataMachine\Core\Agents\AgentBundler;
+use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\AgentBundleFlowFile;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
+
+$assertions = 0;
+$failures   = 0;
+
+$assert = function ( string $label, bool $condition ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+	++$failures;
+	echo "FAIL: {$label}\n";
+};
+
+function export_agent_private( string $method, array $args = array() ) {
+	$reflection = new ReflectionMethod( AgentBundler::class, $method );
+	return $reflection->invokeArgs( null, $args );
+}
+
+echo "=== Export Agent Ability Smoke ===\n";
+
+echo "\n[1] Export manifest profiles and filter contract\n";
+$seen_filter = false;
+add_filter(
+	'datamachine_agent_export_manifest',
+	function ( array $manifest, int $agent_id, array $context ) use ( &$seen_filter ) {
+		$seen_filter = 42 === $agent_id && 'fork' === ( $context['profile'] ?? '' );
+		$manifest['soul'] = false;
+		return $manifest;
+	},
+	10,
+	3
+);
+$fork_manifest = export_agent_private( 'resolve_export_manifest', array( 42, array( 'profile' => 'fork' ) ) );
+$assert( 'manifest filter fires with profile context', $seen_filter );
+$assert( 'fork profile omits handler auth', 'omit' === $fork_manifest['handler_auth'] );
+$assert( 'filter return participates in resolved manifest', false === $fork_manifest['soul'] );
+$backup_manifest = export_agent_private( 'resolve_export_manifest', array( 42, array( 'profile' => 'backup' ) ) );
+$assert( 'backup profile includes memory', true === $backup_manifest['memory'] );
+$assert( 'backup profile keeps full handler auth', 'full' === $backup_manifest['handler_auth'] );
+
+echo "\n[2] Handler auth refs never emit raw secrets\n";
+add_filter(
+	'datamachine_handler_config_to_auth_ref',
+	function ( array $config, string $handler_slug, array $context ) {
+		unset( $handler_slug );
+		unset( $context );
+		$config['auth_ref'] = 'email:default';
+		return $config;
+	},
+	10,
+	3
+);
+$step = array(
+	'handler_configs' => array(
+		'email' => array(
+			'username'     => 'person@example.com',
+			'access_token' => 'secret-token',
+			'nested'       => array( 'password' => 'secret-password' ),
+		),
+	),
+);
+$refs_configs = export_agent_private( 'handler_configs_from_flow_step', array( $step, 'refs', array() ) );
+$assert( 'refs mode preserves auth_ref', 'email:default' === ( $refs_configs['email']['auth_ref'] ?? '' ) );
+$assert( 'refs mode strips access_token', ! array_key_exists( 'access_token', $refs_configs['email'] ) );
+$assert( 'refs mode strips nested password', ! array_key_exists( 'password', $refs_configs['email']['nested'] ?? array() ) );
+$full_configs = export_agent_private( 'handler_configs_from_flow_step', array( $step, 'full', array() ) );
+$assert( 'full mode preserves raw config for backups', 'secret-token' === ( $full_configs['email']['access_token'] ?? '' ) );
+$omit_configs = export_agent_private( 'handler_configs_from_flow_step', array( $step, 'omit', array() ) );
+$assert( 'omit mode strips handler configs', array() === $omit_configs );
+
+echo "\n[3] Directory output is deterministic\n";
+$directory = new AgentBundleDirectory(
+	new AgentBundleManifest(
+		'2026-04-28T00:00:00+00:00',
+		'data-machine/test',
+		'agent-test',
+		'1',
+		'',
+		'',
+		array( 'slug' => 'agent-test', 'label' => 'Agent Test', 'description' => '', 'agent_config' => array( 'b' => 2, 'a' => 1 ) ),
+		array( 'memory' => array( 'agent/SOUL.md' ), 'pipelines' => array( 'pipeline-a' ), 'flows' => array( 'flow-a' ), 'handler_auth' => 'refs' )
+	),
+	array( 'agent/SOUL.md' => "Soul\n" ),
+	array( new AgentBundlePipelineFile( 'pipeline-a', 'Pipeline A', array( array( 'step_position' => 0, 'step_type' => 'fetch', 'step_config' => array( 'z' => true, 'a' => true ) ) ) ) ),
+	array( new AgentBundleFlowFile( 'flow-a', 'Flow A', 'pipeline-a', 'manual', array(), array( array( 'step_position' => 0, 'handler_configs' => array( 'email' => array( 'auth_ref' => 'email:default' ) ) ) ) ) )
+);
+$tmp_base = sys_get_temp_dir() . '/datamachine-export-agent-smoke-' . getmypid();
+$dir_a    = $tmp_base . '/a';
+$dir_b    = $tmp_base . '/b';
+$directory->write( $dir_a );
+$directory->write( $dir_b );
+$manifest_a = file_get_contents( $dir_a . '/manifest.json' );
+$manifest_b = file_get_contents( $dir_b . '/manifest.json' );
+$assert( 'manifest export is byte-identical across writes', $manifest_a === $manifest_b );
+$assert( 'pipeline export is byte-identical across writes', file_get_contents( $dir_a . '/pipelines/pipeline-a.json' ) === file_get_contents( $dir_b . '/pipelines/pipeline-a.json' ) );
+$assert( 'manifest JSON sorts object keys', false !== strpos( (string) $manifest_a, "\"a\": 1,\n            \"b\": 2" ) );
+
+echo "\n[4] Ability and CLI route through value-object exporter\n";
+$ability_source = file_get_contents( __DIR__ . '/../inc/Abilities/AgentAbilities.php' ) ?: '';
+$cli_source     = file_get_contents( __DIR__ . '/../inc/Cli/Commands/AgentsCommand.php' ) ?: '';
+$bundler_source = file_get_contents( __DIR__ . '/../inc/Core/Agents/AgentBundler.php' ) ?: '';
+$assert( 'ability registers datamachine/export-agent', str_contains( $ability_source, "'datamachine/export-agent'" ) );
+$assert( 'ability calls AgentBundler export_directory_object', str_contains( $ability_source, 'export_directory_object' ) );
+$assert( 'ability writes AgentBundleDirectory directly', str_contains( $ability_source, '$directory->write( $destination )' ) );
+$assert( 'CLI export calls generic ability', str_contains( $cli_source, 'AgentAbilities::exportAgent' ) );
+$assert( 'bundler applies datamachine_agent_export_manifest once', 1 === substr_count( $bundler_source, 'datamachine_agent_export_manifest' ) );
+
+echo "\nAssertions: {$assertions}\n";
+if ( $failures > 0 ) {
+	echo "Failures: {$failures}\n";
+	exit( 1 );
+}
+
+echo "All export-agent ability smoke assertions passed.\n";

--- a/tests/export-agent-ability-smoke.php
+++ b/tests/export-agent-ability-smoke.php
@@ -66,6 +66,7 @@ require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleSlugTrait.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleManifest.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundlePipelineFile.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleFlowFile.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleDirectory.php';
 require_once __DIR__ . '/../inc/Core/Agents/AgentBundler.php';
 


### PR DESCRIPTION
## Summary
- Add `datamachine/export-agent` so agents can be exported as portable bundle directories or ZIP archives.
- Route `wp datamachine agents export` through the same ability path and support share, backup, and fork profiles.
- Extend bundle export context so handler auth can be emitted as refs, full config, or omitted with secret-like values stripped in refs mode.

## Changes
- Registers the export ability with directory/ZIP output and profile selection.
- Adds `datamachine_agent_export_manifest` handling to the bundle value-object export path.
- Adds smoke coverage for ability output, CLI routing, profile defaults, auth-ref rewriting, and secret stripping.

## Tests
- `php tests/export-agent-ability-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php tests/auth-ref-handler-config-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/agent-bundle-portable-update-smoke.php`
- `git diff --check`

Closes #1305
Refs #1304

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the export ability, CLI routing, bundle context handling, and smoke coverage; Chris reviews and owns the final change.