### PR TITLE
Harden guideline-backed memory capability checks

### DIFF
--- a/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
@@ -48,6 +48,13 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 	const META_HASH           = '_datamachine_memory_hash';
 	const META_BYTES          = '_datamachine_memory_bytes';
 
+	const GUIDELINE_META_SCOPE        = '_wp_guideline_scope';
+	const GUIDELINE_META_USER_ID      = '_wp_guideline_user_id';
+	const GUIDELINE_META_WORKSPACE_ID = '_wp_guideline_workspace_id';
+
+	const GUIDELINE_SCOPE_PRIVATE_MEMORY     = 'private_user_workspace_memory';
+	const GUIDELINE_SCOPE_WORKSPACE_GUIDANCE = 'workspace_shared_guidance';
+
 	/**
 	 * Whether the host has the Guidelines substrate this store needs.
 	 *
@@ -90,6 +97,10 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 			return AgentMemoryReadResult::not_found();
 		}
 
+		if ( ! $this->can_read_post( $post ) ) {
+			return AgentMemoryReadResult::not_found();
+		}
+
 		$content = (string) $post->post_content;
 		$hash    = (string) get_post_meta( $post->ID, self::META_HASH, true );
 		if ( '' === $hash ) {
@@ -128,9 +139,18 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 			}
 		}
 
-		$hash   = sha1( $content );
-		$bytes  = strlen( $content );
-		$author = $scope->user_id > 0 ? $scope->user_id : 0;
+		if ( $existing instanceof \WP_Post && ! $this->can_write_post( $existing ) ) {
+			return AgentMemoryWriteResult::failure( 'capability' );
+		}
+
+		if ( ! $existing instanceof \WP_Post && ! $this->can_create_scope( $scope ) ) {
+			return AgentMemoryWriteResult::failure( 'capability' );
+		}
+
+		$hash               = sha1( $content );
+		$bytes              = strlen( $content );
+		$author             = $scope->user_id > 0 ? $scope->user_id : 0;
+		$guideline_metadata = $this->guideline_metadata_for_scope( $scope );
 
 		if ( $existing instanceof \WP_Post ) {
 			$updated = wp_update_post(
@@ -151,11 +171,28 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 			update_post_meta( $existing->ID, self::META_BYTES, $bytes );
 			update_post_meta( $existing->ID, self::META_WORKSPACE_TYPE, $scope->workspace_type );
 			update_post_meta( $existing->ID, self::META_WORKSPACE_ID, $scope->workspace_id );
+			foreach ( $guideline_metadata as $meta_key => $meta_value ) {
+				update_post_meta( $existing->ID, $meta_key, $meta_value );
+			}
 
 			$this->emit_guideline_updated_event( $existing->ID );
 
 			return AgentMemoryWriteResult::ok( $hash, $bytes );
 		}
+
+		$meta_input = array_merge(
+			array(
+				self::META_LAYER          => $scope->layer,
+				self::META_WORKSPACE_TYPE => $scope->workspace_type,
+				self::META_WORKSPACE_ID   => $scope->workspace_id,
+				self::META_USER_ID        => $scope->user_id,
+				self::META_AGENT_ID       => $scope->agent_id,
+				self::META_FILENAME       => $scope->filename,
+				self::META_HASH           => $hash,
+				self::META_BYTES          => $bytes,
+			),
+			$guideline_metadata
+		);
 
 		$post_id = wp_insert_post(
 			array(
@@ -167,16 +204,7 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 				'post_author'    => $author,
 				'comment_status' => 'closed',
 				'ping_status'    => 'closed',
-				'meta_input'     => array(
-					self::META_LAYER          => $scope->layer,
-					self::META_WORKSPACE_TYPE => $scope->workspace_type,
-					self::META_WORKSPACE_ID   => $scope->workspace_id,
-					self::META_USER_ID        => $scope->user_id,
-					self::META_AGENT_ID       => $scope->agent_id,
-					self::META_FILENAME       => $scope->filename,
-					self::META_HASH           => $hash,
-					self::META_BYTES          => $bytes,
-				),
+				'meta_input'     => $meta_input,
 			),
 			true
 		);
@@ -206,7 +234,8 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 	 * @inheritDoc
 	 */
 	public function exists( AgentMemoryScope $scope ): bool {
-		return $this->find_post( $scope ) instanceof \WP_Post;
+		$post = $this->find_post( $scope );
+		return $post instanceof \WP_Post && $this->can_read_post( $post );
 	}
 
 	/**
@@ -216,6 +245,10 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 		$post = $this->find_post( $scope );
 		if ( ! $post instanceof \WP_Post ) {
 			return AgentMemoryWriteResult::ok( '', 0 );
+		}
+
+		if ( ! $this->can_write_post( $post ) ) {
+			return AgentMemoryWriteResult::failure( 'capability' );
 		}
 
 		$deleted = wp_delete_post( $post->ID, true );
@@ -236,6 +269,10 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 		$entries = array();
 
 		foreach ( $posts as $post ) {
+			if ( ! $this->can_read_post( $post ) ) {
+				continue;
+			}
+
 			$filename = (string) get_post_meta( $post->ID, self::META_FILENAME, true );
 			if ( '' === $filename || false !== strpos( $filename, '/' ) ) {
 				continue;
@@ -263,6 +300,10 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 		$entries = array();
 
 		foreach ( $posts as $post ) {
+			if ( ! $this->can_read_post( $post ) ) {
+				continue;
+			}
+
 			$filename = (string) get_post_meta( $post->ID, self::META_FILENAME, true );
 			if ( 0 !== strpos( $filename, $prefix . '/' ) ) {
 				continue;
@@ -395,5 +436,112 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 		$updated = false === $updated ? null : (int) $updated;
 
 		return new AgentMemoryListEntry( $filename, $layer, $bytes, $updated );
+	}
+
+	/**
+	 * Build the shared wp_guideline metadata required by Agents API.
+	 *
+	 * @param AgentMemoryScope $scope Memory scope.
+	 * @return array<string, string|int>
+	 */
+	private function guideline_metadata_for_scope( AgentMemoryScope $scope ): array {
+		return array(
+			self::GUIDELINE_META_SCOPE        => $this->guideline_scope_for_layer( $scope->layer ),
+			self::GUIDELINE_META_USER_ID      => $scope->user_id,
+			self::GUIDELINE_META_WORKSPACE_ID => $scope->workspace_id,
+		);
+	}
+
+	/**
+	 * Map Data Machine memory layers to Agents API guideline scopes.
+	 *
+	 * @param string $layer Memory layer.
+	 * @return string Guideline scope value.
+	 */
+	private function guideline_scope_for_layer( string $layer ): string {
+		if ( 'shared' === $layer || 'network' === $layer ) {
+			return self::GUIDELINE_SCOPE_WORKSPACE_GUIDANCE;
+		}
+
+		return self::GUIDELINE_SCOPE_PRIVATE_MEMORY;
+	}
+
+	/**
+	 * Check whether the current context may read a guideline-backed memory post.
+	 *
+	 * @param \WP_Post $post Memory post.
+	 * @return bool Whether read is allowed.
+	 */
+	private function can_read_post( \WP_Post $post ): bool {
+		if ( $this->should_bypass_capability_checks() ) {
+			return true;
+		}
+
+		return $this->is_private_memory_post( $post )
+			? current_user_can( 'read_private_agent_memory', $post->ID )
+			: current_user_can( 'read_workspace_guidelines', $post->ID );
+	}
+
+	/**
+	 * Check whether the current context may edit/delete a guideline-backed memory post.
+	 *
+	 * @param \WP_Post $post Memory post.
+	 * @return bool Whether write is allowed.
+	 */
+	private function can_write_post( \WP_Post $post ): bool {
+		if ( $this->should_bypass_capability_checks() ) {
+			return true;
+		}
+
+		return $this->is_private_memory_post( $post )
+			? current_user_can( 'edit_private_agent_memory', $post->ID )
+			: current_user_can( 'edit_workspace_guidelines', $post->ID );
+	}
+
+	/**
+	 * Check whether the current context may create memory for a scope.
+	 *
+	 * @param AgentMemoryScope $scope Target scope.
+	 * @return bool Whether create is allowed.
+	 */
+	private function can_create_scope( AgentMemoryScope $scope ): bool {
+		if ( $this->should_bypass_capability_checks() ) {
+			return true;
+		}
+
+		if ( self::GUIDELINE_SCOPE_PRIVATE_MEMORY === $this->guideline_scope_for_layer( $scope->layer ) ) {
+			return $this->current_user_owns_scope( $scope ) && current_user_can( 'edit_agent_memory' );
+		}
+
+		return current_user_can( 'edit_workspace_guidelines' );
+	}
+
+	/**
+	 * Whether capability checks should be bypassed for privileged non-interactive execution.
+	 *
+	 * @return bool Whether to bypass.
+	 */
+	private function should_bypass_capability_checks(): bool {
+		return ( defined( 'WP_CLI' ) && WP_CLI ) || ! function_exists( 'current_user_can' );
+	}
+
+	/**
+	 * Check if a memory post is private user-workspace memory.
+	 *
+	 * @param \WP_Post $post Memory post.
+	 * @return bool Whether post is private memory.
+	 */
+	private function is_private_memory_post( \WP_Post $post ): bool {
+		return self::GUIDELINE_SCOPE_PRIVATE_MEMORY === get_post_meta( $post->ID, self::GUIDELINE_META_SCOPE, true );
+	}
+
+	/**
+	 * Check if the current user owns a private memory scope.
+	 *
+	 * @param AgentMemoryScope $scope Memory scope.
+	 * @return bool Whether the current user owns the scope.
+	 */
+	private function current_user_owns_scope( AgentMemoryScope $scope ): bool {
+		return function_exists( 'get_current_user_id' ) && $scope->user_id > 0 && get_current_user_id() === $scope->user_id;
 	}
 }

