### PR TITLE
Nudge pipeline assertions after setup tools

### DIFF
--- a/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
+++ b/inc/Engine/AI/DataMachineHandlerCompletionPolicy.php
@@ -45,6 +45,11 @@ class DataMachineHandlerCompletionPolicy implements WP_Agent_Conversation_Comple
 		$mode            = (string) ( $runtime_context['mode'] ?? '' );
 
 		if ( 'pipeline' !== $mode || ! $is_handler_tool || ! ( $tool_result['success'] ?? false ) ) {
+			$missing_assertions = $this->incompleteAssertionsDecision( $runtime_context, $turn_count );
+			if ( null !== $missing_assertions ) {
+				return $missing_assertions;
+			}
+
 			return WP_Agent_Conversation_Completion_Decision::incomplete();
 		}
 

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -377,6 +377,25 @@ $assertion_decision = $assertion_policy->recordToolResult(
 assert_runtime_policy( ! $assertion_decision->isComplete(), 'handler policy waits when generic assertions are missing' );
 assert_runtime_policy( str_contains( $assertion_decision->context()['continuation_message'] ?? '', 'completion signals are still missing' ), 'handler policy provides assertion continuation nudge' );
 
+$non_handler_assertion_policy = new DataMachineHandlerCompletionPolicy(
+	array(),
+	new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
+		array(
+			'required_tool_names' => array( 'create_github_pull_request', 'comment_github_pull_request' ),
+		)
+	)
+);
+$non_handler_assertion_decision = $non_handler_assertion_policy->recordToolResult(
+	'workspace_worktree_add',
+	array( 'name' => 'workspace_worktree_add' ),
+	array( 'success' => true ),
+	array( 'mode' => 'pipeline' ),
+	1
+);
+
+assert_runtime_policy( ! $non_handler_assertion_decision->isComplete(), 'handler policy waits after non-handler tools when generic assertions are missing' );
+assert_runtime_policy( str_contains( $non_handler_assertion_decision->context()['continuation_message'] ?? '', 'create_github_pull_request' ), 'handler policy nudges after non-handler tools with missing assertions' );
+
 $dispatch_count     = 0;
 $provider_context   = null;
 $completion_policy  = new RuntimePolicySmokeCompletionPolicy();


### PR DESCRIPTION
## Summary
- Evaluate generic completion assertions after non-handler tools in pipeline runs instead of returning a bare incomplete decision.
- This keeps setup/workspace tools like `workspace_worktree_add` from leaving the model without a targeted continuation nudge when required terminal tools are still missing.
- Add smoke coverage for both the policy decision and a full pipeline-mode conversation where a setup tool must continue to a required PR tool.

## Testing
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `php -l inc/Engine/AI/DataMachineHandlerCompletionPolicy.php && php -l tests/agent-conversation-runtime-policy-smoke.php`
- `./vendor/bin/phpcs inc/Engine/AI/DataMachineHandlerCompletionPolicy.php tests/agent-conversation-runtime-policy-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the iterator smoke stopping after a setup tool, drafted the completion-policy nudge fix and smoke coverage, and ran local validation. Chris remains responsible for review and merge.