### PR TITLE
Normalize provider tool parameter schemas

### DIFF
--- a/inc/Engine/AI/ProviderRequestAssembler.php
+++ b/inc/Engine/AI/ProviderRequestAssembler.php
@@ -92,12 +92,64 @@ class ProviderRequestAssembler {
 			$structured[ $tool_name ] = array(
 				'name'           => $tool_name,
 				'description'    => $tool_config['description'] ?? '',
-				'parameters'     => $tool_config['parameters'] ?? array(),
+				'parameters'     => self::normalizeToolParameters( $tool_config['parameters'] ?? array() ),
 				'handler'        => $tool_config['handler'] ?? null,
 				'handler_config' => $tool_config['handler_config'] ?? array(),
 			);
 		}
 
 		return $structured;
+	}
+
+	/**
+	 * Normalize raw tool parameters to canonical JSON Schema object form.
+	 *
+	 * Tool definitions historically used a flat property map with optional
+	 * property-level `required` flags. Providers expect the canonical root schema.
+	 *
+	 * @param mixed $parameters Raw tool parameters definition.
+	 * @return array<string, mixed>
+	 */
+	private static function normalizeToolParameters( mixed $parameters ): array {
+		if ( ! is_array( $parameters ) || empty( $parameters ) ) {
+			return array(
+				'type'       => 'object',
+				'properties' => array(),
+			);
+		}
+
+		if ( isset( $parameters['type'] ) || isset( $parameters['properties'] ) || isset( $parameters['required'] ) ) {
+			$parameters['type']       = $parameters['type'] ?? 'object';
+			$parameters['properties'] = is_array( $parameters['properties'] ?? null ) ? $parameters['properties'] : array();
+			return $parameters;
+		}
+
+		$properties = array();
+		$required   = array();
+
+		foreach ( $parameters as $name => $schema ) {
+			if ( ! is_string( $name ) || '' === $name ) {
+				continue;
+			}
+
+			$property_schema = is_array( $schema ) ? $schema : array( 'type' => 'string' );
+			if ( ! empty( $property_schema['required'] ) ) {
+				$required[] = $name;
+			}
+			unset( $property_schema['required'] );
+
+			$properties[ $name ] = $property_schema;
+		}
+
+		$normalized = array(
+			'type'       => 'object',
+			'properties' => $properties,
+		);
+
+		if ( ! empty( $required ) ) {
+			$normalized['required'] = $required;
+		}
+
+		return $normalized;
 	}
 }

--- a/tests/wp-ai-client-tool-schema-smoke.php
+++ b/tests/wp-ai-client-tool-schema-smoke.php
@@ -175,6 +175,53 @@ $assert( 'object' === ( $schema['type'] ?? null ), 'canonical parameter schema r
 $assert( array( 'reason' ) === ( $schema['required'] ?? null ), 'canonical object-level required array is preserved' );
 $assert( 'string' === ( $schema['properties']['reason']['type'] ?? null ), 'property schema fields are preserved' );
 
+// --- Legacy flat parameter map normalization ---------------------------------
+//
+// Older internal tools may still declare parameters as a flat property map. The
+// provider-facing schema must still be canonical JSON Schema.
+$captured_request = array();
+\DataMachine\Tests\Unit\Support\WpAiClientTestDouble::reset();
+\DataMachine\Tests\Unit\Support\WpAiClientTestDouble::set_response_callback(
+	function ( array $request ) use ( &$captured_request ): array {
+		$captured_request = $request;
+		return array(
+			'success' => true,
+			'data'    => array( 'content' => 'ok' ),
+		);
+	},
+);
+
+\DataMachine\Engine\AI\RequestBuilder::build(
+	array(
+		array(
+			'role'    => 'user',
+			'content' => 'Run legacy tool.',
+		),
+	),
+	'openai',
+	'gpt-smoke',
+	array(
+		'client/legacy_schema_tool' => array(
+			'name'        => 'client/legacy_schema_tool',
+			'description' => 'Legacy schema test tool.',
+			'parameters'  => array(
+				'reason' => array(
+					'type'        => 'string',
+					'description' => 'Reason text.',
+					'required'    => true,
+				),
+			),
+		),
+	),
+	'pipeline',
+	array( 'job_id' => 1686 )
+);
+
+$legacy_schema = $captured_request['tools']['client/legacy_schema_tool']['parameters'] ?? null;
+$assert( 'object' === ( $legacy_schema['type'] ?? null ), 'legacy flat parameter map becomes a root object schema' );
+$assert( array( 'reason' ) === ( $legacy_schema['required'] ?? null ), 'legacy property-level required flag becomes object-level required array' );
+$assert( ! isset( $legacy_schema['properties']['reason']['required'] ), 'legacy property-level required flag is removed from property schema' );
+
 // --- Empty-prompt fallback ----------------------------------------------------
 //
 // Regression coverage for https://github.com/Extra-Chill/data-machine/issues/1789.


### PR DESCRIPTION
## Summary
- Normalize all provider-facing tool parameter definitions to canonical root object JSON Schemas during request assembly.
- Preserve canonical schemas while adapting legacy flat property maps and property-level `required` flags before they reach `wp-ai-client`.
- Add smoke coverage for legacy flat parameter map normalization.

## Testing
- `php tests/wp-ai-client-tool-schema-smoke.php`
- `php tests/fetch-item-dispositions-smoke.php`
- `php tests/global-tool-array-items-smoke.php`
- `homeboy test --path . --extension wordpress --changed-since origin/main --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced repeated downstream strict-schema failures to provider-facing normalization, drafted the assembler normalization and smoke coverage, and ran local verification; Chris remains responsible for review and merge.