### PR TITLE
Expose in-flight run artifacts to tools

### DIFF
--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -19,10 +19,11 @@ class JobArtifacts {
 	/**
 	 * Build a deterministic artifact payload for a job.
 	 *
-	 * @param int $job_id Job ID.
+	 * @param int   $job_id                    Job ID.
+	 * @param array $additional_tool_summaries Tool summaries accumulated before engine_data persistence.
 	 * @return array{success: bool, artifacts?: array, error?: string}
 	 */
-	public function get( int $job_id ): array {
+	public function get( int $job_id, array $additional_tool_summaries = array() ): array {
 		if ( $job_id <= 0 ) {
 			return array(
 				'success' => false,
@@ -40,7 +41,10 @@ class JobArtifacts {
 
 		$engine_data = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 		$agent       = $this->resolve_agent( $job, $engine_data );
-		$tool_calls  = $this->successful_tool_summaries( $engine_data );
+		$tool_calls  = array_merge(
+			$this->successful_tool_summaries( $engine_data ),
+			$this->successful_tool_summaries_from_list( $additional_tool_summaries )
+		);
 		$payload     = array(
 			'job_id'                 => $job_id,
 			'status'                 => (string) ( $job['status'] ?? '' ),
@@ -84,6 +88,13 @@ class JobArtifacts {
 	 */
 	private function successful_tool_summaries( array $engine_data ): array {
 		$summaries = is_array( $engine_data['tool_execution_summary'] ?? null ) ? $engine_data['tool_execution_summary'] : array();
+		return $this->successful_tool_summaries_from_list( $summaries );
+	}
+
+	/**
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function successful_tool_summaries_from_list( array $summaries ): array {
 		$successes = array();
 
 		foreach ( $summaries as $summary ) {

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -697,7 +697,7 @@ class AIStep extends Step {
 	 * @return array<int, array<string, mixed>>
 	 */
 	private static function summarizeToolExecutions( array $loop_result ): array {
-		$results   = is_array( $loop_result['tool_execution_results'] ?? null ) ? $loop_result['tool_execution_results'] : array();
+		$results = is_array( $loop_result['tool_execution_results'] ?? null ) ? $loop_result['tool_execution_results'] : array();
 		return function_exists( 'DataMachine\Engine\AI\datamachine_summarize_tool_execution_results' )
 			? \DataMachine\Engine\AI\datamachine_summarize_tool_execution_results( $results )
 			: array();

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -698,40 +698,9 @@ class AIStep extends Step {
 	 */
 	private static function summarizeToolExecutions( array $loop_result ): array {
 		$results   = is_array( $loop_result['tool_execution_results'] ?? null ) ? $loop_result['tool_execution_results'] : array();
-		$summaries = array();
-
-		foreach ( $results as $result ) {
-			if ( ! is_array( $result ) ) {
-				continue;
-			}
-
-			$tool_name   = sanitize_key( (string) ( $result['tool_name'] ?? '' ) );
-			$tool_result = is_array( $result['result'] ?? null ) ? $result['result'] : array();
-			$parameters  = is_array( $result['parameters'] ?? null ) ? $result['parameters'] : array();
-			if ( '' === $tool_name ) {
-				continue;
-			}
-
-			$summary = array(
-				'tool_name'  => $tool_name,
-				'success'    => true === ( $tool_result['success'] ?? false ),
-				'turn_count' => isset( $result['turn_count'] ) ? (int) $result['turn_count'] : null,
-				'summary'    => isset( $tool_result['message'] ) ? sanitize_text_field( (string) $tool_result['message'] ) : null,
-			);
-
-			if ( 'agent_daily_memory' === $tool_name ) {
-				$summary['action'] = isset( $parameters['action'] ) ? sanitize_key( (string) $parameters['action'] ) : null;
-				$summary['date']   = isset( $parameters['date'] ) ? sanitize_text_field( (string) $parameters['date'] ) : gmdate( 'Y-m-d' );
-				$summary['mode']   = isset( $parameters['mode'] ) ? sanitize_key( (string) $parameters['mode'] ) : null;
-			}
-
-			$summaries[] = array_filter(
-				$summary,
-				static fn( $value ) => null !== $value && '' !== $value
-			);
-		}
-
-		return $summaries;
+		return function_exists( 'DataMachine\Engine\AI\datamachine_summarize_tool_execution_results' )
+			? \DataMachine\Engine\AI\datamachine_summarize_tool_execution_results( $results )
+			: array();
 	}
 
 	/**

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -20,6 +20,7 @@ use AgentsAPI\AI\WP_Agent_Conversation_Result;
 use AgentsAPI\AI\WP_Agent_Transcript_Persister;
 use AgentsAPI\AI\WP_Agent_Message;
 use AgentsAPI\AI\WP_Agent_Null_Transcript_Persister;
+use DataMachine\Core\JobArtifacts;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
@@ -508,14 +509,16 @@ function datamachine_build_turn_runner(
 				$messages[] = ConversationManager::formatToolCallMessage( $tool_name, $tool_parameters, $turn_count );
 
 				// Execute through DM's ToolExecutor (action policy, post tracking).
+				$tool_payload = datamachine_payload_with_inflight_run_artifacts( $loop_payload, $tool_execution_results );
+
 				$tool_result = ToolExecutor::executeTool(
 					$tool_name,
 					$tool_parameters,
 					$tools,
-					$loop_payload,
+					$tool_payload,
 					$mode,
-					(int) ( $loop_payload['agent_id'] ?? 0 ),
-					is_array( $loop_payload['client_context'] ?? null ) ? $loop_payload['client_context'] : array()
+					(int) ( $tool_payload['agent_id'] ?? 0 ),
+					is_array( $tool_payload['client_context'] ?? null ) ? $tool_payload['client_context'] : array()
 				);
 
 				do_action(
@@ -847,6 +850,78 @@ function datamachine_resolve_transcript_persister( array $payload ): WP_Agent_Tr
 	}
 
 	return new WP_Agent_Null_Transcript_Persister();
+}
+
+/**
+ * Add an in-flight run artifact payload for tools that finalize a run.
+ *
+ * The AI step persists tool summaries after the conversation loop returns. A
+ * PR-creation tool runs inside that same loop, so artifact-aware tools need a
+ * snapshot of successful tool calls that already happened in the current loop.
+ *
+ * @param array $payload                Clean loop payload.
+ * @param array $tool_execution_results Tool execution results accumulated so far.
+ * @return array Payload with run_artifacts when they can be built.
+ */
+function datamachine_payload_with_inflight_run_artifacts( array $payload, array $tool_execution_results ): array {
+	$job_id = (int) ( $payload['job_id'] ?? 0 );
+	if ( $job_id <= 0 || empty( $tool_execution_results ) ) {
+		return $payload;
+	}
+
+	$artifact_result = ( new JobArtifacts() )->get(
+		$job_id,
+		datamachine_summarize_tool_execution_results( $tool_execution_results )
+	);
+	if ( empty( $artifact_result['success'] ) || ! is_array( $artifact_result['artifacts'] ?? null ) ) {
+		return $payload;
+	}
+
+	$payload['run_artifacts'] = $artifact_result['artifacts'];
+	return $payload;
+}
+
+/**
+ * Build a bounded, non-secret summary of in-flight tool calls.
+ *
+ * @param array $tool_execution_results Tool execution results accumulated by the loop.
+ * @return array<int, array<string, mixed>>
+ */
+function datamachine_summarize_tool_execution_results( array $tool_execution_results ): array {
+	$summaries = array();
+
+	foreach ( $tool_execution_results as $result ) {
+		if ( ! is_array( $result ) ) {
+			continue;
+		}
+
+		$tool_name   = sanitize_key( (string) ( $result['tool_name'] ?? '' ) );
+		$tool_result = is_array( $result['result'] ?? null ) ? $result['result'] : array();
+		$parameters  = is_array( $result['parameters'] ?? null ) ? $result['parameters'] : array();
+		if ( '' === $tool_name ) {
+			continue;
+		}
+
+		$summary = array(
+			'tool_name'  => $tool_name,
+			'success'    => true === ( $tool_result['success'] ?? false ),
+			'turn_count' => isset( $result['turn_count'] ) ? (int) $result['turn_count'] : null,
+			'summary'    => isset( $tool_result['message'] ) ? sanitize_text_field( (string) $tool_result['message'] ) : null,
+		);
+
+		if ( 'agent_daily_memory' === $tool_name ) {
+			$summary['action'] = isset( $parameters['action'] ) ? sanitize_key( (string) $parameters['action'] ) : null;
+			$summary['date']   = isset( $parameters['date'] ) ? sanitize_text_field( (string) $parameters['date'] ) : gmdate( 'Y-m-d' );
+			$summary['mode']   = isset( $parameters['mode'] ) ? sanitize_key( (string) $parameters['mode'] ) : null;
+		}
+
+		$summaries[] = array_filter(
+			$summary,
+			static fn( $value ) => null !== $value && '' !== $value
+		);
+	}
+
+	return $summaries;
 }
 
 /**

--- a/tests/job-artifacts-daily-memory-smoke.php
+++ b/tests/job-artifacts-daily-memory-smoke.php
@@ -53,6 +53,18 @@ $assert(
 );
 
 $assert(
+	false !== strpos( $job_artifacts, 'additional_tool_summaries' )
+		&& false !== strpos( $job_artifacts, 'successful_tool_summaries_from_list' ),
+	'job artifact builder accepts in-flight tool summaries before engine_data persistence'
+);
+
+$assert(
+	false !== strpos( $loop, 'datamachine_payload_with_inflight_run_artifacts' )
+		&& false !== strpos( $loop, 'datamachine_summarize_tool_execution_results' ),
+	'conversation loop passes in-flight run artifacts to artifact-aware tools'
+);
+
+$assert(
 	false !== strpos( $job_artifacts, "'type'                 => 'agent_daily_memory'" )
 		&& false !== strpos( $job_artifacts, "memory/agent/daily/%s/%s/%s.md" )
 		&& false !== strpos( $job_artifacts, "'content'              =>" ),


### PR DESCRIPTION
## Summary
- Build run artifact payloads from successful tool calls already completed in the current conversation loop.
- Let artifact-aware tools, such as direct PR creation, see daily-memory writes before the AI step persists final engine data.
- Share the tool execution summarizer between the AI step persistence path and in-flight artifact payload path.

## Why
World Creator PR #30 showed completion evidence but no journal content because `create_github_pull_request` ran before `AIStep` persisted `tool_execution_summary` into job engine data. The PR tool needs an in-flight artifact snapshot, not only the after-the-loop persisted state.

## Testing
- `php -l inc/Core/JobArtifacts.php && php -l inc/Engine/AI/conversation-loop.php && php -l inc/Core/Steps/AI/AIStep.php && php -l tests/job-artifacts-daily-memory-smoke.php`
- `php tests/job-artifacts-daily-memory-smoke.php`
- `homeboy lint --changed-since origin/main` (reported no changed files before commit; no findings)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the World Creator artifact timing gap, drafted the Data Machine in-flight artifact fix, and ran targeted smoke checks.