### PR TITLE
Consume Agents API action policy vocabulary

### DIFF
--- a/inc/Engine/AI/Actions/ActionPolicyResolver.php
+++ b/inc/Engine/AI/Actions/ActionPolicyResolver.php
@@ -34,6 +34,7 @@
 
 namespace DataMachine\Engine\AI\Actions;
 
+use AgentsAPI\AI\Tools\ActionPolicy;
 use DataMachine\Core\Database\Agents\Agents;
 
 defined( 'ABSPATH' ) || exit;
@@ -50,10 +51,13 @@ class ActionPolicyResolver {
 
 	/**
 	 * Valid policy values. Returned by resolveForTool().
+	 *
+	 * Keep the legacy Data Machine constant names as public aliases while the
+	 * generic vocabulary lives in Agents API.
 	 */
-	public const POLICY_DIRECT    = 'direct';
-	public const POLICY_PREVIEW   = 'preview';
-	public const POLICY_FORBIDDEN = 'forbidden';
+	public const POLICY_DIRECT    = ActionPolicy::DIRECT;
+	public const POLICY_PREVIEW   = ActionPolicy::PREVIEW;
+	public const POLICY_FORBIDDEN = ActionPolicy::FORBIDDEN;
 
 	/**
 	 * Resolve the action policy for a single tool invocation.
@@ -277,23 +281,14 @@ class ActionPolicyResolver {
 	/**
 	 * Normalize a user-supplied policy value.
 	 *
-	 * Returns one of the POLICY_* constants, or an empty string when the
+	 * Returns one of the Agents API policy constants, or an empty string when the
 	 * value is not recognized (caller drops it).
 	 *
 	 * @param mixed $value Raw value from config or tool def.
 	 * @return string Normalized policy or ''.
 	 */
 	private function normalizePolicyValue( $value ): string {
-		if ( class_exists( 'AgentsAPI\\AI\\Tools\\ActionPolicy' ) ) {
-			return \AgentsAPI\AI\Tools\ActionPolicy::normalize( $value ) ?? '';
-		}
-
-		if ( ! is_string( $value ) ) {
-			return '';
-		}
-
-		$value = strtolower( trim( $value ) );
-		return in_array( $value, array( self::POLICY_DIRECT, self::POLICY_PREVIEW, self::POLICY_FORBIDDEN ), true ) ? $value : '';
+		return ActionPolicy::normalize( $value ) ?? '';
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Engine\AI\Tools;
 
+use AgentsAPI\AI\Tools\ActionPolicy;
 use DataMachine\Core\WordPress\PostTracking;
 use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
 use DataMachine\Engine\AI\Actions\PendingActionHelper;
@@ -80,7 +81,7 @@ class ToolExecutor {
 			)
 		);
 
-		if ( ActionPolicyResolver::POLICY_FORBIDDEN === $policy ) {
+		if ( ActionPolicy::refusesExecution( $policy ) ) {
 			return array(
 				'success'        => false,
 				'error'          => sprintf( 'Tool "%s" is not permitted in the current context (action_policy=forbidden).', $tool_name ),
@@ -89,7 +90,7 @@ class ToolExecutor {
 			);
 		}
 
-		if ( ActionPolicyResolver::POLICY_PREVIEW === $policy ) {
+		if ( ActionPolicy::stagesApproval( $policy ) ) {
 			// Tool must declare how to build an action kind and summary.
 			// If it hasn't opted into the preview pipeline properly, fall
 			// back to 'direct' and log a warning — preview is a contract,

--- a/tests/Unit/Engine/AI/Actions/ActionPolicyResolverTest.php
+++ b/tests/Unit/Engine/AI/Actions/ActionPolicyResolverTest.php
@@ -21,6 +21,8 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
 use WP_UnitTestCase;
 
+require_once dirname( __DIR__, 5 ) . '/vendor/automattic/agents-api/src/Tools/ActionPolicy.php';
+
 class ActionPolicyResolverTest extends WP_UnitTestCase {
 
 	private ActionPolicyResolver $resolver;

--- a/tests/Unit/Engine/AI/Actions/ActionPolicyResolverTest.php
+++ b/tests/Unit/Engine/AI/Actions/ActionPolicyResolverTest.php
@@ -16,6 +16,7 @@
 
 namespace DataMachine\Tests\Unit\Engine\AI\Actions;
 
+use AgentsAPI\AI\Tools\ActionPolicy;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
 use WP_UnitTestCase;
@@ -46,6 +47,12 @@ class ActionPolicyResolverTest extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( ActionPolicyResolver::POLICY_DIRECT, $policy );
+	}
+
+	public function test_legacy_policy_constants_alias_agents_api_vocabulary(): void {
+		$this->assertSame( ActionPolicy::DIRECT, ActionPolicyResolver::POLICY_DIRECT );
+		$this->assertSame( ActionPolicy::PREVIEW, ActionPolicyResolver::POLICY_PREVIEW );
+		$this->assertSame( ActionPolicy::FORBIDDEN, ActionPolicyResolver::POLICY_FORBIDDEN );
 	}
 
 	public function test_tool_declared_default_overrides_global_default(): void {

--- a/tests/Unit/Engine/AI/Actions/ActionPolicyResolverTest.php
+++ b/tests/Unit/Engine/AI/Actions/ActionPolicyResolverTest.php
@@ -21,7 +21,9 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
 use WP_UnitTestCase;
 
-require_once dirname( __DIR__, 5 ) . '/vendor/automattic/agents-api/src/Tools/ActionPolicy.php';
+if ( ! class_exists( ActionPolicy::class ) ) {
+	require_once dirname( __DIR__, 5 ) . '/vendor/automattic/agents-api/src/Tools/ActionPolicy.php';
+}
 
 class ActionPolicyResolverTest extends WP_UnitTestCase {
 

--- a/tests/pending-actions-agents-api-contract-smoke.php
+++ b/tests/pending-actions-agents-api-contract-smoke.php
@@ -77,7 +77,7 @@ foreach ( $expected_agents_api_approval_primitives as $class_name => $primitive 
 }
 datamachine_pending_actions_assert( str_contains( $adapter_source, 'implements PendingActionStoreInterface' ), 'store adapter implements Agents API PendingActionStoreInterface', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $resolver_adapter, 'implements PendingActionResolverInterface' ), 'resolver adapter implements Agents API PendingActionResolverInterface', $failures, $passes );
-datamachine_pending_actions_assert( str_contains( $action_policy, 'AgentsAPI\\AI\\Tools\\ActionPolicy::normalize' ), 'ActionPolicyResolver feature-detects Agents API ActionPolicy vocabulary', $failures, $passes );
+datamachine_pending_actions_assert( str_contains( $action_policy, 'use AgentsAPI\\AI\\Tools\\ActionPolicy;' ) && str_contains( $action_policy, 'ActionPolicy::normalize' ), 'ActionPolicyResolver consumes Agents API ActionPolicy vocabulary', $failures, $passes );
 datamachine_pending_actions_assert( str_contains( $resolver_adapter, 'ApprovalDecision' ), 'resolver adapter consumes Agents API ApprovalDecision vocabulary', $failures, $passes );
 
 echo "\n[2] Durable storage preserves legacy lookup while retaining audit rows:\n";

--- a/tests/tool-executor-ability-native-smoke.php
+++ b/tests/tool-executor-ability-native-smoke.php
@@ -156,6 +156,7 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 	use DataMachine\Engine\AI\Tools\Execution\ToolExecutionCore;
 	use DataMachine\Engine\AI\Tools\ToolExecutor;
 
+	require_once dirname( __DIR__ ) . '/vendor/automattic/agents-api/src/Tools/ActionPolicy.php';
 	require_once dirname( __DIR__ ) . '/inc/Engine/AI/Tools/ToolParameters.php';
 	require_once dirname( __DIR__ ) . '/inc/Engine/AI/Tools/Execution/ToolExecutionCore.php';
 	require_once dirname( __DIR__ ) . '/inc/Engine/AI/Tools/ToolExecutor.php';


### PR DESCRIPTION
## Summary
- Alias Data Machine `ActionPolicyResolver::POLICY_*` constants to the Agents API action-policy vocabulary.
- Route action-policy normalization and ToolExecutor policy checks through `AgentsAPI\AI\Tools\ActionPolicy` while preserving Data Machine precedence and behavior.
- Refresh focused resolver and smoke coverage for the Agents API vocabulary dependency.

## Verification
- `php tests/pending-actions-agents-api-contract-smoke.php`
- `php tests/tool-executor-ability-native-smoke.php`
- `homeboy test data-machine --changed-since origin/main --skip-lint`
- `homeboy lint data-machine --changed-only --summary`
- `vendor/bin/phpcs inc/Engine/AI/Actions/ActionPolicyResolver.php inc/Engine/AI/Tools/ToolExecutor.php tests/Unit/Engine/AI/Actions/ActionPolicyResolverTest.php tests/pending-actions-agents-api-contract-smoke.php`

## Notes
- Full `homeboy lint data-machine` still reports existing broad frontend lint failures unrelated to this PR; changed-file lint passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** drafted the focused implementation and tests; Chris reviews before merge.

Fixes #1745
Part of #1741