### PR TITLE
Fix flow user message updates for AI-only flows

### DIFF
--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -1090,15 +1090,26 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		// Validate step resolution BEFORE any writes (atomic: fail fast, change nothing).
-		$needs_step = null !== $user_message || null !== $handler_config;
+		// AI prompt updates target AI steps; handler config updates target handler-backed steps.
+		$message_step = $step;
+		$handler_step = $step;
 
-		if ( $needs_step && null === $step ) {
-			$resolved = $this->resolveHandlerStep( $flow_id );
-			if ( $resolved['error'] ) {
+		if ( null !== $user_message && null === $message_step ) {
+			$resolved = $this->resolveAiStep( $flow_id );
+			if ( ! empty( $resolved['error'] ) ) {
 				WP_CLI::error( $resolved['error'] );
 				return;
 			}
-			$step = $resolved['step_id'];
+			$message_step = $resolved['step_id'];
+		}
+
+		if ( null !== $handler_config && null === $handler_step ) {
+			$resolved = $this->resolveHandlerStep( $flow_id );
+			if ( ! empty( $resolved['error'] ) ) {
+				WP_CLI::error( $resolved['error'] );
+				return;
+			}
+			$handler_step = $resolved['step_id'];
 		}
 
 		// Phase 1: Flow-level updates (name, scheduling).
@@ -1141,7 +1152,7 @@ class FlowsCommand extends BaseCommand {
 			$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
 			$step_result  = $step_ability->execute(
 				array(
-					'flow_step_id' => $step,
+					'flow_step_id' => $message_step,
 					'user_message' => $user_message,
 				)
 			);
@@ -1151,7 +1162,7 @@ class FlowsCommand extends BaseCommand {
 				return;
 			}
 
-			WP_CLI::success( 'User message updated for step: ' . $step );
+			WP_CLI::success( 'User message updated for step: ' . $message_step );
 		}
 
 		if ( null !== $handler_config ) {
@@ -1169,7 +1180,7 @@ class FlowsCommand extends BaseCommand {
 			}
 
 			$step_input = array(
-				'flow_step_id'   => $step,
+				'flow_step_id'   => $handler_step,
 				'handler_config' => $unwrapped_config,
 			);
 
@@ -1186,8 +1197,70 @@ class FlowsCommand extends BaseCommand {
 			}
 
 			$updated_keys = implode( ', ', array_keys( $unwrapped_config ) );
-			WP_CLI::success( sprintf( 'Handler config updated for step %s: %s', $step, $updated_keys ) );
+			WP_CLI::success( sprintf( 'Handler config updated for step %s: %s', $handler_step, $updated_keys ) );
 		}
+	}
+
+	/**
+	 * Resolve the AI step for a flow when --step is not provided.
+	 *
+	 * @param int $flow_id Flow ID.
+	 * @return array{step_id: string|null, error: string|null}
+	 */
+	private function resolveAiStep( int $flow_id ): array {
+		global $wpdb;
+
+		$flow = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT flow_config FROM {$wpdb->prefix}datamachine_flows WHERE flow_id = %d",
+				$flow_id
+			),
+			ARRAY_A
+		);
+
+		if ( ! $flow ) {
+			return array(
+				'step_id' => null,
+				'error'   => 'Flow not found',
+			);
+		}
+
+		$flow_config = json_decode( $flow['flow_config'], true );
+		if ( empty( $flow_config ) ) {
+			return array(
+				'step_id' => null,
+				'error'   => 'Flow has no steps',
+			);
+		}
+
+		$ai_steps = array();
+		foreach ( $flow_config as $step_id => $step_data ) {
+			if ( 'ai' === ( $step_data['step_type'] ?? '' ) ) {
+				$ai_steps[] = $step_id;
+			}
+		}
+
+		if ( empty( $ai_steps ) ) {
+			return array(
+				'step_id' => null,
+				'error'   => 'Flow has no AI steps',
+			);
+		}
+
+		if ( count( $ai_steps ) > 1 ) {
+			return array(
+				'step_id' => null,
+				'error'   => sprintf(
+					'Flow has multiple AI steps. Use --step=<id> to specify. Available: %s',
+					implode( ', ', $ai_steps )
+				),
+			);
+		}
+
+		return array(
+			'step_id' => $ai_steps[0],
+			'error'   => null,
+		);
 	}
 
 	/**

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -711,7 +711,7 @@ class PipelinesCommand extends BaseCommand {
 
 			if ( null === $step_id ) {
 				$resolved = $this->resolveAiStep( $pipeline_id );
-				if ( $resolved['error'] ) {
+				if ( ! empty( $resolved['error'] ) ) {
 					WP_CLI::error( $resolved['error'] );
 					return;
 				}

--- a/tests/flow-update-set-user-message-smoke.php
+++ b/tests/flow-update-set-user-message-smoke.php
@@ -156,6 +156,91 @@ function resolve_ai_active_prompt_for_test( array $step_data ): array {
 	);
 }
 
+/**
+ * Inline reimplementation of FlowsCommand::resolveAiStep(). Used by
+ * `flow update --set-user-message` when --step is omitted.
+ */
+function resolve_ai_step_for_test( array $flow_config ): array {
+	if ( empty( $flow_config ) ) {
+		return array(
+			'step_id' => null,
+			'error'   => 'Flow has no steps',
+		);
+	}
+
+	$ai_steps = array();
+	foreach ( $flow_config as $step_id => $step_data ) {
+		if ( 'ai' === ( $step_data['step_type'] ?? '' ) ) {
+			$ai_steps[] = $step_id;
+		}
+	}
+
+	if ( empty( $ai_steps ) ) {
+		return array(
+			'step_id' => null,
+			'error'   => 'Flow has no AI steps',
+		);
+	}
+
+	if ( count( $ai_steps ) > 1 ) {
+		return array(
+			'step_id' => null,
+			'error'   => sprintf(
+				'Flow has multiple AI steps. Use --step=<id> to specify. Available: %s',
+				implode( ', ', $ai_steps )
+			),
+		);
+	}
+
+	return array(
+		'step_id' => $ai_steps[0],
+		'error'   => null,
+	);
+}
+
+/**
+ * Inline reimplementation of FlowsCommand::resolveHandlerStep(). Used by
+ * handler-config updates when --step is omitted.
+ */
+function resolve_handler_step_for_test( array $flow_config ): array {
+	if ( empty( $flow_config ) ) {
+		return array(
+			'step_id' => null,
+			'error'   => 'Flow has no steps',
+		);
+	}
+
+	$handler_steps = array();
+	foreach ( $flow_config as $step_id => $step_data ) {
+		$handler_slugs = $step_data['handler_slugs'] ?? array();
+		if ( ! empty( $handler_slugs ) ) {
+			$handler_steps[] = $step_id;
+		}
+	}
+
+	if ( empty( $handler_steps ) ) {
+		return array(
+			'step_id' => null,
+			'error'   => 'Flow has no handler steps',
+		);
+	}
+
+	if ( count( $handler_steps ) > 1 ) {
+		return array(
+			'step_id' => null,
+			'error'   => sprintf(
+				'Flow has multiple handler steps. Use --step=<id> to specify. Available: %s',
+				implode( ', ', $handler_steps )
+			),
+		);
+	}
+
+	return array(
+		'step_id' => $handler_steps[0],
+		'error'   => null,
+	);
+}
+
 $failed = 0;
 $total  = 0;
 
