### PR TITLE
docs(agent): clarify direct wp ai client consumption

### DIFF
--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -32,14 +32,14 @@ Treat `data-machine/agents-api/` like WordPress core substrate while it still li
 - Data Machine and other product consumers own any admin/product UI they build on top of the substrate.
 - Later standalone extraction means moving the already-bounded module into its own plugin/repo and adding plugin bootstrap, release, dependency, and distribution ceremony.
 - `ai-http-client` is not future architecture. It is only packaging precedent for bundled-then-extracted code.
-- The future runtime dependency direction is `Data Machine -> agents-api -> wp-ai-client`; `ai-http-client` dies as part of [#1027](https://github.com/Extra-Chill/data-machine/issues/1027) / [#1633](https://github.com/Extra-Chill/data-machine/issues/1633).
+- The future runtime dependency direction is `Data Machine product adapter -> Agents API run request -> wp-ai-client public API`; `ai-http-client` dies as part of [#1027](https://github.com/Extra-Chill/data-machine/issues/1027) / [#1633](https://github.com/Extra-Chill/data-machine/issues/1633).
 
 ```text
-WordPress / wp-ai-client
+wp-ai-client public API
         ↑
-data-machine/agents-api
+Agents API run request
         ↑
-Data Machine pipelines/product
+Data Machine product adapter
 ```
 
 ## Target Vocabulary
@@ -65,7 +65,7 @@ Use these checks before moving anything:
 - If a plugin can use it without knowing about flows, pipeline steps, handlers, queues, jobs, or Data Machine content operations, it is an Agents API candidate.
 - If it translates Data Machine concepts into runtime concepts, it is a Data Machine adapter.
 - If it owns flows, jobs, queues, handlers, scheduled automation, retention, admin UI, or content ops, it stays Data Machine product.
-- If it uses host-specific implementation vocabulary directly, treat that code as source material only until normalized behind WordPress-shaped contracts.
+- If it uses host-specific provider, storage, or implementation vocabulary directly, treat that code as source material only until normalized behind WordPress-shaped contracts.
 
 ## Backend-Only UI Boundary
 
@@ -95,7 +95,7 @@ Substrate CRUD is allowed when it is backend-only and generic: interfaces/servic
 | Data Machine adapter | Glue that turns flows/jobs/pipelines into generic runtime inputs. | `AIStep`, pipeline tool-policy args, transcript persistence policy, adjacent handler tools. |
 | Data Machine product | Data Machine automation/product layer. | Jobs, flows, pipelines, handlers, queues, retention, content abilities, admin UI. |
 | Intelligence domain | Intelligence plugin concerns, not Data Machine or Agents API. | Wiki, briefings, digests, domain brains. |
-| External host source material | Useful precedent only. | Normalize behind generic WordPress-shaped contracts before anything becomes public API. |
+| Host-specific source material | Useful precedent only. | Provider/storage implementations that must be normalized behind WordPress-shaped contracts before they can inform Agents API. |
 
 ## Current `Engine\AI` Namespace Split
 
@@ -169,8 +169,8 @@ These are plausibly generic implementations, but should not move until naming an
 |---|---|---|---|
 | `AIConversationLoop` | `inc/Engine/AI/AIConversationLoop.php` | Name says AI and still carries the compatibility facade/result shape, but handler completion and transcript persistence now route through runtime collaborators. | Keep shrinking the compatibility adapter by extracting provider request assembly and Data Machine logging policy next. |
 | `ProviderRequestAssembler` | `inc/Engine/AI/ProviderRequestAssembler.php` | Normalizes messages, tools, model, and caller-selected directives without dispatching, logging, or discovering Data Machine directives. | Good in-place request assembly candidate once prompt/directive vocabulary is settled. |
-| `RequestBuilder` | `inc/Engine/AI/RequestBuilder.php` | Data Machine adapter around provider assembly: discovers/directive-policies `datamachine_directives`, emits `datamachine_log`, applies request-size guardrails, and still carries legacy provider-dispatch compatibility. | Keep as Data Machine adapter unless/until the `ai-http-client` / `chubes_ai_request` bridge is removed in favor of `wp-ai-client`. |
-| `WpAiClientAdapter` | `inc/Engine/AI/WpAiClientAdapter.php` | Generic bridge to WordPress AI client, but currently lives as Data Machine implementation detail. | Good implementation candidate once request/message contracts are generic. |
+| `RequestBuilder` | `inc/Engine/AI/RequestBuilder.php` | Data Machine adapter around provider assembly: discovers/directive-policies `datamachine_directives`, emits `datamachine_log`, applies request-size guardrails, and still carries Data Machine request-array compatibility. | Keep as Data Machine adapter while those product concerns remain. Provider dispatch should consume `wp-ai-client` directly. |
+| `WpAiClientAdapter` | `inc/Engine/AI/WpAiClientAdapter.php` | Data Machine adapter that maps the assembled provider request array onto the wp-ai-client public API and normalizes the result back to Data Machine's historical response array. | Keep in Data Machine until request/message contracts are generic enough for an Agents API provider runtime implementation. |
 | `RequestMetadata` | `inc/Engine/AI/RequestMetadata.php` | Generic inspection/size metadata. | Move after field names are checked against Agents API message/tool vocabulary. |
 | `RequestInspector` | `inc/Engine/AI/RequestInspector.php` | Generic debugging/inspection value, likely useful across runtimes. | Rename away from Data Machine only if public debug surface is desired. |
 | `PromptBuilder` | `inc/Engine/AI/PromptBuilder.php` | Generic system-message composition engine, but wired to Data Machine directives. | Extract lower-level composer after directive contract is settled. |
@@ -235,7 +235,7 @@ Conversation storage is split in place, but only the narrow transcript surface i
 | Retention | `ConversationRetentionInterface`, retention system tasks/CLI | Backend cleanup methods may be generic, but scheduling and retention policy are Data Machine product. |
 | Reporting | `ConversationReportingInterface`, daily memory/retention status readers | Product-shaped metrics today. Keep separate from transcript CRUD. |
 
-Do not decide an `agents_session` CPT, a host-specific storage backend, or a new Agents API filter name in this in-place clarification. The current goal is only to make the dependency direction obvious: Data Machine chat product consumes transcript persistence; transcript persistence does not require Data Machine chat product behavior.
+Do not decide an `agents_session` CPT, host-specific conversation storage, or a new Agents API filter name in this in-place clarification. The current goal is only to make the dependency direction obvious: Data Machine chat product consumes transcript persistence; transcript persistence does not require Data Machine chat product behavior.
 
 ## Data Machine Product
 
@@ -266,6 +266,18 @@ Data Machine should not absorb Intelligence-specific vocabulary during extractio
 | Briefings and digests | Intelligence | Domain workflows built on top of runtime and search abilities. |
 | Domain brains and generated/shared wikis | Intelligence | Product/domain policy, not Agents API. |
 | Intelligence memory policy additions | Intelligence | May consume generic memory contracts, but policy names and wiki roots stay outside Agents API. |
+
+## Host-Specific Source Material
+
+These are reference points only. Do not expose them as public Data Machine or Agents API vocabulary.
+
+| Source | How to use it |
+|---|---|
+| Host message DTOs | Reference for message object semantics. Normalize behind `WP_Agent_Message` or neutral envelopes. |
+| Host agent runtime classes | Reference for run-loop integration and provider routing. Do not require inheritance from host runtime classes. |
+| Host agent stores | Reference for persistence/adoption semantics. Do not leak storage names into public API. |
+| Host conversation storage | Reference for compaction/resilience. Keep Data Machine/Agents API conversation store contracts portable and site-owned unless explicitly swapped. |
+| Host agent UX precedents | Reference for WordPress-hosted agent UX and memory injection, not a dependency or target vocabulary. |
 
 ## Hook Name Map
 
@@ -342,14 +354,14 @@ These tests currently pin the substrate most relevant to extraction.
 5. Split provider request assembly from `RequestBuilder` so Data Machine directives/logging stay adapter behavior and provider dispatch targets `wp-ai-client`, not `ai-http-client`.
 6. Split `ToolExecutor` into ability-native runtime execution plus Data Machine product hooks for pending actions and post-origin tracking.
 7. Decide whether Agents API owns persistence tables or only contracts plus optional stores.
-8. Keep host-specific implementation classes behind adapters. No public contract should require a host-owned message, agent, store, or conversation-storage class.
+8. Keep host-specific provider and storage classes behind adapters. No public contract should require implementation-specific message, agent, or conversation-storage DTOs.
 
 ## Non-Goals
 
 - Do not move files as part of this map.
 - Do not frame the next step as direct external repository extraction; the next code step is the in-repo `data-machine/agents-api/` module.
 - Do not rename runtime classes before the target contracts are settled.
-- Do not make Data Machine depend on host-specific implementation vocabulary.
+- Do not make Data Machine or Agents API depend on host-specific provider or storage vocabulary.
 - Do not make Agents API depend on `ai-http-client`; that package is only a packaging precedent and a removal target.
 - Do not move Data Machine flows, pipelines, jobs, handlers, queues, retention, content ops, or admin UI into Agents API.
 - Do not move Intelligence wiki/briefing/domain-brain vocabulary into Data Machine or Agents API.

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -36,14 +36,14 @@ Treat `data-machine/agents-api/` like WordPress core substrate while it still li
 Dependency direction:
 
 ```text
-WordPress / wp-ai-client
+wp-ai-client public API
         ↑
-data-machine/agents-api
+Agents API run request
         ↑
-Data Machine pipelines/product
+Data Machine product adapter
 ```
 
-`ai-http-client` is not future architecture. It is only packaging precedent for bundled-then-extracted code. The future runtime dependency direction is `Data Machine -> agents-api -> wp-ai-client`; `ai-http-client` dies as part of [#1027](https://github.com/Extra-Chill/data-machine/issues/1027) / [#1633](https://github.com/Extra-Chill/data-machine/issues/1633).
+`ai-http-client` is not future architecture. It is only packaging precedent for bundled-then-extracted code. The future runtime dependency direction is `Data Machine product adapter -> Agents API run request -> wp-ai-client public API`; `ai-http-client` dies as part of [#1027](https://github.com/Extra-Chill/data-machine/issues/1027) / [#1633](https://github.com/Extra-Chill/data-machine/issues/1633).
 
 ## Current State
 

--- a/inc/Engine/AI/WpAiClientAdapter.php
+++ b/inc/Engine/AI/WpAiClientAdapter.php
@@ -2,13 +2,16 @@
 /**
  * WordPress AI Client adapter.
  *
- * Bridges Data Machine's RequestBuilder to WordPress core's `wp_ai_client_prompt()`
- * fluent API. Core's AI client plus registered provider plugins are the only
- * supported agent-runtime provider path.
+ * Data Machine request-execution adapter for WordPress core's `wp_ai_client_prompt()`
+ * fluent API. RequestBuilder stays in the Data Machine product layer while it carries
+ * directive discovery, logging, and legacy request-array normalization; the provider
+ * runtime it consumes is the wp-ai-client public API.
  *
- * Scope: this class is the request-execution bridge only. Admin UI, REST endpoints,
- * settings, and provider/model discovery continue to flow through the existing
- * legacy filter surface until those layers are migrated separately.
+ * Scope: this class converts Data Machine's assembled provider request shape into
+ * wp-ai-client calls and normalizes the result back to Data Machine's historical
+ * response array. It is adapter vocabulary because it belongs to Data Machine's
+ * product/runtime compatibility layer, not because Agents API requires a bridge to
+ * wp-ai-client.
  *
  * @package DataMachine\Engine\AI
  * @since 0.69.1
@@ -29,8 +32,9 @@ class WpAiClientAdapter {
 	 *   3. The requested provider is registered in the default registry — i.e. a
 	 *      provider plugin like `ai-provider-for-openai` is installed and active.
 	 *
-	 * If any condition fails, callers surface a request-runtime error instead of
-	 * falling back to a secondary provider client.
+	 * If any condition fails, callers surface a structured request error. The
+	 * provider runtime path is wp-ai-client; there is no ai-http-client fallback in
+	 * this Agents API direction.
 	 *
 	 * @since 0.69.1
 	 *
@@ -64,9 +68,9 @@ class WpAiClientAdapter {
 	 * Returns Data Machine's existing normalized response shape so the conversation
 	 * loop, tool executor, and downstream consumers do not change.
 	 *
-	 * If the request contains content that the bridge does not yet translate (currently:
+	 * If the request contains content that the adapter does not yet translate (currently:
 	 * any non-string message content such as multi-modal blocks), this method returns
-	 * `null` so the caller can surface an unsupported request-shape error.
+	 * `null` so the caller can return a structured unsupported-shape error.
 	 *
 	 * @since 0.69.1
 	 *
@@ -74,10 +78,11 @@ class WpAiClientAdapter {
 	 * @param string $provider  Provider identifier.
 	 * @param array  $tools     Structured tools (name => ['name', 'description', 'parameters', ...]).
 	 * @return array|null Response array on success, error response array on AI failure, or null if the
-	 *                    bridge cannot handle this request shape.
+	 *                    adapter cannot handle this request shape.
 	 */
 	public static function dispatch( array $request, string $provider, array $tools ): ?array {
-		// Bail on request shapes the wp-ai-client bridge does not translate yet.
+		// Bail with an unsupported-shape signal on non-string content until this adapter
+		// can map multi-modal request parts into wp-ai-client DTOs.
 		foreach ( $request['messages'] ?? array() as $message ) {
 			if ( isset( $message['content'] ) && ! is_string( $message['content'] ) ) {
 				return null;
@@ -354,8 +359,9 @@ class WpAiClientAdapter {
 	/**
 	 * Resolve the API key for this provider via DM's existing key plumbing.
 	 *
-	 * Reads Data Machine's existing provider-key filter so admin UX, network
-	 * settings, and key persistence remain unchanged until those surfaces migrate.
+	 * Reads the same `chubes_ai_provider_api_keys` filter that ai-http-client uses,
+	 * so admin UX, network settings, and key persistence remain unchanged while
+	 * Data Machine request assembly consumes wp-ai-client directly.
 	 *
 	 * @since 0.69.1
 	 *

--- a/tests/agents-api-wp-ai-client-vocabulary-smoke.php
+++ b/tests/agents-api-wp-ai-client-vocabulary-smoke.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Static smoke test for Agents API wp-ai-client vocabulary (#1652).
+ *
+ * Run with: php tests/agents-api-wp-ai-client-vocabulary-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-wp-ai-client-vocabulary-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+$root = realpath( __DIR__ . '/..' );
+agents_api_smoke_assert_equals( true, is_string( $root ), 'repository root resolves', $failures, $passes );
+
+$scanned_files = array(
+	'docs/development/agents-api-extraction-map.md',
+	'docs/development/agents-api-pre-extraction-audit.md',
+	'docs/core-system/request-builder.md',
+	'inc/Engine/AI/RequestBuilder.php',
+	'inc/Engine/AI/WpAiClientAdapter.php',
+	'inc/Engine/AI/WpAiClientCapability.php',
+);
+
+$provider_slug        = 'wp-' . 'ai-client';
+$provider_func_prefix = 'wp_' . 'ai_client';
+$connector_word       = 'bri' . 'dge';
+
+$forbidden_architecture_phrases = array(
+	$connector_word . ' to ' . $provider_slug,
+	$provider_slug . ' ' . $connector_word,
+	$connector_word . ' to ' . $provider_func_prefix,
+	$provider_func_prefix . ' ' . $connector_word,
+);
+
+$matches = array();
+foreach ( $scanned_files as $relative_path ) {
+	$path = (string) $root . '/' . $relative_path;
+	agents_api_smoke_assert_equals( true, is_file( $path ), $relative_path . ' exists', $failures, $passes );
+	$source = strtolower( (string) file_get_contents( $path ) );
+
+	foreach ( $forbidden_architecture_phrases as $phrase ) {
+		if ( str_contains( $source, $phrase ) ) {
+			$matches[] = $relative_path . ' contains "' . $phrase . '"';
+		}
+	}
+}
+
+agents_api_smoke_assert_equals( array(), $matches, 'docs/comments avoid forbidden final-architecture provider wording', $failures, $passes );
+
+$agents_api_dir = (string) $root . '/agents-api';
+$host_terms     = array( 'wpcom', 'wpcOM', 'dolly', 'odie', 'wordpress.com', 'automattic ai framework' );
+$host_matches   = array();
+$iterator       = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $agents_api_dir ) );
+
+foreach ( $iterator as $file ) {
+	if ( ! $file->isFile() || 'php' !== $file->getExtension() ) {
+		continue;
+	}
+
+	$source = strtolower( (string) file_get_contents( $file->getPathname() ) );
+	foreach ( $host_terms as $term ) {
+		if ( str_contains( $source, strtolower( $term ) ) ) {
+			$host_matches[] = str_replace( $agents_api_dir . '/', '', $file->getPathname() ) . ' contains ' . $term;
+		}
+	}
+}
+
+agents_api_smoke_assert_equals( array(), $host_matches, 'agents-api has no host-specific implementation vocabulary', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API wp-ai-client vocabulary', $failures, $passes );


### PR DESCRIPTION
## Summary
- Clarifies that Data Machine adapts product request shapes into Agents API run requests, and Agents API consumes the `wp-ai-client` public API directly.
- Removes final-architecture “bridge” wording around `wp-ai-client` from the active extraction docs and `WpAiClientAdapter` comments.

## Changes
- Updates the Agents API extraction map and pre-extraction audit dependency diagrams to use `Data Machine product adapter -> Agents API run request -> wp-ai-client public API`.
- Reframes `WpAiClientAdapter` as a Data Machine product/runtime compatibility adapter rather than Agents API vocabulary.
- Adds a static smoke test that blocks “bridge to wp-ai-client” final-architecture wording and host-specific implementation vocabulary inside `agents-api/`.
- Cleans existing lint drift in the touched `WpAiClientAdapter` file so changed-since lint stays green.

## Tests
- `php tests/agents-api-wp-ai-client-vocabulary-smoke.php`
- `php tests/agents-api-no-product-imports-smoke.php`
- `php -l inc/Engine/AI/WpAiClientAdapter.php && php -l tests/agents-api-wp-ai-client-vocabulary-smoke.php`
- `git diff --check`
- `homeboy lint data-machine --path "/Users/chubes/Developer/data-machine@agents-api-wp-ai-client-vocabulary" --changed-since origin/main`
- `homeboy audit data-machine --path "/Users/chubes/Developer/data-machine@agents-api-wp-ai-client-vocabulary" --changed-since origin/main` (passes; reports existing doc-reference audit warnings in the touched extraction docs)

Closes #1652

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the wording cleanup, static smoke test, and focused verification; Chris remains responsible for review and merge.
