### PR TITLE
refactor(memory): clarify agent memory store boundary

### DIFF
--- a/docs/architecture/agent-memory-backends.md
+++ b/docs/architecture/agent-memory-backends.md
@@ -1,6 +1,6 @@
 # Agent Memory Backends
 
-Data Machine treats agent memory as logical markdown files. The storage backend is replaceable, but the identity, registry, injection, and editing rules stay in Data Machine.
+Data Machine treats agent memory as logical memory records that usually render as markdown files. The storage backend is replaceable, but the current registry, injection, editing rules, abilities, and scaffolding stay in Data Machine.
 
 This lets self-hosted installs keep the current disk-backed workflow while managed hosts can project the same logical memory into a WordPress-native store such as `wp_guideline` when that substrate exists.
 
@@ -20,6 +20,8 @@ Every memory file is addressed by an `AgentMemoryScope` four-tuple:
 | `filename` | File name or relative path within the layer, such as `MEMORY.md`, `contexts/editor.md`, or `daily/2026/04/17.md`. |
 
 Backends translate that tuple to their own physical key: a filesystem path, a database row, a post, or another host-owned identifier. Callers should use `AgentMemory` and should not branch on the concrete backend.
+
+This tuple is the candidate Agents API memory identity. Data Machine-specific concerns such as seed scaffolding, file editability, prompt-injection policy, and operator abilities are intentionally outside the persistence-store contract.
 
 ## Runtime Flow
 
@@ -60,7 +62,7 @@ The disk store intentionally does not implement compare-and-swap writes; it acce
 
 ## Backend Selection
 
-Data Machine resolves memory persistence through one filter:
+Data Machine resolves memory persistence through one current filter:
 
 ```php
 apply_filters(
@@ -71,6 +73,8 @@ apply_filters(
 ```
 
 Return an `AgentMemoryStoreInterface` implementation to replace the disk default for the given scope. Return `null` to keep `DiskAgentMemoryStore`.
+
+Future Agents API extraction should introduce its neutral resolver/filter name in the extracted package with a migration plan. Data Machine does not add a second alias today; `datamachine_memory_store` remains the active public behavior until ownership actually moves.
 
 Backend selection should be capability-driven:
 
@@ -116,7 +120,7 @@ The memory-store seam is not a replacement for AI Framework. Data Machine still 
 - Read and write memory through `AgentMemory`, not `AgentMemoryStoreFactory` directly.
 - Implement `AgentMemoryStoreInterface` when replacing persistence.
 - Preserve the four-tuple identity model exactly, even if the physical backend has different keys.
-- Keep section parsing, scaffolding, editability gating, and registry semantics above the store layer.
+- Keep section parsing, scaffolding, editability gating, ability permissions, prompt-injection policy, and registry semantics above the store layer.
 - Gate guideline-backed stores on real substrate availability; do not assume `wp_guideline` exists.
 - Prefer disk when DMC/local writable filesystem support exists, because that is the projection external coding agents can inspect.
 

--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -15,7 +15,7 @@ Mirror the WordPress Abilities API shape instead of importing Data Machine, wpco
 | `datamachine_register_agents` | `wp_agents_api_init` or `wp_register_agents` | Prefer a core-shaped init hook; exact name needs review against Abilities API precedent. |
 | `MessageEnvelope` | `WP_Agent_Message` or neutral envelope | Contract is generic. Data Machine schema/name is not. |
 | `ConversationStoreInterface` | `WP_Agent_Conversation_Store_Interface` | Keep transcript/session/read-state split if it remains boring. |
-| `AgentMemoryStoreInterface` | `WP_Agent_Memory_Store_Interface` | Generic identity tuple needs naming review. |
+| `AgentMemoryStoreInterface` | `WP_Agent_Memory_Store_Interface` | Generic identity tuple needs naming review; Data Machine scaffolding/abilities stay outside the store contract. |
 | `RuntimeToolDeclaration` | `WP_Agent_Tool_Declaration` | Should stay ability-native and run-scoped. |
 | `LoopEventSinkInterface` | `WP_Agent_Run_Event_Sink_Interface` | Useful for logs, streaming, chat UIs, and async workers. |
 | REST `datamachine/v1` agent routes | REST `wp-agents/v1` | Data Machine product routes stay under `datamachine/v1`. |
