### PR TITLE
Require successful tools for completion assertions

### DIFF
--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -57,12 +57,14 @@ class DataMachineCompletionAssertions {
 	 * @param array      $tool_result Tool result.
 	 */
 	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result ): void {
-		if ( '' !== $tool_name ) {
+		$tool_succeeded = true === ( $tool_result['success'] ?? false );
+
+		if ( '' !== $tool_name && $tool_succeeded ) {
 			$this->executed_tool_names[] = $tool_name;
 		}
 
 		$is_handler_tool = is_array( $tool_def ) && isset( $tool_def['handler'] );
-		if ( $is_handler_tool && ( $tool_result['success'] ?? false ) ) {
+		if ( $is_handler_tool && $tool_succeeded ) {
 			$this->available_output_packet_types[] = 'ai_handler_complete';
 			return;
 		}

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -641,6 +641,34 @@ $non_handler_assertion_decision = $non_handler_assertion_policy->recordToolResul
 assert_runtime_policy( ! $non_handler_assertion_decision->isComplete(), 'handler policy waits after non-handler tools when generic assertions are missing' );
 assert_runtime_policy( str_contains( $non_handler_assertion_decision->context()['continuation_message'] ?? '', 'create_github_pull_request' ), 'handler policy nudges after non-handler tools with missing assertions' );
 
+$failed_required_tool_policy = new DataMachineHandlerCompletionPolicy(
+	array(),
+	new \DataMachine\Engine\AI\DataMachineCompletionAssertions(
+		array(
+			'required_tool_names' => array( 'workspace_edit', 'workspace_git_commit' ),
+		)
+	)
+);
+$failed_required_tool_policy->recordToolResult(
+	'workspace_edit',
+	array( 'name' => 'workspace_edit' ),
+	array(
+		'success' => false,
+		'error'   => 'old_string not found in file content.',
+	),
+	array( 'mode' => 'pipeline' ),
+	1
+);
+$failed_required_tool_decision = $failed_required_tool_policy->recordNaturalCompletion(
+	array( array( 'role' => 'user', 'content' => 'edit then commit' ) ),
+	'I cannot proceed.',
+	array( 'mode' => 'pipeline' ),
+	2
+);
+
+assert_runtime_policy( ! $failed_required_tool_decision->isComplete(), 'failed required tool does not satisfy completion assertion' );
+assert_runtime_policy( array( 'workspace_edit', 'workspace_git_commit' ) === ( $failed_required_tool_decision->context()['missing']['tool_names'] ?? null ), 'failed required tool remains in missing assertion list' );
+
 $dispatch_count     = 0;
 $provider_context   = null;
 $completion_policy  = new RuntimePolicySmokeCompletionPolicy();


### PR DESCRIPTION
## Summary
- Count `required_tool_names` completion assertions only after a tool result reports success.
- Keep failed required tools in the missing assertion list so continuation nudges ask the agent to recover the failed step instead of moving on to downstream actions.
- Add runtime policy smoke coverage for a failed `workspace_edit` remaining unsatisfied.

This fixes the iterator failure mode seen after Extra-Chill/data-machine-code#301: a failed workspace edit was incorrectly treated as satisfying the edit requirement, so the loop kept asking for commit/push/PR even though no change had been staged.

## Testing
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `php -l inc/Engine/AI/DataMachineCompletionAssertions.php && php -l tests/agent-conversation-runtime-policy-smoke.php`
- `git diff --check`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@fix-completion-assertions-success --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the iterator smoke failure, drafting the runtime assertion fix and regression test, and running local verification; Chris remains responsible for review and merge.