### PR TITLE
refactor(agent): rename memory store seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,11 +246,11 @@ See [`docs/core-system/ai-conversation-loop.md`](docs/core-system/ai-conversatio
 
 ## Memory Storage Adapters
 
-Agent memory files (MEMORY.md, SOUL.md, USER.md, NETWORK.md, AGENTS.md, plus any custom files registered through `MemoryFileRegistry`) persist on the local filesystem by default. The persistence layer is swappable through a single filter (`datamachine_memory_store`), enabling DB-backed implementations on managed hosts that don't expose a writable filesystem.
+Agent memory files (MEMORY.md, SOUL.md, USER.md, NETWORK.md, AGENTS.md, plus any custom files registered through `MemoryFileRegistry`) persist on the local filesystem by default. The persistence layer is swappable through a single Agents API-shaped filter (`agents_api_memory_store`), enabling DB-backed implementations on managed hosts that don't expose a writable filesystem.
 
 ```php
 add_filter(
-    'datamachine_memory_store',
+    'agents_api_memory_store',
     function ( $store, $scope ) {
         // Return an AgentMemoryStoreInterface to replace the disk default
         // for this scope, or null to let Data Machine read/write through

--- a/docs/architecture/agent-memory-backends.md
+++ b/docs/architecture/agent-memory-backends.md
@@ -39,7 +39,7 @@ CoreMemoryFilesDirective
         |
         v
 AgentMemoryStoreFactory
-  datamachine_memory_store filter
+  agents_api_memory_store filter
         |
         +--> DiskAgentMemoryStore (default)
         |
@@ -62,11 +62,11 @@ The disk store intentionally does not implement compare-and-swap writes; it acce
 
 ## Backend Selection
 
-Data Machine resolves memory persistence through one current filter:
+Data Machine resolves memory persistence through one current Agents API-shaped filter:
 
 ```php
 apply_filters(
-    'datamachine_memory_store',
+    'agents_api_memory_store',
     null,
     AgentMemoryScope $scope
 );
@@ -74,7 +74,7 @@ apply_filters(
 
 Return an `AgentMemoryStoreInterface` implementation to replace the disk default for the given scope. Return `null` to keep `DiskAgentMemoryStore`.
 
-Future Agents API extraction should introduce its neutral resolver/filter name in the extracted package with a migration plan. Data Machine does not add a second alias today; `datamachine_memory_store` remains the active public behavior until ownership actually moves.
+`agents_api_memory_store` replaces the earlier `datamachine_memory_store` name in-place. Data Machine intentionally does not call both filters; consumers should migrate to the Agents API-shaped hook rather than relying on a permanent alias.
 
 Backend selection should be capability-driven:
 
@@ -95,7 +95,7 @@ DMC should be treated as a projection provider, not the memory model:
 | Logical memory identity and access | Data Machine (`AgentMemoryScope`, `AgentMemory`) |
 | Registered memory files and mode-aware injection | Data Machine (`MemoryFileRegistry`, directives) |
 | Disk file projection for local coding agents | DMC + `DiskAgentMemoryStore` environment capability |
-| Managed-host alternate backend | Consumer plugin via `datamachine_memory_store` |
+| Managed-host alternate backend | Consumer plugin via `agents_api_memory_store` |
 
 `MEMORY.md` is not deprecated. On disk-capable installs it remains the agent's persistent knowledge file. On hosts without disk, the same logical `MEMORY.md` may be represented by another backend while still appearing to Data Machine as `(agent, user_id, agent_id, MEMORY.md)`.
 

--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -51,7 +51,7 @@ These are closest to generic public contracts. Most should be extracted as contr
 | `LoopEventSinkInterface` | `inc/Engine/AI/LoopEventSinkInterface.php` | Transport-neutral event sink for logs, streaming, CLI, REST, or chat UIs. | Make event vocabulary public and provider-neutral before extraction. |
 | `NullLoopEventSink` | `inc/Engine/AI/NullLoopEventSink.php` | Generic no-op implementation for optional event sinks. | Implementation can move with the interface. |
 | `RuntimeToolDeclaration` | `inc/Engine/AI/Tools/RuntimeToolDeclaration.php` | Validates run-scoped client/runtime tool declarations without Data Machine state. | Rename around `WP_Agent_Tool_Declaration`; keep executor/source/scope vocabulary generic. |
-| `AgentMemoryStoreInterface` | `inc/Core/FilesRepository/AgentMemoryStoreInterface.php` | Generic memory persistence seam. | Rename `AgentMemoryScope` tuple fields only if needed; keep CAS/hash behavior. |
+| `AgentMemoryStoreInterface` | `inc/Core/FilesRepository/AgentMemoryStoreInterface.php` | Generic memory persistence seam using the `agents_api_memory_store` resolver hook. | Rename `AgentMemoryScope` tuple fields only if needed; keep CAS/hash behavior. |
 | `AgentMemoryScope` | `inc/Core/FilesRepository/AgentMemoryScope.php` | Encodes memory identity independently of disk/database implementations. | Review `layer`, `user_id`, `agent_id`, `filename` as the public model. |
 | `AgentMemoryReadResult` | `inc/Core/FilesRepository/AgentMemoryReadResult.php` | Store-neutral read result. | Generic result value object can move unchanged after naming cleanup. |
 | `AgentMemoryWriteResult` | `inc/Core/FilesRepository/AgentMemoryWriteResult.php` | Store-neutral write result with hash/bytes/error shape. | Generic result value object can move unchanged after naming cleanup. |
@@ -173,7 +173,7 @@ These are reference points only. Do not expose them as public Data Machine or Ag
 |---|---|---|
 | `datamachine_conversation_runner` | Agents API public candidate | Generic runtime replacement seam. Rename and formalize result contract. |
 | `datamachine_conversation_store` | Agents API public candidate | Generic conversation persistence swap seam. Rename and keep narrow contracts. |
-| `datamachine_memory_store` | Agents API public candidate | Generic memory persistence swap seam. Keep as Data Machine's current public behavior until extraction; introduce a neutral Agents API filter only when that package owns the resolver and migration path. |
+| `agents_api_memory_store` | Agents API public candidate | Generic memory persistence swap seam. Renamed in place from `datamachine_memory_store`; do not mirror the old hook under a runtime alias. |
 | `datamachine_register_agents` | Agents API public candidate | Registration hook should become WordPress-shaped. |
 | `datamachine_registered_agent_reconciled` | Agents API implementation candidate | Lifecycle event is useful, current reconciliation semantics are Data Machine implementation. |
 | `datamachine_guideline_updated` | Agents API public candidate | Generic memory/guideline change event after naming review. |

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -12,7 +12,7 @@ The initial untangling wave is complete:
 - Adjacent handler tools are a Data Machine provider instead of generic source-registry behavior.
 - Ability-native tool execution is separated from Data Machine pending-action and post-tracking decorators.
 - Declarative agent registration is separated from Data Machine materialization.
-- Memory store ownership is documented behind a neutral store contract.
+- Memory store ownership is documented behind an Agents API-shaped store contract and filter name.
 - Conversation transcript storage is narrowed behind a transcript facade.
 - The runner request boundary exists.
 
@@ -33,11 +33,12 @@ Target shape:
 
 ### 2. Runtime Hooks And Filters
 
-These are still Data Machine-named even when the seam is generic:
+These generic seams still need Agents API naming decisions or have already moved
+in place:
 
 - `datamachine_conversation_runner`
 - `datamachine_conversation_store`
-- `datamachine_memory_store`
+- `agents_api_memory_store`
 - `datamachine_tool_sources`
 - `datamachine_tool_sources_for_mode`
 - `datamachine_register_agents`
@@ -46,8 +47,8 @@ These are still Data Machine-named even when the seam is generic:
 Target shape:
 
 - Decide the `agents_api_*` / `wp_agents_api_*` hook names before extraction.
-- Keep existing Data Machine hooks while code is in this repository.
-- Do not add runtime fallback ladders that survive extraction. When Agents API owns the seam, migrate consumers to the new hook names directly.
+- Keep existing Data Machine hooks while code is in this repository unless a seam can move cleanly to Agents API vocabulary in place.
+- Do not add runtime fallback ladders that survive extraction. When a seam moves to a new hook name, migrate consumers to the new hook directly.
 
 ### 3. Message Envelope Vocabulary
 
@@ -79,6 +80,12 @@ Target shape:
 - `GuidelineAgentMemoryStore` becomes the core-friendly/default implementation where `wp_guideline` exists.
 - `DiskAgentMemoryStore` becomes `MarkdownMemoryStore` only if disk-backed agent memory is part of the public Agents API product.
 - Data Machine file scaffolding stays a Data Machine adapter.
+
+Current in-place migration:
+
+- `agents_api_memory_store` is the active memory-store resolver hook.
+- The previous `datamachine_memory_store` hook is intentionally not mirrored; pre-1.0 consumers should register on `agents_api_memory_store`.
+- `DiskAgentMemoryStore` keeps its class name until a physical Agents API package decides whether disk/markdown memory is part of the public product.
 
 ### 6. Tool Registry And Execution
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -1476,11 +1476,11 @@ default ([`DiskAgentMemoryStore`](../../../inc/Core/FilesRepository/DiskAgentMem
 preserves byte-for-byte the filesystem behavior the codebase used before this
 seam was introduced.
 
-**Current filter: `datamachine_memory_store`**
+**Current filter: `agents_api_memory_store`**
 
 ```php
 apply_filters(
-    'datamachine_memory_store',
+    'agents_api_memory_store',
     null,                       // Return AgentMemoryStoreInterface to short-circuit
     AgentMemoryScope $scope     // Identifies (layer, user_id, agent_id, filename)
 );
@@ -1490,17 +1490,18 @@ Return an [`AgentMemoryStoreInterface`](../../../inc/Core/FilesRepository/AgentM
 implementation to replace the disk default for this scope. Return `null` (the
 default) to let Data Machine read and write through the filesystem.
 
-This is the only runtime filter in Data Machine today. A future Agents API
-extraction should introduce a neutral resolver/filter name in the extracted
-package with an explicit migration path; Data Machine does not mirror this hook
-under a second alias before ownership moves.
+This is the only runtime filter in Data Machine today. It replaces the earlier
+`datamachine_memory_store` name in-place so the memory-store seam already uses
+Agents API vocabulary before physical extraction. Data Machine does not mirror
+the old name under a second alias because that would create a permanent
+compatibility ladder instead of moving ownership.
 
 **Use case**: managed-host environments where the local filesystem is not
 writable (e.g. WordPress.com, VIP). A consumer plugin (e.g. Intelligence)
 ships a DB-backed implementation and registers it conditionally:
 
 ```php
-add_filter( 'datamachine_memory_store', function ( $store, $scope ) {
+add_filter( 'agents_api_memory_store', function ( $store, $scope ) {
     if ( $store instanceof AgentMemoryStoreInterface ) {
         return $store;  // someone else already swapped
     }

--- a/inc/Abilities/DailyMemoryAbilities.php
+++ b/inc/Abilities/DailyMemoryAbilities.php
@@ -49,7 +49,7 @@ class DailyMemoryAbilities {
 	 *
 	 * Returns the default DailyMemory unless a plugin provides an
 	 * alternative via the `datamachine_daily_memory_storage` filter.
-		 * DailyMemory itself writes through `agents_api_memory_store`; the
+	 * DailyMemory itself writes through `agents_api_memory_store`; the
 	 * daily-specific filter is only for replacing the whole ability backend.
 	 *
 	 * @since 0.47.0

--- a/inc/Abilities/DailyMemoryAbilities.php
+++ b/inc/Abilities/DailyMemoryAbilities.php
@@ -8,14 +8,14 @@
  * Ability-level storage is resolved via the
  * `datamachine_daily_memory_storage` filter. The default implementation
  * is DailyMemory, which persists through the unified
- * `datamachine_memory_store` seam as agent-layer files under
+ * `agents_api_memory_store` seam as agent-layer files under
  * `daily/YYYY/MM/DD.md`.
  *
  * Precedence: a valid DailyMemoryStorage returned by
  * `datamachine_daily_memory_storage` replaces the backend for these
  * abilities. If that filter is absent or returns an invalid value,
  * DailyMemory remains active and the active AgentMemoryStoreInterface
- * selected by `datamachine_memory_store` handles persistence.
+ * selected by `agents_api_memory_store` handles persistence.
  *
  * @package DataMachine\Abilities
  * @since 0.32.0
@@ -49,7 +49,7 @@ class DailyMemoryAbilities {
 	 *
 	 * Returns the default DailyMemory unless a plugin provides an
 	 * alternative via the `datamachine_daily_memory_storage` filter.
-	 * DailyMemory itself writes through `datamachine_memory_store`; the
+		 * DailyMemory itself writes through `agents_api_memory_store`; the
 	 * daily-specific filter is only for replacing the whole ability backend.
 	 *
 	 * @since 0.47.0
@@ -69,7 +69,7 @@ class DailyMemoryAbilities {
 		 * daily memory ability operations (read, write, append, list, search,
 		 * delete) will use the returned backend.
 		 *
-		 * This filter is narrower than `datamachine_memory_store`: it bypasses
+		 * This filter is narrower than `agents_api_memory_store`: it bypasses
 		 * the default DailyMemory implementation rather than swapping the
 		 * underlying whole-memory persistence store.
 		 *
@@ -79,6 +79,7 @@ class DailyMemoryAbilities {
 		 * @param int                $user_id  WordPress user ID.
 		 * @param int                $agent_id Agent ID.
 		 */
+		/** @var mixed $storage */
 		$storage = apply_filters( 'datamachine_daily_memory_storage', $default, $user_id, $agent_id );
 
 		// Safety: if the filter returns something that doesn't implement the interface, fall back.

--- a/inc/Core/FilesRepository/AgentMemory.php
+++ b/inc/Core/FilesRepository/AgentMemory.php
@@ -7,7 +7,7 @@
  * on any agent file (MEMORY.md, SOUL.md, USER.md, etc.).
  *
  * Persistence is delegated to an {@see AgentMemoryStoreInterface} resolved
- * via the `datamachine_memory_store` filter. The default store
+ * via the `agents_api_memory_store` filter. The default store
  * ({@see DiskAgentMemoryStore}) preserves the byte-for-byte filesystem
  * behavior the codebase used before the store seam was introduced.
  *
@@ -472,7 +472,7 @@ class AgentMemory {
 	 * @param string      $query         Search term.
 	 * @param string|null $section       Optional section filter (exact name without ##).
 	 * @param int         $context_lines Number of context lines above/below each match.
-	 * @return array{success: bool, query: string, matches: array, match_count: int}
+	 * @return array{success: bool, query: string, matches: array, match_count: int, message?: string}
 	 */
 	public function search( string $query, ?string $section = null, int $context_lines = 2 ): array {
 		$result = $this->store->read( $this->scope );
@@ -480,6 +480,7 @@ class AgentMemory {
 		if ( ! $result->exists ) {
 			return array(
 				'success'     => false,
+				'query'       => $query,
 				'message'     => sprintf( 'File %s does not exist.', $this->scope->filename ),
 				'matches'     => array(),
 				'match_count' => 0,
@@ -676,7 +677,8 @@ class AgentMemory {
 		}
 
 		// If scaffold didn't create it (no template for this file), create a stub.
-		if ( ! $this->store->exists( $this->scope ) ) {
+		$current = $this->store->read( $this->scope );
+		if ( ! $current->exists ) {
 			$this->store->write( $this->scope, "# {$this->scope->filename}\n", null );
 		}
 	}
@@ -693,7 +695,7 @@ class AgentMemory {
 	 * @return string Sanitized filename.
 	 */
 	private function sanitize_filename( string $filename ): string {
-		$segments = array_filter( explode( '/', $filename ), 'strlen' );
+		$segments = array_filter( explode( '/', $filename ), static fn( string $segment ): bool => '' !== $segment );
 		$clean    = array();
 		foreach ( $segments as $segment ) {
 			$clean[] = preg_replace( '/[^a-zA-Z0-9._-]/', '', basename( $segment ) );

--- a/inc/Core/FilesRepository/AgentMemoryStoreFactory.php
+++ b/inc/Core/FilesRepository/AgentMemoryStoreFactory.php
@@ -4,13 +4,13 @@
  *
  * Resolves the active {@see AgentMemoryStoreInterface} implementation.
  *
- * This is Data Machine's current resolver for a generic agent-memory
- * persistence contract. It intentionally keeps one public swap point: the
- * existing `datamachine_memory_store` filter, until an Agents API extraction
- * can introduce its own vocabulary and migration path. No caller should branch
- * on the concrete backend.
+ * This is Data Machine's in-place resolver for a generic agent-memory
+ * persistence contract. It intentionally keeps one public swap point using
+ * Agents API vocabulary: the `agents_api_memory_store` filter. The previous
+ * `datamachine_memory_store` name is not mirrored at runtime; consumers should
+ * migrate to the new hook instead of relying on a permanent alias.
  *
- * Single resolution point so every consumer (AgentMemory, DailyMemory,
+ * Single resolution point so every Data Machine consumer (AgentMemory, DailyMemory,
  * AgentFileAbilities, CoreMemoryFilesDirective) gets the same swap mechanism
  * without duplicating the filter call.
  *
@@ -48,10 +48,10 @@ class AgentMemoryStoreFactory {
 		 * the default disk-backed store. Return null (the default) to use the
 		 * built-in {@see DiskAgentMemoryStore}.
 		 *
-		 * This remains the only runtime filter in Data Machine. A future extracted
-		 * Agents API can add a neutral filter name when it owns the resolver; adding
-		 * a second alias here would create a permanent compatibility surface without
-		 * moving ownership.
+		 * This is the only runtime filter for memory-store replacement. It replaces
+		 * the earlier `datamachine_memory_store` name in-place so the seam already
+		 * uses Agents API vocabulary before physical extraction. Data Machine does
+		 * not call both names because a dual-hook ladder would become permanent API.
 		 *
 		 * The disk default preserves byte-for-byte the behavior Data Machine
 		 * had before this seam was introduced — self-hosted users see no
@@ -64,7 +64,7 @@ class AgentMemoryStoreFactory {
 		 *                                              or a swap implementation.
 		 * @param AgentMemoryScope               $scope The scope being acted on.
 		 */
-		$store = apply_filters( 'datamachine_memory_store', null, $scope );
+		$store = apply_filters( 'agents_api_memory_store', null, $scope );
 
 		if ( $store instanceof AgentMemoryStoreInterface ) {
 			return $store;

--- a/inc/Core/FilesRepository/AgentMemoryStoreInterface.php
+++ b/inc/Core/FilesRepository/AgentMemoryStoreInterface.php
@@ -8,10 +8,9 @@
  *
  * Default implementation ({@see DiskAgentMemoryStore}) preserves today's
  * filesystem behavior. Consumers can swap in an alternate store via the
- * current `datamachine_memory_store` filter (e.g. a DB-backed store on
- * managed hosts where the filesystem is not writable). A future Agents API
- * extraction should rename the resolver/filter in that plugin's vocabulary;
- * this interface is the behavior to carry forward.
+ * `agents_api_memory_store` filter (e.g. a DB-backed store on managed hosts
+ * where the filesystem is not writable). This interface is the behavior to
+ * carry forward when Agents API owns the contract physically.
  *
  * Implementations are responsible for:
  * - translating an {@see AgentMemoryScope} to a physical key (path, row, URL);

--- a/inc/Core/FilesRepository/DailyMemory.php
+++ b/inc/Core/FilesRepository/DailyMemory.php
@@ -12,7 +12,7 @@
  *
  * Persistence is delegated to the {@see AgentMemoryStoreInterface}
  * registered for the agent layer (resolved through the
- * `datamachine_memory_store` filter). Daily files are addressed as
+ * `agents_api_memory_store` filter). Daily files are addressed as
  * relative paths within the agent layer (`daily/YYYY/MM/DD.md`), so a
  * single store swap covers MEMORY.md, daily memory, and context files
  * uniformly.
@@ -199,7 +199,7 @@ class DailyMemory implements DailyMemoryStorage {
 		if ( empty( $result['success'] ) ) {
 			return array(
 				'success' => false,
-				'message' => $result['message'] ?? sprintf( 'Failed to write daily memory for %s-%s-%s.', $year, $month, $day ),
+				'message' => $result['message'],
 			);
 		}
 
@@ -240,7 +240,7 @@ class DailyMemory implements DailyMemoryStorage {
 		if ( empty( $result['success'] ) ) {
 			return array(
 				'success' => false,
-				'message' => $result['message'] ?? sprintf( 'Failed to append to daily memory for %s-%s-%s.', $year, $month, $day ),
+				'message' => $result['message'],
 			);
 		}
 
@@ -273,7 +273,7 @@ class DailyMemory implements DailyMemoryStorage {
 		if ( empty( $result['success'] ) ) {
 			return array(
 				'success' => false,
-				'message' => $result['message'] ?? sprintf( 'Failed to delete daily memory for %s-%s-%s.', $year, $month, $day ),
+				'message' => $result['message'],
 			);
 		}
 
@@ -393,7 +393,7 @@ class DailyMemory implements DailyMemoryStorage {
 					continue;
 				}
 
-				$lines      = explode( "\n", $result['content'] );
+				$lines      = explode( "\n", $result['content'] ?? '' );
 				$line_count = count( $lines );
 
 				foreach ( $lines as $index => $line ) {

--- a/inc/Core/FilesRepository/DailyMemoryStorage.php
+++ b/inc/Core/FilesRepository/DailyMemoryStorage.php
@@ -5,7 +5,7 @@
  * Contract for daily memory storage backends used by the Daily Memory
  * abilities. The default implementation is {@see DailyMemory}, which
  * delegates persistence to the active {@see AgentMemoryStoreInterface}
- * resolved through `datamachine_memory_store`.
+ * resolved through `agents_api_memory_store`.
  *
  * `datamachine_daily_memory_storage` is a narrower escape hatch for
  * replacing the ability-level daily memory backend entirely. When that

--- a/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
@@ -9,7 +9,7 @@
  * Data Machine does not register the Guidelines substrate and does not make
  * this store the default. Consumers that run on a host where Guidelines are
  * available can feature-detect {@see self::is_available()} and opt in via the
- * current `datamachine_memory_store` filter. When unavailable, the built-in
+ * `agents_api_memory_store` filter. When unavailable, the built-in
  * disk store remains the default behavior.
  *
  * Identity model: one post = one (layer, user_id, agent_id, filename) tuple.

--- a/tests/agent-memory-events-smoke.php
+++ b/tests/agent-memory-events-smoke.php
@@ -294,7 +294,7 @@ function datamachine_agent_memory_events_matching( string $hook ): array {
 
 $store = new AgentMemoryEventsFakeStore();
 add_filter(
-	'datamachine_memory_store',
+	'agents_api_memory_store',
 	function ( $_default, AgentMemoryScope $_scope ) use ( $store ) {
 		unset( $_default, $_scope );
 		return $store;

--- a/tests/agent-memory-store-factory-contract-smoke.php
+++ b/tests/agent-memory-store-factory-contract-smoke.php
@@ -2,7 +2,7 @@
 /**
  * Pure-PHP smoke tests for the agent memory store resolver contract.
  *
- * Verifies that Data Machine still has one active store seam, invalid filter
+ * Verifies that Data Machine still has one active Agents API store seam, invalid filter
  * returns do not replace the default, and callers can operate against the
  * interface without knowing which backing store is active.
  */
@@ -151,7 +151,7 @@ datamachine_agent_memory_store_contract_reset_filters();
 $fake_store       = new AgentMemoryStoreContractFakeStore();
 $filter_arguments = array();
 add_filter(
-	'datamachine_memory_store',
+	'agents_api_memory_store',
 	static function ( $store, AgentMemoryScope $filter_scope ) use ( $fake_store, &$filter_arguments ) {
 		$filter_arguments[] = array( $store, $filter_scope );
 		return $fake_store;
@@ -161,7 +161,7 @@ add_filter(
 );
 
 $selected_store = AgentMemoryStoreFactory::for_scope( $scope );
-datamachine_agent_memory_store_contract_assert( $fake_store === $selected_store, 'factory selects a valid store from datamachine_memory_store' );
+datamachine_agent_memory_store_contract_assert( $fake_store === $selected_store, 'factory selects a valid store from agents_api_memory_store' );
 datamachine_agent_memory_store_contract_assert( 1 === count( $filter_arguments ), 'store filter is invoked once for one resolution' );
 datamachine_agent_memory_store_contract_assert( null === $filter_arguments[0][0], 'store filter receives null as the default candidate' );
 datamachine_agent_memory_store_contract_assert( $scope === $filter_arguments[0][1], 'store filter receives the scope being resolved' );
@@ -172,7 +172,7 @@ datamachine_agent_memory_store_contract_assert( "# Memory\n" === $read->content,
 
 datamachine_agent_memory_store_contract_reset_filters();
 add_filter(
-	'datamachine_memory_store',
+	'agents_api_memory_store',
 	static fn( $_store, $_scope ) => new stdClass(),
 	10,
 	2
@@ -182,14 +182,14 @@ datamachine_agent_memory_store_contract_assert( $invalid_store instanceof DiskAg
 
 datamachine_agent_memory_store_contract_reset_filters();
 add_filter(
-	'agents_api_memory_store',
+	'datamachine_memory_store',
 	static function ( $_store, $_scope ) use ( $fake_store ) {
 		return $fake_store;
 	},
 	10,
 	2
 );
-$future_filter_store = AgentMemoryStoreFactory::for_scope( $scope );
-datamachine_agent_memory_store_contract_assert( $future_filter_store instanceof DiskAgentMemoryStore, 'undocumented future filter names are not active Data Machine behavior' );
+$old_filter_store = AgentMemoryStoreFactory::for_scope( $scope );
+datamachine_agent_memory_store_contract_assert( $old_filter_store instanceof DiskAgentMemoryStore, 'old datamachine_memory_store filter is not mirrored as a runtime alias' );
 
 echo "Agent memory store factory contract smoke passed.\n";

--- a/tests/daily-memory-store-seam-smoke.php
+++ b/tests/daily-memory-store-seam-smoke.php
@@ -159,7 +159,7 @@ function datamachine_daily_memory_store_seam_assert( bool $condition, string $me
 
 $store = new DailyMemorySeamFakeStore();
 add_filter(
-	'datamachine_memory_store',
+	'agents_api_memory_store',
 	function ( $default, AgentMemoryScope $scope ) use ( $store ) {
 		return $store;
 	},
@@ -174,7 +174,7 @@ datamachine_daily_memory_store_seam_assert( true === $append['success'], 'append
 
 $read = $daily->read( '2026', '04', '28' );
 datamachine_daily_memory_store_seam_assert( true === $read['success'], 'read succeeds through the fake memory store' );
-datamachine_daily_memory_store_seam_assert( false !== strpos( $read['content'], 'First note.' ), 'read returns content written by append' );
+datamachine_daily_memory_store_seam_assert( isset( $read['content'] ) && false !== strpos( $read['content'], 'First note.' ), 'read returns content written by append' );
 
 $daily->write( '2026', '04', '29', 'Second note.' );
 

--- a/tests/memory-bundle-policy-smoke.php
+++ b/tests/memory-bundle-policy-smoke.php
@@ -256,7 +256,7 @@ function memory_policy_assert( bool $condition, string $message ): void {
 
 $store = new MemoryPolicyFakeStore();
 add_filter(
-	'datamachine_memory_store',
+	'agents_api_memory_store',
 	static function ( $_default, AgentMemoryScope $_scope ) use ( $store ) {
 		unset( $_default, $_scope );
 		return $store;


### PR DESCRIPTION
## Summary
- Rename the active memory-store resolver hook from `datamachine_memory_store` to `agents_api_memory_store` so the in-place seam uses Agents API vocabulary.
- Document the no-alias migration path and keep `DiskAgentMemoryStore` as the current class name until a physical Agents API package decides whether markdown/disk memory is public product.
- Update memory-store smokes and related docs to pin the single active hook and preserve current disk-backed default behavior.

## Tests
- `php tests/agent-memory-store-factory-contract-smoke.php`
- `php tests/guideline-agent-memory-store-smoke.php`
- `php tests/daily-memory-store-seam-smoke.php`
- `php tests/memory-bundle-policy-smoke.php`
- `php tests/agent-memory-events-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-memory-store --changed-since origin/main --summary`

Closes #1592

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the hook rename, updated docs/tests, ran focused validation, and prepared the PR. Chris remains responsible for review and merge.