### PR TITLE
fix(settings): migrate legacy mode model settings

### DIFF
--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -29,6 +29,7 @@ require_once __DIR__ . '/split-queue-payload.php';
 require_once __DIR__ . '/user-message-queue-mode.php';
 require_once __DIR__ . '/webhook-auth-v2.php';
 require_once __DIR__ . '/agent-config-model-shape.php';
+require_once __DIR__ . '/settings-mode-models.php';
 require_once __DIR__ . '/bundle-artifacts.php';
 
 // Schema-migration runtime — defines `datamachine_run_schema_migrations()`

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -123,6 +123,10 @@ function datamachine_run_schema_migrations(): void {
 	// Idempotent.
 	datamachine_migrate_agent_config_model_shape();
 
+	// Migrate legacy site/network context_models and agent_models settings to
+	// canonical mode_models storage (idempotent).
+	datamachine_migrate_settings_mode_models();
+
 	// Drop redundant _datamachine_post_pipeline_id rows (#1091). Idempotent.
 	datamachine_drop_redundant_post_pipeline_meta();
 

--- a/inc/migrations/settings-mode-models.php
+++ b/inc/migrations/settings-mode-models.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Data Machine — Migrate legacy settings model keys to `mode_models`.
+ *
+ * The execution-mode model setting was renamed from earlier
+ * `context_models` / `agent_models` shapes to `mode_models`, but existing
+ * installs can still carry the old keys in datamachine_settings and
+ * datamachine_network_settings. New readers only consult `mode_models`, so
+ * those installs fall through to default_model and pipeline jobs run on the
+ * wrong model.
+ *
+ * @package DataMachine
+ * @since 0.99.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Migrate site and network model settings to the canonical `mode_models` key.
+ *
+ * Idempotent: gated on `datamachine_settings_mode_models_migrated`.
+ *
+ * @since 0.99.0
+ * @return void
+ */
+function datamachine_migrate_settings_mode_models(): void {
+	if ( get_option( 'datamachine_settings_mode_models_migrated', false ) ) {
+		return;
+	}
+
+	$site_settings = get_option( 'datamachine_settings', array() );
+	if ( is_array( $site_settings ) ) {
+		update_option( 'datamachine_settings', datamachine_migrate_settings_mode_models_array( $site_settings ), true );
+	}
+
+	$network_settings = get_site_option( 'datamachine_network_settings', array() );
+	if ( is_array( $network_settings ) ) {
+		update_site_option( 'datamachine_network_settings', datamachine_migrate_settings_mode_models_array( $network_settings ) );
+	}
+
+	update_option( 'datamachine_settings_mode_models_migrated', true, true );
+}
+
+/**
+ * Normalize a settings array to canonical mode_models storage.
+ *
+ * @since 0.99.0
+ * @param array $settings Raw settings array.
+ * @return array Settings array with legacy model keys removed.
+ */
+function datamachine_migrate_settings_mode_models_array( array $settings ): array {
+	$legacy = array();
+
+	if ( isset( $settings['context_models'] ) && is_array( $settings['context_models'] ) ) {
+		$legacy = $settings['context_models'];
+	} elseif ( isset( $settings['agent_models'] ) && is_array( $settings['agent_models'] ) ) {
+		$legacy = $settings['agent_models'];
+	}
+
+	if ( empty( $settings['mode_models'] ) && ! empty( $legacy ) ) {
+		$settings['mode_models'] = datamachine_sanitize_settings_mode_models( $legacy );
+	}
+
+	unset( $settings['context_models'], $settings['agent_models'] );
+
+	return $settings;
+}
+
+/**
+ * Sanitize persisted mode model entries without filtering extension modes.
+ *
+ * @since 0.99.0
+ * @param array $mode_models Raw mode model map.
+ * @return array Sanitized mode model map.
+ */
+function datamachine_sanitize_settings_mode_models( array $mode_models ): array {
+	$sanitized = array();
+
+	foreach ( $mode_models as $mode => $config ) {
+		if ( ! is_array( $config ) ) {
+			continue;
+		}
+
+		$mode = sanitize_key( (string) $mode );
+		if ( '' === $mode ) {
+			continue;
+		}
+
+		$sanitized[ $mode ] = array(
+			'provider' => sanitize_text_field( $config['provider'] ?? '' ),
+			'model'    => sanitize_text_field( $config['model'] ?? '' ),
+		);
+	}
+
+	return $sanitized;
+}

--- a/tests/Unit/Core/NetworkSettingsTest.php
+++ b/tests/Unit/Core/NetworkSettingsTest.php
@@ -91,7 +91,7 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 	public function test_is_network_key(): void {
 		$this->assertTrue( NetworkSettings::isNetworkKey( 'default_provider' ) );
 		$this->assertTrue( NetworkSettings::isNetworkKey( 'default_model' ) );
-		$this->assertTrue( NetworkSettings::isNetworkKey( 'agent_models' ) );
+		$this->assertTrue( NetworkSettings::isNetworkKey( 'mode_models' ) );
 		$this->assertFalse( NetworkSettings::isNetworkKey( 'disabled_tools' ) );
 		$this->assertFalse( NetworkSettings::isNetworkKey( 'site_context_enabled' ) );
 	}
@@ -105,16 +105,16 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 		$this->assertSame( 'anthropic', $raw['default_provider'] );
 	}
 
