### PR TITLE
fix(deps): update BFB ability category metadata

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -68,16 +68,16 @@
         },
         {
             "name": "chubes4/block-format-bridge",
-            "version": "v0.6.0",
+            "version": "v0.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "d7cfaa385f76fcc1e086dc095e86fdb118c7df90"
+                "reference": "bf7a4d724498573ae583503669a24c31f0cb1a2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/d7cfaa385f76fcc1e086dc095e86fdb118c7df90",
-                "reference": "d7cfaa385f76fcc1e086dc095e86fdb118c7df90",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/bf7a4d724498573ae583503669a24c31f0cb1a2e",
+                "reference": "bf7a4d724498573ae583503669a24c31f0cb1a2e",
                 "shasum": ""
             },
             "require": {
@@ -112,10 +112,10 @@
             "description": "WordPress plugin orchestrating bidirectional content format conversion (HTML, Blocks, Markdown) via a unified adapter API.",
             "homepage": "https://github.com/chubes4/block-format-bridge",
             "support": {
-                "source": "https://github.com/chubes4/block-format-bridge/tree/v0.6.0",
+                "source": "https://github.com/chubes4/block-format-bridge/tree/v0.6.1",
                 "issues": "https://github.com/chubes4/block-format-bridge/issues"
             },
-            "time": "2026-04-29T19:59:14+00:00"
+            "time": "2026-04-29T20:26:23+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/tests/bfb-substrate-bundle-smoke.php
+++ b/tests/bfb-substrate-bundle-smoke.php
@@ -149,8 +149,10 @@ if ( ! function_exists( 'wp_register_ability' ) ) {
 // --- Composer/package assertions ------------------------------------
 
 $root          = dirname( __DIR__ );
-$composer_json = json_decode( file_get_contents( $root . '/composer.json' ), true );
-$composer_lock = json_decode( file_get_contents( $root . '/composer.lock' ), true );
+$composer_json_contents = file_get_contents( $root . '/composer.json' );
+$composer_lock_contents = file_get_contents( $root . '/composer.lock' );
+$composer_json          = json_decode( false === $composer_json_contents ? '{}' : $composer_json_contents, true );
+$composer_lock          = json_decode( false === $composer_lock_contents ? '{}' : $composer_lock_contents, true );
 
 assert_bfb_bundle(
 	'composer-json-requires-bfb',
@@ -197,19 +199,28 @@ foreach ( $h2bc_globals as $class_name ) {
 	assert_bfb_bundle( "global-{$class_name}-not-created", ! class_exists( $class_name, false ) );
 }
 
-foreach ( $GLOBALS['__bfb_bundle_actions'] as $action ) {
+$registered_actions = $GLOBALS['__bfb_bundle_actions'];
+/** @var array<int, array{hook:string, callback:mixed}> $registered_actions */
+foreach ( $registered_actions as $action ) {
 	if ( 'wp_abilities_api_categories_init' === $action['hook'] && is_callable( $action['callback'] ) ) {
 		call_user_func( $action['callback'] );
 	}
 }
 
-foreach ( $GLOBALS['__bfb_bundle_actions'] as $action ) {
+$registered_actions = $GLOBALS['__bfb_bundle_actions'];
+/** @var array<int, array{hook:string, callback:mixed}> $registered_actions */
+foreach ( $registered_actions as $action ) {
 	if ( 'wp_abilities_api_init' === $action['hook'] && is_callable( $action['callback'] ) ) {
 		call_user_func( $action['callback'] );
 	}
 }
 
-assert_bfb_bundle( 'bfb-ability-category-registered', isset( $GLOBALS['__bfb_bundle_ability_categories']['block-format-bridge'] ) );
+$registered_ability_categories = $GLOBALS['__bfb_bundle_ability_categories'];
+$registered_abilities          = $GLOBALS['__bfb_bundle_abilities'];
+/** @var array<string, array<string, mixed>> $registered_ability_categories */
+/** @var array<string, array<string, mixed>> $registered_abilities */
+
+assert_bfb_bundle( 'bfb-ability-category-registered', isset( $registered_ability_categories['block-format-bridge'] ) );
 
 $bfb_ability_names = array(
 	'block-format-bridge/get-capabilities',
@@ -218,15 +229,15 @@ $bfb_ability_names = array(
 );
 
 foreach ( $bfb_ability_names as $ability_name ) {
-	assert_bfb_bundle( "{$ability_name}-registered", isset( $GLOBALS['__bfb_bundle_abilities'][ $ability_name ] ) );
+	assert_bfb_bundle( "{$ability_name}-registered", isset( $registered_abilities[ $ability_name ] ) );
 	assert_bfb_bundle(
 		"{$ability_name}-has-category",
-		'block-format-bridge' === ( $GLOBALS['__bfb_bundle_abilities'][ $ability_name ]['category'] ?? null )
+		'block-format-bridge' === ( $registered_abilities[ $ability_name ]['category'] ?? null )
 	);
 }
 
 echo "\nBFB substrate bundle smoke: {$total} assertions, {$failed} failures.\n";
 
-if ( $failed > 0 ) {
+if ( $failed > 0 ) { // @phpstan-ignore-line Smoke assertion counter is mutated through assert_bfb_bundle().
 	exit( 1 );
 }

--- a/tests/bfb-substrate-bundle-smoke.php
+++ b/tests/bfb-substrate-bundle-smoke.php
@@ -39,6 +39,8 @@ function assert_bfb_bundle( string $name, bool $condition ): void {
 
 $GLOBALS['__bfb_bundle_actions'] = array();
 $GLOBALS['__bfb_bundle_filters'] = array();
+$GLOBALS['__bfb_bundle_ability_categories'] = array();
+$GLOBALS['__bfb_bundle_abilities'] = array();
 
 if ( ! function_exists( 'did_action' ) ) {
 	function did_action( $hook = '' ) {
@@ -132,6 +134,18 @@ if ( ! function_exists( '__' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	function wp_register_ability_category( string $slug, array $args ): void {
+		$GLOBALS['__bfb_bundle_ability_categories'][ $slug ] = $args;
+	}
+}
+
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $name, array $args ): void {
+		$GLOBALS['__bfb_bundle_abilities'][ $name ] = $args;
+	}
+}
+
 // --- Composer/package assertions ------------------------------------
 
 $root          = dirname( __DIR__ );
@@ -181,6 +195,34 @@ $h2bc_globals = array(
 
 foreach ( $h2bc_globals as $class_name ) {
 	assert_bfb_bundle( "global-{$class_name}-not-created", ! class_exists( $class_name, false ) );
+}
+
+foreach ( $GLOBALS['__bfb_bundle_actions'] as $action ) {
+	if ( 'wp_abilities_api_categories_init' === $action['hook'] && is_callable( $action['callback'] ) ) {
+		call_user_func( $action['callback'] );
+	}
+}
+
+foreach ( $GLOBALS['__bfb_bundle_actions'] as $action ) {
+	if ( 'wp_abilities_api_init' === $action['hook'] && is_callable( $action['callback'] ) ) {
+		call_user_func( $action['callback'] );
+	}
+}
+
+assert_bfb_bundle( 'bfb-ability-category-registered', isset( $GLOBALS['__bfb_bundle_ability_categories']['block-format-bridge'] ) );
+
+$bfb_ability_names = array(
+	'block-format-bridge/get-capabilities',
+	'block-format-bridge/convert',
+	'block-format-bridge/normalize',
+);
+
+foreach ( $bfb_ability_names as $ability_name ) {
+	assert_bfb_bundle( "{$ability_name}-registered", isset( $GLOBALS['__bfb_bundle_abilities'][ $ability_name ] ) );
+	assert_bfb_bundle(
+		"{$ability_name}-has-category",
+		'block-format-bridge' === ( $GLOBALS['__bfb_bundle_abilities'][ $ability_name ]['category'] ?? null )
+	);
 }
 
 echo "\nBFB substrate bundle smoke: {$total} assertions, {$failed} failures.\n";


### PR DESCRIPTION
## Summary
- Update the bundled Block Format Bridge dependency to v0.6.1, which registers its Abilities API category and declares that category on each BFB ability.
- Extend the BFB substrate smoke so Data Machine catches missing BFB ability category metadata before WordPress 6.9 can emit boot notices again.

## Tests
- `php tests/bfb-substrate-bundle-smoke.php`
- `php tests/content-format-helper-smoke.php`
- `php tests/content-format-abilities-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-ability-category-registration --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-ability-category-registration --changed-since origin/main`

Closes #1603

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the missing ability category source, shipped the upstream BFB fix/release, updated Data Machine's dependency lock, added regression smoke coverage, and ran focused verification.
