### PR TITLE
chore(lint): apply homeboy lint --fix to clear post-merge debt from #1833

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -272,8 +272,8 @@ class AgentBundleCommand extends BaseCommand {
 		);
 
 		if ( $plan->has_pending_approval() ) {
-			$agent             = $this->resolve_bundle_agent( $bundle, $slug );
-			$rebased_artifacts = $rebase_local
+			$agent                      = $this->resolve_bundle_agent( $bundle, $slug );
+			$rebased_artifacts          = $rebase_local
 				? $this->rebase_locally_modified( $plan, $bundle, $slug, $policy_name )
 				: array();
 			$pending                    = AgentBundleUpgradePendingAction::stage(
@@ -420,7 +420,7 @@ class AgentBundleCommand extends BaseCommand {
 			if ( ! is_array( $row ) ) {
 				continue;
 			}
-			$key = AgentBundleArtifactExtensions::artifact_key( (string) ( $row['artifact_type'] ?? '' ), (string) ( $row['artifact_id'] ?? '' ) );
+			$key                     = AgentBundleArtifactExtensions::artifact_key( (string) ( $row['artifact_type'] ?? '' ), (string) ( $row['artifact_id'] ?? '' ) );
 			$installed_index[ $key ] = $row;
 		}
 
@@ -471,7 +471,7 @@ class AgentBundleCommand extends BaseCommand {
 					'artifact_id'   => (string) $target['artifact_id'],
 					'source_path'   => (string) ( $target['source_path'] ?? '' ),
 					'base'          => $base_payload,
-					'local'         => $local['payload']  ?? null,
+					'local'         => $local['payload'] ?? null,
 					'remote'        => $target['payload'] ?? null,
 				),
 				$policy_name

--- a/inc/Core/Database/BundleArtifacts/InstalledBundleArtifacts.php
+++ b/inc/Core/Database/BundleArtifacts/InstalledBundleArtifacts.php
@@ -258,10 +258,10 @@ final class InstalledBundleArtifacts extends BaseRepository {
 		$result = $this->wpdb->delete(
 			$this->table_name,
 			array(
-				'agent_id'       => max( 0, $agent_id ),
-				'bundle_slug'    => $bundle_slug,
-				'artifact_type'  => $artifact_type,
-				'artifact_id'    => $artifact_id,
+				'agent_id'      => max( 0, $agent_id ),
+				'bundle_slug'   => $bundle_slug,
+				'artifact_type' => $artifact_type,
+				'artifact_id'   => $artifact_id,
 			),
 			array( '%d', '%s', '%s', '%s' )
 		);
@@ -311,11 +311,11 @@ final class InstalledBundleArtifacts extends BaseRepository {
 
 	private function safe_log_context( array $row ): array {
 		return array(
-			'agent_id'       => (int) $row['agent_id'],
-			'bundle_slug'    => (string) $row['bundle_slug'],
-			'artifact_type'  => (string) $row['artifact_type'],
-			'artifact_id'    => (string) $row['artifact_id'],
-			'local_status'   => AgentBundleArtifactStatus::classify( (string) $row['installed_hash'], isset( $row['current_hash'] ) ? (string) $row['current_hash'] : null ),
+			'agent_id'      => (int) $row['agent_id'],
+			'bundle_slug'   => (string) $row['bundle_slug'],
+			'artifact_type' => (string) $row['artifact_type'],
+			'artifact_id'   => (string) $row['artifact_id'],
+			'local_status'  => AgentBundleArtifactStatus::classify( (string) $row['installed_hash'], isset( $row['current_hash'] ) ? (string) $row['current_hash'] : null ),
 		);
 	}
 }

--- a/inc/Engine/AI/RequestMetadata.php
+++ b/inc/Engine/AI/RequestMetadata.php
@@ -146,8 +146,8 @@ class RequestMetadata {
 		);
 	}
 
-	private static function threshold( string $filter, int $default ): int {
-		$value = (int) apply_filters( $filter, $default );
+	private static function threshold( string $filter, int $default_value ): int {
+		$value = (int) apply_filters( $filter, $default_value );
 		return max( 0, $value );
 	}
 

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -640,9 +640,9 @@ class ToolManager {
 	 * @param callable $callable Callable to inspect.
 	 * @return bool True for ($tools, $handler_slug, ...) callbacks.
 	 */
-	private function uses_filter_convention( $callable ): bool {
+	private function uses_filter_convention( $callable_fn ): bool {
 		try {
-			$ref = $this->reflect_callable( $callable );
+			$ref = $this->reflect_callable( $callable_fn );
 			if ( null === $ref ) {
 				return false;
 			}
@@ -670,13 +670,13 @@ class ToolManager {
 	 * @return \ReflectionFunctionAbstract|null Reflection object, or null when unsupported.
 	 * @throws \ReflectionException When reflection fails.
 	 */
-	private function reflect_callable( $callable ): ?\ReflectionFunctionAbstract {
-		if ( is_array( $callable ) ) {
-			return new \ReflectionMethod( $callable[0], $callable[1] );
+	private function reflect_callable( $callable_fn ): ?\ReflectionFunctionAbstract {
+		if ( is_array( $callable_fn ) ) {
+			return new \ReflectionMethod( $callable_fn[0], $callable_fn[1] );
 		}
 
-		if ( $callable instanceof \Closure || is_string( $callable ) ) {
-			return new \ReflectionFunction( $callable );
+		if ( $callable_fn instanceof \Closure || is_string( $callable_fn ) ) {
+			return new \ReflectionFunction( $callable_fn );
 		}
 
 		return null;

--- a/inc/Engine/AI/WpAiClientCache.php
+++ b/inc/Engine/AI/WpAiClientCache.php
@@ -69,12 +69,12 @@ abstract class WpAiClientTransientCacheBase {
 	 * @param mixed  $default Default value.
 	 * @return mixed
 	 */
-	public function get( $key, $default = null ) {
+	public function get( $key, $default_value = null ) {
 		$this->validateKey( $key );
 
 		$cached = get_transient( $this->transientKey( $key ) );
 		if ( ! is_array( $cached ) || ! array_key_exists( 'value', $cached ) ) {
-			return $default;
+			return $default_value;
 		}
 
 		return $cached['value'];
@@ -129,10 +129,10 @@ abstract class WpAiClientTransientCacheBase {
 	 * @param mixed    $default Default value.
 	 * @return iterable
 	 */
-	public function getMultiple( $keys, $default = null ) {
+	public function getMultiple( $keys, $default_value = null ) {
 		$values = array();
 		foreach ( $this->iterableKeys( $keys ) as $key ) {
-			$values[ $key ] = $this->get( $key, $default );
+			$values[ $key ] = $this->get( $key, $default_value );
 		}
 
 		return $values;

--- a/inc/Engine/Bundle/AgentBundleArtifactRebase.php
+++ b/inc/Engine/Bundle/AgentBundleArtifactRebase.php
@@ -63,8 +63,8 @@ final class AgentBundleArtifactRebase {
 		$artifact_type = (string) ( $artifact['artifact_type'] ?? '' );
 		$artifact_id   = (string) ( $artifact['artifact_id'] ?? '' );
 		$artifact_key  = AgentBundleArtifactExtensions::artifact_key( $artifact_type, $artifact_id );
-		$base          = $artifact['base']   ?? null;
-		$local         = $artifact['local']  ?? null;
+		$base          = $artifact['base'] ?? null;
+		$local         = $artifact['local'] ?? null;
 		$remote        = $artifact['remote'] ?? null;
 
 		$policies = self::policies();
@@ -101,18 +101,18 @@ final class AgentBundleArtifactRebase {
 		$remote_hash = null === $remote ? null : AgentBundleArtifactHasher::hash( $remote );
 
 		return array(
-			'artifact_key'   => $artifact_key,
-			'artifact_type'  => $artifact_type,
-			'artifact_id'    => $artifact_id,
-			'source_path'    => (string) ( $artifact['source_path'] ?? '' ),
-			'policy'         => $policy_name,
-			'merged'         => $merged,
-			'merged_hash'    => $merged_hash,
-			'base_hash'      => $base_hash,
-			'local_hash'     => $local_hash,
-			'remote_hash'    => $remote_hash,
-			'decisions'      => $decisions,
-			'ambiguous'      => $ambiguous,
+			'artifact_key'      => $artifact_key,
+			'artifact_type'     => $artifact_type,
+			'artifact_id'       => $artifact_id,
+			'source_path'       => (string) ( $artifact['source_path'] ?? '' ),
+			'policy'            => $policy_name,
+			'merged'            => $merged,
+			'merged_hash'       => $merged_hash,
+			'base_hash'         => $base_hash,
+			'local_hash'        => $local_hash,
+			'remote_hash'       => $remote_hash,
+			'decisions'         => $decisions,
+			'ambiguous'         => $ambiguous,
 			'requires_approval' => ! empty( $ambiguous ),
 		);
 	}
@@ -198,8 +198,8 @@ final class AgentBundleArtifactRebase {
 			return self::policy_conservative( $input );
 		}
 
-		$base   = is_array( $input['base'] ?? null )   ? $input['base']   : array();
-		$local  = is_array( $input['local'] ?? null )  ? $input['local']  : array();
+		$base   = is_array( $input['base'] ?? null ) ? $input['base'] : array();
+		$local  = is_array( $input['local'] ?? null ) ? $input['local'] : array();
 		$remote = is_array( $input['remote'] ?? null ) ? $input['remote'] : array();
 
 		$decisions = array();
@@ -210,16 +210,16 @@ final class AgentBundleArtifactRebase {
 		// fight runtime cron throttles; if they need to force a schedule change,
 		// it must be explicit (not in scope for v1).
 		if ( array_key_exists( 'scheduling_config', $local ) ) {
-			$merged['scheduling_config']      = $local['scheduling_config'];
-			$decisions['scheduling_config']   = array(
+			$merged['scheduling_config']    = $local['scheduling_config'];
+			$decisions['scheduling_config'] = array(
 				'source' => 'local',
 				'reason' => 'burn_in_preserve_scheduling',
 			);
 		}
 
 		// Walk flow_config step by step, merging per-step keys.
-		$base_steps   = is_array( $base['flow_config']   ?? null ) ? $base['flow_config']   : array();
-		$local_steps  = is_array( $local['flow_config']  ?? null ) ? $local['flow_config']  : array();
+		$base_steps   = is_array( $base['flow_config'] ?? null ) ? $base['flow_config'] : array();
+		$local_steps  = is_array( $local['flow_config'] ?? null ) ? $local['flow_config'] : array();
 		$remote_steps = is_array( $remote['flow_config'] ?? null ) ? $remote['flow_config'] : array();
 		$merged_steps = is_array( $merged['flow_config'] ?? null ) ? $merged['flow_config'] : array();
 
@@ -231,19 +231,19 @@ final class AgentBundleArtifactRebase {
 		);
 
 		foreach ( $step_ids as $step_id ) {
-			$base_step   = is_array( $base_steps[ $step_id ]   ?? null ) ? $base_steps[ $step_id ]   : array();
-			$local_step  = is_array( $local_steps[ $step_id ]  ?? null ) ? $local_steps[ $step_id ]  : array();
+			$base_step   = is_array( $base_steps[ $step_id ] ?? null ) ? $base_steps[ $step_id ] : array();
+			$local_step  = is_array( $local_steps[ $step_id ] ?? null ) ? $local_steps[ $step_id ] : array();
 			$remote_step = is_array( $remote_steps[ $step_id ] ?? null ) ? $remote_steps[ $step_id ] : array();
 
 			if ( empty( $remote_step ) && ! empty( $local_step ) ) {
 				// Remote dropped this step; without explicit policy, keep local
 				// and flag as ambiguous so operator confirms.
-				$merged_steps[ $step_id ]                            = $local_step;
-				$decisions[ "flow_config.{$step_id}" ]               = array(
+				$merged_steps[ $step_id ]              = $local_step;
+				$decisions[ "flow_config.{$step_id}" ] = array(
 					'source' => 'ambiguous',
 					'reason' => 'remote_dropped_step',
 				);
-				$ambiguous[] = "flow_config.{$step_id}";
+				$ambiguous[]                           = "flow_config.{$step_id}";
 				continue;
 			}
 
@@ -252,8 +252,8 @@ final class AgentBundleArtifactRebase {
 			// Preserve per-step runtime queue fields from local.
 			foreach ( array( 'prompt_queue', 'config_patch_queue', 'queue_mode', '_queue_consume_revision' ) as $rt_field ) {
 				if ( array_key_exists( $rt_field, $local_step ) ) {
-					$merged_step[ $rt_field ]                                       = $local_step[ $rt_field ];
-					$decisions[ "flow_config.{$step_id}.{$rt_field}" ]              = array(
+					$merged_step[ $rt_field ]                          = $local_step[ $rt_field ];
+					$decisions[ "flow_config.{$step_id}.{$rt_field}" ] = array(
 						'source' => 'local',
 						'reason' => 'burn_in_preserve_runtime_queue',
 					);
@@ -263,12 +263,12 @@ final class AgentBundleArtifactRebase {
 			}
 
 			// Merge handler_config keys (single-handler shape).
-			$base_hc   = is_array( $base_step['handler_config']   ?? null ) ? $base_step['handler_config']   : array();
-			$local_hc  = is_array( $local_step['handler_config']  ?? null ) ? $local_step['handler_config']  : array();
+			$base_hc   = is_array( $base_step['handler_config'] ?? null ) ? $base_step['handler_config'] : array();
+			$local_hc  = is_array( $local_step['handler_config'] ?? null ) ? $local_step['handler_config'] : array();
 			$remote_hc = is_array( $remote_step['handler_config'] ?? null ) ? $remote_step['handler_config'] : array();
 
 			if ( ! empty( $local_hc ) || ! empty( $remote_hc ) ) {
-				$merged_hc                               = self::merge_handler_config(
+				$merged_hc                     = self::merge_handler_config(
 					$base_hc,
 					$local_hc,
 					$remote_hc,
@@ -276,21 +276,21 @@ final class AgentBundleArtifactRebase {
 					$decisions,
 					$ambiguous
 				);
-				$merged_step['handler_config']           = $merged_hc;
+				$merged_step['handler_config'] = $merged_hc;
 			}
 
 			// Merge handler_configs (multi-handler shape: keyed by handler slug).
-			$base_hcs   = is_array( $base_step['handler_configs']   ?? null ) ? $base_step['handler_configs']   : array();
-			$local_hcs  = is_array( $local_step['handler_configs']  ?? null ) ? $local_step['handler_configs']  : array();
+			$base_hcs   = is_array( $base_step['handler_configs'] ?? null ) ? $base_step['handler_configs'] : array();
+			$local_hcs  = is_array( $local_step['handler_configs'] ?? null ) ? $local_step['handler_configs'] : array();
 			$remote_hcs = is_array( $remote_step['handler_configs'] ?? null ) ? $remote_step['handler_configs'] : array();
 
 			if ( ! empty( $local_hcs ) || ! empty( $remote_hcs ) ) {
 				$merged_hcs = array();
 				$slugs      = array_unique( array_merge( array_keys( $local_hcs ), array_keys( $remote_hcs ) ) );
 				foreach ( $slugs as $slug ) {
-					$lc                  = is_array( $local_hcs[ $slug ]  ?? null ) ? $local_hcs[ $slug ]  : array();
+					$lc                  = is_array( $local_hcs[ $slug ] ?? null ) ? $local_hcs[ $slug ] : array();
 					$rc                  = is_array( $remote_hcs[ $slug ] ?? null ) ? $remote_hcs[ $slug ] : array();
-					$bc                  = is_array( $base_hcs[ $slug ]   ?? null ) ? $base_hcs[ $slug ]   : array();
+					$bc                  = is_array( $base_hcs[ $slug ] ?? null ) ? $base_hcs[ $slug ] : array();
 					$merged_hcs[ $slug ] = self::merge_handler_config(
 						$bc,
 						$lc,
@@ -314,7 +314,7 @@ final class AgentBundleArtifactRebase {
 		// it ambiguous so an operator confirms.
 		$top_keys = array_unique(
 			array_merge(
-				array_keys( is_array( $local )  ? $local  : array() ),
+				array_keys( is_array( $local ) ? $local : array() ),
 				array_keys( is_array( $remote ) ? $remote : array() )
 			)
 		);
@@ -322,8 +322,8 @@ final class AgentBundleArtifactRebase {
 			if ( in_array( $key, array( 'flow_config', 'scheduling_config' ), true ) ) {
 				continue;
 			}
-			$base_val   = $base[ $key ]   ?? null;
-			$local_val  = $local[ $key ]  ?? null;
+			$base_val   = $base[ $key ] ?? null;
+			$local_val  = $local[ $key ] ?? null;
 			$remote_val = $remote[ $key ] ?? null;
 
 			if ( $local_val === $remote_val ) {
@@ -334,12 +334,12 @@ final class AgentBundleArtifactRebase {
 			$remote_changed = $remote_val !== $base_val;
 
 			if ( $local_changed && $remote_changed ) {
-				$merged[ $key ]      = $local_val;
-				$decisions[ $key ]   = array(
+				$merged[ $key ]    = $local_val;
+				$decisions[ $key ] = array(
 					'source' => 'ambiguous',
 					'reason' => 'both_diverged_from_base',
 				);
-				$ambiguous[]         = $key;
+				$ambiguous[]       = $key;
 				continue;
 			}
 
@@ -395,12 +395,12 @@ final class AgentBundleArtifactRebase {
 		$merged = array();
 
 		foreach ( $keys as $key ) {
-			$base_val   = $base[ $key ]   ?? null;
-			$local_val  = $local[ $key ]  ?? null;
+			$base_val   = $base[ $key ] ?? null;
+			$local_val  = $local[ $key ] ?? null;
 			$remote_val = $remote[ $key ] ?? null;
 			$path       = $path_prefix . '.' . (string) $key;
 
-			$local_changed  = array_key_exists( $key, $local )  && $local_val  !== $base_val;
+			$local_changed  = array_key_exists( $key, $local ) && $local_val !== $base_val;
 			$remote_changed = array_key_exists( $key, $remote ) && $remote_val !== $base_val;
 
 			// Identical local and remote → take it, no decision noise.
@@ -414,7 +414,7 @@ final class AgentBundleArtifactRebase {
 			// Local-preserved throttle key: keep local if it diverged from base.
 			if ( in_array( (string) $key, $local_preserve_keys, true ) ) {
 				if ( $local_changed && ! $remote_changed ) {
-					$merged[ $key ]    = $local_val;
+					$merged[ $key ]     = $local_val;
 					$decisions[ $path ] = array(
 						'source' => 'local',
 						'reason' => 'burn_in_preserve_throttle',
@@ -423,18 +423,18 @@ final class AgentBundleArtifactRebase {
 				}
 				if ( $local_changed && $remote_changed ) {
 					// Both moved this throttle. Default to local (safer) but flag ambiguous.
-					$merged[ $key ]    = $local_val;
+					$merged[ $key ]     = $local_val;
 					$decisions[ $path ] = array(
 						'source' => 'ambiguous',
 						'reason' => 'throttle_diverged_in_local_and_remote',
 					);
-					$ambiguous[]       = $path;
+					$ambiguous[]        = $path;
 					continue;
 				}
 				// Local unchanged from base; safe to take remote when remote moved
 				// (e.g. bundle deliberately raised throttle and local never overrode).
 				if ( array_key_exists( $key, $remote ) ) {
-					$merged[ $key ]    = $remote_val;
+					$merged[ $key ]     = $remote_val;
 					$decisions[ $path ] = array(
 						'source' => 'remote',
 						'reason' => 'local_unchanged_from_base',
@@ -447,7 +447,7 @@ final class AgentBundleArtifactRebase {
 
 			// Source-shape keys default to remote when remote diverged.
 			if ( $remote_changed && ! $local_changed ) {
-				$merged[ $key ]    = $remote_val;
+				$merged[ $key ]     = $remote_val;
 				$decisions[ $path ] = array(
 					'source' => 'remote',
 					'reason' => 'remote_source_shape_change',
@@ -456,7 +456,7 @@ final class AgentBundleArtifactRebase {
 			}
 
 			if ( $local_changed && ! $remote_changed ) {
-				$merged[ $key ]    = $local_val;
+				$merged[ $key ]     = $local_val;
 				$decisions[ $path ] = array(
 					'source' => 'local',
 					'reason' => 'remote_unchanged_from_base',
@@ -467,12 +467,12 @@ final class AgentBundleArtifactRebase {
 			if ( $local_changed && $remote_changed ) {
 				// Both moved a non-throttle key. Default merged value to local
 				// (don't silently clobber) and flag for approval.
-				$merged[ $key ]    = $local_val;
+				$merged[ $key ]     = $local_val;
 				$decisions[ $path ] = array(
 					'source' => 'ambiguous',
 					'reason' => 'both_diverged_from_base',
 				);
-				$ambiguous[]       = $path;
+				$ambiguous[]        = $path;
 				continue;
 			}
 
@@ -510,7 +510,7 @@ final class AgentBundleArtifactRebase {
 		$keys  = array_unique( array_merge( array_keys( $local ), array_keys( $remote ) ) );
 		foreach ( $keys as $key ) {
 			$child_prefix = '' === $prefix ? (string) $key : $prefix . '.' . (string) $key;
-			$lv           = $local[ $key ]  ?? null;
+			$lv           = $local[ $key ] ?? null;
 			$rv           = $remote[ $key ] ?? null;
 			if ( $lv === $rv ) {
 				continue;

--- a/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
+++ b/inc/Engine/Bundle/AgentBundleUpgradePendingAction.php
@@ -117,15 +117,15 @@ final class AgentBundleUpgradePendingAction {
 			$apply_artifact = $artifact;
 			$rebase_meta    = null;
 			if ( isset( $rebased_by_key[ $key ] ) ) {
-				$rebase_entry           = $rebased_by_key[ $key ];
+				$rebase_entry              = $rebased_by_key[ $key ];
 				$apply_artifact['payload'] = $rebase_entry['merged'] ?? $artifact['payload'] ?? null;
 				if ( isset( $rebase_entry['merged_hash'] ) ) {
 					$apply_artifact['hash'] = (string) $rebase_entry['merged_hash'];
 				}
 				$rebase_meta = array(
-					'policy'     => (string) ( $rebase_entry['policy'] ?? '' ),
+					'policy'      => (string) ( $rebase_entry['policy'] ?? '' ),
 					'merged_hash' => isset( $rebase_entry['merged_hash'] ) ? (string) $rebase_entry['merged_hash'] : null,
-					'decisions'  => is_array( $rebase_entry['decisions'] ?? null ) ? $rebase_entry['decisions'] : array(),
+					'decisions'   => is_array( $rebase_entry['decisions'] ?? null ) ? $rebase_entry['decisions'] : array(),
 				);
 			}
 

--- a/tests/agent-config-model-shape-migration-smoke.php
+++ b/tests/agent-config-model-shape-migration-smoke.php
@@ -35,9 +35,9 @@ if ( ! defined( 'ARRAY_A' ) ) {
 
 $options = array();
 
-function get_option( string $key, $default = false ) {
+function get_option( string $key, $default_value = false ) {
 	global $options;
-	return array_key_exists( $key, $options ) ? $options[ $key ] : $default;
+	return array_key_exists( $key, $options ) ? $options[ $key ] : $default_value;
 }
 
 function update_option( string $key, $value, bool $autoload = true ): bool {

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -45,9 +45,9 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 }
 
 if ( ! function_exists( 'get_option' ) ) {
-	function get_option( string $name, $default = false ) {
+	function get_option( string $name, $default_value = false ) {
 		unset( $name );
-		return $default;
+		return $default_value;
 	}
 }
 

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -54,8 +54,8 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 }
 
 if ( ! function_exists( 'get_option' ) ) {
-	function get_option( string $_option, $default = false ) {
-		return $default;
+	function get_option( string $_option, $default_value = false ) {
+		return $default_value;
 	}
 }
 

--- a/tests/ai-loop-event-sink-smoke.php
+++ b/tests/ai-loop-event-sink-smoke.php
@@ -72,8 +72,8 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 }
 
 if ( ! function_exists( 'get_option' ) ) {
-	function get_option( string $_option, $default = false ) {
-		return $default;
+	function get_option( string $_option, $default_value = false ) {
+		return $default_value;
 	}
 }
 

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -39,10 +39,10 @@ class DataMachineAIBackpressureSmokeAction {
 	}
 }
 
-function get_option( string $name, mixed $default = false ): mixed {
+function get_option( string $name, mixed $default_value = false ): mixed {
 	return array_key_exists( $name, $GLOBALS['datamachine_ai_backpressure_options'] )
 		? $GLOBALS['datamachine_ai_backpressure_options'][ $name ]
-		: $default;
+		: $default_value;
 }
 
 function add_option( string $name, mixed $value = '', mixed $deprecated = '', mixed $autoload = null ): bool {

--- a/tests/auth-ref-handler-config-smoke.php
+++ b/tests/auth-ref-handler-config-smoke.php
@@ -85,8 +85,8 @@ if ( ! function_exists( 'apply_filters' ) ) {
 }
 
 if ( ! function_exists( 'get_site_option' ) ) {
-	function get_site_option( string $option, $default = false ) {
-		return $GLOBALS['auth_ref_smoke_options'][ $option ] ?? $default;
+	function get_site_option( string $option, $default_value = false ) {
+		return $GLOBALS['auth_ref_smoke_options'][ $option ] ?? $default_value;
 	}
 }
 

--- a/tests/daily-memory-store-seam-smoke.php
+++ b/tests/daily-memory-store-seam-smoke.php
@@ -169,7 +169,7 @@ function datamachine_daily_memory_store_seam_assert( bool $condition, string $me
 $store = new DailyMemorySeamFakeStore();
 add_filter(
 	'agents_api_memory_store',
-	function ( $default, AgentMemoryScope $scope ) use ( $store ) {
+	function ( $default_value, AgentMemoryScope $scope ) use ( $store ) {
 		return $store;
 	},
 	10,

--- a/tests/flow-step-legacy-handler-field-smoke.php
+++ b/tests/flow-step-legacy-handler-field-smoke.php
@@ -54,8 +54,8 @@ function assert_equals( $expected, $actual, string $name, array &$failures, int 
 	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }
 
-function assert_absent( string $key, array $array, string $name, array &$failures, int &$passes ): void {
-	assert_equals( false, array_key_exists( $key, $array ), $name, $failures, $passes );
+function assert_absent( string $key, array $array_value, string $name, array &$failures, int &$passes ): void {
+	assert_equals( false, array_key_exists( $key, $array_value ), $name, $failures, $passes );
 }
 
 function assert_not_contains( string $needle, string $haystack, string $name, array &$failures, int &$passes ): void {

--- a/tests/handler-slug-scalar-migration-smoke.php
+++ b/tests/handler-slug-scalar-migration-smoke.php
@@ -16,9 +16,9 @@ if ( ! defined( 'ARRAY_A' ) ) {
 
 $options = array();
 
-function get_option( string $key, $default = false ) {
+function get_option( string $key, $default_value = false ) {
 	global $options;
-	return array_key_exists( $key, $options ) ? $options[ $key ] : $default;
+	return array_key_exists( $key, $options ) ? $options[ $key ] : $default_value;
 }
 
 function update_option( string $key, $value, bool $autoload = true ): bool {

--- a/tests/import-agent-ability-smoke.php
+++ b/tests/import-agent-ability-smoke.php
@@ -58,8 +58,8 @@ namespace {
 		return (int) ( $GLOBALS['datamachine_test_current_user_id'] ?? 0 );
 	}
 
-	function get_option( string $name, mixed $default = false ): mixed {
-		return $GLOBALS['datamachine_test_options'][ $name ] ?? $default;
+	function get_option( string $name, mixed $default_value = false ): mixed {
+		return $GLOBALS['datamachine_test_options'][ $name ] ?? $default_value;
 	}
 
 	function apply_filters( string $hook_name, mixed $value, mixed ...$args ): mixed {

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -73,8 +73,8 @@ $GLOBALS['__test_actions']         = array();
 $GLOBALS['__test_migration_calls'] = array();
 
 if ( ! function_exists( 'get_option' ) ) {
-	function get_option( $name, $default = false ) {
-		return $GLOBALS['__test_options'][ $name ] ?? $default;
+	function get_option( $name, $default_value = false ) {
+		return $GLOBALS['__test_options'][ $name ] ?? $default_value;
 	}
 }
 

--- a/tests/prompt-auth-template-artifacts-smoke.php
+++ b/tests/prompt-auth-template-artifacts-smoke.php
@@ -111,8 +111,8 @@ if ( ! function_exists( 'plugin_dir_url' ) ) {
 $GLOBALS['__prompt_smoke_options'] = array();
 
 if ( ! function_exists( 'get_option' ) ) {
-	function get_option( $key, $default = false ) {
-		return $GLOBALS['__prompt_smoke_options'][ $key ] ?? $default;
+	function get_option( $key, $default_value = false ) {
+		return $GLOBALS['__prompt_smoke_options'][ $key ] ?? $default_value;
 	}
 }
 

--- a/tests/settings-mode-models-migration-smoke.php
+++ b/tests/settings-mode-models-migration-smoke.php
@@ -14,9 +14,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 $options      = array();
 $site_options = array();
 
-function get_option( string $key, $default = false ) {
+function get_option( string $key, $default_value = false ) {
 	global $options;
-	return array_key_exists( $key, $options ) ? $options[ $key ] : $default;
+	return array_key_exists( $key, $options ) ? $options[ $key ] : $default_value;
 }
 
 function update_option( string $key, $value, bool $autoload = true ): bool {
@@ -25,9 +25,9 @@ function update_option( string $key, $value, bool $autoload = true ): bool {
 	return true;
 }
 
-function get_site_option( string $key, $default = false ) {
+function get_site_option( string $key, $default_value = false ) {
 	global $site_options;
-	return array_key_exists( $key, $site_options ) ? $site_options[ $key ] : $default;
+	return array_key_exists( $key, $site_options ) ? $site_options[ $key ] : $default_value;
 }
 
 function update_site_option( string $key, $value ): bool {

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -75,8 +75,8 @@ function assert_equals( $expected, $actual, string $name, array &$failures, int 
 	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }
 
-function assert_absent( string $key, array $array, string $name, array &$failures, int &$passes ): void {
-	assert_equals( false, array_key_exists( $key, $array ), $name, $failures, $passes );
+function assert_absent( string $key, array $array_value, string $name, array &$failures, int &$passes ): void {
+	assert_equals( false, array_key_exists( $key, $array_value ), $name, $failures, $passes );
 }
 
 echo "handler config shape smoke (#1293)\n";

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -58,8 +58,8 @@ function current_action(): string {
 	return '';
 }
 
-function get_option( string $key, $default = false ) {
-	return $default;
+function get_option( string $key, $default_value = false ) {
+	return $default_value;
 }
 
 class WP_Abilities_Registry {

--- a/tests/transcript-policy-smoke.php
+++ b/tests/transcript-policy-smoke.php
@@ -46,11 +46,11 @@ class TranscriptPolicyEngineDataStub {
 // Stub get_option() for site-level resolution.
 $GLOBALS['transcript_policy_test_site_option'] = false;
 if ( ! function_exists( 'get_option' ) ) {
-	function get_option( $name, $default = false ) {
+	function get_option( $name, $default_value = false ) {
 		if ( 'datamachine_persist_pipeline_transcripts' === $name ) {
-			return $GLOBALS['transcript_policy_test_site_option'] ?? $default;
+			return $GLOBALS['transcript_policy_test_site_option'] ?? $default_value;
 		}
-		return $default;
+		return $default_value;
 	}
 }
 

--- a/tests/upsert-handler-result-handoff-smoke.php
+++ b/tests/upsert-handler-result-handoff-smoke.php
@@ -47,8 +47,8 @@ function current_action(): string {
 	return '';
 }
 
-function get_option( string $key, $default = false ) {
-	return $default;
+function get_option( string $key, $default_value = false ) {
+	return $default_value;
 }
 
 require_once __DIR__ . '/../inc/Core/DataPacket.php';

--- a/tests/webhook-auth-v2-migration-smoke.php
+++ b/tests/webhook-auth-v2-migration-smoke.php
@@ -16,9 +16,9 @@ if ( ! defined( 'ARRAY_A' ) ) {
 
 $options = array();
 
-function get_option( string $key, $default = false ) {
+function get_option( string $key, $default_value = false ) {
 	global $options;
-	return array_key_exists( $key, $options ) ? $options[ $key ] : $default;
+	return array_key_exists( $key, $options ) ? $options[ $key ] : $default_value;
 }
 
 function update_option( string $key, $value, bool $autoload = true ): bool {

--- a/tests/wordpress-publish-content-format-smoke.php
+++ b/tests/wordpress-publish-content-format-smoke.php
@@ -10,9 +10,9 @@
 namespace DataMachine\Core {
     class PluginSettings {
 
-        public static function get( string $key, array $default = array() ): array {
+        public static function get( string $key, array $default_value = array() ): array {
             unset( $key );
-            return $default;
+            return $default_value;
         }
     }
 }

--- a/tests/wp-ai-client-persistent-cache-smoke.php
+++ b/tests/wp-ai-client-persistent-cache-smoke.php
@@ -7,11 +7,11 @@
 
 namespace Psr\SimpleCache {
 	interface CacheInterface {
-		public function get( $key, $default = null );
+		public function get( $key, $default_value = null );
 		public function set( $key, $value, $ttl = null );
 		public function delete( $key );
 		public function clear();
-		public function getMultiple( $keys, $default = null );
+		public function getMultiple( $keys, $default_value = null );
 		public function setMultiple( $values, $ttl = null );
 		public function deleteMultiple( $keys );
 		public function has( $key );
@@ -68,8 +68,8 @@ namespace {
 		return true;
 	}
 
-	function get_option( string $name, $default = false ) {
-		return $GLOBALS['datamachine_cache_smoke_options'][ $name ] ?? $default;
+	function get_option( string $name, $default_value = false ) {
+		return $GLOBALS['datamachine_cache_smoke_options'][ $name ] ?? $default_value;
 	}
 
 	function update_option( string $name, $value, bool $autoload = true ): bool {

--- a/tests/wp-ai-client-provider-admin-smoke.php
+++ b/tests/wp-ai-client-provider-admin-smoke.php
@@ -23,8 +23,8 @@ namespace {
 		return trim( (string) $value );
 	}
 
-	function get_option( string $name, $default = false ) {
-		return $GLOBALS['datamachine_provider_admin_options'][ $name ] ?? $default;
+	function get_option( string $name, $default_value = false ) {
+		return $GLOBALS['datamachine_provider_admin_options'][ $name ] ?? $default_value;
 	}
 
 	function update_option( string $name, $value, bool $autoload = true ): bool {
@@ -33,8 +33,8 @@ namespace {
 		return true;
 	}
 
-	function get_site_option( string $name, $default = false ) {
-		return $GLOBALS['datamachine_provider_admin_site_options'][ $name ] ?? $default;
+	function get_site_option( string $name, $default_value = false ) {
+		return $GLOBALS['datamachine_provider_admin_site_options'][ $name ] ?? $default_value;
 	}
 
 	function maybe_unserialize( $value ) {

--- a/tests/wp-ai-client-request-timeout-smoke.php
+++ b/tests/wp-ai-client-request-timeout-smoke.php
@@ -78,11 +78,11 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 }
 
 if ( ! function_exists( 'get_option' ) ) {
-	function get_option( string $option, $default = false ) {
+	function get_option( string $option, $default_value = false ) {
 		if ( 'datamachine_settings' === $option ) {
 			return $GLOBALS['datamachine_timeout_test_settings'];
 		}
-		return $default;
+		return $default_value;
 	}
 }
 

--- a/tests/wp-ai-client-tool-schema-smoke.php
+++ b/tests/wp-ai-client-tool-schema-smoke.php
@@ -67,9 +67,9 @@ function sanitize_key( $key ): string {
 	return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $key ) ?? '' );
 }
 
-function get_option( string $option, $default = false ) {
+function get_option( string $option, $default_value = false ) {
 	unset( $option );
-	return $default;
+	return $default_value;
 }
 
 $captured_request = array();


### PR DESCRIPTION
## Summary

The squash-merge of #1833 (`260fcbc9`) failed CI lint with 75 findings. This PR applies the automatic fixes that `homeboy lint --fix` produces — pure mechanical formatting, no behavior changes.

## What changed

```
36 whitespace findings
25 formatting findings (mostly WordPress array key alignment)
14 misc findings (1 phpcbf, 1 reserved-param, 12 misc)
```

Produced by:

```bash
homeboy lint data-machine --changed-since 6e9fd06f --fix
```

The `6e9fd06f` baseline is the merge base of #1833 — so this scope covers every file that was touched in or since the rebase + snapshot squash-merge.

## Why CI failed despite local lint passing

`vendor/bin/phpcs --standard=WordPress` passed locally on the rebase PR, but the CI's `homeboy lint` ruleset is stricter (catches whitespace and array alignment that vanilla WPCS lets through). Local pre-flight should ideally use `homeboy lint` too — noted for future PRs.

## Verification

- `homeboy lint data-machine --changed-since 6e9fd06f`: passes with 0 findings
- All affected bundle smokes still pass (**96 assertions across 4 files**):
  - `agent-bundle-artifact-rebase-smoke.php` — 35
  - `agent-bundle-pending-action-rebase-smoke.php` — 13
  - `agent-bundle-installed-payload-snapshot-smoke.php` — 15
  - `agent-bundle-installed-artifact-smoke.php` — 33

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Detected the post-merge lint failure, ran `homeboy lint --fix` to produce the mechanical changes, verified smokes still pass. Chris reviewed the scope.