### PR TITLE
feat(agent): add WordPress-shaped registry vocabulary

### DIFF
--- a/docs/core-filters.md
+++ b/docs/core-filters.md
@@ -2,17 +2,17 @@
 
 ## Actions
 
-### `datamachine_register_agents`
+### `wp_agents_api_init`
 
-Fires once per request when the AgentRegistry is first consumed. Plugins declare agent roles inside this callback; DM reconciles declarations against the `datamachine_agents` table on `init` priority 15.
+Fires once per request when the AgentRegistry is first consumed. Plugins declare agent roles inside this callback; DM reconciles declarations against the `datamachine_agents` table on `init` priority 15 while Data Machine hosts the in-place Agents API substrate.
 
-Same API DM itself uses to register the default site administrator agent. Registrations are collected statically; last-wins on slug collision so plugins can override via hook priority.
+Same API DM itself uses to register the default site administrator agent. Registrations are collected statically; last-wins on slug collision so plugins can override via hook priority. The legacy `datamachine_register_agents` action and `datamachine_register_agent()` wrapper still fire while this surface lives in Data Machine, but new code should use the WordPress-shaped names.
 
-**Since:** 0.71.0
+**Since:** 0.99.0
 
 ```php
-add_action( 'datamachine_register_agents', function () {
-    datamachine_register_agent( 'wiki-generator', array(
+add_action( 'wp_agents_api_init', function () {
+    wp_register_agent( 'wiki-generator', array(
         'label'        => 'Wiki Generator',
         'description'  => 'Fetches sources, distills into wiki articles.',
         'memory_seeds' => array(

--- a/docs/core-system/agent-registration.md
+++ b/docs/core-system/agent-registration.md
@@ -1,23 +1,23 @@
 # Agent Registration
 
-Declarative agent registration via the `datamachine_register_agents` action. Plugins (and Data Machine itself) declare agent roles once; DM's registry reconciles those declarations against the `datamachine_agents` table on `init`.
+Declarative agent registration via the `wp_agents_api_init` action. Plugins (and Data Machine itself) declare agent roles once; the side-effect-free registry collects those declarations, and Data Machine's materializer reconciles them against the `datamachine_agents` table on `init` while Data Machine hosts the in-place substrate.
 
 **Since:** 0.71.0
-**Source:** `inc/Engine/Agents/AgentRegistry.php`, `inc/Engine/Agents/register-agents.php`
+**Source:** `inc/Engine/Agents/class-wp-agent.php`, `inc/Engine/Agents/class-wp-agents-registry.php`, `inc/Engine/Agents/AgentRegistry.php`, `inc/Engine/Agents/register-agents.php`
 
 ## Why
 
 Agents were previously materialized imperatively — either via `AgentAbilities::createAgent()` from CLI/REST, or lazily via `datamachine_resolve_or_create_agent_id()` on first chat turn. That works for per-user personal agents but doesn't give extensions a clean way to ship a bundled agent role (e.g. a wiki-generator, a support-triage bot, a content-reviewer).
 
-The registry mirrors the `register_post_type()` / `register_taxonomy()` pattern: plugins declare the role, DM owns the runtime. The same API DM uses internally is the API any plugin uses. DM dogfoods it — the default site administrator agent is now registered through the hook.
+The registry mirrors the `register_post_type()` / `register_taxonomy()` pattern: plugins declare the role, Data Machine owns today's runtime. The public vocabulary mirrors the Abilities API direction (`wp_register_agent()`, `WP_Agent`, `WP_Agents_Registry`, `wp_agents_api_init`) so the generic registry can move cleanly if Agents API is extracted later. Data Machine dogfoods it — the default site administrator agent is registered through the same hook.
 
 ## Declaring an agent
 
 Inside your plugin:
 
 ```php
