### PR TITLE
refactor(agent): split request assembly boundary

### DIFF
--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -97,7 +97,8 @@ These are plausibly generic implementations, but should not move until naming an
 | Surface | Current location | Why it is not public-ready yet | Extraction direction |
 |---|---|---|---|
 | `AIConversationLoop` | `inc/Engine/AI/AIConversationLoop.php` | Name says AI and still carries the compatibility facade/result shape, but handler completion and transcript persistence now route through runtime collaborators. | Keep shrinking the compatibility adapter by extracting provider request assembly and Data Machine logging policy next. |
-| `RequestBuilder` | `inc/Engine/AI/RequestBuilder.php` | Mostly generic request assembly, but dispatch falls back to `chubes_ai_request` and applies Data Machine directives. | Extract assembler separately from provider dispatch and Data Machine directive policy. |
+| `ProviderRequestAssembler` | `inc/Engine/AI/ProviderRequestAssembler.php` | Normalizes messages, tools, model, and caller-selected directives without dispatching, logging, or discovering Data Machine directives. | Good in-place request assembly candidate once prompt/directive vocabulary is settled. |
+| `RequestBuilder` | `inc/Engine/AI/RequestBuilder.php` | Data Machine adapter around provider assembly: discovers/directive-policies `datamachine_directives`, emits `datamachine_log`, applies request-size guardrails, and dispatches via wp-ai-client or `chubes_ai_request`. | Keep as Data Machine adapter unless/until the legacy provider dispatch bridge is replaced. |
 | `WpAiClientAdapter` | `inc/Engine/AI/WpAiClientAdapter.php` | Generic bridge to WordPress AI client, but currently lives as Data Machine implementation detail. | Good implementation candidate once request/message contracts are generic. |
 | `RequestMetadata` | `inc/Engine/AI/RequestMetadata.php` | Generic inspection/size metadata. | Move after field names are checked against Agents API message/tool vocabulary. |
 | `RequestInspector` | `inc/Engine/AI/RequestInspector.php` | Generic debugging/inspection value, likely useful across runtimes. | Rename away from Data Machine only if public debug surface is desired. |
@@ -270,6 +271,7 @@ These tests currently pin the substrate most relevant to extraction.
 | `tests/system-task-agent-context-smoke.php` | Agent context propagation through system tasks. | Data Machine adapter/product. |
 | `tests/agent-call-migration-smoke.php` | Agent-call migration. | Agent-call primitive may inform Agents API; migration stays Data Machine. |
 | `tests/agent-bundle-*.php` | Bundle format, artifact store, upgrade planner, portable update. | Split pure manifest/auth/template artifacts from flow/pipeline file adapters. |
+| `tests/ai-request-inspector-smoke.php` | Provider request assembly without dispatch plus Data Machine request inspection surface. | Split generic `ProviderRequestAssembler` assertions from Data Machine `RequestBuilder` directive-policy assertions during extraction. |
 
 ## First Seams To Make Boring
 

