### PR TITLE
fix(ai): allow tool-only result text

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -458,7 +458,15 @@ class RequestBuilder {
 	 * @return string Text content.
 	 */
 	public static function resultText( \WordPress\AiClient\Results\DTO\GenerativeAiResult $result ): string {
-		return (string) $result->toText();
+		try {
+			return (string) $result->toText();
+		} catch ( \Throwable $e ) {
+			if ( str_contains( $e->getMessage(), 'No text content found' ) ) {
+				return '';
+			}
+
+			throw $e;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Prevent valid tool-only AI responses from failing the conversation loop when the result has no text candidate.

## Changes
- Catch `No text content found...` exceptions from `GenerativeAiResult::toText()` and treat them as empty assistant text.
- Preserve existing behavior for other result extraction errors by rethrowing.

## Tests
- `php -l inc/Engine/AI/RequestBuilder.php`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@release-bundle-upgrade-normalized-artifacts --changed-since origin/main --summary`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@release-bundle-upgrade-normalized-artifacts --changed-since origin/main --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the tool-only AI response failure, drafted the focused guard, and ran local verification. Chris remains responsible for review and merge.