### PR TITLE
Fix pipeline transcript lookup

### DIFF
--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -465,6 +465,9 @@ class JobsCommand extends BaseCommand {
 		$job                   = $jobs[0];
 		$engine_data           = $job['engine_data'] ?? array();
 		$transcript_session_id = $engine_data['transcript_session_id'] ?? '';
+		if ( empty( $transcript_session_id ) ) {
+			$transcript_session_id = $this->findTranscriptSessionIdForJob( $job_id );
+		}
 
 		if ( empty( $transcript_session_id ) ) {
 			WP_CLI::error(
@@ -521,6 +524,30 @@ class JobsCommand extends BaseCommand {
 		}
 
 		$this->renderTranscriptText( $job_id, (string) $transcript_session_id, $session, $messages, $metadata );
+	}
+
+	/**
+	 * Locate a pipeline transcript by metadata for jobs created before engine_data
+	 * stored transcript_session_id.
+	 *
+	 * @param int $job_id Job ID.
+	 * @return string Transcript session ID, or empty string when none exists.
+	 */
+	private function findTranscriptSessionIdForJob( int $job_id ): string {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'datamachine_chat_sessions';
+		$like  = '%"job_id":' . $job_id . '%';
+		$row   = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT session_id FROM %i WHERE mode = %s AND metadata LIKE %s ORDER BY created_at DESC LIMIT 1',
+				$table,
+				'pipeline',
+				$like
+			)
+		);
+
+		return is_string( $row ) ? $row : '';
 	}
 
 	/**

--- a/inc/Engine/AI/ConversationManager.php
+++ b/inc/Engine/AI/ConversationManager.php
@@ -433,7 +433,7 @@ class ConversationManager {
 	private static function buildDuplicateToolCallError( string $tool_name, string $mode ): string {
 		switch ( $mode ) {
 			case 'pipeline':
-				return "DUPLICATE REJECTED: You already called {$tool_name} with these exact parameters earlier in this conversation. Do NOT call it again. Move on — call the publish handler tool now to complete this step.";
+				return "DUPLICATE REJECTED: You already called {$tool_name} with these exact parameters earlier in this conversation. Do NOT call it again. Move on to the next required pipeline action using the result you already have.";
 			case 'bridge':
 				return "DUPLICATE REJECTED: You already called {$tool_name} with these exact parameters. Do NOT call it again. Continue your response to the user using the result you already have.";
 			case 'chat':

--- a/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
+++ b/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
@@ -105,6 +105,11 @@ class DataMachinePipelineTranscriptPersister implements AgentConversationTranscr
 			return '';
 		}
 
+		$job_id = (int) ( $runtime_context['job_id'] ?? 0 );
+		if ( $job_id > 0 ) {
+			datamachine_merge_engine_data( $job_id, array( 'transcript_session_id' => $session_id ) );
+		}
+
 		do_action(
 			'datamachine_log',
 			'debug',

--- a/tests/duplicate-tool-call-mode-aware-smoke.php
+++ b/tests/duplicate-tool-call-mode-aware-smoke.php
@@ -3,8 +3,8 @@
  * Smoke tests for the mode-aware duplicate-tool-call correction message.
  *
  * Regression coverage for #1441: when a pipeline AI step double-calls a tool,
- * the correction message must instruct the model to keep going (call the
- * publish handler) rather than the chat-shaped "task is done — end the
+ * the correction message must instruct the model to keep going to the next
+ * pipeline action rather than the chat-shaped "task is done — end the
  * conversation". The chat-mode behavior must remain identical to the
  * pre-fix-1441 message so existing chat callers are unaffected.
  *
@@ -68,18 +68,22 @@ datamachine_dup_msg_assert(
 	'Explicit chat mode does NOT mention the publish handler.'
 );
 
-// --- Pipeline mode tells the AI to call the publish handler. -----------------
+// --- Pipeline mode tells the AI to continue the pipeline. --------------------
 
 $pipeline_envelope = ConversationManager::generateDuplicateToolCallMessage( 'foo', 0, 'pipeline' );
 $pipeline_error    = $extract_error( $pipeline_envelope );
 
 datamachine_dup_msg_assert(
-	str_contains( $pipeline_error, 'publish handler' ),
-	'Pipeline mode instructs the AI to call the publish handler.'
+	str_contains( $pipeline_error, 'next required pipeline action' ),
+	'Pipeline mode instructs the AI to move to the next required pipeline action.'
 );
 datamachine_dup_msg_assert(
 	! str_contains( $pipeline_error, 'end the conversation' ),
 	'Pipeline mode does NOT tell the AI to end the conversation.'
+);
+datamachine_dup_msg_assert(
+	! str_contains( $pipeline_error, 'publish handler' ),
+	'Pipeline mode does NOT assume a publish handler is configured.'
 );
 datamachine_dup_msg_assert(
 	str_contains( $pipeline_error, 'foo' ),

--- a/tests/pipeline-transcript-session-link-smoke.php
+++ b/tests/pipeline-transcript-session-link-smoke.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Source smoke coverage for pipeline transcript job linkage.
+ *
+ * Run with: php tests/pipeline-transcript-session-link-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$root      = dirname( __DIR__ );
+$persister = file_get_contents( $root . '/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php' );
+$jobs_cli  = file_get_contents( $root . '/inc/Cli/Commands/JobsCommand.php' );
+
+$failures = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	echo "FAIL: {$message}\n";
+	$failures[] = $message;
+};
+
+$assert(
+	false !== strpos( $persister, 'datamachine_merge_engine_data' )
+		&& false !== strpos( $persister, '\'transcript_session_id\' => $session_id' ),
+	'persister stores transcript_session_id on the originating job'
+);
+
+$assert(
+	false !== strpos( $jobs_cli, 'findTranscriptSessionIdForJob' ),
+	'jobs transcript command has metadata fallback for old transcript rows'
+);
+
+$assert(
+	false !== strpos( $jobs_cli, 'metadata LIKE' ) && false !== strpos( $jobs_cli, 'datamachine_chat_sessions' ),
+	'metadata fallback searches pipeline transcript rows by job_id'
+);
+
+echo "\n";
+if ( empty( $failures ) ) {
+	echo "OK: pipeline transcript session link smoke assertions passed.\n";
+	exit( 0 );
+}
+
+echo sprintf( "FAILED: %d assertion(s) failed.\n", count( $failures ) );
+exit( 1 );


### PR DESCRIPTION
## Summary
- Store pipeline transcript session IDs back onto the originating job so `jobs transcript <id>` can resolve persisted transcripts.
- Let `jobs transcript <id>` recover older transcript rows by `metadata.job_id` when `engine_data.transcript_session_id` is missing.
- Make duplicate tool-call guidance generic instead of assuming every pipeline has a publish handler.

## Testing
- `php -l inc/Core/Steps/AI/AIStep.php && php -l inc/Engine/AI/DataMachineHandlerCompletionPolicy.php && php -l inc/Engine/AI/conversation-loop.php && php -l inc/Engine/AI/DataMachinePipelineTranscriptPersister.php && php -l inc/Cli/Commands/JobsCommand.php && php -l inc/Engine/AI/ConversationManager.php`
- `php tests/agent-conversation-runtime-policy-smoke.php && php tests/duplicate-tool-call-mode-aware-smoke.php && php tests/pipeline-transcript-session-link-smoke.php`
- `./vendor/bin/phpcs inc/Cli/Commands/JobsCommand.php inc/Core/Steps/AI/AIStep.php inc/Engine/AI/ConversationManager.php inc/Engine/AI/DataMachineHandlerCompletionPolicy.php inc/Engine/AI/DataMachinePipelineTranscriptPersister.php inc/Engine/AI/conversation-loop.php tests/agent-conversation-runtime-policy-smoke.php tests/duplicate-tool-call-mode-aware-smoke.php tests/pipeline-transcript-session-link-smoke.php`

## Notes
- The GitHub issue creation workflow should use the existing AI -> publish pipeline shape. This PR intentionally does not add AI-only terminal tool support.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed transcript lookup behavior, drafted the focused runtime fix, and added smoke coverage. Chris reviewed the architecture direction and requested the terminal-tool path be removed.