### PR TITLE
fix: continue after handler setup tools

### DIFF
--- a/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
+++ b/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
@@ -54,6 +54,11 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 		}
 
 		if ( empty( $this->configured_handlers ) ) {
+			$missing_assertions = $this->incompleteAssertionsDecision( $runtime_context, $turn_count );
+			if ( null !== $missing_assertions ) {
+				return $missing_assertions;
+			}
+
 			return WP_Agent_Conversation_Completion_Decision::complete(
 				'AIConversationLoop: Handler tool executed without configured handler list, ending conversation',
 				array(
@@ -65,6 +70,11 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 
 		$remaining = array_diff( $this->configured_handlers, array_unique( $this->executed_handler_slugs ) );
 		if ( empty( $remaining ) ) {
+			$missing_assertions = $this->incompleteAssertionsDecision( $runtime_context, $turn_count );
+			if ( null !== $missing_assertions ) {
+				return $missing_assertions;
+			}
+
 			return WP_Agent_Conversation_Completion_Decision::complete(
 				'AIConversationLoop: All configured handlers executed, ending conversation',
 				array(
@@ -108,6 +118,36 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 				'satisfied'            => $evaluation['satisfied'],
 				'required'             => $this->assertions->required(),
 				'continuation_message' => DataMachineCompletionAssertions::buildNudge( $evaluation['missing'], $messages ),
+			)
+		);
+	}
+
+	/**
+	 * Keep handler-style tools from ending a run before generic completion
+	 * assertions are satisfied.
+	 *
+	 * @param array $runtime_context Caller-owned runtime context.
+	 * @param int   $turn_count      Current turn count.
+	 * @return WP_Agent_Conversation_Completion_Decision|null
+	 */
+	private function incompleteAssertionsDecision( array $runtime_context, int $turn_count ): ?WP_Agent_Conversation_Completion_Decision {
+		if ( ! $this->assertions->hasAssertions() ) {
+			return null;
+		}
+
+		$evaluation = $this->assertions->evaluate( $runtime_context );
+		if ( $evaluation['complete'] ) {
+			return null;
+		}
+
+		return WP_Agent_Conversation_Completion_Decision::incomplete(
+			'AIConversationLoop: Handler completion assertions missing, nudging continuation',
+			array(
+				'turn_count'           => $turn_count,
+				'missing'              => $evaluation['missing'],
+				'satisfied'            => $evaluation['satisfied'],
+				'required'             => $this->assertions->required(),
+				'continuation_message' => DataMachineCompletionAssertions::buildNudge( $evaluation['missing'], array() ),
 			)
 		);
 	}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -344,6 +344,7 @@ function datamachine_build_turn_runner(
 		// Process tool calls.
 		$tool_execution_results = array();
 		$conversation_complete  = false;
+		$completion_nudge      = '';
 		if ( ! empty( $tool_calls ) ) {
 			foreach ( $tool_calls as $tool_call ) {
 				$tool_name       = $tool_call['name'];
@@ -464,10 +465,19 @@ function datamachine_build_turn_runner(
 					$turn_count
 				);
 
+				if ( ! $conversation_complete && '' === $completion_nudge ) {
+					$completion_nudge = (string) ( $completion_decision->context()['continuation_message'] ?? '' );
+				}
+
 				// Break out of tool processing when conversation is complete.
 				if ( $conversation_complete ) {
 					break;
 				}
+			}
+
+			if ( '' !== $completion_nudge ) {
+				$messages[] = ConversationManager::buildConversationMessage( 'user', $completion_nudge );
+				do_action( 'datamachine_ai_completion_nudge_added', $mode, $messages, $loop_payload, array( 'continuation_message' => $completion_nudge ) );
 			}
 		} else {
 			$natural_completion_decision = $completion_policy instanceof NaturalCompletionPolicyInterface

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -303,6 +303,25 @@ assert_runtime_policy( 3 === $nudge_dispatch_count, 'missing natural assertion n
 assert_runtime_policy( str_contains( wp_json_encode( $nudge_second_request ), 'completion signals are still missing' ), 'nudge is appended before retry request' );
 assert_runtime_policy( 1 === count( $nudge_result['tool_execution_results'] ?? array() ), 'nudged loop captures required tool result' );
 
+$assertion_policy = new DataMachineHandlerCompletionPolicy(
+	array(),
+	new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
+		array(
+			'required_tool_names' => array( 'create_github_pull_request', 'comment_github_pull_request' ),
+		)
+	)
+);
+$assertion_decision = $assertion_policy->recordToolResult(
+	'workspace_read',
+	array( 'handler' => 'workspace_read' ),
+	array( 'success' => true ),
+	array( 'mode' => 'pipeline' ),
+	1
+);
+
+assert_runtime_policy( ! $assertion_decision->isComplete(), 'handler policy waits when generic assertions are missing' );
+assert_runtime_policy( str_contains( $assertion_decision->context()['continuation_message'] ?? '', 'completion signals are still missing' ), 'handler policy provides assertion continuation nudge' );
+
 $dispatch_count     = 0;
 $provider_context   = null;
 $completion_policy  = new RuntimePolicySmokeCompletionPolicy();


### PR DESCRIPTION
## Summary
- Prevents pipeline handler-style tools from completing an AI step while generic `completion_assertions` are still missing.
- Carries handler-generated continuation nudges back into the conversation so setup/read/status tools can lead to the required follow-up actions.
- Adds smoke coverage for handler tools waiting on required PR/comment completion assertions.

## Verification
- `php -l inc/Engine/AI/conversation-loop.php && php -l inc/Engine/AI/DataMachineHandlerCompletionPolicy.php && php -l tests/agent-conversation-runtime-policy-smoke.php`
- `composer install`
- `php tests/agent-conversation-runtime-policy-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the iterator continuation failure, drafted the completion-policy fix and smoke coverage, and ran local validation; Chris remains responsible for review and merge.