### PR TITLE
Honor bundle flow schedules

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -831,13 +831,26 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	private function flow_payload( array $flow, string $portable_slug ): array {
+		$scheduling_policy = $this->flow_scheduling_policy( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() );
+
 		return array(
 			'portable_slug'     => $portable_slug,
 			'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
 			'flow_config'       => $this->flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
-			'scheduling_policy' => 'create_paused_upgrade_preserve_existing',
+			'scheduling_policy' => $scheduling_policy,
 			'queue_policy'      => 'create_seed_upgrade_preserve_existing',
 		);
+	}
+
+	private function flow_scheduling_policy( array $config ): string {
+		$interval = (string) ( $config['interval'] ?? 'manual' );
+		$enabled  = array_key_exists( 'enabled', $config ) ? false !== $config['enabled'] : 'manual' !== $interval;
+
+		if ( 'manual' === $interval || ! $enabled ) {
+			return 'create_paused_upgrade_preserve_existing';
+		}
+
+		return 'create_bundle_schedule_upgrade_preserve_existing';
 	}
 
 	private function flow_config_without_runtime_queues( array $flow_config ): array {

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -1052,8 +1052,8 @@ class AgentsCommand extends AgentBundleCommand {
 	 * Import an agent from a portable bundle.
 	 *
 	 * Creates a new agent from a previously exported bundle. Pipelines and
-	 * flows are recreated with new IDs. Flows are imported in paused/manual
-	 * state to prevent immediate execution.
+	 * flows are recreated with new IDs. Flow scheduling follows the bundle's
+	 * reviewed schedule on create and preserves local schedules on upgrade.
 	 *
 	 * ## OPTIONS
 	 *

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -746,7 +746,7 @@ class AgentBundler {
 				);
 			}
 
-			// 5. Import flows: create paused, preserve local schedules/queues on update.
+			// 5. Import flows: honor bundle schedules on create, preserve local schedules/queues on update.
 			$flow_count = 0;
 			foreach ( $bundle['flows'] ?? array() as $flow_data ) {
 				$old_pipeline_id = (int) ( $flow_data['original_pipeline_id'] ?? 0 );
@@ -762,13 +762,7 @@ class AgentBundler {
 				);
 				$artifact_key  = 'flow:' . $portable_slug;
 
-				// Force paused/manual scheduling on create.
-				$scheduling            = $flow_data['scheduling_config'] ?? array();
-				$scheduling['enabled'] = false;
-				if ( ! isset( $scheduling['interval'] ) || 'manual' !== $scheduling['interval'] ) {
-					$scheduling['_original_interval'] = $scheduling['interval'] ?? 'manual';
-					$scheduling['interval']           = 'manual';
-				}
+				$scheduling = $this->bundle_create_scheduling_config( is_array( $flow_data['scheduling_config'] ?? null ) ? $flow_data['scheduling_config'] : array() );
 
 				$flow_config         = is_array( $flow_data['flow_config'] ?? null ) ? $flow_data['flow_config'] : array();
 				$existing_flow       = $this->flows_repo->get_by_portable_slug( (int) $new_pipeline_id, $portable_slug );
@@ -1162,13 +1156,37 @@ class AgentBundler {
 	}
 
 	private function flow_artifact_payload( array $flow, string $portable_slug ): array {
+		$scheduling_policy = $this->bundle_scheduling_policy( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() );
+
 		return array(
 			'portable_slug'     => $portable_slug,
 			'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
 			'flow_config'       => $this->flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
-			'scheduling_policy' => 'create_paused_upgrade_preserve_existing',
+			'scheduling_policy' => $scheduling_policy,
 			'queue_policy'      => 'create_seed_upgrade_preserve_existing',
 		);
+	}
+
+	private function bundle_create_scheduling_config( array $config ): array {
+		$config   = $this->sanitize_scheduling_config( $config );
+		$interval = (string) ( $config['interval'] ?? 'manual' );
+
+		$config['interval'] = $interval;
+		if ( ! array_key_exists( 'enabled', $config ) ) {
+			$config['enabled'] = 'manual' !== $interval;
+		}
+
+		return $config;
+	}
+
+	private function bundle_scheduling_policy( array $config ): string {
+		$create_config = $this->bundle_create_scheduling_config( $config );
+
+		if ( 'manual' === (string) ( $create_config['interval'] ?? 'manual' ) || false === ( $create_config['enabled'] ?? true ) ) {
+			return 'create_paused_upgrade_preserve_existing';
+		}
+
+		return 'create_bundle_schedule_upgrade_preserve_existing';
 	}
 
 	private function artifact_has_local_modifications( ?array $record, mixed $current_payload ): bool {

--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -121,7 +121,7 @@ final class AgentBundleArrayAdapter {
 				'flow_name'            => $flow['name'],
 				'flow_config'          => $flow_config,
 				'scheduling_config'    => array(
-					'enabled'   => false,
+					'enabled'   => 'manual' !== $flow['schedule'],
 					'interval'  => $flow['schedule'],
 					'max_items' => $flow['max_items'],
 				),

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -116,6 +116,29 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_import_honors_scheduled_bundle_flows_on_create(): void {
+		$bundle = $this->fixture_bundle( 'scheduled-agent' );
+		$bundle['flows'][0]['scheduling_config'] = array(
+			'enabled'  => true,
+			'interval' => 'daily',
+			'max_items' => array(
+				'mcp' => 5,
+			),
+		);
+
+		$result = $this->bundler->import( $bundle, null, $this->owner_id );
+
+		$this->assertTrue( (bool) $result['success'], 'Scheduled bundle import succeeds.' );
+
+		$agent    = $this->agents_repo->get_by_slug( 'scheduled-agent' );
+		$pipeline = $this->pipelines_repo->get_by_portable_slug( (int) $agent['agent_id'], 'static-site-pipeline' );
+		$flow     = $this->flows_repo->get_by_portable_slug( (int) $pipeline['pipeline_id'], 'static-site-flow' );
+
+		$this->assertSame( 'daily', $flow['scheduling_config']['interval'] ?? null, 'Importer preserves the bundle interval.' );
+		$this->assertTrue( $flow['scheduling_config']['enabled'] ?? false, 'Importer keeps scheduled bundle flows enabled.' );
+		$this->assertSame( array( 'mcp' => 5 ), $flow['scheduling_config']['max_items'] ?? null, 'Importer preserves bundle max item caps.' );
+	}
+
 	/**
 	 * The silent-partial-success regression in #1801: a failure after the agent row was claimed used
 	 * to return `success: true` with a populated agent_id summary, while the row was rolled back at


### PR DESCRIPTION
## Summary
- Honor bundle-declared flow schedules on first import instead of forcing scheduled flows into paused/manual mode.
- Keep manual or explicitly disabled bundle flows paused on create, and continue preserving local schedules on upgrade.
- Reflect the create-time scheduling policy in bundle artifact payloads so scheduled bundle flows are distinguishable from paused/manual ones.

## Testing
- `php -l inc/Core/Agents/AgentBundler.php && php -l inc/Engine/Bundle/AgentBundleArrayAdapter.php && php -l inc/Cli/Commands/AgentBundleCommand.php && php -l inc/Cli/Commands/AgentsCommand.php && php -l tests/Unit/Core/Agents/AgentBundlerImportTest.php`
- `git diff --check`
- `./vendor/bin/phpcs inc/Core/Agents/AgentBundler.php inc/Engine/Bundle/AgentBundleArrayAdapter.php inc/Cli/Commands/AgentBundleCommand.php inc/Cli/Commands/AgentsCommand.php tests/Unit/Core/Agents/AgentBundlerImportTest.php`
- `homeboy test data-machine --path "/Users/chubes/Developer/data-machine@fix-bundle-scheduling-policy" --force-hot` (`1224 passed, 3 skipped`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the bundle scheduling policy gap, drafted the Data Machine importer fix and regression coverage, and ran local validation. Chris identified the upstream contract issue and remains responsible for review and merge.