### PR TITLE
refactor(agents): split registry materialization

### DIFF
--- a/inc/Engine/Agents/AgentMaterializer.php
+++ b/inc/Engine/Agents/AgentMaterializer.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Agent Materializer
+ *
+ * Data Machine-specific reconciliation for declarative agent definitions.
+ *
+ * @package DataMachine\Engine\Agents
+ * @since   0.98.0
+ */
+
+namespace DataMachine\Engine\Agents;
+
+use DataMachine\Abilities\File\ScaffoldAbilities;
+use DataMachine\Core\Database\Agents\AgentAccess;
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\FilesRepository\DirectoryManager;
+
+defined( 'ABSPATH' ) || exit;
+
+class AgentMaterializer {
+
+	/**
+	 * Reconcile registered definitions against the `datamachine_agents` table.
+	 *
+	 * For each registered slug:
+	 *   - Row already exists -> leave it alone (mutable fields are DB-owned)
+	 *   - Row missing        -> resolve owner, create row, bootstrap access,
+	 *                          ensure agent directory, trigger scaffold ability
+	 *
+	 * Idempotent: safe to call multiple times per request. Returns a
+	 * summary of what happened for logging / testing.
+	 *
+	 * @since 0.98.0
+	 *
+	 * @param array<string, array> $definitions Registered agent definitions keyed by slug.
+	 * @return array{
+	 *     created: string[],
+	 *     existing: string[],
+	 *     skipped: string[],
+	 * }
+	 */
+	public static function reconcile( array $definitions ): array {
+		$summary = array(
+			'created'  => array(),
+			'existing' => array(),
+			'skipped'  => array(),
+		);
+
+		if ( ! class_exists( Agents::class ) ) {
+			return $summary;
+		}
+
+		$repo = new Agents();
+
+		foreach ( $definitions as $slug => $def ) {
+			$existing = $repo->get_by_slug( $slug );
+			if ( $existing ) {
+				$summary['existing'][] = $slug;
+				continue;
+			}
+
+			$owner_id = self::resolve_owner( $def );
+			if ( $owner_id <= 0 ) {
+				$summary['skipped'][] = $slug;
+				continue;
+			}
+
+			$agent_id = $repo->create_if_missing(
+				$slug,
+				$def['label'],
+				$owner_id,
+				$def['default_config']
+			);
+
+			if ( $agent_id <= 0 ) {
+				$summary['skipped'][] = $slug;
+				continue;
+			}
+
+			// Bootstrap owner access (mirrors AgentAbilities::createAgent()).
+			if ( class_exists( AgentAccess::class ) ) {
+				( new AgentAccess() )->bootstrap_owner_access( $agent_id, $owner_id );
+			}
+
+			// Ensure agent directory exists.
+			if ( class_exists( DirectoryManager::class ) ) {
+				$dir_mgr   = new DirectoryManager();
+				$agent_dir = $dir_mgr->get_agent_identity_directory( $slug );
+				$dir_mgr->ensure_directory_exists( $agent_dir );
+			}
+
+			// Scaffold agent-layer memory files (SOUL.md, MEMORY.md, etc.).
+			// The scaffold filter consults AgentRegistry for a matching
+			// `memory_seeds` entry per filename and substitutes bundled
+			// content when present.
+			$scaffold = ScaffoldAbilities::get_ability();
+			if ( $scaffold ) {
+				$scaffold->execute(
+					array(
+						'layer'      => 'agent',
+						'agent_slug' => $slug,
+						'agent_id'   => $agent_id,
+					)
+				);
+			}
+
+			/**
+			 * Fires after a registered agent is materialized into the database.
+			 *
+			 * @since 0.71.0
+			 *
+			 * @param int    $agent_id Newly created agent row ID.
+			 * @param string $slug     Registered slug.
+			 * @param array  $def      Full registration definition.
+			 */
+			do_action( 'datamachine_registered_agent_reconciled', $agent_id, $slug, $def );
+
+			$summary['created'][] = $slug;
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Resolve the owner user ID for a registered agent.
+	 *
+	 * Calls the registration's `owner_resolver` when provided and falls
+	 * back to `DirectoryManager::get_default_agent_user_id()`.
+	 *
+	 * @param array $def Registration definition.
+	 * @return int User ID, or 0 when resolution fails.
+	 */
+	private static function resolve_owner( array $def ): int {
+		if ( isset( $def['owner_resolver'] ) && is_callable( $def['owner_resolver'] ) ) {
+			$resolved = (int) call_user_func( $def['owner_resolver'] );
+			if ( $resolved > 0 ) {
+				return $resolved;
+			}
+		}
+
+		if ( class_exists( DirectoryManager::class ) ) {
+			return (int) DirectoryManager::get_default_agent_user_id();
+		}
+
+		return 0;
+	}
+}

--- a/inc/Engine/Agents/AgentRegistry.php
+++ b/inc/Engine/Agents/AgentRegistry.php
@@ -5,8 +5,9 @@
  * Declarative registration surface for Data Machine agents. Plugins
  * (and DM core itself) declare agent roles by calling
  * `datamachine_register_agent()` inside a `datamachine_register_agents`
- * action callback. The registry collects definitions and reconciles
- * them against the `datamachine_agents` table on init.
+ * action callback. The registry collects definitions; Data Machine's
+ * materializer reconciles them against the `datamachine_agents` table
+ * on init.
  *
  * Registration is side-effect free — adding a slug to the registry
  * does not touch the database. Reconciliation materializes missing
@@ -24,11 +25,6 @@
  */
 
 namespace DataMachine\Engine\Agents;
-
-use DataMachine\Abilities\File\ScaffoldAbilities;
-use DataMachine\Core\Database\Agents\AgentAccess;
-use DataMachine\Core\Database\Agents\Agents;
-use DataMachine\Core\FilesRepository\DirectoryManager;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -164,111 +160,7 @@ class AgentRegistry {
 	 * }
 	 */
 	public static function reconcile(): array {
-		self::ensure_fired();
-
-		$summary = array(
-			'created'  => array(),
-			'existing' => array(),
-			'skipped'  => array(),
-		);
-
-		if ( ! class_exists( Agents::class ) ) {
-			return $summary;
-		}
-
-		$repo = new Agents();
-
-		foreach ( self::$agents as $slug => $def ) {
-			$existing = $repo->get_by_slug( $slug );
-			if ( $existing ) {
-				$summary['existing'][] = $slug;
-				continue;
-			}
-
-			$owner_id = self::resolve_owner( $def );
-			if ( $owner_id <= 0 ) {
-				$summary['skipped'][] = $slug;
-				continue;
-			}
-
-			$agent_id = $repo->create_if_missing(
-				$slug,
-				$def['label'],
-				$owner_id,
-				$def['default_config']
-			);
-
-			if ( $agent_id <= 0 ) {
-				$summary['skipped'][] = $slug;
-				continue;
-			}
-
-			// Bootstrap owner access (mirrors AgentAbilities::createAgent()).
-			if ( class_exists( AgentAccess::class ) ) {
-				( new AgentAccess() )->bootstrap_owner_access( $agent_id, $owner_id );
-			}
-
-			// Ensure agent directory exists.
-			if ( class_exists( DirectoryManager::class ) ) {
-				$dir_mgr   = new DirectoryManager();
-				$agent_dir = $dir_mgr->get_agent_identity_directory( $slug );
-				$dir_mgr->ensure_directory_exists( $agent_dir );
-			}
-
-			// Scaffold agent-layer memory files (SOUL.md, MEMORY.md, etc.).
-			// The scaffold filter consults AgentRegistry for a matching
-			// `memory_seeds` entry per filename and substitutes bundled
-			// content when present.
-			$scaffold = ScaffoldAbilities::get_ability();
-			if ( $scaffold ) {
-				$scaffold->execute(
-					array(
-						'layer'      => 'agent',
-						'agent_slug' => $slug,
-						'agent_id'   => $agent_id,
-					)
-				);
-			}
-
-			/**
-			 * Fires after a registered agent is materialized into the database.
-			 *
-			 * @since 0.71.0
-			 *
-			 * @param int    $agent_id Newly created agent row ID.
-			 * @param string $slug     Registered slug.
-			 * @param array  $def      Full registration definition.
-			 */
-			do_action( 'datamachine_registered_agent_reconciled', $agent_id, $slug, $def );
-
-			$summary['created'][] = $slug;
-		}
-
-		return $summary;
-	}
-
-	/**
-	 * Resolve the owner user ID for a registered agent.
-	 *
-	 * Calls the registration's `owner_resolver` when provided and falls
-	 * back to `DirectoryManager::get_default_agent_user_id()`.
-	 *
-	 * @param array $def Registration definition.
-	 * @return int User ID, or 0 when resolution fails.
-	 */
-	private static function resolve_owner( array $def ): int {
-		if ( isset( $def['owner_resolver'] ) && is_callable( $def['owner_resolver'] ) ) {
-			$resolved = (int) call_user_func( $def['owner_resolver'] );
-			if ( $resolved > 0 ) {
-				return $resolved;
-			}
-		}
-
-		if ( class_exists( DirectoryManager::class ) ) {
-			return (int) DirectoryManager::get_default_agent_user_id();
-		}
-
-		return 0;
+		return AgentMaterializer::reconcile( self::get_all() );
 	}
 
 	/**

--- a/tests/agent-registry-materializer-smoke.php
+++ b/tests/agent-registry-materializer-smoke.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Pure-PHP smoke test for agent registry/materializer split (#1566).
+ *
+ * Run with: php tests/agent-registry-materializer-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$GLOBALS['__agent_materializer_actions'] = array();
+
+	function sanitize_title( string $value ): string {
+		$value = strtolower( $value );
+		$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+		return trim( (string) $value, '-' );
+	}
+
+	function sanitize_file_name( string $value ): string {
+		return basename( $value );
+	}
+
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['__agent_materializer_actions'][ $hook ][] = $args;
+	}
+}
+
+namespace DataMachine\Core\Database\Agents {
+	class Agents {
+		/** @var array<string, array> */
+		public static array $rows = array();
+
+		public function get_by_slug( string $agent_slug ): ?array {
+			return self::$rows[ $agent_slug ] ?? null;
+		}
+
+		public function create_if_missing( string $agent_slug, string $agent_name, int $owner_id, array $agent_config = array() ): int {
+			if ( isset( self::$rows[ $agent_slug ] ) ) {
+				return (int) self::$rows[ $agent_slug ]['agent_id'];
+			}
+
+			$agent_id = count( self::$rows ) + 100;
+			self::$rows[ $agent_slug ] = array(
+				'agent_id'     => $agent_id,
+				'agent_slug'   => $agent_slug,
+				'agent_name'   => $agent_name,
+				'owner_id'     => $owner_id,
+				'agent_config' => $agent_config,
+			);
+
+			return $agent_id;
+		}
+	}
+
+	class AgentAccess {
+		/** @var array<int, array{agent_id:int, owner_id:int}> */
+		public static array $bootstrapped = array();
+
+		public function bootstrap_owner_access( int $agent_id, int $owner_id ): bool {
+			self::$bootstrapped[] = array(
+				'agent_id' => $agent_id,
+				'owner_id' => $owner_id,
+			);
+			return true;
+		}
+	}
+}
+
+namespace DataMachine\Core\FilesRepository {
+	class DirectoryManager {
+		public static int $default_user_id = 0;
+
+		/** @var string[] */
+		public static array $ensured = array();
+
+		public static function get_default_agent_user_id(): int {
+			return self::$default_user_id;
+		}
+
+		public function get_agent_identity_directory( string $slug ): string {
+			return '/agents/' . $slug;
+		}
+
+		public function ensure_directory_exists( string $path ): void {
+			self::$ensured[] = $path;
+		}
+	}
+}
+
+namespace DataMachine\Abilities\File {
+	class ScaffoldAbilities {
+		public static ?ScaffoldAbilityStub $ability = null;
+
+		public static function get_ability(): ?ScaffoldAbilityStub {
+			return self::$ability;
+		}
+	}
+
+	class ScaffoldAbilityStub {
+		/** @var array<int, array> */
+		public array $calls = array();
+
+		public function execute( array $args ): void {
+			$this->calls[] = $args;
+		}
+	}
+}
+
+namespace {
+	require_once __DIR__ . '/../inc/Engine/Agents/AgentMaterializer.php';
+	require_once __DIR__ . '/../inc/Engine/Agents/AgentRegistry.php';
+
+	use DataMachine\Abilities\File\ScaffoldAbilities;
+	use DataMachine\Abilities\File\ScaffoldAbilityStub;
+	use DataMachine\Core\Database\Agents\AgentAccess;
+	use DataMachine\Core\Database\Agents\Agents;
+	use DataMachine\Core\FilesRepository\DirectoryManager;
+	use DataMachine\Engine\Agents\AgentRegistry;
+
+	$failures = array();
+	$passes   = 0;
+
+	function assert_agent_materializer_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+		if ( $expected === $actual ) {
+			++$passes;
+			echo "  PASS {$name}\n";
+			return;
+		}
+
+		$failures[] = $name;
+		echo "  FAIL {$name}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	}
+
+	function reset_agent_materializer_smoke(): void {
+		AgentRegistry::reset_for_tests();
+		Agents::$rows                                    = array();
+		AgentAccess::$bootstrapped                       = array();
+		DirectoryManager::$default_user_id               = 0;
+		DirectoryManager::$ensured                       = array();
+		ScaffoldAbilities::$ability                      = new ScaffoldAbilityStub();
+		$GLOBALS['__agent_materializer_actions'] = array();
+	}
+
+	echo "agent-registry-materializer-smoke\n";
+
+	echo "\n[1] registry collects normalized declarative definitions without materializing rows:\n";
+	reset_agent_materializer_smoke();
+	AgentRegistry::register(
+		'Example Agent!',
+		array(
+			'label'          => 'Example Agent',
+			'description'    => 'Collect only',
+			'memory_seeds'   => array( '../SOUL.md' => '/tmp/seed-soul.md' ),
+			'owner_resolver' => static fn() => 7,
+			'default_config' => array( 'default_provider' => 'openai' ),
+		)
+	);
+	$definitions = AgentRegistry::get_all();
+	assert_agent_materializer_equals( array( 'example-agent' ), array_keys( $definitions ), 'definition slug is normalized', $failures, $passes );
+	assert_agent_materializer_equals( 'Example Agent', $definitions['example-agent']['label'] ?? '', 'definition label is preserved', $failures, $passes );
+	assert_agent_materializer_equals( array(), Agents::$rows, 'collecting definitions does not create agent rows', $failures, $passes );
+
+	echo "\n[2] reconciliation creates rows, access grants, directories, scaffold calls, and action hooks:\n";
+	$summary = AgentRegistry::reconcile();
+	assert_agent_materializer_equals( array( 'created' => array( 'example-agent' ), 'existing' => array(), 'skipped' => array() ), $summary, 'created summary matches pre-split registry behavior', $failures, $passes );
+	assert_agent_materializer_equals( 7, Agents::$rows['example-agent']['owner_id'] ?? 0, 'owner resolver controls created row owner', $failures, $passes );
+	assert_agent_materializer_equals( array( 'default_provider' => 'openai' ), Agents::$rows['example-agent']['agent_config'] ?? array(), 'default config persists on creation', $failures, $passes );
+	assert_agent_materializer_equals( array( array( 'agent_id' => 100, 'owner_id' => 7 ) ), AgentAccess::$bootstrapped, 'owner access is bootstrapped', $failures, $passes );
+	assert_agent_materializer_equals( array( '/agents/example-agent' ), DirectoryManager::$ensured, 'agent directory is ensured', $failures, $passes );
+	assert_agent_materializer_equals( array( array( 'layer' => 'agent', 'agent_slug' => 'example-agent', 'agent_id' => 100 ) ), ScaffoldAbilities::$ability->calls, 'agent scaffold ability is executed', $failures, $passes );
+	assert_agent_materializer_equals( 'example-agent', $GLOBALS['__agent_materializer_actions']['datamachine_registered_agent_reconciled'][0][1] ?? '', 'reconciled action still fires with slug', $failures, $passes );
+
+	echo "\n[3] existing rows are adopted and mutable fields stay DB-owned:\n";
+	$summary = AgentRegistry::reconcile();
+	assert_agent_materializer_equals( array( 'created' => array(), 'existing' => array( 'example-agent' ), 'skipped' => array() ), $summary, 'second reconcile reports existing row', $failures, $passes );
+	assert_agent_materializer_equals( 1, count( AgentAccess::$bootstrapped ), 'existing row does not bootstrap access again', $failures, $passes );
+	assert_agent_materializer_equals( 1, count( ScaffoldAbilities::$ability->calls ), 'existing row does not scaffold again', $failures, $passes );
+
+	echo "\n[4] materializer owns Data Machine side-effect dependencies:\n";
+	$registry_source     = (string) file_get_contents( __DIR__ . '/../inc/Engine/Agents/AgentRegistry.php' );
+	$materializer_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/Agents/AgentMaterializer.php' );
+	assert_agent_materializer_equals( false, false !== strpos( $registry_source, 'Core\\Database\\Agents' ), 'registry no longer imports agent database repositories', $failures, $passes );
+	assert_agent_materializer_equals( false, false !== strpos( $registry_source, 'ScaffoldAbilities' ), 'registry no longer imports scaffold ability', $failures, $passes );
+	assert_agent_materializer_equals( true, false !== strpos( $materializer_source, 'Core\\Database\\Agents' ), 'materializer owns agent database repositories', $failures, $passes );
+	assert_agent_materializer_equals( true, false !== strpos( $materializer_source, 'ScaffoldAbilities' ), 'materializer owns scaffold ability', $failures, $passes );
+
+	if ( $failures ) {
+		echo "\nFAILED: " . count( $failures ) . " agent registry/materializer assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$passes} agent registry/materializer assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Split Data Machine's side-effecting registered-agent reconciliation into `AgentMaterializer`.
- Leave `AgentRegistry` as the declarative definition collector while preserving its public `reconcile()` compatibility wrapper.
- Add a pure-PHP smoke proving collection stays side-effect free and reconciliation still creates/adopts rows, bootstraps access, ensures directories, runs scaffold, and fires the existing action.

## Behavior preserved
- `datamachine_register_agent()` remains unchanged.
- `datamachine_register_agents` remains unchanged.
- `AgentRegistry::reconcile()` remains available and returns the same summary shape.
- Existing row adoption, owner access bootstrap, directory creation, scaffold execution, and `datamachine_registered_agent_reconciled` action behavior are preserved.

## Tests
- `php -l inc/Engine/Agents/AgentRegistry.php`
- `php -l inc/Engine/Agents/AgentMaterializer.php`
- `php -l tests/agent-registry-materializer-smoke.php`
- `php tests/agent-registry-materializer-smoke.php` — 17 assertions passed
- `git diff --check`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@split-agent-registry-materializer --changed-since origin/main` — passed, but selected 0 files
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@split-agent-registry-materializer --changed-since origin/main` — passed, but reported "No files changed since origin/main"
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@split-agent-registry-materializer --changed-since origin/main` — passed, but selected 0 impacted tests

Scoped Homeboy caveats observed:
- `homeboy lint --glob "inc/Engine/Agents/*.php"` misrouted PHP files through ESLint and hit scoped-PHPStan context misses already seen in this repo.
- `homeboy lint --file inc/Engine/Agents/AgentMaterializer.php` reported scoped-PHPStan `method.notFound` for existing `Agents::get_by_slug()` / `create_if_missing()` context; the same false-positive shape reproduces on existing `ToolPolicyResolver.php` with `Agents::get_agent()`.
- `homeboy test --file tests/agent-registry-materializer-smoke.php` fell back to the broader PHPUnit suite and failed on unrelated harness/setup failures; the focused PHP smoke above passes.

Closes #1566.

Note: the attached cook prompt referenced `#1569`, but the matching issue title/body is `#1566`; current `#1569` is the separate run-loop request/result boundary issue.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / `openai/gpt-5.5`)
- **Used for:** Refactor implementation, smoke test drafting, local verification, and PR preparation. Chris remains responsible for review and merge.
