### PR TITLE
fix(tasks): preserve matching recurring schedules

### DIFF
--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -14,7 +14,7 @@
  *   - Look up interval seconds from the datamachine_scheduler_intervals filter.
  *   - Compute a deterministic stagger offset so co-scheduled actions don't
  *     all fire at the same moment.
- *   - Clear existing actions before rescheduling (idempotent reschedule).
+ *   - Preserve matching pending actions and only reschedule changed slots.
  *   - Verify persistence after scheduling (AS can silently drop actions if
  *     its tables aren't ready during CLI activation).
  *   - Unschedule cleanly when a schedule is disabled.
@@ -60,9 +60,10 @@ class RecurringScheduler {
 	 *   - interval key from the datamachine_scheduler_intervals filter
 	 *     (or its aliases)                 → as_schedule_recurring_action.
 	 *
-	 * Always clears any existing action for (hook, args, group) before
-	 * scheduling to guarantee idempotent rescheduling, and verifies AS
-	 * actually persisted the action before returning success.
+	 * Preserves an existing pending action for (hook, args, group) when its
+	 * schedule semantics already match the requested configuration. Clears and
+	 * recreates the slot only when missing or changed, and verifies AS actually
+	 * persisted newly-created actions before returning success.
 	 *
 	 * @param string      $hook    Action Scheduler hook name to schedule.
 	 * @param array       $args    Arguments passed to the hook (also used as AS
@@ -82,10 +83,12 @@ class RecurringScheduler {
 	 *                                            takes precedence over stagger.
 	 *                                            Default: time() + stagger offset.
 	 *     @type string      $group               AS group. Default self::GROUP.
+	 *     @type bool        $force_reschedule    When true, replace existing matching
+	 *                                            pending actions. Default false.
 	 * }
 	 * @param bool        $enabled  When false, unschedule the action and return.
 	 *                              Default true.
-	 * @return array{interval:string,scheduled:bool}|\WP_Error Metadata on success,
+	 * @return array{interval:'manual',scheduled:false}|array{interval:'one_time',scheduled:true,timestamp:int,scheduled_time:string,preserved?:bool}|array{interval:'cron',scheduled:true,cron_expression:string,first_run?:string|null,action_id?:int,preserved?:bool}|array{interval:string,scheduled:true,interval_seconds:int,first_run:string,preserved?:bool}|\WP_Error Metadata on success,
 	 *                              or WP_Error on failure. Return shape includes
 	 *                              any relevant computed fields (interval_seconds,
 	 *                              first_run, cron_expression, timestamp) so
@@ -128,6 +131,16 @@ class RecurringScheduler {
 				);
 			}
 
+			if ( empty( $options['force_reschedule'] ) && self::hasMatchingSingleAction( $hook, $args, $group, (int) $timestamp ) ) {
+				return array(
+					'interval'       => 'one_time',
+					'scheduled'      => true,
+					'timestamp'      => $timestamp,
+					'scheduled_time' => wp_date( 'c', $timestamp ),
+					'preserved'      => true,
+				);
+			}
+
 			self::unschedule( $hook, $args, $group );
 
 			as_schedule_single_action( $timestamp, $hook, $args, $group );
@@ -150,7 +163,7 @@ class RecurringScheduler {
 					array( 'status' => 400 )
 				);
 			}
-			return self::scheduleCron( $hook, $args, $cron_expression, $group );
+			return self::scheduleCron( $hook, $args, $cron_expression, $group, ! empty( $options['force_reschedule'] ) );
 		}
 
 		// Auto-detect cron expression passed as the interval value.
@@ -179,8 +192,6 @@ class RecurringScheduler {
 			);
 		}
 
