### PR TITLE
refactor(agent): split runtime loop policy boundary

### DIFF
--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -48,6 +48,8 @@ These are closest to generic public contracts. Most should be extracted as contr
 |---|---|---|---|
 | `AgentMessageEnvelope` | `inc/Engine/AI/AgentMessageEnvelope.php` | JSON-friendly canonical message envelope independent of flows/jobs. | Schema is `agents-api.message`; review whether physical extraction keeps this class name or adopts `WP_Agent_Message`. |
 | `AgentConversationResult` | `inc/Engine/AI/AgentConversationResult.php` | Validates result arrays from any runtime runner. | Rename to `WP_Agent_Run_Result` or split into result value object plus validator. |
+| `AgentConversationCompletionPolicyInterface` | `inc/Engine/AI/AgentConversationCompletionPolicyInterface.php` | Generic runtime collaborator for deciding whether a tool result completes a run. | Keep Data Machine handler semantics in adapter implementations, not in the loop contract. |
+| `AgentConversationTranscriptPersisterInterface` | `inc/Engine/AI/AgentConversationTranscriptPersisterInterface.php` | Generic runtime collaborator for optional transcript persistence. | Future extraction should pair this with the transcript store contract and keep job/flow metadata in Data Machine adapters. |
 | `LoopEventSinkInterface` | `inc/Engine/AI/LoopEventSinkInterface.php` | Transport-neutral event sink for logs, streaming, CLI, REST, or chat UIs. | Make event vocabulary public and provider-neutral before extraction. |
 | `NullLoopEventSink` | `inc/Engine/AI/NullLoopEventSink.php` | Generic no-op implementation for optional event sinks. | Implementation can move with the interface. |
 | `RuntimeToolDeclaration` | `inc/Engine/AI/Tools/RuntimeToolDeclaration.php` | Validates run-scoped client/runtime tool declarations without Data Machine state. | Rename around `WP_Agent_Tool_Declaration`; keep executor/source/scope vocabulary generic. |
@@ -76,7 +78,7 @@ These are plausibly generic implementations, but should not move until naming an
 
 | Surface | Current location | Why it is not public-ready yet | Extraction direction |
 |---|---|---|---|
-| `AIConversationLoop` | `inc/Engine/AI/AIConversationLoop.php` | Name says AI, result shape and payload include Data Machine job/flow context, and built-in completion behavior knows handler tools. | Split generic turn loop from Data Machine completion policy and pipeline handler tracking. |
+| `AIConversationLoop` | `inc/Engine/AI/AIConversationLoop.php` | Name says AI and still carries the compatibility facade/result shape, but handler completion and transcript persistence now route through runtime collaborators. | Keep shrinking the compatibility adapter by extracting provider request assembly and Data Machine logging policy next. |
 | `RequestBuilder` | `inc/Engine/AI/RequestBuilder.php` | Mostly generic request assembly, but dispatch falls back to `chubes_ai_request` and applies Data Machine directives. | Extract assembler separately from provider dispatch and Data Machine directive policy. |
 | `WpAiClientAdapter` | `inc/Engine/AI/WpAiClientAdapter.php` | Generic bridge to WordPress AI client, but currently lives as Data Machine implementation detail. | Good implementation candidate once request/message contracts are generic. |
 | `RequestMetadata` | `inc/Engine/AI/RequestMetadata.php` | Generic inspection/size metadata. | Move after field names are checked against Agents API message/tool vocabulary. |
@@ -116,12 +118,13 @@ These should stay in Data Machine as compatibility glue if a generic runtime plu
 | `AIStep` | `inc/Core/Steps/AI/AIStep.php` | Converts flow-step config, data packets, queue prompt head, image engine data, adjacent steps, job snapshot, and transcript policy into a runtime run. |
 | `ToolPolicyResolver::getPipelinePolicyArgs()` | `inc/Engine/AI/Tools/ToolPolicyResolver.php` | Translates `FlowStepConfig` enabled/disabled tool fields into generic resolver args. This is a prime adapter extraction seam. |
 | `ToolPolicyResolver::gatherPipelineTools()` | `inc/Engine/AI/Tools/ToolPolicyResolver.php` | Knows pipeline handler/tool behavior and should not become public Agents API. |
-| `PipelineTranscriptPolicy` | `inc/Engine/AI/PipelineTranscriptPolicy.php` | Reads flow/pipeline config and site option to decide transcript persistence. Generic runtime should receive an already-normalized boolean/policy. |
+| `PipelineTranscriptPolicy` | `inc/Engine/AI/PipelineTranscriptPolicy.php` | Reads flow/pipeline config and site option to decide transcript persistence. Generic runtime receives the normalized decision through `DataMachinePipelineTranscriptPersister`. |
 | `ToolSourceRegistry::SOURCE_ADJACENT_HANDLERS` | `inc/Engine/AI/Tools/ToolSourceRegistry.php` | Data Machine-specific source that exposes publish/upsert handler tools next to AI steps. |
 | `ToolSourceRegistry::SOURCE_STATIC_REGISTRY` / `DataMachineToolRegistrySource` | `inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php` | Data Machine-specific source that adapts the curated `datamachine_tools` registry into runtime tool resolution. |
 | `FlowStepConfig::getAdjacentRequiredHandlerSlugsForAi()` consumers | `AIStep` and tool policy code | Converts pipeline topology into handler completion requirements. |
 | `QueueableTrait` prompt consumption in `AIStep` | `inc/Core/Steps/AI/AIStep.php` | Data Machine flow queue semantics (`static`, `drain`, `loop`) feeding a runtime user-message slot. |