@@ -173,7 +173,7 @@ These are reference points only. Do not expose them as public Data Machine or Ag
 |---|---|---|
 | `datamachine_conversation_runner` | Agents API public candidate | Generic runtime replacement seam. Rename and formalize result contract. |
 | `datamachine_conversation_store` | Agents API public candidate | Generic conversation persistence swap seam. Rename and keep narrow contracts. |
-| `datamachine_memory_store` | Agents API public candidate | Generic memory persistence swap seam. Rename to Agents API vocabulary. |
+| `datamachine_memory_store` | Agents API public candidate | Generic memory persistence swap seam. Keep as Data Machine's current public behavior until extraction; introduce a neutral Agents API filter only when that package owns the resolver and migration path. |
 | `datamachine_register_agents` | Agents API public candidate | Registration hook should become WordPress-shaped. |
 | `datamachine_registered_agent_reconciled` | Agents API implementation candidate | Lifecycle event is useful, current reconciliation semantics are Data Machine implementation. |
 | `datamachine_guideline_updated` | Agents API public candidate | Generic memory/guideline change event after naming review. |

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -1469,11 +1469,14 @@ arrays are projection shapes at provider boundaries, not the store contract.
 ### AgentMemoryStoreInterface (`/inc/Core/FilesRepository/AgentMemoryStoreInterface.php`)
 
 **Purpose**: Single seam between agent memory operations and the underlying
-persistence backend. The disk default ([`DiskAgentMemoryStore`](../../../inc/Core/FilesRepository/DiskAgentMemoryStore.php))
+persistence backend. The contract is generic agent-memory persistence: it does
+not own section parsing, scaffold/default-file creation, editability, ability
+permissions, prompt injection, flows, jobs, or pipeline behavior. The disk
+default ([`DiskAgentMemoryStore`](../../../inc/Core/FilesRepository/DiskAgentMemoryStore.php))
 preserves byte-for-byte the filesystem behavior the codebase used before this
 seam was introduced.
 
