### PR TITLE
Gate daily memory tool for pipelines

### DIFF
--- a/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
@@ -17,11 +17,12 @@ defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Engine\AI\Tools\BaseTool;
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Abilities\PermissionHelper;
 
 class AgentDailyMemory extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'abilities' => array( 'datamachine/daily-memory-read', 'datamachine/daily-memory-write', 'datamachine/daily-memory-list', 'datamachine/search-daily-memory' ) ) );
+		$this->registerTool( 'agent_daily_memory', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline_policy' ), array( 'abilities' => array( 'datamachine/daily-memory-read', 'datamachine/daily-memory-write', 'datamachine/daily-memory-list', 'datamachine/search-daily-memory' ) ) );
 	}
 
 	/**
@@ -54,7 +55,7 @@ class AgentDailyMemory extends BaseTool {
 	 */
 	private function handleRead( array $parameters ): array {
 		$ability = wp_get_ability( 'datamachine/daily-memory-read' );
-		$user_id = $this->resolve_user_id( $parameters );
+		$scope   = $this->resolve_scope( $parameters );
 
 		if ( ! $ability ) {
 			return $this->buildErrorResponse(
@@ -65,8 +66,9 @@ class AgentDailyMemory extends BaseTool {
 
 		$result = $ability->execute(
 			array(
-				'user_id' => $user_id,
-				'date'    => $parameters['date'] ?? gmdate( 'Y-m-d' ),
+				'user_id'  => $scope['user_id'],
+				'agent_id' => $scope['agent_id'],
+				'date'     => $parameters['date'] ?? gmdate( 'Y-m-d' ),
 			)
 		);
 
@@ -96,7 +98,7 @@ class AgentDailyMemory extends BaseTool {
 	 */
 	private function handleWrite( array $parameters ): array {
 		$content = $parameters['content'] ?? '';
-		$user_id = $this->resolve_user_id( $parameters );
+		$scope   = $this->resolve_scope( $parameters );
 
 		if ( '' === $content ) {
 			return $this->buildErrorResponse(
@@ -116,10 +118,11 @@ class AgentDailyMemory extends BaseTool {
 
 		$result = $ability->execute(
 			array(
-				'user_id' => $user_id,
-				'content' => $content,
-				'date'    => $parameters['date'] ?? gmdate( 'Y-m-d' ),
-				'mode'    => $parameters['mode'] ?? 'append',
+				'user_id'  => $scope['user_id'],
+				'agent_id' => $scope['agent_id'],
+				'content'  => $content,
+				'date'     => $parameters['date'] ?? gmdate( 'Y-m-d' ),
+				'mode'     => $parameters['mode'] ?? 'append',
 			)
 		);
 
@@ -148,7 +151,7 @@ class AgentDailyMemory extends BaseTool {
 	 */
 	private function handleList( array $parameters = array() ): array {
 		$ability = wp_get_ability( 'datamachine/daily-memory-list' );
-		$user_id = $this->resolve_user_id( $parameters );
+		$scope   = $this->resolve_scope( $parameters );
 
 		if ( ! $ability ) {
 			return $this->buildErrorResponse(
@@ -157,7 +160,7 @@ class AgentDailyMemory extends BaseTool {
 			);
 		}
 
-		$result = $ability->execute( array( 'user_id' => $user_id ) );
+		$result = $ability->execute( $scope );
 
 		if ( is_wp_error( $result ) ) {
 			return $this->buildErrorResponse( $result->get_error_message(), 'agent_daily_memory' );
@@ -185,7 +188,7 @@ class AgentDailyMemory extends BaseTool {
 	 */
 	private function handleSearch( array $parameters ): array {
 		$query   = $parameters['query'] ?? '';
-		$user_id = $this->resolve_user_id( $parameters );
+		$scope   = $this->resolve_scope( $parameters );
 
 		if ( '' === $query ) {
 			return $this->buildErrorResponse(
@@ -205,10 +208,11 @@ class AgentDailyMemory extends BaseTool {
 
 		$result = $ability->execute(
 			array(
-				'user_id' => $user_id,
-				'query'   => $query,
-				'from'    => $parameters['from'] ?? null,
-				'to'      => $parameters['to'] ?? null,
+				'user_id'  => $scope['user_id'],
+				'agent_id' => $scope['agent_id'],
+				'query'    => $query,
+				'from'     => $parameters['from'] ?? null,
+				'to'       => $parameters['to'] ?? null,
 			)
 		);
 
@@ -287,25 +291,42 @@ class AgentDailyMemory extends BaseTool {
 	}
 
 	/**
-	 * Resolve scoped user ID from tool parameters.
+	 * Resolve scoped memory identifiers from execution context.
 	 *
 	 * @param array $parameters Tool parameters.
-	 * @return int
+	 * @return array{user_id: int, agent_id: int}
 	 */
-	private function resolve_user_id( array $parameters ): int {
+	private function resolve_scope( array $parameters ): array {
 		$directory_manager = new DirectoryManager();
+
+		if ( PermissionHelper::in_agent_context() ) {
+			return array(
+				'user_id'  => $directory_manager->get_effective_user_id( PermissionHelper::acting_user_id() ),
+				'agent_id' => (int) PermissionHelper::get_acting_agent_id(),
+			);
+		}
+
 		$raw_user_id       = (int) ( $parameters['user_id'] ?? 0 );
 
 		if ( $raw_user_id > 0 ) {
-			return $directory_manager->get_effective_user_id( $raw_user_id );
+			return array(
+				'user_id'  => $directory_manager->get_effective_user_id( $raw_user_id ),
+				'agent_id' => 0,
+			);
 		}
 
 		$current_user_id = get_current_user_id();
 		if ( $current_user_id > 0 ) {
-			return $directory_manager->get_effective_user_id( $current_user_id );
+			return array(
+				'user_id'  => $directory_manager->get_effective_user_id( $current_user_id ),
+				'agent_id' => 0,
+			);
 		}
 
-		return $directory_manager->get_effective_user_id( 0 );
+		return array(
+			'user_id'  => $directory_manager->get_effective_user_id( 0 ),
+			'agent_id' => 0,
+		);
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php
+++ b/inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php
@@ -31,14 +31,18 @@ final class DataMachineToolRegistrySource {
 	 * @param string $mode Agent mode slug.
 	 * @return array Tools keyed by tool name.
 	 */
-	public function __invoke( string $mode ): array {
+	public function __invoke( string $mode, array $args = array() ): array {
 		$available_tools = array();
 		$all_tools       = $this->tool_manager->get_all_tools();
-		$mode_tools      = $this->filterByMode( $all_tools, $mode );
+		$mode_tools      = $this->filterByMode( $all_tools, $mode, $args );
 
 		foreach ( $mode_tools as $tool_name => $tool_config ) {
 			if ( ! is_array( $tool_config ) || empty( $tool_config ) ) {
 				continue;
+			}
+
+			if ( ToolPolicyResolver::MODE_PIPELINE === $mode && in_array( 'pipeline_policy', $tool_config['modes'] ?? array(), true ) ) {
+				$tool_config['modes'] = array_values( array_unique( array_merge( $tool_config['modes'], array( ToolPolicyResolver::MODE_PIPELINE ) ) ) );
 			}
 
 			if ( ToolPolicyResolver::MODE_PIPELINE === $mode ) {
@@ -76,13 +80,20 @@ final class DataMachineToolRegistrySource {
 	 * @param string $mode  Mode slug to filter by.
 	 * @return array Filtered tools.
 	 */
-	private function filterByMode( array $tools, string $mode ): array {
+	private function filterByMode( array $tools, string $mode, array $args = array() ): array {
 		return array_filter(
 			$tools,
-			static function ( $tool ) use ( $mode ) {
+			static function ( $tool, string $tool_name ) use ( $mode, $args ) {
 				$modes = $tool['modes'] ?? array();
+				if ( ToolPolicyResolver::MODE_PIPELINE === $mode
+					&& in_array( 'pipeline_policy', $modes, true )
+					&& in_array( $tool_name, $args['allow_only'] ?? array(), true ) ) {
+					return true;
+				}
+
 				return in_array( $mode, $modes, true );
-			}
+			},
+			ARRAY_FILTER_USE_BOTH
 		);
 	}
 }

--- a/tests/agent-daily-memory-pipeline-scope-smoke.php
+++ b/tests/agent-daily-memory-pipeline-scope-smoke.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Pure-PHP smoke test for pipeline-scoped agent_daily_memory calls (#1877).
+ *
+ * Run with: php tests/agent-daily-memory-pipeline-scope-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		private static ?int $agent_id = null;
+		private static int $owner_id = 0;
+
+		public static function set_agent_context( int $agent_id, int $owner_id ): void {
+			self::$agent_id = $agent_id;
+			self::$owner_id = $owner_id;
+		}
+
+		public static function clear_agent_context(): void {
+			self::$agent_id = null;
+			self::$owner_id = 0;
+		}
+
+		public static function in_agent_context(): bool {
+			return null !== self::$agent_id;
+		}
+
+		public static function acting_user_id(): int {
+			return self::$owner_id;
+		}
+
+		public static function get_acting_agent_id(): ?int {
+			return self::$agent_id;
+		}
+	}
+}
+
+namespace DataMachine\Core\FilesRepository {
+	class DirectoryManager {
+		public function get_effective_user_id( int $user_id = 0 ): int {
+			return $user_id > 0 ? $user_id : 1;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$agent_daily_memory_ability_inputs = array();
+	$agent_daily_memory_current_user_id = 0;
+
+	function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		// Tool registration is not under test here.
+	}
+
+	function wp_get_ability( string $name ) {
+		return new class( $name ) {
+			private string $name;
+
+			public function __construct( string $name ) {
+				$this->name = $name;
+			}
+
+			public function execute( array $input ): array {
+				global $agent_daily_memory_ability_inputs;
+				$agent_daily_memory_ability_inputs[ $this->name ] = $input;
+
+				return array( 'success' => true );
+			}
+		};
+	}
+
+	function is_wp_error( $value ): bool {
+		return false;
+	}
+
+	function get_current_user_id(): int {
+		global $agent_daily_memory_current_user_id;
+		return $agent_daily_memory_current_user_id;
+	}
+
+	require_once __DIR__ . '/../inc/Engine/AI/Tools/BaseTool.php';
+	require_once __DIR__ . '/../inc/Engine/AI/Tools/Global/AgentDailyMemory.php';
+
+	use DataMachine\Abilities\PermissionHelper;
+	use DataMachine\Engine\AI\Tools\Global\AgentDailyMemory;
+
+	$failures = array();
+	$passes   = 0;
+
+	function assert_daily_memory_scope( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+		if ( $expected === $actual ) {
+			++$passes;
+			echo "  ✓ {$name}\n";
+			return;
+		}
+
+		$failures[] = $name;
+		echo "  ✗ {$name}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	}
+
+	echo "agent-daily-memory-pipeline-scope-smoke (#1877)\n";
+
+	$tool = new AgentDailyMemory();
+	PermissionHelper::set_agent_context( 42, 77 );
+
+	$tool->handle_tool_call( array( 'action' => 'write', 'content' => 'entry', 'user_id' => 999 ) );
+	assert_daily_memory_scope(
+		array(
+			'user_id'  => 77,
+			'agent_id' => 42,
+			'content'  => 'entry',
+			'date'     => gmdate( 'Y-m-d' ),
+			'mode'     => 'append',
+		),
+		$agent_daily_memory_ability_inputs['datamachine/daily-memory-write'] ?? null,
+		'write ignores model user_id and uses executing agent scope',
+		$failures,
+		$passes
+	);
+
+	$tool->handle_tool_call( array( 'action' => 'read', 'date' => '2026-05-08', 'user_id' => 999 ) );
+	assert_daily_memory_scope(
+		array(
+			'user_id'  => 77,
+			'agent_id' => 42,
+			'date'     => '2026-05-08',
+		),
+		$agent_daily_memory_ability_inputs['datamachine/daily-memory-read'] ?? null,
+		'read uses executing agent scope',
+		$failures,
+		$passes
+	);
+
+	$tool->handle_tool_call( array( 'action' => 'list', 'user_id' => 999 ) );
+	assert_daily_memory_scope(
+		array(
+			'user_id'  => 77,
+			'agent_id' => 42,
+		),
+		$agent_daily_memory_ability_inputs['datamachine/daily-memory-list'] ?? null,
+		'list uses executing agent scope',
+		$failures,
+		$passes
+	);
+
+	$tool->handle_tool_call( array( 'action' => 'search', 'query' => 'entry', 'user_id' => 999 ) );
+	assert_daily_memory_scope(
+		array(
+			'user_id'  => 77,
+			'agent_id' => 42,
+			'query'    => 'entry',
+			'from'     => null,
+			'to'       => null,
+		),
+		$agent_daily_memory_ability_inputs['datamachine/search-daily-memory'] ?? null,
+		'search uses executing agent scope',
+		$failures,
+		$passes
+	);
+
+	PermissionHelper::clear_agent_context();
+	$tool->handle_tool_call( array( 'action' => 'read', 'date' => '2026-05-09', 'user_id' => 123 ) );
+	assert_daily_memory_scope(
+		array(
+			'user_id'  => 123,
+			'agent_id' => 0,
+			'date'     => '2026-05-09',
+		),
+		$agent_daily_memory_ability_inputs['datamachine/daily-memory-read'] ?? null,
+		'non-agent chat behavior preserves explicit user_id scope',
+		$failures,
+		$passes
+	);
+
+	if ( $failures ) {
+		echo "\nFAILED: " . count( $failures ) . " daily memory scope assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\nAll {$passes} daily memory scope assertions passed.\n";
+}

--- a/tests/global-tool-pipeline-modes-smoke.php
+++ b/tests/global-tool-pipeline-modes-smoke.php
@@ -80,9 +80,8 @@ echo "Global tool pipeline-mode smoke (#1442)\n";
 echo "---------------------------------------\n";
 
 $chat_only = array(
-	'queue_validator'    => array( 'inc/Engine/AI/Tools/Global/QueueValidator.php', 'DataMachine\Engine\AI\Tools\Global\QueueValidator' ),
-	'agent_memory'       => array( 'inc/Engine/AI/Tools/Global/AgentMemory.php', 'DataMachine\Engine\AI\Tools\Global\AgentMemory' ),
-	'agent_daily_memory' => array( 'inc/Engine/AI/Tools/Global/AgentDailyMemory.php', 'DataMachine\Engine\AI\Tools\Global\AgentDailyMemory' ),
+	'queue_validator' => array( 'inc/Engine/AI/Tools/Global/QueueValidator.php', 'DataMachine\Engine\AI\Tools\Global\QueueValidator' ),
+	'agent_memory'    => array( 'inc/Engine/AI/Tools/Global/AgentMemory.php', 'DataMachine\Engine\AI\Tools\Global\AgentMemory' ),
 );
 
 foreach ( $chat_only as $tool => [ $path, $class_name ] ) {
@@ -104,6 +103,29 @@ foreach ( $chat_only as $tool => [ $path, $class_name ] ) {
 		$passes
 	);
 }
+
+load_global_tool_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentDailyMemory.php', 'DataMachine\Engine\AI\Tools\Global\AgentDailyMemory' );
+
+$chat_tools     = resolve_tools_for_pipeline_modes( 'chat' );
+$pipeline_tools = resolve_tools_for_pipeline_modes( 'pipeline' );
+assert_true_for_pipeline_modes(
+	isset( $chat_tools['agent_daily_memory'] ),
+	'agent_daily_memory resolves in chat mode',
+	$failures,
+	$passes
+);
+assert_true_for_pipeline_modes(
+	! isset( $pipeline_tools['agent_daily_memory'] ),
+	'agent_daily_memory does not resolve in default pipeline mode',
+	$failures,
+	$passes
+);
+assert_true_for_pipeline_modes(
+	file_contains_for_pipeline_modes( 'inc/Engine/AI/Tools/Global/AgentDailyMemory.php', "array( 'chat', 'pipeline_policy' )" ),
+	'agent_daily_memory declares policy-controlled pipeline availability',
+	$failures,
+	$passes
+);
 
 $pipeline_tools = array(
 	'web_fetch'             => array( 'inc/Engine/AI/Tools/Global/WebFetch.php', 'DataMachine\Engine\AI\Tools\Global\WebFetch' ),

--- a/tests/pipeline-tool-policy-snapshot-smoke.php
+++ b/tests/pipeline-tool-policy-snapshot-smoke.php
@@ -84,10 +84,11 @@ class SnapshotPolicyToolManager extends ToolManager {
 
 	public function get_all_tools(): array {
 		return array(
-			'alpha_tool'  => array( 'modes' => array( 'pipeline' ) ),
-			'beta_tool'   => array( 'modes' => array( 'pipeline' ) ),
-			'danger_tool' => array( 'modes' => array( 'pipeline' ) ),
-			'chat_only'   => array( 'modes' => array( 'chat' ) ),
+			'alpha_tool'         => array( 'modes' => array( 'pipeline' ) ),
+			'beta_tool'          => array( 'modes' => array( 'pipeline' ) ),
+			'danger_tool'        => array( 'modes' => array( 'pipeline' ) ),
+			'agent_daily_memory' => array( 'modes' => array( 'chat', 'pipeline_policy' ) ),
+			'chat_only'          => array( 'modes' => array( 'chat' ) ),
 		);
 	}
 
@@ -150,7 +151,20 @@ $tools   = resolve_policy_tools_for_test(
 	$manager
 );
 assert_policy_equals( array( 'alpha_tool' ), array_keys( $tools ), 'allowlist keeps only enabled tool', $failures, $passes );
-assert_policy_equals( array( null, null, null ), $manager->availability_contexts, 'pipeline availability does not pass context IDs', $failures, $passes );
+assert_policy_equals( array( null, null, null ), $manager->availability_contexts, 'pipeline availability does not pass context IDs for default pipeline tools', $failures, $passes );
+
+$manager = new SnapshotPolicyToolManager();
+$tools   = resolve_policy_tools_for_test(
+	array(
+		'step_type'        => 'ai',
+		'pipeline_step_id' => 'ephemeral_pipeline_0',
+		'enabled_tools'    => array( 'agent_daily_memory' ),
+	),
+	array(),
+	$manager
+);
+assert_policy_equals( array( 'agent_daily_memory' ), array_keys( $tools ), 'allowlist can intentionally grant policy-controlled daily memory tool', $failures, $passes );
+assert_policy_equals( array( null, null, null, null ), $manager->availability_contexts, 'policy-controlled daily memory still uses pipeline availability checks', $failures, $passes );
 
 echo "\n[2] ephemeral workflow disabled_tools deny from snapshot:\n";
 $ephemeral = WorkflowConfigFactory::buildEphemeralConfigs(
@@ -168,7 +182,7 @@ $flow_step_config     = $ephemeral['flow_config']['ephemeral_step_0'];
 $pipeline_step_config = $ephemeral['pipeline_config']['ephemeral_pipeline_0'];
 $manager              = new SnapshotPolicyToolManager();
 $tools                = resolve_policy_tools_for_test( $flow_step_config, $pipeline_step_config, $manager );
-assert_policy_equals( array( 'alpha_tool', 'beta_tool' ), array_keys( $tools ), 'ephemeral disabled_tools removes denied tool without DB row', $failures, $passes );
+assert_policy_equals( array( 'alpha_tool', 'beta_tool' ), array_keys( $tools ), 'ephemeral disabled_tools removes denied tool without DB row and does not auto-grant daily memory', $failures, $passes );
 assert_policy_equals( array( null, null, null ), $manager->availability_contexts, 'ephemeral policy never re-reads by synthetic pipeline step ID', $failures, $passes );
 
 echo "\n[3] persistent workflow disabled_tools still apply from snapshot:\n";


### PR DESCRIPTION
## Summary
- Adds policy-controlled pipeline availability for `agent_daily_memory` so `enabled_tools` can intentionally grant it without changing default pipeline tool exposure.
- Resolves daily-memory tool calls through the active `PermissionHelper` agent context so pipeline reads/writes/list/search target the executing agent scope, not model-supplied `user_id`.
- Pins the default/no-auto-grant behavior and scoped ability inputs with targeted smokes.

## Tests
- `php tests/global-tool-pipeline-modes-smoke.php`
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `php tests/agent-daily-memory-pipeline-scope-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php inc/Engine/AI/Tools/Global/AgentDailyMemory.php tests/global-tool-pipeline-modes-smoke.php tests/pipeline-tool-policy-snapshot-smoke.php tests/agent-daily-memory-pipeline-scope-smoke.php`
- `composer test -- --filter ToolPolicyResolverTest`

Fixes #1877.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and focused tests; Chris remains responsible for review and validation.