--- a/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
@@ -478,7 +478,9 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 		}
 
 		return $this->is_private_memory_post( $post )
+			// phpcs:ignore WordPress.WP.Capabilities.Unknown -- Agents API registers this guideline capability.
 			? current_user_can( 'read_private_agent_memory', $post->ID )
+			// phpcs:ignore WordPress.WP.Capabilities.Unknown -- Agents API registers this guideline capability.
 			: current_user_can( 'read_workspace_guidelines', $post->ID );
 	}
 
@@ -494,7 +496,9 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 		}
 
 		return $this->is_private_memory_post( $post )
+			// phpcs:ignore WordPress.WP.Capabilities.Unknown -- Agents API registers this guideline capability.
 			? current_user_can( 'edit_private_agent_memory', $post->ID )
+			// phpcs:ignore WordPress.WP.Capabilities.Unknown -- Agents API registers this guideline capability.
 			: current_user_can( 'edit_workspace_guidelines', $post->ID );
 	}
 
@@ -510,9 +514,11 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 		}
 
 		if ( self::GUIDELINE_SCOPE_PRIVATE_MEMORY === $this->guideline_scope_for_layer( $scope->layer ) ) {
+			// phpcs:ignore WordPress.WP.Capabilities.Unknown -- Agents API registers this guideline capability.
 			return $this->current_user_owns_scope( $scope ) && current_user_can( 'edit_agent_memory' );
 		}
 
