### PR TITLE
Fix nested tool schema required normalization

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -787,6 +787,10 @@ class RequestBuilder {
 	 * @return array<string, mixed>
 	 */
 	private static function normalizeRequiredFlags( array $schema ): array {
+		if ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
+			$schema['items'] = self::normalizeRequiredFlags( $schema['items'] );
+		}
+
 		if ( empty( $schema['properties'] ) || ! is_array( $schema['properties'] ) ) {
 			return $schema;
 		}
@@ -794,16 +798,16 @@ class RequestBuilder {
 		$required = isset( $schema['required'] ) && is_array( $schema['required'] ) ? $schema['required'] : array();
 
 		foreach ( $schema['properties'] as $property_name => $property_schema ) {
-			if ( ! is_array( $property_schema ) || ! array_key_exists( 'required', $property_schema ) ) {
+			if ( ! is_array( $property_schema ) ) {
 				continue;
 			}
 
-			if ( true === $property_schema['required'] ) {
+			if ( true === ( $property_schema['required'] ?? null ) ) {
 				$required[] = (string) $property_name;
 			}
 
 			unset( $property_schema['required'] );
-			$schema['properties'][ $property_name ] = $property_schema;
+			$schema['properties'][ $property_name ] = self::normalizeRequiredFlags( $property_schema );
 		}
 
 		$required = array_values( array_unique( array_filter( $required, 'is_string' ) ) );

--- a/tests/wp-ai-client-tool-schema-smoke.php
+++ b/tests/wp-ai-client-tool-schema-smoke.php
@@ -39,6 +39,7 @@ require_once $root . '/inc/Engine/AI/Directives/DirectivePolicyResolver.php';
 require_once $root . '/inc/Engine/AI/PromptBuilder.php';
 require_once $root . '/inc/Engine/AI/ProviderRequestAssembler.php';
 require_once $root . '/inc/Engine/AI/RequestMetadata.php';
+require_once $root . '/inc/Core/PluginSettings.php';
 require_once $root . '/inc/Engine/AI/WpAiClientProviderAdmin.php';
 require_once $root . '/inc/Engine/AI/RequestBuilder.php';
 
@@ -138,6 +139,17 @@ $response = \DataMachine\Engine\AI\RequestBuilder::build(
 					'type'     => 'string',
 					'required' => false,
 				),
+				'policy' => array(
+					'type'       => 'object',
+					'required'   => false,
+					'properties' => array(
+						'allow' => array(
+							'type'     => 'array',
+							'items'    => array( 'type' => 'string' ),
+							'required' => false,
+						),
+					),
+				),
 			),
 		),
 	),
@@ -163,6 +175,8 @@ $assert( 'object' === ( $schema['type'] ?? null ), 'legacy parameter map is wrap
 $assert( array( 'reason' ) === ( $schema['required'] ?? null ), 'property-level required=true is lifted to object-level required array' );
 $assert( ! isset( $schema['properties']['reason']['required'] ), 'required flag is removed from required property schema' );
 $assert( ! isset( $schema['properties']['note']['required'] ), 'required flag is removed from optional property schema' );
+$assert( ! isset( $schema['properties']['policy']['required'] ), 'required flag is removed from nested object property schema' );
+$assert( ! isset( $schema['properties']['policy']['properties']['allow']['required'] ), 'required flag is removed from nested object child property schema' );
 $assert( 'string' === ( $schema['properties']['reason']['type'] ?? null ), 'property schema fields are preserved' );
 
 // --- Empty-prompt fallback ----------------------------------------------------


### PR DESCRIPTION
## Summary
- Recursively normalizes legacy property-level `required` flags in wp-ai-client tool schemas so nested object properties no longer leak `required: false` into strict JSON Schema requests.
- Extends the wp-ai-client tool schema smoke to cover nested optional object properties.

## Testing
- `php tests/wp-ai-client-tool-schema-smoke.php`
- `homeboy lint --path . --extension wordpress --changed-since origin/main --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the strict schema rejection, drafted the recursive normalizer/test update, and ran local smoke/lint checks for Chris to review.