### PR TITLE
refactor(tools): split execution core from Data Machine decorators

### DIFF
--- a/inc/Engine/AI/Tools/Execution/ToolExecutionCore.php
+++ b/inc/Engine/AI/Tools/Execution/ToolExecutionCore.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * Generic AI tool execution core.
+ *
+ * Handles the tool definition lookup, required-parameter validation, parameter
+ * assembly, and direct ability/legacy tool execution. Data Machine product
+ * decorators such as action staging and post-origin tracking stay in
+ * ToolExecutor.
+ *
+ * @package DataMachine\Engine\AI\Tools\Execution
+ */
+
+namespace DataMachine\Engine\AI\Tools\Execution;
+
+use DataMachine\Engine\AI\Tools\ToolParameters;
+
+defined( 'ABSPATH' ) || exit;
+
+class ToolExecutionCore {
+
+	/**
+	 * Prepare a tool call for direct execution.
+	 *
+	 * @param string $tool_name       Tool name to execute.
+	 * @param array  $tool_parameters Parameters from AI.
+	 * @param array  $available_tools Available tools array.
+	 * @param array  $payload         Step payload.
+	 * @return array Prepared invocation or normalized error result.
+	 */
+	public function prepareToolCall( string $tool_name, array $tool_parameters, array $available_tools, array $payload ): array {
+		$tool_def = $available_tools[ $tool_name ] ?? null;
+		if ( ! $tool_def ) {
+			return array(
+				'ready'     => false,
+				'success'   => false,
+				'error'     => "Tool '{$tool_name}' not found",
+				'tool_name' => $tool_name,
+			);
+		}
+
+		$validation = self::validateRequiredParameters( $tool_parameters, $tool_def );
+		if ( ! $validation['valid'] ) {
+			return array(
+				'ready'     => false,
+				'success'   => false,
+				'error'     => sprintf(
+					'%s requires the following parameters: %s. Please provide these parameters and try again.',
+					ucwords( str_replace( '_', ' ', $tool_name ) ),
+					implode( ', ', $validation['missing'] )
+				),
+				'tool_name' => $tool_name,
+			);
+		}
+
+		return array(
+			'ready'      => true,
+			'tool_def'   => $tool_def,
+			'parameters' => ToolParameters::buildParameters(
+				$tool_parameters,
+				$payload,
+				$tool_def
+			),
+		);
+	}
+
+	/**
+	 * Execute a prepared tool definition directly.
+	 *
+	 * @param string $tool_name  Tool name.
+	 * @param array  $parameters Complete tool parameters.
+	 * @param array  $tool_def   Tool definition.
+	 * @return array Tool execution result.
+	 */
+	public function executePreparedTool( string $tool_name, array $parameters, array $tool_def ): array {
+		if ( self::isAbilityOnlyTool( $tool_def ) ) {
+			return $this->executeAbilityTool( $tool_name, $parameters, $tool_def );
+		}
+
+		return $this->executeLegacyTool( $tool_name, $parameters, $tool_def );
+	}
+
+	/**
+	 * Execute tool with generic parameter validation and result normalization.
+	 *
+	 * @param string $tool_name       Tool name to execute.
+	 * @param array  $tool_parameters Parameters from AI.
+	 * @param array  $available_tools Available tools array.
+	 * @param array  $payload         Step payload.
+	 * @return array Tool execution result.
+	 */
+	public function executeTool( string $tool_name, array $tool_parameters, array $available_tools, array $payload ): array {
+		$prepared = $this->prepareToolCall( $tool_name, $tool_parameters, $available_tools, $payload );
+		if ( empty( $prepared['ready'] ) ) {
+			unset( $prepared['ready'] );
+			return $prepared;
+		}
+
+		return $this->executePreparedTool( $tool_name, $prepared['parameters'], $prepared['tool_def'] );
+	}
+
+	/**
+	 * Validate that all required parameters are present.
+	 *
+	 * @param array $tool_parameters Parameters from AI.
+	 * @param array $tool_def        Tool definition with parameter specs.
+	 * @return array Validation result with 'valid', 'required', and 'missing' keys.
+	 */
+	public static function validateRequiredParameters( array $tool_parameters, array $tool_def ): array {
+		$required = array();
+		$missing  = array();
+
+		$param_defs = $tool_def['parameters'] ?? array();
+
+		foreach ( $param_defs as $param_name => $param_config ) {
+			if ( ! is_array( $param_config ) ) {
+				continue;
+			}
+
+			if ( ! empty( $param_config['required'] ) ) {
+				$required[] = $param_name;
+
+				if ( ! isset( $tool_parameters[ $param_name ] ) || '' === $tool_parameters[ $param_name ] ) {
+					$missing[] = $param_name;
+				}
+			}
+		}
+
+		return array(
+			'valid'    => empty( $missing ),
+			'required' => $required,
+			'missing'  => $missing,
+		);
+	}
+
+	/**
+	 * Whether a tool should execute directly through a linked WordPress Ability.
+	 *
+	 * @param array $tool_def Tool definition.
+	 * @return bool
+	 */
+	private static function isAbilityOnlyTool( array $tool_def ): bool {
+		return ! empty( $tool_def['ability'] )
+			&& empty( $tool_def['class'] )
+			&& empty( $tool_def['method'] );
+	}
+
+	/**
+	 * Execute a tool through its linked WordPress Ability.
+	 *
+	 * @param string $tool_name  Tool name.
+	 * @param array  $parameters Complete tool parameters.
+	 * @param array  $tool_def   Tool definition.
+	 * @return array Tool execution result.
+	 */
+	private function executeAbilityTool( string $tool_name, array $parameters, array $tool_def ): array {
+		$ability_slug = (string) $tool_def['ability'];
+		if ( ! class_exists( '\\WP_Abilities_Registry' ) ) {
+			return array(
+				'success'   => false,
+				'error'     => sprintf( "Tool '%s' references ability '%s', but the WordPress Abilities API is not available.", $tool_name, $ability_slug ),
+				'tool_name' => $tool_name,
+				'ability'   => $ability_slug,
+			);
+		}
+
+		$registry = \WP_Abilities_Registry::get_instance();
+		$ability  = $registry->get_registered( $ability_slug );
+
+		if ( ! $ability ) {
+			return array(
+				'success'   => false,
+				'error'     => sprintf( "Tool '%s' references missing ability '%s'.", $tool_name, $ability_slug ),
+				'tool_name' => $tool_name,
+				'ability'   => $ability_slug,
+			);
+		}
+
+		$permission = $ability->check_permissions( $parameters );
+		if ( is_wp_error( $permission ) ) {
+			return array(
+				'success'   => false,
+				'error'     => $permission->get_error_message(),
+				'tool_name' => $tool_name,
+				'ability'   => $ability_slug,
+			);
+		}
+
+		if ( true !== $permission ) {
+			return array(
+				'success'   => false,
+				'error'     => sprintf( "Tool '%s' is not permitted by ability '%s'.", $tool_name, $ability_slug ),
+				'tool_name' => $tool_name,
+				'ability'   => $ability_slug,
+			);
+		}
+
+		$result = $ability->execute( $parameters );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'   => false,
+				'error'     => $result->get_error_message(),
+				'tool_name' => $tool_name,
+				'ability'   => $ability_slug,
+			);
+		}
+
+		if ( is_array( $result ) ) {
+			return $result;
+		}
+
+		return array(
+			'success'   => true,
+			'tool_name' => $tool_name,
+			'ability'   => $ability_slug,
+			'result'    => $result,
+		);
+	}
+
+	/**
+	 * Execute a legacy class/method tool definition.
+	 *
+	 * @param string $tool_name  Tool name.
+	 * @param array  $parameters Complete tool parameters.
+	 * @param array  $tool_def   Tool definition.
+	 * @return array Tool execution result.
+	 */
+	private function executeLegacyTool( string $tool_name, array $parameters, array $tool_def ): array {
+		if ( ! isset( $tool_def['class'] ) || empty( $tool_def['class'] ) ) {
+			return array(
+				'success'   => false,
+				'error'     => "Tool '{$tool_name}' is missing required 'class' definition. This may indicate the tool was not properly resolved from a callable.",
+				'tool_name' => $tool_name,
+			);
+		}
+
+		$class_name = $tool_def['class'];
+		if ( ! class_exists( $class_name ) ) {
+			return array(
+				'success'   => false,
+				'error'     => "Tool class '{$class_name}' not found",
+				'tool_name' => $tool_name,
+			);
+		}
+
+		$method = $tool_def['method'] ?? null;
+		if ( ! $method || ! method_exists( $class_name, $method ) ) {
+			return array(
+				'success'   => false,
+				'error'     => sprintf(
+					"Tool '%s' definition is missing required 'method' key or method '%s' does not exist on class '%s'.",
+					$tool_name,
+					$method ?? '(none)',
+					$class_name
+				),
+				'tool_name' => $tool_name,
+			);
+		}
+
+		$tool_handler = new $class_name();
+		return $tool_handler->$method( $parameters, $tool_def );
+	}
+}

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -14,6 +14,7 @@ namespace DataMachine\Engine\AI\Tools;
 use DataMachine\Core\WordPress\PostTracking;
 use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
 use DataMachine\Engine\AI\Actions\PendingActionHelper;
