### PR TITLE
feat(agent): project bundles as agent packages

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -514,7 +514,7 @@ class AgentBundleCommand extends BaseCommand {
 
 	private function output_plan( array $plan, array $assoc_args ): void {
 		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
-			WP_CLI::line( wp_json_encode( $plan, JSON_PRETTY_PRINT ) );
+			WP_CLI::line( (string) wp_json_encode( $plan, JSON_PRETTY_PRINT ) );
 			return;
 		}
 
@@ -543,7 +543,7 @@ class AgentBundleCommand extends BaseCommand {
 
 	private function output( array $value, array $assoc_args, array $table_fields ): void {
 		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
-			WP_CLI::line( wp_json_encode( $value, JSON_PRETTY_PRINT ) );
+			WP_CLI::line( (string) wp_json_encode( $value, JSON_PRETTY_PRINT ) );
 			return;
 		}
 

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -500,13 +500,15 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	private function bundle_summary( array $bundle, string $slug = '' ): array {
-		$agent = is_array( $bundle['agent'] ?? null ) ? $bundle['agent'] : array();
+		$package = AgentBundler::package_from_bundle( $bundle );
+
 		return array(
-			'bundle_slug'    => (string) ( $bundle['bundle_slug'] ?? sanitize_title( (string) ( $agent['agent_slug'] ?? 'agent-bundle' ) ) ),
-			'bundle_version' => (string) ( $bundle['bundle_version'] ?? '' ),
-			'target_slug'    => '' !== $slug ? sanitize_title( $slug ) : sanitize_title( (string) ( $agent['agent_slug'] ?? '' ) ),
+			'bundle_slug'    => $package->get_slug(),
+			'bundle_version' => $package->get_version(),
+			'target_slug'    => '' !== $slug ? sanitize_title( $slug ) : $package->get_agent()->get_slug(),
 			'pipelines'      => count( $bundle['pipelines'] ?? array() ),
 			'flows'          => count( $bundle['flows'] ?? array() ),
+			'artifacts'      => count( $package->get_artifacts() ),
 		);
 	}
 

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -1236,7 +1236,7 @@ class AgentBundler {
 	 * @return string JSON string.
 	 */
 	public function to_json( array $bundle ): string {
-		return wp_json_encode( $bundle, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		return (string) wp_json_encode( $bundle, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 	}
 
 	/**

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -25,6 +25,7 @@ use DataMachine\Engine\Bundle\AgentBundleFlowFile;
 use DataMachine\Engine\Bundle\AgentBundleLegacyAdapter;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
+use DataMachine\Engine\Bundle\AgentPackageProjection;
 use DataMachine\Engine\Bundle\BundleValidationException;
 use DataMachine\Engine\Bundle\PortableSlug;
 
@@ -236,11 +237,34 @@ class AgentBundler {
 			)
 		);
 
+		$directory = new AgentBundleDirectory( $manifest, $memory_files, $pipeline_documents, $flow_documents, array(), $extension_artifacts );
+
 		return array(
 			'success'   => true,
 			'agent'     => $agent,
-			'directory' => new AgentBundleDirectory( $manifest, $memory_files, $pipeline_documents, $flow_documents, array(), $extension_artifacts ),
+			'directory' => $directory,
+			'package'   => AgentPackageProjection::from_directory( $directory ),
 		);
+	}
+
+	/**
+	 * Project a legacy bundle array to the Core-shaped package contract.
+	 *
+	 * @param array<string,mixed> $bundle Legacy bundle array.
+	 * @return \WP_Agent_Package
+	 */
+	public static function package_from_bundle( array $bundle ): \WP_Agent_Package {
+		return AgentPackageProjection::from_legacy_bundle( $bundle );
+	}
+
+	/**
+	 * Project a bundle directory to the Core-shaped package contract.
+	 *
+	 * @param AgentBundleDirectory $directory Bundle directory.
+	 * @return \WP_Agent_Package
+	 */
+	public static function package_from_directory( AgentBundleDirectory $directory ): \WP_Agent_Package {
+		return AgentPackageProjection::from_directory( $directory );
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentPackageProjection.php
+++ b/inc/Engine/Bundle/AgentPackageProjection.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Data Machine package projection helpers.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Projects Data Machine bundle documents into Core-shaped agent packages.
+ */
+final class AgentPackageProjection {
+
+	/**
+	 * Build a package from a bundle directory value object.
+	 *
+	 * @param AgentBundleDirectory $directory Bundle directory.
+	 * @return \WP_Agent_Package
+	 */
+	public static function from_directory( AgentBundleDirectory $directory ): \WP_Agent_Package {
+		$manifest = $directory->manifest()->to_array();
+
+		return \WP_Agent_Package::from_array(
+			array(
+				'slug'      => (string) $manifest['bundle_slug'],
+				'version'   => (string) $manifest['bundle_version'],
+				'agent'     => self::agent_from_manifest( $manifest ),
+				'artifacts' => self::artifacts_from_directory( $directory ),
+				'meta'      => self::meta_from_manifest( $manifest ),
+			)
+		);
+	}
+
+	/**
+	 * Build a package from a legacy bundle array.
+	 *
+	 * @param array<string,mixed> $bundle Legacy bundle array.
+	 * @return \WP_Agent_Package
+	 */
+	public static function from_legacy_bundle( array $bundle ): \WP_Agent_Package {
+		return self::from_directory( AgentBundleLegacyAdapter::from_legacy_bundle( $bundle ) );
+	}
+
+	/**
+	 * Build agent package metadata from a bundle manifest.
+	 *
+	 * @param array<string,mixed> $manifest Bundle manifest.
+	 * @return array<string,mixed>
+	 */
+	private static function agent_from_manifest( array $manifest ): array {
+		$agent = is_array( $manifest['agent'] ?? null ) ? $manifest['agent'] : array();
+
+		return array(
+			'slug'           => (string) ( $agent['slug'] ?? '' ),
+			'label'          => (string) ( $agent['label'] ?? ( $agent['slug'] ?? '' ) ),
+			'description'    => (string) ( $agent['description'] ?? '' ),
+			'default_config' => is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array(),
+			'meta'           => array(
+				'package_source' => 'data-machine',
+			),
+		);
+	}
+
+	/**
+	 * Build package metadata from a bundle manifest.
+	 *
+	 * @param array<string,mixed> $manifest Bundle manifest.
+	 * @return array<string,mixed>
+	 */
+	private static function meta_from_manifest( array $manifest ): array {
+		return array(
+			'schema_version'  => (int) ( $manifest['schema_version'] ?? BundleSchema::VERSION ),
+			'exported_at'     => (string) ( $manifest['exported_at'] ?? '' ),
+			'exported_by'     => (string) ( $manifest['exported_by'] ?? '' ),
+			'source_ref'      => (string) ( $manifest['source_ref'] ?? '' ),
+			'source_revision' => (string) ( $manifest['source_revision'] ?? '' ),
+			'included'        => is_array( $manifest['included'] ?? null ) ? $manifest['included'] : array(),
+			'materializer'    => 'data-machine',
+		);
+	}
+
+	/**
+	 * Build typed artifact declarations from Data Machine bundle documents.
+	 *
+	 * @param AgentBundleDirectory $directory Bundle directory.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function artifacts_from_directory( AgentBundleDirectory $directory ): array {
+		$artifacts = array();
+
+		foreach ( $directory->pipelines() as $pipeline ) {
+			$document    = $pipeline->to_array();
+			$artifacts[] = self::artifact(
+				'datamachine/pipeline',
+				(string) $document['slug'],
+				(string) $document['name'],
+				BundleSchema::PIPELINES_DIR . '/' . $document['slug'] . '.json',
+				array( 'step_count' => count( is_array( $document['steps'] ?? null ) ? $document['steps'] : array() ) )
+			);
+		}
+
+		foreach ( $directory->flows() as $flow ) {
+			$document    = $flow->to_array();
+			$artifacts[] = self::artifact(
+				'datamachine/flow',
+				(string) $document['slug'],
+				(string) $document['name'],
+				BundleSchema::FLOWS_DIR . '/' . $document['slug'] . '.json',
+				array(
+					'pipeline_slug' => (string) ( $document['pipeline_slug'] ?? '' ),
+					'step_count'    => count( is_array( $document['steps'] ?? null ) ? $document['steps'] : array() ),
+				)
+			);
+		}
+
+		foreach ( self::artifact_file_maps( $directory ) as $directory_name => $definition ) {
+			foreach ( $definition['files'] as $relative_path => $payload ) {
+				$slug        = self::slug_from_path( (string) $relative_path );
+				$artifacts[] = self::artifact(
+					$definition['type'],
+					$slug,
+					$slug,
+					$directory_name . '/' . ltrim( (string) $relative_path, '/' ),
+					array( 'payload_kind' => is_array( $payload ) ? 'json' : 'text' )
+				);
+			}
+		}
+
+		return $artifacts;
+	}
+
+	/**
+	 * Build artifact file directory definitions.
+	 *
+	 * @param AgentBundleDirectory $directory Bundle directory.
+	 * @return array<string,array{type:string,files:array<string,array|string>}>
+	 */
+	private static function artifact_file_maps( AgentBundleDirectory $directory ): array {
+		return array(
+			BundleSchema::PROMPTS_DIR       => array(
+				'type'  => 'datamachine/prompt',
+				'files' => $directory->prompts(),
+			),
+			BundleSchema::RUBRICS_DIR       => array(
+				'type'  => 'datamachine/rubric',
+				'files' => $directory->rubrics(),
+			),
+			BundleSchema::TOOL_POLICIES_DIR => array(
+				'type'  => 'datamachine/tool-policy',
+				'files' => $directory->tool_policies(),
+			),
+			BundleSchema::AUTH_REFS_DIR     => array(
+				'type'  => 'datamachine/auth-ref',
+				'files' => $directory->auth_refs(),
+			),
+			BundleSchema::SEED_QUEUES_DIR   => array(
+				'type'  => 'datamachine/queue-seed',
+				'files' => $directory->seed_queues(),
+			),
+		);
+	}
+
+	/**
+	 * Build an artifact declaration.
+	 *
+	 * @param string              $type   Artifact type.
+	 * @param string              $slug   Artifact slug.
+	 * @param string              $label  Artifact label.
+	 * @param string              $source Source path.
+	 * @param array<string,mixed> $meta   Artifact metadata.
+	 * @return array<string,mixed>
+	 */
+	private static function artifact( string $type, string $slug, string $label, string $source, array $meta = array() ): array {
+		return array(
+			'type'   => $type,
+			'slug'   => $slug,
+			'label'  => $label,
+			'source' => $source,
+			'meta'   => array_merge(
+				array(
+					'materializer' => 'data-machine',
+				),
+				$meta
+			),
+		);
+	}
+
+	/**
+	 * Build an artifact slug from a package-relative path.
+	 *
+	 * @param string $path Relative path.
+	 * @return string
+	 */
+	private static function slug_from_path( string $path ): string {
+		$basename = basename( str_replace( '\\', '/', $path ) );
+		$slug     = preg_replace( '/\.[^.]+$/', '', $basename );
+
+		return is_string( $slug ) && '' !== $slug ? $slug : $basename;
+	}
+}

--- a/inc/Engine/Bundle/register-agent-package-artifacts.php
+++ b/inc/Engine/Bundle/register-agent-package-artifacts.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Data Machine agent package artifact type registrations.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_agent_package_artifacts_init', __NAMESPACE__ . '\register_datamachine_agent_package_artifact_types' );
+
+/**
+ * Register Data Machine-owned agent package artifact types.
+ *
+ * @return void
+ */
+function register_datamachine_agent_package_artifact_types(): void {
+	if ( ! function_exists( 'wp_register_agent_package_artifact_type' ) ) {
+		return;
+	}
+
+	foreach ( datamachine_agent_package_artifact_type_definitions() as $type => $args ) {
+		wp_register_agent_package_artifact_type( $type, $args );
+	}
+}
+
+/**
+ * Data Machine package artifact type metadata.
+ *
+ * @return array<string,array<string,string>>
+ */
+function datamachine_agent_package_artifact_type_definitions(): array {
+	return array(
+		'datamachine/pipeline'    => array(
+			'label'       => 'Data Machine pipeline',
+			'description' => 'A portable Data Machine pipeline document.',
+		),
+		'datamachine/flow'        => array(
+			'label'       => 'Data Machine flow',
+			'description' => 'A portable Data Machine flow document.',
+		),
+		'datamachine/prompt'      => array(
+			'label'       => 'Data Machine prompt',
+			'description' => 'A reusable prompt artifact owned by Data Machine materialization.',
+		),
+		'datamachine/rubric'      => array(
+			'label'       => 'Data Machine rubric',
+			'description' => 'A reusable rubric artifact owned by Data Machine materialization.',
+		),
+		'datamachine/tool-policy' => array(
+			'label'       => 'Data Machine tool policy',
+			'description' => 'A portable tool policy artifact for Data Machine package installs.',
+		),
+		'datamachine/auth-ref'    => array(
+			'label'       => 'Data Machine auth reference',
+			'description' => 'A portable auth reference artifact resolved by Data Machine during install.',
+		),
+		'datamachine/queue-seed'  => array(
+			'label'       => 'Data Machine queue seed',
+			'description' => 'A portable queue seed artifact for Data Machine flow setup.',
+		),
+	);
+}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -51,6 +51,7 @@ require_once __DIR__ . '/Api/StepTypes.php';
 require_once __DIR__ . '/Api/Handlers.php';
 require_once __DIR__ . '/Api/Tools.php';
 require_once __DIR__ . '/Api/Chat/ChatFilters.php';
+require_once __DIR__ . '/Engine/Bundle/register-agent-package-artifacts.php';
 require_once __DIR__ . '/Engine/Bundle/AgentBundleUpgradeActionHandlers.php';
 require_once __DIR__ . '/Engine/AI/Directives/CoreMemoryFilesDirective.php';
 require_once __DIR__ . '/Engine/AI/Directives/AgentModeDirective.php';

--- a/tests/datamachine-package-artifacts-smoke.php
+++ b/tests/datamachine-package-artifacts-smoke.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Pure-PHP smoke test for Data Machine package artifact projection (#1689).
+ *
+ * Run with: php tests/datamachine-package-artifacts-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failures = array();
+$passes   = 0;
+
+echo "datamachine-package-artifacts-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+agents_api_smoke_require_module();
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/register-agent-package-artifacts.php';
+
+use DataMachine\Core\Agents\AgentBundler;
+use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\AgentBundleFlowFile;
+use DataMachine\Engine\Bundle\AgentBundleLegacyAdapter;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
+use DataMachine\Engine\Bundle\AgentPackageProjection;
+use DataMachine\Engine\Bundle\BundleSchema;
+
+function datamachine_package_smoke_reset_registry(): void {
+	do_action( 'init' );
+	WP_Agent_Package_Artifacts_Registry::reset_for_tests();
+}
+
+function datamachine_package_smoke_artifacts_by_type( WP_Agent_Package $package ): array {
+	$indexed = array();
+	foreach ( $package->get_artifacts() as $artifact ) {
+		$indexed[ $artifact->get_type() . ':' . $artifact->get_slug() ] = $artifact->to_array();
+	}
+	ksort( $indexed, SORT_STRING );
+	return $indexed;
+}
+
+echo "\n[1] Data Machine registers package artifact types through the generic registry:\n";
+datamachine_package_smoke_reset_registry();
+$registered_types = wp_get_agent_package_artifact_types();
+$pipeline_type    = $registered_types['datamachine/pipeline'] ?? null;
+agents_api_smoke_assert_equals( true, wp_has_agent_package_artifact_type( 'datamachine/pipeline' ), 'pipeline artifact type is registered', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_agent_package_artifact_type( 'datamachine/flow' ), 'flow artifact type is registered', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_agent_package_artifact_type( 'datamachine/queue-seed' ), 'queue seed artifact type is registered', $failures, $passes );
+agents_api_smoke_assert_equals( 'Data Machine pipeline', $pipeline_type instanceof WP_Agent_Package_Artifact_Type ? $pipeline_type->get_label() : '', 'registered type carries Data Machine metadata outside agents-api', $failures, $passes );
+
+echo "\n[2] Bundle directories project to Core-shaped WP_Agent_Package identity:\n";
+$directory = new AgentBundleDirectory(
+	new AgentBundleManifest(
+		'2026-04-30T12:00:00Z',
+		'data-machine/test',
+		'WooCommerce Wiki Package',
+		'2026.04.30',
+		'refs/heads/main',
+		'abc123',
+		array(
+			'slug'         => 'WooCommerce Agent',
+			'label'        => 'WooCommerce Agent',
+			'description'  => 'Maintains generated WooCommerce knowledge.',
+			'agent_config' => array( 'mode_models' => array( 'pipeline' => 'gpt-5.4' ) ),
+		),
+		array(
+			'memory'        => array( 'agent/SOUL.md' ),
+			'pipelines'     => array( 'daily-ingest' ),
+			'flows'         => array( 'daily-ingest-flow' ),
+			'prompts'       => array( 'extract-facts' ),
+			'rubrics'       => array( 'wiki-quality' ),
+			'tool_policies' => array( 'read-only-context' ),
+			'auth_refs'     => array( 'github-default' ),
+			'seed_queues'   => array( 'mgs-topic-loop' ),
+			'extensions'    => array(),
+			'handler_auth'  => 'refs',
+		)
+	),
+	array( 'agent/SOUL.md' => "# Agent\n" ),
+	array(
+		new AgentBundlePipelineFile(
+			'daily-ingest',
+			'Daily ingest',
+			array(
+				array(
+					'step_position' => 0,
+					'step_type'     => 'fetch',
+					'step_config'   => array( 'step_type' => 'fetch' ),
+				),
+			)
+		),
+	),
+	array(
+		new AgentBundleFlowFile(
+			'daily-ingest-flow',
+			'Daily ingest flow',
+			'daily-ingest',
+			'manual',
+			array( 'per_run' => 5 ),
+			array(
+				array(
+					'step_position'   => 0,
+					'handler_configs' => array(),
+					'step_type'       => 'fetch',
+				),
+			)
+		),
+	),
+	array(
+		BundleSchema::PROMPTS_DIR       => array( 'extract-facts.md' => "Extract facts.\n" ),
+		BundleSchema::RUBRICS_DIR       => array( 'wiki-quality.json' => array( 'min_score' => 4 ) ),
+		BundleSchema::TOOL_POLICIES_DIR => array( 'read-only-context.json' => array( 'allow' => array( 'datamachine/search' ) ) ),
+		BundleSchema::AUTH_REFS_DIR     => array( 'github-default.json' => array( 'ref' => 'github:default' ) ),
+		BundleSchema::SEED_QUEUES_DIR   => array( 'mgs-topic-loop.json' => array( 'mode' => 'loop', 'items' => array( 'HPOS' ) ) ),
+	)
+);
+
+$package   = AgentPackageProjection::from_directory( $directory );
+$artifacts = datamachine_package_smoke_artifacts_by_type( $package );
+agents_api_smoke_assert_equals( 'woocommerce-wiki-package', $package->get_slug(), 'package slug comes from bundle manifest through WP_Agent_Package', $failures, $passes );
+agents_api_smoke_assert_equals( '2026.04.30', $package->get_version(), 'package version comes from WP_Agent_Package', $failures, $passes );
+agents_api_smoke_assert_equals( 'woocommerce-agent', $package->get_agent()->get_slug(), 'agent slug is normalized by WP_Agent', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'pipeline' => 'gpt-5.4' ), $package->get_agent()->get_default_config()['mode_models'] ?? array(), 'agent_config projects to WP_Agent default_config', $failures, $passes );
+agents_api_smoke_assert_equals( 'pipelines/daily-ingest.json', $artifacts['datamachine/pipeline:daily-ingest']['source'] ?? '', 'pipeline artifact keeps package-local source', $failures, $passes );
+agents_api_smoke_assert_equals( 'flows/daily-ingest-flow.json', $artifacts['datamachine/flow:daily-ingest-flow']['source'] ?? '', 'flow artifact keeps package-local source', $failures, $passes );
+agents_api_smoke_assert_equals( 'prompts/extract-facts.md', $artifacts['datamachine/prompt:extract-facts']['source'] ?? '', 'prompt artifact is typed without moving prompt fields into agents-api', $failures, $passes );
+agents_api_smoke_assert_equals( 'seed-queues/mgs-topic-loop.json', $artifacts['datamachine/queue-seed:mgs-topic-loop']['source'] ?? '', 'queue seed artifact is typed as a Data Machine payload', $failures, $passes );
+
+echo "\n[3] Existing bundle paths can read package identity from WP_Agent_Package:\n";
+$legacy_bundle   = AgentBundleLegacyAdapter::to_legacy_bundle( $directory );
+$legacy_package  = AgentBundler::package_from_bundle( $legacy_bundle );
+$command_source  = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/AgentBundleCommand.php' );
+$bundler_source  = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Core/Agents/AgentBundler.php' );
+agents_api_smoke_assert_equals( 'woocommerce-wiki-package', $legacy_package->get_slug(), 'legacy bundle projection preserves package identity', $failures, $passes );
+agents_api_smoke_assert_equals( 'daily-ingest-flow', $legacy_package->get_artifacts()[0]->get_slug(), 'legacy bundle projection preserves typed artifact payloads', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $command_source, 'AgentBundler::package_from_bundle( $bundle )' ), 'package install/diff summary reads identity through WP_Agent_Package', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $bundler_source, '\'package\'   => AgentPackageProjection::from_directory( $directory )' ), 'export directory path exposes package projection alongside Data Machine directory', $failures, $passes );
+
+agents_api_smoke_finish( 'Data Machine package artifact projection', $failures, $passes );


### PR DESCRIPTION
## Summary

- Registers Data Machine-owned `datamachine/*` package artifact types through the generic `WP_Agent_Package` artifact registry.
- Adds a narrow projection from existing Data Machine bundle directory/legacy bundle objects into `WP_Agent_Package` artifacts.
- Routes package install/diff summary identity through `WP_Agent_Package` while preserving existing Data Machine import/diff materialization behavior.

## Changes

- Adds `DataMachine\Engine\Bundle\AgentPackageProjection` to project bundle directories and legacy bundle arrays into `WP_Agent_Package`.
- Registers `datamachine/pipeline`, `datamachine/flow`, `datamachine/prompt`, `datamachine/rubric`, `datamachine/tool-policy`, `datamachine/auth-ref`, and `datamachine/queue-seed` on `wp_agent_package_artifacts_init`.
- Exposes package projections from `AgentBundler` and includes the projection in `export_directory_object()` results.
- Updates `AgentBundleCommand::bundle_summary()` to read package slug/version/agent identity from `WP_Agent_Package`.
- Adds `tests/datamachine-package-artifacts-smoke.php` covering registration, projection, and the real CLI identity path.

## Tests

- `php -l inc/Engine/Bundle/AgentPackageProjection.php && php -l inc/Engine/Bundle/register-agent-package-artifacts.php && php -l inc/Core/Agents/AgentBundler.php && php -l inc/Cli/Commands/AgentBundleCommand.php && php -l tests/datamachine-package-artifacts-smoke.php`
- `php tests/agents-api-package-contract-smoke.php`
- `php tests/agents-api-bootstrap-smoke.php`
- `php tests/agents-api-no-product-imports-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php tests/datamachine-package-artifacts-smoke.php`
- Scoped `homeboy lint --file ... --summary` for all changed files.

Closes #1689

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the Data Machine package projection slice, adding artifact type registration, writing focused smoke coverage, and running verification. Chris remains responsible for review and merge.