### PR TITLE
Expose generic run metrics

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -239,6 +239,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\Job\ProblemFlowsAbility();
 	new \DataMachine\Abilities\Job\RecoverStuckJobsAbility();
 	new \DataMachine\Abilities\Job\JobsSummaryAbility();
+	new \DataMachine\Abilities\Job\RunMetricsAbility();
 	new \DataMachine\Abilities\Job\FailJobAbility();
 	new \DataMachine\Abilities\Job\RetryJobAbility();
 	new \DataMachine\Abilities\LogAbilities();

--- a/inc/Abilities/Job/RetryJobAbility.php
+++ b/inc/Abilities/Job/RetryJobAbility.php
@@ -115,6 +115,7 @@ class RetryJobAbility {
 		$engine_data = $this->db_jobs->retrieve_engine_data( $job_id );
 
 		// Mark as failed for retry.
+		\DataMachine\Core\RunMetrics::increment( $job_id, 'retried' );
 		$this->db_jobs->complete_job( $job_id, 'failed - manual_retry' );
 
 		do_action( 'datamachine_job_complete', $job_id, 'failed' );

--- a/inc/Abilities/Job/RunMetricsAbility.php
+++ b/inc/Abilities/Job/RunMetricsAbility.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Run Metrics Ability.
+ *
+ * @package DataMachine\Abilities\Job
+ */
+
+namespace DataMachine\Abilities\Job;
+
+use DataMachine\Core\RunMetrics;
+
+defined( 'ABSPATH' ) || exit;
+
+class RunMetricsAbility {
+
+	use JobHelpers;
+
+	public function __construct() {
+		$this->initDatabases();
+		$this->registerAbility();
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/get-run-metrics',
+				array(
+					'label'               => __( 'Get Run Metrics', 'data-machine' ),
+					'description'         => __( 'Get generic run metrics for a flow, pipeline, batch, or system-task job.', 'data-machine' ),
+					'category'            => 'datamachine-jobs',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'job_id' ),
+						'properties' => array(
+							'job_id' => array(
+								'type'        => 'integer',
+								'minimum'     => 1,
+								'description' => __( 'Job ID whose run metrics should be returned.', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'metrics' => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function execute( array $input ): array {
+		$job_id = (int) ( $input['job_id'] ?? 0 );
+		if ( $job_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'job_id must be a positive integer.',
+			);
+		}
+
+		$job = $this->db_jobs->get_job( $job_id );
+		if ( ! $job ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Job %d not found.', $job_id ),
+			);
+		}
+
+		$jobs = $this->enrichJobNames( array( $job ) );
+		$job  = $this->addDisplayFields( $jobs[0] );
+
+		return array(
+			'success' => true,
+			'metrics' => RunMetrics::fromJob( $job ),
+		);
+	}
+}

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -21,6 +21,7 @@ use DataMachine\Abilities\Job\GetJobsAbility;
 use DataMachine\Abilities\Job\JobsSummaryAbility;
 use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Abilities\Job\RetryJobAbility;
+use DataMachine\Abilities\Job\RunMetricsAbility;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
 use AgentsAPI\AI\AgentMessageEnvelope;
@@ -878,6 +879,88 @@ class JobsCommand extends BaseCommand {
 		}
 
 		$this->format_items( $items, array( 'status', 'count' ), $assoc_args );
+	}
+
+	/**
+	 * Show run metrics for a job.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <job_id>
+	 * : The job ID to inspect.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Show run metrics for a long backfill parent job
+	 *     wp datamachine jobs metrics 844
+	 *
+	 *     # Machine-readable metrics
+	 *     wp datamachine jobs metrics 844 --format=json
+	 *
+	 * @subcommand metrics
+	 */
+	public function metrics( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) || ! is_numeric( $args[0] ) || (int) $args[0] <= 0 ) {
+			WP_CLI::error( 'Job ID is required and must be a positive integer.' );
+			return;
+		}
+
+		$result = ( new RunMetricsAbility() )->execute( array( 'job_id' => (int) $args[0] ) );
+		if ( ! $result['success'] ) {
+			WP_CLI::error( $result['error'] ?? 'Unknown error occurred' );
+			return;
+		}
+
+		$metrics = $result['metrics'] ?? array();
+		$format  = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $metrics, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		if ( 'yaml' === $format ) {
+			/** @phpstan-ignore-next-line Spyc is provided by WP-CLI at runtime. */
+			WP_CLI::log( (string) call_user_func( array( 'Spyc', 'YAMLDump' ), $metrics, false, false, true ) );
+			return;
+		}
+
+		$counts     = $metrics['counts'] ?? array();
+		$children   = $metrics['child_jobs'] ?? array();
+		$timestamps = $metrics['timestamps'] ?? array();
+
+		WP_CLI::log( sprintf( 'Job ID: %d', $metrics['job_id'] ?? 0 ) );
+		WP_CLI::log( sprintf( 'Status: %s', $metrics['status'] ?? '' ) );
+		WP_CLI::log( sprintf( 'Source: %s', $metrics['source'] ?? '' ) );
+		WP_CLI::log( sprintf( 'Label: %s', $metrics['label'] ?? '' ) );
+		WP_CLI::log( sprintf( 'Flow ID: %s', $metrics['flow_id'] ?? 'N/A' ) );
+		WP_CLI::log( sprintf( 'Pipeline ID: %s', $metrics['pipeline_id'] ?? 'N/A' ) );
+		WP_CLI::log( sprintf( 'Started: %s', $timestamps['started_at'] ?? '-' ) );
+		WP_CLI::log( sprintf( 'Last Activity: %s', $timestamps['last_activity_at'] ?? '-' ) );
+		WP_CLI::log( sprintf( 'Completed: %s', $timestamps['completed_at'] ?? '-' ) );
+		WP_CLI::log( sprintf( 'Duration: %s seconds', null === ( $metrics['duration_seconds'] ?? null ) ? '-' : (string) $metrics['duration_seconds'] ) );
+		WP_CLI::log( '' );
+
+		WP_CLI::log( 'Counts:' );
+		foreach ( $counts as $key => $value ) {
+			WP_CLI::log( sprintf( '  %s: %d', $key, (int) $value ) );
+		}
+		WP_CLI::log( '' );
+
+		WP_CLI::log( 'Child Jobs:' );
+		foreach ( $children as $key => $value ) {
+			WP_CLI::log( sprintf( '  %s: %d', $key, (int) $value ) );
+		}
 	}
 
 	/**

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -176,6 +176,15 @@ class BatchScheduler {
 			)
 		);
 
+		\DataMachine\Core\RunMetrics::start(
+			$parent_job_id,
+			array(
+				'batch_context'             => $context,
+				'batch_total'               => $total,
+				'batch_completion_strategy' => $completion_strategy,
+			)
+		);
+
 		if ( function_exists( 'as_schedule_single_action' ) ) {
 			as_schedule_single_action(
 				time(),

--- a/inc/Core/Database/Jobs/JobsStatus.php
+++ b/inc/Core/Database/Jobs/JobsStatus.php
@@ -16,6 +16,7 @@ namespace DataMachine\Core\Database\Jobs;
 
 use DataMachine\Core\Database\BaseRepository;
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\RunMetrics;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -46,6 +47,10 @@ class JobsStatus extends BaseRepository {
 			array( '%s' ), // Format for data
 			array( '%d' )  // Format for WHERE
 		);
+
+		if ( false !== $updated ) {
+			RunMetrics::start( $job_id, array( 'status' => $status ) );
+		}
 
 		return false !== $updated;
 	}
@@ -85,6 +90,7 @@ class JobsStatus extends BaseRepository {
 		);
 
 		if ( false !== $updated ) {
+			RunMetrics::complete( $job_id, $status );
 			do_action( 'datamachine_job_complete', $job_id, $status );
 		}
 

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Generic run metrics helpers.
+ *
+ * Stores durable, generic progress counters in job engine_data so long flow,
+ * pipeline, batch, and system-task runs can report progress without owning a
+ * domain-specific metrics table.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+class RunMetrics {
+
+	private const KEY = 'run_metrics';
+
+	private const COUNT_KEYS = array(
+		'processed',
+		'skipped',
+		'failed',
+		'retried',
+		'scheduled',
+		'staged_actions',
+		'accepted_actions',
+		'rejected_actions',
+	);
+
+	public static function start( int $job_id, array $context = array() ): bool {
+		if ( $job_id <= 0 ) {
+			return false;
+		}
+
+		$engine  = EngineData::retrieve( $job_id );
+		$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
+		$now     = self::now();
+
+		if ( empty( $metrics['started_at'] ) ) {
+			$metrics['started_at'] = $now;
+		}
+		$metrics['last_activity_at'] = $now;
+
+		if ( ! empty( $context ) ) {
+			$metrics['context'] = array_replace_recursive(
+				is_array( $metrics['context'] ?? null ) ? $metrics['context'] : array(),
+				self::sanitizeContext( $context )
+			);
+		}
+
+		$engine[ self::KEY ] = $metrics;
+		return EngineData::persist( $job_id, $engine );
+	}
+
+	public static function increment( int $job_id, string $key, int $amount = 1 ): bool {
+		if ( $job_id <= 0 || $amount <= 0 ) {
+			return false;
+		}
+
+		$engine  = EngineData::retrieve( $job_id );
+		$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
+
+		if ( ! isset( $metrics['counts'][ $key ] ) ) {
+			$metrics['counts'][ $key ] = 0;
+		}
+
+		$metrics['counts'][ $key ] = max( 0, (int) $metrics['counts'][ $key ] + $amount );
+		$metrics['last_activity_at'] = self::now();
+
+		$engine[ self::KEY ] = $metrics;
+		return EngineData::persist( $job_id, $engine );
+	}
+
+	public static function complete( int $job_id, string $status ): bool {
+		if ( $job_id <= 0 ) {
+			return false;
+		}
+
+		$engine  = EngineData::retrieve( $job_id );
+		$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
+		$now     = self::now();
+
+		if ( empty( $metrics['started_at'] ) ) {
+			$metrics['started_at'] = $engine['started_at'] ?? ( $engine['job']['created_at'] ?? $now );
+		}
+
+		$metrics['completed_at']     = $now;
+		$metrics['last_activity_at'] = $now;
+		$metrics['duration_seconds'] = self::durationSeconds( $metrics['started_at'], $now );
+		$metrics['terminal_status']  = $status;
+
+		if ( JobStatus::isStatusFailure( $status ) ) {
+			$metrics['counts']['failed'] = max( 1, (int) ( $metrics['counts']['failed'] ?? 0 ) );
+		} elseif ( str_starts_with( $status, JobStatus::AGENT_SKIPPED ) || str_starts_with( $status, JobStatus::COMPLETED_NO_ITEMS ) ) {
+			$metrics['counts']['skipped'] = max( 1, (int) ( $metrics['counts']['skipped'] ?? 0 ) );
+		} elseif ( JobStatus::COMPLETED === $status ) {
+			$metrics['counts']['processed'] = max( 1, (int) ( $metrics['counts']['processed'] ?? 0 ) );
+		}
+
+		$engine[ self::KEY ] = $metrics;
+		return EngineData::persist( $job_id, $engine );
+	}
+
+	public static function fromJob( array $job ): array {
+		$engine  = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
+		$status  = (string) ( $job['status'] ?? '' );
+
+		$started_at = $metrics['started_at'] ?: ( $engine['started_at'] ?? ( $job['created_at'] ?? null ) );
+		$ended_at   = $metrics['completed_at'] ?: ( $job['completed_at'] ?? null );
+		$last       = $metrics['last_activity_at'] ?: ( $ended_at ?: $started_at );
+		$counts     = $metrics['counts'];
+
+		foreach ( self::inferCountsFromEngine( $engine, $status ) as $key => $value ) {
+			$counts[ $key ] = max( (int) ( $counts[ $key ] ?? 0 ), (int) $value );
+		}
+
+		return array(
+			'job_id'           => (int) ( $job['job_id'] ?? 0 ),
+			'source'           => $job['source'] ?? null,
+			'label'            => $job['label'] ?? ( $job['display_label'] ?? null ),
+			'flow_id'          => $job['flow_id'] ?? null,
+			'pipeline_id'      => $job['pipeline_id'] ?? null,
+			'parent_job_id'    => isset( $job['parent_job_id'] ) ? (int) $job['parent_job_id'] : 0,
+			'status'           => $status,
+			'counts'           => $counts,
+			'child_jobs'       => self::childTotals( (int) ( $job['job_id'] ?? 0 ) ),
+			'timestamps'       => array(
+				'created_at'       => $job['created_at'] ?? null,
+				'started_at'       => $started_at,
+				'last_activity_at' => $last,
+				'completed_at'     => $ended_at,
+			),
+			'duration_seconds' => self::durationSeconds( $started_at, $ended_at ?: self::now() ),
+			'context'          => $metrics['context'],
+			'token_usage'      => self::tokenUsage( $engine ),
+			'cost'             => self::cost( $engine ),
+		);
+	}
+
+	public static function normalize( $metrics ): array {
+		$metrics = is_array( $metrics ) ? $metrics : array();
+		$counts  = is_array( $metrics['counts'] ?? null ) ? $metrics['counts'] : array();
+
+		foreach ( self::COUNT_KEYS as $key ) {
+			$counts[ $key ] = max( 0, (int) ( $counts[ $key ] ?? 0 ) );
+		}
+
+		return array(
+			'counts'            => $counts,
+			'started_at'        => isset( $metrics['started_at'] ) ? (string) $metrics['started_at'] : null,
+			'last_activity_at'  => isset( $metrics['last_activity_at'] ) ? (string) $metrics['last_activity_at'] : null,
+			'completed_at'      => isset( $metrics['completed_at'] ) ? (string) $metrics['completed_at'] : null,
+			'duration_seconds'  => isset( $metrics['duration_seconds'] ) ? max( 0, (int) $metrics['duration_seconds'] ) : null,
+			'terminal_status'   => isset( $metrics['terminal_status'] ) ? (string) $metrics['terminal_status'] : null,
+			'context'           => is_array( $metrics['context'] ?? null ) ? $metrics['context'] : array(),
+		);
+	}
+
+	private static function now(): string {
+		return function_exists( 'current_time' ) ? current_time( 'mysql', true ) : gmdate( 'Y-m-d H:i:s' );
+	}
+
+	private static function durationSeconds( $start, $end ): ?int {
+		if ( empty( $start ) || empty( $end ) ) {
+			return null;
+		}
+
+		$start_ts = strtotime( (string) $start );
+		$end_ts   = strtotime( (string) $end );
+		if ( false === $start_ts || false === $end_ts ) {
+			return null;
+		}
+
+		return max( 0, $end_ts - $start_ts );
+	}
+
+	private static function sanitizeContext( array $context ): array {
+		$out = array();
+		foreach ( $context as $key => $value ) {
+			$key = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $key ) : preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+			if ( '' === $key ) {
+				continue;
+			}
+			if ( is_scalar( $value ) || null === $value ) {
+				$out[ $key ] = $value;
+			}
+		}
+		return $out;
+	}
+
+	private static function inferCountsFromEngine( array $engine, string $status ): array {
+		$counts = array();
+
+		if ( isset( $engine['batch_results'] ) && is_array( $engine['batch_results'] ) ) {
+			$counts['processed'] = (int) ( $engine['batch_results']['completed'] ?? 0 );
+			$counts['failed']    = (int) ( $engine['batch_results']['failed'] ?? 0 );
+			$counts['skipped']   = (int) ( $engine['batch_results']['skipped'] ?? 0 );
+		}
+
+		foreach ( array( 'batch_scheduled', 'tasks_scheduled' ) as $key ) {
+			if ( isset( $engine[ $key ] ) ) {
+				$counts['scheduled'] = max( (int) ( $counts['scheduled'] ?? 0 ), (int) $engine[ $key ] );
+			}
+		}
+
+		if ( ! empty( $engine['skipped'] ) || str_starts_with( $status, JobStatus::AGENT_SKIPPED ) || str_starts_with( $status, JobStatus::COMPLETED_NO_ITEMS ) ) {
+			$counts['skipped'] = max( 1, (int) ( $counts['skipped'] ?? 0 ) );
+		}
+
+		if ( JobStatus::isStatusFailure( $status ) ) {
+			$counts['failed'] = max( 1, (int) ( $counts['failed'] ?? 0 ) );
+		}
+
+		return $counts;
+	}
+
+	private static function childTotals( int $job_id ): array {
+		$empty = array(
+			'total'      => 0,
+			'pending'    => 0,
+			'processing' => 0,
+			'completed'  => 0,
+			'skipped'    => 0,
+			'failed'     => 0,
+		);
+
+		if ( $job_id <= 0 ) {
+			return $empty;
+		}
+
+		global $wpdb;
+		if ( ! is_object( $wpdb ) ) {
+			return $empty;
+		}
+
+		$table = $wpdb->prefix . 'datamachine_jobs';
+		$row   = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT COUNT(*) AS total,
+					SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) AS pending,
+					SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) AS processing,
+					SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
+					SUM(CASE WHEN status LIKE 'agent_skipped%%' OR status LIKE 'completed_no_items%%' THEN 1 ELSE 0 END) AS skipped,
+					SUM(CASE WHEN status LIKE 'failed%%' THEN 1 ELSE 0 END) AS failed
+				FROM {$table}
+				WHERE parent_job_id = %d",
+				$job_id
+			),
+			ARRAY_A
+		);
+
+		return array(
+			'total'      => (int) ( $row['total'] ?? 0 ),
+			'pending'    => (int) ( $row['pending'] ?? 0 ),
+			'processing' => (int) ( $row['processing'] ?? 0 ),
+			'completed'  => (int) ( $row['completed'] ?? 0 ),
+			'skipped'    => (int) ( $row['skipped'] ?? 0 ),
+			'failed'     => (int) ( $row['failed'] ?? 0 ),
+		);
+	}
+
+	private static function tokenUsage( array $engine ): ?array {
+		$usage = $engine['token_usage'] ?? ( $engine['usage'] ?? null );
+		return is_array( $usage ) ? $usage : null;
+	}
+
+	private static function cost( array $engine ) {
+		if ( isset( $engine['cost'] ) && is_numeric( $engine['cost'] ) ) {
+			return (float) $engine['cost'];
+		}
+		if ( isset( $engine['usage']['cost'] ) && is_numeric( $engine['usage']['cost'] ) ) {
+			return (float) $engine['usage']['cost'];
+		}
+		return null;
+	}
+}

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -65,7 +65,7 @@ class RunMetrics {
 			$metrics['counts'][ $key ] = 0;
 		}
 
-		$metrics['counts'][ $key ] = max( 0, (int) $metrics['counts'][ $key ] + $amount );
+		$metrics['counts'][ $key ]   = max( 0, (int) $metrics['counts'][ $key ] + $amount );
 		$metrics['last_activity_at'] = self::now();
 
 		$engine[ self::KEY ] = $metrics;
@@ -107,10 +107,11 @@ class RunMetrics {
 		$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
 		$status  = (string) ( $job['status'] ?? '' );
 
-		$started_at = $metrics['started_at'] ?: ( $engine['started_at'] ?? ( $job['created_at'] ?? null ) );
-		$ended_at   = $metrics['completed_at'] ?: ( $job['completed_at'] ?? null );
-		$last       = $metrics['last_activity_at'] ?: ( $ended_at ?: $started_at );
-		$counts     = $metrics['counts'];
+		$started_at   = ! empty( $metrics['started_at'] ) ? $metrics['started_at'] : ( $engine['started_at'] ?? ( $job['created_at'] ?? null ) );
+		$ended_at     = ! empty( $metrics['completed_at'] ) ? $metrics['completed_at'] : ( $job['completed_at'] ?? null );
+		$last         = ! empty( $metrics['last_activity_at'] ) ? $metrics['last_activity_at'] : ( ! empty( $ended_at ) ? $ended_at : $started_at );
+		$counts       = $metrics['counts'];
+		$duration_end = ! empty( $ended_at ) ? $ended_at : self::now();
 
 		foreach ( self::inferCountsFromEngine( $engine, $status ) as $key => $value ) {
 			$counts[ $key ] = max( (int) ( $counts[ $key ] ?? 0 ), (int) $value );
@@ -132,7 +133,7 @@ class RunMetrics {
 				'last_activity_at' => $last,
 				'completed_at'     => $ended_at,
 			),
-			'duration_seconds' => self::durationSeconds( $started_at, $ended_at ?: self::now() ),
+			'duration_seconds' => self::durationSeconds( $started_at, $duration_end ),
 			'context'          => $metrics['context'],
 			'token_usage'      => self::tokenUsage( $engine ),
 			'cost'             => self::cost( $engine ),
@@ -148,13 +149,13 @@ class RunMetrics {
 		}
 
 		return array(
-			'counts'            => $counts,
-			'started_at'        => isset( $metrics['started_at'] ) ? (string) $metrics['started_at'] : null,
-			'last_activity_at'  => isset( $metrics['last_activity_at'] ) ? (string) $metrics['last_activity_at'] : null,
-			'completed_at'      => isset( $metrics['completed_at'] ) ? (string) $metrics['completed_at'] : null,
-			'duration_seconds'  => isset( $metrics['duration_seconds'] ) ? max( 0, (int) $metrics['duration_seconds'] ) : null,
-			'terminal_status'   => isset( $metrics['terminal_status'] ) ? (string) $metrics['terminal_status'] : null,
-			'context'           => is_array( $metrics['context'] ?? null ) ? $metrics['context'] : array(),
+			'counts'           => $counts,
+			'started_at'       => isset( $metrics['started_at'] ) ? (string) $metrics['started_at'] : null,
+			'last_activity_at' => isset( $metrics['last_activity_at'] ) ? (string) $metrics['last_activity_at'] : null,
+			'completed_at'     => isset( $metrics['completed_at'] ) ? (string) $metrics['completed_at'] : null,
+			'duration_seconds' => isset( $metrics['duration_seconds'] ) ? max( 0, (int) $metrics['duration_seconds'] ) : null,
+			'terminal_status'  => isset( $metrics['terminal_status'] ) ? (string) $metrics['terminal_status'] : null,
+			'context'          => is_array( $metrics['context'] ?? null ) ? $metrics['context'] : array(),
 		);
 	}
 
@@ -242,10 +243,14 @@ class RunMetrics {
 					SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) AS pending,
 					SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) AS processing,
 					SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
-					SUM(CASE WHEN status LIKE 'agent_skipped%%' OR status LIKE 'completed_no_items%%' THEN 1 ELSE 0 END) AS skipped,
-					SUM(CASE WHEN status LIKE 'failed%%' THEN 1 ELSE 0 END) AS failed
-				FROM {$table}
+					SUM(CASE WHEN status LIKE %s OR status LIKE %s THEN 1 ELSE 0 END) AS skipped,
+					SUM(CASE WHEN status LIKE %s THEN 1 ELSE 0 END) AS failed
+				FROM %i
 				WHERE parent_job_id = %d",
+				$wpdb->esc_like( JobStatus::AGENT_SKIPPED ) . '%',
+				$wpdb->esc_like( JobStatus::COMPLETED_NO_ITEMS ) . '%',
+				$wpdb->esc_like( JobStatus::FAILED ) . '%',
+				$table,
 				$job_id
 			),
 			ARRAY_A

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -64,6 +64,32 @@ function datamachine_register_core_actions() {
 	add_action( 'datamachine_fail_job', array( FailJobHandler::class, 'handle' ), 10, 3 );
 	add_action( 'datamachine_job_complete', array( JobCompleteHandler::class, 'handle' ), 10, 2 );
 	add_action( 'datamachine_log', array( LogHandler::class, 'handle' ), 10, 3 );
+	add_action(
+		'datamachine_pending_action_staged',
+		function ( string $action_id, array $payload ): void {
+			$context = is_array( $payload['context'] ?? null ) ? $payload['context'] : array();
+			$job_id  = (int) ( $context['job_id'] ?? 0 );
+			if ( $job_id > 0 ) {
+				\DataMachine\Core\RunMetrics::increment( $job_id, 'staged_actions' );
+			}
+		},
+		10,
+		2
+	);
+	add_action(
+		'datamachine_pending_action_resolved',
+		function ( string $decision, string $action_id, string $kind, array $payload, $result ): void {
+			$context = is_array( $payload['context'] ?? null ) ? $payload['context'] : array();
+			$job_id  = (int) ( $context['job_id'] ?? 0 );
+			if ( $job_id <= 0 ) {
+				return;
+			}
+			$key = 'accepted' === $decision ? 'accepted_actions' : 'rejected_actions';
+			\DataMachine\Core\RunMetrics::increment( $job_id, $key );
+		},
+		10,
+		5
+	);
 
 	// AI library error logging — universal handler for all AI interactions (pipeline agents, chat agents).
 	add_action(

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -78,7 +78,9 @@ function datamachine_register_core_actions() {
 	);
 	add_action(
 		'datamachine_pending_action_resolved',
-		function ( string $decision, string $action_id, string $kind, array $payload, $result ): void {
+		function ( string $decision, string $action_id, string $kind, array $payload ): void {
+			$action_id;
+			$kind;
 			$context = is_array( $payload['context'] ?? null ) ? $payload['context'] : array();
 			$job_id  = (int) ( $context['job_id'] ?? 0 );
 			if ( $job_id <= 0 ) {

--- a/inc/Engine/Actions/Handlers/MarkItemProcessedHandler.php
+++ b/inc/Engine/Actions/Handlers/MarkItemProcessedHandler.php
@@ -60,6 +60,12 @@ class MarkItemProcessedHandler {
 
 		$db_processed_items = new \DataMachine\Core\Database\ProcessedItems\ProcessedItems();
 
-		return $db_processed_items->add_processed_item( $flow_step_id, $source_type, $item_identifier, $job_id );
+		$result = $db_processed_items->add_processed_item( $flow_step_id, $source_type, $item_identifier, $job_id );
+
+		if ( $result ) {
+			\DataMachine\Core\RunMetrics::increment( $job_id, 'processed' );
+		}
+
+		return $result;
 	}
 }

--- a/tests/run-metrics-smoke.php
+++ b/tests/run-metrics-smoke.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Pure-PHP smoke test for generic run metrics shaping.
+ *
+ * Run with: php tests/run-metrics-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/RunMetrics.php';
+
+use DataMachine\Core\RunMetrics;
+
+function dm_assert( bool $cond, string $msg ): void {
+	if ( $cond ) {
+		echo "  [PASS] {$msg}\n";
+		return;
+	}
+	echo "  [FAIL] {$msg}\n";
+	exit( 1 );
+}
+
+echo "=== run-metrics-smoke ===\n";
+
+echo "\n[1] normalize fills generic counters\n";
+$normalized = RunMetrics::normalize(
+	array(
+		'counts'     => array(
+			'processed'      => 4,
+			'staged_actions' => 2,
+		),
+		'started_at' => '2026-05-03 10:00:00',
+	)
+);
+
+dm_assert( 4 === $normalized['counts']['processed'], 'processed count preserved' );
+dm_assert( 2 === $normalized['counts']['staged_actions'], 'staged action count preserved' );
+dm_assert( 0 === $normalized['counts']['failed'], 'missing failed count defaults to zero' );
+dm_assert( 0 === $normalized['counts']['retried'], 'missing retried count defaults to zero' );
+
+echo "\n[2] fromJob combines persisted metrics, batch results, tokens, and duration\n";
+$metrics = RunMetrics::fromJob(
+	array(
+		'job_id'        => 123,
+		'source'        => 'pipeline',
+		'label'         => 'Backfill',
+		'flow_id'       => '77',
+		'pipeline_id'   => '12',
+		'status'        => 'completed',
+		'created_at'    => '2026-05-03 09:59:50',
+		'completed_at'  => '2026-05-03 10:05:00',
+		'engine_data'   => array(
+			'run_metrics'   => array(
+				'counts'     => array(
+					'staged_actions' => 3,
+					'accepted_actions' => 2,
+				),
+				'started_at' => '2026-05-03 10:00:00',
+			),
+			'batch_results' => array(
+				'completed' => 8,
+				'failed'    => 1,
+				'skipped'   => 2,
+			),
+			'token_usage'   => array(
+				'total_tokens' => 99,
+			),
+		),
+	)
+);
+
+dm_assert( 123 === $metrics['job_id'], 'job_id surfaced' );
+dm_assert( 8 === $metrics['counts']['processed'], 'batch completed count maps to processed' );
+dm_assert( 2 === $metrics['counts']['skipped'], 'batch skipped count surfaced' );
+dm_assert( 1 === $metrics['counts']['failed'], 'batch failed count surfaced' );
+dm_assert( 3 === $metrics['counts']['staged_actions'], 'staged action count surfaced' );
+dm_assert( 2 === $metrics['counts']['accepted_actions'], 'accepted action count surfaced' );
+dm_assert( 300 === $metrics['duration_seconds'], 'duration uses started/completed timestamps' );
+dm_assert( 99 === $metrics['token_usage']['total_tokens'], 'token usage is exposed when present' );
+
+echo "\n[3] status-derived counts cover terminal no-item and failed jobs\n";
+$skipped = RunMetrics::fromJob(
+	array(
+		'job_id'      => 124,
+		'source'      => 'system',
+		'status'      => 'completed_no_items',
+		'created_at'  => '2026-05-03 10:00:00',
+		'engine_data' => array(),
+	)
+);
+$failed = RunMetrics::fromJob(
+	array(
+		'job_id'      => 125,
+		'source'      => 'system',
+		'status'      => 'failed - boom',
+		'created_at'  => '2026-05-03 10:00:00',
+		'engine_data' => array(),
+	)
+);
+
+dm_assert( 1 === $skipped['counts']['skipped'], 'completed_no_items increments skipped' );
+dm_assert( 1 === $failed['counts']['failed'], 'failed status increments failed' );
+
+echo "\n=== run-metrics-smoke: ALL PASS ===\n";


### PR DESCRIPTION
## Summary
- Add generic `RunMetrics` persisted in job `engine_data` for processed/skipped/failed/retried/staged action counters, child job totals, timestamps, duration, and optional token/cost data.
- Wire metrics updates into job lifecycle, processed-item marking, batch starts, retries, and pending-action staging/resolution.
- Expose metrics through `datamachine/get-run-metrics` and `wp datamachine jobs metrics <job_id>`.

## Testing
- `php tests/run-metrics-smoke.php`
- `php tests/jobs-get-children-smoke.php`
- `php tests/task-scheduler-batch-parent-link-smoke.php`
- `php tests/systemtask-passthrough-smoke.php`
- `./vendor/bin/phpcs inc/Core/RunMetrics.php inc/Abilities/Job/RunMetricsAbility.php inc/Cli/Commands/JobsCommand.php inc/Core/Database/Jobs/JobsStatus.php inc/Engine/Actions/DataMachineActions.php inc/Engine/Actions/Handlers/MarkItemProcessedHandler.php inc/Core/ActionScheduler/BatchScheduler.php inc/Abilities/Job/RetryJobAbility.php data-machine.php tests/run-metrics-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic metrics implementation, CLI/ability surfaces, and focused smoke coverage; Chris remains responsible for review and merge.