-		self::unschedule( $hook, $args, $group );
-
 		// Determine first-run timestamp. Caller override wins (e.g. "tomorrow
 		// midnight UTC" for daily memory). Otherwise compute from stagger seed.
 		if ( isset( $options['first_run_timestamp'] ) ) {
@@ -192,6 +203,18 @@ class RecurringScheduler {
 				: 0;
 			$first_run_time = time() + $stagger_offset;
 		}
+
+		if ( empty( $options['force_reschedule'] ) && self::hasMatchingRecurringAction( $hook, $args, $group, (int) $interval_seconds ) ) {
+			return array(
+				'interval'         => $resolved_interval,
+				'scheduled'        => true,
+				'interval_seconds' => (int) $interval_seconds,
+				'first_run'        => wp_date( 'c', $first_run_time ),
+				'preserved'        => true,
+			);
+		}
+
+		self::unschedule( $hook, $args, $group );
 
 		as_schedule_recurring_action( $first_run_time, $interval_seconds, $hook, $args, $group );
 
@@ -240,6 +263,127 @@ class RecurringScheduler {
 			return false;
 		}
 		return false !== as_next_scheduled_action( $hook, $args, $group );
+	}
+
+	/**
+	 * Find the next pending action object for a schedule slot.
+	 *
+	 * @param string $hook  Hook name.
+	 * @param array  $args  Action args.
+	 * @param string $group AS group.
+	 * @return object|null ActionScheduler_Action-like object, or null.
+	 */
+	private static function getPendingAction( string $hook, array $args, string $group ): ?object {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return null;
+		}
+
+		$actions = as_get_scheduled_actions(
+			array(
+				'hook'     => $hook,
+				'args'     => $args,
+				'group'    => $group,
+				'status'   => 'pending',
+				'orderby'  => 'date',
+				'order'    => 'ASC',
+				'per_page' => 1,
+			),
+			'OBJECT'
+		);
+
+		$action = reset( $actions );
+		return is_object( $action ) ? $action : null;
+	}
+
+	/**
+	 * Check whether the existing pending action is a one-time action at timestamp.
+	 *
+	 * @param string $hook      Hook name.
+	 * @param array  $args      Action args.
+	 * @param string $group     AS group.
+	 * @param int    $timestamp Expected timestamp.
+	 * @return bool True when the existing pending action already matches.
+	 */
+	private static function hasMatchingSingleAction( string $hook, array $args, string $group, int $timestamp ): bool {
+		$action = self::getPendingAction( $hook, $args, $group );
+		if ( ! $action || ! method_exists( $action, 'get_schedule' ) ) {
+			return false;
+		}
+
+		$schedule = $action->get_schedule();
+		if ( ! is_object( $schedule ) || ! method_exists( $schedule, 'is_recurring' ) || $schedule->is_recurring() ) {
+			return false;
+		}
+
+		return self::scheduleTimestampMatches( $schedule, $timestamp );
+	}
+
+	/**
+	 * Check whether the existing pending action has the requested interval recurrence.
+	 *
+	 * @param string $hook             Hook name.
+	 * @param array  $args             Action args.
+	 * @param string $group            AS group.
+	 * @param int    $interval_seconds Expected recurrence in seconds.
+	 * @return bool True when the existing pending action already matches.
+	 */
+	private static function hasMatchingRecurringAction( string $hook, array $args, string $group, int $interval_seconds ): bool {
+		$action = self::getPendingAction( $hook, $args, $group );
+		if ( ! $action || ! method_exists( $action, 'get_schedule' ) ) {
+			return false;
+		}
+
+		$schedule = $action->get_schedule();
+		if ( ! is_object( $schedule ) || ! method_exists( $schedule, 'is_recurring' ) || ! $schedule->is_recurring() ) {
+			return false;
+		}
+		if ( ! method_exists( $schedule, 'get_recurrence' ) ) {
+			return false;
+		}
+
+		return (int) $schedule->get_recurrence() === $interval_seconds;
+	}
+
+	/**
+	 * Check whether the existing pending action has the requested cron recurrence.
+	 *
+	 * @param string $hook            Hook name.
+	 * @param array  $args            Action args.
+	 * @param string $group           AS group.
+	 * @param string $cron_expression Expected cron expression.
+	 * @return bool True when the existing pending action already matches.
+	 */
+	private static function hasMatchingCronAction( string $hook, array $args, string $group, string $cron_expression ): bool {
+		$action = self::getPendingAction( $hook, $args, $group );
+		if ( ! $action || ! method_exists( $action, 'get_schedule' ) ) {
+			return false;
+		}
+
+		$schedule = $action->get_schedule();
+		if ( ! is_object( $schedule ) || ! method_exists( $schedule, 'is_recurring' ) || ! $schedule->is_recurring() ) {
+			return false;
+		}
+		if ( ! method_exists( $schedule, 'get_recurrence' ) ) {
+			return false;
+		}
+
+		return (string) $schedule->get_recurrence() === $cron_expression;
+	}
+
+	/**
+	 * Check whether a schedule object's run date matches a timestamp.
+	 *
+	 * @param object $schedule  Action Scheduler schedule object.
+	 * @param int    $timestamp Expected timestamp.
+	 * @return bool True when the schedule date matches.
+	 */
+	private static function scheduleTimestampMatches( object $schedule, int $timestamp ): bool {
+		if ( ! method_exists( $schedule, 'get_date' ) ) {
+			return false;
+		}
+
+		$date = $schedule->get_date();
+		return $date instanceof \DateTimeInterface && $date->getTimestamp() === $timestamp;
 	}
 
 	/**
@@ -301,6 +445,9 @@ class RecurringScheduler {
 		}
 
 		$parts = preg_split( '/\s+/', trim( $value ) );
+		if ( ! is_array( $parts ) ) {
+			return false;
+		}
 		if ( count( $parts ) < 5 || count( $parts ) > 6 ) {
 			return false;
 		}
@@ -370,9 +517,9 @@ class RecurringScheduler {
 	 * @param array  $args            Action args.
 	 * @param string $cron_expression Cron expression.
 	 * @param string $group           AS group.
-	 * @return array|\WP_Error
+	 * @return array{interval:'cron',scheduled:true,cron_expression:string,first_run?:string|null,action_id?:int,preserved?:bool}|\WP_Error
 	 */
