### PR TITLE
chore(deps): update Block Format Bridge to v0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=8.2",
 		"woocommerce/action-scheduler": "^3.9",
 		"chubes4/ai-http-client": "^2.0.13",
-		"chubes4/block-format-bridge": "^0.4"
+		"chubes4/block-format-bridge": "^0.6"
 	},
 	"require-dev": {
 		"php-stubs/wordpress-stubs": "^6.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb8ee794e4793804034c976b0e7f08c0",
+    "content-hash": "cd21fbb2238b1278591c5aebf49f197a",
     "packages": [
         {
             "name": "chubes4/ai-http-client",
@@ -68,16 +68,16 @@
         },
         {
             "name": "chubes4/block-format-bridge",
-            "version": "v0.4.0",
+            "version": "v0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "e8b032bad4d2fe4e9ef06f008d52ed2d55d7d86d"
+                "reference": "d7cfaa385f76fcc1e086dc095e86fdb118c7df90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/e8b032bad4d2fe4e9ef06f008d52ed2d55d7d86d",
-                "reference": "e8b032bad4d2fe4e9ef06f008d52ed2d55d7d86d",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/d7cfaa385f76fcc1e086dc095e86fdb118c7df90",
+                "reference": "d7cfaa385f76fcc1e086dc095e86fdb118c7df90",
                 "shasum": ""
             },
             "require": {
@@ -86,7 +86,7 @@
                 "php": "^8.1"
             },
             "require-dev": {
-                "chubes4/html-to-blocks-converter": "dev-main",
+                "chubes4/html-to-blocks-converter": "^0.6",
                 "humbug/php-scoper": "^0.18.19"
             },
             "type": "wordpress-plugin",
@@ -112,10 +112,10 @@
             "description": "WordPress plugin orchestrating bidirectional content format conversion (HTML, Blocks, Markdown) via a unified adapter API.",
             "homepage": "https://github.com/chubes4/block-format-bridge",
             "support": {
-                "source": "https://github.com/chubes4/block-format-bridge/tree/v0.4.0",
+                "source": "https://github.com/chubes4/block-format-bridge/tree/v0.6.0",
                 "issues": "https://github.com/chubes4/block-format-bridge/issues"
             },
-            "time": "2026-04-28T17:37:17+00:00"
+            "time": "2026-04-29T19:59:14+00:00"
         },
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
## Summary
- Updates Data Machine's bundled Block Format Bridge dependency to v0.6.0.
- Pulls in BFB conversion options and the refreshed h2bc v0.6.1 bundle.

## Tests
- `php tests/bfb-substrate-bundle-smoke.php && php tests/content-format-helper-smoke.php && php tests/content-format-abilities-smoke.php && php tests/wordpress-publish-content-format-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated the Composer constraint/lockfile and ran focused BFB/content-format smokes; Chris remains responsible for review and merge.
