### PR TITLE
Clarify Agents API approval boundary docs

### DIFF
--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -43,7 +43,7 @@ Data Machine now treats the standalone `extra-chill/agents-api` package/plugin a
 - `agents-api` must not import Data Machine product namespaces.
 - Data Machine may import and consume `agents-api` as product code.
 - `agents-api` owns runner interfaces, value objects, and generic contracts first; Data Machine keeps `AIConversationLoop` and the built-in compatibility runner while they still carry Data Machine job, flow, handler, logging, transcript, and legacy result-shape assumptions.
-- Data Machine keeps flows, pipelines, jobs, handlers, queues, retention, pending actions, content operations, and admin UI.
+- Data Machine keeps flows, pipelines, jobs, handlers, queues, retention, concrete pending-action storage/resolution, content operations, and admin UI. The generic pending-action / diff-approval contract vocabulary belongs in a later Agents API extraction stage.
 - `agents-api` is backend-only and invisible by default: no admin menus, screens, human CRUD forms, React apps, or Data Machine product UI.
 - Data Machine and other product consumers own any admin/product UI they build on top of the substrate.
 - Standalone extraction means the bounded module now lives in its own plugin/repo with plugin bootstrap, release, dependency, and distribution ceremony.
@@ -74,6 +74,7 @@ Mirror the WordPress Abilities API shape instead of importing Data Machine produ
 | `AgentMemoryStoreInterface` | `WP_Agent_Memory_Store_Interface` | Generic identity tuple needs naming review; Data Machine scaffolding/abilities stay outside the store contract. |
 | `RuntimeToolDeclaration` | `WP_Agent_Tool_Declaration` | Should stay ability-native and run-scoped. |
 | `LoopEventSinkInterface` | `WP_Agent_Run_Event_Sink_Interface` | Useful for logs, streaming, chat UIs, and async workers. |
