### PR TITLE
fix(ai): normalize wp-ai-client tool schemas

### DIFF
--- a/inc/Engine/AI/WpAiClientAdapter.php
+++ b/inc/Engine/AI/WpAiClientAdapter.php
@@ -620,16 +620,58 @@ class WpAiClientAdapter {
 			return null;
 		}
 
+		$schema = $parameters;
+
 		// Already a JSON-schema-shaped object.
-		if ( isset( $parameters['type'] ) || isset( $parameters['properties'] ) || isset( $parameters['$ref'] ) ) {
-			return $parameters;
+		if ( ! isset( $schema['type'] ) && ! isset( $schema['properties'] ) && ! isset( $schema['$ref'] ) ) {
+			// Best effort: assume the array IS the properties map, wrap it.
+			$schema = array(
+				'type'       => 'object',
+				'properties' => $schema,
+			);
 		}
 
-		// Best effort: assume the array IS the properties map, wrap it.
-		return array(
-			'type'       => 'object',
-			'properties' => $parameters,
-		);
+		return self::normalizeJsonSchemaRequiredFlags( $schema );
+	}
+
+	/**
+	 * Convert Data Machine's legacy property-level required flags to JSON Schema.
+	 *
+	 * Some tools historically declared required fields as
+	 * `{ properties: { foo: { required: true } } }`. OpenAI's tool schema accepts
+	 * the standard object-level `required: [ "foo" ]` shape instead.
+	 *
+	 * @param array<string, mixed> $schema JSON schema.
+	 * @return array<string, mixed>
+	 */
+	private static function normalizeJsonSchemaRequiredFlags( array $schema ): array {
+		if ( empty( $schema['properties'] ) || ! is_array( $schema['properties'] ) ) {
+			return $schema;
+		}
+
+		$required = isset( $schema['required'] ) && is_array( $schema['required'] ) ? $schema['required'] : array();
+
+		foreach ( $schema['properties'] as $property_name => $property_schema ) {
+			if ( ! is_array( $property_schema ) || ! array_key_exists( 'required', $property_schema ) ) {
+				continue;
+			}
+
+			if ( true === $property_schema['required'] ) {
+				$required[] = (string) $property_name;
+			}
+
+			unset( $property_schema['required'] );
+			$schema['properties'][ $property_name ] = $property_schema;
+		}
+
+		$required = array_values( array_unique( array_filter( $required, 'is_string' ) ) );
+		if ( ! empty( $required ) ) {
+			$schema['required'] = $required;
+		} else {
+			unset( $schema['required'] );
+		}
+
+		return $schema;
 	}
 
 	/**

--- a/tests/wp-ai-client-tool-schema-smoke.php
+++ b/tests/wp-ai-client-tool-schema-smoke.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Pure-PHP smoke test for wp-ai-client tool schema normalization.
+ *
+ * Run with: php tests/wp-ai-client-tool-schema-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$assertions = 0;
+$failures   = array();
+
+$assert = function ( bool $condition, string $message ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = $message;
+		echo "FAIL: {$message}\n";
+		return;
+	}
+
+	echo "PASS: {$message}\n";
+};
+
+$root = dirname( __DIR__ );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $root . '/' );
+}
+
+require_once $root . '/tests/Unit/Support/WpAiClientTestDoubles.php';
+require_once $root . '/inc/Engine/AI/WpAiClientAdapter.php';
+
+$method = new ReflectionMethod( DataMachine\Engine\AI\WpAiClientAdapter::class, 'ensureJsonSchema' );
+
+$schema = $method->invoke(
+	null,
+	array(
+		'reason' => array(
+			'type'        => 'string',
+			'description' => 'Skip reason.',
+			'required'    => true,
+		),
+		'note'   => array(
+			'type'     => 'string',
+			'required' => false,
+		),
+	)
+);
+
+$assert( is_array( $schema ), 'legacy parameter map normalizes to a schema array' );
+$assert( 'object' === ( $schema['type'] ?? null ), 'legacy parameter map is wrapped as an object schema' );
+$assert( array( 'reason' ) === ( $schema['required'] ?? null ), 'property-level required=true is lifted to object-level required array' );
+$assert( ! isset( $schema['properties']['reason']['required'] ), 'required flag is removed from required property schema' );
+$assert( ! isset( $schema['properties']['note']['required'] ), 'required flag is removed from optional property schema' );
+$assert( 'string' === ( $schema['properties']['reason']['type'] ?? null ), 'property schema fields are preserved' );
+
+echo "\n{$assertions} assertions, " . count( $failures ) . " failures\n";
+
+if ( ! empty( $failures ) ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Normalize legacy Data Machine tool schemas before handing them to `wp-ai-client`.
- Preserve compatibility with existing tool definitions that declare `required => true` on individual properties.

## Changes
- Convert property-level `required` flags into object-level JSON Schema `required` arrays in `WpAiClientAdapter`.
- Strip the legacy per-property `required` key so OpenAI receives a stricter schema shape.
- Add a pure-PHP smoke test for the `skip_item`-class schema shape.

## Tests
- `php tests/wp-ai-client-tool-schema-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-wp-ai-client-tool-schema --file inc/Engine/AI/WpAiClientAdapter.php --summary`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-wp-ai-client-tool-schema --file tests/wp-ai-client-tool-schema-smoke.php --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the live `wp-ai-client` OpenAI schema rejection, drafting the schema normalization fix, and running focused validation. Chris remains responsible for review and merge.
