### PR TITLE
feat(agents-api): add agent package contract

### DIFF
--- a/agents-api/agents-api.php
+++ b/agents-api/agents-api.php
@@ -17,6 +17,10 @@ define( 'AGENTS_API_LOADED', true );
 define( 'AGENTS_API_PATH', __DIR__ . '/' );
 
 require_once AGENTS_API_PATH . 'inc/class-wp-agent.php';
+require_once AGENTS_API_PATH . 'inc/class-wp-agent-package.php';
+require_once AGENTS_API_PATH . 'inc/class-wp-agent-package-adoption-diff.php';
+require_once AGENTS_API_PATH . 'inc/class-wp-agent-package-adoption-result.php';
+require_once AGENTS_API_PATH . 'inc/class-wp-agent-package-adopter-interface.php';
 require_once AGENTS_API_PATH . 'inc/class-wp-agents-registry.php';
 require_once AGENTS_API_PATH . 'inc/register-agents.php';
 require_once AGENTS_API_PATH . 'inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php';

--- a/agents-api/inc/class-wp-agent-package-adopter-interface.php
+++ b/agents-api/inc/class-wp-agent-package-adopter-interface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * WP_Agent_Package_Adopter_Interface contract.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! interface_exists( 'WP_Agent_Package_Adopter_Interface' ) ) {
+	/**
+	 * Contract for runtimes that can materialize agent package definitions.
+	 */
+	interface WP_Agent_Package_Adopter_Interface {
+
+		/**
+		 * Returns the adoption diff for a package without applying changes.
+		 *
+		 * @param WP_Agent_Package $package Agent package definition.
+		 * @return WP_Agent_Package_Adoption_Diff
+		 */
+		public function diff( WP_Agent_Package $package ): WP_Agent_Package_Adoption_Diff;
+
+		/**
+		 * Adopts or updates a package in the implementing runtime.
+		 *
+		 * @param WP_Agent_Package  $package Agent package definition.
+		 * @param array<string,mixed> $options Implementation-specific adoption options.
+		 * @return WP_Agent_Package_Adoption_Result
+		 */
+		public function adopt( WP_Agent_Package $package, array $options = array() ): WP_Agent_Package_Adoption_Result;
+	}
+}

--- a/agents-api/inc/class-wp-agent-package-adoption-diff.php
+++ b/agents-api/inc/class-wp-agent-package-adoption-diff.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * WP_Agent_Package_Adoption_Diff value object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Package_Adoption_Diff' ) ) {
+	/**
+	 * Describes what an adopter would change for an agent package.
+	 */
+	final class WP_Agent_Package_Adoption_Diff {
+
+		/**
+		 * Adoption status.
+		 *
+		 * @var string
+		 */
+		private string $status;
+
+		/**
+		 * Change entries.
+		 *
+		 * @var array<int, array<string, mixed>>
+		 */
+		private array $changes;
+
+		/**
+		 * Warning messages.
+		 *
+		 * @var array<int, string>
+		 */
+		private array $warnings;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string                         $status   Diff status.
+		 * @param array<int, mixed>               $changes  Change entries.
+		 * @param array<int, string>             $warnings Warning messages.
+		 */
+		public function __construct( string $status, array $changes = array(), array $warnings = array() ) {
+			$this->status   = $this->prepare_status( $status );
+			$this->changes  = $this->prepare_changes( $changes );
+			$this->warnings = $this->prepare_strings( $warnings );
+		}
+
+		/**
+		 * Retrieves the diff status.
+		 *
+		 * @return string
+		 */
+		public function get_status(): string {
+			return $this->status;
+		}
+
+		/**
+		 * Retrieves normalized changes.
+		 *
+		 * @return array<int, array<string, mixed>>
+		 */
+		public function get_changes(): array {
+			return $this->changes;
+		}
+
+		/**
+		 * Retrieves warnings.
+		 *
+		 * @return array<int, string>
+		 */
+		public function get_warnings(): array {
+			return $this->warnings;
+		}
+
+		/**
+		 * Exports the value object.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function to_array(): array {
+			return array(
+				'status'   => $this->status,
+				'changes'  => $this->changes,
+				'warnings' => $this->warnings,
+			);
+		}
+
+		/**
+		 * Validates status.
+		 *
+		 * @param string $status Raw status.
+		 * @return string
+		 */
+		private function prepare_status( string $status ): string {
+			$status  = sanitize_title( $status );
+			$allowed = array( 'clean', 'needs-adoption', 'needs-update', 'blocked' );
+			if ( ! in_array( $status, $allowed, true ) ) {
+				throw new InvalidArgumentException( 'Agent package adoption diff status must be one of clean, needs-adoption, needs-update, blocked.' );
+			}
+
+			return $status;
+		}
+
+		/**
+		 * Normalizes change entries.
+		 *
+		 * @param array<int, mixed> $changes Raw changes.
+		 * @return array<int, array<string, mixed>>
+		 */
+		private function prepare_changes( array $changes ): array {
+			$prepared = array();
+			foreach ( $changes as $change ) {
+				if ( is_array( $change ) ) {
+					$prepared[] = $change;
+				}
+			}
+
+			return $prepared;
+		}
+
+		/**
+		 * Normalizes string lists.
+		 *
+		 * @param array<int, string> $values Raw values.
+		 * @return array<int, string>
+		 */
+		private function prepare_strings( array $values ): array {
+			$prepared = array();
+			foreach ( $values as $value ) {
+				$value = trim( (string) $value );
+				if ( '' !== $value ) {
+					$prepared[] = $value;
+				}
+			}
+
+			return array_values( array_unique( $prepared ) );
+		}
+	}
+}

