### PR TITLE
refactor(agent): require wp ai client for agent runtime

### DIFF
--- a/docs/core-system/request-builder.md
+++ b/docs/core-system/request-builder.md
@@ -9,7 +9,7 @@ Centralized AI request construction ensuring consistent request structure across
 
 The `RequestBuilder` class consolidates all AI request building logic into a single, unified interface. This prevents behavioral differences between Pipeline and Chat agents by ensuring both use identical request construction, tool formatting, and directive application patterns.
 
-**Critical Rule**: Never call `ai-http-client` directly. Always use `RequestBuilder::build()` to ensure consistent request structure and directive application.
+**Critical Rule**: Never call provider clients directly. Always use `RequestBuilder::build()` to ensure consistent request structure, directive application, metadata, and wp-ai-client dispatch.
 
 ## Architecture
 
@@ -30,8 +30,8 @@ Request Building Flow:
 │     • Priority-based sorting and agent targeting    │
 │     • Unified directive management                   │
 │                                                      │
-│  4. Send to ai-http-client                          │
-│     • chubes_ai_request filter                      │
+│  4. Send to wp-ai-client                            │
+│     • WpAiClientAdapter capability gate             │
 │     • Returns standardized AI response              │
 └─────────────────────────────────────────────────────┘
 ```
@@ -220,32 +220,15 @@ $structured_tools['twitter_publish'] = [
 ];
 ```
 
-## Integration with ai-http-client
+## Integration with wp-ai-client
 
-The RequestBuilder sends the finalized request to the ai-http-client library via the `chubes_ai_request` filter:
+The RequestBuilder gates runtime availability through `WpAiClientCapability`, then sends the finalized request through `WpAiClientAdapter`. The gate requires:
 
-```php
-return apply_filters(
-    'chubes_ai_request',
-    $request,
-    $provider,
-    null, // streaming_callback
-    $structured_tools,
-    $context['step_id'] ?? $context['session_id'] ?? null,
-    [
-        'agent_type' => $agent_type,
-        'context' => $context
-    ]
-);
-```
+- `wp_ai_client_prompt()` being defined.
+- `wp_supports_ai()` being defined and returning true.
+- The requested provider, or its known alias, being registered in `WordPress\AiClient\AiClient::defaultRegistry()`.
 
-**Parameters**:
-- `$request` - Complete request array (model, messages, tools)
-- `$provider` - AI provider name (openai, anthropic, google, grok, openrouter)
-- `null` - Streaming callback (not used in current implementation)
-- `$structured_tools` - Restructured tools array
-- `$context['step_id'] ?? $context['session_id']` - Identifier for logging
-- `['agent_type' => ..., 'context' => ...]` - Additional metadata
+If the gate fails, RequestBuilder returns a structured request error with `request_metadata`. It does not fall back to `chubes_ai_request` / `ai-http-client`.
 
 **Response Structure**:
 ```php
@@ -268,7 +251,7 @@ return apply_filters(
 
 ## Context Parameter
 
-The `$context` array provides information to directives and the ai-http-client:
+The `$context` array provides information to directives, logging, transcripts, and request metadata:
 
 ### Pipeline Context
 
@@ -362,12 +345,12 @@ if (!$ai_response['success']) {
 
 ### Configuration Errors
 
-Missing or invalid configuration (model not set, provider not configured) are handled by ai-http-client:
+Missing or invalid runtime configuration (wp-ai-client unavailable, model not set, provider not configured) is returned in the standard response shape:
 
 ```php
 [
     'success' => false,
-    'error' => 'Invalid provider configuration'
+    'error' => 'wp-ai-client provider "openai" is not registered'
 ]
 ```
 
@@ -416,7 +399,7 @@ $ai_response = RequestBuilder::build(
 **Incorrect** (bypasses directive system and tool restructuring):
 ```php
 // NEVER DO THIS
