### PR TITLE
Consume Agents API transcript lock contract

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "109576b004ef61783456e27ad841e553aa59f25a"
+                "reference": "3697c0414950633fcb86a5654df07bc3de173b94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/109576b004ef61783456e27ad841e553aa59f25a",
-                "reference": "109576b004ef61783456e27ad841e553aa59f25a",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/3697c0414950633fcb86a5654df07bc3de173b94",
+                "reference": "3697c0414950633fcb86a5654df07bc3de173b94",
                 "shasum": ""
             },
             "require": {
@@ -31,6 +31,7 @@
                     "php tests/message-envelope-smoke.php",
                     "php tests/registry-smoke.php",
                     "php tests/execution-principal-smoke.php",
+                    "php tests/caller-context-smoke.php",
                     "php tests/authorization-smoke.php",
                     "php tests/action-policy-values-smoke.php",
                     "php tests/consent-policy-smoke.php",
@@ -45,6 +46,7 @@
                     "php tests/workspace-scope-smoke.php",
                     "php tests/compaction-item-smoke.php",
                     "php tests/conversation-runner-contracts-smoke.php",
+                    "php tests/conversation-transcript-lock-smoke.php",
                     "php tests/conversation-compaction-smoke.php",
                     "php tests/markdown-section-compaction-smoke.php",
                     "php tests/context-registry-smoke.php",
@@ -69,7 +71,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-04T15:07:00+00:00"
+            "time": "2026-05-04T19:27:48+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/data-machine.php
+++ b/data-machine.php
@@ -494,6 +494,7 @@ add_action(
 		\DataMachine\Core\Database\Chat\Chat::ensure_workspace_columns();
 		\DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();
 		\DataMachine\Core\Database\Chat\Chat::ensure_last_read_at_column();
+		\DataMachine\Core\Database\Chat\Chat::ensure_transcript_lock_columns();
 		\DataMachine\Engine\AI\Actions\PendingActionStore::ensure_workspace_columns();
 	},
 	6
@@ -677,6 +678,7 @@ function datamachine_activate_for_site() {
 	\DataMachine\Core\Database\Chat\Chat::ensure_workspace_columns();
 	\DataMachine\Core\Database\Chat\Chat::ensure_agent_id_column();
 	\DataMachine\Core\Database\Chat\Chat::ensure_last_read_at_column();
+	\DataMachine\Core\Database\Chat\Chat::ensure_transcript_lock_columns();
 
 	\DataMachine\Engine\AI\Actions\PendingActionStore::create_table();
 

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -133,6 +133,11 @@ class ChatOrchestrator {
 			}
 		}
 
+		$lock_token = $chat_db->acquire_session_lock( $session_id );
+		if ( null === $lock_token ) {
+			return self::sessionLockContentionError();
+		}
+
 		// --- Build user message (text or multi-modal with attachments) ---
 		$attachments = $options['attachments'] ?? array();
 
@@ -197,6 +202,7 @@ class ChatOrchestrator {
 		);
 
 		if ( is_wp_error( $result ) ) {
+			$chat_db->release_session_lock( $session_id, $lock_token );
 			return $result;
 		}
 
@@ -242,6 +248,7 @@ class ChatOrchestrator {
 			$provider,
 			$model
 		);
+		$chat_db->release_session_lock( $session_id, $lock_token );
 
 		// --- Title generation for new/untitled sessions ---
 		if ( $update_success ) {
@@ -348,6 +355,10 @@ class ChatOrchestrator {
 		$model                = $session['model'] ?? $chat_defaults['model'];
 		$message_count_before = count( $messages );
 		$selected_pipeline_id = $metadata['selected_pipeline_id'] ?? null;
+		$lock_token           = $chat_db->acquire_session_lock( $session_id );
+		if ( null === $lock_token ) {
+			return self::sessionLockContentionError();
+		}
 
 		$result = self::executeConversationTurn(
 			$session_id,
@@ -364,6 +375,7 @@ class ChatOrchestrator {
 		);
 
 		if ( is_wp_error( $result ) ) {
+			$chat_db->release_session_lock( $session_id, $lock_token );
 			return $result;
 		}
 
@@ -408,6 +420,7 @@ class ChatOrchestrator {
 			$provider,
 			$model
 		);
+		$chat_db->release_session_lock( $session_id, $lock_token );
 
 		$continue_response = array(
 			'session_id'        => $session_id,
@@ -424,6 +437,19 @@ class ChatOrchestrator {
 		do_action( 'datamachine_chat_response_complete', $session_id, $continue_response, (int) ( $session['agent_id'] ?? 0 ), $user_id );
 
 		return $continue_response;
+	}
+
+	/**
+	 * Build a standard response for an actively locked chat transcript.
+	 *
+	 * @return WP_Error
+	 */
+	private static function sessionLockContentionError(): WP_Error {
+		return new WP_Error(
+			'session_lock_contention',
+			__( 'This chat session is already processing another request.', 'data-machine' ),
+			array( 'status' => 409 )
+		);
 	}
 
 	/**

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -65,6 +65,8 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			last_read_at DATETIME NULL,
 			expires_at DATETIME NULL,
+			transcript_lock_token VARCHAR(64) NULL,
+			transcript_lock_expires_at DATETIME NULL,
 			PRIMARY KEY  (session_id),
 			KEY workspace (workspace_type, workspace_id),
 			KEY user_id (user_id),
@@ -73,7 +75,8 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			KEY user_mode (user_id, mode),
 			KEY created_at (created_at),
 			KEY updated_at (updated_at),
-			KEY expires_at (expires_at)
+			KEY expires_at (expires_at),
+			KEY transcript_lock_expires_at (transcript_lock_expires_at)
 		) {$charset_collate};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
@@ -215,6 +218,27 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		// `AFTER <col>` is MySQL-only; SQLite (Studio) rejects it. Column position
 		// is cosmetic — both engines accept the bare ADD COLUMN form.
 		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN last_read_at DATETIME NULL', $table_name ) );
+	}
+
+	/**
+	 * Ensure transcript lock columns exist for Agents API single-writer locking.
+	 *
+	 * @return void
+	 */
+	public static function ensure_transcript_lock_columns(): void {
+		global $wpdb;
+
+		$table_name = self::get_prefixed_table_name();
+
+		if ( ! self::column_exists( $table_name, 'transcript_lock_token', $wpdb ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN transcript_lock_token VARCHAR(64) NULL', $table_name ) );
+		}
+
+		if ( ! self::column_exists( $table_name, 'transcript_lock_expires_at', $wpdb ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD COLUMN transcript_lock_expires_at DATETIME NULL', $table_name ) );
+		}
 	}
 
 	/**
@@ -491,6 +515,90 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Acquire an advisory transcript lock for a chat session.
+	 *
+	 * @param string $session_id   Session UUID.
+	 * @param int    $ttl_seconds  Lock TTL in seconds.
+	 * @return string|null Lock token, or null when another active writer owns it.
+	 */
+	public function acquire_session_lock( string $session_id, int $ttl_seconds = 300 ): ?string {
+		global $wpdb;
+
+		$table_name = self::get_prefixed_table_name();
+		$token      = $this->generate_lock_token();
+		$now        = current_time( 'mysql', true );
+		$expires_at = gmdate( 'Y-m-d H:i:s', strtotime( $now ) + max( 1, $ttl_seconds ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i
+				SET transcript_lock_token = %s, transcript_lock_expires_at = %s
+				WHERE session_id = %s
+				AND (
+					transcript_lock_token IS NULL
+					OR transcript_lock_token = %s
+					OR transcript_lock_expires_at IS NULL
+					OR transcript_lock_expires_at <= %s
+				)',
+				$table_name,
+				$token,
+				$expires_at,
+				$session_id,
+				'',
+				$now
+			)
+		);
+
+		if ( 1 !== (int) $result ) {
+			return null;
+		}
+
+		return $token;
+	}
+
+	/**
+	 * Release an advisory transcript lock if the active token matches.
+	 *
+	 * @param string $session_id  Session UUID.
+	 * @param string $lock_token  Token returned by acquire_session_lock().
+	 * @return bool True when the active lock was released.
+	 */
+	public function release_session_lock( string $session_id, string $lock_token ): bool {
+		global $wpdb;
+
+		$table_name = self::get_prefixed_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i
+				SET transcript_lock_token = NULL, transcript_lock_expires_at = NULL
+				WHERE session_id = %s AND transcript_lock_token = %s',
+				$table_name,
+				$session_id,
+				$lock_token
+			)
+		);
+
+		return 1 === (int) $result;
+	}
+
+	/**
+	 * Generate an opaque lock ownership token.
+	 *
+	 * @return string
+	 */
+	private function generate_lock_token(): string {
+		try {
+			return bin2hex( random_bytes( 32 ) );
+		} catch ( \Throwable $e ) {
+			unset( $e );
+			return str_replace( '-', '', wp_generate_uuid4() ) . str_replace( '.', '', uniqid( '', true ) );
+		}
 	}
 
 	/**

--- a/inc/Core/Database/Chat/ConversationStoreInterface.php
+++ b/inc/Core/Database/Chat/ConversationStoreInterface.php
@@ -37,11 +37,13 @@
 namespace DataMachine\Core\Database\Chat;
 
 use AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface;
+use AgentsAPI\Core\Database\Chat\ConversationTranscriptLockInterface;
 
 defined( 'ABSPATH' ) || exit;
 
 interface ConversationStoreInterface extends
 	ConversationTranscriptStoreInterface,
+	ConversationTranscriptLockInterface,
 	ConversationSessionIndexInterface,
 	ConversationReadStateInterface,
 	ConversationRetentionInterface,

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -58,6 +58,7 @@ function datamachine_run_conversation(
 	$event_sink           = datamachine_resolve_event_sink( $payload );
 	$completion_policy    = datamachine_resolve_completion_policy( $mode, $payload );
 	$transcript_persister = datamachine_resolve_transcript_persister( $payload );
+	$transcript_lock      = $payload['transcript_lock'] ?? $payload['transcript_lock_store'] ?? null;
 
 	// Strip runtime objects from the loop payload before passing to tools/requests.
 	$loop_payload = datamachine_payload_without_runtime_objects( $payload );
@@ -147,6 +148,9 @@ function datamachine_run_conversation(
 				),
 				'should_continue'      => $should_continue,
 				'transcript_persister' => $transcript_persister,
+				'transcript_lock'      => $transcript_lock,
+				'transcript_session_id' => (string) ( $loop_payload['transcript_session_id'] ?? $loop_payload['session_id'] ?? '' ),
+				'transcript_lock_ttl'  => (int) ( $payload['transcript_lock_ttl'] ?? 300 ),
 				'on_event'             => $on_event,
 			)
 		);
@@ -563,7 +567,7 @@ function datamachine_resolve_transcript_persister( array $payload ): AgentConver
  * @return array Clean payload.
  */
 function datamachine_payload_without_runtime_objects( array $payload ): array {
-	unset( $payload['event_sink'], $payload['completion_policy'], $payload['transcript_persister'] );
+	unset( $payload['event_sink'], $payload['completion_policy'], $payload['transcript_persister'], $payload['transcript_lock'], $payload['transcript_lock_store'] );
 	return $payload;
 }
 

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -129,10 +129,10 @@ function datamachine_run_conversation(
 			$messages,
 			$turn_runner,
 			array(
-				'max_turns'            => $max_turns,
-				'budgets'              => array( $turn_budget ),
-				'context'              => array_merge( $loop_payload, array( 'mode' => $mode ) ),
-				'request'              => new \AgentsAPI\AI\AgentConversationRequest(
+				'max_turns'             => $max_turns,
+				'budgets'               => array( $turn_budget ),
+				'context'               => array_merge( $loop_payload, array( 'mode' => $mode ) ),
+				'request'               => new \AgentsAPI\AI\AgentConversationRequest(
 					$messages,
 					array(),
 					null,
@@ -146,12 +146,12 @@ function datamachine_run_conversation(
 					$single_turn,
 					WordPressWorkspaceScope::current()
 				),
-				'should_continue'      => $should_continue,
-				'transcript_persister' => $transcript_persister,
-				'transcript_lock'      => $transcript_lock,
+				'should_continue'       => $should_continue,
+				'transcript_persister'  => $transcript_persister,
+				'transcript_lock'       => $transcript_lock,
 				'transcript_session_id' => (string) ( $loop_payload['transcript_session_id'] ?? $loop_payload['session_id'] ?? '' ),
-				'transcript_lock_ttl'  => (int) ( $payload['transcript_lock_ttl'] ?? 300 ),
-				'on_event'             => $on_event,
+				'transcript_lock_ttl'   => (int) ( $payload['transcript_lock_ttl'] ?? 300 ),
+				'on_event'              => $on_event,
 			)
 		);
 	} catch ( \RuntimeException $e ) {

--- a/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
+++ b/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
@@ -22,6 +22,7 @@ use DataMachine\Core\Database\Chat\ConversationRetentionInterface;
 use DataMachine\Core\Database\Chat\ConversationSessionIndexInterface;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Chat\ConversationStoreInterface;
+use AgentsAPI\Core\Database\Chat\ConversationTranscriptLockInterface;
 use AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface;
 use AgentsAPI\Core\Workspace\AgentWorkspaceScope;
 use WP_UnitTestCase;
@@ -48,6 +49,7 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( ConversationStoreInterface::class, $store );
 		$this->assertInstanceOf( ConversationTranscriptStoreInterface::class, $store );
+		$this->assertInstanceOf( ConversationTranscriptLockInterface::class, $store );
 		$this->assertInstanceOf( ConversationSessionIndexInterface::class, $store );
 		$this->assertInstanceOf( ConversationReadStateInterface::class, $store );
 		$this->assertInstanceOf( ConversationRetentionInterface::class, $store );
@@ -63,9 +65,52 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$this->assertSame( ConversationStoreFactory::get(), $store );
 	}
 
+	public function test_builtin_chat_store_honors_transcript_lock_contract(): void {
+		global $wpdb;
+
+		$store      = ConversationStoreFactory::get();
+		$session_id = $store->create_session( 1, 0, array(), 'chat' );
+
+		$token_a = $store->acquire_session_lock( $session_id, 300 );
+		$token_b = $store->acquire_session_lock( $session_id, 300 );
+
+		$this->assertIsString( $token_a );
+		$this->assertNotSame( '', $token_a );
+		$this->assertNull( $token_b );
+
+		$wpdb->update(
+			$store->get_table_name(),
+			array( 'transcript_lock_expires_at' => gmdate( 'Y-m-d H:i:s', time() - 60 ) ),
+			array( 'session_id' => $session_id ),
+			array( '%s' ),
+			array( '%s' )
+		);
+
+		$token_c = $store->acquire_session_lock( $session_id, 300 );
+		$this->assertIsString( $token_c );
+		$this->assertNotSame( $token_a, $token_c );
+		$this->assertFalse( $store->release_session_lock( $session_id, $token_a ) );
+		$this->assertTrue( $store->release_session_lock( $session_id, $token_c ) );
+		$this->assertTrue(
+			$store->update_session(
+				$session_id,
+				array(
+					array(
+						'role'    => 'user',
+						'content' => 'Hello',
+					),
+				),
+				array( 'status' => 'completed' ),
+				'openai',
+				'gpt-test'
+			)
+		);
+	}
+
 	public function test_conversation_store_interface_is_composed_from_narrow_contracts(): void {
 		$reflection = new \ReflectionClass( ConversationStoreInterface::class );
 		$expected   = array(
+			ConversationTranscriptLockInterface::class,
 			ConversationTranscriptStoreInterface::class,
 			ConversationSessionIndexInterface::class,
 			ConversationReadStateInterface::class,
@@ -94,6 +139,7 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 
 		$this->assertSame( $memory_store, $resolved );
 		$this->assertInstanceOf( ConversationTranscriptStoreInterface::class, $resolved );
+		$this->assertInstanceOf( ConversationTranscriptLockInterface::class, $resolved );
 		$this->assertInstanceOf( ConversationSessionIndexInterface::class, $resolved );
 		$this->assertInstanceOf( ConversationReadStateInterface::class, $resolved );
 		$this->assertInstanceOf( ConversationRetentionInterface::class, $resolved );
@@ -115,6 +161,7 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 
 		$this->assertSame( $memory_store, $resolved );
 		$this->assertInstanceOf( ConversationTranscriptStoreInterface::class, $resolved );
+		$this->assertInstanceOf( ConversationTranscriptLockInterface::class, $resolved );
 	}
 
 	public function test_misbehaving_filter_falls_back_to_default(): void {

--- a/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
+++ b/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
@@ -25,6 +25,19 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 	 */
 	private array $sessions = array();
 
+	/** @var array<string, array{token: string, expires_at: int}> */
+	private array $locks = array();
+
+	/** @var int|null Test-controlled clock. */
+	private ?int $now = null;
+
+	/** @var int Lock token counter. */
+	private int $lock_counter = 0;
+
+	public function set_clock( int $now ): void {
+		$this->now = $now;
+	}
+
 	public function create_session( ...$args ): string {
 		list( $workspace, $user_id, $agent_id, $metadata, $context ) = $this->normalize_create_session_args( $args );
 
@@ -121,6 +134,36 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 			$this->sessions[ $session_id ]['model'] = $model;
 		}
 
+		return true;
+	}
+
+	public function acquire_session_lock( string $session_id, int $ttl_seconds = 300 ): ?string {
+		if ( ! isset( $this->sessions[ $session_id ] ) ) {
+			return null;
+		}
+
+		$now    = $this->now ?? time();
+		$active = $this->locks[ $session_id ] ?? null;
+		if ( null !== $active && $active['expires_at'] > $now ) {
+			return null;
+		}
+
+		$token                       = 'mem-lock-' . ++$this->lock_counter;
+		$this->locks[ $session_id ] = array(
+			'token'      => $token,
+			'expires_at' => $now + max( 1, $ttl_seconds ),
+		);
+
+		return $token;
+	}
+
+	public function release_session_lock( string $session_id, string $lock_token ): bool {
+		$active = $this->locks[ $session_id ] ?? null;
+		if ( null === $active || $active['token'] !== $lock_token ) {
+			return false;
+		}
+
+		unset( $this->locks[ $session_id ] );
 		return true;
 	}
 

--- a/tests/agents-api-bootstrap-smoke.php
+++ b/tests/agents-api-bootstrap-smoke.php
@@ -24,6 +24,7 @@ $namespace_map = array(
 	'DataMachine\\Engine\\AI\\AgentConversationResult'                      => 'AgentsAPI\\AI\\AgentConversationResult',
 	'DataMachine\\Engine\\AI\\Tools\\RuntimeToolDeclaration'                => 'AgentsAPI\\AI\\Tools\\RuntimeToolDeclaration',
 	'DataMachine\\Core\\Database\\Chat\\ConversationTranscriptStoreInterface' => 'AgentsAPI\\Core\\Database\\Chat\\ConversationTranscriptStoreInterface',
+	'DataMachine\\Core\\Database\\Chat\\ConversationTranscriptLockInterface' => 'AgentsAPI\\Core\\Database\\Chat\\ConversationTranscriptLockInterface',
 	'DataMachine\\Core\\FilesRepository\\AgentMemoryStoreInterface'           => 'AgentsAPI\\Core\\FilesRepository\\AgentMemoryStoreInterface',
 	'DataMachine\\Core\\FilesRepository\\AgentMemoryScope'                    => 'AgentsAPI\\Core\\FilesRepository\\AgentMemoryScope',
 );

--- a/tests/conversation-store-contracts-smoke.php
+++ b/tests/conversation-store-contracts-smoke.php
@@ -37,6 +37,7 @@ use DataMachine\Core\Database\Chat\ConversationRetentionInterface;
 use DataMachine\Core\Database\Chat\ConversationSessionIndexInterface;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Chat\ConversationStoreInterface;
+use AgentsAPI\Core\Database\Chat\ConversationTranscriptLockInterface;
 use AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface;
 use DataMachine\Tests\Unit\Core\Database\Chat\InMemoryConversationStore;
 
@@ -52,6 +53,7 @@ $assert_true = static function ( bool $condition, string $label ) use ( &$failur
 
 $narrow_contracts = array(
 	ConversationTranscriptStoreInterface::class,
+	ConversationTranscriptLockInterface::class,
 	ConversationSessionIndexInterface::class,
 	ConversationReadStateInterface::class,
 	ConversationRetentionInterface::class,
@@ -64,6 +66,7 @@ foreach ( $narrow_contracts as $contract ) {
 }
 
 $transcript_ref = new ReflectionClass( ConversationTranscriptStoreInterface::class );
+$lock_ref       = new ReflectionClass( ConversationTranscriptLockInterface::class );
 $assert_true( ! $transcript_ref->implementsInterface( ConversationSessionIndexInterface::class ), 'transcript contract does not include session index surface' );
 $assert_true( ! $transcript_ref->implementsInterface( ConversationReadStateInterface::class ), 'transcript contract does not include read-state surface' );
 $assert_true( ! $transcript_ref->implementsInterface( ConversationRetentionInterface::class ), 'transcript contract does not include retention surface' );
@@ -84,6 +87,19 @@ $assert_true(
 		'update_title',
 	) === $transcript_methods,
 	'transcript contract stays limited to transcript/session CRUD methods'
+);
+
+$lock_methods = array_map(
+	static fn( ReflectionMethod $method ): string => $method->getName(),
+	$lock_ref->getMethods()
+);
+sort( $lock_methods );
+$assert_true(
+	array(
+		'acquire_session_lock',
+		'release_session_lock',
+	) === $lock_methods,
+	'transcript lock contract stays limited to acquire/release methods'
 );
 
 foreach ( $narrow_contracts as $contract ) {

--- a/tests/conversation-transcript-lock-smoke.php
+++ b/tests/conversation-transcript-lock-smoke.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Pure-PHP smoke test for Data Machine's Agents API transcript lock adoption.
+ *
+ * Run with: php tests/conversation-transcript-lock-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 86400 );
+}
+
+function did_action( string $hook = '' ): int {
+	return 0;
+}
+
+function doing_action( string $hook = '' ): bool {
+	return false;
+}
+
+function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	// no-op
+}
+
+function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	// no-op
+}
+
+require_once __DIR__ . '/agents-api-loader.php';
+datamachine_tests_require_agents_api();
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use AgentsAPI\Core\Database\Chat\ConversationTranscriptLockInterface;
+use DataMachine\Tests\Unit\Core\Database\Chat\InMemoryConversationStore;
+
+$failures = array();
+$passes   = 0;
+
+$assert_equals = static function ( mixed $expected, mixed $actual, string $label ) use ( &$failures, &$passes ): void {
+	if ( $expected === $actual ) {
+		echo "PASS: {$label}\n";
+		++$passes;
+		return;
+	}
+
+	echo "FAIL: {$label}\n";
+	$failures[] = $label;
+};
+
+echo "data-machine-conversation-transcript-lock-smoke\n";
+
+$store = new InMemoryConversationStore();
+$store->set_clock( 1000 );
+$session_id = $store->create_session( 1, 0, array(), 'chat' );
+
+$assert_equals( true, $store instanceof ConversationTranscriptLockInterface, 'Data Machine aggregate store implements Agents API lock contract' );
+
+echo "\n[1] Acquire then release succeeds:\n";
+$token = $store->acquire_session_lock( $session_id, 30 );
+$assert_equals( true, is_string( $token ) && '' !== $token, 'acquire returns an ownership token' );
+$assert_equals( true, $store->release_session_lock( $session_id, (string) $token ), 'release accepts the active token' );
+
+echo "\n[2] Contention returns null:\n";
+$token_a = $store->acquire_session_lock( $session_id, 30 );
+$token_b = $store->acquire_session_lock( $session_id, 30 );
+$assert_equals( true, is_string( $token_a ) && '' !== $token_a, 'first contender acquires lock' );
+$assert_equals( null, $token_b, 'second contender is denied while lock is active' );
+
+echo "\n[3] TTL expiry permits reacquisition:\n";
+$store->set_clock( 1031 );
+$token_c = $store->acquire_session_lock( $session_id, 30 );
+$assert_equals( true, is_string( $token_c ) && '' !== $token_c && $token_c !== $token_a, 'expired lock is reclaimable with a new token' );
+
+echo "\n[4] Stale token release is rejected:\n";
+$assert_equals( false, $store->release_session_lock( $session_id, (string) $token_a ), 'stale token does not release reacquired lock' );
+$assert_equals( true, $store->release_session_lock( $session_id, (string) $token_c ), 'current token still releases after stale rejection' );
+
+echo "\n[5] Non-contended chat writes still work:\n";
+$messages = array(
+	array(
+		'role'    => 'user',
+		'content' => 'Hello',
+	),
+);
+$assert_equals( true, $store->update_session( $session_id, $messages, array( 'status' => 'completed' ), 'openai', 'gpt-test' ), 'session update succeeds without an active lock' );
+$session = $store->get_session( $session_id );
+$assert_equals( 1, count( $session['messages'] ?? array() ), 'non-contended update persists messages' );
+
+echo "\n";
+if ( empty( $failures ) ) {
+	echo "All Data Machine conversation transcript lock smoke tests passed ({$passes} assertions).\n";
+	exit( 0 );
+}
+
+echo sprintf( "%d failure(s):\n", count( $failures ) );
+foreach ( $failures as $failure ) {
+	echo "  - {$failure}\n";
+}
+exit( 1 );


### PR DESCRIPTION
## Summary
- Implements the canonical Agents API `ConversationTranscriptLockInterface` on Data Machine's conversation store.
- Adds persisted transcript lock columns plus token-checked acquire/release behavior for chat/session rows.
- Locks chat and continue writes to return `409` on active contention while preserving normal non-contended writes.
- Updates `automattic/agents-api` to the merged lock contract from Automattic/agents-api#82.

Fixes #1775.

## Tests
- `php tests/conversation-transcript-lock-smoke.php`
- `php tests/conversation-store-contracts-smoke.php`
- `php tests/agents-api-bootstrap-smoke.php`
- `vendor/bin/phpcs data-machine.php inc/Api/Chat/ChatOrchestrator.php inc/Core/Database/Chat/Chat.php inc/Core/Database/Chat/ConversationStoreInterface.php inc/Engine/AI/conversation-loop.php tests/Unit/Core/Database/Chat/InMemoryConversationStore.php tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php tests/agents-api-bootstrap-smoke.php tests/conversation-store-contracts-smoke.php tests/conversation-transcript-lock-smoke.php`
- `homeboy test data-machine -- --filter=ConversationStoreFactoryTest` (runs full Playground PHPUnit suite: 1205 passed, 3 skipped)
- `homeboy lint data-machine` (fails on pre-existing React/JS lint findings outside this change; changed PHP files pass PHPCS)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the lock store integration, chat orchestration wiring, focused tests, and running verification; Chris remains responsible for review and merge.