### PR TITLE
feat(agents-api): add package artifact registry

### DIFF
--- a/agents-api/agents-api.php
+++ b/agents-api/agents-api.php
@@ -17,12 +17,16 @@ define( 'AGENTS_API_LOADED', true );
 define( 'AGENTS_API_PATH', __DIR__ . '/' );
 
 require_once AGENTS_API_PATH . 'inc/class-wp-agent.php';
+require_once AGENTS_API_PATH . 'inc/class-wp-agent-package-artifact.php';
+require_once AGENTS_API_PATH . 'inc/class-wp-agent-package-artifact-type.php';
+require_once AGENTS_API_PATH . 'inc/class-wp-agent-package-artifacts-registry.php';
 require_once AGENTS_API_PATH . 'inc/class-wp-agent-package.php';
 require_once AGENTS_API_PATH . 'inc/class-wp-agent-package-adoption-diff.php';
 require_once AGENTS_API_PATH . 'inc/class-wp-agent-package-adoption-result.php';
 require_once AGENTS_API_PATH . 'inc/class-wp-agent-package-adopter-interface.php';
 require_once AGENTS_API_PATH . 'inc/class-wp-agents-registry.php';
 require_once AGENTS_API_PATH . 'inc/register-agents.php';
+require_once AGENTS_API_PATH . 'inc/register-agent-package-artifacts.php';
 require_once AGENTS_API_PATH . 'inc/Core/Database/Chat/ConversationTranscriptStoreInterface.php';
 require_once AGENTS_API_PATH . 'inc/AI/AgentMessageEnvelope.php';
 require_once AGENTS_API_PATH . 'inc/AI/AgentConversationResult.php';

