### PR TITLE
fix(ai): make duplicate tool call message mode-aware

### DIFF
--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -326,7 +326,14 @@ $validation_result = ConversationManager::validateToolCall(
 );
 
 if ($validation_result['is_duplicate']) {
-    $correction_message = ConversationManager::generateDuplicateToolCallMessage($tool_name);
+    // $mode is the loop's current execution mode ('chat', 'pipeline', 'bridge', ...).
+    // The correction message is shaped per-mode so pipeline AI steps are told to
+    // call the publish handler instead of ending the conversation. See #1441.
+    $correction_message = ConversationManager::generateDuplicateToolCallMessage(
+        $tool_name,
+        $turn_count,
+        $mode
+    );
     $messages[] = $correction_message;
     continue; // Skip execution
 }

--- a/docs/core-system/conversation-manager.md
+++ b/docs/core-system/conversation-manager.md
@@ -341,23 +341,46 @@ $extracted = ConversationManager::extractToolCallFromMessage($message);
 
 #### generateDuplicateToolCallMessage()
 
-Generate a user message for duplicate tool call prevention.
+Generate a tool-result message for duplicate tool call prevention. The
+correction message is **mode-aware** so the AI receives continuation guidance
+appropriate to the current execution mode.
 
 **Signature**:
 ```php
-public static function generateDuplicateToolCallMessage(string $tool_name): array
+public static function generateDuplicateToolCallMessage(
+    string $tool_name,
+    int $turn_count = 0,
+    string $mode = 'chat'
+): array
 ```
 
 **Parameters**:
 - `$tool_name` (string) - Tool name that was duplicated
+- `$turn_count` (int) - Current conversation turn (0 = no turn display)
+- `$mode` (string) - Execution mode (`'chat'`, `'pipeline'`, `'bridge'`, ...). Defaults to `'chat'` so existing callers retain prior behavior.
 
-**Returns**: Formatted user message with correction guidance
+**Returns**: Formatted tool-result envelope (`success: false`, `error: <mode-shaped guidance>`)
+
+**Mode behavior**:
+- `'chat'` (default) — instructs the AI to **end the conversation**. The tool's success IS the answer to the user's question.
+- `'pipeline'` — instructs the AI to **call the publish handler tool now** to complete the step. Pipeline conversations have downstream work after the duplicated tool call.
+- `'bridge'` — instructs the AI to **continue its response to the user** using the result it already has.
+- Unknown modes fall back to chat semantics.
 
 **Example**:
 ```php
-$message = ConversationManager::generateDuplicateToolCallMessage('google_search');
-// Returns: ['role' => 'user', 'content' => 'You just called the Google Search tool with the exact same parameters as your previous action. Please try a different approach or use different parameters instead.']
+// Chat: AI is told the task is done.
+$msg = ConversationManager::generateDuplicateToolCallMessage('google_search');
+
+// Pipeline: AI is told to move on to the publish handler.
+$msg = ConversationManager::generateDuplicateToolCallMessage(
+    'queue_validator',
+    $turn_count,
+    'pipeline'
+);
 ```
