### PR TITLE
refactor(ai): rename agent conversation seam

### DIFF
--- a/docs/core-system/ai-message-envelope.md
+++ b/docs/core-system/ai-message-envelope.md
@@ -104,7 +104,7 @@ shape.
 ## Adapter Guidance
 
 Runtime adapters using `datamachine_conversation_runner` may return messages in
-either legacy or envelope shape. `AIConversationResult::normalize()` normalizes
+either legacy or envelope shape. `AgentConversationResult::normalize()` normalizes
 every returned message to the canonical envelope before callers store or render
 the result.
 

--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -47,7 +47,7 @@ These are closest to generic public contracts. Most should be extracted as contr
 | Surface | Current location | Why it fits | Target notes |
 |---|---|---|---|
 | `MessageEnvelope` | `inc/Engine/AI/MessageEnvelope.php` | JSON-friendly canonical message envelope independent of flows/jobs. | Rename schema away from `datamachine.ai.message`; review whether public class is `WP_Agent_Message` or a neutral envelope helper. |
-| `AIConversationResult` | `inc/Engine/AI/AIConversationResult.php` | Validates result arrays from any runtime runner. | Rename to `WP_Agent_Run_Result` or split into result value object plus validator. |
+| `AgentConversationResult` | `inc/Engine/AI/AgentConversationResult.php` | Validates result arrays from any runtime runner. | Rename to `WP_Agent_Run_Result` or split into result value object plus validator. |
 | `LoopEventSinkInterface` | `inc/Engine/AI/LoopEventSinkInterface.php` | Transport-neutral event sink for logs, streaming, CLI, REST, or chat UIs. | Make event vocabulary public and provider-neutral before extraction. |
 | `NullLoopEventSink` | `inc/Engine/AI/NullLoopEventSink.php` | Generic no-op implementation for optional event sinks. | Implementation can move with the interface. |
 | `RuntimeToolDeclaration` | `inc/Engine/AI/Tools/RuntimeToolDeclaration.php` | Validates run-scoped client/runtime tool declarations without Data Machine state. | Rename around `WP_Agent_Tool_Declaration`; keep executor/source/scope vocabulary generic. |
@@ -193,7 +193,7 @@ These tests currently pin the substrate most relevant to extraction.
 | Test | Covers | Extraction signal |
 |---|---|---|
 | `tests/ai-message-envelope-smoke.php` | Message envelope normalization/projection and result validation. | Move with message/result contracts. |
