### PR TITLE
fix(migrations): skip deferred migrations during install

### DIFF
--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -158,7 +158,7 @@ function datamachine_run_schema_migrations(): void {
  * @return void
  */
 function datamachine_maybe_run_deferred_migrations(): void {
-	if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
+	if ( function_exists( 'wp_installing' ) && wp_installing() ) {
 		return;
 	}
 

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -158,6 +158,10 @@ function datamachine_run_schema_migrations(): void {
  * @return void
  */
 function datamachine_maybe_run_deferred_migrations(): void {
+	if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
+		return;
+	}
+
 	// Cheap path: option matches code. Most requests on a stable install.
 	$persisted = get_option( 'datamachine_db_version', '' );
 	if ( DATAMACHINE_VERSION === $persisted ) {

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -286,22 +286,6 @@ assert_runtime(
 	DATAMACHINE_VERSION === $GLOBALS['__test_options']['datamachine_db_version']
 );
 
-echo "\n[deferred:6] WP_INSTALLING short-circuits before option access\n";
-$GLOBALS['__test_migration_calls'] = array();
-unset( $GLOBALS['__test_options']['datamachine_db_version'] );
-if ( ! defined( 'WP_INSTALLING' ) ) {
-	define( 'WP_INSTALLING', true );
-}
-datamachine_maybe_run_deferred_migrations();
-assert_runtime(
-	'no migrations called while WordPress is installing',
-	0 === count( $GLOBALS['__test_migration_calls'] )
-);
-assert_runtime(
-	'db_version option not created while WordPress is installing',
-	! isset( $GLOBALS['__test_options']['datamachine_db_version'] )
-);
-
 // ---------------------------------------------------------------
 // SECTION 3: hook registration shape.
 // ---------------------------------------------------------------

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -286,6 +286,22 @@ assert_runtime(
 	DATAMACHINE_VERSION === $GLOBALS['__test_options']['datamachine_db_version']
 );
 
+echo "\n[deferred:6] WP_INSTALLING short-circuits before option access\n";
+$GLOBALS['__test_migration_calls'] = array();
+unset( $GLOBALS['__test_options']['datamachine_db_version'] );
+if ( ! defined( 'WP_INSTALLING' ) ) {
+	define( 'WP_INSTALLING', true );
+}
+datamachine_maybe_run_deferred_migrations();
+assert_runtime(
+	'no migrations called while WordPress is installing',
+	0 === count( $GLOBALS['__test_migration_calls'] )
+);
+assert_runtime(
+	'db_version option not created while WordPress is installing',
+	! isset( $GLOBALS['__test_options']['datamachine_db_version'] )
+);
+
 // ---------------------------------------------------------------
 // SECTION 3: hook registration shape.
 // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Skip deferred schema migrations while WordPress is installing, before wp-phpunit has created core tables.
- Extend the migration runtime smoke to cover the WP_INSTALLING guard.

## Tests
- php tests/migration-runtime-smoke.php
- php -l inc/migrations/runtime.php
- php -l tests/migration-runtime-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the install-time migration failure surfaced by the Playground runner fix, drafted the guard and smoke coverage; Chris reviewed through the local verification flow.
