### PR TITLE
Omit empty tool schema properties

### DIFF
--- a/inc/Engine/AI/ProviderRequestAssembler.php
+++ b/inc/Engine/AI/ProviderRequestAssembler.php
@@ -113,14 +113,15 @@ class ProviderRequestAssembler {
 	private static function normalizeToolParameters( mixed $parameters ): array {
 		if ( ! is_array( $parameters ) || empty( $parameters ) ) {
 			return array(
-				'type'       => 'object',
-				'properties' => array(),
+				'type' => 'object',
 			);
 		}
 
 		if ( isset( $parameters['type'] ) || isset( $parameters['properties'] ) || isset( $parameters['required'] ) ) {
-			$parameters['type']       = $parameters['type'] ?? 'object';
-			$parameters['properties'] = is_array( $parameters['properties'] ?? null ) ? $parameters['properties'] : array();
+			$parameters['type'] = $parameters['type'] ?? 'object';
+			if ( isset( $parameters['properties'] ) && is_array( $parameters['properties'] ) && empty( $parameters['properties'] ) ) {
+				unset( $parameters['properties'] );
+			}
 			return $parameters;
 		}
 
@@ -142,9 +143,12 @@ class ProviderRequestAssembler {
 		}
 
 		$normalized = array(
-			'type'       => 'object',
-			'properties' => $properties,
+			'type' => 'object',
 		);
+
+		if ( ! empty( $properties ) ) {
+			$normalized['properties'] = $properties;
+		}
 
 		if ( ! empty( $required ) ) {
 			$normalized['required'] = $required;

--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -773,7 +773,7 @@ class RequestBuilder {
 		}
 
 		if ( isset( $parameters['properties'] ) && is_array( $parameters['properties'] ) && empty( $parameters['properties'] ) ) {
-			$parameters['properties'] = (object) array();
+			unset( $parameters['properties'] );
 		}
 
 		return $parameters;

--- a/tests/wp-ai-client-tool-schema-smoke.php
+++ b/tests/wp-ai-client-tool-schema-smoke.php
@@ -309,7 +309,7 @@ $captured_request = array();
 $empty_schema = $captured_request['tools']['client/no_arg_tool']['parameters'] ?? null;
 $assert( is_array( $empty_schema ), 'no-argument tools use a parameter schema array' );
 $assert( 'object' === ( $empty_schema['type'] ?? null ), 'no-argument tools use object parameter schemas' );
-$assert( isset( $empty_schema['properties'] ) && $empty_schema['properties'] instanceof stdClass, 'no-argument tool properties encode as a JSON object' );
+$assert( ! str_contains( json_encode( $empty_schema ), '[]' ), 'no-argument tool schema avoids PHP empty-array JSON encoding' );
 
 echo "\n{$assertions} assertions, " . count( $failures ) . " failures\n";
 


### PR DESCRIPTION
## Summary
- Omit empty `properties` maps from provider-facing tool schemas instead of relying on PHP empty-array/object encoding.
- Keep no-argument tools as valid root `type: object` schemas while avoiding JSON `[]` in strict provider requests.
- Update smoke coverage for the no-argument schema JSON encoding edge.

## Testing
- `php tests/wp-ai-client-tool-schema-smoke.php`
- `php tests/global-tool-array-items-smoke.php`
- `homeboy test --path . --extension wordpress --changed-since origin/main --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced strict provider rejection of empty DMC tool properties, drafted the provider-facing schema serialization fix, and ran local verification; Chris remains responsible for review and merge.