+		// phpcs:ignore WordPress.WP.Capabilities.Unknown -- Agents API registers this guideline capability.
 		return current_user_can( 'edit_workspace_guidelines' );
 	}
 

--- a/tests/guideline-agent-memory-store-smoke.php
+++ b/tests/guideline-agent-memory-store-smoke.php
@@ -13,6 +13,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $GLOBALS['datamachine_guideline_post_types'] = array();
 $GLOBALS['datamachine_guideline_taxonomies'] = array();
+$GLOBALS['datamachine_guideline_posts']      = array();
+$GLOBALS['datamachine_guideline_post_meta']  = array();
+$GLOBALS['datamachine_guideline_user_id']    = 0;
+$GLOBALS['datamachine_guideline_user_caps']  = array();
+
+if ( ! class_exists( 'WP_Post' ) ) {
+	class WP_Post {
+
+		public int $ID;
+		public string $post_type         = 'wp_guideline';
+		public string $post_content      = '';
+		public string $post_modified_gmt = '2026-05-04 00:00:00';
+		public string $post_name         = '';
+
+		public function __construct( array $args ) {
+			foreach ( $args as $key => $value ) {
+				$this->{$key} = $value;
+			}
+		}
+	}
+}
 
 if ( ! function_exists( 'post_type_exists' ) ) {
 	function post_type_exists( string $post_type ): bool {
@@ -23,6 +44,76 @@ if ( ! function_exists( 'post_type_exists' ) ) {
 if ( ! function_exists( 'taxonomy_exists' ) ) {
 	function taxonomy_exists( string $taxonomy ): bool {
 		return in_array( $taxonomy, $GLOBALS['datamachine_guideline_taxonomies'], true );
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return (int) $GLOBALS['datamachine_guideline_user_id'];
+	}
+}
+
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $capability, ...$args ): bool {
+		$user_id = get_current_user_id();
+		$caps    = $GLOBALS['datamachine_guideline_user_caps'][ $user_id ] ?? array();
+		$post_id = isset( $args[0] ) ? (int) $args[0] : 0;
+
+		if ( in_array( 'do_not_allow', $caps, true ) ) {
+			return false;
+		}
+
+		if ( 'read_private_agent_memory' === $capability || 'edit_private_agent_memory' === $capability ) {
+			$owner_id = (int) ( $GLOBALS['datamachine_guideline_post_meta'][ $post_id ][ \DataMachine\Core\FilesRepository\GuidelineAgentMemoryStore::GUIDELINE_META_USER_ID ] ?? 0 );
+			if ( $owner_id !== $user_id ) {
+				return false;
+			}
+
+			$primitive = 'read_private_agent_memory' === $capability ? 'read' : 'edit_posts';
+			return in_array( $primitive, $caps, true );
+		}
+
+		if ( 'edit_agent_memory' === $capability || 'read_workspace_guidelines' === $capability ) {
+			return in_array( 'edit_posts', $caps, true );
+		}
+
+		if ( 'edit_workspace_guidelines' === $capability ) {
+			return in_array( 'publish_posts', $caps, true );
+		}
+
+		return in_array( $capability, $caps, true );
+	}
+}
+
+if ( ! function_exists( 'get_posts' ) ) {
+	function get_posts( array $args ): array {
+		$name = $args['name'] ?? '';
+		foreach ( $GLOBALS['datamachine_guideline_posts'] as $post ) {
+			if ( $post instanceof WP_Post && $post->post_name === $name ) {
+				return array( $post );
+			}
+		}
+
+		return array();
+	}
+}
+
+if ( ! class_exists( 'WP_Query' ) ) {
+	class WP_Query {
+
+		public array $posts = array();
+
+		public function __construct( array $_args ) {
+			unset( $_args );
+			$this->posts = array_values( $GLOBALS['datamachine_guideline_posts'] );
+		}
+	}
+}
+
+if ( ! function_exists( 'get_post_meta' ) ) {
+	function get_post_meta( int $post_id, string $key, bool $_single = false ) {
+		unset( $_single );
+		return $GLOBALS['datamachine_guideline_post_meta'][ $post_id ][ $key ] ?? '';
 	}
 }
 
@@ -132,5 +223,105 @@ foreach ( $actual_meta as $meta_key ) {
 		"Meta key {$meta_key} is not Intelligence-branded"
 	);
 }
