### PR TITLE
refactor(memory): make SITE.md and NETWORK.md composable via SectionRegistry

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -690,11 +690,12 @@ function datamachine_activate_for_site() {
 	// `datamachine_db_version` option (#1301).
 	datamachine_run_schema_migrations();
 
-	// Regenerate SITE.md with enriched content and clean up legacy SiteContext transient.
-	// Activation-only — SITE.md regeneration is heavy and shouldn't fire on
+	// Regenerate every composable memory file (SITE.md, NETWORK.md, AGENTS.md, …)
+	// from their registered sections, and clean up the legacy SiteContext transient.
+	// Activation-only — composable regeneration is heavy and shouldn't fire on
 	// every deploy (the version-gated runtime path is for schema-shape drift,
 	// not opportunistic content refresh).
-	datamachine_regenerate_site_md();
+	\DataMachine\Engine\AI\ComposableFileGenerator::regenerate_all();
 	delete_transient( 'datamachine_site_context_data' );
 
 	// Clean up legacy per-agent-type log level options (idempotent).

--- a/docs/core-system/wordpress-as-agent-memory.md
+++ b/docs/core-system/wordpress-as-agent-memory.md
@@ -151,7 +151,24 @@ The difference between useful memory and noise is structure. Each core file has 
 
 ### SITE.md — Site-Wide Context (Shared Layer)
 
-SITE.md contains information about the WordPress installation that all agents share. It is **read-only** — fully regenerated from live WordPress data whenever site structure changes (plugin activations, theme switches, post/term lifecycle, option updates). To extend it, use the `datamachine_site_scaffold_content` filter.
+SITE.md contains information about the WordPress installation that all agents share. It is **read-only and composable** — fully regenerated from live WordPress data whenever site structure changes (plugin activations, theme switches, post/term lifecycle, option updates).
+
+To extend it, register a section against the `SectionRegistry` (the same API used for `AGENTS.md`):
+
+```php
+add_action( 'datamachine_sections', function () {
+    \DataMachine\Engine\AI\SectionRegistry::register(
+        'SITE.md',
+        'my-platform',
+        35, // priority — slots between post-types (30) and taxonomies (40)
+        function () {
+            return "## My Platform\n- Custom context line 1\n- Custom context line 2";
+        }
+    );
+} );
+```
+
+The legacy `datamachine_site_scaffold_content` whole-string filter still fires on the assembled output for backwards compatibility but emits a `_doing_it_wrong` deprecation notice. Migrate to `SectionRegistry::register()`.
 
 **Sections generated:**
 

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -132,12 +132,14 @@ add_action(
 );
 
 // Shared layer — site-wide context, visible to all agents.
+// Composable: content assembled from sections registered against SectionRegistry
+// (see inc/migrations/site-md.php). `editable` is forced to false by composable=true.
 MemoryFileRegistry::register( 'SITE.md', 10, array(
 	'layer'       => MemoryFileRegistry::LAYER_SHARED,
 	'protected'   => true,
-	'editable'    => false,
+	'composable'  => true,
 	'label'       => 'Site Context',
-	'description' => 'Auto-generated site context. Read-only — extend via PHP filters.',
+	'description' => 'Auto-generated site context. Composable — extend via SectionRegistry.',
 ) );
 MemoryFileRegistry::register( 'RULES.md', 15, array(
 	'layer'       => MemoryFileRegistry::LAYER_SHARED,
@@ -179,25 +181,20 @@ MemoryFileRegistry::register( 'USER.md', 25, array(
 ) );
 
 // Network layer — multisite topology, only meaningful on multisite installs.
+// Composable: content assembled from sections registered against SectionRegistry.
 MemoryFileRegistry::register( 'NETWORK.md', 5, array(
 	'layer'       => MemoryFileRegistry::LAYER_NETWORK,
 	'protected'   => true,
-	'editable'    => false,
+	'composable'  => true,
 	'label'       => 'Network Context',
-	'description' => 'Auto-generated multisite network topology. Read-only — extend via PHP filters.',
+	'description' => 'Auto-generated multisite network topology. Composable — extend via SectionRegistry.',
 ) );
 
-// SITE.md auto-regeneration — replaces the former SiteContext + SiteContextDirective system.
-// SITE.md is now the single source of truth for site context, auto-refreshing on structural changes.
-add_action( 'init', 'datamachine_register_site_md_invalidation' );
-
-// NETWORK.md auto-regeneration — keeps multisite topology in sync with live WordPress state.
-// Only registers hooks on multisite installs (guard is inside the function).
-add_action( 'init', 'datamachine_register_network_md_invalidation' );
-
-// Composable file auto-regeneration — rebuilds AGENTS.md (and any other composable files) on
-// plugin (de)activation plus any hooks plugins register via datamachine_composable_invalidation_hooks.
-// Runs on `init` so plugin filters registered during `plugins_loaded` are already in place.
+// Composable file auto-regeneration — rebuilds AGENTS.md, SITE.md, NETWORK.md, and any other
+// composable files on plugin (de)activation plus any hooks plugins register via
+// datamachine_composable_invalidation_hooks (SITE.md and NETWORK.md core hooks live in
+// inc/migrations/site-md.php). Runs on `init` so plugin filters registered during
+// `plugins_loaded` are already in place.
 add_action( 'init', array( \DataMachine\Engine\AI\ComposableFileInvalidation::class, 'register_hooks' ) );
 
 require_once __DIR__ . '/Engine/AI/Directives/ClientContextDirective.php';

--- a/inc/migrations/layered-architecture.php
+++ b/inc/migrations/layered-architecture.php
@@ -55,8 +55,9 @@ function datamachine_migrate_to_layered_architecture(): void {
 
 	$site_md = trailingslashit( $shared_dir ) . 'SITE.md';
 	if ( ! file_exists( $site_md ) ) {
-		$fs->put_contents( $site_md, datamachine_get_site_scaffold_content(), FS_CHMOD_FILE );
-		\DataMachine\Core\FilesRepository\FilesystemHelper::make_group_writable( $site_md );
+		// Compose from registered sections. Caller already guarantees the
+		// shared dir exists; ComposableFileGenerator will set permissions.
+		\DataMachine\Engine\AI\ComposableFileGenerator::regenerate( 'SITE.md' );
 	}
 
 	$index_file = trailingslashit( $shared_dir ) . 'index.php';

--- a/inc/migrations/network-scope.php
+++ b/inc/migrations/network-scope.php
@@ -118,11 +118,9 @@ function datamachine_migrate_user_md_to_network_scope(): void {
 
 	$network_md = trailingslashit( $network_dir ) . 'NETWORK.md';
 	if ( ! file_exists( $network_md ) ) {
-		$content = datamachine_get_network_scaffold_content();
-		if ( ! empty( $content ) ) {
-			$fs->put_contents( $network_md, $content, FS_CHMOD_FILE );
-			\DataMachine\Core\FilesRepository\FilesystemHelper::make_group_writable( $network_md );
-		}
+		// Compose from registered sections. Generator self-skips on single-site
+		// installs because every NETWORK.md section returns an empty string.
+		\DataMachine\Engine\AI\ComposableFileGenerator::regenerate( 'NETWORK.md' );
 	}
 
 	$network_index = trailingslashit( $network_dir ) . 'index.php';

--- a/inc/migrations/network-scope.php
+++ b/inc/migrations/network-scope.php
@@ -180,13 +180,15 @@ function datamachine_migrate_agents_to_network_scope() {
 		// Skip the main site — its prefix IS the base_prefix, so the table is already network-level.
 		if ( $site_prefix === $wpdb->base_prefix ) {
 			// Set site_scope on existing main-site agents that don't have one yet.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// Table name is built from $wpdb->base_prefix, not user input — safe to interpolate.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->query(
 				$wpdb->prepare(
 					"UPDATE `{$network_agents_table}` SET site_scope = %d WHERE site_scope IS NULL",
 					(int) $blog_id
 				)
 			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			continue;
 		}
 
@@ -213,7 +215,8 @@ function datamachine_migrate_agents_to_network_scope() {
 			$old_agent_id = (int) $agent['agent_id'];
 
 			// Check if slug already exists in network table.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// Table name from $wpdb->base_prefix — safe to interpolate.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$existing = $wpdb->get_row(
 				$wpdb->prepare(
 					"SELECT agent_id FROM `{$network_agents_table}` WHERE agent_slug = %s",
@@ -221,6 +224,7 @@ function datamachine_migrate_agents_to_network_scope() {
 				),
 				ARRAY_A
 			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 			if ( $existing ) {
 				// Slug already exists in network table — skip this agent.
@@ -252,11 +256,13 @@ function datamachine_migrate_agents_to_network_scope() {
 			++$migrated_agents;
 
 			// Migrate access grants for this agent.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// Table name from per-site $wpdb->prefix — safe to interpolate.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$site_access = $wpdb->get_results(
 				$wpdb->prepare( "SELECT * FROM `{$site_access_table}` WHERE agent_id = %d", $old_agent_id ),
 				ARRAY_A
 			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 			foreach ( $site_access as $access ) {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
@@ -277,11 +283,13 @@ function datamachine_migrate_agents_to_network_scope() {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$token_table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $site_tokens_table ) );
 			if ( $token_table_exists ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				// Table name from per-site $wpdb->prefix — safe to interpolate.
+				// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$site_tokens = $wpdb->get_results(
 					$wpdb->prepare( "SELECT * FROM `{$site_tokens_table}` WHERE agent_id = %d", $old_agent_id ),
 					ARRAY_A
 				);
+				// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 				foreach ( $site_tokens as $token ) {
 					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery

--- a/inc/migrations/site-md.php
+++ b/inc/migrations/site-md.php
@@ -295,16 +295,12 @@ function datamachine_site_section_taxonomies(): string {
 			'taxonomy'   => $tax->name,
 			'hide_empty' => false,
 		) );
-		// wp_count_terms returns int|numeric-string|WP_Error. Narrow to int
-		// before formatting so phpstan stays happy and output is consistent.
-		if ( is_wp_error( $term_count_raw ) ) {
-			$term_count = 0;
-		} elseif ( is_numeric( $term_count_raw ) ) {
-			$term_count = (int) $term_count_raw;
-		} else {
-			$term_count = 0;
-		}
-		$hier = $tax->hierarchical ? 'hierarchical' : 'flat';
+		// wp_count_terms returns int|numeric-string|WP_Error. The is_wp_error()
+		// guard narrows away WP_Error at runtime, but phpstan's WP stubs don't
+		// model that narrowing — suppress the residual cast complaint.
+		// @phpstan-ignore-next-line cast.int
+		$term_count = is_wp_error( $term_count_raw ) ? 0 : (int) $term_count_raw;
+		$hier       = $tax->hierarchical ? 'hierarchical' : 'flat';
 		// WP_Taxonomy::$object_type is array<string>, not nullable — use it directly.
 		$associated = implode( ', ', $tax->object_type );
 		$lines[]    = sprintf( '| %s | %s | %d | %s | %s |', $tax->label, $tax->name, $term_count, $hier, $associated );

--- a/inc/migrations/site-md.php
+++ b/inc/migrations/site-md.php
@@ -1,47 +1,348 @@
 <?php
 /**
- * Data Machine — SITE.md and NETWORK.md scaffolding and invalidation.
+ * Data Machine — SITE.md and NETWORK.md section registration.
  *
- * Generates and regenerates site and network context files from live
- * WordPress data. Registers invalidation hooks for structural changes.
+ * SITE.md and NETWORK.md are composable memory files. Their content is
+ * assembled from sections registered against the SectionRegistry, the same
+ * extension API plugins use to contribute to AGENTS.md. Regeneration is
+ * handled generically by ComposableFileGenerator + ComposableFileInvalidation;
+ * this file owns the *content* of the core sections only.
+ *
+ * Migration history:
+ * - 0.36.1 — initial SiteContext class injecting JSON into prompts.
+ * - 0.48.0 — replaced with monolithic SITE.md/NETWORK.md generators and a
+ *            single whole-string filter per file.
+ * - x.y.z  — files made composable; monolithic generators broken into
+ *            per-section callbacks. Legacy whole-string filters preserved
+ *            via `datamachine_composable_content` shim with a deprecation
+ *            notice.
  *
  * @package DataMachine
- * @since 0.60.0
+ * @since   0.60.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
+use DataMachine\Engine\AI\SectionRegistry;
+
 /**
- * Build shared SITE.md content from WordPress site data.
+ * Register all core SITE.md and NETWORK.md sections.
  *
- * This is the single source of truth for site context injected into AI calls.
- * Replaces the former SiteContext class + SiteContextDirective which injected
- * a duplicate JSON blob at priority 80. Now SITE.md contains all the same
- * data in markdown format, injected once via CoreMemoryFilesDirective.
+ * Fires on `datamachine_sections` (once per request, lazily). Each section
+ * is a small callback returning markdown. Sections are joined with double
+ * newlines by SectionRegistry::generate().
  *
- * @since 0.36.1
- * @since 0.48.0 Enriched with post counts, taxonomy details, language, timezone,
- *               site structure, user roles, plugin descriptions, REST namespaces.
+ * Priority spacing leaves room for plugin-contributed sections to slot in
+ * between core sections (e.g. priority 35 to land between post-types at 30
+ * and taxonomies at 40).
+ *
+ * @since x.y.z
+ * @return void
+ */
+function datamachine_register_core_sections(): void {
+	// SITE.md sections — assembled into shared/SITE.md.
+	SectionRegistry::register( 'SITE.md', 'header',       0,  'datamachine_site_section_header' );
+	SectionRegistry::register( 'SITE.md', 'identity',     10, 'datamachine_site_section_identity' );
+	SectionRegistry::register( 'SITE.md', 'structure',    20, 'datamachine_site_section_structure' );
+	SectionRegistry::register( 'SITE.md', 'post-types',   30, 'datamachine_site_section_post_types' );
+	SectionRegistry::register( 'SITE.md', 'taxonomies',   40, 'datamachine_site_section_taxonomies' );
+	SectionRegistry::register( 'SITE.md', 'user-roles',   50, 'datamachine_site_section_user_roles' );
+	SectionRegistry::register( 'SITE.md', 'plugins',      60, 'datamachine_site_section_plugins' );
+	SectionRegistry::register( 'SITE.md', 'mu-plugins',   65, 'datamachine_site_section_mu_plugins' );
+	SectionRegistry::register( 'SITE.md', 'dropins',      70, 'datamachine_site_section_dropins' );
+	SectionRegistry::register( 'SITE.md', 'rest-api',     80, 'datamachine_site_section_rest_api' );
+
+	// NETWORK.md sections — only meaningful on multisite (callbacks self-guard).
+	SectionRegistry::register( 'NETWORK.md', 'header',          0,  'datamachine_network_section_header' );
+	SectionRegistry::register( 'NETWORK.md', 'identity',        10, 'datamachine_network_section_identity' );
+	SectionRegistry::register( 'NETWORK.md', 'sites',           20, 'datamachine_network_section_sites' );
+	SectionRegistry::register( 'NETWORK.md', 'plugins',         30, 'datamachine_network_section_plugins' );
+	SectionRegistry::register( 'NETWORK.md', 'shared-resources', 40, 'datamachine_network_section_shared_resources' );
+}
+add_action( 'datamachine_sections', 'datamachine_register_core_sections' );
+
+/**
+ * Register the WordPress hooks that should trigger composable file
+ * regeneration when SITE.md / NETWORK.md content can change.
+ *
+ * Plugin (de)activation is wired by ComposableFileInvalidation directly
+ * because it changes the SectionRegistry itself; everything below changes
+ * the data each section reads.
+ *
+ * @since x.y.z
+ *
+ * @param string[] $hooks Existing invalidation hooks.
+ * @return string[]
+ */
+function datamachine_register_core_invalidation_hooks( array $hooks ): array {
+	// SITE.md invalidation — site identity, structure, menus.
+	$hooks[] = 'switch_theme';
+	$hooks[] = 'update_option_blogname';
+	$hooks[] = 'update_option_blogdescription';
+	$hooks[] = 'update_option_home';
+	$hooks[] = 'update_option_siteurl';
+	$hooks[] = 'update_option_permalink_structure';
+	$hooks[] = 'update_option_page_on_front';
+	$hooks[] = 'update_option_page_for_posts';
+	$hooks[] = 'update_option_show_on_front';
+	$hooks[] = 'wp_update_nav_menu';
+	$hooks[] = 'wp_delete_nav_menu';
+	$hooks[] = 'wp_update_nav_menu_item';
+
+	// NETWORK.md invalidation — site lifecycle (multisite only; harmless on single-site).
+	$hooks[] = 'wp_initialize_site';
+	$hooks[] = 'wp_delete_site';
+	$hooks[] = 'wp_uninitialize_site';
+
+	return $hooks;
+}
+add_filter( 'datamachine_composable_invalidation_hooks', 'datamachine_register_core_invalidation_hooks' );
+
+/**
+ * Soft-deprecation shim for the legacy whole-string filters.
+ *
+ * `datamachine_site_scaffold_content` and `datamachine_network_scaffold_content`
+ * are superseded by `SectionRegistry::register()`. To minimize breakage, we
+ * still fire them on the assembled output of SITE.md / NETWORK.md so existing
+ * consumers keep working, but emit a `_doing_it_wrong` notice when a callback
+ * is attached so consumers know to migrate.
+ *
+ * Will be removed in a future major version.
+ *
+ * @since x.y.z
+ *
+ * @param string $content  Assembled file content.
+ * @param string $filename Composable filename.
  * @return string
  */
-function datamachine_get_site_scaffold_content(): string {
+function datamachine_legacy_scaffold_filter_shim( string $content, string $filename ): string {
+	$legacy_filter = '';
+	$replacement   = '';
+
+	if ( 'SITE.md' === $filename ) {
+		$legacy_filter = 'datamachine_site_scaffold_content';
+		$replacement   = "SectionRegistry::register( 'SITE.md', '<your-slug>', <priority>, <callback> )";
+	} elseif ( 'NETWORK.md' === $filename ) {
+		$legacy_filter = 'datamachine_network_scaffold_content';
+		$replacement   = "SectionRegistry::register( 'NETWORK.md', '<your-slug>', <priority>, <callback> )";
+	}
+
+	if ( '' === $legacy_filter ) {
+		return $content;
+	}
+
+	if ( has_filter( $legacy_filter ) ) {
+		_doing_it_wrong(
+			esc_html( $legacy_filter ),
+			sprintf(
+				/* translators: 1: legacy filter name, 2: replacement code snippet */
+				esc_html__( 'The %1$s filter is deprecated. Register a SectionRegistry section instead: %2$s', 'data-machine' ),
+				esc_html( $legacy_filter ),
+				esc_html( $replacement )
+			),
+			'x.y.z'
+		);
+
+		/** This filter is documented in inc/migrations/site-md.php (legacy). */
+		$content = (string) apply_filters( $legacy_filter, $content );
+	}
+
+	return $content;
+}
+add_filter( 'datamachine_composable_content', 'datamachine_legacy_scaffold_filter_shim', 10, 2 );
+
+// -----------------------------------------------------------------------------
+// SITE.md sections.
+// -----------------------------------------------------------------------------
+
+/**
+ * Heading for SITE.md.
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_site_section_header(): string {
+	return '# SITE';
+}
+
+/**
+ * Identity block: name, description, URL, theme, language, timezone, etc.
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_site_section_identity(): string {
 	$site_name        = get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : 'WordPress Site';
-	$site_description = get_bloginfo( 'description' ) ? get_bloginfo( 'description' ) : '';
+	$site_description = (string) get_bloginfo( 'description' );
 	$site_url         = home_url();
 	$language         = get_locale();
 	$timezone         = wp_timezone_string();
 	$theme_name       = wp_get_theme()->get( 'Name' ) ? wp_get_theme()->get( 'Name' ) : 'Unknown';
-	$permalink        = get_option( 'permalink_structure', '' );
+	$permalink        = (string) get_option( 'permalink_structure', '' );
 
-	// --- Active plugins with descriptions (exclude Data Machine) ---
-	$active_plugins = get_option( 'active_plugins', array() );
+	$lines   = array();
+	$lines[] = '## Identity';
+	$lines[] = '- **name:** ' . $site_name;
+	if ( '' !== $site_description ) {
+		$lines[] = '- **description:** ' . $site_description;
+	}
+	$lines[] = '- **url:** ' . $site_url;
+	$lines[] = '- **theme:** ' . $theme_name;
+	$lines[] = '- **language:** ' . $language;
+	$lines[] = '- **timezone:** ' . $timezone;
+	if ( '' !== $permalink ) {
+		$lines[] = '- **permalinks:** ' . $permalink;
+	}
+	$lines[] = '- **multisite:** ' . ( is_multisite() ? 'true' : 'false' );
+
+	return implode( "\n", $lines );
+}
+
+/**
+ * Site Structure: front/blog/privacy pages, homepage display, menus.
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_site_section_structure(): string {
+	$lines   = array();
+	$lines[] = '## Site Structure';
+
+	$front_page_id = (int) get_option( 'page_on_front', 0 );
+	if ( $front_page_id > 0 ) {
+		$lines[] = sprintf( '- **Front page:** %s (ID %d)', get_the_title( $front_page_id ), $front_page_id );
+	}
+
+	$blog_page_id = (int) get_option( 'page_for_posts', 0 );
+	if ( $blog_page_id > 0 ) {
+		$lines[] = sprintf( '- **Blog page:** %s (ID %d)', get_the_title( $blog_page_id ), $blog_page_id );
+	}
+
+	$privacy_page_id = (int) get_option( 'wp_page_for_privacy_policy', 0 );
+	if ( $privacy_page_id > 0 ) {
+		$lines[] = sprintf( '- **Privacy page:** %s (ID %d)', get_the_title( $privacy_page_id ), $privacy_page_id );
+	}
+
+	$show_on_front = get_option( 'show_on_front', 'posts' );
+	$lines[]       = '- **Homepage displays:** ' . ( 'page' === $show_on_front ? 'static page' : 'latest posts' );
+
+	// Menus subsection — only emitted when at least one menu location is registered.
+	$registered_menus = get_registered_nav_menus();
+	$menu_locations   = get_nav_menu_locations();
+
+	if ( ! empty( $registered_menus ) ) {
+		$lines[] = '';
+		$lines[] = '### Menus';
+		foreach ( $registered_menus as $location => $description ) {
+			$assigned = 'unassigned';
+			if ( ! empty( $menu_locations[ $location ] ) ) {
+				$menu_obj = wp_get_nav_menu_object( $menu_locations[ $location ] );
+				$assigned = $menu_obj ? $menu_obj->name : 'unassigned';
+			}
+			$lines[] = sprintf( '- **%s** (%s): %s', $description, $location, $assigned );
+		}
+	}
+
+	return implode( "\n", $lines );
+}
+
+/**
+ * Post type table.
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_site_section_post_types(): string {
+	$post_types = get_post_types( array( 'public' => true ), 'objects' );
+
+	$lines   = array();
+	$lines[] = '## Post Types';
+	$lines[] = '| Label | Slug | Published | Type |';
+	$lines[] = '|-------|------|-----------|------|';
+
+	foreach ( $post_types as $pt ) {
+		$count     = wp_count_posts( $pt->name );
+		$published = isset( $count->publish ) ? (int) $count->publish : 0;
+		$hier      = $pt->hierarchical ? 'hierarchical' : 'flat';
+		$lines[]   = sprintf( '| %s | %s | %d | %s |', $pt->label, $pt->name, $published, $hier );
+	}
+
+	return implode( "\n", $lines );
+}
+
+/**
+ * Taxonomy table.
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_site_section_taxonomies(): string {
+	$taxonomies = get_taxonomies( array( 'public' => true ), 'objects' );
+
+	$lines   = array();
+	$lines[] = '## Taxonomies';
+	$lines[] = '| Label | Slug | Terms | Type | Post Types |';
+	$lines[] = '|-------|------|-------|------|------------|';
+
+	foreach ( $taxonomies as $tax ) {
+		$term_count = wp_count_terms( array(
+			'taxonomy'   => $tax->name,
+			'hide_empty' => false,
+		) );
+		if ( is_wp_error( $term_count ) ) {
+			$term_count = 0;
+		}
+		$hier       = $tax->hierarchical ? 'hierarchical' : 'flat';
+		$associated = implode( ', ', $tax->object_type ?? array() );
+		$lines[]    = sprintf( '| %s | %s | %d | %s | %s |', $tax->label, $tax->name, (int) $term_count, $hier, $associated );
+	}
+
+	return implode( "\n", $lines );
+}
+
+/**
+ * User roles list. Returns empty string when no custom roles exist
+ * (matches legacy behavior — the section was conditional on custom roles).
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_site_section_user_roles(): string {
+	$wp_roles      = wp_roles();
+	$role_names    = $wp_roles->get_names();
+	$default_roles = array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' );
+	$custom_roles  = array_diff( array_keys( $role_names ), $default_roles );
+
+	if ( empty( $custom_roles ) ) {
+		return '';
+	}
+
+	$lines   = array();
+	$lines[] = '## User Roles';
+
+	foreach ( $role_names as $slug => $name ) {
+		$is_custom = in_array( $slug, $custom_roles, true ) ? ' (custom)' : '';
+		$lines[]   = sprintf( '- %s (`%s`)%s', translate_user_role( $name ), $slug, $is_custom );
+	}
+
+	return implode( "\n", $lines );
+}
+
+/**
+ * Active plugins (excluding Data Machine itself), with descriptions.
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_site_section_plugins(): string {
+	$active_plugins = (array) get_option( 'active_plugins', array() );
 
 	if ( is_multisite() ) {
 		$network_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
 		$active_plugins  = array_unique( array_merge( $active_plugins, $network_plugins ) );
 	}
 
-	$plugin_entries = array();
+	$entries = array();
 	foreach ( $active_plugins as $plugin_file ) {
 		$plugin_path = WP_PLUGIN_DIR . '/' . $plugin_file;
 		if ( function_exists( 'get_plugin_data' ) && file_exists( $plugin_path ) ) {
@@ -54,357 +355,185 @@ function datamachine_get_site_scaffold_content(): string {
 			$plugin_desc = '';
 		}
 
+		// Skip Data Machine's own plugin entry — it's always active and adds noise.
 		if ( 'data-machine' === strtolower( (string) $plugin_name ) || 0 === strpos( $plugin_file, 'data-machine/' ) ) {
 			continue;
 		}
 
-		$plugin_entries[] = array(
+		$entries[] = array(
 			'name' => $plugin_name,
 			'desc' => $plugin_desc,
 		);
 	}
 
-	// --- Post types with counts ---
-	$post_types      = get_post_types( array( 'public' => true ), 'objects' );
-	$post_type_lines = array();
-	foreach ( $post_types as $pt ) {
-		$count             = wp_count_posts( $pt->name );
-		$published         = isset( $count->publish ) ? (int) $count->publish : 0;
-		$hier              = $pt->hierarchical ? 'hierarchical' : 'flat';
-		$post_type_lines[] = sprintf( '| %s | %s | %d | %s |', $pt->label, $pt->name, $published, $hier );
-	}
-
-	// --- Taxonomies with term counts ---
-	$taxonomies     = get_taxonomies( array( 'public' => true ), 'objects' );
-	$taxonomy_lines = array();
-	foreach ( $taxonomies as $tax ) {
-		$term_count = wp_count_terms( array(
-			'taxonomy'   => $tax->name,
-			'hide_empty' => false,
-		) );
-		if ( is_wp_error( $term_count ) ) {
-			$term_count = 0;
-		}
-		$hier             = $tax->hierarchical ? 'hierarchical' : 'flat';
-		$associated       = implode( ', ', $tax->object_type ?? array() );
-		$taxonomy_lines[] = sprintf( '| %s | %s | %d | %s | %s |', $tax->label, $tax->name, (int) $term_count, $hier, $associated );
-	}
-
-	// --- Key pages ---
-	$key_pages = array();
-
-	$front_page_id = (int) get_option( 'page_on_front', 0 );
-	if ( $front_page_id > 0 ) {
-		$key_pages[] = sprintf( '- **Front page:** %s (ID %d)', get_the_title( $front_page_id ), $front_page_id );
-	}
-
-	$blog_page_id = (int) get_option( 'page_for_posts', 0 );
-	if ( $blog_page_id > 0 ) {
-		$key_pages[] = sprintf( '- **Blog page:** %s (ID %d)', get_the_title( $blog_page_id ), $blog_page_id );
-	}
-
-	$privacy_page_id = (int) get_option( 'wp_page_for_privacy_policy', 0 );
-	if ( $privacy_page_id > 0 ) {
-		$key_pages[] = sprintf( '- **Privacy page:** %s (ID %d)', get_the_title( $privacy_page_id ), $privacy_page_id );
-	}
-
-	$show_on_front = get_option( 'show_on_front', 'posts' );
-	$key_pages[]   = '- **Homepage displays:** ' . ( 'page' === $show_on_front ? 'static page' : 'latest posts' );
-
-	// --- Menus ---
-	$registered_menus = get_registered_nav_menus();
-	$menu_locations   = get_nav_menu_locations();
-	$menu_lines       = array();
-
-	foreach ( $registered_menus as $location => $description ) {
-		$assigned = 'unassigned';
-		if ( ! empty( $menu_locations[ $location ] ) ) {
-			$menu_obj = wp_get_nav_menu_object( $menu_locations[ $location ] );
-			$assigned = $menu_obj ? $menu_obj->name : 'unassigned';
-		}
-		$menu_lines[] = sprintf( '- **%s** (%s): %s', $description, $location, $assigned );
-	}
-
-	// --- User roles ---
-	$wp_roles      = wp_roles();
-	$role_names    = $wp_roles->get_names();
-	$default_roles = array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' );
-	$custom_roles  = array_diff( array_keys( $role_names ), $default_roles );
-	$role_lines    = array();
-
-	foreach ( $role_names as $slug => $name ) {
-		$user_count   = count( get_users( array(
-			'role'   => $slug,
-			'fields' => 'ID',
-			'number' => 1,
-		) ) );
-		$is_custom    = in_array( $slug, $custom_roles, true ) ? ' (custom)' : '';
-		$role_lines[] = sprintf( '- %s (`%s`)%s', translate_user_role( $name ), $slug, $is_custom );
-	}
-
-	// --- REST API namespaces (custom only) ---
-	$rest_namespaces  = array();
-	$builtin_prefixes = array( 'wp/', 'oembed/', 'wp-site-health/' );
-
-	if ( function_exists( 'rest_get_server' ) && did_action( 'rest_api_init' ) ) {
-		$routes = rest_get_server()->get_namespaces();
-		foreach ( $routes as $namespace ) {
-			$is_builtin = false;
-			foreach ( $builtin_prefixes as $prefix ) {
-				if ( 0 === strpos( $namespace . '/', $prefix ) || 'wp' === $namespace ) {
-					$is_builtin = true;
-					break;
-				}
-			}
-			if ( ! $is_builtin ) {
-				$rest_namespaces[] = $namespace;
-			}
-		}
-	}
-
-	// --- Build SITE.md ---
 	$lines   = array();
-	$lines[] = '# SITE';
-	$lines[] = '';
-	$lines[] = '## Identity';
-	$lines[] = '- **name:** ' . $site_name;
-	if ( ! empty( $site_description ) ) {
-		$lines[] = '- **description:** ' . $site_description;
-	}
-	$lines[] = '- **url:** ' . $site_url;
-	$lines[] = '- **theme:** ' . $theme_name;
-	$lines[] = '- **language:** ' . $language;
-	$lines[] = '- **timezone:** ' . $timezone;
-	if ( ! empty( $permalink ) ) {
-		$lines[] = '- **permalinks:** ' . $permalink;
-	}
-	$lines[] = '- **multisite:** ' . ( is_multisite() ? 'true' : 'false' );
-	$lines[] = '';
-
-	// --- Site Structure ---
-	$lines[] = '## Site Structure';
-
-	foreach ( $key_pages as $page_line ) {
-		$lines[] = $page_line;
-	}
-	$lines[] = '';
-
-	if ( ! empty( $menu_lines ) ) {
-		$lines[] = '### Menus';
-		foreach ( $menu_lines as $menu_line ) {
-			$lines[] = $menu_line;
-		}
-		$lines[] = '';
-	}
-
-	// --- Content Model ---
-	$lines[] = '## Post Types';
-	$lines[] = '| Label | Slug | Published | Type |';
-	$lines[] = '|-------|------|-----------|------|';
-	foreach ( $post_type_lines as $line ) {
-		$lines[] = $line;
-	}
-	$lines[] = '';
-
-	$lines[] = '## Taxonomies';
-	$lines[] = '| Label | Slug | Terms | Type | Post Types |';
-	$lines[] = '|-------|------|-------|------|------------|';
-	foreach ( $taxonomy_lines as $line ) {
-		$lines[] = $line;
-	}
-	$lines[] = '';
-
-	// --- User Roles ---
-	if ( ! empty( $custom_roles ) ) {
-		$lines[] = '## User Roles';
-		foreach ( $role_lines as $role_line ) {
-			$lines[] = $role_line;
-		}
-		$lines[] = '';
-	}
-
-	// --- Active Plugins with descriptions ---
 	$lines[] = '## Active Plugins';
-	if ( ! empty( $plugin_entries ) ) {
-		foreach ( $plugin_entries as $entry ) {
-			$desc_suffix = '';
-			if ( ! empty( $entry['desc'] ) ) {
-				// Truncate long descriptions to keep SITE.md scannable.
-				$desc = wp_strip_all_tags( $entry['desc'] );
-				if ( strlen( $desc ) > 120 ) {
-					$desc = substr( $desc, 0, 117 ) . '...';
-				}
-				$desc_suffix = ' — ' . $desc;
-			}
-			$lines[] = '- **' . $entry['name'] . '**' . $desc_suffix;
-		}
-	} else {
+
+	if ( empty( $entries ) ) {
 		$lines[] = '- (none)';
+		return implode( "\n", $lines );
 	}
 
-	// --- Must-Use Plugins ---
-	if ( function_exists( 'get_mu_plugins' ) ) {
-		$mu_plugins = get_mu_plugins();
-		if ( ! empty( $mu_plugins ) ) {
-			$lines[] = '';
-			$lines[] = '## Must-Use Plugins';
-			foreach ( $mu_plugins as $mu_file => $mu_data ) {
-				$mu_name = ! empty( $mu_data['Name'] ) ? $mu_data['Name'] : basename( $mu_file, '.php' );
-
-				if ( 'data-machine' === strtolower( $mu_name ) ) {
-					continue;
-				}
-
-				$mu_desc_suffix = '';
-				if ( ! empty( $mu_data['Description'] ) ) {
-					$mu_desc = wp_strip_all_tags( $mu_data['Description'] );
-					if ( strlen( $mu_desc ) > 120 ) {
-						$mu_desc = substr( $mu_desc, 0, 117 ) . '...';
-					}
-					$mu_desc_suffix = ' — ' . $mu_desc;
-				}
-				$lines[] = '- **' . $mu_name . '**' . $mu_desc_suffix;
+	foreach ( $entries as $entry ) {
+		$desc_suffix = '';
+		if ( ! empty( $entry['desc'] ) ) {
+			$desc = wp_strip_all_tags( $entry['desc'] );
+			if ( strlen( $desc ) > 120 ) {
+				$desc = substr( $desc, 0, 117 ) . '...';
 			}
+			$desc_suffix = ' — ' . $desc;
+		}
+		$lines[] = '- **' . $entry['name'] . '**' . $desc_suffix;
+	}
+
+	return implode( "\n", $lines );
+}
+
+/**
+ * Must-Use plugins. Returns empty string when none are present.
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_site_section_mu_plugins(): string {
+	if ( ! function_exists( 'get_mu_plugins' ) ) {
+		return '';
+	}
+
+	$mu_plugins = get_mu_plugins();
+	if ( empty( $mu_plugins ) ) {
+		return '';
+	}
+
+	$lines   = array();
+	$lines[] = '## Must-Use Plugins';
+
+	$emitted = false;
+	foreach ( $mu_plugins as $mu_file => $mu_data ) {
+		$mu_name = ! empty( $mu_data['Name'] ) ? $mu_data['Name'] : basename( $mu_file, '.php' );
+
+		if ( 'data-machine' === strtolower( $mu_name ) ) {
+			continue;
+		}
+
+		$mu_desc_suffix = '';
+		if ( ! empty( $mu_data['Description'] ) ) {
+			$mu_desc = wp_strip_all_tags( $mu_data['Description'] );
+			if ( strlen( $mu_desc ) > 120 ) {
+				$mu_desc = substr( $mu_desc, 0, 117 ) . '...';
+			}
+			$mu_desc_suffix = ' — ' . $mu_desc;
+		}
+		$lines[] = '- **' . $mu_name . '**' . $mu_desc_suffix;
+		$emitted = true;
+	}
+
+	if ( ! $emitted ) {
+		return '';
+	}
+
+	return implode( "\n", $lines );
+}
+
+/**
+ * Drop-ins (advanced-cache.php, object-cache.php, etc.).
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_site_section_dropins(): string {
+	if ( ! function_exists( 'get_dropins' ) ) {
+		return '';
+	}
+
+	$dropins = get_dropins();
+	if ( empty( $dropins ) ) {
+		return '';
+	}
+
+	$lines   = array();
+	$lines[] = '## Drop-ins';
+
+	foreach ( $dropins as $dropin_file => $dropin_data ) {
+		$dropin_name = ! empty( $dropin_data['Name'] ) ? $dropin_data['Name'] : $dropin_file;
+
+		$dropin_desc_suffix = '';
+		if ( ! empty( $dropin_data['Description'] ) ) {
+			$dropin_desc = wp_strip_all_tags( $dropin_data['Description'] );
+			if ( strlen( $dropin_desc ) > 120 ) {
+				$dropin_desc = substr( $dropin_desc, 0, 117 ) . '...';
+			}
+			$dropin_desc_suffix = ' — ' . $dropin_desc;
+		}
+		$lines[] = '- **' . $dropin_name . '** (`' . $dropin_file . '`)' . $dropin_desc_suffix;
+	}
+
+	return implode( "\n", $lines );
+}
+
+/**
+ * Custom REST API namespaces. Excludes core WP namespaces.
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_site_section_rest_api(): string {
+	if ( ! function_exists( 'rest_get_server' ) || ! did_action( 'rest_api_init' ) ) {
+		return '';
+	}
+
+	$builtin_prefixes = array( 'wp/', 'oembed/', 'wp-site-health/' );
+	$rest_namespaces  = array();
+
+	foreach ( rest_get_server()->get_namespaces() as $namespace ) {
+		$is_builtin = false;
+		foreach ( $builtin_prefixes as $prefix ) {
+			if ( 0 === strpos( $namespace . '/', $prefix ) || 'wp' === $namespace ) {
+				$is_builtin = true;
+				break;
+			}
+		}
+		if ( ! $is_builtin ) {
+			$rest_namespaces[] = $namespace;
 		}
 	}
 
-	// --- Drop-ins ---
-	if ( function_exists( 'get_dropins' ) ) {
-		$dropins = get_dropins();
-		if ( ! empty( $dropins ) ) {
-			$lines[] = '';
-			$lines[] = '## Drop-ins';
-			foreach ( $dropins as $dropin_file => $dropin_data ) {
-				$dropin_name = ! empty( $dropin_data['Name'] ) ? $dropin_data['Name'] : $dropin_file;
-
-				$dropin_desc_suffix = '';
-				if ( ! empty( $dropin_data['Description'] ) ) {
-					$dropin_desc = wp_strip_all_tags( $dropin_data['Description'] );
-					if ( strlen( $dropin_desc ) > 120 ) {
-						$dropin_desc = substr( $dropin_desc, 0, 117 ) . '...';
-					}
-					$dropin_desc_suffix = ' — ' . $dropin_desc;
-				}
-				$lines[] = '- **' . $dropin_name . '** (`' . $dropin_file . '`)' . $dropin_desc_suffix;
-			}
-		}
+	if ( empty( $rest_namespaces ) ) {
+		return '';
 	}
 
-	// --- REST API namespaces ---
-	if ( ! empty( $rest_namespaces ) ) {
-		$lines[] = '';
-		$lines[] = '## REST API';
-		$lines[] = '- **Custom namespaces:** ' . implode( ', ', $rest_namespaces );
+	$lines   = array();
+	$lines[] = '## REST API';
+	$lines[] = '- **Custom namespaces:** ' . implode( ', ', $rest_namespaces );
+
+	return implode( "\n", $lines );
+}
+
+// -----------------------------------------------------------------------------
+// NETWORK.md sections (multisite only — every callback short-circuits otherwise).
+// -----------------------------------------------------------------------------
+
+/**
+ * Heading for NETWORK.md. Empty on single-site installs so the entire
+ * file collapses to nothing and ComposableFileGenerator skips the write.
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_network_section_header(): string {
+	if ( ! is_multisite() ) {
+		return '';
 	}
-
-	$content = implode( "\n", $lines ) . "\n";
-
-	/**
-	 * Filter the auto-generated SITE.md content.
-	 *
-	 * Allows plugins and themes to append or modify the site context
-	 * that is injected into AI agent calls. SITE.md is read-only in the
-	 * admin UI; this filter is the only extension point.
-	 *
-	 * @since 0.50.0
-	 *
-	 * @param string $content The generated SITE.md markdown content.
-	 */
-	return apply_filters( 'datamachine_site_scaffold_content', $content );
+	return '# Network';
 }
 
 /**
- * Regenerate SITE.md on disk from current WordPress state.
+ * Network identity: name, primary site, count.
  *
- * Called by invalidation hooks when site structure changes (plugins,
- * themes, post types, taxonomies, options). Debounced via a short-lived
- * transient to avoid excessive writes during bulk operations.
- *
- * SITE.md is read-only — it is fully regenerated from live WordPress data.
- * To extend SITE.md content, use the `datamachine_site_scaffold_content` filter.
- *
- * @since 0.48.0
- * @since 0.50.0 Removed <!-- CUSTOM --> marker; SITE.md is now read-only.
- * @return void
+ * @since x.y.z
+ * @return string
  */
-function datamachine_regenerate_site_md(): void {
-	// Debounce: skip if we regenerated in the last 60 seconds.
-	if ( get_transient( 'datamachine_site_md_regenerating' ) ) {
-		return;
-	}
-	set_transient( 'datamachine_site_md_regenerating', 1, 60 );
-
-	// Check the setting — if disabled, skip regeneration.
-	if ( ! \DataMachine\Core\PluginSettings::get( 'site_context_enabled', true ) ) {
-		return;
-	}
-
-	$directory_manager = new \DataMachine\Core\FilesRepository\DirectoryManager();
-	$shared_dir        = $directory_manager->get_shared_directory();
-	$site_md_path      = trailingslashit( $shared_dir ) . 'SITE.md';
-
-	$fs = \DataMachine\Core\FilesRepository\FilesystemHelper::get();
-	if ( ! $fs ) {
-		return;
-	}
-
-	$content = datamachine_get_site_scaffold_content();
-
-	if ( ! is_dir( $shared_dir ) ) {
-		wp_mkdir_p( $shared_dir );
-	}
-
-	$fs->put_contents( $site_md_path, $content, FS_CHMOD_FILE );
-	\DataMachine\Core\FilesRepository\FilesystemHelper::make_group_writable( $site_md_path );
-}
-
-/**
- * Register hooks that trigger SITE.md regeneration on structural changes.
- *
- * Only hooks into events that change the actual structure of the site:
- * plugin/theme changes, site identity options, and menu changes.
- * Post and term lifecycle hooks were intentionally removed — stale
- * published counts and term counts are not meaningful to AI agents,
- * and those hooks (especially save_post) fire far too frequently.
- *
- * @since 0.48.0
- * @return void
- */
-function datamachine_register_site_md_invalidation(): void {
-	$callback = 'datamachine_regenerate_site_md';
-
-	// Plugin/theme structural changes — always regenerate.
-	add_action( 'switch_theme', $callback );
-	add_action( 'activated_plugin', $callback );
-	add_action( 'deactivated_plugin', $callback );
-
-	// Site identity and structure changes.
-	add_action( 'update_option_blogname', $callback );
-	add_action( 'update_option_blogdescription', $callback );
-	add_action( 'update_option_home', $callback );
-	add_action( 'update_option_siteurl', $callback );
-	add_action( 'update_option_permalink_structure', $callback );
-	add_action( 'update_option_page_on_front', $callback );
-	add_action( 'update_option_page_for_posts', $callback );
-	add_action( 'update_option_show_on_front', $callback );
-
-	// Menu changes.
-	add_action( 'wp_update_nav_menu', $callback );
-	add_action( 'wp_delete_nav_menu', $callback );
-	add_action( 'wp_update_nav_menu_item', $callback );
-}
-
-/**
- * Build NETWORK.md scaffold content from WordPress multisite data.
- *
- * Generates a markdown summary of the multisite network topology
- * including all sites, network-activated plugins, and shared resources.
- * Returns empty string on single-site installs.
- *
- * @since 0.48.0
- * @return string NETWORK.md content, or empty string if not multisite.
- */
-function datamachine_get_network_scaffold_content(): string {
+function datamachine_network_section_identity(): string {
 	if ( ! is_multisite() ) {
 		return '';
 	}
@@ -414,12 +543,36 @@ function datamachine_get_network_scaffold_content(): string {
 	$main_site_id = get_main_site_id();
 	$main_site    = get_site( $main_site_id );
 	$main_url     = $main_site ? $main_site->domain . $main_site->path : home_url();
+	$site_count   = get_blog_count();
 
-	// --- Sites ---
-	$sites      = get_sites( array( 'number' => 100 ) );
-	$site_count = get_blog_count();
+	$lines   = array();
+	$lines[] = '## Identity';
+	$lines[] = '- **network_name:** ' . $network_name;
+	$lines[] = '- **primary_site:** ' . $main_url;
+	$lines[] = '- **sites_count:** ' . $site_count;
 
-	$site_lines = array();
+	return implode( "\n", $lines );
+}
+
+/**
+ * Sites table.
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_network_section_sites(): string {
+	if ( ! is_multisite() ) {
+		return '';
+	}
+
+	$sites        = get_sites( array( 'number' => 100 ) );
+	$main_site_id = get_main_site_id();
+
+	$lines   = array();
+	$lines[] = '## Sites';
+	$lines[] = '| Site | URL | Theme |';
+	$lines[] = '|------|-----|-------|';
+
 	foreach ( $sites as $site ) {
 		$blog_id = (int) $site->blog_id;
 
@@ -429,11 +582,24 @@ function datamachine_get_network_scaffold_content(): string {
 		$theme = wp_get_theme()->get( 'Name' ) ? wp_get_theme()->get( 'Name' ) : 'Unknown';
 		restore_current_blog();
 
-		$is_main      = ( $blog_id === $main_site_id ) ? ' (main)' : '';
-		$site_lines[] = sprintf( '| %s%s | %s | %s |', $name, $is_main, $url, $theme );
+		$is_main = ( $blog_id === $main_site_id ) ? ' (main)' : '';
+		$lines[] = sprintf( '| %s%s | %s | %s |', $name, $is_main, $url, $theme );
 	}
 
-	// --- Network-activated plugins ---
+	return implode( "\n", $lines );
+}
+
+/**
+ * Network-activated plugins (excluding Data Machine itself).
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_network_section_plugins(): string {
+	if ( ! is_multisite() ) {
+		return '';
+	}
+
 	$network_plugins = get_site_option( 'active_sitewide_plugins', array() );
 	$plugin_names    = array();
 
@@ -452,138 +618,111 @@ function datamachine_get_network_scaffold_content(): string {
 		}
 	}
 
-	// --- Build content ---
 	$lines   = array();
-	$lines[] = '# Network';
-	$lines[] = '';
-	$lines[] = '## Identity';
-	$lines[] = '- **network_name:** ' . $network_name;
-	$lines[] = '- **primary_site:** ' . $main_url;
-	$lines[] = '- **sites_count:** ' . $site_count;
-	$lines[] = '';
-	$lines[] = '## Sites';
-	$lines[] = '| Site | URL | Theme |';
-	$lines[] = '|------|-----|-------|';
-
-	foreach ( $site_lines as $line ) {
-		$lines[] = $line;
-	}
-
-	$lines[] = '';
 	$lines[] = '## Network Plugins';
-	if ( ! empty( $plugin_names ) ) {
+
+	if ( empty( $plugin_names ) ) {
+		$lines[] = '- (none)';
+	} else {
 		foreach ( $plugin_names as $name ) {
 			$lines[] = '- ' . $name;
 		}
-	} else {
-		$lines[] = '- (none)';
 	}
 
-	$lines[] = '';
+	return implode( "\n", $lines );
+}
+
+/**
+ * Shared resources block. Currently a static descriptor of how users and
+ * media are scoped on the network.
+ *
+ * @since x.y.z
+ * @return string
+ */
+function datamachine_network_section_shared_resources(): string {
+	if ( ! is_multisite() ) {
+		return '';
+	}
+
+	$lines   = array();
 	$lines[] = '## Shared Resources';
 	$lines[] = '- **Users:** network-wide (see USER.md)';
 	$lines[] = '- **Media:** per-site uploads';
 
-	$content = implode( "\n", $lines ) . "\n";
+	return implode( "\n", $lines );
+}
 
-	/**
-	 * Filter the auto-generated NETWORK.md content.
-	 *
-	 * Allows plugins and themes to append or modify the network context
-	 * that is injected into AI agent calls. NETWORK.md is read-only in the
-	 * admin UI; this filter is the only extension point.
-	 *
-	 * @since 0.50.0
-	 *
-	 * @param string $content The generated NETWORK.md markdown content.
-	 */
-	return apply_filters( 'datamachine_network_scaffold_content', $content );
+// -----------------------------------------------------------------------------
+// Backwards-compat shims for callers that still build SITE.md / NETWORK.md
+// content directly (activation, layered-architecture migration, network-scope
+// migration). These delegate to ComposableFileGenerator and remain available
+// so external callers don't break across the migration.
+// -----------------------------------------------------------------------------
+
+/**
+ * Build SITE.md content via the SectionRegistry.
+ *
+ * Preserved for backwards compatibility with any external callers that
+ * imported the legacy function. Internal callers should use
+ * `\DataMachine\Engine\AI\SectionRegistry::generate( 'SITE.md' )` directly.
+ *
+ * @since 0.36.1
+ * @since x.y.z Delegates to SectionRegistry. The whole-string filter
+ *              `datamachine_site_scaffold_content` is now applied via the
+ *              `datamachine_composable_content` shim and emits a deprecation
+ *              notice when used.
+ * @return string
+ */
+function datamachine_get_site_scaffold_content(): string {
+	$content = SectionRegistry::generate( 'SITE.md' );
+	return '' === $content ? '' : $content . "\n";
 }
 
 /**
- * Regenerate NETWORK.md from live WordPress multisite data.
+ * Build NETWORK.md content via the SectionRegistry.
  *
- * Same pattern as datamachine_regenerate_site_md():
- * - 60-second debounce via transient
- * - Respects site_context_enabled setting
- * - Only runs on multisite installs
+ * Preserved for backwards compatibility. Returns an empty string on
+ * single-site installs (every NETWORK.md section short-circuits there).
  *
- * NETWORK.md is read-only — fully regenerated from live multisite data.
- * To extend NETWORK.md content, use the `datamachine_network_scaffold_content` filter.
+ * @since 0.48.0
+ * @since x.y.z Delegates to SectionRegistry.
+ * @return string
+ */
+function datamachine_get_network_scaffold_content(): string {
+	if ( ! is_multisite() ) {
+		return '';
+	}
+	$content = SectionRegistry::generate( 'NETWORK.md' );
+	return '' === $content ? '' : $content . "\n";
+}
+
+/**
+ * Regenerate SITE.md on disk.
+ *
+ * @since 0.48.0
+ * @since x.y.z Delegates to ComposableFileGenerator.
+ * @return void
+ */
+function datamachine_regenerate_site_md(): void {
+	if ( ! \DataMachine\Core\PluginSettings::get( 'site_context_enabled', true ) ) {
+		return;
+	}
+	\DataMachine\Engine\AI\ComposableFileGenerator::regenerate( 'SITE.md' );
+}
+
+/**
+ * Regenerate NETWORK.md on disk.
  *
  * @since 0.49.1
- * @since 0.50.0 Removed <!-- CUSTOM --> marker; NETWORK.md is now read-only.
+ * @since x.y.z Delegates to ComposableFileGenerator.
  * @return void
  */
 function datamachine_regenerate_network_md(): void {
 	if ( ! is_multisite() ) {
 		return;
 	}
-
-	// Debounce: skip if we regenerated in the last 60 seconds.
-	// Use a network-wide transient so subsites don't each trigger a write.
-	if ( get_site_transient( 'datamachine_network_md_regenerating' ) ) {
-		return;
-	}
-	set_site_transient( 'datamachine_network_md_regenerating', 1, 60 );
-
-	// Check the setting — if disabled, skip regeneration.
 	if ( ! \DataMachine\Core\PluginSettings::get( 'site_context_enabled', true ) ) {
 		return;
 	}
-
-	$directory_manager = new \DataMachine\Core\FilesRepository\DirectoryManager();
-	$network_dir       = $directory_manager->get_network_directory();
-	$network_md_path   = trailingslashit( $network_dir ) . 'NETWORK.md';
-
-	$fs = \DataMachine\Core\FilesRepository\FilesystemHelper::get();
-	if ( ! $fs ) {
-		return;
-	}
-
-	$content = datamachine_get_network_scaffold_content();
-
-	if ( empty( $content ) ) {
-		return;
-	}
-
-	if ( ! is_dir( $network_dir ) ) {
-		wp_mkdir_p( $network_dir );
-	}
-
-	$fs->put_contents( $network_md_path, $content, FS_CHMOD_FILE );
-	\DataMachine\Core\FilesRepository\FilesystemHelper::make_group_writable( $network_md_path );
-}
-
-/**
- * Register hooks that trigger NETWORK.md regeneration on structural changes.
- *
- * Only registers on multisite installs. Covers site lifecycle, URL changes,
- * network plugin activations, and theme switches. The debounce in
- * datamachine_regenerate_network_md() prevents excessive writes.
- *
- * @since 0.49.1
- * @return void
- */
-function datamachine_register_network_md_invalidation(): void {
-	if ( ! is_multisite() ) {
-		return;
-	}
-
-	$callback = 'datamachine_regenerate_network_md';
-
-	// Site lifecycle — new sites, deleted sites.
-	add_action( 'wp_initialize_site', $callback );
-	add_action( 'wp_delete_site', $callback );
-	add_action( 'wp_uninitialize_site', $callback );
-
-	// Site identity changes — URL or name changes on any site.
-	add_action( 'update_option_siteurl', $callback );
-	add_action( 'update_option_home', $callback );
-	add_action( 'update_option_blogname', $callback );
-
-	// Plugin/theme structural changes — affects network plugin list.
-	add_action( 'activated_plugin', $callback );
-	add_action( 'deactivated_plugin', $callback );
-	add_action( 'switch_theme', $callback );
+	\DataMachine\Engine\AI\ComposableFileGenerator::regenerate( 'NETWORK.md' );
 }

--- a/inc/migrations/site-md.php
+++ b/inc/migrations/site-md.php
@@ -41,22 +41,22 @@ use DataMachine\Engine\AI\SectionRegistry;
  */
 function datamachine_register_core_sections(): void {
 	// SITE.md sections — assembled into shared/SITE.md.
-	SectionRegistry::register( 'SITE.md', 'header',       0,  'datamachine_site_section_header' );
-	SectionRegistry::register( 'SITE.md', 'identity',     10, 'datamachine_site_section_identity' );
-	SectionRegistry::register( 'SITE.md', 'structure',    20, 'datamachine_site_section_structure' );
-	SectionRegistry::register( 'SITE.md', 'post-types',   30, 'datamachine_site_section_post_types' );
-	SectionRegistry::register( 'SITE.md', 'taxonomies',   40, 'datamachine_site_section_taxonomies' );
-	SectionRegistry::register( 'SITE.md', 'user-roles',   50, 'datamachine_site_section_user_roles' );
-	SectionRegistry::register( 'SITE.md', 'plugins',      60, 'datamachine_site_section_plugins' );
-	SectionRegistry::register( 'SITE.md', 'mu-plugins',   65, 'datamachine_site_section_mu_plugins' );
-	SectionRegistry::register( 'SITE.md', 'dropins',      70, 'datamachine_site_section_dropins' );
-	SectionRegistry::register( 'SITE.md', 'rest-api',     80, 'datamachine_site_section_rest_api' );
+	SectionRegistry::register( 'SITE.md', 'header', 0, 'datamachine_site_section_header' );
+	SectionRegistry::register( 'SITE.md', 'identity', 10, 'datamachine_site_section_identity' );
+	SectionRegistry::register( 'SITE.md', 'structure', 20, 'datamachine_site_section_structure' );
+	SectionRegistry::register( 'SITE.md', 'post-types', 30, 'datamachine_site_section_post_types' );
+	SectionRegistry::register( 'SITE.md', 'taxonomies', 40, 'datamachine_site_section_taxonomies' );
+	SectionRegistry::register( 'SITE.md', 'user-roles', 50, 'datamachine_site_section_user_roles' );
+	SectionRegistry::register( 'SITE.md', 'plugins', 60, 'datamachine_site_section_plugins' );
+	SectionRegistry::register( 'SITE.md', 'mu-plugins', 65, 'datamachine_site_section_mu_plugins' );
+	SectionRegistry::register( 'SITE.md', 'dropins', 70, 'datamachine_site_section_dropins' );
+	SectionRegistry::register( 'SITE.md', 'rest-api', 80, 'datamachine_site_section_rest_api' );
 
 	// NETWORK.md sections — only meaningful on multisite (callbacks self-guard).
-	SectionRegistry::register( 'NETWORK.md', 'header',          0,  'datamachine_network_section_header' );
-	SectionRegistry::register( 'NETWORK.md', 'identity',        10, 'datamachine_network_section_identity' );
-	SectionRegistry::register( 'NETWORK.md', 'sites',           20, 'datamachine_network_section_sites' );
-	SectionRegistry::register( 'NETWORK.md', 'plugins',         30, 'datamachine_network_section_plugins' );
+	SectionRegistry::register( 'NETWORK.md', 'header', 0, 'datamachine_network_section_header' );
+	SectionRegistry::register( 'NETWORK.md', 'identity', 10, 'datamachine_network_section_identity' );
+	SectionRegistry::register( 'NETWORK.md', 'sites', 20, 'datamachine_network_section_sites' );
+	SectionRegistry::register( 'NETWORK.md', 'plugins', 30, 'datamachine_network_section_plugins' );
 	SectionRegistry::register( 'NETWORK.md', 'shared-resources', 40, 'datamachine_network_section_shared_resources' );
 }
 add_action( 'datamachine_sections', 'datamachine_register_core_sections' );
@@ -253,7 +253,12 @@ function datamachine_site_section_structure(): string {
  * @return string
  */
 function datamachine_site_section_post_types(): string {
+	// The bundled phpstan stub for get_post_types() only declares one param,
+	// but the WP signature is (array $args, string $output, string $operator)
+	// and we need 'objects' to access WP_Post_Type properties below.
+	// @phpstan-ignore-next-line arguments.count
 	$post_types = get_post_types( array( 'public' => true ), 'objects' );
+	/** @var WP_Post_Type[] $post_types */
 
 	$lines   = array();
 	$lines[] = '## Post Types';
@@ -277,6 +282,7 @@ function datamachine_site_section_post_types(): string {
  * @return string
  */
 function datamachine_site_section_taxonomies(): string {
+	/** @var WP_Taxonomy[] $taxonomies */
 	$taxonomies = get_taxonomies( array( 'public' => true ), 'objects' );
 
 	$lines   = array();
@@ -285,16 +291,23 @@ function datamachine_site_section_taxonomies(): string {
 	$lines[] = '|-------|------|-------|------|------------|';
 
 	foreach ( $taxonomies as $tax ) {
-		$term_count = wp_count_terms( array(
+		$term_count_raw = wp_count_terms( array(
 			'taxonomy'   => $tax->name,
 			'hide_empty' => false,
 		) );
-		if ( is_wp_error( $term_count ) ) {
+		// wp_count_terms returns int|numeric-string|WP_Error. Narrow to int
+		// before formatting so phpstan stays happy and output is consistent.
+		if ( is_wp_error( $term_count_raw ) ) {
+			$term_count = 0;
+		} elseif ( is_numeric( $term_count_raw ) ) {
+			$term_count = (int) $term_count_raw;
+		} else {
 			$term_count = 0;
 		}
-		$hier       = $tax->hierarchical ? 'hierarchical' : 'flat';
-		$associated = implode( ', ', $tax->object_type ?? array() );
-		$lines[]    = sprintf( '| %s | %s | %d | %s | %s |', $tax->label, $tax->name, (int) $term_count, $hier, $associated );
+		$hier = $tax->hierarchical ? 'hierarchical' : 'flat';
+		// WP_Taxonomy::$object_type is array<string>, not nullable — use it directly.
+		$associated = implode( ', ', $tax->object_type );
+		$lines[]    = sprintf( '| %s | %s | %d | %s | %s |', $tax->label, $tax->name, $term_count, $hier, $associated );
 	}
 
 	return implode( "\n", $lines );
@@ -344,6 +357,7 @@ function datamachine_site_section_plugins(): string {
 
 	$entries = array();
 	foreach ( $active_plugins as $plugin_file ) {
+		$plugin_file = (string) $plugin_file;
 		$plugin_path = WP_PLUGIN_DIR . '/' . $plugin_file;
 		if ( function_exists( 'get_plugin_data' ) && file_exists( $plugin_path ) ) {
 			$plugin_data = get_plugin_data( $plugin_path, false, false );
@@ -603,7 +617,11 @@ function datamachine_network_section_plugins(): string {
 	$network_plugins = get_site_option( 'active_sitewide_plugins', array() );
 	$plugin_names    = array();
 
-	foreach ( array_keys( $network_plugins ) as $plugin_file ) {
+	foreach ( array_keys( (array) $network_plugins ) as $plugin_file ) {
+		// active_sitewide_plugins is keyed by plugin file path (strings), but
+		// array_keys() returns array<int, int|string>. Cast for strict-typing tools.
+		$plugin_file = (string) $plugin_file;
+
 		if ( 0 === strpos( $plugin_file, 'data-machine/' ) ) {
 			continue;
 		}


### PR DESCRIPTION
Closes #1721.

## Summary

`SITE.md` and `NETWORK.md` were generated by monolithic functions, each with one whole-string filter as the only extension hook. They now use the same `SectionRegistry` + `ComposableFileGenerator` infrastructure as `AGENTS.md` — dogfooding the public extension API instead of running on a parallel legacy track.

> **Architectural principle:** core memory files should dogfood the same extension API they expose to plugins. `AGENTS.md` did. `SITE.md` and `NETWORK.md` didn't. This closes that gap.

## What changed

| File | Before | After |
|------|--------|-------|
| `inc/bootstrap.php` | Registered `SITE.md` / `NETWORK.md` with `editable=false` and bespoke `init`-time invalidation hooks | `composable=true`, regeneration owned by the existing `ComposableFileInvalidation` |
| `inc/migrations/site-md.php` | One ~300-line generator per file + one whole-string filter | 10 SITE.md sections + 5 NETWORK.md sections registered against `datamachine_sections`. Existing invalidation hooks (option updates, menu changes, multisite lifecycle) wire in via `datamachine_composable_invalidation_hooks` |
| `data-machine.php` (activation) | `datamachine_regenerate_site_md()` | `ComposableFileGenerator::regenerate_all()` — also rebuilds AGENTS.md, NETWORK.md, future composable files |
| `inc/migrations/layered-architecture.php`<br>`inc/migrations/network-scope.php` | Direct calls to legacy generator + `put_contents` | Delegated to `ComposableFileGenerator::regenerate()` |

## Backwards compatibility

Soft deprecation, not hard break:

- **Legacy filters** (`datamachine_site_scaffold_content`, `datamachine_network_scaffold_content`) still fire on the assembled output via a `datamachine_composable_content` shim. They emit `_doing_it_wrong` notices when callbacks are attached, so consumers know to migrate.
- **Legacy public functions** (`datamachine_get_site_scaffold_content`, `datamachine_get_network_scaffold_content`, `datamachine_regenerate_site_md`, `datamachine_regenerate_network_md`) preserved as thin shims around `SectionRegistry::generate()` / `ComposableFileGenerator::regenerate()`.

Removal of these shims is a future major.

## How to extend now

Plugins register sections the same way they contribute to `AGENTS.md`:

\`\`\`php
add_action( 'datamachine_sections', function () {
    \DataMachine\Engine\AI\SectionRegistry::register(
        'SITE.md',
        'my-platform',
        35, // priority — slots between post-types (30) and taxonomies (40)
        function () {
            return \"## My Platform\n- Custom context line\";
        }
    );
} );
\`\`\`

If a section's content depends on live state (an option, a custom table, a remote API), the plugin also adds the relevant action hook names via the existing filter:

\`\`\`php
add_filter( 'datamachine_composable_invalidation_hooks', function ( array \$hooks ) {
    \$hooks[] = 'update_option_my_platform_setting';
    return \$hooks;
} );
\`\`\`

`ComposableFileInvalidation` debounces regeneration to one run per 60 seconds.

## Verification

Tested against \`extrachill.com\` (WP 7.0-RC2, multisite, DM 0.103.10) by overlaying the 5 changed files onto the live install and regenerating both files via \`wp datamachine memory compose\`:

\`\`\`
$ diff SITE.md.before SITE.md.after
76d75
< - **AI Client** — An AI client and API for WordPress to communicate with...
\`\`\`

The single-line diff is unrelated drift (the \`wp-ai-client\` plugin was deactivated between snapshots — WP 7.0 ships it natively). All 10 SITE.md sections and all 5 NETWORK.md sections render byte-equivalent to the legacy output: identity blocks, post-type/taxonomy tables, user roles, plugin lists, drop-ins, REST namespaces, network sites/plugins/shared resources.

Also verified:
- New \`SectionRegistry::register('SITE.md', ...)\` from a third-party slots correctly between core sections by priority.
- Legacy \`datamachine_site_scaffold_content\` filter still fires and triggers a deprecation notice.
- Single-site install: every NETWORK.md section returns \`''\`, generator skips the write (existing empty-content guard in \`ComposableFileGenerator\`).

## Diff scope

\`\`\`
data-machine.php                              |   7 +-
docs/core-system/wordpress-as-agent-memory.md |  19 +-
inc/bootstrap.php                             |  27 +-
inc/migrations/layered-architecture.php       |   5 +-
inc/migrations/network-scope.php              |   8 +-
inc/migrations/site-md.php                    | 963 ++++++++++++++++--------
6 files changed, 591 insertions(+), 438 deletions(-)
\`\`\`

\`site-md.php\` is a near-total rewrite (the monolithic generators broken into ~15 small section callbacks). The other four files are surgical.