### PR TITLE
Persist wp-ai-client metadata cache

### DIFF
--- a/inc/Abilities/Media/ImageGenerationAbilities.php
+++ b/inc/Abilities/Media/ImageGenerationAbilities.php
@@ -211,6 +211,8 @@ class ImageGenerationAbilities {
 		}
 
 		try {
+			\DataMachine\Engine\AI\WpAiClientCache::install();
+
 			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
 			/** @var callable $has_provider wp-ai-client exposes this through __call() in some versions. */
 			$has_provider = array( $registry, 'hasProvider' );

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -16,6 +16,8 @@ use DataMachine\Engine\AI\Directives\DirectivePolicyResolver;
 
 defined( 'ABSPATH' ) || exit;
 
+require_once __DIR__ . '/WpAiClientCache.php';
+
 class RequestBuilder {
 
 	/**
@@ -58,6 +60,8 @@ class RequestBuilder {
 		array $payload = array(),
 		?array &$request_metadata = null
 	) {
+		WpAiClientCache::install();
+
 		$assembled          = self::assemble( $messages, $provider, $model, $tools, $mode, $payload );
 		$request            = $assembled['request'];
 		$provider_request   = ProviderRequestAssembler::toProviderRequest( $request );
@@ -436,6 +440,8 @@ class RequestBuilder {
 		if ( ! class_exists( '\\WordPress\\AiClient\\AiClient' ) ) {
 			return 'wp-ai-client is unavailable: WordPress\\AiClient\\AiClient is not loaded';
 		}
+
+		WpAiClientCache::install();
 
 		try {
 			$registry = \WordPress\AiClient\AiClient::defaultRegistry();

--- a/inc/Engine/AI/WpAiClientCache.php
+++ b/inc/Engine/AI/WpAiClientCache.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Persistent wp-ai-client cache integration.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Installs a WordPress-backed PSR-16 cache for wp-ai-client.
+ */
+class WpAiClientCache {
+
+	/**
+	 * Install the cache into wp-ai-client when available.
+	 *
+	 * @return void
+	 */
+	public static function install(): void {
+		$ai_client_class = '\WordPress\AiClient\AiClient';
+		if ( ! class_exists( $ai_client_class ) || ! method_exists( $ai_client_class, 'setCache' ) ) {
+			return;
+		}
+
+		if ( ! class_exists( WpAiClientTransientCache::class ) ) {
+			return;
+		}
+
+		if ( method_exists( $ai_client_class, 'getCache' ) ) {
+			try {
+				if ( null !== $ai_client_class::getCache() ) {
+					return;
+				}
+			} catch ( \Throwable $e ) {
+				unset( $e );
+			}
+		}
+
+		try {
+			$ai_client_class::setCache( new WpAiClientTransientCache() );
+		} catch ( \Throwable $e ) {
+			unset( $e );
+		}
+	}
+}
+
+/**
+ * Shared implementation for transient-backed wp-ai-client caches.
+ */
+abstract class WpAiClientTransientCacheBase {
+
+	/**
+	 * Cache version option used to logically clear Data Machine's namespace.
+	 */
+	private const VERSION_OPTION = 'datamachine_wp_ai_client_cache_version';
+
+	/**
+	 * Prefix for transient keys.
+	 */
+	private const TRANSIENT_PREFIX = 'datamachine_wp_ai_client_';
+
+	/**
+	 * Fetches a value from the cache.
+	 *
+	 * @param string $key     Cache key.
+	 * @param mixed  $default Default value.
+	 * @return mixed
+	 */
+	public function get( $key, $default = null ) {
+		$this->validateKey( $key );
+
+		$cached = get_transient( $this->transientKey( $key ) );
+		if ( ! is_array( $cached ) || ! array_key_exists( 'value', $cached ) ) {
+			return $default;
+		}
+
+		return $cached['value'];
+	}
+
+	/**
+	 * Stores a value in the cache.
+	 *
+	 * @param string                 $key   Cache key.
+	 * @param mixed                  $value Cache value.
+	 * @param null|int|\DateInterval $ttl   TTL.
+	 * @return bool
+	 */
+	public function set( $key, $value, $ttl = null ) {
+		$this->validateKey( $key );
+
+		$expiration = $this->ttlToSeconds( $ttl );
+		if ( $expiration < 0 ) {
+			return $this->delete( $key );
+		}
+
+		return set_transient( $this->transientKey( $key ), array( 'value' => $value ), $expiration );
+	}
+
+	/**
+	 * Deletes a value from the cache.
+	 *
+	 * @param string $key Cache key.
+	 * @return bool
+	 */
+	public function delete( $key ) {
+		$this->validateKey( $key );
+
+		return delete_transient( $this->transientKey( $key ) );
+	}
+
+	/**
+	 * Clears this adapter's logical namespace.
+	 *
+	 * @return bool
+	 */
+	public function clear() {
+		$version = (int) get_option( self::VERSION_OPTION, 1 );
+
+		return update_option( self::VERSION_OPTION, max( 1, $version ) + 1, false );
+	}
+
+	/**
+	 * Fetches multiple values from the cache.
+	 *
+	 * @param iterable $keys    Cache keys.
+	 * @param mixed    $default Default value.
+	 * @return iterable
+	 */
+	public function getMultiple( $keys, $default = null ) {
+		$values = array();
+		foreach ( $this->iterableKeys( $keys ) as $key ) {
+			$values[ $key ] = $this->get( $key, $default );
+		}
+
+		return $values;
+	}
+
+	/**
+	 * Stores multiple values in the cache.
+	 *
+	 * @param iterable               $values Key/value map.
+	 * @param null|int|\DateInterval $ttl    TTL.
+	 * @return bool
+	 */
+	public function setMultiple( $values, $ttl = null ) {
+		$ok = true;
+		foreach ( $this->iterableValues( $values ) as $key => $value ) {
+			$ok = $this->set( $key, $value, $ttl ) && $ok;
+		}
+
+		return $ok;
+	}
+
+	/**
+	 * Deletes multiple values from the cache.
+	 *
+	 * @param iterable $keys Cache keys.
+	 * @return bool
+	 */
+	public function deleteMultiple( $keys ) {
+		$ok = true;
+		foreach ( $this->iterableKeys( $keys ) as $key ) {
+			$ok = $this->delete( $key ) && $ok;
+		}
+
+		return $ok;
+	}
+
+	/**
+	 * Determines whether a key exists in the cache.
+	 *
+	 * @param string $key Cache key.
+	 * @return bool
+	 */
+	public function has( $key ) {
+		$missing = new \stdClass();
+
+		return $missing !== $this->get( $key, $missing );
+	}
+
+	/**
+	 * Builds a WordPress-safe transient key from the wp-ai-client key.
+	 *
+	 * @param string $key Original cache key.
+	 * @return string
+	 */
+	private function transientKey( string $key ): string {
+		$version = (int) get_option( self::VERSION_OPTION, 1 );
+
+		return self::TRANSIENT_PREFIX . max( 1, $version ) . '_' . md5( $key );
+	}
+
+	/**
+	 * Converts a PSR-16 TTL to WordPress transient seconds.
+	 *
+	 * @param null|int|\DateInterval $ttl TTL.
+	 * @return int
+	 */
+	private function ttlToSeconds( $ttl ): int {
+		if ( null === $ttl ) {
+			return 0;
+		}
+
+		if ( $ttl instanceof \DateInterval ) {
+			$now    = new \DateTimeImmutable();
+			$future = $now->add( $ttl );
+
+			return $future->getTimestamp() - $now->getTimestamp();
+		}
+
+		if ( is_numeric( $ttl ) ) {
+			return (int) $ttl;
+		}
+
+		throw new \InvalidArgumentException( 'Cache TTL must be null, an integer, or a DateInterval.' );
+	}
+
+	/**
+	 * Validate a PSR-16 key.
+	 *
+	 * @param mixed $key Cache key.
+	 * @return void
+	 */
+	private function validateKey( $key ): void {
+		if ( ! is_string( $key ) || '' === $key ) {
+			throw new \InvalidArgumentException( 'Cache key must be a non-empty string.' );
+		}
+	}
+
+	/**
+	 * Normalize iterable keys.
+	 *
+	 * @param mixed $keys Keys.
+	 * @return iterable
+	 */
+	private function iterableKeys( $keys ): iterable {
+		if ( ! is_iterable( $keys ) ) {
+			throw new \InvalidArgumentException( 'Cache keys must be iterable.' );
+		}
+
+		foreach ( $keys as $key ) {
+			$this->validateKey( $key );
+			yield $key;
+		}
+	}
+
+	/**
+	 * Normalize iterable key/value pairs.
+	 *
+	 * @param mixed $values Values.
+	 * @return iterable
+	 */
+	private function iterableValues( $values ): iterable {
+		if ( ! is_iterable( $values ) ) {
+			throw new \InvalidArgumentException( 'Cache values must be iterable.' );
+		}
+
+		foreach ( $values as $key => $value ) {
+			$this->validateKey( $key );
+			yield $key => $value;
+		}
+	}
+}
+
+if ( interface_exists( '\WordPress\AiClientDependencies\Psr\SimpleCache\CacheInterface' ) ) {
+	/**
+	 * Transient-backed cache for WordPress' scoped wp-ai-client dependency namespace.
+	 */
+	class WpAiClientTransientCache extends WpAiClientTransientCacheBase implements \WordPress\AiClientDependencies\Psr\SimpleCache\CacheInterface {}
+} elseif ( interface_exists( '\Psr\SimpleCache\CacheInterface' ) ) {
+	/**
+	 * Transient-backed cache for unscoped php-ai-client installs.
+	 */
+	class WpAiClientTransientCache extends WpAiClientTransientCacheBase implements \Psr\SimpleCache\CacheInterface {}
+}

--- a/inc/Engine/AI/WpAiClientProviderAdmin.php
+++ b/inc/Engine/AI/WpAiClientProviderAdmin.php
@@ -9,6 +9,8 @@ namespace DataMachine\Engine\AI;
 
 defined( 'ABSPATH' ) || exit;
 
+require_once __DIR__ . '/WpAiClientCache.php';
+
 /**
  * Reads provider metadata and API-key settings through wp-ai-client / Connectors.
  */
@@ -354,6 +356,8 @@ class WpAiClientProviderAdmin {
 		if ( ! class_exists( $ai_client_class ) ) {
 			return null;
 		}
+
+		WpAiClientCache::install();
 
 		try {
 			$registry = $ai_client_class::defaultRegistry();

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -67,7 +67,10 @@ require_once __DIR__ . '/Engine/Agents/datamachine-register-agents.php';
 use DataMachine\Engine\AI\MemoryFileRegistry;
 use DataMachine\Engine\AI\AgentModeRegistry;
 use DataMachine\Engine\AI\IterationBudgetRegistry;
+use DataMachine\Engine\AI\WpAiClientCache;
 use DataMachine\Core\PluginSettings;
+
+add_action( 'plugins_loaded', array( WpAiClientCache::class, 'install' ), 20 );
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/wp-ai-client-persistent-cache-smoke.php
+++ b/tests/wp-ai-client-persistent-cache-smoke.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Smoke test for Data Machine's persistent wp-ai-client cache adapter.
+ *
+ * Run with: php tests/wp-ai-client-persistent-cache-smoke.php
+ */
+
+namespace Psr\SimpleCache {
+	interface CacheInterface {
+		public function get( $key, $default = null );
+		public function set( $key, $value, $ttl = null );
+		public function delete( $key );
+		public function clear();
+		public function getMultiple( $keys, $default = null );
+		public function setMultiple( $values, $ttl = null );
+		public function deleteMultiple( $keys );
+		public function has( $key );
+	}
+}
+
+namespace WordPress\AiClient {
+	class AiClient {
+		private static ?\Psr\SimpleCache\CacheInterface $cache = null;
+
+		public static function setCache( ?\Psr\SimpleCache\CacheInterface $cache ): void {
+			self::$cache = $cache;
+		}
+
+		public static function getCache(): ?\Psr\SimpleCache\CacheInterface {
+			return self::$cache;
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ );
+
+	$GLOBALS['datamachine_cache_smoke_transients'] = array();
+	$GLOBALS['datamachine_cache_smoke_options']    = array();
+	$GLOBALS['datamachine_cache_smoke_now']        = 1_700_000_000;
+
+	function get_transient( string $key ) {
+		$entry = $GLOBALS['datamachine_cache_smoke_transients'][ $key ] ?? null;
+		if ( ! is_array( $entry ) ) {
+			return false;
+		}
+
+		if ( 0 !== $entry['expires'] && $entry['expires'] <= $GLOBALS['datamachine_cache_smoke_now'] ) {
+			unset( $GLOBALS['datamachine_cache_smoke_transients'][ $key ] );
+			return false;
+		}
+
+		return $entry['value'];
+	}
+
+	function set_transient( string $key, $value, int $expiration = 0 ): bool {
+		$GLOBALS['datamachine_cache_smoke_transients'][ $key ] = array(
+			'value'   => $value,
+			'expires' => $expiration > 0 ? $GLOBALS['datamachine_cache_smoke_now'] + $expiration : 0,
+		);
+
+		return true;
+	}
+
+	function delete_transient( string $key ): bool {
+		unset( $GLOBALS['datamachine_cache_smoke_transients'][ $key ] );
+
+		return true;
+	}
+
+	function get_option( string $name, $default = false ) {
+		return $GLOBALS['datamachine_cache_smoke_options'][ $name ] ?? $default;
+	}
+
+	function update_option( string $name, $value, bool $autoload = true ): bool {
+		unset( $autoload );
+		$GLOBALS['datamachine_cache_smoke_options'][ $name ] = $value;
+
+		return true;
+	}
+
+	require_once __DIR__ . '/../inc/Engine/AI/WpAiClientCache.php';
+
+	use DataMachine\Engine\AI\WpAiClientCache;
+
+	$assertions = 0;
+	$failures   = array();
+	$assert     = function ( bool $condition, string $message ) use ( &$assertions, &$failures ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			$failures[] = $message;
+		}
+	};
+
+	WpAiClientCache::install();
+	// @phpstan-ignore-next-line Smoke stub exposes getCache().
+	$cache = \WordPress\AiClient\AiClient::getCache();
+
+	$assert( $cache instanceof \Psr\SimpleCache\CacheInterface, 'Data Machine installs a PSR-16 cache into wp-ai-client' );
+
+	$cache->set( 'ai_client_1.3.1_e723aa456086a7a24a491e8e87739a4b_models', array( 'models' => array( 'gpt-5' ) ), 60 );
+	$assert( array( 'models' => array( 'gpt-5' ) ) === $cache->get( 'ai_client_1.3.1_e723aa456086a7a24a491e8e87739a4b_models' ), 'cache returns stored metadata payload' );
+
+	$GLOBALS['datamachine_cache_smoke_now'] += 61;
+	$assert( 'miss' === $cache->get( 'ai_client_1.3.1_e723aa456086a7a24a491e8e87739a4b_models', 'miss' ), 'cache respects TTL expiry' );
+
+	$cache->set( 'false-value', false, 60 );
+	$assert( $cache->has( 'false-value' ), 'cache can distinguish false values from misses' );
+
+	$cache->set( 'clear-test', 'before-clear', 60 );
+	$cache->clear();
+	$assert( 'miss' === $cache->get( 'clear-test', 'miss' ), 'clear logically invalidates Data Machine namespace' );
+
+	$existing = new class() implements \Psr\SimpleCache\CacheInterface {
+		public function get( $key, $default = null ) { return $default; }
+		public function set( $key, $value, $ttl = null ) { return true; }
+		public function delete( $key ) { return true; }
+		public function clear() { return true; }
+		public function getMultiple( $keys, $default = null ) { return array(); }
+		public function setMultiple( $values, $ttl = null ) { return true; }
+		public function deleteMultiple( $keys ) { return true; }
+		public function has( $key ) { return false; }
+	};
+
+	// @phpstan-ignore-next-line Smoke stub exposes setCache().
+	\WordPress\AiClient\AiClient::setCache( $existing );
+	WpAiClientCache::install();
+	// @phpstan-ignore-next-line Smoke stub exposes getCache().
+	$assert( $existing === \WordPress\AiClient\AiClient::getCache(), 'installer preserves an existing wp-ai-client cache' );
+
+	if ( $failures ) {
+		foreach ( $failures as $failure ) {
+			fwrite( STDERR, "FAIL: {$failure}\n" );
+		}
+		exit( 1 );
+	}
+
+	echo "wp-ai-client persistent cache smoke passed ({$assertions} assertions)\n";
+}


### PR DESCRIPTION
## Summary
- Install a WordPress transient-backed PSR-16 cache into wp-ai-client when no cache has already been configured.
- Ensure Data Machine installs the cache before provider metadata/model lookup paths used by requests, provider admin, and image generation.
- Add a standalone smoke test for TTL expiry, false values, namespace clearing, and preserving an existing wp-ai-client cache.

Fixes #1717.
Related upstream issue: WordPress/php-ai-client#230.
Related upstream PR: WordPress/php-ai-client#231.

## Testing
- `php tests/wp-ai-client-persistent-cache-smoke.php`
- `php -l inc/Engine/AI/WpAiClientCache.php`
- `php -l inc/Engine/AI/RequestBuilder.php`
- `php -l inc/Engine/AI/WpAiClientProviderAdmin.php`
- `php -l inc/Abilities/Media/ImageGenerationAbilities.php`
- `php -l inc/bootstrap.php`

## Notes
- `vendor/bin/phpcs` is not available in this worktree.
- `homeboy lint` currently reports the repository's existing PHPStan baseline; the new smoke-test findings from this branch were fixed before opening this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the wp-ai-client metadata timeout path, drafting the cache integration and smoke test, and running local verification. Chris remains responsible for reviewing and shipping the change.