### PR TITLE
fix(fetch): claim in-flight source items

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -15,6 +15,7 @@
 namespace DataMachine\Abilities\Engine;
 
 use DataMachine\Abilities\StepTypeAbilities;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\EngineData;
 use DataMachine\Core\FilesRepository\FileCleanup;
 use DataMachine\Core\FilesRepository\FileRetrieval;
@@ -378,6 +379,8 @@ class ExecuteStepAbility {
 			// Failed overrides should NOT mark items as processed.
 			if ( str_starts_with( $status_override, JobStatus::FAILED ) === false ) {
 				$this->markCompletedItemProcessed( $job_id );
+			} else {
+				$this->releaseInFlightItemClaim( $job_id );
 			}
 			$this->db_jobs->complete_job( $job_id, $status_override );
 
@@ -734,6 +737,43 @@ class ExecuteStepAbility {
 				'fetch_flow_step_id' => $fetch_flow_step_id,
 			)
 		);
+	}
+
+	/**
+	 * Release this job's in-flight source claim after a failed status override.
+	 *
+	 * Most failures flow through datamachine_fail_job, whose handler releases
+	 * claims centrally. Failed status overrides complete the job directly, so
+	 * they need the same release here.
+	 *
+	 * @param int $job_id Failed job ID.
+	 */
+	private function releaseInFlightItemClaim( int $job_id ): void {
+		$engine_data = datamachine_get_engine_data( $job_id );
+
+		$item_identifier = $engine_data['item_identifier'] ?? null;
+		$source_type     = $engine_data['source_type'] ?? null;
+
+		if ( empty( $item_identifier ) || empty( $source_type ) ) {
+			return;
+		}
+
+		$fetch_flow_step_id = null;
+		$flow_config        = $engine_data['flow_config'] ?? array();
+
+		foreach ( $flow_config as $step_id => $config ) {
+			$step_type = $config['step_type'] ?? '';
+			if ( in_array( $step_type, array( 'fetch', 'event_import' ), true ) ) {
+				$fetch_flow_step_id = $step_id;
+				break;
+			}
+		}
+
+		if ( empty( $fetch_flow_step_id ) ) {
+			return;
+		}
+
+		( new ProcessedItems() )->release_claim( $fetch_flow_step_id, (string) $source_type, (string) $item_identifier );
 	}
 
 	/**

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -20,7 +20,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class ProcessedItems extends BaseRepository {
 
-	const TABLE_NAME = 'datamachine_processed_items';
+	const TABLE_NAME                = 'datamachine_processed_items';
+	const STATUS_CLAIMED            = 'claimed';
+	const STATUS_PROCESSED          = 'processed';
+	const DEFAULT_CLAIM_TTL_SECONDS = 3600;
 
 
 	/**
@@ -33,7 +36,39 @@ class ProcessedItems extends BaseRepository {
 	 */
 	public function has_item_been_processed( string $flow_step_id, string $source_type, string $item_identifier ): bool {
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$count = $this->wpdb->get_var( $this->wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s', $this->table_name, $flow_step_id, $source_type, $item_identifier ) );
+		$count = $this->wpdb->get_var( $this->wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND status = %s', $this->table_name, $flow_step_id, $source_type, $item_identifier, self::STATUS_PROCESSED ) );
+
+		return $count > 0;
+	}
+
+	/**
+	 * Checks if a source item is actively claimed by an in-flight job.
+	 *
+	 * Expired claims are ignored and cleaned before checking.
+	 *
+	 * @param string $flow_step_id    Flow step ID.
+	 * @param string $source_type     Source type.
+	 * @param string $item_identifier Unique item identifier.
+	 * @return bool True when an active claim exists.
+	 */
+	public function has_active_claim( string $flow_step_id, string $source_type, string $item_identifier ): bool {
+		$this->delete_expired_claims();
+
+		$now = current_time( 'mysql', true );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with %i table placeholder.
+		$count = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND status = %s AND (claim_expires_at IS NULL OR claim_expires_at > %s)',
+				$this->table_name,
+				$flow_step_id,
+				$source_type,
+				$item_identifier,
+				self::STATUS_CLAIMED,
+				$now
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		return $count > 0;
 	}
@@ -49,7 +84,7 @@ class ProcessedItems extends BaseRepository {
 	 */
 	public function has_processed_items( string $flow_step_id ): bool {
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$count = $this->wpdb->get_var( $this->wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE flow_step_id = %s LIMIT 1', $this->table_name, $flow_step_id ) );
+		$count = $this->wpdb->get_var( $this->wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE flow_step_id = %s AND status = %s LIMIT 1', $this->table_name, $flow_step_id, self::STATUS_PROCESSED ) );
 
 		return $count > 0;
 	}
@@ -72,11 +107,12 @@ class ProcessedItems extends BaseRepository {
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$value = $this->wpdb->get_var(
 			$this->wpdb->prepare(
-				'SELECT UNIX_TIMESTAMP(processed_timestamp) FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s',
+				'SELECT UNIX_TIMESTAMP(processed_timestamp) FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND status = %s',
 				$this->table_name,
 				$flow_step_id,
 				$source_type,
-				$item_identifier
+				$item_identifier,
+				self::STATUS_PROCESSED
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -148,18 +184,21 @@ class ProcessedItems extends BaseRepository {
 		$placeholders = implode( ',', array_fill( 0, count( $candidates ), '%s' ) );
 
 		$sql = sprintf(
-			'SELECT item_identifier FROM %%i WHERE flow_step_id = %%s AND source_type = %%s AND processed_timestamp < %%s AND item_identifier IN (%s) ORDER BY processed_timestamp ASC LIMIT %%d',
+			'SELECT item_identifier FROM %%i WHERE flow_step_id = %%s AND source_type = %%s AND status = %%s AND processed_timestamp < %%s AND item_identifier IN (%s) ORDER BY processed_timestamp ASC LIMIT %%d',
 			$placeholders
 		);
+		/** @var literal-string $sql */
 
 		$prepare_args = array_merge(
-			array( $this->table_name, $flow_step_id, $source_type, $cutoff_datetime ),
+			array( $this->table_name, $flow_step_id, $source_type, self::STATUS_PROCESSED, $cutoff_datetime ),
 			$candidates,
 			array( $limit )
 		);
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic IN() placeholder list.
 		$rows = $this->wpdb->get_col( $this->wpdb->prepare( $sql, ...$prepare_args ) );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		return array_map( 'strval', (array) $rows );
 	}
@@ -199,17 +238,20 @@ class ProcessedItems extends BaseRepository {
 		$placeholders = implode( ',', array_fill( 0, count( $candidates ), '%s' ) );
 
 		$sql = sprintf(
-			'SELECT item_identifier FROM %%i WHERE flow_step_id = %%s AND source_type = %%s AND item_identifier IN (%s)',
+			'SELECT item_identifier FROM %%i WHERE flow_step_id = %%s AND source_type = %%s AND status = %%s AND item_identifier IN (%s)',
 			$placeholders
 		);
+		/** @var literal-string $sql */
 
 		$prepare_args = array_merge(
-			array( $this->table_name, $flow_step_id, $source_type ),
+			array( $this->table_name, $flow_step_id, $source_type, self::STATUS_PROCESSED ),
 			$candidates
 		);
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic IN() placeholder list.
 		$existing = $this->wpdb->get_col( $this->wpdb->prepare( $sql, ...$prepare_args ) );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		$existing = array_flip( array_map( 'strval', (array) $existing ) );
 
 		$result = array();
@@ -236,10 +278,28 @@ class ProcessedItems extends BaseRepository {
 	 * @return bool True on successful insertion, false otherwise.
 	 */
 	public function add_processed_item( string $flow_step_id, string $source_type, string $item_identifier, int $job_id ): bool {
+		$now = current_time( 'mysql', true );
 
-		// Check if it exists first to avoid unnecessary insert attempts and duplicate key errors
-		if ( $this->has_item_been_processed( $flow_step_id, $source_type, $item_identifier ) ) {
-			// Item already processed - return true to indicate success (idempotent behavior)
+		// Convert an existing in-flight claim to final processed state, or refresh
+		// an existing processed row idempotently. The unique key guarantees one row
+		// per source item, so this is safe across child-job races.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with %i table placeholder.
+		$updated = $this->wpdb->query(
+			$this->wpdb->prepare(
+				'UPDATE %i SET job_id = %d, status = %s, processed_timestamp = %s, claim_expires_at = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s',
+				$this->table_name,
+				$job_id,
+				self::STATUS_PROCESSED,
+				$now,
+				$flow_step_id,
+				$source_type,
+				$item_identifier
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( false !== $updated && $updated > 0 ) {
 			return true;
 		}
 
@@ -251,13 +311,15 @@ class ProcessedItems extends BaseRepository {
 				'source_type'     => $source_type,
 				'item_identifier' => $item_identifier,
 				'job_id'          => $job_id,
-				// processed_timestamp defaults to NOW()
+				'status'          => self::STATUS_PROCESSED,
+				// processed_timestamp defaults to NOW().
 			),
 			array(
 				'%s', // flow_step_id
 				'%s', // source_type
 				'%s', // item_identifier
 				'%d', // job_id
+				'%s', // status
 			)
 		);
 
@@ -287,6 +349,129 @@ class ProcessedItems extends BaseRepository {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Atomically claim a source item for in-flight processing.
+	 *
+	 * @param string $flow_step_id     Flow step ID.
+	 * @param string $source_type      Source type.
+	 * @param string $item_identifier  Unique item identifier.
+	 * @param int    $job_id           Job creating the claim.
+	 * @param int    $ttl_seconds      Claim TTL in seconds.
+	 * @return bool True when this caller owns the claim; false when already processed or actively claimed.
+	 */
+	public function claim_item( string $flow_step_id, string $source_type, string $item_identifier, int $job_id, int $ttl_seconds = self::DEFAULT_CLAIM_TTL_SECONDS ): bool {
+		if ( $ttl_seconds < 1 ) {
+			$ttl_seconds = self::DEFAULT_CLAIM_TTL_SECONDS;
+		}
+
+		$this->delete_expired_claims();
+
+		$expires_at = gmdate( 'Y-m-d H:i:s', time() + $ttl_seconds );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $this->wpdb->insert(
+			$this->table_name,
+			array(
+				'flow_step_id'     => $flow_step_id,
+				'source_type'      => $source_type,
+				'item_identifier'  => $item_identifier,
+				'job_id'           => $job_id,
+				'status'           => self::STATUS_CLAIMED,
+				'claim_expires_at' => $expires_at,
+			),
+			array( '%s', '%s', '%s', '%d', '%s', '%s' )
+		);
+
+		if ( false !== $result ) {
+			return true;
+		}
+
+		// If the reprocess filter let a completed row through, atomically convert
+		// that processed row into a claim. Active claims remain untouched, so a
+		// parallel fetch still loses the race.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with %i table placeholder.
+		$claimed_existing_processed = $this->wpdb->query(
+			$this->wpdb->prepare(
+				'UPDATE %i SET job_id = %d, status = %s, claim_expires_at = %s WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND status = %s',
+				$this->table_name,
+				$job_id,
+				self::STATUS_CLAIMED,
+				$expires_at,
+				$flow_step_id,
+				$source_type,
+				$item_identifier,
+				self::STATUS_PROCESSED
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		return false !== $claimed_existing_processed && $claimed_existing_processed > 0;
+	}
+
+	/**
+	 * Release an in-flight claim so failed downstream work can retry later.
+	 *
+	 * @param string $flow_step_id    Flow step ID.
+	 * @param string $source_type     Source type.
+	 * @param string $item_identifier Unique item identifier.
+	 * @return int|false Number of rows released, or false on error.
+	 */
+	public function release_claim( string $flow_step_id, string $source_type, string $item_identifier ): int|false {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $this->wpdb->delete(
+			$this->table_name,
+			array(
+				'flow_step_id'    => $flow_step_id,
+				'source_type'     => $source_type,
+				'item_identifier' => $item_identifier,
+				'status'          => self::STATUS_CLAIMED,
+			),
+			array( '%s', '%s', '%s', '%s' )
+		);
+	}
+
+	/**
+	 * Release all in-flight claims owned by a job.
+	 *
+	 * @param int $job_id Job ID.
+	 * @return int|false Number of rows released, or false on error.
+	 */
+	public function release_claims_for_job( int $job_id ): int|false {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $this->wpdb->delete(
+			$this->table_name,
+			array(
+				'job_id' => $job_id,
+				'status' => self::STATUS_CLAIMED,
+			),
+			array( '%d', '%s' )
+		);
+	}
+
+	/**
+	 * Delete expired in-flight claims.
+	 *
+	 * @return int|false Number of rows deleted, or false on error.
+	 */
+	public function delete_expired_claims(): int|false {
+		$now = current_time( 'mysql', true );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Prepared with %i table placeholder.
+		$result = $this->wpdb->query(
+			$this->wpdb->prepare(
+				'DELETE FROM %i WHERE status = %s AND claim_expires_at IS NOT NULL AND claim_expires_at <= %s',
+				$this->table_name,
+				self::STATUS_CLAIMED,
+				$now
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		return false === $result ? false : (int) $result;
 	}
 
 	/**
@@ -397,7 +582,7 @@ class ProcessedItems extends BaseRepository {
 			)
 		);
 
-		return $result;
+		return false === $result ? false : (int) $result;
 	}
 
 	/**
@@ -423,12 +608,14 @@ class ProcessedItems extends BaseRepository {
 		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		$result = $this->wpdb->query(
 			$this->wpdb->prepare(
-				'DELETE FROM %i WHERE processed_timestamp < %s',
+				'DELETE FROM %i WHERE status = %s AND processed_timestamp < %s',
 				$this->table_name,
+				self::STATUS_PROCESSED,
 				$cutoff_datetime
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL
+		$result = false === $result ? false : (int) $result;
 
 		do_action(
 			'datamachine_log',
@@ -464,8 +651,9 @@ class ProcessedItems extends BaseRepository {
 		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 		$count = $this->wpdb->get_var(
 			$this->wpdb->prepare(
-				'SELECT COUNT(*) FROM %i WHERE processed_timestamp < %s',
+				'SELECT COUNT(*) FROM %i WHERE status = %s AND processed_timestamp < %s',
 				$this->table_name,
+				self::STATUS_PROCESSED,
 				$cutoff_datetime
 			)
 		);
@@ -488,12 +676,15 @@ class ProcessedItems extends BaseRepository {
             source_type VARCHAR(50) NOT NULL,
             item_identifier VARCHAR(255) NOT NULL,
             job_id BIGINT(20) UNSIGNED NOT NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'processed',
+			claim_expires_at DATETIME NULL,
             processed_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
             PRIMARY KEY  (id),
             UNIQUE KEY `flow_source_item` (flow_step_id, source_type, item_identifier(191)),
             KEY `flow_step_id` (flow_step_id),
             KEY `source_type` (source_type),
             KEY `job_id` (job_id),
+			KEY `status_claim_expires` (status, claim_expires_at),
             KEY `flow_source_ts` (flow_step_id, source_type, processed_timestamp)
         ) $charset_collate;";
 
@@ -505,6 +696,7 @@ class ProcessedItems extends BaseRepository {
 
 		// dbDelta is also unreliable at adding regular indexes to existing tables.
 		self::ensure_flow_source_ts_index( $this->table_name );
+		self::ensure_claim_columns( $this->table_name );
 
 		// Log table creation
 		do_action(
@@ -617,5 +809,35 @@ class ProcessedItems extends BaseRepository {
 			'Added composite index flow_source_ts to processed_items table',
 			array( 'table_name' => $table_name )
 		);
+	}
+
+	/**
+	 * Ensure in-flight claim columns and index exist on upgraded installs.
+	 *
+	 * @param string $table_name Full table name.
+	 */
+	public static function ensure_claim_columns( string $table_name ): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$status_column = $wpdb->get_var( "SHOW COLUMNS FROM {$table_name} LIKE 'status'" );
+		if ( ! $status_column ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'processed'" );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$claim_column = $wpdb->get_var( "SHOW COLUMNS FROM {$table_name} LIKE 'claim_expires_at'" );
+		if ( ! $claim_column ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query( "ALTER TABLE {$table_name} ADD COLUMN claim_expires_at DATETIME NULL" );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$index = $wpdb->get_row( "SHOW INDEX FROM {$table_name} WHERE Key_name = 'status_claim_expires'" );
+		if ( ! $index ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query( "ALTER TABLE {$table_name} ADD KEY `status_claim_expires` (status, claim_expires_at)" );
+		}
 	}
 }

--- a/inc/Core/ExecutionContext.php
+++ b/inc/Core/ExecutionContext.php
@@ -275,6 +275,56 @@ class ExecutionContext {
 	}
 
 	/**
+	 * Check if an item has an active in-flight claim.
+	 *
+	 * Active claims are separate from final processed rows and intentionally do
+	 * not run through `datamachine_should_reprocess_item`; a claimed item is
+	 * already being worked by another job and should not be scheduled again.
+	 *
+	 * @param string $item_identifier Item identifier.
+	 * @return bool True if actively claimed.
+	 */
+	public function isItemClaimed( string $item_identifier ): bool {
+		if ( $this->isDirect() || $this->isStandalone() || ! $this->flow_step_id ) {
+			return false;
+		}
+
+		$db_processed_items = new ProcessedItems();
+		return $db_processed_items->has_active_claim(
+			$this->flow_step_id,
+			$this->handler_type,
+			$item_identifier
+		);
+	}
+
+	/**
+	 * Atomically claim an item for this job's in-flight processing.
+	 *
+	 * In direct/standalone modes there is no persisted dedupe surface, so claims
+	 * are treated as successful no-ops.
+	 *
+	 * @param string $item_identifier Item identifier.
+	 * @return bool True when the item may be scheduled.
+	 */
+	public function claimItemForProcessing( string $item_identifier ): bool {
+		if ( $this->isDirect() || $this->isStandalone() || ! $this->flow_step_id ) {
+			return true;
+		}
+
+		if ( empty( $this->job_id ) ) {
+			return false;
+		}
+
+		$db_processed_items = new ProcessedItems();
+		return $db_processed_items->claim_item(
+			$this->flow_step_id,
+			$this->handler_type,
+			$item_identifier,
+			(int) $this->job_id
+		);
+	}
+
+	/**
 	 * Mark an item as processed.
 	 *
 	 * In direct mode, does nothing (no deduplication tracking).

--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -77,11 +77,11 @@ abstract class FetchHandler {
 			? $result['items']
 			: array( $result );
 
-		// Dedup: filter out already-processed items.
+		// Dedup: filter out already-processed and actively claimed items.
 		// Items with metadata['item_identifier'] are checked against the processed items
-		// database. Already-processed items are removed. New items are NOT yet
-		// marked — marking happens after the max_items cap so we don't permanently
-		// discard items that simply didn't fit in this batch.
+		// database. Already-processed/claimed items are removed. New items are NOT yet
+		// claimed — claim creation happens after the max_items cap so we don't block
+		// items that simply didn't fit in this batch.
 		$items = $this->filterProcessed( $items, $context );
 
 		// Apply max_items cap.
@@ -91,6 +91,11 @@ abstract class FetchHandler {
 		if ( $max_items > 0 && count( $items ) > $max_items ) {
 			$items = array_slice( $items, 0, $max_items );
 		}
+
+		// Claim only the items this fetch will actually schedule. Claims close the
+		// race between parallel parent flow ticks while still deferring final
+		// processed marking until the downstream pipeline completes successfully.
+		$items = $this->claimItems( $items, $context );
 
 		// NOTE: Items are NOT marked as processed here. Marking is deferred
 		// to ExecuteStepAbility::markCompletedItemProcessed() which runs when
@@ -106,11 +111,11 @@ abstract class FetchHandler {
 	}
 
 	/**
-	 * Filter out already-processed items WITHOUT marking new ones.
+	 * Filter out already-processed or actively claimed items WITHOUT marking new ones.
 	 *
 	 * Items with metadata['item_identifier'] are checked against the processed items
-	 * database. Already-processed items are removed. New items pass through
-	 * but are NOT marked as processed here — marking is deferred to
+	 * database. Already-processed and actively claimed items are removed. New
+	 * items pass through but are NOT marked as processed here — marking is deferred to
 	 * ExecuteStepAbility::markCompletedItemProcessed() when the full pipeline
 	 * completes successfully, so failed downstream steps don't cause dropped items.
 	 *
@@ -136,8 +141,49 @@ abstract class FetchHandler {
 				continue;
 			}
 
-			// Already processed — skip.
+			// Already processed or actively claimed by another in-flight run — skip.
 			if ( $context->isItemProcessed( (string) $item_identifier ) ) {
+				continue;
+			}
+
+			if ( $context->isItemClaimed( (string) $item_identifier ) ) {
+				continue;
+			}
+
+			$result[] = $item;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Claim items that survived dedup and max_items selection.
+	 *
+	 * A failed claim means another parallel fetch won the race after our initial
+	 * filter check. Drop that item from this run so only one child pipeline job
+	 * is scheduled for the source item.
+	 *
+	 * @param array            $items   Items selected for scheduling.
+	 * @param ExecutionContext $context Execution context.
+	 * @return array Items whose claim was acquired, plus identifier-less items.
+	 */
+	private function claimItems( array $items, ExecutionContext $context ): array {
+		$result = array();
+
+		foreach ( $items as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			$item_identifier = $item['metadata']['item_identifier'] ?? null;
+
+			// No item_identifier — no dedupe contract, pass through unchanged.
+			if ( null === $item_identifier || '' === $item_identifier ) {
+				$result[] = $item;
+				continue;
+			}
+
+			if ( ! $context->claimItemForProcessing( (string) $item_identifier ) ) {
 				continue;
 			}
 

--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -121,6 +121,7 @@ class FailJobHandler {
 		}
 
 		$db_processed_items->delete_processed_items( array( 'job_id' => $job_id ) );
+		self::releaseInFlightSourceClaims( $db_processed_items, $job_id, $engine_data );
 
 		$cleanup_files = \DataMachine\Core\PluginSettings::get( 'cleanup_job_data_on_failure', true );
 		$files_cleaned = false;
@@ -151,5 +152,60 @@ class FailJobHandler {
 		);
 
 		return true;
+	}
+
+	/**
+	 * Release in-flight source-item claims for failed jobs.
+	 *
+	 * Parent fetch jobs own claims by job_id until their children are scheduled;
+	 * child jobs carry item_identifier/source_type in engine_data. Release both
+	 * shapes so failed downstream work can retry on the next fetch tick.
+	 *
+	 * @param \DataMachine\Core\Database\ProcessedItems\ProcessedItems $db_processed_items Processed items repository.
+	 * @param int                                                        $job_id             Failed job ID.
+	 * @param array                                                      $engine_data        Failed job engine data.
+	 * @return void
+	 */
+	private static function releaseInFlightSourceClaims( \DataMachine\Core\Database\ProcessedItems\ProcessedItems $db_processed_items, int $job_id, array $engine_data ): void {
+		$db_processed_items->release_claims_for_job( $job_id );
+
+		$item_identifier = $engine_data['item_identifier'] ?? null;
+		$source_type     = $engine_data['source_type'] ?? null;
+		if ( empty( $item_identifier ) || empty( $source_type ) ) {
+			return;
+		}
+
+		$fetch_flow_step_id = self::resolveFetchFlowStepId( $engine_data );
+		if ( empty( $fetch_flow_step_id ) ) {
+			return;
+		}
+
+		$db_processed_items->release_claim( $fetch_flow_step_id, (string) $source_type, (string) $item_identifier );
+	}
+
+	/**
+	 * Resolve the fetch/event_import step ID from a job engine snapshot.
+	 *
+	 * @param array $engine_data Job engine data.
+	 * @return string|null Fetch flow step ID, or null when unavailable.
+	 */
+	private static function resolveFetchFlowStepId( array $engine_data ): ?string {
+		$flow_config = $engine_data['flow_config'] ?? array();
+		if ( ! is_array( $flow_config ) ) {
+			return null;
+		}
+
+		foreach ( $flow_config as $step_id => $config ) {
+			if ( ! is_array( $config ) ) {
+				continue;
+			}
+
+			$step_type = $config['step_type'] ?? '';
+			if ( in_array( $step_type, array( 'fetch', 'event_import' ), true ) ) {
+				return (string) $step_id;
+			}
+		}
+
+		return null;
 	}
 }

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -32,6 +32,7 @@ require_once __DIR__ . '/agent-config-model-shape.php';
 require_once __DIR__ . '/settings-mode-models.php';
 require_once __DIR__ . '/ai-provider-keys.php';
 require_once __DIR__ . '/bundle-artifacts.php';
+require_once __DIR__ . '/processed-item-claims.php';
 
 // Schema-migration runtime — defines `datamachine_run_schema_migrations()`
 // and `datamachine_maybe_run_deferred_migrations()`. Hooked at

--- a/inc/migrations/processed-item-claims.php
+++ b/inc/migrations/processed-item-claims.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Data Machine — Processed-item in-flight claim columns.
+ *
+ * @package DataMachine
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Add claim state columns to the processed-items ledger.
+ *
+ * Idempotent: gated on `datamachine_processed_item_claims_migrated`, with
+ * repository-level column/index checks doing the actual schema work.
+ *
+ * @return void
+ */
+function datamachine_migrate_processed_item_claims(): void {
+	if ( get_option( 'datamachine_processed_item_claims_migrated', false ) ) {
+		return;
+	}
+
+	$db_processed_items = new \DataMachine\Core\Database\ProcessedItems\ProcessedItems();
+	\DataMachine\Core\Database\ProcessedItems\ProcessedItems::ensure_claim_columns( $db_processed_items->get_table_name() );
+
+	update_option( 'datamachine_processed_item_claims_migrated', true, true );
+}

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -135,6 +135,9 @@ function datamachine_run_schema_migrations(): void {
 
 	// Ensure installed bundle artifact tracking table exists on upgraded installs (#1531).
 	datamachine_migrate_bundle_artifacts_table();
+
+	// Add in-flight source-item claim state to processed_items (#1682).
+	datamachine_migrate_processed_item_claims();
 }
 
 /**

--- a/tests/processed-item-claims-smoke.php
+++ b/tests/processed-item-claims-smoke.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Pure-PHP smoke test for in-flight source-item claims (#1682).
+ *
+ * Run with: php tests/processed-item-claims-smoke.php
+ *
+ * The production path is database-backed, but the race contract is simple:
+ * the existing (flow_step_id, source_type, item_identifier) unique key must
+ * represent exactly one active state at a time: claimed or processed.
+ *
+ * @package DataMachine\Tests
+ */
+
+$failed = 0;
+$total  = 0;
+
+function assert_claims_smoke( string $name, bool $cond, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $cond ) {
+		echo "  [PASS] $name\n";
+		return;
+	}
+
+	echo "  [FAIL] $name" . ( $detail ? " — $detail" : '' ) . "\n";
+	++$failed;
+}
+
+final class ClaimsLedgerForSmoke {
+	public const CLAIMED = 'claimed';
+	public const PROCESSED = 'processed';
+
+	/** @var array<string,array{status:string,job_id:int,expires:int|null}> */
+	private array $rows = array();
+	private int $now = 1000;
+
+	public function tick( int $seconds ): void {
+		$this->now += $seconds;
+	}
+
+	public function claim( string $flow_step_id, string $source_type, string $item_identifier, int $job_id, int $ttl = 3600 ): bool {
+		$this->deleteExpiredClaims();
+		$key = $this->key( $flow_step_id, $source_type, $item_identifier );
+
+		if ( isset( $this->rows[ $key ] ) ) {
+			return false;
+		}
+
+		$this->rows[ $key ] = array(
+			'status'  => self::CLAIMED,
+			'job_id'  => $job_id,
+			'expires' => $this->now + $ttl,
+		);
+
+		return true;
+	}
+
+	public function release( string $flow_step_id, string $source_type, string $item_identifier ): void {
+		$key = $this->key( $flow_step_id, $source_type, $item_identifier );
+		if ( isset( $this->rows[ $key ] ) && self::CLAIMED === $this->rows[ $key ]['status'] ) {
+			unset( $this->rows[ $key ] );
+		}
+	}
+
+	public function markProcessed( string $flow_step_id, string $source_type, string $item_identifier, int $job_id ): void {
+		$key = $this->key( $flow_step_id, $source_type, $item_identifier );
+		$this->rows[ $key ] = array(
+			'status'  => self::PROCESSED,
+			'job_id'  => $job_id,
+			'expires' => null,
+		);
+	}
+
+	public function shouldSkip( string $flow_step_id, string $source_type, string $item_identifier ): bool {
+		$this->deleteExpiredClaims();
+		return isset( $this->rows[ $this->key( $flow_step_id, $source_type, $item_identifier ) ] );
+	}
+
+	public function status( string $flow_step_id, string $source_type, string $item_identifier ): ?string {
+		$key = $this->key( $flow_step_id, $source_type, $item_identifier );
+		return $this->rows[ $key ]['status'] ?? null;
+	}
+
+	private function deleteExpiredClaims(): void {
+		foreach ( $this->rows as $key => $row ) {
+			if ( self::CLAIMED === $row['status'] && null !== $row['expires'] && $row['expires'] <= $this->now ) {
+				unset( $this->rows[ $key ] );
+			}
+		}
+	}
+
+	private function key( string $flow_step_id, string $source_type, string $item_identifier ): string {
+		return implode( '|', array( $flow_step_id, $source_type, $item_identifier ) );
+	}
+}
+
+$ledger = new ClaimsLedgerForSmoke();
+$flow   = 'fetch-step_5';
+$source = 'mgs';
+$item   = 'ticket-123';
+
+echo "Case 1: parallel parents cannot claim the same item\n";
+assert_claims_smoke( 'first parent claim succeeds', $ledger->claim( $flow, $source, $item, 100 ) );
+assert_claims_smoke( 'second parent claim fails while first is active', ! $ledger->claim( $flow, $source, $item, 101 ) );
+assert_claims_smoke( 'active claim makes fetch skip item', $ledger->shouldSkip( $flow, $source, $item ) );
+assert_claims_smoke( 'row is in claimed state before completion', ClaimsLedgerForSmoke::CLAIMED === $ledger->status( $flow, $source, $item ) );
+
+echo "Case 2: failed downstream work releases claim for retry\n";
+$ledger->release( $flow, $source, $item );
+assert_claims_smoke( 'released claim no longer skips', ! $ledger->shouldSkip( $flow, $source, $item ) );
+assert_claims_smoke( 'later parent can reclaim after release', $ledger->claim( $flow, $source, $item, 102 ) );
+
+echo "Case 3: successful completion converts claim to processed\n";
+$ledger->markProcessed( $flow, $source, $item, 200 );
+assert_claims_smoke( 'row is processed after final completion', ClaimsLedgerForSmoke::PROCESSED === $ledger->status( $flow, $source, $item ) );
+assert_claims_smoke( 'processed row makes future fetch skip', $ledger->shouldSkip( $flow, $source, $item ) );
+assert_claims_smoke( 'processed row cannot be reclaimed', ! $ledger->claim( $flow, $source, $item, 103 ) );
+
+echo "Case 4: stale claims expire\n";
+$stale = 'ticket-456';
+assert_claims_smoke( 'short claim succeeds', $ledger->claim( $flow, $source, $stale, 300, 5 ) );
+$ledger->tick( 5 );
+assert_claims_smoke( 'expired claim no longer skips', ! $ledger->shouldSkip( $flow, $source, $stale ) );
+assert_claims_smoke( 'expired claim can be reclaimed', $ledger->claim( $flow, $source, $stale, 301 ) );
+
+echo "Case 5: production files expose the claim contract\n";
+$processed_items = file_get_contents( __DIR__ . '/../inc/Core/Database/ProcessedItems/ProcessedItems.php' );
+$fetch_handler   = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );
+$fail_handler    = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Handlers/FailJobHandler.php' );
+$execute_step    = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php' );
+
+assert_claims_smoke( 'repository defines claimed status', (bool) preg_match( "/STATUS_CLAIMED\s*=\s*'claimed'/", $processed_items ) );
+assert_claims_smoke( 'repository defines processed status', (bool) preg_match( "/STATUS_PROCESSED\s*=\s*'processed'/", $processed_items ) );
+assert_claims_smoke( 'repository has atomic claim method', str_contains( $processed_items, 'function claim_item' ) );
+assert_claims_smoke( 'repository has release claim method', str_contains( $processed_items, 'function release_claim' ) );
+assert_claims_smoke( 'repository ensures claim columns', str_contains( $processed_items, 'function ensure_claim_columns' ) );
+assert_claims_smoke( 'fetch filters active claims', str_contains( $fetch_handler, 'isItemClaimed' ) );
+assert_claims_smoke( 'fetch claims after max_items', strpos( $fetch_handler, 'array_slice' ) < strpos( $fetch_handler, 'claimItems' ) );
+assert_claims_smoke( 'fail handler releases claims', str_contains( $fail_handler, 'releaseInFlightSourceClaims' ) );
+assert_claims_smoke( 'failed status override releases claim', str_contains( $execute_step, 'releaseInFlightItemClaim' ) );
+
+echo "\nProcessed item claims smoke complete: {$total} assertions, {$failed} failures.\n";
+if ( $failed > 0 ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Adds in-flight source-item claims so parallel fetch ticks cannot schedule duplicate children before final processed marking catches up.
- Keeps final processed marking deferred until downstream completion, so failed AI/upsert work can still retry.

## Changes
- Extends `datamachine_processed_items` with `status` and `claim_expires_at` columns plus an idempotent migration.
- Filters active claims during fetch dedupe, then atomically claims only items that survive `max_items` selection.
- Converts claims to processed rows on successful final completion and releases claims on downstream failure or failed status override.
- Adds claim expiry cleanup to prevent stuck in-flight rows from living forever.
- Adds a focused pure-PHP smoke covering parallel claim attempts, failure release, success conversion, expiry, and production contract hooks.

## Tests
- `php -l inc/Core/Database/ProcessedItems/ProcessedItems.php && php -l inc/Core/ExecutionContext.php && php -l inc/Core/Steps/Fetch/Handlers/FetchHandler.php && php -l inc/Engine/Actions/Handlers/FailJobHandler.php && php -l inc/Abilities/Engine/ExecuteStepAbility.php && php -l inc/migrations/processed-item-claims.php && php tests/processed-item-claims-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-inflight-source-item-claims --file inc/Core/Database/ProcessedItems/ProcessedItems.php --summary`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-inflight-source-item-claims --changed-since HEAD`

Closes #1682

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the claim-state flow, migration, and focused smoke test; Chris remains responsible for review and merge.
