### PR TITLE
refactor(agent): define agents api hook names

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,11 @@ OpenAI, Anthropic, Google, Grok, OpenRouter — configure a global default per-s
 
 ## Runtime Adapters
 
-Data Machine ships its own multi-turn conversation loop and uses it by default. The loop is also swappable: a single filter (`datamachine_conversation_runner`) lets an external runtime take over while Data Machine still provides pipelines, flows, tool resolution, abilities, and memory.
+Data Machine ships its own multi-turn conversation loop and uses it by default. The loop is also swappable: a single Agents API-shaped filter (`agents_api_conversation_runner`) lets an external runtime take over while Data Machine still provides pipelines, flows, tool resolution, abilities, and memory.
 
 ```php
 add_filter(
-    'datamachine_conversation_runner',
+    'agents_api_conversation_runner',
     function ( $result, $messages, $tools, $provider, $model, $context, $payload, $max_turns, $single_turn ) {
         // Return an array matching AIConversationLoop::execute()'s shape to
         // replace the built-in loop, or null to let Data Machine run it.

--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -111,7 +111,7 @@ if ($turn_count >= $max_turns && !$conversation_complete) {
 
 All callers should use the static `AIConversationLoop::run()` entry point. It
 accepts the same arguments as `execute()` and returns the same result shape,
-but first gives a registered runtime adapter (via the `datamachine_conversation_runner`
+but first gives a registered runtime adapter (via the `agents_api_conversation_runner`
 filter) the opportunity to short-circuit the built-in loop. See
 [Runtime Adapters](#runtime-adapters) below.
 
@@ -195,7 +195,7 @@ about that runtime.
 
 ```php
 apply_filters(
-    'datamachine_conversation_runner',
+    'agents_api_conversation_runner',
     null,           // Return non-null to short-circuit the built-in loop
     $messages,
     $tools,
@@ -236,7 +236,7 @@ projection at the provider boundary, not the runtime/storage contract.
 
 ```php
 add_filter(
-    'datamachine_conversation_runner',
+    'agents_api_conversation_runner',
     function ( $result, $messages, $tools, $provider, $model, $context, $payload, $max_turns, $single_turn ) {
         // Only take over for a specific context.
         if ( 'chat' !== $context ) {
@@ -272,7 +272,7 @@ conversation is run.
 Runtime adapters and the upcoming wp-ai-client migration operate at different
 layers and are independent:
 
-- `datamachine_conversation_runner` replaces the **conversation loop** — turn
+- `agents_api_conversation_runner` replaces the **conversation loop** — turn
   management, tool execution, completion detection.
 - The wp-ai-client migration (see Extra-Chill/data-machine#1027) replaces the
   **LLM request layer** that the built-in loop calls internally — a single
@@ -280,7 +280,7 @@ layers and are independent:
 
 When wp-ai-client lands, Data Machine's built-in `execute()` will call
 `wp_ai_client_prompt()` in place of `apply_filters('chubes_ai_request', ...)`.
-The `run()` entry point and the `datamachine_conversation_runner` filter
+The `run()` entry point and the `agents_api_conversation_runner` filter
 contract are unchanged, and adapters that replace the entire loop are
 unaffected — they bring their own LLM client as part of their runtime.
 

--- a/docs/core-system/ai-message-envelope.md
+++ b/docs/core-system/ai-message-envelope.md
@@ -103,7 +103,7 @@ shape.
 
 ## Adapter Guidance
 
-Runtime adapters using `datamachine_conversation_runner` may return messages in
+Runtime adapters using `agents_api_conversation_runner` may return messages in
 either legacy or envelope shape. `AgentConversationResult::normalize()` normalizes
 every returned message to the canonical envelope before callers store or render
 the result.

--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -66,7 +66,7 @@ These are closest to generic public contracts. Most should be extracted as contr
 | `ConversationStoreInterface` | `inc/Core/Database/Chat/ConversationStoreInterface.php` | Aggregate Data Machine chat-product compatibility contract. | Do not extract as the default public contract unless Agents API deliberately wants the full aggregate. Prefer the transcript interface first. |
 | `ConversationStoreFactory::get_transcript_store()` | `inc/Core/Database/Chat/ConversationStoreFactory.php` | Narrow resolver for runtime transcript persistence. | Current implementation reuses the Data Machine aggregate filter for compatibility; future Agents API can own a transcript-specific resolver/filter. |
 | `datamachine_conversation_store` filter | `ConversationStoreFactory::get()` | Existing Data Machine aggregate store swap seam. | Keep while code lives in Data Machine. A future Agents API filter should not force chat UI/listing/read-state/reporting responsibilities onto transcript-only backends. |
-| `datamachine_conversation_runner` filter | `AIConversationLoop::run()` | Runner replacement seam is generic. | Target should be a runtime runner interface/filter, not Data Machine named. |
+| `agents_api_conversation_runner` filter | `AIConversationLoop::run()` | Runner replacement seam is generic. | Renamed in place from `datamachine_conversation_runner`; do not mirror the old hook under a runtime alias. |
 | `datamachine_guideline_updated` action | `GuidelineAgentMemoryStore` | Logical memory/guideline change event is generic. | Target event must not assume Data Machine option names or storage. |
 | `wp_register_agent()` helper | `inc/Engine/Agents/register-agents.php` | Declarative agent registration is core-shaped. | Public helper contributes definitions only; persistence reconciliation is not part of the helper contract. |
 | `wp_agents_api_init` action | `inc/Engine/Agents/register-agents.php` | Registration collection hook is generic. | Keep as the in-place Agents API-shaped hook while Data Machine hosts the substrate. |
@@ -188,18 +188,36 @@ These are reference points only. Do not expose them as public Data Machine or Ag
 | `Conversation_Storage` | Reference for compaction/resilience. Keep Data Machine/Agents API conversation store contracts portable and site-owned unless explicitly swapped. |
 | Dolly agent architecture | Reference for WordPress-hosted agent UX and memory injection, not a dependency or target vocabulary. |
 
+## Hook Name Map
+
+This map records the in-place hook vocabulary while Data Machine still hosts the
+Agents API substrate. Generic runtime seams should use Agents API-shaped names;
+Data Machine product and compatibility seams keep Data Machine names.
+
+| Previous hook/filter | Current hook/filter | Decision |
+|---|---|---|
+| `datamachine_conversation_runner` | `agents_api_conversation_runner` | Hard-cut rename. Generic runtime replacement seam. |
+| `datamachine_tool_sources` | `agents_api_tool_sources` | Hard-cut rename. Generic source-provider composition seam; Data Machine sources remain providers. |
+| `datamachine_tool_sources_for_mode` | `agents_api_tool_sources_for_mode` | Hard-cut rename. Generic mode-to-source ordering seam. |
+| `datamachine_memory_store` | `agents_api_memory_store` | Already renamed in place; old hook is intentionally not mirrored. |
+| `wp_agents_api_init` | `wp_agents_api_init` | Already WordPress-shaped registration hook. |
+| `datamachine_conversation_store` | `datamachine_conversation_store` | Keep. This swaps Data Machine's aggregate chat store; a future Agents API transcript hook must be narrower. |
+| `datamachine_guideline_updated` | `datamachine_guideline_updated` | Keep for this slice. Event payload and external projection consumers need a narrower Agents API memory-event decision. |
+| `datamachine_registered_agent_reconciled` | `datamachine_registered_agent_reconciled` | Keep. This is Data Machine materialization/persistence lifecycle, not pure declarative registration. |
+| `datamachine_tools` | `datamachine_tools` | Keep. Legacy/product tool registry; Agents API should prefer ability-native runtime declarations. |
+
 ## Hook And Filter Classification
 
 | Hook/filter | Bucket | Notes |
 |---|---|---|
-| `datamachine_conversation_runner` | Agents API public candidate | Generic runtime replacement seam. Rename and formalize result contract. |
+| `agents_api_conversation_runner` | Agents API public candidate | Generic runtime replacement seam. Renamed in place from `datamachine_conversation_runner`. |
 | `datamachine_conversation_store` | Data Machine compatibility seam today | Existing aggregate store swap seam. A future Agents API transcript-store filter should be narrower instead of carrying Data Machine chat product responsibilities. |
 | `wp_agents_api_init` | Agents API public candidate | Registration hook is now WordPress-shaped in-place; Data Machine still fires the legacy hook while it hosts the substrate. |
 | `agents_api_memory_store` | Agents API public candidate | Generic memory persistence swap seam. Renamed in place from `datamachine_memory_store`; do not mirror the old hook under a runtime alias. |
 | `datamachine_registered_agent_reconciled` | Agents API implementation candidate | Lifecycle event is useful, current reconciliation semantics are Data Machine implementation. |
 | `datamachine_guideline_updated` | Agents API public candidate | Generic memory/guideline change event after naming review. |
-| `datamachine_tool_sources` | Agents API implementation candidate | Generic source-provider idea; current defaults include Data Machine adjacent handlers. |
-| `datamachine_tool_sources_for_mode` | Agents API implementation candidate | Generic mode policy idea; mode names need Agents API contract. |
+| `agents_api_tool_sources` | Agents API implementation candidate | Generic source-provider idea; current defaults include Data Machine adjacent handlers as Data Machine providers. |
+| `agents_api_tool_sources_for_mode` | Agents API implementation candidate | Generic mode policy idea; mode names need Agents API contract. |
 | `datamachine_tools` | Data Machine product today | Current registry includes legacy Data Machine handler/class shapes. Ability-native subset can inform Agents API. |
 | `datamachine_directives` | Agents API implementation candidate | Generic prompt/guideline provider idea, but current directive classes use Data Machine modes. |
 | `datamachine_pre_ai_step_check` | Data Machine adapter | Pipeline AI-step skip hook. |

--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -193,6 +193,9 @@ These are reference points only. Do not expose them as public Data Machine or Ag
 This map records the in-place hook vocabulary while Data Machine still hosts the
 Agents API substrate. Generic runtime seams should use Agents API-shaped names;
 Data Machine product and compatibility seams keep Data Machine names.
+Hard-cut hook renames assume active cross-repo consumers are updated in lockstep;
+this slice's known companion is the Intelligence tier-3 runner adapter update in
+Automattic/intelligence#285.
 
 | Previous hook/filter | Current hook/filter | Decision |
 |---|---|---|

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -38,11 +38,11 @@ Target shape:
 These generic seams still need Agents API naming decisions or have already moved
 in place:
 
-- `datamachine_conversation_runner`
+- `agents_api_conversation_runner`
 - `datamachine_conversation_store`
 - `agents_api_memory_store`
-- `datamachine_tool_sources`
-- `datamachine_tool_sources_for_mode`
+- `agents_api_tool_sources`
+- `agents_api_tool_sources_for_mode`
 - `wp_agents_api_init`
 - `datamachine_guideline_updated`
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -1343,15 +1343,15 @@ $final_response = \DataMachine\Engine\AI\AIConversationLoop::run(
 ): array
 ```
 
-`run()` internally applies the `datamachine_conversation_runner` filter, giving
+`run()` internally applies the `agents_api_conversation_runner` filter, giving
 a registered runtime adapter the chance to short-circuit the built-in loop. If
 no adapter returns an array, Data Machine's built-in `execute()` runs.
 
-**Filter: `datamachine_conversation_runner`**
+**Filter: `agents_api_conversation_runner`**
 
 ```php
 apply_filters(
-    'datamachine_conversation_runner',
+    'agents_api_conversation_runner',
     null,           // Return non-null array to short-circuit
     $messages, $tools, $provider, $model,
     $context, $payload, $max_turns, $single_turn
@@ -1370,7 +1370,7 @@ for the full adapter contract.
 - Turn-based state management with chronological ordering
 - Duplicate message prevention
 - Maximum turn limiting (default: 25)
-- Runtime-swappable via `datamachine_conversation_runner`
+- Runtime-swappable via `agents_api_conversation_runner`
 
 ### ConversationStoreInterface (`/inc/Core/Database/Chat/ConversationStoreInterface.php`)
 

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -32,7 +32,7 @@ class AIConversationLoop {
 	 *
 	 * This is the canonical entry point every caller should use instead of
 	 * instantiating AIConversationLoop directly. It exposes a single filter
-	 * (`datamachine_conversation_runner`) that lets a consumer short-circuit the
+	 * (`agents_api_conversation_runner`) that lets a consumer short-circuit the
 	 * built-in loop with an alternative runtime while receiving the exact
 	 * same argument list and returning the exact same result shape. If the
 	 * filter returns null (the default), the built-in loop runs unchanged.
@@ -98,7 +98,7 @@ class AIConversationLoop {
 		 * @param bool       $single_turn  Single-turn mode flag.
 		 */
 		$filter_args = array(
-			'datamachine_conversation_runner',
+			'agents_api_conversation_runner',
 			null,
 			$messages,
 			$tools,

--- a/inc/Engine/AI/Tools/ToolSourceRegistry.php
+++ b/inc/Engine/AI/Tools/ToolSourceRegistry.php
@@ -61,7 +61,7 @@ class ToolSourceRegistry {
 	private function getRegisteredSources( string $mode, array $args ): array {
 		// @phpstan-ignore-next-line WordPress apply_filters accepts additional hook arguments.
 		$sources = apply_filters(
-			'datamachine_tool_sources',
+			'agents_api_tool_sources',
 			array(
 				self::SOURCE_STATIC_REGISTRY   => new DataMachineToolRegistrySource( $this->tool_manager ),
 				self::SOURCE_ADJACENT_HANDLERS => new AdjacentHandlerToolSource(),
@@ -87,7 +87,7 @@ class ToolSourceRegistry {
 			: array( self::SOURCE_STATIC_REGISTRY );
 
 		// @phpstan-ignore-next-line WordPress apply_filters accepts additional hook arguments.
-		$sources = apply_filters( 'datamachine_tool_sources_for_mode', $sources, $mode, $args );
+		$sources = apply_filters( 'agents_api_tool_sources_for_mode', $sources, $mode, $args );
 
 		if ( ! is_array( $sources ) ) {
 			return array();

--- a/tests/agent-conversation-result-smoke.php
+++ b/tests/agent-conversation-result-smoke.php
@@ -15,7 +15,7 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	function apply_filters( string $hook, $value ) {
 		global $datamachine_test_conversation_runner_result;
 
-		if ( 'datamachine_conversation_runner' === $hook ) {
+		if ( 'agents_api_conversation_runner' === $hook ) {
 			return $datamachine_test_conversation_runner_result;
 		}
 

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -128,10 +128,10 @@ assert_runner_request( array( 'wiki_upsert' ) === $request->adapterContext()['co
 assert_runner_request( false === $request->adapterContext()['persist_transcript'], 'adapter context carries transcript policy' );
 assert_runner_request( array( 'snapshot' => 'present' ) === $request->adapterContext()['engine'], 'adapter context carries engine snapshot' );
 
-// 2. The legacy facade still passes the old argument list to the runner filter.
+// 2. The compatibility facade passes the historical argument list to the Agents API runner filter.
 $legacy_filter_args = null;
 add_filter(
-	'datamachine_conversation_runner',
+	'agents_api_conversation_runner',
 	function ( $result, ...$args ) use ( &$legacy_filter_args ) {
 		$legacy_filter_args = array_merge( array( $result ), $args );
 		return null;
@@ -192,6 +192,29 @@ assert_runner_request( array() === $result['tool_execution_results'], 'facade no
 assert_runner_request( 5 === ( $result['usage']['total_tokens'] ?? null ), 'facade preserves usage totals' );
 assert_runner_request( is_array( $dispatched_request ), 'built-in runner dispatched a provider request' );
 assert_runner_request( array( 'turn_started', 'request_built', 'completed' ) === array_column( $sink->events, 'event' ), 'event sink survives request boundary' );
+
+$legacy_filter_ran = false;
+add_filter(
+	'datamachine_conversation_runner',
+	function ( $result ) use ( &$legacy_filter_ran ) {
+		$legacy_filter_ran = true;
+		return $result;
+	},
+	10,
+	1
+);
+
+AIConversationLoop::run(
+	$messages,
+	$tools,
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	$payload,
+	7,
+	true
+);
+assert_runner_request( false === $legacy_filter_ran, 'legacy Data Machine conversation-runner filter is no longer mirrored' );
 
 if ( runner_request_failure_count() > 0 ) {
 	exit( 1 );

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -199,7 +199,7 @@ assert_source_equals( array( 'custom_static_tool' ), array_keys( resolve_source_
 echo "\n[3] filters can add a source without disturbing default order:\n";
 remove_all_filters_for_source_smoke();
 add_filter(
-	'datamachine_tool_sources',
+	'agents_api_tool_sources',
 	static function ( array $sources, string $mode, array $args, ToolManager $tool_manager ): array {
 		unset( $mode, $args, $tool_manager );
 		$sources['extra_source'] = static function (): array {
@@ -213,7 +213,7 @@ add_filter(
 	4
 );
 add_filter(
-	'datamachine_tool_sources_for_mode',
+	'agents_api_tool_sources_for_mode',
 	static function ( array $sources, string $mode, array $args ): array {
 		unset( $args );
 		if ( ToolPolicyResolver::MODE_CHAT === $mode ) {
@@ -226,6 +226,30 @@ add_filter(
 );
 $tools = resolve_source_tools( ToolPolicyResolver::MODE_CHAT, new SourcePolicyToolManager() );
 assert_source_equals( array( 'chat_static_tool', 'extra_tool' ), array_keys( $tools ), 'filter appends extra source after static source', $failures, $passes );
+remove_all_filters_for_source_smoke();
+add_filter(
+	'datamachine_tool_sources',
+	static function ( array $sources ): array {
+		$sources['legacy_source'] = static function (): array {
+			return array(
+				'legacy_tool' => array( 'origin' => 'legacy', 'access_level' => 'public' ),
+			);
+		};
+		return $sources;
+	},
+	10,
+	1
+);
+add_filter(
+	'datamachine_tool_sources_for_mode',
+	static function ( array $sources ): array {
+		$sources[] = 'legacy_source';
+		return $sources;
+	},
+	10,
+	1
+);
+assert_source_equals( array( 'chat_static_tool' ), array_keys( resolve_source_tools( ToolPolicyResolver::MODE_CHAT, new SourcePolicyToolManager() ) ), 'legacy Data Machine tool-source filters are no longer mirrored', $failures, $passes );
 
 echo "\n[4] Data Machine source adapters own product vocabulary:\n";
 $registry_source          = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php' );


### PR DESCRIPTION
## Summary
- Rename the generic conversation-runner seam to `agents_api_conversation_runner`.
- Rename tool-source composition filters to `agents_api_tool_sources` and `agents_api_tool_sources_for_mode`.
- Document the hook-name map so Data Machine product/compatibility hooks stay clearly separated from Agents API-shaped runtime seams.

## Changes
- Hard-cuts the runner and tool-source filter names with no permanent fallback ladders.
- Coordinates the runner hook cut with Automattic/intelligence#285; this PR should not be released in isolation while Intelligence still registers `datamachine_conversation_runner`.
- Leaves `datamachine_conversation_store`, `datamachine_guideline_updated`, and `datamachine_registered_agent_reconciled` Data Machine-named for this slice because their current contracts still carry aggregate chat, memory-event, or materialization semantics.
- Updates focused smokes to assert the old runner/tool-source hooks are no longer mirrored.

## Cross-repo check
- Active primary checkout hits for `datamachine_conversation_runner`: Intelligence tier-3 adapter only, fixed in Automattic/intelligence#285.
- Active primary checkout hits for `datamachine_tool_sources` / `datamachine_tool_sources_for_mode`: none found outside Data Machine.
- DMC and MDI primary checkouts are clean for the renamed tool-source filters.

## Tests
- `php tests/agent-conversation-result-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`
- `php tests/tool-source-registry-smoke.php`
- `php -l inc/Engine/AI/AIConversationLoop.php && php -l inc/Engine/AI/Tools/ToolSourceRegistry.php && php -l tests/agent-conversation-result-smoke.php && php -l tests/agent-conversation-runner-request-smoke.php && php -l tests/tool-source-registry-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-agents-api-hook-names --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-agents-api-hook-names --changed-since origin/main --json-summary` *(non-blocking contextual findings only; no changed-since baseline found)*

Closes #1589.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the hook/filter rename slice, updated documentation and focused smokes, checked active cross-repo consumers, and ran verification. Chris remains responsible for review and merge.