--- a/inc/Engine/AI/ProviderRequestAssembler.php
+++ b/inc/Engine/AI/ProviderRequestAssembler.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Provider request assembler.
+ *
+ * Builds the provider request payload without Data Machine dispatch, logging, or
+ * directive discovery policy. Callers pass the directive list they want applied.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+class ProviderRequestAssembler {
+
+	/**
+	 * Assemble a provider request without dispatching it.
+	 *
+	 * @param array  $messages   Initial messages array with role/content.
+	 * @param string $provider   AI provider name.
+	 * @param string $model      Model identifier.
+	 * @param array  $tools      Raw tools array from filters or runtime declarations.
+	 * @param string $mode       Execution mode.
+	 * @param array  $payload    Request payload.
+	 * @param array  $directives Directive configs already selected by the caller.
+	 * @return array Assembled request and inspection metadata.
+	 */
+	public function assemble(
+		array $messages,
+		string $provider,
+		string $model,
+		array $tools,
+		string $mode,
+		array $payload = array(),
+		array $directives = array()
+	): array {
+		$structured_tools = self::restructureTools( $tools );
+
+		$prompt_builder = new PromptBuilder();
+		$prompt_builder->setMessages( $messages )->setTools( $structured_tools );
+
+		foreach ( $directives as $directive ) {
+			$prompt_builder->addDirective(
+				$directive['class'],
+				$directive['priority'],
+				$directive['modes'] ?? array( 'all' )
+			);
+		}
+
+		$request             = $prompt_builder->buildDetailed( $mode, $provider, $payload );
+		$request['messages'] = AgentMessageEnvelope::normalize_many( $request['messages'] ?? array() );
+		$applied_directives  = $request['applied_directives'] ?? array();
+		$directive_metadata  = $request['directive_metadata'] ?? array();
+		$directive_breakdown = $request['directive_breakdown'] ?? array();
+		unset( $request['applied_directives'], $request['directive_metadata'], $request['directive_breakdown'] );
+		$request['model'] = $model;
+
+		return array(
+			'request'             => $request,
+			'structured_tools'    => $structured_tools,
+			'applied_directives'  => $applied_directives,
+			'directive_metadata'  => $directive_metadata,
+			'directive_breakdown' => $directive_breakdown,
+		);
+	}
+
+	/**
+	 * Convert assembled request messages into provider-facing message arrays.
+	 *
+	 * @param array $request Assembled request.
+	 * @return array Provider request.
+	 */
+	public static function toProviderRequest( array $request ): array {
+		$provider_request             = $request;
+		$provider_request['messages'] = AgentMessageEnvelope::to_provider_messages( $request['messages'] ?? array() );
+		return $provider_request;
+	}
+
+	/**
+	 * Normalize raw tool definitions to the provider request shape.
+	 *
+	 * @param array $raw_tools Raw tools keyed by name.
+	 * @return array Structured tools with explicit fields.
+	 */
+	public static function restructureTools( array $raw_tools ): array {
+		$structured = array();
+
+		foreach ( $raw_tools as $tool_name => $tool_config ) {
+			$structured[ $tool_name ] = array(
+				'name'           => $tool_name,
+				'description'    => $tool_config['description'] ?? '',
+				'parameters'     => $tool_config['parameters'] ?? array(),
+				'handler'        => $tool_config['handler'] ?? null,
+				'handler_config' => $tool_config['handler_config'] ?? array(),
+			);
+		}
+
+		return $structured;
+	}
+}

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -46,13 +46,12 @@ class RequestBuilder {
 		string $mode,
 		array $payload = array()
 	): array {
-		$assembled                    = self::assemble( $messages, $provider, $model, $tools, $mode, $payload );
-		$request                      = $assembled['request'];
-		$provider_request             = $request;
-		$provider_request['messages'] = AgentMessageEnvelope::to_provider_messages( $request['messages'] ?? array() );
-		$structured_tools             = $assembled['structured_tools'];
-		$applied_directives           = $assembled['applied_directives'];
-		$directive_metadata           = $assembled['directive_metadata'];
+		$assembled          = self::assemble( $messages, $provider, $model, $tools, $mode, $payload );
+		$request            = $assembled['request'];
+		$provider_request   = ProviderRequestAssembler::toProviderRequest( $request );
+		$structured_tools   = $assembled['structured_tools'];
+		$applied_directives = $assembled['applied_directives'];
+		$directive_metadata = $assembled['directive_metadata'];
 
 		$request_metadata = RequestMetadata::build(
 			$provider_request,
@@ -169,12 +168,7 @@ class RequestBuilder {
 		string $mode,
 		array $payload = array()
 	): array {
-		$structured_tools = self::restructure_tools( $tools );
 		$payload          = self::withDirectiveContext( $payload );
-
-		$promptBuilder = new PromptBuilder();
-		$promptBuilder->setMessages( $messages )->setTools( $structured_tools );
-
 		$directives       = apply_filters( 'datamachine_directives', array() );
 		$directive_policy = ( new DirectivePolicyResolver() )->resolve(
 			$directives,
@@ -185,56 +179,17 @@ class RequestBuilder {
 		);
 		$directives       = $directive_policy['directives'];
 		$suppressed       = $directive_policy['suppressed'];
-		foreach ( $directives as $directive ) {
-			$promptBuilder->addDirective(
-				$directive['class'],
-				$directive['priority'],
-				$directive['modes'] ?? array( 'all' )
-			);
-		}
 
-		$request             = $promptBuilder->buildDetailed( $mode, $provider, $payload );
-		$request['messages'] = AgentMessageEnvelope::normalize_many( $request['messages'] ?? array() );
-		$applied_directives  = $request['applied_directives'] ?? array();
-		$directive_metadata  = $request['directive_metadata'] ?? array();
-		$directive_breakdown = $request['directive_breakdown'] ?? array();
-		unset( $request['applied_directives'], $request['directive_metadata'], $request['directive_breakdown'] );
-		$request['model'] = $model;
+		$assembled = ( new ProviderRequestAssembler() )->assemble( $messages, $provider, $model, $tools, $mode, $payload, $directives );
 
 		return array(
-			'request'               => $request,
-			'structured_tools'      => $structured_tools,
-			'applied_directives'    => $applied_directives,
-			'directive_metadata'    => $directive_metadata,
-			'directive_breakdown'   => $directive_breakdown,
+			'request'               => $assembled['request'],
+			'structured_tools'      => $assembled['structured_tools'],
+			'applied_directives'    => $assembled['applied_directives'],
+			'directive_metadata'    => $assembled['directive_metadata'],
+			'directive_breakdown'   => $assembled['directive_breakdown'],
 			'suppressed_directives' => $suppressed,
 		);
-	}
-
-	/**
-	 * Restructure tools with explicit field mapping
-	 *
-	 * Normalizes raw tool definitions to ensure all tools have consistent structure
-	 * with name, description, parameters, handler, and handler_config fields.
-	 * Prevents tool format mismatches with AI providers.
-	 *
-	 * @param array $raw_tools Raw tools array from filters
-	 * @return array Structured tools with explicit fields
-	 */
-	private static function restructure_tools( array $raw_tools ): array {
-		$structured = array();
-
-		foreach ( $raw_tools as $tool_name => $tool_config ) {
-			$structured[ $tool_name ] = array(
-				'name'           => $tool_name,
-				'description'    => $tool_config['description'] ?? '',
-				'parameters'     => $tool_config['parameters'] ?? array(),
-				'handler'        => $tool_config['handler'] ?? null,
-				'handler_config' => $tool_config['handler_config'] ?? array(),
-			);
-		}
-
-		return $structured;
 	}
 
 	/**

--- a/tests/ai-request-inspector-smoke.php
+++ b/tests/ai-request-inspector-smoke.php
@@ -47,6 +47,7 @@ require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveOutputValidator.ph
 require_once __DIR__ . '/../inc/Engine/AI/Directives/DirectiveRenderer.php';
 require_once __DIR__ . '/../inc/Engine/AI/AgentMessageEnvelope.php';
 require_once __DIR__ . '/../inc/Engine/AI/PromptBuilder.php';
+require_once __DIR__ . '/../inc/Engine/AI/ProviderRequestAssembler.php';
 require_once __DIR__ . '/../inc/Engine/AI/RequestBuilder.php';
 
 class Test_Request_Inspector_Directive implements \DataMachine\Engine\AI\Directives\DirectiveInterface {
@@ -76,9 +77,10 @@ function assert_test( string $name, bool $cond, string $detail = '' ): void {
 	}
 }
 
-echo "Case 1: RequestBuilder::assemble builds the request without provider dispatch\n";
+echo "Case 1: ProviderRequestAssembler builds without Data Machine hooks or dispatch\n";
 
-$dispatch_count = 0;
+$dispatch_count             = 0;
+$directive_discovery_count  = 0;
 add_filter(
 	'chubes_ai_request',
 	function ( $request ) use ( &$dispatch_count ) {
@@ -89,12 +91,8 @@ add_filter(
 
 add_filter(
 	'datamachine_directives',
-	function ( array $directives ): array {
-		$directives[] = array(
-			'class'    => Test_Request_Inspector_Directive::class,
-			'priority' => 20,
-			'modes'    => array( 'pipeline' ),
-		);
+	function ( array $directives ) use ( &$directive_discovery_count ): array {
+		++$directive_discovery_count;
 		return $directives;
 	}
 );
@@ -117,6 +115,45 @@ $tools = array(
 	),
 );
 
+$generic_assembled = ( new \DataMachine\Engine\AI\ProviderRequestAssembler() )->assemble(
+	$messages,
+	'openai',
+	'gpt-test',
+	$tools,
+	'pipeline',
+	array(
+		'job_id'       => 1423,
+		'flow_step_id' => 'ai_step_1',
+		'step_id'      => 'pipeline_ai_1',
+	),
+	array(
+		array(
+			'class'    => Test_Request_Inspector_Directive::class,
+			'priority' => 20,
+			'modes'    => array( 'pipeline' ),
+		),
+	)
+);
+
+assert_test( 'generic assembler did not call chubes_ai_request', 0 === $dispatch_count );
+assert_test( 'generic assembler did not discover datamachine_directives', 0 === $directive_discovery_count );
+assert_test( 'generic assembler set model', 'gpt-test' === ( $generic_assembled['request']['model'] ?? '' ) );
+assert_test( 'generic assembler restructured tool', 'inspect_tool' === ( $generic_assembled['structured_tools']['inspect_tool']['name'] ?? '' ) );
+
+echo "\nCase 2: RequestBuilder::assemble applies Data Machine directive policy without provider dispatch\n";
+
+add_filter(
+	'datamachine_directives',
+	function ( array $directives ): array {
+		$directives[] = array(
+			'class'    => Test_Request_Inspector_Directive::class,
+			'priority' => 20,
+			'modes'    => array( 'pipeline' ),
+		);
+		return $directives;
+	}
+);
+
 $assembled = \DataMachine\Engine\AI\RequestBuilder::assemble(
 	$messages,
 	'openai',
@@ -131,12 +168,13 @@ $assembled = \DataMachine\Engine\AI\RequestBuilder::assemble(
 );
 
 assert_test( 'assemble did not call chubes_ai_request', 0 === $dispatch_count );
+assert_test( 'RequestBuilder discovered datamachine directives once', 1 === $directive_discovery_count );
 assert_test( 'request model set', 'gpt-test' === ( $assembled['request']['model'] ?? '' ) );
 assert_test( 'directive prepended a system message', 'system' === ( $assembled['request']['messages'][0]['role'] ?? '' ) );
 assert_test( 'original user message preserved', 'Original user packet' === ( $assembled['request']['messages'][1]['content'] ?? '' ) );
 assert_test( 'tool restructured with explicit name', 'inspect_tool' === ( $assembled['structured_tools']['inspect_tool']['name'] ?? '' ) );
 
-echo "\nCase 2: directive breakdown and byte counts are deterministic\n";
+echo "\nCase 3: directive breakdown and byte counts are deterministic\n";
 
 $breakdown = $assembled['directive_breakdown'][0] ?? array();
 assert_test( 'fake directive appears in breakdown', Test_Request_Inspector_Directive::class === ( $breakdown['class'] ?? '' ) );
@@ -152,7 +190,7 @@ assert_test( 'request JSON byte count stable', 496 === $request_json_bytes, 'got
 assert_test( 'messages JSON byte count stable', 277 === $messages_json_bytes, 'got ' . $messages_json_bytes );
 assert_test( 'tools JSON byte count stable', 178 === $tools_json_bytes, 'got ' . $tools_json_bytes );
 
-echo "\nCase 3: CLI command surface is registered and documented\n";
+echo "\nCase 4: CLI command surface is registered and documented\n";
 
 $bootstrap = (string) file_get_contents( __DIR__ . '/../inc/Cli/Bootstrap.php' );
 $command   = (string) file_get_contents( __DIR__ . '/../inc/Cli/Commands/AICommand.php' );

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -137,6 +137,11 @@ function assert_true( bool $condition, string $label ): void {
 	$failures[] = $label;
 }
 
+function failure_count(): int {
+	global $failures;
+	return count( $failures );
+}
+
 function reset_smoke_state(): void {
 	$GLOBALS['datamachine_test_filters'] = array();
 	$GLOBALS['datamachine_test_logs']    = array();
@@ -169,7 +174,7 @@ function build_smoke_request(): array {
 			);
 		},
 		10,
-		6
+		1
 	);
 
 	return RequestBuilder::build(
@@ -193,7 +198,8 @@ foreach ( array( 'datamachine_ai_request_warning_bytes', 'datamachine_ai_message
 	add_filter( $filter, fn() => 1 );
 }
 $response = build_smoke_request();
-assert_true( ! empty( $GLOBALS['datamachine_test_logs'] ), 'oversized request emits a pre-dispatch warning' );
+// @phpstan-ignore-next-line Smoke logs are mutated indirectly through the do_action() stub.
+assert_true( count( $GLOBALS['datamachine_test_logs'] ) > 0, 'oversized request emits a pre-dispatch warning' );
 assert_true( isset( $response['request_metadata']['request_json_bytes'] ), 'response carries request metadata' );
 assert_true( 'RULES.md' === ( $response['request_metadata']['memory_files'][0]['filename'] ?? '' ), 'memory file metadata is compactly captured' );
 
@@ -205,9 +211,11 @@ foreach ( array( 'datamachine_ai_request_warning_bytes', 'datamachine_ai_message
 build_smoke_request();
 $guardrail_warnings = array_filter(
 	$GLOBALS['datamachine_test_logs'],
-	fn( $entry ) => 'warning' === ( $entry[0] ?? '' ) && 'AI request size guardrail warning' === ( $entry[1] ?? '' )
+	// @phpstan-ignore-next-line Smoke logs are runtime-mutated arrays from do_action().
+	fn( $entry ) => is_array( $entry ) && isset( $entry[0], $entry[1] ) && 'warning' === $entry[0] && 'AI request size guardrail warning' === $entry[1]
 );
-assert_true( empty( $guardrail_warnings ), 'small request does not emit guardrail warning' );
+// @phpstan-ignore-next-line Smoke logs are mutated indirectly through the do_action() stub.
+assert_true( 0 === count( $guardrail_warnings ), 'small request does not emit guardrail warning' );
 
 // 3. Simulated persisted pipeline transcript stores request_metadata in session metadata.
 $store    = new RequestMetadataSmokeStore();
@@ -238,12 +246,13 @@ $render->invoke(
 assert_true( in_array( 'Transcript for job 279', WP_CLI::$logs, true ), 'legacy transcript renders without request metadata' );
 
 echo "\n";
-if ( empty( $failures ) ) {
+if ( 0 === failure_count() ) {
 	echo "All AI request metadata guardrail smoke tests passed.\n";
 	exit( 0 );
 }
 
 echo sprintf( "%d failure(s):\n", count( $failures ) );
+// @phpstan-ignore-next-line Smoke assertions mutate failures through assert_true().
 foreach ( $failures as $failure ) {
 	echo "  - {$failure}\n";
 }

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -82,7 +82,7 @@ require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 use DataMachine\Cli\Commands\JobsCommand;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Chat\ConversationStoreInterface;
-use DataMachine\Engine\AI\AIConversationLoop;
+use DataMachine\Engine\AI\DataMachinePipelineTranscriptPersister;
 use DataMachine\Engine\AI\Directives\DirectiveInterface;
 use DataMachine\Engine\AI\RequestBuilder;
 
@@ -214,9 +214,7 @@ $store    = new RequestMetadataSmokeStore();
 $property = new ReflectionProperty( ConversationStoreFactory::class, 'instance' );
 $property->setValue( null, $store );
 
-$method = new ReflectionMethod( AIConversationLoop::class, 'maybePersistTranscript' );
-$session_id = $method->invoke(
-	null,
+$session_id = ( new DataMachinePipelineTranscriptPersister() )->persist(
 	array( array( 'role' => 'user', 'content' => 'hello' ) ),
 	'openai',
 	'gpt-smoke',

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -138,8 +138,27 @@ function assert_true( bool $condition, string $label ): void {
 }
 
 function failure_count(): int {
+	return count( smoke_failures() );
+}
+
+function smoke_failures(): array {
 	global $failures;
-	return count( $failures );
+	return array_values( $failures );
+}
+
+function smoke_logs(): array {
+	$logs = $GLOBALS['datamachine_test_logs'] ?? array();
+	return is_array( $logs ) ? array_values( $logs ) : array();
+}
+
+function count_guardrail_warnings(): int {
+	$count = 0;
+	foreach ( smoke_logs() as $entry ) {
+		if ( is_array( $entry ) && 'warning' === ( $entry[0] ?? '' ) && 'AI request size guardrail warning' === ( $entry[1] ?? '' ) ) {
+			++$count;
+		}
+	}
+	return $count;
 }
 
 function reset_smoke_state(): void {
@@ -198,8 +217,7 @@ foreach ( array( 'datamachine_ai_request_warning_bytes', 'datamachine_ai_message
 	add_filter( $filter, fn() => 1 );
 }
 $response = build_smoke_request();
-// @phpstan-ignore-next-line Smoke logs are mutated indirectly through the do_action() stub.
-assert_true( count( $GLOBALS['datamachine_test_logs'] ) > 0, 'oversized request emits a pre-dispatch warning' );
+assert_true( count( smoke_logs() ) > 0, 'oversized request emits a pre-dispatch warning' );
 assert_true( isset( $response['request_metadata']['request_json_bytes'] ), 'response carries request metadata' );
 assert_true( 'RULES.md' === ( $response['request_metadata']['memory_files'][0]['filename'] ?? '' ), 'memory file metadata is compactly captured' );
 
@@ -209,13 +227,7 @@ foreach ( array( 'datamachine_ai_request_warning_bytes', 'datamachine_ai_message
 	add_filter( $filter, fn() => 999999999 );
 }
 build_smoke_request();
-$guardrail_warnings = array_filter(
-	$GLOBALS['datamachine_test_logs'],
-	// @phpstan-ignore-next-line Smoke logs are runtime-mutated arrays from do_action().
-	fn( $entry ) => is_array( $entry ) && isset( $entry[0], $entry[1] ) && 'warning' === $entry[0] && 'AI request size guardrail warning' === $entry[1]
-);
-// @phpstan-ignore-next-line Smoke logs are mutated indirectly through the do_action() stub.
-assert_true( 0 === count( $guardrail_warnings ), 'small request does not emit guardrail warning' );
+assert_true( 0 === count_guardrail_warnings(), 'small request does not emit guardrail warning' );
 
 // 3. Simulated persisted pipeline transcript stores request_metadata in session metadata.
 $store    = new RequestMetadataSmokeStore();
@@ -246,14 +258,13 @@ $render->invoke(
 assert_true( in_array( 'Transcript for job 279', WP_CLI::$logs, true ), 'legacy transcript renders without request metadata' );
 
 echo "\n";
-if ( 0 === failure_count() ) {
-	echo "All AI request metadata guardrail smoke tests passed.\n";
-	exit( 0 );
+if ( failure_count() > 0 ) {
+	echo sprintf( "%d failure(s):\n", failure_count() );
+	foreach ( smoke_failures() as $failure ) {
+		echo "  - {$failure}\n";
+	}
+	exit( 1 );
 }
 
-echo sprintf( "%d failure(s):\n", count( $failures ) );
-// @phpstan-ignore-next-line Smoke assertions mutate failures through assert_true().
-foreach ( $failures as $failure ) {
-	echo "  - {$failure}\n";
-}
-exit( 1 );
+echo "All AI request metadata guardrail smoke tests passed.\n";
+exit( 0 );


### PR DESCRIPTION
## Summary
- Split provider request assembly into a dedicated `ProviderRequestAssembler` so request normalization can be exercised without Data Machine directive discovery, logging, or provider dispatch.
- Keep `RequestBuilder` as the Data Machine adapter that applies directive policy, guardrail logging, wp-ai-client dispatch, and legacy `chubes_ai_request` fallback.

## Changes
- Added `ProviderRequestAssembler` for message/tool/model normalization and caller-supplied directive application.
- Updated `RequestBuilder::assemble()` to resolve Data Machine directives and delegate generic assembly to the new boundary.
- Expanded request-inspector smoke coverage to prove generic assembly avoids Data Machine hooks and dispatch.
- Updated request metadata smoke coverage to use the transcript persister seam introduced by the recent runtime policy split.
- Refreshed the Agents API extraction map with the new request assembly boundary.

## Tests
- `php tests/ai-request-inspector-smoke.php` — 28 assertions, 0 failures.
- `php tests/ai-request-metadata-guardrails-smoke.php` — passed.
- `php tests/agent-conversation-runner-request-smoke.php` — passed.
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@split-agent-request-assembly --changed-since origin/main` — passed.
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@split-agent-request-assembly --changed-since origin/main` — passed; it still prints repository-wide contextual/baseline findings, but the gate returns `passed: true`.
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@split-agent-request-assembly --changed-since origin/main` — failed with broad test harness/bootstrap drift: 1209 tests selected, 169 errors, 134 failures, 4 skipped, 1 risky. Failures are dominated by abilities/categories/tasks not being registered in the Homeboy WP test harness and do not point at `ProviderRequestAssembler`, `RequestBuilder`, or the request-assembly smokes.

Closes #1617.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the request assembly boundary and focused validation; Chris remains responsible for review and merge.
