### PR TITLE
Persist pending actions durably

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "22fe638f510ed03c4d2a4fddf8f5c631b9e1de66"
+                "reference": "969cf5572f9df05feaf48e98efd2d6a592e96eb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/22fe638f510ed03c4d2a4fddf8f5c631b9e1de66",
-                "reference": "22fe638f510ed03c4d2a4fddf8f5c631b9e1de66",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/969cf5572f9df05feaf48e98efd2d6a592e96eb8",
+                "reference": "969cf5572f9df05feaf48e98efd2d6a592e96eb8",
                 "shasum": ""
             },
             "require": {
@@ -30,7 +30,10 @@
                     "php tests/bootstrap-smoke.php",
                     "php tests/registry-smoke.php",
                     "php tests/execution-principal-smoke.php",
+                    "php tests/action-policy-values-smoke.php",
                     "php tests/tool-runtime-smoke.php",
+                    "php tests/pending-action-store-contract-smoke.php",
+                    "php tests/approval-resolver-contract-smoke.php",
                     "php tests/identity-smoke.php",
                     "php tests/compaction-item-smoke.php",
                     "php tests/conversation-runner-contracts-smoke.php",
@@ -56,7 +59,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-02T23:25:36+00:00"
+            "time": "2026-05-03T15:11:07+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",
@@ -1558,6 +1561,6 @@
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/data-machine.php
+++ b/data-machine.php
@@ -292,6 +292,7 @@ function datamachine_run_datamachine_plugin() {
 	// ActionPolicy + unified pending-action resolver. Content abilities register
 	// themselves on `datamachine_pending_action_handlers` via
 	// inc/Abilities/Content/ContentActionHandlers.php (required above).
+	new \DataMachine\Engine\AI\Actions\PendingActionInspectionAbility();
 	new \DataMachine\Engine\AI\Actions\ResolvePendingActionAbility();
 	new \DataMachine\Engine\AI\Actions\ResolvePendingAction();
 
@@ -673,6 +674,8 @@ function datamachine_activate_for_site() {
 	\DataMachine\Core\Database\Chat\Chat::ensure_mode_column();
 	\DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();
 	\DataMachine\Core\Database\Chat\Chat::ensure_last_read_at_column();
+
+	\DataMachine\Engine\AI\Actions\PendingActionStore::create_table();
 
 	// Ensure default agent memory files exist.
 	// During activation the Abilities API is unavailable (init already fired before

--- a/docs/core-system/pending-actions.md
+++ b/docs/core-system/pending-actions.md
@@ -1,0 +1,37 @@
+# Pending Actions
+
+Data Machine implements the Agents API pending-action approval storage contract with WordPress-backed durable storage.
+
+## Boundary
+
+- Agents API owns generic approval vocabulary and contracts.
+- Data Machine owns the concrete WordPress table, CLI, REST routes, abilities, and legacy resolver/tool compatibility.
+- Domain plugins register action-specific handlers through `datamachine_pending_action_handlers`.
+
+## Available Agents API Contracts
+
+Data Machine directly adapts to these merged contracts from `automattic/agents-api`:
+
+- `AgentsAPI\AI\Approvals\PendingActionStoreInterface`
+- `AgentsAPI\AI\Approvals\PendingActionResolverInterface`
+- `AgentsAPI\AI\Approvals\PendingActionHandlerInterface`
+- `AgentsAPI\AI\Approvals\ApprovalDecision`
+- `AgentsAPI\AI\Approvals\PendingAction`
+- `AgentsAPI\AI\Tools\ActionPolicy`
+
+The compatibility seam remains the existing `datamachine_pending_action_handlers` map. Handler objects that implement `AgentsAPI\AI\Approvals\PendingActionHandlerInterface` can be placed under the same `apply` key and Data Machine will dispatch to the Agents API handler method. Legacy callable handlers continue to receive the stored `apply_input` and full Data Machine payload.
+
+## Surfaces
+
+- Ability: `datamachine/list-pending-actions`
+- Ability: `datamachine/get-pending-action`
+- Ability: `datamachine/summarize-pending-actions`
+- Resolver ability: `datamachine/resolve-pending-action`
+- Chat tool: `resolve_pending_action`
+- REST: `GET /datamachine/v1/actions`
+- REST: `GET /datamachine/v1/actions/{action_id}`
+- REST: `GET /datamachine/v1/actions/summary`
+- REST resolver: `POST /datamachine/v1/actions/resolve`
+- CLI: `wp datamachine pending-actions list|get|summary`
+
+`PendingActionStore::get()` remains the live-pending lookup used by legacy callers. Resolved rows are retained for audit and are available through inspect/list/get surfaces.

--- a/inc/Cli/Bootstrap.php
+++ b/inc/Cli/Bootstrap.php
@@ -28,6 +28,8 @@ WP_CLI::add_command( 'datamachine posts', Commands\PostsCommand::class );
 WP_CLI::add_command( 'datamachine logs', Commands\LogsCommand::class );
 WP_CLI::add_command( 'datamachine agent', Commands\AgentsCommand::class );
 WP_CLI::add_command( 'datamachine agents', Commands\AgentsCommand::class );
+WP_CLI::add_command( 'datamachine pending-actions', Commands\PendingActionsCommand::class );
+WP_CLI::add_command( 'datamachine pending-action', Commands\PendingActionsCommand::class );
 
 // Canonical home for agent memory-file operations.
 WP_CLI::add_command( 'datamachine memory', Commands\MemoryCommand::class );

--- a/inc/Cli/Commands/PendingActionsCommand.php
+++ b/inc/Cli/Commands/PendingActionsCommand.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * WP-CLI pending-actions command.
+ *
+ * @package DataMachine\Cli\Commands
+ */
+
+namespace DataMachine\Cli\Commands;
+
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Engine\AI\Actions\PendingActionInspectionAbility;
+use DataMachine\Engine\AI\Actions\PendingActionStore;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Inspect durable pending-action approval queues.
+ */
+class PendingActionsCommand extends BaseCommand {
+
+	/**
+	 * List pending actions.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--status=<status>]
+	 * : Filter by status: pending, accepted, rejected, expired, deleted.
+	 *
+	 * [--kind=<kind>]
+	 * : Filter by action kind.
+	 *
+	 * [--agent_id=<id>]
+	 * : Filter by acting agent ID.
+	 *
+	 * [--created_by=<id>]
+	 * : Filter by creator user ID.
+	 *
+	 * [--limit=<limit>]
+	 * : Number of rows to return. Default 50, max 200.
+	 *
+	 * [--offset=<offset>]
+	 * : Offset for pagination.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 *   - ids
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine pending-actions list
+	 *     wp datamachine pending-actions list --status=pending --format=json
+	 */
+	public function list( array $args, array $assoc_args ): void {
+		$filters = PendingActionInspectionAbility::normalize_filters( $assoc_args );
+		$rows    = PendingActionStore::list( $filters );
+
+		$fields = array( 'action_id', 'kind', 'summary', 'status', 'agent_id', 'created_by', 'created_at_iso', 'expires_at_iso' );
+		$this->format_items( $rows, $fields, $assoc_args, 'action_id' );
+	}
+
+	/**
+	 * Get a pending action by ID.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action_id>
+	 * : Pending action ID.
+	 *
+	 * [--format=<format>]
+	 * : Output format. Default json.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine pending-actions get act_123
+	 */
+	public function get( array $args, array $assoc_args ): void {
+		$action_id = isset( $args[0] ) ? (string) $args[0] : '';
+		if ( '' === $action_id ) {
+			WP_CLI::error( 'action_id is required.' );
+		}
+
+		$action = PendingActionStore::inspect( $action_id );
+		if ( null === $action ) {
+			WP_CLI::error( 'Pending action not found.' );
+		}
+
+		$format = $assoc_args['format'] ?? 'json';
+		WP_CLI\Utils\format_items( $format, array( $action ), array_keys( $action ) );
+	}
+
+	/**
+	 * Summarize pending actions.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--status=<status>]
+	 * : Filter by status before summarizing.
+	 *
+	 * [--kind=<kind>]
+	 * : Filter by action kind before summarizing.
+	 *
+	 * [--format=<format>]
+	 * : Output format. Default json.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine pending-actions summary
+	 */
+	public function summary( array $args, array $assoc_args ): void {
+		$summary = PendingActionStore::summary( PendingActionInspectionAbility::normalize_filters( $assoc_args ) );
+		$format  = $assoc_args['format'] ?? 'json';
+
+		WP_CLI\Utils\format_items( $format, array( $summary ), array_keys( $summary ) );
+	}
+}

--- a/inc/Engine/AI/Actions/ActionPolicyResolver.php
+++ b/inc/Engine/AI/Actions/ActionPolicyResolver.php
@@ -284,16 +284,16 @@ class ActionPolicyResolver {
 	 * @return string Normalized policy or ''.
 	 */
 	private function normalizePolicyValue( $value ): string {
+		if ( class_exists( 'AgentsAPI\\AI\\Tools\\ActionPolicy' ) ) {
+			return \AgentsAPI\AI\Tools\ActionPolicy::normalize( $value ) ?? '';
+		}
+
 		if ( ! is_string( $value ) ) {
 			return '';
 		}
+
 		$value = strtolower( trim( $value ) );
-		$allowed = array(
-			self::POLICY_DIRECT,
-			self::POLICY_PREVIEW,
-			self::POLICY_FORBIDDEN,
-		);
-		return in_array( $value, $allowed, true ) ? $value : '';
+		return in_array( $value, array( self::POLICY_DIRECT, self::POLICY_PREVIEW, self::POLICY_FORBIDDEN ), true ) ? $value : '';
 	}
 
 	/**

--- a/inc/Engine/AI/Actions/PendingActionHelper.php
+++ b/inc/Engine/AI/Actions/PendingActionHelper.php
@@ -99,6 +99,12 @@ class PendingActionHelper {
 			'created_by'   => $user_id,
 			'context'      => $context,
 		);
+		if ( isset( $args['ttl'] ) ) {
+			$payload['ttl'] = (int) $args['ttl'];
+		}
+		if ( isset( $args['expires_at'] ) ) {
+			$payload['expires_at'] = $args['expires_at'];
+		}
 
 		$stored = PendingActionStore::store( $action_id, $payload );
 		if ( ! $stored ) {
@@ -108,6 +114,8 @@ class PendingActionHelper {
 				'error_code' => 'store_failed',
 			);
 		}
+
+		$stored_payload = PendingActionStore::get( $action_id ) ?? $payload;
 
 		/**
 		 * Fires when a pending action has been staged and is awaiting resolution.
@@ -134,7 +142,7 @@ class PendingActionHelper {
 				'decision'  => '<accepted|rejected>',
 			),
 			'instruction'    => 'Show this preview to the user and wait for their confirmation. Do not call resolve_pending_action until they explicitly approve or reject. If the user asks to modify, call the original tool again with updated parameters instead of resolving this action.',
-			'expires_at'     => time() + HOUR_IN_SECONDS,
+			'expires_at'     => isset( $stored_payload['expires_at'] ) ? (int) $stored_payload['expires_at'] : null,
 		);
 	}
 }

--- a/inc/Engine/AI/Actions/PendingActionHelper.php
+++ b/inc/Engine/AI/Actions/PendingActionHelper.php
@@ -70,9 +70,9 @@ class PendingActionHelper {
 
 		if ( '' === $kind ) {
 			return array(
-				'staged'      => false,
-				'error'       => 'PendingActionHelper::stage() requires a non-empty kind.',
-				'error_code'  => 'invalid_kind',
+				'staged'     => false,
+				'error'      => 'PendingActionHelper::stage() requires a non-empty kind.',
+				'error_code' => 'invalid_kind',
 			);
 		}
 

--- a/inc/Engine/AI/Actions/PendingActionInspectionAbility.php
+++ b/inc/Engine/AI/Actions/PendingActionInspectionAbility.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Pending-action list/get/summary abilities and REST surfaces.
+ *
+ * @package DataMachine\Engine\AI\Actions
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+use DataMachine\Abilities\PermissionHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Exposes durable pending-action queues to agents and operators.
+ */
+final class PendingActionInspectionAbility {
+
+	/** @var bool */
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->register_abilities();
+		$this->register_rest_routes();
+		self::$registered = true;
+	}
+
+	/**
+	 * Register WordPress abilities.
+	 */
+	private function register_abilities(): void {
+		$register = function () {
+			wp_register_ability(
+				'datamachine/list-pending-actions',
+				array(
+					'label'               => __( 'List Pending Actions', 'data-machine' ),
+					'description'         => __( 'List staged pending actions awaiting review or already resolved for audit.', 'data-machine' ),
+					'category'            => 'datamachine-actions',
+					'input_schema'        => self::query_schema(),
+					'output_schema'       => self::list_output_schema(),
+					'execute_callback'    => array( self::class, 'list_actions' ),
+					'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/get-pending-action',
+				array(
+					'label'               => __( 'Get Pending Action', 'data-machine' ),
+					'description'         => __( 'Fetch a staged or resolved pending action by ID.', 'data-machine' ),
+					'category'            => 'datamachine-actions',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'action_id' ),
+						'properties' => array(
+							'action_id' => array( 'type' => 'string' ),
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'get_action' ),
+					'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/summarize-pending-actions',
+				array(
+					'label'               => __( 'Summarize Pending Actions', 'data-machine' ),
+					'description'         => __( 'Summarize pending actions by status, kind, agent, and context.', 'data-machine' ),
+					'category'            => 'datamachine-actions',
+					'input_schema'        => self::query_schema(),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'summary' ),
+					'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register );
+		}
+	}
+
+	/**
+	 * Register REST routes for operators that do not call abilities directly.
+	 */
+	private function register_rest_routes(): void {
+		add_action(
+			'rest_api_init',
+			function () {
+				register_rest_route(
+					'datamachine/v1',
+					'/actions',
+					array(
+						'methods'             => 'GET',
+						'callback'            => static fn( \WP_REST_Request $request ) => new \WP_REST_Response( self::list_actions( self::request_to_filters( $request ) ), 200 ),
+						'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
+					)
+				);
+
+				register_rest_route(
+					'datamachine/v1',
+					'/actions/summary',
+					array(
+						'methods'             => 'GET',
+						'callback'            => static fn( \WP_REST_Request $request ) => new \WP_REST_Response( self::summary( self::request_to_filters( $request ) ), 200 ),
+						'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
+					)
+				);
+
+				register_rest_route(
+					'datamachine/v1',
+					'/actions/(?P<action_id>[a-zA-Z0-9_\-]+)',
+					array(
+						'methods'             => 'GET',
+						'callback'            => array( self::class, 'handle_get_rest' ),
+						'permission_callback' => fn() => PermissionHelper::can( 'chat' ),
+					)
+				);
+			}
+		);
+	}
+
+	/**
+	 * Ability callback: list actions.
+	 */
+	public static function list_actions( array $input ): array {
+		return array(
+			'success' => true,
+			'actions' => PendingActionStore::list( self::normalize_filters( $input ) ),
+		);
+	}
+
+	/**
+	 * Ability callback: get one action.
+	 */
+	public static function get_action( array $input ): array {
+		$action_id = isset( $input['action_id'] ) ? sanitize_text_field( (string) $input['action_id'] ) : '';
+		if ( '' === $action_id ) {
+			return array( 'success' => false, 'error' => 'action_id is required.' );
+		}
+
+		$action = PendingActionStore::inspect( $action_id );
+		if ( null === $action ) {
+			return array( 'success' => false, 'error' => 'Pending action not found.', 'action_id' => $action_id );
+		}
+
+		return array( 'success' => true, 'action' => $action );
+	}
+
+	/**
+	 * Ability callback: summarize actions.
+	 */
+	public static function summary( array $input ): array {
+		return array(
+			'success' => true,
+			'summary' => PendingActionStore::summary( self::normalize_filters( $input ) ),
+		);
+	}
+
+	/**
+	 * REST callback for a single action.
+	 */
+	public static function handle_get_rest( \WP_REST_Request $request ): \WP_REST_Response {
+		$result = self::get_action( array( 'action_id' => $request->get_param( 'action_id' ) ) );
+		return new \WP_REST_Response( $result, ! empty( $result['success'] ) ? 200 : 404 );
+	}
+
+	/**
+	 * Convert request params to filters.
+	 */
+	private static function request_to_filters( \WP_REST_Request $request ): array {
+		return self::normalize_filters( $request->get_params() );
+	}
+
+	/**
+	 * Normalize query filters.
+	 */
+	public static function normalize_filters( array $input ): array {
+		$filters = array();
+		foreach ( array( 'status', 'kind', 'created_after', 'created_before' ) as $key ) {
+			if ( isset( $input[ $key ] ) && '' !== $input[ $key ] ) {
+				$filters[ $key ] = sanitize_text_field( (string) $input[ $key ] );
+			}
+		}
+
+		foreach ( array( 'agent_id', 'created_by', 'limit', 'offset' ) as $key ) {
+			if ( isset( $input[ $key ] ) && '' !== $input[ $key ] ) {
+				$filters[ $key ] = (int) $input[ $key ];
+			}
+		}
+
+		if ( isset( $input['context'] ) && is_array( $input['context'] ) ) {
+			$filters['context'] = array_map( 'sanitize_text_field', $input['context'] );
+		}
+
+		return $filters;
+	}
+
+	/**
+	 * Shared query schema.
+	 */
+	private static function query_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'status'         => array( 'type' => 'string' ),
+				'kind'           => array( 'type' => 'string' ),
+				'agent_id'       => array( 'type' => 'integer' ),
+				'created_by'     => array( 'type' => 'integer' ),
+				'context'        => array( 'type' => 'object' ),
+				'created_after'  => array( 'type' => 'string' ),
+				'created_before' => array( 'type' => 'string' ),
+				'limit'          => array( 'type' => 'integer', 'default' => 50 ),
+				'offset'         => array( 'type' => 'integer', 'default' => 0 ),
+			),
+		);
+	}
+
+	/**
+	 * List output schema.
+	 */
+	private static function list_output_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success' => array( 'type' => 'boolean' ),
+				'actions' => array( 'type' => 'array' ),
+			),
+		);
+	}
+}

