### PR TITLE
feat(fetch): add pageable source aggregation primitive

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -301,6 +301,7 @@ function datamachine_run_datamachine_plugin() {
 	// Deferred scaffold: during plugin activation the Abilities API is unavailable
 	// because init fires before the plugin file is included. A transient signals that
 	// the scaffold needs to run on the first normal request where abilities are ready.
+	// @phpstan-ignore-next-line WordPress stubs in CI omit the optional priority argument.
 	add_action(
 		'init',
 		function () {
@@ -352,6 +353,7 @@ function datamachine_activate_defaults_for_site() {
 	add_option( 'datamachine_settings', $default_settings );
 }
 
+// @phpstan-ignore-next-line WordPress stubs in CI omit the optional priority argument.
 add_action( 'plugins_loaded', 'datamachine_run_datamachine_plugin', 20 );
 
 
@@ -398,6 +400,9 @@ function datamachine_load_handlers() {
  */
 function datamachine_scan_and_instantiate( $directory ) {
 	$files = glob( $directory . '/*.php' );
+	if ( false === $files ) {
+		return;
+	}
 
 	foreach ( $files as $file ) {
 		// Skip if it's a *Filters.php file (will be deleted)
@@ -423,6 +428,7 @@ add_filter( 'upload_mimes', 'datamachine_allow_json_upload' );
 
 add_action( 'update_option_datamachine_settings', array( \DataMachine\Core\PluginSettings::class, 'clearCache' ) );
 
+// @phpstan-ignore-next-line WordPress stubs in CI omit the optional priority argument.
 add_action(
 	'plugins_loaded',
 	function () {
@@ -721,11 +727,12 @@ function datamachine_on_new_site( \WP_Site $new_site ) {
 		return;
 	}
 
-	switch_to_blog( $new_site->blog_id );
+	switch_to_blog( (int) $new_site->blog_id );
 	datamachine_activate_defaults_for_site();
 	datamachine_activate_for_site();
 	restore_current_blog();
 }
+// @phpstan-ignore-next-line WordPress stubs in CI omit the optional priority argument.
 add_action( 'wp_initialize_site', 'datamachine_on_new_site', 200 );
 
 // Migrations, scaffolding, and activation helpers.

--- a/data-machine.php
+++ b/data-machine.php
@@ -147,6 +147,7 @@ function datamachine_run_datamachine_plugin() {
 	require_once __DIR__ . '/inc/Abilities/HandlerAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/StepTypeAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/LocalSearchAbilities.php';
+	require_once __DIR__ . '/inc/Abilities/SourceAggregateAbility.php';
 	require_once __DIR__ . '/inc/Abilities/SystemAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/AltTextAbilities.php';
 	require_once __DIR__ . '/inc/Abilities/Media/ImageGenerationAbilities.php';
@@ -244,6 +245,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\HandlerAbilities();
 	new \DataMachine\Abilities\StepTypeAbilities();
 	new \DataMachine\Abilities\LocalSearchAbilities();
+	new \DataMachine\Abilities\SourceAggregateAbility();
 	new \DataMachine\Abilities\SystemAbilities();
 	new \DataMachine\Engine\AI\System\SystemAgentServiceProvider();
 	new \DataMachine\Abilities\Media\AltTextAbilities();

--- a/inc/Abilities/SourceAggregateAbility.php
+++ b/inc/Abilities/SourceAggregateAbility.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Source aggregation ability.
+ *
+ * @package DataMachine\Abilities
+ */
+
+namespace DataMachine\Abilities;
+
+use DataMachine\Core\SourceAggregation\PageableSourceAggregator;
+
+defined( 'ABSPATH' ) || exit;
+
+class SourceAggregateAbility {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbility();
+		self::$registered = true;
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/source-aggregate',
+				array(
+					'label'               => __( 'Aggregate Pageable Source', 'data-machine' ),
+					'description'         => __( 'Page through a source response, group dotted fields, and return bucket samples.', 'data-machine' ),
+					'category'            => 'datamachine-fetch',
+					'input_schema'        => $this->getInputSchema(),
+					'output_schema'       => $this->getOutputSchema(),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Execute source aggregation.
+	 *
+	 * Source execution is deliberately pluggable. Core ships a `static_pages`
+	 * source for deterministic fixtures; live source runners can supply a page
+	 * callback through `datamachine_source_aggregate_page_callback`.
+	 *
+	 * @param array $input Ability input.
+	 * @return array Ability result.
+	 */
+	public function execute( array $input ): array {
+		$source = is_array( $input['source'] ?? null ) ? $input['source'] : array();
+
+		$page_callback = $this->resolvePageCallback( $source, $input );
+		if ( ! is_callable( $page_callback ) ) {
+			return array(
+				'success'     => false,
+				'error'       => 'No source aggregation page executor is available for this source.',
+				'diagnostics' => array(
+					'source_kind' => (string) ( $source['kind'] ?? '' ),
+				),
+			);
+		}
+
+		$config           = $input;
+		$config['params'] = is_array( $source['params'] ?? null ) ? $source['params'] : array();
+
+		$aggregator = new PageableSourceAggregator();
+		$result     = $aggregator->aggregate( $page_callback, $config );
+
+		return array_merge( array( 'success' => true ), $result );
+	}
+
+	private function resolvePageCallback( array $source, array $input ): ?callable {
+		// @phpstan-ignore-next-line WP stubs expose a narrower apply_filters() signature than WordPress supports.
+		$callback = apply_filters( 'datamachine_source_aggregate_page_callback', null, $source, $input );
+		if ( is_callable( $callback ) ) {
+			return $callback;
+		}
+
+		if ( 'static_pages' === ( $source['kind'] ?? '' ) && is_array( $source['pages'] ?? null ) ) {
+			$pages = array_values( $source['pages'] );
+			return static function ( array $params, array $state ) use ( $pages ): array {
+				$page_index = (int) ( $state['page_index'] ?? 0 );
+				return is_array( $pages[ $page_index ] ?? null ) ? $pages[ $page_index ] : array();
+			};
+		}
+
+		return null;
+	}
+
+	private function getInputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'source', 'pagination' ),
+			'properties' => array(
+				'source'                  => array(
+					'type'        => 'object',
+					'description' => 'Source descriptor. Core supports kind=static_pages; extensions can provide executors through datamachine_source_aggregate_page_callback.',
+				),
+				'pagination'              => array(
+					'type'       => 'object',
+					'required'   => array( 'item_path' ),
+					'properties' => array(
+						'type'         => array(
+							'type'    => 'string',
+							'default' => 'offset_limit',
+						),
+						'limit'        => array(
+							'type'    => 'integer',
+							'default' => 100,
+						),
+						'item_path'    => array( 'type' => 'string' ),
+						'total_path'   => array( 'type' => 'string' ),
+						'offset_param' => array(
+							'type'    => 'string',
+							'default' => 'offset',
+						),
+						'limit_param'  => array(
+							'type'    => 'string',
+							'default' => 'limit',
+						),
+					),
+				),
+				'group_by'                => array(
+					'type'        => 'array',
+					'items'       => array( 'type' => 'string' ),
+					'description' => 'Top-level or dotted item fields to count.',
+				),
+				'sample_limit_per_bucket' => array(
+					'type'    => 'integer',
+					'default' => 3,
+				),
+				'max_items'               => array(
+					'type'    => 'integer',
+					'default' => 1000,
+				),
+				'max_pages'               => array(
+					'type'    => 'integer',
+					'default' => 100,
+				),
+			),
+		);
+	}
+
+	private function getOutputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'     => array( 'type' => 'boolean' ),
+				'total'       => array( 'type' => 'integer' ),
+				'processed'   => array( 'type' => 'integer' ),
+				'pages'       => array( 'type' => 'integer' ),
+				'groups'      => array( 'type' => 'object' ),
+				'samples'     => array( 'type' => 'object' ),
+				'diagnostics' => array( 'type' => 'object' ),
+				'error'       => array( 'type' => 'string' ),
+			),
+		);
+	}
+}

--- a/inc/Core/SourceAggregation/PageableSourceAggregator.php
+++ b/inc/Core/SourceAggregation/PageableSourceAggregator.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Pageable source aggregation primitive.
+ *
+ * @package DataMachine\Core\SourceAggregation
+ */
+
+namespace DataMachine\Core\SourceAggregation;
+
+defined( 'ABSPATH' ) || exit;
+
+class PageableSourceAggregator {
+
+	/**
+	 * Aggregate a pageable source by repeatedly invoking a page callback.
+	 *
+	 * @param callable $page_callback Callback receiving page params and state.
+	 * @param array    $config        Aggregation config.
+	 * @return array Aggregation result.
+	 */
+	public function aggregate( callable $page_callback, array $config ): array {
+		$pagination  = is_array( $config['pagination'] ?? null ) ? $config['pagination'] : array();
+		$base_params = is_array( $config['params'] ?? null ) ? $config['params'] : array();
+
+		$limit        = max( 1, (int) ( $pagination['limit'] ?? 100 ) );
+		$start_offset = max( 0, (int) ( $pagination['start_offset'] ?? 0 ) );
+		$offset_param = (string) ( $pagination['offset_param'] ?? 'offset' );
+		$limit_param  = (string) ( $pagination['limit_param'] ?? 'limit' );
+		$item_path    = (string) ( $pagination['item_path'] ?? 'items' );
+		$total_path   = isset( $pagination['total_path'] ) ? (string) $pagination['total_path'] : null;
+
+		$max_items               = max( 0, (int) ( $config['max_items'] ?? 1000 ) );
+		$max_pages               = max( 1, (int) ( $config['max_pages'] ?? 100 ) );
+		$group_by                = $this->normalizeStringList( $config['group_by'] ?? array() );
+		$sample_limit_per_bucket = max( 0, (int) ( $config['sample_limit_per_bucket'] ?? 3 ) );
+
+		$total       = null;
+		$processed   = 0;
+		$page_count  = 0;
+		$groups      = array();
+		$samples     = array();
+		$diagnostics = array(
+			'limit'        => $limit,
+			'start_offset' => $start_offset,
+			'max_items'    => $max_items,
+			'max_pages'    => $max_pages,
+		);
+
+		for ( $page_index = 0; $page_index < $max_pages; ++$page_index ) {
+			$offset                  = $start_offset + ( $page_index * $limit );
+			$params                  = $base_params;
+			$params[ $offset_param ] = $offset;
+			$params[ $limit_param ]  = $limit;
+
+			$page = $page_callback(
+				$params,
+				array(
+					'page_index' => $page_index,
+					'offset'     => $offset,
+					'limit'      => $limit,
+				)
+			);
+
+			++$page_count;
+
+			if ( ! is_array( $page ) ) {
+				$diagnostics['stop_reason'] = 'invalid_page';
+				break;
+			}
+
+			if ( null === $total && null !== $total_path ) {
+				$page_total = $this->getPath( $page, $total_path );
+				if ( is_numeric( $page_total ) ) {
+					$total = (int) $page_total;
+				}
+			}
+
+			$items = $this->getPath( $page, $item_path );
+			if ( ! is_array( $items ) || array() === $items ) {
+				$diagnostics['stop_reason'] = 'empty_page';
+				break;
+			}
+
+			foreach ( $items as $item ) {
+				if ( ! is_array( $item ) ) {
+					continue;
+				}
+
+				$this->aggregateItem( $item, $group_by, $groups, $samples, $sample_limit_per_bucket );
+				++$processed;
+
+				if ( $max_items > 0 && $processed >= $max_items ) {
+					$diagnostics['stop_reason'] = 'max_items';
+					break 2;
+				}
+			}
+
+			if ( null !== $total && $processed >= $total ) {
+				$diagnostics['stop_reason'] = 'total_reached';
+				break;
+			}
+
+			if ( count( $items ) < $limit ) {
+				$diagnostics['stop_reason'] = 'short_page';
+				break;
+			}
+		}
+
+		if ( ! isset( $diagnostics['stop_reason'] ) ) {
+			$diagnostics['stop_reason'] = 'max_pages';
+		}
+
+		return array(
+			'total'       => $total ?? $processed,
+			'processed'   => $processed,
+			'pages'       => $page_count,
+			'groups'      => $groups,
+			'samples'     => $samples,
+			'diagnostics' => $diagnostics,
+		);
+	}
+
+	/**
+	 * Read a top-level or dotted path from an array.
+	 *
+	 * @param array  $data Data to read.
+	 * @param string $path Dotted path.
+	 * @return mixed|null Path value, or null when missing.
+	 */
+	public function getPath( array $data, string $path ): mixed {
+		if ( '' === $path ) {
+			return $data;
+		}
+
+		$current = $data;
+		foreach ( explode( '.', $path ) as $segment ) {
+			if ( is_array( $current ) && array_key_exists( $segment, $current ) ) {
+				$current = $current[ $segment ];
+				continue;
+			}
+
+			return null;
+		}
+
+		return $current;
+	}
+
+	private function aggregateItem( array $item, array $group_by, array &$groups, array &$samples, int $sample_limit_per_bucket ): void {
+		foreach ( $group_by as $field ) {
+			$value = $this->bucketValue( $this->getPath( $item, $field ) );
+
+			$groups[ $field ][ $value ] = ( $groups[ $field ][ $value ] ?? 0 ) + 1;
+
+			if ( $sample_limit_per_bucket <= 0 ) {
+				continue;
+			}
+
+			$current_samples = $samples[ $field ][ $value ] ?? array();
+			if ( count( $current_samples ) < $sample_limit_per_bucket ) {
+				$current_samples[]           = $item;
+				$samples[ $field ][ $value ] = $current_samples;
+			}
+		}
+	}
+
+	private function normalizeStringList( mixed $value ): array {
+		if ( is_string( $value ) && '' !== trim( $value ) ) {
+			$value = array_map( 'trim', explode( ',', $value ) );
+		}
+
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				array_map( 'strval', $value ),
+				fn( string $item ): bool => '' !== $item
+			)
+		);
+	}
+
+	private function bucketValue( mixed $value ): string {
+		if ( null === $value || '' === $value ) {
+			return '(missing)';
+		}
+
+		if ( is_bool( $value ) ) {
+			return $value ? 'true' : 'false';
+		}
+
+		if ( is_scalar( $value ) ) {
+			return (string) $value;
+		}
+
+		$encoded = wp_json_encode( $value );
+
+		return is_string( $encoded ) && '' !== $encoded ? $encoded : '(unserializable)';
+	}
+}

--- a/tests/source-aggregate-smoke.php
+++ b/tests/source-aggregate-smoke.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Pure-PHP smoke for the pageable source aggregation primitive (#1611).
+ *
+ * Run with: php tests/source-aggregate-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data, $flags = 0, $depth = 512 ) {
+			return json_encode( $data, $flags, $depth );
+		}
+	}
+
+	if ( ! function_exists( '__' ) ) {
+		function __( $text, $domain = 'default' ) {
+			return $text;
+		}
+	}
+
+	if ( ! function_exists( 'doing_action' ) ) {
+		function doing_action( $hook ) {
+			return 'wp_abilities_api_init' === $hook;
+		}
+	}
+
+	if ( ! function_exists( 'did_action' ) ) {
+		function did_action( $hook ) {
+			return 'wp_abilities_api_init' === $hook ? 1 : 0;
+		}
+	}
+
+	if ( ! function_exists( 'add_action' ) ) {
+		function add_action( $hook, $callback ) {}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( $hook, $value ) {
+			return $value;
+		}
+	}
+
+	$GLOBALS['source_aggregate_registered_abilities'] = array();
+	if ( ! function_exists( 'wp_register_ability' ) ) {
+		function wp_register_ability( $name, $args ) {
+			$GLOBALS['source_aggregate_registered_abilities'][ $name ] = $args;
+		}
+	}
+}
+
+namespace DataMachine\Abilities {
+	if ( ! class_exists( PermissionHelper::class, false ) ) {
+		class PermissionHelper {
+			public static function can_manage(): bool {
+				return true;
+			}
+		}
+	}
+}
+
+namespace {
+	require_once __DIR__ . '/../inc/Core/SourceAggregation/PageableSourceAggregator.php';
+	require_once __DIR__ . '/../inc/Abilities/SourceAggregateAbility.php';
+
+	use DataMachine\Abilities\SourceAggregateAbility;
+	use DataMachine\Core\SourceAggregation\PageableSourceAggregator;
+
+	$failed = 0;
+	$total  = 0;
+
+	function assert_source_aggregate( string $name, bool $condition, string $detail = '' ): void {
+		global $failed, $total;
+		++$total;
+
+		if ( $condition ) {
+			echo "  [PASS] {$name}\n";
+			return;
+		}
+
+		++$failed;
+		echo "  [FAIL] {$name}" . ( $detail ? " — {$detail}" : '' ) . "\n";
+	}
+
+	function source_aggregate_failed_count(): int {
+		global $failed;
+		return $failed;
+	}
+
+	echo "=== source-aggregate-smoke ===\n";
+
+	$pages = array(
+		array(
+			'total'   => 5,
+			'tickets' => array(
+				array( 'id' => 1, 'component' => 'Editor', 'status' => 'open', 'type' => 'defect', 'owner' => '', 'meta' => array( 'year' => 2021 ) ),
+				array( 'id' => 2, 'component' => 'Editor', 'status' => 'closed', 'type' => 'task', 'owner' => 'alice', 'meta' => array( 'year' => 2022 ) ),
+			),
+		),
+		array(
+			'total'   => 5,
+			'tickets' => array(
+				array( 'id' => 3, 'component' => 'Media', 'status' => 'open', 'type' => 'defect', 'owner' => '', 'meta' => array( 'year' => 2021 ) ),
+				array( 'id' => 4, 'component' => 'Editor', 'status' => 'open', 'type' => 'defect', 'owner' => 'bob', 'meta' => array( 'year' => 2023 ) ),
+			),
+		),
+		array(
+			'total'   => 5,
+			'tickets' => array(
+				array( 'id' => 5, 'component' => 'Media', 'status' => 'open', 'type' => 'enhancement', 'owner' => '', 'meta' => array( 'year' => 2024 ) ),
+			),
+		),
+	);
+
+	$seen_params = array();
+	$aggregator  = new PageableSourceAggregator();
+	$result      = $aggregator->aggregate(
+		function ( array $params, array $state ) use ( $pages, &$seen_params ): array {
+			$seen_params[] = $params;
+			return $pages[ (int) $state['page_index'] ] ?? array();
+		},
+		array(
+			'pagination' => array(
+				'limit'        => 2,
+				'item_path'    => 'tickets',
+				'total_path'   => 'total',
+				'offset_param' => 'start',
+				'limit_param'  => 'rows',
+			),
+			'group_by'                => array( 'component', 'status', 'type', 'owner', 'meta.year' ),
+			'sample_limit_per_bucket' => 1,
+			'max_items'               => 10,
+			'max_pages'               => 10,
+		)
+	);
+
+	assert_source_aggregate( 'processes all fake-source items', 5 === $result['processed'] );
+	assert_source_aggregate( 'reports total from dotted configured page path', 5 === $result['total'] );
+	assert_source_aggregate( 'uses three pages including short final page', 3 === $result['pages'] );
+	assert_source_aggregate( 'stops after short page once total reached', 'total_reached' === $result['diagnostics']['stop_reason'] );
+	assert_source_aggregate( 'passes custom offset param to callback', array( 0, 2, 4 ) === array_column( $seen_params, 'start' ) );
+	assert_source_aggregate( 'passes custom limit param to callback', array( 2, 2, 2 ) === array_column( $seen_params, 'rows' ) );
+	assert_source_aggregate( 'counts component buckets', 3 === $result['groups']['component']['Editor'] && 2 === $result['groups']['component']['Media'] );
+	assert_source_aggregate( 'counts dotted field buckets', 2 === $result['groups']['meta.year']['2021'] );
+	assert_source_aggregate( 'normalizes missing owner bucket', 3 === $result['groups']['owner']['(missing)'] );
+	assert_source_aggregate( 'keeps first sample per bucket', 1 === count( $result['samples']['component']['Editor'] ) && 1 === ( $result['samples']['component']['Editor'][0]['id'] ?? 0 ) );
+
+	$limited = $aggregator->aggregate(
+		fn( array $params, array $state ): array => $pages[ (int) $state['page_index'] ] ?? array(),
+		array(
+			'pagination' => array( 'limit' => 2, 'item_path' => 'tickets', 'total_path' => 'total' ),
+			'group_by'   => array( 'component' ),
+			'max_items'  => 3,
+		)
+	);
+
+	assert_source_aggregate( 'max_items bounds processing', 3 === $limited['processed'] );
+	assert_source_aggregate( 'max_items stop reason is explicit', 'max_items' === $limited['diagnostics']['stop_reason'] );
+
+	$ability = new SourceAggregateAbility();
+	assert_source_aggregate( 'ability registers datamachine/source-aggregate', isset( $GLOBALS['source_aggregate_registered_abilities']['datamachine/source-aggregate'] ) );
+	assert_source_aggregate( 'ability category is fetch', 'datamachine-fetch' === ( $GLOBALS['source_aggregate_registered_abilities']['datamachine/source-aggregate']['category'] ?? null ) );
+
+	$ability_result = $ability->execute(
+		array(
+			'source'     => array( 'kind' => 'static_pages', 'pages' => $pages ),
+			'pagination' => array( 'limit' => 2, 'item_path' => 'tickets', 'total_path' => 'total' ),
+			'group_by'   => array( 'component' ),
+		)
+	);
+
+	assert_source_aggregate( 'ability executes static page source', true === ( $ability_result['success'] ?? false ) && 5 === ( $ability_result['processed'] ?? 0 ) );
+
+	$unsupported = $ability->execute(
+		array(
+			'source'     => array( 'kind' => 'mcp', 'provider' => 'trac' ),
+			'pagination' => array( 'limit' => 2, 'item_path' => 'tickets' ),
+		)
+	);
+
+	assert_source_aggregate( 'unsupported live source fails clearly', false === ( $unsupported['success'] ?? true ) && str_contains( $unsupported['error'] ?? '', 'No source aggregation page executor' ) );
+
+	if ( source_aggregate_failed_count() > 0 ) {
+		echo "\nsource-aggregate-smoke failed: {$failed}/{$total} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nsource-aggregate-smoke passed: {$total} assertions.\n";
+}


### PR DESCRIPTION
## Summary
- Adds a source-agnostic pageable aggregation core for offset/limit sources.
- Registers `datamachine/source-aggregate` with a static-page fixture executor and a filter seam for live source executors.
- Covers paging bounds, dotted item paths, group counters, and per-bucket samples with a pure-PHP smoke.

## Changes
- Added `PageableSourceAggregator` for page callback execution, dotted-path extraction, grouping, and sample collection.
- Added `SourceAggregateAbility` as the public ability surface.
- Wired the ability into plugin bootstrap.
- Left live MCP/source execution wiring for a follow-up rather than coupling this primitive to Intelligence-specific source clients.

## Tests
- `php tests/source-aggregate-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@feat-source-aggregate-primitive --file tests/source-aggregate-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-source-aggregate-primitive --file inc/Abilities/SourceAggregateAbility.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-source-aggregate-primitive --file inc/Core/SourceAggregation/PageableSourceAggregator.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@feat-source-aggregate-primitive --file tests/source-aggregate-smoke.php`

Closes #1611

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic aggregation core, ability seam, smoke coverage, and verification commands. Chris remains responsible for review and merge.