### PR TITLE
Add natural completion assertions

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -272,6 +272,7 @@ class AIStep extends Step {
 				'step_id'                     => $pipeline_step_id,
 				'data'                        => $this->dataPackets,
 				'engine'                      => $this->engine,
+				'engine_data'                 => $this->engine->all(),
 				'user_id'                     => $user_id,
 				'agent_id'                    => $agent_id,
 				'pipeline_id'                 => $job_snapshot['pipeline_id'] ?? null,
@@ -292,6 +293,14 @@ class AIStep extends Step {
 			$required_handler_slugs = FlowStepConfig::getAdjacentRequiredHandlerSlugsForAi( $previous_step_config, $next_step_config );
 
 			$engine_data = $this->engine->all();
+
+			$completion_assertions = self::mergeCompletionAssertions(
+				is_array( $pipeline_step_config['completion_assertions'] ?? null ) ? $pipeline_step_config['completion_assertions'] : array(),
+				is_array( $this->flow_step_config['completion_assertions'] ?? null ) ? $this->flow_step_config['completion_assertions'] : array()
+			);
+			if ( ! empty( $completion_assertions ) ) {
+				$payload['completion_assertions'] = $completion_assertions;
+			}
 
 			// Tool categories can be specified at the pipeline step level or pipeline level.
 			// This allows pipelines to declare which ability categories are relevant,
@@ -549,6 +558,51 @@ class AIStep extends Step {
 	 */
 	public static function sanitizeDataPacketsForAi( array $data_packets ): array {
 		return DataPacketPromptProjector::project( $data_packets );
+	}
+
+	/**
+	 * Merge pipeline-level and flow-level generic completion assertions.
+	 *
+	 * @param array $pipeline_assertions Pipeline step assertions.
+	 * @param array $flow_assertions     Flow step assertions.
+	 * @return array<string, array<int, string>> Merged assertions.
+	 */
+	private static function mergeCompletionAssertions( array $pipeline_assertions, array $flow_assertions ): array {
+		$merged = array();
+		foreach ( array( 'required_engine_data_keys', 'required_tool_names', 'required_output_packet_types' ) as $key ) {
+			$values = array_merge(
+				self::normalizeCompletionAssertionList( $pipeline_assertions[ $key ] ?? array() ),
+				self::normalizeCompletionAssertionList( $flow_assertions[ $key ] ?? array() )
+			);
+			if ( ! empty( $values ) ) {
+				$merged[ $key ] = array_values( array_unique( $values ) );
+			}
+		}
+
+		return $merged;
+	}
+
+	/**
+	 * @param mixed $value Raw assertion list.
+	 * @return array<int, string>
+	 */
+	private static function normalizeCompletionAssertionList( $value ): array {
+		if ( is_string( $value ) && '' !== $value ) {
+			$value = array( $value );
+		}
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $value as $item ) {
+			$item = trim( (string) $item );
+			if ( '' !== $item ) {
+				$items[] = $item;
+			}
+		}
+
+		return $items;
 	}
 
 	/**

--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Generic Data Machine completion assertions.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Tracks generic completion signals across a conversation run.
+ */
+class DataMachineCompletionAssertions {
+
+	/** @var array<int, string> */
+	private array $required_engine_data_keys;
+
+	/** @var array<int, string> */
+	private array $required_tool_names;
+
+	/** @var array<int, string> */
+	private array $required_output_packet_types;
+
+	/** @var array<int, string> */
+	private array $executed_tool_names = array();
+
+	/** @var array<int, string> */
+	private array $available_output_packet_types = array();
+
+	/**
+	 * @param array $config Assertion config.
+	 */
+	public function __construct( array $config = array() ) {
+		$this->required_engine_data_keys    = $this->sanitizeList( $config['required_engine_data_keys'] ?? array() );
+		$this->required_tool_names          = $this->sanitizeList( $config['required_tool_names'] ?? array() );
+		$this->required_output_packet_types = $this->sanitizeList( $config['required_output_packet_types'] ?? array() );
+	}
+
+	/**
+	 * Whether this assertion set has any active requirements.
+	 *
+	 * @return bool
+	 */
+	public function hasAssertions(): bool {
+		return ! empty( $this->required_engine_data_keys )
+			|| ! empty( $this->required_tool_names )
+			|| ! empty( $this->required_output_packet_types );
+	}
+
+	/**
+	 * Record a tool result as a possible completion signal.
+	 *
+	 * @param string     $tool_name   Tool name.
+	 * @param array|null $tool_def    Tool definition.
+	 * @param array      $tool_result Tool result.
+	 */
+	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result ): void {
+		if ( '' !== $tool_name ) {
+			$this->executed_tool_names[] = $tool_name;
+		}
+
+		$is_handler_tool = is_array( $tool_def ) && isset( $tool_def['handler'] );
+		if ( $is_handler_tool && ( $tool_result['success'] ?? false ) ) {
+			$this->available_output_packet_types[] = 'ai_handler_complete';
+			return;
+		}
+
+		$this->available_output_packet_types[] = 'tool_result';
+	}
+
+	/**
+	 * Evaluate assertions at natural completion time.
+	 *
+	 * @param array  $runtime_context Caller-owned runtime context.
+	 * @param string $assistant_text  Latest assistant text.
+	 * @return array{complete: bool, missing: array<string, array<int, string>>, satisfied: array<string, array<int, string>>}
+	 */
+	public function evaluate( array $runtime_context, string $assistant_text = '' ): array {
+		if ( ! $this->hasAssertions() ) {
+			return array(
+				'complete'  => true,
+				'missing'   => array(),
+				'satisfied' => array(),
+			);
+		}
+
+		$output_packet_types = array_unique( $this->available_output_packet_types );
+		if ( empty( $output_packet_types ) && '' !== trim( $assistant_text ) ) {
+			$output_packet_types[] = 'ai_response';
+		}
+
+		$satisfied = array(
+			'engine_data_keys'    => $this->satisfiedEngineDataKeys( $runtime_context ),
+			'tool_names'          => array_values( array_intersect( $this->required_tool_names, array_unique( $this->executed_tool_names ) ) ),
+			'output_packet_types' => array_values( array_intersect( $this->required_output_packet_types, $output_packet_types ) ),
+		);
+
+		$missing = array_filter(
+			array(
+				'engine_data_keys'    => array_values( array_diff( $this->required_engine_data_keys, $satisfied['engine_data_keys'] ) ),
+				'tool_names'          => array_values( array_diff( $this->required_tool_names, $satisfied['tool_names'] ) ),
+				'output_packet_types' => array_values( array_diff( $this->required_output_packet_types, $satisfied['output_packet_types'] ) ),
+			)
+		);
+
+		return array(
+			'complete'  => empty( $missing ),
+			'missing'   => $missing,
+			'satisfied' => array_filter( $satisfied ),
+		);
+	}
+
+	/**
+	 * Build a positive nudge for missing completion signals.
+	 *
+	 * @param array $missing Missing assertions grouped by type.
+	 * @param array $messages Current conversation messages.
+	 * @return string Nudge message.
+	 */
+	public static function buildNudge( array $missing, array $messages ): string {
+		$parts = array();
+		foreach ( $missing as $type => $values ) {
+			if ( ! is_array( $values ) || empty( $values ) ) {
+				continue;
+			}
+			$label   = str_replace( '_', ' ', (string) $type );
+			$parts[] = $label . ': ' . implode( ', ', array_map( 'strval', $values ) );
+		}
+
+		$goal = self::extractGoal( $messages );
+		$nudge = 'Please continue. The work is close, but these completion signals are still missing: ' . implode( '; ', $parts ) . '.';
+		if ( '' !== $goal ) {
+			$nudge .= ' Original goal/context: ' . $goal;
+		}
+		$nudge .= ' Use the available tools as needed, then only finish once those signals are present.';
+
+		return $nudge;
+	}
+
+	/**
+	 * Return required assertion config for diagnostics.
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	public function required(): array {
+		return array_filter(
+			array(
+				'engine_data_keys'    => $this->required_engine_data_keys,
+				'tool_names'          => $this->required_tool_names,
+				'output_packet_types' => $this->required_output_packet_types,
+			)
+		);
+	}
+
+	/**
+	 * @param mixed $value Raw list.
+	 * @return array<int, string>
+	 */
+	private function sanitizeList( $value ): array {
+		if ( is_string( $value ) && '' !== $value ) {
+			$value = array( $value );
+		}
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $value as $item ) {
+			$item = trim( (string) $item );
+			if ( '' !== $item ) {
+				$items[] = $item;
+			}
+		}
+
+		return array_values( array_unique( $items ) );
+	}
+
+	/**
+	 * @param array $runtime_context Caller-owned runtime context.
+	 * @return array<int, string>
+	 */
+	private function satisfiedEngineDataKeys( array $runtime_context ): array {
+		$engine = $runtime_context['engine'] ?? null;
+		$data   = is_array( $runtime_context['engine_data'] ?? null ) ? $runtime_context['engine_data'] : array();
+
+		if ( is_object( $engine ) && method_exists( $engine, 'all' ) ) {
+			$engine_data = $engine->all();
+			if ( is_array( $engine_data ) ) {
+				$data = $engine_data;
+			}
+		}
+
+		$satisfied = array();
+		foreach ( $this->required_engine_data_keys as $key ) {
+			if ( array_key_exists( $key, $data ) && null !== $data[ $key ] && '' !== $data[ $key ] && array() !== $data[ $key ] ) {
+				$satisfied[] = $key;
+				continue;
+			}
+
+			if ( is_object( $engine ) && method_exists( $engine, 'get' ) ) {
+				$value = $engine->get( $key );
+				if ( null !== $value && '' !== $value && array() !== $value ) {
+					$satisfied[] = $key;
+				}
+			}
+		}
+
+		return array_values( array_unique( $satisfied ) );
+	}
+
+	/**
+	 * @param array $messages Current messages.
+	 * @return string Extracted goal/context.
+	 */
+	private static function extractGoal( array $messages ): string {
+		foreach ( $messages as $message ) {
+			if ( 'user' !== ( $message['role'] ?? '' ) ) {
+				continue;
+			}
+
+			$content = $message['content'] ?? '';
+			if ( is_array( $content ) ) {
+				$content = wp_json_encode( $content );
+			}
+
+			$content = trim( (string) $content );
+			if ( '' === $content ) {
+				continue;
+			}
+
+			return strlen( $content ) > 300 ? substr( $content, 0, 297 ) . '...' : $content;
+		}
+
+		return '';
+	}
+}

