### PR TITLE
Adopt agent authorization contracts

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -6,7 +6,6 @@
  * Version:           0.103.14
  * Requires at least: 6.9
  * Requires PHP:     8.2
- * Requires Plugins: agents-api
  * Author:          Chris Huber, extrachill
  * Author URI:      https://chubes.net
  * License:         GPL v2 or later
@@ -35,31 +34,6 @@ if ( ! defined( 'AGENTS_API_LOADED' ) ) {
 		require_once $datamachine_agents_api_bootstrap;
 	}
 }
-
-$datamachine_agents_api_auth_contracts = array(
-	'WP_Agent_Capability_Ceiling'              => 'src/Auth/class-wp-agent-capability-ceiling.php',
-	'AgentsAPI\\AI\\AgentExecutionPrincipal' => 'src/Runtime/AgentExecutionPrincipal.php',
-	'WP_Agent_Access_Grant'                    => 'src/Auth/class-wp-agent-access-grant.php',
-	'WP_Agent_Access_Store_Interface'          => 'src/Auth/class-wp-agent-access-store-interface.php',
-	'WP_Agent_Token'                           => 'src/Auth/class-wp-agent-token.php',
-	'WP_Agent_Token_Store_Interface'           => 'src/Auth/class-wp-agent-token-store-interface.php',
-	'WP_Agent_Authorization_Policy_Interface'  => 'src/Auth/class-wp-agent-authorization-policy-interface.php',
-	'WP_Agent_Token_Authenticator'             => 'src/Auth/class-wp-agent-token-authenticator.php',
-	'WP_Agent_WordPress_Authorization_Policy'  => 'src/Auth/class-wp-agent-wordpress-authorization-policy.php',
-);
-
-foreach ( $datamachine_agents_api_auth_contracts as $datamachine_agents_api_symbol => $datamachine_agents_api_relative_path ) {
-	if ( class_exists( $datamachine_agents_api_symbol, false ) || interface_exists( $datamachine_agents_api_symbol, false ) ) {
-		continue;
-	}
-
-	$datamachine_agents_api_contract_path = __DIR__ . '/vendor/automattic/agents-api/' . $datamachine_agents_api_relative_path;
-	if ( file_exists( $datamachine_agents_api_contract_path ) ) {
-		require_once $datamachine_agents_api_contract_path;
-	}
-}
-
-unset( $datamachine_agents_api_auth_contracts, $datamachine_agents_api_symbol, $datamachine_agents_api_relative_path, $datamachine_agents_api_contract_path );
 
 // WP-CLI integration
 if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/data-machine.php
+++ b/data-machine.php
@@ -36,6 +36,31 @@ if ( ! defined( 'AGENTS_API_LOADED' ) ) {
 	}
 }
 
