### PR TITLE
test(migrations): baseline runtime smoke analysis

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,97 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to function function_exists\(\) with ''datamachine_assign…''\|''datamachine…''\|''datamachine_drop…''\|''datamachine_migrate…''\|''datamachine_strip…'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments ''datamachine_assign…''\|''datamachine…''\|''datamachine_drop…''\|''datamachine_migrate…''\|''datamachine_strip…'', array\{\} and true will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Comparison operation "\>" between \*NEVER\* and 1 results in an error\.$#'
+			identifier: greater.invalid
+			count: 1
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Empty array passed to foreach\.$#'
+			identifier: foreach.emptyArray
+			count: 1
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Offset ''datamachine_db_version'' does not exist on array\{\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Offset ''priority'' on null on left side of \?\? does not exist\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 8
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between false and false will always evaluate to false\.$#'
+			identifier: notIdentical.alwaysFalse
+			count: 7
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between null and null will always evaluate to false\.$#'
+			identifier: notIdentical.alwaysFalse
+			count: 1
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''0\.84\.0\-test'' and ''0\.79\.0\-stale'' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''0\.84\.0\-test'' and ''0\.84\.0\-test'' will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''0\.84\.0\-test'' and ''99\.99\.0\-future'' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between 0 and 0 will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 4
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between 0 and 21 will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 4
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between 5 and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: tests/migration-runtime-smoke.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: tests/migration-runtime-smoke.php

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -1,4 +1,6 @@
 <?php
+// @phpstan-ignore-file
+
 /**
  * Pure-PHP smoke test for the schema-migration runtime (#1301).
  *

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -1,5 +1,4 @@
 <?php
-// @phpstan-ignore-file
 
 /**
  * Pure-PHP smoke test for the schema-migration runtime (#1301).


### PR DESCRIPTION
## Summary
- Adds a PHPStan baseline for the pure-PHP migration runtime smoke harness so scoped lint can stay green without rewriting runtime-oriented assertions for static analysis.
- Leaves the smoke's execution contract intact; the harness still validates the migration chain and deferred runtime behavior directly.

## Tests
- `php tests/migration-runtime-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-migration-runtime-smoke-phpstan --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the PHPStan release blocker, generated the narrow baseline, and ran the focused checks. Chris remains responsible for review and merge.