### PR TITLE
feat(bundle): support plugin-defined artifact extensions

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -13,6 +13,7 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
+use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
 use DataMachine\Engine\Bundle\PortableSlug;
@@ -222,6 +223,7 @@ class AgentBundleCommand extends BaseCommand {
 				$plan,
 				array(
 					'bundle'           => $this->bundle_summary( $bundle, $slug ),
+					'agent'            => $agent ? $agent : array(),
 					'target_artifacts' => $this->bundle_artifacts( $bundle ),
 					'summary'          => 'Review locally modified bundle artifacts before applying.',
 					'agent_id'         => $agent ? (int) $agent['agent_id'] : 0,
@@ -355,6 +357,10 @@ class AgentBundleCommand extends BaseCommand {
 			);
 		}
 
+		foreach ( AgentBundleArtifactExtensions::normalize_artifacts( is_array( $bundle['extension_artifacts'] ?? null ) ? $bundle['extension_artifacts'] : array() ) as $artifact ) {
+			$artifacts[] = $artifact;
+		}
+
 		return $artifacts;
 	}
 
@@ -401,6 +407,15 @@ class AgentBundleCommand extends BaseCommand {
 				);
 			}
 		}
+
+		$artifacts = array_merge(
+			$artifacts,
+			AgentBundleArtifactExtensions::current_artifacts(
+				$agent,
+				$installed,
+				array( 'agent_id' => $agent_id )
+			)
+		);
 
 		return $artifacts;
 	}
@@ -534,8 +549,9 @@ class AgentBundleCommand extends BaseCommand {
 			return (int) $value;
 		}
 		$user = is_email( $value ) ? get_user_by( 'email', $value ) : get_user_by( 'login', $value );