-| `tests/ai-conversation-result-smoke.php` | Conversation result shape validation. | Move with runner result contract. |
+| `tests/agent-conversation-result-smoke.php` | Conversation result shape validation. | Move with runner result contract. |
 | `tests/conversation-store-contracts-smoke.php` | Split store interfaces and factory return type. | Move with conversation store contracts. |
 | `tests/guideline-agent-memory-store-smoke.php` | Optional guideline-backed memory implementation. | Move or duplicate if Agents API ships memory store implementations. |
 | `tests/daily-memory-store-seam-smoke.php` | Daily memory through memory store seam. | Data Machine product consuming generic memory store. |

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -1,0 +1,159 @@
+# Agents API Pre-Extraction Audit
+
+Parent issue: [Explore splitting Agents API out of Data Machine](https://github.com/Extra-Chill/data-machine/issues/1561)
+
+This audit records the remaining work after the first in-place untangling wave. The boundary is now mostly visible: Data Machine owns pipelines and automation; the future Agents API owns generic agent runtime primitives. The next phase is to make those primitives look like Agents API while they still live in this repository.
+
+## Current State
+
+The initial untangling wave is complete:
+
+- Pipeline tool policy translation is separated from generic tool policy resolution.
+- Adjacent handler tools are a Data Machine provider instead of generic source-registry behavior.
+- Ability-native tool execution is separated from Data Machine pending-action and post-tracking decorators.
+- Declarative agent registration is separated from Data Machine materialization.
+- Memory store ownership is documented behind a neutral store contract.
+- Conversation transcript storage is narrowed behind a transcript facade.
+- The runner request boundary exists.
+
+This branch starts the naming phase by renaming the neutral runner result/request seam from `AIConversation*` to `AgentConversation*` while leaving `AIConversationLoop` as the temporary compatibility facade.
+
+## Remaining In-Place Rename Work
+
+### 1. Runner Facade
+
+`AIConversationLoop` still carries the old runtime name and owns built-in loop execution. It should not be physically extracted until the generic loop and the Data Machine completion/transcript policies are separated further.
+
+Target shape:
+
+- `AgentConversationRunnerInterface` is the public runtime boundary.
+- `AgentConversationRequest` and `AgentConversationResult` are neutral value contracts.
+- `AIConversationLoop` remains a Data Machine compatibility facade until callers are moved to the new name.
+- A future `AgentConversationLoop` or `WP_Agent_Runner` should not know about `job_id`, `flow_step_id`, `pipeline_id`, or handler completion policy.
+
+### 2. Runtime Hooks And Filters
+
+These are still Data Machine-named even when the seam is generic:
+
+- `datamachine_conversation_runner`
+- `datamachine_conversation_store`
+- `datamachine_memory_store`
+- `datamachine_tool_sources`
+- `datamachine_tool_sources_for_mode`
+- `datamachine_register_agents`
+- `datamachine_guideline_updated`
+
+Target shape:
+
+- Decide the `agents_api_*` / `wp_agents_api_*` hook names before extraction.
+- Keep existing Data Machine hooks while code is in this repository.
+- Do not add runtime fallback ladders that survive extraction. When Agents API owns the seam, migrate consumers to the new hook names directly.
+
+### 3. Message Envelope Vocabulary
+
+`MessageEnvelope` is generic but still declares the schema `datamachine.ai.message`.
+
+Target shape:
+
+- Decide whether the public class is `WP_Agent_Message`, `AgentMessageEnvelope`, or a lower-level normalizer.
+- Rename schema metadata away from `datamachine.ai.message` before physical extraction.
+- Keep wpcom message DTOs as adapters/source material, not public dependency vocabulary.
+
+### 4. Conversation Storage Boundary
+
+The transcript interfaces are now separated, but the storage implementation still lives under `Core\Database\Chat` and the aggregate store includes chat UI concerns.
+
+Target shape:
+
+- Extract transcript CRUD first.
+- Keep read state, reporting, retention, and session list behavior optional or Data Machine-owned until proven generic.
+- Keep Data Machine chat UI as product surface.
+
+### 5. Memory Store Boundary
+
+The memory store contract is close to extractable.
+
+Target shape:
+
+- `AgentMemoryStoreInterface` becomes a WordPress-shaped Agents API contract.
+- `GuidelineAgentMemoryStore` becomes the core-friendly/default implementation where `wp_guideline` exists.
+- `DiskAgentMemoryStore` becomes `MarkdownMemoryStore` only if disk-backed agent memory is part of the public Agents API product.
+- Data Machine file scaffolding stays a Data Machine adapter.
+
+### 6. Tool Registry And Execution
+
+The execution core is split, but `ToolManager` still centers on `datamachine_tools` and legacy handler/class tool declarations.
+
+Target shape:
+
+- Agents API should prefer Ability-native tools and runtime tool declarations.
+- Data Machine can keep its curated `datamachine_tools` compatibility/product registry.
+- Adjacent handler tools stay Data Machine-only.
+
+### 7. Agent Registry And Identity
+
+Declarative registration is separated from materialization, but the public helper is still `datamachine_register_agent()` and persistence still targets Data Machine tables.
+
+Target shape:
+
+- Mirror Abilities API: `wp_register_agent()`, `WP_Agent`, `WP_Agents_Registry`, `wp_agents_api_init`.
+- Data Machine reconciler continues to create its rows/access records from registered definitions while Data Machine hosts the substrate.
+- Decide whether Agents API owns persistence tables, only contracts, or optional stores before moving repositories.
+
+### 8. Data Machine Product Still Under `Engine\AI`
+
+System tasks, retention tasks, pending actions, and several product tools still live under `Engine\AI`.
+
+Target shape:
+
+- Do not move these into Agents API.
+- Rename namespaces later if useful, but treat them as Data Machine automation/product surface.
+- Use them as consumers of Agents API, not part of the substrate.
+
+## Lingering Entanglement Checklist
+
+Before physical extraction, verify that generic runtime candidates do not:
+
+- Import `DataMachine\Core\Steps\*`.
+- Require `job_id`, `flow_step_id`, `pipeline_id`, `flow_id`, or `handler_slug` as first-class fields.
+- Call Data Machine job/engine APIs directly.
+- Emit `datamachine_log` directly instead of using a generic event sink.
+- Depend on `datamachine_tools` legacy class/method declarations.
+- Mention wpcom classes in public signatures.
+
+## What Agents API Can Enable Without Data Machine
+
+Agents API should be useful even when a site does not install Data Machine. In that shape, a plugin could build:
+
+- A single-purpose site copilot that registers an agent, grants a bounded tool set, persists memory, and runs conversations.
+- A support bot that reads tickets or docs through abilities and writes responses through approved tools.
+- A personal knowledge agent with guideline-backed memory and a chat UI supplied by the consuming plugin.
+- A code-review or repository agent that uses GitHub abilities without adopting Data Machine pipelines.
+- A Slack, email, or helpdesk assistant that owns its own channel adapter and delegates only the runtime loop to Agents API.
+- A domain expert agent bundled by another plugin, with default memory/guidelines and a constrained tool policy.
+- A WordPress.com-hosted agent that uses wpcom provider/storage adapters while sharing the same public WordPress-shaped contracts.
+
+Agents API should provide the substrate for those products:
+
+- Agent registration and identity.
+- Message/result contracts.
+- Conversation runner contract.
+- Tool declaration and execution contracts.
+- Memory store contract and default memory implementations.
+- Conversation transcript contract.
+- Event sink / streaming / observation contract.
+- Permission ceiling and acting-context primitives.
+
+## What Still Requires Data Machine
+
+Data Machine remains the product layer for automation workflows. Without Data Machine, consumers do not get:
+
+- Flow and pipeline builders.
+- Fetch -> AI -> publish orchestration.
+- Queue modes, config patch queues, and backfill rotation.
+- Jobs, parent/child fan-out, Action Scheduler orchestration, and undo/effect tracking.
+- Fetch/publish/upsert handler ecosystem.
+- Retention tasks and pipeline logs.
+- Data Machine content operations such as alt text, meta descriptions, IndexNow, post/taxonomy/block automation, and pipeline admin UI.
+
+That distinction is the point of the split: Agents API makes agents possible; Data Machine makes repeatable content/data automation products out of agents.

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -61,7 +61,7 @@ class AIConversationLoop {
 		int $max_turns = PluginSettings::DEFAULT_MAX_TURNS,
 		bool $single_turn = false
 	): array {
-		$request = AIConversationRequest::fromRunArgs(
+		$request = AgentConversationRequest::fromRunArgs(
 			$messages,
 			$tools,
 			$provider,
@@ -116,7 +116,7 @@ class AIConversationLoop {
 			return self::normalizeResultForRun( $result, $messages );
 		}
 
-		$result = ( new BuiltInAIConversationRunner() )->run( $request );
+		$result = ( new BuiltInAgentConversationRunner() )->run( $request );
 
 		return self::normalizeResultForRun( $result, $messages );
 	}
@@ -130,7 +130,7 @@ class AIConversationLoop {
 	 */
 	private static function normalizeResultForRun( array $result, array $fallback_messages ): array {
 		try {
-			return AIConversationResult::normalize( $result );
+			return AgentConversationResult::normalize( $result );
 		} catch ( \InvalidArgumentException $e ) {
 			return array(
 				'messages'               => $fallback_messages,

--- a/inc/Engine/AI/AgentConversationRequest.php
+++ b/inc/Engine/AI/AgentConversationRequest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * AI conversation runner request contract.
+ * Agent conversation runner request contract.
  *
  * @package DataMachine\Engine\AI
  */
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Neutral request object for conversation runner implementations.
  */
-class AIConversationRequest {
+class AgentConversationRequest {
 
 	/** @var array Initial conversation messages. */
 	private array $messages;

--- a/inc/Engine/AI/AgentConversationResult.php
+++ b/inc/Engine/AI/AgentConversationResult.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * AI conversation result contract.
+ * Agent conversation result contract.
  *
  * @package DataMachine\Engine\AI
  */
@@ -12,10 +12,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Validates and normalizes AIConversationLoop result arrays.
+ * Validates and normalizes agent conversation result arrays.
  */
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
-class AIConversationResult {
+class AgentConversationResult {
 
 	/**
 	 * Validate and normalize a loop result.
@@ -99,6 +99,6 @@ class AIConversationResult {
 	 * @return \InvalidArgumentException Validation exception.
 	 */
 	private static function invalid( string $path, string $reason ): \InvalidArgumentException {
-		return new \InvalidArgumentException( 'invalid_ai_conversation_result: ' . $path . ' ' . $reason );
+		return new \InvalidArgumentException( 'invalid_agent_conversation_result: ' . $path . ' ' . $reason );
 	}
 }

--- a/inc/Engine/AI/AgentConversationRunnerInterface.php
+++ b/inc/Engine/AI/AgentConversationRunnerInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * AI conversation runner interface.
+ * Agent conversation runner interface.
  *
  * @package DataMachine\Engine\AI
  */
@@ -14,13 +14,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Transport-neutral runner boundary for conversation execution.
  */
-interface AIConversationRunnerInterface {
+interface AgentConversationRunnerInterface {
 
 	/**
 	 * Run an AI conversation request.
 	 *
-	 * @param AIConversationRequest $request Conversation request.
+	 * @param AgentConversationRequest $request Conversation request.
 	 * @return array Raw AIConversationLoop result shape.
 	 */
-	public function run( AIConversationRequest $request ): array;
+	public function run( AgentConversationRequest $request ): array;
 }

--- a/inc/Engine/AI/BuiltInAgentConversationRunner.php
+++ b/inc/Engine/AI/BuiltInAgentConversationRunner.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Built-in AI conversation runner.
+ * Built-in agent conversation runner.
  *
  * @package DataMachine\Engine\AI
  */
@@ -14,15 +14,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Adapter that runs Data Machine's existing conversation loop implementation.
  */
-class BuiltInAIConversationRunner implements AIConversationRunnerInterface {
+class BuiltInAgentConversationRunner implements AgentConversationRunnerInterface {
 
 	/**
 	 * Run an AI conversation request through the legacy loop implementation.
 	 *
-	 * @param AIConversationRequest $request Conversation request.
+	 * @param AgentConversationRequest $request Conversation request.
 	 * @return array Raw AIConversationLoop result shape.
 	 */
-	public function run( AIConversationRequest $request ): array {
+	public function run( AgentConversationRequest $request ): array {
 		$loop = new AIConversationLoop();
 
 		return $loop->execute( ...$request->toLegacyArgs() );

--- a/tests/agent-conversation-result-smoke.php
+++ b/tests/agent-conversation-result-smoke.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Smoke tests for AI conversation result validation.
+ * Smoke tests for agent conversation result validation.
  *
  * @package DataMachine\Tests
  */
@@ -8,7 +8,7 @@
 require_once __DIR__ . '/bootstrap-unit.php';
 
 use DataMachine\Engine\AI\AIConversationLoop;
-use DataMachine\Engine\AI\AIConversationResult;
+use DataMachine\Engine\AI\AgentConversationResult;
 use DataMachine\Engine\AI\MessageEnvelope;
 
 if ( ! function_exists( 'apply_filters' ) ) {
@@ -23,7 +23,7 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	}
 }
 
-function datamachine_ai_conversation_result_assert( bool $condition, string $message ): void {
+function datamachine_agent_conversation_result_assert( bool $condition, string $message ): void {
 	if ( ! $condition ) {
 		throw new RuntimeException( $message );
 	}
@@ -51,13 +51,13 @@ $valid_result = array(
 	'usage'                  => array( 'total_tokens' => 10 ),
 );
 
-$normalized = AIConversationResult::normalize( $valid_result );
-datamachine_ai_conversation_result_assert(
+$normalized = AgentConversationResult::normalize( $valid_result );
+datamachine_agent_conversation_result_assert(
 	MessageEnvelope::TYPE_TEXT === $normalized['messages'][0]['type'],
 	'Valid built-in-shaped result should normalize messages to canonical envelopes.'
 );
 ++$assertions;
-datamachine_ai_conversation_result_assert(
+datamachine_agent_conversation_result_assert(
 	'Done.' === $normalized['messages'][0]['content'],
 	'Canonical envelope preserves message content.'
 );
@@ -65,13 +65,13 @@ datamachine_ai_conversation_result_assert(
 
 $without_tool_results = $valid_result;
 unset( $without_tool_results['tool_execution_results'] );
-$normalized_without_tools = AIConversationResult::normalize( $without_tool_results );
-datamachine_ai_conversation_result_assert(
+$normalized_without_tools = AgentConversationResult::normalize( $without_tool_results );
+datamachine_agent_conversation_result_assert(
 	array_key_exists( 'tool_execution_results', $normalized_without_tools ),
 	'Missing tool_execution_results should normalize to an explicit empty list.'
 );
 ++$assertions;
-datamachine_ai_conversation_result_assert(
+datamachine_agent_conversation_result_assert(
 	array() === $normalized_without_tools['tool_execution_results'],
 	'Normalized tool_execution_results should be empty.'
 );
@@ -81,11 +81,11 @@ $malformed_tool_result = $valid_result;
 unset( $malformed_tool_result['tool_execution_results'][0]['parameters'] );
 
 try {
-	AIConversationResult::normalize( $malformed_tool_result );
+	AgentConversationResult::normalize( $malformed_tool_result );
 	throw new RuntimeException( 'Malformed tool result should throw.' );
 } catch ( InvalidArgumentException $e ) {
-	datamachine_ai_conversation_result_assert(
-		str_contains( $e->getMessage(), 'invalid_ai_conversation_result: tool_execution_results[0].parameters' ),
+	datamachine_agent_conversation_result_assert(
+		str_contains( $e->getMessage(), 'invalid_agent_conversation_result: tool_execution_results[0].parameters' ),
 		'Malformed tool result should include a machine-readable field path.'
 	);
 	++$assertions;
@@ -95,11 +95,11 @@ $missing_messages = $valid_result;
 unset( $missing_messages['messages'] );
 
 try {
-	AIConversationResult::normalize( $missing_messages );
+	AgentConversationResult::normalize( $missing_messages );
 	throw new RuntimeException( 'Missing messages should throw.' );
 } catch ( InvalidArgumentException $e ) {
-	datamachine_ai_conversation_result_assert(
-		str_contains( $e->getMessage(), 'invalid_ai_conversation_result: messages' ),
+	datamachine_agent_conversation_result_assert(
+		str_contains( $e->getMessage(), 'invalid_agent_conversation_result: messages' ),
 		'Missing messages should include a machine-readable field path.'
 	);
 	++$assertions;
@@ -109,11 +109,11 @@ $malformed_message = $valid_result;
 $malformed_message['messages'][0] = 'not a message array';
 
 try {
-	AIConversationResult::normalize( $malformed_message );
+	AgentConversationResult::normalize( $malformed_message );
 	throw new RuntimeException( 'Malformed message should throw.' );
 } catch ( InvalidArgumentException $e ) {
-	datamachine_ai_conversation_result_assert(
-		str_contains( $e->getMessage(), 'invalid_ai_conversation_result: messages[0]' ),
+	datamachine_agent_conversation_result_assert(
+		str_contains( $e->getMessage(), 'invalid_agent_conversation_result: messages[0]' ),
 		'Malformed message should include a machine-readable field path.'
 	);
 	++$assertions;
@@ -130,17 +130,17 @@ $runner_result = AIConversationLoop::run(
 	1
 );
 
-datamachine_ai_conversation_result_assert(
+datamachine_agent_conversation_result_assert(
 	isset( $runner_result['error'] ),
 	'Malformed runner output should return an explicit AI loop error.'
 );
 ++$assertions;
-datamachine_ai_conversation_result_assert(
-	str_contains( $runner_result['error'], 'invalid_ai_conversation_result: tool_execution_results[0].parameters' ),
+datamachine_agent_conversation_result_assert(
+	str_contains( $runner_result['error'], 'invalid_agent_conversation_result: tool_execution_results[0].parameters' ),
 	'Runner validation error should preserve the machine-readable field path.'
 );
 ++$assertions;
-datamachine_ai_conversation_result_assert(
+datamachine_agent_conversation_result_assert(
 	array() === $runner_result['tool_execution_results'],
 	'Runner validation failure should expose an empty tool result list.'
 );
@@ -157,15 +157,15 @@ $runner_valid_result = AIConversationLoop::run(
 	1
 );
 
-datamachine_ai_conversation_result_assert(
+datamachine_agent_conversation_result_assert(
 	! isset( $runner_valid_result['error'] ),
 	'Valid runner output should not become an error result.'
 );
 ++$assertions;
-datamachine_ai_conversation_result_assert(
+datamachine_agent_conversation_result_assert(
 	true === $runner_valid_result['tool_execution_results'][0]['is_handler_tool'],
 	'Valid handler-tool output should preserve handler-tool metadata.'
 );
 ++$assertions;
 
-echo 'AI conversation result smoke passed (' . $assertions . " assertions).\n";
+echo 'Agent conversation result smoke passed (' . $assertions . " assertions).\n";

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Smoke test for the AI conversation request/runner boundary.
+ * Smoke test for the agent conversation request/runner boundary.
  *
- * Run with: php tests/ai-conversation-runner-request-smoke.php
+ * Run with: php tests/agent-conversation-runner-request-smoke.php
  *
  * @package DataMachine\Tests
  */
@@ -50,7 +50,7 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 require_once __DIR__ . '/bootstrap-unit.php';
 
 use DataMachine\Engine\AI\AIConversationLoop;
-use DataMachine\Engine\AI\AIConversationRequest;
+use DataMachine\Engine\AI\AgentConversationRequest;
 use DataMachine\Engine\AI\LoopEventSinkInterface;
 
 class RunnerRequestSmokeSink implements LoopEventSinkInterface {
@@ -103,7 +103,7 @@ $payload  = array(
 );
 
 // 1. The request object exposes generic runner inputs and Data Machine adapter context.
-$request = AIConversationRequest::fromRunArgs(
+$request = AgentConversationRequest::fromRunArgs(
 	$messages,
 	$tools,
 	'openai',
@@ -197,4 +197,4 @@ if ( runner_request_failure_count() > 0 ) {
 	exit( 1 );
 }
 
-echo "\nAll AI conversation runner request smoke tests passed.\n";
+echo "\nAll agent conversation runner request smoke tests passed.\n";

--- a/tests/ai-message-envelope-smoke.php
+++ b/tests/ai-message-envelope-smoke.php
@@ -9,7 +9,7 @@
 
 require_once __DIR__ . '/bootstrap-unit.php';
 
-use DataMachine\Engine\AI\AIConversationResult;
+use DataMachine\Engine\AI\AgentConversationResult;
 use DataMachine\Engine\AI\ConversationManager;
 use DataMachine\Engine\AI\MessageEnvelope;
 
@@ -150,7 +150,7 @@ $multimodal_envelope = MessageEnvelope::normalize( $multimodal_legacy );
 datamachine_message_envelope_assert( MessageEnvelope::TYPE_MULTIMODAL_PART === $multimodal_envelope['type'], 'Array content infers multimodal_part type.' );
 datamachine_message_envelope_count();
 
-$result = AIConversationResult::normalize(
+$result = AgentConversationResult::normalize(
 	array(
 		'messages'               => array( $typed_final_result ),
 		'final_content'          => 'Finished.',
@@ -162,7 +162,7 @@ $result = AIConversationResult::normalize(
 	)
 );
 
-datamachine_message_envelope_assert( MessageEnvelope::TYPE_FINAL_RESULT === $result['messages'][0]['type'], 'AIConversationResult accepts typed envelopes and returns canonical envelopes.' );
+datamachine_message_envelope_assert( MessageEnvelope::TYPE_FINAL_RESULT === $result['messages'][0]['type'], 'AgentConversationResult accepts typed envelopes and returns canonical envelopes.' );
 datamachine_message_envelope_count();
 
 try {


### PR DESCRIPTION
## Summary
- Rename the neutral conversation runner seam from `AIConversation*` to `AgentConversation*` while keeping `AIConversationLoop` as the compatibility facade.
- Add a pre-extraction audit documenting the remaining in-place Agents API boundary work and what Agents API enables without Data Machine.
- Update extraction/message docs and smoke tests for the new seam names.

## Tests
- `php tests/agent-conversation-result-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`
- `php tests/ai-message-envelope-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-in-place --changed-since origin/main --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing the remaining Agents API/Data Machine boundary, applying the in-place rename slice, writing the pre-extraction audit doc, and running focused verification. Chris remains responsible for review and merge decisions.