### PR TITLE
Support outcome-aware completion assertions

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -598,6 +598,14 @@ class AIStep extends Step {
 			}
 		}
 
+		$complete_when_any = array_merge(
+			is_array( $pipeline_assertions['complete_when_any'] ?? null ) ? $pipeline_assertions['complete_when_any'] : array(),
+			is_array( $flow_assertions['complete_when_any'] ?? null ) ? $flow_assertions['complete_when_any'] : array()
+		);
+		if ( ! empty( $complete_when_any ) ) {
+			$merged['complete_when_any'] = array_values( $complete_when_any );
+		}
+
 		return $merged;
 	}
 

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -451,16 +451,16 @@ class AIStep extends Step {
 					$this->job_id,
 					$failure_reason,
 					array(
-						'flow_step_id'                      => $this->flow_step_id,
-						'ai_error'                          => $loop_result['error'],
-						'error_code'                        => $loop_result['error_code'] ?? null,
-						'unavailable_required_tool_names'   => is_array( $loop_result['unavailable_required_tool_names'] ?? null ) ? $loop_result['unavailable_required_tool_names'] : array(),
-						'ai_provider'                       => $provider_name,
-						'request_metadata'                  => $request_metadata,
-						'transport_profile'                 => is_array( $request_metadata['transport'] ?? null ) ? $request_metadata['transport'] : array(),
-						'retry_after'                       => $loop_result['retry_after'] ?? null,
-						'retry_after_seconds'               => $loop_result['retry_after_seconds'] ?? null,
-						'headers'                           => is_array( $loop_result['headers'] ?? null ) ? $loop_result['headers'] : array(),
+						'flow_step_id'                    => $this->flow_step_id,
+						'ai_error'                        => $loop_result['error'],
+						'error_code'                      => $loop_result['error_code'] ?? null,
+						'unavailable_required_tool_names' => is_array( $loop_result['unavailable_required_tool_names'] ?? null ) ? $loop_result['unavailable_required_tool_names'] : array(),
+						'ai_provider'                     => $provider_name,
+						'request_metadata'                => $request_metadata,
+						'transport_profile'               => is_array( $request_metadata['transport'] ?? null ) ? $request_metadata['transport'] : array(),
+						'retry_after'                     => $loop_result['retry_after'] ?? null,
+						'retry_after_seconds'             => $loop_result['retry_after_seconds'] ?? null,
+						'headers'                         => is_array( $loop_result['headers'] ?? null ) ? $loop_result['headers'] : array(),
 					)
 				);
 				return array();

