### PR TITLE
Fix CLI drain in Studio

### DIFF
--- a/inc/Cli/Commands/DrainCommand.php
+++ b/inc/Cli/Commands/DrainCommand.php
@@ -156,6 +156,7 @@ class DrainCommand extends BaseCommand {
 			'action-scheduler action run ' . implode( ' ', array_map( 'intval', $action_ids ) ),
 			array(
 				'exit_error' => false,
+				'launch'     => false,
 				'return'     => 'all',
 			)
 		);

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -43,6 +43,7 @@ assert_drain_contains( "datamachine_execute_step'", $drain_src, 'drain includes 
 assert_drain_contains( 'getDuePendingActionIds', $drain_src, 'drain queries concrete due Data Machine action IDs' );
 assert_drain_contains( 'action-scheduler action run ', $drain_src, 'drain runs concrete action IDs instead of generic queue runner' );
 assert_drain_contains( "'exit_error' => false", $drain_src, 'drain failure is surfaced as warning instead of fataling after job start' );
+assert_drain_contains( "'launch'     => false", $drain_src, 'drain runs nested WP-CLI command in-process for Studio compatibility' );
 assert_drain_contains( "'return'     => 'all'", $drain_src, 'drain captures Action Scheduler command result' );
 assert_drain_contains( "'remaining_pending'", $drain_src, 'drain reports remaining pending actions' );
 assert_drain_contains( "'batch_chunks'", $drain_src, 'drain reports batch chunk counts' );


### PR DESCRIPTION
## Summary
- Fixes `wp datamachine drain` in Studio/local runtimes where WP-CLI child-process launch points at an unavailable PHP binary.
- Keeps the Action Scheduler command execution in-process while preserving warning-based error handling.

## Changes
- Adds `launch => false` to the nested `WP_CLI::runcommand()` call used by the drain command.
- Extends the drain smoke test to assert in-process nested command execution.

## Tests
- `php tests/flow-run-cli-drain-smoke.php`
- `php -l inc/Cli/Commands/DrainCommand.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Studio WP-CLI child-process failure, drafted the minimal patch, and ran targeted smoke/syntax checks. Chris remains responsible for review and merge.