--- a/agents-api/inc/class-wp-agent-package-artifact-type.php
+++ b/agents-api/inc/class-wp-agent-package-artifact-type.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * WP_Agent_Package_Artifact_Type definition object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Package_Artifact_Type' ) ) {
+	/**
+	 * Metadata and lifecycle callbacks for a package artifact type.
+	 */
+	final class WP_Agent_Package_Artifact_Type {
+
+		/**
+		 * Artifact type slug.
+		 *
+		 * @var string
+		 */
+		private string $type;
+
+		/**
+		 * Human-readable label.
+		 *
+		 * @var string
+		 */
+		private string $label;
+
+		/**
+		 * Type description.
+		 *
+		 * @var string
+		 */
+		private string $description = '';
+
+		/**
+		 * Validation callback.
+		 *
+		 * @var callable|null
+		 */
+		private $validate_callback = null;
+
+		/**
+		 * Diff callback.
+		 *
+		 * @var callable|null
+		 */
+		private $diff_callback = null;
+
+		/**
+		 * Import callback.
+		 *
+		 * @var callable|null
+		 */
+		private $import_callback = null;
+
+		/**
+		 * Delete callback.
+		 *
+		 * @var callable|null
+		 */
+		private $delete_callback = null;
+
+		/**
+		 * Optional metadata.
+		 *
+		 * @var array<string, mixed>
+		 */
+		private array $meta = array();
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string $type Artifact type slug.
+		 * @param array  $args Registration arguments.
+		 */
+		public function __construct( string $type, array $args = array() ) {
+			$this->type  = WP_Agent_Package_Artifact::prepare_type( $type );
+			$this->label = isset( $args['label'] ) ? trim( (string) $args['label'] ) : $this->type;
+
+			if ( '' === $this->label ) {
+				$this->label = $this->type;
+			}
+
+			$this->description = isset( $args['description'] ) ? trim( (string) $args['description'] ) : '';
+
+			foreach ( array( 'validate_callback', 'diff_callback', 'import_callback', 'delete_callback' ) as $property ) {
+				if ( ! array_key_exists( $property, $args ) ) {
+					continue;
+				}
+
+				if ( null !== $args[ $property ] && ! is_callable( $args[ $property ] ) ) {
+					throw new InvalidArgumentException( sprintf( 'Agent package artifact type %s property must be callable.', esc_html( $property ) ) );
+				}
+
+				$this->$property = $args[ $property ];
+			}
+
+			if ( isset( $args['meta'] ) ) {
+				if ( ! is_array( $args['meta'] ) ) {
+					throw new InvalidArgumentException( 'Agent package artifact type meta property must be an array.' );
+				}
+
+				$this->meta = $args['meta'];
+			}
+		}
+
+		/**
+		 * Retrieves the artifact type slug.
+		 *
+		 * @return string
+		 */
+		public function get_type(): string {
+			return $this->type;
+		}
+
+		/**
+		 * Retrieves the label.
+		 *
+		 * @return string
+		 */
+		public function get_label(): string {
+			return $this->label;
+		}
+
+		/**
+		 * Retrieves the description.
+		 *
+		 * @return string
+		 */
+		public function get_description(): string {
+			return $this->description;
+		}
+
+		/**
+		 * Retrieves the validation callback.
+		 *
+		 * @return callable|null
+		 */
+		public function get_validate_callback() {
+			return $this->validate_callback;
+		}
+
+		/**
+		 * Retrieves the diff callback.
+		 *
+		 * @return callable|null
+		 */
+		public function get_diff_callback() {
+			return $this->diff_callback;
+		}
+
+		/**
+		 * Retrieves the import callback.
+		 *
+		 * @return callable|null
+		 */
+		public function get_import_callback() {
+			return $this->import_callback;
+		}
+
+		/**
+		 * Retrieves the delete callback.
+		 *
+		 * @return callable|null
+		 */
+		public function get_delete_callback() {
+			return $this->delete_callback;
+		}
+
+		/**
+		 * Retrieves metadata.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function get_meta(): array {
+			return $this->meta;
+		}
+
+		/**
+		 * Exports registration arguments.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function to_array(): array {
+			return array(
+				'type'              => $this->type,
+				'label'             => $this->label,
+				'description'       => $this->description,
+				'validate_callback' => $this->validate_callback,
+				'diff_callback'     => $this->diff_callback,
+				'import_callback'   => $this->import_callback,
+				'delete_callback'   => $this->delete_callback,
+				'meta'              => $this->meta,
+			);
+		}
+	}
+}

--- a/agents-api/inc/class-wp-agent-package-artifact.php
+++ b/agents-api/inc/class-wp-agent-package-artifact.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * WP_Agent_Package_Artifact definition object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Package_Artifact' ) ) {
+	/**
+	 * Portable package artifact declaration.
+	 *
+	 * The artifact records identity and payload location only. Product plugins own
+	 * interpretation of the payload for their registered artifact type.
+	 */
+	final class WP_Agent_Package_Artifact {
+
+		/**
+		 * Artifact type slug.
+		 *
+		 * @var string
+		 */
+		private string $type;
+
+		/**
+		 * Artifact slug.
+		 *
+		 * @var string
+		 */
+		private string $slug;
+
+		/**
+		 * Human-readable label.
+		 *
+		 * @var string
+		 */
+		private string $label;
+
+		/**
+		 * Artifact description.
+		 *
+		 * @var string
+		 */
+		private string $description = '';
+
+		/**
+		 * Relative source path inside the package.
+		 *
+		 * @var string
+		 */
+		private string $source = '';
+
+		/**
+		 * Optional checksum string.
+		 *
+		 * @var string
+		 */
+		private string $checksum = '';
+
+		/**
+		 * Required capability or component strings.
+		 *
+		 * @var array<int, string>
+		 */
+		private array $requires = array();
+
+		/**
+		 * Optional artifact metadata.
+		 *
+		 * @var array<string, mixed>
+		 */
+		private array $meta = array();
+
+		/**
+		 * Constructor.
+		 *
+		 * @param array<string,mixed> $artifact Artifact declaration.
+		 */
+		public function __construct( array $artifact ) {
+			$this->type        = self::prepare_type( $artifact['type'] ?? '' );
+			$this->slug        = $this->prepare_slug( $artifact['slug'] ?? '' );
+			$this->label       = isset( $artifact['label'] ) ? trim( (string) $artifact['label'] ) : $this->slug;
+			$this->description = isset( $artifact['description'] ) ? trim( (string) $artifact['description'] ) : '';
+			$this->source      = isset( $artifact['source'] ) ? trim( (string) $artifact['source'] ) : '';
+			$this->checksum    = isset( $artifact['checksum'] ) ? trim( (string) $artifact['checksum'] ) : '';
+
+			if ( isset( $artifact['requires'] ) ) {
+				$this->requires = $this->prepare_string_list( $artifact['requires'], 'requires' );
+			}
+
+			if ( isset( $artifact['meta'] ) ) {
+				if ( ! is_array( $artifact['meta'] ) ) {
+					throw new InvalidArgumentException( 'Agent package artifact meta property must be an array.' );
+				}
+
+				$this->meta = $artifact['meta'];
+			}
+
+			if ( '' === $this->label ) {
+				$this->label = $this->slug;
+			}
+		}
+
+		/**
+		 * Creates an artifact from an array.
+		 *
+		 * @param array<string,mixed> $artifact Artifact declaration.
+		 * @return self
+		 */
+		public static function from_array( array $artifact ): self {
+			return new self( $artifact );
+		}
+
+		/**
+		 * Normalizes an artifact type slug.
+		 *
+		 * @param mixed $type Raw type.
+		 * @return string
+		 */
+		public static function prepare_type( $type ): string {
+			$type = strtolower( trim( (string) $type ) );
+			if ( ! preg_match( '/^[a-z0-9][a-z0-9_.-]*\/[a-z0-9][a-z0-9_.\/-]*$/', $type ) ) {
+				throw new InvalidArgumentException( 'Agent package artifact type must be a namespaced slug.' );
+			}
+
+			return $type;
+		}
+
+		/**
+		 * Retrieves the artifact type.
+		 *
+		 * @return string
+		 */
+		public function get_type(): string {
+			return $this->type;
+		}
+
+		/**
+		 * Retrieves the artifact slug.
+		 *
+		 * @return string
+		 */
+		public function get_slug(): string {
+			return $this->slug;
+		}
+
+		/**
+		 * Retrieves the label.
+		 *
+		 * @return string
+		 */
+		public function get_label(): string {
+			return $this->label;
+		}
+
+		/**
+		 * Retrieves the description.
+		 *
+		 * @return string
+		 */
+		public function get_description(): string {
+			return $this->description;
+		}
+
+		/**
+		 * Retrieves the source path.
+		 *
+		 * @return string
+		 */
+		public function get_source(): string {
+			return $this->source;
+		}
+
+		/**
+		 * Retrieves the checksum.
+		 *
+		 * @return string
+		 */
+		public function get_checksum(): string {
+			return $this->checksum;
+		}
+
+		/**
+		 * Retrieves required capability or component strings.
+		 *
+		 * @return array<int, string>
+		 */
+		public function get_requires(): array {
+			return $this->requires;
+		}
+
+		/**
+		 * Retrieves metadata.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function get_meta(): array {
+			return $this->meta;
+		}
+
+		/**
+		 * Exports the normalized declaration.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function to_array(): array {
+			return array(
+				'type'        => $this->type,
+				'slug'        => $this->slug,
+				'label'       => $this->label,
+				'description' => $this->description,
+				'source'      => $this->source,
+				'checksum'    => $this->checksum,
+				'requires'    => $this->requires,
+				'meta'        => $this->meta,
+			);
+		}
+
+		/**
+		 * Prepares the artifact slug.
+		 *
+		 * @param mixed $slug Raw slug.
+		 * @return string
+		 */
+		private function prepare_slug( $slug ): string {
+			$slug = sanitize_title( (string) $slug );
+			if ( '' === $slug ) {
+				throw new InvalidArgumentException( 'Agent package artifact slug cannot be empty.' );
+			}
+
+			return $slug;
+		}
+
+		/**
+		 * Prepares a unique string list.
+		 *
+		 * @param mixed  $values Raw values.
+		 * @param string $field  Field label for errors.
+		 * @return array<int, string>
+		 */
+		private function prepare_string_list( $values, string $field ): array {
+			if ( ! is_array( $values ) ) {
+				throw new InvalidArgumentException( sprintf( 'Agent package artifact %s property must be an array.', esc_html( $field ) ) );
+			}
+
+			$prepared = array();
+			foreach ( $values as $value ) {
+				$value = strtolower( trim( (string) $value ) );
+				if ( '' !== $value && preg_match( '/^[a-z0-9:_\.\/-]+$/', $value ) ) {
+					$prepared[] = $value;
+				}
+			}
+
+			$prepared = array_values( array_unique( $prepared ) );
+			sort( $prepared );
+
+			return $prepared;
+		}
+	}
+}

