### PR TITLE
Fix runtime boot after late plugin inclusion

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -71,6 +71,12 @@ function datamachine_run_datamachine_plugin() {
 		return;
 	}
 
+	static $runtime_loaded = false;
+	if ( $runtime_loaded ) {
+		return;
+	}
+	$runtime_loaded = true;
+
 	// Set Action Scheduler timeout to 10 minutes (600 seconds) for large tasks
 	add_filter(
 		'action_scheduler_timeout_period',
@@ -430,8 +436,12 @@ function datamachine_activate_defaults_for_site() {
 	add_option( 'datamachine_settings', $default_settings );
 }
 
-// @phpstan-ignore-next-line WordPress stubs in CI omit the optional priority argument.
-add_action( 'plugins_loaded', 'datamachine_run_datamachine_plugin', 20 );
+if ( did_action( 'plugins_loaded' ) ) {
+	datamachine_run_datamachine_plugin();
+} else {
+	// @phpstan-ignore-next-line WordPress stubs in CI omit the optional priority argument.
+	add_action( 'plugins_loaded', 'datamachine_run_datamachine_plugin', 20 );
+}
 
 
 

--- a/tests/late-plugins-loaded-runtime-smoke.php
+++ b/tests/late-plugins-loaded-runtime-smoke.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Smoke test for late plugin inclusion after plugins_loaded has fired.
+ *
+ * Run with: php tests/late-plugins-loaded-runtime-smoke.php
+ */
+
+$source = file_get_contents( dirname( __DIR__ ) . '/data-machine.php' );
+if ( false === $source ) {
+	fwrite( STDERR, "FAIL: unable to read data-machine.php\n" );
+	exit( 1 );
+}
+
+$assertions = 0;
+$assert     = function ( string $label, bool $condition ) use ( &$assertions ): void {
+	++$assertions;
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$label}\n" );
+		exit( 1 );
+	}
+
+	echo "ok - {$label}\n";
+};
+
+echo "=== Late Plugins Loaded Runtime Smoke ===\n";
+
+$assert( 'runtime boot checks plugins_loaded state', str_contains( $source, "did_action( 'plugins_loaded' )" ) );
+$assert( 'runtime boots immediately after late inclusion', str_contains( $source, "datamachine_run_datamachine_plugin();\n} else {" ) );
+$assert( 'runtime still hooks normal plugin load', str_contains( $source, "add_action( 'plugins_loaded', 'datamachine_run_datamachine_plugin', 20 );" ) );
+$assert( 'runtime boot is idempotent', str_contains( $source, 'static $runtime_loaded = false;' ) );
+
+echo "All {$assertions} late plugins_loaded runtime assertions passed.\n";


### PR DESCRIPTION
## Summary
- Boot the Data Machine runtime immediately when the plugin is included after `plugins_loaded` has already fired.
- Keep the normal `plugins_loaded` hook for standard plugin load order while making runtime boot idempotent.
- Add smoke coverage for the late-inclusion runtime path.

## Testing
- `php -l data-machine.php`
- `php -l tests/late-plugins-loaded-runtime-smoke.php`
- `php tests/late-plugins-loaded-runtime-smoke.php`
- `vendor/bin/phpcs data-machine.php tests/late-plugins-loaded-runtime-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Playground iterator runtime bootstrap failure, drafted the minimal code/test change, and ran focused verification. Chris reviewed the direction and requested the PR.