### PR TITLE
docs: audit approval primitive adapter migration

### DIFF
--- a/docs/development/agents-api-extraction-map.md
+++ b/docs/development/agents-api-extraction-map.md
@@ -6,7 +6,7 @@ Parent issue: [Explore splitting Agents API out of Data Machine](https://github.
 
 Strategy update: [Agents API blocker: update extraction docs around in-repo module strategy](https://github.com/Extra-Chill/data-machine/issues/1640)
 
-Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618) ([docs](agents-api-standalone-skeleton-plan.md)), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [registration lifecycle](https://github.com/Extra-Chill/data-machine/issues/1671), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), [one-shot AI boundary](https://github.com/Extra-Chill/data-machine/issues/1693), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
+Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618) ([docs](agents-api-standalone-skeleton-plan.md)), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [registration lifecycle](https://github.com/Extra-Chill/data-machine/issues/1671), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), [one-shot AI boundary](https://github.com/Extra-Chill/data-machine/issues/1693), [approval primitive migration umbrella](https://github.com/Extra-Chill/data-machine/issues/1741), [pending-action store adapter](https://github.com/Extra-Chill/data-machine/issues/1742), [approval-required envelope adapter](https://github.com/Extra-Chill/data-machine/issues/1743), [approval resolver adapter](https://github.com/Extra-Chill/data-machine/issues/1744), [action-policy vocabulary adapter](https://github.com/Extra-Chill/data-machine/issues/1745), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
 
 ## Namespace Map
 
@@ -43,7 +43,7 @@ Data Machine now treats the standalone `extra-chill/agents-api` package/plugin a
 - `agents-api` must not import Data Machine product namespaces.
 - Data Machine may import and consume `agents-api` as product code.
 - `agents-api` owns runner interfaces, value objects, and generic contracts first; Data Machine keeps `AIConversationLoop` and the built-in compatibility runner while they still carry Data Machine job, flow, handler, logging, transcript, and legacy result-shape assumptions.
-- Data Machine keeps flows, pipelines, jobs, handlers, queues, retention, concrete pending-action storage/resolution, content operations, and admin UI. The generic pending-action / diff-approval contract vocabulary belongs in a later Agents API extraction stage.
+- Data Machine keeps flows, pipelines, jobs, handlers, queues, retention, concrete pending-action storage/resolution, content operations, and admin UI. Generic approval primitives now come from Agents API; Data Machine's pending-action work is an adapter migration tracked by [#1741](https://github.com/Extra-Chill/data-machine/issues/1741) and split across [#1742](https://github.com/Extra-Chill/data-machine/issues/1742)-[#1745](https://github.com/Extra-Chill/data-machine/issues/1745).
 - `agents-api` is backend-only and invisible by default: no admin menus, screens, human CRUD forms, React apps, or Data Machine product UI.
 - Data Machine and other product consumers own any admin/product UI they build on top of the substrate.
 - Standalone extraction means the bounded module now lives in its own plugin/repo with plugin bootstrap, release, dependency, and distribution ceremony.
@@ -74,7 +74,7 @@ Mirror the WordPress Abilities API shape instead of importing Data Machine produ
 | `AgentMemoryStoreInterface` | `WP_Agent_Memory_Store_Interface` | Generic identity tuple needs naming review; Data Machine scaffolding/abilities stay outside the store contract. |
 | `RuntimeToolDeclaration` | `WP_Agent_Tool_Declaration` | Should stay ability-native and run-scoped. |
 | `LoopEventSinkInterface` | `WP_Agent_Run_Event_Sink_Interface` | Useful for logs, streaming, chat UIs, and async workers. |
-| Data Machine pending actions / diff approvals | Future Agents API approval contract | Agents API should own the generic contract/value/envelope/policy vocabulary for approval-gated agent effects. Data Machine keeps the current transient/database implementation, resolver ability, REST route, chat wrapper, product handlers, and permission checks. |
+| Data Machine pending actions / diff approvals | Agents API approval primitives consumed through Data Machine adapters | Agents API owns generic approval contracts and policy vocabulary. Data Machine keeps concrete pending-action persistence, resolver ability, REST route, chat wrapper, product handlers, and permission checks while adapting to those primitives. |
 | REST `datamachine/v1` agent routes | REST `wp-agents/v1` deferred | [#1670](https://github.com/Extra-Chill/data-machine/issues/1670) reserves the namespace but defers public REST controllers from the first standalone extraction. Data Machine product routes stay under `datamachine/v1`. |
 
 ## Registration Lifecycle
@@ -102,7 +102,20 @@ Use these checks before moving anything:
 - If it uses host-specific provider, storage, or implementation vocabulary directly, treat that code as source material only until normalized behind WordPress-shaped contracts.
 - If it only needs to execute a single prompt/model request, it should use `wp-ai-client` directly instead of introducing Agents API.
 - If it needs durable agent runtime behavior, it should use Agents API and let that runtime call `wp-ai-client` directly for provider execution.
-- If it describes approval-gated agent effects, diff envelopes, or action-resolution policy without Data Machine storage/routes/UI, it is an Agents API contract candidate. If it persists, resolves, displays, or permission-checks Data Machine pending actions, it stays a Data Machine adapter/product surface.
+- If it describes approval-gated agent effects, diff envelopes, action-resolution policy, or approve/reject decisions without Data Machine storage/routes/UI, consume the Agents API approval primitive. If it persists, resolves, displays, audits, or permission-checks Data Machine pending actions, it stays a Data Machine adapter/product surface.
+
+## Approval Primitive Adapter Migration
+
+[#1741](https://github.com/Extra-Chill/data-machine/issues/1741) is the umbrella for making Data Machine consume Agents API approval primitives without moving Data Machine product surfaces into the substrate. The migration is intentionally file-scoped so each adapter can land independently and preserve existing preview/approve behavior.
+
+| Slice | Data Machine surface | Agents API primitive to consume | Boundary rule |
+|---|---|---|---|
+| [#1742](https://github.com/Extra-Chill/data-machine/issues/1742) | `PendingActionStore` / store adapter | `AgentsAPI\AI\Approvals\PendingActionStoreInterface` | Keep Data Machine's concrete storage, table/transient compatibility, TTL, audit rows, and lookup behavior in Data Machine. |
+| [#1743](https://github.com/Extra-Chill/data-machine/issues/1743) | `PendingActionHelper` staging result | Agents API `approval_required` envelope vocabulary | Preserve compatibility fields such as `staged`, `action_id`, `resolve_with`, and `resolve_params`; keep Data Machine route/tool names as adapter metadata. |
+| [#1744](https://github.com/Extra-Chill/data-machine/issues/1744) | `ResolvePendingActionAbility` / resolver adapter | `AgentsAPI\AI\Approvals\ApprovalDecision`, `PendingActionResolverInterface`, and `PendingActionHandlerInterface` | Keep `datamachine/resolve-pending-action`, `datamachine/v1/actions/resolve`, permission checks, and `datamachine_pending_action_handlers` compatibility. |
+| [#1745](https://github.com/Extra-Chill/data-machine/issues/1745) | `ActionPolicyResolver` / `ToolExecutor` policy checks | `AgentsAPI\AI\Tools\ActionPolicy` | Preserve Data Machine precedence for deny lists, agent overrides, category overrides, tool defaults, mode presets, and `datamachine_tool_action_policy`. |
+
+Acceptance guard: `tests/pending-actions-agents-api-contract-smoke.php` should stay a static boundary smoke. It pins the expected Agents API classes Data Machine consumes and verifies that Data Machine remains the adapter for storage, routes, abilities, handlers, CLI, and upgrade paths. It must not grow into a behavioral clone of the child-issue tests.
 
 ## Backend-Only UI Boundary
 

--- a/docs/development/agents-api-pre-extraction-audit.md
+++ b/docs/development/agents-api-pre-extraction-audit.md
@@ -4,7 +4,7 @@ Parent issue: [Explore splitting Agents API out of Data Machine](https://github.
 
 Strategy issue: [Agents API blocker: update extraction docs around in-repo module strategy](https://github.com/Extra-Chill/data-machine/issues/1640)
 
-Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618) ([docs](agents-api-standalone-skeleton-plan.md)), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [registration lifecycle](https://github.com/Extra-Chill/data-machine/issues/1671), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), [one-shot AI boundary](https://github.com/Extra-Chill/data-machine/issues/1693), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
+Related blockers: [standalone extraction umbrella](https://github.com/Extra-Chill/data-machine/issues/1596), [standalone skeleton plan](https://github.com/Extra-Chill/data-machine/issues/1618) ([docs](agents-api-standalone-skeleton-plan.md)), [in-repo module boundary](https://github.com/Extra-Chill/data-machine/issues/1631), [candidate relocation](https://github.com/Extra-Chill/data-machine/issues/1632), [wp-ai-client dependency contract](https://github.com/Extra-Chill/data-machine/issues/1633), [built-in loop ownership](https://github.com/Extra-Chill/data-machine/issues/1634), [backend-only boundary](https://github.com/Extra-Chill/data-machine/issues/1651), [agent category/capability metadata](https://github.com/Extra-Chill/data-machine/issues/1669), [REST surface decision](https://github.com/Extra-Chill/data-machine/issues/1670), [registration lifecycle](https://github.com/Extra-Chill/data-machine/issues/1671), [core-shape readiness checklist](https://github.com/Extra-Chill/data-machine/issues/1672), [one-shot AI boundary](https://github.com/Extra-Chill/data-machine/issues/1693), [approval primitive migration umbrella](https://github.com/Extra-Chill/data-machine/issues/1741), [pending-action store adapter](https://github.com/Extra-Chill/data-machine/issues/1742), [approval-required envelope adapter](https://github.com/Extra-Chill/data-machine/issues/1743), [approval resolver adapter](https://github.com/Extra-Chill/data-machine/issues/1744), [action-policy vocabulary adapter](https://github.com/Extra-Chill/data-machine/issues/1745), and [ai-http-client removal](https://github.com/Extra-Chill/data-machine/issues/1027).
 
 This audit records the work that made the Agents API boundary extractable. Data Machine owns pipelines and automation; Agents API owns generic agent runtime primitives. The in-repo module phase is complete, and Data Machine now consumes the standalone `extra-chill/agents-api` package/plugin instead of carrying a second authoritative copy.
 
@@ -28,7 +28,7 @@ That module was treated like WordPress core substrate while it lived inside Data
 - Data Machine consumes `agents-api` as product code.
 - `agents-api` must not import Data Machine product namespaces.
 - `agents-api` owns runner interfaces, value objects, and generic contracts first; Data Machine keeps `AIConversationLoop` and the built-in compatibility runner until the loop no longer carries Data Machine job, flow, handler, logging, transcript, or legacy payload/result assumptions.
-- `agents-api` should also own generic pending-action / diff-approval contract vocabulary in a later extraction stage: approval action values, diff/change envelopes, resolver result shapes, and policy/permission-ceiling concepts that are not tied to Data Machine storage or routes.
+- `agents-api` owns generic approval primitive vocabulary: action-policy values, pending-action store/resolver/handler contracts, approve/reject decisions, and approval-required envelope semantics that are not tied to Data Machine storage or routes.
 - Data Machine keeps flows, pipelines, jobs, handlers, queues, retention, concrete pending-action storage/resolution, content operations, and admin UI.
 - `agents-api` is backend-only and invisible by default: no admin menus, screens, human CRUD forms, React apps, or Data Machine product UI.
 - Data Machine and other product consumers own any admin/product UI they build on top of the substrate.
@@ -148,7 +148,7 @@ REST acceptance gates before any future controller lands:
 | Built-in loop ownership is settled: Data Machine keeps compatibility loop until completion/transcript/provider/logging assumptions are behind generic collaborators. | Must fix | [#1634](https://github.com/Extra-Chill/data-machine/issues/1634) |
 | Provider runtime depends directly on `wp-ai-client`; no `ai-http-client` or `chubes_ai_request` runtime fallback survives inside `agents-api`. | Must fix | [#1633](https://github.com/Extra-Chill/data-machine/issues/1633), [#1027](https://github.com/Extra-Chill/data-machine/issues/1027), [#1660](https://github.com/Extra-Chill/data-machine/issues/1660), [#1661](https://github.com/Extra-Chill/data-machine/issues/1661) |
 | Memory and transcript interfaces are generic and UI-free. Data Machine chat/session switcher/read-state/reporting remain product adapters unless separately adopted. | Must fix | [#1632](https://github.com/Extra-Chill/data-machine/issues/1632), [#1651](https://github.com/Extra-Chill/data-machine/issues/1651) |
-| Data Machine adapters own flows, jobs, pipelines, handlers, concrete pending-action storage/resolution, bundles, queues, retention, content operations, and chat/admin UI. Agents API owns only planned generic approval contract/value/envelope/policy vocabulary. | Must fix | [#1561](https://github.com/Extra-Chill/data-machine/issues/1561), [#1640](https://github.com/Extra-Chill/data-machine/issues/1640), [#1651](https://github.com/Extra-Chill/data-machine/issues/1651) |
+| Data Machine adapters own flows, jobs, pipelines, handlers, concrete pending-action storage/resolution, bundles, queues, retention, content operations, and chat/admin UI. Approval-gated behavior consumes Agents API primitives through Data Machine adapters instead of duplicating generic vocabulary locally. | Must fix | [#1561](https://github.com/Extra-Chill/data-machine/issues/1561), [#1640](https://github.com/Extra-Chill/data-machine/issues/1640), [#1651](https://github.com/Extra-Chill/data-machine/issues/1651), [#1741](https://github.com/Extra-Chill/data-machine/issues/1741) |
 | Standalone skeleton documents that `wp-agents/v1` is absent in v1 and includes no REST controllers until the REST acceptance gates are satisfied. | Must fix | [#1618](https://github.com/Extra-Chill/data-machine/issues/1618), [#1670](https://github.com/Extra-Chill/data-machine/issues/1670) |
 | Optional future stores, sessions, async run state, REST controllers, category parity, and product UI are deferred until the core backend contracts are extractable. | Can follow | [#1596](https://github.com/Extra-Chill/data-machine/issues/1596), [#1670](https://github.com/Extra-Chill/data-machine/issues/1670), [#1669](https://github.com/Extra-Chill/data-machine/issues/1669) |
 
@@ -253,14 +253,17 @@ Target shape:
 
 ### 8. Pending-Action / Approval Boundary
 
-The current Data Machine pending-action implementation is not the upstream contract, but it identifies a generic seam that should be promoted later.
+Data Machine pending actions are now an adapter over Agents API approval primitives, not the source of truth for generic approval vocabulary. The migration is coordinated by [#1741](https://github.com/Extra-Chill/data-machine/issues/1741) and split into narrow file-scoped PRs so the concrete Data Machine product behavior stays stable.
 
-Target shape:
+Adapter checklist:
 
-- Agents API owns the generic approval contract vocabulary: pending-action/action value objects, diff/change envelopes, resolver result shapes, and policy/permission-ceiling concepts.
-- Data Machine owns the transient/database implementation, `datamachine/resolve-pending-action`, `datamachine/v1/actions/resolve`, the chat wrapper, product handlers, and Data Machine permission checks.
-- Do not import or reference non-existent upstream approval classes from Data Machine yet; phrase current work as source material for the next extraction stage.
+- [#1742](https://github.com/Extra-Chill/data-machine/issues/1742): adapt `PendingActionStore` to `AgentsAPI\AI\Approvals\PendingActionStoreInterface` while preserving Data Machine storage, IDs, TTL/table compatibility, audit rows, and legacy lookup defaults.
+- [#1743](https://github.com/Extra-Chill/data-machine/issues/1743): adapt `PendingActionHelper` staging to Agents API `approval_required` envelope semantics while preserving downstream compatibility fields such as `staged`, `action_id`, `resolve_with`, and `resolve_params`.
+- [#1744](https://github.com/Extra-Chill/data-machine/issues/1744): adapt `ResolvePendingActionAbility` to `AgentsAPI\AI\Approvals\ApprovalDecision`, `PendingActionResolverInterface`, and `PendingActionHandlerInterface` while keeping `datamachine/resolve-pending-action`, `datamachine/v1/actions/resolve`, permission checks, and `datamachine_pending_action_handlers` compatibility.
+- [#1745](https://github.com/Extra-Chill/data-machine/issues/1745): adapt Data Machine action policy checks to `AgentsAPI\AI\Tools\ActionPolicy` while preserving existing Data Machine precedence and `direct` / `preview` / `forbidden` behavior.
+- Data Machine owns the concrete storage/resolution implementation, resolver ability, REST route, chat wrapper, product handlers, CLI/operator surfaces, and Data Machine permission checks.
 - Keep Data Machine route names and storage keys out of future Agents API public contracts.
+- Keep `tests/pending-actions-agents-api-contract-smoke.php` as a static boundary guard for the expected imported Agents API classes and adapter ownership. Child PR tests should prove behavior for their file slice; this audit smoke should not duplicate that implementation coverage.
 
 ### 9. Data Machine Product Still Under `Engine\AI`
 
@@ -304,7 +307,7 @@ Agents API should provide the substrate for those products:
 - Message/result contracts.
 - Conversation runner contract.
 - Tool declaration and execution contracts.
-- Generic pending-action / diff-approval contract vocabulary.
+- Generic approval primitive vocabulary consumed by products through adapters.
 - Memory store contract and default memory implementations.
 - Conversation transcript contract.
 - Event sink / streaming / observation contract.

--- a/tests/pending-actions-agents-api-contract-smoke.php
+++ b/tests/pending-actions-agents-api-contract-smoke.php
@@ -1,6 +1,10 @@
 <?php
 /**
- * Pure-PHP smoke coverage for Data Machine pending-action approval surfaces.
+ * Static smoke coverage for Data Machine pending-action approval adapter surfaces.
+ *
+ * This pins the #1741 boundary without duplicating the behavior tests owned by
+ * #1742-#1745: Agents API owns generic approval primitives, while Data Machine
+ * owns concrete storage, routes, abilities, handlers, CLI, and upgrade paths.
  *
  * Run with: php tests/pending-actions-agents-api-contract-smoke.php
  *
@@ -41,20 +45,40 @@ $cli_bootstrap      = datamachine_pending_actions_source( 'inc/Cli/Bootstrap.php
 $cli_command_source = datamachine_pending_actions_source( 'inc/Cli/Commands/PendingActionsCommand.php' );
 $plugin_source      = datamachine_pending_actions_source( 'data-machine.php' );
 $runtime_source     = datamachine_pending_actions_source( 'inc/migrations/runtime.php' );
-$agents_store       = datamachine_pending_actions_source( 'vendor/automattic/agents-api/src/Approvals/PendingActionStoreInterface.php' );
-$agents_policy      = datamachine_pending_actions_source( 'vendor/automattic/agents-api/src/Tools/ActionPolicy.php' );
-$agents_resolver    = datamachine_pending_actions_source( 'vendor/automattic/agents-api/src/Approvals/PendingActionResolverInterface.php' );
-$agents_handler     = datamachine_pending_actions_source( 'vendor/automattic/agents-api/src/Approvals/PendingActionHandlerInterface.php' );
 $action_policy      = datamachine_pending_actions_source( 'inc/Engine/AI/Actions/ActionPolicyResolver.php' );
 
+$expected_agents_api_approval_primitives = array(
+	'AgentsAPI\\AI\\Approvals\\PendingActionStoreInterface'    => array(
+		'path' => 'vendor/automattic/agents-api/src/Approvals/PendingActionStoreInterface.php',
+		'type' => 'interface PendingActionStoreInterface',
+	),
+	'AgentsAPI\\AI\\Approvals\\PendingActionResolverInterface' => array(
+		'path' => 'vendor/automattic/agents-api/src/Approvals/PendingActionResolverInterface.php',
+		'type' => 'interface PendingActionResolverInterface',
+	),
+	'AgentsAPI\\AI\\Approvals\\PendingActionHandlerInterface'  => array(
+		'path' => 'vendor/automattic/agents-api/src/Approvals/PendingActionHandlerInterface.php',
+		'type' => 'interface PendingActionHandlerInterface',
+	),
+	'AgentsAPI\\AI\\Approvals\\ApprovalDecision'               => array(
+		'path' => 'vendor/automattic/agents-api/src/Approvals/ApprovalDecision.php',
+		'type' => 'final class ApprovalDecision',
+	),
+	'AgentsAPI\\AI\\Tools\\ActionPolicy'                       => array(
+		'path' => 'vendor/automattic/agents-api/src/Tools/ActionPolicy.php',
+		'type' => 'final class ActionPolicy',
+	),
+);
+
 echo "\n[1] Data Machine adapts to merged Agents API contracts:\n";
+foreach ( $expected_agents_api_approval_primitives as $class_name => $primitive ) {
+	$primitive_source = datamachine_pending_actions_source( $primitive['path'] );
+	datamachine_pending_actions_assert( str_contains( $primitive_source, $primitive['type'] ), $class_name . ' is available from the installed Agents API dependency', $failures, $passes );
+}
 datamachine_pending_actions_assert( str_contains( $adapter_source, 'implements PendingActionStoreInterface' ), 'store adapter implements Agents API PendingActionStoreInterface', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $resolver_adapter, 'implements PendingActionResolverInterface' ), 'resolver adapter implements Agents API PendingActionResolverInterface', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $action_policy, 'AgentsAPI\\AI\\Tools\\ActionPolicy::normalize' ), 'ActionPolicyResolver feature-detects Agents API ActionPolicy vocabulary', $failures, $passes );
-datamachine_pending_actions_assert( str_contains( $agents_store, 'interface PendingActionStoreInterface' ), 'installed Agents API exposes the pending action store contract', $failures, $passes );
-datamachine_pending_actions_assert( str_contains( $agents_policy, 'final class ActionPolicy' ), 'installed Agents API exposes the action policy vocabulary', $failures, $passes );
-datamachine_pending_actions_assert( str_contains( $agents_resolver, 'interface PendingActionResolverInterface' ), 'installed Agents API exposes the resolver contract', $failures, $passes );
-datamachine_pending_actions_assert( str_contains( $agents_handler, 'interface PendingActionHandlerInterface' ), 'installed Agents API exposes the handler contract', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $resolver_adapter, 'ApprovalDecision' ), 'resolver adapter consumes Agents API ApprovalDecision vocabulary', $failures, $passes );
 
 echo "\n[2] Durable storage preserves legacy lookup while retaining audit rows:\n";
 datamachine_pending_actions_assert( str_contains( $store_source, 'CREATE TABLE {$table_name}' ), 'PendingActionStore creates a durable table', $failures, $passes );


### PR DESCRIPTION
## Summary
- Updates the Agents API extraction docs from a planned pending-action boundary to a concrete approval primitive adapter checklist for #1741.
- Maps the file-scoped migration slices for #1742-#1745 without moving runtime PHP implementation into this PR.
- Tightens the pending-action Agents API contract smoke so it explicitly lists the approval primitives Data Machine should consume.

Refs #1741.

## Testing
- `php tests/pending-actions-agents-api-contract-smoke.php`
- `php -l tests/pending-actions-agents-api-contract-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** drafted focused docs/static smoke; Chris reviews before merge.