-add_action( 'datamachine_register_agents', function () {
-    datamachine_register_agent( 'wiki-generator', array(
+add_action( 'wp_agents_api_init', function () {
+    wp_register_agent( 'wiki-generator', array(
         'label'        => __( 'Wiki Generator', 'my-plugin' ),
         'description'  => __( 'Fetches sources, distills into wiki articles, cross-links.', 'my-plugin' ),
         'memory_seeds' => array(
@@ -36,7 +36,7 @@ That's it. On the next request where `init` fires, DM reconciles the registratio
 
 ## Registration arguments
 
-`datamachine_register_agent( string $slug, array $args )`
+`wp_register_agent( string|WP_Agent $agent, array $args = array() )`
 
 | Key | Type | Description |
 |---|---|---|
@@ -55,10 +55,10 @@ Slugs are passed through `sanitize_title()`. They must be unique across a site (
 Reconciliation runs on `init` at priority 15:
 
 - Priority 10: `wp_abilities_api_init` fires. Abilities register.
-- **Priority 15: `AgentRegistry::reconcile()` fires the `datamachine_register_agents` action, collects registrations, creates missing DB rows, scaffolds agent-layer memory files.**
+- **Priority 15: `AgentRegistry::reconcile()` fires the `wp_agents_api_init` action, collects registrations, creates missing DB rows, scaffolds agent-layer memory files.**
 - Priority 20: existing `datamachine_needs_scaffold` transient check. No-op when the registry has already scaffolded.
 
-The `datamachine_register_agents` action is also fired lazily by `AgentRegistry::get_all()` / `get()` / `reconcile()` — so any caller can query the registry regardless of hook ordering.
+The `wp_agents_api_init` action is also fired lazily by `AgentRegistry::get_all()` / `get()` / `reconcile()` — so any caller can query the registry regardless of hook ordering. The legacy `datamachine_register_agents` hook and `datamachine_register_agent()` wrapper still fire while this surface lives in Data Machine; new code should use the WordPress-shaped names.
 
 ## Memory seed resolution
 
@@ -96,11 +96,11 @@ do_action( 'datamachine_registered_agent_reconciled', int $agent_id, string $slu
 Data Machine registers its default site administrator agent through the same hook:
 
 ```php
-add_action( 'datamachine_register_agents', function () {
+add_action( 'wp_agents_api_init', function () {
     $default_user_id = DirectoryManager::get_default_agent_user_id();
     $user            = get_user_by( 'id', $default_user_id );
 
-    datamachine_register_agent(
+    wp_register_agent(
         sanitize_title( $user->user_login ),
         array(
             'label'          => $user->display_name,
@@ -117,7 +117,7 @@ Same API. Same hook priority as any plugin. On existing installs this is a no-op
 
 | Scenario | Pattern |
 |---|---|
-| A role bundled with a plugin, same on every install | **Register** via `datamachine_register_agents` |
+| A role bundled with a plugin, same on every install | **Register** via `wp_agents_api_init` |
 | A user-created agent with install-specific name, owner, config | **Create imperatively** via `AgentAbilities::createAgent()` |
 | Lazy provisioning of a per-user agent on first chat turn | **Use** `datamachine_resolve_or_create_agent_id($user_id)` |
 
@@ -132,8 +132,8 @@ Two override paths. Pick based on what you're trying to change.
 Hook at a higher priority and re-register with the same slug:
 
 ```php
-add_action( 'datamachine_register_agents', function () {
-    datamachine_register_agent( 'wiki-generator', array(
+add_action( 'wp_agents_api_init', function () {
+    wp_register_agent( 'wiki-generator', array(
         'label'        => __( 'Custom Wiki Generator', 'my-override' ),
         'memory_seeds' => array(
             'SOUL.md' => __DIR__ . '/custom-wiki-soul.md',
@@ -158,7 +158,7 @@ Every DM core registration is a **named function** — callers can remove it cle
 
 ```php
 remove_action(
-    'datamachine_register_agents',
+    'wp_agents_api_init',
     'datamachine_register_default_admin_agent',
     10
 );
@@ -180,6 +180,6 @@ Registry-level overrides are the right tool for declaring defaults; content-leve
 ## Related
 
 - `docs/core-system/multi-agent-architecture.md` — agents table schema, access control, filesystem layout
-- `docs/core-filters.md` — the `datamachine_register_agents` action, `datamachine_registered_agent_reconciled` action, `datamachine_scaffold_content` filter
+- `docs/core-filters.md` — the `wp_agents_api_init` action, `datamachine_registered_agent_reconciled` action, `datamachine_scaffold_content` filter
 - `inc/Abilities/File/ScaffoldAbilities.php` — scaffold ability that honors registered `memory_seeds` content
 - `inc/migrations/scaffolding.php` — default `datamachine_scaffold_content` generators

--- a/docs/core-system/multi-agent-architecture.md
+++ b/docs/core-system/multi-agent-architecture.md
@@ -12,7 +12,7 @@ The multi-agent system consists of five layers:
 4. **Database scoping** — agent_id on pipelines, flows, jobs, and chat sessions
 5. **Resolution** — CLI and API helpers that resolve the active agent from context
 
-Plugins that ship bundled agent roles (e.g. a wiki-generator, a support-triage bot) declare them via the `datamachine_register_agents` action. See `agent-registration.md` for the declarative registration surface.
+Plugins that ship bundled agent roles (e.g. a wiki-generator, a support-triage bot) declare them via the `wp_agents_api_init` action and `wp_register_agent()` helper. See `agent-registration.md` for the declarative registration surface.
 
 ## Agents Table
 

--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -10,9 +10,9 @@ Mirror the WordPress Abilities API shape instead of importing Data Machine, wpco
 
 | Current Data Machine surface | Possible Agents API vocabulary | Notes |
 |---|---|---|
-| `datamachine_register_agent()` | `wp_register_agent()` | Same declarative pattern, but without DB reconciliation side effects in the public helper. |
-| `AgentRegistry` | `WP_Agents_Registry` | Registry should collect definitions. Persistence/adoption can remain adapter territory. |
-| `datamachine_register_agents` | `wp_agents_api_init` or `wp_register_agents` | Prefer a core-shaped init hook; exact name needs review against Abilities API precedent. |
+| `wp_register_agent()` | `wp_register_agent()` | Same declarative pattern as Abilities API-style registration; no DB reconciliation side effects in the public helper. |
+| `WP_Agent` / `WP_Agents_Registry` | `WP_Agent` / `WP_Agents_Registry` | Registry collects definitions. Persistence/adoption remains Data Machine adapter territory. |
+| `wp_agents_api_init` | `wp_agents_api_init` | Core-shaped init hook mirrored in-place while Data Machine hosts the substrate. |
 | `MessageEnvelope` | `WP_Agent_Message` or neutral envelope | Contract is generic. Data Machine schema/name is not. |
 | `ConversationStoreInterface` | `WP_Agent_Conversation_Store_Interface` | Keep transcript/session/read-state split if it remains boring. |
 | `AgentMemoryStoreInterface` | `WP_Agent_Memory_Store_Interface` | Generic identity tuple needs naming review; Data Machine scaffolding/abilities stay outside the store contract. |
@@ -65,8 +65,8 @@ These are closest to generic public contracts. Most should be extracted as contr
 | `datamachine_conversation_store` filter | `ConversationStoreFactory::get()` | Store swap seam is generic. | Target should be an Agents API store resolver/filter. |
 | `datamachine_conversation_runner` filter | `AIConversationLoop::run()` | Runner replacement seam is generic. | Target should be a runtime runner interface/filter, not Data Machine named. |
 | `datamachine_guideline_updated` action | `GuidelineAgentMemoryStore` | Logical memory/guideline change event is generic. | Target event must not assume Data Machine option names or storage. |
-| `datamachine_register_agent()` helper | `inc/Engine/Agents/register-agents.php` | Declarative agent registration is core-shaped. | Public helper should become `wp_register_agent()`; persistence reconciliation should not be part of the helper contract. |
-| `datamachine_register_agents` action | `inc/Engine/Agents/register-agents.php` | Registration collection hook is generic. | Rename to `wp_agents_api_init` or a core-reviewed equivalent. |
+| `wp_register_agent()` helper | `inc/Engine/Agents/register-agents.php` | Declarative agent registration is core-shaped. | Public helper contributes definitions only; persistence reconciliation is not part of the helper contract. |
+| `wp_agents_api_init` action | `inc/Engine/Agents/register-agents.php` | Registration collection hook is generic. | Keep as the in-place Agents API-shaped hook while Data Machine hosts the substrate. |
 | `datamachine_registered_agent_reconciled` action | `AgentRegistry::reconcile()` | Useful lifecycle event, but current name includes persistence behavior. | Public API should define lifecycle events separately from Data Machine DB reconciliation. |
 
 ## Agents API Implementation Candidate
@@ -101,7 +101,7 @@ These are plausibly generic implementations, but should not move until naming an
 | `GuidelineAgentMemoryStore` | `inc/Core/FilesRepository/GuidelineAgentMemoryStore.php` | Generic implementation for `wp_guideline`, but Data Machine does not own that substrate. | Agents API can ship it as optional implementation guarded by `post_type_exists()`. |
 | `DiskAgentMemoryStore` | `inc/Core/FilesRepository/DiskAgentMemoryStore.php` | Generic self-hosted implementation, but path conventions are Data Machine runtime conventions. | Extract only if Agents API deliberately supports disk memory. |
 | `AgentMemoryStoreFactory` | `inc/Core/FilesRepository/AgentMemoryStoreFactory.php` | Generic store resolver pattern. | Rename filter and return type; preserve single resolution point. |
-| `AgentRegistry` | `inc/Engine/Agents/AgentRegistry.php` | Generic declarative registry mixed with Data Machine DB reconciliation/scaffolding. | Split into registry contract plus Data Machine reconciler. |
+| `WP_Agent` / `WP_Agents_Registry` / `AgentRegistry` | `inc/Engine/Agents/class-wp-agent.php`, `inc/Engine/Agents/class-wp-agents-registry.php`, `inc/Engine/Agents/AgentRegistry.php` | Generic declarative registry now has WordPress-shaped facade; Data Machine reconciliation is delegated to `AgentMaterializer`. | Extract facade/registry contract first; keep Data Machine materializer as consumer. |
 | `Agents`, `AgentAccess`, `AgentTokens` repositories | `inc/Core/Database/Agents/` | Generic identity/access/token data model, but table names and permissions are Data Machine-owned. | Extract only after deciding whether Agents API owns persistence tables or just contracts. |
 | `AgentAbilities`, `AgentTokenAbilities`, `AgentRemoteCallAbilities`, `AgentCallAbilities` | `inc/Abilities/` | Ability shapes are generic candidates, but slugs and permission helpers are Data Machine-specific. | Re-register as `wp-agents/v1`/Agents API abilities after permission model settles. |
 
@@ -174,7 +174,7 @@ These are reference points only. Do not expose them as public Data Machine or Ag
 | `datamachine_conversation_runner` | Agents API public candidate | Generic runtime replacement seam. Rename and formalize result contract. |
 | `datamachine_conversation_store` | Agents API public candidate | Generic conversation persistence swap seam. Rename and keep narrow contracts. |
 | `datamachine_memory_store` | Agents API public candidate | Generic memory persistence swap seam. Keep as Data Machine's current public behavior until extraction; introduce a neutral Agents API filter only when that package owns the resolver and migration path. |
-| `datamachine_register_agents` | Agents API public candidate | Registration hook should become WordPress-shaped. |
+| `wp_agents_api_init` | Agents API public candidate | Registration hook is now WordPress-shaped in-place; Data Machine still fires the legacy hook while it hosts the substrate. |
 | `datamachine_registered_agent_reconciled` | Agents API implementation candidate | Lifecycle event is useful, current reconciliation semantics are Data Machine implementation. |
 | `datamachine_guideline_updated` | Agents API public candidate | Generic memory/guideline change event after naming review. |
 | `datamachine_tool_sources` | Agents API implementation candidate | Generic source-provider idea; current defaults include Data Machine adjacent handlers. |

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -40,13 +40,13 @@ These are still Data Machine-named even when the seam is generic:
 - `datamachine_memory_store`
 - `datamachine_tool_sources`
 - `datamachine_tool_sources_for_mode`
-- `datamachine_register_agents`
+- `wp_agents_api_init`
 - `datamachine_guideline_updated`
 
 Target shape:
 
 - Decide the `agents_api_*` / `wp_agents_api_*` hook names before extraction.
-- Keep existing Data Machine hooks while code is in this repository.
+- Keep existing Data Machine hooks while code is in this repository, but make new registrations use the WordPress-shaped hook/helper.
 - Do not add runtime fallback ladders that survive extraction. When Agents API owns the seam, migrate consumers to the new hook names directly.
 
 ### 3. Message Envelope Vocabulary
@@ -92,11 +92,11 @@ Target shape:
 
 ### 7. Agent Registry And Identity
 
-Declarative registration is separated from materialization, but the public helper is still `datamachine_register_agent()` and persistence still targets Data Machine tables.
+Declarative registration is separated from materialization, and the public vocabulary is now mirrored in-place as `wp_register_agent()`, `WP_Agent`, `WP_Agents_Registry`, and `wp_agents_api_init`. Persistence still targets Data Machine tables through the materializer while Data Machine hosts the substrate.
 
 Target shape:
 
-- Mirror Abilities API: `wp_register_agent()`, `WP_Agent`, `WP_Agents_Registry`, `wp_agents_api_init`.
+- Extract the WordPress-shaped facade/registry contract before moving Data Machine persistence repositories.
 - Data Machine reconciler continues to create its rows/access records from registered definitions while Data Machine hosts the substrate.
 - Decide whether Agents API owns persistence tables, only contracts, or optional stores before moving repositories.
 

--- a/inc/Engine/Agents/AgentRegistry.php
+++ b/inc/Engine/Agents/AgentRegistry.php
@@ -2,12 +2,12 @@
 /**
  * Agent Registry
  *
- * Declarative registration surface for Data Machine agents. Plugins
- * (and DM core itself) declare agent roles by calling
- * `datamachine_register_agent()` inside a `datamachine_register_agents`
- * action callback. The registry collects definitions; Data Machine's
- * materializer reconciles them against the `datamachine_agents` table
- * on init.
+ * Declarative registration surface for agents. Plugins (and DM core
+ * itself) declare agent roles by calling `wp_register_agent()` inside a
+ * `wp_agents_api_init` action callback. The registry collects definitions;
+ * Data Machine's materializer consumes them and reconciles them against
+ * the `datamachine_agents` table on init while Data Machine hosts the
+ * substrate.
  *
  * Registration is side-effect free — adding a slug to the registry
  * does not touch the database. Reconciliation materializes missing
@@ -15,7 +15,7 @@
  * leaves existing rows alone (owner_id, agent_config, and other
  * mutable fields remain DB-owned).
  *
- * Plugins ship declarative agent definitions; DM owns the runtime.
+ * Plugins ship declarative agent definitions; DM owns today's runtime.
  * The split mirrors the WordPress pattern where
  * `register_post_type()` is declarative and the posts table stays
  * operator-mutable.
@@ -38,7 +38,7 @@ class AgentRegistry {
 	private static array $agents = array();
 
 	/**
-	 * Whether the `datamachine_register_agents` action has fired.
+	 * Whether the agent registration actions have fired.
 	 *
 	 * @var bool
 	 */
@@ -47,7 +47,7 @@ class AgentRegistry {
 	/**
 	 * Register an agent definition.
 	 *
-	 * Call from inside a `datamachine_register_agents` action callback.
+	 * Call from inside a `wp_agents_api_init` action callback.
 	 * Later registrations for the same slug overwrite earlier ones — this
 	 * matches WordPress hook semantics, so plugins can override core or
 	 * other plugins via action priority.
@@ -113,7 +113,7 @@ class AgentRegistry {
 	/**
 	 * Get all registered agent definitions.
 	 *
-	 * Fires the `datamachine_register_agents` action once per request so
+	 * Fires the `wp_agents_api_init` action once per request so
 	 * callers can lazily collect registrations without needing to worry
 	 * about hook ordering.
 	 *
@@ -164,7 +164,7 @@ class AgentRegistry {
 	}
 
 	/**
-	 * Ensure the `datamachine_register_agents` action has fired.
+	 * Ensure the agent registration actions have fired.
 	 *
 	 * Plugins register their agents inside action callbacks — collecting
 	 * them lazily lets callers of `get_all()` / `reconcile()` / `get()`
@@ -180,12 +180,23 @@ class AgentRegistry {
 		self::$registration_fired = true;
 
 		/**
-		 * Fires to let plugins register Data Machine agents.
+		 * Fires to let plugins register agents.
 		 *
-		 * Callbacks should call `datamachine_register_agent()` to contribute
+		 * Callbacks should call `wp_register_agent()` to contribute
 		 * one or more agent definitions. Registrations are collected into a
 		 * central registry and reconciled against the `datamachine_agents`
 		 * table on `init` (priority 15).
+		 *
+		 * @since 0.99.0
+		 */
+		do_action( 'wp_agents_api_init' );
+
+		/**
+		 * Fires to let existing Data Machine consumers register agents.
+		 *
+		 * This hook remains while the Agents API surface lives in Data Machine.
+		 * New code should use `wp_agents_api_init` and `wp_register_agent()` so
+		 * the registry vocabulary can move cleanly when Agents API is extracted.
 		 *
 		 * @since 0.71.0
 		 */

--- a/inc/Engine/Agents/class-wp-agent.php
+++ b/inc/Engine/Agents/class-wp-agent.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * WP_Agent definition object.
+ *
+ * @package DataMachine\Engine\Agents
+ * @since   0.99.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent' ) ) {
+	/**
+	 * Declarative agent definition.
+	 *
+	 * This mirrors WordPress value-object vocabulary while the underlying
+	 * registry still lives in Data Machine. Constructing an agent definition
+	 * does not create Data Machine DB rows, access records, directories, or
+	 * scaffold files.
+	 *
+	 * @since 0.99.0
+	 */
+	class WP_Agent {
+
+		/**
+		 * Agent slug.
+		 *
+		 * @var string
+		 */
+		public string $slug;
+
+		/**
+		 * Registration arguments.
+		 *
+		 * @var array
+		 */
+		private array $args;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string $slug Unique agent slug.
+		 * @param array  $args Registration arguments.
+		 */
+		public function __construct( string $slug, array $args = array() ) {
+			$this->slug = sanitize_title( $slug );
+			$this->args = $args;
+		}
+
+		/**
+		 * Return registration arguments for the registry.
+		 *
+		 * @return array
+		 */
+		public function to_array(): array {
+			return $this->args;
+		}
+	}
+}

--- a/inc/Engine/Agents/class-wp-agents-registry.php
+++ b/inc/Engine/Agents/class-wp-agents-registry.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * WP_Agents_Registry facade.
+ *
+ * @package DataMachine\Engine\Agents
+ * @since   0.99.0
+ */
+
+use DataMachine\Engine\Agents\AgentRegistry;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agents_Registry' ) ) {
+	/**
+	 * WordPress-shaped facade for the in-place agent registry.
+	 *
+	 * Data Machine remains the materialization consumer. This facade only
+	 * contributes definitions to the side-effect-free registry.
+	 *
+	 * @since 0.99.0
+	 */
+	class WP_Agents_Registry {
+
+		/**
+		 * Register an agent definition.
+		 *
+		 * @param string|WP_Agent $agent Agent slug or definition object.
+		 * @param array           $args  Registration arguments when `$agent` is a slug.
+		 * @return void
+		 */
+		public static function register( $agent, array $args = array() ): void {
+			if ( $agent instanceof WP_Agent ) {
+				AgentRegistry::register( $agent->slug, $agent->to_array() );
+				return;
+			}
+
+			AgentRegistry::register( (string) $agent, $args );
+		}
+
+		/**
+		 * Get all registered agent definitions.
+		 *
+		 * @return array<string, array>
+		 */
+		public static function get_all(): array {
+			return AgentRegistry::get_all();
+		}
+
+		/**
+		 * Get a single registered agent definition by slug.
+		 *
+		 * @param string $slug Agent slug.
+		 * @return array|null Definition, or null if not registered.
+		 */
+		public static function get( string $slug ): ?array {
+			return AgentRegistry::get( $slug );
+		}
+	}
+}

--- a/inc/Engine/Agents/register-agents.php
+++ b/inc/Engine/Agents/register-agents.php
@@ -61,7 +61,7 @@ if ( ! function_exists( 'wp_register_agent' ) ) {
  * @return void
  */
 function datamachine_register_agent( string $slug, array $args = array() ): void {
-	wp_register_agent( $slug, $args );
+	AgentRegistry::register( $slug, $args );
 }
 
 /**

--- a/inc/Engine/Agents/register-agents.php
+++ b/inc/Engine/Agents/register-agents.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Agent Registration — global helper + hook wiring.
+ * Agent Registration — global helpers + hook wiring.
  *
- * Defines the top-level `datamachine_register_agent()` function that
- * plugins call from inside a `datamachine_register_agents` action
- * callback to declare agents. Wires reconciliation on `init` and a
- * scaffold generator that surfaces each registered agent's bundled
- * `memory_seeds` entries as scaffold content for their respective
- * agent-layer memory files (SOUL.md, MEMORY.md, or any custom file
- * registered via `MemoryFileRegistry::register()`).
+ * Defines the top-level `wp_register_agent()` function that plugins call
+ * from inside a `wp_agents_api_init` action callback to declare agents.
+ * Wires reconciliation on `init` and a scaffold generator that surfaces
+ * each registered agent's bundled `memory_seeds` entries as scaffold
+ * content for their respective agent-layer memory files (SOUL.md,
+ * MEMORY.md, or any custom file registered via
+ * `MemoryFileRegistry::register()`).
  *
  * Also dogfoods the API: DM itself registers the site's default
  * administrator agent through the same hook plugins use. On existing
@@ -25,12 +25,34 @@ use DataMachine\Engine\Agents\AgentRegistry;
 
 defined( 'ABSPATH' ) || exit;
 
+require_once __DIR__ . '/class-wp-agent.php';
+require_once __DIR__ . '/class-wp-agents-registry.php';
+
+if ( ! function_exists( 'wp_register_agent' ) ) {
+	/**
+	 * Register an agent.
+	 *
+	 * Call from inside a `wp_agents_api_init` action callback. The registry
+	 * collects all definitions; Data Machine reconciles them against the
+	 * `datamachine_agents` table on `init` priority 15 while it hosts the
+	 * in-place substrate.
+	 *
+	 * @since 0.99.0
+	 *
+	 * @param string|WP_Agent $agent Agent slug or definition object.
+	 * @param array           $args  Registration arguments. See AgentRegistry::register().
+	 * @return void
+	 */
+	function wp_register_agent( $agent, array $args = array() ): void {
+		WP_Agents_Registry::register( $agent, $args );
+	}
+}
+
 /**
  * Register a Data Machine agent.
  *
- * Call from inside a `datamachine_register_agents` action callback.
- * The registry collects all definitions and reconciles them against
- * the `datamachine_agents` table on `init` priority 15.
+ * Existing Data Machine-named wrapper for the in-place transition. New
+ * declarations should use `wp_register_agent()` from `wp_agents_api_init`.
  *
  * @since 0.71.0
  *
@@ -39,7 +61,7 @@ defined( 'ABSPATH' ) || exit;
  * @return void
  */
 function datamachine_register_agent( string $slug, array $args = array() ): void {
-	AgentRegistry::register( $slug, $args );
+	wp_register_agent( $slug, $args );
 }
 
 /**
@@ -133,7 +155,7 @@ add_filter(
  * default admin-agent registration can `remove_action()` it cleanly:
  *
  *     remove_action(
- *         'datamachine_register_agents',
+ *         'wp_agents_api_init',
  *         'datamachine_register_default_admin_agent',
  *         10
  *     );
@@ -170,8 +192,8 @@ function datamachine_register_default_admin_agent(): void {
 	$default_config = array();
 	if ( class_exists( '\\DataMachine\\Core\\PluginSettings' ) ) {
 		$resolved = \DataMachine\Core\PluginSettings::getModelForMode( 'chat' );
-		$provider = isset( $resolved['provider'] ) ? (string) $resolved['provider'] : '';
-		$model    = isset( $resolved['model'] ) ? (string) $resolved['model'] : '';
+		$provider = (string) $resolved['provider'];
+		$model    = (string) $resolved['model'];
 
 		if ( '' !== $provider ) {
 			$default_config['default_provider'] = $provider;
@@ -181,7 +203,7 @@ function datamachine_register_default_admin_agent(): void {
 		}
 	}
 
-	datamachine_register_agent(
+	wp_register_agent(
 		$slug,
 		array(
 			'label'          => (string) $user->display_name,
@@ -191,4 +213,4 @@ function datamachine_register_default_admin_agent(): void {
 		)
 	);
 }
-add_action( 'datamachine_register_agents', 'datamachine_register_default_admin_agent', 10 );
+add_action( 'wp_agents_api_init', 'datamachine_register_default_admin_agent', 10 );

--- a/inc/Engine/Agents/register-agents.php
+++ b/inc/Engine/Agents/register-agents.php
@@ -191,7 +191,13 @@ function datamachine_register_default_admin_agent(): void {
 
 	$default_config = array();
 	if ( class_exists( '\\DataMachine\\Core\\PluginSettings' ) ) {
-		$resolved = \DataMachine\Core\PluginSettings::getModelForMode( 'chat' );
+		$resolved = array_merge(
+			array(
+				'provider' => '',
+				'model'    => '',
+			),
+			\DataMachine\Core\PluginSettings::getModelForMode( 'chat' )
+		);
 		$provider = (string) $resolved['provider'];
 		$model    = (string) $resolved['model'];
 

--- a/inc/Engine/Agents/register-agents.php
+++ b/inc/Engine/Agents/register-agents.php
@@ -191,15 +191,9 @@ function datamachine_register_default_admin_agent(): void {
 
 	$default_config = array();
 	if ( class_exists( '\\DataMachine\\Core\\PluginSettings' ) ) {
-		$resolved = array_merge(
-			array(
-				'provider' => '',
-				'model'    => '',
-			),
-			\DataMachine\Core\PluginSettings::getModelForMode( 'chat' )
-		);
-		$provider = (string) $resolved['provider'];
-		$model    = (string) $resolved['model'];
+		$resolved = \DataMachine\Core\PluginSettings::getModelForMode( 'chat' );
+		$provider = isset( $resolved['provider'] ) ? (string) $resolved['provider'] : ''; // @phpstan-ignore isset.offset
+		$model    = isset( $resolved['model'] ) ? (string) $resolved['model'] : ''; // @phpstan-ignore isset.offset
 
 		if ( '' !== $provider ) {
 			$default_config['default_provider'] = $provider;

--- a/tests/agent-registry-materializer-smoke.php
+++ b/tests/agent-registry-materializer-smoke.php
@@ -248,8 +248,10 @@ namespace {
 	assert_agent_materializer_equals( 1, count( ScaffoldAbilities::$ability->calls ), 'existing row does not scaffold again', $failures, $passes );
 
 	echo "\n[4] materializer owns Data Machine side-effect dependencies:\n";
+	$registration_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/Agents/register-agents.php' );
 	$registry_source     = (string) file_get_contents( __DIR__ . '/../inc/Engine/Agents/AgentRegistry.php' );
 	$materializer_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/Agents/AgentMaterializer.php' );
+	assert_agent_materializer_equals( false, (bool) preg_match( '/function\s+datamachine_register_agent[^{]*{[^}]*wp_register_agent\s*\(/s', $registration_source ), 'legacy helper writes directly to Data Machine registry instead of delegating to wp_register_agent', $failures, $passes );
 	assert_agent_materializer_equals( false, false !== strpos( $registry_source, 'Core\\Database\\Agents' ), 'registry no longer imports agent database repositories', $failures, $passes );
 	assert_agent_materializer_equals( false, false !== strpos( $registry_source, 'ScaffoldAbilities' ), 'registry no longer imports scaffold ability', $failures, $passes );
 	assert_agent_materializer_equals( true, false !== strpos( $materializer_source, 'Core\\Database\\Agents' ), 'materializer owns agent database repositories', $failures, $passes );

--- a/tests/agent-registry-materializer-smoke.php
+++ b/tests/agent-registry-materializer-smoke.php
@@ -13,6 +13,7 @@ namespace {
 	}
 
 	$GLOBALS['__agent_materializer_actions'] = array();
+	$GLOBALS['__agent_materializer_hooks']   = array();
 
 	function sanitize_title( string $value ): string {
 		$value = strtolower( $value );
@@ -26,6 +27,23 @@ namespace {
 
 	function do_action( string $hook, ...$args ): void {
 		$GLOBALS['__agent_materializer_actions'][ $hook ][] = $args;
+		$callbacks = $GLOBALS['__agent_materializer_hooks'][ $hook ] ?? array();
+		ksort( $callbacks );
+
+		foreach ( $callbacks as $priority_callbacks ) {
+			foreach ( $priority_callbacks as $callback ) {
+				call_user_func_array( $callback, $args );
+			}
+		}
+	}
+
+	function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		unset( $accepted_args );
+		$GLOBALS['__agent_materializer_hooks'][ $hook ][ $priority ][] = $callback;
+	}
+
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		add_action( $hook, $callback, $priority, $accepted_args );
 	}
 }
 
@@ -113,6 +131,7 @@ namespace DataMachine\Abilities\File {
 namespace {
 	require_once __DIR__ . '/../inc/Engine/Agents/AgentMaterializer.php';
 	require_once __DIR__ . '/../inc/Engine/Agents/AgentRegistry.php';
+	require_once __DIR__ . '/../inc/Engine/Agents/register-agents.php';
 
 	use DataMachine\Abilities\File\ScaffoldAbilities;
 	use DataMachine\Abilities\File\ScaffoldAbilityStub;
@@ -145,13 +164,65 @@ namespace {
 		DirectoryManager::$ensured                       = array();
 		ScaffoldAbilities::$ability                      = new ScaffoldAbilityStub();
 		$GLOBALS['__agent_materializer_actions'] = array();
+		$GLOBALS['__agent_materializer_hooks']   = array();
 	}
 
 	echo "agent-registry-materializer-smoke\n";
 
-	echo "\n[1] registry collects normalized declarative definitions without materializing rows:\n";
+	echo "\n[1] WordPress-shaped registry vocabulary collects definitions without materializing rows:\n";
 	reset_agent_materializer_smoke();
-	AgentRegistry::register(
+	wp_register_agent(
+		new WP_Agent(
+			'Example Agent!',
+			array(
+				'label'          => 'Example Agent',
+				'description'    => 'Collect only',
+				'memory_seeds'   => array( '../SOUL.md' => '/tmp/seed-soul.md' ),
+				'owner_resolver' => static fn() => 7,
+				'default_config' => array( 'default_provider' => 'openai' ),
+			)
+		)
+	);
+	$definitions = WP_Agents_Registry::get_all();
+	assert_agent_materializer_equals( true, class_exists( 'WP_Agent' ), 'WP_Agent definition object is available', $failures, $passes );
+	assert_agent_materializer_equals( true, class_exists( 'WP_Agents_Registry' ), 'WP_Agents_Registry facade is available', $failures, $passes );
+	assert_agent_materializer_equals( array( 'example-agent' ), array_keys( $definitions ), 'definition slug is normalized', $failures, $passes );
+	assert_agent_materializer_equals( 'Example Agent', $definitions['example-agent']['label'] ?? '', 'definition label is preserved', $failures, $passes );
+	assert_agent_materializer_equals( array(), Agents::$rows, 'collecting definitions does not create agent rows', $failures, $passes );
+
+	echo "\n[1b] wp_agents_api_init is the primary collection hook while legacy hook remains available:\n";
+	reset_agent_materializer_smoke();
+	add_action(
+		'wp_agents_api_init',
+		static function (): void {
+			wp_register_agent(
+				'hook-agent',
+				array(
+					'label'          => 'Hook Agent',
+					'owner_resolver' => static fn() => 9,
+				)
+			);
+		}
+	);
+	add_action(
+		'datamachine_register_agents',
+		static function (): void {
+			datamachine_register_agent(
+				'legacy-agent',
+				array(
+					'label'          => 'Legacy Agent',
+					'owner_resolver' => static fn() => 11,
+				)
+			);
+		}
+	);
+	$definitions = AgentRegistry::get_all();
+	assert_agent_materializer_equals( array( 'hook-agent', 'legacy-agent' ), array_keys( $definitions ), 'new and in-repo legacy hooks both contribute definitions', $failures, $passes );
+	assert_agent_materializer_equals( array(), Agents::$rows, 'hook collection remains side-effect free', $failures, $passes );
+
+	echo "\n[2] reconciliation creates rows, access grants, directories, scaffold calls, and action hooks:\n";
+	reset_agent_materializer_smoke();
+	wp_register_agent(
 		'Example Agent!',
 		array(
 			'label'          => 'Example Agent',
@@ -161,12 +232,6 @@ namespace {
 			'default_config' => array( 'default_provider' => 'openai' ),
 		)
 	);
-	$definitions = AgentRegistry::get_all();
-	assert_agent_materializer_equals( array( 'example-agent' ), array_keys( $definitions ), 'definition slug is normalized', $failures, $passes );
-	assert_agent_materializer_equals( 'Example Agent', $definitions['example-agent']['label'] ?? '', 'definition label is preserved', $failures, $passes );
-	assert_agent_materializer_equals( array(), Agents::$rows, 'collecting definitions does not create agent rows', $failures, $passes );
-
-	echo "\n[2] reconciliation creates rows, access grants, directories, scaffold calls, and action hooks:\n";
 	$summary = AgentRegistry::reconcile();
 	assert_agent_materializer_equals( array( 'created' => array( 'example-agent' ), 'existing' => array(), 'skipped' => array() ), $summary, 'created summary matches pre-split registry behavior', $failures, $passes );
 	assert_agent_materializer_equals( 7, Agents::$rows['example-agent']['owner_id'] ?? 0, 'owner resolver controls created row owner', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add `WP_Agent`, `WP_Agents_Registry`, `wp_register_agent()`, and `wp_agents_api_init` as the in-place Agents API-shaped registration vocabulary.
- Keep Data Machine materialization as the consumer that creates DB rows, access grants, directories, and scaffold files.
- Update agent registration and extraction docs to make the WordPress-shaped vocabulary primary while preserving the legacy Data Machine hook/helper during the in-repo transition.

## Tests
- `php tests/agent-registry-materializer-smoke.php` — passed, 21 assertions.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-agent-registry --changed-since origin/main --summary` — passed, no baseline drift.

## Homeboy test status
- Branch check: `homeboy test data-machine --path /Users/chubes/Developer/data-machine@agents-api-agent-registry --changed-since origin/main --summary` still fails in the broad changed-since test harness.
- Main comparison: `homeboy test data-machine --path /Users/chubes/Developer/data-machine@agents-api-agent-registry-main-compare --summary` was run in a temporary clean `origin/main` worktree, then the worktree was removed. Main also fails with the same failure classes, including `AltTextTask::execute()` missing, `BaseOAuth2Provider::refresh_token()` missing, `ImportExport.php` array passed to `json_decode()`, `PipelineStepAbilitiesTest::test_add_pipeline_step_ai_type_without_step_config_uses_defaults`, and `BaseAuthProviderEncryptionTest::test_different_salts_cannot_decrypt_each_others_data`.
- Conclusion: the red Homeboy test check is pre-existing suite drift, not branch-caused. This branch's focused registry smoke and changed-since lint pass.

Closes #1594

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the in-place registry vocabulary changes, docs updates, smoke coverage, and verification commands for Chris to review.