### PR TITLE
Consume Agents API overflow strategy

### DIFF
--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -27,6 +27,9 @@ use DataMachine\Core\PluginSettings;
 use DataMachine\Core\FilesRepository\AgentMemory;
 use DataMachine\Core\FilesRepository\DailyMemory;
 use DataMachine\Engine\AI\RequestBuilder;
+use AgentsAPI\AI\AgentConversationCompaction;
+use AgentsAPI\AI\AgentMarkdownSectionCompactionAdapter;
+use AgentsAPI\AI\AgentMessageEnvelope;
 
 class DailyMemoryTask extends SystemTask {
 
@@ -416,7 +419,7 @@ class DailyMemoryTask extends SystemTask {
 		);
 		$target_size = max( 1024, $target_size );
 
-		$split = self::splitMemorySectionsForOverflow( $memory_content, $target_size, $date );
+		$split = self::planMemoryOverflowArchive( $memory_content, $target_size, $date );
 		if ( empty( $split['archived'] ) ) {
 			return null;
 		}
@@ -475,62 +478,125 @@ class DailyMemoryTask extends SystemTask {
 	}
 
 	/**
-	 * Split markdown into persistent head sections and archived tail sections.
+	 * Plan a deterministic overflow archive through Agents API compaction primitives.
 	 *
 	 * @param string $content     Full MEMORY.md content.
 	 * @param int    $target_size Target persistent size in bytes.
 	 * @param string $date        Archive date.
 	 * @return array{persistent: string, archived: string, persistent_blocks: int, archived_blocks: int}
 	 */
-	private static function splitMemorySectionsForOverflow( string $content, int $target_size, string $date ): array {
-		$blocks = preg_split( '/(?=^## .+$)/m', trim( $content ), -1, PREG_SPLIT_NO_EMPTY );
-		if ( ! is_array( $blocks ) || count( $blocks ) < 2 ) {
+	private static function planMemoryOverflowArchive( string $content, int $target_size, string $date ): array {
+		$items         = AgentMarkdownSectionCompactionAdapter::parse( $content );
+		$section_count = 0;
+		foreach ( $items as $item ) {
+			if ( AgentMarkdownSectionCompactionAdapter::TYPE_SECTION === ( $item['type'] ?? '' ) ) {
+				++$section_count;
+			}
+		}
+
+		if ( $section_count < 2 ) {
 			return array(
 				'persistent'        => $content,
 				'archived'          => '',
-				'persistent_blocks' => count( is_array( $blocks ) ? $blocks : array() ),
+				'persistent_blocks' => count( $items ),
 				'archived_blocks'   => 0,
 			);
 		}
 
-		$persistent = array();
-		$archived   = array();
-		$pointer    = sprintf(
+		$pointer         = self::buildOverflowArchivePointer( $date );
+		$retained_budget = max( 1, $target_size - strlen( $pointer ) );
+		$messages        = array();
+
+		// Agents API's overflow archive strategy archives the start of a stream.
+		// Daily Memory overflow needs tail-section archival, so project sections in
+		// reverse order and restore markdown order after Agents API chooses the cut.
+		foreach ( array_reverse( $items ) as $item ) {
+			$messages[] = AgentMessageEnvelope::text(
+				'system',
+				(string) ( $item['content'] ?? '' ),
+				array(
+					'datamachine_markdown_item' => $item,
+				)
+			);
+		}
+
+		$result = AgentConversationCompaction::compact(
+			$messages,
+			array(
+				'overflow_archive_enabled'   => true,
+				'overflow_threshold_bytes'   => 1,
+				'overflow_retained_messages' => max( 1, count( $messages ) - 1 ),
+				'overflow_retained_bytes'    => $retained_budget,
+				'overflow_stub_prefix'       => 'Daily Memory overflow archived without summarization.',
+				'preserve_tool_boundaries'   => false,
+			),
+			static function (): string {
+				throw new \RuntimeException( 'Daily Memory deterministic overflow must not invoke a summarizer.' );
+			}
+		);
+
+		$status = (string) ( $result['metadata']['compaction']['status'] ?? '' );
+		if ( AgentConversationCompaction::STATUS_ARCHIVED !== $status || empty( $result['archive_items'] ) ) {
+			return array(
+				'persistent'        => $content,
+				'archived'          => '',
+				'persistent_blocks' => count( $items ),
+				'archived_blocks'   => 0,
+			);
+		}
+
+		$archived_items   = self::markdownItemsFromCompactionMessages( $result['archive_items'] );
+		$persistent_items = self::markdownItemsFromCompactionMessages( $result['messages'] );
+
+		return array(
+			'persistent'        => rtrim( AgentMarkdownSectionCompactionAdapter::reconstruct( $persistent_items ) . $pointer ) . "\n",
+			'archived'          => AgentMarkdownSectionCompactionAdapter::reconstruct( $archived_items ),
+			'persistent_blocks' => count( $persistent_items ),
+			'archived_blocks'   => count( $archived_items ),
+		);
+	}
+
+	/**
+	 * Build the Data Machine-owned overflow archive pointer text.
+	 *
+	 * @param string $date Archive date.
+	 * @return string Pointer markdown.
+	 */
+	private static function buildOverflowArchivePointer( string $date ): string {
+		return sprintf(
 			"\n## Archived Memory Overflow\n\nOn %s, Daily Memory archived older MEMORY.md sections verbatim to `daily/%s`. Use daily memory search/read when those details are needed.\n",
 			$date,
 			str_replace( '-', '/', $date ) . '.md'
 		);
+	}
 
-		foreach ( $blocks as $index => $block ) {
-			$block = trim( $block );
-			if ( '' === $block ) {
-				continue;
+	/**
+	 * Extract original markdown items from Agents API compaction messages.
+	 *
+	 * @param array<int, array<string, mixed>> $messages Compaction messages.
+	 * @return array<int, array<string, mixed>> Markdown items in source document order.
+	 */
+	private static function markdownItemsFromCompactionMessages( array $messages ): array {
+		$items = array();
+		foreach ( $messages as $message ) {
+			$metadata = is_array( $message['metadata'] ?? null ) ? $message['metadata'] : array();
+			$item     = $metadata['datamachine_markdown_item'] ?? null;
+			if ( is_array( $item ) ) {
+				$items[] = $item;
 			}
-
-			$candidate = implode( "\n\n", array_merge( $persistent, array( $block ) ) ) . $pointer;
-			if ( 0 === $index || strlen( $candidate ) <= $target_size ) {
-				$persistent[] = $block;
-				continue;
-			}
-
-			$archived[] = $block;
 		}
 
-		if ( empty( $archived ) ) {
-			return array(
-				'persistent'        => $content,
-				'archived'          => '',
-				'persistent_blocks' => count( $persistent ),
-				'archived_blocks'   => 0,
-			);
-		}
+		usort(
+			$items,
+			static function ( array $left, array $right ): int {
+				$left_order  = (int) ( $left['metadata']['order'] ?? 0 );
+				$right_order = (int) ( $right['metadata']['order'] ?? 0 );
 
-		return array(
-			'persistent'        => rtrim( implode( "\n\n", $persistent ) . $pointer ) . "\n",
-			'archived'          => implode( "\n\n", $archived ),
-			'persistent_blocks' => count( $persistent ),
-			'archived_blocks'   => count( $archived ),
+				return $left_order <=> $right_order;
+			}
 		);
+
+		return $items;
 	}
 
 	/**

--- a/tests/daily-memory-overflow-split-smoke.php
+++ b/tests/daily-memory-overflow-split-smoke.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Pure-PHP smoke for the Daily Memory deterministic overflow split.
+ * Pure-PHP smoke for the Daily Memory deterministic overflow archive plan.
  *
  * Run with: php tests/daily-memory-overflow-split-smoke.php
  *
@@ -23,84 +23,49 @@ function dm_overflow_assert( bool $condition, string $label, array &$failures, i
 	echo "FAIL: {$label}\n";
 }
 
-/**
- * Mirrors DailyMemoryTask::splitMemorySectionsForOverflow().
- *
- * @return array{persistent: string, archived: string, persistent_blocks: int, archived_blocks: int}
- */
-function dm_overflow_split( string $content, int $target_size, string $date ): array {
-	$blocks = preg_split( '/(?=^## .+$)/m', trim( $content ), -1, PREG_SPLIT_NO_EMPTY );
-	if ( ! is_array( $blocks ) || count( $blocks ) < 2 ) {
-		return array(
-			'persistent'        => $content,
-			'archived'          => '',
-			'persistent_blocks' => count( is_array( $blocks ) ? $blocks : array() ),
-			'archived_blocks'   => 0,
-		);
-	}
-
-	$persistent = array();
-	$archived   = array();
-	$pointer    = sprintf(
-		"\n## Archived Memory Overflow\n\nOn %s, Daily Memory archived older MEMORY.md sections verbatim to `daily/%s`. Use daily memory search/read when those details are needed.\n",
-		$date,
-		str_replace( '-', '/', $date ) . '.md'
-	);
-
-	foreach ( $blocks as $index => $block ) {
-		$block = trim( $block );
-		if ( '' === $block ) {
-			continue;
-		}
-
-		$candidate = implode( "\n\n", array_merge( $persistent, array( $block ) ) ) . $pointer;
-		if ( 0 === $index || strlen( $candidate ) <= $target_size ) {
-			$persistent[] = $block;
-			continue;
-		}
-
-		$archived[] = $block;
-	}
-
-	if ( empty( $archived ) ) {
-		return array(
-			'persistent'        => $content,
-			'archived'          => '',
-			'persistent_blocks' => count( $persistent ),
-			'archived_blocks'   => 0,
-		);
-	}
-
-	return array(
-		'persistent'        => rtrim( implode( "\n\n", $persistent ) . $pointer ) . "\n",
-		'archived'          => implode( "\n\n", $archived ),
-		'persistent_blocks' => count( $persistent ),
-		'archived_blocks'   => count( $archived ),
-	);
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 }
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $_hook, callable $_callback, int $_priority = 10, int $_accepted_args = 1 ): void {}
+}
+
+require_once __DIR__ . '/agents-api-loader.php';
+datamachine_tests_require_agents_api();
+require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/SystemTask.php';
+require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/DailyMemoryTask.php';
 
 $source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/System/Tasks/DailyMemoryTask.php' );
 dm_overflow_assert( str_contains( $source, 'maybeHandleDeterministicOverflow' ), 'production task has deterministic overflow hook', $failures, $passes );
-dm_overflow_assert( str_contains( $source, 'splitMemorySectionsForOverflow' ), 'production task has section-split helper', $failures, $passes );
+dm_overflow_assert( ! str_contains( $source, 'splitMemorySectionsForOverflow' ), 'local section-split helper is removed', $failures, $passes );
+dm_overflow_assert( str_contains( $source, 'AgentConversationCompaction::compact' ), 'overflow decision is delegated to Agents API compaction', $failures, $passes );
+dm_overflow_assert( str_contains( $source, 'AgentMarkdownSectionCompactionAdapter::parse' ), 'markdown projection uses Agents API adapter', $failures, $passes );
 dm_overflow_assert( str_contains( $source, 'datamachine_daily_memory_overflow_threshold' ), 'overflow threshold is filterable', $failures, $passes );
 dm_overflow_assert( str_contains( $source, 'datamachine_daily_memory_overflow_target_size' ), 'overflow target size is filterable', $failures, $passes );
 
-$content = "# Agent Memory\n\nIntro stays.\n\n";
-for ( $i = 1; $i <= 8; $i++ ) {
-	$content .= "## Section {$i}\n\n" . str_repeat( "Line {$i} persistent or session detail.\n", 12 ) . "\n";
+$method = new ReflectionMethod( DataMachine\Engine\AI\System\Tasks\DailyMemoryTask::class, 'planMemoryOverflowArchive' );
+
+$sections = array();
+$content  = "# Agent Memory\n\nIntro stays.\n\n";
+for ( $i = 1; $i <= 90; $i++ ) {
+	$newline         = 0 === $i % 3 ? "\r\n" : "\n";
+	$sections[ $i ]  = "## Section {$i}{$newline}{$newline}" . str_repeat( "Line {$i} persistent or session detail.{$newline}", 80 ) . $newline;
+	$content        .= $sections[ $i ];
 }
 
-$split = dm_overflow_split( $content, 1400, '2026-05-01' );
+$split = $method->invoke( null, $content, 8192, '2026-05-01' );
 dm_overflow_assert( '' !== $split['archived'], 'oversized input produces archive content', $failures, $passes );
 dm_overflow_assert( str_contains( $split['persistent'], 'Archived Memory Overflow' ), 'persistent output includes archive pointer', $failures, $passes );
 dm_overflow_assert( str_contains( $split['persistent'], 'daily/2026/05/01.md' ), 'archive pointer names daily file path', $failures, $passes );
 dm_overflow_assert( str_contains( $split['persistent'], '## Section 1' ), 'persistent output keeps early sections', $failures, $passes );
-dm_overflow_assert( str_contains( $split['archived'], '## Section 8' ), 'archive output keeps later sections verbatim', $failures, $passes );
-dm_overflow_assert( ! str_contains( $split['persistent'], '## Section 8' ), 'archived sections are removed from persistent output', $failures, $passes );
+dm_overflow_assert( strlen( $content ) > 250000, '~250KB live stress input shape is covered', $failures, $passes );
+dm_overflow_assert( strlen( $split['persistent'] ) <= 8192, 'persistent output reduces to target size', $failures, $passes );
+dm_overflow_assert( str_contains( $split['archived'], $sections[90] ), 'archive output keeps later sections verbatim', $failures, $passes );
+dm_overflow_assert( ! str_contains( $split['persistent'], '## Section 90' ), 'archived tail sections are removed from persistent output', $failures, $passes );
 dm_overflow_assert( $split['persistent_blocks'] > 0, 'persistent block count reported', $failures, $passes );
 dm_overflow_assert( $split['archived_blocks'] > 0, 'archived block count reported', $failures, $passes );
 
-$small = dm_overflow_split( "## Only\n\nSmall file.\n", 1400, '2026-05-01' );
+$small = $method->invoke( null, "## Only\n\nSmall file.\n", 1400, '2026-05-01' );
 dm_overflow_assert( '' === $small['archived'], 'single-section small input does not split', $failures, $passes );
 
 echo "\n{$passes} passed, " . count( $failures ) . " failed\n";


### PR DESCRIPTION
## Summary
- Routes DailyMemoryTask's deterministic overflow fallback through Agents API compaction primitives instead of the local section-split helper.
- Keeps Data Machine responsible for MEMORY.md persistence, daily archive writes, and the archive pointer text.
- Expands overflow smoke coverage to exercise a ~250KB memory file reducing to target-size persistent output while archiving tail sections verbatim.

## Tests
- php tests/daily-memory-overflow-split-smoke.php
- php tests/daily-memory-conservation-smoke.php
- php tests/daily-memory-unconfigured-model-skip-smoke.php
- php tests/internal-message-envelope-authoring-smoke.php
- php tests/agents-api-wp-ai-client-vocabulary-smoke.php
- php -l inc/Engine/AI/System/Tasks/DailyMemoryTask.php
- php -l tests/daily-memory-overflow-split-smoke.php
- vendor/bin/phpcs inc/Engine/AI/System/Tasks/DailyMemoryTask.php tests/daily-memory-overflow-split-smoke.php
- homeboy test --changed-since origin/main --skip-lint
- homeboy test data-machine

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting issue #1708 and Agents API primitives, implementing the DailyMemoryTask migration, and updating/running smoke and full test coverage. Chris remains responsible for review and final submission.

Fixes #1708