### PR TITLE
Refresh Data Machine docs for current surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Machine
 
-Agentic infrastructure for WordPress.
+Agentic workflow automation for WordPress.
 
 ## What It Does
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ Data Machine turns a WordPress site into an agent runtime — persistent identit
 
 **Pipelines** define the workflow template. **Flows** schedule when they run. **Jobs** track each execution with full undo support.
 
-### Agent Contexts
+### Agent Modes
 
-One agent, three operational modes — same identity and memory, different tools:
+One agent, three operational modes — same identity and memory, different guidance and tools:
 
-| Context | Purpose | Tools |
+| Mode | Purpose | Tools |
 |---------|---------|-------|
 | **Pipeline** | Automated workflow execution | Handler-specific tools scoped to the current step |
 | **Chat** | Conversational interface in wp-admin | 30+ management tools (flows, pipelines, jobs, logs, memory, content) |
 | **System** | Background infrastructure tasks | Alt text, daily memory, image generation, internal linking, meta descriptions (GitHub issues in data-machine-code extension) |
 
-Configure AI provider and model per context in Settings. Each context falls back to the global default if no override is set.
+Built-in mode guidance is injected by `AgentModeDirective` at runtime and extensions can register more modes through `AgentModeRegistry`. Configure AI provider and model per mode in Settings. Each mode falls back to the global default if no override is set.
 
 ### Agent Memory
 
@@ -61,13 +61,15 @@ Typed, permissioned functions registered via WordPress's Abilities API. Extensio
 
 | Ability | Description |
 |---------|-------------|
-| `datamachine/upload-media` | Upload/fetch image or video, store in repository or Media Library |
-| `datamachine/validate-media` | Validate against platform constraints (duration, size, codec, aspect ratio) |
-| `datamachine/video-metadata` | Extract duration, resolution, codec via ffprobe |
-| `datamachine/instagram-publish` | Publish to Instagram (image, carousel, Reel, Story) |
-| `datamachine/twitter-publish` | Publish to Twitter with media support |
-| `datamachine/flow-execute` | Execute a flow programmatically |
-| ... | 40+ abilities across media, publishing, content, SEO, and infrastructure |
+| `datamachine/query-posts` | Query WordPress posts for pipeline/content operations |
+| `datamachine/publish-wordpress` | Publish canonical content to WordPress |
+| `datamachine/update-wordpress` | Update existing WordPress content |
+| `datamachine/generate-alt-text` | Generate alt text for media |
+| `datamachine/generate-meta-description` | Generate SEO meta descriptions |
+| `datamachine/run-flow` | Execute a flow programmatically |
+| ... | Additional core abilities across pipelines, flows, jobs, memory, media, SEO, email, and infrastructure |
+
+Social publishing, workspace, and GitHub abilities live in extension plugins such as data-machine-socials and data-machine-code.
 
 ### Content Formats
 
@@ -221,7 +223,7 @@ Full REST API under `datamachine/v1`:
 
 ## AI Providers
 
-OpenAI, Anthropic, Google, Grok, OpenRouter — configure a global default per-site, with per-context overrides for pipeline, chat, and system.
+OpenAI, Anthropic, Google, Grok, OpenRouter — configure a global default per-site, with per-mode overrides for pipeline, chat, and system.
 
 ## Runtime Adapters
 
@@ -285,8 +287,7 @@ homeboy lint data-machine    # PHPCS with WordPress standards
 
 - [docs/](docs/) — User documentation
 - [docs/architecture/pipeline-execution-axes.md](docs/architecture/pipeline-execution-axes.md) — Four orthogonal axes of work expansion in a pipeline
-- [skills/data-machine/SKILL.md](skills/data-machine/SKILL.md) — Agent integration patterns
-- [AGENTS.md](AGENTS.md) — Technical reference for contributors
+- Data Machine skill and agent instruction files are generated into consumer environments rather than stored in this plugin tree
 - [docs/CHANGELOG.md](docs/CHANGELOG.md) — Version history
 
 ## Star History

--- a/docs/ai-directives.md
+++ b/docs/ai-directives.md
@@ -1,100 +1,13 @@
 # AI Directive System
 
-Data Machine uses a modular directive system to provide context and guidance to AI agents. These directives are combined to form the system prompt for every AI request.
+Data Machine assembles AI request context through directive classes registered on the `datamachine_directives` filter. The current implementation is documented in [core-system/ai-directives.md](core-system/ai-directives.md).
 
-## Architecture
+Key current facts:
 
-The directive system is built on a modular architecture using the following core components:
+- `AgentModeDirective` injects built-in mode guidance for `chat`, `pipeline`, and `system` at priority 22.
+- The former `PipelineCoreDirective`, `ChatAgentDirective`, `SystemAgentDirective`, and `SiteContextDirective` classes were removed during the AgentMode refactor.
+- `CoreMemoryFilesDirective` injects registered memory files from the shared, agent, and user layers.
+- Pipeline, flow, daily-memory, and chat-inventory directives add request-specific context after the core mode and memory layers.
+- Tools are injected by `RequestBuilder` through `PromptBuilder::setTools()`, not by a directive class.
 
