### PR TITLE
fix(pipeline-card): hoist hooks above early-return guard (rules-of-hooks)

### DIFF
--- a/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineCard.jsx
+++ b/inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineCard.jsx
@@ -45,10 +45,6 @@ export default function PipelineCard( {
 	const deleteStepMutation = useDeletePipelineStep();
 	const { openModal } = useUIStore();
 
-	if ( ! pipeline ) {
-		return null;
-	}
-
 	/**
 	 * Handle pipeline name change
 	 */
@@ -69,13 +65,13 @@ export default function PipelineCard( {
 	 */
 	const handleStepAdded = useCallback(
 		( pipelineId ) => {
-			const nextOrder = ( pipeline.pipeline_steps || [] ).length + 1;
+			const nextOrder = ( pipeline?.pipeline_steps || [] ).length + 1;
 			openModal( MODAL_TYPES.STEP_SELECTION, {
 				pipelineId,
 				nextExecutionOrder: nextOrder,
 			} );
 		},
-		[ pipeline.pipeline_steps, openModal ]
+		[ pipeline?.pipeline_steps, openModal ]
 	);
 
 	/**
@@ -85,7 +81,7 @@ export default function PipelineCard( {
 		async ( stepId ) => {
 			try {
 				await deleteStepMutation.mutateAsync( {
-					pipelineId: pipeline.pipeline_id,
+					pipelineId: pipeline?.pipeline_id,
 					stepId,
 				} );
 			} catch ( error ) {
@@ -98,7 +94,7 @@ export default function PipelineCard( {
 				);
 			}
 		},
-		[ pipeline.pipeline_id, deleteStepMutation ]
+		[ pipeline?.pipeline_id, deleteStepMutation ]
 	);
 
 	/**
@@ -106,18 +102,22 @@ export default function PipelineCard( {
 	 */
 	const handleOpenContextFiles = useCallback( () => {
 		openModal( MODAL_TYPES.CONTEXT_FILES, {
-			pipelineId: pipeline.pipeline_id,
+			pipelineId: pipeline?.pipeline_id,
 		} );
-	}, [ pipeline.pipeline_id, openModal ] );
+	}, [ pipeline?.pipeline_id, openModal ] );
 
 	/**
 	 * Handle memory files modal open
 	 */
 	const handleOpenMemoryFiles = useCallback( () => {
 		openModal( MODAL_TYPES.MEMORY_FILES, {
-			pipelineId: pipeline.pipeline_id,
+			pipelineId: pipeline?.pipeline_id,
 		} );
-	}, [ pipeline.pipeline_id, openModal ] );
+	}, [ pipeline?.pipeline_id, openModal ] );
+
+	if ( ! pipeline ) {
+		return null;
+	}
 
 	return (
 		<Card className="datamachine-pipeline-card" size="large">


### PR DESCRIPTION
## Summary

`PipelineCard` placed an early `return null` for `! pipeline` **before** six `useCallback` declarations. That violates React's Rules of Hooks: when `pipeline` toggles between `null` and a real value (which happens on every fresh load until the pipeline query resolves), the hook count changes between renders. React responds with "Rendered more hooks than during the previous render" — silent state corruption or a hard crash, depending on which other hooks are upstream.

## Fix

- Hoisted all six `useCallback` declarations above the `if ( ! pipeline ) { return null; }` guard so the hook count is stable across renders.
- Switched callback bodies and dependency arrays to optional chaining (`pipeline?.pipeline_id`, `pipeline?.pipeline_steps`) since the callbacks are now constructed before the null check. The early return still guarantees these callbacks are never invoked while `pipeline` is null, so behavior is unchanged.
- No other files touched. No version bump. No CHANGELOG edit.

## Verification

- `homeboy lint` no longer reports `react-hooks/rules-of-hooks` against `PipelineCard.jsx`. The only remaining `rules-of-hooks` finding in the repo is in `AuthProvidersTab.jsx` (a separate, pre-existing violation, out of scope here).
- No JS test suite covers this component (no `test` script in `package.json`); smoke-checked by re-reading the component to confirm the hoisted callbacks still close over `pipeline` semantically the same way.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the hoist + optional-chaining edit and this PR description. Chris reviewed the change and confirmed the behavioral equivalence (callbacks never fire while `pipeline` is null because the early return still gates rendering).