### PR TITLE
docs(ai): clarify conversation transcript storage boundary

### DIFF
--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -14,7 +14,7 @@ Mirror the WordPress Abilities API shape instead of importing Data Machine, wpco
 | `AgentRegistry` | `WP_Agents_Registry` | Registry should collect definitions. Persistence/adoption can remain adapter territory. |
 | `datamachine_register_agents` | `wp_agents_api_init` or `wp_register_agents` | Prefer a core-shaped init hook; exact name needs review against Abilities API precedent. |
 | `MessageEnvelope` | `WP_Agent_Message` or neutral envelope | Contract is generic. Data Machine schema/name is not. |
-| `ConversationStoreInterface` | `WP_Agent_Conversation_Store_Interface` | Keep transcript/session/read-state split if it remains boring. |
+| `ConversationTranscriptStoreInterface` | `WP_Agent_Conversation_Transcript_Store_Interface` | Transcript CRUD is the first extractable storage contract. Keep chat-product listing/read-state/reporting separate. |
 | `AgentMemoryStoreInterface` | `WP_Agent_Memory_Store_Interface` | Generic identity tuple needs naming review; Data Machine scaffolding/abilities stay outside the store contract. |
 | `RuntimeToolDeclaration` | `WP_Agent_Tool_Declaration` | Should stay ability-native and run-scoped. |
 | `LoopEventSinkInterface` | `WP_Agent_Run_Event_Sink_Interface` | Useful for logs, streaming, chat UIs, and async workers. |
@@ -33,7 +33,7 @@ Use these checks before moving anything:
 
 | Bucket | Meaning | Current examples |
 |---|---|---|
-| Agents API public candidate | Generic WordPress-shaped contract or value object. | Message envelopes, conversation store interfaces, memory store interface, runtime tool declaration validation, agent registration vocabulary. |
+| Agents API public candidate | Generic WordPress-shaped contract or value object. | Message envelopes, transcript store interface, memory store interface, runtime tool declaration validation, agent registration vocabulary. |
 | Agents API implementation candidate | Generic implementation, but naming or assumptions need cleanup first. | Built-in loop, request assembly, tool executor, guideline memory store, directive renderer. |
 | Data Machine adapter | Glue that turns flows/jobs/pipelines into generic runtime inputs. | `AIStep`, pipeline tool-policy args, transcript persistence policy, adjacent handler tools. |
 | Data Machine product | Data Machine automation/product layer. | Jobs, flows, pipelines, handlers, queues, retention, content abilities, admin UI. |
@@ -56,13 +56,14 @@ These are closest to generic public contracts. Most should be extracted as contr
 | `AgentMemoryReadResult` | `inc/Core/FilesRepository/AgentMemoryReadResult.php` | Store-neutral read result. | Generic result value object can move unchanged after naming cleanup. |
 | `AgentMemoryWriteResult` | `inc/Core/FilesRepository/AgentMemoryWriteResult.php` | Store-neutral write result with hash/bytes/error shape. | Generic result value object can move unchanged after naming cleanup. |
 | `AgentMemoryListEntry` | `inc/Core/FilesRepository/AgentMemoryListEntry.php` | Store-neutral list entry. | Good candidate if file-backed memory stays in scope. |
