### PR TITLE
fix(auth-providers): hoist useState above early-return guard in CallbackUrlDisplay (rules-of-hooks)

### DIFF
--- a/inc/Core/Admin/Settings/assets/react/components/tabs/AuthProvidersTab.jsx
+++ b/inc/Core/Admin/Settings/assets/react/components/tabs/AuthProvidersTab.jsx
@@ -216,11 +216,11 @@ const ConfigForm = ( { provider, onSave, isSaving } ) => {
  * Callback URL display for OAuth providers.
  */
 const CallbackUrlDisplay = ( { url } ) => {
+	const [ copied, setCopied ] = useState( false );
+
 	if ( ! url ) {
 		return null;
 	}
-
-	const [ copied, setCopied ] = useState( false );
 
 	const handleCopy = () => {
 		navigator.clipboard.writeText( url ).then( () => {


### PR DESCRIPTION
## Summary

The inner `CallbackUrlDisplay` component in `AuthProvidersTab.jsx` had an early `return null` for falsy `url` placed **before** its `useState` declaration. This violates [React's Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks): hooks must be called in the same order on every render.

When `url` toggled between truthy and falsy, the hook call order changed across renders — which risks silent state corruption (slot misalignment with sibling hooks) or a hard "Rendered fewer hooks than expected" crash.

## The fix

Hoisted `const [ copied, setCopied ] = useState( false );` above the `if ( ! url ) { return null; }` guard. The hook itself never depended on `url` — only the JSX below it does — so the early return after the hook is correct.

```diff
 const CallbackUrlDisplay = ( { url } ) => {
-    if ( ! url ) {
-        return null;
-    }
-
-    const [ copied, setCopied ] = useState( false );
+    const [ copied, setCopied ] = useState( false );
+
+    if ( ! url ) {
+        return null;
+    }
```

No behavior change beyond moving the guard.

## Verification

- `homeboy lint` no longer reports `react-hooks/rules-of-hooks` for `inc/Core/Admin/Settings/assets/react/components/tabs/AuthProvidersTab.jsx`. (Other rules-of-hooks errors still exist in `PipelineCard.jsx` — out of scope here, separate finding.)
- Read-through of the component confirms the hoisted hook makes semantic sense: `copied` is local UI state that shouldn't change shape based on whether a URL was passed.
- No `CHANGELOG.md` edits, no version bumps.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the hoist edit and PR copy after Chris (via Franklin) flagged the violation. Chris reviews the patch and merges.