### PR TITLE
fix(deps): update Block Format Bridge to v0.6.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -68,16 +68,16 @@
         },
         {
             "name": "chubes4/block-format-bridge",
-            "version": "v0.6.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "bf7a4d724498573ae583503669a24c31f0cb1a2e"
+                "reference": "9f49e7e29659821da8cc5bd2b75e7306dc7d1d8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/bf7a4d724498573ae583503669a24c31f0cb1a2e",
-                "reference": "bf7a4d724498573ae583503669a24c31f0cb1a2e",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/9f49e7e29659821da8cc5bd2b75e7306dc7d1d8f",
+                "reference": "9f49e7e29659821da8cc5bd2b75e7306dc7d1d8f",
                 "shasum": ""
             },
             "require": {
@@ -112,10 +112,10 @@
             "description": "WordPress plugin orchestrating bidirectional content format conversion (HTML, Blocks, Markdown) via a unified adapter API.",
             "homepage": "https://github.com/chubes4/block-format-bridge",
             "support": {
-                "source": "https://github.com/chubes4/block-format-bridge/tree/v0.6.1",
+                "source": "https://github.com/chubes4/block-format-bridge/tree/v0.6.2",
                 "issues": "https://github.com/chubes4/block-format-bridge/issues"
             },
-            "time": "2026-04-29T20:26:23+00:00"
+            "time": "2026-04-29T21:55:27+00:00"
         },
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
## Summary
- Updates the bundled Block Format Bridge dependency to v0.6.2 so Data Machine picks up the h2bc static-site fidelity fixes.
- Keeps the Data Machine substrate lockfile aligned with the released BFB patch.

## Tests
- php tests/bfb-substrate-bundle-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Dependency refresh, focused smoke verification, and PR drafting; Chris remains responsible for review and merge.