### PR TITLE
test(agent): add tool substrate boundary smoke

### DIFF
--- a/tests/runtime-tool-declaration-smoke.php
+++ b/tests/runtime-tool-declaration-smoke.php
@@ -19,6 +19,39 @@ function datamachine_runtime_tool_assert( bool $condition, string $message ): vo
 
 $assertions = 0;
 
+$runtime_tool_file = dirname( __DIR__ ) . '/agents-api/inc/Engine/AI/Tools/RuntimeToolDeclaration.php';
+$legacy_tool_file  = dirname( __DIR__ ) . '/inc/Engine/AI/Tools/RuntimeToolDeclaration.php';
+
+datamachine_runtime_tool_assert(
+	is_file( $runtime_tool_file ),
+	'RuntimeToolDeclaration should live in the in-repo Agents API module.'
+);
+++$assertions;
+datamachine_runtime_tool_assert(
+	! file_exists( $legacy_tool_file ),
+	'RuntimeToolDeclaration should not exist in the Data Machine product tool tree.'
+);
+++$assertions;
+
+$runtime_tool_source = (string) file_get_contents( $runtime_tool_file );
+$forbidden_tokens    = array(
+	'datamachine_tools',
+	'FlowStepConfig',
+	'AdjacentHandlerToolSource',
+	'DataMachineToolRegistrySource',
+	'ToolPolicyResolver',
+	'PendingAction',
+	'post_origin',
+	'handler_slug',
+);
+foreach ( $forbidden_tokens as $token ) {
+	datamachine_runtime_tool_assert(
+		! str_contains( $runtime_tool_source, $token ),
+		'RuntimeToolDeclaration should not mention Data Machine product token: ' . $token
+	);
+	++$assertions;
+}
+
 $valid = array(
 	'name'        => 'client/select_block',
 	'description' => 'Select a block in the active editor.',


### PR DESCRIPTION
## Summary
- Proves the runtime tool declaration contract is loaded from the in-repo Agents API module.
- Pins the boundary so the generic runtime tool declaration cannot drift back into Data Machine product tool vocabulary.

## Changes
- Extends `tests/runtime-tool-declaration-smoke.php` with module-location assertions.
- Adds static guardrails against `datamachine_tools`, handler/pipeline policy adapters, pending actions, and handler slug vocabulary in `RuntimeToolDeclaration`.

## Tests
- `php tests/runtime-tool-declaration-smoke.php`
- `php tests/agents-api-bootstrap-smoke.php`
- `php tests/tool-source-registry-smoke.php`
- `php tests/tool-policy-resolver-adjacency-smoke.php`
- `php tests/tool-executor-ability-native-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-tool-contracts-boundary --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@agents-api-tool-contracts-boundary --changed-since origin/main`

Closes #1636

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added the focused boundary smoke, ran local verification, and drafted this PR description. Chris remains responsible for review and merge.