### PR TITLE
refactor(ai): add conversation runner request boundary

### DIFF
--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -61,6 +61,17 @@ class AIConversationLoop {
 		int $max_turns = PluginSettings::DEFAULT_MAX_TURNS,
 		bool $single_turn = false
 	): array {
+		$request = AIConversationRequest::fromRunArgs(
+			$messages,
+			$tools,
+			$provider,
+			$model,
+			$mode,
+			$payload,
+			$max_turns,
+			$single_turn
+		);
+
 		/**
 		 * Filter: allow a consumer to replace Data Machine's built-in
 		 * conversation loop with an alternative runtime.
@@ -105,17 +116,7 @@ class AIConversationLoop {
 			return self::normalizeResultForRun( $result, $messages );
 		}
 
-		$loop   = new self();
-		$result = $loop->execute(
-			$messages,
-			$tools,
-			$provider,
-			$model,
-			$mode,
-			$payload,
-			$max_turns,
-			$single_turn
-		);
+		$result = ( new BuiltInAIConversationRunner() )->run( $request );
 
 		return self::normalizeResultForRun( $result, $messages );
 	}

--- a/inc/Engine/AI/AIConversationRequest.php
+++ b/inc/Engine/AI/AIConversationRequest.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * AI conversation runner request contract.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+use DataMachine\Core\PluginSettings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Neutral request object for conversation runner implementations.
+ */
+class AIConversationRequest {
+
+	/** @var array Initial conversation messages. */
+	private array $messages;
+
+	/** @var array Available AI tools. */
+	private array $tools;
+
+	/** @var array Provider/model configuration. */
+	private array $model_config;
+
+	/** @var string Execution mode. */
+	private string $mode;
+
+	/** @var int Maximum turn budget requested by caller. */
+	private int $max_turns;
+
+	/** @var bool Whether to stop after one model turn. */
+	private bool $single_turn;
+
+	/** @var LoopEventSinkInterface Event sink carried by the request. */
+	private LoopEventSinkInterface $event_sink;
+
+	/** @var array Original loop payload. */
+	private array $payload;
+
+	/** @var array Data Machine adapter context. */
+	private array $adapter_context;
+
+	/**
+	 * Build a request from the legacy AIConversationLoop::run() argument list.
+	 *
+	 * @param array  $messages    Initial conversation messages.
+	 * @param array  $tools       Available tools for AI.
+	 * @param string $provider    AI provider identifier.
+	 * @param string $model       AI model identifier.
+	 * @param string $mode        Execution mode.
+	 * @param array  $payload     Step payload / loop context.
+	 * @param int    $max_turns   Maximum conversation turns.
+	 * @param bool   $single_turn Single-turn mode flag.
+	 * @return self Request object.
+	 */
+	public static function fromRunArgs(
+		array $messages,
+		array $tools,
+		string $provider,
+		string $model,
+		string $mode,
+		array $payload = array(),
+		int $max_turns = PluginSettings::DEFAULT_MAX_TURNS,
+		bool $single_turn = false
+	): self {
+		return new self(
+			$messages,
+			$tools,
+			array(
+				'provider' => $provider,
+				'model'    => $model,
+			),
+			$mode,
+			$payload,
+			$max_turns,
+			$single_turn
+		);
+	}
+
+	/**
+	 * @param array $messages     Initial conversation messages.
+	 * @param array $tools        Available tools for AI.
+	 * @param array $model_config Provider/model configuration.
+	 * @param string $mode        Execution mode.
+	 * @param array $payload      Step payload / loop context.
+	 * @param int   $max_turns    Maximum conversation turns.
+	 * @param bool  $single_turn  Single-turn mode flag.
+	 */
+	public function __construct(
+		array $messages,
+		array $tools,
+		array $model_config,
+		string $mode,
+		array $payload = array(),
+		int $max_turns = PluginSettings::DEFAULT_MAX_TURNS,
+		bool $single_turn = false
+	) {
+		$this->messages        = $messages;
+		$this->tools           = $tools;
+		$this->model_config    = $model_config;
+		$this->mode            = $mode;
+		$this->payload         = $payload;
+		$this->max_turns       = $max_turns;
+		$this->single_turn     = $single_turn;
+		$this->event_sink      = self::resolveEventSink( $payload );
+		$this->adapter_context = self::buildAdapterContext( $payload );
+	}
+
+	/** @return array Initial conversation messages. */
+	public function messages(): array {
+		return $this->messages;
+	}
+
+	/** @return array Available AI tools. */
+	public function tools(): array {
+		return $this->tools;
+	}
+
+	/** @return array Provider/model configuration. */
+	public function modelConfig(): array {
+		return $this->model_config;
+	}
+
+	/** @return string Provider identifier. */
+	public function provider(): string {
+		return (string) ( $this->model_config['provider'] ?? '' );
+	}
+
+	/** @return string Model identifier. */
+	public function model(): string {
+		return (string) ( $this->model_config['model'] ?? '' );
+	}
+
+	/** @return string Execution mode. */
+	public function mode(): string {
+		return $this->mode;
+	}
+
+	/** @return int Maximum turn budget requested by caller. */
+	public function maxTurns(): int {
+		return $this->max_turns;
+	}
+
+	/** @return bool Whether to stop after one model turn. */
+	public function singleTurn(): bool {
+		return $this->single_turn;
+	}
+
+	/** @return LoopEventSinkInterface Event sink carried by the request. */
+	public function eventSink(): LoopEventSinkInterface {
+		return $this->event_sink;
+	}
+
+	/** @return array Original loop payload. */
+	public function payload(): array {
+		return $this->payload;
+	}
+
+	/** @return array Data Machine adapter context. */
+	public function adapterContext(): array {
+		return $this->adapter_context;
+	}
+
+	/**
+	 * Return the legacy AIConversationLoop::execute() argument list.
+	 *
+	 * @return array Legacy arguments.
+	 */
+	public function toLegacyArgs(): array {
+		return array(
+			$this->messages,
+			$this->tools,
+			$this->provider(),
+			$this->model(),
+			$this->mode,
+			$this->payload,
+			$this->max_turns,
+			$this->single_turn,
+		);
+	}
+
+	/**
+	 * Resolve observer sink from payload without exposing payload shape to runners.
+	 *
+	 * @param array $payload Loop payload.
+	 * @return LoopEventSinkInterface Event sink.
+	 */
+	private static function resolveEventSink( array $payload ): LoopEventSinkInterface {
+		$sink = $payload['event_sink'] ?? null;
+
+		if ( $sink instanceof LoopEventSinkInterface ) {
+			return $sink;
+		}
+
+		return new NullLoopEventSink();
+	}
+
+	/**
+	 * Extract Data Machine-specific adapter context from the legacy payload.
+	 *
+	 * @param array $payload Loop payload.
+	 * @return array Adapter context.
+	 */
+	private static function buildAdapterContext( array $payload ): array {
+		return array(
+			'job_id'                   => $payload['job_id'] ?? null,
+			'flow_step_id'             => $payload['flow_step_id'] ?? null,
+			'pipeline_id'              => $payload['pipeline_id'] ?? null,
+			'flow_id'                  => $payload['flow_id'] ?? null,
+			'configured_handler_slugs' => $payload['configured_handler_slugs'] ?? array(),
+			'persist_transcript'       => $payload['persist_transcript'] ?? false,
+			'engine'                   => $payload['engine'] ?? null,
+		);
+	}
+}

--- a/inc/Engine/AI/AIConversationRunnerInterface.php
+++ b/inc/Engine/AI/AIConversationRunnerInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * AI conversation runner interface.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Transport-neutral runner boundary for conversation execution.
+ */
+interface AIConversationRunnerInterface {
+
+	/**
+	 * Run an AI conversation request.
+	 *
+	 * @param AIConversationRequest $request Conversation request.
+	 * @return array Raw AIConversationLoop result shape.
+	 */
+	public function run( AIConversationRequest $request ): array;
+}

--- a/inc/Engine/AI/BuiltInAIConversationRunner.php
+++ b/inc/Engine/AI/BuiltInAIConversationRunner.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Built-in AI conversation runner.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adapter that runs Data Machine's existing conversation loop implementation.
+ */
+class BuiltInAIConversationRunner implements AIConversationRunnerInterface {
+
+	/**
+	 * Run an AI conversation request through the legacy loop implementation.
+	 *
+	 * @param AIConversationRequest $request Conversation request.
+	 * @return array Raw AIConversationLoop result shape.
+	 */
+	public function run( AIConversationRequest $request ): array {
+		$loop = new AIConversationLoop();
+
+		return $loop->execute( ...$request->toLegacyArgs() );
+	}
+}

--- a/tests/ai-conversation-runner-request-smoke.php
+++ b/tests/ai-conversation-runner-request-smoke.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Smoke test for the AI conversation request/runner boundary.
+ *
+ * Run with: php tests/ai-conversation-runner-request-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$GLOBALS['datamachine_runner_request_filters'] = array();
+$GLOBALS['datamachine_runner_request_logs']    = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['datamachine_runner_request_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$callbacks = $GLOBALS['datamachine_runner_request_filters'][ $hook ] ?? array();
+		ksort( $callbacks );
+
+		foreach ( $callbacks as $priority_callbacks ) {
+			foreach ( $priority_callbacks as $entry ) {
+				$callback      = $entry[0];
+				$accepted_args = $entry[1];
+				$value         = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['datamachine_runner_request_logs'][] = array_merge( array( $hook ), $args );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $flags = 0 ) {
+		return json_encode( $data, $flags );
+	}
+}
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+use DataMachine\Engine\AI\AIConversationLoop;
+use DataMachine\Engine\AI\AIConversationRequest;
+use DataMachine\Engine\AI\LoopEventSinkInterface;
+
+class RunnerRequestSmokeSink implements LoopEventSinkInterface {
+	public array $events = array();
+
+	public function emit( string $event, array $payload = array() ): void {
+		$this->events[] = array(
+			'event'   => $event,
+			'payload' => $payload,
+		);
+	}
+}
+
+$failures = array();
+
+function assert_runner_request( bool $condition, string $label ): void {
+	global $failures;
+
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	echo "FAIL: {$label}\n";
+	$failures[] = $label;
+}
+
+function runner_request_failure_count(): int {
+	global $failures;
+	return count( $failures );
+}
+
+$messages = array(
+	array(
+		'role'    => 'user',
+		'content' => 'hello runner boundary',
+	),
+);
+$tools    = array();
+$sink     = new RunnerRequestSmokeSink();
+$payload  = array(
+	'job_id'                   => 1569,
+	'flow_step_id'             => 'flow-step-smoke',
+	'pipeline_id'              => 31,
+	'flow_id'                  => 41,
+	'configured_handler_slugs' => array( 'wiki_upsert' ),
+	'persist_transcript'       => false,
+	'engine'                   => array( 'snapshot' => 'present' ),
+	'event_sink'               => $sink,
+);
+
+// 1. The request object exposes generic runner inputs and Data Machine adapter context.
+$request = AIConversationRequest::fromRunArgs(
+	$messages,
+	$tools,
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	$payload,
+	7,
+	true
+);
+
+assert_runner_request( $messages === $request->messages(), 'request keeps messages as generic input' );
+assert_runner_request( $tools === $request->tools(), 'request keeps tools as generic input' );
+assert_runner_request( 'openai' === $request->provider(), 'request exposes provider from model config' );
+assert_runner_request( 'gpt-smoke' === $request->model(), 'request exposes model from model config' );
+assert_runner_request( 'pipeline' === $request->mode(), 'request exposes mode' );
+assert_runner_request( 7 === $request->maxTurns(), 'request exposes max turns' );
+assert_runner_request( true === $request->singleTurn(), 'request exposes single-turn flag' );
+assert_runner_request( $sink === $request->eventSink(), 'request exposes event sink' );
+assert_runner_request( 1569 === $request->adapterContext()['job_id'], 'adapter context carries job id' );
+assert_runner_request( 31 === $request->adapterContext()['pipeline_id'], 'adapter context carries pipeline id' );
+assert_runner_request( array( 'wiki_upsert' ) === $request->adapterContext()['configured_handler_slugs'], 'adapter context carries handler completion policy' );
+assert_runner_request( false === $request->adapterContext()['persist_transcript'], 'adapter context carries transcript policy' );
+assert_runner_request( array( 'snapshot' => 'present' ) === $request->adapterContext()['engine'], 'adapter context carries engine snapshot' );
+
+// 2. The legacy facade still passes the old argument list to the runner filter.
+$legacy_filter_args = null;
+add_filter(
+	'datamachine_conversation_runner',
+	function ( $result, ...$args ) use ( &$legacy_filter_args ) {
+		$legacy_filter_args = array_merge( array( $result ), $args );
+		return null;
+	},
+	10,
+	9
+);
+
+$dispatched_request = null;
+add_filter(
+	'chubes_ai_request',
+	function ( array $request_body, ...$args ) use ( &$dispatched_request ) {
+		unset( $args );
+		$dispatched_request = $request_body;
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'facade ok',
+				'tool_calls' => array(),
+				'usage'      => array(
+					'prompt_tokens'     => 2,
+					'completion_tokens' => 3,
+					'total_tokens'      => 5,
+				),
+			),
+		);
+	},
+	10,
+	6
+);
+
+$result = AIConversationLoop::run(
+	$messages,
+	$tools,
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	$payload,
+	7,
+	true
+);
+
+assert_runner_request( array_key_exists( 0, $legacy_filter_args ) && null === $legacy_filter_args[0], 'runner filter still receives nullable result seed first' );
+assert_runner_request( $messages === ( $legacy_filter_args[1] ?? null ), 'runner filter still receives legacy messages argument' );
+assert_runner_request( $tools === ( $legacy_filter_args[2] ?? null ), 'runner filter still receives legacy tools argument' );
+assert_runner_request( 'openai' === ( $legacy_filter_args[3] ?? null ), 'runner filter still receives legacy provider argument' );
+assert_runner_request( 'gpt-smoke' === ( $legacy_filter_args[4] ?? null ), 'runner filter still receives legacy model argument' );
+assert_runner_request( 'pipeline' === ( $legacy_filter_args[5] ?? null ), 'runner filter still receives legacy mode argument' );
+assert_runner_request( $payload === ( $legacy_filter_args[6] ?? null ), 'runner filter still receives legacy payload argument' );
+assert_runner_request( 7 === ( $legacy_filter_args[7] ?? null ), 'runner filter still receives legacy max-turns argument' );
+assert_runner_request( true === ( $legacy_filter_args[8] ?? null ), 'runner filter still receives legacy single-turn argument' );
+
+assert_runner_request( 'facade ok' === $result['final_content'], 'facade result comes back through built-in runner path' );
+assert_runner_request( true === $result['completed'], 'facade preserves completed result shape' );
+assert_runner_request( 1 === $result['turn_count'], 'facade preserves turn count' );
+assert_runner_request( array() === $result['tool_execution_results'], 'facade normalizes optional tool execution results' );
+assert_runner_request( 5 === ( $result['usage']['total_tokens'] ?? null ), 'facade preserves usage totals' );
+assert_runner_request( is_array( $dispatched_request ), 'built-in runner dispatched a provider request' );
+assert_runner_request( array( 'turn_started', 'request_built', 'completed' ) === array_column( $sink->events, 'event' ), 'event sink survives request boundary' );
+
+if ( runner_request_failure_count() > 0 ) {
+	exit( 1 );
+}
+
+echo "\nAll AI conversation runner request smoke tests passed.\n";


### PR DESCRIPTION
## Summary
- Adds an `AIConversationRequest` value object and `AIConversationRunnerInterface` to put a neutral request/result boundary behind `AIConversationLoop::run()`.
- Keeps the existing public `AIConversationLoop::run()` signature and `datamachine_conversation_runner` filter behavior intact while delegating built-in execution through `BuiltInAIConversationRunner`.

## Changes
- Groups generic run inputs separately from Data Machine adapter context.
- Preserves legacy runner filter arguments for existing integrations.
- Adds smoke coverage proving the old facade still returns the same normalized result shape through the new runner path.

## Tests
- `php tests/ai-conversation-runner-request-smoke.php`
- `php tests/ai-loop-event-sink-smoke.php`
- `php tests/ai-request-metadata-guardrails-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@untangle-agent-runner-boundary --changed-since origin/main`

Closes #1569

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the behavior-preserving request/runner boundary, smoke coverage, and validation commands. Chris remains responsible for review and merge.