-| `ConversationTranscriptStoreInterface` | `inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php` | Transcript CRUD is generic conversation persistence. | Rename chat/session wording to agent conversation wording where appropriate. |
-| `ConversationSessionIndexInterface` | `inc/Core/Database/Chat/ConversationSessionIndexInterface.php` | Conversation listing is generic. | Keep `(user_id, agent_id, context)` only if Agents API adopts that identity model. |
-| `ConversationReadStateInterface` | `inc/Core/Database/Chat/ConversationReadStateInterface.php` | Read-state is generic session UI behavior. | Could be optional interface in Agents API. |
-| `ConversationRetentionInterface` | `inc/Core/Database/Chat/ConversationRetentionInterface.php` | Cleanup contract is generic, but scheduling is not. | Interface may move; Data Machine retention tasks stay product. |
-| `ConversationReportingInterface` | `inc/Core/Database/Chat/ConversationReportingInterface.php` | Metrics/reporting reads are generic. | Could be optional interface in Agents API. |
-| `ConversationStoreInterface` | `inc/Core/Database/Chat/ConversationStoreInterface.php` | Aggregate conversation store contract. | Extract after deciding whether the aggregate remains public or only narrow interfaces move. |
-| `datamachine_conversation_store` filter | `ConversationStoreFactory::get()` | Store swap seam is generic. | Target should be an Agents API store resolver/filter. |
+| `ConversationTranscriptStoreInterface` | `inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php` | Transcript CRUD is generic conversation persistence. | First extraction candidate. Rename namespace/vocabulary later; do not require chat UI listing/read-state/reporting for transcript-only backends. |
+| `ConversationSessionIndexInterface` | `inc/Core/Database/Chat/ConversationSessionIndexInterface.php` | Session listing can be generic for UIs, but it is not required for transcript persistence. | Treat as optional until Agents API adopts an identity/listing model. Data Machine chat switcher uses it today. |
+| `ConversationReadStateInterface` | `inc/Core/Database/Chat/ConversationReadStateInterface.php` | Read-state is generic UI behavior, not transcript CRUD. | Optional interface at most. Data Machine chat unread state keeps consuming it. |
+| `ConversationRetentionInterface` | `inc/Core/Database/Chat/ConversationRetentionInterface.php` | Cleanup methods can be backend-generic, but retention policy/scheduling is product behavior. | Data Machine retention tasks stay product; future Agents API may expose only optional backend cleanup. |
+| `ConversationReportingInterface` | `inc/Core/Database/Chat/ConversationReportingInterface.php` | Metrics/reporting reads are useful but product-shaped today. | Optional interface at most. Data Machine daily memory and retention CLI keep consuming it. |
+| `ConversationStoreInterface` | `inc/Core/Database/Chat/ConversationStoreInterface.php` | Aggregate Data Machine chat-product compatibility contract. | Do not extract as the default public contract unless Agents API deliberately wants the full aggregate. Prefer the transcript interface first. |
+| `ConversationStoreFactory::get_transcript_store()` | `inc/Core/Database/Chat/ConversationStoreFactory.php` | Narrow resolver for runtime transcript persistence. | Current implementation reuses the Data Machine aggregate filter for compatibility; future Agents API can own a transcript-specific resolver/filter. |
+| `datamachine_conversation_store` filter | `ConversationStoreFactory::get()` | Existing Data Machine aggregate store swap seam. | Keep while code lives in Data Machine. A future Agents API filter should not force chat UI/listing/read-state/reporting responsibilities onto transcript-only backends. |
 | `datamachine_conversation_runner` filter | `AIConversationLoop::run()` | Runner replacement seam is generic. | Target should be a runtime runner interface/filter, not Data Machine named. |
 | `datamachine_guideline_updated` action | `GuidelineAgentMemoryStore` | Logical memory/guideline change event is generic. | Target event must not assume Data Machine option names or storage. |
 | `datamachine_register_agent()` helper | `inc/Engine/Agents/register-agents.php` | Declarative agent registration is core-shaped. | Public helper should become `wp_register_agent()`; persistence reconciliation should not be part of the helper contract. |
@@ -125,6 +126,21 @@ These should stay in Data Machine as compatibility glue if a generic runtime plu
 | `Api\Agents`, `Api\AgentFiles`, `Api\AgentPing` | `inc/Api/` | Current REST routes are Data Machine API shape. They can adapt to future `wp-agents/v1` contracts. |
 | `AgentsCommand`, `MemoryCommand` | `inc/Cli/Commands/` | Operator CLI wrapping current Data Machine repositories and abilities. Generic WP-CLI commands should be designed separately. |
 
