### PR TITLE
Fix ability bootstrap ordering before system task registration

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -277,7 +277,6 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\LocalSearchAbilities();
 	new \DataMachine\Abilities\SourceAggregateAbility();
 	new \DataMachine\Abilities\SystemAbilities();
-	new \DataMachine\Engine\AI\System\SystemAgentServiceProvider();
 	new \DataMachine\Abilities\Media\AltTextAbilities();
 	new \DataMachine\Abilities\Media\ImageGenerationAbilities();
 	new \DataMachine\Abilities\Media\MediaAbilities();
@@ -328,6 +327,10 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\Publish\SendEmailAbility();
 	new \DataMachine\Abilities\Update\UpdateWordPressAbility();
 	new \DataMachine\Abilities\Handler\TestHandlerAbility();
+
+	// Register system tasks after every ability hook is attached. Task registry
+	// initialization can resolve abilities, which lazily fires wp_abilities_api_init.
+	new \DataMachine\Engine\AI\System\SystemAgentServiceProvider();
 
 	// Deferred scaffold: during plugin activation the Abilities API is unavailable
 	// because init fires before the plugin file is included. A transient signals that

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -409,8 +409,6 @@ class AgentAbilities {
 			$register_callback();
 		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
 			add_action( 'wp_abilities_api_init', $register_callback );
-		} else {
-			$register_callback();
 		}
 	}
 

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -409,6 +409,8 @@ class AgentAbilities {
 			$register_callback();
 		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
 			add_action( 'wp_abilities_api_init', $register_callback );
+		} else {
+			$register_callback();
 		}
 	}
 

--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -173,8 +173,6 @@ class UpsertPostAbility {
 			$register();
 		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
 			add_action( 'wp_abilities_api_init', $register );
-		} else {
-			$register();
 		}
 	}
 

--- a/tests/agent-abilities-late-registration-smoke.php
+++ b/tests/agent-abilities-late-registration-smoke.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Smoke test for AgentAbilities registration after wp_abilities_api_init fired.
+ * Smoke test for AgentAbilities registration timing.
  *
  * Run with: php tests/agent-abilities-late-registration-smoke.php
  */
@@ -46,25 +46,25 @@ namespace {
 		echo "ok - {$label}\n";
 	};
 
-	echo "=== AgentAbilities Late Registration Smoke (#1846) ===\n";
+	echo "=== AgentAbilities Registration Timing Smoke (#1846) ===\n";
 
 	new AgentAbilities();
 
 	$registered = array_keys( $GLOBALS['datamachine_test_registered_abilities'] );
-	$expected   = array(
-		'datamachine/export-agent',
-		'datamachine/rename-agent',
-		'datamachine/list-agents',
-		'datamachine/create-agent',
-		'datamachine/import-agent',
-		'datamachine/get-agent',
-		'datamachine/update-agent',
-		'datamachine/delete-agent',
-	);
 
-	$assert( 'registers immediately after wp_abilities_api_init has fired', in_array( 'datamachine/import-agent', $registered, true ) );
-	$assert( 'registers all agent abilities', array() === array_diff( $expected, $registered ) );
+	$assert( 'does not call wp_register_ability after wp_abilities_api_init has fired', array() === $registered );
 	$assert( 'does not defer to an already-fired action', array() === $GLOBALS['datamachine_test_added_actions'] );
 
-	echo "All {$assertions} AgentAbilities late registration assertions passed.\n";
+	$plugin_source   = file_get_contents( dirname( __DIR__ ) . '/data-machine.php' ) ?: '';
+	$provider_offset = strpos( $plugin_source, 'new \\DataMachine\\Engine\\AI\\System\\SystemAgentServiceProvider();' );
+	$agent_offset    = strpos( $plugin_source, 'new \\DataMachine\\Abilities\\AgentAbilities();' );
+	$upsert_offset   = strpos( $plugin_source, 'new \\DataMachine\\Abilities\\Content\\UpsertPostAbility();' );
+
+	$assert( 'system provider is present', false !== $provider_offset );
+	$assert( 'agent abilities are present', false !== $agent_offset );
+	$assert( 'upsert-post ability is present', false !== $upsert_offset );
+	$assert( 'system provider initializes after agent abilities', $agent_offset < $provider_offset );
+	$assert( 'system provider initializes after upsert-post ability', $upsert_offset < $provider_offset );
+
+	echo "All {$assertions} AgentAbilities registration timing assertions passed.\n";
 }

