### PR TITLE
fix(runtime): load full runtime during PHPUnit

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -336,6 +336,10 @@ function datamachine_run_datamachine_plugin() {
  * @return bool True when full runtime registration should run.
  */
 function datamachine_should_load_full_runtime(): bool {
+	if ( defined( 'WP_TESTS_DOMAIN' ) || defined( 'WP_TESTS_CONFIG_FILE_PATH' ) ) {
+		return true;
+	}
+
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		return true;
 	}

--- a/tests/frontend-runtime-gate-smoke.php
+++ b/tests/frontend-runtime-gate-smoke.php
@@ -31,6 +31,7 @@ $assert = static function ( string $name, bool $condition ) use ( &$failed, &$to
 
 $assert( 'runtime-gate-function-exists', str_contains( $source, 'function datamachine_should_load_full_runtime(): bool' ) );
 $assert( 'main-runtime-checks-gate-first', (bool) preg_match( '/function datamachine_run_datamachine_plugin\(\) \{\s*if \( ! datamachine_should_load_full_runtime\(\) \)/', $source ) );
+$assert( 'wp-tests-get-full-runtime', str_contains( $source, "defined( 'WP_TESTS_DOMAIN' )" ) );
 $assert( 'wp-cli-gets-full-runtime', str_contains( $source, "defined( 'WP_CLI' ) && WP_CLI" ) );
 $assert( 'admin-ajax-cron-get-full-runtime', str_contains( $source, 'is_admin() || wp_doing_ajax() || wp_doing_cron()' ) );
 $assert( 'rest-path-gets-full-runtime', str_contains( $source, 'str_starts_with( $path, \'/wp-json/\' )' ) );


### PR DESCRIPTION
## Summary
- Treat WordPress PHPUnit requests as full-runtime requests so ability/tool registration still runs under the frontend lazy-runtime gate.
- Extend the frontend runtime gate smoke to pin the PHPUnit bypass while preserving the normal frontend lazy default.

## Tests
- `php tests/frontend-runtime-gate-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-runtime-test-gate -- tests/Unit/Abilities/AgentContextPropagationTest.php tests/Unit/Abilities/FileAbilitiesTest.php tests/Unit/Engine/AI/Tools/ToolPolicyResolverTest.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Homeboy changed-since test failures and drafted the targeted runtime-gate fix; Chris remains responsible for review and merge.