### PR TITLE
fix(agent): move package lifecycle CLI under agent

### DIFF
--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -103,10 +103,10 @@ Portable flow-step policy fields are explicit in `flows/<flow-slug>.json`:
 
 ## CLI
 
-Bundle operations live under `wp datamachine agent-bundle`:
+Agent package operations live under `wp datamachine agent`:
 
 - `install <path>` imports a local bundle path (`.zip`, `.json`, or directory).
-- `list` reports installed bundle-backed agents.
+- `installed` reports installed package-backed agents without clobbering `agent list`.
 - `status <slug>` reports installed version and tracked artifact state by agent slug or bundle slug.
 - `diff <path>` builds a read-only upgrade plan.
 - `upgrade <path>` applies clean updates and stages locally modified artifacts as PendingActions.

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -27,7 +27,6 @@ WP_CLI::add_command( 'datamachine posts', Commands\PostsCommand::class );
 WP_CLI::add_command( 'datamachine logs', Commands\LogsCommand::class );
 WP_CLI::add_command( 'datamachine agent', Commands\AgentsCommand::class );
 WP_CLI::add_command( 'datamachine agents', Commands\AgentsCommand::class );
-WP_CLI::add_command( 'datamachine agent-bundle', Commands\AgentBundleCommand::class );
 
 // Canonical home for agent memory-file operations.
 WP_CLI::add_command( 'datamachine memory', Commands\MemoryCommand::class );

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Agent bundle WP-CLI command.
+ * Agent package lifecycle helpers for WP-CLI.
  *
  * @package DataMachine\Cli\Commands
  */
