### PR TITLE
fix(ai): declare items schema on local_search post_types

### DIFF
--- a/inc/Engine/AI/Tools/Global/LocalSearch.php
+++ b/inc/Engine/AI/Tools/Global/LocalSearch.php
@@ -79,6 +79,7 @@ class LocalSearch extends BaseTool {
 					'type'        => 'array',
 					'required'    => false,
 					'description' => 'Post types to search (default: ["post", "page"]). Use ["datamachine_events"] for events.',
+					'items'       => array( 'type' => 'string' ),
 				),
 				'title_only' => array(
 					'type'        => 'boolean',

--- a/tests/global-tool-array-items-smoke.php
+++ b/tests/global-tool-array-items-smoke.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Smoke tests for global-tool parameter schemas.
+ *
+ * Regression coverage for the LocalSearch `post_types` schema bug: every
+ * global AI tool that declares an `array`-typed parameter MUST also declare
+ * an `items` keyword. JSON Schema requires it, OpenAI's strict-mode tool
+ * validation rejects requests that omit it, and wp-ai-client now forwards
+ * those rejections instead of silently stripping them.
+ *
+ * Run with: php tests/global-tool-array-items-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$assertions = 0;
+$failures   = array();
+
+$assert = function ( bool $condition, string $message ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		$failures[] = $message;
+		echo "FAIL: {$message}\n";
+		return;
+	}
+
+	echo "PASS: {$message}\n";
+};
+
+// Bare-bones bootstrap so the global-tool classes load without WordPress.
+$root = dirname( __DIR__ );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $root . '/' );
+}
+
+// Stub WP functions/constants the global-tool classes touch at construction
+// time. None of these are exercised by getToolDefinition() itself; we only
+// need them to satisfy guard clauses and `defined( 'ABSPATH' ) || exit` at
+// the top of each tool file.
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		unset( $tag, $callback, $priority, $accepted_args );
+	}
+}
+
+require_once $root . '/inc/Engine/AI/Tools/BaseTool.php';
+
+$tools_dir = $root . '/inc/Engine/AI/Tools/Global';
+$tool_files = glob( $tools_dir . '/*.php' ) ?: array();
+
+$schemas_checked = 0;
+$array_params_checked = 0;
+
+foreach ( $tool_files as $file ) {
+	require_once $file;
+
+	$class_short = basename( $file, '.php' );
+	$class_fqn   = 'DataMachine\\Engine\\AI\\Tools\\Global\\' . $class_short;
+
+	if ( ! class_exists( $class_fqn ) ) {
+		$assert( false, "{$class_short}: class not found at {$class_fqn}" );
+		continue;
+	}
+
+	if ( ! method_exists( $class_fqn, 'getToolDefinition' ) ) {
+		// Tool may not declare a definition (e.g. abstract). Skip without
+		// counting against us — the schema check only applies to tools that
+		// register parameters.
+		continue;
+	}
+
+	try {
+		$instance   = new $class_fqn();
+		$definition = $instance->getToolDefinition();
+	} catch ( \Throwable $e ) {
+		$assert( false, "{$class_short}: getToolDefinition threw: " . $e->getMessage() );
+		continue;
+	}
+
+	if ( ! is_array( $definition ) || empty( $definition['parameters'] ) || ! is_array( $definition['parameters'] ) ) {
+		// No params to validate. Tool may legitimately take none.
+		continue;
+	}
+
+	++$schemas_checked;
+
+	foreach ( $definition['parameters'] as $param_name => $param_schema ) {
+		if ( ! is_array( $param_schema ) ) {
+			$assert(
+				false,
+				"{$class_short}.{$param_name}: parameter schema is not an array"
+			);
+			continue;
+		}
+
+		$type = $param_schema['type'] ?? null;
+
+		if ( 'array' !== $type ) {
+			continue;
+		}
+
+		++$array_params_checked;
+
+		$assert(
+			isset( $param_schema['items'] ) && is_array( $param_schema['items'] ),
+			"{$class_short}.{$param_name}: array-typed parameter declares 'items' (JSON Schema requirement; OpenAI strict mode rejects without)"
+		);
+
+		if ( isset( $param_schema['items'] ) && is_array( $param_schema['items'] ) ) {
+			$assert(
+				isset( $param_schema['items']['type'] ),
+				"{$class_short}.{$param_name}.items: items declares a 'type'"
+			);
+		}
+	}
+}
+
+$assert(
+	$schemas_checked > 0,
+	"smoke covered at least one global tool definition (got {$schemas_checked})"
+);
+
+$assert(
+	$array_params_checked > 0,
+	"smoke exercised at least one array-typed parameter (got {$array_params_checked})"
+);
+
+echo "\n{$assertions} assertions, " . count( $failures ) . " failures\n";
+echo "(Checked {$schemas_checked} global tools, {$array_params_checked} array-typed parameters)\n";
+
+if ( ! empty( $failures ) ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary

- Add `'items' => array( 'type' => 'string' )` to `LocalSearch`'s `post_types` parameter schema so OpenAI's strict tool-call validation accepts it.
- Add `tests/global-tool-array-items-smoke.php` to lock the convention in across every current and future global tool.

## Background

JSON Schema requires every `array`-typed parameter to declare an `items` keyword. OpenAI's strict-mode tool validation enforces this. When `local_search` is in the AI step's available-tools list, the request now fails at the request-builder boundary with:

```
Bad Request (400) - Invalid schema for function 'local_search':
In context=('properties', 'post_types'), array schema missing items.
```

The bug has been in the file since it was first written, but the old `ai-http-client` shim either stripped malformed array schemas before sending, or hit a less strict OpenAI mode. The wp-ai-client direct dispatch path (the #1646/#1656/#1680/#1685 cluster) forwards the strict request unchanged, so the failure now surfaces.

Discovered while investigating wire pipeline failures on extrachill.com (deployed 0.103.6 today). Affected jobs: `failed - ai_processing_failed` with the OpenAI 400 in `error_message`. Bonnaroo / coachella / electricforest / etc. on the wire pipeline all have `local_search` in their pipeline-mode tool list.

## Fix

```php
'post_types' => array(
    'type'        => 'array',
    'required'    => false,
    'description' => 'Post types to search (default: ["post", "page"]). Use ["datamachine_events"] for events.',
    'items'       => array( 'type' => 'string' ),  // ← added
),
```

Every other array-typed parameter in the codebase (e.g. `InternalLinkAudit::types`, `InternalLinkingAbilities::*`, `AgentMemoryAbilities::*`, `PipelineStepAbilities::*`, `UpdateWordPressAbility::*`) already declares `items`. LocalSearch was the only outlier.

## Tests

```bash
$ php tests/global-tool-array-items-smoke.php

PASS: InternalLinkAudit.types: array-typed parameter declares 'items' ...
PASS: InternalLinkAudit.types.items: items declares a 'type'
PASS: LocalSearch.post_types: array-typed parameter declares 'items' ...
PASS: LocalSearch.post_types.items: items declares a 'type'
PASS: smoke covered at least one global tool definition (got 14)
PASS: smoke exercised at least one array-typed parameter (got 2)

6 assertions, 0 failures
(Checked 14 global tools, 2 array-typed parameters)
```

Test fails on revert of the `LocalSearch.php` change (verified locally with `git stash`):

```
FAIL: LocalSearch.post_types: array-typed parameter declares 'items' ...
5 assertions, 1 failures
```

The smoke walks every class in `inc/Engine/AI/Tools/Global/`, calls `getToolDefinition()`, and asserts that any parameter with `'type' => 'array'` declares an `items` keyword. New global tools that miss the convention will fail this smoke.

## Risk

| Risk | Assessment |
|---|---|
| Behavior change for `local_search` callers | Just adds a stricter element-type declaration. The existing implementation (`LocalSearchAbilities::execute`) already coerces `post_types` to strings via WordPress's `get_post_types()` filter, so no runtime change. |
| Other tools with the same bug | Codebase grep confirmed LocalSearch is the only offender. Smoke locks this in. |
| Test suite collisions | Pure-PHP smoke, no PHPUnit, runs as `php tests/<name>.php`. Same shape as `tests/global-tool-pipeline-modes-smoke.php` and `tests/wp-ai-client-tool-schema-smoke.php`. |