### PR TITLE
fix(runtime): skip heavy bootstrap on frontend views

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -43,6 +43,9 @@ if ( ! class_exists( 'ActionScheduler' ) ) {
 
 
 function datamachine_run_datamachine_plugin() {
+	if ( ! datamachine_should_load_full_runtime() ) {
+		return;
+	}
 
 	// Set Action Scheduler timeout to 10 minutes (600 seconds) for large tasks
 	add_filter(
@@ -318,6 +321,38 @@ function datamachine_run_datamachine_plugin() {
 			$index->delete( (int) $post_id );
 		}
 	);
+}
+
+/**
+ * Determine whether the full Data Machine runtime is needed for this request.
+ *
+ * Normal frontend page views do not need the agent, REST, tool, queue, or admin
+ * runtime. Keeping that machinery out of the hot path protects theme rendering
+ * while preserving every interactive/background entry point.
+ *
+ * @return bool True when full runtime registration should run.
+ */
+function datamachine_should_load_full_runtime(): bool {
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return true;
+	}
+
+	if ( is_admin() || wp_doing_ajax() || wp_doing_cron() ) {
+		return true;
+	}
+
+	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '';
+	$path        = (string) wp_parse_url( $request_uri, PHP_URL_PATH );
+
+	if ( str_starts_with( $path, '/wp-json/' ) || str_starts_with( $path, '/datamachine-auth/' ) ) {
+		return true;
+	}
+
+	if ( isset( $_GET['rest_route'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Request-shape detection only.
+		return true;
+	}
+
+	return (bool) apply_filters( 'datamachine_should_load_full_runtime', false, $request_uri );
 }
 
 

--- a/data-machine.php
+++ b/data-machine.php
@@ -352,7 +352,7 @@ function datamachine_should_load_full_runtime(): bool {
 		return true;
 	}
 
-	return (bool) apply_filters( 'datamachine_should_load_full_runtime', false, $request_uri );
+	return (bool) apply_filters( 'datamachine_should_load_full_runtime', false );
 }
 
 
@@ -431,6 +431,9 @@ function datamachine_load_handlers() {
  */
 function datamachine_scan_and_instantiate( $directory ) {
 	$files = glob( $directory . '/*.php' );
+	if ( false === $files ) {
+		return;
+	}
 
 	foreach ( $files as $file ) {
 		// Skip if it's a *Filters.php file (will be deleted)
@@ -754,7 +757,7 @@ function datamachine_on_new_site( \WP_Site $new_site ) {
 		return;
 	}
 
-	switch_to_blog( $new_site->blog_id );
+	switch_to_blog( (int) $new_site->blog_id );
 	datamachine_activate_defaults_for_site();
 	datamachine_activate_for_site();
 	restore_current_blog();

--- a/tests/frontend-runtime-gate-smoke.php
+++ b/tests/frontend-runtime-gate-smoke.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Smoke test: normal frontend page views skip Data Machine's heavy runtime.
+ *
+ * Run with: php tests/frontend-runtime-gate-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$plugin_file = dirname( __DIR__ ) . '/data-machine.php';
+$source      = file_get_contents( $plugin_file );
+
+if ( false === $source ) {
+	fwrite( STDERR, "FAIL: data-machine.php is not readable\n" );
+	exit( 1 );
+}
+
+$failed = 0;
+$total  = 0;
+
+$assert = static function ( string $name, bool $condition ) use ( &$failed, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+
+	echo "  FAIL: {$name}\n";
+	++$failed;
+};
+
+$assert( 'runtime-gate-function-exists', str_contains( $source, 'function datamachine_should_load_full_runtime(): bool' ) );
+$assert( 'main-runtime-checks-gate-first', (bool) preg_match( '/function datamachine_run_datamachine_plugin\(\) \{\s*if \( ! datamachine_should_load_full_runtime\(\) \)/', $source ) );
+$assert( 'wp-cli-gets-full-runtime', str_contains( $source, "defined( 'WP_CLI' ) && WP_CLI" ) );
+$assert( 'admin-ajax-cron-get-full-runtime', str_contains( $source, 'is_admin() || wp_doing_ajax() || wp_doing_cron()' ) );
+$assert( 'rest-path-gets-full-runtime', str_contains( $source, 'str_starts_with( $path, \'/wp-json/\' )' ) );
+$assert( 'oauth-callback-gets-full-runtime', str_contains( $source, 'str_starts_with( $path, \'/datamachine-auth/\' )' ) );
+$assert( 'plain-permalink-rest-route-gets-full-runtime', str_contains( $source, 'isset( $_GET[\'rest_route\'] )' ) );
+$assert( 'extensions-can-opt-in', str_contains( $source, "apply_filters( 'datamachine_should_load_full_runtime'" ) );
+$assert( 'frontend-default-is-lazy', str_contains( $source, "apply_filters( 'datamachine_should_load_full_runtime', false" ) );
+
+if ( $failed > 0 ) {
+	fwrite( STDERR, "frontend runtime gate smoke failed: {$failed}/{$total}\n" );
+	exit( 1 );
+}
+
+echo "Frontend runtime gate smoke passed: {$total} assertions.\n";


### PR DESCRIPTION
## Summary
- Skips Data Machine's heavy agent/tool/admin runtime registration for ordinary frontend page views.
- Keeps the full runtime active for WP-CLI, wp-admin, AJAX, cron, REST, and Data Machine OAuth callback requests.
- Adds a smoke test locking the frontend runtime gate contract.

## Why
Imported static HTML themes were spending most of their request time in Data Machine bootstrap, not in theme/block rendering. On intelligence-chubes4, the WordPress Is Dead pages dropped from roughly 0.9-1.1s TTFB to roughly 0.5-0.7s with this gate while importer smokes remained green.

## Tests
- php tests/frontend-runtime-gate-smoke.php
- php -l data-machine.php
- php tests/bfb-substrate-bundle-smoke.php
- homeboy lint data-machine --path /Users/chubes/Developer/data-machine@lazy-frontend-runtime --changed-since origin/main
- homeboy audit data-machine --path /Users/chubes/Developer/data-machine@lazy-frontend-runtime --changed-since origin/main
- Live probe on intelligence-chubes4: frontend page timing improved, REST/admin paths still load full runtime, static importer smokes passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Profiling the frontend request path, implementing the runtime gate, adding smoke coverage, and running local/live verification; Chris remains responsible for review and merge.