+
+echo "\nTest: guideline metadata maps Data Machine layers to Agents API scopes\n";
+
+$guideline_constants = array(
+	GuidelineAgentMemoryStore::GUIDELINE_META_SCOPE        => GuidelineAgentMemoryStore::GUIDELINE_SCOPE_PRIVATE_MEMORY,
+	GuidelineAgentMemoryStore::GUIDELINE_META_USER_ID      => 7,
+	GuidelineAgentMemoryStore::GUIDELINE_META_WORKSPACE_ID => '1',
+);
+
+datamachine_guideline_memory_assert(
+	'_wp_guideline_scope' === GuidelineAgentMemoryStore::GUIDELINE_META_SCOPE,
+	'Guideline store stamps Agents API scope metadata key'
+);
+datamachine_guideline_memory_assert(
+	'private_user_workspace_memory' === GuidelineAgentMemoryStore::GUIDELINE_SCOPE_PRIVATE_MEMORY,
+	'Guideline store uses Agents API private memory scope value'
+);
+datamachine_guideline_memory_assert(
+	'workspace_shared_guidance' === GuidelineAgentMemoryStore::GUIDELINE_SCOPE_WORKSPACE_GUIDANCE,
+	'Guideline store uses Agents API workspace guidance scope value'
+);
+
+echo "\nTest: private memory requires explicit owner capability metadata\n";
+
+$store         = new GuidelineAgentMemoryStore();
+$private_scope = new AgentMemoryScope( 'user', 7, 42, 'USER.md' );
+$post_id       = 200;
+
+$GLOBALS['datamachine_guideline_posts'][ $post_id ] = new WP_Post(
+	array(
+		'ID'           => $post_id,
+		'post_name'    => GuidelineAgentMemoryStore::post_name_for_scope( $private_scope ),
+		'post_content' => 'Private profile',
+	)
+);
+$GLOBALS['datamachine_guideline_post_meta'][ $post_id ] = array_merge(
+	array(
+		GuidelineAgentMemoryStore::META_LAYER    => 'user',
+		GuidelineAgentMemoryStore::META_USER_ID  => 7,
+		GuidelineAgentMemoryStore::META_AGENT_ID => 42,
+		GuidelineAgentMemoryStore::META_FILENAME => 'USER.md',
+		GuidelineAgentMemoryStore::META_HASH     => sha1( 'Private profile' ),
+		GuidelineAgentMemoryStore::META_BYTES    => strlen( 'Private profile' ),
+	),
+	$guideline_constants
+);
+
+$GLOBALS['datamachine_guideline_user_id']      = 8;
+$GLOBALS['datamachine_guideline_user_caps'][8] = array( 'read', 'edit_posts', 'publish_posts', 'read_private_posts' );
+$GLOBALS['datamachine_guideline_user_caps'][7] = array( 'read', 'edit_posts' );
+$non_owner_private_memory_read                 = $store->read( $private_scope );
+
+datamachine_guideline_memory_assert(
+	false === $non_owner_private_memory_read->exists,
+	'Non-owner cannot read private memory even with read_private_posts/editor/admin-style caps'
+);
+datamachine_guideline_memory_assert(
+	false === $store->exists( $private_scope ),
+	'Private memory existence is not revealed to non-owner readers'
+);
+
+$GLOBALS['datamachine_guideline_user_id'] = 7;
+$owner_private_memory_read                = $store->read( $private_scope );
+
+datamachine_guideline_memory_assert(
+	true === $owner_private_memory_read->exists && 'Private profile' === $owner_private_memory_read->content,
+	'Owner can read private memory through explicit owner metadata'
+);
+
+echo "\nTest: workspace-shared guidance uses workspace guideline capabilities\n";
+
+$shared_scope = new AgentMemoryScope( 'shared', 7, 42, 'RULES.md' );
+$post_id      = 201;
+
+$GLOBALS['datamachine_guideline_posts'][ $post_id ] = new WP_Post(
+	array(
+		'ID'           => $post_id,
+		'post_name'    => GuidelineAgentMemoryStore::post_name_for_scope( $shared_scope ),
+		'post_content' => 'Shared rules',
+	)
+);
+$GLOBALS['datamachine_guideline_post_meta'][ $post_id ] = array(
+	GuidelineAgentMemoryStore::META_LAYER                 => 'shared',
+	GuidelineAgentMemoryStore::META_USER_ID               => 7,
+	GuidelineAgentMemoryStore::META_AGENT_ID              => 42,
+	GuidelineAgentMemoryStore::META_FILENAME              => 'RULES.md',
+	GuidelineAgentMemoryStore::META_HASH                  => sha1( 'Shared rules' ),
+	GuidelineAgentMemoryStore::META_BYTES                 => strlen( 'Shared rules' ),
+	GuidelineAgentMemoryStore::GUIDELINE_META_SCOPE        => GuidelineAgentMemoryStore::GUIDELINE_SCOPE_WORKSPACE_GUIDANCE,
+	GuidelineAgentMemoryStore::GUIDELINE_META_USER_ID      => 7,
+	GuidelineAgentMemoryStore::GUIDELINE_META_WORKSPACE_ID => '1',
+);
+
+$GLOBALS['datamachine_guideline_user_id'] = 8;
+$shared_guidance_read                     = $store->read( $shared_scope );
+
+datamachine_guideline_memory_assert(
+	true === $shared_guidance_read->exists && 'Shared rules' === $shared_guidance_read->content,
+	'Workspace-shared guidance reads use read_workspace_guidelines/editor threshold'
+);
 
 echo "\nAll smoke tests passed.\n";

