### PR TITLE
fix(agents-api): align registration lifecycle

### DIFF
--- a/agents-api/agents-api.php
+++ b/agents-api/agents-api.php
@@ -36,3 +36,5 @@ require_once AGENTS_API_PATH . 'inc/Core/FilesRepository/AgentMemoryListEntry.ph
 require_once AGENTS_API_PATH . 'inc/Core/FilesRepository/AgentMemoryReadResult.php';
 require_once AGENTS_API_PATH . 'inc/Core/FilesRepository/AgentMemoryWriteResult.php';
 require_once AGENTS_API_PATH . 'inc/Core/FilesRepository/AgentMemoryStoreInterface.php';
+
+add_action( 'init', array( 'WP_Agents_Registry', 'init' ), 10 );

--- a/agents-api/inc/class-wp-agents-registry.php
+++ b/agents-api/inc/class-wp-agents-registry.php
@@ -21,6 +21,13 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		private static ?self $instance = null;
 
 		/**
+		 * Whether the public registration hook has fired.
+		 *
+		 * @var bool
+		 */
+		private static bool $initialized = false;
+
+		/**
 		 * Registered agent definitions, keyed by slug.
 		 *
 		 * @var array<string, WP_Agent>
@@ -107,31 +114,57 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		}
 
 		/**
+		 * Initialize the registry and fire the public registration hook.
+		 *
+		 * This is wired to WordPress' `init` action by the module bootstrap so
+		 * `wp_agents_api_init` follows the same deterministic lifecycle shape as
+		 * the Abilities API's registration hook. Late reads may still initialize
+		 * the registry object, but they do not reopen the registration window.
+		 *
+		 * @return self|null Registry instance, or null when init has not fired.
+		 */
+		public static function init(): ?self {
+			$registry = self::get_instance();
+			if ( null === $registry || self::$initialized ) {
+				return $registry;
+			}
+
+			self::$initialized = true;
+
+			/**
+			 * Fires to let plugins register agents.
+			 *
+			 * Callbacks should call `wp_register_agent()` to contribute one or more
+			 * agent definitions. The registry only collects definitions; consumers
+			 * decide whether and how to materialize them.
+			 */
+			do_action( 'wp_agents_api_init', $registry );
+
+			return $registry;
+		}
+
+		/**
 		 * Retrieve the registry singleton.
 		 *
 		 * @return self|null Registry instance, or null when init has not fired.
 		 */
 		public static function get_instance(): ?self {
-			if ( function_exists( 'did_action' ) && ! did_action( 'init' ) ) {
-				_doing_it_wrong(
-					__METHOD__,
-					'Agents API should not be initialized before the <code>init</code> action has fired.',
-					'0.102.8'
-				);
+			$init_started = function_exists( 'did_action' ) && did_action( 'init' );
+			$doing_init   = function_exists( 'doing_action' ) && doing_action( 'init' );
+
+			if ( ! $init_started && ! $doing_init ) {
+				if ( function_exists( '_doing_it_wrong' ) ) {
+					_doing_it_wrong(
+						__METHOD__,
+						'Agents API should not be initialized before the <code>init</code> action has fired.',
+						'0.102.8'
+					);
+				}
 				return null;
 			}
 
 			if ( null === self::$instance ) {
 				self::$instance = new self();
-
-				/**
-				 * Fires to let plugins register agents.
-				 *
-				 * Callbacks should call `wp_register_agent()` to contribute one or more
-				 * agent definitions. The registry only collects definitions; consumers
-				 * decide whether and how to materialize them.
-				 */
-				do_action( 'wp_agents_api_init', self::$instance );
 			}
 
 			return self::$instance;
@@ -144,7 +177,8 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 		 * @return void
 		 */
 		public static function reset_for_tests(): void {
-			self::$instance = null;
+			self::$instance    = null;
+			self::$initialized = false;
 		}
 
 		/**

--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -6,7 +6,7 @@ Parent issue: [Explore splitting Agents API out of Data Machine](https://github.
 
 Strategy update: [Agents API blocker: update extraction docs around in-repo module strategy](https://github.com/Extra-Chill/data-machine/issues/1640)
 
-Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618) ([docs](agents-api-standalone-skeleton-plan.md)), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), [one-shot AI boundary](https://github.com/Extra-Chill/data-machine/issues/1693), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
+Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618) ([docs](agents-api-standalone-skeleton-plan.md)), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [registration lifecycle](https://github.com/Extra-Chill/data-machine/issues/1671), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), [one-shot AI boundary](https://github.com/Extra-Chill/data-machine/issues/1693), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
 
 ## Namespace Map
 
@@ -75,6 +75,21 @@ Mirror the WordPress Abilities API shape instead of importing Data Machine produ
 | `RuntimeToolDeclaration` | `WP_Agent_Tool_Declaration` | Should stay ability-native and run-scoped. |
 | `LoopEventSinkInterface` | `WP_Agent_Run_Event_Sink_Interface` | Useful for logs, streaming, chat UIs, and async workers. |
 | REST `datamachine/v1` agent routes | REST `wp-agents/v1` deferred | [#1670](https://github.com/Extra-Chill/data-machine/issues/1670) reserves the namespace but defers public REST controllers from the first standalone extraction. Data Machine product routes stay under `datamachine/v1`. |
+
+## Registration Lifecycle
+
+`wp_agents_api_init` intentionally mirrors the Abilities API registration window where practical: the module wires registry initialization to WordPress `init`, callbacks register definitions only while the public hook is running, and reads after initialization do not replay the hook.
+
+| Lifecycle concern | Abilities API shape | Agents API in-repo shape |
+|---|---|---|
+| Bootstrap hook | WordPress fires `wp_abilities_api_init` during `init`. | `agents-api/agents-api.php` hooks `WP_Agents_Registry::init()` to `init`, which fires `wp_agents_api_init`. |
+| Registration helper timing | `wp_register_ability()` is valid only during `wp_abilities_api_init`. | `wp_register_agent()` is valid only during `wp_agents_api_init`; calls before or after the hook return `null` and emit `_doing_it_wrong()`. |
+| Pre-init reads | Registry access before `init` is invalid. | `WP_Agents_Registry::get_instance()` returns `null` before `init` and emits `_doing_it_wrong()`; public getters return empty/null/false. |
+| Lazy reads | Reads do not reopen the registration window after the hook has fired. | `wp_get_agents()`, `wp_get_agent()`, and Data Machine reconciliation read the initialized registry without refiring `wp_agents_api_init`. |
+| Materialization | Abilities are registered definitions; consumers decide how to use them. | Agent definitions are registered definitions; Data Machine materializes rows at `init` priority 15 after registration has completed. |
+| Divergence | Abilities are executable REST-discoverable units with categories. | Agents stay backend-only in v1: no category registry, no public `wp-agents/v1` routes, and no persistence side effects in `wp_register_agent()`. |
+
+The remaining intentional divergence is product ownership, not hook timing: Data Machine owns today's materializer, tables, agent directories, access rows, scaffolding, and admin/CLI product surfaces while the in-repo Agents API owns only backend registration vocabulary and generic runtime contracts.
 
 ## Boundary Rules
 

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -4,7 +4,7 @@ Parent issue: [Explore splitting Agents API out of Data Machine](https://github.
 
 Strategy issue: [Agents API blocker: update extraction docs around in-repo module strategy](https://github.com/Extra-Chill/data-machine/issues/1640)
 
-Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618) ([docs](agents-api-standalone-skeleton-plan.md)), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), [one-shot AI boundary](https://github.com/Extra-Chill/data-machine/issues/1693), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
+Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618) ([docs](agents-api-standalone-skeleton-plan.md)), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [registration lifecycle](https://github.com/Extra-Chill/data-machine/issues/1671), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), [one-shot AI boundary](https://github.com/Extra-Chill/data-machine/issues/1693), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
 
 This audit records the remaining work after the first in-place untangling wave. The boundary is now mostly visible: Data Machine owns pipelines and automation; the future Agents API owns generic agent runtime primitives. The next phase is to make those primitives live behind an in-repo `data-machine/agents-api/` module boundary while they still ship with Data Machine.
 
@@ -75,6 +75,15 @@ Before standalone extraction, the in-repo module should satisfy these gates:
 - Data Machine product code imports the module as a dependency instead of reaching across same-layer runtime/product paths.
 - Provider runtime code targets `wp-ai-client`; no `ai-http-client` fallback is introduced or preserved inside `agents-api`.
 - One-shot AI calls may use `wp-ai-client` directly without Agents API. Data Machine pipeline AI steps should not move to Agents API solely for provider dispatch.
+
+Registration lifecycle gate for [#1671](https://github.com/Extra-Chill/data-machine/issues/1671):
+
+- `agents-api/agents-api.php` wires `WP_Agents_Registry::init()` to WordPress `init`.
+- `WP_Agents_Registry::init()` fires `wp_agents_api_init` once per request, matching the Abilities API's deterministic registration-window shape.
+- `wp_register_agent()` is valid only while `wp_agents_api_init` is running; calls before or after that hook return `null` and emit `_doing_it_wrong()`.
+- Public reads before `init` return empty/null/false and emit `_doing_it_wrong()` through `WP_Agents_Registry::get_instance()`.
+- Public reads after `init` do not replay the hook, so callbacks added after initialization are not collected lazily.
+- Data Machine materialization remains product-owned: `AgentRegistry::reconcile()` runs at `init` priority 15, after `wp_agents_api_init` has collected definitions and before existing scaffold checks.
 
 ## Core-Shape Decisions
 

--- a/inc/Engine/Agents/AgentRegistry.php
+++ b/inc/Engine/Agents/AgentRegistry.php
@@ -41,9 +41,7 @@ class AgentRegistry {
 	 * Register an agent definition.
 	 *
 	 * Call from inside a `wp_agents_api_init` action callback.
-	 * Later registrations for the same slug overwrite earlier ones — this
-	 * matches WordPress hook semantics, so plugins can override core or
-	 * other plugins via action priority.
+	 * Duplicate slugs are rejected by the underlying Agents API registry.
 	 *
 	 * @since 0.71.0
 	 *
@@ -83,9 +81,7 @@ class AgentRegistry {
 	/**
 	 * Get all registered agent definitions.
 	 *
-	 * Fires the `wp_agents_api_init` action once per request so
-	 * callers can lazily collect registrations without needing to worry
-	 * about hook ordering.
+	 * Reads the definitions collected during `wp_agents_api_init`.
 	 *
 	 * @since 0.71.0
 	 *
@@ -153,9 +149,9 @@ class AgentRegistry {
 	/**
 	 * Ensure the agent registration actions have fired.
 	 *
-	 * Plugins register their agents inside action callbacks — collecting
-	 * them lazily lets callers of `get_all()` / `reconcile()` / `get()`
-	 * work regardless of hook ordering.
+	 * The Agents API module fires `wp_agents_api_init` from WordPress `init`.
+	 * Data Machine keeps its legacy in-repo hook behind this adapter while the
+	 * substrate is hosted here.
 	 *
 	 * @return void
 	 */

--- a/tests/agent-registry-materializer-smoke.php
+++ b/tests/agent-registry-materializer-smoke.php
@@ -186,7 +186,7 @@ namespace {
 		$GLOBALS['__agent_materializer_hooks']   = array();
 		$GLOBALS['__agent_materializer_current'] = array();
 		$GLOBALS['__agent_materializer_done']    = array();
-		do_action( 'init' );
+		add_action( 'init', array( 'WP_Agents_Registry', 'init' ), 10 );
 	}
 
 	echo "agent-registry-materializer-smoke\n";
@@ -210,6 +210,7 @@ namespace {
 			);
 		}
 	);
