### PR TITLE
fix(ai): convert wp-ai-client history to message DTOs

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -178,7 +178,10 @@ class RequestBuilder {
 					continue;
 				}
 
-				$history[] = $message;
+				$history_message = self::wpAiClientHistoryMessage( $message );
+				if ( null !== $history_message ) {
+					$history[] = $history_message;
+				}
 			}
 
 			if ( ! empty( $system_parts ) ) {
@@ -234,6 +237,67 @@ class RequestBuilder {
 		);
 
 		return $result;
+	}
+
+	/**
+	 * Convert Data Machine's canonical provider-message array into a wp-ai-client message DTO.
+	 *
+	 * @param array $message Provider-message array.
+	 * @return \WordPress\AiClient\Messages\DTO\Message|null Message DTO, or null when the shape is unsupported.
+	 */
+	private static function wpAiClientHistoryMessage( array $message ): ?\WordPress\AiClient\Messages\DTO\Message {
+		$role = (string) ( $message['role'] ?? '' );
+		$text = self::wpAiClientMessageText( $message['content'] ?? '' );
+		if ( null === $text ) {
+			return null;
+		}
+
+		$parts = array( new \WordPress\AiClient\Messages\DTO\MessagePart( $text ) );
+
+		if ( 'assistant' === $role || 'model' === $role ) {
+			return new \WordPress\AiClient\Messages\DTO\ModelMessage( $parts );
+		}
+
+		if ( 'user' === $role ) {
+			return new \WordPress\AiClient\Messages\DTO\UserMessage( $parts );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Extract text content from canonical message content shapes.
+	 *
+	 * @param mixed $content Message content.
+	 * @return string|null Text content, or null when no text is available.
+	 */
+	private static function wpAiClientMessageText( $content ): ?string {
+		if ( is_string( $content ) ) {
+			return '' !== $content ? $content : null;
+		}
+
+		if ( ! is_array( $content ) ) {
+			return null;
+		}
+
+		$parts = array();
+		foreach ( $content as $part ) {
+			if ( is_string( $part ) && '' !== $part ) {
+				$parts[] = $part;
+				continue;
+			}
+
+			if ( ! is_array( $part ) ) {
+				continue;
+			}
+
+			$text = $part['text'] ?? $part['content'] ?? null;
+			if ( is_string( $text ) && '' !== $text ) {
+				$parts[] = $text;
+			}
+		}
+
+		return ! empty( $parts ) ? implode( "\n\n", $parts ) : null;
 	}
 
 	/**

--- a/tests/wp-ai-client-request-timeout-smoke.php
+++ b/tests/wp-ai-client-request-timeout-smoke.php
@@ -205,6 +205,10 @@ $result = RequestBuilder::build(
 			'role'    => 'user',
 			'content' => 'hello',
 		),
+		array(
+			'role'    => 'assistant',
+			'content' => 'hi there',
+		),
 	),
 	'openai',
 	'gpt-smoke',
@@ -219,6 +223,10 @@ assert_timeout_smoke( 300.0 === ( $timeout_context['timeout'] ?? null ), 'Data M
 assert_timeout_smoke( 'pipeline' === ( $timeout_context['mode'] ?? null ), 'Data Machine timeout filter receives execution mode' );
 assert_timeout_smoke( 'openai' === ( $timeout_context['provider'] ?? null ), 'Data Machine timeout filter receives provider' );
 assert_timeout_smoke( 'gpt-smoke' === ( $timeout_context['model'] ?? null ), 'Data Machine timeout filter receives model' );
+
+$captured_history = TimeoutPromptBuilderDouble::$captured_request['history'] ?? array();
+assert_timeout_smoke( isset( $captured_history[0] ) && $captured_history[0] instanceof \WordPress\AiClient\Messages\DTO\UserMessage, 'Data Machine converts user history arrays to wp-ai-client UserMessage DTOs' );
+assert_timeout_smoke( isset( $captured_history[1] ) && $captured_history[1] instanceof \WordPress\AiClient\Messages\DTO\ModelMessage, 'Data Machine converts assistant history arrays to wp-ai-client ModelMessage DTOs' );
 
 assert_timeout_smoke( 0 === timeout_smoke_filter_count( 'wp_ai_client_default_request_timeout' ), 'Data Machine removes temporary wp-ai-client timeout filter after dispatch' );
 


### PR DESCRIPTION
## Summary
- Convert Data Machine provider-message history arrays into wp-ai-client `UserMessage` / `ModelMessage` DTOs before calling `with_history()`.
- Extend the existing wp-ai-client request smoke to assert user and assistant history are passed as DTOs.

## Tests
- `php tests/wp-ai-client-request-timeout-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-wp-ai-client-history-dto --file inc/Engine/AI/RequestBuilder.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-wp-ai-client-history-dto --file tests/wp-ai-client-request-timeout-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the live wp-ai-client history DTO mismatch, implemented the adapter fix, and ran focused verification. Chris remains responsible for review and merge.