### PR TITLE
Use effective agent resolution for memory CLI

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -820,12 +820,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "ec60bd98ce25f4d4cc4481cc08e6377a48e741b0"
+                "reference": "9d3d06a28402a66b9b74cf6b54ce90f59e4cab8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/ec60bd98ce25f4d4cc4481cc08e6377a48e741b0",
-                "reference": "ec60bd98ce25f4d4cc4481cc08e6377a48e741b0",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/9d3d06a28402a66b9b74cf6b54ce90f59e4cab8a",
+                "reference": "9d3d06a28402a66b9b74cf6b54ce90f59e4cab8a",
                 "shasum": ""
             },
             "require": {
@@ -839,6 +839,7 @@
                     "php tests/message-envelope-smoke.php",
                     "php tests/registry-smoke.php",
                     "php tests/execution-principal-smoke.php",
+                    "php tests/effective-agent-resolver-smoke.php",
                     "php tests/caller-context-smoke.php",
                     "php tests/authorization-smoke.php",
                     "php tests/action-policy-values-smoke.php",
@@ -879,7 +880,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-05T01:09:16+00:00"
+            "time": "2026-05-08T14:27:01+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/inc/Cli/AgentResolver.php
+++ b/inc/Cli/AgentResolver.php
@@ -16,6 +16,7 @@ namespace DataMachine\Cli;
 
 use WP_CLI;
 use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\FilesRepository\DirectoryManager;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -92,6 +93,56 @@ class AgentResolver {
 	}
 
 	/**
+	 * Resolve effective agent context for agent-scoped operations.
+	 *
+	 * Explicit `--agent` remains authoritative. Without it, the Agents API
+	 * effective-agent resolver may derive the agent from the execution principal
+	 * or from a single unambiguous owner candidate. Ambiguous owner fallbacks fail
+	 * closed instead of silently selecting the first owned agent.
+	 *
+	 * @param array $assoc_args Command arguments.
+	 * @return array{agent_id: int|null, user_id: int|null, agent_slug: string|null}
+	 */
+	public static function resolveEffectiveContext( array $assoc_args ): array {
+		$explicit = self::resolveContext( $assoc_args );
+		if ( null !== $explicit['agent_id'] ) {
+			$agents_repo = new Agents();
+			$agent       = $agents_repo->get_agent( (int) $explicit['agent_id'] );
+
+			return array(
+				'agent_id'   => (int) $explicit['agent_id'],
+				'user_id'    => null !== $explicit['user_id'] ? (int) $explicit['user_id'] : null,
+				'agent_slug' => $agent ? (string) $agent['agent_slug'] : null,
+			);
+		}
+
+		$directory_manager = new DirectoryManager();
+		$user_id           = UserResolver::resolve( $assoc_args );
+		$effective_user_id = $directory_manager->get_effective_user_id( $user_id );
+
+		$agent_slug = self::resolveEffectiveAgentSlugForUser( $effective_user_id );
+		if ( '' === $agent_slug ) {
+			return array(
+				'agent_id'   => null,
+				'user_id'    => $effective_user_id,
+				'agent_slug' => null,
+			);
+		}
+
+		$agents_repo = new Agents();
+		$agent       = $agents_repo->get_by_slug( $agent_slug );
+		if ( ! $agent ) {
+			WP_CLI::error( sprintf( 'Resolved effective agent "%s" was not found.', $agent_slug ) );
+		}
+
+		return array(
+			'agent_id'   => (int) $agent['agent_id'],
+			'user_id'    => (int) $agent['owner_id'],
+			'agent_slug' => (string) $agent['agent_slug'],
+		);
+	}
+
+	/**
 	 * Build scoping input from CLI flags.
 	 *
 	 * Resolves --agent (preferred) or --user (fallback) into input
@@ -116,5 +167,41 @@ class AgentResolver {
 
 		// No scoping — return empty (show all).
 		return array();
+	}
+
+	/**
+	 * Resolve an effective agent slug for an owner using Agents API semantics.
+	 *
+	 * @param int $owner_user_id Owner WordPress user ID.
+	 * @return string Effective agent slug, or empty string when none exists.
+	 */
+	private static function resolveEffectiveAgentSlugForUser( int $owner_user_id ): string {
+		if ( ! class_exists( '\\AgentsAPI\\AI\\WP_Agent_Effective_Agent_Resolver' ) ) {
+			WP_CLI::error( 'Agents API effective agent resolver is unavailable. Update the agents-api dependency or pass --agent explicitly.' );
+		}
+
+		$agents_repo = new Agents();
+		$owned       = $agents_repo->get_all_by_owner_id( $owner_user_id );
+		$slugs       = array_values( array_filter( array_map( static fn( $agent ) => (string) ( $agent['agent_slug'] ?? '' ), $owned ) ) );
+
+		$principal_context = array();
+		if ( class_exists( '\\AgentsAPI\\AI\\WP_Agent_Execution_Principal' ) ) {
+			$principal_context['request_context'] = \AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_CLI;
+		}
+
+		try {
+			return \AgentsAPI\AI\WP_Agent_Effective_Agent_Resolver::resolve(
+				array(
+					'owner_user_id'     => $owner_user_id,
+					'owner_agent_slugs' => $slugs,
+					'resolve_principal' => true,
+					'principal_context' => $principal_context,
+				)
+			);
+		} catch ( \InvalidArgumentException $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
+
+		return '';
 	}
 }

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -263,8 +263,8 @@ class MemoryCommand extends BaseCommand {
 			return;
 		}
 
-		$from_file     = $assoc_args['from-file'] ?? null;
-		$stdin_marker  = ( ! empty( $args ) && '-' === end( $args ) );
+		$from_file    = $assoc_args['from-file'] ?? null;
+		$stdin_marker = ( ! empty( $args ) && '-' === end( $args ) );
 		reset( $args );
 
 		if ( null !== $from_file && $stdin_marker ) {
@@ -297,7 +297,7 @@ class MemoryCommand extends BaseCommand {
 				return;
 			}
 
-			$content = file_get_contents( $from_file );
+			$content = file_get_contents( $from_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- CLI reads a local filesystem path supplied by --from-file.
 			if ( false === $content ) {
 				WP_CLI::error( sprintf( 'Failed to read --from-file path: %s', $from_file ) );
 				return;

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -985,13 +985,13 @@ class MemoryCommand extends BaseCommand {
 	 * @return array Input parameters with user_id and/or agent_id.
 	 */
 	private function resolveMemoryScoping( array $assoc_args ): array {
-		$agent_id = AgentResolver::resolve( $assoc_args );
+		$context = AgentResolver::resolveEffectiveContext( $assoc_args );
 
-		if ( null !== $agent_id ) {
-			return array( 'agent_id' => $agent_id );
+		if ( null !== $context['agent_id'] ) {
+			return array( 'agent_id' => (int) $context['agent_id'] );
 		}
 
-		return array( 'user_id' => UserResolver::resolve( $assoc_args ) );
+		return array( 'user_id' => (int) $context['user_id'] );
 	}
 
 	private function get_agent_dir( int $user_id = 0, ?int $agent_id = null ): string {
@@ -1253,11 +1253,13 @@ class MemoryCommand extends BaseCommand {
 				$effective_user_id = DirectoryManager::get_default_agent_user_id();
 			}
 		} else {
-			// Legacy user-based resolution (single-agent compat).
-			$user_id           = UserResolver::resolve( $assoc_args );
-			$effective_user_id = $directory_manager->get_effective_user_id( $user_id );
-			$agent_slug        = $directory_manager->get_agent_slug_for_user( $effective_user_id );
-			$agent_dir         = $directory_manager->get_agent_identity_directory_for_user( $effective_user_id );
+			$context           = AgentResolver::resolveEffectiveContext( $assoc_args );
+			$effective_user_id = (int) $context['user_id'];
+			$agent_slug        = (string) $context['agent_slug'];
+			if ( '' === $agent_slug ) {
+				$agent_slug = $directory_manager->get_agent_slug_for_user( $effective_user_id );
+			}
+			$agent_dir = $directory_manager->get_agent_identity_directory( $agent_slug );
 		}
 
 		$shared_dir  = $directory_manager->get_shared_directory();

--- a/tests/cli-effective-agent-resolver-smoke.php
+++ b/tests/cli-effective-agent-resolver-smoke.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Pure-PHP smoke test for Data Machine CLI effective agent resolution.
+ *
+ * Run with: php tests/cli-effective-agent-resolver-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$failures = array();
+	$passes   = 0;
+
+	echo "datamachine-cli-effective-agent-resolver-smoke\n";
+
+	require_once __DIR__ . '/agents-api-smoke-helpers.php';
+	datamachine_tests_require_agents_api();
+
+	class WP_CLI {
+		public static function error( string $message ): void {
+			throw new RuntimeException( $message );
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Agents {
+	class Agents {
+		public static array $rows = array();
+
+		public function get_agent( int $agent_id ): ?array {
+			foreach ( self::$rows as $row ) {
+				if ( (int) $row['agent_id'] === $agent_id ) {
+					return $row;
+				}
+			}
+
+			return null;
+		}
+
+		public function get_by_slug( string $agent_slug ): ?array {
+			foreach ( self::$rows as $row ) {
+				if ( $row['agent_slug'] === $agent_slug ) {
+					return $row;
+				}
+			}
+
+			return null;
+		}
+
+		public function get_all_by_owner_id( int $owner_id ): array {
+			return array_values( array_filter( self::$rows, static fn( $row ) => (int) $row['owner_id'] === $owner_id ) );
+		}
+	}
+}
+
+namespace DataMachine\Core\FilesRepository {
+	class DirectoryManager {
+		public function get_effective_user_id( int $user_id = 0 ): int {
+			return $user_id > 0 ? $user_id : 1;
+		}
+	}
+}
+
+namespace DataMachine\Cli {
+	class UserResolver {
+		public static function resolve( array $assoc_args ): int {
+			return (int) ( $assoc_args['user'] ?? 0 );
+		}
+	}
+}
+
+namespace {
+	require_once __DIR__ . '/../inc/Cli/AgentResolver.php';
+
+	DataMachine\Core\Database\Agents\Agents::$rows = array(
+		array(
+			'agent_id'   => 1,
+			'agent_slug' => 'admin',
+			'owner_id'   => 1,
+		),
+		array(
+			'agent_id'   => 2,
+			'agent_slug' => 'intelligence-chubes4',
+			'owner_id'   => 1,
+		),
+		array(
+			'agent_id'   => 3,
+			'agent_slug' => 'solo-agent',
+			'owner_id'   => 2,
+		),
+	);
+
+	$context = DataMachine\Cli\AgentResolver::resolveEffectiveContext( array( 'agent' => 'intelligence-chubes4' ) );
+	agents_api_smoke_assert_equals( 2, $context['agent_id'], 'explicit --agent resolves to agent id', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, $context['user_id'], 'explicit --agent carries owner user id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'intelligence-chubes4', $context['agent_slug'], 'explicit --agent carries slug', $failures, $passes );
+
+	$context = DataMachine\Cli\AgentResolver::resolveEffectiveContext( array( 'user' => 2 ) );
+	agents_api_smoke_assert_equals( 3, $context['agent_id'], 'single owned agent resolves from owner fallback', $failures, $passes );
+	agents_api_smoke_assert_equals( 'solo-agent', $context['agent_slug'], 'single owner fallback carries slug', $failures, $passes );
+
+	try {
+		DataMachine\Cli\AgentResolver::resolveEffectiveContext( array( 'user' => 1 ) );
+		agents_api_smoke_assert_equals( true, false, 'ambiguous owner fallback is rejected', $failures, $passes );
+	} catch ( RuntimeException $e ) {
+		agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'ambiguous' ), 'ambiguous owner fallback is rejected', $failures, $passes );
+	}
+
+	agents_api_smoke_finish( 'Data Machine CLI effective agent resolver', $failures, $passes );
+}


### PR DESCRIPTION
## Summary
- Routes memory CLI scoping through the Agents API effective-agent resolver when `--agent` is not provided.
- Keeps explicit `--agent` authoritative while allowing principal-derived or single-owner resolution.
- Fails closed when an owner has multiple candidate agents instead of silently selecting the first owned agent.
- Updates the `automattic/agents-api` lockfile reference to include `WP_Agent_Effective_Agent_Resolver` from Automattic/agents-api#111.

## Testing
- `php tests/cli-effective-agent-resolver-smoke.php`
- `php -l inc/Cli/AgentResolver.php && php -l inc/Cli/Commands/MemoryCommand.php && php -l tests/cli-effective-agent-resolver-smoke.php`
- `vendor/bin/phpcs inc/Cli/AgentResolver.php inc/Cli/Commands/MemoryCommand.php tests/cli-effective-agent-resolver-smoke.php`
- `homeboy test data-machine --force-hot`

## Notes
- `homeboy lint data-machine --force-hot` still reports existing frontend lint debt outside this change; modified PHP files pass PHPCS.

Depends on Automattic/agents-api#111.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the Data Machine integration, adding targeted smoke coverage, updating the Agents API dev dependency, and drafting this PR description. Chris directed the upstream/downstream flow and reviewed the architecture.