-| `ConversationManager` transcript persistence calls from `AIStep` | `AIStep`/`ConversationManager` | Adapts a pipeline job run to the conversation store. Generic runtime should not know jobs. |
+| `DataMachinePipelineTranscriptPersister` | `inc/Engine/AI/DataMachinePipelineTranscriptPersister.php` | Adapts a pipeline job run to the transcript store. Generic runtime calls the transcript persister contract and does not own job metadata. |
+| `DataMachineHandlerCompletionPolicy` | `inc/Engine/AI/DataMachineHandlerCompletionPolicy.php` | Adapts adjacent-handler completion rules into a runtime completion policy. Generic runtime calls the policy contract and does not own pipeline handler semantics. |
 | `SystemAgentServiceProvider` task registration | `inc/Engine/AI/System/SystemAgentServiceProvider.php` | Registers Data Machine system tasks into Data Machine scheduling. The generic runtime may supply a task interface, not these tasks. |
 | `AgentCallTask` | `inc/Engine/AI/System/Tasks/AgentCallTask.php` | Bridges scheduled/system tasks into the agent-call primitive. |
 | `AgentBundler` and bundle CLI adapters | `inc/Core/Agents/AgentBundler.php`, `inc/Cli/Commands/AgentBundleCommand.php` | Convert Data Machine pipelines/flows into portable agent bundle artifacts. Bundle primitives may split, but flow/pipeline import/export remains adapter/product. |
@@ -212,6 +215,7 @@ These tests currently pin the substrate most relevant to extraction.
 |---|---|---|
 | `tests/ai-message-envelope-smoke.php` | Agent message envelope normalization/projection and result validation. | Move with message/result contracts. |
 | `tests/agent-conversation-result-smoke.php` | Conversation result shape validation. | Move with runner result contract. |
+| `tests/agent-conversation-runtime-policy-smoke.php` | Runtime completion and transcript collaborator seams. | Split generic policy/persister contracts from Data Machine handler/transcript adapter assertions during extraction. |
 | `tests/conversation-store-contracts-smoke.php` | Split store interfaces, transcript-only method boundary, and factory return types. | Move transcript CRUD coverage with the generic contract; keep aggregate/product assertions with Data Machine. |
 | `tests/guideline-agent-memory-store-smoke.php` | Optional guideline-backed memory implementation. | Move or duplicate if Agents API ships memory store implementations. |
 | `tests/daily-memory-store-seam-smoke.php` | Daily memory through memory store seam. | Data Machine product consuming generic memory store. |
@@ -231,8 +235,8 @@ These tests currently pin the substrate most relevant to extraction.
 
 1. Split pipeline policy translation out of `ToolPolicyResolver` so the resolver no longer imports or reads `FlowStepConfig`.
 2. Split `AgentRegistry` into a pure registry and a Data Machine reconciler that creates database rows, access rows, directories, and scaffold files.
-3. Split `AIConversationLoop` completion policy so handler-tool completion is injected by Data Machine rather than built into a generic loop.
-4. Rename and stabilize message/result/store interfaces in place before moving namespaces.
+3. Rename and stabilize message/result/store interfaces in place before moving namespaces.
+4. Split provider request assembly from `RequestBuilder` so Data Machine directives/logging and `chubes_ai_request` fallback are adapter behavior.
 5. Split `ToolExecutor` into ability-native runtime execution plus Data Machine product hooks for pending actions and post-origin tracking.
 6. Decide whether Agents API owns persistence tables or only contracts plus optional stores.
 7. Keep wpcom/AI Framework classes behind adapters. No public contract should require `\WPCOM\AI\Message`, `\Agent`, `\AgentsStore`, or `Conversation_Storage`.

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -15,6 +15,7 @@ The initial untangling wave is complete:
 - Conversation transcript storage is narrowed behind a transcript facade, and the aggregate chat-product store is documented as a Data Machine compatibility layer rather than the default extraction target.
 - Memory store ownership is documented behind an Agents API-shaped store contract and filter name.
 - The runner request boundary exists.
+- The built-in loop now receives runtime completion and transcript collaborators. Data Machine's handler-completion and pipeline-transcript behavior lives behind adapter classes instead of being hardcoded as generic loop state.
 
 This branch starts the naming phase by renaming the neutral runner result/request seam from `AIConversation*` to `AgentConversation*` while leaving `AIConversationLoop` as the temporary compatibility facade.
 
@@ -29,6 +30,7 @@ Target shape:
 - `AgentConversationRunnerInterface` is the public runtime boundary.
 - `AgentConversationRequest` and `AgentConversationResult` are neutral value contracts.
 - `AIConversationLoop` remains a Data Machine compatibility facade until callers are moved to the new name.
