### PR TITLE
Apply wp-ai-client connect timeout to cURL

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -137,7 +137,11 @@ class RequestBuilder {
 		$timeout_filter  = static function ( $default_timeout ) use ( $request_timeout ) {
 			return max( (float) $default_timeout, $request_timeout );
 		};
-		$curl_filter     = static function ( $handle ) use ( $request_timeout ) {
+		$curl_filter     = static function ( $handle ) use ( $request_timeout, $connect_timeout ) {
+			if ( defined( 'CURLOPT_CONNECTTIMEOUT' ) ) {
+				curl_setopt( $handle, CURLOPT_CONNECTTIMEOUT, (int) ceil( $connect_timeout ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_setopt -- WordPress exposes the cURL handle only through this hook.
+			}
+
 			if ( defined( 'CURLOPT_LOW_SPEED_TIME' ) ) {
 				curl_setopt( $handle, CURLOPT_LOW_SPEED_TIME, (int) ceil( $request_timeout ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_setopt -- WordPress exposes the cURL handle only through this hook.
 			}

--- a/tests/wp-ai-client-request-timeout-smoke.php
+++ b/tests/wp-ai-client-request-timeout-smoke.php
@@ -278,6 +278,10 @@ assert_timeout_smoke( isset( $captured_history[1] ) && $captured_history[1] inst
 assert_timeout_smoke( 'continue' === $captured_prompt, 'Data Machine passes latest user message as wp-ai-client prompt' );
 assert_timeout_smoke( 1 === ( TimeoutPromptBuilderDouble::$captured_request['curl_filter_count'] ?? null ), 'Data Machine scopes cURL low-speed settings during wp-ai-client dispatch' );
 
+$request_builder_source = file_get_contents( __DIR__ . '/../inc/Engine/AI/RequestBuilder.php' );
+assert_timeout_smoke( is_string( $request_builder_source ) && str_contains( $request_builder_source, 'CURLOPT_CONNECTTIMEOUT' ), 'Data Machine scopes cURL connect timeout during wp-ai-client dispatch' );
+assert_timeout_smoke( is_string( $request_builder_source ) && str_contains( $request_builder_source, 'use ( $request_timeout, $connect_timeout )' ), 'Data Machine cURL timeout hook receives request and connect timeouts' );
+
 assert_timeout_smoke( 0 === timeout_smoke_filter_count( 'wp_ai_client_default_request_timeout' ), 'Data Machine removes temporary wp-ai-client timeout filter after dispatch' );
 assert_timeout_smoke( 0 === timeout_smoke_filter_count( 'http_api_curl' ), 'Data Machine removes temporary cURL low-speed filter after dispatch' );
 


### PR DESCRIPTION
## Summary
- Applies Data Machine's resolved wp-ai-client connect timeout to WordPress HTTP's cURL handle via `CURLOPT_CONNECTTIMEOUT`.
- Keeps the existing low-speed timeout behavior unchanged.
- Extends the wp-ai-client timeout smoke test to assert that the cURL hook receives both request and connect timeouts.

## Why
PR #1796 added a connect-timeout setting/filter and propagated request options through the model and prompt builder. Local validation then showed WordPress core's `WP_AI_Client_HTTP_Client` maps only total timeout from `RequestOptions` into WP HTTP args, so the actual cURL connect timeout still needed to be applied through Data Machine's scoped `http_api_curl` hook.

## Testing
- `php tests/wp-ai-client-request-timeout-smoke.php` — 25 assertions
- `php -l inc/Engine/AI/RequestBuilder.php && php -l tests/wp-ai-client-request-timeout-smoke.php`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the follow-up patch, smoke assertion updates, and PR description; Chris remains responsible for review and testing.