### PR TITLE
Adapt transcript sessions to agent slugs

### DIFF
--- a/inc/Abilities/Chat/CreateChatSessionAbility.php
+++ b/inc/Abilities/Chat/CreateChatSessionAbility.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Abilities\Chat;
 
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 
 defined( 'ABSPATH' ) || exit;
@@ -39,24 +40,28 @@ class CreateChatSessionAbility {
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
-							'user_id'  => array(
+							'user_id'    => array(
 								'type'        => 'integer',
 								'description' => __( 'User ID who owns the session.', 'data-machine' ),
 							),
-							'agent_id' => array(
+							'agent_id'   => array(
 								'type'        => 'integer',
-								'description' => __( 'First-class agent ID for this session.', 'data-machine' ),
+								'description' => __( 'Data Machine internal agent ID for this session.', 'data-machine' ),
 							),
-							'mode'     => array(
+							'agent_slug' => array(
+								'type'        => 'string',
+								'description' => __( 'Registered agent slug for this session.', 'data-machine' ),
+							),
+							'mode'       => array(
 								'type'        => 'string',
 								'default'     => 'chat',
 								'description' => __( 'Execution mode (chat, pipeline, system).', 'data-machine' ),
 							),
-							'source'   => array(
+							'source'     => array(
 								'type'        => 'string',
 								'description' => __( 'Session source identifier (e.g. ping, chat).', 'data-machine' ),
 							),
-							'metadata' => array(
+							'metadata'   => array(
 								'type'        => 'object',
 								'description' => __( 'Additional metadata for the session.', 'data-machine' ),
 							),
@@ -99,10 +104,13 @@ class CreateChatSessionAbility {
 			);
 		}
 
-		$user_id  = (int) $input['user_id'];
-		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$mode     = ! empty( $input['mode'] ) ? sanitize_text_field( $input['mode'] ) : 'chat';
-		$source   = ! empty( $input['source'] ) ? sanitize_text_field( $input['source'] ) : null;
+		$user_id    = (int) $input['user_id'];
+		$agent_id   = (int) ( $input['agent_id'] ?? 0 );
+		$agent_slug = ! empty( $input['agent_slug'] )
+			? sanitize_title( (string) $input['agent_slug'] )
+			: ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
+		$mode       = ! empty( $input['mode'] ) ? sanitize_text_field( $input['mode'] ) : 'chat';
+		$source     = ! empty( $input['source'] ) ? sanitize_text_field( $input['source'] ) : null;
 
 		if ( ! $this->can_access_user_sessions( $user_id ) ) {
 			return array(
@@ -125,7 +133,7 @@ class CreateChatSessionAbility {
 			$session_metadata = array_merge( $session_metadata, $input['metadata'] );
 		}
 
-		$session_id = $this->chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_id, $session_metadata, $mode );
+		$session_id = $this->chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_slug, $session_metadata, $mode );
 
 		if ( empty( $session_id ) ) {
 			return array(

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -589,10 +589,11 @@ class ChatOrchestrator {
 		$ability = wp_get_ability( 'datamachine/create-chat-session' );
 
 		if ( $ability ) {
+			$agent_slug = ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
 			$input = array(
-				'user_id'  => $user_id,
-				'agent_id' => $agent_id,
-				'mode'     => 'chat',
+				'user_id'    => $user_id,
+				'agent_slug' => $agent_slug,
+				'mode'       => 'chat',
 			);
 
 			if ( $source ) {
@@ -636,7 +637,8 @@ class ChatOrchestrator {
 			$metadata['source'] = $source;
 		}
 
-		$session_id = $chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_id, $metadata, 'chat' );
+		$agent_slug = ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
+		$session_id = $chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_slug, $metadata, 'chat' );
 
 		if ( empty( $session_id ) ) {
 			return new WP_Error(

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -590,7 +590,7 @@ class ChatOrchestrator {
 
 		if ( $ability ) {
 			$agent_slug = ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
-			$input = array(
+			$input      = array(
 				'user_id'    => $user_id,
 				'agent_slug' => $agent_slug,
 				'mode'       => 'chat',

--- a/inc/Cli/Commands/ChatCommand.php
+++ b/inc/Cli/Commands/ChatCommand.php
@@ -287,7 +287,8 @@ class ChatCommand extends BaseCommand {
 		);
 
 		$chat_db    = ConversationStoreFactory::get();
-		$session_id = $chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_id, $metadata, $context );
+		$agent_slug = ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
+		$session_id = $chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_slug, $metadata, $context );
 
 		if ( empty( $session_id ) ) {
 			WP_CLI::error( 'Failed to create chat session.' );

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -12,6 +12,7 @@
 namespace DataMachine\Core\Database\Chat;
 
 use DataMachine\Core\Admin\DateFormatter;
+use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\BaseRepository;
 use AgentsAPI\AI\WP_Agent_Message;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
@@ -270,7 +271,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 *
 	 * @param WP_Agent_Workspace_Scope $workspace Workspace owning the session.
 	 * @param int                 $user_id   WordPress user ID.
-	 * @param int                 $agent_id  Agent ID.
+	 * @param string              $agent_slug Registered agent slug.
 	 * @param array               $metadata  Optional session metadata.
 	 * @param string              $context   Execution context (chat, pipeline, system).
 	 * @return string Session ID (UUID)
@@ -278,7 +279,26 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	public function create_session( ...$args ): string {
 		global $wpdb;
 
-		list( $workspace, $user_id, $agent_id, $metadata, $context ) = self::normalize_create_session_args( $args );
+		list( $workspace, $user_id, $agent, $metadata, $context ) = self::normalize_create_session_args( $args );
+
+		try {
+			$identity   = self::resolve_agent_identity_for_session( $agent );
+			$agent_id   = $identity['agent_id'];
+			$agent_slug = $identity['agent_slug'];
+		} catch ( \InvalidArgumentException $e ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Failed to resolve transcript session agent identity',
+				array(
+					'user_id' => $user_id,
+					'agent'   => is_scalar( $agent ) ? (string) $agent : gettype( $agent ),
+					'error'   => $e->getMessage(),
+					'mode'    => $context,
+				)
+			);
+			return '';
+		}
 
 		$session_id = wp_generate_uuid4();
 		$table_name = self::get_prefixed_table_name();
@@ -289,6 +309,9 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				'workspace_id'   => $workspace->workspace_id,
 			)
 		);
+		if ( '' !== $agent_slug ) {
+			$metadata['agent_slug'] = $agent_slug;
+		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$result = $wpdb->insert(
@@ -342,14 +365,14 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 	 * Normalize create-session arguments across current and workspace-aware contracts.
 	 *
 	 * @param array $args Raw method arguments.
-	 * @return array{0:WP_Agent_Workspace_Scope,1:int,2:int,3:array,4:string}
+	 * @return array{0:WP_Agent_Workspace_Scope,1:int,2:int|string,3:array,4:string}
 	 */
 	private static function normalize_create_session_args( array $args ): array {
 		if ( isset( $args[0] ) && $args[0] instanceof WP_Agent_Workspace_Scope ) {
 			return array(
 				$args[0],
 				(int) ( $args[1] ?? 0 ),
-				(int) ( $args[2] ?? 0 ),
+				is_string( $args[2] ?? null ) ? (string) $args[2] : (int) ( $args[2] ?? 0 ),
 				is_array( $args[3] ?? null ) ? $args[3] : array(),
 				(string) ( $args[4] ?? 'chat' ),
 			);
@@ -358,9 +381,50 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		return array(
 			WordPressWorkspaceScope::current(),
 			(int) ( $args[0] ?? 0 ),
-			(int) ( $args[1] ?? 0 ),
+			is_string( $args[1] ?? null ) ? (string) $args[1] : (int) ( $args[1] ?? 0 ),
 			is_array( $args[2] ?? null ) ? $args[2] : array(),
 			(string) ( $args[3] ?? 'chat' ),
+		);
+	}
+
+	/**
+	 * Resolve the generic transcript agent slug to Data Machine's stored agent ID.
+	 *
+	 * Integer input is retained as a Data Machine-internal compatibility path for
+	 * callers that have not crossed the generic Agents API boundary.
+	 *
+	 * @param int|string $agent Agent slug, agent ID, or empty value.
+	 * @return array{agent_id:int,agent_slug:string}
+	 */
+	private static function resolve_agent_identity_for_session( int|string $agent ): array {
+		if ( is_int( $agent ) || is_numeric( $agent ) ) {
+			$agent_id = (int) $agent;
+			if ( $agent_id <= 0 ) {
+				return array(
+					'agent_id'   => 0,
+					'agent_slug' => '',
+				);
+			}
+
+			$identity = ( new AgentIdentityResolver() )->resolve_agent_identity( $agent_id );
+			return array(
+				'agent_id'   => $identity->agent_id,
+				'agent_slug' => $identity->agent_slug,
+			);
+		}
+
+		$agent_slug = AgentIdentityResolver::normalize_agent_slug( $agent );
+		if ( '' === $agent_slug ) {
+			return array(
+				'agent_id'   => 0,
+				'agent_slug' => '',
+			);
+		}
+
+		$identity = ( new AgentIdentityResolver() )->resolve_agent_identity( $agent_slug );
+		return array(
+			'agent_id'   => $identity->agent_id,
+			'agent_slug' => $identity->agent_slug,
 		);
 	}
 
@@ -415,10 +479,31 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			return null;
 		}
 
-		$session['messages'] = self::normalize_messages( json_decode( $session['messages'], true ) ?? array() );
-		$session['metadata'] = json_decode( $session['metadata'], true ) ?? array();
+		$session['messages']   = self::normalize_messages( json_decode( $session['messages'], true ) ?? array() );
+		$session['metadata']   = json_decode( $session['metadata'], true ) ?? array();
+		$session['agent_slug'] = self::resolve_agent_slug_from_session_row( $session );
 
 		return $session;
+	}
+
+	/**
+	 * Resolve the generic transcript agent slug from a stored session row.
+	 *
+	 * @param array<string,mixed> $session Stored session row.
+	 * @return string|null Agent slug when resolvable.
+	 */
+	private static function resolve_agent_slug_from_session_row( array $session ): ?string {
+		$agent_id = isset( $session['agent_id'] ) ? (int) $session['agent_id'] : 0;
+		if ( $agent_id <= 0 ) {
+			return null;
+		}
+
+		try {
+			return ( new AgentIdentityResolver() )->resolve_agent_slug( $agent_id );
+		} catch ( \InvalidArgumentException $e ) {
+			unset( $e );
+			return null;
+		}
 	}
 
 	/**
@@ -935,8 +1020,9 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			return null;
 		}
 
-		$session['messages'] = self::normalize_messages( json_decode( $session['messages'], true ) ?? array() );
-		$session['metadata'] = json_decode( $session['metadata'], true ) ?? array();
+		$session['messages']   = self::normalize_messages( json_decode( $session['messages'], true ) ?? array() );
+		$session['metadata']   = json_decode( $session['metadata'], true ) ?? array();
+		$session['agent_slug'] = self::resolve_agent_slug_from_session_row( $session );
 
 		return $session;
 	}

--- a/inc/Core/Database/Chat/ConversationStoreFactory.php
+++ b/inc/Core/Database/Chat/ConversationStoreFactory.php
@@ -24,6 +24,7 @@ namespace DataMachine\Core\Database\Chat;
 
 use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+use DataMachine\Core\Agents\AgentIdentityResolver;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -130,6 +131,33 @@ class ConversationStoreFactory {
 		$blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 1;
 
 		return WP_Agent_Workspace_Scope::from_parts( 'site', (string) max( 1, $blog_id ) );
+	}
+
+	/**
+	 * Resolve an internal Data Machine agent ID to the generic transcript slug.
+	 *
+	 * @param int $agent_id Internal Data Machine agent ID.
+	 * @return string Registered agent slug, or empty string for agent-less/unknown sessions.
+	 */
+	public static function resolve_agent_slug_for_transcript( int $agent_id ): string {
+		if ( $agent_id <= 0 ) {
+			return '';
+		}
+
+		try {
+			return ( new AgentIdentityResolver() )->resolve_agent_slug( $agent_id );
+		} catch ( \InvalidArgumentException $e ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Unable to resolve agent slug for transcript store call',
+				array(
+					'agent_id' => $agent_id,
+					'error'    => $e->getMessage(),
+				)
+			);
+			return '';
+		}
 	}
 
 	/**

--- a/inc/Core/Database/Chat/ConversationStoreInterface.php
+++ b/inc/Core/Database/Chat/ConversationStoreInterface.php
@@ -21,7 +21,7 @@
  * - normalizing messages on read to Data Machine's canonical AI message envelope
  *   (see docs/development/hooks/core-filters.md#message-shape-contract);
  * - preserving per-session identity via UUIDv4 session IDs;
- * - honoring the `(user_id, agent_id, context)` triple when listing.
+ * - honoring Data Machine's internal `(user_id, agent_id, context)` triple when listing.
  *
  * Session-scope policy (ownership checks, token resolution, agent adoption,
  * listing visibility, title generation, retention schedules) stays in the

--- a/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
+++ b/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
@@ -42,8 +42,11 @@ class DataMachinePipelineTranscriptPersister implements WP_Agent_Transcript_Pers
 		$store     = ConversationStoreFactory::get_transcript_store();
 		$workspace = $request->workspace() ?? WordPressWorkspaceScope::current();
 
-		$user_id  = (int) ( $runtime_context['user_id'] ?? 0 );
-		$agent_id = (int) ( $runtime_context['agent_id'] ?? 0 );
+		$user_id    = (int) ( $runtime_context['user_id'] ?? 0 );
+		$agent_id   = (int) ( $runtime_context['agent_id'] ?? 0 );
+		$agent_slug = ! empty( $runtime_context['agent_slug'] )
+			? (string) $runtime_context['agent_slug']
+			: ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
 
 		$store_metadata = array(
 			'source'       => 'pipeline_transcript',
@@ -73,7 +76,7 @@ class DataMachinePipelineTranscriptPersister implements WP_Agent_Transcript_Pers
 			$store_metadata['request_metadata'] = $result['request_metadata'];
 		}
 
-		$session_id = $store->create_session( $workspace, $user_id, $agent_id, $store_metadata, 'pipeline' );
+		$session_id = $store->create_session( $workspace, $user_id, $agent_slug, $store_metadata, 'pipeline' );
 
 		if ( '' === $session_id ) {
 			do_action(

--- a/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
+++ b/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
@@ -15,6 +15,7 @@
 namespace DataMachine\Tests\Unit\Core\Database\Chat;
 
 use DataMachine\Abilities\Chat\ListChatSessionsAbility;
+use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Chat\Chat;
 use DataMachine\Core\Database\Chat\ConversationReadStateInterface;
 use DataMachine\Core\Database\Chat\ConversationReportingInterface;
@@ -105,6 +106,44 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 				'gpt-test'
 			)
 		);
+	}
+
+	public function test_builtin_chat_store_accepts_agent_slug_and_stores_agent_id(): void {
+		$store      = ConversationStoreFactory::get();
+		$agent_id   = $this->create_agent( 'transcript-slug-agent' );
+		$session_id = $store->create_session( $this->workspace(), 12, 'transcript-slug-agent', array(), 'chat' );
+
+		$session = $store->get_session( $session_id );
+
+		$this->assertNotSame( '', $session_id );
+		$this->assertNotNull( $session );
+		$this->assertSame( $agent_id, (int) $session['agent_id'] );
+		$this->assertSame( 'transcript-slug-agent', $session['agent_slug'] );
+		$this->assertSame( 'transcript-slug-agent', $session['metadata']['agent_slug'] );
+	}
+
+	public function test_builtin_chat_store_keeps_internal_agent_id_compatibility(): void {
+		$store      = ConversationStoreFactory::get();
+		$agent_id   = $this->create_agent( 'transcript-id-agent' );
+		$session_id = $store->create_session( $this->workspace(), 12, $agent_id, array(), 'chat' );
+
+		$session = $store->get_session( $session_id );
+
+		$this->assertNotSame( '', $session_id );
+		$this->assertNotNull( $session );
+		$this->assertSame( $agent_id, (int) $session['agent_id'] );
+		$this->assertSame( 'transcript-id-agent', $session['agent_slug'] );
+	}
+
+	public function test_in_memory_store_accepts_agent_slug_and_exposes_it_on_get_session(): void {
+		$store      = new InMemoryConversationStore();
+		$session_id = $store->create_session( $this->workspace(), 5, 'memory-agent', array(), 'pipeline' );
+
+		$session = $store->get_session( $session_id );
+
+		$this->assertNotNull( $session );
+		$this->assertSame( 'memory-agent', $session['agent_slug'] );
+		$this->assertNull( $session['agent_id'] );
 	}
 
 	public function test_conversation_store_interface_is_composed_from_narrow_contracts(): void {
@@ -413,5 +452,10 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 
 	private function workspace(): WP_Agent_Workspace_Scope {
 		return WP_Agent_Workspace_Scope::from_parts( 'site', 'https://example.test' );
+	}
+
+	private function create_agent( string $slug ): int {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		return ( new Agents() )->create_if_missing( $slug, $slug, $user_id );
 	}
 }

--- a/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
+++ b/tests/Unit/Core/Database/Chat/InMemoryConversationStore.php
@@ -39,11 +39,16 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 	}
 
 	public function create_session( ...$args ): string {
-		list( $workspace, $user_id, $agent_id, $metadata, $context ) = $this->normalize_create_session_args( $args );
+		list( $workspace, $user_id, $agent, $metadata, $context ) = $this->normalize_create_session_args( $args );
+		$agent_id   = is_int( $agent ) ? $agent : 0;
+		$agent_slug = is_string( $agent ) ? sanitize_title( $agent ) : '';
 
 		$session_id = 'mem-' . bin2hex( random_bytes( 6 ) );
 		$now        = gmdate( 'Y-m-d H:i:s' );
 		$metadata   = array_merge( $metadata, $workspace->to_array() );
+		if ( '' !== $agent_slug ) {
+			$metadata['agent_slug'] = $agent_slug;
+		}
 
 		$this->sessions[ $session_id ] = array(
 			'session_id'     => $session_id,
@@ -51,6 +56,7 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 			'workspace_id'   => $workspace->workspace_id,
 			'user_id'        => $user_id,
 			'agent_id'       => $agent_id > 0 ? $agent_id : null,
+			'agent_slug'     => '' !== $agent_slug ? $agent_slug : null,
 			'title'          => null,
 			'messages'       => array(),
 			'metadata'       => $metadata,
@@ -68,14 +74,14 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 
 	/**
 	 * @param array $args Raw create-session arguments.
-	 * @return array{0:WP_Agent_Workspace_Scope,1:int,2:int,3:array,4:string}
+	 * @return array{0:WP_Agent_Workspace_Scope,1:int,2:int|string,3:array,4:string}
 	 */
 	private function normalize_create_session_args( array $args ): array {
 		if ( isset( $args[0] ) && $args[0] instanceof WP_Agent_Workspace_Scope ) {
 			return array(
 				$args[0],
 				(int) ( $args[1] ?? 0 ),
-				(int) ( $args[2] ?? 0 ),
+				is_string( $args[2] ?? null ) ? (string) $args[2] : (int) ( $args[2] ?? 0 ),
 				is_array( $args[3] ?? null ) ? $args[3] : array(),
 				(string) ( $args[4] ?? 'chat' ),
 			);
@@ -84,7 +90,7 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 		return array(
 			WP_Agent_Workspace_Scope::from_parts( 'site', '1' ),
 			(int) ( $args[0] ?? 0 ),
-			(int) ( $args[1] ?? 0 ),
+			is_string( $args[1] ?? null ) ? (string) $args[1] : (int) ( $args[1] ?? 0 ),
 			is_array( $args[2] ?? null ) ? $args[2] : array(),
 			(string) ( $args[3] ?? 'chat' ),
 		);
@@ -115,7 +121,16 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 	}
 
 	public function get_session( string $session_id ): ?array {
-		return $this->sessions[ $session_id ] ?? null;
+		$session = $this->sessions[ $session_id ] ?? null;
+		if ( null === $session ) {
+			return null;
+		}
+
+		if ( ! array_key_exists( 'agent_slug', $session ) ) {
+			$session['agent_slug'] = null;
+		}
+
+		return $session;
 	}
 
 	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '', ?string $provider_response_id = null ): bool {
@@ -206,7 +221,7 @@ class InMemoryConversationStore implements ConversationStoreInterface {
 				'message_count' => count( $messages ),
 				'unread_count'  => $this->count_unread( $messages, $session['last_read_at'] ),
 				'agent_id'      => $session['agent_id'],
-				'agent_slug'    => null,
+				'agent_slug'    => $session['agent_slug'] ?? null,
 				'agent_name'    => null,
 				'created_at'    => $session['created_at'],
 				'updated_at'    => $session['updated_at'],

--- a/tests/agents-api-transcript-store-smoke.php
+++ b/tests/agents-api-transcript-store-smoke.php
@@ -55,7 +55,13 @@ class AgentsApiFakeTranscriptStore implements WP_Agent_Conversation_Store {
 	 */
 	private array $sessions = array();
 
-	public function create_session( \AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace, int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string {
+	public function create_session( ...$args ): string {
+		$workspace   = $args[0];
+		$user_id     = (int) ( $args[1] ?? 0 );
+		$agent       = $args[2] ?? '';
+		$agent_slug  = is_string( $agent ) ? $agent : '';
+		$metadata    = is_array( $args[3] ?? null ) ? $args[3] : array();
+		$context     = (string) ( $args[4] ?? 'chat' );
 		$session_id = 'session-' . ( count( $this->sessions ) + 1 );
 
 		$this->sessions[ $session_id ] = array(
@@ -63,7 +69,7 @@ class AgentsApiFakeTranscriptStore implements WP_Agent_Conversation_Store {
 			'workspace_type' => $workspace->workspace_type,
 			'workspace_id'   => $workspace->workspace_id,
 			'user_id'        => $user_id,
-			'agent_id'       => $agent_id,
+			'agent_slug'     => $agent_slug,
 			'title'          => '',
 			'messages'       => array(),
 			'metadata'       => $metadata,
@@ -137,7 +143,7 @@ $store = new AgentsApiFakeTranscriptStore();
 $assert_true( in_array( WP_Agent_Conversation_Store::class, class_implements( $store ), true ), 'fake store can implement transcript contract without chat product interfaces' );
 
 $workspace  = WP_Agent_Workspace_Scope::from_parts( 'site', 'https://example.test' );
-$session_id = $store->create_session( $workspace, 7, 3, array( 'source' => 'smoke' ), 'pipeline' );
+$session_id = $store->create_session( $workspace, 7, 'smoke-agent', array( 'source' => 'smoke' ), 'pipeline' );
 $assert_true( 'session-1' === $session_id, 'fake store creates transcript session IDs' );
 $assert_true( null !== $store->get_recent_pending_session( $workspace, 7, 600, 'pipeline' ), 'fake store can query pending transcript sessions' );
 

--- a/tests/ai-request-metadata-guardrails-smoke.php
+++ b/tests/ai-request-metadata-guardrails-smoke.php
@@ -121,9 +121,15 @@ class RequestMetadataSmokeStore implements ConversationStoreInterface {
 	public array $sessions = array();
 	public array $updated  = array();
 
-	public function create_session( WP_Agent_Workspace_Scope $workspace, int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string {
+	public function create_session( ...$args ): string {
+		$workspace  = $args[0];
+		$user_id    = (int) ( $args[1] ?? 0 );
+		$agent      = $args[2] ?? '';
+		$agent_slug = is_string( $agent ) ? $agent : '';
+		$metadata   = is_array( $args[3] ?? null ) ? $args[3] : array();
+		$context    = (string) ( $args[4] ?? 'chat' );
 		$metadata['workspace'] = $workspace->to_array();
-		$this->sessions['smoke-session'] = compact( 'user_id', 'agent_id', 'metadata', 'context' );
+		$this->sessions['smoke-session'] = compact( 'user_id', 'agent_slug', 'metadata', 'context' );
 		return 'smoke-session';
 	}
 
@@ -134,6 +140,8 @@ class RequestMetadataSmokeStore implements ConversationStoreInterface {
 		return true;
 	}
 	public function delete_session( string $session_id ): bool { return true; }
+	public function acquire_session_lock( string $session_id, int $ttl_seconds = 300 ): ?string { return 'smoke-lock'; }
+	public function release_session_lock( string $session_id, string $lock_token ): bool { return true; }
 	public function get_user_sessions( int $user_id, int $limit = 20, int $offset = 0, ?string $context = null, ?int $agent_id = null ): array { return array(); }
 	public function get_user_session_count( int $user_id, ?string $context = null, ?int $agent_id = null ): int { return 0; }
 	public function get_recent_pending_session( WP_Agent_Workspace_Scope $workspace, int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array { return null; }


### PR DESCRIPTION
## Summary
- Adapt the Data Machine transcript store boundary so `create_session()` accepts Agents API `agent_slug` values while continuing to persist internal `agent_id` values in `wp_datamachine_chat_sessions`.
- Resolve stored `agent_id` values back to `agent_slug` on session reads and keep the in-memory test adapter aligned with the generic session shape.
- Update direct transcript-store callsites to pass agent slugs, preserving internal ID compatibility as a store-local normalization path.

Closes #1865.

## Dependency / stack
- Built on the `AgentIdentity` / `AgentIdentityResolver` primitives from PR #1871.
- PR #1871 is merged, so this PR targets `main`.
- This is intentionally a boundary translation patch only; it does not implement broad dual-write #1867 or public input migration #1868.

## Testing
- `php -l` on changed PHP files
- `php tests/agents-api-transcript-store-smoke.php`
- `vendor/bin/phpcs <changed files>`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@issue-1865-transcript-agent-slug-adapter --force-hot -- --filter ConversationStoreFactoryTest`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@issue-1865-transcript-agent-slug-adapter --skip-lint --force-hot`

## Notes
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@issue-1865-transcript-agent-slug-adapter --force-hot` still reports existing repository-wide JS lint findings outside this patch.
- `php tests/ai-request-metadata-guardrails-smoke.php` reaches the store double but then fails in this local dependency setup because `WordPress\AiClient\Messages\DTO\MessagePart` is unavailable.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the transcript-store agent slug adapter, updated focused tests, and ran validation; Chris remains responsible for review and merge.