### PR TITLE
feat(bundle): materialize artifact directories

### DIFF
--- a/inc/Engine/Bundle/AgentBundleDirectory.php
+++ b/inc/Engine/Bundle/AgentBundleDirectory.php
@@ -9,6 +9,8 @@ namespace DataMachine\Engine\Bundle;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable WordPress.WP.AlternativeFunctions -- Bundle directories intentionally use local filesystem I/O.
+
 /**
  * Pure filesystem adapter for schema_version 1 agent bundle directories.
  */
@@ -21,24 +23,28 @@ final class AgentBundleDirectory {
 	private array $pipelines;
 	/** @var AgentBundleFlowFile[] */
 	private array $flows;
+	/** @var array<string,array<string,array|string>> */
+	private array $artifact_files;
 
 	/**
 	 * @param AgentBundleManifest       $manifest Bundle manifest.
 	 * @param array<string,string>      $memory_files Relative memory path => contents.
 	 * @param AgentBundlePipelineFile[] $pipelines Pipeline files.
 	 * @param AgentBundleFlowFile[]     $flows Flow files.
+	 * @param array<string,array<string,array|string>> $artifact_files Artifact directory => relative path => decoded JSON payload or text contents.
 	 */
-	public function __construct( AgentBundleManifest $manifest, array $memory_files, array $pipelines, array $flows ) {
-		$this->manifest     = $manifest;
-		$this->memory_files = self::normalize_memory_files( $memory_files );
-		$this->pipelines    = self::sort_documents_by_slug( $pipelines, AgentBundlePipelineFile::class );
-		$this->flows        = self::sort_documents_by_slug( $flows, AgentBundleFlowFile::class );
+	public function __construct( AgentBundleManifest $manifest, array $memory_files, array $pipelines, array $flows, array $artifact_files = array() ) {
+		$this->manifest       = $manifest;
+		$this->memory_files   = self::normalize_memory_files( $memory_files );
+		$this->pipelines      = self::sort_documents_by_slug( $pipelines, AgentBundlePipelineFile::class );
+		$this->flows          = self::sort_documents_by_slug( $flows, AgentBundleFlowFile::class );
+		$this->artifact_files = self::normalize_artifact_files( $artifact_files );
 	}
 
 	public static function read( string $directory ): self {
 		$directory = rtrim( $directory, '/\\' );
 		if ( ! is_dir( $directory ) ) {
-			throw new BundleValidationException( "Bundle directory does not exist: {$directory}" );
+			throw new BundleValidationException( sprintf( 'Bundle directory does not exist: %s', esc_html( $directory ) ) );
 		}
 
 		$manifest_path = $directory . '/' . BundleSchema::MANIFEST_FILE;
@@ -54,7 +60,8 @@ final class AgentBundleDirectory {
 			$manifest,
 			self::read_memory_files( $directory . '/' . BundleSchema::MEMORY_DIR ),
 			self::read_documents( $directory . '/' . BundleSchema::PIPELINES_DIR, AgentBundlePipelineFile::class ),
-			self::read_documents( $directory . '/' . BundleSchema::FLOWS_DIR, AgentBundleFlowFile::class )
+			self::read_documents( $directory . '/' . BundleSchema::FLOWS_DIR, AgentBundleFlowFile::class ),
+			self::read_artifact_directories( $directory )
 		);
 	}
 
@@ -64,6 +71,9 @@ final class AgentBundleDirectory {
 		self::ensure_directory( $directory . '/' . BundleSchema::MEMORY_DIR );
 		self::ensure_directory( $directory . '/' . BundleSchema::PIPELINES_DIR );
 		self::ensure_directory( $directory . '/' . BundleSchema::FLOWS_DIR );
+		foreach ( self::artifact_directories() as $artifact_directory ) {
+			self::ensure_directory( $directory . '/' . $artifact_directory );
+		}
 
 		file_put_contents( $directory . '/' . BundleSchema::MANIFEST_FILE, BundleSchema::encode_json( $this->manifest->to_array() ) );
 
@@ -79,6 +89,14 @@ final class AgentBundleDirectory {
 
 		foreach ( $this->flows as $flow ) {
 			file_put_contents( $directory . '/' . BundleSchema::FLOWS_DIR . '/' . $flow->slug() . '.json', BundleSchema::encode_json( $flow->to_array() ) );
+		}
+
+		foreach ( $this->artifact_files as $artifact_directory => $files ) {
+			foreach ( $files as $relative_path => $payload ) {
+				$path = $directory . '/' . $artifact_directory . '/' . $relative_path;
+				self::ensure_directory( dirname( $path ) );
+				file_put_contents( $path, is_array( $payload ) ? BundleSchema::encode_json( $payload ) : $payload );
+			}
 		}
 	}
 
@@ -101,12 +119,37 @@ final class AgentBundleDirectory {
 		return $this->flows;
 	}
 
+	/** @return array<string,array|string> */
+	public function prompts(): array {
+		return $this->artifact_files[ BundleSchema::PROMPTS_DIR ];
+	}
+
+	/** @return array<string,array|string> */
+	public function rubrics(): array {
+		return $this->artifact_files[ BundleSchema::RUBRICS_DIR ];
+	}
+
+	/** @return array<string,array|string> */
+	public function tool_policies(): array {
+		return $this->artifact_files[ BundleSchema::TOOL_POLICIES_DIR ];
+	}
+
+	/** @return array<string,array|string> */
+	public function auth_refs(): array {
+		return $this->artifact_files[ BundleSchema::AUTH_REFS_DIR ];
+	}
+
+	/** @return array<string,array|string> */
+	public function seed_queues(): array {
+		return $this->artifact_files[ BundleSchema::SEED_QUEUES_DIR ];
+	}
+
 	private static function ensure_directory( string $directory ): void {
 		if ( is_dir( $directory ) ) {
 			return;
 		}
 		if ( ! mkdir( $directory, 0775, true ) && ! is_dir( $directory ) ) {
-			throw new BundleValidationException( "Unable to create bundle directory: {$directory}" );
+			throw new BundleValidationException( sprintf( 'Unable to create bundle directory: %s', esc_html( $directory ) ) );
 		}
 	}
 
@@ -117,11 +160,35 @@ final class AgentBundleDirectory {
 			$relative_path = str_replace( '\\', '/', (string) $relative_path );
 			$relative_path = ltrim( $relative_path, '/' );
 			if ( str_contains( $relative_path, '..' ) || '' === $relative_path ) {
-				throw new BundleValidationException( "Invalid memory file path: {$relative_path}" );
+				throw new BundleValidationException( sprintf( 'Invalid memory file path: %s', esc_html( $relative_path ) ) );
 			}
 			$normalized[ $relative_path ] = (string) $contents;
 		}
 		ksort( $normalized, SORT_STRING );
+		return $normalized;
+	}
+
+	/** @return array<string,array<string,array|string>> */
+	private static function normalize_artifact_files( array $artifact_files ): array {
+		$normalized = array_fill_keys( self::artifact_directories(), array() );
+		foreach ( $artifact_files as $artifact_directory => $files ) {
+			$artifact_directory = (string) $artifact_directory;
+			if ( ! in_array( $artifact_directory, self::artifact_directories(), true ) ) {
+				throw new BundleValidationException( sprintf( 'Invalid artifact directory: %s', esc_html( $artifact_directory ) ) );
+			}
+			if ( ! is_array( $files ) ) {
+				throw new BundleValidationException( sprintf( 'Artifact directory %s must be an object.', esc_html( $artifact_directory ) ) );
+			}
+			foreach ( $files as $relative_path => $payload ) {
+				$relative_path = self::normalize_relative_path( (string) $relative_path, $artifact_directory );
+				if ( ! is_array( $payload ) ) {
+					$payload = (string) $payload;
+				}
+				$normalized[ $artifact_directory ][ $relative_path ] = $payload;
+			}
+			ksort( $normalized[ $artifact_directory ], SORT_STRING );
+		}
+
 		return $normalized;
 	}
 
@@ -137,38 +204,92 @@ final class AgentBundleDirectory {
 			if ( ! $file->isFile() ) {
 				continue;
 			}
-			$path             = $file->getPathname();
-			$relative         = str_replace( '\\', '/', substr( $path, strlen( $directory ) + 1 ) );
+			$path               = $file->getPathname();
+			$relative           = str_replace( '\\', '/', substr( $path, strlen( $directory ) + 1 ) );
 			$files[ $relative ] = (string) file_get_contents( $path );
 		}
 		ksort( $files, SORT_STRING );
 		return $files;
 	}
 
+	/** @return array<string,array<string,array|string>> */
+	private static function read_artifact_directories( string $directory ): array {
+		$artifact_files = array();
+		foreach ( self::artifact_directories() as $artifact_directory ) {
+			$artifact_files[ $artifact_directory ] = self::read_artifact_files( $directory . '/' . $artifact_directory );
+		}
+
+		return $artifact_files;
+	}
+
+	/** @return array<string,array|string> */
+	private static function read_artifact_files( string $directory ): array {
+		if ( ! is_dir( $directory ) ) {
+			return array();
+		}
+
+		$files    = array();
+		$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $directory, \FilesystemIterator::SKIP_DOTS ) );
+		foreach ( $iterator as $file ) {
+			if ( ! $file->isFile() ) {
+				continue;
+			}
+			$path               = $file->getPathname();
+			$relative           = str_replace( '\\', '/', substr( $path, strlen( $directory ) + 1 ) );
+			$contents           = (string) file_get_contents( $path );
+			$files[ $relative ] = str_ends_with( $relative, '.json' ) ? BundleSchema::decode_json( $contents, $relative ) : $contents;
+		}
+		ksort( $files, SORT_STRING );
+
+		return $files;
+	}
+
 	/** @return array */
