### PR TITLE
fix(test): load full runtime in unit tests

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -344,6 +344,13 @@ function datamachine_should_load_full_runtime(): bool {
 		return true;
 	}
 
+	// WordPress PHPUnit loads plugins through a frontend-shaped request. Keep the
+	// full runtime available so ability/tool registration tests exercise the same
+	// surfaces as CLI, REST, admin, cron, and Ajax entry points.
+	if ( defined( 'WP_TESTS_DOMAIN' ) || defined( 'WP_TESTS_EMAIL' ) || defined( 'WP_TESTS_TITLE' ) ) {
+		return true;
+	}
+
 	if ( is_admin() || wp_doing_ajax() || wp_doing_cron() ) {
 		return true;
 	}


### PR DESCRIPTION
## Summary
- Load the full Data Machine runtime when running WordPress PHPUnit so ability and tool registration tests exercise the same surfaces as CLI, REST, admin, cron, and Ajax requests.

## Changes
- Treat the standard WordPress test-suite constants as full-runtime contexts in `datamachine_should_load_full_runtime()`.
- Keeps normal frontend requests on the lightweight path while restoring test-suite visibility for registered abilities/tools.

## Tests
- `php -l data-machine.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-current-unit-suite-drift --changed-since origin/main`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-current-unit-suite-drift -- --filter 'MultiAgentScopingTest|ToolPolicyResolverTest|MemoryPolicyResolverTest'` (ran full suite; passed: 1209 tests, 3810 assertions, 3 skipped)
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-current-unit-suite-drift --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-current-unit-suite-drift --changed-since origin/main`

## Refs
- Unblocks #1621

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the PHPUnit runtime gating failure, applying the targeted runtime-context fix, and running verification; Chris remains responsible for review and merge.
