### PR TITLE
Normalize handler-free flow step settings

### DIFF
--- a/docs/api/endpoints/parameter-systems.md
+++ b/docs/api/endpoints/parameter-systems.md
@@ -294,14 +294,16 @@ $prompt_queue = $flow_step_config['prompt_queue'];     // From flow (AI steps)
 $queue_mode = $flow_step_config['queue_mode'];         // drain | loop | static
 $handler_slugs = $flow_step_config['handler_slugs'];     // Handler-backed steps
 $handler_configs = $flow_step_config['handler_configs']; // Config map keyed by handler slug
+$flow_step_settings = $flow_step_config['flow_step_settings']; // Handler-free step settings
 ```
 
 Handler-backed flow steps use the plural shape consistently, even when the
 step type supports only one handler. Older singular input (`handler_slug` +
 `handler_config`) is accepted at import/API boundaries and normalized before
 storage. Handler-free step types that own settings, such as `system_task`, may
-still store those settings in `handler_config` because there is no handler slug
-to key a `handler_configs` map.
+store those settings in `flow_step_settings` because there is no handler slug
+to key a `handler_configs` map. Older handler-free `handler_config` rows are
+normalized to `flow_step_settings` when read or rewritten.
 
 ## Data Packet Integration
 

--- a/docs/core-system/system-tasks.md
+++ b/docs/core-system/system-tasks.md
@@ -233,7 +233,7 @@ A pipeline step type that bridges system tasks into the pipeline engine. This al
 
 ### How It Works
 
-1. Reads `handler_config.task` to determine the task type
+1. Reads `flow_step_settings.task` to determine the task type
 2. Creates a child DM job for independent tracking
 3. Injects pipeline context (e.g., `post_id` from a preceding Publish step) into task params
 4. Executes the task handler synchronously

--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -230,7 +230,7 @@ class ConfigureFlowStepsAbility {
 			if ( isset( $fc['flow_id'] ) ) {
 				$flow_handler_configs = is_array( $fc['handler_configs'] ?? null ) ? $fc['handler_configs'] : array();
 				if ( ! empty( $flow_handler_configs ) ) {
-					$config_slug = is_string( $target_handler_slug ) && '' !== $target_handler_slug ? $target_handler_slug : $handler_slug;
+					$config_slug                                = is_string( $target_handler_slug ) && '' !== $target_handler_slug ? $target_handler_slug : $handler_slug;
 					$flow_configs_by_id[ (int) $fc['flow_id'] ] = is_string( $config_slug ) && is_array( $flow_handler_configs[ $config_slug ] ?? null ) ? $flow_handler_configs[ $config_slug ] : array();
 				} elseif ( is_array( $fc['flow_step_settings'] ?? null ) ) {
 					$flow_configs_by_id[ (int) $fc['flow_id'] ] = $fc['flow_step_settings'];
@@ -552,12 +552,20 @@ class ConfigureFlowStepsAbility {
 
 				$target = FlowStepTargetResolver::resolve( $flow_config, (string) $step_key, $config );
 				if ( empty( $target['success'] ) ) {
-					$errors[] = array_merge( array( 'flow_id' => $flow_id ), $target['error'] );
+					$target_error = is_array( $target['error'] ?? null ) ? $target['error'] : array( 'error' => 'Unable to resolve flow step target' );
+					$errors[]     = array_merge( array( 'flow_id' => $flow_id ), $target_error );
 					continue;
 				}
 
-				$flow_step_id = $target['flow_step_id'];
-				$step_type    = $target['step_type'] ?? (string) $step_key;
+				$flow_step_id = (string) ( $target['flow_step_id'] ?? '' );
+				if ( '' === $flow_step_id ) {
+					$errors[] = array(
+						'flow_id' => $flow_id,
+						'error'   => 'Unable to resolve flow step target',
+					);
+					continue;
+				}
+				$step_type = $target['step_type'] ?? (string) $step_key;
 
 				$handler_slug   = $config['handler_slug'] ?? null;
 				$handler_config = $config['handler_config'] ?? array();
@@ -585,7 +593,7 @@ class ConfigureFlowStepsAbility {
 				}
 
 				if ( ! empty( $handler_slug ) || ! empty( $handler_config ) ) {
-					$success = $this->updateHandler( $flow_step_id, $effective_slug ?? '', $handler_config );
+					$success = $this->updateHandler( $flow_step_id, $effective_slug, $handler_config );
 					if ( ! $success ) {
 						$errors[] = array(
 							'flow_id'      => $flow_id,

--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -73,9 +73,13 @@ class ConfigureFlowStepsAbility {
 								'type'        => 'object',
 								'description' => __( 'Canonical handler configuration map keyed by handler slug.', 'data-machine' ),
 							),
+							'flow_step_settings'  => array(
+								'type'        => 'object',
+								'description' => __( 'Canonical settings object for handler-free flow steps.', 'data-machine' ),
+							),
 							'flow_configs'        => array(
 								'type'        => 'array',
-								'description' => __( 'Per-flow configurations: [{flow_id: int, handler_config: object}]', 'data-machine' ),
+								'description' => __( 'Per-flow configurations: [{flow_id: int, handler_config|flow_step_settings|handler_configs: object}]', 'data-machine' ),
 							),
 							'user_message'        => array(
 								'type'        => 'string',
@@ -151,6 +155,7 @@ class ConfigureFlowStepsAbility {
 		$target_handler_slug = $input['target_handler_slug'] ?? null;
 		$field_map           = $input['field_map'] ?? array();
 		$handler_configs     = is_array( $input['handler_configs'] ?? null ) ? $input['handler_configs'] : array();
+		$flow_step_settings  = is_array( $input['flow_step_settings'] ?? null ) ? $input['flow_step_settings'] : array();
 		$handler_config      = $input['handler_config'] ?? array();
 		$flow_configs        = $input['flow_configs'] ?? array();
 		$user_message        = $input['user_message'] ?? null;
@@ -174,6 +179,9 @@ class ConfigureFlowStepsAbility {
 		if ( empty( $handler_config ) && ! empty( $handler_configs ) ) {
 			$config_slug    = is_string( $target_handler_slug ) && '' !== $target_handler_slug ? $target_handler_slug : $handler_slug;
 			$handler_config = is_string( $config_slug ) && is_array( $handler_configs[ $config_slug ] ?? null ) ? $handler_configs[ $config_slug ] : array();
+		}
+		if ( empty( $handler_config ) && ! empty( $flow_step_settings ) ) {
+			$handler_config = $flow_step_settings;
 		}
 
 		$flows = $this->db_flows->get_flows_for_pipeline( $pipeline_id );
@@ -224,6 +232,8 @@ class ConfigureFlowStepsAbility {
 				if ( ! empty( $flow_handler_configs ) ) {
 					$config_slug = is_string( $target_handler_slug ) && '' !== $target_handler_slug ? $target_handler_slug : $handler_slug;
 					$flow_configs_by_id[ (int) $fc['flow_id'] ] = is_string( $config_slug ) && is_array( $flow_handler_configs[ $config_slug ] ?? null ) ? $flow_handler_configs[ $config_slug ] : array();
+				} elseif ( is_array( $fc['flow_step_settings'] ?? null ) ) {
+					$flow_configs_by_id[ (int) $fc['flow_id'] ] = $fc['flow_step_settings'];
 				} else {
 					$flow_configs_by_id[ (int) $fc['flow_id'] ] = $fc['handler_config'] ?? array();
 				}

--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -338,8 +338,8 @@ trait FlowStepHelpers {
 		$stored_config = $this->handler_abilities->applyDefaults( $effective_slug, $merged_config );
 
 		if ( ! $uses_handler ) {
-			$step['handler_config'] = $stored_config;
-			unset( $step['handler_slug'], $step['handler_slugs'], $step['handler_configs'] );
+			$step['flow_step_settings'] = $stored_config;
+			unset( $step['handler_slug'], $step['handler_slugs'], $step['handler_config'], $step['handler_configs'] );
 		} else {
 			$current_slugs = FlowStepConfig::getHandlerSlugs( $step );
 			if ( ! in_array( $effective_slug, $current_slugs, true ) ) {

--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -306,8 +306,8 @@ trait FlowStepHelpers {
 
 		$step = &$flow_config[ $flow_step_id ];
 
-		$uses_handler     = FlowStepConfig::usesHandler( $step );
-		$effective_slug   = $uses_handler
+		$uses_handler   = FlowStepConfig::usesHandler( $step );
+		$effective_slug = $uses_handler
 			? FlowStepConfig::getEffectiveSlug( $step, $handler_slug )
 			: ( $step['step_type'] ?? '' );
 

--- a/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
+++ b/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
@@ -52,6 +52,10 @@ class UpdateFlowStepAbility {
 								'type'        => 'object',
 								'description' => __( 'Canonical handler configuration map keyed by handler slug.', 'data-machine' ),
 							),
+							'flow_step_settings' => array(
+								'type'        => 'object',
+								'description' => __( 'Canonical settings object for handler-free flow steps.', 'data-machine' ),
+							),
 							'user_message'       => array(
 								'type'        => 'string',
 								'description' => __( 'User message for AI steps', 'data-machine' ),
@@ -103,6 +107,7 @@ class UpdateFlowStepAbility {
 		$flow_step_id     = $input['flow_step_id'] ?? null;
 		$handler_slug     = $input['handler_slug'] ?? null;
 		$handler_configs  = is_array( $input['handler_configs'] ?? null ) ? $input['handler_configs'] : array();
+		$flow_step_settings = is_array( $input['flow_step_settings'] ?? null ) ? $input['flow_step_settings'] : array();
 		$handler_config   = $input['handler_config'] ?? array();
 		$user_message     = $input['user_message'] ?? null;
 
@@ -117,8 +122,11 @@ class UpdateFlowStepAbility {
 			$handler_slug   = is_string( $handler_slug ) && '' !== $handler_slug ? $handler_slug : array_key_first( $handler_configs );
 			$handler_config = is_string( $handler_slug ) && is_array( $handler_configs[ $handler_slug ] ?? null ) ? $handler_configs[ $handler_slug ] : array();
 		}
+		if ( empty( $handler_config ) && ! empty( $flow_step_settings ) ) {
+			$handler_config = $flow_step_settings;
+		}
 
-		$has_handler_update = ! empty( $handler_slug ) || ! empty( $handler_config ) || ! empty( $handler_configs );
+		$has_handler_update = ! empty( $handler_slug ) || ! empty( $handler_config ) || ! empty( $handler_configs ) || ! empty( $flow_step_settings );
 		$has_message_update = null !== $user_message;
 		$has_add_handler    = ! empty( $input['add_handler'] );
 		$has_remove_handler = ! empty( $input['remove_handler'] );
@@ -174,7 +182,7 @@ class UpdateFlowStepAbility {
 				$updated_fields[] = 'handler_slug';
 			}
 			if ( ! empty( $handler_config ) ) {
-				$updated_fields[] = 'handler_config';
+				$updated_fields[] = FlowStepConfig::usesHandler( $existing_step ) ? 'handler_config' : 'flow_step_settings';
 			}
 		}
 

--- a/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
+++ b/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
@@ -104,12 +104,12 @@ class UpdateFlowStepAbility {
 	 * @return array Result with update status.
 	 */
 	public function execute( array $input ): array {
-		$flow_step_id     = $input['flow_step_id'] ?? null;
-		$handler_slug     = $input['handler_slug'] ?? null;
-		$handler_configs  = is_array( $input['handler_configs'] ?? null ) ? $input['handler_configs'] : array();
+		$flow_step_id       = $input['flow_step_id'] ?? null;
+		$handler_slug       = $input['handler_slug'] ?? null;
+		$handler_configs    = is_array( $input['handler_configs'] ?? null ) ? $input['handler_configs'] : array();
 		$flow_step_settings = is_array( $input['flow_step_settings'] ?? null ) ? $input['flow_step_settings'] : array();
-		$handler_config   = $input['handler_config'] ?? array();
-		$user_message     = $input['user_message'] ?? null;
+		$handler_config     = $input['handler_config'] ?? array();
+		$user_message       = $input['user_message'] ?? null;
 
 		if ( empty( $flow_step_id ) || ! is_string( $flow_step_id ) ) {
 			return array(
@@ -140,10 +140,13 @@ class UpdateFlowStepAbility {
 
 		$validation = $this->validateFlowStepId( $flow_step_id );
 		if ( ! $validation['valid'] ) {
-			return $validation['error_response'];
+			return is_array( $validation['error_response'] ?? null ) ? $validation['error_response'] : array(
+				'success' => false,
+				'error'   => 'Invalid flow_step_id',
+			);
 		}
 
-		$existing_step = $validation['step_config'];
+		$existing_step = is_array( $validation['step_config'] ?? null ) ? $validation['step_config'] : array();
 
 		$updated_fields = array();
 

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -29,6 +29,7 @@ use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
 use DataMachine\Engine\Bundle\AgentPackageProjection;
 use DataMachine\Engine\Bundle\BundleValidationException;
 use DataMachine\Engine\Bundle\PortableSlug;
+use DataMachine\Core\Steps\FlowStepConfig;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -358,12 +359,15 @@ class AgentBundler {
 				'step_position'   => (int) ( $step['execution_order'] ?? count( $steps ) ),
 				'handler_configs' => self::handler_configs_from_flow_step( $step, $handler_auth, $context ),
 			);
+			if ( ! FlowStepConfig::usesHandler( $step ) && ! empty( FlowStepConfig::getPrimaryHandlerConfig( $step ) ) ) {
+				$document_step['flow_step_settings'] = FlowStepConfig::getPrimaryHandlerConfig( $step );
+			}
 
 			if ( ! isset( $step['step_type'] ) && isset( $pipeline_step_types_by_id[ $pipeline_step_id ] ) ) {
 				$document_step['step_type'] = $pipeline_step_types_by_id[ $pipeline_step_id ];
 			}
 
-			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'handler_config', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'enabled' ) as $field ) {
+			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'enabled' ) as $field ) {
 				if ( array_key_exists( $field, $step ) ) {
 					$document_step[ $field ] = $step[ $field ];
 				}

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -275,6 +275,7 @@ class AgentBundler {
 		 * @param int                                $agent_id Agent ID being exported.
 		 * @param array                              $agent    Agent row.
 		 */
+		/** @var mixed $extras */
 		$extras = apply_filters( 'datamachine_bundle_export_extras', array(), $agent_id, $agent );
 		if ( ! is_array( $extras ) ) {
 			return array();
@@ -1079,10 +1080,6 @@ class AgentBundler {
 	 * is the safety net that cleans up any rows we know we created.
 	 */
 	private function begin_transaction(): bool {
-		if ( ! isset( $this->agents_repo ) ) {
-			return false;
-		}
-
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$result = $wpdb->query( 'START TRANSACTION' );

--- a/inc/Core/Steps/FlowStepConfig.php
+++ b/inc/Core/Steps/FlowStepConfig.php
@@ -287,7 +287,7 @@ class FlowStepConfig {
 			return self::getHandlerConfigForSlug( $step_config, $slug );
 		}
 
-		$config = $step_config['handler_config'] ?? array();
+		$config = $step_config['flow_step_settings'] ?? ( $step_config['handler_config'] ?? array() );
 		return is_array( $config ) ? $config : array();
 	}
 
@@ -355,14 +355,16 @@ class FlowStepConfig {
 		$uses_handler = self::usesHandler( $step_config );
 		$scalar_slug     = is_string( $step_config['handler_slug'] ?? null ) ? $step_config['handler_slug'] : '';
 		$scalar_config   = is_array( $step_config['handler_config'] ?? null ) ? $step_config['handler_config'] : array();
+		$step_settings   = is_array( $step_config['flow_step_settings'] ?? null ) ? $step_config['flow_step_settings'] : array();
 		$handler_slugs   = self::sanitizeSlugList( is_array( $step_config['handler_slugs'] ?? null ) ? $step_config['handler_slugs'] : array() );
 		$handler_configs = is_array( $step_config['handler_configs'] ?? null ) ? $step_config['handler_configs'] : array();
 
-		unset( $step_config['handler'], $step_config['handler_slug'], $step_config['handler_slugs'], $step_config['handler_config'], $step_config['handler_configs'] );
+		unset( $step_config['handler'], $step_config['handler_slug'], $step_config['handler_slugs'], $step_config['handler_config'], $step_config['handler_configs'], $step_config['flow_step_settings'] );
 
 		if ( ! $uses_handler ) {
-			if ( ! empty( $scalar_config ) ) {
-				$step_config['handler_config'] = $scalar_config;
+			$settings = ! empty( $step_settings ) ? $step_settings : $scalar_config;
+			if ( ! empty( $settings ) ) {
+				$step_config['flow_step_settings'] = $settings;
 			}
 			return $step_config;
 		}

--- a/inc/Core/Steps/FlowStepConfig.php
+++ b/inc/Core/Steps/FlowStepConfig.php
@@ -306,7 +306,7 @@ class FlowStepConfig {
 				return is_array( $config ) ? $config : array();
 			}
 
-			$config = $slug === ( $step_config['handler_slug'] ?? null ) ? ( $step_config['handler_config'] ?? array() ) : array();
+			$config = ( $step_config['handler_slug'] ?? null ) === $slug ? ( $step_config['handler_config'] ?? array() ) : array();
 			return is_array( $config ) ? $config : array();
 		}
 
@@ -352,7 +352,7 @@ class FlowStepConfig {
 	 * @return array Canonicalized step configuration.
 	 */
 	public static function normalizeHandlerShape( array $step_config ): array {
-		$uses_handler = self::usesHandler( $step_config );
+		$uses_handler    = self::usesHandler( $step_config );
 		$scalar_slug     = is_string( $step_config['handler_slug'] ?? null ) ? $step_config['handler_slug'] : '';
 		$scalar_config   = is_array( $step_config['handler_config'] ?? null ) ? $step_config['handler_config'] : array();
 		$step_settings   = is_array( $step_config['flow_step_settings'] ?? null ) ? $step_config['flow_step_settings'] : array();
@@ -450,26 +450,5 @@ class FlowStepConfig {
 			}
 		}
 		return $clean;
-	}
-
-	/**
-	 * Log a handler-shape contract violation.
-	 *
-	 * @param string $message Violation message.
-	 * @param array  $step_config Step configuration array.
-	 * @return void
-	 */
-	private static function warnContractViolation( string $message, array $step_config ): void {
-		if ( function_exists( 'do_action' ) ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'FlowStepConfig handler-shape contract violation',
-				array(
-					'message'   => $message,
-					'step_type' => $step_config['step_type'] ?? '',
-				)
-			);
-		}
 	}
 }

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -38,12 +38,12 @@ class FlowStepConfigFactory {
 				),
 				self::promptQueueFromWorkflowStep( $step ),
 				array(
-					'queue_mode'       => 'static',
-					'disabled_tools'   => $step['disabled_tools'] ?? array(),
-					'pipeline_id'      => 'direct',
-					'flow_id'          => 'direct',
-					'handler_slug'     => $step['handler_slug'] ?? '',
-					'handler_config'   => $step['handler_config'] ?? array(),
+					'queue_mode'         => 'static',
+					'disabled_tools'     => $step['disabled_tools'] ?? array(),
+					'pipeline_id'        => 'direct',
+					'flow_id'            => 'direct',
+					'handler_slug'       => $step['handler_slug'] ?? '',
+					'handler_config'     => $step['handler_config'] ?? array(),
 					'flow_step_settings' => $step['flow_step_settings'] ?? array(),
 				)
 			)
@@ -106,18 +106,18 @@ class FlowStepConfigFactory {
 	public static function build( array $args ): array {
 		$step_config = array();
 		$copy_fields = array(
-			'flow_step_id'       => true,
-			'pipeline_step_id'   => true,
-			'step_type'          => true,
-			'execution_order'    => true,
-			'enabled_tools'      => true,
-			'disabled_tools'     => true,
+			'flow_step_id'                        => true,
+			'pipeline_step_id'                    => true,
+			'step_type'                           => true,
+			'execution_order'                     => true,
+			'enabled_tools'                       => true,
+			'disabled_tools'                      => true,
 			QueueAbility::SLOT_PROMPT_QUEUE       => true,
 			QueueAbility::SLOT_CONFIG_PATCH_QUEUE => true,
-			'queue_mode'         => true,
-			'pipeline_id'        => true,
-			'flow_id'            => true,
-			'handler'            => true,
+			'queue_mode'                          => true,
+			'pipeline_id'                         => true,
+			'flow_id'                             => true,
+			'handler'                             => true,
 		);
 
 		foreach ( $args as $field => $value ) {
@@ -307,7 +307,7 @@ class FlowStepConfigFactory {
 				'added_at' => $added_at ?? gmdate( 'c' ),
 			),
 		);
-		$step_config['queue_mode']   = 'static';
+		$step_config['queue_mode']                      = 'static';
 
 		return $step_config;
 	}

--- a/inc/Core/Steps/FlowStepConfigFactory.php
+++ b/inc/Core/Steps/FlowStepConfigFactory.php
@@ -44,6 +44,7 @@ class FlowStepConfigFactory {
 					'flow_id'          => 'direct',
 					'handler_slug'     => $step['handler_slug'] ?? '',
 					'handler_config'   => $step['handler_config'] ?? array(),
+					'flow_step_settings' => $step['flow_step_settings'] ?? array(),
 				)
 			)
 		);
@@ -125,10 +126,11 @@ class FlowStepConfigFactory {
 			}
 		}
 
-		$handler_slug    = $args['handler_slug'] ?? '';
-		$handler_config  = $args['handler_config'] ?? array();
-		$handler_slugs   = is_array( $args['handler_slugs'] ?? null ) ? $args['handler_slugs'] : array();
-		$handler_configs = is_array( $args['handler_configs'] ?? null ) ? $args['handler_configs'] : array();
+		$handler_slug       = $args['handler_slug'] ?? '';
+		$handler_config     = $args['handler_config'] ?? array();
+		$flow_step_settings = is_array( $args['flow_step_settings'] ?? null ) ? $args['flow_step_settings'] : array();
+		$handler_slugs      = is_array( $args['handler_slugs'] ?? null ) ? $args['handler_slugs'] : array();
+		$handler_configs    = is_array( $args['handler_configs'] ?? null ) ? $args['handler_configs'] : array();
 
 		if ( FlowStepConfig::usesHandler( $step_config ) ) {
 			if ( is_string( $handler_slug ) && '' !== $handler_slug ) {
@@ -147,8 +149,11 @@ class FlowStepConfigFactory {
 					)
 				)
 			);
-		} elseif ( ! empty( $handler_config ) ) {
-			$step_config['handler_config'] = $handler_config;
+		} else {
+			$settings = ! empty( $flow_step_settings ) ? $flow_step_settings : ( is_array( $handler_config ) ? $handler_config : array() );
+			if ( ! empty( $settings ) ) {
+				$step_config['flow_step_settings'] = $settings;
+			}
 		}
 
 		return $step_config;
@@ -206,7 +211,7 @@ class FlowStepConfigFactory {
 	 */
 	public static function withHandlerFields( array $step_config, array $handler_fields ): array {
 		$overlay = array();
-		foreach ( array( 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs' ) as $field ) {
+		foreach ( array( 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs', 'flow_step_settings' ) as $field ) {
 			if ( array_key_exists( $field, $handler_fields ) ) {
 				$overlay[ $field ] = $handler_fields[ $field ];
 			}
@@ -236,7 +241,7 @@ class FlowStepConfigFactory {
 			$existing_config = $merge ? FlowStepConfig::getPrimaryHandlerConfig( $step_config ) : array();
 			return self::withHandlerFields(
 				$step_config,
-				array( 'handler_config' => array_merge( $existing_config, $handler_config ) )
+				array( 'flow_step_settings' => array_merge( $existing_config, $handler_config ) )
 			);
 		}
 

--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -27,6 +27,7 @@ use DataMachine\Core\Steps\Step;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\JobStatus;
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
 use DataMachine\Engine\Tasks\TaskRegistry;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -229,6 +230,19 @@ class SystemTaskStep extends Step {
 		// envelope below to call executeTask(). Passthrough methods are
 		// pure declarations with no side effects.
 		$task_for_passthrough = new $handler_class();
+		if ( ! $task_for_passthrough instanceof SystemTask ) {
+			do_action(
+				'datamachine_fail_job',
+				$this->job_id,
+				'system_task_invalid_handler',
+				array(
+					'flow_step_id'  => $this->flow_step_id,
+					'task_type'     => $task_type,
+					'error_message' => 'System task handler must extend SystemTask.',
+				)
+			);
+			return array();
+		}
 
 		// Inject the standard pipeline-execution context bundle when the
 		// task declares it needs it. Replaces the per-task `if` block
@@ -248,10 +262,10 @@ class SystemTaskStep extends Step {
 		// task can read them from $params at execution time. Tasks
 		// opt in by listing key names from
 		// SystemTask::getFlowStepConfigPassthrough().
-		$fsc                  = $this->flow_step_config ?? array();
+		$fsc                   = $this->flow_step_config ?? array();
 		$flow_step_config_keys = $task_for_passthrough->getFlowStepConfigPassthrough();
 		foreach ( $flow_step_config_keys as $key ) {
-			if ( ! is_string( $key ) || '' === $key ) {
+			if ( '' === $key ) {
 				continue;
 			}
 			if ( array_key_exists( $key, $fsc ) ) {

--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -93,8 +93,8 @@ class SystemTaskStep extends Step {
 	 * @return bool
 	 */
 	protected function validateStepConfiguration(): bool {
-		$handler_config = $this->getHandlerConfig();
-		$task_type      = $handler_config['task'] ?? '';
+		$step_settings = $this->getHandlerConfig();
+		$task_type     = $step_settings['task'] ?? '';
 
 		if ( empty( $task_type ) ) {
 			do_action(
@@ -103,7 +103,7 @@ class SystemTaskStep extends Step {
 				'system_task_missing_task_type',
 				array(
 					'flow_step_id'  => $this->flow_step_id,
-					'error_message' => 'System Task step requires a task type in handler_config.',
+					'error_message' => 'System Task step requires a task type in flow_step_settings.',
 				)
 			);
 			return false;

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -199,8 +199,8 @@ abstract class SystemTask {
 	 * @param string $message Error message.
 	 */
 	protected function failJob( int $jobId, string $message ): void {
-		$jobs_db     = new Jobs();
-		$engine_data = $jobs_db->retrieve_engine_data( $jobId );
+		$jobs_db              = new Jobs();
+		$engine_data          = $jobs_db->retrieve_engine_data( $jobId );
 		$engine_data['error'] = $message;
 		$jobs_db->store_engine_data( $jobId, $engine_data );
 		$jobs_db->complete_job( $jobId, 'failed: ' . $message );
@@ -443,7 +443,7 @@ abstract class SystemTask {
 	public function undo( int $jobId, array $engineData ): array {
 		// First try effects from the job itself (backward compat for
 		// jobs that completed before the migration).
-		$effects = $engineData['effects'] ?? array();
+		$effects = is_array( $engineData['effects'] ?? null ) ? $engineData['effects'] : array();
 
 		// If no self-effects, gather from child step jobs.
 		if ( empty( $effects ) ) {
@@ -452,7 +452,7 @@ abstract class SystemTask {
 
 			foreach ( $children as $child ) {
 				$child_data    = $child['engine_data'] ?? array();
-				$child_effects = $child_data['effects'] ?? array();
+				$child_effects = is_array( $child_data['effects'] ?? null ) ? $child_data['effects'] : array();
 				$effects       = array_merge( $effects, $child_effects );
 			}
 		}
@@ -529,7 +529,7 @@ abstract class SystemTask {
 	 * Undo a single effect by dispatching to the appropriate handler.
 	 *
 	 * @param array $effect Single effect entry.
-	 * @return array{status: string, type: string, reason?: string}
+	 * @return array<string, mixed>
 	 * @since 0.33.0
 	 */
 	protected function undoEffect( array $effect ): array {
@@ -566,23 +566,44 @@ abstract class SystemTask {
 		$revision_id = $effect['revision_id'] ?? 0;
 
 		if ( $post_id <= 0 ) {
-			return array( 'status' => 'failed', 'type' => 'post_content_modified', 'reason' => 'Missing post_id' );
+			return array(
+				'status' => 'failed',
+				'type'   => 'post_content_modified',
+				'reason' => 'Missing post_id',
+			);
 		}
 		if ( $revision_id <= 0 ) {
-			return array( 'status' => 'failed', 'type' => 'post_content_modified', 'reason' => 'No revision_id' );
+			return array(
+				'status' => 'failed',
+				'type'   => 'post_content_modified',
+				'reason' => 'No revision_id',
+			);
 		}
 
 		$revision = get_post( $revision_id );
-		if ( ! $revision || 'revision' !== $revision->post_type ) {
-			return array( 'status' => 'failed', 'type' => 'post_content_modified', 'reason' => "Revision #{$revision_id} not found" );
+		if ( ! $revision instanceof \WP_Post || 'revision' !== $revision->post_type ) {
+			return array(
+				'status' => 'failed',
+				'type'   => 'post_content_modified',
+				'reason' => "Revision #{$revision_id} not found",
+			);
 		}
 
 		$restored = wp_restore_post_revision( $revision_id );
 		if ( ! $restored ) {
-			return array( 'status' => 'failed', 'type' => 'post_content_modified', 'reason' => "Failed to restore revision #{$revision_id}" );
+			return array(
+				'status' => 'failed',
+				'type'   => 'post_content_modified',
+				'reason' => "Failed to restore revision #{$revision_id}",
+			);
 		}
 
-		return array( 'status' => 'reverted', 'type' => 'post_content_modified', 'post_id' => $post_id, 'revision_id' => $revision_id );
+		return array(
+			'status'      => 'reverted',
+			'type'        => 'post_content_modified',
+			'post_id'     => $post_id,
+			'revision_id' => $revision_id,
+		);
 	}
 
 	/**
@@ -596,7 +617,11 @@ abstract class SystemTask {
 		$meta_key = $effect['target']['meta_key'] ?? '';
 
 		if ( $post_id <= 0 || empty( $meta_key ) ) {
-			return array( 'status' => 'failed', 'type' => 'post_meta_set', 'reason' => 'Missing post_id or meta_key' );
+			return array(
+				'status' => 'failed',
+				'type'   => 'post_meta_set',
+				'reason' => 'Missing post_id or meta_key',
+			);
 		}
 
 		if ( array_key_exists( 'previous_value', $effect ) && null !== $effect['previous_value'] ) {
@@ -605,7 +630,12 @@ abstract class SystemTask {
 			delete_post_meta( $post_id, $meta_key );
 		}
 
-		return array( 'status' => 'reverted', 'type' => 'post_meta_set', 'post_id' => $post_id, 'meta_key' => $meta_key );
+		return array(
+			'status'   => 'reverted',
+			'type'     => 'post_meta_set',
+			'post_id'  => $post_id,
+			'meta_key' => $meta_key,
+		);
 	}
 
 	/**
@@ -619,7 +649,11 @@ abstract class SystemTask {
 		$field   = $effect['target']['field'] ?? '';
 
 		if ( $post_id <= 0 || empty( $field ) ) {
-			return array( 'status' => 'failed', 'type' => 'post_field_set', 'reason' => 'Missing post_id or field' );
+			return array(
+				'status' => 'failed',
+				'type'   => 'post_field_set',
+				'reason' => 'Missing post_id or field',
+			);
 		}
 
 		$update = array( 'ID' => $post_id );
@@ -632,10 +666,19 @@ abstract class SystemTask {
 
 		$result = wp_update_post( $update, true );
 		if ( is_wp_error( $result ) ) {
-			return array( 'status' => 'failed', 'type' => 'post_field_set', 'reason' => $result->get_error_message() );
+			return array(
+				'status' => 'failed',
+				'type'   => 'post_field_set',
+				'reason' => $result->get_error_message(),
+			);
 		}
 
-		return array( 'status' => 'reverted', 'type' => 'post_field_set', 'post_id' => $post_id, 'field' => $field );
+		return array(
+			'status'  => 'reverted',
+			'type'    => 'post_field_set',
+			'post_id' => $post_id,
+			'field'   => $field,
+		);
 	}
 
 	/**
@@ -648,15 +691,27 @@ abstract class SystemTask {
 		$attachment_id = $effect['target']['attachment_id'] ?? 0;
 
 		if ( $attachment_id <= 0 ) {
-			return array( 'status' => 'failed', 'type' => 'attachment_created', 'reason' => 'Missing attachment_id' );
+			return array(
+				'status' => 'failed',
+				'type'   => 'attachment_created',
+				'reason' => 'Missing attachment_id',
+			);
 		}
 
 		$deleted = wp_delete_attachment( $attachment_id, true );
 		if ( ! $deleted ) {
-			return array( 'status' => 'failed', 'type' => 'attachment_created', 'reason' => "Failed to delete attachment #{$attachment_id}" );
+			return array(
+				'status' => 'failed',
+				'type'   => 'attachment_created',
+				'reason' => "Failed to delete attachment #{$attachment_id}",
+			);
 		}
 
-		return array( 'status' => 'reverted', 'type' => 'attachment_created', 'attachment_id' => $attachment_id );
+		return array(
+			'status'        => 'reverted',
+			'type'          => 'attachment_created',
+			'attachment_id' => $attachment_id,
+		);
 	}
 
 	/**
@@ -669,7 +724,11 @@ abstract class SystemTask {
 		$post_id = $effect['target']['post_id'] ?? 0;
 
 		if ( $post_id <= 0 ) {
-			return array( 'status' => 'failed', 'type' => 'featured_image_set', 'reason' => 'Missing post_id' );
+			return array(
+				'status' => 'failed',
+				'type'   => 'featured_image_set',
+				'reason' => 'Missing post_id',
+			);
 		}
 
 		$previous = $effect['previous_value'] ?? 0;
@@ -679,6 +738,10 @@ abstract class SystemTask {
 			delete_post_thumbnail( $post_id );
 		}
 
-		return array( 'status' => 'reverted', 'type' => 'featured_image_set', 'post_id' => $post_id );
+		return array(
+			'status'  => 'reverted',
+			'type'    => 'featured_image_set',
+			'post_id' => $post_id,
+		);
 	}
 }

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -67,8 +67,8 @@ abstract class SystemTask {
 		return array(
 			'steps' => array(
 				array(
-					'type'           => 'system_task',
-					'handler_config' => array(
+					'type'               => 'system_task',
+					'flow_step_settings' => array(
 						'task'   => $this->getTaskType(),
 						'params' => $params,
 					),

--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -499,9 +499,9 @@ class ImportExport {
 				'handler_slugs'   => FlowStepConfig::getHandlerSlugs( $flow_step ),
 				'handler_configs' => FlowStepConfig::getHandlerConfigs( $flow_step ),
 			);
-		} elseif ( ! FlowStepConfig::usesHandler( $flow_step ) && ! empty( $flow_step['handler_config'] ) ) {
+		} elseif ( ! FlowStepConfig::usesHandler( $flow_step ) && ! empty( FlowStepConfig::getPrimaryHandlerConfig( $flow_step ) ) ) {
 			$settings = array(
-				'handler_config' => $flow_step['handler_config'],
+				'flow_step_settings' => FlowStepConfig::getPrimaryHandlerConfig( $flow_step ),
 			);
 		}
 

--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -7,6 +7,8 @@
 
 namespace DataMachine\Engine\Bundle;
 
+use DataMachine\Core\Steps\FlowStepConfig;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -295,11 +297,14 @@ final class AgentBundleArrayAdapter {
 				'step_position'   => (int) ( $step['execution_order'] ?? count( $steps ) ),
 				'handler_configs' => self::handler_configs_from_step( $step ),
 			);
+			if ( ! FlowStepConfig::usesHandler( $step ) && ! empty( FlowStepConfig::getPrimaryHandlerConfig( $step ) ) ) {
+				$document_step['flow_step_settings'] = FlowStepConfig::getPrimaryHandlerConfig( $step );
+			}
 			if ( ! isset( $step['step_type'] ) && isset( $pipeline_step_types_by_id[ $pipeline_step_id ] ) ) {
 				$document_step['step_type'] = $pipeline_step_types_by_id[ $pipeline_step_id ];
 			}
 
-			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'handler_config', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'enabled' ) as $field ) {
+			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'enabled' ) as $field ) {
 				if ( array_key_exists( $field, $step ) ) {
 					$document_step[ $field ] = $step[ $field ];
 				}
@@ -319,7 +324,7 @@ final class AgentBundleArrayAdapter {
 			'execution_order'  => (int) $step['step_position'],
 		);
 
-		foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'enabled' ) as $field ) {
+		foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'enabled' ) as $field ) {
 			if ( array_key_exists( $field, $step ) ) {
 				$config[ $field ] = $step[ $field ];
 			}

--- a/tests/Unit/Engine/AI/System/Tasks/ImageGenerationTaskTest.php
+++ b/tests/Unit/Engine/AI/System/Tasks/ImageGenerationTaskTest.php
@@ -58,7 +58,7 @@ class ImageGenerationTaskTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'steps', $workflow );
 		$this->assertCount( 1, $workflow['steps'] );
 		$this->assertSame( 'system_task', $workflow['steps'][0]['type'] );
-		$this->assertSame( 'image_generation', $workflow['steps'][0]['handler_config']['task'] );
+		$this->assertSame( 'image_generation', $workflow['steps'][0]['flow_step_settings']['task'] );
 	}
 
 	public function test_execute_task_fails_when_image_file_missing(): void {

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -183,7 +183,7 @@ assert_adapter_equals(
 		'provider' => 'github',
 		'auth_ref' => 'github:default',
 	),
-	$flow['steps'][0]['handler_config']
+	$flow['steps'][0]['handler_configs']['mcp'] ?? null
 );
 assert_adapter_equals( 'flow document preserves step type', 'fetch', $flow['steps'][0]['step_type'] );
 assert_adapter_equals( 'flow document preserves config patch queue', array( 'after' => '2026-04-01' ), $flow['steps'][0]['config_patch_queue'][0]['patch'] ?? null );
@@ -222,7 +222,7 @@ assert_adapter_equals(
 		'auth_ref' => 'github:default',
 		'provider' => 'github',
 	),
-	$round_steps[0]['handler_config']
+	$round_steps[0]['handler_configs']['mcp'] ?? null
 );
 assert_adapter_equals( 'round-trip preserves step type', 'fetch', $round_steps[0]['step_type'] );
 assert_adapter_equals( 'round-trip preserves config patch queue', array( 'after' => '2026-04-01' ), $round_steps[0]['config_patch_queue'][0]['patch'] ?? null );

--- a/tests/import-export-portable-flow-settings-smoke.php
+++ b/tests/import-export-portable-flow-settings-smoke.php
@@ -118,8 +118,8 @@ $fetch_settings = call_import_export_private(
 	)
 );
 
-assert_csv_equals( 'webhook_payload', $fetch_settings['handler_slug'] ?? null, 'fetch handler_slug still exports', $failures, $passes );
-assert_csv_equals( array( 'payload_path' => 'pull_request' ), $fetch_settings['handler_config'] ?? null, 'fetch handler_config still exports', $failures, $passes );
+assert_csv_equals( array( 'webhook_payload' ), $fetch_settings['handler_slugs'] ?? null, 'fetch handler_slugs export', $failures, $passes );
+assert_csv_equals( array( 'payload_path' => 'pull_request' ), $fetch_settings['handler_configs']['webhook_payload'] ?? null, 'fetch handler_configs export', $failures, $passes );
 assert_csv_equals( array( 'after' => '2026-04-01' ), $fetch_settings['config_patch_queue'][0]['patch'] ?? null, 'fetch config_patch_queue exports canonical patch entry', $failures, $passes );
 assert_csv_equals( 'drain', $fetch_settings['queue_mode'] ?? null, 'fetch queue_mode exports as portable settings', $failures, $passes );
 

--- a/tests/system-run-task-params-smoke.php
+++ b/tests/system-run-task-params-smoke.php
@@ -161,8 +161,8 @@ function smoke_default_system_task_workflow( string $task_type, array $params ):
 	return array(
 		'steps' => array(
 			array(
-				'type'           => 'system_task',
-				'handler_config' => array(
+				'type'               => 'system_task',
+				'flow_step_settings' => array(
 					'task'   => $task_type,
 					'params' => $params,
 				),
@@ -226,7 +226,7 @@ $scheduled_params = array(
 $initial          = smoke_build_task_scheduler_initial_data( 'wiki_maintain', $scheduled_params );
 $assert( 'TaskScheduler initial_data stores task_params', $scheduled_params === $initial['task_params'] );
 $workflow = smoke_default_system_task_workflow( 'wiki_maintain', $initial['task_params'] );
-$assert( 'SystemTask workflow stores params in handler_config', $scheduled_params === $workflow['steps'][0]['handler_config']['params'] );
+$assert( 'SystemTask workflow stores params in flow_step_settings', $scheduled_params === $workflow['steps'][0]['flow_step_settings']['params'] );
 
 echo "\n[4] Source tripwires\n";
 $system_command = file_get_contents( __DIR__ . '/../inc/Cli/Commands/SystemCommand.php' );

--- a/tests/system-task-config-passthrough-smoke.php
+++ b/tests/system-task-config-passthrough-smoke.php
@@ -82,13 +82,13 @@ function assert_absent( string $key, array $array_value, string $name, array &$f
 echo "handler config shape smoke (#1293)\n";
 echo "-----------------------------------\n";
 
-echo "\n[1] system_task stores handler_config without synthetic slugs:\n";
+echo "\n[1] system_task stores flow_step_settings without synthetic slugs:\n";
 $built = build_configs_from_workflow_for_test(
 	array(
 		'steps' => array(
 			array(
 				'type'           => 'system_task',
-				'handler_config' => array(
+				'flow_step_settings' => array(
 					'task'   => 'daily_memory_generation',
 					'params' => array(),
 				),
@@ -101,7 +101,9 @@ assert_equals( array( 'task' => 'daily_memory_generation', 'params' => array() )
 assert_equals( 'system_task', FlowStepConfig::getEffectiveSlug( $step0 ), 'system_task settings slug is step_type', $failures, $passes );
 assert_absent( 'handler_slug', $step0, 'system_task has no handler_slug', $failures, $passes );
 assert_absent( 'handler_slugs', $step0, 'system_task has no handler_slugs', $failures, $passes );
+assert_absent( 'handler_config', $step0, 'system_task has no handler_config', $failures, $passes );
 assert_absent( 'handler_configs', $step0, 'system_task has no handler_configs', $failures, $passes );
+assert_equals( array( 'task' => 'daily_memory_generation', 'params' => array() ), $step0['flow_step_settings'] ?? array(), 'system_task stores flow_step_settings', $failures, $passes );
 
 echo "\n[2] fetch stores handler_slugs + handler_configs:\n";
 $built = build_configs_from_workflow_for_test(
@@ -175,7 +177,8 @@ $system_task = FlowStepConfig::normalizeHandlerShape(
 		'handler_config' => array( 'task' => 'agent_call' ),
 	)
 );
-assert_equals( array( 'task' => 'agent_call' ), $system_task['handler_config'] ?? array(), 'system_task config preserved', $failures, $passes );
+assert_equals( array( 'task' => 'agent_call' ), $system_task['flow_step_settings'] ?? array(), 'legacy system_task config normalizes to flow_step_settings', $failures, $passes );
+assert_absent( 'handler_config', $system_task, 'system_task scalar handler_config is removed', $failures, $passes );
 assert_absent( 'handler_slugs', $system_task, 'system_task slugs remain absent', $failures, $passes );
 
 $fetch = FlowStepConfig::normalizeHandlerShape(

--- a/tests/system-task-workflow-validation-smoke.php
+++ b/tests/system-task-workflow-validation-smoke.php
@@ -4,7 +4,7 @@
  *
  * The validator only enforces STRUCTURAL invariants — the workflow has
  * steps, each step has a registered type. Per-type config requirements
- * (handler_slug presence, handler_config shape, etc.) belong to each
+ * (handler_slug presence, flow_step_settings shape, etc.) belong to each
  * step type's own executeStep() at runtime, not here.
  *
  * Run with: php tests/system-task-workflow-validation-smoke.php
@@ -88,8 +88,8 @@ echo "\n[1] system_task workflow with no handler_slug — VALID (regression fix)
 $wf = array(
 	'steps' => array(
 		array(
-			'type'           => 'system_task',
-			'handler_config' => array(
+			'type'               => 'system_task',
+			'flow_step_settings' => array(
 				'task'   => 'daily_memory_generation',
 				'params' => array(),
 			),
@@ -145,7 +145,7 @@ $wf = array(
 	'steps' => array(
 		array( 'type' => 'fetch', 'handler_slug' => 'rss' ),
 		array( 'type' => 'ai' ),
-		array( 'type' => 'system_task', 'handler_config' => array( 'task' => 'cleanup' ) ),
+		array( 'type' => 'system_task', 'flow_step_settings' => array( 'task' => 'cleanup' ) ),
 	),
 );
 $r = validate_workflow_for_test( $wf );
@@ -183,8 +183,8 @@ echo "\n[13] real-world DailyMemoryTask workflow — VALID (the bug case)\n";
 $wf = array(
 	'steps' => array(
 		array(
-			'type'           => 'system_task',
-			'handler_config' => array(
+			'type'               => 'system_task',
+			'flow_step_settings' => array(
 				'task'   => 'daily_memory_generation',
 				'params' => array( 'date' => '2026-04-24' ),
 			),

--- a/tests/tool-policy-resolver-adjacency-smoke.php
+++ b/tests/tool-policy-resolver-adjacency-smoke.php
@@ -170,7 +170,7 @@ $args         = array(
 	'previous_step_config' => array(
 		'flow_step_id'    => 'flow_sys_1',
 		'step_type'       => 'system_task',
-		'handler_config'  => array( 'task' => 'daily_memory_generation', 'params' => array() ),
+		'flow_step_settings' => array( 'task' => 'daily_memory_generation', 'params' => array() ),
 	),
 	'next_step_config'     => null,
 );
@@ -195,7 +195,7 @@ $args         = array(
 	'next_step_config'     => array(
 		'flow_step_id'    => 'flow_sys_2',
 		'step_type'       => 'system_task',
-		'handler_config'  => array( 'task' => 'agent_call', 'params' => array() ),
+		'flow_step_settings' => array( 'task' => 'agent_call', 'params' => array() ),
 	),
 );
 $tools = gather_pipeline_handler_tools_for_test( $args, $tool_manager );

--- a/tests/workflow-spec-contract-smoke.php
+++ b/tests/workflow-spec-contract-smoke.php
@@ -140,7 +140,7 @@ $valid_workflow = array(
 	'steps' => array(
 		array( 'type' => 'fetch' ),
 		array( 'type' => 'ai' ),
-		array( 'type' => 'system_task', 'handler_config' => array( 'task' => 'daily_memory_generation' ) ),
+		array( 'type' => 'system_task', 'flow_step_settings' => array( 'task' => 'daily_memory_generation' ) ),
 	),
 );
 
@@ -166,7 +166,7 @@ $configs         = WorkflowConfigFactory::buildEphemeralConfigs(
 			array(
 				'type'           => 'system_task',
 				'label'          => 'Cleanup',
-				'handler_config' => array( 'task' => 'retention_logs' ),
+				'flow_step_settings' => array( 'task' => 'retention_logs' ),
 			),
 		),
 	)


### PR DESCRIPTION
## Summary
- Adds `flow_step_settings` as the canonical settings field for handler-free flow steps such as `system_task`.
- Stops new system task workflows, updates, exports, and bundle documents from writing handler-free `handler_config`.
- Keeps old persisted handler-free `handler_config` rows readable by normalizing them to `flow_step_settings` when rewritten.

## Testing
- `php tests/system-task-config-passthrough-smoke.php`
- `php tests/system-run-task-params-smoke.php`
- `php tests/system-task-workflow-validation-smoke.php`
- `php tests/workflow-spec-contract-smoke.php`
- `php tests/tool-policy-resolver-adjacency-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `homeboy test data-machine --force-hot -- --filter=ImageGenerationTaskTest`
- `vendor/bin/phpcs --standard=phpcs.xml.dist ...changed PHP files...`
- `git diff --check`
- `homeboy test data-machine --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and validating the flow step settings normalization; Chris remains responsible for review and final approval.