### PR TITLE
test(agent): enforce backend-only agents api boundary

### DIFF
--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -6,7 +6,7 @@ Parent issue: [Explore splitting Agents API out of Data Machine](https://github.
 
 Strategy update: [Agents API blocker: update extraction docs around in-repo module strategy](https://github.com/Extra-Chill/data-machine/issues/1640)
 
-Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
+Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
 
 ## Current Strategy
 
@@ -28,6 +28,8 @@ Treat `data-machine/agents-api/` like WordPress core substrate while it still li
 - Data Machine may import and consume `agents-api` as product code.
 - `agents-api` owns runner interfaces, value objects, and generic contracts first; Data Machine keeps `AIConversationLoop` and the built-in compatibility runner while they still carry Data Machine job, flow, handler, logging, transcript, and legacy result-shape assumptions.
 - Data Machine keeps flows, pipelines, jobs, handlers, queues, retention, pending actions, content operations, and admin UI.
+- `agents-api` is backend-only and invisible by default: no admin menus, screens, human CRUD forms, React apps, or Data Machine product UI.
+- Data Machine and other product consumers own any admin/product UI they build on top of the substrate.
 - Later standalone extraction means moving the already-bounded module into its own plugin/repo and adding plugin bootstrap, release, dependency, and distribution ceremony.
 - `ai-http-client` is not future architecture. It is only packaging precedent for bundled-then-extracted code.
 - The future runtime dependency direction is `Data Machine -> agents-api -> wp-ai-client`; `ai-http-client` dies as part of [#1027](https://github.com/Extra-Chill/data-machine/issues/1027) / [#1633](https://github.com/Extra-Chill/data-machine/issues/1633).
@@ -42,7 +44,7 @@ Data Machine pipelines/product
 
 ## Target Vocabulary
 
-Mirror the WordPress Abilities API shape instead of importing Data Machine, wpcom, or Automattic AI Framework names into the public contract.
+Mirror the WordPress Abilities API shape instead of importing Data Machine product names or host-specific implementation names into the public contract.
 
 | Current Data Machine surface | Possible Agents API vocabulary | Notes |
 |---|---|---|
@@ -63,7 +65,26 @@ Use these checks before moving anything:
 - If a plugin can use it without knowing about flows, pipeline steps, handlers, queues, jobs, or Data Machine content operations, it is an Agents API candidate.
 - If it translates Data Machine concepts into runtime concepts, it is a Data Machine adapter.
 - If it owns flows, jobs, queues, handlers, scheduled automation, retention, admin UI, or content ops, it stays Data Machine product.
-- If it uses wpcom or Automattic AI Framework vocabulary directly, treat that code as source material only until normalized behind WordPress-shaped contracts.
+- If it uses host-specific implementation vocabulary directly, treat that code as source material only until normalized behind WordPress-shaped contracts.
+
+## Backend-Only UI Boundary
+
+Agents API is a generic WordPress-shaped substrate. It should be usable by any plugin that wants to register, run, persist, or observe agents without adopting Data Machine as a product.
+
+`agents-api` may own backend contracts and implementations for:
+
+- registration vocabulary and registries.
+- runtime request/result/message contracts.
+- memory, transcript, tool, event, and permission-ceiling contracts.
+- direct public WordPress APIs such as Abilities API and `wp-ai-client`.
+
+`agents-api` must not own product/admin surfaces:
+
+- admin menus, screens, list tables, settings forms, or React admin apps.
+- human agent CRUD screens or workflows.
+- Data Machine flow, pipeline, chat, bundle, queue, job, retention, or content-operation UI.
+
+Substrate CRUD is allowed when it is backend-only and generic: interfaces/services for definitions, sessions, memories, transcripts, tools, and run state. Product CRUD belongs to consumers: screens, forms, routes, workflows, and opinionated management UX. Data Machine may provide those product surfaces while consuming `agents-api`; the dependency direction must not reverse.
 
 ## Bucket Summary
 
@@ -74,7 +95,7 @@ Use these checks before moving anything:
 | Data Machine adapter | Glue that turns flows/jobs/pipelines into generic runtime inputs. | `AIStep`, pipeline tool-policy args, transcript persistence policy, adjacent handler tools. |
 | Data Machine product | Data Machine automation/product layer. | Jobs, flows, pipelines, handlers, queues, retention, content abilities, admin UI. |
 | Intelligence domain | Intelligence plugin concerns, not Data Machine or Agents API. | Wiki, briefings, digests, domain brains. |
-| wpcom source material | Useful precedent only. | `\WPCOM\AI\Message`, `\Agent`, `\AgentsStore`, `Conversation_Storage`. |
+| External host source material | Useful precedent only. | Normalize behind generic WordPress-shaped contracts before anything becomes public API. |
 
 ## Current `Engine\AI` Namespace Split
 
@@ -214,7 +235,7 @@ Conversation storage is split in place, but only the narrow transcript surface i
 | Retention | `ConversationRetentionInterface`, retention system tasks/CLI | Backend cleanup methods may be generic, but scheduling and retention policy are Data Machine product. |
 | Reporting | `ConversationReportingInterface`, daily memory/retention status readers | Product-shaped metrics today. Keep separate from transcript CRUD. |
 
-Do not decide an `agents_session` CPT, wpcom `Conversation_Storage`, or a new Agents API filter name in this in-place clarification. The current goal is only to make the dependency direction obvious: Data Machine chat product consumes transcript persistence; transcript persistence does not require Data Machine chat product behavior.
+Do not decide an `agents_session` CPT, a host-specific storage backend, or a new Agents API filter name in this in-place clarification. The current goal is only to make the dependency direction obvious: Data Machine chat product consumes transcript persistence; transcript persistence does not require Data Machine chat product behavior.
 
 ## Data Machine Product
 
@@ -245,18 +266,6 @@ Data Machine should not absorb Intelligence-specific vocabulary during extractio
 | Briefings and digests | Intelligence | Domain workflows built on top of runtime and search abilities. |
 | Domain brains and generated/shared wikis | Intelligence | Product/domain policy, not Agents API. |
 | Intelligence memory policy additions | Intelligence | May consume generic memory contracts, but policy names and wiki roots stay outside Agents API. |
-
-## wpcom Source Material
-
-These are reference points only. Do not expose them as public Data Machine or Agents API vocabulary.
-
-| Source | How to use it |
-|---|---|
-| `\WPCOM\AI\Message` | Reference for message object semantics. Normalize behind `WP_Agent_Message` or neutral envelopes. |
-| `\Agent` / AI Framework agent classes | Reference for run-loop integration and provider routing. Do not require inheritance from wpcom classes. |
-| `\AgentsStore` | Reference for persistence/adoption semantics. Do not leak storage names into public API. |
-| `Conversation_Storage` | Reference for compaction/resilience. Keep Data Machine/Agents API conversation store contracts portable and site-owned unless explicitly swapped. |
-| Dolly agent architecture | Reference for WordPress-hosted agent UX and memory injection, not a dependency or target vocabulary. |
 
 ## Hook Name Map
 
@@ -333,14 +342,14 @@ These tests currently pin the substrate most relevant to extraction.
 5. Split provider request assembly from `RequestBuilder` so Data Machine directives/logging stay adapter behavior and provider dispatch targets `wp-ai-client`, not `ai-http-client`.
 6. Split `ToolExecutor` into ability-native runtime execution plus Data Machine product hooks for pending actions and post-origin tracking.
 7. Decide whether Agents API owns persistence tables or only contracts plus optional stores.
-8. Keep wpcom/AI Framework classes behind adapters. No public contract should require `\WPCOM\AI\Message`, `\Agent`, `\AgentsStore`, or `Conversation_Storage`.
+8. Keep host-specific implementation classes behind adapters. No public contract should require a host-owned message, agent, store, or conversation-storage class.
 
 ## Non-Goals
 
 - Do not move files as part of this map.
 - Do not frame the next step as direct external repository extraction; the next code step is the in-repo `data-machine/agents-api/` module.
 - Do not rename runtime classes before the target contracts are settled.
-- Do not make Data Machine depend on wpcom or Automattic AI Framework vocabulary.
+- Do not make Data Machine depend on host-specific implementation vocabulary.
 - Do not make Agents API depend on `ai-http-client`; that package is only a packaging precedent and a removal target.
 - Do not move Data Machine flows, pipelines, jobs, handlers, queues, retention, content ops, or admin UI into Agents API.
 - Do not move Intelligence wiki/briefing/domain-brain vocabulary into Data Machine or Agents API.

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -4,7 +4,7 @@ Parent issue: [Explore splitting Agents API out of Data Machine](https://github.
 
 Strategy issue: [Agents API blocker: update extraction docs around in-repo module strategy](https://github.com/Extra-Chill/data-machine/issues/1640)
 
-Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
+Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
 
 This audit records the remaining work after the first in-place untangling wave. The boundary is now mostly visible: Data Machine owns pipelines and automation; the future Agents API owns generic agent runtime primitives. The next phase is to make those primitives live behind an in-repo `data-machine/agents-api/` module boundary while they still ship with Data Machine.
 
@@ -29,6 +29,8 @@ Treat `data-machine/agents-api/` like WordPress core substrate while it still li
 - `agents-api` must not import Data Machine product namespaces.
 - `agents-api` owns runner interfaces, value objects, and generic contracts first; Data Machine keeps `AIConversationLoop` and the built-in compatibility runner until the loop no longer carries Data Machine job, flow, handler, logging, transcript, or legacy payload/result assumptions.
 - Data Machine keeps flows, pipelines, jobs, handlers, queues, retention, pending actions, content operations, and admin UI.
+- `agents-api` is backend-only and invisible by default: no admin menus, screens, human CRUD forms, React apps, or Data Machine product UI.
+- Data Machine and other product consumers own any admin/product UI they build on top of the substrate.
 - Later standalone extraction means moving the already-bounded module into its own plugin/repo and adding plugin bootstrap, dependency, release, and distribution ceremony.
 
 Dependency direction:
@@ -66,6 +68,7 @@ Before standalone extraction, the in-repo module should satisfy these gates:
 - `data-machine/agents-api/` exists and loads before Data Machine product runtime bootstraps.
 - A bootstrap smoke can load `agents-api` without Data Machine product code.
 - No `agents-api` file imports `DataMachine\Core\Steps`, `DataMachine\Core\Database\Jobs`, handler, queue, retention, pending-action, admin UI, or content-operation namespaces.
+- No `agents-api` file registers admin menus, admin screens, settings forms, or admin-only UI hooks.
 - Data Machine product code imports the module as a dependency instead of reaching across same-layer runtime/product paths.
 - Provider runtime code targets `wp-ai-client`; no `ai-http-client` fallback is introduced or preserved inside `agents-api`.
 
@@ -113,7 +116,7 @@ Target shape:
 
 - Review whether the physically extracted public class should stay `AgentMessageEnvelope` or become `WP_Agent_Message`.
 - Keep schema metadata generic; do not reintroduce Data Machine-owned schema names for the shared contract.
-- Keep wpcom message DTOs as adapters/source material, not public dependency vocabulary.
+- Keep host-specific message DTOs as adapters/source material, not public dependency vocabulary.
 
 ### 4. Conversation Storage Boundary
 
@@ -190,7 +193,7 @@ Before physical extraction, verify that generic runtime candidates do not:
 - Emit `datamachine_log` directly instead of using a generic event sink.
 - Depend on `datamachine_tools` legacy class/method declarations.
 - Depend on `ai-http-client` or `chubes_ai_*` filters.
-- Mention wpcom classes in public signatures.
+- Mention host-specific classes in public signatures.
 
 ## What Agents API Can Enable Without Data Machine
 
@@ -202,7 +205,7 @@ Agents API should be useful even when a site does not install Data Machine. In t
 - A code-review or repository agent that uses GitHub abilities without adopting Data Machine pipelines.
 - A Slack, email, or helpdesk assistant that owns its own channel adapter and delegates only the runtime loop to Agents API.
 - A domain expert agent bundled by another plugin, with default memory/guidelines and a constrained tool policy.
-- A WordPress.com-hosted agent that uses wpcom provider/storage adapters while sharing the same public WordPress-shaped contracts.
+- A hosted agent that uses environment-specific provider/storage adapters while sharing the same public WordPress-shaped contracts.
 
 Agents API should provide the substrate for those products:
 

--- a/tests/agents-api-no-product-imports-smoke.php
+++ b/tests/agents-api-no-product-imports-smoke.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Static smoke test proving agents-api does not import Data Machine product code (#1639).
+ * Static smoke test proving agents-api stays product-free and UI-free (#1639, #1651).
  *
  * Run with: php tests/agents-api-no-product-imports-smoke.php
  *
@@ -21,6 +21,7 @@ $forbidden_namespaces = array(
 	'DataMachine\\Core\\Steps',
 	'DataMachine\\Core\\Database\\Jobs',
 	'DataMachine\\Core\\Admin',
+	'DataMachine\\Core\\Assets',
 	'DataMachine\\Engine\\Handlers',
 	'DataMachine\\Core\\ActionScheduler',
 	'DataMachine\\Engine\\AI\\System\\Tasks\\Retention',
@@ -28,6 +29,26 @@ $forbidden_namespaces = array(
 	'DataMachine\\Engine\\Flows',
 	'DataMachine\\Engine\\Queue',
 	'DataMachine\\Core\\Content',
+);
+
+$forbidden_admin_apis = array(
+	'add_menu_page',
+	'add_submenu_page',
+	'add_options_page',
+	'add_management_page',
+	'add_dashboard_page',
+	'add_theme_page',
+	'add_plugins_page',
+	'register_setting',
+);
+
+$forbidden_admin_hooks = array(
+	'admin_menu',
+	'network_admin_menu',
+	'user_admin_menu',
+	'admin_init',
+	'admin_enqueue_scripts',
+	'admin_post_',
 );
 
 $matches  = array();
@@ -48,9 +69,23 @@ foreach ( $iterator as $file ) {
 	if ( preg_match( '/(?:use\s+|new\s+|extends\s+|implements\s+|instanceof\s+)\\?DataMachine\\\\/', $source ) ) {
 		$matches[] = str_replace( (string) $agents_api_dir . '/', '', $file->getPathname() ) . ' imports a DataMachine namespace';
 	}
+
+	foreach ( $forbidden_admin_apis as $function_name ) {
+		if ( preg_match( '/\\b' . preg_quote( $function_name, '/' ) . '\\s*\(/', $source ) ) {
+			$matches[] = str_replace( (string) $agents_api_dir . '/', '', $file->getPathname() ) . ' registers admin UI via ' . $function_name;
+		}
+	}
+
+	foreach ( $forbidden_admin_hooks as $hook_name ) {
+		if ( preg_match( '/add_action\s*\(\s*[\'\"]' . preg_quote( $hook_name, '/' ) . '/', $source ) ) {
+			$matches[] = str_replace( (string) $agents_api_dir . '/', '', $file->getPathname() ) . ' registers admin hook ' . $hook_name;
+		}
+	}
 }
 
-agents_api_smoke_assert_equals( array(), $matches, 'agents-api has no Data Machine product imports', $failures, $passes );
+agents_api_smoke_assert_equals( array(), $matches, 'agents-api has no Data Machine product imports or admin UI registrations', $failures, $passes );
 agents_api_smoke_assert_equals( $forbidden_namespaces, array_values( array_unique( $forbidden_namespaces ) ), 'forbidden namespace list has no duplicates', $failures, $passes );
+agents_api_smoke_assert_equals( $forbidden_admin_apis, array_values( array_unique( $forbidden_admin_apis ) ), 'forbidden admin API list has no duplicates', $failures, $passes );
+agents_api_smoke_assert_equals( $forbidden_admin_hooks, array_values( array_unique( $forbidden_admin_hooks ) ), 'forbidden admin hook list has no duplicates', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API no-product-imports', $failures, $passes );


### PR DESCRIPTION
## Summary
- Document `agents-api/` as a backend-only, UI-free substrate that product plugins consume for admin and CRUD surfaces.
- Remove host-specific implementation references from the Agents API boundary docs in favor of generic WordPress-shaped adapter language.
- Extend the no-product-import static smoke so `agents-api/` fails if it registers admin menus/screens/settings hooks or imports Data Machine admin/product namespaces.

## Boundary
- Allowed in `agents-api/`: registration, runtime/message/memory/transcript/tool/event contracts, and direct public WordPress APIs such as Abilities API and `wp-ai-client`.
- Not allowed in `agents-api/`: admin menus/screens, human agent CRUD UI, Data Machine flow/pipeline/chat/bundle/job/queue/retention/content-operation UI, or host-specific implementation vocabulary.
- Data Machine remains the product consumer that may provide admin/product UI on top of the substrate.

## Tests
- `php tests/agents-api-no-product-imports-smoke.php`
- `php tests/agents-api-bootstrap-smoke.php`
- `php tests/agents-api-registration-smoke.php`
- `php tests/agents-api-memory-store-smoke.php`
- `php tests/agents-api-transcript-store-smoke.php`
- `git diff --check`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-backend-only-boundary --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@agents-api-backend-only-boundary --changed-since origin/main` — passed, with existing doc-reference warnings in touched docs.

Closes #1651

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the docs/test update, ran focused validation, and prepared the PR. Chris remains responsible for review and merge.