-- **DirectiveInterface**: Standard interface for all directive classes — defines `get_outputs()`.
-- **PromptBuilder**: Unified manager that collects, sorts, filters, and renders directives for AI requests.
-- **DirectiveRenderer**: Renders directive outputs into system messages (`{role: 'system', content: ...}`).
-- **DirectiveOutputValidator**: Ensures directive output follows the expected schema (`system_text`, `system_json`, or `system_file`).
-
-## Directive Priority & Layering
-
-Directives are layered by priority (lowest number = highest priority) to create a cohesive context:
-
-| Priority | Directive | Contexts | Purpose |
-|----------|-----------|----------|---------|
-| **10** | PipelineCoreDirective | pipeline | Pipeline agent identity and operational principles |
-| **15** | ChatAgentDirective | chat | Chat agent identity and behavioral instructions |
-| **20** | SystemAgentDirective | system | System agent identity and capabilities |
-| **20** | CoreMemoryFilesDirective | **all** | SITE.md, RULES.md, SOUL.md, MEMORY.md, USER.md, custom files |
-| **40** | PipelineMemoryFilesDirective | pipeline | Per-pipeline selectable memory files |
-| **45** | ChatPipelinesDirective | chat | Pipeline/flow/handler inventory |
-| **45** | FlowMemoryFilesDirective | pipeline | Per-flow selectable memory files (additive) |
-| **46** | DailyMemorySelectorDirective | pipeline | Daily memory files by selection mode |
-| **50** | PipelineSystemPromptDirective | pipeline | User-configured task instructions + workflow visualization |
-| **80** | SiteContextDirective | **all** | WordPress site metadata |
-
-**Note**: Tools are injected by `RequestBuilder` via `PromptBuilder::setTools()`, not as a directive class.
-
-### ChatAgentDirective (Priority 15)
-Specialized directive for the conversational chat interface. It instructs the agent on discovery and configuration patterns, emphasizing querying existing workflows before creating new ones. Includes error handling taxonomy and action-oriented behavioral guidelines.
-
-### SystemAgentDirective (Priority 20)
-Defines the system agent identity for internal operations — session title generation, GitHub issue creation, and system maintenance tasks. Dynamically lists available GitHub repos at runtime.
-
-### CoreMemoryFilesDirective (Priority 20)
-Reads core memory files from three directory layers and injects them as system messages: SITE.md + RULES.md (shared), SOUL.md + MEMORY.md (agent), USER.md (user). Self-healing — creates missing agent files before reading. Applied to **all** agent types.
-
-### PipelineMemoryFilesDirective (Priority 40)
-Injects agent memory files selected for a specific pipeline. Files are stored in the agent directory and selected per-pipeline via the admin UI. SOUL.md is excluded (always injected separately at Priority 20). This enables pipelines to access strategy documents, reference material, or other persistent context.
-
-### FlowMemoryFilesDirective (Priority 45)
-Injects additional memory files configured per-flow (additive to pipeline memory files at P40). Different flows on the same pipeline can reference different memory files.
-
-### DailyMemorySelectorDirective (Priority 46)
-Injects daily memory files based on flow-level configuration. Supports four modes: `recent_days`, `specific_dates`, `date_range`, and `months`. Size-capped at 100KB with newest-first ordering.
-
-### ChatPipelinesDirective (Priority 45)
-Provides the conversational agent with a JSON inventory of available pipelines. When a pipeline is selected in the UI, `selected_pipeline_id` is used to prioritize and expand context for that specific pipeline, including its flow summaries and handler configurations.
-
-### PipelineSystemPromptDirective (Priority 50)
-Injects the user-configured pipeline system prompt along with a workflow visualization showing the step sequence and a "YOU ARE HERE" marker for spatial awareness.
-
-### SiteContextDirective (Priority 80)
-Injects comprehensive WordPress site metadata as JSON. Toggleable, cached, and filterable. Applied to **all** agent types as the final directive.
-
-## Context-Specific Stacks
-
-**Chat**: ChatAgentDirective → CoreMemoryFiles → ChatPipelines → SiteContext
-
-**Pipeline**: PipelineCore → CoreMemoryFiles → PipelineMemoryFiles → FlowMemoryFiles → DailyMemorySelector → PipelineSystemPrompt → SiteContext
-
-**System**: SystemAgent → CoreMemoryFiles → SiteContext
-
-## Memory System Integration
-
-The directive system integrates with Data Machine's file-based agent memory:
-
-- **SITE.md** and **RULES.md** are always injected (Priority 20) from the shared directory
-- **SOUL.md** and **MEMORY.md** are always injected (Priority 20) from the agent directory
-- **USER.md** is always injected (Priority 20) from the user directory
-- **Pipeline Memory Files** (Priority 40) are selectable per-pipeline via the admin UI
-- **Flow Memory Files** (Priority 45) are selectable per-flow
-- **Daily Memory** (Priority 46) is configurable per-flow with mode selection
-- Files are stored in `{wp-content}/uploads/datamachine-files/{shared,agents,users}/`
-
-## Registration
-
-Directives are registered via WordPress filters:
-
-```php
-add_filter('datamachine_directives', function($directives) {
-    $directives[] = [
-        'class'       => MyCustomDirective::class,
-        'priority'    => 25,
-        'modes'       => ['pipeline', 'chat', 'all'],
-    ];
-    return $directives;
-});
-```
-
-## Implementation Notes
-
-- Directives should be read-only and never mutate the AI request structure directly.
-- Use `DirectiveOutputValidator` to ensure responses from the AI follow the correct `system_text`, `system_json`, or `system_file` formats.
-- Context injection should be minimal and focused on what the agent needs for the current task.
-- See `docs/core-system/ai-directives.md` for detailed implementation reference including agent-specific behavior, caching strategy, and extensibility hooks.
+Use [core-system/ai-directives.md](core-system/ai-directives.md) as the authoritative reference for priorities, mode assignments, filters, and examples.

