### PR TITLE
feat(bundle): accept remote URLs for agent install/import/upgrade (#1826)

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -17,6 +17,7 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Agents\AgentAccess;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
+use DataMachine\Engine\Bundle\BundleSource;
 use DataMachine\Engine\Bundle\BundleValidationException;
 
 defined( 'ABSPATH' ) || exit;
@@ -237,7 +238,7 @@ class AgentAbilities {
 						'properties' => array(
 							'source'      => array(
 								'type'        => 'string',
-								'description' => 'Local bundle source path. Supports bundle directories, .json files, and .zip archives.',
+								'description' => 'Bundle source: local path (directory, .zip, .json) or remote URL (HTTPS to a .zip/.json or a GitHub blob/tree/archive URL).',
 							),
 							'slug'        => array(
 								'type'        => 'string',
@@ -672,15 +673,24 @@ class AgentAbilities {
 	 */
 	public static function importAgent( array $input ): array {
 		$source = trim( (string) ( $input['source'] ?? '' ) );
-		if ( '' === $source || ! file_exists( $source ) ) {
+		if ( '' === $source ) {
 			return array(
 				'success' => false,
-				'error'   => 'Bundle source not found.',
+				'error'   => 'Bundle source is required.',
+			);
+		}
+
+		$resolved = BundleSource::resolve( $source );
+		if ( is_wp_error( $resolved ) ) {
+			return array(
+				'success' => false,
+				'error'   => $resolved->get_error_message(),
 			);
 		}
 
 		$on_conflict = (string) ( $input['on_conflict'] ?? 'error' );
 		if ( ! in_array( $on_conflict, array( 'error', 'skip' ), true ) ) {
+			BundleSource::cleanup( $resolved, $source );
 			return array(
 				'success' => false,
 				'error'   => 'on_conflict must be one of: error, skip.',
@@ -689,6 +699,7 @@ class AgentAbilities {
 
 		$owner_id = self::resolve_import_owner_id( isset( $input['owner_id'] ) ? (int) $input['owner_id'] : 0 );
 		if ( $owner_id <= 0 ) {
+			BundleSource::cleanup( $resolved, $source );
 			return array(
 				'success' => false,
 				'error'   => 'Unable to resolve import owner. Pass owner_id, authenticate as a user, or set datamachine_default_owner_id.',
@@ -696,12 +707,25 @@ class AgentAbilities {
 		}
 
 		$bundler = new AgentBundler();
-		$bundle  = self::load_import_bundle( $bundler, $source );
+		$bundle  = self::load_import_bundle( $bundler, $resolved );
+
+		// from_zip() extracts to its own tempdir and from_json() reads
+		// the file into memory, so the resolver's temp file is safe to
+		// remove now (success or failure of parse).
+		BundleSource::cleanup( $resolved, $source );
+
 		if ( ! is_array( $bundle ) ) {
 			return array(
 				'success' => false,
 				'error'   => 'Failed to parse bundle. Use a bundle directory, .json file, or .zip archive.',
 			);
+		}
+
+		// Stamp the original remote source so installed bundle metadata
+		// records where this came from. v1 leaves source_revision empty
+		// because GitHub archive responses don't expose a usable SHA.
+		if ( BundleSource::is_remote( $source ) && empty( $bundle['source_ref'] ) ) {
+			$bundle['source_ref'] = $source;
 		}
 
 		$slug = sanitize_title( (string) ( $bundle['agent']['agent_slug'] ?? '' ) );

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -17,6 +17,7 @@ use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
 use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
+use DataMachine\Engine\Bundle\BundleSource;
 use DataMachine\Engine\Bundle\PortableSlug;
 use WP_CLI;
 
@@ -397,22 +398,40 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	private function load_bundle_arg( array $args ): array {
-		$path = (string) ( $args[0] ?? '' );
-		if ( '' === $path || ! file_exists( $path ) ) {
-			WP_CLI::error( 'Bundle path not found.' );
+		$source = (string) ( $args[0] ?? '' );
+		if ( '' === $source ) {
+			WP_CLI::error( 'Bundle source is required.' );
+		}
+
+		$resolved = BundleSource::resolve( $source );
+		if ( is_wp_error( $resolved ) ) {
+			WP_CLI::error( $resolved->get_error_message() );
 		}
 
 		$bundle = null;
-		if ( is_dir( $path ) ) {
-			$bundle = $this->bundler()->from_directory( $path );
-		} elseif ( preg_match( '/\.zip$/i', $path ) ) {
-			$bundle = $this->bundler()->from_zip( $path );
-		} elseif ( preg_match( '/\.json$/i', $path ) ) {
-			$bundle = $this->bundler()->from_json( (string) file_get_contents( $path ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if ( is_dir( $resolved ) ) {
+			$bundle = $this->bundler()->from_directory( $resolved );
+		} elseif ( preg_match( '/\.zip$/i', $resolved ) ) {
+			$bundle = $this->bundler()->from_zip( $resolved );
+		} elseif ( preg_match( '/\.json$/i', $resolved ) ) {
+			$bundle = $this->bundler()->from_json( (string) file_get_contents( $resolved ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		}
+
+		// Resolver downloaded a temp file for remote sources; from_zip()
+		// extracts to its own tempdir and from_json() reads contents into
+		// memory, so the downloaded file is safe to clean up now.
+		BundleSource::cleanup( $resolved, $source );
 
 		if ( ! is_array( $bundle ) ) {
 			WP_CLI::error( 'Failed to parse bundle. Use .zip, .json, or a bundle directory.' );
+		}
+
+		// Stamp the original source URL into the bundle so installed
+		// metadata records where this came from. AgentBundler::import()
+		// reads $bundle['source_ref']. source_revision is left empty in
+		// v1 — GitHub archive responses don't expose a usable SHA.
+		if ( BundleSource::is_remote( $source ) && empty( $bundle['source_ref'] ) ) {
+			$bundle['source_ref'] = $source;
 		}
 
 		return $bundle;

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -13,6 +13,7 @@ namespace DataMachine\Cli\Commands;
 use WP_CLI;
 use DataMachine\Abilities\AgentAbilities;
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Engine\Bundle\BundleSource;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -1106,11 +1107,16 @@ class AgentsCommand extends AgentBundleCommand {
 		$format   = (string) ( $assoc_args['format'] ?? 'table' );
 
 		if ( empty( $path ) ) {
-			WP_CLI::error( 'Bundle path is required.' );
+			WP_CLI::error( 'Bundle source is required.' );
 			return;
 		}
 
-		if ( ! file_exists( $path ) ) {
+		// Validate locally before forwarding to the ability so that
+		// obvious garbage (typos, missing local file) fails fast with a
+		// human-friendly CLI error instead of a generic ability response.
+		// The ability re-runs BundleSource::resolve() to actually
+		// hydrate any temp file.
+		if ( ! BundleSource::is_remote( $path ) && ! file_exists( $path ) ) {
 			WP_CLI::error( sprintf( 'Path not found: %s', $path ) );
 			return;
 		}

--- a/inc/Engine/Bundle/BundleSource.php
+++ b/inc/Engine/Bundle/BundleSource.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Bundle source resolver — accept local paths or remote URLs.
+ *
+ * Hydrates remote agent bundle URLs (HTTPS to .zip/.json or GitHub
+ * blob/tree/archive/raw URLs) into a local filesystem path that
+ * AgentBundler::from_directory / from_zip / from_json can consume.
+ *
+ * Local paths pass through unchanged.
+ *
+ * Cleanup contract: callers MUST invoke {@see self::cleanup()} once they
+ * are done with the resolved path (after AgentBundler::import() returns,
+ * success OR failure) to delete any temp file that was downloaded.
+ *
+ * @package DataMachine\Engine\Bundle
+ * @since   0.10.3
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolve agent bundle source strings into local filesystem paths.
+ */
+final class BundleSource {
+
+	/**
+	 * Resolve a bundle source string into a local path.
+	 *
+	 * Local paths (directories, .zip, .json) that exist on disk are
+	 * returned unchanged. HTTP/HTTPS URLs are downloaded to a temporary
+	 * file under {@see sys_get_temp_dir()} and that path is returned.
+	 *
+	 * GitHub repository URLs (blob/tree/archive/raw) are normalized to
+	 * a downloadable archive or raw URL before fetching.
+	 *
+	 * Callers MUST invoke {@see self::cleanup()} after they are done
+	 * with the resolved path to delete temp files.
+	 *
+	 * @param string $source Bundle source — local path or remote URL.
+	 * @return string|WP_Error Absolute local filesystem path on success.
+	 */
+	public static function resolve( string $source ) {
+		$source = trim( $source );
+
+		if ( '' === $source ) {
+			return new WP_Error(
+				'datamachine_bundle_source_invalid',
+				'Bundle source is empty.'
+			);
+		}
+
+		if ( ! self::is_remote( $source ) ) {
+			if ( ! file_exists( $source ) ) {
+				return new WP_Error(
+					'datamachine_bundle_source_invalid',
+					sprintf( 'Bundle path not found: %s', $source )
+				);
+			}
+
+			return $source;
+		}
+
+		$fetch_url = self::normalize_github_url( $source );
+
+		if ( ! preg_match( '#\.(zip|json)(\?.*)?$#i', $fetch_url ) ) {
+			return new WP_Error(
+				'datamachine_bundle_source_invalid',
+				sprintf(
+					'Remote bundle URL must point to a .zip or .json (after GitHub normalization). Got: %s',
+					$fetch_url
+				)
+			);
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+
+		$timeout   = (int) apply_filters( 'datamachine_bundle_source_download_timeout', 60, $source );
+		$temp_file = download_url( $fetch_url, $timeout );
+
+		if ( is_wp_error( $temp_file ) ) {
+			return new WP_Error(
+				'datamachine_bundle_source_download_failed',
+				sprintf(
+					'Failed to download bundle from %s: %s',
+					$fetch_url,
+					$temp_file->get_error_message()
+				)
+			);
+		}
+
+		// download_url() returns a temp file with no extension. The
+		// downstream parser branches on extension (.zip vs .json), so
+		// rename the temp file to preserve the extension from the URL.
+		$expected_ext = preg_match( '#\.(zip|json)(\?.*)?$#i', $fetch_url, $m ) ? strtolower( $m[1] ) : '';
+		if ( '' !== $expected_ext ) {
+			$with_ext = $temp_file . '.' . $expected_ext;
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+			if ( @rename( $temp_file, $with_ext ) ) {
+				$temp_file = $with_ext;
+			}
+		}
+
+		return $temp_file;
+	}
+
+	/**
+	 * Is this source a remote URL?
+	 *
+	 * @param string $source Source string.
+	 * @return bool
+	 */
+	public static function is_remote( string $source ): bool {
+		return (bool) preg_match( '#^https?://#i', trim( $source ) );
+	}
+
+	/**
+	 * Normalize a GitHub URL into a downloadable archive or raw URL.
+	 *
+	 * Cases handled:
+	 * - archive/refs/heads/<branch>.zip → unchanged
+	 * - archive/<sha>.zip → unchanged
+	 * - blob/<ref>/<path>.{zip,json} → raw.githubusercontent.com/.../<ref>/<path>
+	 * - raw/<ref>/<path> → already raw, pass through
+	 * - tree/<branch> → archive/refs/heads/<branch>.zip
+	 *
+	 * Bare repo URLs (https://github.com/<org>/<repo>) and any other
+	 * shape are returned unchanged. The caller validates the final
+	 * extension and rejects unsupported targets.
+	 *
+	 * @param string $url URL to normalize.
+	 * @return string Normalized URL.
+	 */
+	public static function normalize_github_url( string $url ): string {
+		$url = trim( $url );
+
+		if ( ! preg_match( '#^https?://github\.com/#i', $url ) && ! preg_match( '#^https?://raw\.githubusercontent\.com/#i', $url ) ) {
+			return $url;
+		}
+
+		// Already a raw.githubusercontent.com URL — pass through.
+		if ( preg_match( '#^https?://raw\.githubusercontent\.com/#i', $url ) ) {
+			return $url;
+		}
+
+		// Already an archive URL — pass through.
+		if ( preg_match( '#^https?://github\.com/[^/]+/[^/]+/archive/.+\.zip$#i', $url ) ) {
+			return $url;
+		}
+
+		// blob/<ref>/<path> → raw URL.
+		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/blob/(.+)$#i', $url, $m ) ) {
+			return "https://raw.githubusercontent.com/{$m[1]}/{$m[2]}/{$m[3]}";
+		}
+
+		// raw/<ref>/<path> → raw URL.
+		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/raw/(.+)$#i', $url, $m ) ) {
+			return "https://raw.githubusercontent.com/{$m[1]}/{$m[2]}/{$m[3]}";
+		}
+
+		// tree/<branch> → archive zip for that branch.
+		if ( preg_match( '#^https?://github\.com/([^/]+)/([^/]+)/tree/([^/]+)/?$#i', $url, $m ) ) {
+			return "https://github.com/{$m[1]}/{$m[2]}/archive/refs/heads/{$m[3]}.zip";
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Delete the resolved temp file when it differs from the original
+	 * source string.
+	 *
+	 * Safe to call unconditionally: if the resolved path equals the
+	 * original local source, this is a no-op. Long-running PHP
+	 * processes (wp-cron, action scheduler) need this to avoid leaking
+	 * downloaded archives across runs.
+	 *
+	 * @param string $resolved_path   Path returned by {@see self::resolve()}.
+	 * @param string $original_source Original source string passed to resolve().
+	 */
+	public static function cleanup( string $resolved_path, string $original_source ): void {
+		if ( '' === $resolved_path ) {
+			return;
+		}
+
+		if ( ! self::is_remote( $original_source ) ) {
+			return;
+		}
+
+		if ( $resolved_path === $original_source ) {
+			return;
+		}
+
+		if ( ! file_exists( $resolved_path ) ) {
+			return;
+		}
+
+		// Only delete files inside the system temp dir to avoid
+		// accidentally removing user-supplied local paths if the caller
+		// passed something unexpected. realpath() both ends because
+		// some platforms (macOS) symlink /tmp to /private/tmp.
+		$temp_dir_real = realpath( sys_get_temp_dir() );
+		$resolved_real = realpath( $resolved_path );
+		if ( false === $temp_dir_real || false === $resolved_real ) {
+			return;
+		}
+		$temp_dir_real = rtrim( $temp_dir_real, '/\\' );
+		if ( 0 !== strpos( $resolved_real, $temp_dir_real ) ) {
+			return;
+		}
+
+		wp_delete_file( $resolved_path );
+	}
+}

--- a/tests/bundle-source-smoke.php
+++ b/tests/bundle-source-smoke.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * Behavior smoke test for BundleSource resolver (#1826).
+ *
+ * Run with: php tests/bundle-source-smoke.php
+ */
+
+namespace {
+	// Use a throwaway ABSPATH so the require_once in BundleSource resolves
+	// against a stub file in /tmp, not inside the plugin tree.
+	$datamachine_test_abspath = sys_get_temp_dir() . '/datamachine-bundle-source-test-' . uniqid() . '/';
+	@mkdir( $datamachine_test_abspath . 'wp-admin/includes', 0777, true );
+	@file_put_contents( $datamachine_test_abspath . 'wp-admin/includes/file.php', "<?php\n// test stub\n" );
+	define( 'ABSPATH', $datamachine_test_abspath );
+
+	register_shutdown_function( function () use ( $datamachine_test_abspath ) {
+		// Best-effort cleanup of the stub tree.
+		$files = @glob( $datamachine_test_abspath . '/*' );
+		if ( is_array( $files ) ) {
+			foreach ( new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator( $datamachine_test_abspath, RecursiveDirectoryIterator::SKIP_DOTS ),
+				RecursiveIteratorIterator::CHILD_FIRST
+			) as $item ) {
+				if ( $item->isDir() ) {
+					@rmdir( $item->getPathname() );
+				} else {
+					@unlink( $item->getPathname() );
+				}
+			}
+			@rmdir( $datamachine_test_abspath );
+		}
+	} );
+
+	// Minimal WP_Error stub.
+	class WP_Error {
+		private string $code;
+		private string $message;
+
+		public function __construct( string $code, string $message ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+
+	function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+		return $value;
+	}
+
+	function wp_delete_file( string $path ): void {
+		if ( file_exists( $path ) ) {
+			unlink( $path ); // phpcs:ignore
+		}
+	}
+
+	// Minimal download_url stub. Tests that exercise the download path
+	// override this via $GLOBALS['datamachine_test_download_url'].
+	function download_url( string $url, int $timeout = 30 ): mixed {
+		$override = $GLOBALS['datamachine_test_download_url'] ?? null;
+		if ( is_callable( $override ) ) {
+			return $override( $url, $timeout );
+		}
+
+		return new WP_Error( 'no_stub', 'download_url is not stubbed in this test.' );
+	}
+
+}
+
+namespace DataMachine\Engine\Bundle {
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSource.php';
+}
+
+namespace {
+	use DataMachine\Engine\Bundle\BundleSource;
+
+	$assertions = 0;
+	$assert     = function ( string $label, bool $condition ) use ( &$assertions ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			fwrite( STDERR, "FAIL: {$label}\n" );
+			exit( 1 );
+		}
+		echo "ok - {$label}\n";
+	};
+
+	echo "=== BundleSource Smoke (#1826) ===\n";
+
+	echo "\n[1] is_remote()\n";
+	$assert( 'http URL is remote', BundleSource::is_remote( 'http://example.com/bundle.zip' ) );
+	$assert( 'https URL is remote', BundleSource::is_remote( 'https://example.com/bundle.zip' ) );
+	$assert( 'HTTPS uppercase is remote', BundleSource::is_remote( 'HTTPS://example.com/bundle.zip' ) );
+	$assert( 'local absolute path is not remote', ! BundleSource::is_remote( '/tmp/bundle.zip' ) );
+	$assert( 'local relative path is not remote', ! BundleSource::is_remote( './bundle.zip' ) );
+	$assert( 'file:// is not remote (treated as local for safety)', ! BundleSource::is_remote( 'file:///tmp/bundle.zip' ) );
+	$assert( 'empty string is not remote', ! BundleSource::is_remote( '' ) );
+
+	echo "\n[2] normalize_github_url() — all documented cases\n";
+
+	// archive/refs/heads/<branch>.zip — unchanged
+	$archive_branch = 'https://github.com/foo/bar/archive/refs/heads/main.zip';
+	$assert(
+		'archive/refs/heads/<branch>.zip is unchanged',
+		$archive_branch === BundleSource::normalize_github_url( $archive_branch )
+	);
+
+	// archive/<sha>.zip — unchanged (matches generic archive .zip)
+	$archive_sha = 'https://github.com/foo/bar/archive/abc123.zip';
+	$assert(
+		'archive/<sha>.zip is unchanged',
+		$archive_sha === BundleSource::normalize_github_url( $archive_sha )
+	);
+
+	// blob/<ref>/<path>.json → raw URL
+	$blob       = 'https://github.com/foo/bar/blob/main/bundles/agent.json';
+	$normalized = BundleSource::normalize_github_url( $blob );
+	$assert(
+		'blob/<ref>/<path>.json normalizes to raw.githubusercontent.com',
+		'https://raw.githubusercontent.com/foo/bar/main/bundles/agent.json' === $normalized
+	);
+
+	// blob/<ref>/<path>.zip → raw URL
+	$blob_zip = 'https://github.com/foo/bar/blob/main/bundles/agent.zip';
+	$assert(
+		'blob/<ref>/<path>.zip normalizes to raw',
+		'https://raw.githubusercontent.com/foo/bar/main/bundles/agent.zip' === BundleSource::normalize_github_url( $blob_zip )
+	);
+
+	// raw/<ref>/<path> → raw.githubusercontent.com
+	$raw_legacy = 'https://github.com/foo/bar/raw/main/bundles/agent.json';
+	$assert(
+		'raw/<ref>/<path> normalizes to raw.githubusercontent.com',
+		'https://raw.githubusercontent.com/foo/bar/main/bundles/agent.json' === BundleSource::normalize_github_url( $raw_legacy )
+	);
+
+	// already raw.githubusercontent.com → unchanged
+	$raw_direct = 'https://raw.githubusercontent.com/foo/bar/main/bundle.json';
+	$assert(
+		'raw.githubusercontent.com URL is unchanged',
+		$raw_direct === BundleSource::normalize_github_url( $raw_direct )
+	);
+
+	// tree/<branch> → archive zip
+	$tree = 'https://github.com/foo/bar/tree/main';
+	$assert(
+		'tree/<branch> normalizes to archive zip',
+		'https://github.com/foo/bar/archive/refs/heads/main.zip' === BundleSource::normalize_github_url( $tree )
+	);
+
+	// tree/<branch>/ trailing slash also handled
+	$tree_slash = 'https://github.com/foo/bar/tree/develop/';
+	$assert(
+		'tree/<branch>/ trailing slash normalizes',
+		'https://github.com/foo/bar/archive/refs/heads/develop.zip' === BundleSource::normalize_github_url( $tree_slash )
+	);
+
+	// non-github URL → unchanged
+	$other = 'https://example.com/bundle.zip';
+	$assert(
+		'non-github URL is unchanged',
+		$other === BundleSource::normalize_github_url( $other )
+	);
+
+	// bare repo URL → unchanged (caller will reject as missing extension)
+	$bare = 'https://github.com/foo/bar';
+	$assert(
+		'bare repo URL is unchanged (caller rejects)',
+		$bare === BundleSource::normalize_github_url( $bare )
+	);
+
+	echo "\n[3] resolve() — local paths\n";
+
+	// Existing local file is returned as-is.
+	$tmp_local = tempnam( sys_get_temp_dir(), 'datamachine-bundle-test-' );
+	rename( $tmp_local, $tmp_local . '.json' );
+	$tmp_local = $tmp_local . '.json';
+	file_put_contents( $tmp_local, '{}' );
+	$resolved = BundleSource::resolve( $tmp_local );
+	$assert( 'existing local .json path resolves as-is', $resolved === $tmp_local );
+	wp_delete_file( $tmp_local );
+
+	// Missing local path returns WP_Error.
+	$missing = BundleSource::resolve( '/definitely/not/a/real/path/here.json' );
+	$assert( 'missing local path returns WP_Error', is_wp_error( $missing ) );
+	$assert(
+		'missing local path uses datamachine_bundle_source_invalid code',
+		$missing instanceof WP_Error && 'datamachine_bundle_source_invalid' === $missing->get_error_code()
+	);
+
+	// Empty source returns WP_Error.
+	$empty = BundleSource::resolve( '' );
+	$assert( 'empty source returns WP_Error', is_wp_error( $empty ) );
+
+	echo "\n[4] resolve() — remote URLs (download_url stubbed)\n";
+
+	// Successful download path returns a temp file.
+	$fake_payload = '{"bundle_version":"1","agent":{"agent_slug":"x","agent_name":"X"}}';
+	$GLOBALS['datamachine_test_download_url'] = function ( string $url, int $timeout ) use ( $fake_payload ): string {
+		$tmp = tempnam( sys_get_temp_dir(), 'datamachine-stub-download-' );
+		file_put_contents( $tmp, $fake_payload );
+		return $tmp;
+	};
+
+	$source   = 'https://example.com/some-bundle.json';
+	$resolved = BundleSource::resolve( $source );
+	$assert( 'remote .json resolves to a string path', is_string( $resolved ) );
+	$assert(
+		'remote .json resolved path lives in sys_get_temp_dir',
+		is_string( $resolved ) && 0 === strpos( realpath( $resolved ), realpath( sys_get_temp_dir() ) )
+	);
+	$assert(
+		'remote .json resolved path preserves .json extension',
+		is_string( $resolved ) && preg_match( '/\.json$/', $resolved )
+	);
+	$assert(
+		'remote .json resolved file contains downloaded payload',
+		is_string( $resolved ) && $fake_payload === file_get_contents( $resolved )
+	);
+
+	// cleanup() removes the temp file.
+	BundleSource::cleanup( $resolved, $source );
+	$assert( 'cleanup removes temp file for remote source', ! file_exists( $resolved ) );
+
+	// cleanup() is a no-op for local sources (does NOT delete user files).
+	$user_file = tempnam( sys_get_temp_dir(), 'datamachine-user-file-' );
+	file_put_contents( $user_file, 'do not delete me' );
+	BundleSource::cleanup( $user_file, $user_file );
+	$assert( 'cleanup is no-op when source is local', file_exists( $user_file ) );
+	wp_delete_file( $user_file );
+
+	echo "\n[5] resolve() — error paths\n";
+
+	// download_url returns WP_Error → resolver wraps as datamachine_bundle_source_download_failed.
+	$GLOBALS['datamachine_test_download_url'] = function () {
+		return new WP_Error( 'http_404', 'Not Found' );
+	};
+	$err = BundleSource::resolve( 'https://example.com/missing.zip' );
+	$assert( 'download_url failure returns WP_Error', is_wp_error( $err ) );
+	$assert(
+		'download failure uses datamachine_bundle_source_download_failed code',
+		$err instanceof WP_Error && 'datamachine_bundle_source_download_failed' === $err->get_error_code()
+	);
+
+	// Remote URL without .zip/.json extension is rejected before download.
+	$GLOBALS['datamachine_test_download_url'] = function () {
+		fwrite( STDERR, "FAIL: download_url should not have been called for unsupported extension\n" );
+		exit( 1 );
+	};
+	$bad_ext = BundleSource::resolve( 'https://example.com/something' );
+	$assert( 'remote URL without .zip/.json is rejected', is_wp_error( $bad_ext ) );
+
+	// Bare GitHub repo URL → no normalization, no extension, rejected.
+	$bare_repo = BundleSource::resolve( 'https://github.com/foo/bar' );
+	$assert( 'bare GitHub repo URL is rejected (no extension)', is_wp_error( $bare_repo ) );
+
+	echo "\n[6] resolve() — GitHub blob/tree URLs round-trip through normalization\n";
+
+	// blob URL pointing at .json should be normalized and downloaded.
+	$GLOBALS['datamachine_test_seen_url']    = '';
+	$GLOBALS['datamachine_test_download_url'] = function ( string $url, int $timeout ): string {
+		$GLOBALS['datamachine_test_seen_url'] = $url;
+		$tmp = tempnam( sys_get_temp_dir(), 'datamachine-stub-blob-' );
+		file_put_contents( $tmp, '{}' );
+		return $tmp;
+	};
+	$blob_src = 'https://github.com/org/repo/blob/main/agent.json';
+	$resolved = BundleSource::resolve( $blob_src );
+	$assert( 'GitHub blob URL resolves to a temp file', is_string( $resolved ) );
+	$assert(
+		'GitHub blob URL is normalized to raw.githubusercontent.com before download',
+		'https://raw.githubusercontent.com/org/repo/main/agent.json' === $GLOBALS['datamachine_test_seen_url']
+	);
+	if ( is_string( $resolved ) ) {
+		BundleSource::cleanup( $resolved, $blob_src );
+	}
+
+	// tree URL → archive .zip download
+	$GLOBALS['datamachine_test_download_url'] = function ( string $url, int $timeout ): string {
+		$GLOBALS['datamachine_test_seen_url'] = $url;
+		$tmp = tempnam( sys_get_temp_dir(), 'datamachine-stub-tree-' );
+		file_put_contents( $tmp, 'PK' );
+		return $tmp;
+	};
+	$tree_src = 'https://github.com/org/repo/tree/main';
+	$resolved = BundleSource::resolve( $tree_src );
+	$assert( 'GitHub tree URL resolves to a temp file', is_string( $resolved ) );
+	$assert(
+		'GitHub tree URL is normalized to archive zip before download',
+		'https://github.com/org/repo/archive/refs/heads/main.zip' === $GLOBALS['datamachine_test_seen_url']
+	);
+	if ( is_string( $resolved ) ) {
+		BundleSource::cleanup( $resolved, $tree_src );
+	}
+
+	echo "\nAssertions: {$assertions}\n";
+	echo "PASS\n";
+}

--- a/tests/import-agent-ability-smoke.php
+++ b/tests/import-agent-ability-smoke.php
@@ -6,7 +6,29 @@
  */
 
 namespace {
-	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	// Use a throwaway ABSPATH so BundleSource's require_once resolves to
+	// a stub file in /tmp instead of polluting the plugin tree.
+	$datamachine_test_abspath = sys_get_temp_dir() . '/datamachine-import-agent-test-' . uniqid() . '/';
+	@mkdir( $datamachine_test_abspath . 'wp-admin/includes', 0777, true );
+	@file_put_contents( $datamachine_test_abspath . 'wp-admin/includes/file.php', "<?php\n// test stub\n" );
+	define( 'ABSPATH', $datamachine_test_abspath );
+
+	register_shutdown_function( function () use ( $datamachine_test_abspath ) {
+		if ( ! is_dir( $datamachine_test_abspath ) ) {
+			return;
+		}
+		foreach ( new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $datamachine_test_abspath, RecursiveDirectoryIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST
+		) as $item ) {
+			if ( $item->isDir() ) {
+				@rmdir( $item->getPathname() );
+			} else {
+				@unlink( $item->getPathname() );
+			}
+		}
+		@rmdir( $datamachine_test_abspath );
+	} );
 
 	class WP_Error {
 		private string $code;
@@ -52,6 +74,18 @@ namespace {
 	function is_wp_error( mixed $thing ): bool {
 		return $thing instanceof WP_Error;
 	}
+
+	function wp_delete_file( string $path ): void {
+		if ( file_exists( $path ) ) {
+			unlink( $path ); // phpcs:ignore
+		}
+	}
+
+	function download_url( string $url, int $timeout = 30 ): mixed {
+		return new WP_Error( 'no_stub', 'download_url is not stubbed.' );
+	}
+
+
 
 	eval(
 		<<<'PHP'
@@ -108,6 +142,10 @@ namespace {
 	);
 
 	eval( 'namespace DataMachine\\Core\\FilesRepository; class DirectoryManager {}' );
+}
+
+namespace DataMachine\Engine\Bundle {
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSource.php';
 }
 
 namespace DataMachine\Abilities {


### PR DESCRIPTION
## Summary

- Add a `BundleSource` resolver that hydrates HTTP/HTTPS bundle URLs (and GitHub blob/tree/raw URLs) into a local temp file, so `wp datamachine agent install`, `agent import`, `agent upgrade`, and `agent diff` all accept remote sources alongside the existing local paths.
- Wire the resolver into all four entry points and the `datamachine/import-agent` ability, so MCP/REST callers benefit too. Schema `source` description updated to document the URL shapes.
- Stamp the original remote URL into `$bundle['source_ref']` so installed bundle metadata records where the agent came from.

Closes #1826

## GitHub URL shapes the resolver normalizes

| Input | Output |
|---|---|
| `archive/refs/heads/<branch>.zip` | unchanged |
| `archive/<sha>.zip` | unchanged |
| `blob/<ref>/<path>.{zip,json}` | `https://raw.githubusercontent.com/<org>/<repo>/<ref>/<path>` |
| `raw/<ref>/<path>` | `https://raw.githubusercontent.com/<org>/<repo>/<ref>/<path>` |
| `https://raw.githubusercontent.com/...` | unchanged |
| `tree/<branch>` | `archive/refs/heads/<branch>.zip` |

After normalization the resolver requires the URL to point at a `.zip` or `.json`. Bare repo URLs and other shapes are rejected with `datamachine_bundle_source_invalid` rather than silently guessing a default branch.

## Temp-file cleanup contract

The resolver downloads remote URLs to `sys_get_temp_dir()`. Callers MUST invoke `BundleSource::cleanup($resolved, $original)` after they're done with the resolved path. `cleanup()` is a no-op for local sources and only deletes files inside the system temp dir, so it's safe to call unconditionally.

All four entry points already do this immediately after parsing, since `AgentBundler::from_zip()` extracts to its own tempdir and `from_json()` reads file contents into memory — the resolver's temp file isn't needed past parse. This avoids leaking downloaded archives across long-running PHP processes (wp-cron, action scheduler).

## `source_revision` gap

`source_ref` is stamped with the original (un-normalized) URL the user passed. `source_revision` stays empty in v1: GitHub archive responses don't expose a usable SHA in headers reliably, so v1 documents the gap rather than papering over it. Existing `source_ref`/`source_revision` plumbing in `AgentTemplateMetadata` and `AgentBundler::import()` is unchanged — the metadata flows through `$bundle['source_ref']` which the importer already reads.

## Out of scope (follow-ups)

- Auto re-fetch on upgrade (re-resolve `source_ref` instead of requiring a fresh URL).
- Auth headers / GHE PATs for private repos. v2 should accept a `--token` flag or env var.
- Drift detection vs. remote.
- Capture a usable `source_revision` (likely needs a sidecar API call to resolve a branch tip to a SHA).

## Validation

- `php tests/bundle-source-smoke.php` — 35 assertions, PASS. Covers `is_remote()`, every documented `normalize_github_url()` case, local-path resolve, missing-path WP_Error, remote download (download_url stubbed via `pre_http_request` pattern), error wrapping, extension-validation rejection, and cleanup behavior including the no-op-for-local-source guarantee.
- `php tests/import-agent-ability-smoke.php` — 22 assertions, still PASS after extending it to load `BundleSource`.
- `php tests/agent-bundle-format-smoke.php`, `tests/agent-bundle-portable-update-smoke.php`, `tests/agent-bundle-runtime-drift-smoke.php` — all PASS, no regressions in the existing bundle test suite.
- `vendor/bin/phpcs` — clean on every modified file.
- `homeboy lint` and `homeboy audit` — clean.
- End-to-end testing of the live `wp datamachine agent install <url>` command was not run because the studio site I'm reviewing from runs the deployed plugin copy, not this worktree. Local-path regression path is covered by the existing smoke suite plus the new `is_remote=false` branch in `BundleSource::resolve()`.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the `BundleSource` resolver, wired it into the four entry points, updated the import-agent ability schema, and wrote the new `tests/bundle-source-smoke.php` plus the small extension to the existing `import-agent-ability-smoke.php`. Chris reviewed the diff and ran the smoke suite locally.