+	do_action( 'init' );
 	$definitions = AgentRegistry::get_all();
 	assert_agent_materializer_equals( true, class_exists( 'WP_Agent' ), 'WP_Agent definition object is available', $failures, $passes );
 	assert_agent_materializer_equals( true, class_exists( 'WP_Agents_Registry' ), 'WP_Agents_Registry facade is available', $failures, $passes );
@@ -243,6 +244,7 @@ namespace {
 			);
 		}
 	);
+	do_action( 'init' );
 	$definitions = AgentRegistry::get_all();
 	assert_agent_materializer_equals( array( 'hook-agent', 'legacy-agent' ), array_keys( $definitions ), 'new and in-repo legacy hooks both contribute definitions', $failures, $passes );
 	assert_agent_materializer_equals( array(), Agents::$rows, 'hook collection remains side-effect free', $failures, $passes );
@@ -264,6 +266,7 @@ namespace {
 			);
 		}
 	);
+	do_action( 'init' );
 	$summary = AgentRegistry::reconcile();
 	assert_agent_materializer_equals( array( 'created' => array( 'example-agent' ), 'existing' => array(), 'skipped' => array() ), $summary, 'created summary matches pre-split registry behavior', $failures, $passes );
 	assert_agent_materializer_equals( 7, Agents::$rows['example-agent']['owner_id'] ?? 0, 'owner resolver controls created row owner', $failures, $passes );