+- `AgentConversationCompletionPolicyInterface` and `AgentConversationTranscriptPersisterInterface` are in-place runtime collaborator seams; Data Machine provides the current handler-completion and transcript adapters.
 - A future `AgentConversationLoop` or `WP_Agent_Runner` should not know about `job_id`, `flow_step_id`, `pipeline_id`, or handler completion policy.
 
 ### 2. Runtime Hooks And Filters

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -11,7 +11,6 @@
 
 namespace DataMachine\Engine\AI;
 
-use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\IterationBudgetRegistry;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
@@ -190,7 +189,9 @@ class AIConversationLoop {
 		$tool_execution_results = array();
 		$last_request_metadata  = array();
 		$event_sink             = self::resolveEventSink( $payload );
-		$loop_payload           = self::payloadWithoutEventSink( $payload );
+		$completion_policy      = self::resolveCompletionPolicy( $mode, $payload );
+		$transcript_persister   = self::resolveTranscriptPersister( $payload );
+		$loop_payload           = self::payloadWithoutRuntimeObjects( $payload );
 
 		// Accumulate token usage across all turns.
 		$total_usage = array(
@@ -198,13 +199,6 @@ class AIConversationLoop {
 			'completion_tokens' => 0,
 			'total_tokens'      => 0,
 		);
-
-		// Track which handler tools have been executed for multi-handler support.
-		// In pipeline mode, conversation should only complete when all handlers
-		// required by the adjacent step have fired, not just the first one.
-		$executed_handler_slugs = array();
-		$configured_handlers    = $loop_payload['configured_handler_slugs'] ?? array();
-		$configured_handlers    = is_array( $configured_handlers ) ? array_values( $configured_handlers ) : array();
 
 		// Build base log metadata from payload for consistent logging.
 		$base_log_context = array_filter(
@@ -290,7 +284,7 @@ class AIConversationLoop {
 				// Persist transcript on the error path too — this is exactly
 				// the scenario the feature exists for. Failing silently here
 				// would defeat the debugging value.
-				$transcript_session_id = self::maybePersistTranscript(
+				$transcript_session_id = $transcript_persister->persist(
 					$messages,
 					$provider,
 					$model,
@@ -471,64 +465,21 @@ class AIConversationLoop {
 					$tool_def        = $tools[ $tool_name ] ?? null;
 					$is_handler_tool = $tool_def && isset( $tool_def['handler'] );
 
-					// Track handler tool execution in pipeline mode.
-					// Only complete when ALL configured handlers have fired (multi-handler support).
-					if ( 'pipeline' === $mode && $is_handler_tool && ( $tool_result['success'] ?? false ) ) {
-						$handler_slug = $tool_def['handler'] ?? null;
-						if ( $handler_slug ) {
-							$executed_handler_slugs[] = $handler_slug;
-						}
-
-						// If we know which handlers are configured, wait for all of them.
-						// Otherwise fall back to completing on first handler (backward compat).
-						if ( ! empty( $configured_handlers ) ) {
-							$remaining = array_diff( $configured_handlers, array_unique( $executed_handler_slugs ) );
-							if ( empty( $remaining ) ) {
-								$conversation_complete = true;
-								do_action(
-									'datamachine_log',
-									'debug',
-									'AIConversationLoop: All configured handlers executed, ending conversation',
-									array_merge(
-										$base_log_context,
-										array(
-											'tool_name'  => $tool_name,
-											'turn_count' => $turn_count,
-											'executed_handlers' => array_unique( $executed_handler_slugs ),
-											'configured_handlers' => $configured_handlers,
-										)
-									)
-								);
-							} else {
-								do_action(
-									'datamachine_log',
-									'debug',
-									'AIConversationLoop: Handler executed, waiting for remaining handlers',
-									array_merge(
-										$base_log_context,
-										array(
-											'tool_name' => $tool_name,
-											'remaining_handlers' => array_values( $remaining ),
-										)
-									)
-								);
-							}
-						} else {
-							// No handler list available — legacy behavior: complete on first handler
-							$conversation_complete = true;
-							do_action(
-								'datamachine_log',
-								'debug',
-								'AIConversationLoop: Handler tool executed (legacy mode), ending conversation',
-								array_merge(
-									$base_log_context,
-									array(
-										'tool_name'  => $tool_name,
-										'turn_count' => $turn_count,
-									)
-								)
-							);
-						}
+					$completion_decision   = $completion_policy->recordToolResult(
+						$tool_name,
+						is_array( $tool_def ) ? $tool_def : null,
+						$tool_result,
+						$mode,
+						$turn_count
+					);
+					$conversation_complete = $completion_decision->isComplete();
+					if ( '' !== $completion_decision->message() ) {
+						do_action(
+							'datamachine_log',
+							'debug',
+							$completion_decision->message(),
+							array_merge( $base_log_context, $completion_decision->context() )
+						);
 					}
 
 					// Store tool execution result separately for data packet processing
@@ -614,7 +565,7 @@ class AIConversationLoop {
 			$result['max_turns_reached'] = true;
 		}
 
-		$transcript_session_id = self::maybePersistTranscript(
+		$transcript_session_id = $transcript_persister->persist(
 			$messages,
 			$provider,
 			$model,
@@ -659,14 +610,58 @@ class AIConversationLoop {
 	}
 
 	/**
-	 * Remove observer-only payload values before dispatching requests or tools.
+	 * Remove runtime-only payload values before dispatching requests or tools.
 	 *
 	 * @param array $payload Loop payload.
-	 * @return array Payload without the loop event sink object.
+	 * @return array Payload without runtime collaborator objects.
 	 */
-	private static function payloadWithoutEventSink( array $payload ): array {
+	private static function payloadWithoutRuntimeObjects( array $payload ): array {
 		unset( $payload['event_sink'] );
+		unset( $payload['completion_policy'] );
+		unset( $payload['transcript_persister'] );
 		return $payload;
+	}
+
+	/**
+	 * Resolve the runtime completion policy carried by the adapter payload.
+	 *
+	 * @param string $mode    Execution mode.
+	 * @param array  $payload Loop payload.
+	 * @return AgentConversationCompletionPolicyInterface Completion policy.
+	 */
+	private static function resolveCompletionPolicy( string $mode, array $payload ): AgentConversationCompletionPolicyInterface {
+		$policy = $payload['completion_policy'] ?? null;
+		if ( $policy instanceof AgentConversationCompletionPolicyInterface ) {
+			return $policy;
+		}
+
+		$configured_handlers = $payload['configured_handler_slugs'] ?? array();
+		$configured_handlers = is_array( $configured_handlers ) ? array_values( $configured_handlers ) : array();
+
+		if ( ! empty( $configured_handlers ) || 'pipeline' === $mode ) {
+			return new DataMachineHandlerCompletionPolicy( $configured_handlers );
+		}
+
+		return new DefaultAgentConversationCompletionPolicy();
+	}
+
+	/**
+	 * Resolve the runtime transcript persister carried by the adapter payload.
+	 *
+	 * @param array $payload Loop payload.
+	 * @return AgentConversationTranscriptPersisterInterface Transcript persister.
+	 */
+	private static function resolveTranscriptPersister( array $payload ): AgentConversationTranscriptPersisterInterface {
+		$persister = $payload['transcript_persister'] ?? null;
+		if ( $persister instanceof AgentConversationTranscriptPersisterInterface ) {
+			return $persister;
+		}
+
+		if ( ! empty( $payload['persist_transcript'] ) ) {
+			return new DataMachinePipelineTranscriptPersister();
+		}
+
+		return new NullAgentConversationTranscriptPersister();
 	}
 
 	/**
@@ -690,117 +685,5 @@ class AIConversationLoop {
 				)
 			);
 		}
-	}
-
-	/**
-	 * Persist the conversation transcript when the caller has opted in.
-	 *
-	 * Opt-in is signaled by `$payload['persist_transcript']` (resolved in
-	 * AIStep::executeStep() via PipelineTranscriptPolicy). When enabled,
-	 * a chat session is created with `mode='pipeline'` and metadata
-	 * `source='pipeline_transcript'` so it can be filtered out of the
-	 * human chat session list.
-	 *
-	 * Persistence is opportunistic: any failure (store unavailable,
-	 * insert error) is logged at debug level and returns an empty
-	 * string. Transcript persistence MUST NOT break the AI step.
-	 *
-	 * @param array  $messages Final conversation messages.
-	 * @param string $provider Provider identifier.
-	 * @param string $model    Model identifier.
-	 * @param array  $payload  Loop payload (job_id, agent_id, etc.).
-	 * @param array  $result   Loop result so far (used for outcome metadata).
-	 * @return string Session ID on success, empty string when not persisted.
-	 */
-	private static function maybePersistTranscript(
-		array $messages,
-		string $provider,
-		string $model,
-		array $payload,
-		array $result
-	): string {
-		if ( empty( $payload['persist_transcript'] ) ) {
-			return '';
-		}
-
-		// Without messages there's nothing useful to persist. This guards
-		// against the early-failure path where the first AI request errored
-		// before any message was assembled.
-		if ( empty( $messages ) ) {
-			return '';
-		}
-
-		$store = ConversationStoreFactory::get_transcript_store();
-
-		$user_id  = (int) ( $payload['user_id'] ?? 0 );
-		$agent_id = (int) ( $payload['agent_id'] ?? 0 );
-
-		$metadata = array(
-			'source'       => 'pipeline_transcript',
-			'job_id'       => $payload['job_id'] ?? null,
-			'flow_step_id' => $payload['flow_step_id'] ?? null,
-			'pipeline_id'  => $payload['pipeline_id'] ?? null,
-			'flow_id'      => $payload['flow_id'] ?? null,
-			'agent_id'     => $agent_id > 0 ? $agent_id : null,
-			'owner_id'     => $user_id > 0 ? $user_id : null,
-			'provider'     => $provider,
-			'model'        => $model,
-			'turn_count'   => $result['turn_count'] ?? 0,
-			'completed'    => (bool) ( $result['completed'] ?? false ),
-			'error'        => $result['error'] ?? null,
-			'usage'        => $result['usage'] ?? array(),
-		);
-
-		if ( ! empty( $result['request_metadata'] ) && is_array( $result['request_metadata'] ) ) {
-			$metadata['request_metadata'] = $result['request_metadata'];
-		}
-
-		$session_id = $store->create_session( $user_id, $agent_id, $metadata, 'pipeline' );
-
-		if ( '' === $session_id ) {
-			do_action(
-				'datamachine_log',
-				'debug',
-				'AIConversationLoop: Failed to create transcript session',
-				array(
-					'job_id'       => $payload['job_id'] ?? null,
-					'flow_step_id' => $payload['flow_step_id'] ?? null,
-				)
-			);
-			return '';
-		}
-
-		$updated = $store->update_session( $session_id, $messages, $metadata, $provider, $model );
-		if ( ! $updated ) {
-			do_action(
-				'datamachine_log',
-				'debug',
-				'AIConversationLoop: Failed to write transcript messages',
-				array(
-					'session_id'   => $session_id,
-					'job_id'       => $payload['job_id'] ?? null,
-					'flow_step_id' => $payload['flow_step_id'] ?? null,
-				)
-			);
-			// Best-effort cleanup so we don't leave an empty pipeline-mode
-			// row behind. Failure to delete is non-fatal — retention will
-			// catch it eventually.
-			$store->delete_session( $session_id );
-			return '';
-		}
-
-		do_action(
-			'datamachine_log',
-			'debug',
-			'AIConversationLoop: Transcript persisted',
-			array(
-				'session_id'   => $session_id,
-				'job_id'       => $payload['job_id'] ?? null,
-				'flow_step_id' => $payload['flow_step_id'] ?? null,
-				'turn_count'   => $result['turn_count'] ?? 0,
-			)
-		);
-
-		return $session_id;
 	}
 }

--- a/inc/Engine/AI/AgentConversationCompletionDecision.php
+++ b/inc/Engine/AI/AgentConversationCompletionDecision.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Runtime completion decision value.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable completion decision returned by runtime completion policies.
+ */
+class AgentConversationCompletionDecision {
+
+	/** @var bool Whether the current conversation should stop. */
+	private bool $complete;
+
+	/** @var string Optional diagnostic message for adapter logs. */
+	private string $message;
+
+	/** @var array Optional diagnostic context for adapter logs. */
+	private array $context;
+
+	/**
+	 * @param bool   $complete Whether the current conversation should stop.
+	 * @param string $message  Optional diagnostic message.
+	 * @param array  $context  Optional diagnostic context.
+	 */
+	private function __construct( bool $complete, string $message = '', array $context = array() ) {
+		$this->complete = $complete;
+		$this->message  = $message;
+		$this->context  = $context;
+	}
+
+	/**
+	 * Build a non-completing decision.
+	 *
+	 * @param string $message Optional diagnostic message.
+	 * @param array  $context Optional diagnostic context.
+	 * @return self
+	 */
+	public static function incomplete( string $message = '', array $context = array() ): self {
+		return new self( false, $message, $context );
+	}
+
+	/**
+	 * Build a completing decision.
+	 *
+	 * @param string $message Optional diagnostic message.
+	 * @param array  $context Optional diagnostic context.
+	 * @return self
+	 */
+	public static function complete( string $message = '', array $context = array() ): self {
+		return new self( true, $message, $context );
+	}
+
+	/** @return bool Whether the current conversation should stop. */
+	public function isComplete(): bool {
+		return $this->complete;
+	}
+
+	/** @return string Optional diagnostic message. */
+	public function message(): string {
+		return $this->message;
+	}
+
+	/** @return array Optional diagnostic context. */
+	public function context(): array {
+		return $this->context;
+	}
+}

--- a/inc/Engine/AI/AgentConversationCompletionPolicyInterface.php
+++ b/inc/Engine/AI/AgentConversationCompletionPolicyInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Runtime completion policy contract.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Decides whether a tool result completes a conversation run.
+ */
+interface AgentConversationCompletionPolicyInterface {
+
+	/**
+	 * Record a tool result and decide whether the runtime should stop.
+	 *
+	 * @param string     $tool_name   Tool name from the model response.
+	 * @param array|null $tool_def    Tool definition from the active tool set.
+	 * @param array      $tool_result Tool execution result.
+	 * @param string     $mode        Runtime mode.
+	 * @param int        $turn_count  Current turn count.
+	 * @return AgentConversationCompletionDecision Completion decision.
+	 */
+	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, string $mode, int $turn_count ): AgentConversationCompletionDecision;
+}

--- a/inc/Engine/AI/AgentConversationTranscriptPersisterInterface.php
+++ b/inc/Engine/AI/AgentConversationTranscriptPersisterInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Runtime transcript persistence contract.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Persists a completed or failed conversation transcript when requested.
+ */
+interface AgentConversationTranscriptPersisterInterface {
+
+	/**
+	 * Persist a runtime transcript.
+	 *
+	 * @param array  $messages Final conversation messages.
+	 * @param string $provider Provider identifier.
+	 * @param string $model    Model identifier.
+	 * @param array  $payload  Adapter payload.
+	 * @param array  $result   Loop result so far.
+	 * @return string Session ID on success, empty string when not persisted.
+	 */
+	public function persist( array $messages, string $provider, string $model, array $payload, array $result ): string;
+}

--- a/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
+++ b/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Data Machine handler completion policy.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Preserves pipeline handler completion behavior outside the generic turn loop.
+ */
+class DataMachineHandlerCompletionPolicy implements AgentConversationCompletionPolicyInterface {
+
+	/** @var array Required handler slugs configured by the adjacent pipeline step. */
+	private array $configured_handlers;
+
+	/** @var array Handler slugs that have completed successfully. */
+	private array $executed_handler_slugs = array();
+
+	/**
+	 * @param array $configured_handlers Required handler slugs.
+	 */
+	public function __construct( array $configured_handlers = array() ) {
+		$this->configured_handlers = array_values( $configured_handlers );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, string $mode, int $turn_count ): AgentConversationCompletionDecision {
+		$is_handler_tool = is_array( $tool_def ) && isset( $tool_def['handler'] );
+
+		if ( 'pipeline' !== $mode || ! $is_handler_tool || ! ( $tool_result['success'] ?? false ) ) {
+			return AgentConversationCompletionDecision::incomplete();
+		}
+
+		$handler_slug = $tool_def['handler'] ?? null;
+		if ( $handler_slug ) {
+			$this->executed_handler_slugs[] = $handler_slug;
+		}
+
+		if ( empty( $this->configured_handlers ) ) {
+			return AgentConversationCompletionDecision::complete(
+				'AIConversationLoop: Handler tool executed (legacy mode), ending conversation',
+				array(
+					'tool_name'  => $tool_name,
+					'turn_count' => $turn_count,
+				)
+			);
+		}
+
+		$remaining = array_diff( $this->configured_handlers, array_unique( $this->executed_handler_slugs ) );
+		if ( empty( $remaining ) ) {
+			return AgentConversationCompletionDecision::complete(
+				'AIConversationLoop: All configured handlers executed, ending conversation',
+				array(
+					'tool_name'           => $tool_name,
+					'turn_count'          => $turn_count,
+					'executed_handlers'   => array_unique( $this->executed_handler_slugs ),
+					'configured_handlers' => $this->configured_handlers,
+				)
+			);
+		}
+
+		return AgentConversationCompletionDecision::incomplete(
+			'AIConversationLoop: Handler executed, waiting for remaining handlers',
+			array(
+				'tool_name'          => $tool_name,
+				'remaining_handlers' => array_values( $remaining ),
+			)
+		);
+	}
+}

--- a/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
+++ b/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Data Machine pipeline transcript persister.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Persists opted-in pipeline transcripts through Data Machine's transcript store.
+ */
+class DataMachinePipelineTranscriptPersister implements AgentConversationTranscriptPersisterInterface {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function persist( array $messages, string $provider, string $model, array $payload, array $result ): string {
+		if ( empty( $payload['persist_transcript'] ) ) {
+			return '';
+		}
+
+		// Without messages there's nothing useful to persist. This guards
+		// against the early-failure path where the first AI request errored
+		// before any message was assembled.
+		if ( empty( $messages ) ) {
+			return '';
+		}
+
+		$store = ConversationStoreFactory::get_transcript_store();
+
+		$user_id  = (int) ( $payload['user_id'] ?? 0 );
+		$agent_id = (int) ( $payload['agent_id'] ?? 0 );
+
+		$metadata = array(
+			'source'       => 'pipeline_transcript',
+			'job_id'       => $payload['job_id'] ?? null,
+			'flow_step_id' => $payload['flow_step_id'] ?? null,
+			'pipeline_id'  => $payload['pipeline_id'] ?? null,
+			'flow_id'      => $payload['flow_id'] ?? null,
+			'agent_id'     => $agent_id > 0 ? $agent_id : null,
+			'owner_id'     => $user_id > 0 ? $user_id : null,
+			'provider'     => $provider,
+			'model'        => $model,
+			'turn_count'   => $result['turn_count'] ?? 0,
+			'completed'    => (bool) ( $result['completed'] ?? false ),
+			'error'        => $result['error'] ?? null,
+			'usage'        => $result['usage'] ?? array(),
+		);
+
+		if ( ! empty( $result['request_metadata'] ) && is_array( $result['request_metadata'] ) ) {
+			$metadata['request_metadata'] = $result['request_metadata'];
+		}
+
+		$session_id = $store->create_session( $user_id, $agent_id, $metadata, 'pipeline' );
+
+		if ( '' === $session_id ) {
+			do_action(
+				'datamachine_log',
+				'debug',
+				'AIConversationLoop: Failed to create transcript session',
+				array(
+					'job_id'       => $payload['job_id'] ?? null,
+					'flow_step_id' => $payload['flow_step_id'] ?? null,
+				)
+			);
+			return '';
+		}
+
+		$updated = $store->update_session( $session_id, $messages, $metadata, $provider, $model );
+		if ( ! $updated ) {
+			do_action(
+				'datamachine_log',
+				'debug',
+				'AIConversationLoop: Failed to write transcript messages',
+				array(
+					'session_id'   => $session_id,
+					'job_id'       => $payload['job_id'] ?? null,
+					'flow_step_id' => $payload['flow_step_id'] ?? null,
+				)
+			);
+			// Best-effort cleanup so we don't leave an empty pipeline-mode row behind.
+			$store->delete_session( $session_id );
+			return '';
+		}
+
+		do_action(
+			'datamachine_log',
+			'debug',
+			'AIConversationLoop: Transcript persisted',
+			array(
+				'session_id'   => $session_id,
+				'job_id'       => $payload['job_id'] ?? null,
+				'flow_step_id' => $payload['flow_step_id'] ?? null,
+				'turn_count'   => $result['turn_count'] ?? 0,
+			)
+		);
+
+		return $session_id;
+	}
+}

--- a/inc/Engine/AI/DefaultAgentConversationCompletionPolicy.php
+++ b/inc/Engine/AI/DefaultAgentConversationCompletionPolicy.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Default runtime completion policy.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Generic policy: tool calls alone do not complete the loop.
+ */
+class DefaultAgentConversationCompletionPolicy implements AgentConversationCompletionPolicyInterface {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, string $mode, int $turn_count ): AgentConversationCompletionDecision {
+		unset( $tool_name, $tool_def, $tool_result, $mode, $turn_count );
+
+		return AgentConversationCompletionDecision::incomplete();
+	}
+}

--- a/inc/Engine/AI/NullAgentConversationTranscriptPersister.php
+++ b/inc/Engine/AI/NullAgentConversationTranscriptPersister.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Null transcript persister.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * No-op transcript persistence implementation.
+ */
+class NullAgentConversationTranscriptPersister implements AgentConversationTranscriptPersisterInterface {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function persist( array $messages, string $provider, string $model, array $payload, array $result ): string {
+		unset( $messages, $provider, $model, $payload, $result );
+
+		return '';
+	}
+}

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Smoke tests for the agent conversation runtime policy boundary.
+ *
+ * Run with: php tests/agent-conversation-runtime-policy-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$GLOBALS['datamachine_runtime_policy_filters'] = array();
+$GLOBALS['datamachine_runtime_policy_logs']    = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['datamachine_runtime_policy_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$callbacks = $GLOBALS['datamachine_runtime_policy_filters'][ $hook ] ?? array();
+		ksort( $callbacks );
+
+		foreach ( $callbacks as $priority_callbacks ) {
+			foreach ( $priority_callbacks as $entry ) {
+				$callback      = $entry[0];
+				$accepted_args = $entry[1];
+				$value         = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['datamachine_runtime_policy_logs'][] = array_merge( array( $hook ), $args );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $flags = 0 ) {
+		return json_encode( $data, $flags );
+	}
+}
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+use DataMachine\Engine\AI\AIConversationLoop;
+use DataMachine\Engine\AI\AgentConversationCompletionDecision;
+use DataMachine\Engine\AI\AgentConversationCompletionPolicyInterface;
+use DataMachine\Engine\AI\AgentConversationTranscriptPersisterInterface;
+use DataMachine\Engine\AI\DataMachineHandlerCompletionPolicy;
+
+class RuntimePolicySmokeCompletionPolicy implements AgentConversationCompletionPolicyInterface {
+	public array $calls = array();
+
+	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, string $mode, int $turn_count ): AgentConversationCompletionDecision {
+		$this->calls[] = compact( 'tool_name', 'tool_def', 'tool_result', 'mode', 'turn_count' );
+
+		return AgentConversationCompletionDecision::complete(
+			'RuntimePolicySmoke: custom policy completed',
+			array( 'tool_name' => $tool_name )
+		);
+	}
+}
+
+class RuntimePolicySmokeTranscriptPersister implements AgentConversationTranscriptPersisterInterface {
+	public array $calls = array();
+
+	public function persist( array $messages, string $provider, string $model, array $payload, array $result ): string {
+		$this->calls[] = compact( 'messages', 'provider', 'model', 'payload', 'result' );
+
+		return 'runtime-policy-transcript';
+	}
+}
+
+class RuntimePolicySmokeTool {
+	public function execute( array $parameters, array $tool_def ): array {
+		unset( $tool_def );
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'message' => 'tool handled ' . ( $parameters['name'] ?? 'unknown' ),
+			),
+		);
+	}
+}
+
+$failures   = array();
+$assertions = 0;
+
+function assert_runtime_policy( bool $condition, string $label ): void {
+	global $failures, $assertions;
+
+	++$assertions;
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	echo "FAIL: {$label}\n";
+	$failures[] = $label;
+}
+
+function runtime_policy_logs_contain( string $message ): bool {
+	foreach ( $GLOBALS['datamachine_runtime_policy_logs'] as $entry ) {
+		if ( 'datamachine_log' === ( $entry[0] ?? '' ) && $message === ( $entry[2] ?? '' ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function runtime_policy_failure_count(): int {
+	global $failures;
+
+	return count( $failures );
+}
+
+// 1. Data Machine's handler policy is a runtime collaborator, not inline loop state.
+$handler_policy = new DataMachineHandlerCompletionPolicy( array( 'wordpress_publish', 'pinterest_publish' ) );
+$first_decision = $handler_policy->recordToolResult(
+	'publish_wordpress',
+	array( 'handler' => 'wordpress_publish' ),
+	array( 'success' => true ),
+	'pipeline',
+	1
+);
+$second_decision = $handler_policy->recordToolResult(
+	'publish_pinterest',
+	array( 'handler' => 'pinterest_publish' ),
+	array( 'success' => true ),
+	'pipeline',
+	2
+);
+
+assert_runtime_policy( ! $first_decision->isComplete(), 'handler policy waits for remaining configured handlers' );
+assert_runtime_policy( array( 'pinterest_publish' ) === ( $first_decision->context()['remaining_handlers'] ?? null ), 'handler policy reports remaining handlers' );
+assert_runtime_policy( $second_decision->isComplete(), 'handler policy completes after all configured handlers fire' );
+assert_runtime_policy( array( 'wordpress_publish', 'pinterest_publish' ) === array_values( $second_decision->context()['executed_handlers'] ?? array() ), 'handler policy reports executed handlers' );
+
+// 2. Injected completion/transcript collaborators steer the loop without leaking into provider payloads.
+$dispatch_count     = 0;
+$provider_context   = null;
+$completion_policy  = new RuntimePolicySmokeCompletionPolicy();
+$transcript_policy  = new RuntimePolicySmokeTranscriptPersister();
+
+add_filter(
+	'chubes_ai_request',
+	function ( array $request_body, string $provider, $streaming_callback, array $tools, $step_id, array $context ) use ( &$dispatch_count, &$provider_context ) {
+		unset( $request_body, $provider, $streaming_callback, $tools, $step_id );
+		++$dispatch_count;
+		$provider_context = $context;
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => '',
+				'tool_calls' => array(
+					array(
+						'name'       => 'runtime_policy_tool',
+						'parameters' => array( 'name' => 'Ada' ),
+					),
+				),
+				'usage'      => array( 'prompt_tokens' => 3, 'completion_tokens' => 2, 'total_tokens' => 5 ),
+			),
+		);
+	},
+	10,
+	6
+);
+
+$result = ( new AIConversationLoop() )->execute(
+	array( array( 'role' => 'user', 'content' => 'run one tool' ) ),
+	array(
+		'runtime_policy_tool' => array(
+			'name'        => 'runtime_policy_tool',
+			'description' => 'Runtime policy smoke tool',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	'chat',
+	array(
+		'completion_policy'    => $completion_policy,
+		'transcript_persister' => $transcript_policy,
+		'job_id'               => 1588,
+	),
+	5
+);
+
+assert_runtime_policy( 1 === $dispatch_count, 'custom completion policy stopped the loop after one provider request' );
+assert_runtime_policy( true === $result['completed'], 'custom completion policy marked the result complete' );
+assert_runtime_policy( 'runtime-policy-transcript' === ( $result['transcript_session_id'] ?? null ), 'custom transcript persister can attach a transcript session id' );
+assert_runtime_policy( 1 === count( $completion_policy->calls ), 'custom completion policy received one tool result' );
+assert_runtime_policy( 'runtime_policy_tool' === ( $completion_policy->calls[0]['tool_name'] ?? null ), 'custom completion policy receives tool name' );
+assert_runtime_policy( 1 === count( $transcript_policy->calls ), 'custom transcript persister was called once on success' );
+assert_runtime_policy( ! array_key_exists( 'completion_policy', $provider_context['payload'] ?? array() ), 'completion policy object is stripped before provider dispatch' );
+assert_runtime_policy( ! array_key_exists( 'transcript_persister', $provider_context['payload'] ?? array() ), 'transcript persister object is stripped before provider dispatch' );
+assert_runtime_policy( runtime_policy_logs_contain( 'RuntimePolicySmoke: custom policy completed' ), 'completion policy diagnostic message is logged by the adapter' );
+
+if ( runtime_policy_failure_count() > 0 ) {
+	exit( 1 );
+}
+
+echo "\nAgent conversation runtime policy smoke passed ({$assertions} assertions).\n";


### PR DESCRIPTION
## Summary
- Introduces runtime completion and transcript collaborator seams so the built-in agent loop no longer owns Data Machine handler-completion or pipeline-transcript persistence decisions directly.
- Keeps `AIConversationLoop` as the compatibility facade while documenting the updated Agents API extraction boundary.

Closes #1588.

## Changes
- Added generic runtime collaborator contracts for completion policy and transcript persistence, plus null/default implementations.
- Moved Data Machine-specific adjacent-handler completion tracking into `DataMachineHandlerCompletionPolicy`.
- Moved pipeline transcript persistence into `DataMachinePipelineTranscriptPersister`.
- Strips runtime-only collaborator objects before provider/tool dispatch.
- Added `tests/agent-conversation-runtime-policy-smoke.php` and updated extraction docs to reflect the completed seam.

## Tests
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`
- `php tests/ai-loop-event-sink-smoke.php`
- `php tests/agent-conversation-result-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-agent-runtime-facade --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-agent-runtime-facade --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runtime collaborator refactor, smoke coverage, docs updates, and local verification. Chris remains responsible for review and merge decisions.
