### PR TITLE
Fix wp-ai-client pipeline prompt dispatch

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -65,6 +65,10 @@ class RequestBuilder {
 		$assembled          = self::assemble( $messages, $provider, $model, $tools, $mode, $payload );
 		$request            = $assembled['request'];
 		$provider_request   = ProviderRequestAssembler::toProviderRequest( $request );
+		$prompt_context     = self::wpAiClientPromptContext( $request['messages'] ?? array() );
+		if ( '' !== $prompt_context['prompt'] ) {
+			$provider_request['prompt'] = $prompt_context['prompt'];
+		}
 		$structured_tools   = $assembled['structured_tools'];
 		$applied_directives = $assembled['applied_directives'];
 		$directive_metadata = $assembled['directive_metadata'];
@@ -176,7 +180,7 @@ class RequestBuilder {
 				$model_instance->setRequestOptions( $request_options );
 			}
 
-			$builder = \wp_ai_client_prompt()
+			$builder = \wp_ai_client_prompt( $prompt_context['prompt'] )
 				->using_provider( $provider_id )
 				->using_model( $model_instance );
 
@@ -185,36 +189,12 @@ class RequestBuilder {
 				$builder = $builder->using_model_config( $model_config );
 			}
 
-			$history      = array();
-			$system_parts = array();
-			foreach ( $request['messages'] ?? array() as $message ) {
-				if ( ! is_array( $message ) ) {
-					continue;
-				}
-
-				$role    = (string) ( $message['role'] ?? '' );
-				$content = $message['content'] ?? '';
-				if ( '' === $content || array() === $content ) {
-					continue;
-				}
-
-				if ( 'system' === $role && is_string( $content ) ) {
-					$system_parts[] = $content;
-					continue;
-				}
-
-				$history_message = self::wpAiClientHistoryMessage( $message );
-				if ( null !== $history_message ) {
-					$history[] = $history_message;
-				}
+			if ( ! empty( $prompt_context['system_parts'] ) ) {
+				$builder = $builder->using_system_instruction( implode( "\n\n", $prompt_context['system_parts'] ) );
 			}
 
-			if ( ! empty( $system_parts ) ) {
-				$builder = $builder->using_system_instruction( implode( "\n\n", $system_parts ) );
-			}
-
-			if ( ! empty( $history ) ) {
-				$builder = $builder->with_history( ...$history );
+			if ( ! empty( $prompt_context['history'] ) ) {
+				$builder = $builder->with_history( ...$prompt_context['history'] );
 			}
 
 			$function_declarations = array();
@@ -289,6 +269,68 @@ class RequestBuilder {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Split Data Machine messages into wp-ai-client's current prompt + history.
+	 *
+	 * wp-ai-client requires a current prompt passed to wp_ai_client_prompt().
+	 * Supplying only with_history() makes provider dispatch fail with an empty
+	 * prompt even when Data Machine has valid user messages. The latest user
+	 * message is the current prompt; earlier conversational turns remain history.
+	 *
+	 * @param array $messages Canonical message envelopes.
+	 * @return array{prompt:string,system_parts:array<int,string>,history:array<int,\WordPress\AiClient\Messages\DTO\Message>}
+	 */
+	private static function wpAiClientPromptContext( array $messages ): array {
+		$prompt_index = null;
+		$prompt       = '';
+		$system_parts = array();
+
+		foreach ( $messages as $index => $message ) {
+			if ( ! is_array( $message ) ) {
+				continue;
+			}
+
+			$role    = (string) ( $message['role'] ?? '' );
+			$content = $message['content'] ?? '';
+			if ( '' === $content || array() === $content ) {
+				continue;
+			}
+
+			if ( 'system' === $role && is_string( $content ) ) {
+				$system_parts[] = $content;
+				continue;
+			}
+
+			if ( 'user' !== $role ) {
+				continue;
+			}
+
+			$text = self::wpAiClientMessageText( $content );
+			if ( null !== $text ) {
+				$prompt_index = $index;
+				$prompt       = $text;
+			}
+		}
+
+		$history = array();
+		foreach ( $messages as $index => $message ) {
+			if ( $index === $prompt_index || ! is_array( $message ) ) {
+				continue;
+			}
+
+			$history_message = self::wpAiClientHistoryMessage( $message );
+			if ( null !== $history_message ) {
+				$history[] = $history_message;
+			}
+		}
+
+		return array(
+			'prompt'       => $prompt,
+			'system_parts' => $system_parts,
+			'history'      => $history,
+		);
 	}
 
 	/**

--- a/tests/wp-ai-client-request-timeout-smoke.php
+++ b/tests/wp-ai-client-request-timeout-smoke.php
@@ -217,6 +217,10 @@ $result = RequestBuilder::build(
 			'role'    => 'assistant',
 			'content' => 'hi there',
 		),
+		array(
+			'role'    => 'user',
+			'content' => 'continue',
+		),
 	),
 	'openai',
 	'gpt-smoke',
@@ -239,8 +243,10 @@ assert_timeout_smoke( 240.0 === $captured_request_options?->getTimeout(), 'Data 
 assert_timeout_smoke( 30.0 === $captured_request_options?->getConnectTimeout(), 'Data Machine caps RequestOptions connect timeout at 30 seconds' );
 
 $captured_history = TimeoutPromptBuilderDouble::$captured_request['history'] ?? array();
+$captured_prompt  = TimeoutPromptBuilderDouble::$captured_request['prompt'] ?? null;
 assert_timeout_smoke( isset( $captured_history[0] ) && $captured_history[0] instanceof \WordPress\AiClient\Messages\DTO\UserMessage, 'Data Machine converts user history arrays to wp-ai-client UserMessage DTOs' );
 assert_timeout_smoke( isset( $captured_history[1] ) && $captured_history[1] instanceof \WordPress\AiClient\Messages\DTO\ModelMessage, 'Data Machine converts assistant history arrays to wp-ai-client ModelMessage DTOs' );
+assert_timeout_smoke( 'continue' === $captured_prompt, 'Data Machine passes latest user message as wp-ai-client prompt' );
 assert_timeout_smoke( 1 === ( TimeoutPromptBuilderDouble::$captured_request['curl_filter_count'] ?? null ), 'Data Machine scopes cURL low-speed settings during wp-ai-client dispatch' );
 
 assert_timeout_smoke( 0 === timeout_smoke_filter_count( 'wp_ai_client_default_request_timeout' ), 'Data Machine removes temporary wp-ai-client timeout filter after dispatch' );

--- a/tests/wp-ai-client-tool-schema-smoke.php
+++ b/tests/wp-ai-client-tool-schema-smoke.php
@@ -155,9 +155,9 @@ $assert( null !== $function_call, 'tool-call result remains a wp-ai-client Funct
 $assert( 'client/test_tool' === $function_call->getName(), 'tool-call name is read from FunctionCall DTO' );
 $assert( array( 'reason' => 'covered' ) === $function_call->getArgs(), 'tool-call args are read from FunctionCall DTO' );
 $assert( 7 === $response->getTokenUsage()->getTotalTokens(), 'token usage is read from token usage DTO' );
+$assert( 'Describe this file.' === ( $captured_request['prompt'] ?? null ), 'latest user message becomes the wp-ai-client prompt' );
 $assert( 'System directive.' === ( $captured_request['messages'][0]['content'] ?? null ), 'system instruction reaches wp-ai-client builder' );
-$assert( 'Run tool.' === ( $captured_request['messages'][1]['content'] ?? null ), 'user message reaches wp-ai-client builder' );
-$assert( is_array( $captured_request['messages'][2]['content'] ?? null ), 'multimodal message content passes through to wp-ai-client builder' );
+$assert( 'Run tool.' === ( $captured_request['messages'][1]['content'] ?? null ), 'earlier user message remains wp-ai-client history' );
 $assert( is_array( $schema ), 'legacy parameter map normalizes to a schema array' );
 $assert( 'object' === ( $schema['type'] ?? null ), 'legacy parameter map is wrapped as an object schema' );
 $assert( array( 'reason' ) === ( $schema['required'] ?? null ), 'property-level required=true is lifted to object-level required array' );


### PR DESCRIPTION
## Summary
- Pass the latest Data Machine user message as the active `wp_ai_client_prompt()` text instead of sending every user message through history.
- Keep system instructions and earlier turns mapped to wp-ai-client system/history surfaces.
- Update wp-ai-client smoke coverage to catch empty active prompt regressions.

## Why
Pipeline AI steps could build valid Data Machine messages from fetched packets, but wp-ai-client still rejected the provider request because no active prompt text was supplied. This made source-backed brain jobs fail with `Cannot generate from an empty prompt` even when the job had fetched item context.

Addresses the prompt-dispatch portion of #1783. A separate no-output/soft-skip behavior remains: after this fix, the WordPress.com MGS validation no longer fails with `ai_processing_failed`, but children that produce no writable output still finish as `empty_data_packet_returned` and make the parent batch fail.

## Testing
- `php tests/wp-ai-client-tool-schema-smoke.php`
- `php tests/wp-ai-client-request-timeout-smoke.php`
- `php -l inc/Engine/AI/RequestBuilder.php`
- Local validation on `intelligence-chubes4`: deployed branch ZIP and reran `studio wp datamachine flow run 2 --count=1 --drain --format=json`; the previous `Cannot generate from an empty prompt` failure was eliminated, but no-output children still failed as `empty_data_packet_returned`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the wp-ai-client request adapter bug, drafting the code/test changes, and running focused verification. Chris remains responsible for review and merge.