### PR TITLE
refactor(agents-api): neutralize conversation tool result contract

### DIFF
--- a/agents-api/inc/Engine/AI/AgentConversationResult.php
+++ b/agents-api/inc/Engine/AI/AgentConversationResult.php
@@ -79,8 +79,8 @@ class AgentConversationResult {
 				throw self::invalid( $path . '.parameters', 'must be an array' );
 			}
 
-			if ( ! array_key_exists( 'is_handler_tool', $tool_result ) || ! is_bool( $tool_result['is_handler_tool'] ) ) {
-				throw self::invalid( $path . '.is_handler_tool', 'must be a boolean' );
+			if ( array_key_exists( 'is_handler_tool', $tool_result ) && ! is_bool( $tool_result['is_handler_tool'] ) ) {
+				throw self::invalid( $path . '.is_handler_tool', 'must be a boolean when present' );
 			}
 
 			if ( ! array_key_exists( 'turn_count', $tool_result ) || ! is_int( $tool_result['turn_count'] ) ) {

--- a/tests/agent-conversation-result-smoke.php
+++ b/tests/agent-conversation-result-smoke.php
@@ -63,6 +63,31 @@ datamachine_agent_conversation_result_assert(
 );
 ++$assertions;
 
+$generic_tool_result = $valid_result;
+unset( $generic_tool_result['tool_execution_results'][0]['is_handler_tool'] );
+$generic_tool_result['tool_execution_results'][0]['tool_name'] = 'search_knowledge_base';
+$generic_tool_result['tool_execution_results'][0]['result']    = array( 'success' => true, 'items' => array() );
+$normalized_generic_tool_result = AgentConversationResult::normalize( $generic_tool_result );
+datamachine_agent_conversation_result_assert(
+	! array_key_exists( 'is_handler_tool', $normalized_generic_tool_result['tool_execution_results'][0] ),
+	'Generic tool execution result should not require Data Machine handler metadata.'
+);
+++$assertions;
+
+$malformed_handler_metadata = $valid_result;
+$malformed_handler_metadata['tool_execution_results'][0]['is_handler_tool'] = 'yes';
+
+try {
+	AgentConversationResult::normalize( $malformed_handler_metadata );
+	throw new RuntimeException( 'Malformed handler metadata should throw.' );
+} catch ( InvalidArgumentException $e ) {
+	datamachine_agent_conversation_result_assert(
+		str_contains( $e->getMessage(), 'invalid_agent_conversation_result: tool_execution_results[0].is_handler_tool' ),
+		'Present handler-tool metadata should still be type checked.'
+	);
+	++$assertions;
+}
+
 $without_tool_results = $valid_result;
 unset( $without_tool_results['tool_execution_results'] );
 $normalized_without_tools = AgentConversationResult::normalize( $without_tool_results );


### PR DESCRIPTION
## Summary
- Neutralizes the generic Agents API conversation result contract by making Data Machine handler-tool metadata optional instead of required.
- Keeps Data Machine pipeline behavior unchanged by preserving `is_handler_tool` when the built-in loop projects handler tool results.

## Changes
- `AgentConversationResult::normalize()` now accepts generic tool execution results without `is_handler_tool`.
- Present `is_handler_tool` metadata is still validated as boolean so Data Machine projections remain typed.
- Expanded the conversation result smoke to cover generic tool results and handler metadata preservation.

## Tests
- `php tests/agent-conversation-result-smoke.php`
- `php tests/upsert-handler-result-handoff-smoke.php`
- `php tests/ai-message-envelope-smoke.php`
- `php -l agents-api/inc/Engine/AI/AgentConversationResult.php && php -l tests/agent-conversation-result-smoke.php`

Closes #1667

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing and testing the Agents API conversation result contract cleanup under Chris's review.