### PR TITLE
fix(agent): allow bundle artifact upgrades on import

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -247,7 +247,7 @@ class AgentAbilities {
 							),
 							'on_conflict' => array(
 								'type'        => 'string',
-								'enum'        => array( 'error', 'skip' ),
+								'enum'        => array( 'error', 'skip', 'upgrade' ),
 								'description' => 'How to handle an existing target agent slug.',
 							),
 							'owner_id'    => array(
@@ -703,11 +703,11 @@ class AgentAbilities {
 		$revision = BundleSource::is_remote( $source ) ? BundleSource::last_resolved_revision() : null;
 
 		$on_conflict = (string) ( $input['on_conflict'] ?? 'error' );
-		if ( ! in_array( $on_conflict, array( 'error', 'skip' ), true ) ) {
+		if ( ! in_array( $on_conflict, array( 'error', 'skip', 'upgrade' ), true ) ) {
 			BundleSource::cleanup( $resolved, $source );
 			return array(
 				'success' => false,
-				'error'   => 'on_conflict must be one of: error, skip.',
+				'error'   => 'on_conflict must be one of: error, skip, upgrade.',
 			);
 		}
 
@@ -769,16 +769,25 @@ class AgentAbilities {
 			);
 		}
 
-		if ( $existing ) {
+		if ( $existing && 'upgrade' !== $on_conflict ) {
 			return array(
 				'success'    => false,
 				'agent_id'   => (int) $existing['agent_id'],
 				'agent_slug' => $slug,
-				'error'      => sprintf( 'Agent slug "%s" already exists. Use on_conflict=skip to no-op, or import with a new slug.', $slug ),
+				'error'      => sprintf( 'Agent slug "%s" already exists. Use on_conflict=skip to no-op, on_conflict=upgrade to reconcile bundle artifacts, or import with a new slug.', $slug ),
 			);
 		}
 
-		$result = $bundler->import( $bundle, null, $owner_id, ! empty( $input['dry_run'] ) );
+		$result = $bundler->import(
+			$bundle,
+			null,
+			$owner_id,
+			! empty( $input['dry_run'] ),
+			array(
+				'is_upgrade'        => 'upgrade' === $on_conflict,
+				'reconcile_runtime' => 'upgrade' === $on_conflict,
+			)
+		);
 		if ( empty( $result['success'] ) ) {
 			$result['auth_warnings'] = $auth_warnings;
 			return $result;

--- a/tests/import-agent-ability-smoke.php
+++ b/tests/import-agent-ability-smoke.php
@@ -107,8 +107,8 @@ namespace {
 				return is_array( $bundle ) ? $bundle : null;
 			}
 
-			public function import( array $bundle, ?string $new_slug = null, int $owner_id = 0, bool $dry_run = false ): array {
-				self::$last_import = compact( 'bundle', 'new_slug', 'owner_id', 'dry_run' );
+			public function import( array $bundle, ?string $new_slug = null, int $owner_id = 0, bool $dry_run = false, array $options = array() ): array {
+				self::$last_import = compact( 'bundle', 'new_slug', 'owner_id', 'dry_run', 'options' );
 
 				return array(
 					'success' => true,
@@ -145,6 +145,7 @@ namespace {
 }
 
 namespace DataMachine\Engine\Bundle {
+	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSourceAuth.php';
 	require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleSource.php';
 }
 
@@ -249,11 +250,25 @@ namespace {
 	$result = AgentAbilities::importAgent(
 		array(
 			'source'      => $bundle_path,
-			'on_conflict' => 'replace',
+			'on_conflict' => 'overwrite',
 		)
 	);
-	$assert( 'unsupported replace policy is rejected', false === $result['success'] );
-	$assert( 'replace policy is no longer claimed', str_contains( $result['error'], 'error, skip' ) );
+	$assert( 'unsupported overwrite policy is rejected', false === $result['success'] );
+	$assert( 'overwrite policy is not claimed', str_contains( $result['error'], 'error, skip, upgrade' ) );
+
+	$result = AgentAbilities::importAgent(
+		array(
+			'source'      => $bundle_path,
+			'on_conflict' => 'upgrade',
+		)
+	);
+	$assert( 'conflict upgrade succeeds', true === $result['success'] );
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
+	$assert( 'conflict upgrade reaches bundler import', ! empty( AgentBundler::$last_import ) );
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
+	$assert( 'conflict upgrade passes upgrade option', true === AgentBundler::$last_import['options']['is_upgrade'] );
+	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
+	$assert( 'conflict upgrade reconciles runtime artifacts', true === AgentBundler::$last_import['options']['reconcile_runtime'] );
 
 	echo "\n[2] Accepted import path\n";
 	$reset();


### PR DESCRIPTION
## Summary
- Add `on_conflict=upgrade` to the `datamachine/import-agent` ability so package-backed agents can reconcile missing or stale bundle artifacts.
- Route upgrade imports through `AgentBundler::import()` with `is_upgrade` and runtime reconciliation enabled.
- Extend the import-agent smoke test to cover skip, unsupported policies, and upgrade passthrough.

## Testing
- `php -l inc/Abilities/AgentAbilities.php`
- `php -l tests/import-agent-ability-smoke.php`
- `php tests/import-agent-ability-smoke.php`
- Verified wc-site-generator iterator smoke locally with this branch: bundle import reports 1 pipeline and 1 flow imported; flow resolves and runs until the expected fake OpenAI key 401.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the iterator smoke import conflict, drafted the import ability upgrade path, and ran targeted smoke validation; Chris remains responsible for review and merge.