### PR TITLE
Prefer agent slugs for public inputs

### DIFF
--- a/docs/core-system/multi-agent-architecture.md
+++ b/docs/core-system/multi-agent-architecture.md
@@ -214,21 +214,23 @@ Creating an agent:
 |--------|----------|-------------|------------|
 | `GET` | `/datamachine/v1/agents` | List agents (scoped by access grants for non-admins) | Logged-in user |
 | `POST` | `/datamachine/v1/agents` | Create new agent | `manage_agents` |
-| `GET` | `/datamachine/v1/agents/{agent_id}` | Get single agent with details | `manage_agents` |
-| `PUT/PATCH` | `/datamachine/v1/agents/{agent_id}` | Update agent fields | `manage_agents` |
-| `DELETE` | `/datamachine/v1/agents/{agent_id}` | Delete agent (optional `delete_files`) | `manage_agents` |
+| `GET` | `/datamachine/v1/agents/{agent_slug}` | Get single agent with details | `manage_agents` |
+| `PUT/PATCH` | `/datamachine/v1/agents/{agent_slug}` | Update agent fields | `manage_agents` |
+| `DELETE` | `/datamachine/v1/agents/{agent_slug}` | Delete agent (optional `delete_files`) | `manage_agents` |
 
 ### Access Management
 
 | Method | Endpoint | Description | Permission |
 |--------|----------|-------------|------------|
-| `GET` | `/datamachine/v1/agents/{agent_id}/access` | List access grants (enriched with user display names) | `manage_agents` |
-| `POST` | `/datamachine/v1/agents/{agent_id}/access` | Grant access (`user_id` + `role`) | `manage_agents` |
-| `DELETE` | `/datamachine/v1/agents/{agent_id}/access/{user_id}` | Revoke access (blocked for owner) | `manage_agents` |
+| `GET` | `/datamachine/v1/agents/{agent_slug}/access` | List access grants (enriched with user display names) | `manage_agents` |
+| `POST` | `/datamachine/v1/agents/{agent_slug}/access` | Grant access (`user_id` + `role`) | `manage_agents` |
+| `DELETE` | `/datamachine/v1/agents/{agent_slug}/access/{user_id}` | Revoke access (blocked for owner) | `manage_agents` |
+
+Numeric `{agent_id}` routes remain supported for compatibility, but new public integrations should use `{agent_slug}`.
 
 **List scoping:** The `GET /agents` endpoint is accessible to any logged-in user. Admins see all agents. Non-admin users only see agents they have explicit access grants for — the endpoint queries `AgentAccess::get_agent_ids_for_user()` to filter results.
 
-**Owner protection:** The `DELETE /agents/{agent_id}/access/{user_id}` endpoint prevents revoking the owner's access. Ownership must be transferred before the owner's grant can be removed.
+**Owner protection:** The `DELETE /agents/{agent_slug}/access/{user_id}` endpoint prevents revoking the owner's access. Ownership must be transferred before the owner's grant can be removed.
 
 ## CLI
 

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -13,6 +13,7 @@ namespace DataMachine\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Agents\AgentBundler;
+use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Agents\AgentAccess;
 use DataMachine\Core\FilesRepository\DirectoryManager;