--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -55,24 +55,26 @@ Available to all AI agents (pipeline + chat + standalone) via `datamachine_globa
 - **Features**: Post type and category filtering, force rebuild option, internal/external/all scope for broken link checks, configurable result limits
 - **Use Cases**: SEO link auditing, orphaned content discovery, broken link detection
 
-**GitHub Tools** — multi-tool class (@since v0.24.0, **moved to data-machine-code extension**)
+**GitHub Tools** — multi-tool class (@since v0.24.0, **data-machine-code extension only**)
 - `create_github_issue` — Create a GitHub issue in a repository. Async — uses System Agent for execution.
 - `list_github_issues` — List issues from a GitHub repository with state, label, and pagination filters
 - `get_github_issue` — Get a single GitHub issue with full details including body, labels, and comments
 - `manage_github_issue` — Update, close, or comment on a GitHub issue
 - `list_github_pulls` — List pull requests from a repository with state filtering
 - `list_github_repos` — List GitHub repositories for a user or organization
-- **Configuration**: GitHub PAT required
+- **Configuration**: GitHub PAT required in the `data-machine-code` extension
 - **Use Cases**: Bug reports, feature requests, task tracking from AI workflows
+- **Availability**: Not registered by Data Machine core.
 
-**Workspace Tools** — multi-tool class (@since v0.37.0, **moved to data-machine-code extension**)
+**Workspace Tools** — multi-tool class (@since v0.37.0, **data-machine-code extension only**)
 - `workspace_path` — Get the Data Machine workspace path, optionally ensure it exists
 - `workspace_list` — List repositories currently present in the workspace
 - `workspace_show` — Show detailed repo info (branch, remote, latest commit, dirty count)
 - `workspace_ls` — List directory contents within a workspace repository
 - `workspace_read` — Read a text file from a workspace repo with optional offset/limit for large files
-- **Configuration**: None required
+- **Configuration**: Configure and operate through the `data-machine-code` extension
 - **Use Cases**: Repository browsing, code review, workspace navigation
+- **Availability**: Not registered by Data Machine core.
 
 **Image Generation** (`image_generation`)
 - **Purpose**: Generate images using AI models (Google Imagen 4, Flux, etc.) via Replicate. Returns a URL to the generated image. Async — uses System Agent.

--- a/docs/api/endpoints/chat.md
+++ b/docs/api/endpoints/chat.md
@@ -252,12 +252,12 @@ add_filter('datamachine_tool_enabled', function($enabled, $tool_name, $tool_conf
 
 **Directive Registration** (@since v0.2.5):
 ```php
-// Current: Unified directive registration with agent type targeting
+// Current: Unified directive registration with mode targeting
 add_filter('datamachine_directives', function($directives) {
     $directives[] = [
-        'class' => ChatAgentDirective::class,
-        'priority' => 10,
-        'agent_types' => ['chat']
+        'class' => MyChatDirective::class,
+        'priority' => 45,
+        'modes' => ['chat']
     ];
     return $directives;
 });
@@ -333,7 +333,7 @@ Chat agent discovers tools via three sources:
 
 ### Unified Directive System (@since v0.2.5)
 
-Directives are registered via the `datamachine_directives` filter with priority and agent targeting:
+Directives are registered via the `datamachine_directives` filter with priority and mode targeting:
 
 ```php
 add_filter('datamachine_directives', function($directives) {
@@ -341,14 +341,14 @@ add_filter('datamachine_directives', function($directives) {
     $directives[] = [
         'class' => MyDirective::class,
         'priority' => 25,
-        'agent_types' => ['all']  // Applies to chat and pipeline agents
+        'modes' => ['all']  // Applies to all agent modes
     ];
 
     // Chat-specific directive
     $directives[] = [
         'class' => MyChatDirective::class,
-        'priority' => 15,
-        'agent_types' => ['chat']  // Applies only to chat agent
+        'priority' => 45,
+        'modes' => ['chat']  // Applies only to chat mode
     ];
 
     return $directives;
@@ -356,11 +356,10 @@ add_filter('datamachine_directives', function($directives) {
 ```
 
 **Priority Guidelines**:
-- **10-19**: Core agent identity and foundational instructions
-- **20-29**: Global system prompts and universal behavior
-- **30-39**: Agent-specific system prompts and context
-- **40-49**: Workflow and execution context directives
-- **50+**: Environmental and site-specific directives
+- **20**: Registered memory files
+- **22**: Runtime agent-mode guidance
+- **25-35**: Caller, daily memory, and client-reported context
+- **40-50**: Pipeline, flow, chat inventory, and workflow-specific directives
 
 
 

--- a/docs/api/endpoints/system.md
+++ b/docs/api/endpoints/system.md
@@ -108,13 +108,23 @@ curl https://example.com/wp-json/datamachine/v1/system/tasks \
 
 | Task Type | Class | Description |
 |---|---|---|
