### PR TITLE
Fix wp-ai-client request timeout propagation

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -165,7 +165,18 @@ class RequestBuilder {
 			/** @var callable $model_resolver wp-ai-client exposes this through __call() in some versions. */
 			$model_resolver = array( $registry, 'getProviderModel' );
 			$model_instance = call_user_func( $model_resolver, $provider_id, $model, null );
-			$builder        = \wp_ai_client_prompt()
+			if (
+				is_object( $model_instance )
+				&& method_exists( $model_instance, 'setRequestOptions' )
+				&& class_exists( '\WordPress\AiClient\Providers\Http\DTO\RequestOptions' )
+			) {
+				$request_options = new \WordPress\AiClient\Providers\Http\DTO\RequestOptions();
+				$request_options->setTimeout( $request_timeout );
+				$request_options->setConnectTimeout( min( 30.0, $request_timeout ) );
+				$model_instance->setRequestOptions( $request_options );
+			}
+
+			$builder = \wp_ai_client_prompt()
 				->using_provider( $provider_id )
 				->using_model( $model_instance );
 

--- a/tests/Unit/Support/WpAiClientTestDoubles.php
+++ b/tests/Unit/Support/WpAiClientTestDoubles.php
@@ -209,6 +209,27 @@ namespace DataMachine\Tests\Unit\Support {
 			);
 		}
 	}
+
+	class WpAiClientModelDouble {
+		private string $model;
+		private ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions $request_options = null;
+
+		public function __construct( string $model ) {
+			$this->model = $model;
+		}
+
+		public function setRequestOptions( \WordPress\AiClient\Providers\Http\DTO\RequestOptions $request_options ): void {
+			$this->request_options = $request_options;
+		}
+
+		public function getRequestOptions(): ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions {
+			return $this->request_options;
+		}
+
+		public function __toString(): string {
+			return $this->model;
+		}
+	}
 }
 
 namespace WordPress\AiClient\Files\Enums {
@@ -297,7 +318,12 @@ namespace WordPress\AiClient\Providers {
 			public function setProviderRequestAuthentication( string $provider, $auth ): void {
 			}
 
-			public function getProviderModel( string $provider, string $model, $config = null ): string {
+			public function getProviderModel( string $provider, string $model, $config = null ) {
+				unset( $provider, $config );
+				if ( ! empty( $GLOBALS['datamachine_test_wp_ai_client_model_with_request_options'] ) ) {
+					return new \DataMachine\Tests\Unit\Support\WpAiClientModelDouble( $model );
+				}
+
 				return $model;
 			}
 		}
@@ -305,6 +331,29 @@ namespace WordPress\AiClient\Providers {
 }
 
 namespace WordPress\AiClient\Providers\Http\DTO {
+	if ( ! class_exists( RequestOptions::class ) ) {
+		class RequestOptions {
+			private ?float $timeout = null;
+			private ?float $connect_timeout = null;
+
+			public function setTimeout( ?float $timeout ): void {
+				$this->timeout = $timeout;
+			}
+
+			public function setConnectTimeout( ?float $timeout ): void {
+				$this->connect_timeout = $timeout;
+			}
+
+			public function getTimeout(): ?float {
+				return $this->timeout;
+			}
+
+			public function getConnectTimeout(): ?float {
+				return $this->connect_timeout;
+			}
+		}
+	}
+
 	if ( ! class_exists( ApiKeyRequestAuthentication::class ) ) {
 		class ApiKeyRequestAuthentication {
 			private string $api_key;

--- a/tests/wp-ai-client-request-timeout-smoke.php
+++ b/tests/wp-ai-client-request-timeout-smoke.php
@@ -195,6 +195,7 @@ function timeout_smoke_filter_count( string $tag ): int {
 }
 
 $timeout_context = null;
+$GLOBALS['datamachine_test_wp_ai_client_model_with_request_options'] = true;
 
 add_filter(
 	'datamachine_wp_ai_client_request_timeout',
@@ -230,6 +231,12 @@ assert_timeout_smoke( 300.0 === ( $timeout_context['timeout'] ?? null ), 'Data M
 assert_timeout_smoke( 'pipeline' === ( $timeout_context['mode'] ?? null ), 'Data Machine timeout filter receives execution mode' );
 assert_timeout_smoke( 'openai' === ( $timeout_context['provider'] ?? null ), 'Data Machine timeout filter receives provider' );
 assert_timeout_smoke( 'gpt-smoke' === ( $timeout_context['model'] ?? null ), 'Data Machine timeout filter receives model' );
+
+$captured_model           = TimeoutPromptBuilderDouble::$captured_request['model'] ?? null;
+$captured_request_options = is_object( $captured_model ) && method_exists( $captured_model, 'getRequestOptions' ) ? $captured_model->getRequestOptions() : null;
+assert_timeout_smoke( $captured_request_options instanceof \WordPress\AiClient\Providers\Http\DTO\RequestOptions, 'Data Machine applies wp-ai-client RequestOptions to API-based models' );
+assert_timeout_smoke( 240.0 === $captured_request_options?->getTimeout(), 'Data Machine sets RequestOptions timeout from scoped request timeout' );
+assert_timeout_smoke( 30.0 === $captured_request_options?->getConnectTimeout(), 'Data Machine caps RequestOptions connect timeout at 30 seconds' );
 
 $captured_history = TimeoutPromptBuilderDouble::$captured_request['history'] ?? array();
 assert_timeout_smoke( isset( $captured_history[0] ) && $captured_history[0] instanceof \WordPress\AiClient\Messages\DTO\UserMessage, 'Data Machine converts user history arrays to wp-ai-client UserMessage DTOs' );


### PR DESCRIPTION
## Summary
- Propagates Data Machine's computed wp-ai-client timeout into API-based models via `RequestOptions` when the installed client supports it.
- Keeps the existing WordPress HTTP timeout and cURL low-speed hooks as compatibility fallbacks.
- Extends the wp-ai-client timeout smoke test to prove API-based models receive timeout and connect timeout request options.

Fixes #1724.

## Tests
- `php -l inc/Engine/AI/RequestBuilder.php`
- `php -l tests/wp-ai-client-request-timeout-smoke.php`
- `php -l tests/Unit/Support/WpAiClientTestDoubles.php`
- `php tests/wp-ai-client-request-timeout-smoke.php`
- `php tests/wp-ai-client-runtime-gate-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-wp-ai-client-request-options-timeout`

## Known validation notes
- `php tests/wp-ai-client-tool-schema-smoke.php` currently reports one multimodal assertion failure unrelated to this change.
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-wp-ai-client-request-options-timeout` still reports existing repository-wide PHPStan findings; rerunning after the local style fix showed no findings in the changed files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused RequestBuilder timeout propagation change, updated smoke-test doubles and coverage, and ran local validation; Chris remains responsible for review and merge.