### PR TITLE
feat: CLI commands to reassign agent_id on pipelines and flows

### DIFF
--- a/inc/Abilities/Flow/DuplicateFlowAbility.php
+++ b/inc/Abilities/Flow/DuplicateFlowAbility.php
@@ -172,6 +172,12 @@ class DuplicateFlowAbility {
 			'scheduling_config' => $scheduling_config,
 		);
 
+		// Propagate agent_id from source flow (or override from input).
+		$agent_id = $input['agent_id'] ?? ( $source_flow['agent_id'] ?? null );
+		if ( ! empty( $agent_id ) ) {
+			$flow_data['agent_id'] = (int) $agent_id;
+		}
+
 		$new_flow_id = $this->db_flows->create_flow( $flow_data );
 		if ( ! $new_flow_id ) {
 			do_action(

--- a/inc/Abilities/Flow/UpdateFlowAbility.php
+++ b/inc/Abilities/Flow/UpdateFlowAbility.php
@@ -51,6 +51,10 @@ class UpdateFlowAbility {
 									'interval' => array( 'type' => 'string' ),
 								),
 							),
+							'agent_id'          => array(
+								'type'        => 'integer',
+								'description' => __( 'New agent ID to assign', 'data-machine' ),
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -88,6 +92,7 @@ class UpdateFlowAbility {
 		$flow_id           = $input['flow_id'] ?? null;
 		$flow_name         = $input['flow_name'] ?? null;
 		$scheduling_config = $input['scheduling_config'] ?? null;
+		$agent_id          = $input['agent_id'] ?? null;
 
 		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
 			return array(
@@ -98,10 +103,10 @@ class UpdateFlowAbility {
 
 		$flow_id = (int) $flow_id;
 
-		if ( null === $flow_name && null === $scheduling_config ) {
+		if ( null === $flow_name && null === $scheduling_config && null === $agent_id ) {
 			return array(
 				'success' => false,
-				'error'   => 'Must provide flow_name or scheduling_config to update',
+				'error'   => 'Must provide flow_name, scheduling_config, or agent_id to update',
 			);
 		}
 
@@ -131,6 +136,20 @@ class UpdateFlowAbility {
 				return array(
 					'success' => false,
 					'error'   => 'Failed to update flow name',
+				);
+			}
+		}
+
+		if ( null !== $agent_id ) {
+			$success = $this->db_flows->update_flow(
+				$flow_id,
+				array( 'agent_id' => absint( $agent_id ) )
+			);
+
+			if ( ! $success ) {
+				return array(
+					'success' => false,
+					'error'   => 'Failed to update flow agent_id',
 				);
 			}
 		}

--- a/inc/Abilities/Pipeline/UpdatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/UpdatePipelineAbility.php
@@ -42,6 +42,10 @@ class UpdatePipelineAbility {
 								'type'        => 'string',
 								'description' => __( 'New pipeline name', 'data-machine' ),
 							),
+							'agent_id'      => array(
+								'type'        => 'integer',
+								'description' => __( 'New agent ID to assign', 'data-machine' ),
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -77,6 +81,7 @@ class UpdatePipelineAbility {
 	public function execute( array $input ): array {
 		$pipeline_id   = $input['pipeline_id'] ?? null;
 		$pipeline_name = $input['pipeline_name'] ?? null;
+		$agent_id      = $input['agent_id'] ?? null;
 
 		if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
 			return array(
@@ -87,10 +92,10 @@ class UpdatePipelineAbility {
 
 		$pipeline_id = (int) $pipeline_id;
 
-		if ( null === $pipeline_name ) {
+		if ( null === $pipeline_name && null === $agent_id ) {
 			return array(
 				'success' => false,
-				'error'   => 'Must provide pipeline_name to update',
+				'error'   => 'Must provide pipeline_name or agent_id to update',
 			);
 		}
 
@@ -102,17 +107,26 @@ class UpdatePipelineAbility {
 			);
 		}
 
-		$pipeline_name = sanitize_text_field( wp_unslash( $pipeline_name ) );
-		if ( empty( trim( $pipeline_name ) ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Pipeline name cannot be empty',
-			);
+		$update_data = array();
+
+		if ( null !== $pipeline_name ) {
+			$pipeline_name = sanitize_text_field( wp_unslash( $pipeline_name ) );
+			if ( empty( trim( $pipeline_name ) ) ) {
+				return array(
+					'success' => false,
+					'error'   => 'Pipeline name cannot be empty',
+				);
+			}
+			$update_data['pipeline_name'] = $pipeline_name;
+		}
+
+		if ( null !== $agent_id ) {
+			$update_data['agent_id'] = absint( $agent_id );
 		}
 
 		$success = $this->db_pipelines->update_pipeline(
 			$pipeline_id,
-			array( 'pipeline_name' => $pipeline_name )
+			$update_data
 		);
 
 		if ( ! $success ) {
@@ -122,20 +136,23 @@ class UpdatePipelineAbility {
 			);
 		}
 
+		$updated_pipeline = $this->db_pipelines->get_pipeline( $pipeline_id );
+		$final_name       = $updated_pipeline['pipeline_name'] ?? $pipeline_name ?? '';
+
 		do_action(
 			'datamachine_log',
 			'info',
 			'Pipeline updated via ability',
 			array(
-				'pipeline_id'   => $pipeline_id,
-				'pipeline_name' => $pipeline_name,
+				'pipeline_id'    => $pipeline_id,
+				'updated_fields' => array_keys( $update_data ),
 			)
 		);
 
 		return array(
 			'success'       => true,
 			'pipeline_id'   => $pipeline_id,
-			'pipeline_name' => $pipeline_name,
+			'pipeline_name' => $final_name,
 			'message'       => 'Pipeline updated successfully',
 		);
 	}

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -138,11 +138,24 @@ class FlowsCommand extends BaseCommand {
 	 * [--pipeline=<id>]
 	 * : Pipeline ID for pause/resume scoping.
 	 *
-	 * [--agent=<slug_or_id>]
-	 * : Agent slug or ID for scoping (pause/resume/list).
-	 *
-	 * [--yes]
-	 * : Skip confirmation prompt (delete subcommand).
+ * [--agent=<slug_or_id>]
+ * : Agent slug or ID. For update: set the flow's agent_id.
+ *   For pause/resume/list: scope by agent.
+ *   For reassign: see --from-agent / --to-agent instead.
+ *
+ * [--from-agent=<id>]
+ * : Source agent ID for bulk reassign. Accepts raw numeric ID (need not exist in agents table).
+ *   Mutually exclusive with --where-null.
+ *
+ * [--where-null]
+ * : Target rows where agent_id IS NULL (reassign subcommand).
+ *   Mutually exclusive with --from-agent.
+ *
+ * [--to-agent=<slug_or_id>]
+ * : Destination agent slug or ID for bulk reassign. Must be a valid agent.
+ *
+ * [--yes]
+ * : Skip confirmation prompt (delete/reassign subcommands).
 	 *
 	 * ## EXAMPLES
 	 *
@@ -203,9 +216,21 @@ class FlowsCommand extends BaseCommand {
 	 *     # Resume a single flow
 	 *     wp datamachine flows resume 42
 	 *
-	 *     # Resume all flows for an agent
-	 *     wp datamachine flows resume --agent=my-agent
-	 */
+ *     # Resume all flows for an agent
+ *     wp datamachine flows resume --agent=my-agent
+ *
+ *     # Update flow agent
+ *     wp datamachine flows update 42 --agent=events-bot
+ *
+ *     # Bulk reassign: move orphan flows → events-bot
+ *     wp datamachine flows reassign --where-null --to-agent=events-bot
+ *
+ *     # Bulk reassign: move flows from agent_id=1 → events-bot
+ *     wp datamachine flows reassign --from-agent=1 --to-agent=events-bot
+ *
+ *     # Dry-run reassign
+ *     wp datamachine flows reassign --where-null --to-agent=events-bot --dry-run
+ */
 	public function __invoke( array $args, array $assoc_args ): void {
 		$flow_id     = null;
 		$pipeline_id = null;
@@ -266,6 +291,12 @@ class FlowsCommand extends BaseCommand {
 				return;
 			}
 			$this->deleteFlow( (int) $args[1], $assoc_args );
+			return;
+		}
+
+		// Handle 'reassign' subcommand.
+		if ( ! empty( $args ) && 'reassign' === $args[0] ) {
+			$this->reassignFlows( $assoc_args );
 			return;
 		}
 
@@ -1015,6 +1046,7 @@ class FlowsCommand extends BaseCommand {
 		$name           = $assoc_args['name'] ?? null;
 		$scheduling     = $assoc_args['scheduling'] ?? null;
 		$scheduled_at   = $assoc_args['scheduled-at'] ?? null;
+		$has_agent      = isset( $assoc_args['agent'] );
 		$user_message   = isset( $assoc_args['set-user-message'] )
 			? wp_kses_post( wp_unslash( $assoc_args['set-user-message'] ) )
 			: null;
@@ -1033,9 +1065,28 @@ class FlowsCommand extends BaseCommand {
 			return;
 		}
 
-		if ( null === $name && null === $scheduling && null === $user_message && null === $handler_config ) {
-			WP_CLI::error( 'Must provide --name, --scheduling, --set-user-message, --scheduled-at, or --handler-config to update' );
+		if ( null === $name && null === $scheduling && null === $user_message && null === $handler_config && ! $has_agent ) {
+			WP_CLI::error( 'Must provide --name, --scheduling, --set-user-message, --scheduled-at, --handler-config, or --agent to update' );
 			return;
+		}
+
+		// Update agent_id if --agent provided.
+		if ( $has_agent ) {
+			$new_agent_id = AgentResolver::resolve( $assoc_args );
+			if ( null === $new_agent_id ) {
+				WP_CLI::error( 'Could not resolve --agent to a valid agent.' );
+				return;
+			}
+
+			$flows_repo = new \DataMachine\Core\Database\Flows\Flows();
+			$success    = $flows_repo->update_flow( $flow_id, array( 'agent_id' => $new_agent_id ) );
+
+			if ( ! $success ) {
+				WP_CLI::error( 'Failed to update flow agent_id.' );
+				return;
+			}
+
+			WP_CLI::success( sprintf( 'Flow %d agent set to agent_id=%d.', $flow_id, $new_agent_id ) );
 		}
 
 		// Validate step resolution BEFORE any writes (atomic: fail fast, change nothing).
@@ -1795,5 +1846,102 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		return array( 'interval' => $scheduling );
+	}
+
+	/**
+	 * Bulk-reassign agent_id on flows.
+	 *
+	 * Requires exactly one of --from-agent or --where-null, plus --to-agent.
+	 *
+	 * @param array $assoc_args Associative arguments.
+	 */
+	private function reassignFlows( array $assoc_args ): void {
+		$has_from = isset( $assoc_args['from-agent'] );
+		$has_null = isset( $assoc_args['where-null'] );
+		$has_to   = isset( $assoc_args['to-agent'] );
+		$dry_run  = isset( $assoc_args['dry-run'] );
+		$skip     = isset( $assoc_args['yes'] );
+		$format   = $assoc_args['format'] ?? 'table';
+
+		if ( ! $has_to ) {
+			WP_CLI::error( '--to-agent is required.' );
+			return;
+		}
+
+		if ( ! $has_from && ! $has_null ) {
+			WP_CLI::error( 'Must provide --from-agent=<id> or --where-null to specify which flows to reassign.' );
+			return;
+		}
+
+		if ( $has_from && $has_null ) {
+			WP_CLI::error( '--from-agent and --where-null are mutually exclusive.' );
+			return;
+		}
+
+		// Resolve --to-agent through AgentResolver (must be a valid agent).
+		$to_agent_id = AgentResolver::resolve( array( 'agent' => $assoc_args['to-agent'] ) );
+		if ( null === $to_agent_id ) {
+			WP_CLI::error( 'Could not resolve --to-agent to a valid agent.' );
+			return;
+		}
+
+		// Parse --from-agent as raw integer (may reference a stale/non-existent agent_id).
+		$from_agent_id = null;
+		if ( $has_from ) {
+			$from_agent_id = absint( $assoc_args['from-agent'] );
+			if ( $from_agent_id <= 0 ) {
+				WP_CLI::error( '--from-agent must be a positive integer.' );
+				return;
+			}
+			if ( $from_agent_id === $to_agent_id ) {
+				WP_CLI::error( '--from-agent and --to-agent resolve to the same agent_id.' );
+				return;
+			}
+		}
+
+		$flows_repo = new \DataMachine\Core\Database\Flows\Flows();
+		$flow_count = $flows_repo->count_by_agent_id( $from_agent_id );
+
+		$source_label = null === $from_agent_id ? 'NULL' : (string) $from_agent_id;
+
+		if ( 0 === $flow_count ) {
+			WP_CLI::warning( sprintf( 'No flows found with agent_id=%s. Nothing to do.', $source_label ) );
+			return;
+		}
+
+		WP_CLI::log( sprintf(
+			'Found %d flow(s) with agent_id=%s → reassign to agent_id=%d.',
+			$flow_count,
+			$source_label,
+			$to_agent_id
+		) );
+
+		if ( $dry_run ) {
+			WP_CLI::success( 'Dry-run complete. No changes made.' );
+			return;
+		}
+
+		if ( ! $skip ) {
+			WP_CLI::confirm( sprintf(
+				'Reassign %d flow(s) from agent_id=%s to agent_id=%d?',
+				$flow_count,
+				$source_label,
+				$to_agent_id
+			) );
+		}
+
+		$flows_updated = $flows_repo->reassign_agent_id( $from_agent_id, $to_agent_id );
+
+		if ( $flows_updated < 0 ) {
+			WP_CLI::error( 'Database error during flow reassignment.' );
+			return;
+		}
+
+		WP_CLI::success( sprintf(
+			'Done. %d flow(s) reassigned from agent_id=%s to agent_id=%d.',
+			$flows_updated,
+			$source_label,
+			$to_agent_id
+		) );
 	}
 }

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -89,11 +89,31 @@ class PipelinesCommand extends BaseCommand {
 	 * : Target a specific pipeline step for system prompt update.
 	 *   Use --step to target a specific step when multiple exist.
 	 *
-	 * [--force]
-	 * : Skip confirmation prompt (delete subcommand).
-	 *
-	 * [--dry-run]
-	 * : Validate without creating (create subcommand).
+ * [--agent=<slug_or_id>]
+ * : Agent slug or ID. For update: set the pipeline's agent_id.
+ *   For reassign: see --from-agent / --to-agent instead.
+ *   For list: filter by agent.
+ *
+ * [--cascade-flows]
+ * : When updating a pipeline's agent, also reassign its child flows (update subcommand).
+ *   Default: off for single update, on for bulk reassign.
+ *
+ * [--from-agent=<id>]
+ * : Source agent ID for bulk reassign. Accepts raw numeric ID (need not exist in agents table).
+ *   Mutually exclusive with --where-null.
+ *
+ * [--where-null]
+ * : Target rows where agent_id IS NULL (reassign subcommand).
+ *   Mutually exclusive with --from-agent.
+ *
+ * [--to-agent=<slug_or_id>]
+ * : Destination agent slug or ID for bulk reassign. Must be a valid agent.
+ *
+ * [--force]
+ * : Skip confirmation prompt (delete/reassign subcommands).
+ *
+ * [--dry-run]
+ * : Show what would change without committing (create/reassign subcommands).
 	 *
 	 * [--add=<filename>]
 	 * : Attach a memory file to a pipeline (memory-files subcommand).
@@ -161,9 +181,24 @@ class PipelinesCommand extends BaseCommand {
 	 *     # Attach a memory file
 	 *     wp datamachine pipelines memory-files 5 --add=content-briefing.md
 	 *
-	 *     # Detach a memory file
-	 *     wp datamachine pipelines memory-files 5 --remove=content-briefing.md
-	 *
+ *     # Detach a memory file
+ *     wp datamachine pipelines memory-files 5 --remove=content-briefing.md
+ *
+ *     # Update pipeline agent
+ *     wp datamachine pipelines update 13 --agent=events-bot
+ *
+ *     # Update pipeline agent and cascade to child flows
+ *     wp datamachine pipelines update 13 --agent=events-bot --cascade-flows
+ *
+ *     # Bulk reassign: move orphan pipelines → events-bot
+ *     wp datamachine pipelines reassign --where-null --to-agent=events-bot
+ *
+ *     # Bulk reassign: move pipelines from agent_id=1 → events-bot
+ *     wp datamachine pipelines reassign --from-agent=1 --to-agent=events-bot
+ *
+ *     # Dry-run reassign
+ *     wp datamachine pipelines reassign --where-null --to-agent=events-bot --dry-run
+ *
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
 		$pipeline_id = null;
@@ -191,6 +226,12 @@ class PipelinesCommand extends BaseCommand {
 				return;
 			}
 			$this->deletePipeline( (int) $args[1], $assoc_args );
+			return;
+		}
+
+		// Handle 'reassign' subcommand.
+		if ( ! empty( $args ) && 'reassign' === $args[0] ) {
+			$this->reassignPipelines( $assoc_args );
 			return;
 		}
 
@@ -545,14 +586,45 @@ class PipelinesCommand extends BaseCommand {
 		$has_name          = isset( $assoc_args['name'] );
 		$has_config        = isset( $assoc_args['config'] );
 		$has_system_prompt = isset( $assoc_args['set-system-prompt'] );
+		$has_agent         = isset( $assoc_args['agent'] );
 
-		if ( ! $has_name && ! $has_config && ! $has_system_prompt ) {
-			WP_CLI::error( 'Must provide --name, --config, and/or --set-system-prompt to update' );
+		if ( ! $has_name && ! $has_config && ! $has_system_prompt && ! $has_agent ) {
+			WP_CLI::error( 'Must provide --name, --config, --set-system-prompt, and/or --agent to update' );
 			return;
 		}
 
 		$result       = null;
 		$step_results = array();
+
+		// Update agent_id if --agent provided.
+		if ( $has_agent ) {
+			$new_agent_id = AgentResolver::resolve( $assoc_args );
+			if ( null === $new_agent_id ) {
+				WP_CLI::error( 'Could not resolve --agent to a valid agent.' );
+				return;
+			}
+
+			$pipelines_repo = new \DataMachine\Core\Database\Pipelines\Pipelines();
+			$success        = $pipelines_repo->update_pipeline( $pipeline_id, array( 'agent_id' => $new_agent_id ) );
+
+			if ( ! $success ) {
+				WP_CLI::error( 'Failed to update pipeline agent_id.' );
+				return;
+			}
+
+			WP_CLI::log( sprintf( 'Agent: set to agent_id=%d', $new_agent_id ) );
+
+			// Cascade to child flows if requested.
+			if ( isset( $assoc_args['cascade-flows'] ) ) {
+				$flows_repo    = new \DataMachine\Core\Database\Flows\Flows();
+				$flows_updated = $flows_repo->reassign_agent_id_for_pipeline( $pipeline_id, null, $new_agent_id );
+				if ( $flows_updated >= 0 ) {
+					WP_CLI::log( sprintf( 'Cascade: %d child flow(s) reassigned to agent_id=%d.', $flows_updated, $new_agent_id ) );
+				} else {
+					WP_CLI::warning( 'Failed to cascade agent_id to child flows.' );
+				}
+			}
+		}
 
 		// Update name if provided.
 		if ( $has_name ) {
@@ -665,7 +737,7 @@ class PipelinesCommand extends BaseCommand {
 		}
 
 		// Determine if any updates succeeded.
-		$any_success = ( $result && $result['success'] ) ||
+		$any_success = $has_agent || ( $result && $result['success'] ) ||
 			array_filter( $step_results, fn( $r ) => $r['success'] ?? false );
 
 		if ( ! $any_success ) {
@@ -894,5 +966,125 @@ class PipelinesCommand extends BaseCommand {
 		if ( 'json' === $format ) {
 			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
 		}
+	}
+
+	/**
+	 * Bulk-reassign agent_id on pipelines.
+	 *
+	 * Requires exactly one of --from-agent or --where-null, plus --to-agent.
+	 *
+	 * @param array $assoc_args Associative arguments.
+	 */
+	private function reassignPipelines( array $assoc_args ): void {
+		$has_from     = isset( $assoc_args['from-agent'] );
+		$has_null     = isset( $assoc_args['where-null'] );
+		$has_to       = isset( $assoc_args['to-agent'] );
+		$dry_run      = isset( $assoc_args['dry-run'] );
+		$force        = isset( $assoc_args['force'] );
+		$no_cascade   = isset( $assoc_args['no-cascade-flows'] );
+		$format       = $assoc_args['format'] ?? 'table';
+
+		if ( ! $has_to ) {
+			WP_CLI::error( '--to-agent is required.' );
+			return;
+		}
+
+		if ( ! $has_from && ! $has_null ) {
+			WP_CLI::error( 'Must provide --from-agent=<id> or --where-null to specify which pipelines to reassign.' );
+			return;
+		}
+
+		if ( $has_from && $has_null ) {
+			WP_CLI::error( '--from-agent and --where-null are mutually exclusive.' );
+			return;
+		}
+
+		// Resolve --to-agent through AgentResolver (must be a valid agent).
+		$to_agent_id = AgentResolver::resolve( array( 'agent' => $assoc_args['to-agent'] ) );
+		if ( null === $to_agent_id ) {
+			WP_CLI::error( 'Could not resolve --to-agent to a valid agent.' );
+			return;
+		}
+
+		// Parse --from-agent as raw integer (may reference a stale/non-existent agent_id).
+		$from_agent_id = null;
+		if ( $has_from ) {
+			$from_agent_id = absint( $assoc_args['from-agent'] );
+			if ( $from_agent_id <= 0 ) {
+				WP_CLI::error( '--from-agent must be a positive integer.' );
+				return;
+			}
+			if ( $from_agent_id === $to_agent_id ) {
+				WP_CLI::error( '--from-agent and --to-agent resolve to the same agent_id.' );
+				return;
+			}
+		}
+
+		$pipelines_repo = new \DataMachine\Core\Database\Pipelines\Pipelines();
+		$flows_repo     = new \DataMachine\Core\Database\Flows\Flows();
+
+		// Count matching pipelines.
+		$pipeline_count = $pipelines_repo->count_by_agent_id( $from_agent_id );
+		$flow_count     = $no_cascade ? 0 : $flows_repo->count_by_agent_id( $from_agent_id );
+
+		$source_label = null === $from_agent_id ? 'NULL' : (string) $from_agent_id;
+
+		if ( 0 === $pipeline_count && 0 === $flow_count ) {
+			WP_CLI::warning( sprintf( 'No pipelines or flows found with agent_id=%s. Nothing to do.', $source_label ) );
+			return;
+		}
+
+		WP_CLI::log( sprintf(
+			'Found %d pipeline(s) and %d flow(s) with agent_id=%s → reassign to agent_id=%d.',
+			$pipeline_count,
+			$flow_count,
+			$source_label,
+			$to_agent_id
+		) );
+
+		if ( $dry_run ) {
+			WP_CLI::success( 'Dry-run complete. No changes made.' );
+			return;
+		}
+
+		if ( ! $force ) {
+			WP_CLI::confirm( sprintf(
+				'Reassign %d pipeline(s)%s from agent_id=%s to agent_id=%d?',
+				$pipeline_count,
+				$no_cascade ? '' : sprintf( ' and %d flow(s)', $flow_count ),
+				$source_label,
+				$to_agent_id
+			) );
+		}
+
+		// Execute pipeline reassignment.
+		$pipelines_updated = $pipelines_repo->reassign_agent_id( $from_agent_id, $to_agent_id );
+
+		if ( $pipelines_updated < 0 ) {
+			WP_CLI::error( 'Database error during pipeline reassignment.' );
+			return;
+		}
+
+		WP_CLI::log( sprintf( 'Pipelines reassigned: %d', $pipelines_updated ) );
+
+		// Cascade to flows unless --no-cascade-flows.
+		$flows_updated = 0;
+		if ( ! $no_cascade ) {
+			$flows_updated = $flows_repo->reassign_agent_id( $from_agent_id, $to_agent_id );
+
+			if ( $flows_updated < 0 ) {
+				WP_CLI::warning( 'Database error during flow cascade reassignment.' );
+			} else {
+				WP_CLI::log( sprintf( 'Flows reassigned (cascade): %d', $flows_updated ) );
+			}
+		}
+
+		WP_CLI::success( sprintf(
+			'Done. %d pipeline(s) and %d flow(s) reassigned from agent_id=%s to agent_id=%d.',
+			$pipelines_updated,
+			$flows_updated,
+			$source_label,
+			$to_agent_id
+		) );
 	}
 }

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -470,7 +470,7 @@ class PipelinesCommand extends BaseCommand {
 		}
 
 		$summary = implode( ' | ', array_unique( $parts ) );
-		return $summary ?: '—';
+		return '' !== $summary ? $summary : '—';
 	}
 
 	/**
@@ -976,13 +976,13 @@ class PipelinesCommand extends BaseCommand {
 	 * @param array $assoc_args Associative arguments.
 	 */
 	private function reassignPipelines( array $assoc_args ): void {
-		$has_from     = isset( $assoc_args['from-agent'] );
-		$has_null     = isset( $assoc_args['where-null'] );
-		$has_to       = isset( $assoc_args['to-agent'] );
-		$dry_run      = isset( $assoc_args['dry-run'] );
-		$force        = isset( $assoc_args['force'] );
-		$no_cascade   = isset( $assoc_args['no-cascade-flows'] );
-		$format       = $assoc_args['format'] ?? 'table';
+		$has_from   = isset( $assoc_args['from-agent'] );
+		$has_null   = isset( $assoc_args['where-null'] );
+		$has_to     = isset( $assoc_args['to-agent'] );
+		$dry_run    = isset( $assoc_args['dry-run'] );
+		$force      = isset( $assoc_args['force'] );
+		$no_cascade = isset( $assoc_args['no-cascade-flows'] );
+		$format     = $assoc_args['format'] ?? 'table';
 
 		if ( ! $has_to ) {
 			WP_CLI::error( '--to-agent is required.' );

--- a/inc/Core/Database/Flows/Flows.php
+++ b/inc/Core/Database/Flows/Flows.php
@@ -769,6 +769,17 @@ class Flows extends BaseRepository {
 			}
 		}
 
+		if ( array_key_exists( 'agent_id', $flow_data ) ) {
+			$agent_id = $flow_data['agent_id'];
+			if ( null === $agent_id ) {
+				$update_data['agent_id'] = null;
+				$update_formats[]        = null;
+			} else {
+				$update_data['agent_id'] = absint( $agent_id );
+				$update_formats[]        = '%d';
+			}
+		}
+
 		if ( empty( $update_data ) ) {
 			do_action(
 				'datamachine_log',
@@ -1154,5 +1165,152 @@ class Flows extends BaseRepository {
 		}
 
 		return array();
+	}
+
+	/**
+	 * Bulk-reassign agent_id on flows.
+	 *
+	 * @param int|null $from_agent_id Source agent ID, or null to target rows where agent_id IS NULL.
+	 * @param int      $to_agent_id   Destination agent ID.
+	 * @return int Number of rows updated, or -1 on DB error.
+	 */
+	public function reassign_agent_id( ?int $from_agent_id, int $to_agent_id ): int {
+		if ( null === $from_agent_id ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $this->table_name, not user input.
+			$result = $this->wpdb->query(
+				$this->wpdb->prepare(
+					"UPDATE {$this->table_name} SET agent_id = %d WHERE agent_id IS NULL",
+					$to_agent_id
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $this->table_name, not user input.
+			$result = $this->wpdb->query(
+				$this->wpdb->prepare(
+					"UPDATE {$this->table_name} SET agent_id = %d WHERE agent_id = %d",
+					$to_agent_id,
+					$from_agent_id
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+		}
+
+		if ( false === $result ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Failed to reassign flow agent_id',
+				array(
+					'from_agent_id' => $from_agent_id,
+					'to_agent_id'   => $to_agent_id,
+					'db_error'      => $this->wpdb->last_error,
+				)
+			);
+			return -1;
+		}
+
+		if ( $result > 0 ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Reassigned flow agent_id',
+				array(
+					'from_agent_id' => $from_agent_id,
+					'to_agent_id'   => $to_agent_id,
+					'rows_updated'  => $result,
+				)
+			);
+		}
+
+		return (int) $result;
+	}
+
+	/**
+	 * Count flows by agent_id.
+	 *
+	 * @param int|null $agent_id Agent ID, or null to count rows where agent_id IS NULL.
+	 * @return int Row count.
+	 */
+	public function count_by_agent_id( ?int $agent_id ): int {
+		if ( null === $agent_id ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:disable WordPress.DB.PreparedSQL
+			$count = $this->wpdb->get_var(
+				"SELECT COUNT(*) FROM {$this->table_name} WHERE agent_id IS NULL"
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:disable WordPress.DB.PreparedSQL
+			$count = $this->wpdb->get_var(
+				$this->wpdb->prepare(
+					"SELECT COUNT(*) FROM {$this->table_name} WHERE agent_id = %d",
+					$agent_id
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+		}
+
+		return (int) $count;
+	}
+
+	/**
+	 * Bulk-reassign agent_id on flows belonging to a specific pipeline.
+	 *
+	 * Used for cascade: when a pipeline's agent_id changes, its child flows follow.
+	 *
+	 * @param int      $pipeline_id    Pipeline ID whose flows should be reassigned.
+	 * @param int|null $from_agent_id  Source agent ID, or null to include all flows on this pipeline
+	 *                                 regardless of their current agent_id.
+	 * @param int      $to_agent_id    Destination agent ID.
+	 * @return int Number of rows updated, or -1 on DB error.
+	 */
+	public function reassign_agent_id_for_pipeline( int $pipeline_id, ?int $from_agent_id, int $to_agent_id ): int {
+		if ( null === $from_agent_id ) {
+			// Reassign ALL flows on this pipeline (any current agent_id, including NULL).
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:disable WordPress.DB.PreparedSQL
+			$result = $this->wpdb->query(
+				$this->wpdb->prepare(
+					"UPDATE {$this->table_name} SET agent_id = %d WHERE pipeline_id = %d AND (agent_id IS NULL OR agent_id != %d)",
+					$to_agent_id,
+					$pipeline_id,
+					$to_agent_id
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:disable WordPress.DB.PreparedSQL
+			$result = $this->wpdb->query(
+				$this->wpdb->prepare(
+					"UPDATE {$this->table_name} SET agent_id = %d WHERE pipeline_id = %d AND agent_id = %d",
+					$to_agent_id,
+					$pipeline_id,
+					$from_agent_id
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+		}
+
+		if ( false === $result ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Failed to reassign flow agent_id for pipeline',
+				array(
+					'pipeline_id'   => $pipeline_id,
+					'from_agent_id' => $from_agent_id,
+					'to_agent_id'   => $to_agent_id,
+					'db_error'      => $this->wpdb->last_error,
+				)
+			);
+			return -1;
+		}
+
+		return (int) $result;
 	}
 }

--- a/inc/Core/Database/Pipelines/Pipelines.php
+++ b/inc/Core/Database/Pipelines/Pipelines.php
@@ -284,6 +284,17 @@ class Pipelines extends BaseRepository {
 			}
 		}
 
+		if ( array_key_exists( 'agent_id', $pipeline_data ) ) {
+			$agent_id = $pipeline_data['agent_id'];
+			if ( null === $agent_id ) {
+				$update_data['agent_id'] = null;
+				$format[]                = null;
+			} else {
+				$update_data['agent_id'] = absint( $agent_id );
+				$format[]                = '%d';
+			}
+		}
+
 		// Always update the updated_at timestamp
 		$update_data['updated_at'] = current_time( 'mysql', true );
 		$format[]                  = '%s';
@@ -782,5 +793,97 @@ class Pipelines extends BaseRepository {
 				'action'     => 'create_table',
 			)
 		);
+	}
+
+	/**
+	 * Bulk-reassign agent_id on pipelines.
+	 *
+	 * @param int|null $from_agent_id Source agent ID, or null to target rows where agent_id IS NULL.
+	 * @param int      $to_agent_id   Destination agent ID.
+	 * @return int Number of rows updated, or -1 on DB error.
+	 */
+	public function reassign_agent_id( ?int $from_agent_id, int $to_agent_id ): int {
+		if ( null === $from_agent_id ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $this->table_name, not user input.
+			$result = $this->wpdb->query(
+				$this->wpdb->prepare(
+					"UPDATE {$this->table_name} SET agent_id = %d, updated_at = %s WHERE agent_id IS NULL",
+					$to_agent_id,
+					current_time( 'mysql', true )
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $this->table_name, not user input.
+			$result = $this->wpdb->query(
+				$this->wpdb->prepare(
+					"UPDATE {$this->table_name} SET agent_id = %d, updated_at = %s WHERE agent_id = %d",
+					$to_agent_id,
+					current_time( 'mysql', true ),
+					$from_agent_id
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+		}
+
+		if ( false === $result ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Failed to reassign pipeline agent_id',
+				array(
+					'from_agent_id' => $from_agent_id,
+					'to_agent_id'   => $to_agent_id,
+					'db_error'      => $this->wpdb->last_error,
+				)
+			);
+			return -1;
+		}
+
+		if ( $result > 0 ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Reassigned pipeline agent_id',
+				array(
+					'from_agent_id' => $from_agent_id,
+					'to_agent_id'   => $to_agent_id,
+					'rows_updated'  => $result,
+				)
+			);
+		}
+
+		return (int) $result;
+	}
+
+	/**
+	 * Count pipelines by agent_id.
+	 *
+	 * @param int|null $agent_id Agent ID, or null to count rows where agent_id IS NULL.
+	 * @return int Row count.
+	 */
+	public function count_by_agent_id( ?int $agent_id ): int {
+		if ( null === $agent_id ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:disable WordPress.DB.PreparedSQL
+			$count = $this->wpdb->get_var(
+				"SELECT COUNT(*) FROM {$this->table_name} WHERE agent_id IS NULL"
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:disable WordPress.DB.PreparedSQL
+			$count = $this->wpdb->get_var(
+				$this->wpdb->prepare(
+					"SELECT COUNT(*) FROM {$this->table_name} WHERE agent_id = %d",
+					$agent_id
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL
+		}
+
+		return (int) $count;
 	}
 }

--- a/inc/Core/WordPress/PostTracking.php
+++ b/inc/Core/WordPress/PostTracking.php
@@ -148,8 +148,8 @@ class PostTracking {
 	 *
 	 * Reads _datamachine_post_flow_id from post meta and resolves the
 	 * agent ID via the flows table. datamachine_flows.agent_id is set at
-	 * flow creation (see Flows::create_flow) and is not mutated by
-	 * update_flow, so the resolution is stable.
+	 * flow creation and can be changed via update_flow or CLI reassign.
+	 * Resolution reflects the current agent_id at query time.
 	 *
 	 * @param int $post_id WordPress post ID.
 	 * @return int Agent ID, or 0 if the post was not produced by DM,
@@ -179,8 +179,8 @@ class PostTracking {
 	 *
 	 * Used to translate "posts produced by agent N" queries into
 	 * meta_query clauses on _datamachine_post_flow_id, since agent_id
-	 * is not stored on posts. datamachine_flows.agent_id is set at flow
-	 * creation and is not mutated by update_flow.
+	 * is not stored on posts. datamachine_flows.agent_id can be changed
+	 * via update_flow or CLI reassign; resolution reflects current state.
 	 *
 	 * @param int $agent_id Agent ID.
 	 * @return int[] Flow IDs belonging to the agent. Empty array if none.

--- a/tests/pipeline-flow-reassign-agent-smoke.php
+++ b/tests/pipeline-flow-reassign-agent-smoke.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * Smoke test for pipeline/flow agent_id reassign methods and CLI wiring.
+ *
+ * Validates that:
+ * - Pipelines::update_pipeline() accepts agent_id in its whitelist
+ * - Flows::update_flow() accepts agent_id in its whitelist
+ * - New repo methods exist with correct signatures
+ * - CLI command classes have the new reassign methods
+ * - UpdatePipelineAbility and UpdateFlowAbility accept agent_id in schema
+ * - DuplicateFlowAbility propagates agent_id from source flow
+ *
+ * Run with: php tests/pipeline-flow-reassign-agent-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$failures = array();
+$passes   = 0;
+
+function smoke_assert( bool $condition, string $name, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+}
+
+echo "\n=== Pipeline/Flow agent_id reassign smoke tests ===\n\n";
+
+// ── 1. Pipelines repo methods ──────────────────────────────────────────
+
+echo "--- Pipelines repo ---\n";
+
+$pipelines_class = 'DataMachine\\Core\\Database\\Pipelines\\Pipelines';
+
+// Check class is autoloadable (won't instantiate since no DB).
+$pipelines_file = __DIR__ . '/../inc/Core/Database/Pipelines/Pipelines.php';
+$pipelines_src  = file_get_contents( $pipelines_file );
+
+// update_pipeline accepts agent_id
+smoke_assert(
+	str_contains( $pipelines_src, "array_key_exists( 'agent_id', \$pipeline_data )" ),
+	'Pipelines::update_pipeline() has agent_id whitelist entry',
+	$failures,
+	$passes
+);
+
+// reassign_agent_id method exists
+smoke_assert(
+	str_contains( $pipelines_src, 'public function reassign_agent_id( ?int $from_agent_id, int $to_agent_id ): int' ),
+	'Pipelines::reassign_agent_id() method exists with correct signature',
+	$failures,
+	$passes
+);
+
+// count_by_agent_id method exists
+smoke_assert(
+	str_contains( $pipelines_src, 'public function count_by_agent_id( ?int $agent_id ): int' ),
+	'Pipelines::count_by_agent_id() method exists with correct signature',
+	$failures,
+	$passes
+);
+
+// reassign_agent_id handles NULL source
+smoke_assert(
+	str_contains( $pipelines_src, 'WHERE agent_id IS NULL' ),
+	'Pipelines::reassign_agent_id() handles NULL source (WHERE agent_id IS NULL)',
+	$failures,
+	$passes
+);
+
+// ── 2. Flows repo methods ──────────────────────────────────────────────
+
+echo "\n--- Flows repo ---\n";
+
+$flows_file = __DIR__ . '/../inc/Core/Database/Flows/Flows.php';
+$flows_src  = file_get_contents( $flows_file );
+
+// update_flow accepts agent_id
+smoke_assert(
+	str_contains( $flows_src, "array_key_exists( 'agent_id', \$flow_data )" ),
+	'Flows::update_flow() has agent_id whitelist entry',
+	$failures,
+	$passes
+);
+
+// reassign_agent_id method exists
+smoke_assert(
+	str_contains( $flows_src, 'public function reassign_agent_id( ?int $from_agent_id, int $to_agent_id ): int' ),
+	'Flows::reassign_agent_id() method exists with correct signature',
+	$failures,
+	$passes
+);
+
+// count_by_agent_id method exists
+smoke_assert(
+	str_contains( $flows_src, 'public function count_by_agent_id( ?int $agent_id ): int' ),
+	'Flows::count_by_agent_id() method exists with correct signature',
+	$failures,
+	$passes
+);
+
+// reassign_agent_id_for_pipeline method exists
+smoke_assert(
+	str_contains( $flows_src, 'public function reassign_agent_id_for_pipeline( int $pipeline_id, ?int $from_agent_id, int $to_agent_id ): int' ),
+	'Flows::reassign_agent_id_for_pipeline() method exists with correct signature',
+	$failures,
+	$passes
+);
+
+// ── 3. PipelinesCommand CLI wiring ─────────────────────────────────────
+
+echo "\n--- PipelinesCommand CLI ---\n";
+
+$pipelines_cmd_file = __DIR__ . '/../inc/Cli/Commands/PipelinesCommand.php';
+$pipelines_cmd_src  = file_get_contents( $pipelines_cmd_file );
+
+// reassign dispatch in __invoke
+smoke_assert(
+	str_contains( $pipelines_cmd_src, "'reassign' === \$args[0]" ),
+	'PipelinesCommand dispatches reassign subcommand',
+	$failures,
+	$passes
+);
+
+// reassignPipelines method exists
+smoke_assert(
+	str_contains( $pipelines_cmd_src, 'private function reassignPipelines(' ),
+	'PipelinesCommand::reassignPipelines() method exists',
+	$failures,
+	$passes
+);
+
+// --agent wired into updatePipeline
+smoke_assert(
+	str_contains( $pipelines_cmd_src, "AgentResolver::resolve( \$assoc_args )" )
+	&& str_contains( $pipelines_cmd_src, "update_pipeline( \$pipeline_id, array( 'agent_id' => \$new_agent_id ) )" ),
+	'PipelinesCommand::updatePipeline() handles --agent flag',
+	$failures,
+	$passes
+);
+
+// --cascade-flows support
+smoke_assert(
+	str_contains( $pipelines_cmd_src, 'cascade-flows' ),
+	'PipelinesCommand supports --cascade-flows flag',
+	$failures,
+	$passes
+);
+
+// --from-agent accepts raw integer (not via AgentResolver)
+smoke_assert(
+	str_contains( $pipelines_cmd_src, "absint( \$assoc_args['from-agent'] )" ),
+	'PipelinesCommand --from-agent uses raw absint (not AgentResolver)',
+	$failures,
+	$passes
+);
+
+// --to-agent goes through AgentResolver
+smoke_assert(
+	str_contains( $pipelines_cmd_src, "AgentResolver::resolve( array( 'agent' => \$assoc_args['to-agent'] ) )" ),
+	'PipelinesCommand --to-agent uses AgentResolver',
+	$failures,
+	$passes
+);
+
+// --dry-run support
+smoke_assert(
+	str_contains( $pipelines_cmd_src, 'Dry-run complete' ),
+	'PipelinesCommand supports --dry-run',
+	$failures,
+	$passes
+);
+
+// ── 4. FlowsCommand CLI wiring ────────────────────────────────────────
+
+echo "\n--- FlowsCommand CLI ---\n";
+
+$flows_cmd_file = __DIR__ . '/../inc/Cli/Commands/Flows/FlowsCommand.php';
+$flows_cmd_src  = file_get_contents( $flows_cmd_file );
+
+// reassign dispatch in __invoke
+smoke_assert(
+	str_contains( $flows_cmd_src, "'reassign' === \$args[0]" ),
+	'FlowsCommand dispatches reassign subcommand',
+	$failures,
+	$passes
+);
+
+// reassignFlows method exists
+smoke_assert(
+	str_contains( $flows_cmd_src, 'private function reassignFlows(' ),
+	'FlowsCommand::reassignFlows() method exists',
+	$failures,
+	$passes
+);
+
+// --agent wired into updateFlow
+smoke_assert(
+	str_contains( $flows_cmd_src, "\$has_agent      = isset( \$assoc_args['agent'] )" ),
+	'FlowsCommand::updateFlow() checks --agent flag',
+	$failures,
+	$passes
+);
+
+// ── 5. Ability layer ──────────────────────────────────────────────────
+
+echo "\n--- Ability layer ---\n";
+
+$update_pipeline_ability_file = __DIR__ . '/../inc/Abilities/Pipeline/UpdatePipelineAbility.php';
+$update_pipeline_ability_src  = file_get_contents( $update_pipeline_ability_file );
+
+smoke_assert(
+	str_contains( $update_pipeline_ability_src, "'agent_id'" )
+	&& str_contains( $update_pipeline_ability_src, "'type'        => 'integer'" ),
+	'UpdatePipelineAbility schema includes agent_id (integer)',
+	$failures,
+	$passes
+);
+
+$update_flow_ability_file = __DIR__ . '/../inc/Abilities/Flow/UpdateFlowAbility.php';
+$update_flow_ability_src  = file_get_contents( $update_flow_ability_file );
+
+smoke_assert(
+	str_contains( $update_flow_ability_src, "'agent_id'" )
+	&& str_contains( $update_flow_ability_src, "update_flow(\n\t\t\t\t\$flow_id,\n\t\t\t\tarray( 'agent_id' => absint( \$agent_id ) )" ),
+	'UpdateFlowAbility handles agent_id in execute()',
+	$failures,
+	$passes
+);
+
+// ── 6. DuplicateFlowAbility bug fix ───────────────────────────────────
+
+echo "\n--- DuplicateFlowAbility bug fix ---\n";
+
+$dup_flow_file = __DIR__ . '/../inc/Abilities/Flow/DuplicateFlowAbility.php';
+$dup_flow_src  = file_get_contents( $dup_flow_file );
+
+smoke_assert(
+	str_contains( $dup_flow_src, "\$agent_id = \$input['agent_id'] ?? ( \$source_flow['agent_id'] ?? null )" ),
+	'DuplicateFlowAbility propagates agent_id from source flow',
+	$failures,
+	$passes
+);
+
+// ── 7. PostTracking docblock update ───────────────────────────────────
+
+echo "\n--- PostTracking docblock ---\n";
+
+$post_tracking_file = __DIR__ . '/../inc/Core/WordPress/PostTracking.php';
+$post_tracking_src  = file_get_contents( $post_tracking_file );
+
+smoke_assert(
+	str_contains( $post_tracking_src, 'can be changed via update_flow or CLI reassign' ),
+	'PostTracking docblock updated to reflect mutable agent_id',
+	$failures,
+	$passes
+);
+
+smoke_assert(
+	! str_contains( $post_tracking_src, 'is not mutated by update_flow' ),
+	'PostTracking no longer claims agent_id is immutable',
+	$failures,
+	$passes
+);
+
+// ── Summary ───────────────────────────────────────────────────────────
+
+echo "\n" . str_repeat( '─', 60 ) . "\n";
+$total = $passes + count( $failures );
+echo sprintf( "Results: %d/%d passed", $passes, $total );
+
+if ( count( $failures ) > 0 ) {
+	echo sprintf( ", %d FAILED:\n", count( $failures ) );
+	foreach ( $failures as $f ) {
+		echo "  ✗ {$f}\n";
+	}
+	exit( 1 );
+} else {
+	echo " — all green ✓\n";
+	exit( 0 );
+}


### PR DESCRIPTION
## Summary

Adds CLI commands to reassign `agent_id` on pipelines and flows — both single-row updates and bulk operations. This unblocks the agent bundle export workflow on sites where pipelines/flows have stale or NULL `agent_id` values (e.g. events.extrachill.com has 132 orphan pipelines and 417 orphan flows).

## Changes

### Database layer
- `Pipelines::update_pipeline()` and `Flows::update_flow()` now accept `agent_id` in their data whitelist
- New bulk methods: `reassign_agent_id()`, `count_by_agent_id()` on both repos
- New cascade method: `Flows::reassign_agent_id_for_pipeline()` for moving a pipeline's child flows

### CLI surface

```bash
# Single-row
wp datamachine pipeline update 13 --agent=events-bot [--cascade-flows]
wp datamachine flow update 42 --agent=wire-bot

# Bulk reassign (with dry-run and cascade)
wp datamachine pipeline reassign --from-agent=1 --to-agent=events-bot [--dry-run] [--force]
wp datamachine pipeline reassign --where-null --to-agent=events-bot [--dry-run] [--force]
wp datamachine flow reassign --from-agent=1 --to-agent=wire-bot [--dry-run] [--yes]
wp datamachine flow reassign --where-null --to-agent=wire-bot [--dry-run] [--yes]
```

**Key design decision:** `--from-agent` accepts raw numeric IDs without agent-table validation so stale `agent_id` values (like `agent_id=1` that doesn't exist in agents table) can be cleaned up. `--to-agent` goes through `AgentResolver` and must be a valid agent.

### Bug fixes
- **DuplicateFlowAbility**: now propagates `agent_id` from source flow (was silently dropping it, unlike DuplicatePipelineAbility)
- **PostTracking**: updated docblocks that incorrectly stated agent_id is immutable

### Ability layer
- `UpdatePipelineAbility` and `UpdateFlowAbility` schemas now include `agent_id` as an optional integer

## Migration recipe (post-merge)

```bash
# Dry-run first
wp datamachine pipeline reassign --where-null --to-agent=events-bot --dry-run --url=events.extrachill.com
wp datamachine flow reassign --where-null --to-agent=events-bot --dry-run --url=events.extrachill.com

# Execute
wp datamachine pipeline reassign --from-agent=1 --to-agent=events-bot --force --url=events.extrachill.com
wp datamachine pipeline reassign --where-null --to-agent=events-bot --force --url=events.extrachill.com
wp datamachine flow reassign --from-agent=1 --to-agent=events-bot --yes --url=events.extrachill.com
wp datamachine flow reassign --where-null --to-agent=events-bot --yes --url=events.extrachill.com

# Verify bundle export works
wp datamachine agent export events-bot --url=events.extrachill.com
```

## Testing
- 23/23 smoke tests pass (`php tests/pipeline-flow-reassign-agent-smoke.php`)
- Existing smoke tests unaffected (agent-bundle-format: 71/71, flow-update-set-user-message: 31/31)