+| `agent_call` | `AgentCallTask` | Call a remote or external agent |
 | `image_generation` | `ImageGenerationTask` | Generate images using AI models via Replicate |
 | `image_optimization` | `ImageOptimizationTask` | Optimize images for web delivery |
 | `alt_text_generation` | `AltTextTask` | Generate descriptive alt text for images |
-| `github_create_issue` | `GitHubIssueTask` | Create GitHub issues from AI workflows |
 | `internal_linking` | `InternalLinkingTask` | Analyze and suggest internal link improvements |
 | `daily_memory_generation` | `DailyMemoryTask` | Generate daily memory summaries |
 | `meta_description_generation` | `MetaDescriptionTask` | Generate meta descriptions for SEO |
+| `retention_completed_jobs` | `RetentionCompletedJobsTask` | Clean completed jobs according to retention policy |
+| `retention_failed_jobs` | `RetentionFailedJobsTask` | Clean failed jobs according to retention policy |
+| `retention_logs` | `RetentionLogsTask` | Clean logs according to retention policy |
+| `retention_processed_items` | `RetentionProcessedItemsTask` | Clean processed-item records according to retention policy |
+| `retention_as_actions` | `RetentionActionSchedulerTask` | Clean Action Scheduler actions according to retention policy |
+| `retention_stale_claims` | `RetentionStaleClaimsTask` | Clean stale processed-item claims |
+| `retention_files` | `RetentionFilesTask` | Clean managed files according to retention policy |
+| `retention_chat_sessions` | `RetentionChatSessionsTask` | Clean chat sessions according to retention policy |
+
+GitHub issue creation moved to the `data-machine-code` extension and is not a Data Machine core system task.
 
 ### POST /system/tasks/{task_type}/run
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,16 +95,13 @@ datamachine-files/
 │   │   └── MEMORY.md
 │   └── 2/
 │       └── USER.md
-└── pipeline-{id}/       # Pipeline-scoped files
-    ├── context/
-    └── flow-{id}/
 ```
 
 **CoreMemoryFilesDirective** (Priority 20) loads files from layers in order:
 1. SITE.md → RULES.md from the shared layer
 2. SOUL.md → MEMORY.md from the agent layer
 3. USER.md → MEMORY.md from the user layer
-4. Custom files from `MemoryFileRegistry` (extensions)
+4. Custom files from `MemoryFileRegistry` (extensions), including files selected by pipelines and flows
 
 See [WordPress as Agent Memory](core-system/wordpress-as-agent-memory.md) for full memory documentation.
 
@@ -142,7 +139,7 @@ Background AI operations that run outside the normal pipeline model:
     │                                          │
 ImageGenerationTask  AltTextTask  DailyMemoryTask
 ImageOptimizationTask  InternalLinkingTask
-GitHubIssueTask  MetaDescriptionTask
+AgentCallTask  MetaDescriptionTask  RetentionTask
 ```
 
 **Undo System**: Tasks that record effects in `engine_data` can be reversed:
@@ -153,13 +150,13 @@ GitHubIssueTask  MetaDescriptionTask
 
 ### Workspace System
 
-Secure file management outside the web root for agent operations. **Moved to data-machine-code extension.**
+Secure file management outside the web root for agent operations lives in the `data-machine-code` extension plugin, not Data Machine core.
 
-- **Location**: `/var/lib/datamachine/workspace/` (or `DATAMACHINE_WORKSPACE_PATH`)
+- **Location**: Managed by data-machine-code workspace settings
 - **Git-aware**: Clone, status, pull, add, commit, push, log, diff
 - **File ops**: Read (with pagination), write, edit (find-replace), list directory
 - **Security**: Outside web root; mutating ops are CLI-only (not REST-exposed)
-- **CLI**: `wp datamachine-code workspace {path,list,clone,remove,show,read,ls,write,edit,git}`
+- **CLI**: `wp datamachine-code workspace {path,list,clone,remove,show,read,ls,write,edit,git,worktree}`
 
 ### Engine Data Architecture
 
@@ -201,7 +198,7 @@ $image_url = $engine_data['image_url'] ?? null;
 - **Agent abilities** - Agent CRUD, access grants, tokens, remote calls, memory, and daily memory
 - **File abilities** - Agent files, flow uploads, cleanup, and memory scaffolding
 
-**Coding workspace note**: Git-aware workspace and GitHub coding operations moved to the `data-machine-code` extension plugin. Data Machine core no longer registers `WorkspaceAbilities` or GitHub issue abilities.
+**Coding workspace note**: Git-aware workspace and GitHub coding operations live in the `data-machine-code` extension plugin. Data Machine core no longer registers `WorkspaceAbilities` or GitHub issue abilities.
 
 **Benefits**:
 - **3x Performance Improvement**: Direct method calls eliminate filter indirection
@@ -225,16 +222,15 @@ Priority-ordered context injection into every AI request:
 
 | Priority | Directive | Context | Purpose |
 |----------|-----------|---------|---------|
-| 10 | `PipelineCoreDirective` | Pipeline | Base pipeline identity |
-| 15 | `ChatAgentDirective` | Chat | Chat agent instructions |
 | 20 | `CoreMemoryFilesDirective` | All | Layer files + custom registry |