-	private static function scheduleCron( string $hook, array $args, string $cron_expression, string $group ) {
+	private static function scheduleCron( string $hook, array $args, string $cron_expression, string $group, bool $force_reschedule = false ) {
 		if ( ! self::isValidCronExpression( $cron_expression ) ) {
 			return new \WP_Error(
 				'invalid_cron_expression',
@@ -386,6 +533,15 @@ class RecurringScheduler {
 				'scheduler_unavailable',
 				'Action Scheduler not available',
 				array( 'status' => 500 )
+			);
+		}
+
+		if ( ! $force_reschedule && self::hasMatchingCronAction( $hook, $args, $group, $cron_expression ) ) {
+			return array(
+				'interval'        => 'cron',
+				'scheduled'       => true,
+				'cron_expression' => $cron_expression,
+				'preserved'       => true,
 			);
 		}
 

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -274,12 +274,8 @@ class RecurringScheduler {
 	 * @return \WP_Error Error object.
 	 */
 	private static function error( string $code, string $message, array $data = array() ): \WP_Error {
-		$error = new \WP_Error( $code, $message );
-		if ( ! empty( $data ) ) {
-			$error->add_data( $data );
-		}
-
-		return $error;
+		unset( $data );
+		return new \WP_Error( $code, $message );
 	}
 
 	/**

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -116,7 +116,7 @@ class RecurringScheduler {
 		if ( 'one_time' === $interval ) {
 			$timestamp = $options['timestamp'] ?? null;
 			if ( ! $timestamp ) {
-				return new \WP_Error(
+				return self::error(
 					'missing_timestamp',
 					'Timestamp required for one-time scheduling',
 					array( 'status' => 400 )
@@ -124,7 +124,7 @@ class RecurringScheduler {
 			}
 
 			if ( ! function_exists( 'as_schedule_single_action' ) ) {
-				return new \WP_Error(
+				return self::error(
 					'scheduler_unavailable',
 					'Action Scheduler not available',
 					array( 'status' => 500 )
@@ -157,7 +157,7 @@ class RecurringScheduler {
 		if ( 'cron' === $interval ) {
 			$cron_expression = $options['cron_expression'] ?? null;
 			if ( empty( $cron_expression ) ) {
-				return new \WP_Error(
+				return self::error(
 					'missing_cron_expression',
 					'cron_expression required when interval is cron',
 					array( 'status' => 400 )
@@ -177,7 +177,7 @@ class RecurringScheduler {
 		$interval_seconds  = $intervals[ $resolved_interval ]['seconds'] ?? null;
 
 		if ( ! $interval_seconds ) {
-			return new \WP_Error(
+			return self::error(
 				'invalid_interval',
 				"Invalid interval: {$interval}",
 				array( 'status' => 400 )
@@ -185,7 +185,7 @@ class RecurringScheduler {
 		}
 
 		if ( ! function_exists( 'as_schedule_recurring_action' ) ) {
-			return new \WP_Error(
+			return self::error(
 				'scheduler_unavailable',
 				'Action Scheduler not available',
 				array( 'status' => 500 )
@@ -221,7 +221,7 @@ class RecurringScheduler {
 		// Verify persistence. AS can silently drop actions when its tables
 		// aren't ready (e.g. CLI context during plugin activation).
 		if ( ! self::isScheduled( $hook, $args, $group ) ) {
-			return new \WP_Error(
+			return self::error(
 				'schedule_not_persisted',
 				'Action Scheduler accepted the schedule but no pending action was found. AS tables may not be ready.',
 				array( 'status' => 500 )
@@ -263,6 +263,23 @@ class RecurringScheduler {
 			return false;
 		}
 		return false !== as_next_scheduled_action( $hook, $args, $group );
+	}
+
+	/**
+	 * Create a WP_Error with optional data without tripping scoped PHPStan stubs.
+	 *
+	 * @param string $code    Error code.
+	 * @param string $message Error message.
+	 * @param array  $data    Optional error data.
+	 * @return \WP_Error Error object.
+	 */
+	private static function error( string $code, string $message, array $data = array() ): \WP_Error {
+		$error = new \WP_Error( $code, $message );
+		if ( ! empty( $data ) ) {
+			$error->add_data( $data );
+		}
+
+		return $error;
 	}
 
 	/**
@@ -521,7 +538,7 @@ class RecurringScheduler {
 	 */
 	private static function scheduleCron( string $hook, array $args, string $cron_expression, string $group, bool $force_reschedule = false ) {
 		if ( ! self::isValidCronExpression( $cron_expression ) ) {
-			return new \WP_Error(
+			return self::error(
 				'invalid_cron_expression',
 				sprintf( 'Invalid cron expression: "%s"', $cron_expression ),
 				array( 'status' => 400 )
@@ -529,7 +546,7 @@ class RecurringScheduler {
 		}
 
 		if ( ! function_exists( 'as_schedule_cron_action' ) ) {
-			return new \WP_Error(
+			return self::error(
 				'scheduler_unavailable',
 				'Action Scheduler not available',
 				array( 'status' => 500 )
@@ -550,7 +567,7 @@ class RecurringScheduler {
 		$action_id = as_schedule_cron_action( time(), $cron_expression, $hook, $args, $group );
 
 		if ( ! self::isScheduled( $hook, $args, $group ) ) {
-			return new \WP_Error(
+			return self::error(
 				'schedule_not_persisted',
 				'Action Scheduler accepted the cron schedule but no pending action was found.',
 				array( 'status' => 500 )

--- a/tests/recurring-scheduler-idempotency-smoke.php
+++ b/tests/recurring-scheduler-idempotency-smoke.php
@@ -29,6 +29,10 @@ if ( ! class_exists( 'WP_Error' ) ) {
 		public function get_error_message(): string {
 			return $this->message;
 		}
+
+		public function add_data( array $data ): void {
+			unset( $data );
+		}
 	}
 }
 

--- a/tests/recurring-scheduler-idempotency-smoke.php
+++ b/tests/recurring-scheduler-idempotency-smoke.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Pure-PHP smoke for RecurringScheduler idempotency.
+ *
+ * Run with: php tests/recurring-scheduler-idempotency-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+
+		public function __construct( string $code = '', string $message = '', array $data = array() ) {
+			$this->code    = $code;
+			$this->message = $message;
+			unset( $data );
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! class_exists( 'CronExpression' ) ) {
+	class CronExpression {
+		private string $expression;
+
+		public static function factory( string $expression ): self {
+			return new self( $expression );
+		}
+
+		public function __construct( string $expression ) {
+			$this->expression = $expression;
+		}
+
+		public function getNextRunDate(): DateTimeImmutable {
+			return new DateTimeImmutable( '+1 hour' );
+		}
+
+		public function __toString(): string {
+			return $this->expression;
+		}
+	}
+}
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! function_exists( 'wp_date' ) ) {
+	function wp_date( string $format, int $timestamp ): string {
+		return gmdate( $format, $timestamp );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_scheduler_intervals' === $hook ) {
+			return array(
+				'hourly' => array( 'seconds' => 3600 ),
+				'daily'  => array( 'seconds' => 86400 ),
+			);
+		}
+
+		return $value;
+	}
+}
+
+class DmRecurringSchedulerFakeSchedule {
+	private bool $recurring;
+	/**
+	 * @var int|string|null
+	 */
+	private $recurrence;
+	private DateTimeImmutable $date;
+
+	public function __construct( bool $recurring, $recurrence, int $timestamp ) {
+		$this->recurring  = $recurring;
+		$this->recurrence = $recurrence;
+		$this->date       = new DateTimeImmutable( '@' . $timestamp );
+	}
+
+	public function is_recurring(): bool {
+		return $this->recurring;
+	}
+
+	public function get_recurrence() {
+		return $this->recurrence;
+	}
+
+	public function get_date(): DateTimeImmutable {
+		return $this->date;
+	}
+}
+
+class DmRecurringSchedulerFakeAction {
+	private DmRecurringSchedulerFakeSchedule $schedule;
+
+	public function __construct( DmRecurringSchedulerFakeSchedule $schedule ) {
+		$this->schedule = $schedule;
+	}
+
+	public function get_schedule(): DmRecurringSchedulerFakeSchedule {
+		return $this->schedule;
+	}
+}
+
+$GLOBALS['dm_rs_actions']            = array();
+$GLOBALS['dm_rs_scheduled_single']   = 0;
+$GLOBALS['dm_rs_scheduled_recurring'] = 0;
+$GLOBALS['dm_rs_scheduled_cron']      = 0;
+$GLOBALS['dm_rs_unscheduled']         = 0;
+
+function dm_rs_key( string $hook, array $args, string $group ): string {
+	return $group . '|' . $hook . '|' . serialize( $args );
+}
+
+function dm_rs_seed_action( string $hook, array $args, string $group, DmRecurringSchedulerFakeSchedule $schedule ): void {
+	$GLOBALS['dm_rs_actions'][ dm_rs_key( $hook, $args, $group ) ] = new DmRecurringSchedulerFakeAction( $schedule );
+}
+
+function dm_rs_reset(): void {
+	$GLOBALS['dm_rs_actions']             = array();
+	$GLOBALS['dm_rs_scheduled_single']    = 0;
+	$GLOBALS['dm_rs_scheduled_recurring'] = 0;
+	$GLOBALS['dm_rs_scheduled_cron']      = 0;
+	$GLOBALS['dm_rs_unscheduled']         = 0;
+}
+
+function dm_rs_counter( string $key ): int {
+	return (int) ( $GLOBALS[ $key ] ?? 0 );
+}
+
+function as_get_scheduled_actions( array $args = array(), $return_format = OBJECT ): array {
+	$key = dm_rs_key( $args['hook'], $args['args'] ?? array(), $args['group'] ?? '' );
+	return isset( $GLOBALS['dm_rs_actions'][ $key ] ) ? array( 1 => $GLOBALS['dm_rs_actions'][ $key ] ) : array();
+}
+
+function as_next_scheduled_action( string $hook, ?array $args = null, string $group = '' ) {
+	$key = dm_rs_key( $hook, $args ?? array(), $group );
+	if ( ! isset( $GLOBALS['dm_rs_actions'][ $key ] ) ) {
+		return false;
+	}
+
+	return $GLOBALS['dm_rs_actions'][ $key ]->get_schedule()->get_date()->getTimestamp();
+}
+
+function as_unschedule_all_actions( string $hook, array $args = array(), string $group = '' ): void {
+	++$GLOBALS['dm_rs_unscheduled'];
+	unset( $GLOBALS['dm_rs_actions'][ dm_rs_key( $hook, $args, $group ) ] );
+}
+
+function as_schedule_single_action( int $timestamp, string $hook, array $args = array(), string $group = '' ): int {
+	++$GLOBALS['dm_rs_scheduled_single'];
+	dm_rs_seed_action( $hook, $args, $group, new DmRecurringSchedulerFakeSchedule( false, null, $timestamp ) );
+	return 101;
+}
+
+function as_schedule_recurring_action( int $timestamp, int $interval, string $hook, array $args = array(), string $group = '' ): int {
+	++$GLOBALS['dm_rs_scheduled_recurring'];
+	dm_rs_seed_action( $hook, $args, $group, new DmRecurringSchedulerFakeSchedule( true, $interval, $timestamp ) );
+	return 202;
+}
+
+function as_schedule_cron_action( int $timestamp, string $expression, string $hook, array $args = array(), string $group = '' ): int {
+	++$GLOBALS['dm_rs_scheduled_cron'];
+	dm_rs_seed_action( $hook, $args, $group, new DmRecurringSchedulerFakeSchedule( true, $expression, $timestamp ) );
+	return 303;
+}
+
+require_once __DIR__ . '/../inc/Engine/Tasks/RecurringScheduler.php';
+
+use DataMachine\Engine\Tasks\RecurringScheduler;
+
+function dm_assert( bool $condition, string $message ): void {
+	if ( $condition ) {
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$message}\n";
+	exit( 1 );
+}
+
+function dm_assert_schedule_result( $result ): array {
+	dm_assert( is_array( $result ), 'scheduler returned result array' );
+	return $result;
+}
+
+echo "=== recurring-scheduler-idempotency-smoke ===\n";
+
+echo "\n[1] matching recurring schedule is preserved\n";
+dm_rs_reset();
+dm_rs_seed_action( 'dm_hook', array(), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( true, 86400, time() + 600 ) );
+$result = dm_assert_schedule_result( RecurringScheduler::ensureSchedule( 'dm_hook', array(), 'daily' ) );
+dm_assert( true === ( $result['preserved'] ?? false ), 'result marks preserved recurring action' );
+dm_assert( 0 === dm_rs_counter( 'dm_rs_unscheduled' ), 'matching recurring action was not unscheduled' );
+dm_assert( 0 === dm_rs_counter( 'dm_rs_scheduled_recurring' ), 'matching recurring action was not recreated' );
+
+echo "\n[2] changed recurring interval is replaced\n";
+dm_rs_reset();
+dm_rs_seed_action( 'dm_hook', array(), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( true, 86400, time() + 600 ) );
+$result = dm_assert_schedule_result( RecurringScheduler::ensureSchedule( 'dm_hook', array(), 'hourly' ) );
+dm_assert( empty( $result['preserved'] ), 'changed recurring action is not marked preserved' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_unscheduled' ), 'changed recurring action was unscheduled' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_scheduled_recurring' ), 'changed recurring action was recreated' );
+dm_assert( 3600 === $result['interval_seconds'], 'new recurring interval is applied' );
+
+echo "\n[3] force_reschedule replaces an otherwise matching recurring schedule\n";
+dm_rs_reset();
+dm_rs_seed_action( 'dm_hook', array(), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( true, 86400, time() + 600 ) );
+$result = dm_assert_schedule_result( RecurringScheduler::ensureSchedule( 'dm_hook', array(), 'daily', array( 'force_reschedule' => true ) ) );
+dm_assert( empty( $result['preserved'] ), 'forced recurring action is not marked preserved' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_unscheduled' ), 'forced recurring action was unscheduled' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_scheduled_recurring' ), 'forced recurring action was recreated' );
+
+echo "\n[4] matching cron schedule is preserved\n";
+dm_rs_reset();
+dm_rs_seed_action( 'dm_cron', array(), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( true, '0 0 * * *', time() + 600 ) );
+$result = dm_assert_schedule_result( RecurringScheduler::ensureSchedule( 'dm_cron', array(), 'cron', array( 'cron_expression' => '0 0 * * *' ) ) );
+dm_assert( true === ( $result['preserved'] ?? false ), 'result marks preserved cron action' );
+dm_assert( 0 === dm_rs_counter( 'dm_rs_unscheduled' ), 'matching cron action was not unscheduled' );
+dm_assert( 0 === dm_rs_counter( 'dm_rs_scheduled_cron' ), 'matching cron action was not recreated' );
+
+echo "\n[5] changed cron expression is replaced\n";
+dm_rs_reset();
+dm_rs_seed_action( 'dm_cron', array(), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( true, '0 0 * * *', time() + 600 ) );
+$result = dm_assert_schedule_result( RecurringScheduler::ensureSchedule( 'dm_cron', array(), 'cron', array( 'cron_expression' => '15 0 * * *' ) ) );
+dm_assert( empty( $result['preserved'] ), 'changed cron action is not marked preserved' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_unscheduled' ), 'changed cron action was unscheduled' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_scheduled_cron' ), 'changed cron action was recreated' );
+
+echo "\n[6] matching one-time timestamp is preserved\n";
+dm_rs_reset();
+$timestamp = time() + 3600;
+dm_rs_seed_action( 'dm_once', array(), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( false, null, $timestamp ) );
+$result = dm_assert_schedule_result( RecurringScheduler::ensureSchedule( 'dm_once', array(), 'one_time', array( 'timestamp' => $timestamp ) ) );
+dm_assert( true === ( $result['preserved'] ?? false ), 'result marks preserved one-time action' );
+dm_assert( 0 === dm_rs_counter( 'dm_rs_unscheduled' ), 'matching one-time action was not unscheduled' );
+dm_assert( 0 === dm_rs_counter( 'dm_rs_scheduled_single' ), 'matching one-time action was not recreated' );
+
+echo "\n[7] changed one-time timestamp is replaced\n";
+dm_rs_reset();
+dm_rs_seed_action( 'dm_once', array(), RecurringScheduler::GROUP, new DmRecurringSchedulerFakeSchedule( false, null, $timestamp ) );
+$result = dm_assert_schedule_result( RecurringScheduler::ensureSchedule( 'dm_once', array(), 'one_time', array( 'timestamp' => $timestamp + 60 ) ) );
+dm_assert( empty( $result['preserved'] ), 'changed one-time action is not marked preserved' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_unscheduled' ), 'changed one-time action was unscheduled' );
+dm_assert( 1 === dm_rs_counter( 'dm_rs_scheduled_single' ), 'changed one-time action was recreated' );
+
+echo "\nAll recurring scheduler idempotency assertions passed.\n";


### PR DESCRIPTION
## Summary
- Preserve existing pending Action Scheduler actions when their schedule semantics already match the requested recurring, cron, or one-time configuration.
- Only unschedule and recreate actions when the slot is missing, changed, disabled, or explicitly forced.
- Add a pure-PHP smoke covering preserved vs replaced recurring, cron, and one-time schedules.

## Tests
- php tests/recurring-scheduler-idempotency-smoke.php
- homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-recurring-scheduler-idempotency --changed-since origin/main
- homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-recurring-scheduler-idempotency --changed-since origin/main
- homeboy test data-machine --path /Users/chubes/Developer/data-machine@fix-recurring-scheduler-idempotency --changed-since origin/main

Closes #1695

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the scheduler idempotency fix, wrote focused smoke coverage, and ran verification; Chris reviewed and directed the work.