--- a/inc/Engine/AI/Actions/PendingActionInspectionAbility.php
+++ b/inc/Engine/AI/Actions/PendingActionInspectionAbility.php
@@ -146,15 +146,25 @@ final class PendingActionInspectionAbility {
 	public static function get_action( array $input ): array {
 		$action_id = isset( $input['action_id'] ) ? sanitize_text_field( (string) $input['action_id'] ) : '';
 		if ( '' === $action_id ) {
-			return array( 'success' => false, 'error' => 'action_id is required.' );
+			return array(
+				'success' => false,
+				'error'   => 'action_id is required.',
+			);
 		}
 
 		$action = PendingActionStore::inspect( $action_id );
 		if ( null === $action ) {
-			return array( 'success' => false, 'error' => 'Pending action not found.', 'action_id' => $action_id );
+			return array(
+				'success'   => false,
+				'error'     => 'Pending action not found.',
+				'action_id' => $action_id,
+			);
 		}
 
-		return array( 'success' => true, 'action' => $action );
+		return array(
+			'success' => true,
+			'action'  => $action,
+		);
 	}
 
 	/**
@@ -220,8 +230,14 @@ final class PendingActionInspectionAbility {
 				'context'        => array( 'type' => 'object' ),
 				'created_after'  => array( 'type' => 'string' ),
 				'created_before' => array( 'type' => 'string' ),
-				'limit'          => array( 'type' => 'integer', 'default' => 50 ),
-				'offset'         => array( 'type' => 'integer', 'default' => 0 ),
+				'limit'          => array(
+					'type'    => 'integer',
+					'default' => 50,
+				),
+				'offset'         => array(
+					'type'    => 'integer',
+					'default' => 0,
+				),
 			),
 		);
 	}

--- a/inc/Engine/AI/Actions/PendingActionResolverAdapter.php
+++ b/inc/Engine/AI/Actions/PendingActionResolverAdapter.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Agents API adapter for Data Machine pending-action resolution.
+ *
+ * @package DataMachine\Engine\AI\Actions
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+use AgentsAPI\AI\Approvals\ApprovalDecision;
+use AgentsAPI\AI\Approvals\PendingActionResolverInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Implements the generic Agents API resolver contract while preserving
+ * `datamachine/resolve-pending-action` as the single Data Machine resolver.
+ */
+final class PendingActionResolverAdapter implements PendingActionResolverInterface {
+
+	/**
+	 * Resolve a pending action by identifier.
+	 *
+	 * @param string           $pending_action_id Stable pending-action identifier.
+	 * @param ApprovalDecision $decision          Accepted/rejected decision.
+	 * @param array            $payload           Fresh resolver payload.
+	 * @param array            $context           Optional caller context.
+	 * @return mixed
+	 */
+	public function resolve_pending_action( string $pending_action_id, ApprovalDecision $decision, array $payload = array(), array $context = array() ): mixed {
+		return ResolvePendingActionAbility::execute(
+			array(
+				'action_id' => $pending_action_id,
+				'decision'  => $decision->value(),
+				'payload'   => $payload,
+				'context'   => $context,
+			)
+		);
+	}
+}

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -25,8 +25,8 @@
  *       'context'       => array( ... ),   // free-form (session_id, bridge_app, etc.)
  *   )
  *