--- a/tests/agent-abilities-late-registration-smoke.php
+++ b/tests/agent-abilities-late-registration-smoke.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Smoke test for AgentAbilities registration after wp_abilities_api_init fired.
+ *
+ * Run with: php tests/agent-abilities-late-registration-smoke.php
+ */
+
+namespace {
+	define( 'ABSPATH', sys_get_temp_dir() . '/datamachine-agent-abilities-late-registration/' );
+
+	$GLOBALS['datamachine_test_registered_abilities'] = array();
+	$GLOBALS['datamachine_test_added_actions']        = array();
+
+	function doing_action( string $hook = '' ): bool {
+		return false;
+	}
+
+	function did_action( string $hook = '' ): int {
+		return 'wp_abilities_api_init' === $hook ? 1 : 0;
+	}
+
+	function add_action( string $hook, callable $callback ): void {
+		$GLOBALS['datamachine_test_added_actions'][] = array( $hook, $callback );
+	}
+
+	function wp_register_ability( string $name, array $args ): void {
+		$GLOBALS['datamachine_test_registered_abilities'][ $name ] = $args;
+	}
+}
+
+namespace DataMachine\Abilities {
+	require_once dirname( __DIR__ ) . '/inc/Abilities/AgentAbilities.php';
+}
+
+namespace {
+	use DataMachine\Abilities\AgentAbilities;
+
+	$assertions = 0;
+	$assert     = function ( string $label, bool $condition ) use ( &$assertions ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			fwrite( STDERR, "FAIL: {$label}\n" );
+			exit( 1 );
+		}
+
+		echo "ok - {$label}\n";
+	};
+
+	echo "=== AgentAbilities Late Registration Smoke (#1846) ===\n";
+
+	new AgentAbilities();
+
+	$registered = array_keys( $GLOBALS['datamachine_test_registered_abilities'] );
+	$expected   = array(
+		'datamachine/export-agent',
+		'datamachine/rename-agent',
+		'datamachine/list-agents',
+		'datamachine/create-agent',
+		'datamachine/import-agent',
+		'datamachine/get-agent',
+		'datamachine/update-agent',
+		'datamachine/delete-agent',
+	);
+
+	$assert( 'registers immediately after wp_abilities_api_init has fired', in_array( 'datamachine/import-agent', $registered, true ) );
+	$assert( 'registers all agent abilities', array() === array_diff( $expected, $registered ) );
+	$assert( 'does not defer to an already-fired action', array() === $GLOBALS['datamachine_test_added_actions'] );
+
+	echo "All {$assertions} AgentAbilities late registration assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Move `SystemAgentServiceProvider` initialization after Data Machine ability constructors so task registry setup cannot fire `wp_abilities_api_init` before later ability hooks are attached.
- Keep `AgentAbilities` and `UpsertPostAbility` aligned with the Abilities API requirement by avoiding direct `wp_register_ability()` calls after `wp_abilities_api_init` has already fired.
- Add a pure-PHP smoke test for the Playground/CI bootstrap ordering contract around `datamachine/import-agent` and `datamachine/upsert-post`.

Closes #1846.

## Tests
- `php -l data-machine.php`
- `php -l inc/Abilities/AgentAbilities.php`
- `php -l inc/Abilities/Content/UpsertPostAbility.php`
- `php -l tests/agent-abilities-late-registration-smoke.php`
- `php tests/agent-abilities-late-registration-smoke.php`
- `php tests/import-agent-ability-smoke.php`
- `vendor/bin/phpcs data-machine.php inc/Abilities/AgentAbilities.php inc/Abilities/Content/UpsertPostAbility.php tests/agent-abilities-late-registration-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the failing ability registration path, corrected bootstrap ordering, updated targeted smoke coverage, and ran focused verification. Chris remains responsible for review and merge.