### PR TITLE
test(agent): add agents api module boundary smokes

### DIFF
--- a/tests/agents-api-bootstrap-smoke.php
+++ b/tests/agents-api-bootstrap-smoke.php
@@ -11,123 +11,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
-$GLOBALS['__agents_api_smoke_actions'] = array();
-
-function sanitize_title( string $value ): string {
-	$value = strtolower( $value );
-	$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
-	return trim( (string) $value, '-' );
-}
-
-function sanitize_file_name( string $value ): string {
-	return basename( $value );
-}
-
-function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
-	unset( $accepted_args );
-	$GLOBALS['__agents_api_smoke_actions'][ $hook ][ $priority ][] = $callback;
-}
-
-function do_action( string $hook, ...$args ): void {
-	$callbacks = $GLOBALS['__agents_api_smoke_actions'][ $hook ] ?? array();
-	ksort( $callbacks );
-
-	foreach ( $callbacks as $priority_callbacks ) {
-		foreach ( $priority_callbacks as $callback ) {
-			call_user_func_array( $callback, $args );
-		}
-	}
-}
-
 $failures = array();
 $passes   = 0;
 
-function assert_agents_api_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
-	if ( $expected === $actual ) {
-		++$passes;
-		echo "  PASS {$name}\n";
-		return;
-	}
-
-	$failures[] = $name;
-	echo "  FAIL {$name}\n";
-	echo '    expected: ' . var_export( $expected, true ) . "\n";
-	echo '    actual:   ' . var_export( $actual, true ) . "\n";
-}
-
 echo "agents-api-bootstrap-smoke\n";
 
-require_once __DIR__ . '/../agents-api/agents-api.php';
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
 
 echo "\n[1] Module bootstrap exposes registration facade without Data Machine product code:\n";
-assert_agents_api_equals( true, defined( 'AGENTS_API_LOADED' ), 'module marks itself loaded', $failures, $passes );
-assert_agents_api_equals( true, function_exists( 'wp_register_agent' ), 'wp_register_agent helper is available', $failures, $passes );
-assert_agents_api_equals( true, class_exists( 'WP_Agent' ), 'WP_Agent value object is available', $failures, $passes );
-assert_agents_api_equals( true, class_exists( 'WP_Agents_Registry' ), 'WP_Agents_Registry facade is available', $failures, $passes );
-assert_agents_api_equals( true, interface_exists( 'DataMachine\\Core\\Database\\Chat\\ConversationTranscriptStoreInterface' ), 'ConversationTranscriptStoreInterface contract is available', $failures, $passes );
-assert_agents_api_equals( true, class_exists( 'DataMachine\\Engine\\AI\\AgentMessageEnvelope' ), 'AgentMessageEnvelope contract is available', $failures, $passes );
-assert_agents_api_equals( true, class_exists( 'DataMachine\\Engine\\AI\\AgentConversationResult' ), 'AgentConversationResult contract is available', $failures, $passes );
-assert_agents_api_equals( true, class_exists( 'DataMachine\\Engine\\AI\\Tools\\RuntimeToolDeclaration' ), 'RuntimeToolDeclaration contract is available', $failures, $passes );
-assert_agents_api_equals( true, interface_exists( 'DataMachine\\Core\\FilesRepository\\AgentMemoryStoreInterface' ), 'AgentMemoryStoreInterface contract is available', $failures, $passes );
-assert_agents_api_equals( true, class_exists( 'DataMachine\\Core\\FilesRepository\\AgentMemoryScope' ), 'AgentMemoryScope contract is available', $failures, $passes );
-assert_agents_api_equals( false, class_exists( 'DataMachine\\Engine\\Agents\\AgentRegistry', false ), 'Data Machine registry is not loaded by module bootstrap', $failures, $passes );
-assert_agents_api_equals( false, class_exists( 'DataMachine\\Engine\\AI\\AIConversationLoop', false ), 'Data Machine compatibility loop is not loaded by module bootstrap', $failures, $passes );
-assert_agents_api_equals( false, class_exists( 'DataMachine\\Engine\\AI\\BuiltInAgentConversationRunner', false ), 'Data Machine built-in runner is not loaded by module bootstrap', $failures, $passes );
-assert_agents_api_equals( false, class_exists( 'DataMachine\\Core\\FilesRepository\\DiskAgentMemoryStore', false ), 'Data Machine disk memory store is not loaded by module bootstrap', $failures, $passes );
+agents_api_smoke_assert_equals( true, defined( 'AGENTS_API_LOADED' ), 'module marks itself loaded', $failures, $passes );
+agents_api_smoke_assert_equals( true, defined( 'AGENTS_API_PATH' ), 'module path constant is available', $failures, $passes );
+agents_api_smoke_assert_equals( realpath( __DIR__ . '/../agents-api' ) . '/', AGENTS_API_PATH, 'module path points at agents-api directory', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_register_agent' ), 'wp_register_agent helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent' ), 'WP_Agent value object is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agents_Registry' ), 'WP_Agents_Registry facade is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, interface_exists( 'DataMachine\\Core\\Database\\Chat\\ConversationTranscriptStoreInterface' ), 'ConversationTranscriptStoreInterface contract is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'DataMachine\\Engine\\AI\\AgentMessageEnvelope' ), 'AgentMessageEnvelope contract is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'DataMachine\\Engine\\AI\\AgentConversationResult' ), 'AgentConversationResult contract is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'DataMachine\\Engine\\AI\\Tools\\RuntimeToolDeclaration' ), 'RuntimeToolDeclaration contract is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, interface_exists( 'DataMachine\\Core\\FilesRepository\\AgentMemoryStoreInterface' ), 'AgentMemoryStoreInterface contract is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'DataMachine\\Core\\FilesRepository\\AgentMemoryScope' ), 'AgentMemoryScope contract is available', $failures, $passes );
+agents_api_smoke_assert_equals( false, class_exists( 'DataMachine\\Engine\\Agents\\AgentRegistry', false ), 'Data Machine registry is not loaded by module bootstrap', $failures, $passes );
+agents_api_smoke_assert_equals( false, class_exists( 'DataMachine\\Core\\Database\\Jobs\\Jobs', false ), 'Data Machine jobs repository is not loaded by module bootstrap', $failures, $passes );
+agents_api_smoke_assert_equals( false, class_exists( 'DataMachine\\Engine\\AI\\AIConversationLoop', false ), 'Data Machine compatibility loop is not loaded by module bootstrap', $failures, $passes );
+agents_api_smoke_assert_equals( false, class_exists( 'DataMachine\\Engine\\AI\\BuiltInAgentConversationRunner', false ), 'Data Machine built-in runner is not loaded by module bootstrap', $failures, $passes );
+agents_api_smoke_assert_equals( false, class_exists( 'DataMachine\\Core\\FilesRepository\\DiskAgentMemoryStore', false ), 'Data Machine disk memory store is not loaded by module bootstrap', $failures, $passes );
 
