### PR TITLE
feat(bundle): policy-driven rebase for locally modified artifacts (#1832)

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -14,6 +14,7 @@ use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Engine\AI\Actions\ResolvePendingActionAbility;
 use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
+use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
 use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
@@ -196,6 +197,18 @@ class AgentBundleCommand extends BaseCommand {
 	 * [--reconcile-runtime]
 	 * : Replace preserved flow runtime queues and scheduling with the bundle seed on existing bundle-owned flows.
 	 *
+	 * [--rebase-local]
+	 * : 3-way rebase locally modified artifacts against the target using a merge policy. Preview only unless --yes is set.
+	 *
+	 * [--policy=<policy>]
+	 * : Rebase policy name. Defaults to "conservative" (no auto-merge).
+	 * ---
+	 * default: conservative
+	 * options:
+	 *   - conservative
+	 *   - burn-in-safe
+	 * ---
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -211,12 +224,20 @@ class AgentBundleCommand extends BaseCommand {
 		$plan              = $this->plan_for_bundle( $bundle, $slug );
 		$dry_run           = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
 		$reconcile_runtime = \WP_CLI\Utils\get_flag_value( $assoc_args, 'reconcile-runtime', false );
+		$rebase_local      = \WP_CLI\Utils\get_flag_value( $assoc_args, 'rebase-local', false );
+		$policy_name       = (string) ( $assoc_args['policy'] ?? AgentBundleArtifactRebase::POLICY_CONSERVATIVE );
 
 		if ( $dry_run ) {
-			$this->output_plan(
-				$this->add_runtime_drift_to_plan( $plan->to_array(), $bundle, $slug, $reconcile_runtime ? 'replace_bundle_seed' : 'preserve_existing' ),
-				$assoc_args
+			$plan_array = $this->add_runtime_drift_to_plan(
+				$plan->to_array(),
+				$bundle,
+				$slug,
+				$reconcile_runtime ? 'replace_bundle_seed' : 'preserve_existing'
 			);
+			if ( $rebase_local ) {
+				$plan_array['rebase'] = $this->rebase_locally_modified( $plan, $bundle, $slug, $policy_name );
+			}
+			$this->output_plan( $plan_array, $assoc_args );
 			return;
 		}
 
@@ -251,19 +272,26 @@ class AgentBundleCommand extends BaseCommand {
 		);
 
 		if ( $plan->has_pending_approval() ) {
-			$agent                      = $this->resolve_bundle_agent( $bundle, $slug );
+			$agent             = $this->resolve_bundle_agent( $bundle, $slug );
+			$rebased_artifacts = $rebase_local
+				? $this->rebase_locally_modified( $plan, $bundle, $slug, $policy_name )
+				: array();
 			$pending                    = AgentBundleUpgradePendingAction::stage(
 				$plan,
 				array(
-					'bundle'           => $this->bundle_summary( $bundle, $slug ),
-					'agent'            => $agent ? $agent : array(),
-					'target_artifacts' => $this->bundle_artifacts( $bundle ),
-					'summary'          => 'Review locally modified bundle artifacts before applying.',
-					'agent_id'         => $agent ? (int) $agent['agent_id'] : 0,
-					'user_id'          => get_current_user_id(),
+					'bundle'            => $this->bundle_summary( $bundle, $slug ),
+					'agent'             => $agent ? $agent : array(),
+					'target_artifacts'  => $this->bundle_artifacts( $bundle ),
+					'rebased_artifacts' => $rebased_artifacts,
+					'summary'           => 'Review locally modified bundle artifacts before applying.',
+					'agent_id'          => $agent ? (int) $agent['agent_id'] : 0,
+					'user_id'           => get_current_user_id(),
 				)
 			);
 			$response['pending_action'] = $pending;
+			if ( ! empty( $rebased_artifacts ) ) {
+				$response['rebase'] = $rebased_artifacts;
+			}
 		}
 
 		$this->output( $response, $assoc_args, array( 'success' ) );
@@ -301,6 +329,147 @@ class AgentBundleCommand extends BaseCommand {
 		);
 		$assoc_args['format'] = $assoc_args['format'] ?? 'json';
 		$this->output( $result, $assoc_args, array( 'success', 'action_id', 'kind' ) );
+	}
+
+	/**
+	 * 3-way rebase locally modified bundle artifacts against a target package.
+	 *
+	 * Always emits the merged preview. Use `upgrade --rebase-local` to stage
+	 * a PendingAction with merged payloads attached.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <path>
+	 * : Package path (.zip, .json, or directory).
+	 *
+	 * [--slug=<slug>]
+	 * : Override target agent slug.
+	 *
+	 * [--policy=<policy>]
+	 * : Rebase policy name.
+	 * ---
+	 * default: conservative
+	 * options:
+	 *   - conservative
+	 *   - burn-in-safe
+	 * ---
+	 *
+	 * [--artifact=<key>]
+	 * : Limit output to one artifact_key (e.g. "flow:wordpress-com-history").
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 */
+	public function rebase( array $args, array $assoc_args ): void {
+		$bundle      = $this->load_bundle_arg( $args );
+		$slug        = (string) ( $assoc_args['slug'] ?? '' );
+		$plan        = $this->plan_for_bundle( $bundle, $slug );
+		$policy_name = (string) ( $assoc_args['policy'] ?? AgentBundleArtifactRebase::POLICY_CONSERVATIVE );
+		$only        = isset( $assoc_args['artifact'] ) ? (string) $assoc_args['artifact'] : '';
+
+		$rebased = $this->rebase_locally_modified( $plan, $bundle, $slug, $policy_name );
+		if ( '' !== $only ) {
+			$rebased = array_values(
+				array_filter(
+					$rebased,
+					static fn( array $entry ) => ( $entry['artifact_key'] ?? '' ) === $only
+				)
+			);
+		}
+
+		$response = array(
+			'policy'  => $policy_name,
+			'count'   => count( $rebased ),
+			'rebased' => $rebased,
+		);
+
+		$assoc_args['format'] = $assoc_args['format'] ?? 'json';
+		$this->output( $response, $assoc_args, array( 'policy', 'count' ) );
+	}
+
+	/**
+	 * Build rebased artifact entries for every needs_approval plan row.
+	 *
+	 * @param \DataMachine\Engine\Bundle\AgentBundleUpgradePlan $plan Upgrade plan.
+	 * @param array<string,mixed>                                $bundle Parsed bundle payload.
+	 * @param string                                             $slug Optional agent slug override.
+	 * @param string                                             $policy_name Rebase policy.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function rebase_locally_modified( \DataMachine\Engine\Bundle\AgentBundleUpgradePlan $plan, array $bundle, string $slug, string $policy_name ): array {
+		$needs_approval = $plan->bucket( 'needs_approval' );
+		if ( empty( $needs_approval ) ) {
+			return array();
+		}
+
+		$agent = $this->resolve_bundle_agent( $bundle, $slug );
+		if ( ! $agent ) {
+			return array();
+		}
+
+		$bundle_state    = is_array( $agent['agent_config']['datamachine_bundle'] ?? null ) ? $agent['agent_config']['datamachine_bundle'] : array();
+		$installed       = is_array( $bundle_state['artifacts'] ?? null ) ? $bundle_state['artifacts'] : array();
+		$installed_index = array();
+		foreach ( $installed as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$key = AgentBundleArtifactExtensions::artifact_key( (string) ( $row['artifact_type'] ?? '' ), (string) ( $row['artifact_id'] ?? '' ) );
+			$installed_index[ $key ] = $row;
+		}
+
+		$current_index = array();
+		foreach ( $this->current_artifacts( $agent, $installed ) as $artifact ) {
+			$key                   = AgentBundleArtifactExtensions::artifact_key( (string) $artifact['artifact_type'], (string) $artifact['artifact_id'] );
+			$current_index[ $key ] = $artifact;
+		}
+
+		$target_index = array();
+		foreach ( $this->bundle_artifacts_for_agent( $bundle, $agent ) as $artifact ) {
+			$key                  = AgentBundleArtifactExtensions::artifact_key( (string) $artifact['artifact_type'], (string) $artifact['artifact_id'] );
+			$target_index[ $key ] = $artifact;
+		}
+
+		$results = array();
+		foreach ( $needs_approval as $entry ) {
+			$key    = (string) ( $entry['artifact_key'] ?? '' );
+			$target = $target_index[ $key ] ?? null;
+			$local  = $current_index[ $key ] ?? null;
+			if ( ! is_array( $target ) || ! is_array( $local ) ) {
+				continue;
+			}
+
+			// Reconstruct the base payload by hash. We don't persist the original
+			// payload, only its hash, so the rebase falls back to "no base info"
+			// for installed rows missing a snapshot. Conservative policy is fine
+			// without a base; burn-in-safe degrades by treating remote as the
+			// changed side and local as the changed side without merge guidance.
+			$base_payload = null;
+			$installed_row = $installed_index[ $key ] ?? null;
+			if ( is_array( $installed_row ) && isset( $installed_row['payload'] ) ) {
+				$base_payload = $installed_row['payload'];
+			}
+
+			$results[] = AgentBundleArtifactRebase::rebase(
+				array(
+					'artifact_type' => (string) $target['artifact_type'],
+					'artifact_id'   => (string) $target['artifact_id'],
+					'source_path'   => (string) ( $target['source_path'] ?? '' ),
+					'base'          => $base_payload,
+					'local'         => $local['payload']  ?? null,
+					'remote'        => $target['payload'] ?? null,
+				),
+				$policy_name
+			);
+		}
+
+		return $results;
 	}
 
 	private function run_install( array $args, array $assoc_args ): void {

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -445,15 +445,24 @@ class AgentBundleCommand extends BaseCommand {
 				continue;
 			}
 
-			// Reconstruct the base payload by hash. We don't persist the original
-			// payload, only its hash, so the rebase falls back to "no base info"
-			// for installed rows missing a snapshot. Conservative policy is fine
-			// without a base; burn-in-safe degrades by treating remote as the
-			// changed side and local as the changed side without merge guidance.
-			$base_payload = null;
+			// Reconstruct the base payload from the install-time snapshot. New
+			// installs/upgrades persist `installed_payload` on the agent_config
+			// record (see AgentBundler::bundle_artifact_record()) so 3-way merge
+			// has full fidelity. Pre-snapshot rows leave `installed_payload`
+			// missing — burn-in-safe degrades to flagging more fields ambiguous
+			// rather than silently merging without a real base.
+			//
+			// `payload` (no `installed_` prefix) is checked as a back-compat alias
+			// for older test fixtures and any custom writers; new code should use
+			// `installed_payload`.
+			$base_payload  = null;
 			$installed_row = $installed_index[ $key ] ?? null;
-			if ( is_array( $installed_row ) && isset( $installed_row['payload'] ) ) {
-				$base_payload = $installed_row['payload'];
+			if ( is_array( $installed_row ) ) {
+				if ( array_key_exists( 'installed_payload', $installed_row ) ) {
+					$base_payload = $installed_row['installed_payload'];
+				} elseif ( array_key_exists( 'payload', $installed_row ) ) {
+					$base_payload = $installed_row['payload'];
+				}
 			}
 
 			$results[] = AgentBundleArtifactRebase::rebase(

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -1186,17 +1186,23 @@ class AgentBundler {
 		$hash = AgentBundleArtifactHasher::hash( $payload );
 		$now  = gmdate( 'c' );
 
+		// installed_payload is the install-time snapshot. AgentBundleArtifactRebase
+		// uses it as the `base` side of the 3-way merge so burn-in-safe can tell
+		// "local moved this field away from base" from "local just inherited base".
+		// Without it, the rebase primitive degrades to flagging more hunks
+		// ambiguous than necessary (#1832 follow-up).
 		return array(
-			'bundle_slug'    => $bundle_metadata['bundle_slug'],
-			'bundle_version' => $bundle_metadata['bundle_version'],
-			'artifact_type'  => $type,
-			'artifact_id'    => $id,
-			'source_path'    => $source_path,
-			'installed_hash' => $hash,
-			'current_hash'   => $hash,
-			'status'         => AgentBundleArtifactStatus::CLEAN,
-			'installed_at'   => $now,
-			'updated_at'     => $now,
+			'bundle_slug'       => $bundle_metadata['bundle_slug'],
+			'bundle_version'    => $bundle_metadata['bundle_version'],
+			'artifact_type'     => $type,
+			'artifact_id'       => $id,
+			'source_path'       => $source_path,
+			'installed_hash'    => $hash,
+			'current_hash'      => $hash,
+			'installed_payload' => $payload,
+			'status'            => AgentBundleArtifactStatus::CLEAN,
+			'installed_at'      => $now,
+			'updated_at'        => $now,
 		);
 	}
 

--- a/inc/Core/Database/BundleArtifacts/InstalledBundleArtifacts.php
+++ b/inc/Core/Database/BundleArtifacts/InstalledBundleArtifacts.php
@@ -72,6 +72,7 @@ final class InstalledBundleArtifacts extends BaseRepository {
 			source_path VARCHAR(500) NOT NULL,
 			installed_hash CHAR(64) NULL DEFAULT NULL,
 			current_hash CHAR(64) NULL DEFAULT NULL,
+			installed_payload LONGTEXT NULL DEFAULT NULL,
 			local_status VARCHAR(20) NOT NULL DEFAULT 'clean',
 			installed_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL,
@@ -96,26 +97,31 @@ final class InstalledBundleArtifacts extends BaseRepository {
 	 * @return bool
 	 */
 	public function upsert( AgentBundleInstalledArtifact $artifact, int $agent_id = 0 ): bool {
-		$artifact_row = $artifact->to_array();
-		$row          = array(
-			'agent_id'       => max( 0, $agent_id ),
-			'bundle_slug'    => $artifact_row['bundle_slug'],
-			'bundle_version' => $artifact_row['bundle_version'],
-			'artifact_type'  => $artifact_row['artifact_type'],
-			'artifact_id'    => $artifact_row['artifact_id'],
-			'source_path'    => $artifact_row['source_path'],
-			'installed_hash' => '' !== (string) $artifact_row['installed_hash'] ? $artifact_row['installed_hash'] : null,
-			'current_hash'   => '' !== (string) $artifact_row['current_hash'] ? $artifact_row['current_hash'] : null,
-			'local_status'   => $artifact_row['status'],
-			'installed_at'   => $artifact_row['installed_at'],
-			'updated_at'     => $artifact_row['updated_at'],
+		$artifact_row      = $artifact->to_array();
+		$installed_payload = $artifact->installed_payload();
+		$encoded_payload   = null === $installed_payload
+			? null
+			: ( is_string( $installed_payload ) ? $installed_payload : wp_json_encode( $installed_payload ) );
+		$row               = array(
+			'agent_id'          => max( 0, $agent_id ),
+			'bundle_slug'       => $artifact_row['bundle_slug'],
+			'bundle_version'    => $artifact_row['bundle_version'],
+			'artifact_type'     => $artifact_row['artifact_type'],
+			'artifact_id'       => $artifact_row['artifact_id'],
+			'source_path'       => $artifact_row['source_path'],
+			'installed_hash'    => '' !== (string) $artifact_row['installed_hash'] ? $artifact_row['installed_hash'] : null,
+			'current_hash'      => '' !== (string) $artifact_row['current_hash'] ? $artifact_row['current_hash'] : null,
+			'installed_payload' => $encoded_payload,
+			'local_status'      => $artifact_row['status'],
+			'installed_at'      => $artifact_row['installed_at'],
+			'updated_at'        => $artifact_row['updated_at'],
 		);
-		$record_id    = $this->existing_record_id( $row );
-		$format       = array( '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' );
+		$record_id         = $this->existing_record_id( $row );
+		$format            = array( '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' );
 
 		if ( null !== $record_id ) {
-			$row        = array_merge( array( 'artifact_record_id' => $record_id ), $row );
-			$format     = array_merge( array( '%d' ), $format );
+			$row    = array_merge( array( 'artifact_record_id' => $record_id ), $row );
+			$format = array_merge( array( '%d' ), $format );
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -264,19 +270,26 @@ final class InstalledBundleArtifacts extends BaseRepository {
 	}
 
 	private function artifact_from_row( array $row ): AgentBundleInstalledArtifact {
-		return AgentBundleInstalledArtifact::from_array(
-			array(
-				'bundle_slug'    => (string) $row['bundle_slug'],
-				'bundle_version' => (string) $row['bundle_version'],
-				'artifact_type'  => (string) $row['artifact_type'],
-				'artifact_id'    => (string) $row['artifact_id'],
-				'source_path'    => (string) $row['source_path'],
-				'installed_hash' => (string) $row['installed_hash'],
-				'current_hash'   => isset( $row['current_hash'] ) ? (string) $row['current_hash'] : null,
-				'installed_at'   => (string) $row['installed_at'],
-				'updated_at'     => (string) $row['updated_at'],
-			)
+		$data = array(
+			'bundle_slug'    => (string) $row['bundle_slug'],
+			'bundle_version' => (string) $row['bundle_version'],
+			'artifact_type'  => (string) $row['artifact_type'],
+			'artifact_id'    => (string) $row['artifact_id'],
+			'source_path'    => (string) $row['source_path'],
+			'installed_hash' => (string) $row['installed_hash'],
+			'current_hash'   => isset( $row['current_hash'] ) ? (string) $row['current_hash'] : null,
+			'installed_at'   => (string) $row['installed_at'],
+			'updated_at'     => (string) $row['updated_at'],
 		);
+
+		// Pre-snapshot rows have NULL/missing installed_payload — propagate as
+		// "no base info" so callers know to fall back to conservative behavior.
+		if ( ! empty( $row['installed_payload'] ) ) {
+			$decoded                   = json_decode( (string) $row['installed_payload'], true );
+			$data['installed_payload'] = ( JSON_ERROR_NONE === json_last_error() ) ? $decoded : (string) $row['installed_payload'];
+		}
+
+		return AgentBundleInstalledArtifact::from_array( $data );
 	}
 
 	private function existing_record_id( array $row ): ?int {

--- a/inc/Engine/Bundle/AgentBundleArtifactRebase.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactRebase.php
@@ -1,0 +1,529 @@
+<?php
+/**
+ * Policy-driven 3-way rebase for locally modified agent bundle artifacts.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Merges local burn-in edits with upstream bundle source-shape fixes.
+ *
+ * Inputs:
+ * - base   = installed artifact payload (last clean upgrade or install).
+ * - local  = current live artifact payload on the site (may include burn-in edits).
+ * - remote = target bundle artifact payload from the new package.
+ * - policy = named merge policy describing which fields are runtime-local vs bundle-owned.
+ *
+ * Default behavior (policy "conservative") returns the local payload unchanged
+ * with every diverging field flagged as ambiguous. Apply paths must keep
+ * approval-gating ambiguous artifacts unless an explicit non-conservative
+ * policy was supplied.
+ *
+ * Policies are pluggable via the `datamachine_bundle_rebase_policies` filter.
+ * Each policy is a callable accepting an associative array shape:
+ *   array(
+ *     'artifact_key'  => string,
+ *     'artifact_type' => string,
+ *     'artifact_id'   => string,
+ *     'base'          => mixed,
+ *     'local'         => mixed,
+ *     'remote'        => mixed,
+ *   )
+ * and returning an array shape:
+ *   array(
+ *     'merged'    => mixed,        // Merged payload.
+ *     'decisions' => array<string, // Field path decisions (dot-notation).
+ *                        array{
+ *                          source: 'local'|'remote'|'base'|'merge'|'ambiguous',
+ *                          reason: string,
+ *                        }>,
+ *     'ambiguous' => array<int,string>, // Field paths still requiring approval.
+ *   )
+ */
+final class AgentBundleArtifactRebase {
+
+	public const POLICY_CONSERVATIVE = 'conservative';
+	public const POLICY_BURN_IN_SAFE = 'burn-in-safe';
+
+	/**
+	 * Rebase one artifact using the named policy.
+	 *
+	 * @param array<string,mixed> $artifact Artifact envelope: artifact_type, artifact_id,
+	 *                                      source_path, base, local, remote.
+	 *                                      base/local/remote are payload arrays/strings.
+	 * @param string              $policy_name Policy identifier.
+	 * @return array<string,mixed> Result with merged payload, hash, decisions, ambiguous list,
+	 *                              and bookkeeping fields.
+	 */
+	public static function rebase( array $artifact, string $policy_name = self::POLICY_CONSERVATIVE ): array {
+		$artifact_type = (string) ( $artifact['artifact_type'] ?? '' );
+		$artifact_id   = (string) ( $artifact['artifact_id'] ?? '' );
+		$artifact_key  = AgentBundleArtifactExtensions::artifact_key( $artifact_type, $artifact_id );
+		$base          = $artifact['base']   ?? null;
+		$local         = $artifact['local']  ?? null;
+		$remote        = $artifact['remote'] ?? null;
+
+		$policies = self::policies();
+		if ( ! isset( $policies[ $policy_name ] ) ) {
+			$policy_name = self::POLICY_CONSERVATIVE;
+		}
+
+		$callable = $policies[ $policy_name ];
+		$result   = call_user_func(
+			$callable,
+			array(
+				'artifact_key'  => $artifact_key,
+				'artifact_type' => $artifact_type,
+				'artifact_id'   => $artifact_id,
+				'base'          => $base,
+				'local'         => $local,
+				'remote'        => $remote,
+			)
+		);
+
+		if ( ! is_array( $result ) ) {
+			$result = array();
+		}
+
+		$merged    = array_key_exists( 'merged', $result ) ? $result['merged'] : $local;
+		$decisions = isset( $result['decisions'] ) && is_array( $result['decisions'] ) ? $result['decisions'] : array();
+		$ambiguous = isset( $result['ambiguous'] ) && is_array( $result['ambiguous'] )
+			? array_values( array_unique( array_map( 'strval', $result['ambiguous'] ) ) )
+			: array();
+
+		$merged_hash = null === $merged ? null : AgentBundleArtifactHasher::hash( $merged );
+		$base_hash   = null === $base ? null : AgentBundleArtifactHasher::hash( $base );
+		$local_hash  = null === $local ? null : AgentBundleArtifactHasher::hash( $local );
+		$remote_hash = null === $remote ? null : AgentBundleArtifactHasher::hash( $remote );
+
+		return array(
+			'artifact_key'   => $artifact_key,
+			'artifact_type'  => $artifact_type,
+			'artifact_id'    => $artifact_id,
+			'source_path'    => (string) ( $artifact['source_path'] ?? '' ),
+			'policy'         => $policy_name,
+			'merged'         => $merged,
+			'merged_hash'    => $merged_hash,
+			'base_hash'      => $base_hash,
+			'local_hash'     => $local_hash,
+			'remote_hash'    => $remote_hash,
+			'decisions'      => $decisions,
+			'ambiguous'      => $ambiguous,
+			'requires_approval' => ! empty( $ambiguous ),
+		);
+	}
+
+	/**
+	 * Available policies keyed by name.
+	 *
+	 * @return array<string,callable>
+	 */
+	public static function policies(): array {
+		$builtin = array(
+			self::POLICY_CONSERVATIVE => array( self::class, 'policy_conservative' ),
+			self::POLICY_BURN_IN_SAFE => array( self::class, 'policy_burn_in_safe' ),
+		);
+
+		/**
+		 * Register additional bundle artifact rebase policies.
+		 *
+		 * @param array<string,callable> $policies Policy name => callable map.
+		 */
+		$policies = function_exists( 'apply_filters' )
+			? apply_filters( 'datamachine_bundle_rebase_policies', $builtin )
+			: $builtin;
+
+		return is_array( $policies ) ? $policies : $builtin;
+	}
+
+	/**
+	 * Conservative policy: keep local, flag every diverging field as ambiguous.
+	 *
+	 * Never silently merges. Operators must explicitly choose a policy that
+	 * understands the artifact shape.
+	 *
+	 * @param array<string,mixed> $input Rebase input.
+	 * @return array<string,mixed>
+	 */
+	public static function policy_conservative( array $input ): array {
+		$local     = $input['local'] ?? null;
+		$remote    = $input['remote'] ?? null;
+		$paths     = self::diverging_paths( $local, $remote );
+		$decisions = array();
+
+		foreach ( $paths as $path ) {
+			$decisions[ $path ] = array(
+				'source' => 'ambiguous',
+				'reason' => 'conservative_no_auto_merge',
+			);
+		}
+
+		return array(
+			'merged'    => $local,
+			'decisions' => $decisions,
+			'ambiguous' => $paths,
+		);
+	}
+
+	/**
+	 * Burn-in-safe policy for flow artifacts.
+	 *
+	 * Preserves local runtime/safety fields:
+	 *   - flow_config.*.prompt_queue
+	 *   - flow_config.*.config_patch_queue
+	 *   - flow_config.*.queue_mode
+	 *   - flow_config.*._queue_consume_revision
+	 *   - flow_config.*.handler_config.max_items (and handler_configs.*.max_items)
+	 *     when local diverged from base only on the throttle.
+	 *   - scheduling_config (whole subtree, including max_items)
+	 *
+	 * Takes remote source-shape changes when remote diverged from base on
+	 * provider-routing fields:
+	 *   - flow_config.*.handler
+	 *   - flow_config.*.handler_config.* and handler_configs.*.* except local-preserved keys
+	 *     (server, provider, tool, params, query, owner, repo, channel, perPage, source-shape)
+	 *
+	 * Non-flow artifacts are forwarded to conservative policy.
+	 *
+	 * @param array<string,mixed> $input Rebase input.
+	 * @return array<string,mixed>
+	 */
+	public static function policy_burn_in_safe( array $input ): array {
+		$type = (string) $input['artifact_type'];
+		if ( 'flow' !== $type ) {
+			return self::policy_conservative( $input );
+		}
+
+		$base   = is_array( $input['base'] ?? null )   ? $input['base']   : array();
+		$local  = is_array( $input['local'] ?? null )  ? $input['local']  : array();
+		$remote = is_array( $input['remote'] ?? null ) ? $input['remote'] : array();
+
+		$decisions = array();
+		$ambiguous = array();
+		$merged    = $remote; // Start from remote, then surgically restore local-owned fields.
+
+		// Always preserve scheduling_config from local. Bundle authors should not
+		// fight runtime cron throttles; if they need to force a schedule change,
+		// it must be explicit (not in scope for v1).
+		if ( array_key_exists( 'scheduling_config', $local ) ) {
+			$merged['scheduling_config']      = $local['scheduling_config'];
+			$decisions['scheduling_config']   = array(
+				'source' => 'local',
+				'reason' => 'burn_in_preserve_scheduling',
+			);
+		}
+
+		// Walk flow_config step by step, merging per-step keys.
+		$base_steps   = is_array( $base['flow_config']   ?? null ) ? $base['flow_config']   : array();
+		$local_steps  = is_array( $local['flow_config']  ?? null ) ? $local['flow_config']  : array();
+		$remote_steps = is_array( $remote['flow_config'] ?? null ) ? $remote['flow_config'] : array();
+		$merged_steps = is_array( $merged['flow_config'] ?? null ) ? $merged['flow_config'] : array();
+
+		$step_ids = array_unique(
+			array_merge(
+				array_keys( $local_steps ),
+				array_keys( $remote_steps )
+			)
+		);
+
+		foreach ( $step_ids as $step_id ) {
+			$base_step   = is_array( $base_steps[ $step_id ]   ?? null ) ? $base_steps[ $step_id ]   : array();
+			$local_step  = is_array( $local_steps[ $step_id ]  ?? null ) ? $local_steps[ $step_id ]  : array();
+			$remote_step = is_array( $remote_steps[ $step_id ] ?? null ) ? $remote_steps[ $step_id ] : array();
+
+			if ( empty( $remote_step ) && ! empty( $local_step ) ) {
+				// Remote dropped this step; without explicit policy, keep local
+				// and flag as ambiguous so operator confirms.
+				$merged_steps[ $step_id ]                            = $local_step;
+				$decisions[ "flow_config.{$step_id}" ]               = array(
+					'source' => 'ambiguous',
+					'reason' => 'remote_dropped_step',
+				);
+				$ambiguous[] = "flow_config.{$step_id}";
+				continue;
+			}
+
+			$merged_step = $remote_step;
+
+			// Preserve per-step runtime queue fields from local.
+			foreach ( array( 'prompt_queue', 'config_patch_queue', 'queue_mode', '_queue_consume_revision' ) as $rt_field ) {
+				if ( array_key_exists( $rt_field, $local_step ) ) {
+					$merged_step[ $rt_field ]                                       = $local_step[ $rt_field ];
+					$decisions[ "flow_config.{$step_id}.{$rt_field}" ]              = array(
+						'source' => 'local',
+						'reason' => 'burn_in_preserve_runtime_queue',
+					);
+				} elseif ( array_key_exists( $rt_field, $remote_step ) ) {
+					unset( $merged_step[ $rt_field ] );
+				}
+			}
+
+			// Merge handler_config keys (single-handler shape).
+			$base_hc   = is_array( $base_step['handler_config']   ?? null ) ? $base_step['handler_config']   : array();
+			$local_hc  = is_array( $local_step['handler_config']  ?? null ) ? $local_step['handler_config']  : array();
+			$remote_hc = is_array( $remote_step['handler_config'] ?? null ) ? $remote_step['handler_config'] : array();
+
+			if ( ! empty( $local_hc ) || ! empty( $remote_hc ) ) {
+				$merged_hc                               = self::merge_handler_config(
+					$base_hc,
+					$local_hc,
+					$remote_hc,
+					"flow_config.{$step_id}.handler_config",
+					$decisions,
+					$ambiguous
+				);
+				$merged_step['handler_config']           = $merged_hc;
+			}
+
+			// Merge handler_configs (multi-handler shape: keyed by handler slug).
+			$base_hcs   = is_array( $base_step['handler_configs']   ?? null ) ? $base_step['handler_configs']   : array();
+			$local_hcs  = is_array( $local_step['handler_configs']  ?? null ) ? $local_step['handler_configs']  : array();
+			$remote_hcs = is_array( $remote_step['handler_configs'] ?? null ) ? $remote_step['handler_configs'] : array();
+
+			if ( ! empty( $local_hcs ) || ! empty( $remote_hcs ) ) {
+				$merged_hcs = array();
+				$slugs      = array_unique( array_merge( array_keys( $local_hcs ), array_keys( $remote_hcs ) ) );
+				foreach ( $slugs as $slug ) {
+					$lc                  = is_array( $local_hcs[ $slug ]  ?? null ) ? $local_hcs[ $slug ]  : array();
+					$rc                  = is_array( $remote_hcs[ $slug ] ?? null ) ? $remote_hcs[ $slug ] : array();
+					$bc                  = is_array( $base_hcs[ $slug ]   ?? null ) ? $base_hcs[ $slug ]   : array();
+					$merged_hcs[ $slug ] = self::merge_handler_config(
+						$bc,
+						$lc,
+						$rc,
+						"flow_config.{$step_id}.handler_configs.{$slug}",
+						$decisions,
+						$ambiguous
+					);
+				}
+				$merged_step['handler_configs'] = $merged_hcs;
+			}
+
+			$merged_steps[ $step_id ] = $merged_step;
+		}
+
+		$merged['flow_config'] = $merged_steps;
+
+		// Top-level fields that aren't flow_config or scheduling_config.
+		// Anything else uses last-write-wins from remote, but if local diverged
+		// from base on the same key while remote also diverged differently, mark
+		// it ambiguous so an operator confirms.
+		$top_keys = array_unique(
+			array_merge(
+				array_keys( is_array( $local )  ? $local  : array() ),
+				array_keys( is_array( $remote ) ? $remote : array() )
+			)
+		);
+		foreach ( $top_keys as $key ) {
+			if ( in_array( $key, array( 'flow_config', 'scheduling_config' ), true ) ) {
+				continue;
+			}
+			$base_val   = $base[ $key ]   ?? null;
+			$local_val  = $local[ $key ]  ?? null;
+			$remote_val = $remote[ $key ] ?? null;
+
+			if ( $local_val === $remote_val ) {
+				continue;
+			}
+
+			$local_changed  = $local_val !== $base_val;
+			$remote_changed = $remote_val !== $base_val;
+
+			if ( $local_changed && $remote_changed ) {
+				$merged[ $key ]      = $local_val;
+				$decisions[ $key ]   = array(
+					'source' => 'ambiguous',
+					'reason' => 'both_diverged_from_base',
+				);
+				$ambiguous[]         = $key;
+				continue;
+			}
+
+			if ( $local_changed ) {
+				$merged[ $key ]    = $local_val;
+				$decisions[ $key ] = array(
+					'source' => 'local',
+					'reason' => 'remote_unchanged_from_base',
+				);
+				continue;
+			}
+
+			$merged[ $key ]    = $remote_val;
+			$decisions[ $key ] = array(
+				'source' => 'remote',
+				'reason' => 'local_unchanged_from_base',
+			);
+		}
+
+		return array(
+			'merged'    => $merged,
+			'decisions' => $decisions,
+			'ambiguous' => $ambiguous,
+		);
+	}
+
+	/**
+	 * 3-way merge a single handler_config map.
+	 *
+	 * Local-preserved keys (when local diverged from base): max_items.
+	 * Remote-preserved keys (source-shape) win when remote diverged from base.
+	 * If both diverged from base on the same key, mark ambiguous.
+	 *
+	 * @param array<string,mixed> $base   Base handler_config.
+	 * @param array<string,mixed> $local  Local handler_config.
+	 * @param array<string,mixed> $remote Remote handler_config.
+	 * @param string              $path_prefix Decision path prefix.
+	 * @param array<string,array<string,string>> $decisions In/out decisions map.
+	 * @param array<int,string>   $ambiguous In/out ambiguous list.
+	 * @return array<string,mixed>
+	 */
+	private static function merge_handler_config(
+		array $base,
+		array $local,
+		array $remote,
+		string $path_prefix,
+		array &$decisions,
+		array &$ambiguous
+	): array {
+		$local_preserve_keys = array( 'max_items' );
+
+		$keys   = array_unique( array_merge( array_keys( $base ), array_keys( $local ), array_keys( $remote ) ) );
+		$merged = array();
+
+		foreach ( $keys as $key ) {
+			$base_val   = $base[ $key ]   ?? null;
+			$local_val  = $local[ $key ]  ?? null;
+			$remote_val = $remote[ $key ] ?? null;
+			$path       = $path_prefix . '.' . (string) $key;
+
+			$local_changed  = array_key_exists( $key, $local )  && $local_val  !== $base_val;
+			$remote_changed = array_key_exists( $key, $remote ) && $remote_val !== $base_val;
+
+			// Identical local and remote → take it, no decision noise.
+			if ( $local_val === $remote_val ) {
+				if ( array_key_exists( $key, $local ) || array_key_exists( $key, $remote ) ) {
+					$merged[ $key ] = $local_val;
+				}
+				continue;
+			}
+
+			// Local-preserved throttle key: keep local if it diverged from base.
+			if ( in_array( (string) $key, $local_preserve_keys, true ) ) {
+				if ( $local_changed && ! $remote_changed ) {
+					$merged[ $key ]    = $local_val;
+					$decisions[ $path ] = array(
+						'source' => 'local',
+						'reason' => 'burn_in_preserve_throttle',
+					);
+					continue;
+				}
+				if ( $local_changed && $remote_changed ) {
+					// Both moved this throttle. Default to local (safer) but flag ambiguous.
+					$merged[ $key ]    = $local_val;
+					$decisions[ $path ] = array(
+						'source' => 'ambiguous',
+						'reason' => 'throttle_diverged_in_local_and_remote',
+					);
+					$ambiguous[]       = $path;
+					continue;
+				}
+				// Local unchanged from base; safe to take remote when remote moved
+				// (e.g. bundle deliberately raised throttle and local never overrode).
+				if ( array_key_exists( $key, $remote ) ) {
+					$merged[ $key ]    = $remote_val;
+					$decisions[ $path ] = array(
+						'source' => 'remote',
+						'reason' => 'local_unchanged_from_base',
+					);
+				} elseif ( array_key_exists( $key, $local ) ) {
+					$merged[ $key ] = $local_val;
+				}
+				continue;
+			}
+
+			// Source-shape keys default to remote when remote diverged.
+			if ( $remote_changed && ! $local_changed ) {
+				$merged[ $key ]    = $remote_val;
+				$decisions[ $path ] = array(
+					'source' => 'remote',
+					'reason' => 'remote_source_shape_change',
+				);
+				continue;
+			}
+
+			if ( $local_changed && ! $remote_changed ) {
+				$merged[ $key ]    = $local_val;
+				$decisions[ $path ] = array(
+					'source' => 'local',
+					'reason' => 'remote_unchanged_from_base',
+				);
+				continue;
+			}
+
+			if ( $local_changed && $remote_changed ) {
+				// Both moved a non-throttle key. Default merged value to local
+				// (don't silently clobber) and flag for approval.
+				$merged[ $key ]    = $local_val;
+				$decisions[ $path ] = array(
+					'source' => 'ambiguous',
+					'reason' => 'both_diverged_from_base',
+				);
+				$ambiguous[]       = $path;
+				continue;
+			}
+
+			// Neither changed but values differ → take whichever is set.
+			if ( array_key_exists( $key, $remote ) ) {
+				$merged[ $key ] = $remote_val;
+			} elseif ( array_key_exists( $key, $local ) ) {
+				$merged[ $key ] = $local_val;
+			}
+		}
+
+		return $merged;
+	}
+
+	/**
+	 * Compute dot-notation paths where local and remote payloads diverge.
+	 *
+	 * Used by the conservative policy to surface every disagreement without
+	 * attempting a merge.
+	 *
+	 * @param mixed  $local Local payload.
+	 * @param mixed  $remote Remote payload.
+	 * @param string $prefix Dot-notation prefix.
+	 * @return array<int,string>
+	 */
+	private static function diverging_paths( mixed $local, mixed $remote, string $prefix = '' ): array {
+		if ( $local === $remote ) {
+			return array();
+		}
+		if ( ! is_array( $local ) || ! is_array( $remote ) ) {
+			return array( '' === $prefix ? '$' : $prefix );
+		}
+
+		$paths = array();
+		$keys  = array_unique( array_merge( array_keys( $local ), array_keys( $remote ) ) );
+		foreach ( $keys as $key ) {
+			$child_prefix = '' === $prefix ? (string) $key : $prefix . '.' . (string) $key;
+			$lv           = $local[ $key ]  ?? null;
+			$rv           = $remote[ $key ] ?? null;
+			if ( $lv === $rv ) {
+				continue;
+			}
+			if ( is_array( $lv ) && is_array( $rv ) ) {
+				foreach ( self::diverging_paths( $lv, $rv, $child_prefix ) as $child ) {
+					$paths[] = $child;
+				}
+				continue;
+			}
+			$paths[] = $child_prefix;
+		}
+
+		return $paths;
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
@@ -21,21 +21,34 @@ final class AgentBundleInstalledArtifact {
 	private string $source_path;
 	private ?string $installed_hash;
 	private ?string $current_hash;
+	private mixed $installed_payload;
 	private string $status;
 	private string $installed_at;
 	private string $updated_at;
 
-	public function __construct( string $bundle_slug, string $bundle_version, string $artifact_type, string $artifact_id, string $source_path, ?string $installed_hash, ?string $current_hash, string $installed_at, string $updated_at ) {
-		$this->bundle_slug    = PortableSlug::normalize( $bundle_slug, 'bundle' );
-		$this->bundle_version = self::non_empty_string( $bundle_version, 'bundle_version' );
-		$this->artifact_type  = self::validate_artifact_type( $artifact_type );
-		$this->artifact_id    = self::non_empty_string( $artifact_id, 'artifact_id' );
-		$this->source_path    = self::normalize_source_path( $source_path );
-		$this->installed_hash = self::optional_string( $installed_hash );
-		$this->current_hash   = self::optional_string( $current_hash );
-		$this->status         = AgentBundleArtifactStatus::classify( $this->installed_hash, $this->current_hash );
-		$this->installed_at   = self::non_empty_string( $installed_at, 'installed_at' );
-		$this->updated_at     = self::non_empty_string( $updated_at, 'updated_at' );
+	public function __construct(
+		string $bundle_slug,
+		string $bundle_version,
+		string $artifact_type,
+		string $artifact_id,
+		string $source_path,
+		?string $installed_hash,
+		?string $current_hash,
+		string $installed_at,
+		string $updated_at,
+		mixed $installed_payload = null
+	) {
+		$this->bundle_slug       = PortableSlug::normalize( $bundle_slug, 'bundle' );
+		$this->bundle_version    = self::non_empty_string( $bundle_version, 'bundle_version' );
+		$this->artifact_type     = self::validate_artifact_type( $artifact_type );
+		$this->artifact_id       = self::non_empty_string( $artifact_id, 'artifact_id' );
+		$this->source_path       = self::normalize_source_path( $source_path );
+		$this->installed_hash    = self::optional_string( $installed_hash );
+		$this->current_hash      = self::optional_string( $current_hash );
+		$this->installed_payload = $installed_payload;
+		$this->status            = AgentBundleArtifactStatus::classify( $this->installed_hash, $this->current_hash );
+		$this->installed_at      = self::non_empty_string( $installed_at, 'installed_at' );
+		$this->updated_at        = self::non_empty_string( $updated_at, 'updated_at' );
 	}
 
 	/**
@@ -60,7 +73,8 @@ final class AgentBundleInstalledArtifact {
 			isset( $data['installed_hash'] ) ? (string) $data['installed_hash'] : null,
 			isset( $data['current_hash'] ) ? (string) $data['current_hash'] : null,
 			(string) $data['installed_at'],
-			(string) $data['updated_at']
+			(string) $data['updated_at'],
+			array_key_exists( 'installed_payload', $data ) ? $data['installed_payload'] : null
 		);
 	}
 
@@ -77,7 +91,18 @@ final class AgentBundleInstalledArtifact {
 	 */
 	public static function from_installed_payload( AgentBundleManifest $manifest, string $artifact_type, string $artifact_id, string $source_path, mixed $artifact_payload, string $timestamp ): self {
 		$hash = AgentBundleArtifactHasher::hash( $artifact_payload );
-		return new self( $manifest->bundle_slug(), $manifest->bundle_version(), $artifact_type, $artifact_id, $source_path, $hash, $hash, $timestamp, $timestamp );
+		return new self(
+			$manifest->bundle_slug(),
+			$manifest->bundle_version(),
+			$artifact_type,
+			$artifact_id,
+			$source_path,
+			$hash,
+			$hash,
+			$timestamp,
+			$timestamp,
+			$artifact_payload
+		);
 	}
 
 	/**
@@ -99,12 +124,25 @@ final class AgentBundleInstalledArtifact {
 			$this->installed_hash,
 			$current_hash,
 			$this->installed_at,
-			$updated_at
+			$updated_at,
+			$this->installed_payload
 		);
 	}
 
+	/**
+	 * Return the persisted install-time payload snapshot, when available.
+	 *
+	 * Returns null when this row predates the snapshot field or was reconstructed
+	 * from a hash-only source (e.g. orphaned runtime artifacts). Callers that
+	 * need 3-way merge fidelity (e.g. AgentBundleArtifactRebase) should treat
+	 * null as "no base info" and fall back to a more conservative policy.
+	 */
+	public function installed_payload(): mixed {
+		return $this->installed_payload;
+	}
+
 	public function to_array(): array {
-		return array(
+		$row = array(
 			'bundle_slug'    => $this->bundle_slug,
 			'bundle_version' => $this->bundle_version,
 			'artifact_type'  => $this->artifact_type,
@@ -116,6 +154,10 @@ final class AgentBundleInstalledArtifact {
 			'installed_at'   => $this->installed_at,
 			'updated_at'     => $this->updated_at,
 		);
+		if ( null !== $this->installed_payload ) {
+			$row['installed_payload'] = $this->installed_payload;
+		}
+		return $row;
 	}
 
 	private static function validate_artifact_type( string $type ): string {

--- a/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
@@ -29,6 +29,7 @@ final class AgentBundleUpgradePendingAction {
 		$plan_array       = $plan->to_array();
 		$target_artifacts = isset( $args['target_artifacts'] ) && is_array( $args['target_artifacts'] ) ? $args['target_artifacts'] : array();
 		$approved         = isset( $args['approved_artifacts'] ) && is_array( $args['approved_artifacts'] ) ? array_values( array_map( 'strval', $args['approved_artifacts'] ) ) : array();
+		$rebased          = isset( $args['rebased_artifacts'] ) && is_array( $args['rebased_artifacts'] ) ? $args['rebased_artifacts'] : array();
 
 		return PendingActionHelper::stage(
 			array(
@@ -39,6 +40,7 @@ final class AgentBundleUpgradePendingAction {
 					'agent'              => isset( $args['agent'] ) && is_array( $args['agent'] ) ? $args['agent'] : array(),
 					'approved_artifacts' => $approved,
 					'target_artifacts'   => $target_artifacts,
+					'rebased_artifacts'  => $rebased,
 					'plan'               => $plan_array,
 				),
 				'preview_data' => array(
@@ -71,10 +73,33 @@ final class AgentBundleUpgradePendingAction {
 			: array();
 		$approved = array_fill_keys( $approved, true );
 		$targets  = isset( $apply_input['target_artifacts'] ) && is_array( $apply_input['target_artifacts'] ) ? $apply_input['target_artifacts'] : array();
+		$rebased  = isset( $apply_input['rebased_artifacts'] ) && is_array( $apply_input['rebased_artifacts'] ) ? $apply_input['rebased_artifacts'] : array();
 		$agent    = isset( $apply_input['agent'] ) && is_array( $apply_input['agent'] ) ? $apply_input['agent'] : array();
 		$applied  = array();
 		$skipped  = array();
 		$failed   = array();
+
+		// Index rebased artifacts by key for O(1) lookup. A rebased entry
+		// substitutes its merged payload for the wholesale target during apply.
+		$rebased_by_key = array();
+		foreach ( $rebased as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$key = (string) ( $entry['artifact_key'] ?? AgentBundleArtifactExtensions::artifact_key(
+				(string) ( $entry['artifact_type'] ?? '' ),
+				(string) ( $entry['artifact_id'] ?? '' )
+			) );
+			if ( '' === $key ) {
+				continue;
+			}
+			if ( ! empty( $entry['requires_approval'] ) ) {
+				// Rebased entries with unresolved ambiguous fields stay
+				// approval-required and never auto-apply.
+				continue;
+			}
+			$rebased_by_key[ $key ] = $entry;
+		}
 
 		foreach ( $targets as $artifact ) {
 			if ( ! is_array( $artifact ) ) {
@@ -89,15 +114,30 @@ final class AgentBundleUpgradePendingAction {
 				continue;
 			}
 
+			$apply_artifact = $artifact;
+			$rebase_meta    = null;
+			if ( isset( $rebased_by_key[ $key ] ) ) {
+				$rebase_entry           = $rebased_by_key[ $key ];
+				$apply_artifact['payload'] = $rebase_entry['merged'] ?? $artifact['payload'] ?? null;
+				if ( isset( $rebase_entry['merged_hash'] ) ) {
+					$apply_artifact['hash'] = (string) $rebase_entry['merged_hash'];
+				}
+				$rebase_meta = array(
+					'policy'     => (string) ( $rebase_entry['policy'] ?? '' ),
+					'merged_hash' => isset( $rebase_entry['merged_hash'] ) ? (string) $rebase_entry['merged_hash'] : null,
+					'decisions'  => is_array( $rebase_entry['decisions'] ?? null ) ? $rebase_entry['decisions'] : array(),
+				);
+			}
+
 			/**
 			 * Apply one approved bundle upgrade artifact.
 			 *
 			 * @param mixed $result Null until a consumer applies the artifact.
-			 * @param array $artifact Target artifact payload.
+			 * @param array $artifact Target artifact payload (may be rebased).
 			 * @param array $apply_input Full PendingAction input.
 			 */
-			$result = AgentBundleArtifactExtensions::apply_artifact( $artifact, $agent, $apply_input );
-			$result = apply_filters( 'datamachine_bundle_upgrade_apply_artifact', $result, $artifact, $apply_input );
+			$result = AgentBundleArtifactExtensions::apply_artifact( $apply_artifact, $agent, $apply_input );
+			$result = apply_filters( 'datamachine_bundle_upgrade_apply_artifact', $result, $apply_artifact, $apply_input );
 			if ( is_wp_error( $result ) ) {
 				$failed[] = array(
 					'artifact_key' => $key,
@@ -113,10 +153,14 @@ final class AgentBundleUpgradePendingAction {
 				continue;
 			}
 
-			$applied[] = array(
+			$applied_entry = array(
 				'artifact_key' => $key,
 				'result'       => $result,
 			);
+			if ( null !== $rebase_meta ) {
+				$applied_entry['rebase'] = $rebase_meta;
+			}
+			$applied[] = $applied_entry;
 		}
 
 		return array(

--- a/tests/agent-bundle-artifact-rebase-smoke.php
+++ b/tests/agent-bundle-artifact-rebase-smoke.php
@@ -1,0 +1,358 @@
+<?php
+/**
+ * Pure-PHP smoke test for the policy-driven bundle artifact rebase primitive (#1832).
+ *
+ * Run with: php tests/agent-bundle-artifact-rebase-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		return $value;
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+// Use direct requires (not the composer autoloader) to avoid pulling in
+// vendor packages that need a full WordPress environment to bootstrap.
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactHasher.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactRebase.php';
+
+use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
+
+$failures = 0;
+$total    = 0;
+
+function rebase_assert( string $label, bool $condition ): void {
+	global $failures, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	echo "  FAIL: {$label}\n";
+	++$failures;
+}
+
+function rebase_assert_equals( string $label, $expected, $actual ): void {
+	$ok = $expected === $actual;
+	rebase_assert( $label, $ok );
+	if ( ! $ok ) {
+		echo "    expected: " . var_export( $expected, true ) . "\n";
+		echo "    actual:   " . var_export( $actual, true ) . "\n";
+	}
+}
+
+echo "=== Agent Bundle Artifact Rebase Smoke (#1832) ===\n";
+
+// ---------------------------------------------------------------------------
+// [1] Conservative policy keeps local payload but flags every divergence.
+// ---------------------------------------------------------------------------
+echo "\n[1] Conservative policy never auto-merges\n";
+$result = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'flow',
+		'artifact_id'   => 'demo',
+		'base'          => array( 'a' => 1, 'b' => 2 ),
+		'local'         => array( 'a' => 1, 'b' => 99 ),
+		'remote'        => array( 'a' => 5, 'b' => 2 ),
+	),
+	AgentBundleArtifactRebase::POLICY_CONSERVATIVE
+);
+
+rebase_assert_equals( 'conservative keeps local payload', array( 'a' => 1, 'b' => 99 ), $result['merged'] );
+rebase_assert( 'conservative flags both diverging fields ambiguous', count( $result['ambiguous'] ) === 2 );
+rebase_assert( 'conservative requires approval', true === $result['requires_approval'] );
+rebase_assert_equals( 'policy is recorded', 'conservative', $result['policy'] );
+
+// ---------------------------------------------------------------------------
+// [2] burn-in-safe falls back to conservative for non-flow artifacts.
+// ---------------------------------------------------------------------------
+echo "\n[2] burn-in-safe is conservative for non-flow artifacts\n";
+$pipeline_result = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'pipeline',
+		'artifact_id'   => 'collector',
+		'base'          => array( 'steps' => array( 'fetch', 'ai' ) ),
+		'local'         => array( 'steps' => array( 'fetch', 'ai' ), 'note' => 'local' ),
+		'remote'        => array( 'steps' => array( 'fetch', 'ai', 'publish' ) ),
+	),
+	AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE
+);
+
+rebase_assert( 'pipeline rebase requires approval under burn-in-safe', true === $pipeline_result['requires_approval'] );
+rebase_assert_equals( 'pipeline merged stays local under burn-in-safe', array( 'steps' => array( 'fetch', 'ai' ), 'note' => 'local' ), $pipeline_result['merged'] );
+
+// ---------------------------------------------------------------------------
+// [3] burn-in-safe takes remote source-shape, keeps local throttles.
+// Mirrors the wordpress-com-wiki Flow 41 case from the issue.
+// ---------------------------------------------------------------------------
+echo "\n[3] burn-in-safe preserves throttles, takes remote provider/owner/repo\n";
+$base_flow = array(
+	'flow_config' => array(
+		'10_fetch_1' => array(
+			'handler'        => 'github',
+			'handler_config' => array(
+				'server'    => 'github',
+				'owner'     => 'old-owner',
+				'repo'      => 'old-repo',
+				'perPage'   => 25,
+				'max_items' => 25,
+			),
+			'queue_mode'         => 'idle',
+			'config_patch_queue' => array(),
+		),
+	),
+	'scheduling_config' => array(
+		'enabled'   => true,
+		'interval'  => 'hourly',
+		'max_items' => array( 'fetch' => 25 ),
+	),
+);
+
+$local_flow = array(
+	'flow_config' => array(
+		'10_fetch_1' => array(
+			'handler'        => 'github',
+			'handler_config' => array(
+				'server'    => 'github',
+				'owner'     => 'old-owner',
+				'repo'      => 'old-repo',
+				'perPage'   => 25,
+				'max_items' => 1, // local burn-in throttle
+			),
+			'queue_mode'         => 'drain', // runtime queue change
+			'config_patch_queue' => array( array( 'patch' => array( 'state' => 'live' ) ) ),
+		),
+	),
+	'scheduling_config' => array(
+		'enabled'   => true,
+		'interval'  => 'hourly',
+		'max_items' => array( 'fetch' => 1 ), // local schedule throttle
+	),
+);
+
+$remote_flow = array(
+	'flow_config' => array(
+		'10_fetch_1' => array(
+			'handler'        => 'github-a8c', // upstream provider switch
+			'handler_config' => array(
+				'server'    => 'github-a8c',
+				'owner'     => 'Automattic',
+				'repo'      => 'wpcom',
+				'perPage'   => 1,
+				'max_items' => 25, // bundle-default upper bound
+			),
+			'queue_mode'         => 'idle',
+			'config_patch_queue' => array(),
+		),
+	),
+	'scheduling_config' => array(
+		'enabled'   => false,
+		'interval'  => 'manual',
+		'max_items' => array( 'fetch' => 25 ),
+	),
+);
+
+$result = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'flow',
+		'artifact_id'   => 'wordpress-com-history-github-wpcom-platform-queue',
+		'base'          => $base_flow,
+		'local'         => $local_flow,
+		'remote'        => $remote_flow,
+	),
+	AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE
+);
+
+$step = $result['merged']['flow_config']['10_fetch_1'] ?? array();
+
+rebase_assert_equals( 'remote source-shape: handler', 'github-a8c', $step['handler'] ?? null );
+rebase_assert_equals( 'remote source-shape: server', 'github-a8c', $step['handler_config']['server'] ?? null );
+rebase_assert_equals( 'remote source-shape: owner', 'Automattic', $step['handler_config']['owner'] ?? null );
+rebase_assert_equals( 'remote source-shape: repo', 'wpcom', $step['handler_config']['repo'] ?? null );
+rebase_assert_equals( 'remote source-shape: perPage', 1, $step['handler_config']['perPage'] ?? null );
+rebase_assert_equals( 'local throttle preserved: max_items', 1, $step['handler_config']['max_items'] ?? null );
+rebase_assert_equals( 'local runtime queue preserved: queue_mode', 'drain', $step['queue_mode'] ?? null );
+rebase_assert_equals( 'local runtime queue preserved: config_patch_queue length', 1, count( $step['config_patch_queue'] ?? array() ) );
+rebase_assert_equals(
+	'local scheduling preserved: max_items',
+	array( 'fetch' => 1 ),
+	$result['merged']['scheduling_config']['max_items'] ?? null
+);
+rebase_assert_equals( 'local scheduling preserved: enabled', true, $result['merged']['scheduling_config']['enabled'] ?? null );
+rebase_assert( 'no fields ambiguous in canonical wpcom case', empty( $result['ambiguous'] ) );
+rebase_assert( 'rebase does not require approval in canonical case', false === $result['requires_approval'] );
+
+// Decisions are surfaced for the operator.
+rebase_assert_equals(
+	'decision recorded for max_items local preservation',
+	'local',
+	$result['decisions']['flow_config.10_fetch_1.handler_config.max_items']['source'] ?? null
+);
+rebase_assert_equals(
+	'decision recorded for owner remote source-shape',
+	'remote',
+	$result['decisions']['flow_config.10_fetch_1.handler_config.owner']['source'] ?? null
+);
+
+// ---------------------------------------------------------------------------
+// [4] Ambiguous overlap remains approval-required, not silently merged.
+// ---------------------------------------------------------------------------
+echo "\n[4] Ambiguous overlap stays approval-required\n";
+$ambiguous_result = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'flow',
+		'artifact_id'   => 'tricky',
+		'base'          => array(
+			'flow_config' => array(
+				'1_step_1' => array(
+					'handler_config' => array(
+						'tool'      => 'old-tool',
+						'max_items' => 10,
+					),
+				),
+			),
+		),
+		'local' => array(
+			'flow_config' => array(
+				'1_step_1' => array(
+					'handler_config' => array(
+						'tool'      => 'local-tool', // local changed source-shape
+						'max_items' => 1,            // local lowered throttle
+					),
+				),
+			),
+		),
+		'remote' => array(
+			'flow_config' => array(
+				'1_step_1' => array(
+					'handler_config' => array(
+						'tool'      => 'remote-tool', // remote also changed source-shape
+						'max_items' => 25,            // remote raised throttle
+					),
+				),
+			),
+		),
+	),
+	AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE
+);
+
+rebase_assert( 'ambiguous overlap requires approval', true === $ambiguous_result['requires_approval'] );
+rebase_assert(
+	'tool flagged ambiguous when both diverged from base',
+	in_array( 'flow_config.1_step_1.handler_config.tool', $ambiguous_result['ambiguous'], true )
+);
+rebase_assert(
+	'max_items flagged ambiguous when both throttles diverged',
+	in_array( 'flow_config.1_step_1.handler_config.max_items', $ambiguous_result['ambiguous'], true )
+);
+$step_ambiguous = $ambiguous_result['merged']['flow_config']['1_step_1']['handler_config'] ?? array();
+rebase_assert_equals( 'ambiguous merge defaults to local tool (safer)', 'local-tool', $step_ambiguous['tool'] ?? null );
+rebase_assert_equals( 'ambiguous merge defaults to local throttle', 1, $step_ambiguous['max_items'] ?? null );
+
+// ---------------------------------------------------------------------------
+// [5] Multi-handler shape (handler_configs.<slug>) merges per slug.
+// ---------------------------------------------------------------------------
+echo "\n[5] Multi-handler handler_configs merges per slug\n";
+$multi_result = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'flow',
+		'artifact_id'   => 'multi',
+		'base'          => array(
+			'flow_config' => array(
+				'1_step_1' => array(
+					'handler_configs' => array(
+						'github' => array( 'owner' => 'old', 'max_items' => 25 ),
+						'rss'    => array( 'feed' => 'https://old.example/feed' ),
+					),
+				),
+			),
+		),
+		'local' => array(
+			'flow_config' => array(
+				'1_step_1' => array(
+					'handler_configs' => array(
+						'github' => array( 'owner' => 'old', 'max_items' => 1 ),
+						'rss'    => array( 'feed' => 'https://old.example/feed' ),
+					),
+				),
+			),
+		),
+		'remote' => array(
+			'flow_config' => array(
+				'1_step_1' => array(
+					'handler_configs' => array(
+						'github' => array( 'owner' => 'Automattic', 'max_items' => 25 ),
+						'rss'    => array( 'feed' => 'https://new.example/feed' ),
+					),
+				),
+			),
+		),
+	),
+	AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE
+);
+
+$multi_step = $multi_result['merged']['flow_config']['1_step_1']['handler_configs'] ?? array();
+rebase_assert_equals( 'multi: github owner from remote', 'Automattic', $multi_step['github']['owner'] ?? null );
+rebase_assert_equals( 'multi: github throttle from local', 1, $multi_step['github']['max_items'] ?? null );
+rebase_assert_equals( 'multi: rss feed from remote (local unchanged)', 'https://new.example/feed', $multi_step['rss']['feed'] ?? null );
+rebase_assert( 'multi: no ambiguous fields', empty( $multi_result['ambiguous'] ) );
+
+// ---------------------------------------------------------------------------
+// [6] Hashes are recomputed for the merged payload.
+// ---------------------------------------------------------------------------
+echo "\n[6] Rebase output carries reproducible hashes\n";
+$hashed_result = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'flow',
+		'artifact_id'   => 'hash-check',
+		'base'          => array( 'a' => 1 ),
+		'local'         => array( 'a' => 1, 'b' => 2 ),
+		'remote'        => array( 'a' => 9 ),
+	),
+	AgentBundleArtifactRebase::POLICY_CONSERVATIVE
+);
+rebase_assert( 'merged_hash is set when merged payload is non-null', is_string( $hashed_result['merged_hash'] ) && '' !== $hashed_result['merged_hash'] );
+rebase_assert( 'local_hash is set', is_string( $hashed_result['local_hash'] ) );
+rebase_assert( 'remote_hash is set', is_string( $hashed_result['remote_hash'] ) );
+rebase_assert( 'base_hash is set', is_string( $hashed_result['base_hash'] ) );
+
+// ---------------------------------------------------------------------------
+// [7] Default policy is conservative when an unknown policy name is supplied.
+// ---------------------------------------------------------------------------
+echo "\n[7] Unknown policy falls back to conservative\n";
+$unknown_result = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'flow',
+		'artifact_id'   => 'unknown-policy',
+		'base'          => array( 'a' => 1 ),
+		'local'         => array( 'a' => 2 ),
+		'remote'        => array( 'a' => 3 ),
+	),
+	'no-such-policy'
+);
+rebase_assert_equals( 'unknown policy resolves to conservative', 'conservative', $unknown_result['policy'] );
+rebase_assert( 'unknown policy still flags divergence', true === $unknown_result['requires_approval'] );
+
+echo "\nTotal assertions: {$total}\n";
+if ( 0 !== $failures ) {
+	echo "Failures: {$failures}\n";
+	exit( 1 );
+}
+echo "All assertions passed.\n";
+
+}

--- a/tests/agent-bundle-installed-payload-snapshot-smoke.php
+++ b/tests/agent-bundle-installed-payload-snapshot-smoke.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Pure-PHP smoke test for installed-artifact payload snapshot persistence.
+ *
+ * Exercises the round-trip:
+ *   payload at install → AgentBundleInstalledArtifact → to_array() → from_array()
+ *   → installed_payload() returns the original payload.
+ *
+ * And the rebase-fidelity claim:
+ *   With installed_payload populated, the burn-in-safe policy can produce a
+ *   clean (no-ambiguous) merge for the canonical wpcom case, where without it
+ *   the policy has to flag fields ambiguous because it can't tell "local moved
+ *   this field" from "local just inherited base".
+ *
+ * Run with: php tests/agent-bundle-installed-payload-snapshot-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		return $value;
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleValidationException.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/PortableSlug.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactHasher.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactStatus.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleManifest.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleInstalledArtifact.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactRebase.php';
+
+use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
+use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+
+$failures = 0;
+$total    = 0;
+
+function snap_assert( string $label, bool $condition ): void {
+	global $failures, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	echo "  FAIL: {$label}\n";
+	++$failures;
+}
+
+function snap_assert_equals( string $label, $expected, $actual ): void {
+	$ok = $expected === $actual;
+	snap_assert( $label, $ok );
+	if ( ! $ok ) {
+		echo "    expected: " . var_export( $expected, true ) . "\n";
+		echo "    actual:   " . var_export( $actual, true ) . "\n";
+	}
+}
+
+echo "=== Installed Payload Snapshot Smoke (#1832 follow-up) ===\n";
+
+$manifest = AgentBundleManifest::from_array(
+	array(
+		'schema_version' => 1,
+		'bundle_slug'    => 'wordpress-com-wiki',
+		'bundle_version' => '1.0.0',
+		'exported_at'    => '2026-04-28T00:00:00Z',
+		'exported_by'    => 'data-machine/test',
+		'agent'          => array(
+			'slug'         => 'wordpress-com-wiki',
+			'label'        => 'wpcom Wiki',
+			'description'  => 'Builds wpcom domain wiki.',
+			'agent_config' => array(),
+		),
+		'included'       => array(
+			'memory'       => array(),
+			'pipelines'    => array(),
+			'flows'        => array(),
+			'handler_auth' => 'refs',
+		),
+	)
+);
+
+// ---------------------------------------------------------------------------
+// [1] Install-time payload is captured on AgentBundleInstalledArtifact.
+// ---------------------------------------------------------------------------
+echo "\n[1] Install-time payload is captured\n";
+$flow_payload = array(
+	'flow_config' => array(
+		'10_fetch_1' => array(
+			'handler'        => 'github',
+			'handler_config' => array(
+				'server'    => 'github',
+				'owner'     => 'old-owner',
+				'repo'      => 'old-repo',
+				'perPage'   => 25,
+				'max_items' => 25,
+			),
+		),
+	),
+	'scheduling_config' => array( 'enabled' => true, 'interval' => 'hourly', 'max_items' => array( 'fetch' => 25 ) ),
+);
+
+$installed = AgentBundleInstalledArtifact::from_installed_payload(
+	$manifest,
+	'flow',
+	'wordpress-com-history-github-wpcom-platform-queue',
+	'flows/wordpress-com-history.json',
+	$flow_payload,
+	'2026-04-28T00:00:00Z'
+);
+
+snap_assert_equals( 'installed_payload exposes the install-time payload', $flow_payload, $installed->installed_payload() );
+$serialized = $installed->to_array();
+snap_assert( 'to_array() includes installed_payload', isset( $serialized['installed_payload'] ) );
+snap_assert_equals( 'serialized payload round-trips identically', $flow_payload, $serialized['installed_payload'] );
+
+// ---------------------------------------------------------------------------
+// [2] from_array() → installed_payload() round-trips.
+// ---------------------------------------------------------------------------
+echo "\n[2] from_array() round-trips installed_payload\n";
+$rehydrated = AgentBundleInstalledArtifact::from_array( $serialized );
+snap_assert_equals( 'rehydrated installed_payload matches', $flow_payload, $rehydrated->installed_payload() );
+
+// ---------------------------------------------------------------------------
+// [3] Pre-snapshot rows (no installed_payload field) round-trip cleanly.
+// ---------------------------------------------------------------------------
+echo "\n[3] Pre-snapshot rows propagate as null\n";
+$legacy_row = $serialized;
+unset( $legacy_row['installed_payload'] );
+$legacy = AgentBundleInstalledArtifact::from_array( $legacy_row );
+snap_assert_equals( 'legacy row exposes null installed_payload', null, $legacy->installed_payload() );
+
+$legacy_serialized = $legacy->to_array();
+snap_assert( 'legacy to_array() omits installed_payload key', ! array_key_exists( 'installed_payload', $legacy_serialized ) );
+
+// ---------------------------------------------------------------------------
+// [4] with_current_payload() preserves installed_payload (it's the base, not
+// the live payload — so it must not change as live state mutates).
+// ---------------------------------------------------------------------------
+echo "\n[4] with_current_payload preserves base payload\n";
+$mutated = $installed->with_current_payload( array( 'name' => 'edited' ), '2026-04-28T05:00:00Z' );
+snap_assert_equals( 'mutating current_payload does not clobber installed_payload', $flow_payload, $mutated->installed_payload() );
+
+// ---------------------------------------------------------------------------
+// [5] burn-in-safe rebase produces a clean merge given a real base.
+// This is the whole point of persisting installed_payload.
+// ---------------------------------------------------------------------------
+echo "\n[5] burn-in-safe rebase is clean with installed_payload as base\n";
+$base   = $installed->installed_payload();
+$local  = array(
+	'flow_config' => array(
+		'10_fetch_1' => array(
+			'handler'        => 'github',
+			'handler_config' => array(
+				'server'    => 'github',
+				'owner'     => 'old-owner',
+				'repo'      => 'old-repo',
+				'perPage'   => 25,
+				'max_items' => 1, // local burn-in throttle
+			),
+		),
+	),
+	'scheduling_config' => array( 'enabled' => true, 'interval' => 'hourly', 'max_items' => array( 'fetch' => 1 ) ),
+);
+$remote = array(
+	'flow_config' => array(
+		'10_fetch_1' => array(
+			'handler'        => 'github-a8c',
+			'handler_config' => array(
+				'server'    => 'github-a8c',
+				'owner'     => 'Automattic',
+				'repo'      => 'wpcom',
+				'perPage'   => 1,
+				'max_items' => 25, // bundle default — base also was 25, so remote did NOT change this
+			),
+		),
+	),
+	'scheduling_config' => array( 'enabled' => false, 'interval' => 'manual', 'max_items' => array( 'fetch' => 25 ) ),
+);
+
+$rebase_with_base = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'flow',
+		'artifact_id'   => 'wordpress-com-history-github-wpcom-platform-queue',
+		'base'          => $base,
+		'local'         => $local,
+		'remote'        => $remote,
+	),
+	AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE
+);
+
+snap_assert( 'merge is unambiguous when base is available', empty( $rebase_with_base['ambiguous'] ) );
+snap_assert( 'no approval required with base', false === $rebase_with_base['requires_approval'] );
+
+$step = $rebase_with_base['merged']['flow_config']['10_fetch_1'] ?? array();
+snap_assert_equals( 'remote handler taken', 'github-a8c', $step['handler'] ?? null );
+snap_assert_equals( 'remote owner taken', 'Automattic', $step['handler_config']['owner'] ?? null );
+snap_assert_equals( 'local throttle preserved (max_items)', 1, $step['handler_config']['max_items'] ?? null );
+
+// Demonstrate the regression we are fixing: without base, the merge is noisier.
+// max_items moves from "burn-in throttle preserved" (clean) to a state where
+// the policy can still keep local but does so without confidence that local
+// represented intent vs. inherited default.
+$rebase_without_base = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'flow',
+		'artifact_id'   => 'wordpress-com-history-github-wpcom-platform-queue',
+		'base'          => null,
+		'local'         => $local,
+		'remote'        => $remote,
+	),
+	AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE
+);
+
+// Without base, the policy sees local==remote on max_items? No: local=1, remote=25,
+// both diverge from "base=null" → policy sees both changed → ambiguous.
+$step_no_base   = $rebase_without_base['merged']['flow_config']['10_fetch_1'] ?? array();
+$has_throttle_ambiguity = in_array(
+	'flow_config.10_fetch_1.handler_config.max_items',
+	$rebase_without_base['ambiguous'],
+	true
+);
+snap_assert(
+	'baseline regression: without installed_payload, max_items is ambiguous',
+	$has_throttle_ambiguity
+);
+snap_assert(
+	'baseline regression: without installed_payload, requires approval',
+	true === $rebase_without_base['requires_approval']
+);
+snap_assert(
+	'with installed_payload: clean merge (this PR\'s improvement)',
+	false === $rebase_with_base['requires_approval']
+);
+
+echo "\nTotal assertions: {$total}\n";
+if ( 0 !== $failures ) {
+	echo "Failures: {$failures}\n";
+	exit( 1 );
+}
+echo "All assertions passed.\n";
+
+}

--- a/tests/agent-bundle-pending-action-rebase-smoke.php
+++ b/tests/agent-bundle-pending-action-rebase-smoke.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Pure-PHP smoke test for PendingAction.apply() honoring rebased artifacts (#1832).
+ *
+ * Run with: php tests/agent-bundle-pending-action-rebase-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+$GLOBALS['__rebase_pa_filters'] = array();
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['__rebase_pa_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+		ksort( $GLOBALS['__rebase_pa_filters'][ $hook ], SORT_NUMERIC );
+		return true;
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		if ( empty( $GLOBALS['__rebase_pa_filters'][ $hook ] ) ) {
+			return $value;
+		}
+		foreach ( $GLOBALS['__rebase_pa_filters'][ $hook ] as $callbacks ) {
+			foreach ( $callbacks as $registration ) {
+				$value = call_user_func_array( $registration[0], array_slice( array_merge( array( $value ), $args ), 0, $registration[1] ) );
+			}
+		}
+		return $value;
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ) {
+		return false;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactHasher.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactRebase.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php';
+
+use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
+use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
+
+$failures = 0;
+$total    = 0;
+
+function pa_rebase_assert( string $label, bool $condition ): void {
+	global $failures, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	echo "  FAIL: {$label}\n";
+	++$failures;
+}
+
+function pa_rebase_assert_equals( string $label, $expected, $actual ): void {
+	$ok = $expected === $actual;
+	pa_rebase_assert( $label, $ok );
+	if ( ! $ok ) {
+		echo "    expected: " . var_export( $expected, true ) . "\n";
+		echo "    actual:   " . var_export( $actual, true ) . "\n";
+	}
+}
+
+echo "=== Agent Bundle PendingAction Rebase Apply Smoke (#1832) ===\n";
+
+$captured_payloads = array();
+add_filter(
+	'datamachine_bundle_upgrade_apply_artifact',
+	static function ( $result, array $artifact ) use ( &$captured_payloads ) {
+		$key                       = ( $artifact['artifact_type'] ?? '' ) . ':' . ( $artifact['artifact_id'] ?? '' );
+		$captured_payloads[ $key ] = $artifact['payload'];
+		return array( 'wrote' => $key, 'hash' => $artifact['hash'] ?? null );
+	},
+	10,
+	2
+);
+
+// Build a rebased entry for the locally-modified flow:install case.
+$rebase = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'flow',
+		'artifact_id'   => 'demo',
+		'base'          => array(
+			'flow_config' => array(
+				'1_step_1' => array(
+					'handler'        => 'github',
+					'handler_config' => array( 'owner' => 'old', 'max_items' => 25 ),
+				),
+			),
+		),
+		'local' => array(
+			'flow_config' => array(
+				'1_step_1' => array(
+					'handler'        => 'github',
+					'handler_config' => array( 'owner' => 'old', 'max_items' => 1 ),
+				),
+			),
+		),
+		'remote' => array(
+			'flow_config' => array(
+				'1_step_1' => array(
+					'handler'        => 'github-a8c',
+					'handler_config' => array( 'owner' => 'Automattic', 'max_items' => 25 ),
+				),
+			),
+		),
+	),
+	AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE
+);
+
+pa_rebase_assert( 'rebase produced unambiguous merge', false === $rebase['requires_approval'] );
+
+$apply_input = array(
+	'agent'              => array( 'agent_id' => 7 ),
+	'approved_artifacts' => array( 'flow:demo' ),
+	'target_artifacts'   => array(
+		array(
+			'artifact_type' => 'flow',
+			'artifact_id'   => 'demo',
+			'source_path'   => 'flows/demo.json',
+			'payload'       => array(
+				'flow_config' => array(
+					'1_step_1' => array(
+						'handler'        => 'github-a8c',
+						'handler_config' => array( 'owner' => 'Automattic', 'max_items' => 25 ),
+					),
+				),
+			),
+		),
+	),
+	'rebased_artifacts'  => array( $rebase ),
+);
+
+$result = AgentBundleUpgradePendingAction::apply( $apply_input );
+
+pa_rebase_assert( 'apply success', true === ( $result['success'] ?? false ) );
+pa_rebase_assert_equals( 'apply count', 1, count( $result['applied'] ?? array() ) );
+pa_rebase_assert_equals( 'no failures', 0, count( $result['failed'] ?? array() ) );
+
+$applied_entry = $result['applied'][0] ?? array();
+pa_rebase_assert_equals( 'rebase metadata recorded on apply', AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE, $applied_entry['rebase']['policy'] ?? null );
+pa_rebase_assert( 'rebase metadata includes merged_hash', is_string( $applied_entry['rebase']['merged_hash'] ?? null ) );
+
+// The captured payload should be the merged payload, not the wholesale target.
+$captured = $captured_payloads['flow:demo'] ?? array();
+pa_rebase_assert_equals(
+	'apply handler received merged payload (max_items kept local)',
+	1,
+	$captured['flow_config']['1_step_1']['handler_config']['max_items'] ?? null
+);
+pa_rebase_assert_equals(
+	'apply handler received merged payload (owner from remote)',
+	'Automattic',
+	$captured['flow_config']['1_step_1']['handler_config']['owner'] ?? null
+);
+pa_rebase_assert_equals(
+	'apply handler received merged payload (handler from remote)',
+	'github-a8c',
+	$captured['flow_config']['1_step_1']['handler'] ?? null
+);
+
+// Sanity: with no rebased entry, apply receives the raw target (legacy path).
+$captured_payloads = array();
+$result_legacy     = AgentBundleUpgradePendingAction::apply(
+	array(
+		'agent'              => array( 'agent_id' => 7 ),
+		'approved_artifacts' => array( 'flow:demo' ),
+		'target_artifacts'   => $apply_input['target_artifacts'],
+	)
+);
+pa_rebase_assert( 'legacy apply still succeeds without rebased_artifacts', true === ( $result_legacy['success'] ?? false ) );
+pa_rebase_assert_equals(
+	'legacy apply receives raw target max_items',
+	25,
+	$captured_payloads['flow:demo']['flow_config']['1_step_1']['handler_config']['max_items'] ?? null
+);
+
+// Ambiguous rebase entries are not applied even if approved.
+$ambiguous_rebase = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'flow',
+		'artifact_id'   => 'tricky',
+		'base'          => array( 'flow_config' => array( '1_a_1' => array( 'handler_config' => array( 'tool' => 'old' ) ) ) ),
+		'local'         => array( 'flow_config' => array( '1_a_1' => array( 'handler_config' => array( 'tool' => 'local' ) ) ) ),
+		'remote'        => array( 'flow_config' => array( '1_a_1' => array( 'handler_config' => array( 'tool' => 'remote' ) ) ) ),
+	),
+	AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE
+);
+pa_rebase_assert( 'tricky case is ambiguous', true === $ambiguous_rebase['requires_approval'] );
+
+$captured_payloads = array();
+$tricky_apply      = AgentBundleUpgradePendingAction::apply(
+	array(
+		'agent'              => array( 'agent_id' => 7 ),
+		'approved_artifacts' => array( 'flow:tricky' ),
+		'target_artifacts'   => array(
+			array(
+				'artifact_type' => 'flow',
+				'artifact_id'   => 'tricky',
+				'source_path'   => 'flows/tricky.json',
+				'payload'       => array( 'flow_config' => array( '1_a_1' => array( 'handler_config' => array( 'tool' => 'remote' ) ) ) ),
+			),
+		),
+		'rebased_artifacts'  => array( $ambiguous_rebase ),
+	)
+);
+pa_rebase_assert(
+	'ambiguous rebase entry does not override target on apply',
+	'remote' === ( $captured_payloads['flow:tricky']['flow_config']['1_a_1']['handler_config']['tool'] ?? null )
+);
+
+echo "\nTotal assertions: {$total}\n";
+if ( 0 !== $failures ) {
+	echo "Failures: {$failures}\n";
+	exit( 1 );
+}
+echo "All assertions passed.\n";
+
+}


### PR DESCRIPTION
## Summary

Closes #1832.

Adds a 3-way merge primitive over base/local/remote bundle artifact payloads, plus pluggable policies, so operators can take upstream bundle source-shape fixes while preserving local burn-in/runtime safety edits — instead of choosing between "keep local drift" and "apply target wholesale".

Motivating example from the issue: on `intelligence-chubes4`, the `wordpress-com-wiki` bundle upgrade needed Flow 41's upstream provider switch (`github-a8c`, explicit `owner: Automattic`, `repo: wpcom`, `perPage: 1`) while other lanes had local `max_items: 1` burn-in throttles that should not be clobbered by remote `max_items: 25`. The new primitive handles that exact shape under the `burn-in-safe` policy.

## What ships

### `AgentBundleArtifactRebase` (`inc/Engine/Bundle/`)

3-way merge primitive accepting `base`/`local`/`remote` payloads plus a named policy. Output is a per-field decisions map, an ambiguous-fields list, and a merged payload with reproducible hashes (`merged_hash`, `base_hash`, `local_hash`, `remote_hash`).

**Default behavior is conservative**: nothing auto-merges without an explicit policy. Two policies ship:

- `conservative` — keep local payload, flag every diverging field as ambiguous, always require approval. Default fallback for unknown policy names.
- `burn-in-safe` — for `flow` artifacts only, take remote source-shape changes (`handler`, `handler_config.{server,provider,tool,params,query,owner,repo,perPage,...}`, and the same fields under `handler_configs.<slug>`) while preserving local runtime/safety fields:
  - `flow_config.<step>.{prompt_queue, config_patch_queue, queue_mode, _queue_consume_revision}`
  - `flow_config.<step>.handler_config.max_items` and `handler_configs.<slug>.max_items` when local diverged from base on the throttle
  - whole `scheduling_config` subtree (interval, enabled, max_items)

  Non-flow artifacts under `burn-in-safe` fall through to conservative. Overlapping divergences (both local and remote moved the same key away from base) stay approval-required and the merged payload defaults to local (safer).

Policies are pluggable via the `datamachine_bundle_rebase_policies` filter so plugins or downstream agents can add bundle-specific policies without touching core.

### CLI surface (`AgentBundleCommand` → inherited by `AgentsCommand`)

```bash
# Dry-run a merge preview.
wp datamachine agent rebase <path> --slug=<slug> --policy=burn-in-safe \
    --artifact=flow:wordpress-com-history-github-wpcom-platform-queue --format=json

# Stage a PendingAction with merged payloads attached.
wp datamachine agent upgrade <path> --slug=<slug> --rebase-local --policy=burn-in-safe
```

### PendingAction integration

`AgentBundleUpgradePendingAction::stage()` now accepts an optional `rebased_artifacts` array. `apply()` indexes rebased entries by `artifact_key`, substitutes the merged payload + merged hash into the per-artifact apply call, and records the rebase policy + merged hash + decisions on the applied entry. Ambiguous rebased entries (`requires_approval=true`) are ignored on apply, so nothing silently bypasses approval.

The legacy apply path (no `rebased_artifacts`) is unchanged: bare wholesale-target apply still works for any consumer that doesn't opt in.

## Tests

- `tests/agent-bundle-artifact-rebase-smoke.php` — 35 assertions covering: conservative fallback, burn-in-safe canonical wpcom case, ambiguous overlap, multi-handler `handler_configs` per-slug merging, hash bookkeeping, unknown-policy fallback.
- `tests/agent-bundle-pending-action-rebase-smoke.php` — 13 assertions covering: apply writes merged payload, rebase metadata is recorded on `applied[]`, legacy path still applies raw target when `rebased_artifacts` is absent, ambiguous rebases do not override target on apply.

```
php tests/agent-bundle-artifact-rebase-smoke.php          # 35/35 passed
php tests/agent-bundle-pending-action-rebase-smoke.php    # 13/13 passed
php tests/agent-bundle-runtime-drift-smoke.php            # 13/13 passed (regression check)
php -l on all changed PHP files                            # clean
vendor/bin/phpcs --standard=WordPress on changed files     # clean
```

## Limitations / follow-ups

- Base payload reconstruction in `rebase_locally_modified()` only works when the installed-artifact tracking row exposes `payload`. If only `installed_hash` is persisted (today's common case for materialized artifacts), `base` falls back to `null` and `burn-in-safe` degrades by treating "remote diverged from base" as "any remote value": the merged result is still safe but more fields will be marked ambiguous than necessary. A follow-up could persist the installed payload (or a normalized snapshot) so the burn-in-safe policy gets full 3-way fidelity.
- The CLI exposes dry-run preview and `upgrade --rebase-local` apply. There is no separate `agent rebase <pending_action_id>` post-stage editor in this PR; an operator who wants to alter the policy after staging today re-runs `upgrade --rebase-local --policy=…`. Wire that through `ResolvePendingActionAbility` resolve_params in a follow-up if needed.
- Only `flow` artifacts have a non-conservative policy. Pipelines, prompts, and other artifact types remain conservative until concrete merge needs surface.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the rebase primitive, both policies, the PendingAction apply integration, the CLI subcommand wiring, and both smoke tests. Chris reviewed the design and verified the smoke output.