### PR TITLE
refactor(chat): narrow transcript store resolution

### DIFF
--- a/inc/Core/Database/Chat/ConversationStoreFactory.php
+++ b/inc/Core/Database/Chat/ConversationStoreFactory.php
@@ -78,6 +78,7 @@ class ConversationStoreFactory {
 		 *
 		 * @param ConversationStoreInterface $store Default MySQL-table store.
 		 */
+		/** @var mixed $resolved */
 		$resolved = apply_filters( 'datamachine_conversation_store', $default );
 
 		if ( $resolved instanceof ConversationStoreInterface ) {
@@ -96,6 +97,20 @@ class ConversationStoreFactory {
 
 		self::$instance = $default;
 		return self::$instance;
+	}
+
+	/**
+	 * Resolve the active transcript store.
+	 *
+	 * This intentionally reuses the aggregate store/filter resolution so the
+	 * existing `datamachine_conversation_store` seam and chat UI callers keep
+	 * their current behavior while runtime transcript persistence depends only
+	 * on the narrow CRUD contract.
+	 *
+	 * @return ConversationTranscriptStoreInterface
+	 */
+	public static function get_transcript_store(): ConversationTranscriptStoreInterface {
+		return self::get();
 	}
 
 	/**

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -87,7 +87,7 @@ class AIConversationLoop {
 		 * @param int        $max_turns    Maximum conversation turns.
 		 * @param bool       $single_turn  Single-turn mode flag.
 		 */
-		$result = apply_filters(
+		$filter_args = array(
 			'datamachine_conversation_runner',
 			null,
 			$messages,
@@ -97,8 +97,9 @@ class AIConversationLoop {
 			$mode,
 			$payload,
 			$max_turns,
-			$single_turn
+			$single_turn,
 		);
+		$result      = call_user_func_array( 'apply_filters', $filter_args );
 
 		if ( is_array( $result ) ) {
 			return self::normalizeResultForRun( $result, $messages );

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -728,7 +728,7 @@ class AIConversationLoop {
 			return '';
 		}
 
-		$store = ConversationStoreFactory::get();
+		$store = ConversationStoreFactory::get_transcript_store();
 
 		$user_id  = (int) ( $payload['user_id'] ?? 0 );
 		$agent_id = (int) ( $payload['agent_id'] ?? 0 );

--- a/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
+++ b/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
@@ -54,6 +54,14 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( Chat::class, $store );
 	}
 
+	public function test_transcript_resolution_returns_narrow_contract(): void {
+		$store = ConversationStoreFactory::get_transcript_store();
+
+		$this->assertInstanceOf( ConversationTranscriptStoreInterface::class, $store );
+		$this->assertInstanceOf( ConversationStoreInterface::class, ConversationStoreFactory::get() );
+		$this->assertSame( ConversationStoreFactory::get(), $store );
+	}
+
 	public function test_conversation_store_interface_is_composed_from_narrow_contracts(): void {
 		$reflection = new \ReflectionClass( ConversationStoreInterface::class );
 		$expected   = array(
@@ -90,6 +98,22 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( ConversationRetentionInterface::class, $resolved );
 		$this->assertInstanceOf( ConversationReportingInterface::class, $resolved );
 		$this->assertNotInstanceOf( Chat::class, $resolved );
+	}
+
+	public function test_transcript_resolution_uses_conversation_store_filter(): void {
+		$memory_store = new InMemoryConversationStore();
+
+		add_filter(
+			'datamachine_conversation_store',
+			static fn() => $memory_store,
+			10,
+			1
+		);
+
+		$resolved = ConversationStoreFactory::get_transcript_store();
+
+		$this->assertSame( $memory_store, $resolved );
+		$this->assertInstanceOf( ConversationTranscriptStoreInterface::class, $resolved );
 	}
 
 	public function test_misbehaving_filter_falls_back_to_default(): void {
@@ -211,6 +235,64 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 
 		$metrics = $store->get_storage_metrics();
 		$this->assertSame( 3, $metrics['rows'] );
+	}
+
+	public function test_transcript_only_contract_can_persist_messages(): void {
+		$store      = new InMemoryConversationStore();
+		$transcript = $this->persist_fixture_transcript( $store );
+
+		$this->assertSame( 'openai', $transcript['provider'] );
+		$this->assertSame( 'gpt-test', $transcript['model'] );
+		$this->assertSame( 'pipeline', $transcript['context'] );
+		$this->assertSame( 'assistant response', $transcript['messages'][1]['content'] );
+		$this->assertSame( 99, $transcript['metadata']['job_id'] );
+	}
+
+	/**
+	 * Persist a transcript through only the narrow runtime contract.
+	 *
+	 * @param ConversationTranscriptStoreInterface $store Transcript store.
+	 * @return array<string, mixed>
+	 */
+	private function persist_fixture_transcript( ConversationTranscriptStoreInterface $store ): array {
+		$session_id = $store->create_session(
+			5,
+			7,
+			array(
+				'source' => 'pipeline_transcript',
+				'job_id' => 99,
+			),
+			'pipeline'
+		);
+
+		$this->assertNotSame( '', $session_id );
+
+		$updated = $store->update_session(
+			$session_id,
+			array(
+				array(
+					'role'    => 'user',
+					'content' => 'input',
+				),
+				array(
+					'role'    => 'assistant',
+					'content' => 'assistant response',
+				),
+			),
+			array(
+				'source' => 'pipeline_transcript',
+				'job_id' => 99,
+			),
+			'openai',
+			'gpt-test'
+		);
+
+		$this->assertTrue( $updated );
+
+		$session = $store->get_session( $session_id );
+		$this->assertNotNull( $session );
+
+		return $session;
 	}
 
 	public function test_list_sessions_for_day_observed_by_swapped_store_through_factory(): void {

--- a/tests/conversation-store-contracts-smoke.php
+++ b/tests/conversation-store-contracts-smoke.php
@@ -38,17 +38,15 @@ use DataMachine\Core\Database\Chat\ConversationStoreInterface;
 use DataMachine\Core\Database\Chat\ConversationTranscriptStoreInterface;
 use DataMachine\Tests\Unit\Core\Database\Chat\InMemoryConversationStore;
 
-$failures = array();
-
-function assert_true( bool $condition, string $label ): void {
-	global $failures;
+$failures    = array();
+$assert_true = static function ( bool $condition, string $label ) use ( &$failures ): void {
 	if ( $condition ) {
 		echo "PASS: {$label}\n";
 		return;
 	}
 	echo "FAIL: {$label}\n";
 	$failures[] = $label;
-}
+};
 
 $narrow_contracts = array(
 	ConversationTranscriptStoreInterface::class,
@@ -60,19 +58,24 @@ $narrow_contracts = array(
 
 $aggregate = new ReflectionClass( ConversationStoreInterface::class );
 foreach ( $narrow_contracts as $contract ) {
-	assert_true( $aggregate->implementsInterface( $contract ), "aggregate composes {$contract}" );
+	$assert_true( $aggregate->implementsInterface( $contract ), "aggregate composes {$contract}" );
 }
 
 foreach ( $narrow_contracts as $contract ) {
-	assert_true( is_subclass_of( Chat::class, $contract ), "Chat implements {$contract}" );
-	assert_true( is_subclass_of( InMemoryConversationStore::class, $contract ), "InMemoryConversationStore implements {$contract}" );
+	$chat_ref = new ReflectionClass( Chat::class );
+	$test_ref = new ReflectionClass( InMemoryConversationStore::class );
+	$assert_true( $chat_ref->implementsInterface( $contract ), "Chat implements {$contract}" );
+	$assert_true( $test_ref->implementsInterface( $contract ), "InMemoryConversationStore implements {$contract}" );
 }
 
-assert_true( is_subclass_of( Chat::class, ConversationStoreInterface::class ), 'Chat remains a ConversationStoreInterface aggregate' );
-assert_true( is_subclass_of( InMemoryConversationStore::class, ConversationStoreInterface::class ), 'test adapter remains a ConversationStoreInterface aggregate' );
+$assert_true( ( new ReflectionClass( Chat::class ) )->implementsInterface( ConversationStoreInterface::class ), 'Chat remains a ConversationStoreInterface aggregate' );
+$assert_true( ( new ReflectionClass( InMemoryConversationStore::class ) )->implementsInterface( ConversationStoreInterface::class ), 'test adapter remains a ConversationStoreInterface aggregate' );
 
 $factory_get = new ReflectionMethod( ConversationStoreFactory::class, 'get' );
-assert_true( ConversationStoreInterface::class === (string) $factory_get->getReturnType(), 'factory still returns the aggregate contract' );
+$assert_true( ConversationStoreInterface::class === (string) $factory_get->getReturnType(), 'factory still returns the aggregate contract' );
+
+$factory_transcript_get = new ReflectionMethod( ConversationStoreFactory::class, 'get_transcript_store' );
+$assert_true( ConversationTranscriptStoreInterface::class === (string) $factory_transcript_get->getReturnType(), 'factory exposes the narrow transcript contract' );
 
 echo "\n";
 if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary
- Splits the runtime transcript persistence resolution onto the narrower transcript-store contract while preserving the aggregate chat facade for current callers.
- Keeps the existing `datamachine_conversation_store` filter as the single backend swap seam.

## Changes
- Added `ConversationStoreFactory::get_transcript_store()` returning `ConversationTranscriptStoreInterface` while reusing the aggregate factory/filter cache.
- Updated `AIConversationLoop` transcript persistence to resolve through the transcript-only accessor.
- Added coverage proving the aggregate factory remains intact, filtered stores still resolve, and transcript persistence works through the narrow contract.

## Tests
- `php tests/conversation-store-contracts-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@untangle-conversation-transcript-store --changed-since origin/main`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@untangle-conversation-transcript-store --changed-since origin/main`

Closes #1568

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the boundary refactor, focused tests, and validation commands; Chris retains review responsibility for the final change.