### PR TITLE
Fail unavailable required completion tools before AI calls

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -431,6 +431,9 @@ class AIStep extends Step {
 			// Check for errors
 			if ( isset( $loop_result['error'] ) ) {
 				$request_metadata = is_array( $loop_result['request_metadata'] ?? null ) ? $loop_result['request_metadata'] : array();
+				$failure_reason   = 'completion_required_tool_unavailable' === ( $loop_result['error_code'] ?? '' )
+					? 'completion_required_tool_unavailable'
+					: 'ai_processing_failed';
 				// Record the transcript on the failure path too so operators
 				// can `wp datamachine jobs transcript <id>` and see exactly
 				// what the model received before the AI request died. This
@@ -446,16 +449,18 @@ class AIStep extends Step {
 				do_action(
 					'datamachine_fail_job',
 					$this->job_id,
-					'ai_processing_failed',
+					$failure_reason,
 					array(
-						'flow_step_id'        => $this->flow_step_id,
-						'ai_error'            => $loop_result['error'],
-						'ai_provider'         => $provider_name,
-						'request_metadata'    => $request_metadata,
-						'transport_profile'   => is_array( $request_metadata['transport'] ?? null ) ? $request_metadata['transport'] : array(),
-						'retry_after'         => $loop_result['retry_after'] ?? null,
-						'retry_after_seconds' => $loop_result['retry_after_seconds'] ?? null,
-						'headers'             => is_array( $loop_result['headers'] ?? null ) ? $loop_result['headers'] : array(),
+						'flow_step_id'                      => $this->flow_step_id,
+						'ai_error'                          => $loop_result['error'],
+						'error_code'                        => $loop_result['error_code'] ?? null,
+						'unavailable_required_tool_names'   => is_array( $loop_result['unavailable_required_tool_names'] ?? null ) ? $loop_result['unavailable_required_tool_names'] : array(),
+						'ai_provider'                       => $provider_name,
+						'request_metadata'                  => $request_metadata,
+						'transport_profile'                 => is_array( $request_metadata['transport'] ?? null ) ? $request_metadata['transport'] : array(),
+						'retry_after'                       => $loop_result['retry_after'] ?? null,
+						'retry_after_seconds'               => $loop_result['retry_after_seconds'] ?? null,
+						'headers'                           => is_array( $loop_result['headers'] ?? null ) ? $loop_result['headers'] : array(),
 					)
 				);
 				return array();

--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -157,6 +157,29 @@ class DataMachineCompletionAssertions {
 	}
 
 	/**
+	 * Return required tool names.
+	 *
+	 * @return array<int, string>
+	 */
+	public function requiredToolNames(): array {
+		return $this->required_tool_names;
+	}
+
+	/**
+	 * Return required tools that are not available to the model.
+	 *
+	 * @param array $tools Available tools keyed by tool name.
+	 * @return array<int, string>
+	 */
+	public function unavailableRequiredToolNames( array $tools ): array {
+		if ( empty( $this->required_tool_names ) ) {
+			return array();
+		}
+
+		return array_values( array_diff( $this->required_tool_names, array_keys( $tools ) ) );
+	}
+
+	/**
 	 * @param mixed $value Raw list.
 	 * @return array<int, string>
 	 */

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -56,7 +56,8 @@ function datamachine_run_conversation(
 
 	// Resolve DM runtime collaborators from the payload.
 	$event_sink           = datamachine_resolve_event_sink( $payload );
-	$completion_policy    = datamachine_resolve_completion_policy( $mode, $payload );
+	$assertions           = datamachine_resolve_completion_assertions( $payload );
+	$completion_policy    = datamachine_resolve_completion_policy( $mode, $payload, $assertions );
 	$tool_runtime_rules   = datamachine_resolve_tool_runtime_rules( $payload );
 	$transcript_persister = datamachine_resolve_transcript_persister( $payload );
 	$transcript_lock      = $payload['transcript_lock'] ?? $payload['transcript_lock_store'] ?? null;
@@ -91,6 +92,59 @@ function datamachine_run_conversation(
 		),
 		fn( $v ) => null !== $v
 	);
+
+	$unavailable_required_tools = $assertions->unavailableRequiredToolNames( $tools );
+	if ( ! empty( $unavailable_required_tools ) ) {
+		$error_message = sprintf(
+			'Completion assertions require unavailable tool(s): %s. Update the AI step tool policy so every completion_assertions.required_tool_names entry is available to the model.',
+			implode( ', ', $unavailable_required_tools )
+		);
+
+		datamachine_emit_loop_event(
+			$event_sink,
+			'completion_assertions_unavailable',
+			array_merge(
+				$base_log_context,
+				array(
+					'required_tool_names'             => $assertions->requiredToolNames(),
+					'unavailable_required_tool_names' => $unavailable_required_tools,
+					'available_tool_names'            => array_keys( $tools ),
+					'error_message'                   => $error_message,
+				)
+			)
+		);
+
+		do_action(
+			'datamachine_log',
+			'error',
+			'datamachine_run_conversation: Required completion assertion tool unavailable',
+			array_merge(
+				$base_log_context,
+				array(
+					'required_tool_names'             => $assertions->requiredToolNames(),
+					'unavailable_required_tool_names' => $unavailable_required_tools,
+					'available_tool_names'            => array_keys( $tools ),
+				)
+			)
+		);
+
+		return array(
+			'messages'                         => $messages,
+			'final_content'                    => '',
+			'turn_count'                       => 0,
+			'completed'                        => false,
+			'last_tool_calls'                  => array(),
+			'tool_execution_results'           => array(),
+			'error'                            => $error_message,
+			'error_code'                       => 'completion_required_tool_unavailable',
+			'completion_assertions_required'    => $assertions->required(),
+			'unavailable_required_tool_names'   => $unavailable_required_tools,
+			'available_tool_names'              => array_keys( $tools ),
+			'usage'                            => array(),
+			'request_metadata'                 => array(),
+			'status'                           => 'error',
+		);
+	}
 
 	// Bridge DM's LoopEventSinkInterface to upstream's on_event callable.
 	$on_event = static function ( string $event, array $event_payload ) use ( $event_sink, $base_log_context ): void {
@@ -730,13 +784,13 @@ function datamachine_resolve_event_sink( array $payload ): LoopEventSinkInterfac
  * @param array  $payload Loop payload.
  * @return WP_Agent_Conversation_Completion_Policy
  */
-function datamachine_resolve_completion_policy( string $mode, array $payload ): WP_Agent_Conversation_Completion_Policy {
+function datamachine_resolve_completion_policy( string $mode, array $payload, ?DataMachineCompletionAssertions $assertions = null ): WP_Agent_Conversation_Completion_Policy {
 	$policy = $payload['completion_policy'] ?? null;
 	if ( $policy instanceof WP_Agent_Conversation_Completion_Policy ) {
 		return $policy;
 	}
 
-	$assertions = datamachine_resolve_completion_assertions( $payload );
+	$assertions = $assertions ?? datamachine_resolve_completion_assertions( $payload );
 
 	$configured_handlers = $payload['configured_handler_slugs'] ?? array();
 	$configured_handlers = is_array( $configured_handlers ) ? array_values( $configured_handlers ) : array();

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -129,6 +129,26 @@ class RuntimePolicySmokeTool {
 	}
 }
 
+class RuntimePolicySmokeMaybeFailTool {
+	public function execute( array $parameters, array $tool_def ): array {
+		unset( $tool_def );
+
+		if ( ! empty( $parameters['fail'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'requested failure',
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'message' => 'required tool succeeded',
+			),
+		);
+	}
+}
+
 $failures   = array();
 $assertions = 0;
 
@@ -668,6 +688,136 @@ $failed_required_tool_decision = $failed_required_tool_policy->recordNaturalComp
 
 assert_runtime_policy( ! $failed_required_tool_decision->isComplete(), 'failed required tool does not satisfy completion assertion' );
 assert_runtime_policy( array( 'workspace_edit', 'workspace_git_commit' ) === ( $failed_required_tool_decision->context()['missing']['tool_names'] ?? null ), 'failed required tool remains in missing assertion list' );
+
+$daily_memory_unavailable_dispatch_count = 0;
+$daily_memory_unavailable_sink           = new RuntimePolicySmokeEventSink();
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$daily_memory_unavailable_dispatch_count ) {
+		++$daily_memory_unavailable_dispatch_count;
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'This provider call should not happen.',
+				'tool_calls' => array(),
+			),
+		);
+	}
+);
+
+$daily_memory_unavailable_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'write daily memory before finishing' ) ),
+	array(
+		'create_github_pull_request' => array(
+			'name'        => 'create_github_pull_request',
+			'description' => 'Open a pull request',
+			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'class'       => RuntimePolicySmokeTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	array(
+		'event_sink'            => $daily_memory_unavailable_sink,
+		'completion_assertions' => array(
+			'required_tool_names' => array( 'create_github_pull_request', 'agent_daily_memory' ),
+		),
+	),
+	5
+);
+
+assert_runtime_policy( 0 === $daily_memory_unavailable_dispatch_count, 'unavailable required tool fails before provider dispatch' );
+assert_runtime_policy( 'completion_required_tool_unavailable' === ( $daily_memory_unavailable_result['error_code'] ?? '' ), 'unavailable required tool returns clear error code' );
+assert_runtime_policy( array( 'agent_daily_memory' ) === ( $daily_memory_unavailable_result['unavailable_required_tool_names'] ?? null ), 'unavailable required tool diagnostic names missing tool' );
+assert_runtime_policy( str_contains( $daily_memory_unavailable_result['error'] ?? '', 'agent_daily_memory' ), 'unavailable required tool error message names daily memory' );
+assert_runtime_policy( array( 'agent_daily_memory' ) === ( runtime_policy_first_event_payload( $daily_memory_unavailable_sink, 'completion_assertions_unavailable' )['unavailable_required_tool_names'] ?? null ), 'unavailable required tool emits preflight event' );
+
+$daily_memory_success_dispatch_count = 0;
+WpAiClientTestDouble::reset();
+WpAiClientTestDouble::set_response_callback(
+	function () use ( &$daily_memory_success_dispatch_count ) {
+		++$daily_memory_success_dispatch_count;
+
+		if ( 1 === $daily_memory_success_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => 'Done without memory.',
+					'tool_calls' => array(),
+				),
+			);
+		}
+
+		if ( 2 === $daily_memory_success_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'name'       => 'agent_daily_memory',
+							'parameters' => array( 'fail' => true ),
+						),
+					),
+				),
+			);
+		}
+
+		if ( 3 === $daily_memory_success_dispatch_count ) {
+			return array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'name'       => 'agent_daily_memory',
+							'parameters' => array(),
+						),
+					),
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'content'    => 'Complete after successful memory write.',
+				'tool_calls' => array(),
+			),
+		);
+	}
+);
+
+$daily_memory_success_result = datamachine_run_conversation(
+	array( array( 'role' => 'user', 'content' => 'finish only after daily memory succeeds' ) ),
+	array(
+		'agent_daily_memory' => array(
+			'name'        => 'agent_daily_memory',
+			'description' => 'Write daily memory',
+			'parameters'  => array( 'fail' => array( 'type' => 'boolean' ) ),
+			'class'       => RuntimePolicySmokeMaybeFailTool::class,
+			'method'      => 'execute',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	'pipeline',
+	array(
+		'completion_assertions' => array(
+			'required_tool_names' => array( 'agent_daily_memory' ),
+		),
+	),
+	6
+);
+
+$daily_memory_tool_results = $daily_memory_success_result['tool_execution_results'] ?? array();
+assert_runtime_policy( 4 === $daily_memory_success_dispatch_count, 'required daily memory nudges until successful tool result and then natural completion' );
+assert_runtime_policy( false === ( $daily_memory_tool_results[0]['result']['success'] ?? null ), 'failed daily memory call is captured but not sufficient' );
+assert_runtime_policy( true === ( $daily_memory_tool_results[1]['result']['success'] ?? null ), 'successful daily memory call satisfies required tool assertion' );
+assert_runtime_policy( ! empty( $daily_memory_success_result['completed'] ), 'daily memory assertion result completes after successful tool call' );
 
 $dispatch_count     = 0;
 $provider_context   = null;


### PR DESCRIPTION
## Summary
- Fail conversation runs before provider dispatch when `completion_assertions.required_tool_names` contains tools not exposed by the resolved tool policy.
- Preserve handler completion behavior while carrying the clear failure reason and unavailable tool diagnostics through AI step job failure context.
- Add regression smoke coverage for unavailable required tools, daily-memory required-tool success, and the existing pipeline allowlist path for `agent_daily_memory`.

Fixes #1882.

## Tests
- `php -l inc/Engine/AI/DataMachineCompletionAssertions.php`
- `php -l inc/Engine/AI/conversation-loop.php`
- `php -l inc/Core/Steps/AI/AIStep.php`
- `php -l tests/agent-conversation-runtime-policy-smoke.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `php tests/pipeline-tool-policy-snapshot-smoke.php`
- `composer lint -- inc/Engine/AI/DataMachineCompletionAssertions.php inc/Engine/AI/conversation-loop.php inc/Core/Steps/AI/AIStep.php tests/agent-conversation-runtime-policy-smoke.php`
- `composer test` (1248 tests, 1245 passed, 3 skipped)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the completion assertion preflight and drafted focused regression smoke tests; Chris remains responsible for review and validation.