### PR TITLE
Consume Agents API workspace scope

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -491,8 +491,10 @@ add_action(
 			return;
 		}
 		\DataMachine\Core\Database\Chat\Chat::ensure_mode_column();
+		\DataMachine\Core\Database\Chat\Chat::ensure_workspace_columns();
 		\DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();
 		\DataMachine\Core\Database\Chat\Chat::ensure_last_read_at_column();
+		\DataMachine\Engine\AI\Actions\PendingActionStore::ensure_workspace_columns();
 	},
 	6
 );
@@ -672,6 +674,7 @@ function datamachine_activate_for_site() {
 
 	\DataMachine\Core\Database\Chat\Chat::create_table();
 	\DataMachine\Core\Database\Chat\Chat::ensure_mode_column();
+	\DataMachine\Core\Database\Chat\Chat::ensure_workspace_columns();
 	\DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();
 	\DataMachine\Core\Database\Chat\Chat::ensure_last_read_at_column();
 

--- a/inc/Abilities/Chat/CreateChatSessionAbility.php
+++ b/inc/Abilities/Chat/CreateChatSessionAbility.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Abilities\Chat;
 
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
+
 defined( 'ABSPATH' ) || exit;
 
 class CreateChatSessionAbility {
@@ -123,7 +125,7 @@ class CreateChatSessionAbility {
 			$session_metadata = array_merge( $session_metadata, $input['metadata'] );
 		}
 
-		$session_id = $this->chat_db->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() ), $user_id, $agent_id, $session_metadata, $mode );
+		$session_id = $this->chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_id, $session_metadata, $mode );
 
 		if ( empty( $session_id ) ) {
 			return array(

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -18,6 +18,7 @@ namespace DataMachine\Api\Chat;
 
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 use DataMachine\Engine\AI\ConversationManager;
 use DataMachine\Engine\AI\DataMachineAgentConsentPolicy;
 use DataMachine\Engine\AI\Tools\ToolManager;
@@ -102,7 +103,7 @@ class ChatOrchestrator {
 			$session_metadata = $session['metadata'] ?? array();
 		} else {
 			// Check for recent pending session to prevent duplicates from timeout retries.
-			$pending_session = $chat_db->get_recent_pending_session( self::workspace_scope(), $user_id, 600, 'chat', $acting_token_id );
+			$pending_session = $chat_db->get_recent_pending_session( WordPressWorkspaceScope::current(), $user_id, 600, 'chat', $acting_token_id );
 
 			if ( $pending_session ) {
 				$session_id       = $pending_session['session_id'];
@@ -609,7 +610,7 @@ class ChatOrchestrator {
 			$metadata['source'] = $source;
 		}
 
-		$session_id = $chat_db->create_session( self::workspace_scope(), $user_id, $agent_id, $metadata, 'chat' );
+		$session_id = $chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_id, $metadata, 'chat' );
 
 		if ( empty( $session_id ) ) {
 			return new WP_Error(
@@ -774,10 +775,4 @@ class ChatOrchestrator {
 		}
 	}
 
-	/**
-	 * Resolve the current site workspace for transcript storage.
-	 */
-	private static function workspace_scope(): \AgentsAPI\Core\Workspace\AgentWorkspaceScope {
-		return ConversationStoreFactory::default_workspace();
-	}
 }

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -774,5 +774,4 @@ class ChatOrchestrator {
 			);
 		}
 	}
-
 }

--- a/inc/Cli/Commands/ChatCommand.php
+++ b/inc/Cli/Commands/ChatCommand.php
@@ -13,6 +13,7 @@ namespace DataMachine\Cli\Commands;
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -286,7 +287,7 @@ class ChatCommand extends BaseCommand {
 		);
 
 		$chat_db    = ConversationStoreFactory::get();