--- a/tests/agents-api-registration-smoke.php
+++ b/tests/agents-api-registration-smoke.php
@@ -21,8 +21,24 @@ function agents_api_registration_reset(): void {
 	$GLOBALS['__agents_api_smoke_wrong']   = array();
 	$GLOBALS['__agents_api_smoke_current'] = array();
 	$GLOBALS['__agents_api_smoke_done']    = array();
+	add_action( 'init', array( 'WP_Agents_Registry', 'init' ), 10 );
+}
+
+function agents_api_registration_fire_init(): void {
 	do_action( 'init' );
 }
+
+echo "\n[0] Registry is unavailable before init and registration waits for wp_agents_api_init:\n";
+agents_api_registration_reset();
+agents_api_smoke_assert_equals( array(), wp_get_agents(), 'pre-init reads return an empty map', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $GLOBALS['__agents_api_smoke_wrong'] ), 'pre-init read emits doing-it-wrong notice', $failures, $passes );
+agents_api_smoke_assert_equals( 0, did_action( 'wp_agents_api_init' ), 'pre-init read does not fire registration hook', $failures, $passes );
+$GLOBALS['__agents_api_smoke_wrong'] = array();
+wp_register_agent( 'too-early', array( 'label' => 'Too Early' ) );
+agents_api_smoke_assert_equals( 1, count( $GLOBALS['__agents_api_smoke_wrong'] ), 'pre-hook registration is rejected', $failures, $passes );
+agents_api_registration_fire_init();
+agents_api_smoke_assert_equals( 1, did_action( 'wp_agents_api_init' ), 'init fires public registration hook once', $failures, $passes );
+agents_api_smoke_assert_equals( array(), wp_get_agents(), 'rejected pre-hook registration is not collected', $failures, $passes );
 
 echo "\n[1] Hook registration normalizes definitions without side effects:\n";
 agents_api_registration_reset();