--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -23,8 +23,14 @@ class DataMachineCompletionAssertions {
 	/** @var array<int, string> */
 	private array $required_output_packet_types;
 
+	/** @var array<int, array{tools: array<int, array{name: string, required_output: array<int, string>}>}> */
+	private array $complete_when_any;
+
 	/** @var array<int, string> */
 	private array $executed_tool_names = array();
+
+	/** @var array<string, array<int, array>> */
+	private array $successful_tool_results = array();
 
 	/** @var array<int, string> */
 	private array $available_output_packet_types = array();
@@ -36,6 +42,7 @@ class DataMachineCompletionAssertions {
 		$this->required_engine_data_keys    = $this->sanitizeList( $config['required_engine_data_keys'] ?? array() );
 		$this->required_tool_names          = $this->sanitizeList( $config['required_tool_names'] ?? array() );
 		$this->required_output_packet_types = $this->sanitizeList( $config['required_output_packet_types'] ?? array() );
+		$this->complete_when_any            = $this->sanitizeOutcomeAssertions( $config['complete_when_any'] ?? array() );
 	}
 
 	/**
@@ -46,7 +53,8 @@ class DataMachineCompletionAssertions {
 	public function hasAssertions(): bool {
 		return ! empty( $this->required_engine_data_keys )
 			|| ! empty( $this->required_tool_names )
-			|| ! empty( $this->required_output_packet_types );
+			|| ! empty( $this->required_output_packet_types )
+			|| ! empty( $this->complete_when_any );
 	}
 
 	/**
@@ -61,6 +69,7 @@ class DataMachineCompletionAssertions {
 
 		if ( '' !== $tool_name && $tool_succeeded ) {
 			$this->executed_tool_names[] = $tool_name;
+			$this->successful_tool_results[ $tool_name ][] = $tool_result;
 		}
 
 		$is_handler_tool = is_array( $tool_def ) && isset( $tool_def['handler'] );
@@ -93,10 +102,13 @@ class DataMachineCompletionAssertions {
 			$output_packet_types[] = 'ai_response';
 		}
 
+		$outcome_evaluation = $this->evaluateOutcomeAssertions();
+
 		$satisfied = array(
 			'engine_data_keys'    => $this->satisfiedEngineDataKeys( $runtime_context ),
 			'tool_names'          => array_values( array_intersect( $this->required_tool_names, array_unique( $this->executed_tool_names ) ) ),
 			'output_packet_types' => array_values( array_intersect( $this->required_output_packet_types, $output_packet_types ) ),
+			'complete_when_any'   => $outcome_evaluation['satisfied'],
 		);
 
 		$missing = array_filter(
@@ -104,6 +116,7 @@ class DataMachineCompletionAssertions {
 				'engine_data_keys'    => array_values( array_diff( $this->required_engine_data_keys, $satisfied['engine_data_keys'] ) ),
 				'tool_names'          => array_values( array_diff( $this->required_tool_names, $satisfied['tool_names'] ) ),
 				'output_packet_types' => array_values( array_diff( $this->required_output_packet_types, $satisfied['output_packet_types'] ) ),
+				'complete_when_any'   => $outcome_evaluation['missing'],
 			)
 		);
 
@@ -152,6 +165,7 @@ class DataMachineCompletionAssertions {
 				'engine_data_keys'    => $this->required_engine_data_keys,
 				'tool_names'          => $this->required_tool_names,
 				'output_packet_types' => $this->required_output_packet_types,
+				'complete_when_any'   => $this->complete_when_any,
 			)
 		);
 	}
@@ -172,11 +186,122 @@ class DataMachineCompletionAssertions {
 	 * @return array<int, string>
 	 */
 	public function unavailableRequiredToolNames( array $tools ): array {
-		if ( empty( $this->required_tool_names ) ) {
+		$required_tool_names = $this->required_tool_names;
+		if ( ! empty( $this->complete_when_any ) && ! $this->hasAvailableOutcomePath( $tools ) ) {
+			$required_tool_names = array_merge( $required_tool_names, $this->outcomeToolNames() );
+		}
+
+		if ( empty( $required_tool_names ) ) {
 			return array();
 		}
 
-		return array_values( array_diff( $this->required_tool_names, array_keys( $tools ) ) );
+		return array_values( array_diff( array_values( array_unique( $required_tool_names ) ), array_keys( $tools ) ) );
+	}
+
+	/**
+	 * @return array{satisfied: array<int, string>, missing: array<int, string>}
+	 */
+	private function evaluateOutcomeAssertions(): array {
+		if ( empty( $this->complete_when_any ) ) {
+			return array(
+				'satisfied' => array(),
+				'missing'   => array(),
+			);
+		}
+
+		$missing = array();
+		foreach ( $this->complete_when_any as $index => $outcome ) {
+			$outcome_missing = $this->missingOutcomeRequirements( $outcome );
+			if ( empty( $outcome_missing ) ) {
+				return array(
+					'satisfied' => array( 'outcome_' . ( $index + 1 ) ),
+					'missing'   => array(),
+				);
+			}
+
+			$missing[] = 'outcome_' . ( $index + 1 ) . ': ' . implode( ', ', $outcome_missing );
+		}
+
+		return array(
+			'satisfied' => array(),
+			'missing'   => $missing,
+		);
+	}
+
+	/**
+	 * @param array{tools: array<int, array{name: string, required_output: array<int, string>}>} $outcome Outcome assertion.
+	 * @return array<int, string>
+	 */
+	private function missingOutcomeRequirements( array $outcome ): array {
+		$missing = array();
+		foreach ( $outcome['tools'] as $tool ) {
+			$name = $tool['name'];
+			if ( empty( $this->successful_tool_results[ $name ] ) ) {
+				$missing[] = $name;
+				continue;
+			}
+
+			foreach ( $tool['required_output'] as $field ) {
+				if ( ! $this->toolHasOutputField( $name, $field ) ) {
+					$missing[] = $name . '.' . $field;
+				}
+			}
+		}
+
+		return array_values( array_unique( $missing ) );
+	}
+
+	private function toolHasOutputField( string $tool_name, string $field ): bool {
+		foreach ( $this->successful_tool_results[ $tool_name ] ?? array() as $result ) {
+			if ( $this->hasNonEmptyPath( $result, $field ) ) {
+				return true;
+			}
+
+			if ( is_array( $result['data'] ?? null ) && $this->hasNonEmptyPath( $result['data'], $field ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private function hasNonEmptyPath( array $data, string $path ): bool {
+		$segments = explode( '.', $path );
+		$value    = $data;
+		foreach ( $segments as $segment ) {
+			if ( ! is_array( $value ) || ! array_key_exists( $segment, $value ) ) {
+				return false;
+			}
+
+			$value = $value[ $segment ];
+		}
+
+		return null !== $value && '' !== $value && array() !== $value;
+	}
+
+	private function hasAvailableOutcomePath( array $tools ): bool {
+		foreach ( $this->complete_when_any as $outcome ) {
+			$names = array_map( static fn( array $tool ): string => $tool['name'], $outcome['tools'] );
+			if ( empty( array_diff( $names, array_keys( $tools ) ) ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @return array<int, string>
+	 */
+	private function outcomeToolNames(): array {
+		$names = array();
+		foreach ( $this->complete_when_any as $outcome ) {
+			foreach ( $outcome['tools'] as $tool ) {
+				$names[] = $tool['name'];
+			}
+		}
+
+		return array_values( array_unique( $names ) );
 	}
 
 	/**
@@ -200,6 +325,46 @@ class DataMachineCompletionAssertions {
 		}
 
 		return array_values( array_unique( $items ) );
+	}
+
+	/**
+	 * @param mixed $value Raw outcome assertions.
+	 * @return array<int, array{tools: array<int, array{name: string, required_output: array<int, string>}>}>
+	 */
+	private function sanitizeOutcomeAssertions( $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$outcomes = array();
+		foreach ( $value as $outcome ) {
+			if ( ! is_array( $outcome ) || ! is_array( $outcome['tools'] ?? null ) ) {
+				continue;
+			}
+
+			$tools = array();
+			foreach ( $outcome['tools'] as $tool ) {
+				if ( ! is_array( $tool ) ) {
+					continue;
+				}
+
+				$name = trim( (string) ( $tool['name'] ?? '' ) );
+				if ( '' === $name ) {
+					continue;
+				}
+
+				$tools[] = array(
+					'name'            => $name,
+					'required_output' => $this->sanitizeList( $tool['required_output'] ?? array() ),
+				);
+			}
+
+			if ( ! empty( $tools ) ) {
+				$outcomes[] = array( 'tools' => $tools );
+			}
+		}
+
+		return $outcomes;
 	}
 
 	/**

--- a/inc/Engine/AI/DataMachineCompletionAssertions.php
+++ b/inc/Engine/AI/DataMachineCompletionAssertions.php
@@ -68,7 +68,7 @@ class DataMachineCompletionAssertions {
 		$tool_succeeded = true === ( $tool_result['success'] ?? false );
 
 		if ( '' !== $tool_name && $tool_succeeded ) {
-			$this->executed_tool_names[] = $tool_name;
+			$this->executed_tool_names[]                   = $tool_name;
 			$this->successful_tool_results[ $tool_name ][] = $tool_result;
 		}
 
@@ -144,7 +144,7 @@ class DataMachineCompletionAssertions {
 			$parts[] = $label . ': ' . implode( ', ', array_map( 'strval', $values ) );
 		}
 
-		$goal = self::extractGoal( $messages );
+		$goal  = self::extractGoal( $messages );
 		$nudge = 'Please continue. The work is close, but these completion signals are still missing: ' . implode( '; ', $parts ) . '.';
 		if ( '' !== $goal ) {
 			$nudge .= ' Original goal/context: ' . $goal;

--- a/tests/Unit/Auth/CallerContextTest.php
+++ b/tests/Unit/Auth/CallerContextTest.php
@@ -89,11 +89,16 @@ class CallerContextTest extends WP_UnitTestCase {
 	}
 
 	public function test_is_cross_site_requires_remote_host(): void {
-		$local = new \WP_Agent_Caller_Context( 'some-agent', 0, \WP_Agent_Caller_Context::SELF_HOST, 2, 'cid' );
+		$local = \WP_Agent_Caller_Context::top_of_chain( 'cid' );
 		$this->assertFalse( $local->is_cross_site() );
 
 		$remote = new \WP_Agent_Caller_Context( 'some-agent', 0, 'https://chubes.net', 1, 'cid' );
 		$this->assertTrue( $remote->is_cross_site() );
+	}
+
+	public function test_chained_context_rejects_self_host(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		new \WP_Agent_Caller_Context( 'some-agent', 0, \WP_Agent_Caller_Context::SELF_HOST, 2, 'cid' );
 	}
 
 	public function test_outbound_fresh_chain_shape(): void {

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -689,6 +689,125 @@ $failed_required_tool_decision = $failed_required_tool_policy->recordNaturalComp
 assert_runtime_policy( ! $failed_required_tool_decision->isComplete(), 'failed required tool does not satisfy completion assertion' );
 assert_runtime_policy( array( 'workspace_edit', 'workspace_git_commit' ) === ( $failed_required_tool_decision->context()['missing']['tool_names'] ?? null ), 'failed required tool remains in missing assertion list' );
 
+$outcome_assertions_config = array(
+	'complete_when_any' => array(
+		array(
+			'tools' => array(
+				array(
+					'name'            => 'create_github_pull_request',
+					'success'         => true,
+					'required_output' => 'html_url',
+				),
+				array(
+					'name'    => 'comment_github_pull_request',
+					'success' => true,
+				),
+			),
+		),
+		array(
+			'tools' => array(
+				array(
+					'name'            => 'create_github_issue',
+					'success'         => true,
+					'required_output' => 'html_url',
+				),
+				array(
+					'name'    => 'comment_github_pull_request',
+					'success' => true,
+				),
+			),
+		),
+	),
+);
+
+$pr_outcome_policy = new DataMachineHandlerCompletionPolicy(
+	array(),
+	new \DataMachine\Engine\AI\DataMachineCompletionAssertions( $outcome_assertions_config )
+);
+$pr_outcome_policy->recordToolResult(
+	'create_github_pull_request',
+	array( 'name' => 'create_github_pull_request' ),
+	array(
+		'success' => true,
+		'data'    => array( 'html_url' => 'https://github.com/Extra-Chill/data-machine/pull/1' ),
+	),
+	array( 'mode' => 'pipeline' ),
+	1
+);
+$pr_outcome_policy->recordToolResult(
+	'comment_github_pull_request',
+	array( 'name' => 'comment_github_pull_request' ),
+	array( 'success' => true ),
+	array( 'mode' => 'pipeline' ),
+	2
+);
+$pr_outcome_decision = $pr_outcome_policy->recordNaturalCompletion(
+	array( array( 'role' => 'user', 'content' => 'open a PR or fallback issue, then comment on source PR' ) ),
+	'Complete via PR path.',
+	array( 'mode' => 'pipeline' ),
+	3
+);
+assert_runtime_policy( $pr_outcome_decision->isComplete(), 'complete_when_any PR path satisfies completion assertion' );
+
+$issue_outcome_policy = new DataMachineHandlerCompletionPolicy(
+	array(),
+	new \DataMachine\Engine\AI\DataMachineCompletionAssertions( $outcome_assertions_config )
+);
+$issue_outcome_policy->recordToolResult(
+	'create_github_issue',
+	array( 'name' => 'create_github_issue' ),
+	array(
+		'success'  => true,
+		'html_url' => 'https://github.com/Extra-Chill/data-machine/issues/1',
+	),
+	array( 'mode' => 'pipeline' ),
+	1
+);
+$issue_outcome_policy->recordToolResult(
+	'comment_github_pull_request',
+	array( 'name' => 'comment_github_pull_request' ),
+	array( 'success' => true ),
+	array( 'mode' => 'pipeline' ),
+	2
+);
+$issue_outcome_decision = $issue_outcome_policy->recordNaturalCompletion(
+	array( array( 'role' => 'user', 'content' => 'open a PR or fallback issue, then comment on source PR' ) ),
+	'Complete via issue fallback path.',
+	array( 'mode' => 'pipeline' ),
+	3
+);
+assert_runtime_policy( $issue_outcome_decision->isComplete(), 'complete_when_any issue fallback path satisfies completion assertion' );
+
+$failed_outcome_policy = new DataMachineHandlerCompletionPolicy(
+	array(),
+	new \DataMachine\Engine\AI\DataMachineCompletionAssertions( $outcome_assertions_config )
+);
+$failed_outcome_policy->recordToolResult(
+	'create_github_issue',
+	array( 'name' => 'create_github_issue' ),
+	array(
+		'success' => false,
+		'data'    => array( 'html_url' => 'https://github.com/Extra-Chill/data-machine/issues/1' ),
+	),
+	array( 'mode' => 'pipeline' ),
+	1
+);
+$failed_outcome_policy->recordToolResult(
+	'comment_github_pull_request',
+	array( 'name' => 'comment_github_pull_request' ),
+	array( 'success' => true ),
+	array( 'mode' => 'pipeline' ),
+	2
+);
+$failed_outcome_decision = $failed_outcome_policy->recordNaturalCompletion(
+	array( array( 'role' => 'user', 'content' => 'open a PR or fallback issue, then comment on source PR' ) ),
+	'Cannot complete because the issue call failed.',
+	array( 'mode' => 'pipeline' ),
+	3
+);
+assert_runtime_policy( ! $failed_outcome_decision->isComplete(), 'failed complete_when_any tool result does not satisfy completion assertion' );
+assert_runtime_policy( isset( $failed_outcome_decision->context()['missing']['complete_when_any'] ), 'failed complete_when_any path reports missing outcome assertion' );
+
 $daily_memory_unavailable_dispatch_count = 0;
 $daily_memory_unavailable_sink           = new RuntimePolicySmokeEventSink();
 WpAiClientTestDouble::reset();


### PR DESCRIPTION
## Summary
- Adds `complete_when_any` completion assertions so runtime completion can accept alternative successful tool paths, such as PR or issue fallback outcomes.
- Tracks successful tool results by name and supports required non-empty output fields from either the tool result root or `data` payload.
- Preserves existing `required_tool_names` behavior while allowing AI step assertion merging to carry outcome assertions from pipeline and flow config.

Fixes #1886.

## Tests
- `php -l inc/Engine/AI/DataMachineCompletionAssertions.php`
- `php -l inc/Core/Steps/AI/AIStep.php`
- `php -l tests/agent-conversation-runtime-policy-smoke.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/DataMachineCompletionAssertions.php inc/Core/Steps/AI/AIStep.php tests/agent-conversation-runtime-policy-smoke.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the focused completion assertion changes, adding smoke coverage, and running verification commands; Chris remains responsible for review and merge.