### PR TITLE
feat(bundle): expose system prompt artifact metadata

### DIFF
--- a/inc/Api/System/System.php
+++ b/inc/Api/System/System.php
@@ -16,6 +16,7 @@ use WP_REST_Request;
 use WP_Error;
 use DataMachine\Engine\Tasks\TaskRegistry;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachine\Engine\AI\System\SystemTaskPromptRegistry;
 use DataMachine\Core\Database\Jobs\JobsOperations;
 
 if ( ! defined('ABSPATH') ) {
@@ -176,7 +177,7 @@ class System {
 	 * @return array|WP_Error Response data or error
 	 */
 	public static function get_status( WP_REST_Request $request ) {
-		$request;
+		unset( $request );
 		return rest_ensure_response(
 			array(
 				'success' => true,
@@ -197,7 +198,7 @@ class System {
 	 * @since 0.32.0
 	 */
 	public static function get_tasks( WP_REST_Request $request ) {
-		$request;
+		unset( $request );
 		$registry  = TaskRegistry::getRegistry();
 		$last_runs = self::get_last_runs( array_keys( $registry ) );
 
@@ -270,7 +271,7 @@ class System {
 	 * @since 0.41.0
 	 */
 	public static function get_prompts( WP_REST_Request $request ) {
-		$request;
+		unset( $request );
 		$handlers  = TaskRegistry::getHandlers();
 		$overrides = SystemTask::getAllPromptOverrides();
 
@@ -281,7 +282,11 @@ class System {
 				continue;
 			}
 
-			$task        = new $handler_class();
+			$task = new $handler_class();
+			if ( ! $task instanceof SystemTask ) {
+				continue;
+			}
+
 			$definitions = $task->getPromptDefinitions();
 
 			if ( empty( $definitions ) ) {
@@ -306,20 +311,16 @@ class System {
 				 */
 				$variables = apply_filters(
 					'datamachine_task_prompt_variable_definitions',
-					$definition['variables'] ?? array(),
+					$definition['variables'],
 					$task_type,
 					$prompt_key
 				);
 
-				$prompts[] = array(
-					'task_type'    => $task_type,
-					'prompt_key'   => $prompt_key,
-					'label'        => $definition['label'],
-					'description'  => $definition['description'],
-					'default'      => $definition['default'],
-					'variables'    => $variables,
-					'has_override' => $has_override,
-					'override'     => $has_override ? $overrides[ $task_type ][ $prompt_key ] : null,
+				$prompts[] = self::format_prompt_response(
+					$task_type,
+					$prompt_key,
+					array_merge( $definition, array( 'variables' => $variables ) ),
+					$has_override ? $overrides[ $task_type ][ $prompt_key ] : null
 				);
 			}
 		}
@@ -334,7 +335,7 @@ class System {
 	 * Get a specific prompt's definition and current value.
 	 *
 	 * @param WP_REST_Request $request Request with task_type and prompt_key.
-	 * @return \WP_REST_Response|WP_Error
+	 * @return \WP_REST_Response|WP_Error|array
 	 * @since 0.41.0
 	 */
 	public static function get_prompt( WP_REST_Request $request ) {
@@ -343,7 +344,7 @@ class System {
 
 		$definition = self::resolve_prompt_definition( $task_type, $prompt_key );
 
-		if ( is_wp_error( $definition ) ) {
+		if ( $definition instanceof WP_Error ) {
 			return $definition;
 		}
 
@@ -353,25 +354,49 @@ class System {
 
 		return rest_ensure_response( array(
 			'success' => true,
-			'data'    => array(
-				'task_type'    => $task_type,
-				'prompt_key'   => $prompt_key,
-				'label'        => $definition['label'],
-				'description'  => $definition['description'],
-				'default'      => $definition['default'],
-				'variables'    => $definition['variables'],
-				'has_override' => $has_override,
-				'override'     => $has_override ? $overrides[ $task_type ][ $prompt_key ] : null,
-				'effective'    => $has_override ? $overrides[ $task_type ][ $prompt_key ] : $definition['default'],
-			),
+			'data'    => self::format_prompt_response( $task_type, $prompt_key, $definition, $has_override ? $overrides[ $task_type ][ $prompt_key ] : null ),
 		) );
+	}
+
+	/**
+	 * Format a system task prompt response with versioned artifact metadata.
+	 *
+	 * @param string      $task_type   Task type identifier.
+	 * @param string      $prompt_key  Prompt key within the task.
+	 * @param array       $definition  Prompt definition.
+	 * @param string|null $override    Local override content.
+	 * @return array<string,mixed>
+	 */
+	private static function format_prompt_response( string $task_type, string $prompt_key, array $definition, ?string $override ): array {
+		$artifact = SystemTaskPromptRegistry::artifact_from_definition( $task_type, $prompt_key, $definition );
+		$resolved = SystemTaskPromptRegistry::resolve_effective_prompt( $task_type, $prompt_key, $artifact, $override );
+
+		return array(
+			'task_type'            => $task_type,
+			'prompt_key'           => $prompt_key,
+			'label'                => $definition['label'],
+			'description'          => $definition['description'],
+			'default'              => $definition['default'],
+			'variables'            => $definition['variables'],
+			'has_override'         => null !== $override && '' !== $override,
+			'override'             => $override,
+			'effective'            => $resolved['content'],
+			'effective_source'     => $resolved['source'],
+			'effective_hash'       => $resolved['content_hash'],
+			'artifact_id'          => $resolved['artifact_id'],
+			'artifact_type'        => $artifact ? $artifact->artifact_type() : 'prompt',
+			'artifact_version'     => $resolved['version'],
+			'artifact_source_path' => $artifact ? $artifact->source_path() : '',
+			'artifact_hash'        => $artifact ? $artifact->content_hash() : '',
+			'artifact_changelog'   => $artifact ? $artifact->version_metadata()['changelog'] : '',
+		);
 	}
 
 	/**
 	 * Set a prompt override for a specific task prompt.
 	 *
 	 * @param WP_REST_Request $request Request with task_type, prompt_key, and prompt.
-	 * @return \WP_REST_Response|WP_Error
+	 * @return \WP_REST_Response|WP_Error|array
 	 * @since 0.41.0
 	 */
 	public static function set_prompt( WP_REST_Request $request ) {
@@ -381,7 +406,7 @@ class System {
 
 		$definition = self::resolve_prompt_definition( $task_type, $prompt_key );
 
-		if ( is_wp_error( $definition ) ) {
+		if ( $definition instanceof WP_Error ) {
 			return $definition;
 		}
 
@@ -409,7 +434,7 @@ class System {
 	 * Reset a prompt override to default (remove the override).
 	 *
 	 * @param WP_REST_Request $request Request with task_type and prompt_key.
-	 * @return \WP_REST_Response|WP_Error
+	 * @return \WP_REST_Response|WP_Error|array
 	 * @since 0.41.0
 	 */
 	public static function reset_prompt( WP_REST_Request $request ) {
@@ -418,7 +443,7 @@ class System {
 
 		$definition = self::resolve_prompt_definition( $task_type, $prompt_key );
 
-		if ( is_wp_error( $definition ) ) {
+		if ( $definition instanceof WP_Error ) {
 			return $definition;
 		}
 
@@ -466,7 +491,16 @@ class System {
 			);
 		}
 
-		$task        = new $handler_class();
+		$task = new $handler_class();
+		if ( ! $task instanceof SystemTask ) {
+			return new WP_Error(
+				'invalid_task_class',
+			// translators: %s: fully-qualified task handler class name.
+				sprintf( __( 'Task handler class is not a SystemTask: %s', 'data-machine' ), $handler_class ),
+				array( 'status' => 500 )
+			);
+		}
+
 		$definitions = $task->getPromptDefinitions();
 
 		if ( ! isset( $definitions[ $prompt_key ] ) ) {

--- a/inc/Engine/AI/System/SystemTaskPromptRegistry.php
+++ b/inc/Engine/AI/System/SystemTaskPromptRegistry.php
@@ -86,10 +86,17 @@ final class SystemTaskPromptRegistry {
 		 */
 		$resolved = apply_filters( 'datamachine_system_task_effective_prompt', $resolved, $task_type, $prompt_key, $artifact, $override );
 
+		$final_content = isset( $resolved['content'] ) ? (string) $resolved['content'] : $content;
+		$initial_hash  = hash( 'sha256', $content );
+		$content_hash  = isset( $resolved['content_hash'] ) ? (string) $resolved['content_hash'] : hash( 'sha256', $final_content );
+		if ( $final_content !== $content && $content_hash === $initial_hash ) {
+			$content_hash = hash( 'sha256', $final_content );
+		}
+
 		return array(
-			'content'      => isset( $resolved['content'] ) ? (string) $resolved['content'] : $content,
+			'content'      => $final_content,
 			'artifact_id'  => isset( $resolved['artifact_id'] ) ? (string) $resolved['artifact_id'] : ( $artifact ? $artifact->artifact_id() : self::artifact_id( $task_type, $prompt_key ) ),
-			'content_hash' => isset( $resolved['content_hash'] ) ? (string) $resolved['content_hash'] : hash( 'sha256', isset( $resolved['content'] ) ? (string) $resolved['content'] : $content ),
+			'content_hash' => $content_hash,
 			'source'       => isset( $resolved['source'] ) ? (string) $resolved['source'] : $source,
 			'version'      => isset( $resolved['version'] ) ? (string) $resolved['version'] : ( $artifact ? $artifact->version() : '' ),
 			'artifact'     => $resolved['artifact'] ?? $artifact,

--- a/tests/prompt-auth-template-artifacts-smoke.php
+++ b/tests/prompt-auth-template-artifacts-smoke.php
@@ -68,6 +68,40 @@ if ( ! function_exists( 'trailingslashit' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request {
+		private array $params;
+
+		public function __construct( array $params = array() ) {
+			$this->params = $params;
+		}
+
+		public function get_param( string $key ) {
+			return $this->params[ $key ] ?? null;
+		}
+	}
+}
+
+if ( ! function_exists( 'rest_ensure_response' ) ) {
+	function rest_ensure_response( $response ) {
+		return $response;
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( ...$args ) {
+			unset( $args );
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+
 if ( ! function_exists( 'plugin_dir_url' ) ) {
 	function plugin_dir_url( $file ) {
 		return 'http://example.test/plugin/';
@@ -93,6 +127,7 @@ require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
 use DataMachine\Engine\AI\System\SystemTaskPromptRegistry;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
+use DataMachine\Api\System\System;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\AgentTemplateMetadata;
 use DataMachine\Engine\Bundle\AuthRef;
@@ -118,6 +153,11 @@ function prompt_artifact_assert( string $label, bool $condition ): void {
 
 function prompt_artifact_assert_equals( string $label, $expected, $actual ): void {
 	prompt_artifact_assert( $label, $expected === $actual );
+}
+
+function prompt_artifact_failure_count(): int {
+	global $failures;
+	return (int) $failures;
 }
 
 final class FixturePromptTask extends SystemTask {
@@ -146,13 +186,26 @@ final class FixturePromptTask extends SystemTask {
 
 final class FixtureAuthRefResolver implements AuthRefResolverInterface {
 
+	/**
+	 * @return array{resolved:bool,ref:string,provider:string,account:string,config?:array,warning?:string}
+	 */
 	public function resolve( AuthRef $ref, array $context = array() ): array {
+		unset( $context );
 		if ( 'github:automattic' !== $ref->ref() ) {
-			return AuthRefResolver::unresolved( $ref, 'Fixture resolver skipped ref.' );
+			return array(
+				'resolved' => false,
+				'ref'      => $ref->ref(),
+				'provider' => $ref->provider(),
+				'account'  => $ref->account(),
+				'warning'  => 'Fixture resolver skipped ref.',
+			);
 		}
 
 		return array(
 			'resolved' => true,
+			'ref'      => $ref->ref(),
+			'provider' => $ref->provider(),
+			'account'  => $ref->account(),
 			'config'   => array(
 				'account_id'   => 42,
 				'access_token' => 'should-not-export',
@@ -218,7 +271,8 @@ SystemTask::setPromptOverride( 'fixture_generation', 'generate', '' );
 
 add_filter(
 	'datamachine_system_task_effective_prompt',
-	static function ( array $resolved, string $task_type, string $prompt_key ): array {
+	static function ( array $resolved, string $task_type, string $prompt_key, ?PromptArtifact $artifact = null, ?string $override = null ): array {
+		unset( $artifact, $override );
 		if ( 'fixture_generation' === $task_type && 'generate' === $prompt_key ) {
 			$resolved['content'] = 'Filtered artifact prompt.';
 			$resolved['source']  = 'filter';
@@ -234,6 +288,30 @@ $definition_artifact = SystemTaskPromptRegistry::artifact_from_definition( 'fixt
 prompt_artifact_assert( 'definition produces a prompt artifact', $definition_artifact instanceof PromptArtifact );
 prompt_artifact_assert_equals( 'default artifact ID is stable', 'system-task:fixture_generation:generate', $definition_artifact->artifact_id() );
 prompt_artifact_assert_equals( 'definition version propagates to artifact', '2026.04.28', $definition_artifact->version() );
+
+add_filter(
+	'datamachine_tasks',
+	static function ( array $tasks ): array {
+		$tasks['fixture_generation'] = FixturePromptTask::class;
+		return $tasks;
+	},
+	10,
+	1
+);
+
+$prompt_list_response = System::get_prompts( new WP_REST_Request() );
+/** @var array{data: array<int,array<string,mixed>>} $prompt_list_response */
+$prompt_row           = $prompt_list_response['data'][0] ?? array();
+prompt_artifact_assert_equals( 'REST prompt list exposes artifact ID', 'system-task:fixture_generation:generate', $prompt_row['artifact_id'] ?? null );
+prompt_artifact_assert_equals( 'REST prompt list exposes artifact version', '2026.04.28', $prompt_row['artifact_version'] ?? null );
+prompt_artifact_assert_equals( 'REST prompt list exposes filtered effective source', 'filter', $prompt_row['effective_source'] ?? null );
+prompt_artifact_assert_equals( 'REST prompt list hash matches effective content', hash( 'sha256', 'Filtered artifact prompt.' ), $prompt_row['effective_hash'] ?? null );
+
+$prompt_detail_response = System::get_prompt( new WP_REST_Request( array( 'task_type' => 'fixture_generation', 'prompt_key' => 'generate' ) ) );
+/** @var array{data: array<string,mixed>} $prompt_detail_response */
+$prompt_detail          = $prompt_detail_response['data'];
+prompt_artifact_assert_equals( 'REST prompt detail exposes artifact source path', 'system-tasks/fixture_generation/generate.md', $prompt_detail['artifact_source_path'] ?? null );
+prompt_artifact_assert_equals( 'REST prompt detail exposes default artifact hash', hash( 'sha256', 'Write about {{topic}}.' ), $prompt_detail['artifact_hash'] ?? null );
 
 echo "\n[3] Agent template source/version metadata round-trips\n";
 $manifest       = AgentBundleManifest::from_array(
@@ -297,7 +375,8 @@ prompt_artifact_assert( 'malformed auth refs fail clearly', $threw );
 
 add_filter(
 	'datamachine_auth_ref_resolvers',
-	static function ( array $resolvers ): array {
+	static function ( array $resolvers, array $context = array() ): array {
+		unset( $context );
 		$resolvers[] = new FixtureAuthRefResolver();
 		return $resolvers;
 	},
@@ -317,6 +396,6 @@ echo "\n=== Results ===\n";
 echo "Passed: {$passes}\n";
 echo "Failed: {$failures}\n";
 
-if ( $failures > 0 ) {
+if ( prompt_artifact_failure_count() > 0 || getenv( 'DATAMACHINE_FORCE_PROMPT_ARTIFACT_FAILURE' ) ) {
 	exit( 1 );
 }


### PR DESCRIPTION
## Summary
- Exposes system task prompt artifact metadata through the existing system prompt REST responses so prompt/rubric behavior can be reviewed and upgraded as versioned bundle substrate.
- Keeps effective prompt hashes aligned with the final resolved content, including filtered prompt stores.

## Changes
- Adds artifact ID, type, version, source path, default hash, changelog, effective source, and effective hash to system prompt list/detail responses.
- Reuses `SystemTaskPromptRegistry` for REST formatting so API consumers see the same effective prompt envelope used at runtime.
- Recomputes the effective prompt hash when a filter changes content without supplying a replacement hash.
- Extends the prompt/auth/template artifact smoke to cover REST-visible artifact metadata.

## Tests
- `php tests/prompt-auth-template-artifacts-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@expose-system-prompt-artifacts --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@expose-system-prompt-artifacts --changed-since origin/main`

## Refs
- Refs #1535
- Refs #1536
- Refs #1540
- Refs #1137

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the prompt artifact REST metadata slice, updating smoke coverage, and running verification; Chris remains responsible for review and merge.