-	public function test_agent_models_stored_at_network_level(): void {
-		$agent_models = array(
+	public function test_mode_models_stored_at_network_level(): void {
+		$mode_models = array(
 			'chat'     => array( 'provider' => 'anthropic', 'model' => 'claude-sonnet-4-20250514' ),
 			'pipeline' => array( 'provider' => 'openai', 'model' => 'gpt-4o-mini' ),
 		);
 
-		NetworkSettings::update( array( 'agent_models' => $agent_models ) );
+		NetworkSettings::update( array( 'mode_models' => $mode_models ) );
 		NetworkSettings::clearCache();
 
-		$this->assertSame( $agent_models, NetworkSettings::get( 'agent_models' ) );
+		$this->assertSame( $mode_models, NetworkSettings::get( 'mode_models' ) );
 	}
 
 	// --- PluginSettings::resolve() cascade ---
@@ -165,14 +165,14 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 
 	public function test_get_agent_model_site_override_wins(): void {
 		update_option( 'datamachine_settings', array(
-			'agent_models' => array(
+			'mode_models' => array(
 				'chat' => array( 'provider' => 'openai', 'model' => 'gpt-4o' ),
 			),
 		) );
 		PluginSettings::clearCache();
 
 		NetworkSettings::update( array(
-			'agent_models' => array(
+			'mode_models' => array(
 				'chat' => array( 'provider' => 'anthropic', 'model' => 'claude-sonnet-4-20250514' ),
 			),
 		) );
@@ -183,12 +183,12 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 		$this->assertSame( 'gpt-4o', $result['model'] );
 	}
 
-	public function test_get_agent_model_falls_back_to_network_agent_models(): void {
+	public function test_get_agent_model_falls_back_to_network_mode_models(): void {
 		update_option( 'datamachine_settings', array() );
 		PluginSettings::clearCache();
 
 		NetworkSettings::update( array(
-			'agent_models' => array(
+			'mode_models' => array(
 				'pipeline' => array( 'provider' => 'openai', 'model' => 'gpt-4o-mini' ),
 			),
 		) );
@@ -228,14 +228,14 @@ class NetworkSettingsTest extends WP_UnitTestCase {
 		// Site has provider override for chat, but no model.
 		// Network has model for chat.
 		update_option( 'datamachine_settings', array(
-			'agent_models' => array(
+			'mode_models' => array(
 				'chat' => array( 'provider' => 'openai', 'model' => '' ),
 			),
 		) );
 		PluginSettings::clearCache();
 
 		NetworkSettings::update( array(
-			'agent_models' => array(
+			'mode_models' => array(
 				'chat' => array( 'provider' => 'anthropic', 'model' => 'claude-sonnet-4-20250514' ),
 			),
 		) );

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -126,6 +126,7 @@ $migration_chain = array(
 	'datamachine_migrate_user_message_queue_mode',
 	'datamachine_migrate_webhook_auth_v2',
 	'datamachine_migrate_agent_config_model_shape',
+	'datamachine_migrate_settings_mode_models',
 	'datamachine_drop_redundant_post_pipeline_meta',
 	'datamachine_migrate_bundle_artifacts_table',
 );

--- a/tests/settings-mode-models-migration-smoke.php
+++ b/tests/settings-mode-models-migration-smoke.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Pure-PHP smoke test for legacy settings model-key migration.
+ *
+ * Run with: php tests/settings-mode-models-migration-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$options      = array();
+$site_options = array();
+
+function get_option( string $key, $default = false ) {
+	global $options;
+	return array_key_exists( $key, $options ) ? $options[ $key ] : $default;
+}
+
+function update_option( string $key, $value, bool $autoload = true ): bool {
+	global $options;
+	$options[ $key ] = $value;
+	return true;
+}
+
+function get_site_option( string $key, $default = false ) {
+	global $site_options;
+	return array_key_exists( $key, $site_options ) ? $site_options[ $key ] : $default;
+}
+
+function update_site_option( string $key, $value ): bool {
+	global $site_options;
+	$site_options[ $key ] = $value;
+	return true;
+}
+
+function sanitize_key( $key ) {
+	$key = strtolower( (string) $key );
+	return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+}
+
+function sanitize_text_field( $value ) {
+	return trim( (string) $value );
+}
+
+require_once __DIR__ . '/../inc/migrations/settings-mode-models.php';
+
+$failures = array();
+$passes   = 0;
+
+function assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS: {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  FAIL: {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+echo "settings-mode-models migration smoke\n";
+echo "------------------------------------\n";
+
+echo "\n[settings:1] Migrates site context_models to mode_models\n";
+$options['datamachine_settings'] = array(
+	'context_models'  => array(
+		'pipeline' => array( 'provider' => 'openai', 'model' => 'gpt-5.4' ),
+	),
+	'default_model'   => 'gpt-5.4-mini',
+	'unrelated_value' => true,
+);
+$site_options['datamachine_network_settings'] = array();
+
+datamachine_migrate_settings_mode_models();
+
+assert_equals(
+	array(
+		'default_model'   => 'gpt-5.4-mini',
+		'unrelated_value' => true,
+		'mode_models'     => array(
+			'pipeline' => array( 'provider' => 'openai', 'model' => 'gpt-5.4' ),
+		),
+	),
+	$options['datamachine_settings'],
+	'site context_models moved and legacy key removed',
+	$failures,
+	$passes
+);
+
+echo "\n[settings:2] Migrates network agent_models to mode_models\n";
+$options      = array();
+$site_options = array(
+	'datamachine_network_settings' => array(
+		'agent_models'     => array(
+			'chat' => array( 'provider' => 'anthropic', 'model' => 'claude-sonnet-4-20250514' ),
+		),
+		'default_provider' => 'openai',
+	),
+);
+
+datamachine_migrate_settings_mode_models();
+
+assert_equals(
+	array(
+		'default_provider' => 'openai',
+		'mode_models'      => array(
+			'chat' => array( 'provider' => 'anthropic', 'model' => 'claude-sonnet-4-20250514' ),
+		),
+	),
+	$site_options['datamachine_network_settings'],
+	'network agent_models moved and legacy key removed',
+	$failures,
+	$passes
+);
+
+echo "\n[settings:3] Existing mode_models wins over legacy keys\n";
+$options      = array(
+	'datamachine_settings' => array(
+		'mode_models'    => array(
+			'pipeline' => array( 'provider' => 'openai', 'model' => 'gpt-5.4' ),
+		),
+		'context_models' => array(
+			'pipeline' => array( 'provider' => 'openai', 'model' => 'gpt-5.4-mini' ),
+		),
+	),
+);
+$site_options = array();
+
+datamachine_migrate_settings_mode_models();
+
+assert_equals(
+	array(
+		'mode_models' => array(
+			'pipeline' => array( 'provider' => 'openai', 'model' => 'gpt-5.4' ),
+		),
+	),
+	$options['datamachine_settings'],
+	'canonical mode_models preserved and legacy key removed',
+	$failures,
+	$passes
+);
+
+echo "\n[settings:4] Migration is gated\n";
+$options      = array(
+	'datamachine_settings_mode_models_migrated' => true,
+	'datamachine_settings' => array(
+		'context_models' => array(
+			'pipeline' => array( 'provider' => 'openai', 'model' => 'gpt-5.4' ),
+		),
+	),
+);
+$site_options = array();
+
+datamachine_migrate_settings_mode_models();
+
+assert_equals(
+	array(
+		'context_models' => array(
+			'pipeline' => array( 'provider' => 'openai', 'model' => 'gpt-5.4' ),
+		),
+	),
+	$options['datamachine_settings'],
+	'gate prevents re-entry',
+	$failures,
+	$passes
+);
+
+echo "\n[settings:5] Direct array helper sanitizes extension modes\n";
+$normalized = datamachine_migrate_settings_mode_models_array(
+	array(
+		'agent_models' => array(
+			'Pipeline!' => array( 'provider' => ' openai ', 'model' => ' gpt-5.4 ' ),
+			'invalid'   => 'not an array',
+		),
+	)
+);
+
+assert_equals(
+	array(
+		'mode_models' => array(
+			'pipeline' => array( 'provider' => 'openai', 'model' => 'gpt-5.4' ),
+		),
+	),
+	$normalized,
+	'helper normalizes mode keys and drops invalid entries',
+	$failures,
+	$passes
+);
+
+echo "\n------------------------------------\n";
+if ( ! empty( $failures ) ) {
+	echo count( $failures ) . " failure(s)\n";
+	exit( 1 );
+}
+
+echo "All {$passes} assertions passed.\n";


### PR DESCRIPTION
## Summary
- Migrate legacy `context_models` / `agent_models` settings into canonical `mode_models` storage for site and network settings.
- Remove the stale test vocabulary so model resolution tests exercise the current settings contract.

## Why
Existing installs can still carry the old settings keys after the modes rename. Current pipeline model resolution only reads `mode_models`, so those installs silently fall back to `default_model` and can run pipeline jobs on the wrong model.

## Tests
- `php tests/settings-mode-models-migration-smoke.php`
- `php tests/migration-runtime-smoke.php`
- `php -l inc/migrations/settings-mode-models.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-mode-model-settings-migration --file inc/migrations/settings-mode-models.php --summary`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-mode-model-settings-migration --file tests/settings-mode-models-migration-smoke.php --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5, model ID `openai/gpt-5.5`)
- **Used for:** Diagnosing the live model-resolution fallback, drafting the migration and smoke coverage, and running local verification. Chris reviewed the behavior through the live pipeline repro.
