### PR TITLE
docs(agents-api): clarify wp-ai-client boundary

### DIFF
--- a/docs/core-system/request-builder.md
+++ b/docs/core-system/request-builder.md
@@ -9,7 +9,7 @@ Centralized AI request construction ensuring consistent request structure across
 
 The `RequestBuilder` class consolidates all AI request building logic into a single, unified interface. This prevents behavioral differences between Pipeline and Chat agents by ensuring both use identical request construction, tool formatting, and directive application patterns.
 
-**Critical Rule**: Never call provider clients directly. Always use `RequestBuilder::build()` to ensure consistent request structure, directive application, metadata, and wp-ai-client dispatch.
+**Critical Rule**: Data Machine runtime code should not bypass its own request assembly. Use `RequestBuilder::build()` for Data Machine chat and pipeline AI steps so directive application, metadata, request guardrails, and wp-ai-client dispatch stay consistent. This rule is not an Agents API boundary: plugins that only need one-shot AI operations may call `wp-ai-client` directly without routing through Data Machine or Agents API.
 
 ## Architecture
 
@@ -31,7 +31,7 @@ Request Building Flow:
 │     • Unified directive management                   │
 │                                                      │
 │  4. Send to wp-ai-client                            │
-│     • WpAiClientAdapter capability gate             │
+│     • RequestBuilder capability gate                │
 │     • Returns standardized AI response              │
 └─────────────────────────────────────────────────────┘
 ```

--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -6,7 +6,7 @@ Parent issue: [Explore splitting Agents API out of Data Machine](https://github.
 
 Strategy update: [Agents API blocker: update extraction docs around in-repo module strategy](https://github.com/Extra-Chill/data-machine/issues/1640)
 
-Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
+Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), [one-shot AI boundary](https://github.com/Extra-Chill/data-machine/issues/1693), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
 
 ## Namespace Map
 
@@ -48,14 +48,15 @@ Treat `data-machine/agents-api/` like WordPress core substrate while it still li
 - Data Machine and other product consumers own any admin/product UI they build on top of the substrate.
 - Later standalone extraction means moving the already-bounded module into its own plugin/repo and adding plugin bootstrap, release, dependency, and distribution ceremony.
 - `ai-http-client` is not future architecture. It is only packaging precedent for bundled-then-extracted code.
-- The future runtime dependency direction is `Data Machine product adapter -> Agents API run request -> wp-ai-client public API`; `ai-http-client` dies as part of [#1027](https://github.com/Extra-Chill/data-machine/issues/1027) / [#1633](https://github.com/Extra-Chill/data-machine/issues/1633).
+- The future provider primitive is `wp-ai-client`, not Agents API. `ai-http-client` dies as part of [#1027](https://github.com/Extra-Chill/data-machine/issues/1027) / [#1633](https://github.com/Extra-Chill/data-machine/issues/1633).
+- One-shot AI operations call `wp-ai-client` directly. Durable agent runs use Agents API, and Agents API provider code consumes `wp-ai-client` directly inside that runtime.
+- Data Machine pipeline AI steps should not move to Agents API solely for provider dispatch. They only need Agents API when the product needs durable runtime semantics such as sessions, locks, memory composition, event sinks, multi-turn tool loops, or portable agent declarations.
 
 ```text
