### PR TITLE
Require canonical AI tool schemas

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -759,7 +759,7 @@ class RequestBuilder {
 	}
 
 	/**
-	 * Normalize Data Machine's tool parameter map into a JSON Schema object.
+	 * Return the canonical JSON Schema object for tool parameters.
 	 *
 	 * @param mixed $parameters Raw parameters definition.
 	 * @return array<string, mixed>|null
@@ -769,54 +769,6 @@ class RequestBuilder {
 			return null;
 		}
 
-		$schema = $parameters;
-		if ( ! isset( $schema['type'] ) && ! isset( $schema['properties'] ) && ! isset( $schema['$ref'] ) ) {
-			$schema = array(
-				'type'       => 'object',
-				'properties' => $schema,
-			);
-		}
-
-		return self::normalizeRequiredFlags( $schema );
-	}
-
-	/**
-	 * Convert property-level required flags to JSON Schema object-level required list.
-	 *
-	 * @param array<string, mixed> $schema JSON schema.
-	 * @return array<string, mixed>
-	 */
-	private static function normalizeRequiredFlags( array $schema ): array {
-		if ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
-			$schema['items'] = self::normalizeRequiredFlags( $schema['items'] );
-		}
-
-		if ( empty( $schema['properties'] ) || ! is_array( $schema['properties'] ) ) {
-			return $schema;
-		}
-
-		$required = isset( $schema['required'] ) && is_array( $schema['required'] ) ? $schema['required'] : array();
-
-		foreach ( $schema['properties'] as $property_name => $property_schema ) {
-			if ( ! is_array( $property_schema ) ) {
-				continue;
-			}
-
-			if ( true === ( $property_schema['required'] ?? null ) ) {
-				$required[] = (string) $property_name;
-			}
-
-			unset( $property_schema['required'] );
-			$schema['properties'][ $property_name ] = self::normalizeRequiredFlags( $property_schema );
-		}
-
-		$required = array_values( array_unique( array_filter( $required, 'is_string' ) ) );
-		if ( ! empty( $required ) ) {
-			$schema['required'] = $required;
-		} else {
-			unset( $schema['required'] );
-		}
-
-		return $schema;
+		return $parameters;
 	}
 }