--- a/agents-api/inc/class-wp-agent-package-adoption-result.php
+++ b/agents-api/inc/class-wp-agent-package-adoption-result.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * WP_Agent_Package_Adoption_Result value object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Package_Adoption_Result' ) ) {
+	/**
+	 * Describes the outcome of adopting an agent package.
+	 */
+	final class WP_Agent_Package_Adoption_Result {
+
+		/**
+		 * Adoption status.
+		 *
+		 * @var string
+		 */
+		private string $status;
+
+		/**
+		 * Adopted agent slug.
+		 *
+		 * @var string
+		 */
+		private string $agent_slug;
+
+		/**
+		 * Result messages.
+		 *
+		 * @var array<int, string>
+		 */
+		private array $messages;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string             $status     Result status.
+		 * @param string             $agent_slug Adopted agent slug.
+		 * @param array<int, string> $messages   Result messages.
+		 */
+		public function __construct( string $status, string $agent_slug, array $messages = array() ) {
+			$this->status     = $this->prepare_status( $status );
+			$this->agent_slug = sanitize_title( $agent_slug );
+			$this->messages   = $this->prepare_messages( $messages );
+
+			if ( '' === $this->agent_slug ) {
+				throw new InvalidArgumentException( 'Agent package adoption result requires an agent slug.' );
+			}
+		}
+
+		/**
+		 * Retrieves the result status.
+		 *
+		 * @return string
+		 */
+		public function get_status(): string {
+			return $this->status;
+		}
+
+		/**
+		 * Retrieves the adopted agent slug.
+		 *
+		 * @return string
+		 */
+		public function get_agent_slug(): string {
+			return $this->agent_slug;
+		}
+
+		/**
+		 * Retrieves messages.
+		 *
+		 * @return array<int, string>
+		 */
+		public function get_messages(): array {
+			return $this->messages;
+		}
+
+		/**
+		 * Exports the value object.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function to_array(): array {
+			return array(
+				'status'     => $this->status,
+				'agent_slug' => $this->agent_slug,
+				'messages'   => $this->messages,
+			);
+		}
+
+		/**
+		 * Validates status.
+		 *
+		 * @param string $status Raw status.
+		 * @return string
+		 */
+		private function prepare_status( string $status ): string {
+			$status  = sanitize_title( $status );
+			$allowed = array( 'adopted', 'updated', 'skipped', 'failed' );
+			if ( ! in_array( $status, $allowed, true ) ) {
+				throw new InvalidArgumentException( 'Agent package adoption result status must be one of adopted, updated, skipped, failed.' );
+			}
+
+			return $status;
+		}
+
+		/**
+		 * Normalizes messages.
+		 *
+		 * @param array<int, string> $messages Raw messages.
+		 * @return array<int, string>
+		 */
+		private function prepare_messages( array $messages ): array {
+			$prepared = array();
+			foreach ( $messages as $message ) {
+				$message = trim( (string) $message );
+				if ( '' !== $message ) {
+					$prepared[] = $message;
+				}
+			}
+
+			return $prepared;
+		}
+	}
+}

