### PR TITLE
Add central agent identity resolver

### DIFF
--- a/inc/Cli/AgentResolver.php
+++ b/inc/Cli/AgentResolver.php
@@ -15,6 +15,7 @@
 namespace DataMachine\Cli;
 
 use WP_CLI;
+use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 
@@ -38,30 +39,20 @@ class AgentResolver {
 			return null;
 		}
 
-		$agents_repo = new Agents();
+		$resolver = new AgentIdentityResolver();
 
-		// Numeric: treat as agent ID.
-		if ( is_numeric( $agent_value ) ) {
-			$agent = $agents_repo->get_agent( (int) $agent_value );
-			if ( ! $agent ) {
-				WP_CLI::error( sprintf( 'Agent ID %d not found.', (int) $agent_value ) );
-			}
-			return (int) $agent['agent_id'];
-		}
-
-		// String: treat as agent slug.
-		$agent = $agents_repo->get_by_slug( sanitize_title( $agent_value ) );
-		if ( ! $agent ) {
+		try {
+			return $resolver->resolve_agent_id( $agent_value );
+		} catch ( \InvalidArgumentException $e ) {
 			// Suggest available agents.
+			$agents_repo = new Agents();
 			$all_agents = $agents_repo->get_all();
 			$slugs      = array_column( $all_agents, 'agent_slug' );
 			$hint       = ! empty( $slugs )
 				? sprintf( ' Available: %s', implode( ', ', $slugs ) )
 				: '';
-			WP_CLI::error( sprintf( 'Agent "%s" not found.%s', $agent_value, $hint ) );
+			WP_CLI::error( $e->getMessage() . $hint );
 		}
-
-		return (int) $agent['agent_id'];
 	}
 
 	/**

--- a/inc/Cli/AgentResolver.php
+++ b/inc/Cli/AgentResolver.php
@@ -46,9 +46,9 @@ class AgentResolver {
 		} catch ( \InvalidArgumentException $e ) {
 			// Suggest available agents.
 			$agents_repo = new Agents();
-			$all_agents = $agents_repo->get_all();
-			$slugs      = array_column( $all_agents, 'agent_slug' );
-			$hint       = ! empty( $slugs )
+			$all_agents  = $agents_repo->get_all();
+			$slugs       = array_column( $all_agents, 'agent_slug' );
+			$hint        = ! empty( $slugs )
 				? sprintf( ' Available: %s', implode( ', ', $slugs ) )
 				: '';
 			WP_CLI::error( $e->getMessage() . $hint );

--- a/inc/Core/Agents/AgentIdentity.php
+++ b/inc/Core/Agents/AgentIdentity.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Agent identity value object.
+ *
+ * @package DataMachine\Core\Agents
+ */
+
+namespace DataMachine\Core\Agents;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Canonical resolved agent identity.
+ */
+class AgentIdentity {
+
+	/**
+	 * Internal database row ID.
+	 *
+	 * @var int
+	 */
+	public int $agent_id;
+
+	/**
+	 * Public agent slug.
+	 *
+	 * @var string
+	 */
+	public string $agent_slug;
+
+	/**
+	 * Owner WordPress user ID.
+	 *
+	 * @var int
+	 */
+	public int $owner_id;
+
+	/**
+	 * Display name.
+	 *
+	 * @var string
+	 */
+	public string $agent_name;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int    $agent_id   Internal database row ID.
+	 * @param string $agent_slug Public agent slug.
+	 * @param int    $owner_id   Owner WordPress user ID.
+	 * @param string $agent_name Display name.
+	 */
+	public function __construct( int $agent_id, string $agent_slug, int $owner_id, string $agent_name ) {
+		$this->agent_id   = $agent_id;
+		$this->agent_slug = $agent_slug;
+		$this->owner_id   = $owner_id;
+		$this->agent_name = $agent_name;
+	}
+
+	/**
+	 * Build an identity from an agents repository row.
+	 *
+	 * @param array $row Agent repository row.
+	 * @return self
+	 */
+	public static function from_row( array $row ): self {
+		$agent_id   = (int) ( $row['agent_id'] ?? 0 );
+		$agent_slug = (string) ( $row['agent_slug'] ?? '' );
+		$owner_id   = (int) ( $row['owner_id'] ?? 0 );
+		$agent_name = (string) ( $row['agent_name'] ?? '' );
+
+		if ( $agent_id <= 0 || '' === $agent_slug || $owner_id <= 0 ) {
+			throw new \InvalidArgumentException( 'Agent row is missing required identity fields.' );
+		}
+
+		return new self( $agent_id, $agent_slug, $owner_id, $agent_name );
+	}
+
+	/**
+	 * Convert to an array for contexts that still pass associative payloads.
+	 *
+	 * @return array{agent_id:int, agent_slug:string, owner_id:int, agent_name:string}
+	 */
+	public function to_array(): array {
+		return array(
+			'agent_id'   => $this->agent_id,
+			'agent_slug' => $this->agent_slug,
+			'owner_id'   => $this->owner_id,
+			'agent_name' => $this->agent_name,
+		);
+	}
+}

