### PR TITLE
Use Agents API markdown overflow planner

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -820,16 +820,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "9d3d06a28402a66b9b74cf6b54ce90f59e4cab8a"
+                "reference": "ed6ffa82eb374dd431a54291eba6138b870d4cef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/9d3d06a28402a66b9b74cf6b54ce90f59e4cab8a",
-                "reference": "9d3d06a28402a66b9b74cf6b54ce90f59e4cab8a",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/ed6ffa82eb374dd431a54291eba6138b870d4cef",
+                "reference": "ed6ffa82eb374dd431a54291eba6138b870d4cef",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
+            },
+            "suggest": {
+                "woocommerce/action-scheduler": "Required to actually run cron-triggered workflows. The substrate detects Action Scheduler at runtime and no-ops cleanly when absent; install this package (or any plugin that ships it, like WooCommerce) to enable scheduled workflow runs."
             },
             "default-branch": true,
             "type": "wordpress-plugin",
@@ -854,6 +857,7 @@
                     "php tests/approval-action-value-shape-smoke.php",
                     "php tests/workspace-scope-smoke.php",
                     "php tests/compaction-item-smoke.php",
+                    "php tests/compaction-conservation-smoke.php",
                     "php tests/conversation-runner-contracts-smoke.php",
                     "php tests/conversation-transcript-lock-smoke.php",
                     "php tests/conversation-compaction-smoke.php",
@@ -866,8 +870,15 @@
                     "php tests/conversation-loop-events-smoke.php",
                     "php tests/iteration-budget-smoke.php",
                     "php tests/conversation-loop-budgets-smoke.php",
+                    "php tests/channels-smoke.php",
+                    "php tests/webhook-safety-smoke.php",
+                    "php tests/remote-bridge-smoke.php",
                     "php tests/context-authority-smoke.php",
                     "php tests/guidelines-substrate-smoke.php",
+                    "php tests/workflow-bindings-smoke.php",
+                    "php tests/workflow-spec-validator-smoke.php",
+                    "php tests/workflow-runner-smoke.php",
+                    "php tests/agents-workflow-ability-smoke.php",
                     "php tests/no-product-imports-smoke.php"
                 ]
             },
@@ -880,7 +891,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-05-08T14:27:01+00:00"
+            "time": "2026-05-09T17:26:05+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
+++ b/inc/Engine/AI/System/Tasks/DailyMemoryTask.php
@@ -27,9 +27,7 @@ use DataMachine\Core\PluginSettings;
 use DataMachine\Core\FilesRepository\AgentMemory;
 use DataMachine\Core\FilesRepository\DailyMemory;
 use DataMachine\Engine\AI\RequestBuilder;
-use AgentsAPI\AI\WP_Agent_Conversation_Compaction;
 use AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter;
