### PR TITLE
Preserve bundle completion assertions

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -368,7 +368,7 @@ class AgentBundler {
 				$document_step['step_type'] = $pipeline_step_types_by_id[ $pipeline_step_id ];
 			}
 
-			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'enabled' ) as $field ) {
+			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'enabled' ) as $field ) {
 				if ( array_key_exists( $field, $step ) ) {
 					$document_step[ $field ] = $step[ $field ];
 				}

--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -304,7 +304,7 @@ final class AgentBundleArrayAdapter {
 				$document_step['step_type'] = $pipeline_step_types_by_id[ $pipeline_step_id ];
 			}
 
-			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'enabled' ) as $field ) {
+			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'enabled' ) as $field ) {
 				if ( array_key_exists( $field, $step ) ) {
 					$document_step[ $field ] = $step[ $field ];
 				}
@@ -324,7 +324,7 @@ final class AgentBundleArrayAdapter {
 			'execution_order'  => (int) $step['step_position'],
 		);
 
-		foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'enabled' ) as $field ) {
+		foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'enabled' ) as $field ) {
 			if ( array_key_exists( $field, $step ) ) {
 				$config[ $field ] = $step[ $field ];
 			}

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -32,6 +32,7 @@ final class AgentBundleFlowFile {
 		'prompt_queue',
 		'config_patch_queue',
 		'queue_mode',
+		'completion_assertions',
 		'enabled',
 	);
 
@@ -117,6 +118,13 @@ final class AgentBundleFlowFile {
 		if ( 'handler_config' === $field ) {
 			if ( ! is_array( $value ) ) {
 				throw new BundleValidationException( 'flow file handler_config must be an object.' );
+			}
+			return $value;
+		}
+
+		if ( 'completion_assertions' === $field ) {
+			if ( ! is_array( $value ) ) {
+				throw new BundleValidationException( 'flow file completion_assertions must be an object.' );
 			}
 			return $value;
 		}

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -143,6 +143,12 @@ $array_bundle = array(
 					'pipeline_id'      => 88,
 					'flow_id'          => 144,
 					'execution_order'  => 1,
+					'completion_assertions' => array(
+						'required_tool_names' => array(
+							'create_github_pull_request',
+							'comment_github_pull_request',
+						),
+					),
 					'enabled_tools'    => array( 'datamachine/get-github-pull-review-context' ),
 					'disabled_tools'   => array( 'datamachine/delete-flow' ),
 					'prompt_queue'     => array(
@@ -189,6 +195,7 @@ assert_adapter_equals( 'flow document preserves step type', 'fetch', $flow['step
 assert_adapter_equals( 'flow document preserves config patch queue', array( 'after' => '2026-04-01' ), $flow['steps'][0]['config_patch_queue'][0]['patch'] ?? null );
 assert_adapter_equals( 'flow document preserves AI enabled tools', array( 'datamachine/get-github-pull-review-context' ), $flow['steps'][1]['enabled_tools'] );
 assert_adapter_equals( 'flow document preserves AI disabled tools', array( 'datamachine/delete-flow' ), $flow['steps'][1]['disabled_tools'] );
+assert_adapter_equals( 'flow document preserves completion assertions', array( 'create_github_pull_request', 'comment_github_pull_request' ), $flow['steps'][1]['completion_assertions']['required_tool_names'] ?? null );
 assert_adapter_equals( 'flow document preserves prompt queue', 'Review PR #1', $flow['steps'][1]['prompt_queue'][0]['prompt'] );
 assert_adapter_equals( 'flow document preserves queue mode', 'loop', $flow['steps'][1]['queue_mode'] );
 assert_adapter_equals( 'flow document preserves scheduling interval', 'hourly', $flow['schedule'] );
@@ -229,6 +236,7 @@ assert_adapter_equals( 'round-trip preserves config patch queue', array( 'after'
 assert_adapter_equals( 'round-trip preserves enabled flag', true, $round_steps[0]['enabled'] );
 assert_adapter_equals( 'round-trip preserves enabled tools', array( 'datamachine/get-github-pull-review-context' ), $round_steps[1]['enabled_tools'] );
 assert_adapter_equals( 'round-trip preserves disabled tools', array( 'datamachine/delete-flow' ), $round_steps[1]['disabled_tools'] );
+assert_adapter_equals( 'round-trip preserves completion assertions', array( 'create_github_pull_request', 'comment_github_pull_request' ), $round_steps[1]['completion_assertions']['required_tool_names'] ?? null );
 assert_adapter_equals( 'round-trip preserves prompt queue', 'Review PR #1', $round_steps[1]['prompt_queue'][0]['prompt'] );
 assert_adapter_equals( 'round-trip preserves queue mode', 'loop', $round_steps[1]['queue_mode'] );
 assert_adapter_equals( 'round-trip preserves scheduling interval', 'hourly', $round_flow['scheduling_config']['interval'] );


### PR DESCRIPTION
## Summary
- Preserve flow-level `completion_assertions` when bundle flows are normalized, exported, and adapted back into runtime arrays.
- Add adapter smoke coverage so imported bundle assertions survive directory write/read and array round-trip.

## Testing
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php tests/agent-bundle-format-smoke.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `./vendor/bin/phpcs inc/Engine/Bundle/AgentBundleFlowFile.php inc/Engine/Bundle/AgentBundleArrayAdapter.php inc/Core/Agents/AgentBundler.php tests/agent-bundler-directory-adapter-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Traced the bundle assertion propagation gap, drafted the preservation fix and smoke coverage, and ran local validation. Chris remains responsible for review and merge.