### PR TITLE
Add completion nudge observability

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -357,7 +357,7 @@ function datamachine_build_turn_runner(
 		// Process tool calls.
 		$tool_execution_results = array();
 		$conversation_complete  = false;
-		$completion_nudge      = '';
+		$completion_nudge       = '';
 		if ( ! empty( $tool_calls ) ) {
 			foreach ( $tool_calls as $tool_call ) {
 				$tool_name       = $tool_call['name'];
@@ -572,7 +572,7 @@ function datamachine_record_completion_nudge(
 	array $decision_context,
 	int $turn_count
 ): void {
-	$diagnostic = datamachine_completion_nudge_diagnostic( $decision_context, $turn_count, count( $completion_nudges ) + 1 );
+	$diagnostic          = datamachine_completion_nudge_diagnostic( $decision_context, $turn_count, count( $completion_nudges ) + 1 );
 	$completion_nudges[] = $diagnostic;
 
 	$event_payload = array_merge(

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -73,6 +73,7 @@ function datamachine_run_conversation(
 	$last_tool_calls       = array();
 	$final_content         = '';
 	$turns_run             = 0;
+	$completion_nudges     = array();
 	$total_usage           = array(
 		'prompt_tokens'     => 0,
 		'completion_tokens' => 0,
@@ -111,6 +112,7 @@ function datamachine_run_conversation(
 		$last_tool_calls,
 		$final_content,
 		$turns_run,
+		$completion_nudges,
 		$total_usage
 	);
 
@@ -198,6 +200,14 @@ function datamachine_run_conversation(
 	$result['turn_count']       = $turns_run;
 	$result['completed']        = 'budget_exceeded' !== ( $result['status'] ?? '' );
 	$result['last_tool_calls']  = $last_tool_calls;
+	if ( ! empty( $completion_nudges ) ) {
+		$latest_nudge                              = $completion_nudges[ count( $completion_nudges ) - 1 ];
+		$result['completion_nudge_count']          = count( $completion_nudges );
+		$result['completion_nudge']                = $latest_nudge['completion_nudge'] ?? '';
+		$result['completion_assertions_required']  = $latest_nudge['completion_assertions_required'] ?? array();
+		$result['completion_assertions_missing']   = $latest_nudge['completion_assertions_missing'] ?? array();
+		$result['completion_assertions_satisfied'] = $latest_nudge['completion_assertions_satisfied'] ?? array();
+	}
 
 	// Map upstream budget_exceeded status to DM's max_turns_reached flag
 	// for backward compatibility with ChatOrchestrator response shaping.
@@ -233,6 +243,7 @@ function datamachine_run_conversation(
  * @param array                                           &$last_tool_calls        Mutable last tool calls.
  * @param string                                          &$final_content          Mutable final assistant content.
  * @param int                                             &$turns_run              Mutable executed turn count.
+ * @param array                                           &$completion_nudges      Mutable nudge diagnostics.
  * @param array                                           &$total_usage           Mutable usage accumulator.
  * @return callable Turn runner closure.
  */
@@ -249,6 +260,7 @@ function datamachine_build_turn_runner(
 	array &$last_tool_calls,
 	string &$final_content,
 	int &$turns_run,
+	array &$completion_nudges,
 	array &$total_usage
 ): callable {
 	return static function ( array $messages, array $turn_context ) use (
@@ -264,6 +276,7 @@ function datamachine_build_turn_runner(
 		&$last_tool_calls,
 		&$final_content,
 		&$turns_run,
+		&$completion_nudges,
 		&$total_usage
 	): array {
 		// The upstream loop provides the turn number via turn_context.
@@ -435,7 +448,7 @@ function datamachine_build_turn_runner(
 					$tool_name,
 					is_array( $tool_def ) ? $tool_def : null,
 					$tool_result,
-					array_merge( $turn_context, array( 'mode' => $mode ) ),
+					array_merge( $turn_context, $loop_payload, array( 'mode' => $mode ) ),
 					$turn_count
 				);
 				$conversation_complete = $completion_decision->isComplete();
@@ -477,7 +490,16 @@ function datamachine_build_turn_runner(
 
 			if ( '' !== $completion_nudge ) {
 				$messages[] = ConversationManager::buildConversationMessage( 'user', $completion_nudge );
-				do_action( 'datamachine_ai_completion_nudge_added', $mode, $messages, $loop_payload, array( 'continuation_message' => $completion_nudge ) );
+				datamachine_record_completion_nudge(
+					$completion_nudges,
+					$event_sink,
+					$base_log_context,
+					$mode,
+					$messages,
+					$loop_payload,
+					array_merge( $completion_decision->context(), array( 'continuation_message' => $completion_nudge ) ),
+					$turn_count
+				);
 			}
 		} else {
 			$natural_completion_decision = $completion_policy instanceof NaturalCompletionPolicyInterface
@@ -505,7 +527,16 @@ function datamachine_build_turn_runner(
 				$completion_nudge = (string) ( $natural_completion_decision->context()['continuation_message'] ?? '' );
 				if ( '' !== $completion_nudge ) {
 					$messages[] = ConversationManager::buildConversationMessage( 'user', $completion_nudge );
-					do_action( 'datamachine_ai_completion_nudge_added', $mode, $messages, $loop_payload, $natural_completion_decision->context() );
+					datamachine_record_completion_nudge(
+						$completion_nudges,
+						$event_sink,
+						$base_log_context,
+						$mode,
+						$messages,
+						$loop_payload,
+						$natural_completion_decision->context(),
+						$turn_count
+					);
 				}
 			}
 		}
@@ -517,6 +548,83 @@ function datamachine_build_turn_runner(
 			'completion_nudge'       => $completion_nudge ?? '',
 		);
 	};
+}
+
+/**
+ * Record completion nudge diagnostics for events, transcripts, and job probes.
+ *
+ * @param array                  $completion_nudges Mutable nudge diagnostics.
+ * @param LoopEventSinkInterface $event_sink        Event sink.
+ * @param array                  $base_log_context  Base log context.
+ * @param string                 $mode              Runtime mode.
+ * @param array                  $messages          Current conversation messages.
+ * @param array                  $loop_payload      Loop payload.
+ * @param array                  $decision_context  Completion decision context.
+ * @param int                    $turn_count        Current turn count.
+ */
+function datamachine_record_completion_nudge(
+	array &$completion_nudges,
+	LoopEventSinkInterface $event_sink,
+	array $base_log_context,
+	string $mode,
+	array $messages,
+	array $loop_payload,
+	array $decision_context,
+	int $turn_count
+): void {
+	$diagnostic = datamachine_completion_nudge_diagnostic( $decision_context, $turn_count, count( $completion_nudges ) + 1 );
+	$completion_nudges[] = $diagnostic;
+
+	$event_payload = array_merge(
+		$base_log_context,
+		$diagnostic,
+		array(
+			'mode'          => $mode,
+			'message_count' => count( $messages ),
+		)
+	);
+
+	datamachine_emit_loop_event( $event_sink, 'completion_nudge_added', $event_payload );
+	do_action( 'datamachine_ai_completion_nudge_added', $mode, $messages, $loop_payload, $event_payload );
+
+	$job_id = (int) ( $loop_payload['job_id'] ?? 0 );
+	if ( $job_id > 0 && function_exists( '\datamachine_merge_engine_data' ) ) {
+		\datamachine_merge_engine_data(
+			$job_id,
+			array(
+				'completion_nudge_count'          => $diagnostic['completion_nudge_count'],
+				'completion_nudge'                => $diagnostic['completion_nudge'],
+				'completion_assertions_required'  => $diagnostic['completion_assertions_required'],
+				'completion_assertions_missing'   => $diagnostic['completion_assertions_missing'],
+				'completion_assertions_satisfied' => $diagnostic['completion_assertions_satisfied'],
+				'completion_nudge_last_turn'      => $turn_count,
+			)
+		);
+	}
+}
+
+/**
+ * Build a bounded completion nudge diagnostic payload.
+ *
+ * @param array $decision_context Completion decision context.
+ * @param int   $turn_count       Current turn count.
+ * @param int   $nudge_count      Nudge count.
+ * @return array<string, mixed>
+ */
+function datamachine_completion_nudge_diagnostic( array $decision_context, int $turn_count, int $nudge_count ): array {
+	$completion_nudge = (string) ( $decision_context['continuation_message'] ?? '' );
+	if ( strlen( $completion_nudge ) > 2000 ) {
+		$completion_nudge = substr( $completion_nudge, 0, 1997 ) . '...';
+	}
+
+	return array(
+		'completion_nudge_count'          => $nudge_count,
+		'completion_nudge'                => $completion_nudge,
+		'completion_assertions_required'  => is_array( $decision_context['required'] ?? null ) ? $decision_context['required'] : array(),
+		'completion_assertions_missing'   => is_array( $decision_context['missing'] ?? null ) ? $decision_context['missing'] : array(),
+		'completion_assertions_satisfied' => is_array( $decision_context['satisfied'] ?? null ) ? $decision_context['satisfied'] : array(),
+		'completion_nudge_turn'           => $turn_count,
+	);
 }
 
 /**

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 $GLOBALS['datamachine_runtime_policy_filters'] = array();
 $GLOBALS['datamachine_runtime_policy_logs']    = array();
+$GLOBALS['datamachine_runtime_engine_merges']  = array();
 
 if ( ! function_exists( 'add_filter' ) ) {
 	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
@@ -41,6 +42,13 @@ if ( ! function_exists( 'do_action' ) ) {
 	}
 }
 
+if ( ! function_exists( 'datamachine_merge_engine_data' ) ) {
+	function datamachine_merge_engine_data( int $job_id, array $data ): bool {
+		$GLOBALS['datamachine_runtime_engine_merges'][ $job_id ][] = $data;
+		return true;
+	}
+}
+
 if ( ! function_exists( 'wp_json_encode' ) ) {
 	function wp_json_encode( $data, int $flags = 0 ) {
 		return json_encode( $data, $flags );
@@ -67,6 +75,7 @@ use AgentsAPI\AI\WP_Agent_Conversation_Completion_Policy;
 use AgentsAPI\AI\WP_Agent_Conversation_Request;
 use AgentsAPI\AI\WP_Agent_Transcript_Persister;
 use DataMachine\Engine\AI\DataMachineHandlerCompletionPolicy;
+use DataMachine\Engine\AI\LoopEventSinkInterface;
 use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 
 use function DataMachine\Engine\AI\datamachine_run_conversation;
@@ -96,6 +105,14 @@ class RuntimePolicySmokeTranscriptPersister implements WP_Agent_Transcript_Persi
 		$this->calls[] = compact( 'messages', 'provider', 'model', 'payload', 'result' );
 
 		return 'runtime-policy-transcript';
+	}
+}
+
+class RuntimePolicySmokeEventSink implements LoopEventSinkInterface {
+	public array $events = array();
+
+	public function emit( string $event, array $payload = array() ): void {
+		$this->events[] = compact( 'event', 'payload' );
 	}
 }
 
@@ -142,6 +159,27 @@ function runtime_policy_failure_count(): int {
 	global $failures;
 
 	return count( $failures );
+}
+
+function runtime_policy_action_count( string $hook ): int {
+	$count = 0;
+	foreach ( $GLOBALS['datamachine_runtime_policy_logs'] as $entry ) {
+		if ( $hook === ( $entry[0] ?? '' ) ) {
+			++$count;
+		}
+	}
+
+	return $count;
+}
+
+function runtime_policy_first_event_payload( RuntimePolicySmokeEventSink $sink, string $event ): array {
+	foreach ( $sink->events as $entry ) {
+		if ( $event === ( $entry['event'] ?? '' ) ) {
+			return is_array( $entry['payload'] ?? null ) ? $entry['payload'] : array();
+		}
+	}
+
+	return array();
 }
 
 // 1. Data Machine's handler policy is a runtime collaborator, not inline loop state.
@@ -197,6 +235,7 @@ assert_runtime_policy( 1 === $natural_dispatch_count, 'default no-tool response 
 assert_runtime_policy( ! empty( $natural_result['completed'] ), 'default natural completion result is completed' );
 
 $satisfied_dispatch_count = 0;
+$satisfied_nudge_actions  = runtime_policy_action_count( 'datamachine_ai_completion_nudge_added' );
 WpAiClientTestDouble::reset();
 WpAiClientTestDouble::set_response_callback(
 	function () use ( &$satisfied_dispatch_count ) {
@@ -231,9 +270,13 @@ $satisfied_result = datamachine_run_conversation(
 
 assert_runtime_policy( 1 === $satisfied_dispatch_count, 'satisfied natural assertion completes without nudge' );
 assert_runtime_policy( ! empty( $satisfied_result['completed'] ), 'satisfied natural assertion result is completed' );
+assert_runtime_policy( ! isset( $satisfied_result['completion_nudge_count'] ), 'satisfied natural assertion has no nudge diagnostics' );
+assert_runtime_policy( $satisfied_nudge_actions === runtime_policy_action_count( 'datamachine_ai_completion_nudge_added' ), 'satisfied natural assertion emits no nudge action' );
 
 $nudge_dispatch_count = 0;
 $nudge_second_request = null;
+$nudge_event_sink     = new RuntimePolicySmokeEventSink();
+$nudge_transcript     = new RuntimePolicySmokeTranscriptPersister();
 WpAiClientTestDouble::reset();
 WpAiClientTestDouble::set_response_callback(
 	function ( array $request_body ) use ( &$nudge_dispatch_count, &$nudge_second_request ) {
@@ -292,6 +335,9 @@ $nudge_result = datamachine_run_conversation(
 	'gpt-smoke',
 	'chat',
 	array(
+		'event_sink'            => $nudge_event_sink,
+		'transcript_persister'  => $nudge_transcript,
+		'job_id'                => 4242,
 		'completion_assertions' => array(
 			'required_tool_names' => array( 'runtime_policy_tool' ),
 		),
@@ -302,6 +348,15 @@ $nudge_result = datamachine_run_conversation(
 assert_runtime_policy( 3 === $nudge_dispatch_count, 'missing natural assertion nudges and keeps loop running' );
 assert_runtime_policy( str_contains( wp_json_encode( $nudge_second_request ), 'completion signals are still missing' ), 'nudge is appended before retry request' );
 assert_runtime_policy( 1 === count( $nudge_result['tool_execution_results'] ?? array() ), 'nudged loop captures required tool result' );
+assert_runtime_policy( 1 === ( $nudge_result['completion_nudge_count'] ?? 0 ), 'nudged loop returns nudge count diagnostic' );
+assert_runtime_policy( array( 'runtime_policy_tool' ) === ( $nudge_result['completion_assertions_missing']['tool_names'] ?? null ), 'nudged loop returns missing assertion diagnostic' );
+assert_runtime_policy( str_contains( $nudge_result['completion_nudge'] ?? '', 'runtime_policy_tool' ), 'nudged loop returns latest nudge message' );
+assert_runtime_policy( 1 === count( array_filter( $nudge_event_sink->events, fn( $entry ) => 'completion_nudge_added' === ( $entry['event'] ?? '' ) ) ), 'nudged loop emits completion_nudge_added event' );
+$nudge_event_payload = runtime_policy_first_event_payload( $nudge_event_sink, 'completion_nudge_added' );
+assert_runtime_policy( array( 'runtime_policy_tool' ) === ( $nudge_event_payload['completion_assertions_missing']['tool_names'] ?? null ), 'nudge event includes missing assertion context' );
+assert_runtime_policy( str_contains( wp_json_encode( $nudge_transcript->calls[0]['messages'] ?? array() ), 'completion signals are still missing' ), 'transcript messages include nudge message' );
+assert_runtime_policy( 1 === ( $GLOBALS['datamachine_runtime_engine_merges'][4242][0]['completion_nudge_count'] ?? 0 ), 'job engine_data merge includes nudge count' );
+assert_runtime_policy( array( 'runtime_policy_tool' ) === ( $GLOBALS['datamachine_runtime_engine_merges'][4242][0]['completion_assertions_missing']['tool_names'] ?? null ), 'job engine_data merge includes missing assertions' );
 
 $assertion_policy = new DataMachineHandlerCompletionPolicy(
 	array(),


### PR DESCRIPTION
## Summary
- Emit a structured `completion_nudge_added` loop event whenever completion assertions trigger a continuation nudge.
- Return bounded nudge diagnostics from the conversation loop and mirror the latest summary into job `engine_data` for CI/operator probes.
- Keep the nudge message in the conversation messages so persisted job transcripts expose the continuation request.

## Context
- Follow-up to #1855, #1856, and #1859.
- This preserves the existing completion behavior while making assertion/nudge state observable.

## Diagnostics exposed
- `completion_assertions_required`
- `completion_assertions_missing`
- `completion_assertions_satisfied`
- `completion_nudge_count`
- `completion_nudge`
- `completion_nudge_last_turn` in job `engine_data`

CI can read these from job details / engine data after a run, or inspect persisted transcripts with `wp datamachine jobs transcript <job_id>` when transcript persistence is enabled. Event consumers can listen for the `completion_nudge_added` loop event.

## Testing
- `php -l inc/Engine/AI/conversation-loop.php && php -l tests/agent-conversation-runtime-policy-smoke.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `composer lint`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented nudge observability diagnostics, updated focused smoke coverage, and ran local verification; Chris remains responsible for review and merge.