@@ -43,15 +59,16 @@ add_action(
 		);
 	}
 );
+agents_api_registration_fire_init();
 
 $agents = wp_get_agents();
 $agent  = wp_get_agent( 'Example Agent!' );
 agents_api_smoke_assert_equals( array( 'example-agent' ), array_keys( $agents ), 'definition slug is normalized', $failures, $passes );
-agents_api_smoke_assert_equals( 'Example Agent', $agents['example-agent']->get_label() ?? '', 'definition label is preserved', $failures, $passes );
-agents_api_smoke_assert_equals( 'Standalone module smoke', $agents['example-agent']->get_description() ?? '', 'definition description is preserved', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'SOUL.md' => '/tmp/seed-soul.md' ), $agents['example-agent']->get_memory_seeds() ?? array(), 'memory seed filenames are sanitized', $failures, $passes );
+agents_api_smoke_assert_equals( 'Example Agent', $agents['example-agent']->get_label(), 'definition label is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'Standalone module smoke', $agents['example-agent']->get_description(), 'definition description is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'SOUL.md' => '/tmp/seed-soul.md' ), $agents['example-agent']->get_memory_seeds(), 'memory seed filenames are sanitized', $failures, $passes );
 agents_api_smoke_assert_equals( true, is_callable( $agents['example-agent']->get_owner_resolver() ?? null ), 'callable owner resolver is preserved', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'default_provider' => 'openai' ), $agents['example-agent']->get_default_config() ?? array(), 'default config is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'default_provider' => 'openai' ), $agents['example-agent']->get_default_config(), 'default config is preserved', $failures, $passes );
 agents_api_smoke_assert_equals( true, $agent instanceof WP_Agent, 'wp_get_agent returns an agent object', $failures, $passes );
 agents_api_smoke_assert_equals( 'example-agent', $agent ? $agent->get_slug() : '', 'agent getter exposes slug', $failures, $passes );
 agents_api_smoke_assert_equals( 'Example Agent', $agent ? $agent->get_label() : '', 'agent getter exposes label', $failures, $passes );
