### PR TITLE
Document Agents API runtime substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Data Machine turns a WordPress site into an agent runtime — persistent identit
 - **Multi-agent** — Multiple agents with scoped pipelines, flows, jobs, and filesystem directories
 - **Self-scheduling** — Agents schedule their own recurring tasks using flows, prompt queues, and Agent Pings
 
+Data Machine builds on [Agents API](https://github.com/Automattic/agents-api) for generic agent runtime contracts and durable agent primitives. Data Machine owns the WordPress automation product layer: pipelines, flows, jobs, handlers, tools, abilities, memory files, system tasks, and admin/CLI surfaces.
+
 ## Architecture
 
 ### Pipelines
@@ -227,7 +229,7 @@ OpenAI, Anthropic, Google, Grok, OpenRouter — configure a global default per-s
 
 ## Runtime Adapters
 
-Data Machine ships its own multi-turn conversation loop and uses it by default. The loop is also swappable: a single Agents API-shaped filter (`agents_api_conversation_runner`) lets an external runtime take over while Data Machine still provides pipelines, flows, tool resolution, abilities, and memory.
+Data Machine's runtime seams use Agents API vocabulary. The conversation loop is swappable through `agents_api_conversation_runner`, letting another durable agent runtime take over while Data Machine still provides pipelines, flows, jobs, tool resolution, abilities, and memory integration.
 
 ```php
 add_filter(


### PR DESCRIPTION
## Summary
- Add an explicit README link to the Agents API repository.
- Clarify that Data Machine builds on Agents API for generic runtime contracts and durable agent primitives while owning the WordPress automation product layer.
- Update runtime adapter wording to use Agents API vocabulary.

## Verification
- README local markdown link check
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the README wording and ran lightweight verification. Chris remains responsible for review and merge.