### PR TITLE
Guard scheduler checks before AS datastore init

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -48,6 +48,23 @@ if ( ! class_exists( 'ActionScheduler' ) ) {
 	require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';
 }
 
+if ( function_exists( 'wp_installing' ) && wp_installing() ) {
+	add_action( 'wp_loaded', 'datamachine_skip_action_scheduler_migration_during_install', 0 );
+}
+
+/**
+ * Prevent AS migration scheduling during wp-phpunit install bootstrap.
+ *
+ * @return void
+ */
+function datamachine_skip_action_scheduler_migration_during_install(): void {
+	if ( ! class_exists( '\Action_Scheduler\Migration\Controller' ) ) {
+		return;
+	}
+
+	remove_action( 'wp_loaded', array( \Action_Scheduler\Migration\Controller::instance(), 'schedule_migration' ) );
+}
+
 
 function datamachine_run_datamachine_plugin() {
 	if ( ! datamachine_should_load_full_runtime() ) {

--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -135,9 +135,30 @@ class FlowFormatter {
 			return null;
 		}
 
+		if ( ! self::is_action_scheduler_datastore_ready() ) {
+			return null;
+		}
+
 		$next_timestamp = as_next_scheduled_action( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
 
 		return $next_timestamp ? wp_date( 'Y-m-d H:i:s', $next_timestamp, new \DateTimeZone( 'UTC' ) ) : null;
+	}
+
+	/**
+	 * Check whether Action Scheduler's datastore is ready for procedural API reads.
+	 *
+	 * @return bool True when Action Scheduler can safely query scheduled actions.
+	 */
+	private static function is_action_scheduler_datastore_ready(): bool {
+		if ( function_exists( 'did_action' ) && 0 === did_action( 'action_scheduler_init' ) ) {
+			return false;
+		}
+
+		if ( ! class_exists( '\ActionScheduler' ) || ! method_exists( '\ActionScheduler', 'is_initialized' ) ) {
+			return true;
+		}
+
+		return \ActionScheduler::is_initialized();
 	}
 
 	/**

--- a/inc/Engine/Tasks/RecurringScheduler.php
+++ b/inc/Engine/Tasks/RecurringScheduler.php
@@ -262,7 +262,29 @@ class RecurringScheduler {
 		if ( ! function_exists( 'as_next_scheduled_action' ) ) {
 			return false;
 		}
+
+		if ( ! self::isActionSchedulerDataStoreReady() ) {
+			return false;
+		}
+
 		return false !== as_next_scheduled_action( $hook, $args, $group );
+	}
+
+	/**
+	 * Check whether Action Scheduler's datastore is ready for procedural API reads.
+	 *
+	 * @return bool True when Action Scheduler can safely query scheduled actions.
+	 */
+	private static function isActionSchedulerDataStoreReady(): bool {
+		if ( function_exists( 'did_action' ) && 0 === did_action( 'action_scheduler_init' ) ) {
+			return false;
+		}
+
+		if ( ! class_exists( '\ActionScheduler' ) || ! method_exists( '\ActionScheduler', 'is_initialized' ) ) {
+			return true;
+		}
+
+		return \ActionScheduler::is_initialized();
 	}
 
 	/**
@@ -288,6 +310,10 @@ class RecurringScheduler {
 	 */
 	private static function getPendingAction( string $hook, array $args, string $group ): ?object {
 		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+			return null;
+		}
+
+		if ( ! self::isActionSchedulerDataStoreReady() ) {
 			return null;
 		}
 

--- a/tests/recurring-scheduler-as-readiness-smoke.php
+++ b/tests/recurring-scheduler-as-readiness-smoke.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Pure-PHP smoke for RecurringScheduler Action Scheduler datastore readiness.
+ *
+ * Run with: php tests/recurring-scheduler-as-readiness-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( string $code = '', string $message = '', array $data = array() ) {
+			unset( $code, $message, $data );
+		}
+	}
+}
+
+class ActionScheduler {
+	public static bool $initialized = false;
+
+	public static function is_initialized( $function_name = null ): bool {
+		unset( $function_name );
+		return self::$initialized;
+	}
+}
+
+$GLOBALS['datamachine_as_next_scheduled_calls'] = 0;
+
+function as_next_scheduled_action( string $hook, ?array $args = null, string $group = '' ) {
+	unset( $hook, $args, $group );
+	++$GLOBALS['datamachine_as_next_scheduled_calls'];
+	return time() + 3600;
+}
+
+require_once __DIR__ . '/../inc/Engine/Tasks/RecurringScheduler.php';
+
+use DataMachine\Engine\Tasks\RecurringScheduler;
+
+function datamachine_assert( bool $condition, string $message ): void {
+	if ( $condition ) {
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+
+	echo "  [FAIL] {$message}\n";
+	exit( 1 );
+}
+
+echo "=== recurring-scheduler-as-readiness-smoke ===\n";
+
+ActionScheduler::$initialized = false;
+$result                       = RecurringScheduler::isScheduled( 'datamachine_hook', array(), RecurringScheduler::GROUP );
+datamachine_assert( false === $result, 'uninitialized Action Scheduler datastore reports unscheduled' );
+datamachine_assert( 0 === $GLOBALS['datamachine_as_next_scheduled_calls'], 'as_next_scheduled_action is not called before datastore initialization' );
+
+ActionScheduler::$initialized = true;
+$result                       = RecurringScheduler::isScheduled( 'datamachine_hook', array(), RecurringScheduler::GROUP );
+datamachine_assert( true === $result, 'initialized Action Scheduler datastore delegates to as_next_scheduled_action' );
+datamachine_assert( 1 === $GLOBALS['datamachine_as_next_scheduled_calls'], 'as_next_scheduled_action is called after datastore initialization' );
+
+echo "\nAll recurring scheduler AS readiness assertions passed.\n";


### PR DESCRIPTION
## Summary
- Guard Data Machine scheduler reads against Action Scheduler's readiness signal before calling AS procedural query APIs.
- Skip Action Scheduler's background migration scheduling during wp-phpunit install bootstrap while leaving datastore setup intact.
- Add a pure-PHP smoke covering the uninitialized datastore path.

## Testing
- `php tests/recurring-scheduler-as-readiness-smoke.php`
- `php tests/recurring-scheduler-idempotency-smoke.php`
- `composer run lint`
- `homeboy test data-machine`
- `DM_PATH=/Users/chubes/Developer/data-machine@fix-as-datastore-readiness-guard DMC_PATH=/Users/chubes/Developer/dmc-proof-no-requires/data-machine-code bash tests/playground-ci/scripts/run-stage-1.sh`
- `DM_PATH=/Users/chubes/Developer/data-machine@fix-as-datastore-readiness-guard DMC_PATH=/Users/chubes/Developer/dmc-proof-no-requires/data-machine-code bash tests/playground-ci/scripts/run-stage-2.sh`
- `DM_PATH=/Users/chubes/Developer/data-machine@fix-as-datastore-readiness-guard DMC_PATH=/Users/chubes/Developer/dmc-proof-no-requires/data-machine-code bash tests/playground-ci/scripts/run-stage-3.sh`

## Notes
- Stage 1/2 no longer print the Action Scheduler datastore initialization notice.
- Stage 3 passed on retry after one transient `fetch failed` from Playground before WordPress bootstrap completed.
- External proof used a temporary DMC copy with its `Requires Plugins: data-machine` header removed to avoid the validation runner also mounting the primary Data Machine checkout while this PR branch lives in a worktree named `data-machine@fix-as-datastore-readiness-guard`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the code/test changes and ran verification; Chris reviews the final diff.