@@ -62,7 +79,7 @@ agents_api_smoke_assert_equals( array(), $agent ? $agent->get_meta() : array( 'm
 agents_api_smoke_assert_equals( true, wp_has_agent( 'example-agent' ), 'wp_has_agent reports registered slug', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'example-agent' ), array_keys( wp_get_agents() ), 'wp_get_agents returns object map', $failures, $passes );
 
-echo "\n[2] Public registration hook fires once on first read:\n";
+echo "\n[2] Public registration hook fires once on init:\n";
 agents_api_registration_reset();
 $hook_calls = 0;
 add_action(
@@ -73,11 +90,21 @@ add_action(
 	}
 );
 
+agents_api_registration_fire_init();
 $agents = wp_get_agents();
-agents_api_smoke_assert_equals( 1, $hook_calls, 'registration hook fires on first get_all call', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $hook_calls, 'registration hook fires on init', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'hook-agent' ), array_keys( $agents ), 'hook-registered definition is collected', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'hook-agent' ), array_keys( wp_get_agents() ), 'registration hook does not refire on subsequent reads', $failures, $passes );
 agents_api_smoke_assert_equals( 1, $hook_calls, 'hook call count remains stable after second read', $failures, $passes );
+
+add_action(
+	'wp_agents_api_init',
+	static function (): void {
+		wp_register_agent( 'too-late', array( 'label' => 'Too Late' ) );
+	}
+);
+agents_api_smoke_assert_equals( array( 'hook-agent' ), array_keys( wp_get_agents() ), 'callbacks added after init are not replayed by lazy reads', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $hook_calls, 'late callbacks do not refire registration hook', $failures, $passes );
 
 echo "\n[3] Invalid definitions are rejected or normalized predictably:\n";
 agents_api_registration_reset();
@@ -101,14 +128,15 @@ add_action(
 		wp_register_agent( 'Unknown Property', array( 'label' => 'Unknown Property', 'mystery' => true ) );
 	}
 );
+agents_api_registration_fire_init();
 
 $agents = wp_get_agents();
 agents_api_smoke_assert_equals( array( 'minimal-agent', 'messy-seeds', 'unknown-property' ), array_keys( $agents ), 'empty slugs are ignored while valid slugs are kept', $failures, $passes );