+## Conversation Storage Boundary
+
+Conversation storage is split in place, but only the narrow transcript surface is ready to treat as a generic Agents API candidate.
+
+| Layer | Current surface | Boundary decision |
+|---|---|---|
+| Generic transcript CRUD | `ConversationTranscriptStoreInterface`, `ConversationStoreFactory::get_transcript_store()` | Candidate for Agents API ownership. Runtime persistence should depend on this surface when it only needs complete transcript sessions. |
+| Data Machine compatibility aggregate | `ConversationStoreInterface`, `ConversationStoreFactory::get()`, `datamachine_conversation_store` | Stays in Data Machine for now so chat UI, REST, CLI, retention, and reporting keep one behavior-preserving resolver. |
+| Chat UI/session switcher | `ConversationSessionIndexInterface`, chat REST/abilities/UI callers | Product behavior today. It may become an optional Agents API UI contract later, but transcript-only backends should not implement it by default. |
+| Read state | `ConversationReadStateInterface` | Optional UI behavior. Not part of transcript persistence. |
+| Retention | `ConversationRetentionInterface`, retention system tasks/CLI | Backend cleanup methods may be generic, but scheduling and retention policy are Data Machine product. |
+| Reporting | `ConversationReportingInterface`, daily memory/retention status readers | Product-shaped metrics today. Keep separate from transcript CRUD. |
+
+Do not decide an `agents_session` CPT, wpcom `Conversation_Storage`, or a new Agents API filter name in this in-place clarification. The current goal is only to make the dependency direction obvious: Data Machine chat product consumes transcript persistence; transcript persistence does not require Data Machine chat product behavior.
+
 ## Data Machine Product
 
 These should stay in Data Machine. They may consume Agents API later, but should not move into it.
@@ -172,7 +188,7 @@ These are reference points only. Do not expose them as public Data Machine or Ag
 | Hook/filter | Bucket | Notes |
 |---|---|---|
 | `datamachine_conversation_runner` | Agents API public candidate | Generic runtime replacement seam. Rename and formalize result contract. |
-| `datamachine_conversation_store` | Agents API public candidate | Generic conversation persistence swap seam. Rename and keep narrow contracts. |
+| `datamachine_conversation_store` | Data Machine compatibility seam today | Existing aggregate store swap seam. A future Agents API transcript-store filter should be narrower instead of carrying Data Machine chat product responsibilities. |
 | `datamachine_memory_store` | Agents API public candidate | Generic memory persistence swap seam. Keep as Data Machine's current public behavior until extraction; introduce a neutral Agents API filter only when that package owns the resolver and migration path. |
 | `datamachine_register_agents` | Agents API public candidate | Registration hook should become WordPress-shaped. |
 | `datamachine_registered_agent_reconciled` | Agents API implementation candidate | Lifecycle event is useful, current reconciliation semantics are Data Machine implementation. |
@@ -194,7 +210,7 @@ These tests currently pin the substrate most relevant to extraction.
 |---|---|---|
 | `tests/ai-message-envelope-smoke.php` | Message envelope normalization/projection and result validation. | Move with message/result contracts. |
 | `tests/agent-conversation-result-smoke.php` | Conversation result shape validation. | Move with runner result contract. |
-| `tests/conversation-store-contracts-smoke.php` | Split store interfaces and factory return type. | Move with conversation store contracts. |
+| `tests/conversation-store-contracts-smoke.php` | Split store interfaces, transcript-only method boundary, and factory return types. | Move transcript CRUD coverage with the generic contract; keep aggregate/product assertions with Data Machine. |
 | `tests/guideline-agent-memory-store-smoke.php` | Optional guideline-backed memory implementation. | Move or duplicate if Agents API ships memory store implementations. |
 | `tests/daily-memory-store-seam-smoke.php` | Daily memory through memory store seam. | Data Machine product consuming generic memory store. |
 | `tests/agent-memory-events-smoke.php` | Memory/guideline change events. | Move event contract after naming review. |

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -13,7 +13,7 @@ The initial untangling wave is complete:
 - Ability-native tool execution is separated from Data Machine pending-action and post-tracking decorators.
 - Declarative agent registration is separated from Data Machine materialization.
 - Memory store ownership is documented behind a neutral store contract.
-- Conversation transcript storage is narrowed behind a transcript facade.
+- Conversation transcript storage is narrowed behind a transcript facade, and the aggregate chat-product store is documented as a Data Machine compatibility layer rather than the default extraction target.
 - The runner request boundary exists.
 
 This branch starts the naming phase by renaming the neutral runner result/request seam from `AIConversation*` to `AgentConversation*` while leaving `AIConversationLoop` as the temporary compatibility facade.
@@ -61,13 +61,14 @@ Target shape:
 
 ### 4. Conversation Storage Boundary
 