-**Filter: `datamachine_memory_store`**
+**Current filter: `datamachine_memory_store`**
 
 ```php
 apply_filters(
@@ -1486,6 +1489,11 @@ apply_filters(
 Return an [`AgentMemoryStoreInterface`](../../../inc/Core/FilesRepository/AgentMemoryStoreInterface.php)
 implementation to replace the disk default for this scope. Return `null` (the
 default) to let Data Machine read and write through the filesystem.
+
+This is the only runtime filter in Data Machine today. A future Agents API
+extraction should introduce a neutral resolver/filter name in the extracted
+package with an explicit migration path; Data Machine does not mirror this hook
+under a second alias before ownership moves.
 
 **Use case**: managed-host environments where the local filesystem is not
 writable (e.g. WordPress.com, VIP). A consumer plugin (e.g. Intelligence)
@@ -1513,9 +1521,10 @@ add_filter( 'datamachine_memory_store', function ( $store, $scope ) {
 - `delete( $scope )` → `AgentMemoryWriteResult` (idempotent)
 - `list_layer( $scope_query )` → `AgentMemoryListEntry[]` (enumerates one layer)
 
-Section parsing, scaffolding, editability gating, and registry-driven
-convention-path semantics stay in `AgentMemory` (the high-level facade).
-The store is the dumb persistence layer underneath.
+Section parsing, scaffolding, editability gating, ability permissions,
+prompt-injection policy, and registry-driven convention-path semantics stay in
+`AgentMemory` and its higher-level callers. The store is the persistence layer
+underneath.
 
 **Single consumer of the store**: `\DataMachine\Core\FilesRepository\AgentMemory`.
 

--- a/inc/Core/FilesRepository/AgentMemoryListEntry.php
+++ b/inc/Core/FilesRepository/AgentMemoryListEntry.php
@@ -2,7 +2,7 @@
 /**
  * Agent Memory List Entry
  *
- * Immutable value object representing a single file in a layer listing
+ * Store-neutral value object representing a single file in a layer listing
  * returned by AgentMemoryStoreInterface::list_layer().
  *
  * @package DataMachine\Core\FilesRepository

--- a/inc/Core/FilesRepository/AgentMemoryReadResult.php
+++ b/inc/Core/FilesRepository/AgentMemoryReadResult.php
@@ -2,7 +2,7 @@
 /**
  * Agent Memory Read Result
  *
- * Immutable value object returned by AgentMemoryStoreInterface::read().
+ * Store-neutral value object returned by AgentMemoryStoreInterface::read().
  *
  * @package DataMachine\Core\FilesRepository
  * @since   next

--- a/inc/Core/FilesRepository/AgentMemoryScope.php
+++ b/inc/Core/FilesRepository/AgentMemoryScope.php
@@ -2,12 +2,12 @@
 /**
  * Agent Memory Scope
  *
- * Immutable value object that uniquely identifies an agent memory file
+ * Immutable value object that uniquely identifies an agent memory record
  * across the four-tuple primary key (layer, user_id, agent_id, filename).
  *
  * Same identity model as the on-disk path encoding, just decoupled from
- * the filesystem so an alternate store (e.g. database-backed) can map it
- * to its own physical key.
+ * the filesystem so an alternate store (e.g. database-backed, guideline-backed,
+ * or host-native) can map it to its own physical key.
  *
  * @package DataMachine\Core\FilesRepository
  * @since   next

--- a/inc/Core/FilesRepository/AgentMemoryStoreFactory.php
+++ b/inc/Core/FilesRepository/AgentMemoryStoreFactory.php
@@ -2,9 +2,13 @@
 /**
  * Agent Memory Store Factory
  *
- * Resolves the active {@see AgentMemoryStoreInterface} implementation
- * via the `datamachine_memory_store` filter, falling back to the
- * built-in {@see DiskAgentMemoryStore}.
+ * Resolves the active {@see AgentMemoryStoreInterface} implementation.
+ *
+ * This is Data Machine's current resolver for a generic agent-memory
+ * persistence contract. It intentionally keeps one public swap point: the
+ * existing `datamachine_memory_store` filter, until an Agents API extraction
+ * can introduce its own vocabulary and migration path. No caller should branch
+ * on the concrete backend.
  *
  * Single resolution point so every consumer (AgentMemory, DailyMemory,
  * AgentFileAbilities, CoreMemoryFilesDirective) gets the same swap mechanism
@@ -43,6 +47,11 @@ class AgentMemoryStoreFactory {
 		 * Return an {@see AgentMemoryStoreInterface} instance to short-circuit
 		 * the default disk-backed store. Return null (the default) to use the
 		 * built-in {@see DiskAgentMemoryStore}.
+		 *
+		 * This remains the only runtime filter in Data Machine. A future extracted
+		 * Agents API can add a neutral filter name when it owns the resolver; adding
+		 * a second alias here would create a permanent compatibility surface without
+		 * moving ownership.
 		 *
 		 * The disk default preserves byte-for-byte the behavior Data Machine
 		 * had before this seam was introduced — self-hosted users see no

--- a/inc/Core/FilesRepository/AgentMemoryStoreInterface.php
+++ b/inc/Core/FilesRepository/AgentMemoryStoreInterface.php
@@ -2,12 +2,16 @@
 /**
  * Agent Memory Store Interface
  *
- * Single seam between agent memory operations and the underlying
- * persistence backend. Default implementation ({@see DiskAgentMemoryStore})
- * preserves today's filesystem behavior. Consumers can swap in an
- * alternate store via the `datamachine_memory_store` filter
- * (e.g. a DB-backed store on managed hosts where the filesystem is
- * not writable).
+ * Generic persistence contract for agent memory. Data Machine consumes this
+ * seam today, but the contract deliberately describes agent-memory storage:
+ * not flows, pipelines, jobs, abilities, scaffolding, or prompt injection.
+ *
+ * Default implementation ({@see DiskAgentMemoryStore}) preserves today's
+ * filesystem behavior. Consumers can swap in an alternate store via the
+ * current `datamachine_memory_store` filter (e.g. a DB-backed store on
+ * managed hosts where the filesystem is not writable). A future Agents API
+ * extraction should rename the resolver/filter in that plugin's vocabulary;
+ * this interface is the behavior to carry forward.
  *
  * Implementations are responsible for:
  * - translating an {@see AgentMemoryScope} to a physical key (path, row, URL);
@@ -16,11 +20,12 @@
  * - honoring the layer + user_id + agent_id + filename four-tuple as the
  *   identity model.
  *
- * Section parsing, scaffolding, editability gating, and registry-driven
- * convention-path semantics all stay in the higher-level callers
+ * Section parsing, scaffold/default-file creation, editability gating,
+ * ability permissions, prompt-injection policy, and registry-driven
+ * convention-path semantics all stay in higher-level callers
  * ({@see AgentMemory}, {@see \DataMachine\Abilities\File\AgentFileAbilities},
  * {@see \DataMachine\Engine\AI\MemoryFileRegistry}). The store is the
- * dumb persistence layer underneath.
+ * persistence layer underneath.
  *
  * @package DataMachine\Core\FilesRepository
  * @since   next

--- a/inc/Core/FilesRepository/AgentMemoryWriteResult.php
+++ b/inc/Core/FilesRepository/AgentMemoryWriteResult.php
@@ -2,7 +2,7 @@
 /**
  * Agent Memory Write Result
  *
- * Immutable value object returned by AgentMemoryStoreInterface::write()
+ * Store-neutral value object returned by AgentMemoryStoreInterface::write()
  * and ::delete().
  *
  * @package DataMachine\Core\FilesRepository

--- a/inc/Core/FilesRepository/DiskAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/DiskAgentMemoryStore.php
@@ -115,12 +115,10 @@ class DiskAgentMemoryStore implements AgentMemoryStoreInterface {
 
 		$deleted = wp_delete_file( $filepath );
 
-		// wp_delete_file returns void; verify by re-checking existence.
-		if ( file_exists( $filepath ) ) {
+		if ( ! $deleted ) {
 			return AgentMemoryWriteResult::failure( 'io' );
 		}
 
-		unset( $deleted );
 		return AgentMemoryWriteResult::ok( '', 0 );
 	}
 

--- a/inc/Core/FilesRepository/DiskAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/DiskAgentMemoryStore.php
@@ -3,9 +3,13 @@
  * Disk Agent Memory Store
  *
  * Default implementation of {@see AgentMemoryStoreInterface} that persists
- * agent memory files on the local filesystem under wp-uploads. Preserves
- * the byte-for-byte behavior the codebase used before the store seam was
- * introduced.
+ * agent memory records as markdown files on the local filesystem under
+ * wp-uploads. Preserves the byte-for-byte behavior the codebase used before
+ * the store seam was introduced.
+ *
+ * This name describes the current Data Machine implementation. In a future
+ * Agents API extraction, the same behavior may be documented as a markdown or
+ * local-file memory store; no public rename happens in this PR.
  *
  * Concurrency: this implementation does not implement compare-and-swap.
  * The `$if_match` parameter on write() is accepted but ignored — the

--- a/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
@@ -3,14 +3,14 @@
  * Guideline Agent Memory Store
  *
  * Optional {@see AgentMemoryStoreInterface} implementation that persists
- * agent memory files as `wp_guideline` posts tagged with
+ * agent memory records as `wp_guideline` posts tagged with
  * `wp_guideline_type=memory`.
  *
  * Data Machine does not register the Guidelines substrate and does not make
  * this store the default. Consumers that run on a host where Guidelines are
  * available can feature-detect {@see self::is_available()} and opt in via the
- * `datamachine_memory_store` filter. When unavailable, the built-in disk store
- * remains the default behavior.
+ * current `datamachine_memory_store` filter. When unavailable, the built-in
+ * disk store remains the default behavior.
  *
  * Identity model: one post = one (layer, user_id, agent_id, filename) tuple.
  * Filename is the relative path within the layer (`MEMORY.md`,

--- a/tests/agent-memory-store-factory-contract-smoke.php
+++ b/tests/agent-memory-store-factory-contract-smoke.php
@@ -173,7 +173,7 @@ datamachine_agent_memory_store_contract_assert( "# Memory\n" === $read->content,
 datamachine_agent_memory_store_contract_reset_filters();
 add_filter(
 	'datamachine_memory_store',
-	static fn() => new stdClass(),
+	static fn( $_store, $_scope ) => new stdClass(),
 	10,
 	2
 );
@@ -183,7 +183,7 @@ datamachine_agent_memory_store_contract_assert( $invalid_store instanceof DiskAg
 datamachine_agent_memory_store_contract_reset_filters();
 add_filter(
 	'agents_api_memory_store',
-	static function () use ( $fake_store ) {
+	static function ( $_store, $_scope ) use ( $fake_store ) {
 		return $fake_store;
 	},
 	10,

--- a/tests/agent-memory-store-factory-contract-smoke.php
+++ b/tests/agent-memory-store-factory-contract-smoke.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Pure-PHP smoke tests for the agent memory store resolver contract.
+ *
+ * Verifies that Data Machine still has one active store seam, invalid filter
+ * returns do not replace the default, and callers can operate against the
+ * interface without knowing which backing store is active.
+ */
+
+define( 'ABSPATH', __DIR__ . '/../' );
+
+$GLOBALS['datamachine_agent_memory_store_contract_filters'] = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['datamachine_agent_memory_store_contract_filters'][ $hook ][ $priority ][] = array(
+			'callback'      => $callback,
+			'accepted_args' => $accepted_args,
+		);
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$filters = $GLOBALS['datamachine_agent_memory_store_contract_filters'][ $hook ] ?? array();
+		ksort( $filters );
+
+		foreach ( $filters as $callbacks ) {
+			foreach ( $callbacks as $filter ) {
+				$value = $filter['callback']( ...array_slice( array_merge( array( $value ), $args ), 0, $filter['accepted_args'] ) );
+			}
+		}
+
+		return $value;
+	}
+}
+
+require_once __DIR__ . '/../inc/Engine/AI/MemoryFileRegistry.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/DirectoryManager.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/FilesystemHelper.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryScope.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryReadResult.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryWriteResult.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryListEntry.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryStoreInterface.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/DiskAgentMemoryStore.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/AgentMemoryStoreFactory.php';
+
+use DataMachine\Core\FilesRepository\AgentMemoryListEntry;
+use DataMachine\Core\FilesRepository\AgentMemoryReadResult;
+use DataMachine\Core\FilesRepository\AgentMemoryScope;
+use DataMachine\Core\FilesRepository\AgentMemoryStoreFactory;
+use DataMachine\Core\FilesRepository\AgentMemoryStoreInterface;
+use DataMachine\Core\FilesRepository\AgentMemoryWriteResult;
+use DataMachine\Core\FilesRepository\DiskAgentMemoryStore;
+
+class AgentMemoryStoreContractFakeStore implements AgentMemoryStoreInterface {
+	/** @var array<string, string> */
+	public array $files = array();
+
+	/** @var AgentMemoryScope[] */
+	public array $scopes = array();
+
+	public function read( AgentMemoryScope $scope ): AgentMemoryReadResult {
+		$this->scopes[] = $scope;
+		if ( ! array_key_exists( $scope->key(), $this->files ) ) {
+			return AgentMemoryReadResult::not_found();
+		}
+
+		$content = $this->files[ $scope->key() ];
+		return new AgentMemoryReadResult( true, $content, sha1( $content ), strlen( $content ), 123 );
+	}
+
+	public function write( AgentMemoryScope $scope, string $content, ?string $_if_match = null ): AgentMemoryWriteResult {
+		unset( $_if_match );
+		$this->scopes[] = $scope;
+		$this->files[ $scope->key() ] = $content;
+
+		return AgentMemoryWriteResult::ok( sha1( $content ), strlen( $content ) );
+	}
+
+	public function exists( AgentMemoryScope $scope ): bool {
+		$this->scopes[] = $scope;
+		return array_key_exists( $scope->key(), $this->files );
+	}
+
+	public function delete( AgentMemoryScope $scope ): AgentMemoryWriteResult {
+		$this->scopes[] = $scope;
+		unset( $this->files[ $scope->key() ] );
+
+		return AgentMemoryWriteResult::ok( '', 0 );
+	}
+
+	public function list_layer( AgentMemoryScope $scope_query ): array {
+		$this->scopes[] = $scope_query;
+		$entries        = array();
+
+		foreach ( $this->files as $key => $content ) {
+			[ $layer, $user_id, $agent_id, $filename ] = explode( ':', $key, 4 );
+			if ( $layer !== $scope_query->layer || (int) $user_id !== $scope_query->user_id || (int) $agent_id !== $scope_query->agent_id ) {
+				continue;
+			}
+
+			if ( false !== strpos( $filename, '/' ) ) {
+				continue;
+			}
+
+			$entries[] = new AgentMemoryListEntry( $filename, $layer, strlen( $content ), 123 );
+		}
+
+		return $entries;
+	}
+
+	public function list_subtree( AgentMemoryScope $scope_query, string $prefix ): array {
+		$this->scopes[] = $scope_query;
+		unset( $prefix );
+		return array();
+	}
+}
+
+function datamachine_agent_memory_store_contract_assert( bool $condition, string $message ): void {
+	static $assertions = 0;
+	++$assertions;
+
+	if ( ! $condition ) {
+		fwrite( STDERR, "Assertion failed: {$message}\n" );
+		exit( 1 );
+	}
+
+	echo "ok {$assertions} - {$message}\n";
+}
+
+function datamachine_agent_memory_store_contract_reset_filters(): void {
+	$GLOBALS['datamachine_agent_memory_store_contract_filters'] = array();
+}
+
+function datamachine_agent_memory_store_contract_round_trip( AgentMemoryStoreInterface $store, AgentMemoryScope $scope ): AgentMemoryReadResult {
+	$write = $store->write( $scope, "# Memory\n" );
+	datamachine_agent_memory_store_contract_assert( true === $write->success, 'interface write succeeds without concrete-store branching' );
+
+	return $store->read( $scope );
+}
+
+$scope = new AgentMemoryScope( 'agent', 7, 42, 'MEMORY.md' );
+
+datamachine_agent_memory_store_contract_reset_filters();
+$default_store = AgentMemoryStoreFactory::for_scope( $scope );
+datamachine_agent_memory_store_contract_assert( $default_store instanceof DiskAgentMemoryStore, 'factory falls back to the disk store with no filter' );
+
+datamachine_agent_memory_store_contract_reset_filters();
+$fake_store       = new AgentMemoryStoreContractFakeStore();
+$filter_arguments = array();
+add_filter(
+	'datamachine_memory_store',
+	static function ( $store, AgentMemoryScope $filter_scope ) use ( $fake_store, &$filter_arguments ) {
+		$filter_arguments[] = array( $store, $filter_scope );
+		return $fake_store;
+	},
+	10,
+	2
+);
+
+$selected_store = AgentMemoryStoreFactory::for_scope( $scope );
+datamachine_agent_memory_store_contract_assert( $fake_store === $selected_store, 'factory selects a valid store from datamachine_memory_store' );
+datamachine_agent_memory_store_contract_assert( 1 === count( $filter_arguments ), 'store filter is invoked once for one resolution' );
+datamachine_agent_memory_store_contract_assert( null === $filter_arguments[0][0], 'store filter receives null as the default candidate' );
+datamachine_agent_memory_store_contract_assert( $scope === $filter_arguments[0][1], 'store filter receives the scope being resolved' );
+
+$read = datamachine_agent_memory_store_contract_round_trip( $selected_store, $scope );
+datamachine_agent_memory_store_contract_assert( true === $read->exists, 'selected store returns content through the interface contract' );
+datamachine_agent_memory_store_contract_assert( "# Memory\n" === $read->content, 'selected store preserves content through read/write round trip' );
+
+datamachine_agent_memory_store_contract_reset_filters();
+add_filter(
+	'datamachine_memory_store',
+	static fn() => new stdClass(),
+	10,
+	2
+);
+$invalid_store = AgentMemoryStoreFactory::for_scope( $scope );
+datamachine_agent_memory_store_contract_assert( $invalid_store instanceof DiskAgentMemoryStore, 'factory ignores non-AgentMemoryStoreInterface filter returns' );
+
+datamachine_agent_memory_store_contract_reset_filters();
+add_filter(
+	'agents_api_memory_store',
+	static function () use ( $fake_store ) {
+		return $fake_store;
+	},
+	10,
+	2
+);
+$future_filter_store = AgentMemoryStoreFactory::for_scope( $scope );
+datamachine_agent_memory_store_contract_assert( $future_filter_store instanceof DiskAgentMemoryStore, 'undocumented future filter names are not active Data Machine behavior' );
+
+echo "Agent memory store factory contract smoke passed.\n";


### PR DESCRIPTION
## Summary
- Clarifies the agent-memory store contract as generic persistence rather than Data Machine scaffolding, ability, prompt-injection, or workflow behavior.
- Documents that datamachine_memory_store remains Data Machine's only current runtime seam until a future Agents API package owns a neutral resolver and migration path.
- Adds a pure-PHP resolver-contract smoke covering default fallback, valid store replacement, invalid return fallback, and non-activation of speculative future filter names.

## Boundary clarified
- Store implementations own persistence for the layer/user/agent/filename tuple and store-neutral result objects.
- Data Machine callers continue to own section parsing, scaffolding, editability, permissions, prompt injection, registry conventions, and product/operator surfaces.
- No class renames, storage changes, on-disk path changes, or compatibility aliases are introduced.

## Tests
- php tests/agent-memory-store-factory-contract-smoke.php
- php tests/daily-memory-store-seam-smoke.php
- php tests/guideline-agent-memory-store-smoke.php
- php tests/agent-memory-events-smoke.php
- php tests/memory-bundle-policy-smoke.php
- php -l tests/agent-memory-store-factory-contract-smoke.php
- git diff --check
- homeboy audit data-machine --path /Users/chubes/Developer/data-machine@neutralize-agent-memory-store --changed-since origin/main passed.
- homeboy lint data-machine --path /Users/chubes/Developer/data-machine@neutralize-agent-memory-store --changed-since origin/main hit the known changed-scope routing gap: PHPCS passed, then ESLint was run against Markdown/PHP files and failed with parsing errors.
- homeboy test data-machine --path /Users/chubes/Developer/data-machine@neutralize-agent-memory-store --changed-since origin/main selected tests/agent-memory-store-factory-contract-smoke.php but then ran the full PHPUnit suite and failed with unrelated harness/registration failures. Focused pure-PHP smokes above passed.

Closes #1567

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the contract/doc cleanup, adding the focused smoke test, running validation, and preparing this PR for Chris to review.