-wp-ai-client public API
-        ↑
-Agents API run request
-        ↑
-Data Machine product adapter
+Abilities API  -> actions and tools
+wp-ai-client   -> provider/model prompt execution
+Agents API     -> durable agent runtime behavior
+Data Machine   -> automation product built on those substrates
 ```
 
 ## Target Vocabulary
@@ -83,6 +84,8 @@ Use these checks before moving anything:
 - If it translates Data Machine concepts into runtime concepts, it is a Data Machine adapter.
 - If it owns flows, jobs, queues, handlers, scheduled automation, retention, admin UI, or content ops, it stays Data Machine product.
 - If it uses host-specific provider, storage, or implementation vocabulary directly, treat that code as source material only until normalized behind WordPress-shaped contracts.
+- If it only needs to execute a single prompt/model request, it should use `wp-ai-client` directly instead of introducing Agents API.
+- If it needs durable agent runtime behavior, it should use Agents API and let that runtime call `wp-ai-client` directly for provider execution.
 
 ## Backend-Only UI Boundary
 
@@ -94,6 +97,7 @@ Agents API is a generic WordPress-shaped substrate. It should be usable by any p
 - runtime request/result/message contracts.
 - memory, transcript, tool, event, and permission-ceiling contracts.
 - direct public WordPress APIs such as Abilities API and `wp-ai-client`.
+- durable agent runtime behavior built above those public APIs.
 
 `agents-api` must not own product/admin surfaces:
 
@@ -157,7 +161,7 @@ The current namespace is intentionally mixed while extraction stays in place. Tr
 | Current namespace/surface | Bucket | Boundary decision |
 |---|---|---|
 | `AgentsAPI\AI\AgentMessageEnvelope`, `AgentsAPI\AI\AgentConversationResult`, plus `DataMachine\Engine\AI\AgentConversationRequest`, `AgentConversationRunnerInterface`, `AgentConversationCompletionPolicyInterface`, `AgentConversationTranscriptPersisterInterface`, `LoopEventSinkInterface` | Agents API public candidate | Generic contracts/value objects. `AgentMessageEnvelope` and `AgentConversationResult` now live in the in-repo `agents-api/` module under neutral namespaces. `AgentConversationRequest` keeps Data Machine job/flow/pipeline/handler/transcript fields in adapter context rather than the generic runtime payload, so it remains outside until that compatibility shape is gone. |
-| `DataMachine\Engine\AI\BuiltInAgentConversationRunner`, `AIConversationLoop`, `RequestBuilder`, `WpAiClientAdapter`, `RequestInspector`, `RequestMetadata`, `ConversationManager` | Agents API implementation candidate | Runtime implementation candidates, but still hosted by Data Machine and still carrying compatibility/provider/logging assumptions. Future provider direction is `wp-ai-client`; `ai-http-client` is removal work, not an Agents API runtime layer. |
+| `DataMachine\Engine\AI\BuiltInAgentConversationRunner`, `AIConversationLoop`, `RequestBuilder`, `RequestInspector`, `RequestMetadata`, `ConversationManager` | Agents API implementation candidate | Runtime implementation candidates, but still hosted by Data Machine and still carrying compatibility/provider/logging assumptions. Future provider primitive is direct `wp-ai-client`; `ai-http-client` is removal work, not an Agents API runtime layer. |
 | `AgentsAPI\AI\Tools\RuntimeToolDeclaration`, plus `DataMachine\Engine\AI\Tools\Execution\ToolExecutionCore`, `Tools\ToolSourceRegistry`, `Tools\Policy\ToolPolicyFilter`, `Tools\ToolResultFinder` | Mixed runtime candidate | `RuntimeToolDeclaration` now lives in the in-repo `agents-api/` module under a neutral namespace. The remaining generic-looking pieces still sit next to Data Machine adapters and should move only after their source-provider, policy, and execution boundaries are proven generic. |
 | `DataMachine\Engine\AI\Tools\Sources\DataMachineToolRegistrySource`, `Tools\Sources\AdjacentHandlerToolSource`, `Tools\Policy\DataMachineAgentToolPolicyProvider`, `Tools\Policy\DataMachineMandatoryToolPolicy`, `Tools\Policy\DataMachineToolAccessPolicy`, `Tools\ToolManager`, `Tools\ToolPolicyResolver`, `Tools\ToolParameters` payload merging | Data Machine adapter/product | These translate Data Machine handler, pipeline, queue, permission, persisted-agent, and legacy tool registry concepts into runtime inputs. They stay Data Machine. |
 | `DataMachine\Engine\AI\Tools\Global\*` | Data Machine product | Curated product/site-ops tools. Individual capabilities may move to abilities later, but the bundle is not the Agents API registry. |
@@ -222,8 +226,7 @@ These are plausibly generic implementations, but should not move until naming an
 |---|---|---|---|
 | `AIConversationLoop` | `inc/Engine/AI/AIConversationLoop.php` | Name says AI and still carries the compatibility facade/result shape, but handler completion and transcript persistence now route through runtime collaborators. | Keep shrinking the compatibility adapter by extracting provider request assembly and Data Machine logging policy next. |
 | `ProviderRequestAssembler` | `inc/Engine/AI/ProviderRequestAssembler.php` | Normalizes messages, tools, model, and caller-selected directives without dispatching, logging, or discovering Data Machine directives. | Good in-place request assembly candidate once prompt/directive vocabulary is settled. |
-| `RequestBuilder` | `inc/Engine/AI/RequestBuilder.php` | Data Machine adapter around provider assembly: discovers/directive-policies `datamachine_directives`, emits `datamachine_log`, applies request-size guardrails, and still carries Data Machine request-array compatibility. | Keep as Data Machine adapter while those product concerns remain. Provider dispatch should consume `wp-ai-client` directly. |
-| `WpAiClientAdapter` | `inc/Engine/AI/WpAiClientAdapter.php` | Data Machine adapter that maps the assembled provider request array onto the wp-ai-client public API and normalizes the result back to Data Machine's historical response array. | Keep in Data Machine until request/message contracts are generic enough for an Agents API provider runtime implementation. |
+| `RequestBuilder` | `inc/Engine/AI/RequestBuilder.php` | Data Machine adapter around provider assembly: discovers/directive-policies `datamachine_directives`, emits `datamachine_log`, applies request-size guardrails, maps Data Machine's request array onto the `wp-ai-client` public API, and still carries Data Machine response compatibility. | Keep as Data Machine adapter while those product concerns remain. Do not move pipeline AI steps to Agents API solely to reach provider dispatch; one-shot/pipeline requests should consume `wp-ai-client` directly unless they need durable agent runtime semantics. |
 | `RequestMetadata` | `inc/Engine/AI/RequestMetadata.php` | Generic inspection/size metadata. | Move after field names are checked against Agents API message/tool vocabulary. |
 | `RequestInspector` | `inc/Engine/AI/RequestInspector.php` | Generic debugging/inspection value, likely useful across runtimes. | Rename away from Data Machine only if public debug surface is desired. |
 | `PromptBuilder` | `inc/Engine/AI/PromptBuilder.php` | Generic system-message composition engine, but wired to Data Machine directives. | Extract lower-level composer after directive contract is settled. |
@@ -370,7 +373,7 @@ Automattic/intelligence#285.
 | `datamachine_pre_ai_step_check` | Data Machine adapter | Pipeline AI-step skip hook. |
 | `datamachine_log` | Data Machine product | Product logging surface. Generic runtime events should use loop event sinks. |
 | `chubes_ai_request` | Legacy provider bridge to delete | Legacy `ai-http-client` provider-dispatch filter. Do not carry this into Agents API public vocabulary or architecture; removal belongs to #1027 / #1633. |
-| `WpAiClientCapability::unavailableReason()` | Agents API implementation candidate | Single wp-ai-client runtime capability gate. Missing support is surfaced as a request error; no `ai-http-client` fallback belongs in Agents API. |
+| `RequestBuilder::wpAiClientUnavailableReason()` | Data Machine adapter today | Product-level `wp-ai-client` capability gate. Missing support is surfaced as a request error; no `ai-http-client` fallback belongs in Agents API. |
 
 ## Test Coverage Map
 

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -4,7 +4,7 @@ Parent issue: [Explore splitting Agents API out of Data Machine](https://github.
 
 Strategy issue: [Agents API blocker: update extraction docs around in-repo module strategy](https://github.com/Extra-Chill/data-machine/issues/1640)
 
-Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
+Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), [one-shot AI boundary](https://github.com/Extra-Chill/data-machine/issues/1693), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
 
 This audit records the remaining work after the first in-place untangling wave. The boundary is now mostly visible: Data Machine owns pipelines and automation; the future Agents API owns generic agent runtime primitives. The next phase is to make those primitives live behind an in-repo `data-machine/agents-api/` module boundary while they still ship with Data Machine.
 
@@ -33,17 +33,20 @@ Treat `data-machine/agents-api/` like WordPress core substrate while it still li
 - Data Machine and other product consumers own any admin/product UI they build on top of the substrate.
 - Later standalone extraction means moving the already-bounded module into its own plugin/repo and adding plugin bootstrap, dependency, release, and distribution ceremony.
 
-Dependency direction:
+WordPress substrate boundary:
 
 ```text