-| 20 | `SystemAgentDirective` | System | System task identity |
+| 22 | `AgentModeDirective` | All | Mode-specific guidance for chat, pipeline, and system |
+| 25 | `CallerContextDirective` | All, cross-site only | Authenticated A2A caller identity |
+| 35 | `AgentDailyMemoryDirective` | Chat, pipeline | Recent daily archives when enabled |
+| 35 | `ClientContextDirective` | All | Free-form client-reported context |
 | 40 | `PipelineMemoryFilesDirective` | Pipeline | Per-pipeline memory files |
 | 45 | `ChatPipelinesDirective` | Chat | Pipeline/flow context |
 | 45 | `FlowMemoryFilesDirective` | Pipeline | Per-flow memory files |
-| 46 | `DailyMemorySelectorDirective` | Pipeline | Selected daily memory |
 | 50 | `PipelineSystemPromptDirective` | Pipeline | Workflow instructions |
-| 80 | `SiteContextDirective` | All | WordPress metadata (filterable) |
 
 Directives implement `DirectiveInterface` and return arrays of typed outputs:
 - `system_text` — plain text content

--- a/docs/core-system/prompt-builder.md
+++ b/docs/core-system/prompt-builder.md
@@ -66,9 +66,9 @@ Directives are registered via the `datamachine_directives` filter:
 ```php
 add_filter('datamachine_directives', function($directives) {
     $directives[] = [
-        'class' => GlobalSystemPromptDirective::class,
+        'class' => MyDirective::class,
         'priority' => 20,
-        'agent_types' => ['all']
+        'modes' => ['all']
     ];
 
     return $directives;
@@ -79,24 +79,19 @@ add_filter('datamachine_directives', function($directives) {
 
 **Priority Order** (lower = applied first):
 
-- **10-19**: Core agent identity and foundational instructions
-- **20-29**: Global system prompts and universal behavior
-- **30-39**: Agent-specific system prompts and context
-- **40-49**: Workflow and execution context directives
-- **50+**: Environmental and site-specific directives
+- **20**: Registered memory files
+- **22**: Runtime agent-mode guidance
+- **25-35**: Caller, daily memory, and client-reported context
+- **40-50**: Pipeline, flow, chat inventory, and workflow-specific directives
 
 ## Current Directive Implementations
 
-### Global Directives (apply to all agents)
-- `GlobalSystemPromptDirective` - User-configured global AI behavior (priority 20)
-- `SiteContextDirective` - WordPress site context injection (priority 50)
-
-### Pipeline Directives
-- `PipelineCoreDirective` - Foundational pipeline agent identity (priority 10)
-- `PipelineSystemPromptDirective` - User-defined pipeline prompts (priority 30)
-
-### Chat Directives
-- `ChatAgentDirective` - Chat agent identity and capabilities (priority 10)
+- `CoreMemoryFilesDirective` - Registered memory files from shared, agent, and user layers (priority 20)
+- `AgentModeDirective` - Runtime mode guidance for chat, pipeline, system, and extension modes (priority 22)
+- `CallerContextDirective` - Authenticated cross-site caller identity (priority 25)
+- `AgentDailyMemoryDirective` and `ClientContextDirective` - Optional daily memory and client context (priority 35)
+- `PipelineMemoryFilesDirective`, `FlowMemoryFilesDirective`, and `PipelineSystemPromptDirective` - Pipeline-specific context (priorities 40, 45, 50)
+- `ChatPipelinesDirective` - Pipeline and flow inventory for chat (priority 45)
 
 ## Integration with RequestBuilder
 
@@ -109,7 +104,7 @@ $promptBuilder->setMessages($messages)
               ->setTools($structured_tools);
 
 // Apply directives via PromptBuilder
-$request = $promptBuilder->build($agent_type, $provider, $context);
+$request = $promptBuilder->build($agent_mode, $provider, $context);
 ```
 
 ## Migration from Legacy System
@@ -118,7 +113,7 @@ $request = $promptBuilder->build($agent_type, $provider, $context);
 ```php
 // Separate filters with inconsistent ordering
 add_filter('datamachine_global_directives', 'apply_global_directive', 10, 5); // LEGACY - use datamachine_directives instead
-add_filter('datamachine_agent_directives', 'apply_agent_directive', 10, 5); // LEGACY - use datamachine_directives with agent_types to target 'pipeline'/'chat'
+add_filter('datamachine_agent_directives', 'apply_agent_directive', 10, 5); // LEGACY - use datamachine_directives with modes to target 'pipeline'/'chat'
 ```
 
 ### After (v0.2.5+)
@@ -128,7 +123,7 @@ add_filter('datamachine_directives', function($directives) {
     $directives[] = [
         'class' => MyDirective::class,
         'priority' => 25,
-        'agent_types' => ['all']
+        'modes' => ['all']
     ];
     return $directives;
 });