--- a/tests/guideline-agent-memory-store-smoke.php
+++ b/tests/guideline-agent-memory-store-smoke.php
@@ -248,7 +248,7 @@ datamachine_guideline_memory_assert(
 echo "\nTest: private memory requires explicit owner capability metadata\n";
 
 $store         = new GuidelineAgentMemoryStore();
-$private_scope = new AgentMemoryScope( 'user', 7, 42, 'USER.md' );
+$private_scope = new AgentMemoryScope( 'user', 'site', '1', 7, 42, 'USER.md' );
 $post_id       = 200;
 
 $GLOBALS['datamachine_guideline_posts'][ $post_id ] = new WP_Post(
@@ -294,7 +294,7 @@ datamachine_guideline_memory_assert(
 
 echo "\nTest: workspace-shared guidance uses workspace guideline capabilities\n";
 
-$shared_scope = new AgentMemoryScope( 'shared', 7, 42, 'RULES.md' );
+$shared_scope = new AgentMemoryScope( 'shared', 'site', '1', 7, 42, 'RULES.md' );
 $post_id      = 201;
 
 $GLOBALS['datamachine_guideline_posts'][ $post_id ] = new WP_Post(


### PR DESCRIPTION
## Summary
- Stamps guideline-backed memory with the Agents API private-memory/workspace-guidance metadata model.
- Enforces guideline-backed private memory reads/writes/deletes through explicit owner-aware memory capabilities instead of private post semantics.
- Extends the guideline memory smoke test to prove a non-owner with `read_private_posts` cannot read or detect another user's private memory.

Fixes #1763

## Tests
- `php tests/guideline-agent-memory-store-smoke.php`
- `php tests/agent-memory-events-smoke.php`
- `vendor/bin/phpcs inc/Core/FilesRepository/GuidelineAgentMemoryStore.php tests/guideline-agent-memory-store-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@issue-1763-guideline-memory-capabilities --skip-lint`
- `homeboy lint --path /Users/chubes/Developer/data-machine@issue-1763-guideline-memory-capabilities` fails on existing frontend lint backlog unrelated to this PHP-only change (602 findings).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the guideline-backed memory capability alignment, smoke test coverage, and local verification. Chris remains responsible for review and submission.