### PR TITLE
refactor(agents-api): harden agent registration facade

### DIFF
--- a/agents-api/inc/class-wp-agent.php
+++ b/agents-api/inc/class-wp-agent.php
@@ -81,7 +81,7 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 			$properties = $this->prepare_properties( $args );
 			foreach ( $properties as $property_name => $property_value ) {
 				if ( ! property_exists( $this, $property_name ) ) {
-					$this->doing_it_wrong( __METHOD__, sprintf( 'Property "%s" is not a valid property for agent "%s".', $property_name, $this->slug ) );
+					$this->notice_invalid_property( __METHOD__, sprintf( 'Property "%s" is not a valid property for agent "%s".', $property_name, $this->slug ) );
 					continue;
 				}
 
@@ -254,7 +254,7 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		 * @param string $message       Notice message.
 		 * @return void
 		 */
-		private function doing_it_wrong( string $function_name, string $message ): void {
+		private function notice_invalid_property( string $function_name, string $message ): void {
 			if ( function_exists( '_doing_it_wrong' ) ) {
 				$function_name = function_exists( 'esc_html' ) ? esc_html( $function_name ) : $function_name;
 				$message       = function_exists( 'esc_html' ) ? esc_html( $message ) : $message;

--- a/agents-api/inc/class-wp-agent.php
+++ b/agents-api/inc/class-wp-agent.php
@@ -22,14 +22,49 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		 *
 		 * @var string
 		 */
-		public string $slug;
+		protected string $slug;
 
 		/**
-		 * Registration arguments.
+		 * Human-readable label.
 		 *
-		 * @var array
+		 * @var string
 		 */
-		private array $args;
+		protected string $label;
+
+		/**
+		 * Agent description.
+		 *
+		 * @var string
+		 */
+		protected string $description = '';
+
+		/**
+		 * Memory seed files keyed by scaffold filename.
+		 *
+		 * @var array<string, string>
+		 */
+		protected array $memory_seeds = array();
+
+		/**
+		 * Optional owner resolver callback.
+		 *
+		 * @var callable|null
+		 */
+		protected $owner_resolver = null;
+
+		/**
+		 * Initial agent config for first materialization.
+		 *
+		 * @var array<string, mixed>
+		 */
+		protected array $default_config = array();
+
+		/**
+		 * Optional metadata.
+		 *
+		 * @var array<string, mixed>
+		 */
+		protected array $meta = array();
 
 		/**
 		 * Constructor.
@@ -39,7 +74,160 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		 */
 		public function __construct( string $slug, array $args = array() ) {
 			$this->slug = sanitize_title( $slug );
-			$this->args = $args;
+			if ( '' === $this->slug ) {
+				throw new InvalidArgumentException( 'Agent slug cannot be empty.' );
+			}
+
+			$properties = $this->prepare_properties( $args );
+			foreach ( $properties as $property_name => $property_value ) {
+				if ( ! property_exists( $this, $property_name ) ) {
+					$this->doing_it_wrong( __METHOD__, sprintf( 'Property "%s" is not a valid property for agent "%s".', $property_name, $this->slug ) );
+					continue;
+				}
+
+				$this->$property_name = $property_value;
+			}
+		}
+
+		/**
+		 * Prepare and validate constructor properties.
+		 *
+		 * @param array<string, mixed> $args Registration arguments.
+		 * @return array<string, mixed>
+		 * @throws InvalidArgumentException When an argument has an invalid type.
+		 */
+		protected function prepare_properties( array $args ): array {
+			$properties = array();
+
+			$properties['label'] = isset( $args['label'] ) ? (string) $args['label'] : $this->slug;
+			if ( '' === $properties['label'] ) {
+				$properties['label'] = $this->slug;
+			}
+
+			$properties['description'] = isset( $args['description'] ) ? (string) $args['description'] : '';
+
+			if ( isset( $args['memory_seeds'] ) ) {
+				if ( ! is_array( $args['memory_seeds'] ) ) {
+					throw new InvalidArgumentException( 'Agent memory_seeds property must be an array.' );
+				}
+
+				$properties['memory_seeds'] = $this->prepare_memory_seeds( $args['memory_seeds'] );
+			}
+
+			if ( isset( $args['owner_resolver'] ) ) {
+				if ( ! is_callable( $args['owner_resolver'] ) ) {
+					throw new InvalidArgumentException( 'Agent owner_resolver property must be callable.' );
+				}
+
+				$properties['owner_resolver'] = $args['owner_resolver'];
+			}
+
+			if ( isset( $args['default_config'] ) ) {
+				if ( ! is_array( $args['default_config'] ) ) {
+					throw new InvalidArgumentException( 'Agent default_config property must be an array.' );
+				}
+
+				$properties['default_config'] = $args['default_config'];
+			}
+
+			if ( isset( $args['meta'] ) ) {
+				if ( ! is_array( $args['meta'] ) ) {
+					throw new InvalidArgumentException( 'Agent meta property must be an array.' );
+				}
+
+				$properties['meta'] = $args['meta'];
+			}
+
+			foreach ( $args as $property_name => $property_value ) {
+				if ( ! array_key_exists( $property_name, $properties ) && ! property_exists( $this, (string) $property_name ) ) {
+					$properties[ (string) $property_name ] = $property_value;
+				}
+			}
+
+			return $properties;
+		}
+
+		/**
+		 * Prepare memory seed file map.
+		 *
+		 * @param array<mixed, mixed> $memory_seeds Raw memory seed map.
+		 * @return array<string, string>
+		 */
+		private function prepare_memory_seeds( array $memory_seeds ): array {
+			$prepared = array();
+
+			foreach ( $memory_seeds as $filename => $path ) {
+				$filename = sanitize_file_name( (string) $filename );
+				$path     = (string) $path;
+				if ( '' !== $filename && '' !== $path ) {
+					$prepared[ $filename ] = $path;
+				}
+			}
+
+			return $prepared;
+		}
+
+		/**
+		 * Retrieves the agent slug.
+		 *
+		 * @return string
+		 */
+		public function get_slug(): string {
+			return $this->slug;
+		}
+
+		/**
+		 * Retrieves the agent label.
+		 *
+		 * @return string
+		 */
+		public function get_label(): string {
+			return $this->label;
+		}
+
+		/**
+		 * Retrieves the agent description.
+		 *
+		 * @return string
+		 */
+		public function get_description(): string {
+			return $this->description;
+		}
+
+		/**
+		 * Retrieves memory seed file map.
+		 *
+		 * @return array<string, string>
+		 */
+		public function get_memory_seeds(): array {
+			return $this->memory_seeds;
+		}
+
+		/**
+		 * Retrieves the owner resolver callback.
+		 *
+		 * @return callable|null
+		 */
+		public function get_owner_resolver() {
+			return $this->owner_resolver;
+		}
+
+		/**
+		 * Retrieves initial materialization config.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function get_default_config(): array {
+			return $this->default_config;
+		}
+
+		/**
+		 * Retrieves optional metadata.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function get_meta(): array {
+			return $this->meta;
 		}
 
 		/**
@@ -48,7 +236,30 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		 * @return array
 		 */
 		public function to_array(): array {
-			return $this->args;
+			return array(
+				'slug'           => $this->slug,
+				'label'          => $this->label,
+				'description'    => $this->description,
+				'memory_seeds'   => $this->memory_seeds,
+				'owner_resolver' => $this->owner_resolver,
+				'default_config' => $this->default_config,
+				'meta'           => $this->meta,
+			);
+		}
+
+		/**
+		 * Emit a WordPress-style invalid-usage notice when available.
+		 *
+		 * @param string $function_name Function or method name.
+		 * @param string $message       Notice message.
+		 * @return void
+		 */
+		private function doing_it_wrong( string $function_name, string $message ): void {
+			if ( function_exists( '_doing_it_wrong' ) ) {
+				$function_name = function_exists( 'esc_html' ) ? esc_html( $function_name ) : $function_name;
+				$message       = function_exists( 'esc_html' ) ? esc_html( $message ) : $message;
+				_doing_it_wrong( $function_name, $message, '0.71.0' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- _doing_it_wrong receives a message, not direct output.
+			}
 		}
 	}
 }

--- a/agents-api/inc/class-wp-agents-registry.php
+++ b/agents-api/inc/class-wp-agents-registry.php
@@ -62,7 +62,7 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 			try {
 				$agent = $agent instanceof WP_Agent ? $agent : new WP_Agent( (string) $agent, $args );
 			} catch ( InvalidArgumentException $e ) {
-				$this->doing_it_wrong( __METHOD__, $e->getMessage() );
+				$this->notice_invalid_registration( __METHOD__, $e->getMessage() );
 				return null;
 			}
 
@@ -150,7 +150,7 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 			self::ensure_fired();
 			$slug = sanitize_title( $slug );
 			if ( ! isset( self::get_instance()->registered_agents[ $slug ] ) ) {
-				self::get_instance()->doing_it_wrong( __METHOD__, sprintf( 'Agent "%s" not found.', $slug ) );
+				self::get_instance()->notice_invalid_registration( __METHOD__, sprintf( 'Agent "%s" not found.', $slug ) );
 				return null;
 			}
 
@@ -213,7 +213,7 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		 * @param string $message       Notice message.
 		 * @return void
 		 */
-		private function doing_it_wrong( string $function_name, string $message ): void {
+		private function notice_invalid_registration( string $function_name, string $message ): void {
 			if ( function_exists( '_doing_it_wrong' ) ) {
 				$function_name = function_exists( 'esc_html' ) ? esc_html( $function_name ) : $function_name;
 				$message       = function_exists( 'esc_html' ) ? esc_html( $message ) : $message;

--- a/agents-api/inc/class-wp-agents-registry.php
+++ b/agents-api/inc/class-wp-agents-registry.php
@@ -17,11 +17,18 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 	class WP_Agents_Registry {
 
 		/**
+		 * Singleton instance.
+		 *
+		 * @var self|null
+		 */
+		private static ?self $instance = null;
+
+		/**
 		 * Registered agent definitions, keyed by slug.
 		 *
-		 * @var array<string, array>
+		 * @var array<string, WP_Agent>
 		 */
-		private static array $agents = array();
+		private array $registered_agents = array();
 
 		/**
 		 * Whether the public registration action has fired.
@@ -35,45 +42,32 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		 *
 		 * @param string|WP_Agent $agent Agent slug or definition object.
 		 * @param array           $args  Registration arguments when `$agent` is a slug.
-		 * @return void
+		 * @return WP_Agent|null Registered agent, or null on invalid arguments.
 		 */
-		public static function register( $agent, array $args = array() ): void {
-			if ( $agent instanceof WP_Agent ) {
-				$slug = $agent->slug;
-				$args = $agent->to_array();
-			} else {
-				$slug = (string) $agent;
+		public static function register( $agent, array $args = array() ): ?WP_Agent {
+			return self::get_instance()->register_agent( $agent, $args );
+		}
+
+		/**
+		 * Register an agent definition on this registry instance.
+		 *
+		 * Duplicate slugs intentionally remain last-wins while the registry is
+		 * in-repo: Data Machine uses hook priority for fresh-install overrides.
+		 *
+		 * @param string|WP_Agent $agent Agent slug or definition object.
+		 * @param array           $args  Registration arguments when `$agent` is a slug.
+		 * @return WP_Agent|null Registered agent, or null on invalid arguments.
+		 */
+		public function register_agent( $agent, array $args = array() ): ?WP_Agent {
+			try {
+				$agent = $agent instanceof WP_Agent ? $agent : new WP_Agent( (string) $agent, $args );
+			} catch ( InvalidArgumentException $e ) {
+				$this->doing_it_wrong( __METHOD__, $e->getMessage() );
+				return null;
 			}
 
-			$slug = sanitize_title( $slug );
-			if ( '' === $slug ) {
-				return;
-			}
-
-			$label = isset( $args['label'] ) ? (string) $args['label'] : '';
-			if ( '' === $label ) {
-				$label = $slug;
-			}
-
-			$memory_seeds = array();
-			if ( isset( $args['memory_seeds'] ) && is_array( $args['memory_seeds'] ) ) {
-				foreach ( $args['memory_seeds'] as $filename => $path ) {
-					$filename = sanitize_file_name( (string) $filename );
-					$path     = (string) $path;
-					if ( '' !== $filename && '' !== $path ) {
-						$memory_seeds[ $filename ] = $path;
-					}
-				}
-			}
-
-			self::$agents[ $slug ] = array(
-				'slug'           => $slug,
-				'label'          => $label,
-				'description'    => isset( $args['description'] ) ? (string) $args['description'] : '',
-				'memory_seeds'   => $memory_seeds,
-				'owner_resolver' => isset( $args['owner_resolver'] ) && is_callable( $args['owner_resolver'] ) ? $args['owner_resolver'] : null,
-				'default_config' => isset( $args['default_config'] ) && is_array( $args['default_config'] ) ? $args['default_config'] : array(),
-			);
+			$this->registered_agents[ $agent->get_slug() ] = $agent;
+			return $agent;
 		}
 
 		/**
@@ -83,7 +77,20 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		 */
 		public static function get_all(): array {
 			self::ensure_fired();
-			return self::$agents;
+			return array_map(
+				static fn( WP_Agent $agent ): array => $agent->to_array(),
+				self::get_instance()->registered_agents
+			);
+		}
+
+		/**
+		 * Get all registered agent objects.
+		 *
+		 * @return array<string, WP_Agent>
+		 */
+		public static function get_all_registered(): array {
+			self::ensure_fired();
+			return self::get_instance()->registered_agents;
 		}
 
 		/**
@@ -94,8 +101,76 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		 */
 		public static function get( string $slug ): ?array {
 			self::ensure_fired();
+			$slug  = sanitize_title( $slug );
+			$agent = self::get_instance()->registered_agents[ $slug ] ?? null;
+			return $agent instanceof WP_Agent ? $agent->to_array() : null;
+		}
+
+		/**
+		 * Get a single registered agent object by slug.
+		 *
+		 * @param string $slug Agent slug.
+		 * @return WP_Agent|null Agent object, or null when not registered.
+		 */
+		public static function get_registered( string $slug ): ?WP_Agent {
+			self::ensure_fired();
 			$slug = sanitize_title( $slug );
-			return self::$agents[ $slug ] ?? null;
+			return self::get_instance()->registered_agents[ $slug ] ?? null;
+		}
+
+		/**
+		 * Check whether an agent is registered.
+		 *
+		 * @param string $slug Agent slug.
+		 * @return bool
+		 */
+		public static function has( string $slug ): bool {
+			self::ensure_fired();
+			$slug = sanitize_title( $slug );
+			return isset( self::get_instance()->registered_agents[ $slug ] );
+		}
+
+		/**
+		 * Check whether an agent is registered.
+		 *
+		 * @param string $slug Agent slug.
+		 * @return bool
+		 */
+		public static function is_registered( string $slug ): bool {
+			return self::has( $slug );
+		}
+
+		/**
+		 * Unregister an agent definition.
+		 *
+		 * @param string $slug Agent slug.
+		 * @return WP_Agent|null Removed agent, or null when not registered.
+		 */
+		public static function unregister( string $slug ): ?WP_Agent {
+			self::ensure_fired();
+			$slug = sanitize_title( $slug );
+			if ( ! isset( self::get_instance()->registered_agents[ $slug ] ) ) {
+				self::get_instance()->doing_it_wrong( __METHOD__, sprintf( 'Agent "%s" not found.', $slug ) );
+				return null;
+			}
+
+			$agent = self::get_instance()->registered_agents[ $slug ];
+			unset( self::get_instance()->registered_agents[ $slug ] );
+
+			return $agent;
+		}
+
+		/**
+		 * Retrieve the registry singleton.
+		 *
+		 * @return self
+		 */
+		public static function get_instance(): self {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
 		}
 
 		/**
@@ -127,8 +202,23 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		 * @return void
 		 */
 		public static function reset_for_tests(): void {
-			self::$agents             = array();
+			self::$instance           = new self();
 			self::$registration_fired = false;
+		}
+
+		/**
+		 * Emit a WordPress-style invalid-usage notice when available.
+		 *
+		 * @param string $function_name Function or method name.
+		 * @param string $message       Notice message.
+		 * @return void
+		 */
+		private function doing_it_wrong( string $function_name, string $message ): void {
+			if ( function_exists( '_doing_it_wrong' ) ) {
+				$function_name = function_exists( 'esc_html' ) ? esc_html( $function_name ) : $function_name;
+				$message       = function_exists( 'esc_html' ) ? esc_html( $message ) : $message;
+				_doing_it_wrong( $function_name, $message, '0.71.0' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- _doing_it_wrong receives a message, not direct output.
+			}
 		}
 	}
 }

--- a/agents-api/inc/register-agents.php
+++ b/agents-api/inc/register-agents.php
@@ -16,9 +16,56 @@ if ( ! function_exists( 'wp_register_agent' ) ) {
 	 *
 	 * @param string|WP_Agent $agent Agent slug or definition object.
 	 * @param array           $args  Registration arguments.
-	 * @return void
+	 * @return WP_Agent|null Registered agent, or null on invalid arguments.
 	 */
-	function wp_register_agent( $agent, array $args = array() ): void {
-		WP_Agents_Registry::register( $agent, $args );
+	function wp_register_agent( $agent, array $args = array() ): ?WP_Agent {
+		return WP_Agents_Registry::get_instance()->register_agent( $agent, $args );
+	}
+}
+
+if ( ! function_exists( 'wp_get_agent' ) ) {
+	/**
+	 * Retrieves a registered agent object.
+	 *
+	 * @param string $slug Agent slug.
+	 * @return WP_Agent|null Registered agent, or null when not registered.
+	 */
+	function wp_get_agent( string $slug ): ?WP_Agent {
+		return WP_Agents_Registry::get_registered( $slug );
+	}
+}
+
+if ( ! function_exists( 'wp_get_agents' ) ) {
+	/**
+	 * Retrieves all registered agent objects.
+	 *
+	 * @return array<string, WP_Agent>
+	 */
+	function wp_get_agents(): array {
+		return WP_Agents_Registry::get_all_registered();
+	}
+}
+
+if ( ! function_exists( 'wp_has_agent' ) ) {
+	/**
+	 * Checks whether an agent is registered.
+	 *
+	 * @param string $slug Agent slug.
+	 * @return bool
+	 */
+	function wp_has_agent( string $slug ): bool {
+		return WP_Agents_Registry::has( $slug );
+	}
+}
+
+if ( ! function_exists( 'wp_unregister_agent' ) ) {
+	/**
+	 * Unregisters an agent definition.
+	 *
+	 * @param string $slug Agent slug.
+	 * @return WP_Agent|null Removed agent, or null when not registered.
+	 */
+	function wp_unregister_agent( string $slug ): ?WP_Agent {
+		return WP_Agents_Registry::unregister( $slug );
 	}
 }

--- a/docs/core-system/agent-registration.md
+++ b/docs/core-system/agent-registration.md
@@ -9,7 +9,7 @@ Declarative agent registration via the `wp_agents_api_init` action. Plugins (and
 
 Agents were previously materialized imperatively — either via `AgentAbilities::createAgent()` from CLI/REST, or lazily via `datamachine_resolve_or_create_agent_id()` on first chat turn. That works for per-user personal agents but doesn't give extensions a clean way to ship a bundled agent role (e.g. a wiki-generator, a support-triage bot, a content-reviewer).
 
-The registry mirrors the `register_post_type()` / `register_taxonomy()` pattern: plugins declare the role, Data Machine owns today's runtime. The public vocabulary mirrors the Abilities API direction (`wp_register_agent()`, `WP_Agent`, `WP_Agents_Registry`, `wp_agents_api_init`) so the generic registry can move cleanly if Agents API is extracted later. Data Machine dogfoods it — the default site administrator agent is registered through the same hook.
+The registry mirrors the `register_post_type()` / `register_taxonomy()` pattern: plugins declare the role, Data Machine owns today's runtime. The public vocabulary mirrors the Abilities API direction (`wp_register_agent()`, `wp_get_agent()`, `wp_get_agents()`, `wp_has_agent()`, `wp_unregister_agent()`, `WP_Agent`, `WP_Agents_Registry`, `wp_agents_api_init`) so the generic registry can move cleanly if Agents API is extracted later. Data Machine dogfoods it — the default site administrator agent is registered through the same hook.
 
 ## Declaring an agent
 
@@ -45,10 +45,29 @@ That's it. On the next request where `init` fires, DM reconciles the registratio
 | `memory_seeds` | array<string,string> | Map of `filename => absolute path`. Each entry surfaces the bundled file as scaffold content for that filename when the target file does not yet exist on disk. Works for any filename registered via `MemoryFileRegistry::register()` — `SOUL.md` and `MEMORY.md` are common, but plugins can seed custom agent-layer files through the same primitive. See [Memory seed resolution](#memory-seed-resolution). |
 | `owner_resolver` | callable | Returns `int user_id`. Called once at row-creation time. Defaults to `DirectoryManager::get_default_agent_user_id()`. |
 | `default_config` | array | Initial `agent_config` persisted on creation. Subsequent config changes go through the DB — the registration never overrides user-edited config. |
+| `meta` | array | Optional registry metadata for future consumers. Data Machine's current materializer ignores it. |
 
 ### Slug semantics
 
-Slugs are passed through `sanitize_title()`. They must be unique across a site (DB column has a UNIQUE constraint on `agent_slug`). Two plugins registering the same slug is resolved by **last-wins** — this matches WP action/filter semantics, so plugins can override core or other plugins by hooking at a higher priority.
+Slugs are passed through `sanitize_title()`. Empty slugs are rejected. They must be unique across a site (DB column has a UNIQUE constraint on `agent_slug`). Two plugins registering the same slug is resolved by **last-wins** — this intentionally diverges from the Abilities API's duplicate rejection. Data Machine relies on hook priority as a fresh-install override mechanism while the registry lives in-repo.
+
+`WP_Agent` is a prepared definition object, not a database row. It validates property types, normalizes the slug and memory seed filenames, and exposes getters (`get_slug()`, `get_label()`, `get_description()`, `get_memory_seeds()`, `get_owner_resolver()`, `get_default_config()`, `get_meta()`).
+
+Invalid property types reject the definition with a `_doing_it_wrong()` notice when WordPress provides that function. Unknown properties are ignored with the same notice style so future registry fields do not accidentally become materializer inputs.
+
+## Lifecycle compared to Abilities API
+
+Agents API deliberately follows the Abilities API vocabulary without copying every lifecycle constraint yet:
+
+| Surface | Abilities API | Agents API in Data Machine |
+|---|---|---|
+| Init action | `wp_abilities_api_init` | `wp_agents_api_init` |
+| Registry initialization | Lazy singleton after `init` | Lazy singleton on first registry read or registration |
+| Registration timing | Must happen during `wp_abilities_api_init` | Should happen during `wp_agents_api_init`, but direct registration remains supported |
+| Duplicate registration | Rejected with `_doing_it_wrong()` | Last registration wins |
+| Lookup helpers | `wp_get_ability()`, `wp_get_abilities()`, `wp_has_ability()`, `wp_unregister_ability()` | `wp_get_agent()`, `wp_get_agents()`, `wp_has_agent()`, `wp_unregister_agent()` |
+
+The timing divergence is intentional for v1. Data Machine's materializer fires registry reads from `init` priority 15, and some tests/consumers register definitions directly before that lazy collection path. Rejecting outside-hook registration would be more core-shaped, but it would be a behavior change for the in-repo substrate. New code should still prefer the hook form so extraction can tighten timing later.
 
 ## Reconciliation
 

--- a/tests/agents-api-bootstrap-smoke.php
+++ b/tests/agents-api-bootstrap-smoke.php
@@ -24,6 +24,10 @@ agents_api_smoke_assert_equals( true, defined( 'AGENTS_API_LOADED' ), 'module ma
 agents_api_smoke_assert_equals( true, defined( 'AGENTS_API_PATH' ), 'module path constant is available', $failures, $passes );
 agents_api_smoke_assert_equals( realpath( __DIR__ . '/../agents-api' ) . '/', AGENTS_API_PATH, 'module path points at agents-api directory', $failures, $passes );
 agents_api_smoke_assert_equals( true, function_exists( 'wp_register_agent' ), 'wp_register_agent helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_get_agent' ), 'wp_get_agent helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_get_agents' ), 'wp_get_agents helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_has_agent' ), 'wp_has_agent helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_unregister_agent' ), 'wp_unregister_agent helper is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent' ), 'WP_Agent value object is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agents_Registry' ), 'WP_Agents_Registry facade is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, interface_exists( 'DataMachine\\Core\\Database\\Chat\\ConversationTranscriptStoreInterface' ), 'ConversationTranscriptStoreInterface contract is available', $failures, $passes );

--- a/tests/agents-api-registration-smoke.php
+++ b/tests/agents-api-registration-smoke.php
@@ -17,6 +17,7 @@ agents_api_smoke_require_module();
 
 echo "\n[1] Direct registration normalizes definitions without side effects:\n";
 WP_Agents_Registry::reset_for_tests();
+$GLOBALS['__agents_api_smoke_wrong'] = array();
 wp_register_agent(
 	new WP_Agent(
 		'Example Agent!',
@@ -31,12 +32,22 @@ wp_register_agent(
 );
 
 $definitions = WP_Agents_Registry::get_all();
+$agent       = wp_get_agent( 'Example Agent!' );
 agents_api_smoke_assert_equals( array( 'example-agent' ), array_keys( $definitions ), 'definition slug is normalized', $failures, $passes );
 agents_api_smoke_assert_equals( 'Example Agent', $definitions['example-agent']['label'] ?? '', 'definition label is preserved', $failures, $passes );
 agents_api_smoke_assert_equals( 'Standalone module smoke', $definitions['example-agent']['description'] ?? '', 'definition description is preserved', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'SOUL.md' => '/tmp/seed-soul.md' ), $definitions['example-agent']['memory_seeds'] ?? array(), 'memory seed filenames are sanitized', $failures, $passes );
 agents_api_smoke_assert_equals( true, is_callable( $definitions['example-agent']['owner_resolver'] ?? null ), 'callable owner resolver is preserved', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'default_provider' => 'openai' ), $definitions['example-agent']['default_config'] ?? array(), 'default config is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( true, $agent instanceof WP_Agent, 'wp_get_agent returns an agent object', $failures, $passes );
+agents_api_smoke_assert_equals( 'example-agent', $agent ? $agent->get_slug() : '', 'agent getter exposes slug', $failures, $passes );
+agents_api_smoke_assert_equals( 'Example Agent', $agent ? $agent->get_label() : '', 'agent getter exposes label', $failures, $passes );
+agents_api_smoke_assert_equals( 'Standalone module smoke', $agent ? $agent->get_description() : '', 'agent getter exposes description', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'SOUL.md' => '/tmp/seed-soul.md' ), $agent ? $agent->get_memory_seeds() : array(), 'agent getter exposes memory seeds', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'default_provider' => 'openai' ), $agent ? $agent->get_default_config() : array(), 'agent getter exposes default config', $failures, $passes );
+agents_api_smoke_assert_equals( array(), $agent ? $agent->get_meta() : array( 'missing' ), 'agent getter exposes default meta', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_agent( 'example-agent' ), 'wp_has_agent reports registered slug', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'example-agent' ), array_keys( wp_get_agents() ), 'wp_get_agents returns object map', $failures, $passes );
 
 echo "\n[2] Public registration hook fires once on first read:\n";
 WP_Agents_Registry::reset_for_tests();
@@ -55,9 +66,10 @@ agents_api_smoke_assert_equals( array( 'hook-agent' ), array_keys( $definitions 
 agents_api_smoke_assert_equals( array( 'hook-agent' ), array_keys( WP_Agents_Registry::get_all() ), 'registration hook does not refire on subsequent reads', $failures, $passes );
 agents_api_smoke_assert_equals( 1, $hook_calls, 'hook call count remains stable after second read', $failures, $passes );
 
-echo "\n[3] Invalid definitions are ignored or normalized predictably:\n";
+echo "\n[3] Invalid definitions are rejected or normalized predictably:\n";
 WP_Agents_Registry::reset_for_tests();
 $GLOBALS['__agents_api_smoke_actions'] = array();
+$GLOBALS['__agents_api_smoke_wrong']   = array();
 wp_register_agent( '!!!', array( 'label' => 'Invalid' ) );
 wp_register_agent( 'Minimal Agent' );
 wp_register_agent(
@@ -68,14 +80,33 @@ wp_register_agent(
 			''             => '/tmp/empty.md',
 			'empty-path.md' => '',
 		),
-		'owner_resolver' => 'not callable',
 	)
 );
+wp_register_agent( 'Bad Resolver', array( 'owner_resolver' => 'not callable' ) );
+wp_register_agent( 'Bad Seeds', array( 'memory_seeds' => 'not an array' ) );
+wp_register_agent( 'Unknown Property', array( 'label' => 'Unknown Property', 'mystery' => true ) );
 
 $definitions = WP_Agents_Registry::get_all();
-agents_api_smoke_assert_equals( array( 'minimal-agent', 'messy-seeds' ), array_keys( $definitions ), 'empty slugs are ignored while valid slugs are kept', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'minimal-agent', 'messy-seeds', 'unknown-property' ), array_keys( $definitions ), 'empty slugs are ignored while valid slugs are kept', $failures, $passes );
 agents_api_smoke_assert_equals( 'minimal-agent', $definitions['minimal-agent']['label'] ?? '', 'missing label falls back to slug', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'MEMORY.md' => '/tmp/MEMORY.md' ), $definitions['messy-seeds']['memory_seeds'] ?? array(), 'empty memory seed keys and paths are dropped', $failures, $passes );
-agents_api_smoke_assert_equals( null, $definitions['messy-seeds']['owner_resolver'] ?? null, 'non-callable owner resolver is dropped', $failures, $passes );
+agents_api_smoke_assert_equals( false, isset( $definitions['bad-resolver'] ), 'non-callable owner resolver rejects definition', $failures, $passes );
+agents_api_smoke_assert_equals( false, isset( $definitions['bad-seeds'] ), 'non-array memory seeds reject definition', $failures, $passes );
+agents_api_smoke_assert_equals( 'Unknown Property', $definitions['unknown-property']['label'] ?? '', 'unknown properties do not block otherwise valid definitions', $failures, $passes );
+agents_api_smoke_assert_equals( 4, count( $GLOBALS['__agents_api_smoke_wrong'] ), 'invalid registrations emit doing-it-wrong notices', $failures, $passes );
+
+echo "\n[4] Duplicate registration and lifecycle divergences are explicit:\n";
+WP_Agents_Registry::reset_for_tests();
+$GLOBALS['__agents_api_smoke_actions'] = array();
+$GLOBALS['__agents_api_smoke_wrong']   = array();
+wp_register_agent( 'duplicate-agent', array( 'label' => 'First Label' ) );
+wp_register_agent( 'duplicate-agent', array( 'label' => 'Second Label' ) );
+$definitions = WP_Agents_Registry::get_all();
+agents_api_smoke_assert_equals( 'Second Label', $definitions['duplicate-agent']['label'] ?? '', 'duplicate registrations remain last-wins for override hooks', $failures, $passes );
+agents_api_smoke_assert_equals( array(), $GLOBALS['__agents_api_smoke_wrong'], 'outside-hook direct registration remains supported for lazy materialization', $failures, $passes );
+$removed = wp_unregister_agent( 'duplicate-agent' );
+agents_api_smoke_assert_equals( true, $removed instanceof WP_Agent, 'wp_unregister_agent returns removed object', $failures, $passes );
+agents_api_smoke_assert_equals( false, wp_has_agent( 'duplicate-agent' ), 'wp_unregister_agent removes registered slug', $failures, $passes );
+agents_api_smoke_assert_equals( null, wp_get_agent( 'duplicate-agent' ), 'wp_get_agent returns null after unregister', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API registration', $failures, $passes );

--- a/tests/agents-api-smoke-helpers.php
+++ b/tests/agents-api-smoke-helpers.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $GLOBALS['__agents_api_smoke_actions'] = array();
+$GLOBALS['__agents_api_smoke_wrong']   = array();
 
 function sanitize_title( string $value ): string {
 	$value = strtolower( $value );
@@ -35,6 +36,14 @@ function do_action( string $hook, ...$args ): void {
 			call_user_func_array( $callback, $args );
 		}
 	}
+}
+
+function _doing_it_wrong( string $function_name, string $message, string $version ): void {
+	$GLOBALS['__agents_api_smoke_wrong'][] = array(
+		'function' => $function_name,
+		'message'  => $message,
+		'version'  => $version,
+	);
 }
 
 function agents_api_smoke_assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {


### PR DESCRIPTION
## Summary
- Hardens the in-repo Agents API registration facade toward WordPress core Abilities API shape while preserving Data Machine materialization behavior.
- Documents the intentional lifecycle divergences that remain: lazy reads, outside-hook direct registration, and last-wins duplicate overrides.

## Changes
- Converts `WP_Agent` into a prepared definition object with typed properties, validation, normalized memory seeds, and getters.
- Adds registry/helper parity for object lookup, listing, existence checks, and unregistering via `wp_get_agent()`, `wp_get_agents()`, `wp_has_agent()`, and `wp_unregister_agent()`.
- Keeps `WP_Agents_Registry::get()` / `get_all()` array output for Data Machine's existing materializer path.
- Expands pure-PHP smoke coverage for valid registration, invalid slug/property handling, duplicates, lazy hook reads, helper parity, unregistering, and getter output.
- Updates the registration docs with an Abilities API lifecycle comparison table and explicit divergence notes.

## Tests
- `php tests/agents-api-bootstrap-smoke.php`
- `php tests/agents-api-registration-smoke.php`
- `php tests/agent-registry-materializer-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-core-registration --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@agents-api-core-registration --changed-since origin/main`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@agents-api-core-registration --changed-since origin/main`

Closes #1665
Refs #1671

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing and testing the Agents API registration/lifecycle hardening under Chris's review.