--- a/agents-api/inc/class-wp-agent-package-artifact.php
+++ b/agents-api/inc/class-wp-agent-package-artifact.php
@@ -82,7 +82,7 @@ if ( ! class_exists( 'WP_Agent_Package_Artifact' ) ) {
 			$this->slug        = $this->prepare_slug( $artifact['slug'] ?? '' );
 			$this->label       = isset( $artifact['label'] ) ? trim( (string) $artifact['label'] ) : $this->slug;
 			$this->description = isset( $artifact['description'] ) ? trim( (string) $artifact['description'] ) : '';
-			$this->source      = isset( $artifact['source'] ) ? trim( (string) $artifact['source'] ) : '';
+			$this->source      = $this->prepare_source( $artifact['source'] ?? '' );
 			$this->checksum    = isset( $artifact['checksum'] ) ? trim( (string) $artifact['checksum'] ) : '';
 
 			if ( isset( $artifact['requires'] ) ) {
@@ -230,6 +230,35 @@ if ( ! class_exists( 'WP_Agent_Package_Artifact' ) ) {
 			}
 
 			return $slug;
+		}
+
+		/**
+		 * Prepares the package-relative source path.
+		 *
+		 * @param mixed $source Raw source path.
+		 * @return string
+		 */
+		private function prepare_source( $source ): string {
+			$source = trim( str_replace( '\\', '/', (string) $source ) );
+			if ( '' === $source ) {
+				return '';
+			}
+
+			if ( str_starts_with( $source, '/' ) || preg_match( '/^[A-Za-z]:\//', $source ) ) {
+				throw new InvalidArgumentException( 'Agent package artifact source must be relative to the package.' );
+			}
+
+			$parts = array_filter(
+				explode( '/', $source ),
+				static function ( string $part ): bool {
+					return '' !== $part;
+				}
+			);
+			if ( in_array( '..', $parts, true ) ) {
+				throw new InvalidArgumentException( 'Agent package artifact source cannot contain parent directory segments.' );
+			}
+
+			return implode( '/', $parts );
 		}
 
 		/**

--- a/agents-api/inc/class-wp-agent-package-artifacts-registry.php
+++ b/agents-api/inc/class-wp-agent-package-artifacts-registry.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * WP_Agent_Package_Artifacts_Registry facade.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Package_Artifacts_Registry' ) ) {
+	/**
+	 * Manages package artifact type registration and lookup.
+	 */
+	final class WP_Agent_Package_Artifacts_Registry {
+
+		/**
+		 * Singleton instance.
+		 *
+		 * @var self|null
+		 */
+		private static ?self $instance = null;
+
+		/**
+		 * Registered artifact types, keyed by type slug.
+		 *
+		 * @var array<string, WP_Agent_Package_Artifact_Type>
+		 */
+		private array $registered_types = array();
+
+		/**
+		 * Register an artifact type.
+		 *
+		 * @param string|WP_Agent_Package_Artifact_Type $type Artifact type slug or object.
+		 * @param array                                 $args Registration arguments when `$type` is a slug.
+		 * @return WP_Agent_Package_Artifact_Type|null Registered type, or null on invalid arguments.
+		 */
+		public function register( $type, array $args = array() ): ?WP_Agent_Package_Artifact_Type {
+			try {
+				$type = $type instanceof WP_Agent_Package_Artifact_Type ? $type : new WP_Agent_Package_Artifact_Type( (string) $type, $args );
+			} catch ( InvalidArgumentException $e ) {
+				$this->notice_invalid_registration( __METHOD__, $e->getMessage() );
+				return null;
+			}
+
+			if ( $this->is_registered( $type->get_type() ) ) {
+				$this->notice_invalid_registration( __METHOD__, sprintf( 'Agent package artifact type "%s" is already registered.', $type->get_type() ) );
+				return null;
+			}
+
+			$this->registered_types[ $type->get_type() ] = $type;
+			return $type;
+		}
+
+		/**
+		 * Get all registered artifact types.
+		 *
+		 * @return array<string, WP_Agent_Package_Artifact_Type>
+		 */
+		public function get_all_registered(): array {
+			return $this->registered_types;
+		}
+
+		/**
+		 * Get a registered artifact type by slug.
+		 *
+		 * @param string $type Artifact type slug.
+		 * @return WP_Agent_Package_Artifact_Type|null Artifact type, or null when not registered.
+		 */
+		public function get_registered( string $type ): ?WP_Agent_Package_Artifact_Type {
+			try {
+				$type = WP_Agent_Package_Artifact::prepare_type( $type );
+			} catch ( InvalidArgumentException $e ) {
+				$this->notice_invalid_registration( __METHOD__, $e->getMessage() );
+				return null;
+			}
+
+			if ( ! $this->is_registered( $type ) ) {
+				$this->notice_invalid_registration( __METHOD__, sprintf( 'Agent package artifact type "%s" not found.', $type ) );
+				return null;
+			}
+
+			return $this->registered_types[ $type ];
+		}
+
+		/**
+		 * Check whether an artifact type is registered.
+		 *
+		 * @param string $type Artifact type slug.
+		 * @return bool
+		 */
+		public function is_registered( string $type ): bool {
+			try {
+				$type = WP_Agent_Package_Artifact::prepare_type( $type );
+			} catch ( InvalidArgumentException $e ) {
+				return false;
+			}
+
+			return isset( $this->registered_types[ $type ] );
+		}
+
+		/**
+		 * Unregister an artifact type.
+		 *
+		 * @param string $type Artifact type slug.
+		 * @return WP_Agent_Package_Artifact_Type|null Removed type, or null when not registered.
+		 */
+		public function unregister( string $type ): ?WP_Agent_Package_Artifact_Type {
+			try {
+				$type = WP_Agent_Package_Artifact::prepare_type( $type );
+			} catch ( InvalidArgumentException $e ) {
+				$this->notice_invalid_registration( __METHOD__, $e->getMessage() );
+				return null;
+			}
+
+			if ( ! $this->is_registered( $type ) ) {
+				$this->notice_invalid_registration( __METHOD__, sprintf( 'Agent package artifact type "%s" not found.', $type ) );
+				return null;
+			}
+
+			$artifact_type = $this->registered_types[ $type ];
+			unset( $this->registered_types[ $type ] );
+
+			return $artifact_type;
+		}
+
+		/**
+		 * Retrieve the registry singleton.
+		 *
+		 * @return self|null Registry instance, or null when init has not fired.
+		 */
+		public static function get_instance(): ?self {
+			if ( function_exists( 'did_action' ) && ! did_action( 'init' ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					'Agent package artifact types should not be initialized before the <code>init</code> action has fired.',
+					'0.102.8'
+				);
+				return null;
+			}
+
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+
+				/**
+				 * Fires to let plugins register package artifact types.
+				 *
+				 * Callbacks should call `wp_register_agent_package_artifact_type()` to
+				 * contribute type metadata and lifecycle callbacks. The registry only
+				 * collects definitions; consumers decide when to invoke callbacks.
+				 */
+				do_action( 'wp_agent_package_artifacts_init', self::$instance );
+			}
+
+			return self::$instance;
+		}
+
+		/**
+		 * Reset internal state. Test helper only.
+		 *
+		 * @internal
+		 * @return void
+		 */
+		public static function reset_for_tests(): void {
+			self::$instance = null;
+		}
+
+		/**
+		 * Wakeup magic method.
+		 *
+		 * @throws LogicException If the registry object is unserialized.
+		 */
+		public function __wakeup(): void {
+			throw new LogicException( __CLASS__ . ' should never be unserialized.' );
+		}
+
+		/**
+		 * Sleep magic method.
+		 *
+		 * @throws LogicException If the registry object is serialized.
+		 */
+		public function __sleep(): array {
+			throw new LogicException( __CLASS__ . ' should never be serialized.' );
+		}
+
+		/**
+		 * Emit a WordPress-style invalid-usage notice when available.
+		 *
+		 * @param string $function_name Function or method name.
+		 * @param string $message       Notice message.
+		 * @return void
+		 */
+		private function notice_invalid_registration( string $function_name, string $message ): void {
+			if ( function_exists( '_doing_it_wrong' ) ) {
+				$function_name = function_exists( 'esc_html' ) ? esc_html( $function_name ) : $function_name;
+				$message       = function_exists( 'esc_html' ) ? esc_html( $message ) : $message;
+				_doing_it_wrong( $function_name, $message, '0.102.8' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- _doing_it_wrong receives a message, not direct output.
+			}
+		}
+	}
+}