@@ -22,17 +22,21 @@ use WP_CLI;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Install, inspect, and upgrade portable agent bundles.
+ * Install, inspect, and upgrade portable agent packages.
+ *
+ * This class is intentionally not registered as a top-level command. Its
+ * public lifecycle methods are inherited by AgentsCommand so operators use
+ * `wp datamachine agent ...` as the canonical surface.
  */
 class AgentBundleCommand extends BaseCommand {
 
 	/**
-	 * Install a bundle from a local file or directory.
+	 * Install an agent package from a local file or directory.
 	 *
 	 * ## OPTIONS
 	 *
 	 * <path>
-	 * : Bundle path (.zip, .json, or directory).
+	 * : Package path (.zip, .json, or directory).
 	 *
 	 * [--slug=<slug>]
 	 * : Override target agent slug.
@@ -60,7 +64,7 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	/**
-	 * List installed agent bundles.
+	 * List installed package-backed agents.
 	 *
 	 * ## OPTIONS
 	 *
@@ -74,9 +78,9 @@ class AgentBundleCommand extends BaseCommand {
 	 *   - csv
 	 *   - count
 	 * ---
-	 * @subcommand list
+	 * @subcommand installed
 	 */
-	public function list_( array $args, array $assoc_args ): void {
+	public function installed( array $args, array $assoc_args ): void {
 		unset( $args );
 
 		$items = array();
@@ -104,12 +108,12 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	/**
-	 * Show installed bundle status for an agent or bundle slug.
+	 * Show installed package status for an agent or package slug.
 	 *
 	 * ## OPTIONS
 	 *
 	 * <slug>
-	 * : Agent slug or bundle slug.
+	 * : Agent slug or package slug.
 	 *
 	 * [--format=<format>]
 	 * : Output format.
@@ -132,12 +136,12 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	/**
-	 * Show an upgrade diff for a bundle path.
+	 * Show an upgrade diff for a package path.
 	 *
 	 * ## OPTIONS
 	 *
 	 * <path>
-	 * : Bundle path (.zip, .json, or directory).
+	 * : Package path (.zip, .json, or directory).
 	 *
 	 * [--slug=<slug>]
 	 * : Override target agent slug.
@@ -158,7 +162,7 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	/**
-	 * Upgrade an installed bundle.
+	 * Upgrade an installed agent package.
 	 *
 	 * Clean artifacts are applied through the importer. Approval-required changes
 	 * are staged as PendingActions.
@@ -166,7 +170,7 @@ class AgentBundleCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * <path>
-	 * : Bundle path (.zip, .json, or directory).
+	 * : Package path (.zip, .json, or directory).
 	 *
 	 * [--slug=<slug>]
 	 * : Override target agent slug.
@@ -237,7 +241,7 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	/**
-	 * Resolve a staged bundle PendingAction.
+	 * Resolve a staged package PendingAction.
 	 *
 	 * ## OPTIONS
 	 *

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -11,9 +11,7 @@
 namespace DataMachine\Cli\Commands;
 
 use WP_CLI;
-use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\AgentAbilities;
-use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 
 defined( 'ABSPATH' ) || exit;
@@ -23,7 +21,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 0.37.0
  */
-class AgentsCommand extends BaseCommand {
+class AgentsCommand extends AgentBundleCommand {
 
 	/**
 	 * List registered agent identities.

--- a/tests/agent-bundle-portable-update-smoke.php
+++ b/tests/agent-bundle-portable-update-smoke.php
@@ -193,6 +193,7 @@ $agent_bundler_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Agent
 $pipelines_source     = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Pipelines/Pipelines.php' ) ?: '';
 $flows_source         = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Flows/Flows.php' ) ?: '';
 $bootstrap_source     = file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Bootstrap.php' ) ?: '';
+$agents_cli_source    = file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/AgentsCommand.php' ) ?: '';
 $bundle_cli_source    = file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/AgentBundleCommand.php' ) ?: '';
 assert_bundle_update( 'importer resolves existing pipelines by portable slug', str_contains( $agent_bundler_source, 'get_by_portable_slug( $agent_id, $portable_slug )' ) );
 assert_bundle_update( 'importer updates existing pipelines instead of duplicating', str_contains( $agent_bundler_source, 'update_pipeline(' ) );
@@ -200,17 +201,21 @@ assert_bundle_update( 'importer resolves existing flows by portable slug', str_c
 assert_bundle_update( 'importer updates existing flows instead of duplicating', str_contains( $agent_bundler_source, 'update_flow(' ) );
 assert_bundle_update( 'pipelines repository exposes portable slug lookup', str_contains( $pipelines_source, 'function get_by_portable_slug' ) );
 assert_bundle_update( 'flows repository exposes portable slug lookup', str_contains( $flows_source, 'function get_by_portable_slug' ) );
-assert_bundle_update( 'agent-bundle CLI command is registered', str_contains( $bootstrap_source, "WP_CLI::add_command( 'datamachine agent-bundle', Commands\\AgentBundleCommand::class );" ) );
-assert_bundle_update( 'agent-bundle CLI exposes install command', str_contains( $bundle_cli_source, 'function install(' ) );
-assert_bundle_update( 'agent-bundle CLI exposes list command', str_contains( $bundle_cli_source, 'function list_(' ) );
-assert_bundle_update( 'agent-bundle CLI exposes status command', str_contains( $bundle_cli_source, 'function status(' ) );
-assert_bundle_update( 'agent-bundle CLI exposes diff command', str_contains( $bundle_cli_source, 'function diff(' ) );
-assert_bundle_update( 'agent-bundle CLI exposes upgrade command', str_contains( $bundle_cli_source, 'function upgrade(' ) );
-assert_bundle_update( 'agent-bundle CLI stages PendingActions for approval-required upgrades', str_contains( $bundle_cli_source, 'AgentBundleUpgradePendingAction::stage' ) );
-assert_bundle_update( 'agent-bundle CLI resolves staged apply actions', str_contains( $bundle_cli_source, 'ResolvePendingActionAbility::execute' ) );
+assert_bundle_update( 'agent command is registered', str_contains( $bootstrap_source, "WP_CLI::add_command( 'datamachine agent', Commands\\AgentsCommand::class );" ) );
+assert_bundle_update( 'top-level agent-bundle command is not registered', ! str_contains( $bootstrap_source, 'datamachine agent-bundle' ) );
+assert_bundle_update( 'agent CLI inherits package lifecycle helper', str_contains( $agents_cli_source, 'class AgentsCommand extends AgentBundleCommand' ) );
+assert_bundle_update( 'package CLI exposes install command', str_contains( $bundle_cli_source, 'function install(' ) );
+assert_bundle_update( 'package CLI exposes non-conflicting installed command', str_contains( $bundle_cli_source, 'function installed(' ) );
+assert_bundle_update( 'package CLI does not claim agent list command', ! str_contains( $bundle_cli_source, '@subcommand list' ) );
+assert_bundle_update( 'package CLI exposes status command', str_contains( $bundle_cli_source, 'function status(' ) );
+assert_bundle_update( 'package CLI exposes diff command', str_contains( $bundle_cli_source, 'function diff(' ) );
+assert_bundle_update( 'package CLI exposes upgrade command', str_contains( $bundle_cli_source, 'function upgrade(' ) );
+assert_bundle_update( 'package CLI stages PendingActions for approval-required upgrades', str_contains( $bundle_cli_source, 'AgentBundleUpgradePendingAction::stage' ) );
+assert_bundle_update( 'package CLI resolves staged apply actions', str_contains( $bundle_cli_source, 'ResolvePendingActionAbility::execute' ) );
 
-if ( ! empty( $failures ) ) {
-	echo "\nFAILED: " . count( $failures ) . " portable update assertions failed.\n";
+$failure_count = is_array( $GLOBALS['failures'] ?? null ) ? count( $GLOBALS['failures'] ) : 0;
+if ( 0 !== $failure_count ) {
+	echo "\nFAILED: " . $failure_count . " portable update assertions failed.\n";
 	exit( 1 );
 }
 


### PR DESCRIPTION
## Summary
- Move portable agent package lifecycle commands onto the canonical `wp datamachine agent ...` surface.
- Remove the registered top-level `wp datamachine agent-bundle` command so operators manage agents, not bundles.

## Changes
- `AgentsCommand` now inherits the package lifecycle verbs from the existing `AgentBundleCommand` helper.
- `agent-bundle list` becomes `agent installed` to avoid clobbering the existing `agent list` identity listing.
- Docs and the portable-update smoke now assert the canonical command surface and the removed top-level registration.

## Tests
- `php -l inc/Cli/Bootstrap.php`
- `php -l inc/Cli/Commands/AgentsCommand.php`
- `php -l inc/Cli/Commands/AgentBundleCommand.php`
- `php tests/agent-bundle-portable-update-smoke.php`
- `php tests/agent-bundle-installed-artifact-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@rename-agent-bundle-cli --file inc/Cli/Bootstrap.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@rename-agent-bundle-cli --file inc/Cli/Commands/AgentsCommand.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@rename-agent-bundle-cli --file inc/Cli/Commands/AgentBundleCommand.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@rename-agent-bundle-cli --file tests/agent-bundle-portable-update-smoke.php`

## Refs
- Follow-up to the portable agent package/bundle lifecycle work.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI surface cleanup, updated docs/tests, and ran focused verification. Chris remains responsible for review and merge.