--- a/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
@@ -250,46 +250,42 @@ class AgentDailyMemory extends BaseTool {
 			'description'     => 'Manage daily memory journal entries (daily/YYYY/MM/DD.md). Use for session activity, temporal events, and work logs. Use "write" to record today\'s session notes (defaults to append mode). Use "read" to review a specific day. Use "search" to find past entries by keyword. Use "list" to see which days have entries. Daily memory captures WHAT HAPPENED — persistent knowledge belongs in agent_memory (MEMORY.md) instead.',
 			'requires_config' => false,
 			'parameters'      => array(
-				'user_id' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id' => array(
 					'type'        => 'integer',
-					'required'    => false,
 					'description' => 'Optional WordPress user ID for layered memory context. Defaults to current user context.',
 				),
-				'action'  => array(
+					'action'  => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Action to perform: "read" (get daily file), "write" (add to daily file), "list" (show all daily files), or "search" (find entries by keyword).',
 				),
-				'date'    => array(
+					'date'    => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Date in YYYY-MM-DD format. Defaults to today. Used by "read" and "write".',
 				),
-				'content' => array(
+					'content' => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Content to write. Required for "write" action. Use markdown format with ### headings for session sections.',
 				),
-				'mode'    => array(
+					'mode'    => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Write mode: "append" adds to end of file (default), "write" replaces the entire file. Prefer "append" to preserve earlier entries from the same day.',
 				),
-				'query'   => array(
+					'query'   => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Search term for "search" action. Case-insensitive substring match across all daily files.',
 				),
-				'from'    => array(
+					'from'    => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Start date (YYYY-MM-DD) for "search" action. Omit for no lower bound.',
 				),
-				'to'      => array(
+					'to'      => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'End date (YYYY-MM-DD) for "search" action. Omit for no upper bound.',
 				),
+				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/AgentMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentMemory.php
@@ -211,36 +211,34 @@ class AgentMemory extends BaseTool {
 			'description'     => 'Manage persistent agent files with section-level operations. Works on any agent file: MEMORY.md (default), SOUL.md, USER.md, etc. Stored as markdown with ## section headers. Use "list_sections" to see what exists, "get" to read content, and "update" to write. Use "append" mode to add new information without losing existing content. Use "set" mode to replace a section entirely. For session activity and temporal events, use agent_daily_memory instead.',
 			'requires_config' => false,
 			'parameters'      => array(
-				'user_id' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id' => array(
 					'type'        => 'integer',
-					'required'    => false,
 					'description' => 'Optional WordPress user ID for layered memory context. Defaults to current user context.',
 				),
-				'action'  => array(
+					'action'  => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Action to perform: "get" (read file/section), "update" (write to section), or "list_sections" (show all section headers).',
 				),
-				'file'    => array(
+					'file'    => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Target file. Defaults to MEMORY.md. Use SOUL.md, USER.md, SITE.md, etc. for other agent files.',
 				),
-				'section' => array(
+					'section' => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Section name without "##" prefix. Required for "update". Optional for "get" (omit to read full file).',
 				),
-				'content' => array(
+					'content' => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Content to write. Required for "update" action.',
 				),
-				'mode'    => array(
+					'mode'    => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Write mode for "update": "set" replaces section content (default), "append" adds to end of section.',
 				),
+				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/AmazonAffiliateLink.php
+++ b/inc/Engine/AI/Tools/Global/AmazonAffiliateLink.php
@@ -276,11 +276,14 @@ class AmazonAffiliateLink extends BaseTool {
 			'description'     => 'Search Amazon products and return an affiliate link with the product title, URL, and thumbnail. Use when content mentions a specific product the reader might want to buy. Only use for genuinely relevant product references — not every noun.',
 			'requires_config' => true,
 			'parameters'      => array(
-				'query' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'query' => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Product search query (e.g., "Lodge cast iron Dutch oven", "KitchenAid stand mixer"). Be specific for best results.',
 				),
+				),
+				'required'   => array( 'query' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/BingWebmaster.php
+++ b/inc/Engine/AI/Tools/Global/BingWebmaster.php
@@ -71,21 +71,22 @@ class BingWebmaster extends BaseTool {
 			'description'     => 'Fetch search analytics data from Bing Webmaster Tools. Returns query performance stats, traffic rankings, page-level stats, or crawl information for the configured site. Use to analyze search visibility, top queries, and crawl health on Bing.',
 			'requires_config' => true,
 			'parameters'      => array(
-				'action'   => array(
+				'type'       => 'object',
+				'properties' => array(
+					'action'   => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Analytics action to perform: query_stats (search query performance), traffic_stats (rank and traffic data), page_stats (per-page metrics), crawl_stats (crawl information).',
 				),
-				'site_url' => array(
+					'site_url' => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Site URL to query. Defaults to the configured site URL.',
 				),
-				'limit'    => array(
+					'limit'    => array(
 					'type'        => 'integer',
-					'required'    => false,
 					'description' => 'Maximum number of results to return (default: 20).',
 				),
+				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
+++ b/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
@@ -72,56 +72,50 @@ class GoogleAnalytics extends BaseTool {
 			'description'     => 'Fetch visitor analytics from Google Analytics (GA4). Get page performance metrics, traffic sources, daily trends, real-time active users, top events, user demographics, landing pages, engagement metrics, and new-vs-returning user breakdown. Supports sorting, hostname filtering for multisite, and period-over-period comparison.',
 			'requires_config' => true,
 			'parameters'      => array(
-				'action'      => array(
+				'type'       => 'object',
+				'properties' => array(
+					'action'      => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Action to perform: page_stats (per-page views, sessions, bounce rate), traffic_sources (where visitors come from), date_stats (daily trends over time), realtime (active users right now), top_events (most triggered events), user_demographics (visitor country and device breakdown), landing_pages (entry pages with session metrics), engagement (engagement rate, session quality, pages/session), new_vs_returning (new vs returning user comparison).',
 				),
-				'property_id' => array(
+					'property_id' => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'GA4 property ID (numeric). Defaults to the configured property ID.',
 				),
-				'start_date'  => array(
+					'start_date'  => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Start date in YYYY-MM-DD format (defaults to 28 days ago). Not used for realtime action.',
 				),
-				'end_date'    => array(
+					'end_date'    => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'End date in YYYY-MM-DD format (defaults to yesterday). Not used for realtime action.',
 				),
-				'limit'       => array(
+					'limit'       => array(
 					'type'        => 'integer',
-					'required'    => false,
 					'description' => 'Row limit (default: 25, max: 10000).',
 				),
-				'page_filter' => array(
+					'page_filter' => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Filter results to pages with paths containing this string.',
 				),
-				'hostname'    => array(
+					'hostname'    => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Filter to pages on this hostname (for multisite GA4 properties).',
 				),
-				'sort_by'     => array(
+					'sort_by'     => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Sort results by this metric or dimension field name (e.g. bounceRate, sessions, engagementRate).',
 				),
-				'order'       => array(
+					'order'       => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Sort direction: asc or desc (default: desc).',
 				),
-				'compare'     => array(
+					'compare'     => array(
 					'type'        => 'boolean',
-					'required'    => false,
 					'description' => 'Compare against the previous period of equal length. Adds delta percentage columns.',
 				),
+				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/GoogleSearch.php
+++ b/inc/Engine/AI/Tools/Global/GoogleSearch.php
@@ -143,16 +143,18 @@ class GoogleSearch extends BaseTool {
 			'description'     => 'Search the web using Google Custom Search and return 1-10 structured JSON results with titles, links, and snippets. Best for discovering external information when you don\'t have specific URLs. Use for current events, factual verification, or broad topic research. Returns complete web search data in JSON format with title, link, snippet for each result.',
 			'requires_config' => true,
 			'parameters'      => array(
-				'query'         => array(
+				'type'       => 'object',
+				'properties' => array(
+					'query'         => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Search query for external web information. Returns JSON with "results" array containing web search results.',
 				),
-				'site_restrict' => array(
+					'site_restrict' => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Restrict search to specific domain (e.g., "wikipedia.org" for Wikipedia only)',
 				),
+				),
+				'required'   => array( 'query' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/GoogleSearchConsole.php
+++ b/inc/Engine/AI/Tools/Global/GoogleSearchConsole.php
@@ -71,51 +71,46 @@ class GoogleSearchConsole extends BaseTool {
 			'description'     => 'Interact with Google Search Console. Fetch search analytics (query stats, page metrics, daily trends), inspect URLs for index status and mobile usability, and manage sitemaps (list, get details, submit).',
 			'requires_config' => true,
 			'parameters'      => array(
-				'action'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'action'       => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Action to perform: query_stats (top search queries), page_stats (per-page metrics), query_page_stats (query+page combos), date_stats (daily trends), inspect_url (check index/crawl status for a URL), list_sitemaps (list all submitted sitemaps), get_sitemap (details for one sitemap), submit_sitemap (submit a sitemap to Google).',
 				),
-				'url'          => array(
+					'url'          => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Full URL to inspect. Required for inspect_url action.',
 				),
-				'sitemap_url'  => array(
+					'sitemap_url'  => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Sitemap URL. Required for get_sitemap and submit_sitemap actions.',
 				),
-				'site_url'     => array(
+					'site_url'     => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Site URL (sc-domain: or https://). Defaults to the configured site URL.',
 				),
-				'start_date'   => array(
+					'start_date'   => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Start date in YYYY-MM-DD format (defaults to 28 days ago).',
 				),
-				'end_date'     => array(
+					'end_date'     => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'End date in YYYY-MM-DD format (defaults to 3 days ago for final data).',
 				),
-				'limit'        => array(
+					'limit'        => array(
 					'type'        => 'integer',
-					'required'    => false,
 					'description' => 'Row limit (default: 25, max: 25000).',
 				),
-				'url_filter'   => array(
+					'url_filter'   => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Filter results to URLs containing this string.',
 				),
-				'query_filter' => array(
+					'query_filter' => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Filter results to queries containing this string.',
 				),
+				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/ImageGeneration.php
+++ b/inc/Engine/AI/Tools/Global/ImageGeneration.php
@@ -92,26 +92,26 @@ class ImageGeneration extends BaseTool {
 			'description'     => 'Generate images using wp-ai-client image models. Returns a pending image-generation job that will sideload the generated image and optionally set it as featured media. Use descriptive, detailed prompts for best results. Default aspect ratio is 3:4 (portrait, ideal for Pinterest and blog featured images).',
 			'requires_config' => true,
 			'parameters'      => array(
-				'prompt'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'prompt'       => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Detailed image generation prompt describing the desired image. Be specific about style, composition, lighting, and subject.',
 				),
-				'model'        => array(
+					'model'        => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'wp-ai-client model identifier. Defaults to the image generation tool configuration.',
 				),
-				'provider'     => array(
+					'provider'     => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'wp-ai-client provider identifier. Defaults to the image generation tool configuration.',
 				),
-				'aspect_ratio' => array(
+					'aspect_ratio' => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Image aspect ratio. Options: 1:1, 3:4, 4:3, 9:16, 16:9. Default: 3:4 (portrait).',
 				),
+				),
+				'required'   => array( 'prompt' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/InternalLinkAudit.php
+++ b/inc/Engine/AI/Tools/Global/InternalLinkAudit.php
@@ -94,49 +94,45 @@ class InternalLinkAudit extends BaseTool {
 			'description'     => 'Audit links on this WordPress site. Four actions: "audit" scans post content to build a link graph (cached 24hr), "orphans" lists posts with zero inbound links, "backlinks" gets all posts linking to a given post_id, "broken" performs HTTP HEAD checks for broken URLs (expensive, supports internal/external/all scope). Always run "audit" first, then use other actions for specific checks.',
 			'requires_config' => false,
 			'parameters'      => array(
-				'action'    => array(
+				'type'       => 'object',
+				'properties' => array(
+					'action'    => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Action to perform: "audit" (scan + cache link graph), "orphans" (list orphaned posts), "backlinks" (get posts linking to a given post_id), or "broken" (HTTP check for broken links).',
 					'enum'        => array( 'audit', 'orphans', 'backlinks', 'broken' ),
 				),
-				'post_id'   => array(
+					'post_id'   => array(
 					'type'        => 'integer',
-					'required'    => false,
 					'description' => 'Post ID to get backlinks for (backlinks action only).',
 				),
-				'post_type' => array(
+					'post_type' => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Post type to audit (default: "post").',
 				),
-				'category'  => array(
+					'category'  => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Category slug to limit audit scope (audit action only).',
 				),
-				'force'     => array(
+					'force'     => array(
 					'type'        => 'boolean',
-					'required'    => false,
 					'description' => 'Force rebuild even if cached graph exists (audit action only).',
 				),
-				'scope'     => array(
+					'scope'     => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Link scope for broken action: "internal" (default), "external", or "all".',
 					'enum'        => array( 'internal', 'external', 'all' ),
 				),
-				'limit'     => array(
+					'limit'     => array(
 					'type'        => 'integer',
-					'required'    => false,
 					'description' => 'Maximum results to return. For orphans: max posts (default 50). For broken: max URLs to check (default 200).',
 				),
-				'types'     => array(
+					'types'     => array(
 					'type'        => 'array',
-					'required'    => false,
 					'description' => 'Optional edge types to include (e.g. ["html_anchor"], ["wikilink"]). Omit for all registered types.',
 					'items'       => array( 'type' => 'string' ),
 				),
+				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/LocalSearch.php
+++ b/inc/Engine/AI/Tools/Global/LocalSearch.php
@@ -70,22 +70,23 @@ class LocalSearch extends BaseTool {
 			'description'     => 'Search this WordPress site for posts by title or content. Returns up to 10 results with titles, excerpts, permalinks, and metadata. Automatically tries multiple search strategies (standard search, title matching, split queries) if initial search returns no results. For best results, search for ONE item at a time. Use title_only=true for precise title matching.',
 			'requires_config' => false,
 			'parameters'      => array(
-				'query'      => array(
+				'type'       => 'object',
+				'properties' => array(
+					'query'      => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Search terms to find relevant posts. For best results, use simple queries for one item at a time rather than multiple comma-separated items.',
 				),
-				'post_types' => array(
+					'post_types' => array(
 					'type'        => 'array',
-					'required'    => false,
 					'description' => 'Post types to search (default: ["post", "page"]). Use ["datamachine_events"] for events.',
 					'items'       => array( 'type' => 'string' ),
 				),
-				'title_only' => array(
+					'title_only' => array(
 					'type'        => 'boolean',
-					'required'    => false,
 					'description' => 'Search only post titles instead of full content (default: false). Use for precise title matching when you know the exact or partial title.',
 				),
+				),
+				'required'   => array( 'query' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/PageSpeed.php
+++ b/inc/Engine/AI/Tools/Global/PageSpeed.php
@@ -72,21 +72,22 @@ class PageSpeed extends BaseTool {
 			'description'     => 'Run Google PageSpeed Insights (Lighthouse) audits on any URL. Get performance scores, Core Web Vitals (LCP, CLS, INP, FCP, TTFB), accessibility and SEO scores, and actionable optimization opportunities with estimated savings. Use to audit page speed, monitor site health, and identify performance improvements.',
 			'requires_config' => false,
 			'parameters'      => array(
-				'action'   => array(
+				'type'       => 'object',
+				'properties' => array(
+					'action'   => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Action to perform: analyze (full Lighthouse audit with all category scores and key metrics), performance (focused Core Web Vitals and performance metrics), opportunities (optimization suggestions sorted by estimated savings).',
 				),
-				'url'      => array(
+					'url'      => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'URL to analyze. Defaults to the WordPress site home URL.',
 				),
-				'strategy' => array(
+					'strategy' => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Device strategy: mobile (default) or desktop.',
 				),
+				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/QueueValidator.php
+++ b/inc/Engine/AI/Tools/Global/QueueValidator.php
@@ -345,31 +345,30 @@ class QueueValidator extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Check if a topic already exists as a published post or in a Data Machine queue before generating content. Returns "clear" if no duplicates found, or "duplicate" with match details (title, similarity score, source). Always use this before adding topics to the queue or starting content generation to avoid duplicate work.',
 			'parameters'  => array(
-				'topic'                => array(
+				'type'       => 'object',
+				'properties' => array(
+					'topic'                => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Topic or title to validate against existing content and queue items.',
 				),
-				'post_type'            => array(
+					'post_type'            => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'WordPress post type to check against (default: "post"). Use "recipe" for recipe validation, or any registered custom post type.',
 				),
-				'flow_id'              => array(
+					'flow_id'              => array(
 					'type'        => 'integer',
-					'required'    => false,
 					'description' => 'Data Machine flow ID to check queue against. Required together with flow_step_id to enable queue checking.',
 				),
-				'flow_step_id'         => array(
+					'flow_step_id'         => array(
 					'type'        => 'string',
-					'required'    => false,
 					'description' => 'Flow step ID to check queue against. Required together with flow_id to enable queue checking.',
 				),
-				'similarity_threshold' => array(
+					'similarity_threshold' => array(
 					'type'        => 'number',
-					'required'    => false,
 					'description' => 'Jaccard similarity threshold between 0.0 and 1.0 (default: 0.65). Lower values catch more potential duplicates.',
 				),
+				),
+				'required'   => array( 'topic' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/WebFetch.php
+++ b/inc/Engine/AI/Tools/Global/WebFetch.php
@@ -104,11 +104,14 @@ class WebFetch extends BaseTool {
 			'description'     => 'Fetch and extract readable content from any HTTP/HTTPS web page URL (50K character limit). Use when you have a specific URL to retrieve full article content. Automatically converts HTML to readable text. Best for single-page content analysis after discovery via Google Search.',
 			'requires_config' => false,
 			'parameters'      => array(
-				'url' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'url' => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'Full HTTP/HTTPS URL to fetch content from. Must be a valid web address.',
 				),
+				),
+				'required'   => array( 'url' ),
 			),
 		);
 	}

--- a/inc/Engine/AI/Tools/Global/WordPressPostReader.php
+++ b/inc/Engine/AI/Tools/Global/WordPressPostReader.php
@@ -106,16 +106,18 @@ class WordPressPostReader extends BaseTool {
 			'description'     => 'Read full content and metadata from a specific WordPress post by permalink URL. Use after Local Search when you need complete post content instead of excerpts. Accepts standard WordPress permalinks (e.g., /post-slug/) or shortlinks (?p=123). Does NOT accept REST API URLs (/wp-json/...). Essential for content analysis before WordPress Update operations.',
 			'requires_config' => false,
 			'parameters'      => array(
-				'source_url'   => array(
+				'type'       => 'object',
+				'properties' => array(
+					'source_url'   => array(
 					'type'        => 'string',
-					'required'    => true,
 					'description' => 'WordPress permalink URL (e.g., https://site.com/post-slug/ or https://site.com/?p=123). Do not use REST API URLs.',
 				),
-				'include_meta' => array(
+					'include_meta' => array(
 					'type'        => 'boolean',
-					'required'    => false,
 					'description' => 'Include custom fields in response (default: false)',
 				),
+				),
+				'required'   => array( 'source_url' ),
 			),
 		);
 	}

--- a/tests/Unit/Engine/AI/Tools/Global/BingWebmasterTest.php
+++ b/tests/Unit/Engine/AI/Tools/Global/BingWebmasterTest.php
@@ -41,12 +41,11 @@ class BingWebmasterTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'description', $def );
 		$this->assertArrayHasKey( 'parameters', $def );
 		$this->assertTrue( $def['requires_config'] );
-		$this->assertArrayHasKey( 'action', $def['parameters'] );
-		$this->assertTrue( $def['parameters']['action']['required'] );
-		$this->assertArrayHasKey( 'site_url', $def['parameters'] );
-		$this->assertFalse( $def['parameters']['site_url']['required'] );
-		$this->assertArrayHasKey( 'limit', $def['parameters'] );
-		$this->assertFalse( $def['parameters']['limit']['required'] );
+		$this->assertSame( 'object', $def['parameters']['type'] );
+		$this->assertSame( array( 'action' ), $def['parameters']['required'] );
+		$this->assertArrayHasKey( 'action', $def['parameters']['properties'] );
+		$this->assertArrayHasKey( 'site_url', $def['parameters']['properties'] );
+		$this->assertArrayHasKey( 'limit', $def['parameters']['properties'] );
 	}
 
 	/**

--- a/tests/Unit/Engine/AI/Tools/Global/QueueValidatorTest.php
+++ b/tests/Unit/Engine/AI/Tools/Global/QueueValidatorTest.php
@@ -177,8 +177,9 @@ class QueueValidatorTest extends WP_UnitTestCase {
 		$this->assertSame( 'handle_tool_call', $def['method'] );
 		$this->assertArrayHasKey( 'description', $def );
 		$this->assertArrayHasKey( 'parameters', $def );
-		$this->assertArrayHasKey( 'topic', $def['parameters'] );
-		$this->assertTrue( $def['parameters']['topic']['required'] );
+		$this->assertSame( 'object', $def['parameters']['type'] );
+		$this->assertSame( array( 'topic' ), $def['parameters']['required'] );
+		$this->assertArrayHasKey( 'topic', $def['parameters']['properties'] );
 		$this->assertArrayNotHasKey( 'requires_config', $def );
 	}
 }

--- a/tests/global-tool-array-items-smoke.php
+++ b/tests/global-tool-array-items-smoke.php
@@ -54,6 +54,44 @@ $tool_files = glob( $tools_dir . '/*.php' ) ?: array();
 $schemas_checked = 0;
 $array_params_checked = 0;
 
+$assert_schema_shape = function ( array $schema, string $path ) use ( &$assert, &$assert_schema_shape, &$array_params_checked ): void {
+	if ( array_key_exists( 'required', $schema ) ) {
+		$assert(
+			is_array( $schema['required'] ),
+			"{$path}: required is an object-level JSON Schema array"
+		);
+	}
+
+	if ( 'array' === ( $schema['type'] ?? null ) ) {
+		++$array_params_checked;
+		$assert(
+			isset( $schema['items'] ) && is_array( $schema['items'] ),
+			"{$path}: array schema declares 'items' (JSON Schema requirement; OpenAI strict mode rejects without)"
+		);
+
+		if ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
+			$assert(
+				isset( $schema['items']['type'] ),
+				"{$path}.items: items declares a 'type'"
+			);
+			$assert_schema_shape( $schema['items'], "{$path}.items" );
+		}
+	}
+
+	foreach ( $schema['properties'] ?? array() as $property_name => $property_schema ) {
+		if ( ! is_array( $property_schema ) ) {
+			$assert( false, "{$path}.properties.{$property_name}: property schema is not an array" );
+			continue;
+		}
+
+		$assert(
+			! array_key_exists( 'required', $property_schema ) || is_array( $property_schema['required'] ),
+			"{$path}.properties.{$property_name}: does not use property-level required flags"
+		);
+		$assert_schema_shape( $property_schema, "{$path}.properties.{$property_name}" );
+	}
+};
+
 foreach ( $tool_files as $file ) {
 	require_once $file;
 
@@ -86,36 +124,9 @@ foreach ( $tool_files as $file ) {
 	}
 
 	++$schemas_checked;
-
-	foreach ( $definition['parameters'] as $param_name => $param_schema ) {
-		if ( ! is_array( $param_schema ) ) {
-			$assert(
-				false,
-				"{$class_short}.{$param_name}: parameter schema is not an array"
-			);
-			continue;
-		}
-
-		$type = $param_schema['type'] ?? null;
-
-		if ( 'array' !== $type ) {
-			continue;
-		}
-
-		++$array_params_checked;
-
-		$assert(
-			isset( $param_schema['items'] ) && is_array( $param_schema['items'] ),
-			"{$class_short}.{$param_name}: array-typed parameter declares 'items' (JSON Schema requirement; OpenAI strict mode rejects without)"
-		);
-
-		if ( isset( $param_schema['items'] ) && is_array( $param_schema['items'] ) ) {
-			$assert(
-				isset( $param_schema['items']['type'] ),
-				"{$class_short}.{$param_name}.items: items declares a 'type'"
-			);
-		}
-	}
+	$assert( 'object' === ( $definition['parameters']['type'] ?? null ), "{$class_short}: parameters is a canonical object schema" );
+	$assert( isset( $definition['parameters']['properties'] ) && is_array( $definition['parameters']['properties'] ), "{$class_short}: parameters declares properties" );
+	$assert_schema_shape( $definition['parameters'], $class_short . '.parameters' );
 }
 
 $assert(

--- a/tests/wp-ai-client-tool-schema-smoke.php
+++ b/tests/wp-ai-client-tool-schema-smoke.php
@@ -130,26 +130,26 @@ $response = \DataMachine\Engine\AI\RequestBuilder::build(
 			'name'        => 'client/test_tool',
 			'description' => 'Test tool.',
 			'parameters'  => array(
-				'reason' => array(
-					'type'        => 'string',
-					'description' => 'Skip reason.',
-					'required'    => true,
-				),
-				'note'   => array(
-					'type'     => 'string',
-					'required' => false,
-				),
-				'policy' => array(
-					'type'       => 'object',
-					'required'   => false,
-					'properties' => array(
-						'allow' => array(
-							'type'     => 'array',
-							'items'    => array( 'type' => 'string' ),
-							'required' => false,
+				'type'       => 'object',
+				'properties' => array(
+					'reason' => array(
+						'type'        => 'string',
+						'description' => 'Skip reason.',
+					),
+					'note'   => array(
+						'type' => 'string',
+					),
+					'policy' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'allow' => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'string' ),
+							),
 						),
 					),
 				),
+				'required'   => array( 'reason' ),
 			),
 		),
 	),
@@ -170,13 +170,9 @@ $assert( 7 === $response->getTokenUsage()->getTotalTokens(), 'token usage is rea
 $assert( 'Describe this file.' === ( $captured_request['prompt'] ?? null ), 'latest user message becomes the wp-ai-client prompt' );
 $assert( 'System directive.' === ( $captured_request['messages'][0]['content'] ?? null ), 'system instruction reaches wp-ai-client builder' );
 $assert( 'Run tool.' === ( $captured_request['messages'][1]['content'] ?? null ), 'earlier user message remains wp-ai-client history' );
-$assert( is_array( $schema ), 'legacy parameter map normalizes to a schema array' );
-$assert( 'object' === ( $schema['type'] ?? null ), 'legacy parameter map is wrapped as an object schema' );
-$assert( array( 'reason' ) === ( $schema['required'] ?? null ), 'property-level required=true is lifted to object-level required array' );
-$assert( ! isset( $schema['properties']['reason']['required'] ), 'required flag is removed from required property schema' );
-$assert( ! isset( $schema['properties']['note']['required'] ), 'required flag is removed from optional property schema' );
-$assert( ! isset( $schema['properties']['policy']['required'] ), 'required flag is removed from nested object property schema' );
-$assert( ! isset( $schema['properties']['policy']['properties']['allow']['required'] ), 'required flag is removed from nested object child property schema' );
+$assert( is_array( $schema ), 'canonical parameter schema reaches wp-ai-client as an array' );
+$assert( 'object' === ( $schema['type'] ?? null ), 'canonical parameter schema remains an object schema' );
+$assert( array( 'reason' ) === ( $schema['required'] ?? null ), 'canonical object-level required array is preserved' );
 $assert( 'string' === ( $schema['properties']['reason']['type'] ?? null ), 'property schema fields are preserved' );
 
 // --- Empty-prompt fallback ----------------------------------------------------


### PR DESCRIPTION
## Summary
- Removes request-time conversion from Data Machine's old property-level `required` tool schema convention.
- Migrates built-in global AI tools to canonical JSON Schema objects with object-level `required` arrays.
- Extends schema smoke coverage to reject property-level `required` flags in global tool schemas.

## Testing
- `php tests/wp-ai-client-tool-schema-smoke.php`
- `php tests/global-tool-array-items-smoke.php`
- `homeboy lint --path . --extension wordpress --changed-since origin/main --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited the active AI tool schema path, migrated built-in tool schemas, removed the compatibility normalization, and ran targeted checks for Chris to review.