--- a/docs/core-system/request-builder.md
+++ b/docs/core-system/request-builder.md
@@ -145,31 +145,26 @@ add_filter('datamachine_directives', function($directives) {
     $directives[] = [
         'class' => MyDirective::class,
         'priority' => 20,  // Lower numbers applied first
-        'agent_types' => ['all']  // 'all', 'pipeline', 'chat', or array
+        'modes' => ['all']  // 'all', 'pipeline', 'chat', 'system', or extension mode
     ];
     return $directives;
 });
 ```
 
 **Priority Order** (lower = applied first):
-- **10**: Core agent identity and foundational instructions
-- **20**: Global system prompts (user-configured)
-- **30**: Pipeline-specific system prompts
-- **40**: Context and workflow-specific directives
-- **50**: Site context and environmental directives
+- **20**: Registered memory files
+- **22**: Runtime agent-mode guidance
+- **25-35**: Caller, daily memory, and client-reported context
+- **40-50**: Pipeline, flow, chat inventory, and workflow-specific directives
 
 ### Current Directive Implementations
 
-**Global Directives** (apply to all agents):
-- `GlobalSystemPromptDirective` - User-configured global AI behavior (priority 20)
-- `SiteContextDirective` - WordPress site context injection (priority 50)
-
-**Pipeline Directives**:
-- `PipelineCoreDirective` - Foundational pipeline agent identity (priority 10)
-- `PipelineSystemPromptDirective` - User-defined pipeline prompts (priority 30)
-
-**Chat Directives**:
-- `ChatAgentDirective` - Chat agent identity and capabilities (priority 10)
+- `CoreMemoryFilesDirective` - Registered memory files from shared, agent, and user layers (priority 20)
+- `AgentModeDirective` - Runtime mode guidance for chat, pipeline, system, and extension modes (priority 22)
+- `CallerContextDirective` - Authenticated cross-site caller identity (priority 25)
+- `AgentDailyMemoryDirective` and `ClientContextDirective` - Optional daily memory and client context (priority 35)
+- `PipelineMemoryFilesDirective`, `FlowMemoryFilesDirective`, and `PipelineSystemPromptDirective` - Pipeline-specific context (priorities 40, 45, 50)
+- `ChatPipelinesDirective` - Pipeline and flow inventory for chat (priority 45)
 
 ## Tool Restructuring
 
@@ -453,12 +448,12 @@ $tool_calls = $ai_response['data']['tool_calls'] ?? [];
 Register directives using the unified `datamachine_directives` filter with appropriate priorities:
 
 ```php
-// Register a global directive (applies to all agents)
+// Register a global directive (applies to all modes)
 add_filter('datamachine_directives', function($directives) {
     $directives[] = [
         'class' => MyGlobalDirective::class,
-        'priority' => 25,  // Between global prompt (20) and pipeline prompts (30)
-        'agent_types' => ['all']
+        'priority' => 25,
+        'modes' => ['all']
     ];
     return $directives;
 });