--- a/inc/Core/Agents/AgentIdentityResolver.php
+++ b/inc/Core/Agents/AgentIdentityResolver.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Agent identity resolver.
+ *
+ * @package DataMachine\Core\Agents
+ */
+
+namespace DataMachine\Core\Agents;
+
+use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Resolves public agent slugs and internal agent IDs through one primitive.
+ */
+class AgentIdentityResolver {
+
+	/**
+	 * Agents repository.
+	 *
+	 * @var AgentsRepository
+	 */
+	private AgentsRepository $agents_repository;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AgentsRepository|null $agents_repository Optional repository override.
+	 */
+	public function __construct( ?AgentsRepository $agents_repository = null ) {
+		$this->agents_repository = $agents_repository ?? new AgentsRepository();
+	}
+
+	/**
+	 * Normalize an agent slug the same way Data Machine stores agent slugs.
+	 *
+	 * @param string $agent_slug Raw slug.
+	 * @return string Normalized slug.
+	 */
+	public static function normalize_agent_slug( string $agent_slug ): string {
+		return sanitize_title( trim( $agent_slug ) );
+	}
+
+	/**
+	 * Resolve a mixed agent identifier into a canonical identity.
+	 *
+	 * @param int|string|array $agent Agent ID, agent slug, or context array.
+	 * @return AgentIdentity Resolved identity.
+	 */
+	public function resolve_agent_identity( int|string|array $agent ): AgentIdentity {
+		if ( is_array( $agent ) ) {
+			return $this->resolve_from_context( $agent );
+		}
+
+		if ( is_int( $agent ) || is_numeric( $agent ) ) {
+			return $this->resolve_from_id( (int) $agent );
+		}
+
+		return $this->resolve_from_slug( (string) $agent );
+	}
+
+	/**
+	 * Resolve any scalar agent identifier to an internal agent ID.
+	 *
+	 * @param int|string $agent Agent ID or slug.
+	 * @return int Internal agent ID.
+	 */
+	public function resolve_agent_id( int|string $agent ): int {
+		return $this->resolve_agent_identity( $agent )->agent_id;
+	}
+
+	/**
+	 * Resolve any scalar agent identifier to a public agent slug.
+	 *
+	 * @param int|string $agent Agent ID or slug.
+	 * @return string Public agent slug.
+	 */
+	public function resolve_agent_slug( int|string $agent ): string {
+		return $this->resolve_agent_identity( $agent )->agent_slug;
+	}
+
+	/**
+	 * Resolve identity from a persisted or runtime context array.
+	 *
+	 * `agent_id` remains authoritative for old persisted contexts. When both
+	 * fields are present, the slug must match the row resolved by `agent_id`.
+	 *
+	 * @param array $context Context containing agent_id and/or agent_slug.
+	 * @return AgentIdentity Resolved identity.
+	 */
+	private function resolve_from_context( array $context ): AgentIdentity {
+		$agent_id   = isset( $context['agent_id'] ) && is_numeric( $context['agent_id'] ) ? (int) $context['agent_id'] : 0;
+		$agent_slug = isset( $context['agent_slug'] ) ? self::normalize_agent_slug( (string) $context['agent_slug'] ) : '';
+
+		if ( $agent_id > 0 ) {
+			$identity = $this->resolve_from_id( $agent_id );
+
+			if ( '' !== $agent_slug && $agent_slug !== $identity->agent_slug ) {
+				throw new \InvalidArgumentException(
+					sprintf(
+						'Agent identity mismatch: agent_id %d resolves to "%s", not "%s".',
+						absint( $identity->agent_id ),
+						esc_html( $identity->agent_slug ),
+						esc_html( $agent_slug )
+					)
+				);
+			}
+
+			return $identity;
+		}
+
+		if ( '' !== $agent_slug ) {
+			return $this->resolve_from_slug( $agent_slug );
+		}
+
+		throw new \InvalidArgumentException( 'Agent identity requires agent_id or agent_slug.' );
+	}
+
+	/**
+	 * Resolve identity from an internal agent ID.
+	 *
+	 * @param int $agent_id Internal agent ID.
+	 * @return AgentIdentity Resolved identity.
+	 */
+	private function resolve_from_id( int $agent_id ): AgentIdentity {
+		if ( $agent_id <= 0 ) {
+			throw new \InvalidArgumentException( 'Agent ID must be a positive integer.' );
+		}
+
+		$agent = $this->agents_repository->get_agent( $agent_id );
+		if ( ! $agent ) {
+			throw new \InvalidArgumentException( sprintf( 'Agent ID %d not found.', absint( $agent_id ) ) );
+		}
+
+		return AgentIdentity::from_row( $agent );
+	}
+
+	/**
+	 * Resolve identity from a public agent slug.
+	 *
+	 * @param string $agent_slug Public agent slug.
+	 * @return AgentIdentity Resolved identity.
+	 */
+	private function resolve_from_slug( string $agent_slug ): AgentIdentity {
+		$agent_slug = self::normalize_agent_slug( $agent_slug );
+		if ( '' === $agent_slug ) {
+			throw new \InvalidArgumentException( 'Agent slug must not be empty.' );
+		}
+
+		$agent = $this->agents_repository->get_by_slug( $agent_slug );
+		if ( ! $agent ) {
+			throw new \InvalidArgumentException( sprintf( 'Agent "%s" not found.', esc_html( $agent_slug ) ) );
+		}
+
+		return AgentIdentity::from_row( $agent );
+	}
+}

