### PR TITLE
Adopt Agents API approval envelopes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "969cf5572f9df05feaf48e98efd2d6a592e96eb8"
+                "reference": "15e4e0de554bbfe5e474544c157365f655faf028"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/969cf5572f9df05feaf48e98efd2d6a592e96eb8",
-                "reference": "969cf5572f9df05feaf48e98efd2d6a592e96eb8",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/15e4e0de554bbfe5e474544c157365f655faf028",
+                "reference": "15e4e0de554bbfe5e474544c157365f655faf028",
                 "shasum": ""
             },
             "require": {
@@ -28,6 +28,7 @@
             "scripts": {
                 "test": [
                     "php tests/bootstrap-smoke.php",
+                    "php tests/message-envelope-smoke.php",
                     "php tests/registry-smoke.php",
                     "php tests/execution-principal-smoke.php",
                     "php tests/action-policy-values-smoke.php",
@@ -35,6 +36,7 @@
                     "php tests/pending-action-store-contract-smoke.php",
                     "php tests/approval-resolver-contract-smoke.php",
                     "php tests/identity-smoke.php",
+                    "php tests/approval-action-value-shape-smoke.php",
                     "php tests/compaction-item-smoke.php",
                     "php tests/conversation-runner-contracts-smoke.php",
                     "php tests/conversation-compaction-smoke.php",
@@ -59,7 +61,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-03T15:11:07+00:00"
+            "time": "2026-05-03T15:27:13+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/inc/Engine/AI/Actions/PendingActionHelper.php
+++ b/inc/Engine/AI/Actions/PendingActionHelper.php
@@ -29,12 +29,18 @@
 
 namespace DataMachine\Engine\AI\Actions;
 
+use AgentsAPI\AI\AgentMessageEnvelope;
+use AgentsAPI\AI\Approvals\PendingAction;
+
 defined( 'ABSPATH' ) || exit;
 
 class PendingActionHelper {
 
 	/**
 	 * Stage a tool invocation for user approval.
+	 *
+	 * The returned value is an Agents API approval_required envelope with the
+	 * legacy staged-action fields mirrored at the top level for existing clients.
 	 *
 	 * @param array $args {
 	 *     Staging arguments.
@@ -130,7 +136,10 @@ class PendingActionHelper {
 		 */
 		do_action( 'datamachine_pending_action_staged', $action_id, $payload );
 
-		return array(
+		$expires_at = isset( $stored_payload['expires_at'] ) ? (int) $stored_payload['expires_at'] : null;
+		$created_at = isset( $stored_payload['created_at'] ) ? (int) $stored_payload['created_at'] : time();
+
+		$legacy_payload = array(
 			'staged'         => true,
 			'action_id'      => $action_id,
 			'kind'           => $kind,
@@ -142,7 +151,52 @@ class PendingActionHelper {
 				'decision'  => '<accepted|rejected>',
 			),
 			'instruction'    => 'Show this preview to the user and wait for their confirmation. Do not call resolve_pending_action until they explicitly approve or reject. If the user asks to modify, call the original tool again with updated parameters instead of resolving this action.',
-			'expires_at'     => isset( $stored_payload['expires_at'] ) ? (int) $stored_payload['expires_at'] : null,
+			'expires_at'     => $expires_at,
 		);
+
+		$pending_action = array(
+			'action_id'   => $action_id,
+			'kind'        => 'tool_action',
+			'summary'     => $payload['summary'],
+			'preview'     => $preview_data,
+			'apply_input' => $apply_input,
+			'created_by'  => $user_id > 0 ? (string) $user_id : null,
+			'agent_id'    => $agent_id > 0 ? (string) $agent_id : null,
+			'context'     => $context,
+			'created_at'  => gmdate( 'c', $created_at ),
+			'expires_at'  => null !== $expires_at ? gmdate( 'c', $expires_at ) : null,
+		);
+
+		if ( class_exists( PendingAction::class ) ) {
+			$pending_action = PendingAction::from_array( $pending_action )->to_array();
+		}
+
+		$envelope_payload  = array_merge(
+			$legacy_payload,
+			array(
+				'pending_action' => $pending_action,
+			)
+		);
+		$envelope_metadata = array(
+			'adapter'     => 'data-machine',
+			'datamachine' => array(
+				'kind'         => $kind,
+				'resolve_with' => 'resolve_pending_action',
+			),
+		);
+
+		$envelope = method_exists( AgentMessageEnvelope::class, 'approvalRequired' )
+			? AgentMessageEnvelope::approvalRequired( $payload['summary'], $envelope_payload, $envelope_metadata )
+			: array(
+				'schema'   => AgentMessageEnvelope::SCHEMA,
+				'version'  => AgentMessageEnvelope::VERSION,
+				'type'     => AgentMessageEnvelope::TYPE_APPROVAL_REQUIRED,
+				'role'     => 'tool',
+				'content'  => $payload['summary'],
+				'payload'  => $envelope_payload,
+				'metadata' => $envelope_metadata,
+			);
+
+		return array_merge( $envelope, $legacy_payload );
 	}
 }

--- a/tests/pending-action-helper-approval-envelope-smoke.php
+++ b/tests/pending-action-helper-approval-envelope-smoke.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Smoke coverage for PendingActionHelper's approval-required result shape.
+ *
+ * Run with: php tests/pending-action-helper-approval-envelope-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+require_once __DIR__ . '/bootstrap-unit.php';
+
+use AgentsAPI\AI\AgentMessageEnvelope;
+use DataMachine\Engine\AI\Actions\PendingActionHelper;
+use DataMachine\Engine\AI\Actions\PendingActionStore;
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ): string {
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key ) ?? '';
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $value ): string {
+		return strip_tags( (string) $value );
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return 123;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $_hook, $value, ...$_args ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $_hook, ...$_args ): void {}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, int $flags = 0, int $depth = 512 ) {
+		return json_encode( $value, $flags, $depth );
+	}
+}
+
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4(): string {
+		return '00000000-0000-4000-8000-000000000001';
+	}
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( string $key, $value, int $_expiration = 0 ): bool {
+		$GLOBALS['datamachine_pending_action_helper_transients'][ $key ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( string $key ) {
+		return $GLOBALS['datamachine_pending_action_helper_transients'][ $key ] ?? false;
+	}
+}
+
+function datamachine_pending_action_helper_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+$GLOBALS['datamachine_pending_action_helper_transients'] = array();
+
+$result = PendingActionHelper::stage(
+	array(
+		'kind'         => 'wiki_upsert',
+		'summary'      => '<strong>Update Wiki Page</strong>',
+		'apply_input'  => array(
+			'title'   => 'Demo',
+			'content' => 'Updated content.',
+		),
+		'preview_data' => array(
+			'diff' => '- old' . "\n" . '+ new',
+		),
+		'agent_id'     => 456,
+		'context'      => array(
+			'tool_name'  => 'wiki_upsert',
+			'session_id' => 'session_123',
+		),
+	)
+);
+
+datamachine_pending_action_helper_assert( AgentMessageEnvelope::SCHEMA === $result['schema'], 'Result uses the Agents API envelope schema.' );
+datamachine_pending_action_helper_assert( AgentMessageEnvelope::TYPE_APPROVAL_REQUIRED === $result['type'], 'Result is an approval_required envelope.' );
+datamachine_pending_action_helper_assert( 'tool' === $result['role'], 'Approval-required envelope uses the tool role.' );
+
+datamachine_pending_action_helper_assert( true === $result['staged'], 'Legacy top-level staged flag is preserved.' );
+datamachine_pending_action_helper_assert( true === $result['payload']['staged'], 'Payload staged flag is available to envelope-aware clients.' );
+datamachine_pending_action_helper_assert( $result['action_id'] === $result['payload']['action_id'], 'Legacy action_id is mirrored in the envelope payload.' );
+datamachine_pending_action_helper_assert( 'wiki_upsert' === $result['kind'], 'Legacy Data Machine action kind is preserved at top level.' );
+datamachine_pending_action_helper_assert( 'wiki_upsert' === $result['payload']['kind'], 'Legacy Data Machine action kind is preserved in payload.' );
+datamachine_pending_action_helper_assert( 'resolve_pending_action' === $result['resolve_with'], 'Legacy resolver tool name is preserved at top level.' );
+datamachine_pending_action_helper_assert( 'resolve_pending_action' === $result['payload']['resolve_with'], 'Legacy resolver tool name is preserved in payload.' );
+datamachine_pending_action_helper_assert( 'Update Wiki Page' === $result['summary'], 'Summary is sanitized for legacy clients.' );
+datamachine_pending_action_helper_assert( 'Update Wiki Page' === $result['content'], 'Envelope content carries the human summary.' );
+
+$pending_action = $result['payload']['pending_action'];
+datamachine_pending_action_helper_assert( $result['action_id'] === $pending_action['action_id'], 'Agents API pending action carries the staged action ID.' );
+datamachine_pending_action_helper_assert( 'tool_action' === $pending_action['kind'], 'Agents API pending action keeps a generic action kind.' );
+datamachine_pending_action_helper_assert( array( 'diff' => "- old\n+ new" ) === $pending_action['preview'], 'Agents API pending action carries preview data.' );
+datamachine_pending_action_helper_assert( '123' === $pending_action['created_by'], 'Agents API pending action records creator identity as a string.' );
+datamachine_pending_action_helper_assert( '456' === $pending_action['agent_id'], 'Agents API pending action records agent identity as a string.' );
+datamachine_pending_action_helper_assert( isset( $pending_action['created_at'] ) && is_string( $pending_action['created_at'] ), 'Agents API pending action carries an ISO creation timestamp.' );
+datamachine_pending_action_helper_assert( isset( $pending_action['expires_at'] ) && is_string( $pending_action['expires_at'] ), 'Agents API pending action carries an ISO expiration timestamp.' );
+
+datamachine_pending_action_helper_assert( 'data-machine' === $result['metadata']['adapter'], 'Data Machine is identified as adapter metadata.' );
+datamachine_pending_action_helper_assert( 'wiki_upsert' === $result['metadata']['datamachine']['kind'], 'Data Machine handler kind lives in adapter metadata.' );
+datamachine_pending_action_helper_assert( 'resolve_pending_action' === $result['metadata']['datamachine']['resolve_with'], 'Data Machine resolver name lives in adapter metadata.' );
+
+$stored = PendingActionStore::get( $result['action_id'] );
+datamachine_pending_action_helper_assert( is_array( $stored ), 'Pending action is still stored through the existing store.' );
+datamachine_pending_action_helper_assert( 'wiki_upsert' === $stored['kind'], 'Stored Data Machine resolver kind is unchanged.' );
+datamachine_pending_action_helper_assert( array( 'title' => 'Demo', 'content' => 'Updated content.' ) === $stored['apply_input'], 'Stored apply input is unchanged.' );
+
+$normalized = AgentMessageEnvelope::normalize( $result );
+datamachine_pending_action_helper_assert( AgentMessageEnvelope::TYPE_APPROVAL_REQUIRED === $normalized['type'], 'Result normalizes as an approval_required envelope.' );
+datamachine_pending_action_helper_assert( $result['payload'] === $normalized['payload'], 'Envelope payload survives normalization.' );
+
+echo "PendingActionHelper approval envelope smoke passed.\n";


### PR DESCRIPTION
## Summary
- Return an Agents API `approval_required` envelope from `PendingActionHelper::stage()` while mirroring the existing staged-action fields for current chat clients.
- Represent staged tool approvals as generic Agents API pending actions, keeping Data Machine handler and resolver names in adapter metadata.
- Bump the locked Agents API dependency to the commit containing the approval-required envelope builder and pending action value object.

## Testing
- `php tests/pending-action-helper-approval-envelope-smoke.php`
- `php tests/ai-message-envelope-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@consume-agents-api-approval-envelope -- --filter=ContentActionHandlersTest`
- `vendor/bin/phpcs inc/Engine/AI/Actions/PendingActionHelper.php tests/pending-action-helper-approval-envelope-smoke.php`

## Notes
- `homeboy lint --path /Users/chubes/Developer/data-machine@consume-agents-api-approval-envelope` still reports the existing broad JS/admin lint backlog outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** drafted the focused implementation and tests; Chris reviews before merge.