### PR TITLE
fix(ai): extend wp-ai-client request timeout

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -19,6 +19,16 @@ defined( 'ABSPATH' ) || exit;
 class RequestBuilder {
 
 	/**
+	 * Default timeout for Data Machine wp-ai-client requests.
+	 *
+	 * WordPress AI Client defaults to 30 seconds, which is too short for
+	 * non-streaming LLM requests with large prompts. Studio's cURL low-speed
+	 * watchdog is longer than this; without raising the AI Client request
+	 * timeout, the request-level cap wins first.
+	 */
+	private const DEFAULT_WP_AI_CLIENT_REQUEST_TIMEOUT = 300.0;
+
+	/**
 	 * Build standardized AI request for any execution mode.
 	 *
 	 * Centralizes request construction logic to ensure chat and pipeline flows
@@ -110,8 +120,15 @@ class RequestBuilder {
 			return new \WP_Error( 'wp_ai_client_unavailable', $unavailable_reason );
 		}
 
-		$result = null;
+		$result          = null;
+		$request_timeout = self::wpAiClientRequestTimeout( $mode, $provider, $model, $payload );
+		$timeout_filter  = static function ( $default_timeout ) use ( $request_timeout ) {
+			return max( (float) $default_timeout, $request_timeout );
+		};
+
 		try {
+			add_filter( 'wp_ai_client_default_request_timeout', $timeout_filter, 10, 1 );
+
 			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
 			/** @var callable $has_provider wp-ai-client exposes this through __call() in some versions. */
 			$has_provider = array( $registry, 'hasProvider' );
@@ -192,6 +209,10 @@ class RequestBuilder {
 			$result = $builder->generate_text_result();
 		} catch ( \Throwable $e ) {
 			$result = new \WP_Error( 'wp_ai_client_text_exception', 'wp-ai-client request failed: ' . $e->getMessage() );
+		} finally {
+			if ( function_exists( 'remove_filter' ) ) {
+				remove_filter( 'wp_ai_client_default_request_timeout', $timeout_filter, 10 );
+			}
 		}
 
 		do_action(
@@ -212,6 +233,32 @@ class RequestBuilder {
 		);
 
 		return $result;
+	}
+
+	/**
+	 * Resolve the request timeout Data Machine applies to wp-ai-client calls.
+	 *
+	 * @param string $mode     Execution mode.
+	 * @param string $provider Provider identifier.
+	 * @param string $model    Model identifier.
+	 * @param array  $payload  Step payload.
+	 * @return float Timeout in seconds.
+	 */
+	private static function wpAiClientRequestTimeout( string $mode, string $provider, string $model, array $payload ): float {
+		$timeout = apply_filters(
+			'datamachine_wp_ai_client_request_timeout',
+			self::DEFAULT_WP_AI_CLIENT_REQUEST_TIMEOUT,
+			$mode,
+			$provider,
+			$model,
+			$payload
+		);
+
+		if ( ! is_numeric( $timeout ) ) {
+			return self::DEFAULT_WP_AI_CLIENT_REQUEST_TIMEOUT;
+		}
+
+		return max( 0.0, (float) $timeout );
 	}
 
 	/**

--- a/tests/wp-ai-client-request-timeout-smoke.php
+++ b/tests/wp-ai-client-request-timeout-smoke.php
@@ -46,7 +46,7 @@ if ( ! function_exists( 'apply_filters' ) ) {
 
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( string $tag, ...$args ): void {
-		unset( $tag, $args );
+		$GLOBALS['datamachine_timeout_test_last_action'] = array( $tag, $args );
 	}
 }
 
@@ -82,6 +82,9 @@ if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
 }
 
 class TimeoutPromptBuilderDouble {
+	/** @var array<string, mixed> */
+	public static array $captured_request = array();
+
 	private string $provider = '';
 	private mixed $model = null;
 	private array $history = array();
@@ -127,7 +130,7 @@ class TimeoutPromptBuilderDouble {
 	}
 
 	public function generate_text_result() {
-		$GLOBALS['datamachine_timeout_captured_request'] = array(
+		self::$captured_request = array(
 			'provider' => $this->provider,
 			'model'    => $this->model,
 			'prompt'   => $this->prompt,
@@ -170,8 +173,21 @@ function timeout_smoke_failure_count(): int {
 	return count( $failures );
 }
 
-$GLOBALS['datamachine_timeout_captured_request'] = null;
-$timeout_context                              = null;
+function timeout_smoke_filter_count( string $tag ): int {
+	$filters = $GLOBALS['datamachine_timeout_test_filters'];
+	if ( ! is_array( $filters ) || ! isset( $filters[ $tag ] ) || ! is_array( $filters[ $tag ] ) ) {
+		return 0;
+	}
+
+	$count = 0;
+	foreach ( $filters[ $tag ] as $callbacks ) {
+		$count += is_array( $callbacks ) ? count( $callbacks ) : 0;
+	}
+
+	return $count;
+}
+
+$timeout_context = null;
 
 add_filter(
 	'datamachine_wp_ai_client_request_timeout',
@@ -197,23 +213,14 @@ $result = RequestBuilder::build(
 	array( 'job_id' => 1695 )
 );
 
-if ( is_wp_error( $result ) ) {
-	echo 'RequestBuilder error: ' . $result->get_error_message() . "\n";
-}
-
 assert_timeout_smoke( ! is_wp_error( $result ), 'RequestBuilder dispatch succeeds with wp-ai-client test double' );
-assert_timeout_smoke( 240.0 === ( $GLOBALS['datamachine_timeout_captured_request']['timeout'] ?? null ), 'Data Machine applies scoped wp-ai-client request timeout' );
+assert_timeout_smoke( 240.0 === ( TimeoutPromptBuilderDouble::$captured_request['timeout'] ?? null ), 'Data Machine applies scoped wp-ai-client request timeout' );
 assert_timeout_smoke( 300.0 === ( $timeout_context['timeout'] ?? null ), 'Data Machine timeout filter receives product default' );
 assert_timeout_smoke( 'pipeline' === ( $timeout_context['mode'] ?? null ), 'Data Machine timeout filter receives execution mode' );
 assert_timeout_smoke( 'openai' === ( $timeout_context['provider'] ?? null ), 'Data Machine timeout filter receives provider' );
 assert_timeout_smoke( 'gpt-smoke' === ( $timeout_context['model'] ?? null ), 'Data Machine timeout filter receives model' );
 
-$remaining_wp_ai_filters = 0;
-foreach ( $GLOBALS['datamachine_timeout_test_filters']['wp_ai_client_default_request_timeout'] ?? array() as $callbacks ) {
-	$remaining_wp_ai_filters += count( $callbacks );
-}
-
-assert_timeout_smoke( 0 === $remaining_wp_ai_filters, 'Data Machine removes temporary wp-ai-client timeout filter after dispatch' );
+assert_timeout_smoke( 0 === timeout_smoke_filter_count( 'wp_ai_client_default_request_timeout' ), 'Data Machine removes temporary wp-ai-client timeout filter after dispatch' );
 
 if ( timeout_smoke_failure_count() > 0 ) {
 	exit( 1 );

--- a/tests/wp-ai-client-request-timeout-smoke.php
+++ b/tests/wp-ai-client-request-timeout-smoke.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Smoke test for Data Machine's wp-ai-client request timeout boundary.
+ *
+ * Run with: php tests/wp-ai-client-request-timeout-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$GLOBALS['datamachine_timeout_test_filters'] = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['datamachine_timeout_test_filters'][ $tag ][ $priority ][] = array( $callback, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'remove_filter' ) ) {
+	function remove_filter( string $tag, callable $callback, int $priority = 10 ): void {
+		foreach ( $GLOBALS['datamachine_timeout_test_filters'][ $tag ][ $priority ] ?? array() as $index => $entry ) {
+			if ( $entry[0] === $callback ) {
+				unset( $GLOBALS['datamachine_timeout_test_filters'][ $tag ][ $priority ][ $index ] );
+			}
+		}
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $tag, $value, ...$args ) {
+		$callbacks = $GLOBALS['datamachine_timeout_test_filters'][ $tag ] ?? array();
+		ksort( $callbacks );
+
+		foreach ( $callbacks as $priority_callbacks ) {
+			foreach ( $priority_callbacks as $entry ) {
+				$callback      = $entry[0];
+				$accepted_args = $entry[1];
+				$value         = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $tag, ...$args ): void {
+		unset( $tag, $args );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $flags = 0 ) {
+		return json_encode( $data, $flags );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( string $text ): string {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key ) ?? '' );
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $option, $default = false ) {
+		unset( $option );
+		return $default;
+	}
+}
+
+if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+	function wp_ai_client_prompt( $prompt = null ): TimeoutPromptBuilderDouble {
+		return new TimeoutPromptBuilderDouble( is_string( $prompt ) ? $prompt : '' );
+	}
+}
+
+class TimeoutPromptBuilderDouble {
+	private string $provider = '';
+	private mixed $model = null;
+	private array $history = array();
+	private float $request_timeout = 30.0;
+
+	public function __construct( private string $prompt = '' ) {
+		$filtered_timeout = apply_filters( 'wp_ai_client_default_request_timeout', $this->request_timeout );
+		if ( is_numeric( $filtered_timeout ) ) {
+			$this->request_timeout = (float) $filtered_timeout;
+		}
+	}
+
+	public function using_provider( string $provider ): self {
+		$this->provider = $provider;
+		return $this;
+	}
+
+	public function using_model( $model ): self {
+		$this->model = $model;
+		return $this;
+	}
+
+	public function using_model_config( $model_config ): self {
+		unset( $model_config );
+		return $this;
+	}
+
+	public function using_system_instruction( string $system_instruction ): self {
+		$this->history[] = array( 'role' => 'system', 'content' => $system_instruction );
+		return $this;
+	}
+
+	public function with_history( ...$messages ): self {
+		foreach ( $messages as $message ) {
+			$this->history[] = $message;
+		}
+		return $this;
+	}
+
+	public function using_function_declarations( ...$declarations ): self {
+		unset( $declarations );
+		return $this;
+	}
+
+	public function generate_text_result() {
+		$GLOBALS['datamachine_timeout_captured_request'] = array(
+			'provider' => $this->provider,
+			'model'    => $this->model,
+			'prompt'   => $this->prompt,
+			'timeout'  => $this->request_timeout,
+			'history'  => $this->history,
+		);
+
+		return \WordPress\AiClient\Results\DTO\GenerativeAiResult::fromData(
+			array(
+				'content' => 'ok',
+				'usage'   => array( 'prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2 ),
+			)
+		);
+	}
+}
+
+require_once __DIR__ . '/bootstrap-unit.php';
+require_once __DIR__ . '/Unit/Support/WpAiClientTestDoubles.php';
+
+use DataMachine\Engine\AI\RequestBuilder;
+
+$failures   = array();
+$assertions = 0;
+
+function assert_timeout_smoke( bool $condition, string $label ): void {
+	global $failures, $assertions;
+
+	++$assertions;
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	echo "FAIL: {$label}\n";
+	$failures[] = $label;
+}
+
+function timeout_smoke_failure_count(): int {
+	global $failures;
+	return count( $failures );
+}
+
+$GLOBALS['datamachine_timeout_captured_request'] = null;
+$timeout_context                              = null;
+
+add_filter(
+	'datamachine_wp_ai_client_request_timeout',
+	function ( float $timeout, string $mode, string $provider, string $model, array $payload ) use ( &$timeout_context ): float {
+		$timeout_context = compact( 'timeout', 'mode', 'provider', 'model', 'payload' );
+		return 240.0;
+	},
+	10,
+	5
+);
+
+$result = RequestBuilder::build(
+	array(
+		array(
+			'role'    => 'user',
+			'content' => 'hello',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array(),
+	'pipeline',
+	array( 'job_id' => 1695 )
+);
+
+if ( is_wp_error( $result ) ) {
+	echo 'RequestBuilder error: ' . $result->get_error_message() . "\n";
+}
+
+assert_timeout_smoke( ! is_wp_error( $result ), 'RequestBuilder dispatch succeeds with wp-ai-client test double' );
+assert_timeout_smoke( 240.0 === ( $GLOBALS['datamachine_timeout_captured_request']['timeout'] ?? null ), 'Data Machine applies scoped wp-ai-client request timeout' );
+assert_timeout_smoke( 300.0 === ( $timeout_context['timeout'] ?? null ), 'Data Machine timeout filter receives product default' );
+assert_timeout_smoke( 'pipeline' === ( $timeout_context['mode'] ?? null ), 'Data Machine timeout filter receives execution mode' );
+assert_timeout_smoke( 'openai' === ( $timeout_context['provider'] ?? null ), 'Data Machine timeout filter receives provider' );
+assert_timeout_smoke( 'gpt-smoke' === ( $timeout_context['model'] ?? null ), 'Data Machine timeout filter receives model' );
+
+$remaining_wp_ai_filters = 0;
+foreach ( $GLOBALS['datamachine_timeout_test_filters']['wp_ai_client_default_request_timeout'] ?? array() as $callbacks ) {
+	$remaining_wp_ai_filters += count( $callbacks );
+}
+
+assert_timeout_smoke( 0 === $remaining_wp_ai_filters, 'Data Machine removes temporary wp-ai-client timeout filter after dispatch' );
+
+if ( timeout_smoke_failure_count() > 0 ) {
+	exit( 1 );
+}
+
+echo "\nwp-ai-client request timeout smoke passed ({$assertions} assertions).\n";


### PR DESCRIPTION
## Summary

- Raise Data Machine's wp-ai-client request timeout to 300s only around Data Machine's AI dispatch path.
- Add `datamachine_wp_ai_client_request_timeout` so deployments can tune the timeout with mode/provider/model/payload context.
- Cover the scoped filter behavior with a pure-PHP smoke test.

## Why

WordPress AI Client defaults `wp_ai_client_default_request_timeout` to 30s. That request-level cap fires before Studio's longer cURL low-speed watchdog can help, causing long non-streaming OpenAI `/v1/responses` calls to fail with cURL 28 after 30000ms.

Data Machine is the product layer choosing to run long LLM jobs through `wp_ai_client_prompt()`, so it should opt into a longer timeout at its own dispatch boundary instead of changing the whole site's wp-ai-client behavior.

## Tests

- `php tests/wp-ai-client-request-timeout-smoke.php`
- `php tests/wp-ai-client-runtime-gate-smoke.php`
- `php -l inc/Engine/AI/RequestBuilder.php`
- `php -l tests/wp-ai-client-request-timeout-smoke.php`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Live timeout diagnosis on `intelligence-chubes4`, implementation, and smoke-test coverage. Chris identified the Studio PR context and directed Data Machine to use the wp-ai-client timeout filter.
