### PR TITLE
Report bundle runtime queue drift

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -16,6 +16,7 @@ use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
 use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
+use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
 use DataMachine\Engine\Bundle\PortableSlug;
 use WP_CLI;
 
@@ -49,6 +50,9 @@ class AgentBundleCommand extends BaseCommand {
 	 *
 	 * [--yes]
 	 * : Skip confirmation.
+	 *
+	 * [--reconcile-runtime]
+	 * : Replace preserved flow runtime queues and scheduling with the bundle seed on existing bundle-owned flows.
 	 *
 	 * [--format=<format>]
 	 * : Output format.
@@ -157,7 +161,11 @@ class AgentBundleCommand extends BaseCommand {
 	 */
 	public function diff( array $args, array $assoc_args ): void {
 		$bundle = $this->load_bundle_arg( $args );
-		$plan   = $this->plan_for_bundle( $bundle, (string) ( $assoc_args['slug'] ?? '' ) )->to_array();
+		$plan   = $this->add_runtime_drift_to_plan(
+			$this->plan_for_bundle( $bundle, (string) ( $assoc_args['slug'] ?? '' ) )->to_array(),
+			$bundle,
+			(string) ( $assoc_args['slug'] ?? '' )
+		);
 		$this->output_plan( $plan, $assoc_args );
 	}
 
@@ -184,6 +192,9 @@ class AgentBundleCommand extends BaseCommand {
 	 * [--yes]
 	 * : Skip confirmation.
 	 *
+	 * [--reconcile-runtime]
+	 * : Replace preserved flow runtime queues and scheduling with the bundle seed on existing bundle-owned flows.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -194,13 +205,17 @@ class AgentBundleCommand extends BaseCommand {
 	 * ---
 	 */
 	public function upgrade( array $args, array $assoc_args ): void {
-		$bundle  = $this->load_bundle_arg( $args );
-		$slug    = (string) ( $assoc_args['slug'] ?? '' );
-		$plan    = $this->plan_for_bundle( $bundle, $slug );
-		$dry_run = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$bundle            = $this->load_bundle_arg( $args );
+		$slug              = (string) ( $assoc_args['slug'] ?? '' );
+		$plan              = $this->plan_for_bundle( $bundle, $slug );
+		$dry_run           = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$reconcile_runtime = \WP_CLI\Utils\get_flag_value( $assoc_args, 'reconcile-runtime', false );
 
 		if ( $dry_run ) {
-			$this->output_plan( $plan->to_array(), $assoc_args );
+			$this->output_plan(
+				$this->add_runtime_drift_to_plan( $plan->to_array(), $bundle, $slug, $reconcile_runtime ? 'replace_bundle_seed' : 'preserve_existing' ),
+				$assoc_args
+			);
 			return;
 		}
 
@@ -209,7 +224,7 @@ class AgentBundleCommand extends BaseCommand {
 		}
 
 		$owner_id = isset( $assoc_args['owner'] ) ? $this->resolve_user_id( $assoc_args['owner'] ) : 0;
-		$result   = $this->bundler()->import( $bundle, '' !== $slug ? $slug : null, $owner_id, false );
+		$result   = $this->bundler()->import( $bundle, '' !== $slug ? $slug : null, $owner_id, false, array( 'reconcile_runtime' => $reconcile_runtime ) );
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( (string) ( $result['error'] ?? 'Bundle upgrade failed.' ) );
 			return;
@@ -275,17 +290,97 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	private function run_install( array $args, array $assoc_args ): void {
-		$bundle  = $this->load_bundle_arg( $args );
-		$slug    = isset( $assoc_args['slug'] ) ? sanitize_title( (string) $assoc_args['slug'] ) : null;
-		$owner   = isset( $assoc_args['owner'] ) ? $this->resolve_user_id( $assoc_args['owner'] ) : 0;
-		$dry_run = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$bundle            = $this->load_bundle_arg( $args );
+		$slug              = isset( $assoc_args['slug'] ) ? sanitize_title( (string) $assoc_args['slug'] ) : null;
+		$owner             = isset( $assoc_args['owner'] ) ? $this->resolve_user_id( $assoc_args['owner'] ) : 0;
+		$dry_run           = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$reconcile_runtime = \WP_CLI\Utils\get_flag_value( $assoc_args, 'reconcile-runtime', false );
 
 		if ( ! $dry_run && ! isset( $assoc_args['yes'] ) ) {
 			WP_CLI::confirm( sprintf( 'Install agent bundle "%s"?', $this->bundle_summary( $bundle, (string) $slug )['target_slug'] ) );
 		}
 
-		$result = $this->bundler()->import( $bundle, $slug, $owner, $dry_run );
+		$result = $this->bundler()->import( $bundle, $slug, $owner, $dry_run, array( 'reconcile_runtime' => $reconcile_runtime ) );
+		$agent  = $this->resolve_bundle_agent( $bundle, (string) $slug );
+		if ( $agent ) {
+			$result['runtime_drift'] = $this->runtime_drifts_for_bundle( $bundle, $agent, $reconcile_runtime ? 'replace_bundle_seed' : 'preserve_existing' );
+		}
 		$this->output( $result, $assoc_args, array( 'success', 'message' ) );
+	}
+
+	private function add_runtime_drift_to_plan( array $plan, array $bundle, string $slug = '', string $decision = 'preserve_existing' ): array {
+		$agent = $this->resolve_bundle_agent( $bundle, $slug );
+		if ( ! $agent ) {
+			return $plan;
+		}
+
+		$drifts = $this->runtime_drifts_for_bundle( $bundle, $agent, $decision );
+		if ( empty( $drifts ) ) {
+			return $plan;
+		}
+
+		$plan['runtime_drift'] = $drifts;
+		foreach ( $drifts as $drift ) {
+			$plan['warnings'][] = $drift;
+		}
+		$plan['counts']['warnings'] = count( $plan['warnings'] ?? array() );
+
+		return $plan;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function runtime_drifts_for_bundle( array $bundle, array $agent, string $decision ): array {
+		$agent_id                   = (int) ( $agent['agent_id'] ?? 0 );
+		$pipeline_id_map            = array();
+		$existing_pipelines_by_slug = array();
+		$drifts                     = array();
+
+		foreach ( $this->pipelines()->get_all_pipelines( null, $agent_id ) as $pipeline ) {
+			$existing_pipelines_by_slug[ (string) ( $pipeline['portable_slug'] ?? '' ) ] = $pipeline;
+		}
+
+		foreach ( $bundle['pipelines'] ?? array() as $pipeline ) {
+			if ( ! is_array( $pipeline ) ) {
+				continue;
+			}
+			$slug = PortableSlug::normalize( (string) ( $pipeline['portable_slug'] ?? ( $pipeline['pipeline_name'] ?? 'pipeline' ) ), 'pipeline' );
+			if ( isset( $existing_pipelines_by_slug[ $slug ] ) ) {
+				$pipeline_id_map[ (int) ( $pipeline['original_id'] ?? 0 ) ] = (int) ( $existing_pipelines_by_slug[ $slug ]['pipeline_id'] ?? 0 );
+			}
+		}
+
+		foreach ( $bundle['flows'] ?? array() as $flow ) {
+			if ( ! is_array( $flow ) ) {
+				continue;
+			}
+			$old_pipeline_id = (int) ( $flow['original_pipeline_id'] ?? 0 );
+			$new_pipeline_id = (int) ( $pipeline_id_map[ $old_pipeline_id ] ?? 0 );
+			if ( $new_pipeline_id <= 0 ) {
+				continue;
+			}
+			$flow_slug     = PortableSlug::normalize( (string) ( $flow['portable_slug'] ?? ( $flow['flow_name'] ?? 'flow' ) ), 'flow' );
+			$existing_flow = $this->flows()->get_by_portable_slug( $new_pipeline_id, $flow_slug );
+			if ( ! $existing_flow ) {
+				continue;
+			}
+			$target_flow = array_merge(
+				$flow,
+				array(
+					'flow_config' => $this->remap_flow_step_ids(
+						is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array(),
+						$old_pipeline_id,
+						$new_pipeline_id,
+						(int) $existing_flow['flow_id']
+					),
+				)
+			);
+			$preview = AgentBundleRuntimeDrift::preview( $flow_slug, $existing_flow, $target_flow, $decision );
+			if ( null !== $preview ) {
+				$drifts[] = $preview;
+			}
+		}
+
+		return $drifts;
 	}
 
 	private function load_bundle_arg( array $args ): array {

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -374,7 +374,7 @@ class AgentBundleCommand extends BaseCommand {
 					),
 				)
 			);
-			$preview = AgentBundleRuntimeDrift::preview( $flow_slug, $existing_flow, $target_flow, $decision );
+			$preview     = AgentBundleRuntimeDrift::preview( $flow_slug, $existing_flow, $target_flow, $decision );
 			if ( null !== $preview ) {
 				$drifts[] = $preview;
 			}

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -24,6 +24,7 @@ use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleFlowFile;
 use DataMachine\Engine\Bundle\AgentBundleLegacyAdapter;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
 use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
 use DataMachine\Engine\Bundle\AgentPackageProjection;
 use DataMachine\Engine\Bundle\BundleValidationException;
@@ -444,9 +445,10 @@ class AgentBundler {
 	 * @param string|null $new_slug Optional override slug.
 	 * @param int         $owner_id WordPress user ID to own the imported agent.
 	 * @param bool        $dry_run  If true, validate without writing.
+	 * @param array       $options  Import options.
 	 * @return array{success: bool, message?: string, error?: string, summary?: array}
 	 */
-	public function import( array $bundle, ?string $new_slug = null, int $owner_id = 0, bool $dry_run = false ): array {
+	public function import( array $bundle, ?string $new_slug = null, int $owner_id = 0, bool $dry_run = false, array $options = array() ): array {
 		// Validate bundle.
 		if ( empty( $bundle['bundle_version'] ) || empty( $bundle['agent'] ) ) {
 			return array(
@@ -470,6 +472,7 @@ class AgentBundler {
 			'source_revision' => $bundle_source_revision,
 		);
 		$is_portable_bundle     = ! empty( $bundle['bundle_slug'] ) || $this->bundle_has_portable_artifacts( $bundle );
+		$reconcile_runtime     = ! empty( $options['reconcile_runtime'] );
 
 		// Check for slug collision.
 		$existing = $this->agents_repo->get_by_slug( $slug );
@@ -516,6 +519,7 @@ class AgentBundler {
 			'extension_artifacts' => count( $bundle['extension_artifacts'] ?? array() ),
 			'has_user_template'   => ! empty( $bundle['user_template'] ),
 			'upgrade'             => (bool) $existing,
+			'runtime_policy'      => $reconcile_runtime ? 'replace_bundle_seed' : 'preserve_existing',
 		);
 
 		if ( $dry_run ) {
@@ -586,6 +590,7 @@ class AgentBundler {
 
 		$artifact_records = $config['datamachine_bundle']['artifacts'];
 		$conflicts        = array();
+		$runtime_drift    = array();
 
 		// 4. Import pipelines — build old→new ID map.
 		$pipeline_id_map = array(); // old_id => new_id.
@@ -690,15 +695,28 @@ class AgentBundler {
 
 			$flow_config         = is_array( $flow_data['flow_config'] ?? null ) ? $flow_data['flow_config'] : array();
 			$existing_flow       = $this->flows_repo->get_by_portable_slug( (int) $new_pipeline_id, $portable_slug );
+			$target_flow_config  = $existing_flow
+				? $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, (int) $new_pipeline_id, (int) $existing_flow['flow_id'] )
+				: $flow_config;
 			$flow_payload_source = array_merge(
 				$flow_data,
 				array(
-					'flow_config' => $existing_flow
-						? $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, (int) $new_pipeline_id, (int) $existing_flow['flow_id'] )
-						: $flow_config,
+					'flow_config' => $target_flow_config,
 				)
 			);
 			$payload             = $this->flow_artifact_payload( $flow_payload_source, $portable_slug );
+
+			if ( $existing_flow ) {
+				$preview = AgentBundleRuntimeDrift::preview(
+					$portable_slug,
+					$existing_flow,
+					array_merge( $flow_data, array( 'flow_config' => $target_flow_config ) ),
+					$reconcile_runtime ? 'replace_bundle_seed' : 'preserve_existing'
+				);
+				if ( null !== $preview ) {
+					$runtime_drift[] = $preview;
+				}
+			}
 
 			if (
 				$existing_flow
@@ -722,14 +740,20 @@ class AgentBundler {
 			if ( $existing_flow ) {
 				$new_flow_id = (int) $existing_flow['flow_id'];
 				$flow_config = $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, (int) $new_pipeline_id, $new_flow_id );
-				$flow_config = $this->preserve_runtime_queue_fields( $flow_config, $existing_flow['flow_config'] ?? array() );
+				$flow_config = $reconcile_runtime
+					? AgentBundleRuntimeDrift::replace_runtime_queue_fields( $flow_config, $target_flow_config )
+					: $this->preserve_runtime_queue_fields( $flow_config, $existing_flow['flow_config'] ?? array() );
+				$update_data = array(
+					'flow_name'     => $flow_data['flow_name'],
+					'flow_config'   => $flow_config,
+					'portable_slug' => $portable_slug,
+				);
+				if ( $reconcile_runtime ) {
+					$update_data['scheduling_config'] = $flow_data['scheduling_config'] ?? array();
+				}
 				$this->flows_repo->update_flow(
 					$new_flow_id,
-					array(
-						'flow_name'     => $flow_data['flow_name'],
-						'flow_config'   => $flow_config,
-						'portable_slug' => $portable_slug,
-					)
+					$update_data
 				);
 			} else {
 				$new_flow_id = $this->flows_repo->create_flow( array(
@@ -838,6 +862,7 @@ class AgentBundler {
 		$summary['pipelines_imported'] = count( $pipeline_id_map );
 		$summary['flows_imported']     = $flow_count;
 		$summary['conflicts']          = $conflicts;
+		$summary['runtime_drift']      = $runtime_drift;
 
 		$config['datamachine_bundle']['artifacts'] = $artifact_records;
 		$this->agents_repo->update_agent( $agent_id, array( 'agent_config' => $config ) );

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -472,7 +472,7 @@ class AgentBundler {
 			'source_revision' => $bundle_source_revision,
 		);
 		$is_portable_bundle     = ! empty( $bundle['bundle_slug'] ) || $this->bundle_has_portable_artifacts( $bundle );
-		$reconcile_runtime     = ! empty( $options['reconcile_runtime'] );
+		$reconcile_runtime      = ! empty( $options['reconcile_runtime'] );
 
 		// Check for slug collision.
 		$existing = $this->agents_repo->get_by_slug( $slug );

--- a/inc/Engine/Bundle/AgentBundleRuntimeDrift.php
+++ b/inc/Engine/Bundle/AgentBundleRuntimeDrift.php
@@ -32,26 +32,26 @@ final class AgentBundleRuntimeDrift {
 		}
 
 		return array(
-			'artifact_key' => 'flow:' . $artifact_id,
+			'artifact_key'  => 'flow:' . $artifact_id,
 			'artifact_type' => 'flow',
-			'artifact_id' => $artifact_id,
-			'reason' => 'runtime_queue_drift',
-			'summary' => sprintf( 'flow %s: preserved runtime queue or scheduling differs from bundle seed', $artifact_id ),
-			'decision' => $decision,
-			'queue_depth' => array(
+			'artifact_id'   => $artifact_id,
+			'reason'        => 'runtime_queue_drift',
+			'summary'       => sprintf( 'flow %s: preserved runtime queue or scheduling differs from bundle seed', $artifact_id ),
+			'decision'      => $decision,
+			'queue_depth'   => array(
 				'current' => self::queue_depth( $current_flow_config ),
-				'target' => self::queue_depth( $target_flow_config ),
+				'target'  => self::queue_depth( $target_flow_config ),
 			),
-			'queue_mode' => array(
+			'queue_mode'    => array(
 				'current' => self::queue_modes( $current_flow_config ),
-				'target' => self::queue_modes( $target_flow_config ),
+				'target'  => self::queue_modes( $target_flow_config ),
 			),
-			'scheduling' => array(
+			'scheduling'    => array(
 				'current' => $current_schedule,
-				'target' => $target_schedule,
+				'target'  => $target_schedule,
 				'changed' => $scheduling_changed,
 			),
-			'steps' => $step_diffs,
+			'steps'         => $step_diffs,
 		);
 	}
 
@@ -94,8 +94,8 @@ final class AgentBundleRuntimeDrift {
 
 			$diffs[] = array(
 				'flow_step_id' => (string) $flow_step_id,
-				'current' => $current,
-				'target' => $target,
+				'current'      => $current,
+				'target'       => $target,
 			);
 		}
 
@@ -104,17 +104,17 @@ final class AgentBundleRuntimeDrift {
 
 	private static function step_runtime_preview( array $step ): array {
 		return array(
-			'queue_mode' => (string) ( $step['queue_mode'] ?? '' ),
-			'prompt_queue_depth' => self::list_depth( $step['prompt_queue'] ?? array() ),
+			'queue_mode'               => (string) ( $step['queue_mode'] ?? '' ),
+			'prompt_queue_depth'       => self::list_depth( $step['prompt_queue'] ?? array() ),
 			'config_patch_queue_depth' => self::list_depth( $step['config_patch_queue'] ?? array() ),
 		);
 	}
 
 	private static function queue_depth( array $flow_config ): array {
 		$depth = array(
-			'prompt_queue' => 0,
+			'prompt_queue'       => 0,
 			'config_patch_queue' => 0,
-			'total' => 0,
+			'total'              => 0,
 		);
 
 		foreach ( $flow_config as $step ) {
@@ -142,8 +142,8 @@ final class AgentBundleRuntimeDrift {
 
 	private static function scheduling_preview( array $scheduling ): array {
 		return array(
-			'enabled' => (bool) ( $scheduling['enabled'] ?? false ),
-			'interval' => (string) ( $scheduling['interval'] ?? 'manual' ),
+			'enabled'   => (bool) ( $scheduling['enabled'] ?? false ),
+			'interval'  => (string) ( $scheduling['interval'] ?? 'manual' ),
 			'max_items' => is_array( $scheduling['max_items'] ?? null ) ? $scheduling['max_items'] : array(),
 		);
 	}

--- a/inc/Engine/Bundle/AgentBundleRuntimeDrift.php
+++ b/inc/Engine/Bundle/AgentBundleRuntimeDrift.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Runtime drift detection for bundle-owned flows.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Compares queue and scheduling state that bundle upgrades preserve by default.
+ */
+final class AgentBundleRuntimeDrift {
+
+	private const QUEUE_FIELDS = array( 'prompt_queue', 'config_patch_queue', 'queue_mode' );
+
+	/**
+	 * Build a machine-readable drift preview for one existing flow.
+	 */
+	public static function preview( string $artifact_id, array $current_flow, array $target_flow, string $decision = 'preserve_existing' ): ?array {
+		$current_flow_config = is_array( $current_flow['flow_config'] ?? null ) ? $current_flow['flow_config'] : array();
+		$target_flow_config  = is_array( $target_flow['flow_config'] ?? null ) ? $target_flow['flow_config'] : array();
+		$current_schedule    = self::scheduling_preview( is_array( $current_flow['scheduling_config'] ?? null ) ? $current_flow['scheduling_config'] : array() );
+		$target_schedule     = self::scheduling_preview( is_array( $target_flow['scheduling_config'] ?? null ) ? $target_flow['scheduling_config'] : array() );
+		$step_diffs          = self::step_diffs( $current_flow_config, $target_flow_config );
+		$scheduling_changed  = $current_schedule !== $target_schedule;
+
+		if ( empty( $step_diffs ) && ! $scheduling_changed ) {
+			return null;
+		}
+
+		return array(
+			'artifact_key' => 'flow:' . $artifact_id,
+			'artifact_type' => 'flow',
+			'artifact_id' => $artifact_id,
+			'reason' => 'runtime_queue_drift',
+			'summary' => sprintf( 'flow %s: preserved runtime queue or scheduling differs from bundle seed', $artifact_id ),
+			'decision' => $decision,
+			'queue_depth' => array(
+				'current' => self::queue_depth( $current_flow_config ),
+				'target' => self::queue_depth( $target_flow_config ),
+			),
+			'queue_mode' => array(
+				'current' => self::queue_modes( $current_flow_config ),
+				'target' => self::queue_modes( $target_flow_config ),
+			),
+			'scheduling' => array(
+				'current' => $current_schedule,
+				'target' => $target_schedule,
+				'changed' => $scheduling_changed,
+			),
+			'steps' => $step_diffs,
+		);
+	}
+
+	/**
+	 * Replace only bundle-owned runtime queue fields on matching flow steps.
+	 */
+	public static function replace_runtime_queue_fields( array $incoming_flow_config, array $target_flow_config ): array {
+		foreach ( $incoming_flow_config as $flow_step_id => &$step ) {
+			if ( ! is_array( $step ) || ! is_array( $target_flow_config[ $flow_step_id ] ?? null ) ) {
+				continue;
+			}
+			foreach ( self::QUEUE_FIELDS as $field ) {
+				if ( array_key_exists( $field, $target_flow_config[ $flow_step_id ] ) ) {
+					$step[ $field ] = $target_flow_config[ $flow_step_id ][ $field ];
+				} else {
+					unset( $step[ $field ] );
+				}
+			}
+			unset( $step['_queue_consume_revision'] );
+		}
+		unset( $step );
+
+		return $incoming_flow_config;
+	}
+
+	private static function step_diffs( array $current_flow_config, array $target_flow_config ): array {
+		$diffs = array();
+		$ids   = array_unique( array_merge( array_keys( $current_flow_config ), array_keys( $target_flow_config ) ) );
+		sort( $ids, SORT_STRING );
+
+		foreach ( $ids as $flow_step_id ) {
+			$current_step = is_array( $current_flow_config[ $flow_step_id ] ?? null ) ? $current_flow_config[ $flow_step_id ] : array();
+			$target_step  = is_array( $target_flow_config[ $flow_step_id ] ?? null ) ? $target_flow_config[ $flow_step_id ] : array();
+			$current      = self::step_runtime_preview( $current_step );
+			$target       = self::step_runtime_preview( $target_step );
+
+			if ( $current === $target ) {
+				continue;
+			}
+
+			$diffs[] = array(
+				'flow_step_id' => (string) $flow_step_id,
+				'current' => $current,
+				'target' => $target,
+			);
+		}
+
+		return $diffs;
+	}
+
+	private static function step_runtime_preview( array $step ): array {
+		return array(
+			'queue_mode' => (string) ( $step['queue_mode'] ?? '' ),
+			'prompt_queue_depth' => self::list_depth( $step['prompt_queue'] ?? array() ),
+			'config_patch_queue_depth' => self::list_depth( $step['config_patch_queue'] ?? array() ),
+		);
+	}
+
+	private static function queue_depth( array $flow_config ): array {
+		$depth = array(
+			'prompt_queue' => 0,
+			'config_patch_queue' => 0,
+			'total' => 0,
+		);
+
+		foreach ( $flow_config as $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+			$depth['prompt_queue']       += self::list_depth( $step['prompt_queue'] ?? array() );
+			$depth['config_patch_queue'] += self::list_depth( $step['config_patch_queue'] ?? array() );
+		}
+
+		$depth['total'] = $depth['prompt_queue'] + $depth['config_patch_queue'];
+		return $depth;
+	}
+
+	private static function queue_modes( array $flow_config ): array {
+		$modes = array();
+		foreach ( $flow_config as $flow_step_id => $step ) {
+			if ( is_array( $step ) && array_key_exists( 'queue_mode', $step ) ) {
+				$modes[ (string) $flow_step_id ] = (string) $step['queue_mode'];
+			}
+		}
+		ksort( $modes, SORT_STRING );
+		return $modes;
+	}
+
+	private static function scheduling_preview( array $scheduling ): array {
+		return array(
+			'enabled' => (bool) ( $scheduling['enabled'] ?? false ),
+			'interval' => (string) ( $scheduling['interval'] ?? 'manual' ),
+			'max_items' => is_array( $scheduling['max_items'] ?? null ) ? $scheduling['max_items'] : array(),
+		);
+	}
+
+	private static function list_depth( mixed $value ): int {
+		return is_array( $value ) && array_is_list( $value ) ? count( $value ) : 0;
+	}
+}

--- a/tests/agent-bundle-runtime-drift-smoke.php
+++ b/tests/agent-bundle-runtime-drift-smoke.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Pure-PHP smoke test for bundle-preserved runtime queue drift reporting.
+ *
+ * Run with: php tests/agent-bundle-runtime-drift-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleRuntimeDrift.php';
+
+use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
+
+$failures = array();
+$passes   = 0;
+
+function agent_bundle_runtime_drift_assert( bool $condition, string $name, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+}
+
+echo "agent-bundle-runtime-drift-smoke\n";
+
+$current_flow = array(
+	'flow_config'       => array(
+		'88_fetch_2' => array(
+			'queue_mode'         => 'drain',
+			'config_patch_queue' => array(
+				array( 'patch' => array( 'max_items' => 50, 'state' => 'stale-a' ) ),
+				array( 'patch' => array( 'max_items' => 50, 'state' => 'stale-b' ) ),
+			),
+		),
+	),
+	'scheduling_config' => array(
+		'enabled'   => true,
+		'interval'  => 'hourly',
+		'max_items' => array( 'fetch' => 50 ),
+	),
+);
+
+$target_flow = array(
+	'flow_config'       => array(
+		'88_fetch_2' => array(
+			'queue_mode'         => 'loop',
+			'config_patch_queue' => array(
+				array( 'patch' => array( 'max_items' => 5, 'state' => 'reviewed' ) ),
+			),
+		),
+	),
+	'scheduling_config' => array(
+		'enabled'   => false,
+		'interval'  => 'manual',
+		'max_items' => array( 'fetch' => 5 ),
+	),
+);
+
+$preview = AgentBundleRuntimeDrift::preview( 'wordpress-com-digest', $current_flow, $target_flow, 'preserve_existing' );
+
+agent_bundle_runtime_drift_assert( is_array( $preview ), 'stale queue drift is detected', $failures, $passes );
+agent_bundle_runtime_drift_assert( 'preserve_existing' === ( $preview['decision'] ?? null ), 'default install policy preserves runtime queues', $failures, $passes );
+agent_bundle_runtime_drift_assert( 2 === ( $preview['queue_depth']['current']['config_patch_queue'] ?? null ), 'current queue depth is reported', $failures, $passes );
+agent_bundle_runtime_drift_assert( 1 === ( $preview['queue_depth']['target']['config_patch_queue'] ?? null ), 'target queue depth is reported', $failures, $passes );
+agent_bundle_runtime_drift_assert( 'drain' === ( $preview['queue_mode']['current']['88_fetch_2'] ?? null ), 'current queue mode is reported', $failures, $passes );
+agent_bundle_runtime_drift_assert( 'loop' === ( $preview['queue_mode']['target']['88_fetch_2'] ?? null ), 'target queue mode is reported', $failures, $passes );
+agent_bundle_runtime_drift_assert( true === ( $preview['scheduling']['changed'] ?? null ), 'scheduling drift is reported', $failures, $passes );
+agent_bundle_runtime_drift_assert( array( 'fetch' => 50 ) === ( $preview['scheduling']['current']['max_items'] ?? null ), 'current scheduling max_items is reported', $failures, $passes );
+agent_bundle_runtime_drift_assert( array( 'fetch' => 5 ) === ( $preview['scheduling']['target']['max_items'] ?? null ), 'target scheduling max_items is reported', $failures, $passes );
+
+$preserved_config = $current_flow['flow_config'];
+agent_bundle_runtime_drift_assert( 2 === count( $preserved_config['88_fetch_2']['config_patch_queue'] ), 'default install leaves existing queue untouched', $failures, $passes );
+
+$reconciled_config = AgentBundleRuntimeDrift::replace_runtime_queue_fields( $current_flow['flow_config'], $target_flow['flow_config'] );
+agent_bundle_runtime_drift_assert( $target_flow['flow_config']['88_fetch_2']['config_patch_queue'] === $reconciled_config['88_fetch_2']['config_patch_queue'], 'explicit reconcile applies bundle seed queue', $failures, $passes );
+agent_bundle_runtime_drift_assert( 'loop' === ( $reconciled_config['88_fetch_2']['queue_mode'] ?? null ), 'explicit reconcile applies bundle seed queue mode', $failures, $passes );
+
+$clean_preview = AgentBundleRuntimeDrift::preview(
+	'wordpress-com-digest',
+	array(
+		'flow_config'       => $reconciled_config,
+		'scheduling_config' => $target_flow['scheduling_config'],
+	),
+	$target_flow,
+	'preserve_existing'
+);
+
+agent_bundle_runtime_drift_assert( null === $clean_preview, 'second diff is clean after runtime reconciliation', $failures, $passes );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " agent bundle runtime drift assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} agent bundle runtime drift assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Report preserved flow runtime queue and scheduling drift in bundle diff previews instead of showing misleading no-op results.
- Add an explicit `--reconcile-runtime` install/upgrade policy to replace preserved queues and scheduling with the bundle seed.
- Add focused smoke coverage for drift detection, default preservation, explicit reconciliation, and clean second diff behavior.

## Testing
- `php tests/agent-bundle-runtime-drift-smoke.php`
- `php tests/agent-bundle-portable-update-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php tests/agent-bundle-installed-artifact-smoke.php`
- `php tests/agent-bundle-artifact-store-smoke.php`
- `php tests/agent-bundle-extension-artifacts-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/ai-error-status-propagation-smoke.php`
- `./vendor/bin/phpcs inc/Engine/Bundle/AgentBundleRuntimeDrift.php inc/Core/Agents/AgentBundler.php inc/Cli/Commands/AgentBundleCommand.php tests/agent-bundle-runtime-drift-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-bundle-queue-drift` passed: 1209 tests, 1206 passed, 3 skipped, 0 failed

## Notes
- Default install/upgrade behavior still preserves existing runtime queues.
- Existing ad hoc smoke harness failures in `agent-bundle-upgrade-planner-smoke.php` and `memory-bundle-policy-smoke.php` are due missing environment classes, while the full Homeboy PHPUnit suite passes.
- The related empty data packet AI failure appears separate; existing `ai-error-status-propagation-smoke.php` passes and no AI packet handling changes are included here.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris remains responsible for review and final merge decision.