+use DataMachine\Engine\AI\Tools\Execution\ToolExecutionCore;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -55,33 +56,15 @@ class ToolExecutor {
 		int $agent_id = 0,
 		array $client_context = array()
 	): array {
-		$tool_def = $available_tools[ $tool_name ] ?? null;
-		if ( ! $tool_def ) {
-			return array(
-				'success'   => false,
-				'error'     => "Tool '{$tool_name}' not found",
-				'tool_name' => $tool_name,
-			);
+		$core     = new ToolExecutionCore();
+		$prepared = $core->prepareToolCall( $tool_name, $tool_parameters, $available_tools, $payload );
+		if ( empty( $prepared['ready'] ) ) {
+			unset( $prepared['ready'] );
+			return $prepared;
 		}
 
-		$validation = self::validateRequiredParameters( $tool_parameters, $tool_def );
-		if ( ! $validation['valid'] ) {
-			return array(
-				'success'   => false,
-				'error'     => sprintf(
-					'%s requires the following parameters: %s. Please provide these parameters and try again.',
-					ucwords( str_replace( '_', ' ', $tool_name ) ),
-					implode( ', ', $validation['missing'] )
-				),
-				'tool_name' => $tool_name,
-			);
-		}
-
-		$complete_parameters = ToolParameters::buildParameters(
-			$tool_parameters,
-			$payload,
-			$tool_def
-		);
+		$tool_def            = $prepared['tool_def'];
+		$complete_parameters = $prepared['parameters'];
 
 		// Resolve the action policy for this invocation. Tools without
 		// action_policy metadata resolve to 'direct' and behave exactly
@@ -155,11 +138,7 @@ class ToolExecutor {
 		}
 
 		// Policy is 'direct' (or 'preview' fell back) — execute the tool normally.
-		if ( self::isAbilityOnlyTool( $tool_def ) ) {
-			$tool_result = self::executeAbilityTool( $tool_name, $complete_parameters, $tool_def );
-		} else {
-			$tool_result = self::executeLegacyTool( $tool_name, $complete_parameters, $tool_def );
-		}
+		$tool_result = $core->executePreparedTool( $tool_name, $complete_parameters, $tool_def );
 
 		// Automatic post origin tracking — applies to every tool whose result
 		// contains an extractable post_id. This covers both handler tools
@@ -178,139 +157,6 @@ class ToolExecutor {
 		}
 
 		return $tool_result;
-	}
-
-	/**
-	 * Whether a tool should execute directly through a linked WordPress Ability.
-	 *
-	 * Legacy class/method definitions stay authoritative during the migration.
-	 * This branch only handles the new ability-native shape for a single linked
-	 * ability; composed multi-ability tools remain on their existing adapters.
-	 *
-	 * @param array $tool_def Tool definition.
-	 * @return bool
-	 */
-	private static function isAbilityOnlyTool( array $tool_def ): bool {
-		return ! empty( $tool_def['ability'] )
-			&& empty( $tool_def['class'] )
-			&& empty( $tool_def['method'] );
-	}
-
-	/**
-	 * Execute a tool through its linked WordPress Ability.
-	 *
-	 * @param string $tool_name  Tool name.
-	 * @param array  $parameters Complete tool parameters.
-	 * @param array  $tool_def   Tool definition.
-	 * @return array Tool execution result.
-	 */
-	private static function executeAbilityTool( string $tool_name, array $parameters, array $tool_def ): array {
-		$ability_slug = (string) $tool_def['ability'];
-		if ( ! class_exists( '\\WP_Abilities_Registry' ) ) {
-			return array(
-				'success'   => false,
-				'error'     => sprintf( "Tool '%s' references ability '%s', but the WordPress Abilities API is not available.", $tool_name, $ability_slug ),
-				'tool_name' => $tool_name,
-				'ability'   => $ability_slug,
-			);
-		}
-
-		$registry     = \WP_Abilities_Registry::get_instance();
-		$ability      = $registry ? $registry->get_registered( $ability_slug ) : null;
-
-		if ( ! $ability ) {
-			return array(
-				'success'   => false,
-				'error'     => sprintf( "Tool '%s' references missing ability '%s'.", $tool_name, $ability_slug ),
-				'tool_name' => $tool_name,
-				'ability'   => $ability_slug,
-			);
-		}
-
-		$permission = $ability->check_permissions( $parameters );
-		if ( is_wp_error( $permission ) ) {
-			return array(
-				'success'   => false,
-				'error'     => $permission->get_error_message(),
-				'tool_name' => $tool_name,
-				'ability'   => $ability_slug,
-			);
-		}
-
-		if ( true !== $permission ) {
-			return array(
-				'success'   => false,
-				'error'     => sprintf( "Tool '%s' is not permitted by ability '%s'.", $tool_name, $ability_slug ),
-				'tool_name' => $tool_name,
-				'ability'   => $ability_slug,
-			);
-		}
-
-		$result = $ability->execute( $parameters );
-		if ( is_wp_error( $result ) ) {
-			return array(
-				'success'   => false,
-				'error'     => $result->get_error_message(),
-				'tool_name' => $tool_name,
-				'ability'   => $ability_slug,
-			);
-		}
-
-		if ( is_array( $result ) ) {
-			return $result;
-		}
-
-		return array(
-			'success'   => true,
-			'tool_name' => $tool_name,
-			'ability'   => $ability_slug,
-			'result'    => $result,
-		);
-	}
-
-	/**
-	 * Execute a legacy class/method tool definition.
-	 *
-	 * @param string $tool_name  Tool name.
-	 * @param array  $parameters Complete tool parameters.
-	 * @param array  $tool_def   Tool definition.
-	 * @return array Tool execution result.
-	 */
-	private static function executeLegacyTool( string $tool_name, array $parameters, array $tool_def ): array {
-		// Ensure tool definition has required 'class' key.
-		if ( ! isset( $tool_def['class'] ) || empty( $tool_def['class'] ) ) {
-			return array(
-				'success'   => false,
-				'error'     => "Tool '{$tool_name}' is missing required 'class' definition. This may indicate the tool was not properly resolved from a callable.",
-				'tool_name' => $tool_name,
-			);
-		}
-
-		$class_name = $tool_def['class'];
-		if ( ! class_exists( $class_name ) ) {
-			return array(
-				'success'   => false,
-				'error'     => "Tool class '{$class_name}' not found",
-				'tool_name' => $tool_name,
-			);
-		}
-
-		$method = $tool_def['method'] ?? null;
-		if ( ! $method || ! method_exists( $class_name, $method ) ) {
-			return array(
-				'success'   => false,
-				'error'     => sprintf(
-					"Tool '%s' definition is missing required 'method' key or method '%s' does not exist on class '%s'.",
-					$tool_name,
-					$method ?? '(none)',
-					$class_name
-				),
-				'tool_name' => $tool_name,
-			);
-		}
-
-		$tool_handler = new $class_name();
-		return $tool_handler->$method( $parameters, $tool_def );
 	}
 
 	/**
@@ -382,37 +228,4 @@ class ToolExecutor {
 		return array_diff_key( $parameters, $redact );
 	}
 
-	/**
-	 * Validate that all required parameters are present.
-	 *
-	 * @param  array $tool_parameters Parameters from AI
-	 * @param  array $tool_def        Tool definition with parameter specs
-	 * @return array Validation result with 'valid', 'required', and 'missing' keys
-	 */
-	private static function validateRequiredParameters( array $tool_parameters, array $tool_def ): array {
-		$required = array();
-		$missing  = array();
-
-		$param_defs = $tool_def['parameters'] ?? array();
-
-		foreach ( $param_defs as $param_name => $param_config ) {
-			if ( ! is_array( $param_config ) ) {
-				continue;
-			}
-
-			if ( ! empty( $param_config['required'] ) ) {
-				$required[] = $param_name;
-
-				if ( ! isset( $tool_parameters[ $param_name ] ) || '' === $tool_parameters[ $param_name ] ) {
-					$missing[] = $param_name;
-				}
-			}
-		}
-
-		return array(
-			'valid'    => empty( $missing ),
-			'required' => $required,
-			'missing'  => $missing,
-		);
-	}
 }