--- a/agents-api/inc/class-wp-agent-package.php
+++ b/agents-api/inc/class-wp-agent-package.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * WP_Agent_Package definition object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Package' ) ) {
+	/**
+	 * Declarative package containing an agent definition and generic artifacts.
+	 *
+	 * Package parsing is intentionally storage/runtime neutral. It does not create
+	 * database rows, files, queues, or scheduled work; adopters decide how to map
+	 * this definition into their own runtime.
+	 */
+	final class WP_Agent_Package {
+
+		/**
+		 * Package slug.
+		 *
+		 * @var string
+		 */
+		private string $slug;
+
+		/**
+		 * Package version.
+		 *
+		 * @var string
+		 */
+		private string $version;
+
+		/**
+		 * Agent definition.
+		 *
+		 * @var WP_Agent
+		 */
+		private WP_Agent $agent;
+
+		/**
+		 * Declared capability strings.
+		 *
+		 * @var array<int, string>
+		 */
+		private array $capabilities = array();
+
+		/**
+		 * Generic artifact definitions.
+		 *
+		 * @var array<int, array<string, string>>
+		 */
+		private array $artifacts = array();
+
+		/**
+		 * Optional package metadata.
+		 *
+		 * @var array<string, mixed>
+		 */
+		private array $meta = array();
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string|array<string,mixed> $slug_or_manifest Package slug or manifest array.
+		 * @param array<string,mixed>        $args             Package arguments.
+		 */
+		public function __construct( $slug_or_manifest, array $args = array() ) {
+			$manifest = is_array( $slug_or_manifest ) ? $slug_or_manifest : array_merge( $args, array( 'slug' => (string) $slug_or_manifest ) );
+
+			$this->slug         = $this->prepare_slug( $manifest['slug'] ?? '' );
+			$this->version      = isset( $manifest['version'] ) ? trim( (string) $manifest['version'] ) : '1.0.0';
+			$this->agent        = $this->prepare_agent( $manifest['agent'] ?? null );
+			$this->capabilities = $this->prepare_string_list( $manifest['capabilities'] ?? array(), 'capabilities' );
+			$this->artifacts    = $this->prepare_artifacts( $manifest['artifacts'] ?? array() );
+
+			if ( isset( $manifest['meta'] ) ) {
+				if ( ! is_array( $manifest['meta'] ) ) {
+					throw new InvalidArgumentException( 'Agent package meta property must be an array.' );
+				}
+
+				$this->meta = $manifest['meta'];
+			}
+
+			if ( '' === $this->version ) {
+				throw new InvalidArgumentException( 'Agent package version cannot be empty.' );
+			}
+		}
+
+		/**
+		 * Creates a package from a manifest array.
+		 *
+		 * @param array<string,mixed> $manifest Package manifest.
+		 * @return self
+		 */
+		public static function from_array( array $manifest ): self {
+			return new self( $manifest );
+		}
+
+		/**
+		 * Retrieves the package slug.
+		 *
+		 * @return string
+		 */
+		public function get_slug(): string {
+			return $this->slug;
+		}
+
+		/**
+		 * Retrieves the package version.
+		 *
+		 * @return string
+		 */
+		public function get_version(): string {
+			return $this->version;
+		}
+
+		/**
+		 * Retrieves the package agent definition.
+		 *
+		 * @return WP_Agent
+		 */
+		public function get_agent(): WP_Agent {
+			return $this->agent;
+		}
+
+		/**
+		 * Retrieves capability strings.
+		 *
+		 * @return array<int, string>
+		 */
+		public function get_capabilities(): array {
+			return $this->capabilities;
+		}
+
+		/**
+		 * Retrieves artifact definitions.
+		 *
+		 * @return array<int, array<string, string>>
+		 */
+		public function get_artifacts(): array {
+			return $this->artifacts;
+		}
+
+		/**
+		 * Retrieves package metadata.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function get_meta(): array {
+			return $this->meta;
+		}
+
+		/**
+		 * Exports the normalized package manifest.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function to_array(): array {
+			return array(
+				'slug'         => $this->slug,
+				'version'      => $this->version,
+				'agent'        => $this->agent->to_array(),
+				'capabilities' => $this->capabilities,
+				'artifacts'    => $this->artifacts,
+				'meta'         => $this->meta,
+			);
+		}
+
+		/**
+		 * Prepares the package slug.
+		 *
+		 * @param mixed $slug Raw slug.
+		 * @return string
+		 */
+		private function prepare_slug( $slug ): string {
+			$slug = sanitize_title( (string) $slug );
+			if ( '' === $slug ) {
+				throw new InvalidArgumentException( 'Agent package slug cannot be empty.' );
+			}
+
+			return $slug;
+		}
+
+		/**
+		 * Prepares the agent definition.
+		 *
+		 * @param mixed $agent Raw agent definition.
+		 * @return WP_Agent
+		 */
+		private function prepare_agent( $agent ): WP_Agent {
+			if ( $agent instanceof WP_Agent ) {
+				return $agent;
+			}
+
+			if ( ! is_array( $agent ) ) {
+				throw new InvalidArgumentException( 'Agent package requires an agent definition.' );
+			}
+
+			$slug = $agent['slug'] ?? '';
+			if ( '' === sanitize_title( (string) $slug ) ) {
+				throw new InvalidArgumentException( 'Agent package agent slug cannot be empty.' );
+			}
+
+			$args = $agent;
+			unset( $args['slug'] );
+
+			return new WP_Agent( (string) $slug, $args );
+		}
+
+		/**
+		 * Prepares a unique string list.
+		 *
+		 * @param mixed  $values Raw values.
+		 * @param string $field  Field label for errors.
+		 * @return array<int, string>
+		 */
+		private function prepare_string_list( $values, string $field ): array {
+			if ( ! is_array( $values ) ) {
+				throw new InvalidArgumentException( sprintf( 'Agent package %s property must be an array.', esc_html( $field ) ) );
+			}
+
+			$prepared = array();
+			foreach ( $values as $value ) {
+				$value = trim( strtolower( (string) $value ) );
+				if ( '' !== $value && preg_match( '/^[a-z0-9:_\.\/-]+$/', $value ) ) {
+					$prepared[] = $value;
+				}
+			}
+
+			$prepared = array_values( array_unique( $prepared ) );
+			sort( $prepared );
+
+			return $prepared;
+		}
+
+		/**
+		 * Prepares artifact declarations.
+		 *
+		 * @param mixed $artifacts Raw artifacts.
+		 * @return array<int, array<string, string>>
+		 */
+		private function prepare_artifacts( $artifacts ): array {
+			if ( ! is_array( $artifacts ) ) {
+				throw new InvalidArgumentException( 'Agent package artifacts property must be an array.' );
+			}
+
+			$prepared = array();
+			foreach ( $artifacts as $artifact ) {
+				if ( ! is_array( $artifact ) ) {
+					throw new InvalidArgumentException( 'Agent package artifacts must be objects.' );
+				}
+
+				$type = sanitize_title( (string) ( $artifact['type'] ?? '' ) );
+				$slug = sanitize_title( (string) ( $artifact['slug'] ?? '' ) );
+				if ( '' === $type || '' === $slug ) {
+					throw new InvalidArgumentException( 'Agent package artifacts require type and slug.' );
+				}
+
+				$row = array(
+					'type'        => $type,
+					'slug'        => $slug,
+					'label'       => isset( $artifact['label'] ) ? trim( (string) $artifact['label'] ) : $slug,
+					'description' => isset( $artifact['description'] ) ? trim( (string) $artifact['description'] ) : '',
+					'source'      => isset( $artifact['source'] ) ? trim( (string) $artifact['source'] ) : '',
+				);
+
+				$prepared[] = $row;
+			}
+
+			usort(
+				$prepared,
+				static function ( array $a, array $b ): int {
+					return array( $a['type'], $a['slug'] ) <=> array( $b['type'], $b['slug'] );
+				}
+			);
+
+			return $prepared;
+		}
+	}
+}

