### PR TITLE
refactor(ai): rename message envelope vocabulary

### DIFF
--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -227,7 +227,7 @@ Data Machine makes no assumptions about how the adapter produces that result.
 A consumer can delegate to any external runtime — its own `Agent` subclass, a
 remote RPC service, a different language — as long as the return shape is
 honored. Returned messages may use the legacy `role/content/metadata` shape or
-the versioned [AI Message Envelope](./ai-message-envelope.md); Data Machine
+the versioned [Agent Message Envelope](./ai-message-envelope.md); Data Machine
 normalizes every returned message to the canonical envelope before callers store
 or render the result. Provider-specific `role/content/metadata` arrays are now a
 projection at the provider boundary, not the runtime/storage contract.

--- a/docs/core-system/ai-message-envelope.md
+++ b/docs/core-system/ai-message-envelope.md
@@ -1,18 +1,17 @@
-# AI Message Envelope
+# Agent Message Envelope
 
-**File**: `/inc/Engine/AI/MessageEnvelope.php`
+**File**: `/inc/Engine/AI/AgentMessageEnvelope.php`
 
-Data Machine's canonical internal AI message shape is a JSON-friendly typed
-envelope. Runtime code, chat storage, and transcript storage should store and
-return envelopes. Provider-specific `role/content/metadata` arrays are a
-projection used at the current `ai-http-client` boundary, not the internal
-contract.
+The canonical agent message shape is a JSON-friendly typed envelope. Runtime
+code, chat storage, and transcript storage should store and return envelopes.
+Provider-specific `role/content/metadata` arrays are a projection used at the
+current `ai-http-client` boundary, not the internal contract.
 
 ## Envelope Shape
 
 ```php
 [
-    'schema'   => 'datamachine.ai.message',
+    'schema'   => 'agents-api.message',
     'version'  => 1,
     'type'     => 'text',
     'role'     => 'assistant',
@@ -39,22 +38,23 @@ Supported `type` values:
 - `delta`
 - `multimodal_part`
 
-Use `payload` for type-specific fields that Data Machine understands, such as
-tool names, tool parameters, turn numbers, and tool result data. Use `metadata`
-for extension/provider details that should be preserved but are not part of the
-type contract.
+Use `payload` for type-specific fields that the agent runtime understands, such
+as tool names, tool parameters, turn numbers, and tool result data. Use
+`metadata` for extension/provider details that should be preserved but are not
+part of the type contract.
 
 ## Compatibility
 
-`MessageEnvelope::normalize()` accepts existing `role/content/metadata` rows and
-versioned envelopes. It also accepts the short-lived `data` envelope key from the
-initial envelope draft as a read-time compatibility input and rewrites it to
+`AgentMessageEnvelope::normalize()` accepts existing `role/content/metadata` rows
+and versioned envelopes. It also accepts the short-lived `data` envelope key from
+the initial envelope draft as a read-time compatibility input and rewrites it to
 `payload`.
 
 New writes should store canonical envelopes. Current provider requests use
-`MessageEnvelope::to_provider_message()` / `to_provider_messages()` to project
-envelopes into the `role/content/metadata` shape expected by `ai-http-client`.
-That projection folds the envelope `type` and `payload` into provider metadata.
+`AgentMessageEnvelope::to_provider_message()` / `to_provider_messages()` to
+project envelopes into the `role/content/metadata` shape expected by
+`ai-http-client`. That projection folds the envelope `type` and `payload` into
+provider metadata.
 
 ## Type Payload
 
@@ -77,7 +77,7 @@ normalize to:
 
 ```php
 [
-    'schema'  => 'datamachine.ai.message',
+    'schema'  => 'agents-api.message',
     'version' => 1,
     'type'    => 'tool_call',
     'role'    => 'assistant',

--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -13,7 +13,7 @@ Mirror the WordPress Abilities API shape instead of importing Data Machine, wpco
 | `datamachine_register_agent()` | `wp_register_agent()` | Same declarative pattern, but without DB reconciliation side effects in the public helper. |
 | `AgentRegistry` | `WP_Agents_Registry` | Registry should collect definitions. Persistence/adoption can remain adapter territory. |
 | `datamachine_register_agents` | `wp_agents_api_init` or `wp_register_agents` | Prefer a core-shaped init hook; exact name needs review against Abilities API precedent. |
-| `MessageEnvelope` | `WP_Agent_Message` or neutral envelope | Contract is generic. Data Machine schema/name is not. |
+| `AgentMessageEnvelope` | `WP_Agent_Message` or same class name | Contract is generic and now uses Agents API-shaped vocabulary in place. |
 | `ConversationStoreInterface` | `WP_Agent_Conversation_Store_Interface` | Keep transcript/session/read-state split if it remains boring. |
 | `AgentMemoryStoreInterface` | `WP_Agent_Memory_Store_Interface` | Generic identity tuple needs naming review; Data Machine scaffolding/abilities stay outside the store contract. |
 | `RuntimeToolDeclaration` | `WP_Agent_Tool_Declaration` | Should stay ability-native and run-scoped. |
@@ -46,7 +46,7 @@ These are closest to generic public contracts. Most should be extracted as contr
 
 | Surface | Current location | Why it fits | Target notes |
 |---|---|---|---|
-| `MessageEnvelope` | `inc/Engine/AI/MessageEnvelope.php` | JSON-friendly canonical message envelope independent of flows/jobs. | Rename schema away from `datamachine.ai.message`; review whether public class is `WP_Agent_Message` or a neutral envelope helper. |
+| `AgentMessageEnvelope` | `inc/Engine/AI/AgentMessageEnvelope.php` | JSON-friendly canonical message envelope independent of flows/jobs. | Schema is `agents-api.message`; review whether physical extraction keeps this class name or adopts `WP_Agent_Message`. |
 | `AgentConversationResult` | `inc/Engine/AI/AgentConversationResult.php` | Validates result arrays from any runtime runner. | Rename to `WP_Agent_Run_Result` or split into result value object plus validator. |
 | `LoopEventSinkInterface` | `inc/Engine/AI/LoopEventSinkInterface.php` | Transport-neutral event sink for logs, streaming, CLI, REST, or chat UIs. | Make event vocabulary public and provider-neutral before extraction. |
 | `NullLoopEventSink` | `inc/Engine/AI/NullLoopEventSink.php` | Generic no-op implementation for optional event sinks. | Implementation can move with the interface. |
@@ -192,7 +192,7 @@ These tests currently pin the substrate most relevant to extraction.
 
 | Test | Covers | Extraction signal |
 |---|---|---|
-| `tests/ai-message-envelope-smoke.php` | Message envelope normalization/projection and result validation. | Move with message/result contracts. |
+| `tests/ai-message-envelope-smoke.php` | Agent message envelope normalization/projection and result validation. | Move with message/result contracts. |
 | `tests/agent-conversation-result-smoke.php` | Conversation result shape validation. | Move with runner result contract. |
 | `tests/conversation-store-contracts-smoke.php` | Split store interfaces and factory return type. | Move with conversation store contracts. |
 | `tests/guideline-agent-memory-store-smoke.php` | Optional guideline-backed memory implementation. | Move or duplicate if Agents API ships memory store implementations. |

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -51,12 +51,14 @@ Target shape:
 
 ### 3. Message Envelope Vocabulary
 
-`MessageEnvelope` is generic but still declares the schema `datamachine.ai.message`.
+`AgentMessageEnvelope` is the in-place Agents API-shaped name for the generic
+message contract. Its schema is `agents-api.message` while the class still lives
+inside Data Machine.
 
 Target shape:
 
-- Decide whether the public class is `WP_Agent_Message`, `AgentMessageEnvelope`, or a lower-level normalizer.
-- Rename schema metadata away from `datamachine.ai.message` before physical extraction.
+- Review whether the physically extracted public class should stay `AgentMessageEnvelope` or become `WP_Agent_Message`.
+- Keep schema metadata generic; do not reintroduce Data Machine-owned schema names for the shared contract.
 - Keep wpcom message DTOs as adapters/source material, not public dependency vocabulary.
 
 ### 4. Conversation Storage Boundary

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -1419,14 +1419,14 @@ factory caches the store per request and applies the filter exactly once.
 
 **Message shape contract**
 
-Stores MUST normalize messages on read to Data Machine's canonical AI message
-envelope, documented in
+Stores MUST normalize messages on read to the canonical agent message envelope,
+documented in
 [`ai-message-envelope.md`](../../core-system/ai-message-envelope.md). The
 chat/session storage contract is this JSON-friendly envelope shape:
 
 ```php
 [
-	'schema'     => 'datamachine.ai.message',
+	'schema'     => 'agents-api.message',
 	'version'    => 1,
 	'type'       => 'text'|'tool_call'|'tool_result'|...,
 	'role'       => 'user'|'assistant'|'system'|'tool',
@@ -1441,7 +1441,7 @@ chat/session storage contract is this JSON-friendly envelope shape:
 
 The five Chat Session abilities and the DM chat UI consume this shape.
 Adapter stores that wrap another host runtime are responsible for translating
-host-specific message objects into Data Machine's envelope at the boundary and
+host-specific message objects into the canonical envelope at the boundary and
 returning envelopes on the way out. Provider-specific `role/content/metadata`
 arrays are projection shapes at provider boundaries, not the store contract.
 

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -14,7 +14,7 @@ namespace DataMachine\Abilities;
 use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Engine\AI\RequestBuilder;
-use DataMachine\Engine\AI\MessageEnvelope;
+use DataMachine\Engine\AI\AgentMessageEnvelope;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\Tasks\TaskScheduler;
@@ -547,7 +547,7 @@ class SystemAbilities {
 		$first_assistant_response = null;
 
 		foreach ( $messages as $msg ) {
-			$msg     = MessageEnvelope::normalize( $msg );
+			$msg     = AgentMessageEnvelope::normalize( $msg );
 			$role    = $msg['role'] ?? '';
 			$content = $msg['content'] ?? '';
 			$content = is_string( $content ) ? $content : wp_json_encode( $content, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -208,8 +208,8 @@ class SystemAbilities {
 	 * @param array $options Optional check options
 	 * @return array System diagnostic results
 	 */
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Shared diagnostic callback signature receives per-check options.
 	private function runSystemDiagnostics( array $options = array() ): array {
-		$options;
 		return array(
 			'version'     => defined( 'DATAMACHINE_VERSION' ) ? DATAMACHINE_VERSION : 'unknown',
 			'php_version' => PHP_VERSION,
@@ -246,7 +246,7 @@ class SystemAbilities {
 	 */
 	private function checkRestApi(): array {
 		$server     = rest_get_server();
-		$namespaces = $server ? $server->get_namespaces() : array();
+		$namespaces = $server->get_namespaces();
 
 		return array(
 			'namespace_registered' => in_array( 'datamachine/v1', $namespaces, true ),
@@ -410,7 +410,7 @@ class SystemAbilities {
 	 * @param string $task_type Task type identifier.
 	 * @param array  $meta      Normalized task registry metadata.
 	 * @param array  $params    Proposed task params.
-	 * @return array{success: bool, task_params?: array, error?: string, message?: string}
+	 * @return array{success:false,error:string,message:string}|array{success:true,task_params:array}
 	 */
 	private static function validateRunTaskParams( string $task_type, array $meta, array $params ): array {
 		$schema          = is_array( $meta['params_schema'] ?? null ) ? $meta['params_schema'] : array();
@@ -659,6 +659,7 @@ class SystemAbilities {
 		 *     @type string $conversation_context     Formatted "User: ... Assistant: ..." context string.
 		 * }
 		 */
+		/** @phpstan-ignore-next-line WordPress filters accept context arguments beyond the filtered value. */
 		$prompt = apply_filters(
 			'datamachine_session_title_prompt',
 			$default_prompt,

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -23,7 +23,7 @@ use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Abilities\Job\RetryJobAbility;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
-use DataMachine\Engine\AI\MessageEnvelope;
+use DataMachine\Engine\AI\AgentMessageEnvelope;
 use DataMachine\Engine\Tasks\TaskRegistry;
 
 defined( 'ABSPATH' ) || exit;
@@ -545,9 +545,9 @@ class JobsCommand extends BaseCommand {
 		WP_CLI::log( '' );
 
 		foreach ( $messages as $idx => $message ) {
-			$message = MessageEnvelope::normalize( $message );
+			$message = AgentMessageEnvelope::normalize( $message );
 			$role    = $message['role'] ?? 'unknown';
-			$type    = $message['type'] ?? MessageEnvelope::TYPE_TEXT;
+			$type    = $message['type'] ?? AgentMessageEnvelope::TYPE_TEXT;
 			$content = $message['content'] ?? '';
 			$header  = sprintf( '[%d] %s (%s)', $idx, $role, $type );
 

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -24,6 +24,7 @@ use DataMachine\Abilities\Job\RetryJobAbility;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Engine\AI\AgentMessageEnvelope;
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
 use DataMachine\Engine\Tasks\TaskRegistry;
 
 defined( 'ABSPATH' ) || exit;
@@ -374,7 +375,8 @@ class JobsCommand extends BaseCommand {
 		}
 
 		if ( 'yaml' === $format ) {
-			WP_CLI::log( \Spyc::YAMLDump( $job, false, false, true ) );
+			/** @phpstan-ignore-next-line Spyc is provided by WP-CLI at runtime. */
+			WP_CLI::log( (string) call_user_func( array( 'Spyc', 'YAMLDump' ), $job, false, false, true ) );
 			return;
 		}
 
@@ -492,7 +494,8 @@ class JobsCommand extends BaseCommand {
 				'model'      => $session['model'] ?? null,
 				'messages'   => $messages,
 			);
-			WP_CLI::log( \Spyc::YAMLDump( $payload, false, false, true ) );
+			/** @phpstan-ignore-next-line Spyc is provided by WP-CLI at runtime. */
+			WP_CLI::log( (string) call_user_func( array( 'Spyc', 'YAMLDump' ), $payload, false, false, true ) );
 			return;
 		}
 
@@ -720,6 +723,7 @@ class JobsCommand extends BaseCommand {
 
 		// Get the latest log message (usually contains failure reason).
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		/** @var object{message?: string, log_date_gmt?: string}|null $log */
 		$log = $wpdb->get_row(
 			$wpdb->prepare(
 				'SELECT message, log_date_gmt
@@ -733,7 +737,8 @@ class JobsCommand extends BaseCommand {
 		);
 
 		if ( $log && ! empty( $log->message ) ) {
-			WP_CLI::log( sprintf( '  Last Log: %s (%s)', $log->message, $log->log_date_gmt ) );
+			$log_date_gmt = is_string( $log->log_date_gmt ?? null ) ? $log->log_date_gmt : '';
+			WP_CLI::log( sprintf( '  Last Log: %s (%s)', $log->message, $log_date_gmt ) );
 		}
 	}
 
@@ -1240,6 +1245,11 @@ class JobsCommand extends BaseCommand {
 			}
 
 			$task = new $handlers[ $jtype ]();
+			if ( ! $task instanceof SystemTask ) {
+				WP_CLI::warning( sprintf( 'Job #%d: task type "%s" is not a SystemTask.', $jid, $jtype ) );
+				++$total_skipped;
+				continue;
+			}
 
 			if ( ! $task->supportsUndo() ) {
 				WP_CLI::log( sprintf( '  Job #%d: task type "%s" does not support undo.', $jid, $jtype ) );
@@ -1251,11 +1261,11 @@ class JobsCommand extends BaseCommand {
 			// the parent has no own effects; aggregate from children
 			// via Jobs::get_children so the preview is accurate.
 			if ( $dry_run ) {
-				$preview_effects = $engine_data['effects'] ?? array();
+				$preview_effects = is_array( $engine_data['effects'] ?? null ) ? $engine_data['effects'] : array();
 				if ( empty( $preview_effects ) ) {
 					foreach ( $jobs_db->get_children( (int) $jid ) as $child ) {
 						$child_data      = is_array( $child['engine_data'] ?? null ) ? $child['engine_data'] : array();
-						$child_effects   = $child_data['effects'] ?? array();
+						$child_effects   = is_array( $child_data['effects'] ?? null ) ? $child_data['effects'] : array();
 						$preview_effects = array_merge( $preview_effects, $child_effects );
 					}
 				}
@@ -1282,9 +1292,9 @@ class JobsCommand extends BaseCommand {
 			WP_CLI::log( sprintf( '  Job #%d (%s): undoing...', $jid, $jtype ) );
 			$result = $task->undo( $jid, $engine_data );
 
-			$reverted = is_array( $result['reverted'] ?? null ) ? $result['reverted'] : array();
-			$skipped  = is_array( $result['skipped'] ?? null ) ? $result['skipped'] : array();
-			$failed   = is_array( $result['failed'] ?? null ) ? $result['failed'] : array();
+			$reverted = $result['reverted'];
+			$skipped  = $result['skipped'];
+			$failed   = $result['failed'];
 
 			if ( empty( $reverted ) && empty( $skipped ) && empty( $failed ) ) {
 				WP_CLI::log( sprintf( '  Job #%d (%s): no effects to undo.', $jid, $jtype ) );

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -13,7 +13,7 @@ namespace DataMachine\Core\Database\Chat;
 
 use DataMachine\Core\Admin\DateFormatter;
 use DataMachine\Core\Database\BaseRepository;
-use DataMachine\Engine\AI\MessageEnvelope;
+use DataMachine\Engine\AI\AgentMessageEnvelope;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -333,7 +333,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		$table_name = self::get_prefixed_table_name();
 
 		try {
-			$normalized_messages = MessageEnvelope::normalize_many( $messages );
+			$normalized_messages = AgentMessageEnvelope::normalize_many( $messages );
 		} catch ( \InvalidArgumentException $e ) {
 			do_action(
 				'datamachine_log',
@@ -789,14 +789,14 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		$count = 0;
 
 		foreach ( $messages as $msg ) {
-			$msg = MessageEnvelope::normalize( $msg );
+			$msg = AgentMessageEnvelope::normalize( $msg );
 			if ( ( $msg['role'] ?? '' ) !== 'assistant' ) {
 				continue;
 			}
 
 			// Skip tool call/result messages — only count visible assistant responses.
-			$type = $msg['type'] ?? MessageEnvelope::TYPE_TEXT;
-			if ( MessageEnvelope::TYPE_TOOL_CALL === $type || MessageEnvelope::TYPE_TOOL_RESULT === $type ) {
+			$type = $msg['type'] ?? AgentMessageEnvelope::TYPE_TEXT;
+			if ( AgentMessageEnvelope::TYPE_TOOL_CALL === $type || AgentMessageEnvelope::TYPE_TOOL_RESULT === $type ) {
 				continue;
 			}
 
@@ -822,7 +822,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 */
 	private static function normalize_messages( array $messages ): array {
 		try {
-			return MessageEnvelope::normalize_many( $messages );
+			return AgentMessageEnvelope::normalize_many( $messages );
 		} catch ( \InvalidArgumentException $e ) {
 			do_action(
 				'datamachine_log',

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -862,7 +862,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		global $wpdb;
 
 		$table_name   = self::get_prefixed_table_name();
-		$last_read_at = current_time( 'mysql', true );
+		$last_read_at = (string) current_time( 'mysql', true );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$result = $wpdb->update(
@@ -903,7 +903,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		global $wpdb;
 
 		$table_name  = self::get_prefixed_table_name();
-		$cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$retention_days} days" ) );
+		$cutoff_date = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$deleted = $wpdb->query(
@@ -955,7 +955,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		}
 
 		$table_name  = self::get_prefixed_table_name();
-		$cutoff_date = gmdate( 'Y-m-d H:i:s', strtotime( "-{$retention_days} days" ) );
+		$cutoff_date = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$deleted = $wpdb->query(

--- a/inc/Engine/AI/AgentConversationResult.php
+++ b/inc/Engine/AI/AgentConversationResult.php
@@ -40,7 +40,7 @@ class AgentConversationResult {
 			}
 
 			try {
-				$message = MessageEnvelope::normalize( $message );
+				$message = AgentMessageEnvelope::normalize( $message );
 			} catch ( \InvalidArgumentException $e ) {
 				throw self::invalid( $path, $e->getMessage() );
 			}

--- a/inc/Engine/AI/AgentMessageEnvelope.php
+++ b/inc/Engine/AI/AgentMessageEnvelope.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * JSON-friendly AI message envelope contract.
+ * JSON-friendly agent message envelope contract.
  *
  * @package DataMachine\Engine\AI
  */
@@ -12,11 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Normalizes Data Machine AI messages into the canonical typed envelope.
+ * Normalizes agent messages into the canonical typed envelope.
  */
-class MessageEnvelope {
+class AgentMessageEnvelope {
 
-	public const SCHEMA  = 'datamachine.ai.message';
+	public const SCHEMA  = 'agents-api.message';
 	public const VERSION = 1;
 
 	public const TYPE_TEXT              = 'text';

--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -189,8 +189,8 @@ class ConversationManager {
 	 * @param array  $tool_parameters Original tool parameters
 	 * @return string Human-readable success/failure message
 	 */
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Kept for callers that pass original tool params alongside result data.
 	public static function generateSuccessMessage( string $tool_name, array $tool_result, array $tool_parameters ): string {
-		$tool_parameters;
 		$success = $tool_result['success'] ?? false;
 		$data    = $tool_result['data'] ?? array();
 

--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -39,7 +39,7 @@ class ConversationManager {
 	 * @return array Message envelope.
 	 */
 	public static function buildConversationMessage( string $role, $content, array $metadata = array() ): array {
-		return MessageEnvelope::text( $role, $content, array_merge( array( 'timestamp' => gmdate( 'c' ) ), $metadata ) );
+		return AgentMessageEnvelope::text( $role, $content, array_merge( array( 'timestamp' => gmdate( 'c' ) ), $metadata ) );
 	}
 
 	/**
@@ -125,7 +125,7 @@ class ConversationManager {
 			$message .= ' with parameters: ' . implode( ', ', $params_str );
 		}
 
-		return MessageEnvelope::toolCall(
+		return AgentMessageEnvelope::toolCall(
 			$message,
 			$tool_name,
 			$tool_parameters,
@@ -178,7 +178,7 @@ class ConversationManager {
 			$payload['error'] = $tool_result['error'];
 		}
 
-		return MessageEnvelope::toolResult( $content, $tool_name, $payload, array( 'timestamp' => gmdate( 'c' ) ) );
+		return AgentMessageEnvelope::toolResult( $content, $tool_name, $payload, array( 'timestamp' => gmdate( 'c' ) ) );
 	}
 
 	/**
@@ -298,13 +298,13 @@ class ConversationManager {
 
 		// Scan ALL previous tool_call messages, not just the most recent one.
 		for ( $i = count( $conversation_messages ) - 1; $i >= 0; $i-- ) {
-			$message = MessageEnvelope::normalize( $conversation_messages[ $i ] );
+			$message = AgentMessageEnvelope::normalize( $conversation_messages[ $i ] );
 
 			if ( 'assistant' !== $message['role'] ) {
 				continue;
 			}
 
-			if ( MessageEnvelope::TYPE_TOOL_CALL !== $message['type'] ) {
+			if ( AgentMessageEnvelope::TYPE_TOOL_CALL !== $message['type'] ) {
 				continue;
 			}
 
@@ -339,9 +339,9 @@ class ConversationManager {
 	 * @return array|null Tool call details or null if not a tool call message
 	 */
 	public static function extractToolCallFromMessage( array $message ): ?array {
-		$envelope = MessageEnvelope::normalize( $message );
+		$envelope = AgentMessageEnvelope::normalize( $message );
 
-		if ( MessageEnvelope::TYPE_TOOL_CALL === $envelope['type'] ) {
+		if ( AgentMessageEnvelope::TYPE_TOOL_CALL === $envelope['type'] ) {
 			$tool_name  = $envelope['payload']['tool_name'] ?? null;
 			$parameters = $envelope['payload']['parameters'] ?? null;
 

--- a/inc/Engine/AI/PromptBuilder.php
+++ b/inc/Engine/AI/PromptBuilder.php
@@ -188,7 +188,7 @@ class PromptBuilder {
 		$directive_messages = DirectiveRenderer::renderMessages( $validated_outputs );
 
 		return array(
-			'messages'            => MessageEnvelope::normalize_many( array_merge( $directive_messages, $conversation_messages ) ),
+			'messages'            => AgentMessageEnvelope::normalize_many( array_merge( $directive_messages, $conversation_messages ) ),
 			'tools'               => $this->tools,
 			'applied_directives'  => $applied_directives,
 			'directive_metadata'  => $directive_metadata,

--- a/inc/Engine/AI/PromptBuilder.php
+++ b/inc/Engine/AI/PromptBuilder.php
@@ -148,8 +148,12 @@ class PromptBuilder {
 			}
 
 			$stepId          = $payload['step_id'] ?? null;
-			$directive_class = is_string( $directive ) ? $directive : get_class( $directive );
-			$directive_name  = substr( $directive_class, strrpos( $directive_class, '\\' ) + 1 );
+			$directive_class = is_string( $directive ) ? $directive : ( is_object( $directive ) ? get_class( $directive ) : '' );
+			if ( '' === $directive_class ) {
+				continue;
+			}
+			$namespace_pos  = strrpos( $directive_class, '\\' );
+			$directive_name = false === $namespace_pos ? $directive_class : substr( $directive_class, $namespace_pos + 1 );
 
 			$outputs = null;
 
@@ -163,7 +167,6 @@ class PromptBuilder {
 				continue;
 			}
 
-			$outputs = is_array( $outputs ) ? $outputs : array();
 			if ( ! empty( $outputs ) ) {
 				$directive_outputs = array_merge( $directive_outputs, $outputs );
 			}

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -129,6 +129,7 @@ class RequestBuilder {
 		}
 
 		// Legacy path: ai-http-client via chubes_ai_request filter.
+		/** @phpstan-ignore-next-line WordPress filters accept context arguments beyond the filtered value. */
 		$response = apply_filters(
 			'chubes_ai_request',
 			$provider_request,
@@ -182,7 +183,7 @@ class RequestBuilder {
 			)
 		);
 		$directives       = $directive_policy['directives'];
-		$suppressed       = $directive_policy['suppressed'] ?? array();
+		$suppressed       = $directive_policy['suppressed'];
 		foreach ( $directives as $directive ) {
 			$promptBuilder->addDirective(
 				$directive['class'],

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -49,7 +49,7 @@ class RequestBuilder {
 		$assembled                    = self::assemble( $messages, $provider, $model, $tools, $mode, $payload );
 		$request                      = $assembled['request'];
 		$provider_request             = $request;
-		$provider_request['messages'] = MessageEnvelope::to_provider_messages( $request['messages'] ?? array() );
+		$provider_request['messages'] = AgentMessageEnvelope::to_provider_messages( $request['messages'] ?? array() );
 		$structured_tools             = $assembled['structured_tools'];
 		$applied_directives           = $assembled['applied_directives'];
 		$directive_metadata           = $assembled['directive_metadata'];
@@ -192,7 +192,7 @@ class RequestBuilder {
 		}
 
 		$request             = $promptBuilder->buildDetailed( $mode, $provider, $payload );
-		$request['messages'] = MessageEnvelope::normalize_many( $request['messages'] ?? array() );
+		$request['messages'] = AgentMessageEnvelope::normalize_many( $request['messages'] ?? array() );
 		$applied_directives  = $request['applied_directives'] ?? array();
 		$directive_metadata  = $request['directive_metadata'] ?? array();
 		$directive_breakdown = $request['directive_breakdown'] ?? array();

--- a/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
+++ b/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
@@ -13,7 +13,7 @@
 namespace DataMachine\Tests\Unit\Core\Database\Chat;
 
 use DataMachine\Core\Database\Chat\ConversationStoreInterface;
-use DataMachine\Engine\AI\MessageEnvelope;
+use DataMachine\Engine\AI\AgentMessageEnvelope;
 
 class InMemoryConversationStore implements ConversationStoreInterface {
 
@@ -174,12 +174,12 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 	public function count_unread( array $messages, ?string $last_read_at ): int {
 		$count = 0;
 		foreach ( $messages as $msg ) {
-			$msg = MessageEnvelope::normalize( $msg );
+			$msg = AgentMessageEnvelope::normalize( $msg );
 			if ( ( $msg['role'] ?? '' ) !== 'assistant' ) {
 				continue;
 			}
-			$type = $msg['type'] ?? MessageEnvelope::TYPE_TEXT;
-			if ( MessageEnvelope::TYPE_TOOL_CALL === $type || MessageEnvelope::TYPE_TOOL_RESULT === $type ) {
+			$type = $msg['type'] ?? AgentMessageEnvelope::TYPE_TEXT;
+			if ( AgentMessageEnvelope::TYPE_TOOL_CALL === $type || AgentMessageEnvelope::TYPE_TOOL_RESULT === $type ) {
 				continue;
 			}
 			if ( null === $last_read_at ) {

--- a/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
+++ b/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
@@ -219,7 +219,7 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 	}
 
 	public function cleanup_old_sessions( int $retention_days ): int {
-		$cutoff  = gmdate( 'Y-m-d H:i:s', strtotime( "-{$retention_days} days" ) );
+		$cutoff  = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
 		$deleted = 0;
 		foreach ( $this->sessions as $id => $session ) {
 			if ( $session['updated_at'] < $cutoff ) {

--- a/tests/agent-conversation-result-smoke.php
+++ b/tests/agent-conversation-result-smoke.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/bootstrap-unit.php';
 
 use DataMachine\Engine\AI\AIConversationLoop;
 use DataMachine\Engine\AI\AgentConversationResult;
-use DataMachine\Engine\AI\MessageEnvelope;
+use DataMachine\Engine\AI\AgentMessageEnvelope;
 
 if ( ! function_exists( 'apply_filters' ) ) {
 	function apply_filters( string $hook, $value ) {
@@ -53,7 +53,7 @@ $valid_result = array(
 
 $normalized = AgentConversationResult::normalize( $valid_result );
 datamachine_agent_conversation_result_assert(
-	MessageEnvelope::TYPE_TEXT === $normalized['messages'][0]['type'],
+	AgentMessageEnvelope::TYPE_TEXT === $normalized['messages'][0]['type'],
 	'Valid built-in-shaped result should normalize messages to canonical envelopes.'
 );
 ++$assertions;

--- a/tests/ai-message-envelope-smoke.php
+++ b/tests/ai-message-envelope-smoke.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Smoke tests for the AI message envelope contract.
+ * Smoke tests for the agent message envelope contract.
  *
  * Run with: php tests/ai-message-envelope-smoke.php
  *
@@ -11,7 +11,7 @@ require_once __DIR__ . '/bootstrap-unit.php';
 
 use DataMachine\Engine\AI\AgentConversationResult;
 use DataMachine\Engine\AI\ConversationManager;
-use DataMachine\Engine\AI\MessageEnvelope;
+use DataMachine\Engine\AI\AgentMessageEnvelope;
 
 function datamachine_message_envelope_assert( bool $condition, string $message ): void {
 	if ( ! $condition ) {
@@ -30,16 +30,16 @@ $legacy_text = array(
 	'content' => 'Hello world.',
 );
 
-$text_envelope = MessageEnvelope::normalize( $legacy_text );
-datamachine_message_envelope_assert( MessageEnvelope::SCHEMA === $text_envelope['schema'], 'Legacy text normalizes to the Data Machine schema.' );
+$text_envelope = AgentMessageEnvelope::normalize( $legacy_text );
+datamachine_message_envelope_assert( AgentMessageEnvelope::SCHEMA === $text_envelope['schema'], 'Legacy text normalizes to the Agents API schema.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( MessageEnvelope::VERSION === $text_envelope['version'], 'Legacy text normalizes to the current envelope version.' );
+datamachine_message_envelope_assert( AgentMessageEnvelope::VERSION === $text_envelope['version'], 'Legacy text normalizes to the current envelope version.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( MessageEnvelope::TYPE_TEXT === $text_envelope['type'], 'Legacy text infers text type.' );
+datamachine_message_envelope_assert( AgentMessageEnvelope::TYPE_TEXT === $text_envelope['type'], 'Legacy text infers text type.' );
 datamachine_message_envelope_count();
 datamachine_message_envelope_assert( array() === $text_envelope['payload'], 'Plain legacy text normalizes with an empty payload.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( $legacy_text === MessageEnvelope::to_provider_message( $legacy_text ), 'Plain legacy text projects without provider metadata churn.' );
+datamachine_message_envelope_assert( $legacy_text === AgentMessageEnvelope::to_provider_message( $legacy_text ), 'Plain legacy text projects without provider metadata churn.' );
 datamachine_message_envelope_count();
 
 $legacy_tool_call = array(
@@ -53,18 +53,18 @@ $legacy_tool_call = array(
 	),
 );
 
-$tool_call_envelope = MessageEnvelope::normalize( $legacy_tool_call );
-datamachine_message_envelope_assert( MessageEnvelope::TYPE_TOOL_CALL === $tool_call_envelope['type'], 'Legacy tool call keeps explicit tool_call type.' );
+$tool_call_envelope = AgentMessageEnvelope::normalize( $legacy_tool_call );
+datamachine_message_envelope_assert( AgentMessageEnvelope::TYPE_TOOL_CALL === $tool_call_envelope['type'], 'Legacy tool call keeps explicit tool_call type.' );
 datamachine_message_envelope_count();
 datamachine_message_envelope_assert( 'wiki_upsert' === $tool_call_envelope['payload']['tool_name'], 'Tool call tool_name is promoted to envelope payload.' );
 datamachine_message_envelope_count();
 datamachine_message_envelope_assert( array( 'title' => 'Demo' ) === $tool_call_envelope['payload']['parameters'], 'Tool call parameters are promoted to envelope payload.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( $legacy_tool_call === MessageEnvelope::to_provider_message( $tool_call_envelope ), 'Tool call envelope projects back to provider message shape.' );
+datamachine_message_envelope_assert( $legacy_tool_call === AgentMessageEnvelope::to_provider_message( $tool_call_envelope ), 'Tool call envelope projects back to provider message shape.' );
 datamachine_message_envelope_count();
 
 $built_tool_call = ConversationManager::formatToolCallMessage( 'wiki_upsert', array( 'title' => 'Demo' ), 3 );
-datamachine_message_envelope_assert( MessageEnvelope::TYPE_TOOL_CALL === $built_tool_call['type'], 'ConversationManager emits tool_call envelopes.' );
+datamachine_message_envelope_assert( AgentMessageEnvelope::TYPE_TOOL_CALL === $built_tool_call['type'], 'ConversationManager emits tool_call envelopes.' );
 datamachine_message_envelope_count();
 datamachine_message_envelope_assert( 'wiki_upsert' === $built_tool_call['payload']['tool_name'], 'ConversationManager stores tool call details in payload.' );
 datamachine_message_envelope_count();
@@ -81,60 +81,60 @@ $legacy_tool_result = array(
 	),
 );
 
-$tool_result_envelope = MessageEnvelope::normalize( $legacy_tool_result );
-datamachine_message_envelope_assert( MessageEnvelope::TYPE_TOOL_RESULT === $tool_result_envelope['type'], 'Legacy tool result keeps explicit tool_result type.' );
+$tool_result_envelope = AgentMessageEnvelope::normalize( $legacy_tool_result );
+datamachine_message_envelope_assert( AgentMessageEnvelope::TYPE_TOOL_RESULT === $tool_result_envelope['type'], 'Legacy tool result keeps explicit tool_result type.' );
 datamachine_message_envelope_count();
 datamachine_message_envelope_assert( true === $tool_result_envelope['payload']['success'], 'Tool result success is promoted to envelope payload.' );
 datamachine_message_envelope_count();
 datamachine_message_envelope_assert( array( 'post_id' => 123 ) === $tool_result_envelope['payload']['tool_data'], 'Tool result data is promoted to envelope payload.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( $legacy_tool_result === MessageEnvelope::to_provider_message( $tool_result_envelope ), 'Tool result envelope projects back to provider message shape.' );
+datamachine_message_envelope_assert( $legacy_tool_result === AgentMessageEnvelope::to_provider_message( $tool_result_envelope ), 'Tool result envelope projects back to provider message shape.' );
 datamachine_message_envelope_count();
 
 $typed_final_result = array(
-	'schema'   => MessageEnvelope::SCHEMA,
-	'version'  => MessageEnvelope::VERSION,
-	'type'     => MessageEnvelope::TYPE_FINAL_RESULT,
+	'schema'   => AgentMessageEnvelope::SCHEMA,
+	'version'  => AgentMessageEnvelope::VERSION,
+	'type'     => AgentMessageEnvelope::TYPE_FINAL_RESULT,
 	'role'     => 'assistant',
 	'content'  => 'Finished.',
 	'payload'  => array( 'status' => 'complete' ),
 	'metadata' => array( 'provider_message_id' => 'msg_123' ),
 );
 
-$typed_envelope = MessageEnvelope::normalize( $typed_final_result );
+$typed_envelope = AgentMessageEnvelope::normalize( $typed_final_result );
 datamachine_message_envelope_assert( 'assistant' === $typed_envelope['role'], 'Future typed envelope keeps role in canonical output.' );
 datamachine_message_envelope_count();
 datamachine_message_envelope_assert( 'Finished.' === $typed_envelope['content'], 'Future typed envelope keeps content in canonical output.' );
 datamachine_message_envelope_count();
-datamachine_message_envelope_assert( MessageEnvelope::TYPE_FINAL_RESULT === $typed_envelope['type'], 'Future typed envelope keeps type as a top-level field.' );
+datamachine_message_envelope_assert( AgentMessageEnvelope::TYPE_FINAL_RESULT === $typed_envelope['type'], 'Future typed envelope keeps type as a top-level field.' );
 datamachine_message_envelope_count();
 datamachine_message_envelope_assert( 'complete' === $typed_envelope['payload']['status'], 'Future typed envelope keeps type-specific data in payload.' );
 datamachine_message_envelope_count();
 datamachine_message_envelope_assert( 'msg_123' === $typed_envelope['metadata']['provider_message_id'], 'Future typed envelope preserves extension metadata.' );
 datamachine_message_envelope_count();
 
-$typed_provider = MessageEnvelope::to_provider_message( $typed_envelope );
-datamachine_message_envelope_assert( MessageEnvelope::TYPE_FINAL_RESULT === $typed_provider['metadata']['type'], 'Provider projection folds type into metadata.' );
+$typed_provider = AgentMessageEnvelope::to_provider_message( $typed_envelope );
+datamachine_message_envelope_assert( AgentMessageEnvelope::TYPE_FINAL_RESULT === $typed_provider['metadata']['type'], 'Provider projection folds type into metadata.' );
 datamachine_message_envelope_count();
 datamachine_message_envelope_assert( 'complete' === $typed_provider['metadata']['status'], 'Provider projection folds payload into metadata.' );
 datamachine_message_envelope_count();
 
 $typed_delta = array(
-	'schema'  => MessageEnvelope::SCHEMA,
-	'version' => MessageEnvelope::VERSION,
-	'type'    => MessageEnvelope::TYPE_DELTA,
+	'schema'  => AgentMessageEnvelope::SCHEMA,
+	'version' => AgentMessageEnvelope::VERSION,
+	'type'    => AgentMessageEnvelope::TYPE_DELTA,
 	'content' => 'partial token',
 	'payload' => array( 'index' => 0 ),
 );
 
-$delta_envelope = MessageEnvelope::normalize( $typed_delta );
+$delta_envelope = AgentMessageEnvelope::normalize( $typed_delta );
 datamachine_message_envelope_assert( 'assistant' === $delta_envelope['role'], 'Typed delta envelope gets assistant default role.' );
 datamachine_message_envelope_count();
 
 $old_data_envelope = $typed_delta;
 $old_data_envelope['data'] = $old_data_envelope['payload'];
 unset( $old_data_envelope['payload'] );
-$old_data_normalized = MessageEnvelope::normalize( $old_data_envelope );
+$old_data_normalized = AgentMessageEnvelope::normalize( $old_data_envelope );
 datamachine_message_envelope_assert( array( 'index' => 0 ) === $old_data_normalized['payload'], 'Old data envelope key is accepted as a read-time compatibility input.' );
 datamachine_message_envelope_count();
 
@@ -146,8 +146,8 @@ $multimodal_legacy = array(
 	),
 );
 
-$multimodal_envelope = MessageEnvelope::normalize( $multimodal_legacy );
-datamachine_message_envelope_assert( MessageEnvelope::TYPE_MULTIMODAL_PART === $multimodal_envelope['type'], 'Array content infers multimodal_part type.' );
+$multimodal_envelope = AgentMessageEnvelope::normalize( $multimodal_legacy );
+datamachine_message_envelope_assert( AgentMessageEnvelope::TYPE_MULTIMODAL_PART === $multimodal_envelope['type'], 'Array content infers multimodal_part type.' );
 datamachine_message_envelope_count();
 
 $result = AgentConversationResult::normalize(
@@ -162,14 +162,14 @@ $result = AgentConversationResult::normalize(
 	)
 );
 
-datamachine_message_envelope_assert( MessageEnvelope::TYPE_FINAL_RESULT === $result['messages'][0]['type'], 'AgentConversationResult accepts typed envelopes and returns canonical envelopes.' );
+datamachine_message_envelope_assert( AgentMessageEnvelope::TYPE_FINAL_RESULT === $result['messages'][0]['type'], 'AgentConversationResult accepts typed envelopes and returns canonical envelopes.' );
 datamachine_message_envelope_count();
 
 try {
-	MessageEnvelope::normalize(
+	AgentMessageEnvelope::normalize(
 		array(
-			'schema'  => MessageEnvelope::SCHEMA,
-			'version' => MessageEnvelope::VERSION,
+			'schema'  => AgentMessageEnvelope::SCHEMA,
+			'version' => AgentMessageEnvelope::VERSION,
 			'type'    => 'unknown_type',
 			'content' => 'bad',
 		)

--- a/tests/ai-request-inspector-smoke.php
+++ b/tests/ai-request-inspector-smoke.php
@@ -152,8 +152,8 @@ assert_test( 'tools JSON byte count stable', 178 === $tools_json_bytes, 'got ' .
 
 echo "\nCase 3: CLI command surface is registered and documented\n";
 
-$bootstrap = file_get_contents( __DIR__ . '/../inc/Cli/Bootstrap.php' );
-$command   = file_get_contents( __DIR__ . '/../inc/Cli/Commands/AICommand.php' );
+$bootstrap = (string) file_get_contents( __DIR__ . '/../inc/Cli/Bootstrap.php' );
+$command   = (string) file_get_contents( __DIR__ . '/../inc/Cli/Commands/AICommand.php' );
 
 assert_test( 'datamachine ai namespace registered', false !== strpos( $bootstrap, "datamachine ai" ) );
 assert_test( 'inspect-request subcommand declared', false !== strpos( $command, '@subcommand inspect-request' ) );
@@ -164,14 +164,15 @@ assert_test( 'json output path exists', false !== strpos( $command, "'json' === 
 assert_test( 'table output includes directive section', false !== strpos( $command, "Directives" ) );
 assert_test( 'table output includes largest tools section', false !== strpos( $command, "Largest tools" ) );
 
-$plugin  = file_get_contents( __DIR__ . '/../data-machine.php' );
-$ability = file_get_contents( __DIR__ . '/../inc/Abilities/AI/InspectRequestAbility.php' );
+$plugin  = (string) file_get_contents( __DIR__ . '/../data-machine.php' );
+$ability = (string) file_get_contents( __DIR__ . '/../inc/Abilities/AI/InspectRequestAbility.php' );
 
 assert_test( 'inspect request ability loaded by plugin bootstrap', false !== strpos( $plugin, 'InspectRequestAbility.php' ) );
 assert_test( 'inspect request ability instantiated by plugin bootstrap', false !== strpos( $plugin, 'new \\DataMachine\\Abilities\\AI\\InspectRequestAbility()' ) );
 assert_test( 'ability registers datamachine/inspect-ai-request', false !== strpos( $ability, 'datamachine/inspect-ai-request' ) );
 
 echo "\n$total assertions, $failed failures\n";
-if ( $failed > 0 ) {
+$failed_count = (int) ( $GLOBALS['failed'] ?? $failed );
+if ( $failed_count > 0 ) {
 	exit( 1 );
 }

--- a/tests/ai-request-inspector-smoke.php
+++ b/tests/ai-request-inspector-smoke.php
@@ -45,7 +45,7 @@ require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveInterface.php';
 require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectivePolicyResolver.php';
 require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveOutputValidator.php';
 require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveRenderer.php';
-require_once __DIR__ . '/../inc/Engine/AI/MessageEnvelope.php';
+require_once __DIR__ . '/../inc/Engine/AI/AgentMessageEnvelope.php';
 require_once __DIR__ . '/../inc/Engine/AI/PromptBuilder.php';
 require_once __DIR__ . '/../inc/Engine/AI/RequestBuilder.php';
 
@@ -146,8 +146,8 @@ $request_json_bytes = strlen( wp_json_encode( $assembled['request'], JSON_UNESCA
 $messages_json_bytes = strlen( wp_json_encode( $assembled['request']['messages'], JSON_UNESCAPED_UNICODE ) );
 $tools_json_bytes = strlen( wp_json_encode( $assembled['request']['tools'], JSON_UNESCAPED_UNICODE ) );
 
-assert_test( 'request JSON byte count stable', 504 === $request_json_bytes, 'got ' . $request_json_bytes );
-assert_test( 'messages JSON byte count stable', 285 === $messages_json_bytes, 'got ' . $messages_json_bytes );
+assert_test( 'request JSON byte count stable', 496 === $request_json_bytes, 'got ' . $request_json_bytes );
+assert_test( 'messages JSON byte count stable', 277 === $messages_json_bytes, 'got ' . $messages_json_bytes );
 assert_test( 'tools JSON byte count stable', 178 === $tools_json_bytes, 'got ' . $tools_json_bytes );
 
 echo "\nCase 3: CLI command surface is registered and documented\n";


### PR DESCRIPTION
## Summary
- Rename the canonical message envelope value object to `AgentMessageEnvelope` while it remains in Data Machine.
- Move the generic schema from `datamachine.ai.message` to `agents-api.message` and update runtime callsites, smoke coverage, and extraction docs.
- Keep provider projection/storage normalization behavior unchanged; no WPCOM classes or compatibility shim added.
- Clear scoped PHPCS/PHPStan drift in the touched files so the changed-since lint gate stays green.

## Tests
- `php tests/ai-message-envelope-smoke.php` ✅
- `php tests/agent-conversation-result-smoke.php` ✅
- `php tests/ai-request-inspector-smoke.php` ✅
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-message-envelope --changed-since origin/main --summary` ✅

Closes #1590

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the vocabulary rename, updated docs/tests/callsites, cleared scoped lint findings in touched files, and ran focused verification. Chris remains responsible for review and merge.
