### PR TITLE
refactor(agents-api): align agent registry with core lifecycle

### DIFF
--- a/agents-api/agents-api.php
+++ b/agents-api/agents-api.php
@@ -2,8 +2,7 @@
 /**
  * Agents API bootstrap.
  *
- * In-repo WordPress-shaped agent substrate bundled by Data Machine while the
- * extraction boundary is still being proven in place.
+ * WordPress-shaped agent substrate.
  *
  * @package AgentsAPI
  */

--- a/agents-api/inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php
+++ b/agents-api/inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php
@@ -8,9 +8,6 @@
  * to a transcript row. It deliberately does not include chat UI listing,
  * read-state, retention scheduling, or reporting/metrics responsibilities.
  *
- * Data Machine's chat product consumes this neutral contract through its
- * aggregate store and factory adapters.
- *
  * @package AgentsAPI
  */
 

--- a/agents-api/inc/Engine/AI/AgentMessageEnvelope.php
+++ b/agents-api/inc/Engine/AI/AgentMessageEnvelope.php
@@ -139,7 +139,7 @@ class AgentMessageEnvelope {
 	}
 
 	/**
-	 * Project an envelope to Data Machine's provider request message shape.
+	 * Project an envelope to a provider request message shape.
 	 *
 	 * @param array $message Typed envelope or legacy message.
 	 * @return array<string, mixed> Provider-facing message.
@@ -170,7 +170,7 @@ class AgentMessageEnvelope {
 	}
 
 	/**
-	 * Project envelopes to Data Machine's provider request message shape.
+	 * Project envelopes to a provider request message shape.
 	 *
 	 * @param array $messages Typed envelopes or legacy messages.
 	 * @return array<int, array<string, mixed>> Provider-facing messages.

--- a/agents-api/inc/Engine/AI/Tools/RuntimeToolDeclaration.php
+++ b/agents-api/inc/Engine/AI/Tools/RuntimeToolDeclaration.php
@@ -3,7 +3,7 @@
  * Runtime tool declaration validator.
  *
  * Runtime tools are declared by a client or transport for one agent run and
- * are executed outside Data Machine. This class only validates the declaration
+ * are executed by the client. This class only validates the declaration
  * shape; it intentionally does not register, expose, or execute those tools.
  *
  * @package AgentsAPI

--- a/agents-api/inc/class-wp-agent.php
+++ b/agents-api/inc/class-wp-agent.php
@@ -261,5 +261,23 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 				_doing_it_wrong( $function_name, $message, '0.71.0' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- _doing_it_wrong receives a message, not direct output.
 			}
 		}
+
+		/**
+		 * Wakeup magic method.
+		 *
+		 * @throws LogicException If the agent object is unserialized.
+		 */
+		public function __wakeup(): void {
+			throw new LogicException( __CLASS__ . ' should never be unserialized.' );
+		}
+
+		/**
+		 * Sleep magic method.
+		 *
+		 * @throws LogicException If the agent object is serialized.
+		 */
+		public function __sleep(): array {
+			throw new LogicException( __CLASS__ . ' should never be serialized.' );
+		}
 	}
 }

--- a/agents-api/inc/class-wp-agents-registry.php
+++ b/agents-api/inc/class-wp-agents-registry.php
@@ -9,12 +9,9 @@ defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 	/**
-	 * WordPress-shaped declarative agent registry.
-	 *
-	 * The registry collects definitions only. Data Machine consumes these
-	 * definitions later when it materializes rows/access/scaffolding.
+	 * Manages the registration and lookup of agents.
 	 */