--- a/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
+++ b/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Preserves pipeline handler completion behavior outside the generic turn loop.
  */
-class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Completion_Policy {
+class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Completion_Policy, NaturalCompletionPolicyInterface {
 
 	/** @var array Required handler slugs configured by the adjacent pipeline step. */
 	private array $configured_handlers;
@@ -23,17 +23,24 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 	/** @var array Handler slugs that have completed successfully. */
 	private array $executed_handler_slugs = array();
 
+	/** @var DataMachineCompletionAssertions Generic completion assertions. */
+	private DataMachineCompletionAssertions $assertions;
+
 	/**
-	 * @param array $configured_handlers Required handler slugs.
+	 * @param array                                $configured_handlers Required handler slugs.
+	 * @param DataMachineCompletionAssertions|null $assertions          Optional generic assertions.
 	 */
-	public function __construct( array $configured_handlers = array() ) {
+	public function __construct( array $configured_handlers = array(), ?DataMachineCompletionAssertions $assertions = null ) {
 		$this->configured_handlers = array_values( $configured_handlers );
+		$this->assertions          = $assertions ?? new DataMachineCompletionAssertions();
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, array $runtime_context, int $turn_count ): WP_Agent_Conversation_Completion_Decision {
+		$this->assertions->recordToolResult( $tool_name, $tool_def, $tool_result );
+
 		$is_handler_tool = is_array( $tool_def ) && isset( $tool_def['handler'] );
 		$mode            = (string) ( $runtime_context['mode'] ?? '' );
 
@@ -74,6 +81,33 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 			array(
 				'tool_name'          => $tool_name,
 				'remaining_handlers' => array_values( $remaining ),
+			)
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function recordNaturalCompletion( array $messages, string $assistant_text, array $runtime_context, int $turn_count ): WP_Agent_Conversation_Completion_Decision {
+		$evaluation = $this->assertions->evaluate( $runtime_context, $assistant_text );
+		if ( $evaluation['complete'] ) {
+			return WP_Agent_Conversation_Completion_Decision::complete(
+				$this->assertions->hasAssertions() ? 'AIConversationLoop: Natural completion assertions satisfied' : '',
+				array(
+					'turn_count' => $turn_count,
+					'satisfied'  => $evaluation['satisfied'],
+				)
+			);
+		}
+
+		return WP_Agent_Conversation_Completion_Decision::incomplete(
+			'AIConversationLoop: Natural completion assertions missing, nudging continuation',
+			array(
+				'turn_count'           => $turn_count,
+				'missing'              => $evaluation['missing'],
+				'satisfied'            => $evaluation['satisfied'],
+				'required'             => $this->assertions->required(),
+				'continuation_message' => DataMachineCompletionAssertions::buildNudge( $evaluation['missing'], $messages ),
 			)
 		);
 	}

--- a/inc/Engine/AI/DefaultAgentConversationCompletionPolicy.php
+++ b/inc/Engine/AI/DefaultAgentConversationCompletionPolicy.php
@@ -15,14 +15,53 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Generic policy: tool calls alone do not complete the loop.
  */
-class DefaultAgentConversationCompletionPolicy implements WP_Agent_Conversation_Completion_Policy {
+class DefaultAgentConversationCompletionPolicy implements WP_Agent_Conversation_Completion_Policy, NaturalCompletionPolicyInterface {
+
+	/** @var DataMachineCompletionAssertions Generic completion assertions. */
+	private DataMachineCompletionAssertions $assertions;
+
+	/**
+	 * @param DataMachineCompletionAssertions|null $assertions Optional completion assertions.
+	 */
+	public function __construct( ?DataMachineCompletionAssertions $assertions = null ) {
+		$this->assertions = $assertions ?? new DataMachineCompletionAssertions();
+	}
 
 	/**
 	 * @inheritDoc
 	 */
 	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, array $runtime_context, int $turn_count ): WP_Agent_Conversation_Completion_Decision {
-		unset( $tool_name, $tool_def, $tool_result, $runtime_context, $turn_count );
+		unset( $runtime_context, $turn_count );
+
+		$this->assertions->recordToolResult( $tool_name, $tool_def, $tool_result );
 
 		return WP_Agent_Conversation_Completion_Decision::incomplete();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function recordNaturalCompletion( array $messages, string $assistant_text, array $runtime_context, int $turn_count ): WP_Agent_Conversation_Completion_Decision {
+		$evaluation = $this->assertions->evaluate( $runtime_context, $assistant_text );
+		if ( $evaluation['complete'] ) {
+			return WP_Agent_Conversation_Completion_Decision::complete(
+				$this->assertions->hasAssertions() ? 'AIConversationLoop: Natural completion assertions satisfied' : '',
+				array(
+					'turn_count' => $turn_count,
+					'satisfied'  => $evaluation['satisfied'],
+				)
+			);
+		}
+
+		return WP_Agent_Conversation_Completion_Decision::incomplete(
+			'AIConversationLoop: Natural completion assertions missing, nudging continuation',
+			array(
+				'turn_count'           => $turn_count,
+				'missing'              => $evaluation['missing'],
+				'satisfied'            => $evaluation['satisfied'],
+				'required'             => $this->assertions->required(),
+				'continuation_message' => DataMachineCompletionAssertions::buildNudge( $evaluation['missing'], $messages ),
+			)
+		);
 	}
 }

--- a/inc/Engine/AI/NaturalCompletionPolicyInterface.php
+++ b/inc/Engine/AI/NaturalCompletionPolicyInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Data Machine natural completion policy extension.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+use AgentsAPI\AI\WP_Agent_Conversation_Completion_Decision;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Optional extension point for policies that need to inspect no-tool completion.
+ */
+interface NaturalCompletionPolicyInterface {
+
+	/**
+	 * Decide whether a no-tool assistant response may naturally complete the run.
+	 *
+	 * @param array  $messages        Current conversation messages.
+	 * @param string $assistant_text  Latest assistant text.
+	 * @param array  $runtime_context Caller-owned runtime context.
+	 * @param int    $turn_count      Current turn count.
+	 * @return WP_Agent_Conversation_Completion_Decision Completion decision.
+	 */
+	public function recordNaturalCompletion( array $messages, string $assistant_text, array $runtime_context, int $turn_count ): WP_Agent_Conversation_Completion_Decision;
+}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -126,7 +126,7 @@ function datamachine_run_conversation(
 		if ( ! empty( $result['conversation_complete'] ) ) {
 			return false;
 		}
-		return ! empty( $result['tool_execution_results'] );
+		return ! empty( $result['tool_execution_results'] ) || ! empty( $result['completion_nudge'] );
 	};
 
 	// Run through the upstream substrate loop.
@@ -470,13 +470,41 @@ function datamachine_build_turn_runner(
 				}
 			}
 		} else {
-			$conversation_complete = true;
+			$natural_completion_decision = $completion_policy instanceof NaturalCompletionPolicyInterface
+				? $completion_policy->recordNaturalCompletion(
+					$messages,
+					$ai_content,
+					array_merge( $turn_context, $loop_payload, array( 'mode' => $mode ) ),
+					$turn_count
+				)
+				: \AgentsAPI\AI\WP_Agent_Conversation_Completion_Decision::complete();
+
+			$conversation_complete = $natural_completion_decision->isComplete();
+			$completion_nudge      = '';
+
+			if ( '' !== $natural_completion_decision->message() ) {
+				do_action(
+					'datamachine_log',
+					'debug',
+					$natural_completion_decision->message(),
+					array_merge( $base_log_context, $natural_completion_decision->context() )
+				);
+			}
+
+			if ( ! $conversation_complete ) {
+				$completion_nudge = (string) ( $natural_completion_decision->context()['continuation_message'] ?? '' );
+				if ( '' !== $completion_nudge ) {
+					$messages[] = ConversationManager::buildConversationMessage( 'user', $completion_nudge );
+					do_action( 'datamachine_ai_completion_nudge_added', $mode, $messages, $loop_payload, $natural_completion_decision->context() );
+				}
+			}
 		}
 
 		return array(
 			'messages'               => $messages,
 			'tool_execution_results' => $tool_execution_results,
 			'conversation_complete'  => $conversation_complete,
+			'completion_nudge'       => $completion_nudge ?? '',
 		);
 	};
 }
@@ -556,14 +584,27 @@ function datamachine_resolve_completion_policy( string $mode, array $payload ): 
 		return $policy;
 	}
 