--- a/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
+++ b/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
@@ -7,6 +7,7 @@
 
 namespace DataMachine\Tests\Unit\AI\Tools;
 
+use DataMachine\Engine\AI\Tools\Execution\ToolExecutionCore;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
 use DataMachine\Engine\AI\Tools\ToolManager;
 use WP_UnitTestCase;
@@ -263,7 +264,7 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 	}
 
 	private function invokeValidateMethod( array $tool_parameters, array $tool_def ): array {
-		$reflection = new ReflectionClass( ToolExecutor::class );
+		$reflection = new ReflectionClass( ToolExecutionCore::class );
 		$method     = $reflection->getMethod( 'validateRequiredParameters' );
 		$method->setAccessible( true );
 

--- a/tests/tool-executor-ability-native-smoke.php
+++ b/tests/tool-executor-ability-native-smoke.php
@@ -17,7 +17,7 @@ namespace {
 			private string $message;
 
 			public function __construct( string $code = '', string $message = '' ) {
-				$this->message = $message;
+				$this->message = '' !== $message ? $message : $code;
 			}
 
 			public function get_error_message(): string {
@@ -34,6 +34,23 @@ namespace {
 
 	if ( ! function_exists( 'do_action' ) ) {
 		function do_action( ...$args ) {
+		}
+	}
+
+	if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+		function wp_strip_all_tags( string $text ): string {
+			return strip_tags( $text );
+		}
+	}
+
+	if ( ! function_exists( 'wp_trim_words' ) ) {
+		function wp_trim_words( string $text, int $num_words = 55, ?string $more = null ): string {
+			$words = preg_split( '/\s+/', trim( $text ) );
+			if ( ! is_array( $words ) || count( $words ) <= $num_words ) {
+				return $text;
+			}
+
+			return implode( ' ', array_slice( $words, 0, $num_words ) ) . ( $more ?? '...' );
 		}
 	}
 
@@ -100,10 +117,27 @@ namespace DataMachine\Engine\AI\Actions {
 			return $args['tool_def']['action_policy'] ?? self::POLICY_DIRECT;
 		}
 	}
+
+	class PendingActionHelper {
+		/** @var list<array<string, mixed>> */
+		public static array $staged = array();
+
+		public static function stage( array $args ): array {
+			self::$staged[] = $args;
+
+			return array(
+				'staged'    => true,
+				'action_id' => 'pending_1',
+				'kind'      => $args['kind'] ?? '',
+				'summary'   => $args['summary'] ?? '',
+			);
+		}
+	}
 }
 
 namespace DataMachine\Core\WordPress {
 	class PostTracking {
+		/** @var list<array<string, mixed>> */
 		public static array $stored = array();
 
 		public static function extractPostId( array $tool_result ): int {
@@ -118,9 +152,12 @@ namespace DataMachine\Core\WordPress {
 
 namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 	use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
+	use DataMachine\Engine\AI\Actions\PendingActionHelper;
+	use DataMachine\Engine\AI\Tools\Execution\ToolExecutionCore;
 	use DataMachine\Engine\AI\Tools\ToolExecutor;
 
 	require_once dirname( __DIR__ ) . '/inc/Engine/AI/Tools/ToolParameters.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/AI/Tools/Execution/ToolExecutionCore.php';
 	require_once dirname( __DIR__ ) . '/inc/Engine/AI/Tools/ToolExecutor.php';
 
 	$failed = 0;
@@ -136,6 +173,18 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 
 		echo "  FAIL: {$name}\n";
 		++$failed;
+	}
+
+	function post_tracking_count(): int {
+		return count( \DataMachine\Core\WordPress\PostTracking::$stored );
+	}
+
+	function first_pending_apply_job_id(): ?int {
+		return PendingActionHelper::$staged[0]['apply_input']['job_id'] ?? null;
+	}
+
+	function ability_execute_count( \Ability_Native_Smoke_Ability $ability ): int {
+		return $ability->execute_count;
 	}
 
 	class LegacyTool {
@@ -202,7 +251,64 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 	assert_smoke( 'ability execute callback ran exactly once', 1 === $ability->execute_count );
 	assert_smoke( 'AI parameter reached ability input', 'hello' === ( $result['received']['message'] ?? null ) );
 	assert_smoke( 'payload parameter reached ability input', 42 === ( $result['received']['job_id'] ?? null ) );
-	assert_smoke( 'successful ability result still participates in post tracking', 1 === count( \DataMachine\Core\WordPress\PostTracking::$stored ) );
+	assert_smoke( 'successful ability result still participates in post tracking', 1 === post_tracking_count() );
+
+	echo "\n[core:1] Generic execution core runs without Data Machine decorators\n";
+	\DataMachine\Core\WordPress\PostTracking::$stored = array();
+	$core_ability = new \Ability_Native_Smoke_Ability(
+		fn( $input ) => true,
+		fn( $input ) => 'scalar-ok'
+	);
+	$registry->register_for_smoke( 'datamachine/core-ability', $core_ability );
+	$core_result = ( new ToolExecutionCore() )->executeTool(
+		'core_ability_tool',
+		array( 'message' => 'core' ),
+		array(
+			'core_ability_tool' => array(
+				'ability'    => 'datamachine/core-ability',
+				'parameters' => array(
+					'message' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+			),
+		),
+		array( 'job_id' => 42 )
+	);
+	assert_smoke( 'core wraps scalar ability result with normalized envelope', true === ( $core_result['success'] ?? false ) && 'scalar-ok' === ( $core_result['result'] ?? null ) );
+	assert_smoke( 'core result includes ability slug', 'datamachine/core-ability' === ( $core_result['ability'] ?? null ) );
+	assert_smoke( 'core path does not perform post tracking decoration', 0 === post_tracking_count() );
+
+	echo "\n[decorator:1] ToolExecutor still stages pending actions before direct execution\n";
+	PendingActionHelper::$staged = array();
+	$preview_ability             = new \Ability_Native_Smoke_Ability(
+		fn( $input ) => true,
+		fn( $input ) => array(
+			'success' => true,
+			'post_id' => 456,
+		)
+	);
+	$registry->register_for_smoke( 'datamachine/preview-ability', $preview_ability );
+	$result = execute_tool(
+		'preview_tool',
+		array( 'message' => 'needs approval' ),
+		array(
+			'ability'       => 'datamachine/preview-ability',
+			'action_policy' => ActionPolicyResolver::POLICY_PREVIEW,
+			'action_kind'   => 'preview_kind',
+			'parameters'    => array(
+				'message' => array(
+					'type'     => 'string',
+					'required' => true,
+				),
+			),
+		)
+	);
+	assert_smoke( 'preview policy returns staged action result', true === ( $result['staged'] ?? false ) && 'pending_1' === ( $result['action_id'] ?? null ) );
+	assert_smoke( 'pending action helper received complete merged parameters', 42 === first_pending_apply_job_id() );
+	assert_smoke( 'preview policy does not execute ability directly', 0 === ability_execute_count( $preview_ability ) );
+	assert_smoke( 'preview policy does not post-track unexecuted action', 0 === post_tracking_count() );
 
 	echo "\n[legacy:1] Legacy class/method tool still executes\n";
 	LegacyTool::$calls = 0;
@@ -244,11 +350,9 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 		)
 	);
 	assert_smoke( 'permission-denied ability fails', false === ( $result['success'] ?? true ) );
-	assert_smoke( 'permission-denied ability execute callback did not run', 0 === $denied->execute_count );
+	assert_smoke( 'permission-denied ability execute callback did not run', 0 === ability_execute_count( $denied ) );
 	assert_smoke( 'permission-denied error names the ability slug', false !== strpos( $result['error'] ?? '', 'datamachine/denied-ability' ) );
 
 	echo "\nAssertions: " . ( $total - $failed ) . " passed, {$failed} failed, {$total} total\n";
-	if ( $failed > 0 ) {
-		exit( 1 );
-	}
+	exit( (int) $failed );
 }

--- a/tests/tool-executor-ability-native-smoke.php
+++ b/tests/tool-executor-ability-native-smoke.php
@@ -176,10 +176,12 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 	}
 
 	function post_tracking_count(): int {
+		// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 		return count( \DataMachine\Core\WordPress\PostTracking::$stored );
 	}
 
 	function first_pending_apply_job_id(): ?int {
+		// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 		return PendingActionHelper::$staged[0]['apply_input']['job_id'] ?? null;
 	}
 
@@ -254,6 +256,7 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 	assert_smoke( 'successful ability result still participates in post tracking', 1 === post_tracking_count() );
 
 	echo "\n[core:1] Generic execution core runs without Data Machine decorators\n";
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 	\DataMachine\Core\WordPress\PostTracking::$stored = array();
 	$core_ability = new \Ability_Native_Smoke_Ability(
 		fn( $input ) => true,
@@ -281,6 +284,7 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 	assert_smoke( 'core path does not perform post tracking decoration', 0 === post_tracking_count() );
 
 	echo "\n[decorator:1] ToolExecutor still stages pending actions before direct execution\n";
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 	PendingActionHelper::$staged = array();
 	$preview_ability             = new \Ability_Native_Smoke_Ability(
 		fn( $input ) => true,


### PR DESCRIPTION
## Summary
- Extracts `ToolExecutionCore` as the generic direct-execution path for tool lookup, required-parameter validation, parameter assembly, ability-native execution, legacy class/method execution, and result normalization.
- Leaves `ToolExecutor` as the Data Machine-facing orchestrator that still owns action policy resolution, PendingAction staging, and post-origin tracking.

## Behavior preserved
- Public tool result shapes are unchanged for missing tools, missing required params, ability-native tools, permission failures, WP_Error failures, scalar ability results, and legacy class/method tools.
- Preview policy still stages before direct execution and does not execute/post-track the underlying ability.
- Direct successful execution still passes through Data Machine post-origin tracking from `ToolExecutor`.
- Legacy class/method metadata still wins over linked ability metadata during the migration window.

## Tests
- `php tests/tool-executor-ability-native-smoke.php` — 19 assertions passing.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@untangle-tool-executor-decorators --file inc/Engine/AI/Tools/Execution/ToolExecutionCore.php --summary` — passed.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@untangle-tool-executor-decorators --file inc/Engine/AI/Tools/ToolExecutor.php --summary` — passed.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@untangle-tool-executor-decorators --file tests/Unit/AI/Tools/ToolExecutorValidationTest.php --summary` — passed.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@untangle-tool-executor-decorators --file tests/tool-executor-ability-native-smoke.php --summary` — passed.
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@untangle-tool-executor-decorators --changed-since origin/main` — passed; reported existing repository audit findings outside this PR.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@untangle-tool-executor-decorators --changed-since origin/main` — failed due known Homeboy extension routing PHP files into ESLint (`Parsing error: Unexpected token` on touched PHP files); direct file lint above passed.
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@untangle-tool-executor-decorators --changed-since origin/main` — failed due known broad PHPUnit routing; selected 128 files / ran 1209 tests and failed across unrelated settings/import/tool-policy fixtures.

Closes #1565

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the behavior-preserving refactor, updated focused smoke coverage, and ran validation commands. Chris remains responsible for review and merge.