- * Uses WordPress transients with a 1-hour TTL. Stale pending actions
- * auto-expire if never resolved.
+	 * Uses durable WordPress database storage in normal runtime. Pure-PHP smoke
+	 * tests and pre-table boot can still fall back to the legacy transient path.
  *
  * @package DataMachine\Engine\AI\Actions
  * @since   0.72.0
@@ -39,14 +39,98 @@ defined( 'ABSPATH' ) || exit;
 class PendingActionStore {
 
 	/**
-	 * Transient TTL in seconds (1 hour).
+	 * Pending status values.
 	 */
-	private const TTL = HOUR_IN_SECONDS;
+	public const STATUS_PENDING  = 'pending';
+	public const STATUS_ACCEPTED = 'accepted';
+	public const STATUS_REJECTED = 'rejected';
+	public const STATUS_EXPIRED  = 'expired';
+	public const STATUS_DELETED  = 'deleted';
 
 	/**
-	 * Transient key prefix. Short to keep option_name under DB limits.
+	 * Database table name without WordPress prefix.
 	 */
-	private const PREFIX = 'dm_pa_';
+	private const TABLE_NAME = 'datamachine_pending_actions';
+
+	/**
+	 * Default TTL for unattended exception queues.
+	 */
+	private const DEFAULT_TTL = 604800;
+
+	/**
+	 * Minimum TTL in seconds.
+	 */
+	private const MIN_TTL = 3600;
+
+	/**
+	 * Transient fallback key prefix for pure-PHP smoke tests and pre-table boot.
+	 */
+	private const TRANSIENT_PREFIX = 'dm_pa_';
+
+	/**
+	 * Agents API store adapter singleton.
+	 *
+	 * @var PendingActionStoreAdapter|null
+	 */
+	private static ?PendingActionStoreAdapter $adapter = null;
+
+	/**
+	 * Create or update the durable pending-actions table.
+	 */
+	public static function create_table(): void {
+		global $wpdb;
+
+		$table_name      = self::get_table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$sql = "CREATE TABLE {$table_name} (
+			action_id varchar(191) NOT NULL,
+			kind varchar(100) NOT NULL,
+			summary text NOT NULL,
+			preview_data longtext NULL,
+			apply_input longtext NULL,
+			agent_id bigint(20) unsigned NULL,
+			created_by bigint(20) unsigned NULL,
+			context longtext NULL,
+			status varchar(20) NOT NULL DEFAULT 'pending',
+			created_at datetime NOT NULL,
+			expires_at datetime NULL,
+			resolved_at datetime NULL,
+			resolved_by bigint(20) unsigned NULL,
+			resolution_result longtext NULL,
+			resolution_error text NULL,
+			PRIMARY KEY  (action_id),
+			KEY status (status),
+			KEY kind (kind),
+			KEY agent_id (agent_id),
+			KEY created_by (created_by),
+			KEY expires_at (expires_at),
+			KEY created_at (created_at)
+		) {$charset_collate};";
+
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Get the prefixed pending-actions table name.
+	 */
+	public static function get_table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . self::TABLE_NAME;
+	}
+
+	/**
+	 * Return the Agents API store adapter when the contract is available.
+	 */
+	public static function adapter(): PendingActionStoreAdapter {
+		if ( null === self::$adapter ) {
+			self::$adapter = new PendingActionStoreAdapter();
+		}
+
+		return self::$adapter;
+	}
 
 	/**
 	 * Store a pending action.
@@ -59,10 +143,51 @@ class PendingActionStore {
 	 * @return bool Whether the transient was written.
 	 */
 	public static function store( string $action_id, array $payload ): bool {
-		$payload['created_at'] = time();
-		$payload['action_id']  = $action_id;
+		global $wpdb;
 
-		return set_transient( self::PREFIX . $action_id, $payload, self::TTL );
+		if ( ! self::has_database() ) {
+			$payload['created_at'] = time();
+			$payload['expires_at'] = time() + self::resolve_ttl( $payload );
+			$payload['action_id']  = $action_id;
+			$payload['status']     = self::STATUS_PENDING;
+
+			return set_transient( self::TRANSIENT_PREFIX . $action_id, $payload, self::resolve_ttl( $payload ) );
+		}
+
+		$now        = time();
+		$ttl        = self::resolve_ttl( $payload );
+		$expires_at = isset( $payload['expires_at'] ) ? self::normalize_timestamp( $payload['expires_at'] ) : ( $now + $ttl );
+		$created_at = isset( $payload['created_at'] ) ? self::normalize_timestamp( $payload['created_at'] ) : $now;
+
+		$payload['created_at'] = $created_at;
+		$payload['expires_at'] = $expires_at;
+		$payload['action_id']  = $action_id;
+		$payload['status']     = self::STATUS_PENDING;
+
+		$row = array(
+			'action_id'         => $action_id,
+			'kind'              => sanitize_key( (string) ( $payload['kind'] ?? '' ) ),
+			'summary'           => (string) ( $payload['summary'] ?? '' ),
+			'preview_data'      => self::encode_json( $payload['preview_data'] ?? array() ),
+			'apply_input'       => self::encode_json( $payload['apply_input'] ?? array() ),
+			'agent_id'          => self::nullable_positive_int( $payload['agent_id'] ?? null ),
+			'created_by'        => self::nullable_positive_int( $payload['created_by'] ?? null ),
+			'context'           => self::encode_json( $payload['context'] ?? array() ),
+			'status'            => self::STATUS_PENDING,
+			'created_at'        => gmdate( 'Y-m-d H:i:s', $created_at ),
+			'expires_at'        => $expires_at > 0 ? gmdate( 'Y-m-d H:i:s', $expires_at ) : null,
+			'resolved_at'       => null,
+			'resolved_by'       => null,
+			'resolution_result' => null,
+			'resolution_error'  => null,
+		);
+
+		$formats = array( '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$stored = $wpdb->replace( self::get_table_name(), $row, $formats );
+
+		return false !== $stored;
 	}
 
 	/**
@@ -71,14 +196,40 @@ class PendingActionStore {
 	 * @param string $action_id Action identifier.
 	 * @return array|null The payload, or null if not found / expired.
 	 */
-	public static function get( string $action_id ): ?array {
-		$data = get_transient( self::PREFIX . $action_id );
+	public static function get( string $action_id, bool $include_resolved = false ): ?array {
+		if ( ! self::has_database() ) {
+			$data = get_transient( self::TRANSIENT_PREFIX . $action_id );
+			return is_array( $data ) ? $data : null;
+		}
 
-		if ( false === $data || ! is_array( $data ) ) {
+		$row = self::get_row( $action_id );
+
+		if ( null === $row ) {
 			return null;
 		}
 
-		return $data;
+		if ( ! $include_resolved && self::STATUS_PENDING !== $row['status'] ) {
+			return null;
+		}
+
+		if ( self::STATUS_PENDING === $row['status'] && self::is_expired_row( $row ) ) {
+			self::record_resolution( $action_id, self::STATUS_EXPIRED, null, 'Pending action expired.' );
+			if ( ! $include_resolved ) {
+				return null;
+			}
+
+			$row = self::get_row( $action_id );
+			if ( null === $row ) {
+				return null;
+			}
+		}
+
+		$payload = self::row_to_payload( $row );
+		if ( ! is_array( $payload ) ) {
+			return null;
+		}
+
+		return $payload;
 	}
 
 	/**
@@ -88,7 +239,174 @@ class PendingActionStore {
 	 * @return bool Whether the transient was deleted.
 	 */
 	public static function delete( string $action_id ): bool {
-		return delete_transient( self::PREFIX . $action_id );
+		if ( ! self::has_database() ) {
+			return delete_transient( self::TRANSIENT_PREFIX . $action_id );
+		}
+
+		return self::record_resolution( $action_id, self::STATUS_DELETED, null, 'Pending action deleted.' );
+	}
+
+	/**
+	 * Record a terminal resolution while retaining the row for audit/listing.
+	 *
+	 * @param string      $action_id Action identifier.
+	 * @param string      $decision  Terminal status.
+	 * @param mixed|null  $result    Resolution result.
+	 * @param string|null $error     Resolution error.
+	 * @return bool Whether the row was updated.
+	 */
+	public static function record_resolution( string $action_id, string $decision, $result = null, ?string $error = null ): bool {
+		global $wpdb;
+
+		if ( ! self::has_database() ) {
+			return delete_transient( self::TRANSIENT_PREFIX . $action_id );
+		}
+
+		$status = self::normalize_status( $decision );
+		if ( '' === $status ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$updated = $wpdb->update(
+			self::get_table_name(),
+			array(
+				'status'            => $status,
+				'resolved_at'       => current_time( 'mysql', true ),
+				'resolved_by'       => get_current_user_id(),
+				'resolution_result' => self::encode_json( $result ),
+				'resolution_error'  => $error,
+			),
+			array( 'action_id' => $action_id ),
+			array( '%s', '%s', '%d', '%s', '%s' ),
+			array( '%s' )
+		);
+
+		return false !== $updated;
+	}
+
+	/**
+	 * List pending-action rows for operator and agent inspection.
+	 *
+	 * @param array $filters Query filters.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function list( array $filters = array() ): array {
+		if ( ! self::has_database() ) {
+			return array();
+		}
+
+		self::expire_due_actions();
+
+		global $wpdb;
+
+		$where = array( '1=1' );
+		$args  = array();
+
+		self::add_filter_clause( $where, $args, $filters, 'status', 'status', '%s' );
+		self::add_filter_clause( $where, $args, $filters, 'kind', 'kind', '%s' );
+		self::add_filter_clause( $where, $args, $filters, 'agent_id', 'agent_id', '%d' );
+		self::add_filter_clause( $where, $args, $filters, 'created_by', 'created_by', '%d' );
+
+		if ( ! empty( $filters['context'] ) && is_array( $filters['context'] ) ) {
+			foreach ( $filters['context'] as $key => $value ) {
+				$where[] = 'context LIKE %s';
+				$args[]  = '%' . $wpdb->esc_like( '"' . (string) $key . '"' ) . '%' . $wpdb->esc_like( (string) $value ) . '%';
+			}
+		}
+
+		if ( ! empty( $filters['created_after'] ) ) {
+			$where[] = 'created_at >= %s';
+			$args[]  = gmdate( 'Y-m-d H:i:s', self::normalize_timestamp( $filters['created_after'] ) );
+		}
+
+		if ( ! empty( $filters['created_before'] ) ) {
+			$where[] = 'created_at <= %s';
+			$args[]  = gmdate( 'Y-m-d H:i:s', self::normalize_timestamp( $filters['created_before'] ) );
+		}
+
+		$limit  = isset( $filters['limit'] ) ? max( 1, min( 200, (int) $filters['limit'] ) ) : 50;
+		$offset = isset( $filters['offset'] ) ? max( 0, (int) $filters['offset'] ) : 0;
+
+		$sql = sprintf(
+			'SELECT * FROM %%i WHERE %s ORDER BY created_at DESC LIMIT %%d OFFSET %%d',
+			implode( ' AND ', $where )
+		);
+
+		$prepare_args = array_merge( array( self::get_table_name() ), $args, array( $limit, $offset ) );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $wpdb->get_results( $wpdb->prepare( $sql, ...$prepare_args ), ARRAY_A );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+
+		return array_values( array_filter( array_map( array( self::class, 'row_to_payload' ), (array) $rows ) ) );
+	}
+
+	/**
+	 * Fetch a single action for inspection, including resolved rows.
+	 */
+	public static function inspect( string $action_id ): ?array {
+		return self::get( $action_id, true );
+	}
+
+	/**
+	 * Summarize pending actions by status, kind, agent, and context key.
+	 *
+	 * @param array $filters Query filters.
+	 * @return array<string,mixed>
+	 */
+	public static function summary( array $filters = array() ): array {
+		$rows = self::list( array_merge( $filters, array( 'limit' => $filters['limit'] ?? 200 ) ) );
+
+		$summary = array(
+			'total'        => count( $rows ),
+			'by_status'    => array(),
+			'by_kind'      => array(),
+			'by_agent_id'  => array(),
+			'by_context'   => array(),
+		);
+
+		foreach ( $rows as $row ) {
+			self::increment_summary_bucket( $summary['by_status'], (string) ( $row['status'] ?? '' ) );
+			self::increment_summary_bucket( $summary['by_kind'], (string) ( $row['kind'] ?? '' ) );
+			self::increment_summary_bucket( $summary['by_agent_id'], (string) ( $row['agent_id'] ?? '0' ) );
+
+			$context = isset( $row['context'] ) && is_array( $row['context'] ) ? $row['context'] : array();
+			foreach ( $context as $key => $value ) {
+				$bucket = (string) $key . ':' . ( is_scalar( $value ) ? (string) $value : wp_json_encode( $value ) );
+				self::increment_summary_bucket( $summary['by_context'], $bucket );
+			}
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Mark currently expired pending actions.
+	 *
+	 * @return int Number of rows updated.
+	 */
+	public static function expire_due_actions(): int {
+		global $wpdb;
+
+		if ( ! self::has_database() ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$updated = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET status = %s, resolved_at = %s, resolution_error = %s WHERE status = %s AND expires_at IS NOT NULL AND expires_at <= %s',
+				self::get_table_name(),
+				self::STATUS_EXPIRED,
+				current_time( 'mysql', true ),
+				'Pending action expired.',
+				self::STATUS_PENDING,
+				current_time( 'mysql', true )
+			)
+		);
+
+		return false === $updated ? 0 : (int) $updated;
 	}
 
 	/**
@@ -98,5 +416,174 @@ class PendingActionStore {
 	 */
 	public static function generate_id(): string {
 		return 'act_' . wp_generate_uuid4();
+	}
+
+	/**
+	 * Get a raw row by action ID.
+	 */
+	private static function get_row( string $action_id ): ?array {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+		$row = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE action_id = %s', self::get_table_name(), $action_id ),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+
+		return is_array( $row ) ? $row : null;
+	}
+
+	/**
+	 * Convert a DB row to the legacy plus durable public payload shape.
+	 */
+	private static function row_to_payload( array $row ): array {
+		$created_at = self::mysql_to_timestamp( (string) ( $row['created_at'] ?? '' ) );
+		$expires_at = self::mysql_to_timestamp( (string) ( $row['expires_at'] ?? '' ) );
+
+		return array(
+			'action_id'          => (string) ( $row['action_id'] ?? '' ),
+			'kind'               => (string) ( $row['kind'] ?? '' ),
+			'summary'            => (string) ( $row['summary'] ?? '' ),
+			'preview_data'       => self::decode_json( $row['preview_data'] ?? null ),
+			'preview'            => self::decode_json( $row['preview_data'] ?? null ),
+			'apply_input'        => self::decode_json( $row['apply_input'] ?? null ),
+			'agent_id'           => isset( $row['agent_id'] ) ? (int) $row['agent_id'] : 0,
+			'created_by'         => isset( $row['created_by'] ) ? (int) $row['created_by'] : 0,
+			'context'            => self::decode_json( $row['context'] ?? null ),
+			'status'             => (string) ( $row['status'] ?? self::STATUS_PENDING ),
+			'created_at'         => $created_at,
+			'created_at_iso'     => $created_at > 0 ? gmdate( 'c', $created_at ) : null,
+			'expires_at'         => $expires_at,
+			'expires_at_iso'     => $expires_at > 0 ? gmdate( 'c', $expires_at ) : null,
+			'resolved_at'        => self::mysql_to_timestamp( (string) ( $row['resolved_at'] ?? '' ) ),
+			'resolved_by'        => isset( $row['resolved_by'] ) ? (int) $row['resolved_by'] : 0,
+			'resolution_result'  => self::decode_json( $row['resolution_result'] ?? null ),
+			'resolution_error'   => isset( $row['resolution_error'] ) ? (string) $row['resolution_error'] : null,
+		);
+	}
+
+	/**
+	 * Add a scalar SQL filter clause.
+	 */
+	private static function add_filter_clause( array &$where, array &$args, array $filters, string $filter_key, string $column, string $format ): void {
+		if ( ! array_key_exists( $filter_key, $filters ) || '' === $filters[ $filter_key ] || null === $filters[ $filter_key ] ) {
+			return;
+		}
+
+		$where[] = $column . ' = ' . $format;
+		$args[]  = '%d' === $format ? (int) $filters[ $filter_key ] : (string) $filters[ $filter_key ];
+	}
+
+	/**
+	 * Resolve the configured TTL in seconds.
+	 */
+	private static function resolve_ttl( array $payload ): int {
+		$ttl = isset( $payload['ttl'] ) ? (int) $payload['ttl'] : self::DEFAULT_TTL;
+
+		/**
+		 * Filter pending-action TTL in seconds.
+		 *
+		 * @param int   $ttl     TTL in seconds.
+		 * @param array $payload Pending action payload.
+		 */
+		$ttl = (int) apply_filters( 'datamachine_pending_action_ttl', $ttl, $payload );
+
+		return max( self::MIN_TTL, $ttl );
+	}
+
+	/**
+	 * Check whether a real wpdb object is available.
+	 */
+	private static function has_database(): bool {
+		global $wpdb;
+		return is_object( $wpdb ) && method_exists( $wpdb, 'replace' ) && method_exists( $wpdb, 'get_row' );
+	}
+
+	/**
+	 * Normalize mixed timestamp input to a Unix timestamp.
+	 */
+	private static function normalize_timestamp( $value ): int {
+		if ( is_numeric( $value ) ) {
+			return (int) $value;
+		}
+
+		if ( is_string( $value ) && '' !== trim( $value ) ) {
+			$timestamp = strtotime( $value );
+			return false === $timestamp ? 0 : $timestamp;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Convert MySQL datetime to Unix timestamp.
+	 */
+	private static function mysql_to_timestamp( string $value ): int {
+		if ( '' === $value || '0000-00-00 00:00:00' === $value ) {
+			return 0;
+		}
+
+		$timestamp = strtotime( $value . ' UTC' );
+		return false === $timestamp ? 0 : $timestamp;
+	}
+
+	/**
+	 * Encode JSON with WordPress flags.
+	 */
+	private static function encode_json( $value ): ?string {
+		if ( null === $value ) {
+			return null;
+		}
+
+		$encoded = wp_json_encode( $value );
+		return false === $encoded ? null : $encoded;
+	}
+
+	/**
+	 * Decode JSON array/value data.
+	 */
+	private static function decode_json( $value ) {
+		if ( null === $value || '' === $value ) {
+			return array();
+		}
+
+		$decoded = json_decode( (string) $value, true );
+		return JSON_ERROR_NONE === json_last_error() ? $decoded : array();
+	}
+
+	/**
+	 * Normalize nullable IDs.
+	 */
+	private static function nullable_positive_int( $value ): ?int {
+		$value = (int) $value;
+		return $value > 0 ? $value : null;
+	}
+
+	/**
+	 * Normalize terminal status values.
+	 */
+	private static function normalize_status( string $status ): string {
+		$allowed = array( self::STATUS_PENDING, self::STATUS_ACCEPTED, self::STATUS_REJECTED, self::STATUS_EXPIRED, self::STATUS_DELETED );
+		return in_array( $status, $allowed, true ) ? $status : '';
+	}
+
+	/**
+	 * Determine if a pending row is expired.
+	 */
+	private static function is_expired_row( array $row ): bool {
+		$expires_at = self::mysql_to_timestamp( (string) ( $row['expires_at'] ?? '' ) );
+		return $expires_at > 0 && $expires_at <= time();
+	}
+
+	/**
+	 * Increment a summary bucket.
+	 */
+	private static function increment_summary_bucket( array &$bucket, string $key ): void {
+		$key = '' === $key ? '(none)' : $key;
+		if ( ! isset( $bucket[ $key ] ) ) {
+			$bucket[ $key ] = 0;
+		}
+		++$bucket[ $key ];
 	}
 }

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -359,11 +359,11 @@ class PendingActionStore {
 		$rows = self::list( array_merge( $filters, array( 'limit' => $filters['limit'] ?? 200 ) ) );
 
 		$summary = array(
-			'total'        => count( $rows ),
-			'by_status'    => array(),
-			'by_kind'      => array(),
-			'by_agent_id'  => array(),
-			'by_context'   => array(),
+			'total'       => count( $rows ),
+			'by_status'   => array(),
+			'by_kind'     => array(),
+			'by_agent_id' => array(),
+			'by_context'  => array(),
 		);
 
 		foreach ( $rows as $row ) {
@@ -442,24 +442,24 @@ class PendingActionStore {
 		$expires_at = self::mysql_to_timestamp( (string) ( $row['expires_at'] ?? '' ) );
 
 		return array(
-			'action_id'          => (string) ( $row['action_id'] ?? '' ),
-			'kind'               => (string) ( $row['kind'] ?? '' ),
-			'summary'            => (string) ( $row['summary'] ?? '' ),
-			'preview_data'       => self::decode_json( $row['preview_data'] ?? null ),
-			'preview'            => self::decode_json( $row['preview_data'] ?? null ),
-			'apply_input'        => self::decode_json( $row['apply_input'] ?? null ),
-			'agent_id'           => isset( $row['agent_id'] ) ? (int) $row['agent_id'] : 0,
-			'created_by'         => isset( $row['created_by'] ) ? (int) $row['created_by'] : 0,
-			'context'            => self::decode_json( $row['context'] ?? null ),
-			'status'             => (string) ( $row['status'] ?? self::STATUS_PENDING ),
-			'created_at'         => $created_at,
-			'created_at_iso'     => $created_at > 0 ? gmdate( 'c', $created_at ) : null,
-			'expires_at'         => $expires_at,
-			'expires_at_iso'     => $expires_at > 0 ? gmdate( 'c', $expires_at ) : null,
-			'resolved_at'        => self::mysql_to_timestamp( (string) ( $row['resolved_at'] ?? '' ) ),
-			'resolved_by'        => isset( $row['resolved_by'] ) ? (int) $row['resolved_by'] : 0,
-			'resolution_result'  => self::decode_json( $row['resolution_result'] ?? null ),
-			'resolution_error'   => isset( $row['resolution_error'] ) ? (string) $row['resolution_error'] : null,
+			'action_id'         => (string) ( $row['action_id'] ?? '' ),
+			'kind'              => (string) ( $row['kind'] ?? '' ),
+			'summary'           => (string) ( $row['summary'] ?? '' ),
+			'preview_data'      => self::decode_json( $row['preview_data'] ?? null ),
+			'preview'           => self::decode_json( $row['preview_data'] ?? null ),
+			'apply_input'       => self::decode_json( $row['apply_input'] ?? null ),
+			'agent_id'          => isset( $row['agent_id'] ) ? (int) $row['agent_id'] : 0,
+			'created_by'        => isset( $row['created_by'] ) ? (int) $row['created_by'] : 0,
+			'context'           => self::decode_json( $row['context'] ?? null ),
+			'status'            => (string) ( $row['status'] ?? self::STATUS_PENDING ),
+			'created_at'        => $created_at,
+			'created_at_iso'    => $created_at > 0 ? gmdate( 'c', $created_at ) : null,
+			'expires_at'        => $expires_at,
+			'expires_at_iso'    => $expires_at > 0 ? gmdate( 'c', $expires_at ) : null,
+			'resolved_at'       => self::mysql_to_timestamp( (string) ( $row['resolved_at'] ?? '' ) ),
+			'resolved_by'       => isset( $row['resolved_by'] ) ? (int) $row['resolved_by'] : 0,
+			'resolution_result' => self::decode_json( $row['resolution_result'] ?? null ),
+			'resolution_error'  => isset( $row['resolution_error'] ) ? (string) $row['resolution_error'] : null,
 		);
 	}
 

--- a/inc/Engine/AI/Actions/PendingActionStoreAdapter.php
+++ b/inc/Engine/AI/Actions/PendingActionStoreAdapter.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Agents API adapter for Data Machine pending-action storage.
+ *
+ * @package DataMachine\Engine\AI\Actions
+ */
+
+namespace DataMachine\Engine\AI\Actions;
+
+use AgentsAPI\AI\Approvals\PendingActionStoreInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Implements the generic Agents API store contract without changing the
+ * existing static Data Machine PendingActionStore facade.
+ */
+final class PendingActionStoreAdapter implements PendingActionStoreInterface {
+
+	/**
+	 * Persist a pending action payload.
+	 *
+	 * @param string $action_id Durable action identifier.
+	 * @param array  $payload   JSON-serializable pending action payload.
+	 * @return bool
+	 */
+	public function store( string $action_id, array $payload ): bool {
+		return PendingActionStore::store( $action_id, $payload );
+	}
+
+	/**
+	 * Retrieve a pending action payload.
+	 *
+	 * Agents API's merged contract is intentionally minimal and describes only
+	 * the live pending lifecycle. Data Machine's richer inspect/list surfaces
+	 * expose resolved audit rows separately.
+	 *
+	 * @param string $action_id Durable action identifier.
+	 * @return array|null
+	 */
+	public function get( string $action_id ): ?array {
+		return PendingActionStore::get( $action_id );
+	}
+
+	/**
+	 * Delete a pending action payload.
+	 *
+	 * @param string $action_id Durable action identifier.
+	 * @return bool
+	 */
+	public function delete( string $action_id ): bool {
+		return PendingActionStore::delete( $action_id );
+	}
+}

--- a/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
+++ b/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
@@ -51,6 +51,24 @@ class ResolvePendingActionAbility {
 	 */
 	private static bool $registered = false;
 
+	/**
+	 * Agents API resolver adapter singleton.
+	 *
+	 * @var PendingActionResolverAdapter|null
+	 */
+	private static ?PendingActionResolverAdapter $adapter = null;
+
+	/**
+	 * Return the Agents API resolver adapter.
+	 */
+	public static function adapter(): PendingActionResolverAdapter {
+		if ( null === self::$adapter ) {
+			self::$adapter = new PendingActionResolverAdapter();
+		}
+
+		return self::$adapter;
+	}
+
 	public function __construct() {
 		if ( self::$registered ) {
 			return;
@@ -198,6 +216,8 @@ class ResolvePendingActionAbility {
 		$kind        = (string) ( $payload['kind'] ?? '' );
 		$user_id     = get_current_user_id();
 		$apply_input = isset( $payload['apply_input'] ) && is_array( $payload['apply_input'] ) ? $payload['apply_input'] : array();
+		$resolver_payload = isset( $input['payload'] ) && is_array( $input['payload'] ) ? $input['payload'] : array();
+		$resolver_context = isset( $input['context'] ) && is_array( $input['context'] ) ? $input['context'] : array();
 
 		if ( '' === $kind ) {
 			PendingActionStore::delete( $action_id );
@@ -211,10 +231,10 @@ class ResolvePendingActionAbility {
 		$handlers = self::getKindHandlers();
 		$handler  = $handlers[ $kind ] ?? null;
 
-		if ( ! is_array( $handler ) || empty( $handler['apply'] ) || ! is_callable( $handler['apply'] ) ) {
+		if ( ! is_array( $handler ) || empty( $handler['apply'] ) || ! self::isApplyHandler( $handler['apply'] ) ) {
 			// No handler registered — can't apply, but reject is still safe.
 			if ( 'rejected' === $decision ) {
-				PendingActionStore::delete( $action_id );
+				PendingActionStore::record_resolution( $action_id, PendingActionStore::STATUS_REJECTED, null, null );
 				self::fireResolvedAction( $decision, $action_id, $kind, $payload, null );
 				return array(
 					'success'   => true,
@@ -253,10 +273,8 @@ class ResolvePendingActionAbility {
 			}
 		}
 
-		// Always clean up the stored payload after a decision is made.
-		PendingActionStore::delete( $action_id );
-
 		if ( 'rejected' === $decision ) {
+			PendingActionStore::record_resolution( $action_id, PendingActionStore::STATUS_REJECTED, null, null );
 			self::fireResolvedAction( $decision, $action_id, $kind, $payload, null );
 			return array(
 				'success'   => true,
@@ -267,11 +285,11 @@ class ResolvePendingActionAbility {
 		}
 
 		// Accepted: invoke the apply handler with the stored input.
-		$result = call_user_func( $handler['apply'], $apply_input, $payload );
-
-		self::fireResolvedAction( $decision, $action_id, $kind, $payload, $result );
+		$result = self::applyHandler( $handler, $apply_input, $payload, $resolver_payload, $resolver_context );
 
 		if ( is_wp_error( $result ) ) {
+			PendingActionStore::record_resolution( $action_id, PendingActionStore::STATUS_ACCEPTED, null, $result->get_error_message() );
+			self::fireResolvedAction( $decision, $action_id, $kind, $payload, $result );
 			return array(
 				'success'   => false,
 				'decision'  => 'accepted',
@@ -282,6 +300,8 @@ class ResolvePendingActionAbility {
 		}
 
 		if ( is_array( $result ) && array_key_exists( 'success', $result ) && false === $result['success'] ) {
+			PendingActionStore::record_resolution( $action_id, PendingActionStore::STATUS_ACCEPTED, $result, $result['error'] ?? 'Apply handler reported failure.' );
+			self::fireResolvedAction( $decision, $action_id, $kind, $payload, $result );
 			return array(
 				'success'   => false,
 				'decision'  => 'accepted',
@@ -291,6 +311,9 @@ class ResolvePendingActionAbility {
 				'error'     => $result['error'] ?? 'Apply handler reported failure.',
 			);
 		}
+
+		PendingActionStore::record_resolution( $action_id, PendingActionStore::STATUS_ACCEPTED, $result, null );
+		self::fireResolvedAction( $decision, $action_id, $kind, $payload, $result );
 
 		return array(
 			'success'   => true,
@@ -323,6 +346,52 @@ class ResolvePendingActionAbility {
 		 */
 		$handlers = apply_filters( 'datamachine_pending_action_handlers', array() );
 		return is_array( $handlers ) ? $handlers : array();
+	}
+
+	/**
+	 * Apply a pending-action handler.
+	 *
+	 * The legacy Data Machine handler map remains the compatibility surface today.
+	 * When Agents API PR #51's handler contract is installed, object handlers can
+	 * implement it and be placed under the same `apply` key without introducing a
+	 * parallel Data Machine primitive.
+	 *
+	 * @param array $handler     Handler configuration.
+	 * @param array $apply_input Stored apply input.
+	 * @param array $payload     Stored pending action payload.
+	 * @param array $resolver_payload Fresh resolver payload.
+	 * @param array $resolver_context Optional resolver context.
+	 * @return mixed
+	 */
+	private static function applyHandler( array $handler, array $apply_input, array $payload, array $resolver_payload = array(), array $resolver_context = array() ) {
+		$apply = $handler['apply'];
+		if (
+			is_object( $apply )
+			&& interface_exists( 'AgentsAPI\\AI\\Approvals\\PendingActionHandlerInterface' )
+			&& is_a( $apply, 'AgentsAPI\\AI\\Approvals\\PendingActionHandlerInterface' )
+			&& class_exists( 'AgentsAPI\\AI\\Approvals\\ApprovalDecision' )
+		) {
+			$decision = \AgentsAPI\AI\Approvals\ApprovalDecision::accepted();
+			return $apply->handle_pending_action( $decision, $apply_input, $resolver_payload, $resolver_context );
+		}
+
+		return call_user_func( $apply, $apply_input, $payload );
+	}
+
+	/**
+	 * Determine if a handler entry can apply accepted actions.
+	 *
+	 * @param mixed $apply Handler entry.
+	 * @return bool
+	 */
+	private static function isApplyHandler( $apply ): bool {
+		if ( is_callable( $apply ) ) {
+			return true;
+		}
+
+		return is_object( $apply )
+			&& interface_exists( 'AgentsAPI\\AI\\Approvals\\PendingActionHandlerInterface' )
+			&& is_a( $apply, 'AgentsAPI\\AI\\Approvals\\PendingActionHandlerInterface' );
 	}
 
 	/**

--- a/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
+++ b/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
@@ -213,9 +213,9 @@ class ResolvePendingActionAbility {
 			);
 		}
 
-		$kind        = (string) ( $payload['kind'] ?? '' );
-		$user_id     = get_current_user_id();
-		$apply_input = isset( $payload['apply_input'] ) && is_array( $payload['apply_input'] ) ? $payload['apply_input'] : array();
+		$kind             = (string) ( $payload['kind'] ?? '' );
+		$user_id          = get_current_user_id();
+		$apply_input      = isset( $payload['apply_input'] ) && is_array( $payload['apply_input'] ) ? $payload['apply_input'] : array();
 		$resolver_payload = isset( $input['payload'] ) && is_array( $input['payload'] ) ? $input['payload'] : array();
 		$resolver_context = isset( $input['context'] ) && is_array( $input['context'] ) ? $input['context'] : array();
 

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -33,6 +33,7 @@ require_once __DIR__ . '/settings-mode-models.php';
 require_once __DIR__ . '/ai-provider-keys.php';
 require_once __DIR__ . '/bundle-artifacts.php';
 require_once __DIR__ . '/processed-item-claims.php';
+require_once __DIR__ . '/pending-actions.php';
 
 // Schema-migration runtime — defines `datamachine_run_schema_migrations()`
 // and `datamachine_maybe_run_deferred_migrations()`. Hooked at

--- a/inc/migrations/pending-actions.php
+++ b/inc/migrations/pending-actions.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Data Machine — pending-action durable table migration.
+ *
+ * @package DataMachine
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Ensure the durable pending-action table exists on upgraded installs.
+ */
+function datamachine_migrate_pending_actions_table(): void {
+	\DataMachine\Engine\AI\Actions\PendingActionStore::create_table();
+}

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -138,6 +138,9 @@ function datamachine_run_schema_migrations(): void {
 
 	// Add in-flight source-item claim state to processed_items (#1682).
 	datamachine_migrate_processed_item_claims();
+
+	// Ensure durable pending-action storage exists for background approval queues (#1736/#1737).
+	datamachine_migrate_pending_actions_table();
 }
 
 /**

--- a/tests/pending-actions-agents-api-contract-smoke.php
+++ b/tests/pending-actions-agents-api-contract-smoke.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Pure-PHP smoke coverage for Data Machine pending-action approval surfaces.
+ *
+ * Run with: php tests/pending-actions-agents-api-contract-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failures = array();
+$passes   = 0;
+
+echo "pending-actions-agents-api-contract-smoke\n";
+
+function datamachine_pending_actions_assert( bool $condition, string $message, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	$failures[] = $message;
+	echo "FAIL: {$message}\n";
+}
+
+function datamachine_pending_actions_source( string $path ): string {
+	$contents = file_get_contents( dirname( __DIR__ ) . '/' . $path );
+	if ( false === $contents ) {
+		throw new RuntimeException( 'Unable to read ' . $path );
+	}
+
+	return $contents;
+}
+
+$store_source       = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/PendingActionStore.php' );
+$adapter_source     = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/PendingActionStoreAdapter.php' );
+$resolver_adapter   = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/PendingActionResolverAdapter.php' );
+$resolver_source    = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/ResolvePendingActionAbility.php' );
+$inspection_source  = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/PendingActionInspectionAbility.php' );
+$cli_bootstrap      = datamachine_pending_actions_source( 'inc/Cli/Bootstrap.php' );
+$cli_command_source = datamachine_pending_actions_source( 'inc/Cli/Commands/PendingActionsCommand.php' );
+$plugin_source      = datamachine_pending_actions_source( 'data-machine.php' );
+$runtime_source     = datamachine_pending_actions_source( 'inc/migrations/runtime.php' );
+$agents_store       = datamachine_pending_actions_source( 'vendor/automattic/agents-api/src/Approvals/PendingActionStoreInterface.php' );
+$agents_policy      = datamachine_pending_actions_source( 'vendor/automattic/agents-api/src/Tools/ActionPolicy.php' );
+$agents_resolver    = datamachine_pending_actions_source( 'vendor/automattic/agents-api/src/Approvals/PendingActionResolverInterface.php' );
+$agents_handler     = datamachine_pending_actions_source( 'vendor/automattic/agents-api/src/Approvals/PendingActionHandlerInterface.php' );
+$action_policy      = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/ActionPolicyResolver.php' );
+
+echo "\n[1] Data Machine adapts to merged Agents API contracts:\n";
+datamachine_pending_actions_assert( str_contains( $adapter_source, 'implements PendingActionStoreInterface' ), 'store adapter implements Agents API PendingActionStoreInterface', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $resolver_adapter, 'implements PendingActionResolverInterface' ), 'resolver adapter implements Agents API PendingActionResolverInterface', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $action_policy, 'AgentsAPI\\AI\\Tools\\ActionPolicy::normalize' ), 'ActionPolicyResolver feature-detects Agents API ActionPolicy vocabulary', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $agents_store, 'interface PendingActionStoreInterface' ), 'installed Agents API exposes the pending action store contract', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $agents_policy, 'final class ActionPolicy' ), 'installed Agents API exposes the action policy vocabulary', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $agents_resolver, 'interface PendingActionResolverInterface' ), 'installed Agents API exposes the resolver contract', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $agents_handler, 'interface PendingActionHandlerInterface' ), 'installed Agents API exposes the handler contract', $failures, $passes );
+
+echo "\n[2] Durable storage preserves legacy lookup while retaining audit rows:\n";
+datamachine_pending_actions_assert( str_contains( $store_source, 'CREATE TABLE {$table_name}' ), 'PendingActionStore creates a durable table', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $store_source, 'datamachine_pending_actions' ), 'durable table uses Data Machine pending-actions table name', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $store_source, 'public static function get( string $action_id, bool $include_resolved = false )' ), 'legacy get defaults to live-pending rows only', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $store_source, 'public static function inspect( string $action_id ): ?array' ), 'inspect surface can fetch resolved audit rows', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $resolver_source, 'record_resolution( $action_id, PendingActionStore::STATUS_ACCEPTED' ), 'accepted resolutions are retained instead of transient-deleted', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $resolver_source, 'record_resolution( $action_id, PendingActionStore::STATUS_REJECTED' ), 'rejected resolutions are retained instead of transient-deleted', $failures, $passes );
+
+echo "\n[3] List/get/summary surfaces are registered for agents and operators:\n";
+foreach ( array( 'datamachine/list-pending-actions', 'datamachine/get-pending-action', 'datamachine/summarize-pending-actions' ) as $ability ) {
+	datamachine_pending_actions_assert( str_contains( $inspection_source, $ability ), $ability . ' ability is registered', $failures, $passes );
+}
+foreach ( array( '/actions', '/actions/(?P<action_id>', '/actions/summary' ) as $route ) {
+	datamachine_pending_actions_assert( str_contains( $inspection_source, $route ), $route . ' REST route is registered', $failures, $passes );
+}
+datamachine_pending_actions_assert( str_contains( $cli_bootstrap, 'datamachine pending-actions' ), 'pending-actions CLI command is registered', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $cli_command_source, 'public function list' ) && str_contains( $cli_command_source, 'public function get' ) && str_contains( $cli_command_source, 'public function summary' ), 'CLI exposes list/get/summary subcommands', $failures, $passes );
+
+echo "\n[4] Existing resolver and handler compatibility remains the canonical resolution path:\n";
+datamachine_pending_actions_assert( str_contains( $resolver_source, 'datamachine_pending_action_handlers' ), 'legacy pending action handler filter remains in resolver', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $resolver_source, 'PendingActionHandlerInterface' ), 'Agents API handler contract is bridged through the existing handler filter', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $plugin_source, 'new \\DataMachine\\Engine\\AI\\Actions\\ResolvePendingActionAbility();' ), 'existing resolve ability remains registered', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $plugin_source, 'new \\DataMachine\\Engine\\AI\\Actions\\ResolvePendingAction();' ), 'existing chat resolver tool remains registered', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $runtime_source, 'datamachine_migrate_pending_actions_table' ), 'upgrade path creates pending-action table on deployed installs', $failures, $passes );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures:\n";
+	foreach ( $failures as $failure ) {
+		echo '- ' . $failure . "\n";
+	}
+	exit( 1 );
+}
+
+echo "\nPending action Agents API contract smoke passed ({$passes} assertions).\n";


### PR DESCRIPTION
## Summary
- Implement durable WordPress-backed PendingAction storage aligned with Agents API approval contracts, including store/resolver adapters and ActionPolicy feature detection.
- Add list/get/summary ability, REST, and WP-CLI inspection surfaces while preserving `datamachine/resolve-pending-action`, the REST resolver, chat tool, and `datamachine_pending_action_handlers` compatibility.
- Retain resolved/rejected/expired rows for audit while keeping legacy `PendingActionStore::get()` scoped to live pending actions.

## Testing
- `vendor/bin/phpcs inc/Engine/AI/Actions/PendingActionStore.php inc/Engine/AI/Actions/PendingActionStoreAdapter.php inc/Engine/AI/Actions/PendingActionResolverAdapter.php inc/Engine/AI/Actions/PendingActionInspectionAbility.php inc/Engine/AI/Actions/ResolvePendingActionAbility.php inc/Engine/AI/Actions/PendingActionHelper.php inc/Engine/AI/Actions/ActionPolicyResolver.php inc/Cli/Commands/PendingActionsCommand.php inc/migrations/pending-actions.php data-machine.php inc/Cli/Bootstrap.php inc/migrations/load.php inc/migrations/runtime.php tests/pending-actions-agents-api-contract-smoke.php`
- `php tests/pending-actions-agents-api-contract-smoke.php`
- `php tests/memory-bundle-policy-smoke.php`
- `php tests/tool-executor-ability-native-smoke.php`
- `php tests/agent-bundle-upgrade-planner-smoke.php`
- `php tests/agents-api-bootstrap-smoke.php`
- `php tests/agents-api-wp-ai-client-vocabulary-smoke.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented the pending-action storage/adapters/surfaces and focused tests; Chris reviews and owns the submitted change.

Fixes #1736.
Fixes #1737.