+
+**Background**: see [data-machine #1441](https://github.com/Extra-Chill/data-machine/issues/1441) — chat-shaped guidance was previously emitted for every mode, which caused pipeline AI steps to silently end mid-conversation after a duplicate tool call instead of finishing the publish step.
 
 ---
 

--- a/inc/Engine/AI/AIConversationLoop.php
+++ b/inc/Engine/AI/AIConversationLoop.php
@@ -395,7 +395,11 @@ class AIConversationLoop {
 					);
 
 					if ( $validation_result['is_duplicate'] ) {
-						$correction_message = ConversationManager::generateDuplicateToolCallMessage( $tool_name, $turn_count );
+						$correction_message = ConversationManager::generateDuplicateToolCallMessage(
+							$tool_name,
+							$turn_count,
+							$mode
+						);
 						$messages[]         = $correction_message;
 
 						do_action(

--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -398,17 +398,48 @@ class ConversationManager {
 	/**
 	 * Generate a tool result message for duplicate tool call prevention.
 	 *
-	 * @param string $tool_name Tool name that was duplicated
+	 * The correction message is mode-aware. Chat-mode conversations end after a
+	 * duplicate (the tool's result IS the answer to the user's question), but
+	 * pipeline-mode conversations still have downstream work — typically a
+	 * publish handler tool — so the AI must be told to keep going. Bridge mode
+	 * is treated like chat-with-continuation since the conversation is with a
+	 * remote user. Unknown modes fall back to chat semantics.
+	 *
+	 * @param string $tool_name  Tool name that was duplicated
 	 * @param int    $turn_count Current conversation turn
+	 * @param string $mode       Execution mode ('chat', 'pipeline', 'bridge', ...). Defaults to 'chat'.
 	 * @return array Formatted tool result message
 	 */
-	public static function generateDuplicateToolCallMessage( string $tool_name, int $turn_count = 0 ): array {
+	public static function generateDuplicateToolCallMessage(
+		string $tool_name,
+		int $turn_count = 0,
+		string $mode = 'chat'
+	): array {
 		$tool_result = array(
 			'success' => false,
-			'error'   => "DUPLICATE REJECTED: You already called {$tool_name} with these exact parameters earlier in this conversation and it succeeded. Do NOT call it again. Do NOT call skip_item about this. The task is done — end the conversation.",
+			'error'   => self::buildDuplicateToolCallError( $tool_name, $mode ),
 		);
 
 		return self::formatToolResultMessage( $tool_name, $tool_result, array(), false, $turn_count );
+	}
+
+	/**
+	 * Build the mode-appropriate correction text for a duplicate tool call.
+	 *
+	 * @param string $tool_name Tool name that was duplicated.
+	 * @param string $mode      Execution mode slug.
+	 * @return string Correction message routed to the AI.
+	 */
+	private static function buildDuplicateToolCallError( string $tool_name, string $mode ): string {
+		switch ( $mode ) {
+			case 'pipeline':
+				return "DUPLICATE REJECTED: You already called {$tool_name} with these exact parameters earlier in this conversation. Do NOT call it again. Move on — call the publish handler tool now to complete this step.";
+			case 'bridge':
+				return "DUPLICATE REJECTED: You already called {$tool_name} with these exact parameters. Do NOT call it again. Continue your response to the user using the result you already have.";
+			case 'chat':
+			default:
+				return "DUPLICATE REJECTED: You already called {$tool_name} with these exact parameters earlier in this conversation and it succeeded. Do NOT call it again. Do NOT call skip_item about this. The task is done — end the conversation.";
+		}
 	}
 
 	/**

--- a/tests/duplicate-tool-call-mode-aware-smoke.php
+++ b/tests/duplicate-tool-call-mode-aware-smoke.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Smoke tests for the mode-aware duplicate-tool-call correction message.
+ *
+ * Regression coverage for #1441: when a pipeline AI step double-calls a tool,
+ * the correction message must instruct the model to keep going (call the
+ * publish handler) rather than the chat-shaped "task is done — end the
+ * conversation". The chat-mode behavior must remain identical to the
+ * pre-fix-1441 message so existing chat callers are unaffected.
+ *
+ * Run with: php tests/duplicate-tool-call-mode-aware-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+use AgentsAPI\AI\AgentMessageEnvelope;
+use DataMachine\Engine\AI\ConversationManager;
+
+function datamachine_dup_msg_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+	$GLOBALS['datamachine_dup_msg_assertions'] = ( $GLOBALS['datamachine_dup_msg_assertions'] ?? 0 ) + 1;
+}
+
+$GLOBALS['datamachine_dup_msg_assertions'] = 0;
+
+// Helper: pull the AI-facing error string out of a duplicate-correction envelope.
+$extract_error = static function ( array $envelope ): string {
+	return (string) ( $envelope['payload']['error'] ?? '' );
+};
+
+// --- Default arg keeps chat semantics. ---------------------------------------
+
+$default_envelope = ConversationManager::generateDuplicateToolCallMessage( 'queue_validator' );
+$default_error    = $extract_error( $default_envelope );
+
+datamachine_dup_msg_assert(
+	str_contains( $default_error, 'end the conversation' ),
+	'Default arg (no mode) preserves chat-mode "end the conversation" message.'
+);
+datamachine_dup_msg_assert(
+	str_contains( $default_error, 'queue_validator' ),
+	'Default arg renders the duplicated tool name into the error.'
+);
+datamachine_dup_msg_assert(
+	AgentMessageEnvelope::TYPE_TOOL_RESULT === $default_envelope['type'],
+	'Duplicate-correction message is emitted as a tool_result envelope.'
+);
+datamachine_dup_msg_assert(
+	false === ( $default_envelope['payload']['success'] ?? null ),
+	'Duplicate-correction payload reports success=false.'
+);
+
+// --- Explicit chat mode matches default. -------------------------------------
+
+$chat_envelope = ConversationManager::generateDuplicateToolCallMessage( 'foo', 0, 'chat' );
+$chat_error    = $extract_error( $chat_envelope );
+
+datamachine_dup_msg_assert(
+	str_contains( $chat_error, 'end the conversation' ),
+	'Explicit chat mode emits the chat-shaped end-the-conversation guidance.'
+);
+datamachine_dup_msg_assert(
+	! str_contains( $chat_error, 'publish handler' ),
+	'Explicit chat mode does NOT mention the publish handler.'
+);
+
+// --- Pipeline mode tells the AI to call the publish handler. -----------------
+
+$pipeline_envelope = ConversationManager::generateDuplicateToolCallMessage( 'foo', 0, 'pipeline' );
+$pipeline_error    = $extract_error( $pipeline_envelope );
+
+datamachine_dup_msg_assert(
+	str_contains( $pipeline_error, 'publish handler' ),
+	'Pipeline mode instructs the AI to call the publish handler.'
+);
+datamachine_dup_msg_assert(
+	! str_contains( $pipeline_error, 'end the conversation' ),
+	'Pipeline mode does NOT tell the AI to end the conversation.'
+);
+datamachine_dup_msg_assert(
+	str_contains( $pipeline_error, 'foo' ),
+	'Pipeline mode renders the duplicated tool name into the error.'
+);
+
+// --- Bridge mode tells the AI to continue its response. ----------------------
+
+$bridge_envelope = ConversationManager::generateDuplicateToolCallMessage( 'foo', 0, 'bridge' );
+$bridge_error    = $extract_error( $bridge_envelope );
+
+datamachine_dup_msg_assert(
+	str_contains( $bridge_error, 'Continue' ),
+	'Bridge mode instructs the AI to continue its response to the user.'
+);
+datamachine_dup_msg_assert(
+	! str_contains( $bridge_error, 'end the conversation' ),
+	'Bridge mode does NOT tell the AI to end the conversation.'
+);
+
+// --- Unknown modes fall through to chat semantics. ---------------------------
+
+$unknown_envelope = ConversationManager::generateDuplicateToolCallMessage( 'foo', 0, 'totally-not-a-mode' );
+$unknown_error    = $extract_error( $unknown_envelope );
+
+datamachine_dup_msg_assert(
+	str_contains( $unknown_error, 'end the conversation' ),
+	'Unknown mode falls back to chat-mode "end the conversation" wording.'
+);
+
+// --- Turn count propagates through to the envelope payload. ------------------
+
+$turn_envelope = ConversationManager::generateDuplicateToolCallMessage( 'foo', 7, 'pipeline' );
+datamachine_dup_msg_assert(
+	7 === ( $turn_envelope['payload']['turn'] ?? null ),
+	'Turn count propagates into the duplicate-correction envelope payload.'
+);
+
+// --- Done. -------------------------------------------------------------------
+
+printf(
+	"OK  %d assertions passed (duplicate-tool-call mode-aware smoke).\n",
+	(int) $GLOBALS['datamachine_dup_msg_assertions']
+);


### PR DESCRIPTION
## Summary

- Make `ConversationManager::generateDuplicateToolCallMessage()` mode-aware so pipeline-mode duplicates don't silently halt the conversation mid-step.
- Update the sole call site (`AIConversationLoop:398`) to thread `$mode` through.
- Add `tests/duplicate-tool-call-mode-aware-smoke.php` (13 assertions) covering each mode branch.
- Update `docs/core-system/conversation-manager.md` and `docs/core-system/ai-conversation-loop.md` to reflect the new signature and mode behavior.

Closes #1441 (the message-mode bug; the `queue_validator`-pipeline-injection symptom from #1441 was already fixed in #1452).

## Background

When `AIConversationLoop` intercepts a duplicate tool call, it injects a correction message into the conversation. Pre-fix, the message was always:

> DUPLICATE REJECTED: ... The task is done — end the conversation.

That wording is correct for **chat** mode — the tool's result IS the answer to the user's question. It's wrong for **pipeline** mode, where the AI still has to call the publish handler before the step can complete. The AI complied with the chat-shaped guidance, emitted ~123 tokens of nothing, and `PublishStep` then bailed with `empty_data_packet_returned`. That's the failure mode that took down the Festival Wire pipeline for six days (Apr 22-28, see #1441).

PR #1452 already addressed the original outage by dropping `queue_validator` from pipeline-mode tool registration. This PR closes the underlying class of bug so any **future** pipeline tool that ever double-calls won't trigger the same silent stop.

## Behavior matrix

| Mode | Guidance |
|---|---|
| `chat` (default) | "The task is done — end the conversation." (unchanged from pre-fix) |
| `pipeline` | "Move on — call the publish handler tool now to complete this step." |
| `bridge` | "Continue your response to the user using the result you already have." |
| _unknown_ | Falls back to chat semantics. |

The default arg is `'chat'`, so any external caller keeps current behavior. The only internal caller (`AIConversationLoop`) already has `$mode` in scope at the call site (line 173 function parameter).

## Tests

```bash
php tests/duplicate-tool-call-mode-aware-smoke.php
# OK  13 assertions passed (duplicate-tool-call mode-aware smoke).
```

Existing nearby smokes still pass:

- `tests/ai-message-envelope-smoke.php` — 28 assertions
- `tests/conversation-store-contracts-smoke.php` — pass
- `tests/agent-conversation-result-smoke.php` — 14 assertions
- `tests/upsert-handler-result-handoff-smoke.php` — 9/9

## Risk

| Risk | Assessment |
|---|---|
| Breaking chat callers | Default arg `'chat'` keeps the chat path byte-identical to pre-fix wording. |
| Other call sites | Grepped: only ONE internal call site in the whole repo (`AIConversationLoop:398`). Two doc references updated. |
| Unknown mode strings | `default:` case falls through to chat semantics. |