-echo "\n[2] Public registration hook collects definitions once and stays side-effect free:\n";
-add_action(
-	'wp_agents_api_init',
-	static function (): void {
-		wp_register_agent(
-			new WP_Agent(
-				'Example Agent!',
-				array(
-					'label'          => 'Example Agent',
-					'description'    => 'Standalone module smoke',
-					'memory_seeds'   => array( '../SOUL.md' => '/tmp/seed-soul.md' ),
-					'owner_resolver' => static fn() => 7,
-					'default_config' => array( 'default_provider' => 'openai' ),
-				)
-			)
-		);
-	}
-);
-
-$definitions = WP_Agents_Registry::get_all();
-assert_agents_api_equals( array( 'example-agent' ), array_keys( $definitions ), 'definition slug is normalized', $failures, $passes );
-assert_agents_api_equals( 'Example Agent', $definitions['example-agent']['label'] ?? '', 'definition label is preserved', $failures, $passes );
-assert_agents_api_equals( array( 'SOUL.md' => '/tmp/seed-soul.md' ), $definitions['example-agent']['memory_seeds'] ?? array(), 'memory seed filenames are sanitized', $failures, $passes );
-assert_agents_api_equals( array( 'example-agent' ), array_keys( WP_Agents_Registry::get_all() ), 'registration hook fires only once', $failures, $passes );
-
-echo "\n[3] agents-api files do not import Data Machine product namespaces:\n";
-$forbidden_import = false;
-$forbidden_loop   = false;
-$iterator         = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( __DIR__ . '/../agents-api' ) );
-foreach ( $iterator as $file ) {
-	if ( ! $file->isFile() || 'php' !== $file->getExtension() ) {
-		continue;
-	}
-
-	$source = (string) file_get_contents( $file->getPathname() );
-	if ( preg_match( '/(?:use\s+|new\s+|extends\s+|implements\s+|::|instanceof\s+)\\?DataMachine\\\\/', $source ) ) {
-		$forbidden_import = true;
-	}
-
-	if ( preg_match( '/\\b(?:AIConversationLoop|BuiltInAgentConversationRunner)\\b/', $source ) ) {
-		$forbidden_loop = true;
-	}
-
-	if ( $forbidden_import || $forbidden_loop ) {
-		break;
-	}
-}
-assert_agents_api_equals( false, $forbidden_import, 'agents-api has no DataMachine namespace imports', $failures, $passes );
-assert_agents_api_equals( false, $forbidden_loop, 'agents-api does not contain Data Machine loop implementation classes', $failures, $passes );
-
-if ( $failures ) {
-	echo "\nFAILED: " . count( $failures ) . " Agents API bootstrap assertions failed.\n";
-	exit( 1 );
-}
-
-echo "\nAll {$passes} Agents API bootstrap assertions passed.\n";
+agents_api_smoke_finish( 'Agents API bootstrap', $failures, $passes );

