### PR TITLE
Keep no-argument tool schemas provider-compatible

### DIFF
--- a/inc/Engine/AI/RequestBuilder.php
+++ b/inc/Engine/AI/RequestBuilder.php
@@ -773,7 +773,12 @@ class RequestBuilder {
 		}
 
 		if ( isset( $parameters['properties'] ) && is_array( $parameters['properties'] ) && empty( $parameters['properties'] ) ) {
-			$parameters['properties'] = (object) array();
+			$parameters['properties'] = array(
+				'_unused' => array(
+					'type'        => 'boolean',
+					'description' => 'Ignored placeholder for providers that require at least one object property.',
+				),
+			);
 		}
 
 		return $parameters;

--- a/tests/wp-ai-client-tool-schema-smoke.php
+++ b/tests/wp-ai-client-tool-schema-smoke.php
@@ -262,7 +262,7 @@ $captured_request = array();
 $empty_schema = $captured_request['tools']['client/no_arg_tool']['parameters'] ?? null;
 $assert( is_array( $empty_schema ), 'no-argument tools use a parameter schema array' );
 $assert( 'object' === ( $empty_schema['type'] ?? null ), 'no-argument tools use object parameter schemas' );
-$assert( isset( $empty_schema['properties'] ) && $empty_schema['properties'] instanceof stdClass, 'no-argument tool properties encode as a JSON object' );
+$assert( isset( $empty_schema['properties']['_unused'] ), 'no-argument tool properties include an ignored provider-compatible placeholder' );
 
 echo "\n{$assertions} assertions, " . count( $failures ) . " failures\n";
 


### PR DESCRIPTION
## Summary
- Replace empty no-argument tool `properties` maps with an ignored optional placeholder property before wp-ai-client dispatch.
- Covers providers that reject empty object schemas even when the tool has no real inputs.

## Testing
- `php -l inc/Engine/AI/RequestBuilder.php && php -l tests/wp-ai-client-tool-schema-smoke.php`
- `php tests/wp-ai-client-tool-schema-smoke.php`
- `homeboy lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed OpenAI no-argument tool schema validation, drafted the provider-compatible normalizer update, and ran local validation; Chris remains responsible for review and merge.