### PR TITLE
refactor(agent): pass directive context through adapter

### DIFF
--- a/inc/Engine/AI/PromptBuilder.php
+++ b/inc/Engine/AI/PromptBuilder.php
@@ -130,13 +130,9 @@ class PromptBuilder {
 		$applied_directives    = array();
 		$directive_metadata    = array();
 		$directive_breakdown   = array();
-		$validation_context    = array_filter(
-			array(
-				'job_id'       => $payload['job_id'] ?? null,
-				'flow_step_id' => $payload['flow_step_id'] ?? null,
-			),
-			fn( $v ) => null !== $v
-		);
+		$validation_context    = is_array( $payload['directive_context'] ?? null )
+			? $payload['directive_context']
+			: array();
 
 		foreach ( $this->directives as $directiveConfig ) {
 			$directive = $directiveConfig['directive'];

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -170,6 +170,7 @@ class RequestBuilder {
 		array $payload = array()
 	): array {
 		$structured_tools = self::restructure_tools( $tools );
+		$payload          = self::withDirectiveContext( $payload );
 
 		$promptBuilder = new PromptBuilder();
 		$promptBuilder->setMessages( $messages )->setTools( $structured_tools );
@@ -234,5 +235,36 @@ class RequestBuilder {
 		}
 
 		return $structured;
+	}
+
+	/**
+	 * Carry Data Machine validation identifiers through an explicit directive context.
+	 *
+	 * PromptBuilder is the generic prompt/directive assembly surface; it should not
+	 * know about jobs or flow steps directly. RequestBuilder is still the Data
+	 * Machine adapter layer, so it maps the existing payload shape into the neutral
+	 * context consumed by directive validation/logging.
+	 *
+	 * @param array $payload Step or chat payload.
+	 * @return array Payload with directive_context populated when available.
+	 */
+	private static function withDirectiveContext( array $payload ): array {
+		if ( isset( $payload['directive_context'] ) && is_array( $payload['directive_context'] ) ) {
+			return $payload;
+		}
+
+		$context = array_filter(
+			array(
+				'job_id'       => $payload['job_id'] ?? null,
+				'flow_step_id' => $payload['flow_step_id'] ?? null,
+			),
+			fn( $value ) => null !== $value
+		);
+
+		if ( ! empty( $context ) ) {
+			$payload['directive_context'] = $context;
+		}
+
+		return $payload;
 	}
 }

--- a/tests/ai-request-inspector-smoke.php
+++ b/tests/ai-request-inspector-smoke.php
@@ -51,10 +51,12 @@ require_once __DIR__ . '/../inc/Engine/AI/RequestBuilder.php';
 
 class Test_Request_Inspector_Directive implements \DataMachine\Engine\AI\Directives\DirectiveInterface {
 	public static function get_outputs( string $_provider_name, array $_tools, ?string $_step_id = null, array $payload = array() ): array {
+		$directive_context = is_array( $payload['directive_context'] ?? null ) ? $payload['directive_context'] : array();
+
 		return array(
 			array(
 				'type'    => 'system_text',
-				'content' => 'Inspect directive for job ' . ( $payload['job_id'] ?? 'none' ),
+				'content' => 'Inspect directive for job ' . ( $directive_context['job_id'] ?? 'none' ),
 			),
 		);
 	}
@@ -170,6 +172,15 @@ $ability = (string) file_get_contents( __DIR__ . '/../inc/Abilities/AI/InspectRe
 assert_test( 'inspect request ability loaded by plugin bootstrap', false !== strpos( $plugin, 'InspectRequestAbility.php' ) );
 assert_test( 'inspect request ability instantiated by plugin bootstrap', false !== strpos( $plugin, 'new \\DataMachine\\Abilities\\AI\\InspectRequestAbility()' ) );
 assert_test( 'ability registers datamachine/inspect-ai-request', false !== strpos( $ability, 'datamachine/inspect-ai-request' ) );
+
+echo "\nCase 4: prompt validation context is adapter-provided\n";
+
+$prompt_builder_source  = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/PromptBuilder.php' );
+$request_builder_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/RequestBuilder.php' );
+
+assert_test( 'PromptBuilder no longer reads job_id directly', false === strpos( $prompt_builder_source, "\$payload['job_id']" ) );
+assert_test( 'PromptBuilder no longer reads flow_step_id directly', false === strpos( $prompt_builder_source, "\$payload['flow_step_id']" ) );
+assert_test( 'RequestBuilder maps legacy identifiers into directive_context', false !== strpos( $request_builder_source, "'directive_context'" ) );
 
 echo "\n$total assertions, $failed failures\n";
 $failed_count = (int) ( $GLOBALS['failed'] ?? $failed );


### PR DESCRIPTION
## Summary
- Move directive validation/log context behind an explicit `directive_context` payload entry so `PromptBuilder` no longer reads Data Machine `job_id` / `flow_step_id` fields directly.
- Populate `directive_context` in `RequestBuilder`, preserving the existing payload behavior for pipeline/chat callers while keeping the prompt builder extraction-ready.
- Extend the request inspector smoke to prove directives consume the adapter-provided context and that `PromptBuilder` stays free of direct job/flow payload reads.

Closes #1615.

## Tests
- `php tests/ai-request-inspector-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`
- `php tests/ai-loop-event-sink-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-agents-runtime-couplings --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-agents-runtime-couplings --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited the runtime prompt/conversation coupling surface, implemented the directive-context adapter seam, updated focused smoke coverage, and ran local validation. Chris remains responsible for review and merge.