### PR TITLE
Add AI tool runtime rules

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -369,7 +369,7 @@ class AgentBundler {
 				$document_step['step_type'] = $pipeline_step_types_by_id[ $pipeline_step_id ];
 			}
 
-			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'enabled' ) as $field ) {
+			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'tool_runtime_rules', 'enabled' ) as $field ) {
 				if ( array_key_exists( $field, $step ) ) {
 					$document_step[ $field ] = $step[ $field ];
 				}

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -302,6 +302,14 @@ class AIStep extends Step {
 				$payload['completion_assertions'] = $completion_assertions;
 			}
 
+			$tool_runtime_rules = self::mergeListConfigField(
+				is_array( $pipeline_step_config['tool_runtime_rules'] ?? null ) ? $pipeline_step_config['tool_runtime_rules'] : array(),
+				is_array( $this->flow_step_config['tool_runtime_rules'] ?? null ) ? $this->flow_step_config['tool_runtime_rules'] : array()
+			);
+			if ( ! empty( $tool_runtime_rules ) ) {
+				$payload['tool_runtime_rules'] = $tool_runtime_rules;
+			}
+
 			// Tool categories can be specified at the pipeline step level or pipeline level.
 			// This allows pipelines to declare which ability categories are relevant,
 			// reducing tool bloat by excluding irrelevant tools from the AI context.
@@ -603,6 +611,17 @@ class AIStep extends Step {
 		}
 
 		return $items;
+	}
+
+	/**
+	 * Merge pipeline-level and flow-level list config fields.
+	 *
+	 * @param array $pipeline_values Pipeline step values.
+	 * @param array $flow_values     Flow step values.
+	 * @return array<int,mixed> Merged list values.
+	 */
+	private static function mergeListConfigField( array $pipeline_values, array $flow_values ): array {
+		return array_values( array_merge( $pipeline_values, $flow_values ) );
 	}
 
 	/**

--- a/inc/Engine/AI/DataMachineToolRuntimeRules.php
+++ b/inc/Engine/AI/DataMachineToolRuntimeRules.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Generic Data Machine tool runtime rules.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+use AgentsAPI\AI\WP_Agent_Message;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enforces bounded tool sequencing rules during an AI conversation.
+ */
+class DataMachineToolRuntimeRules {
+
+	/** @var array<int,array<string,mixed>> */
+	private array $rules;
+
+	/**
+	 * @param array $rules Runtime rule config.
+	 */
+	public function __construct( array $rules = array() ) {
+		$this->rules = $this->normalizeRules( $rules );
+	}
+
+	/**
+	 * Whether any active rules are configured.
+	 */
+	public function hasRules(): bool {
+		return ! empty( $this->rules );
+	}
+
+	/**
+	 * Evaluate a proposed tool call against configured runtime rules.
+	 *
+	 * @param string $tool_name Tool name.
+	 * @param array  $messages  Current conversation messages.
+	 * @return array{allowed:bool,error:string,context:array<string,mixed>}
+	 */
+	public function evaluate( string $tool_name, array $messages ): array {
+		foreach ( $this->rules as $rule ) {
+			$result = $this->evaluateRule( $rule, $tool_name, $messages );
+			if ( ! $result['allowed'] ) {
+				return $result;
+			}
+		}
+
+		return array(
+			'allowed' => true,
+			'error'   => '',
+			'context' => array(),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $rule Runtime rule.
+	 * @return array{allowed:bool,error:string,context:array<string,mixed>}
+	 */
+	private function evaluateRule( array $rule, string $tool_name, array $messages ): array {
+		$after_tool = (string) $rule['after_tool'];
+		$after_index = $this->lastToolCallIndex( $messages, $after_tool );
+		if ( $after_index < 0 ) {
+			return array( 'allowed' => true, 'error' => '', 'context' => array() );
+		}
+
+		$then_require_one_of = (array) $rule['then_require_one_of'];
+		if ( in_array( $tool_name, $then_require_one_of, true ) ) {
+			return array( 'allowed' => true, 'error' => '', 'context' => array() );
+		}
+
+		$limited_tools = (array) $rule['limited_tools'];
+		$max_calls     = (int) $rule['max_calls'];
+		$limited_count = $this->countToolCallsAfter( $messages, $after_index, $limited_tools );
+		if ( $limited_count < $max_calls ) {
+			return array( 'allowed' => true, 'error' => '', 'context' => array() );
+		}
+
+		$required = implode( ', ', $then_require_one_of );
+		$error    = sprintf(
+			'TOOL POLICY REJECTED: After %1$s, you already used %2$d of %3$d allowed inspection tools. Do not inspect more. Next tool must be one of: %4$s.',
+			$after_tool,
+			$limited_count,
+			$max_calls,
+			$required
+		);
+
+		return array(
+			'allowed' => false,
+			'error'   => $error,
+			'context' => array(
+				'rule_id'             => (string) $rule['id'],
+				'after_tool'          => $after_tool,
+				'limited_tools'       => $limited_tools,
+				'limited_count'       => $limited_count,
+				'max_calls'           => $max_calls,
+				'then_require_one_of' => $then_require_one_of,
+				'rejected_tool'       => $tool_name,
+			),
+		);
+	}
+
+	/**
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function normalizeRules( array $rules ): array {
+		$normalized = array();
+		foreach ( $rules as $index => $rule ) {
+			if ( ! is_array( $rule ) ) {
+				continue;
+			}
+
+			$after_tool          = $this->sanitizeToolName( $rule['after_tool'] ?? '' );
+			$limited_tools       = $this->sanitizeToolList( $rule['limited_tools'] ?? $rule['limited_tool_names'] ?? array() );
+			$then_require_one_of = $this->sanitizeToolList( $rule['then_require_one_of'] ?? array() );
+			$max_calls           = max( 0, (int) ( $rule['max_calls'] ?? 0 ) );
+
+			if ( '' === $after_tool || empty( $limited_tools ) || empty( $then_require_one_of ) || $max_calls <= 0 ) {
+				continue;
+			}
+
+			$normalized[] = array(
+				'id'                  => $this->sanitizeRuleId( $rule['id'] ?? 'tool-runtime-rule-' . $index ),
+				'after_tool'          => $after_tool,
+				'limited_tools'       => $limited_tools,
+				'max_calls'           => $max_calls,
+				'then_require_one_of' => $then_require_one_of,
+			);
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $messages Conversation messages.
+	 */
+	private function lastToolCallIndex( array $messages, string $tool_name ): int {
+		for ( $i = count( $messages ) - 1; $i >= 0; $i-- ) {
+			$call = $this->toolCallFromMessage( $messages[ $i ] );
+			if ( $call && $call['tool_name'] === $tool_name ) {
+				return $i;
+			}
+		}
+
+		return -1;
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $messages Conversation messages.
+	 * @param array<int,string>              $tool_names Limited tool names.
+	 */
+	private function countToolCallsAfter( array $messages, int $after_index, array $tool_names ): int {
+		$count = 0;
+		for ( $i = $after_index + 1; $i < count( $messages ); $i++ ) {
+			$call = $this->toolCallFromMessage( $messages[ $i ] );
+			if ( $call && in_array( $call['tool_name'], $tool_names, true ) ) {
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * @param array<string,mixed> $message Conversation message.
+	 * @return array{tool_name:string}|null
+	 */
+	private function toolCallFromMessage( array $message ): ?array {
+		$envelope = WP_Agent_Message::normalize( $message );
+		if ( WP_Agent_Message::TYPE_TOOL_CALL !== $envelope['type'] ) {
+			return null;
+		}
+
+		$tool_name = $envelope['payload']['tool_name'] ?? null;
+		if ( ! is_string( $tool_name ) || '' === $tool_name ) {
+			return null;
+		}
+
+		return array( 'tool_name' => $tool_name );
+	}
+
+	private function sanitizeRuleId( $value ): string {
+		$id = preg_replace( '/[^a-zA-Z0-9_\-]/', '-', (string) $value ) ?? '';
+		return '' !== $id ? $id : 'tool-runtime-rule';
+	}
+
+	private function sanitizeToolName( $value ): string {
+		$value = trim( (string) $value );
+		return '' !== $value ? $value : '';
+	}
+
+	/**
+	 * @param mixed $value Raw list.
+	 * @return array<int,string>
+	 */
+	private function sanitizeToolList( $value ): array {
+		if ( is_string( $value ) && '' !== $value ) {
+			$value = array( $value );
+		}
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$tools = array();
+		foreach ( $value as $tool ) {
+			$tool = $this->sanitizeToolName( $tool );
+			if ( '' !== $tool ) {
+				$tools[] = $tool;
+			}
+		}
+
+		return array_values( array_unique( $tools ) );
+	}
+}

--- a/inc/Engine/AI/DataMachineToolRuntimeRules.php
+++ b/inc/Engine/AI/DataMachineToolRuntimeRules.php
@@ -60,22 +60,34 @@ class DataMachineToolRuntimeRules {
 	 * @return array{allowed:bool,error:string,context:array<string,mixed>}
 	 */
 	private function evaluateRule( array $rule, string $tool_name, array $messages ): array {
-		$after_tool = (string) $rule['after_tool'];
+		$after_tool  = (string) $rule['after_tool'];
 		$after_index = $this->lastToolCallIndex( $messages, $after_tool );
 		if ( $after_index < 0 ) {
-			return array( 'allowed' => true, 'error' => '', 'context' => array() );
+			return array(
+				'allowed' => true,
+				'error'   => '',
+				'context' => array(),
+			);
 		}
 
 		$then_require_one_of = (array) $rule['then_require_one_of'];
 		if ( in_array( $tool_name, $then_require_one_of, true ) ) {
-			return array( 'allowed' => true, 'error' => '', 'context' => array() );
+			return array(
+				'allowed' => true,
+				'error'   => '',
+				'context' => array(),
+			);
 		}
 
 		$limited_tools = (array) $rule['limited_tools'];
 		$max_calls     = (int) $rule['max_calls'];
 		$limited_count = $this->countToolCallsAfter( $messages, $after_index, $limited_tools );
 		if ( $limited_count < $max_calls ) {
-			return array( 'allowed' => true, 'error' => '', 'context' => array() );
+			return array(
+				'allowed' => true,
+				'error'   => '',
+				'context' => array(),
+			);
 		}
 
 		$required = implode( ', ', $then_require_one_of );
@@ -152,8 +164,9 @@ class DataMachineToolRuntimeRules {
 	 * @param array<int,string>              $tool_names Limited tool names.
 	 */
 	private function countToolCallsAfter( array $messages, int $after_index, array $tool_names ): int {
-		$count = 0;
-		for ( $i = $after_index + 1; $i < count( $messages ); $i++ ) {
+		$count         = 0;
+		$message_count = count( $messages );
+		for ( $i = $after_index + 1; $i < $message_count; $i++ ) {
 			$call = $this->toolCallFromMessage( $messages[ $i ] );
 			if ( $call && in_array( $call['tool_name'], $tool_names, true ) ) {
 				++$count;

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -57,6 +57,7 @@ function datamachine_run_conversation(
 	// Resolve DM runtime collaborators from the payload.
 	$event_sink           = datamachine_resolve_event_sink( $payload );
 	$completion_policy    = datamachine_resolve_completion_policy( $mode, $payload );
+	$tool_runtime_rules   = datamachine_resolve_tool_runtime_rules( $payload );
 	$transcript_persister = datamachine_resolve_transcript_persister( $payload );
 	$transcript_lock      = $payload['transcript_lock'] ?? $payload['transcript_lock_store'] ?? null;
 
@@ -108,6 +109,7 @@ function datamachine_run_conversation(
 		$event_sink,
 		$base_log_context,
 		$completion_policy,
+		$tool_runtime_rules,
 		$last_request_metadata,
 		$last_tool_calls,
 		$final_content,
@@ -128,7 +130,7 @@ function datamachine_run_conversation(
 		if ( ! empty( $result['conversation_complete'] ) ) {
 			return false;
 		}
-		return ! empty( $result['tool_execution_results'] ) || ! empty( $result['completion_nudge'] ) || ! empty( $result['duplicate_tool_call_rejected'] );
+		return ! empty( $result['tool_execution_results'] ) || ! empty( $result['completion_nudge'] ) || ! empty( $result['duplicate_tool_call_rejected'] ) || ! empty( $result['tool_runtime_rule_rejected'] );
 	};
 
 	// Run through the upstream substrate loop.
@@ -238,6 +240,7 @@ function datamachine_run_conversation(
  * @param LoopEventSinkInterface                          $event_sink             DM event sink.
  * @param array                                           $base_log_context       Base log context.
  * @param WP_Agent_Conversation_Completion_Policy       $completion_policy      Completion policy.
+ * @param DataMachineToolRuntimeRules                   $tool_runtime_rules     Tool runtime rules.
  * @param array                                           &$last_request_metadata Mutable request metadata.
  * @param array                                           &$last_tool_calls        Mutable last tool calls.
  * @param string                                          &$final_content          Mutable final assistant content.
@@ -255,6 +258,7 @@ function datamachine_build_turn_runner(
 	LoopEventSinkInterface $event_sink,
 	array $base_log_context,
 	WP_Agent_Conversation_Completion_Policy $completion_policy,
+	DataMachineToolRuntimeRules $tool_runtime_rules,
 	array &$last_request_metadata,
 	array &$last_tool_calls,
 	string &$final_content,
@@ -271,6 +275,7 @@ function datamachine_build_turn_runner(
 		$event_sink,
 		$base_log_context,
 		$completion_policy,
+		$tool_runtime_rules,
 		&$last_request_metadata,
 		&$last_tool_calls,
 		&$final_content,
@@ -358,6 +363,7 @@ function datamachine_build_turn_runner(
 		$conversation_complete  = false;
 		$completion_nudge       = '';
 		$duplicate_rejected     = false;
+		$runtime_rule_rejected  = false;
 		if ( ! empty( $tool_calls ) ) {
 			foreach ( $tool_calls as $tool_call ) {
 				$tool_name       = $tool_call['name'];
@@ -407,6 +413,30 @@ function datamachine_build_turn_runner(
 							array(
 								'turn_count' => $turn_count,
 								'tool_name'  => $tool_name,
+							)
+						)
+					);
+					continue;
+				}
+
+				$runtime_rule_result = $tool_runtime_rules->evaluate( $tool_name, $messages );
+				if ( ! $runtime_rule_result['allowed'] ) {
+					$tool_result = array(
+						'success' => false,
+						'error'   => $runtime_rule_result['error'],
+					);
+					$messages[] = ConversationManager::formatToolResultMessage( $tool_name, $tool_result, $tool_parameters, false, $turn_count );
+					$runtime_rule_rejected = true;
+					do_action(
+						'datamachine_log',
+						'info',
+						'datamachine_run_conversation: Tool runtime rule rejected call',
+						array_merge(
+							$base_log_context,
+							array(
+								'turn_count' => $turn_count,
+								'tool_name'  => $tool_name,
+								'policy'     => $runtime_rule_result['context'],
 							)
 						)
 					);
@@ -548,6 +578,7 @@ function datamachine_build_turn_runner(
 			'conversation_complete'  => $conversation_complete,
 			'completion_nudge'       => $completion_nudge ?? '',
 			'duplicate_tool_call_rejected' => $duplicate_rejected,
+			'tool_runtime_rule_rejected' => $runtime_rule_rejected,
 		);
 	};
 }
@@ -725,6 +756,17 @@ function datamachine_resolve_completion_policy( string $mode, array $payload ): 
 function datamachine_resolve_completion_assertions( array $payload ): DataMachineCompletionAssertions {
 	$config = $payload['completion_assertions'] ?? array();
 	return new DataMachineCompletionAssertions( is_array( $config ) ? $config : array() );
+}
+
+/**
+ * Resolve generic tool runtime rules from loop payload.
+ *
+ * @param array $payload Loop payload.
+ * @return DataMachineToolRuntimeRules
+ */
+function datamachine_resolve_tool_runtime_rules( array $payload ): DataMachineToolRuntimeRules {
+	$config = $payload['tool_runtime_rules'] ?? array();
+	return new DataMachineToolRuntimeRules( is_array( $config ) ? $config : array() );
 }
 
 /**

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -402,7 +402,7 @@ function datamachine_build_turn_runner(
 				// Validate for duplicate tool calls.
 				$validation_result = ConversationManager::validateToolCall( $tool_name, $tool_parameters, $messages );
 				if ( $validation_result['is_duplicate'] ) {
-					$messages[]          = ConversationManager::generateDuplicateToolCallMessage( $tool_name, $turn_count, $mode );
+					$messages[]         = ConversationManager::generateDuplicateToolCallMessage( $tool_name, $turn_count, $mode );
 					$duplicate_rejected = true;
 					do_action(
 						'datamachine_log',
@@ -425,7 +425,7 @@ function datamachine_build_turn_runner(
 						'success' => false,
 						'error'   => $runtime_rule_result['error'],
 					);
-					$messages[]             = ConversationManager::formatToolResultMessage( $tool_name, $tool_result, $tool_parameters, false, $turn_count );
+					$messages[]            = ConversationManager::formatToolResultMessage( $tool_name, $tool_result, $tool_parameters, false, $turn_count );
 					$runtime_rule_rejected = true;
 					do_action(
 						'datamachine_log',

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -402,7 +402,7 @@ function datamachine_build_turn_runner(
 				// Validate for duplicate tool calls.
 				$validation_result = ConversationManager::validateToolCall( $tool_name, $tool_parameters, $messages );
 				if ( $validation_result['is_duplicate'] ) {
-					$messages[] = ConversationManager::generateDuplicateToolCallMessage( $tool_name, $turn_count, $mode );
+					$messages[]          = ConversationManager::generateDuplicateToolCallMessage( $tool_name, $turn_count, $mode );
 					$duplicate_rejected = true;
 					do_action(
 						'datamachine_log',
@@ -421,7 +421,7 @@ function datamachine_build_turn_runner(
 
 				$runtime_rule_result = $tool_runtime_rules->evaluate( $tool_name, $messages );
 				if ( ! $runtime_rule_result['allowed'] ) {
-					$tool_result = array(
+					$tool_result           = array(
 						'success' => false,
 						'error'   => $runtime_rule_result['error'],
 					);

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -425,7 +425,7 @@ function datamachine_build_turn_runner(
 						'success' => false,
 						'error'   => $runtime_rule_result['error'],
 					);
-					$messages[] = ConversationManager::formatToolResultMessage( $tool_name, $tool_result, $tool_parameters, false, $turn_count );
+					$messages[]             = ConversationManager::formatToolResultMessage( $tool_name, $tool_result, $tool_parameters, false, $turn_count );
 					$runtime_rule_rejected = true;
 					do_action(
 						'datamachine_log',

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -573,12 +573,12 @@ function datamachine_build_turn_runner(
 		}
 
 		return array(
-			'messages'               => $messages,
-			'tool_execution_results' => $tool_execution_results,
-			'conversation_complete'  => $conversation_complete,
-			'completion_nudge'       => $completion_nudge ?? '',
+			'messages'                     => $messages,
+			'tool_execution_results'       => $tool_execution_results,
+			'conversation_complete'        => $conversation_complete,
+			'completion_nudge'             => $completion_nudge ?? '',
 			'duplicate_tool_call_rejected' => $duplicate_rejected,
-			'tool_runtime_rule_rejected' => $runtime_rule_rejected,
+			'tool_runtime_rule_rejected'   => $runtime_rule_rejected,
 		);
 	};
 }

--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -304,7 +304,7 @@ final class AgentBundleArrayAdapter {
 				$document_step['step_type'] = $pipeline_step_types_by_id[ $pipeline_step_id ];
 			}
 
-			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'enabled' ) as $field ) {
+			foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'tool_runtime_rules', 'enabled' ) as $field ) {
 				if ( array_key_exists( $field, $step ) ) {
 					$document_step[ $field ] = $step[ $field ];
 				}
@@ -324,7 +324,7 @@ final class AgentBundleArrayAdapter {
 			'execution_order'  => (int) $step['step_position'],
 		);
 
-		foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'enabled' ) as $field ) {
+		foreach ( array( 'step_type', 'handler_slug', 'handler_slugs', 'handler_config', 'handler_configs', 'flow_step_settings', 'enabled_tools', 'disabled_tools', 'prompt_queue', 'config_patch_queue', 'queue_mode', 'completion_assertions', 'tool_runtime_rules', 'enabled' ) as $field ) {
 			if ( array_key_exists( $field, $step ) ) {
 				$config[ $field ] = $step[ $field ];
 			}

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -33,6 +33,7 @@ final class AgentBundleFlowFile {
 		'config_patch_queue',
 		'queue_mode',
 		'completion_assertions',
+		'tool_runtime_rules',
 		'enabled',
 	);
 
@@ -125,6 +126,13 @@ final class AgentBundleFlowFile {
 		if ( 'completion_assertions' === $field ) {
 			if ( ! is_array( $value ) ) {
 				throw new BundleValidationException( 'flow file completion_assertions must be an object.' );
+			}
+			return $value;
+		}
+
+		if ( 'tool_runtime_rules' === $field ) {
+			if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
+				throw new BundleValidationException( 'flow file tool_runtime_rules must be a list.' );
 			}
 			return $value;
 		}

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -50,7 +50,7 @@ final class AgentBundleFlowFile {
 		BundleSchema::assert_supported_version( $data, 'flow file' );
 		foreach ( array( 'slug', 'name', 'pipeline_slug', 'schedule', 'max_items', 'steps' ) as $field ) {
 			if ( ! array_key_exists( $field, $data ) ) {
-				throw new BundleValidationException( "flow file is missing required field {$field}." );
+				throw new BundleValidationException( sprintf( 'flow file is missing required field %s.', $field ) );
 			}
 		}
 
@@ -81,7 +81,7 @@ final class AgentBundleFlowFile {
 			}
 			foreach ( array( 'step_position', 'handler_configs' ) as $field ) {
 				if ( ! array_key_exists( $field, $step ) ) {
-					throw new BundleValidationException( "flow file step is missing required field {$field}." );
+					throw new BundleValidationException( sprintf( 'flow file step is missing required field %s.', $field ) );
 				}
 			}
 			if ( ! is_array( $step['handler_configs'] ) ) {
@@ -164,13 +164,13 @@ final class AgentBundleFlowFile {
 	 */
 	private static function normalize_string_list( string $field, $value ): array {
 		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
-			throw new BundleValidationException( "flow file {$field} must be a list of strings." );
+			throw new BundleValidationException( sprintf( 'flow file %s must be a list of strings.', $field ) );
 		}
 
 		$normalized = array();
 		foreach ( $value as $item ) {
 			if ( ! is_string( $item ) ) {
-				throw new BundleValidationException( "flow file {$field} must be a list of strings." );
+				throw new BundleValidationException( sprintf( 'flow file %s must be a list of strings.', $field ) );
 			}
 			$normalized[] = $item;
 		}

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -50,7 +50,7 @@ final class AgentBundleFlowFile {
 		BundleSchema::assert_supported_version( $data, 'flow file' );
 		foreach ( array( 'slug', 'name', 'pipeline_slug', 'schedule', 'max_items', 'steps' ) as $field ) {
 			if ( ! array_key_exists( $field, $data ) ) {
-				throw new BundleValidationException( sprintf( 'flow file is missing required field %s.', $field ) );
+				throw new BundleValidationException( sprintf( 'flow file is missing required field %s.', esc_html( $field ) ) );
 			}
 		}
 
@@ -81,7 +81,7 @@ final class AgentBundleFlowFile {
 			}
 			foreach ( array( 'step_position', 'handler_configs' ) as $field ) {
 				if ( ! array_key_exists( $field, $step ) ) {
-					throw new BundleValidationException( sprintf( 'flow file step is missing required field %s.', $field ) );
+					throw new BundleValidationException( sprintf( 'flow file step is missing required field %s.', esc_html( $field ) ) );
 				}
 			}
 			if ( ! is_array( $step['handler_configs'] ) ) {
@@ -164,13 +164,13 @@ final class AgentBundleFlowFile {
 	 */
 	private static function normalize_string_list( string $field, $value ): array {
 		if ( ! is_array( $value ) || ! array_is_list( $value ) ) {
-			throw new BundleValidationException( sprintf( 'flow file %s must be a list of strings.', $field ) );
+			throw new BundleValidationException( sprintf( 'flow file %s must be a list of strings.', esc_html( $field ) ) );
 		}
 
 		$normalized = array();
 		foreach ( $value as $item ) {
 			if ( ! is_string( $item ) ) {
-				throw new BundleValidationException( sprintf( 'flow file %s must be a list of strings.', $field ) );
+				throw new BundleValidationException( sprintf( 'flow file %s must be a list of strings.', esc_html( $field ) ) );
 			}
 			$normalized[] = $item;
 		}

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -149,6 +149,14 @@ $array_bundle = array(
 							'comment_github_pull_request',
 						),
 					),
+					'tool_runtime_rules' => array(
+						array(
+							'after_tool'          => 'workspace_worktree_add',
+							'limited_tools'       => array( 'workspace_read' ),
+							'max_calls'           => 4,
+							'then_require_one_of' => array( 'workspace_edit', 'create_github_issue' ),
+						),
+					),
 					'enabled_tools'    => array( 'datamachine/get-github-pull-review-context' ),
 					'disabled_tools'   => array( 'datamachine/delete-flow' ),
 					'prompt_queue'     => array(
@@ -196,6 +204,7 @@ assert_adapter_equals( 'flow document preserves config patch queue', array( 'aft
 assert_adapter_equals( 'flow document preserves AI enabled tools', array( 'datamachine/get-github-pull-review-context' ), $flow['steps'][1]['enabled_tools'] );
 assert_adapter_equals( 'flow document preserves AI disabled tools', array( 'datamachine/delete-flow' ), $flow['steps'][1]['disabled_tools'] );
 assert_adapter_equals( 'flow document preserves completion assertions', array( 'create_github_pull_request', 'comment_github_pull_request' ), $flow['steps'][1]['completion_assertions']['required_tool_names'] ?? null );
+assert_adapter_equals( 'flow document preserves tool runtime rules', 4, $flow['steps'][1]['tool_runtime_rules'][0]['max_calls'] ?? null );
 assert_adapter_equals( 'flow document preserves prompt queue', 'Review PR #1', $flow['steps'][1]['prompt_queue'][0]['prompt'] );
 assert_adapter_equals( 'flow document preserves queue mode', 'loop', $flow['steps'][1]['queue_mode'] );
 assert_adapter_equals( 'flow document preserves scheduling interval', 'hourly', $flow['schedule'] );
@@ -237,6 +246,7 @@ assert_adapter_equals( 'round-trip preserves enabled flag', true, $round_steps[0
 assert_adapter_equals( 'round-trip preserves enabled tools', array( 'datamachine/get-github-pull-review-context' ), $round_steps[1]['enabled_tools'] );
 assert_adapter_equals( 'round-trip preserves disabled tools', array( 'datamachine/delete-flow' ), $round_steps[1]['disabled_tools'] );
 assert_adapter_equals( 'round-trip preserves completion assertions', array( 'create_github_pull_request', 'comment_github_pull_request' ), $round_steps[1]['completion_assertions']['required_tool_names'] ?? null );
+assert_adapter_equals( 'round-trip preserves tool runtime rules', array( 'workspace_edit', 'create_github_issue' ), $round_steps[1]['tool_runtime_rules'][0]['then_require_one_of'] ?? null );
 assert_adapter_equals( 'round-trip preserves prompt queue', 'Review PR #1', $round_steps[1]['prompt_queue'][0]['prompt'] );
 assert_adapter_equals( 'round-trip preserves queue mode', 'loop', $round_steps[1]['queue_mode'] );
 assert_adapter_equals( 'round-trip preserves scheduling interval', 'hourly', $round_flow['scheduling_config']['interval'] );

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -440,6 +440,86 @@ assert_runtime_policy( 2 === count( $duplicate_result['tool_execution_results'] 
 assert_runtime_policy( 'second_policy_tool' === ( $duplicate_result['tool_execution_results'][1]['tool_name'] ?? '' ), 'duplicate recovery reaches next required tool' );
 assert_runtime_policy( str_contains( wp_json_encode( $duplicate_transcript->calls[0]['messages'] ?? array() ), 'DUPLICATE REJECTED' ), 'duplicate recovery transcript includes correction message' );
 
+$runtime_rule_dispatch_count = 0;
+$runtime_rule_transcript     = new RuntimePolicySmokeTranscriptPersister();
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$runtime_rule_dispatch_count ) {
+		++$runtime_rule_dispatch_count;
+
+		$tool_name = match ( $runtime_rule_dispatch_count ) {
+			1 => 'workspace_worktree_add',
+			2, 3, 4 => 'workspace_read',
+			default => 'create_github_issue',
+		};
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => '',
+				'tool_calls' => array(
+					array(
+						'name'       => $tool_name,
+						'parameters' => array( 'name' => 'rule-smoke-' . $runtime_rule_dispatch_count ),
+					),
+				),
+			),
+		);
+	}
+);
+
+$runtime_rule_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'enforce inspection budget before fallback issue' ) ),
+	array(
+		'workspace_worktree_add' => array(
+			'name'        => 'workspace_worktree_add',
+			'description' => 'Prepare a workspace',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+		'workspace_read'         => array(
+			'name'        => 'workspace_read',
+			'description' => 'Inspect a workspace file',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+		'create_github_issue'    => array(
+			'name'        => 'create_github_issue',
+			'description' => 'Open a fallback issue',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	array(
+		'transcript_persister'  => $runtime_rule_transcript,
+		'completion_assertions' => array(
+			'required_tool_names' => array( 'create_github_issue' ),
+		),
+		'tool_runtime_rules'    => array(
+			array(
+				'id'                  => 'inspection-budget-smoke',
+				'after_tool'          => 'workspace_worktree_add',
+				'limited_tools'       => array( 'workspace_read' ),
+				'max_calls'           => 2,
+				'then_require_one_of' => array( 'create_github_issue' ),
+			),
+		),
+	),
+	6
+);
+
+$runtime_rule_tool_names = array_map( static fn( $entry ) => (string) ( $entry['tool_name'] ?? '' ), $runtime_rule_result['tool_execution_results'] ?? array() );
+assert_runtime_policy( $runtime_rule_dispatch_count >= 4, 'runtime rule rejection keeps loop running for correction' );
+assert_runtime_policy( 2 === count( array_filter( $runtime_rule_tool_names, static fn( $tool_name ) => 'workspace_read' === $tool_name ) ), 'runtime rule result excludes rejected inspection call' );
+assert_runtime_policy( 'create_github_issue' === ( $runtime_rule_result['tool_execution_results'][3]['tool_name'] ?? '' ), 'runtime rule allows required fallback tool after rejection' );
+assert_runtime_policy( str_contains( wp_json_encode( $runtime_rule_transcript->calls[0]['messages'] ?? array() ), 'TOOL POLICY REJECTED' ), 'runtime rule transcript includes rejection message' );
+
 $assertion_policy = new DataMachineHandlerCompletionPolicy(
 	array(),
 	new \DataMachine\Engine\AI\DataMachineCompletionAssertions(


### PR DESCRIPTION
## Summary
- Add generic AI `tool_runtime_rules` that can reject stateful tool-loop patterns before execution.
- Thread runtime rules from pipeline/flow AI step config into the conversation loop.
- Preserve `tool_runtime_rules` through agent bundle import/export.

## Testing
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php -l inc/Engine/AI/DataMachineToolRuntimeRules.php && php -l inc/Engine/AI/conversation-loop.php && php -l inc/Core/Steps/AI/AIStep.php`
- `php -l inc/Core/Agents/AgentBundler.php && php -l inc/Engine/Bundle/AgentBundleArrayAdapter.php && php -l inc/Engine/Bundle/AgentBundleFlowFile.php`
- `php -l tests/agent-bundler-directory-adapter-smoke.php && php -l tests/agent-conversation-runtime-policy-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runtime rule implementation, bundle plumbing, and smoke coverage; Chris reviewed direction and will remain responsible for final validation.