### PR TITLE
Carry agent slugs through runtime contexts

### DIFF
--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -14,6 +14,7 @@
 
 namespace DataMachine\Abilities\Engine;
 
+use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Engine\ExecutionPlan;
 
 defined( 'ABSPATH' ) || exit;
@@ -131,6 +132,15 @@ class RunFlowAbility {
 
 		$pipeline_id = (int) $flow['pipeline_id'];
 
+		$agent_identity = null;
+		if ( ! empty( $flow['agent_id'] ) ) {
+			try {
+				$agent_identity = ( new AgentIdentityResolver() )->resolve_agent_identity( (int) $flow['agent_id'] );
+			} catch ( \InvalidArgumentException $e ) {
+				$agent_identity = null;
+			}
+		}
+
 		// Use provided job_id or create new one (for scheduled/recurring flows).
 		if ( ! $job_id ) {
 			$job_data = array(
@@ -142,8 +152,8 @@ class RunFlowAbility {
 			);
 
 			// Propagate agent_id from flow to job.
-			if ( ! empty( $flow['agent_id'] ) ) {
-				$job_data['agent_id'] = (int) $flow['agent_id'];
+			if ( null !== $agent_identity ) {
+				$job_data['agent_id'] = $agent_identity->agent_id;
 			}
 
 			$job_id = $this->db_jobs->create_job( $job_data );
@@ -195,8 +205,9 @@ class RunFlowAbility {
 			'created_at'  => current_time( 'mysql', true ),
 		);
 
-		if ( ! empty( $flow['agent_id'] ) ) {
-			$job_snapshot['agent_id'] = (int) $flow['agent_id'];
+		if ( null !== $agent_identity ) {
+			$job_snapshot['agent_id']   = $agent_identity->agent_id;
+			$job_snapshot['agent_slug'] = $agent_identity->agent_slug;
 		}
 
 		$engine_snapshot = array(

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Abilities\Job;
 
+use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Steps\WorkflowConfigFactory;
 use DataMachine\Core\Steps\WorkflowSpecValidator;
 use DataMachine\Engine\ExecutionPlan;
@@ -158,8 +159,26 @@ class ExecuteWorkflowAbility {
 			$caller_snapshot,
 			array( 'job_id' => $job_id )
 		);
-		if ( ! empty( $initial_data['agent_id'] ) && empty( $job_snapshot['agent_id'] ) ) {
-			$job_snapshot['agent_id'] = (int) $initial_data['agent_id'];
+		$identity_context = array_filter(
+			array(
+				'agent_slug' => $job_snapshot['agent_slug'] ?? ( $initial_data['agent_slug'] ?? null ),
+				'agent_id'   => $job_snapshot['agent_id'] ?? ( $initial_data['agent_id'] ?? null ),
+			),
+			fn( $value ) => null !== $value && '' !== $value && 0 !== $value
+		);
+		if ( ! empty( $identity_context ) ) {
+			try {
+				$identity                   = ( new AgentIdentityResolver() )->resolve_agent_identity( $identity_context );
+				$job_snapshot['agent_id']   = $identity->agent_id;
+				$job_snapshot['agent_slug'] = $identity->agent_slug;
+			} catch ( \InvalidArgumentException $e ) {
+				if ( ! empty( $initial_data['agent_id'] ) && empty( $job_snapshot['agent_id'] ) ) {
+					$job_snapshot['agent_id'] = (int) $initial_data['agent_id'];
+				}
+				if ( ! empty( $initial_data['agent_slug'] ) && empty( $job_snapshot['agent_slug'] ) ) {
+					$job_snapshot['agent_slug'] = sanitize_title( (string) $initial_data['agent_slug'] );
+				}
+			}
 		}
 		$engine_data['job'] = $job_snapshot;
 

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -153,8 +153,8 @@ class ExecuteWorkflowAbility {
 		// 'job' snapshot in initial_data with agent_id/user_id; this
 		// layers our authoritative job_id on top of any caller-provided
 		// snapshot.
-		$caller_snapshot = is_array( $engine_data['job'] ?? null ) ? $engine_data['job'] : array();
-		$job_snapshot    = array_merge(
+		$caller_snapshot  = is_array( $engine_data['job'] ?? null ) ? $engine_data['job'] : array();
+		$job_snapshot     = array_merge(
 			array( 'user_id' => (int) ( $initial_data['user_id'] ?? 0 ) ),
 			$caller_snapshot,
 			array( 'job_id' => $job_id )

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -66,6 +66,7 @@ class ChatOrchestrator {
 		$max_turns            = $options['max_turns'] ?? PluginSettings::get( 'max_turns', PluginSettings::DEFAULT_MAX_TURNS );
 		$request_id           = $options['request_id'] ?? null;
 		$agent_id             = (int) ( $options['agent_id'] ?? 0 );
+		$agent_slug           = (string) ( $options['agent_slug'] ?? '' );
 
 		$chat_db                     = ConversationStoreFactory::get();
 		$session_metadata            = array();
@@ -197,6 +198,7 @@ class ChatOrchestrator {
 				'mode'                 => ToolPolicyResolver::MODE_CHAT,
 				'user_id'              => $user_id,
 				'agent_id'             => $agent_id,
+				'agent_slug'           => $agent_slug,
 				'client_context'       => $options['client_context'] ?? array(),
 			)
 		);
@@ -371,6 +373,8 @@ class ChatOrchestrator {
 				'selected_pipeline_id' => $selected_pipeline_id,
 				'mode'                 => ToolPolicyResolver::MODE_CHAT,
 				'user_id'              => (int) ( $session['user_id'] ?? 0 ),
+				'agent_id'             => (int) ( $session['agent_id'] ?? 0 ),
+				'agent_slug'           => (string) ( $session['agent_slug'] ?? '' ),
 			)
 		);
 
@@ -696,6 +700,10 @@ class ChatOrchestrator {
 				$agent_id = datamachine_resolve_or_create_agent_id( $user_id );
 			}
 
+			if ( '' === $agent_slug && $agent_id > 0 ) {
+				$agent_slug = ConversationStoreFactory::resolve_agent_slug_for_transcript( $agent_id );
+			}
+
 			$resolver       = new ToolPolicyResolver();
 			$all_tools      = $resolver->resolve(
 				array(
@@ -710,6 +718,9 @@ class ChatOrchestrator {
 				'user_id'    => $user_id,
 				'agent_id'   => $agent_id,
 			);
+			if ( '' !== $agent_slug ) {
+				$loop_context['agent_slug'] = $agent_slug;
+			}
 			if ( $selected_pipeline_id ) {
 				$loop_context['selected_pipeline_id'] = $selected_pipeline_id;
 			}

--- a/inc/Core/Agents/AgentIdentityResolver.php
+++ b/inc/Core/Agents/AgentIdentityResolver.php
@@ -85,8 +85,8 @@ class AgentIdentityResolver {
 	/**
 	 * Resolve identity from a persisted or runtime context array.
 	 *
-	 * `agent_id` remains authoritative for old persisted contexts. When both
-	 * fields are present, the slug must match the row resolved by `agent_id`.
+	 * `agent_slug` is canonical for portable contexts. `agent_id` remains a
+	 * fallback for older persisted contexts that predate slug snapshots.
 	 *
 	 * @param array $context Context containing agent_id and/or agent_slug.
 	 * @return AgentIdentity Resolved identity.
@@ -95,25 +95,18 @@ class AgentIdentityResolver {
 		$agent_id   = isset( $context['agent_id'] ) && is_numeric( $context['agent_id'] ) ? (int) $context['agent_id'] : 0;
 		$agent_slug = isset( $context['agent_slug'] ) ? self::normalize_agent_slug( (string) $context['agent_slug'] ) : '';
 
-		if ( $agent_id > 0 ) {
-			$identity = $this->resolve_from_id( $agent_id );
-
-			if ( '' !== $agent_slug && $agent_slug !== $identity->agent_slug ) {
-				throw new \InvalidArgumentException(
-					sprintf(
-						'Agent identity mismatch: agent_id %d resolves to "%s", not "%s".',
-						absint( $identity->agent_id ),
-						esc_html( $identity->agent_slug ),
-						esc_html( $agent_slug )
-					)
-				);
+		if ( '' !== $agent_slug ) {
+			try {
+				return $this->resolve_from_slug( $agent_slug );
+			} catch ( \InvalidArgumentException $e ) {
+				if ( $agent_id <= 0 ) {
+					throw $e;
+				}
 			}
-
-			return $identity;
 		}
 
-		if ( '' !== $agent_slug ) {
-			return $this->resolve_from_slug( $agent_slug );
+		if ( $agent_id > 0 ) {
+			return $this->resolve_from_id( $agent_id );
 		}
 
 		throw new \InvalidArgumentException( 'Agent identity requires agent_id or agent_slug.' );

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -3,6 +3,7 @@
 namespace DataMachine\Core\Steps\AI;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\DataPacket;
 use DataMachine\Core\Database\Jobs\Jobs;
@@ -81,7 +82,8 @@ class AIStep extends Step {
 
 		$pipeline_step_config = $this->engine->getPipelineStepConfig( $pipeline_step_id );
 		$job_snapshot         = $this->engine->get( 'job' );
-		$agent_id             = (int) ( $job_snapshot['agent_id'] ?? 0 );
+		$job_snapshot         = is_array( $job_snapshot ) ? $job_snapshot : array();
+		$agent_id             = $this->resolveAgentIdFromJobSnapshot( $job_snapshot );
 
 		// Model/provider resolved exclusively via mode system (agent → site → network).
 		// Pipeline-level model/provider fields are ignored — mode_models is the authority.
@@ -148,7 +150,9 @@ class AIStep extends Step {
 
 		// Resolve user_id and agent_id from engine snapshot (set by RunFlowAbility).
 		$job_snapshot = $this->engine->get( 'job' );
-		$agent_id     = (int) ( $job_snapshot['agent_id'] ?? 0 );
+		$job_snapshot = is_array( $job_snapshot ) ? $job_snapshot : array();
+		$agent_id     = $this->resolveAgentIdFromJobSnapshot( $job_snapshot );
+		$agent_slug   = $this->resolveAgentSlugFromJobSnapshot( $job_snapshot, $agent_id );
 		$user_id      = (int) ( $job_snapshot['user_id'] ?? 0 );
 
 		// Model/provider resolved exclusively via mode system — pipeline config is ignored.
@@ -275,6 +279,7 @@ class AIStep extends Step {
 				'engine_data'                 => $this->engine->all(),
 				'user_id'                     => $user_id,
 				'agent_id'                    => $agent_id,
+				'agent_slug'                  => $agent_slug,
 				'pipeline_id'                 => $job_snapshot['pipeline_id'] ?? null,
 				'flow_id'                     => $job_snapshot['flow_id'] ?? null,
 				'persist_transcript'          => $persist_transcript,
@@ -315,6 +320,7 @@ class AIStep extends Step {
 					array(
 						'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
 						'agent_id'             => $agent_id,
+						'agent_slug'           => $agent_slug,
 						'previous_step_config' => $previous_step_config,
 						'next_step_config'     => $next_step_config,
 						'pipeline_step_id'     => $pipeline_step_id,
@@ -603,6 +609,40 @@ class AIStep extends Step {
 		}
 
 		return $items;
+	}
+
+	/**
+	 * Resolve agent ID from a portable job snapshot.
+	 */
+	private function resolveAgentIdFromJobSnapshot( array $job_snapshot ): int {
+		if ( empty( $job_snapshot['agent_slug'] ) && empty( $job_snapshot['agent_id'] ) ) {
+			return 0;
+		}
+
+		try {
+			return ( new AgentIdentityResolver() )->resolve_agent_identity( $job_snapshot )->agent_id;
+		} catch ( \InvalidArgumentException $e ) {
+			return (int) ( $job_snapshot['agent_id'] ?? 0 );
+		}
+	}
+
+	/**
+	 * Resolve agent slug from a portable job snapshot.
+	 */
+	private function resolveAgentSlugFromJobSnapshot( array $job_snapshot, int $agent_id ): string {
+		if ( ! empty( $job_snapshot['agent_slug'] ) ) {
+			return sanitize_title( (string) $job_snapshot['agent_slug'] );
+		}
+
+		if ( $agent_id <= 0 ) {
+			return '';
+		}
+
+		try {
+			return ( new AgentIdentityResolver() )->resolve_agent_slug( $agent_id );
+		} catch ( \InvalidArgumentException $e ) {
+			return '';
+		}
 	}
 
 	/**

--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -21,6 +21,7 @@
 namespace DataMachine\Core\Steps\SystemTask;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\DataPacket;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Steps\Step;
@@ -194,7 +195,17 @@ class SystemTaskStep extends Step {
 		// and behaviour matches single-agent installs.
 		$parent_job_snapshot = $this->engine->getJobContext();
 		$parent_agent_id     = (int) ( $parent_job_snapshot['agent_id'] ?? 0 );
+		$parent_agent_slug   = '';
 		$parent_user_id      = (int) ( $parent_job_snapshot['user_id'] ?? 0 );
+		if ( ! empty( $parent_job_snapshot['agent_slug'] ) || $parent_agent_id > 0 ) {
+			try {
+				$identity            = ( new AgentIdentityResolver() )->resolve_agent_identity( $parent_job_snapshot );
+				$parent_agent_id     = $identity->agent_id;
+				$parent_agent_slug   = $identity->agent_slug;
+			} catch ( \InvalidArgumentException $e ) {
+				$parent_agent_slug = ! empty( $parent_job_snapshot['agent_slug'] ) ? sanitize_title( (string) $parent_job_snapshot['agent_slug'] ) : '';
+			}
+		}
 
 		// Store task params in child job engine_data.
 		$child_engine_data = array_merge( $task_params, array(
@@ -212,6 +223,9 @@ class SystemTaskStep extends Step {
 		if ( $parent_agent_id > 0 ) {
 			$child_engine_data['agent_id'] = $parent_agent_id;
 		}
+		if ( '' !== $parent_agent_slug ) {
+			$child_engine_data['agent_slug'] = $parent_agent_slug;
+		}
 		if ( $parent_user_id > 0 ) {
 			$child_engine_data['user_id'] = $parent_user_id;
 		}
@@ -222,6 +236,9 @@ class SystemTaskStep extends Step {
 		);
 		if ( $parent_agent_id > 0 ) {
 			$child_job_snapshot['agent_id'] = $parent_agent_id;
+		}
+		if ( '' !== $parent_agent_slug ) {
+			$child_job_snapshot['agent_slug'] = $parent_agent_slug;
 		}
 		$child_engine_data['job'] = $child_job_snapshot;
 

--- a/inc/Core/Steps/SystemTask/SystemTaskStep.php
+++ b/inc/Core/Steps/SystemTask/SystemTaskStep.php
@@ -199,9 +199,9 @@ class SystemTaskStep extends Step {
 		$parent_user_id      = (int) ( $parent_job_snapshot['user_id'] ?? 0 );
 		if ( ! empty( $parent_job_snapshot['agent_slug'] ) || $parent_agent_id > 0 ) {
 			try {
-				$identity            = ( new AgentIdentityResolver() )->resolve_agent_identity( $parent_job_snapshot );
-				$parent_agent_id     = $identity->agent_id;
-				$parent_agent_slug   = $identity->agent_slug;
+				$identity          = ( new AgentIdentityResolver() )->resolve_agent_identity( $parent_job_snapshot );
+				$parent_agent_id   = $identity->agent_id;
+				$parent_agent_slug = $identity->agent_slug;
 			} catch ( \InvalidArgumentException $e ) {
 				$parent_agent_slug = ! empty( $parent_job_snapshot['agent_slug'] ) ? sanitize_title( (string) $parent_job_snapshot['agent_slug'] ) : '';
 			}

--- a/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
+++ b/inc/Engine/AI/DataMachinePipelineTranscriptPersister.php
@@ -57,6 +57,7 @@ class DataMachinePipelineTranscriptPersister implements WP_Agent_Transcript_Pers
 			'pipeline_id'  => $runtime_context['pipeline_id'] ?? null,
 			'flow_id'      => $runtime_context['flow_id'] ?? null,
 			'agent_id'     => $agent_id > 0 ? $agent_id : null,
+			'agent_slug'   => '' !== $agent_slug ? $agent_slug : null,
 			'owner_id'     => $user_id > 0 ? $user_id : null,
 			'provider'     => $provider,
 			'model'        => $model,

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -579,6 +579,7 @@ class RequestBuilder {
 			array(
 				'job_id'       => $payload['job_id'] ?? null,
 				'flow_step_id' => $payload['flow_step_id'] ?? null,
+				'agent_slug'   => $payload['agent_slug'] ?? null,
 			),
 			fn( $value ) => null !== $value
 		);

--- a/inc/Engine/AI/RequestInspector.php
+++ b/inc/Engine/AI/RequestInspector.php
@@ -261,8 +261,8 @@ class RequestInspector {
 		EngineData $engine,
 		array $job
 	): array {
-		$job_snapshot = $engine->getJobContext();
-		$user_id      = (int) ( $job_snapshot['user_id'] ?? ( $job['user_id'] ?? 0 ) );
+		$job_snapshot     = $engine->getJobContext();
+		$user_id          = (int) ( $job_snapshot['user_id'] ?? ( $job['user_id'] ?? 0 ) );
 		$identity_context = array_filter(
 			array(
 				'agent_slug' => $job_snapshot['agent_slug'] ?? null,

--- a/inc/Engine/AI/RequestInspector.php
+++ b/inc/Engine/AI/RequestInspector.php
@@ -9,6 +9,7 @@
 
 namespace DataMachine\Engine\AI;
 
+use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\EngineData;
 use DataMachine\Core\FilesRepository\FileRetrieval;
@@ -99,6 +100,7 @@ class RequestInspector {
 		$pipeline_step_config = $engine->getPipelineStepConfig( $pipeline_step_id );
 		$tool_categories      = $pipeline_step_config['tool_categories'] ?? $engine->get( 'pipeline_tool_categories' ) ?? array();
 		$agent_id             = (int) ( $payload['agent_id'] ?? 0 );
+		$agent_slug           = (string) ( $payload['agent_slug'] ?? '' );
 
 		$resolver = new ToolPolicyResolver();
 		$tools    = $resolver->resolve(
@@ -106,6 +108,7 @@ class RequestInspector {
 				array(
 					'mode'                 => ToolPolicyResolver::MODE_PIPELINE,
 					'agent_id'             => $agent_id,
+					'agent_slug'           => $agent_slug,
 					'previous_step_config' => $previous_step_config,
 					'next_step_config'     => $next_step_config,
 					'pipeline_step_id'     => $pipeline_step_id,
@@ -260,7 +263,25 @@ class RequestInspector {
 	): array {
 		$job_snapshot = $engine->getJobContext();
 		$user_id      = (int) ( $job_snapshot['user_id'] ?? ( $job['user_id'] ?? 0 ) );
-		$agent_id     = (int) ( $job_snapshot['agent_id'] ?? ( $job['agent_id'] ?? 0 ) );
+		$identity_context = array_filter(
+			array(
+				'agent_slug' => $job_snapshot['agent_slug'] ?? null,
+				'agent_id'   => $job_snapshot['agent_id'] ?? ( $job['agent_id'] ?? null ),
+			),
+			fn( $value ) => null !== $value && '' !== $value && 0 !== $value
+		);
+		$agent_id         = (int) ( $job_snapshot['agent_id'] ?? ( $job['agent_id'] ?? 0 ) );
+		$agent_slug       = ! empty( $job_snapshot['agent_slug'] ) ? sanitize_title( (string) $job_snapshot['agent_slug'] ) : '';
+		if ( ! empty( $identity_context ) ) {
+			try {
+				$identity   = ( new AgentIdentityResolver() )->resolve_agent_identity( $identity_context );
+				$agent_id   = $identity->agent_id;
+				$agent_slug = $identity->agent_slug;
+			} catch ( \InvalidArgumentException $e ) {
+				// Keep the raw snapshot values for inspecting legacy/in-flight jobs.
+				unset( $e );
+			}
+		}
 
 		return array(
 			'job_id'             => $job_id,
@@ -270,6 +291,7 @@ class RequestInspector {
 			'engine'             => $engine,
 			'user_id'            => $user_id,
 			'agent_id'           => $agent_id,
+			'agent_slug'         => $agent_slug,
 			'pipeline_id'        => $job_snapshot['pipeline_id'] ?? ( $job['pipeline_id'] ?? null ),
 			'flow_id'            => $job_snapshot['flow_id'] ?? ( $job['flow_id'] ?? null ),
 			'persist_transcript' => false,

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -397,7 +397,7 @@ function datamachine_build_turn_runner(
 				// Validate for duplicate tool calls.
 				$validation_result = ConversationManager::validateToolCall( $tool_name, $tool_parameters, $messages );
 				if ( $validation_result['is_duplicate'] ) {
-					$messages[] = ConversationManager::generateDuplicateToolCallMessage( $tool_name, $turn_count, $mode );
+					$messages[]         = ConversationManager::generateDuplicateToolCallMessage( $tool_name, $turn_count, $mode );
 					$duplicate_rejected = true;
 					do_action(
 						'datamachine_log',
@@ -544,10 +544,10 @@ function datamachine_build_turn_runner(
 		}
 
 		return array(
-			'messages'               => $messages,
-			'tool_execution_results' => $tool_execution_results,
-			'conversation_complete'  => $conversation_complete,
-			'completion_nudge'       => $completion_nudge ?? '',
+			'messages'                     => $messages,
+			'tool_execution_results'       => $tool_execution_results,
+			'conversation_complete'        => $conversation_complete,
+			'completion_nudge'             => $completion_nudge ?? '',
 			'duplicate_tool_call_rejected' => $duplicate_rejected,
 		);
 	};

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -86,6 +86,7 @@ function datamachine_run_conversation(
 			'mode'         => $mode,
 			'job_id'       => $loop_payload['job_id'] ?? null,
 			'flow_step_id' => $loop_payload['flow_step_id'] ?? null,
+			'agent_slug'   => $loop_payload['agent_slug'] ?? null,
 		),
 		fn( $v ) => null !== $v
 	);

--- a/inc/Engine/Tasks/TaskScheduler.php
+++ b/inc/Engine/Tasks/TaskScheduler.php
@@ -22,6 +22,7 @@ namespace DataMachine\Engine\Tasks;
 defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Core\ActionScheduler\BatchScheduler;
+use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\JobStatus;
 
@@ -115,8 +116,18 @@ class TaskScheduler {
 		// Resolve agent identity from the context. Callers without
 		// agent_id/user_id continue to work — the resulting job runs
 		// without an agent (matching pre-multi-agent behaviour).
-		$context_user_id  = (int) ( $context['user_id'] ?? 0 );
-		$context_agent_id = (int) ( $context['agent_id'] ?? 0 );
+		$context_user_id    = (int) ( $context['user_id'] ?? 0 );
+		$context_agent_id   = (int) ( $context['agent_id'] ?? 0 );
+		$context_agent_slug = '';
+		if ( ! empty( $context['agent_slug'] ) || $context_agent_id > 0 ) {
+			try {
+				$identity           = ( new AgentIdentityResolver() )->resolve_agent_identity( $context );
+				$context_agent_id   = $identity->agent_id;
+				$context_agent_slug = $identity->agent_slug;
+			} catch ( \InvalidArgumentException $e ) {
+				$context_agent_slug = ! empty( $context['agent_slug'] ) ? sanitize_title( (string) $context['agent_slug'] ) : '';
+			}
+		}
 
 		// Mirror RunFlowAbility's engine_data['job'] shape so downstream
 		// step types (AIStep, SystemTaskStep) can read agent identity
@@ -126,6 +137,9 @@ class TaskScheduler {
 		);
 		if ( $context_agent_id > 0 ) {
 			$job_snapshot['agent_id'] = $context_agent_id;
+		}
+		if ( '' !== $context_agent_slug ) {
+			$job_snapshot['agent_slug'] = $context_agent_slug;
 		}
 
 		$result = $ability->execute( array(
@@ -138,6 +152,7 @@ class TaskScheduler {
 				'parent_job_id' => $parentJobId,
 				'user_id'       => $context_user_id,
 				'agent_id'      => $context_agent_id,
+				'agent_slug'    => $context_agent_slug,
 				'job'           => $job_snapshot,
 			),
 		) );

--- a/tests/Unit/Core/Agents/AgentIdentityResolverTest.php
+++ b/tests/Unit/Core/Agents/AgentIdentityResolverTest.php
@@ -93,17 +93,32 @@ class AgentIdentityResolverTest extends WP_UnitTestCase {
 		$this->resolver->resolve_agent_identity( 99999 );
 	}
 
-	public function test_rejects_mismatched_array_identity(): void {
-		$agent_id = $this->create_agent( 'matching-agent' );
+	public function test_array_context_prefers_agent_slug_over_mismatched_id(): void {
+		$stale_agent_id = $this->create_agent( 'stale-id-agent' );
+		$agent_id       = $this->create_agent( 'portable-slug-agent' );
 
-		$this->expectException( \InvalidArgumentException::class );
-		$this->expectExceptionMessage( 'Agent identity mismatch' );
-
-		$this->resolver->resolve_agent_identity(
+		$identity = $this->resolver->resolve_agent_identity(
 			array(
-				'agent_id'   => $agent_id,
-				'agent_slug' => 'other-agent',
+				'agent_id'   => $stale_agent_id,
+				'agent_slug' => 'portable-slug-agent',
 			)
 		);
+
+		$this->assertSame( $agent_id, $identity->agent_id );
+		$this->assertSame( 'portable-slug-agent', $identity->agent_slug );
+	}
+
+	public function test_array_context_falls_back_to_agent_id_when_slug_is_unresolved(): void {
+		$agent_id = $this->create_agent( 'legacy-fallback-agent' );
+
+		$identity = $this->resolver->resolve_agent_identity(
+			array(
+				'agent_id'   => $agent_id,
+				'agent_slug' => 'missing-agent-slug',
+			)
+		);
+
+		$this->assertSame( $agent_id, $identity->agent_id );
+		$this->assertSame( 'legacy-fallback-agent', $identity->agent_slug );
 	}
 }

--- a/tests/execute-workflow-initial-data-contract-smoke.php
+++ b/tests/execute-workflow-initial-data-contract-smoke.php
@@ -11,6 +11,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		return strtolower( trim( preg_replace( '/[^a-z0-9]+/i', '-', $title ), '-' ) );
+	}
+}
+
 /**
  * Mirror of ExecuteWorkflowAbility::execute()'s create_args parent link.
  */
@@ -46,6 +52,9 @@ function build_execute_workflow_engine_data_for_contract_test( int $job_id, arra
 	);
 	if ( ! empty( $initial_data['agent_id'] ) && empty( $job_snapshot['agent_id'] ) ) {
 		$job_snapshot['agent_id'] = (int) $initial_data['agent_id'];
+	}
+	if ( ! empty( $initial_data['agent_slug'] ) && empty( $job_snapshot['agent_slug'] ) ) {
+		$job_snapshot['agent_slug'] = sanitize_title( (string) $initial_data['agent_slug'] );
 	}
 	$engine_data['job'] = $job_snapshot;
 
@@ -92,6 +101,7 @@ $initial_data = array(
 	'pipeline_config' => array( 'poisoned_pipeline' => array( 'system_prompt' => 'caller override' ) ),
 	'parent_job_id'   => 64,
 	'agent_id'        => 2,
+	'agent_slug'      => 'Wayward Son',
 	'user_id'         => 1,
 	'job'             => array(
 		'user_id' => 1,
@@ -112,9 +122,11 @@ dm_assert_same( 64, $create_args['parent_job_id'] ?? null, 'parent_job_id preser
 
 echo "\n[3] flat identity fields still route into the job snapshot\n";
 dm_assert_same( 2, $engine_data['agent_id'], 'flat agent_id remains in engine_data' );
+dm_assert_same( 'Wayward Son', $engine_data['agent_slug'], 'flat agent_slug remains in engine_data' );
 dm_assert_same( 1, $engine_data['user_id'], 'flat user_id remains in engine_data' );
 dm_assert_same( 100, $engine_data['job']['job_id'], 'authoritative job_id wins in job snapshot' );
 dm_assert_same( 2, $engine_data['job']['agent_id'], 'flat agent_id fills missing job.agent_id' );
+dm_assert_same( 'wayward-son', $engine_data['job']['agent_slug'], 'flat agent_slug fills missing job.agent_slug' );
 dm_assert_same( 1, $engine_data['job']['user_id'], 'job.user_id preserved from caller snapshot' );
 
 echo "\n[4] caller job snapshot identity is preserved when provided\n";

--- a/tests/system-task-agent-context-smoke.php
+++ b/tests/system-task-agent-context-smoke.php
@@ -35,6 +35,12 @@ if ( ! function_exists( 'current_time' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $title ): string {
+		return strtolower( trim( preg_replace( '/[^a-z0-9]+/i', '-', $title ), '-' ) );
+	}
+}
+
 // ─── Harness functions mirroring production paths ───────────────────
 
 /**
@@ -46,14 +52,18 @@ function build_task_scheduler_initial_data(
 	array $context,
 	int $parent_job_id
 ): array {
-	$context_user_id  = (int) ( $context['user_id'] ?? 0 );
-	$context_agent_id = (int) ( $context['agent_id'] ?? 0 );
+	$context_user_id    = (int) ( $context['user_id'] ?? 0 );
+	$context_agent_id   = (int) ( $context['agent_id'] ?? 0 );
+	$context_agent_slug = ! empty( $context['agent_slug'] ) ? sanitize_title( (string) $context['agent_slug'] ) : '';
 
 	$job_snapshot = array(
 		'user_id' => $context_user_id,
 	);
 	if ( $context_agent_id > 0 ) {
 		$job_snapshot['agent_id'] = $context_agent_id;
+	}
+	if ( '' !== $context_agent_slug ) {
+		$job_snapshot['agent_slug'] = $context_agent_slug;
 	}
 
 	return array(
@@ -63,6 +73,7 @@ function build_task_scheduler_initial_data(
 		'parent_job_id' => $parent_job_id,
 		'user_id'       => $context_user_id,
 		'agent_id'      => $context_agent_id,
+		'agent_slug'    => $context_agent_slug,
 		'job'           => $job_snapshot,
 	);
 }
@@ -87,6 +98,9 @@ function build_engine_data_job_snapshot( int $job_id, array $initial_data ): arr
 	if ( ! empty( $initial_data['agent_id'] ) && empty( $job_snapshot['agent_id'] ) ) {
 		$job_snapshot['agent_id'] = (int) $initial_data['agent_id'];
 	}
+	if ( ! empty( $initial_data['agent_slug'] ) && empty( $job_snapshot['agent_slug'] ) ) {
+		$job_snapshot['agent_slug'] = sanitize_title( (string) $initial_data['agent_slug'] );
+	}
 	$engine_data['job'] = $job_snapshot;
 
 	return $engine_data;
@@ -104,6 +118,7 @@ function build_system_task_child_engine_data(
 ): array {
 	$parent_job_snapshot = $parent_engine_data['job'] ?? array();
 	$parent_agent_id     = (int) ( $parent_job_snapshot['agent_id'] ?? 0 );
+	$parent_agent_slug   = ! empty( $parent_job_snapshot['agent_slug'] ) ? sanitize_title( (string) $parent_job_snapshot['agent_slug'] ) : '';
 	$parent_user_id      = (int) ( $parent_job_snapshot['user_id'] ?? 0 );
 
 	$child_engine_data = array_merge( $task_params, array(
@@ -116,6 +131,9 @@ function build_system_task_child_engine_data(
 	if ( $parent_agent_id > 0 ) {
 		$child_engine_data['agent_id'] = $parent_agent_id;
 	}
+	if ( '' !== $parent_agent_slug ) {
+		$child_engine_data['agent_slug'] = $parent_agent_slug;
+	}
 	if ( $parent_user_id > 0 ) {
 		$child_engine_data['user_id'] = $parent_user_id;
 	}
@@ -126,6 +144,9 @@ function build_system_task_child_engine_data(
 	);
 	if ( $parent_agent_id > 0 ) {
 		$child_job_snapshot['agent_id'] = $parent_agent_id;
+	}
+	if ( '' !== $parent_agent_slug ) {
+		$child_job_snapshot['agent_slug'] = $parent_agent_slug;
 	}
 	$child_engine_data['job'] = $child_job_snapshot;
 
@@ -200,6 +221,16 @@ $assert( 'job snapshot present', is_array( $initial['job'] ) );
 $assert( 'job.agent_id present', 2 === $initial['job']['agent_id'] );
 $assert( 'job.user_id present', 1 === $initial['job']['user_id'] );
 
+echo "\n[1b] TaskScheduler initial_data dual-writes agent_slug when provided\n";
+$initial = build_task_scheduler_initial_data(
+	'daily_memory_generation',
+	array( 'date' => '2026-04-25' ),
+	array( 'agent_id' => 2, 'agent_slug' => 'Wayward Son', 'user_id' => 1 ),
+	0
+);
+$assert( 'flat agent_slug present', 'wayward-son' === $initial['agent_slug'] );
+$assert( 'job.agent_slug present', 'wayward-son' === $initial['job']['agent_slug'] );
+
 echo "\n[2] TaskScheduler initial_data without agent context (back-compat)\n";
 $initial = build_task_scheduler_initial_data( 'image_optimization', array(), array(), 0 );
 $assert( 'flat agent_id is 0', 0 === $initial['agent_id'] );
@@ -232,19 +263,22 @@ $assert( 'engine_data.job.user_id is 0', 0 === $engine['job']['user_id'] );
 echo "\n[5] SystemTaskStep child engine_data carries parent agent_id\n";
 $parent_engine = array(
 	'job' => array(
-		'job_id'   => 500,
-		'agent_id' => 2,
-		'user_id'  => 1,
+		'job_id'     => 500,
+		'agent_id'   => 2,
+		'agent_slug' => 'wayward-son',
+		'user_id'    => 1,
 	),
 );
 $child = build_system_task_child_engine_data( 500, $parent_engine, 501, 'alt_text_generation', array( 'attachment_id' => 42 ) );
 $assert( 'child task_type set', 'alt_text_generation' === $child['task_type'] );
 $assert( 'child has flat agent_id from parent', 2 === $child['agent_id'] );
+$assert( 'child has flat agent_slug from parent', 'wayward-son' === $child['agent_slug'] );
 $assert( 'child has flat user_id from parent', 1 === $child['user_id'] );
 $assert( 'child has job snapshot', is_array( $child['job'] ) );
 $assert( 'child.job.job_id is child id', 501 === $child['job']['job_id'] );
 $assert( 'child.job.parent_job_id linked', 500 === $child['job']['parent_job_id'] );
 $assert( 'child.job.agent_id from parent', 2 === $child['job']['agent_id'] );
+$assert( 'child.job.agent_slug from parent', 'wayward-son' === $child['job']['agent_slug'] );
 $assert( 'task params preserved', 42 === $child['attachment_id'] );
 
 echo "\n[6] SystemTaskStep child without agent context (legacy flow)\n";


### PR DESCRIPTION
## Summary
- Prefer `agent_slug` over `agent_id` in the central identity resolver for runtime context arrays, with `agent_id` fallback for older queued or persisted snapshots.
- Add `agent_slug` alongside existing agent IDs in flow/job snapshots, direct workflow initial data, AI loop payloads, transcript metadata, chat loop context, system-task child context, and request inspection context.
- Cover slug preference/fallback plus workflow/system-task dual-write behavior with focused tests.

Closes #1867.

## Testing
- `php tests/system-task-agent-context-smoke.php`
- `php tests/execute-workflow-initial-data-contract-smoke.php`
- `homeboy test --path . --extension wordpress --force-hot -- tests/Unit/Core/Agents/AgentIdentityResolverTest.php`
- `homeboy test --path . --extension wordpress --force-hot`
- `homeboy lint --path . --extension wordpress --force-hot --changed-only --errors-only`

Full `homeboy lint --path . --extension wordpress --force-hot` was also attempted and still fails on pre-existing unrelated React/JS lint findings outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the dual-write/fallback changes, updated focused tests, and ran validation; Chris reviewed the direction and migration constraints.