-	private static function read_documents( string $directory, string $class ): array {
+	private static function read_documents( string $directory, string $document_class ): array {
 		if ( ! is_dir( $directory ) ) {
 			return array();
 		}
 
 		$documents = array();
-		$paths     = glob( $directory . '/*.json' ) ?: array();
+		$paths     = glob( $directory . '/*.json' );
+		$paths     = false === $paths ? array() : $paths;
 		sort( $paths, SORT_STRING );
 		foreach ( $paths as $path ) {
-			$documents[] = $class::from_array( BundleSchema::decode_json( (string) file_get_contents( $path ), basename( $path ) ) );
+			$documents[] = $document_class::from_array( BundleSchema::decode_json( (string) file_get_contents( $path ), basename( $path ) ) );
 		}
 
-		return self::sort_documents_by_slug( $documents, $class );
+		return self::sort_documents_by_slug( $documents, $document_class );
 	}
 
 	/** @return array */
-	private static function sort_documents_by_slug( array $documents, string $class ): array {
+	private static function sort_documents_by_slug( array $documents, string $document_class ): array {
 		foreach ( $documents as $document ) {
-			if ( ! $document instanceof $class ) {
-				throw new BundleValidationException( "Expected {$class} document." );
+			if ( ! $document instanceof $document_class ) {
+				throw new BundleValidationException( sprintf( 'Expected %s document.', esc_html( $document_class ) ) );
 			}
 		}
 		usort( $documents, fn( $a, $b ) => strcmp( $a->slug(), $b->slug() ) );
 		return $documents;
+	}
+
+	/** @return string[] */
+	private static function artifact_directories(): array {
+		return array(
+			BundleSchema::PROMPTS_DIR,
+			BundleSchema::RUBRICS_DIR,
+			BundleSchema::TOOL_POLICIES_DIR,
+			BundleSchema::AUTH_REFS_DIR,
+			BundleSchema::SEED_QUEUES_DIR,
+		);
+	}
+
+	private static function normalize_relative_path( string $relative_path, string $label ): string {
+		$relative_path = str_replace( '\\', '/', $relative_path );
+		$relative_path = ltrim( $relative_path, '/' );
+		if ( str_contains( $relative_path, '..' ) || '' === $relative_path ) {
+			throw new BundleValidationException( sprintf( 'Invalid %s file path: %s', esc_html( $label ), esc_html( $relative_path ) ) );
+		}
+
+		return $relative_path;
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
@@ -123,17 +123,42 @@ final class AgentBundleUpgradePlanner {
 			);
 		}
 
+		foreach ( self::materialized_artifact_directories() as $directory => $type ) {
+			$method = str_replace( '-', '_', $directory );
+			foreach ( $bundle->{$method}() as $relative_path => $payload ) {
+				$artifacts[] = array(
+					'artifact_type' => $type,
+					'artifact_id'   => self::artifact_id_from_relative_path( (string) $relative_path ),
+					'source_path'   => $directory . '/' . $relative_path,
+					'payload'       => $payload,
+				);
+			}
+		}
+
 		return $artifacts;
+	}
+
+	/** @return array<string,string> */
+	private static function materialized_artifact_directories(): array {
+		return array(
+			BundleSchema::PROMPTS_DIR       => 'prompt',
+			BundleSchema::RUBRICS_DIR       => 'rubric',
+			BundleSchema::TOOL_POLICIES_DIR => 'tool_policy',
+			BundleSchema::AUTH_REFS_DIR     => 'auth_ref',
+			BundleSchema::SEED_QUEUES_DIR   => 'seed_queue',
+		);
+	}
+
+	private static function artifact_id_from_relative_path( string $relative_path ): string {
+		$relative_path = preg_replace( '/\.(json|md|txt)$/i', '', $relative_path );
+		return null === $relative_path ? '' : $relative_path;
 	}
 
 	/** @param array<int,array<string,mixed>|AgentBundleInstalledArtifact> $artifacts */
 	private static function index_installed_artifacts( array $artifacts ): array {
 		$indexed = array();
 		foreach ( $artifacts as $artifact ) {
-			$row = $artifact instanceof AgentBundleInstalledArtifact ? $artifact->to_array() : $artifact;
-			if ( ! is_array( $row ) ) {
-				continue;
-			}
+			$row             = $artifact instanceof AgentBundleInstalledArtifact ? $artifact->to_array() : $artifact;
 			$key             = self::artifact_key( (string) ( $row['artifact_type'] ?? '' ), (string) ( $row['artifact_id'] ?? '' ) );
 			$indexed[ $key ] = $row;
 		}
@@ -146,9 +171,6 @@ final class AgentBundleUpgradePlanner {
 	private static function index_artifacts( array $artifacts ): array {
 		$indexed = array();
 		foreach ( $artifacts as $artifact ) {
-			if ( ! is_array( $artifact ) ) {
-				continue;
-			}
 			$key             = self::artifact_key( (string) ( $artifact['artifact_type'] ?? '' ), (string) ( $artifact['artifact_id'] ?? '' ) );
 			$indexed[ $key ] = $artifact;
 		}

--- a/tests/agent-bundle-format-smoke.php
+++ b/tests/agent-bundle-format-smoke.php
@@ -317,7 +317,14 @@ $bundle = new AgentBundleDirectory(
 		'daily/2026-04-26.md' => "# Daily\n",
 	),
 	array( $pipeline ),
-	array( $flow )
+	array( $flow ),
+	array(
+		BundleSchema::PROMPTS_DIR       => array( 'extract-facts.md' => "Extract facts.\n" ),
+		BundleSchema::RUBRICS_DIR       => array( 'wiki-quality.json' => array( 'min_score' => 4, 'slug' => 'wiki-quality' ) ),
+		BundleSchema::TOOL_POLICIES_DIR => array( 'read-only-context.json' => array( 'allow' => array( 'datamachine/search' ) ) ),
+		BundleSchema::AUTH_REFS_DIR     => array( 'github-default.json' => array( 'ref' => 'github:default', 'metadata' => array( 'account_id' => 42 ) ) ),
+		BundleSchema::SEED_QUEUES_DIR   => array( 'mgs-topic-loop.json' => array( 'mode' => 'loop', 'items' => array( 'launch history' ) ) ),
+	)
 );
 $tmp = sys_get_temp_dir() . '/datamachine-agent-bundle-' . getmypid();
 rm_tree( $tmp );
@@ -327,6 +334,11 @@ assert_bundle( 'manifest.json written', is_file( $tmp . '/manifest.json' ) );
 assert_bundle( 'memory/SOUL.md written as markdown file', is_file( $tmp . '/memory/SOUL.md' ) );
 assert_bundle( 'pipeline file named by portable slug', is_file( $tmp . '/pipelines/wc-daily-ingest.json' ) );
 assert_bundle( 'flow file named by portable slug', is_file( $tmp . '/flows/wc-daily-ingest-flow.json' ) );
+assert_bundle( 'prompt artifact written', is_file( $tmp . '/prompts/extract-facts.md' ) );
+assert_bundle( 'rubric artifact written', is_file( $tmp . '/rubrics/wiki-quality.json' ) );
+assert_bundle( 'tool policy artifact written', is_file( $tmp . '/tool-policies/read-only-context.json' ) );
+assert_bundle( 'auth ref artifact written', is_file( $tmp . '/auth-refs/github-default.json' ) );
+assert_bundle( 'seed queue artifact written', is_file( $tmp . '/seed-queues/mgs-topic-loop.json' ) );
 
 $read = AgentBundleDirectory::read( $tmp );
 assert_bundle_equals( 'read manifest preserves agent slug', 'woocommerce-agent', $read->manifest()->agent_slug() );
@@ -334,6 +346,18 @@ assert_bundle_equals( 'read memory files preserve nested daily file', "# Daily\n
 assert_bundle_equals( 'one pipeline read', 1, count( $read->pipelines() ) );
 assert_bundle_equals( 'one flow read', 1, count( $read->flows() ) );
 assert_bundle_equals( 'round-trip manifest array stable', $manifest->to_array(), $read->manifest()->to_array() );
+assert_bundle_equals( 'read prompt artifact keeps text payload', "Extract facts.\n", $read->prompts()['extract-facts.md'] ?? null );
+assert_bundle_equals( 'read rubric artifact decodes JSON payload', 4, $read->rubrics()['wiki-quality.json']['min_score'] ?? null );
+assert_bundle_equals( 'read tool policy artifact decodes JSON payload', array( 'datamachine/search' ), $read->tool_policies()['read-only-context.json']['allow'] ?? null );
+assert_bundle_equals( 'read auth ref artifact decodes JSON payload', 'github:default', $read->auth_refs()['github-default.json']['ref'] ?? null );
+assert_bundle_equals( 'read seed queue artifact decodes JSON payload', 'launch history', $read->seed_queues()['mgs-topic-loop.json']['items'][0] ?? null );
+
+$round_trip = sys_get_temp_dir() . '/datamachine-agent-bundle-round-trip-' . getmypid();
+rm_tree( $round_trip );
+$read->write( $round_trip );
+assert_bundle_equals( 'round-trip prompt contents preserved', "Extract facts.\n", file_get_contents( $round_trip . '/prompts/extract-facts.md' ) );
+assert_bundle_equals( 'round-trip auth ref JSON is deterministic', file_get_contents( $tmp . '/auth-refs/github-default.json' ), file_get_contents( $round_trip . '/auth-refs/github-default.json' ) );
+rm_tree( $round_trip );
 
 echo "\n[5] JSON output is stable and review-friendly\n";
 $encoded_manifest = file_get_contents( $tmp . '/manifest.json' );

--- a/tests/agent-bundle-upgrade-planner-smoke.php
+++ b/tests/agent-bundle-upgrade-planner-smoke.php
@@ -123,6 +123,7 @@ if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		private string $message;
 		public function __construct( string $code = '', string $message = '' ) {
+			unset( $code );
 			$this->message = $message;
 		}
 		public function get_error_message() {
@@ -136,8 +137,11 @@ require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleUpgradeActionHa
 
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
 use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
+use DataMachine\Engine\Bundle\BundleSchema;
 
 $failures = 0;
 $total    = 0;
@@ -221,7 +225,7 @@ echo "\n[2] Preview diff is artifact-level and secret-safe\n";
 $approval = $plan_array['needs_approval'][0] ?? array();
 assert_upgrade_plan( 'approval entry includes before payload', isset( $approval['diff']['before']['note'] ) );
 assert_upgrade_plan_equals( 'secret-like target keys are redacted', '[redacted]', $approval['diff']['after']['api_token'] ?? null );
-assert_upgrade_plan( 'raw secret value is absent from preview', false === strpos( json_encode( $plan_array ), 'secret-token-value' ) );
+assert_upgrade_plan( 'raw secret value is absent from preview', false === strpos( (string) json_encode( $plan_array ), 'secret-token-value' ) );
 
 echo "\n[3] PendingAction stages bundle-upgrade previews\n";
 $staged = AgentBundleUpgradePendingAction::stage(
@@ -261,7 +265,71 @@ assert_upgrade_plan_equals( 'only approved artifact writer ran', array( 'pipelin
 assert_upgrade_plan_equals( 'apply result records one applied artifact', 1, count( $resolved['result']['applied'] ?? array() ) );
 assert_upgrade_plan_equals( 'unapproved target artifacts are skipped', 3, count( $resolved['result']['skipped'] ?? array() ) );
 
+echo "\n[5] Directory artifacts materialize every advertised artifact type\n";
+$directory = new AgentBundleDirectory(
+	new AgentBundleManifest(
+		'2026-04-28T12:00:00Z',
+		'data-machine/test',
+		'Bundle Artifact Dirs',
+		'1.0.0',
+		'refs/heads/main',
+		'abc123',
+		array(
+			'slug'         => 'bundle-agent',
+			'label'        => 'Bundle Agent',
+			'description'  => 'Tests materialized bundle artifacts.',
+			'agent_config' => array(),
+		),
+		array(
+			'memory'        => array( 'MEMORY.md' ),
+			'pipelines'     => array(),
+			'flows'         => array(),
+			'prompts'       => array( 'extract-facts' ),
+			'rubrics'       => array( 'wiki-quality' ),
+			'tool_policies' => array( 'read-only-context' ),
+			'auth_refs'     => array( 'github-default' ),
+			'seed_queues'   => array( 'mgs-topic-loop' ),
+			'handler_auth'  => 'refs',
+		)
+	),
+	array( 'MEMORY.md' => "memory\n" ),
+	array(),
+	array(),
+	array(
+		BundleSchema::PROMPTS_DIR       => array( 'extract-facts.md' => "Extract facts.\n" ),
+		BundleSchema::RUBRICS_DIR       => array( 'wiki-quality.json' => array( 'threshold' => 4 ) ),
+		BundleSchema::TOOL_POLICIES_DIR => array( 'read-only-context.json' => array( 'allow' => array( 'datamachine/search' ) ) ),
+		BundleSchema::AUTH_REFS_DIR     => array(
+			'github-default.json' => array(
+				'ref'        => 'github:default',
+				'account_id' => 42,
+				'api_key'    => 'do-not-show',
+				'nested'     => array( 'refresh_token' => 'also-secret' ),
+			),
+		),
+		BundleSchema::SEED_QUEUES_DIR   => array( 'mgs-topic-loop.json' => array( 'items' => array( 'launch history' ) ) ),
+	)
+);
+$artifacts          = AgentBundleUpgradePlanner::artifacts_from_bundle( $directory );
+$artifacts_by_key   = array();
+foreach ( $artifacts as $artifact ) {
+	$artifacts_by_key[ $artifact['artifact_type'] . ':' . $artifact['artifact_id'] ] = $artifact;
+}
+assert_upgrade_plan( 'prompt artifact emitted from prompts directory', isset( $artifacts_by_key['prompt:extract-facts'] ) );
+assert_upgrade_plan( 'rubric artifact emitted from rubrics directory', isset( $artifacts_by_key['rubric:wiki-quality'] ) );
+assert_upgrade_plan( 'tool policy artifact emitted from tool-policies directory', isset( $artifacts_by_key['tool_policy:read-only-context'] ) );
+assert_upgrade_plan( 'auth ref artifact emitted from auth-refs directory', isset( $artifacts_by_key['auth_ref:github-default'] ) );
+assert_upgrade_plan( 'seed queue artifact emitted from seed-queues directory', isset( $artifacts_by_key['seed_queue:mgs-topic-loop'] ) );
+assert_upgrade_plan_equals( 'prompt source path is deterministic', 'prompts/extract-facts.md', $artifacts_by_key['prompt:extract-facts']['source_path'] ?? null );
+
+$auth_plan = AgentBundleUpgradePlanner::plan( array(), array(), array( $artifacts_by_key['auth_ref:github-default'] ) )->to_array();
+$auth_diff = $auth_plan['auto_apply'][0]['diff']['after'] ?? array();
+assert_upgrade_plan_equals( 'auth ref api_key is redacted in preview', '[redacted]', $auth_diff['api_key'] ?? null );
+assert_upgrade_plan_equals( 'auth ref nested refresh token is redacted in preview', '[redacted]', $auth_diff['nested']['refresh_token'] ?? null );
+assert_upgrade_plan( 'auth ref preview does not leak raw secret values', false === strpos( (string) json_encode( $auth_plan ), 'do-not-show' ) && false === strpos( (string) json_encode( $auth_plan ), 'also-secret' ) );
+
 echo "\nTotal assertions: {$total}\n";
+// @phpstan-ignore-next-line Smoke assertions mutate this counter through a global helper.
 if ( 0 !== $failures ) {
 	echo "Failures: {$failures}\n";
 	exit( 1 );


### PR DESCRIPTION
## Summary
- Materialize the advertised agent-bundle artifact directories in `AgentBundleDirectory` so prompt, rubric, tool-policy, auth-ref, and seed-queue files survive read/write round trips.
- Extend bundle upgrade planning so those directories emit artifact entries for preview/apply planning without adding runtime import/apply handlers.

## Changes
- Store generic artifact directory files as relative path to decoded JSON payload or text content.
- Preserve deterministic directory creation, file ordering, and JSON output for the advertised artifact directories.
- Add planner artifact extraction for prompt, rubric, tool_policy, auth_ref, and seed_queue artifacts.
- Extend smoke coverage for round-trip preservation, planner emission, and auth-ref secret redaction.

## Tests
- `php -l inc/Engine/Bundle/AgentBundleDirectory.php && php -l inc/Engine/Bundle/AgentBundleUpgradePlanner.php && php tests/agent-bundle-format-smoke.php && php tests/agent-bundle-upgrade-planner-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@bundle-artifact-dirs --changed-since origin/main`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@bundle-artifact-dirs --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@bundle-artifact-dirs --changed-since origin/main`

Closes #1576

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused implementation and smoke coverage; Chris remains responsible for review and merge.