### PR TITLE
fix: reconcile terminal-backed stale actions

### DIFF
--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -54,15 +54,16 @@ class RecoverStuckJobsAbility {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'   => array( 'type' => 'boolean' ),
-							'recovered' => array( 'type' => 'integer' ),
-							'skipped'   => array( 'type' => 'integer' ),
-							'timed_out' => array( 'type' => 'integer' ),
-							'requeued'  => array( 'type' => 'integer' ),
-							'dry_run'   => array( 'type' => 'boolean' ),
-							'jobs'      => array( 'type' => 'array' ),
-							'message'   => array( 'type' => 'string' ),
-							'error'     => array( 'type' => 'string' ),
+							'success'       => array( 'type' => 'boolean' ),
+							'recovered'     => array( 'type' => 'integer' ),
+							'skipped'       => array( 'type' => 'integer' ),
+							'timed_out'     => array( 'type' => 'integer' ),
+							'stale_actions' => array( 'type' => 'integer' ),
+							'requeued'      => array( 'type' => 'integer' ),
+							'dry_run'       => array( 'type' => 'boolean' ),
+							'jobs'          => array( 'type' => 'array' ),
+							'message'       => array( 'type' => 'string' ),
+							'error'         => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),
@@ -196,8 +197,9 @@ class RecoverStuckJobsAbility {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-		$timed_out = 0;
-		$requeued  = 0;
+		$timed_out     = 0;
+		$stale_actions = 0;
+		$requeued      = 0;
 
 		foreach ( $timed_out_jobs as $job ) {
 			$engine_data = json_decode( $job->engine_data, true );
@@ -291,33 +293,259 @@ class RecoverStuckJobsAbility {
 			}
 		}
 
-		$message = $dry_run
-			? sprintf( 'Dry run complete. Would recover %d jobs, timeout %d jobs.', $recovered, $timed_out )
-			: sprintf( 'Recovery complete. Recovered: %d, Timed out: %d, Requeued: %d', $recovered, $timed_out, $requeued );
+		$terminal_actions = $this->getTerminalBackedInProgressActions( $flow_id );
+		foreach ( $terminal_actions as $action ) {
+			$job_id         = (int) $action['job_id'];
+			$action_id      = (int) $action['action_id'];
+			$job_flow_id    = (int) $action['flow_id'];
+			$terminal_state = (string) $action['job_status'];
 
-		if ( ! $dry_run && ( $recovered > 0 || $timed_out > 0 ) ) {
+			if ( $dry_run ) {
+				++$stale_actions;
+				$jobs[] = array(
+					'job_id'        => $job_id,
+					'flow_id'       => $job_flow_id,
+					'action_id'     => $action_id,
+					'status'        => 'would_reconcile_action',
+					'target_status' => $terminal_state,
+				);
+				continue;
+			}
+
+			if ( $this->completeTerminalBackedAction( $action_id, $job_id, $terminal_state ) ) {
+				++$stale_actions;
+				$jobs[] = array(
+					'job_id'        => $job_id,
+					'flow_id'       => $job_flow_id,
+					'action_id'     => $action_id,
+					'status'        => 'reconciled_action',
+					'target_status' => $terminal_state,
+				);
+			} else {
+				++$skipped;
+				$jobs[] = array(
+					'job_id'    => $job_id,
+					'flow_id'   => $job_flow_id,
+					'action_id' => $action_id,
+					'status'    => 'skipped',
+					'reason'    => 'Action Scheduler reconciliation failed',
+				);
+			}
+		}
+
+		$message = $dry_run
+			? sprintf( 'Dry run complete. Would recover %d jobs, timeout %d jobs, reconcile %d terminal-backed actions.', $recovered, $timed_out, $stale_actions )
+			: sprintf( 'Recovery complete. Recovered: %d, Timed out: %d, Reconciled actions: %d, Requeued: %d', $recovered, $timed_out, $stale_actions, $requeued );
+
+		if ( ! $dry_run && ( $recovered > 0 || $timed_out > 0 || $stale_actions > 0 ) ) {
 			do_action(
 				'datamachine_log',
 				'info',
 				'Stuck jobs recovered via ability',
 				array(
-					'recovered' => $recovered,
-					'timed_out' => $timed_out,
-					'requeued'  => $requeued,
-					'flow_id'   => $flow_id,
+					'recovered'     => $recovered,
+					'timed_out'     => $timed_out,
+					'stale_actions' => $stale_actions,
+					'requeued'      => $requeued,
+					'flow_id'       => $flow_id,
 				)
 			);
 		}
 
 		return array(
-			'success'   => true,
-			'recovered' => $recovered,
-			'skipped'   => $skipped,
-			'timed_out' => $timed_out,
-			'requeued'  => $requeued,
-			'dry_run'   => $dry_run,
-			'jobs'      => $jobs,
-			'message'   => $message,
+			'success'       => true,
+			'recovered'     => $recovered,
+			'skipped'       => $skipped,
+			'timed_out'     => $timed_out,
+			'stale_actions' => $stale_actions,
+			'requeued'      => $requeued,
+			'dry_run'       => $dry_run,
+			'jobs'          => $jobs,
+			'message'       => $message,
 		);
+	}
+
+	/**
+	 * Find in-progress Action Scheduler step actions whose Data Machine job is terminal.
+	 *
+	 * @param int|null $flow_id Optional flow filter.
+	 * @return array<int,array{action_id:int,job_id:int,flow_id:int,job_status:string}>
+	 */
+	private function getTerminalBackedInProgressActions( ?int $flow_id ): array {
+		global $wpdb;
+
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$jobs_table    = $wpdb->prefix . 'datamachine_jobs';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names are generated from the WP prefix.
+		$actions = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT action_id, args
+				 FROM {$actions_table}
+				 WHERE hook = %s
+				 AND status = %s
+				 AND args LIKE %s",
+				'datamachine_execute_step',
+				'in-progress',
+				'%"job_id"%'
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		if ( empty( $actions ) ) {
+			return array();
+		}
+
+		$action_job_ids = array();
+		foreach ( $actions as $action ) {
+			$job_id = $this->extractActionJobId( (string) ( $action->args ?? '' ) );
+			if ( $job_id > 0 ) {
+				$action_job_ids[ (int) $action->action_id ] = $job_id;
+			}
+		}
+
+		if ( empty( $action_job_ids ) ) {
+			return array();
+		}
+
+		$placeholders = implode( ',', array_fill( 0, count( $action_job_ids ), '%d' ) );
+		$query_args   = array_values( $action_job_ids );
+		$query_args   = array_merge( $query_args, JobStatus::FINAL_STATUSES );
+
+		$where = "WHERE job_id IN ({$placeholders}) AND status IN (%s,%s,%s,%s)";
+		if ( $flow_id ) {
+			$where        .= ' AND flow_id = %d';
+			$query_args[] = $flow_id;
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic placeholder list is prepared below.
+		$terminal_jobs = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT job_id, flow_id, status
+				 FROM {$jobs_table}
+				 {$where}",
+				$query_args
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		if ( empty( $terminal_jobs ) ) {
+			return array();
+		}
+
+		$jobs_by_id = array();
+		foreach ( $terminal_jobs as $job ) {
+			$jobs_by_id[ (int) $job['job_id'] ] = $job;
+		}
+
+		$terminal_actions = array();
+		foreach ( $action_job_ids as $action_id => $job_id ) {
+			if ( ! isset( $jobs_by_id[ $job_id ] ) ) {
+				continue;
+			}
+
+			$job = $jobs_by_id[ $job_id ];
+			$terminal_actions[] = array(
+				'action_id'  => (int) $action_id,
+				'job_id'     => (int) $job_id,
+				'flow_id'    => (int) $job['flow_id'],
+				'job_status' => (string) $job['status'],
+			);
+		}
+
+		return $terminal_actions;
+	}
+
+	/**
+	 * Extract the Data Machine job ID from Action Scheduler args.
+	 *
+	 * @param string $args Action Scheduler args payload.
+	 * @return int Job ID, or 0 when unavailable.
+	 */
+	private function extractActionJobId( string $args ): int {
+		$decoded = json_decode( $args, true );
+		if ( is_array( $decoded ) ) {
+			if ( isset( $decoded['job_id'] ) && is_numeric( $decoded['job_id'] ) ) {
+				return (int) $decoded['job_id'];
+			}
+
+			foreach ( $decoded as $value ) {
+				if ( is_array( $value ) && isset( $value['job_id'] ) && is_numeric( $value['job_id'] ) ) {
+					return (int) $value['job_id'];
+				}
+			}
+		}
+
+		$unserialized = maybe_unserialize( $args );
+		if ( is_array( $unserialized ) ) {
+			if ( isset( $unserialized['job_id'] ) && is_numeric( $unserialized['job_id'] ) ) {
+				return (int) $unserialized['job_id'];
+			}
+
+			foreach ( $unserialized as $value ) {
+				if ( is_array( $value ) && isset( $value['job_id'] ) && is_numeric( $value['job_id'] ) ) {
+					return (int) $value['job_id'];
+				}
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Complete a stale in-progress Action Scheduler action without touching the terminal job.
+	 *
+	 * @param int    $action_id Action Scheduler action ID.
+	 * @param int    $job_id Data Machine job ID.
+	 * @param string $job_status Terminal Data Machine job status.
+	 * @return bool Whether the Action Scheduler row was reconciled.
+	 */
+	private function completeTerminalBackedAction( int $action_id, int $job_id, string $job_status ): bool {
+		global $wpdb;
+
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$logs_table    = $wpdb->prefix . 'actionscheduler_logs';
+		$now_gmt       = current_time( 'mysql', true );
+		$now_local     = current_time( 'mysql', false );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->update(
+			$actions_table,
+			array(
+				'status'             => 'complete',
+				'claim_id'           => 0,
+				'last_attempt_gmt'   => $now_gmt,
+				'last_attempt_local' => $now_local,
+			),
+			array(
+				'action_id' => $action_id,
+				'status'    => 'in-progress',
+			),
+			array( '%s', '%d', '%s', '%s' ),
+			array( '%d', '%s' )
+		);
+
+		if ( false === $result || 0 === (int) $result ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->insert(
+			$logs_table,
+			array(
+				'action_id'      => $action_id,
+				'message'        => sprintf(
+					'Data Machine reconciled stale in-progress action: job %d is already terminal (%s).',
+					$job_id,
+					$job_status
+				),
+				'log_date_gmt'   => $now_gmt,
+				'log_date_local' => $now_local,
+			),
+			array( '%d', '%s', '%s', '%s' )
+		);
+
+		return true;
 	}
 }

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -408,24 +408,24 @@ class RecoverStuckJobsAbility {
 			return array();
 		}
 
-		$job_placeholders = implode( ',', array_fill( 0, count( $action_job_ids ), '%d' ) );
+		$job_placeholders    = implode( ',', array_fill( 0, count( $action_job_ids ), '%d' ) );
 		$status_placeholders = implode( ',', array_fill( 0, count( JobStatus::FINAL_STATUSES ), '%s' ) );
-		$query_args = array_values( $action_job_ids );
-		$query_args = array_merge( $query_args, JobStatus::FINAL_STATUSES );
+		$query_args          = array_values( $action_job_ids );
+		$query_args          = array_merge( $query_args, JobStatus::FINAL_STATUSES );
 
 		$sql = "SELECT job_id, flow_id, status
 			 FROM {$jobs_table}
 			 WHERE job_id IN ({$job_placeholders})
-			 AND status IN ({$status_placeholders})";
+				 AND status IN ({$status_placeholders})";
 		if ( $flow_id ) {
-			$sql .= ' AND flow_id = %d';
+			$sql         .= ' AND flow_id = %d';
 			$query_args[] = $flow_id;
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic placeholder list is prepared below.
 		$terminal_jobs = $wpdb->get_results(
-			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- The dynamic SQL contains only generated placeholders; values are supplied in matching order.
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- The dynamic SQL contains only generated placeholders; values are supplied in matching order.
 				$sql,
 				$query_args
 			),
@@ -448,7 +448,7 @@ class RecoverStuckJobsAbility {
 				continue;
 			}
 
-			$job = $jobs_by_id[ $job_id ];
+			$job                = $jobs_by_id[ $job_id ];
 			$terminal_actions[] = array(
 				'action_id'  => (int) $action_id,
 				'job_id'     => (int) $job_id,

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -408,22 +408,25 @@ class RecoverStuckJobsAbility {
 			return array();
 		}
 
-		$placeholders = implode( ',', array_fill( 0, count( $action_job_ids ), '%d' ) );
-		$query_args   = array_values( $action_job_ids );
-		$query_args   = array_merge( $query_args, JobStatus::FINAL_STATUSES );
+		$job_placeholders = implode( ',', array_fill( 0, count( $action_job_ids ), '%d' ) );
+		$status_placeholders = implode( ',', array_fill( 0, count( JobStatus::FINAL_STATUSES ), '%s' ) );
+		$query_args = array_values( $action_job_ids );
+		$query_args = array_merge( $query_args, JobStatus::FINAL_STATUSES );
 
-		$where = "WHERE job_id IN ({$placeholders}) AND status IN (%s,%s,%s,%s)";
+		$sql = "SELECT job_id, flow_id, status
+			 FROM {$jobs_table}
+			 WHERE job_id IN ({$job_placeholders})
+			 AND status IN ({$status_placeholders})";
 		if ( $flow_id ) {
-			$where        .= ' AND flow_id = %d';
+			$sql .= ' AND flow_id = %d';
 			$query_args[] = $flow_id;
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic placeholder list is prepared below.
 		$terminal_jobs = $wpdb->get_results(
+			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- The dynamic SQL contains only generated placeholders; values are supplied in matching order.
 			$wpdb->prepare(
-				"SELECT job_id, flow_id, status
-				 FROM {$jobs_table}
-				 {$where}",
+				$sql,
 				$query_args
 			),
 			ARRAY_A

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -103,7 +103,7 @@ class JobsCommand extends BaseCommand {
 			return;
 		}
 
-		WP_CLI::log( sprintf( 'Found %d stuck jobs with job_status in engine_data.', count( $jobs ) ) );
+		WP_CLI::log( sprintf( 'Found %d stuck jobs or stale actions.', count( $jobs ) ) );
 
 		if ( $dry_run ) {
 			WP_CLI::log( 'Dry run - no changes will be made.' );
@@ -130,6 +130,26 @@ class JobsCommand extends BaseCommand {
 				WP_CLI::log( sprintf( 'Would timeout job %d (flow %d)', $job['job_id'], $job['flow_id'] ) );
 			} elseif ( 'timed_out' === $job['status'] ) {
 				WP_CLI::log( sprintf( 'Timed out job %d (flow %d)', $job['job_id'], $job['flow_id'] ) );
+			} elseif ( 'would_reconcile_action' === $job['status'] ) {
+				WP_CLI::log(
+					sprintf(
+						'Would reconcile Action Scheduler action %d for terminal job %d (flow %d, status %s)',
+						$job['action_id'],
+						$job['job_id'],
+						$job['flow_id'],
+						$job['target_status']
+					)
+				);
+			} elseif ( 'reconciled_action' === $job['status'] ) {
+				WP_CLI::log(
+					sprintf(
+						'Reconciled Action Scheduler action %d for terminal job %d (flow %d, status %s)',
+						$job['action_id'],
+						$job['job_id'],
+						$job['flow_id'],
+						$job['target_status']
+					)
+				);
 			}
 		}
 

--- a/tests/recover-stuck-terminal-actions-smoke.php
+++ b/tests/recover-stuck-terminal-actions-smoke.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Smoke coverage for terminal-backed Action Scheduler stale action recovery.
+ *
+ * @package DataMachine\Tests
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+if ( ! function_exists( 'maybe_unserialize' ) ) {
+	function maybe_unserialize( $data ) {
+		if ( ! is_string( $data ) ) {
+			return $data;
+		}
+
+		$unserialized = @unserialize( $data );
+		return false === $unserialized && 'b:0;' !== $data ? $data : $unserialized;
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Abilities/Job/JobHelpers.php';
+require_once __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php';
+
+$failures = array();
+
+$assert = static function ( string $label, bool $condition ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	echo "FAIL: {$label}\n";
+	$failures[] = $label;
+};
+
+$reflection = new ReflectionClass( DataMachine\Abilities\Job\RecoverStuckJobsAbility::class );
+$ability    = $reflection->newInstanceWithoutConstructor();
+$extract    = $reflection->getMethod( 'extractActionJobId' );
+$detect     = $reflection->getMethod( 'getTerminalBackedInProgressActions' );
+
+$assert(
+	'extracts job_id from JSON object args',
+	123 === $extract->invoke( $ability, '{"job_id":123,"flow_step_id":"step-a"}' )
+);
+
+$assert(
+	'extracts job_id from JSON array args',
+	456 === $extract->invoke( $ability, '[{"job_id":456,"flow_step_id":"step-b"}]' )
+);
+
+$assert(
+	'extracts job_id from serialized args',
+	789 === $extract->invoke( $ability, serialize( array( 'job_id' => 789 ) ) )
+);
+
+$GLOBALS['wpdb'] = new class() {
+	public string $prefix = 'wp_';
+
+	public function prepare( string $query, ...$args ): string {
+		unset( $args );
+		return $query;
+	}
+
+	public function get_results( string $query, string $output = 'OBJECT' ): array {
+		unset( $output );
+
+		if ( str_contains( $query, 'actionscheduler_actions' ) ) {
+			return array(
+				(object) array(
+					'action_id' => 9006,
+					'args'      => '{"job_id":290,"flow_step_id":"3_bundle_step_1_2"}',
+				),
+			);
+		}
+
+		if ( str_contains( $query, 'datamachine_jobs' ) ) {
+			return array(
+				array(
+					'job_id'  => 290,
+					'flow_id' => 98,
+					'status'  => 'failed',
+				),
+			);
+		}
+
+		return array();
+	}
+};
+
+$terminal_actions = $detect->invoke( $ability, null );
+
+$assert(
+	'models stale in-progress action backed by terminal job',
+	array(
+		array(
+			'action_id'  => 9006,
+			'job_id'     => 290,
+			'flow_id'    => 98,
+			'job_status' => 'failed',
+		),
+	) === $terminal_actions
+);
+
+$ability_src = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php' );
+$cli_src     = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' );
+
+$assert(
+	'detects in-progress execute-step actions with job_id args',
+	str_contains( $ability_src, 'AND args LIKE %s' )
+		&& str_contains( $ability_src, "'datamachine_execute_step'" )
+		&& str_contains( $ability_src, "'in-progress'" )
+);
+
+$assert(
+	'limits stale action matches to terminal Data Machine jobs',
+	str_contains( $ability_src, 'JobStatus::FINAL_STATUSES' )
+		&& str_contains( $ability_src, 'getTerminalBackedInProgressActions' )
+);
+
+$assert(
+	'dry run reports terminal-backed actions without reconciliation',
+	str_contains( $ability_src, "'would_reconcile_action'" )
+		&& str_contains( $cli_src, 'Would reconcile Action Scheduler action %d for terminal job %d' )
+);
+
+$assert(
+	'non-dry run completes only the stale Action Scheduler row',
+	str_contains( $ability_src, "'status'             => 'complete'" )
+		&& str_contains( $ability_src, "'status'    => 'in-progress'" )
+		&& str_contains( $ability_src, 'without touching the terminal job' )
+);
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAILED: " . count( $failures ) . " terminal action recovery assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nOK: terminal action recovery smoke assertions passed.\n";


### PR DESCRIPTION
## Summary
- Detects `datamachine_execute_step` Action Scheduler actions stuck `in-progress` when their backing Data Machine job is already terminal.
- Reports those terminal-backed stale actions in `wp datamachine jobs recover-stuck --dry-run` output.
- Reconciles non-dry-run recovery by marking only the stale Action Scheduler row `complete`, clearing its claim, and adding an AS log entry without mutating the terminal Data Machine job.

Fixes #1726.

## Testing
- `php -l inc/Abilities/Job/RecoverStuckJobsAbility.php`
- `php -l inc/Cli/Commands/JobsCommand.php`
- `php -l tests/recover-stuck-terminal-actions-smoke.php`
- `php tests/recover-stuck-terminal-actions-smoke.php`
- `vendor/bin/phpcs inc/Abilities/Job/RecoverStuckJobsAbility.php inc/Cli/Commands/JobsCommand.php tests/recover-stuck-terminal-actions-smoke.php`
- `composer lint`
- `git diff --check`

## Test caveat
- `composer test` currently fails outside this change with 14 `AgentsAPI\\AI\\IterationBudget` class-not-found errors in the test harness and one existing `PipelineExecutionContractTest` assertion failure. The targeted smoke and lint checks above pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the recovery implementation, smoke coverage, verification commands, and PR description; Chris remains responsible for review and merge.