--- a/agents-api/inc/class-wp-agent-package.php
+++ b/agents-api/inc/class-wp-agent-package.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'WP_Agent_Package' ) ) {
 		/**
 		 * Generic artifact definitions.
 		 *
-		 * @var array<int, array<string, string>>
+		 * @var array<int, WP_Agent_Package_Artifact>
 		 */
 		private array $artifacts = array();
 
@@ -136,7 +136,7 @@ if ( ! class_exists( 'WP_Agent_Package' ) ) {
 		/**
 		 * Retrieves artifact definitions.
 		 *
-		 * @return array<int, array<string, string>>
+		 * @return array<int, WP_Agent_Package_Artifact>
 		 */
 		public function get_artifacts(): array {
 			return $this->artifacts;
@@ -162,7 +162,12 @@ if ( ! class_exists( 'WP_Agent_Package' ) ) {
 				'version'      => $this->version,
 				'agent'        => $this->agent->to_array(),
 				'capabilities' => $this->capabilities,
-				'artifacts'    => $this->artifacts,
+				'artifacts'    => array_map(
+					static function ( WP_Agent_Package_Artifact $artifact ): array {
+						return $artifact->to_array();
+					},
+					$this->artifacts
+				),
 				'meta'         => $this->meta,
 			);
 		}
@@ -238,7 +243,7 @@ if ( ! class_exists( 'WP_Agent_Package' ) ) {
 		 * Prepares artifact declarations.
 		 *
 		 * @param mixed $artifacts Raw artifacts.
-		 * @return array<int, array<string, string>>
+		 * @return array<int, WP_Agent_Package_Artifact>
 		 */
 		private function prepare_artifacts( $artifacts ): array {
 			if ( ! is_array( $artifacts ) ) {
@@ -247,31 +252,22 @@ if ( ! class_exists( 'WP_Agent_Package' ) ) {
 
 			$prepared = array();
 			foreach ( $artifacts as $artifact ) {
+				if ( $artifact instanceof WP_Agent_Package_Artifact ) {
+					$prepared[] = $artifact;
+					continue;
+				}
+
 				if ( ! is_array( $artifact ) ) {
 					throw new InvalidArgumentException( 'Agent package artifacts must be objects.' );
 				}
 
-				$type = sanitize_title( (string) ( $artifact['type'] ?? '' ) );
-				$slug = sanitize_title( (string) ( $artifact['slug'] ?? '' ) );
-				if ( '' === $type || '' === $slug ) {
-					throw new InvalidArgumentException( 'Agent package artifacts require type and slug.' );
-				}
-
-				$row = array(
-					'type'        => $type,
-					'slug'        => $slug,
-					'label'       => isset( $artifact['label'] ) ? trim( (string) $artifact['label'] ) : $slug,
-					'description' => isset( $artifact['description'] ) ? trim( (string) $artifact['description'] ) : '',
-					'source'      => isset( $artifact['source'] ) ? trim( (string) $artifact['source'] ) : '',
-				);
-
-				$prepared[] = $row;
+				$prepared[] = new WP_Agent_Package_Artifact( $artifact );
 			}
 
 			usort(
 				$prepared,
-				static function ( array $a, array $b ): int {
-					return array( $a['type'], $a['slug'] ) <=> array( $b['type'], $b['slug'] );
+				static function ( WP_Agent_Package_Artifact $a, WP_Agent_Package_Artifact $b ): int {
+					return array( $a->get_type(), $a->get_slug() ) <=> array( $b->get_type(), $b->get_slug() );
 				}
 			);
 

--- a/agents-api/inc/register-agent-package-artifacts.php
+++ b/agents-api/inc/register-agent-package-artifacts.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Agent package artifact type registration helpers.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'wp_register_agent_package_artifact_type' ) ) {
+	/**
+	 * Register an agent package artifact type.
+	 *
+	 * Call from inside a `wp_agent_package_artifacts_init` action callback. The
+	 * registry collects type metadata without deciding when lifecycle callbacks run.
+	 *
+	 * @param string|WP_Agent_Package_Artifact_Type $type Artifact type slug or object.
+	 * @param array                                 $args Registration arguments.
+	 * @return WP_Agent_Package_Artifact_Type|null Registered artifact type, or null on invalid arguments.
+	 */
+	function wp_register_agent_package_artifact_type( $type, array $args = array() ): ?WP_Agent_Package_Artifact_Type {
+		$slug = $type instanceof WP_Agent_Package_Artifact_Type ? $type->get_type() : (string) $type;
+		if ( ! doing_action( 'wp_agent_package_artifacts_init' ) ) {
+			_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					'Agent package artifact types must be registered on the %1$s action. The artifact type %2$s was not registered.',
+					'<code>wp_agent_package_artifacts_init</code>',
+					'<code>' . esc_html( $slug ) . '</code>'
+				),
+				'0.102.8'
+			);
+			return null;
+		}
+
+		$registry = WP_Agent_Package_Artifacts_Registry::get_instance();
+		if ( null === $registry ) {
+			return null;
+		}
+
+		return $registry->register( $type, $args );
+	}
+}
+
+if ( ! function_exists( 'wp_get_agent_package_artifact_type' ) ) {
+	/**
+	 * Retrieves a registered agent package artifact type.
+	 *
+	 * @param string $type Artifact type slug.
+	 * @return WP_Agent_Package_Artifact_Type|null Registered type, or null when not registered.
+	 */
+	function wp_get_agent_package_artifact_type( string $type ): ?WP_Agent_Package_Artifact_Type {
+		$registry = WP_Agent_Package_Artifacts_Registry::get_instance();
+		if ( null === $registry ) {
+			return null;
+		}
+
+		return $registry->get_registered( $type );
+	}
+}
+
+if ( ! function_exists( 'wp_get_agent_package_artifact_types' ) ) {
+	/**
+	 * Retrieves all registered agent package artifact types.
+	 *
+	 * @return array<string, WP_Agent_Package_Artifact_Type>
+	 */
+	function wp_get_agent_package_artifact_types(): array {
+		$registry = WP_Agent_Package_Artifacts_Registry::get_instance();
+		if ( null === $registry ) {
+			return array();
+		}
+
+		return $registry->get_all_registered();
+	}
+}
+
+if ( ! function_exists( 'wp_has_agent_package_artifact_type' ) ) {
+	/**
+	 * Checks whether an agent package artifact type is registered.
+	 *
+	 * @param string $type Artifact type slug.
+	 * @return bool
+	 */
+	function wp_has_agent_package_artifact_type( string $type ): bool {
+		$registry = WP_Agent_Package_Artifacts_Registry::get_instance();
+		if ( null === $registry ) {
+			return false;
+		}
+
+		return $registry->is_registered( $type );
+	}
+}
+
+if ( ! function_exists( 'wp_unregister_agent_package_artifact_type' ) ) {
+	/**
+	 * Unregisters an agent package artifact type.
+	 *
+	 * @param string $type Artifact type slug.
+	 * @return WP_Agent_Package_Artifact_Type|null Removed type, or null when not registered.
+	 */
+	function wp_unregister_agent_package_artifact_type( string $type ): ?WP_Agent_Package_Artifact_Type {
+		$registry = WP_Agent_Package_Artifacts_Registry::get_instance();
+		if ( null === $registry ) {
+			return null;
+		}
+
+		return $registry->unregister( $type );
+	}
+}

--- a/tests/agents-api-bootstrap-smoke.php
+++ b/tests/agents-api-bootstrap-smoke.php
@@ -37,8 +37,16 @@ agents_api_smoke_assert_equals( true, function_exists( 'wp_get_agent' ), 'wp_get
 agents_api_smoke_assert_equals( true, function_exists( 'wp_get_agents' ), 'wp_get_agents helper is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, function_exists( 'wp_has_agent' ), 'wp_has_agent helper is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, function_exists( 'wp_unregister_agent' ), 'wp_unregister_agent helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_register_agent_package_artifact_type' ), 'wp_register_agent_package_artifact_type helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_get_agent_package_artifact_type' ), 'wp_get_agent_package_artifact_type helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_get_agent_package_artifact_types' ), 'wp_get_agent_package_artifact_types helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_has_agent_package_artifact_type' ), 'wp_has_agent_package_artifact_type helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_unregister_agent_package_artifact_type' ), 'wp_unregister_agent_package_artifact_type helper is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent' ), 'WP_Agent value object is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agents_Registry' ), 'WP_Agents_Registry facade is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Artifact' ), 'WP_Agent_Package_Artifact value object is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Artifact_Type' ), 'WP_Agent_Package_Artifact_Type value object is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Artifacts_Registry' ), 'WP_Agent_Package_Artifacts_Registry facade is available', $failures, $passes );
 foreach ( $namespace_map as $legacy_class => $target_class ) {
 	agents_api_smoke_assert_equals( true, class_exists( $target_class ) || interface_exists( $target_class ), $target_class . ' contract is available', $failures, $passes );
 	agents_api_smoke_assert_equals( false, class_exists( $legacy_class, false ) || interface_exists( $legacy_class, false ), $legacy_class . ' compatibility alias is not loaded', $failures, $passes );

--- a/tests/agents-api-package-contract-smoke.php
+++ b/tests/agents-api-package-contract-smoke.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Pure-PHP smoke test for Agents API package/adoption contract (#1686).
+ * Pure-PHP smoke test for Agents API package/adoption contract (#1686, #1688).
  *
  * Run with: php tests/agents-api-package-contract-smoke.php
  *
@@ -14,6 +14,15 @@ echo "agents-api-package-contract-smoke\n";
 
 require_once __DIR__ . '/agents-api-smoke-helpers.php';
 agents_api_smoke_require_module();
+
+function agents_api_package_artifacts_reset(): void {
+	WP_Agent_Package_Artifacts_Registry::reset_for_tests();
+	$GLOBALS['__agents_api_smoke_actions'] = array();
+	$GLOBALS['__agents_api_smoke_wrong']   = array();
+	$GLOBALS['__agents_api_smoke_current'] = array();
+	$GLOBALS['__agents_api_smoke_done']    = array();
+	do_action( 'init' );
+}
 
 echo "\n[1] Package manifests normalize generic agent metadata:\n";
 $package = WP_Agent_Package::from_array(
@@ -38,16 +47,21 @@ $package = WP_Agent_Package::from_array(
 		'capabilities' => array( 'knowledge.read', 'knowledge.write', 'knowledge.read' ),
 		'artifacts'    => array(
 			array(
-				'type'        => 'prompt',
+				'type'        => 'intelligence/brain',
 				'slug'        => 'Historical Synthesis',
 				'label'       => 'Historical synthesis',
 				'description' => 'Converts source packets into grounded wiki notes.',
-				'source'      => 'prompts/historical-synthesis.md',
+				'source'      => 'brains/historical-synthesis.json',
+				'checksum'    => 'sha256:abc123',
+				'requires'    => array( 'intelligence', 'intelligence' ),
+				'meta'        => array( 'root' => 'wordpress-com' ),
 			),
 			array(
-				'type'   => 'memory',
-				'slug'   => 'Source Notes',
-				'source' => 'memory/MEMORY.md',
+				'type'        => 'datamachine/flow',
+				'slug'        => 'Source Notes',
+				'label'       => 'Source notes',
+				'description' => 'Loops through source windows.',
+				'source'      => 'artifacts/source-notes.json',
 			),
 		),
 		'meta'         => array(
@@ -63,8 +77,11 @@ agents_api_smoke_assert_equals( 'wordpress-com-wiki', $package->get_agent()->get
 agents_api_smoke_assert_equals( 'WordPress.com Wiki', $package->get_agent()->get_label(), 'agent label is preserved', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'knowledge.read', 'knowledge.write' ), $package->get_capabilities(), 'capabilities are deduped and sorted', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'SOUL.md' => 'memory/SOUL.md', 'MEMORY.md' => 'memory/MEMORY.md' ), $package->get_agent()->get_memory_seeds(), 'agent memory seeds use existing WP_Agent validation', $failures, $passes );
-agents_api_smoke_assert_equals( 'memory', $manifest['artifacts'][0]['type'], 'artifacts sort deterministically by type', $failures, $passes );
-agents_api_smoke_assert_equals( 'prompt', $manifest['artifacts'][1]['type'], 'prompt artifact is generic package metadata', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Package_Artifact::class, get_class( $package->get_artifacts()[0] ), 'package artifacts normalize to artifact objects', $failures, $passes );
+agents_api_smoke_assert_equals( 'datamachine/flow', $manifest['artifacts'][0]['type'], 'artifacts preserve typed namespaced slugs', $failures, $passes );
+agents_api_smoke_assert_equals( 'intelligence/brain', $manifest['artifacts'][1]['type'], 'package carries another typed artifact without importing product code', $failures, $passes );
+agents_api_smoke_assert_equals( 'sha256:abc123', $manifest['artifacts'][1]['checksum'], 'artifact checksum is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'intelligence' ), $manifest['artifacts'][1]['requires'], 'artifact requires list is deduped', $failures, $passes );
 agents_api_smoke_assert_equals( 'wordpress-com', $package->get_agent()->get_meta()['domain'] ?? '', 'agent meta can describe a domain without product vocabulary', $failures, $passes );
 
 echo "\n[2] Invalid package manifests fail before materialization:\n";
@@ -94,11 +111,61 @@ try {
 		)
 	);
 } catch ( InvalidArgumentException $e ) {
-	$threw = str_contains( $e->getMessage(), 'artifacts require type and slug' );
+	$threw = str_contains( $e->getMessage(), 'type must be a namespaced slug' );
 }
 agents_api_smoke_assert_equals( true, $threw, 'malformed artifact is rejected', $failures, $passes );
 
-echo "\n[3] Adopter contracts stay runtime-neutral:\n";
+echo "\n[3] Artifact type registry mirrors agent registration lifecycle:\n";
+agents_api_package_artifacts_reset();
+$validate_callback = static function ( WP_Agent_Package_Artifact $artifact ): bool {
+	return '' !== $artifact->get_source();
+};
+$diff_callback     = static function (): array {
+	return array( 'status' => 'changed' );
+};
+add_action(
+	'wp_agent_package_artifacts_init',
+	static function () use ( $validate_callback, $diff_callback ): void {
+		wp_register_agent_package_artifact_type(
+			'datamachine/flow',
+			array(
+				'label'             => 'Package flow artifact',
+				'description'       => 'Registered by a product plugin.',
+				'validate_callback' => $validate_callback,
+				'diff_callback'     => $diff_callback,
+				'import_callback'   => static fn() => 'imported',
+				'delete_callback'   => static fn() => 'deleted',
+				'meta'              => array( 'owner' => 'example' ),
+			)
+		);
+		wp_register_agent_package_artifact_type( 'intelligence/brain', array( 'label' => 'Brain artifact' ) );
+		wp_register_agent_package_artifact_type( 'datamachine/flow', array( 'label' => 'Duplicate' ) );
+		wp_register_agent_package_artifact_type( 'broken', array( 'label' => 'Broken' ) );
+		wp_register_agent_package_artifact_type( 'example/bad-callback', array( 'validate_callback' => 'not callable' ) );
+	}
+);
+
+$artifact_types = wp_get_agent_package_artifact_types();
+$artifact_type  = wp_get_agent_package_artifact_type( 'DATAMACHINE/FLOW' );
+agents_api_smoke_assert_equals( array( 'datamachine/flow', 'intelligence/brain' ), array_keys( $artifact_types ), 'artifact type slugs are normalized and collected', $failures, $passes );
+agents_api_smoke_assert_equals( true, $artifact_type instanceof WP_Agent_Package_Artifact_Type, 'artifact type getter returns object', $failures, $passes );
+agents_api_smoke_assert_equals( 'Package flow artifact', $artifact_type ? $artifact_type->get_label() : '', 'artifact type label is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( true, is_callable( $artifact_type ? $artifact_type->get_validate_callback() : null ), 'validate callback is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( true, is_callable( $artifact_type ? $artifact_type->get_diff_callback() : null ), 'diff callback is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( true, is_callable( $artifact_type ? $artifact_type->get_import_callback() : null ), 'import callback is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( true, is_callable( $artifact_type ? $artifact_type->get_delete_callback() : null ), 'delete callback is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'owner' => 'example' ), $artifact_type ? $artifact_type->get_meta() : array(), 'artifact type meta is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_agent_package_artifact_type( 'datamachine/flow' ), 'wp_has_agent_package_artifact_type reports registered slug', $failures, $passes );
+agents_api_smoke_assert_equals( false, wp_has_agent_package_artifact_type( 'broken' ), 'invalid unnamespaced type is rejected', $failures, $passes );
+agents_api_smoke_assert_equals( 3, count( $GLOBALS['__agents_api_smoke_wrong'] ), 'duplicate and invalid type registrations emit notices', $failures, $passes );
+$removed = wp_unregister_agent_package_artifact_type( 'intelligence/brain' );
+agents_api_smoke_assert_equals( true, $removed instanceof WP_Agent_Package_Artifact_Type, 'unregister returns removed artifact type', $failures, $passes );
+agents_api_smoke_assert_equals( false, wp_has_agent_package_artifact_type( 'intelligence/brain' ), 'unregister removes artifact type', $failures, $passes );
+$GLOBALS['__agents_api_smoke_wrong'] = array();
+wp_register_agent_package_artifact_type( 'outside/hook', array( 'label' => 'Outside Hook' ) );
+agents_api_smoke_assert_equals( 1, count( $GLOBALS['__agents_api_smoke_wrong'] ), 'outside-hook direct artifact type registration is rejected', $failures, $passes );
+
+echo "\n[4] Adopter contracts stay runtime-neutral:\n";
 class Agents_API_Package_Smoke_Adopter implements WP_Agent_Package_Adopter_Interface {
 	public function diff( WP_Agent_Package $package ): WP_Agent_Package_Adoption_Diff {
 		return new WP_Agent_Package_Adoption_Diff(
@@ -127,12 +194,16 @@ agents_api_smoke_assert_equals( 'agent', $diff->get_changes()[0]['type'] ?? '', 
 agents_api_smoke_assert_equals( 'adopted', $result->get_status(), 'adopter result exposes generic status', $failures, $passes );
 agents_api_smoke_assert_equals( 'wordpress-com-wiki', $result->get_agent_slug(), 'adopter result references normalized agent slug', $failures, $passes );
 
-echo "\n[4] Public package contract has no product vocabulary:\n";
+echo "\n[5] Public package contract has no product vocabulary:\n";
 $contract_files = array(
 	'agents-api/inc/class-wp-agent-package.php',
+	'agents-api/inc/class-wp-agent-package-artifact.php',
+	'agents-api/inc/class-wp-agent-package-artifact-type.php',
+	'agents-api/inc/class-wp-agent-package-artifacts-registry.php',
 	'agents-api/inc/class-wp-agent-package-adopter-interface.php',
 	'agents-api/inc/class-wp-agent-package-adoption-diff.php',
 	'agents-api/inc/class-wp-agent-package-adoption-result.php',
+	'agents-api/inc/register-agent-package-artifacts.php',
 );
 $forbidden = array( 'DataMachine\\', 'pipeline', 'flow', 'job', 'handler', 'Intelligence', 'wpcom', 'Dolly', 'Odie' );
 $matches   = array();

--- a/tests/agents-api-package-contract-smoke.php
+++ b/tests/agents-api-package-contract-smoke.php
@@ -115,6 +115,34 @@ try {
 }
 agents_api_smoke_assert_equals( true, $threw, 'malformed artifact is rejected', $failures, $passes );
 
+$threw = false;
+try {
+	WP_Agent_Package::from_array(
+		array(
+			'slug'      => 'valid-package',
+			'agent'     => array( 'slug' => 'valid-agent' ),
+			'artifacts' => array( array( 'type' => 'example/file', 'slug' => 'bad-source', 'source' => '../outside.json' ) ),
+		)
+	);
+} catch ( InvalidArgumentException $e ) {
+	$threw = str_contains( $e->getMessage(), 'source cannot contain parent directory segments' );
+}
+agents_api_smoke_assert_equals( true, $threw, 'artifact source rejects traversal', $failures, $passes );
+
+$threw = false;
+try {
+	WP_Agent_Package::from_array(
+		array(
+			'slug'      => 'valid-package',
+			'agent'     => array( 'slug' => 'valid-agent' ),
+			'artifacts' => array( array( 'type' => 'example/file', 'slug' => 'absolute-source', 'source' => '/tmp/outside.json' ) ),
+		)
+	);
+} catch ( InvalidArgumentException $e ) {
+	$threw = str_contains( $e->getMessage(), 'source must be relative to the package' );
+}
+agents_api_smoke_assert_equals( true, $threw, 'artifact source rejects absolute paths', $failures, $passes );
+
 echo "\n[3] Artifact type registry mirrors agent registration lifecycle:\n";
 agents_api_package_artifacts_reset();
 $validate_callback = static function ( WP_Agent_Package_Artifact $artifact ): bool {


### PR DESCRIPTION
## Summary

- Adds a Core-shaped typed artifact registry for `WP_Agent_Package` artifacts.
- Normalizes package artifact declarations into `WP_Agent_Package_Artifact` objects while keeping exported manifests array-shaped.
- Adds focused smoke coverage for typed package artifacts that remain product-neutral across Data Machine and Intelligence artifact examples.

## Changes

- Introduces `WP_Agent_Package_Artifact`, `WP_Agent_Package_Artifact_Type`, and `WP_Agent_Package_Artifacts_Registry` under `agents-api/inc/`.
- Adds public helpers: `wp_register_agent_package_artifact_type()`, `wp_get_agent_package_artifact_type()`, `wp_get_agent_package_artifact_types()`, `wp_has_agent_package_artifact_type()`, and `wp_unregister_agent_package_artifact_type()`.
- Adds the `wp_agent_package_artifacts_init` registration hook.
- Updates `WP_Agent_Package` to store artifacts as typed value objects and export normalized arrays.
- Validates artifact `source` as a package-relative path, rejecting absolute paths and parent-directory traversal.
- Expands Agents API bootstrap/package smokes to cover the new public surface and product-vocabulary boundary.

## Tests

- `php -l agents-api/agents-api.php`
- `php -l agents-api/inc/class-wp-agent-package.php`
- `php -l agents-api/inc/class-wp-agent-package-artifact.php`
- `php -l agents-api/inc/class-wp-agent-package-artifact-type.php`
- `php -l agents-api/inc/class-wp-agent-package-artifacts-registry.php`
- `php -l agents-api/inc/register-agent-package-artifacts.php`
- `php tests/agents-api-package-contract-smoke.php`
- `php tests/agents-api-registration-smoke.php`
- `php tests/agents-api-bootstrap-smoke.php`
- `php tests/agents-api-no-product-imports-smoke.php`
- Scoped `homeboy lint` for changed package artifact files and smoke.

Closes #1688

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the typed package artifact registry substrate, wiring the package artifact value object, writing focused smoke coverage, reviewing/fixing path validation, and running verification. Chris remains responsible for review and merge.
