### PR TITLE
fix(ai): extend wp-ai-client curl low-speed window

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -126,9 +126,19 @@ class RequestBuilder {
 		$timeout_filter  = static function ( $default_timeout ) use ( $request_timeout ) {
 			return max( (float) $default_timeout, $request_timeout );
 		};
+		$curl_filter     = static function ( $handle ) use ( $request_timeout ) {
+			if ( defined( 'CURLOPT_LOW_SPEED_TIME' ) ) {
+				curl_setopt( $handle, CURLOPT_LOW_SPEED_TIME, (int) ceil( $request_timeout ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_setopt -- WordPress exposes the cURL handle only through this hook.
+			}
+
+			if ( defined( 'CURLOPT_LOW_SPEED_LIMIT' ) ) {
+				curl_setopt( $handle, CURLOPT_LOW_SPEED_LIMIT, 1 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_setopt -- WordPress exposes the cURL handle only through this hook.
+			}
+		};
 
 		try {
 			add_filter( 'wp_ai_client_default_request_timeout', $timeout_filter, 10, 1 );
+			add_action( 'http_api_curl', $curl_filter, 10, 1 );
 
 			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
 			/** @var callable $has_provider wp-ai-client exposes this through __call() in some versions. */
@@ -216,6 +226,7 @@ class RequestBuilder {
 		} finally {
 			if ( function_exists( 'remove_filter' ) ) {
 				remove_filter( 'wp_ai_client_default_request_timeout', $timeout_filter, 10 );
+				remove_filter( 'http_api_curl', $curl_filter, 10 );
 			}
 		}
 

--- a/tests/wp-ai-client-request-timeout-smoke.php
+++ b/tests/wp-ai-client-request-timeout-smoke.php
@@ -17,6 +17,12 @@ if ( ! function_exists( 'add_filter' ) ) {
 	}
 }
 
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		add_filter( $tag, $callback, $priority, $accepted_args );
+	}
+}
+
 if ( ! function_exists( 'remove_filter' ) ) {
 	function remove_filter( string $tag, callable $callback, int $priority = 10 ): void {
 		foreach ( $GLOBALS['datamachine_timeout_test_filters'][ $tag ][ $priority ] ?? array() as $index => $entry ) {
@@ -131,11 +137,12 @@ class TimeoutPromptBuilderDouble {
 
 	public function generate_text_result() {
 		self::$captured_request = array(
-			'provider' => $this->provider,
-			'model'    => $this->model,
-			'prompt'   => $this->prompt,
-			'timeout'  => $this->request_timeout,
-			'history'  => $this->history,
+			'provider'          => $this->provider,
+			'model'             => $this->model,
+			'prompt'            => $this->prompt,
+			'timeout'           => $this->request_timeout,
+			'history'           => $this->history,
+			'curl_filter_count' => timeout_smoke_filter_count( 'http_api_curl' ),
 		);
 
 		return \WordPress\AiClient\Results\DTO\GenerativeAiResult::fromData(
@@ -227,8 +234,10 @@ assert_timeout_smoke( 'gpt-smoke' === ( $timeout_context['model'] ?? null ), 'Da
 $captured_history = TimeoutPromptBuilderDouble::$captured_request['history'] ?? array();
 assert_timeout_smoke( isset( $captured_history[0] ) && $captured_history[0] instanceof \WordPress\AiClient\Messages\DTO\UserMessage, 'Data Machine converts user history arrays to wp-ai-client UserMessage DTOs' );
 assert_timeout_smoke( isset( $captured_history[1] ) && $captured_history[1] instanceof \WordPress\AiClient\Messages\DTO\ModelMessage, 'Data Machine converts assistant history arrays to wp-ai-client ModelMessage DTOs' );
+assert_timeout_smoke( 1 === ( TimeoutPromptBuilderDouble::$captured_request['curl_filter_count'] ?? null ), 'Data Machine scopes cURL low-speed settings during wp-ai-client dispatch' );
 
 assert_timeout_smoke( 0 === timeout_smoke_filter_count( 'wp_ai_client_default_request_timeout' ), 'Data Machine removes temporary wp-ai-client timeout filter after dispatch' );
+assert_timeout_smoke( 0 === timeout_smoke_filter_count( 'http_api_curl' ), 'Data Machine removes temporary cURL low-speed filter after dispatch' );
 
 if ( timeout_smoke_failure_count() > 0 ) {
 	exit( 1 );


### PR DESCRIPTION
## Summary
- Scope an `http_api_curl` filter around Data Machine wp-ai-client dispatch so long-running AI calls inherit Data Machine's request timeout as the cURL low-speed window.
- Keep the low-speed limit permissive for AI responses that can legitimately stay quiet while OpenAI prepares output.
- Extend the wp-ai-client timeout smoke to verify the cURL filter is installed during dispatch and removed afterward.

## Tests
- `php tests/wp-ai-client-request-timeout-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-wp-ai-client-history-dto --file inc/Engine/AI/RequestBuilder.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-wp-ai-client-history-dto --file tests/wp-ai-client-request-timeout-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the live cURL low-speed timeout, implemented the scoped transport filter, and ran focused verification. Chris remains responsible for review and merge.