### PR TITLE
Normalize handler-backed step config shape

### DIFF
--- a/docs/api/endpoints/parameter-systems.md
+++ b/docs/api/endpoints/parameter-systems.md
@@ -292,8 +292,16 @@ $execution_order = $flow_step_config['execution_order']; // From pipeline
 $system_prompt = $flow_step_config['system_prompt'];   // From pipeline (AI steps)
 $prompt_queue = $flow_step_config['prompt_queue'];     // From flow (AI steps)
 $queue_mode = $flow_step_config['queue_mode'];         // drain | loop | static
-$handler_config = $flow_step_config['handler_config']; // Handler settings
+$handler_slugs = $flow_step_config['handler_slugs'];     // Handler-backed steps
+$handler_configs = $flow_step_config['handler_configs']; // Config map keyed by handler slug
 ```
+
+Handler-backed flow steps use the plural shape consistently, even when the
+step type supports only one handler. Older singular input (`handler_slug` +
+`handler_config`) is accepted at import/API boundaries and normalized before
+storage. Handler-free step types that own settings, such as `system_task`, may
+still store those settings in `handler_config` because there is no handler slug
+to key a `handler_configs` map.
 
 ## Data Packet Integration
 

--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -67,7 +67,11 @@ class ConfigureFlowStepsAbility {
 							),
 							'handler_config'      => array(
 								'type'        => 'object',
-								'description' => __( 'Handler configuration to apply to all matching steps', 'data-machine' ),
+								'description' => __( 'Single handler configuration to apply to matching steps. Prefer handler_configs for new callers.', 'data-machine' ),
+							),
+							'handler_configs'     => array(
+								'type'        => 'object',
+								'description' => __( 'Canonical handler configuration map keyed by handler slug.', 'data-machine' ),
 							),
 							'flow_configs'        => array(
 								'type'        => 'array',
@@ -146,6 +150,7 @@ class ConfigureFlowStepsAbility {
 		$handler_slug        = $input['handler_slug'] ?? null;
 		$target_handler_slug = $input['target_handler_slug'] ?? null;
 		$field_map           = $input['field_map'] ?? array();
+		$handler_configs     = is_array( $input['handler_configs'] ?? null ) ? $input['handler_configs'] : array();
 		$handler_config      = $input['handler_config'] ?? array();
 		$flow_configs        = $input['flow_configs'] ?? array();
 		$user_message        = $input['user_message'] ?? null;
@@ -164,6 +169,11 @@ class ConfigureFlowStepsAbility {
 				'success' => false,
 				'error'   => "Target handler '{$target_handler_slug}' not found",
 			);
+		}
+
+		if ( empty( $handler_config ) && ! empty( $handler_configs ) ) {
+			$config_slug    = is_string( $target_handler_slug ) && '' !== $target_handler_slug ? $target_handler_slug : $handler_slug;
+			$handler_config = is_string( $config_slug ) && is_array( $handler_configs[ $config_slug ] ?? null ) ? $handler_configs[ $config_slug ] : array();
 		}
 
 		$flows = $this->db_flows->get_flows_for_pipeline( $pipeline_id );
@@ -210,7 +220,13 @@ class ConfigureFlowStepsAbility {
 		$flow_configs_by_id = array();
 		foreach ( $flow_configs as $fc ) {
 			if ( isset( $fc['flow_id'] ) ) {
-				$flow_configs_by_id[ (int) $fc['flow_id'] ] = $fc['handler_config'] ?? array();
+				$flow_handler_configs = is_array( $fc['handler_configs'] ?? null ) ? $fc['handler_configs'] : array();
+				if ( ! empty( $flow_handler_configs ) ) {
+					$config_slug = is_string( $target_handler_slug ) && '' !== $target_handler_slug ? $target_handler_slug : $handler_slug;
+					$flow_configs_by_id[ (int) $fc['flow_id'] ] = is_string( $config_slug ) && is_array( $flow_handler_configs[ $config_slug ] ?? null ) ? $flow_handler_configs[ $config_slug ] : array();
+				} else {
+					$flow_configs_by_id[ (int) $fc['flow_id'] ] = $fc['handler_config'] ?? array();
+				}
 			}
 		}
 

--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -307,7 +307,6 @@ trait FlowStepHelpers {
 		$step = &$flow_config[ $flow_step_id ];
 
 		$uses_handler     = FlowStepConfig::usesHandler( $step );
-		$is_multi_handler = FlowStepConfig::isMultiHandler( $step );
 		$effective_slug   = $uses_handler
 			? FlowStepConfig::getEffectiveSlug( $step, $handler_slug )
 			: ( $step['step_type'] ?? '' );
@@ -341,7 +340,7 @@ trait FlowStepHelpers {
 		if ( ! $uses_handler ) {
 			$step['handler_config'] = $stored_config;
 			unset( $step['handler_slug'], $step['handler_slugs'], $step['handler_configs'] );
-		} elseif ( $is_multi_handler ) {
+		} else {
 			$current_slugs = FlowStepConfig::getHandlerSlugs( $step );
 			if ( ! in_array( $effective_slug, $current_slugs, true ) ) {
 				$current_slugs = array( $effective_slug );
@@ -350,15 +349,11 @@ trait FlowStepHelpers {
 				array_unshift( $current_slugs, $effective_slug );
 			}
 
-			$handler_configs                    = is_array( $step['handler_configs'] ?? null ) ? $step['handler_configs'] : array();
+			$handler_configs                    = FlowStepConfig::getHandlerConfigs( $step );
 			$handler_configs[ $effective_slug ] = $stored_config;
 			$step['handler_slugs']              = $current_slugs;
 			$step['handler_configs']            = $handler_configs;
 			unset( $step['handler_slug'], $step['handler_config'] );
-		} else {
-			$step['handler_slug']   = $effective_slug;
-			$step['handler_config'] = $stored_config;
-			unset( $step['handler_slugs'], $step['handler_configs'] );
 		}
 
 		$step['enabled'] = true;

--- a/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
+++ b/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
@@ -46,7 +46,11 @@ class UpdateFlowStepAbility {
 							),
 							'handler_config'     => array(
 								'type'        => 'object',
-								'description' => __( 'Handler configuration settings to merge', 'data-machine' ),
+								'description' => __( 'Single handler configuration settings to merge. Prefer handler_configs for new callers.', 'data-machine' ),
+							),
+							'handler_configs'    => array(
+								'type'        => 'object',
+								'description' => __( 'Canonical handler configuration map keyed by handler slug.', 'data-machine' ),
 							),
 							'user_message'       => array(
 								'type'        => 'string',
@@ -96,10 +100,11 @@ class UpdateFlowStepAbility {
 	 * @return array Result with update status.
 	 */
 	public function execute( array $input ): array {
-		$flow_step_id   = $input['flow_step_id'] ?? null;
-		$handler_slug   = $input['handler_slug'] ?? null;
-		$handler_config = $input['handler_config'] ?? array();
-		$user_message   = $input['user_message'] ?? null;
+		$flow_step_id     = $input['flow_step_id'] ?? null;
+		$handler_slug     = $input['handler_slug'] ?? null;
+		$handler_configs  = is_array( $input['handler_configs'] ?? null ) ? $input['handler_configs'] : array();
+		$handler_config   = $input['handler_config'] ?? array();
+		$user_message     = $input['user_message'] ?? null;
 
 		if ( empty( $flow_step_id ) || ! is_string( $flow_step_id ) ) {
 			return array(
@@ -108,7 +113,12 @@ class UpdateFlowStepAbility {
 			);
 		}
 
-		$has_handler_update = ! empty( $handler_slug ) || ! empty( $handler_config );
+		if ( empty( $handler_config ) && ! empty( $handler_configs ) ) {
+			$handler_slug   = is_string( $handler_slug ) && '' !== $handler_slug ? $handler_slug : array_key_first( $handler_configs );
+			$handler_config = is_string( $handler_slug ) && is_array( $handler_configs[ $handler_slug ] ?? null ) ? $handler_configs[ $handler_slug ] : array();
+		}
+
+		$has_handler_update = ! empty( $handler_slug ) || ! empty( $handler_config ) || ! empty( $handler_configs );
 		$has_message_update = null !== $user_message;
 		$has_add_handler    = ! empty( $input['add_handler'] );
 		$has_remove_handler = ! empty( $input['remove_handler'] );

--- a/inc/Core/Admin/FlowFormatter.php
+++ b/inc/Core/Admin/FlowFormatter.php
@@ -71,8 +71,14 @@ class FlowFormatter {
 				$primary_config = FlowStepConfig::getPrimaryHandlerConfig( $step_data );
 				$with_defaults  = $handler_abilities->applyDefaults( $effective_slug, $primary_config );
 
-				if ( FlowStepConfig::isMultiHandler( $step_data ) ) {
-					$step_data['handler_configs'][ $effective_slug ] = $with_defaults;
+				if ( FlowStepConfig::usesHandler( $step_data ) ) {
+					$handler_slugs = FlowStepConfig::getHandlerSlugs( $step_data );
+					if ( ! in_array( $effective_slug, $handler_slugs, true ) ) {
+						$handler_slugs[] = $effective_slug;
+					}
+					$step_data['handler_slugs']                          = $handler_slugs;
+					$step_data['handler_configs'][ $effective_slug ]     = $with_defaults;
+					unset( $step_data['handler_slug'], $step_data['handler_config'] );
 				} else {
 					$step_data['handler_config'] = $with_defaults;
 				}

--- a/inc/Core/Steps/FlowStepConfig.php
+++ b/inc/Core/Steps/FlowStepConfig.php
@@ -90,10 +90,10 @@ class FlowStepConfig {
 	}
 
 	/**
-	 * Return whether this step type supports multiple handlers.
+	 * Return whether this step type supports more than one handler.
 	 *
 	 * @param array $step_config Step configuration array.
-	 * @return bool True when the step stores handler_slugs as a list.
+	 * @return bool True when the step can store multiple handler slugs.
 	 */
 	public static function isMultiHandler( array $step_config ): bool {
 		$capabilities = self::getCapabilities( $step_config );
@@ -101,11 +101,11 @@ class FlowStepConfig {
 	}
 
 	/**
-	 * Get the scalar handler slug for single-handler step types.
+	 * Get the primary handler slug.
 	 *
-	 * Calling this on a multi-handler step is a contract violation: callers
-	 * that need every handler must use getHandlerSlugs(). Handler-free steps
-	 * return null.
+	 * Handler-backed steps use the same `handler_slugs` list in storage whether
+	 * they support one handler or many. This convenience accessor returns the
+	 * first configured handler for callers that operate on a primary handler.
 	 *
 	 * @param array $step_config Step configuration array.
 	 * @return string|null Handler slug, or null when not configured/applicable.
@@ -115,41 +115,20 @@ class FlowStepConfig {
 			return null;
 		}
 
-		if ( self::isMultiHandler( $step_config ) ) {
-			self::warnContractViolation( 'getHandlerSlug() called for a multi-handler step', $step_config );
-			return null;
-		}
-
-		$slug = $step_config['handler_slug'] ?? null;
-		if ( ! is_string( $slug ) || '' === $slug ) {
-			return null;
-		}
-
-		return $slug;
+		$slugs = self::getConfiguredHandlerSlugs( $step_config );
+		return $slugs[0] ?? null;
 	}
 
 	/**
-	 * Get handler slugs for multi-handler step types.
+	 * Get configured handler slugs.
 	 *
-	 * Calling this on a single-handler step is a contract violation: callers
-	 * that need the single slug must use getHandlerSlug(). Handler-free steps
-	 * return an empty array.
+	 * Handler-free steps return an empty array.
 	 *
 	 * @param array $step_config Step configuration array.
 	 * @return array<int, string> Handler slugs.
 	 */
 	public static function getHandlerSlugs( array $step_config ): array {
-		if ( ! self::usesHandler( $step_config ) ) {
-			return array();
-		}
-
-		if ( ! self::isMultiHandler( $step_config ) ) {
-			self::warnContractViolation( 'getHandlerSlugs() called for a single-handler step', $step_config );
-			return array();
-		}
-
-		$slugs = $step_config['handler_slugs'] ?? array();
-		return self::sanitizeSlugList( is_array( $slugs ) ? $slugs : array() );
+		return self::getConfiguredHandlerSlugs( $step_config );
 	}
 
 	/**
@@ -166,12 +145,12 @@ class FlowStepConfig {
 			return array();
 		}
 
-		if ( self::isMultiHandler( $step_config ) ) {
-			$slugs = $step_config['handler_slugs'] ?? array();
-			return self::sanitizeSlugList( is_array( $slugs ) ? $slugs : array() );
+		$slugs = self::sanitizeSlugList( is_array( $step_config['handler_slugs'] ?? null ) ? $step_config['handler_slugs'] : array() );
+		if ( ! empty( $slugs ) ) {
+			return $slugs;
 		}
 
-		$slug = $step_config['handler_slug'] ?? '';
+		$slug = $step_config['handler_slug'] ?? null;
 		return is_string( $slug ) && '' !== $slug ? array( $slug ) : array();
 	}
 
@@ -299,12 +278,13 @@ class FlowStepConfig {
 	 * @return array Primary handler configuration.
 	 */
 	public static function getPrimaryHandlerConfig( array $step_config ): array {
-		if ( self::isMultiHandler( $step_config ) ) {
+		if ( self::usesHandler( $step_config ) ) {
 			$slug = self::getPrimaryHandlerSlug( $step_config );
-			if ( ! empty( $slug ) && ! empty( $step_config['handler_configs'][ $slug ] ) && is_array( $step_config['handler_configs'][ $slug ] ) ) {
-				return $step_config['handler_configs'][ $slug ];
+			if ( null === $slug ) {
+				return array();
 			}
-			return array();
+
+			return self::getHandlerConfigForSlug( $step_config, $slug );
 		}
 
 		$config = $step_config['handler_config'] ?? array();
@@ -319,8 +299,14 @@ class FlowStepConfig {
 	 * @return array Handler configuration.
 	 */
 	public static function getHandlerConfigForSlug( array $step_config, string $slug ): array {
-		if ( self::isMultiHandler( $step_config ) ) {
-			$config = $step_config['handler_configs'][ $slug ] ?? array();
+		if ( self::usesHandler( $step_config ) ) {
+			$configs = is_array( $step_config['handler_configs'] ?? null ) ? $step_config['handler_configs'] : array();
+			if ( array_key_exists( $slug, $configs ) ) {
+				$config = $configs[ $slug ];
+				return is_array( $config ) ? $config : array();
+			}
+
+			$config = $slug === ( $step_config['handler_slug'] ?? null ) ? ( $step_config['handler_config'] ?? array() ) : array();
 			return is_array( $config ) ? $config : array();
 		}
 
@@ -339,9 +325,15 @@ class FlowStepConfig {
 	 * @return array<string, array> Handler/settings configs keyed by slug.
 	 */
 	public static function getHandlerConfigs( array $step_config ): array {
-		if ( self::isMultiHandler( $step_config ) ) {
-			$configs = $step_config['handler_configs'] ?? array();
-			return is_array( $configs ) ? $configs : array();
+		if ( self::usesHandler( $step_config ) ) {
+			$configs = is_array( $step_config['handler_configs'] ?? null ) ? $step_config['handler_configs'] : array();
+			foreach ( self::getConfiguredHandlerSlugs( $step_config ) as $slug ) {
+				if ( ! array_key_exists( $slug, $configs ) ) {
+					$configs[ $slug ] = self::getHandlerConfigForSlug( $step_config, $slug );
+				}
+			}
+
+			return array_filter( $configs, 'is_array' );
 		}
 
 		$slug   = self::getEffectiveSlug( $step_config );
@@ -361,9 +353,6 @@ class FlowStepConfig {
 	 */
 	public static function normalizeHandlerShape( array $step_config ): array {
 		$uses_handler = self::usesHandler( $step_config );
-		$is_multi     = self::isMultiHandler( $step_config );
-		$step_type    = $step_config['step_type'] ?? '';
-
 		$scalar_slug     = is_string( $step_config['handler_slug'] ?? null ) ? $step_config['handler_slug'] : '';
 		$scalar_config   = is_array( $step_config['handler_config'] ?? null ) ? $step_config['handler_config'] : array();
 		$handler_slugs   = self::sanitizeSlugList( is_array( $step_config['handler_slugs'] ?? null ) ? $step_config['handler_slugs'] : array() );
@@ -378,21 +367,18 @@ class FlowStepConfig {
 			return $step_config;
 		}
 
-		if ( $is_multi ) {
-			if ( ! empty( $handler_slugs ) ) {
-				$step_config['handler_slugs'] = $handler_slugs;
-			}
-			if ( ! empty( $handler_configs ) ) {
-				$step_config['handler_configs'] = $handler_configs;
-			}
-			return $step_config;
+		if ( empty( $handler_slugs ) && '' !== $scalar_slug ) {
+			$handler_slugs = array( $scalar_slug );
+		}
+		if ( '' !== $scalar_slug && ! array_key_exists( $scalar_slug, $handler_configs ) ) {
+			$handler_configs[ $scalar_slug ] = $scalar_config;
 		}
 
-		if ( '' !== $scalar_slug ) {
-			$step_config['handler_slug'] = $scalar_slug;
+		if ( ! empty( $handler_slugs ) ) {
+			$step_config['handler_slugs'] = $handler_slugs;
 		}
-		if ( ! empty( $scalar_config ) || '' !== $scalar_slug ) {
-			$step_config['handler_config'] = $scalar_config;
+		if ( ! empty( $handler_configs ) ) {
+			$step_config['handler_configs'] = array_filter( $handler_configs, 'is_array' );
 		}
 		return $step_config;
 	}

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -125,18 +125,29 @@ class FlowStepConfigFactory {
 			}
 		}
 
-		$handler_slug   = $args['handler_slug'] ?? '';
-		$handler_config = $args['handler_config'] ?? array();
+		$handler_slug    = $args['handler_slug'] ?? '';
+		$handler_config  = $args['handler_config'] ?? array();
+		$handler_slugs   = is_array( $args['handler_slugs'] ?? null ) ? $args['handler_slugs'] : array();
+		$handler_configs = is_array( $args['handler_configs'] ?? null ) ? $args['handler_configs'] : array();
 
-		if ( is_string( $handler_slug ) && '' !== $handler_slug ) {
-			if ( FlowStepConfig::isMultiHandler( $step_config ) ) {
-				$step_config['handler_slugs']   = array( $handler_slug );
-				$step_config['handler_configs'] = array( $handler_slug => $handler_config );
-			} else {
-				$step_config['handler_slug']   = $handler_slug;
-				$step_config['handler_config'] = $handler_config;
+		if ( FlowStepConfig::usesHandler( $step_config ) ) {
+			if ( is_string( $handler_slug ) && '' !== $handler_slug ) {
+				$handler_slugs[] = $handler_slug;
+				if ( ! array_key_exists( $handler_slug, $handler_configs ) ) {
+					$handler_configs[ $handler_slug ] = $handler_config;
+				}
 			}
-		} elseif ( ! FlowStepConfig::usesHandler( $step_config ) && ! empty( $handler_config ) ) {
+
+			$step_config = FlowStepConfig::normalizeHandlerShape(
+				array_merge(
+					$step_config,
+					array(
+						'handler_slugs'   => $handler_slugs,
+						'handler_configs' => $handler_configs,
+					)
+				)
+			);
+		} elseif ( ! empty( $handler_config ) ) {
 			$step_config['handler_config'] = $handler_config;
 		}
 
@@ -219,7 +230,6 @@ class FlowStepConfigFactory {
 	 */
 	public static function withHandlerConfig( array $step_config, string $handler_slug = '', array $handler_config = array(), bool $merge = false ): array {
 		$uses_handler   = FlowStepConfig::usesHandler( $step_config );
-		$is_multi       = FlowStepConfig::isMultiHandler( $step_config );
 		$effective_slug = FlowStepConfig::getEffectiveSlug( $step_config, $handler_slug );
 
 		if ( ! $uses_handler ) {
@@ -237,29 +247,19 @@ class FlowStepConfigFactory {
 		$existing_config = $merge ? FlowStepConfig::getHandlerConfigForSlug( $step_config, $effective_slug ) : array();
 		$stored_config   = array_merge( $existing_config, $handler_config );
 
-		if ( $is_multi ) {
-			$slugs = '' !== $handler_slug ? array( $effective_slug ) : FlowStepConfig::getHandlerSlugs( $step_config );
-			if ( empty( $slugs ) ) {
-				$slugs = array( $effective_slug );
-			}
-
-			$configs                    = '' !== $handler_slug ? array() : FlowStepConfig::getHandlerConfigs( $step_config );
-			$configs[ $effective_slug ] = $stored_config;
-
-			return self::withHandlerFields(
-				$step_config,
-				array(
-					'handler_slugs'   => $slugs,
-					'handler_configs' => $configs,
-				)
-			);
+		$slugs = FlowStepConfig::getHandlerSlugs( $step_config );
+		if ( ! in_array( $effective_slug, $slugs, true ) ) {
+			$slugs[] = $effective_slug;
 		}
+
+		$configs                    = FlowStepConfig::getHandlerConfigs( $step_config );
+		$configs[ $effective_slug ] = $stored_config;
 
 		return self::withHandlerFields(
 			$step_config,
 			array(
-				'handler_slug'   => $effective_slug,
-				'handler_config' => $stored_config,
+				'handler_slugs'   => $slugs,
+				'handler_configs' => $configs,
 			)
 		);
 	}

--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -494,15 +494,10 @@ class ImportExport {
 		$settings        = array();
 		$primary_handler = FlowStepConfig::getPrimaryHandlerSlug( $flow_step ) ?? '';
 
-		if ( FlowStepConfig::isMultiHandler( $flow_step ) && ! empty( $primary_handler ) ) {
+		if ( FlowStepConfig::usesHandler( $flow_step ) && ! empty( $primary_handler ) ) {
 			$settings = array(
 				'handler_slugs'   => FlowStepConfig::getHandlerSlugs( $flow_step ),
 				'handler_configs' => FlowStepConfig::getHandlerConfigs( $flow_step ),
-			);
-		} elseif ( FlowStepConfig::usesHandler( $flow_step ) && ! empty( $primary_handler ) ) {
-			$settings = array(
-				'handler_slug'   => $primary_handler,
-				'handler_config' => FlowStepConfig::getPrimaryHandlerConfig( $flow_step ),
 			);
 		} elseif ( ! FlowStepConfig::usesHandler( $flow_step ) && ! empty( $flow_step['handler_config'] ) ) {
 			$settings = array(

--- a/tests/Unit/Cli/Commands/Flows/BulkConfigCommandTest.php
+++ b/tests/Unit/Cli/Commands/Flows/BulkConfigCommandTest.php
@@ -14,6 +14,7 @@ namespace DataMachine\Tests\Unit\Cli\Commands\Flows;
 use DataMachine\Abilities\FlowStep\ConfigureFlowStepsAbility;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\Steps\FlowStepConfig;
 use WP_UnitTestCase;
 
 class BulkConfigCommandTest extends WP_UnitTestCase {
@@ -121,12 +122,12 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 		$this->assertSame( 2, $result['steps_modified'] );
 
 		// Verify both flows got the new max_items.
-		$flow_1 = $this->flows->get_flow( $this->flow_id_1 );
-		$config_1 = $flow_1['flow_config'][ $this->flow_step_id_1 ]['handler_config'] ?? array();
+		$flow_1   = $this->flows->get_flow( $this->flow_id_1 );
+		$config_1 = FlowStepConfig::getPrimaryHandlerConfig( $flow_1['flow_config'][ $this->flow_step_id_1 ] ?? array() );
 		$this->assertSame( 10, $config_1['max_items'] );
 
-		$flow_2 = $this->flows->get_flow( $this->flow_id_2 );
-		$config_2 = $flow_2['flow_config'][ $this->flow_step_id_2 ]['handler_config'] ?? array();
+		$flow_2   = $this->flows->get_flow( $this->flow_id_2 );
+		$config_2 = FlowStepConfig::getPrimaryHandlerConfig( $flow_2['flow_config'][ $this->flow_step_id_2 ] ?? array() );
 		$this->assertSame( 10, $config_2['max_items'] );
 	}
 
@@ -139,8 +140,8 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 		) );
 
 		// feed_url should be preserved (merge, not replace).
-		$flow_1  = $this->flows->get_flow( $this->flow_id_1 );
-		$config  = $flow_1['flow_config'][ $this->flow_step_id_1 ]['handler_config'] ?? array();
+		$flow_1 = $this->flows->get_flow( $this->flow_id_1 );
+		$config = FlowStepConfig::getPrimaryHandlerConfig( $flow_1['flow_config'][ $this->flow_step_id_1 ] ?? array() );
 		$this->assertSame( 'https://example.com/feed', $config['feed_url'] );
 		$this->assertSame( 20, $config['max_items'] );
 	}
@@ -172,8 +173,8 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 		$this->assertCount( 2, $result['would_update'] );
 
 		// Verify nothing was actually changed.
-		$flow_1  = $this->flows->get_flow( $this->flow_id_1 );
-		$config  = $flow_1['flow_config'][ $this->flow_step_id_1 ]['handler_config'] ?? array();
+		$flow_1 = $this->flows->get_flow( $this->flow_id_1 );
+		$config = FlowStepConfig::getPrimaryHandlerConfig( $flow_1['flow_config'][ $this->flow_step_id_1 ] ?? array() );
 		$this->assertSame( 5, $config['max_items'] );
 	}
 
@@ -189,8 +190,8 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 		$this->assertSame( 2, $result['flows_updated'] );
 
 		// Verify both flows updated.
-		$flow_1  = $this->flows->get_flow( $this->flow_id_1 );
-		$config_1 = $flow_1['flow_config'][ $this->flow_step_id_1 ]['handler_config'] ?? array();
+		$flow_1   = $this->flows->get_flow( $this->flow_id_1 );
+		$config_1 = FlowStepConfig::getPrimaryHandlerConfig( $flow_1['flow_config'][ $this->flow_step_id_1 ] ?? array() );
 		$this->assertSame( 7, $config_1['max_items'] );
 	}
 
@@ -223,13 +224,13 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['success'] );
 
 		// Flow 1 gets the shared config.
-		$flow_1  = $this->flows->get_flow( $this->flow_id_1 );
-		$config_1 = $flow_1['flow_config'][ $this->flow_step_id_1 ]['handler_config'] ?? array();
+		$flow_1   = $this->flows->get_flow( $this->flow_id_1 );
+		$config_1 = FlowStepConfig::getPrimaryHandlerConfig( $flow_1['flow_config'][ $this->flow_step_id_1 ] ?? array() );
 		$this->assertSame( 10, $config_1['max_items'] );
 
 		// Flow 2 gets the per-flow override (wins over shared).
-		$flow_2  = $this->flows->get_flow( $this->flow_id_2 );
-		$config_2 = $flow_2['flow_config'][ $this->flow_step_id_2 ]['handler_config'] ?? array();
+		$flow_2   = $this->flows->get_flow( $this->flow_id_2 );
+		$config_2 = FlowStepConfig::getPrimaryHandlerConfig( $flow_2['flow_config'][ $this->flow_step_id_2 ] ?? array() );
 		$this->assertSame( 25, $config_2['max_items'] );
 	}
 

--- a/tests/Unit/Engine/ImportExportStepConfigTest.php
+++ b/tests/Unit/Engine/ImportExportStepConfigTest.php
@@ -15,6 +15,7 @@ use DataMachine\Abilities\Pipeline\CreatePipelineAbility;
 use DataMachine\Abilities\PipelineStepAbilities;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Engine\Actions\ImportExport;
 use WP_UnitTestCase;
 
@@ -223,13 +224,13 @@ class ImportExportStepConfigTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( $imported_flow_step_id, $imported_flow_config );
 		$imported_step = $imported_flow_config[ $imported_flow_step_id ];
 
-		$this->assertSame( 'rss', $imported_step['handler_slug'] );
+		$this->assertSame( array( 'rss' ), $imported_step['handler_slugs'] );
 		$this->assertSame(
 			array(
 				'feed_url'  => 'https://example.com/feed',
 				'max_items' => 25,
 			),
-			$imported_step['handler_config']
+			FlowStepConfig::getPrimaryHandlerConfig( $imported_step )
 		);
 		$this->assertTrue( $imported_step['enabled'] );
 	}

--- a/tests/flow-step-legacy-handler-field-smoke.php
+++ b/tests/flow-step-legacy-handler-field-smoke.php
@@ -79,7 +79,7 @@ $synced_step = array(
 );
 assert_absent( 'handler', $synced_step, 'synced step has no legacy handler field', $failures, $passes );
 
-echo "\n[2] configured single-handler step stores scalar canonical fields:\n";
+echo "\n[2] configured single-handler step stores plural canonical fields:\n";
 $single = FlowStepConfig::normalizeHandlerShape(
 	array_merge(
 		$synced_step,
@@ -90,11 +90,13 @@ $single = FlowStepConfig::normalizeHandlerShape(
 		)
 	)
 );
-assert_equals( 'rss', $single['handler_slug'] ?? null, 'single-handler slug is canonical scalar', $failures, $passes );
-assert_equals( array( 'url' => 'https://example.com/feed.xml' ), $single['handler_config'] ?? array(), 'single-handler config is canonical scalar', $failures, $passes );
+assert_equals( array( 'rss' ), $single['handler_slugs'] ?? array(), 'single-handler slug is canonical list', $failures, $passes );
+assert_equals( array( 'rss' => array( 'url' => 'https://example.com/feed.xml' ) ), $single['handler_configs'] ?? array(), 'single-handler config is canonical map', $failures, $passes );
+assert_equals( 'rss', FlowStepConfig::getHandlerSlug( $single ), 'single-handler primary slug accessor reads canonical list', $failures, $passes );
+assert_equals( array( 'url' => 'https://example.com/feed.xml' ), FlowStepConfig::getPrimaryHandlerConfig( $single ), 'single-handler primary config accessor reads canonical map', $failures, $passes );
 assert_absent( 'handler', $single, 'single-handler step drops legacy handler field', $failures, $passes );
-assert_absent( 'handler_slugs', $single, 'single-handler step has no plural slugs', $failures, $passes );
-assert_absent( 'handler_configs', $single, 'single-handler step has no plural configs', $failures, $passes );
+assert_absent( 'handler_slug', $single, 'single-handler step drops scalar slug', $failures, $passes );
+assert_absent( 'handler_config', $single, 'single-handler step drops scalar config', $failures, $passes );
 
 echo "\n[3] configured multi-handler step stores plural canonical fields:\n";
 $multi = FlowStepConfig::normalizeHandlerShape(
@@ -127,7 +129,7 @@ $restored = FlowStepConfig::normalizeHandlerShape(
 		'handler_configs'  => array( 'rss' => array( 'url' => 'https://example.com/feed.xml' ) ),
 	)
 );
-assert_equals( 'rss', $restored['handler_slug'] ?? null, 'restored single-handler slug comes from canonical import settings', $failures, $passes );
+assert_equals( array( 'rss' ), $restored['handler_slugs'] ?? array(), 'restored single-handler slug comes from canonical import settings', $failures, $passes );
 assert_absent( 'handler', $restored, 'restored step drops stale imported handler field', $failures, $passes );
 
 echo "\n[5] writer sources no longer seed or persist the legacy field:\n";

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -103,7 +103,7 @@ assert_absent( 'handler_slug', $step0, 'system_task has no handler_slug', $failu
 assert_absent( 'handler_slugs', $step0, 'system_task has no handler_slugs', $failures, $passes );
 assert_absent( 'handler_configs', $step0, 'system_task has no handler_configs', $failures, $passes );
 
-echo "\n[2] fetch stores scalar handler_slug + handler_config:\n";
+echo "\n[2] fetch stores handler_slugs + handler_configs:\n";
 $built = build_configs_from_workflow_for_test(
 	array(
 		'steps' => array(
@@ -116,11 +116,13 @@ $built = build_configs_from_workflow_for_test(
 	)
 );
 $step0 = $built['flow_config']['ephemeral_step_0'];
-assert_equals( 'mcp', FlowStepConfig::getHandlerSlug( $step0 ), 'fetch handler slug is scalar', $failures, $passes );
+assert_equals( 'mcp', FlowStepConfig::getHandlerSlug( $step0 ), 'fetch handler slug accessor reads primary slug', $failures, $passes );
 assert_equals( array( 'mcp' ), FlowStepConfig::getConfiguredHandlerSlugs( $step0 ), 'fetch generic slug list has one slug', $failures, $passes );
 assert_equals( array( 'server' => 'a8c' ), FlowStepConfig::getPrimaryHandlerConfig( $step0 ), 'fetch config reachable', $failures, $passes );
-assert_absent( 'handler_slugs', $step0, 'fetch has no handler_slugs', $failures, $passes );
-assert_absent( 'handler_configs', $step0, 'fetch has no handler_configs', $failures, $passes );
+assert_equals( array( 'mcp' ), $step0['handler_slugs'] ?? array(), 'fetch stores plural handler_slugs', $failures, $passes );
+assert_equals( array( 'mcp' => array( 'server' => 'a8c' ) ), $step0['handler_configs'] ?? array(), 'fetch stores plural handler_configs', $failures, $passes );
+assert_absent( 'handler_slug', $step0, 'fetch has no scalar handler_slug', $failures, $passes );
+assert_absent( 'handler_config', $step0, 'fetch has no scalar handler_config', $failures, $passes );
 
 echo "\n[3] publish keeps multi-handler list shape:\n";
 $built = build_configs_from_workflow_for_test(
@@ -183,9 +185,10 @@ $fetch = FlowStepConfig::normalizeHandlerShape(
 		'handler_config' => array( 'url' => 'https://example.com/feed.xml' ),
 	)
 );
-assert_equals( 'rss', $fetch['handler_slug'] ?? null, 'fetch scalar slug preserved', $failures, $passes );
-assert_equals( array( 'url' => 'https://example.com/feed.xml' ), $fetch['handler_config'] ?? array(), 'fetch scalar config preserved', $failures, $passes );
-assert_absent( 'handler_slugs', $fetch, 'fetch plural slugs remain absent', $failures, $passes );
+assert_equals( array( 'rss' ), $fetch['handler_slugs'] ?? array(), 'fetch singular slug normalizes to plural list', $failures, $passes );
+assert_equals( array( 'rss' => array( 'url' => 'https://example.com/feed.xml' ) ), $fetch['handler_configs'] ?? array(), 'fetch singular config normalizes to plural map', $failures, $passes );
+assert_absent( 'handler_slug', $fetch, 'fetch scalar slug is removed', $failures, $passes );
+assert_absent( 'handler_config', $fetch, 'fetch scalar config is removed', $failures, $passes );
 
 $publish = FlowStepConfig::normalizeHandlerShape(
 	array(


### PR DESCRIPTION
## Summary
- Stores handler-backed flow steps with canonical `handler_slugs` and `handler_configs` fields, including single-handler steps.
- Keeps singular `handler_slug`/`handler_config` accepted at API and import boundaries, then normalizes before storage.
- Updates tests and docs to distinguish handler-backed config maps from handler-free step settings.

## Testing
- `php tests/flow-step-legacy-handler-field-smoke.php`
- `php tests/system-task-config-passthrough-smoke.php`
- `php tests/flow-update-set-user-message-smoke.php`
- `homeboy test data-machine --force-hot -- --filter=BulkConfigCommandTest`
- `homeboy test data-machine --force-hot -- --filter=ImportExportStepConfigTest`
- `vendor/bin/phpcs --standard=phpcs.xml.dist ...changed PHP files...`
- `git diff --check`
- `homeboy test data-machine --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and validating the handler config normalization changes; Chris remains responsible for review and final approval.