### PR TITLE
Consume Agents API consent policy contracts

### DIFF
--- a/inc/Abilities/AgentMemoryAbilities.php
+++ b/inc/Abilities/AgentMemoryAbilities.php
@@ -14,6 +14,7 @@ namespace DataMachine\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\FilesRepository\AgentMemory;
+use DataMachine\Engine\AI\DataMachineAgentConsentPolicy;
 use DataMachine\Engine\AI\Memory\MemorySectionPendingAction;
 use DataMachine\Engine\AI\Memory\SelfMemoryWritePolicy;
 
@@ -336,6 +337,23 @@ class AgentMemoryAbilities {
 	 * @return array Result.
 	 */
 	public static function updateMemory( array $input ): array {
+		$consent_decision = DataMachineAgentConsentPolicy::get()->can_store_memory(
+			array(
+				'mode'               => 'ability',
+				'interactive'        => true,
+				'permission_granted' => PermissionHelper::can_manage(),
+				'agent_id'           => (int) ( $input['agent_id'] ?? 0 ),
+				'user_id'            => (int) ( $input['user_id'] ?? 0 ),
+			)
+		);
+		if ( ! $consent_decision->is_allowed() ) {
+			return array(
+				'success'          => false,
+				'message'          => 'Memory write consent denied.',
+				'consent_decision' => $consent_decision->to_array(),
+			);
+		}
+
 		$memory  = self::resolveMemory( $input );
 		$section = $input['section'];
 		$content = $input['content'];

--- a/inc/Abilities/AgentMemoryAbilities.php
+++ b/inc/Abilities/AgentMemoryAbilities.php
@@ -145,39 +145,39 @@ class AgentMemoryAbilities {
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
-							'agent_id'           => array(
+							'agent_id'          => array(
 								'type'        => array( 'integer', 'null' ),
 								'description' => 'Optional target agent. Defaults to the current acting agent; other agents require explicit delegation.',
 							),
-							'file'               => array(
+							'file'              => array(
 								'type'        => 'string',
 								'description' => 'Target memory file. Defaults to MEMORY.md.',
 								'default'     => 'MEMORY.md',
 							),
-							'section'            => array(
+							'section'           => array(
 								'type'        => 'string',
 								'description' => 'Section name to create or update.',
 							),
-							'section_type'       => array(
+							'section_type'      => array(
 								'type'        => 'string',
 								'description' => 'Operational section type, such as operating_note, source_quirk, run_lesson, or task_note.',
 								'default'     => 'operating_note',
 							),
-							'content'            => array(
+							'content'           => array(
 								'type'        => 'string',
 								'description' => 'Operational memory content to write.',
 							),
-							'mode'               => array(
+							'mode'              => array(
 								'type'        => 'string',
 								'enum'        => array( 'set', 'append' ),
 								'description' => 'Write mode. Defaults to append.',
 								'default'     => 'append',
 							),
-							'reason'             => array(
+							'reason'            => array(
 								'type'        => 'string',
 								'description' => 'Why this operational note should be recorded.',
 							),
-							'requires_approval'  => array(
+							'requires_approval' => array(
 								'type'        => 'boolean',
 								'description' => 'Force PendingAction preview instead of direct write.',
 								'default'     => false,

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -22,7 +22,6 @@ use DataMachine\Engine\AI\ConversationManager;
 use DataMachine\Engine\AI\DataMachineAgentConsentPolicy;
 use DataMachine\Engine\AI\Tools\ToolManager;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
-use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
 use WP_Error;
 
 use function DataMachine\Engine\AI\datamachine_run_conversation;
@@ -778,7 +777,7 @@ class ChatOrchestrator {
 	/**
 	 * Resolve the current site workspace for transcript storage.
 	 */
-	private static function workspace_scope(): AgentWorkspaceScope {
-		return AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() );
+	private static function workspace_scope(): \AgentsAPI\Core\Workspace\AgentWorkspaceScope {
+		return ConversationStoreFactory::default_workspace();
 	}
 }

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -19,6 +19,7 @@ namespace DataMachine\Api\Chat;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\ConversationManager;
+use DataMachine\Engine\AI\DataMachineAgentConsentPolicy;
 use DataMachine\Engine\AI\Tools\ToolManager;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
@@ -66,9 +67,17 @@ class ChatOrchestrator {
 		$request_id           = $options['request_id'] ?? null;
 		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
 
-		$chat_db          = ConversationStoreFactory::get();
-		$session_metadata = array();
-		$acting_token_id  = \DataMachine\Abilities\PermissionHelper::get_acting_token_id();
+		$chat_db                     = ConversationStoreFactory::get();
+		$session_metadata            = array();
+		$acting_token_id             = \DataMachine\Abilities\PermissionHelper::get_acting_token_id();
+		$transcript_consent_decision = DataMachineAgentConsentPolicy::get()->can_store_transcript(
+			array(
+				'mode'        => 'chat',
+				'interactive' => true,
+				'user_id'     => $user_id,
+				'agent_id'    => $agent_id,
+			)
+		);
 
 		// --- Session resolution ---
 		if ( $session_id ) {
@@ -144,9 +153,12 @@ class ChatOrchestrator {
 			array_merge(
 				$session_metadata,
 				array(
-					'status'        => 'processing',
-					'started_at'    => current_time( 'mysql', true ),
-					'message_count' => count( $messages ),
+					'status'            => 'processing',
+					'started_at'        => current_time( 'mysql', true ),
+					'message_count'     => count( $messages ),
+					'consent_decisions' => array(
+						'store_transcript' => $transcript_consent_decision->to_array(),
+					),
 				)
 			),
 			$provider,

--- a/inc/Core/Database/Chat/ConversationStoreFactory.php
+++ b/inc/Core/Database/Chat/ConversationStoreFactory.php
@@ -23,6 +23,7 @@
 namespace DataMachine\Core\Database\Chat;
 
 use AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface;
+use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -118,6 +119,17 @@ class ConversationStoreFactory {
 	 */
 	public static function get_transcript_store(): ConversationTranscriptStoreInterface {
 		return self::get();
+	}
+
+	/**
+	 * Resolve Data Machine's default workspace scope for local chat/transcripts.
+	 *
+	 * @return AgentWorkspaceScope
+	 */
+	public static function default_workspace(): AgentWorkspaceScope {
+		$blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 1;
+
+		return AgentWorkspaceScope::from_parts( 'site', (string) max( 1, $blog_id ) );
 	}
 
 	/**

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -234,15 +234,15 @@ class AIStep extends Step {
 		$persist_transcript          = $transcript_consent_decision->is_allowed();
 
 		$payload = array(
-			'job_id'             => $this->job_id,
-			'flow_step_id'       => $this->flow_step_id,
-			'step_id'            => $pipeline_step_id,
-			'data'               => $this->dataPackets,
-			'engine'             => $this->engine,
-			'user_id'            => $user_id,
-			'agent_id'           => $agent_id,
-			'pipeline_id'        => $job_snapshot['pipeline_id'] ?? null,
-			'flow_id'            => $job_snapshot['flow_id'] ?? null,
+			'job_id'                      => $this->job_id,
+			'flow_step_id'                => $this->flow_step_id,
+			'step_id'                     => $pipeline_step_id,
+			'data'                        => $this->dataPackets,
+			'engine'                      => $this->engine,
+			'user_id'                     => $user_id,
+			'agent_id'                    => $agent_id,
+			'pipeline_id'                 => $job_snapshot['pipeline_id'] ?? null,
+			'flow_id'                     => $job_snapshot['flow_id'] ?? null,
 			'persist_transcript'          => $persist_transcript,
 			'transcript_consent_decision' => $transcript_consent_decision->to_array(),
 		);

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -230,7 +230,8 @@ class AIStep extends Step {
 		// Resolution order: flow > pipeline > site option (default false).
 		// The boolean is threaded through $payload so the loop doesn't need
 		// to repeat the lookup every turn.
-		$persist_transcript = PipelineTranscriptPolicy::shouldPersist( $this->engine );
+		$transcript_consent_decision = PipelineTranscriptPolicy::decision( $this->engine );
+		$persist_transcript          = $transcript_consent_decision->is_allowed();
 
 		$payload = array(
 			'job_id'             => $this->job_id,
@@ -242,7 +243,8 @@ class AIStep extends Step {
 			'agent_id'           => $agent_id,
 			'pipeline_id'        => $job_snapshot['pipeline_id'] ?? null,
 			'flow_id'            => $job_snapshot['flow_id'] ?? null,
-			'persist_transcript' => $persist_transcript,
+			'persist_transcript'          => $persist_transcript,
+			'transcript_consent_decision' => $transcript_consent_decision->to_array(),
 		);
 
 		$navigator             = new \DataMachine\Engine\StepNavigator();

--- a/inc/Engine/AI/DataMachineAgentConsentPolicy.php
+++ b/inc/Engine/AI/DataMachineAgentConsentPolicy.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Data Machine agent consent policy adapter.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+use AgentsAPI\AI\Consent\AgentConsentDecision;
+use AgentsAPI\AI\Consent\AgentConsentOperation;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Implements Agents API consent decisions using Data Machine product policy.
+ */
+class DataMachineAgentConsentPolicy implements \WP_Agent_Consent_Policy_Interface {
+
+	/**
+	 * Resolve the active product policy.
+	 *
+	 * @return \WP_Agent_Consent_Policy_Interface
+	 */
+	public static function get(): \WP_Agent_Consent_Policy_Interface {
+		$policy = apply_filters( 'datamachine_agent_consent_policy', new self() );
+
+		return $policy instanceof \WP_Agent_Consent_Policy_Interface ? $policy : new self();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function can_store_memory( array $context = array() ): AgentConsentDecision {
+		if ( true === ( $context['permission_granted'] ?? null ) || true === ( $context[ AgentConsentOperation::STORE_MEMORY ] ?? null ) ) {
+			return $this->allowed( AgentConsentOperation::STORE_MEMORY, 'datamachine_memory_permission', $context );
+		}
+
+		return $this->denied( AgentConsentOperation::STORE_MEMORY, 'datamachine_memory_permission_missing', $context );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function can_use_memory( array $context = array() ): AgentConsentDecision {
+		if ( false === ( $context[ AgentConsentOperation::USE_MEMORY ] ?? null ) ) {
+			return $this->denied( AgentConsentOperation::USE_MEMORY, 'datamachine_memory_use_denied', $context );
+		}
+
+		return $this->allowed( AgentConsentOperation::USE_MEMORY, 'datamachine_memory_policy', $context );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function can_store_transcript( array $context = array() ): AgentConsentDecision {
+		$mode = strtolower( (string) ( $context['mode'] ?? '' ) );
+
+		if ( 'chat' === $mode && true === $this->is_interactive( $context ) ) {
+			return $this->allowed( AgentConsentOperation::STORE_TRANSCRIPT, 'datamachine_chat_session', $context );
+		}
+
+		if ( true === ( $context['persist_transcript'] ?? null ) || true === ( $context[ AgentConsentOperation::STORE_TRANSCRIPT ] ?? null ) ) {
+			return $this->allowed( AgentConsentOperation::STORE_TRANSCRIPT, 'datamachine_transcript_opt_in', $context );
+		}
+
+		return $this->denied( AgentConsentOperation::STORE_TRANSCRIPT, 'datamachine_transcript_not_configured', $context );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function can_share_transcript( array $context = array() ): AgentConsentDecision {
+		if ( true === ( $context[ AgentConsentOperation::SHARE_TRANSCRIPT ] ?? null ) ) {
+			return $this->allowed( AgentConsentOperation::SHARE_TRANSCRIPT, 'explicit_share_transcript_consent', $context );
+		}
+
+		return $this->denied( AgentConsentOperation::SHARE_TRANSCRIPT, 'share_transcript_consent_missing', $context );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function can_escalate_to_human( array $context = array() ): AgentConsentDecision {
+		if ( true === ( $context[ AgentConsentOperation::ESCALATE_TO_HUMAN ] ?? null ) ) {
+			return $this->allowed( AgentConsentOperation::ESCALATE_TO_HUMAN, 'explicit_escalation_consent', $context );
+		}
+
+		return $this->denied( AgentConsentOperation::ESCALATE_TO_HUMAN, 'escalation_consent_missing', $context );
+	}
+
+	/**
+	 * Build an allowed decision.
+	 *
+	 * @param string $operation Consent operation.
+	 * @param string $reason    Reason code.
+	 * @param array  $context   Policy context.
+	 * @return AgentConsentDecision
+	 */
+	private function allowed( string $operation, string $reason, array $context ): AgentConsentDecision {
+		return AgentConsentDecision::allowed( $operation, $reason, $this->audit_metadata( $operation, $context ) );
+	}
+
+	/**
+	 * Build a denied decision.
+	 *
+	 * @param string $operation Consent operation.
+	 * @param string $reason    Reason code.
+	 * @param array  $context   Policy context.
+	 * @return AgentConsentDecision
+	 */
+	private function denied( string $operation, string $reason, array $context ): AgentConsentDecision {
+		return AgentConsentDecision::denied( $operation, $reason, $this->audit_metadata( $operation, $context ) );
+	}
+
+	/**
+	 * Whether context came from an interactive user flow.
+	 *
+	 * @param array $context Policy context.
+	 * @return bool
+	 */
+	private function is_interactive( array $context ): bool {
+		if ( true === ( $context['interactive'] ?? null ) ) {
+			return true;
+		}
+
+		$mode = strtolower( (string) ( $context['mode'] ?? '' ) );
+
+		return in_array( $mode, array( 'chat', 'rest', 'interactive' ), true );
+	}
+
+	/**
+	 * Build audit-safe decision metadata.
+	 *
+	 * @param string $operation Consent operation.
+	 * @param array  $context   Policy context.
+	 * @return array
+	 */
+	private function audit_metadata( string $operation, array $context ): array {
+		return array(
+			'policy'             => 'datamachine',
+			'operation'          => $operation,
+			'mode'               => (string) ( $context['mode'] ?? '' ),
+			'interactive'        => $this->is_interactive( $context ),
+			'agent_id'           => isset( $context['agent_id'] ) ? (int) $context['agent_id'] : 0,
+			'user_id'            => isset( $context['user_id'] ) ? (int) $context['user_id'] : 0,
+			'configured_setting' => (string) ( $context['configured_setting'] ?? '' ),
+		);
+	}
+}

--- a/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
+++ b/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
@@ -59,6 +59,12 @@ class DataMachinePipelineTranscriptPersister implements AgentConversationTranscr
 			'usage'        => $result['usage'] ?? array(),
 		);
 
+		if ( ! empty( $runtime_context['transcript_consent_decision'] ) && is_array( $runtime_context['transcript_consent_decision'] ) ) {
+			$store_metadata['consent_decisions'] = array(
+				'store_transcript' => $runtime_context['transcript_consent_decision'],
+			);
+		}
+
 		if ( ! empty( $result['request_metadata'] ) && is_array( $result['request_metadata'] ) ) {
 			$store_metadata['request_metadata'] = $result['request_metadata'];
 		}

--- a/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
+++ b/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
@@ -69,7 +69,7 @@ class DataMachinePipelineTranscriptPersister implements AgentConversationTranscr
 			$store_metadata['request_metadata'] = $result['request_metadata'];
 		}
 
-		$session_id = $store->create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope::from_parts( 'site', (string) get_current_blog_id() ), $user_id, $agent_id, $store_metadata, 'pipeline' );
+		$session_id = $store->create_session( ConversationStoreFactory::default_workspace(), $user_id, $agent_id, $store_metadata, 'pipeline' );
 
 		if ( '' === $session_id ) {
 			do_action(

--- a/inc/Engine/AI/Memory/SelfMemoryWritePolicy.php
+++ b/inc/Engine/AI/Memory/SelfMemoryWritePolicy.php
@@ -9,6 +9,7 @@ namespace DataMachine\Engine\AI\Memory;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\FilesRepository\AgentMemory;
+use DataMachine\Engine\AI\DataMachineAgentConsentPolicy;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -35,6 +36,19 @@ final class SelfMemoryWritePolicy {
 		$current_agent_id = PermissionHelper::get_acting_agent_id();
 		if ( null === $current_agent_id ) {
 			return self::deny( 'Self-memory writes require an active agent context.', 'missing_agent_context' );
+		}
+
+		$consent_decision = DataMachineAgentConsentPolicy::get()->can_store_memory(
+			array(
+				'mode'               => 'self_memory',
+				'interactive'        => false,
+				'permission_granted' => true,
+				'agent_id'           => $current_agent_id,
+				'user_id'            => PermissionHelper::acting_user_id(),
+			)
+		);
+		if ( ! $consent_decision->is_allowed() ) {
+			return self::deny( 'Self-memory write consent denied.', $consent_decision->reason() );
 		}
 
 		$target_agent_id = absint( $input['agent_id'] ?? $current_agent_id );

--- a/inc/Engine/AI/PipelineTranscriptPolicy.php
+++ b/inc/Engine/AI/PipelineTranscriptPolicy.php
@@ -25,6 +25,7 @@
 
 namespace DataMachine\Engine\AI;
 
+use AgentsAPI\AI\Consent\AgentConsentDecision;
 use DataMachine\Core\EngineData;
 
 defined( 'ABSPATH' ) || exit;
@@ -51,20 +52,61 @@ class PipelineTranscriptPolicy {
 	 * @return bool True when the AI loop should persist its $messages array.
 	 */
 	public static function shouldPersist( EngineData $engine ): bool {
+		return self::decision( $engine )->is_allowed();
+	}
+
+	/**
+	 * Resolve the Agents API consent decision for pipeline transcript storage.
+	 *
+	 * @param EngineData $engine Engine data snapshot for the running job.
+	 * @return AgentConsentDecision Consent decision with audit metadata.
+	 */
+	public static function decision( EngineData $engine ): AgentConsentDecision {
 		$flow_config     = $engine->getFlowConfig();
 		$pipeline_config = $engine->getPipelineConfig();
+		$job_snapshot    = $engine->get( 'job' );
+		$context         = array(
+			'mode'        => 'pipeline',
+			'interactive' => false,
+			'agent_id'    => (int) ( $job_snapshot['agent_id'] ?? 0 ),
+			'user_id'     => (int) ( $job_snapshot['user_id'] ?? 0 ),
+		);
 
 		$flow_override = self::extract( $flow_config );
 		if ( null !== $flow_override ) {
-			return $flow_override;
+			return DataMachineAgentConsentPolicy::get()->can_store_transcript(
+				array_merge(
+					$context,
+					array(
+						'persist_transcript' => $flow_override,
+						'configured_setting' => 'flow.persist_transcripts',
+					)
+				)
+			);
 		}
 
 		$pipeline_override = self::extract( $pipeline_config );
 		if ( null !== $pipeline_override ) {
-			return $pipeline_override;
+			return DataMachineAgentConsentPolicy::get()->can_store_transcript(
+				array_merge(
+					$context,
+					array(
+						'persist_transcript' => $pipeline_override,
+						'configured_setting' => 'pipeline.persist_transcripts',
+					)
+				)
+			);
 		}
 
-		return (bool) get_option( self::OPTION_NAME, false );
+		return DataMachineAgentConsentPolicy::get()->can_store_transcript(
+			array_merge(
+				$context,
+				array(
+					'persist_transcript' => (bool) get_option( self::OPTION_NAME, false ),
+					'configured_setting' => self::OPTION_NAME,
+				)
+			)
+		);
 	}
 
 	/**

--- a/tests/agents-api-consent-policy-smoke.php
+++ b/tests/agents-api-consent-policy-smoke.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Smoke coverage for Data Machine's Agents API consent policy adapter.
+ *
+ * Run with: php tests/agents-api-consent-policy-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+require_once __DIR__ . '/agents-api-loader.php';
+datamachine_tests_require_agents_api();
+
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/DataMachineAgentConsentPolicy.php';
+
+use AgentsAPI\AI\Consent\AgentConsentOperation;
+use DataMachine\Engine\AI\DataMachineAgentConsentPolicy;
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-consent-policy-smoke\n";
+
+$assert_true = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "FAIL: {$label}\n";
+};
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $_hook_name, $value ) {
+		return $value;
+	}
+}
+
+$policy = DataMachineAgentConsentPolicy::get();
+
+$assert_true( $policy instanceof WP_Agent_Consent_Policy_Interface, 'Data Machine exposes the Agents API consent policy interface' );
+$assert_true( AgentConsentOperation::STORE_MEMORY === 'store_memory', 'Agents API memory operation vocabulary is installed' );
+$assert_true( AgentConsentOperation::STORE_TRANSCRIPT === 'store_transcript', 'Agents API transcript operation vocabulary is installed' );
+
+$memory_decision = $policy->can_store_memory(
+	array(
+		'mode'               => 'ability',
+		'interactive'        => true,
+		'permission_granted' => true,
+		'agent_id'           => 3,
+		'user_id'            => 7,
+	)
+);
+$assert_true( $memory_decision->is_allowed(), 'memory storage consent follows Data Machine memory permissions' );
+$assert_true( AgentConsentOperation::STORE_MEMORY === $memory_decision->operation(), 'memory decision uses Agents API store_memory operation' );
+
+$pipeline_default = $policy->can_store_transcript(
+	array(
+		'mode'        => 'pipeline',
+		'interactive' => false,
+		'agent_id'    => 3,
+		'user_id'     => 7,
+	)
+);
+$assert_true( ! $pipeline_default->is_allowed(), 'non-interactive transcript storage remains denied by default' );
+$assert_true( AgentConsentOperation::STORE_TRANSCRIPT === $pipeline_default->operation(), 'pipeline decision uses Agents API store_transcript operation' );
+
+$pipeline_opt_in = $policy->can_store_transcript(
+	array(
+		'mode'                => 'pipeline',
+		'interactive'         => false,
+		'persist_transcript'  => true,
+		'configured_setting'  => 'datamachine_persist_pipeline_transcripts',
+		'agent_id'            => 3,
+		'user_id'             => 7,
+	)
+);
+$assert_true( $pipeline_opt_in->is_allowed(), 'non-interactive transcript storage is allowed only when configured' );
+$assert_true( 'datamachine_transcript_opt_in' === $pipeline_opt_in->reason(), 'configured pipeline transcript consent has stable audit reason' );
+
+$chat_decision = $policy->can_store_transcript(
+	array(
+		'mode'        => 'chat',
+		'interactive' => true,
+		'agent_id'    => 3,
+		'user_id'     => 7,
+	)
+);
+$assert_true( $chat_decision->is_allowed(), 'interactive chat transcript storage preserves chat session behavior' );
+
+$share_default = $policy->can_share_transcript( array( 'mode' => 'chat', 'interactive' => true ) );
+$assert_true( ! $share_default->is_allowed(), 'transcript sharing is independently denied without explicit consent' );
+$assert_true( AgentConsentOperation::SHARE_TRANSCRIPT === $share_default->operation(), 'sharing decision uses Agents API share_transcript operation' );
+
+$escalation_default = $policy->can_escalate_to_human( array( 'mode' => 'chat', 'interactive' => true ) );
+$assert_true( ! $escalation_default->is_allowed(), 'human escalation is independently denied without explicit consent' );
+$assert_true( AgentConsentOperation::ESCALATE_TO_HUMAN === $escalation_default->operation(), 'escalation decision uses Agents API escalate_to_human operation' );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " Data Machine consent policy assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} Data Machine consent policy assertions passed.\n";

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -103,6 +103,8 @@ use DataMachine\Core\Database\Chat\ConversationStoreInterface;
 use DataMachine\Engine\AI\DataMachinePipelineTranscriptPersister;
 use DataMachine\Engine\AI\Directives\DirectiveInterface;
 use DataMachine\Engine\AI\RequestBuilder;
+use AgentsAPI\AI\AgentConversationRequest;
+use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
 
 class RequestMetadataSmokeDirective implements DirectiveInterface {
 	public static function get_outputs( string $provider_name, array $tools, ?string $step_id = null, array $payload = array() ): array {
@@ -119,7 +121,8 @@ class RequestMetadataSmokeStore implements ConversationStoreInterface {
 	public array $sessions = array();
 	public array $updated  = array();
 
-	public function create_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope $workspace, int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string {
+	public function create_session( AgentWorkspaceScope $workspace, int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string {
+		$metadata['workspace'] = $workspace->to_array();
 		$this->sessions['smoke-session'] = compact( 'user_id', 'agent_id', 'metadata', 'context' );
 		return 'smoke-session';
 	}
@@ -132,7 +135,7 @@ class RequestMetadataSmokeStore implements ConversationStoreInterface {
 	public function delete_session( string $session_id ): bool { return true; }
 	public function get_user_sessions( int $user_id, int $limit = 20, int $offset = 0, ?string $context = null, ?int $agent_id = null ): array { return array(); }
 	public function get_user_session_count( int $user_id, ?string $context = null, ?int $agent_id = null ): int { return 0; }
-	public function get_recent_pending_session( \AgentsAPI\Core\Workspace\AgentWorkspaceScope $workspace, int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array { return null; }
+	public function get_recent_pending_session( AgentWorkspaceScope $workspace, int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array { return null; }
 	public function update_title( string $session_id, string $title ): bool { return true; }
 	public function count_unread( array $messages, ?string $last_read_at ): int { return 0; }
 	public function mark_session_read( string $session_id, int $user_id ) { return gmdate( 'Y-m-d H:i:s' ); }
@@ -285,9 +288,13 @@ $property->setValue( null, $store );
 
 $session_id = ( new DataMachinePipelineTranscriptPersister() )->persist(
 	array( array( 'role' => 'user', 'content' => 'hello' ) ),
-	'openai',
-	'gpt-smoke',
-	array( 'persist_transcript' => true, 'job_id' => 279, 'flow_step_id' => 12, 'user_id' => 1, 'agent_id' => 2 ),
+	new AgentConversationRequest(
+		array( array( 'role' => 'user', 'content' => 'hello' ) ),
+		array(),
+		null,
+		array( 'persist_transcript' => true, 'job_id' => 279, 'flow_step_id' => 12, 'user_id' => 1, 'agent_id' => 2 ),
+		array( 'provider' => 'openai', 'model' => 'gpt-smoke' )
+	),
 	array( 'turn_count' => 1, 'completed' => false, 'request_metadata' => $request_metadata )
 );
 assert_true( 'smoke-session' === $session_id, 'simulated pipeline transcript is persisted' );


### PR DESCRIPTION
## Summary
- Consume the Agents API consent policy contracts for Data Machine memory and transcript decisions.
- Separate memory storage, raw transcript storage, transcript sharing, and escalation consent decisions through a Data Machine product-policy adapter.
- Carry consent decision audit metadata into chat and pipeline transcript metadata while keeping non-interactive transcript storage opt-in.
- Align local transcript/memory store seams with the Agents API dependency level needed for the consent contracts.

Closes #1760.
Part of #1755.

## Tests
- `php tests/agents-api-consent-policy-smoke.php`
- `php tests/agents-api-transcript-store-smoke.php`
- `php tests/agents-api-memory-store-smoke.php`
- `php tests/agent-memory-store-factory-contract-smoke.php`
- `php tests/daily-memory-store-seam-smoke.php`
- `php tests/guideline-agent-memory-store-smoke.php`
- `php tests/agent-memory-events-smoke.php`
- `php tests/memory-bundle-policy-smoke.php`
- `php tests/ai-request-metadata-guardrails-smoke.php`
- `vendor/bin/phpcs <changed PHP files>`

## Known verification notes
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-adopt-agents-consent-policy --force-hot` currently fails before tests run because Homeboy resolves a stale `Extra-Chill/agents-api` checkout whose transcript interface lacks the workspace-scope parameter now present in the Agents API dependency consumed by this branch.
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-adopt-agents-consent-policy --force-hot` reports existing broad JS lint debt unrelated to these PHP changes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Source audit, implementation, test updates, dependency alignment, and PR preparation. Chris remains responsible for review and validation.