-The transcript interfaces are now separated, but the storage implementation still lives under `Core\Database\Chat` and the aggregate store includes chat UI concerns.
+The transcript interface is now separated from the aggregate chat-product store. The implementation still lives under `Core\Database\Chat` while extraction is in-place, but the dependency direction is explicit: runtime transcript persistence depends on `ConversationTranscriptStoreInterface`, while Data Machine chat UI/REST/CLI/retention/reporting depend on the broader `ConversationStoreInterface` aggregate.
 
 Target shape:
 
 - Extract transcript CRUD first.
 - Keep read state, reporting, retention, and session list behavior optional or Data Machine-owned until proven generic.
 - Keep Data Machine chat UI as product surface.
+- Do not expose `datamachine_conversation_store` as the future Agents API transcript filter without narrowing its contract; it currently requires the Data Machine aggregate for behavior compatibility.
 
 ### 5. Memory Store Boundary
 

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -20,12 +20,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Chat Database Manager
+ * Data Machine chat database manager.
  *
- * Implements {@see ConversationStoreInterface} so the conversation
- * storage backend can be swapped via the `datamachine_conversation_store`
- * filter. Resolve via {@see ConversationStoreFactory::get()} rather than
- * instantiating this class directly.
+ * Implements the full {@see ConversationStoreInterface} aggregate for the
+ * Data Machine chat product: transcript CRUD, session switcher indexes,
+ * read state, retention cleanup, and reporting. Runtime code that only needs
+ * transcript persistence should depend on
+ * {@see ConversationTranscriptStoreInterface} via
+ * {@see ConversationStoreFactory::get_transcript_store()}.
  */
 class Chat extends BaseRepository implements ConversationStoreInterface {
 

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -904,8 +904,12 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	public function cleanup_old_sessions( int $retention_days ): int {
 		global $wpdb;
 
-		$table_name  = self::get_prefixed_table_name();
-		$cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$retention_days} days" ) );
+		$table_name       = self::get_prefixed_table_name();
+		$cutoff_timestamp = strtotime( "-{$retention_days} days" );
+		if ( false === $cutoff_timestamp ) {
+			return 0;
+		}
+		$cutoff_date = gmdate( 'Y-m-d H:i:s', $cutoff_timestamp );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$deleted = $wpdb->query(
@@ -956,8 +960,12 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			return 0;
 		}
 
-		$table_name  = self::get_prefixed_table_name();
-		$cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$retention_days} days" ) );
+		$table_name       = self::get_prefixed_table_name();
+		$cutoff_timestamp = strtotime( "-{$retention_days} days" );
+		if ( false === $cutoff_timestamp ) {
+			return 0;
+		}
+		$cutoff_date = gmdate( 'Y-m-d H:i:s', $cutoff_timestamp );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$deleted = $wpdb->query(

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -20,14 +20,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Data Machine chat database manager.
+ * Chat Database Manager
  *
- * Implements the full {@see ConversationStoreInterface} aggregate for the
- * Data Machine chat product: transcript CRUD, session switcher indexes,
- * read state, retention cleanup, and reporting. Runtime code that only needs
- * transcript persistence should depend on
- * {@see ConversationTranscriptStoreInterface} via
- * {@see ConversationStoreFactory::get_transcript_store()}.
+ * Implements {@see ConversationStoreInterface} so the conversation
+ * storage backend can be swapped via the `datamachine_conversation_store`
+ * filter. Resolve via {@see ConversationStoreFactory::get()} rather than
+ * instantiating this class directly.
  */
 class Chat extends BaseRepository implements ConversationStoreInterface {
 
@@ -904,12 +902,8 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	public function cleanup_old_sessions( int $retention_days ): int {
 		global $wpdb;
 
-		$table_name       = self::get_prefixed_table_name();
-		$cutoff_timestamp = strtotime( "-{$retention_days} days" );
-		if ( false === $cutoff_timestamp ) {
-			return 0;
-		}
-		$cutoff_date = gmdate( 'Y-m-d H:i:s', $cutoff_timestamp );
+		$table_name  = self::get_prefixed_table_name();
+		$cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$retention_days} days" ) );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$deleted = $wpdb->query(
@@ -960,12 +954,8 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			return 0;
 		}
 
-		$table_name       = self::get_prefixed_table_name();
-		$cutoff_timestamp = strtotime( "-{$retention_days} days" );
-		if ( false === $cutoff_timestamp ) {
-			return 0;
-		}
-		$cutoff_date = gmdate( 'Y-m-d H:i:s', $cutoff_timestamp );
+		$table_name  = self::get_prefixed_table_name();
+		$cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$retention_days} days" ) );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$deleted = $wpdb->query(

