### PR TITLE
Fix fetch disposition tool schemas

### DIFF
--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -475,11 +475,14 @@ abstract class FetchHandler {
 			'disposition'    => 'reject_source',
 			'description'    => 'Reject this fetched source item after reasoned content/source evaluation. Use when the source itself is irrelevant, too thin, duplicate, noisy, spammy, or otherwise fails the pipeline quality or relevance criteria. The source item will be marked as processed and will not normally be refetched.',
 			'parameters'     => array(
-				'reason' => array(
-					'type'        => 'string',
-					'description' => 'Concise categorical rejection reason, following the vocabulary defined in the pipeline system prompt or RULES.md.',
-					'required'    => true,
+				'type'       => 'object',
+				'properties' => array(
+					'reason' => array(
+						'type'        => 'string',
+						'description' => 'Concise categorical rejection reason, following the vocabulary defined in the pipeline system prompt or RULES.md.',
+					),
 				),
+				'required'   => array( 'reason' ),
 			),
 			'handler_config' => $handler_config,
 		);
@@ -501,11 +504,14 @@ abstract class FetchHandler {
 			'disposition'    => 'defer_item',
 			'description'    => 'Defer this fetched source item when the agent cannot safely complete processing now because of runtime failures, tool errors, missing context, uncertainty, or temporary limitations. The source claim will be released and the item will remain eligible to be fetched and retried later; it will not be marked processed.',
 			'parameters'     => array(
-				'reason' => array(
-					'type'        => 'string',
-					'description' => 'Concise reason explaining why processing cannot safely complete now and should be retried later.',
-					'required'    => true,
+				'type'       => 'object',
+				'properties' => array(
+					'reason' => array(
+						'type'        => 'string',
+						'description' => 'Concise reason explaining why processing cannot safely complete now and should be retried later.',
+					),
 				),
+				'required'   => array( 'reason' ),
 			),
 			'handler_config' => $handler_config,
 		);

--- a/tests/fetch-item-dispositions-smoke.php
+++ b/tests/fetch-item-dispositions-smoke.php
@@ -123,6 +123,9 @@ namespace {
 	assert_fetch_disposition_smoke( 'fetch surface exposes reject_source', str_contains( $fetch_handler, "'reject_source'" ) );
 	assert_fetch_disposition_smoke( 'fetch surface exposes defer_item', str_contains( $fetch_handler, "'defer_item'" ) );
 	assert_fetch_disposition_smoke( 'fetch surface avoids legacy skip tool registration', ! str_contains( $fetch_handler, "'skip_item'" ) );
+	assert_fetch_disposition_smoke( 'fetch disposition schemas use canonical root object schemas', 2 === substr_count( $fetch_handler, "'type'       => 'object'" ) );
+	assert_fetch_disposition_smoke( 'fetch disposition schemas use object-level required arrays', 2 === substr_count( $fetch_handler, "'required'   => array( 'reason' )" ) );
+	assert_fetch_disposition_smoke( 'fetch disposition schemas avoid property-level required flags', ! str_contains( $fetch_handler, "'required'    => true" ) );
 	assert_fetch_disposition_smoke( 'reject_source describes reasoned content/source rejection', str_contains( $fetch_handler, 'reasoned content/source evaluation' ) );
 	assert_fetch_disposition_smoke( 'defer_item describes safe completion and retry eligibility', str_contains( $fetch_handler, 'cannot safely complete processing now' ) && str_contains( $fetch_handler, 'remain eligible' ) );
 	assert_fetch_disposition_smoke( 'normal completion still marks processed', str_contains( $execute_step, '$this->markCompletedItemProcessed( $job_id );' ) && str_contains( $execute_step, 'JobStatus::COMPLETED' ) );


### PR DESCRIPTION
## Summary
- Convert `reject_source` and `defer_item` fetch disposition tools to canonical root object JSON Schemas.
- Add smoke coverage so fetch disposition tools do not regress to property-level `required` flags.

## Testing
- `php tests/fetch-item-dispositions-smoke.php`
- `php tests/wp-ai-client-tool-schema-smoke.php`
- `php tests/global-tool-array-items-smoke.php`
- `homeboy test --path . --extension wordpress --changed-since origin/main --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the downstream `reject_source` schema failure to handler-resolved tool definitions, drafted the focused schema/test change, and ran local verification; Chris remains responsible for review and merge.