### PR TITLE
Import bundled daily memory into runtime store

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -16,6 +16,7 @@ namespace DataMachine\Core\Agents;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\FilesRepository\DailyMemory;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Engine\Bundle\AgentBundleArtifactHasher;
@@ -660,7 +661,7 @@ class AgentBundler {
 			}
 
 			// 2. Write agent identity files.
-			$this->write_agent_files( $slug, $bundle['files'] ?? array() );
+			$this->write_agent_files( $slug, $agent_id, $owner_id, $bundle['files'] ?? array() );
 
 			// 3. Write USER.md template if provided.
 			if ( ! empty( $bundle['user_template'] ) ) {
@@ -1492,14 +1493,22 @@ class AgentBundler {
 	/**
 	 * Write agent identity files to disk.
 	 *
-	 * @param string $slug  Agent slug.
-	 * @param array  $files filename => content map.
+	 * @param string $slug     Agent slug.
+	 * @param int    $agent_id Imported agent ID.
+	 * @param int    $owner_id Imported agent owner ID.
+	 * @param array  $files    filename => content map.
 	 */
-	private function write_agent_files( string $slug, array $files ): void {
+	private function write_agent_files( string $slug, int $agent_id, int $owner_id, array $files ): void {
 		$agent_dir = $this->directory_manager->get_agent_identity_directory( $slug );
 		$this->directory_manager->ensure_directory_exists( $agent_dir );
 
 		foreach ( $files as $relative_path => $content ) {
+			$relative_path = str_replace( '\\', '/', (string) $relative_path );
+			if ( preg_match( '#^daily/(\d{4})/(\d{2})/(\d{2})\.md$#', $relative_path, $matches ) ) {
+				( new DailyMemory( $owner_id, $agent_id ) )->write( $matches[1], $matches[2], $matches[3], (string) $content );
+				continue;
+			}
+
 			$full_path = $agent_dir . '/' . $relative_path;
 
 			// Ensure subdirectories exist (e.g., contexts/).

--- a/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
@@ -206,15 +206,19 @@ class AgentDailyMemory extends BaseTool {
 			);
 		}
 
-		$result = $ability->execute(
-			array(
-				'user_id'  => $scope['user_id'],
-				'agent_id' => $scope['agent_id'],
-				'query'    => $query,
-				'from'     => $parameters['from'] ?? null,
-				'to'       => $parameters['to'] ?? null,
-			)
+		$input = array(
+			'user_id'  => $scope['user_id'],
+			'agent_id' => $scope['agent_id'],
+			'query'    => $query,
 		);
+		if ( isset( $parameters['from'] ) ) {
+			$input['from'] = $parameters['from'];
+		}
+		if ( isset( $parameters['to'] ) ) {
+			$input['to'] = $parameters['to'];
+		}
+
+		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
 			return $this->buildErrorResponse( $result->get_error_message(), 'agent_daily_memory' );

--- a/tests/Unit/Auth/CallerContextTest.php
+++ b/tests/Unit/Auth/CallerContextTest.php
@@ -89,9 +89,15 @@ class CallerContextTest extends WP_UnitTestCase {
 	}
 
 	public function test_is_cross_site_requires_remote_host(): void {
-		$local = new \WP_Agent_Caller_Context( 'some-agent', 0, \WP_Agent_Caller_Context::SELF_HOST, 2, 'cid' );
+		$local = \WP_Agent_Caller_Context::top_of_chain( 'cid' );
 		$this->assertFalse( $local->is_cross_site() );
 
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'caller_host chained context (chain_depth > 0) must specify a remote caller host' );
+		new \WP_Agent_Caller_Context( 'some-agent', 0, \WP_Agent_Caller_Context::SELF_HOST, 2, 'cid' );
+	}
+
+	public function test_is_cross_site_accepts_remote_host(): void {
 		$remote = new \WP_Agent_Caller_Context( 'some-agent', 0, 'https://chubes.net', 1, 'cid' );
 		$this->assertTrue( $remote->is_cross_site() );
 	}

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -19,14 +19,91 @@
 
 namespace DataMachine\Tests\Unit\Core\Agents;
 
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_List_Entry;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Metadata;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Query;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Read_Result;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Scope;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Store;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Store_Capabilities;
+use AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Write_Result;
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
 use DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts;
 use DataMachine\Core\Database\Flows\Flows as FlowsRepository;
 use DataMachine\Core\Database\Pipelines\Pipelines as PipelinesRepository;
+use DataMachine\Engine\AI\Tools\Global\AgentDailyMemory;
 use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use WP_UnitTestCase;
+
+final class DailyMemoryImportFakeStore implements WP_Agent_Memory_Store {
+
+	/** @var array<string,string> */
+	public array $files = array();
+
+	/** @var array<string,WP_Agent_Memory_Scope> */
+	private array $scopes = array();
+
+	public function capabilities(): WP_Agent_Memory_Store_Capabilities {
+		return WP_Agent_Memory_Store_Capabilities::none();
+	}
+
+	public function read( WP_Agent_Memory_Scope $scope, array $metadata_fields = WP_Agent_Memory_Metadata::FIELDS ): WP_Agent_Memory_Read_Result {
+		unset( $metadata_fields );
+		if ( ! array_key_exists( $scope->key(), $this->files ) ) {
+			return WP_Agent_Memory_Read_Result::not_found();
+		}
+
+		$content = $this->files[ $scope->key() ];
+		return new WP_Agent_Memory_Read_Result( true, $content, sha1( $content ), strlen( $content ), 123 );
+	}
+
+	public function write( WP_Agent_Memory_Scope $scope, string $content, ?string $if_match = null, ?WP_Agent_Memory_Metadata $metadata = null ): WP_Agent_Memory_Write_Result {
+		unset( $if_match, $metadata );
+		$this->files[ $scope->key() ]  = $content;
+		$this->scopes[ $scope->key() ] = $scope;
+
+		return WP_Agent_Memory_Write_Result::ok( sha1( $content ), strlen( $content ) );
+	}
+
+	public function exists( WP_Agent_Memory_Scope $scope ): bool {
+		return array_key_exists( $scope->key(), $this->files );
+	}
+
+	public function delete( WP_Agent_Memory_Scope $scope ): WP_Agent_Memory_Write_Result {
+		unset( $this->files[ $scope->key() ], $this->scopes[ $scope->key() ] );
+		return WP_Agent_Memory_Write_Result::ok( '', 0 );
+	}
+
+	public function list_layer( WP_Agent_Memory_Scope $scope_query, ?WP_Agent_Memory_Query $query = null ): array {
+		unset( $scope_query, $query );
+		return array();
+	}
+
+	public function list_subtree( WP_Agent_Memory_Scope $scope_query, string $prefix, ?WP_Agent_Memory_Query $query = null ): array {
+		unset( $query );
+		$entries = array();
+
+		foreach ( $this->files as $key => $content ) {
+			$scope = $this->scopes[ $key ] ?? null;
+			if ( ! $scope instanceof WP_Agent_Memory_Scope ) {
+				continue;
+			}
+			if ( $scope->layer !== $scope_query->layer || $scope->user_id !== $scope_query->user_id || $scope->agent_id !== $scope_query->agent_id ) {
+				continue;
+			}
+			if ( 0 !== strpos( $scope->filename, $prefix . '/' ) ) {
+				continue;
+			}
+
+			$entries[] = new WP_Agent_Memory_List_Entry( $scope->filename, $scope->layer, strlen( $content ), 123 );
+		}
+
+		return $entries;
+	}
+}
 
 class AgentBundlerImportTest extends WP_UnitTestCase {
 
@@ -35,6 +112,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 	private PipelinesRepository $pipelines_repo;
 	private FlowsRepository $flows_repo;
 	private int $owner_id;
+	private $memory_store_filter = null;
 
 	public function set_up(): void {
 		parent::set_up();
@@ -65,6 +143,11 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 
 		remove_all_actions( 'datamachine_bundle_import_pre_commit' );
 		remove_all_actions( 'datamachine_bundle_import_post_claim_started' );
+		if ( null !== $this->memory_store_filter ) {
+			remove_filter( 'agents_api_memory_store', $this->memory_store_filter, 10 );
+			$this->memory_store_filter = null;
+		}
+		PermissionHelper::clear_agent_context();
 
 		parent::tear_down();
 	}
@@ -137,6 +220,64 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertSame( 'daily', $flow['scheduling_config']['interval'] ?? null, 'Importer preserves the bundle interval.' );
 		$this->assertTrue( $flow['scheduling_config']['enabled'] ?? false, 'Importer keeps scheduled bundle flows enabled.' );
 		$this->assertSame( array( 'mcp' => 5 ), $flow['scheduling_config']['max_items'] ?? null, 'Importer preserves bundle max item caps.' );
+	}
+
+	public function test_import_seeds_agent_daily_memory_into_runtime_store(): void {
+		$store                     = new DailyMemoryImportFakeStore();
+		$this->memory_store_filter = static fn( $default, WP_Agent_Memory_Scope $scope ) => $store;
+		add_filter( 'agents_api_memory_store', $this->memory_store_filter, 10, 2 );
+
+		$bundle = $this->fixture_bundle( 'daily-memory-agent' );
+		$bundle['files']['daily/2026/05/09.md'] = "# Daily Memory: 2026-05-09\n\nImported bundle memory with alpha-sentinel.\n";
+		$bundle_dir = sys_get_temp_dir() . '/datamachine-daily-memory-bundle-' . getmypid();
+		$this->remove_tree( $bundle_dir );
+		$this->assertTrue( $this->bundler->to_directory( $bundle, $bundle_dir ), 'Bundle directory write succeeds.' );
+		$this->assertFileExists( $bundle_dir . '/memory/agent/daily/2026/05/09.md', 'Daily memory is represented under memory/agent/daily in the bundle directory.' );
+		$bundle = $this->bundler->from_directory( $bundle_dir );
+		$this->assertIsArray( $bundle, 'Bundle directory reads back into importable bundle data.' );
+
+		$result = $this->bundler->import( $bundle, null, $this->owner_id );
+		$this->remove_tree( $bundle_dir );
+
+		$this->assertTrue( (bool) $result['success'], 'Bundle import succeeds.' );
+		$agent = $this->agents_repo->get_by_slug( 'daily-memory-agent' );
+		$this->assertNotEmpty( $agent, 'Imported agent exists.' );
+
+		PermissionHelper::set_agent_context( (int) $agent['agent_id'], $this->owner_id );
+		$tool = new AgentDailyMemory();
+
+		$read = $tool->handle_tool_call(
+			array(
+				'action' => 'read',
+				'date'   => '2026-05-09',
+			)
+		);
+		$this->assertTrue( (bool) ( $read['success'] ?? false ), 'Daily memory tool reads imported daily memory.' );
+		$this->assertStringContainsString( 'alpha-sentinel', $read['data']['content'] ?? '' );
+
+		$search = $tool->handle_tool_call(
+			array(
+				'action' => 'search',
+				'query'  => 'alpha-sentinel',
+			)
+		);
+		$this->assertTrue( (bool) ( $search['success'] ?? false ), 'Daily memory tool searches imported daily memory.' );
+		$this->assertSame( 1, $search['data']['match_count'] ?? 0 );
+	}
+
+	private function remove_tree( string $path ): void {
+		if ( ! is_dir( $path ) ) {
+			return;
+		}
+
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $path, \FilesystemIterator::SKIP_DOTS ),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ( $iterator as $file ) {
+			$file->isDir() ? rmdir( $file->getPathname() ) : unlink( $file->getPathname() );
+		}
+		rmdir( $path );
 	}
 
 	public function test_import_reenqueues_existing_scheduled_flow_when_action_is_missing(): void {

--- a/tests/agent-daily-memory-pipeline-scope-smoke.php
+++ b/tests/agent-daily-memory-pipeline-scope-smoke.php
@@ -155,8 +155,6 @@ namespace {
 			'user_id'  => 77,
 			'agent_id' => 42,
 			'query'    => 'entry',
-			'from'     => null,
-			'to'       => null,
 		),
 		$agent_daily_memory_ability_inputs['datamachine/search-daily-memory'] ?? null,
 		'search uses executing agent scope',


### PR DESCRIPTION
## Summary
- Route imported agent daily memory files through `DailyMemory` so `memory/agent/daily/YYYY/MM/DD.md` bundle files seed the active runtime memory store for the imported agent.
- Preserve existing agent memory import behavior for non-daily files while avoiding `null` optional date range fields in `agent_daily_memory` search calls.
- Add smoke coverage that round-trips a bundle directory with `memory/agent/daily/...`, imports it, and verifies `agent_daily_memory` can read and search the imported entry.

Closes #1892.

## Tests
- `php -l inc/Core/Agents/AgentBundler.php`
- `php -l inc/Engine/AI/Tools/Global/AgentDailyMemory.php`
- `php -l tests/Unit/Core/Agents/AgentBundlerImportTest.php`
- `php -l tests/agent-daily-memory-pipeline-scope-smoke.php`
- `php tests/agent-daily-memory-pipeline-scope-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine@import-bundled-daily-memory --extension wordpress --force-hot -- tests/Unit/Core/Agents/AgentBundlerImportTest.php`
- `vendor/bin/phpcs inc/Core/Agents/AgentBundler.php inc/Engine/AI/Tools/Global/AgentDailyMemory.php tests/Unit/Core/Agents/AgentBundlerImportTest.php tests/agent-daily-memory-pipeline-scope-smoke.php`

## Notes
- Full `homeboy lint --path /Users/chubes/Developer/data-machine@import-bundled-daily-memory --extension wordpress --force-hot` is still blocked by existing unrelated frontend lint findings outside this patch.
- GitHub/DMC behavior and outbound export of job-written daily memory remain out of scope for this first-wave PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal importer/tool/test changes and ran targeted verification; Chris remains responsible for review and merge.