--- a/tests/agents-api-no-product-imports-smoke.php
+++ b/tests/agents-api-no-product-imports-smoke.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Static smoke test proving agents-api does not import Data Machine product code (#1639).
+ *
+ * Run with: php tests/agents-api-no-product-imports-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-no-product-imports-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+$agents_api_dir = realpath( __DIR__ . '/../agents-api' );
+agents_api_smoke_assert_equals( true, is_string( $agents_api_dir ), 'agents-api directory exists', $failures, $passes );
+
+$forbidden_namespaces = array(
+	'DataMachine\\Core\\Steps',
+	'DataMachine\\Core\\Database\\Jobs',
+	'DataMachine\\Core\\Admin',
+	'DataMachine\\Engine\\Handlers',
+	'DataMachine\\Core\\ActionScheduler',
+	'DataMachine\\Engine\\AI\\System\\Tasks\\Retention',
+	'DataMachine\\Engine\\Pipelines',
+	'DataMachine\\Engine\\Flows',
+	'DataMachine\\Engine\\Queue',
+	'DataMachine\\Core\\Content',
+);
+
+$matches  = array();
+$iterator = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( (string) $agents_api_dir ) );
+foreach ( $iterator as $file ) {
+	if ( ! $file->isFile() || 'php' !== $file->getExtension() ) {
+		continue;
+	}
+
+	$source = (string) file_get_contents( $file->getPathname() );
+	foreach ( $forbidden_namespaces as $namespace ) {
+		$quoted = preg_quote( $namespace, '/' );
+		if ( preg_match( '/(?:use\s+|new\s+|extends\s+|implements\s+|instanceof\s+|\\\\)' . $quoted . '(?:\\\\|;|\s|\(|::)/', $source ) ) {
+			$matches[] = str_replace( (string) $agents_api_dir . '/', '', $file->getPathname() ) . ' imports ' . $namespace;
+		}
+	}
+
+	if ( preg_match( '/(?:use\s+|new\s+|extends\s+|implements\s+|instanceof\s+)\\?DataMachine\\\\/', $source ) ) {
+		$matches[] = str_replace( (string) $agents_api_dir . '/', '', $file->getPathname() ) . ' imports a DataMachine namespace';
+	}
+}
+
+agents_api_smoke_assert_equals( array(), $matches, 'agents-api has no Data Machine product imports', $failures, $passes );
+agents_api_smoke_assert_equals( $forbidden_namespaces, array_values( array_unique( $forbidden_namespaces ) ), 'forbidden namespace list has no duplicates', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API no-product-imports', $failures, $passes );

--- a/tests/agents-api-registration-smoke.php
+++ b/tests/agents-api-registration-smoke.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Pure-PHP smoke test for Agents API registration semantics (#1639).
+ *
+ * Run with: php tests/agents-api-registration-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-registration-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Direct registration normalizes definitions without side effects:\n";
+WP_Agents_Registry::reset_for_tests();
+wp_register_agent(
+	new WP_Agent(
+		'Example Agent!',
+		array(
+			'label'          => 'Example Agent',
+			'description'    => 'Standalone module smoke',
+			'memory_seeds'   => array( '../SOUL.md' => '/tmp/seed-soul.md' ),
+			'owner_resolver' => static fn() => 7,
+			'default_config' => array( 'default_provider' => 'openai' ),
+		)
+	)
+);
+
+$definitions = WP_Agents_Registry::get_all();
+agents_api_smoke_assert_equals( array( 'example-agent' ), array_keys( $definitions ), 'definition slug is normalized', $failures, $passes );
+agents_api_smoke_assert_equals( 'Example Agent', $definitions['example-agent']['label'] ?? '', 'definition label is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'Standalone module smoke', $definitions['example-agent']['description'] ?? '', 'definition description is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'SOUL.md' => '/tmp/seed-soul.md' ), $definitions['example-agent']['memory_seeds'] ?? array(), 'memory seed filenames are sanitized', $failures, $passes );
+agents_api_smoke_assert_equals( true, is_callable( $definitions['example-agent']['owner_resolver'] ?? null ), 'callable owner resolver is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'default_provider' => 'openai' ), $definitions['example-agent']['default_config'] ?? array(), 'default config is preserved', $failures, $passes );
+
+echo "\n[2] Public registration hook fires once on first read:\n";
+WP_Agents_Registry::reset_for_tests();
+$hook_calls = 0;
+add_action(
+	'wp_agents_api_init',
+	static function () use ( &$hook_calls ): void {
+		++$hook_calls;
+		wp_register_agent( 'Hook Agent', array( 'label' => 'Hook Agent' ) );
+	}
+);
+
+$definitions = WP_Agents_Registry::get_all();
+agents_api_smoke_assert_equals( 1, $hook_calls, 'registration hook fires on first get_all call', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'hook-agent' ), array_keys( $definitions ), 'hook-registered definition is collected', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'hook-agent' ), array_keys( WP_Agents_Registry::get_all() ), 'registration hook does not refire on subsequent reads', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $hook_calls, 'hook call count remains stable after second read', $failures, $passes );
+
+echo "\n[3] Invalid definitions are ignored or normalized predictably:\n";
+WP_Agents_Registry::reset_for_tests();
+$GLOBALS['__agents_api_smoke_actions'] = array();
+wp_register_agent( '!!!', array( 'label' => 'Invalid' ) );
+wp_register_agent( 'Minimal Agent' );
+wp_register_agent(
+	'Messy Seeds',
+	array(
+		'memory_seeds'   => array(
+			'../MEMORY.md' => '/tmp/MEMORY.md',
+			''             => '/tmp/empty.md',
+			'empty-path.md' => '',
+		),
+		'owner_resolver' => 'not callable',
+	)
+);
+
+$definitions = WP_Agents_Registry::get_all();
+agents_api_smoke_assert_equals( array( 'minimal-agent', 'messy-seeds' ), array_keys( $definitions ), 'empty slugs are ignored while valid slugs are kept', $failures, $passes );
+agents_api_smoke_assert_equals( 'minimal-agent', $definitions['minimal-agent']['label'] ?? '', 'missing label falls back to slug', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'MEMORY.md' => '/tmp/MEMORY.md' ), $definitions['messy-seeds']['memory_seeds'] ?? array(), 'empty memory seed keys and paths are dropped', $failures, $passes );
+agents_api_smoke_assert_equals( null, $definitions['messy-seeds']['owner_resolver'] ?? null, 'non-callable owner resolver is dropped', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API registration', $failures, $passes );

--- a/tests/agents-api-smoke-helpers.php
+++ b/tests/agents-api-smoke-helpers.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Shared pure-PHP harness for Agents API module smokes.
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$GLOBALS['__agents_api_smoke_actions'] = array();
+
+function sanitize_title( string $value ): string {
+	$value = strtolower( $value );
+	$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+	return trim( (string) $value, '-' );
+}
+
+function sanitize_file_name( string $value ): string {
+	return basename( $value );
+}
+
+function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $accepted_args );
+	$GLOBALS['__agents_api_smoke_actions'][ $hook ][ $priority ][] = $callback;
+}
+
+function do_action( string $hook, ...$args ): void {
+	$callbacks = $GLOBALS['__agents_api_smoke_actions'][ $hook ] ?? array();
+	ksort( $callbacks );
+
+	foreach ( $callbacks as $priority_callbacks ) {
+		foreach ( $priority_callbacks as $callback ) {
+			call_user_func_array( $callback, $args );
+		}
+	}
+}
+
+function agents_api_smoke_assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function agents_api_smoke_require_module(): void {
+	require_once __DIR__ . '/../agents-api/agents-api.php';
+}
+
+function agents_api_smoke_finish( string $label, array $failures, int $passes ): void {
+	if ( $failures ) {
+		echo "\nFAILED: " . count( $failures ) . " {$label} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$passes} {$label} assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Splits the existing Agents API bootstrap smoke into focused module-level coverage for bootstrap, registration semantics, and product-namespace isolation.
- Adds a shared pure-PHP smoke harness so the in-repo `agents-api/` module can be exercised without loading Data Machine product runtime.
- Adds a static no-product-imports smoke that fails if `agents-api/` imports Data Machine product namespaces for steps, jobs, admin, handlers, retention, flows, pipelines, queues, or content ops.

## Tests
- `php tests/agents-api-bootstrap-smoke.php && php tests/agents-api-registration-smoke.php && php tests/agents-api-no-product-imports-smoke.php`
- `php -l tests/agents-api-smoke-helpers.php && php -l tests/agents-api-bootstrap-smoke.php && php -l tests/agents-api-registration-smoke.php && php -l tests/agents-api-no-product-imports-smoke.php`
- `git diff --check origin/main...HEAD`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-module-smokes --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@agents-api-module-smokes --changed-since origin/main`

## Closes #1639
Closes #1639.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the smoke-test split, ran focused verification, and prepared the PR. Chris remains responsible for review and merge.