### PR TITLE
Resolve prompt files in agent bundles

### DIFF
--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -18,6 +18,7 @@ use DataMachine\Engine\Bundle\AgentBundleArtifactRebase;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePendingAction;
 use DataMachine\Engine\Bundle\AgentBundleUpgradePlanner;
 use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
+use DataMachine\Engine\Bundle\BundleValidationException;
 use DataMachine\Engine\Bundle\BundleSource;
 use DataMachine\Engine\Bundle\BundleSourceAuth;
 use DataMachine\Engine\Bundle\PortableSlug;
@@ -611,12 +612,17 @@ class AgentBundleCommand extends BaseCommand {
 		$revision = BundleSource::is_remote( $source ) ? BundleSource::last_resolved_revision() : null;
 
 		$bundle = null;
-		if ( is_dir( $resolved ) ) {
-			$bundle = $this->bundler()->from_directory( $resolved );
-		} elseif ( preg_match( '/\.zip$/i', $resolved ) ) {
-			$bundle = $this->bundler()->from_zip( $resolved );
-		} elseif ( preg_match( '/\.json$/i', $resolved ) ) {
-			$bundle = $this->bundler()->from_json( (string) file_get_contents( $resolved ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		try {
+			if ( is_dir( $resolved ) ) {
+				$bundle = $this->bundler()->from_directory( $resolved );
+			} elseif ( preg_match( '/\.zip$/i', $resolved ) ) {
+				$bundle = $this->bundler()->from_zip( $resolved );
+			} elseif ( preg_match( '/\.json$/i', $resolved ) ) {
+				$bundle = $this->bundler()->from_json( (string) file_get_contents( $resolved ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			}
+		} catch ( BundleValidationException $e ) {
+			BundleSource::cleanup( $resolved, $source );
+			WP_CLI::error( $e->getMessage() );
 		}
 
 		// Resolver downloaded a temp file for remote sources; from_zip()

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -1724,7 +1724,9 @@ class AgentBundler {
 		try {
 			return AgentBundleArrayAdapter::to_array_bundle( AgentBundleDirectory::read( $directory ) );
 		} catch ( BundleValidationException $e ) {
-			unset( $e );
+			if ( $this->is_directory_bundle_schema( $directory ) ) {
+				throw $e;
+			}
 			// Fall through to the legacy monolithic manifest reader for old exports.
 		}
 
@@ -1776,6 +1778,16 @@ class AgentBundler {
 		}
 
 		return $bundle;
+	}
+
+	private function is_directory_bundle_schema( string $directory ): bool {
+		$manifest_path = rtrim( $directory, '/\\' ) . '/manifest.json';
+		if ( ! file_exists( $manifest_path ) ) {
+			return false;
+		}
+
+		$manifest = json_decode( $this->read_text_file( $manifest_path ), true );
+		return is_array( $manifest ) && array_key_exists( 'schema_version', $manifest );
 	}
 
 	/**
@@ -1870,17 +1882,22 @@ class AgentBundler {
 		// Find the manifest.json — it might be in a subdirectory.
 		$bundle = null;
 
-		if ( file_exists( $temp_dir . '/manifest.json' ) ) {
-			$bundle = $this->from_directory( $temp_dir );
-		} else {
-			// Look one level deep.
-			$subdirs = $this->glob_directories( $temp_dir );
-			foreach ( $subdirs as $subdir ) {
-				if ( file_exists( $subdir . '/manifest.json' ) ) {
-					$bundle = $this->from_directory( $subdir );
-					break;
+		try {
+			if ( file_exists( $temp_dir . '/manifest.json' ) ) {
+				$bundle = $this->from_directory( $temp_dir );
+			} else {
+				// Look one level deep.
+				$subdirs = $this->glob_directories( $temp_dir );
+				foreach ( $subdirs as $subdir ) {
+					if ( file_exists( $subdir . '/manifest.json' ) ) {
+						$bundle = $this->from_directory( $subdir );
+						break;
+					}
 				}
 			}
+		} catch ( BundleValidationException $e ) {
+			$this->rm_rf( $temp_dir );
+			throw $e;
 		}
 
 		$this->rm_rf( $temp_dir );

--- a/inc/Engine/Bundle/AgentBundleDirectory.php
+++ b/inc/Engine/Bundle/AgentBundleDirectory.php
@@ -295,8 +295,8 @@ final class AgentBundleDirectory {
 		$paths     = is_array( $paths ) ? $paths : array();
 		sort( $paths, SORT_STRING );
 		foreach ( $paths as $path ) {
-			$document = BundleSchema::decode_json( self::read_file( $path ), basename( $path ) );
-			$document = self::resolve_prompt_file_fields( $document, $document_class, $bundle_root, basename( $path ) );
+			$document    = BundleSchema::decode_json( self::read_file( $path ), basename( $path ) );
+			$document    = self::resolve_prompt_file_fields( $document, $document_class, $bundle_root, basename( $path ) );
 			$documents[] = $document_class::from_array( $document );
 		}
 

--- a/inc/Engine/Bundle/AgentBundleDirectory.php
+++ b/inc/Engine/Bundle/AgentBundleDirectory.php
@@ -67,8 +67,8 @@ final class AgentBundleDirectory {
 		return new self(
 			$manifest,
 			self::read_memory_files( $directory . '/' . BundleSchema::MEMORY_DIR ),
-			self::read_documents( $directory . '/' . BundleSchema::PIPELINES_DIR, AgentBundlePipelineFile::class ),
-			self::read_documents( $directory . '/' . BundleSchema::FLOWS_DIR, AgentBundleFlowFile::class ),
+			self::read_documents( $directory . '/' . BundleSchema::PIPELINES_DIR, AgentBundlePipelineFile::class, $directory ),
+			self::read_documents( $directory . '/' . BundleSchema::FLOWS_DIR, AgentBundleFlowFile::class, $directory ),
 			self::read_artifact_directories( $directory ),
 			self::read_extension_artifacts( $directory . '/' . BundleSchema::EXTENSIONS_DIR ),
 			self::read_extras( $directory )
@@ -285,7 +285,7 @@ final class AgentBundleDirectory {
 	}
 
 	/** @return array */
-	private static function read_documents( string $directory, string $document_class ): array {
+	private static function read_documents( string $directory, string $document_class, string $bundle_root ): array {
 		if ( ! is_dir( $directory ) ) {
 			return array();
 		}
@@ -295,10 +295,62 @@ final class AgentBundleDirectory {
 		$paths     = is_array( $paths ) ? $paths : array();
 		sort( $paths, SORT_STRING );
 		foreach ( $paths as $path ) {
-			$documents[] = $document_class::from_array( BundleSchema::decode_json( self::read_file( $path ), basename( $path ) ) );
+			$document = BundleSchema::decode_json( self::read_file( $path ), basename( $path ) );
+			$document = self::resolve_prompt_file_fields( $document, $document_class, $bundle_root, basename( $path ) );
+			$documents[] = $document_class::from_array( $document );
 		}
 
 		return self::sort_documents_by_slug( $documents, $document_class );
+	}
+
+	private static function resolve_prompt_file_fields( array $document, string $document_class, string $bundle_root, string $label ): array {
+		if ( empty( $document['steps'] ) || ! is_array( $document['steps'] ) ) {
+			return $document;
+		}
+
+		foreach ( $document['steps'] as $step_index => $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+
+			if ( AgentBundlePipelineFile::class === $document_class ) {
+				$step_config = is_array( $step['step_config'] ?? null ) ? $step['step_config'] : array();
+				if ( array_key_exists( 'system_prompt_file', $step_config ) ) {
+					$step_config['system_prompt'] = self::read_bundle_prompt_file( (string) $step_config['system_prompt_file'], $bundle_root, $label );
+					unset( $step_config['system_prompt_file'] );
+					$document['steps'][ $step_index ]['step_config'] = $step_config;
+				}
+				continue;
+			}
+
+			if ( AgentBundleFlowFile::class !== $document_class || empty( $step['prompt_queue'] ) || ! is_array( $step['prompt_queue'] ) ) {
+				continue;
+			}
+
+			foreach ( $step['prompt_queue'] as $queue_index => $entry ) {
+				if ( ! is_array( $entry ) || ! array_key_exists( 'prompt_file', $entry ) ) {
+					continue;
+				}
+				$entry['prompt'] = self::read_bundle_prompt_file( (string) $entry['prompt_file'], $bundle_root, $label );
+				unset( $entry['prompt_file'] );
+				$document['steps'][ $step_index ]['prompt_queue'][ $queue_index ] = $entry;
+			}
+		}
+
+		return $document;
+	}
+
+	private static function read_bundle_prompt_file( string $relative_path, string $bundle_root, string $label ): string {
+		$relative_path = self::normalize_relative_path( $relative_path, $label . ' prompt' );
+		$bundle_real   = realpath( $bundle_root );
+		$path          = $bundle_root . '/' . $relative_path;
+		$file_real     = realpath( $path );
+
+		if ( false === $bundle_real || false === $file_real || ! str_starts_with( $file_real, $bundle_real . DIRECTORY_SEPARATOR ) || ! is_file( $file_real ) ) {
+			throw new BundleValidationException( sprintf( '%s references missing prompt file: %s', esc_html( $label ), esc_html( $relative_path ) ) );
+		}
+
+		return self::read_file( $file_real );
 	}
 
 	/**

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -17,6 +17,12 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	}
 }
 
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
 if ( ! function_exists( 'did_action' ) ) {
 	function did_action( $hook = '' ) {
 		return 0;
@@ -39,6 +45,7 @@ require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
+use DataMachine\Engine\Bundle\BundleValidationException;
 
 $failures = array();
 $passes   = 0;
@@ -251,7 +258,47 @@ assert_adapter_equals( 'round-trip preserves prompt queue', 'Review PR #1', $rou
 assert_adapter_equals( 'round-trip preserves queue mode', 'loop', $round_steps[1]['queue_mode'] );
 assert_adapter_equals( 'round-trip preserves scheduling interval', 'hourly', $round_flow['scheduling_config']['interval'] );
 
-echo "\n[3] AgentBundler directory methods route through the adapter\n";
+echo "\n[3] Directory read resolves prompt file references relative to bundle root\n";
+if ( ! is_dir( $tmp . '/prompts' ) ) {
+	mkdir( $tmp . '/prompts', 0775, true );
+}
+file_put_contents( $tmp . '/prompts/system.md', "Review from file.\n" );
+file_put_contents( $tmp . '/prompts/queue.md', "Review PR from file.\n" );
+
+$pipeline_path = $tmp . '/pipelines/pr-review-pipeline.json';
+$pipeline_json = json_decode( file_get_contents( $pipeline_path ), true );
+$pipeline_json['steps'][1]['step_config']['system_prompt_file'] = 'prompts/system.md';
+unset( $pipeline_json['steps'][1]['step_config']['system_prompt'] );
+file_put_contents( $pipeline_path, wp_json_encode( $pipeline_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );
+
+$flow_path = $tmp . '/flows/pr-review-flow.json';
+$flow_json = json_decode( file_get_contents( $flow_path ), true );
+$flow_json['steps'][1]['prompt_queue'][0]['prompt_file'] = 'prompts/queue.md';
+unset( $flow_json['steps'][1]['prompt_queue'][0]['prompt'] );
+file_put_contents( $flow_path, wp_json_encode( $flow_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );
+
+$file_backed_round_trip = AgentBundleArrayAdapter::to_array_bundle( AgentBundleDirectory::read( $tmp ) );
+$file_backed_pipeline_steps = array_values( $file_backed_round_trip['pipelines'][0]['pipeline_config'] );
+$file_backed_flow_steps = array_values( $file_backed_round_trip['flows'][0]['flow_config'] );
+
+assert_adapter_equals( 'system_prompt_file resolves into system_prompt', "Review from file.\n", $file_backed_pipeline_steps[1]['system_prompt'] ?? null );
+assert_adapter_equals( 'system_prompt_file does not leak into runtime config', false, array_key_exists( 'system_prompt_file', $file_backed_pipeline_steps[1] ) );
+assert_adapter_equals( 'prompt_file resolves into prompt queue entry', "Review PR from file.\n", $file_backed_flow_steps[1]['prompt_queue'][0]['prompt'] ?? null );
+assert_adapter_equals( 'prompt_file does not leak into runtime queue', false, array_key_exists( 'prompt_file', $file_backed_flow_steps[1]['prompt_queue'][0] ?? array() ) );
+
+$flow_json['steps'][1]['prompt_queue'][0]['prompt_file'] = 'prompts/missing.md';
+unset( $flow_json['steps'][1]['prompt_queue'][0]['prompt'] );
+file_put_contents( $flow_path, wp_json_encode( $flow_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );
+
+$missing_prompt_failed_clearly = false;
+try {
+	AgentBundleDirectory::read( $tmp );
+} catch ( BundleValidationException $e ) {
+	$missing_prompt_failed_clearly = false !== strpos( $e->getMessage(), 'references missing prompt file: prompts/missing.md' );
+}
+assert_adapter( 'missing prompt_file fails clearly', $missing_prompt_failed_clearly );
+
+echo "\n[4] AgentBundler directory methods route through the adapter\n";
 $agent_bundler_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Agents/AgentBundler.php' ) ?: '';
 assert_adapter( 'export builds AgentBundleDirectory value objects first', false !== strpos( $agent_bundler_source, 'public function export_directory_object' ) );
 assert_adapter( 'export adapts value-object directory back to bundle array', false !== strpos( $agent_bundler_source, 'AgentBundleArrayAdapter::to_array_bundle( $directory )' ) );


### PR DESCRIPTION
## Summary
- Resolve `system_prompt_file` in directory bundle pipeline step configs relative to the bundle root.
- Resolve `prompt_file` in flow `prompt_queue` entries when importing directory or zip bundles.
- Surface bundle validation errors directly in CLI imports so missing prompt files fail with the referenced path.

## Testing
- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php -l inc/Engine/Bundle/AgentBundleDirectory.php`
- `php -l inc/Core/Agents/AgentBundler.php`
- `php -l inc/Cli/Commands/AgentBundleCommand.php`
- `composer lint -- inc/Engine/Bundle/AgentBundleDirectory.php inc/Core/Agents/AgentBundler.php inc/Cli/Commands/AgentBundleCommand.php tests/agent-bundler-directory-adapter-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the scoped bundle prompt file resolution change and updated focused smoke coverage; Chris remains responsible for review and testing.