### PR TITLE
fix(bundle): normalize package upgrade artifacts

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -339,8 +339,8 @@ class AgentBundleCommand extends BaseCommand {
 
 	/** @return array<int,array<string,mixed>> */
 	private function bundle_artifacts_for_agent( array $bundle, ?array $agent ): array {
-		$artifacts = array();
-		$agent_id  = is_array( $agent ) ? (int) ( $agent['agent_id'] ?? 0 ) : 0;
+		$artifacts                  = array();
+		$agent_id                   = is_array( $agent ) ? (int) ( $agent['agent_id'] ?? 0 ) : 0;
 		$pipeline_id_map            = array();
 		$existing_pipelines_by_slug = array();
 
@@ -356,10 +356,11 @@ class AgentBundleCommand extends BaseCommand {
 			}
 			$slug = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
 			if ( isset( $existing_pipelines_by_slug[ $slug ] ) ) {
-				$old_id                        = (int) ( $pipeline['original_id'] ?? 0 );
-				$new_id                        = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
-				$pipeline_id_map[ $old_id ]     = $new_id;
-				$pipeline['pipeline_config']    = $this->remap_pipeline_step_ids(
+				$old_id = (int) ( $pipeline['original_id'] ?? 0 );
+				$new_id = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
+
+				$pipeline_id_map[ $old_id ]  = $new_id;
+				$pipeline['pipeline_config'] = $this->remap_pipeline_step_ids(
 					is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
 					$old_id,
 					$new_id
@@ -443,6 +444,7 @@ class AgentBundleCommand extends BaseCommand {
 			}
 			if ( 'flow' === $type && isset( $flow_by_slug[ $id ] ) ) {
 				$flow = $this->normalize_current_flow_ids( $flow_by_slug[ $id ] );
+
 				$artifacts[] = array(
 					'artifact_type' => 'flow',
 					'artifact_id'   => $id,

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -327,19 +327,45 @@ class AgentBundleCommand extends BaseCommand {
 		return AgentBundleUpgradePlanner::plan(
 			$installed,
 			$this->current_artifacts( $agent, $installed ),
-			$this->bundle_artifacts( $bundle ),
+			$this->bundle_artifacts_for_agent( $bundle, $agent ),
 			$this->bundle_summary( $bundle, $slug )
 		);
 	}
 
 	/** @return array<int,array<string,mixed>> */
 	private function bundle_artifacts( array $bundle ): array {
+		return $this->bundle_artifacts_for_agent( $bundle, null );
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function bundle_artifacts_for_agent( array $bundle, ?array $agent ): array {
 		$artifacts = array();
+		$agent_id  = is_array( $agent ) ? (int) ( $agent['agent_id'] ?? 0 ) : 0;
+		$pipeline_id_map            = array();
+		$existing_pipelines_by_slug = array();
+
+		if ( $agent_id > 0 ) {
+			foreach ( $this->pipelines()->get_all_pipelines( null, $agent_id ) as $pipeline ) {
+				$existing_pipelines_by_slug[ (string) ( $pipeline['portable_slug'] ?? '' ) ] = $pipeline;
+			}
+		}
+
 		foreach ( $bundle['pipelines'] ?? array() as $pipeline ) {
 			if ( ! is_array( $pipeline ) ) {
 				continue;
 			}
-			$slug        = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
+			$slug = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
+			if ( isset( $existing_pipelines_by_slug[ $slug ] ) ) {
+				$old_id                        = (int) ( $pipeline['original_id'] ?? 0 );
+				$new_id                        = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
+				$pipeline_id_map[ $old_id ]     = $new_id;
+				$pipeline['pipeline_config']    = $this->remap_pipeline_step_ids(
+					is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array(),
+					$old_id,
+					$new_id
+				);
+			}
+
 			$artifacts[] = array(
 				'artifact_type' => 'pipeline',
 				'artifact_id'   => $slug,
@@ -352,7 +378,20 @@ class AgentBundleCommand extends BaseCommand {
 			if ( ! is_array( $flow ) ) {
 				continue;
 			}
-			$slug        = PortableSlug::normalize( (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ), 'flow' );
+			$slug            = PortableSlug::normalize( (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ), 'flow' );
+			$old_pipeline_id = (int) ( $flow['original_pipeline_id'] ?? 0 );
+			$new_pipeline_id = (int) ( $pipeline_id_map[ $old_pipeline_id ] ?? 0 );
+			$existing_flow   = $new_pipeline_id > 0 ? $this->flows()->get_by_portable_slug( $new_pipeline_id, $slug ) : null;
+
+			if ( $existing_flow ) {
+				$flow['flow_config'] = $this->remap_flow_step_ids(
+					is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array(),
+					$old_pipeline_id,
+					$new_pipeline_id,
+					(int) $existing_flow['flow_id']
+				);
+			}
+
 			$artifacts[] = array(
 				'artifact_type' => 'flow',
 				'artifact_id'   => $slug,
@@ -403,11 +442,12 @@ class AgentBundleCommand extends BaseCommand {
 				);
 			}
 			if ( 'flow' === $type && isset( $flow_by_slug[ $id ] ) ) {
+				$flow = $this->normalize_current_flow_ids( $flow_by_slug[ $id ] );
 				$artifacts[] = array(
 					'artifact_type' => 'flow',
 					'artifact_id'   => $id,
 					'source_path'   => (string) ( $record['source_path'] ?? '' ),
-					'payload'       => $this->flow_payload( $flow_by_slug[ $id ], $id ),
+					'payload'       => $this->flow_payload( $flow, $id ),
 				);
 			}
 		}
@@ -445,12 +485,80 @@ class AgentBundleCommand extends BaseCommand {
 	private function flow_config_without_runtime_queues( array $flow_config ): array {
 		foreach ( $flow_config as &$step ) {
 			if ( is_array( $step ) ) {
-				unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'] );
+				unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'], $step['_queue_consume_revision'] );
 			}
 		}
 		unset( $step );
 
 		return $flow_config;
+	}
+
+	private function normalize_current_flow_ids( array $flow ): array {
+		$new_pipeline_id = (int) ( $flow['pipeline_id'] ?? 0 );
+		$flow_id         = (int) ( $flow['flow_id'] ?? 0 );
+		$flow_config     = is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array();
+
+		foreach ( $flow_config as $step_config ) {
+			if ( ! is_array( $step_config ) || ! isset( $step_config['pipeline_id'] ) ) {
+				continue;
+			}
+
+			$old_pipeline_id = (int) $step_config['pipeline_id'];
+			if ( $old_pipeline_id > 0 && $new_pipeline_id > 0 && $flow_id > 0 ) {
+				$flow['flow_config'] = $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, $new_pipeline_id, $flow_id );
+			}
+
+			break;
+		}
+
+		return $flow;
+	}
+
+	private function remap_pipeline_step_ids( array $pipeline_config, int $old_pipeline_id, int $new_pipeline_id ): array {
+		$remapped = array();
+
+		foreach ( $pipeline_config as $pipeline_step_id => $step_config ) {
+			$new_pipeline_step_id = $this->remap_step_id_prefix( (string) $pipeline_step_id, $old_pipeline_id, $new_pipeline_id );
+			if ( is_array( $step_config ) ) {
+				$step_config['pipeline_step_id'] = $new_pipeline_step_id;
+			}
+
+			$remapped[ $new_pipeline_step_id ] = $step_config;
+		}
+
+		return $remapped;
+	}
+
+	private function remap_flow_step_ids( array $flow_config, int $old_pipeline_id, int $new_pipeline_id, int $new_flow_id ): array {
+		$remapped = array();
+
+		foreach ( $flow_config as $flow_step_id => $step_config ) {
+			$pipeline_step_id = is_array( $step_config ) && is_string( $step_config['pipeline_step_id'] ?? null )
+				? $step_config['pipeline_step_id']
+				: preg_replace( '/_\d+$/', '', (string) $flow_step_id );
+			$pipeline_step_id = $this->remap_step_id_prefix( (string) $pipeline_step_id, $old_pipeline_id, $new_pipeline_id );
+			$new_flow_step_id = $pipeline_step_id . '_' . $new_flow_id;
+
+			if ( is_array( $step_config ) ) {
+				$step_config['pipeline_step_id'] = $pipeline_step_id;
+				$step_config['pipeline_id']      = $new_pipeline_id;
+				$step_config['flow_id']          = $new_flow_id;
+				$step_config['flow_step_id']     = $new_flow_step_id;
+			}
+
+			$remapped[ $new_flow_step_id ] = $step_config;
+		}
+
+		return $remapped;
+	}
+
+	private function remap_step_id_prefix( string $step_id, int $old_pipeline_id, int $new_pipeline_id ): string {
+		$prefix = $old_pipeline_id . '_';
+		if ( $old_pipeline_id === $new_pipeline_id || ! str_starts_with( $step_id, $prefix ) ) {
+			return $step_id;
+		}
+
+		return $new_pipeline_id . '_' . substr( $step_id, strlen( $prefix ) );
 	}
 
 	private function resolve_bundle_agent( array $bundle, string $slug = '' ): ?array {

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -597,14 +597,22 @@ class AgentBundler {
 				'pipeline'
 			);
 			$artifact_key      = 'pipeline:' . $portable_slug;
-			$payload           = $this->pipeline_artifact_payload( $pipeline_data, $portable_slug );
 			$existing_pipeline = $this->pipelines_repo->get_by_portable_slug( $agent_id, $portable_slug );
+			$target_pipeline   = $pipeline_data;
+			if ( $existing_pipeline ) {
+				$target_pipeline['pipeline_config'] = $this->remap_pipeline_step_ids( $pipeline_config, $old_id, (int) $existing_pipeline['pipeline_id'] );
+			}
+			$payload = $this->pipeline_artifact_payload( $target_pipeline, $portable_slug );
 
 			if (
 				$existing_pipeline
 				&& $this->artifact_has_local_modifications(
 					$artifact_records[ $artifact_key ] ?? null,
 					$this->pipeline_artifact_payload( $existing_pipeline, $portable_slug )
+				)
+				&& ! hash_equals(
+					AgentBundleArtifactHasher::hash( $payload ),
+					AgentBundleArtifactHasher::hash( $this->pipeline_artifact_payload( $existing_pipeline, $portable_slug ) )
 				)
 			) {
 				$conflicts[]                = array(
@@ -697,6 +705,10 @@ class AgentBundler {
 				&& $this->artifact_has_local_modifications(
 					$artifact_records[ $artifact_key ] ?? null,
 					$this->flow_artifact_payload( $existing_flow, $portable_slug )
+				)
+				&& ! hash_equals(
+					AgentBundleArtifactHasher::hash( $payload ),
+					AgentBundleArtifactHasher::hash( $this->normalized_existing_flow_payload( $existing_flow, $portable_slug, (int) $new_pipeline_id ) )
 				)
 			) {
 				$conflicts[] = array(
@@ -922,11 +934,13 @@ class AgentBundler {
 	}
 
 	private function preserve_runtime_queue_fields( array $incoming_flow_config, array $existing_flow_config ): array {
+		$runtime_fields = array( 'prompt_queue', 'config_patch_queue', 'queue_mode', '_queue_consume_revision' );
+
 		foreach ( $incoming_flow_config as $flow_step_id => &$step ) {
 			if ( ! is_array( $step ) || ! is_array( $existing_flow_config[ $flow_step_id ] ?? null ) ) {
 				continue;
 			}
-			foreach ( array( 'prompt_queue', 'config_patch_queue', 'queue_mode' ) as $field ) {
+			foreach ( $runtime_fields as $field ) {
 				if ( array_key_exists( $field, $existing_flow_config[ $flow_step_id ] ) ) {
 					$step[ $field ] = $existing_flow_config[ $flow_step_id ][ $field ];
 				}
@@ -942,11 +956,31 @@ class AgentBundler {
 			if ( ! is_array( $step ) ) {
 				continue;
 			}
-			unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'] );
+			unset( $step['prompt_queue'], $step['config_patch_queue'], $step['queue_mode'], $step['_queue_consume_revision'] );
 		}
 		unset( $step );
 
 		return $flow_config;
+	}
+
+	private function normalized_existing_flow_payload( array $flow, string $portable_slug, int $new_pipeline_id ): array {
+		$flow_id     = (int) ( $flow['flow_id'] ?? 0 );
+		$flow_config = is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array();
+
+		foreach ( $flow_config as $step_config ) {
+			if ( ! is_array( $step_config ) || ! isset( $step_config['pipeline_id'] ) ) {
+				continue;
+			}
+
+			$old_pipeline_id = (int) $step_config['pipeline_id'];
+			if ( $old_pipeline_id > 0 && $flow_id > 0 ) {
+				$flow['flow_config'] = $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, $new_pipeline_id, $flow_id );
+			}
+
+			break;
+		}
+
+		return $this->flow_artifact_payload( $flow, $portable_slug );
 	}
 
 	/**

--- a/tests/agent-bundle-portable-update-smoke.php
+++ b/tests/agent-bundle-portable-update-smoke.php
@@ -189,6 +189,24 @@ $preserved = call_bundle_private( $bundler, 'preserve_runtime_queue_fields', arr
 assert_bundle_update_equals( 'upgrade preserves existing config_patch_queue', 'Local queue head', $preserved['flow-step-1']['config_patch_queue'][0]['patch']['query'] ?? null );
 assert_bundle_update_equals( 'upgrade preserves existing queue_mode', 'static', $preserved['flow-step-1']['queue_mode'] ?? null );
 
+$runtime_stripped_payload = call_bundle_private(
+	$bundler,
+	'flow_artifact_payload',
+	array(
+		array(
+			'flow_name'   => 'Runtime queue revision test',
+			'flow_config' => array(
+				'2_bundle_step_0_4' => array(
+					'pipeline_step_id'         => '2_bundle_step_0',
+					'_queue_consume_revision' => 17,
+				),
+			),
+		),
+		'runtime-queue-revision-test',
+	)
+);
+assert_bundle_update( 'flow artifact hashing ignores queue consume revision', ! isset( $runtime_stripped_payload['flow_config']['2_bundle_step_0_4']['_queue_consume_revision'] ) );
+
 $remapped_pipeline = call_bundle_private(
 	$bundler,
 	'remap_pipeline_step_ids',
@@ -228,6 +246,29 @@ assert_bundle_update_equals( 'flow step metadata pipeline_step_id remaps', '3_bu
 assert_bundle_update_equals( 'flow step metadata pipeline_id remaps', 3, $remapped_flow['3_bundle_step_0_9']['pipeline_id'] ?? null );
 assert_bundle_update_equals( 'flow step metadata flow_id remaps', 9, $remapped_flow['3_bundle_step_0_9']['flow_id'] ?? null );
 
+$normalized_existing_flow_payload = call_bundle_private(
+	$bundler,
+	'normalized_existing_flow_payload',
+	array(
+		array(
+			'flow_id'     => 9,
+			'flow_name'   => 'Existing stale flow',
+			'flow_config' => array(
+				'3_bundle_step_0_9' => array(
+					'flow_step_id'     => '2_bundle_step_0_9',
+					'pipeline_step_id' => '2_bundle_step_0',
+					'pipeline_id'      => 2,
+					'flow_id'          => 9,
+				),
+			),
+		),
+		'existing-stale-flow',
+		3,
+	)
+);
+assert_bundle_update( 'existing stale flow payload normalizes step key', isset( $normalized_existing_flow_payload['flow_config']['3_bundle_step_0_9'] ) );
+assert_bundle_update_equals( 'existing stale flow payload normalizes pipeline metadata', 3, $normalized_existing_flow_payload['flow_config']['3_bundle_step_0_9']['pipeline_id'] ?? null );
+
 $agent_bundler_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Agents/AgentBundler.php' ) ?: '';
 $pipelines_source     = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Pipelines/Pipelines.php' ) ?: '';
 $flows_source         = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Flows/Flows.php' ) ?: '';
@@ -251,6 +292,7 @@ assert_bundle_update( 'package CLI exposes diff command', str_contains( $bundle_
 assert_bundle_update( 'package CLI exposes upgrade command', str_contains( $bundle_cli_source, 'function upgrade(' ) );
 assert_bundle_update( 'package CLI stages PendingActions for approval-required upgrades', str_contains( $bundle_cli_source, 'AgentBundleUpgradePendingAction::stage' ) );
 assert_bundle_update( 'package CLI resolves staged apply actions', str_contains( $bundle_cli_source, 'ResolvePendingActionAbility::execute' ) );
+assert_bundle_update( 'package CLI plans target artifacts in installed ID space', str_contains( $bundle_cli_source, 'bundle_artifacts_for_agent' ) );
 
 $failure_count = is_array( $GLOBALS['failures'] ?? null ) ? count( $GLOBALS['failures'] ) : 0;
 if ( 0 !== $failure_count ) {


### PR DESCRIPTION
## Summary
- Fix package upgrade planning so target bundle artifacts are compared in the installed pipeline/flow ID space.
- Allow package upgrades to repair stale embedded workflow metadata without treating ID normalization as a local edit.
- Treat `_queue_consume_revision` as runtime-only queue state so package hashes stay stable.

## Changes
- Normalize target pipeline and flow artifacts against installed portable-slug matches before diffing.
- Normalize current stale flow payloads before checking whether package metadata drift is a real local modification.
- Preserve/strip `_queue_consume_revision` with other runtime queue fields.
- Extend the portable bundle smoke test for queue revision stripping and stale flow metadata normalization.

## Tests
- `php -l inc/Core/Agents/AgentBundler.php`
- `php -l inc/Cli/Commands/AgentBundleCommand.php`
- `php -l tests/agent-bundle-portable-update-smoke.php`
- `php tests/agent-bundle-portable-update-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the package upgrade normalization bug, drafted the code changes and smoke coverage, and ran local verification. Chris remains responsible for review and merge.