### PR TITLE
fix(engine): preserve explicit AI failure statuses

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -599,6 +599,31 @@ class ExecuteStepAbility {
 		}
 
 		// Non-fetch steps: empty data packet is an actual failure.
+		$already_failed_status = $this->getAlreadyFailedJobStatus( $job_id );
+		if ( null !== $already_failed_status ) {
+			do_action(
+				'datamachine_log',
+				'debug',
+				'Step returned no data after job was already marked failed',
+				array(
+					'job_id'       => $job_id,
+					'pipeline_id'  => $pipeline_id,
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+					'step_class'   => $step_class,
+					'step_type'    => $step_type,
+					'job_status'   => $already_failed_status,
+				)
+			);
+
+			return array(
+				'success'      => true,
+				'step_success' => false,
+				'outcome'      => 'failed',
+				'error'        => $already_failed_status,
+			);
+		}
+
 		do_action(
 			'datamachine_log',
 			'error',
@@ -628,6 +653,34 @@ class ExecuteStepAbility {
 			'step_success' => false,
 			'outcome'      => 'failed',
 		);
+	}
+
+	/**
+	 * Return the persisted failure status when the step itself already failed the job.
+	 *
+	 * Some steps, notably AIStep, call datamachine_fail_job with a precise failure
+	 * reason and then return no packets. Do not reclassify that empty packet list as
+	 * a generic execution failure.
+	 *
+	 * @param int $job_id Job ID.
+	 * @return string|null Persisted failed status, or null when the job has not already failed.
+	 */
+	private function getAlreadyFailedJobStatus( int $job_id ): ?string {
+		if ( ! isset( $this->db_jobs ) ) {
+			return null;
+		}
+
+		$job = $this->db_jobs->get_job( $job_id );
+		if ( ! is_array( $job ) ) {
+			return null;
+		}
+
+		$status = $job['status'] ?? '';
+		if ( ! is_string( $status ) || '' === $status ) {
+			return null;
+		}
+
+		return JobStatus::isStatusFailure( $status ) ? $status : null;
 	}
 
 	/**

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -20,6 +20,7 @@ use DataMachine\Core\FilesRepository\FileCleanup;
 use DataMachine\Core\FilesRepository\FileRetrieval;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Core\Steps\Step;
 use DataMachine\Engine\StepNavigator;
 
 defined( 'ABSPATH' ) || exit;
@@ -163,6 +164,9 @@ class ExecuteStepAbility {
 
 			$step_class = $step_definition['class'] ?? '';
 			$flow_step  = new $step_class();
+			if ( ! $flow_step instanceof Step ) {
+				throw new \RuntimeException( sprintf( 'Step class "%s" must extend DataMachine\\Core\\Steps\\Step.', $step_class ) );
+			}
 
 			$payload = array(
 				'job_id'       => $job_id,
@@ -172,23 +176,6 @@ class ExecuteStepAbility {
 			);
 
 			$dataPackets = $flow_step->execute( $payload );
-
-			if ( ! is_array( $dataPackets ) ) {
-				do_action(
-					'datamachine_fail_job',
-					$job_id,
-					'step_execution_failure',
-					array(
-						'flow_step_id' => $flow_step_id,
-						'class'        => $step_class,
-						'reason'       => 'non_array_payload_returned',
-					)
-				);
-				return array(
-					'success' => false,
-					'error'   => 'Step returned non-array payload.',
-				);
-			}
 
 			$payload['data'] = $dataPackets;
 			$step_success    = $this->evaluateStepSuccess( $dataPackets, $job_id, $flow_step_id );
@@ -248,9 +235,9 @@ class ExecuteStepAbility {
 	 * @param string     $flow_step_id    Flow step ID.
 	 * @param int        $job_id          Job ID.
 	 * @param array      $engine_snapshot Raw engine snapshot data.
-	 * @return array|null Flow step config or null.
+	 * @return array Flow step config, or an empty array when not found.
 	 */