-		if ( ! $user ) {
+		if ( ! $user instanceof \WP_User ) {
 			WP_CLI::error( sprintf( 'User "%s" not found.', (string) $value ) );
+			return 0;
 		}
 
 		return (int) $user->ID;

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -18,6 +18,7 @@ use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
 use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleFlowFile;
@@ -116,6 +117,7 @@ class AgentBundler {
 		$flows                     = $this->flows_repo->get_all_flows( null, $agent_id );
 		$pipeline_documents        = array();
 		$flow_documents            = array();
+		$extension_artifacts       = AgentBundleArtifactExtensions::export_artifacts( $agent, array( 'agent_id' => $agent_id ) );
 		$memory_files              = array();
 		$pipeline_slugs_by_id      = array();
 		$pipeline_step_types_by_id = array();
@@ -185,9 +187,10 @@ class AgentBundler {
 			}
 		}
 
-		$pipeline_slugs = array_map( fn( AgentBundlePipelineFile $pipeline ) => $pipeline->slug(), $pipeline_documents );
-		$flow_slugs     = array_map( fn( AgentBundleFlowFile $flow ) => $flow->slug(), $flow_documents );
-		$manifest       = new AgentBundleManifest(
+		$pipeline_slugs  = array_map( fn( AgentBundlePipelineFile $pipeline ) => $pipeline->slug(), $pipeline_documents );
+		$flow_slugs      = array_map( fn( AgentBundleFlowFile $flow ) => $flow->slug(), $flow_documents );
+		$extension_paths = array_map( static fn( array $artifact ) => (string) ( $artifact['source_path'] ?? '' ), $extension_artifacts );
+		$manifest        = new AgentBundleManifest(
 			gmdate( 'c' ),
 			defined( 'DATAMACHINE_VERSION' ) ? 'data-machine/' . DATAMACHINE_VERSION : 'data-machine/unknown',
 			sanitize_title( (string) $agent['agent_slug'] ),
@@ -204,6 +207,7 @@ class AgentBundler {
 				'memory'       => array_keys( $memory_files ),
 				'pipelines'    => $pipeline_slugs,
 				'flows'        => $flow_slugs,
+				'extensions'   => array_values( array_filter( $extension_paths ) ),
 				'handler_auth' => 'refs',
 			)
 		);
@@ -211,7 +215,7 @@ class AgentBundler {
 		return array(
 			'success'   => true,
 			'agent'     => $agent,
-			'directory' => new AgentBundleDirectory( $manifest, $memory_files, $pipeline_documents, $flow_documents ),
+			'directory' => new AgentBundleDirectory( $manifest, $memory_files, $pipeline_documents, $flow_documents, array(), $extension_artifacts ),
 		);
 	}
 
@@ -315,7 +319,7 @@ class AgentBundler {
 			? sanitize_title( $new_slug )
 			: sanitize_title( $agent_data['agent_slug'] );
 		$bundle_slug            = PortableSlug::normalize( (string) ( $bundle['bundle_slug'] ?? $slug ), 'bundle' );
-		$bundle_version         = trim( (string) ( $bundle['bundle_version'] ?? self::BUNDLE_VERSION ) );
+		$bundle_version         = trim( (string) $bundle['bundle_version'] );
 		$bundle_source_ref      = trim( (string) ( $bundle['source_ref'] ?? '' ) );
 		$bundle_source_revision = trim( (string) ( $bundle['source_revision'] ?? '' ) );
 		$bundle_metadata        = array(
@@ -360,16 +364,17 @@ class AgentBundler {
 
 		// Build summary for dry-run reporting.
 		$summary = array(
-			'agent_slug'        => $slug,
-			'agent_name'        => $agent_data['agent_name'],
-			'owner_id'          => $owner_id,
-			'bundle_slug'       => $bundle_slug,
-			'bundle_version'    => $bundle_version,
-			'files'             => count( $bundle['files'] ?? array() ),
-			'pipelines'         => count( $bundle['pipelines'] ?? array() ),
-			'flows'             => count( $bundle['flows'] ?? array() ),
-			'has_user_template' => ! empty( $bundle['user_template'] ),
-			'upgrade'           => (bool) $existing,
+			'agent_slug'          => $slug,
+			'agent_name'          => $agent_data['agent_name'],
+			'owner_id'            => $owner_id,
+			'bundle_slug'         => $bundle_slug,
+			'bundle_version'      => $bundle_version,
+			'files'               => count( $bundle['files'] ?? array() ),
+			'pipelines'           => count( $bundle['pipelines'] ?? array() ),
+			'flows'               => count( $bundle['flows'] ?? array() ),
+			'extension_artifacts' => count( $bundle['extension_artifacts'] ?? array() ),
+			'has_user_template'   => ! empty( $bundle['user_template'] ),
+			'upgrade'             => (bool) $existing,
 		);
 
 		if ( $dry_run ) {
@@ -438,7 +443,7 @@ class AgentBundler {
 			$this->write_user_template( $owner_id, $bundle['user_template'] );
 		}
 
-		$artifact_records = $config['datamachine_bundle']['artifacts'] ?? array();
+		$artifact_records = $config['datamachine_bundle']['artifacts'];
 		$conflicts        = array();
 
 		// 4. Import pipelines — build old→new ID map.
@@ -596,6 +601,66 @@ class AgentBundler {
 			}
 		}
 
+		// 6. Apply plugin-owned artifacts through their owning plugin.
+		$agent_context               = array_merge(
+			$agent_data,
+			array(
+				'agent_id'   => $agent_id,
+				'agent_slug' => $slug,
+				'agent_name' => $agent_data['agent_name'] ?? $slug,
+				'owner_id'   => $owner_id,
+			)
+		);
+		$current_extension_artifacts = self::index_artifacts(
+			AgentBundleArtifactExtensions::current_artifacts(
+				$agent_context,
+				array_values( $artifact_records ),
+				array( 'bundle' => $bundle_metadata )
+			)
+		);
+
+		foreach ( AgentBundleArtifactExtensions::normalize_artifacts( is_array( $bundle['extension_artifacts'] ?? null ) ? $bundle['extension_artifacts'] : array() ) as $artifact ) {
+			$artifact_key = self::artifact_key( (string) $artifact['artifact_type'], (string) $artifact['artifact_id'] );
+			$current      = $current_extension_artifacts[ $artifact_key ] ?? null;
+
+			if (
+				$current
+				&& $this->artifact_has_local_modifications(
+					$artifact_records[ $artifact_key ] ?? null,
+					$current['payload'] ?? null
+				)
+			) {
+				$conflicts[] = array(
+					'artifact_type' => $artifact['artifact_type'],
+					'artifact_id'   => $artifact['artifact_id'],
+					'reason'        => 'local_modified',
+				);
+				continue;
+			}
+
+			$result = AgentBundleArtifactExtensions::apply_artifact(
+				$artifact,
+				$agent_context,
+				array( 'bundle' => $bundle_metadata )
+			);
+			if ( null === $result || is_wp_error( $result ) ) {
+				$conflicts[] = array(
+					'artifact_type' => $artifact['artifact_type'],
+					'artifact_id'   => $artifact['artifact_id'],
+					'reason'        => is_wp_error( $result ) ? $result->get_error_message() : 'missing_apply_handler',
+				);
+				continue;
+			}
+
+			$artifact_records[ $artifact_key ] = $this->bundle_artifact_record(
+				$bundle_metadata,
+				(string) $artifact['artifact_type'],
+				(string) $artifact['artifact_id'],
+				(string) $artifact['source_path'],
+				$artifact['payload'] ?? null
+			);
+		}
+
 		$summary['agent_id']           = $agent_id;
 		$summary['pipelines_imported'] = count( $pipeline_id_map );
 		$summary['flows_imported']     = $flow_count;
@@ -628,6 +693,9 @@ class AgentBundler {
 				return true;
 			}
 		}
+		if ( ! empty( $bundle['extension_artifacts'] ) ) {
+			return true;
+		}
 		return false;
 	}
 
@@ -649,7 +717,7 @@ class AgentBundler {
 		);
 	}
 
-	private function artifact_has_local_modifications( ?array $record, array $current_payload ): bool {
+	private function artifact_has_local_modifications( ?array $record, mixed $current_payload ): bool {
 		if ( empty( $record['installed_hash'] ) ) {
 			return false;
 		}
@@ -660,7 +728,7 @@ class AgentBundler {
 		);
 	}
 
-	private function bundle_artifact_record( array $bundle_metadata, string $type, string $id, string $source_path, array $payload ): array {
+	private function bundle_artifact_record( array $bundle_metadata, string $type, string $id, string $source_path, mixed $payload ): array {
 		$hash = AgentBundleArtifactHasher::hash( $payload );
 		$now  = gmdate( 'c' );
 
@@ -676,6 +744,20 @@ class AgentBundler {
 			'installed_at'   => $now,
 			'updated_at'     => $now,
 		);
+	}
+
+	/** @param array<int,array<string,mixed>> $artifacts */
+	private static function index_artifacts( array $artifacts ): array {
+		$indexed = array();
+		foreach ( $artifacts as $artifact ) {
+			$indexed[ self::artifact_key( (string) ( $artifact['artifact_type'] ?? '' ), (string) ( $artifact['artifact_id'] ?? '' ) ) ] = $artifact;
+		}
+
+		return $indexed;
+	}
+
+	private static function artifact_key( string $type, string $id ): string {
+		return sanitize_key( $type ) . ':' . $id;
 	}
 
 	private function preserve_runtime_queue_fields( array $incoming_flow_config, array $existing_flow_config ): array {
@@ -725,7 +807,7 @@ class AgentBundler {
 		foreach ( $identity_files as $filename ) {
 			$path = $agent_dir . '/' . $filename;
 			if ( file_exists( $path ) ) {
-				$files[ $filename ] = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				$files[ $filename ] = $this->read_text_file( $path );
 			}
 		}
 		return $files;
@@ -742,7 +824,7 @@ class AgentBundler {
 		$path     = $user_dir . '/USER.md';
 
 		if ( file_exists( $path ) ) {
-			return file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			return $this->read_text_file( $path );
 		}
 
 		return '';
@@ -809,7 +891,7 @@ class AgentBundler {
 			}
 
 			$relative_path           = $prefix . $file->getFilename();
-			$files[ $relative_path ] = file_get_contents( $file->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$files[ $relative_path ] = $this->read_text_file( $file->getPathname() );
 		}
 
 		return $files;
@@ -1067,7 +1149,7 @@ class AgentBundler {
 			return null;
 		}
 
-		$manifest = json_decode( file_get_contents( $manifest_path ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$manifest = json_decode( $this->read_text_file( $manifest_path ), true );
 		if ( ! is_array( $manifest ) ) {
 			return null;
 		}
@@ -1084,13 +1166,13 @@ class AgentBundler {
 		// Read USER.md template.
 		$user_md_path            = $directory . '/USER.md';
 		$bundle['user_template'] = file_exists( $user_md_path )
-			? file_get_contents( $user_md_path ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			? $this->read_text_file( $user_md_path )
 			: '';
 
 		// Read pipeline memory files.
 		$pipelines_dir = $directory . '/pipelines';
 		if ( is_dir( $pipelines_dir ) ) {
-			$pipeline_dirs = glob( $pipelines_dir . '/*', GLOB_ONLYDIR );
+			$pipeline_dirs = $this->glob_directories( $pipelines_dir );
 			foreach ( $pipeline_dirs as $i => $pipeline_dir ) {
 				if ( isset( $bundle['pipelines'][ $i ] ) ) {
 					$bundle['pipelines'][ $i ]['memory_file_contents'] = $this->read_directory_recursive( $pipeline_dir );
@@ -1101,7 +1183,7 @@ class AgentBundler {
 		// Read flow memory files.
 		$flows_dir = $directory . '/flows';
 		if ( is_dir( $flows_dir ) ) {
-			$flow_dirs = glob( $flows_dir . '/*', GLOB_ONLYDIR );
+			$flow_dirs = $this->glob_directories( $flows_dir );
 			foreach ( $flow_dirs as $i => $flow_dir ) {
 				if ( isset( $bundle['flows'][ $i ] ) ) {
 					$bundle['flows'][ $i ]['memory_file_contents'] = $this->read_directory_recursive( $flow_dir );
@@ -1140,7 +1222,7 @@ class AgentBundler {
 			} elseif ( $item->isFile() ) {
 				$ext = strtolower( $item->getExtension() );
 				if ( in_array( $ext, array( 'md', 'txt', 'json', 'yaml', 'yml', 'csv' ), true ) ) {
-					$files[ $relative ] = file_get_contents( $item->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+					$files[ $relative ] = $this->read_text_file( $item->getPathname() );
 				}
 			}
 		}
@@ -1208,7 +1290,7 @@ class AgentBundler {
 			$bundle = $this->from_directory( $temp_dir );
 		} else {
 			// Look one level deep.
-			$subdirs = glob( $temp_dir . '/*', GLOB_ONLYDIR );
+			$subdirs = $this->glob_directories( $temp_dir );
 			foreach ( $subdirs as $subdir ) {
 				if ( file_exists( $subdir . '/manifest.json' ) ) {
 					$bundle = $this->from_directory( $subdir );
@@ -1219,6 +1301,28 @@ class AgentBundler {
 
 		$this->rm_rf( $temp_dir );
 		return $bundle;
+	}
+
+	/**
+	 * Read a text file as a string.
+	 *
+	 * @param string $path File path.
+	 * @return string File contents, or empty string when unreadable.
+	 */
+	private function read_text_file( string $path ): string {
+		$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		return is_string( $contents ) ? $contents : '';
+	}
+
+	/**
+	 * Return one-level child directories for a path.
+	 *
+	 * @param string $directory Directory path.
+	 * @return string[] Child directory paths.
+	 */
+	private function glob_directories( string $directory ): array {
+		$directories = glob( $directory . '/*', GLOB_ONLYDIR );
+		return is_array( $directories ) ? $directories : array();
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundleArtifactExtensions.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactExtensions.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Extension hooks for plugin-owned agent bundle artifacts.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes generic artifact envelopes exchanged with owning plugins.
+ */
+final class AgentBundleArtifactExtensions {
+
+	/**
+	 * Collect plugin-provided target artifacts for export.
+	 *
+	 * @param array<string,mixed> $agent Agent database row.
+	 * @param array<string,mixed> $context Export context.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function export_artifacts( array $agent, array $context = array() ): array {
+		/**
+		 * Let plugins contribute target artifacts to an agent bundle export.
+		 *
+		 * @param array<int,array<string,mixed>> $artifacts Artifact envelopes.
+		 * @param array<string,mixed>            $agent Agent database row.
+		 * @param array<string,mixed>            $context Export context.
+		 */
+		$artifacts = self::apply_filter( 'datamachine_agent_bundle_export_artifacts', array(), $agent, $context );
+
+		return self::normalize_artifacts( is_array( $artifacts ) ? $artifacts : array() );
+	}
+
+	/**
+	 * Collect plugin-reported current artifact state for drift planning.
+	 *
+	 * @param array<string,mixed> $agent Agent database row.
+	 * @param array<int,array<string,mixed>> $installed Installed artifact rows.
+	 * @param array<string,mixed> $context Planning context.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function current_artifacts( array $agent, array $installed = array(), array $context = array() ): array {
+		/**
+		 * Let plugins report local state for plugin-owned bundle artifacts.
+		 *
+		 * @param array<int,array<string,mixed>> $artifacts Artifact envelopes.
+		 * @param array<string,mixed>            $agent Agent database row.
+		 * @param array<string,mixed>            $context Planning context.
+		 */
+		$artifacts = self::apply_filter(
+			'datamachine_agent_bundle_current_artifacts',
+			array(),
+			$agent,
+			array_merge( $context, array( 'installed_artifacts' => $installed ) )
+		);
+
+		return self::normalize_artifacts( is_array( $artifacts ) ? $artifacts : array() );
+	}
+
+	/**
+	 * Route an artifact apply operation to the owning plugin.
+	 *
+	 * @param array<string,mixed> $artifact Target artifact envelope.
+	 * @param array<string,mixed> $agent Agent database row.
+	 * @param array<string,mixed> $context Apply context.
+	 * @return mixed|null
+	 */
+	public static function apply_artifact( array $artifact, array $agent = array(), array $context = array() ): mixed {
+		/**
+		 * Apply one plugin-owned bundle artifact.
+		 *
+		 * Return null to decline handling the artifact.
+		 *
+		 * @param mixed               $result Null until a plugin applies the artifact.
+		 * @param array<string,mixed> $artifact Target artifact envelope.
+		 * @param array<string,mixed> $agent Agent database row.
+		 * @param array<string,mixed> $context Apply context.
+		 */
+		return self::apply_filter( 'datamachine_agent_bundle_apply_artifact', null, $artifact, $agent, $context );
+	}
+
+	/**
+	 * Normalize artifact envelopes and reject unknown plugin artifact types.
+	 *
+	 * @param array<int,array<string,mixed>> $artifacts Raw artifact envelopes.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function normalize_artifacts( array $artifacts ): array {
+		$allowed    = BundleSchema::artifact_types();
+		$normalized = array();
+
+		foreach ( $artifacts as $artifact ) {
+			$type        = self::sanitize_key( (string) ( $artifact['artifact_type'] ?? '' ) );
+			$id          = trim( (string) ( $artifact['artifact_id'] ?? '' ) );
+			$source_path = self::source_path( (string) ( $artifact['source_path'] ?? '' ), $type, $id );
+			if ( '' === $type || '' === $id || ! in_array( $type, $allowed, true ) ) {
+				continue;
+			}
+
+			$normalized[] = array(
+				'artifact_type' => $type,
+				'artifact_id'   => $id,
+				'source_path'   => $source_path,
+				'payload'       => $artifact['payload'] ?? null,
+			);
+		}
+
+		usort(
+			$normalized,
+			static function ( array $a, array $b ): int {
+				$type_compare = strcmp( (string) $a['artifact_type'], (string) $b['artifact_type'] );
+				if ( 0 !== $type_compare ) {
+					return $type_compare;
+				}
+
+				return strcmp( (string) $a['artifact_id'], (string) $b['artifact_id'] );
+			}
+		);
+
+		return $normalized;
+	}
+
+	private static function source_path( string $source_path, string $type, string $id ): string {
+		$source_path = str_replace( '\\', '/', trim( $source_path ) );
+		$source_path = ltrim( $source_path, '/' );
+		if ( '' === $source_path ) {
+			$source_path = self::default_source_path( $type, $id );
+		}
+
+		if ( str_contains( $source_path, '..' ) || ! str_starts_with( $source_path, BundleSchema::EXTENSIONS_DIR . '/' ) || ! str_ends_with( $source_path, '.json' ) ) {
+			$source_path = self::default_source_path( $type, $id );
+		}
+
+		return $source_path;
+	}
+
+	private static function default_source_path( string $type, string $id ): string {
+		return BundleSchema::EXTENSIONS_DIR . '/' . $type . '/' . self::sanitize_path_id( $id ) . '.json';
+	}
+
+	private static function sanitize_key( string $key ): string {
+		if ( \function_exists( 'sanitize_key' ) ) {
+			return \sanitize_key( $key );
+		}
+
+		$sanitized = preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key );
+		return strtolower( is_string( $sanitized ) ? $sanitized : '' );
+	}
+
+	private static function sanitize_path_id( string $id ): string {
+		if ( \function_exists( 'sanitize_title' ) ) {
+			return \sanitize_title( $id );
+		}
+
+		$sanitized = preg_replace( '/[^a-zA-Z0-9]+/', '-', $id );
+		return trim( strtolower( is_string( $sanitized ) ? $sanitized : '' ), '-' );
+	}
+
+	private static function apply_filter( string $hook, mixed $value, mixed ...$args ): mixed {
+		if ( ! \function_exists( 'apply_filters' ) ) {
+			return $value;
+		}
+
+		return call_user_func_array( 'apply_filters', array_merge( array( $hook, $value ), $args ) );
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleDirectory.php
+++ b/inc/Engine/Bundle/AgentBundleDirectory.php
@@ -25,6 +25,8 @@ final class AgentBundleDirectory {
 	private array $flows;
 	/** @var array<string,array<string,array|string>> */
 	private array $artifact_files;
+	/** @var array<int,array<string,mixed>> */
+	private array $extension_artifacts;
 
 	/**
 	 * @param AgentBundleManifest       $manifest Bundle manifest.
@@ -32,13 +34,15 @@ final class AgentBundleDirectory {
 	 * @param AgentBundlePipelineFile[] $pipelines Pipeline files.
 	 * @param AgentBundleFlowFile[]     $flows Flow files.
 	 * @param array<string,array<string,array|string>> $artifact_files Artifact directory => relative path => decoded JSON payload or text contents.
+	 * @param array<int,array<string,mixed>> $extension_artifacts Plugin-owned artifact envelopes.
 	 */
-	public function __construct( AgentBundleManifest $manifest, array $memory_files, array $pipelines, array $flows, array $artifact_files = array() ) {
-		$this->manifest       = $manifest;
-		$this->memory_files   = self::normalize_memory_files( $memory_files );
-		$this->pipelines      = self::sort_documents_by_slug( $pipelines, AgentBundlePipelineFile::class );
-		$this->flows          = self::sort_documents_by_slug( $flows, AgentBundleFlowFile::class );
-		$this->artifact_files = self::normalize_artifact_files( $artifact_files );
+	public function __construct( AgentBundleManifest $manifest, array $memory_files, array $pipelines, array $flows, array $artifact_files = array(), array $extension_artifacts = array() ) {
+		$this->manifest            = $manifest;
+		$this->memory_files        = self::normalize_memory_files( $memory_files );
+		$this->pipelines           = self::sort_documents_by_slug( $pipelines, AgentBundlePipelineFile::class );
+		$this->flows               = self::sort_documents_by_slug( $flows, AgentBundleFlowFile::class );
+		$this->artifact_files      = self::normalize_artifact_files( $artifact_files );
+		$this->extension_artifacts = AgentBundleArtifactExtensions::normalize_artifacts( $extension_artifacts );
 	}
 
 	public static function read( string $directory ): self {
@@ -53,7 +57,7 @@ final class AgentBundleDirectory {
 		}
 
 		$manifest = AgentBundleManifest::from_array(
-			BundleSchema::decode_json( (string) file_get_contents( $manifest_path ), 'manifest.json' )
+			BundleSchema::decode_json( self::read_file( $manifest_path ), 'manifest.json' )
 		);
 
 		return new self(
@@ -61,7 +65,8 @@ final class AgentBundleDirectory {
 			self::read_memory_files( $directory . '/' . BundleSchema::MEMORY_DIR ),
 			self::read_documents( $directory . '/' . BundleSchema::PIPELINES_DIR, AgentBundlePipelineFile::class ),
 			self::read_documents( $directory . '/' . BundleSchema::FLOWS_DIR, AgentBundleFlowFile::class ),
-			self::read_artifact_directories( $directory )
+			self::read_artifact_directories( $directory ),
+			self::read_extension_artifacts( $directory . '/' . BundleSchema::EXTENSIONS_DIR )
 		);
 	}
 
@@ -74,29 +79,36 @@ final class AgentBundleDirectory {
 		foreach ( self::artifact_directories() as $artifact_directory ) {
 			self::ensure_directory( $directory . '/' . $artifact_directory );
 		}
+		self::ensure_directory( $directory . '/' . BundleSchema::EXTENSIONS_DIR );
 
-		file_put_contents( $directory . '/' . BundleSchema::MANIFEST_FILE, BundleSchema::encode_json( $this->manifest->to_array() ) );
+		self::write_file( $directory . '/' . BundleSchema::MANIFEST_FILE, BundleSchema::encode_json( $this->manifest->to_array() ) );
 
 		foreach ( $this->memory_files as $relative_path => $contents ) {
 			$path = $directory . '/' . BundleSchema::MEMORY_DIR . '/' . $relative_path;
 			self::ensure_directory( dirname( $path ) );
-			file_put_contents( $path, $contents );
+			self::write_file( $path, $contents );
 		}
 
 		foreach ( $this->pipelines as $pipeline ) {
-			file_put_contents( $directory . '/' . BundleSchema::PIPELINES_DIR . '/' . $pipeline->slug() . '.json', BundleSchema::encode_json( $pipeline->to_array() ) );
+			self::write_file( $directory . '/' . BundleSchema::PIPELINES_DIR . '/' . $pipeline->slug() . '.json', BundleSchema::encode_json( $pipeline->to_array() ) );
 		}
 
 		foreach ( $this->flows as $flow ) {
-			file_put_contents( $directory . '/' . BundleSchema::FLOWS_DIR . '/' . $flow->slug() . '.json', BundleSchema::encode_json( $flow->to_array() ) );
+			self::write_file( $directory . '/' . BundleSchema::FLOWS_DIR . '/' . $flow->slug() . '.json', BundleSchema::encode_json( $flow->to_array() ) );
 		}
 
 		foreach ( $this->artifact_files as $artifact_directory => $files ) {
 			foreach ( $files as $relative_path => $payload ) {
 				$path = $directory . '/' . $artifact_directory . '/' . $relative_path;
 				self::ensure_directory( dirname( $path ) );
-				file_put_contents( $path, is_array( $payload ) ? BundleSchema::encode_json( $payload ) : $payload );
+				self::write_file( $path, is_array( $payload ) ? BundleSchema::encode_json( $payload ) : $payload );
 			}
+		}
+
+		foreach ( $this->extension_artifacts as $artifact ) {
+			$path = $directory . '/' . $artifact['source_path'];
+			self::ensure_directory( dirname( $path ) );
+			self::write_file( $path, BundleSchema::encode_json( $artifact ) );
 		}
 	}
 
@@ -142,6 +154,11 @@ final class AgentBundleDirectory {
 	/** @return array<string,array|string> */
 	public function seed_queues(): array {
 		return $this->artifact_files[ BundleSchema::SEED_QUEUES_DIR ];
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function extension_artifacts(): array {
+		return $this->extension_artifacts;
 	}
 
 	private static function ensure_directory( string $directory ): void {
@@ -206,7 +223,7 @@ final class AgentBundleDirectory {
 			}
 			$path               = $file->getPathname();
 			$relative           = str_replace( '\\', '/', substr( $path, strlen( $directory ) + 1 ) );
-			$files[ $relative ] = (string) file_get_contents( $path );
+			$files[ $relative ] = self::read_file( $path );
 		}
 		ksort( $files, SORT_STRING );
 		return $files;
@@ -236,7 +253,7 @@ final class AgentBundleDirectory {
 			}
 			$path               = $file->getPathname();
 			$relative           = str_replace( '\\', '/', substr( $path, strlen( $directory ) + 1 ) );
-			$contents           = (string) file_get_contents( $path );
+			$contents           = self::read_file( $path );
 			$files[ $relative ] = str_ends_with( $relative, '.json' ) ? BundleSchema::decode_json( $contents, $relative ) : $contents;
 		}
 		ksort( $files, SORT_STRING );
@@ -252,13 +269,36 @@ final class AgentBundleDirectory {
 
 		$documents = array();
 		$paths     = glob( $directory . '/*.json' );
-		$paths     = false === $paths ? array() : $paths;
+		$paths     = is_array( $paths ) ? $paths : array();
 		sort( $paths, SORT_STRING );
 		foreach ( $paths as $path ) {
-			$documents[] = $document_class::from_array( BundleSchema::decode_json( (string) file_get_contents( $path ), basename( $path ) ) );
+			$documents[] = $document_class::from_array( BundleSchema::decode_json( self::read_file( $path ), basename( $path ) ) );
 		}
 
 		return self::sort_documents_by_slug( $documents, $document_class );
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function read_extension_artifacts( string $directory ): array {
+		if ( ! is_dir( $directory ) ) {
+			return array();
+		}
+
+		$artifacts = array();
+		$iterator  = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $directory, \FilesystemIterator::SKIP_DOTS ) );
+		foreach ( $iterator as $file ) {
+			if ( ! $file->isFile() || 'json' !== strtolower( $file->getExtension() ) ) {
+				continue;
+			}
+
+			$artifact = BundleSchema::decode_json( self::read_file( $file->getPathname() ), $file->getFilename() );
+			if ( ! isset( $artifact['source_path'] ) ) {
+				$artifact['source_path'] = BundleSchema::EXTENSIONS_DIR . '/' . str_replace( '\\', '/', substr( $file->getPathname(), strlen( $directory ) + 1 ) );
+			}
+			$artifacts[] = $artifact;
+		}
+
+		return AgentBundleArtifactExtensions::normalize_artifacts( $artifacts );
 	}
 
 	/** @return array */
@@ -291,5 +331,14 @@ final class AgentBundleDirectory {
 		}
 
 		return $relative_path;
+	}
+
+	private static function read_file( string $path ): string {
+		$contents = file_get_contents( $path );
+		return is_string( $contents ) ? $contents : '';
+	}
+
+	private static function write_file( string $path, string $contents ): void {
+		file_put_contents( $path, $contents );
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
@@ -120,8 +120,10 @@ final class AgentBundleInstalledArtifact {
 
 	private static function validate_artifact_type( string $type ): string {
 		$type = self::non_empty_string( $type, 'artifact_type' );
-		if ( ! in_array( $type, BundleSchema::ARTIFACT_TYPES, true ) ) {
-			throw new BundleValidationException( sprintf( 'installed bundle artifact_type must be one of: %s.', esc_html( implode( ', ', BundleSchema::ARTIFACT_TYPES ) ) ) );
+		$allowed = BundleSchema::artifact_types();
+		if ( ! in_array( $type, $allowed, true ) ) {
+			$allowed_label = \function_exists( 'esc_html' ) ? \esc_html( implode( ', ', $allowed ) ) : implode( ', ', $allowed );
+			throw new BundleValidationException( sprintf( 'installed bundle artifact_type must be one of: %s.', $allowed_label ) );
 		}
 
 		return $type;

--- a/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
@@ -119,11 +119,11 @@ final class AgentBundleInstalledArtifact {
 	}
 
 	private static function validate_artifact_type( string $type ): string {
-		$type = self::non_empty_string( $type, 'artifact_type' );
+		$type    = self::non_empty_string( $type, 'artifact_type' );
 		$allowed = BundleSchema::artifact_types();
 		if ( ! in_array( $type, $allowed, true ) ) {
-			$allowed_label = \function_exists( 'esc_html' ) ? \esc_html( implode( ', ', $allowed ) ) : implode( ', ', $allowed );
-			throw new BundleValidationException( sprintf( 'installed bundle artifact_type must be one of: %s.', $allowed_label ) );
+			$allowed_label = implode( ', ', $allowed );
+			throw new BundleValidationException( sprintf( 'installed bundle artifact_type must be one of: %s.', esc_html( $allowed_label ) ) );
 		}
 
 		return $type;

--- a/inc/Engine/Bundle/AgentBundleLegacyAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleLegacyAdapter.php
@@ -50,7 +50,9 @@ final class AgentBundleLegacyAdapter {
 			$manifest,
 			self::memory_files_from_legacy( $bundle, $pipeline_slugs, $flow_slugs ),
 			self::pipeline_files_from_legacy( $bundle['pipelines'] ?? array(), $pipeline_slugs ),
-			self::flow_files_from_legacy( $bundle['flows'] ?? array(), $bundle['pipelines'] ?? array(), $pipeline_slugs, $flow_slugs )
+			self::flow_files_from_legacy( $bundle['flows'] ?? array(), $bundle['pipelines'] ?? array(), $pipeline_slugs, $flow_slugs ),
+			array(),
+			is_array( $bundle['extension_artifacts'] ?? null ) ? $bundle['extension_artifacts'] : array()
 		);
 	}
 
@@ -143,6 +145,7 @@ final class AgentBundleLegacyAdapter {
 			'user_template'         => $memory_files['USER.md'] ?? '',
 			'pipelines'             => $pipelines,
 			'flows'                 => $flows,
+			'extension_artifacts'   => $directory->extension_artifacts(),
 			'abilities_manifest'    => array(),
 		);
 	}

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -150,7 +150,7 @@ final class AgentBundleManifest {
 			if ( ! is_array( $included[ $field ] ) || ! array_is_list( $included[ $field ] ) ) {
 				throw new BundleValidationException( sprintf( 'manifest.json included.%s must be a list.', esc_html( $field ) ) );
 			}
-			$included[ $field ] = array_values( array_map( 'strval', $included[ $field ] ) );
+			$included[ $field ] = array_map( 'strval', $included[ $field ] );
 			sort( $included[ $field ], SORT_STRING );
 		}
 

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -142,11 +142,11 @@ final class AgentBundleManifest {
 			}
 		}
 
-		foreach ( array( 'prompts', 'rubrics', 'tool_policies', 'auth_refs', 'seed_queues' ) as $field ) {
+		foreach ( array( 'prompts', 'rubrics', 'tool_policies', 'auth_refs', 'seed_queues', 'extensions' ) as $field ) {
 			$included[ $field ] = $included[ $field ] ?? array();
 		}
 
-		foreach ( array( 'memory', 'pipelines', 'flows', 'prompts', 'rubrics', 'tool_policies', 'auth_refs', 'seed_queues' ) as $field ) {
+		foreach ( array( 'memory', 'pipelines', 'flows', 'prompts', 'rubrics', 'tool_policies', 'auth_refs', 'seed_queues', 'extensions' ) as $field ) {
 			if ( ! is_array( $included[ $field ] ) || ! array_is_list( $included[ $field ] ) ) {
 				throw new BundleValidationException( sprintf( 'manifest.json included.%s must be a list.', esc_html( $field ) ) );
 			}
@@ -169,6 +169,7 @@ final class AgentBundleManifest {
 			'tool_policies' => $included['tool_policies'],
 			'auth_refs'     => $included['auth_refs'],
 			'seed_queues'   => $included['seed_queues'],
+			'extensions'    => $included['extensions'],
 			'handler_auth'  => $included['handler_auth'],
 		);
 	}

--- a/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
@@ -36,6 +36,7 @@ final class AgentBundleUpgradePendingAction {
 				'summary'      => (string) ( $args['summary'] ?? 'Review bundle upgrade artifacts.' ),
 				'apply_input'  => array(
 					'bundle'             => isset( $args['bundle'] ) && is_array( $args['bundle'] ) ? $args['bundle'] : array(),
+					'agent'              => isset( $args['agent'] ) && is_array( $args['agent'] ) ? $args['agent'] : array(),
 					'approved_artifacts' => $approved,
 					'target_artifacts'   => $target_artifacts,
 					'plan'               => $plan_array,
@@ -70,6 +71,7 @@ final class AgentBundleUpgradePendingAction {
 			: array();
 		$approved = array_fill_keys( $approved, true );
 		$targets  = isset( $apply_input['target_artifacts'] ) && is_array( $apply_input['target_artifacts'] ) ? $apply_input['target_artifacts'] : array();
+		$agent    = isset( $apply_input['agent'] ) && is_array( $apply_input['agent'] ) ? $apply_input['agent'] : array();
 		$applied  = array();
 		$skipped  = array();
 		$failed   = array();
@@ -94,7 +96,8 @@ final class AgentBundleUpgradePendingAction {
 			 * @param array $artifact Target artifact payload.
 			 * @param array $apply_input Full PendingAction input.
 			 */
-			$result = apply_filters( 'datamachine_bundle_upgrade_apply_artifact', null, $artifact, $apply_input );
+			$result = AgentBundleArtifactExtensions::apply_artifact( $artifact, $agent, $apply_input );
+			$result = apply_filters( 'datamachine_bundle_upgrade_apply_artifact', $result, $artifact, $apply_input );
 			if ( is_wp_error( $result ) ) {
 				$failed[] = array(
 					'artifact_key' => $key,

--- a/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
@@ -135,6 +135,10 @@ final class AgentBundleUpgradePlanner {
 			}
 		}
 
+		foreach ( $bundle->extension_artifacts() as $artifact ) {
+			$artifacts[] = $artifact;
+		}
+
 		return $artifacts;
 	}
 

--- a/inc/Engine/Bundle/BundleSchema.php
+++ b/inc/Engine/Bundle/BundleSchema.php
@@ -34,7 +34,9 @@ final class BundleSchema {
 
 	public const SEED_QUEUES_DIR = 'seed-queues';
 
-	public const ARTIFACT_TYPES = array(
+	public const EXTENSIONS_DIR = 'extensions';
+
+	public const CORE_ARTIFACT_TYPES = array(
 		'agent',
 		'memory',
 		'pipeline',
@@ -46,6 +48,60 @@ final class BundleSchema {
 		'seed_queue',
 		'schedule',
 	);
+
+	public const ARTIFACT_TYPES = self::CORE_ARTIFACT_TYPES;
+
+	/**
+	 * Return all artifact types known to the bundle runtime.
+	 *
+	 * Plugins register their own artifact types here while keeping semantics in
+	 * the owning plugin. Data Machine only hashes, diffs, and routes envelopes.
+	 *
+	 * @return string[]
+	 */
+	public static function artifact_types(): array {
+		$types = self::CORE_ARTIFACT_TYPES;
+
+		/**
+		 * Register plugin-owned agent bundle artifact types.
+		 *
+		 * @param string[] $types Known artifact type slugs.
+		 */
+		$types = self::apply_filter( 'datamachine_agent_bundle_artifact_types', $types );
+		if ( ! is_array( $types ) ) {
+			$types = self::CORE_ARTIFACT_TYPES;
+		}
+
+		$normalized = array();
+		foreach ( $types as $type ) {
+			$type = self::sanitize_key( (string) $type );
+			if ( '' !== $type ) {
+				$normalized[] = $type;
+			}
+		}
+
+		$normalized = array_values( array_unique( $normalized ) );
+		sort( $normalized, SORT_STRING );
+
+		return $normalized;
+	}
+
+	private static function apply_filter( string $hook, array $value ): mixed {
+		if ( ! \function_exists( 'apply_filters' ) ) {
+			return $value;
+		}
+
+		return call_user_func_array( 'apply_filters', array( $hook, $value ) );
+	}
+
+	private static function sanitize_key( string $key ): string {
+		if ( \function_exists( 'sanitize_key' ) ) {
+			return \sanitize_key( $key );
+		}
+
+		$sanitized = preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key );
+		return strtolower( is_string( $sanitized ) ? $sanitized : '' );
+	}
 
 	/**
 	 * Encode bundle JSON in a stable, review-friendly shape.
@@ -72,7 +128,7 @@ final class BundleSchema {
 	public static function decode_json( string $json, string $label ): array {
 		$data = json_decode( $json, true );
 		if ( ! is_array( $data ) ) {
-			throw new BundleValidationException( sprintf( '%s is not valid JSON.', $label ) );
+			throw new BundleValidationException( sprintf( '%s is not valid JSON.', esc_html( $label ) ) );
 		}
 
 		return $data;
@@ -85,10 +141,11 @@ final class BundleSchema {
 	 * @param string $label Human-readable document label.
 	 */
 	public static function assert_supported_version( array $data, string $label ): void {
-		$version = (int) ( $data['schema_version'] ?? 0 );
+		$version           = (int) ( $data['schema_version'] ?? 0 );
+		$supported_version = self::VERSION;
 		if ( self::VERSION !== $version ) {
 			throw new BundleValidationException(
-				sprintf( '%s uses unsupported schema_version %d; this Data Machine build supports schema_version %d.', $label, $version, self::VERSION )
+				sprintf( '%s uses unsupported schema_version %s; this Data Machine build supports schema_version %s.', esc_html( $label ), esc_html( (string) $version ), esc_html( (string) $supported_version ) )
 			);
 		}
 	}

--- a/tests/agent-bundle-extension-artifacts-smoke.php
+++ b/tests/agent-bundle-extension-artifacts-smoke.php
@@ -233,7 +233,7 @@ $manifest = new AgentBundleManifest(
 		'handler_auth' => 'refs',
 	)
 );
-$directory = new AgentBundleDirectory( $manifest, array(), array(), array(), $export_artifacts );
+$directory = new AgentBundleDirectory( $manifest, array(), array(), array(), array(), $export_artifacts );
 $tmp       = sys_get_temp_dir() . '/datamachine-extension-bundle-' . getmypid();
 extension_rm_tree( $tmp );
 $directory->write( $tmp );

--- a/tests/agent-bundle-extension-artifacts-smoke.php
+++ b/tests/agent-bundle-extension-artifacts-smoke.php
@@ -132,6 +132,11 @@ function extension_rm_tree( string $dir ): void {
 	rmdir( $dir );
 }
 
+function extension_json_encode( array $value ): string {
+	$encoded = json_encode( $value );
+	return is_string( $encoded ) ? $encoded : '';
+}
+
 add_filter(
 	'datamachine_agent_bundle_artifact_types',
 	static function ( array $types ): array {
@@ -199,7 +204,7 @@ assert_extension_bundle_equals( 'export hook saw agent slug', 'bundle-agent', $e
 assert_extension_bundle_equals( 'unknown artifact types are ignored', 1, count( $export_artifacts ) );
 assert_extension_bundle_equals( 'export artifact payload preserved', 'Seed', $export_artifacts[0]['payload']['label'] ?? null );
 
-$current_artifacts = AgentBundleArtifactExtensions::current_artifacts( $agent, array( 'installed-row' ), array( 'phase' => 'plan' ) );
+$current_artifacts = AgentBundleArtifactExtensions::current_artifacts( $agent, array( array( 'artifact_id' => 'installed-row' ) ), array( 'phase' => 'plan' ) );
 assert_extension_bundle_equals( 'current hook returns fake artifact', 'fake_plugin_artifact', $current_artifacts[0]['artifact_type'] ?? null );
 
 echo "\n[2] Directory bundles persist plugin artifacts under extensions/\n";
@@ -240,12 +245,12 @@ $current_payload = $export_artifacts[0]['payload'];
 $clean_plan      = AgentBundleUpgradePlanner::plan( array( $installed ), AgentBundleArtifactExtensions::current_artifacts( $agent, array( $installed->to_array() ) ), array( $target_artifact ) )->to_array();
 assert_extension_bundle_equals( 'clean installed plugin artifact auto-applies', 'fake_plugin_artifact:seed', $clean_plan['auto_apply'][0]['artifact_key'] ?? null );
 assert_extension_bundle_equals( 'secret-like plugin target keys are redacted', '[redacted]', $clean_plan['auto_apply'][0]['diff']['after']['api_token'] ?? null );
-assert_extension_bundle( 'raw plugin secret is absent from plan', false === strpos( json_encode( $clean_plan ), 'target-secret-token' ) );
+assert_extension_bundle( 'raw plugin secret is absent from plan', false === strpos( extension_json_encode( $clean_plan ), 'target-secret-token' ) );
 
 $current_payload = array( 'label' => 'Locally edited', 'api_token' => 'local-secret-token' );
 $modified_plan   = AgentBundleUpgradePlanner::plan( array( $installed ), AgentBundleArtifactExtensions::current_artifacts( $agent, array( $installed->to_array() ) ), array( $target_artifact ) )->to_array();
 assert_extension_bundle_equals( 'locally modified plugin artifact needs approval', 'fake_plugin_artifact:seed', $modified_plan['needs_approval'][0]['artifact_key'] ?? null );
-assert_extension_bundle( 'raw local plugin secret is absent from plan', false === strpos( json_encode( $modified_plan ), 'local-secret-token' ) );
+assert_extension_bundle( 'raw local plugin secret is absent from plan', false === strpos( extension_json_encode( $modified_plan ), 'local-secret-token' ) );
 
 echo "\n[4] PendingAction apply routes approved plugin artifacts to plugin callback\n";
 $apply_result = AgentBundleUpgradePendingAction::apply(
@@ -262,7 +267,7 @@ assert_extension_bundle_equals( 'unapproved plugin artifact is staged/skipped', 
 extension_rm_tree( $tmp );
 
 echo "\nTotal assertions: {$total}\n";
-if ( 0 !== $failures ) {
+if ( 0 !== (int) $GLOBALS['failures'] ) {
 	echo "Failures: {$failures}\n";
 	exit( 1 );
 }

--- a/tests/agent-bundle-extension-artifacts-smoke.php
+++ b/tests/agent-bundle-extension-artifacts-smoke.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Pure-PHP smoke test for plugin-defined agent bundle artifacts (#1577).
+ *
+ * Run with: php tests/agent-bundle-extension-artifacts-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['__bundle_extension_filters'] = array();
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $key ) );
+	}
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		$title = strtolower( preg_replace( '/[^a-zA-Z0-9]+/', '-', (string) $title ) );
+		return trim( $title, '-' );
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error;
+	}
+}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $message;
+		public function __construct( string $code = '', string $message = '' ) {
+			unset( $code );
+			$this->message = $message;
+		}
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['__bundle_extension_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+		ksort( $GLOBALS['__bundle_extension_filters'][ $hook ], SORT_NUMERIC );
+		return true;
+	}
+}
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook = '' ) {
+		unset( $hook );
+		return 0;
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		return add_filter( $hook, $callback, $priority, $accepted_args );
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['__bundle_extension_filters'][ $hook ] ) ) {
+			return $value;
+		}
+		foreach ( $GLOBALS['__bundle_extension_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as $registration ) {
+				$value = call_user_func_array( $registration[0], array_slice( array_merge( array( $value ), $args ), 0, $registration[1] ) );
+			}
+		}
+		return $value;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
+use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
+use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
+use DataMachine\Engine\Bundle\AgentBundleLegacyAdapter;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
+use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
+
+$failures = 0;
+$total    = 0;
+
+function assert_extension_bundle( string $label, bool $condition ): void {
+	global $failures, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	echo "  FAIL: {$label}\n";
+	++$failures;
+}
+
+function assert_extension_bundle_equals( string $label, $expected, $actual ): void {
+	assert_extension_bundle( $label, $expected === $actual );
+}
+
+function extension_artifact( string $id, array $payload, string $source_path = '' ): array {
+	return array(
+		'artifact_type' => 'fake_plugin_artifact',
+		'artifact_id'   => $id,
+		'source_path'   => $source_path ?: 'extensions/fake-plugin/' . $id . '.json',
+		'payload'       => $payload,
+	);
+}
+
+function extension_rm_tree( string $dir ): void {
+	if ( ! is_dir( $dir ) ) {
+		return;
+	}
+	$iterator = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $dir, FilesystemIterator::SKIP_DOTS ), RecursiveIteratorIterator::CHILD_FIRST );
+	foreach ( $iterator as $file ) {
+		$file->isDir() ? rmdir( $file->getPathname() ) : unlink( $file->getPathname() );
+	}
+	rmdir( $dir );
+}
+
+add_filter(
+	'datamachine_agent_bundle_artifact_types',
+	static function ( array $types ): array {
+		$types[] = 'fake_plugin_artifact';
+		return $types;
+	},
+	10,
+	1
+);
+
+$export_context = array();
+add_filter(
+	'datamachine_agent_bundle_export_artifacts',
+	static function ( array $artifacts, array $agent, array $context ) use ( &$export_context ): array {
+		$export_context = array( 'agent_slug' => $agent['agent_slug'] ?? '', 'context' => $context );
+		$artifacts[]    = extension_artifact( 'seed', array( 'label' => 'Seed', 'api_token' => 'secret-export-token' ) );
+		$artifacts[]    = array(
+			'artifact_type' => 'unknown_plugin_artifact',
+			'artifact_id'   => 'ignored',
+			'payload'       => array( 'ignored' => true ),
+		);
+		return $artifacts;
+	},
+	10,
+	3
+);
+
+$current_payload = array( 'label' => 'Seed', 'api_token' => 'secret-export-token' );
+add_filter(
+	'datamachine_agent_bundle_current_artifacts',
+	static function ( array $artifacts, array $agent, array $context ) use ( &$current_payload ): array {
+		unset( $agent );
+		assert_extension_bundle( 'current hook receives installed artifacts context', isset( $context['installed_artifacts'] ) );
+		$artifacts[] = extension_artifact( 'seed', $current_payload );
+		return $artifacts;
+	},
+	10,
+	3
+);
+
+$applied = array();
+add_filter(
+	'datamachine_agent_bundle_apply_artifact',
+	static function ( $result, array $artifact, array $agent, array $context ) use ( &$applied ) {
+		unset( $context );
+		if ( 'fake_plugin_artifact' !== ( $artifact['artifact_type'] ?? '' ) ) {
+			return $result;
+		}
+		$applied[] = array( 'id' => $artifact['artifact_id'], 'agent' => $agent['agent_slug'] ?? '' );
+		return array( 'applied' => $artifact['artifact_id'] );
+	},
+	10,
+	4
+);
+
+echo "=== Agent Bundle Extension Artifact Smoke (#1577) ===\n";
+
+echo "\n[1] Plugins register artifact types and export/current artifacts\n";
+$types = DataMachine\Engine\Bundle\BundleSchema::artifact_types();
+assert_extension_bundle( 'fake plugin type is registered', in_array( 'fake_plugin_artifact', $types, true ) );
+
+$agent            = array( 'agent_id' => 7, 'agent_slug' => 'bundle-agent' );
+$export_artifacts = AgentBundleArtifactExtensions::export_artifacts( $agent, array( 'phase' => 'export' ) );
+assert_extension_bundle_equals( 'export hook saw agent slug', 'bundle-agent', $export_context['agent_slug'] ?? null );
+assert_extension_bundle_equals( 'unknown artifact types are ignored', 1, count( $export_artifacts ) );
+assert_extension_bundle_equals( 'export artifact payload preserved', 'Seed', $export_artifacts[0]['payload']['label'] ?? null );
+
+$current_artifacts = AgentBundleArtifactExtensions::current_artifacts( $agent, array( 'installed-row' ), array( 'phase' => 'plan' ) );
+assert_extension_bundle_equals( 'current hook returns fake artifact', 'fake_plugin_artifact', $current_artifacts[0]['artifact_type'] ?? null );
+
+echo "\n[2] Directory bundles persist plugin artifacts under extensions/\n";
+$manifest = new AgentBundleManifest(
+	'2026-04-28T00:00:00Z',
+	'data-machine/test',
+	'Fake Bundle',
+	'1.0.0',
+	'',
+	'',
+	array(
+		'slug'         => 'bundle-agent',
+		'label'        => 'Bundle Agent',
+		'description'  => '',
+		'agent_config' => array(),
+	),
+	array(
+		'memory'       => array(),
+		'pipelines'    => array(),
+		'flows'        => array(),
+		'extensions'   => array( 'extensions/fake-plugin/seed.json' ),
+		'handler_auth' => 'refs',
+	)
+);
+$directory = new AgentBundleDirectory( $manifest, array(), array(), array(), $export_artifacts );
+$tmp       = sys_get_temp_dir() . '/datamachine-extension-bundle-' . getmypid();
+extension_rm_tree( $tmp );
+$directory->write( $tmp );
+assert_extension_bundle( 'extension artifact file written', is_file( $tmp . '/extensions/fake-plugin/seed.json' ) );
+$read = AgentBundleDirectory::read( $tmp );
+assert_extension_bundle_equals( 'extension artifact read from directory', 'seed', $read->extension_artifacts()[0]['artifact_id'] ?? null );
+assert_extension_bundle_equals( 'legacy adapter preserves extension artifacts', 'seed', AgentBundleLegacyAdapter::to_legacy_bundle( $read )['extension_artifacts'][0]['artifact_id'] ?? null );
+
+echo "\n[3] Planner treats plugin artifacts like core artifacts and redacts secrets\n";
+$target_artifact = extension_artifact( 'seed', array( 'label' => 'Target', 'api_token' => 'target-secret-token' ) );
+$installed       = AgentBundleInstalledArtifact::from_installed_payload( $manifest, 'fake_plugin_artifact', 'seed', 'extensions/fake-plugin/seed.json', $export_artifacts[0]['payload'], '2026-04-28T00:00:00Z' );
+$current_payload = $export_artifacts[0]['payload'];
+$clean_plan      = AgentBundleUpgradePlanner::plan( array( $installed ), AgentBundleArtifactExtensions::current_artifacts( $agent, array( $installed->to_array() ) ), array( $target_artifact ) )->to_array();
+assert_extension_bundle_equals( 'clean installed plugin artifact auto-applies', 'fake_plugin_artifact:seed', $clean_plan['auto_apply'][0]['artifact_key'] ?? null );
+assert_extension_bundle_equals( 'secret-like plugin target keys are redacted', '[redacted]', $clean_plan['auto_apply'][0]['diff']['after']['api_token'] ?? null );
+assert_extension_bundle( 'raw plugin secret is absent from plan', false === strpos( json_encode( $clean_plan ), 'target-secret-token' ) );
+
+$current_payload = array( 'label' => 'Locally edited', 'api_token' => 'local-secret-token' );
+$modified_plan   = AgentBundleUpgradePlanner::plan( array( $installed ), AgentBundleArtifactExtensions::current_artifacts( $agent, array( $installed->to_array() ) ), array( $target_artifact ) )->to_array();
+assert_extension_bundle_equals( 'locally modified plugin artifact needs approval', 'fake_plugin_artifact:seed', $modified_plan['needs_approval'][0]['artifact_key'] ?? null );
+assert_extension_bundle( 'raw local plugin secret is absent from plan', false === strpos( json_encode( $modified_plan ), 'local-secret-token' ) );
+
+echo "\n[4] PendingAction apply routes approved plugin artifacts to plugin callback\n";
+$apply_result = AgentBundleUpgradePendingAction::apply(
+	array(
+		'agent'              => $agent,
+		'approved_artifacts' => array( 'fake_plugin_artifact:seed' ),
+		'target_artifacts'   => array( $target_artifact, extension_artifact( 'unapproved', array( 'label' => 'Skip' ) ) ),
+	)
+);
+assert_extension_bundle( 'apply succeeds through plugin callback', true === ( $apply_result['success'] ?? false ) );
+assert_extension_bundle_equals( 'plugin callback received approved artifact', array( array( 'id' => 'seed', 'agent' => 'bundle-agent' ) ), $applied );
+assert_extension_bundle_equals( 'unapproved plugin artifact is staged/skipped', 1, count( $apply_result['skipped'] ?? array() ) );
+
+extension_rm_tree( $tmp );
+
+echo "\nTotal assertions: {$total}\n";
+if ( 0 !== $failures ) {
+	echo "Failures: {$failures}\n";
+	exit( 1 );
+}
+
+echo "All assertions passed.\n";

--- a/tests/agent-bundle-extension-artifacts-smoke.php
+++ b/tests/agent-bundle-extension-artifacts-smoke.php
@@ -11,6 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 }
 
+if ( class_exists( 'PHPUnit\\Framework\\TestCase', false ) ) {
+	return;
+}
+
 $GLOBALS['__bundle_extension_filters'] = array();
 
 if ( ! function_exists( 'wp_json_encode' ) ) {


### PR DESCRIPTION
## Summary
- Adds generic extension points for plugin-owned agent bundle artifacts so downstream plugins can export, diff, stage, and apply their own bundle files without Data Machine knowing their semantics.
- Persists plugin artifacts under `extensions/`, includes them in manifest metadata, and routes import / PendingAction apply through owner callbacks.

## Changes
- Adds `AgentBundleArtifactExtensions` for type registration, export/current/apply callbacks, normalization, and source-path validation.
- Extends bundle schema, directory read/write, legacy adapter, installed-artifact validation, planner, CLI drift planning, and PendingAction apply to include registered plugin artifact types.
- Adds a fake-plugin smoke test proving registration, directory round-trip, planner classification, safe redaction, and approved-only apply routing.

## Tests
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@bundle-plugin-artifacts --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@bundle-plugin-artifacts --changed-since origin/main`
- `php tests/agent-bundle-extension-artifacts-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/agent-bundle-upgrade-planner-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php tests/agent-bundle-installed-artifact-smoke.php`
- `php tests/agent-bundle-portable-update-smoke.php`

`homeboy test data-machine --path /Users/chubes/Developer/data-machine@bundle-plugin-artifacts --changed-since origin/main` selected a broad PHPUnit set and failed in existing test-harness/plugin-registration areas unrelated to this diff; the focused bundle smokes above pass.

Closes #1577

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris reviewed and owns the final change.
