### PR TITLE
Fix bundle import scheduling repair

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -17,6 +17,7 @@ use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
 use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
 use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
@@ -815,18 +816,20 @@ class AgentBundler {
 				}
 
 				if ( $existing_flow ) {
-					$new_flow_id = (int) $existing_flow['flow_id'];
-					$flow_config = $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, (int) $new_pipeline_id, $new_flow_id );
-					$flow_config = $reconcile_runtime
+					$new_flow_id          = (int) $existing_flow['flow_id'];
+					$scheduling_to_ensure = is_array( $existing_flow['scheduling_config'] ?? null ) ? $existing_flow['scheduling_config'] : array();
+					$flow_config          = $this->remap_flow_step_ids( $flow_config, $old_pipeline_id, (int) $new_pipeline_id, $new_flow_id );
+					$flow_config          = $reconcile_runtime
 					? AgentBundleRuntimeDrift::replace_runtime_queue_fields( $flow_config, $target_flow_config )
 					: $this->preserve_runtime_queue_fields( $flow_config, $existing_flow['flow_config'] ?? array() );
-					$update_data = array(
+					$update_data          = array(
 						'flow_name'     => $flow_data['flow_name'],
 						'flow_config'   => $flow_config,
 						'portable_slug' => $portable_slug,
 					);
 					if ( $reconcile_runtime ) {
 						$update_data['scheduling_config'] = $flow_data['scheduling_config'] ?? array();
+						$scheduling_to_ensure             = is_array( $flow_data['scheduling_config'] ?? null ) ? $flow_data['scheduling_config'] : array();
 					}
 					if ( ! $this->flows_repo->update_flow( $new_flow_id, $update_data ) ) {
 						throw new \RuntimeException( sprintf( 'Failed to update flow "%s".', $portable_slug ) );
@@ -858,7 +861,10 @@ class AgentBundler {
 					) ) {
 						throw new \RuntimeException( sprintf( 'Failed to update freshly-created flow "%s".', $portable_slug ) );
 					}
+					$scheduling_to_ensure = $scheduling;
 				}
+
+				$this->ensure_imported_flow_schedule( (int) $new_flow_id, $scheduling_to_ensure );
 
 				++$flow_count;
 				$artifact_records[ $artifact_key ] = $this->bundle_artifact_record(
@@ -1179,6 +1185,38 @@ class AgentBundler {
 		}
 
 		return $config;
+	}
+
+	private function ensure_imported_flow_schedule( int $flow_id, array $config ): void {
+		$config   = $this->bundle_create_scheduling_config( $config );
+		$interval = (string) ( $config['interval'] ?? 'manual' );
+
+		if ( 'manual' === $interval || false === ( $config['enabled'] ?? true ) ) {
+			return;
+		}
+
+		$result = FlowScheduling::handle_scheduling_update( $flow_id, $config );
+		if ( is_wp_error( $result ) ) {
+			throw new \RuntimeException(
+				sprintf(
+					'Failed to schedule imported flow %d: %s',
+					(int) $flow_id,
+					esc_html( $result->get_error_message() )
+				)
+			);
+		}
+
+		$flow             = $this->flows_repo->get_flow( $flow_id );
+		$scheduled_config = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
+		foreach ( array( 'enabled', 'max_items' ) as $metadata_key ) {
+			if ( array_key_exists( $metadata_key, $config ) ) {
+				$scheduled_config[ $metadata_key ] = $config[ $metadata_key ];
+			}
+		}
+
+		if ( ! $this->flows_repo->update_flow( $flow_id, array( 'scheduling_config' => $scheduled_config ) ) ) {
+			throw new \RuntimeException( sprintf( 'Failed to preserve imported flow schedule metadata for flow %d.', (int) $flow_id ) );
+		}
 	}
 
 	private function bundle_scheduling_policy( array $config ): string {

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -139,6 +139,43 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'mcp' => 5 ), $flow['scheduling_config']['max_items'] ?? null, 'Importer preserves bundle max item caps.' );
 	}
 
+	public function test_import_reenqueues_existing_scheduled_flow_when_action_is_missing(): void {
+		if ( ! function_exists( 'as_unschedule_all_actions' ) || ! function_exists( 'as_next_scheduled_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler functions are required for schedule re-enqueue assertions.' );
+		}
+
+		$bundle = $this->fixture_bundle( 'scheduled-action-repair-agent' );
+		$bundle['flows'][0]['scheduling_config'] = array(
+			'enabled'  => true,
+			'interval' => 'daily',
+			'max_items' => array(
+				'mcp' => 5,
+			),
+		);
+
+		$first = $this->bundler->import( $bundle, null, $this->owner_id );
+		$this->assertTrue( (bool) $first['success'], 'Initial scheduled import succeeds.' );
+
+		$agent    = $this->agents_repo->get_by_slug( 'scheduled-action-repair-agent' );
+		$pipeline = $this->pipelines_repo->get_by_portable_slug( (int) $agent['agent_id'], 'static-site-pipeline' );
+		$flow     = $this->flows_repo->get_by_portable_slug( (int) $pipeline['pipeline_id'], 'static-site-flow' );
+		$flow_id  = (int) $flow['flow_id'];
+
+		as_unschedule_all_actions( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' );
+		$this->assertFalse( as_next_scheduled_action( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' ), 'Test setup removes the scheduled action while preserving flow row scheduling.' );
+
+		$second = $this->bundler->import(
+			$bundle,
+			null,
+			$this->owner_id,
+			false,
+			array( 'is_upgrade' => true )
+		);
+
+		$this->assertTrue( (bool) $second['success'], 'Upgrade import succeeds when only the scheduled action is missing.' );
+		$this->assertNotFalse( as_next_scheduled_action( 'datamachine_run_flow_now', array( $flow_id ), 'data-machine' ), 'Importer re-creates the missing scheduled action for an enabled non-manual flow.' );
+	}
+
 	public function test_reconcile_runtime_replaces_local_modified_flow_queue_and_schedule(): void {
 		$bundle = $this->fixture_bundle( 'runtime-reconcile-agent' );
 		$bundle['flows'][0]['flow_config']['1_step-uuid_1'] = array_merge(


### PR DESCRIPTION
## Summary
- Ensure bundle import runs the shared flow scheduling primitive for enabled non-manual imported flows so missing Action Scheduler rows are recreated.
- Preserve bundle scheduling metadata such as `enabled` and `max_items` after the scheduler writes canonical interval/first-run fields.
- Add regression coverage for an enabled scheduled flow whose pending Action Scheduler action was lost before bundle upgrade import.

## Testing
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-bundle-import-reenqueue-scheduled-flows --extension wordpress --force-hot -- --filter=AgentBundlerImportTest`
- `homeboy test --path /Users/chubes/Developer/data-machine@fix-bundle-import-reenqueue-scheduled-flows --extension wordpress --force-hot`
- `homeboy lint --path /Users/chubes/Developer/data-machine@fix-bundle-import-reenqueue-scheduled-flows --extension wordpress --changed-only --force-hot`
- `php tests/agent-bundle-runtime-drift-smoke.php`
- `php -l inc/Core/Agents/AgentBundler.php && php -l tests/Unit/Core/Agents/AgentBundlerImportTest.php`

Closes #1860.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the import scheduling repair, regression test, and verification notes for Chris to review.