### PR TITLE
fix: allow manual runs for paused flows

### DIFF
--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -43,17 +43,21 @@ class RunFlowAbility {
 						'type'       => 'object',
 						'required'   => array( 'flow_id' ),
 						'properties' => array(
-							'flow_id'      => array(
+							'flow_id'        => array(
 								'type'        => 'integer',
 								'description' => __( 'Flow ID to execute.', 'data-machine' ),
 							),
-							'job_id'       => array(
+							'job_id'         => array(
 								'type'        => array( 'integer', 'null' ),
 								'description' => __( 'Pre-created job ID (optional, for API-triggered executions).', 'data-machine' ),
 							),
-							'initial_data' => array(
+							'initial_data'   => array(
 								'type'        => 'object',
 								'description' => __( 'Optional initial engine data to merge (e.g. webhook payloads, API context).', 'data-machine' ),
+							),
+							'respect_paused' => array(
+								'type'        => 'boolean',
+								'description' => __( 'Internal scheduler safety flag. When true, paused flows are skipped.', 'data-machine' ),
 							),
 						),
 					),
@@ -91,7 +95,7 @@ class RunFlowAbility {
 	/**
 	 * Execute the run-flow ability.
 	 *
-	 * @param array $input Input with flow_id, optional job_id and initial_data.
+	 * @param array $input Input with flow_id, optional job_id, initial_data, and respect_paused.
 	 * @return array Result with success status and execution details.
 	 */
 	public function execute( array $input ): array {
@@ -107,10 +111,12 @@ class RunFlowAbility {
 			);
 		}
 
-		// Check if flow is paused (enabled=false). Safety net for AS hooks
-		// that were already queued before the flow was paused.
+		// Check if flow is paused only for scheduler-triggered executions.
+		// Direct ability/manual runs are allowed even when recurring schedules
+		// are paused.
 		$scheduling_config = $flow['scheduling_config'] ?? array();
-		if ( ! \DataMachine\Core\Database\Flows\Flows::is_flow_enabled( $scheduling_config ) ) {
+		$respect_paused    = true === ( $input['respect_paused'] ?? false );
+		if ( $respect_paused && ! \DataMachine\Core\Database\Flows\Flows::is_flow_enabled( $scheduling_config ) ) {
 			do_action(
 				'datamachine_log',
 				'info',

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -96,8 +96,9 @@ function datamachine_register_execution_engine() {
 			if ( $ability ) {
 				$ability->execute(
 					array(
-						'flow_id' => $flow_id,
-						'job_id'  => $job_id ? (int) $job_id : null,
+						'flow_id'        => $flow_id,
+						'job_id'         => $job_id ? (int) $job_id : null,
+						'respect_paused' => true,
 					)
 				);
 			}

--- a/tests/run-flow-paused-manual-smoke.php
+++ b/tests/run-flow-paused-manual-smoke.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Pure-PHP smoke test for paused flow manual execution semantics.
+ *
+ * Run with: php tests/run-flow-paused-manual-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$run_flow_file = __DIR__ . '/../inc/Abilities/Engine/RunFlowAbility.php';
+$engine_file   = __DIR__ . '/../inc/Engine/Actions/Engine.php';
+$run_flow_src  = file_get_contents( $run_flow_file ) ?: '';
+$engine_src    = file_get_contents( $engine_file ) ?: '';
+
+$assertions = 0;
+
+function assert_run_flow_paused_true( bool $condition, string $message ): void {
+	global $assertions;
+	++$assertions;
+
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function assert_run_flow_paused_contains( string $needle, string $haystack, string $message ): void {
+	assert_run_flow_paused_true( false !== strpos( $haystack, $needle ), $message );
+}
+
+assert_run_flow_paused_contains( "'respect_paused' => array(", $run_flow_src, 'run-flow ability exposes scheduler safety input' );
+assert_run_flow_paused_contains( '$respect_paused    = true === ( $input[\'respect_paused\'] ?? false );', $run_flow_src, 'run-flow defaults paused guard off for direct/manual execution' );
+assert_run_flow_paused_contains( 'if ( $respect_paused && ! \\DataMachine\\Core\\Database\\Flows\\Flows::is_flow_enabled( $scheduling_config ) )', $run_flow_src, 'paused guard only runs when scheduler safety flag is set' );
+assert_run_flow_paused_contains( "'respect_paused' => true,", $engine_src, 'Action Scheduler hook bridge preserves paused-flow safety' );
+
+echo "OK ({$assertions} assertions)\n";


### PR DESCRIPTION
## Summary
- Allows explicit `datamachine/run-flow` executions to run paused flows.
- Preserves paused-flow protection for scheduled/Action Scheduler-triggered executions via `respect_paused`.
- Adds a focused smoke test for the manual-run contract.

## Testing
- `php tests/run-flow-paused-manual-smoke.php`
- `php -l inc/Abilities/Engine/RunFlowAbility.php tests/run-flow-paused-manual-smoke.php`
- `vendor/bin/phpcs inc/Abilities/Engine/RunFlowAbility.php tests/run-flow-paused-manual-smoke.php`
- `homeboy test data-machine --changed-since main --skip-lint`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting and testing the paused-flow manual execution fix under Chris's direction.