### PR TITLE
fix(memory): archive runaway memory before AI compaction

### DIFF
--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -101,6 +101,17 @@ class DailyMemoryTask extends SystemTask {
 		$memory_content = $result['content'];
 		$original_size  = strlen( $memory_content );
 
+		$overflow_result = $this->maybeHandleDeterministicOverflow( $jobId, $memory, $daily, $memory_content, $original_size, $date );
+		if ( null !== $overflow_result ) {
+			if ( empty( $overflow_result['success'] ) ) {
+				$this->failJob( $jobId, $overflow_result['message'] ?? 'Daily memory overflow split failed.' );
+				return;
+			}
+
+			$this->completeJob( $jobId, $overflow_result );
+			return;
+		}
+
 		// Skip if MEMORY.md is within the recommended threshold and no activity context.
 		$context = $this->gatherContext( $params );
 		if ( $original_size <= AgentMemory::MAX_FILE_SIZE && empty( $context ) ) {
@@ -363,6 +374,165 @@ class DailyMemoryTask extends SystemTask {
 				'new_size'      => $new_size,
 				'archived_size' => $archived_size,
 			)
+		);
+	}
+
+	/**
+	 * Deterministically split very large MEMORY.md files before invoking AI.
+	 *
+	 * Extremely large memory files can exceed the practical request envelope for
+	 * non-streaming provider calls. This path archives whole tail sections verbatim
+	 * and leaves a small persistent file with an archive pointer, preserving every
+	 * byte without asking the model to process the entire oversized file.
+	 *
+	 * @param int         $jobId          Job ID.
+	 * @param AgentMemory $memory         Agent memory facade.
+	 * @param DailyMemory $daily          Daily memory facade.
+	 * @param string      $memory_content Current MEMORY.md content.
+	 * @param int         $original_size  Original byte size.
+	 * @param string      $date           Archive date.
+	 * @return array|null Result array when handled, null when normal AI compaction should proceed.
+	 */
+	private function maybeHandleDeterministicOverflow( int $jobId, AgentMemory $memory, DailyMemory $daily, string $memory_content, int $original_size, string $date ): ?array {
+		$threshold = (int) apply_filters(
+			'datamachine_daily_memory_overflow_threshold',
+			AgentMemory::MAX_FILE_SIZE * 4,
+			array(
+				'job_id'        => $jobId,
+				'date'          => $date,
+				'original_size' => $original_size,
+			)
+		);
+
+		if ( $threshold <= 0 || $original_size <= $threshold ) {
+			return null;
+		}
+
+		$target_size = (int) apply_filters(
+			'datamachine_daily_memory_overflow_target_size',
+			AgentMemory::MAX_FILE_SIZE,
+			array(
+				'job_id'        => $jobId,
+				'date'          => $date,
+				'original_size' => $original_size,
+			)
+		);
+		$target_size = max( 1024, $target_size );
+
+		$split = self::splitMemorySectionsForOverflow( $memory_content, $target_size, $date );
+		if ( empty( $split['archived'] ) ) {
+			return null;
+		}
+
+		$write_result = $memory->replace_all( $split['persistent'] );
+		if ( empty( $write_result['success'] ) ) {
+			return array(
+				'success' => false,
+				'message' => $write_result['message'],
+			);
+		}
+
+		$parts        = explode( '-', $date );
+		$archive_body = "\n### Archived from oversized MEMORY.md\n\n" . $split['archived'] . "\n";
+		$append       = $daily->append( $parts[0], $parts[1], $parts[2], $archive_body );
+		if ( empty( $append['success'] ) ) {
+			return array(
+				'success' => false,
+				'message' => $append['message'],
+			);
+		}
+
+		$archived_size = strlen( $split['archived'] );
+		$new_size      = strlen( $split['persistent'] );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			sprintf(
+				'Daily memory overflow split complete: %s -> %s (%s archived verbatim to daily/%s)',
+				size_format( $original_size ),
+				size_format( $new_size ),
+				size_format( $archived_size ),
+				$date
+			),
+			array(
+				'date'              => $date,
+				'original_size'     => $original_size,
+				'new_size'          => $new_size,
+				'archived_size'     => $archived_size,
+				'archived_blocks'   => $split['archived_blocks'],
+				'persistent_blocks' => $split['persistent_blocks'],
+			)
+		);
+
+		return array(
+			'success'           => true,
+			'date'              => $date,
+			'original_size'     => $original_size,
+			'new_size'          => $new_size,
+			'archived_size'     => $archived_size,
+			'overflow_split'    => true,
+			'archived_blocks'   => $split['archived_blocks'],
+			'persistent_blocks' => $split['persistent_blocks'],
+		);
+	}
+
+	/**
+	 * Split markdown into persistent head sections and archived tail sections.
+	 *
+	 * @param string $content     Full MEMORY.md content.
+	 * @param int    $target_size Target persistent size in bytes.
+	 * @param string $date        Archive date.
+	 * @return array{persistent: string, archived: string, persistent_blocks: int, archived_blocks: int}
+	 */
+	private static function splitMemorySectionsForOverflow( string $content, int $target_size, string $date ): array {
+		$blocks = preg_split( '/(?=^## .+$)/m', trim( $content ), -1, PREG_SPLIT_NO_EMPTY );
+		if ( ! is_array( $blocks ) || count( $blocks ) < 2 ) {
+			return array(
+				'persistent'        => $content,
+				'archived'          => '',
+				'persistent_blocks' => count( is_array( $blocks ) ? $blocks : array() ),
+				'archived_blocks'   => 0,
+			);
+		}
+
+		$persistent = array();
+		$archived   = array();
+		$pointer    = sprintf(
+			"\n## Archived Memory Overflow\n\nOn %s, Daily Memory archived older MEMORY.md sections verbatim to `daily/%s`. Use daily memory search/read when those details are needed.\n",
+			$date,
+			str_replace( '-', '/', $date ) . '.md'
+		);
+
+		foreach ( $blocks as $index => $block ) {
+			$block = trim( $block );
+			if ( '' === $block ) {
+				continue;
+			}
+
+			$candidate = implode( "\n\n", array_merge( $persistent, array( $block ) ) ) . $pointer;
+			if ( 0 === $index || strlen( $candidate ) <= $target_size ) {
+				$persistent[] = $block;
+				continue;
+			}
+
+			$archived[] = $block;
+		}
+
+		if ( empty( $archived ) ) {
+			return array(
+				'persistent'        => $content,
+				'archived'          => '',
+				'persistent_blocks' => count( $persistent ),
+				'archived_blocks'   => 0,
+			);
+		}
+
+		return array(
+			'persistent'        => rtrim( implode( "\n\n", $persistent ) . $pointer ) . "\n",
+			'archived'          => implode( "\n\n", $archived ),
+			'persistent_blocks' => count( $persistent ),
+			'archived_blocks'   => count( $archived ),
 		);
 	}
 