--- a/tests/Unit/Core/Agents/AgentIdentityResolverTest.php
+++ b/tests/Unit/Core/Agents/AgentIdentityResolverTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Agent identity resolver tests.
+ *
+ * @package DataMachine\Tests\Unit\Core\Agents
+ */
+
+namespace DataMachine\Tests\Unit\Core\Agents;
+
+use DataMachine\Core\Agents\AgentIdentityResolver;
+use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
+use WP_UnitTestCase;
+
+class AgentIdentityResolverTest extends WP_UnitTestCase {
+
+	private AgentsRepository $repo;
+	private AgentIdentityResolver $resolver;
+	private int $owner_id;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		$this->repo      = new AgentsRepository();
+		$this->resolver  = new AgentIdentityResolver( $this->repo );
+		$this->owner_id  = self::factory()->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function tear_down(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agents" );
+
+		parent::tear_down();
+	}
+
+	private function create_agent( string $slug = 'test-agent', string $name = 'Test Agent' ): int {
+		return $this->repo->create_if_missing( $slug, $name, $this->owner_id );
+	}
+
+	public function test_resolves_slug_to_id(): void {
+		$agent_id = $this->create_agent( 'slug-agent' );
+
+		$this->assertSame( $agent_id, $this->resolver->resolve_agent_id( 'slug-agent' ) );
+	}
+
+	public function test_resolves_id_to_slug(): void {
+		$agent_id = $this->create_agent( 'id-agent' );
+
+		$this->assertSame( 'id-agent', $this->resolver->resolve_agent_slug( $agent_id ) );
+	}
+
+	public function test_resolves_array_context_from_agent_id_only(): void {
+		$agent_id = $this->create_agent( 'persisted-id-agent', 'Persisted ID Agent' );
+
+		$identity = $this->resolver->resolve_agent_identity( array( 'agent_id' => $agent_id ) );
+
+		$this->assertSame( $agent_id, $identity->agent_id );
+		$this->assertSame( 'persisted-id-agent', $identity->agent_slug );
+		$this->assertSame( $this->owner_id, $identity->owner_id );
+		$this->assertSame( 'Persisted ID Agent', $identity->agent_name );
+	}
+
+	public function test_resolves_array_context_from_agent_slug(): void {
+		$agent_id = $this->create_agent( 'array-slug-agent' );
+
+		$identity = $this->resolver->resolve_agent_identity( array( 'agent_slug' => 'array-slug-agent' ) );
+
+		$this->assertSame( $agent_id, $identity->agent_id );
+		$this->assertSame( 'array-slug-agent', $identity->agent_slug );
+	}
+
+	public function test_normalizes_slug_before_resolution(): void {
+		$agent_id = $this->create_agent( 'mixed-case-agent' );
+
+		$this->assertSame( $agent_id, $this->resolver->resolve_agent_id( ' Mixed Case Agent ' ) );
+	}
+
+	public function test_rejects_missing_identity(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Agent identity requires agent_id or agent_slug.' );
+
+		$this->resolver->resolve_agent_identity( array( 'owner_id' => $this->owner_id ) );
+	}
+
+	public function test_rejects_invalid_id(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Agent ID 99999 not found.' );
+
+		$this->resolver->resolve_agent_identity( 99999 );
+	}
+
+	public function test_rejects_mismatched_array_identity(): void {
+		$agent_id = $this->create_agent( 'matching-agent' );
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Agent identity mismatch' );
+
+		$this->resolver->resolve_agent_identity(
+			array(
+				'agent_id'   => $agent_id,
+				'agent_slug' => 'other-agent',
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a central `AgentIdentity` value object and `AgentIdentityResolver` for canonical slug/id translation through `AgentsRepository`.
- Preserves persisted `agent_id`-only context resolution while rejecting missing, invalid, or mismatched identity inputs clearly.
- Routes CLI `--agent` resolution through the new resolver without changing database schema.

Closes #1866.

## Tests
- `php -l inc/Core/Agents/AgentIdentity.php`
- `php -l inc/Core/Agents/AgentIdentityResolver.php`
- `php -l inc/Cli/AgentResolver.php`
- `php -l tests/Unit/Core/Agents/AgentIdentityResolverTest.php`
- `homeboy lint --changed-only --errors-only`
- `homeboy test --changed-since origin/main` (reported no impacted tests)
- `homeboy test` (1237 tests, 1234 passed, 3 skipped)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the agent identity resolver, CLI integration, and focused tests; Chris to review and validate before merge.