### PR TITLE
Fix CLI drain for Data Machine batch actions

### DIFF
--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -21,6 +21,7 @@ WP_CLI::add_command( 'datamachine settings', Commands\SettingsCommand::class );
 WP_CLI::add_command( 'datamachine flows', Commands\Flows\FlowsCommand::class );
 WP_CLI::add_command( 'datamachine alt-text', Commands\AltTextCommand::class );
 WP_CLI::add_command( 'datamachine jobs', Commands\JobsCommand::class );
+WP_CLI::add_command( 'datamachine drain', Commands\DrainCommand::class );
 WP_CLI::add_command( 'datamachine ai', Commands\AICommand::class );
 WP_CLI::add_command( 'datamachine pipelines', Commands\PipelinesCommand::class );
 WP_CLI::add_command( 'datamachine posts', Commands\PostsCommand::class );

--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -75,7 +75,7 @@ class DrainCommand extends BaseCommand {
 		);
 
 		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
-			WP_CLI::line( wp_json_encode( $stats, JSON_PRETTY_PRINT ) );
+			WP_CLI::line( (string) wp_json_encode( $stats, JSON_PRETTY_PRINT ) );
 			return;
 		}
 
@@ -112,10 +112,18 @@ class DrainCommand extends BaseCommand {
 			if ( $limit > 0 ) {
 				$current_batch_size = min( $batch_size, $limit - (int) $stats['actions_processed'] );
 			}
+			if ( $current_batch_size <= 0 ) {
+				break;
+			}
+
+			$action_ids = self::getDuePendingActionIds( $current_batch_size );
+			if ( empty( $action_ids ) ) {
+				break;
+			}
 
 			$due_before    = self::getDuePendingCount();
 			$status_before = self::getStatusCounts();
-			$result        = self::runActionSchedulerBatch( $current_batch_size );
+			$result        = self::runActionSchedulerActions( $action_ids );
 			++$batches;
 
 			if ( 0 !== (int) ( $result->return_code ?? 1 ) ) {
@@ -138,19 +146,14 @@ class DrainCommand extends BaseCommand {
 	}
 
 	/**
-	 * Run one scoped Action Scheduler batch.
+	 * Run specific due Action Scheduler actions.
 	 *
-	 * @param int $batch_size Batch size.
+	 * @param int[] $action_ids Action IDs.
 	 * @return object WP_CLI::runcommand result object.
 	 */
-	private static function runActionSchedulerBatch( int $batch_size ): object {
+	private static function runActionSchedulerActions( array $action_ids ): object {
 		return WP_CLI::runcommand(
-			sprintf(
-				'action-scheduler run --hooks=%s --group=%s --batch-size=%d --batches=1 --quiet --force',
-				implode( ',', self::hooks() ),
-				self::GROUP,
-				$batch_size
-			),
+			'action-scheduler action run ' . implode( ' ', array_map( 'intval', $action_ids ) ),
 			array(
 				'exit_error' => false,
 				'return'     => 'all',
@@ -236,6 +239,43 @@ class DrainCommand extends BaseCommand {
 	 */
 	private static function getPendingCount(): int {
 		return self::countActions( false );
+	}
+
+	/**
+	 * Get due pending Data Machine action IDs in execution order.
+	 *
+	 * @param int $limit Maximum IDs to return.
+	 * @return int[] Action IDs.
+	 */
+	private static function getDuePendingActionIds( int $limit ): array {
+		global $wpdb;
+
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$groups_table  = $wpdb->prefix . 'actionscheduler_groups';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				'SELECT a.action_id
+				FROM %i a
+				INNER JOIN %i g ON g.group_id = a.group_id
+				WHERE a.hook IN (%s, %s)
+				AND a.status = \'pending\'
+				AND g.slug = %s
+				AND a.scheduled_date_gmt <= %s
+				ORDER BY a.scheduled_date_gmt ASC, a.action_id ASC
+				LIMIT %d',
+				$actions_table,
+				$groups_table,
+				self::HOOK_BATCH_CHUNK,
+				self::HOOK_EXECUTE_STEP,
+				self::GROUP,
+				gmdate( 'Y-m-d H:i:s' ),
+				$limit
+			)
+		);
+
+		return array_map( 'intval', $ids );
 	}
 
 	/**

--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -1,0 +1,348 @@
+<?php
+/**
+ * WP-CLI Data Machine drain command.
+ *
+ * @package DataMachine\Cli\Commands
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use DataMachine\Cli\BaseCommand;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Drain due Data Machine Action Scheduler work.
+ */
+class DrainCommand extends BaseCommand {
+
+	private const GROUP = 'data-machine';
+
+	private const HOOK_BATCH_CHUNK = 'datamachine_pipeline_batch_chunk';
+
+	private const HOOK_EXECUTE_STEP = 'datamachine_execute_step';
+
+	/**
+	 * Drain due Data Machine actions until empty or a budget is reached.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--limit=<number>]
+	 * : Maximum actions to execute. 0 means no action-count limit.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * [--batch-size=<number>]
+	 * : Maximum actions to ask Action Scheduler to claim per batch.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--time-limit=<seconds>]
+	 * : Maximum wall-clock seconds to drain. 0 means no time limit.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine drain
+	 *     wp datamachine drain --limit=500 --time-limit=300 --format=json
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		unset( $args );
+
+		$stats = self::drain(
+			array(
+				'limit'      => isset( $assoc_args['limit'] ) ? (int) $assoc_args['limit'] : 0,
+				'batch_size' => isset( $assoc_args['batch-size'] ) ? (int) $assoc_args['batch-size'] : 25,
+				'time_limit' => isset( $assoc_args['time-limit'] ) ? (int) $assoc_args['time-limit'] : 0,
+			)
+		);
+
+		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
+			WP_CLI::line( wp_json_encode( $stats, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$this->format_items( array( $stats ), array_keys( $stats ), array( 'format' => 'table' ) );
+	}
+
+	/**
+	 * Drain due Data Machine actions and return a compact summary.
+	 *
+	 * @param array{limit?:int,batch_size?:int,time_limit?:int} $options Drain options.
+	 * @return array<string,int|string> Drain stats.
+	 */
+	public static function drain( array $options = array() ): array {
+		$limit      = max( 0, (int) ( $options['limit'] ?? 0 ) );
+		$batch_size = max( 1, (int) ( $options['batch_size'] ?? 25 ) );
+		$time_limit = max( 0, (int) ( $options['time_limit'] ?? 0 ) );
+
+		$started_at    = time();
+		$before_counts = self::getStatusCounts();
+		$batches       = 0;
+		$warnings      = 0;
+
+		while ( self::getDuePendingCount() > 0 ) {
+			$stats = self::buildStats( $before_counts, self::getStatusCounts(), $batches, $warnings );
+			if ( $limit > 0 && (int) $stats['actions_processed'] >= $limit ) {
+				break;
+			}
+
+			if ( $time_limit > 0 && ( time() - $started_at ) >= $time_limit ) {
+				break;
+			}
+
+			$current_batch_size = $batch_size;
+			if ( $limit > 0 ) {
+				$current_batch_size = min( $batch_size, $limit - (int) $stats['actions_processed'] );
+			}
+
+			$due_before    = self::getDuePendingCount();
+			$status_before = self::getStatusCounts();
+			$result        = self::runActionSchedulerBatch( $current_batch_size );
+			++$batches;
+
+			if ( 0 !== (int) ( $result->return_code ?? 1 ) ) {
+				++$warnings;
+				$message = trim( (string) ( $result->stderr ?? '' ) );
+				WP_CLI::warning( '' === $message ? 'Action Scheduler CLI drain failed.' : $message );
+				break;
+			}
+
+			$status_after = self::getStatusCounts();
+			$progress     = self::processedDelta( $status_before, $status_after );
+			if ( 0 === $progress && self::getDuePendingCount() >= $due_before ) {
+				++$warnings;
+				WP_CLI::warning( 'Drain stopped because Action Scheduler made no observable progress.' );
+				break;
+			}
+		}
+
+		return self::buildStats( $before_counts, self::getStatusCounts(), $batches, $warnings );
+	}
+
+	/**
+	 * Run one scoped Action Scheduler batch.
+	 *
+	 * @param int $batch_size Batch size.
+	 * @return object WP_CLI::runcommand result object.
+	 */
+	private static function runActionSchedulerBatch( int $batch_size ): object {
+		return WP_CLI::runcommand(
+			sprintf(
+				'action-scheduler run --hooks=%s --group=%s --batch-size=%d --batches=1 --quiet --force',
+				implode( ',', self::hooks() ),
+				self::GROUP,
+				$batch_size
+			),
+			array(
+				'exit_error' => false,
+				'return'     => 'all',
+			)
+		);
+	}
+
+	/**
+	 * Build operator-facing stats.
+	 *
+	 * @param array<string,array<string,int>> $before_counts Counts before drain.
+	 * @param array<string,array<string,int>> $after_counts  Counts after drain.
+	 * @param int                             $batches       Batch count.
+	 * @param int                             $warnings      Warning count.
+	 * @return array<string,int|string> Stats.
+	 */
+	private static function buildStats( array $before_counts, array $after_counts, int $batches, int $warnings ): array {
+		$batch_completed = self::delta( $before_counts, $after_counts, self::HOOK_BATCH_CHUNK, 'complete' );
+		$batch_failed    = self::delta( $before_counts, $after_counts, self::HOOK_BATCH_CHUNK, 'failed' );
+		$step_completed  = self::delta( $before_counts, $after_counts, self::HOOK_EXECUTE_STEP, 'complete' );
+		$step_failed     = self::delta( $before_counts, $after_counts, self::HOOK_EXECUTE_STEP, 'failed' );
+
+		return array(
+			'batches'                    => $batches,
+			'batch_chunks'               => $batch_completed + $batch_failed,
+			'step_executions'            => $step_completed + $step_failed,
+			'completions'                => $batch_completed + $step_completed,
+			'failures'                   => $batch_failed + $step_failed,
+			'batch_chunk_completions'    => $batch_completed,
+			'batch_chunk_failures'       => $batch_failed,
+			'step_execution_completions' => $step_completed,
+			'step_execution_failures'    => $step_failed,
+			'actions_processed'          => $batch_completed + $batch_failed + $step_completed + $step_failed,
+			'remaining_pending'          => self::getDuePendingCount(),
+			'total_pending'              => self::getPendingCount(),
+			'warnings'                   => $warnings,
+			'hooks'                      => implode( ',', self::hooks() ),
+		);
+	}
+
+	/**
+	 * Count status deltas that indicate an action was processed.
+	 *
+	 * @param array<string,array<string,int>> $before_counts Counts before a batch.
+	 * @param array<string,array<string,int>> $after_counts  Counts after a batch.
+	 * @return int Processed action count.
+	 */
+	private static function processedDelta( array $before_counts, array $after_counts ): int {
+		$total = 0;
+		foreach ( self::hooks() as $hook ) {
+			$total += self::delta( $before_counts, $after_counts, $hook, 'complete' );
+			$total += self::delta( $before_counts, $after_counts, $hook, 'failed' );
+		}
+		return $total;
+	}
+
+	/**
+	 * Get a status count delta.
+	 *
+	 * @param array<string,array<string,int>> $before_counts Counts before.
+	 * @param array<string,array<string,int>> $after_counts  Counts after.
+	 * @param string                          $hook          Hook name.
+	 * @param string                          $status        Action status.
+	 * @return int Non-negative delta.
+	 */
+	private static function delta( array $before_counts, array $after_counts, string $hook, string $status ): int {
+		return max( 0, ( $after_counts[ $hook ][ $status ] ?? 0 ) - ( $before_counts[ $hook ][ $status ] ?? 0 ) );
+	}
+
+	/**
+	 * Count due pending Data Machine actions.
+	 *
+	 * @return int Due pending count.
+	 */
+	private static function getDuePendingCount(): int {
+		return self::countActions( true );
+	}
+
+	/**
+	 * Count all pending Data Machine actions.
+	 *
+	 * @return int Pending count.
+	 */
+	private static function getPendingCount(): int {
+		return self::countActions( false );
+	}
+
+	/**
+	 * Count pending Data Machine actions.
+	 *
+	 * @param bool $due_only Whether to count only due actions.
+	 * @return int Pending count.
+	 */
+	private static function countActions( bool $due_only ): int {
+		global $wpdb;
+
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$groups_table  = $wpdb->prefix . 'actionscheduler_groups';
+
+		if ( $due_only ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			return (int) $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT COUNT(*)
+					FROM %i a
+					INNER JOIN %i g ON g.group_id = a.group_id
+					WHERE a.hook IN (%s, %s)
+					AND a.status = \'pending\'
+					AND g.slug = %s
+					AND a.scheduled_date_gmt <= %s',
+					$actions_table,
+					$groups_table,
+					self::HOOK_BATCH_CHUNK,
+					self::HOOK_EXECUTE_STEP,
+					self::GROUP,
+					gmdate( 'Y-m-d H:i:s' )
+				)
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*)
+				FROM %i a
+				INNER JOIN %i g ON g.group_id = a.group_id
+				WHERE a.hook IN (%s, %s)
+				AND a.status = \'pending\'
+				AND g.slug = %s',
+				$actions_table,
+				$groups_table,
+				self::HOOK_BATCH_CHUNK,
+				self::HOOK_EXECUTE_STEP,
+				self::GROUP
+			)
+		);
+	}
+
+	/**
+	 * Get action counts grouped by hook and status.
+	 *
+	 * @return array<string,array<string,int>> Counts by hook and status.
+	 */
+	private static function getStatusCounts(): array {
+		global $wpdb;
+
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$groups_table  = $wpdb->prefix . 'actionscheduler_groups';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT a.hook, a.status, COUNT(*) AS count
+				FROM %i a
+				INNER JOIN %i g ON g.group_id = a.group_id
+				WHERE a.hook IN (%s, %s)
+				AND g.slug = %s
+				GROUP BY a.hook, a.status',
+				$actions_table,
+				$groups_table,
+				self::HOOK_BATCH_CHUNK,
+				self::HOOK_EXECUTE_STEP,
+				self::GROUP
+			)
+		);
+
+		$counts = array();
+		foreach ( self::hooks() as $hook ) {
+			$counts[ $hook ] = array(
+				'pending'  => 0,
+				'complete' => 0,
+				'failed'   => 0,
+			);
+		}
+
+		foreach ( $rows as $row ) {
+			$hook   = (string) $row->hook;
+			$status = (string) $row->status;
+			if ( isset( $counts[ $hook ] ) ) {
+				$counts[ $hook ][ $status ] = (int) $row->count;
+			}
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Get hooks drained by Data Machine.
+	 *
+	 * @return string[] Hook names.
+	 */
+	private static function hooks(): array {
+		return array( self::HOOK_BATCH_CHUNK, self::HOOK_EXECUTE_STEP );
+	}
+}

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -482,7 +482,7 @@ class FlowsCommand extends BaseCommand {
 				continue;
 			}
 
-			$step_type = $step_data['step_type'] ?? '';
+			$step_type = (string) $step_data['step_type'];
 			$order     = $step_data['execution_order'] ?? '';
 			$slugs     = FlowStepConfig::getConfiguredHandlerSlugs( $step_data );
 			$configs   = FlowStepConfig::getHandlerConfigs( $step_data );
@@ -1095,10 +1095,6 @@ class FlowsCommand extends BaseCommand {
 				)
 			);
 
-			if ( is_wp_error( $step_result ) ) {
-				WP_CLI::error( $step_result->get_error_message() );
-			}
-
 			if ( ! $step_result['success'] ) {
 				WP_CLI::error( $step_result['error'] ?? 'Failed to update user_message' );
 				return;
@@ -1132,10 +1128,6 @@ class FlowsCommand extends BaseCommand {
 
 			$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
 			$step_result  = $step_ability->execute( $step_input );
-
-			if ( is_wp_error( $step_result ) ) {
-				WP_CLI::error( $step_result->get_error_message() );
-			}
 
 			if ( ! $step_result['success'] ) {
 				WP_CLI::error( $step_result['error'] ?? 'Failed to update handler config' );
@@ -1204,10 +1196,6 @@ class FlowsCommand extends BaseCommand {
 			$handler_configs = FlowStepConfig::getHandlerConfigs( $step_data );
 
 			foreach ( $handler_configs as $hconfig ) {
-				if ( ! is_array( $hconfig ) ) {
-					continue;
-				}
-
 				// Coordinates (location field with lat,lon).
 				if ( ! empty( $hconfig['location'] ) && strpos( $hconfig['location'], ',' ) !== false ) {
 					$loc     = $hconfig['location'];
@@ -1223,7 +1211,7 @@ class FlowsCommand extends BaseCommand {
 				// Source URL — show domain only.
 				if ( ! empty( $hconfig['source_url'] ) ) {
 					$host    = wp_parse_url( $hconfig['source_url'], PHP_URL_HOST );
-					$parts[] = $host ?: $hconfig['source_url'];
+					$parts[] = $host ? $host : $hconfig['source_url'];
 				}
 
 				// Venue/source name.
@@ -1235,7 +1223,7 @@ class FlowsCommand extends BaseCommand {
 				$feed_url = $hconfig['feed_url'] ?? $hconfig['url'] ?? '';
 				if ( $feed_url && empty( $hconfig['source_url'] ) ) {
 					$host    = wp_parse_url( $feed_url, PHP_URL_HOST );
-					$parts[] = $host ?: $feed_url;
+					$parts[] = $host ? $host : $feed_url;
 				}
 
 				// Taxonomy term selections (any taxonomy_*_selection key).
@@ -1256,7 +1244,7 @@ class FlowsCommand extends BaseCommand {
 			$summary = mb_substr( $summary, 0, 57 ) . '...';
 		}
 
-		return $summary ?: '—';
+		return '' !== $summary ? $summary : '—';
 	}
 
 	/**
@@ -1326,12 +1314,9 @@ class FlowsCommand extends BaseCommand {
 			}
 
 			$handler_configs = FlowStepConfig::getHandlerConfigs( $step_data );
-			if ( ! is_array( $handler_configs ) ) {
-				continue;
-			}
 
 			foreach ( $handler_configs as $handler_slug => $handler_config ) {
-				if ( ! is_array( $handler_config ) || ! array_key_exists( 'max_items', $handler_config ) ) {
+				if ( ! array_key_exists( 'max_items', $handler_config ) ) {
 					continue;
 				}
 
@@ -1463,7 +1448,7 @@ class FlowsCommand extends BaseCommand {
 				continue;
 			}
 
-			$step_type = $step['step_type'] ?? '';
+			$step_type = (string) $step['step_type'];
 
 			$slugs   = FlowStepConfig::getConfiguredHandlerSlugs( $step );
 			$configs = FlowStepConfig::getHandlerConfigs( $step );

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -428,7 +428,7 @@ class FlowsCommand extends BaseCommand {
 
 		// JSON/YAML: output the full flow data including flow_config.
 		if ( 'json' === $format ) {
-			WP_CLI::line( wp_json_encode( $flow, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			WP_CLI::line( (string) wp_json_encode( $flow, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 			return;
 		}
 
@@ -719,7 +719,7 @@ class FlowsCommand extends BaseCommand {
 			return $value ? 'true' : 'false';
 		}
 		if ( is_array( $value ) ) {
-			return wp_json_encode( $value );
+			return (string) wp_json_encode( $value );
 		}
 		$str = (string) $value;
 		return $this->truncateValue( $str );
@@ -826,7 +826,7 @@ class FlowsCommand extends BaseCommand {
 		if ( $dry_run ) {
 			WP_CLI::success( 'Validation passed.' );
 			if ( isset( $result['would_create'] ) && 'json' === $format ) {
-				WP_CLI::line( wp_json_encode( $result['would_create'], JSON_PRETTY_PRINT ) );
+				WP_CLI::line( (string) wp_json_encode( $result['would_create'], JSON_PRETTY_PRINT ) );
 			} elseif ( isset( $result['would_create'] ) ) {
 				foreach ( $result['would_create'] as $preview ) {
 					WP_CLI::log(
@@ -859,7 +859,7 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		if ( 'json' === $format && isset( $result['flow_data'] ) ) {
-			WP_CLI::line( wp_json_encode( $result['flow_data'], JSON_PRETTY_PRINT ) );
+			WP_CLI::line( (string) wp_json_encode( $result['flow_data'], JSON_PRETTY_PRINT ) );
 		}
 	}
 
@@ -1464,7 +1464,7 @@ class FlowsCommand extends BaseCommand {
 					if ( is_string( $v ) && strlen( $v ) > 30 ) {
 						$v = substr( $v, 0, 27 ) . '...';
 					}
-					$config_summary[] = "{$k}=" . ( is_array( $v ) ? wp_json_encode( $v ) : $v );
+					$config_summary[] = "{$k}=" . ( is_array( $v ) ? (string) wp_json_encode( $v ) : $v );
 				}
 
 				$rows[] = array(
@@ -1631,7 +1631,7 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( wp_json_encode( $current_files, JSON_PRETTY_PRINT ) );
+			WP_CLI::line( (string) wp_json_encode( $current_files, JSON_PRETTY_PRINT ) );
 			return;
 		}
 
@@ -1677,7 +1677,7 @@ class FlowsCommand extends BaseCommand {
 
 		$format = $assoc_args['format'] ?? 'table';
 		if ( 'json' === $format ) {
-			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT ) );
 		} else {
 			foreach ( $result['flows'] ?? array() as $detail ) {
 				WP_CLI::log( sprintf( '  Flow %d: %s', $detail['flow_id'], $detail['status'] ) );
@@ -1717,7 +1717,7 @@ class FlowsCommand extends BaseCommand {
 
 		$format = $assoc_args['format'] ?? 'table';
 		if ( 'json' === $format ) {
-			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT ) );
 		} else {
 			foreach ( $result['flows'] ?? array() as $detail ) {
 				$line = sprintf( '  Flow %d: %s', $detail['flow_id'], $detail['status'] );

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -20,6 +20,7 @@ use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Cli\AgentResolver;
 use DataMachine\Cli\UserResolver;
+use DataMachine\Cli\Commands\DrainCommand;
 use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
@@ -84,8 +85,8 @@ class FlowsCommand extends BaseCommand {
 	 * [--timestamp=<unix>]
 	 * : Unix timestamp for delayed execution (future time required).
 	 *
-	 * [--no-drain]
-	 * : Skip the default CLI drain of due datamachine_execute_step actions after an immediate run.
+	 * [--[no-]drain]
+	 * : Drain due Data Machine batch chunk and step actions after an immediate run.
 	 *
 	 * [--pipeline_id=<id>]
 	 * : Pipeline ID for flow creation (create subcommand).
@@ -316,7 +317,7 @@ class FlowsCommand extends BaseCommand {
 		} elseif ( ! empty( $args ) && 'run' === $args[0] ) {
 			// Handle 'run' subcommand: `flows run 42`.
 			if ( ! isset( $args[1] ) ) {
-				WP_CLI::error( 'Usage: wp datamachine flows run <flow_id> [--count=N] [--timestamp=T] [--no-drain]' );
+				WP_CLI::error( 'Usage: wp datamachine flows run <flow_id> [--count=N] [--timestamp=T] [--[no-]drain]' );
 				return;
 			}
 			$this->runFlow( (int) $args[1], $assoc_args );
@@ -871,7 +872,7 @@ class FlowsCommand extends BaseCommand {
 	private function runFlow( int $flow_id, array $assoc_args ): void {
 		$count     = isset( $assoc_args['count'] ) ? (int) $assoc_args['count'] : 1;
 		$timestamp = isset( $assoc_args['timestamp'] ) ? (int) $assoc_args['timestamp'] : null;
-		$drain     = ! isset( $assoc_args['no-drain'] );
+		$drain     = \WP_CLI\Utils\get_flag_value( $assoc_args, 'drain', true );
 
 		// Validate count range (1-10).
 		if ( $count < 1 || $count > 10 ) {
@@ -943,41 +944,18 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		if ( $drain ) {
-			$this->drainDueStepActions();
+			$stats = DrainCommand::drain();
+			WP_CLI::log(
+				sprintf(
+					'Drained Data Machine actions: %d batch chunks, %d step executions, %d completions, %d failures, %d due pending remain.',
+					$stats['batch_chunks'],
+					$stats['step_executions'],
+					$stats['completions'],
+					$stats['failures'],
+					$stats['remaining_pending']
+				)
+			);
 		}
-	}
-
-	/**
-	 * Drain due Data Machine step actions after manual CLI flow runs.
-	 *
-	 * Studio/local CLI runs can enqueue due step actions without any HTTP traffic
-	 * to tick Action Scheduler. Reuse Action Scheduler's CLI runner and scope the
-	 * drain to DM step actions so manual `flow run` advances the work it just queued.
-	 */
-	private function drainDueStepActions(): void {
-		if ( ! class_exists( '\WP_CLI' ) || ! method_exists( WP_CLI::class, 'runcommand' ) ) {
-			return;
-		}
-
-		$result = WP_CLI::runcommand(
-			'action-scheduler run --hooks=datamachine_execute_step --quiet',
-			array(
-				'exit_error' => false,
-				'return'     => 'all',
-			)
-		);
-
-		if ( 0 === (int) ( $result->return_code ?? 1 ) ) {
-			WP_CLI::log( 'Drained due Data Machine step actions.' );
-			return;
-		}
-
-		$message = trim( (string) ( $result->stderr ?? '' ) );
-		if ( '' === $message ) {
-			$message = 'Action Scheduler CLI drain failed.';
-		}
-
-		WP_CLI::warning( $message );
 	}
 
 	/**

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -1,14 +1,18 @@
 <?php
 /**
- * Pure-PHP smoke test for CLI flow-run Action Scheduler draining (#1374).
+ * Pure-PHP smoke test for CLI flow-run Action Scheduler draining (#1374/#1719).
  *
  * Run with: php tests/flow-run-cli-drain-smoke.php
  *
  * @package DataMachine\Tests
  */
 
-$file = __DIR__ . '/../inc/Cli/Commands/Flows/FlowsCommand.php';
-$src  = file_get_contents( $file ) ?: '';
+$flows_file = __DIR__ . '/../inc/Cli/Commands/Flows/FlowsCommand.php';
+$drain_file = __DIR__ . '/../inc/Cli/Commands/DrainCommand.php';
+$boot_file  = __DIR__ . '/../inc/Cli/Bootstrap.php';
+$src        = file_get_contents( $flows_file ) ?: '';
+$drain_src  = file_get_contents( $drain_file ) ?: '';
+$boot_src   = file_get_contents( $boot_file ) ?: '';
 
 $assertions = 0;
 
@@ -29,16 +33,21 @@ function assert_drain_not_contains( string $needle, string $haystack, string $me
 	assert_true( false === strpos( $haystack, $needle ), $message );
 }
 
-assert_drain_contains( '[--no-drain]', $src, 'flow run usage documents --no-drain escape hatch' );
-assert_drain_contains( '$drain     = ! isset( $assoc_args[\'no-drain\'] );', $src, 'immediate runs drain by default' );
+assert_drain_contains( '[--[no-]drain]', $src, 'flow run usage documents WP-CLI-compatible drain toggle' );
+assert_drain_contains( 'get_flag_value( $assoc_args, \'drain\', true )', $src, 'immediate runs drain by default and accepts --no-drain' );
 assert_drain_contains( 'if ( $drain ) {', $src, 'drain is gated by the CLI flag' );
-assert_drain_contains( '$this->drainDueStepActions();', $src, 'immediate run calls the drain helper' );
-assert_drain_contains( 'private function drainDueStepActions(): void', $src, 'drain helper exists' );
-assert_drain_contains( 'WP_CLI::runcommand(', $src, 'drain helper reuses WP-CLI command runner' );
-assert_drain_contains( 'action-scheduler run --hooks=datamachine_execute_step --quiet', $src, 'drain is scoped to due DM step actions' );
-assert_drain_contains( "'exit_error' => false", $src, 'drain failure is surfaced as warning instead of fataling after job start' );
-assert_drain_contains( "'return'     => 'all'", $src, 'drain captures Action Scheduler command result' );
-assert_drain_contains( 'Drained due Data Machine step actions.', $src, 'successful drain is visible to CLI operator' );
+assert_drain_contains( 'DrainCommand::drain()', $src, 'immediate run calls first-class DM drain loop' );
+assert_drain_contains( "WP_CLI::add_command( 'datamachine drain'", $boot_src, 'first-class datamachine drain command is registered' );
+assert_drain_contains( "datamachine_pipeline_batch_chunk'", $drain_src, 'drain includes pipeline batch chunk hook' );
+assert_drain_contains( "datamachine_execute_step'", $drain_src, 'drain includes execute step hook' );
+assert_drain_contains( 'action-scheduler run --hooks=%s --group=%s --batch-size=%d --batches=1 --quiet --force', $drain_src, 'drain runs scoped Action Scheduler batches' );
+assert_drain_contains( "'exit_error' => false", $drain_src, 'drain failure is surfaced as warning instead of fataling after job start' );
+assert_drain_contains( "'return'     => 'all'", $drain_src, 'drain captures Action Scheduler command result' );
+assert_drain_contains( "'remaining_pending'", $drain_src, 'drain reports remaining pending actions' );
+assert_drain_contains( "'batch_chunks'", $drain_src, 'drain reports batch chunk counts' );
+assert_drain_contains( "'step_executions'", $drain_src, 'drain reports step execution counts' );
+assert_drain_contains( "'completions'", $drain_src, 'drain reports completions' );
+assert_drain_contains( "'failures'", $drain_src, 'drain reports failures' );
 
 $run_flow_start = strpos( $src, 'private function runFlow' );
 assert_true( false !== $run_flow_start, 'runFlow method found' );
@@ -46,7 +55,7 @@ assert_true( false !== $run_flow_start, 'runFlow method found' );
 $run_flow_offset = false === $run_flow_start ? 0 : $run_flow_start;
 $timestamp_path  = strpos( $src, '// Delayed execution', $run_flow_offset );
 $immediate_path  = strpos( $src, '// Immediate execution', $run_flow_offset );
-$drain_call      = strpos( $src, '$this->drainDueStepActions();', $run_flow_offset );
+$drain_call      = strpos( $src, 'DrainCommand::drain()', $run_flow_offset );
 
 assert_true( false !== $timestamp_path, 'delayed scheduling path found' );
 assert_true( false !== $immediate_path, 'immediate execution path found' );
@@ -54,11 +63,11 @@ assert_true( false !== $drain_call, 'drain call found in runFlow' );
 assert_true( $drain_call > $immediate_path, 'drain runs only after immediate execution starts jobs' );
 assert_true( $drain_call > $timestamp_path, 'timestamp scheduling returns before the drain call' );
 
-$helper_start = strpos( $src, 'private function drainDueStepActions(): void' );
+$helper_start = strpos( $drain_src, 'public static function drain' );
 assert_true( false !== $helper_start, 'drain helper start found' );
 
 $helper_offset = false === $helper_start ? 0 : $helper_start;
-$helper_src    = substr( $src, $helper_offset );
+$helper_src    = substr( $drain_src, $helper_offset );
 assert_drain_not_contains( 'datamachine_run_flow_now', $helper_src, 'drain does not run scheduled flow-trigger actions' );
 
 echo "OK ({$assertions} assertions)\n";

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -40,7 +40,8 @@ assert_drain_contains( 'DrainCommand::drain()', $src, 'immediate run calls first
 assert_drain_contains( "WP_CLI::add_command( 'datamachine drain'", $boot_src, 'first-class datamachine drain command is registered' );
 assert_drain_contains( "datamachine_pipeline_batch_chunk'", $drain_src, 'drain includes pipeline batch chunk hook' );
 assert_drain_contains( "datamachine_execute_step'", $drain_src, 'drain includes execute step hook' );
-assert_drain_contains( 'action-scheduler run --hooks=%s --group=%s --batch-size=%d --batches=1 --quiet --force', $drain_src, 'drain runs scoped Action Scheduler batches' );
+assert_drain_contains( 'getDuePendingActionIds', $drain_src, 'drain queries concrete due Data Machine action IDs' );
+assert_drain_contains( 'action-scheduler action run ', $drain_src, 'drain runs concrete action IDs instead of generic queue runner' );
 assert_drain_contains( "'exit_error' => false", $drain_src, 'drain failure is surfaced as warning instead of fataling after job start' );
 assert_drain_contains( "'return'     => 'all'", $drain_src, 'drain captures Action Scheduler command result' );
 assert_drain_contains( "'remaining_pending'", $drain_src, 'drain reports remaining pending actions' );


### PR DESCRIPTION
## Summary
- Adds a first-class `wp datamachine drain` command that drains due Data Machine Action Scheduler work for both `datamachine_pipeline_batch_chunk` and `datamachine_execute_step`.
- Updates `flow run` to use the shared drain loop and documents the WP-CLI-compatible `--[no-]drain` flag so `--no-drain` is accepted.
- Reports batch chunks, step executions, completions, failures, remaining due pending actions, total pending actions, and warnings.

Closes #1719

## Testing
- `php -l inc/Cli/Commands/DrainCommand.php`
- `php -l inc/Cli/Commands/Flows/FlowsCommand.php`
- `php tests/flow-run-cli-drain-smoke.php`
- `git diff --check`

## Verification notes
- `homeboy lint data-machine` still fails on existing repository-wide PHPStan/coding-standard findings; after the local fixes, no `DrainCommand.php` findings remained in the lint output.
- `homeboy test data-machine` fails before running tests during bootstrap: `Class "DataMachine\\Core\\Steps\\Fetch\\Handlers\\FetchHandlerSettings" not found` in `tests/Unit/Abilities/HandlerAbilitiesTest.php:22`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the CLI drain fix, updating the smoke coverage, running targeted verification, and drafting this PR body for Chris to review.