### PR TITLE
Declare run artifact egress policy

### DIFF
--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -189,6 +189,7 @@ class RunFlowAbility {
 
 		$flow_config       = $flow['flow_config'] ?? array();
 		$scheduling_config = $flow['scheduling_config'] ?? array();
+		$run_artifact_policy = \DataMachine\Engine\Bundle\BundleSchema::normalize_run_artifact_egress_policy( $scheduling_config['run_artifacts'] ?? array() );
 
 		// Load pipeline config.
 		$pipeline        = $this->db_pipelines->get_pipeline( $pipeline_id );
@@ -224,6 +225,10 @@ class RunFlowAbility {
 			'flow_config'     => $flow_config,
 			'pipeline_config' => $pipeline_config,
 		);
+		if ( ! empty( $run_artifact_policy ) ) {
+			$engine_snapshot['run_artifact_egress_policy'] = $run_artifact_policy;
+			$engine_snapshot['flow']['run_artifacts']       = $run_artifact_policy;
+		}
 
 		// Merge initial_data (e.g. webhook payloads, API context) into the
 		// engine snapshot. initial_data keys go underneath so engine

--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -187,8 +187,8 @@ class RunFlowAbility {
 		// Transition job from pending to processing.
 		$this->db_jobs->start_job( $job_id );
 
-		$flow_config       = $flow['flow_config'] ?? array();
-		$scheduling_config = $flow['scheduling_config'] ?? array();
+		$flow_config         = $flow['flow_config'] ?? array();
+		$scheduling_config   = $flow['scheduling_config'] ?? array();
 		$run_artifact_policy = \DataMachine\Engine\Bundle\BundleSchema::normalize_run_artifact_egress_policy( $scheduling_config['run_artifacts'] ?? array() );
 
 		// Load pipeline config.
@@ -227,7 +227,7 @@ class RunFlowAbility {
 		);
 		if ( ! empty( $run_artifact_policy ) ) {
 			$engine_snapshot['run_artifact_egress_policy'] = $run_artifact_policy;
-			$engine_snapshot['flow']['run_artifacts']       = $run_artifact_policy;
+			$engine_snapshot['flow']['run_artifacts']      = $run_artifact_policy;
 		}
 
 		// Merge initial_data (e.g. webhook payloads, API context) into the

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -204,7 +204,8 @@ class AgentBundler {
 								'flow_id'  => $flow_id,
 							)
 						)
-					)
+					),
+					\DataMachine\Engine\Bundle\BundleSchema::normalize_run_artifact_egress_policy( $scheduling['run_artifacts'] ?? array() )
 				);
 
 				if ( ! empty( $export_manifest['memory'] ) ) {
@@ -524,6 +525,7 @@ class AgentBundler {
 		$bundle_version         = trim( (string) $bundle['bundle_version'] );
 		$bundle_source_ref      = trim( (string) ( $bundle['source_ref'] ?? '' ) );
 		$bundle_source_revision = trim( (string) ( $bundle['source_revision'] ?? '' ) );
+		$bundle_run_artifacts   = \DataMachine\Engine\Bundle\BundleSchema::normalize_run_artifact_egress_policy( $bundle['run_artifacts'] ?? array() );
 		$bundle_metadata        = array(
 			'bundle_slug'     => $bundle_slug,
 			'bundle_version'  => $bundle_version,
@@ -586,6 +588,9 @@ class AgentBundler {
 			'upgrade'             => (bool) $existing,
 			'runtime_policy'      => $reconcile_runtime ? 'replace_bundle_seed' : 'preserve_existing',
 		);
+		if ( ! empty( $bundle_run_artifacts ) ) {
+			$summary['run_artifacts'] = $bundle_run_artifacts;
+		}
 
 		if ( $dry_run ) {
 			// Check ability mismatches.
@@ -634,6 +639,9 @@ class AgentBundler {
 			$bundle_metadata,
 			array( 'artifacts' => $existing_bundle_state['artifacts'] ?? array() )
 			);
+			if ( ! empty( $bundle_run_artifacts ) ) {
+				$config['datamachine_bundle']['run_artifacts'] = $bundle_run_artifacts;
+			}
 
 			if ( $existing ) {
 				$agent_id = (int) $existing['agent_id'];
@@ -768,7 +776,12 @@ class AgentBundler {
 				);
 				$artifact_key  = 'flow:' . $portable_slug;
 
-				$scheduling = $this->bundle_create_scheduling_config( is_array( $flow_data['scheduling_config'] ?? null ) ? $flow_data['scheduling_config'] : array() );
+
+				$flow_run_artifacts = \DataMachine\Engine\Bundle\BundleSchema::normalize_run_artifact_egress_policy( $flow_data['run_artifacts'] ?? $bundle_run_artifacts );
+				$scheduling         = $this->bundle_create_scheduling_config( is_array( $flow_data['scheduling_config'] ?? null ) ? $flow_data['scheduling_config'] : array() );
+				if ( ! empty( $flow_run_artifacts ) ) {
+					$scheduling['run_artifacts'] = $flow_run_artifacts;
+				}
 
 				$flow_config         = is_array( $flow_data['flow_config'] ?? null ) ? $flow_data['flow_config'] : array();
 				$existing_flow       = $this->flows_repo->get_by_portable_slug( (int) $new_pipeline_id, $portable_slug );
@@ -827,9 +840,15 @@ class AgentBundler {
 						'flow_config'   => $flow_config,
 						'portable_slug' => $portable_slug,
 					);
+					if ( ! empty( $flow_run_artifacts ) ) {
+						$update_scheduling                  = is_array( $existing_flow['scheduling_config'] ?? null ) ? $existing_flow['scheduling_config'] : array();
+						$update_scheduling['run_artifacts'] = $flow_run_artifacts;
+						$update_data['scheduling_config']   = $update_scheduling;
+						$scheduling_to_ensure               = $update_scheduling;
+					}
 					if ( $reconcile_runtime ) {
-						$update_data['scheduling_config'] = $flow_data['scheduling_config'] ?? array();
-						$scheduling_to_ensure             = is_array( $flow_data['scheduling_config'] ?? null ) ? $flow_data['scheduling_config'] : array();
+						$update_data['scheduling_config'] = $scheduling;
+						$scheduling_to_ensure             = $scheduling;
 					}
 					if ( ! $this->flows_repo->update_flow( $new_flow_id, $update_data ) ) {
 						throw new \RuntimeException( sprintf( 'Failed to update flow "%s".', $portable_slug ) );
@@ -1165,14 +1184,20 @@ class AgentBundler {
 
 	private function flow_artifact_payload( array $flow, string $portable_slug ): array {
 		$scheduling_policy = $this->bundle_scheduling_policy( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() );
+		$run_artifacts     = \DataMachine\Engine\Bundle\BundleSchema::normalize_run_artifact_egress_policy( $flow['run_artifacts'] ?? $flow['scheduling_config']['run_artifacts'] ?? array() );
 
-		return array(
+		$payload = array(
 			'portable_slug'     => $portable_slug,
 			'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
 			'flow_config'       => $this->flow_config_without_runtime_queues( is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array() ),
 			'scheduling_policy' => $scheduling_policy,
 			'queue_policy'      => 'create_seed_upgrade_preserve_existing',
 		);
+		if ( ! empty( $run_artifacts ) ) {
+			$payload['run_artifacts'] = $run_artifacts;
+		}
+
+		return $payload;
 	}
 
 	private function bundle_create_scheduling_config( array $config ): array {

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -776,7 +776,6 @@ class AgentBundler {
 				);
 				$artifact_key  = 'flow:' . $portable_slug;
 
-
 				$flow_run_artifacts = \DataMachine\Engine\Bundle\BundleSchema::normalize_run_artifact_egress_policy( $flow_data['run_artifacts'] ?? $bundle_run_artifacts );
 				$scheduling         = $this->bundle_create_scheduling_config( is_array( $flow_data['scheduling_config'] ?? null ) ? $flow_data['scheduling_config'] : array() );
 				if ( ! empty( $flow_run_artifacts ) ) {

--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -45,7 +45,8 @@ final class AgentBundleArrayAdapter {
 				'pipelines'    => array_values( $pipeline_slugs ),
 				'flows'        => array_values( $flow_slugs ),
 				'handler_auth' => 'refs',
-			)
+			),
+			BundleSchema::normalize_run_artifact_egress_policy( $bundle['run_artifacts'] ?? array() )
 		);
 
 		return new AgentBundleDirectory(
@@ -116,7 +117,7 @@ final class AgentBundleArrayAdapter {
 				$flow_config[ $flow_step_id ] = self::flow_step_config_from_document_step( $step, $pipeline_id, $flow_id, $pipeline_step_id, $flow_step_id );
 			}
 
-			$flows[] = array(
+			$flow_entry = array(
 				'original_id'          => $flow_id,
 				'original_pipeline_id' => $pipeline_id,
 				'portable_slug'        => $slug,
@@ -129,9 +130,14 @@ final class AgentBundleArrayAdapter {
 				),
 				'memory_file_contents' => self::strip_memory_prefix( $memory_files, 'flows/' . $slug . '/' ),
 			);
+			$flow_run_artifacts = BundleSchema::normalize_run_artifact_egress_policy( $flow['run_artifacts'] ?? array() );
+			if ( ! empty( $flow_run_artifacts ) ) {
+				$flow_entry['run_artifacts'] = $flow_run_artifacts;
+			}
+			$flows[] = $flow_entry;
 		}
 
-		return array(
+		$bundle = array(
 			'bundle_version'        => $manifest['bundle_version'],
 			'bundle_slug'           => $manifest['bundle_slug'],
 			'source_ref'            => $manifest['source_ref'] ?? '',
@@ -152,6 +158,12 @@ final class AgentBundleArrayAdapter {
 			'extras'                => $directory->extras(),
 			'abilities_manifest'    => array(),
 		);
+		$run_artifacts = BundleSchema::normalize_run_artifact_egress_policy( $manifest['run_artifacts'] ?? array() );
+		if ( ! empty( $run_artifacts ) ) {
+			$bundle['run_artifacts'] = $run_artifacts;
+		}
+
+		return $bundle;
 	}
 
 	/** @param array<int,array<string,mixed>> $pipelines */
@@ -264,7 +276,8 @@ final class AgentBundleArrayAdapter {
 				$pipeline_slug,
 				(string) ( $scheduling['interval'] ?? 'manual' ),
 				is_array( $scheduling['max_items'] ?? null ) ? $scheduling['max_items'] : array(),
-				self::flow_steps_from_config( $flow['flow_config'] ?? array(), $pipeline_step_types_by_id )
+				self::flow_steps_from_config( $flow['flow_config'] ?? array(), $pipeline_step_types_by_id ),
+				BundleSchema::normalize_run_artifact_egress_policy( $flow['run_artifacts'] ?? $scheduling['run_artifacts'] ?? array() )
 			);
 		}
 		return $files;

--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -117,7 +117,7 @@ final class AgentBundleArrayAdapter {
 				$flow_config[ $flow_step_id ] = self::flow_step_config_from_document_step( $step, $pipeline_id, $flow_id, $pipeline_step_id, $flow_step_id );
 			}
 
-			$flow_entry = array(
+			$flow_entry         = array(
 				'original_id'          => $flow_id,
 				'original_pipeline_id' => $pipeline_id,
 				'portable_slug'        => $slug,
@@ -137,7 +137,7 @@ final class AgentBundleArrayAdapter {
 			$flows[] = $flow_entry;
 		}
 
-		$bundle = array(
+		$bundle        = array(
 			'bundle_version'        => $manifest['bundle_version'],
 			'bundle_slug'           => $manifest['bundle_slug'],
 			'source_ref'            => $manifest['source_ref'] ?? '',

--- a/inc/Engine/Bundle/AgentBundleFlowFile.php
+++ b/inc/Engine/Bundle/AgentBundleFlowFile.php
@@ -21,6 +21,7 @@ final class AgentBundleFlowFile {
 	private string $schedule;
 	private array $max_items;
 	private array $steps;
+	private array $run_artifacts;
 
 	private const OPTIONAL_STEP_FIELDS = array(
 		'step_type',
@@ -37,13 +38,14 @@ final class AgentBundleFlowFile {
 		'enabled',
 	);
 
-	public function __construct( string $slug, string $name, string $pipeline_slug, string $schedule, array $max_items, array $steps ) {
+	public function __construct( string $slug, string $name, string $pipeline_slug, string $schedule, array $max_items, array $steps, array $run_artifacts = array() ) {
 		$this->slug          = PortableSlug::normalize( $slug, 'flow' );
 		$this->name          = $name;
 		$this->pipeline_slug = PortableSlug::normalize( $pipeline_slug, 'pipeline' );
 		$this->schedule      = $schedule;
 		$this->max_items     = $max_items;
 		$this->steps         = self::validate_steps( $steps );
+		$this->run_artifacts = BundleSchema::normalize_run_artifact_egress_policy( $run_artifacts );
 	}
 
 	public static function from_array( array $data ): self {
@@ -58,11 +60,19 @@ final class AgentBundleFlowFile {
 			throw new BundleValidationException( 'flow file max_items must be an object and steps must be a list.' );
 		}
 
-		return new self( (string) $data['slug'], (string) $data['name'], (string) $data['pipeline_slug'], (string) $data['schedule'], $data['max_items'], $data['steps'] );
+		return new self(
+			(string) $data['slug'],
+			(string) $data['name'],
+			(string) $data['pipeline_slug'],
+			(string) $data['schedule'],
+			$data['max_items'],
+			$data['steps'],
+			is_array( $data['run_artifacts'] ?? null ) ? $data['run_artifacts'] : array()
+		);
 	}
 
 	public function to_array(): array {
-		return array(
+		$data = array(
 			'schema_version' => BundleSchema::VERSION,
 			'slug'           => $this->slug,
 			'name'           => $this->name,
@@ -71,6 +81,16 @@ final class AgentBundleFlowFile {
 			'max_items'      => $this->max_items,
 			'steps'          => $this->steps,
 		);
+
+		if ( ! empty( $this->run_artifacts ) ) {
+			$data['run_artifacts'] = $this->run_artifacts;
+		}
+
+		return $data;
+	}
+
+	public function run_artifacts(): array {
+		return $this->run_artifacts;
 	}
 
 	private static function validate_steps( array $steps ): array {

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -22,8 +22,9 @@ final class AgentBundleManifest {
 	private string $source_revision;
 	private array $agent;
 	private array $included;
+	private array $run_artifacts;
 
-	public function __construct( string $exported_at, string $exported_by, string $bundle_slug, string $bundle_version, string $source_ref, string $source_revision, array $agent, array $included ) {
+	public function __construct( string $exported_at, string $exported_by, string $bundle_slug, string $bundle_version, string $source_ref, string $source_revision, array $agent, array $included, array $run_artifacts = array() ) {
 		$this->exported_at     = $exported_at;
 		$this->exported_by     = $exported_by;
 		$this->bundle_slug     = PortableSlug::normalize( $bundle_slug, 'bundle' );
@@ -32,6 +33,7 @@ final class AgentBundleManifest {
 		$this->source_revision = self::validate_optional_string( $source_revision, 'source_revision' );
 		$this->agent           = self::validate_agent( $agent );
 		$this->included        = self::validate_included( $included );
+		$this->run_artifacts   = BundleSchema::normalize_run_artifact_egress_policy( $run_artifacts );
 	}
 
 	/**
@@ -61,7 +63,8 @@ final class AgentBundleManifest {
 			(string) ( $data['source_ref'] ?? '' ),
 			(string) ( $data['source_revision'] ?? '' ),
 			$data['agent'],
-			$data['included']
+			$data['included'],
+			is_array( $data['run_artifacts'] ?? null ) ? $data['run_artifacts'] : array()
 		);
 	}
 
@@ -71,7 +74,7 @@ final class AgentBundleManifest {
 	 * @return array
 	 */
 	public function to_array(): array {
-		return array(
+		$data = array(
 			'schema_version'  => BundleSchema::VERSION,
 			'bundle_slug'     => $this->bundle_slug,
 			'bundle_version'  => $this->bundle_version,
@@ -82,6 +85,12 @@ final class AgentBundleManifest {
 			'agent'           => $this->agent,
 			'included'        => $this->included,
 		);
+
+		if ( ! empty( $this->run_artifacts ) ) {
+			$data['run_artifacts'] = $this->run_artifacts;
+		}
+
+		return $data;
 	}
 
 	public function agent_slug(): string {
@@ -111,6 +120,10 @@ final class AgentBundleManifest {
 			'source_ref'      => $this->source_ref,
 			'source_revision' => $this->source_revision,
 		);
+	}
+
+	public function run_artifacts(): array {
+		return $this->run_artifacts;
 	}
 
 	private static function validate_agent( array $agent ): array {

--- a/inc/Engine/Bundle/BundleSchema.php
+++ b/inc/Engine/Bundle/BundleSchema.php
@@ -100,6 +100,18 @@ final class BundleSchema {
 
 	public const ARTIFACT_TYPES = self::CORE_ARTIFACT_TYPES;
 
+	public const RUN_ARTIFACT_EGRESS_TARGETS = array(
+		'artifact',
+		'bundle-file',
+		'pr-body',
+	);
+
+	public const RUN_ARTIFACT_SOURCES = array(
+		'completion_assertions',
+		'daily_memory',
+		'transcript_summary',
+	);
+
 	/**
 	 * Return all artifact types known to the bundle runtime.
 	 *
@@ -190,6 +202,82 @@ final class BundleSchema {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Normalize declarative run artifact egress policy.
+	 *
+	 * Data Machine only validates and exposes this policy. Consumers such as Data
+	 * Machine Code decide what `bundle-file` or `pr-body` mean in a given runtime.
+	 * Unknown sources or egress targets are dropped so older/future bundle authors
+	 * get deterministic behavior without triggering GitHub-specific code here.
+	 *
+	 * @param mixed $policy Raw policy value.
+	 * @return array<string,array<string,mixed>> Normalized source policy map.
+	 */
+	public static function normalize_run_artifact_egress_policy( mixed $policy ): array {
+		if ( ! is_array( $policy ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( self::RUN_ARTIFACT_SOURCES as $source ) {
+			if ( ! is_array( $policy[ $source ] ?? null ) ) {
+				continue;
+			}
+
+			$source_policy = $policy[ $source ];
+			$egress        = self::normalize_run_artifact_egress_targets( $source_policy['egress'] ?? array() );
+			if ( empty( $egress ) ) {
+				continue;
+			}
+
+			$entry = array( 'egress' => $egress );
+			if ( 'daily_memory' === $source && is_string( $source_policy['bundle_relative_path'] ?? null ) ) {
+				$path = self::normalize_bundle_relative_path( $source_policy['bundle_relative_path'] );
+				if ( '' !== $path ) {
+					$entry['bundle_relative_path'] = $path;
+				}
+			}
+
+			$normalized[ $source ] = $entry;
+		}
+
+		ksort( $normalized, SORT_STRING );
+		return $normalized;
+	}
+
+	/** @return string[] */
+	private static function normalize_run_artifact_egress_targets( mixed $targets ): array {
+		if ( ! is_array( $targets ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $targets as $target ) {
+			if ( ! is_string( $target ) ) {
+				continue;
+			}
+			$target = self::sanitize_key( $target );
+			if ( in_array( $target, self::RUN_ARTIFACT_EGRESS_TARGETS, true ) ) {
+				$normalized[] = $target;
+			}
+		}
+
+		$normalized = array_values( array_unique( $normalized ) );
+		sort( $normalized, SORT_STRING );
+		return $normalized;
+	}
+
+	private static function normalize_bundle_relative_path( string $path ): string {
+		$path = str_replace( '\\', '/', trim( $path ) );
+		$path = preg_replace( '#/+#', '/', $path );
+		$path = ltrim( is_string( $path ) ? $path : '', '/' );
+		if ( '' === $path || str_contains( $path, '../' ) || str_starts_with( $path, '..' ) ) {
+			return '';
+		}
+
+		return $path;
 	}
 
 	/**

--- a/tests/Unit/AI/Directives/CallerContextDirectiveTest.php
+++ b/tests/Unit/AI/Directives/CallerContextDirectiveTest.php
@@ -35,13 +35,6 @@ class CallerContextDirectiveTest extends WP_UnitTestCase {
 		$this->assertSame( array(), $outputs );
 	}
 
-	public function test_no_output_when_depth_set_but_host_is_self(): void {
-		// Depth alone doesn't qualify — remote caller_host is the A2A signal.
-		PermissionHelper::set_caller_context( new \WP_Agent_Caller_Context( 'some-agent', 0, \WP_Agent_Caller_Context::SELF_HOST, 2, 'chain-id' ) );
-		$outputs = CallerContextDirective::get_outputs( 'openai', array() );
-		$this->assertSame( array(), $outputs );
-	}
-
 	public function test_emits_system_text_for_cross_site_call(): void {
 		PermissionHelper::set_caller_context( new \WP_Agent_Caller_Context(
 			'franklin-bot',

--- a/tests/Unit/Auth/CallerContextTest.php
+++ b/tests/Unit/Auth/CallerContextTest.php
@@ -88,10 +88,12 @@ class CallerContextTest extends WP_UnitTestCase {
 		$this->assertSame( 3, $ctx->chain_depth );
 	}
 
-	public function test_is_cross_site_requires_remote_host(): void {
-		$local = new \WP_Agent_Caller_Context( 'some-agent', 0, \WP_Agent_Caller_Context::SELF_HOST, 2, 'cid' );
-		$this->assertFalse( $local->is_cross_site() );
+	public function test_chained_context_requires_remote_host(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		new \WP_Agent_Caller_Context( 'some-agent', 0, \WP_Agent_Caller_Context::SELF_HOST, 2, 'cid' );
+	}
 
+	public function test_is_cross_site_requires_remote_host(): void {
 		$remote = new \WP_Agent_Caller_Context( 'some-agent', 0, 'https://chubes.net', 1, 'cid' );
 		$this->assertTrue( $remote->is_cross_site() );
 	}

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -23,9 +23,12 @@ use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
 use DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts;
 use DataMachine\Core\Database\Flows\Flows as FlowsRepository;
+use DataMachine\Core\Database\Jobs\Jobs as JobsRepository;
 use DataMachine\Core\Database\Pipelines\Pipelines as PipelinesRepository;
+use DataMachine\Abilities\Engine\RunFlowAbility;
 use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\BundleSchema;
 use WP_UnitTestCase;
 
 class AgentBundlerImportTest extends WP_UnitTestCase {
@@ -42,6 +45,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		AgentsRepository::create_table();
 		PipelinesRepository::create_table();
 		FlowsRepository::create_table();
+		JobsRepository::create_table();
 		InstalledBundleArtifacts::create_table();
 
 		$this->bundler        = new AgentBundler();
@@ -60,6 +64,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agents" );
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}datamachine_pipelines" );
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}datamachine_flows" );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}datamachine_jobs" );
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}datamachine_bundle_artifacts" );
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 
@@ -137,6 +142,81 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertSame( 'daily', $flow['scheduling_config']['interval'] ?? null, 'Importer preserves the bundle interval.' );
 		$this->assertTrue( $flow['scheduling_config']['enabled'] ?? false, 'Importer keeps scheduled bundle flows enabled.' );
 		$this->assertSame( array( 'mcp' => 5 ), $flow['scheduling_config']['max_items'] ?? null, 'Importer preserves bundle max item caps.' );
+	}
+
+	public function test_import_exposes_run_artifact_egress_policy_in_agent_and_flow_metadata(): void {
+		$bundle                  = $this->fixture_bundle( 'artifact-policy-agent' );
+		$bundle['run_artifacts'] = array(
+			'daily_memory'          => array(
+				'egress'               => array( 'bundle-file', 'pr-body', 'github-comment' ),
+				'bundle_relative_path' => 'memory/agent/daily/{yyyy}/{mm}/{dd}.md',
+			),
+			'completion_assertions' => array(
+				'egress' => array( 'pr-body' ),
+			),
+			'transcript_summary'    => array(
+				'egress' => array( 'artifact' ),
+			),
+			'unknown_future_source' => array(
+				'egress' => array( 'pr-body' ),
+			),
+		);
+
+		$result = $this->bundler->import( $bundle, null, $this->owner_id );
+
+		$this->assertTrue( (bool) $result['success'], 'Artifact policy bundle import succeeds.' );
+
+		$expected = array(
+			'completion_assertions' => array(
+				'egress' => array( 'pr-body' ),
+			),
+			'daily_memory'          => array(
+				'egress'               => array( 'bundle-file', 'pr-body' ),
+				'bundle_relative_path' => 'memory/agent/daily/{yyyy}/{mm}/{dd}.md',
+			),
+			'transcript_summary'    => array(
+				'egress' => array( 'artifact' ),
+			),
+		);
+
+		$agent    = $this->agents_repo->get_by_slug( 'artifact-policy-agent' );
+		$pipeline = $this->pipelines_repo->get_by_portable_slug( (int) $agent['agent_id'], 'static-site-pipeline' );
+		$flow     = $this->flows_repo->get_by_portable_slug( (int) $pipeline['pipeline_id'], 'static-site-flow' );
+
+		$this->assertSame( $expected, BundleSchema::normalize_run_artifact_egress_policy( $agent['agent_config']['datamachine_bundle']['run_artifacts'] ?? array() ), 'Agent bundle metadata exposes normalized run artifact policy.' );
+		$this->assertSame( $expected, BundleSchema::normalize_run_artifact_egress_policy( $flow['scheduling_config']['run_artifacts'] ?? array() ), 'Flow runtime metadata exposes normalized run artifact policy.' );
+		$this->assertSame( $expected, $result['summary']['run_artifacts'] ?? array(), 'Import summary exposes normalized run artifact policy.' );
+	}
+
+	public function test_run_flow_copies_run_artifact_egress_policy_to_job_engine_data(): void {
+		$bundle                  = $this->fixture_bundle( 'artifact-runtime-agent' );
+		$bundle['run_artifacts'] = array(
+			'daily_memory' => array(
+				'egress'               => array( 'bundle-file', 'pr-body' ),
+				'bundle_relative_path' => 'memory/agent/daily/{yyyy}/{mm}/{dd}.md',
+			),
+		);
+
+		$result = $this->bundler->import( $bundle, null, $this->owner_id );
+		$this->assertTrue( (bool) $result['success'], 'Artifact runtime policy bundle import succeeds.' );
+
+		$agent    = $this->agents_repo->get_by_slug( 'artifact-runtime-agent' );
+		$pipeline = $this->pipelines_repo->get_by_portable_slug( (int) $agent['agent_id'], 'static-site-pipeline' );
+		$flow     = $this->flows_repo->get_by_portable_slug( (int) $pipeline['pipeline_id'], 'static-site-flow' );
+
+		$run = ( new RunFlowAbility() )->execute( array( 'flow_id' => (int) $flow['flow_id'] ) );
+		$this->assertTrue( (bool) $run['success'], 'Flow run initializes job runtime metadata.' );
+
+		$engine_data = ( new JobsRepository() )->retrieve_engine_data( (int) $run['job_id'] );
+		$expected    = array(
+			'daily_memory' => array(
+				'egress'               => array( 'bundle-file', 'pr-body' ),
+				'bundle_relative_path' => 'memory/agent/daily/{yyyy}/{mm}/{dd}.md',
+			),
+		);
+
+		$this->assertSame( $expected, $engine_data['run_artifact_egress_policy'] ?? array(), 'Job engine_data exposes run artifact egress policy.' );
+		$this->assertSame( $expected, $engine_data['flow']['run_artifacts'] ?? array(), 'Flow runtime metadata exposes run artifact egress policy.' );
 	}
 
 	public function test_import_reenqueues_existing_scheduled_flow_when_action_is_missing(): void {

--- a/tests/run-artifact-egress-policy-smoke.php
+++ b/tests/run-artifact-egress-policy-smoke.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Pure-PHP smoke test for run artifact egress bundle policy.
+ *
+ * Run with: php tests/run-artifact-egress-policy-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+require_once __DIR__ . '/../inc/Engine/Bundle/BundleValidationException.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/PortableSlug.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleSlugTrait.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/BundleSchema.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleManifest.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleFlowFile.php';
+
+use DataMachine\Engine\Bundle\AgentBundleFlowFile;
+use DataMachine\Engine\Bundle\AgentBundleManifest;
+use DataMachine\Engine\Bundle\BundleSchema;
+
+$failures = array();
+$passes   = 0;
+
+function assert_policy_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+echo "run-artifact-egress-policy-smoke\n";
+
+$raw_policy = array(
+	'daily_memory'          => array(
+		'egress'               => array( 'bundle-file', 'pr-body', 'github-comment', 'bundle-file' ),
+		'bundle_relative_path' => '/memory/agent/daily/{yyyy}/{mm}/{dd}.md',
+	),
+	'completion_assertions' => array(
+		'egress' => array( 'pr-body' ),
+	),
+	'transcript_summary'    => array(
+		'egress' => array( 'artifact' ),
+	),
+	'unknown_source'        => array(
+		'egress' => array( 'pr-body' ),
+	),
+);
+
+$expected = array(
+	'completion_assertions' => array(
+		'egress' => array( 'pr-body' ),
+	),
+	'daily_memory'          => array(
+		'egress'               => array( 'bundle-file', 'pr-body' ),
+		'bundle_relative_path' => 'memory/agent/daily/{yyyy}/{mm}/{dd}.md',
+	),
+	'transcript_summary'    => array(
+		'egress' => array( 'artifact' ),
+	),
+);
+
+assert_policy_equals( $expected, BundleSchema::normalize_run_artifact_egress_policy( $raw_policy ), 'normalizes supported sources and egress targets', $failures, $passes );
+assert_policy_equals( array(), BundleSchema::normalize_run_artifact_egress_policy( array() ), 'empty policy stays empty for existing bundles', $failures, $passes );
+
+$manifest = new AgentBundleManifest(
+	'2026-05-09T00:00:00+00:00',
+	'data-machine/test',
+	'artifact-policy-agent',
+	'1',
+	'',
+	'',
+	array(
+		'slug'         => 'artifact-policy-agent',
+		'label'        => 'Artifact Policy Agent',
+		'description'  => '',
+		'agent_config' => array(),
+	),
+	array(
+		'memory'       => array(),
+		'pipelines'    => array(),
+		'flows'        => array(),
+		'handler_auth' => 'refs',
+	),
+	$raw_policy
+);
+
+assert_policy_equals( $expected, $manifest->to_array()['run_artifacts'] ?? array(), 'manifest round-trips run artifact policy', $failures, $passes );
+
+$flow_file = new AgentBundleFlowFile(
+	'artifact-flow',
+	'Artifact Flow',
+	'artifact-pipeline',
+	'manual',
+	array(),
+	array(
+		array(
+			'step_position'   => 0,
+			'handler_configs' => array(),
+		),
+	),
+	$raw_policy
+);
+
+assert_policy_equals( $expected, $flow_file->to_array()['run_artifacts'] ?? array(), 'flow file round-trips run artifact policy', $failures, $passes );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " run artifact policy assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} run artifact policy assertions passed.\n";


### PR DESCRIPTION
## Summary
- Adds a normalized `run_artifacts` policy surface for bundle and flow manifests.
- Persists imported policy into agent bundle metadata, flow runtime metadata, and job `engine_data` as `run_artifact_egress_policy`.
- Keeps Data Machine GitHub-neutral by only validating/exposing policy targets; DMC can implement repo/PR effects later.

Refs #1893. Context: #1888, #1891.

## Tests
- `php -l inc/Engine/Bundle/BundleSchema.php && php -l inc/Engine/Bundle/AgentBundleManifest.php && php -l inc/Engine/Bundle/AgentBundleFlowFile.php && php -l inc/Engine/Bundle/AgentBundleArrayAdapter.php && php -l inc/Core/Agents/AgentBundler.php && php -l inc/Abilities/Engine/RunFlowAbility.php && php -l tests/Unit/Core/Agents/AgentBundlerImportTest.php && php -l tests/run-artifact-egress-policy-smoke.php`
- `php tests/run-artifact-egress-policy-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/data-machine@bundle-run-artifact-egress-policy --extension wordpress --changed-since main`
- `homeboy test --path /Users/chubes/Developer/data-machine@bundle-run-artifact-egress-policy --extension wordpress --changed-since main`
- `homeboy test --path /Users/chubes/Developer/data-machine@bundle-run-artifact-egress-policy --extension wordpress`

## Schema notes
- Supported artifact sources: `daily_memory`, `completion_assertions`, `transcript_summary`.
- Supported egress targets: `bundle-file`, `pr-body`, `artifact`.
- Unknown sources and egress targets are ignored during normalization so bundles remain deterministic without adding GitHub-specific behavior.
- `daily_memory.bundle_relative_path` is normalized as a bundle-relative path and may include date placeholders such as `{yyyy}/{mm}/{dd}`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the schema/import/runtime metadata changes and focused tests; Chris remains responsible for review and merge.