+$datamachine_agents_api_auth_contracts = array(
+	'WP_Agent_Capability_Ceiling'              => 'src/Auth/class-wp-agent-capability-ceiling.php',
+	'AgentsAPI\\AI\\AgentExecutionPrincipal' => 'src/Runtime/AgentExecutionPrincipal.php',
+	'WP_Agent_Access_Grant'                    => 'src/Auth/class-wp-agent-access-grant.php',
+	'WP_Agent_Access_Store_Interface'          => 'src/Auth/class-wp-agent-access-store-interface.php',
+	'WP_Agent_Token'                           => 'src/Auth/class-wp-agent-token.php',
+	'WP_Agent_Token_Store_Interface'           => 'src/Auth/class-wp-agent-token-store-interface.php',
+	'WP_Agent_Authorization_Policy_Interface'  => 'src/Auth/class-wp-agent-authorization-policy-interface.php',
+	'WP_Agent_Token_Authenticator'             => 'src/Auth/class-wp-agent-token-authenticator.php',
+	'WP_Agent_WordPress_Authorization_Policy'  => 'src/Auth/class-wp-agent-wordpress-authorization-policy.php',
+);
+
+foreach ( $datamachine_agents_api_auth_contracts as $datamachine_agents_api_symbol => $datamachine_agents_api_relative_path ) {
+	if ( class_exists( $datamachine_agents_api_symbol, false ) || interface_exists( $datamachine_agents_api_symbol, false ) ) {
+		continue;
+	}
+
+	$datamachine_agents_api_contract_path = __DIR__ . '/vendor/automattic/agents-api/' . $datamachine_agents_api_relative_path;
+	if ( file_exists( $datamachine_agents_api_contract_path ) ) {
+		require_once $datamachine_agents_api_contract_path;
+	}
+}
+
+unset( $datamachine_agents_api_auth_contracts, $datamachine_agents_api_symbol, $datamachine_agents_api_relative_path, $datamachine_agents_api_contract_path );
+
 // WP-CLI integration
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once __DIR__ . '/inc/Cli/Bootstrap.php';

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -648,8 +648,8 @@ class AgentAbilities {
 				if ( $target_user_id > 0 && $owner_id === $target_user_id ) {
 					$item['user_role'] = 'admin';
 				} elseif ( $target_user_id > 0 ) {
-					$grant             = $access_repo->get_access( $agent_id, $target_user_id );
-					$item['user_role'] = $grant && isset( $grant['role'] ) ? (string) $grant['role'] : null;
+					$grant             = $access_repo->get_access( (string) $agent_id, $target_user_id );
+					$item['user_role'] = $grant instanceof \WP_Agent_Access_Grant ? $grant->role : null;
 				} else {
 					$item['user_role'] = null;
 				}
@@ -1040,7 +1040,10 @@ class AgentAbilities {
 
 		// Enrich with access grants.
 		$access_repo = new \DataMachine\Core\Database\Agents\AgentAccess();
-		$access      = $access_repo->get_users_for_agent( (int) $agent['agent_id'] );
+		$access      = array_map(
+			static fn( \WP_Agent_Access_Grant $grant ): array => $grant->to_array(),
+			$access_repo->get_users_for_agent( (string) (int) $agent['agent_id'] )
+		);
 
 		// Check for agent directory.
 		$directory_manager = new DirectoryManager();

--- a/inc/Abilities/AgentTokenAbilities.php
+++ b/inc/Abilities/AgentTokenAbilities.php
@@ -207,7 +207,7 @@ class AgentTokenAbilities {
 		}
 
 		$tokens_repo = new AgentTokens();
-		$result      = $tokens_repo->create_token(
+		$result      = $tokens_repo->create_bearer_token(
 			$agent_id,
 			$agent['agent_slug'],
 			$label,
@@ -319,7 +319,10 @@ class AgentTokenAbilities {
 		}
 
 		$tokens_repo = new AgentTokens();
-		$tokens      = $tokens_repo->list_tokens( $agent_id );
+		$tokens      = array_map(
+			static fn( \WP_Agent_Token $token ): array => $token->to_metadata_array(),
+			$tokens_repo->list_tokens( (string) $agent_id )
+		);
 
 		return array(
 			'success' => true,

--- a/inc/Abilities/Chat/CreateChatSessionAbility.php
+++ b/inc/Abilities/Chat/CreateChatSessionAbility.php
@@ -11,8 +11,6 @@
 
 namespace DataMachine\Abilities\Chat;
 
-use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
-
 defined( 'ABSPATH' ) || exit;
 
 class CreateChatSessionAbility {
@@ -125,7 +123,7 @@ class CreateChatSessionAbility {
 			$session_metadata = array_merge( $session_metadata, $input['metadata'] );
 		}
 
-		$session_id = $this->chat_db->create_session( AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() ), $user_id, $agent_id, $session_metadata, $mode );
+		$session_id = $this->chat_db->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() ), $user_id, $agent_id, $session_metadata, $mode );
 
 		if ( empty( $session_id ) ) {
 			return array(

--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -8,6 +8,8 @@
 
 namespace DataMachine\Abilities;
 
+use AgentsAPI\AI\AgentExecutionPrincipal;
+
 /**
  * Helper class for ability permission checks.
  *
@@ -96,7 +98,15 @@ class PermissionHelper {
 	 * @since 0.47.0
 	 * @var array|null
 	 */
-	private static ?array $agent_token_capabilities = null;
+	private static ?\WP_Agent_Capability_Ceiling $capability_ceiling = null;
+
+	/**
+	 * Agents API execution principal for the current request.
+	 *
+	 * @since 0.103.15
+	 * @var AgentExecutionPrincipal|null
+	 */
+	private static ?AgentExecutionPrincipal $execution_principal = null;
 
 	/**
 	 * Cross-site caller context for the current request.
@@ -257,7 +267,34 @@ class PermissionHelper {
 		self::$acting_agent_id          = $agent_id;
 		self::$acting_token_id          = $token_id;
 		self::$agent_owner_id           = $owner_id;
-		self::$agent_token_capabilities = $capabilities;
+		self::$capability_ceiling       = new \WP_Agent_Capability_Ceiling(
+			$owner_id,
+			$capabilities,
+			array(
+				'agent_id' => $agent_id,
+				'token_id' => $token_id,
+			)
+		);
+		self::$execution_principal      = null !== $token_id
+			? AgentExecutionPrincipal::agent_token(
+				$owner_id,
+				(string) $agent_id,
+				$token_id,
+				AgentExecutionPrincipal::REQUEST_CONTEXT_REST,
+				array(),
+				null,
+				null,
+				self::$capability_ceiling
+			)
+			: AgentExecutionPrincipal::user_session(
+				$owner_id,
+				(string) $agent_id,
+				AgentExecutionPrincipal::REQUEST_CONTEXT_REST,
+				array(),
+				null,
+				null,
+				self::$capability_ceiling
+			);
 	}
 
 	/**
@@ -269,8 +306,34 @@ class PermissionHelper {
 		self::$acting_agent_id          = null;
 		self::$acting_token_id          = null;
 		self::$agent_owner_id           = 0;
-		self::$agent_token_capabilities = null;
+		self::$capability_ceiling       = null;
+		self::$execution_principal      = null;
 		self::$caller_context           = null;
+	}
+
+	/**
+	 * Set the Agents API execution principal for the current request.
+	 *
+	 * @since 0.103.15
+	 *
+	 * @param AgentExecutionPrincipal $principal Execution principal.
+	 */
+	public static function set_execution_principal( AgentExecutionPrincipal $principal ): void {
+		self::$execution_principal = $principal;
+		if ( property_exists( $principal, 'capability_ceiling' ) && $principal->capability_ceiling instanceof \WP_Agent_Capability_Ceiling ) {
+			self::$capability_ceiling = $principal->capability_ceiling;
+		}
+	}
+
+	/**
+	 * Get the current Agents API execution principal, if one is active.
+	 *
+	 * @since 0.103.15
+	 *
+	 * @return AgentExecutionPrincipal|null
+	 */
+	public static function get_execution_principal(): ?AgentExecutionPrincipal {
+		return self::$execution_principal;
 	}
 
 	/**
@@ -361,26 +424,27 @@ class PermissionHelper {
 	 * @return bool
 	 */
 	private static function agent_can( string $action ): bool {
-		// Check token-level capability restrictions.
-		if ( null !== self::$agent_token_capabilities ) {
-			$mapped_capability = self::CAPABILITY_MAP[ $action ] ?? null;
-
-			if ( empty( $mapped_capability ) ) {
-				return false;
-			}
-
-			// Token must explicitly include this capability.
-			if ( ! in_array( $mapped_capability, self::$agent_token_capabilities, true ) ) {
-				return false;
-			}
+		$capability = self::CAPABILITY_MAP[ $action ] ?? null;
+		if ( empty( $capability ) || self::$agent_owner_id <= 0 ) {
+			return false;
 		}
 
-		// Ceiling check: owner must have this WordPress capability.
-		if ( self::$agent_owner_id > 0 ) {
-			return self::user_can( self::$agent_owner_id, $action );
-		}
+		$principal = self::$execution_principal ?? AgentExecutionPrincipal::user_session(
+			self::$agent_owner_id,
+			(string) self::$acting_agent_id,
+			AgentExecutionPrincipal::REQUEST_CONTEXT_REST,
+			array(),
+			null,
+			null,
+			self::$capability_ceiling
+		);
 
-		return false;
+		$policy = new \WP_Agent_WordPress_Authorization_Policy(
+			null,
+			static fn( int $user_id, string $required_capability ): bool => self::user_has_capability( $user_id, $required_capability )
+		);
+
+		return $policy->can( $principal, $capability, array( 'capability_ceiling' => self::$capability_ceiling ) );
 	}
 
 	/**
@@ -580,7 +644,8 @@ class PermissionHelper {
 
 		// Check explicit access grants.
 		$access_repo = new \DataMachine\Core\Database\Agents\AgentAccess();
-		$can_access  = $access_repo->user_can_access( $agent_id, $user_id, $minimum_role );
+		$grant       = $access_repo->get_access( (string) $agent_id, $user_id );
+		$can_access  = $grant instanceof \WP_Agent_Access_Grant && $grant->role_meets( $minimum_role );
 
 		/**
 		 * Filter whether a user can access an agent.
@@ -640,15 +705,22 @@ class PermissionHelper {
 			return false;
 		}
 
-		if ( user_can( $user_id, $mapped_capability ) ) {
-			return true;
-		}
+		return self::user_has_capability( $user_id, $mapped_capability );
+	}
 
-		// Backward compatibility for legacy installs/roles.
-		if ( user_can( $user_id, 'manage_options' ) ) {
-			return true;
-		}
-
-		return false;
+	/**
+	 * Check a concrete WordPress capability for a user under Data Machine policy.
+	 *
+	 * Administrators retain Data Machine admin behavior through manage_options;
+	 * named Data Machine caps remain the narrower operator/viewer surface.
+	 *
+	 * @since 0.103.15
+	 *
+	 * @param int    $user_id    User ID.
+	 * @param string $capability WordPress capability.
+	 * @return bool
+	 */
+	private static function user_has_capability( int $user_id, string $capability ): bool {
+		return user_can( $user_id, $capability ) || user_can( $user_id, 'manage_options' );
 	}
 }

--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -264,10 +264,10 @@ class PermissionHelper {
 	 * @param int|null   $token_id     Token ID for login-level runtime scoping.
 	 */
 	public static function set_agent_context( int $agent_id, int $owner_id, ?array $capabilities = null, ?int $token_id = null ): void {
-		self::$acting_agent_id          = $agent_id;
-		self::$acting_token_id          = $token_id;
-		self::$agent_owner_id           = $owner_id;
-		self::$capability_ceiling       = new \WP_Agent_Capability_Ceiling(
+		self::$acting_agent_id     = $agent_id;
+		self::$acting_token_id     = $token_id;
+		self::$agent_owner_id      = $owner_id;
+		self::$capability_ceiling  = new \WP_Agent_Capability_Ceiling(
 			$owner_id,
 			$capabilities,
 			array(
@@ -275,7 +275,7 @@ class PermissionHelper {
 				'token_id' => $token_id,
 			)
 		);
-		self::$execution_principal      = null !== $token_id
+		self::$execution_principal = null !== $token_id
 			? AgentExecutionPrincipal::agent_token(
 				$owner_id,
 				(string) $agent_id,
@@ -303,12 +303,12 @@ class PermissionHelper {
 	 * @since 0.47.0
 	 */
 	public static function clear_agent_context(): void {
-		self::$acting_agent_id          = null;
-		self::$acting_token_id          = null;
-		self::$agent_owner_id           = 0;
-		self::$capability_ceiling       = null;
-		self::$execution_principal      = null;
-		self::$caller_context           = null;
+		self::$acting_agent_id     = null;
+		self::$acting_token_id     = null;
+		self::$agent_owner_id      = 0;
+		self::$capability_ceiling  = null;
+		self::$execution_principal = null;
+		self::$caller_context      = null;
 	}
 
 	/**
@@ -372,7 +372,7 @@ class PermissionHelper {
 	 * @return bool
 	 */
 	public static function in_cross_site_context(): bool {
-		return self::$caller_context !== null && self::$caller_context->isCrossSite();
+		return null !== self::$caller_context && self::$caller_context->isCrossSite();
 	}
 
 	/**

--- a/inc/Api/Agents.php
+++ b/inc/Api/Agents.php
@@ -614,18 +614,18 @@ class Agents {
 		}
 
 		$access_repo = new AgentAccess();
-		$grants      = $access_repo->get_users_for_agent( $agent_id );
+		$grants      = $access_repo->get_users_for_agent( (string) $agent_id );
 
 		// Enrich with user display names.
 		$data = array();
 		foreach ( $grants as $grant ) {
-			$user   = get_user_by( 'id', $grant['user_id'] );
+			$user   = get_user_by( 'id', $grant->user_id );
 			$data[] = array(
-				'user_id'      => (int) $grant['user_id'],
+				'user_id'      => $grant->user_id,
 				'display_name' => $user ? $user->display_name : __( '(unknown user)', 'data-machine' ),
 				'user_email'   => $user ? $user->user_email : '',
-				'role'         => (string) $grant['role'],
-				'granted_at'   => $grant['granted_at'] ?? '',
+				'role'         => $grant->role,
+				'granted_at'   => $grant->granted_at ?? '',
 			);
 		}
 
@@ -671,7 +671,12 @@ class Agents {
 		}
 
 		$access_repo = new AgentAccess();
-		$ok          = $access_repo->grant_access( $agent_id, $user_id, $role );
+		try {
+			$access_repo->grant_access( new \WP_Agent_Access_Grant( (string) $agent_id, $user_id, (string) $role ) );
+			$ok = true;
+		} catch ( \Throwable $e ) {
+			$ok = false;
+		}
 
 		if ( ! $ok ) {
 			return new WP_Error(
@@ -726,7 +731,7 @@ class Agents {
 		}
 
 		$access_repo = new AgentAccess();
-		$ok          = $access_repo->revoke_access( $agent_id, $user_id );
+		$ok          = $access_repo->revoke_access( (string) $agent_id, $user_id );
 
 		if ( ! $ok ) {
 			return new WP_Error(

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -94,7 +94,7 @@ class ChatOrchestrator {
 			$session_metadata = $session['metadata'] ?? array();
 		} else {
 			// Check for recent pending session to prevent duplicates from timeout retries.
-			$pending_session = $chat_db->get_recent_pending_session( AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() ), $user_id, 600, 'chat', $acting_token_id );
+			$pending_session = $chat_db->get_recent_pending_session( self::workspace_scope(), $user_id, 600, 'chat', $acting_token_id );
 
 			if ( $pending_session ) {
 				$session_id       = $pending_session['session_id'];
@@ -598,7 +598,7 @@ class ChatOrchestrator {
 			$metadata['source'] = $source;
 		}
 
-		$session_id = $chat_db->create_session( AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() ), $user_id, $agent_id, $metadata, 'chat' );
+		$session_id = $chat_db->create_session( self::workspace_scope(), $user_id, $agent_id, $metadata, 'chat' );
 
 		if ( empty( $session_id ) ) {
 			return new WP_Error(
@@ -761,5 +761,12 @@ class ChatOrchestrator {
 				array( 'status' => 500 )
 			);
 		}
+	}
+
+	/**
+	 * Resolve the current site workspace for transcript storage.
+	 */
+	private static function workspace_scope(): AgentWorkspaceScope {
+		return AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() );
 	}
 }

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -493,7 +493,7 @@ class AgentsCommand extends AgentBundleCommand {
 
 		switch ( $action ) {
 			case 'list':
-				$grants = $access_repo->get_users_for_agent( $agent_id );
+				$grants = $access_repo->get_users_for_agent( (string) $agent_id );
 
 				if ( empty( $grants ) ) {
 					WP_CLI::warning( sprintf( 'No access grants for agent "%s".', $slug ) );
@@ -502,11 +502,11 @@ class AgentsCommand extends AgentBundleCommand {
 
 				$items = array();
 				foreach ( $grants as $grant ) {
-					$user    = get_user_by( 'id', $grant['user_id'] );
+					$user    = get_user_by( 'id', $grant->user_id );
 					$items[] = array(
-						'user_id' => $grant['user_id'],
+						'user_id' => $grant->user_id,
 						'login'   => $user ? $user->user_login : '(deleted)',
-						'role'    => $grant['role'],
+						'role'    => $grant->role,
 					);
 				}
 
@@ -523,7 +523,12 @@ class AgentsCommand extends AgentBundleCommand {
 				$user_id = $this->resolveUserId( $user_value );
 				$role    = $assoc_args['role'] ?? 'operator';
 
-				$ok = $access_repo->grant_access( $agent_id, $user_id, $role );
+				try {
+					$access_repo->grant_access( new \WP_Agent_Access_Grant( (string) $agent_id, $user_id, (string) $role ) );
+					$ok = true;
+				} catch ( \Throwable $e ) {
+					$ok = false;
+				}
 				if ( $ok ) {
 					$user = get_user_by( 'id', $user_id );
 					WP_CLI::success( sprintf(
@@ -545,7 +550,7 @@ class AgentsCommand extends AgentBundleCommand {
 				}
 
 				$user_id = $this->resolveUserId( $user_value );
-				$ok      = $access_repo->revoke_access( $agent_id, $user_id );
+				$ok      = $access_repo->revoke_access( (string) $agent_id, $user_id );
 
 				if ( $ok ) {
 					WP_CLI::success( sprintf( 'Revoked access for user %d on agent "%s".', $user_id, $slug ) );

--- a/inc/Cli/Commands/ChatCommand.php
+++ b/inc/Cli/Commands/ChatCommand.php
@@ -11,7 +11,6 @@
 namespace DataMachine\Cli\Commands;
 
 use WP_CLI;
-use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 
@@ -287,7 +286,7 @@ class ChatCommand extends BaseCommand {
 		);
 
 		$chat_db    = ConversationStoreFactory::get();
-		$session_id = $chat_db->create_session( AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() ), $user_id, $agent_id, $metadata, $context );
+		$session_id = $chat_db->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() ), $user_id, $agent_id, $metadata, $context );
 
 		if ( empty( $session_id ) ) {
 			WP_CLI::error( 'Failed to create chat session.' );

--- a/inc/Core/Auth/AgentAuthMiddleware.php
+++ b/inc/Core/Auth/AgentAuthMiddleware.php
@@ -126,8 +126,8 @@ class AgentAuthMiddleware {
 		}
 
 		// Parse cross-site caller context from A2A headers (no-op for non-A2A requests).
-		$request      = self::current_rest_request();
-		$inbound_ctx  = $request !== null
+		$request     = self::current_rest_request();
+		$inbound_ctx = null !== $request
 			? CallerContext::fromRequest( $request )
 			: new CallerContext();
 

--- a/inc/Core/Auth/AgentAuthMiddleware.php
+++ b/inc/Core/Auth/AgentAuthMiddleware.php
@@ -27,6 +27,7 @@ use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Agents\AgentTokens;
 use DataMachine\Engine\AI\IterationBudgetRegistry;
+use AgentsAPI\AI\AgentExecutionPrincipal;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -75,11 +76,12 @@ class AgentAuthMiddleware {
 			return null; // Not our token — pass through to WordPress/other auth.
 		}
 
-		// Resolve token hash against database.
-		$tokens_repo  = new AgentTokens();
-		$token_record = $tokens_repo->resolve_token( $raw_token );
+		// Resolve token through the generic Agents API token contract.
+		$tokens_repo   = new AgentTokens();
+		$authenticator = new \WP_Agent_Token_Authenticator( $tokens_repo, self::TOKEN_PREFIX );
+		$principal     = $authenticator->authenticate_bearer_token( $raw_token, AgentExecutionPrincipal::REQUEST_CONTEXT_REST );
 
-		if ( ! $token_record ) {
+		if ( ! $principal ) {
 			do_action(
 				'datamachine_log',
 				'warning',
@@ -94,8 +96,9 @@ class AgentAuthMiddleware {
 			);
 		}
 
-		$agent_id = (int) $token_record['agent_id'];
-		$token_id = (int) $token_record['token_id'];
+		$agent_id = (int) $principal->effective_agent_id;
+		$token_id = (int) $principal->token_id;
+		$token    = $tokens_repo->get_token( $token_id );
 
 		// Verify agent exists.
 		$agents_repo = new Agents();
@@ -121,9 +124,6 @@ class AgentAuthMiddleware {
 				array( 'status' => 401 )
 			);
 		}
-
-		// Track token usage.
-		$tokens_repo->touch_last_used( $token_id );
 
 		// Parse cross-site caller context from A2A headers (no-op for non-A2A requests).
 		$request      = self::current_rest_request();
@@ -176,9 +176,10 @@ class AgentAuthMiddleware {
 		wp_set_current_user( $owner_id );
 
 		// Set agent execution context in PermissionHelper.
-		// This adds the agent_id scoping layer and optional capability restrictions.
-		$token_capabilities = $token_record['capabilities'] ?? null;
+		// This adds the agent_id scoping layer and the Agents API capability ceiling.
+		$token_capabilities = $token instanceof \WP_Agent_Token ? $token->allowed_capabilities : null;
 		PermissionHelper::set_agent_context( $agent_id, $owner_id, $token_capabilities, $token_id );
+		PermissionHelper::set_execution_principal( $principal );
 
 		// Expose the caller context for downstream code (ChatOrchestrator,
 		// abilities, logging) that wants to know who's calling and where
@@ -195,7 +196,7 @@ class AgentAuthMiddleware {
 					'agent_slug'           => $agent['agent_slug'],
 					'owner_id'             => $owner_id,
 					'token_id'             => $token_id,
-					'token_label'          => $token_record['label'] ?? '',
+					'token_label'          => $principal->request_metadata['token_label'] ?? '',
 					'has_cap_restrictions' => null !== $token_capabilities,
 				),
 				$inbound_ctx->toLogContext()

--- a/inc/Core/Auth/AgentAuthorize.php
+++ b/inc/Core/Auth/AgentAuthorize.php
@@ -323,7 +323,7 @@ class AgentAuthorize {
 		$tokens_repo = new AgentTokens();
 		$token_label = ! empty( $label ) ? $label : 'authorize-flow-' . gmdate( 'Y-m-d' );
 
-		$result = $tokens_repo->create_token(
+		$result = $tokens_repo->create_bearer_token(
 			(int) $agent['agent_id'],
 			$agent['agent_slug'],
 			$token_label,
@@ -380,7 +380,8 @@ class AgentAuthorize {
 
 		// Check access grants.
 		$access_repo = new AgentAccess();
-		return $access_repo->user_can_access( (int) $agent['agent_id'], $user_id, 'admin' );
+		$grant = $access_repo->get_access( (string) (int) $agent['agent_id'], $user_id );
+		return $grant instanceof \WP_Agent_Access_Grant && $grant->role_meets( \WP_Agent_Access_Grant::ROLE_ADMIN );
 	}
 
 	/**

--- a/inc/Core/Auth/AgentAuthorize.php
+++ b/inc/Core/Auth/AgentAuthorize.php
@@ -380,7 +380,7 @@ class AgentAuthorize {
 
 		// Check access grants.
 		$access_repo = new AgentAccess();
-		$grant = $access_repo->get_access( (string) (int) $agent['agent_id'], $user_id );
+		$grant       = $access_repo->get_access( (string) (int) $agent['agent_id'], $user_id );
 		return $grant instanceof \WP_Agent_Access_Grant && $grant->role_meets( \WP_Agent_Access_Grant::ROLE_ADMIN );
 	}
 
@@ -616,19 +616,19 @@ class AgentAuthorize {
 
 		<dl class="agent-info">
 			<dt>Agent</dt>
-			<dd>' . $agent_name . ' <code style="font-size:0.8125rem;color:#646970">(' . $agent_slug . ')</code></dd>
+			<dd>' . esc_html( $agent_name ) . ' <code style="font-size:0.8125rem;color:#646970">(' . esc_html( $agent_slug ) . ')</code></dd>
 			<dt>Owner</dt>
-			<dd>' . $owner_name . '</dd>
+			<dd>' . esc_html( $owner_name ) . '</dd>
 			<dt>Redirect</dt>
-			<dd><code style="font-size:0.8125rem">' . $uri_display . '</code></dd>
+			<dd><code style="font-size:0.8125rem">' . esc_html( $uri_display ) . '</code></dd>
 		</dl>
 
 		<div class="auth-notice">
-			This will create a bearer token granting <strong>' . $agent_name . '</strong> API access to this site with your permissions. The token does not expire.
+			This will create a bearer token granting <strong>' . esc_html( $agent_name ) . '</strong> API access to this site with your permissions. The token does not expire.
 		</div>
 
 		<form method="POST" action="' . esc_url( $action_url ) . '">
-			<input type="hidden" name="agent_slug" value="' . $agent_slug . '">
+			<input type="hidden" name="agent_slug" value="' . esc_attr( $agent_slug ) . '">
 			<input type="hidden" name="redirect_uri" value="' . esc_attr( $redirect_uri ) . '">
 			<input type="hidden" name="label" value="' . esc_attr( $label ) . '">
 			<input type="hidden" name="_authorize_nonce" value="' . esc_attr( $nonce ) . '">' .
@@ -645,7 +645,7 @@ class AgentAuthorize {
 			</div>
 		</form>
 
-		<div class="auth-user">Signed in as <strong>' . $user_name . '</strong></div>
+		<div class="auth-user">Signed in as <strong>' . esc_html( $user_name ) . '</strong></div>
 	</div>
 </body>
 </html>';

--- a/inc/Core/Database/Agents/AgentAccess.php
+++ b/inc/Core/Database/Agents/AgentAccess.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class AgentAccess extends BaseRepository {
+class AgentAccess extends BaseRepository implements \WP_Agent_Access_Store_Interface {
 
 	/**
 	 * Table name (without prefix).
@@ -31,7 +31,7 @@ class AgentAccess extends BaseRepository {
 	 * - operator: run flows, view jobs, manage queue
 	 * - viewer: read-only access to pipelines, flows, jobs
 	 */
-	const VALID_ROLES = array( 'admin', 'operator', 'viewer' );
+	const VALID_ROLES = array( \WP_Agent_Access_Grant::ROLE_ADMIN, \WP_Agent_Access_Grant::ROLE_OPERATOR, \WP_Agent_Access_Grant::ROLE_VIEWER );
 
 	/**
 	 * Use network-level prefix so access grants are shared across the multisite network.
@@ -81,12 +81,11 @@ class AgentAccess extends BaseRepository {
 	 * @param string $role     Access role (admin, operator, viewer).
 	 * @return bool True on success.
 	 */
-	public function grant_access( int $agent_id, int $user_id, string $role = 'viewer' ): bool {
-		if ( ! in_array( $role, self::VALID_ROLES, true ) ) {
-			return false;
-		}
-
-		$existing = $this->get_access( $agent_id, $user_id );
+	public function grant_access( \WP_Agent_Access_Grant $grant ): \WP_Agent_Access_Grant {
+		$agent_id = (int) $grant->agent_id;
+		$user_id  = $grant->user_id;
+		$role     = $grant->role;
+		$existing = $this->get_access( $grant->agent_id, $user_id, $grant->workspace_id );
 
 		if ( $existing ) {
 			// Update existing role.
@@ -102,7 +101,12 @@ class AgentAccess extends BaseRepository {
 				array( '%d', '%d' )
 			);
 
-			return false !== $result;
+			if ( false === $result ) {
+				throw new \RuntimeException( 'datamachine_agent_access_update_failed' );
+			}
+
+			$updated = $this->get_access( $grant->agent_id, $user_id, $grant->workspace_id );
+			return $updated ?? $grant;
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
@@ -117,7 +121,12 @@ class AgentAccess extends BaseRepository {
 			array( '%d', '%d', '%s', '%s' )
 		);
 
-		return false !== $result;
+		if ( false === $result ) {
+			throw new \RuntimeException( 'datamachine_agent_access_insert_failed' );
+		}
+
+		$created = $this->get_access( $grant->agent_id, $user_id, $grant->workspace_id );
+		return $created ?? $grant;
 	}
 
 	/**
@@ -127,12 +136,12 @@ class AgentAccess extends BaseRepository {
 	 * @param int $user_id  WordPress user ID.
 	 * @return bool True on success.
 	 */
-	public function revoke_access( int $agent_id, int $user_id ): bool {
+	public function revoke_access( string $agent_id, int $user_id, ?string $workspace_id = null ): bool {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$result = $this->wpdb->delete(
 			$this->table_name,
 			array(
-				'agent_id' => $agent_id,
+				'agent_id' => (int) $agent_id,
 				'user_id'  => $user_id,
 			),
 			array( '%d', '%d' )
@@ -148,20 +157,20 @@ class AgentAccess extends BaseRepository {
 	 * @param int $user_id  WordPress user ID.
 	 * @return array|null Access row or null.
 	 */
-	public function get_access( int $agent_id, int $user_id ): ?array {
+	public function get_access( string $agent_id, int $user_id, ?string $workspace_id = null ): ?\WP_Agent_Access_Grant {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$row = $this->wpdb->get_row(
 			$this->wpdb->prepare(
 				'SELECT * FROM %i WHERE agent_id = %d AND user_id = %d',
 				$this->table_name,
-				$agent_id,
+				(int) $agent_id,
 				$user_id
 			),
 			ARRAY_A
 		);
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 
-		return $row ? $row : null;
+		return $row ? self::grant_from_row( $row ) : null;
 	}
 
 	/**
@@ -171,7 +180,7 @@ class AgentAccess extends BaseRepository {
 	 * @param string|null $minimum_role Minimum role to filter by (null = any role).
 	 * @return int[] Array of agent IDs.
 	 */
-	public function get_agent_ids_for_user( int $user_id, ?string $minimum_role = null ): array {
+	public function get_agent_ids_for_user( int $user_id, ?string $minimum_role = null, ?string $workspace_id = null ): array {
 		if ( null !== $minimum_role ) {
 			$allowed_roles = $this->roles_at_or_above( $minimum_role );
 			if ( empty( $allowed_roles ) ) {
@@ -209,19 +218,19 @@ class AgentAccess extends BaseRepository {
 	 * @param int $agent_id Agent ID.
 	 * @return array[] Array of access rows.
 	 */
-	public function get_users_for_agent( int $agent_id ): array {
+	public function get_users_for_agent( string $agent_id, ?string $workspace_id = null ): array {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$results = $this->wpdb->get_results(
 			$this->wpdb->prepare(
 				'SELECT * FROM %i WHERE agent_id = %d ORDER BY granted_at ASC',
 				$this->table_name,
-				$agent_id
+				(int) $agent_id
 			),
 			ARRAY_A
 		);
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 
-		return $results ? $results : array();
+		return array_map( array( self::class, 'grant_from_row' ), $results ? $results : array() );
 	}
 
 	/**
@@ -233,13 +242,13 @@ class AgentAccess extends BaseRepository {
 	 * @return bool True if user has the required access level.
 	 */
 	public function user_can_access( int $agent_id, int $user_id, string $minimum_role = 'viewer' ): bool {
-		$access = $this->get_access( $agent_id, $user_id );
+		$access = $this->get_access( (string) $agent_id, $user_id );
 
 		if ( ! $access ) {
 			return false;
 		}
 
-		return $this->role_meets_minimum( $access['role'], $minimum_role );
+		return $access->role_meets( $minimum_role );
 	}
 
 	/**
@@ -252,7 +261,30 @@ class AgentAccess extends BaseRepository {
 	 * @return bool True on success.
 	 */
 	public function bootstrap_owner_access( int $agent_id, int $owner_id ): bool {
-		return $this->grant_access( $agent_id, $owner_id, 'admin' );
+		try {
+			$this->grant_access( new \WP_Agent_Access_Grant( (string) $agent_id, $owner_id, \WP_Agent_Access_Grant::ROLE_ADMIN ) );
+			return true;
+		} catch ( \Throwable $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Convert a persisted access row into the Agents API grant contract.
+	 *
+	 * @param array<string,mixed> $row Database row.
+	 */
+	private static function grant_from_row( array $row ): \WP_Agent_Access_Grant {
+		return new \WP_Agent_Access_Grant(
+			(string) ( $row['agent_id'] ?? '' ),
+			(int) ( $row['user_id'] ?? 0 ),
+			(string) ( $row['role'] ?? \WP_Agent_Access_Grant::ROLE_VIEWER ),
+			null,
+			isset( $row['id'] ) ? (int) $row['id'] : null,
+			null,
+			isset( $row['granted_at'] ) ? (string) $row['granted_at'] : null,
+			array( 'source' => 'datamachine_agent_access' )
+		);
 	}
 
 	/**

--- a/inc/Core/Database/Agents/AgentTokens.php
+++ b/inc/Core/Database/Agents/AgentTokens.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class AgentTokens extends BaseRepository {
+class AgentTokens extends BaseRepository implements \WP_Agent_Token_Store_Interface {
 
 	/**
 	 * Table name (without prefix).
@@ -87,21 +87,63 @@ class AgentTokens extends BaseRepository {
 	 * @param string|null $expires_at   Expiry datetime string (null = never).
 	 * @return array{token_id: int, raw_token: string, token_prefix: string}|null Created token data or null on failure.
 	 */
-	public function create_token( int $agent_id, string $agent_slug, string $label = '', ?array $capabilities = null, ?string $expires_at = null ): ?array {
+	public function create_bearer_token( int $agent_id, string $agent_slug, string $label = '', ?array $capabilities = null, ?string $expires_at = null ): ?array {
 		// Generate cryptographically random token.
 		$random_bytes = bin2hex( random_bytes( 32 ) );
 		$raw_token    = self::TOKEN_PREFIX . $agent_slug . '_' . $random_bytes;
-		$token_hash   = hash( 'sha256', $raw_token );
+		$token_hash   = \WP_Agent_Token::hash_token( $raw_token );
 		$prefix       = substr( $raw_token, 0, 12 );
+		$agents_repo  = new Agents();
+		$agent        = $agents_repo->get_agent( $agent_id );
+
+		if ( ! $agent ) {
+			return null;
+		}
+
+		try {
+			$token = $this->create_token(
+				new \WP_Agent_Token(
+					1,
+					(string) $agent_id,
+					(int) $agent['owner_id'],
+					$token_hash,
+					$prefix,
+					sanitize_text_field( $label ),
+					$capabilities,
+					$expires_at,
+					null,
+					current_time( 'mysql', true ),
+					null,
+					null,
+					array( 'agent_slug' => $agent_slug )
+				)
+			);
+		} catch ( \Throwable $e ) {
+			$this->log_db_error( 'Create agent token', array( 'agent_id' => $agent_id ) );
+			return null;
+		}
+
+		return array(
+			'token_id'     => $token->token_id,
+			'raw_token'    => $raw_token,
+			'token_prefix' => $token->token_prefix,
+		);
+	}
+
+	/**
+	 * Create a token metadata record for a pre-hashed token.
+	 */
+	public function create_token( \WP_Agent_Token $token ): \WP_Agent_Token {
+		$agent_id = (int) $token->agent_id;
 
 		$insert_data = array(
 			'agent_id'     => $agent_id,
-			'token_hash'   => $token_hash,
-			'token_prefix' => $prefix,
-			'label'        => sanitize_text_field( $label ),
-			'capabilities' => null !== $capabilities ? wp_json_encode( $capabilities ) : null,
-			'expires_at'   => $expires_at,
-			'created_at'   => current_time( 'mysql', true ),
+			'token_hash'   => $token->token_hash,
+			'token_prefix' => $token->token_prefix,
+			'label'        => sanitize_text_field( $token->label ),
+			'capabilities' => null !== $token->allowed_capabilities ? wp_json_encode( $token->allowed_capabilities ) : null,
+			'expires_at'   => $token->expires_at,
+			'created_at'   => $token->created_at ?? current_time( 'mysql', true ),
 		);
 
 		$formats = array( '%d', '%s', '%s', '%s', '%s', '%s', '%s' );
@@ -111,14 +153,11 @@ class AgentTokens extends BaseRepository {
 
 		if ( false === $result ) {
 			$this->log_db_error( 'Create agent token', array( 'agent_id' => $agent_id ) );
-			return null;
+			throw new \RuntimeException( 'datamachine_agent_token_insert_failed' );
 		}
 
-		return array(
-			'token_id'     => (int) $this->wpdb->insert_id,
-			'raw_token'    => $raw_token,
-			'token_prefix' => $prefix,
-		);
+		$created = $this->get_token( (int) $this->wpdb->insert_id );
+		return $created ?? $token;
 	}
 
 	/**
@@ -131,8 +170,7 @@ class AgentTokens extends BaseRepository {
 	 * @param string $raw_token Raw bearer token from Authorization header.
 	 * @return array|null Token record (with agent_id) or null if not found/expired.
 	 */
-	public function resolve_token( string $raw_token ): ?array {
-		$token_hash = hash( 'sha256', $raw_token );
+	public function resolve_token_hash( string $token_hash ): ?\WP_Agent_Token {
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$row = $this->wpdb->get_row(
@@ -149,20 +187,7 @@ class AgentTokens extends BaseRepository {
 			return null;
 		}
 
-		// Check expiry.
-		if ( ! empty( $row['expires_at'] ) ) {
-			$expires_timestamp = strtotime( $row['expires_at'] );
-			if ( $expires_timestamp && $expires_timestamp < time() ) {
-				return null;
-			}
-		}
-
-		// Decode capabilities JSON.
-		if ( ! empty( $row['capabilities'] ) ) {
-			$row['capabilities'] = json_decode( $row['capabilities'], true );
-		}
-
-		return $row;
+		return $this->token_from_row( $row );
 	}
 
 	/**
@@ -173,11 +198,11 @@ class AgentTokens extends BaseRepository {
 	 * @param int $token_id Token ID.
 	 * @return void
 	 */
-	public function touch_last_used( int $token_id ): void {
+	public function touch_token( int $token_id, ?string $used_at = null ): void {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$this->wpdb->update(
 			$this->table_name,
-			array( 'last_used_at' => current_time( 'mysql', true ) ),
+			array( 'last_used_at' => $used_at ?? current_time( 'mysql', true ) ),
 			array( 'token_id' => $token_id ),
 			array( '%s' ),
 			array( '%d' )
@@ -191,13 +216,13 @@ class AgentTokens extends BaseRepository {
 	 * @param int $agent_id Agent ID (for authorization — ensures token belongs to this agent).
 	 * @return bool True if deleted, false if not found or wrong agent.
 	 */
-	public function revoke_token( int $token_id, int $agent_id ): bool {
+	public function revoke_token( int $token_id, string $agent_id ): bool {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$result = $this->wpdb->delete(
 			$this->table_name,
 			array(
 				'token_id' => $token_id,
-				'agent_id' => $agent_id,
+				'agent_id' => (int) $agent_id,
 			),
 			array( '%d', '%d' )
 		);
@@ -213,11 +238,11 @@ class AgentTokens extends BaseRepository {
 	 * @param int $agent_id Agent ID.
 	 * @return int Number of tokens revoked.
 	 */
-	public function revoke_all_for_agent( int $agent_id ): int {
+	public function revoke_all_tokens_for_agent( string $agent_id ): int {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$result = $this->wpdb->delete(
 			$this->table_name,
-			array( 'agent_id' => $agent_id ),
+			array( 'agent_id' => (int) $agent_id ),
 			array( '%d' )
 		);
 
@@ -232,13 +257,13 @@ class AgentTokens extends BaseRepository {
 	 * @param int $agent_id Agent ID.
 	 * @return array[] Array of token metadata rows.
 	 */
-	public function list_tokens( int $agent_id ): array {
+	public function list_tokens( string $agent_id ): array {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$results = $this->wpdb->get_results(
 			$this->wpdb->prepare(
-				'SELECT token_id, agent_id, token_prefix, label, capabilities, last_used_at, expires_at, created_at FROM %i WHERE agent_id = %d ORDER BY created_at DESC',
+				'SELECT token_id, agent_id, token_hash, token_prefix, label, capabilities, last_used_at, expires_at, created_at FROM %i WHERE agent_id = %d ORDER BY created_at DESC',
 				$this->table_name,
-				$agent_id
+				(int) $agent_id
 			),
 			ARRAY_A
 		);
@@ -248,13 +273,7 @@ class AgentTokens extends BaseRepository {
 			return array();
 		}
 
-		foreach ( $results as &$row ) {
-			if ( ! empty( $row['capabilities'] ) ) {
-				$row['capabilities'] = json_decode( $row['capabilities'], true );
-			}
-		}
-
-		return $results;
+		return array_values( array_filter( array_map( array( $this, 'token_from_row' ), $results ) ) );
 	}
 
 	/**
@@ -263,11 +282,11 @@ class AgentTokens extends BaseRepository {
 	 * @param int $token_id Token ID.
 	 * @return array|null Token metadata or null.
 	 */
-	public function get_token( int $token_id ): ?array {
+	public function get_token( int $token_id ): ?\WP_Agent_Token {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$row = $this->wpdb->get_row(
 			$this->wpdb->prepare(
-				'SELECT token_id, agent_id, token_prefix, label, capabilities, last_used_at, expires_at, created_at FROM %i WHERE token_id = %d',
+				'SELECT token_id, agent_id, token_hash, token_prefix, label, capabilities, last_used_at, expires_at, created_at FROM %i WHERE token_id = %d',
 				$this->table_name,
 				$token_id
 			),
@@ -275,15 +294,7 @@ class AgentTokens extends BaseRepository {
 		);
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 
-		if ( ! $row ) {
-			return null;
-		}
-
-		if ( ! empty( $row['capabilities'] ) ) {
-			$row['capabilities'] = json_decode( $row['capabilities'], true );
-		}
-
-		return $row;
+		return $row ? $this->token_from_row( $row ) : null;
 	}
 
 	/**
@@ -294,5 +305,42 @@ class AgentTokens extends BaseRepository {
 	 */
 	public function count_tokens( int $agent_id ): int {
 		return $this->count_rows( 'agent_id = %d', array( $agent_id ) );
+	}
+
+	/**
+	 * Convert a persisted token row into the Agents API token contract.
+	 *
+	 * @param array<string,mixed> $row Database row.
+	 */
+	private function token_from_row( array $row ): ?\WP_Agent_Token {
+		$agent_id    = (int) ( $row['agent_id'] ?? 0 );
+		$agents_repo = new Agents();
+		$agent       = $agents_repo->get_agent( $agent_id );
+
+		if ( ! $agent ) {
+			return null;
+		}
+
+		$capabilities = null;
+		if ( ! empty( $row['capabilities'] ) ) {
+			$decoded      = json_decode( (string) $row['capabilities'], true );
+			$capabilities = is_array( $decoded ) ? array_values( array_map( 'strval', $decoded ) ) : null;
+		}
+
+		return new \WP_Agent_Token(
+			(int) ( $row['token_id'] ?? 0 ),
+			(string) $agent_id,
+			(int) $agent['owner_id'],
+			(string) ( $row['token_hash'] ?? str_repeat( '0', 64 ) ),
+			(string) ( $row['token_prefix'] ?? '' ),
+			(string) ( $row['label'] ?? '' ),
+			$capabilities,
+			isset( $row['expires_at'] ) ? (string) $row['expires_at'] : null,
+			isset( $row['last_used_at'] ) ? (string) $row['last_used_at'] : null,
+			isset( $row['created_at'] ) ? (string) $row['created_at'] : null,
+			null,
+			null,
+			array( 'agent_slug' => (string) $agent['agent_slug'] )
+		);
 	}
 }

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -223,7 +223,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * @param int                 $user_id   WordPress user ID.
 	 * @param int                 $agent_id  Agent ID.
 	 * @param array               $metadata  Optional session metadata.
-	 * @param string              $context   Execution mode (chat, pipeline, system).
+	 * @param string              $context   Execution context (chat, pipeline, system).
 	 * @return string Session ID (UUID)
 	 */
 	public function create_session(
@@ -316,11 +316,8 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			return null;
 		}
 
-		$session['messages']       = self::normalize_messages( json_decode( $session['messages'], true ) ?? array() );
-		$session['metadata']       = json_decode( $session['metadata'], true ) ?? array();
-		$session['workspace_type'] = (string) ( $session['metadata']['workspace_type'] ?? 'site' );
-		$session['workspace_id']   = (string) ( $session['metadata']['workspace_id'] ?? (string) get_current_blog_id() );
-		$session['context']        = $session['mode'] ?? 'chat';
+		$session['messages'] = self::normalize_messages( json_decode( $session['messages'], true ) ?? array() );
+		$session['metadata'] = json_decode( $session['metadata'], true ) ?? array();
 
 		return $session;
 	}
@@ -748,11 +745,8 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			return null;
 		}
 
-		$session['messages']       = self::normalize_messages( json_decode( $session['messages'], true ) ?? array() );
-		$session['metadata']       = json_decode( $session['metadata'], true ) ?? array();
-		$session['workspace_type'] = (string) ( $session['metadata']['workspace_type'] ?? $workspace->workspace_type );
-		$session['workspace_id']   = (string) ( $session['metadata']['workspace_id'] ?? $workspace->workspace_id );
-		$session['context']        = $session['mode'] ?? $context;
+		$session['messages'] = self::normalize_messages( json_decode( $session['messages'], true ) ?? array() );
+		$session['metadata'] = json_decode( $session['metadata'], true ) ?? array();
 
 		return $session;
 	}

--- a/inc/Core/FilesRepository/AgentMemory.php
+++ b/inc/Core/FilesRepository/AgentMemory.php
@@ -72,11 +72,12 @@ class AgentMemory {
 		$this->directory_manager = new DirectoryManager();
 		$effective_user_id       = $this->directory_manager->get_effective_user_id( $user_id );
 		$safe_filename           = $this->sanitize_filename( $filename );
+		$workspace               = self::workspace_parts();
 
 		$this->scope = new AgentMemoryScope(
 			$layer ?? self::resolve_layer_for( $safe_filename ),
-			'site',
-			self::workspace_id(),
+			$workspace['type'],
+			$workspace['id'],
 			$effective_user_id,
 			$agent_id,
 			$safe_filename
@@ -106,13 +107,6 @@ class AgentMemory {
 	 */
 	public function get_scope(): AgentMemoryScope {
 		return $this->scope;
-	}
-
-	/**
-	 * Resolve the current WordPress site workspace ID.
-	 */
-	private static function workspace_id(): string {
-		return function_exists( 'get_current_blog_id' ) ? (string) get_current_blog_id() : '1';
 	}
 
 	/**
@@ -235,7 +229,8 @@ class AgentMemory {
 	public static function list_layer( string $layer, int $user_id = 0, int $agent_id = 0 ): array {
 		$dm                = new DirectoryManager();
 		$effective_user_id = $dm->get_effective_user_id( $user_id );
-		$scope_query       = new AgentMemoryScope( $layer, 'site', self::workspace_id(), $effective_user_id, $agent_id, '' );
+		$workspace         = self::workspace_parts();
+		$scope_query       = new AgentMemoryScope( $layer, $workspace['type'], $workspace['id'], $effective_user_id, $agent_id, '' );
 		$store             = AgentMemoryStoreFactory::for_scope( $scope_query );
 
 		return $store->list_layer( $scope_query );
@@ -263,7 +258,8 @@ class AgentMemory {
 	public static function list_subtree( string $layer, int $user_id, int $agent_id, string $prefix ): array {
 		$dm                = new DirectoryManager();
 		$effective_user_id = $dm->get_effective_user_id( $user_id );
-		$scope_query       = new AgentMemoryScope( $layer, 'site', self::workspace_id(), $effective_user_id, $agent_id, '' );
+		$workspace         = self::workspace_parts();
+		$scope_query       = new AgentMemoryScope( $layer, $workspace['type'], $workspace['id'], $effective_user_id, $agent_id, '' );
 		$store             = AgentMemoryStoreFactory::for_scope( $scope_query );
 
 		return $store->list_subtree( $scope_query, $prefix );
@@ -715,6 +711,19 @@ class AgentMemory {
 			$clean[] = preg_replace( '/[^a-zA-Z0-9._-]/', '', basename( $segment ) );
 		}
 		return implode( '/', $clean );
+	}
+
+	/**
+	 * Resolve the current site workspace identity for memory storage.
+	 *
+	 * @since next
+	 * @return array{type:string,id:string}
+	 */
+	private static function workspace_parts(): array {
+		return array(
+			'type' => 'site',
+			'id'   => function_exists( 'get_current_blog_id' ) ? (string) get_current_blog_id() : '1',
+		);
 	}
 
 	/**

--- a/inc/Core/FilesRepository/DiskAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/DiskAgentMemoryStore.php
@@ -78,7 +78,7 @@ class DiskAgentMemoryStore implements AgentMemoryStoreInterface {
 			$bytes,
 			false === $updated_at ? null : (int) $updated_at,
 			null,
-			$this->capabilities()->unsupported_metadata_fields( $metadata_fields, 'read' ),
+			$metadata_fields,
 		);
 	}
 
@@ -88,6 +88,8 @@ class DiskAgentMemoryStore implements AgentMemoryStoreInterface {
 	 * `$if_match` is intentionally ignored — see class docblock.
 	 */
 	public function write( AgentMemoryScope $scope, string $content, ?string $if_match = null, ?AgentMemoryMetadata $metadata = null ): AgentMemoryWriteResult {
+		unset( $metadata );
+
 		$filepath = $this->resolve_filepath( $scope );
 		$dir      = dirname( $filepath );
 
@@ -143,6 +145,8 @@ class DiskAgentMemoryStore implements AgentMemoryStoreInterface {
 	 * @inheritDoc
 	 */
 	public function list_layer( AgentMemoryScope $scope_query, ?AgentMemoryQuery $query = null ): array {
+		unset( $query );
+
 		$layer_dir = $this->resolve_layer_directory( $scope_query );
 
 		if ( ! is_dir( $layer_dir ) ) {
@@ -182,6 +186,8 @@ class DiskAgentMemoryStore implements AgentMemoryStoreInterface {
 	 * including the prefix (e.g. `daily/2026/04/17.md`).
 	 */
 	public function list_subtree( AgentMemoryScope $scope_query, string $prefix, ?AgentMemoryQuery $query = null ): array {
+		unset( $query );
+
 		$prefix = trim( $prefix, '/' );
 		if ( '' === $prefix ) {
 			return array();

--- a/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
@@ -39,12 +39,14 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 	const TAXONOMY    = 'wp_guideline_type';
 	const TERM_MEMORY = 'memory';
 
-	const META_LAYER    = '_datamachine_memory_layer';
-	const META_USER_ID  = '_datamachine_memory_user_id';
-	const META_AGENT_ID = '_datamachine_memory_agent_id';
-	const META_FILENAME = '_datamachine_memory_filename';
-	const META_HASH     = '_datamachine_memory_hash';
-	const META_BYTES    = '_datamachine_memory_bytes';
+	const META_LAYER          = '_datamachine_memory_layer';
+	const META_WORKSPACE_TYPE = '_datamachine_memory_workspace_type';
+	const META_WORKSPACE_ID   = '_datamachine_memory_workspace_id';
+	const META_USER_ID        = '_datamachine_memory_user_id';
+	const META_AGENT_ID       = '_datamachine_memory_agent_id';
+	const META_FILENAME       = '_datamachine_memory_filename';
+	const META_HASH           = '_datamachine_memory_hash';
+	const META_BYTES          = '_datamachine_memory_bytes';
 
 	/**
 	 * Whether the host has the Guidelines substrate this store needs.
@@ -100,13 +102,15 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 		$updated = strtotime( (string) $post->post_modified_gmt );
 		$updated = false === $updated ? null : (int) $updated;
 
-		return new AgentMemoryReadResult( true, $content, $hash, $bytes, $updated, null, $this->capabilities()->unsupported_metadata_fields( $metadata_fields, 'read' ) );
+		return new AgentMemoryReadResult( true, $content, $hash, $bytes, $updated, null, $metadata_fields );
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	public function write( AgentMemoryScope $scope, string $content, ?string $if_match = null, ?AgentMemoryMetadata $metadata = null ): AgentMemoryWriteResult {
+		unset( $metadata );
+
 		if ( ! self::is_available() ) {
 			return AgentMemoryWriteResult::failure( 'capability' );
 		}
@@ -145,6 +149,8 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 
 			update_post_meta( $existing->ID, self::META_HASH, $hash );
 			update_post_meta( $existing->ID, self::META_BYTES, $bytes );
+			update_post_meta( $existing->ID, self::META_WORKSPACE_TYPE, $scope->workspace_type );
+			update_post_meta( $existing->ID, self::META_WORKSPACE_ID, $scope->workspace_id );
 
 			$this->emit_guideline_updated_event( $existing->ID );
 
@@ -162,12 +168,14 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 				'comment_status' => 'closed',
 				'ping_status'    => 'closed',
 				'meta_input'     => array(
-					self::META_LAYER    => $scope->layer,
-					self::META_USER_ID  => $scope->user_id,
-					self::META_AGENT_ID => $scope->agent_id,
-					self::META_FILENAME => $scope->filename,
-					self::META_HASH     => $hash,
-					self::META_BYTES    => $bytes,
+					self::META_LAYER          => $scope->layer,
+					self::META_WORKSPACE_TYPE => $scope->workspace_type,
+					self::META_WORKSPACE_ID   => $scope->workspace_id,
+					self::META_USER_ID        => $scope->user_id,
+					self::META_AGENT_ID       => $scope->agent_id,
+					self::META_FILENAME       => $scope->filename,
+					self::META_HASH           => $hash,
+					self::META_BYTES          => $bytes,
 				),
 			),
 			true
@@ -222,6 +230,8 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 	 * @inheritDoc
 	 */
 	public function list_layer( AgentMemoryScope $scope_query, ?AgentMemoryQuery $query = null ): array {
+		unset( $query );
+
 		$posts   = $this->query_scope_posts( $scope_query, null );
 		$entries = array();
 
@@ -242,6 +252,8 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 	 * @inheritDoc
 	 */
 	public function list_subtree( AgentMemoryScope $scope_query, string $prefix, ?AgentMemoryQuery $query = null ): array {
+		unset( $query );
+
 		$prefix = trim( $prefix, '/' );
 		if ( '' === $prefix ) {
 			return array();
@@ -307,6 +319,16 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 			array(
 				'key'     => self::META_LAYER,
 				'value'   => $scope_query->layer,
+				'compare' => '=',
+			),
+			array(
+				'key'     => self::META_WORKSPACE_TYPE,
+				'value'   => $scope_query->workspace_type,
+				'compare' => '=',
+			),
+			array(
+				'key'     => self::META_WORKSPACE_ID,
+				'value'   => $scope_query->workspace_id,
 				'compare' => '=',
 			),
 			array(

--- a/inc/Engine/AI/Actions/PendingActionStoreAdapter.php
+++ b/inc/Engine/AI/Actions/PendingActionStoreAdapter.php
@@ -7,9 +7,9 @@
 
 namespace DataMachine\Engine\AI\Actions;
 
+use AgentsAPI\AI\Approvals\PendingActionStoreInterface;
 use AgentsAPI\AI\Approvals\ApprovalDecision;
 use AgentsAPI\AI\Approvals\PendingAction;
-use AgentsAPI\AI\Approvals\PendingActionStoreInterface;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -20,46 +20,33 @@ defined( 'ABSPATH' ) || exit;
 final class PendingActionStoreAdapter implements PendingActionStoreInterface {
 
 	/**
-	 * Persist a pending action payload.
-	 *
-	 * @param PendingAction $action Durable pending action record.
-	 * @return bool
+	 * Persist a pending action record.
 	 */
 	public function store( PendingAction $action ): bool {
-		$payload = $this->payload_from_action( $action );
+		$payload = self::payload_from_action( $action );
 		return PendingActionStore::store( $action->get_action_id(), $payload );
 	}
 
 	/**
-	 * Retrieve a pending action payload.
-	 *
-	 * Agents API's merged contract is intentionally minimal and describes only
-	 * the live pending lifecycle. Data Machine's richer inspect/list surfaces
-	 * expose resolved audit rows separately.
-	 *
-	 * @param string $action_id        Durable action identifier.
-	 * @param bool   $include_resolved Whether terminal audit rows may be returned.
-	 * @return PendingAction|null
+	 * Retrieve a pending action record.
 	 */
 	public function get( string $action_id, bool $include_resolved = false ): ?PendingAction {
 		$payload = PendingActionStore::get( $action_id, $include_resolved );
-		return is_array( $payload ) ? $this->action_from_payload( $payload ) : null;
+		return is_array( $payload ) ? self::action_from_payload( $payload ) : null;
 	}
 
 	/**
 	 * List durable pending action records.
 	 *
-	 * @param array<string,mixed> $filters Query filters.
 	 * @return array<int,PendingAction>
 	 */
 	public function list( array $filters = array() ): array {
-		return array_values( array_filter( array_map( array( $this, 'action_from_payload' ), PendingActionStore::list( $filters ) ) ) );
+		return array_values( array_filter( array_map( array( self::class, 'action_from_payload' ), PendingActionStore::list( $filters ) ) ) );
 	}
 
 	/**
 	 * Summarize durable pending action records.
 	 *
-	 * @param array<string,mixed> $filters Query filters.
 	 * @return array<string,mixed>
 	 */
 	public function summary( array $filters = array() ): array {
@@ -67,27 +54,20 @@ final class PendingActionStoreAdapter implements PendingActionStoreInterface {
 	}
 
 	/**
-	 * Record a terminal resolution while retaining audit data.
+	 * Record a terminal resolution while retaining the action for audit.
 	 *
-	 * @param string           $action_id Durable action identifier.
-	 * @param ApprovalDecision $decision  Accepted/rejected decision.
-	 * @param string           $resolver  Resolver identifier.
-	 * @param mixed|null       $result    Resolution result.
-	 * @param string|null      $error     Resolution error.
-	 * @param array<string,mixed> $metadata Resolution metadata.
-	 * @return bool
+	 * @param mixed|null $result Resolution result.
 	 */
 	public function record_resolution( string $action_id, ApprovalDecision $decision, string $resolver, $result = null, ?string $error = null, array $metadata = array() ): bool {
+		unset( $resolver, $metadata );
 		return PendingActionStore::record_resolution( $action_id, $decision->value(), $result, $error );
 	}
 
 	/**
 	 * Mark due pending actions as expired.
-	 *
-	 * @param string|null $before Timestamp boundary.
-	 * @return int
 	 */
 	public function expire( ?string $before = null ): int {
+		unset( $before );
 		return PendingActionStore::expire_due_actions();
 	}
 
@@ -102,48 +82,56 @@ final class PendingActionStoreAdapter implements PendingActionStoreInterface {
 	}
 
 	/**
-	 * Convert an Agents API record into Data Machine's durable payload shape.
+	 * Convert an Agents API action into Data Machine's persisted payload shape.
 	 *
-	 * @param PendingAction $action Durable pending action record.
 	 * @return array<string,mixed>
 	 */
-	private function payload_from_action( PendingAction $action ): array {
+	private static function payload_from_action( PendingAction $action ): array {
 		$data = $action->to_array();
-
-		$data['preview_data'] = $data['preview'];
-		$data['agent_id']     = is_numeric( $data['agent'] ?? null ) ? (int) $data['agent'] : 0;
-		$data['created_by']   = is_numeric( $data['creator'] ?? null ) ? (int) $data['creator'] : 0;
-		$data['context']      = is_array( $data['metadata'] ?? null ) ? $data['metadata'] : array();
-
-		return $data;
+		return array(
+			'kind'         => $data['kind'],
+			'summary'      => $data['summary'],
+			'preview_data' => $data['preview'],
+			'preview'      => $data['preview'],
+			'apply_input'  => $data['apply_input'],
+			'agent_id'     => isset( $data['agent'] ) && is_numeric( $data['agent'] ) ? (int) $data['agent'] : 0,
+			'created_by'   => isset( $data['creator'] ) && is_numeric( $data['creator'] ) ? (int) $data['creator'] : 0,
+			'context'      => array(
+				'workspace' => $data['workspace'] ?? null,
+				'metadata'  => $data['metadata'] ?? array(),
+			),
+			'created_at'   => $data['created_at'],
+			'expires_at'   => $data['expires_at'] ?? null,
+		);
 	}
 
 	/**
-	 * Convert Data Machine's payload shape into the Agents API value object.
+	 * Convert a Data Machine payload into an Agents API pending-action record.
 	 *
-	 * @param array<string,mixed> $payload Stored payload.
-	 * @return PendingAction|null
+	 * @param array<string,mixed> $payload Pending action payload.
 	 */
-	private function action_from_payload( array $payload ): ?PendingAction {
+	private static function action_from_payload( array $payload ): ?PendingAction {
 		try {
+			$context = is_array( $payload['context'] ?? null ) ? $payload['context'] : array();
 			return PendingAction::from_array(
 				array(
 					'action_id'           => (string) ( $payload['action_id'] ?? '' ),
 					'kind'                => (string) ( $payload['kind'] ?? '' ),
-					'summary'             => (string) ( $payload['summary'] ?? 'Pending action' ),
-					'preview'             => $payload['preview'] ?? $payload['preview_data'] ?? array(),
+					'summary'             => (string) ( $payload['summary'] ?? '' ),
+					'preview'             => $payload['preview'] ?? ( $payload['preview_data'] ?? array() ),
 					'apply_input'         => $payload['apply_input'] ?? array(),
-					'agent'               => isset( $payload['agent_id'] ) ? (string) (int) $payload['agent_id'] : null,
-					'creator'             => isset( $payload['created_by'] ) ? (string) (int) $payload['created_by'] : null,
+					'workspace'           => $context['workspace'] ?? null,
+					'agent'               => isset( $payload['agent_id'] ) && (int) $payload['agent_id'] > 0 ? (string) (int) $payload['agent_id'] : null,
+					'creator'             => isset( $payload['created_by'] ) && (int) $payload['created_by'] > 0 ? (string) (int) $payload['created_by'] : null,
 					'status'              => (string) ( $payload['status'] ?? PendingActionStore::STATUS_PENDING ),
-					'created_at'          => $this->iso_time( $payload['created_at'] ?? $payload['created_at_iso'] ?? null ),
-					'expires_at'          => $this->optional_iso_time( $payload['expires_at'] ?? $payload['expires_at_iso'] ?? null ),
-					'resolved_at'         => $this->optional_iso_time( $payload['resolved_at'] ?? null ),
-					'resolver'            => ! empty( $payload['resolved_by'] ) ? (string) (int) $payload['resolved_by'] : null,
+					'created_at'          => self::timestamp_to_iso( $payload['created_at'] ?? null ),
+					'expires_at'          => self::optional_timestamp_to_iso( $payload['expires_at'] ?? null ),
+					'resolved_at'         => self::optional_timestamp_to_iso( $payload['resolved_at'] ?? null ),
+					'resolver'            => isset( $payload['resolved_by'] ) && (int) $payload['resolved_by'] > 0 ? (string) (int) $payload['resolved_by'] : null,
 					'resolution_result'   => $payload['resolution_result'] ?? null,
 					'resolution_error'    => $payload['resolution_error'] ?? null,
 					'resolution_metadata' => array(),
-					'metadata'            => isset( $payload['context'] ) && is_array( $payload['context'] ) ? $payload['context'] : array(),
+					'metadata'            => is_array( $context['metadata'] ?? null ) ? $context['metadata'] : array(),
 				)
 			);
 		} catch ( \InvalidArgumentException $error ) {
@@ -152,27 +140,29 @@ final class PendingActionStoreAdapter implements PendingActionStoreInterface {
 	}
 
 	/**
-	 * Normalize a required timestamp to ISO-8601.
+	 * Convert timestamp-like values into the required ISO-ish string.
 	 *
-	 * @param mixed $value Timestamp value.
-	 * @return string
+	 * @param mixed $value Timestamp-like value.
 	 */
-	private function iso_time( $value ): string {
-		$timestamp = is_numeric( $value ) ? (int) $value : strtotime( (string) $value );
-		return gmdate( 'c', false === $timestamp || $timestamp <= 0 ? time() : $timestamp );
+	private static function timestamp_to_iso( $value ): string {
+		return self::optional_timestamp_to_iso( $value ) ?? gmdate( 'c' );
 	}
 
 	/**
-	 * Normalize an optional timestamp to ISO-8601.
+	 * Convert optional timestamp-like values into ISO-ish strings.
 	 *
-	 * @param mixed $value Timestamp value.
-	 * @return string|null
+	 * @param mixed $value Timestamp-like value.
 	 */
-	private function optional_iso_time( $value ): ?string {
-		if ( null === $value || '' === $value || 0 === $value || '0' === $value ) {
-			return null;
+	private static function optional_timestamp_to_iso( $value ): ?string {
+		if ( is_numeric( $value ) && (int) $value > 0 ) {
+			return gmdate( 'c', (int) $value );
 		}
 
-		return $this->iso_time( $value );
+		if ( is_string( $value ) && '' !== trim( $value ) ) {
+			$timestamp = strtotime( $value );
+			return false === $timestamp ? null : gmdate( 'c', $timestamp );
+		}
+
+		return null;
 	}
 }

--- a/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
+++ b/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
@@ -9,7 +9,6 @@ namespace DataMachine\Engine\AI;
 
 use AgentsAPI\AI\AgentConversationRequest;
 use AgentsAPI\AI\AgentConversationTranscriptPersisterInterface;
-use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 
 defined( 'ABSPATH' ) || exit;
@@ -64,7 +63,7 @@ class DataMachinePipelineTranscriptPersister implements AgentConversationTranscr
 			$store_metadata['request_metadata'] = $result['request_metadata'];
 		}
 
-		$session_id = $store->create_session( AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() ), $user_id, $agent_id, $store_metadata, 'pipeline' );
+		$session_id = $store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() ), $user_id, $agent_id, $store_metadata, 'pipeline' );
 
 		if ( '' === $session_id ) {
 			do_action(

--- a/tests/Unit/Abilities/ListAgentsAbilityTest.php
+++ b/tests/Unit/Abilities/ListAgentsAbilityTest.php
@@ -87,7 +87,7 @@ class ListAgentsAbilityTest extends WP_UnitTestCase {
 
 	public function test_default_scope_returns_granted_agents_for_non_admin(): void {
 		$agent_id = $this->repo->create_if_missing( 'shared', 'Shared', $this->owner_user );
-		$this->access_repo->grant_access( $agent_id, $this->granted_user, 'operator' );
+		$this->access_repo->grant_access( new \WP_Agent_Access_Grant( (string) $agent_id, $this->granted_user, 'operator' ) );
 
 		wp_set_current_user( $this->granted_user );
 		$result = AgentAbilities::listAgents( array() );
@@ -100,10 +100,10 @@ class ListAgentsAbilityTest extends WP_UnitTestCase {
 	public function test_default_scope_unions_owned_and_granted_without_dupes(): void {
 		$owned_id   = $this->repo->create_if_missing( 'owned', 'Owned', $this->granted_user );
 		$granted_id = $this->repo->create_if_missing( 'granted', 'Granted', $this->owner_user );
-		$this->access_repo->grant_access( $granted_id, $this->granted_user, 'viewer' );
+		$this->access_repo->grant_access( new \WP_Agent_Access_Grant( (string) $granted_id, $this->granted_user, 'viewer' ) );
 
 		// Also grant access on an agent the user owns — must not duplicate the row.
-		$this->access_repo->grant_access( $owned_id, $this->granted_user, 'viewer' );
+		$this->access_repo->grant_access( new \WP_Agent_Access_Grant( (string) $owned_id, $this->granted_user, 'viewer' ) );
 
 		wp_set_current_user( $this->granted_user );
 		$result = AgentAbilities::listAgents( array() );
@@ -214,7 +214,7 @@ class ListAgentsAbilityTest extends WP_UnitTestCase {
 
 	public function test_include_role_returns_granted_role(): void {
 		$agent_id = $this->repo->create_if_missing( 'shared', 'Shared', $this->owner_user );
-		$this->access_repo->grant_access( $agent_id, $this->granted_user, 'operator' );
+		$this->access_repo->grant_access( new \WP_Agent_Access_Grant( (string) $agent_id, $this->granted_user, 'operator' ) );
 
 		wp_set_current_user( $this->granted_user );
 		$result = AgentAbilities::listAgents( array( 'include_role' => true ) );
@@ -224,7 +224,7 @@ class ListAgentsAbilityTest extends WP_UnitTestCase {
 
 	public function test_include_role_reflects_target_user_not_caller(): void {
 		$agent_id = $this->repo->create_if_missing( 'shared', 'Shared', $this->owner_user );
-		$this->access_repo->grant_access( $agent_id, $this->granted_user, 'viewer' );
+		$this->access_repo->grant_access( new \WP_Agent_Access_Grant( (string) $agent_id, $this->granted_user, 'viewer' ) );
 
 		// Admin queries on behalf of granted_user — role must be 'viewer' (granted_user's role),
 		// not 'admin' (caller's role).

--- a/tests/Unit/Abilities/PermissionHelperTest.php
+++ b/tests/Unit/Abilities/PermissionHelperTest.php
@@ -21,6 +21,9 @@ class PermissionHelperTest extends WP_UnitTestCase {
 	 * Reset state after each test.
 	 */
 	public function tear_down(): void {
+		PermissionHelper::clear_agent_context();
+		wp_set_current_user( 0 );
+
 		// Ensure authenticated context is always reset.
 		// Use reflection since there's no public reset method.
 		$reflection = new \ReflectionClass( PermissionHelper::class );
@@ -180,5 +183,36 @@ class PermissionHelperTest extends WP_UnitTestCase {
 		// After all calls complete, context must be reset.
 		$this->assertFalse( PermissionHelper::is_authenticated_context() );
 		$this->assertFalse( PermissionHelper::can_manage() );
+	}
+
+	public function test_agent_token_context_uses_agents_api_capability_ceiling(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		PermissionHelper::set_agent_context(
+			123,
+			$user_id,
+			array( 'datamachine_chat' ),
+			456
+		);
+
+		$principal = PermissionHelper::get_execution_principal();
+
+		$this->assertInstanceOf( \AgentsAPI\AI\AgentExecutionPrincipal::class, $principal );
+		$this->assertSame( \AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_AGENT_TOKEN, $principal->auth_source );
+		$this->assertTrue( PermissionHelper::can( 'chat' ) );
+		$this->assertFalse( PermissionHelper::can( 'manage_agents' ) );
+	}
+
+	public function test_user_session_agent_context_uses_owner_ceiling_without_token_id(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		PermissionHelper::set_agent_context( 123, $user_id );
+
+		$principal = PermissionHelper::get_execution_principal();
+
+		$this->assertInstanceOf( \AgentsAPI\AI\AgentExecutionPrincipal::class, $principal );
+		$this->assertSame( \AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER, $principal->auth_source );
+		$this->assertNull( $principal->token_id );
+		$this->assertTrue( PermissionHelper::can( 'manage_agents' ) );
 	}
 }

--- a/tests/Unit/Abilities/SelfServiceAgentCreationTest.php
+++ b/tests/Unit/Abilities/SelfServiceAgentCreationTest.php
@@ -201,10 +201,10 @@ class SelfServiceAgentCreationTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['success'] );
 
 		$access_repo = new AgentAccess();
-		$grant       = $access_repo->get_access( (int) $result['agent_id'], $this->subscriber_id );
+		$grant       = $access_repo->get_access( (string) (int) $result['agent_id'], $this->subscriber_id );
 
 		$this->assertNotNull( $grant, 'Owner access row must exist after self-service creation' );
-		$this->assertSame( 'admin', (string) $grant['role'] );
+		$this->assertSame( 'admin', $grant->role );
 	}
 
 	// ---------------------------------------------------------------

--- a/tests/Unit/Abilities/SystemAbilitiesTest.php
+++ b/tests/Unit/Abilities/SystemAbilitiesTest.php
@@ -9,7 +9,6 @@
 
 namespace DataMachine\Tests\Unit\Abilities;
 
-use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
 use DataMachine\Abilities\SystemAbilities;
 use DataMachine\Core\Database\Chat\Chat as ChatDatabase;
 use DataMachine\Core\PluginSettings;
@@ -48,7 +47,7 @@ class SystemAbilitiesTest extends WP_UnitTestCase {
 	 */
 	private function create_test_session( array $messages, ?string $title = null ): string {
 		$session_id = $this->chat_db->create_session(
-			AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() ),
+			\AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ),
 			$this->test_user_id,
 			0,
 			array( 'status' => 'completed' ),

--- a/tests/Unit/Api/AgentsListEndpointTest.php
+++ b/tests/Unit/Api/AgentsListEndpointTest.php
@@ -101,7 +101,7 @@ class AgentsListEndpointTest extends WP_UnitTestCase {
 	 */
 	public function test_non_admin_granted_user_sees_agent_with_granted_role(): void {
 		$agent_id = $this->repo->create_if_missing( 'shared-agent', 'Shared Agent', $this->owner_user );
-		$this->access_repo->grant_access( $agent_id, $this->granted_user, 'operator' );
+		$this->access_repo->grant_access( new \WP_Agent_Access_Grant( (string) $agent_id, $this->granted_user, 'operator' ) );
 
 		wp_set_current_user( $this->granted_user );
 		$result = $this->call_handle_list();
@@ -117,7 +117,7 @@ class AgentsListEndpointTest extends WP_UnitTestCase {
 	public function test_non_admin_sees_union_of_owned_and_granted_agents(): void {
 		$owned_id   = $this->repo->create_if_missing( 'owned', 'Owned', $this->granted_user );
 		$granted_id = $this->repo->create_if_missing( 'granted', 'Granted', $this->owner_user );
-		$this->access_repo->grant_access( $granted_id, $this->granted_user, 'viewer' );
+		$this->access_repo->grant_access( new \WP_Agent_Access_Grant( (string) $granted_id, $this->granted_user, 'viewer' ) );
 
 		wp_set_current_user( $this->granted_user );
 		$result = $this->call_handle_list();
@@ -144,7 +144,7 @@ class AgentsListEndpointTest extends WP_UnitTestCase {
 	 */
 	public function test_owned_and_granted_dedupes_with_admin_role_wins(): void {
 		$agent_id = $this->repo->create_if_missing( 'mine', 'Mine', $this->owner_user );
-		$this->access_repo->grant_access( $agent_id, $this->owner_user, 'viewer' );
+		$this->access_repo->grant_access( new \WP_Agent_Access_Grant( (string) $agent_id, $this->owner_user, 'viewer' ) );
 
 		wp_set_current_user( $this->owner_user );
 		$result = $this->call_handle_list();

--- a/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
+++ b/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
@@ -14,8 +14,6 @@
 
 namespace DataMachine\Tests\Unit\Core\Database\Chat;
 
-use AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface;
-use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
 use DataMachine\Abilities\Chat\ListChatSessionsAbility;
 use DataMachine\Core\Database\Chat\Chat;
 use DataMachine\Core\Database\Chat\ConversationReadStateInterface;
@@ -24,6 +22,7 @@ use DataMachine\Core\Database\Chat\ConversationRetentionInterface;
 use DataMachine\Core\Database\Chat\ConversationSessionIndexInterface;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Chat\ConversationStoreInterface;
+use AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface;
 use WP_UnitTestCase;
 
 class ConversationStoreFactoryTest extends WP_UnitTestCase {
@@ -178,9 +177,8 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 	// -----------------------------------------------------------------
 
 	public function test_list_sessions_for_day_returns_rows_in_chronological_order(): void {
-		$store     = new InMemoryConversationStore();
-		$workspace = AgentWorkspaceScope::from_parts( 'site', '1' );
-		$user      = 42;
+		$store = new InMemoryConversationStore();
+		$user  = 42;
 
 		// Seed three sessions across two days with explicit created_at values
 		// by updating the in-memory rows directly via reflection — we don't
@@ -188,9 +186,9 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$today     = gmdate( 'Y-m-d' );
 		$yesterday = gmdate( 'Y-m-d', time() - DAY_IN_SECONDS );
 
-		$a = $store->create_session( $workspace, $user );
-		$b = $store->create_session( $workspace, $user );
-		$c = $store->create_session( $workspace, $user );
+		$a = $store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), $user );
+		$b = $store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), $user );
+		$c = $store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), $user );
 
 		$ref      = new \ReflectionClass( $store );
 		$sessions = $ref->getProperty( 'sessions' );
@@ -222,8 +220,7 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 	}
 
 	public function test_get_storage_metrics_returns_rows_shape(): void {
-		$store     = new InMemoryConversationStore();
-		$workspace = AgentWorkspaceScope::from_parts( 'site', '1' );
+		$store = new InMemoryConversationStore();
 
 		$metrics = $store->get_storage_metrics();
 
@@ -232,9 +229,9 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'size_mb', $metrics );
 		$this->assertSame( 0, $metrics['rows'] );
 
-		$store->create_session( $workspace, 1 );
-		$store->create_session( $workspace, 1 );
-		$store->create_session( $workspace, 2 );
+		$store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), 1 );
+		$store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), 1 );
+		$store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), 2 );
 
 		$metrics = $store->get_storage_metrics();
 		$this->assertSame( 3, $metrics['rows'] );
@@ -259,7 +256,7 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 	 */
 	private function persist_fixture_transcript( ConversationTranscriptStoreInterface $store ): array {
 		$session_id = $store->create_session(
-			AgentWorkspaceScope::from_parts( 'site', '1' ),
+			\AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ),
 			5,
 			7,
 			array(
@@ -309,7 +306,7 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		);
 		ConversationStoreFactory::reset();
 
-		$session_id = $store->create_session( AgentWorkspaceScope::from_parts( 'site', '1' ), 7, 0, array(), 'chat' );
+		$session_id = $store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), 7, 0, array(), 'chat' );
 		$ref        = new \ReflectionClass( $store );
 		$sessions   = $ref->getProperty( 'sessions' );
 		$sessions->setAccessible( true );
@@ -330,7 +327,7 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		wp_set_current_user( $user_id );
 
 		// Seed the in-memory store with a session under the target user.
-		$session_id = $memory_store->create_session( AgentWorkspaceScope::from_parts( 'site', '1' ), $user_id, 0, array(), 'chat' );
+		$session_id = $memory_store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), $user_id, 0, array(), 'chat' );
 		$memory_store->update_session(
 			$session_id,
 			array(

--- a/tests/agent-memory-events-smoke.php
+++ b/tests/agent-memory-events-smoke.php
@@ -236,11 +236,11 @@ class AgentMemoryEventsFakeStore implements AgentMemoryStoreInterface {
 		}
 
 		$content = $this->files[ $scope->key() ];
-		return new AgentMemoryReadResult( true, $content, sha1( $content ), strlen( $content ), 123 );
+		return new AgentMemoryReadResult( true, $content, sha1( $content ), strlen( $content ), 123, null, $metadata_fields );
 	}
 
-	public function write( AgentMemoryScope $scope, string $content, ?string $_if_match = null, ?AgentMemoryMetadata $_metadata = null ): AgentMemoryWriteResult {
-		unset( $_if_match, $_metadata );
+	public function write( AgentMemoryScope $scope, string $content, ?string $_if_match = null, ?AgentMemoryMetadata $metadata = null ): AgentMemoryWriteResult {
+		unset( $_if_match, $metadata );
 		if ( $this->fail_next_write ) {
 			$this->fail_next_write = false;
 			return AgentMemoryWriteResult::failure( 'io' );
@@ -264,13 +264,13 @@ class AgentMemoryEventsFakeStore implements AgentMemoryStoreInterface {
 		return AgentMemoryWriteResult::ok( '', 0 );
 	}
 
-	public function list_layer( AgentMemoryScope $_scope_query, ?AgentMemoryQuery $_query = null ): array {
-		unset( $_scope_query, $_query );
+	public function list_layer( AgentMemoryScope $_scope_query, ?AgentMemoryQuery $query = null ): array {
+		unset( $_scope_query, $query );
 		return array();
 	}
 
-	public function list_subtree( AgentMemoryScope $_scope_query, string $_prefix, ?AgentMemoryQuery $_query = null ): array {
-		unset( $_scope_query, $_prefix, $_query );
+	public function list_subtree( AgentMemoryScope $_scope_query, string $_prefix, ?AgentMemoryQuery $query = null ): array {
+		unset( $_scope_query, $_prefix, $query );
 		return array();
 	}
 }

--- a/tests/agent-memory-store-factory-contract-smoke.php
+++ b/tests/agent-memory-store-factory-contract-smoke.php
@@ -48,8 +48,8 @@ use AgentsAPI\Core\FilesRepository\AgentMemoryMetadata;
 use AgentsAPI\Core\FilesRepository\AgentMemoryQuery;
 use AgentsAPI\Core\FilesRepository\AgentMemoryReadResult;
 use AgentsAPI\Core\FilesRepository\AgentMemoryScope;
-use DataMachine\Core\FilesRepository\AgentMemoryStoreFactory;
 use AgentsAPI\Core\FilesRepository\AgentMemoryStoreCapabilities;
+use DataMachine\Core\FilesRepository\AgentMemoryStoreFactory;
 use AgentsAPI\Core\FilesRepository\AgentMemoryStoreInterface;
 use AgentsAPI\Core\FilesRepository\AgentMemoryWriteResult;
 use DataMachine\Core\FilesRepository\DiskAgentMemoryStore;
@@ -72,11 +72,11 @@ class AgentMemoryStoreContractFakeStore implements AgentMemoryStoreInterface {
 		}
 
 		$content = $this->files[ $scope->key() ];
-		return new AgentMemoryReadResult( true, $content, sha1( $content ), strlen( $content ), 123 );
+		return new AgentMemoryReadResult( true, $content, sha1( $content ), strlen( $content ), 123, null, $metadata_fields );
 	}
 
-	public function write( AgentMemoryScope $scope, string $content, ?string $_if_match = null, ?AgentMemoryMetadata $_metadata = null ): AgentMemoryWriteResult {
-		unset( $_if_match, $_metadata );
+	public function write( AgentMemoryScope $scope, string $content, ?string $_if_match = null, ?AgentMemoryMetadata $metadata = null ): AgentMemoryWriteResult {
+		unset( $_if_match, $metadata );
 		$this->scopes[] = $scope;
 		$this->files[ $scope->key() ] = $content;
 
@@ -96,13 +96,14 @@ class AgentMemoryStoreContractFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function list_layer( AgentMemoryScope $scope_query, ?AgentMemoryQuery $query = null ): array {
+		unset( $query );
+
 		$this->scopes[] = $scope_query;
 		$entries        = array();
 
 		foreach ( $this->files as $key => $content ) {
 			[ $layer, $workspace_type, $workspace_id, $user_id, $agent_id, $filename ] = explode( ':', $key, 6 );
-			unset( $workspace_type, $workspace_id );
-			if ( $layer !== $scope_query->layer || (int) $user_id !== $scope_query->user_id || (int) $agent_id !== $scope_query->agent_id ) {
+			if ( $layer !== $scope_query->layer || $workspace_type !== $scope_query->workspace_type || $workspace_id !== $scope_query->workspace_id || (int) $user_id !== $scope_query->user_id || (int) $agent_id !== $scope_query->agent_id ) {
 				continue;
 			}
 
@@ -118,7 +119,7 @@ class AgentMemoryStoreContractFakeStore implements AgentMemoryStoreInterface {
 
 	public function list_subtree( AgentMemoryScope $scope_query, string $prefix, ?AgentMemoryQuery $query = null ): array {
 		$this->scopes[] = $scope_query;
-		unset( $prefix );
+		unset( $prefix, $query );
 		return array();
 	}
 }

--- a/tests/agents-api-memory-store-smoke.php
+++ b/tests/agents-api-memory-store-smoke.php
@@ -104,10 +104,12 @@ class AgentsApiMemoryFakeStore implements AgentMemoryStoreInterface {
 		}
 
 		$content = $this->records[ $key ];
-		return new AgentMemoryReadResult( true, $content, sha1( $content ), strlen( $content ), 123 );
+		return new AgentMemoryReadResult( true, $content, sha1( $content ), strlen( $content ), 123, null, $metadata_fields );
 	}
 
 	public function write( AgentMemoryScope $scope, string $content, ?string $if_match = null, ?AgentMemoryMetadata $metadata = null ): AgentMemoryWriteResult {
+		unset( $metadata );
+
 		$current = $this->read( $scope );
 		if ( null !== $if_match && $current->hash !== $if_match ) {
 			return AgentMemoryWriteResult::failure( 'conflict' );
@@ -127,17 +129,20 @@ class AgentsApiMemoryFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function list_layer( AgentMemoryScope $scope_query, ?AgentMemoryQuery $query = null ): array {
+		unset( $query );
+
 		return $this->list_subtree( $scope_query, '' );
 	}
 
 	public function list_subtree( AgentMemoryScope $scope_query, string $prefix, ?AgentMemoryQuery $query = null ): array {
+		unset( $query );
+
 		$entries = array();
 		$prefix  = trim( $prefix, '/' );
 
 		foreach ( $this->records as $key => $content ) {
 			list( $layer, $workspace_type, $workspace_id, $user_id, $agent_id, $filename ) = explode( ':', $key, 6 );
-			unset( $workspace_type, $workspace_id );
-			if ( $layer !== $scope_query->layer || (int) $user_id !== $scope_query->user_id || (int) $agent_id !== $scope_query->agent_id ) {
+			if ( $layer !== $scope_query->layer || $workspace_type !== $scope_query->workspace_type || $workspace_id !== $scope_query->workspace_id || (int) $user_id !== $scope_query->user_id || (int) $agent_id !== $scope_query->agent_id ) {
 				continue;
 			}
 

--- a/tests/agents-api-transcript-store-smoke.php
+++ b/tests/agents-api-transcript-store-smoke.php
@@ -32,7 +32,6 @@ require_once __DIR__ . '/agents-api-loader.php';
 datamachine_tests_require_agents_api();
 
 use AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface;
-use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
 
 $failures = array();
 $passes   = 0;
@@ -55,27 +54,24 @@ class AgentsApiFakeTranscriptStore implements ConversationTranscriptStoreInterfa
 	 */
 	private array $sessions = array();
 
-	public function create_session( AgentWorkspaceScope $workspace, int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string {
+	public function create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope $workspace, int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string {
 		$session_id = 'session-' . ( count( $this->sessions ) + 1 );
-		$metadata   = array_merge( $metadata, $workspace->to_array() );
 
 		$this->sessions[ $session_id ] = array(
-			'session_id'     => $session_id,
-			'user_id'        => $user_id,
-			'agent_id'       => $agent_id,
-			'title'          => '',
-			'messages'       => array(),
-			'metadata'       => $metadata,
-			'provider'       => '',
-			'model'          => '',
-			'context'        => $context,
-			'mode'           => $context,
-			'workspace_type' => $workspace->workspace_type,
-			'workspace_id'   => $workspace->workspace_id,
-			'created_at'     => gmdate( 'Y-m-d H:i:s' ),
-			'updated_at'     => gmdate( 'Y-m-d H:i:s' ),
-			'last_read_at'   => null,
-			'expires_at'     => null,
+			'session_id'   => $session_id,
+			'user_id'      => $user_id,
+			'agent_id'     => $agent_id,
+			'title'        => '',
+			'messages'     => array(),
+			'metadata'     => $metadata,
+			'provider'     => '',
+			'model'        => '',
+			'context'      => $context,
+			'mode'         => $context,
+			'created_at'   => gmdate( 'Y-m-d H:i:s' ),
+			'updated_at'   => gmdate( 'Y-m-d H:i:s' ),
+			'last_read_at' => null,
+			'expires_at'   => null,
 		);
 
 		return $session_id;
@@ -104,11 +100,11 @@ class AgentsApiFakeTranscriptStore implements ConversationTranscriptStoreInterfa
 		return true;
 	}
 
-	public function get_recent_pending_session( AgentWorkspaceScope $workspace, int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
-		unset( $seconds, $token_id );
+	public function get_recent_pending_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope $workspace, int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
+		unset( $workspace, $seconds, $token_id );
 
 		foreach ( array_reverse( $this->sessions ) as $session ) {
-			if ( $workspace->workspace_type === $session['workspace_type'] && $workspace->workspace_id === $session['workspace_id'] && $user_id === $session['user_id'] && $context === $session['context'] && array() === $session['messages'] ) {
+			if ( $user_id === $session['user_id'] && $context === $session['context'] && array() === $session['messages'] ) {
 				return $session;
 			}
 		}
@@ -136,7 +132,7 @@ $assert_true( false === interface_exists( 'DataMachine\\Core\\Database\\Chat\\Co
 $store = new AgentsApiFakeTranscriptStore();
 $assert_true( in_array( ConversationTranscriptStoreInterface::class, class_implements( $store ), true ), 'fake store can implement transcript contract without chat product interfaces' );
 
-$workspace  = AgentWorkspaceScope::from_parts( 'site', '1' );
+$workspace  = \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' );
 $session_id = $store->create_session( $workspace, 7, 3, array( 'source' => 'smoke' ), 'pipeline' );
 $assert_true( 'session-1' === $session_id, 'fake store creates transcript session IDs' );
 $assert_true( null !== $store->get_recent_pending_session( $workspace, 7, 600, 'pipeline' ), 'fake store can query pending transcript sessions' );

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -119,7 +119,7 @@ class RequestMetadataSmokeStore implements ConversationStoreInterface {
 	public array $sessions = array();
 	public array $updated  = array();
 
-	public function create_session( int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string {
+	public function create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope $workspace, int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string {
 		$this->sessions['smoke-session'] = compact( 'user_id', 'agent_id', 'metadata', 'context' );
 		return 'smoke-session';
 	}
@@ -132,7 +132,7 @@ class RequestMetadataSmokeStore implements ConversationStoreInterface {
 	public function delete_session( string $session_id ): bool { return true; }
 	public function get_user_sessions( int $user_id, int $limit = 20, int $offset = 0, ?string $context = null, ?int $agent_id = null ): array { return array(); }
 	public function get_user_session_count( int $user_id, ?string $context = null, ?int $agent_id = null ): int { return 0; }
-	public function get_recent_pending_session( int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array { return null; }
+	public function get_recent_pending_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope $workspace, int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array { return null; }
 	public function update_title( string $session_id, string $title ): bool { return true; }
 	public function count_unread( array $messages, ?string $last_read_at ): int { return 0; }
 	public function mark_session_read( string $session_id, int $user_id ) { return gmdate( 'Y-m-d H:i:s' ); }

--- a/tests/guideline-agent-memory-store-smoke.php
+++ b/tests/guideline-agent-memory-store-smoke.php
@@ -106,6 +106,8 @@ datamachine_guideline_memory_assert(
 
 $expected_meta = array(
 	'_datamachine_memory_layer',
+	'_datamachine_memory_workspace_type',
+	'_datamachine_memory_workspace_id',
 	'_datamachine_memory_user_id',
 	'_datamachine_memory_agent_id',
 	'_datamachine_memory_filename',
@@ -116,7 +118,7 @@ $expected_meta = array(
 $reflection  = new ReflectionClass( GuidelineAgentMemoryStore::class );
 $actual_meta = array_values( array_intersect_key(
 	$reflection->getConstants(),
-	array_flip( array( 'META_LAYER', 'META_USER_ID', 'META_AGENT_ID', 'META_FILENAME', 'META_HASH', 'META_BYTES' ) )
+	array_flip( array( 'META_LAYER', 'META_WORKSPACE_TYPE', 'META_WORKSPACE_ID', 'META_USER_ID', 'META_AGENT_ID', 'META_FILENAME', 'META_HASH', 'META_BYTES' ) )
 ) );
 
 datamachine_guideline_memory_assert(

--- a/tests/pending-actions-agents-api-contract-smoke.php
+++ b/tests/pending-actions-agents-api-contract-smoke.php
@@ -170,26 +170,27 @@ require_once dirname( __DIR__ ) . '/inc/Engine/AI/Actions/PendingActionStore.php
 
 $store     = \DataMachine\Engine\AI\Actions\PendingActionStore::adapter();
 $action_id = \DataMachine\Engine\AI\Actions\PendingActionStore::generate_id();
-$payload   = array(
-	'action_id'    => $action_id,
-	'kind'         => 'contract_smoke',
-	'summary'      => 'Contract smoke',
-	'preview'      => array( 'ok' => true ),
-	'preview_data' => array( 'ok' => true ),
-	'apply_input'  => array( 'value' => 1 ),
-	'created_at'   => gmdate( 'c' ),
-	'expires_at'   => gmdate( 'c', time() + 3600 ),
-	'ttl'          => 10,
+$action    = \AgentsAPI\AI\Approvals\PendingAction::from_array(
+	array(
+		'action_id'   => $action_id,
+		'kind'        => 'contract_smoke',
+		'summary'     => 'Contract smoke',
+		'preview'     => array( 'ok' => true ),
+		'apply_input' => array( 'value' => 1 ),
+		'created_at'  => gmdate( 'c' ),
+		'metadata'    => array( 'ttl' => 10 ),
+	)
 );
 
 datamachine_pending_actions_assert( $store instanceof \AgentsAPI\AI\Approvals\PendingActionStoreInterface, 'PendingActionStore adapter is an Agents API store', $failures, $passes );
 datamachine_pending_actions_assert( str_starts_with( $action_id, 'act_' ), 'legacy generate_id returns namespaced action IDs', $failures, $passes );
-datamachine_pending_actions_assert( $store->store( \AgentsAPI\AI\Approvals\PendingAction::from_array( $payload ) ), 'contract store writes through transient fallback', $failures, $passes );
+datamachine_pending_actions_assert( $store->store( $action ), 'contract store writes through transient fallback', $failures, $passes );
 
 $stored = $store->get( $action_id );
 datamachine_pending_actions_assert( $stored instanceof \AgentsAPI\AI\Approvals\PendingAction && 'contract_smoke' === $stored->get_kind(), 'contract get reads the stored pending action', $failures, $passes );
 datamachine_pending_actions_assert( $stored instanceof \AgentsAPI\AI\Approvals\PendingAction && $action_id === $stored->get_action_id(), 'contract store preserves action ID in payload', $failures, $passes );
-datamachine_pending_actions_assert( $stored instanceof \AgentsAPI\AI\Approvals\PendingAction && null !== $stored->get_expires_at() && strtotime( $stored->get_expires_at() ) >= strtotime( $stored->get_created_at() ) + 3600, 'transient fallback preserves minimum TTL behavior', $failures, $passes );
+$stored_payload = \DataMachine\Engine\AI\Actions\PendingActionStore::get( $action_id );
+datamachine_pending_actions_assert( isset( $stored_payload['expires_at'], $stored_payload['created_at'] ) && $stored_payload['expires_at'] >= $stored_payload['created_at'] + 3600, 'transient fallback preserves minimum TTL behavior', $failures, $passes );
 datamachine_pending_actions_assert( $store->delete( $action_id ), 'contract delete removes transient fallback payload', $failures, $passes );
 datamachine_pending_actions_assert( null === $store->get( $action_id ), 'contract get returns null after delete', $failures, $passes );
 


### PR DESCRIPTION
## Summary
- Maps Data Machine agent access grants and bearer tokens onto the Agents API authorization value objects and store contracts.
- Routes bearer-token authentication through `WP_Agent_Token_Authenticator` while preserving owner capability ceilings and token allow-list restrictions.
- Converts contract objects back to Data Machine API/CLI response shapes at the product boundary and adds focused user-session/token ceiling coverage.

Fixes #1757.

## Testing
- `php tests/agents-api-bootstrap-smoke.php`
- `php tests/pending-actions-agents-api-contract-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-1757-agents-auth-contracts --force-hot` (1204 passed, 3 skipped)
- `vendor/bin/phpcs data-machine.php inc/Abilities/PermissionHelper.php inc/Core/Auth/AgentAuthMiddleware.php inc/Core/Database/Agents/AgentAccess.php inc/Core/Database/Agents/AgentTokens.php inc/Api/Agents.php inc/Cli/Commands/AgentsCommand.php inc/Abilities/AgentTokenAbilities.php inc/Core/Auth/AgentAuthorize.php inc/Abilities/AgentAbilities.php tests/Unit/Abilities/PermissionHelperTest.php tests/Unit/Api/AgentsListEndpointTest.php tests/Unit/Abilities/ListAgentsAbilityTest.php tests/Unit/Abilities/SelfServiceAgentCreationTest.php`

## Notes
- Full `homeboy lint --path /Users/chubes/Developer/data-machine@fix-1757-agents-auth-contracts --force-hot` still reports pre-existing frontend lint findings outside this change.
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-1757-agents-auth-contracts --changed-since origin/main --force-hot` reported no changed-file findings, and targeted PHPCS on changed PHP files passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Source audit, implementation drafting, focused test updates, dependency verification, and test/lint execution. Chris remains responsible for review and testing.