### PR TITLE
refactor(agent): move transcript contract into agents api module

### DIFF
--- a/agents-api/agents-api.php
+++ b/agents-api/agents-api.php
@@ -20,6 +20,7 @@ define( 'AGENTS_API_PATH', __DIR__ . '/' );
 require_once AGENTS_API_PATH . 'inc/class-wp-agent.php';
 require_once AGENTS_API_PATH . 'inc/class-wp-agents-registry.php';
 require_once AGENTS_API_PATH . 'inc/register-agents.php';
+require_once AGENTS_API_PATH . 'inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php';
 require_once AGENTS_API_PATH . 'inc/Engine/AI/AgentMessageEnvelope.php';
 require_once AGENTS_API_PATH . 'inc/Engine/AI/AgentConversationResult.php';
 require_once AGENTS_API_PATH . 'inc/Engine/AI/Tools/RuntimeToolDeclaration.php';

--- a/agents-api/inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php
+++ b/agents-api/inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Agent conversation transcript persistence contract.
+ *
+ * This is the narrow, generic storage seam for complete conversation
+ * transcripts. It covers session row creation, transcript reads/writes,
+ * deletion, retry deduplication, and the stored display title that belongs
+ * to a transcript row. It deliberately does not include chat UI listing,
+ * read-state, retention scheduling, or reporting/metrics responsibilities.
+ *
+ * The interface keeps its current namespace while the Agents API extraction is
+ * in-place. Conceptually, this is the contract that a future Agents API package
+ * can own; Data Machine's chat product consumes it through its aggregate store
+ * and factory adapters.
+ *
+ * @package AgentsAPI
+ */
+
+namespace DataMachine\Core\Database\Chat;
+
+defined( 'ABSPATH' ) || exit;
+
+interface ConversationTranscriptStoreInterface {
+
+	/**
+	 * Create a new conversation transcript session and return its ID.
+	 *
+	 * @param int    $user_id  WordPress user ID owning the session.
+	 * @param int    $agent_id Agent ID (0 = legacy agent-less session).
+	 * @param array  $metadata Arbitrary session metadata (JSON-serializable).
+	 * @param string $context  Execution mode ('chat', 'pipeline', 'system').
+	 * @return string Session ID (UUIDv4), or empty string on failure.
+	 */
+	public function create_session( int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string;
+
+	/**
+	 * Retrieve a transcript session by ID.
+	 *
+	 * Returns the session as an associative array with keys:
+	 * session_id, user_id, agent_id, title, messages (decoded array),
+	 * metadata (decoded array), provider, model, context/mode, created_at,
+	 * updated_at, last_read_at, expires_at.
+	 *
+	 * @param string $session_id Session UUID.
+	 * @return array|null Session data or null if not found.
+	 */
+	public function get_session( string $session_id ): ?array;
+
+	/**
+	 * Replace a session's messages + metadata.
+	 *
+	 * @param string $session_id Session UUID.
+	 * @param array  $messages   Complete messages array (not a delta).
+	 * @param array  $metadata   Updated metadata.
+	 * @param string $provider   Optional AI provider identifier.
+	 * @param string $model      Optional AI model identifier.
+	 * @return bool True on success.
+	 */
+	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '' ): bool;
+
+	/**
+	 * Delete a session by ID. Idempotent.
+	 *
+	 * @param string $session_id Session UUID.
+	 * @return bool True on success.
+	 */
+	public function delete_session( string $session_id ): bool;
+
+	/**
+	 * Find a recent pending session for deduplication after request timeouts.
+	 *
+	 * Returns the most recent session that belongs to $user_id, was created
+	 * within $seconds, and is either empty or actively processing. Used by
+	 * the orchestrator to avoid duplicate sessions when a timeout triggers a
+	 * client retry while PHP keeps executing.
+	 *
+	 * @param int      $user_id  WordPress user ID.
+	 * @param int      $seconds  Lookback window (default 600 = 10 minutes).
+	 * @param string   $context  Context filter.
+	 * @param int|null $token_id Optional token ID for login-scoped dedup.
+	 * @return array|null Session data or null if none.
+	 */
+	public function get_recent_pending_session( int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array;
+
+	/**
+	 * Set a transcript session's stored display title.
+	 *
+	 * Title generation and UI policy stay above the store. This mutator remains
+	 * here because the persisted title is part of the transcript/session record.
+	 *
+	 * @param string $session_id Session UUID.
+	 * @param string $title      New title.
+	 * @return bool True on success.
+	 */
+	public function update_title( string $session_id, string $title ): bool;
+}

--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -111,7 +111,7 @@ These are closest to generic public contracts. Most should be extracted as contr
 | `AgentMemoryReadResult` | `inc/Core/FilesRepository/AgentMemoryReadResult.php` | Store-neutral read result. | Generic result value object can move unchanged after naming cleanup. |
 | `AgentMemoryWriteResult` | `inc/Core/FilesRepository/AgentMemoryWriteResult.php` | Store-neutral write result with hash/bytes/error shape. | Generic result value object can move unchanged after naming cleanup. |
 | `AgentMemoryListEntry` | `inc/Core/FilesRepository/AgentMemoryListEntry.php` | Store-neutral list entry. | Good candidate if file-backed memory stays in scope. |
-| `ConversationTranscriptStoreInterface` | `inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php` | Transcript CRUD is generic conversation persistence. | First extraction candidate. Rename namespace/vocabulary later; do not require chat UI listing/read-state/reporting for transcript-only backends. |
+| `ConversationTranscriptStoreInterface` | `agents-api/inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php` | Transcript CRUD is generic conversation persistence. | Now lives in the in-repo Agents API module while preserving its namespace for behavior compatibility. Rename namespace/vocabulary later; do not require chat UI listing/read-state/reporting for transcript-only backends. |
 | `ConversationSessionIndexInterface` | `inc/Core/Database/Chat/ConversationSessionIndexInterface.php` | Session listing can be generic for UIs, but it is not required for transcript persistence. | Treat as optional until Agents API adopts an identity/listing model. Data Machine chat switcher uses it today. |
 | `ConversationReadStateInterface` | `inc/Core/Database/Chat/ConversationReadStateInterface.php` | Read-state is generic UI behavior, not transcript CRUD. | Optional interface at most. Data Machine chat unread state keeps consuming it. |
 | `ConversationRetentionInterface` | `inc/Core/Database/Chat/ConversationRetentionInterface.php` | Cleanup methods can be backend-generic, but retention policy/scheduling is product behavior. | Data Machine retention tasks stay product; future Agents API may expose only optional backend cleanup. |
@@ -192,7 +192,7 @@ Conversation storage is split in place, but only the narrow transcript surface i
 
 | Layer | Current surface | Boundary decision |
 |---|---|---|
-| Generic transcript CRUD | `ConversationTranscriptStoreInterface`, `ConversationStoreFactory::get_transcript_store()` | Candidate for Agents API ownership. Runtime persistence should depend on this surface when it only needs complete transcript sessions. |
+| Generic transcript CRUD | `ConversationTranscriptStoreInterface`, `ConversationStoreFactory::get_transcript_store()` | The interface now lives in `agents-api/`; Data Machine's factory remains the product adapter. Runtime persistence should depend on this surface when it only needs complete transcript sessions. |
 | Data Machine compatibility aggregate | `ConversationStoreInterface`, `ConversationStoreFactory::get()`, `datamachine_conversation_store` | Stays in Data Machine for now so chat UI, REST, CLI, retention, and reporting keep one behavior-preserving resolver. |
 | Chat UI/session switcher | `ConversationSessionIndexInterface`, chat REST/abilities/UI callers | Product behavior today. It may become an optional Agents API UI contract later, but transcript-only backends should not implement it by default. |
 | Read state | `ConversationReadStateInterface` | Optional UI behavior. Not part of transcript persistence. |

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -115,7 +115,7 @@ Target shape:
 
 ### 4. Conversation Storage Boundary
 
-The transcript interface is now separated from the aggregate chat-product store. The implementation still lives under `Core\Database\Chat` while extraction is in-place, but the dependency direction is explicit: runtime transcript persistence depends on `ConversationTranscriptStoreInterface`, while Data Machine chat UI/REST/CLI/retention/reporting depend on the broader `ConversationStoreInterface` aggregate.
+The transcript interface is now separated from the aggregate chat-product store. The interface lives in the in-repo `agents-api/` module while preserving its current namespace for behavior compatibility, and the dependency direction is explicit: runtime transcript persistence depends on `ConversationTranscriptStoreInterface`, while Data Machine chat UI/REST/CLI/retention/reporting depend on the broader `ConversationStoreInterface` aggregate.
 
 Target shape:
 

--- a/inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php
+++ b/inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php
@@ -1,97 +1,10 @@
 <?php
 /**
- * Agent conversation transcript persistence contract.
- *
- * This is the narrow, generic storage seam for complete conversation
- * transcripts. It covers session row creation, transcript reads/writes,
- * deletion, retry deduplication, and the stored display title that belongs
- * to a transcript row. It deliberately does not include chat UI listing,
- * read-state, retention scheduling, or reporting/metrics responsibilities.
- *
- * The interface still lives under the Data Machine chat namespace while the
- * Agents API extraction is in-place. Conceptually, this is the contract that
- * a future Agents API package can own; Data Machine's chat product consumes it
- * through {@see ConversationStoreInterface} and {@see ConversationStoreFactory}.
+ * Backward-compatible include path for the Agents API transcript contract.
  *
  * @package DataMachine\Core\Database\Chat
- * @since   next
  */
-
-namespace DataMachine\Core\Database\Chat;
 
 defined( 'ABSPATH' ) || exit;
 
-interface ConversationTranscriptStoreInterface {
-
-	/**
-	 * Create a new conversation transcript session and return its ID.
-	 *
-	 * @param int    $user_id  WordPress user ID owning the session.
-	 * @param int    $agent_id Agent ID (0 = legacy agent-less session).
-	 * @param array  $metadata Arbitrary session metadata (JSON-serializable).
-	 * @param string $context  Execution mode ('chat', 'pipeline', 'system').
-	 * @return string Session ID (UUIDv4), or empty string on failure.
-	 */
-	public function create_session( int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string;
-
-	/**
-	 * Retrieve a transcript session by ID.
-	 *
-	 * Returns the session as an associative array with keys:
-	 * session_id, user_id, agent_id, title, messages (decoded array),
-	 * metadata (decoded array), provider, model, context/mode, created_at,
-	 * updated_at, last_read_at, expires_at.
-	 *
-	 * @param string $session_id Session UUID.
-	 * @return array|null Session data or null if not found.
-	 */
-	public function get_session( string $session_id ): ?array;
-
-	/**
-	 * Replace a session's messages + metadata.
-	 *
-	 * @param string $session_id Session UUID.
-	 * @param array  $messages   Complete messages array (not a delta).
-	 * @param array  $metadata   Updated metadata.
-	 * @param string $provider   Optional AI provider identifier.
-	 * @param string $model      Optional AI model identifier.
-	 * @return bool True on success.
-	 */
-	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '' ): bool;
-
-	/**
-	 * Delete a session by ID. Idempotent.
-	 *
-	 * @param string $session_id Session UUID.
-	 * @return bool True on success.
-	 */
-	public function delete_session( string $session_id ): bool;
-
-	/**
-	 * Find a recent pending session for deduplication after request timeouts.
-	 *
-	 * Returns the most recent session that belongs to $user_id, was created
-	 * within $seconds, and is either empty or actively processing. Used by
-	 * the orchestrator to avoid duplicate sessions when a timeout triggers a
-	 * client retry while PHP keeps executing.
-	 *
-	 * @param int      $user_id  WordPress user ID.
-	 * @param int      $seconds  Lookback window (default 600 = 10 minutes).
-	 * @param string   $context  Context filter.
-	 * @param int|null $token_id Optional token ID for login-scoped dedup.
-	 * @return array|null Session data or null if none.
-	 */
-	public function get_recent_pending_session( int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array;
-
-	/**
-	 * Set a transcript session's stored display title.
-	 *
-	 * Title generation and UI policy stay above the store. This mutator remains
-	 * here because the persisted title is part of the transcript/session record.
-	 *
-	 * @param string $session_id Session UUID.
-	 * @param string $title      New title.
-	 * @return bool True on success.
-	 */
-	public function update_title( string $session_id, string $title ): bool;
-}
+require_once dirname( __DIR__, 4 ) . '/agents-api/inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php';

--- a/tests/agents-api-bootstrap-smoke.php
+++ b/tests/agents-api-bootstrap-smoke.php
@@ -64,6 +64,7 @@ assert_agents_api_equals( true, defined( 'AGENTS_API_LOADED' ), 'module marks it
 assert_agents_api_equals( true, function_exists( 'wp_register_agent' ), 'wp_register_agent helper is available', $failures, $passes );
 assert_agents_api_equals( true, class_exists( 'WP_Agent' ), 'WP_Agent value object is available', $failures, $passes );
 assert_agents_api_equals( true, class_exists( 'WP_Agents_Registry' ), 'WP_Agents_Registry facade is available', $failures, $passes );
+assert_agents_api_equals( true, interface_exists( 'DataMachine\\Core\\Database\\Chat\\ConversationTranscriptStoreInterface' ), 'ConversationTranscriptStoreInterface contract is available', $failures, $passes );
 assert_agents_api_equals( true, class_exists( 'DataMachine\\Engine\\AI\\AgentMessageEnvelope' ), 'AgentMessageEnvelope contract is available', $failures, $passes );
 assert_agents_api_equals( true, class_exists( 'DataMachine\\Engine\\AI\\AgentConversationResult' ), 'AgentConversationResult contract is available', $failures, $passes );
 assert_agents_api_equals( true, class_exists( 'DataMachine\\Engine\\AI\\Tools\\RuntimeToolDeclaration' ), 'RuntimeToolDeclaration contract is available', $failures, $passes );

--- a/tests/agents-api-transcript-store-smoke.php
+++ b/tests/agents-api-transcript-store-smoke.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Agents API transcript store contract boundary.
+ *
+ * Run with: php tests/agents-api-transcript-store-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$GLOBALS['__agents_api_transcript_smoke_actions'] = array();
+
+function sanitize_title( string $value ): string {
+	$value = strtolower( $value );
+	$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+	return trim( (string) $value, '-' );
+}
+
+function sanitize_file_name( string $value ): string {
+	return basename( $value );
+}
+
+function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $accepted_args );
+	$GLOBALS['__agents_api_transcript_smoke_actions'][ $hook ][ $priority ][] = $callback;
+}
+
+require_once __DIR__ . '/../agents-api/agents-api.php';
+
+use DataMachine\Core\Database\Chat\ConversationTranscriptStoreInterface;
+
+$failures = array();
+$passes   = 0;
+
+$assert_true = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "FAIL: {$label}\n";
+};
+
+class AgentsApiFakeTranscriptStore implements ConversationTranscriptStoreInterface {
+
+	/**
+	 * @var array<string, array<string, mixed>>
+	 */
+	private array $sessions = array();
+
+	public function create_session( int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string {
+		$session_id = 'session-' . ( count( $this->sessions ) + 1 );
+
+		$this->sessions[ $session_id ] = array(
+			'session_id'   => $session_id,
+			'user_id'      => $user_id,
+			'agent_id'     => $agent_id,
+			'title'        => '',
+			'messages'     => array(),
+			'metadata'     => $metadata,
+			'provider'     => '',
+			'model'        => '',
+			'context'      => $context,
+			'mode'         => $context,
+			'created_at'   => gmdate( 'Y-m-d H:i:s' ),
+			'updated_at'   => gmdate( 'Y-m-d H:i:s' ),
+			'last_read_at' => null,
+			'expires_at'   => null,
+		);
+
+		return $session_id;
+	}
+
+	public function get_session( string $session_id ): ?array {
+		return $this->sessions[ $session_id ] ?? null;
+	}
+
+	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '' ): bool {
+		if ( ! isset( $this->sessions[ $session_id ] ) ) {
+			return false;
+		}
+
+		$this->sessions[ $session_id ]['messages']   = $messages;
+		$this->sessions[ $session_id ]['metadata']   = $metadata;
+		$this->sessions[ $session_id ]['provider']   = $provider;
+		$this->sessions[ $session_id ]['model']      = $model;
+		$this->sessions[ $session_id ]['updated_at'] = gmdate( 'Y-m-d H:i:s' );
+
+		return true;
+	}
+
+	public function delete_session( string $session_id ): bool {
+		unset( $this->sessions[ $session_id ] );
+		return true;
+	}
+
+	public function get_recent_pending_session( int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
+		unset( $seconds, $token_id );
+
+		foreach ( array_reverse( $this->sessions ) as $session ) {
+			if ( $user_id === $session['user_id'] && $context === $session['context'] && array() === $session['messages'] ) {
+				return $session;
+			}
+		}
+
+		return null;
+	}
+
+	public function update_title( string $session_id, string $title ): bool {
+		if ( ! isset( $this->sessions[ $session_id ] ) ) {
+			return false;
+		}
+
+		$this->sessions[ $session_id ]['title'] = $title;
+		return true;
+	}
+}
+
+echo "agents-api-transcript-store-smoke\n";
+
+$assert_true( defined( 'AGENTS_API_LOADED' ), 'agents-api bootstrap loads without Data Machine product runtime' );
+$assert_true( interface_exists( ConversationTranscriptStoreInterface::class ), 'transcript contract is loaded by agents-api bootstrap' );
+$assert_true( false === class_exists( 'DataMachine\\Core\\Database\\Chat\\Chat', false ), 'Data Machine chat table implementation is not loaded' );
+$assert_true( false === interface_exists( 'DataMachine\\Core\\Database\\Chat\\ConversationStoreInterface', false ), 'Data Machine aggregate chat contract is not loaded' );
+
+$store = new AgentsApiFakeTranscriptStore();
+$assert_true( in_array( ConversationTranscriptStoreInterface::class, class_implements( $store ), true ), 'fake store can implement transcript contract without chat product interfaces' );
+
+$session_id = $store->create_session( 7, 3, array( 'source' => 'smoke' ), 'pipeline' );
+$assert_true( 'session-1' === $session_id, 'fake store creates transcript session IDs' );
+$assert_true( null !== $store->get_recent_pending_session( 7, 600, 'pipeline' ), 'fake store can query pending transcript sessions' );
+
+$updated = $store->update_session(
+	$session_id,
+	array(
+		array(
+			'role'    => 'user',
+			'content' => 'Hello transcript store',
+		),
+	),
+	array( 'source' => 'updated' ),
+	'openai',
+	'gpt-5.4'
+);
+$assert_true( true === $updated, 'fake store updates complete transcript data' );
+
+$store->update_title( $session_id, 'Transcript Smoke' );
+$session = $store->get_session( $session_id );
+$assert_true( 'Transcript Smoke' === ( $session['title'] ?? '' ), 'fake store updates stored transcript title' );
+$assert_true( 'gpt-5.4' === ( $session['model'] ?? '' ), 'fake store preserves provider metadata without Data Machine pipeline objects' );
+
+$store->delete_session( $session_id );
+$assert_true( null === $store->get_session( $session_id ), 'fake store deletes transcript sessions idempotently' );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " Agents API transcript assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} Agents API transcript assertions passed.\n";


### PR DESCRIPTION
## Summary

- Moves the narrow conversation transcript CRUD contract into the in-repo Agents API module while preserving the current namespace and Data Machine include path for compatibility.
- Keeps Data Machine's chat aggregate, table implementation, session listing, read state, reporting, and retention behavior outside `agents-api/`.

## Changes

- Loads `ConversationTranscriptStoreInterface` from `agents-api/agents-api.php`.
- Leaves `inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php` as a compatibility include path for existing Composer/autoload callers.
- Adds a pure module smoke with a fake transcript store proving the contract can be implemented and used without loading Data Machine chat product runtime.
- Updates Agents API extraction docs to reflect the new transcript-contract home.

## Tests

- `php tests/agents-api-transcript-store-smoke.php`
- `php tests/agents-api-bootstrap-smoke.php`
- `php tests/conversation-store-contracts-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-transcript-contract --changed-since origin/main`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@agents-api-transcript-contract --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@agents-api-transcript-contract --changed-since origin/main`

Closes #1635

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the transcript contract move, added the focused module smoke, ran checks, and drafted this PR description for Chris to review.
