### PR TITLE
refactor(ai): route image generation through wp-ai-client

### DIFF
--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -2,7 +2,7 @@
 /**
  * Image Generation Abilities
  *
- * Primitive ability for AI image generation via Replicate API.
+ * Primitive ability for AI image generation via wp-ai-client.
  * All image generation — tools, CLI, REST, chat — flows through this ability.
  *
  * Includes optional prompt refinement: uses Data Machine's configured AI provider
@@ -16,9 +16,10 @@
 namespace DataMachine\Abilities\Media;
 
 use DataMachine\Abilities\PermissionHelper;
-use DataMachine\Core\HttpClient;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\RequestBuilder;
+use DataMachine\Engine\AI\WpAiClientAdapter;
+use DataMachine\Engine\AI\WpAiClientCapability;
 use DataMachine\Engine\Tasks\TaskScheduler;
 
 defined( 'ABSPATH' ) || exit;
@@ -33,11 +34,18 @@ class ImageGenerationAbilities {
 	const CONFIG_OPTION = 'datamachine_image_generation_config';
 
 	/**
-	 * Default model identifier on Replicate.
+	 * Default provider identifier for wp-ai-client image generation.
 	 *
 	 * @var string
 	 */
-	const DEFAULT_MODEL = 'google/imagen-4-fast';
+	const DEFAULT_PROVIDER = 'openai';
+
+	/**
+	 * Default model identifier for wp-ai-client image generation.
+	 *
+	 * @var string
+	 */
+	const DEFAULT_MODEL = 'gpt-image-1';
 
 	/**
 	 * Default aspect ratio for generated images.
@@ -70,7 +78,7 @@ class ImageGenerationAbilities {
 				'datamachine/generate-image',
 				array(
 					'label'               => 'Generate Image',
-					'description'         => 'Generate an image using AI models via Replicate API',
+					'description'         => 'Generate an image using AI models via wp-ai-client',
 					'category'            => 'datamachine-media',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -82,7 +90,11 @@ class ImageGenerationAbilities {
 							),
 							'model'           => array(
 								'type'        => 'string',
-								'description' => 'Replicate model identifier (default: google/imagen-4-fast).',
+								'description' => 'wp-ai-client model identifier. Defaults to the image generation tool configuration.',
+							),
+							'provider'        => array(
+								'type'        => 'string',
+								'description' => 'wp-ai-client provider identifier. Defaults to the image generation tool configuration.',
 							),
 							'aspect_ratio'    => array(
 								'type'        => 'string',
@@ -114,12 +126,12 @@ class ImageGenerationAbilities {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'       => array( 'type' => 'boolean' ),
-							'pending'       => array( 'type' => 'boolean' ),
-							'job_id'        => array( 'type' => 'integer' ),
-							'prediction_id' => array( 'type' => 'string' ),
-							'message'       => array( 'type' => 'string' ),
-							'error'         => array( 'type' => 'string' ),
+							'success'   => array( 'type' => 'boolean' ),
+							'pending'   => array( 'type' => 'boolean' ),
+							'job_id'    => array( 'type' => 'integer' ),
+							'image_url' => array( 'type' => 'string' ),
+							'message'   => array( 'type' => 'string' ),
+							'error'     => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'generateImage' ),
@@ -137,11 +149,11 @@ class ImageGenerationAbilities {
 	}
 
 	/**
-	 * Generate an image via Replicate API.
+	 * Generate an image via wp-ai-client.
 	 *
 	 * Optionally refines the prompt using Data Machine's configured AI provider,
-	 * then starts a Replicate prediction and hands off to the System Agent
-	 * for async polling and completion.
+	 * then asks wp-ai-client to generate the image and hands off to the System
+	 * Agent for media sideloading and post mutation.
 	 *
 	 * @param array $input Ability input.
 	 * @return array Ability response.
@@ -157,11 +169,28 @@ class ImageGenerationAbilities {
 		}
 
 		$config = self::get_config();
-
-		if ( empty( $config['api_key'] ) ) {
+		if ( empty( $config ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'Image generation not configured. Add a Replicate API key in Settings.',
+				'error'   => 'Image generation not configured. Select a wp-ai-client provider and model in Settings.',
+			);
+		}
+
+		$provider = ! empty( $input['provider'] ) ? sanitize_text_field( $input['provider'] ) : ( $config['default_provider'] ?? self::DEFAULT_PROVIDER );
+		$model    = ! empty( $input['model'] ) ? sanitize_text_field( $input['model'] ) : ( $config['default_model'] ?? self::DEFAULT_MODEL );
+
+		if ( empty( $provider ) || empty( $model ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Image generation not configured. Select a wp-ai-client provider and model in Settings.',
+			);
+		}
+
+		$unavailable_reason = WpAiClientCapability::unavailableReason( $provider );
+		if ( null !== $unavailable_reason ) {
+			return array(
+				'success' => false,
+				'error'   => $unavailable_reason,
 			);
 		}
 
@@ -177,48 +206,29 @@ class ImageGenerationAbilities {
 			// If refinement fails, continue with the original prompt — never block.
 		}
 
-		$model        = ! empty( $input['model'] ) ? sanitize_text_field( $input['model'] ) : ( $config['default_model'] ?? self::DEFAULT_MODEL );
 		$aspect_ratio = ! empty( $input['aspect_ratio'] ) ? sanitize_text_field( $input['aspect_ratio'] ) : ( $config['default_aspect_ratio'] ?? self::DEFAULT_ASPECT_RATIO );
 
 		if ( ! in_array( $aspect_ratio, self::VALID_ASPECT_RATIOS, true ) ) {
 			$aspect_ratio = self::DEFAULT_ASPECT_RATIO;
 		}
 
-		$input_params = self::buildInputParams( $prompt, $aspect_ratio, $model );
-
-		// Start Replicate prediction.
-		$result = HttpClient::post(
-			"https://api.replicate.com/v1/models/{$model}/predictions",
-			array(
-				'timeout' => 30,
-				'headers' => array(
-					'Authorization' => 'Token ' . $config['api_key'],
-					'Content-Type'  => 'application/json',
-				),
-				'body'    => wp_json_encode( array(
-					'input' => $input_params,
-				) ),
-				'context' => 'Image Generation Ability',
-			)
-		);
+		$result = WpAiClientAdapter::generateImage( $prompt, $provider, $model, $aspect_ratio );
 
 		if ( ! $result['success'] ) {
 			return array(
 				'success' => false,
-				'error'   => 'Failed to start image generation: ' . ( $result['error'] ?? 'Unknown error' ),
+				'error'   => 'Failed to generate image: ' . ( $result['error'] ?? 'Unknown error' ),
 			);
 		}
 
-		$prediction = json_decode( $result['data'], true );
-
-		if ( json_last_error() !== JSON_ERROR_NONE || empty( $prediction['id'] ) ) {
+		if ( empty( $result['image_url'] ) && empty( $result['image_data_uri'] ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'Invalid response from Replicate API.',
+				'error'   => 'wp-ai-client image generation returned no usable image.',
 			);
 		}
 
-		// Hand off to System Agent for async polling.
+		// Hand off to System Agent for async media handling and post mutation.
 		$context = array();
 		if ( ! empty( $input['pipeline_job_id'] ) ) {
 			$context['pipeline_job_id'] = (int) $input['pipeline_job_id'];
@@ -236,7 +246,9 @@ class ImageGenerationAbilities {
 		$jobId = TaskScheduler::schedule(
 			'image_generation',
 			array(
-				'prediction_id'   => $prediction['id'],
+				'image_url'       => $result['image_url'] ?? '',
+				'image_data_uri'  => $result['image_data_uri'] ?? '',
+				'provider'        => $result['provider'] ?? $provider,
 				'model'           => $model,
 				'prompt'          => $prompt,
 				'original_prompt' => $original_prompt,
@@ -254,11 +266,11 @@ class ImageGenerationAbilities {
 		}
 
 		return array(
-			'success'       => true,
-			'pending'       => true,
-			'job_id'        => $jobId,
-			'prediction_id' => $prediction['id'],
-			'message'       => "Image generation scheduled (Job #{$jobId}). Model: {$model}, aspect ratio: {$aspect_ratio}."
+			'success'   => true,
+			'pending'   => true,
+			'job_id'    => $jobId,
+			'image_url' => $result['image_url'] ?? '',
+			'message'   => "Image generation scheduled (Job #{$jobId}). Model: {$model}, aspect ratio: {$aspect_ratio}."
 				. ( $prompt !== $original_prompt ? ' Prompt was refined by AI.' : '' ),
 		);
 	}
@@ -416,41 +428,20 @@ class ImageGenerationAbilities {
 	}
 
 	/**
-	 * Build model-specific input parameters for Replicate.
-	 *
-	 * @param string $prompt       Image generation prompt.
-	 * @param string $aspect_ratio Aspect ratio.
-	 * @param string $model        Model identifier.
-	 * @return array Input parameters.
-	 */
-	private static function buildInputParams( string $prompt, string $aspect_ratio, string $model ): array {
-		if ( false !== strpos( $model, 'imagen' ) ) {
-			return array(
-				'prompt'              => $prompt,
-				'aspect_ratio'        => $aspect_ratio,
-				'output_format'       => 'jpg',
-				'safety_filter_level' => 'block_only_high',
-			);
-		}
-
-		// Flux and other models.
-		return array(
-			'prompt'         => $prompt,
-			'num_outputs'    => 1,
-			'aspect_ratio'   => $aspect_ratio,
-			'output_format'  => 'webp',
-			'output_quality' => 90,
-		);
-	}
-
-	/**
 	 * Check if image generation is configured.
 	 *
 	 * @return bool
 	 */
 	public static function is_configured(): bool {
 		$config = self::get_config();
-		return ! empty( $config['api_key'] );
+		if ( empty( $config ) ) {
+			return false;
+		}
+
+		$provider = $config['default_provider'] ?? self::DEFAULT_PROVIDER;
+		$model    = $config['default_model'] ?? self::DEFAULT_MODEL;
+
+		return ! empty( $provider ) && ! empty( $model ) && null === WpAiClientCapability::unavailableReason( (string) $provider );
 	}
 
 	/**

--- a/inc/Abilities/Media/ImageTemplateAbilities.php
+++ b/inc/Abilities/Media/ImageTemplateAbilities.php
@@ -3,7 +3,7 @@
  * Image Template Abilities
  *
  * Ability for rendering images from registered GD templates.
-	 * Complements ImageGenerationAbilities (AI image models) with
+ * Complements ImageGenerationAbilities (AI image models) with
  * deterministic, text-heavy, brand-consistent graphic output.
  *
  * @package DataMachine\Abilities\Media
@@ -20,7 +20,8 @@ class ImageTemplateAbilities {
 
 	private static bool $registered = false;
 
-	public function __construct() {		if ( self::$registered ) {
+	public function __construct() {
+		if ( self::$registered ) {
 			return;
 		}
 		$this->registerAbilities();
@@ -317,13 +318,14 @@ class ImageTemplateAbilities {
 				continue;
 			}
 
-			$ext       = strtolower( pathinfo( $source_path, PATHINFO_EXTENSION ) ) ?: 'png';
+			$ext       = strtolower( pathinfo( $source_path, PATHINFO_EXTENSION ) );
+			$ext       = '' !== $ext ? $ext : 'png';
 			$suffix    = count( $file_paths ) > 1 ? '-' . ( $index + 1 ) : '';
 			$filename  = $key . $suffix . '.' . $ext;
 			$dest_path = trailingslashit( $bucket_dir ) . $filename;
 			$dest_url  = trailingslashit( $bucket_url ) . $filename;
 
-			if ( ! @copy( $source_path, $dest_path ) ) {
+			if ( ! copy( $source_path, $dest_path ) ) {
 				$failures[] = basename( $source_path );
 				continue;
 			}
@@ -361,7 +363,7 @@ class ImageTemplateAbilities {
 	 * @return array Result with template definitions.
 	 */
 	public static function listTemplates( array $input ): array {
-		$input;
+		unset( $input );
 		return array(
 			'success'   => true,
 			'templates' => TemplateRegistry::get_template_definitions(),

--- a/inc/Abilities/Media/ImageTemplateAbilities.php
+++ b/inc/Abilities/Media/ImageTemplateAbilities.php
@@ -3,7 +3,7 @@
  * Image Template Abilities
  *
  * Ability for rendering images from registered GD templates.
- * Complements ImageGenerationAbilities (AI/Replicate) with
+	 * Complements ImageGenerationAbilities (AI image models) with
  * deterministic, text-heavy, brand-consistent graphic output.
  *
  * @package DataMachine\Abilities\Media

--- a/inc/Cli/Commands/ImageCommand.php
+++ b/inc/Cli/Commands/ImageCommand.php
@@ -2,7 +2,7 @@
 /**
  * WP-CLI Image Command
  *
- * Provides CLI access to AI image generation (Replicate) and
+ * Provides CLI access to AI image generation (wp-ai-client) and
  * GD template rendering. Wraps ImageGenerationAbilities and
  * ImageTemplateAbilities.
  *
@@ -23,10 +23,10 @@ defined( 'ABSPATH' ) || exit;
 class ImageCommand extends BaseCommand {
 
 	/**
-	 * Generate an AI image via Replicate.
+	 * Generate an AI image via wp-ai-client.
 	 *
-	 * Starts an async prediction on Replicate and schedules a System Agent
-	 * task to poll for completion. Optionally refines the prompt via the
+	 * Generates the image through wp-ai-client and schedules a System Agent
+	 * task for media handling and post updates. Optionally refines the prompt via the
 	 * configured AI provider before sending to the image model.
 	 *
 	 * ## OPTIONS
@@ -38,7 +38,10 @@ class ImageCommand extends BaseCommand {
 	 * : Post ID to attach the generated image to.
 	 *
 	 * [--model=<model>]
-	 * : Replicate model identifier (default: google/imagen-4-fast).
+	 * : wp-ai-client model identifier.
+	 *
+	 * [--provider=<provider>]
+	 * : wp-ai-client provider identifier.
 	 *
 	 * [--aspect_ratio=<ratio>]
 	 * : Image aspect ratio: 1:1, 3:4, 4:3, 9:16, 16:9 (default: 3:4).
@@ -86,7 +89,7 @@ class ImageCommand extends BaseCommand {
 		}
 
 		if ( ! ImageGenerationAbilities::is_configured() ) {
-			WP_CLI::error( 'Image generation not configured. Add a Replicate API key in Settings → Image Generation.' );
+			WP_CLI::error( 'Image generation not configured. Select a wp-ai-client provider/model in Settings → Image Generation and configure provider credentials.' );
 			return;
 		}
 
@@ -97,6 +100,9 @@ class ImageCommand extends BaseCommand {
 		}
 		if ( ! empty( $assoc_args['model'] ) ) {
 			$input['model'] = $assoc_args['model'];
+		}
+		if ( ! empty( $assoc_args['provider'] ) ) {
+			$input['provider'] = $assoc_args['provider'];
 		}
 		if ( ! empty( $assoc_args['aspect_ratio'] ) ) {
 			$input['aspect_ratio'] = $assoc_args['aspect_ratio'];
@@ -131,13 +137,13 @@ class ImageCommand extends BaseCommand {
 
 		$items = array(
 			array(
-				'job_id'        => $result['job_id'] ?? '',
-				'prediction_id' => $result['prediction_id'] ?? '',
-				'status'        => $result['pending'] ? 'pending' : 'complete',
+				'job_id'    => $result['job_id'] ?? '',
+				'image_url' => $result['image_url'] ?? '',
+				'status'    => $result['pending'] ? 'pending' : 'complete',
 			),
 		);
 
-		$this->format_items( $items, array( 'job_id', 'prediction_id', 'status' ), $assoc_args );
+		$this->format_items( $items, array( 'job_id', 'image_url', 'status' ), $assoc_args );
 	}
 
 	/**
@@ -336,7 +342,7 @@ class ImageCommand extends BaseCommand {
 	/**
 	 * Check image generation configuration status.
 	 *
-	 * Shows whether the Replicate API key is configured and prompt
+	 * Shows whether wp-ai-client image generation is configured and prompt
 	 * refinement is enabled.
 	 *
 	 * ## EXAMPLES
@@ -349,13 +355,18 @@ class ImageCommand extends BaseCommand {
 		$configured    = ImageGenerationAbilities::is_configured();
 		$refinement    = ImageGenerationAbilities::is_refinement_enabled();
 		$config        = ImageGenerationAbilities::get_config();
+		$provider      = $config['default_provider'] ?? ImageGenerationAbilities::DEFAULT_PROVIDER;
 		$default_model = $config['default_model'] ?? ImageGenerationAbilities::DEFAULT_MODEL;
 		$default_ratio = $config['default_aspect_ratio'] ?? ImageGenerationAbilities::DEFAULT_ASPECT_RATIO;
 
 		$items = array(
 			array(
-				'setting' => 'Replicate API Key',
+				'setting' => 'wp-ai-client Image Provider',
 				'value'   => $configured ? 'Configured' : 'Not configured',
+			),
+			array(
+				'setting' => 'Default Provider',
+				'value'   => $provider,
 			),
 			array(
 				'setting' => 'Prompt Refinement',

--- a/inc/Cli/Commands/ImageCommand.php
+++ b/inc/Cli/Commands/ImageCommand.php
@@ -129,7 +129,7 @@ class ImageCommand extends BaseCommand {
 		$format = $assoc_args['format'] ?? 'table';
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( \wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			WP_CLI::line( self::encode_json( $result ) );
 			return;
 		}
 
@@ -284,7 +284,7 @@ class ImageCommand extends BaseCommand {
 		$format = $assoc_args['format'] ?? 'table';
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( \wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			WP_CLI::line( self::encode_json( $result ) );
 			return;
 		}
 
@@ -446,7 +446,7 @@ class ImageCommand extends BaseCommand {
 		);
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( \wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			WP_CLI::line( self::encode_json( $result ) );
 			return;
 		}
 
@@ -568,7 +568,7 @@ class ImageCommand extends BaseCommand {
 		);
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( \wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			WP_CLI::line( self::encode_json( $result ) );
 			return;
 		}
 
@@ -605,5 +605,16 @@ class ImageCommand extends BaseCommand {
 		if ( ! empty( $result['batch_id'] ) ) {
 			WP_CLI::log( sprintf( 'Batch ID: %d — track progress with: wp datamachine jobs list --parent_id=%d', $result['batch_id'], $result['batch_id'] ) );
 		}
+	}
+
+	/**
+	 * Encode CLI JSON output.
+	 *
+	 * @param array $data Data to encode.
+	 * @return string JSON payload.
+	 */
+	private static function encode_json( array $data ): string {
+		$encoded = \wp_json_encode( $data, JSON_PRETTY_PRINT );
+		return false === $encoded ? '{}' : $encoded;
 	}
 }

--- a/inc/Engine/AI/System/Tasks/ImageGenerationTask.php
+++ b/inc/Engine/AI/System/Tasks/ImageGenerationTask.php
@@ -2,8 +2,7 @@
 /**
  * Image Generation Task for System Agent.
  *
- * Handles async image generation through Replicate API. Polls for prediction
- * status and handles completion, failure, or rescheduling for continued polling.
+ * Handles async media processing for wp-ai-client generated images.
  *
  * @package DataMachine\Engine\AI\System\Tasks
  * @since 0.22.4
@@ -14,104 +13,43 @@ namespace DataMachine\Engine\AI\System\Tasks;
 
 defined( 'ABSPATH' ) || exit;
 
-use DataMachine\Core\HttpClient;
-
 class ImageGenerationTask extends SystemTask {
 
-	const MAX_ATTEMPTS = 24;
 	const JPEG_QUALITY = 85;
 
 	/**
 	 * Execute image generation task.
 	 *
 	 * @param int   $jobId  Job ID from DM Jobs table.
-	 * @param array $params Task parameters containing prediction_id, api_key, etc.
+	 * @param array $params Task parameters containing generated image file data.
 	 */
 	public function executeTask( int $jobId, array $params ): void {
-		$prediction_id = $params['prediction_id'] ?? '';
-		$model         = $params['model'] ?? 'unknown';
+		$image_url      = $params['image_url'] ?? '';
+		$image_data_uri = $params['image_data_uri'] ?? '';
+		$model          = $params['model'] ?? 'unknown';
+		$prompt         = $params['prompt'] ?? '';
+		$aspect_ratio   = $params['aspect_ratio'] ?? '';
 
-		$config       = \DataMachine\Abilities\Media\ImageGenerationAbilities::get_config();
-		$api_key      = $config['api_key'] ?? '';
-		$prompt       = $params['prompt'] ?? '';
-		$aspect_ratio = $params['aspect_ratio'] ?? '';
-
-		if ( empty( $prediction_id ) ) {
-			$this->failJob( $jobId, 'Missing prediction_id in task parameters' );
+		if ( empty( $image_url ) && empty( $image_data_uri ) ) {
+			$this->failJob( $jobId, 'Missing generated image file in task parameters' );
 			return;
 		}
 
-		if ( empty( $api_key ) ) {
-			$this->failJob( $jobId, 'Replicate API key not configured' );
-			return;
-		}
-
-		$jobs_db     = new \DataMachine\Core\Database\Jobs\Jobs();
-		$job         = $jobs_db->get_job( $jobId );
-		$engine_data = $job['engine_data'] ?? array();
-		if ( ! isset( $engine_data['max_attempts'] ) ) {
-			$engine_data['max_attempts'] = self::MAX_ATTEMPTS;
-			$jobs_db->store_engine_data( $jobId, $engine_data );
-		}
-
-		$result = HttpClient::get(
-			"https://api.replicate.com/v1/predictions/{$prediction_id}",
-			array(
-				'timeout' => 15,
-				'headers' => array(
-					'Authorization' => 'Token ' . $api_key,
-				),
-				'context' => 'System Agent Image Generation Poll',
-			)
+		$this->handleSuccess(
+			$jobId,
+			array( 'output' => ! empty( $image_url ) ? $image_url : $image_data_uri ),
+			$model,
+			$prompt,
+			$aspect_ratio,
+			$params
 		);
-
-		if ( ! $result['success'] ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				"System Agent image generation HTTP error for job {$jobId}: " . ( $result['error'] ?? 'Unknown error' ),
-				array(
-					'job_id'        => $jobId,
-					'task_type'     => $this->getTaskType(),
-					'context'       => 'system',
-					'prediction_id' => $prediction_id,
-					'error'         => $result['error'] ?? 'Unknown HTTP error',
-				)
-			);
-
-			$this->reschedule( $jobId, 5 );
-			return;
-		}
-
-		$status_data = json_decode( $result['data'], true );
-		$status      = $status_data['status'] ?? '';
-
-		switch ( $status ) {
-			case 'succeeded':
-				$this->handleSuccess( $jobId, $status_data, $model, $prompt, $aspect_ratio, $params );
-				break;
-
-			case 'failed':
-			case 'canceled':
-				$error = $status_data['error'] ?? "Prediction {$status}";
-				$this->failJob( $jobId, "Replicate prediction failed: {$error}" );
-				break;
-
-			case 'starting':
-			case 'processing':
-				$this->reschedule( $jobId, 5 );
-				break;
-
-			default:
-				$this->failJob( $jobId, "Unknown prediction status: {$status}" );
-		}
 	}
 
 	/**
 	 * Handle successful prediction completion.
 	 *
 	 * @param int    $jobId       Job ID.
-	 * @param array  $statusData  Replicate prediction status data.
+	 * @param array  $statusData  Generated image status data.
 	 * @param string $model       Model used for generation.
 	 * @param string $prompt      Original prompt.
 	 * @param string $aspectRatio Original aspect ratio.
@@ -128,7 +66,7 @@ class ImageGenerationTask extends SystemTask {
 		}
 
 		if ( empty( $image_url ) ) {
-			$this->failJob( $jobId, 'Replicate prediction succeeded but no image URL found in output' );
+			$this->failJob( $jobId, 'Image generation succeeded but no image file found in output' );
 			return;
 		}
 
@@ -137,7 +75,7 @@ class ImageGenerationTask extends SystemTask {
 
 		$sideload_result = $this->sideloadImage( $image_url, $prompt, $model );
 
-		if ( is_wp_error( $sideload_result ) ) {
+		if ( $sideload_result instanceof \WP_Error ) {
 			do_action(
 				'datamachine_log',
 				'warning',
@@ -150,9 +88,9 @@ class ImageGenerationTask extends SystemTask {
 					'error'     => $sideload_result->get_error_message(),
 				)
 			);
-		} else {
-			$attachment_id  = $sideload_result['attachment_id'];
-			$attachment_url = $sideload_result['attachment_url'];
+		} elseif ( is_array( $sideload_result ) ) {
+			$attachment_id  = (int) ( $sideload_result['attachment_id'] ?? 0 );
+			$attachment_url = (string) ( $sideload_result['attachment_url'] ?? '' );
 		}
 
 		$image_file_path = null;
@@ -230,7 +168,12 @@ class ImageGenerationTask extends SystemTask {
 				'datamachine_log',
 				'debug',
 				"System Agent: Post #{$post_id} already has a featured image, skipping",
-				array( 'job_id' => $jobId, 'post_id' => $post_id, 'attachment_id' => $attachmentId, 'context' => 'system' )
+				array(
+					'job_id'        => $jobId,
+					'post_id'       => $post_id,
+					'attachment_id' => $attachmentId,
+					'context'       => 'system',
+				)
 			);
 			return array();
 		}
@@ -242,7 +185,12 @@ class ImageGenerationTask extends SystemTask {
 				'datamachine_log',
 				'info',
 				"System Agent: Featured image set on post #{$post_id} (attachment #{$attachmentId})",
-				array( 'job_id' => $jobId, 'post_id' => $post_id, 'attachment_id' => $attachmentId, 'context' => 'system' )
+				array(
+					'job_id'        => $jobId,
+					'post_id'       => $post_id,
+					'attachment_id' => $attachmentId,
+					'context'       => 'system',
+				)
 			);
 
 			return array(
@@ -283,15 +231,17 @@ class ImageGenerationTask extends SystemTask {
 			require_once ABSPATH . 'wp-admin/includes/image.php';
 		}
 
-		$tmp_file = download_url( $image_url );
+		$tmp_file = str_starts_with( $image_url, 'data:' )
+			? $this->dataUriToTempFile( $image_url )
+			: download_url( $image_url );
 
-		if ( is_wp_error( $tmp_file ) ) {
+		if ( $tmp_file instanceof \WP_Error ) {
 			return $tmp_file;
 		}
 
 		$tmp_file = $this->maybeConvertToJpeg( $tmp_file );
 
-		if ( is_wp_error( $tmp_file ) ) {
+		if ( $tmp_file instanceof \WP_Error ) {
 			return $tmp_file;
 		}
 
@@ -305,12 +255,14 @@ class ImageGenerationTask extends SystemTask {
 
 		$attachment_id = media_handle_sideload( $file_array, 0 );
 
-		if ( is_wp_error( $attachment_id ) ) {
+		if ( $attachment_id instanceof \WP_Error ) {
 			if ( file_exists( $tmp_file ) ) {
 				wp_delete_file( $tmp_file );
 			}
 			return $attachment_id;
 		}
+
+		$attachment_id = (int) $attachment_id;
 
 		$title = mb_substr( $prompt, 0, 200 );
 		wp_update_post( array(
@@ -331,6 +283,41 @@ class ImageGenerationTask extends SystemTask {
 		);
 	}
 
+	protected function dataUriToTempFile( string $dataUri ): string|\WP_Error {
+		if ( ! preg_match( '/^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/', $dataUri, $matches ) ) {
+			return new \WP_Error(
+				'datamachine_invalid_image_data_uri',
+				'Generated image data URI is invalid.'
+			);
+		}
+
+		$decoded = base64_decode( $matches[2], true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		if ( false === $decoded ) {
+			return new \WP_Error(
+				'datamachine_invalid_image_base64',
+				'Generated image data could not be decoded.'
+			);
+		}
+
+		$tmp_file = wp_tempnam( 'datamachine-generated-image' );
+		if ( ! $tmp_file ) {
+			return new \WP_Error(
+				'datamachine_image_tempfile_failed',
+				'Could not create a temporary file for generated image data.'
+			);
+		}
+
+		if ( false === file_put_contents( $tmp_file, $decoded ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			wp_delete_file( $tmp_file );
+			return new \WP_Error(
+				'datamachine_image_tempfile_write_failed',
+				'Could not write generated image data to a temporary file.'
+			);
+		}
+
+		return $tmp_file;
+	}
+
 	protected function maybeConvertToJpeg( string $tmp_file ): string|\WP_Error {
 		$check = wp_get_image_mime( $tmp_file );
 
@@ -343,20 +330,24 @@ class ImageGenerationTask extends SystemTask {
 		}
 
 		$editor = wp_get_image_editor( $tmp_file );
-		if ( is_wp_error( $editor ) ) {
+		if ( $editor instanceof \WP_Error ) {
 			return $tmp_file;
 		}
 
 		$editor->set_quality( self::JPEG_QUALITY );
 		$converted = $editor->save( $tmp_file . '.jpg', 'image/jpeg' );
 
-		if ( is_wp_error( $converted ) ) {
+		if ( $converted instanceof \WP_Error ) {
+			return $tmp_file;
+		}
+
+		if ( empty( $converted['path'] ) ) {
 			return $tmp_file;
 		}
 
 		wp_delete_file( $tmp_file );
 
-		return $converted['path'];
+		return (string) $converted['path'];
 	}
 
 	protected function insertImageInContent( int $jobId, int $attachmentId, array $params ): array {
@@ -377,7 +368,7 @@ class ImageGenerationTask extends SystemTask {
 		}
 
 		$post = get_post( $post_id );
-		if ( ! $post ) {
+		if ( ! $post instanceof \WP_Post ) {
 			return array();
 		}
 
@@ -494,7 +485,11 @@ class ImageGenerationTask extends SystemTask {
 				$total_blocks = count( $blocks );
 				$gaps         = array();
 
-				$gaps[] = array( 'start' => 0, 'end' => $image_positions[0], 'size' => $image_positions[0] );
+				$gaps[] = array(
+					'start' => 0,
+					'end'   => $image_positions[0],
+					'size'  => $image_positions[0],
+				);
 
 				$image_positions_count = count( $image_positions );
 				for ( $j = 0; $j < $image_positions_count - 1; $j++ ) {
@@ -506,7 +501,11 @@ class ImageGenerationTask extends SystemTask {
 				}
 
 				$last   = end( $image_positions );
-				$gaps[] = array( 'start' => $last, 'end' => $total_blocks, 'size' => $total_blocks - $last );
+				$gaps[] = array(
+					'start' => $last,
+					'end'   => $total_blocks,
+					'size'  => $total_blocks - $last,
+				);
 
 				usort( $gaps, fn( $a, $b ) => $b['size'] <=> $a['size'] );
 				$largest = $gaps[0];
@@ -529,7 +528,7 @@ class ImageGenerationTask extends SystemTask {
 	public static function getTaskMeta(): array {
 		return array(
 			'label'           => 'Image Generation',
-			'description'     => 'Generate images via Replicate API and assign as featured images or insert into content.',
+			'description'     => 'Process wp-ai-client generated images and assign as featured images or insert into content.',
 			'setting_key'     => null,
 			'default_enabled' => true,
 			'trigger'         => 'AI tool call',

--- a/inc/Engine/AI/Tools/Global/ImageGeneration.php
+++ b/inc/Engine/AI/Tools/Global/ImageGeneration.php
@@ -32,7 +32,7 @@ class ImageGeneration extends BaseTool {
 	/**
 	 * Execute image generation by delegating to the ability.
 	 *
-	 * @param array $parameters Contains 'prompt' and optional 'model', 'aspect_ratio'.
+	 * @param array $parameters Contains 'prompt' and optional 'provider', 'model', 'aspect_ratio'.
 	 * @param array $tool_def   Tool definition (unused).
 	 * @return array Result with pending status on success.
 	 */
@@ -48,6 +48,7 @@ class ImageGeneration extends BaseTool {
 
 		$input = array(
 			'prompt'       => $parameters['prompt'] ?? '',
+			'provider'     => $parameters['provider'] ?? '',
 			'model'        => $parameters['model'] ?? '',
 			'aspect_ratio' => $parameters['aspect_ratio'] ?? '',
 		);
@@ -88,7 +89,7 @@ class ImageGeneration extends BaseTool {
 		return array(
 			'class'           => __CLASS__,
 			'method'          => 'handle_tool_call',
-			'description'     => 'Generate images using AI models (Google Imagen 4, Flux, etc.) via Replicate. Returns a URL to the generated image. Use descriptive, detailed prompts for best results. Default aspect ratio is 3:4 (portrait, ideal for Pinterest and blog featured images).',
+			'description'     => 'Generate images using wp-ai-client image models. Returns a pending image-generation job that will sideload the generated image and optionally set it as featured media. Use descriptive, detailed prompts for best results. Default aspect ratio is 3:4 (portrait, ideal for Pinterest and blog featured images).',
 			'requires_config' => true,
 			'parameters'      => array(
 				'prompt'       => array(
@@ -99,7 +100,12 @@ class ImageGeneration extends BaseTool {
 				'model'        => array(
 					'type'        => 'string',
 					'required'    => false,
-					'description' => 'Replicate model identifier (default: google/imagen-4-fast). Other options: black-forest-labs/flux-schnell, etc.',
+					'description' => 'wp-ai-client model identifier. Defaults to the image generation tool configuration.',
+				),
+				'provider'     => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'wp-ai-client provider identifier. Defaults to the image generation tool configuration.',
 				),
 				'aspect_ratio' => array(
 					'type'        => 'string',
@@ -159,26 +165,32 @@ class ImageGeneration extends BaseTool {
 	}
 
 	/**
-	 * Save configuration from settings page.
+	 * Get configuration option name.
 	 *
-	 * @param string $tool_id     Tool identifier.
-	 * @param array  $config_data Configuration data.
+	 * @return string
 	 */
 	protected function get_config_option_name(): string {
 		return ImageGenerationAbilities::CONFIG_OPTION;
 	}
 
+	/**
+	 * Validate and normalize settings-page configuration.
+	 *
+	 * @param array $config_data Configuration data.
+	 * @return array
+	 */
 	protected function validate_and_build_config( array $config_data ): array {
-		$api_key = sanitize_text_field( $config_data['api_key'] ?? '' );
+		$provider = sanitize_text_field( $config_data['default_provider'] ?? ImageGenerationAbilities::DEFAULT_PROVIDER );
+		$model    = sanitize_text_field( $config_data['default_model'] ?? ImageGenerationAbilities::DEFAULT_MODEL );
 
-		if ( empty( $api_key ) ) {
-			return array( 'error' => __( 'Replicate API key is required', 'data-machine' ) );
+		if ( empty( $provider ) || empty( $model ) ) {
+			return array( 'error' => __( 'wp-ai-client provider and model are required', 'data-machine' ) );
 		}
 
 		return array(
 			'config'  => array(
-				'api_key'                   => $api_key,
-				'default_model'             => sanitize_text_field( $config_data['default_model'] ?? ImageGenerationAbilities::DEFAULT_MODEL ),
+				'default_provider'          => $provider,
+				'default_model'             => $model,
 				'default_aspect_ratio'      => sanitize_text_field( $config_data['default_aspect_ratio'] ?? ImageGenerationAbilities::DEFAULT_ASPECT_RATIO ),
 				'prompt_refinement_enabled' => ! empty( $config_data['prompt_refinement_enabled'] ),
 				'prompt_style_guide'        => sanitize_textarea_field( $config_data['prompt_style_guide'] ?? '' ),
@@ -200,19 +212,19 @@ class ImageGeneration extends BaseTool {
 		}
 
 		return array(
-			'api_key'                   => array(
-				'type'        => 'password',
-				'label'       => __( 'Replicate API Key', 'data-machine' ),
-				'placeholder' => __( 'Enter your Replicate API key', 'data-machine' ),
+			'default_provider'          => array(
+				'type'        => 'text',
+				'label'       => __( 'Default Provider', 'data-machine' ),
+				'placeholder' => ImageGenerationAbilities::DEFAULT_PROVIDER,
 				'required'    => true,
-				'description' => __( 'Get your API key from replicate.com/account/api-tokens', 'data-machine' ),
+				'description' => __( 'wp-ai-client provider identifier. API keys are configured through the provider settings, not this tool.', 'data-machine' ),
 			),
 			'default_model'             => array(
 				'type'        => 'text',
 				'label'       => __( 'Default Model', 'data-machine' ),
 				'placeholder' => ImageGenerationAbilities::DEFAULT_MODEL,
 				'required'    => false,
-				'description' => __( 'Replicate model identifier. Default: google/imagen-4-fast. AI agents can override per-call.', 'data-machine' ),
+				'description' => __( 'wp-ai-client image model identifier. AI agents can override per-call.', 'data-machine' ),
 			),
 			'default_aspect_ratio'      => array(
 				'type'        => 'select',

--- a/inc/Engine/AI/WpAiClientAdapter.php
+++ b/inc/Engine/AI/WpAiClientAdapter.php
@@ -67,15 +67,14 @@ class WpAiClientAdapter {
 		}
 
 		try {
-			$model_instance = $registry->getProviderModel( $resolved_id, $model, null );
+			$model_instance = self::getProviderModel( $registry, $resolved_id, $model, null );
 
-			/** @var \WP_AI_Client_Prompt_Builder $builder */
 			$builder = \wp_ai_client_prompt( $prompt )
 				->using_provider( $resolved_id )
 				->using_model( $model_instance );
 
 			if ( class_exists( '\\WordPress\\AiClient\\Files\\Enums\\FileTypeEnum' ) ) {
-				$builder = $builder->as_output_file_type( \WordPress\AiClient\Files\Enums\FileTypeEnum::remote() );
+				$builder = self::callBuilderMethod( $builder, 'as_output_file_type', \WordPress\AiClient\Files\Enums\FileTypeEnum::remote() );
 			}
 
 			$builder = self::applyImageAspectRatio( $builder, $aspect_ratio );
@@ -161,17 +160,21 @@ class WpAiClientAdapter {
 			return $builder;
 		}
 
-		/** @var \WP_AI_Client_Prompt_Builder $builder */
+		$orientation_setter = array( $builder, 'as_output_media_orientation' );
+		if ( ! is_callable( $orientation_setter ) ) {
+			return $builder;
+		}
+
 		if ( '1:1' === $aspect_ratio ) {
-			return $builder->as_output_media_orientation( \WordPress\AiClient\Files\Enums\MediaOrientationEnum::square() );
+			return call_user_func( $orientation_setter, \WordPress\AiClient\Files\Enums\MediaOrientationEnum::square() );
 		}
 
 		if ( in_array( $aspect_ratio, array( '3:4', '9:16' ), true ) ) {
-			return $builder->as_output_media_orientation( \WordPress\AiClient\Files\Enums\MediaOrientationEnum::portrait() );
+			return call_user_func( $orientation_setter, \WordPress\AiClient\Files\Enums\MediaOrientationEnum::portrait() );
 		}
 
 		if ( in_array( $aspect_ratio, array( '4:3', '16:9' ), true ) ) {
-			return $builder->as_output_media_orientation( \WordPress\AiClient\Files\Enums\MediaOrientationEnum::landscape() );
+			return call_user_func( $orientation_setter, \WordPress\AiClient\Files\Enums\MediaOrientationEnum::landscape() );
 		}
 
 		return $builder;
@@ -274,31 +277,35 @@ class WpAiClientAdapter {
 		$model_config = self::buildModelConfig( $request );
 
 		try {
-			$model_instance = $registry->getProviderModel( $resolved_id, $model, $model_config );
+			$model_instance = self::getProviderModel( $registry, $resolved_id, $model, $model_config );
 		} catch ( \Throwable $e ) {
 			return self::errorResponse( $provider, 'wp-ai-client model resolution failed: ' . $e->getMessage() );
 		}
 
 		try {
-			/** @var \WP_AI_Client_Prompt_Builder $builder */
 			$builder = \wp_ai_client_prompt()
 				->using_provider( $resolved_id )
 				->using_model( $model_instance );
 
 			if ( null !== $conversation['system'] && '' !== $conversation['system'] ) {
-				$builder = $builder->using_system_instruction( $conversation['system'] );
+				$builder = self::callBuilderMethod( $builder, 'using_system_instruction', $conversation['system'] );
 			}
 
 			if ( ! empty( $conversation['history'] ) ) {
-				$builder = $builder->with_history( ...$conversation['history'] );
+				$builder = self::callBuilderMethod( $builder, 'with_history', ...$conversation['history'] );
 			}
 
 			$declarations = self::buildFunctionDeclarations( $tools );
 			if ( ! empty( $declarations ) ) {
-				$builder = $builder->using_function_declarations( ...$declarations );
+				$builder = self::callBuilderMethod( $builder, 'using_function_declarations', ...$declarations );
 			}
 
-			$result = $builder->generate_text_result();
+			$generator = array( $builder, 'generate_text_result' );
+			if ( ! is_callable( $generator ) ) {
+				return self::errorResponse( $provider, 'wp-ai-client text generation API is unavailable' );
+			}
+
+			$result = call_user_func( $generator );
 		} catch ( \Throwable $e ) {
 			return self::errorResponse( $provider, 'wp-ai-client request threw: ' . $e->getMessage() );
 		}
@@ -511,6 +518,39 @@ class WpAiClientAdapter {
 		}
 
 		return array();
+	}
+
+	/**
+	 * Resolve a provider model through wp-ai-client's registry.
+	 *
+	 * @param \WordPress\AiClient\Providers\ProviderRegistry $registry Provider registry.
+	 * @param string                                          $provider Provider identifier.
+	 * @param string                                          $model    Model identifier.
+	 * @param mixed                                           $config   Optional model config.
+	 * @return mixed Provider model instance.
+	 *
+	 * @throws \RuntimeException When the registry cannot resolve models.
+	 */
+	private static function getProviderModel( \WordPress\AiClient\Providers\ProviderRegistry $registry, string $provider, string $model, $config ) {
+		return call_user_func( array( $registry, 'getProviderModel' ), $provider, $model, $config );
+	}
+
+	/**
+	 * Call a wp-ai-client builder method exposed directly or through __call().
+	 *
+	 * @param object $builder Builder instance.
+	 * @param string $method  Builder method name.
+	 * @param mixed  ...$args Method arguments.
+	 * @return object Builder instance.
+	 */
+	private static function callBuilderMethod( object $builder, string $method, ...$args ): object {
+		$callback = array( $builder, $method );
+		if ( ! is_callable( $callback ) ) {
+			return $builder;
+		}
+
+		$result = call_user_func( $callback, ...$args );
+		return is_object( $result ) ? $result : $builder;
 	}
 
 	/**

--- a/inc/Engine/AI/WpAiClientAdapter.php
+++ b/inc/Engine/AI/WpAiClientAdapter.php
@@ -80,7 +80,12 @@ class WpAiClientAdapter {
 
 			$builder = self::applyImageAspectRatio( $builder, $aspect_ratio );
 
-			$supported = call_user_func( array( $builder, 'is_supported_for_image_generation' ) );
+			$support_check = array( $builder, 'is_supported_for_image_generation' );
+			if ( ! is_callable( $support_check ) ) {
+				return self::errorResponse( $provider, 'wp-ai-client image support checks are unavailable' );
+			}
+
+			$supported = call_user_func( $support_check );
 			if ( is_wp_error( $supported ) ) {
 				return self::errorResponse(
 					$provider,
@@ -99,7 +104,12 @@ class WpAiClientAdapter {
 				);
 			}
 
-			$file = call_user_func( array( $builder, 'generate_image' ) );
+			$image_generator = array( $builder, 'generate_image' );
+			if ( ! is_callable( $image_generator ) ) {
+				return self::errorResponse( $provider, 'wp-ai-client image generation API is unavailable' );
+			}
+
+			$file = call_user_func( $image_generator );
 			if ( is_wp_error( $file ) ) {
 				return self::errorResponse( $provider, 'wp-ai-client image generation failed: ' . $file->get_error_message() );
 			}

--- a/inc/Engine/AI/WpAiClientAdapter.php
+++ b/inc/Engine/AI/WpAiClientAdapter.php
@@ -24,6 +24,150 @@ defined( 'ABSPATH' ) || exit;
 class WpAiClientAdapter {
 
 	/**
+	 * Generate an image through wp-ai-client and return the generated file handle.
+	 *
+	 * Data Machine owns prompt refinement, post-context handling, and media insertion.
+	 * Provider dispatch belongs to wp-ai-client, so this method deliberately returns
+	 * only the generated file pointer/data plus a normalized error envelope.
+	 *
+	 * @since next
+	 *
+	 * @param string $prompt       Image generation prompt.
+	 * @param string $provider     Provider identifier.
+	 * @param string $model        Model identifier.
+	 * @param string $aspect_ratio Requested product-level aspect ratio.
+	 * @return array Generated image response.
+	 */
+	public static function generateImage( string $prompt, string $provider, string $model, string $aspect_ratio ): array {
+		if ( '' === trim( $prompt ) ) {
+			return self::errorResponse( $provider, 'wp-ai-client image generation requires a prompt' );
+		}
+
+		if ( '' === trim( $model ) ) {
+			return self::errorResponse( $provider, 'wp-ai-client image generation requires a model identifier' );
+		}
+
+		try {
+			$registry    = \WordPress\AiClient\AiClient::defaultRegistry();
+			$resolved_id = self::resolveRegisteredProviderId( $registry, $provider );
+		} catch ( \Throwable $e ) {
+			return self::errorResponse( $provider, 'wp-ai-client image provider resolution failed: ' . $e->getMessage() );
+		}
+
+		$api_key = WpAiClientProviderAdmin::resolveApiKey( $provider );
+		if ( '' !== $api_key ) {
+			try {
+				$registry->setProviderRequestAuthentication(
+					$resolved_id,
+					new \WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication( $api_key )
+				);
+			} catch ( \Throwable $e ) {
+				return self::errorResponse( $provider, 'wp-ai-client image auth setup failed: ' . $e->getMessage() );
+			}
+		}
+
+		try {
+			$model_instance = $registry->getProviderModel( $resolved_id, $model, null );
+
+			/** @var \WP_AI_Client_Prompt_Builder $builder */
+			$builder = \wp_ai_client_prompt( $prompt )
+				->using_provider( $resolved_id )
+				->using_model( $model_instance );
+
+			if ( class_exists( '\\WordPress\\AiClient\\Files\\Enums\\FileTypeEnum' ) ) {
+				$builder = $builder->as_output_file_type( \WordPress\AiClient\Files\Enums\FileTypeEnum::remote() );
+			}
+
+			$builder = self::applyImageAspectRatio( $builder, $aspect_ratio );
+
+			$supported = call_user_func( array( $builder, 'is_supported_for_image_generation' ) );
+			if ( is_wp_error( $supported ) ) {
+				return self::errorResponse(
+					$provider,
+					'wp-ai-client image support check failed: ' . $supported->get_error_message()
+				);
+			}
+
+			if ( ! $supported ) {
+				return self::errorResponse(
+					$provider,
+					sprintf(
+						'wp-ai-client model "%s" does not support image generation for provider "%s"',
+						$model,
+						$resolved_id
+					)
+				);
+			}
+
+			$file = call_user_func( array( $builder, 'generate_image' ) );
+			if ( is_wp_error( $file ) ) {
+				return self::errorResponse( $provider, 'wp-ai-client image generation failed: ' . $file->get_error_message() );
+			}
+		} catch ( \Throwable $e ) {
+			return self::errorResponse( $provider, 'wp-ai-client image generation threw: ' . $e->getMessage() );
+		}
+
+		if ( ! is_object( $file ) ) {
+			return self::errorResponse( $provider, 'wp-ai-client image generation returned an invalid file object' );
+		}
+
+		$image_url      = method_exists( $file, 'getUrl' ) ? call_user_func( array( $file, 'getUrl' ) ) : null;
+		$image_data_uri = method_exists( $file, 'getDataUri' ) ? call_user_func( array( $file, 'getDataUri' ) ) : null;
+
+		if ( empty( $image_url ) && empty( $image_data_uri ) ) {
+			return self::errorResponse( $provider, 'wp-ai-client image generation returned no usable image file' );
+		}
+
+		$response = array(
+			'success'  => true,
+			'provider' => $resolved_id,
+			'model'    => $model,
+		);
+
+		if ( ! empty( $image_url ) ) {
+			$response['image_url'] = $image_url;
+		}
+
+		if ( ! empty( $image_data_uri ) ) {
+			$response['image_data_uri'] = $image_data_uri;
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Apply Data Machine's historical aspect-ratio vocabulary to wp-ai-client.
+	 *
+	 * wp-ai-client's OpenAI-compatible model base supports a small exact-ratio set;
+	 * for DM's existing portrait/landscape presets, request orientation instead of
+	 * inventing provider-specific size parameters.
+	 *
+	 * @param object $builder      WP_AI_Client_Prompt_Builder-like object.
+	 * @param string $aspect_ratio Product-level aspect ratio.
+	 * @return object Builder instance.
+	 */
+	private static function applyImageAspectRatio( object $builder, string $aspect_ratio ): object {
+		if ( ! class_exists( '\\WordPress\\AiClient\\Files\\Enums\\MediaOrientationEnum' ) ) {
+			return $builder;
+		}
+
+		/** @var \WP_AI_Client_Prompt_Builder $builder */
+		if ( '1:1' === $aspect_ratio ) {
+			return $builder->as_output_media_orientation( \WordPress\AiClient\Files\Enums\MediaOrientationEnum::square() );
+		}
+
+		if ( in_array( $aspect_ratio, array( '3:4', '9:16' ), true ) ) {
+			return $builder->as_output_media_orientation( \WordPress\AiClient\Files\Enums\MediaOrientationEnum::portrait() );
+		}
+
+		if ( in_array( $aspect_ratio, array( '4:3', '16:9' ), true ) ) {
+			return $builder->as_output_media_orientation( \WordPress\AiClient\Files\Enums\MediaOrientationEnum::landscape() );
+		}
+
+		return $builder;
+	}
+
+	/**
 	 * Determine whether the wp-ai-client path should handle the given provider.
 	 *
 	 * Three conditions must all hold:
@@ -120,16 +264,13 @@ class WpAiClientAdapter {
 		$model_config = self::buildModelConfig( $request );
 
 		try {
-			if ( ! method_exists( $registry, 'getProviderModel' ) ) {
-				return self::errorResponse( $provider, 'wp-ai-client registry cannot resolve provider models' );
-			}
-
-			$model_instance = call_user_func( array( $registry, 'getProviderModel' ), $resolved_id, $model, $model_config );
+			$model_instance = $registry->getProviderModel( $resolved_id, $model, $model_config );
 		} catch ( \Throwable $e ) {
 			return self::errorResponse( $provider, 'wp-ai-client model resolution failed: ' . $e->getMessage() );
 		}
 
 		try {
+			/** @var \WP_AI_Client_Prompt_Builder $builder */
 			$builder = \wp_ai_client_prompt()
 				->using_provider( $resolved_id )
 				->using_model( $model_instance );
@@ -150,6 +291,10 @@ class WpAiClientAdapter {
 			$result = $builder->generate_text_result();
 		} catch ( \Throwable $e ) {
 			return self::errorResponse( $provider, 'wp-ai-client request threw: ' . $e->getMessage() );
+		}
+
+		if ( is_wp_error( $result ) ) {
+			return self::errorResponse( $provider, 'wp-ai-client request failed: ' . $result->get_error_message() );
 		}
 
 		return self::normalizeResult( $result, $provider );

--- a/inc/Engine/AI/WpAiClientAdapter.php
+++ b/inc/Engine/AI/WpAiClientAdapter.php
@@ -523,16 +523,21 @@ class WpAiClientAdapter {
 	/**
 	 * Resolve a provider model through wp-ai-client's registry.
 	 *
-	 * @param \WordPress\AiClient\Providers\ProviderRegistry $registry Provider registry.
-	 * @param string                                          $provider Provider identifier.
-	 * @param string                                          $model    Model identifier.
-	 * @param mixed                                           $config   Optional model config.
+	 * @param object $registry Provider registry.
+	 * @param string $provider Provider identifier.
+	 * @param string $model    Model identifier.
+	 * @param mixed  $config   Optional model config.
 	 * @return mixed Provider model instance.
 	 *
 	 * @throws \RuntimeException When the registry cannot resolve models.
 	 */
-	private static function getProviderModel( \WordPress\AiClient\Providers\ProviderRegistry $registry, string $provider, string $model, $config ) {
-		return call_user_func( array( $registry, 'getProviderModel' ), $provider, $model, $config );
+	private static function getProviderModel( object $registry, string $provider, string $model, $config ) {
+		$callback = array( $registry, 'getProviderModel' );
+		if ( ! is_callable( $callback ) ) {
+			throw new \RuntimeException( 'wp-ai-client provider registry cannot resolve models.' );
+		}
+
+		return call_user_func( $callback, $provider, $model, $config );
 	}
 
 	/**

--- a/inc/Engine/AI/WpAiClientAdapter.php
+++ b/inc/Engine/AI/WpAiClientAdapter.php
@@ -530,6 +530,7 @@ class WpAiClientAdapter {
 	 * @return mixed Provider model instance.
 	 */
 	private static function getProviderModel( \WordPress\AiClient\Providers\ProviderRegistry $registry, string $provider, string $model, $config ) {
+		/** @var callable $callback wp-ai-client exposes this through __call() in some versions. */
 		$callback = array( $registry, 'getProviderModel' );
 		return call_user_func( $callback, $provider, $model, $config );
 	}

--- a/inc/Engine/AI/WpAiClientAdapter.php
+++ b/inc/Engine/AI/WpAiClientAdapter.php
@@ -530,7 +530,8 @@ class WpAiClientAdapter {
 	 * @return mixed Provider model instance.
 	 */
 	private static function getProviderModel( \WordPress\AiClient\Providers\ProviderRegistry $registry, string $provider, string $model, $config ) {
-		return $registry->getProviderModel( $provider, $model, $config );
+		$callback = array( $registry, 'getProviderModel' );
+		return call_user_func( $callback, $provider, $model, $config );
 	}
 
 	/**

--- a/inc/Engine/AI/WpAiClientAdapter.php
+++ b/inc/Engine/AI/WpAiClientAdapter.php
@@ -523,21 +523,14 @@ class WpAiClientAdapter {
 	/**
 	 * Resolve a provider model through wp-ai-client's registry.
 	 *
-	 * @param object $registry Provider registry.
-	 * @param string $provider Provider identifier.
-	 * @param string $model    Model identifier.
-	 * @param mixed  $config   Optional model config.
+	 * @param \WordPress\AiClient\Providers\ProviderRegistry $registry Provider registry.
+	 * @param string                                          $provider Provider identifier.
+	 * @param string                                          $model    Model identifier.
+	 * @param mixed                                           $config   Optional model config.
 	 * @return mixed Provider model instance.
-	 *
-	 * @throws \RuntimeException When the registry cannot resolve models.
 	 */
-	private static function getProviderModel( object $registry, string $provider, string $model, $config ) {
-		$callback = array( $registry, 'getProviderModel' );
-		if ( ! is_callable( $callback ) ) {
-			throw new \RuntimeException( 'wp-ai-client provider registry cannot resolve models.' );
-		}
-
-		return call_user_func( $callback, $provider, $model, $config );
+	private static function getProviderModel( \WordPress\AiClient\Providers\ProviderRegistry $registry, string $provider, string $model, $config ) {
+		return $registry->getProviderModel( $provider, $model, $config );
 	}
 
 	/**

--- a/tests/Unit/AI/Tools/ImageGenerationToolCallTest.php
+++ b/tests/Unit/AI/Tools/ImageGenerationToolCallTest.php
@@ -3,7 +3,7 @@
  * Tests for ImageGeneration tool handle_tool_call method.
  *
  * Tests the tool layer's delegation to the ability and response handling.
- * Uses pre_http_request filter to mock Replicate API.
+ * Uses wp-ai-client test doubles to mock provider dispatch.
  *
  * @package DataMachine\Tests\Unit\AI\Tools
  */
@@ -11,8 +11,10 @@
 namespace DataMachine\Tests\Unit\AI\Tools;
 
 use DataMachine\Engine\AI\Tools\Global\ImageGeneration;
+use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 use WP_UnitTestCase;
-use WP_Error;
+
+require_once dirname( dirname( __DIR__ ) ) . '/Support/WpAiClientTestDoubles.php';
 
 class ImageGenerationToolCallTest extends WP_UnitTestCase {
 
@@ -25,114 +27,78 @@ class ImageGenerationToolCallTest extends WP_UnitTestCase {
 		wp_set_current_user( $admin_id );
 
 		$this->tool = new ImageGeneration();
+		WpAiClientTestDouble::reset();
+		WpAiClientTestDouble::set_response_callback( array( $this, 'mock_image_response' ) );
 	}
 
 	public function tear_down(): void {
 		delete_site_option( 'datamachine_image_generation_config' );
+		WpAiClientTestDouble::reset();
 		parent::tear_down();
 	}
 
-	/**
-	 * Helper: add pre_http_request filter that returns a successful Replicate prediction.
-	 *
-	 * @param string $prediction_id Prediction ID to return.
-	 * @return callable The filter callback (for removal).
-	 */
-	private function mock_replicate_success( string $prediction_id = 'pred_abc123' ): callable {
-		$filter = function ( $preempt, $parsed_args, $url ) use ( $prediction_id ) {
-			if ( str_contains( $url, 'replicate.com' ) ) {
-				return array(
-					'response' => array( 'code' => 201, 'message' => 'Created' ),
-					'body'     => wp_json_encode( array( 'id' => $prediction_id, 'status' => 'starting' ) ),
-					'headers'  => array(),
-					'cookies'  => array(),
-				);
-			}
-			return $preempt;
-		};
-		add_filter( 'pre_http_request', $filter, 10, 3 );
-		return $filter;
+	public function mock_image_response( array $request ): array {
+		return array(
+			'success' => true,
+			'data'    => array( 'image_url' => 'https://example.com/generated.png' ),
+		);
 	}
 
 	/**
-	 * Test handle_tool_call handles WP_Error from HTTP failure.
+	 * Test handle_tool_call handles provider failure.
 	 */
 	public function test_handle_tool_call_wp_error(): void {
-		$filter = function ( $preempt, $parsed_args, $url ) {
-			if ( str_contains( $url, 'replicate.com' ) ) {
-				return new WP_Error( 'http_request_failed', 'Replicate API connection failed' );
-			}
-			return $preempt;
-		};
-		add_filter( 'pre_http_request', $filter, 10, 3 );
+		WpAiClientTestDouble::set_response_callback( function (): array {
+			return array( 'success' => false, 'error' => 'Provider connection failed' );
+		} );
 
-		update_site_option( 'datamachine_image_generation_config', array( 'api_key' => 'test-key' ) );
+		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
 
 		$result = $this->tool->handle_tool_call( array( 'prompt' => 'A beautiful sunset' ) );
 
 		$this->assertFalse( $result['success'] );
 		$this->assertStringContainsString( 'failed', strtolower( $result['error'] ) );
 		$this->assertSame( 'image_generation', $result['tool_name'] );
-
-		remove_filter( 'pre_http_request', $filter, 10 );
 	}
 
 	/**
 	 * Test handle_tool_call handles error from ability result.
 	 */
 	public function test_handle_tool_call_ability_error(): void {
-		$filter = function ( $preempt, $parsed_args, $url ) {
-			if ( str_contains( $url, 'replicate.com' ) ) {
-				return array(
-					'response' => array( 'code' => 401, 'message' => 'Unauthorized' ),
-					'body'     => wp_json_encode( array( 'detail' => 'Invalid API key' ) ),
-					'headers'  => array(),
-					'cookies'  => array(),
-				);
-			}
-			return $preempt;
-		};
-		add_filter( 'pre_http_request', $filter, 10, 3 );
-
-		update_site_option( 'datamachine_image_generation_config', array( 'api_key' => 'bad-key' ) );
+		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'missing-provider', 'default_model' => 'gpt-image-1' ) );
 
 		$result = $this->tool->handle_tool_call( array( 'prompt' => 'A beautiful sunset' ) );
 
 		$this->assertFalse( $result['success'] );
 		$this->assertNotEmpty( $result['error'] );
 		$this->assertSame( 'image_generation', $result['tool_name'] );
-
-		remove_filter( 'pre_http_request', $filter, 10 );
 	}
 
 	/**
 	 * Test handle_tool_call delegates to ability successfully.
 	 */
 	public function test_handle_tool_call_success_basic(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'api_key' => 'test-key' ) );
-		$filter = $this->mock_replicate_success( 'pred_abc123' );
+		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
 
 		$result = $this->tool->handle_tool_call( array( 'prompt' => 'A beautiful sunset' ) );
 
 		$this->assertTrue( $result['success'] );
 		$this->assertTrue( $result['pending'] );
 		$this->assertIsInt( $result['job_id'] );
-		$this->assertSame( 'pred_abc123', $result['prediction_id'] );
+		$this->assertSame( 'https://example.com/generated.png', $result['image_url'] );
 		$this->assertSame( 'image_generation', $result['tool_name'] );
-
-		remove_filter( 'pre_http_request', $filter, 10 );
 	}
 
 	/**
 	 * Test handle_tool_call passes parameters through.
 	 */
 	public function test_handle_tool_call_with_parameters(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'api_key' => 'test-key' ) );
-		$filter = $this->mock_replicate_success( 'pred_xyz789' );
+		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
 
 		$result = $this->tool->handle_tool_call( array(
 			'prompt'       => 'A serene mountain landscape',
-			'model'        => 'google/imagen-4-fast',
+			'provider'     => 'openai',
+			'model'        => 'gpt-image-1',
 			'aspect_ratio' => '16:9',
 			'job_id'       => 456,
 		) );
@@ -140,23 +106,18 @@ class ImageGenerationToolCallTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['success'] );
 		$this->assertTrue( $result['pending'] );
 		$this->assertIsInt( $result['job_id'] );
-		$this->assertSame( 'pred_xyz789', $result['prediction_id'] );
+		$this->assertSame( 'https://example.com/generated.png', $result['image_url'] );
 		$this->assertSame( 'image_generation', $result['tool_name'] );
-
-		remove_filter( 'pre_http_request', $filter, 10 );
 	}
 
 	/**
 	 * Test handle_tool_call always returns tool_name.
 	 */
 	public function test_handle_tool_call_returns_tool_name(): void {
-		update_site_option( 'datamachine_image_generation_config', array( 'api_key' => 'test-key' ) );
-		$filter = $this->mock_replicate_success( 'pred_name111' );
+		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
 
 		$result = $this->tool->handle_tool_call( array( 'prompt' => 'Test image' ) );
 
 		$this->assertSame( 'image_generation', $result['tool_name'] );
-
-		remove_filter( 'pre_http_request', $filter, 10 );
 	}
 }

--- a/tests/Unit/Abilities/ImageGenerationPromptRefinementTest.php
+++ b/tests/Unit/Abilities/ImageGenerationPromptRefinementTest.php
@@ -249,9 +249,9 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 	}
 
 	public function test_generate_image_applies_refinement_when_enabled(): void {
-		// Configure image generation and AI provider
 		update_site_option( 'datamachine_image_generation_config', array(
-			'api_key'                   => 'test-replicate-key',
+			'default_provider'          => 'openai',
+			'default_model'             => 'gpt-image-1',
 			'prompt_refinement_enabled' => true,
 		) );
 		$this->set_plugin_settings( array(
@@ -259,53 +259,40 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 			'default_model'    => 'gpt-4',
 		) );
 
-		// Mock Replicate API — HttpClient::post() expects 201 for POST requests.
-		$http_filter = function ( $preempt, $args, $url ) {
-			if ( str_contains( $url, 'replicate.com' ) ) {
+		WpAiClientTestDouble::set_response_callback( function ( array $request ): array {
+			if ( ( $request['capability'] ?? '' ) === 'image_generation' ) {
 				return array(
-					'response' => array( 'code' => 201, 'message' => 'Created' ),
-					'body'     => wp_json_encode( array( 'id' => 'test-prediction-id' ) ),
-					'headers'  => array(),
-					'cookies'  => array(),
+					'success' => true,
+					'data'    => array( 'image_url' => 'https://example.com/refined.png' ),
 				);
 			}
-			return $preempt;
-		};
-		add_filter( 'pre_http_request', $http_filter, 10, 3 );
+
+			return $this->mock_ai_response( $request );
+		} );
 
 		$result = ImageGenerationAbilities::generateImage( array( 'prompt' => 'The Spiritual Meaning of Cranes' ) );
 
 		$this->assertTrue( $result['success'], 'generateImage should succeed. Error: ' . ( $result['error'] ?? 'none' ) );
 		$this->assertStringContainsString( 'Prompt was refined', $result['message'] );
-
-		remove_filter( 'pre_http_request', $http_filter, 10 );
 	}
 
 	public function test_generate_image_skips_refinement_when_disabled(): void {
 		update_site_option( 'datamachine_image_generation_config', array(
-			'api_key'                   => 'test-replicate-key',
+			'default_provider'          => 'openai',
+			'default_model'             => 'gpt-image-1',
 			'prompt_refinement_enabled' => false,
 		) );
 
-		// Mock Replicate API.
-		$http_filter = function ( $preempt, $args, $url ) {
-			if ( str_contains( $url, 'replicate.com' ) ) {
-				return array(
-					'response' => array( 'code' => 201, 'message' => 'Created' ),
-					'body'     => wp_json_encode( array( 'id' => 'test-prediction-id' ) ),
-					'headers'  => array(),
-					'cookies'  => array(),
-				);
-			}
-			return $preempt;
-		};
-		add_filter( 'pre_http_request', $http_filter, 10, 3 );
+		WpAiClientTestDouble::set_response_callback( function (): array {
+			return array(
+				'success' => true,
+				'data'    => array( 'image_url' => 'https://example.com/unrefined.png' ),
+			);
+		} );
 
 		$result = ImageGenerationAbilities::generateImage( array( 'prompt' => 'The Spiritual Meaning of Cranes' ) );
 
 		$this->assertTrue( $result['success'] );
 		$this->assertStringNotContainsString( 'Prompt was refined', $result['message'] );
-
-		remove_filter( 'pre_http_request', $http_filter, 10 );
 	}
 }

--- a/tests/Unit/Abilities/Media/ImageGenerationAbilitiesTest.php
+++ b/tests/Unit/Abilities/Media/ImageGenerationAbilitiesTest.php
@@ -8,7 +8,10 @@
 namespace DataMachine\Tests\Unit\Abilities\Media;
 
 use DataMachine\Abilities\Media\ImageGenerationAbilities;
+use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 use WP_UnitTestCase;
+
+require_once dirname( dirname( __DIR__ ) ) . '/Support/WpAiClientTestDoubles.php';
 
 class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 
@@ -17,20 +20,31 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 
-		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		datamachine_register_capabilities();
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
+
+		WpAiClientTestDouble::reset();
+		WpAiClientTestDouble::set_response_callback( array( $this, 'mock_image_response' ) );
 
 		$this->abilities = new ImageGenerationAbilities();
 	}
 
 	public function tear_down(): void {
 		delete_site_option( 'datamachine_image_generation_config' );
+		WpAiClientTestDouble::reset();
 		parent::tear_down();
 	}
 
-	/**
-	 * Test ability registration.
-	 */
+	public function mock_image_response( array $request ): array {
+		return array(
+			'success' => true,
+			'data'    => array(
+				'image_url' => 'https://example.com/generated.png',
+			),
+		);
+	}
+
 	public function test_ability_registered(): void {
 		$ability = wp_get_ability( 'datamachine/generate-image' );
 
@@ -38,199 +52,107 @@ class ImageGenerationAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'datamachine/generate-image', $ability->get_name() );
 	}
 
-	/**
-	 * Test generateImage with missing prompt.
-	 */
 	public function test_generate_image_missing_prompt(): void {
-		$result = ImageGenerationAbilities::generateImage( [] );
+		$result = ImageGenerationAbilities::generateImage( array() );
 
 		$this->assertFalse( $result['success'] );
 		$this->assertStringContainsString( 'requires a prompt', $result['error'] );
 	}
 
-	/**
-	 * Test generateImage with empty prompt.
-	 */
 	public function test_generate_image_empty_prompt(): void {
-		$result = ImageGenerationAbilities::generateImage( [ 'prompt' => '' ] );
+		$result = ImageGenerationAbilities::generateImage( array( 'prompt' => '' ) );
 
 		$this->assertFalse( $result['success'] );
 		$this->assertStringContainsString( 'requires a prompt', $result['error'] );
 	}
 
-	/**
-	 * Test generateImage with missing config.
-	 */
-	public function test_generate_image_missing_config(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
+	public function test_generate_image_missing_provider(): void {
+		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => '', 'default_model' => 'gpt-image-1' ) );
 
-		$result = ImageGenerationAbilities::generateImage( [ 'prompt' => 'Test prompt' ] );
+		$result = ImageGenerationAbilities::generateImage( array( 'prompt' => 'Test prompt' ) );
 
 		$this->assertFalse( $result['success'] );
 		$this->assertStringContainsString( 'not configured', $result['error'] );
 	}
 
-	/**
-	 * Test generateImage with missing API key in config.
-	 */
-	public function test_generate_image_missing_api_key(): void {
-		update_site_option( 'datamachine_image_generation_config', [
-			'default_model' => 'google/imagen-4-fast'
-		] );
+	public function test_generate_image_unregistered_provider(): void {
+		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'missing-provider', 'default_model' => 'image-model' ) );
 
-		$result = ImageGenerationAbilities::generateImage( [ 'prompt' => 'Test prompt' ] );
+		$result = ImageGenerationAbilities::generateImage( array( 'prompt' => 'Test prompt' ) );
 
 		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'not configured', $result['error'] );
+		$this->assertStringContainsString( 'not registered', $result['error'] );
 	}
 
-	/**
-	 * Test generateImage with HTTP error.
-	 */
-	public function test_generate_image_http_error(): void {
-		update_site_option( 'datamachine_image_generation_config', [
-			'api_key' => 'test-key'
-		] );
+	public function test_generate_image_support_check_failure(): void {
+		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'text-only-model' ) );
+		WpAiClientTestDouble::set_response_callback( function (): array {
+			return array( 'success' => true, 'supported' => false );
+		} );
 
-		$filter = function( $result, $parsed_args, $url ) {
-			if ( str_contains( $url, 'replicate.com' ) ) {
-				return new \WP_Error( 'http_request_failed', 'Network timeout' );
-			}
-			return $result;
-		};
-		add_filter( 'pre_http_request', $filter, 10, 3 );
-
-		$result = ImageGenerationAbilities::generateImage( [ 'prompt' => 'Test prompt' ] );
+		$result = ImageGenerationAbilities::generateImage( array( 'prompt' => 'Test prompt' ) );
 
 		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'Failed to start image generation', $result['error'] );
-
-		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertStringContainsString( 'does not support image generation', $result['error'] );
 	}
 
-	/**
-	 * Test generateImage with invalid JSON response.
-	 */
-	public function test_generate_image_invalid_json(): void {
-		update_site_option( 'datamachine_image_generation_config', [
-			'api_key' => 'test-key'
-		] );
+	public function test_generate_image_provider_error(): void {
+		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
+		WpAiClientTestDouble::set_response_callback( function (): array {
+			return array( 'success' => false, 'error' => 'Provider unavailable' );
+		} );
 
-		$filter = function( $result, $parsed_args, $url ) {
-			if ( str_contains( $url, 'replicate.com' ) ) {
-				return array(
-					'response' => array( 'code' => 200, 'message' => 'OK' ),
-					'body'     => 'invalid json response',
-					'headers'  => array(),
-					'cookies'  => array(),
-				);
-			}
-			return $result;
-		};
-		add_filter( 'pre_http_request', $filter, 10, 3 );
-
-		$result = ImageGenerationAbilities::generateImage( [ 'prompt' => 'Test prompt' ] );
+		$result = ImageGenerationAbilities::generateImage( array( 'prompt' => 'Test prompt' ) );
 
 		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'Invalid response from Replicate API', $result['error'] );
-
-		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertStringContainsString( 'Failed to generate image', $result['error'] );
+		$this->assertStringContainsString( 'Provider unavailable', $result['error'] );
 	}
 
-	/**
-	 * Test generateImage with missing prediction ID in response.
-	 */
-	public function test_generate_image_missing_prediction_id(): void {
-		update_site_option( 'datamachine_image_generation_config', [
-			'api_key' => 'test-key'
-		] );
+	public function test_generate_image_success_schedules_job(): void {
+		update_site_option( 'datamachine_image_generation_config', array(
+			'default_provider'     => 'openai',
+			'default_model'        => 'gpt-image-1',
+			'default_aspect_ratio' => '3:4',
+		) );
 
-		$filter = function( $result, $parsed_args, $url ) {
-			if ( str_contains( $url, 'replicate.com' ) ) {
-				return array(
-					'response' => array( 'code' => 200, 'message' => 'OK' ),
-					'body'     => wp_json_encode( array( 'status' => 'starting' ) ),
-					'headers'  => array(),
-					'cookies'  => array(),
-				);
-			}
-			return $result;
-		};
-		add_filter( 'pre_http_request', $filter, 10, 3 );
+		$captured_request = null;
+		WpAiClientTestDouble::set_response_callback( function ( array $request ) use ( &$captured_request ): array {
+			$captured_request = $request;
+			return array(
+				'success' => true,
+				'data'    => array( 'image_url' => 'https://example.com/generated.png' ),
+			);
+		} );
 
-		$result = ImageGenerationAbilities::generateImage( [ 'prompt' => 'Test prompt' ] );
-
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'Invalid response from Replicate API', $result['error'] );
-
-		remove_filter( 'pre_http_request', $filter, 10 );
-	}
-
-	/**
-	 * Test generateImage success — Replicate returns prediction, scheduler creates job.
-	 */
-	public function test_generate_image_success(): void {
-		update_site_option( 'datamachine_image_generation_config', [
-			'api_key' => 'test-key',
-			'default_model' => 'google/imagen-4-fast',
-			'default_aspect_ratio' => '3:4'
-		] );
-
-		$filter = function( $result, $parsed_args, $url ) {
-			if ( str_contains( $url, 'replicate.com' ) ) {
-				$body = json_decode( $parsed_args['body'], true );
-				$this->assertSame( 'Test prompt', $body['input']['prompt'] );
-
-				return array(
-					'response' => array( 'code' => 201, 'message' => 'Created' ),
-					'body'     => wp_json_encode( array( 'id' => 'pred_123' ) ),
-					'headers'  => array(),
-					'cookies'  => array(),
-				);
-			}
-			return $result;
-		};
-		add_filter( 'pre_http_request', $filter, 10, 3 );
-
-		$result = ImageGenerationAbilities::generateImage( [ 'prompt' => 'Test prompt' ] );
+		$result = ImageGenerationAbilities::generateImage( array( 'prompt' => 'Test prompt' ) );
 
 		$this->assertTrue( $result['success'] );
 		$this->assertTrue( $result['pending'] );
 		$this->assertIsInt( $result['job_id'] );
-		$this->assertSame( 'pred_123', $result['prediction_id'] );
-
-		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertSame( 'https://example.com/generated.png', $result['image_url'] );
+		$this->assertSame( 'Test prompt', $captured_request['prompt'] ?? '' );
+		$this->assertSame( 'openai', $captured_request['provider'] ?? '' );
+		$this->assertSame( 'gpt-image-1', $captured_request['model'] ?? '' );
 	}
 
-	/**
-	 * Test is_configured returns false when no config.
-	 */
-	public function test_is_configured_false(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
+	public function test_is_configured_false_when_provider_unavailable(): void {
+		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'missing-provider', 'default_model' => 'gpt-image-1' ) );
 		$this->assertFalse( ImageGenerationAbilities::is_configured() );
 	}
 
-	/**
-	 * Test is_configured returns true when api_key present.
-	 */
-	public function test_is_configured_true(): void {
-		update_site_option( 'datamachine_image_generation_config', [ 'api_key' => 'test-key' ] );
+	public function test_is_configured_true_when_provider_and_model_available(): void {
+		update_site_option( 'datamachine_image_generation_config', array( 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ) );
 		$this->assertTrue( ImageGenerationAbilities::is_configured() );
 	}
 
-	/**
-	 * Test get_config returns empty array by default.
-	 */
 	public function test_get_config_empty(): void {
 		delete_site_option( 'datamachine_image_generation_config' );
-		$this->assertSame( [], ImageGenerationAbilities::get_config() );
+		$this->assertSame( array(), ImageGenerationAbilities::get_config() );
 	}
 
-	/**
-	 * Test get_config returns stored configuration.
-	 */
 	public function test_get_config_returns_stored(): void {
-		$config = [ 'api_key' => 'test-key', 'default_model' => 'custom-model' ];
+		$config = array( 'default_provider' => 'openai', 'default_model' => 'custom-model' );
 		update_site_option( 'datamachine_image_generation_config', $config );
 		$this->assertSame( $config, ImageGenerationAbilities::get_config() );
 	}

--- a/tests/Unit/Engine/AI/System/Tasks/ImageGenerationTaskTest.php
+++ b/tests/Unit/Engine/AI/System/Tasks/ImageGenerationTaskTest.php
@@ -54,14 +54,14 @@ class ImageGenerationTaskTest extends WP_UnitTestCase {
 	}
 
 	public function test_get_workflow_returns_system_task_step(): void {
-		$workflow = $this->task->getWorkflow( [ 'prediction_id' => 'test' ] );
+		$workflow = $this->task->getWorkflow( [ 'image_url' => 'https://example.com/generated.png' ] );
 		$this->assertArrayHasKey( 'steps', $workflow );
 		$this->assertCount( 1, $workflow['steps'] );
 		$this->assertSame( 'system_task', $workflow['steps'][0]['type'] );
 		$this->assertSame( 'image_generation', $workflow['steps'][0]['handler_config']['task'] );
 	}
 
-	public function test_execute_task_fails_when_prediction_id_missing(): void {
+	public function test_execute_task_fails_when_image_file_missing(): void {
 		$jobs_db = new \DataMachine\Core\Database\Jobs\Jobs();
 		$job_id = $jobs_db->create_job( [
 			'pipeline_id' => 'direct',
@@ -80,9 +80,7 @@ class ImageGenerationTaskTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'failed', strtolower( $job['status'] ?? '' ) );
 	}
 
-	public function test_execute_task_fails_when_api_key_not_configured(): void {
-		delete_site_option( 'datamachine_image_generation_config' );
-
+	public function test_execute_task_processes_generated_image_url(): void {
 		$jobs_db = new \DataMachine\Core\Database\Jobs\Jobs();
 		$job_id = $jobs_db->create_job( [
 			'pipeline_id' => 'direct',
@@ -95,10 +93,15 @@ class ImageGenerationTaskTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Could not create test job.' );
 		}
 
-		$this->task->executeTask( (int) $job_id, [ 'prediction_id' => 'test-pred-123' ] );
+		$task = new TestableImageGenerationTask();
+		$task->executeTask( (int) $job_id, [
+			'image_url' => 'https://example.com/generated.png',
+			'model'     => 'gpt-image-1',
+			'prompt'    => 'test prompt',
+		] );
 
 		$job = $jobs_db->get_job( (int) $job_id );
-		$this->assertStringContainsString( 'failed', strtolower( $job['status'] ?? '' ) );
+		$this->assertStringContainsString( 'completed', strtolower( $job['status'] ?? '' ) );
 	}
 
 	public function test_handle_success_passes_params_to_try_set_featured_image(): void {

--- a/tests/Unit/Engine/AI/Tools/Global/ImageGenerationTest.php
+++ b/tests/Unit/Engine/AI/Tools/Global/ImageGenerationTest.php
@@ -9,7 +9,10 @@ namespace DataMachine\Tests\Unit\Engine\AI\Tools\Global;
 
 use DataMachine\Engine\AI\Tools\Global\ImageGeneration;
 use DataMachine\Abilities\Media\ImageGenerationAbilities;
+use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 use WP_UnitTestCase;
+
+require_once dirname( __DIR__, 4 ) . '/Support/WpAiClientTestDoubles.php';
 
 class ImageGenerationTest extends WP_UnitTestCase {
 
@@ -23,10 +26,12 @@ class ImageGenerationTest extends WP_UnitTestCase {
 		wp_set_current_user( $admin_id );
 
 		$this->tool = new ImageGeneration();
+		WpAiClientTestDouble::reset();
 	}
 
 	public function tear_down(): void {
 		delete_site_option( 'datamachine_image_generation_config' );
+		WpAiClientTestDouble::reset();
 		parent::tear_down();
 	}
 
@@ -35,8 +40,8 @@ class ImageGenerationTest extends WP_UnitTestCase {
 		$this->assertFalse( ImageGeneration::is_configured() );
 	}
 
-	public function test_is_configured_returns_true_when_api_key_set(): void {
-		update_site_option( 'datamachine_image_generation_config', [ 'api_key' => 'test-key' ] );
+	public function test_is_configured_returns_true_when_provider_and_model_set(): void {
+		update_site_option( 'datamachine_image_generation_config', [ 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ] );
 		$this->assertTrue( ImageGeneration::is_configured() );
 	}
 
@@ -46,7 +51,7 @@ class ImageGenerationTest extends WP_UnitTestCase {
 	}
 
 	public function test_get_config_returns_stored_config(): void {
-		$config = [ 'api_key' => 'test-key', 'default_model' => 'flux' ];
+		$config = [ 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ];
 		update_site_option( 'datamachine_image_generation_config', $config );
 		$this->assertSame( $config, ImageGeneration::get_config() );
 	}
@@ -60,7 +65,7 @@ class ImageGenerationTest extends WP_UnitTestCase {
 		delete_site_option( 'datamachine_image_generation_config' );
 		$this->assertFalse( $this->tool->check_configuration( true, 'image_generation' ) );
 
-		update_site_option( 'datamachine_image_generation_config', [ 'api_key' => 'test-key' ] );
+		update_site_option( 'datamachine_image_generation_config', [ 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ] );
 		$this->assertTrue( $this->tool->check_configuration( false, 'image_generation' ) );
 	}
 
@@ -70,14 +75,14 @@ class ImageGenerationTest extends WP_UnitTestCase {
 	}
 
 	public function test_get_configuration_returns_config_for_image_generation(): void {
-		$config = [ 'api_key' => 'test-key' ];
+		$config = [ 'default_provider' => 'openai', 'default_model' => 'gpt-image-1' ];
 		update_site_option( 'datamachine_image_generation_config', $config );
 		$this->assertSame( $config, $this->tool->get_configuration( [], 'image_generation' ) );
 	}
 
 	public function test_get_config_fields_returns_fields_for_image_generation(): void {
 		$fields = $this->tool->get_config_fields( [], 'image_generation' );
-		$this->assertArrayHasKey( 'api_key', $fields );
+		$this->assertArrayHasKey( 'default_provider', $fields );
 		$this->assertArrayHasKey( 'default_model', $fields );
 		$this->assertArrayHasKey( 'default_aspect_ratio', $fields );
 	}
@@ -89,7 +94,7 @@ class ImageGenerationTest extends WP_UnitTestCase {
 
 	public function test_get_config_fields_returns_fields_when_tool_id_empty(): void {
 		$fields = $this->tool->get_config_fields( [], '' );
-		$this->assertArrayHasKey( 'api_key', $fields );
+		$this->assertArrayHasKey( 'default_provider', $fields );
 	}
 
 	public function test_get_tool_definition_has_required_keys(): void {

--- a/tests/Unit/Support/WpAiClientTestDoubles.php
+++ b/tests/Unit/Support/WpAiClientTestDoubles.php
@@ -16,8 +16,8 @@ namespace {
 	}
 
 	if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
-		function wp_ai_client_prompt(): \DataMachine\Tests\Unit\Support\WpAiClientPromptBuilderDouble {
-			return new \DataMachine\Tests\Unit\Support\WpAiClientPromptBuilderDouble();
+		function wp_ai_client_prompt( $prompt = null ): \DataMachine\Tests\Unit\Support\WpAiClientPromptBuilderDouble {
+			return new \DataMachine\Tests\Unit\Support\WpAiClientPromptBuilderDouble( is_string( $prompt ) ? $prompt : '' );
 		}
 	}
 }
@@ -55,11 +55,16 @@ namespace DataMachine\Tests\Unit\Support {
 	}
 
 	class WpAiClientPromptBuilderDouble {
+		private string $prompt = '';
 		private string $provider = '';
 		private mixed $model = null;
 		private string $system_instruction = '';
 		private array $history = array();
 		private array $function_declarations = array();
+
+		public function __construct( string $prompt = '' ) {
+			$this->prompt = $prompt;
+		}
 
 		public function using_provider( string $provider ): self {
 			$this->provider = $provider;
@@ -69,6 +74,37 @@ namespace DataMachine\Tests\Unit\Support {
 		public function using_model( $model ): self {
 			$this->model = $model;
 			return $this;
+		}
+
+		public function as_output_file_type( $file_type ): self {
+			return $this;
+		}
+
+		public function as_output_media_orientation( $orientation ): self {
+			return $this;
+		}
+
+		public function is_supported_for_image_generation(): bool {
+			$request  = $this->to_request_array();
+			$response = WpAiClientTestDouble::dispatch( $request + array( 'capability_check' => 'image_generation' ), $this->provider );
+
+			return $response['supported'] ?? true;
+		}
+
+		public function generate_image(): \WordPress\AiClient\Files\DTO\File|\WP_Error {
+			$request  = $this->to_request_array();
+			$response = WpAiClientTestDouble::dispatch( $request + array( 'capability' => 'image_generation' ), $this->provider );
+
+			if ( empty( $response['success'] ) ) {
+				return new \WP_Error( 'test_image_generation_failed', $response['error'] ?? 'Image generation failed' );
+			}
+
+			$file = (string) ( $response['data']['image_url'] ?? $response['data']['image_data_uri'] ?? '' );
+			if ( '' === $file ) {
+				return new \WP_Error( 'test_image_generation_empty', 'No image returned' );
+			}
+
+			return new \WordPress\AiClient\Files\DTO\File( $file, $response['data']['mime_type'] ?? 'image/png' );
 		}
 
 		public function using_system_instruction( string $system_instruction ): self {
@@ -124,9 +160,63 @@ namespace DataMachine\Tests\Unit\Support {
 			return array(
 				'provider' => $this->provider,
 				'model'    => $this->model,
+				'prompt'   => $this->prompt,
 				'messages' => $messages,
 				'tools'    => $tools,
 			);
+		}
+	}
+}
+
+namespace WordPress\AiClient\Files\Enums {
+	if ( ! class_exists( FileTypeEnum::class ) ) {
+		class FileTypeEnum {
+			public static function remote(): self {
+				return new self();
+			}
+		}
+	}
+
+	if ( ! class_exists( MediaOrientationEnum::class ) ) {
+		class MediaOrientationEnum {
+			public static function square(): self {
+				return new self();
+			}
+
+			public static function portrait(): self {
+				return new self();
+			}
+
+			public static function landscape(): self {
+				return new self();
+			}
+		}
+	}
+}
+
+namespace WordPress\AiClient\Files\DTO {
+	if ( ! class_exists( File::class ) ) {
+		class File {
+			private ?string $url = null;
+			private ?string $data_uri = null;
+
+			public function __construct( string $file, ?string $mime_type = null ) {
+				unset( $mime_type );
+
+				if ( str_starts_with( $file, 'data:' ) ) {
+					$this->data_uri = $file;
+				} else {
+					$this->url = $file;
+				}
+			}
+
+			public function getUrl(): ?string {
+				return $this->url;
+			}
+
+			public function getDataUri(): ?string {
+				return $this->data_uri;
+			}
 		}
 	}
 }

--- a/tests/image-generation-wp-ai-client-boundary-smoke.php
+++ b/tests/image-generation-wp-ai-client-boundary-smoke.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Pure-PHP smoke test for the image-generation wp-ai-client boundary.
+ *
+ * Run with: php tests/image-generation-wp-ai-client-boundary-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$assertions = 0;
+$failures   = array();
+
+$assert = function ( bool $condition, string $message ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = $message;
+		echo "FAIL: {$message}\n";
+		return;
+	}
+
+	echo "PASS: {$message}\n";
+};
+
+$root    = dirname( __DIR__ );
+$ability = (string) file_get_contents( $root . '/inc/Abilities/Media/ImageGenerationAbilities.php' );
+$adapter = (string) file_get_contents( $root . '/inc/Engine/AI/WpAiClientAdapter.php' );
+$task    = (string) file_get_contents( $root . '/inc/Engine/AI/System/Tasks/ImageGenerationTask.php' );
+$tool    = (string) file_get_contents( $root . '/inc/Engine/AI/Tools/Global/ImageGeneration.php' );
+$cli     = (string) file_get_contents( $root . '/inc/Cli/Commands/ImageCommand.php' );
+
+$assert( str_contains( $ability, 'WpAiClientAdapter::generateImage' ), 'image ability dispatches through WpAiClientAdapter::generateImage' );
+$assert( ! str_contains( $ability, 'HttpClient::post' ), 'image ability does not start direct HTTP predictions' );
+$assert( ! str_contains( $ability, 'api.replicate.com' ), 'image ability has no Replicate API endpoint' );
+$assert( ! str_contains( $ability, 'prediction_id' ), 'image ability no longer schedules prediction ids' );
+$assert( str_contains( $adapter, "'generate_image'" ), 'wp-ai-client adapter uses the public generate_image API' );
+$assert( str_contains( $adapter, "'is_supported_for_image_generation'" ), 'wp-ai-client adapter checks image-generation support' );
+$assert( str_contains( $adapter, 'FileTypeEnum::remote()' ), 'wp-ai-client adapter requests remote generated files when supported' );
+$assert( str_contains( $adapter, 'MediaOrientationEnum::portrait()' ), 'wp-ai-client adapter maps portrait aspect ratios to orientation' );
+$assert( str_contains( $task, 'image_url' ), 'system task consumes generated image URLs' );
+$assert( str_contains( $task, 'image_data_uri' ), 'system task consumes inline generated image data' );
+$assert( ! str_contains( $task, 'HttpClient::get' ), 'system task no longer polls direct provider HTTP status' );
+$assert( ! str_contains( $task, 'api.replicate.com' ), 'system task has no Replicate API endpoint' );
+$assert( str_contains( $tool, 'default_provider' ), 'tool settings collect provider id instead of provider API key' );
+$assert( ! str_contains( $tool, 'Replicate API Key' ), 'tool settings no longer ask for a Replicate key' );
+$assert( str_contains( $cli, '--provider=<provider>' ), 'CLI exposes provider override' );
+$assert( ! str_contains( $cli, 'prediction_id' ), 'CLI output no longer exposes prediction ids' );
+
+echo "\n{$assertions} assertions, " . count( $failures ) . " failures\n";
+
+if ( ! empty( $failures ) ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Routes Data Machine image generation through the generic `wp-ai-client` image-generation APIs instead of direct Replicate dispatch.
- Keeps Data Machine's async media/post mutation job, but changes the provider boundary to consume generated image URLs or data URIs.
- Updates image-generation tool, CLI, tests, and boundary smoke coverage for the wp-ai-client contract.

## Changes
- Adds `WpAiClientAdapter::generateImage()` with provider/model resolution, support checks, remote-file output preference, and aspect-ratio orientation mapping.
- Updates image generation abilities and task execution to schedule/process generated image files rather than polling provider prediction IDs.
- Replaces Replicate-specific tool/CLI settings with provider/model configuration language.
- Extends wp-ai-client test doubles and image-generation unit coverage.

## Tests
- `php -l inc/Abilities/Media/ImageGenerationAbilities.php inc/Abilities/Media/ImageTemplateAbilities.php inc/Cli/Commands/ImageCommand.php inc/Engine/AI/System/Tasks/ImageGenerationTask.php inc/Engine/AI/Tools/Global/ImageGeneration.php inc/Engine/AI/WpAiClientAdapter.php`
- `php -l tests/Unit/AI/Tools/ImageGenerationToolCallTest.php tests/Unit/Abilities/ImageGenerationPromptRefinementTest.php tests/Unit/Abilities/Media/ImageGenerationAbilitiesTest.php tests/Unit/Engine/AI/System/Tasks/ImageGenerationTaskTest.php tests/Unit/Engine/AI/Tools/Global/ImageGenerationTest.php tests/Unit/Support/WpAiClientTestDoubles.php tests/image-generation-wp-ai-client-boundary-smoke.php`
- `php tests/image-generation-wp-ai-client-boundary-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@migrate-image-generation-wp-ai-client --changed-since origin/main`
- Focused `homeboy lint ... --file <changed file> --summary` for the touched production files, support double, and boundary smoke.
- `git diff --check`

Full `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@migrate-image-generation-wp-ai-client --summary` still reports broad pre-existing repository drift outside this PR, including PHPStan errors in `tests/Unit/Events/UniversalWebScraperFlowTest.php`. Focused lint on changed files passed.

Closes #1661.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the migration, updated tests, ran focused verification, and prepared this PR. Chris remains responsible for review and final acceptance.