### PR TITLE
fix: avoid poisoning source items on transport exhaustion

### DIFF
--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -495,6 +495,45 @@ class JobRetryPolicy {
 	 * @return void
 	 */
 	private static function recordPoisonItem( int $job_id, string $reason, array $context_data, array $engine_data, int $attempt, int $max_attempts ): void {
+		$retry_class = self::classifyFailure( $reason, $context_data );
+		if ( ! self::shouldPoisonSourceItem( $retry_class ) ) {
+			\datamachine_merge_engine_data(
+				$job_id,
+				array(
+					'retry' => array(
+						'attempts'       => $attempt,
+						'max_attempts'   => $max_attempts,
+						'last_reason'    => $reason,
+						'last_retryable' => true,
+						'retry_class'    => $retry_class,
+						'exhausted'      => true,
+					),
+				)
+			);
+
+			do_action(
+				'datamachine_log',
+				'error',
+				'Job retry policy exhausted provider/system retry without isolating source item',
+				array_filter(
+					array(
+						'job_id'          => $job_id,
+						'item_identifier' => $engine_data['item_identifier'] ?? null,
+						'source_type'     => $engine_data['source_type'] ?? null,
+						'flow_step_id'    => $context_data['flow_step_id'] ?? null,
+						'reason'          => $reason,
+						'retry_class'     => $retry_class,
+						'attempts'        => $attempt,
+						'max_attempts'    => $max_attempts,
+						'recorded_at'     => gmdate( 'c' ),
+					),
+					fn( $value ) => null !== $value
+				)
+			);
+
+			return;
+		}
+
 		$poison = array_filter(
 			array(
 				'isolated'        => true,
@@ -529,6 +568,24 @@ class JobRetryPolicy {
 			'error',
 			'Job retry policy isolated poison item after retry exhaustion',
 			$poison
+		);
+	}
+
+	/**
+	 * Whether retry exhaustion should isolate the current source item.
+	 *
+	 * Provider and transport failures are not evidence that the source item is
+	 * malformed. Marking them as poison hides retryable source work behind an
+	 * infrastructure outage.
+	 *
+	 * @param string $retry_class Retry classification.
+	 * @return bool
+	 */
+	private static function shouldPoisonSourceItem( string $retry_class ): bool {
+		return ! in_array(
+			$retry_class,
+			array( 'transport_connect_timeout', 'transport_dns', 'transport_network', 'provider_rate_limit', 'provider_overload' ),
+			true
 		);
 	}
 }

--- a/tests/job-retry-policy-smoke.php
+++ b/tests/job-retry-policy-smoke.php
@@ -39,6 +39,13 @@ function wp_rand( int $min, int $max ): int {
 	return $min;
 }
 
+$merged_engine_data = array();
+function datamachine_merge_engine_data( int $job_id, array $data ): void {
+	global $merged_engine_data;
+	$job_id;
+	$merged_engine_data = $data;
+}
+
 require_once __DIR__ . '/../inc/Core/JobRetryPolicy.php';
 
 $reflection          = new ReflectionClass( DataMachine\Core\JobRetryPolicy::class );
@@ -48,6 +55,7 @@ $is_retryable        = $reflection->getMethod( 'isRetryableFailure' );
 $resolve_delay       = $reflection->getMethod( 'resolveDelay' );
 $classify_failure    = $reflection->getMethod( 'classifyFailure' );
 $resolve_policy      = $reflection->getMethod( 'resolvePolicy' );
+$record_poison_item  = $reflection->getMethod( 'recordPoisonItem' );
 
 echo "Case 1: Retry-After values are normalized\n";
 assert_retry_policy_smoke( 'numeric Retry-After is seconds', 90 === $extract_retry_after->invoke( null, array( 'retry_after' => '90' ) ) );
@@ -92,7 +100,27 @@ assert_retry_policy_smoke( 'rate limit is classified separately', 'provider_rate
 assert_retry_policy_smoke( 'rate limit keeps default base delay', 60 === $rate_delay, 'delay was ' . $rate_delay );
 assert_retry_policy_smoke( 'generic retryable AI failure keeps default base delay', 60 === $generic_delay, 'delay was ' . $generic_delay );
 
-echo "Case 5: Production code exposes retry/backoff hooks and metadata\n";
+echo "Case 5: Transport retry exhaustion does not poison source items\n";
+$merged_engine_data = array();
+$record_poison_item->invoke(
+	null,
+	123,
+	'ai_processing_failed',
+	array(
+		'flow_step_id' => 'step-1',
+		'ai_error'     => 'Network error occurred while sending request: cURL error 28: Connection timed out after 15000 milliseconds',
+	),
+	array(
+		'item_identifier' => 'source-item-1',
+		'source_type'     => 'mcp',
+	),
+	3,
+	3
+);
+assert_retry_policy_smoke( 'exhausted transport failures mark retry exhausted', true === ( $merged_engine_data['retry']['exhausted'] ?? false ) );
+assert_retry_policy_smoke( 'exhausted transport failures do not isolate source item', ! isset( $merged_engine_data['poison_item'] ) );
+
+echo "Case 6: Production code exposes retry/backoff hooks and metadata\n";
 $policy_src = file_get_contents( __DIR__ . '/../inc/Core/JobRetryPolicy.php' ) ?: '';
 $fail_src   = file_get_contents( __DIR__ . '/../inc/Engine/Actions/Handlers/FailJobHandler.php' ) ?: '';
 $ai_src     = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' ) ?: '';


### PR DESCRIPTION
## Summary
- Avoid marking source items as poison when retry exhaustion is caused by provider/transport failures like cURL 28, DNS, network errors, rate limits, or provider overloads.
- Preserve retry exhaustion metadata so operators can still see that the provider/system failure exhausted attempts.
- Add smoke coverage proving transport exhaustion does not isolate the source item.

## Testing
- `php tests/job-retry-policy-smoke.php`
- `php -l inc/Core/JobRetryPolicy.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the retry-classification behavior, drafted the policy change and smoke coverage; Chris reviewed and directed the TDD workflow.