### PR TITLE
Preserve job data when retry is pending

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -590,12 +590,23 @@ class ExecuteStepAbility {
 		}
 
 		// Non-fetch steps: empty data packet is an actual failure.
-		$already_failed_status = $this->getAlreadyFailedJobStatus( $job_id );
-		if ( null !== $already_failed_status ) {
+		// Some steps (notably AIStep) call datamachine_fail_job with a precise
+		// reason and then return no packets. The defensive check here covers
+		// two shapes:
+		//   - The step's failure was finalized → status starts with `failed`.
+		//   - The step's failure was caught by JobRetryPolicy, which parked the
+		//     job back to `pending` and scheduled a retry via Action Scheduler.
+		// In both cases the per-step failure has already been routed; firing
+		// `datamachine_fail_job` again here would double-record the failure
+		// and (when the second reason is non-retryable) trigger
+		// `cleanup_job_data_packets` even though a retry is still pending,
+		// orphaning the next attempt with no input data.
+		$prior_status = $this->getPriorTerminalStatus( $job_id );
+		if ( null !== $prior_status ) {
 			do_action(
 				'datamachine_log',
 				'debug',
-				'Step returned no data after job was already marked failed',
+				'Step returned no data after job was already marked failed or rescheduled for retry',
 				array(
 					'job_id'       => $job_id,
 					'pipeline_id'  => $pipeline_id,
@@ -603,7 +614,7 @@ class ExecuteStepAbility {
 					'flow_step_id' => $flow_step_id,
 					'step_class'   => $step_class,
 					'step_type'    => $step_type,
-					'job_status'   => $already_failed_status,
+					'job_status'   => $prior_status,
 				)
 			);
 
@@ -611,7 +622,7 @@ class ExecuteStepAbility {
 				'success'      => true,
 				'step_success' => false,
 				'outcome'      => 'failed',
-				'error'        => $already_failed_status,
+				'error'        => $prior_status,
 			);
 		}
 
@@ -647,16 +658,22 @@ class ExecuteStepAbility {
 	}
 
 	/**
-	 * Return the persisted failure status when the step itself already failed the job.
+	 * Return a status marker when the step's prior failure is already routed.
 	 *
-	 * Some steps, notably AIStep, call datamachine_fail_job with a precise failure
-	 * reason and then return no packets. Do not reclassify that empty packet list as
-	 * a generic execution failure.
+	 * Some steps, notably AIStep, call datamachine_fail_job with a precise
+	 * failure reason and then return no packets. Do not reclassify that empty
+	 * packet list as a generic execution failure.
+	 *
+	 * Returns the persisted status string when:
+	 *   - The job is already in a `failed` status (terminal failure routed).
+	 *   - The job is in `pending` status with a future-dated retry recorded in
+	 *     engine_data['retry']['next_retry_at'] — i.e. JobRetryPolicy already
+	 *     accepted ownership of this failure and parked the job for retry.
 	 *
 	 * @param int $job_id Job ID.
-	 * @return string|null Persisted failed status, or null when the job has not already failed.
+	 * @return string|null Status marker, or null when no prior route exists.
 	 */
-	private function getAlreadyFailedJobStatus( int $job_id ): ?string {
+	private function getPriorTerminalStatus( int $job_id ): ?string {
 		if ( ! isset( $this->db_jobs ) ) {
 			return null;
 		}
@@ -671,7 +688,37 @@ class ExecuteStepAbility {
 			return null;
 		}
 
-		return JobStatus::isStatusFailure( $status ) ? $status : null;
+		if ( JobStatus::isStatusFailure( $status ) ) {
+			return $status;
+		}
+
+		if ( JobStatus::PENDING === JobStatus::fromString( $status )->getBaseStatus() && $this->hasPendingRetry( $job_id ) ) {
+			return $status;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check whether the job has a future-dated retry recorded in engine_data.
+	 *
+	 * `JobRetryPolicy::recordRetry` writes `engine_data['retry']['next_retry_at']`
+	 * as an ISO 8601 timestamp when scheduling a retry. Treat any non-empty value
+	 * here as authoritative — the scheduler may not have fired yet, but the policy
+	 * has already taken ownership of the failure path.
+	 *
+	 * @param int $job_id Job ID.
+	 * @return bool
+	 */
+	private function hasPendingRetry( int $job_id ): bool {
+		if ( ! function_exists( 'datamachine_get_engine_data' ) ) {
+			return false;
+		}
+
+		$engine_data = datamachine_get_engine_data( $job_id );
+		$retry       = is_array( $engine_data['retry'] ?? null ) ? $engine_data['retry'] : array();
+
+		return ! empty( $retry['next_retry_at'] );
 	}
 
 	/**

--- a/inc/Engine/Actions/Handlers/FailJobHandler.php
+++ b/inc/Engine/Actions/Handlers/FailJobHandler.php
@@ -131,10 +131,18 @@ class FailJobHandler {
 		$db_processed_items->delete_processed_items( array( 'job_id' => $job_id ) );
 		self::releaseInFlightSourceClaims( $db_processed_items, $job_id, $engine_data );
 
-		$cleanup_files = \DataMachine\Core\PluginSettings::get( 'cleanup_job_data_on_failure', true );
-		$files_cleaned = false;
+		$cleanup_files          = \DataMachine\Core\PluginSettings::get( 'cleanup_job_data_on_failure', true );
+		$files_cleaned          = false;
+		$retry_pending          = self::hasPendingRetry( $engine_data );
 
-		if ( $cleanup_files ) {
+		// Skip cleanup whenever a retry is already scheduled for this job.
+		// JobRetryPolicy::recordRetry writes the next_retry_at timestamp before
+		// rescheduling the next Action Scheduler attempt; deleting the packet
+		// file before that retry runs would orphan the next attempt with no
+		// input data. This is defense-in-depth on top of the duplicate-fail-job
+		// guard in ExecuteStepAbility — even if a future caller fires fail-job
+		// during a pending retry, the data file survives until retry exhausts.
+		if ( $cleanup_files && ! $retry_pending ) {
 			$job = $db_jobs->get_job( $job_id );
 			if ( $job && function_exists( 'datamachine_get_file_context' ) && ! empty( $job['flow_id'] ) ) {
 				$cleanup       = new \DataMachine\Core\FilesRepository\FileCleanup();
@@ -156,10 +164,28 @@ class FailJobHandler {
 				'processed_items_cleaned' => true,
 				'files_cleanup_enabled'   => $cleanup_files,
 				'files_cleaned'           => $files_cleaned,
+				'retry_pending'           => $retry_pending,
 			)
 		);
 
 		return true;
+	}
+
+	/**
+	 * Detect whether the engine snapshot already reflects a scheduled retry.
+	 *
+	 * `JobRetryPolicy::recordRetry` stamps `engine_data['retry']['next_retry_at']`
+	 * before rescheduling the next attempt. Any non-empty value means the policy
+	 * has taken ownership of the failure path — finalizing the failure here would
+	 * race ahead of that retry and (when cleanup is enabled) orphan the rescheduled
+	 * attempt with no input data.
+	 *
+	 * @param array $engine_data Engine snapshot read prior to fail finalization.
+	 * @return bool
+	 */
+	private static function hasPendingRetry( array $engine_data ): bool {
+		$retry = is_array( $engine_data['retry'] ?? null ) ? $engine_data['retry'] : array();
+		return ! empty( $retry['next_retry_at'] );
 	}
 
 	/**

--- a/tests/ai-error-status-propagation-smoke.php
+++ b/tests/ai-error-status-propagation-smoke.php
@@ -34,6 +34,15 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+$datamachine_test_engine_data = array();
+
+if ( ! function_exists( 'datamachine_get_engine_data' ) ) {
+	function datamachine_get_engine_data( int $job_id ): array {
+		global $datamachine_test_engine_data;
+		return $datamachine_test_engine_data[ $job_id ] ?? array();
+	}
+}
+
 require_once __DIR__ . '/../inc/Core/JobStatus.php';
 require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
@@ -128,11 +137,14 @@ $invoke_empty_ai_route = function ( string $status ) use ( $build_ability ): arr
 
 echo "=== ai-error-status-propagation-smoke ===\n";
 
+$short_circuit_message = 'Step returned no data after job was already marked failed or rescheduled for retry';
+
 echo "\n[1] explicit AI failure is not reclassified as empty packets\n";
-$datamachine_action_log = datamachine_empty_action_log();
-$result                 = $invoke_empty_ai_route( 'failed - ai_processing_failed' );
-$failed_jobs            = $actions_by_hook( 'datamachine_fail_job' );
-$debug_logs             = $logs_with_message( 'Step returned no data after job was already marked failed' );
+$datamachine_action_log       = datamachine_empty_action_log();
+$datamachine_test_engine_data = array();
+$result                       = $invoke_empty_ai_route( 'failed - ai_processing_failed' );
+$failed_jobs                  = $actions_by_hook( 'datamachine_fail_job' );
+$debug_logs                   = $logs_with_message( $short_circuit_message );
 
 $assert( 'route still reports failed outcome', 'failed' === ( $result['outcome'] ?? '' ) );
 $assert( 'route preserves persisted AI failure status as error', 'failed - ai_processing_failed' === ( $result['error'] ?? '' ) );
@@ -140,15 +152,47 @@ $assert( 'generic fail-job action is not emitted again', empty( $failed_jobs ) )
 $assert( 'debug log records already-failed short circuit', 1 === count( $debug_logs ) );
 
 echo "\n[2] ordinary empty AI packet failures still use existing generic path\n";
-$datamachine_action_log = datamachine_empty_action_log();
-$result                 = $invoke_empty_ai_route( 'processing' );
-$failed_jobs            = $actions_by_hook( 'datamachine_fail_job' );
-$last_failure           = end( $failed_jobs );
-$failure_reason         = is_array( $last_failure ) ? ( $last_failure['args'][2]['reason'] ?? '' ) : '';
+$datamachine_action_log       = datamachine_empty_action_log();
+$datamachine_test_engine_data = array();
+$result                       = $invoke_empty_ai_route( 'processing' );
+$failed_jobs                  = $actions_by_hook( 'datamachine_fail_job' );
+$last_failure                 = end( $failed_jobs );
+$failure_reason               = is_array( $last_failure ) ? ( $last_failure['args'][2]['reason'] ?? '' ) : '';
 
 $assert( 'ordinary empty packet route still fails', 'failed' === ( $result['outcome'] ?? '' ) );
 $assert( 'ordinary empty packet still emits fail-job action', 1 === count( $failed_jobs ) );
 $assert( 'ordinary empty packet reason remains empty_data_packet_returned', 'empty_data_packet_returned' === $failure_reason );
+
+echo "\n[3] pending-status job with a scheduled retry short-circuits without re-firing fail-job\n";
+$datamachine_action_log       = datamachine_empty_action_log();
+$datamachine_test_engine_data = array(
+	123 => array(
+		'retry' => array(
+			'attempts'      => 1,
+			'next_retry_at' => gmdate( 'c', time() + 60 ),
+		),
+	),
+);
+$result      = $invoke_empty_ai_route( 'pending' );
+$failed_jobs = $actions_by_hook( 'datamachine_fail_job' );
+$debug_logs  = $logs_with_message( $short_circuit_message );
+
+$assert( 'pending+retry route reports failed outcome', 'failed' === ( $result['outcome'] ?? '' ) );
+$assert( 'pending+retry route surfaces pending status as error marker', 'pending' === ( $result['error'] ?? '' ) );
+$assert( 'pending+retry route does NOT emit a second fail-job action', empty( $failed_jobs ) );
+$assert( 'pending+retry route logs the short-circuit message', 1 === count( $debug_logs ) );
+
+echo "\n[4] pending-status job WITHOUT retry metadata still falls through to fail-job\n";
+$datamachine_action_log       = datamachine_empty_action_log();
+$datamachine_test_engine_data = array();
+$result                       = $invoke_empty_ai_route( 'pending' );
+$failed_jobs                  = $actions_by_hook( 'datamachine_fail_job' );
+$last_failure                 = end( $failed_jobs );
+$failure_reason               = is_array( $last_failure ) ? ( $last_failure['args'][2]['reason'] ?? '' ) : '';
+
+$assert( 'pending without retry still fails through generic path', 'failed' === ( $result['outcome'] ?? '' ) );
+$assert( 'pending without retry still emits fail-job action', 1 === count( $failed_jobs ) );
+$assert( 'pending without retry reason is empty_data_packet_returned', 'empty_data_packet_returned' === $failure_reason );
 
 if ( $failures > 0 ) {
 	echo "\n=== ai-error-status-propagation-smoke: {$failures} FAILURE(S) / {$total} assertions ===\n";


### PR DESCRIPTION
## Summary
- In \`ExecuteStepAbility::routeAfterExecution\`, treat \`pending\` jobs that have \`engine_data['retry']['next_retry_at']\` set as already-routed failures, alongside the existing \`failed - *\` short-circuit. Renames the helper to \`getPriorTerminalStatus\` and adds \`hasPendingRetry()\`.
- In \`FailJobHandler\`, skip \`cleanup_job_data_packets\` whenever the engine snapshot already shows a scheduled retry — defense-in-depth so any future caller cannot inadvertently delete the input data file out from under a pending retry.
- Extend \`tests/ai-error-status-propagation-smoke.php\` with two new cases covering the pending+retry short-circuit and the regression guard for pending-without-retry.

## Why
Validating the WordPress.com brain’s MGS flow on \`intelligence-chubes4\` surfaced a runtime where every retry exhausted into \`Cannot generate from an empty prompt\` even though the original failure was a transient cURL timeout. Tracing the actual log stream and on-disk \`data.json\` files exposed the real bug:

1. AIStep’s wp-ai-client call fails with a transient transport error (e.g. cURL 28 timeout).
2. \`do_action('datamachine_fail_job', 'ai_processing_failed', …)\` runs. \`JobRetryPolicy::maybeRetry\` accepts ownership: it stamps \`engine_data['retry']['next_retry_at']\`, sets the job status to \`pending\`, and schedules the next attempt via Action Scheduler.
3. AIStep returns \`array()\`. \`ExecuteStepAbility::routeAfterExecution\` falls into the empty-packet branch, calls \`getAlreadyFailedJobStatus\`, which returns \`null\` because the status is \`pending\`, not \`failed\`.
4. ExecuteStepAbility fires a **second** \`datamachine_fail_job\`, this time with \`reason: empty_data_packet_returned\`. That reason has none of the retryable needles (\`timeout\`, \`429\`, \`5xx\`, etc.), so \`JobRetryPolicy::maybeRetry\` returns \`retried: false\`.
5. \`FailJobHandler\` finalizes the job and runs \`cleanup_job_data_packets\` — deleting \`wp-content/uploads/datamachine-files/pipeline-N/flow-N/jobs/job-X/data.json\` while a retry is still scheduled.
6. 60s later the retry fires, \`FileRetrieval::retrieve_data_by_job_id\` returns \`array()\`, the AI step has no input, and wp-ai-client rejects the request as \`Cannot generate from an empty prompt\`.

This change closes the cycle at both ends: the duplicate fail-job at the source (ExecuteStepAbility), and the cleanup that orphans the next attempt (FailJobHandler).

## Behavior
- **Before:** First attempt transient failure → retry scheduled → cleanup deletes data → retry sees no input → final failure with misleading \`Cannot generate from an empty prompt\`.
- **After:** First attempt transient failure → retry scheduled → data preserved → retry runs against the original packet → succeeds, soft-skips, or fails with the real reason. No more spurious \`empty_data_packet_returned\` rolling parents into \`failed - All N child jobs failed\` purely as a side effect of retry plumbing.

## Testing
- \`php tests/ai-error-status-propagation-smoke.php\` — 14 assertions, including two new cases for the pending+retry short-circuit and pending-without-retry fallthrough.
- \`php tests/wp-ai-client-tool-schema-smoke.php\` — existing wp-ai-client coverage unchanged (19 assertions).
- \`php tests/wp-ai-client-request-timeout-smoke.php\` — existing timeout coverage unchanged (15 assertions).
- \`php -l inc/Abilities/Engine/ExecuteStepAbility.php\`
- \`php -l inc/Engine/Actions/Handlers/FailJobHandler.php\`
- \`php -l tests/ai-error-status-propagation-smoke.php\`

End-to-end validation will follow on \`intelligence-chubes4\` once merged: the WordPress.com MGS flow’s retry attempts should now run against their original fetched packets and either succeed or fail with their real upstream reason (rate limit, true empty AI output, etc.) instead of the spurious empty-prompt cascade.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Tracing the empty-prompt failure across the AI step, fail-job handler, retry policy, and file cleanup; identifying the duplicate fail-job + cleanup-during-retry interaction; drafting the targeted code change and extended smoke coverage. Chris remains responsible for review and merge.