### PR TITLE
docs(agents-api): add core-shape extraction gates

### DIFF
--- a/docs/core-system/agent-registration.md
+++ b/docs/core-system/agent-registration.md
@@ -46,6 +46,21 @@ That's it. On the next request where `init` fires, DM reconciles the registratio
 | `owner_resolver` | callable | Returns `int user_id`. Called once at row-creation time. Defaults to `DirectoryManager::get_default_agent_user_id()`. |
 | `default_config` | array | Initial `agent_config` persisted on creation. Subsequent config changes go through the DB — the registration never overrides user-edited config. |
 
+### Category and metadata policy
+
+The current registry intentionally does **not** implement Abilities API-style categories.
+
+Abilities need first-class categories because abilities are many small executable actions exposed through REST discovery and filtering. Agents are runtime definitions; their executable surface should be discovered through abilities/runtime tool declarations and explicit policy, not through a second category hierarchy on the agent object.
+
+Agents API v1 should therefore keep category semantics out of `WP_Agent`:
+
+- No `WP_Agent_Category` registry in the first standalone extraction.
+- No category-derived permissions, REST visibility, tool policy, or memory policy.
+- Data Machine admin grouping remains Data Machine product behavior.
+- Future descriptive `metadata`, `type`, `capabilities`, or `annotations` fields can be added after the public class contract is finalized, but they must be non-authoritative until a separate issue defines their semantics.
+
+See `docs/development/agents-api-pre-extraction-audit.md` for the extraction checklist and the comparison to Abilities API categories.
+
 ### Slug semantics
 
 Slugs are passed through `sanitize_title()`. They must be unique across a site (DB column has a UNIQUE constraint on `agent_slug`). Two plugins registering the same slug is resolved by **last-wins** — this matches WP action/filter semantics, so plugins can override core or other plugins by hooking at a higher priority.