-agents_api_smoke_assert_equals( 'minimal-agent', $agents['minimal-agent']->get_label() ?? '', 'missing label falls back to slug', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'MEMORY.md' => '/tmp/MEMORY.md' ), $agents['messy-seeds']->get_memory_seeds() ?? array(), 'empty memory seed keys and paths are dropped', $failures, $passes );
+agents_api_smoke_assert_equals( 'minimal-agent', $agents['minimal-agent']->get_label(), 'missing label falls back to slug', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'MEMORY.md' => '/tmp/MEMORY.md' ), $agents['messy-seeds']->get_memory_seeds(), 'empty memory seed keys and paths are dropped', $failures, $passes );
 agents_api_smoke_assert_equals( false, isset( $agents['bad-resolver'] ), 'non-callable owner resolver rejects definition', $failures, $passes );
 agents_api_smoke_assert_equals( false, isset( $agents['bad-seeds'] ), 'non-array memory seeds reject definition', $failures, $passes );
-agents_api_smoke_assert_equals( 'Unknown Property', $agents['unknown-property']->get_label() ?? '', 'unknown properties do not block otherwise valid definitions', $failures, $passes );
+agents_api_smoke_assert_equals( 'Unknown Property', $agents['unknown-property']->get_label(), 'unknown properties do not block otherwise valid definitions', $failures, $passes );
 agents_api_smoke_assert_equals( 4, count( $GLOBALS['__agents_api_smoke_wrong'] ), 'invalid registrations emit doing-it-wrong notices', $failures, $passes );
 
 echo "\n[4] Duplicate registration and lifecycle errors follow core shape:\n";
@@ -120,8 +148,9 @@ add_action(
 		wp_register_agent( 'duplicate-agent', array( 'label' => 'Second Label' ) );
 	}
 );
+agents_api_registration_fire_init();
 $agents = wp_get_agents();
-agents_api_smoke_assert_equals( 'First Label', $agents['duplicate-agent']->get_label() ?? '', 'duplicate registrations keep the first definition', $failures, $passes );
+agents_api_smoke_assert_equals( 'First Label', $agents['duplicate-agent']->get_label(), 'duplicate registrations keep the first definition', $failures, $passes );
 agents_api_smoke_assert_equals( 1, count( $GLOBALS['__agents_api_smoke_wrong'] ), 'duplicate registration emits doing-it-wrong notice', $failures, $passes );
 $GLOBALS['__agents_api_smoke_wrong'] = array();
 wp_register_agent( 'outside-hook', array( 'label' => 'Outside Hook' ) );


### PR DESCRIPTION
## Summary
- Align `wp_agents_api_init` with the Abilities API-style lifecycle by firing it from WordPress `init` instead of first registry read.
- Document the registration lifecycle and keep Data Machine materialization as a product-owned `init:15` reconciliation step.

## Changes
- Add `WP_Agents_Registry::init()` and wire it from `agents-api/agents-api.php` on `init`.
- Keep `wp_register_agent()` valid only during `wp_agents_api_init`; pre-init reads return empty/null/false and emit `_doing_it_wrong()`.
- Update registration/materializer smokes to cover pre-init reads, pre-hook registration, init registration, duplicate reads, late callbacks, and duplicate registrations.
- Add lifecycle documentation to the Agents API extraction docs and audit checklist.

## Tests
- `php tests/agents-api-registration-smoke.php`
- `php tests/agent-registry-materializer-smoke.php`
- `for test_file in tests/*agents-api*smoke.php tests/agent-registry-materializer-smoke.php; do php "$test_file" || exit 1; done`
- `for file in agents-api/agents-api.php agents-api/inc/class-wp-agents-registry.php inc/Engine/Agents/AgentRegistry.php tests/agent-registry-materializer-smoke.php tests/agents-api-registration-smoke.php; do php -l "$file" || exit 1; done`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@agents-api-lifecycle --changed-since origin/main`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@agents-api-lifecycle --changed-since origin/main`

Closes #1671

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the lifecycle alignment, updating focused smoke coverage, and drafting the extraction-doc updates. Chris remains responsible for review and merge.
