### PR TITLE
fix(test): inspect wp-ai-client prompt slot in refinement context test

### DIFF
--- a/tests/Unit/Abilities/ImageGenerationPromptRefinementTest.php
+++ b/tests/Unit/Abilities/ImageGenerationPromptRefinementTest.php
@@ -151,12 +151,17 @@ class ImageGenerationPromptRefinementTest extends WP_UnitTestCase {
 		ImageGenerationAbilities::refine_prompt( 'Crane meaning', 'This article explores the spiritual symbolism of cranes in various cultures.' );
 
 		$this->assertNotNull( $captured_request );
-		// Directives prepend messages, so find the last user message (our refinement request).
-		$user_message = '';
-		foreach ( array_reverse( $captured_request['messages'] ) as $msg ) {
-			if ( ( $msg['role'] ?? '' ) === 'user' ) {
-				$user_message = $msg['content'] ?? '';
-				break;
+		// `RequestBuilder::wpAiClientPromptContext()` lifts the latest user
+		// message into wp-ai-client's `prompt` slot and routes earlier turns
+		// through `with_history()`. Search both surfaces so the assertion
+		// stays true regardless of how many user messages were sent.
+		$user_message = (string) ( $captured_request['prompt'] ?? '' );
+		if ( '' === $user_message || ! str_contains( $user_message, 'Article context:' ) ) {
+			foreach ( array_reverse( $captured_request['messages'] ) as $msg ) {
+				if ( ( $msg['role'] ?? '' ) === 'user' ) {
+					$user_message = $msg['content'] ?? '';
+					break;
+				}
 			}
 		}
 		$this->assertStringContainsString( 'Article context:', $user_message );


### PR DESCRIPTION
## Summary

`ImageGenerationPromptRefinementTest::test_refine_prompt_includes_post_context_when_provided` was failing on `main`.

The assertion walked `$captured_request['messages']` looking for the user message it had just sent. As of #1784 / #1791, `RequestBuilder::wpAiClientPromptContext()` lifts the latest user message into wp-ai-client's `$request['prompt']` slot and routes earlier turns through `with_history()`. `refine_prompt()` only sends a single user message, so it lands in `prompt` and never appears in `messages` — the assertion was reading an empty string against `'Article context:'`.

This is a test-side staleness, not a production bug. The other test in the same file (`test_refine_prompt_uses_custom_style_guide`) inspects `system` messages, which still flow through `messages` via `system_instruction`, so that one continued to pass.

## Fix

Look at `$captured_request['prompt']` first (where the active user message ends up), fall back to user-role messages in `history`. The assertion stays correct regardless of how many user turns the caller sends.

## Test results

`homeboy test data-machine --skip-lint`:
- Before: 1229 passed, **1 failed** (this test), 3 skipped, 1233 total.
- After: **1230 passed, 0 failed, 3 skipped**, 1233 total.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the test failure against current `RequestBuilder` behavior, applying the test-side fix, and PR preparation. Chris remains responsible for review and merge.