--- a/inc/Core/Database/Chat/ConversationStoreFactory.php
+++ b/inc/Core/Database/Chat/ConversationStoreFactory.php
@@ -2,13 +2,15 @@
 /**
  * Conversation Store Factory
  *
- * Resolves the active {@see ConversationStoreInterface} implementation
- * via the `datamachine_conversation_store` filter, falling back to the
- * built-in {@see Chat} MySQL-table store.
+ * Resolves the active Data Machine {@see ConversationStoreInterface}
+ * aggregate via the `datamachine_conversation_store` filter, falling back
+ * to the built-in {@see Chat} MySQL-table store.
  *
- * Single resolution point so every consumer (ChatOrchestrator, the
- * Chat Session abilities trait, ChatCommand, SystemAbilities) gets the
- * same swap mechanism without duplicating the filter call.
+ * Single resolution point so every aggregate consumer (ChatOrchestrator, the
+ * Chat Session abilities trait, ChatCommand, SystemAbilities) gets the same
+ * swap mechanism without duplicating the filter call. Runtime code that only
+ * persists transcripts should use {@see self::get_transcript_store()} to depend
+ * on the narrow generic contract instead of the Data Machine chat aggregate.
  *
  * Instances are resolved once per request and cached, mirroring how a
  * single `new ChatDatabase()` per callsite behaved before — no behavior
@@ -32,7 +34,7 @@ class ConversationStoreFactory {
 	private static ?ConversationStoreInterface $instance = null;
 
 	/**
-	 * Resolve the active conversation store.
+	 * Resolve the active Data Machine aggregate conversation store.
 	 *
 	 * First call runs the filter and caches the result. Subsequent calls
 	 * within the same request return the cached instance. Use
@@ -48,7 +50,7 @@ class ConversationStoreFactory {
 		$default = new Chat();
 
 		/**
-		 * Filter: swap the chat conversation persistence backend.
+		 * Filter: swap the Data Machine chat conversation persistence backend.
 		 *
 		 * Return a {@see ConversationStoreInterface} aggregate to short-circuit
 		 * the default MySQL-table store. Return the default (or anything not
@@ -70,9 +72,12 @@ class ConversationStoreFactory {
 		 *     }, 10, 1 );
 		 *
 		 * The store MUST normalize messages on read to Data Machine message
-		 * shape. Implementations that only need a slice of the store surface can
-		 * target the narrower contracts, but this filter still expects the full
-		 * aggregate for behavior compatibility.
+		 * shape. Implementations that only need transcript CRUD should target
+		 * {@see ConversationTranscriptStoreInterface}; this legacy Data Machine
+		 * filter still expects the full aggregate so chat UI, REST, CLI, retention,
+		 * and reporting callers keep their existing behavior. A future Agents API
+		 * resolver can expose a narrower transcript-store filter without carrying
+		 * those Data Machine product responsibilities.
 		 *
 		 * @since next
 		 *
@@ -100,12 +105,12 @@ class ConversationStoreFactory {
 	}
 
 	/**
-	 * Resolve the active transcript store.
+	 * Resolve the active generic transcript store.
 	 *
-	 * This intentionally reuses the aggregate store/filter resolution so the
-	 * existing `datamachine_conversation_store` seam and chat UI callers keep
-	 * their current behavior while runtime transcript persistence depends only
-	 * on the narrow CRUD contract.
+	 * This intentionally reuses the aggregate store/filter resolution while the
+	 * code lives in Data Machine. The returned type is the extraction boundary:
+	 * runtime transcript persistence depends only on CRUD, not Data Machine's
+	 * chat session index, read-state, retention, or reporting product surface.
 	 *
 	 * @return ConversationTranscriptStoreInterface
 	 */

