### PR TITLE
Preserve agent scope for daily memory tools

### DIFF
--- a/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentDailyMemory.php
@@ -306,7 +306,15 @@ class AgentDailyMemory extends BaseTool {
 			);
 		}
 
-		$raw_user_id       = (int) ( $parameters['user_id'] ?? 0 );
+		$raw_agent_id = (int) ( $parameters['agent_id'] ?? 0 );
+		$raw_user_id  = (int) ( $parameters['user_id'] ?? 0 );
+
+		if ( $raw_agent_id > 0 ) {
+			return array(
+				'user_id'  => $directory_manager->get_effective_user_id( $raw_user_id > 0 ? $raw_user_id : get_current_user_id() ),
+				'agent_id' => $raw_agent_id,
+			);
+		}
 
 		if ( $raw_user_id > 0 ) {
 			return array(

--- a/tests/agent-daily-memory-pipeline-scope-smoke.php
+++ b/tests/agent-daily-memory-pipeline-scope-smoke.php
@@ -163,6 +163,21 @@ namespace {
 	);
 
 	PermissionHelper::clear_agent_context();
+	$tool->handle_tool_call( array( 'action' => 'write', 'content' => 'pipeline entry', 'user_id' => 77, 'agent_id' => 42 ) );
+	assert_daily_memory_scope(
+		array(
+			'user_id'  => 77,
+			'agent_id' => 42,
+			'content'  => 'pipeline entry',
+			'date'     => gmdate( 'Y-m-d' ),
+			'mode'     => 'append',
+		),
+		$agent_daily_memory_ability_inputs['datamachine/daily-memory-write'] ?? null,
+		'pipeline payload agent_id preserves agent memory scope without permission context',
+		$failures,
+		$passes
+	);
+
 	$tool->handle_tool_call( array( 'action' => 'read', 'date' => '2026-05-09', 'user_id' => 123 ) );
 	assert_daily_memory_scope(
 		array(


### PR DESCRIPTION
## Summary
- Preserve `agent_id` from pipeline tool payloads when `agent_daily_memory` runs outside `PermissionHelper` agent context.
- Keeps daily memory writes/readbacks agent-scoped so run artifacts can export bundle-file journals.

## Testing
- `php -l inc/Engine/AI/Tools/Global/AgentDailyMemory.php && php -l tests/agent-daily-memory-pipeline-scope-smoke.php`
- `php tests/agent-daily-memory-pipeline-scope-smoke.php`
- `homeboy lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed why World Creator daily memory was satisfied but not exported, drafted the scope fix, and ran local validation; Chris remains responsible for review and merge.