@@ -46,11 +47,18 @@ class AgentAbilities {
 					'category'            => 'datamachine-agent',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'required'   => array( 'agent_id' ),
 						'properties' => array(
+							'agent'       => array(
+								'type'        => 'string',
+								'description' => 'Agent slug or ID to export. Slugs are preferred.',
+							),
+							'agent_slug'  => array(
+								'type'        => 'string',
+								'description' => 'Agent slug to export. Prefer agent for new callers.',
+							),
 							'agent_id'    => array(
 								'type'        => 'integer',
-								'description' => 'Agent ID to export.',
+								'description' => 'Agent ID to export. Supported for compatibility; prefer agent slug.',
 							),
 							'profile'     => array(
 								'type'        => 'string',
@@ -334,11 +342,18 @@ class AgentAbilities {
 					'category'            => 'datamachine-agent',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'required'   => array( 'agent_id' ),
 						'properties' => array(
+							'agent'        => array(
+								'type'        => 'string',
+								'description' => 'Agent slug or ID to update. Slugs are preferred.',
+							),
+							'agent_slug'   => array(
+								'type'        => 'string',
+								'description' => 'Agent slug to update. Prefer agent for new callers.',
+							),
 							'agent_id'     => array(
 								'type'        => 'integer',
-								'description' => 'Agent ID to update.',
+								'description' => 'Agent ID to update. Supported for compatibility; prefer agent slug.',
 							),
 							'agent_name'   => array(
 								'type'        => 'string',
@@ -373,13 +388,17 @@ class AgentAbilities {
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
+							'agent'        => array(
+								'type'        => 'string',
+								'description' => 'Agent slug or ID to delete. Slugs are preferred.',
+							),
 							'agent_slug'   => array(
 								'type'        => 'string',
-								'description' => 'Agent slug (provide this or agent_id).',
+								'description' => 'Agent slug to delete. Prefer agent for new callers.',
 							),
 							'agent_id'     => array(
 								'type'        => 'integer',
-								'description' => 'Agent ID (provide this or agent_slug).',
+								'description' => 'Agent ID to delete. Supported for compatibility; prefer agent slug.',
 							),
 							'delete_files' => array(
 								'type'        => 'boolean',
@@ -1083,20 +1102,64 @@ class AgentAbilities {
 	}
 
 	/**
+	 * Resolve public agent ability input to the internal agent ID.
+	 *
+	 * Accepts the slug-first `agent`/`agent_slug` inputs and keeps `agent_id`
+	 * working for callers that still pass the storage key.
+	 *
+	 * @param array $input Ability input.
+	 * @return int|\WP_Error Agent ID or error.
+	 */
+	private static function resolve_agent_input_id( array $input ): int|\WP_Error {
+		$context = array();
+
+		if ( isset( $input['agent'] ) && '' !== (string) $input['agent'] ) {
+			$context['agent'] = (string) $input['agent'];
+		}
+
+		if ( isset( $input['agent_slug'] ) && '' !== (string) $input['agent_slug'] ) {
+			$context['agent_slug'] = (string) $input['agent_slug'];
+		}
+
+		if ( isset( $input['agent_id'] ) && (int) $input['agent_id'] > 0 ) {
+			$context['agent_id'] = (int) $input['agent_id'];
+		}
+
+		if ( isset( $context['agent'] ) ) {
+			try {
+				$identity = ( new AgentIdentityResolver() )->resolve_agent_identity( $context['agent'] );
+				unset( $context['agent'] );
+				$context['agent_id']   = $context['agent_id'] ?? $identity->agent_id;
+				$context['agent_slug'] = $context['agent_slug'] ?? $identity->agent_slug;
+			} catch ( \InvalidArgumentException $e ) {
+				return new \WP_Error( 'agent_not_found', $e->getMessage() );
+			}
+		}
+
+		try {
+			return ( new AgentIdentityResolver() )->resolve_agent_identity( $context )->agent_id;
+		} catch ( \InvalidArgumentException $e ) {
+			return new \WP_Error( 'agent_not_found', $e->getMessage() );
+		}
+	}
+
+	/**
 	 * Get a single agent by slug or ID.
 	 *
 	 * @param array $input { agent_slug or agent_id }.
 	 * @return array Agent data or error.
 	 */
 	public static function getAgent( array $input ): array {
-		$agents_repo = new Agents();
-		$agent       = null;
-
-		if ( ! empty( $input['agent_slug'] ) ) {
-			$agent = $agents_repo->get_by_slug( sanitize_title( $input['agent_slug'] ) );
-		} elseif ( ! empty( $input['agent_id'] ) ) {
-			$agent = $agents_repo->get_agent( (int) $input['agent_id'] );
+		$agent_id = self::resolve_agent_input_id( $input );
+		if ( is_wp_error( $agent_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => $agent_id->get_error_message(),
+			);
 		}
+
+		$agents_repo = new Agents();
+		$agent       = $agents_repo->get_agent( $agent_id );
 
 		if ( ! $agent ) {
 			return array(
@@ -1142,12 +1205,11 @@ class AgentAbilities {
 	 * @return array Result with updated agent data.
 	 */
 	public static function updateAgent( array $input ): array {
-		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-
-		if ( $agent_id <= 0 ) {
+		$agent_id = self::resolve_agent_input_id( $input );
+		if ( is_wp_error( $agent_id ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'agent_id is required.',
+				'error'   => $agent_id->get_error_message(),
 			);
 		}
 
@@ -1314,11 +1376,11 @@ class AgentAbilities {
 	 * @return array Result.
 	 */
 	public static function exportAgent( array $input ): array {
-		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		if ( $agent_id <= 0 ) {
+		$agent_id = self::resolve_agent_input_id( $input );
+		if ( is_wp_error( $agent_id ) ) {
 			return array(
 				'success' => false,
-				'error'   => 'agent_id is required.',
+				'error'   => $agent_id->get_error_message(),
 			);
 		}
 
@@ -1452,14 +1514,16 @@ class AgentAbilities {
 	 * @return array Result.
 	 */
 	public static function deleteAgent( array $input ): array {
-		$agents_repo = new Agents();
-		$agent       = null;
-
-		if ( ! empty( $input['agent_slug'] ) ) {
-			$agent = $agents_repo->get_by_slug( sanitize_title( $input['agent_slug'] ) );
-		} elseif ( ! empty( $input['agent_id'] ) ) {
-			$agent = $agents_repo->get_agent( (int) $input['agent_id'] );
+		$agent_id = self::resolve_agent_input_id( $input );
+		if ( is_wp_error( $agent_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => $agent_id->get_error_message(),
+			);
 		}
+
+		$agents_repo = new Agents();
+		$agent       = $agents_repo->get_agent( $agent_id );
 
 		if ( ! $agent ) {
 			return array(

--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -524,12 +524,41 @@ class PermissionHelper {
 	 * @return int|null Agent ID to filter by, or null for all agents (admin default).
 	 */
 	public static function resolve_scoped_agent_id( \WP_REST_Request $request, string $action = 'manage_flows' ): ?int {
+		$requested_agent    = $request->get_param( 'agent' );
 		$requested_agent_id = $request->get_param( 'agent_id' );
+		$requested_slug     = $request->get_param( 'agent_slug' );
 		$is_admin           = self::can( $action );
 
-		// Explicit agent_id parameter — use it if caller has access.
-		if ( null !== $requested_agent_id && '' !== $requested_agent_id ) {
-			$agent_id = (int) $requested_agent_id;
+		// Explicit agent parameter — use it if caller has access. `agent` and
+		// `agent_slug` are slug-first aliases; `agent_id` remains compatible.
+		if (
+			( null !== $requested_agent && '' !== $requested_agent )
+			|| ( null !== $requested_slug && '' !== $requested_slug )
+			|| ( null !== $requested_agent_id && '' !== $requested_agent_id )
+		) {
+			$context = array();
+			if ( null !== $requested_agent && '' !== $requested_agent ) {
+				$context['agent'] = (string) $requested_agent;
+			}
+			if ( null !== $requested_slug && '' !== $requested_slug ) {
+				$context['agent_slug'] = (string) $requested_slug;
+			}
+			if ( null !== $requested_agent_id && '' !== $requested_agent_id ) {
+				$context['agent_id'] = (int) $requested_agent_id;
+			}
+
+			try {
+				if ( isset( $context['agent'] ) ) {
+					$identity = ( new \DataMachine\Core\Agents\AgentIdentityResolver() )->resolve_agent_identity( $context['agent'] );
+					unset( $context['agent'] );
+					$context['agent_id']   = $context['agent_id'] ?? $identity->agent_id;
+					$context['agent_slug'] = $context['agent_slug'] ?? $identity->agent_slug;
+				}
+
+				$agent_id = ( new \DataMachine\Core\Agents\AgentIdentityResolver() )->resolve_agent_identity( $context )->agent_id;
+			} catch ( \InvalidArgumentException $e ) {
+				return null;
+			}
 
 			// Admins can access any agent.
 			if ( $is_admin ) {

--- a/inc/Api/Agents.php
+++ b/inc/Api/Agents.php
@@ -14,6 +14,7 @@ namespace DataMachine\Api;
 
 use DataMachine\Abilities\AgentAbilities;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
 use DataMachine\Core\Database\Agents\AgentAccess;
 use WP_REST_Request;
@@ -93,20 +94,27 @@ class Agents {
 			)
 		);
 
-		// Single agent: get, update, delete.
+		$agent_resource_routes = array(
+			'/agents/(?P<agent>[A-Za-z0-9_-]+)',
+			'/agents/(?P<agent_id>\d+)',
+		);
+
+		// Single agent: get, update, delete. Slug routes are preferred; numeric ID
+		// routes remain for compatibility with existing integrations.
+		foreach ( $agent_resource_routes as $agent_resource_route ) {
 		register_rest_route(
 			'datamachine/v1',
-			'/agents/(?P<agent_id>\d+)',
+			$agent_resource_route,
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'handle_get' ),
 					'permission_callback' => $manage_permission,
 					'args'                => array(
-						'agent_id' => array(
-							'type'              => 'integer',
-							'required'          => true,
-							'sanitize_callback' => 'absint',
+						'agent' => array(
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
 				),
@@ -115,10 +123,10 @@ class Agents {
 					'callback'            => array( self::class, 'handle_update' ),
 					'permission_callback' => $manage_permission,
 					'args'                => array(
-						'agent_id'     => array(
-							'type'              => 'integer',
-							'required'          => true,
-							'sanitize_callback' => 'absint',
+						'agent'        => array(
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'agent_name'   => array(
 							'type'              => 'string',
@@ -138,10 +146,10 @@ class Agents {
 					'callback'            => array( self::class, 'handle_delete' ),
 					'permission_callback' => $manage_permission,
 					'args'                => array(
-						'agent_id'     => array(
-							'type'              => 'integer',
-							'required'          => true,
-							'sanitize_callback' => 'absint',
+						'agent'        => array(
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'delete_files' => array(
 							'type'        => 'boolean',
@@ -153,21 +161,28 @@ class Agents {
 				),
 			)
 		);
+		}
+
+		$agent_access_routes = array(
+			'/agents/(?P<agent>[A-Za-z0-9_-]+)/access',
+			'/agents/(?P<agent_id>\d+)/access',
+		);
 
 		// Agent access management.
+		foreach ( $agent_access_routes as $agent_access_route ) {
 		register_rest_route(
 			'datamachine/v1',
-			'/agents/(?P<agent_id>\d+)/access',
+			$agent_access_route,
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'handle_list_access' ),
 					'permission_callback' => $manage_permission,
 					'args'                => array(
-						'agent_id' => array(
-							'type'              => 'integer',
-							'required'          => true,
-							'sanitize_callback' => 'absint',
+						'agent' => array(
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
 				),
@@ -176,10 +191,10 @@ class Agents {
 					'callback'            => array( self::class, 'handle_grant_access' ),
 					'permission_callback' => $manage_permission,
 					'args'                => array(
-						'agent_id' => array(
-							'type'              => 'integer',
-							'required'          => true,
-							'sanitize_callback' => 'absint',
+						'agent'   => array(
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'user_id'  => array(
 							'type'              => 'integer',
@@ -201,20 +216,27 @@ class Agents {
 				),
 			)
 		);
+		}
+
+		$agent_revoke_routes = array(
+			'/agents/(?P<agent>[A-Za-z0-9_-]+)/access/(?P<user_id>\d+)',
+			'/agents/(?P<agent_id>\d+)/access/(?P<user_id>\d+)',
+		);
 
 		// Revoke access (DELETE with user_id in URL).
+		foreach ( $agent_revoke_routes as $agent_revoke_route ) {
 		register_rest_route(
 			'datamachine/v1',
-			'/agents/(?P<agent_id>\d+)/access/(?P<user_id>\d+)',
+			$agent_revoke_route,
 			array(
 				'methods'             => WP_REST_Server::DELETABLE,
 				'callback'            => array( self::class, 'handle_revoke_access' ),
 				'permission_callback' => $manage_permission,
 				'args'                => array(
-					'agent_id' => array(
-						'type'              => 'integer',
-						'required'          => true,
-						'sanitize_callback' => 'absint',
+					'agent'   => array(
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
 					),
 					'user_id'  => array(
 						'type'              => 'integer',
@@ -224,21 +246,28 @@ class Agents {
 				),
 			)
 		);
+		}
+
+		$agent_token_routes = array(
+			'/agents/(?P<agent>[A-Za-z0-9_-]+)/tokens',
+			'/agents/(?P<agent_id>\d+)/tokens',
+		);
 
 		// Agent tokens: list and create.
+		foreach ( $agent_token_routes as $agent_token_route ) {
 		register_rest_route(
 			'datamachine/v1',
-			'/agents/(?P<agent_id>\d+)/tokens',
+			$agent_token_route,
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( self::class, 'handle_list_tokens' ),
 					'permission_callback' => $manage_permission,
 					'args'                => array(
-						'agent_id' => array(
-							'type'              => 'integer',
-							'required'          => true,
-							'sanitize_callback' => 'absint',
+						'agent' => array(
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
 				),
@@ -247,10 +276,10 @@ class Agents {
 					'callback'            => array( self::class, 'handle_create_token' ),
 					'permission_callback' => $manage_permission,
 					'args'                => array(
-						'agent_id'     => array(
-							'type'              => 'integer',
-							'required'          => true,
-							'sanitize_callback' => 'absint',
+						'agent'        => array(
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'label'        => array(
 							'type'              => 'string',
@@ -273,20 +302,27 @@ class Agents {
 				),
 			)
 		);
+		}
+
+		$agent_revoke_token_routes = array(
+			'/agents/(?P<agent>[A-Za-z0-9_-]+)/tokens/(?P<token_id>\d+)',
+			'/agents/(?P<agent_id>\d+)/tokens/(?P<token_id>\d+)',
+		);
 
 		// Revoke a specific token.
+		foreach ( $agent_revoke_token_routes as $agent_revoke_token_route ) {
 		register_rest_route(
 			'datamachine/v1',
-			'/agents/(?P<agent_id>\d+)/tokens/(?P<token_id>\d+)',
+			$agent_revoke_token_route,
 			array(
 				'methods'             => WP_REST_Server::DELETABLE,
 				'callback'            => array( self::class, 'handle_revoke_token' ),
 				'permission_callback' => $manage_permission,
 				'args'                => array(
-					'agent_id' => array(
-						'type'              => 'integer',
-						'required'          => true,
-						'sanitize_callback' => 'absint',
+					'agent'   => array(
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
 					),
 					'token_id' => array(
 						'type'              => 'integer',
@@ -296,6 +332,7 @@ class Agents {
 				),
 			)
 		);
+		}
 	}
 
 	// ---------------------------------------------------------------
@@ -496,8 +533,13 @@ class Agents {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public static function handle_get( WP_REST_Request $request ) {
+		$agent_id = self::resolve_request_agent_id( $request );
+		if ( is_wp_error( $agent_id ) ) {
+			return $agent_id;
+		}
+
 		$result = AgentAbilities::getAgent(
-			array( 'agent_id' => (int) $request->get_param( 'agent_id' ) )
+			array( 'agent_id' => $agent_id )
 		);
 
 		if ( empty( $result['success'] ) ) {
@@ -523,7 +565,12 @@ class Agents {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public static function handle_update( WP_REST_Request $request ) {
-		$input = array( 'agent_id' => (int) $request->get_param( 'agent_id' ) );
+		$agent_id = self::resolve_request_agent_id( $request );
+		if ( is_wp_error( $agent_id ) ) {
+			return $agent_id;
+		}
+
+		$input = array( 'agent_id' => $agent_id );
 
 		// Only include fields that were actually sent.
 		$json_params = $request->get_json_params() ?? array();
@@ -565,9 +612,14 @@ class Agents {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public static function handle_delete( WP_REST_Request $request ) {
+		$agent_id = self::resolve_request_agent_id( $request );
+		if ( is_wp_error( $agent_id ) ) {
+			return $agent_id;
+		}
+
 		$result = AgentAbilities::deleteAgent(
 			array(
-				'agent_id'     => (int) $request->get_param( 'agent_id' ),
+				'agent_id'     => $agent_id,
 				'delete_files' => (bool) $request->get_param( 'delete_files' ),
 			)
 		);
@@ -599,7 +651,10 @@ class Agents {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public static function handle_list_access( WP_REST_Request $request ) {
-		$agent_id = (int) $request->get_param( 'agent_id' );
+		$agent_id = self::resolve_request_agent_id( $request );
+		if ( is_wp_error( $agent_id ) ) {
+			return $agent_id;
+		}
 
 		// Verify agent exists.
 		$agents_repo = new AgentsRepository();
@@ -644,7 +699,11 @@ class Agents {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public static function handle_grant_access( WP_REST_Request $request ) {
-		$agent_id = (int) $request->get_param( 'agent_id' );
+		$agent_id = self::resolve_request_agent_id( $request );
+		if ( is_wp_error( $agent_id ) ) {
+			return $agent_id;
+		}
+
 		$user_id  = (int) $request->get_param( 'user_id' );
 		$role     = $request->get_param( 'role' );
 
@@ -706,7 +765,11 @@ class Agents {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public static function handle_revoke_access( WP_REST_Request $request ) {
-		$agent_id = (int) $request->get_param( 'agent_id' );
+		$agent_id = self::resolve_request_agent_id( $request );
+		if ( is_wp_error( $agent_id ) ) {
+			return $agent_id;
+		}
+
 		$user_id  = (int) $request->get_param( 'user_id' );
 
 		// Verify agent exists.
@@ -764,9 +827,14 @@ class Agents {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public static function handle_list_tokens( WP_REST_Request $request ) {
+		$agent_id = self::resolve_request_agent_id( $request );
+		if ( is_wp_error( $agent_id ) ) {
+			return $agent_id;
+		}
+
 		$abilities = new \DataMachine\Abilities\AgentTokenAbilities();
 		$result    = $abilities->executeListTokens(
-			array( 'agent_id' => (int) $request->get_param( 'agent_id' ) )
+			array( 'agent_id' => $agent_id )
 		);
 
 		if ( empty( $result['success'] ) ) {
@@ -783,10 +851,15 @@ class Agents {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public static function handle_create_token( WP_REST_Request $request ) {
+		$agent_id = self::resolve_request_agent_id( $request );
+		if ( is_wp_error( $agent_id ) ) {
+			return $agent_id;
+		}
+
 		$abilities = new \DataMachine\Abilities\AgentTokenAbilities();
 		$result    = $abilities->executeCreateToken(
 			array(
-				'agent_id'     => (int) $request->get_param( 'agent_id' ),
+				'agent_id'     => $agent_id,
 				'label'        => $request->get_param( 'label' ) ?? '',
 				'capabilities' => $request->get_param( 'capabilities' ),
 				'expires_in'   => $request->get_param( 'expires_in' ),
@@ -808,10 +881,15 @@ class Agents {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public static function handle_revoke_token( WP_REST_Request $request ) {
+		$agent_id = self::resolve_request_agent_id( $request );
+		if ( is_wp_error( $agent_id ) ) {
+			return $agent_id;
+		}
+
 		$abilities = new \DataMachine\Abilities\AgentTokenAbilities();
 		$result    = $abilities->executeRevokeToken(
 			array(
-				'agent_id' => (int) $request->get_param( 'agent_id' ),
+				'agent_id' => $agent_id,
 				'token_id' => (int) $request->get_param( 'token_id' ),
 			)
 		);
@@ -827,6 +905,29 @@ class Agents {
 	// ---------------------------------------------------------------
 	// Helpers
 	// ---------------------------------------------------------------
+
+	/**
+	 * Resolve a REST route agent parameter to the internal agent ID.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return int|WP_Error Agent ID or REST error.
+	 */
+	private static function resolve_request_agent_id( WP_REST_Request $request ): int|WP_Error {
+		$agent = $request->get_param( 'agent' );
+		if ( null === $agent || '' === $agent ) {
+			$agent = $request->get_param( 'agent_id' );
+		}
+
+		try {
+			return ( new AgentIdentityResolver() )->resolve_agent_id( (string) $agent );
+		} catch ( \InvalidArgumentException $e ) {
+			return new WP_Error(
+				'agent_not_found',
+				$e->getMessage(),
+				array( 'status' => 404 )
+			);
+		}
+	}
 
 	/**
 	 * Permission callback — any logged-in user can list their agents.

--- a/inc/Api/Agents.php
+++ b/inc/Api/Agents.php
@@ -102,7 +102,7 @@ class Agents {
 		// Single agent: get, update, delete. Slug routes are preferred; numeric ID
 		// routes remain for compatibility with existing integrations.
 		foreach ( $agent_resource_routes as $agent_resource_route ) {
-		register_rest_route(
+			register_rest_route(
 			'datamachine/v1',
 			$agent_resource_route,
 			array(
@@ -160,7 +160,7 @@ class Agents {
 					),
 				),
 			)
-		);
+			);
 		}
 
 		$agent_access_routes = array(
@@ -170,7 +170,7 @@ class Agents {
 
 		// Agent access management.
 		foreach ( $agent_access_routes as $agent_access_route ) {
-		register_rest_route(
+			register_rest_route(
 			'datamachine/v1',
 			$agent_access_route,
 			array(
@@ -196,13 +196,13 @@ class Agents {
 							'required'          => false,
 							'sanitize_callback' => 'sanitize_text_field',
 						),
-						'user_id'  => array(
+						'user_id' => array(
 							'type'              => 'integer',
 							'required'          => true,
 							'description'       => __( 'WordPress user ID to grant access to.', 'data-machine' ),
 							'sanitize_callback' => 'absint',
 						),
-						'role'     => array(
+						'role'    => array(
 							'type'              => 'string',
 							'required'          => false,
 							'default'           => 'viewer',
@@ -215,7 +215,7 @@ class Agents {
 					),
 				),
 			)
-		);
+			);
 		}
 
 		$agent_revoke_routes = array(
@@ -225,7 +225,7 @@ class Agents {
 
 		// Revoke access (DELETE with user_id in URL).
 		foreach ( $agent_revoke_routes as $agent_revoke_route ) {
-		register_rest_route(
+			register_rest_route(
 			'datamachine/v1',
 			$agent_revoke_route,
 			array(
@@ -238,14 +238,14 @@ class Agents {
 						'required'          => false,
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'user_id'  => array(
+					'user_id' => array(
 						'type'              => 'integer',
 						'required'          => true,
 						'sanitize_callback' => 'absint',
 					),
 				),
 			)
-		);
+			);
 		}
 
 		$agent_token_routes = array(
@@ -255,7 +255,7 @@ class Agents {
 
 		// Agent tokens: list and create.
 		foreach ( $agent_token_routes as $agent_token_route ) {
-		register_rest_route(
+			register_rest_route(
 			'datamachine/v1',
 			$agent_token_route,
 			array(
@@ -301,7 +301,7 @@ class Agents {
 					),
 				),
 			)
-		);
+			);
 		}
 
 		$agent_revoke_token_routes = array(
@@ -311,7 +311,7 @@ class Agents {
 
 		// Revoke a specific token.
 		foreach ( $agent_revoke_token_routes as $agent_revoke_token_route ) {
-		register_rest_route(
+			register_rest_route(
 			'datamachine/v1',
 			$agent_revoke_token_route,
 			array(
@@ -319,7 +319,7 @@ class Agents {
 				'callback'            => array( self::class, 'handle_revoke_token' ),
 				'permission_callback' => $manage_permission,
 				'args'                => array(
-					'agent'   => array(
+					'agent'    => array(
 						'type'              => 'string',
 						'required'          => false,
 						'sanitize_callback' => 'sanitize_text_field',
@@ -331,7 +331,7 @@ class Agents {
 					),
 				),
 			)
-		);
+			);
 		}
 	}
 
@@ -704,8 +704,8 @@ class Agents {
 			return $agent_id;
 		}
 
-		$user_id  = (int) $request->get_param( 'user_id' );
-		$role     = $request->get_param( 'role' );
+		$user_id = (int) $request->get_param( 'user_id' );
+		$role    = $request->get_param( 'role' );
 
 		// Verify agent exists.
 		$agents_repo = new AgentsRepository();
@@ -770,7 +770,7 @@ class Agents {
 			return $agent_id;
 		}
 
-		$user_id  = (int) $request->get_param( 'user_id' );
+		$user_id = (int) $request->get_param( 'user_id' );
 
 		// Verify agent exists.
 		$agents_repo = new AgentsRepository();

--- a/tests/Unit/Abilities/AgentAbilitiesTest.php
+++ b/tests/Unit/Abilities/AgentAbilitiesTest.php
@@ -130,6 +130,21 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'id-lookup-bot', $result['agent']['agent_slug'] );
 	}
 
+	public function test_getAgent_by_generic_agent_slug(): void {
+		$created = AgentAbilities::createAgent(
+			array(
+				'agent_slug' => 'generic-lookup-bot',
+				'owner_id'   => $this->admin_id,
+			)
+		);
+
+		$result = AgentAbilities::getAgent( array( 'agent' => 'generic-lookup-bot' ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $created['agent_id'], $result['agent']['agent_id'] );
+		$this->assertSame( 'generic-lookup-bot', $result['agent']['agent_slug'] );
+	}
+
 	public function test_getAgent_not_found(): void {
 		$result = AgentAbilities::getAgent( array( 'agent_slug' => 'nonexistent-bot' ) );
 
@@ -232,6 +247,26 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'New Name', $result['agent']['agent_name'] );
 	}
 
+	public function test_updateAgent_accepts_agent_slug_alias(): void {
+		AgentAbilities::createAgent(
+			array(
+				'agent_slug' => 'slug-update-bot',
+				'agent_name' => 'Old Slug Name',
+				'owner_id'   => $this->admin_id,
+			)
+		);
+
+		$result = AgentAbilities::updateAgent(
+			array(
+				'agent'      => 'slug-update-bot',
+				'agent_name' => 'New Slug Name',
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'New Slug Name', $result['agent']['agent_name'] );
+	}
+
 	public function test_updateAgent_config(): void {
 		$created = AgentAbilities::createAgent(
 			array(
@@ -275,11 +310,30 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'anthropic', $result['agent']['agent_config']['provider'] );
 	}
 
-	public function test_updateAgent_requires_agent_id(): void {
+	public function test_updateAgent_requires_agent_identity(): void {
 		$result = AgentAbilities::updateAgent( array( 'agent_name' => 'Orphan' ) );
 
 		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'agent_id', $result['error'] );
+		$this->assertStringContainsString( 'Agent identity', $result['error'] );
+	}
+
+	public function test_exportAgent_accepts_agent_slug_alias(): void {
+		AgentAbilities::createAgent(
+			array(
+				'agent_slug' => 'slug-export-bot',
+				'owner_id'   => $this->admin_id,
+			)
+		);
+
+		$result = AgentAbilities::exportAgent(
+			array(
+				'agent'       => 'slug-export-bot',
+				'destination' => sys_get_temp_dir() . '/datamachine-slug-export-bot-' . wp_generate_uuid4(),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'slug-export-bot', $result['agent_slug'] );
 	}
 
 	public function test_updateAgent_rejects_not_found(): void {

--- a/tests/Unit/Api/AgentsEndpointSlugTest.php
+++ b/tests/Unit/Api/AgentsEndpointSlugTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Agents REST slug route handler tests.
+ *
+ * @package DataMachine\Tests\Unit\Api
+ */
+
+namespace DataMachine\Tests\Unit\Api;
+
+use DataMachine\Api\Agents as AgentsRest;
+use DataMachine\Core\Database\Agents\AgentAccess;
+use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
+class AgentsEndpointSlugTest extends WP_UnitTestCase {
+
+	private AgentsRepository $repo;
+	private AgentAccess $access_repo;
+	private int $admin_user;
+	private int $owner_user;
+	private int $granted_user;
+
+	public function set_up(): void {
+		parent::set_up();
+		datamachine_register_capabilities();
+
+		$this->repo         = new AgentsRepository();
+		$this->access_repo  = new AgentAccess();
+		$this->admin_user   = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->owner_user   = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->granted_user = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		wp_set_current_user( $this->admin_user );
+	}
+
+	public function tear_down(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agents" );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agent_access" );
+
+		parent::tear_down();
+	}
+
+	public function test_get_agent_accepts_slug_route_param(): void {
+		$agent_id = $this->repo->create_if_missing( 'rest-slug-bot', 'REST Slug Bot', $this->owner_user );
+		$request  = new WP_REST_Request( 'GET', '/datamachine/v1/agents/rest-slug-bot' );
+		$request->set_param( 'agent', 'rest-slug-bot' );
+
+		$response = AgentsRest::handle_get( $request );
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+		$this->assertSame( $agent_id, $data['data']['agent_id'] );
+		$this->assertSame( 'rest-slug-bot', $data['data']['agent_slug'] );
+	}
+
+	public function test_get_agent_keeps_numeric_id_route_compatibility(): void {
+		$agent_id = $this->repo->create_if_missing( 'rest-id-bot', 'REST ID Bot', $this->owner_user );
+		$request  = new WP_REST_Request( 'GET', '/datamachine/v1/agents/' . $agent_id );
+		$request->set_param( 'agent_id', $agent_id );
+
+		$response = AgentsRest::handle_get( $request );
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+		$this->assertSame( 'rest-id-bot', $data['data']['agent_slug'] );
+	}
+
+	public function test_update_agent_accepts_slug_route_param(): void {
+		$this->repo->create_if_missing( 'rest-update-bot', 'Before', $this->owner_user );
+
+		$request = new WP_REST_Request( 'PATCH', '/datamachine/v1/agents/rest-update-bot' );
+		$request->set_param( 'agent', 'rest-update-bot' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'agent_name' => 'After' ) ) );
+
+		$response = AgentsRest::handle_update( $request );
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+		$this->assertSame( 'After', $data['data']['agent_name'] );
+	}
+
+	public function test_list_access_accepts_slug_route_param(): void {
+		$agent_id = $this->repo->create_if_missing( 'rest-access-bot', 'REST Access Bot', $this->owner_user );
+		$this->access_repo->grant_access( new \WP_Agent_Access_Grant( (string) $agent_id, $this->granted_user, 'operator' ) );
+
+		$request = new WP_REST_Request( 'GET', '/datamachine/v1/agents/rest-access-bot/access' );
+		$request->set_param( 'agent', 'rest-access-bot' );
+
+		$response = AgentsRest::handle_list_access( $request );
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+		$this->assertCount( 1, $data['data'] );
+		$this->assertSame( $this->granted_user, (int) $data['data'][0]['user_id'] );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds slug-first REST aliases for agent resource, access, and token endpoints while preserving numeric ID routes.
- Routes public `agent`, `agent_slug`, and legacy `agent_id` inputs through `AgentIdentityResolver` for agent abilities and scoped REST filtering.
- Updates agent docs and tests to cover slug inputs plus numeric ID compatibility.

Closes #1868

## Tests
- `php -l inc/Api/Agents.php && php -l inc/Abilities/AgentAbilities.php && php -l inc/Abilities/PermissionHelper.php && php -l tests/Unit/Api/AgentsEndpointSlugTest.php && php -l tests/Unit/Abilities/AgentAbilitiesTest.php`
- `homeboy test data-machine -- --filter='AgentAbilitiesTest|AgentsEndpointSlugTest|AgentIdentityResolverTest|AgentResolverTest'`
- `homeboy test data-machine`
- `homeboy lint data-machine --changed-since origin/main`

## Notes
- Full `homeboy lint --path /Users/chubes/Developer/data-machine@issue-1868-slug-first-public-inputs --extension wordpress` still reports pre-existing unrelated React/JS findings outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the slug-first public input aliases, resolver routing, focused tests, and documentation updates; Chris remains responsible for review and validation.