@@ -467,19 +462,18 @@ add_filter('datamachine_directives', function($directives) {
 add_filter('datamachine_directives', function($directives) {
     $directives[] = [
         'class' => MyPipelineDirective::class,
-        'priority' => 35,  // After pipeline system prompts
-        'agent_types' => ['pipeline']
+        'priority' => 40,
+        'modes' => ['pipeline']
     ];
     return $directives;
 });
 ```
 
 **Priority Guidelines**:
-- **10-19**: Core agent identity and foundational instructions
-- **20-29**: Global system prompts and universal behavior
-- **30-39**: Agent-specific system prompts and context
-- **40-49**: Workflow and execution context directives
-- **50+**: Environmental and site-specific directives
+- **20**: Registered memory files
+- **22**: Runtime agent-mode guidance
+- **25-35**: Caller, daily memory, and client-reported context
+- **40-50**: Pipeline, flow, chat inventory, and workflow-specific directives
 
 ## Related Components
 

--- a/docs/core-system/wordpress-as-agent-memory.md
+++ b/docs/core-system/wordpress-as-agent-memory.md
@@ -88,11 +88,9 @@ Total injection capped at 100KB. Files sorted newest-first.
 
 Full conversation history persisted in the database. Sessions survive page reloads and browser restarts. Agent-scoped via `agent_id` column. Configurable retention with automatic cleanup via Action Scheduler.
 
-### 4. Pipeline Context — Workflow Memory
+### 4. Pipeline and Flow Memory — Workflow Context
 
-**Location:** `wp-content/uploads/datamachine-files/pipeline-{id}/context/`
-
-Per-pipeline documents that provide background for specific workflows. Job execution data stored as JSON creates an audit trail of what was processed — transient working memory cleaned by retention policies.
+Pipeline and flow memory is selected from registered memory files instead of a dedicated `pipeline-{id}/context/` directory. Pipeline-level selections are injected by **PipelineMemoryFilesDirective** (Priority 40); flow-level selections are additive and injected by **FlowMemoryFilesDirective** (Priority 45). Job execution data stored as JSON creates an audit trail of what was processed — transient working memory cleaned by retention policies.
 
 ## Multi-Agent Architecture
 
@@ -119,9 +117,9 @@ The `datamachine_agent_access` table implements role-based access:
 ### Resource Scoping
 
 All major resources carry an `agent_id` column:
-- **Pipelines** — each pipeline belongs to an agent
-- **Flows** — each flow belongs to an agent
-- **Jobs** — each job runs under an agent
+- **Pipelines** — each pipeline belongs to an agent-scoped owner
+- **Flows** — each flow belongs to an agent-scoped owner
+- **Jobs** — each job runs under an agent-scoped owner
 - **Chat sessions** — each conversation is agent-scoped
 
 The `PermissionHelper` class provides methods for agent-level access checks:
@@ -330,16 +328,15 @@ Data Machine uses a **directive system** — a priority-ordered chain that injec
 
 | Priority | Directive | Context | What It Injects |
 |----------|-----------|---------|-----------------|
-| 10 | `PipelineCoreDirective` | Pipeline | Base Data Machine identity for pipelines |
-| **15** | **`ChatAgentDirective`** | **Chat** | **Chat agent identity and instructions** |
 | **20** | **`CoreMemoryFilesDirective`** | **All** | **SITE.md, RULES.md (shared), SOUL.md, MEMORY.md (agent), USER.md (user) + custom registry files** |
-| **20** | **`SystemAgentDirective`** | **System** | **System task agent identity** |
+| **22** | **`AgentModeDirective`** | **All** | **Mode-specific guidance for chat, pipeline, and system** |
+| 25 | `CallerContextDirective` | All, cross-site only | Authenticated A2A caller identity |
+| 35 | `AgentDailyMemoryDirective` | Chat, pipeline | Recent daily archives when enabled |
+| 35 | `ClientContextDirective` | All | Client-reported context such as current screen or edited post |
 | 40 | `PipelineMemoryFilesDirective` | Pipeline | Per-pipeline selected additional files |
 | **45** | **`ChatPipelinesDirective`** | **Chat** | **Pipeline/flow context for chat** |
 | **45** | **`FlowMemoryFilesDirective`** | **Pipeline** | **Per-flow selected additional files** |
-| **46** | **`DailyMemorySelectorDirective`** | **Pipeline** | **Selected daily memory files based on flow config** |
 | 50 | `PipelineSystemPromptDirective` | Pipeline | Workflow instructions |
-| 80 | `SiteContextDirective` | All | WordPress metadata (filterable/replaceable) |
 
 ### Core Memory Files (Priority 20)
 
@@ -756,7 +753,7 @@ add_filter('datamachine_directives', function($directives) {
     $directives[] = [
         'class'       => 'MyPlugin\Directives\CustomMemory',
         'priority'    => 25, // Between core memory files (20) and pipeline memory (40)
-        'agent_types' => ['pipeline'],
+        'modes'      => ['pipeline'],
     ];
     return $directives;
 });

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -1,6 +1,6 @@
 # WP-CLI Commands
 
-Data Machine provides 23 WP-CLI command namespaces for managing pipelines, flows, jobs, agents, and more from the command line. All commands are registered under the `datamachine` namespace via `inc/Cli/Bootstrap.php`.
+Data Machine provides a broad WP-CLI surface for managing pipelines, flows, jobs, agents, memory, system tasks, and more from the command line. Commands and their singular/plural aliases are registered under the `datamachine` namespace via `inc/Cli/Bootstrap.php`; use `wp help datamachine` for the authoritative list in a running install.
 
 > **Note:** The `wp datamachine workspace` and `wp datamachine github` commands have been moved to the `data-machine-code` extension plugin.
 
@@ -288,6 +288,7 @@ wp datamachine memory paths
 wp datamachine memory paths --agent=my-agent --format=json
 ```
 
+### datamachine system
 
 System tasks and health checks. **Since**: 0.41.0
 
@@ -324,6 +325,8 @@ wp datamachine batch status 42
 
 # Cancel a running batch
 wp datamachine batch cancel 42
+```
+
 ### datamachine image
 
 Image generation and optimization. **Since**: 0.33.0
@@ -664,6 +667,18 @@ wp datamachine indexnow key show
 wp datamachine indexnow enable
 wp datamachine indexnow disable
 ```
+
+### Other registered commands
+
+The root namespace also registers specialized commands that are documented most accurately by WP-CLI help in the running install:
+
+- `wp datamachine ai`
+- `wp datamachine drain`
+- `wp datamachine email`
+- `wp datamachine external`
+- `wp datamachine retention`
+- `wp datamachine test`
+- `wp datamachine fetch test`
 
 ## Global Options
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -378,42 +378,35 @@ $ai_response = RequestBuilder::build(
     $provider,      // AI provider name
     $model,         // Model identifier
     $tools,         // Raw tools array from filters
-    $agent_type,    // 'chat' or 'pipeline'
+    $agent_mode,    // 'chat', 'pipeline', 'system', or extension mode
     $context        // Agent-specific context
 );
 ```
 
 **Current Directive Implementations**:
 
-**Global Directives** (all agents):
-
-- `GlobalSystemPromptDirective` - Background guidance for all AI agents
-- `SiteContextDirective` - WordPress environment information (optional)
-
-**Pipeline Agent Directives**:
-
-- `PipelineCoreDirective` - Foundational agent identity with tool instructions (priority 10)
-- `PipelineSystemPromptDirective` - User-defined system prompts (priority 20)
-
-**Chat Agent Directives**:
-
-- `ChatAgentDirective` - Chat agent identity and capabilities
+- `CoreMemoryFilesDirective` - Registered memory files from shared, agent, and user layers (priority 20)
+- `AgentModeDirective` - Mode-specific guidance for chat, pipeline, system, and extension modes (priority 22)
+- `CallerContextDirective` - Authenticated cross-site caller identity (priority 25)
+- `AgentDailyMemoryDirective` and `ClientContextDirective` - Optional daily memory and client context (priority 35)
+- `PipelineMemoryFilesDirective`, `FlowMemoryFilesDirective`, and `PipelineSystemPromptDirective` - Pipeline-specific context (priorities 40, 45, 50)
+- `ChatPipelinesDirective` - Pipeline and flow inventory for chat (priority 45)
 
 **Unified Directive Registration**:
 
 ```php
-// Register directives with priority and agent targeting
+// Register directives with priority and mode targeting
 add_filter('datamachine_directives', function($directives) {
     $directives[] = [
         'class' => MyGlobalDirective::class,
         'priority' => 20,  // Lower = applied first
-        'agent_types' => ['all']  // 'all', 'pipeline', 'chat', or array
+        'modes' => ['all']  // 'all', 'pipeline', 'chat', 'system', or extension mode
     ];
 
     $directives[] = [
         'class' => MyPipelineDirective::class,
         'priority' => 30,
-        'agent_types' => ['pipeline']
+        'modes' => ['pipeline']
     ];
 
     return $directives;
@@ -1107,7 +1100,7 @@ This filter, the strategy definition shape, the callback signature, and the retu
 [
     'class' => DirectiveClass::class,   // Directive class name
     'priority' => 20,                    // Priority (lower = applied first)
-    'agent_types' => ['all']             // 'all', 'pipeline', 'chat', or array
+    'modes' => ['all']                   // 'all', 'pipeline', 'chat', 'system', or extension mode
 ]
 ```
 
@@ -1119,14 +1112,14 @@ add_filter('datamachine_directives', function($directives) {
     $directives[] = [
         'class' => MyGlobalDirective::class,
         'priority' => 25,
-        'agent_types' => ['all']
+        'modes' => ['all']
     ];
 
     // Pipeline-specific directive
     $directives[] = [
         'class' => MyPipelineDirective::class,
         'priority' => 35,
-        'agent_types' => ['pipeline']
+        'modes' => ['pipeline']
     ];
 
     return $directives;
@@ -1135,16 +1128,15 @@ add_filter('datamachine_directives', function($directives) {
 
 **Priority Guidelines**:
 
-- **10-19**: Core agent identity and foundational instructions
-- **20-29**: Global system prompts and universal behavior
-- **30-39**: Agent-specific system prompts and context
-- **40-49**: Workflow and execution context directives
-- **50+**: Environmental and site-specific directives
+- **20**: Registered memory files
+- **22**: Runtime agent-mode guidance
+- **25-35**: Caller, daily memory, and client-reported context
+- **40-50**: Pipeline, flow, chat inventory, and workflow-specific directives
 
 ### `datamachine_global_directives` (LEGACY — use `datamachine_directives`)
 
 **Deprecated**: v0.2.5
-**Replacement**: Use `datamachine_directives` with `agent_types => ['all']`
+**Replacement**: Use `datamachine_directives` with `modes => ['all']`
 
 **Purpose**: Modify global AI system directives applied across all AI interactions (pipeline + chat)
 
@@ -1165,7 +1157,7 @@ add_filter('datamachine_directives', function($directives) {
     $directives[] = [
         'class' => MyGlobalDirective::class,
         'priority' => 25,
-        'agent_types' => ['all']
+        'modes' => ['all']
     ];
     return $directives;
 });
@@ -1174,14 +1166,14 @@ add_filter('datamachine_directives', function($directives) {
 ### `datamachine_agent_directives` (LEGACY — use `datamachine_directives`)
 
 **Deprecated**: v0.2.5
-**Replacement**: Use `datamachine_directives` with agent-specific `agent_types` targeting
+**Replacement**: Use `datamachine_directives` with mode-specific `modes` targeting
 
 **Purpose**: Modify AI system directives for specific agent types (pipeline or chat)
 
 **Parameters**:
 
 - `$request` (array) - Current AI request being built
-- `$agent_type` (string) - Agent type ('pipeline' or 'chat')
+- `$agent_type` (string) - Legacy agent type ('pipeline' or 'chat')
 - `$provider` (string) - AI provider (openai, anthropic, etc.)
 - `$tools` (array) - Available tools for the agent
 - `$context` (array) - Agent-specific context data
@@ -1207,7 +1199,7 @@ add_filter('datamachine_directives', function($directives) {
     $directives[] = [
         'class' => MyPipelineDirective::class,
         'priority' => 30,
-        'agent_types' => ['pipeline']
+        'modes' => ['pipeline']
     ];
     return $directives;
 });
@@ -1487,7 +1479,7 @@ apply_filters(
 );
 ```
 
-Return an [`AgentMemoryStoreInterface`](../../../agents-api/inc/Core/FilesRepository/AgentMemoryStoreInterface.php)
+Return an `AgentMemoryStoreInterface`
 implementation to replace the disk default for this scope. Return `null` (the
 default) to let Data Machine read and write through the filesystem.
 


### PR DESCRIPTION
## Summary
- Refresh docs to describe current agent modes and `AgentModeDirective` instead of removed context/directive surfaces.
- Update WP-CLI, system task, memory, and directive docs against the current command/code surface.
- Clarify that workspace and GitHub functionality lives in the `data-machine-code` extension, not Data Machine core.

## Verification
- `studio wp help datamachine`
- `studio wp help datamachine-code workspace`
- UTF-8 local markdown link/path check for changed docs
- `git diff --check`
- Targeted stale-term grep for the drift fixed in this PR

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited the docs against local code/WP-CLI help, drafted the documentation updates, and ran lightweight verification. Chris remains responsible for review and merge.