--- a/tests/daily-memory-overflow-split-smoke.php
+++ b/tests/daily-memory-overflow-split-smoke.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Pure-PHP smoke for the Daily Memory deterministic overflow split.
+ *
+ * Run with: php tests/daily-memory-overflow-split-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$failures = array();
+$passes   = 0;
+
+function dm_overflow_assert( bool $condition, string $label, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "FAIL: {$label}\n";
+}
+
+/**
+ * Mirrors DailyMemoryTask::splitMemorySectionsForOverflow().
+ *
+ * @return array{persistent: string, archived: string, persistent_blocks: int, archived_blocks: int}
+ */
+function dm_overflow_split( string $content, int $target_size, string $date ): array {
+	$blocks = preg_split( '/(?=^## .+$)/m', trim( $content ), -1, PREG_SPLIT_NO_EMPTY );
+	if ( ! is_array( $blocks ) || count( $blocks ) < 2 ) {
+		return array(
+			'persistent'        => $content,
+			'archived'          => '',
+			'persistent_blocks' => count( is_array( $blocks ) ? $blocks : array() ),
+			'archived_blocks'   => 0,
+		);
+	}
+
+	$persistent = array();
+	$archived   = array();
+	$pointer    = sprintf(
+		"\n## Archived Memory Overflow\n\nOn %s, Daily Memory archived older MEMORY.md sections verbatim to `daily/%s`. Use daily memory search/read when those details are needed.\n",
+		$date,
+		str_replace( '-', '/', $date ) . '.md'
+	);
+
+	foreach ( $blocks as $index => $block ) {
+		$block = trim( $block );
+		if ( '' === $block ) {
+			continue;
+		}
+
+		$candidate = implode( "\n\n", array_merge( $persistent, array( $block ) ) ) . $pointer;
+		if ( 0 === $index || strlen( $candidate ) <= $target_size ) {
+			$persistent[] = $block;
+			continue;
+		}
+
+		$archived[] = $block;
+	}
+
+	if ( empty( $archived ) ) {
+		return array(
+			'persistent'        => $content,
+			'archived'          => '',
+			'persistent_blocks' => count( $persistent ),
+			'archived_blocks'   => 0,
+		);
+	}
+
+	return array(
+		'persistent'        => rtrim( implode( "\n\n", $persistent ) . $pointer ) . "\n",
+		'archived'          => implode( "\n\n", $archived ),
+		'persistent_blocks' => count( $persistent ),
+		'archived_blocks'   => count( $archived ),
+	);
+}
+
+$source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/System/Tasks/DailyMemoryTask.php' );
+dm_overflow_assert( str_contains( $source, 'maybeHandleDeterministicOverflow' ), 'production task has deterministic overflow hook', $failures, $passes );
+dm_overflow_assert( str_contains( $source, 'splitMemorySectionsForOverflow' ), 'production task has section-split helper', $failures, $passes );
+dm_overflow_assert( str_contains( $source, 'datamachine_daily_memory_overflow_threshold' ), 'overflow threshold is filterable', $failures, $passes );
+dm_overflow_assert( str_contains( $source, 'datamachine_daily_memory_overflow_target_size' ), 'overflow target size is filterable', $failures, $passes );
+
+$content = "# Agent Memory\n\nIntro stays.\n\n";
+for ( $i = 1; $i <= 8; $i++ ) {
+	$content .= "## Section {$i}\n\n" . str_repeat( "Line {$i} persistent or session detail.\n", 12 ) . "\n";
+}
+
+$split = dm_overflow_split( $content, 1400, '2026-05-01' );
+dm_overflow_assert( '' !== $split['archived'], 'oversized input produces archive content', $failures, $passes );
+dm_overflow_assert( str_contains( $split['persistent'], 'Archived Memory Overflow' ), 'persistent output includes archive pointer', $failures, $passes );
+dm_overflow_assert( str_contains( $split['persistent'], 'daily/2026/05/01.md' ), 'archive pointer names daily file path', $failures, $passes );
+dm_overflow_assert( str_contains( $split['persistent'], '## Section 1' ), 'persistent output keeps early sections', $failures, $passes );
+dm_overflow_assert( str_contains( $split['archived'], '## Section 8' ), 'archive output keeps later sections verbatim', $failures, $passes );
+dm_overflow_assert( ! str_contains( $split['persistent'], '## Section 8' ), 'archived sections are removed from persistent output', $failures, $passes );
+dm_overflow_assert( $split['persistent_blocks'] > 0, 'persistent block count reported', $failures, $passes );
+dm_overflow_assert( $split['archived_blocks'] > 0, 'archived block count reported', $failures, $passes );
+
+$small = dm_overflow_split( "## Only\n\nSmall file.\n", 1400, '2026-05-01' );
+dm_overflow_assert( '' === $small['archived'], 'single-section small input does not split', $failures, $passes );
+
+echo "\n{$passes} passed, " . count( $failures ) . " failed\n";
+if ( ! empty( $failures ) ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Add a deterministic Daily Memory overflow path for runaway `MEMORY.md` files before invoking AI compaction.
- Archive whole tail sections verbatim to daily memory and leave an `Archived Memory Overflow` pointer in `MEMORY.md`.
- Keep normal AI compaction unchanged for moderately sized memory files.

## Why
Franklin's live `MEMORY.md` reached ~248KB. The normal single-request compaction path now reaches OpenAI correctly, but the provider returns 0 bytes for the oversized request until the full request timeout expires. This circuit breaker preserves the runaway content without sending the whole file to the model.

## Tests
- `php tests/daily-memory-overflow-split-smoke.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-daily-memory-overflow --file inc/Engine/AI/System/Tasks/DailyMemoryTask.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-daily-memory-overflow --file tests/daily-memory-overflow-split-smoke.php`
- `homeboy audit data-machine --path /Users/chubes/Developer/data-machine@fix-daily-memory-overflow --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runaway daily-memory compaction failure, implemented the deterministic overflow split, and ran focused verification. Chris remains responsible for review and merge.