-	private function resolveFlowStepConfig( EngineData $engine, string $flow_step_id, int $job_id, array $engine_snapshot ): ?array {
+	private function resolveFlowStepConfig( EngineData $engine, string $flow_step_id, int $job_id, array $engine_snapshot ): array {
 		$flow_step_config = $engine->getFlowStepConfig( $flow_step_id );
 
 		if ( ! $flow_step_config ) {
@@ -484,6 +471,7 @@ class ExecuteStepAbility {
 				$transition_route      = self::resolveTransitionRoute( $flow_step_config, $next_flow_step_config, $dataPackets );
 
 				if ( 'fail' === $transition_route['mode'] ) {
+					$transition_failure_reason = $transition_route['reason'] ?? 'transition_route_failed';
 					do_action(
 						'datamachine_fail_job',
 						$job_id,
@@ -492,7 +480,7 @@ class ExecuteStepAbility {
 							'flow_step_id'      => $flow_step_id,
 							'next_flow_step_id' => $next_flow_step_id,
 							'class'             => $step_class,
-							'reason'            => $transition_route['reason'],
+							'reason'            => $transition_failure_reason,
 						)
 					);
 
@@ -500,7 +488,7 @@ class ExecuteStepAbility {
 						'success'      => true,
 						'step_success' => false,
 						'outcome'      => 'failed',
-						'error'        => $transition_route['reason'],
+						'error'        => $transition_failure_reason,
 					);
 				}
 
@@ -882,7 +870,7 @@ class ExecuteStepAbility {
 	 * Extract failure reason from step packets.
 	 *
 	 * @param array  $dataPackets Data packets from step execution.
-	 * @param string $default Default reason when none found.
+	 * @param string $default_value Default reason when none found.
 	 * @return string
 	 */
 	private function getFailureReasonFromPackets( array $dataPackets, string $default_value ): string {

--- a/tests/ai-error-status-propagation-smoke.php
+++ b/tests/ai-error-status-propagation-smoke.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Pure-PHP smoke test for preserving explicit AI failure job statuses.
+ *
+ * Run with: php tests/ai-error-status-propagation-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+function datamachine_empty_action_log(): array {
+	return getenv( 'DATAMACHINE_SMOKE_ACTION_SEED' ) ? array( array( 'hook' => '', 'args' => array() ) ) : array();
+}
+
+$datamachine_action_log = datamachine_empty_action_log();
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		global $datamachine_action_log;
+		$datamachine_action_log[] = array(
+			'hook' => $hook,
+			'args' => $args,
+		);
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		$key = strtolower( $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
+require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
+require_once __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php';
+
+use DataMachine\Abilities\Engine\ExecuteStepAbility;
+use DataMachine\Core\Database\Jobs\Jobs;
+
+class DataMachine_Test_Jobs_For_AI_Status extends Jobs {
+	private string $status;
+
+	public function __construct( string $status ) {
+		$this->status = $status;
+	}
+
+	public function get_job( int $job_id ): ?array {
+		return array(
+			'job_id' => $job_id,
+			'status' => $this->status,
+		);
+	}
+}
+
+$failures = 0;
+$total    = 0;
+
+$assert = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+	++$total;
+	if ( $condition ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+
+	++$failures;
+	echo "  [FAIL] {$label}\n";
+};
+
+$actions_by_hook = function ( string $hook ) use ( &$datamachine_action_log ): array {
+	$matches = array();
+	foreach ( $datamachine_action_log as $entry ) {
+		if ( $hook === ( $entry['hook'] ?? '' ) ) {
+			$matches[] = $entry;
+		}
+	}
+
+	return $matches;
+};
+
+$logs_with_message = function ( string $message ) use ( &$datamachine_action_log ): array {
+	$matches = array();
+	foreach ( $datamachine_action_log as $entry ) {
+		if ( 'datamachine_log' === ( $entry['hook'] ?? '' ) && $message === ( $entry['args'][1] ?? '' ) ) {
+			$matches[] = $entry;
+		}
+	}
+
+	return $matches;
+};
+
+$build_ability = function ( string $status ): array {
+	$reflection = new ReflectionClass( ExecuteStepAbility::class );
+	$ability    = $reflection->newInstanceWithoutConstructor();
+
+	$db_jobs = $reflection->getProperty( 'db_jobs' );
+	$db_jobs->setValue( $ability, new DataMachine_Test_Jobs_For_AI_Status( $status ) );
+
+	$route = $reflection->getMethod( 'routeAfterExecution' );
+
+	return array( $ability, $route );
+};
+
+$invoke_empty_ai_route = function ( string $status ) use ( $build_ability ): array {
+	list( $ability, $route ) = $build_ability( $status );
+
+	return $route->invoke(
+		$ability,
+		123,
+		'ai_step',
+		9,
+		array(
+			'pipeline_id' => 3,
+			'step_type'   => 'ai',
+		),
+		'ai',
+		'DataMachine\\Core\\Steps\\AI\\AIStep',
+		array(),
+		array( 'data' => array() ),
+		false,
+		null
+	);
+};
+
+echo "=== ai-error-status-propagation-smoke ===\n";
+
+echo "\n[1] explicit AI failure is not reclassified as empty packets\n";
+$datamachine_action_log = datamachine_empty_action_log();
+$result                 = $invoke_empty_ai_route( 'failed - ai_processing_failed' );
+$failed_jobs            = $actions_by_hook( 'datamachine_fail_job' );
+$debug_logs             = $logs_with_message( 'Step returned no data after job was already marked failed' );
+
+$assert( 'route still reports failed outcome', 'failed' === ( $result['outcome'] ?? '' ) );
+$assert( 'route preserves persisted AI failure status as error', 'failed - ai_processing_failed' === ( $result['error'] ?? '' ) );
+$assert( 'generic fail-job action is not emitted again', empty( $failed_jobs ) );
+$assert( 'debug log records already-failed short circuit', 1 === count( $debug_logs ) );
+
+echo "\n[2] ordinary empty AI packet failures still use existing generic path\n";
+$datamachine_action_log = datamachine_empty_action_log();
+$result                 = $invoke_empty_ai_route( 'processing' );
+$failed_jobs            = $actions_by_hook( 'datamachine_fail_job' );
+$last_failure           = end( $failed_jobs );
+$failure_reason         = is_array( $last_failure ) ? ( $last_failure['args'][2]['reason'] ?? '' ) : '';
+
+$assert( 'ordinary empty packet route still fails', 'failed' === ( $result['outcome'] ?? '' ) );
+$assert( 'ordinary empty packet still emits fail-job action', 1 === count( $failed_jobs ) );
+$assert( 'ordinary empty packet reason remains empty_data_packet_returned', 'empty_data_packet_returned' === $failure_reason );
+
+if ( $failures > 0 ) {
+	echo "\n=== ai-error-status-propagation-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";
+	exit( 1 );
+}
+
+echo "\n=== ai-error-status-propagation-smoke: ALL PASS ({$total} assertions) ===\n";


### PR DESCRIPTION
## Summary
- Preserve the original AI provider failure status when an AI step has already failed the job before returning no packets.
- Add a focused smoke test for the live `wp-ai-client` WPCOM wiki-generator case where the provider error was logged but the final job status became `empty_data_packet_returned`.

## Changes
- Short-circuit the generic non-fetch empty-packet failure path when the job is already persisted as failed, keeping statuses such as `failed - ai_processing_failed` intact.
- Keep legitimate empty-packet failures on the existing `empty_data_packet_returned` path when no earlier step-specific failure exists.
- Cleaned small PHPStan drift in `ExecuteStepAbility` that blocked changed-since lint for the touched file.

## Tests
- `php tests/ai-error-status-propagation-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-ai-error-status-propagation --changed-since origin/main --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused status-propagation fix, smoke coverage, and validation; Chris remains responsible for review and merge.