--- a/inc/Core/Database/Chat/ConversationStoreInterface.php
+++ b/inc/Core/Database/Chat/ConversationStoreInterface.php
@@ -1,18 +1,21 @@
 <?php
 /**
- * Aggregate conversation store contract.
+ * Data Machine aggregate conversation store contract.
  *
- * Single seam between chat session operations and the underlying
- * persistence backend. Default implementation ({@see Chat}) preserves
- * today's MySQL-table behavior. Consumers can swap in an alternate
+ * Compatibility seam between Data Machine chat-product operations and the
+ * underlying persistence backend. Default implementation ({@see Chat})
+ * preserves today's MySQL-table behavior. Consumers can swap in an alternate
  * aggregate store via the `datamachine_conversation_store` filter.
  *
- * The narrower contracts this interface composes are the reusable seams
- * for future adapters that only own part of the conversation surface:
- * transcript/session CRUD, session indexes, read state, retention cleanup,
- * and reporting/metrics. Existing callers still request the aggregate via
- * {@see ConversationStoreFactory::get()}, so this split is a contract
- * clarification with no behavior change.
+ * This aggregate is intentionally broader than the generic Agents API storage
+ * candidate. {@see ConversationTranscriptStoreInterface} is the narrow generic
+ * transcript CRUD seam. The other composed interfaces are Data Machine chat
+ * product surfaces today: session switcher indexes, read state, retention
+ * cleanup, and reporting/metrics. They may become optional Agents API
+ * contracts later, but they are not required for a transcript-only backend.
+ * Existing chat UI, REST, CLI, and retention callers still request the
+ * aggregate via {@see ConversationStoreFactory::get()}, so this split is a
+ * contract clarification with no behavior change.
  *
  * Implementations are responsible for:
  * - normalizing messages on read to Data Machine's canonical AI message envelope
@@ -20,11 +23,12 @@
  * - preserving per-session identity via UUIDv4 session IDs;
  * - honoring the `(user_id, agent_id, context)` triple when listing.
  *
- * Session-scope policy (ownership checks, token resolution, agent
- * adoption, title generation) stays in the higher-level callers
+ * Session-scope policy (ownership checks, token resolution, agent adoption,
+ * listing visibility, title generation, retention schedules) stays in the
+ * higher-level Data Machine callers
  * ({@see \DataMachine\Api\Chat\ChatOrchestrator},
  * {@see \DataMachine\Abilities\Chat\ChatSessionHelpers}). The store
- * is the dumb persistence layer underneath.
+ * is the dumb persistence layer underneath those product policies.
  *
  * @package DataMachine\Core\Database\Chat
  * @since   next

--- a/inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php
+++ b/inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php
@@ -1,11 +1,17 @@
 <?php
 /**
- * Conversation transcript store contract.
+ * Agent conversation transcript persistence contract.
  *
- * Covers session row creation, transcript reads/writes, title updates,
- * and retry deduplication. Backends that only need to persist complete
- * conversation transcripts can implement this contract without taking on
- * list, read-state, retention, or metrics responsibilities.
+ * This is the narrow, generic storage seam for complete conversation
+ * transcripts. It covers session row creation, transcript reads/writes,
+ * deletion, retry deduplication, and the stored display title that belongs
+ * to a transcript row. It deliberately does not include chat UI listing,
+ * read-state, retention scheduling, or reporting/metrics responsibilities.
+ *
+ * The interface still lives under the Data Machine chat namespace while the
+ * Agents API extraction is in-place. Conceptually, this is the contract that
+ * a future Agents API package can own; Data Machine's chat product consumes it
+ * through {@see ConversationStoreInterface} and {@see ConversationStoreFactory}.
  *
  * @package DataMachine\Core\Database\Chat
  * @since   next
@@ -18,18 +24,18 @@ defined( 'ABSPATH' ) || exit;
 interface ConversationTranscriptStoreInterface {
 
 	/**
-	 * Create a new chat session and return its ID.
+	 * Create a new conversation transcript session and return its ID.
 	 *
 	 * @param int    $user_id  WordPress user ID owning the session.
 	 * @param int    $agent_id Agent ID (0 = legacy agent-less session).
 	 * @param array  $metadata Arbitrary session metadata (JSON-serializable).
-	 * @param string $context  Execution context ('chat', 'pipeline', 'system').
+	 * @param string $context  Execution mode ('chat', 'pipeline', 'system').
 	 * @return string Session ID (UUIDv4), or empty string on failure.
 	 */
 	public function create_session( int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string;
 
 	/**
-	 * Retrieve a session by ID.
+	 * Retrieve a transcript session by ID.
 	 *
 	 * Returns the session as an associative array with keys:
 	 * session_id, user_id, agent_id, title, messages (decoded array),
@@ -78,7 +84,10 @@ interface ConversationTranscriptStoreInterface {
 	public function get_recent_pending_session( int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array;
 
 	/**
-	 * Set a session's display title.
+	 * Set a transcript session's stored display title.
+	 *
+	 * Title generation and UI policy stay above the store. This mutator remains
+	 * here because the persisted title is part of the transcript/session record.
 	 *
 	 * @param string $session_id Session UUID.
 	 * @param string $title      New title.

--- a/tests/conversation-store-contracts-smoke.php
+++ b/tests/conversation-store-contracts-smoke.php
@@ -61,6 +61,29 @@ foreach ( $narrow_contracts as $contract ) {
 	$assert_true( $aggregate->implementsInterface( $contract ), "aggregate composes {$contract}" );
 }
 
+$transcript_ref = new ReflectionClass( ConversationTranscriptStoreInterface::class );
+$assert_true( ! $transcript_ref->implementsInterface( ConversationSessionIndexInterface::class ), 'transcript contract does not include session index surface' );
+$assert_true( ! $transcript_ref->implementsInterface( ConversationReadStateInterface::class ), 'transcript contract does not include read-state surface' );
+$assert_true( ! $transcript_ref->implementsInterface( ConversationRetentionInterface::class ), 'transcript contract does not include retention surface' );
+$assert_true( ! $transcript_ref->implementsInterface( ConversationReportingInterface::class ), 'transcript contract does not include reporting surface' );
+
+$transcript_methods = array_map(
+	static fn( ReflectionMethod $method ): string => $method->getName(),
+	$transcript_ref->getMethods()
+);
+sort( $transcript_methods );
+$assert_true(
+	array(
+		'create_session',
+		'delete_session',
+		'get_recent_pending_session',
+		'get_session',
+		'update_session',
+		'update_title',
+	) === $transcript_methods,
+	'transcript contract stays limited to transcript/session CRUD methods'
+);
+
 foreach ( $narrow_contracts as $contract ) {
 	$chat_ref = new ReflectionClass( Chat::class );
 	$test_ref = new ReflectionClass( InMemoryConversationStore::class );


### PR DESCRIPTION
## Summary
- Clarifies that `ConversationTranscriptStoreInterface` is the narrow generic transcript CRUD candidate for Agents API extraction.
- Documents `ConversationStoreInterface` / `datamachine_conversation_store` as Data Machine chat-product compatibility surfaces for UI, read state, retention, and reporting.
- Strengthens the conversation-store smoke test to pin the transcript-only method boundary.

## Tests
- `php tests/conversation-store-contracts-smoke.php` — passed.
- `php -l inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php && php -l inc/Core/Database/Chat/ConversationStoreInterface.php && php -l inc/Core/Database/Chat/ConversationStoreFactory.php && php -l tests/conversation-store-contracts-smoke.php` — passed.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-conversation-store --changed-since origin/main --summary` — passed; 4 PHP files analyzed, no findings, no baseline drift.
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@agents-api-conversation-store --changed-since origin/main --summary` — failed in the current Homeboy test harness with 578 tests selected, 16 errors, 17 failures.

Main-branch comparison:

- Created clean comparison worktree `/Users/chubes/Developer/data-machine@agents-api-conversation-store-main-compare` from `origin/main` (`dd0c87bd`).
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@agents-api-conversation-store-main-compare --changed-since origin/main --summary` — passed with 0 impacted tests selected.
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@agents-api-conversation-store-main-compare --summary` — failed on `origin/main` with 1212 tests, 18 errors, 30 failures.
- The PR changed-since failure is the existing broader test-suite drift being selected by Homeboy's changed-test surface, not runtime changes in this PR; `Chat.php` runtime edits were removed from the branch.

Closes #1591

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the boundary clarification, smoke-test assertions, and PR/test workflow. Chris remains responsible for review and merge.