-		$session_id = $chat_db->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() ), $user_id, $agent_id, $metadata, $context );
+		$session_id = $chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_id, $metadata, $context );
 
 		if ( empty( $session_id ) ) {
 			WP_CLI::error( 'Failed to create chat session.' );

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -15,6 +15,7 @@ use DataMachine\Core\Admin\DateFormatter;
 use DataMachine\Core\Database\BaseRepository;
 use AgentsAPI\AI\AgentMessageEnvelope;
 use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -50,6 +51,8 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 
 		$sql = "CREATE TABLE {$table_name} (
 			session_id VARCHAR(50) NOT NULL,
+			workspace_type VARCHAR(50) NOT NULL,
+			workspace_id VARCHAR(191) NOT NULL,
 			user_id BIGINT(20) UNSIGNED NOT NULL,
 			agent_id BIGINT(20) UNSIGNED NULL,
 			title VARCHAR(100) NULL,
@@ -63,6 +66,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			last_read_at DATETIME NULL,
 			expires_at DATETIME NULL,
 			PRIMARY KEY  (session_id),
+			KEY workspace (workspace_type, workspace_id),
 			KEY user_id (user_id),
 			KEY agent_id (agent_id),
 			KEY mode (mode),
@@ -74,6 +78,43 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $sql );
+	}
+
+	/**
+	 * Ensure workspace columns exist for Agents API-scoped transcript rows.
+	 *
+	 * Existing rows are stamped with the current site scope because the prefixed
+	 * WordPress table was already site-local before this generic boundary existed.
+	 *
+	 * @return void
+	 */
+	public static function ensure_workspace_columns(): void {
+		global $wpdb;
+
+		$table_name = self::get_prefixed_table_name();
+		$workspace  = WordPressWorkspaceScope::current();
+
+		if ( ! self::column_exists( $table_name, 'workspace_type', $wpdb ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN workspace_type VARCHAR(50) NULL', $table_name ) );
+		}
+
+		if ( ! self::column_exists( $table_name, 'workspace_id', $wpdb ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN workspace_id VARCHAR(191) NULL', $table_name ) );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET workspace_type = %s, workspace_id = %s WHERE workspace_type IS NULL OR workspace_type = %s OR workspace_id IS NULL OR workspace_id = %s',
+				$table_name,
+				$workspace->workspace_type,
+				$workspace->workspace_id,
+				'',
+				''
+			)
+		);
 	}
 
 	/**
@@ -249,17 +290,19 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		$result = $wpdb->insert(
 			$table_name,
 			array(
-				'session_id' => $session_id,
-				'user_id'    => $user_id,
-				'agent_id'   => $agent_id > 0 ? $agent_id : null,
-				'messages'   => wp_json_encode( array() ),
-				'metadata'   => wp_json_encode( $metadata ),
-				'provider'   => null,
-				'model'      => null,
-				'mode'       => $context,
-				'expires_at' => null,
+				'session_id'     => $session_id,
+				'workspace_type' => $workspace->workspace_type,
+				'workspace_id'   => $workspace->workspace_id,
+				'user_id'        => $user_id,
+				'agent_id'       => $agent_id > 0 ? $agent_id : null,
+				'messages'       => wp_json_encode( array() ),
+				'metadata'       => wp_json_encode( $metadata ),
+				'provider'       => null,
+				'model'          => null,
+				'mode'           => $context,
+				'expires_at'     => null,
 			),
-			array( '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' )
+			array( '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' )
 		);
 
 		if ( false === $result ) {
@@ -707,7 +750,9 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		$cutoff_time = gmdate( 'Y-m-d H:i:s', time() - $seconds );
 
 		$query  = "SELECT * FROM %i
-				WHERE user_id = %d
+				WHERE workspace_type = %s
+				AND workspace_id = %s
+				AND user_id = %d
 				AND mode = %s
 				AND created_at >= %s
 				AND (
@@ -716,6 +761,8 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				)";
 		$params = array(
 			$table_name,
+			$workspace->workspace_type,
+			$workspace->workspace_id,
 			$user_id,
 			$context,
 			$cutoff_time,

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -267,14 +267,10 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * @param string              $context   Execution context (chat, pipeline, system).
 	 * @return string Session ID (UUID)
 	 */
-	public function create_session(
-		AgentWorkspaceScope $workspace,
-		int $user_id,
-		int $agent_id = 0,
-		array $metadata = array(),
-		string $context = 'chat'
-	): string {
+	public function create_session( ...$args ): string {
 		global $wpdb;
+
+		list( $workspace, $user_id, $agent_id, $metadata, $context ) = self::normalize_create_session_args( $args );
 
 		$session_id = wp_generate_uuid4();
 		$table_name = self::get_prefixed_table_name();
@@ -332,6 +328,58 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		);
 
 		return $session_id;
+	}
+
+	/**
+	 * Normalize create-session arguments across current and workspace-aware contracts.
+	 *
+	 * @param array $args Raw method arguments.
+	 * @return array{0:AgentWorkspaceScope,1:int,2:int,3:array,4:string}
+	 */
+	private static function normalize_create_session_args( array $args ): array {
+		if ( isset( $args[0] ) && $args[0] instanceof AgentWorkspaceScope ) {
+			return array(
+				$args[0],
+				(int) ( $args[1] ?? 0 ),
+				(int) ( $args[2] ?? 0 ),
+				is_array( $args[3] ?? null ) ? $args[3] : array(),
+				(string) ( $args[4] ?? 'chat' ),
+			);
+		}
+
+		return array(
+			WordPressWorkspaceScope::current(),
+			(int) ( $args[0] ?? 0 ),
+			(int) ( $args[1] ?? 0 ),
+			is_array( $args[2] ?? null ) ? $args[2] : array(),
+			(string) ( $args[3] ?? 'chat' ),
+		);
+	}
+
+	/**
+	 * Normalize pending-session arguments across current and workspace-aware contracts.
+	 *
+	 * @param array $args Raw method arguments.
+	 * @return array{0:AgentWorkspaceScope,1:int,2:int,3:string,4:int|null}
+	 */
+	private static function normalize_recent_pending_session_args( array $args ): array {
+		if ( isset( $args[0] ) && $args[0] instanceof AgentWorkspaceScope ) {
+			return array(
+				$args[0],
+				(int) ( $args[1] ?? 0 ),
+				(int) ( $args[2] ?? 600 ),
+				(string) ( $args[3] ?? 'chat' ),
+				isset( $args[4] ) ? (int) $args[4] : null,
+			);
+		}
+
+		return array(
+			WordPressWorkspaceScope::current(),
+			(int) ( $args[0] ?? 0 ),
+			(int) ( $args[1] ?? 600 ),
+			(string) ( $args[2] ?? 'chat' ),
+			isset( $args[3] ) ? (int) $args[3] : null,
+		);
 	}
 
 	/**
@@ -737,14 +785,10 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * @param int|null            $token_id  Optional token ID for login-scoped deduplication.
 	 * @return array|null Session data or null if none found
 	 */
-	public function get_recent_pending_session(
-		AgentWorkspaceScope $workspace,
-		int $user_id,
-		int $seconds = 600,
-		string $context = 'chat',
-		?int $token_id = null
-	): ?array {
+	public function get_recent_pending_session( ...$args ): ?array {
 		global $wpdb;
+
+		list( $workspace, $user_id, $seconds, $context, $token_id ) = self::normalize_recent_pending_session_args( $args );
 
 		$table_name  = self::get_prefixed_table_name();
 		$cutoff_time = gmdate( 'Y-m-d H:i:s', time() - $seconds );

--- a/inc/Core/FilesRepository/AgentMemory.php
+++ b/inc/Core/FilesRepository/AgentMemory.php
@@ -25,6 +25,7 @@ use AgentsAPI\Core\FilesRepository\AgentMemoryReadResult;
 use AgentsAPI\Core\FilesRepository\AgentMemoryScope;
 use AgentsAPI\Core\FilesRepository\AgentMemoryStoreInterface;
 use AgentsAPI\Core\FilesRepository\AgentMemoryWriteResult;
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 use DataMachine\Engine\AI\MemoryFileRegistry;
 
 defined( 'ABSPATH' ) || exit;
@@ -73,12 +74,12 @@ class AgentMemory {
 		$this->directory_manager = new DirectoryManager();
 		$effective_user_id       = $this->directory_manager->get_effective_user_id( $user_id );
 		$safe_filename           = $this->sanitize_filename( $filename );
-		$workspace               = self::workspace_parts();
+		$workspace               = WordPressWorkspaceScope::current();
 
 		$this->scope = new AgentMemoryScope(
 			$layer ?? self::resolve_layer_for( $safe_filename ),
-			$workspace['type'],
-			$workspace['id'],
+			$workspace->workspace_type,
+			$workspace->workspace_id,
 			$effective_user_id,
 			$agent_id,
 			$safe_filename
@@ -230,8 +231,8 @@ class AgentMemory {
 	public static function list_layer( string $layer, int $user_id = 0, int $agent_id = 0 ): array {
 		$dm                = new DirectoryManager();
 		$effective_user_id = $dm->get_effective_user_id( $user_id );
-		$workspace         = self::workspace_parts();
-		$scope_query       = new AgentMemoryScope( $layer, $workspace['type'], $workspace['id'], $effective_user_id, $agent_id, '' );
+		$workspace         = WordPressWorkspaceScope::current();
+		$scope_query       = new AgentMemoryScope( $layer, $workspace->workspace_type, $workspace->workspace_id, $effective_user_id, $agent_id, '' );
 		$store             = AgentMemoryStoreFactory::for_scope( $scope_query );
 
 		return $store->list_layer( $scope_query );
@@ -259,8 +260,8 @@ class AgentMemory {
 	public static function list_subtree( string $layer, int $user_id, int $agent_id, string $prefix ): array {
 		$dm                = new DirectoryManager();
 		$effective_user_id = $dm->get_effective_user_id( $user_id );
-		$workspace         = self::workspace_parts();
-		$scope_query       = new AgentMemoryScope( $layer, $workspace['type'], $workspace['id'], $effective_user_id, $agent_id, '' );
+		$workspace         = WordPressWorkspaceScope::current();
+		$scope_query       = new AgentMemoryScope( $layer, $workspace->workspace_type, $workspace->workspace_id, $effective_user_id, $agent_id, '' );
 		$store             = AgentMemoryStoreFactory::for_scope( $scope_query );
 
 		return $store->list_subtree( $scope_query, $prefix );
@@ -723,19 +724,6 @@ class AgentMemory {
 			$clean[] = preg_replace( '/[^a-zA-Z0-9._-]/', '', basename( $segment ) );
 		}
 		return implode( '/', $clean );
-	}
-
-	/**
-	 * Resolve the current site workspace identity for memory storage.
-	 *
-	 * @since next
-	 * @return array{type:string,id:string}
-	 */
-	private static function workspace_parts(): array {
-		return array(
-			'type' => 'site',
-			'id'   => function_exists( 'get_current_blog_id' ) ? (string) get_current_blog_id() : '1',
-		);
 	}
 
 	/**

--- a/inc/Core/FilesRepository/DiskAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/DiskAgentMemoryStore.php
@@ -56,6 +56,7 @@ class DiskAgentMemoryStore implements AgentMemoryStoreInterface {
 	 * @inheritDoc
 	 */
 	public function read( AgentMemoryScope $scope, array $metadata_fields = AgentMemoryMetadata::FIELDS ): AgentMemoryReadResult {
+		unset( $metadata_fields );
 		$filepath = $this->resolve_filepath( $scope );
 
 		if ( ! file_exists( $filepath ) ) {

--- a/inc/Core/FilesRepository/DiskAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/DiskAgentMemoryStore.php
@@ -56,7 +56,6 @@ class DiskAgentMemoryStore implements AgentMemoryStoreInterface {
 	 * @inheritDoc
 	 */
 	public function read( AgentMemoryScope $scope, array $metadata_fields = AgentMemoryMetadata::FIELDS ): AgentMemoryReadResult {
-		unset( $metadata_fields );
 		$filepath = $this->resolve_filepath( $scope );
 
 		if ( ! file_exists( $filepath ) ) {

--- a/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
@@ -93,7 +93,6 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 	 * @inheritDoc
 	 */
 	public function read( AgentMemoryScope $scope, array $metadata_fields = AgentMemoryMetadata::FIELDS ): AgentMemoryReadResult {
-		unset( $metadata_fields );
 		$post = $this->find_post( $scope );
 		if ( ! $post instanceof \WP_Post ) {
 			return AgentMemoryReadResult::not_found();

--- a/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/GuidelineAgentMemoryStore.php
@@ -12,7 +12,7 @@
  * `agents_api_memory_store` filter. When unavailable, the built-in
  * disk store remains the default behavior.
  *
- * Identity model: one post = one (layer, user_id, agent_id, filename) tuple.
+	 * Identity model: one post = one (layer, workspace, user_id, agent_id, filename) tuple.
  * Filename is the relative path within the layer (`MEMORY.md`,
  * `daily/2026/04/17.md`, `contexts/chat.md`).
  *
@@ -93,6 +93,7 @@ class GuidelineAgentMemoryStore implements AgentMemoryStoreInterface {
 	 * @inheritDoc
 	 */
 	public function read( AgentMemoryScope $scope, array $metadata_fields = AgentMemoryMetadata::FIELDS ): AgentMemoryReadResult {
+		unset( $metadata_fields );
 		$post = $this->find_post( $scope );
 		if ( ! $post instanceof \WP_Post ) {
 			return AgentMemoryReadResult::not_found();

--- a/inc/Core/Workspace/WordPressWorkspaceScope.php
+++ b/inc/Core/Workspace/WordPressWorkspaceScope.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * WordPress workspace scope adapter.
+ *
+ * @package DataMachine\Core\Workspace
+ */
+
+namespace DataMachine\Core\Workspace;
+
+use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds the generic Agents API workspace identity for the current WordPress site.
+ */
+class WordPressWorkspaceScope {
+
+	/**
+	 * Return the current site's generic workspace scope.
+	 *
+	 * WordPress-specific details such as blog ID and network ID stay in adapter
+	 * metadata; the generic boundary is the Agents API workspace value object.
+	 *
+	 * @return AgentWorkspaceScope
+	 */
+	public static function current(): AgentWorkspaceScope {
+		return AgentWorkspaceScope::from_parts( 'site', self::current_site_id() );
+	}
+
+	/**
+	 * Return JSON-serializable WordPress adapter metadata for the current site.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function metadata(): array {
+		$metadata = array(
+			'blog_id'  => function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0,
+			'home_url' => function_exists( 'home_url' ) ? untrailingslashit( (string) home_url( '/' ) ) : '',
+			'site_url' => function_exists( 'site_url' ) ? untrailingslashit( (string) site_url( '/' ) ) : '',
+		);
+
+		if ( function_exists( 'get_current_network_id' ) ) {
+			$metadata['network_id'] = (int) get_current_network_id();
+		}
+
+		return array_filter(
+			$metadata,
+			static fn( $value ): bool => null !== $value && '' !== $value
+		);
+	}
+
+	/**
+	 * Resolve a stable current-site workspace identifier.
+	 *
+	 * @return string
+	 */
+	private static function current_site_id(): string {
+		if ( function_exists( 'home_url' ) ) {
+			$home_url = untrailingslashit( (string) home_url( '/' ) );
+			if ( '' !== $home_url ) {
+				return $home_url;
+			}
+		}
+
+		if ( defined( 'ABSPATH' ) && '' !== ABSPATH ) {
+			return 'local:' . rtrim( (string) ABSPATH, '/' );
+		}
+
+		return 'local:unknown';
+	}
+}

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -38,6 +38,7 @@ use AgentsAPI\AI\Approvals\ApprovalDecision;
 use AgentsAPI\AI\Approvals\PendingAction;
 use AgentsAPI\AI\Approvals\PendingActionStatus;
 use AgentsAPI\AI\Approvals\PendingActionStoreInterface;
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -105,6 +106,7 @@ class PendingActionStore {
 			resolution_error text NULL,
 			resolution_metadata longtext NULL,
 			PRIMARY KEY  (action_id),
+			KEY workspace (workspace_type, workspace_id),
 			KEY status (status),
 			KEY kind (kind),
 			KEY agent_id (agent_id),
@@ -112,12 +114,50 @@ class PendingActionStore {
 			KEY created_by (created_by),
 			KEY creator (creator),
 			KEY resolver (resolver),
-			KEY workspace (workspace_type, workspace_id),
 			KEY expires_at (expires_at),
 			KEY created_at (created_at)
 		) {$charset_collate};";
 
 		dbDelta( $sql );
+		self::ensure_workspace_columns();
+	}
+
+	/**
+	 * Ensure workspace columns exist on previously-created audit tables.
+	 *
+	 * @return void
+	 */
+	public static function ensure_workspace_columns(): void {
+		global $wpdb;
+
+		if ( ! self::has_database() ) {
+			return;
+		}
+
+		$table_name = self::get_table_name();
+		$workspace  = WordPressWorkspaceScope::current();
+
+		if ( ! self::column_exists( $table_name, 'workspace_type' ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN workspace_type varchar(50) NULL', $table_name ) );
+		}
+
+		if ( ! self::column_exists( $table_name, 'workspace_id' ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN workspace_id varchar(191) NULL', $table_name ) );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET workspace_type = %s, workspace_id = %s WHERE workspace_type IS NULL OR workspace_type = %s OR workspace_id IS NULL OR workspace_id = %s',
+				$table_name,
+				$workspace->workspace_type,
+				$workspace->workspace_id,
+				'',
+				''
+			)
+		);
 	}
 
 	/**
@@ -151,6 +191,14 @@ class PendingActionStore {
 	 */
 	public static function store( string $action_id, array $payload ): bool {
 		global $wpdb;
+
+		$workspace            = isset( $payload['workspace'] ) && is_array( $payload['workspace'] )
+			? \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_array( $payload['workspace'] )
+			: WordPressWorkspaceScope::current();
+		$payload['workspace'] = $workspace->to_array();
+		$context              = is_array( $payload['context'] ?? null ) ? $payload['context'] : array();
+		$context['wordpress'] = $context['wordpress'] ?? WordPressWorkspaceScope::metadata();
+		$payload['context']   = $context;
 
 		if ( ! self::has_database() ) {
 			$payload['created_at'] = time();
@@ -320,14 +368,14 @@ class PendingActionStore {
 		$args  = array();
 
 		self::add_filter_clause( $where, $args, $filters, 'status', 'status', '%s' );
+		self::add_filter_clause( $where, $args, $filters, 'workspace_type', 'workspace_type', '%s' );
+		self::add_filter_clause( $where, $args, $filters, 'workspace_id', 'workspace_id', '%s' );
 		self::add_filter_clause( $where, $args, $filters, 'kind', 'kind', '%s' );
 		self::add_filter_clause( $where, $args, $filters, 'agent_id', 'agent_id', '%d' );
 		self::add_filter_clause( $where, $args, $filters, 'agent', 'agent', '%s' );
 		self::add_filter_clause( $where, $args, $filters, 'created_by', 'created_by', '%d' );
 		self::add_filter_clause( $where, $args, $filters, 'creator', 'creator', '%s' );
 		self::add_filter_clause( $where, $args, $filters, 'resolver', 'resolver', '%s' );
-		self::add_filter_clause( $where, $args, $filters, 'workspace_type', 'workspace_type', '%s' );
-		self::add_filter_clause( $where, $args, $filters, 'workspace_id', 'workspace_id', '%s' );
 
 		if ( ! empty( $filters['context'] ) && is_array( $filters['context'] ) ) {
 			foreach ( $filters['context'] as $key => $value ) {
@@ -623,6 +671,18 @@ class PendingActionStore {
 
 		$where[] = $column . ' = ' . $format;
 		$args[]  = '%d' === $format ? (int) $filters[ $filter_key ] : (string) $filters[ $filter_key ];
+	}
+
+	/**
+	 * Check whether a pending-action table column exists.
+	 */
+	private static function column_exists( string $table_name, string $column ): bool {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $table_name, $column ) );
+
+		return null !== $result;
 	}
 
 	/**

--- a/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
+++ b/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
@@ -10,6 +10,7 @@ namespace DataMachine\Engine\AI;
 use AgentsAPI\AI\AgentConversationRequest;
 use AgentsAPI\AI\AgentConversationTranscriptPersisterInterface;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -38,13 +39,16 @@ class DataMachinePipelineTranscriptPersister implements AgentConversationTranscr
 			return '';
 		}
 
-		$store = ConversationStoreFactory::get_transcript_store();
+		$store     = ConversationStoreFactory::get_transcript_store();
+		$workspace = $request->workspace() ?? WordPressWorkspaceScope::current();
 
 		$user_id  = (int) ( $runtime_context['user_id'] ?? 0 );
 		$agent_id = (int) ( $runtime_context['agent_id'] ?? 0 );
 
 		$store_metadata = array(
 			'source'       => 'pipeline_transcript',
+			'workspace'    => $workspace->to_array(),
+			'wordpress'    => WordPressWorkspaceScope::metadata(),
 			'job_id'       => $runtime_context['job_id'] ?? null,
 			'flow_step_id' => $runtime_context['flow_step_id'] ?? null,
 			'pipeline_id'  => $runtime_context['pipeline_id'] ?? null,
@@ -69,7 +73,6 @@ class DataMachinePipelineTranscriptPersister implements AgentConversationTranscr
 			$store_metadata['request_metadata'] = $result['request_metadata'];
 		}
 
-		$workspace  = $request->workspace() ?? ConversationStoreFactory::default_workspace();
 		$session_id = $store->create_session( $workspace, $user_id, $agent_id, $store_metadata, 'pipeline' );
 
 		if ( '' === $session_id ) {

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -21,6 +21,7 @@ use AgentsAPI\AI\AgentConversationTranscriptPersisterInterface;
 use AgentsAPI\AI\AgentMessageEnvelope;
 use AgentsAPI\AI\NullAgentConversationTranscriptPersister;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
 
 defined( 'ABSPATH' ) || exit;
@@ -130,6 +131,20 @@ function datamachine_run_conversation(
 				'max_turns'            => $max_turns,
 				'budgets'              => array( $turn_budget ),
 				'context'              => array_merge( $loop_payload, array( 'mode' => $mode ) ),
+				'request'              => new \AgentsAPI\AI\AgentConversationRequest(
+					$messages,
+					array(),
+					null,
+					array_merge( $loop_payload, array( 'mode' => $mode ) ),
+					array(
+						'provider'  => $provider,
+						'model'     => $model,
+						'wordpress' => WordPressWorkspaceScope::metadata(),
+					),
+					$max_turns,
+					$single_turn,
+					WordPressWorkspaceScope::current()
+				),
 				'should_continue'      => $should_continue,
 				'transcript_persister' => $transcript_persister,
 				'on_event'             => $on_event,

--- a/tests/Unit/Abilities/SystemAbilitiesTest.php
+++ b/tests/Unit/Abilities/SystemAbilitiesTest.php
@@ -12,6 +12,7 @@ namespace DataMachine\Tests\Unit\Abilities;
 use DataMachine\Abilities\SystemAbilities;
 use DataMachine\Core\Database\Chat\Chat as ChatDatabase;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 use WP_UnitTestCase;
 
 class SystemAbilitiesTest extends WP_UnitTestCase {
@@ -47,7 +48,7 @@ class SystemAbilitiesTest extends WP_UnitTestCase {
 	 */
 	private function create_test_session( array $messages, ?string $title = null ): string {
 		$session_id = $this->chat_db->create_session(
-			\AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ),
+			WordPressWorkspaceScope::current(),
 			$this->test_user_id,
 			0,
 			array( 'status' => 'completed' ),

--- a/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
+++ b/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
@@ -186,9 +186,9 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$today     = gmdate( 'Y-m-d' );
 		$yesterday = gmdate( 'Y-m-d', time() - DAY_IN_SECONDS );
 
-		$a = $store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), $user );
-		$b = $store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), $user );
-		$c = $store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), $user );
+		$a = $store->create_session( $this->workspace(), $user );
+		$b = $store->create_session( $this->workspace(), $user );
+		$c = $store->create_session( $this->workspace(), $user );
 
 		$ref      = new \ReflectionClass( $store );
 		$sessions = $ref->getProperty( 'sessions' );
@@ -229,9 +229,9 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'size_mb', $metrics );
 		$this->assertSame( 0, $metrics['rows'] );
 
-		$store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), 1 );
-		$store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), 1 );
-		$store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), 2 );
+		$store->create_session( $this->workspace(), 1 );
+		$store->create_session( $this->workspace(), 1 );
+		$store->create_session( $this->workspace(), 2 );
 
 		$metrics = $store->get_storage_metrics();
 		$this->assertSame( 3, $metrics['rows'] );
@@ -256,7 +256,7 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 	 */
 	private function persist_fixture_transcript( ConversationTranscriptStoreInterface $store ): array {
 		$session_id = $store->create_session(
-			\AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ),
+			$this->workspace(),
 			5,
 			7,
 			array(
@@ -306,7 +306,7 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		);
 		ConversationStoreFactory::reset();
 
-		$session_id = $store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), 7, 0, array(), 'chat' );
+		$session_id = $store->create_session( $this->workspace(), 7, 0, array(), 'chat' );
 		$ref        = new \ReflectionClass( $store );
 		$sessions   = $ref->getProperty( 'sessions' );
 		$sessions->setAccessible( true );
@@ -327,7 +327,7 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		wp_set_current_user( $user_id );
 
 		// Seed the in-memory store with a session under the target user.
-		$session_id = $memory_store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' ), $user_id, 0, array(), 'chat' );
+		$session_id = $memory_store->create_session( $this->workspace(), $user_id, 0, array(), 'chat' );
 		$memory_store->update_session(
 			$session_id,
 			array(
@@ -361,5 +361,9 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $result['sessions'] );
 		$this->assertSame( $session_id, $result['sessions'][0]['session_id'] );
 		$this->assertSame( 'hello', $result['sessions'][0]['first_message'] );
+	}
+
+	private function workspace(): AgentWorkspaceScope {
+		return AgentWorkspaceScope::from_parts( 'site', 'https://example.test' );
 	}
 }

--- a/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
+++ b/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
@@ -23,6 +23,7 @@ use DataMachine\Core\Database\Chat\ConversationSessionIndexInterface;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Chat\ConversationStoreInterface;
 use AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface;
+use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
 use WP_UnitTestCase;
 
 class ConversationStoreFactoryTest extends WP_UnitTestCase {

--- a/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
+++ b/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
@@ -32,6 +32,8 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 
 		$this->sessions[ $session_id ] = array(
 			'session_id'   => $session_id,
+			'workspace_type' => $workspace->workspace_type,
+			'workspace_id' => $workspace->workspace_id,
 			'user_id'      => $user_id,
 			'agent_id'     => $agent_id > 0 ? $agent_id : null,
 			'title'        => null,
@@ -145,7 +147,7 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 		$best   = null;
 
 		foreach ( $this->sessions as $session ) {
-			if ( (int) $session['user_id'] !== $user_id ) {
+			if ( $session['workspace_type'] !== $workspace->workspace_type || $session['workspace_id'] !== $workspace->workspace_id || (int) $session['user_id'] !== $user_id ) {
 				continue;
 			}
 			if ( $session['context'] !== $context ) {

--- a/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
+++ b/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
@@ -25,32 +25,80 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 	 */
 	private array $sessions = array();
 
-	public function create_session( AgentWorkspaceScope $workspace, int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string {
+	public function create_session( ...$args ): string {
+		list( $workspace, $user_id, $agent_id, $metadata, $context ) = $this->normalize_create_session_args( $args );
+
 		$session_id = 'mem-' . bin2hex( random_bytes( 6 ) );
 		$now        = gmdate( 'Y-m-d H:i:s' );
 		$metadata   = array_merge( $metadata, $workspace->to_array() );
 
 		$this->sessions[ $session_id ] = array(
-			'session_id'   => $session_id,
-			'workspace_type' => $workspace->workspace_type,
-			'workspace_id' => $workspace->workspace_id,
-			'user_id'      => $user_id,
-			'agent_id'     => $agent_id > 0 ? $agent_id : null,
-			'title'        => null,
-			'messages'     => array(),
-			'metadata'     => $metadata,
-			'provider'     => null,
-			'model'        => null,
-			'context'      => $context,
+			'session_id'     => $session_id,
 			'workspace_type' => $workspace->workspace_type,
 			'workspace_id'   => $workspace->workspace_id,
-			'created_at'   => $now,
-			'updated_at'   => $now,
-			'last_read_at' => null,
-			'expires_at'   => null,
+			'user_id'        => $user_id,
+			'agent_id'       => $agent_id > 0 ? $agent_id : null,
+			'title'          => null,
+			'messages'       => array(),
+			'metadata'       => $metadata,
+			'provider'       => null,
+			'model'          => null,
+			'context'        => $context,
+			'created_at'     => $now,
+			'updated_at'     => $now,
+			'last_read_at'   => null,
+			'expires_at'     => null,
 		);
 
 		return $session_id;
+	}
+
+	/**
+	 * @param array $args Raw create-session arguments.
+	 * @return array{0:AgentWorkspaceScope,1:int,2:int,3:array,4:string}
+	 */
+	private function normalize_create_session_args( array $args ): array {
+		if ( isset( $args[0] ) && $args[0] instanceof AgentWorkspaceScope ) {
+			return array(
+				$args[0],
+				(int) ( $args[1] ?? 0 ),
+				(int) ( $args[2] ?? 0 ),
+				is_array( $args[3] ?? null ) ? $args[3] : array(),
+				(string) ( $args[4] ?? 'chat' ),
+			);
+		}
+
+		return array(
+			AgentWorkspaceScope::from_parts( 'site', '1' ),
+			(int) ( $args[0] ?? 0 ),
+			(int) ( $args[1] ?? 0 ),
+			is_array( $args[2] ?? null ) ? $args[2] : array(),
+			(string) ( $args[3] ?? 'chat' ),
+		);
+	}
+
+	/**
+	 * @param array $args Raw pending-session arguments.
+	 * @return array{0:AgentWorkspaceScope,1:int,2:int,3:string,4:int|null}
+	 */
+	private function normalize_recent_pending_session_args( array $args ): array {
+		if ( isset( $args[0] ) && $args[0] instanceof AgentWorkspaceScope ) {
+			return array(
+				$args[0],
+				(int) ( $args[1] ?? 0 ),
+				(int) ( $args[2] ?? 600 ),
+				(string) ( $args[3] ?? 'chat' ),
+				isset( $args[4] ) ? (int) $args[4] : null,
+			);
+		}
+
+		return array(
+			AgentWorkspaceScope::from_parts( 'site', '1' ),
+			(int) ( $args[0] ?? 0 ),
+			(int) ( $args[1] ?? 600 ),
+			(string) ( $args[2] ?? 'chat' ),
+			isset( $args[3] ) ? (int) $args[3] : null,
+		);
 	}
 
 	public function get_session( string $session_id ): ?array {
@@ -142,7 +190,9 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 		return $count;
 	}
 
-	public function get_recent_pending_session( AgentWorkspaceScope $workspace, int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
+	public function get_recent_pending_session( ...$args ): ?array {
+		list( $workspace, $user_id, $seconds, $context, $token_id ) = $this->normalize_recent_pending_session_args( $args );
+
 		$cutoff = gmdate( 'Y-m-d H:i:s', time() - $seconds );
 		$best   = null;
 

--- a/tests/agent-memory-events-smoke.php
+++ b/tests/agent-memory-events-smoke.php
@@ -231,6 +231,7 @@ class AgentMemoryEventsFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function read( AgentMemoryScope $scope, array $metadata_fields = AgentMemoryMetadata::FIELDS ): AgentMemoryReadResult {
+		unset( $metadata_fields );
 		if ( ! array_key_exists( $scope->key(), $this->files ) ) {
 			return AgentMemoryReadResult::not_found();
 		}
@@ -352,7 +353,7 @@ $GLOBALS['datamachine_agent_memory_events_taxonomies'] = array( GuidelineAgentMe
 $GLOBALS['datamachine_agent_memory_events_actions']    = array();
 
 $guideline_store = new GuidelineAgentMemoryStore();
-$guideline_scope = new AgentMemoryScope( 'agent', 'site', '1', 7, 42, 'GUIDELINE.md' );
+$guideline_scope = new AgentMemoryScope( 'agent', 'site', 'https://example.test', 7, 42, 'GUIDELINE.md' );
 $guideline_write = $guideline_store->write( $guideline_scope, 'Guideline content' );
 datamachine_agent_memory_events_assert( true === $guideline_write->success, 'guideline-backed write succeeds when substrate exists' );
 
@@ -364,7 +365,7 @@ datamachine_agent_memory_events_assert( GuidelineAgentMemoryStore::TERM_MEMORY =
 $GLOBALS['datamachine_agent_memory_events_post_types'] = array();
 $GLOBALS['datamachine_agent_memory_events_taxonomies'] = array();
 $GLOBALS['datamachine_agent_memory_events_actions']    = array();
-$capability_write                                      = $guideline_store->write( new AgentMemoryScope( 'agent', 'site', '1', 7, 42, 'UNAVAILABLE.md' ), 'No substrate' );
+$capability_write                                      = $guideline_store->write( new AgentMemoryScope( 'agent', 'site', 'https://example.test', 7, 42, 'UNAVAILABLE.md' ), 'No substrate' );
 datamachine_agent_memory_events_assert( false === $capability_write->success, 'guideline-backed write fails cleanly without substrate' );
 datamachine_agent_memory_events_assert( array() === datamachine_agent_memory_events_matching( 'datamachine_guideline_updated' ), 'unavailable guideline substrate does not emit guideline event' );
 

--- a/tests/agent-memory-events-smoke.php
+++ b/tests/agent-memory-events-smoke.php
@@ -231,7 +231,6 @@ class AgentMemoryEventsFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function read( AgentMemoryScope $scope, array $metadata_fields = AgentMemoryMetadata::FIELDS ): AgentMemoryReadResult {
-		unset( $metadata_fields );
 		if ( ! array_key_exists( $scope->key(), $this->files ) ) {
 			return AgentMemoryReadResult::not_found();
 		}

--- a/tests/agent-memory-store-factory-contract-smoke.php
+++ b/tests/agent-memory-store-factory-contract-smoke.php
@@ -66,7 +66,6 @@ class AgentMemoryStoreContractFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function read( AgentMemoryScope $scope, array $metadata_fields = AgentMemoryMetadata::FIELDS ): AgentMemoryReadResult {
-		unset( $metadata_fields );
 		$this->scopes[] = $scope;
 		if ( ! array_key_exists( $scope->key(), $this->files ) ) {
 			return AgentMemoryReadResult::not_found();

--- a/tests/agent-memory-store-factory-contract-smoke.php
+++ b/tests/agent-memory-store-factory-contract-smoke.php
@@ -66,6 +66,7 @@ class AgentMemoryStoreContractFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function read( AgentMemoryScope $scope, array $metadata_fields = AgentMemoryMetadata::FIELDS ): AgentMemoryReadResult {
+		unset( $metadata_fields );
 		$this->scopes[] = $scope;
 		if ( ! array_key_exists( $scope->key(), $this->files ) ) {
 			return AgentMemoryReadResult::not_found();
@@ -97,12 +98,21 @@ class AgentMemoryStoreContractFakeStore implements AgentMemoryStoreInterface {
 
 	public function list_layer( AgentMemoryScope $scope_query, ?AgentMemoryQuery $query = null ): array {
 		unset( $query );
-
 		$this->scopes[] = $scope_query;
 		$entries        = array();
 
 		foreach ( $this->files as $key => $content ) {
-			[ $layer, $workspace_type, $workspace_id, $user_id, $agent_id, $filename ] = explode( ':', $key, 6 );
+			$parts = explode( ':', $key );
+			if ( count( $parts ) < 6 ) {
+				continue;
+			}
+
+			$layer          = array_shift( $parts );
+			$workspace_type = array_shift( $parts );
+			$filename       = (string) array_pop( $parts );
+			$agent_id       = (int) array_pop( $parts );
+			$user_id        = (int) array_pop( $parts );
+			$workspace_id   = implode( ':', $parts );
 			if ( $layer !== $scope_query->layer || $workspace_type !== $scope_query->workspace_type || $workspace_id !== $scope_query->workspace_id || (int) $user_id !== $scope_query->user_id || (int) $agent_id !== $scope_query->agent_id ) {
 				continue;
 			}
@@ -118,6 +128,7 @@ class AgentMemoryStoreContractFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function list_subtree( AgentMemoryScope $scope_query, string $prefix, ?AgentMemoryQuery $query = null ): array {
+		unset( $query );
 		$this->scopes[] = $scope_query;
 		unset( $prefix, $query );
 		return array();
@@ -147,7 +158,7 @@ function datamachine_agent_memory_store_contract_round_trip( AgentMemoryStoreInt
 	return $store->read( $scope );
 }
 
-$scope = new AgentMemoryScope( 'agent', 'site', '1', 7, 42, 'MEMORY.md' );
+$scope = new AgentMemoryScope( 'agent', 'site', 'https://example.test', 7, 42, 'MEMORY.md' );
 
 datamachine_agent_memory_store_contract_reset_filters();
 $default_store = AgentMemoryStoreFactory::for_scope( $scope );

--- a/tests/agents-api-memory-store-smoke.php
+++ b/tests/agents-api-memory-store-smoke.php
@@ -97,7 +97,6 @@ class AgentsApiMemoryFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function read( AgentMemoryScope $scope, array $metadata_fields = AgentMemoryMetadata::FIELDS ): AgentMemoryReadResult {
-		unset( $metadata_fields );
 		$key = $scope->key();
 
 		if ( ! array_key_exists( $key, $this->records ) ) {

--- a/tests/agents-api-memory-store-smoke.php
+++ b/tests/agents-api-memory-store-smoke.php
@@ -97,6 +97,7 @@ class AgentsApiMemoryFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function read( AgentMemoryScope $scope, array $metadata_fields = AgentMemoryMetadata::FIELDS ): AgentMemoryReadResult {
+		unset( $metadata_fields );
 		$key = $scope->key();
 
 		if ( ! array_key_exists( $key, $this->records ) ) {
@@ -109,7 +110,6 @@ class AgentsApiMemoryFakeStore implements AgentMemoryStoreInterface {
 
 	public function write( AgentMemoryScope $scope, string $content, ?string $if_match = null, ?AgentMemoryMetadata $metadata = null ): AgentMemoryWriteResult {
 		unset( $metadata );
-
 		$current = $this->read( $scope );
 		if ( null !== $if_match && $current->hash !== $if_match ) {
 			return AgentMemoryWriteResult::failure( 'conflict' );
@@ -130,18 +130,26 @@ class AgentsApiMemoryFakeStore implements AgentMemoryStoreInterface {
 
 	public function list_layer( AgentMemoryScope $scope_query, ?AgentMemoryQuery $query = null ): array {
 		unset( $query );
-
 		return $this->list_subtree( $scope_query, '' );
 	}
 
 	public function list_subtree( AgentMemoryScope $scope_query, string $prefix, ?AgentMemoryQuery $query = null ): array {
 		unset( $query );
-
 		$entries = array();
 		$prefix  = trim( $prefix, '/' );
 
 		foreach ( $this->records as $key => $content ) {
-			list( $layer, $workspace_type, $workspace_id, $user_id, $agent_id, $filename ) = explode( ':', $key, 6 );
+			$parts = explode( ':', $key );
+			if ( count( $parts ) < 6 ) {
+				continue;
+			}
+
+			$layer          = array_shift( $parts );
+			$workspace_type = array_shift( $parts );
+			$filename       = (string) array_pop( $parts );
+			$agent_id       = (int) array_pop( $parts );
+			$user_id        = (int) array_pop( $parts );
+			$workspace_id   = implode( ':', $parts );
 			if ( $layer !== $scope_query->layer || $workspace_type !== $scope_query->workspace_type || $workspace_id !== $scope_query->workspace_id || (int) $user_id !== $scope_query->user_id || (int) $agent_id !== $scope_query->agent_id ) {
 				continue;
 			}
@@ -170,11 +178,11 @@ agents_api_memory_assert( ! class_exists( 'DataMachine\Core\FilesRepository\Agen
 
 echo "\n[2] Fake store satisfies the contract shape in isolation:\n";
 $store = new AgentsApiMemoryFakeStore();
-$scope = new AgentMemoryScope( 'agent', 'site', '1', 7, 42, 'MEMORY.md' );
+$scope = new AgentMemoryScope( 'agent', 'site', 'https://example.test', 7, 42, 'MEMORY.md' );
 
 $missing = $store->read( $scope );
 agents_api_memory_assert_same( false, $missing->exists, 'missing read returns not-found sentinel' );
-agents_api_memory_assert_same( 'agent:site:1:7:42:MEMORY.md', $scope->key(), 'scope exposes stable key' );
+agents_api_memory_assert_same( 'agent:site:https://example.test:7:42:MEMORY.md', $scope->key(), 'scope exposes stable key' );
 
 $write = $store->write( $scope, "First memory\n" );
 agents_api_memory_assert_same( true, $write->success, 'write succeeds' );
@@ -193,13 +201,13 @@ agents_api_memory_assert_same( 'conflict', $conflict->error, 'compare-and-swap c
 $cas_write = $store->write( $scope, "Second memory\n", $read->hash );
 agents_api_memory_assert_same( true, $cas_write->success, 'compare-and-swap write succeeds with matching hash' );
 
-$daily_scope = new AgentMemoryScope( 'agent', 'site', '1', 7, 42, 'daily/2026/04/17.md' );
+$daily_scope = new AgentMemoryScope( 'agent', 'site', 'https://example.test', 7, 42, 'daily/2026/04/17.md' );
 $store->write( $daily_scope, "Daily memory\n" );
 
-$layer_entries = $store->list_layer( new AgentMemoryScope( 'agent', 'site', '1', 7, 42, '' ) );
+$layer_entries = $store->list_layer( new AgentMemoryScope( 'agent', 'site', 'https://example.test', 7, 42, '' ) );
 agents_api_memory_assert_same( array( 'MEMORY.md', 'daily/2026/04/17.md' ), array_map( static fn( AgentMemoryListEntry $entry ): string => $entry->filename, $layer_entries ), 'layer list returns scoped entries' );
 
-$subtree_entries = $store->list_subtree( new AgentMemoryScope( 'agent', 'site', '1', 7, 42, '' ), 'daily' );
+$subtree_entries = $store->list_subtree( new AgentMemoryScope( 'agent', 'site', 'https://example.test', 7, 42, '' ), 'daily' );
 agents_api_memory_assert_same( array( 'daily/2026/04/17.md' ), array_map( static fn( AgentMemoryListEntry $entry ): string => $entry->filename, $subtree_entries ), 'subtree list filters by prefix' );
 
 $delete = $store->delete( $scope );

--- a/tests/agents-api-transcript-store-smoke.php
+++ b/tests/agents-api-transcript-store-smoke.php
@@ -32,6 +32,7 @@ require_once __DIR__ . '/agents-api-loader.php';
 datamachine_tests_require_agents_api();
 
 use AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface;
+use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
 
 $failures = array();
 $passes   = 0;

--- a/tests/agents-api-transcript-store-smoke.php
+++ b/tests/agents-api-transcript-store-smoke.php
@@ -58,20 +58,22 @@ class AgentsApiFakeTranscriptStore implements ConversationTranscriptStoreInterfa
 		$session_id = 'session-' . ( count( $this->sessions ) + 1 );
 
 		$this->sessions[ $session_id ] = array(
-			'session_id'   => $session_id,
-			'user_id'      => $user_id,
-			'agent_id'     => $agent_id,
-			'title'        => '',
-			'messages'     => array(),
-			'metadata'     => $metadata,
-			'provider'     => '',
-			'model'        => '',
-			'context'      => $context,
-			'mode'         => $context,
-			'created_at'   => gmdate( 'Y-m-d H:i:s' ),
-			'updated_at'   => gmdate( 'Y-m-d H:i:s' ),
-			'last_read_at' => null,
-			'expires_at'   => null,
+			'session_id'     => $session_id,
+			'workspace_type' => $workspace->workspace_type,
+			'workspace_id'   => $workspace->workspace_id,
+			'user_id'        => $user_id,
+			'agent_id'       => $agent_id,
+			'title'          => '',
+			'messages'       => array(),
+			'metadata'       => $metadata,
+			'provider'       => '',
+			'model'          => '',
+			'context'        => $context,
+			'mode'           => $context,
+			'created_at'     => gmdate( 'Y-m-d H:i:s' ),
+			'updated_at'     => gmdate( 'Y-m-d H:i:s' ),
+			'last_read_at'   => null,
+			'expires_at'     => null,
 		);
 
 		return $session_id;
@@ -132,7 +134,7 @@ $assert_true( false === interface_exists( 'DataMachine\\Core\\Database\\Chat\\Co
 $store = new AgentsApiFakeTranscriptStore();
 $assert_true( in_array( ConversationTranscriptStoreInterface::class, class_implements( $store ), true ), 'fake store can implement transcript contract without chat product interfaces' );
 
-$workspace  = \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', '1' );
+$workspace  = AgentWorkspaceScope::from_parts( 'site', 'https://example.test' );
 $session_id = $store->create_session( $workspace, 7, 3, array( 'source' => 'smoke' ), 'pipeline' );
 $assert_true( 'session-1' === $session_id, 'fake store creates transcript session IDs' );
 $assert_true( null !== $store->get_recent_pending_session( $workspace, 7, 600, 'pipeline' ), 'fake store can query pending transcript sessions' );

--- a/tests/daily-memory-store-seam-smoke.php
+++ b/tests/daily-memory-store-seam-smoke.php
@@ -89,6 +89,7 @@ class DailyMemorySeamFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function read( AgentMemoryScope $scope, array $metadata_fields = AgentMemoryMetadata::FIELDS ): AgentMemoryReadResult {
+		unset( $metadata_fields );
 		$this->record( 'read', $scope );
 
 		if ( ! array_key_exists( $scope->key(), $this->files ) ) {
@@ -100,6 +101,7 @@ class DailyMemorySeamFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function write( AgentMemoryScope $scope, string $content, ?string $if_match = null, ?AgentMemoryMetadata $metadata = null ): AgentMemoryWriteResult {
+		unset( $metadata );
 		$this->record( 'write', $scope );
 		$this->files[ $scope->key() ] = $content;
 
@@ -119,11 +121,13 @@ class DailyMemorySeamFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function list_layer( AgentMemoryScope $scope_query, ?AgentMemoryQuery $query = null ): array {
+		unset( $query );
 		$this->record( 'list_layer', $scope_query );
 		return array();
 	}
 
 	public function list_subtree( AgentMemoryScope $scope_query, string $prefix, ?AgentMemoryQuery $query = null ): array {
+		unset( $query );
 		$this->record( 'list_subtree', $scope_query );
 		$this->list_prefixes[] = $prefix;
 

--- a/tests/guideline-agent-memory-store-smoke.php
+++ b/tests/guideline-agent-memory-store-smoke.php
@@ -163,9 +163,9 @@ datamachine_guideline_memory_assert(
 
 echo "\nTest: deterministic scope key encoding\n";
 
-$scope = new AgentMemoryScope( 'agent', 'site', '1', 7, 42, 'MEMORY.md' );
-$same  = new AgentMemoryScope( 'agent', 'site', '1', 7, 42, 'MEMORY.md' );
-$daily = new AgentMemoryScope( 'agent', 'site', '1', 7, 42, 'daily/2026/04/17.md' );
+$scope = new AgentMemoryScope( 'agent', 'site', 'https://example.test', 7, 42, 'MEMORY.md' );
+$same  = new AgentMemoryScope( 'agent', 'site', 'https://example.test', 7, 42, 'MEMORY.md' );
+$daily = new AgentMemoryScope( 'agent', 'site', 'https://example.test', 7, 42, 'daily/2026/04/17.md' );
 
 $post_name = GuidelineAgentMemoryStore::post_name_for_scope( $scope );
 datamachine_guideline_memory_assert(
@@ -174,7 +174,7 @@ datamachine_guideline_memory_assert(
 );
 
 datamachine_guideline_memory_assert(
-	'memory-' . sha1( 'agent:site:1:7:42:MEMORY.md' ) === $post_name,
+	'memory-' . sha1( $scope->key() ) === $post_name,
 	'post_name is memory- prefixed sha1 of AgentMemoryScope::key()'
 );
 
@@ -191,7 +191,7 @@ datamachine_guideline_memory_assert(
 echo "\nTest: subtree filenames and Data Machine meta keys\n";
 
 datamachine_guideline_memory_assert(
-	$daily->key() === 'agent:site:1:7:42:daily/2026/04/17.md',
+	$daily->key() === 'agent:site:https://example.test:7:42:daily/2026/04/17.md',
 	'Scope key preserves daily/... filenames'
 );
 

--- a/tests/memory-bundle-policy-smoke.php
+++ b/tests/memory-bundle-policy-smoke.php
@@ -194,13 +194,13 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 use DataMachine\Abilities\PermissionHelper;
 use AgentsAPI\Core\FilesRepository\AgentMemoryListEntry;
-use AgentsAPI\Core\FilesRepository\AgentMemoryReadResult;
-use AgentsAPI\Core\FilesRepository\AgentMemoryScope;
-use AgentsAPI\Core\FilesRepository\AgentMemoryStoreInterface;
-use AgentsAPI\Core\FilesRepository\AgentMemoryWriteResult;
 use AgentsAPI\Core\FilesRepository\AgentMemoryMetadata;
 use AgentsAPI\Core\FilesRepository\AgentMemoryQuery;
+use AgentsAPI\Core\FilesRepository\AgentMemoryReadResult;
+use AgentsAPI\Core\FilesRepository\AgentMemoryScope;
 use AgentsAPI\Core\FilesRepository\AgentMemoryStoreCapabilities;
+use AgentsAPI\Core\FilesRepository\AgentMemoryStoreInterface;
+use AgentsAPI\Core\FilesRepository\AgentMemoryWriteResult;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
 use DataMachine\Engine\AI\Memory\MemorySectionArtifact;
@@ -219,6 +219,7 @@ class MemoryPolicyFakeStore implements AgentMemoryStoreInterface {
 	}
 
 	public function read( AgentMemoryScope $scope, array $metadata_fields = AgentMemoryMetadata::FIELDS ): AgentMemoryReadResult {
+		unset( $metadata_fields );
 		if ( ! array_key_exists( $scope->key(), $this->files ) ) {
 			return AgentMemoryReadResult::not_found();
 		}
@@ -227,8 +228,8 @@ class MemoryPolicyFakeStore implements AgentMemoryStoreInterface {
 		return new AgentMemoryReadResult( true, $content, sha1( $content ), strlen( $content ), 123 );
 	}
 
-	public function write( AgentMemoryScope $scope, string $content, ?string $_if_match = null, ?AgentMemoryMetadata $_metadata = null ): AgentMemoryWriteResult {
-		unset( $_if_match, $_metadata );
+	public function write( AgentMemoryScope $scope, string $content, ?string $_if_match = null, ?AgentMemoryMetadata $metadata = null ): AgentMemoryWriteResult {
+		unset( $_if_match, $metadata );
 		$this->files[ $scope->key() ] = $content;
 		return AgentMemoryWriteResult::ok( sha1( $content ), strlen( $content ) );
 	}
@@ -242,13 +243,15 @@ class MemoryPolicyFakeStore implements AgentMemoryStoreInterface {
 		return AgentMemoryWriteResult::ok( '', 0 );
 	}
 
-	public function list_layer( AgentMemoryScope $_scope_query, ?AgentMemoryQuery $_query = null ): array {
-		unset( $_scope_query, $_query );
+	public function list_layer( AgentMemoryScope $_scope_query, ?AgentMemoryQuery $query = null ): array {
+		unset( $query );
+		unset( $_scope_query );
 		return array();
 	}
 
-	public function list_subtree( AgentMemoryScope $_scope_query, string $_prefix, ?AgentMemoryQuery $_query = null ): array {
-		unset( $_scope_query, $_prefix, $_query );
+	public function list_subtree( AgentMemoryScope $_scope_query, string $_prefix, ?AgentMemoryQuery $query = null ): array {
+		unset( $query );
+		unset( $_scope_query, $_prefix );
 		return array();
 	}
 }


### PR DESCRIPTION
## Summary
- Bumps the bundled Agents API snapshot to the workspace-scope contract from Automattic/agents-api#67.
- Adopts `AgentWorkspaceScope` for memory scopes, transcript session creation/dedupe, and pending-action audit rows.
- Keeps WordPress site details in adapter metadata via `WordPressWorkspaceScope` instead of a parallel generic scope shape.

Fixes #1756
Parent #1755

## Testing
- `php tests/agents-api-transcript-store-smoke.php && php tests/agents-api-memory-store-smoke.php && php tests/guideline-agent-memory-store-smoke.php && php tests/agent-memory-store-factory-contract-smoke.php && php tests/ai-request-metadata-guardrails-smoke.php`
- `vendor/bin/phpcs inc/Core/Workspace/WordPressWorkspaceScope.php inc/Core/Database/Chat/Chat.php inc/Core/FilesRepository/AgentMemory.php inc/Core/FilesRepository/DiskAgentMemoryStore.php inc/Core/FilesRepository/GuidelineAgentMemoryStore.php inc/Engine/AI/DataMachinePipelineTranscriptPersister.php inc/Engine/AI/Actions/PendingActionStore.php inc/Engine/AI/conversation-loop.php tests/agents-api-transcript-store-smoke.php tests/agents-api-memory-store-smoke.php tests/guideline-agent-memory-store-smoke.php tests/agent-memory-store-factory-contract-smoke.php tests/ai-request-metadata-guardrails-smoke.php`
- `git diff --check`

## Notes
- `homeboy lint` currently reports existing repository-wide JavaScript lint findings unrelated to this PHP workspace-scope change.
- `homeboy test` currently resolves `agents-api` from `Extra-Chill/agents-api`, which still exposes the pre-workspace transcript signature, causing a bootstrap signature mismatch. Composer in this branch is locked to `Automattic/agents-api` commit `109576b004ef61783456e27ad841e553aa59f25a`, which contains the required workspace contract.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Source audit, contract adoption, tests, and local verification. Chris reviewed and remains responsible for the change.