### PR TITLE
refactor(tools): move pipeline policy args out of resolver

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -8,6 +8,7 @@ use DataMachine\Core\DataPacket;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\Steps\Step;
 use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Core\Steps\AI\ToolPolicy\PipelineToolPolicyArgs;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
 use DataMachine\Core\Steps\QueueableTrait;
 use DataMachine\Engine\AI\AIConversationLoop;
@@ -277,7 +278,7 @@ class AIStep extends Step {
 					'engine_data'          => $engine_data,
 					'categories'           => $tool_categories,
 				),
-				ToolPolicyResolver::getPipelinePolicyArgs( $this->flow_step_config, $pipeline_step_config )
+				PipelineToolPolicyArgs::fromConfigs( $this->flow_step_config, $pipeline_step_config )
 			)
 		);
 

--- a/inc/Core/Steps/AI/ToolPolicy/PipelineToolPolicyArgs.php
+++ b/inc/Core/Steps/AI/ToolPolicy/PipelineToolPolicyArgs.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Pipeline tool policy argument builder.
+ *
+ * @package DataMachine\Core\Steps\AI\ToolPolicy
+ */
+
+namespace DataMachine\Core\Steps\AI\ToolPolicy;
+
+use DataMachine\Core\Steps\FlowStepConfig;
+
+defined( 'ABSPATH' ) || exit;
+
+class PipelineToolPolicyArgs {
+
+	/**
+	 * Build snapshot-derived pipeline policy arguments.
+	 *
+	 * Pipeline execution must honor the flow/pipeline config captured in the
+	 * current engine snapshot. Do not re-read persisted pipeline rows here:
+	 * direct workflows use synthetic IDs, and historical jobs must inspect the
+	 * policy that existed when they ran.
+	 *
+	 * @param array $flow_step_config     Current flow step config snapshot.
+	 * @param array $pipeline_step_config Current pipeline step config snapshot.
+	 * @return array Resolver args containing allow_only/deny when configured.
+	 */
+	public static function fromConfigs( array $flow_step_config, array $pipeline_step_config ): array {
+		$args          = array();
+		$enabled_tools = FlowStepConfig::getEnabledTools( $flow_step_config );
+
+		if ( ! empty( $enabled_tools ) ) {
+			$args['allow_only'] = self::sanitizeToolList( $enabled_tools );
+		}
+
+		$deny = array_merge(
+			self::sanitizeToolList( is_array( $pipeline_step_config['disabled_tools'] ?? null ) ? $pipeline_step_config['disabled_tools'] : array() ),
+			self::sanitizeToolList( is_array( $flow_step_config['disabled_tools'] ?? null ) ? $flow_step_config['disabled_tools'] : array() )
+		);
+
+		if ( ! empty( $deny ) ) {
+			$args['deny'] = array_values( array_unique( $deny ) );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Sanitize a list of tool slugs.
+	 *
+	 * @param array $tools Raw tool names.
+	 * @return array<int, string> Clean tool names.
+	 */
+	private static function sanitizeToolList( array $tools ): array {
+		$clean = array();
+		foreach ( $tools as $tool ) {
+			if ( ! is_string( $tool ) || '' === $tool ) {
+				continue;
+			}
+			$clean[] = $tool;
+		}
+
+		return array_values( array_unique( $clean ) );
+	}
+}

--- a/inc/Engine/AI/RequestInspector.php
+++ b/inc/Engine/AI/RequestInspector.php
@@ -14,6 +14,7 @@ use DataMachine\Core\EngineData;
 use DataMachine\Core\FilesRepository\FileRetrieval;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\Steps\AI\AIStep;
+use DataMachine\Core\Steps\AI\ToolPolicy\PipelineToolPolicyArgs;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Abilities\Flow\QueueAbility;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
@@ -111,7 +112,7 @@ class RequestInspector {
 					'engine_data'          => $engine->all(),
 					'categories'           => $tool_categories,
 				),
-				ToolPolicyResolver::getPipelinePolicyArgs( $flow_step_config, $pipeline_step_config )
+				PipelineToolPolicyArgs::fromConfigs( $flow_step_config, $pipeline_step_config )
 			)
 		);
 

