### PR TITLE
Add generic job retry backoff policy

### DIFF
--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -1,0 +1,458 @@
+<?php
+/**
+ * Generic job retry/backoff policy.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Core\Database\Jobs\Jobs;
+
+/**
+ * Resolves retryability, backoff, throttling, and retry metadata for jobs.
+ */
+class JobRetryPolicy {
+
+	/**
+	 * Default maximum attempts for retryable failures.
+	 */
+	private const DEFAULT_MAX_ATTEMPTS = 3;
+
+	/**
+	 * Default base delay in seconds for exponential backoff.
+	 */
+	private const DEFAULT_BASE_DELAY = 60;
+
+	/**
+	 * Default maximum delay in seconds.
+	 */
+	private const DEFAULT_MAX_DELAY = 3600;
+
+	/**
+	 * Handle a failure before it is finalized.
+	 *
+	 * @param int    $job_id       Job ID.
+	 * @param string $reason       Failure reason.
+	 * @param array  $context_data Failure context.
+	 * @param Jobs   $db_jobs      Jobs repository.
+	 * @return array{retried:bool,exhausted:bool,attempt:int,max_attempts:int,next_retry_at?:string,retry_after?:int,reason?:string}
+	 */
+	public static function maybeRetry( int $job_id, string $reason, array $context_data, Jobs $db_jobs ): array {
+		$engine_data = \datamachine_get_engine_data( $job_id );
+		$engine_data = is_array( $engine_data ) ? $engine_data : array();
+		$job         = $db_jobs->get_job( $job_id );
+		$job         = is_array( $job ) ? $job : array();
+
+		$policy = self::resolvePolicy( $job_id, $reason, $context_data, $engine_data, $job );
+
+		$attempt      = self::currentAttempt( $engine_data ) + 1;
+		$max_attempts = max( 1, (int) ( $policy['max_attempts'] ?? self::DEFAULT_MAX_ATTEMPTS ) );
+
+		if ( empty( $policy['retryable'] ) ) {
+			return array(
+				'retried'      => false,
+				'exhausted'    => false,
+				'attempt'      => $attempt,
+				'max_attempts' => $max_attempts,
+				'reason'       => 'not_retryable',
+			);
+		}
+
+		if ( $attempt >= $max_attempts ) {
+			self::recordPoisonItem( $job_id, $reason, $context_data, $engine_data, $attempt, $max_attempts );
+
+			return array(
+				'retried'      => false,
+				'exhausted'    => true,
+				'attempt'      => $attempt,
+				'max_attempts' => $max_attempts,
+				'reason'       => 'max_attempts_exhausted',
+			);
+		}
+
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			return array(
+				'retried'      => false,
+				'exhausted'    => false,
+				'attempt'      => $attempt,
+				'max_attempts' => $max_attempts,
+				'reason'       => 'action_scheduler_unavailable',
+			);
+		}
+
+		$delay_seconds = self::resolveDelay( $attempt, $policy, $context_data );
+		$timestamp     = time() + $delay_seconds;
+		$flow_step_id  = (string) ( $context_data['flow_step_id'] ?? '' );
+
+		if ( '' === $flow_step_id ) {
+			return array(
+				'retried'      => false,
+				'exhausted'    => false,
+				'attempt'      => $attempt,
+				'max_attempts' => $max_attempts,
+				'reason'       => 'missing_flow_step_id',
+			);
+		}
+
+		self::recordRetry( $job_id, $reason, $context_data, $engine_data, $attempt, $max_attempts, $delay_seconds, $timestamp, $policy );
+		$db_jobs->update_job_status( $job_id, 'pending' );
+
+		$action_id = as_schedule_single_action(
+			$timestamp,
+			'datamachine_execute_step',
+			array(
+				'job_id'       => $job_id,
+				'flow_step_id' => $flow_step_id,
+			),
+			'data-machine'
+		);
+
+		if ( false === $action_id ) {
+			$db_jobs->update_job_status( $job_id, 'processing' );
+			return array(
+				'retried'      => false,
+				'exhausted'    => false,
+				'attempt'      => $attempt,
+				'max_attempts' => $max_attempts,
+				'reason'       => 'retry_schedule_failed',
+			);
+		}
+
+		do_action(
+			'datamachine_log',
+			'warning',
+			'Job retry scheduled by retry policy',
+			array(
+				'job_id'        => $job_id,
+				'flow_step_id'  => $flow_step_id,
+				'attempt'       => $attempt,
+				'max_attempts'  => $max_attempts,
+				'delay_seconds' => $delay_seconds,
+				'action_id'     => $action_id,
+				'reason'        => $reason,
+				'provider'      => $context_data['ai_provider'] ?? $engine_data['provider'] ?? null,
+				'source_type'   => $engine_data['source_type'] ?? null,
+			)
+		);
+
+		return array(
+			'retried'       => true,
+			'exhausted'     => false,
+			'attempt'       => $attempt,
+			'max_attempts'  => $max_attempts,
+			'next_retry_at' => gmdate( 'c', $timestamp ),
+			'retry_after'   => $delay_seconds,
+		);
+	}
+
+	/**
+	 * Resolve retry policy through generic hooks.
+	 *
+	 * @param int    $job_id       Job ID.
+	 * @param string $reason       Failure reason.
+	 * @param array  $context_data Failure context.
+	 * @param array  $engine_data  Job engine data.
+	 * @param array  $job          Job row.
+	 * @return array
+	 */
+	private static function resolvePolicy( int $job_id, string $reason, array $context_data, array $engine_data, array $job ): array {
+		$retryable = self::isRetryableFailure( $reason, $context_data );
+
+		/**
+		 * Filter whether a job failure is retryable.
+		 *
+		 * @param bool   $retryable    Current retryable decision.
+		 * @param int    $job_id       Job ID.
+		 * @param string $reason       Failure reason.
+		 * @param array  $context_data Failure context.
+		 * @param array  $engine_data  Job engine data.
+		 * @param array  $job          Job row.
+		 */
+		$retryable = (bool) apply_filters( 'datamachine_job_error_retryable', $retryable, $job_id, $reason, $context_data, $engine_data, $job );
+
+		$policy = array(
+			'retryable'     => $retryable,
+			'max_attempts'  => self::DEFAULT_MAX_ATTEMPTS,
+			'base_delay'    => self::DEFAULT_BASE_DELAY,
+			'max_delay'     => self::DEFAULT_MAX_DELAY,
+			'backoff'       => 'exponential',
+			'jitter'        => 0,
+			'retry_after'   => self::extractRetryAfter( $context_data ),
+			'provider'      => $context_data['ai_provider'] ?? $engine_data['provider'] ?? null,
+			'source_type'   => $engine_data['source_type'] ?? null,
+			'pipeline_id'   => $job['pipeline_id'] ?? ( $engine_data['job']['pipeline_id'] ?? null ),
+			'flow_id'       => $job['flow_id'] ?? ( $engine_data['job']['flow_id'] ?? null ),
+			'flow_step_id'  => $context_data['flow_step_id'] ?? null,
+		);
+
+		/**
+		 * Filter retry policy for provider, pipeline, system, and source jobs.
+		 *
+		 * Return keys may include retryable, max_attempts, base_delay, max_delay,
+		 * backoff, jitter, and retry_after.
+		 *
+		 * @param array  $policy       Current retry policy.
+		 * @param int    $job_id       Job ID.
+		 * @param string $reason       Failure reason.
+		 * @param array  $context_data Failure context.
+		 * @param array  $engine_data  Job engine data.
+		 * @param array  $job          Job row.
+		 */
+		$policy = apply_filters( 'datamachine_job_retry_policy', $policy, $job_id, $reason, $context_data, $engine_data, $job );
+
+		return is_array( $policy ) ? $policy : array( 'retryable' => false );
+	}
+
+	/**
+	 * Determine a generic retryability default.
+	 *
+	 * @param string $reason       Failure reason.
+	 * @param array  $context_data Failure context.
+	 * @return bool
+	 */
+	private static function isRetryableFailure( string $reason, array $context_data ): bool {
+		if ( isset( $context_data['retryable'] ) ) {
+			return (bool) $context_data['retryable'];
+		}
+
+		if ( null !== self::extractRetryAfter( $context_data ) ) {
+			return true;
+		}
+
+		$message = strtolower( implode( ' ', array_filter( array(
+			$reason,
+			$context_data['error_message'] ?? '',
+			$context_data['exception_message'] ?? '',
+			$context_data['ai_error'] ?? '',
+		) ) ) );
+
+		foreach ( array( 'rate limit', '429', 'timeout', 'timed out', 'temporar', 'try again', 'throttle', 'overloaded', '503', '502', '504' ) as $needle ) {
+			if ( str_contains( $message, $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Resolve delay with Retry-After and provider/source throttling hooks.
+	 *
+	 * @param int   $attempt      Attempt number being scheduled.
+	 * @param array $policy       Retry policy.
+	 * @param array $context_data Failure context.
+	 * @return int
+	 */
+	private static function resolveDelay( int $attempt, array $policy, array $context_data ): int {
+		$retry_after = isset( $policy['retry_after'] ) ? self::normalizeDelay( $policy['retry_after'] ) : null;
+		if ( null === $retry_after ) {
+			$retry_after = self::extractRetryAfter( $context_data );
+		}
+
+		$base_delay = max( 1, (int) ( $policy['base_delay'] ?? self::DEFAULT_BASE_DELAY ) );
+		$max_delay  = max( $base_delay, (int) ( $policy['max_delay'] ?? self::DEFAULT_MAX_DELAY ) );
+		$delay      = $base_delay;
+
+		if ( 'exponential' === ( $policy['backoff'] ?? 'exponential' ) ) {
+			$delay = $base_delay * ( 2 ** max( 0, $attempt - 1 ) );
+		}
+
+		$delay = min( $max_delay, $delay );
+		if ( null !== $retry_after ) {
+			$delay = max( $delay, $retry_after );
+		}
+
+		/**
+		 * Filter per-provider/source throttle delay for retries.
+		 *
+		 * Return a delay in seconds. Data Machine uses the maximum of the backoff,
+		 * Retry-After, and throttle delay so independent policies compose safely.
+		 *
+		 * @param int   $delay        Current delay in seconds.
+		 * @param array $policy       Retry policy.
+		 * @param int   $attempt      Attempt number being scheduled.
+		 * @param array $context_data Failure context.
+		 */
+		$throttle_delay = apply_filters( 'datamachine_job_retry_throttle_delay', $delay, $policy, $attempt, $context_data );
+		$delay          = max( $delay, self::normalizeDelay( $throttle_delay ) ?? 0 );
+
+		$jitter = max( 0, (int) ( $policy['jitter'] ?? 0 ) );
+		if ( $jitter > 0 ) {
+			$delay += wp_rand( 0, $jitter );
+		}
+
+		return max( 0, $delay );
+	}
+
+	/**
+	 * Extract Retry-After from provider/context data.
+	 *
+	 * @param array $context_data Failure context.
+	 * @return int|null Delay in seconds.
+	 */
+	private static function extractRetryAfter( array $context_data ): ?int {
+		foreach ( array( 'retry_after', 'retry_after_seconds', 'retry-after' ) as $key ) {
+			if ( isset( $context_data[ $key ] ) ) {
+				$delay = self::normalizeDelay( $context_data[ $key ] );
+				if ( null !== $delay ) {
+					return $delay;
+				}
+			}
+		}
+
+		$headers = $context_data['headers'] ?? array();
+		if ( is_array( $headers ) ) {
+			foreach ( array( 'retry-after', 'Retry-After' ) as $key ) {
+				if ( isset( $headers[ $key ] ) ) {
+					$delay = self::normalizeDelay( $headers[ $key ] );
+					if ( null !== $delay ) {
+						return $delay;
+					}
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Normalize a delay value to seconds.
+	 *
+	 * @param mixed $value Delay value or HTTP date.
+	 * @return int|null
+	 */
+	private static function normalizeDelay( mixed $value ): ?int {
+		if ( is_array( $value ) ) {
+			$value = reset( $value );
+		}
+
+		if ( is_numeric( $value ) ) {
+			return max( 0, (int) $value );
+		}
+
+		if ( is_string( $value ) && '' !== trim( $value ) ) {
+			$timestamp = strtotime( $value );
+			if ( false !== $timestamp ) {
+				return max( 0, $timestamp - time() );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Current recorded retry attempt count.
+	 *
+	 * @param array $engine_data Job engine data.
+	 * @return int
+	 */
+	private static function currentAttempt( array $engine_data ): int {
+		$retry = $engine_data['retry'] ?? array();
+		if ( is_array( $retry ) && isset( $retry['attempts'] ) ) {
+			return max( 0, (int) $retry['attempts'] );
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Record retry metadata on the job.
+	 *
+	 * @param int    $job_id        Job ID.
+	 * @param string $reason        Failure reason.
+	 * @param array  $context_data  Failure context.
+	 * @param array  $engine_data   Job engine data.
+	 * @param int    $attempt       Attempt number.
+	 * @param int    $max_attempts  Maximum attempts.
+	 * @param int    $delay_seconds Delay in seconds.
+	 * @param int    $timestamp     Retry timestamp.
+	 * @param array  $policy        Retry policy.
+	 * @return void
+	 */
+	private static function recordRetry( int $job_id, string $reason, array $context_data, array $engine_data, int $attempt, int $max_attempts, int $delay_seconds, int $timestamp, array $policy ): void {
+		$history   = is_array( $engine_data['retry']['history'] ?? null ) ? $engine_data['retry']['history'] : array();
+		$history[] = array_filter(
+			array(
+				'attempt'       => $attempt,
+				'max_attempts'  => $max_attempts,
+				'reason'        => $reason,
+				'flow_step_id'  => $context_data['flow_step_id'] ?? null,
+				'provider'      => $policy['provider'] ?? null,
+				'source_type'   => $policy['source_type'] ?? null,
+				'delay_seconds' => $delay_seconds,
+				'next_retry_at' => gmdate( 'c', $timestamp ),
+				'recorded_at'   => gmdate( 'c' ),
+			),
+			fn( $value ) => null !== $value
+		);
+
+		\datamachine_merge_engine_data(
+			$job_id,
+			array(
+				'retry' => array(
+					'attempts'       => $attempt,
+					'max_attempts'   => $max_attempts,
+					'next_retry_at'  => gmdate( 'c', $timestamp ),
+					'delay_seconds'  => $delay_seconds,
+					'last_reason'    => $reason,
+					'last_retryable' => true,
+					'provider'       => $policy['provider'] ?? null,
+					'source_type'    => $policy['source_type'] ?? null,
+					'history'        => $history,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Record poison-item metadata after retry exhaustion.
+	 *
+	 * @param int    $job_id       Job ID.
+	 * @param string $reason       Failure reason.
+	 * @param array  $context_data Failure context.
+	 * @param array  $engine_data  Job engine data.
+	 * @param int    $attempt      Attempt number.
+	 * @param int    $max_attempts Maximum attempts.
+	 * @return void
+	 */
+	private static function recordPoisonItem( int $job_id, string $reason, array $context_data, array $engine_data, int $attempt, int $max_attempts ): void {
+		$poison = array_filter(
+			array(
+				'isolated'        => true,
+				'job_id'          => $job_id,
+				'item_identifier' => $engine_data['item_identifier'] ?? null,
+				'source_type'     => $engine_data['source_type'] ?? null,
+				'flow_step_id'    => $context_data['flow_step_id'] ?? null,
+				'reason'          => $reason,
+				'attempts'        => $attempt,
+				'max_attempts'    => $max_attempts,
+				'recorded_at'     => gmdate( 'c' ),
+			),
+			fn( $value ) => null !== $value
+		);
+
+		\datamachine_merge_engine_data(
+			$job_id,
+			array(
+				'retry'       => array(
+					'attempts'       => $attempt,
+					'max_attempts'   => $max_attempts,
+					'last_reason'    => $reason,
+					'last_retryable' => true,
+					'exhausted'      => true,
+				),
+				'poison_item' => $poison,
+			)
+		);
+
+		do_action(
+			'datamachine_log',
+			'error',
+			'Job retry policy isolated poison item after retry exhaustion',
+			$poison
+		);
+	}
+}

--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -174,18 +174,18 @@ class JobRetryPolicy {
 		$retryable = (bool) apply_filters( 'datamachine_job_error_retryable', $retryable, $job_id, $reason, $context_data, $engine_data, $job );
 
 		$policy = array(
-			'retryable'     => $retryable,
-			'max_attempts'  => self::DEFAULT_MAX_ATTEMPTS,
-			'base_delay'    => self::DEFAULT_BASE_DELAY,
-			'max_delay'     => self::DEFAULT_MAX_DELAY,
-			'backoff'       => 'exponential',
-			'jitter'        => 0,
-			'retry_after'   => self::extractRetryAfter( $context_data ),
-			'provider'      => $context_data['ai_provider'] ?? $engine_data['provider'] ?? null,
-			'source_type'   => $engine_data['source_type'] ?? null,
-			'pipeline_id'   => $job['pipeline_id'] ?? ( $engine_data['job']['pipeline_id'] ?? null ),
-			'flow_id'       => $job['flow_id'] ?? ( $engine_data['job']['flow_id'] ?? null ),
-			'flow_step_id'  => $context_data['flow_step_id'] ?? null,
+			'retryable'    => $retryable,
+			'max_attempts' => self::DEFAULT_MAX_ATTEMPTS,
+			'base_delay'   => self::DEFAULT_BASE_DELAY,
+			'max_delay'    => self::DEFAULT_MAX_DELAY,
+			'backoff'      => 'exponential',
+			'jitter'       => 0,
+			'retry_after'  => self::extractRetryAfter( $context_data ),
+			'provider'     => $context_data['ai_provider'] ?? $engine_data['provider'] ?? null,
+			'source_type'  => $engine_data['source_type'] ?? null,
+			'pipeline_id'  => $job['pipeline_id'] ?? ( $engine_data['job']['pipeline_id'] ?? null ),
+			'flow_id'      => $job['flow_id'] ?? ( $engine_data['job']['flow_id'] ?? null ),
+			'flow_step_id' => $context_data['flow_step_id'] ?? null,
 		);
 
 		/**

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -394,9 +394,12 @@ class AIStep extends Step {
 				$this->job_id,
 				'ai_processing_failed',
 				array(
-					'flow_step_id' => $this->flow_step_id,
-					'ai_error'     => $loop_result['error'],
-					'ai_provider'  => $provider_name,
+					'flow_step_id'        => $this->flow_step_id,
+					'ai_error'            => $loop_result['error'],
+					'ai_provider'         => $provider_name,
+					'retry_after'         => $loop_result['retry_after'] ?? null,
+					'retry_after_seconds' => $loop_result['retry_after_seconds'] ?? null,
+					'headers'             => is_array( $loop_result['headers'] ?? null ) ? $loop_result['headers'] : array(),
 				)
 			);
 			return array();

--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -8,6 +8,8 @@
 
 namespace DataMachine\Engine\Actions\Handlers;
 
+use DataMachine\Core\JobRetryPolicy;
+
 /**
  * Central job failure handling with cleanup, re-queue, and logging.
  */
@@ -42,6 +44,11 @@ class FailJobHandler {
 
 		$specific_reason = $context_data['reason'] ?? $reason;
 		$status          = \DataMachine\Core\JobStatus::failed( $specific_reason );
+		$retry_result    = JobRetryPolicy::maybeRetry( $job_id, (string) $specific_reason, is_array( $context_data ) ? $context_data : array(), $db_jobs );
+
+		if ( ! empty( $retry_result['retried'] ) ) {
+			return true;
+		}
 
 		// Persist structured error context into engine_data so it is
 		// available from `wp datamachine jobs show` without grepping PHP logs.
@@ -55,6 +62,7 @@ class FailJobHandler {
 			'error_trace'   => isset( $context_data['exception_trace'] )
 				? mb_substr( $context_data['exception_trace'], 0, 2000 )
 				: null,
+			'retry_result'  => $retry_result,
 		);
 		// Strip null values so we only store keys that carry information.
 		$error_data = array_filter( $error_data, fn( $v ) => null !== $v );

--- a/tests/job-retry-policy-smoke.php
+++ b/tests/job-retry-policy-smoke.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Pure-PHP smoke test for generic job retry/backoff policy hooks (#1734).
+ *
+ * Run with: php tests/job-retry-policy-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+$failed = 0;
+$total  = 0;
+
+function assert_retry_policy_smoke( string $name, bool $cond, string $detail = '' ): void {
+	global $failed, $total;
+	++$total;
+	if ( $cond ) {
+		echo "  [PASS] $name\n";
+		return;
+	}
+
+	echo "  [FAIL] $name" . ( $detail ? " - $detail" : '' ) . "\n";
+	++$failed;
+}
+
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+	$args;
+	return $value;
+}
+
+function do_action( string $hook, mixed ...$args ): void {
+	$hook;
+	$args;
+}
+
+function wp_rand( int $min, int $max ): int {
+	$max;
+	return $min;
+}
+
+require_once __DIR__ . '/../inc/Core/JobRetryPolicy.php';
+
+$reflection          = new ReflectionClass( DataMachine\Core\JobRetryPolicy::class );
+$extract_retry_after = $reflection->getMethod( 'extractRetryAfter' );
+$normalize_delay     = $reflection->getMethod( 'normalizeDelay' );
+$is_retryable        = $reflection->getMethod( 'isRetryableFailure' );
+$resolve_delay       = $reflection->getMethod( 'resolveDelay' );
+
+echo "Case 1: Retry-After values are normalized\n";
+assert_retry_policy_smoke( 'numeric Retry-After is seconds', 90 === $extract_retry_after->invoke( null, array( 'retry_after' => '90' ) ) );
+assert_retry_policy_smoke( 'header Retry-After is seconds', 45 === $extract_retry_after->invoke( null, array( 'headers' => array( 'Retry-After' => 45 ) ) ) );
+assert_retry_policy_smoke( 'HTTP-date Retry-After normalizes to non-negative delay', null !== $normalize_delay->invoke( null, gmdate( 'D, d M Y H:i:s \G\M\T', time() + 120 ) ) );
+
+echo "Case 2: Generic transient/provider failures are retryable by default\n";
+assert_retry_policy_smoke( 'explicit retryable flag wins', true === $is_retryable->invoke( null, 'custom_failure', array( 'retryable' => true ) ) );
+assert_retry_policy_smoke( 'Retry-After implies retryable', true === $is_retryable->invoke( null, 'provider_error', array( 'retry_after' => 10 ) ) );
+assert_retry_policy_smoke( 'rate-limit text implies retryable', true === $is_retryable->invoke( null, 'ai_processing_failed', array( 'ai_error' => 'Provider returned 429 rate limit' ) ) );
+assert_retry_policy_smoke( 'validation-style failures are not retryable by default', false === $is_retryable->invoke( null, 'missing_flow_id_in_step_config', array() ) );
+
+echo "Case 3: Backoff composes with Retry-After\n";
+$delay = $resolve_delay->invoke(
+	null,
+	2,
+	array(
+		'base_delay'  => 30,
+		'max_delay'   => 600,
+		'backoff'     => 'exponential',
+		'retry_after' => 300,
+	),
+	array()
+);
+assert_retry_policy_smoke( 'Retry-After is a floor over exponential backoff', 300 === $delay, 'delay was ' . $delay );
+
+echo "Case 4: Production code exposes retry/backoff hooks and metadata\n";
+$policy_src = file_get_contents( __DIR__ . '/../inc/Core/JobRetryPolicy.php' ) ?: '';
+$fail_src   = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Handlers/FailJobHandler.php' ) ?: '';
+$ai_src     = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' ) ?: '';
+
+assert_retry_policy_smoke( 'policy exposes retryable-error hook', str_contains( $policy_src, 'datamachine_job_error_retryable' ) );
+assert_retry_policy_smoke( 'policy exposes retry policy hook', str_contains( $policy_src, 'datamachine_job_retry_policy' ) );
+assert_retry_policy_smoke( 'policy exposes provider/source throttle hook', str_contains( $policy_src, 'datamachine_job_retry_throttle_delay' ) );
+assert_retry_policy_smoke( 'policy records retry metadata', str_contains( $policy_src, "'retry'" ) && str_contains( $policy_src, "'history'" ) );
+assert_retry_policy_smoke( 'policy records poison item isolation metadata', str_contains( $policy_src, "'poison_item'" ) );
+assert_retry_policy_smoke( 'fail handler tries retry before final failure', strpos( $fail_src, 'maybeRetry' ) < strpos( $fail_src, 'complete_job' ) );
+assert_retry_policy_smoke( 'AI failures pass retry-after context', str_contains( $ai_src, "'retry_after'" ) && str_contains( $ai_src, "'headers'" ) );
+
+echo "\nJob retry policy smoke complete: {$total} assertions, {$failed} failures.\n";
+if ( $failed > 0 ) {
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Adds a generic `JobRetryPolicy` on the central `datamachine_fail_job` path for retryability hooks, max attempts, exponential backoff, Retry-After support, and provider/source throttling.
- Records retry metadata and poison-item isolation details in job `engine_data` so operators can inspect retries and exhausted failures.
- Threads AI provider Retry-After/header metadata into the failure path and adds focused smoke coverage for policy behavior.

Closes #1734.

## Testing
- `php -l inc/Core/JobRetryPolicy.php && php -l inc/Engine/Actions/Handlers/FailJobHandler.php && php -l inc/Core/Steps/AI/AIStep.php && php -l tests/job-retry-policy-smoke.php`
- `php tests/job-retry-policy-smoke.php`
- `vendor/bin/phpcs inc/Core/JobRetryPolicy.php inc/Engine/Actions/Handlers/FailJobHandler.php inc/Core/Steps/AI/AIStep.php tests/job-retry-policy-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@job-retry-backoff-policy`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and focused smoke coverage; Chris remains responsible for review and testing.