-wp-ai-client public API
-        ↑
-Agents API run request
-        ↑
-Data Machine product adapter
+Abilities API  -> actions and tools
+wp-ai-client   -> provider/model prompt execution
+Agents API     -> durable agent runtime behavior
+Data Machine   -> automation product built on those substrates
 ```
 
-`ai-http-client` is not future architecture. It is only packaging precedent for bundled-then-extracted code. The future runtime dependency direction is `Data Machine product adapter -> Agents API run request -> wp-ai-client public API`; `ai-http-client` dies as part of [#1027](https://github.com/Extra-Chill/data-machine/issues/1027) / [#1633](https://github.com/Extra-Chill/data-machine/issues/1633).
+`wp-ai-client` remains the direct WordPress provider primitive for one-shot AI operations: summarize text, classify content, generate titles/excerpts, transform content, produce a structured response from one prompt, or run a non-durable pipeline AI step where the product owns orchestration and storage. Agents API provider code may consume `wp-ai-client` directly when implementing durable agent runs, but that does not make Agents API the required path for every model call.
+
+Use Agents API when the caller needs durable agent runtime behavior: agent registration and lookup, chat/session persistence, multi-turn tool loops, memory/guideline composition, conversation locks or queued messages, event sinks, progress/streaming runtime events, provider-agnostic run lifecycle, or portable agent declarations. Data Machine pipeline AI steps should not move to Agents API solely for provider dispatch; they should keep using the direct `wp-ai-client` path unless they need those durable runtime semantics.
+
+`ai-http-client` is not future architecture. It is only packaging precedent for bundled-then-extracted code. The future dependency direction is not "all AI calls -> Agents API -> wp-ai-client"; it is "durable agent runs -> Agents API -> wp-ai-client" plus "one-shot AI operations -> wp-ai-client". `ai-http-client` dies as part of [#1027](https://github.com/Extra-Chill/data-machine/issues/1027) / [#1633](https://github.com/Extra-Chill/data-machine/issues/1633).
 
 ## Current State
 
@@ -71,6 +74,7 @@ Before standalone extraction, the in-repo module should satisfy these gates:
 - No `agents-api` file registers admin menus, admin screens, settings forms, or admin-only UI hooks.
 - Data Machine product code imports the module as a dependency instead of reaching across same-layer runtime/product paths.
 - Provider runtime code targets `wp-ai-client`; no `ai-http-client` fallback is introduced or preserved inside `agents-api`.
+- One-shot AI calls may use `wp-ai-client` directly without Agents API. Data Machine pipeline AI steps should not move to Agents API solely for provider dispatch.
 
 ## Core-Shape Decisions
 

--- a/inc/Engine/AI/README.md
+++ b/inc/Engine/AI/README.md
@@ -2,6 +2,17 @@
 
 `DataMachine\Engine\AI` is a staging namespace while the future Agents API runtime is clarified in place. It is not itself the extraction boundary.
 
+Layer boundaries:
+
+| Layer | Responsibility |
+|---|---|
+| Abilities API | Actions and tools. |
+| wp-ai-client | Direct provider/model prompt execution for one-shot AI operations. |
+| Agents API | Durable agent runtime: registration, memory, transcripts, sessions, locks, event sinks, multi-turn tool loops, and portable declarations. |
+| Data Machine | Automation product: flows, pipelines, jobs, handlers, queues, retention, content operations, and admin UI. |
+
+Data Machine pipeline AI steps should not move to Agents API solely for provider dispatch. They should use the direct `wp-ai-client` path through Data Machine request assembly unless the feature needs durable agent runtime semantics.
+
 Use this quick map before moving or renaming files:
 
 | Area | Boundary |

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -27,7 +27,8 @@ class RequestBuilder {
 	 *
 	 * Dispatch requires WordPress core's wp-ai-client plus a provider plugin that has
 	 * registered the requested provider. Missing wp-ai-client support is surfaced as a
-	 * request error; agents-api must not silently fall back to another provider client.
+	 * request error. Data Machine uses this direct provider path for one-shot/pipeline
+	 * requests; Agents API is only needed when callers require durable runtime semantics.
 	 *
 	 * @param array  $messages    Initial messages array with role/content
 	 * @param string $provider    AI provider name (openai, anthropic, google, grok, openrouter)

--- a/tests/agents-api-wp-ai-client-vocabulary-smoke.php
+++ b/tests/agents-api-wp-ai-client-vocabulary-smoke.php
@@ -50,6 +50,20 @@ foreach ( $scanned_files as $relative_path ) {
 }
 
 agents_api_smoke_assert_equals( array(), $matches, 'docs/comments avoid forbidden final-architecture provider wording', $failures, $passes );
+
+$extraction_map = strtolower( (string) file_get_contents( (string) $root . '/docs/development/agents-api-extraction-map.md' ) );
+$audit_doc      = strtolower( (string) file_get_contents( (string) $root . '/docs/development/agents-api-pre-extraction-audit.md' ) );
+$engine_readme  = strtolower( (string) file_get_contents( (string) $root . '/inc/Engine/AI/README.md' ) );
+$request_docs   = strtolower( (string) file_get_contents( (string) $root . '/docs/core-system/request-builder.md' ) );
+
+agents_api_smoke_assert_equals( true, str_contains( $extraction_map, 'abilities api' ), 'extraction map names Abilities API layer', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $extraction_map, 'one-shot ai operations call `wp-ai-client` directly' ), 'extraction map preserves direct one-shot wp-ai-client usage', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $extraction_map, 'pipeline ai steps should not move to agents api solely for provider dispatch' ), 'extraction map blocks pipeline AI migration for provider dispatch only', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $audit_doc, 'wp-ai-client` remains the direct wordpress provider primitive for one-shot ai operations' ), 'pre-extraction audit preserves direct one-shot provider primitive', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $audit_doc, 'durable agent runtime behavior' ), 'pre-extraction audit names durable runtime boundary', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $engine_readme, 'wp-ai-client | direct provider/model prompt execution for one-shot ai operations' ), 'Engine AI README names direct wp-ai-client layer', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $request_docs, 'plugins that only need one-shot ai operations may call `wp-ai-client` directly' ), 'RequestBuilder docs do not force all plugins through Agents API', $failures, $passes );
+
 $deleted_adapter_path    = '/inc/Engine/AI/WpAiClient' . 'Adapter.php';
 $deleted_capability_path = '/inc/Engine/AI/WpAiClient' . 'Capability.php';
 $deleted_agents_wrapper  = '/agents-api/inc/AI/WpAiClient.php';


### PR DESCRIPTION
## Summary
- Clarifies the Agents API extraction boundary so `wp-ai-client` remains the direct provider primitive for one-shot AI operations.
- Documents that Agents API is for durable agent runtime behavior, not a mandatory routing layer for every model call.

## Changes
- Updates the extraction map and pre-extraction audit with the four-layer boundary: Abilities API, wp-ai-client, Agents API, and Data Machine.
- Clarifies that Data Machine pipeline AI steps should not move to Agents API solely for provider dispatch.
- Updates RequestBuilder docs/comments and the Engine AI namespace README to match the boundary.
- Extends the Agents API wp-ai-client vocabulary smoke to pin the new architecture language.

## Tests
- `php tests/agents-api-wp-ai-client-vocabulary-smoke.php`
- `php -l inc/Engine/AI/RequestBuilder.php && php -l tests/agents-api-wp-ai-client-vocabulary-smoke.php`

Closes #1693

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the documentation/comment updates and vocabulary smoke assertions; Chris remains responsible for review and merge.