### PR TITLE
docs(agent): clarify product runtime boundary

### DIFF
--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -40,6 +40,24 @@ Use these checks before moving anything:
 | Intelligence domain | Intelligence plugin concerns, not Data Machine or Agents API. | Wiki, briefings, digests, domain brains. |
 | wpcom source material | Useful precedent only. | `\WPCOM\AI\Message`, `\Agent`, `\AgentsStore`, `Conversation_Storage`. |
 
+## Current `Engine\AI` Namespace Split
+
+The current namespace is intentionally mixed while extraction stays in place. Treat `DataMachine\Engine\AI` as a staging namespace, not as an extraction boundary. Grep for the class or subnamespace below before assuming a file is part of the future Agents API runtime.
+
+| Current namespace/surface | Bucket | Boundary decision |
+|---|---|---|
+| `DataMachine\Engine\AI\AgentMessageEnvelope`, `AgentConversationRequest`, `AgentConversationResult`, `AgentConversationRunnerInterface`, `AgentConversationCompletionPolicyInterface`, `AgentConversationTranscriptPersisterInterface`, `LoopEventSinkInterface` | Agents API public candidate | Generic contracts/value objects. These are extraction candidates after vocabulary settles. |
+| `DataMachine\Engine\AI\BuiltInAgentConversationRunner`, `AIConversationLoop`, `RequestBuilder`, `WpAiClientAdapter`, `RequestInspector`, `RequestMetadata`, `ConversationManager` | Agents API implementation candidate | Runtime implementation candidates, but still hosted by Data Machine and still carrying compatibility/provider/logging assumptions. |
+| `DataMachine\Engine\AI\Tools\RuntimeToolDeclaration`, `Tools\Execution\ToolExecutionCore`, `Tools\ToolSourceRegistry`, `Tools\ToolResultFinder` | Mixed runtime candidate | Generic pieces exist here, but keep source providers and Data Machine decorators out of the public Agents API surface. |
+| `DataMachine\Engine\AI\Tools\Sources\DataMachineToolRegistrySource`, `Tools\Sources\AdjacentHandlerToolSource`, `Tools\ToolManager`, pipeline-specific methods on `Tools\ToolPolicyResolver`, `Tools\ToolParameters` payload merging | Data Machine adapter/product | These translate Data Machine handler, pipeline, queue, and legacy tool registry concepts into runtime inputs. They stay Data Machine. |
+| `DataMachine\Engine\AI\Tools\Global\*` | Data Machine product | Curated product/site-ops tools. Individual capabilities may move to abilities later, but the bundle is not the Agents API registry. |
+| `DataMachine\Engine\AI\System\*` and `System\Tasks\*` | Data Machine product | System tasks, task prompts, retention cleanup, and scheduled maintenance stay in Data Machine. A future Agents API may provide a task contract, not these tasks. |
+| `DataMachine\Engine\AI\Actions\*` | Data Machine product | Pending-action storage, approval policy, and action-resolution abilities stay Data Machine. Generic approval can be designed later without inheriting these tables/routes. |
+| `DataMachine\Engine\AI\Memory\*`, `MemoryFileRegistry`, `SectionRegistry`, `ComposableFileGenerator`, `ComposableFileInvalidation` | Data Machine adapter/product | Memory policy artifacts and file composition are Data Machine's operator/product layer around the generic memory store contract. |
+| `PipelineTranscriptPolicy`, `DataMachinePipelineTranscriptPersister`, `DataMachineHandlerCompletionPolicy` | Data Machine adapter | Pipeline/job metadata and adjacent-handler completion are normalized for the runtime through collaborator interfaces, but the implementations stay Data Machine. |
+
+Exit rule for this in-place phase: do not physically move broad namespaces just because they sit under `Engine\AI`. Move only once a class is generic by dependency direction, vocabulary, and tests; otherwise document it as a Data Machine adapter or product surface.
+
 ## Agents API Public Candidate
 
 These are closest to generic public contracts. Most should be extracted as contracts/value objects before services.

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -123,6 +123,8 @@ Target shape:
 - Do not move these into Agents API.
 - Rename namespaces later if useful, but treat them as Data Machine automation/product surface.
 - Use them as consumers of Agents API, not part of the substrate.
+- Keep `System\*`, `System\Tasks\*`, `System\Tasks\Retention\*`, `Actions\*`, `Tools\Global\*`, `Tools\Sources\DataMachineToolRegistrySource`, `Tools\Sources\AdjacentHandlerToolSource`, `PipelineTranscriptPolicy`, `DataMachinePipelineTranscriptPersister`, and `DataMachineHandlerCompletionPolicy` in the Data Machine adapter/product bucket until there is a narrow, behavior-preserving move.
+- Use `inc/Engine/AI/README.md` and the extraction map's `Current Engine\AI Namespace Split` table as the grep guide while this namespace remains mixed.
 
 ## Lingering Entanglement Checklist
 

--- a/inc/Engine/AI/README.md
+++ b/inc/Engine/AI/README.md
@@ -1,0 +1,21 @@
+# Engine AI Namespace Boundary
+
+`DataMachine\Engine\AI` is a staging namespace while the future Agents API runtime is clarified in place. It is not itself the extraction boundary.
+
+Use this quick map before moving or renaming files:
+
+| Area | Boundary |
+|---|---|
+| `AgentMessageEnvelope`, `AgentConversation*`, `LoopEventSinkInterface`, `RuntimeToolDeclaration` | Generic runtime candidates. |
+| `BuiltInAgentConversationRunner`, `AIConversationLoop`, request builders, prompt/directive helpers | Implementation candidates, still carrying Data Machine compatibility seams. |
+| `System\*`, `System\Tasks\*`, `System\Tasks\Retention\*` | Data Machine product automation. Do not move into Agents API. |
+| `Actions\*` | Data Machine pending-action product surface. Do not move into Agents API. |
+| `Tools\Global\*` | Data Machine curated site-ops/product tools. Do not treat as the public Agents API tool registry. |
+| `Tools\Sources\DataMachineToolRegistrySource`, `Tools\Sources\AdjacentHandlerToolSource`, pipeline policy helpers | Data Machine adapters from flows/handlers into runtime tool inputs. |
+| `Memory\*`, `MemoryFileRegistry`, `SectionRegistry`, composable file helpers | Data Machine memory policy/file-composition layer around generic memory contracts. |
+| `DataMachinePipelineTranscriptPersister`, `DataMachineHandlerCompletionPolicy`, `PipelineTranscriptPolicy` | Data Machine adapters for job/pipeline metadata and adjacent-handler completion. |
+
+Docs that own the full map:
+
+- `docs/development/agents-api-extraction-map.md`
+- `docs/development/agents-api-pre-extraction-audit.md`


### PR DESCRIPTION
## Summary
- Clarifies that `DataMachine\Engine\AI` is a mixed staging namespace, not the Agents API extraction boundary.
- Adds a concrete namespace split for generic runtime candidates, Data Machine adapters, and Data Machine product surfaces.
- Adds a local `inc/Engine/AI/README.md` grep guide for future namespace moves.

## Changes
- Documented the current `Engine\AI` product/runtime split in the Agents API extraction map.
- Updated the pre-extraction audit to point at the namespace split and list Data Machine-owned surfaces that stay out of Agents API.
- Added a namespace-local README to make the boundary visible next to the mixed code.

## Tests
- `git diff --check`

Closes #1595.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the documentation updates and PR text; Chris remains responsible for review and merge decisions.