+	$assertions = datamachine_resolve_completion_assertions( $payload );
+
 	$configured_handlers = $payload['configured_handler_slugs'] ?? array();
 	$configured_handlers = is_array( $configured_handlers ) ? array_values( $configured_handlers ) : array();
 
 	if ( ! empty( $configured_handlers ) || 'pipeline' === $mode ) {
-		return new DataMachineHandlerCompletionPolicy( $configured_handlers );
+		return new DataMachineHandlerCompletionPolicy( $configured_handlers, $assertions );
 	}
 
-	return new DefaultAgentConversationCompletionPolicy();
+	return new DefaultAgentConversationCompletionPolicy( $assertions );
+}
+
+/**
+ * Resolve generic completion assertions from loop payload.
+ *
+ * @param array $payload Loop payload.
+ * @return DataMachineCompletionAssertions
+ */
+function datamachine_resolve_completion_assertions( array $payload ): DataMachineCompletionAssertions {
+	$config = $payload['completion_assertions'] ?? array();
+	return new DataMachineCompletionAssertions( is_array( $config ) ? $config : array() );
 }
 
 /**

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -167,6 +167,142 @@ assert_runtime_policy( $second_decision->isComplete(), 'handler policy completes
 assert_runtime_policy( array( 'wordpress_publish', 'pinterest_publish' ) === array_values( $second_decision->context()['executed_handlers'] ?? array() ), 'handler policy reports executed handlers' );
 
 // 2. Injected completion/transcript collaborators steer the loop without leaking into provider payloads.
+$natural_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$natural_dispatch_count ) {
+		++$natural_dispatch_count;
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'Natural answer with no tool calls.',
+				'tool_calls' => array(),
+			),
+		);
+	}
+);
+
+$natural_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'answer naturally' ) ),
+	array(),
+	'openai',
+	'gpt-smoke',
+	'chat',
+	array(),
+	5
+);
+
+assert_runtime_policy( 1 === $natural_dispatch_count, 'default no-tool response completes naturally' );
+assert_runtime_policy( ! empty( $natural_result['completed'] ), 'default natural completion result is completed' );
+
+$satisfied_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$satisfied_dispatch_count ) {
+		++$satisfied_dispatch_count;
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'The required engine data is already present.',
+				'tool_calls' => array(),
+			),
+		);
+	}
+);
+
+$satisfied_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'finish once final_url exists' ) ),
+	array(),
+	'openai',
+	'gpt-smoke',
+	'chat',
+	array(
+		'completion_assertions' => array(
+			'required_engine_data_keys' => array( 'final_url' ),
+		),
+		'engine_data'           => array(
+			'final_url' => 'https://example.test/post',
+		),
+	),
+	5
+);
+
+assert_runtime_policy( 1 === $satisfied_dispatch_count, 'satisfied natural assertion completes without nudge' );
+assert_runtime_policy( ! empty( $satisfied_result['completed'] ), 'satisfied natural assertion result is completed' );
+
+$nudge_dispatch_count = 0;
+$nudge_second_request = null;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function ( array $request_body ) use ( &$nudge_dispatch_count, &$nudge_second_request ) {
+		++$nudge_dispatch_count;
+		if ( 2 === $nudge_dispatch_count ) {
+			$nudge_second_request = $request_body;
+		}
+
+		if ( 1 === $nudge_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => 'I am done prematurely.',
+					'tool_calls' => array(),
+				),
+			);
+		}
+
+		if ( 2 === $nudge_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'name'       => 'runtime_policy_tool',
+							'parameters' => array( 'name' => 'Grace' ),
+						),
+					),
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'Now complete after the required tool.',
+				'tool_calls' => array(),
+			),
+		);
+	}
+);
+
+$nudge_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'use the runtime policy tool before finishing' ) ),
+	array(
+		'runtime_policy_tool' => array(
+			'name'        => 'runtime_policy_tool',
+			'description' => 'Runtime policy smoke tool',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	'chat',
+	array(
+		'completion_assertions' => array(
+			'required_tool_names' => array( 'runtime_policy_tool' ),
+		),
+	),
+	5
+);
+
+assert_runtime_policy( 3 === $nudge_dispatch_count, 'missing natural assertion nudges and keeps loop running' );
+assert_runtime_policy( str_contains( wp_json_encode( $nudge_second_request ), 'completion signals are still missing' ), 'nudge is appended before retry request' );
+assert_runtime_policy( 1 === count( $nudge_result['tool_execution_results'] ?? array() ), 'nudged loop captures required tool result' );
+
 $dispatch_count     = 0;
 $provider_context   = null;
 $completion_policy  = new RuntimePolicySmokeCompletionPolicy();


### PR DESCRIPTION
## Summary
- Add Data Machine natural-completion assertion support that evaluates no-tool assistant responses before allowing natural completion.
- Support generic assertions for required engine-data keys, required tool names, and required output packet types, with pipeline-step and flow-step config merging under `completion_assertions`.
- Preserve existing handler completion behavior while adding positive continuation nudges when configured assertions are missing.

Fixes #1855

## Testing
- `php -l inc/Engine/AI/conversation-loop.php && php -l inc/Engine/AI/DefaultAgentConversationCompletionPolicy.php && php -l inc/Engine/AI/DataMachineHandlerCompletionPolicy.php && php -l inc/Engine/AI/DataMachineCompletionAssertions.php && php -l inc/Engine/AI/NaturalCompletionPolicyInterface.php && php -l inc/Core/Steps/AI/AIStep.php && php -l tests/agent-conversation-runtime-policy-smoke.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `composer lint`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the completion assertion/nudge mechanism, updated focused smoke coverage, and ran local verification; Chris remains responsible for review and merge.