+| Data Machine pending actions / diff approvals | Future Agents API approval contract | Agents API should own the generic contract/value/envelope/policy vocabulary for approval-gated agent effects. Data Machine keeps the current transient/database implementation, resolver ability, REST route, chat wrapper, product handlers, and permission checks. |
 | REST `datamachine/v1` agent routes | REST `wp-agents/v1` deferred | [#1670](https://github.com/Extra-Chill/data-machine/issues/1670) reserves the namespace but defers public REST controllers from the first standalone extraction. Data Machine product routes stay under `datamachine/v1`. |
 
 ## Registration Lifecycle
@@ -101,6 +102,7 @@ Use these checks before moving anything:
 - If it uses host-specific provider, storage, or implementation vocabulary directly, treat that code as source material only until normalized behind WordPress-shaped contracts.
 - If it only needs to execute a single prompt/model request, it should use `wp-ai-client` directly instead of introducing Agents API.
 - If it needs durable agent runtime behavior, it should use Agents API and let that runtime call `wp-ai-client` directly for provider execution.
+- If it describes approval-gated agent effects, diff envelopes, or action-resolution policy without Data Machine storage/routes/UI, it is an Agents API contract candidate. If it persists, resolves, displays, or permission-checks Data Machine pending actions, it stays a Data Machine adapter/product surface.
 
 ## Backend-Only UI Boundary
 
@@ -181,7 +183,7 @@ The current namespace is intentionally mixed while extraction stays in place. Tr
 | `DataMachine\Engine\AI\Tools\Sources\DataMachineToolRegistrySource`, `Tools\Sources\AdjacentHandlerToolSource`, `Tools\Policy\DataMachineAgentToolPolicyProvider`, `Tools\Policy\DataMachineMandatoryToolPolicy`, `Tools\Policy\DataMachineToolAccessPolicy`, `Tools\ToolManager`, `Tools\ToolPolicyResolver`, `Tools\ToolParameters` payload merging | Data Machine adapter/product | These translate Data Machine handler, pipeline, queue, permission, persisted-agent, and legacy tool registry concepts into runtime inputs. They stay Data Machine. |
 | `DataMachine\Engine\AI\Tools\Global\*` | Data Machine product | Curated product/site-ops tools. Individual capabilities may move to abilities later, but the bundle is not the Agents API registry. |
 | `DataMachine\Engine\AI\System\*` and `System\Tasks\*` | Data Machine product | System tasks, task prompts, retention cleanup, and scheduled maintenance stay in Data Machine. A future Agents API may provide a task contract, not these tasks. |
-| `DataMachine\Engine\AI\Actions\*` | Data Machine product | Pending-action storage, approval policy, and action-resolution abilities stay Data Machine. Generic approval can be designed later without inheriting these tables/routes. |
+| `DataMachine\Engine\AI\Actions\*` | Mixed source material / Data Machine product | Generic pending-action and diff-approval vocabulary should be promoted to Agents API in a later extraction stage, but the current transient/database store, approval resolver implementation, `datamachine/resolve-pending-action`, `datamachine/v1/actions/resolve`, chat wrapper, product handlers, and permission checks stay Data Machine. Do not import non-existent upstream approval classes yet. |
 | `DataMachine\Engine\AI\Memory\*`, `MemoryFileRegistry`, `SectionRegistry`, `ComposableFileGenerator`, `ComposableFileInvalidation` | Data Machine adapter/product | Memory policy artifacts and file composition are Data Machine's operator/product layer around the generic memory store contract. |
 | `PipelineTranscriptPolicy`, `DataMachinePipelineTranscriptPersister`, `DataMachineHandlerCompletionPolicy` | Data Machine adapter | Pipeline/job metadata and adjacent-handler completion are normalized for the runtime through collaborator interfaces, but the implementations stay Data Machine. |
 
@@ -255,7 +257,7 @@ These are plausibly generic implementations, but should not move until naming an
 | `ClientContextDirective` | `inc/Engine/AI/Directives/ClientContextDirective.php` | Generic client-provided context injection. | Candidate if sanitized context contract is public. |
 | `CallerContextDirective` | `inc/Engine/AI/Directives/CallerContextDirective.php` | Generic caller metadata injection. | Candidate if caller context becomes part of Agents API run input. |
 | `ConversationManager` | `inc/Engine/AI/ConversationManager.php` | Formats tool call/result messages and conversation artifacts. | Split message formatting helpers from Data Machine transcript details. |
-| `ToolExecutor` | `inc/Engine/AI/Tools/ToolExecutor.php` | Executes ability-native and legacy tools with policy staging. | Extract only the ability-native execution path; leave Data Machine post tracking and pending-action glue behind. |
+| `ToolExecutor` | `inc/Engine/AI/Tools/ToolExecutor.php` | Executes ability-native and legacy tools with policy staging. | Extract only the ability-native execution path; leave Data Machine post tracking and concrete pending-action glue behind. A future Agents API approval contract can inform this split after its vocabulary exists. |
 | `RuntimeToolDeclaration` validators in tests | `tests/runtime-tool-declaration-smoke.php` | Tests generic declaration shape. | Move with the declaration contract. |
 | `ToolPolicyFilter` | `inc/Engine/AI/Tools/Policy/ToolPolicyFilter.php` | Generic allow/deny/category/capability filter that takes adapter callbacks for access and mandatory-tool preservation. | Move only with a generic access callback contract; Data Machine permission and handler preservation stay in adapters. |
 | `ToolSourceRegistry` | `inc/Engine/AI/Tools/ToolSourceRegistry.php` | Source-provider composition is generic, but the default providers are Data Machine adapters. | Extract the source registry contract separately from `DataMachineToolRegistrySource` and `AdjacentHandlerToolSource`. |
@@ -287,6 +289,7 @@ These should stay in Data Machine as compatibility glue if a generic runtime plu
 | `QueueableTrait` prompt consumption in `AIStep` | `inc/Core/Steps/AI/AIStep.php` | Data Machine flow queue semantics (`static`, `drain`, `loop`) feeding a runtime user-message slot. |
 | `DataMachinePipelineTranscriptPersister` | `inc/Engine/AI/DataMachinePipelineTranscriptPersister.php` | Adapts a pipeline job run to the transcript store. Generic runtime calls the transcript persister contract and does not own job metadata. |
 | `DataMachineHandlerCompletionPolicy` | `inc/Engine/AI/DataMachineHandlerCompletionPolicy.php` | Adapts adjacent-handler completion rules into a runtime completion policy. Generic runtime calls the policy contract and does not own pipeline handler semantics. |
+| `DataMachine\Engine\AI\Actions\*` storage/resolution | `inc/Engine/AI/Actions/**` | Implements Data Machine's pending-action store, product handlers, resolver ability, REST endpoint, chat wrapper, and permission checks. These adapt current product workflows to the planned generic approval vocabulary. |
 | `SystemAgentServiceProvider` task registration | `inc/Engine/AI/System/SystemAgentServiceProvider.php` | Registers Data Machine system tasks into Data Machine scheduling. The generic runtime may supply a task interface, not these tasks. |
 | `AgentCallTask` | `inc/Engine/AI/System/Tasks/AgentCallTask.php` | Bridges scheduled/system tasks into the agent-call primitive. |
 | `AgentBundler` and bundle CLI adapters | `inc/Core/Agents/AgentBundler.php`, `inc/Cli/Commands/AgentBundleCommand.php` | Convert Data Machine pipelines/flows into portable agent bundle artifacts. Bundle primitives may split, but flow/pipeline import/export remains adapter/product. |
@@ -322,7 +325,7 @@ These should stay in Data Machine. They may consume Agents API later, but should
 | Queue modes and config patch queues | flow queue abilities, `QueueableTrait` | Data Machine scheduling/backfill behavior. |
 | Retention tasks | `inc/Engine/AI/System/Tasks/Retention/**`, `RetentionCommand` | Product cleanup for Data Machine tables/files/Action Scheduler state. |
 | Content operations | post, taxonomy, block, alt text, meta description, image, link, IndexNow abilities | Data Machine content automation. |
-| Pending actions store and approval workflows | `inc/Engine/AI/Actions/**` | Generic approval may exist later, but current implementation is product storage/policy. |
+| Pending-action store and approval adapters | `inc/Engine/AI/Actions/**`, `datamachine/resolve-pending-action`, `datamachine/v1/actions/resolve` | Agents API should own the generic pending-action / diff-approval contract vocabulary later; Data Machine keeps today's storage, resolver ability, REST route, chat wrapper, product handlers, and permission checks. |
 | Admin UI and React pipeline editor | `src/`, `inc/Core/Admin/**` | Data Machine product UI. |
 | Global tools for site ops | `WebFetch`, `WordPressPostReader`, analytics/search console/page speed/image tools | Some tools can become abilities, but the curated Data Machine tool bundle is product. |
 | Agent memory CLI command behavior | `MemoryCommand` | Product/operator surface; generic API should define contracts first. |
@@ -423,7 +426,7 @@ These tests currently pin the substrate most relevant to extraction.
 3. Split `AgentRegistry` into a pure registry and a Data Machine reconciler that creates database rows, access rows, directories, and scaffold files.
 4. Rename and stabilize message/result/store interfaces in place before moving namespaces.
 5. Split provider request assembly from `RequestBuilder` so Data Machine directives/logging stay adapter behavior and provider dispatch targets `wp-ai-client`, not `ai-http-client`.
-6. Split `ToolExecutor` into ability-native runtime execution plus Data Machine product hooks for pending actions and post-origin tracking.
+6. Split `ToolExecutor` into ability-native runtime execution plus Data Machine product hooks for post-origin tracking and current pending-action adapters; promote only the generic approval contract/value/envelope/policy vocabulary to Agents API once that upstream stage exists.
 7. Decide whether Agents API owns persistence tables or only contracts plus optional stores.
 8. Keep host-specific provider and storage classes behind adapters. No public contract should require implementation-specific message, agent, or conversation-storage DTOs.
 

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -28,7 +28,8 @@ That module was treated like WordPress core substrate while it lived inside Data
 - Data Machine consumes `agents-api` as product code.
 - `agents-api` must not import Data Machine product namespaces.
 - `agents-api` owns runner interfaces, value objects, and generic contracts first; Data Machine keeps `AIConversationLoop` and the built-in compatibility runner until the loop no longer carries Data Machine job, flow, handler, logging, transcript, or legacy payload/result assumptions.
-- Data Machine keeps flows, pipelines, jobs, handlers, queues, retention, pending actions, content operations, and admin UI.
+- `agents-api` should also own generic pending-action / diff-approval contract vocabulary in a later extraction stage: approval action values, diff/change envelopes, resolver result shapes, and policy/permission-ceiling concepts that are not tied to Data Machine storage or routes.
+- Data Machine keeps flows, pipelines, jobs, handlers, queues, retention, concrete pending-action storage/resolution, content operations, and admin UI.
 - `agents-api` is backend-only and invisible by default: no admin menus, screens, human CRUD forms, React apps, or Data Machine product UI.
 - Data Machine and other product consumers own any admin/product UI they build on top of the substrate.
 - Standalone extraction moves the already-bounded module into its own plugin/repo and adds plugin bootstrap, dependency, release, and distribution ceremony.
@@ -54,7 +55,7 @@ The initial untangling wave is complete:
 
 - Pipeline tool policy translation is separated from generic tool policy filtering.
 - Adjacent handler tools are a Data Machine provider instead of generic source-registry behavior.
-- Ability-native tool execution is separated from Data Machine pending-action and post-tracking decorators.
+- Ability-native tool execution is separated from Data Machine pending-action and post-tracking decorators. The current decorators remain Data Machine product adapters, while their generic approval/diff vocabulary is upstream source material for Agents API.
 - Declarative agent registration is separated from Data Machine materialization.
 - Conversation transcript storage is narrowed behind a transcript facade, and the aggregate chat-product store is documented as a Data Machine compatibility layer rather than the default extraction target.
 - Memory store contracts/value objects live in the in-repo `agents-api/` module; Data Machine still owns the behavior-preserving factory/default store adapter.
@@ -70,7 +71,7 @@ Before standalone extraction, the in-repo module should satisfy these gates:
 
 - `extra-chill/agents-api` loads before Data Machine product runtime bootstraps.
 - A bootstrap smoke can load `agents-api` without Data Machine product code.
-- No `agents-api` file imports `DataMachine\Core\Steps`, `DataMachine\Core\Database\Jobs`, handler, queue, retention, pending-action, admin UI, or content-operation namespaces.
+- No `agents-api` file imports `DataMachine\Core\Steps`, `DataMachine\Core\Database\Jobs`, handler, queue, retention, Data Machine pending-action implementation, admin UI, or content-operation namespaces.
 - No `agents-api` file registers admin menus, admin screens, settings forms, or admin-only UI hooks.
 - Data Machine product code imports the module as a dependency instead of reaching across same-layer runtime/product paths.
 - Provider runtime code targets `wp-ai-client`; no `ai-http-client` fallback is introduced or preserved inside `agents-api`.
@@ -118,7 +119,7 @@ The deferred shape is reserved as a backend substrate namespace, not a Data Mach
 - `GET /wp-agents/v1/agents` may list registered agent definitions that explicitly opt into REST discovery.
 - `GET /wp-agents/v1/agents/{slug}` may read one registered definition.
 - `POST /wp-agents/v1/agents/{slug}/runs` may eventually execute a generic `AgentConversationRequest` through `AgentConversationRunnerInterface`.
-- Any future transcript, memory, run-state, or session routes require separate decisions. They must not inherit Data Machine chat-session switcher, jobs, flows, pipelines, queues, or pending-action vocabulary.
+- Any future transcript, memory, run-state, approval, or session routes require separate decisions. They must not inherit Data Machine chat-session switcher, jobs, flows, pipelines, queues, or concrete pending-action route/storage vocabulary.
 
 The v1 standalone skeleton should therefore document that `wp-agents/v1` is intentionally absent. Data Machine's existing `datamachine/v1` routes remain product REST for flows, pipelines, jobs, chat UI, agent files, and automation surfaces. They may adapt to Agents API contracts later, but they do not define the public substrate.
 
@@ -138,7 +139,7 @@ REST acceptance gates before any future controller lands:
 |---|---|---|
 | In-repo `agents-api/` module loads before Data Machine product runtime and can boot in a smoke without product code. | Must fix | [#1631](https://github.com/Extra-Chill/data-machine/issues/1631), [#1618](https://github.com/Extra-Chill/data-machine/issues/1618) |
 | Public contract candidates live in the module or have a documented reason to stay in Data Machine for compatibility. | Must fix | [#1632](https://github.com/Extra-Chill/data-machine/issues/1632) |
-| No public `agents-api/` contract imports `DataMachine\` product namespaces or requires jobs, flows, pipelines, handlers, queues, pending actions, content operations, or admin UI. | Must fix | [#1631](https://github.com/Extra-Chill/data-machine/issues/1631), [#1672](https://github.com/Extra-Chill/data-machine/issues/1672) |
+| No public `agents-api/` contract imports `DataMachine\` product namespaces or requires jobs, flows, pipelines, handlers, queues, Data Machine pending-action implementations, content operations, or admin UI. Generic approval contracts must use upstream vocabulary, not Data Machine storage/route names. | Must fix | [#1631](https://github.com/Extra-Chill/data-machine/issues/1631), [#1672](https://github.com/Extra-Chill/data-machine/issues/1672) |
 | `WP_Agent`, `WP_Agents_Registry`, `wp_register_agent()`, and registry lifecycle are validated and documented. | Must fix | [#1618](https://github.com/Extra-Chill/data-machine/issues/1618), [#1632](https://github.com/Extra-Chill/data-machine/issues/1632) |
 | Registration helper parity is decided for `wp_get_agent()`, `wp_get_agents()`, `wp_has_agent()`, and `wp_unregister_agent()`. | Must fix | [#1618](https://github.com/Extra-Chill/data-machine/issues/1618) |
 | Agent categories/capabilities decision is recorded: no v1 category registry; future descriptive metadata only. | Complete | [#1669](https://github.com/Extra-Chill/data-machine/issues/1669) |
@@ -147,7 +148,7 @@ REST acceptance gates before any future controller lands:
 | Built-in loop ownership is settled: Data Machine keeps compatibility loop until completion/transcript/provider/logging assumptions are behind generic collaborators. | Must fix | [#1634](https://github.com/Extra-Chill/data-machine/issues/1634) |
 | Provider runtime depends directly on `wp-ai-client`; no `ai-http-client` or `chubes_ai_request` runtime fallback survives inside `agents-api`. | Must fix | [#1633](https://github.com/Extra-Chill/data-machine/issues/1633), [#1027](https://github.com/Extra-Chill/data-machine/issues/1027), [#1660](https://github.com/Extra-Chill/data-machine/issues/1660), [#1661](https://github.com/Extra-Chill/data-machine/issues/1661) |
 | Memory and transcript interfaces are generic and UI-free. Data Machine chat/session switcher/read-state/reporting remain product adapters unless separately adopted. | Must fix | [#1632](https://github.com/Extra-Chill/data-machine/issues/1632), [#1651](https://github.com/Extra-Chill/data-machine/issues/1651) |
-| Data Machine adapters own flows, jobs, pipelines, handlers, pending actions, bundles, queues, retention, content operations, and chat/admin UI. | Must fix | [#1561](https://github.com/Extra-Chill/data-machine/issues/1561), [#1640](https://github.com/Extra-Chill/data-machine/issues/1640), [#1651](https://github.com/Extra-Chill/data-machine/issues/1651) |
+| Data Machine adapters own flows, jobs, pipelines, handlers, concrete pending-action storage/resolution, bundles, queues, retention, content operations, and chat/admin UI. Agents API owns only planned generic approval contract/value/envelope/policy vocabulary. | Must fix | [#1561](https://github.com/Extra-Chill/data-machine/issues/1561), [#1640](https://github.com/Extra-Chill/data-machine/issues/1640), [#1651](https://github.com/Extra-Chill/data-machine/issues/1651) |
 | Standalone skeleton documents that `wp-agents/v1` is absent in v1 and includes no REST controllers until the REST acceptance gates are satisfied. | Must fix | [#1618](https://github.com/Extra-Chill/data-machine/issues/1618), [#1670](https://github.com/Extra-Chill/data-machine/issues/1670) |
 | Optional future stores, sessions, async run state, REST controllers, category parity, and product UI are deferred until the core backend contracts are extractable. | Can follow | [#1596](https://github.com/Extra-Chill/data-machine/issues/1596), [#1670](https://github.com/Extra-Chill/data-machine/issues/1670), [#1669](https://github.com/Extra-Chill/data-machine/issues/1669) |
 
@@ -250,13 +251,24 @@ Target shape:
 - Data Machine reconciler continues to create its rows/access records from registered definitions while Data Machine hosts the substrate.
 - Decide whether Agents API owns persistence tables, only contracts, or optional stores before moving repositories.
 
-### 8. Data Machine Product Still Under `Engine\AI`
+### 8. Pending-Action / Approval Boundary
 
-System tasks, retention tasks, pending actions, and several product tools still live under `Engine\AI`.
+The current Data Machine pending-action implementation is not the upstream contract, but it identifies a generic seam that should be promoted later.
 
 Target shape:
 
-- Do not move these into Agents API.
+- Agents API owns the generic approval contract vocabulary: pending-action/action value objects, diff/change envelopes, resolver result shapes, and policy/permission-ceiling concepts.
+- Data Machine owns the transient/database implementation, `datamachine/resolve-pending-action`, `datamachine/v1/actions/resolve`, the chat wrapper, product handlers, and Data Machine permission checks.
+- Do not import or reference non-existent upstream approval classes from Data Machine yet; phrase current work as source material for the next extraction stage.
+- Keep Data Machine route names and storage keys out of future Agents API public contracts.
+
+### 9. Data Machine Product Still Under `Engine\AI`
+
+System tasks, retention tasks, concrete pending-action adapters, and several product tools still live under `Engine\AI`.
+
+Target shape:
+
+- Do not move these implementations into Agents API.
 - Rename namespaces later if useful, but treat them as Data Machine automation/product surface.
 - Use them as consumers of Agents API, not part of the substrate.
 - Keep `System\*`, `System\Tasks\*`, `System\Tasks\Retention\*`, `Actions\*`, `Tools\Global\*`, `Tools\Sources\DataMachineToolRegistrySource`, `Tools\Sources\AdjacentHandlerToolSource`, `PipelineTranscriptPolicy`, `DataMachinePipelineTranscriptPersister`, and `DataMachineHandlerCompletionPolicy` in the Data Machine adapter/product bucket until there is a narrow, behavior-preserving move.
@@ -292,6 +304,7 @@ Agents API should provide the substrate for those products:
 - Message/result contracts.
 - Conversation runner contract.
 - Tool declaration and execution contracts.
+- Generic pending-action / diff-approval contract vocabulary.
 - Memory store contract and default memory implementations.
 - Conversation transcript contract.
 - Event sink / streaming / observation contract.

--- a/docs/development/agents-api-standalone-skeleton-plan.md
+++ b/docs/development/agents-api-standalone-skeleton-plan.md
@@ -57,7 +57,7 @@ agents-api/
     no-product-imports-smoke.php
 ```
 
-Do not start with admin assets, React code, REST controllers, Data Machine adapters, or persistence tables. Add those only when a later issue proves they are generic substrate instead of product behavior.
+Do not start with admin assets, React code, REST controllers, Data Machine adapters, or persistence tables. Add those only when a later issue proves they are generic substrate instead of product behavior. Pending-action / diff-approval primitives are not part of this first skeleton, but their generic contract vocabulary belongs upstream when the next extraction stage defines it.
 
 ## Plugin Bootstrap
 
@@ -109,10 +109,11 @@ Rules:
 
 - No `wp-agents/v1` REST routes.
 - No admin UI, React app, settings screen, list table, or agent CRUD screen.
-- No Data Machine flow, pipeline, job, queue, handler, retention, pending-action, content-operation, or chat/session-switcher behavior.
+- No Data Machine flow, pipeline, job, queue, handler, retention, concrete pending-action implementation, content-operation, or chat/session-switcher behavior.
 - No default persistence tables unless a separate issue decides that Agents API owns persistence rather than contracts.
 - No built-in Data Machine compatibility loop.
 - No agent category registry. Descriptive metadata can be considered later, but it must not grant permission, visibility, tool access, or memory access.
+- No generic approval classes yet. A later Agents API stage should define pending-action/action values, diff/change envelopes, resolver result shapes, and approval policy vocabulary without importing Data Machine route, table, or handler names.
 - No Intelligence wiki, briefing, digest, or domain-brain vocabulary.
 
 ## First Files To Move
@@ -160,7 +161,8 @@ Data Machine should remain the product adapter after the first skeleton exists:
 - `AIConversationLoop`, `BuiltInAgentConversationRunner`, `RequestBuilder`, `WpAiClientAdapter`, `PromptBuilder`, and Data Machine directive/logging policy until their Data Machine assumptions are removed.
 - Data Machine transcript persister and handler completion policy implementations.
 - `ToolPolicyResolver`, `DataMachineToolRegistrySource`, `AdjacentHandlerToolSource`, legacy `datamachine_tools`, and mandatory adjacent handler preservation.
-- Jobs, flows, pipelines, handlers, retention tasks, pending actions, content abilities, admin UI, chat UI, and bundle import/export adapters.
+- Jobs, flows, pipelines, handlers, retention tasks, concrete pending-action storage/resolution, content abilities, admin UI, chat UI, and bundle import/export adapters.
+- `datamachine/resolve-pending-action`, `datamachine/v1/actions/resolve`, chat pending-action wrappers, product handlers, and Data Machine permission checks until Agents API has a real upstream approval contract to adapt to.
 - `AgentMemoryStoreFactory`, `DiskAgentMemoryStore`, and Data Machine memory file composition until the default-store decision is separate from the interface.
 
 ## Extraction Sequence
@@ -180,7 +182,7 @@ The first physical extraction PR is not complete until these checks pass:
 | Area | Required proof |
 |---|---|
 | Standalone boot | A clean WordPress/PHP smoke loads `agents-api.php`, exposes `AGENTS_API_LOADED`, `wp_register_agent()`, `WP_Agent`, `WP_Agents_Registry`, package artifact helpers, message/result contracts, runtime tool declarations, transcript store interface, and memory store contracts without loading Data Machine classes. |
-| Product boundary | Static smoke proves standalone `agents-api/` imports no `DataMachine\` namespaces and registers no admin menus, settings screens, REST routes, cron hooks, jobs, flows, queues, handlers, retention tasks, pending actions, or content operations. |
+| Product boundary | Static smoke proves standalone `agents-api/` imports no `DataMachine\` namespaces and registers no admin menus, settings screens, REST routes, cron hooks, jobs, flows, queues, handlers, retention tasks, Data Machine pending-action implementations, or content operations. |
 | Data Machine pipeline behavior | A focused Data Machine AI/pipeline smoke still runs through `AIStep`, tool policy, provider request assembly, transcript persistence, and handler-completion behavior after Data Machine consumes the external plugin. |
 | Intelligence wiki behavior | Intelligence wiki create/read/update or wiki-generator smoke still works with Data Machine plus external Agents API. Wiki behavior must remain Intelligence/Data Machine product behavior, not Agents API vocabulary. |
 | Memory store seam | Existing memory store smoke proves `agents_api_memory_store` resolution, guideline-backed memory if available, and Data Machine default memory behavior still work after contracts move out. |
@@ -194,6 +196,7 @@ Do not start the physical extraction issue until these gates are complete or exp
 - Public registration helper parity is settled: `wp_register_agent()`, `wp_get_agent()`, `wp_get_agents()`, `wp_has_agent()`, and `wp_unregister_agent()`.
 - Generic run/result/message/tool/transcript/memory contracts contain no Data Machine pipeline/handler vocabulary.
 - Built-in loop ownership remains Data Machine until Data Machine completion/transcript/provider/logging assumptions are behind generic collaborators.
+- Pending-action / diff-approval vocabulary is tracked as a later Agents API contract stage, while Data Machine keeps current storage, resolver ability, REST route, chat wrapper, product handlers, and permission checks.
 - Provider/admin settings migration off `chubes_ai_*` surfaces is complete or does not leak into standalone skeleton scope.
 - The v1 REST decision remains explicit: `wp-agents/v1` is absent until separate acceptance gates exist.
 - Data Machine adapter/product responsibilities are still documented in the extraction map.


### PR DESCRIPTION
## Summary
- Clarifies that generic pending-action / diff-approval contract vocabulary belongs in a later Agents API extraction stage.
- Keeps Data Machine responsible for current storage, resolver ability, REST route, chat wrapper, product handlers, and permission checks.
- Updates extraction map, pre-extraction audit, and standalone skeleton plan without touching PHP.

## Verification
- `git diff --check -- docs/development/agents-api-extraction-map.md docs/development/agents-api-pre-extraction-audit.md docs/development/agents-api-standalone-skeleton-plan.md`
- Manual targeted grep/read review of the three scoped docs.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** drafted the focused documentation update; Chris reviews before merge.