### PR TITLE
Consume Agents API loop events

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "109576b004ef61783456e27ad841e553aa59f25a"
+                "reference": "3697c0414950633fcb86a5654df07bc3de173b94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/109576b004ef61783456e27ad841e553aa59f25a",
-                "reference": "109576b004ef61783456e27ad841e553aa59f25a",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/3697c0414950633fcb86a5654df07bc3de173b94",
+                "reference": "3697c0414950633fcb86a5654df07bc3de173b94",
                 "shasum": ""
             },
             "require": {
@@ -31,6 +31,7 @@
                     "php tests/message-envelope-smoke.php",
                     "php tests/registry-smoke.php",
                     "php tests/execution-principal-smoke.php",
+                    "php tests/caller-context-smoke.php",
                     "php tests/authorization-smoke.php",
                     "php tests/action-policy-values-smoke.php",
                     "php tests/consent-policy-smoke.php",
@@ -45,6 +46,7 @@
                     "php tests/workspace-scope-smoke.php",
                     "php tests/compaction-item-smoke.php",
                     "php tests/conversation-runner-contracts-smoke.php",
+                    "php tests/conversation-transcript-lock-smoke.php",
                     "php tests/conversation-compaction-smoke.php",
                     "php tests/markdown-section-compaction-smoke.php",
                     "php tests/context-registry-smoke.php",
@@ -69,7 +71,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-04T15:07:00+00:00"
+            "time": "2026-05-04T19:27:48+00:00"
         },
         {
             "name": "chubes4/block-format-bridge",

--- a/docs/core-system/ai-conversation-loop.md
+++ b/docs/core-system/ai-conversation-loop.md
@@ -1,13 +1,13 @@
 # AI Conversation Loop
 
-**File**: `/inc/Engine/AI/AIConversationLoop.php`
+**File**: `/inc/Engine/AI/conversation-loop.php`
 **Since**: 0.2.0
 
 Multi-turn conversation execution engine for AI agents. Handles automatic tool execution, result feedback, and conversation completion detection for both Pipeline AI and Chat API agents.
 
 ## Purpose
 
-The `AIConversationLoop` class provides centralized multi-turn conversation management, eliminating duplicate conversation logic between Pipeline and Chat agents. It orchestrates the conversation flow, executes tools, manages turn limits, and determines when conversations are complete.
+Data Machine's `datamachine_run_conversation()` adapter provides centralized multi-turn conversation management while delegating generic turn sequencing to `AgentsAPI\AI\AgentConversationLoop`. It orchestrates Data Machine request assembly, product-specific tool execution, turn limits, transcript persistence, and completion detection for Pipeline and Chat agents.
 
 ## Architecture
 
@@ -109,16 +109,12 @@ if ($turn_count >= $max_turns && !$conversation_complete) {
 
 ### Canonical entry point
 
-All callers should use the static `AIConversationLoop::run()` entry point. It
-accepts the same arguments as `execute()` and returns the same result shape,
-but first gives a registered runtime adapter (via the `agents_api_conversation_runner`
-filter) the opportunity to short-circuit the built-in loop. See
-[Runtime Adapters](#runtime-adapters) below.
+All callers should use `DataMachine\Engine\AI\datamachine_run_conversation()`. The function builds a Data Machine turn runner and passes it to `AgentsAPI\AI\AgentConversationLoop::run()` so generic lifecycle behavior stays in Agents API while product adapters own Data Machine request and tool semantics.
 
 ```php
-use DataMachine\Engine\AI\AIConversationLoop;
+use function DataMachine\Engine\AI\datamachine_run_conversation;
 
-$result = AIConversationLoop::run(
+$result = datamachine_run_conversation(
     $messages,        // Initial conversation messages
     $tools,           // Available tools for AI
     $provider,        // AI provider (openai, anthropic, etc.)
@@ -389,64 +385,27 @@ do_action('datamachine_log', 'warning', 'AIConversationLoop: Max turns reached',
 ]);
 ```
 
-## Logging
+## Observability
 
-The conversation loop provides comprehensive logging at each stage:
-
-### Loop Start
+Generic loop lifecycle events come from the Agents API substrate. Cross-cutting observers should subscribe to the canonical `agents_api_loop_event` action instead of Data Machine-local loop conventions:
 
 ```php
-do_action('datamachine_log', 'debug', 'AIConversationLoop: Starting conversation loop', [
-    'agent_type' => $agent_type,
-    'provider' => $provider,
-    'model' => $model,
-    'initial_message_count' => count($messages),
-    'tool_count' => count($tools),
-    'max_turns' => $max_turns
-]);
+add_action(
+    'agents_api_loop_event',
+    static function ( string $event, array $payload ): void {
+        // Generic events include turn_started, completed, failed,
+        // budget_exceeded, and transcript_lock_contention.
+    },
+    10,
+    2
+);
 ```
 
-### Turn Start
+Per-run callers that need direct handling can still pass an `event_sink` in the payload. Data Machine bridges that sink to Agents API's `on_event` option so the caller receives the same generic lifecycle vocabulary for that run.
 
-```php
-do_action('datamachine_log', 'debug', 'AIConversationLoop: Turn started', [
-    'agent_type' => $agent_type,
-    'turn_count' => $turn_count,
-    'message_count' => count($messages)
-]);
-```
+Data Machine-specific observability remains product-specific. Request metadata such as `request_built`, AI request failures, duplicate tool-call prevention, and Data Machine tool execution details continue to use Data Machine's event sink or `datamachine_log` rather than being forced into the generic Agents API lifecycle surface.
 
-### AI Response
-
-```php
-do_action('datamachine_log', 'debug', 'AIConversationLoop: AI returned content', [
-    'agent_type' => $agent_type,
-    'turn_count' => $turn_count,
-    'content_length' => strlen($ai_content),
-    'has_tool_calls' => !empty($tool_calls)
-]);
-```
-
-### Tool Execution
-
-```php
-do_action('datamachine_log', 'debug', 'AIConversationLoop: Processing tool calls', [
-    'agent_type' => $agent_type,
-    'turn_count' => $turn_count,
-    'tool_call_count' => count($tool_calls),
-    'tools' => array_column($tool_calls, 'name')
-]);
-```
-
-### Conversation Complete
-
-```php
-do_action('datamachine_log', 'debug', 'AIConversationLoop: Conversation complete', [
-    'agent_type' => $agent_type,
-    'turn_count' => $turn_count,
-    'final_message_count' => count($messages)
-]);
-```
+Agents API swallows observer exceptions for both `on_event` and `agents_api_loop_event`, and Data Machine's local event sink wrapper also logs sink failures without changing successful loop results.
 
 ## Best Practices
 

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -69,9 +69,9 @@ function datamachine_run_conversation(
 
 	// Mutable state accumulated across turns by the turn runner.
 	$last_request_metadata = array();
-	$last_tool_calls        = array();
-	$final_content          = '';
-	$turns_run              = 0;
+	$last_tool_calls       = array();
+	$final_content         = '';
+	$turns_run             = 0;
 	$total_usage           = array(
 		'prompt_tokens'     => 0,
 		'completion_tokens' => 0,
@@ -313,9 +313,9 @@ function datamachine_build_turn_runner(
 		}
 
 		/** @var \WordPress\AiClient\Results\DTO\GenerativeAiResult $ai_result */
-		$ai_result  = $ai_response;
-		$tool_calls = datamachine_extract_tool_calls( $ai_result );
-		$ai_content = RequestBuilder::resultText( $ai_result );
+		$ai_result       = $ai_response;
+		$tool_calls      = datamachine_extract_tool_calls( $ai_result );
+		$ai_content      = RequestBuilder::resultText( $ai_result );
 		$last_tool_calls = $tool_calls;
 		if ( '' !== $ai_content ) {
 			$final_content = $ai_content;

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -69,6 +69,9 @@ function datamachine_run_conversation(
 
 	// Mutable state accumulated across turns by the turn runner.
 	$last_request_metadata = array();
+	$last_tool_calls        = array();
+	$final_content          = '';
+	$turns_run              = 0;
 	$total_usage           = array(
 		'prompt_tokens'     => 0,
 		'completion_tokens' => 0,
@@ -104,6 +107,9 @@ function datamachine_run_conversation(
 		$base_log_context,
 		$completion_policy,
 		$last_request_metadata,
+		$last_tool_calls,
+		$final_content,
+		$turns_run,
 		$total_usage
 	);
 
@@ -155,9 +161,9 @@ function datamachine_run_conversation(
 		return array(
 			'messages'               => $messages,
 			'final_content'          => '',
-			'turn_count'             => $turn_budget->current(),
+			'turn_count'             => $turns_run,
 			'completed'              => false,
-			'last_tool_calls'        => array(),
+			'last_tool_calls'        => $last_tool_calls,
 			'tool_execution_results' => array(),
 			'error'                  => $e->getMessage(),
 			'usage'                  => $total_usage,
@@ -184,11 +190,16 @@ function datamachine_run_conversation(
 
 	$result['usage']            = $total_usage;
 	$result['request_metadata'] = $last_request_metadata;
+	$result['final_content']    = $final_content;
+	$result['turn_count']       = $turns_run;
+	$result['completed']        = 'budget_exceeded' !== ( $result['status'] ?? '' );
+	$result['last_tool_calls']  = $last_tool_calls;
 
 	// Map upstream budget_exceeded status to DM's max_turns_reached flag
 	// for backward compatibility with ChatOrchestrator response shaping.
-	if ( 'budget_exceeded' === ( $result['status'] ?? '' ) && 'conversation_turns' === ( $result['budget'] ?? '' ) ) {
+	if ( 'budget_exceeded' === ( $result['status'] ?? '' ) && in_array( $result['budget'] ?? '', array( 'conversation_turns', 'turns' ), true ) ) {
 		$result['max_turns_reached'] = true;
+		$result['completed']         = false;
 		$result['warning']           = sprintf(
 			'Maximum conversation turns (%d) reached. Response may be incomplete.',
 			$turn_budget->ceiling()
@@ -215,6 +226,9 @@ function datamachine_run_conversation(
  * @param array                                           $base_log_context       Base log context.
  * @param AgentConversationCompletionPolicyInterface       $completion_policy      Completion policy.
  * @param array                                           &$last_request_metadata Mutable request metadata.
+ * @param array                                           &$last_tool_calls        Mutable last tool calls.
+ * @param string                                          &$final_content          Mutable final assistant content.
+ * @param int                                             &$turns_run              Mutable executed turn count.
  * @param array                                           &$total_usage           Mutable usage accumulator.
  * @return callable Turn runner closure.
  */
@@ -228,6 +242,9 @@ function datamachine_build_turn_runner(
 	array $base_log_context,
 	AgentConversationCompletionPolicyInterface $completion_policy,
 	array &$last_request_metadata,
+	array &$last_tool_calls,
+	string &$final_content,
+	int &$turns_run,
 	array &$total_usage
 ): callable {
 	return static function ( array $messages, array $turn_context ) use (
@@ -240,10 +257,14 @@ function datamachine_build_turn_runner(
 		$base_log_context,
 		$completion_policy,
 		&$last_request_metadata,
+		&$last_tool_calls,
+		&$final_content,
+		&$turns_run,
 		&$total_usage
 	): array {
 		// The upstream loop provides the turn number via turn_context.
 		$turn_count = (int) ( $turn_context['turn'] ?? 1 );
+		$turns_run  = max( $turns_run, $turn_count );
 
 		// Build and dispatch AI request using centralized RequestBuilder.
 		$ai_response = RequestBuilder::build(
@@ -295,6 +316,10 @@ function datamachine_build_turn_runner(
 		$ai_result  = $ai_response;
 		$tool_calls = datamachine_extract_tool_calls( $ai_result );
 		$ai_content = RequestBuilder::resultText( $ai_result );
+		$last_tool_calls = $tool_calls;
+		if ( '' !== $ai_content ) {
+			$final_content = $ai_content;
+		}
 
 		// Accumulate token usage.
 		$token_usage                       = $ai_result->getTokenUsage();

--- a/tests/ai-loop-event-sink-smoke.php
+++ b/tests/ai-loop-event-sink-smoke.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 $GLOBALS['datamachine_event_sink_test_filters'] = array();
 $GLOBALS['datamachine_event_sink_test_logs']    = array();
+$GLOBALS['datamachine_event_sink_test_actions'] = array();
 
 if ( ! function_exists( 'add_filter' ) ) {
 	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
@@ -38,12 +39,41 @@ if ( ! function_exists( 'apply_filters' ) ) {
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( string $hook, ...$args ): void {
 		$GLOBALS['datamachine_event_sink_test_logs'][] = array_merge( array( $hook ), $args );
+
+		$callbacks = $GLOBALS['datamachine_event_sink_test_actions'][ $hook ] ?? array();
+		ksort( $callbacks );
+
+		foreach ( $callbacks as $priority_callbacks ) {
+			foreach ( $priority_callbacks as $entry ) {
+				$callback      = $entry[0];
+				$accepted_args = $entry[1];
+				$callback( ...array_slice( $args, 0, $accepted_args ) );
+			}
+		}
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['datamachine_event_sink_test_actions'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
 	}
 }
 
 if ( ! function_exists( 'wp_json_encode' ) ) {
 	function wp_json_encode( $data, int $flags = 0 ) {
 		return json_encode( $data, $flags );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $_option, $default = false ) {
+		return $default;
 	}
 }
 
@@ -105,6 +135,7 @@ function assert_loop_event_sink( bool $condition, string $label ): void {
 function reset_loop_event_sink_smoke(): void {
 	$GLOBALS['datamachine_event_sink_test_filters'] = array();
 	$GLOBALS['datamachine_event_sink_test_logs']    = array();
+	$GLOBALS['datamachine_event_sink_test_actions'] = array();
 }
 
 function loop_event_sink_event_names( LoopEventSinkSmokeCollector $sink ): array {
@@ -215,7 +246,69 @@ assert_loop_event_sink( isset( $first_request_built['payload']['request_metadata
 
 assert_loop_event_sink( ! array_key_exists( 'event_sink', LoopEventSinkSmokeTool::$last_parameters ), 'event sink object is not forwarded into tool parameters' );
 
-// 3. Failure events are emitted on AI request failure without changing the return array.
+// 3. Cross-cutting observers receive the canonical Agents API loop action.
+reset_loop_event_sink_smoke();
+$action_events  = array();
+$dispatch_count = 0;
+add_action(
+	'agents_api_loop_event',
+	static function ( string $event, array $payload ) use ( &$action_events ): void {
+		$action_events[] = array(
+			'event'   => $event,
+			'payload' => $payload,
+		);
+	},
+	10,
+	2
+);
+
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$dispatch_count ) {
+		++$dispatch_count;
+
+		if ( 1 === $dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'name'       => 'smoke_tool',
+							'parameters' => array( 'name' => 'Grace' ),
+						),
+					),
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'done through action',
+				'tool_calls' => array(),
+			),
+		);
+	}
+);
+
+$action_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'observe via action' ) ),
+	loop_event_sink_tools(),
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	array( 'job_id' => 1774 ),
+	3
+);
+
+$action_event_names = array_map( fn( array $entry ): string => $entry['event'], $action_events );
+assert_loop_event_sink( true === $action_result['completed'], 'canonical action observer does not require a per-run sink' );
+assert_loop_event_sink( in_array( 'turn_started', $action_event_names, true ), 'canonical action observer receives turn_started' );
+assert_loop_event_sink( in_array( 'completed', $action_event_names, true ), 'canonical action observer receives completed' );
+assert_loop_event_sink( ! in_array( 'request_built', $action_event_names, true ), 'Data Machine request_built event stays product-specific' );
+
+// 4. Failure events are emitted on AI request failure without changing the return array.
 reset_loop_event_sink_smoke();
 $failure_sink = new LoopEventSinkSmokeCollector();
 WpAiClientTestDouble::reset();
@@ -250,7 +343,7 @@ if ( $failed_event ) {
 	assert_loop_event_sink( true, 'failure event sink recorded events (failed event may be implicit)' );
 }
 
-// 4. Sink failures are logged and never change loop output.
+// 5. Sink failures are logged and never change loop output.
 reset_loop_event_sink_smoke();
 WpAiClientTestDouble::reset();
 WpAiClientTestDouble::set_response_callback(


### PR DESCRIPTION
## Summary
- Update `automattic/agents-api` to the main commit that includes canonical `agents_api_loop_event` lifecycle emission from Automattic/agents-api#80.
- Keep Data Machine's per-run `event_sink` bridged through Agents API `on_event`, while documenting `agents_api_loop_event` for cross-cutting observers.
- Preserve Data Machine compatibility fields on loop results and keep request/tool observability product-specific.

Fixes #1774

## Tests
- `php tests/ai-loop-event-sink-smoke.php`
- `php tests/agent-conversation-runner-request-smoke.php`
- `php vendor/automattic/agents-api/tests/conversation-loop-events-smoke.php`
- `composer lint`
- `composer test` (1204 passed, 3 skipped)

## Caveats
- One `composer test` attempt timed out during hot-machine Playground startup; a retry completed successfully.
- The full test run still reports the existing non-fatal Action Scheduler bootstrap notice.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing the Data Machine loop observability paths, applying the Agents API loop event migration, updating tests/docs, and running verification. Chris remains responsible for review and merge.