### PR TITLE
Encode empty tool properties as objects

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -766,10 +766,14 @@ class RequestBuilder {
 	 */
 	private static function normalizeToolSchema( $parameters ): array {
 		if ( ! is_array( $parameters ) || empty( $parameters ) ) {
-			return array(
+			$parameters = array(
 				'type'       => 'object',
 				'properties' => array(),
 			);
+		}
+
+		if ( isset( $parameters['properties'] ) && is_array( $parameters['properties'] ) && empty( $parameters['properties'] ) ) {
+			$parameters['properties'] = (object) array();
 		}
 
 		return $parameters;

--- a/tests/wp-ai-client-tool-schema-smoke.php
+++ b/tests/wp-ai-client-tool-schema-smoke.php
@@ -260,7 +260,9 @@ $captured_request = array();
 );
 
 $empty_schema = $captured_request['tools']['client/no_arg_tool']['parameters'] ?? null;
-$assert( array( 'type' => 'object', 'properties' => array() ) === $empty_schema, 'no-argument tools use canonical empty object schema' );
+$assert( is_array( $empty_schema ), 'no-argument tools use a parameter schema array' );
+$assert( 'object' === ( $empty_schema['type'] ?? null ), 'no-argument tools use object parameter schemas' );
+$assert( isset( $empty_schema['properties'] ) && $empty_schema['properties'] instanceof stdClass, 'no-argument tool properties encode as a JSON object' );
 
 echo "\n{$assertions} assertions, " . count( $failures ) . " failures\n";
 


### PR DESCRIPTION
## Summary
- Preserve no-argument tool schemas as JSON objects by casting empty `properties` maps to object semantics before wp-ai-client dispatch.
- Update the wp-ai-client schema smoke to catch `properties: []` regressions for no-argument tools.

## Testing
- `php -l inc/Engine/AI/RequestBuilder.php && php -l tests/wp-ai-client-tool-schema-smoke.php`
- `php tests/wp-ai-client-tool-schema-smoke.php`
- `homeboy lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the World Creator OpenAI schema rejection, drafted the schema-normalization fix, and ran local validation; Chris remains responsible for review and merge.