### PR TITLE
refactor(ai): remove ai http client runtime fallback

### DIFF
--- a/agents-api/inc/Engine/AI/AgentMessageEnvelope.php
+++ b/agents-api/inc/Engine/AI/AgentMessageEnvelope.php
@@ -139,7 +139,7 @@ class AgentMessageEnvelope {
 	}
 
 	/**
-	 * Project an envelope to the current ai-http-client request message shape.
+	 * Project an envelope to Data Machine's provider request message shape.
 	 *
 	 * @param array $message Typed envelope or legacy message.
 	 * @return array<string, mixed> Provider-facing message.
@@ -170,7 +170,7 @@ class AgentMessageEnvelope {
 	}
 
 	/**
-	 * Project envelopes to the current ai-http-client request message shape.
+	 * Project envelopes to Data Machine's provider request message shape.
 	 *
 	 * @param array $messages Typed envelopes or legacy messages.
 	 * @return array<int, array<string, mixed>> Provider-facing messages.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
 	"require": {
 		"php": ">=8.2",
 		"woocommerce/action-scheduler": "^3.9",
-		"chubes4/ai-http-client": "^2.0.13",
 		"chubes4/block-format-bridge": "^0.6"
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,68 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd21fbb2238b1278591c5aebf49f197a",
+    "content-hash": "11d03bfa8bd031c217381d7eeafd94e0",
     "packages": [
-        {
-            "name": "chubes4/ai-http-client",
-            "version": "v2.0.13",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/chubes4/ai-http-client.git",
-                "reference": "e52312a76523a5b9778376a7bbac751c08a3bed6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/chubes4/ai-http-client/zipball/e52312a76523a5b9778376a7bbac751c08a3bed6",
-                "reference": "e52312a76523a5b9778376a7bbac751c08a3bed6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.0",
-                "phpunit/phpunit": "^9.0 || ^10.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "ai-http-client.php"
-                ],
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Chris Huber",
-                    "email": "chris@chubes.net",
-                    "homepage": "https://chubes.net"
-                }
-            ],
-            "description": "A professional WordPress library for unified AI provider communication. Supports OpenAI, Anthropic, Google Gemini, Grok, and OpenRouter with standardized request/response formats.",
-            "homepage": "https://github.com/chubes4/ai-http-client",
-            "keywords": [
-                "Gemini",
-                "OpenRouter",
-                "ai",
-                "anthropic",
-                "artificial-intelligence",
-                "grok",
-                "http-client",
-                "openai",
-                "wordpress"
-            ],
-            "support": {
-                "issues": "https://github.com/chubes4/ai-http-client/issues",
-                "source": "https://github.com/chubes4/ai-http-client"
-            },
-            "time": "2026-01-31T17:55:07+00:00"
-        },
         {
             "name": "chubes4/block-format-bridge",
             "version": "v0.6.6",

--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -672,7 +672,7 @@ AI agents receive available tools based on:
 - Centralized AI request construction for all agents
 - Directive application system (global, agent-specific, pipeline, chat)
 - Tool restructuring for AI provider compatibility
-- Integration with ai-http-client library
+- Integration with the wp-ai-client runtime adapter
 
 **Tool Results Processing**:
 - Tool responses formatted by ConversationManager for AI consumption

--- a/docs/api/endpoints/chat.md
+++ b/docs/api/endpoints/chat.md
@@ -212,7 +212,7 @@ The Chat endpoint uses the Universal Engine architecture at `/inc/Engine/AI/` fo
 - Centralized AI request construction
 - Hierarchical directive application (global → agent → chat-specific)
 - Tool restructuring for provider compatibility
-- Integration with ai-http-client
+- Integration with the wp-ai-client runtime adapter
 
 **ToolExecutor**
 - Universal tool discovery via filters (`datamachine_global_tools`, `datamachine_chat_tools`)

--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -259,11 +259,9 @@ add_filter(
 );
 ```
 
-### Mirrors the AI HTTP Client provider pattern
+### Mirrors the provider-runtime pattern
 
-This is the same extension shape Data Machine's AI HTTP Client uses to allow
-different LLM providers (OpenAI, Anthropic, Gemini, Grok, OpenRouter) to be
-registered via `chubes_ai_request`. A runtime adapter is the same idea, one
+Runtime adapters use the same separation of concerns as provider runtimes, one
 layer up: providers swap how the LLM is called; runtime adapters swap how the
 conversation is run.
 
@@ -278,11 +276,11 @@ layers and are independent:
   **LLM request layer** that the built-in loop calls internally — a single
   HTTP call to an LLM provider.
 
-When wp-ai-client lands, Data Machine's built-in `execute()` will call
-`wp_ai_client_prompt()` in place of `apply_filters('chubes_ai_request', ...)`.
-The `run()` entry point and the `agents_api_conversation_runner` filter
-contract are unchanged, and adapters that replace the entire loop are
-unaffected — they bring their own LLM client as part of their runtime.
+Data Machine's built-in `execute()` calls `wp_ai_client_prompt()` through the
+wp-ai-client adapter. The `run()` entry point and the
+`agents_api_conversation_runner` filter contract are unchanged, and adapters
+that replace the entire loop are unaffected — they bring their own LLM client
+as part of their runtime.
 
 ## Configuration
 

--- a/docs/core-system/ai-message-envelope.md
+++ b/docs/core-system/ai-message-envelope.md
@@ -5,7 +5,7 @@
 The canonical agent message shape is a JSON-friendly typed envelope. Runtime
 code, chat storage, and transcript storage should store and return envelopes.
 Provider-specific `role/content/metadata` arrays are a projection used at the
-current `ai-http-client` boundary, not the internal contract.
+request-runtime boundary, not the internal contract.
 
 ## Envelope Shape
 
@@ -52,9 +52,9 @@ the initial envelope draft as a read-time compatibility input and rewrites it to
 
 New writes should store canonical envelopes. Current provider requests use
 `AgentMessageEnvelope::to_provider_message()` / `to_provider_messages()` to
-project envelopes into the `role/content/metadata` shape expected by
-`ai-http-client`. That projection folds the envelope `type` and `payload` into
-provider metadata.
+project envelopes into Data Machine's `role/content/metadata` provider-message
+shape. That projection folds the envelope `type` and `payload` into provider
+metadata.
 
 ## Type Payload
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -348,9 +348,10 @@ the resolved definition follows the same shape:
 ]
 ```
 
-### `chubes_ai_request`
+### `chubes_ai_request` (removed runtime path)
 
-**Purpose**: Process AI requests with provider routing and modular directive system message injection
+**Purpose**: Historical provider-dispatch filter. Agent runtime requests now go
+through `RequestBuilder::build()` and the wp-ai-client adapter instead.
 
 **Parameters**:
 
@@ -360,7 +361,7 @@ the resolved definition follows the same shape:
 - `$tools` (array) - Available tools array
 - `$pipeline_step_id` (string|null) - Pipeline step ID for context
 
-**Return**: Array with AI response
+**Return**: Historical array response shape.
 
 **Universal Engine Directive System** (@since v0.2.0): Centralized AI request construction via `RequestBuilder` with hierarchical directive application through filter-based architecture.
 
@@ -419,7 +420,7 @@ add_filter('datamachine_directives', function($directives) {
 });
 ```
 
-**Note**: All AI request building now uses `RequestBuilder::build()` to ensure consistent request structure and directive application. Direct calls to `chubes_ai_request` filter are deprecated - use RequestBuilder instead.
+**Note**: All AI request building now uses `RequestBuilder::build()` to ensure consistent request structure and directive application. Do not add new `chubes_ai_request` dispatch sites.
 
 ### `datamachine_session_title_prompt`
 
@@ -1578,5 +1579,5 @@ $response = \DataMachine\Engine\AI\RequestBuilder::build(
 
 - Directive application system (global, agent-specific, pipeline, chat)
 - Tool restructuring for AI provider compatibility
-- Integration with ai-http-client library
+- Integration with the wp-ai-client runtime adapter
 - Unified request format across all providers

--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -27,8 +27,8 @@ class ConversationManager {
 	 *         ['type' => 'file', 'file_path' => '/path/to/image.jpg', 'mime_type' => 'image/jpeg'],
 	 *     ]
 	 *
-	 * The ai-http-client provider layer (Anthropic, OpenAI, Gemini, OpenRouter)
-	 * already handles array content via process_multimodal_messages().
+	 * RequestBuilder currently supports string content for provider dispatch; callers
+	 * should pass array content only when the active runtime can translate it.
 	 *
 	 * @since 0.2.1
 	 * @since 0.53.0 Accepts array content for multi-modal messages.

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -27,7 +27,7 @@ class RequestBuilder {
 	 *
 	 * Dispatch requires WordPress core's wp-ai-client plus a provider plugin that has
 	 * registered the requested provider. Missing wp-ai-client support is surfaced as a
-	 * request error; agents-api must not silently fall back to ai-http-client.
+	 * request error; agents-api must not silently fall back to another provider client.
 	 *
 	 * @param array  $messages    Initial messages array with role/content
 	 * @param string $provider    AI provider name (openai, anthropic, google, grok, openrouter)

--- a/inc/Engine/AI/WpAiClientAdapter.php
+++ b/inc/Engine/AI/WpAiClientAdapter.php
@@ -3,16 +3,12 @@
  * WordPress AI Client adapter.
  *
  * Bridges Data Machine's RequestBuilder to WordPress core's `wp_ai_client_prompt()`
- * fluent API (introduced in WordPress 7.0). When core's AI client is present and a
- * provider plugin (e.g. `ai-provider-for-openai`) has registered the requested
- * provider, this adapter dispatches the request through core. Otherwise the caller
- * falls back to the bundled `ai-http-client` library via the `chubes_ai_request`
- * filter.
+ * fluent API. Core's AI client plus registered provider plugins are the only
+ * supported agent-runtime provider path.
  *
  * Scope: this class is the request-execution bridge only. Admin UI, REST endpoints,
  * settings, and provider/model discovery continue to flow through the existing
- * `chubes_ai_*` filter surface. Once WordPress 7.0 is the minimum supported version
- * those layers will be migrated and `ai-http-client` will be removed entirely.
+ * legacy filter surface until those layers are migrated separately.
  *
  * @package DataMachine\Engine\AI
  * @since 0.69.1
@@ -33,9 +29,8 @@ class WpAiClientAdapter {
 	 *   3. The requested provider is registered in the default registry — i.e. a
 	 *      provider plugin like `ai-provider-for-openai` is installed and active.
 	 *
-	 * If any condition fails, callers must fall back to the legacy
-	 * `chubes_ai_request` filter so behavior is preserved on sites that haven't
-	 * adopted core's provider plugins yet.
+	 * If any condition fails, callers surface a request-runtime error instead of
+	 * falling back to a secondary provider client.
 	 *
 	 * @since 0.69.1
 	 *
@@ -52,9 +47,9 @@ class WpAiClientAdapter {
 		}
 
 		try {
-			$registry        = \WordPress\AiClient\AiClient::defaultRegistry();
-			$registered_ids  = $registry->getRegisteredProviderIds();
-			$normalized_id   = self::normalizeProviderId( $provider );
+			$registry       = \WordPress\AiClient\AiClient::defaultRegistry();
+			$registered_ids = $registry->getRegisteredProviderIds();
+			$normalized_id  = self::normalizeProviderId( $provider );
 		} catch ( \Throwable $e ) {
 			return false;
 		}
@@ -66,12 +61,12 @@ class WpAiClientAdapter {
 	/**
 	 * Dispatch a Data Machine request through wp-ai-client and normalize the result.
 	 *
-	 * Returns the same array shape as `apply_filters('chubes_ai_request', ...)` so the
-	 * conversation loop, tool executor, and downstream consumers do not change.
+	 * Returns Data Machine's existing normalized response shape so the conversation
+	 * loop, tool executor, and downstream consumers do not change.
 	 *
 	 * If the request contains content that the bridge does not yet translate (currently:
 	 * any non-string message content such as multi-modal blocks), this method returns
-	 * `null` so the caller can fall back to the legacy path.
+	 * `null` so the caller can surface an unsupported request-shape error.
 	 *
 	 * @since 0.69.1
 	 *
@@ -79,11 +74,10 @@ class WpAiClientAdapter {
 	 * @param string $provider  Provider identifier.
 	 * @param array  $tools     Structured tools (name => ['name', 'description', 'parameters', ...]).
 	 * @return array|null Response array on success, error response array on AI failure, or null if the
-	 *                    bridge cannot handle this request and the caller should fall back.
+	 *                    bridge cannot handle this request shape.
 	 */
 	public static function dispatch( array $request, string $provider, array $tools ): ?array {
-		// Bail to the legacy path on any non-string content (multi-modal, attachments, etc.).
-		// These cases will be handled by ai-http-client, which already supports them.
+		// Bail on request shapes the wp-ai-client bridge does not translate yet.
 		foreach ( $request['messages'] ?? array() as $message ) {
 			if ( isset( $message['content'] ) && ! is_string( $message['content'] ) ) {
 				return null;
@@ -96,8 +90,8 @@ class WpAiClientAdapter {
 		}
 
 		try {
-			$registry      = \WordPress\AiClient\AiClient::defaultRegistry();
-			$resolved_id   = self::resolveRegisteredProviderId( $registry, $provider );
+			$registry    = \WordPress\AiClient\AiClient::defaultRegistry();
+			$resolved_id = self::resolveRegisteredProviderId( $registry, $provider );
 		} catch ( \Throwable $e ) {
 			return self::errorResponse( $provider, 'wp-ai-client provider resolution failed: ' . $e->getMessage() );
 		}
@@ -149,10 +143,6 @@ class WpAiClientAdapter {
 			$result = $builder->generate_text_result();
 		} catch ( \Throwable $e ) {
 			return self::errorResponse( $provider, 'wp-ai-client request threw: ' . $e->getMessage() );
-		}
-
-		if ( $result instanceof \WP_Error ) {
-			return self::errorResponse( $provider, $result->get_error_message(), $result->get_error_code() );
 		}
 
 		return self::normalizeResult( $result, $provider );
@@ -364,9 +354,8 @@ class WpAiClientAdapter {
 	/**
 	 * Resolve the API key for this provider via DM's existing key plumbing.
 	 *
-	 * Reads the same `chubes_ai_provider_api_keys` filter that ai-http-client uses,
-	 * so admin UX, network settings, and key persistence remain unchanged during
-	 * the bridge period.
+	 * Reads Data Machine's existing provider-key filter so admin UX, network
+	 * settings, and key persistence remain unchanged until those surfaces migrate.
 	 *
 	 * @since 0.69.1
 	 *
@@ -406,7 +395,7 @@ class WpAiClientAdapter {
 	 * @param string                                          $provider
 	 * @return string The registered provider id to use with the registry.
 	 *
-	 * @throws \WordPress\AiClient\Common\Exception\InvalidArgumentException When the provider is not registered.
+	 * @throws \InvalidArgumentException When the provider is not registered.
 	 */
 	private static function resolveRegisteredProviderId( \WordPress\AiClient\Providers\ProviderRegistry $registry, string $provider ): string {
 		$registered = $registry->getRegisteredProviderIds();
@@ -421,8 +410,8 @@ class WpAiClientAdapter {
 		}
 
 		// Surface a clear failure; caller will translate to an error response.
-		throw new \WordPress\AiClient\Common\Exception\InvalidArgumentException(
-			sprintf( 'Provider %s is not registered in wp-ai-client', $provider )
+		throw new \InvalidArgumentException(
+			sprintf( 'Provider %s is not registered in wp-ai-client', esc_html( $provider ) )
 		);
 	}
 

--- a/inc/Engine/AI/WpAiClientCapability.php
+++ b/inc/Engine/AI/WpAiClientCapability.php
@@ -15,7 +15,7 @@ class WpAiClientCapability {
 	 * Explain why wp-ai-client cannot handle this request.
 	 *
 	 * This is the single request-runtime capability gate. It intentionally does not
-	 * preserve an ai-http-client fallback path; unavailable wp-ai-client support is
+	 * preserve a secondary provider fallback path; unavailable wp-ai-client support is
 	 * a configuration/runtime error that should surface before dispatch.
 	 *
 	 * @since next

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -48,10 +48,12 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 }
 
 require_once __DIR__ . '/bootstrap-unit.php';
+require_once __DIR__ . '/Unit/Support/WpAiClientTestDoubles.php';
 
 use DataMachine\Engine\AI\AIConversationLoop;
 use DataMachine\Engine\AI\AgentConversationRequest;
 use DataMachine\Engine\AI\LoopEventSinkInterface;
+use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 
 class RunnerRequestSmokeSink implements LoopEventSinkInterface {
 	public array $events = array();
@@ -149,10 +151,9 @@ add_filter(
 );
 
 $dispatched_request = null;
-add_filter(
-	'chubes_ai_request',
-	function ( array $request_body, ...$args ) use ( &$dispatched_request ) {
-		unset( $args );
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function ( array $request_body ) use ( &$dispatched_request ) {
 		$dispatched_request = $request_body;
 
 		return array(
@@ -167,9 +168,7 @@ add_filter(
 				),
 			),
 		);
-	},
-	10,
-	6
+	}
 );
 
 $result = AIConversationLoop::run(

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -48,12 +48,14 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 }
 
 require_once __DIR__ . '/bootstrap-unit.php';
+require_once __DIR__ . '/Unit/Support/WpAiClientTestDoubles.php';
 
 use DataMachine\Engine\AI\AIConversationLoop;
 use DataMachine\Engine\AI\AgentConversationCompletionDecision;
 use DataMachine\Engine\AI\AgentConversationCompletionPolicyInterface;
 use DataMachine\Engine\AI\AgentConversationTranscriptPersisterInterface;
 use DataMachine\Engine\AI\DataMachineHandlerCompletionPolicy;
+use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 
 class RuntimePolicySmokeCompletionPolicy implements AgentConversationCompletionPolicyInterface {
 	public array $calls = array();
@@ -151,12 +153,11 @@ $provider_context   = null;
 $completion_policy  = new RuntimePolicySmokeCompletionPolicy();
 $transcript_policy  = new RuntimePolicySmokeTranscriptPersister();
 
-add_filter(
-	'chubes_ai_request',
-	function ( array $request_body, string $provider, $streaming_callback, array $tools, $step_id, array $context ) use ( &$dispatch_count, &$provider_context ) {
-		unset( $request_body, $provider, $streaming_callback, $tools, $step_id );
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function ( array $request_body ) use ( &$dispatch_count, &$provider_context ) {
 		++$dispatch_count;
-		$provider_context = $context;
+		$provider_context = $request_body;
 
 		return array(
 			'success' => true,
@@ -171,9 +172,7 @@ add_filter(
 				'usage'      => array( 'prompt_tokens' => 3, 'completion_tokens' => 2, 'total_tokens' => 5 ),
 			),
 		);
-	},
-	10,
-	6
+	}
 );
 
 $result = ( new AIConversationLoop() )->execute(
@@ -204,8 +203,8 @@ assert_runtime_policy( 'runtime-policy-transcript' === ( $result['transcript_ses
 assert_runtime_policy( 1 === count( $completion_policy->calls ), 'custom completion policy received one tool result' );
 assert_runtime_policy( 'runtime_policy_tool' === ( $completion_policy->calls[0]['tool_name'] ?? null ), 'custom completion policy receives tool name' );
 assert_runtime_policy( 1 === count( $transcript_policy->calls ), 'custom transcript persister was called once on success' );
-assert_runtime_policy( ! array_key_exists( 'completion_policy', $provider_context['payload'] ?? array() ), 'completion policy object is stripped before provider dispatch' );
-assert_runtime_policy( ! array_key_exists( 'transcript_persister', $provider_context['payload'] ?? array() ), 'transcript persister object is stripped before provider dispatch' );
+assert_runtime_policy( ! str_contains( wp_json_encode( $provider_context ), 'completion_policy' ), 'completion policy object is stripped before provider dispatch' );
+assert_runtime_policy( ! str_contains( wp_json_encode( $provider_context ), 'transcript_persister' ), 'transcript persister object is stripped before provider dispatch' );
 assert_runtime_policy( runtime_policy_logs_contain( 'RuntimePolicySmoke: custom policy completed' ), 'completion policy diagnostic message is logged by the adapter' );
 
 if ( runtime_policy_failure_count() > 0 ) {

--- a/tests/ai-loop-event-sink-smoke.php
+++ b/tests/ai-loop-event-sink-smoke.php
@@ -48,10 +48,12 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 }
 
 require_once __DIR__ . '/bootstrap-unit.php';
+require_once __DIR__ . '/Unit/Support/WpAiClientTestDoubles.php';
 
 use DataMachine\Engine\AI\AIConversationLoop;
 use DataMachine\Engine\AI\LoopEventSinkInterface;
 use DataMachine\Engine\AI\NullLoopEventSink;
+use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 
 class LoopEventSinkSmokeCollector implements LoopEventSinkInterface {
 	public array $events = array();
@@ -147,10 +149,9 @@ reset_loop_event_sink_smoke();
 $dispatch_count = 0;
 $collector      = new LoopEventSinkSmokeCollector();
 
-add_filter(
-	'chubes_ai_request',
-	function ( ...$args ) use ( &$dispatch_count ) {
-		unset( $args );
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$dispatch_count ) {
 		++$dispatch_count;
 
 		if ( 1 === $dispatch_count ) {
@@ -177,9 +178,7 @@ add_filter(
 				'usage'      => array( 'prompt_tokens' => 4, 'completion_tokens' => 1, 'total_tokens' => 5 ),
 			),
 		);
-	},
-	10,
-	6
+	}
 );
 
 $result = ( new AIConversationLoop() )->execute(
@@ -212,15 +211,11 @@ assert_loop_event_sink( ! array_key_exists( 'event_sink', LoopEventSinkSmokeTool
 // 3. Failure events are emitted on AI request failure without changing the return array.
 reset_loop_event_sink_smoke();
 $failure_sink = new LoopEventSinkSmokeCollector();
-add_filter(
-	'chubes_ai_request',
-	fn( ...$args ) => array(
-		'success'  => false,
-		'error'    => 'provider offline',
-		'provider' => 'openai',
-	),
-	10,
-	6
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () {
+		throw new RuntimeException( 'provider offline' );
+	}
 );
 
 $failure_result = ( new AIConversationLoop() )->execute(
@@ -234,23 +229,21 @@ $failure_result = ( new AIConversationLoop() )->execute(
 );
 
 assert_loop_event_sink( false === $failure_result['completed'], 'failure path preserves completed=false result shape' );
-assert_loop_event_sink( 'provider offline' === ( $failure_result['error'] ?? null ), 'failure path preserves error message' );
+assert_loop_event_sink( str_contains( (string) ( $failure_result['error'] ?? '' ), 'provider offline' ), 'failure path preserves error message' );
 assert_loop_event_sink( array( 'turn_started', 'request_built', 'failed' ) === loop_event_sink_event_names( $failure_sink ), 'failure path emits failed after request_built' );
-assert_loop_event_sink( 'provider offline' === ( $failure_sink->events[2]['payload']['error'] ?? null ), 'failed payload includes the provider error' );
+assert_loop_event_sink( str_contains( (string) ( $failure_sink->events[2]['payload']['error'] ?? '' ), 'provider offline' ), 'failed payload includes the provider error' );
 
 // 4. Sink failures are logged and never change loop output.
 reset_loop_event_sink_smoke();
-add_filter(
-	'chubes_ai_request',
-	fn( ...$args ) => array(
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	fn() => array(
 		'success' => true,
 		'data'    => array(
 			'content'    => 'still done',
 			'tool_calls' => array(),
 		),
-	),
-	10,
-	6
+	)
 );
 
 $throwing_result = ( new AIConversationLoop() )->execute(
@@ -274,6 +267,7 @@ if ( 0 === $failure_count ) {
 }
 
 echo sprintf( "%d failure(s):\n", $failure_count );
+/** @var array<int, string> $failures */
 foreach ( $failures as $failure ) {
 	echo "  - {$failure}\n";
 }

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -78,6 +78,7 @@ function size_format( $bytes ): string {
 }
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+require_once dirname( __DIR__ ) . '/agents-api/agents-api.php';
 
 use DataMachine\Cli\Commands\JobsCommand;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;

--- a/tests/wp-ai-client-runtime-gate-smoke.php
+++ b/tests/wp-ai-client-runtime-gate-smoke.php
@@ -60,6 +60,7 @@ function size_format( $bytes ): string {
 }
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+require_once dirname( __DIR__ ) . '/agents-api/agents-api.php';
 
 use DataMachine\Engine\AI\RequestBuilder;
 use DataMachine\Engine\AI\WpAiClientCapability;


### PR DESCRIPTION
## Summary
- Removes the `chubes4/ai-http-client` Composer dependency now that the built-in agent runtime is gated through `wp-ai-client`.
- Updates runtime docs/comments and focused smoke fixtures so they no longer model `chubes_ai_request` as a fallback path.

## Runtime removal
- Drops `chubes4/ai-http-client` from `composer.json` and `composer.lock`.
- Keeps `RequestBuilder` dispatching only through `WpAiClientCapability` + `WpAiClientAdapter`; unsupported runtime shapes now surface the existing structured wp-ai-client error path instead of falling back.
- Updates focused loop/runtime smokes to use the wp-ai-client test double instead of registering `chubes_ai_request` callbacks.

## Retained legacy surfaces
- `chubes_ai_provider_api_keys`, `chubes_ai_providers`, and `chubes_ai_models` remain in Data Machine provider/settings/admin discovery surfaces for a separate migration.
- `chubes_ai_request_failed` remains as an error code string in chat orchestration, not a provider dispatch hook.
- `chubes_ai_tools` remains as the existing legacy handler-tool surface and is not changed here.

## Tests
- `composer install --no-interaction --prefer-dist`
- `php tests/wp-ai-client-runtime-gate-smoke.php && php tests/ai-request-metadata-guardrails-smoke.php && php tests/ai-request-inspector-smoke.php && php tests/ai-loop-event-sink-smoke.php && php tests/agent-conversation-runtime-policy-smoke.php && php tests/agent-conversation-runner-request-smoke.php && php tests/agents-api-bootstrap-smoke.php && php tests/agents-api-registration-smoke.php && php tests/agents-api-no-product-imports-smoke.php`
- `git diff --check`
- `composer validate --no-check-publish` (passes with the existing `version` field warning)
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@remove-ai-http-client-runtime --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@remove-ai-http-client-runtime --changed-since origin/main`

Refs #1027

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runtime dependency removal, updated focused tests/docs, and ran verification. Chris remains responsible for review and merge.
