### PR TITLE
fix: clear advanced AI concurrency leases

### DIFF
--- a/inc/Engine/AI/PipelineAIConcurrencyLimiter.php
+++ b/inc/Engine/AI/PipelineAIConcurrencyLimiter.php
@@ -138,11 +138,11 @@ class PipelineAIConcurrencyLimiter {
 			}
 
 			$lease = array(
-				'token'       => $token,
-				'provider'    => $provider,
-				'created_at'  => $now,
-				'expires_at'  => $now + self::ttl( $provider, $context ),
-				'job_id'      => (int) ( $context['job_id'] ?? 0 ),
+				'token'        => $token,
+				'provider'     => $provider,
+				'created_at'   => $now,
+				'expires_at'   => $now + self::ttl( $provider, $context ),
+				'job_id'       => (int) ( $context['job_id'] ?? 0 ),
 				'flow_step_id' => (string) ( $context['flow_step_id'] ?? '' ),
 			);
 
@@ -229,7 +229,7 @@ class PipelineAIConcurrencyLimiter {
 
 		foreach ( $actions as $action ) {
 			$args = is_object( $action ) && method_exists( $action, 'get_args' ) ? $action->get_args() : array();
-			if ( $job_id === (int) ( $args['job_id'] ?? 0 ) && $flow_step_id !== (string) ( $args['flow_step_id'] ?? '' ) ) {
+			if ( (int) ( $args['job_id'] ?? 0 ) === $job_id && (string) ( $args['flow_step_id'] ?? '' ) !== $flow_step_id ) {
 				return true;
 			}
 		}

--- a/inc/Engine/AI/PipelineAIConcurrencyLimiter.php
+++ b/inc/Engine/AI/PipelineAIConcurrencyLimiter.php
@@ -19,6 +19,8 @@ class PipelineAIConcurrencyLimiter {
 	private const DEFAULT_LIMIT          = 1;
 	private const DEFAULT_THROTTLE_DELAY = 10;
 	private const DEFAULT_TTL            = 600;
+	private const EXECUTE_STEP_HOOK      = 'datamachine_execute_step';
+	private const ACTION_SCHEDULER_GROUP = 'data-machine';
 
 	/**
 	 * Attempt to acquire pipeline AI capacity.
@@ -125,6 +127,11 @@ class PipelineAIConcurrencyLimiter {
 				$existing = false;
 			}
 
+			if ( is_array( $existing ) && self::isAdvancedOwnerLease( $existing ) ) {
+				delete_option( $option_name );
+				$existing = false;
+			}
+
 			if ( false !== $existing ) {
 				++$active;
 				continue;
@@ -193,6 +200,56 @@ class PipelineAIConcurrencyLimiter {
 	 */
 	private static function optionName( string $scope, int $slot ): string {
 		return 'datamachine_pipeline_ai_lease_' . md5( $scope ) . '_' . $slot;
+	}
+
+	/**
+	 * Check whether a lease owner has already moved to another scheduled step.
+	 *
+	 * @param array $lease Existing lease option value.
+	 */
+	private static function isAdvancedOwnerLease( array $lease ): bool {
+		$job_id       = (int) ( $lease['job_id'] ?? 0 );
+		$flow_step_id = (string) ( $lease['flow_step_id'] ?? '' );
+
+		if ( $job_id <= 0 || '' === $flow_step_id || ! function_exists( 'as_get_scheduled_actions' ) || ! self::isActionSchedulerReady() ) {
+			return false;
+		}
+
+		$actions = as_get_scheduled_actions(
+			array(
+				'hook'     => self::EXECUTE_STEP_HOOK,
+				'group'    => self::ACTION_SCHEDULER_GROUP,
+				'status'   => 'pending',
+				'orderby'  => 'date',
+				'order'    => 'ASC',
+				'per_page' => 250,
+			),
+			'OBJECT'
+		);
+
+		foreach ( $actions as $action ) {
+			$args = is_object( $action ) && method_exists( $action, 'get_args' ) ? $action->get_args() : array();
+			if ( $job_id === (int) ( $args['job_id'] ?? 0 ) && $flow_step_id !== (string) ( $args['flow_step_id'] ?? '' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check whether Action Scheduler can safely answer scheduled-action queries.
+	 */
+	private static function isActionSchedulerReady(): bool {
+		if ( function_exists( 'did_action' ) && 0 === did_action( 'action_scheduler_init' ) ) {
+			return false;
+		}
+
+		if ( ! class_exists( '\ActionScheduler' ) || ! method_exists( '\ActionScheduler', 'is_initialized' ) ) {
+			return true;
+		}
+
+		return \ActionScheduler::is_initialized();
 	}
 
 	/**

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -25,6 +25,19 @@ function assert_ai_backpressure_smoke( string $name, bool $cond, string $detail 
 }
 
 $GLOBALS['datamachine_ai_backpressure_options'] = array();
+$GLOBALS['datamachine_ai_backpressure_actions'] = array();
+
+class DataMachineAIBackpressureSmokeAction {
+	public function __construct( private array $action ) {}
+
+	public function get_args(): array {
+		return $this->action['args'] ?? array();
+	}
+
+	public function get_field( string $field ): mixed {
+		return $this->action[ $field ] ?? null;
+	}
+}
 
 function get_option( string $name, mixed $default = false ): mixed {
 	return array_key_exists( $name, $GLOBALS['datamachine_ai_backpressure_options'] )
@@ -57,6 +70,29 @@ function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
 		return 7;
 	}
 	return $value;
+}
+
+function as_get_scheduled_actions( array $query = array(), string $return_format = 'OBJECT' ): array {
+	unset( $return_format );
+
+	return array_values(
+		array_filter(
+			$GLOBALS['datamachine_ai_backpressure_actions'],
+			static function ( DataMachineAIBackpressureSmokeAction $action ) use ( $query ): bool {
+				foreach ( array( 'hook', 'group', 'status' ) as $field ) {
+					if ( isset( $query[ $field ] ) && $action->get_field( $field ) !== $query[ $field ] ) {
+						return false;
+					}
+				}
+
+				return true;
+			}
+		)
+	);
+}
+
+function did_action( string $hook ): int {
+	return 'action_scheduler_init' === $hook ? 1 : 0;
 }
 
 function sanitize_key( string $key ): string {
@@ -96,7 +132,27 @@ $after_release = PipelineAIConcurrencyLimiter::acquire( 'openai', array( 'job_id
 assert_ai_backpressure_smoke( 'slot can be acquired after release', true === $after_release['acquired'] );
 $after_release['lease']->release();
 
-echo "Case 4: production wiring preserves pipeline semantics\n";
+echo "Case 4: advanced owner step clears stale live lease\n";
+$stale_owner = PipelineAIConcurrencyLimiter::acquire( 'openai', array( 'job_id' => 201, 'flow_step_id' => 'ai-old' ) );
+assert_ai_backpressure_smoke( 'stale owner initially acquires slot', true === $stale_owner['acquired'] );
+$GLOBALS['datamachine_ai_backpressure_actions'][] = new DataMachineAIBackpressureSmokeAction(
+	array(
+		'hook'   => 'datamachine_execute_step',
+		'group'  => 'data-machine',
+		'status' => 'pending',
+		'job_id' => 201,
+		'args'   => array(
+			'job_id'       => 201,
+			'flow_step_id' => 'publish-next',
+		),
+	)
+);
+$after_advanced_owner = PipelineAIConcurrencyLimiter::acquire( 'openai', array( 'job_id' => 202, 'flow_step_id' => 'ai-new' ) );
+assert_ai_backpressure_smoke( 'advanced owner lease does not block new AI work', true === $after_advanced_owner['acquired'] );
+$after_advanced_owner['lease']->release();
+$GLOBALS['datamachine_ai_backpressure_actions'] = array();
+
+echo "Case 5: production wiring preserves pipeline semantics\n";
 $ai_src       = file_get_contents( __DIR__ . '/../inc/Core/Steps/AI/AIStep.php' ) ?: '';
 $engine_src   = file_get_contents( __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '';
 $retry_src    = file_get_contents( __DIR__ . '/../inc/Core/JobRetryPolicy.php' ) ?: '';
@@ -111,6 +167,7 @@ assert_ai_backpressure_smoke( 'fetch steps do not use AI limiter', ! str_contain
 assert_ai_backpressure_smoke( 'upsert steps do not use AI limiter', ! str_contains( $upsert_src, 'PipelineAIConcurrencyLimiter' ) );
 assert_ai_backpressure_smoke( 'existing transport retry classifier remains intact', str_contains( $retry_src, 'transport_connect_timeout' ) && str_contains( $retry_src, 'AI_TRANSPORT_BASE_DELAY' ) );
 assert_ai_backpressure_smoke( 'throttle log includes requested metadata', str_contains( $ai_src, 'rescheduled_for_seconds' ) && str_contains( $ai_src, "'active'" ) && str_contains( $ai_src, "'limit'" ) );
+assert_ai_backpressure_smoke( 'limiter checks for advanced owner leases generically', str_contains( file_get_contents( __DIR__ . '/../inc/Engine/AI/PipelineAIConcurrencyLimiter.php' ) ?: '', 'isAdvancedOwnerLease' ) );
 
 echo "\nAI step backpressure smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- Clear a live pipeline AI concurrency lease when its recorded owner job already has pending scheduled work for another flow step.
- Keep lease recovery generic by checking Data Machine step scheduling state, not source/site/flow-specific details.
- Add smoke coverage for the stale owner advancing from an AI step to a downstream step while the lease remains.

## Tests
- `php tests/ai-step-backpressure-smoke.php`
- `php -l inc/Engine/AI/PipelineAIConcurrencyLimiter.php`
- `php -l tests/ai-step-backpressure-smoke.php`
- `git diff --check`

Fixes #1824.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the stale pipeline AI concurrency lease path from issue evidence, implemented the generic limiter guard and smoke coverage, and ran targeted validation. Chris remains responsible for reviewing and testing the change.