--- a/tests/agents-api-bootstrap-smoke.php
+++ b/tests/agents-api-bootstrap-smoke.php
@@ -20,9 +20,9 @@ require_once __DIR__ . '/agents-api-smoke-helpers.php';
 agents_api_smoke_require_module();
 
 $namespace_map = array(
-	'DataMachine\\Engine\\AI\\AgentMessageEnvelope'                         => 'AgentsAPI\\Engine\\AI\\AgentMessageEnvelope',
-	'DataMachine\\Engine\\AI\\AgentConversationResult'                      => 'AgentsAPI\\Engine\\AI\\AgentConversationResult',
-	'DataMachine\\Engine\\AI\\Tools\\RuntimeToolDeclaration'                => 'AgentsAPI\\Engine\\AI\\Tools\\RuntimeToolDeclaration',
+	'DataMachine\\Engine\\AI\\AgentMessageEnvelope'                         => 'AgentsAPI\\AI\\AgentMessageEnvelope',
+	'DataMachine\\Engine\\AI\\AgentConversationResult'                      => 'AgentsAPI\\AI\\AgentConversationResult',
+	'DataMachine\\Engine\\AI\\Tools\\RuntimeToolDeclaration'                => 'AgentsAPI\\AI\\Tools\\RuntimeToolDeclaration',
 	'DataMachine\\Core\\Database\\Chat\\ConversationTranscriptStoreInterface' => 'AgentsAPI\\Core\\Database\\Chat\\ConversationTranscriptStoreInterface',
 	'DataMachine\\Core\\FilesRepository\\AgentMemoryStoreInterface'           => 'AgentsAPI\\Core\\FilesRepository\\AgentMemoryStoreInterface',
 	'DataMachine\\Core\\FilesRepository\\AgentMemoryScope'                    => 'AgentsAPI\\Core\\FilesRepository\\AgentMemoryScope',

--- a/tests/agents-api-package-contract-smoke.php
+++ b/tests/agents-api-package-contract-smoke.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Pure-PHP smoke test for Agents API package/adoption contract (#1686).
+ *
+ * Run with: php tests/agents-api-package-contract-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-package-contract-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Package manifests normalize generic agent metadata:\n";
+$package = WP_Agent_Package::from_array(
+	array(
+		'slug'         => 'WordPress.com Wiki Package',
+		'version'      => '2026.04.30',
+		'agent'        => array(
+			'slug'           => 'WordPress.com Wiki',
+			'label'          => 'WordPress.com Wiki',
+			'description'    => 'Maintains a historical knowledge base.',
+			'memory_seeds'   => array(
+				'../SOUL.md'   => 'memory/SOUL.md',
+				'../MEMORY.md' => 'memory/MEMORY.md',
+			),
+			'default_config' => array(
+				'model' => array( 'pipeline' => 'gpt-5.4' ),
+			),
+			'meta'           => array(
+				'domain' => 'wordpress-com',
+			),
+		),
+		'capabilities' => array( 'knowledge.read', 'knowledge.write', 'knowledge.read' ),
+		'artifacts'    => array(
+			array(
+				'type'        => 'prompt',
+				'slug'        => 'Historical Synthesis',
+				'label'       => 'Historical synthesis',
+				'description' => 'Converts source packets into grounded wiki notes.',
+				'source'      => 'prompts/historical-synthesis.md',
+			),
+			array(
+				'type'   => 'memory',
+				'slug'   => 'Source Notes',
+				'source' => 'memory/MEMORY.md',
+			),
+		),
+		'meta'         => array(
+			'homepage' => 'https://example.invalid/agents/wordpress-com-wiki',
+		),
+	)
+);
+
+$manifest = $package->to_array();
+agents_api_smoke_assert_equals( 'wordpress-com-wiki-package', $package->get_slug(), 'package slug is normalized', $failures, $passes );
+agents_api_smoke_assert_equals( '2026.04.30', $package->get_version(), 'package version is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'wordpress-com-wiki', $package->get_agent()->get_slug(), 'agent slug is normalized through WP_Agent', $failures, $passes );
+agents_api_smoke_assert_equals( 'WordPress.com Wiki', $package->get_agent()->get_label(), 'agent label is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'knowledge.read', 'knowledge.write' ), $package->get_capabilities(), 'capabilities are deduped and sorted', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'SOUL.md' => 'memory/SOUL.md', 'MEMORY.md' => 'memory/MEMORY.md' ), $package->get_agent()->get_memory_seeds(), 'agent memory seeds use existing WP_Agent validation', $failures, $passes );
+agents_api_smoke_assert_equals( 'memory', $manifest['artifacts'][0]['type'], 'artifacts sort deterministically by type', $failures, $passes );
+agents_api_smoke_assert_equals( 'prompt', $manifest['artifacts'][1]['type'], 'prompt artifact is generic package metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'wordpress-com', $package->get_agent()->get_meta()['domain'] ?? '', 'agent meta can describe a domain without product vocabulary', $failures, $passes );
+
+echo "\n[2] Invalid package manifests fail before materialization:\n";
+$threw = false;
+try {
+	WP_Agent_Package::from_array( array( 'slug' => '!!!', 'agent' => array( 'slug' => 'valid-agent' ) ) );
+} catch ( InvalidArgumentException $e ) {
+	$threw = str_contains( $e->getMessage(), 'package slug cannot be empty' );
+}
+agents_api_smoke_assert_equals( true, $threw, 'empty package slug is rejected', $failures, $passes );
+
+$threw = false;
+try {
+	WP_Agent_Package::from_array( array( 'slug' => 'valid-package' ) );
+} catch ( InvalidArgumentException $e ) {
+	$threw = str_contains( $e->getMessage(), 'requires an agent definition' );
+}
+agents_api_smoke_assert_equals( true, $threw, 'missing agent definition is rejected', $failures, $passes );
+
+$threw = false;
+try {
+	WP_Agent_Package::from_array(
+		array(
+			'slug'      => 'valid-package',
+			'agent'     => array( 'slug' => 'valid-agent' ),
+			'artifacts' => array( array( 'type' => 'prompt' ) ),
+		)
+	);
+} catch ( InvalidArgumentException $e ) {
+	$threw = str_contains( $e->getMessage(), 'artifacts require type and slug' );
+}
+agents_api_smoke_assert_equals( true, $threw, 'malformed artifact is rejected', $failures, $passes );
+
+echo "\n[3] Adopter contracts stay runtime-neutral:\n";
+class Agents_API_Package_Smoke_Adopter implements WP_Agent_Package_Adopter_Interface {
+	public function diff( WP_Agent_Package $package ): WP_Agent_Package_Adoption_Diff {
+		return new WP_Agent_Package_Adoption_Diff(
+			'needs-adoption',
+			array(
+				array(
+					'type'       => 'agent',
+					'slug'       => $package->get_agent()->get_slug(),
+					'operation'  => 'create',
+				),
+			)
+		);
+	}
+
+	public function adopt( WP_Agent_Package $package, array $options = array() ): WP_Agent_Package_Adoption_Result {
+		unset( $options );
+		return new WP_Agent_Package_Adoption_Result( 'adopted', $package->get_agent()->get_slug(), array( 'Package accepted.' ) );
+	}
+}
+
+$adopter = new Agents_API_Package_Smoke_Adopter();
+$diff    = $adopter->diff( $package );
+$result  = $adopter->adopt( $package );
+agents_api_smoke_assert_equals( 'needs-adoption', $diff->get_status(), 'adopter diff exposes generic status', $failures, $passes );
+agents_api_smoke_assert_equals( 'agent', $diff->get_changes()[0]['type'] ?? '', 'adopter diff can describe generic agent changes', $failures, $passes );
+agents_api_smoke_assert_equals( 'adopted', $result->get_status(), 'adopter result exposes generic status', $failures, $passes );
+agents_api_smoke_assert_equals( 'wordpress-com-wiki', $result->get_agent_slug(), 'adopter result references normalized agent slug', $failures, $passes );
+
+echo "\n[4] Public package contract has no product vocabulary:\n";
+$contract_files = array(
+	'agents-api/inc/class-wp-agent-package.php',
+	'agents-api/inc/class-wp-agent-package-adopter-interface.php',
+	'agents-api/inc/class-wp-agent-package-adoption-diff.php',
+	'agents-api/inc/class-wp-agent-package-adoption-result.php',
+);
+$forbidden = array( 'DataMachine\\', 'pipeline', 'flow', 'job', 'handler', 'Intelligence', 'wpcom', 'Dolly', 'Odie' );
+$matches   = array();
+foreach ( $contract_files as $contract_file ) {
+	$source = (string) file_get_contents( dirname( __DIR__ ) . '/' . $contract_file );
+	foreach ( $forbidden as $needle ) {
+		if ( str_contains( $source, $needle ) ) {
+			$matches[] = $contract_file . ' contains ' . $needle;
+		}
+	}
+}
+agents_api_smoke_assert_equals( array(), $matches, 'package contract files avoid product-specific vocabulary', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API package contract', $failures, $passes );


### PR DESCRIPTION
## Summary

- Adds a Core-shaped `WP_Agent_Package` manifest contract to the in-repo `agents-api/` module.
- Adds generic package adoption diff/result contracts that runtimes such as Data Machine can adapt to without exposing product fields in the public package shape.
- Adds focused smoke coverage proving a package-backed brain-style agent can be represented with generic metadata, capabilities, and artifacts only.

## Changes

- Introduces `WP_Agent_Package`, `WP_Agent_Package_Adopter_Interface`, `WP_Agent_Package_Adoption_Diff`, and `WP_Agent_Package_Adoption_Result` under `agents-api/inc/`.
- Loads the new package contracts from `agents-api/agents-api.php`.
- Updates the Agents API bootstrap smoke to assert the current `AgentsAPI\AI\...` namespaces.
- Adds `tests/agents-api-package-contract-smoke.php` with manifest validation, adopter contract, and product-vocabulary guard coverage.

## Tests

- `php -l agents-api/agents-api.php && php -l agents-api/inc/class-wp-agent-package.php && php -l agents-api/inc/class-wp-agent-package-adopter-interface.php && php -l agents-api/inc/class-wp-agent-package-adoption-diff.php && php -l agents-api/inc/class-wp-agent-package-adoption-result.php && php -l tests/agents-api-bootstrap-smoke.php`
- `php tests/agents-api-package-contract-smoke.php`
- `php tests/agents-api-registration-smoke.php`
- `php tests/agents-api-bootstrap-smoke.php`
- `php tests/agents-api-no-product-imports-smoke.php`
- Scoped `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-package-contract --file <changed-file> --summary` for the new/changed Agents API files and smoke.

Closes #1686

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the Core-shaped package/adoption contract slice, writing focused smoke coverage, and running verification. Chris remains responsible for review and merge.