-	class WP_Agents_Registry {
+	final class WP_Agents_Registry {
 
 		/**
 		 * Singleton instance.
@@ -31,38 +28,22 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		private array $registered_agents = array();
 
 		/**
-		 * Whether the public registration action has fired.
-		 *
-		 * @var bool
-		 */
-		private static bool $registration_fired = false;
-
-		/**
-		 * Register an agent definition.
-		 *
-		 * @param string|WP_Agent $agent Agent slug or definition object.
-		 * @param array           $args  Registration arguments when `$agent` is a slug.
-		 * @return WP_Agent|null Registered agent, or null on invalid arguments.
-		 */
-		public static function register( $agent, array $args = array() ): ?WP_Agent {
-			return self::get_instance()->register_agent( $agent, $args );
-		}
-
-		/**
 		 * Register an agent definition on this registry instance.
 		 *
-		 * Duplicate slugs intentionally remain last-wins while the registry is
-		 * in-repo: Data Machine uses hook priority for fresh-install overrides.
-		 *
 		 * @param string|WP_Agent $agent Agent slug or definition object.
 		 * @param array           $args  Registration arguments when `$agent` is a slug.
 		 * @return WP_Agent|null Registered agent, or null on invalid arguments.
 		 */
-		public function register_agent( $agent, array $args = array() ): ?WP_Agent {
+		public function register( $agent, array $args = array() ): ?WP_Agent {
 			try {
 				$agent = $agent instanceof WP_Agent ? $agent : new WP_Agent( (string) $agent, $args );
 			} catch ( InvalidArgumentException $e ) {
 				$this->notice_invalid_registration( __METHOD__, $e->getMessage() );
+				return null;
+			}
+
+			if ( $this->is_registered( $agent->get_slug() ) ) {
+				$this->notice_invalid_registration( __METHOD__, sprintf( 'Agent "%s" is already registered.', $agent->get_slug() ) );
 				return null;
 			}
 
@@ -71,39 +52,12 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		}
 
 		/**
-		 * Get all registered agent definitions.
-		 *
-		 * @return array<string, array>
-		 */
-		public static function get_all(): array {
-			self::ensure_fired();
-			return array_map(
-				static fn( WP_Agent $agent ): array => $agent->to_array(),
-				self::get_instance()->registered_agents
-			);
-		}
-
-		/**
 		 * Get all registered agent objects.
 		 *
 		 * @return array<string, WP_Agent>
 		 */
-		public static function get_all_registered(): array {
-			self::ensure_fired();
-			return self::get_instance()->registered_agents;
-		}
-
-		/**
-		 * Get a single registered agent definition by slug.
-		 *
-		 * @param string $slug Agent slug.
-		 * @return array|null Definition, or null if not registered.
-		 */
-		public static function get( string $slug ): ?array {
-			self::ensure_fired();
-			$slug  = sanitize_title( $slug );
-			$agent = self::get_instance()->registered_agents[ $slug ] ?? null;
-			return $agent instanceof WP_Agent ? $agent->to_array() : null;
+		public function get_all_registered(): array {
+			return $this->registered_agents;
 		}
 
 		/**
@@ -112,10 +66,14 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		 * @param string $slug Agent slug.
 		 * @return WP_Agent|null Agent object, or null when not registered.
 		 */
-		public static function get_registered( string $slug ): ?WP_Agent {
-			self::ensure_fired();
+		public function get_registered( string $slug ): ?WP_Agent {
 			$slug = sanitize_title( $slug );
-			return self::get_instance()->registered_agents[ $slug ] ?? null;
+			if ( ! $this->is_registered( $slug ) ) {
+				$this->notice_invalid_registration( __METHOD__, sprintf( 'Agent "%s" not found.', $slug ) );
+				return null;
+			}
+
+			return $this->registered_agents[ $slug ];
 		}
 
 		/**
@@ -124,20 +82,9 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		 * @param string $slug Agent slug.
 		 * @return bool
 		 */
-		public static function has( string $slug ): bool {
-			self::ensure_fired();
+		public function is_registered( string $slug ): bool {
 			$slug = sanitize_title( $slug );
-			return isset( self::get_instance()->registered_agents[ $slug ] );
-		}
-
-		/**
-		 * Check whether an agent is registered.
-		 *
-		 * @param string $slug Agent slug.
-		 * @return bool
-		 */
-		public static function is_registered( string $slug ): bool {
-			return self::has( $slug );
+			return isset( $this->registered_agents[ $slug ] );
 		}
 
 		/**
@@ -146,16 +93,15 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		 * @param string $slug Agent slug.
 		 * @return WP_Agent|null Removed agent, or null when not registered.
 		 */
-		public static function unregister( string $slug ): ?WP_Agent {
-			self::ensure_fired();
+		public function unregister( string $slug ): ?WP_Agent {
 			$slug = sanitize_title( $slug );
-			if ( ! isset( self::get_instance()->registered_agents[ $slug ] ) ) {
-				self::get_instance()->notice_invalid_registration( __METHOD__, sprintf( 'Agent "%s" not found.', $slug ) );
+			if ( ! $this->is_registered( $slug ) ) {
+				$this->notice_invalid_registration( __METHOD__, sprintf( 'Agent "%s" not found.', $slug ) );
 				return null;
 			}
 
-			$agent = self::get_instance()->registered_agents[ $slug ];
-			unset( self::get_instance()->registered_agents[ $slug ] );
+			$agent = $this->registered_agents[ $slug ];
+			unset( $this->registered_agents[ $slug ] );
 
 			return $agent;
 		}
@@ -163,36 +109,32 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		/**
 		 * Retrieve the registry singleton.
 		 *
-		 * @return self
+		 * @return self|null Registry instance, or null when init has not fired.
 		 */
-		public static function get_instance(): self {
+		public static function get_instance(): ?self {
+			if ( function_exists( 'did_action' ) && ! did_action( 'init' ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					'Agents API should not be initialized before the <code>init</code> action has fired.',
+					'0.102.8'
+				);
+				return null;
+			}
+
 			if ( null === self::$instance ) {
 				self::$instance = new self();
+
+				/**
+				 * Fires to let plugins register agents.
+				 *
+				 * Callbacks should call `wp_register_agent()` to contribute one or more
+				 * agent definitions. The registry only collects definitions; consumers
+				 * decide whether and how to materialize them.
+				 */
+				do_action( 'wp_agents_api_init', self::$instance );
 			}
 
 			return self::$instance;
-		}
-
-		/**
-		 * Ensure the public registration action has fired.
-		 *
-		 * @return void
-		 */
-		private static function ensure_fired(): void {
-			if ( self::$registration_fired ) {
-				return;
-			}
-
-			self::$registration_fired = true;
-
-			/**
-			 * Fires to let plugins register agents.
-			 *
-			 * Callbacks should call `wp_register_agent()` to contribute one or more
-			 * agent definitions. The registry only collects definitions; consumers
-			 * decide whether and how to materialize them.
-			 */
-			do_action( 'wp_agents_api_init' );
 		}
 
 		/**
@@ -202,8 +144,25 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		 * @return void
 		 */
 		public static function reset_for_tests(): void {
-			self::$instance           = new self();
-			self::$registration_fired = false;
+			self::$instance = null;
+		}
+
+		/**
+		 * Wakeup magic method.
+		 *
+		 * @throws LogicException If the registry object is unserialized.
+		 */
+		public function __wakeup(): void {
+			throw new LogicException( __CLASS__ . ' should never be unserialized.' );
+		}
+
+		/**
+		 * Sleep magic method.
+		 *
+		 * @throws LogicException If the registry object is serialized.
+		 */
+		public function __sleep(): array {
+			throw new LogicException( __CLASS__ . ' should never be serialized.' );
 		}
 
 		/**

--- a/agents-api/inc/register-agents.php
+++ b/agents-api/inc/register-agents.php
@@ -19,7 +19,26 @@ if ( ! function_exists( 'wp_register_agent' ) ) {
 	 * @return WP_Agent|null Registered agent, or null on invalid arguments.
 	 */
 	function wp_register_agent( $agent, array $args = array() ): ?WP_Agent {
-		return WP_Agents_Registry::get_instance()->register_agent( $agent, $args );
+		$slug = $agent instanceof WP_Agent ? $agent->get_slug() : (string) $agent;
+		if ( ! doing_action( 'wp_agents_api_init' ) ) {
+			_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					'Agents must be registered on the %1$s action. The agent %2$s was not registered.',
+					'<code>wp_agents_api_init</code>',
+					'<code>' . esc_html( $slug ) . '</code>'
+				),
+				'0.102.8'
+			);
+			return null;
+		}
+
+		$registry = WP_Agents_Registry::get_instance();
+		if ( null === $registry ) {
+			return null;
+		}
+
+		return $registry->register( $agent, $args );
 	}
 }
 
@@ -31,7 +50,12 @@ if ( ! function_exists( 'wp_get_agent' ) ) {
 	 * @return WP_Agent|null Registered agent, or null when not registered.
 	 */
 	function wp_get_agent( string $slug ): ?WP_Agent {
-		return WP_Agents_Registry::get_registered( $slug );
+		$registry = WP_Agents_Registry::get_instance();
+		if ( null === $registry ) {
+			return null;
+		}
+
+		return $registry->get_registered( $slug );
 	}
 }
 
@@ -42,7 +66,12 @@ if ( ! function_exists( 'wp_get_agents' ) ) {
 	 * @return array<string, WP_Agent>
 	 */
 	function wp_get_agents(): array {
-		return WP_Agents_Registry::get_all_registered();
+		$registry = WP_Agents_Registry::get_instance();
+		if ( null === $registry ) {
+			return array();
+		}
+
+		return $registry->get_all_registered();
 	}
 }
 
@@ -54,7 +83,12 @@ if ( ! function_exists( 'wp_has_agent' ) ) {
 	 * @return bool
 	 */
 	function wp_has_agent( string $slug ): bool {
-		return WP_Agents_Registry::has( $slug );
+		$registry = WP_Agents_Registry::get_instance();
+		if ( null === $registry ) {
+			return false;
+		}
+
+		return $registry->is_registered( $slug );
 	}
 }
 
@@ -66,6 +100,11 @@ if ( ! function_exists( 'wp_unregister_agent' ) ) {
 	 * @return WP_Agent|null Removed agent, or null when not registered.
 	 */
 	function wp_unregister_agent( string $slug ): ?WP_Agent {
-		return WP_Agents_Registry::unregister( $slug );
+		$registry = WP_Agents_Registry::get_instance();
+		if ( null === $registry ) {
+			return null;
+		}
+
+		return $registry->unregister( $slug );
 	}
 }

--- a/inc/Engine/Agents/AgentRegistry.php
+++ b/inc/Engine/Agents/AgentRegistry.php
@@ -72,7 +72,12 @@ class AgentRegistry {
 	 * @return void
 	 */
 	public static function register( string $slug, array $args = array() ): void {
-		\WP_Agents_Registry::register( $slug, $args );
+		$registry = \WP_Agents_Registry::get_instance();
+		if ( null === $registry ) {
+			return;
+		}
+
+		$registry->register( $slug, $args );
 	}
 
 	/**
@@ -88,7 +93,15 @@ class AgentRegistry {
 	 */
 	public static function get_all(): array {
 		self::ensure_legacy_fired();
-		return \WP_Agents_Registry::get_all();
+		$registry = \WP_Agents_Registry::get_instance();
+		if ( null === $registry ) {
+			return array();
+		}
+
+		return array_map(
+			static fn( \WP_Agent $agent ): array => $agent->to_array(),
+			$registry->get_all_registered()
+		);
 	}
 
 	/**
@@ -101,7 +114,17 @@ class AgentRegistry {
 	 */
 	public static function get( string $slug ): ?array {
 		self::ensure_legacy_fired();
-		return \WP_Agents_Registry::get( $slug );
+		$registry = \WP_Agents_Registry::get_instance();
+		if ( null === $registry ) {
+			return null;
+		}
+
+		if ( ! $registry->is_registered( $slug ) ) {
+			return null;
+		}
+
+		$agent = $registry->get_registered( $slug );
+		return $agent instanceof \WP_Agent ? $agent->to_array() : null;
 	}
 
 	/**
@@ -137,7 +160,7 @@ class AgentRegistry {
 	 * @return void
 	 */
 	private static function ensure_legacy_fired(): void {
-		\WP_Agents_Registry::get_all();
+		\WP_Agents_Registry::get_instance();
 
 		if ( self::$legacy_registration_fired ) {
 			return;

--- a/tests/agent-registry-materializer-smoke.php
+++ b/tests/agent-registry-materializer-smoke.php
@@ -14,6 +14,8 @@ namespace {
 
 	$GLOBALS['__agent_materializer_actions'] = array();
 	$GLOBALS['__agent_materializer_hooks']   = array();
+	$GLOBALS['__agent_materializer_current'] = array();
+	$GLOBALS['__agent_materializer_done']    = array();
 
 	function sanitize_title( string $value ): string {
 		$value = strtolower( $value );
@@ -26,6 +28,7 @@ namespace {
 	}
 
 	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['__agent_materializer_current'][] = $hook;
 		$GLOBALS['__agent_materializer_actions'][ $hook ][] = $args;
 		$callbacks = $GLOBALS['__agent_materializer_hooks'][ $hook ] ?? array();
 		ksort( $callbacks );
@@ -35,6 +38,21 @@ namespace {
 				call_user_func_array( $callback, $args );
 			}
 		}
+
+		array_pop( $GLOBALS['__agent_materializer_current'] );
+		$GLOBALS['__agent_materializer_done'][ $hook ] = ( $GLOBALS['__agent_materializer_done'][ $hook ] ?? 0 ) + 1;
+	}
+
+	function doing_action( string $hook ): bool {
+		return in_array( $hook, $GLOBALS['__agent_materializer_current'], true );
+	}
+
+	function did_action( string $hook ): int {
+		return (int) ( $GLOBALS['__agent_materializer_done'][ $hook ] ?? 0 );
+	}
+
+	function esc_html( string $value ): string {
+		return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
 	}
 
 	function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
@@ -166,25 +184,33 @@ namespace {
 		ScaffoldAbilities::$ability                      = new ScaffoldAbilityStub();
 		$GLOBALS['__agent_materializer_actions'] = array();
 		$GLOBALS['__agent_materializer_hooks']   = array();
+		$GLOBALS['__agent_materializer_current'] = array();
+		$GLOBALS['__agent_materializer_done']    = array();
+		do_action( 'init' );
 	}
 
 	echo "agent-registry-materializer-smoke\n";
 
 	echo "\n[1] WordPress-shaped registry vocabulary collects definitions without materializing rows:\n";
 	reset_agent_materializer_smoke();
-	wp_register_agent(
-		new WP_Agent(
-			'Example Agent!',
-			array(
-				'label'          => 'Example Agent',
-				'description'    => 'Collect only',
-				'memory_seeds'   => array( '../SOUL.md' => '/tmp/seed-soul.md' ),
-				'owner_resolver' => static fn() => 7,
-				'default_config' => array( 'default_provider' => 'openai' ),
-			)
-		)
+	add_action(
+		'wp_agents_api_init',
+		static function (): void {
+			wp_register_agent(
+				new WP_Agent(
+					'Example Agent!',
+					array(
+						'label'          => 'Example Agent',
+						'description'    => 'Collect only',
+						'memory_seeds'   => array( '../SOUL.md' => '/tmp/seed-soul.md' ),
+						'owner_resolver' => static fn() => 7,
+						'default_config' => array( 'default_provider' => 'openai' ),
+					)
+				)
+			);
+		}
 	);
-	$definitions = WP_Agents_Registry::get_all();
+	$definitions = AgentRegistry::get_all();
 	assert_agent_materializer_equals( true, class_exists( 'WP_Agent' ), 'WP_Agent definition object is available', $failures, $passes );
 	assert_agent_materializer_equals( true, class_exists( 'WP_Agents_Registry' ), 'WP_Agents_Registry facade is available', $failures, $passes );
 	assert_agent_materializer_equals( array( 'example-agent' ), array_keys( $definitions ), 'definition slug is normalized', $failures, $passes );
@@ -223,15 +249,20 @@ namespace {
 
 	echo "\n[2] reconciliation creates rows, access grants, directories, scaffold calls, and action hooks:\n";
 	reset_agent_materializer_smoke();
-	wp_register_agent(
-		'Example Agent!',
-		array(
-			'label'          => 'Example Agent',
-			'description'    => 'Collect only',
-			'memory_seeds'   => array( '../SOUL.md' => '/tmp/seed-soul.md' ),
-			'owner_resolver' => static fn() => 7,
-			'default_config' => array( 'default_provider' => 'openai' ),
-		)
+	add_action(
+		'wp_agents_api_init',
+		static function (): void {
+			wp_register_agent(
+				'Example Agent!',
+				array(
+					'label'          => 'Example Agent',
+					'description'    => 'Collect only',
+					'memory_seeds'   => array( '../SOUL.md' => '/tmp/seed-soul.md' ),
+					'owner_resolver' => static fn() => 7,
+					'default_config' => array( 'default_provider' => 'openai' ),
+				)
+			);
+		}
 	);
 	$summary = AgentRegistry::reconcile();
 	assert_agent_materializer_equals( array( 'created' => array( 'example-agent' ), 'existing' => array(), 'skipped' => array() ), $summary, 'created summary matches pre-split registry behavior', $failures, $passes );

--- a/tests/agents-api-bootstrap-smoke.php
+++ b/tests/agents-api-bootstrap-smoke.php
@@ -49,7 +49,7 @@ agents_api_smoke_assert_equals( false, class_exists( 'DataMachine\\Engine\\AI\\A
 agents_api_smoke_assert_equals( false, class_exists( 'DataMachine\\Engine\\AI\\BuiltInAgentConversationRunner', false ), 'Data Machine built-in runner is not loaded by module bootstrap', $failures, $passes );
 agents_api_smoke_assert_equals( false, class_exists( 'DataMachine\\Core\\FilesRepository\\DiskAgentMemoryStore', false ), 'Data Machine disk memory store is not loaded by module bootstrap', $failures, $passes );
 
-echo "\n[2] Module source keeps Data Machine namespaces out of agents-api contracts:\n";
+echo "\n[2] Module source keeps Data Machine vocabulary out of agents-api contracts:\n";
 $agents_api_files = new RecursiveIteratorIterator(
 	new RecursiveDirectoryIterator( AGENTS_API_PATH, FilesystemIterator::SKIP_DOTS )
 );
@@ -63,6 +63,13 @@ foreach ( $agents_api_files as $file ) {
 		0,
 		preg_match( '/^\s*(namespace|use)\s+DataMachine\\\\/m', is_string( $contents ) ? $contents : '' ),
 		'agents-api source has no Data Machine namespace declaration/import: ' . str_replace( AGENTS_API_PATH, '', $file->getPathname() ),
+		$failures,
+		$passes
+	);
+	agents_api_smoke_assert_equals(
+		false,
+		false !== strpos( is_string( $contents ) ? $contents : '', 'Data Machine' ),
+		'agents-api source has no Data Machine prose coupling: ' . str_replace( AGENTS_API_PATH, '', $file->getPathname() ),
 		$failures,
 		$passes
 	);

--- a/tests/agents-api-registration-smoke.php
+++ b/tests/agents-api-registration-smoke.php
@@ -15,30 +15,43 @@ echo "agents-api-registration-smoke\n";
 require_once __DIR__ . '/agents-api-smoke-helpers.php';
 agents_api_smoke_require_module();
 
-echo "\n[1] Direct registration normalizes definitions without side effects:\n";
-WP_Agents_Registry::reset_for_tests();
-$GLOBALS['__agents_api_smoke_wrong'] = array();
-wp_register_agent(
-	new WP_Agent(
-		'Example Agent!',
-		array(
-			'label'          => 'Example Agent',
-			'description'    => 'Standalone module smoke',
-			'memory_seeds'   => array( '../SOUL.md' => '/tmp/seed-soul.md' ),
-			'owner_resolver' => static fn() => 7,
-			'default_config' => array( 'default_provider' => 'openai' ),
-		)
-	)
+function agents_api_registration_reset(): void {
+	WP_Agents_Registry::reset_for_tests();
+	$GLOBALS['__agents_api_smoke_actions'] = array();
+	$GLOBALS['__agents_api_smoke_wrong']   = array();
+	$GLOBALS['__agents_api_smoke_current'] = array();
+	$GLOBALS['__agents_api_smoke_done']    = array();
+	do_action( 'init' );
+}
+
+echo "\n[1] Hook registration normalizes definitions without side effects:\n";
+agents_api_registration_reset();
+add_action(
+	'wp_agents_api_init',
+	static function (): void {
+		wp_register_agent(
+			new WP_Agent(
+				'Example Agent!',
+				array(
+					'label'          => 'Example Agent',
+					'description'    => 'Standalone module smoke',
+					'memory_seeds'   => array( '../SOUL.md' => '/tmp/seed-soul.md' ),
+					'owner_resolver' => static fn() => 7,
+					'default_config' => array( 'default_provider' => 'openai' ),
+				)
+			)
+		);
+	}
 );
 
-$definitions = WP_Agents_Registry::get_all();
-$agent       = wp_get_agent( 'Example Agent!' );
-agents_api_smoke_assert_equals( array( 'example-agent' ), array_keys( $definitions ), 'definition slug is normalized', $failures, $passes );
-agents_api_smoke_assert_equals( 'Example Agent', $definitions['example-agent']['label'] ?? '', 'definition label is preserved', $failures, $passes );
-agents_api_smoke_assert_equals( 'Standalone module smoke', $definitions['example-agent']['description'] ?? '', 'definition description is preserved', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'SOUL.md' => '/tmp/seed-soul.md' ), $definitions['example-agent']['memory_seeds'] ?? array(), 'memory seed filenames are sanitized', $failures, $passes );
-agents_api_smoke_assert_equals( true, is_callable( $definitions['example-agent']['owner_resolver'] ?? null ), 'callable owner resolver is preserved', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'default_provider' => 'openai' ), $definitions['example-agent']['default_config'] ?? array(), 'default config is preserved', $failures, $passes );
+$agents = wp_get_agents();
+$agent  = wp_get_agent( 'Example Agent!' );
+agents_api_smoke_assert_equals( array( 'example-agent' ), array_keys( $agents ), 'definition slug is normalized', $failures, $passes );
+agents_api_smoke_assert_equals( 'Example Agent', $agents['example-agent']->get_label() ?? '', 'definition label is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'Standalone module smoke', $agents['example-agent']->get_description() ?? '', 'definition description is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'SOUL.md' => '/tmp/seed-soul.md' ), $agents['example-agent']->get_memory_seeds() ?? array(), 'memory seed filenames are sanitized', $failures, $passes );
+agents_api_smoke_assert_equals( true, is_callable( $agents['example-agent']->get_owner_resolver() ?? null ), 'callable owner resolver is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'default_provider' => 'openai' ), $agents['example-agent']->get_default_config() ?? array(), 'default config is preserved', $failures, $passes );
 agents_api_smoke_assert_equals( true, $agent instanceof WP_Agent, 'wp_get_agent returns an agent object', $failures, $passes );
 agents_api_smoke_assert_equals( 'example-agent', $agent ? $agent->get_slug() : '', 'agent getter exposes slug', $failures, $passes );
 agents_api_smoke_assert_equals( 'Example Agent', $agent ? $agent->get_label() : '', 'agent getter exposes label', $failures, $passes );
@@ -50,7 +63,7 @@ agents_api_smoke_assert_equals( true, wp_has_agent( 'example-agent' ), 'wp_has_a
 agents_api_smoke_assert_equals( array( 'example-agent' ), array_keys( wp_get_agents() ), 'wp_get_agents returns object map', $failures, $passes );
 
 echo "\n[2] Public registration hook fires once on first read:\n";
-WP_Agents_Registry::reset_for_tests();
+agents_api_registration_reset();
 $hook_calls = 0;
 add_action(
 	'wp_agents_api_init',
@@ -60,50 +73,59 @@ add_action(
 	}
 );
 
-$definitions = WP_Agents_Registry::get_all();
+$agents = wp_get_agents();
 agents_api_smoke_assert_equals( 1, $hook_calls, 'registration hook fires on first get_all call', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'hook-agent' ), array_keys( $definitions ), 'hook-registered definition is collected', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'hook-agent' ), array_keys( WP_Agents_Registry::get_all() ), 'registration hook does not refire on subsequent reads', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'hook-agent' ), array_keys( $agents ), 'hook-registered definition is collected', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'hook-agent' ), array_keys( wp_get_agents() ), 'registration hook does not refire on subsequent reads', $failures, $passes );
 agents_api_smoke_assert_equals( 1, $hook_calls, 'hook call count remains stable after second read', $failures, $passes );
 
 echo "\n[3] Invalid definitions are rejected or normalized predictably:\n";
-WP_Agents_Registry::reset_for_tests();
-$GLOBALS['__agents_api_smoke_actions'] = array();
-$GLOBALS['__agents_api_smoke_wrong']   = array();
-wp_register_agent( '!!!', array( 'label' => 'Invalid' ) );
-wp_register_agent( 'Minimal Agent' );
-wp_register_agent(
-	'Messy Seeds',
-	array(
-		'memory_seeds'   => array(
-			'../MEMORY.md' => '/tmp/MEMORY.md',
-			''             => '/tmp/empty.md',
-			'empty-path.md' => '',
-		),
-	)
+agents_api_registration_reset();
+add_action(
+	'wp_agents_api_init',
+	static function (): void {
+		wp_register_agent( '!!!', array( 'label' => 'Invalid' ) );
+		wp_register_agent( 'Minimal Agent' );
+		wp_register_agent(
+			'Messy Seeds',
+			array(
+				'memory_seeds' => array(
+					'../MEMORY.md' => '/tmp/MEMORY.md',
+					''             => '/tmp/empty.md',
+					'empty-path.md' => '',
+				),
+			)
+		);
+		wp_register_agent( 'Bad Resolver', array( 'owner_resolver' => 'not callable' ) );
+		wp_register_agent( 'Bad Seeds', array( 'memory_seeds' => 'not an array' ) );
+		wp_register_agent( 'Unknown Property', array( 'label' => 'Unknown Property', 'mystery' => true ) );
+	}
 );
-wp_register_agent( 'Bad Resolver', array( 'owner_resolver' => 'not callable' ) );
-wp_register_agent( 'Bad Seeds', array( 'memory_seeds' => 'not an array' ) );
-wp_register_agent( 'Unknown Property', array( 'label' => 'Unknown Property', 'mystery' => true ) );
 
-$definitions = WP_Agents_Registry::get_all();
-agents_api_smoke_assert_equals( array( 'minimal-agent', 'messy-seeds', 'unknown-property' ), array_keys( $definitions ), 'empty slugs are ignored while valid slugs are kept', $failures, $passes );
-agents_api_smoke_assert_equals( 'minimal-agent', $definitions['minimal-agent']['label'] ?? '', 'missing label falls back to slug', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'MEMORY.md' => '/tmp/MEMORY.md' ), $definitions['messy-seeds']['memory_seeds'] ?? array(), 'empty memory seed keys and paths are dropped', $failures, $passes );
-agents_api_smoke_assert_equals( false, isset( $definitions['bad-resolver'] ), 'non-callable owner resolver rejects definition', $failures, $passes );
-agents_api_smoke_assert_equals( false, isset( $definitions['bad-seeds'] ), 'non-array memory seeds reject definition', $failures, $passes );
-agents_api_smoke_assert_equals( 'Unknown Property', $definitions['unknown-property']['label'] ?? '', 'unknown properties do not block otherwise valid definitions', $failures, $passes );
+$agents = wp_get_agents();
+agents_api_smoke_assert_equals( array( 'minimal-agent', 'messy-seeds', 'unknown-property' ), array_keys( $agents ), 'empty slugs are ignored while valid slugs are kept', $failures, $passes );
+agents_api_smoke_assert_equals( 'minimal-agent', $agents['minimal-agent']->get_label() ?? '', 'missing label falls back to slug', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'MEMORY.md' => '/tmp/MEMORY.md' ), $agents['messy-seeds']->get_memory_seeds() ?? array(), 'empty memory seed keys and paths are dropped', $failures, $passes );
+agents_api_smoke_assert_equals( false, isset( $agents['bad-resolver'] ), 'non-callable owner resolver rejects definition', $failures, $passes );
+agents_api_smoke_assert_equals( false, isset( $agents['bad-seeds'] ), 'non-array memory seeds reject definition', $failures, $passes );
+agents_api_smoke_assert_equals( 'Unknown Property', $agents['unknown-property']->get_label() ?? '', 'unknown properties do not block otherwise valid definitions', $failures, $passes );
 agents_api_smoke_assert_equals( 4, count( $GLOBALS['__agents_api_smoke_wrong'] ), 'invalid registrations emit doing-it-wrong notices', $failures, $passes );
 
-echo "\n[4] Duplicate registration and lifecycle divergences are explicit:\n";
-WP_Agents_Registry::reset_for_tests();
-$GLOBALS['__agents_api_smoke_actions'] = array();
-$GLOBALS['__agents_api_smoke_wrong']   = array();
-wp_register_agent( 'duplicate-agent', array( 'label' => 'First Label' ) );
-wp_register_agent( 'duplicate-agent', array( 'label' => 'Second Label' ) );
-$definitions = WP_Agents_Registry::get_all();
-agents_api_smoke_assert_equals( 'Second Label', $definitions['duplicate-agent']['label'] ?? '', 'duplicate registrations remain last-wins for override hooks', $failures, $passes );
-agents_api_smoke_assert_equals( array(), $GLOBALS['__agents_api_smoke_wrong'], 'outside-hook direct registration remains supported for lazy materialization', $failures, $passes );
+echo "\n[4] Duplicate registration and lifecycle errors follow core shape:\n";
+agents_api_registration_reset();
+add_action(
+	'wp_agents_api_init',
+	static function (): void {
+		wp_register_agent( 'duplicate-agent', array( 'label' => 'First Label' ) );
+		wp_register_agent( 'duplicate-agent', array( 'label' => 'Second Label' ) );
+	}
+);
+$agents = wp_get_agents();
+agents_api_smoke_assert_equals( 'First Label', $agents['duplicate-agent']->get_label() ?? '', 'duplicate registrations keep the first definition', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $GLOBALS['__agents_api_smoke_wrong'] ), 'duplicate registration emits doing-it-wrong notice', $failures, $passes );
+$GLOBALS['__agents_api_smoke_wrong'] = array();
+wp_register_agent( 'outside-hook', array( 'label' => 'Outside Hook' ) );
+agents_api_smoke_assert_equals( 1, count( $GLOBALS['__agents_api_smoke_wrong'] ), 'outside-hook direct registration is rejected', $failures, $passes );
 $removed = wp_unregister_agent( 'duplicate-agent' );
 agents_api_smoke_assert_equals( true, $removed instanceof WP_Agent, 'wp_unregister_agent returns removed object', $failures, $passes );
 agents_api_smoke_assert_equals( false, wp_has_agent( 'duplicate-agent' ), 'wp_unregister_agent removes registered slug', $failures, $passes );

--- a/tests/agents-api-smoke-helpers.php
+++ b/tests/agents-api-smoke-helpers.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $GLOBALS['__agents_api_smoke_actions'] = array();
 $GLOBALS['__agents_api_smoke_wrong']   = array();
+$GLOBALS['__agents_api_smoke_current'] = array();
+$GLOBALS['__agents_api_smoke_done']    = array();
 
 function sanitize_title( string $value ): string {
 	$value = strtolower( $value );
@@ -28,6 +30,7 @@ function add_action( string $hook, callable $callback, int $priority = 10, int $
 }
 
 function do_action( string $hook, ...$args ): void {
+	$GLOBALS['__agents_api_smoke_current'][] = $hook;
 	$callbacks = $GLOBALS['__agents_api_smoke_actions'][ $hook ] ?? array();
 	ksort( $callbacks );
 
@@ -36,6 +39,21 @@ function do_action( string $hook, ...$args ): void {
 			call_user_func_array( $callback, $args );
 		}
 	}
+
+	array_pop( $GLOBALS['__agents_api_smoke_current'] );
+	$GLOBALS['__agents_api_smoke_done'][ $hook ] = ( $GLOBALS['__agents_api_smoke_done'][ $hook ] ?? 0 ) + 1;
+}
+
+function doing_action( string $hook ): bool {
+	return in_array( $hook, $GLOBALS['__agents_api_smoke_current'], true );
+}
+
+function did_action( string $hook ): int {
+	return (int) ( $GLOBALS['__agents_api_smoke_done'][ $hook ] ?? 0 );
+}
+
+function esc_html( string $value ): string {
+	return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
 }
 
 function _doing_it_wrong( string $function_name, string $message, string $version ): void {


### PR DESCRIPTION
## Summary
- Align `WP_Agents_Registry` and `wp_register_agent()` with the WordPress core Abilities API lifecycle: registration happens during `wp_agents_api_init`, duplicates are rejected, and the registry exposes instance methods instead of static shortcuts.
- Remove remaining Data Machine prose coupling from `agents-api/` contracts and keep legacy Data Machine registration compatibility in the Data Machine adapter layer.
- Expand smokes to cover hook-only registration, duplicate/outside-hook rejection, init gating, and the no-Data-Machine-vocabulary boundary.

## Tests
- `php tests/agents-api-registration-smoke.php`
- `php tests/agent-registry-materializer-smoke.php`
- `php tests/agents-api-bootstrap-smoke.php`
- `php tests/agents-api-no-product-imports-smoke.php`
- `homeboy lint data-machine --path "/Users/chubes/Developer/data-machine@agents-api-core-shape-followup" --file agents-api/inc/class-wp-agents-registry.php --summary`
- `homeboy lint data-machine --path "/Users/chubes/Developer/data-machine@agents-api-core-shape-followup" --file agents-api/inc/register-agents.php --summary`
- `homeboy lint data-machine --path "/Users/chubes/Developer/data-machine@agents-api-core-shape-followup" --file inc/Engine/Agents/AgentRegistry.php --summary`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing the Agents API surface against WordPress core Abilities API, drafting the registry/helper cleanup, updating focused smokes, and running local verification. Chris reviewed direction and requested the commit/PR.