### PR TITLE
fix(bundle): repair stale flow metadata on upgrade

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -443,13 +443,11 @@ class AgentBundleCommand extends BaseCommand {
 				);
 			}
 			if ( 'flow' === $type && isset( $flow_by_slug[ $id ] ) ) {
-				$flow = $this->normalize_current_flow_ids( $flow_by_slug[ $id ] );
-
 				$artifacts[] = array(
 					'artifact_type' => 'flow',
 					'artifact_id'   => $id,
 					'source_path'   => (string) ( $record['source_path'] ?? '' ),
-					'payload'       => $this->flow_payload( $flow, $id ),
+					'payload'       => $this->flow_payload( $flow_by_slug[ $id ], $id ),
 				);
 			}
 		}
@@ -493,27 +491,6 @@ class AgentBundleCommand extends BaseCommand {
 		unset( $step );
 
 		return $flow_config;
-	}
-
-	private function normalize_current_flow_ids( array $flow ): array {
-		$new_pipeline_id = (int) ( $flow['pipeline_id'] ?? 0 );
-		$flow_id         = (int) ( $flow['flow_id'] ?? 0 );
-		$flow_config     = is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array();
-
-		foreach ( $flow_config as $step_config ) {
-			if ( ! is_array( $step_config ) || ! isset( $step_config['pipeline_id'] ) ) {
-				continue;
-			}
-
-			$old_pipeline_id = (int) $step_config['pipeline_id'];
-			if ( $old_pipeline_id > 0 && $new_pipeline_id > 0 && $flow_id > 0 ) {
-				$flow['flow_config'] = $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, $new_pipeline_id, $flow_id );
-			}
-
-			break;
-		}
-
-		return $flow;
 	}
 
 	private function remap_pipeline_step_ids( array $pipeline_config, int $old_pipeline_id, int $new_pipeline_id ): array {


### PR DESCRIPTION
## Summary
- Fix package upgrade planning so stale stored flow metadata is still detected as a repairable local artifact.
- Keep target bundle artifacts normalized to installed IDs while comparing current artifacts from actual stored state.

## Changes
- Stop normalizing current flow payloads inside package upgrade planning.
- Leave importer-side stale metadata normalization from #1711 in place so clean stale rows can be repaired without approval.

## Tests
- `php -l inc/Cli/Commands/AgentBundleCommand.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@release-bundle-upgrade-normalized-artifacts --changed-since origin/main --summary`
- `php tests/agent-bundle-portable-update-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed why normalized upgrade planning produced a no-op for stale live flow metadata, drafted the focused fix, and ran local verification. Chris remains responsible for review and merge.