### PR TITLE
feat(bundle): persist install-time payload snapshot for rebase fidelity (#1832 follow-up)

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -445,15 +445,24 @@ class AgentBundleCommand extends BaseCommand {
 				continue;
 			}
 
-			// Reconstruct the base payload by hash. We don't persist the original
-			// payload, only its hash, so the rebase falls back to "no base info"
-			// for installed rows missing a snapshot. Conservative policy is fine
-			// without a base; burn-in-safe degrades by treating remote as the
-			// changed side and local as the changed side without merge guidance.
-			$base_payload = null;
+			// Reconstruct the base payload from the install-time snapshot. New
+			// installs/upgrades persist `installed_payload` on the agent_config
+			// record (see AgentBundler::bundle_artifact_record()) so 3-way merge
+			// has full fidelity. Pre-snapshot rows leave `installed_payload`
+			// missing — burn-in-safe degrades to flagging more fields ambiguous
+			// rather than silently merging without a real base.
+			//
+			// `payload` (no `installed_` prefix) is checked as a back-compat alias
+			// for older test fixtures and any custom writers; new code should use
+			// `installed_payload`.
+			$base_payload  = null;
 			$installed_row = $installed_index[ $key ] ?? null;
-			if ( is_array( $installed_row ) && isset( $installed_row['payload'] ) ) {
-				$base_payload = $installed_row['payload'];
+			if ( is_array( $installed_row ) ) {
+				if ( array_key_exists( 'installed_payload', $installed_row ) ) {
+					$base_payload = $installed_row['installed_payload'];
+				} elseif ( array_key_exists( 'payload', $installed_row ) ) {
+					$base_payload = $installed_row['payload'];
+				}
 			}
 
 			$results[] = AgentBundleArtifactRebase::rebase(

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -1186,17 +1186,23 @@ class AgentBundler {
 		$hash = AgentBundleArtifactHasher::hash( $payload );
 		$now  = gmdate( 'c' );
 
+		// installed_payload is the install-time snapshot. AgentBundleArtifactRebase
+		// uses it as the `base` side of the 3-way merge so burn-in-safe can tell
+		// "local moved this field away from base" from "local just inherited base".
+		// Without it, the rebase primitive degrades to flagging more hunks
+		// ambiguous than necessary (#1832 follow-up).
 		return array(
-			'bundle_slug'    => $bundle_metadata['bundle_slug'],
-			'bundle_version' => $bundle_metadata['bundle_version'],
-			'artifact_type'  => $type,
-			'artifact_id'    => $id,
-			'source_path'    => $source_path,
-			'installed_hash' => $hash,
-			'current_hash'   => $hash,
-			'status'         => AgentBundleArtifactStatus::CLEAN,
-			'installed_at'   => $now,
-			'updated_at'     => $now,
+			'bundle_slug'       => $bundle_metadata['bundle_slug'],
+			'bundle_version'    => $bundle_metadata['bundle_version'],
+			'artifact_type'     => $type,
+			'artifact_id'       => $id,
+			'source_path'       => $source_path,
+			'installed_hash'    => $hash,
+			'current_hash'      => $hash,
+			'installed_payload' => $payload,
+			'status'            => AgentBundleArtifactStatus::CLEAN,
+			'installed_at'      => $now,
+			'updated_at'        => $now,
 		);
 	}
 

--- a/inc/Core/Database/BundleArtifacts/InstalledBundleArtifacts.php
+++ b/inc/Core/Database/BundleArtifacts/InstalledBundleArtifacts.php
@@ -72,6 +72,7 @@ final class InstalledBundleArtifacts extends BaseRepository {
 			source_path VARCHAR(500) NOT NULL,
 			installed_hash CHAR(64) NULL DEFAULT NULL,
 			current_hash CHAR(64) NULL DEFAULT NULL,
+			installed_payload LONGTEXT NULL DEFAULT NULL,
 			local_status VARCHAR(20) NOT NULL DEFAULT 'clean',
 			installed_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL,
@@ -96,26 +97,31 @@ final class InstalledBundleArtifacts extends BaseRepository {
 	 * @return bool
 	 */
 	public function upsert( AgentBundleInstalledArtifact $artifact, int $agent_id = 0 ): bool {
-		$artifact_row = $artifact->to_array();
-		$row          = array(
-			'agent_id'       => max( 0, $agent_id ),
-			'bundle_slug'    => $artifact_row['bundle_slug'],
-			'bundle_version' => $artifact_row['bundle_version'],
-			'artifact_type'  => $artifact_row['artifact_type'],
-			'artifact_id'    => $artifact_row['artifact_id'],
-			'source_path'    => $artifact_row['source_path'],
-			'installed_hash' => '' !== (string) $artifact_row['installed_hash'] ? $artifact_row['installed_hash'] : null,
-			'current_hash'   => '' !== (string) $artifact_row['current_hash'] ? $artifact_row['current_hash'] : null,
-			'local_status'   => $artifact_row['status'],
-			'installed_at'   => $artifact_row['installed_at'],
-			'updated_at'     => $artifact_row['updated_at'],
+		$artifact_row      = $artifact->to_array();
+		$installed_payload = $artifact->installed_payload();
+		$encoded_payload   = null === $installed_payload
+			? null
+			: ( is_string( $installed_payload ) ? $installed_payload : wp_json_encode( $installed_payload ) );
+		$row               = array(
+			'agent_id'          => max( 0, $agent_id ),
+			'bundle_slug'       => $artifact_row['bundle_slug'],
+			'bundle_version'    => $artifact_row['bundle_version'],
+			'artifact_type'     => $artifact_row['artifact_type'],
+			'artifact_id'       => $artifact_row['artifact_id'],
+			'source_path'       => $artifact_row['source_path'],
+			'installed_hash'    => '' !== (string) $artifact_row['installed_hash'] ? $artifact_row['installed_hash'] : null,
+			'current_hash'      => '' !== (string) $artifact_row['current_hash'] ? $artifact_row['current_hash'] : null,
+			'installed_payload' => $encoded_payload,
+			'local_status'      => $artifact_row['status'],
+			'installed_at'      => $artifact_row['installed_at'],
+			'updated_at'        => $artifact_row['updated_at'],
 		);
-		$record_id    = $this->existing_record_id( $row );
-		$format       = array( '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' );
+		$record_id         = $this->existing_record_id( $row );
+		$format            = array( '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' );
 
 		if ( null !== $record_id ) {
-			$row        = array_merge( array( 'artifact_record_id' => $record_id ), $row );
-			$format     = array_merge( array( '%d' ), $format );
+			$row    = array_merge( array( 'artifact_record_id' => $record_id ), $row );
+			$format = array_merge( array( '%d' ), $format );
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -264,19 +270,26 @@ final class InstalledBundleArtifacts extends BaseRepository {
 	}
 
 	private function artifact_from_row( array $row ): AgentBundleInstalledArtifact {
-		return AgentBundleInstalledArtifact::from_array(
-			array(
-				'bundle_slug'    => (string) $row['bundle_slug'],
-				'bundle_version' => (string) $row['bundle_version'],
-				'artifact_type'  => (string) $row['artifact_type'],
-				'artifact_id'    => (string) $row['artifact_id'],
-				'source_path'    => (string) $row['source_path'],
-				'installed_hash' => (string) $row['installed_hash'],
-				'current_hash'   => isset( $row['current_hash'] ) ? (string) $row['current_hash'] : null,
-				'installed_at'   => (string) $row['installed_at'],
-				'updated_at'     => (string) $row['updated_at'],
-			)
+		$data = array(
+			'bundle_slug'    => (string) $row['bundle_slug'],
+			'bundle_version' => (string) $row['bundle_version'],
+			'artifact_type'  => (string) $row['artifact_type'],
+			'artifact_id'    => (string) $row['artifact_id'],
+			'source_path'    => (string) $row['source_path'],
+			'installed_hash' => (string) $row['installed_hash'],
+			'current_hash'   => isset( $row['current_hash'] ) ? (string) $row['current_hash'] : null,
+			'installed_at'   => (string) $row['installed_at'],
+			'updated_at'     => (string) $row['updated_at'],
 		);
+
+		// Pre-snapshot rows have NULL/missing installed_payload — propagate as
+		// "no base info" so callers know to fall back to conservative behavior.
+		if ( ! empty( $row['installed_payload'] ) ) {
+			$decoded                   = json_decode( (string) $row['installed_payload'], true );
+			$data['installed_payload'] = ( JSON_ERROR_NONE === json_last_error() ) ? $decoded : (string) $row['installed_payload'];
+		}
+
+		return AgentBundleInstalledArtifact::from_array( $data );
 	}
 
 	private function existing_record_id( array $row ): ?int {

--- a/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleInstalledArtifact.php
@@ -21,21 +21,34 @@ final class AgentBundleInstalledArtifact {
 	private string $source_path;
 	private ?string $installed_hash;
 	private ?string $current_hash;
+	private mixed $installed_payload;
 	private string $status;
 	private string $installed_at;
 	private string $updated_at;
 
-	public function __construct( string $bundle_slug, string $bundle_version, string $artifact_type, string $artifact_id, string $source_path, ?string $installed_hash, ?string $current_hash, string $installed_at, string $updated_at ) {
-		$this->bundle_slug    = PortableSlug::normalize( $bundle_slug, 'bundle' );
-		$this->bundle_version = self::non_empty_string( $bundle_version, 'bundle_version' );
-		$this->artifact_type  = self::validate_artifact_type( $artifact_type );
-		$this->artifact_id    = self::non_empty_string( $artifact_id, 'artifact_id' );
-		$this->source_path    = self::normalize_source_path( $source_path );
-		$this->installed_hash = self::optional_string( $installed_hash );
-		$this->current_hash   = self::optional_string( $current_hash );
-		$this->status         = AgentBundleArtifactStatus::classify( $this->installed_hash, $this->current_hash );
-		$this->installed_at   = self::non_empty_string( $installed_at, 'installed_at' );
-		$this->updated_at     = self::non_empty_string( $updated_at, 'updated_at' );
+	public function __construct(
+		string $bundle_slug,
+		string $bundle_version,
+		string $artifact_type,
+		string $artifact_id,
+		string $source_path,
+		?string $installed_hash,
+		?string $current_hash,
+		string $installed_at,
+		string $updated_at,
+		mixed $installed_payload = null
+	) {
+		$this->bundle_slug       = PortableSlug::normalize( $bundle_slug, 'bundle' );
+		$this->bundle_version    = self::non_empty_string( $bundle_version, 'bundle_version' );
+		$this->artifact_type     = self::validate_artifact_type( $artifact_type );
+		$this->artifact_id       = self::non_empty_string( $artifact_id, 'artifact_id' );
+		$this->source_path       = self::normalize_source_path( $source_path );
+		$this->installed_hash    = self::optional_string( $installed_hash );
+		$this->current_hash      = self::optional_string( $current_hash );
+		$this->installed_payload = $installed_payload;
+		$this->status            = AgentBundleArtifactStatus::classify( $this->installed_hash, $this->current_hash );
+		$this->installed_at      = self::non_empty_string( $installed_at, 'installed_at' );
+		$this->updated_at        = self::non_empty_string( $updated_at, 'updated_at' );
 	}
 
 	/**
@@ -60,7 +73,8 @@ final class AgentBundleInstalledArtifact {
 			isset( $data['installed_hash'] ) ? (string) $data['installed_hash'] : null,
 			isset( $data['current_hash'] ) ? (string) $data['current_hash'] : null,
 			(string) $data['installed_at'],
-			(string) $data['updated_at']
+			(string) $data['updated_at'],
+			array_key_exists( 'installed_payload', $data ) ? $data['installed_payload'] : null
 		);
 	}
 
@@ -77,7 +91,18 @@ final class AgentBundleInstalledArtifact {
 	 */
 	public static function from_installed_payload( AgentBundleManifest $manifest, string $artifact_type, string $artifact_id, string $source_path, mixed $artifact_payload, string $timestamp ): self {
 		$hash = AgentBundleArtifactHasher::hash( $artifact_payload );
-		return new self( $manifest->bundle_slug(), $manifest->bundle_version(), $artifact_type, $artifact_id, $source_path, $hash, $hash, $timestamp, $timestamp );
+		return new self(
+			$manifest->bundle_slug(),
+			$manifest->bundle_version(),
+			$artifact_type,
+			$artifact_id,
+			$source_path,
+			$hash,
+			$hash,
+			$timestamp,
+			$timestamp,
+			$artifact_payload
+		);
 	}
 
 	/**
@@ -99,12 +124,25 @@ final class AgentBundleInstalledArtifact {
 			$this->installed_hash,
 			$current_hash,
 			$this->installed_at,
-			$updated_at
+			$updated_at,
+			$this->installed_payload
 		);
 	}
 
+	/**
+	 * Return the persisted install-time payload snapshot, when available.
+	 *
+	 * Returns null when this row predates the snapshot field or was reconstructed
+	 * from a hash-only source (e.g. orphaned runtime artifacts). Callers that
+	 * need 3-way merge fidelity (e.g. AgentBundleArtifactRebase) should treat
+	 * null as "no base info" and fall back to a more conservative policy.
+	 */
+	public function installed_payload(): mixed {
+		return $this->installed_payload;
+	}
+
 	public function to_array(): array {
-		return array(
+		$row = array(
 			'bundle_slug'    => $this->bundle_slug,
 			'bundle_version' => $this->bundle_version,
 			'artifact_type'  => $this->artifact_type,
@@ -116,6 +154,10 @@ final class AgentBundleInstalledArtifact {
 			'installed_at'   => $this->installed_at,
 			'updated_at'     => $this->updated_at,
 		);
+		if ( null !== $this->installed_payload ) {
+			$row['installed_payload'] = $this->installed_payload;
+		}
+		return $row;
 	}
 
 	private static function validate_artifact_type( string $type ): string {

--- a/tests/agent-bundle-installed-payload-snapshot-smoke.php
+++ b/tests/agent-bundle-installed-payload-snapshot-smoke.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Pure-PHP smoke test for installed-artifact payload snapshot persistence.
+ *
+ * Exercises the round-trip:
+ *   payload at install → AgentBundleInstalledArtifact → to_array() → from_array()
+ *   → installed_payload() returns the original payload.
+ *
+ * And the rebase-fidelity claim:
+ *   With installed_payload populated, the burn-in-safe policy can produce a
+ *   clean (no-ambiguous) merge for the canonical wpcom case, where without it
+ *   the policy has to flag fields ambiguous because it can't tell "local moved
+ *   this field" from "local just inherited base".
+ *
+ * Run with: php tests/agent-bundle-installed-payload-snapshot-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value, ...$args ) {
+		return $value;
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSchema.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleValidationException.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/PortableSlug.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactHasher.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactStatus.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleManifest.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleInstalledArtifact.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/AgentBundleArtifactRebase.php';
+
+use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
+use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+
+$failures = 0;
+$total    = 0;
+
+function snap_assert( string $label, bool $condition ): void {
+	global $failures, $total;
+	++$total;
+	if ( $condition ) {
+		echo "  PASS: {$label}\n";
+		return;
+	}
+	echo "  FAIL: {$label}\n";
+	++$failures;
+}
+
+function snap_assert_equals( string $label, $expected, $actual ): void {
+	$ok = $expected === $actual;
+	snap_assert( $label, $ok );
+	if ( ! $ok ) {
+		echo "    expected: " . var_export( $expected, true ) . "\n";
+		echo "    actual:   " . var_export( $actual, true ) . "\n";
+	}
+}
+
+echo "=== Installed Payload Snapshot Smoke (#1832 follow-up) ===\n";
+
+$manifest = AgentBundleManifest::from_array(
+	array(
+		'schema_version' => 1,
+		'bundle_slug'    => 'wordpress-com-wiki',
+		'bundle_version' => '1.0.0',
+		'exported_at'    => '2026-04-28T00:00:00Z',
+		'exported_by'    => 'data-machine/test',
+		'agent'          => array(
+			'slug'         => 'wordpress-com-wiki',
+			'label'        => 'wpcom Wiki',
+			'description'  => 'Builds wpcom domain wiki.',
+			'agent_config' => array(),
+		),
+		'included'       => array(
+			'memory'       => array(),
+			'pipelines'    => array(),
+			'flows'        => array(),
+			'handler_auth' => 'refs',
+		),
+	)
+);
+
+// ---------------------------------------------------------------------------
+// [1] Install-time payload is captured on AgentBundleInstalledArtifact.
+// ---------------------------------------------------------------------------
+echo "\n[1] Install-time payload is captured\n";
+$flow_payload = array(
+	'flow_config' => array(
+		'10_fetch_1' => array(
+			'handler'        => 'github',
+			'handler_config' => array(
+				'server'    => 'github',
+				'owner'     => 'old-owner',
+				'repo'      => 'old-repo',
+				'perPage'   => 25,
+				'max_items' => 25,
+			),
+		),
+	),
+	'scheduling_config' => array( 'enabled' => true, 'interval' => 'hourly', 'max_items' => array( 'fetch' => 25 ) ),
+);
+
+$installed = AgentBundleInstalledArtifact::from_installed_payload(
+	$manifest,
+	'flow',
+	'wordpress-com-history-github-wpcom-platform-queue',
+	'flows/wordpress-com-history.json',
+	$flow_payload,
+	'2026-04-28T00:00:00Z'
+);
+
+snap_assert_equals( 'installed_payload exposes the install-time payload', $flow_payload, $installed->installed_payload() );
+$serialized = $installed->to_array();
+snap_assert( 'to_array() includes installed_payload', isset( $serialized['installed_payload'] ) );
+snap_assert_equals( 'serialized payload round-trips identically', $flow_payload, $serialized['installed_payload'] );
+
+// ---------------------------------------------------------------------------
+// [2] from_array() → installed_payload() round-trips.
+// ---------------------------------------------------------------------------
+echo "\n[2] from_array() round-trips installed_payload\n";
+$rehydrated = AgentBundleInstalledArtifact::from_array( $serialized );
+snap_assert_equals( 'rehydrated installed_payload matches', $flow_payload, $rehydrated->installed_payload() );
+
+// ---------------------------------------------------------------------------
+// [3] Pre-snapshot rows (no installed_payload field) round-trip cleanly.
+// ---------------------------------------------------------------------------
+echo "\n[3] Pre-snapshot rows propagate as null\n";
+$legacy_row = $serialized;
+unset( $legacy_row['installed_payload'] );
+$legacy = AgentBundleInstalledArtifact::from_array( $legacy_row );
+snap_assert_equals( 'legacy row exposes null installed_payload', null, $legacy->installed_payload() );
+
+$legacy_serialized = $legacy->to_array();
+snap_assert( 'legacy to_array() omits installed_payload key', ! array_key_exists( 'installed_payload', $legacy_serialized ) );
+
+// ---------------------------------------------------------------------------
+// [4] with_current_payload() preserves installed_payload (it's the base, not
+// the live payload — so it must not change as live state mutates).
+// ---------------------------------------------------------------------------
+echo "\n[4] with_current_payload preserves base payload\n";
+$mutated = $installed->with_current_payload( array( 'name' => 'edited' ), '2026-04-28T05:00:00Z' );
+snap_assert_equals( 'mutating current_payload does not clobber installed_payload', $flow_payload, $mutated->installed_payload() );
+
+// ---------------------------------------------------------------------------
+// [5] burn-in-safe rebase produces a clean merge given a real base.
+// This is the whole point of persisting installed_payload.
+// ---------------------------------------------------------------------------
+echo "\n[5] burn-in-safe rebase is clean with installed_payload as base\n";
+$base   = $installed->installed_payload();
+$local  = array(
+	'flow_config' => array(
+		'10_fetch_1' => array(
+			'handler'        => 'github',
+			'handler_config' => array(
+				'server'    => 'github',
+				'owner'     => 'old-owner',
+				'repo'      => 'old-repo',
+				'perPage'   => 25,
+				'max_items' => 1, // local burn-in throttle
+			),
+		),
+	),
+	'scheduling_config' => array( 'enabled' => true, 'interval' => 'hourly', 'max_items' => array( 'fetch' => 1 ) ),
+);
+$remote = array(
+	'flow_config' => array(
+		'10_fetch_1' => array(
+			'handler'        => 'github-a8c',
+			'handler_config' => array(
+				'server'    => 'github-a8c',
+				'owner'     => 'Automattic',
+				'repo'      => 'wpcom',
+				'perPage'   => 1,
+				'max_items' => 25, // bundle default — base also was 25, so remote did NOT change this
+			),
+		),
+	),
+	'scheduling_config' => array( 'enabled' => false, 'interval' => 'manual', 'max_items' => array( 'fetch' => 25 ) ),
+);
+
+$rebase_with_base = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'flow',
+		'artifact_id'   => 'wordpress-com-history-github-wpcom-platform-queue',
+		'base'          => $base,
+		'local'         => $local,
+		'remote'        => $remote,
+	),
+	AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE
+);
+
+snap_assert( 'merge is unambiguous when base is available', empty( $rebase_with_base['ambiguous'] ) );
+snap_assert( 'no approval required with base', false === $rebase_with_base['requires_approval'] );
+
+$step = $rebase_with_base['merged']['flow_config']['10_fetch_1'] ?? array();
+snap_assert_equals( 'remote handler taken', 'github-a8c', $step['handler'] ?? null );
+snap_assert_equals( 'remote owner taken', 'Automattic', $step['handler_config']['owner'] ?? null );
+snap_assert_equals( 'local throttle preserved (max_items)', 1, $step['handler_config']['max_items'] ?? null );
+
+// Demonstrate the regression we are fixing: without base, the merge is noisier.
+// max_items moves from "burn-in throttle preserved" (clean) to a state where
+// the policy can still keep local but does so without confidence that local
+// represented intent vs. inherited default.
+$rebase_without_base = AgentBundleArtifactRebase::rebase(
+	array(
+		'artifact_type' => 'flow',
+		'artifact_id'   => 'wordpress-com-history-github-wpcom-platform-queue',
+		'base'          => null,
+		'local'         => $local,
+		'remote'        => $remote,
+	),
+	AgentBundleArtifactRebase::POLICY_BURN_IN_SAFE
+);
+
+// Without base, the policy sees local==remote on max_items? No: local=1, remote=25,
+// both diverge from "base=null" → policy sees both changed → ambiguous.
+$step_no_base   = $rebase_without_base['merged']['flow_config']['10_fetch_1'] ?? array();
+$has_throttle_ambiguity = in_array(
+	'flow_config.10_fetch_1.handler_config.max_items',
+	$rebase_without_base['ambiguous'],
+	true
+);
+snap_assert(
+	'baseline regression: without installed_payload, max_items is ambiguous',
+	$has_throttle_ambiguity
+);
+snap_assert(
+	'baseline regression: without installed_payload, requires approval',
+	true === $rebase_without_base['requires_approval']
+);
+snap_assert(
+	'with installed_payload: clean merge (this PR\'s improvement)',
+	false === $rebase_with_base['requires_approval']
+);
+
+echo "\nTotal assertions: {$total}\n";
+if ( 0 !== $failures ) {
+	echo "Failures: {$failures}\n";
+	exit( 1 );
+}
+echo "All assertions passed.\n";
+
+}


### PR DESCRIPTION
## Summary

Stacked on #1833. Closes the "base payload not always reconstructable" limitation called out in that PR.

## Problem

The policy-driven artifact rebase primitive added in #1833 needs the install-time payload as the `base` side of its 3-way merge so it can tell **"local moved this field away from base"** from **"local just inherited base's value"**. Before this PR, installed-artifact tracking persisted only hashes, so:

- `burn-in-safe` policy degraded to flagging more fields ambiguous than necessary
- The canonical wpcom case (Flow 41 wanting upstream provider switch while keeping `max_items: 1` throttles) could not produce a clean unambiguous merge — `max_items` got flagged ambiguous because the policy couldn't tell if local lowered it from base=25 or just inherited base=1
- Operators saw approval prompts on artifacts that should auto-merge cleanly

## What ships

`installed_payload` is now persisted everywhere the install-time hash is already written:

### `AgentBundleInstalledArtifact`
- New optional `installed_payload` field on the value object
- Preserved across `with_current_payload()` (live state mutates, base doesn't)
- Exposed via `installed_payload()` for callers needing 3-way merge fidelity
- `to_array()` omits the key when null so pre-snapshot rows round-trip cleanly

### `InstalledBundleArtifacts` (DB repository)
- Adds `installed_payload LONGTEXT NULL` column
- `dbDelta` migrates existing tables idempotently on the next `plugins_loaded` pass through `datamachine_migrate_bundle_artifacts_table()` — no separate migration step
- `upsert()` encodes payloads via `wp_json_encode`
- `artifact_from_row()` decodes and falls back to raw string if `json_decode` fails (defensive, shouldn't happen in practice)

### `AgentBundler::bundle_artifact_record()`
The canonical writer for the `agent_config`-resident artifact registry — the path `AgentBundleArtifactRebase` actually reads in CLI — now stamps `installed_payload` alongside `installed_hash`. All three call sites in the importer (lines 732/862/929) funnel through this helper, so flow, pipeline, and extension artifacts all get snapshots.

### `AgentBundleCommand::rebase_locally_modified()`
Now prefers the new `installed_payload` key, falling back to the legacy `payload` alias for back-compat with existing test fixtures and any custom writers.

## Backwards compatibility

Pre-snapshot rows (existing installs that upgrade in place) keep working:

- DB migration adds the column with `NULL` default
- Reader detects null/missing `installed_payload` and propagates as null
- Rebase reader passes `base = null` to the rebase primitive
- Policy degrades to today's behavior (more ambiguous fields, requires approval)
- Once an artifact gets re-installed or upgraded, the snapshot is captured and future rebases get full fidelity

## Tests

```
tests/agent-bundle-installed-payload-snapshot-smoke.php   15/15 PASS  (new)
tests/agent-bundle-installed-artifact-smoke.php           33/33 PASS  (existing — no regression)
tests/agent-bundle-artifact-rebase-smoke.php              35/35 PASS  (existing)
tests/agent-bundle-pending-action-rebase-smoke.php        13/13 PASS  (existing)
tests/agent-bundle-runtime-drift-smoke.php                13/13 PASS  (existing)
```

The new smoke test directly demonstrates the fidelity improvement:

```
[5] burn-in-safe rebase is clean with installed_payload as base
  PASS: merge is unambiguous when base is available
  PASS: no approval required with base
  PASS: remote handler taken
  PASS: remote owner taken
  PASS: local throttle preserved (max_items)
  PASS: baseline regression: without installed_payload, max_items is ambiguous
  PASS: baseline regression: without installed_payload, requires approval
  PASS: with installed_payload: clean merge (this PR's improvement)
```

## Lint

- `php -l` on all changed PHP files: clean
- `vendor/bin/phpcs --standard=WordPress` on changed files: clean

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the value-object extension, DB column + migration, importer record writer update, rebase reader update, and the snapshot smoke test. Chris reviewed the design and verified all 109 smoke assertions pass end-to-end.