### PR TITLE
Soft-skip AI steps that produce no actionable output

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -427,7 +427,50 @@ class AIStep extends Step {
 		}
 
 		// Process loop results into data packets
-		return self::processLoopResults( $loop_result, $this->dataPackets, $payload, $available_tools );
+		$outputPackets = self::processLoopResults( $loop_result, $this->dataPackets, $payload, $available_tools );
+
+		// Soft-skip terminal: the AI loop completed without an error but
+		// produced no actionable output (no handler tool, no other tool
+		// result, no AI text content). For autonomous brain flows this is
+		// an intentional skip — the model decided the fetched packet was
+		// not worth writing — not a failure.
+		//
+		// Mark the job as agent_skipped via the engine status override so
+		// the engine routes through routeAfterExecution()'s status_override
+		// branch, completing the child cleanly and preventing parent
+		// batches from rolling these up as "All N child jobs failed".
+		//
+		// Defaults to enabled. Pipelines that genuinely need an empty AI
+		// step to fail can opt out via the filter below.
+		$soft_skip_enabled = (bool) apply_filters(
+			'datamachine_ai_step_soft_skip_on_empty_output',
+			true,
+			$this->engine,
+			$this->flow_step_config,
+			$this->job_id
+		);
+
+		if ( $soft_skip_enabled && empty( $outputPackets ) && ! empty( $this->dataPackets ) ) {
+			$this->engine->set(
+				'job_status',
+				\DataMachine\Core\JobStatus::AGENT_SKIPPED . ' - ai_step_no_actionable_output'
+			);
+
+			do_action(
+				'datamachine_log',
+				'info',
+				'AI step produced no actionable output — soft-skipping job',
+				array(
+					'job_id'        => $this->job_id,
+					'flow_step_id'  => $this->flow_step_id,
+					'turn_count'    => count( $loop_result['messages'] ?? array() ),
+					'tool_results'  => count( $loop_result['tool_execution_results'] ?? array() ),
+					'input_packets' => count( $this->dataPackets ),
+				)
+			);
+		}
+
+		return $outputPackets;
 	}
 
 	/**

--- a/tests/ai-step-soft-skip-empty-output-smoke.php
+++ b/tests/ai-step-soft-skip-empty-output-smoke.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Pure-PHP smoke test for the AI step's soft-skip terminal status.
+ *
+ * AIStep sets a `job_status` engine override of "agent_skipped - ai_step_no_actionable_output"
+ * when the AI loop completed without an error but produced no actionable output.
+ * This test asserts that ExecuteStepAbility::routeAfterExecution() routes that
+ * override through the existing status-override branch — completing the job
+ * with `agent_skipped` and NOT firing `datamachine_fail_job`.
+ *
+ * Run with: php tests/ai-step-soft-skip-empty-output-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+// Stub the FileCleanup + DirectoryManager classes the engine instantiates
+// during the status-override branch of routeAfterExecution(). The smoke does
+// not exercise filesystem cleanup; replacing the real classes keeps this a
+// pure-PHP test.
+namespace DataMachine\Core\FilesRepository {
+	class DirectoryManager {
+	}
+
+	class FileCleanup {
+		public function __construct() {
+		}
+
+		public function cleanup_job_data_packets( int $job_id, array $context ): void {
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$datamachine_action_log = array();
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( string $hook, ...$args ): void {
+			global $datamachine_action_log;
+			$datamachine_action_log[] = array(
+				'hook' => $hook,
+				'args' => $args,
+			);
+		}
+	}
+
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( string $key ): string {
+			$key = strtolower( $key );
+			return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+		}
+	}
+
+	if ( ! function_exists( 'datamachine_get_engine_data' ) ) {
+		function datamachine_get_engine_data( int $job_id ): array {
+			return array();
+		}
+	}
+
+	if ( ! function_exists( 'datamachine_get_file_context' ) ) {
+		function datamachine_get_file_context( $flow_id ): array {
+			return array(
+				'flow_id'          => $flow_id,
+				'data_packets_dir' => sys_get_temp_dir(),
+			);
+		}
+	}
+
+	require_once __DIR__ . '/../inc/Core/JobStatus.php';
+	require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
+	require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
+	require_once __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php';
+
+	use DataMachine\Abilities\Engine\ExecuteStepAbility;
+	use DataMachine\Core\Database\Jobs\Jobs;
+	use DataMachine\Core\JobStatus;
+
+	class DataMachine_Test_Jobs_For_Soft_Skip extends Jobs {
+		public array $completed = array();
+
+		public function __construct() {
+			// Skip parent constructor — bypasses $wpdb access not available in pure-PHP smoke.
+		}
+
+		public function get_job( int $job_id ): ?array {
+			return array(
+				'job_id' => $job_id,
+				'status' => 'processing',
+			);
+		}
+
+		public function complete_job( int $job_id, $status ): bool {
+			$this->completed[] = array(
+				'job_id' => $job_id,
+				'status' => (string) $status,
+			);
+			return true;
+		}
+	}
+
+	$failures = 0;
+	$total    = 0;
+
+	$assert = function ( string $label, bool $condition ) use ( &$failures, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			echo "  [PASS] {$label}\n";
+			return;
+		}
+
+		++$failures;
+		echo "  [FAIL] {$label}\n";
+	};
+
+	$actions_by_hook = function ( string $hook ) use ( &$datamachine_action_log ): array {
+		$matches = array();
+		foreach ( $datamachine_action_log as $entry ) {
+			if ( $hook === ( $entry['hook'] ?? '' ) ) {
+				$matches[] = $entry;
+			}
+		}
+
+		return $matches;
+	};
+
+	$invoke_route = function ( $status_override ) use ( &$datamachine_action_log ) {
+		$datamachine_action_log = array();
+
+		$reflection = new \ReflectionClass( ExecuteStepAbility::class );
+		$ability    = $reflection->newInstanceWithoutConstructor();
+
+		$db_jobs_property = $reflection->getProperty( 'db_jobs' );
+		$db_jobs          = new DataMachine_Test_Jobs_For_Soft_Skip();
+		$db_jobs_property->setValue( $ability, $db_jobs );
+
+		$route = $reflection->getMethod( 'routeAfterExecution' );
+
+		$result = $route->invoke(
+			$ability,
+			456,
+			'ai_step',
+			17,
+			array(
+				'pipeline_id' => 5,
+				'step_type'   => 'ai',
+			),
+			'ai',
+			'DataMachine\\Core\\Steps\\AI\\AIStep',
+			array(),
+			array( 'data' => array() ),
+			false,
+			$status_override
+		);
+
+		return array( $result, $db_jobs );
+	};
+
+	echo "=== ai-step-soft-skip-empty-output-smoke ===\n";
+
+	echo "\n[1] AI step soft-skip override completes the job as agent_skipped\n";
+	list( $result, $db_jobs ) = $invoke_route( JobStatus::AGENT_SKIPPED . ' - ai_step_no_actionable_output' );
+	$failed_jobs              = $actions_by_hook( 'datamachine_fail_job' );
+
+	$assert( 'route reports completed_override outcome', 'completed_override' === ( $result['outcome'] ?? '' ) );
+	$assert( 'route persists agent_skipped status to db', 1 === count( $db_jobs->completed ) );
+	$assert(
+		'persisted status carries the soft-skip reason',
+		JobStatus::AGENT_SKIPPED . ' - ai_step_no_actionable_output' === ( $db_jobs->completed[0]['status'] ?? '' )
+	);
+	$assert( 'datamachine_fail_job is NOT emitted on soft-skip', empty( $failed_jobs ) );
+
+	echo "\n[2] No override still routes to the existing empty-packet failure path\n";
+	list( $result, $db_jobs ) = $invoke_route( null );
+	$failed_jobs              = $actions_by_hook( 'datamachine_fail_job' );
+	$last_failure             = end( $failed_jobs );
+	$failure_reason           = is_array( $last_failure ) ? ( $last_failure['args'][2]['reason'] ?? '' ) : '';
+
+	$assert( 'no override still fails on empty AI packet', 'failed' === ( $result['outcome'] ?? '' ) );
+	$assert( 'no override still emits a single fail-job action', 1 === count( $failed_jobs ) );
+	$assert( 'no override preserves empty_data_packet_returned reason', 'empty_data_packet_returned' === $failure_reason );
+
+	if ( $failures > 0 ) {
+		echo "\n=== ai-step-soft-skip-empty-output-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";
+		exit( 1 );
+	}
+
+	echo "\n=== ai-step-soft-skip-empty-output-smoke: ALL PASS ({$total} assertions) ===\n";
+}


### PR DESCRIPTION
## Summary
- When the AI step's conversation loop completes without an error but emits no actionable output (no handler tool, no other tool result, no AI text content), set a `job_status` engine override of `agent_skipped - ai_step_no_actionable_output` instead of falling through to a generic empty-packet failure.
- Engine routing then completes that child via the existing status-override branch, so parent batches no longer roll those children up as `failed - All N child jobs failed`.
- The new behavior is gated by a `datamachine_ai_step_soft_skip_on_empty_output` filter (default true) so any pipeline that genuinely needs a hard-fail on empty AI output can opt out without re-pinning the old behavior in core.

## Why
For autonomous brain pipelines, the dominant outcome of any source search is: most fetched items don't deserve a wiki page. The pipeline's own system prompt says "skip irrelevant, too-thin, or transient chatter instead of writing filler." Today, every one of those skips renders as `failed - empty_data_packet_returned`, trips parent batches into `failed`, and discourages enabling additional source lanes.

This change makes the model's intended skip path the operational skip path.

Fixes #1789.

## Testing
- `php tests/ai-step-soft-skip-empty-output-smoke.php` (new) — asserts the override completes the job as `agent_skipped`, persists the soft-skip reason, and does NOT emit `datamachine_fail_job`. Also asserts the no-override path still fails with `empty_data_packet_returned`.
- `php tests/ai-error-status-propagation-smoke.php` — existing AI failure status propagation still passes.
- `php tests/wp-ai-client-tool-schema-smoke.php`
- `php tests/wp-ai-client-request-timeout-smoke.php`
- `php -l inc/Core/Steps/AI/AIStep.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Locating the empty-packet fail path, designing the override-based soft-skip, drafting the AIStep change and the new smoke test, and running focused verification. Chris remains responsible for review and merge.