-use AgentsAPI\AI\WP_Agent_Message;
 
 class DailyMemoryTask extends SystemTask {
 
@@ -486,57 +484,19 @@ class DailyMemoryTask extends SystemTask {
 	 * @return array{persistent: string, archived: string, persistent_blocks: int, archived_blocks: int}
 	 */
 	private static function planMemoryOverflowArchive( string $content, int $target_size, string $date ): array {
-		$items         = WP_Agent_Markdown_Section_Compaction_Adapter::parse( $content );
-		$section_count = 0;
-		foreach ( $items as $item ) {
-			if ( WP_Agent_Markdown_Section_Compaction_Adapter::TYPE_SECTION === ( $item['type'] ?? '' ) ) {
-				++$section_count;
-			}
-		}
-
-		if ( $section_count < 2 ) {
-			return array(
-				'persistent'        => $content,
-				'archived'          => '',
-				'persistent_blocks' => count( $items ),
-				'archived_blocks'   => 0,
-			);
-		}
-
-		$pointer         = self::buildOverflowArchivePointer( $date );
-		$retained_budget = max( 1, $target_size - strlen( $pointer ) );
-		$messages        = array();
-
-		// Agents API's overflow archive strategy archives the start of a stream.
-		// Daily Memory overflow needs tail-section archival, so project sections in
-		// reverse order and restore markdown order after Agents API chooses the cut.
-		foreach ( array_reverse( $items ) as $item ) {
-			$messages[] = WP_Agent_Message::text(
-				'system',
-				(string) ( $item['content'] ?? '' ),
-				array(
-					'datamachine_markdown_item' => $item,
-				)
-			);
-		}
-
-		$result = WP_Agent_Conversation_Compaction::compact(
-			$messages,
+		$items = WP_Agent_Markdown_Section_Compaction_Adapter::parse( $content );
+		$split = WP_Agent_Markdown_Section_Compaction_Adapter::split_for_overflow(
+			$items,
 			array(
-				'overflow_archive_enabled'   => true,
-				'overflow_threshold_bytes'   => 1,
-				'overflow_retained_messages' => max( 1, count( $messages ) - 1 ),
-				'overflow_retained_bytes'    => $retained_budget,
-				'overflow_stub_prefix'       => 'Daily Memory overflow archived without summarization.',
-				'preserve_tool_boundaries'   => false,
-			),
-			static function (): string {
-				throw new \RuntimeException( 'Daily Memory deterministic overflow must not invoke a summarizer.' );
-			}
+				'target_bytes'         => $target_size,
+				'pointer_destination'  => 'daily/' . str_replace( '-', '/', $date ) . '.md',
+				'pointer_heading'      => 'Archived Memory Overflow',
+				'pointer_content'      => self::buildOverflowArchivePointerContent( $date ),
+				'conservation_enabled' => true,
+			)
 		);
 
-		$status = (string) ( $result['metadata']['compaction']['status'] ?? '' );
-		if ( WP_Agent_Conversation_Compaction::STATUS_ARCHIVED !== $status || empty( $result['archive_items'] ) ) {
+		if ( WP_Agent_Markdown_Section_Compaction_Adapter::STATUS_ARCHIVED !== ( $split['status'] ?? '' ) || empty( $split['archive_items'] ) ) {
 			return array(
 				'persistent'        => $content,
 				'archived'          => '',
@@ -544,59 +504,26 @@ class DailyMemoryTask extends SystemTask {
 				'archived_blocks'   => 0,
 			);
 		}
-
-		$archived_items   = self::markdownItemsFromCompactionMessages( $result['archive_items'] );
-		$persistent_items = self::markdownItemsFromCompactionMessages( $result['messages'] );
-
 		return array(
-			'persistent'        => rtrim( WP_Agent_Markdown_Section_Compaction_Adapter::reconstruct( $persistent_items ) . $pointer ) . "\n",
-			'archived'          => WP_Agent_Markdown_Section_Compaction_Adapter::reconstruct( $archived_items ),
-			'persistent_blocks' => count( $persistent_items ),
-			'archived_blocks'   => count( $archived_items ),
+			'persistent'        => WP_Agent_Markdown_Section_Compaction_Adapter::reconstruct( $split['retained_items'] ),
+			'archived'          => WP_Agent_Markdown_Section_Compaction_Adapter::reconstruct( $split['archive_items'] ),
+			'persistent_blocks' => count( $split['retained_items'] ),
+			'archived_blocks'   => count( $split['archive_items'] ),
 		);
 	}
 
 	/**
-	 * Build the Data Machine-owned overflow archive pointer text.
+	 * Build the Data Machine-owned overflow archive pointer body.
 	 *
 	 * @param string $date Archive date.
-	 * @return string Pointer markdown.
+	 * @return string Pointer content.
 	 */
-	private static function buildOverflowArchivePointer( string $date ): string {
+	private static function buildOverflowArchivePointerContent( string $date ): string {
 		return sprintf(
-			"\n## Archived Memory Overflow\n\nOn %s, Daily Memory archived older MEMORY.md sections verbatim to `daily/%s`. Use daily memory search/read when those details are needed.\n",
+			"\nOn %s, Daily Memory archived older MEMORY.md sections verbatim to `daily/%s`. Use daily memory search/read when those details are needed.\n",
 			$date,
 			str_replace( '-', '/', $date ) . '.md'
 		);
-	}
-
-	/**
-	 * Extract original markdown items from Agents API compaction messages.
-	 *
-	 * @param array<int, array<string, mixed>> $messages Compaction messages.
-	 * @return array<int, array<string, mixed>> Markdown items in source document order.
-	 */
-	private static function markdownItemsFromCompactionMessages( array $messages ): array {
-		$items = array();
-		foreach ( $messages as $message ) {
-			$metadata = is_array( $message['metadata'] ?? null ) ? $message['metadata'] : array();
-			$item     = $metadata['datamachine_markdown_item'] ?? null;
-			if ( is_array( $item ) ) {
-				$items[] = $item;
-			}
-		}
-
-		usort(
-			$items,
-			static function ( array $left, array $right ): int {
-				$left_order  = (int) ( $left['metadata']['order'] ?? 0 );
-				$right_order = (int) ( $right['metadata']['order'] ?? 0 );
-
-				return $left_order <=> $right_order;
-			}
-		);
-
-		return $items;
 	}
 
 	/**

--- a/tests/Unit/AI/Directives/CallerContextDirectiveTest.php
+++ b/tests/Unit/AI/Directives/CallerContextDirectiveTest.php
@@ -35,6 +35,13 @@ class CallerContextDirectiveTest extends WP_UnitTestCase {
 		$this->assertSame( array(), $outputs );
 	}
 
+	public function test_chained_self_host_context_is_rejected_before_directive(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'chained context (chain_depth > 0) must specify a remote caller host' );
+
+		new \WP_Agent_Caller_Context( 'some-agent', 0, \WP_Agent_Caller_Context::SELF_HOST, 2, 'chain-id' );
+	}
+
 	public function test_emits_system_text_for_cross_site_call(): void {
 		PermissionHelper::set_caller_context( new \WP_Agent_Caller_Context(
 			'franklin-bot',

--- a/tests/daily-memory-overflow-split-smoke.php
+++ b/tests/daily-memory-overflow-split-smoke.php
@@ -38,8 +38,9 @@ require_once __DIR__ . '/../inc/Engine/AI/System/Tasks/DailyMemoryTask.php';
 $source = (string) file_get_contents( __DIR__ . '/../inc/Engine/AI/System/Tasks/DailyMemoryTask.php' );
 dm_overflow_assert( str_contains( $source, 'maybeHandleDeterministicOverflow' ), 'production task has deterministic overflow hook', $failures, $passes );
 dm_overflow_assert( ! str_contains( $source, 'splitMemorySectionsForOverflow' ), 'local section-split helper is removed', $failures, $passes );
-dm_overflow_assert( str_contains( $source, 'WP_Agent_Conversation_Compaction::compact' ), 'overflow decision is delegated to Agents API compaction', $failures, $passes );
+dm_overflow_assert( str_contains( $source, 'WP_Agent_Markdown_Section_Compaction_Adapter::split_for_overflow' ), 'overflow decision is delegated to Agents API markdown compaction', $failures, $passes );
 dm_overflow_assert( str_contains( $source, 'WP_Agent_Markdown_Section_Compaction_Adapter::parse' ), 'markdown projection uses Agents API adapter', $failures, $passes );
+dm_overflow_assert( ! str_contains( $source, 'WP_Agent_Message::text' ), 'fake conversation-message projection is removed', $failures, $passes );
 dm_overflow_assert( str_contains( $source, 'datamachine_daily_memory_overflow_threshold' ), 'overflow threshold is filterable', $failures, $passes );
 dm_overflow_assert( str_contains( $source, 'datamachine_daily_memory_overflow_target_size' ), 'overflow target size is filterable', $failures, $passes );
 


### PR DESCRIPTION
## Summary
- Delegate Daily Memory overflow splitting to `WP_Agent_Markdown_Section_Compaction_Adapter::split_for_overflow()` from Agents API instead of projecting markdown sections through fake conversation messages.
- Keep Data Machine-owned archive pointer wording while removing the local markdown item reconstruction shim.
- Refresh the dev/test Agents API lock reference and align the caller-context directive test with the upstream chained-context invariant.

## Testing
- `php tests/daily-memory-overflow-split-smoke.php`
- `php -l inc/Engine/AI/System/Tasks/DailyMemoryTask.php`
- `php -l tests/daily-memory-overflow-split-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/System/Tasks/DailyMemoryTask.php tests/daily-memory-overflow-split-smoke.php`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@use-agents-api-markdown-overflow --force-hot`
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@use-agents-api-markdown-overflow --changed-since origin/main`
- `homeboy lint data-machine --path /Users/chubes/Developer/data-machine@use-agents-api-markdown-overflow --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the Data Machine integration against the new Agents API markdown overflow helper, updated tests, and ran validation commands for Chris to review.