### PR TITLE
feat(bundle): support auth headers for private GitHub/GHE archives (#1830)

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -107,6 +107,7 @@ function datamachine_run_datamachine_plugin() {
 	// Load and instantiate all handlers - they self-register via constructors
 	datamachine_load_handlers();
 	\DataMachine\Engine\Bundle\AuthRefHandlerConfig::register();
+	\DataMachine\Engine\Bundle\BundleSourceAuth::register();
 	\DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts::register();
 
 	// Initialize FetchHandler to register skip_item tool for all fetch-type handlers

--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -163,14 +163,81 @@ Portable flow-step policy fields are explicit in `flows/<flow-slug>.json`:
 
 Agent package operations live under `wp datamachine agent`:
 
-- `install <path>` imports a local bundle path (`.zip`, `.json`, or directory).
+- `install <path|url>` imports a local bundle path (`.zip`, `.json`, or directory) or a remote URL.
 - `installed` reports installed package-backed agents without clobbering `agent list`.
 - `status <slug>` reports installed version and tracked artifact state by agent slug or bundle slug.
-- `diff <path>` builds a read-only upgrade plan.
-- `upgrade <path>` applies clean updates and stages locally modified artifacts as PendingActions.
+- `diff <path|url>` builds a read-only upgrade plan.
+- `upgrade <path|url>` applies clean updates and stages locally modified artifacts as PendingActions.
 - `apply <pending_action_id>` accepts a staged bundle PendingAction.
 
 Every read/preview command supports `--format=json` for automation.
+
+`install`, `import`, `upgrade`, and `diff` accept `--token=<token>` and `--token-env=<varname>` for one-off authenticated downloads — see [Authenticated Bundle Sources](#authenticated-bundle-sources).
+
+## Authenticated Bundle Sources
+
+Public archives install with no configuration. Private GitHub repositories, GitHub Enterprise (GHE) hosts, and any other URL behind `Authorization: Bearer <token>` are supported through a layered opt-in chain:
+
+1. **CLI flag** (`--token=<token>` / `--token-env=<varname>`) — single-call, never persisted, never logged.
+2. **Environment variable / PHP constant** — `DATAMACHINE_GITHUB_TOKEN` for github.com / raw.githubusercontent.com; per-host symbol for GHE (configured via filter).
+3. **WP option** (github.com only) — `datamachine_bundle_source_github_token`. Lowest precedence convenience slot.
+4. **Filter fallback** — `datamachine_bundle_source_token_for_url` for sigillo, AWS Secrets Manager, Vault, etc.
+5. **Generic per-request filter** — `datamachine_bundle_source_download_args` for arbitrary header injection (any host, any auth scheme).
+
+Data Machine **never persists tokens itself.** Storage and rotation live in the host plugin or operator's environment. Errors that surface from a failed download include the URL but never the `Authorization` header — see `BundleSourceAuth::redact_args_for_log()` if you log the args downstream.
+
+### Example 1 — github.com private archive via env var
+
+```bash
+export DATAMACHINE_GITHUB_TOKEN=ghp_xxx
+wp datamachine agent install https://github.com/private-org/private-repo/archive/refs/heads/main.zip --yes
+```
+
+A 401/403/404 response surfaces as `WP_Error( 'datamachine_bundle_source_auth_required', ... )` with a hint about the configured token slots.
+
+### Example 2 — GHE archive via filter-configured host + constant
+
+```php
+// mu-plugin or theme bootstrap.
+add_filter( 'datamachine_bundle_source_ghe_hosts', function ( array $hosts ): array {
+    $hosts['github.a8c.com'] = 'DATAMACHINE_A8C_GHE_TOKEN';
+    return $hosts;
+} );
+
+define( 'DATAMACHINE_A8C_GHE_TOKEN', 'ghp_yyy' );
+```
+
+```bash
+wp datamachine agent install https://github.a8c.com/team/brain/archive/refs/heads/main.zip --yes
+```
+
+### Example 3 — Custom secret store via filter callback
+
+For sigillo / AWS Secrets Manager / Vault — anything that doesn't fit the env-var/constant model — wire a callback on `datamachine_bundle_source_download_args` and skip the resolution chain entirely:
+
+```php
+add_filter(
+    'datamachine_bundle_source_download_args',
+    function ( array $args, string $source, string $fetch_url ): array {
+        $host = wp_parse_url( $fetch_url, PHP_URL_HOST ) ?: '';
+        if ( str_ends_with( $host, '.example.com' ) ) {
+            $token = my_sigillo_client()->get( "bundles/{$host}" );
+            if ( $token ) {
+                $args['headers']['Authorization'] = 'Bearer ' . $token;
+            }
+        }
+        return $args;
+    },
+    10,
+    3
+);
+```
+
+Or hook the lower-cost `datamachine_bundle_source_token_for_url` fallback when you only want to fill the gap for hosts that have no built-in slot.
+
+### Source Revision Capture
+
+For GitHub archive responses, `BundleSource::fetch_to_tempfile()` reads the response `ETag` header and parses the git SHA out of the `W/"<sha>:<format>"` (or bare `"<sha>"`) shape GitHub serves. When present and parseable the SHA is exposed via `BundleSource::last_resolved_revision()` and stamped onto the bundle as `source_revision`. Best-effort only — installs do not fail when the ETag is absent or unparseable.
 
 ## Follow-Ups
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -1250,6 +1250,86 @@ add_filter(
 
 The paired post-install hook is `datamachine_bundle_install_succeeded` (see core-actions.md). See [Agent Bundles → Extras](../../core-system/agent-bundles.md#reserved-trees-and-extras) for the full contract.
 
+### `datamachine_bundle_source_download_args`
+
+**Purpose**: Mutate the HTTP args used by `BundleSource::resolve()` when downloading a remote bundle. Consumers attach `Authorization` headers, custom user-agents, or any other arg supported by `wp_safe_remote_get()`. The body is streamed to disk via `'stream' => true` + `'filename'`; consumers should leave those keys alone.
+
+**Parameters**:
+
+- `$args` (array) - HTTP args. Includes `timeout`, `headers`, `redirection`, `user-agent`, and a private `datamachine_bundle_source` handle carrying the original `$source` and any caller `$context` (e.g. `cli_token`). The internal handle is stripped before the request flies.
+- `$source` (string) - Original (un-normalized) source string.
+- `$fetch_url` (string) - Normalized URL the request will hit.
+
+**Return**: HTTP args array.
+
+**Usage**:
+```php
+add_filter(
+    'datamachine_bundle_source_download_args',
+    function ( array $args, string $source, string $fetch_url ): array {
+        if ( str_starts_with( $fetch_url, 'https://artifacts.example.com/' ) ) {
+            $args['headers']['Authorization'] = 'Bearer ' . my_secrets_lookup( 'artifacts.example.com' );
+        }
+        return $args;
+    },
+    10,
+    3
+);
+```
+
+Tokens must never be logged. Data Machine does not persist tokens; the host plugin is responsible for retrieval and lifecycle.
+
+### `datamachine_bundle_source_token_for_url`
+
+**Purpose**: Fallback token lookup for hosts that aren't covered by the built-in env / constant / option chain. Fires only when the env var, PHP constant, and (for github.com) WP option `datamachine_bundle_source_github_token` all returned empty. Useful for sigillo, AWS Secrets Manager, Vault, and similar secret stores.
+
+**Parameters**:
+
+- `$token` (string|null) - Always `null` when this filter fires.
+- `$fetch_url` (string) - Normalized URL.
+- `$host` (string) - Lower-cased host portion of the URL.
+- `$context` (array) - Resolution context (e.g. `cli_token`).
+
+**Return**: Token string, or `null`/empty to leave the lookup unresolved.
+
+**Usage**:
+```php
+add_filter(
+    'datamachine_bundle_source_token_for_url',
+    function ( $token, string $url, string $host, array $context ) {
+        if ( null !== $token ) {
+            return $token;
+        }
+        return my_sigillo_client()->get( "bundle-source/{$host}" );
+    },
+    10,
+    4
+);
+```
+
+### `datamachine_bundle_source_ghe_hosts`
+
+**Purpose**: Register GitHub Enterprise hosts that should auto-receive `Authorization: Bearer` headers from `BundleSourceAuth`. The filter value maps each host to the env-var/PHP-constant name that holds its token, mirroring the github.com flow.
+
+**Parameters**:
+
+- `$hosts` (array<string,string>) - Map of `host` → `ENV_OR_CONSTANT_NAME`. Hosts are lower-cased before comparison.
+
+**Return**: Map array.
+
+**Usage**:
+```php
+add_filter(
+    'datamachine_bundle_source_ghe_hosts',
+    function ( array $hosts ): array {
+        $hosts['github.a8c.com'] = 'DATAMACHINE_A8C_GHE_TOKEN';
+        return $hosts;
+    }
+);
+```
+
+With this filter and a `DATAMACHINE_A8C_GHE_TOKEN` env var (or PHP constant) configured, `wp datamachine agent install https://github.a8c.com/team/brain/archive/refs/heads/main.zip` succeeds without any per-call flag. See [Agent Bundles → Authenticated Bundle Sources](../../core-system/agent-bundles.md#authenticated-bundle-sources) for end-to-end examples.
+
 ### `datamachine_agent_export_manifest`
 
 **Purpose**: Adjust the export profile (`soul`, `memory`, `user`, `daily_memory`, `agent_config`, `pipelines`, `flows`, `handler_auth`) used by `AgentBundler::export_directory_object()`. Passed through `share`, `backup`, and `fork` profile defaults before this filter runs.

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -18,6 +18,7 @@ use DataMachine\Core\Database\Agents\AgentAccess;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\BundleSource;
+use DataMachine\Engine\Bundle\BundleSourceAuth;
 use DataMachine\Engine\Bundle\BundleValidationException;
 
 defined( 'ABSPATH' ) || exit;
@@ -256,6 +257,14 @@ class AgentAbilities {
 							'dry_run'     => array(
 								'type'        => 'boolean',
 								'description' => 'Validate and summarize without writing.',
+							),
+							'token'       => array(
+								'type'        => 'string',
+								'description' => 'Auth token for private archive downloads (e.g. GitHub PAT, GHE PAT). Used for this single resolve(); never persisted, never logged. Prefer token_env for repeated use.',
+							),
+							'token_env'   => array(
+								'type'        => 'string',
+								'description' => 'Environment variable (or PHP constant) name to read the auth token from. Used for this single resolve(); never persisted, never logged.',
 							),
 						),
 					),
@@ -680,13 +689,18 @@ class AgentAbilities {
 			);
 		}
 
-		$resolved = BundleSource::resolve( $source );
+		$context  = self::build_resolve_context( $input );
+		$resolved = BundleSource::resolve( $source, $context );
 		if ( is_wp_error( $resolved ) ) {
 			return array(
 				'success' => false,
 				'error'   => $resolved->get_error_message(),
 			);
 		}
+
+		// Snapshot the revision before any nested resolve() call could
+		// reset it.
+		$revision = BundleSource::is_remote( $source ) ? BundleSource::last_resolved_revision() : null;
 
 		$on_conflict = (string) ( $input['on_conflict'] ?? 'error' );
 		if ( ! in_array( $on_conflict, array( 'error', 'skip' ), true ) ) {
@@ -722,10 +736,13 @@ class AgentAbilities {
 		}
 
 		// Stamp the original remote source so installed bundle metadata
-		// records where this came from. v1 leaves source_revision empty
-		// because GitHub archive responses don't expose a usable SHA.
+		// records where this came from. source_revision is best-effort
+		// from the response ETag for GitHub archives (#1830).
 		if ( BundleSource::is_remote( $source ) && empty( $bundle['source_ref'] ) ) {
 			$bundle['source_ref'] = $source;
+		}
+		if ( null !== $revision && empty( $bundle['source_revision'] ) ) {
+			$bundle['source_revision'] = $revision;
 		}
 
 		$slug = sanitize_title( (string) ( $bundle['agent']['agent_slug'] ?? '' ) );
@@ -780,6 +797,23 @@ class AgentAbilities {
 		$result['auth_warnings'] = $auth_warnings;
 
 		return $result;
+	}
+
+	/**
+	 * Build the {@see BundleSource::resolve()} context array from the
+	 * import-agent ability inputs. Honors `token` (literal) and
+	 * `token_env` (env-var or PHP constant name) — both short-circuit
+	 * the env/constant/option/filter chain in
+	 * {@see \DataMachine\Engine\Bundle\BundleSourceAuth::token_for()}.
+	 *
+	 * @param array $input Ability input.
+	 * @return array
+	 */
+	private static function build_resolve_context( array $input ): array {
+		return BundleSourceAuth::build_resolve_context(
+			isset( $input['token'] ) ? (string) $input['token'] : null,
+			isset( $input['token_env'] ) ? (string) $input['token_env'] : null
+		);
 	}
 
 	private static function load_import_bundle( AgentBundler $bundler, string $source ): ?array {

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -19,6 +19,7 @@ use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
 use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
 use DataMachine\Engine\Bundle\BundleSource;
+use DataMachine\Engine\Bundle\BundleSourceAuth;
 use DataMachine\Engine\Bundle\PortableSlug;
 use WP_CLI;
 
@@ -55,6 +56,12 @@ class AgentBundleCommand extends BaseCommand {
 	 *
 	 * [--reconcile-runtime]
 	 * : Replace preserved flow runtime queues and scheduling with the bundle seed on existing bundle-owned flows.
+	 *
+	 * [--token=<token>]
+	 * : Auth token for private archive downloads. Used for this single resolve(); never persisted, never logged.
+	 *
+	 * [--token-env=<varname>]
+	 * : Environment variable (or PHP constant) name to read the auth token from. Preferred over --token for shell-history hygiene.
 	 *
 	 * [--format=<format>]
 	 * : Output format.
@@ -152,6 +159,12 @@ class AgentBundleCommand extends BaseCommand {
 	 * [--slug=<slug>]
 	 * : Override target agent slug.
 	 *
+	 * [--token=<token>]
+	 * : Auth token for private archive downloads. Used for this single resolve(); never persisted, never logged.
+	 *
+	 * [--token-env=<varname>]
+	 * : Environment variable (or PHP constant) name to read the auth token from. Preferred over --token for shell-history hygiene.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -162,7 +175,7 @@ class AgentBundleCommand extends BaseCommand {
 	 * ---
 	 */
 	public function diff( array $args, array $assoc_args ): void {
-		$bundle = $this->load_bundle_arg( $args );
+		$bundle = $this->load_bundle_arg( $args, $assoc_args );
 		$plan   = $this->add_runtime_drift_to_plan(
 			$this->plan_for_bundle( $bundle, (string) ( $assoc_args['slug'] ?? '' ) )->to_array(),
 			$bundle,
@@ -209,6 +222,12 @@ class AgentBundleCommand extends BaseCommand {
 	 *   - burn-in-safe
 	 * ---
 	 *
+	 * [--token=<token>]
+	 * : Auth token for private archive downloads. Used for this single resolve(); never persisted, never logged.
+	 *
+	 * [--token-env=<varname>]
+	 * : Environment variable (or PHP constant) name to read the auth token from. Preferred over --token for shell-history hygiene.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -219,7 +238,7 @@ class AgentBundleCommand extends BaseCommand {
 	 * ---
 	 */
 	public function upgrade( array $args, array $assoc_args ): void {
-		$bundle            = $this->load_bundle_arg( $args );
+		$bundle            = $this->load_bundle_arg( $args, $assoc_args );
 		$slug              = (string) ( $assoc_args['slug'] ?? '' );
 		$plan              = $this->plan_for_bundle( $bundle, $slug );
 		$dry_run           = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
@@ -482,7 +501,7 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	private function run_install( array $args, array $assoc_args ): void {
-		$bundle            = $this->load_bundle_arg( $args );
+		$bundle            = $this->load_bundle_arg( $args, $assoc_args );
 		$slug              = isset( $assoc_args['slug'] ) ? sanitize_title( (string) $assoc_args['slug'] ) : null;
 		$owner             = isset( $assoc_args['owner'] ) ? $this->resolve_user_id( $assoc_args['owner'] ) : 0;
 		$dry_run           = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
@@ -575,16 +594,21 @@ class AgentBundleCommand extends BaseCommand {
 		return $drifts;
 	}
 
-	private function load_bundle_arg( array $args ): array {
+	private function load_bundle_arg( array $args, array $assoc_args = array() ): array {
 		$source = (string) ( $args[0] ?? '' );
 		if ( '' === $source ) {
 			WP_CLI::error( 'Bundle source is required.' );
 		}
 
-		$resolved = BundleSource::resolve( $source );
+		$context  = $this->build_resolve_context( $assoc_args );
+		$resolved = BundleSource::resolve( $source, $context );
 		if ( is_wp_error( $resolved ) ) {
 			WP_CLI::error( $resolved->get_error_message() );
 		}
+
+		// Snapshot the revision before any downstream resolve() call
+		// resets it (e.g. via re-entry through abilities).
+		$revision = BundleSource::is_remote( $source ) ? BundleSource::last_resolved_revision() : null;
 
 		$bundle = null;
 		if ( is_dir( $resolved ) ) {
@@ -606,13 +630,42 @@ class AgentBundleCommand extends BaseCommand {
 
 		// Stamp the original source URL into the bundle so installed
 		// metadata records where this came from. AgentBundler::import()
-		// reads $bundle['source_ref']. source_revision is left empty in
-		// v1 — GitHub archive responses don't expose a usable SHA.
+		// reads $bundle['source_ref']. source_revision is best-effort:
+		// captured from the response ETag for GitHub archives (#1830).
 		if ( BundleSource::is_remote( $source ) && empty( $bundle['source_ref'] ) ) {
 			$bundle['source_ref'] = $source;
 		}
+		if ( null !== $revision && empty( $bundle['source_revision'] ) ) {
+			$bundle['source_revision'] = $revision;
+		}
 
 		return $bundle;
+	}
+
+	/**
+	 * Build the {@see BundleSource::resolve()} context array from CLI
+	 * --token / --token-env flags. The CLI token short-circuits the
+	 * env/constant/option/filter chain in BundleSourceAuth::token_for().
+	 *
+	 * @param array $assoc_args WP_CLI assoc args.
+	 * @return array
+	 */
+	private function build_resolve_context( array $assoc_args ): array {
+		$token     = isset( $assoc_args['token'] ) ? (string) $assoc_args['token'] : null;
+		$token_env = isset( $assoc_args['token-env'] ) ? (string) $assoc_args['token-env'] : null;
+
+		$context = BundleSourceAuth::build_resolve_context( $token, $token_env );
+
+		if ( null !== $token_env && '' !== trim( (string) $token_env ) && empty( $context['cli_token'] ) && null === $token ) {
+			WP_CLI::warning(
+				sprintf(
+					'--token-env=%s did not resolve to a non-empty token. Falling back to environment/constant/option chain.',
+					trim( (string) $token_env )
+				)
+			);
+		}
+
+		return $context;
 	}
 
 	private function plan_for_bundle( array $bundle, string $slug = '' ): \DataMachine\Engine\Bundle\AgentBundleUpgradePlan {

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -1081,6 +1081,12 @@ class AgentsCommand extends AgentBundleCommand {
 	 * [--yes]
 	 * : Skip confirmation prompt.
 	 *
+	 * [--token=<token>]
+	 * : Auth token for private archive downloads. Used for this single resolve(); never persisted, never logged.
+	 *
+	 * [--token-env=<varname>]
+	 * : Environment variable (or PHP constant) name to read the auth token from. Preferred over --token for shell-history hygiene.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Import from ZIP
@@ -1139,15 +1145,24 @@ class AgentsCommand extends AgentBundleCommand {
 			return;
 		}
 
-		$result = $ability->execute(
-			array(
-				'source'      => $path,
-				'slug'        => $new_slug,
-				'owner_id'    => $owner_id,
-				'on_conflict' => (string) ( $assoc_args['on-conflict'] ?? 'error' ),
-				'dry_run'     => $dry_run,
-			)
+		$ability_input = array(
+			'source'      => $path,
+			'slug'        => $new_slug,
+			'owner_id'    => $owner_id,
+			'on_conflict' => (string) ( $assoc_args['on-conflict'] ?? 'error' ),
+			'dry_run'     => $dry_run,
 		);
+
+		// Forward token / token_env to the ability schema. The ability
+		// honors them inside BundleSource::resolve() via $context.
+		if ( isset( $assoc_args['token'] ) ) {
+			$ability_input['token'] = (string) $assoc_args['token'];
+		}
+		if ( isset( $assoc_args['token-env'] ) ) {
+			$ability_input['token_env'] = (string) $assoc_args['token-env'];
+		}
+
+		$result = $ability->execute( $ability_input );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to import agent bundle.' );

--- a/inc/Engine/Bundle/BundleSource.php
+++ b/inc/Engine/Bundle/BundleSource.php
@@ -28,6 +28,19 @@ defined( 'ABSPATH' ) || exit;
 final class BundleSource {
 
 	/**
+	 * Last revision (git SHA) parsed from a successful remote resolve.
+	 *
+	 * Reset at the start of every {@see self::resolve()} call. Best-effort
+	 * GitHub-only capture from response ETag — null when the source was
+	 * local, the response had no ETag, or the ETag did not parse as a
+	 * 40-hex git SHA. Callers that care should snapshot this immediately
+	 * after a successful resolve.
+	 *
+	 * @var string|null
+	 */
+	private static ?string $last_resolved_revision = null;
+
+	/**
 	 * Resolve a bundle source string into a local path.
 	 *
 	 * Local paths (directories, .zip, .json) that exist on disk are
@@ -40,10 +53,17 @@ final class BundleSource {
 	 * Callers MUST invoke {@see self::cleanup()} after they are done
 	 * with the resolved path to delete temp files.
 	 *
-	 * @param string $source Bundle source — local path or remote URL.
+	 * @param string $source  Bundle source — local path or remote URL.
+	 * @param array  $context Optional resolution context (e.g. CLI-supplied token).
+	 *                        Recognized keys:
+	 *                        - 'cli_token' (string): explicit token supplied by the
+	 *                          caller; short-circuits the env/constant/option/filter
+	 *                          chain inside {@see BundleSourceAuth::token_for()}.
 	 * @return string|WP_Error Absolute local filesystem path on success.
 	 */
-	public static function resolve( string $source ) {
+	public static function resolve( string $source, array $context = array() ) {
+		self::$last_resolved_revision = null;
+
 		$source = trim( $source );
 
 		if ( '' === $source ) {
@@ -78,33 +98,223 @@ final class BundleSource {
 
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 
-		$timeout   = (int) apply_filters( 'datamachine_bundle_source_download_timeout', 60, $source );
-		$temp_file = download_url( $fetch_url, $timeout );
+		$args = self::default_download_args( $source, $fetch_url, $context );
 
-		if ( is_wp_error( $temp_file ) ) {
-			return new WP_Error(
-				'datamachine_bundle_source_download_failed',
-				sprintf(
-					'Failed to download bundle from %s: %s',
-					$fetch_url,
-					$temp_file->get_error_message()
-				)
-			);
+		/**
+		 * Filter HTTP request args used to download a remote bundle.
+		 *
+		 * Consumers can inject Authorization headers, custom user-agents,
+		 * or any other args supported by wp_safe_remote_get(). The args
+		 * include 'stream' => true and 'filename' so the body is streamed
+		 * to disk instead of buffered in memory; consumers should leave
+		 * those keys alone.
+		 *
+		 * The token resolution chain in BundleSourceAuth::token_for()
+		 * uses this filter via BundleSourceAuth::inject_github_auth() to
+		 * auto-attach an Authorization: Bearer header for github.com,
+		 * raw.githubusercontent.com, and configured GHE hosts when a
+		 * token is available.
+		 *
+		 * @param array  $args      HTTP args. Includes 'timeout', 'headers',
+		 *                          'redirection', 'user-agent', 'stream',
+		 *                          'filename', and a private 'datamachine_bundle_source'
+		 *                          key carrying the original $source and any
+		 *                          $context such as 'cli_token'.
+		 * @param string $source    Original (un-normalized) source string.
+		 * @param string $fetch_url Normalized URL the request will hit.
+		 */
+		$args = (array) apply_filters(
+			'datamachine_bundle_source_download_args',
+			$args,
+			$source,
+			$fetch_url
+		);
+
+		$result = self::fetch_to_tempfile( $fetch_url, $args );
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
-		// download_url() returns a temp file with no extension. The
+		$temp_file = (string) $result['path'];
+		if ( ! empty( $result['sha'] ) ) {
+			self::$last_resolved_revision = (string) $result['sha'];
+		}
+
+		// fetch_to_tempfile() streams to a tempfile with no extension. The
 		// downstream parser branches on extension (.zip vs .json), so
 		// rename the temp file to preserve the extension from the URL.
 		$expected_ext = preg_match( '#\.(zip|json)(\?.*)?$#i', $fetch_url, $m ) ? strtolower( $m[1] ) : '';
 		if ( '' !== $expected_ext ) {
 			$with_ext = $temp_file . '.' . $expected_ext;
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename,WordPress.PHP.NoSilencedErrors.Discouraged
 			if ( @rename( $temp_file, $with_ext ) ) {
 				$temp_file = $with_ext;
 			}
 		}
 
 		return $temp_file;
+	}
+
+	/**
+	 * Return the source revision (git SHA) captured from the most recent
+	 * successful remote resolve, or null when none was available.
+	 *
+	 * GitHub archive responses ship the commit SHA via the ETag header
+	 * (`W/"<sha>:<format>"` or `"<sha>"`). When present and parseable,
+	 * the SHA is captured here so callers can stamp it onto the bundle
+	 * as `source_revision`. Local resolves and resolves that did not
+	 * yield an ETag return null.
+	 *
+	 * @return string|null 40-hex git SHA on success; null otherwise.
+	 */
+	public static function last_resolved_revision(): ?string {
+		return self::$last_resolved_revision;
+	}
+
+	/**
+	 * Default HTTP args for a remote bundle fetch.
+	 *
+	 * @param string $source    Original source string.
+	 * @param string $fetch_url Normalized URL.
+	 * @param array  $context   Optional resolution context (e.g. CLI token).
+	 * @return array
+	 */
+	private static function default_download_args( string $source, string $fetch_url, array $context = array() ): array {
+		unset( $fetch_url );
+
+		$timeout    = (int) apply_filters( 'datamachine_bundle_source_download_timeout', 60, $source );
+		$user_agent = 'DataMachine/' . ( defined( 'DATAMACHINE_VERSION' ) ? DATAMACHINE_VERSION : 'dev' );
+
+		return array(
+			'timeout'                   => $timeout,
+			'redirection'               => 5,
+			'user-agent'                => $user_agent,
+			'headers'                   => array(),
+			// Internal handle for filter callbacks that need to know
+			// who is calling and which one-off context (e.g. cli_token)
+			// applies. Stripped before the request is dispatched so it
+			// never reaches the wire.
+			'datamachine_bundle_source' => array(
+				'source'  => $source,
+				'context' => $context,
+			),
+		);
+	}
+
+	/**
+	 * Stream a remote URL to a tempfile and capture the response ETag.
+	 *
+	 * Uses wp_safe_remote_get() to enforce the SSL/host policy WP applies
+	 * to user-supplied URLs. The body is streamed directly to disk via
+	 * WP_Http's 'stream' + 'filename' args so multi-MB bundles never sit
+	 * in PHP memory.
+	 *
+	 * @param string $fetch_url Normalized URL.
+	 * @param array  $args      Request args (already passed through the
+	 *                          datamachine_bundle_source_download_args filter).
+	 * @return array{path:string,etag:?string,sha:?string}|WP_Error
+	 */
+	private static function fetch_to_tempfile( string $fetch_url, array $args ) {
+		$temp_path = wp_tempnam( $fetch_url );
+		if ( '' === $temp_path ) {
+			return new WP_Error(
+				'datamachine_bundle_source_tempfile_failed',
+				sprintf( 'Failed to allocate a temporary file for bundle download: %s', $fetch_url )
+			);
+		}
+
+		// Strip the internal handle before the request flies.
+		unset( $args['datamachine_bundle_source'] );
+
+		$args['stream']   = true;
+		$args['filename'] = $temp_path;
+
+		$response = wp_safe_remote_get( $fetch_url, $args );
+
+		if ( is_wp_error( $response ) ) {
+			if ( file_exists( $temp_path ) ) {
+				wp_delete_file( $temp_path );
+			}
+
+			return new WP_Error(
+				'datamachine_bundle_source_download_failed',
+				sprintf(
+					'Failed to download bundle from %s: %s',
+					$fetch_url,
+					$response->get_error_message()
+				)
+			);
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( $code < 200 || $code >= 300 ) {
+			if ( file_exists( $temp_path ) ) {
+				wp_delete_file( $temp_path );
+			}
+
+			if ( in_array( $code, array( 401, 403, 404 ), true ) ) {
+				return new WP_Error(
+					'datamachine_bundle_source_auth_required',
+					sprintf(
+						'Authentication required (HTTP %d) for %s. Configure a token via DATAMACHINE_GITHUB_TOKEN, the datamachine_bundle_source_download_args filter, or the --token / --token-env CLI flags.',
+						$code,
+						$fetch_url
+					)
+				);
+			}
+
+			return new WP_Error(
+				'datamachine_bundle_source_http_error',
+				sprintf( 'HTTP %d fetching %s', $code, $fetch_url )
+			);
+		}
+
+		$etag = (string) wp_remote_retrieve_header( $response, 'etag' );
+		$sha  = self::parse_sha_from_etag( $etag );
+
+		return array(
+			'path' => $temp_path,
+			'etag' => '' !== $etag ? $etag : null,
+			'sha'  => $sha,
+		);
+	}
+
+	/**
+	 * Parse a git SHA out of a response ETag.
+	 *
+	 * GitHub archive endpoints serve ETags in a couple of shapes:
+	 *
+	 *   - `W/"<40-hex>:<format>"` — weak validator for archive endpoints.
+	 *   - `"<40-hex>"` — strong validator on some raw / blob endpoints.
+	 *
+	 * Anything else returns null. The SHA is best-effort: callers must
+	 * tolerate a null result rather than fail the install.
+	 *
+	 * @param string $etag Raw ETag header value.
+	 * @return string|null Lower-case 40-hex SHA on success; null otherwise.
+	 */
+	public static function parse_sha_from_etag( string $etag ): ?string {
+		$etag = trim( $etag );
+		if ( '' === $etag ) {
+			return null;
+		}
+
+		// Strip leading W/ weakness marker.
+		if ( 0 === strncasecmp( $etag, 'W/', 2 ) ) {
+			$etag = substr( $etag, 2 );
+		}
+
+		// Strip surrounding double quotes.
+		$etag = trim( $etag, '"' );
+
+		// Match either a bare 40-hex SHA or a SHA followed by a colon
+		// and an arbitrary format suffix (e.g. ':zipball', ':tarball').
+		if ( preg_match( '/^([0-9a-f]{40})(?::.*)?$/i', $etag, $m ) ) {
+			return strtolower( $m[1] );
+		}
+
+		return null;
 	}
 
 	/**

--- a/inc/Engine/Bundle/BundleSourceAuth.php
+++ b/inc/Engine/Bundle/BundleSourceAuth.php
@@ -1,0 +1,333 @@
+<?php
+/**
+ * Built-in GitHub.com / GHE auth helper for BundleSource downloads.
+ *
+ * Hooks into datamachine_bundle_source_download_args to attach an
+ * Authorization: Bearer header when:
+ *
+ *   - The fetch URL host is github.com or raw.githubusercontent.com, OR
+ *   - The fetch URL host matches an entry in the
+ *     datamachine_bundle_source_ghe_hosts filter map.
+ *
+ * Token resolution chain (first hit wins):
+ *
+ *   1. CLI-supplied token (passed via $context['cli_token']).
+ *   2. Environment variable.
+ *   3. PHP constant of the same name.
+ *   4. WP option (github.com only): datamachine_bundle_source_github_token.
+ *   5. datamachine_bundle_source_token_for_url filter fallback.
+ *
+ * The helper never persists a token. Errors that surface from
+ * BundleSource::fetch_to_tempfile() include the URL but redact the
+ * Authorization header — see {@see self::redact_args_for_log()}.
+ *
+ * @package DataMachine\Engine\Bundle
+ * @since   0.10.4
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Token resolution + GitHub/GHE Authorization injection.
+ */
+final class BundleSourceAuth {
+
+	/**
+	 * Default env/constant name for github.com and raw.githubusercontent.com.
+	 */
+	public const GITHUB_TOKEN_ENV = 'DATAMACHINE_GITHUB_TOKEN';
+
+	/**
+	 * Build a {@see BundleSource::resolve()} context array from caller-
+	 * supplied token / token_env values.
+	 *
+	 * Used by both the WP-CLI surface and the import-agent ability so the
+	 * --token / --token-env (or `token` / `token_env` ability fields)
+	 * always short-circuit the env/constant/option/filter chain identically.
+	 *
+	 * Returns an empty array when no usable token was found, leaving the
+	 * default resolution chain in {@see self::token_for()} to fire.
+	 *
+	 * @param string|null $token       Literal token. Wins over $token_env.
+	 * @param string|null $token_env   Env-var or PHP-constant name to read.
+	 * @return array{cli_token?:string}
+	 */
+	public static function build_resolve_context( ?string $token, ?string $token_env ): array {
+		$resolved = '';
+
+		if ( null !== $token ) {
+			$resolved = trim( $token );
+		}
+
+		if ( '' === $resolved && null !== $token_env ) {
+			$env_var = trim( $token_env );
+			if ( '' !== $env_var ) {
+				$from_env = getenv( $env_var );
+				if ( is_string( $from_env ) ) {
+					$resolved = trim( $from_env );
+				}
+				if ( '' === $resolved && defined( $env_var ) ) {
+					$constant_value = constant( $env_var );
+					if ( is_string( $constant_value ) ) {
+						$resolved = trim( $constant_value );
+					}
+				}
+			}
+		}
+
+		if ( '' === $resolved ) {
+			return array();
+		}
+
+		return array( 'cli_token' => $resolved );
+	}
+
+	/**
+	 * WP option that stores a github.com token (lowest precedence).
+	 */
+	public const GITHUB_TOKEN_OPTION = 'datamachine_bundle_source_github_token';
+
+	/**
+	 * Hook the GitHub/GHE auto-injection callback into the bundle source
+	 * download args filter. Idempotent.
+	 */
+	public static function register(): void {
+		static $registered = false;
+		if ( $registered ) {
+			return;
+		}
+		$registered = true;
+
+		add_filter(
+			'datamachine_bundle_source_download_args',
+			array( self::class, 'inject_github_auth' ),
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Filter callback — auto-attach Authorization for github.com /
+	 * raw.githubusercontent.com / configured GHE hosts.
+	 *
+	 * @param array  $args      Request args.
+	 * @param string $source    Original source string.
+	 * @param string $fetch_url Normalized URL.
+	 * @return array
+	 */
+	public static function inject_github_auth( array $args, string $source, string $fetch_url ): array {
+		unset( $source );
+
+		$host = self::host_for( $fetch_url );
+		if ( '' === $host ) {
+			return $args;
+		}
+
+		// Already-configured Authorization header? Respect it; some
+		// callers manage their own token chain via the filter directly.
+		if ( ! empty( $args['headers']['Authorization'] ) || ! empty( $args['headers']['authorization'] ) ) {
+			return $args;
+		}
+
+		$context   = is_array( $args['datamachine_bundle_source']['context'] ?? null )
+			? (array) $args['datamachine_bundle_source']['context']
+			: array();
+		$is_github = self::is_github_host( $host );
+		$is_ghe    = ! $is_github && array_key_exists( $host, self::ghe_hosts() );
+
+		if ( ! $is_github && ! $is_ghe ) {
+			return $args;
+		}
+
+		$token = self::token_for( $fetch_url, $context );
+		if ( null === $token || '' === $token ) {
+			return $args;
+		}
+
+		if ( ! is_array( $args['headers'] ?? null ) ) {
+			$args['headers'] = array();
+		}
+
+		$args['headers']['Authorization'] = 'Bearer ' . $token;
+
+		return $args;
+	}
+
+	/**
+	 * Resolve a token for a given fetch URL.
+	 *
+	 * Resolution chain (first non-empty hit wins):
+	 *   1. $context['cli_token']
+	 *   2. Environment variable for the host
+	 *   3. PHP constant of the same name
+	 *   4. WP option (github.com only)
+	 *   5. datamachine_bundle_source_token_for_url filter
+	 *
+	 * @param string $fetch_url Normalized URL.
+	 * @param array  $context   Resolution context.
+	 * @return string|null
+	 */
+	public static function token_for( string $fetch_url, array $context = array() ): ?string {
+		$host = self::host_for( $fetch_url );
+
+		// 1. CLI-supplied token short-circuits everything.
+		if ( ! empty( $context['cli_token'] ) ) {
+			$cli_token = trim( (string) $context['cli_token'] );
+			if ( '' !== $cli_token ) {
+				return $cli_token;
+			}
+		}
+
+		$env_var = self::env_var_for_host( $host );
+
+		// 2. Environment variable.
+		if ( '' !== $env_var ) {
+			$from_env = getenv( $env_var );
+			if ( is_string( $from_env ) && '' !== trim( $from_env ) ) {
+				return trim( $from_env );
+			}
+		}
+
+		// 3. PHP constant of the same name.
+		if ( '' !== $env_var && defined( $env_var ) ) {
+			$from_const = constant( $env_var );
+			if ( is_string( $from_const ) && '' !== trim( $from_const ) ) {
+				return trim( $from_const );
+			}
+		}
+
+		// 4. WP option (github.com only).
+		if ( self::is_github_host( $host ) && function_exists( 'get_option' ) ) {
+			$from_option = (string) get_option( self::GITHUB_TOKEN_OPTION, '' );
+			if ( '' !== trim( $from_option ) ) {
+				return trim( $from_option );
+			}
+		}
+
+		/**
+		 * Filter fallback for callers that store secrets elsewhere
+		 * (sigillo, AWS Secrets Manager, etc.).
+		 *
+		 * Return null/empty to leave the resolution unresolved.
+		 *
+		 * @param string|null $token     Current candidate token (always null when this fires).
+		 * @param string      $fetch_url Normalized URL.
+		 * @param string      $host      Lower-cased host.
+		 * @param array       $context   Resolution context.
+		 */
+		$filtered = apply_filters( 'datamachine_bundle_source_token_for_url', null, $fetch_url, $host, $context );
+		if ( is_string( $filtered ) && '' !== trim( $filtered ) ) {
+			return trim( $filtered );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get configured GHE hosts.
+	 *
+	 * Filter shape: `[ '<host>' => '<env-var-or-constant-name>' ]`. The
+	 * env/constant name is the symbol the resolution chain will read for
+	 * tokens scoped to that host.
+	 *
+	 * @return array<string,string>
+	 */
+	public static function ghe_hosts(): array {
+		/**
+		 * Map of GHE host names to the env-var/constant that holds their
+		 * token. Hosts are lower-cased before comparison.
+		 *
+		 * Example:
+		 *
+		 *     add_filter( 'datamachine_bundle_source_ghe_hosts', function ( $hosts ) {
+		 *         $hosts['github.a8c.com'] = 'DATAMACHINE_A8C_GHE_TOKEN';
+		 *         return $hosts;
+		 *     } );
+		 *
+		 * @param array<string,string> $hosts Host → env/constant name map.
+		 */
+		$hosts = (array) apply_filters( 'datamachine_bundle_source_ghe_hosts', array() );
+
+		$normalized = array();
+		foreach ( $hosts as $host => $env_var ) {
+			$host    = strtolower( trim( (string) $host ) );
+			$env_var = trim( (string) $env_var );
+			if ( '' === $host || '' === $env_var ) {
+				continue;
+			}
+			$normalized[ $host ] = $env_var;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Redact sensitive headers in HTTP args before logging.
+	 *
+	 * @param array $args HTTP args.
+	 * @return array
+	 */
+	public static function redact_args_for_log( array $args ): array {
+		if ( ! empty( $args['headers'] ) && is_array( $args['headers'] ) ) {
+			foreach ( $args['headers'] as $name => $value ) {
+				if ( 0 === strcasecmp( (string) $name, 'authorization' ) ) {
+					$args['headers'][ $name ] = '[redacted]';
+				}
+			}
+		}
+
+		unset( $args['datamachine_bundle_source'] );
+
+		return $args;
+	}
+
+	/**
+	 * Lower-cased host portion of a URL, or '' on parse failure.
+	 *
+	 * @param string $url URL.
+	 * @return string
+	 */
+	private static function host_for( string $url ): string {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( ! is_string( $host ) || '' === $host ) {
+			return '';
+		}
+		return strtolower( $host );
+	}
+
+	/**
+	 * Is the given host one of the built-in github.com hosts?
+	 *
+	 * @param string $host Lower-cased host.
+	 * @return bool
+	 */
+	private static function is_github_host( string $host ): bool {
+		return 'github.com' === $host || 'raw.githubusercontent.com' === $host;
+	}
+
+	/**
+	 * Resolve the env var / constant name to read for tokens scoped to
+	 * a given host. Returns '' when the host has no configured slot.
+	 *
+	 * @param string $host Lower-cased host.
+	 * @return string
+	 */
+	private static function env_var_for_host( string $host ): string {
+		if ( '' === $host ) {
+			return '';
+		}
+
+		if ( self::is_github_host( $host ) ) {
+			return self::GITHUB_TOKEN_ENV;
+		}
+
+		$ghe_hosts = self::ghe_hosts();
+		if ( array_key_exists( $host, $ghe_hosts ) ) {
+			return $ghe_hosts[ $host ];
+		}
+
+		return '';
+	}
+}

--- a/tests/bundle-source-auth-smoke.php
+++ b/tests/bundle-source-auth-smoke.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Behavior smoke test for BundleSourceAuth (#1830).
+ *
+ * Run with: php tests/bundle-source-auth-smoke.php
+ */
+
+namespace {
+	$datamachine_test_abspath = sys_get_temp_dir() . '/datamachine-bundle-auth-test-' . uniqid() . '/';
+	@mkdir( $datamachine_test_abspath, 0777, true );
+	define( 'ABSPATH', $datamachine_test_abspath );
+
+	register_shutdown_function( function () use ( $datamachine_test_abspath ) {
+		if ( is_dir( $datamachine_test_abspath ) ) {
+			@rmdir( $datamachine_test_abspath );
+		}
+	} );
+
+	$GLOBALS['datamachine_test_options'] = array();
+	$GLOBALS['datamachine_test_filters'] = array();
+
+	function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+		$override = $GLOBALS['datamachine_test_filters'][ $hook ] ?? null;
+		if ( is_callable( $override ) ) {
+			return $override( $value, ...$args );
+		}
+		return $value;
+	}
+
+	function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): bool {
+		$GLOBALS['datamachine_test_added_filters'][ $hook ][] = $cb;
+		return true;
+	}
+
+	function get_option( string $key, mixed $default = false ): mixed {
+		return $GLOBALS['datamachine_test_options'][ $key ] ?? $default;
+	}
+
+	function wp_parse_url( string $url, int $component = -1 ): mixed {
+		$parts = parse_url( $url );
+		if ( -1 === $component ) {
+			return $parts;
+		}
+		$map = array(
+			PHP_URL_HOST => 'host',
+		);
+		$key = $map[ $component ] ?? null;
+		return $key && isset( $parts[ $key ] ) ? $parts[ $key ] : null;
+	}
+}
+
+namespace DataMachine\Engine\Bundle {
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceAuth.php';
+}
+
+namespace {
+	use DataMachine\Engine\Bundle\BundleSourceAuth;
+
+	$assertions = 0;
+	$assert     = function ( string $label, bool $condition ) use ( &$assertions ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			fwrite( STDERR, "FAIL: {$label}\n" );
+			exit( 1 );
+		}
+		echo "ok - {$label}\n";
+	};
+
+	$reset = function () {
+		$GLOBALS['datamachine_test_filters'] = array();
+		$GLOBALS['datamachine_test_options'] = array();
+		// Best effort: undo putenv from previous block.
+		putenv( 'DATAMACHINE_GITHUB_TOKEN' );
+		putenv( 'DATAMACHINE_A8C_GHE_TOKEN' );
+	};
+
+	echo "=== BundleSourceAuth Smoke (#1830) ===\n";
+
+	echo "\n[1] token_for() — resolution chain\n";
+
+	$reset();
+
+	// 1. CLI token short-circuits everything.
+	putenv( 'DATAMACHINE_GITHUB_TOKEN=from-env' );
+	$assert(
+		'cli_token wins over env',
+		'cli-token' === BundleSourceAuth::token_for( 'https://github.com/o/r/archive/refs/heads/main.zip', array( 'cli_token' => 'cli-token' ) )
+	);
+
+	// 2. env wins when no CLI.
+	$reset();
+	putenv( 'DATAMACHINE_GITHUB_TOKEN=env-token' );
+	$assert(
+		'env var wins when no CLI',
+		'env-token' === BundleSourceAuth::token_for( 'https://github.com/o/r/archive/refs/heads/main.zip' )
+	);
+
+	// 3. Constant wins when no env.
+	$reset();
+	if ( ! defined( 'DATAMACHINE_GITHUB_TOKEN' ) ) {
+		define( 'DATAMACHINE_GITHUB_TOKEN', 'const-token' );
+	}
+	$assert(
+		'constant wins when no env',
+		'const-token' === BundleSourceAuth::token_for( 'https://github.com/o/r/archive/refs/heads/main.zip' )
+	);
+
+	// 4. WP option wins when no env/const.
+	// (Constant is already defined above; create a fresh test process surrogate by mocking via filter.)
+	// Since we can't undefine the constant, exercise the option path via the filter fallback (no const, no env).
+	$reset();
+	// Note: const is sticky from the previous test; the option path would only apply when the const is absent.
+	// To verify option path is read, test through the filter fallback chain:
+	$GLOBALS['datamachine_test_filters']['datamachine_bundle_source_token_for_url'] = function ( $value, $url, $host, $context ) {
+		return null !== $value ? $value : 'filter-fallback';
+	};
+	// Constant DATAMACHINE_GITHUB_TOKEN is still defined → still wins.
+	$assert(
+		'constant still preferred over filter fallback',
+		'const-token' === BundleSourceAuth::token_for( 'https://github.com/o/r/archive/refs/heads/main.zip' )
+	);
+
+	// Filter fallback fires for hosts with no env/const slot.
+	$reset();
+	$GLOBALS['datamachine_test_filters']['datamachine_bundle_source_token_for_url'] = function ( $value, $url, $host, $context ) {
+		if ( null !== $value ) {
+			return $value;
+		}
+		return 'sigillo://secret/' . $host;
+	};
+	$assert(
+		'filter fallback fires for non-default host',
+		'sigillo://secret/example.com' === BundleSourceAuth::token_for( 'https://example.com/path.zip' )
+	);
+
+	echo "\n[2] inject_github_auth() — header injection\n";
+
+	$reset();
+	putenv( 'DATAMACHINE_GITHUB_TOKEN=ghp_test' );
+
+	$args = array(
+		'headers'                   => array(),
+		'datamachine_bundle_source' => array(
+			'source'  => 'https://github.com/o/r/archive/refs/heads/main.zip',
+			'context' => array(),
+		),
+	);
+	$out = BundleSourceAuth::inject_github_auth( $args, $args['datamachine_bundle_source']['source'], $args['datamachine_bundle_source']['source'] );
+	$assert(
+		'github.com archive gets Bearer header from env',
+		( $out['headers']['Authorization'] ?? '' ) === 'Bearer ghp_test'
+	);
+
+	// raw.githubusercontent.com same shape.
+	$reset();
+	putenv( 'DATAMACHINE_GITHUB_TOKEN=ghp_raw' );
+	$args = array(
+		'headers'                   => array(),
+		'datamachine_bundle_source' => array( 'context' => array() ),
+	);
+	$out = BundleSourceAuth::inject_github_auth(
+		$args,
+		'https://raw.githubusercontent.com/o/r/main/agent.json',
+		'https://raw.githubusercontent.com/o/r/main/agent.json'
+	);
+	$assert(
+		'raw.githubusercontent.com gets Bearer header',
+		( $out['headers']['Authorization'] ?? '' ) === 'Bearer ghp_raw'
+	);
+
+	// CLI token short-circuits via context.
+	$reset();
+	$args = array(
+		'headers'                   => array(),
+		'datamachine_bundle_source' => array(
+			'context' => array( 'cli_token' => 'cli-secret' ),
+		),
+	);
+	$out = BundleSourceAuth::inject_github_auth(
+		$args,
+		'https://github.com/o/r/archive/refs/heads/main.zip',
+		'https://github.com/o/r/archive/refs/heads/main.zip'
+	);
+	$assert(
+		'CLI token wins inside inject_github_auth',
+		( $out['headers']['Authorization'] ?? '' ) === 'Bearer cli-secret'
+	);
+
+	// Existing Authorization header is respected.
+	$reset();
+	putenv( 'DATAMACHINE_GITHUB_TOKEN=should-not-overwrite' );
+	$args = array(
+		'headers'                   => array( 'Authorization' => 'Bearer manual' ),
+		'datamachine_bundle_source' => array( 'context' => array() ),
+	);
+	$out = BundleSourceAuth::inject_github_auth(
+		$args,
+		'https://github.com/o/r/archive/refs/heads/main.zip',
+		'https://github.com/o/r/archive/refs/heads/main.zip'
+	);
+	$assert(
+		'pre-set Authorization header is preserved',
+		'Bearer manual' === $out['headers']['Authorization']
+	);
+
+	// Non-github host with no GHE config → no injection.
+	$reset();
+	putenv( 'DATAMACHINE_GITHUB_TOKEN=ghp_unused' );
+	$args = array(
+		'headers'                   => array(),
+		'datamachine_bundle_source' => array( 'context' => array() ),
+	);
+	$out = BundleSourceAuth::inject_github_auth(
+		$args,
+		'https://example.com/bundle.zip',
+		'https://example.com/bundle.zip'
+	);
+	$assert(
+		'non-github host gets no Authorization header',
+		empty( $out['headers']['Authorization'] )
+	);
+
+	echo "\n[3] inject_github_auth() — GHE host via filter\n";
+
+	$reset();
+	putenv( 'DATAMACHINE_A8C_GHE_TOKEN=ghe-tok' );
+	$GLOBALS['datamachine_test_filters']['datamachine_bundle_source_ghe_hosts'] = function ( array $hosts ) {
+		$hosts['github.a8c.com'] = 'DATAMACHINE_A8C_GHE_TOKEN';
+		return $hosts;
+	};
+
+	$args = array(
+		'headers'                   => array(),
+		'datamachine_bundle_source' => array( 'context' => array() ),
+	);
+	$out = BundleSourceAuth::inject_github_auth(
+		$args,
+		'https://github.a8c.com/team/brain/archive/refs/heads/main.zip',
+		'https://github.a8c.com/team/brain/archive/refs/heads/main.zip'
+	);
+	$assert(
+		'GHE host gets Bearer header from filter-configured env',
+		( $out['headers']['Authorization'] ?? '' ) === 'Bearer ghe-tok'
+	);
+
+	// A different GHE host (not configured) gets nothing.
+	$args = array(
+		'headers'                   => array(),
+		'datamachine_bundle_source' => array( 'context' => array() ),
+	);
+	$out = BundleSourceAuth::inject_github_auth(
+		$args,
+		'https://other-ghe.example.com/x/y/archive/refs/heads/main.zip',
+		'https://other-ghe.example.com/x/y/archive/refs/heads/main.zip'
+	);
+	$assert(
+		'unconfigured GHE host gets no header',
+		empty( $out['headers']['Authorization'] )
+	);
+
+	echo "\n[4] redact_args_for_log()\n";
+
+	$reset();
+	$args = array(
+		'headers'                   => array(
+			'Authorization' => 'Bearer ghp_super_secret',
+			'X-Other'       => 'visible',
+		),
+		'datamachine_bundle_source' => array( 'context' => array( 'cli_token' => 'no-leak' ) ),
+	);
+	$logged = BundleSourceAuth::redact_args_for_log( $args );
+	$assert(
+		'Authorization is redacted',
+		'[redacted]' === ( $logged['headers']['Authorization'] ?? '' )
+	);
+	$assert(
+		'other headers pass through',
+		'visible' === ( $logged['headers']['X-Other'] ?? '' )
+	);
+	$assert(
+		'internal handle is stripped from log payload',
+		empty( $logged['datamachine_bundle_source'] )
+	);
+
+	echo "\n[5] ghe_hosts() — normalization\n";
+
+	$reset();
+	$GLOBALS['datamachine_test_filters']['datamachine_bundle_source_ghe_hosts'] = function ( array $hosts ) {
+		return array(
+			'  GitHub.A8C.COM '  => '  DATAMACHINE_A8C_GHE_TOKEN  ',
+			'empty.host'         => '',
+			''                   => 'IGNORED',
+			'good.host'          => 'GOOD_TOKEN',
+		);
+	};
+
+	$hosts = BundleSourceAuth::ghe_hosts();
+	$assert(
+		'host names lowercased and trimmed',
+		isset( $hosts['github.a8c.com'] ) && 'DATAMACHINE_A8C_GHE_TOKEN' === $hosts['github.a8c.com']
+	);
+	$assert(
+		'empty env name dropped',
+		! isset( $hosts['empty.host'] )
+	);
+	$assert(
+		'empty host dropped',
+		! isset( $hosts[''] )
+	);
+	$assert(
+		'good entries preserved',
+		isset( $hosts['good.host'] ) && 'GOOD_TOKEN' === $hosts['good.host']
+	);
+
+	echo "\nAssertions: {$assertions}\n";
+	echo "PASS\n";
+}

--- a/tests/bundle-source-smoke.php
+++ b/tests/bundle-source-smoke.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Behavior smoke test for BundleSource resolver (#1826).
+ * Behavior smoke test for BundleSource resolver (#1826, #1830).
  *
  * Run with: php tests/bundle-source-smoke.php
  */
@@ -55,6 +55,10 @@ namespace {
 	}
 
 	function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+		$override = $GLOBALS['datamachine_test_filters'][ $hook ] ?? null;
+		if ( is_callable( $override ) ) {
+			return $override( $value, ...$args );
+		}
 		return $value;
 	}
 
@@ -64,15 +68,40 @@ namespace {
 		}
 	}
 
-	// Minimal download_url stub. Tests that exercise the download path
-	// override this via $GLOBALS['datamachine_test_download_url'].
-	function download_url( string $url, int $timeout = 30 ): mixed {
-		$override = $GLOBALS['datamachine_test_download_url'] ?? null;
+	function wp_tempnam( string $hint = '' ): string {
+		$tmp = tempnam( sys_get_temp_dir(), 'datamachine-stub-' );
+		return $tmp ?: '';
+	}
+
+	function wp_safe_remote_get( string $url, array $args = array() ): mixed {
+		$override = $GLOBALS['datamachine_test_safe_remote_get'] ?? null;
 		if ( is_callable( $override ) ) {
-			return $override( $url, $timeout );
+			return $override( $url, $args );
 		}
 
-		return new WP_Error( 'no_stub', 'download_url is not stubbed in this test.' );
+		return new WP_Error( 'no_stub', 'wp_safe_remote_get is not stubbed in this test.' );
+	}
+
+	function wp_remote_retrieve_response_code( $response ): int {
+		if ( is_array( $response ) && isset( $response['response']['code'] ) ) {
+			return (int) $response['response']['code'];
+		}
+		return 0;
+	}
+
+	function wp_remote_retrieve_header( $response, string $name ): string {
+		if ( is_array( $response ) && isset( $response['headers'] ) && is_array( $response['headers'] ) ) {
+			foreach ( $response['headers'] as $k => $v ) {
+				if ( 0 === strcasecmp( (string) $k, $name ) ) {
+					return (string) $v;
+				}
+			}
+		}
+		return '';
+	}
+
+	if ( ! defined( 'DATAMACHINE_VERSION' ) ) {
+		define( 'DATAMACHINE_VERSION', '0.0.0-test' );
 	}
 
 }
@@ -94,7 +123,14 @@ namespace {
 		echo "ok - {$label}\n";
 	};
 
-	echo "=== BundleSource Smoke (#1826) ===\n";
+	$reset_stubs = function () {
+		$GLOBALS['datamachine_test_filters']           = array();
+		$GLOBALS['datamachine_test_safe_remote_get']   = null;
+		$GLOBALS['datamachine_test_seen_url']          = '';
+		$GLOBALS['datamachine_test_seen_args']         = array();
+	};
+
+	echo "=== BundleSource Smoke (#1826 + #1830) ===\n";
 
 	echo "\n[1] is_remote()\n";
 	$assert( 'http URL is remote', BundleSource::is_remote( 'http://example.com/bundle.zip' ) );
@@ -107,21 +143,18 @@ namespace {
 
 	echo "\n[2] normalize_github_url() — all documented cases\n";
 
-	// archive/refs/heads/<branch>.zip — unchanged
 	$archive_branch = 'https://github.com/foo/bar/archive/refs/heads/main.zip';
 	$assert(
 		'archive/refs/heads/<branch>.zip is unchanged',
 		$archive_branch === BundleSource::normalize_github_url( $archive_branch )
 	);
 
-	// archive/<sha>.zip — unchanged (matches generic archive .zip)
 	$archive_sha = 'https://github.com/foo/bar/archive/abc123.zip';
 	$assert(
 		'archive/<sha>.zip is unchanged',
 		$archive_sha === BundleSource::normalize_github_url( $archive_sha )
 	);
 
-	// blob/<ref>/<path>.json → raw URL
 	$blob       = 'https://github.com/foo/bar/blob/main/bundles/agent.json';
 	$normalized = BundleSource::normalize_github_url( $blob );
 	$assert(
@@ -129,49 +162,42 @@ namespace {
 		'https://raw.githubusercontent.com/foo/bar/main/bundles/agent.json' === $normalized
 	);
 
-	// blob/<ref>/<path>.zip → raw URL
 	$blob_zip = 'https://github.com/foo/bar/blob/main/bundles/agent.zip';
 	$assert(
 		'blob/<ref>/<path>.zip normalizes to raw',
 		'https://raw.githubusercontent.com/foo/bar/main/bundles/agent.zip' === BundleSource::normalize_github_url( $blob_zip )
 	);
 
-	// raw/<ref>/<path> → raw.githubusercontent.com
 	$raw_legacy = 'https://github.com/foo/bar/raw/main/bundles/agent.json';
 	$assert(
 		'raw/<ref>/<path> normalizes to raw.githubusercontent.com',
 		'https://raw.githubusercontent.com/foo/bar/main/bundles/agent.json' === BundleSource::normalize_github_url( $raw_legacy )
 	);
 
-	// already raw.githubusercontent.com → unchanged
 	$raw_direct = 'https://raw.githubusercontent.com/foo/bar/main/bundle.json';
 	$assert(
 		'raw.githubusercontent.com URL is unchanged',
 		$raw_direct === BundleSource::normalize_github_url( $raw_direct )
 	);
 
-	// tree/<branch> → archive zip
 	$tree = 'https://github.com/foo/bar/tree/main';
 	$assert(
 		'tree/<branch> normalizes to archive zip',
 		'https://github.com/foo/bar/archive/refs/heads/main.zip' === BundleSource::normalize_github_url( $tree )
 	);
 
-	// tree/<branch>/ trailing slash also handled
 	$tree_slash = 'https://github.com/foo/bar/tree/develop/';
 	$assert(
 		'tree/<branch>/ trailing slash normalizes',
 		'https://github.com/foo/bar/archive/refs/heads/develop.zip' === BundleSource::normalize_github_url( $tree_slash )
 	);
 
-	// non-github URL → unchanged
 	$other = 'https://example.com/bundle.zip';
 	$assert(
 		'non-github URL is unchanged',
 		$other === BundleSource::normalize_github_url( $other )
 	);
 
-	// bare repo URL → unchanged (caller will reject as missing extension)
 	$bare = 'https://github.com/foo/bar';
 	$assert(
 		'bare repo URL is unchanged (caller rejects)',
@@ -180,16 +206,17 @@ namespace {
 
 	echo "\n[3] resolve() — local paths\n";
 
-	// Existing local file is returned as-is.
+	$reset_stubs();
+
 	$tmp_local = tempnam( sys_get_temp_dir(), 'datamachine-bundle-test-' );
 	rename( $tmp_local, $tmp_local . '.json' );
 	$tmp_local = $tmp_local . '.json';
 	file_put_contents( $tmp_local, '{}' );
 	$resolved = BundleSource::resolve( $tmp_local );
 	$assert( 'existing local .json path resolves as-is', $resolved === $tmp_local );
+	$assert( 'last_resolved_revision is null after local resolve', null === BundleSource::last_resolved_revision() );
 	wp_delete_file( $tmp_local );
 
-	// Missing local path returns WP_Error.
 	$missing = BundleSource::resolve( '/definitely/not/a/real/path/here.json' );
 	$assert( 'missing local path returns WP_Error', is_wp_error( $missing ) );
 	$assert(
@@ -197,18 +224,23 @@ namespace {
 		$missing instanceof WP_Error && 'datamachine_bundle_source_invalid' === $missing->get_error_code()
 	);
 
-	// Empty source returns WP_Error.
 	$empty = BundleSource::resolve( '' );
 	$assert( 'empty source returns WP_Error', is_wp_error( $empty ) );
 
-	echo "\n[4] resolve() — remote URLs (download_url stubbed)\n";
+	echo "\n[4] resolve() — remote URLs (wp_safe_remote_get stubbed)\n";
 
-	// Successful download path returns a temp file.
+	$reset_stubs();
 	$fake_payload = '{"bundle_version":"1","agent":{"agent_slug":"x","agent_name":"X"}}';
-	$GLOBALS['datamachine_test_download_url'] = function ( string $url, int $timeout ) use ( $fake_payload ): string {
-		$tmp = tempnam( sys_get_temp_dir(), 'datamachine-stub-download-' );
-		file_put_contents( $tmp, $fake_payload );
-		return $tmp;
+	$GLOBALS['datamachine_test_safe_remote_get'] = function ( string $url, array $args ) use ( $fake_payload ): array {
+		$GLOBALS['datamachine_test_seen_url']  = $url;
+		$GLOBALS['datamachine_test_seen_args'] = $args;
+		if ( ! empty( $args['filename'] ) ) {
+			file_put_contents( $args['filename'], $fake_payload );
+		}
+		return array(
+			'response' => array( 'code' => 200 ),
+			'headers'  => array(),
+		);
 	};
 
 	$source   = 'https://example.com/some-bundle.json';
@@ -226,12 +258,19 @@ namespace {
 		'remote .json resolved file contains downloaded payload',
 		is_string( $resolved ) && $fake_payload === file_get_contents( $resolved )
 	);
+	$assert(
+		'request was streamed to disk (stream + filename set)',
+		( $GLOBALS['datamachine_test_seen_args']['stream'] ?? false ) === true
+		&& ! empty( $GLOBALS['datamachine_test_seen_args']['filename'] )
+	);
+	$assert(
+		'no Authorization header is set when no token is available',
+		empty( $GLOBALS['datamachine_test_seen_args']['headers']['Authorization'] )
+	);
 
-	// cleanup() removes the temp file.
 	BundleSource::cleanup( $resolved, $source );
 	$assert( 'cleanup removes temp file for remote source', ! file_exists( $resolved ) );
 
-	// cleanup() is a no-op for local sources (does NOT delete user files).
 	$user_file = tempnam( sys_get_temp_dir(), 'datamachine-user-file-' );
 	file_put_contents( $user_file, 'do not delete me' );
 	BundleSource::cleanup( $user_file, $user_file );
@@ -240,67 +279,238 @@ namespace {
 
 	echo "\n[5] resolve() — error paths\n";
 
-	// download_url returns WP_Error → resolver wraps as datamachine_bundle_source_download_failed.
-	$GLOBALS['datamachine_test_download_url'] = function () {
-		return new WP_Error( 'http_404', 'Not Found' );
+	$reset_stubs();
+	$GLOBALS['datamachine_test_safe_remote_get'] = function (): WP_Error {
+		return new WP_Error( 'http_request_failed', 'connection refused' );
 	};
 	$err = BundleSource::resolve( 'https://example.com/missing.zip' );
-	$assert( 'download_url failure returns WP_Error', is_wp_error( $err ) );
+	$assert( 'wp_safe_remote_get failure returns WP_Error', is_wp_error( $err ) );
 	$assert(
-		'download failure uses datamachine_bundle_source_download_failed code',
+		'transport failure uses datamachine_bundle_source_download_failed code',
 		$err instanceof WP_Error && 'datamachine_bundle_source_download_failed' === $err->get_error_code()
 	);
 
+	// 401 → datamachine_bundle_source_auth_required, no token leakage.
+	$reset_stubs();
+	$GLOBALS['datamachine_test_safe_remote_get'] = function (): array {
+		return array(
+			'response' => array( 'code' => 401 ),
+			'headers'  => array(),
+		);
+	};
+	$auth_err = BundleSource::resolve( 'https://github.com/private-org/private-repo/archive/refs/heads/main.zip' );
+	$assert( '401 returns WP_Error', is_wp_error( $auth_err ) );
+	$assert(
+		'401 uses datamachine_bundle_source_auth_required code',
+		$auth_err instanceof WP_Error && 'datamachine_bundle_source_auth_required' === $auth_err->get_error_code()
+	);
+	$assert(
+		'401 message does not include the word "token" verbatim leaked from a header',
+		$auth_err instanceof WP_Error && false === strpos( $auth_err->get_error_message(), 'Bearer ' )
+	);
+
+	// 403 → same auth-required code.
+	$reset_stubs();
+	$GLOBALS['datamachine_test_safe_remote_get'] = function (): array {
+		return array(
+			'response' => array( 'code' => 403 ),
+			'headers'  => array(),
+		);
+	};
+	$forbidden = BundleSource::resolve( 'https://github.com/p/r/archive/refs/heads/main.zip' );
+	$assert( '403 returns WP_Error', is_wp_error( $forbidden ) );
+	$assert(
+		'403 uses auth_required code',
+		$forbidden instanceof WP_Error && 'datamachine_bundle_source_auth_required' === $forbidden->get_error_code()
+	);
+
+	// 500 → datamachine_bundle_source_http_error.
+	$reset_stubs();
+	$GLOBALS['datamachine_test_safe_remote_get'] = function (): array {
+		return array(
+			'response' => array( 'code' => 500 ),
+			'headers'  => array(),
+		);
+	};
+	$server_err = BundleSource::resolve( 'https://example.com/bundle.zip' );
+	$assert( '500 returns WP_Error', is_wp_error( $server_err ) );
+	$assert(
+		'500 uses datamachine_bundle_source_http_error code',
+		$server_err instanceof WP_Error && 'datamachine_bundle_source_http_error' === $server_err->get_error_code()
+	);
+
 	// Remote URL without .zip/.json extension is rejected before download.
-	$GLOBALS['datamachine_test_download_url'] = function () {
-		fwrite( STDERR, "FAIL: download_url should not have been called for unsupported extension\n" );
+	$reset_stubs();
+	$GLOBALS['datamachine_test_safe_remote_get'] = function () {
+		fwrite( STDERR, "FAIL: wp_safe_remote_get should not have been called for unsupported extension\n" );
 		exit( 1 );
 	};
 	$bad_ext = BundleSource::resolve( 'https://example.com/something' );
 	$assert( 'remote URL without .zip/.json is rejected', is_wp_error( $bad_ext ) );
 
-	// Bare GitHub repo URL → no normalization, no extension, rejected.
 	$bare_repo = BundleSource::resolve( 'https://github.com/foo/bar' );
 	$assert( 'bare GitHub repo URL is rejected (no extension)', is_wp_error( $bare_repo ) );
 
 	echo "\n[6] resolve() — GitHub blob/tree URLs round-trip through normalization\n";
 
-	// blob URL pointing at .json should be normalized and downloaded.
-	$GLOBALS['datamachine_test_seen_url']    = '';
-	$GLOBALS['datamachine_test_download_url'] = function ( string $url, int $timeout ): string {
+	$reset_stubs();
+	$GLOBALS['datamachine_test_safe_remote_get'] = function ( string $url, array $args ): array {
 		$GLOBALS['datamachine_test_seen_url'] = $url;
-		$tmp = tempnam( sys_get_temp_dir(), 'datamachine-stub-blob-' );
-		file_put_contents( $tmp, '{}' );
-		return $tmp;
+		if ( ! empty( $args['filename'] ) ) {
+			file_put_contents( $args['filename'], '{}' );
+		}
+		return array(
+			'response' => array( 'code' => 200 ),
+			'headers'  => array(),
+		);
 	};
 	$blob_src = 'https://github.com/org/repo/blob/main/agent.json';
 	$resolved = BundleSource::resolve( $blob_src );
 	$assert( 'GitHub blob URL resolves to a temp file', is_string( $resolved ) );
 	$assert(
-		'GitHub blob URL is normalized to raw.githubusercontent.com before download',
+		'GitHub blob URL is normalized to raw.githubusercontent.com before fetch',
 		'https://raw.githubusercontent.com/org/repo/main/agent.json' === $GLOBALS['datamachine_test_seen_url']
 	);
 	if ( is_string( $resolved ) ) {
 		BundleSource::cleanup( $resolved, $blob_src );
 	}
 
-	// tree URL → archive .zip download
-	$GLOBALS['datamachine_test_download_url'] = function ( string $url, int $timeout ): string {
+	$reset_stubs();
+	$GLOBALS['datamachine_test_safe_remote_get'] = function ( string $url, array $args ): array {
 		$GLOBALS['datamachine_test_seen_url'] = $url;
-		$tmp = tempnam( sys_get_temp_dir(), 'datamachine-stub-tree-' );
-		file_put_contents( $tmp, 'PK' );
-		return $tmp;
+		if ( ! empty( $args['filename'] ) ) {
+			file_put_contents( $args['filename'], 'PK' );
+		}
+		return array(
+			'response' => array( 'code' => 200 ),
+			'headers'  => array(),
+		);
 	};
 	$tree_src = 'https://github.com/org/repo/tree/main';
 	$resolved = BundleSource::resolve( $tree_src );
 	$assert( 'GitHub tree URL resolves to a temp file', is_string( $resolved ) );
 	$assert(
-		'GitHub tree URL is normalized to archive zip before download',
+		'GitHub tree URL is normalized to archive zip before fetch',
 		'https://github.com/org/repo/archive/refs/heads/main.zip' === $GLOBALS['datamachine_test_seen_url']
 	);
 	if ( is_string( $resolved ) ) {
 		BundleSource::cleanup( $resolved, $tree_src );
 	}
+
+	echo "\n[7] resolve() — datamachine_bundle_source_download_args filter\n";
+
+	$reset_stubs();
+	$GLOBALS['datamachine_test_filters']['datamachine_bundle_source_download_args'] = function ( array $args, string $source, string $fetch_url ): array {
+		$GLOBALS['datamachine_test_filter_source']    = $source;
+		$GLOBALS['datamachine_test_filter_fetch_url'] = $fetch_url;
+		$args['headers']['X-Custom-Header']           = 'beep';
+		return $args;
+	};
+	$GLOBALS['datamachine_test_safe_remote_get'] = function ( string $url, array $args ): array {
+		$GLOBALS['datamachine_test_seen_args'] = $args;
+		if ( ! empty( $args['filename'] ) ) {
+			file_put_contents( $args['filename'], '{}' );
+		}
+		return array(
+			'response' => array( 'code' => 200 ),
+			'headers'  => array(),
+		);
+	};
+	$src      = 'https://example.com/bundle.json';
+	$resolved = BundleSource::resolve( $src );
+	$assert( 'filter receives source URL', ( $GLOBALS['datamachine_test_filter_source'] ?? '' ) === $src );
+	$assert( 'filter receives fetch URL', ( $GLOBALS['datamachine_test_filter_fetch_url'] ?? '' ) === $src );
+	$assert(
+		'filter-injected header reaches wp_safe_remote_get',
+		( $GLOBALS['datamachine_test_seen_args']['headers']['X-Custom-Header'] ?? '' ) === 'beep'
+	);
+	$assert(
+		'internal datamachine_bundle_source key is stripped before request',
+		empty( $GLOBALS['datamachine_test_seen_args']['datamachine_bundle_source'] )
+	);
+	if ( is_string( $resolved ) ) {
+		BundleSource::cleanup( $resolved, $src );
+	}
+
+	echo "\n[8] parse_sha_from_etag()\n";
+
+	$assert(
+		'W/"<sha>:zipball" parses',
+		'abcdef0123456789abcdef0123456789abcdef01' === BundleSource::parse_sha_from_etag( 'W/"abcdef0123456789abcdef0123456789abcdef01:zipball"' )
+	);
+	$assert(
+		'"<sha>" parses',
+		'abcdef0123456789abcdef0123456789abcdef01' === BundleSource::parse_sha_from_etag( '"abcdef0123456789abcdef0123456789abcdef01"' )
+	);
+	$assert(
+		'bare hex parses',
+		'0123456789abcdef0123456789abcdef01234567' === BundleSource::parse_sha_from_etag( '0123456789abcdef0123456789abcdef01234567' )
+	);
+	$assert(
+		'mixed-case hex normalizes to lowercase',
+		'abcdef0123456789abcdef0123456789abcdef01' === BundleSource::parse_sha_from_etag( 'W/"ABCDEF0123456789abcdef0123456789ABCDEF01:tarball"' )
+	);
+	$assert(
+		'short hash returns null',
+		null === BundleSource::parse_sha_from_etag( 'W/"abcd:zipball"' )
+	);
+	$assert(
+		'opaque etag returns null',
+		null === BundleSource::parse_sha_from_etag( '"some-other-format"' )
+	);
+	$assert(
+		'empty etag returns null',
+		null === BundleSource::parse_sha_from_etag( '' )
+	);
+
+	echo "\n[9] resolve() — ETag → last_resolved_revision\n";
+
+	$reset_stubs();
+	$GLOBALS['datamachine_test_safe_remote_get'] = function ( string $url, array $args ): array {
+		if ( ! empty( $args['filename'] ) ) {
+			file_put_contents( $args['filename'], 'PK' );
+		}
+		return array(
+			'response' => array( 'code' => 200 ),
+			'headers'  => array( 'ETag' => 'W/"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef:zipball"' ),
+		);
+	};
+	$resolved = BundleSource::resolve( 'https://github.com/foo/bar/archive/refs/heads/main.zip' );
+	$assert( 'resolve with ETag returns a path', is_string( $resolved ) );
+	$assert(
+		'last_resolved_revision returns parsed SHA',
+		'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' === BundleSource::last_resolved_revision()
+	);
+	if ( is_string( $resolved ) ) {
+		BundleSource::cleanup( $resolved, 'https://github.com/foo/bar/archive/refs/heads/main.zip' );
+	}
+
+	// Unparseable ETag → null revision.
+	$reset_stubs();
+	$GLOBALS['datamachine_test_safe_remote_get'] = function ( string $url, array $args ): array {
+		if ( ! empty( $args['filename'] ) ) {
+			file_put_contents( $args['filename'], 'PK' );
+		}
+		return array(
+			'response' => array( 'code' => 200 ),
+			'headers'  => array( 'ETag' => '"opaque-token"' ),
+		);
+	};
+	$resolved = BundleSource::resolve( 'https://github.com/foo/bar/archive/refs/heads/main.zip' );
+	$assert(
+		'unparseable ETag yields null revision',
+		null === BundleSource::last_resolved_revision()
+	);
+	if ( is_string( $resolved ) ) {
+		BundleSource::cleanup( $resolved, 'https://github.com/foo/bar/archive/refs/heads/main.zip' );
+	}
+
+	// last_resolved_revision is reset when next resolve fails before fetch.
+	BundleSource::resolve( '' );
+	$assert(
+		'last_resolved_revision resets on subsequent resolve()',
+		null === BundleSource::last_resolved_revision()
+	);
 
 	echo "\nAssertions: {$assertions}\n";
 	echo "PASS\n";


### PR DESCRIPTION
## Summary

Closes #1830.

`BundleSource::resolve()` previously called `download_url()` directly, with no way to inject `Authorization` headers. That left private GitHub repos and GitHub Enterprise archives uninstallable, which blocked the per-domain Automattic brain-bundle distribution that motivated this whole capability.

This PR replaces the bare `download_url()` call with a header-aware streaming fetch built on `wp_safe_remote_get()`, ships a built-in github.com / GHE PAT helper, adds CLI flags for one-off installs, and starts capturing `source_revision` from the GitHub archive ETag.

## Changes

- **New filter `datamachine_bundle_source_download_args`** — generic per-request HTTP args mutator. Any consumer can attach Authorization headers, custom user-agents, or any other arg supported by `wp_safe_remote_get()`. The body is streamed to disk via `'stream' => true` + `'filename'`, so multi-MB bundles never sit in PHP memory.
- **New helper `BundleSourceAuth`** — opt-in convenience that auto-injects `Authorization: Bearer <token>` for github.com / raw.githubusercontent.com (token via env var `DATAMACHINE_GITHUB_TOKEN`, PHP constant of the same name, or WP option `datamachine_bundle_source_github_token`) and for filter-configured GHE hosts.
- **New filter `datamachine_bundle_source_token_for_url`** — fallback token lookup for sigillo / Vault / AWS Secrets Manager / etc. Fires only when the env-var / constant / option chain comes up empty.
- **New filter `datamachine_bundle_source_ghe_hosts`** — registers GHE hosts that should auto-receive auth, mapping each host to the env-var/constant name that holds its token. Mirrors the github.com flow.
- **CLI flags `--token=<token>` and `--token-env=<varname>`** on `agent install` / `agent import` / `agent upgrade` / `agent diff`. Tokens scoped to a single resolve(), never persisted, never logged.
- **`datamachine/import-agent` ability** extended with optional `token` / `token_env` fields with the same single-call semantics.
- **Auth errors** — 401/403/404 surface as `WP_Error( 'datamachine_bundle_source_auth_required', ... )` with a clear message that hints at the token slots and never leaks the Authorization header. Other non-2xx becomes `datamachine_bundle_source_http_error`.
- **`source_revision` capture** — `BundleSource::last_resolved_revision()` returns the git SHA parsed from the response ETag (`W/\"<sha>:<format>\"` or bare `\"<sha>\"`). CLI and ability stamp it onto `$bundle['source_revision']` when present. Best-effort: missing or unparseable ETag leaves the field empty rather than failing the install.
- **Token redaction** — `BundleSourceAuth::redact_args_for_log()` masks Authorization and strips the internal `datamachine_bundle_source` handle for any caller that wants to log fetch args downstream.

## Token resolution chain

`BundleSourceAuth::token_for()` resolves the token in this order. First non-empty hit wins:

1. CLI-supplied token (`$context['cli_token']`).
2. Environment variable (`DATAMACHINE_GITHUB_TOKEN` for github hosts; per-host symbol from `datamachine_bundle_source_ghe_hosts` for GHE).
3. PHP constant of the same name.
4. WP option `datamachine_bundle_source_github_token` (github.com only, lowest-precedence convenience slot).
5. `datamachine_bundle_source_token_for_url` filter.

Data Machine never persists tokens itself. Storage and rotation live in the host plugin or operator's environment.

## Token redaction policy

- `WP_Error` messages from the resolver include the URL but never the Authorization header.
- `BundleSourceAuth::redact_args_for_log()` is provided for callers that log fetch args; it replaces any Authorization header value with `[redacted]` and strips the internal `datamachine_bundle_source` handle.
- The internal `datamachine_bundle_source` handle (carrying `source` + `context.cli_token`) is also stripped from the args **before** the request is dispatched, so the token never reaches the wire as anything other than an `Authorization` header.

## Out of scope (deferred)

- Token UI / admin screen. CLI + constants + env vars are enough.
- Token rotation / refresh. PATs are long-lived; refresh is the operator's problem.
- Built-in helpers for non-GitHub hosts (Bitbucket, GitLab). The generic filter covers them.
- Two-way auth (write-back). DMC gitsync handles that.
- `If-None-Match` / conditional requests using the captured ETag. Filed separately if desired.

## Tests

`tests/bundle-source-smoke.php` covers the new fetch path end-to-end:

- Public archive still works, no regression.
- Streaming download writes to a tempfile in `sys_get_temp_dir()`.
- 401/403 → `datamachine_bundle_source_auth_required` with no token leakage in the error message.
- Non-2xx → `datamachine_bundle_source_http_error`.
- `datamachine_bundle_source_download_args` filter receives source + fetch URL and is honored on the actual request.
- Internal `datamachine_bundle_source` handle is stripped before the request flies.
- ETag → SHA parsing for `W/\"<sha>:<format>\"`, bare hex, mixed-case hex, and unparseable shapes.
- `last_resolved_revision()` resets on each `resolve()` call.

`tests/bundle-source-auth-smoke.php` covers the auth helper:

- Token resolution chain (CLI > env > constant > filter fallback).
- GitHub.com / raw.githubusercontent.com header injection.
- GHE host header injection via filter-configured env var.
- Existing Authorization header is preserved (consumer wins).
- Non-github / unconfigured hosts get no header.
- `redact_args_for_log()` masks Authorization and strips the internal handle.
- `ghe_hosts()` normalizes host names and drops empty entries.

`homeboy test --changed-since=main` reports **973 passed, 3 skipped** against `main`. `homeboy lint --changed-since=main` is clean.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** drafted the header-aware fetch loop, BundleSourceAuth helper, CLI / ability wiring, ETag/SHA capture, docs, and smoke tests; Chris reviewed.