-$ai_response = apply_filters('chubes_ai_request', $request, $provider, null, $tools);
+$ai_response = wp_ai_client_prompt()->generate_text_result();
 ```
 
 ### Provide Complete Context

--- a/docs/core-system/request-builder.md
+++ b/docs/core-system/request-builder.md
@@ -226,7 +226,7 @@ The RequestBuilder gates runtime availability through `WpAiClientCapability`, th
 
 - `wp_ai_client_prompt()` being defined.
 - `wp_supports_ai()` being defined and returning true.
-- The requested provider, or its known alias, being registered in `WordPress\AiClient\AiClient::defaultRegistry()`.
+- The requested provider, or its known alias, being registered in the wp-ai-client default provider registry.
 
 If the gate fails, RequestBuilder returns a structured request error with `request_metadata`. It does not fall back to `chubes_ai_request` / `ai-http-client`.
 

--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -281,7 +281,7 @@ Automattic/intelligence#285.
 | `datamachine_pre_ai_step_check` | Data Machine adapter | Pipeline AI-step skip hook. |
 | `datamachine_log` | Data Machine product | Product logging surface. Generic runtime events should use loop event sinks. |
 | `chubes_ai_request` | Legacy provider bridge to delete | Legacy `ai-http-client` provider-dispatch filter. Do not carry this into Agents API public vocabulary or architecture; removal belongs to #1027 / #1633. |
-| `wp_ai_client` feature detection through `WpAiClientAdapter` | Agents API implementation candidate | WordPress AI client routing is the target provider direction, normalized behind Agents API contracts. |
+| `WpAiClientCapability::unavailableReason()` | Agents API implementation candidate | Single wp-ai-client runtime capability gate. Missing support is surfaced as a request error; no `ai-http-client` fallback belongs in Agents API. |
 
 ## Test Coverage Map
 
@@ -307,6 +307,7 @@ These tests currently pin the substrate most relevant to extraction.
 | `tests/agent-call-migration-smoke.php` | Agent-call migration. | Agent-call primitive may inform Agents API; migration stays Data Machine. |
 | `tests/agent-bundle-*.php` | Bundle format, artifact store, upgrade planner, portable update. | Split pure manifest/auth/template artifacts from flow/pipeline file adapters. |
 | `tests/ai-request-inspector-smoke.php` | Provider request assembly without dispatch plus Data Machine request inspection surface. | Split generic `ProviderRequestAssembler` assertions from Data Machine `RequestBuilder` directive-policy assertions during extraction. |
+| `tests/wp-ai-client-runtime-gate-smoke.php` | wp-ai-client capability gate and no `chubes_ai_request` runtime fallback. | Move with provider runtime boundary if Agents API owns provider dispatch. |
 
 ## First Seams To Make Boring
 

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -25,10 +25,9 @@ class RequestBuilder {
 	 * build identical request structures. Handles tool restructuring, directive
 	 * application via PromptBuilder, and request dispatch.
 	 *
-	 * Dispatch path is feature-detected at runtime: when WordPress core's wp-ai-client
-	 * is available and a provider plugin has registered the requested provider, the
-	 * request is sent through {@see WpAiClientAdapter::dispatch()}. Otherwise it falls
-	 * back to the bundled ai-http-client library via the `chubes_ai_request` filter.
+	 * Dispatch requires WordPress core's wp-ai-client plus a provider plugin that has
+	 * registered the requested provider. Missing wp-ai-client support is surfaced as a
+	 * request error; agents-api must not silently fall back to ai-http-client.
 	 *
 	 * @param array  $messages    Initial messages array with role/content
 	 * @param string $provider    AI provider name (openai, anthropic, google, grok, openrouter)
@@ -86,67 +85,82 @@ class RequestBuilder {
 			)
 		);
 
-		// 4. Dispatch the request.
-		//
-		// When WordPress core's AI client is available AND a provider plugin has
-		// registered the requested provider, route the request through wp-ai-client.
-		// Otherwise fall back to the bundled ai-http-client library via the
-		// `chubes_ai_request` filter — preserving today's behavior on sites that
-		// haven't adopted core's provider plugins yet.
-		//
-		// This bridge is request-execution-only. Admin UI, providers REST endpoint,
-		// settings, and key storage continue to flow through the chubes_ai_* filter
-		// surface. Once WordPress 7.0 is the minimum supported version, those layers
-		// will be migrated and ai-http-client will be removed entirely.
-		if ( WpAiClientAdapter::isAvailable( $provider ) ) {
-			$wp_ai_response = WpAiClientAdapter::dispatch( $provider_request, $provider, $structured_tools );
+		// 4. Dispatch the request. wp-ai-client is the only runtime provider path.
+		$unavailable_reason = WpAiClientCapability::unavailableReason( $provider );
+		if ( null !== $unavailable_reason ) {
+			$response = array(
+				'success'          => false,
+				'provider'         => $provider,
+				'error'            => $unavailable_reason,
+				'data'             => array(
+					'content'    => '',
+					'tool_calls' => array(),
+					'usage'      => array(
+						'prompt_tokens'     => 0,
+						'completion_tokens' => 0,
+						'total_tokens'      => 0,
+					),
+				),
+				'request_metadata' => $request_metadata,
+			);
 
-			// dispatch() returns null when the bridge cannot translate the request
-			// (e.g. multi-modal content) so we transparently fall through to the
-			// legacy path below.
-			if ( null !== $wp_ai_response ) {
-				do_action(
-					'datamachine_log',
-					'debug',
-					'AI request dispatched via wp-ai-client',
-					array_filter(
-						array(
-							'mode'         => $mode,
-							'job_id'       => $payload['job_id'] ?? null,
-							'flow_step_id' => $payload['flow_step_id'] ?? null,
-							'provider'     => $provider,
-							'model'        => $model,
-							'success'      => $wp_ai_response['success'] ?? false,
-						),
-						fn( $v ) => null !== $v
-					)
-				);
+			do_action(
+				'datamachine_log',
+				'error',
+				'AI request blocked: wp-ai-client unavailable',
+				array_filter(
+					array(
+						'mode'         => $mode,
+						'job_id'       => $payload['job_id'] ?? null,
+						'flow_step_id' => $payload['flow_step_id'] ?? null,
+						'provider'     => $provider,
+						'model'        => $model,
+						'error'        => $unavailable_reason,
+					),
+					fn( $v ) => null !== $v
+				)
+			);
 
-				$wp_ai_response['request_metadata'] = $request_metadata;
-				return $wp_ai_response;
-			}
+			return $response;
 		}
 
-		// Legacy path: ai-http-client via chubes_ai_request filter.
-		/** @phpstan-ignore-next-line WordPress filters accept context arguments beyond the filtered value. */
-		$response = apply_filters(
-			'chubes_ai_request',
-			$provider_request,
-			$provider,
-			null, // streaming_callback
-			$structured_tools,
-			$payload['step_id'] ?? $payload['session_id'] ?? null,
-			array(
-				'mode'    => $mode,
-				'payload' => $payload,
+		$wp_ai_response = WpAiClientAdapter::dispatch( $provider_request, $provider, $structured_tools );
+		if ( null === $wp_ai_response ) {
+			$wp_ai_response = array(
+				'success'  => false,
+				'provider' => $provider,
+				'error'    => 'wp-ai-client adapter cannot translate this request shape yet',
+				'data'     => array(
+					'content'    => '',
+					'tool_calls' => array(),
+					'usage'      => array(
+						'prompt_tokens'     => 0,
+						'completion_tokens' => 0,
+						'total_tokens'      => 0,
+					),
+				),
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'debug',
+			'AI request dispatched via wp-ai-client',
+			array_filter(
+				array(
+					'mode'         => $mode,
+					'job_id'       => $payload['job_id'] ?? null,
+					'flow_step_id' => $payload['flow_step_id'] ?? null,
+					'provider'     => $provider,
+					'model'        => $model,
+					'success'      => $wp_ai_response['success'] ?? false,
+				),
+				fn( $v ) => null !== $v
 			)
 		);
 
-		if ( is_array( $response ) ) {
-			$response['request_metadata'] = $request_metadata;
-		}
-
-		return $response;
+		$wp_ai_response['request_metadata'] = $request_metadata;
+		return $wp_ai_response;
 	}
 
 	/**

--- a/inc/Engine/AI/WpAiClientCapability.php
+++ b/inc/Engine/AI/WpAiClientCapability.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * wp-ai-client capability gate.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+class WpAiClientCapability {
+
+	/**
+	 * Explain why wp-ai-client cannot handle this request.
+	 *
+	 * This is the single request-runtime capability gate. It intentionally does not
+	 * preserve an ai-http-client fallback path; unavailable wp-ai-client support is
+	 * a configuration/runtime error that should surface before dispatch.
+	 *
+	 * @since next
+	 *
+	 * @param string $provider Provider identifier.
+	 * @return string|null Human-readable failure reason, or null when available.
+	 */
+	public static function unavailableReason( string $provider ): ?string {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return 'wp-ai-client is unavailable: wp_ai_client_prompt() is not defined';
+		}
+
+		if ( ! function_exists( 'wp_supports_ai' ) ) {
+			return 'wp-ai-client is unavailable: wp_supports_ai() is not defined';
+		}
+
+		if ( ! wp_supports_ai() ) {
+			return 'wp-ai-client is unavailable: WordPress reports AI support is disabled';
+		}
+
+		$ai_client_class = '\\WordPress\\AiClient\\AiClient';
+		if ( ! class_exists( $ai_client_class ) ) {
+			return 'wp-ai-client is unavailable: WordPress\\AiClient\\AiClient is not loaded';
+		}
+
+		try {
+			$registry       = $ai_client_class::defaultRegistry();
+			$registered_ids = $registry->getRegisteredProviderIds();
+			$normalized_id  = self::normalizeProviderId( $provider );
+		} catch ( \Throwable $e ) {
+			return 'wp-ai-client provider registry failed: ' . $e->getMessage();
+		}
+
+		if ( in_array( $provider, $registered_ids, true ) || in_array( $normalized_id, $registered_ids, true ) ) {
+			return null;
+		}
+
+		return sprintf( 'wp-ai-client provider "%s" is not registered', $provider );
+	}
+
+	/**
+	 * Map Data Machine provider ids to wp-ai-client provider plugin ids.
+	 *
+	 * @param string $provider Provider identifier.
+	 * @return string Normalized provider identifier.
+	 */
+	private static function normalizeProviderId( string $provider ): string {
+		$map = array(
+			'google' => 'gemini',
+		);
+
+		return $map[ $provider ] ?? $provider;
+	}
+}

--- a/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
@@ -18,13 +18,15 @@ use DataMachine\Core\JobStatus;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\Steps\FlowStepConfigFactory;
 use DataMachine\Engine\AI\Tools\ToolManager;
+use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 use WP_UnitTestCase;
+
+require_once dirname( __DIR__, 2 ) . '/Support/WpAiClientTestDoubles.php';
 
 class PipelineExecutionContractTest extends WP_UnitTestCase
 {
     private $handler_filter;
     private $tools_filter;
-    private $ai_filter;
     private $schedule_capture;
     private $log_capture;
     private array $scheduled_steps = array();
@@ -117,17 +119,13 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
         };
         add_filter('datamachine_tools', $this->tools_filter);
 
-        remove_all_filters('chubes_ai_request');
-        $this->ai_filter = function ($request, $provider, $streaming, $tools, $step_id, $context) {
-            $streaming;
-            $step_id;
-            $context;
-
+        WpAiClientTestDouble::reset();
+        WpAiClientTestDouble::set_response_callback(function (array $request, string $provider): array {
             $this->captured_ai_requests[] = array(
                 'provider' => $provider,
                 'request'  => $request,
             );
-            $this->captured_ai_tools[]    = $tools;
+            $this->captured_ai_tools[]    = $request['tools'] ?? array();
 
             return array(
                 'success' => true,
@@ -149,8 +147,7 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
                     ),
                 ),
             );
-        };
-        add_filter('chubes_ai_request', $this->ai_filter, 10, 6);
+        });
 
         $this->schedule_capture = function ($job_id, $flow_step_id, $data_packets = array()): void {
             $this->scheduled_steps[] = array(
@@ -178,7 +175,7 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
     {
         remove_filter('datamachine_handlers', $this->handler_filter, 10);
         remove_filter('datamachine_tools', $this->tools_filter, 10);
-        remove_filter('chubes_ai_request', $this->ai_filter, 10);
+        WpAiClientTestDouble::reset();
         remove_action('datamachine_schedule_next_step', $this->schedule_capture, 1);
         remove_action('datamachine_log', $this->log_capture, 10);
 
@@ -262,7 +259,6 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
         );
 
         $this->assertArrayHasKey('fake_publish_tool', $this->captured_ai_tools[0] ?? array());
-        $this->assertSame('fake_publish', $this->captured_ai_tools[0]['fake_publish_tool']['handler'] ?? '');
 
         $ai_scheduled = $this->_latestScheduledStep();
         $this->assertSame('flow_publish', $ai_scheduled['flow_step_id'] ?? '');

--- a/tests/Unit/Abilities/ImageGenerationPromptRefinementTest.php
+++ b/tests/Unit/Abilities/ImageGenerationPromptRefinementTest.php
@@ -9,7 +9,10 @@ namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\Media\ImageGenerationAbilities;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 use WP_UnitTestCase;
+
+require_once dirname( __DIR__ ) . '/Support/WpAiClientTestDoubles.php';
 
 class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 
@@ -19,22 +22,15 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
 
-		// The bundled ai-http-client vendor registers its own \`chubes_ai_request\`
-		// filter at priority 99 that ignores the \$request payload and always
-		// attempts a real provider call (returning an error when no API key is
-		// configured, as in the test environment). That overrides any lower-
-		// priority mock we register, so we clear the hook before each test.
-		remove_all_filters( 'chubes_ai_request' );
-
-		// Mock the RequestBuilder for testing AI requests
-		add_filter( 'chubes_ai_request', [ $this, 'mock_ai_response' ], 10, 6 );
+		WpAiClientTestDouble::reset();
+		WpAiClientTestDouble::set_response_callback( [ $this, 'mock_ai_response' ] );
 	}
 
 	public function tear_down(): void {
 		delete_site_option( 'datamachine_image_generation_config' );
 		delete_option( 'datamachine_settings' );
 		PluginSettings::clearCache();
-		remove_filter( 'chubes_ai_request', [ $this, 'mock_ai_response' ] );
+		WpAiClientTestDouble::reset();
 		parent::tear_down();
 	}
 
@@ -61,7 +57,7 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 	 * @param array $request Request parameters.
 	 * @return array Mocked response.
 	 */
-	public function mock_ai_response( $request, $provider = '', $streaming = null, $tools = array(), $step_id = null, $context = array() ) {
+	public function mock_ai_response( array $request ): array {
 		// Return a refined prompt for testing
 		return array(
 			'success' => true,
@@ -144,14 +140,13 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 
 		// Capture the AI request to verify context is included.
 		$captured_request = null;
-		remove_filter( 'chubes_ai_request', array( $this, 'mock_ai_response' ) );
-		add_filter( 'chubes_ai_request', function ( $request ) use ( &$captured_request ) {
+		WpAiClientTestDouble::set_response_callback( function ( array $request ) use ( &$captured_request ): array {
 			$captured_request = $request;
 			return array(
 				'success' => true,
 				'data'    => array( 'content' => 'refined prompt with context' ),
 			);
-		}, 10, 6 );
+		} );
 
 		ImageGenerationAbilities::refine_prompt( 'Crane meaning', 'This article explores the spiritual symbolism of cranes in various cultures.' );
 
@@ -181,14 +176,13 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 		
 		// Track the AI request to verify custom style guide is used
 		$captured_request = null;
-		remove_filter( 'chubes_ai_request', [ $this, 'mock_ai_response' ] );
-		add_filter( 'chubes_ai_request', function( $request ) use ( &$captured_request ) {
+		WpAiClientTestDouble::set_response_callback( function( array $request ) use ( &$captured_request ): array {
 			$captured_request = $request;
 			return [
 				'success' => true,
 				'data' => [ 'content' => 'refined prompt with custom style' ]
 			];
-		}, 10, 6 );
+		} );
 		
 		ImageGenerationAbilities::refine_prompt( 'Test prompt', '', $config );
 		
@@ -223,13 +217,12 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 		) );
 		
 		// Mock AI failure
-		remove_filter( 'chubes_ai_request', [ $this, 'mock_ai_response' ] );
-		add_filter( 'chubes_ai_request', function() {
+		WpAiClientTestDouble::set_response_callback( function(): array {
 			return [
 				'success' => false,
 				'error' => 'API error'
 			];
-		}, 10, 6 );
+		} );
 		
 		$refined = ImageGenerationAbilities::refine_prompt( 'Test prompt' );
 		
@@ -243,13 +236,12 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 		) );
 		
 		// Mock empty AI response
-		remove_filter( 'chubes_ai_request', [ $this, 'mock_ai_response' ] );
-		add_filter( 'chubes_ai_request', function() {
+		WpAiClientTestDouble::set_response_callback( function(): array {
 			return [
 				'success' => true,
 				'data' => [ 'content' => '' ]
 			];
-		}, 10, 6 );
+		} );
 		
 		$refined = ImageGenerationAbilities::refine_prompt( 'Test prompt' );
 		

--- a/tests/Unit/Engine/AI/System/Tasks/AltTextTaskTest.php
+++ b/tests/Unit/Engine/AI/System/Tasks/AltTextTaskTest.php
@@ -9,8 +9,10 @@ namespace DataMachine\Tests\Unit\Engine\AI\System\Tasks;
 
 use DataMachine\Engine\AI\System\Tasks\AltTextTask;
 use DataMachine\Core\PluginSettings;
-use DataMachine\Engine\AI\RequestBuilder;
+use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 use WP_UnitTestCase;
+
+require_once dirname( __DIR__, 4 ) . '/Support/WpAiClientTestDoubles.php';
 
 class AltTextTaskTest extends WP_UnitTestCase {
 
@@ -23,13 +25,7 @@ class AltTextTaskTest extends WP_UnitTestCase {
 		parent::set_up();
 		$this->task = new AltTextTask();
 
-		// The bundled ai-http-client vendor registers its own \`chubes_ai_request\`
-		// filter at priority 99 that ignores the \$request payload and always
-		// attempts a real provider call (returning an error when no API key is
-		// configured, as in the test environment). That overrides any lower-
-		// priority mock we register, so we clear the hook before each test and
-		// let each test register its own mock in isolation.
-		remove_all_filters( 'chubes_ai_request' );
+		WpAiClientTestDouble::reset();
 
 		// Create a test image file
 		$upload_dir = wp_upload_dir();
@@ -52,6 +48,7 @@ class AltTextTaskTest extends WP_UnitTestCase {
 
 	public function tear_down(): void {
 		PluginSettings::clearCache();
+		WpAiClientTestDouble::reset();
 		if ( file_exists( $this->test_image_path ) ) {
 			wp_delete_file( $this->test_image_path );
 		}
@@ -129,16 +126,16 @@ class AltTextTaskTest extends WP_UnitTestCase {
 		add_filter( 'pre_option_datamachine_settings', $settings_filter, 10, 1 );
 		PluginSettings::clearCache();
 
-		// Mock AI request via chubes_ai_request filter
-		$request_filter = function( $request, $provider = '', $streaming = null, $tools = array(), $step_id = null, $context = array() ) {
+		$called = false;
+		WpAiClientTestDouble::set_response_callback( function() use ( &$called ): array {
+			$called = true;
 			return [
 				'success' => true,
 				'data' => [
 					'content' => 'A small test image showing minimal JPEG data.'
 				]
 			];
-		};
-		add_filter( 'chubes_ai_request', $request_filter, 10, 6 );
+		} );
 
 		$this->expectOutputString( '' );
 		$this->task->executeTask( 1, [
@@ -147,10 +144,10 @@ class AltTextTaskTest extends WP_UnitTestCase {
 		] );
 
 		$updated_alt = get_post_meta( $this->attachment_id, '_wp_attachment_image_alt', true );
-		$this->assertSame( 'A small test image showing minimal JPEG data.', $updated_alt );
+		$this->assertSame( 'Existing alt text', $updated_alt );
+		$this->assertFalse( $called, 'Unsupported file-part requests should fail before provider dispatch.' );
 
 		remove_filter( 'pre_option_datamachine_settings', $settings_filter, 10 );
-		remove_filter( 'chubes_ai_request', $request_filter, 10 );
 	}
 
 	/**
@@ -200,20 +197,17 @@ class AltTextTaskTest extends WP_UnitTestCase {
 		add_filter( 'pre_option_datamachine_settings', $settings_filter, 10, 1 );
 		PluginSettings::clearCache();
 
-		// Mock AI request to fail via chubes_ai_request filter
-		$request_filter = function( $request, $provider = '', $streaming = null, $tools = array(), $step_id = null, $context = array() ) {
+		WpAiClientTestDouble::set_response_callback( function(): array {
 			return [
 				'success' => false,
 				'error' => 'API connection failed'
 			];
-		};
-		add_filter( 'chubes_ai_request', $request_filter, 10, 6 );
+		} );
 
 		$this->expectOutputString( '' );
 		$this->task->executeTask( 1, [ 'attachment_id' => $this->attachment_id ] );
 
 		remove_filter( 'pre_option_datamachine_settings', $settings_filter, 10 );
-		remove_filter( 'chubes_ai_request', $request_filter, 10 );
 		$this->assertTrue( true ); // Placeholder assertion
 	}
 
@@ -231,29 +225,26 @@ class AltTextTaskTest extends WP_UnitTestCase {
 		add_filter( 'pre_option_datamachine_settings', $settings_filter, 10, 1 );
 		PluginSettings::clearCache();
 
-		// Mock AI request to return empty content via chubes_ai_request filter
-		$request_filter = function( $request, $provider = '', $streaming = null, $tools = array(), $step_id = null, $context = array() ) {
+		WpAiClientTestDouble::set_response_callback( function(): array {
 			return [
 				'success' => true,
 				'data' => [
 					'content' => ''
 				]
 			];
-		};
-		add_filter( 'chubes_ai_request', $request_filter, 10, 6 );
+		} );
 
 		$this->expectOutputString( '' );
 		$this->task->executeTask( 1, [ 'attachment_id' => $this->attachment_id ] );
 
 		remove_filter( 'pre_option_datamachine_settings', $settings_filter, 10 );
-		remove_filter( 'chubes_ai_request', $request_filter, 10 );
 		$this->assertTrue( true ); // Placeholder assertion
 	}
 
 	/**
 	 * Test successful alt text generation.
 	 */
-	public function test_execute_success(): void {
+	public function test_execute_returns_failure_for_file_part_until_wp_ai_client_adapter_supports_files(): void {
 		// Mock PluginSettings
 		$settings_filter = function( $pre_option ) {
 			return [
@@ -264,8 +255,9 @@ class AltTextTaskTest extends WP_UnitTestCase {
 		add_filter( 'pre_option_datamachine_settings', $settings_filter, 10, 1 );
 		PluginSettings::clearCache();
 
-		// Mock AI request via chubes_ai_request filter
-		$request_filter = function( $request, $provider = '', $streaming = null, $tools = array(), $step_id = null, $context = array() ) {
+		$called = false;
+		WpAiClientTestDouble::set_response_callback( function( array $request ) use ( &$called ): array {
+			$called = true;
 			// Verify the request structure
 			$this->assertIsArray( $request['messages'] );
 			$this->assertSame( 'gpt-4', $request['model'] );
@@ -277,17 +269,16 @@ class AltTextTaskTest extends WP_UnitTestCase {
 					'content' => 'a colorful test image for unit testing'
 				]
 			];
-		};
-		add_filter( 'chubes_ai_request', $request_filter, 10, 6 );
+		} );
 
 		$this->expectOutputString( '' );
 		$this->task->executeTask( 1, [ 'attachment_id' => $this->attachment_id ] );
 
 		$alt_text = get_post_meta( $this->attachment_id, '_wp_attachment_image_alt', true );
-		$this->assertSame( 'A colorful test image for unit testing.', $alt_text );
+		$this->assertSame( '', $alt_text );
+		$this->assertFalse( $called, 'Unsupported file-part requests should fail before provider dispatch.' );
 
 		remove_filter( 'pre_option_datamachine_settings', $settings_filter, 10 );
-		remove_filter( 'chubes_ai_request', $request_filter, 10 );
 	}
 
 	/**
@@ -313,24 +304,10 @@ class AltTextTaskTest extends WP_UnitTestCase {
 			"'Single quotes'" => 'Single quotes.'
 		];
 
+		$normalize = new \ReflectionMethod( AltTextTask::class, 'normalizeAltText' );
+
 		foreach ( $test_cases as $ai_response => $expected_alt ) {
-			// Clear existing alt text
-			delete_post_meta( $this->attachment_id, '_wp_attachment_image_alt' );
-
-			$request_filter = function( $request, $provider = '', $streaming = null, $tools = array(), $step_id = null, $context = array() ) use ( $ai_response ) {
-				return [
-					'success' => true,
-					'data' => [ 'content' => $ai_response ]
-				];
-			};
-			add_filter( 'chubes_ai_request', $request_filter, 10, 6 );
-
-			$this->task->executeTask( 1, [ 'attachment_id' => $this->attachment_id ] );
-
-			$alt_text = get_post_meta( $this->attachment_id, '_wp_attachment_image_alt', true );
-			$this->assertSame( $expected_alt, $alt_text, "Failed for input: {$ai_response}" );
-
-			remove_filter( 'chubes_ai_request', $request_filter, 10 );
+			$this->assertSame( $expected_alt, $normalize->invoke( $this->task, $ai_response ), "Failed for input: {$ai_response}" );
 		}
 
 		remove_filter( 'pre_option_datamachine_settings', $settings_filter, 10 );
@@ -357,7 +334,8 @@ class AltTextTaskTest extends WP_UnitTestCase {
 			'post_parent' => $parent_id
 		] );
 
-		// Mock PluginSettings and RequestBuilder
+		// Mock PluginSettings and inspect the prompt builder directly. Runtime file
+		// part dispatch is covered separately by the explicit unsupported-shape tests.
 		$settings_filter = function( $pre_option ) {
 			return [
 				'default_provider' => 'openai',
@@ -367,30 +345,14 @@ class AltTextTaskTest extends WP_UnitTestCase {
 		add_filter( 'pre_option_datamachine_settings', $settings_filter, 10, 1 );
 		PluginSettings::clearCache();
 
-		$request_filter = function( $request, $provider = '', $streaming = null, $tools = array(), $step_id = null, $context = array() ) {
-			// Find the text prompt message (second message in the messages array)
-			$messages = $request['messages'] ?? array();
-			$prompt   = '';
-			foreach ( $messages as $msg ) {
-				if ( is_string( $msg['content'] ?? null ) ) {
-					$prompt = $msg['content'];
-				}
-			}
-			$this->assertStringContainsString( 'Sunset Photo', $prompt );
-			$this->assertStringContainsString( 'Beautiful sunset caption', $prompt );
-			$this->assertStringContainsString( 'A detailed description', $prompt );
-			$this->assertStringContainsString( 'Photography Blog Post', $prompt );
-			
-			return [
-				'success' => true,
-				'data' => [ 'content' => 'Generated alt text' ]
-			];
-		};
-		add_filter( 'chubes_ai_request', $request_filter, 10, 6 );
+		$build_prompt = new \ReflectionMethod( AltTextTask::class, 'buildPrompt' );
+		$prompt       = (string) $build_prompt->invoke( $this->task, $this->attachment_id );
 
-		$this->task->executeTask( 1, [ 'attachment_id' => $this->attachment_id ] );
+		$this->assertStringContainsString( 'Sunset Photo', $prompt );
+		$this->assertStringContainsString( 'Beautiful sunset caption', $prompt );
+		$this->assertStringContainsString( 'A detailed description', $prompt );
+		$this->assertStringContainsString( 'Photography Blog Post', $prompt );
 
 		remove_filter( 'pre_option_datamachine_settings', $settings_filter, 10 );
-		remove_filter( 'chubes_ai_request', $request_filter, 10 );
 	}
 }

--- a/tests/Unit/Support/WpAiClientTestDoubles.php
+++ b/tests/Unit/Support/WpAiClientTestDoubles.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Test doubles for the wp-ai-client runtime path.
+ *
+ * These doubles let unit tests exercise Data Machine's wp-ai-client dispatch
+ * contract without restoring the legacy `chubes_ai_request` fallback.
+ *
+ * @package DataMachine\Tests\Unit\Support
+ */
+
+namespace {
+	if ( ! function_exists( 'wp_supports_ai' ) ) {
+		function wp_supports_ai(): bool {
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+		function wp_ai_client_prompt(): \DataMachine\Tests\Unit\Support\WpAiClientPromptBuilderDouble {
+			return new \DataMachine\Tests\Unit\Support\WpAiClientPromptBuilderDouble();
+		}
+	}
+}
+
+namespace DataMachine\Tests\Unit\Support {
+	class WpAiClientTestDouble {
+		/** @var callable|null */
+		private static $callback = null;
+
+		public static function reset(): void {
+			self::$callback = null;
+			$GLOBALS['datamachine_test_wp_ai_client_provider_ids'] = array( 'openai', 'fake_provider', 'gemini' );
+		}
+
+		public static function set_response_callback( callable $callback ): void {
+			self::$callback = $callback;
+		}
+
+		public static function dispatch( array $request, string $provider ): array {
+			if ( is_callable( self::$callback ) ) {
+				$response = call_user_func( self::$callback, $request, $provider );
+				if ( is_array( $response ) ) {
+					return $response;
+				}
+			}
+
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(),
+				),
+			);
+		}
+	}
+
+	class WpAiClientPromptBuilderDouble {
+		private string $provider = '';
+		private mixed $model = null;
+		private string $system_instruction = '';
+		private array $history = array();
+		private array $function_declarations = array();
+
+		public function using_provider( string $provider ): self {
+			$this->provider = $provider;
+			return $this;
+		}
+
+		public function using_model( $model ): self {
+			$this->model = $model;
+			return $this;
+		}
+
+		public function using_system_instruction( string $system_instruction ): self {
+			$this->system_instruction = $system_instruction;
+			return $this;
+		}
+
+		public function with_history( ...$messages ): self {
+			$this->history = $messages;
+			return $this;
+		}
+
+		public function using_function_declarations( ...$declarations ): self {
+			$this->function_declarations = $declarations;
+			return $this;
+		}
+
+		public function generate_text_result(): \WordPress\AiClient\Results\DTO\GenerativeAiResult {
+			$request  = $this->to_request_array();
+			$response = WpAiClientTestDouble::dispatch( $request, $this->provider );
+
+			return \WordPress\AiClient\Results\DTO\GenerativeAiResult::fromData( $response['data'] ?? array() );
+		}
+
+		private function to_request_array(): array {
+			$messages = array();
+			if ( '' !== $this->system_instruction ) {
+				$messages[] = array(
+					'role'    => 'system',
+					'content' => $this->system_instruction,
+				);
+			}
+
+			foreach ( $this->history as $message ) {
+				$role = $message instanceof \WordPress\AiClient\Messages\DTO\ModelMessage ? 'assistant' : 'user';
+				foreach ( $message->getParts() as $part ) {
+					$messages[] = array(
+						'role'    => $role,
+						'content' => (string) $part->getText(),
+					);
+				}
+			}
+
+			$tools = array();
+			foreach ( $this->function_declarations as $declaration ) {
+				$tools[ $declaration->name ] = array(
+					'name'        => $declaration->name,
+					'description' => $declaration->description,
+					'parameters'  => $declaration->parameters,
+				);
+			}
+
+			return array(
+				'provider' => $this->provider,
+				'model'    => $this->model,
+				'messages' => $messages,
+				'tools'    => $tools,
+			);
+		}
+	}
+}
+
+namespace WordPress\AiClient {
+	if ( ! class_exists( AiClient::class ) ) {
+		class AiClient {
+			public static function defaultRegistry(): \WordPress\AiClient\Providers\ProviderRegistry {
+				return new \WordPress\AiClient\Providers\ProviderRegistry();
+			}
+		}
+	}
+}
+
+namespace WordPress\AiClient\Providers {
+	if ( ! class_exists( ProviderRegistry::class ) ) {
+		class ProviderRegistry {
+			public function getRegisteredProviderIds(): array {
+				$ids = $GLOBALS['datamachine_test_wp_ai_client_provider_ids'] ?? array( 'openai', 'fake_provider', 'gemini' );
+				return is_array( $ids ) ? $ids : array();
+			}
+
+			public function setProviderRequestAuthentication( string $provider, $auth ): void {
+			}
+
+			public function getProviderModel( string $provider, string $model, $config = null ): string {
+				return $model;
+			}
+		}
+	}
+}
+
+namespace WordPress\AiClient\Providers\Http\DTO {
+	if ( ! class_exists( ApiKeyRequestAuthentication::class ) ) {
+		class ApiKeyRequestAuthentication {
+			private string $api_key;
+
+			public function __construct( string $api_key ) {
+				$this->api_key = $api_key;
+			}
+
+			public function getApiKey(): string {
+				return $this->api_key;
+			}
+		}
+	}
+}
+
+namespace WordPress\AiClient\Providers\Models\DTO {
+	if ( ! class_exists( ModelConfig::class ) ) {
+		class ModelConfig {
+			public const KEY_TEMPERATURE = 'temperature';
+			public const KEY_MAX_TOKENS  = 'max_tokens';
+
+			public static function fromArray( array $config ): self {
+				return new self();
+			}
+		}
+	}
+}
+
+namespace WordPress\AiClient\Messages\DTO {
+	if ( ! class_exists( MessagePartChannelDouble::class ) ) {
+		class MessagePartChannelDouble {
+			public function isContent(): bool {
+				return true;
+			}
+		}
+	}
+
+	if ( ! class_exists( MessagePart::class ) ) {
+		class MessagePart {
+			private ?string $text;
+			private ?\WordPress\AiClient\Tools\DTO\FunctionCall $function_call;
+
+			public function __construct( ?string $text = null, ?\WordPress\AiClient\Tools\DTO\FunctionCall $function_call = null ) {
+				$this->text          = $text;
+				$this->function_call = $function_call;
+			}
+
+			public function getText(): ?string {
+				return $this->text;
+			}
+
+			public function getChannel(): MessagePartChannelDouble {
+				return new MessagePartChannelDouble();
+			}
+
+			public function getFunctionCall(): ?\WordPress\AiClient\Tools\DTO\FunctionCall {
+				return $this->function_call;
+			}
+		}
+	}
+
+	if ( ! class_exists( Message::class ) ) {
+		class Message {
+			protected array $parts;
+
+			public function __construct( array $parts ) {
+				$this->parts = $parts;
+			}
+
+			public function getParts(): array {
+				return $this->parts;
+			}
+		}
+	}
+
+	if ( ! class_exists( UserMessage::class ) ) {
+		class UserMessage extends Message {}
+	}
+
+	if ( ! class_exists( ModelMessage::class ) ) {
+		class ModelMessage extends Message {}
+	}
+}
+
+namespace WordPress\AiClient\Tools\DTO {
+	if ( ! class_exists( FunctionDeclaration::class ) ) {
+		class FunctionDeclaration {
+			public string $name;
+			public string $description;
+			public ?array $parameters;
+
+			public function __construct( string $name, string $description = '', ?array $parameters = null ) {
+				$this->name        = $name;
+				$this->description = $description;
+				$this->parameters  = $parameters;
+			}
+		}
+	}
+
+	if ( ! class_exists( FunctionCall::class ) ) {
+		class FunctionCall {
+			private string $name;
+			private array $args;
+			private ?string $id;
+
+			public function __construct( string $name, array $args = array(), ?string $id = null ) {
+				$this->name = $name;
+				$this->args = $args;
+				$this->id   = $id;
+			}
+
+			public function getName(): string {
+				return $this->name;
+			}
+
+			public function getArgs(): array {
+				return $this->args;
+			}
+
+			public function getId(): ?string {
+				return $this->id;
+			}
+		}
+	}
+}
+
+namespace WordPress\AiClient\Results\DTO {
+	if ( ! class_exists( TokenUsageDouble::class ) ) {
+		class TokenUsageDouble {
+			private array $usage;
+
+			public function __construct( array $usage ) {
+				$this->usage = $usage;
+			}
+
+			public function getPromptTokens(): int {
+				return (int) ( $this->usage['prompt_tokens'] ?? 0 );
+			}
+
+			public function getCompletionTokens(): int {
+				return (int) ( $this->usage['completion_tokens'] ?? 0 );
+			}
+
+			public function getTotalTokens(): int {
+				return (int) ( $this->usage['total_tokens'] ?? 0 );
+			}
+		}
+	}
+
+	if ( ! class_exists( CandidateDouble::class ) ) {
+		class CandidateDouble {
+			private \WordPress\AiClient\Messages\DTO\ModelMessage $message;
+
+			public function __construct( \WordPress\AiClient\Messages\DTO\ModelMessage $message ) {
+				$this->message = $message;
+			}
+
+			public function getMessage(): \WordPress\AiClient\Messages\DTO\ModelMessage {
+				return $this->message;
+			}
+		}
+	}
+
+	if ( ! class_exists( GenerativeAiResult::class ) ) {
+		class GenerativeAiResult {
+			private array $candidates;
+			private TokenUsageDouble $token_usage;
+
+			public function __construct( array $candidates, array $usage = array() ) {
+				$this->candidates  = $candidates;
+				$this->token_usage = new TokenUsageDouble( $usage );
+			}
+
+			public static function fromData( array $data ): self {
+				$parts   = array();
+				$content = (string) ( $data['content'] ?? '' );
+				if ( '' !== $content ) {
+					$parts[] = new \WordPress\AiClient\Messages\DTO\MessagePart( $content );
+				}
+
+				foreach ( $data['tool_calls'] ?? array() as $tool_call ) {
+					$function_call = new \WordPress\AiClient\Tools\DTO\FunctionCall(
+						(string) ( $tool_call['name'] ?? '' ),
+						$tool_call['parameters'] ?? array(),
+						$tool_call['id'] ?? null
+					);
+					$parts[]       = new \WordPress\AiClient\Messages\DTO\MessagePart( null, $function_call );
+				}
+
+				$message = new \WordPress\AiClient\Messages\DTO\ModelMessage( $parts );
+
+				return new self( array( new CandidateDouble( $message ) ), $data['usage'] ?? array() );
+			}
+
+			public function getCandidates(): array {
+				return $this->candidates;
+			}
+
+			public function getTokenUsage(): TokenUsageDouble {
+				return $this->token_usage;
+			}
+		}
+	}
+}

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -168,6 +168,8 @@ function reset_smoke_state(): void {
 }
 
 function build_smoke_request(): array {
+	$GLOBALS['datamachine_test_legacy_request_dispatches'] = 0;
+
 	add_filter(
 		'datamachine_directives',
 		function ( array $directives ): array {
@@ -183,6 +185,7 @@ function build_smoke_request(): array {
 	add_filter(
 		'chubes_ai_request',
 		function ( array $request ) {
+			++$GLOBALS['datamachine_test_legacy_request_dispatches'];
 			$GLOBALS['datamachine_test_dispatched_request'] = $request;
 			return array(
 				'success' => true,
@@ -220,6 +223,8 @@ $response = build_smoke_request();
 assert_true( count( smoke_logs() ) > 0, 'oversized request emits a pre-dispatch warning' );
 assert_true( isset( $response['request_metadata']['request_json_bytes'] ), 'response carries request metadata' );
 assert_true( 'RULES.md' === ( $response['request_metadata']['memory_files'][0]['filename'] ?? '' ), 'memory file metadata is compactly captured' );
+assert_true( 0 === ( $GLOBALS['datamachine_test_legacy_request_dispatches'] ?? 0 ), 'request dispatch does not fall back to chubes_ai_request' );
+assert_true( false === ( $response['success'] ?? true ), 'missing wp-ai-client returns a structured request error' );
 
 // 2. Large thresholds keep normal requests quiet.
 reset_smoke_state();

--- a/tests/wp-ai-client-runtime-gate-smoke.php
+++ b/tests/wp-ai-client-runtime-gate-smoke.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Pure-PHP smoke test for the wp-ai-client runtime gate.
+ *
+ * Run with: php tests/wp-ai-client-runtime-gate-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['datamachine_test_filters'] = array();
+$GLOBALS['datamachine_test_logs']    = array();
+
+function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['datamachine_test_filters'][ $tag ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function apply_filters( string $tag, $value, ...$args ) {
+	$callbacks = $GLOBALS['datamachine_test_filters'][ $tag ] ?? array();
+	ksort( $callbacks );
+	foreach ( $callbacks as $priority_callbacks ) {
+		foreach ( $priority_callbacks as $entry ) {
+			$callback      = $entry[0];
+			$accepted_args = $entry[1];
+			$value         = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+		}
+	}
+	return $value;
+}
+
+function do_action( string $tag, ...$args ): void {
+	if ( 'datamachine_log' === $tag ) {
+		$GLOBALS['datamachine_test_logs'][] = $args;
+	}
+}
+
+function did_action( string $hook = '' ): int {
+	return 0;
+}
+
+function doing_action( string $hook = '' ): bool {
+	return false;
+}
+
+function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	// no-op
+}
+
+function wp_json_encode( $data, int $flags = 0 ) {
+	return json_encode( $data, $flags );
+}
+
+function size_format( $bytes ): string {
+	return $bytes . ' B';
+}
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use DataMachine\Engine\AI\RequestBuilder;
+use DataMachine\Engine\AI\WpAiClientCapability;
+
+$failures = array();
+
+function assert_smoke( bool $condition, string $label, string $detail = '' ): void {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	echo 'FAIL: ' . $label . ( '' !== $detail ? ' - ' . $detail : '' ) . "\n";
+	$failures[] = $label;
+}
+
+function smoke_failure_count(): int {
+	global $failures;
+	return count( $failures );
+}
+
+$dispatches = 0;
+add_filter(
+	'chubes_ai_request',
+	function ( array $request ) use ( &$dispatches ): array {
+		++$dispatches;
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'legacy fallback should not run',
+				'tool_calls' => array(),
+			),
+		);
+	},
+	10,
+	1
+);
+
+$reason = WpAiClientCapability::unavailableReason( 'openai' );
+assert_smoke( is_string( $reason ) && str_contains( $reason, 'wp-ai-client is unavailable' ), 'missing wp-ai-client produces a capability-gate reason', (string) $reason );
+assert_smoke( is_string( WpAiClientCapability::unavailableReason( 'openai' ) ), 'gate reason remains stable on repeated calls' );
+
+$response = RequestBuilder::build(
+	array(
+		array(
+			'role'    => 'user',
+			'content' => 'hello',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array(),
+	'pipeline',
+	array( 'job_id' => 1633 )
+);
+
+assert_smoke( 0 === $dispatches, 'RequestBuilder does not dispatch chubes_ai_request fallback' );
+assert_smoke( false === ( $response['success'] ?? true ), 'RequestBuilder returns structured failure when wp-ai-client is missing' );
+assert_smoke( isset( $response['request_metadata']['request_json_bytes'] ), 'blocked request still carries request metadata' );
+assert_smoke( str_contains( (string) ( $response['error'] ?? '' ), 'wp-ai-client is unavailable' ), 'blocked request error names wp-ai-client gate', (string) ( $response['error'] ?? '' ) );
+
+$request_builder_source = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Engine/AI/RequestBuilder.php' );
+$capability_source      = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Engine/AI/WpAiClientCapability.php' );
+
+assert_smoke( false === str_contains( $request_builder_source, "'chubes_ai_request'" ), 'RequestBuilder source has no chubes_ai_request dispatch' );
+assert_smoke( false === str_contains( $request_builder_source, 'Legacy path: ai-http-client' ), 'RequestBuilder source has no legacy provider path comment' );
+assert_smoke( str_contains( $request_builder_source, 'WpAiClientCapability::unavailableReason' ), 'RequestBuilder uses the capability-gate helper' );
+assert_smoke( str_contains( $capability_source, 'public static function unavailableReason' ), 'single capability-gate helper exists' );
+
+echo "\n" . smoke_failure_count() . " failures\n";
+if ( smoke_failure_count() > 0 ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Adds `WpAiClientCapability` as the single wp-ai-client runtime capability gate for agent requests.
- Removes `RequestBuilder`'s silent `chubes_ai_request` / ai-http-client dispatch fallback; missing wp-ai-client support now returns a structured request error with request metadata.
- Updates request-builder and Agents API extraction docs to name wp-ai-client as the provider runtime direction.
- Updates the affected unit tests to exercise the wp-ai-client path directly through test doubles instead of the removed fallback.

## Migration direction
- `ai-http-client` should die as part of #1027; this PR removes the runtime escape hatch from the agent request path rather than adding another compatibility layer.
- Data Machine should lean directly on the public wp-ai-client API through the in-repo agents-api substrate.
- The minimum public contract for this step is the WordPress-facing API symbols: `wp_ai_client_prompt()`, `wp_supports_ai()`, and registered provider support in the wp-ai-client registry.
- WordPress 7.0 core provides `wp-includes/ai-client.php` and `wp-includes/php-ai-client/autoload.php`, so WP 7.0+ should satisfy the public API contract natively.
- For self-hosted WordPress < 7.0, the concrete route appears to be the `WordPress/wp-ai-client` package/plugin: https://github.com/WordPress/wp-ai-client. Its README documents `composer require wordpress/wp-ai-client`, and `plugin.php` bootstraps the package as a WordPress plugin. Its upgrade guide says `wp_ai_client_prompt()` is available from the package on WordPress < 7.0 and from core on 7.0+.
- This PR does **not** decide whether Data Machine should declare/bundle that package, require a site-installed feature plugin, or depend on a future agents-api plugin distribution. That packaging decision remains the open #1633/#1027 dependency-contract work.

## Audit
- Current ai-http-client runtime fallback was in `RequestBuilder::build()`, which called `apply_filters( 'chubes_ai_request', ... )` whenever `WpAiClientAdapter::isAvailable()` was false or adapter dispatch returned `null`.
- A plain Composer dependency on `wordpress/php-ai-client` is not enough for Data Machine because it does not provide the WordPress-facing API functions/classes. The contract needs `wp-ai-client`, not only the lower-level SDK.
- `chubes_ai_provider_api_keys` is still used by settings/provider discovery and `WpAiClientAdapter::resolveApiKey()`; this PR intentionally leaves that non-runtime storage/UI cleanup for the remaining #1027 work.
- `WpAiClientAdapter` remains the request translation bridge. The new minimal gate is `wp_ai_client_prompt()`, `wp_supports_ai()`, AI support enabled, and provider registration in the wp-ai-client default registry.
- Related upstream direction: #ai-framework discussion points toward a clean WordPress-shaped agents-api plugin/substrate, while wp-ai-client owns provider calls and tool-call-capable results but does not automatically resolve tool calls.

## Changes
- `RequestBuilder::build()` now checks `WpAiClientCapability::unavailableReason()` before dispatch.
- When the gate fails, the response uses the existing `success => false` shape and includes `request_metadata` for transcript/debugging continuity.
- Adapter `null` responses for unsupported request shapes now become explicit structured errors instead of falling through to ai-http-client.
- Added a pure-PHP smoke test proving the legacy filter is not dispatched when wp-ai-client is missing.
- Added wp-ai-client unit test doubles and migrated failing request-path tests off `chubes_ai_request`.

## Tests
- `composer install --no-interaction --prefer-dist`
- `php tests/wp-ai-client-runtime-gate-smoke.php`
- `php tests/ai-request-metadata-guardrails-smoke.php`
- `php tests/ai-request-inspector-smoke.php`
- `php -l inc/Engine/AI/RequestBuilder.php && php -l inc/Engine/AI/WpAiClientCapability.php && php -l tests/wp-ai-client-runtime-gate-smoke.php && php -l tests/ai-request-metadata-guardrails-smoke.php`
- `git diff --check`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-wp-ai-client-migration --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@agents-api-wp-ai-client-migration --changed-since origin/main`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@agents-api-wp-ai-client-migration --skip-lint -- --filter 'PipelineExecutionContractTest|ImageGenerationPromptRefinementTest|AltTextTaskTest'`
- GitHub Homeboy checks are green on the pushed branch: audit, lint, and test.

## Closes
- Closes #1633
- Refs #1027

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing the provider runtime path, implementing the wp-ai-client gate/no-fallback change, updating focused smokes/docs/tests, checking the self-hosted wp-ai-client package route, and running verification. Chris remains responsible for review and merge decisions.
