### PR TITLE
Fix duplicate tool correction continuation

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -128,7 +128,7 @@ function datamachine_run_conversation(
 		if ( ! empty( $result['conversation_complete'] ) ) {
 			return false;
 		}
-		return ! empty( $result['tool_execution_results'] ) || ! empty( $result['completion_nudge'] );
+		return ! empty( $result['tool_execution_results'] ) || ! empty( $result['completion_nudge'] ) || ! empty( $result['duplicate_tool_call_rejected'] );
 	};
 
 	// Run through the upstream substrate loop.
@@ -208,7 +208,6 @@ function datamachine_run_conversation(
 		$result['completion_assertions_missing']   = $latest_nudge['completion_assertions_missing'] ?? array();
 		$result['completion_assertions_satisfied'] = $latest_nudge['completion_assertions_satisfied'] ?? array();
 	}
-
 	// Map upstream budget_exceeded status to DM's max_turns_reached flag
 	// for backward compatibility with ChatOrchestrator response shaping.
 	if ( 'budget_exceeded' === ( $result['status'] ?? '' ) && in_array( $result['budget'] ?? '', array( 'conversation_turns', 'turns' ), true ) ) {
@@ -358,6 +357,7 @@ function datamachine_build_turn_runner(
 		$tool_execution_results = array();
 		$conversation_complete  = false;
 		$completion_nudge       = '';
+		$duplicate_rejected     = false;
 		if ( ! empty( $tool_calls ) ) {
 			foreach ( $tool_calls as $tool_call ) {
 				$tool_name       = $tool_call['name'];
@@ -397,6 +397,7 @@ function datamachine_build_turn_runner(
 				$validation_result = ConversationManager::validateToolCall( $tool_name, $tool_parameters, $messages );
 				if ( $validation_result['is_duplicate'] ) {
 					$messages[] = ConversationManager::generateDuplicateToolCallMessage( $tool_name, $turn_count, $mode );
+					$duplicate_rejected = true;
 					do_action(
 						'datamachine_log',
 						'info',
@@ -546,6 +547,7 @@ function datamachine_build_turn_runner(
 			'tool_execution_results' => $tool_execution_results,
 			'conversation_complete'  => $conversation_complete,
 			'completion_nudge'       => $completion_nudge ?? '',
+			'duplicate_tool_call_rejected' => $duplicate_rejected,
 		);
 	};
 }

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -358,6 +358,88 @@ assert_runtime_policy( str_contains( wp_json_encode( $nudge_transcript->calls[0]
 assert_runtime_policy( 1 === ( $GLOBALS['datamachine_runtime_engine_merges'][4242][0]['completion_nudge_count'] ?? 0 ), 'job engine_data merge includes nudge count' );
 assert_runtime_policy( array( 'runtime_policy_tool' ) === ( $GLOBALS['datamachine_runtime_engine_merges'][4242][0]['completion_assertions_missing']['tool_names'] ?? null ), 'job engine_data merge includes missing assertions' );
 
+$duplicate_dispatch_count = 0;
+$duplicate_transcript     = new RuntimePolicySmokeTranscriptPersister();
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$duplicate_dispatch_count ) {
+		++$duplicate_dispatch_count;
+
+		if ( 1 === $duplicate_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => 'I am done prematurely.',
+					'tool_calls' => array(),
+				),
+			);
+		}
+
+		if ( in_array( $duplicate_dispatch_count, array( 2, 3 ), true ) ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'name'       => 'runtime_policy_tool',
+							'parameters' => array( 'name' => 'Grace' ),
+						),
+					),
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => '',
+				'tool_calls' => array(
+					array(
+						'name'       => 'second_policy_tool',
+						'parameters' => array( 'name' => 'Hopper' ),
+					),
+				),
+			),
+		);
+	}
+);
+
+$duplicate_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'recover from duplicate tool call while completing assertions' ) ),
+	array(
+		'runtime_policy_tool' => array(
+			'name'        => 'runtime_policy_tool',
+			'description' => 'Runtime policy smoke tool',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+		'second_policy_tool'  => array(
+			'name'        => 'second_policy_tool',
+			'description' => 'Second runtime policy smoke tool',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	array(
+		'transcript_persister'  => $duplicate_transcript,
+		'completion_assertions' => array(
+			'required_tool_names' => array( 'runtime_policy_tool', 'second_policy_tool' ),
+		),
+	),
+	6
+);
+
+assert_runtime_policy( $duplicate_dispatch_count >= 4, 'duplicate tool rejection keeps loop running for correction' );
+assert_runtime_policy( 2 === count( $duplicate_result['tool_execution_results'] ?? array() ), 'duplicate recovery result includes only executed tool calls' );
+assert_runtime_policy( 'second_policy_tool' === ( $duplicate_result['tool_execution_results'][1]['tool_name'] ?? '' ), 'duplicate recovery reaches next required tool' );
+assert_runtime_policy( str_contains( wp_json_encode( $duplicate_transcript->calls[0]['messages'] ?? array() ), 'DUPLICATE REJECTED' ), 'duplicate recovery transcript includes correction message' );
+
 $assertion_policy = new DataMachineHandlerCompletionPolicy(
 	array(),
 	new \DataMachine\Engine\AI\DataMachineCompletionAssertions(


### PR DESCRIPTION
## Summary
- Continue the conversation loop after duplicate tool-call correction messages so the model can move to the next required action.
- Add runtime smoke coverage for recovering from a duplicate tool call while completion assertions are still pending.

## Testing
- `php -l inc/Engine/AI/conversation-loop.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the iterator smoke failure, drafted the runtime loop fix and regression smoke; Chris remains responsible for review and merge.