--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -6,7 +6,7 @@ Parent issue: [Explore splitting Agents API out of Data Machine](https://github.
 
 Strategy update: [Agents API blocker: update extraction docs around in-repo module strategy](https://github.com/Extra-Chill/data-machine/issues/1640)
 
-Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
+Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
 
 ## Current Strategy
 
@@ -51,12 +51,13 @@ Mirror the WordPress Abilities API shape instead of importing Data Machine produ
 | `wp_register_agent()` | `wp_register_agent()` | Same declarative pattern as Abilities API-style registration; no DB reconciliation side effects in the public helper. |
 | `WP_Agent` / `WP_Agents_Registry` | `WP_Agent` / `WP_Agents_Registry` | Registry collects definitions. Persistence/adoption remains Data Machine adapter territory. |
 | `wp_agents_api_init` | `wp_agents_api_init` | Core-shaped init hook mirrored in-place while Data Machine hosts the substrate. |
+| Agent categories | No v1 registry | [#1669](https://github.com/Extra-Chill/data-machine/issues/1669) decides against `WP_Agent_Category` parity for v1. Future metadata/annotations may describe agents but must not grant permission or visibility. |
 | `AgentMessageEnvelope` | `WP_Agent_Message` or same class name | Contract is generic and now uses Agents API-shaped vocabulary in place. |
 | `ConversationTranscriptStoreInterface` | `WP_Agent_Conversation_Transcript_Store_Interface` | Transcript CRUD is the first extractable storage contract. Keep chat-product listing/read-state/reporting separate. |
 | `AgentMemoryStoreInterface` | `WP_Agent_Memory_Store_Interface` | Generic identity tuple needs naming review; Data Machine scaffolding/abilities stay outside the store contract. |
 | `RuntimeToolDeclaration` | `WP_Agent_Tool_Declaration` | Should stay ability-native and run-scoped. |
 | `LoopEventSinkInterface` | `WP_Agent_Run_Event_Sink_Interface` | Useful for logs, streaming, chat UIs, and async workers. |
-| REST `datamachine/v1` agent routes | REST `wp-agents/v1` | Data Machine product routes stay under `datamachine/v1`. |
+| REST `datamachine/v1` agent routes | REST `wp-agents/v1` deferred | [#1670](https://github.com/Extra-Chill/data-machine/issues/1670) reserves the namespace but defers public REST controllers from the first standalone extraction. Data Machine product routes stay under `datamachine/v1`. |
 
 ## Boundary Rules
 
@@ -85,6 +86,42 @@ Agents API is a generic WordPress-shaped substrate. It should be usable by any p
 - Data Machine flow, pipeline, chat, bundle, queue, job, retention, or content-operation UI.
 
 Substrate CRUD is allowed when it is backend-only and generic: interfaces/services for definitions, sessions, memories, transcripts, tools, and run state. Product CRUD belongs to consumers: screens, forms, routes, workflows, and opinionated management UX. Data Machine may provide those product surfaces while consuming `agents-api`; the dependency direction must not reverse.
+
+## Category And Metadata Boundary
+
+Abilities API categories are not copied into Agents API v1.
+
+Core's Abilities API uses categories because abilities are many small executable actions. Category registration validates ability definitions, powers REST category discovery, and lets clients filter `GET /wp-abilities/v1/abilities` by action class. Agents are different: an agent is a runtime definition whose executable surface is its abilities/tool declarations, memory policy, run request, and permission ceiling.
+
+The v1 boundary is therefore:
+
+- No `WP_Agent_Category`, `WP_Agent_Categories_Registry`, or `wp_register_agent_category()` in the first standalone module.
+- No category-based permission, tool policy, memory policy, or REST visibility.
+- Data Machine UI grouping stays Data Machine product behavior.
+- Future `WP_Agent` metadata can carry descriptive fields such as `type`, `capabilities`, or `annotations`, but those fields are non-authoritative unless a later issue gives them explicit semantics.
+
+If a future REST or UI consumer proves category parity is needed, it should be added with Abilities API-style registration timing and validation instead of inferred from free-form metadata.
+
+## REST Boundary
+
+`wp-agents/v1` is reserved for a future backend substrate REST namespace, but the first standalone extraction should ship without public REST controllers.
+
+Reasons:
+
+- The PHP contracts are the extraction target; REST would freeze unsettled persistence, visibility, run-state, session, transcript, and permission decisions.
+- Data Machine already owns product REST for flows, pipelines, jobs, chat/session switcher, agent files, bundles, and automation UI under `datamachine/v1`.
+- A generic run endpoint must use `AgentConversationRunnerInterface` and generic request/result schemas, not Data Machine Action Scheduler jobs or pipeline execution vocabulary.
+
+Reserved future shape:
+
+| Route | Status | Notes |
+|---|---|---|
+| `GET /wp-agents/v1/agents` | Deferred | Lists explicitly visible registered definitions only. Requires a visibility decision before implementation. |
+| `GET /wp-agents/v1/agents/{slug}` | Deferred | Reads one visible definition. Must not expose private memory, owner state, tokens, or mutable config by default. |
+| `POST /wp-agents/v1/agents/{slug}/runs` | Deferred | Executes a generic run request. Needs permission ceiling, sync/async, event sink, transcript, and provider error contracts first. |
+| Transcript, memory, session, async run-state routes | Deferred separately | These are not implied by the namespace. Each needs its own storage and visibility decision. |
+
+Standalone skeleton docs should state that `wp-agents/v1` is intentionally absent in v1. Adding REST later requires route schemas, permission callbacks, visibility flags, and non-goals that keep Data Machine product REST out of the substrate.
 
 ## Bucket Summary
 

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -4,7 +4,7 @@ Parent issue: [Explore splitting Agents API out of Data Machine](https://github.
 
 Strategy issue: [Agents API blocker: update extraction docs around in-repo module strategy](https://github.com/Extra-Chill/data-machine/issues/1640)
 
-Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
+Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
 
 This audit records the remaining work after the first in-place untangling wave. The boundary is now mostly visible: Data Machine owns pipelines and automation; the future Agents API owns generic agent runtime primitives. The next phase is to make those primitives live behind an in-repo `data-machine/agents-api/` module boundary while they still ship with Data Machine.
 
@@ -71,6 +71,72 @@ Before standalone extraction, the in-repo module should satisfy these gates:
 - No `agents-api` file registers admin menus, admin screens, settings forms, or admin-only UI hooks.
 - Data Machine product code imports the module as a dependency instead of reaching across same-layer runtime/product paths.
 - Provider runtime code targets `wp-ai-client`; no `ai-http-client` fallback is introduced or preserved inside `agents-api`.
+
+## Core-Shape Decisions
+
+These decisions keep the first standalone shape small enough to extract without freezing Data Machine product vocabulary into the substrate.
+
+### Agent Categories And Capability Metadata
+
+Decision for [#1669](https://github.com/Extra-Chill/data-machine/issues/1669): **no first-class agent category registry in v1**.
+
+Agents differ from Abilities API abilities in the part of the system that needs discovery:
+
+- Abilities are executable units. Core's Abilities API requires category registration because categories organize many small callable actions and drive REST filtering through `GET /wp-abilities/v1/categories` and the `category` collection parameter.
+- Agents are runtime definitions. Their tool surface should be discovered through abilities/runtime tool declarations, not through a second category hierarchy on the agent definition itself.
+- Data Machine UI grouping is not a valid reason to add a generic substrate field. Product UIs can group agents through their own settings, bundles, roles, or persisted metadata.
+- Tool policy and memory policy should key off explicit policy fields, tool declarations, abilities, or run context. They should not infer permissions from a display category.
+
+The v1 extension path is **lightweight metadata**, not category parity:
+
+- Allow a future `metadata`/`annotations` object on `WP_Agent` definitions after the public class contract is finalized.
+- Suggested generic keys, if proven by consumers: `type` for broad role hints, `capabilities` for declarative non-security affordances, and `annotations` for machine-readable hints.
+- Metadata must be descriptive only in v1. It must not grant REST visibility, tool access, memory access, owner access, or execution permission by itself.
+- If a future consumer proves that category parity is necessary, add it as a separate issue with Abilities API-style registration timing, validation, and REST discovery. Do not smuggle category semantics into `default_config`.
+
+### `wp-agents/v1` REST Surface
+
+Decision for [#1670](https://github.com/Extra-Chill/data-machine/issues/1670): **defer public `wp-agents/v1` routes from the first standalone extraction**.
+
+The first extraction should prove the backend PHP substrate before publishing an HTTP contract. A premature REST controller would force decisions that are still unsettled: persistence ownership, visibility flags, run/session identity, transcript exposure, memory exposure, and permission ceilings.
+
+The deferred shape is reserved as a backend substrate namespace, not a Data Machine product API:
+
+- `GET /wp-agents/v1/agents` may list registered agent definitions that explicitly opt into REST discovery.
+- `GET /wp-agents/v1/agents/{slug}` may read one registered definition.
+- `POST /wp-agents/v1/agents/{slug}/runs` may eventually execute a generic `AgentConversationRequest` through `AgentConversationRunnerInterface`.
+- Any future transcript, memory, run-state, or session routes require separate decisions. They must not inherit Data Machine chat-session switcher, jobs, flows, pipelines, queues, or pending-action vocabulary.
+
+The v1 standalone skeleton should therefore document that `wp-agents/v1` is intentionally absent. Data Machine's existing `datamachine/v1` routes remain product REST for flows, pipelines, jobs, chat UI, agent files, and automation surfaces. They may adapt to Agents API contracts later, but they do not define the public substrate.
+
+REST acceptance gates before any future controller lands:
+
+- Define a `show_in_rest`-equivalent visibility flag or intentionally choose authenticated-only discovery with no public listing.
+- Define list/read/run schemas with no Data Machine table names, job IDs, flow IDs, pipeline IDs, or handler slugs in the public contract.
+- Define permission callbacks separately for list, read, and run. `current_user_can( 'read' )` is not automatically sufficient for agent execution.
+- Define whether run endpoints are synchronous only, asynchronous only, or both. Do not reuse Action Scheduler job semantics unless the route is explicitly Data Machine-owned.
+- Decide whether metadata is exposed, and if so which keys are public versus edit-context only.
+
+## Extraction Readiness Checklist
+
+[#1596](https://github.com/Extra-Chill/data-machine/issues/1596) is blocked until every **must-fix** item below is complete or explicitly reclassified in a follow-up decision.
+
+| Gate | Status | Proof issue |
+|---|---|---|
+| In-repo `agents-api/` module loads before Data Machine product runtime and can boot in a smoke without product code. | Must fix | [#1631](https://github.com/Extra-Chill/data-machine/issues/1631), [#1618](https://github.com/Extra-Chill/data-machine/issues/1618) |
+| Public contract candidates live in the module or have a documented reason to stay in Data Machine for compatibility. | Must fix | [#1632](https://github.com/Extra-Chill/data-machine/issues/1632) |
+| No public `agents-api/` contract imports `DataMachine\` product namespaces or requires jobs, flows, pipelines, handlers, queues, pending actions, content operations, or admin UI. | Must fix | [#1631](https://github.com/Extra-Chill/data-machine/issues/1631), [#1672](https://github.com/Extra-Chill/data-machine/issues/1672) |
+| `WP_Agent`, `WP_Agents_Registry`, `wp_register_agent()`, and registry lifecycle are validated and documented. | Must fix | [#1618](https://github.com/Extra-Chill/data-machine/issues/1618), [#1632](https://github.com/Extra-Chill/data-machine/issues/1632) |
+| Registration helper parity is decided for `wp_get_agent()`, `wp_get_agents()`, `wp_has_agent()`, and `wp_unregister_agent()`. | Must fix | [#1618](https://github.com/Extra-Chill/data-machine/issues/1618) |
+| Agent categories/capabilities decision is recorded: no v1 category registry; future descriptive metadata only. | Complete | [#1669](https://github.com/Extra-Chill/data-machine/issues/1669) |
+| `wp-agents/v1` REST decision is recorded: defer public REST from first standalone extraction, reserve namespace for backend substrate. | Complete | [#1670](https://github.com/Extra-Chill/data-machine/issues/1670) |
+| Generic run/result/message contracts contain no Data Machine pipeline/handler vocabulary. | Must fix | [#1596](https://github.com/Extra-Chill/data-machine/issues/1596), [#1634](https://github.com/Extra-Chill/data-machine/issues/1634) |
+| Built-in loop ownership is settled: Data Machine keeps compatibility loop until completion/transcript/provider/logging assumptions are behind generic collaborators. | Must fix | [#1634](https://github.com/Extra-Chill/data-machine/issues/1634) |
+| Provider runtime depends directly on `wp-ai-client`; no `ai-http-client` or `chubes_ai_request` runtime fallback survives inside `agents-api`. | Must fix | [#1633](https://github.com/Extra-Chill/data-machine/issues/1633), [#1027](https://github.com/Extra-Chill/data-machine/issues/1027), [#1660](https://github.com/Extra-Chill/data-machine/issues/1660), [#1661](https://github.com/Extra-Chill/data-machine/issues/1661) |
+| Memory and transcript interfaces are generic and UI-free. Data Machine chat/session switcher/read-state/reporting remain product adapters unless separately adopted. | Must fix | [#1632](https://github.com/Extra-Chill/data-machine/issues/1632), [#1651](https://github.com/Extra-Chill/data-machine/issues/1651) |
+| Data Machine adapters own flows, jobs, pipelines, handlers, pending actions, bundles, queues, retention, content operations, and chat/admin UI. | Must fix | [#1561](https://github.com/Extra-Chill/data-machine/issues/1561), [#1640](https://github.com/Extra-Chill/data-machine/issues/1640), [#1651](https://github.com/Extra-Chill/data-machine/issues/1651) |
+| Standalone skeleton documents that `wp-agents/v1` is absent in v1 and includes no REST controllers until the REST acceptance gates are satisfied. | Must fix | [#1618](https://github.com/Extra-Chill/data-machine/issues/1618), [#1670](https://github.com/Extra-Chill/data-machine/issues/1670) |
+| Optional future stores, sessions, async run state, REST controllers, category parity, and product UI are deferred until the core backend contracts are extractable. | Can follow | [#1596](https://github.com/Extra-Chill/data-machine/issues/1596), [#1670](https://github.com/Extra-Chill/data-machine/issues/1670), [#1669](https://github.com/Extra-Chill/data-machine/issues/1669) |
 
 ## Remaining In-Place Rename Work
 


### PR DESCRIPTION
## Summary
- Documents the Agents API core-shape decisions for category/capability metadata and the deferred `wp-agents/v1` REST surface.
- Adds an extraction readiness checklist that explicitly blocks #1596 until the must-fix gates are complete.
- Updates the agent registration docs so the no-category-v1 decision is visible next to the current registry surface.

## Decisions
- Agents API v1 does not add Abilities API-style category parity; future metadata/annotations stay descriptive unless a later issue gives them explicit semantics.
- `wp-agents/v1` is reserved but intentionally deferred from the first standalone extraction; Data Machine product REST remains under `datamachine/v1`.
- #1596 remains blocked by the readiness checklist until the granular module, helper parity, vocabulary, provider, memory/transcript, and adapter-boundary gates are complete.

## Tests
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-core-design-checklist --changed-since origin/main` passed. Note: Homeboy reported `No files changed since origin/main` for this docs-only diff before returning success.

Closes #1669
Closes #1670
Closes #1672

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and validating Agents API core-shape extraction docs/checklists under Chris's review.