### PR TITLE
fix(deps): refresh BFB to 0.6.4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -68,16 +68,16 @@
         },
         {
             "name": "chubes4/block-format-bridge",
-            "version": "v0.6.3",
+            "version": "v0.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chubes4/block-format-bridge.git",
-                "reference": "7ce298d0c0ca79a4a3a2334dbc435f9053e31798"
+                "reference": "130ae565dc4bca541560f4e1c788bb7e5f3829de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/7ce298d0c0ca79a4a3a2334dbc435f9053e31798",
-                "reference": "7ce298d0c0ca79a4a3a2334dbc435f9053e31798",
+                "url": "https://api.github.com/repos/chubes4/block-format-bridge/zipball/130ae565dc4bca541560f4e1c788bb7e5f3829de",
+                "reference": "130ae565dc4bca541560f4e1c788bb7e5f3829de",
                 "shasum": ""
             },
             "require": {
@@ -112,10 +112,10 @@
             "description": "WordPress plugin orchestrating bidirectional content format conversion (HTML, Blocks, Markdown) via a unified adapter API.",
             "homepage": "https://github.com/chubes4/block-format-bridge",
             "support": {
-                "source": "https://github.com/chubes4/block-format-bridge/tree/v0.6.3",
+                "source": "https://github.com/chubes4/block-format-bridge/tree/v0.6.4",
                 "issues": "https://github.com/chubes4/block-format-bridge/issues"
             },
-            "time": "2026-04-30T02:04:13+00:00"
+            "time": "2026-04-30T02:14:05+00:00"
         },
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
## Summary
- Refreshes the bundled Block Format Bridge dependency to v0.6.4, which includes h2bc v0.6.4 paragraph style-support serialization fixes.

## Tests
- `php tests/content-format-helper-smoke.php`
- `php tests/content-format-abilities-smoke.php`
- `php tests/wordpress-publish-content-format-smoke.php`
- `php tests/bfb-substrate-bundle-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Dependency refresh, focused smoke validation, and PR preparation; Chris remains responsible for review and merge.
