### PR TITLE
refactor(tools): split adjacent handler source from registry

### DIFF
--- a/inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php
+++ b/inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Adjacent handler tool source.
+ *
+ * Pipeline AI steps expose required handler tools from their neighboring steps.
+ *
+ * @package DataMachine\Engine\AI\Tools\Sources
+ */
+
+namespace DataMachine\Engine\AI\Tools\Sources;
+
+use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Engine\AI\Tools\ToolManager;
+use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
+
+defined( 'ABSPATH' ) || exit;
+
+final class AdjacentHandlerToolSource {
+
+	/**
+	 * Gather handler tools from adjacent pipeline steps.
+	 *
+	 * @param string      $mode         Agent mode slug.
+	 * @param array       $args         Full resolution arguments.
+	 * @param ToolManager $tool_manager Tool registry/handler resolver.
+	 * @return array Tools keyed by tool name.
+	 */
+	public function __invoke( string $mode, array $args, ToolManager $tool_manager ): array {
+		if ( ToolPolicyResolver::MODE_PIPELINE !== $mode ) {
+			return array();
+		}
+
+		$available_tools = array();
+		$engine_data     = $args['engine_data'] ?? array();
+
+		foreach ( array( $args['previous_step_config'] ?? null, $args['next_step_config'] ?? null ) as $step_config ) {
+			if ( ! $step_config ) {
+				continue;
+			}
+
+			$handler_slugs = FlowStepConfig::getConfiguredHandlerSlugs( $step_config );
+			$cache_scope   = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
+
+			foreach ( $handler_slugs as $slug ) {
+				$handler_config = FlowStepConfig::getHandlerConfigForSlug( $step_config, $slug );
+				$tools          = $tool_manager->resolveHandlerTools(
+					$slug,
+					$handler_config,
+					$engine_data,
+					$cache_scope
+				);
+
+				foreach ( $tools as $tool_name => $tool_config ) {
+					$available_tools[ $tool_name ] = $tool_config;
+				}
+			}
+		}
+
+		return $available_tools;
+	}
+}

--- a/inc/Engine/AI/Tools/ToolSourceRegistry.php
+++ b/inc/Engine/AI/Tools/ToolSourceRegistry.php
@@ -9,7 +9,7 @@
 
 namespace DataMachine\Engine\AI\Tools;
 
-use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Engine\AI\Tools\Sources\AdjacentHandlerToolSource;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -62,7 +62,7 @@ class ToolSourceRegistry {
 			'datamachine_tool_sources',
 			array(
 				self::SOURCE_STATIC_REGISTRY   => array( $this, 'gatherStaticRegistryTools' ),
-				self::SOURCE_ADJACENT_HANDLERS => array( $this, 'gatherAdjacentHandlerTools' ),
+				self::SOURCE_ADJACENT_HANDLERS => new AdjacentHandlerToolSource(),
 			),
 			$mode,
 			$args,
@@ -157,47 +157,6 @@ class ToolSourceRegistry {
 			}
 
 			$available_tools[ $tool_name ] = $tool_config;
-		}
-
-		return $available_tools;
-	}
-
-	/**
-	 * Gather handler tools from adjacent pipeline steps.
-	 *
-	 * @param string $mode Agent mode slug.
-	 * @param array  $args Full resolution arguments.
-	 * @return array Tools keyed by tool name.
-	 */
-	public function gatherAdjacentHandlerTools( string $mode, array $args ): array {
-		if ( ToolPolicyResolver::MODE_PIPELINE !== $mode ) {
-			return array();
-		}
-
-		$available_tools = array();
-		$engine_data     = $args['engine_data'] ?? array();
-
-		foreach ( array( $args['previous_step_config'] ?? null, $args['next_step_config'] ?? null ) as $step_config ) {
-			if ( ! $step_config ) {
-				continue;
-			}
-
-			$handler_slugs = FlowStepConfig::getConfiguredHandlerSlugs( $step_config );
-			$cache_scope   = $step_config['flow_step_id'] ?? ( $args['cache_scope'] ?? '' );
-
-			foreach ( $handler_slugs as $slug ) {
-				$handler_config = FlowStepConfig::getHandlerConfigForSlug( $step_config, $slug );
-				$tools          = $this->tool_manager->resolveHandlerTools(
-					$slug,
-					$handler_config,
-					$engine_data,
-					$cache_scope
-				);
-
-				foreach ( $tools as $tool_name => $tool_config ) {
-					$available_tools[ $tool_name ] = $tool_config;
-				}
-			}
 		}
 
 		return $available_tools;

--- a/tests/adjacent-handler-tool-policy-smoke.php
+++ b/tests/adjacent-handler-tool-policy-smoke.php
@@ -36,6 +36,7 @@ namespace {
 	}
 
 	require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
+	require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
 	require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 	require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -61,6 +61,7 @@ require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
 require_once __DIR__ . '/../inc/Core/Steps/WorkflowConfigFactory.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -75,6 +75,7 @@ class WP_Abilities_Registry {
 require_once __DIR__ . '/../inc/Core/PluginSettings.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 
@@ -222,6 +223,12 @@ add_filter(
 );
 $tools = resolve_source_tools( ToolPolicyResolver::MODE_CHAT, new SourcePolicyToolManager() );
 assert_source_equals( array( 'chat_static_tool', 'extra_tool' ), array_keys( $tools ), 'filter appends extra source after static source', $failures, $passes );
+
+echo "\n[4] adjacent-handler source owns pipeline config vocabulary:\n";
+$registry_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php' );
+$adjacent_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php' );
+assert_source_equals( false, false !== strpos( $registry_source, 'FlowStepConfig' ), 'generic registry no longer imports FlowStepConfig', $failures, $passes );
+assert_source_equals( true, false !== strpos( $adjacent_source, 'FlowStepConfig' ), 'adjacent-handler source owns FlowStepConfig lookup', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " tool source assertions failed.\n";

--- a/tests/upsert-handler-result-handoff-smoke.php
+++ b/tests/upsert-handler-result-handoff-smoke.php
@@ -59,6 +59,7 @@ require_once __DIR__ . '/../inc/Core/Steps/QueueableTrait.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Engine/AI/ConversationManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolResultFinder.php';


### PR DESCRIPTION
## Summary
- Move adjacent-handler tool lookup out of the generic `ToolSourceRegistry` and into a Data Machine-specific source class.
- Preserve the existing `adjacent_handlers` source slug, source ordering, filters, and resolved tool shape.

## What changed
- Added `AdjacentHandlerToolSource` to own the pipeline-specific `FlowStepConfig` lookup.
- Updated `ToolSourceRegistry` to register the adjacent-handler source as an invokable provider.
- Extended the tool-source smoke to assert the generic registry no longer depends on `FlowStepConfig`.

## Tests
- `php tests/tool-source-registry-smoke.php`
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `php tests/upsert-handler-result-handoff-smoke.php`
- `php tests/adjacent-handler-tool-policy-smoke.php`
- `php -l inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php`
- `php -l inc/Engine/AI/Tools/ToolSourceRegistry.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@untangle-adjacent-handler-tool-source --changed-since origin/main` *(passed; reported no changed files)*
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@untangle-adjacent-handler-tool-source --changed-since origin/main`

Closes #1563

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Refactored the adjacent-handler tool source, updated smoke coverage, ran verification, and drafted this PR description. Chris remains responsible for review and merge.