--- a/inc/Engine/AI/Tools/ToolPolicyResolver.php
+++ b/inc/Engine/AI/Tools/ToolPolicyResolver.php
@@ -24,7 +24,6 @@ namespace DataMachine\Engine\AI\Tools;
 
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Abilities\PermissionHelper;
-use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -145,56 +144,6 @@ class ToolPolicyResolver {
 		$tools = apply_filters( 'datamachine_resolved_tools', $tools, $mode, $args );
 
 		return $tools;
-	}
-
-	/**
-	 * Build snapshot-derived pipeline policy arguments.
-	 *
-	 * Pipeline execution must honor the flow/pipeline config captured in the
-	 * current engine snapshot. Do not re-read persisted pipeline rows here:
-	 * direct workflows use synthetic IDs, and historical jobs must inspect the
-	 * policy that existed when they ran.
-	 *
-	 * @param array $flow_step_config     Current flow step config snapshot.
-	 * @param array $pipeline_step_config Current pipeline step config snapshot.
-	 * @return array Resolver args containing allow_only/deny when configured.
-	 */
-	public static function getPipelinePolicyArgs( array $flow_step_config, array $pipeline_step_config ): array {
-		$args          = array();
-		$enabled_tools = FlowStepConfig::getEnabledTools( $flow_step_config );
-
-		if ( ! empty( $enabled_tools ) ) {
-			$args['allow_only'] = self::sanitizeToolList( $enabled_tools );
-		}
-
-		$deny = array_merge(
-			self::sanitizeToolList( is_array( $pipeline_step_config['disabled_tools'] ?? null ) ? $pipeline_step_config['disabled_tools'] : array() ),
-			self::sanitizeToolList( is_array( $flow_step_config['disabled_tools'] ?? null ) ? $flow_step_config['disabled_tools'] : array() )
-		);
-
-		if ( ! empty( $deny ) ) {
-			$args['deny'] = array_values( array_unique( $deny ) );
-		}
-
-		return $args;
-	}
-
-	/**
-	 * Sanitize a list of tool slugs.
-	 *
-	 * @param array $tools Raw tool names.
-	 * @return array<int, string> Clean tool names.
-	 */
-	private static function sanitizeToolList( array $tools ): array {
-		$clean = array();
-		foreach ( $tools as $tool ) {
-			if ( ! is_string( $tool ) || '' === $tool ) {
-				continue;
-			}
-			$clean[] = $tool;
-		}
-
-		return array_values( array_unique( $clean ) );
 	}
 
 	/**

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -60,10 +60,12 @@ if ( ! function_exists( 'wp_generate_uuid4' ) ) {
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
 require_once __DIR__ . '/../inc/Core/Steps/WorkflowConfigFactory.php';
+require_once __DIR__ . '/../inc/Core/Steps/AI/ToolPolicy/PipelineToolPolicyArgs.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 
+use DataMachine\Core\Steps\AI\ToolPolicy\PipelineToolPolicyArgs;
 use DataMachine\Core\Steps\WorkflowConfigFactory;
 use DataMachine\Engine\AI\Tools\ToolManager;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
@@ -121,7 +123,7 @@ function resolve_policy_tools_for_test( array $flow_step_config, array $pipeline
 				'engine_data'          => array(),
 				'categories'           => array(),
 			),
-			ToolPolicyResolver::getPipelinePolicyArgs( $flow_step_config, $pipeline_step_config )
+			PipelineToolPolicyArgs::fromConfigs( $flow_step_config, $pipeline_step_config )
 		)
 	);
 }
@@ -183,8 +185,30 @@ assert_policy_equals( array( null, null, null ), $manager->availability_contexts
 echo "\n[4] RequestInspector and AIStep share policy input helper:\n";
 $ai_step_source   = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' ) ?: '';
 $inspector_source = file_get_contents( __DIR__ . '/../inc/Engine/AI/RequestInspector.php' ) ?: '';
-assert_policy_equals( 1, substr_count( $ai_step_source, 'ToolPolicyResolver::getPipelinePolicyArgs' ), 'AIStep uses shared policy helper once', $failures, $passes );
-assert_policy_equals( 1, substr_count( $inspector_source, 'ToolPolicyResolver::getPipelinePolicyArgs' ), 'RequestInspector uses shared policy helper once', $failures, $passes );
+assert_policy_equals( 1, substr_count( $ai_step_source, 'PipelineToolPolicyArgs::fromConfigs' ), 'AIStep uses pipeline policy helper once', $failures, $passes );
+assert_policy_equals( 1, substr_count( $inspector_source, 'PipelineToolPolicyArgs::fromConfigs' ), 'RequestInspector uses pipeline policy helper once', $failures, $passes );
+
+echo "\n[5] helper translates flow/pipeline policy fields into resolver args:\n";
+$args = PipelineToolPolicyArgs::fromConfigs(
+	array(
+		'step_type'      => 'ai',
+		'enabled_tools'  => array( 'alpha_tool', '', 'alpha_tool', 42, 'beta_tool' ),
+		'disabled_tools' => array( 'flow_denied', 'shared_denied', '', 'flow_denied' ),
+	),
+	array(
+		'disabled_tools' => array( 'pipeline_denied', 'shared_denied', false, 'pipeline_denied' ),
+	)
+);
+assert_policy_equals(
+	array(
+		'allow_only' => array( 'alpha_tool', 'beta_tool' ),
+		'deny'       => array( 'pipeline_denied', 'shared_denied', 'flow_denied' ),
+	),
+	$args,
+	'enabled_tools and disabled_tools map to allow_only and deny args with original ordering',
+	$failures,
+	$passes
+);
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " pipeline policy assertions failed.\n";


### PR DESCRIPTION
## Summary
- Moves pipeline flow/config policy argument translation out of `ToolPolicyResolver` into a Data Machine step-layer helper.
- Keeps `ToolPolicyResolver::resolve()` focused on generic tool resolution args while preserving pipeline allow/deny behaviour.

## What changed
- Added `DataMachine\Core\Steps\AI\ToolPolicy\PipelineToolPolicyArgs::fromConfigs()` with the previous snapshot-derived policy translation logic.
- Updated `AIStep` and `RequestInspector` to build pipeline policy args before calling `ToolPolicyResolver::resolve()`.
- Removed the `FlowStepConfig` import and `getPipelinePolicyArgs()` helper from `ToolPolicyResolver`.
- Extended `pipeline-tool-policy-snapshot-smoke.php` to verify `enabled_tools` and both disabled-tool sources map to `allow_only` / `deny` without reordering.

## Tests
- `php tests/pipeline-tool-policy-snapshot-smoke.php` — passes, 9 assertions.
- `php -l` on changed PHP files — passes.
- `git diff --check HEAD~1..HEAD` — passes.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@untangle-pipeline-tool-policy-args --changed-since origin/main` — PHPCS passes, then Homeboy routes PHP files through ESLint and fails with PHP parse errors; baseline delta is 0.
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@untangle-pipeline-tool-policy-args --changed-since origin/main` — selects `tests/pipeline-tool-policy-snapshot-smoke.php` but runs the WordPress PHPUnit harness and fails with broad unrelated registry/settings failures (197 errors, 174 failures).

Closes #1564

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the narrow refactor, updated focused smoke coverage, ran local verification, and prepared this PR. Chris remains responsible for review and merge.