### PR TITLE
Expose job artifacts for daily memory

### DIFF
--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -22,6 +22,7 @@ use DataMachine\Abilities\Job\JobsSummaryAbility;
 use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Abilities\Job\RetryJobAbility;
 use DataMachine\Abilities\Job\RunMetricsAbility;
+use DataMachine\Core\JobArtifacts;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
 use AgentsAPI\AI\WP_Agent_Message;
@@ -524,6 +525,53 @@ class JobsCommand extends BaseCommand {
 		}
 
 		$this->renderTranscriptText( $job_id, (string) $transcript_session_id, $session, $messages, $metadata );
+	}
+
+	/**
+	 * Export structured artifacts for a job.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <job_id>
+	 * : The job ID whose artifacts should be exported.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine jobs artifacts 844 --format=json
+	 *
+	 * @subcommand artifacts
+	 */
+	public function artifacts( array $args, array $assoc_args ): void {
+		if ( empty( $args[0] ) || ! is_numeric( $args[0] ) || (int) $args[0] <= 0 ) {
+			WP_CLI::error( 'Job ID is required and must be a positive integer.' );
+			return;
+		}
+
+		$result = ( new JobArtifacts() )->get( (int) $args[0] );
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Failed to build job artifacts.' );
+			return;
+		}
+
+		$payload = $result['artifacts'] ?? array();
+		$format  = $assoc_args['format'] ?? 'json';
+
+		if ( 'yaml' === $format ) {
+			/** @phpstan-ignore-next-line Spyc is provided by WP-CLI at runtime. */
+			WP_CLI::log( (string) call_user_func( array( 'Spyc', 'YAMLDump' ), $payload, false, false, true ) );
+			return;
+		}
+
+		WP_CLI::log( wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
 	}
 
 	/**

--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Job artifact payload builder.
+ *
+ * @package DataMachine\Core
+ */
+
+namespace DataMachine\Core;
+
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\FilesRepository\DailyMemory;
+
+defined( 'ABSPATH' ) || exit;
+
+class JobArtifacts {
+
+	/**
+	 * Build a deterministic artifact payload for a job.
+	 *
+	 * @param int $job_id Job ID.
+	 * @return array{success: bool, artifacts?: array, error?: string}
+	 */
+	public function get( int $job_id ): array {
+		if ( $job_id <= 0 ) {
+			return array(
+				'success' => false,
+				'error'   => 'job_id must be a positive integer.',
+			);
+		}
+
+		$job = ( new Jobs() )->get_job( $job_id );
+		if ( ! $job ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Job %d not found.', $job_id ),
+			);
+		}
+
+		$engine_data = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$agent       = $this->resolve_agent( $job, $engine_data );
+		$tool_calls  = $this->successful_tool_summaries( $engine_data );
+		$payload     = array(
+			'job_id'                  => $job_id,
+			'status'                  => (string) ( $job['status'] ?? '' ),
+			'agent_id'                => $agent['agent_id'],
+			'agent_slug'              => $agent['agent_slug'],
+			'required_tool_names'     => $this->tool_names_from_assertions( $engine_data['completion_assertions_required'] ?? array() ),
+			'satisfied_tool_names'    => $this->tool_names_from_assertions( $engine_data['completion_assertions_satisfied'] ?? array() ),
+			'successful_tool_calls'   => $tool_calls,
+			'transcript'              => $this->transcript_metadata( $job_id, $engine_data ),
+			'daily_memory_artifacts'  => $this->daily_memory_artifacts( $job, $agent, $tool_calls ),
+		);
+
+		return array(
+			'success'   => true,
+			'artifacts' => $payload,
+		);
+	}
+
+	/**
+	 * @return array{agent_id: int|null, agent_slug: string|null}
+	 */
+	private function resolve_agent( array $job, array $engine_data ): array {
+		$agent_id   = (int) ( $job['agent_id'] ?? $engine_data['agent_id'] ?? 0 );
+		$agent_slug = sanitize_title( (string) ( $engine_data['agent_slug'] ?? $job['agent_slug'] ?? '' ) );
+
+		if ( $agent_id > 0 && '' === $agent_slug ) {
+			$agent = ( new Agents() )->get_agent( $agent_id );
+			if ( $agent ) {
+				$agent_slug = sanitize_title( (string) ( $agent['agent_slug'] ?? '' ) );
+			}
+		}
+
+		return array(
+			'agent_id'   => $agent_id > 0 ? $agent_id : null,
+			'agent_slug' => '' !== $agent_slug ? $agent_slug : null,
+		);
+	}
+
+	/**
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function successful_tool_summaries( array $engine_data ): array {
+		$summaries = is_array( $engine_data['tool_execution_summary'] ?? null ) ? $engine_data['tool_execution_summary'] : array();
+		$successes = array();
+
+		foreach ( $summaries as $summary ) {
+			if ( ! is_array( $summary ) || true !== ( $summary['success'] ?? false ) ) {
+				continue;
+			}
+
+			$successes[] = array_filter(
+				array(
+					'tool_name'  => sanitize_key( (string) ( $summary['tool_name'] ?? '' ) ),
+					'success'    => true,
+					'turn_count' => isset( $summary['turn_count'] ) ? (int) $summary['turn_count'] : null,
+					'action'     => isset( $summary['action'] ) ? sanitize_key( (string) $summary['action'] ) : null,
+					'date'       => isset( $summary['date'] ) ? sanitize_text_field( (string) $summary['date'] ) : null,
+					'mode'       => isset( $summary['mode'] ) ? sanitize_key( (string) $summary['mode'] ) : null,
+					'summary'    => isset( $summary['summary'] ) ? sanitize_text_field( (string) $summary['summary'] ) : null,
+				),
+				static fn( $value ) => null !== $value && '' !== $value
+			);
+		}
+
+		return $successes;
+	}
+
+	/**
+	 * @return array<int, string>
+	 */
+	private function tool_names_from_assertions( $assertions ): array {
+		if ( ! is_array( $assertions ) ) {
+			return array();
+		}
+
+		$tool_names = $assertions['tool_names'] ?? array();
+		if ( is_string( $tool_names ) ) {
+			$tool_names = array( $tool_names );
+		}
+		if ( ! is_array( $tool_names ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_unique(
+				array_filter(
+					array_map( static fn( $name ) => sanitize_key( (string) $name ), $tool_names )
+				)
+			)
+		);
+	}
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	private function transcript_metadata( int $job_id, array $engine_data ): ?array {
+		$session_id = (string) ( $engine_data['transcript_session_id'] ?? '' );
+		if ( '' === $session_id ) {
+			$session_id = $this->find_transcript_session_id_for_job( $job_id );
+		}
+
+		if ( '' === $session_id ) {
+			return null;
+		}
+
+		$session = ConversationStoreFactory::get()->get_session( $session_id );
+		if ( ! $session ) {
+			return array(
+				'session_id' => $session_id,
+				'missing'    => true,
+			);
+		}
+
+		$messages = is_array( $session['messages'] ?? null ) ? $session['messages'] : array();
+		$metadata = is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array();
+
+		return array_filter(
+			array(
+				'session_id'    => $session_id,
+				'provider'      => $session['provider'] ?? ( $metadata['provider'] ?? null ),
+				'model'         => $session['model'] ?? ( $metadata['model'] ?? null ),
+				'mode'          => $session['mode'] ?? null,
+				'message_count' => count( $messages ),
+				'turn_count'    => isset( $metadata['turn_count'] ) ? (int) $metadata['turn_count'] : null,
+				'completed'     => isset( $metadata['completed'] ) ? (bool) $metadata['completed'] : null,
+				'usage'         => is_array( $metadata['usage'] ?? null ) ? $metadata['usage'] : null,
+			),
+			static fn( $value ) => null !== $value && array() !== $value
+		);
+	}
+
+	private function find_transcript_session_id_for_job( int $job_id ): string {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'datamachine_chat_sessions';
+		$like  = '%"job_id":' . $job_id . '%';
+		$row   = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT session_id FROM %i WHERE mode = %s AND metadata LIKE %s ORDER BY created_at DESC LIMIT 1',
+				$table,
+				'pipeline',
+				$like
+			)
+		);
+
+		return is_string( $row ) ? $row : '';
+	}
+
+	/**
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function daily_memory_artifacts( array $job, array $agent, array $tool_calls ): array {
+		$agent_id = (int) ( $agent['agent_id'] ?? 0 );
+		if ( $agent_id <= 0 ) {
+			return array();
+		}
+
+		$dates = array();
+		foreach ( $tool_calls as $tool_call ) {
+			if ( 'agent_daily_memory' !== ( $tool_call['tool_name'] ?? '' ) || 'write' !== ( $tool_call['action'] ?? '' ) ) {
+				continue;
+			}
+
+			$date = (string) ( $tool_call['date'] ?? '' );
+			if ( '' === $date ) {
+				$date = gmdate( 'Y-m-d', strtotime( (string) ( $job['completed_at'] ?? $job['created_at'] ?? 'now' ) ) );
+			}
+
+			if ( preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
+				$dates[ $date ] = true;
+			}
+		}
+
+		$artifacts = array();
+		foreach ( array_keys( $dates ) as $date ) {
+			list( $year, $month, $day ) = explode( '-', $date );
+			$daily_memory               = new DailyMemory( (int) ( $job['user_id'] ?? 0 ), $agent_id );
+			$read                       = $daily_memory->read( $year, $month, $day );
+			if ( empty( $read['success'] ) ) {
+				continue;
+			}
+
+			$artifacts[] = array(
+				'type'                 => 'agent_daily_memory',
+				'agent_id'             => $agent_id,
+				'agent_slug'           => $agent['agent_slug'],
+				'date'                 => $date,
+				'source'               => 'daily-memory',
+				'bundle_relative_path' => sprintf( 'memory/agent/daily/%s/%s/%s.md', $year, $month, $day ),
+				'content'              => (string) ( $read['content'] ?? '' ),
+			);
+		}
+
+		return $artifacts;
+	}
+}

--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -42,15 +42,15 @@ class JobArtifacts {
 		$agent       = $this->resolve_agent( $job, $engine_data );
 		$tool_calls  = $this->successful_tool_summaries( $engine_data );
 		$payload     = array(
-			'job_id'                  => $job_id,
-			'status'                  => (string) ( $job['status'] ?? '' ),
-			'agent_id'                => $agent['agent_id'],
-			'agent_slug'              => $agent['agent_slug'],
-			'required_tool_names'     => $this->tool_names_from_assertions( $engine_data['completion_assertions_required'] ?? array() ),
-			'satisfied_tool_names'    => $this->tool_names_from_assertions( $engine_data['completion_assertions_satisfied'] ?? array() ),
-			'successful_tool_calls'   => $tool_calls,
-			'transcript'              => $this->transcript_metadata( $job_id, $engine_data ),
-			'daily_memory_artifacts'  => $this->daily_memory_artifacts( $job, $agent, $tool_calls ),
+			'job_id'                 => $job_id,
+			'status'                 => (string) ( $job['status'] ?? '' ),
+			'agent_id'               => $agent['agent_id'],
+			'agent_slug'             => $agent['agent_slug'],
+			'required_tool_names'    => $this->tool_names_from_assertions( $engine_data['completion_assertions_required'] ?? array() ),
+			'satisfied_tool_names'   => $this->tool_names_from_assertions( $engine_data['completion_assertions_satisfied'] ?? array() ),
+			'successful_tool_calls'  => $tool_calls,
+			'transcript'             => $this->transcript_metadata( $job_id, $engine_data ),
+			'daily_memory_artifacts' => $this->daily_memory_artifacts( $job, $agent, $tool_calls ),
 		);
 
 		return array(

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -451,16 +451,16 @@ class AIStep extends Step {
 					$this->job_id,
 					$failure_reason,
 					array(
-						'flow_step_id'                      => $this->flow_step_id,
-						'ai_error'                          => $loop_result['error'],
-						'error_code'                        => $loop_result['error_code'] ?? null,
-						'unavailable_required_tool_names'   => is_array( $loop_result['unavailable_required_tool_names'] ?? null ) ? $loop_result['unavailable_required_tool_names'] : array(),
-						'ai_provider'                       => $provider_name,
-						'request_metadata'                  => $request_metadata,
-						'transport_profile'                 => is_array( $request_metadata['transport'] ?? null ) ? $request_metadata['transport'] : array(),
-						'retry_after'                       => $loop_result['retry_after'] ?? null,
-						'retry_after_seconds'               => $loop_result['retry_after_seconds'] ?? null,
-						'headers'                           => is_array( $loop_result['headers'] ?? null ) ? $loop_result['headers'] : array(),
+						'flow_step_id'                    => $this->flow_step_id,
+						'ai_error'                        => $loop_result['error'],
+						'error_code'                      => $loop_result['error_code'] ?? null,
+						'unavailable_required_tool_names' => is_array( $loop_result['unavailable_required_tool_names'] ?? null ) ? $loop_result['unavailable_required_tool_names'] : array(),
+						'ai_provider'                     => $provider_name,
+						'request_metadata'                => $request_metadata,
+						'transport_profile'               => is_array( $request_metadata['transport'] ?? null ) ? $request_metadata['transport'] : array(),
+						'retry_after'                     => $loop_result['retry_after'] ?? null,
+						'retry_after_seconds'             => $loop_result['retry_after_seconds'] ?? null,
+						'headers'                         => is_array( $loop_result['headers'] ?? null ) ? $loop_result['headers'] : array(),
 					)
 				);
 				return array();
@@ -486,7 +486,7 @@ class AIStep extends Step {
 			}
 
 			if ( $this->job_id > 0 ) {
-				$artifact_engine_data = datamachine_get_engine_data( $this->job_id );
+				$artifact_engine_data                           = datamachine_get_engine_data( $this->job_id );
 				$artifact_engine_data['tool_execution_summary'] = self::summarizeToolExecutions( $loop_result );
 
 				foreach ( array( 'completion_assertions_required', 'completion_assertions_missing', 'completion_assertions_satisfied' ) as $assertion_key ) {

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -485,6 +485,19 @@ class AIStep extends Step {
 				);
 			}
 
+			if ( $this->job_id > 0 ) {
+				$artifact_engine_data = datamachine_get_engine_data( $this->job_id );
+				$artifact_engine_data['tool_execution_summary'] = self::summarizeToolExecutions( $loop_result );
+
+				foreach ( array( 'completion_assertions_required', 'completion_assertions_missing', 'completion_assertions_satisfied' ) as $assertion_key ) {
+					if ( isset( $loop_result[ $assertion_key ] ) && array() !== $loop_result[ $assertion_key ] ) {
+						$artifact_engine_data[ $assertion_key ] = $loop_result[ $assertion_key ];
+					}
+				}
+
+				datamachine_set_engine_data( $this->job_id, $artifact_engine_data );
+			}
+
 			// Process loop results into data packets
 			return self::processLoopResults( $loop_result, $this->dataPackets, $payload, $available_tools );
 		} finally {
@@ -667,6 +680,50 @@ class AIStep extends Step {
 	 */
 	private static function mergeListConfigField( array $pipeline_values, array $flow_values ): array {
 		return array_values( array_merge( $pipeline_values, $flow_values ) );
+	}
+
+	/**
+	 * Build a bounded, non-secret summary of tool calls for job artifacts.
+	 *
+	 * @param array $loop_result Conversation loop result.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function summarizeToolExecutions( array $loop_result ): array {
+		$results   = is_array( $loop_result['tool_execution_results'] ?? null ) ? $loop_result['tool_execution_results'] : array();
+		$summaries = array();
+
+		foreach ( $results as $result ) {
+			if ( ! is_array( $result ) ) {
+				continue;
+			}
+
+			$tool_name   = sanitize_key( (string) ( $result['tool_name'] ?? '' ) );
+			$tool_result = is_array( $result['result'] ?? null ) ? $result['result'] : array();
+			$parameters  = is_array( $result['parameters'] ?? null ) ? $result['parameters'] : array();
+			if ( '' === $tool_name ) {
+				continue;
+			}
+
+			$summary = array(
+				'tool_name'  => $tool_name,
+				'success'    => true === ( $tool_result['success'] ?? false ),
+				'turn_count' => isset( $result['turn_count'] ) ? (int) $result['turn_count'] : null,
+				'summary'    => isset( $tool_result['message'] ) ? sanitize_text_field( (string) $tool_result['message'] ) : null,
+			);
+
+			if ( 'agent_daily_memory' === $tool_name ) {
+				$summary['action'] = isset( $parameters['action'] ) ? sanitize_key( (string) $parameters['action'] ) : null;
+				$summary['date']   = isset( $parameters['date'] ) ? sanitize_text_field( (string) $parameters['date'] ) : gmdate( 'Y-m-d' );
+				$summary['mode']   = isset( $parameters['mode'] ) ? sanitize_key( (string) $parameters['mode'] ) : null;
+			}
+
+			$summaries[] = array_filter(
+				$summary,
+				static fn( $value ) => null !== $value && '' !== $value
+			);
+		}
+
+		return $summaries;
 	}
 
 	/**

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -129,20 +129,20 @@ function datamachine_run_conversation(
 		);
 
 		return array(
-			'messages'                         => $messages,
-			'final_content'                    => '',
-			'turn_count'                       => 0,
-			'completed'                        => false,
-			'last_tool_calls'                  => array(),
-			'tool_execution_results'           => array(),
-			'error'                            => $error_message,
-			'error_code'                       => 'completion_required_tool_unavailable',
-			'completion_assertions_required'    => $assertions->required(),
-			'unavailable_required_tool_names'   => $unavailable_required_tools,
-			'available_tool_names'              => array_keys( $tools ),
-			'usage'                            => array(),
-			'request_metadata'                 => array(),
-			'status'                           => 'error',
+			'messages'                        => $messages,
+			'final_content'                   => '',
+			'turn_count'                      => 0,
+			'completed'                       => false,
+			'last_tool_calls'                 => array(),
+			'tool_execution_results'          => array(),
+			'error'                           => $error_message,
+			'error_code'                      => 'completion_required_tool_unavailable',
+			'completion_assertions_required'  => $assertions->required(),
+			'unavailable_required_tool_names' => $unavailable_required_tools,
+			'available_tool_names'            => array_keys( $tools ),
+			'usage'                           => array(),
+			'request_metadata'                => array(),
+			'status'                          => 'error',
 		);
 	}
 

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -265,6 +265,12 @@ function datamachine_run_conversation(
 		$result['completion_assertions_missing']   = $latest_nudge['completion_assertions_missing'] ?? array();
 		$result['completion_assertions_satisfied'] = $latest_nudge['completion_assertions_satisfied'] ?? array();
 	}
+	if ( $assertions->hasAssertions() ) {
+		$evaluation                                = $assertions->evaluate( $loop_payload, $final_content );
+		$result['completion_assertions_required']  = $assertions->required();
+		$result['completion_assertions_missing']   = $evaluation['missing'];
+		$result['completion_assertions_satisfied'] = $evaluation['satisfied'];
+	}
 	// Map upstream budget_exceeded status to DM's max_turns_reached flag
 	// for backward compatibility with ChatOrchestrator response shaping.
 	if ( 'budget_exceeded' === ( $result['status'] ?? '' ) && in_array( $result['budget'] ?? '', array( 'conversation_turns', 'turns' ), true ) ) {

--- a/tests/Unit/Auth/CallerContextTest.php
+++ b/tests/Unit/Auth/CallerContextTest.php
@@ -88,10 +88,12 @@ class CallerContextTest extends WP_UnitTestCase {
 		$this->assertSame( 3, $ctx->chain_depth );
 	}
 
-	public function test_is_cross_site_requires_remote_host(): void {
-		$local = new \WP_Agent_Caller_Context( 'some-agent', 0, \WP_Agent_Caller_Context::SELF_HOST, 2, 'cid' );
-		$this->assertFalse( $local->is_cross_site() );
+	public function test_chained_context_requires_remote_host(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		new \WP_Agent_Caller_Context( 'some-agent', 0, \WP_Agent_Caller_Context::SELF_HOST, 2, 'cid' );
+	}
 
+	public function test_is_cross_site_requires_remote_host(): void {
 		$remote = new \WP_Agent_Caller_Context( 'some-agent', 0, 'https://chubes.net', 1, 'cid' );
 		$this->assertTrue( $remote->is_cross_site() );
 	}

--- a/tests/job-artifacts-daily-memory-smoke.php
+++ b/tests/job-artifacts-daily-memory-smoke.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Source smoke coverage for job artifacts and daily memory exports.
+ *
+ * Run with: php tests/job-artifacts-daily-memory-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare(strict_types=1);
+
+$root          = dirname( __DIR__ );
+$job_artifacts = file_get_contents( $root . '/inc/Core/JobArtifacts.php' );
+$jobs_cli      = file_get_contents( $root . '/inc/Cli/Commands/JobsCommand.php' );
+$ai_step       = file_get_contents( $root . '/inc/Core/Steps/AI/AIStep.php' );
+$loop          = file_get_contents( $root . '/inc/Engine/AI/conversation-loop.php' );
+
+$failures = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	echo "FAIL: {$message}\n";
+	$failures[] = $message;
+};
+
+$assert(
+	false !== strpos( $jobs_cli, '@subcommand artifacts' )
+		&& false !== strpos( $jobs_cli, 'new JobArtifacts()' ),
+	'jobs artifacts CLI subcommand delegates to the core artifact builder'
+);
+
+$assert(
+	false !== strpos( $ai_step, "'tool_execution_summary'" )
+		&& false !== strpos( $ai_step, 'summarizeToolExecutions' ),
+	'AI step persists sanitized tool execution summaries into engine_data'
+);
+
+$assert(
+	false !== strpos( $loop, "'completion_assertions_required'  =" )
+		&& false !== strpos( $loop, "'completion_assertions_satisfied' =" ),
+	'conversation loop returns final completion assertion diagnostics even without a nudge'
+);
+
+$assert(
+	false !== strpos( $job_artifacts, "'required_tool_names'")
+		&& false !== strpos( $job_artifacts, "'satisfied_tool_names'" )
+		&& false !== strpos( $job_artifacts, "'successful_tool_calls'" ),
+	'artifact payload includes required/satisfied tools and successful tool summaries'
+);
+
+$assert(
+	false !== strpos( $job_artifacts, "'type'                 => 'agent_daily_memory'" )
+		&& false !== strpos( $job_artifacts, "memory/agent/daily/%s/%s/%s.md" )
+		&& false !== strpos( $job_artifacts, "'content'              =>" ),
+	'daily memory artifacts include type, canonical bundle-relative path, and content'
+);
+
+$assert(
+	false !== strpos( $job_artifacts, 'ConversationStoreFactory::get()->get_session' )
+		&& false !== strpos( $job_artifacts, "'message_count'" ),
+	'artifact payload includes transcript session metadata without raw messages'
+);
+
+echo "\n";
+if ( empty( $failures ) ) {
+	echo "OK: job artifacts daily memory smoke assertions passed.\n";
+	exit( 0 );
+}
+
+echo sprintf( "FAILED: %d assertion(s) failed.\n", count( $failures ) );
+exit( 1 );


### PR DESCRIPTION
## Summary
- Add `wp datamachine jobs artifacts <job_id> --format=json` for deterministic job artifact payloads.
- Persist sanitized successful tool summaries and final completion assertion diagnostics from AI jobs.
- Export job-written `agent_daily_memory` entries with canonical `memory/agent/daily/YYYY/MM/DD.md` bundle-relative paths and transcript metadata when present.

Fixes #1888.
Fixes #1891.

## Tests
- `php -l inc/Core/JobArtifacts.php`
- `php -l inc/Cli/Commands/JobsCommand.php`
- `php -l inc/Core/Steps/AI/AIStep.php`
- `php -l inc/Engine/AI/conversation-loop.php`
- `php tests/job-artifacts-daily-memory-smoke.php`
- `php tests/pipeline-transcript-session-link-smoke.php`
- `php tests/agent-daily-memory-pipeline-scope-smoke.php`
- `php tests/ai-required-handlers-smoke.php`
- `./vendor/bin/phpcs inc/Core/JobArtifacts.php inc/Cli/Commands/JobsCommand.php inc/Core/Steps/AI/AIStep.php inc/Engine/AI/conversation-loop.php tests/job-artifacts-daily-memory-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped implementation, smoke coverage, and CLI/API wiring for Chris to review and test.