### PR TITLE
Match prerequisite tool parameters

### DIFF
--- a/inc/Engine/AI/DataMachineToolRuntimeRules.php
+++ b/inc/Engine/AI/DataMachineToolRuntimeRules.php
@@ -140,8 +140,9 @@ class DataMachineToolRuntimeRules {
 		}
 
 		$required_tools = (array) $rule['require_prior_tool'];
+		$required_parameters = is_array( $rule['require_prior_tool_parameters'] ?? null ) ? $rule['require_prior_tool_parameters'] : array();
 		foreach ( $required_tools as $required_tool ) {
-			if ( $this->lastToolCallIndex( $messages, (string) $required_tool ) >= 0 ) {
+			if ( $this->lastToolCallIndex( $messages, (string) $required_tool, is_array( $required_parameters[ $required_tool ] ?? null ) ? $required_parameters[ $required_tool ] : array() ) >= 0 ) {
 				return array(
 					'allowed' => true,
 					'error'   => '',
@@ -161,10 +162,11 @@ class DataMachineToolRuntimeRules {
 			'allowed' => false,
 			'error'   => $error,
 			'context' => array(
-				'rule_id'            => (string) $rule['id'],
-				'before_tool'        => $before_tool,
-				'require_prior_tool' => $required_tools,
-				'rejected_tool'      => $tool_name,
+				'rule_id'                       => (string) $rule['id'],
+				'before_tool'                   => $before_tool,
+				'require_prior_tool'            => $required_tools,
+				'require_prior_tool_parameters' => $required_parameters,
+				'rejected_tool'                 => $tool_name,
 			),
 		);
 	}
@@ -181,17 +183,19 @@ class DataMachineToolRuntimeRules {
 
 			$type = $this->sanitizeRuleType( $rule['type'] ?? '' );
 			if ( 'require_prior_tool' === $type ) {
-				$before_tool        = $this->sanitizeToolName( $rule['before_tool'] ?? '' );
-				$require_prior_tool = $this->sanitizeToolList( $rule['require_prior_tool'] ?? $rule['require_prior_tools'] ?? array() );
+				$before_tool                   = $this->sanitizeToolName( $rule['before_tool'] ?? '' );
+				$require_prior_tool            = $this->sanitizeToolList( $rule['require_prior_tool'] ?? $rule['require_prior_tools'] ?? array() );
+				$require_prior_tool_parameters = $this->sanitizeToolParameterConditions( $rule['require_prior_tool_parameters'] ?? array(), $require_prior_tool );
 				if ( '' === $before_tool || empty( $require_prior_tool ) ) {
 					continue;
 				}
 
 				$normalized[] = array(
-					'id'                 => $this->sanitizeRuleId( $rule['id'] ?? 'tool-runtime-rule-' . $index ),
-					'type'               => 'require_prior_tool',
-					'before_tool'        => $before_tool,
-					'require_prior_tool' => $require_prior_tool,
+					'id'                              => $this->sanitizeRuleId( $rule['id'] ?? 'tool-runtime-rule-' . $index ),
+					'type'                            => 'require_prior_tool',
+					'before_tool'                     => $before_tool,
+					'require_prior_tool'              => $require_prior_tool,
+					'require_prior_tool_parameters'   => $require_prior_tool_parameters,
 				);
 				continue;
 			}
@@ -220,10 +224,10 @@ class DataMachineToolRuntimeRules {
 	/**
 	 * @param array<int,array<string,mixed>> $messages Conversation messages.
 	 */
-	private function lastToolCallIndex( array $messages, string $tool_name ): int {
+	private function lastToolCallIndex( array $messages, string $tool_name, array $parameter_conditions = array() ): int {
 		for ( $i = count( $messages ) - 1; $i >= 0; $i-- ) {
 			$call = $this->toolCallFromMessage( $messages[ $i ] );
-			if ( $call && $call['tool_name'] === $tool_name ) {
+			if ( $call && $call['tool_name'] === $tool_name && $this->toolCallMatchesParameters( $call, $parameter_conditions ) ) {
 				return $i;
 			}
 		}
@@ -266,7 +270,7 @@ class DataMachineToolRuntimeRules {
 
 	/**
 	 * @param array<string,mixed> $message Conversation message.
-	 * @return array{tool_name:string}|null
+	 * @return array{tool_name:string,parameters:array<string,mixed>}|null
 	 */
 	private function toolCallFromMessage( array $message ): ?array {
 		$envelope = WP_Agent_Message::normalize( $message );
@@ -279,7 +283,31 @@ class DataMachineToolRuntimeRules {
 			return null;
 		}
 
-		return array( 'tool_name' => $tool_name );
+		$parameters = $envelope['payload']['parameters'] ?? array();
+
+		return array(
+			'tool_name'  => $tool_name,
+			'parameters' => is_array( $parameters ) ? $parameters : array(),
+		);
+	}
+
+	/**
+	 * @param array{tool_name:string,parameters:array<string,mixed>} $call Tool call.
+	 * @param array<string,mixed>                                    $conditions Parameter conditions.
+	 */
+	private function toolCallMatchesParameters( array $call, array $conditions ): bool {
+		if ( empty( $conditions ) ) {
+			return true;
+		}
+
+		$parameters = is_array( $call['parameters'] ?? null ) ? $call['parameters'] : array();
+		foreach ( $conditions as $key => $expected ) {
+			if ( ! array_key_exists( $key, $parameters ) || $parameters[ $key ] !== $expected ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	private function sanitizeRuleId( $value ): string {
@@ -290,6 +318,37 @@ class DataMachineToolRuntimeRules {
 	private function sanitizeRuleType( $value ): string {
 		$value = sanitize_key( (string) $value );
 		return in_array( $value, array( 'require_prior_tool' ), true ) ? $value : '';
+	}
+
+	/**
+	 * @param mixed             $value Raw parameter condition map.
+	 * @param array<int,string> $tool_names Tools allowed by the prerequisite rule.
+	 * @return array<string,array<string,mixed>>
+	 */
+	private function sanitizeToolParameterConditions( $value, array $tool_names ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$allowed_tools = array_flip( $tool_names );
+		$conditions    = array();
+		foreach ( $value as $tool_name => $tool_conditions ) {
+			$tool_name = $this->sanitizeToolName( $tool_name );
+			if ( '' === $tool_name || ! isset( $allowed_tools[ $tool_name ] ) || ! is_array( $tool_conditions ) ) {
+				continue;
+			}
+
+			foreach ( $tool_conditions as $parameter => $expected ) {
+				$parameter = sanitize_key( (string) $parameter );
+				if ( '' === $parameter || is_array( $expected ) || is_object( $expected ) ) {
+					continue;
+				}
+
+				$conditions[ $tool_name ][ $parameter ] = $expected;
+			}
+		}
+
+		return $conditions;
 	}
 
 	private function sanitizeToolName( $value ): string {

--- a/inc/Engine/AI/DataMachineToolRuntimeRules.php
+++ b/inc/Engine/AI/DataMachineToolRuntimeRules.php
@@ -139,7 +139,7 @@ class DataMachineToolRuntimeRules {
 			);
 		}
 
-		$required_tools = (array) $rule['require_prior_tool'];
+		$required_tools      = (array) $rule['require_prior_tool'];
 		$required_parameters = is_array( $rule['require_prior_tool_parameters'] ?? null ) ? $rule['require_prior_tool_parameters'] : array();
 		foreach ( $required_tools as $required_tool ) {
 			if ( $this->lastToolCallIndex( $messages, (string) $required_tool, is_array( $required_parameters[ $required_tool ] ?? null ) ? $required_parameters[ $required_tool ] : array() ) >= 0 ) {
@@ -191,11 +191,11 @@ class DataMachineToolRuntimeRules {
 				}
 
 				$normalized[] = array(
-					'id'                              => $this->sanitizeRuleId( $rule['id'] ?? 'tool-runtime-rule-' . $index ),
-					'type'                            => 'require_prior_tool',
-					'before_tool'                     => $before_tool,
-					'require_prior_tool'              => $require_prior_tool,
-					'require_prior_tool_parameters'   => $require_prior_tool_parameters,
+					'id'                            => $this->sanitizeRuleId( $rule['id'] ?? 'tool-runtime-rule-' . $index ),
+					'type'                          => 'require_prior_tool',
+					'before_tool'                   => $before_tool,
+					'require_prior_tool'            => $require_prior_tool,
+					'require_prior_tool_parameters' => $require_prior_tool_parameters,
 				);
 				continue;
 			}

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -549,6 +549,8 @@ WpAiClientTestDouble::set_response_callback(
 			1 => 'create_github_pull_request',
 			2 => 'agent_daily_memory',
 			3 => 'create_github_pull_request',
+			4 => 'agent_daily_memory',
+			5 => 'create_github_pull_request',
 			default => '',
 		};
 
@@ -562,6 +564,11 @@ WpAiClientTestDouble::set_response_callback(
 			);
 		}
 
+		$parameters = array( 'name' => 'pr-prerequisite-smoke-' . $pr_prerequisite_dispatch_count );
+		if ( 'agent_daily_memory' === $tool_name ) {
+			$parameters['action'] = 2 === $pr_prerequisite_dispatch_count ? 'read' : 'write';
+		}
+
 		return array(
 			'success' => true,
 			'data'    => array(
@@ -569,7 +576,7 @@ WpAiClientTestDouble::set_response_callback(
 				'tool_calls' => array(
 					array(
 						'name'       => $tool_name,
-						'parameters' => array( 'name' => 'pr-prerequisite-smoke-' . $pr_prerequisite_dispatch_count ),
+						'parameters' => $parameters,
 					),
 				),
 			),
@@ -590,7 +597,10 @@ $pr_prerequisite_result = datamachine_run_conversation(
 		'agent_daily_memory'         => array(
 			'name'        => 'agent_daily_memory',
 			'description' => 'Write daily memory',
-			'parameters'  => array( 'name' => array( 'type' => 'string' ) ),
+			'parameters'  => array(
+				'name'   => array( 'type' => 'string' ),
+				'action' => array( 'type' => 'string' ),
+			),
 			'class'       => RuntimePolicySmokeTool::class,
 			'method'      => 'execute',
 		),
@@ -608,15 +618,18 @@ $pr_prerequisite_result = datamachine_run_conversation(
 				'type'               => 'require_prior_tool',
 				'before_tool'        => 'create_github_pull_request',
 				'require_prior_tool' => array( 'agent_daily_memory' ),
+				'require_prior_tool_parameters' => array(
+					'agent_daily_memory' => array( 'action' => 'write' ),
+				),
 			),
 		),
 	),
-	6
+	8
 );
 
 $pr_prerequisite_tool_names = array_map( static fn( $entry ) => (string) ( $entry['tool_name'] ?? '' ), $pr_prerequisite_result['tool_execution_results'] ?? array() );
-assert_runtime_policy( 4 === $pr_prerequisite_dispatch_count, 'prior-tool runtime rule rejects premature PR and allows retry after memory' );
-assert_runtime_policy( array( 'agent_daily_memory', 'create_github_pull_request' ) === $pr_prerequisite_tool_names, 'prior-tool runtime rule excludes rejected PR from tool results' );
+assert_runtime_policy( 6 === $pr_prerequisite_dispatch_count, 'prior-tool runtime rule rejects premature PR until parameter-matched memory' );
+assert_runtime_policy( array( 'agent_daily_memory', 'agent_daily_memory', 'create_github_pull_request' ) === $pr_prerequisite_tool_names, 'prior-tool runtime rule excludes rejected PR attempts from tool results' );
 assert_runtime_policy( str_contains( wp_json_encode( $pr_prerequisite_result['messages'] ?? array() ), 'Before using create_github_pull_request' ), 'prior-tool runtime rule explains required tool order' );
 
 $satisfied_runtime_rule_dispatch_count = 0;


### PR DESCRIPTION
## Summary
- Extend `require_prior_tool` runtime rules with optional parameter conditions.
- Allow flows to require a specific prior tool call shape before a finalizer runs.
- Cover the daily-memory `action=write` before PR creation case in the runtime policy smoke test.

## Why
World Creator PR #33 proved `agent_daily_memory` ran before PR creation, but not with `action=write`, so no journal artifact was exported. The runtime rule needs to match the actual write call, not any daily-memory read/list/search call.

## Testing
- `php -l inc/Engine/AI/DataMachineToolRuntimeRules.php && php -l tests/agent-conversation-runtime-policy-smoke.php`
- `php tests/agent-conversation-runtime-policy-smoke.php`
- `homeboy lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the daily-memory action mismatch, added parameter matching to runtime prerequisite rules, and ran targeted smoke/lint checks.