### PR TITLE
Require explicit memory modes for prompt injection

### DIFF
--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -77,10 +77,13 @@ class MemoryFileRegistry {
 	 *                                        A capability string (e.g. 'manage_options') = editable only
 	 *                                        by users with that WordPress capability. Default true.
 	 *                                        Forced to false when composable is true.
-	 *     @type string[]    $modes           Execution modes where this file should be injected.
+	 *     @type string[]    $modes           Execution modes where this file is available.
 	 *                                        Array of mode slugs (e.g. 'chat', 'editor', 'pipeline',
-	 *                                        'system') or array( 'all' ) to inject everywhere.
+	 *                                        'system') or array( 'all' ) to make available everywhere.
 	 *                                        Default array( 'all' ).
+	 *     @type string      $retrieval_policy Context injection policy. Only `always` files are injected
+	 *                                        by CoreMemoryFilesDirective. Use `never` for files that exist
+	 *                                        for external/runtime projection only.
 	 *     @type bool        $composable      Whether this file is auto-generated from registered sections
 	 *                                        via SectionRegistry. Composable files are regenerated on
 	 *                                        demand and are not hand-editable. Default false.
@@ -382,10 +385,11 @@ class MemoryFileRegistry {
 	}
 
 	/**
-	 * Get all files applicable to a specific agent mode.
+	 * Get always-injected files applicable to a specific agent mode.
 	 *
 	 * Returns files that either list the mode in their `modes` array
-	 * or are registered with `['all']` (the default).
+	 * or are registered with `['all']` (the default), excluding files
+	 * whose retrieval policy says they should not be injected eagerly.
 	 *
 	 * @since 0.60.0
 	 * @since 0.68.0 Internal key renamed from contexts to modes.
@@ -403,6 +407,11 @@ class MemoryFileRegistry {
 		return array_filter(
 			self::get_resolved(),
 			function ( $meta ) use ( $mode ) {
+				$retrieval_policy = $meta['retrieval_policy'] ?? WP_Agent_Context_Injection_Policy::ALWAYS;
+				if ( ! WP_Agent_Context_Injection_Policy::is_always_injected( $retrieval_policy ) ) {
+					return false;
+				}
+
 				$modes = $meta['modes'] ?? array( self::MODE_ALL );
 				return in_array( self::MODE_ALL, $modes, true )
 					|| in_array( $mode, $modes, true );

--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -43,6 +43,14 @@ class MemoryFileRegistry {
 	const MODE_ALL = 'all';
 
 	/**
+	 * Default mode list for registered files.
+	 *
+	 * Files without explicit modes are registered and manageable, but are not
+	 * injected into AI prompts. Prompt injection must be an explicit opt-in.
+	 */
+	const MODES_NONE = array();
+
+	/**
 	 * Registered memory files.
 	 *
 	 * @var array<string, array> Filename => file metadata.
@@ -77,13 +85,13 @@ class MemoryFileRegistry {
 	 *                                        A capability string (e.g. 'manage_options') = editable only
 	 *                                        by users with that WordPress capability. Default true.
 	 *                                        Forced to false when composable is true.
-	 *     @type string[]    $modes           Execution modes where this file is available.
+	 *     @type string[]    $modes           Execution modes where this file is available for prompt injection.
 	 *                                        Array of mode slugs (e.g. 'chat', 'editor', 'pipeline',
 	 *                                        'system') or array( 'all' ) to make available everywhere.
-	 *                                        Default array( 'all' ).
+	 *                                        Default empty array: registered but never injected.
 	 *     @type string      $retrieval_policy Context injection policy. Only `always` files are injected
-	 *                                        by CoreMemoryFilesDirective. Use `never` for files that exist
-	 *                                        for external/runtime projection only.
+	 *                                        by CoreMemoryFilesDirective. Defaults to `never` when modes are
+	 *                                        omitted, otherwise `always`.
 	 *     @type bool        $composable      Whether this file is auto-generated from registered sections
 	 *                                        via SectionRegistry. Composable files are regenerated on
 	 *                                        demand and are not hand-editable. Default false.
@@ -111,12 +119,15 @@ class MemoryFileRegistry {
 			$editable = true;
 		}
 
-		// Normalize modes: array of slugs, or ['all'] (default).
-		$modes = $args['modes'] ?? array( self::MODE_ALL );
-		if ( ! is_array( $modes ) || empty( $modes ) ) {
-			$modes = array( self::MODE_ALL );
+		// Normalize modes: omitted means registered but not prompt-injected.
+		$modes = $args['modes'] ?? self::MODES_NONE;
+		if ( ! is_array( $modes ) ) {
+			$modes = self::MODES_NONE;
 		}
 		$modes = array_values( array_unique( array_map( 'sanitize_key', $modes ) ) );
+		$default_retrieval_policy = empty( $modes )
+			? WP_Agent_Context_Injection_Policy::NEVER
+			: WP_Agent_Context_Injection_Policy::ALWAYS;
 
 		// Convention path: relative path from ABSPATH for an additional copy.
 		$convention_path = isset( $args['convention_path'] ) ? ltrim( $args['convention_path'], '/' ) : '';
@@ -132,7 +143,7 @@ class MemoryFileRegistry {
 			'modes'            => $modes,
 			'label'            => $args['label'] ?? self::filename_to_label( $filename ),
 			'description'      => $args['description'] ?? '',
-			'retrieval_policy' => WP_Agent_Context_Injection_Policy::normalize( $args['retrieval_policy'] ?? WP_Agent_Context_Injection_Policy::ALWAYS ),
+			'retrieval_policy' => WP_Agent_Context_Injection_Policy::normalize( $args['retrieval_policy'] ?? $default_retrieval_policy ),
 			'authority_tier'   => $args['authority_tier'] ?? self::default_authority_tier( $layer, $filename ),
 			'provenance'       => is_array( $args['provenance'] ?? null ) ? $args['provenance'] : self::default_provenance( $filename ),
 		);
@@ -388,7 +399,7 @@ class MemoryFileRegistry {
 	 * Get always-injected files applicable to a specific agent mode.
 	 *
 	 * Returns files that either list the mode in their `modes` array
-	 * or are registered with `['all']` (the default), excluding files
+	 * or are registered with `['all']`, excluding files
 	 * whose retrieval policy says they should not be injected eagerly.
 	 *
 	 * @since 0.60.0
@@ -412,7 +423,11 @@ class MemoryFileRegistry {
 					return false;
 				}
 
-				$modes = $meta['modes'] ?? array( self::MODE_ALL );
+				$modes = $meta['modes'] ?? self::MODES_NONE;
+				if ( empty( $modes ) ) {
+					return false;
+				}
+
 				return in_array( self::MODE_ALL, $modes, true )
 					|| in_array( $mode, $modes, true );
 			}
@@ -554,7 +569,7 @@ class MemoryFileRegistry {
 				'editable'         => $source['editable'] ?? true,
 				'composable'       => (bool) ( $source['composable'] ?? false ),
 				'convention_path'  => is_string( $source['convention_path'] ?? null ) ? $source['convention_path'] : '',
-				'modes'            => is_array( $source['modes'] ?? null ) ? $source['modes'] : array( self::MODE_ALL ),
+				'modes'            => is_array( $source['modes'] ?? null ) ? $source['modes'] : self::MODES_NONE,
 				'label'            => is_string( $source['label'] ?? null ) ? $source['label'] : self::filename_to_label( $filename ),
 				'description'      => is_string( $source['description'] ?? null ) ? $source['description'] : '',
 				'retrieval_policy' => is_string( $source['retrieval_policy'] ?? null ) ? $source['retrieval_policy'] : WP_Agent_Context_Injection_Policy::ALWAYS,

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -138,6 +138,7 @@ MemoryFileRegistry::register( 'SITE.md', 10, array(
 	'layer'       => MemoryFileRegistry::LAYER_SHARED,
 	'protected'   => true,
 	'composable'  => true,
+	'modes'       => array( MemoryFileRegistry::MODE_ALL ),
 	'label'       => 'Site Context',
 	'description' => 'Auto-generated site context. Composable — extend via SectionRegistry.',
 ) );
@@ -145,6 +146,7 @@ MemoryFileRegistry::register( 'RULES.md', 15, array(
 	'layer'       => MemoryFileRegistry::LAYER_SHARED,
 	'protected'   => true,
 	'editable'    => 'manage_options',
+	'modes'       => array( MemoryFileRegistry::MODE_ALL ),
 	'label'       => 'Site Rules',
 	'description' => 'Behavioral constraints that apply to every agent. Admin-editable.',
 ) );
@@ -186,6 +188,7 @@ MemoryFileRegistry::register( 'NETWORK.md', 5, array(
 	'layer'       => MemoryFileRegistry::LAYER_NETWORK,
 	'protected'   => true,
 	'composable'  => true,
+	'modes'       => array( MemoryFileRegistry::MODE_ALL ),
 	'label'       => 'Network Context',
 	'description' => 'Auto-generated multisite network topology. Composable — extend via SectionRegistry.',
 ) );

--- a/tests/Unit/AI/Memory/MemoryPolicyResolverTest.php
+++ b/tests/Unit/AI/Memory/MemoryPolicyResolverTest.php
@@ -64,6 +64,15 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 				'modes' => array( 'chat' ),
 			)
 		);
+		MemoryFileRegistry::register(
+			'EXTERNAL_RUNTIME.md',
+			50,
+			array(
+				'layer'            => MemoryFileRegistry::LAYER_SHARED,
+				'modes'            => array( 'all' ),
+				'retrieval_policy' => \WP_Agent_Context_Injection_Policy::NEVER,
+			)
+		);
 
 		$this->resolver = new MemoryPolicyResolver();
 	}
@@ -90,6 +99,7 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'MEMORY.md', $files );
 		$this->assertArrayHasKey( 'USER.md', $files );
 		$this->assertArrayHasKey( 'CHAT_ONLY.md', $files );
+		$this->assertArrayNotHasKey( 'EXTERNAL_RUNTIME.md', $files );
 	}
 
 	public function test_registered_pipeline_context_excludes_chat_only(): void {
@@ -103,6 +113,24 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'MEMORY.md', $files );
 		$this->assertArrayHasKey( 'USER.md', $files );
 		$this->assertArrayNotHasKey( 'CHAT_ONLY.md', $files );
+		$this->assertArrayNotHasKey( 'EXTERNAL_RUNTIME.md', $files );
+	}
+
+	public function test_registered_never_retrieval_policy_is_not_injected_in_any_mode(): void {
+		$chat_files = $this->resolver->resolveRegistered(
+			array(
+				'mode' => MemoryPolicyResolver::MODE_CHAT,
+			)
+		);
+		$pipeline_files = $this->resolver->resolveRegistered(
+			array(
+				'mode' => MemoryPolicyResolver::MODE_PIPELINE,
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'EXTERNAL_RUNTIME.md', $chat_files );
+		$this->assertArrayNotHasKey( 'EXTERNAL_RUNTIME.md', $pipeline_files );
+		$this->assertArrayHasKey( 'EXTERNAL_RUNTIME.md', MemoryFileRegistry::get_all() );
 	}
 
 	public function test_registered_preserves_metadata(): void {

--- a/tests/Unit/AI/Memory/MemoryPolicyResolverTest.php
+++ b/tests/Unit/AI/Memory/MemoryPolicyResolverTest.php
@@ -68,9 +68,7 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 			'EXTERNAL_RUNTIME.md',
 			50,
 			array(
-				'layer'            => MemoryFileRegistry::LAYER_SHARED,
-				'modes'            => array( 'all' ),
-				'retrieval_policy' => \WP_Agent_Context_Injection_Policy::NEVER,
+				'layer' => MemoryFileRegistry::LAYER_SHARED,
 			)
 		);
 
@@ -116,7 +114,7 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'EXTERNAL_RUNTIME.md', $files );
 	}
 
-	public function test_registered_never_retrieval_policy_is_not_injected_in_any_mode(): void {
+	public function test_registered_file_without_modes_is_not_injected_in_any_mode(): void {
 		$chat_files = $this->resolver->resolveRegistered(
 			array(
 				'mode' => MemoryPolicyResolver::MODE_CHAT,
@@ -131,6 +129,7 @@ class MemoryPolicyResolverTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'EXTERNAL_RUNTIME.md', $chat_files );
 		$this->assertArrayNotHasKey( 'EXTERNAL_RUNTIME.md', $pipeline_files );
 		$this->assertArrayHasKey( 'EXTERNAL_RUNTIME.md', MemoryFileRegistry::get_all() );
+		$this->assertSame( \WP_Agent_Context_Injection_Policy::NEVER, MemoryFileRegistry::get_all()['EXTERNAL_RUNTIME.md']['retrieval_policy'] );
 	}
 
 	public function test_registered_preserves_metadata(): void {


### PR DESCRIPTION
## Summary
- Treat memory files without explicit `modes` as registered/manageable but not prompt-injected.
- Keep prompt injection explicit by defaulting omitted modes to `retrieval_policy: never` and filtering non-eager files from `get_for_mode()`.
- Add explicit `MODE_ALL` opt-ins for Data Machine core memory files that should remain injected, plus regression coverage for external runtime files.

## Why
`AGENTS.md` and similar convention files exist for external runtimes with filesystem/WP-CLI access, not for AI prompt memory. Previously, omitted modes defaulted to `all`, so external-only files were injected into pipeline AI requests as noise.

## Testing
- `php -l inc/Engine/AI/MemoryFileRegistry.php`
- `php -l inc/bootstrap.php`
- `php -l tests/Unit/AI/Memory/MemoryPolicyResolverTest.php`
- `homeboy test data-machine` currently fails one unrelated existing test: `DataMachine\\Tests\\Unit\\Abilities\\ImageGenerationPromptRefinementTest::test_refine_prompt_includes_post_context_when_provided` expects `Article context:` but receives an empty string. The memory policy tests passed in the full run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause tracing, implementation, and test updates; Chris reviewed the architecture and directed the explicit opt-in behavior.