@@ -493,6 +578,64 @@ assert_test(
 assert_test(
 	'queue head still resolves',
 	'queue_head' === $resolved['slot'] && 'pinned' === $resolved['value']
+);
+
+// --- Case 13: --set-user-message auto-resolves an AI-only flow.
+echo "\nCase 13: --set-user-message resolves AI-only flow without handler steps\n";
+
+$ai_only_flow_config = array(
+	'19_d8270fc9-0554-4826-a7e4-0fa863f2c4c3_13' => array(
+		'step_type'       => 'ai',
+		'handler_slugs'   => array(),
+		'handler_configs' => array(),
+	),
+);
+
+$resolved_ai_only = resolve_ai_step_for_test( $ai_only_flow_config );
+
+assert_test(
+	'AI-only flow resolves the AI step id for user message updates',
+	'19_d8270fc9-0554-4826-a7e4-0fa863f2c4c3_13' === $resolved_ai_only['step_id']
+		&& null === $resolved_ai_only['error']
+);
+
+$resolved_handler_only = resolve_handler_step_for_test( $ai_only_flow_config );
+
+assert_test(
+	'handler config updates still require handler steps',
+	'Flow has no handler steps' === $resolved_handler_only['error']
+);
+
+// --- Case 14: handler resolution still picks the single handler-backed step.
+echo "\nCase 14: handler-config auto-resolution still targets handler-backed steps\n";
+
+$mixed_flow_config = array(
+	'pstep_ai_uuid_1'    => array(
+		'step_type'       => 'ai',
+		'handler_slugs'   => array(),
+		'handler_configs' => array(),
+	),
+	'pstep_fetch_uuid_1' => array(
+		'step_type'       => 'fetch',
+		'handler_slugs'   => array( 'reddit' ),
+		'handler_configs' => array( 'reddit' => array() ),
+	),
+);
+
+$resolved_handler = resolve_handler_step_for_test( $mixed_flow_config );
+
+assert_test(
+	'handler config resolver ignores AI steps and selects fetch handler step',
+	'pstep_fetch_uuid_1' === $resolved_handler['step_id']
+		&& null === $resolved_handler['error']
+);
+
+$resolved_ai = resolve_ai_step_for_test( $mixed_flow_config );
+
+assert_test(
+	'user message resolver ignores handler steps and selects AI step',
+	'pstep_ai_uuid_1' === $resolved_ai['step_id']
+		&& null === $resolved_ai['error']
 );
 
 echo "\n--- Summary ---\n";


### PR DESCRIPTION
## Summary
- Resolve `flow update --set-user-message` against AI steps instead of handler-backed steps, so AI-only flows can update their per-flow user message.
- Keep handler config auto-resolution scoped to handler-backed steps, preserving the existing requirement for handler config updates.
- Guard the pipeline `--set-system-prompt` resolver error check to avoid undefined `error` notices on success.

## Validation
- `php tests/flow-update-set-user-message-smoke.php` passed: 35 / 35.
- `php -l inc/Cli/Commands/Flows/FlowsCommand.php` passed.
- `php -l inc/Cli/Commands/PipelinesCommand.php` passed.
- `git diff --check` passed.
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-flow-user-message-ai-only` did not run tests: bootstrap failed before execution because `DataMachine\Core\Steps\Fetch\Handlers\FetchHandlerSettings` was not found in `tests/Unit/Abilities/HandlerAbilitiesTest.php`.
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-flow-user-message-ai-only` reported existing repo-wide PHPStan/WPCS findings, not isolated to the touched CLI files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the CLI step-resolution path, drafting the implementation and smoke-test updates, and running local validation. Chris remains responsible for review and final acceptance.