### PR TITLE
Fix plugin-owned bundle artifact package projection

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -930,7 +930,7 @@ class AgentBundler {
 	}
 
 	private static function artifact_key( string $type, string $id ): string {
-		return sanitize_key( $type ) . ':' . $id;
+		return AgentBundleArtifactExtensions::artifact_key( $type, $id );
 	}
 
 	private function preserve_runtime_queue_fields( array $incoming_flow_config, array $existing_flow_config ): array {

--- a/inc/Engine/Bundle/AgentBundleArtifactExtensions.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactExtensions.php
@@ -93,7 +93,7 @@ final class AgentBundleArtifactExtensions {
 		$normalized = array();
 
 		foreach ( $artifacts as $artifact ) {
-			$type        = self::sanitize_key( (string) ( $artifact['artifact_type'] ?? '' ) );
+			$type        = self::sanitize_artifact_type( (string) ( $artifact['artifact_type'] ?? '' ) );
 			$id          = trim( (string) ( $artifact['artifact_id'] ?? '' ) );
 			$source_path = self::source_path( (string) ( $artifact['source_path'] ?? '' ), $type, $id );
 			if ( '' === $type || '' === $id || ! in_array( $type, $allowed, true ) ) {
@@ -139,6 +139,28 @@ final class AgentBundleArtifactExtensions {
 
 	private static function default_source_path( string $type, string $id ): string {
 		return BundleSchema::EXTENSIONS_DIR . '/' . $type . '/' . self::sanitize_path_id( $id ) . '.json';
+	}
+
+	public static function package_artifact_type( string $artifact_type ): string {
+		$artifact_type = self::sanitize_artifact_type( $artifact_type );
+		if ( str_contains( $artifact_type, '/' ) ) {
+			return $artifact_type;
+		}
+
+		return 'datamachine-extension/' . $artifact_type;
+	}
+
+	public static function artifact_key( string $artifact_type, string $artifact_id ): string {
+		return self::sanitize_artifact_type( $artifact_type ) . ':' . $artifact_id;
+	}
+
+	private static function sanitize_artifact_type( string $type ): string {
+		$type = strtolower( trim( str_replace( '\\', '/', $type ) ) );
+		$type = preg_replace( '/[^a-z0-9_\.\/-]+/', '', $type );
+		$type = preg_replace( '#/+#', '/', is_string( $type ) ? $type : '' );
+		$type = trim( is_string( $type ) ? $type : '', '/' );
+
+		return $type;
 	}
 
 	private static function sanitize_key( string $key ): string {

--- a/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
@@ -80,7 +80,7 @@ final class AgentBundleUpgradePendingAction {
 			if ( ! is_array( $artifact ) ) {
 				continue;
 			}
-			$key = sanitize_key( (string) ( $artifact['artifact_type'] ?? '' ) ) . ':' . (string) ( $artifact['artifact_id'] ?? '' );
+			$key = AgentBundleArtifactExtensions::artifact_key( (string) ( $artifact['artifact_type'] ?? '' ), (string) ( $artifact['artifact_id'] ?? '' ) );
 			if ( ! isset( $approved[ $key ] ) ) {
 				$skipped[] = array(
 					'artifact_key' => $key,

--- a/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePlanner.php
@@ -202,7 +202,7 @@ final class AgentBundleUpgradePlanner {
 	}
 
 	private static function artifact_key( string $type, string $id ): string {
-		return sanitize_key( $type ) . ':' . $id;
+		return AgentBundleArtifactExtensions::artifact_key( $type, $id );
 	}
 
 	private static function artifact_hash( ?array $artifact ): ?string {

--- a/inc/Engine/Bundle/AgentPackageProjection.php
+++ b/inc/Engine/Bundle/AgentPackageProjection.php
@@ -129,6 +129,26 @@ final class AgentPackageProjection {
 			}
 		}
 
+		foreach ( $directory->extension_artifacts() as $artifact ) {
+			$artifact_id   = (string) ( $artifact['artifact_id'] ?? '' );
+			$artifact_type = (string) ( $artifact['artifact_type'] ?? '' );
+			$source_path   = (string) ( $artifact['source_path'] ?? '' );
+			if ( '' === $artifact_id || '' === $artifact_type || '' === $source_path ) {
+				continue;
+			}
+
+			$artifacts[] = self::artifact(
+				AgentBundleArtifactExtensions::package_artifact_type( $artifact_type ),
+				$artifact_id,
+				$artifact_id,
+				$source_path,
+				array(
+					'extension_artifact_type' => $artifact_type,
+					'payload_kind'            => 'json',
+				)
+			);
+		}
+
 		return $artifacts;
 	}
 

--- a/inc/Engine/Bundle/BundleSchema.php
+++ b/inc/Engine/Bundle/BundleSchema.php
@@ -74,7 +74,7 @@ final class BundleSchema {
 
 		$normalized = array();
 		foreach ( $types as $type ) {
-			$type = self::sanitize_key( (string) $type );
+			$type = self::sanitize_artifact_type( (string) $type );
 			if ( '' !== $type ) {
 				$normalized[] = $type;
 			}
@@ -92,6 +92,15 @@ final class BundleSchema {
 		}
 
 		return call_user_func_array( 'apply_filters', array( $hook, $value ) );
+	}
+
+	private static function sanitize_artifact_type( string $type ): string {
+		$type = strtolower( trim( str_replace( '\\', '/', $type ) ) );
+		$type = preg_replace( '/[^a-z0-9_\.\/-]+/', '', $type );
+		$type = preg_replace( '#/+#', '/', is_string( $type ) ? $type : '' );
+		$type = trim( is_string( $type ) ? $type : '', '/' );
+
+		return $type;
 	}
 
 	private static function sanitize_key( string $key ): string {

--- a/tests/agent-bundle-extension-artifacts-smoke.php
+++ b/tests/agent-bundle-extension-artifacts-smoke.php
@@ -145,6 +145,7 @@ add_filter(
 	'datamachine_agent_bundle_artifact_types',
 	static function ( array $types ): array {
 		$types[] = 'fake_plugin_artifact';
+		$types[] = 'intelligence/wiki-brain';
 		return $types;
 	},
 	10,
@@ -186,7 +187,7 @@ add_filter(
 	'datamachine_agent_bundle_apply_artifact',
 	static function ( $result, array $artifact, array $agent, array $context ) use ( &$applied ) {
 		unset( $context );
-		if ( 'fake_plugin_artifact' !== ( $artifact['artifact_type'] ?? '' ) ) {
+		if ( ! in_array( $artifact['artifact_type'] ?? '', array( 'fake_plugin_artifact', 'intelligence/wiki-brain' ), true ) ) {
 			return $result;
 		}
 		$applied[] = array( 'id' => $artifact['artifact_id'], 'agent' => $agent['agent_slug'] ?? '' );
@@ -201,6 +202,7 @@ echo "=== Agent Bundle Extension Artifact Smoke (#1577) ===\n";
 echo "\n[1] Plugins register artifact types and export/current artifacts\n";
 $types = DataMachine\Engine\Bundle\BundleSchema::artifact_types();
 assert_extension_bundle( 'fake plugin type is registered', in_array( 'fake_plugin_artifact', $types, true ) );
+assert_extension_bundle( 'namespaced plugin type is registered', in_array( 'intelligence/wiki-brain', $types, true ) );
 
 $agent            = array( 'agent_id' => 7, 'agent_slug' => 'bundle-agent' );
 $export_artifacts = AgentBundleArtifactExtensions::export_artifacts( $agent, array( 'phase' => 'export' ) );
@@ -210,6 +212,19 @@ assert_extension_bundle_equals( 'export artifact payload preserved', 'Seed', $ex
 
 $current_artifacts = AgentBundleArtifactExtensions::current_artifacts( $agent, array( array( 'artifact_id' => 'installed-row' ) ), array( 'phase' => 'plan' ) );
 assert_extension_bundle_equals( 'current hook returns fake artifact', 'fake_plugin_artifact', $current_artifacts[0]['artifact_type'] ?? null );
+
+$namespaced_artifacts = AgentBundleArtifactExtensions::normalize_artifacts(
+	array(
+		array(
+			'artifact_type' => 'intelligence/wiki-brain',
+			'artifact_id'   => 'brain',
+			'payload'       => array( 'root' => 'wordpress-com' ),
+		),
+	)
+);
+assert_extension_bundle_equals( 'namespaced artifact type is preserved', 'intelligence/wiki-brain', $namespaced_artifacts[0]['artifact_type'] ?? null );
+assert_extension_bundle_equals( 'namespaced artifact defaults under extensions', 'extensions/intelligence/wiki-brain/brain.json', $namespaced_artifacts[0]['source_path'] ?? null );
+assert_extension_bundle_equals( 'namespaced artifact apply routes to plugin callback', array( 'applied' => 'brain' ), AgentBundleArtifactExtensions::apply_artifact( $namespaced_artifacts[0], $agent ) );
 
 echo "\n[2] Directory bundles persist plugin artifacts under extensions/\n";
 $manifest = new AgentBundleManifest(
@@ -257,6 +272,7 @@ assert_extension_bundle_equals( 'locally modified plugin artifact needs approval
 assert_extension_bundle( 'raw local plugin secret is absent from plan', false === strpos( extension_json_encode( $modified_plan ), 'local-secret-token' ) );
 
 echo "\n[4] PendingAction apply routes approved plugin artifacts to plugin callback\n";
+$applied      = array();
 $apply_result = AgentBundleUpgradePendingAction::apply(
 	array(
 		'agent'              => $agent,

--- a/tests/agents-api-smoke-helpers.php
+++ b/tests/agents-api-smoke-helpers.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $GLOBALS['__agents_api_smoke_actions'] = array();
+$GLOBALS['__agents_api_smoke_filters'] = array();
 $GLOBALS['__agents_api_smoke_wrong']   = array();
 $GLOBALS['__agents_api_smoke_current'] = array();
 $GLOBALS['__agents_api_smoke_done']    = array();
@@ -29,6 +30,23 @@ function sanitize_file_name( string $value ): string {
 function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
 	unset( $accepted_args );
 	$GLOBALS['__agents_api_smoke_actions'][ $hook ][ $priority ][] = $callback;
+}
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['__agents_api_smoke_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	$callbacks = $GLOBALS['__agents_api_smoke_filters'][ $hook ] ?? array();
+	ksort( $callbacks );
+
+	foreach ( $callbacks as $priority_callbacks ) {
+		foreach ( $priority_callbacks as $registration ) {
+			$value = call_user_func_array( $registration[0], array_slice( array_merge( array( $value ), $args ), 0, $registration[1] ) );
+		}
+	}
+
+	return $value;
 }
 
 function do_action( string $hook, ...$args ): void {
@@ -56,6 +74,37 @@ function did_action( string $hook ): int {
 
 function esc_html( string $value ): string {
 	return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
+}
+
+function __( string $text, string $domain = 'default' ): string {
+	unset( $domain );
+	return $text;
+}
+
+function _x( string $text, string $context, string $domain = 'default' ): string {
+	unset( $context, $domain );
+	return $text;
+}
+
+function post_type_exists( string $post_type ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_post_types'][ $post_type ] );
+}
+
+function register_post_type( string $post_type, array $args = array() ): object {
+	$GLOBALS['__agents_api_smoke_post_types'][ $post_type ] = $args;
+	return (object) array( 'name' => $post_type );
+}
+
+function taxonomy_exists( string $taxonomy ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_taxonomies'][ $taxonomy ] );
+}
+
+function register_taxonomy( string $taxonomy, $object_type, array $args = array() ): object {
+	$GLOBALS['__agents_api_smoke_taxonomies'][ $taxonomy ] = array(
+		'object_type' => $object_type,
+		'args'        => $args,
+	);
+	return (object) array( 'name' => $taxonomy );
 }
 
 function _doing_it_wrong( string $function_name, string $message, string $version ): void {

--- a/tests/datamachine-package-artifacts-smoke.php
+++ b/tests/datamachine-package-artifacts-smoke.php
@@ -50,6 +50,16 @@ agents_api_smoke_assert_equals( true, wp_has_agent_package_artifact_type( 'datam
 agents_api_smoke_assert_equals( 'Data Machine pipeline', $pipeline_type instanceof WP_Agent_Package_Artifact_Type ? $pipeline_type->get_label() : '', 'registered type carries Data Machine metadata outside agents-api', $failures, $passes );
 
 echo "\n[2] Bundle directories project to Core-shaped WP_Agent_Package identity:\n";
+add_filter(
+	'datamachine_agent_bundle_artifact_types',
+	static function ( array $types ): array {
+		$types[] = 'intelligence/wiki-brain';
+		$types[] = 'legacy_plugin_artifact';
+		return $types;
+	},
+	10,
+	1
+);
 $directory = new AgentBundleDirectory(
 	new AgentBundleManifest(
 		'2026-04-30T12:00:00Z',
@@ -73,7 +83,10 @@ $directory = new AgentBundleDirectory(
 			'tool_policies' => array( 'read-only-context' ),
 			'auth_refs'     => array( 'github-default' ),
 			'seed_queues'   => array( 'mgs-topic-loop' ),
-			'extensions'    => array(),
+			'extensions'    => array(
+				'extensions/intelligence/wiki-brain/woocommerce.json',
+				'extensions/legacy-plugin/seed.json',
+			),
 			'handler_auth'  => 'refs',
 		)
 	),
@@ -113,6 +126,20 @@ $directory = new AgentBundleDirectory(
 		BundleSchema::TOOL_POLICIES_DIR => array( 'read-only-context.json' => array( 'allow' => array( 'datamachine/search' ) ) ),
 		BundleSchema::AUTH_REFS_DIR     => array( 'github-default.json' => array( 'ref' => 'github:default' ) ),
 		BundleSchema::SEED_QUEUES_DIR   => array( 'mgs-topic-loop.json' => array( 'mode' => 'loop', 'items' => array( 'HPOS' ) ) ),
+	),
+	array(
+		array(
+			'artifact_type' => 'intelligence/wiki-brain',
+			'artifact_id'   => 'woocommerce',
+			'source_path'   => 'extensions/intelligence/wiki-brain/woocommerce.json',
+			'payload'       => array( 'root' => 'woocommerce' ),
+		),
+		array(
+			'artifact_type' => 'legacy_plugin_artifact',
+			'artifact_id'   => 'seed',
+			'source_path'   => 'extensions/legacy-plugin/seed.json',
+			'payload'       => array( 'label' => 'Seed' ),
+		),
 	)
 );
 
@@ -126,14 +153,18 @@ agents_api_smoke_assert_equals( 'pipelines/daily-ingest.json', $artifacts['datam
 agents_api_smoke_assert_equals( 'flows/daily-ingest-flow.json', $artifacts['datamachine/flow:daily-ingest-flow']['source'] ?? '', 'flow artifact keeps package-local source', $failures, $passes );
 agents_api_smoke_assert_equals( 'prompts/extract-facts.md', $artifacts['datamachine/prompt:extract-facts']['source'] ?? '', 'prompt artifact is typed without moving prompt fields into agents-api', $failures, $passes );
 agents_api_smoke_assert_equals( 'seed-queues/mgs-topic-loop.json', $artifacts['datamachine/queue-seed:mgs-topic-loop']['source'] ?? '', 'queue seed artifact is typed as a Data Machine payload', $failures, $passes );
+agents_api_smoke_assert_equals( 'extensions/intelligence/wiki-brain/woocommerce.json', $artifacts['intelligence/wiki-brain:woocommerce']['source'] ?? '', 'namespaced plugin artifact projects with package-relative extension source', $failures, $passes );
+agents_api_smoke_assert_equals( 'extensions/legacy-plugin/seed.json', $artifacts['datamachine-extension/legacy_plugin_artifact:seed']['source'] ?? '', 'legacy plugin artifact maps to generic package namespace', $failures, $passes );
+agents_api_smoke_assert_equals( 'legacy_plugin_artifact', $artifacts['datamachine-extension/legacy_plugin_artifact:seed']['meta']['extension_artifact_type'] ?? '', 'legacy plugin artifact preserves bundle artifact type in metadata', $failures, $passes );
 
 echo "\n[3] Existing bundle paths can read package identity from WP_Agent_Package:\n";
 $legacy_bundle   = AgentBundleLegacyAdapter::to_legacy_bundle( $directory );
 $legacy_package  = AgentBundler::package_from_bundle( $legacy_bundle );
+$legacy_artifacts = datamachine_package_smoke_artifacts_by_type( $legacy_package );
 $command_source  = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Cli/Commands/AgentBundleCommand.php' );
 $bundler_source  = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Core/Agents/AgentBundler.php' );
 agents_api_smoke_assert_equals( 'woocommerce-wiki-package', $legacy_package->get_slug(), 'legacy bundle projection preserves package identity', $failures, $passes );
-agents_api_smoke_assert_equals( 'daily-ingest-flow', $legacy_package->get_artifacts()[0]->get_slug(), 'legacy bundle projection preserves typed artifact payloads', $failures, $passes );
+agents_api_smoke_assert_equals( 'flows/daily-ingest-flow.json', $legacy_artifacts['datamachine/flow:daily-ingest-flow']['source'] ?? '', 'legacy bundle projection preserves typed artifact payloads', $failures, $passes );
 agents_api_smoke_assert_equals( true, str_contains( $command_source, 'AgentBundler::package_from_bundle( $bundle )' ), 'package install/diff summary reads identity through WP_Agent_Package', $failures, $passes );
 agents_api_smoke_assert_equals( true, str_contains( $bundler_source, '\'package\'   => AgentPackageProjection::from_directory( $directory )' ), 'export directory path exposes package projection alongside Data Machine directory', $failures, $passes );
 


### PR DESCRIPTION
## Summary
- Preserve namespaced plugin-owned bundle artifact types such as `intelligence/wiki-brain` while keeping legacy non-namespaced extension types installable.
- Project `AgentBundleDirectory::extension_artifacts()` into `WP_Agent_Package` artifacts with package-relative `extensions/.../*.json` sources.
- Reuse the normalized extension artifact key across diff/apply/install paths and extend smoke coverage for namespaced and legacy plugin artifacts.

## Tests
- `php tests/datamachine-package-artifacts-smoke.php`
- `php tests/agent-bundle-extension-artifacts-smoke.php`
- `php tests/agent-bundle-upgrade-planner-smoke.php`
- `php tests/agent-bundle-installed-artifact-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `vendor/bin/phpcs inc/Core/Agents/AgentBundler.php inc/Engine/Bundle/AgentBundleArtifactExtensions.php inc/Engine/Bundle/AgentBundleUpgradePendingAction.php inc/Engine/Bundle/AgentBundleUpgradePlanner.php inc/Engine/Bundle/AgentPackageProjection.php inc/Engine/Bundle/BundleSchema.php tests/agents-api-smoke-helpers.php tests/datamachine-package-artifacts-smoke.php tests/agent-bundle-extension-artifacts-smoke.php`
- `git diff --check`

Fixes #1730.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the upstream implementation and smoke test updates; Chris remains responsible for review and merge.